### PR TITLE
Fix code quality review task output handling (#113)

### DIFF
--- a/.claude/skills/ref-pr-workflow/SKILL.md
+++ b/.claude/skills/ref-pr-workflow/SKILL.md
@@ -321,7 +321,7 @@ Start `/wiggum-loop` at Step 0 with these instruction sets:
 **Progress report instructions:**
 - `mkdir -p "$(git rev-parse --show-toplevel)/tmp"`
 - Write evaluation results (user classifications) to `$(git rev-parse --show-toplevel)/tmp/codequality-eval-<N>.txt`
-- Post combined comment (output file written by Claude directly, not a background Task's `output_file`):
+- Post combined comment (constructed from background Task `output_file` paths via the Bash command above):
   ```bash
   post-pr-comment.sh <pr-num> "$(git rev-parse --show-toplevel)/tmp/codequality-output-<N>.txt" "$(git rev-parse --show-toplevel)/tmp/codequality-eval-<N>.txt"
   ```


### PR DESCRIPTION
## Summary

- Step 9 code quality review tasks now use `run_in_background: true` with explicit `TaskOutput` wait, preventing premature output file reads
- Added explicit Bash command to concatenate on-disk output files into `codequality-output-<N>.txt`, avoiding token waste from the Write tool
- No other workflow steps affected

Closes #113