### PR TITLE
Fix script paths in skill instructions

### DIFF
--- a/.claude/skills/pr-workflow-progress-report/SKILL.md
+++ b/.claude/skills/pr-workflow-progress-report/SKILL.md
@@ -15,5 +15,5 @@ mkdir -p tmp
 - Write evaluation results to `tmp/{FILE_PREFIX}-eval-{ITERATION}.txt`
 - Post combined comment:
   ```bash
-  post-pr-comment.sh {PR_NUM} <output_file> tmp/{FILE_PREFIX}-eval-{ITERATION}.txt
+  .claude/skills/ref-pr-workflow/scripts/post-pr-comment.sh {PR_NUM} <output_file> tmp/{FILE_PREFIX}-eval-{ITERATION}.txt
   ```

--- a/.claude/skills/pr-workflow-termination-summary/SKILL.md
+++ b/.claude/skills/pr-workflow-termination-summary/SKILL.md
@@ -36,6 +36,6 @@ mkdir -p tmp
   ```
 - Post:
   ```bash
-  post-pr-comment.sh {PR_NUM} tmp/{FILE_PREFIX}-final.txt
+  .claude/skills/ref-pr-workflow/scripts/post-pr-comment.sh {PR_NUM} tmp/{FILE_PREFIX}-final.txt
   ```
-- Update issue state to step={NEXT_STEP}/phase={NEXT_PHASE} via `issue-state-write`. If `ACTIVE_SKILLS` is provided, include it as the `active_skills` value in the state JSON.
+- Update issue state to step={NEXT_STEP}/phase={NEXT_PHASE} via `.claude/skills/ref-pr-workflow/scripts/issue-state-write`. If `ACTIVE_SKILLS` is provided, include it as the `active_skills` value in the state JSON.

--- a/.claude/skills/ref-code-quality/SKILL.md
+++ b/.claude/skills/ref-code-quality/SKILL.md
@@ -63,7 +63,7 @@ Step 9. Invoke `/wiggum-loop` at Step 0 with these instruction sets:
 - Write evaluation results (user classifications) to `tmp/codequality-eval-<N>.txt`
 - Post combined comment (constructed from background Task `output_file` paths via the Bash command above):
   ```bash
-  post-pr-comment.sh <pr-num> tmp/codequality-output-<N>.txt tmp/codequality-eval-<N>.txt
+  .claude/skills/ref-pr-workflow/scripts/post-pr-comment.sh <pr-num> tmp/codequality-output-<N>.txt tmp/codequality-eval-<N>.txt
   ```
 
 **Termination instructions:**
@@ -111,7 +111,7 @@ Step 9. Invoke `/wiggum-loop` at Step 0 with these instruction sets:
   ```
 - Post as a separate PR comment (distinct from the progress report already posted by progress report instructions):
   ```bash
-  post-pr-comment.sh <pr-num> tmp/codequality-final.txt
+  .claude/skills/ref-pr-workflow/scripts/post-pr-comment.sh <pr-num> tmp/codequality-final.txt
   ```
-- Update state to step=10/phase=security via `issue-state-write` with `active_skills: ["ref-memory-management", "ref-pr-workflow", "ref-security"]`
+- Update state to step=10/phase=security via `.claude/skills/ref-pr-workflow/scripts/issue-state-write` with `active_skills: ["ref-memory-management", "ref-pr-workflow", "ref-security"]`
 - Proceed to Step 10

--- a/.claude/skills/ref-create-pr/SKILL.md
+++ b/.claude/skills/ref-create-pr/SKILL.md
@@ -23,4 +23,4 @@ EOF
 
 Include a separate `Closes #N` for each issue (primary + all implemented dependencies and sub-issues).
 
-On completion → update state to step=6/phase=verify via `issue-state-write` with `active_skills: ["ref-memory-management", "ref-pr-workflow"]`. Return to router for dispatch to verify phase.
+On completion → update state to step=6/phase=verify via `.claude/skills/ref-pr-workflow/scripts/issue-state-write` with `active_skills: ["ref-memory-management", "ref-pr-workflow"]`. Return to router for dispatch to verify phase.

--- a/.claude/skills/ref-implement/SKILL.md
+++ b/.claude/skills/ref-implement/SKILL.md
@@ -18,7 +18,7 @@ CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 If no issue number provided, or `$CURRENT_BRANCH` doesn't start with the issue number followed by `-`: invoke `/worktree` instead. Stop.
 
-On completion → update state to step=2/phase=core via `issue-state-write` with `active_skills: ["ref-memory-management", "ref-pr-workflow", "ref-implement"]`, proceed to Step 2.
+On completion → update state to step=2/phase=core via `.claude/skills/ref-pr-workflow/scripts/issue-state-write` with `active_skills: ["ref-memory-management", "ref-pr-workflow", "ref-implement"]`, proceed to Step 2.
 
 ## Step 2. Planning Phase
 
@@ -31,7 +31,7 @@ Plan must include:
 - Acceptance test strategy: user flows to test with Playwright against Firebase emulators
 - Smoke test strategy: minimal health checks for preview deployments
 
-On completion → update state to step=3/phase=core via `issue-state-write` with `active_skills: ["ref-memory-management", "ref-pr-workflow", "ref-implement"]`, proceed to Step 3.
+On completion → update state to step=3/phase=core via `.claude/skills/ref-pr-workflow/scripts/issue-state-write` with `active_skills: ["ref-memory-management", "ref-pr-workflow", "ref-implement"]`, proceed to Step 3.
 
 ## Step 3. Implementation
 
@@ -44,4 +44,4 @@ Use the Task tool to launch parallel general-purpose subagents:
 
 All run concurrently with main implementation.
 
-On completion → update state to step=4/phase=unit via `issue-state-write` with `active_skills: ["ref-memory-management", "ref-pr-workflow"]`. Return to router for dispatch to unit phase.
+On completion → update state to step=4/phase=unit via `.claude/skills/ref-pr-workflow/scripts/issue-state-write` with `active_skills: ["ref-memory-management", "ref-pr-workflow"]`. Return to router for dispatch to unit phase.

--- a/.claude/skills/ref-memory-management/SKILL.md
+++ b/.claude/skills/ref-memory-management/SKILL.md
@@ -29,7 +29,7 @@ Scripts are in `.claude/skills/ref-pr-workflow/scripts/`. All derive the issue n
 
 # Issue State Rule
 
-Persist workflow state to the issue body so it survives auto-compaction. Use `issue-state-write <issue-number> '<json>'` to update state.
+Persist workflow state to the issue body so it survives auto-compaction. Use `.claude/skills/ref-pr-workflow/scripts/issue-state-write <issue-number> '<json>'` to update state.
 
 State schema:
 ```json
@@ -44,8 +44,8 @@ State schema:
 }
 ```
 
-- **When entering a workflow step or changing phase:** call `issue-state-write` with updated `step`, `step_label`, `phase`, and current `active_skills`
-- **When loading or unloading skills:** include the updated `active_skills` list in the next `issue-state-write` call
+- **When entering a workflow step or changing phase:** call `.claude/skills/ref-pr-workflow/scripts/issue-state-write` with updated `step`, `step_label`, `phase`, and current `active_skills`
+- **When loading or unloading skills:** include the updated `active_skills` list in the next `.claude/skills/ref-pr-workflow/scripts/issue-state-write` call
 - **When entering a wiggum-loop step:** include `wiggum_step` and `wiggum_step_label` in the state
 - **When a wiggum-loop terminates:** omit `wiggum_step` and `wiggum_step_label` from the state
 

--- a/.claude/skills/ref-pr-check/SKILL.md
+++ b/.claude/skills/ref-pr-check/SKILL.md
@@ -9,13 +9,13 @@ allowed-tools: Bash(.claude/skills/ref-pr-workflow/scripts/*), Bash($CLAUDE_PLUG
 
 Self-contained wiggum-loop for Steps 6 (acceptance) and 7 (smoke). Runs in isolated context — cannot invoke other skills.
 
-On load, read issue state via `issue-state-read` to determine entry point:
+On load, read issue state via `.claude/skills/ref-pr-workflow/scripts/issue-state-read` to determine entry point:
 - step=6 → start at Phase 1 (acceptance)
 - step=7 → start at Phase 2 (smoke)
 
 ## Sandbox
 
-Use `dangerouslyDisableSandbox: true` for git write operations (`git add`, `git commit`, `git merge`, `git push`) and all `gh` CLI calls (`gh run list`, `gh run view`, `issue-state-write`, `post-pr-comment.sh`).
+Use `dangerouslyDisableSandbox: true` for git write operations (`git add`, `git commit`, `git merge`, `git push`) and all `gh` CLI calls (`gh run list`, `gh run view`, `.claude/skills/ref-pr-workflow/scripts/issue-state-write`, `.claude/skills/ref-pr-workflow/scripts/post-pr-comment.sh`).
 
 ## Phase 1: Acceptance Tests (Step 6)
 
@@ -42,7 +42,7 @@ If the run is in progress, wait for it to complete before returning output.
 - Write evaluation to `tmp/acceptance-eval-<N>.txt`
 - Post combined comment:
   ```bash
-  post-pr-comment.sh <pr-num> <output_file> tmp/acceptance-eval-<N>.txt
+  .claude/skills/ref-pr-workflow/scripts/post-pr-comment.sh <pr-num> <output_file> tmp/acceptance-eval-<N>.txt
   ```
 - Write checkpoint:
   ```bash
@@ -77,11 +77,11 @@ Fix failures. Commit and push (dangerouslyDisableSandbox). Increment counter. Re
   ```
 - Post:
   ```bash
-  post-pr-comment.sh <pr-num> tmp/acceptance-final.txt
+  .claude/skills/ref-pr-workflow/scripts/post-pr-comment.sh <pr-num> tmp/acceptance-final.txt
   ```
 - Update issue state to step=7/phase=verify:
   ```bash
-  issue-state-write <issue-number> '{"version":1,"step":7,"step_label":"Smoke Test Loop","phase":"verify","active_skills":["ref-memory-management","ref-pr-workflow"]}'
+  .claude/skills/ref-pr-workflow/scripts/issue-state-write <issue-number> '{"version":1,"step":7,"step_label":"Smoke Test Loop","phase":"verify","active_skills":["ref-memory-management","ref-pr-workflow"]}'
   ```
 - Reset iteration counter to 1. Proceed to Phase 2.
 
@@ -103,7 +103,7 @@ Same as Phase 1 Execute (CI monitoring).
 - Write evaluation to `tmp/smoke-eval-<N>.txt`
 - Post combined comment:
   ```bash
-  post-pr-comment.sh <pr-num> <output_file> tmp/smoke-eval-<N>.txt
+  .claude/skills/ref-pr-workflow/scripts/post-pr-comment.sh <pr-num> <output_file> tmp/smoke-eval-<N>.txt
   ```
 - Write checkpoint:
   ```bash
@@ -138,11 +138,11 @@ Fix failures. Commit and push (dangerouslyDisableSandbox). Increment counter. Re
   ```
 - Post:
   ```bash
-  post-pr-comment.sh <pr-num> tmp/smoke-final.txt
+  .claude/skills/ref-pr-workflow/scripts/post-pr-comment.sh <pr-num> tmp/smoke-final.txt
   ```
 - Update issue state to step=8/phase=qa:
   ```bash
-  issue-state-write <issue-number> '{"version":1,"step":8,"step_label":"QA Review Loop","phase":"qa","active_skills":["ref-memory-management","ref-pr-workflow","ref-qa"]}'
+  .claude/skills/ref-pr-workflow/scripts/issue-state-write <issue-number> '{"version":1,"step":8,"step_label":"QA Review Loop","phase":"qa","active_skills":["ref-memory-management","ref-pr-workflow","ref-qa"]}'
   ```
 - Go to Return with status `"success"`.
 

--- a/.claude/skills/ref-pr-workflow/SKILL.md
+++ b/.claude/skills/ref-pr-workflow/SKILL.md
@@ -26,8 +26,8 @@ Reference only. Do not execute this workflow until directed to do so (eg., by `/
 
 ## Resume Logic
 
-1. Run `issue-state-read <issue-number>`. If exit 0 → use `step`, `phase`, `active_skills`, and `wiggum_step` from the JSON. Skip fallback.
-2. If exit 1 → use fallback, then write fresh state via `issue-state-write`.
+1. Run `.claude/skills/ref-pr-workflow/scripts/issue-state-read <issue-number>`. If exit 0 → use `step`, `phase`, `active_skills`, and `wiggum_step` from the JSON. Skip fallback.
+2. If exit 1 → use fallback, then write fresh state via `.claude/skills/ref-pr-workflow/scripts/issue-state-write`.
 
 **Fallback** (scan **Current PR Scope and Status** above; step=1 is intentionally omitted — branch existence implies prerequisites passed):
 - No PR + implementation commits → step=4, phase=unit

--- a/.claude/skills/ref-unit-test/SKILL.md
+++ b/.claude/skills/ref-unit-test/SKILL.md
@@ -11,7 +11,7 @@ Self-contained wiggum-loop for Step 4. Runs in isolated context — cannot invok
 
 ## Sandbox
 
-Use `dangerouslyDisableSandbox: true` for git write operations (`git add`, `git commit`, `git merge`, `git push`) and all `gh` CLI calls (`issue-state-write`, `post-pr-comment.sh`).
+Use `dangerouslyDisableSandbox: true` for git write operations (`git add`, `git commit`, `git merge`, `git push`) and all `gh` CLI calls (`.claude/skills/ref-pr-workflow/scripts/issue-state-write`, `.claude/skills/ref-pr-workflow/scripts/post-pr-comment.sh`).
 
 ## Running Tests
 
@@ -56,7 +56,7 @@ Fix failures. Commit fixes (dangerouslyDisableSandbox). Increment iteration coun
 
 - Update issue state to step=5/phase=core:
   ```bash
-  issue-state-write <issue-number> '{"version":1,"step":5,"step_label":"PR Creation","phase":"core","active_skills":["ref-memory-management","ref-pr-workflow","ref-create-pr"]}'
+  .claude/skills/ref-pr-workflow/scripts/issue-state-write <issue-number> '{"version":1,"step":5,"step_label":"PR Creation","phase":"core","active_skills":["ref-memory-management","ref-pr-workflow","ref-create-pr"]}'
   ```
 - Write final checkpoint:
   ```bash

--- a/.claude/skills/ref-wiggum-loop/SKILL.md
+++ b/.claude/skills/ref-wiggum-loop/SKILL.md
@@ -20,7 +20,7 @@ Plan mode is mandatory at Steps 0 and 3, regardless of loop complexity.
 
 ## State Persistence
 
-Before executing each step, update the issue body state with `wiggum_step` and `wiggum_step_label` set to the current step number and label via `issue-state-write`. Include all existing state fields (`step`, `step_label`, `phase`, `active_skills`) alongside the updated wiggum fields.
+Before executing each step, update the issue body state with `wiggum_step` and `wiggum_step_label` set to the current step number and label via `.claude/skills/ref-pr-workflow/scripts/issue-state-write`. Include all existing state fields (`step`, `step_label`, `phase`, `active_skills`) alongside the updated wiggum fields.
 
 ## Step 0. Initialize
 

--- a/.claude/skills/wiggum-loop/SKILL.md
+++ b/.claude/skills/wiggum-loop/SKILL.md
@@ -7,6 +7,6 @@ description: Generic iterative loop pattern with evaluation and convergence
 
 1. Invoke `/ref-memory-management` and `/ref-wiggum-loop`.
 
-2. Update the issue state's `active_skills` to include `ref-wiggum-loop` (if not already present) via `issue-state-write`.
+2. Update the issue state's `active_skills` to include `ref-wiggum-loop` (if not already present) via `.claude/skills/ref-pr-workflow/scripts/issue-state-write`.
 
 3. If the current plan has an active step recorded, resume at that step. Otherwise, begin at the step specified by the caller (default: Step 0).


### PR DESCRIPTION
## Summary
- Updated all 27 references to `issue-state-read`, `issue-state-write`, and `post-pr-comment.sh` across 11 SKILL.md files to use the correct relative path (`.claude/skills/ref-pr-workflow/scripts/`) instead of bare script names
- Bare names caused execution failures since the scripts aren't on PATH — the correct paths match what's configured in `.claude/settings.json`

## Test plan
- [ ] Verify skill invocations that call `issue-state-write` or `post-pr-comment.sh` execute without "command not found" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)