### PR TITLE
Add Claude browser exploration to QA review loop

### DIFF
--- a/.claude/skills/ref-pr-workflow/scripts/run-unit-tests.sh
+++ b/.claude/skills/ref-pr-workflow/scripts/run-unit-tests.sh
@@ -78,8 +78,9 @@ if [ "$EXPLICIT" = false ]; then
   done <<< "$CHANGED"
 fi
 
-# Filter rules-test: requires Firebase emulators, excluded from vitest workspace config
-if [ "$EXPLICIT" = true ] && [[ -n "${DIRTY_APPS[rules-test]+x}" ]]; then
+# Filter rules-test: requires Firebase emulators (not supported by vitest run);
+# also excluded from vitest workspace projects in vitest.config.ts
+if [[ -n "${DIRTY_APPS[rules-test]+x}" ]]; then
   echo "Warning: rules-test requires Firebase emulators; skipping from vitest run" >&2
 fi
 unset 'DIRTY_APPS[rules-test]'

--- a/.claude/skills/ref-qa/SKILL.md
+++ b/.claude/skills/ref-qa/SKILL.md
@@ -22,8 +22,8 @@ Step 8. Invoke `/wiggum-loop` at Step 0 with these instruction sets:
      ```bash
      .claude/skills/ref-pr-workflow/scripts/run-acceptance-tests.sh <app-dir> <url>
      ```
-  4. If smoke tests fail → fix issues and re-run before involving the user
-  5. Once smoke tests pass, proceed to write the QA testing plan
+  5. If smoke tests fail → fix issues and re-run before involving the user
+  6. Once smoke tests pass, proceed to write the QA testing plan
 - Write a comprehensive QA testing plan with structured checklist items:
   ```
   ## 1. <Title>


### PR DESCRIPTION
## Summary

- Adds a Claude-driven browser exploration phase to the QA review skill (ref-qa/SKILL.md) that executes QA plan checklist items via claude-in-chrome MCP tools before handing off to the user
- Claude opens the app in Chrome, walks through each item (navigate, click, fill, verify), records a GIF, and reports per-item pass/fail/skip with console and network error evidence
- Graceful fallback: if chrome extension is unavailable, exploration is skipped and flow falls through to existing user-driven testing
- Existing user-driven QA phase and wiggum-loop behavior are unchanged

Closes #384