### PR TITLE
Inject Firebase credentials via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Firebase Web API key (find in Firebase Console > Project Settings > General)
+VITE_FIREBASE_API_KEY=
+
+# reCAPTCHA Enterprise site key for Firebase AppCheck (find in Google Cloud Console > reCAPTCHA Enterprise)
+VITE_RECAPTCHA_SITE_KEY=
+
+# Branch to fetch markdown post content from GitHub (default: main)
+VITE_GITHUB_BRANCH=main

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Run acceptance tests
         env:
           VITE_GITHUB_BRANCH: ${{ github.head_ref }}
+          VITE_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          VITE_RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
         run: .claude/skills/ref-pr-workflow/scripts/run-all-acceptance-tests.sh
 
   preview-and-smoke:
@@ -57,6 +59,8 @@ jobs:
         id: deploy
         env:
           VITE_GITHUB_BRANCH: ${{ github.head_ref }}
+          VITE_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          VITE_RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
         run: |
           set -o pipefail
           OUTPUT=$(.claude/skills/ref-pr-workflow/scripts/run-all-preview-deploy-smoke.sh "pr-${{ github.event.pull_request.number }}" | tee /dev/stderr)

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -31,6 +31,8 @@ jobs:
           GA_MEASUREMENT_ID_BUDGET: ${{ secrets.GA_MEASUREMENT_ID_BUDGET }}
           GA_MEASUREMENT_ID_FELLSPIRAL: ${{ secrets.GA_MEASUREMENT_ID_FELLSPIRAL }}
           GA_MEASUREMENT_ID_PRINT: ${{ secrets.GA_MEASUREMENT_ID_PRINT }}
+          VITE_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          VITE_RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
         run: .claude/skills/ref-pr-workflow/scripts/run-all-prod-deploy-smoke.sh
       - name: Cleanup credentials
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 worktrees/
 CLAUDE.local.md
+.env
 node_modules/
 dist/
 functions/lib/

--- a/config/vite.js
+++ b/config/vite.js
@@ -1,6 +1,7 @@
 // App configs include firebase module deduplication and happy-dom for
 // browser-environment tests. Lib configs omit both — libraries that need
 // happy-dom should pass it as an override.
+import path from "node:path";
 import { mergeConfig } from "vite";
 import { defineConfig } from "vitest/config";
 
@@ -13,6 +14,7 @@ const firebaseDedupe = [
 ];
 
 const appBase = defineConfig({
+  envDir: path.resolve(import.meta.dirname, ".."),
   resolve: {
     dedupe: firebaseDedupe,
   },

--- a/firebaseutil/src/config.ts
+++ b/firebaseutil/src/config.ts
@@ -1,8 +1,18 @@
 import type { FirebaseOptions } from "firebase/app";
 
+function requireEnv(name: string): string {
+  const value = import.meta.env[name];
+  if (!value) {
+    throw new Error(
+      `${name} is required. Set it in your .env or build command.`,
+    );
+  }
+  return value;
+}
+
 export const firebaseConfig = {
   projectId: "commons-systems",
-  apiKey: "AIzaSyCeT2nQbB_RCtu2Ybt9D3828okcodri4wc",
+  apiKey: requireEnv("VITE_FIREBASE_API_KEY"),
   authDomain:
     // Preview channel hostnames contain "--" (e.g., "pr-42--site.web.app") and must
     // use the default firebaseapp.com domain since auth cookies are scoped to the project.
@@ -13,4 +23,4 @@ export const firebaseConfig = {
 } satisfies FirebaseOptions;
 
 /** reCAPTCHA Enterprise site key for Firebase AppCheck (shared across all apps in this project). */
-export const RECAPTCHA_SITE_KEY = "6Lfv044sAAAAADtxsrFCfRFer_t7GLf1lG5vmyqN";
+export const RECAPTCHA_SITE_KEY = requireEnv("VITE_RECAPTCHA_SITE_KEY");

--- a/firebaseutil/test/config.test.ts
+++ b/firebaseutil/test/config.test.ts
@@ -1,26 +1,57 @@
-import { describe, it, expect } from "vitest";
-import { firebaseConfig } from "../src/config";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+  // Set valid env vars by default
+  import.meta.env.VITE_FIREBASE_API_KEY = "test-api-key";
+  import.meta.env.VITE_RECAPTCHA_SITE_KEY = "test-recaptcha-key";
+});
 
 describe("firebaseConfig", () => {
-  it("has projectId", () => {
+  it("reads apiKey from VITE_FIREBASE_API_KEY", async () => {
+    import.meta.env.VITE_FIREBASE_API_KEY = "my-api-key";
+    const { firebaseConfig } = await import("../src/config");
+    expect(firebaseConfig.apiKey).toBe("my-api-key");
+  });
+
+  it("has projectId", async () => {
+    const { firebaseConfig } = await import("../src/config");
     expect(firebaseConfig.projectId).toBe("commons-systems");
   });
 
-  it("has apiKey", () => {
-    expect(firebaseConfig.apiKey).toBe(
-      "AIzaSyCeT2nQbB_RCtu2Ybt9D3828okcodri4wc",
-    );
-  });
-
-  it("has authDomain fallback in Node.js", () => {
+  it("has authDomain fallback in Node.js", async () => {
+    const { firebaseConfig } = await import("../src/config");
     expect(firebaseConfig.authDomain).toBe(
       "commons-systems.firebaseapp.com",
     );
   });
 
-  it("has storageBucket", () => {
+  it("has storageBucket", async () => {
+    const { firebaseConfig } = await import("../src/config");
     expect(firebaseConfig.storageBucket).toBe(
       "commons-systems.firebasestorage.app",
+    );
+  });
+
+  it("throws when VITE_FIREBASE_API_KEY is missing", async () => {
+    delete import.meta.env.VITE_FIREBASE_API_KEY;
+    await expect(() => import("../src/config")).rejects.toThrow(
+      "VITE_FIREBASE_API_KEY is required",
+    );
+  });
+});
+
+describe("RECAPTCHA_SITE_KEY", () => {
+  it("reads from VITE_RECAPTCHA_SITE_KEY", async () => {
+    import.meta.env.VITE_RECAPTCHA_SITE_KEY = "my-recaptcha-key";
+    const { RECAPTCHA_SITE_KEY } = await import("../src/config");
+    expect(RECAPTCHA_SITE_KEY).toBe("my-recaptcha-key");
+  });
+
+  it("throws when VITE_RECAPTCHA_SITE_KEY is missing", async () => {
+    delete import.meta.env.VITE_RECAPTCHA_SITE_KEY;
+    await expect(() => import("../src/config")).rejects.toThrow(
+      "VITE_RECAPTCHA_SITE_KEY is required",
     );
   });
 });

--- a/landing/.env.example
+++ b/landing/.env.example
@@ -1,2 +1,0 @@
-# Branch to fetch markdown post content from GitHub (default: main)
-VITE_GITHUB_BRANCH=main


### PR DESCRIPTION
## Summary

- Move `apiKey` and `RECAPTCHA_SITE_KEY` from hardcoded strings in `firebaseutil/src/config.ts` to build-time env vars (`VITE_FIREBASE_API_KEY`, `VITE_RECAPTCHA_SITE_KEY`)
- Build fails with a clear error if either env var is missing (no silent fallback)
- CI workflows read values from GitHub secrets (`FIREBASE_API_KEY`, `RECAPTCHA_SITE_KEY`)
- Root `.env.example` documents required vars; `.env` is gitignored
- `config/vite.js` sets `envDir` to repo root so all apps load a shared `.env` for local dev

## Post-merge action

Add these GitHub repository secrets before merging:
- `FIREBASE_API_KEY` — Firebase Web API key
- `RECAPTCHA_SITE_KEY` — reCAPTCHA Enterprise site key

Closes #324