### PR TITLE
Add markdown download and copy controls

### DIFF
--- a/print/e2e/media.spec.ts
+++ b/print/e2e/media.spec.ts
@@ -54,4 +54,31 @@ test.describe("media", () => {
     await page.locator(".viewer-back").click();
     await expect(page.locator("main h2")).toHaveText("Library");
   });
+
+  test("markdown buttons shown for documents with markdownPath", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("#media-list")).toBeVisible({ timeout: 10000 });
+    const phaedrusItem = page.locator("#media-list .media-item", { hasText: "Phaedrus" });
+    await expect(phaedrusItem.locator(".media-md-download")).toBeVisible();
+    await expect(phaedrusItem.locator(".media-md-copy")).toBeVisible();
+  });
+
+  test("markdown buttons not shown for documents without markdownPath", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("#media-list")).toBeVisible({ timeout: 10000 });
+    await expect(page.locator("#media-list .media-md-download")).toHaveCount(1);
+    const republicItem = page.locator("#media-list .media-item", { hasText: "Republic" });
+    await expect(republicItem.locator(".media-md-download")).toHaveCount(0);
+  });
+
+  test("viewer shows markdown buttons for document with markdownPath", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("#media-list")).toBeVisible({ timeout: 10000 });
+    const phaedrusItem = page.locator("#media-list .media-item", { hasText: "Phaedrus" });
+    await phaedrusItem.locator(".media-view").click();
+    await expect(page.locator(".viewer")).toBeVisible({ timeout: 15000 });
+    await expect(page.locator(".viewer-md-actions")).toBeVisible();
+    await expect(page.locator(".viewer-md-actions .media-md-download")).toBeVisible();
+    await expect(page.locator(".viewer-md-actions .media-md-copy")).toBeVisible();
+  });
 });

--- a/print/e2e/viewer.spec.ts
+++ b/print/e2e/viewer.spec.ts
@@ -679,4 +679,10 @@ test.describe("viewer", () => {
     await expect(page.locator(".viewer")).toBeVisible({ timeout: 15000 });
     await expect(page.locator(".viewer-search")).toHaveClass(/search-hidden/);
   });
+
+  test("viewer does not show markdown buttons for document without markdownPath", async ({ page }) => {
+    await page.goto("/view/plato-republic");
+    await expect(page.locator(".viewer")).toBeVisible({ timeout: 15000 });
+    await expect(page.locator(".viewer-md-actions")).toHaveCount(0);
+  });
 });

--- a/print/scripts/attach-markdown.sh
+++ b/print/scripts/attach-markdown.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # Attach a markdown rendering to an existing media document.
-# Uploads the .md file to GCS and patches the Firestore document's markdownPath field.
+# Verifies the document exists and the GCS destination is unoccupied, then uploads
+# the .md file to GCS and patches the Firestore document's markdownPath field.
 # Usage: attach-markdown.sh <docId> <mdFile>
 set -euo pipefail
 
 BUCKET="gs://commons-systems.firebasestorage.app"
 PROJECT="commons-systems"
+# Targets production only -- no environment parameter by design
 COLLECTION_PATH="print/prod/media"
 
 usage() {
@@ -62,7 +64,9 @@ if [ "$DOC_HTTP" -lt 200 ] || [ "$DOC_HTTP" -ge 300 ]; then
 fi
 
 FILENAME="$(basename "$MD_FILE")"
+# Full GCS object path for upload
 GCS_DEST="${BUCKET}/${COLLECTION_PATH}/${FILENAME}"
+# Firestore markdownPath value, resolved relative to the app storage namespace
 STORAGE_PATH="media/${FILENAME}"
 
 # Check for existing object at destination

--- a/print/scripts/attach-markdown.sh
+++ b/print/scripts/attach-markdown.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Attach a markdown rendering to an existing media document.
+# Uploads the .md file to GCS and patches the Firestore document's markdownPath field.
+# Usage: attach-markdown.sh <docId> <mdFile>
+set -euo pipefail
+
+BUCKET="gs://commons-systems.firebasestorage.app"
+PROJECT="commons-systems"
+COLLECTION_PATH="print/prod/media"
+
+usage() {
+  cat >&2 <<EOF
+Usage: attach-markdown.sh <docId> <mdFile>
+
+Arguments:
+  docId       Firestore document ID of the media item
+  mdFile      Local path to the markdown file to attach
+EOF
+  exit 1
+}
+
+for cmd in gsutil gcloud curl jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "error: required command not found: $cmd" >&2
+    exit 1
+  fi
+done
+
+if [ $# -ne 2 ]; then
+  usage
+fi
+
+DOC_ID="$1"
+MD_FILE="$2"
+
+if [ ! -f "$MD_FILE" ]; then
+  echo "error: file not found: ${MD_FILE}" >&2
+  exit 1
+fi
+
+if [[ "$MD_FILE" != *.md ]]; then
+  echo "error: file must have .md extension: ${MD_FILE}" >&2
+  exit 1
+fi
+
+# Get auth token
+if ! TOKEN="$(gcloud auth print-access-token 2>&1)"; then
+  echo "error: failed to get auth token. Run 'gcloud auth login' first." >&2
+  exit 1
+fi
+
+# Verify document exists
+DOC_URL="https://firestore.googleapis.com/v1/projects/${PROJECT}/databases/(default)/documents/${COLLECTION_PATH}/${DOC_ID}"
+DOC_RESP_FILE=$(mktemp)
+trap 'rm -f "$DOC_RESP_FILE"' EXIT
+DOC_HTTP=$(curl -sS -o "$DOC_RESP_FILE" -w '%{http_code}' "$DOC_URL" \
+  --config <(echo "header = \"Authorization: Bearer ${TOKEN}\""))
+
+if [ "$DOC_HTTP" -lt 200 ] || [ "$DOC_HTTP" -ge 300 ]; then
+  echo "error: document '${DOC_ID}' not found (HTTP ${DOC_HTTP})" >&2
+  exit 1
+fi
+
+FILENAME="$(basename "$MD_FILE")"
+GCS_DEST="${BUCKET}/${COLLECTION_PATH}/${FILENAME}"
+STORAGE_PATH="media/${FILENAME}"
+
+# Check for existing object at destination
+if STAT_OUTPUT=$(gsutil stat "$GCS_DEST" 2>&1); then
+  echo "error: object already exists at ${GCS_DEST}" >&2
+  echo "Rename the file or remove the existing object: gsutil rm ${GCS_DEST}" >&2
+  exit 1
+fi
+if ! echo "$STAT_OUTPUT" | grep -q "No URLs matched"; then
+  echo "error: could not verify object status at ${GCS_DEST}:" >&2
+  echo "$STAT_OUTPUT" >&2
+  exit 1
+fi
+
+# Upload markdown file to GCS
+echo "Uploading ${FILENAME} to GCS..."
+gsutil -h "Content-Type:text/markdown" cp "$MD_FILE" "$GCS_DEST"
+
+echo ""
+echo "=== GCS Object ==="
+gsutil stat "$GCS_DEST"
+
+# Patch Firestore document to set markdownPath
+echo ""
+echo "Patching Firestore document..."
+
+PATCH_BODY=$(jq -n --arg mp "$STORAGE_PATH" '{
+  fields: {
+    markdownPath: { stringValue: $mp }
+  }
+}')
+
+RESP_FILE=$(mktemp)
+trap 'rm -f "$DOC_RESP_FILE" "$RESP_FILE"' EXIT
+HTTP_CODE=$(curl -sS -o "$RESP_FILE" -w '%{http_code}' -X PATCH \
+  "${DOC_URL}?updateMask.fieldPaths=markdownPath" \
+  --config <(echo "header = \"Authorization: Bearer ${TOKEN}\"") \
+  -H "Content-Type: application/json" \
+  -d "$PATCH_BODY")
+
+if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+  echo "error: Firestore PATCH returned HTTP ${HTTP_CODE}:" >&2
+  cat "$RESP_FILE" >&2
+  echo "" >&2
+  echo "The markdown file was uploaded to GCS at: ${GCS_DEST}" >&2
+  echo "To clean up: gsutil rm ${GCS_DEST}" >&2
+  exit 1
+fi
+
+echo ""
+echo "=== Updated Document ==="
+echo "Document ID: ${DOC_ID}"
+echo "markdownPath: ${STORAGE_PATH}"
+echo ""
+echo "Done."

--- a/print/seeds/firestore.ts
+++ b/print/seeds/firestore.ts
@@ -27,6 +27,7 @@ const appSeed: Omit<SeedSpec, "namespace"> = {
             publicDomain: true,
             sourceNotes: "Project Gutenberg eBook #3296: https://www.gutenberg.org/ebooks/3296",
             storagePath: "media/pg3296-images-3.epub",
+            markdownPath: null,
             groupId: null,
             memberEmails: [],
 
@@ -42,6 +43,7 @@ const appSeed: Omit<SeedSpec, "namespace"> = {
             publicDomain: true,
             sourceNotes: "Platonic Foundation: https://www.platonicfoundation.org/translation/phaedrus",
             storagePath: "media/phaedrus-david-horan-translation-7-nov-25.pdf",
+            markdownPath: "media/phaedrus-test.md",
             groupId: null,
             memberEmails: [],
 
@@ -57,6 +59,7 @@ const appSeed: Omit<SeedSpec, "namespace"> = {
             publicDomain: true,
             sourceNotes: "Platonic Foundation: https://www.platonicfoundation.org/translation/republic/republic-all-books/",
             storagePath: "media/republic-i-to-x-david-horan-translation-22-nov-25.pdf",
+            markdownPath: null,
             groupId: null,
             memberEmails: [],
 
@@ -78,6 +81,7 @@ const appSeed: Omit<SeedSpec, "namespace"> = {
             publicDomain: true,
             sourceNotes: "Public domain comic strip by Winsor McCay (1905-1914), sourced from Internet Archive",
             storagePath: "media/test-image-archive.cbz",
+            markdownPath: null,
             groupId: null,
             memberEmails: [],
 
@@ -93,6 +97,7 @@ const appSeed: Omit<SeedSpec, "namespace"> = {
             publicDomain: false,
             sourceNotes: "Test-only private item for emulator testing",
             storagePath: "media/test-private-item.pdf",
+            markdownPath: null,
             groupId: "test-group",
             memberEmails: [TEST_USER.email],
 

--- a/print/seeds/storage.ts
+++ b/print/seeds/storage.ts
@@ -254,6 +254,11 @@ const storageSeed: StorageSeedItem[] = [
     metadata: publicMeta,
   },
   {
+    path: "print/prod/media/phaedrus-test.md",
+    content: "# Phaedrus\n\nBy Plato, translated by David Horan.\n\nThis is a test markdown rendering of the Phaedrus dialogue.\n",
+    metadata: publicMeta,
+  },
+  {
     path: "print/prod/media/republic-i-to-x-david-horan-translation-22-nov-25.pdf",
     content: readFileSync(join(__dirname, "pdf-fixtures/republic-3p.pdf")),
     metadata: publicMeta,

--- a/print/src/firestore.ts
+++ b/print/src/firestore.ts
@@ -29,6 +29,7 @@ function toMediaItem(id: string, data: Record<string, unknown>): MediaItem {
     publicDomain: requireBoolean(data.publicDomain, "publicDomain"),
     sourceNotes: requireString(data.sourceNotes, "sourceNotes"),
     storagePath: requireString(data.storagePath, "storagePath"),
+    markdownPath: optionalString(data.markdownPath, "markdownPath"),
     groupId: optionalString(data.groupId, "groupId"),
     memberEmails: requireStringArray(data.memberEmails, "memberEmails"),
     addedAt: requireIso8601(data.addedAt, "addedAt"),

--- a/print/src/markdown-actions.ts
+++ b/print/src/markdown-actions.ts
@@ -40,3 +40,26 @@ export async function handleMarkdownCopy(storagePath: string, button: HTMLButton
     button.disabled = false;
   }
 }
+
+export function wireMarkdownActions(container: HTMLElement): void {
+  container.addEventListener("click", (e) => {
+    const target = e.target as HTMLElement;
+    const mdDownloadBtn = target.closest(".media-md-download") as HTMLButtonElement | null;
+    if (mdDownloadBtn) {
+      e.preventDefault();
+      const mdPath = mdDownloadBtn.dataset.mdPath!;
+      const title = mdDownloadBtn.dataset.title!;
+      mdDownloadBtn.disabled = true;
+      handleMarkdownDownload(mdPath, title)
+        .catch((err) => logError(err, { operation: "markdown-download" }))
+        .finally(() => { mdDownloadBtn.disabled = false; });
+      return;
+    }
+    const mdCopyBtn = target.closest(".media-md-copy") as HTMLButtonElement | null;
+    if (mdCopyBtn) {
+      e.preventDefault();
+      handleMarkdownCopy(mdCopyBtn.dataset.mdPath!, mdCopyBtn)
+        .catch((err) => logError(err, { operation: "markdown-copy" }));
+    }
+  });
+}

--- a/print/src/markdown-actions.ts
+++ b/print/src/markdown-actions.ts
@@ -1,0 +1,42 @@
+import { logError } from "@commons-systems/errorutil/log";
+import { getMediaDownloadUrl } from "./storage.js";
+import { titleToFilename } from "./slug.js";
+
+export async function handleMarkdownDownload(storagePath: string, title: string): Promise<void> {
+  const url = await getMediaDownloadUrl(storagePath);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = titleToFilename(title);
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+export async function handleMarkdownCopy(storagePath: string, button: HTMLButtonElement): Promise<void> {
+  const originalText = button.textContent;
+  button.disabled = true;
+  try {
+    const url = await getMediaDownloadUrl(storagePath);
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Failed to fetch markdown: ${res.status}`);
+    const text = await res.text();
+    await navigator.clipboard.writeText(text);
+    button.textContent = "Copied!";
+    setTimeout(() => { button.textContent = originalText; }, 1500);
+  } catch (error) {
+    logError(error, { operation: "copy-markdown" });
+    const container = button.closest(".media-actions, .viewer-md-actions");
+    if (container) {
+      const existing = container.querySelector(".copy-error");
+      if (!existing) {
+        const msg = document.createElement("p");
+        msg.className = "copy-error";
+        msg.textContent = "Copy failed. Please try again.";
+        container.appendChild(msg);
+      }
+    }
+  } finally {
+    button.disabled = false;
+  }
+}

--- a/print/src/pages/home.ts
+++ b/print/src/pages/home.ts
@@ -4,6 +4,7 @@ import type { User } from "../auth.js";
 import { DataIntegrityError } from "@commons-systems/firestoreutil/errors";
 import { getPublicMedia, getAllAccessibleMedia } from "../firestore.js";
 import { getMediaDownloadUrl } from "../storage.js";
+import { handleMarkdownDownload, handleMarkdownCopy } from "../markdown-actions.js";
 import type { MediaItem, MediaType } from "../types.js";
 
 function mediaTypeBadge(mediaType: MediaType): string {
@@ -25,6 +26,8 @@ function renderMediaList(items: MediaItem[]): string {
         <div class="media-actions">
           <a href="/view/${escapeHtml(item.id)}" class="media-view" title="View in Reader" aria-label="View ${escapeHtml(item.title)}">&#128196;</a>
           <button class="media-download" data-path="${escapeHtml(item.storagePath)}" title="Download" aria-label="Download ${escapeHtml(item.title)}">&#11015;</button>
+          ${item.markdownPath ? `<button class="media-md-download" data-md-path="${escapeHtml(item.markdownPath)}" data-title="${escapeHtml(item.title)}" title="Download Markdown" aria-label="Download Markdown for ${escapeHtml(item.title)}">&#128220;</button>
+          <button class="media-md-copy" data-md-path="${escapeHtml(item.markdownPath)}" title="Copy Markdown" aria-label="Copy Markdown for ${escapeHtml(item.title)}">&#128203;</button>` : ""}
         </div>
       </li>`;
     })
@@ -94,10 +97,29 @@ export async function renderHome(user: User | null): Promise<string> {
 
 export function afterRenderHome(outlet: HTMLElement): void {
   outlet.addEventListener("click", (e) => {
-    const button = (e.target as HTMLElement).closest(".media-download") as HTMLButtonElement | null;
-    if (button) {
+    const target = e.target as HTMLElement;
+    const downloadBtn = target.closest(".media-download") as HTMLButtonElement | null;
+    if (downloadBtn) {
       e.preventDefault();
-      handleDownload(button).catch((err) => logError(err, { operation: "download" }));
+      handleDownload(downloadBtn).catch((err) => logError(err, { operation: "download" }));
+      return;
+    }
+    const mdDownloadBtn = target.closest(".media-md-download") as HTMLButtonElement | null;
+    if (mdDownloadBtn) {
+      e.preventDefault();
+      const mdPath = mdDownloadBtn.dataset.mdPath!;
+      const title = mdDownloadBtn.dataset.title!;
+      mdDownloadBtn.disabled = true;
+      handleMarkdownDownload(mdPath, title)
+        .catch((err) => logError(err, { operation: "markdown-download" }))
+        .finally(() => { mdDownloadBtn.disabled = false; });
+      return;
+    }
+    const mdCopyBtn = target.closest(".media-md-copy") as HTMLButtonElement | null;
+    if (mdCopyBtn) {
+      e.preventDefault();
+      handleMarkdownCopy(mdCopyBtn.dataset.mdPath!, mdCopyBtn)
+        .catch((err) => logError(err, { operation: "markdown-copy" }));
     }
   });
 }

--- a/print/src/pages/home.ts
+++ b/print/src/pages/home.ts
@@ -4,7 +4,7 @@ import type { User } from "../auth.js";
 import { DataIntegrityError } from "@commons-systems/firestoreutil/errors";
 import { getPublicMedia, getAllAccessibleMedia } from "../firestore.js";
 import { getMediaDownloadUrl } from "../storage.js";
-import { handleMarkdownDownload, handleMarkdownCopy } from "../markdown-actions.js";
+import { wireMarkdownActions } from "../markdown-actions.js";
 import type { MediaItem, MediaType } from "../types.js";
 
 function mediaTypeBadge(mediaType: MediaType): string {
@@ -102,24 +102,7 @@ export function afterRenderHome(outlet: HTMLElement): void {
     if (downloadBtn) {
       e.preventDefault();
       handleDownload(downloadBtn).catch((err) => logError(err, { operation: "download" }));
-      return;
-    }
-    const mdDownloadBtn = target.closest(".media-md-download") as HTMLButtonElement | null;
-    if (mdDownloadBtn) {
-      e.preventDefault();
-      const mdPath = mdDownloadBtn.dataset.mdPath!;
-      const title = mdDownloadBtn.dataset.title!;
-      mdDownloadBtn.disabled = true;
-      handleMarkdownDownload(mdPath, title)
-        .catch((err) => logError(err, { operation: "markdown-download" }))
-        .finally(() => { mdDownloadBtn.disabled = false; });
-      return;
-    }
-    const mdCopyBtn = target.closest(".media-md-copy") as HTMLButtonElement | null;
-    if (mdCopyBtn) {
-      e.preventDefault();
-      handleMarkdownCopy(mdCopyBtn.dataset.mdPath!, mdCopyBtn)
-        .catch((err) => logError(err, { operation: "markdown-copy" }));
     }
   });
+  wireMarkdownActions(outlet);
 }

--- a/print/src/pages/view.ts
+++ b/print/src/pages/view.ts
@@ -2,6 +2,8 @@ import type { User } from "../auth.js";
 import { classifyError } from "@commons-systems/errorutil/classify";
 import { getMediaItem } from "../firestore.js";
 import { getMediaDownloadUrl } from "../storage.js";
+import { handleMarkdownDownload, handleMarkdownCopy } from "../markdown-actions.js";
+import { logError } from "@commons-systems/errorutil/log";
 import type { MediaItem } from "../types.js";
 import { renderViewerShell, initViewer } from "../viewer/shell.js";
 import { createPdfRenderer } from "../viewer/pdf.js";
@@ -103,4 +105,26 @@ export function afterRenderView(outlet: HTMLElement, user: User | null): void {
       if (pos) pos.textContent = `Unsupported media type: ${_exhaustive}`;
     }
   }
+
+  // Wire markdown action buttons (if present)
+  outlet.addEventListener("click", (e) => {
+    const target = e.target as HTMLElement;
+    const mdDownloadBtn = target.closest(".media-md-download") as HTMLButtonElement | null;
+    if (mdDownloadBtn) {
+      e.preventDefault();
+      const mdPath = mdDownloadBtn.dataset.mdPath!;
+      const title = mdDownloadBtn.dataset.title!;
+      mdDownloadBtn.disabled = true;
+      handleMarkdownDownload(mdPath, title)
+        .catch((err) => logError(err, { operation: "markdown-download" }))
+        .finally(() => { mdDownloadBtn.disabled = false; });
+      return;
+    }
+    const mdCopyBtn = target.closest(".media-md-copy") as HTMLButtonElement | null;
+    if (mdCopyBtn) {
+      e.preventDefault();
+      handleMarkdownCopy(mdCopyBtn.dataset.mdPath!, mdCopyBtn)
+        .catch((err) => logError(err, { operation: "markdown-copy" }));
+    }
+  });
 }

--- a/print/src/pages/view.ts
+++ b/print/src/pages/view.ts
@@ -2,8 +2,7 @@ import type { User } from "../auth.js";
 import { classifyError } from "@commons-systems/errorutil/classify";
 import { getMediaItem } from "../firestore.js";
 import { getMediaDownloadUrl } from "../storage.js";
-import { handleMarkdownDownload, handleMarkdownCopy } from "../markdown-actions.js";
-import { logError } from "@commons-systems/errorutil/log";
+import { wireMarkdownActions } from "../markdown-actions.js";
 import type { MediaItem } from "../types.js";
 import { renderViewerShell, initViewer } from "../viewer/shell.js";
 import { createPdfRenderer } from "../viewer/pdf.js";
@@ -106,25 +105,5 @@ export function afterRenderView(outlet: HTMLElement, user: User | null): void {
     }
   }
 
-  // Wire markdown action buttons (if present)
-  outlet.addEventListener("click", (e) => {
-    const target = e.target as HTMLElement;
-    const mdDownloadBtn = target.closest(".media-md-download") as HTMLButtonElement | null;
-    if (mdDownloadBtn) {
-      e.preventDefault();
-      const mdPath = mdDownloadBtn.dataset.mdPath!;
-      const title = mdDownloadBtn.dataset.title!;
-      mdDownloadBtn.disabled = true;
-      handleMarkdownDownload(mdPath, title)
-        .catch((err) => logError(err, { operation: "markdown-download" }))
-        .finally(() => { mdDownloadBtn.disabled = false; });
-      return;
-    }
-    const mdCopyBtn = target.closest(".media-md-copy") as HTMLButtonElement | null;
-    if (mdCopyBtn) {
-      e.preventDefault();
-      handleMarkdownCopy(mdCopyBtn.dataset.mdPath!, mdCopyBtn)
-        .catch((err) => logError(err, { operation: "markdown-copy" }));
-    }
-  });
+  wireMarkdownActions(outlet);
 }

--- a/print/src/slug.ts
+++ b/print/src/slug.ts
@@ -1,0 +1,3 @@
+export function titleToFilename(title: string): string {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") + ".md";
+}

--- a/print/src/types.ts
+++ b/print/src/types.ts
@@ -9,6 +9,7 @@ export interface MediaItem {
   readonly publicDomain: boolean;
   readonly sourceNotes: string;
   readonly storagePath: string;
+  readonly markdownPath: string | null;
   readonly groupId: string | null;
   readonly memberEmails: readonly string[];
   readonly addedAt: string;

--- a/print/src/viewer/shell.ts
+++ b/print/src/viewer/shell.ts
@@ -46,6 +46,10 @@ export function renderViewerShell(item: MediaItem): string {
           ${item.publicDomain ? '<p class="viewer-pd">Public Domain</p>' : ""}
           <p class="viewer-source">${escapeHtml(item.sourceNotes)}</p>
           <div class="viewer-tags">${renderTags(item.tags)}</div>
+          ${item.markdownPath ? `<div class="viewer-md-actions">
+            <button class="media-md-download" data-md-path="${escapeHtml(item.markdownPath)}" data-title="${escapeHtml(item.title)}" title="Download Markdown" aria-label="Download Markdown">&#128220;</button>
+            <button class="media-md-copy" data-md-path="${escapeHtml(item.markdownPath)}" title="Copy Markdown" aria-label="Copy Markdown">&#128203;</button>
+          </div>` : ""}
         </div>
       </aside>
     </div>

--- a/print/test/firestore.test.ts
+++ b/print/test/firestore.test.ts
@@ -43,6 +43,7 @@ function validMediaDoc(
       publicDomain: true,
       sourceNotes: "Public domain source",
       storagePath: `media/${id}.pdf`,
+      markdownPath: null,
       groupId: null,
       memberEmails: ["user@example.com"],
       addedAt: "2026-01-01T00:00:00Z",
@@ -101,6 +102,7 @@ describe("getPublicMedia", () => {
         publicDomain: true,
         sourceNotes: "Public domain source",
         storagePath: "media/doc-2.pdf",
+        markdownPath: null,
         groupId: null,
         memberEmails: ["user@example.com"],
         addedAt: "2026-01-02T00:00:00Z",
@@ -113,6 +115,7 @@ describe("getPublicMedia", () => {
         publicDomain: true,
         sourceNotes: "Public domain source",
         storagePath: "media/doc-1.pdf",
+        markdownPath: null,
         groupId: null,
         memberEmails: ["user@example.com"],
         addedAt: "2026-01-01T00:00:00Z",
@@ -373,10 +376,35 @@ describe("getMediaItem", () => {
       publicDomain: true,
       sourceNotes: "Public domain source",
       storagePath: "media/doc-1.pdf",
+      markdownPath: null,
       groupId: null,
       memberEmails: ["user@example.com"],
       addedAt: "2026-01-01T00:00:00Z",
     });
+  });
+
+  it("parses markdownPath when present as a string", async () => {
+    const docData = validMediaDoc("with-md", { markdownPath: "media/test.md" });
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      id: docData.id,
+      data: docData.data,
+    });
+
+    const result = await getMediaItem("with-md");
+
+    expect(result!.markdownPath).toBe("media/test.md");
+  });
+
+  it("throws DataIntegrityError for non-string non-null markdownPath", async () => {
+    const docData = validMediaDoc("bad-md", { markdownPath: 42 });
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      id: docData.id,
+      data: docData.data,
+    });
+
+    await expect(getMediaItem("bad-md")).rejects.toThrow(DataIntegrityError);
   });
 
   it("throws DataIntegrityError for corrupt document data", async () => {

--- a/print/test/markdown-actions.test.ts
+++ b/print/test/markdown-actions.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockGetMediaDownloadUrl = vi.fn();
+
+vi.mock("../src/storage.js", () => ({
+  getMediaDownloadUrl: (...args: unknown[]) => mockGetMediaDownloadUrl(...args),
+}));
+
+vi.mock("@commons-systems/errorutil/log", () => ({
+  logError: vi.fn(),
+}));
+
+import { handleMarkdownDownload, handleMarkdownCopy } from "../src/markdown-actions";
+
+describe("handleMarkdownDownload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates an anchor element with correct href and download attribute, then clicks it", async () => {
+    mockGetMediaDownloadUrl.mockResolvedValue("https://storage.example.com/media/test.md");
+
+    const appendedChildren: Node[] = [];
+    const removedChildren: Node[] = [];
+    let clicked = false;
+
+    const origCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = origCreateElement(tag);
+      if (tag === "a") {
+        vi.spyOn(el, "click").mockImplementation(() => { clicked = true; });
+      }
+      return el;
+    });
+    vi.spyOn(document.body, "appendChild").mockImplementation((node: Node) => {
+      appendedChildren.push(node);
+      return node;
+    });
+    vi.spyOn(document.body, "removeChild").mockImplementation((node: Node) => {
+      removedChildren.push(node);
+      return node;
+    });
+
+    await handleMarkdownDownload("media/test.md", "Test Title");
+
+    expect(mockGetMediaDownloadUrl).toHaveBeenCalledWith("media/test.md");
+    expect(appendedChildren).toHaveLength(1);
+    const anchor = appendedChildren[0] as HTMLAnchorElement;
+    expect(anchor.download).toBe("test-title.md");
+    expect(anchor.href).toContain("https://storage.example.com/media/test.md");
+    expect(anchor.style.display).toBe("none");
+    expect(clicked).toBe(true);
+    expect(removedChildren).toHaveLength(1);
+    expect(removedChildren[0]).toBe(anchor);
+
+    vi.restoreAllMocks();
+  });
+});
+
+describe("handleMarkdownCopy", () => {
+  let mockWriteText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: mockWriteText },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches markdown content and copies it to clipboard", async () => {
+    mockGetMediaDownloadUrl.mockResolvedValue("https://storage.example.com/media/test.md");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("# Hello World", { status: 200 }),
+    );
+
+    const button = document.createElement("button");
+    button.textContent = "Copy";
+    const container = document.createElement("div");
+    container.className = "media-actions";
+    container.appendChild(button);
+
+    await handleMarkdownCopy("media/test.md", button);
+
+    expect(mockGetMediaDownloadUrl).toHaveBeenCalledWith("media/test.md");
+    expect(mockWriteText).toHaveBeenCalledWith("# Hello World");
+    expect(button.textContent).toBe("Copied!");
+    expect(button.disabled).toBe(false);
+  });
+
+  it("appends error message on fetch failure", async () => {
+    mockGetMediaDownloadUrl.mockResolvedValue("https://storage.example.com/media/test.md");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("", { status: 500 }),
+    );
+
+    const button = document.createElement("button");
+    button.textContent = "Copy";
+    const container = document.createElement("div");
+    container.className = "media-actions";
+    container.appendChild(button);
+
+    await handleMarkdownCopy("media/test.md", button);
+
+    const errorEl = container.querySelector(".copy-error");
+    expect(errorEl).not.toBeNull();
+    expect(errorEl!.textContent).toBe("Copy failed. Please try again.");
+    expect(button.disabled).toBe(false);
+  });
+
+  it("does not add duplicate error messages", async () => {
+    mockGetMediaDownloadUrl.mockResolvedValue("https://storage.example.com/media/test.md");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("", { status: 500 }),
+    );
+
+    const button = document.createElement("button");
+    button.textContent = "Copy";
+    const container = document.createElement("div");
+    container.className = "viewer-md-actions";
+    container.appendChild(button);
+
+    await handleMarkdownCopy("media/test.md", button);
+
+    // Re-mock fetch since Response body is consumed
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response("", { status: 500 }),
+    );
+    await handleMarkdownCopy("media/test.md", button);
+
+    const errors = container.querySelectorAll(".copy-error");
+    expect(errors).toHaveLength(1);
+  });
+
+  it("re-enables button after clipboard write failure", async () => {
+    mockGetMediaDownloadUrl.mockResolvedValue("https://storage.example.com/media/test.md");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("# content", { status: 200 }),
+    );
+    mockWriteText.mockRejectedValue(new Error("clipboard denied"));
+
+    const button = document.createElement("button");
+    button.textContent = "Copy";
+    const container = document.createElement("div");
+    container.className = "media-actions";
+    container.appendChild(button);
+
+    await handleMarkdownCopy("media/test.md", button);
+
+    expect(button.disabled).toBe(false);
+  });
+});

--- a/print/test/pages/home.test.ts
+++ b/print/test/pages/home.test.ts
@@ -33,6 +33,7 @@ function makeMediaItem(overrides: Partial<MediaItem> = {}): MediaItem {
     publicDomain: true,
     sourceNotes: "Public domain source",
     storagePath: "media/test-book.pdf",
+    markdownPath: null,
     groupId: null,
     memberEmails: [],
     addedAt: "2026-01-15T00:00:00Z",
@@ -171,6 +172,29 @@ describe("renderHome", () => {
 
     expect(html).toContain('id="media-error"');
     expect(html).toContain("Could not load media library.");
+  });
+
+  it("renders markdown buttons when markdownPath is non-null", async () => {
+    mockGetPublicMedia.mockResolvedValue([
+      makeMediaItem({ markdownPath: "media/test.md" }),
+    ]);
+
+    const html = await renderHome(null);
+
+    expect(html).toContain('class="media-md-download"');
+    expect(html).toContain('class="media-md-copy"');
+    expect(html).toContain('data-md-path="media/test.md"');
+  });
+
+  it("does not render markdown buttons when markdownPath is null", async () => {
+    mockGetPublicMedia.mockResolvedValue([
+      makeMediaItem(),
+    ]);
+
+    const html = await renderHome(null);
+
+    expect(html).not.toContain("media-md-download");
+    expect(html).not.toContain("media-md-copy");
   });
 
   it("re-throws DataIntegrityError", async () => {

--- a/print/test/slug.test.ts
+++ b/print/test/slug.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { titleToFilename } from "../src/slug";
+
+describe("titleToFilename", () => {
+  it("converts title to lowercase kebab-case with .md extension", () => {
+    expect(titleToFilename("The Confessions of St. Augustine")).toBe("the-confessions-of-st-augustine.md");
+  });
+
+  it("handles special characters", () => {
+    expect(titleToFilename("Plato's Republic (Vol. 1)")).toBe("plato-s-republic-vol-1.md");
+  });
+
+  it("collapses consecutive special characters into a single hyphen", () => {
+    expect(titleToFilename("Hello---World")).toBe("hello-world.md");
+  });
+
+  it("strips leading and trailing hyphens", () => {
+    expect(titleToFilename("--Hello--")).toBe("hello.md");
+  });
+
+  it("handles single word", () => {
+    expect(titleToFilename("Phaedrus")).toBe("phaedrus.md");
+  });
+});

--- a/print/test/viewer/shell.test.ts
+++ b/print/test/viewer/shell.test.ts
@@ -30,6 +30,7 @@ function makeMediaItem(overrides: Partial<MediaItem> = {}): MediaItem {
     publicDomain: true,
     sourceNotes: "Sourced from archive.org",
     storagePath: "media/test-book.pdf",
+    markdownPath: null,
     groupId: null,
     memberEmails: ["user@example.com"],
     addedAt: "2026-01-15T00:00:00Z",
@@ -150,6 +151,23 @@ describe("renderViewerShell", () => {
     const html = renderViewerShell(makeMediaItem());
 
     expect(html).toContain('class="viewer-search search-hidden"');
+  });
+
+  it("renders .viewer-md-actions with both buttons when markdownPath is non-null", () => {
+    const html = renderViewerShell(makeMediaItem({ markdownPath: "media/test.md" }));
+
+    expect(html).toContain('class="viewer-md-actions"');
+    expect(html).toContain('class="media-md-download"');
+    expect(html).toContain('class="media-md-copy"');
+    expect(html).toContain('data-md-path="media/test.md"');
+  });
+
+  it("does not render .viewer-md-actions when markdownPath is null", () => {
+    const html = renderViewerShell(makeMediaItem({ markdownPath: null }));
+
+    expect(html).not.toContain("viewer-md-actions");
+    expect(html).not.toContain("media-md-download");
+    expect(html).not.toContain("media-md-copy");
   });
 
   it("escapes HTML in title", () => {


### PR DESCRIPTION
## Summary

- Add optional `markdownPath` field to `MediaItem` for documents with companion markdown renderings
- Render download-markdown and copy-markdown buttons on the library page and viewer info panel when `markdownPath` is set
- Shared handlers in `markdown-actions.ts`: download uses title-based filename, copy writes to clipboard with transient success state
- New `attach-markdown.sh` script to upload a `.md` file and patch an existing Firestore document
- Seed data updated with Phaedrus markdown rendering for e2e testing

Closes #520