### PR TITLE
Fix QA server conflicts across concurrent worktrees

### DIFF
--- a/.claude/skills/ref-pr-workflow/scripts/lib.sh
+++ b/.claude/skills/ref-pr-workflow/scripts/lib.sh
@@ -63,6 +63,49 @@ get_app_name() {
   basename "$1"
 }
 
+# Return the name of the current git worktree directory, or empty string
+# for a standard (non-worktree) checkout.
+get_worktree_id() {
+  local git_dir common_dir
+  git_dir="$(git rev-parse --git-dir 2>/dev/null)" || return 0
+  common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" || return 0
+  if [ "$git_dir" != "$common_dir" ]; then
+    basename "$git_dir"
+  fi
+}
+
+# Return the project ID for Firebase emulators.
+# Appends worktree name to prevent hub file collisions across worktrees.
+get_emulator_project_id() {
+  local wt_id
+  wt_id="$(get_worktree_id)"
+  if [ -n "$wt_id" ]; then
+    echo "${FIREBASE_PROJECT_ID}-wt-${wt_id}"
+  else
+    echo "$FIREBASE_PROJECT_ID"
+  fi
+}
+
+# Build an environment suffix with optional worktree qualifier.
+# Args: $1 = base suffix (e.g. "qa", "emulator")
+get_env_suffix() {
+  local wt_id
+  wt_id="$(get_worktree_id)"
+  echo "${1}${wt_id:+-$wt_id}"
+}
+
+# Kill a process and all its descendants.
+# Args: $1 = PID to kill
+kill_tree() {
+  local pid="${1:?kill_tree requires a PID argument}"
+  local children
+  children=$(pgrep -P "$pid" 2>/dev/null) || true
+  for child in $children; do
+    kill_tree "$child"
+  done
+  kill "$pid" 2>/dev/null || true
+}
+
 # Print the hosting site ID for an app from .firebaserc deploy targets.
 # Returns code 1 (with stderr message) if no hosting target is found.
 # Args: $1 = repo root, $2 = app name (e.g. "hello")
@@ -115,10 +158,16 @@ delete_preview_channel() {
 }
 
 # Remove the emulator hub file if the PID recorded in it is dead.
-# Safe for concurrent worktrees: only removes if the owning PID has exited.
+# Uses worktree-scoped project ID so each worktree manages its own hub file.
 # (PID recycling could theoretically cause a false positive but is negligible in practice.)
 cleanup_stale_hub() {
-  local hub_file="/tmp/hub-${FIREBASE_PROJECT_ID}.json"
+  # Resolve tmpdir via Node to match the path Firebase emulators use
+  # (os.tmpdir() may differ from shell $TMPDIR on macOS).
+  local tmpdir
+  tmpdir="$(node -e "process.stdout.write(require('os').tmpdir())")"
+  local project_id
+  project_id="$(get_emulator_project_id)"
+  local hub_file="${tmpdir}/hub-${project_id}.json"
   if [ -f "$hub_file" ]; then
     local hub_pid
     hub_pid=$(jq -r '.pid // empty' "$hub_file" 2>/dev/null) || true

--- a/.claude/skills/ref-pr-workflow/scripts/run-acceptance-tests.sh
+++ b/.claude/skills/ref-pr-workflow/scripts/run-acceptance-tests.sh
@@ -13,6 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
 
 APP_NAME=$(get_app_name "$APP_DIR")
+EMULATOR_PROJECT_ID=$(get_emulator_project_id)
 
 cd "$REPO_ROOT/$APP_DIR"
 npm ci
@@ -54,7 +55,7 @@ fi
 BUILD_ARGS=()
 EMULATOR_NAMESPACE=""
 if [ "$USES_FIRESTORE" = true ]; then
-  EMULATOR_NAMESPACE=$(get_firestore_namespace "$APP_NAME" "emulator")
+  EMULATOR_NAMESPACE=$(get_firestore_namespace "$APP_NAME" "$(get_env_suffix emulator)")
   BUILD_ARGS+=("VITE_FIRESTORE_EMULATOR_HOST=localhost:${FIRESTORE_PORT}" "VITE_FIRESTORE_NAMESPACE=${EMULATOR_NAMESPACE}")
 fi
 if [ "$USES_AUTH" = true ]; then
@@ -99,14 +100,14 @@ CONFIG_JSON="$CONFIG_JSON, \"emulators\": $EMULATORS_JSON}"
 
 echo "$CONFIG_JSON" > "$TEMP_FIREBASE_JSON"
 
-# Cleanup on exit: kill emulator, remove temp file
+# Cleanup on exit: kill emulator, remove stale hub and temp config files
 EMULATOR_PID=""
 cleanup() {
   if [ -n "$EMULATOR_PID" ]; then
-    kill "$EMULATOR_PID" 2>/dev/null || true
+    kill_tree "$EMULATOR_PID"
     wait "$EMULATOR_PID" 2>/dev/null || true
   fi
-  cleanup_stale_hub
+  cleanup_stale_hub || echo "WARNING: cleanup_stale_hub failed" >&2
   rm -f "$TEMP_FIREBASE_JSON"
 }
 trap cleanup EXIT INT TERM
@@ -120,7 +121,7 @@ if [ "$USES_AUTH" = true ]; then
   EMULATORS="$EMULATORS,auth"
 fi
 
-npx firebase-tools emulators:start --only "$EMULATORS" --config "$TEMP_FIREBASE_JSON" --project "$FIREBASE_PROJECT_ID" &
+npx firebase-tools emulators:start --only "$EMULATORS" --config "$TEMP_FIREBASE_JSON" --project "$EMULATOR_PROJECT_ID" &
 EMULATOR_PID=$!
 
 # Poll until hosting emulator serves content.

--- a/.claude/skills/ref-pr-workflow/scripts/run-qa-server.sh
+++ b/.claude/skills/ref-pr-workflow/scripts/run-qa-server.sh
@@ -12,6 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
 
 APP_NAME=$(get_app_name "$APP_DIR")
+EMULATOR_PROJECT_ID=$(get_emulator_project_id)
 
 cleanup_stale_hub
 
@@ -69,21 +70,21 @@ CONFIG_JSON="$CONFIG_JSON\"emulators\": $EMULATORS_JSON}"
 
 echo "$CONFIG_JSON" > "$TEMP_FIREBASE_JSON"
 
-# Cleanup on exit: kill Vite + emulators, remove temp file
+# Cleanup on exit: kill Vite + emulators, remove stale hub and temp config files
 EMULATOR_PID=""
 VITE_PID=""
 cleanup() {
   echo ""
   echo "Shutting down..."
   if [ -n "$VITE_PID" ]; then
-    kill "$VITE_PID" 2>/dev/null || true
+    kill_tree "$VITE_PID"
     wait "$VITE_PID" 2>/dev/null || true
   fi
   if [ -n "$EMULATOR_PID" ]; then
-    kill "$EMULATOR_PID" 2>/dev/null || true
+    kill_tree "$EMULATOR_PID"
     wait "$EMULATOR_PID" 2>/dev/null || true
   fi
-  cleanup_stale_hub
+  cleanup_stale_hub || echo "WARNING: cleanup_stale_hub failed" >&2
   rm -f "$TEMP_FIREBASE_JSON"
   echo "QA server stopped."
 }
@@ -91,7 +92,7 @@ trap cleanup EXIT INT TERM
 
 # Start Firebase emulators in background (if any emulators needed)
 if [ -n "$EMULATOR_LIST" ]; then
-  npx firebase-tools emulators:start --only "$EMULATOR_LIST" --config "$TEMP_FIREBASE_JSON" --project "$FIREBASE_PROJECT_ID" &
+  npx firebase-tools emulators:start --only "$EMULATOR_LIST" --config "$TEMP_FIREBASE_JSON" --project "$EMULATOR_PROJECT_ID" &
   EMULATOR_PID=$!
 fi
 
@@ -110,8 +111,8 @@ if [ "$USES_FIRESTORE" = true ]; then
   done
   echo "Firebase Firestore emulator ready on port ${FIRESTORE_PORT}"
 
-  # Seed Firestore with qa namespace
-  NAMESPACE=$(get_firestore_namespace "$APP_NAME" "qa")
+  # Seed Firestore with worktree-scoped qa namespace (e.g., "myapp/qa-main")
+  NAMESPACE=$(get_firestore_namespace "$APP_NAME" "$(get_env_suffix qa)")
   echo "Seeding Firestore (namespace: ${NAMESPACE})..."
   APP_NAME="$APP_NAME" \
   FIRESTORE_EMULATOR_HOST="localhost:${FIRESTORE_PORT}" \


### PR DESCRIPTION
## Summary

- Scope Firebase emulator hub files per worktree by deriving a unique project ID (`commons-systems-wt-<worktree>`) for the `--project` flag, preventing hub file collisions when multiple worktrees run QA servers simultaneously
- Fix process cleanup to recursively kill the full process tree (`npx → node → java`) instead of only the top-level PID, eliminating orphaned emulator processes
- Resolve the hub file path via Node's `os.tmpdir()` to match what Firebase CLI actually uses (may differ from shell `$TMPDIR` on macOS)

## Test plan

- [ ] From one worktree, run `run-qa-server.sh` for an app — confirm it starts and the hub file uses the worktree-scoped project ID
- [ ] From a second worktree, run `run-qa-server.sh` concurrently — confirm independent startup with its own hub file
- [ ] Kill both servers (Ctrl+C) — confirm no orphan Java/node processes remain (`pgrep -f firebase` returns nothing)
- [ ] Verify `cleanup_stale_hub` removes stale hub files from the correct directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)