### PR TITLE
Add test:watch script to 5 packages

### DIFF
--- a/config/package.json
+++ b/config/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint *.js"
   },
   "exports": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsx scripts/sync-feed-urls.ts && tsc",
     "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint src/"
   },
   "engines": {

--- a/idbutil/package.json
+++ b/idbutil/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "scripts": { "test": "vitest run", "lint": "eslint src/" },
+  "scripts": { "test": "vitest run", "test:watch": "vitest", "lint": "eslint src/" },
   "exports": {
     "./connection": "./src/connection.ts"
   },

--- a/rssutil/package.json
+++ b/rssutil/package.json
@@ -4,6 +4,6 @@
   "version": "0.0.0",
   "type": "module",
   "exports": { ".": "./src/index.ts" },
-  "scripts": { "test": "vitest run", "lint": "eslint src/" },
+  "scripts": { "test": "vitest run", "test:watch": "vitest", "lint": "eslint src/" },
   "dependencies": { "@commons-systems/htmlutil": "*" }
 }

--- a/style/package.json
+++ b/style/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint src/"
   }
 }


### PR DESCRIPTION
## Summary

Add `"test:watch": "vitest"` to the 5 packages that had tests but lacked a watch script: config, functions, idbutil, rssutil, style. This makes the developer experience consistent across all packages.

Closes #335