### PR TITLE
Fix image archive viewer broken by __MACOSX resource forks

### DIFF
--- a/print/src/viewer/image-archive.ts
+++ b/print/src/viewer/image-archive.ts
@@ -165,7 +165,7 @@ export function createImageArchiveRenderer(onError?: (err: unknown) => void, sto
       }
 
       const imageEntries = Object.keys(entries)
-        .filter((path) => IMAGE_EXT.test(path))
+        .filter((path) => IMAGE_EXT.test(path) && !path.startsWith("__MACOSX/"))
         .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
         .map((path) => entries[path]!);
 


### PR DESCRIPTION
## Summary
- The Little Nemo `.cbz` archive contains 422 `__MACOSX/._*.jpeg` resource fork files (226-byte Apple Double metadata) alongside 421 real JPEG images
- The `IMAGE_EXT` filter matched these resource forks because they have `.jpeg` extensions
- They sort before real images alphabetically (`__MACOSX/` < `little-nemo-`), so page 1 rendered a resource fork blob as a broken image
- Fix: exclude paths starting with `__MACOSX/` from the image entry list

## Test plan
- [x] All 178 existing tests pass (45 image-archive tests)
- [x] Verified via Playwright that real images (e.g. `little-nemo-19051015-l-01.jpeg`, 1740x2376) render correctly when `__MACOSX` entries are filtered
- [ ] Smoke test on prod after merge: load Little Nemo in the viewer and confirm page 1 displays an image

🤖 Generated with [Claude Code](https://claude.com/claude-code)