### PR TITLE
Tag internal traffic in production analytics

### DIFF
--- a/analyticsutil/src/index.ts
+++ b/analyticsutil/src/index.ts
@@ -1,6 +1,33 @@
-import { initializeAnalytics, logEvent } from "firebase/analytics";
+import {
+  initializeAnalytics,
+  logEvent,
+  setUserProperties,
+} from "firebase/analytics";
 import type { FirebaseApp } from "firebase/app";
 import { classifyError } from "@commons-systems/errorutil/classify";
+
+const STORAGE_KEY = "analytics_traffic_type";
+const PARAM_KEY = "_ct";
+
+function applyTrafficTag(): string {
+  const url = new URL(window.location.href);
+  const param = url.searchParams.get(PARAM_KEY);
+
+  if (param === "internal") {
+    localStorage.setItem(STORAGE_KEY, "internal");
+  } else if (param === "clear") {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+
+  if (param) {
+    url.searchParams.delete(PARAM_KEY);
+    history.replaceState(history.state, "", url.toString());
+  }
+
+  return localStorage.getItem(STORAGE_KEY) === "internal"
+    ? "internal"
+    : "organic";
+}
 
 export function initAnalyticsSafe(app: FirebaseApp): (path: string) => void {
   try {
@@ -24,10 +51,16 @@ export function initAnalytics(app: FirebaseApp): (path: string) => void {
   if (!app.options.appId) {
     throw new Error("Analytics requires appId in Firebase config.");
   }
+
+  const trafficType = applyTrafficTag();
+
   // Disable automatic page views — the returned tracker fires them manually.
   const analytics = initializeAnalytics(app, {
     config: { send_page_view: false },
   });
+
+  setUserProperties(analytics, { traffic_type: trafficType });
+
   return (path: string) => {
     try {
       logEvent(analytics, "page_view", { page_path: path });

--- a/analyticsutil/src/index.ts
+++ b/analyticsutil/src/index.ts
@@ -9,7 +9,23 @@ import { classifyError } from "@commons-systems/errorutil/classify";
 const STORAGE_KEY = "analytics_traffic_type";
 const PARAM_KEY = "_ct";
 
-function applyTrafficTag(): string {
+type TrafficType = "internal" | "organic";
+
+/**
+ * Reads the `_ct` ("classify traffic") URL parameter and updates the persistent
+ * traffic-type flag in localStorage.
+ *
+ * - `?_ct=internal` sets the flag (one-time visit from any team browser)
+ * - `?_ct=clear` removes the flag (escape hatch)
+ * - Unknown values are ignored and left in the URL for debugging
+ *
+ * Recognized values are stripped via `replaceState` so the param is not
+ * re-applied on refresh and does not leak into GA4 `page_path` dimensions.
+ *
+ * @returns `"internal"` if the flag is set, `"organic"` otherwise — used as the
+ *   `traffic_type` GA4 user property.
+ */
+function applyTrafficTag(): TrafficType {
   const url = new URL(window.location.href);
   const param = url.searchParams.get(PARAM_KEY);
 
@@ -19,7 +35,7 @@ function applyTrafficTag(): string {
     localStorage.removeItem(STORAGE_KEY);
   }
 
-  if (param) {
+  if (param === "internal" || param === "clear") {
     url.searchParams.delete(PARAM_KEY);
     history.replaceState(history.state, "", url.toString());
   }
@@ -52,7 +68,17 @@ export function initAnalytics(app: FirebaseApp): (path: string) => void {
     throw new Error("Analytics requires appId in Firebase config.");
   }
 
-  const trafficType = applyTrafficTag();
+  let trafficType: TrafficType = "organic";
+  try {
+    trafficType = applyTrafficTag();
+  } catch (error) {
+    if (classifyError(error) === "programmer") throw error;
+    reportError(
+      new Error(
+        `Failed to apply traffic tag: ${error instanceof Error ? error.message : error}`,
+      ),
+    );
+  }
 
   // Disable automatic page views — the returned tracker fires them manually.
   const analytics = initializeAnalytics(app, {

--- a/analyticsutil/test/index.test.ts
+++ b/analyticsutil/test/index.test.ts
@@ -1,12 +1,13 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { FirebaseApp } from "firebase/app";
 
 vi.mock("firebase/analytics", () => ({
   initializeAnalytics: vi.fn(() => ({ app: {} })),
   logEvent: vi.fn(),
+  setUserProperties: vi.fn(),
 }));
 
-import { initializeAnalytics, logEvent } from "firebase/analytics";
+import { initializeAnalytics, logEvent, setUserProperties } from "firebase/analytics";
 import { initAnalytics, initAnalyticsSafe } from "../src/index";
 
 // reportError is a browser API not available in Node — stub it so tests that
@@ -106,6 +107,101 @@ describe("initAnalytics", () => {
     const tracker = initAnalytics(app);
 
     expect(() => tracker("/about")).toThrow(TypeError);
+  });
+});
+
+describe("traffic tagging", () => {
+  const validApp = { options: { measurementId: "G-TEST", appId: "1:test:web:abc" } } as unknown as FirebaseApp;
+
+  function setLocation(url: string) {
+    Object.defineProperty(window, "location", {
+      value: new URL(url),
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    setLocation("https://example.com/page");
+    vi.spyOn(history, "replaceState").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.mocked(history.replaceState).mockRestore();
+  });
+
+  it("sets localStorage and tags internal when ?_ct=internal", () => {
+    setLocation("https://example.com/page?_ct=internal");
+    initAnalytics(validApp);
+
+    expect(localStorage.getItem("analytics_traffic_type")).toBe("internal");
+    expect(setUserProperties).toHaveBeenCalledWith(expect.anything(), {
+      traffic_type: "internal",
+    });
+  });
+
+  it("strips _ct param from URL after processing", () => {
+    setLocation("https://example.com/page?_ct=internal&other=1");
+    initAnalytics(validApp);
+
+    expect(history.replaceState).toHaveBeenCalledWith(
+      null,
+      "",
+      "https://example.com/page?other=1",
+    );
+  });
+
+  it("removes localStorage and tags organic when ?_ct=clear", () => {
+    localStorage.setItem("analytics_traffic_type", "internal");
+    setLocation("https://example.com/page?_ct=clear");
+    initAnalytics(validApp);
+
+    expect(localStorage.getItem("analytics_traffic_type")).toBeNull();
+    expect(setUserProperties).toHaveBeenCalledWith(expect.anything(), {
+      traffic_type: "organic",
+    });
+  });
+
+  it("tags internal when localStorage flag exists and no param", () => {
+    localStorage.setItem("analytics_traffic_type", "internal");
+    initAnalytics(validApp);
+
+    expect(setUserProperties).toHaveBeenCalledWith(expect.anything(), {
+      traffic_type: "internal",
+    });
+  });
+
+  it("tags organic when no localStorage flag and no param", () => {
+    initAnalytics(validApp);
+
+    expect(setUserProperties).toHaveBeenCalledWith(expect.anything(), {
+      traffic_type: "organic",
+    });
+  });
+
+  it("skips traffic tagging when measurementId is absent", () => {
+    const app = { options: {} } as unknown as FirebaseApp;
+    const consoleDebugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    initAnalytics(app);
+
+    expect(setUserProperties).not.toHaveBeenCalled();
+    expect(localStorage.getItem("analytics_traffic_type")).toBeNull();
+    consoleDebugSpy.mockRestore();
+  });
+
+  it("calls setUserProperties before returning the tracker", () => {
+    const callOrder: string[] = [];
+    vi.mocked(setUserProperties).mockImplementation(() => {
+      callOrder.push("setUserProperties");
+    });
+    vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never);
+
+    const tracker = initAnalytics(validApp);
+    callOrder.push("tracker_returned");
+
+    expect(callOrder).toEqual(["setUserProperties", "tracker_returned"]);
+    expect(tracker).toBeTypeOf("function");
   });
 });
 

--- a/analyticsutil/test/index.test.ts
+++ b/analyticsutil/test/index.test.ts
@@ -208,6 +208,15 @@ describe("traffic tagging", () => {
     });
   });
 
+  it("re-throws TypeError from applyTrafficTag", () => {
+    vi.spyOn(localStorage, "getItem").mockImplementation(() => {
+      throw new TypeError("invalid invocation");
+    });
+    setLocation("https://example.com/page");
+    expect(() => initAnalytics(validApp)).toThrow(TypeError);
+    vi.mocked(localStorage.getItem).mockRestore();
+  });
+
   it("continues with organic tag when localStorage throws", () => {
     const reportErrorSpy = vi.spyOn(globalThis, "reportError").mockImplementation(() => {});
     setLocation("https://example.com/page?_ct=internal");

--- a/analyticsutil/test/index.test.ts
+++ b/analyticsutil/test/index.test.ts
@@ -132,21 +132,26 @@ describe("traffic tagging", () => {
   });
 
   it("sets localStorage and tags internal when ?_ct=internal", () => {
+    const fakeAnalytics = { app: {} };
+    vi.mocked(initializeAnalytics).mockReturnValue(fakeAnalytics as never);
     setLocation("https://example.com/page?_ct=internal");
     initAnalytics(validApp);
 
     expect(localStorage.getItem("analytics_traffic_type")).toBe("internal");
-    expect(setUserProperties).toHaveBeenCalledWith(expect.anything(), {
+    expect(setUserProperties).toHaveBeenCalledWith(fakeAnalytics, {
       traffic_type: "internal",
     });
   });
 
   it("strips _ct param from URL after processing", () => {
     setLocation("https://example.com/page?_ct=internal&other=1");
+    vi.mocked(history.replaceState).mockRestore();
+    history.replaceState({ sentinel: true }, "");
+    vi.spyOn(history, "replaceState").mockImplementation(() => {});
     initAnalytics(validApp);
 
     expect(history.replaceState).toHaveBeenCalledWith(
-      null,
+      { sentinel: true },
       "",
       "https://example.com/page?other=1",
     );
@@ -180,27 +185,60 @@ describe("traffic tagging", () => {
     });
   });
 
-  it("skips traffic tagging when measurementId is absent", () => {
+  it("does not call applyTrafficTag or setUserProperties when measurementId is absent", () => {
     const app = { options: {} } as unknown as FirebaseApp;
+    setLocation("https://example.com/page?_ct=internal");
     const consoleDebugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
     initAnalytics(app);
 
     expect(setUserProperties).not.toHaveBeenCalled();
     expect(localStorage.getItem("analytics_traffic_type")).toBeNull();
+    expect(history.replaceState).not.toHaveBeenCalled();
     consoleDebugSpy.mockRestore();
+  });
+
+  it("ignores unknown _ct values and does not strip URL", () => {
+    setLocation("https://example.com/page?_ct=typo");
+    initAnalytics(validApp);
+
+    expect(localStorage.getItem("analytics_traffic_type")).toBeNull();
+    expect(history.replaceState).not.toHaveBeenCalled();
+    expect(setUserProperties).toHaveBeenCalledWith(expect.anything(), {
+      traffic_type: "organic",
+    });
+  });
+
+  it("continues with organic tag when localStorage throws", () => {
+    const reportErrorSpy = vi.spyOn(globalThis, "reportError").mockImplementation(() => {});
+    setLocation("https://example.com/page?_ct=internal");
+    vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    });
+    initAnalytics(validApp);
+
+    expect(setUserProperties).toHaveBeenCalledWith(expect.anything(), {
+      traffic_type: "organic",
+    });
+    const reported = reportErrorSpy.mock.calls[0][0] as Error;
+    expect(reported.message).toContain("Failed to apply traffic tag");
+    reportErrorSpy.mockRestore();
+    vi.mocked(localStorage.setItem).mockRestore();
   });
 
   it("calls setUserProperties before returning the tracker", () => {
     const callOrder: string[] = [];
+    vi.mocked(initializeAnalytics).mockImplementation(() => {
+      callOrder.push("initializeAnalytics");
+      return { app: {} } as never;
+    });
     vi.mocked(setUserProperties).mockImplementation(() => {
       callOrder.push("setUserProperties");
     });
-    vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never);
 
     const tracker = initAnalytics(validApp);
     callOrder.push("tracker_returned");
 
-    expect(callOrder).toEqual(["setUserProperties", "tracker_returned"]);
+    expect(callOrder).toEqual(["initializeAnalytics", "setUserProperties", "tracker_returned"]);
     expect(tracker).toBeTypeOf("function");
   });
 });

--- a/analyticsutil/tsconfig.json
+++ b/analyticsutil/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@commons-systems/config/tsconfig.lib.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"]
+  },
   "include": ["src", "test"]
 }

--- a/analyticsutil/vite.config.ts
+++ b/analyticsutil/vite.config.ts
@@ -1,3 +1,3 @@
 import { createLibConfig } from "@commons-systems/config/vite";
 
-export default createLibConfig();
+export default createLibConfig({ test: { environment: "happy-dom" } });

--- a/config/playwright.js
+++ b/config/playwright.js
@@ -5,7 +5,9 @@ export default defineConfig({
   testDir: ".", // resolves relative to the consuming config file's directory
   use: {
     baseURL: process.env.BASE_URL || "http://localhost:5173",
-    // Tag all Playwright traffic as internal so it can be filtered from GA4 reports.
+    // Pre-seed localStorage with the internal-traffic flag before any page loads
+    // so initAnalytics sets traffic_type=internal on the GA4 client.
+    // Storage key must match STORAGE_KEY in analyticsutil/src/index.ts.
     storageState: {
       cookies: [],
       origins: [

--- a/config/playwright.js
+++ b/config/playwright.js
@@ -5,6 +5,18 @@ export default defineConfig({
   testDir: ".", // resolves relative to the consuming config file's directory
   use: {
     baseURL: process.env.BASE_URL || "http://localhost:5173",
+    // Tag all Playwright traffic as internal so it can be filtered from GA4 reports.
+    storageState: {
+      cookies: [],
+      origins: [
+        {
+          origin: process.env.BASE_URL || "http://localhost:5173",
+          localStorage: [
+            { name: "analytics_traffic_type", value: "internal" },
+          ],
+        },
+      ],
+    },
   },
   projects: [
     {


### PR DESCRIPTION
## Summary

- Add URL-parameter-driven localStorage flag to tag analytics events with a `traffic_type` user property for GA4 filtering
- `?_ct=internal` sets the flag, `?_ct=clear` removes it, flag persists across sessions
- `setUserProperties` called before any `logEvent` in `analyticsutil/src/index.ts`
- Playwright tests pre-set the localStorage key via `storageState` so all test traffic is tagged internal
- No effect when `measurementId` is absent (preview/emulator environments)

Closes #518