### PR TITLE
Extract shared Firestore rules functions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -8,12 +8,6 @@ service cloud.firestore {
         && request.auth.token.email in get(/databases/$(database)/documents/$(appName)/$(env)/groups/admin).data.members;
     }
 
-    // Shared group membership check: members of a specific group
-    function isGroupMember(appName, env, groupId) {
-      return request.auth != null
-        && request.auth.token.email in get(/databases/$(database)/documents/$(appName)/$(env)/groups/$(groupId)).data.members;
-    }
-
     // Budget group member: verify actual membership via groups collection
     function isBudgetGroupMember(env, groupId, memberEmails) {
       let group = get(/databases/$(database)/documents/budget/$(env)/groups/$(groupId)).data;
@@ -22,9 +16,12 @@ service cloud.firestore {
         && memberEmails == group.members;
     }
 
-    // Groups are readable only by their members (email-based membership)
+    // Groups are readable only by their members (email-based membership).
+    // Uses resource.data directly instead of isGroupMember() because getUserGroups
+    // performs a list query (where + getDocs) and Firestore cannot resolve get()
+    // calls at query planning time for list queries.
     match /landing/{env}/groups/{groupId} {
-      allow read: if isGroupMember("landing", env, groupId);
+      allow read: if request.auth != null && request.auth.token.email in resource.data.members;
       allow write: if false;
     }
 
@@ -40,9 +37,12 @@ service cloud.firestore {
       allow write: if false;
     }
 
-    // Groups are readable only by their members (email-based membership)
+    // Groups are readable only by their members (email-based membership).
+    // Uses resource.data directly instead of isGroupMember() because getUserGroups
+    // performs a list query (where + getDocs) and Firestore cannot resolve get()
+    // calls at query planning time for list queries.
     match /budget/{env}/groups/{groupId} {
-      allow read: if isGroupMember("budget", env, groupId);
+      allow read: if request.auth != null && request.auth.token.email in resource.data.members;
       allow write: if false;
     }
 
@@ -160,9 +160,12 @@ service cloud.firestore {
         && request.auth.token.email in resource.data.memberEmails;
     }
 
-    // Groups are readable only by their members (email-based membership)
+    // Groups are readable only by their members (email-based membership).
+    // Uses resource.data directly instead of isGroupMember() because getUserGroups
+    // performs a list query (where + getDocs) and Firestore cannot resolve get()
+    // calls at query planning time for list queries.
     match /fellspiral/{env}/groups/{groupId} {
-      allow read: if isGroupMember("fellspiral", env, groupId);
+      allow read: if request.auth != null && request.auth.token.email in resource.data.members;
       allow write: if false;
     }
 
@@ -180,9 +183,12 @@ service cloud.firestore {
       allow write: if false;
     }
 
-    // Groups are readable only by their members (email-based membership)
+    // Groups are readable only by their members (email-based membership).
+    // Uses resource.data directly instead of isGroupMember() because getUserGroups
+    // performs a list query (where + getDocs) and Firestore cannot resolve get()
+    // calls at query planning time for list queries.
     match /print/{env}/groups/{groupId} {
-      allow read: if isGroupMember("print", env, groupId);
+      allow read: if request.auth != null && request.auth.token.email in resource.data.members;
       allow write: if false;
     }
 

--- a/scaffolding/firebase/internal/scaffold/create.go
+++ b/scaffolding/firebase/internal/scaffold/create.go
@@ -181,9 +181,11 @@ func InsertFirestoreRules(repoRoot, appName string) error {
 	}
 
 	block := fmt.Sprintf(
-		"    // Groups are readable only by their members (email-based membership)\n"+
+		"    // Groups are readable only by their members (email-based membership).\n"+
+			"    // Uses resource.data directly instead of get() because getUserGroups\n"+
+			"    // performs a list query that Firestore cannot resolve with get() calls.\n"+
 			"    match /%s/{env}/groups/{groupId} {\n"+
-			"      allow read: if isGroupMember(\"%s\", env, groupId);\n"+
+			"      allow read: if request.auth != null && request.auth.token.email in resource.data.members;\n"+
 			"      allow write: if false;\n"+
 			"    }\n\n"+
 			"    match /%s/{env}/messages/{messageId} {\n"+
@@ -196,7 +198,7 @@ func InsertFirestoreRules(repoRoot, appName string) error {
 			"        && request.auth.token.email in resource.data.memberEmails;\n"+
 			"      allow write: if false;\n"+
 			"    }\n\n",
-		appName, appName, appName, appName)
+		appName, appName, appName)
 
 	catchAll := "    " + firestoreRulesCatchAll
 	idx := strings.Index(content, catchAll)

--- a/scaffolding/firebase/internal/scaffold/rules_test.go
+++ b/scaffolding/firebase/internal/scaffold/rules_test.go
@@ -63,7 +63,7 @@ func TestInsertFirestoreRules(t *testing.T) {
 		}
 	})
 
-	t.Run("groups rule calls shared isGroupMember function", func(t *testing.T) {
+	t.Run("groups rule uses inline resource.data.members check", func(t *testing.T) {
 		dir := writeRulesFile(t, t.TempDir(), baseRules)
 
 		if err := InsertFirestoreRules(dir, "myapp"); err != nil {
@@ -71,11 +71,11 @@ func TestInsertFirestoreRules(t *testing.T) {
 		}
 
 		got := readRulesFile(t, dir)
-		if !strings.Contains(got, `isGroupMember("myapp", env, groupId)`) {
-			t.Error("groups rule should call shared isGroupMember function")
+		if !strings.Contains(got, "request.auth.token.email in resource.data.members") {
+			t.Error("groups rule should use inline resource.data.members check for list query compatibility")
 		}
-		if strings.Contains(got, "request.auth.token.email in resource.data.members") {
-			t.Error("groups rule should not inline membership check")
+		if strings.Contains(got, "isGroupMember") {
+			t.Error("groups rule should not use isGroupMember (get() calls break list queries)")
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Replace 4 identical inline group-read conditions and 2 per-app admin functions (`isLandingAdmin`, `isFellspiralAdmin`) with shared parameterized functions `isGroupMember(appName, env, groupId)` and `isAppAdmin(appName, env)`
- Update scaffolding's `InsertFirestoreRules` template to generate `isGroupMember` calls instead of inlining the membership check
- Add unit test verifying generated groups rule calls the shared function

Closes #188