### PR TITLE
Deploy landing app to default commons-systems hosting site

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -9,7 +9,7 @@
           "cs-budget-f920"
         ],
         "landing": [
-          "cs-landing-ce1d"
+          "commons-systems"
         ]
       }
     }


### PR DESCRIPTION
## Summary
- Switch the landing hosting target from the generated `cs-landing-ce1d` site to the project's default `commons-systems` site, so the landing app serves from the main commons.systems domain.

## Test plan
- [ ] Verify preview deploy succeeds on this PR
- [ ] After merge, verify prod deploy targets the correct hosting site

🤖 Generated with [Claude Code](https://claude.com/claude-code)