### PR TITLE
print: email-based storage access, rml-media upload

### DIFF
--- a/print/seeds/firestore.ts
+++ b/print/seeds/firestore.ts
@@ -6,15 +6,17 @@ import type { SeedSpec } from "@commons-systems/firestoreutil/seed";
 //      gsutil cp <file> gs://commons-systems.firebasestorage.app/print/prod/media/
 // 3. Set custom metadata on each object:
 //    - Public domain: gsutil setmeta -h "x-goog-meta-publicDomain:true" gs://.../<file>
-//    - Private: gsutil setmeta -h "x-goog-meta-publicDomain:false" -h "x-goog-meta-{uid}:member" gs://.../<file>
-// Note: Firestore uses memberEmails array for access control; Storage uses per-UID custom metadata keys.
+//    - Private: gsutil setmeta -h "x-goog-meta-publicDomain:false" -h "x-goog-meta-{email}:member" gs://.../<file>
+// Note: Firestore uses memberEmails array for access control; Storage uses per-email custom metadata keys.
 // Both must be kept in sync when granting access to private items (see firestore.rules, storage.rules).
+//
+// Private media documents and groups are managed manually (not in this seed).
+// The media collection is non-convergent so prod deploys won't delete private items.
 
 const appSeed: Omit<SeedSpec, "namespace"> = {
   collections: [
     {
       name: "media",
-      convergent: true,
       documents: [
         {
           id: "gutenberg-3296",
@@ -59,15 +61,15 @@ const appSeed: Omit<SeedSpec, "namespace"> = {
           },
         },
         {
-          id: "private-collection-1",
+          id: "test-private-item",
           data: {
-            title: "Private Collection Item",
+            title: "Test Private Item",
             mediaType: "pdf",
-            tags: { source: "rml-media/print" },
+            tags: { source: "test" },
             publicDomain: false,
-            sourceNotes: "Private GCS bucket rml-media/print — re-upload to Firebase Cloud Storage",
-            storagePath: "media/private-collection-1.pdf",
-            groupId: "natb1-library",
+            sourceNotes: "Test-only private item for emulator testing",
+            storagePath: "media/test-private-item.pdf",
+            groupId: "test-group",
             memberEmails: ["test@example.com"],
             addedAt: "2026-01-18T00:00:00Z",
           },
@@ -79,9 +81,9 @@ const appSeed: Omit<SeedSpec, "namespace"> = {
       testOnly: true,
       documents: [
         {
-          id: "natb1-library",
+          id: "test-group",
           data: {
-            name: "natb1-library",
+            name: "test-group",
             members: ["test@example.com"],
           },
         },

--- a/print/seeds/storage.ts
+++ b/print/seeds/storage.ts
@@ -4,26 +4,29 @@ export interface StorageSeedItem {
   metadata: Record<string, string>;
 }
 
+const publicMeta = { publicDomain: "true" };
+const testPrivateMeta = { publicDomain: "false", "test@example.com": "member" };
+
 const storageSeed: StorageSeedItem[] = [
   {
     path: "print/prod/media/pg3296-images-3.epub",
     content: "dummy epub content for testing",
-    metadata: { publicDomain: "true" },
+    metadata: publicMeta,
   },
   {
     path: "print/prod/media/phaedrus-david-horan-translation-7-nov-25.pdf",
     content: "dummy pdf content for testing",
-    metadata: { publicDomain: "true" },
+    metadata: publicMeta,
   },
   {
     path: "print/prod/media/republic-i-to-x-david-horan-translation-22-nov-25.pdf",
     content: "dummy pdf content for testing",
-    metadata: { publicDomain: "true" },
+    metadata: publicMeta,
   },
   {
-    path: "print/prod/media/private-collection-1.pdf",
+    path: "print/prod/media/test-private-item.pdf",
     content: "dummy private pdf content for testing",
-    metadata: { publicDomain: "false", "test-github-user": "member" },
+    metadata: testPrivateMeta,
   },
 ];
 

--- a/storage.rules
+++ b/storage.rules
@@ -3,7 +3,7 @@ service firebase.storage {
   match /b/{bucket}/o {
     match /print/{env}/media/{fileName} {
       allow read: if resource.metadata["publicDomain"] == "true"
-        || (request.auth != null && resource.metadata[request.auth.uid] == "member");
+        || (request.auth != null && resource.metadata[request.auth.token.email] == "member");
       allow write: if false;
     }
     match /{allPaths=**} {


### PR DESCRIPTION
## Summary
- Switch storage rules from UID-based to email-based metadata access control (`request.auth.token.email` instead of `request.auth.uid`), aligning with Firestore's existing email-based `memberEmails` pattern
- Remove private metadata from seed files — private media documents and groups are managed manually (by Claude or future UI), not checked into the codebase
- Make media collection non-convergent so prod deploys don't delete manually-managed private items
- Uploaded 15 files from `gs://rml-media/print/` to Firebase Cloud Storage with clean kebab-case filenames and email-based private metadata
- Seeded corresponding Firestore media documents and `household` group in prod

## Test plan
- [ ] Verify storage rules deploy succeeds via `storage-deploy.yml`
- [ ] Verify public domain items remain accessible without auth
- [ ] Verify private items require auth with matching email in storage metadata
- [ ] Verify emulator seeding works with test private item and test group

🤖 Generated with [Claude Code](https://claude.com/claude-code)