### PR TITLE
Suppress SSH deprecation warning

### DIFF
--- a/nix/home/ssh.nix
+++ b/nix/home/ssh.nix
@@ -7,16 +7,10 @@
 # - SSH agent integration
 # - Security-focused defaults (modern ciphers, key algorithms)
 # - Host-specific configurations
-# - Automatic key management
 #
 # To add a new host, add an entry to programs.ssh.matchBlocks
 
-{
-  config,
-  pkgs,
-  lib,
-  ...
-}:
+{ ... }:
 
 {
   programs.ssh = {
@@ -41,10 +35,10 @@
         serverAliveInterval = 60;
         serverAliveCountMax = 3;
         hashKnownHosts = true;
+        addKeysToAgent = "no";
         extraOptions = {
           StrictHostKeyChecking = "ask";
           VerifyHostKeyDNS = "yes";
-          AddKeysToAgent = "no";
         };
       };
 


### PR DESCRIPTION
## Summary

Set `enableDefaultConfig = false` and explicitly declare defaults in `matchBlocks."*"` to suppress Home Manager's SSH deprecation warning. Cipher/kex settings remain in `extraConfig` (no structured equivalent).

Closes #64