### PR TITLE
Remove sync syscall that hangs on WSL2

### DIFF
--- a/.claude/hooks/save-skill-state.sh
+++ b/.claude/hooks/save-skill-state.sh
@@ -47,9 +47,6 @@ atomic_write() {
     rm -f "$tmp"
     return 1
   fi
-  if ! sync 2>/dev/null; then
-    echo "[save-skill-state] WARNING: sync failed -- state may not survive a system crash" >&2
-  fi
 }
 
 case "${1:-}" in


### PR DESCRIPTION
## Summary

- Remove the `sync` block from `atomic_write()` in `save-skill-state.sh` — it blocks indefinitely on WSL2's virtual filesystem
- The preceding `mv` (same-filesystem rename) is already atomic on Linux, so `sync` adds no durability benefit

Fixes #117

## Test plan

- [x] `bash -x .claude/hooks/save-skill-state.sh skill test-skill` completes instantly on WSL2

🤖 Generated with [Claude Code](https://claude.com/claude-code)