### PR TITLE
Update /worktree skill for bare repo + worktrees directory structure

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -12,7 +12,7 @@ Set up an isolated git worktree for working on a GitHub issue. Each issue gets i
 When a worktree exists but is not the current directory, prompt the user to close Claude and run:
 
 ```
-cd <project-root>/worktrees/<branch-name> && direnv allow && claude "/pr-workflow #<issue-num>"
+cd <project-root>/worktrees/<branch-name> && claude "/pr-workflow #<issue-num>"
 ```
 
 `<project-root>` is:
@@ -145,5 +145,11 @@ git worktree add -b <branch-name> "$PROJECT_ROOT/worktrees/<branch-name>" origin
 ```
 
 `PROJECT_ROOT` was computed in Section 2 and already accounts for the layout (bare or classic). No `--git-dir` flag is needed — `git worktree add` finds the git dir from the current worktree context.
+
+Then run `direnv allow` for the new directory:
+
+```bash
+direnv allow "$PROJECT_ROOT/worktrees/<branch-name>"
+```
 
 After creation, follow the **Handoff command**.


### PR DESCRIPTION
## Summary

- Detect bare vs classic layout by checking the second line of `git worktree list --porcelain`
- Compute `PROJECT_ROOT` correctly for both layouts (bare: parent of `.bare/`; classic: unchanged)
- Add Section 2.5: offer to convert classic repos to bare layout with step-by-step conversion instructions
- Update worktree creation (Section 4) to use `PROJECT_ROOT` instead of hardcoded `<repo-root>`
- Clarify handoff command path with layout-specific explanation

Closes #66