### PR TITLE
fix: replace email-keyed GCS metadata with member_N fixed keys

### DIFF
--- a/print/seeds/storage.ts
+++ b/print/seeds/storage.ts
@@ -37,7 +37,7 @@ function makePdf(pageCount: number): string {
 }
 
 const publicMeta = { publicDomain: "true" };
-const testPrivateMeta = { publicDomain: "false", "test@example.com": "member" };
+const testPrivateMeta = { publicDomain: "false", member_0: "test@example.com" };
 
 const storageSeed: StorageSeedItem[] = [
   {

--- a/storage.rules
+++ b/storage.rules
@@ -3,7 +3,10 @@ service firebase.storage {
   match /b/{bucket}/o {
     match /print/{env}/media/{fileName} {
       allow read: if resource.metadata["publicDomain"] == "true"
-        || (request.auth != null && resource.metadata[request.auth.token.email] == "member");
+        || (request.auth != null && (
+            resource.metadata["member_0"] == request.auth.token.email
+         || resource.metadata["member_1"] == request.auth.token.email
+         || resource.metadata["member_2"] == request.auth.token.email));
       allow write: if false;
     }
     match /{allPaths=**} {


### PR DESCRIPTION
## Problem

Authenticated users get 403 on all private media items (e.g. `/view/a-pound-of-flesh`).

Root cause: `storage.rules` used `resource.metadata[request.auth.token.email]` — a dynamic CEL bracket lookup where the key contains `@`. The `@` character causes this lookup to silently return null in production GCS (the emulator handled it differently). The metadata was stored correctly; the lookup itself was broken.

## Fix

**`storage.rules`** — replace the dynamic email-key lookup with three fixed-key slots (`member_0`, `member_1`, `member_2`) storing emails as values:

```diff
- || (request.auth != null && resource.metadata[request.auth.token.email] == "member");
+ || (request.auth != null && (
+     resource.metadata["member_0"] == request.auth.token.email
+  || resource.metadata["member_1"] == request.auth.token.email
+  || resource.metadata["member_2"] == request.auth.token.email));
```

**`print/seeds/storage.ts`** — update `testPrivateMeta` to match the new scheme:

```diff
- const testPrivateMeta = { publicDomain: "false", "test@example.com": "member" };
+ const testPrivateMeta = { publicDomain: "false", member_0: "test@example.com" };
```

**GCS objects** — updated `x-goog-meta-member_0:nathan@natb1.com` and cleared the old `x-goog-meta-nathan@natb1.com` key on all 68 objects in `print/prod/media/` via `gsutil setmeta` (0 errors).

## Verification

1. Merge this PR → `storage-deploy.yml` deploys updated rules automatically
2. Log in as `nathan@natb1.com` at `print.commons.systems`
3. Navigate to a private item (e.g. `/view/a-pound-of-flesh`)
4. Confirm PDF viewer loads without 403
5. Confirm public items still load without auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)