### PR TITLE
Display PDF and EPUB table of contents in viewer info panel

### DIFF
--- a/print/e2e/viewer.spec.ts
+++ b/print/e2e/viewer.spec.ts
@@ -679,4 +679,75 @@ test.describe("viewer", () => {
     await expect(page.locator(".viewer")).toBeVisible({ timeout: 15000 });
     await expect(page.locator(".viewer-search")).toHaveClass(/search-hidden/);
   });
+
+  test("EPUB outline is visible with TOC entries", async ({ page }) => {
+    await page.goto("/view/gutenberg-3296");
+    await expect(page.locator(".viewer")).toBeVisible({ timeout: 15000 });
+    await expect(page.locator(".viewer-position")).toContainText("Ch. 1/3", {
+      timeout: 15000,
+    });
+
+    const outline = page.locator(".viewer-outline");
+    await expect(outline).not.toHaveClass(/outline-hidden/, { timeout: 15000 });
+    const entries = page.locator(".viewer-outline-entry");
+    await expect(entries.first()).toBeVisible();
+    expect(await entries.count()).toBeGreaterThanOrEqual(3);
+  });
+
+  test("EPUB outline navigation changes chapter", async ({ page }) => {
+    await page.goto("/view/gutenberg-3296");
+    const position = page.locator(".viewer-position");
+    await expect(position).toContainText("Ch. 1/3", { timeout: 15000 });
+
+    // Click the last TOC entry to navigate to a different chapter
+    const entries = page.locator(".viewer-outline-entry");
+    await entries.last().click();
+    await expect(position).not.toContainText("Ch. 1/3", { timeout: 15000 });
+  });
+
+  test("EPUB outline expand and collapse nested entries", async ({ page }) => {
+    await page.goto("/view/gutenberg-3296");
+    await expect(page.locator(".viewer")).toBeVisible({ timeout: 15000 });
+    await expect(page.locator(".viewer-position")).toContainText("Ch. 1/3", {
+      timeout: 15000,
+    });
+
+    // Wait for outline to populate
+    const outline = page.locator(".viewer-outline");
+    await expect(outline).not.toHaveClass(/outline-hidden/, { timeout: 15000 });
+
+    // First entry has nested children -- toggle button should be present
+    const toggle = page.locator(".viewer-outline-toggle").first();
+    await expect(toggle).toBeVisible();
+
+    // Children start collapsed
+    const children = page.locator(".viewer-outline-children").first();
+    await expect(children).toHaveClass(/outline-collapsed/);
+
+    // Expand
+    await toggle.click();
+    await expect(children).not.toHaveClass(/outline-collapsed/);
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    // Collapse
+    await toggle.click();
+    await expect(children).toHaveClass(/outline-collapsed/);
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("image archive outline is hidden", async ({ page }) => {
+    await page.goto("/view/test-image-archive");
+    await expect(page.locator(".viewer")).toBeVisible({ timeout: 15000 });
+    await expect(page.locator(".viewer-outline")).toHaveClass(/outline-hidden/);
+  });
+
+  test("PDF outline is hidden when PDF has no bookmarks", async ({ page }) => {
+    // The plato-republic seed PDF was truncated with pdf-lib, which strips bookmarks.
+    await page.goto("/view/plato-republic");
+    await expect(page.locator(".viewer")).toBeVisible({ timeout: 15000 });
+    await expect(page.locator(".viewer-position")).toContainText("1 / 3", {
+      timeout: 15000,
+    });
+    await expect(page.locator(".viewer-outline")).toHaveClass(/outline-hidden/);
+  });
 });

--- a/print/seeds/storage.ts
+++ b/print/seeds/storage.ts
@@ -81,8 +81,14 @@ function makeEpub(chapterCount: number, chapterBodies: string[] = []): Buffer {
   // Build manifest and spine entries
   const manifestItems: string[] = [
     `    <item id="css" href="style.css" media-type="text/css"/>`,
+    `    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>`,
   ];
   const spineItems: string[] = [];
+  const chapterTitles = [
+    "Preliminary Confessions",
+    "The Pleasures of Opium",
+    "Introduction to the Pains of Opium",
+  ];
   for (let i = 1; i <= chapterCount; i++) {
     manifestItems.push(
       `    <item id="ch${i}" href="chapter${i}.xhtml" media-type="application/xhtml+xml"/>`,
@@ -109,6 +115,39 @@ ${manifestItems.join("\n")}
 ${spineItems.join("\n")}
   </spine>
 </package>`),
+  });
+
+  // EPUB3 navigation document (TOC).
+  // Chapter 1 has nested sub-entries to exercise expand/collapse in tests.
+  const navItems = Array.from({ length: chapterCount }, (_, i) => {
+    const title = chapterTitles[i] ?? `Chapter ${i + 1}`;
+    if (i === 0) {
+      return `        <li>
+          <a href="chapter1.xhtml">${title}</a>
+          <ol>
+            <li><a href="chapter1.xhtml#part-i">Part I</a></li>
+            <li><a href="chapter1.xhtml#part-ii">Part II</a></li>
+          </ol>
+        </li>`;
+    }
+    return `        <li><a href="chapter${i + 1}.xhtml">${title}</a></li>`;
+  });
+  files.push({
+    name: "OEBPS/nav.xhtml",
+    data: Buffer.from(
+      `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>Table of Contents</title></head>
+<body>
+  <nav epub:type="toc">
+    <h1>Table of Contents</h1>
+    <ol>
+${navItems.join("\n")}
+    </ol>
+  </nav>
+</body>
+</html>`),
   });
 
   // Chapter XHTML files

--- a/print/src/style/viewer.css
+++ b/print/src/style/viewer.css
@@ -250,7 +250,8 @@ body.viewer-active {
 
 .zoom-hidden,
 .spread-hidden,
-.search-hidden {
+.search-hidden,
+.outline-hidden {
   display: none;
 }
 
@@ -386,4 +387,78 @@ body.viewer-active {
   padding: 0.1rem 0.3rem;
   border: 1px solid var(--muted-fg, #888);
   border-radius: 3px;
+}
+
+/* Outline / TOC */
+.viewer-outline-heading {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.viewer-outline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 40vh;
+  overflow-y: auto;
+  border: 1px solid var(--muted-fg, #888);
+  border-radius: 3px;
+}
+
+.viewer-outline-list:empty {
+  display: none;
+}
+
+.viewer-outline-item {
+  font-size: 0.8rem;
+}
+
+.viewer-outline-row {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.3rem 0.5rem;
+  border-bottom: 1px solid var(--muted-fg, #888);
+}
+
+.viewer-outline-item:last-child > .viewer-outline-row {
+  border-bottom: none;
+}
+
+.viewer-outline-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.6rem;
+  color: var(--muted-fg, #888);
+  flex-shrink: 0;
+  width: 1rem;
+  text-align: center;
+}
+
+.viewer-outline-entry {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.viewer-outline-entry:hover {
+  text-decoration: underline;
+}
+
+.viewer-outline-children {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  padding-left: 1rem;
+}
+
+.outline-collapsed {
+  display: none;
 }

--- a/print/src/viewer/epub.ts
+++ b/print/src/viewer/epub.ts
@@ -162,7 +162,7 @@ export function createEpubRenderer(
     async goToOutlineEntry(entry: OutlineEntry): Promise<void> {
       if (!rendition) return;
       const href = outlineHrefMap.get(entry);
-      if (!href) return;
+      if (!href) throw new Error("Outline entry not found in href map");
       const relocated = waitForRelocated();
       await rendition.display(href);
       await relocated;

--- a/print/src/viewer/epub.ts
+++ b/print/src/viewer/epub.ts
@@ -1,5 +1,5 @@
-import ePub, { type Book, type Rendition, type Location } from "epubjs";
-import type { ContentRenderer } from "./types.js";
+import ePub, { type Book, type Rendition, type Location, type NavItem } from "epubjs";
+import type { ContentRenderer, OutlineEntry } from "./types.js";
 
 export function createEpubRenderer(
   onError?: (err: unknown) => void,
@@ -15,6 +15,16 @@ export function createEpubRenderer(
   let _atEnd = false;
   let _currentCfi = "";
   let destroyed = false;
+  const outlineHrefMap = new WeakMap<OutlineEntry, string>();
+
+  function mapNavItems(items: NavItem[]): OutlineEntry[] {
+    return items.map((item) => {
+      const children = item.subitems ? mapNavItems(item.subitems) : [];
+      const entry: OutlineEntry = { title: item.label, children };
+      outlineHrefMap.set(entry, item.href);
+      return entry;
+    });
+  }
 
   // epub.js next()/prev() resolve before the relocated event fires.
   // Callers await this to get updated position state. The 5s timeout
@@ -139,6 +149,23 @@ export function createEpubRenderer(
     },
     get positionLabel() {
       return `Ch. ${_chapterIndex + 1}/${_chapterCount} — p. ${_subPage}/${_subPageTotal}`;
+    },
+
+    async getOutline(): Promise<OutlineEntry[]> {
+      if (!book) return [];
+      await book.loaded.navigation;
+      const toc = book.navigation.toc;
+      if (!toc || toc.length === 0) return [];
+      return mapNavItems(toc);
+    },
+
+    async goToOutlineEntry(entry: OutlineEntry): Promise<void> {
+      if (!rendition) return;
+      const href = outlineHrefMap.get(entry);
+      if (!href) return;
+      const relocated = waitForRelocated();
+      await rendition.display(href);
+      await relocated;
     },
 
     destroy(): void {

--- a/print/src/viewer/outline.ts
+++ b/print/src/viewer/outline.ts
@@ -1,0 +1,115 @@
+import { escapeHtml } from "@commons-systems/htmlutil";
+import type { ContentRenderer, OutlineEntry } from "./types.js";
+
+export function renderOutlineSection(): string {
+  return `
+    <div class="viewer-outline outline-hidden">
+      <h4 class="viewer-outline-heading">Contents</h4>
+      <ul class="viewer-outline-list" role="tree"></ul>
+    </div>
+  `;
+}
+
+function renderEntryItem(entry: OutlineEntry, index: number, depth: number): string {
+  const hasChildren = entry.children.length > 0;
+  const toggleBtn = hasChildren
+    ? `<button class="viewer-outline-toggle" aria-expanded="false" aria-label="Expand">\u25b6</button>`
+    : "";
+  const childrenHtml = hasChildren
+    ? `<ul class="viewer-outline-children outline-collapsed" role="group">${
+        entry.children.map((child, i) => renderEntryItem(child, i, depth + 1)).join("")
+      }</ul>`
+    : "";
+  return `<li class="viewer-outline-item" role="treeitem" data-depth="${depth}" data-index="${index}">` +
+    `<span class="viewer-outline-row">${toggleBtn}<a class="viewer-outline-entry" href="#" data-depth="${depth}" data-index="${index}">${escapeHtml(entry.title)}</a></span>` +
+    childrenHtml +
+    `</li>`;
+}
+
+export function initOutline(
+  container: HTMLElement,
+  renderer: ContentRenderer,
+  onNavigate: () => void,
+): (() => void) | null {
+  if (!renderer.getOutline || !renderer.goToOutlineEntry) return null;
+  const getOutline = renderer.getOutline;
+  const goToOutlineEntry = renderer.goToOutlineEntry;
+
+  const section = container.querySelector(".viewer-outline") as HTMLElement;
+  const list = container.querySelector(".viewer-outline-list") as HTMLUListElement;
+
+  let entries: OutlineEntry[] = [];
+  let destroyed = false;
+
+  function handleEntryClick(e: Event) {
+    e.preventDefault();
+    const anchor = (e.target as HTMLElement).closest(".viewer-outline-entry") as HTMLElement | null;
+    if (!anchor) return;
+    const li = anchor.closest(".viewer-outline-item") as HTMLElement | null;
+    if (!li) return;
+    const entry = findEntryForElement(li);
+    if (!entry) return;
+    goToOutlineEntry(entry).then(() => {
+      onNavigate();
+    }).catch((err) => {
+      reportError(new Error("Outline navigation failed", { cause: err }));
+    });
+  }
+
+  function findEntryForElement(li: HTMLElement): OutlineEntry | null {
+    const path: number[] = [];
+    let current: HTMLElement | null = li;
+    while (current) {
+      const parent = current.parentElement;
+      if (!parent) break;
+      const siblings = Array.from(parent.children).filter(
+        (el) => el.classList.contains("viewer-outline-item"),
+      );
+      const idx = siblings.indexOf(current);
+      if (idx === -1) break;
+      path.unshift(idx);
+      current = parent.closest(".viewer-outline-item") as HTMLElement | null;
+    }
+    let items: readonly OutlineEntry[] = entries;
+    let entry: OutlineEntry | null = null;
+    for (const idx of path) {
+      if (idx >= items.length) return null;
+      entry = items[idx]!;
+      items = entry.children;
+    }
+    return entry;
+  }
+
+  function handleToggleClick(e: Event) {
+    const btn = (e.target as HTMLElement).closest(".viewer-outline-toggle") as HTMLButtonElement | null;
+    if (!btn) return;
+    const li = btn.closest(".viewer-outline-item") as HTMLElement | null;
+    if (!li) return;
+    const childList = li.querySelector(":scope > .viewer-outline-children") as HTMLElement | null;
+    if (!childList) return;
+    const collapsed = childList.classList.toggle("outline-collapsed");
+    btn.setAttribute("aria-expanded", String(!collapsed));
+    btn.textContent = collapsed ? "\u25b6" : "\u25bc";
+    btn.setAttribute("aria-label", collapsed ? "Expand" : "Collapse");
+  }
+
+  // Safe: renderEntryItem escapes all user-provided text via escapeHtml.
+  getOutline().then((result) => {
+    if (destroyed) return;
+    entries = result;
+    if (entries.length === 0) return;
+    section.classList.remove("outline-hidden");
+    list.innerHTML = entries.map((entry, i) => renderEntryItem(entry, i, 0)).join("");
+  }).catch((err) => {
+    reportError(new Error("Failed to load outline", { cause: err }));
+  });
+
+  list.addEventListener("click", handleEntryClick);
+  list.addEventListener("click", handleToggleClick);
+
+  return () => {
+    destroyed = true;
+    list.removeEventListener("click", handleEntryClick);
+    list.removeEventListener("click", handleToggleClick);
+  };
+}

--- a/print/src/viewer/outline.ts
+++ b/print/src/viewer/outline.ts
@@ -10,18 +10,18 @@ export function renderOutlineSection(): string {
   `;
 }
 
-function renderEntryItem(entry: OutlineEntry, index: number, depth: number): string {
+function renderEntryItem(entry: OutlineEntry): string {
   const hasChildren = entry.children.length > 0;
   const toggleBtn = hasChildren
     ? `<button class="viewer-outline-toggle" aria-expanded="false" aria-label="Expand">\u25b6</button>`
     : "";
   const childrenHtml = hasChildren
     ? `<ul class="viewer-outline-children outline-collapsed" role="group">${
-        entry.children.map((child, i) => renderEntryItem(child, i, depth + 1)).join("")
+        entry.children.map((child) => renderEntryItem(child)).join("")
       }</ul>`
     : "";
-  return `<li class="viewer-outline-item" role="treeitem" data-depth="${depth}" data-index="${index}">` +
-    `<span class="viewer-outline-row">${toggleBtn}<a class="viewer-outline-entry" href="#" data-depth="${depth}" data-index="${index}">${escapeHtml(entry.title)}</a></span>` +
+  return `<li class="viewer-outline-item" role="treeitem">` +
+    `<span class="viewer-outline-row">${toggleBtn}<a class="viewer-outline-entry" href="#">${escapeHtml(entry.title)}</a></span>` +
     childrenHtml +
     `</li>`;
 }
@@ -99,7 +99,7 @@ export function initOutline(
     entries = result;
     if (entries.length === 0) return;
     section.classList.remove("outline-hidden");
-    list.innerHTML = entries.map((entry, i) => renderEntryItem(entry, i, 0)).join("");
+    list.innerHTML = entries.map((entry) => renderEntryItem(entry)).join("");
   }).catch((err) => {
     reportError(new Error("Failed to load outline", { cause: err }));
   });

--- a/print/src/viewer/pdf.ts
+++ b/print/src/viewer/pdf.ts
@@ -35,15 +35,19 @@ export function createPdfRenderer(onError?: (err: unknown) => void): ContentRend
     for (const item of items) {
       let page: number | null = null;
       if (item.dest) {
-        let destArray: Array<unknown> | null = null;
-        if (typeof item.dest === "string") {
-          destArray = await pdfDoc!.getDestination(item.dest);
-        } else {
-          destArray = item.dest;
-        }
-        if (destArray && destArray.length > 0) {
-          const pageIndex = await pdfDoc!.getPageIndex(destArray[0] as { num: number; gen: number });
-          page = pageIndex + 1; // 1-based
+        try {
+          let destArray: Array<unknown> | null = null;
+          if (typeof item.dest === "string") {
+            destArray = await pdfDoc!.getDestination(item.dest);
+          } else {
+            destArray = item.dest;
+          }
+          if (destArray && destArray.length > 0) {
+            const pageIndex = await pdfDoc!.getPageIndex(destArray[0] as { num: number; gen: number });
+            page = pageIndex + 1; // 1-based
+          }
+        } catch (err) {
+          reportError(new Error(`Failed to resolve outline destination for "${item.title}"`, { cause: err }));
         }
       }
       const children = item.items.length > 0 ? await resolveOutlineItems(item.items) : [];

--- a/print/src/viewer/pdf.ts
+++ b/print/src/viewer/pdf.ts
@@ -2,7 +2,7 @@ import * as pdfjsLib from "pdfjs-dist";
 import { TextLayer } from "pdfjs-dist";
 import type { PDFDocumentProxy, PDFPageProxy, RenderTask } from "pdfjs-dist";
 import type { PageViewport } from "pdfjs-dist/types/src/display/display_utils.js";
-import type { ContentRenderer } from "./types.js";
+import type { ContentRenderer, OutlineEntry } from "./types.js";
 import { parsePositionPage } from "./types.js";
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjsLib.version}/build/pdf.worker.min.mjs`;
@@ -22,6 +22,39 @@ export function createPdfRenderer(onError?: (err: unknown) => void): ContentRend
   let destroyed = false;
   interface SpreadPage { renderTask: RenderTask; textLayer: TextLayer | null; }
   const spreadPages: SpreadPage[] = [];
+  const outlinePageMap = new WeakMap<OutlineEntry, number>();
+
+  type PdfOutlineItem = {
+    title: string;
+    dest: string | Array<unknown> | null;
+    items: PdfOutlineItem[];
+  };
+
+  async function resolveOutlineItems(items: PdfOutlineItem[]): Promise<OutlineEntry[]> {
+    const entries: OutlineEntry[] = [];
+    for (const item of items) {
+      let page: number | null = null;
+      if (item.dest) {
+        let destArray: Array<unknown> | null = null;
+        if (typeof item.dest === "string") {
+          destArray = await pdfDoc!.getDestination(item.dest);
+        } else {
+          destArray = item.dest;
+        }
+        if (destArray && destArray.length > 0) {
+          const pageIndex = await pdfDoc!.getPageIndex(destArray[0] as { num: number; gen: number });
+          page = pageIndex + 1; // 1-based
+        }
+      }
+      const children = item.items.length > 0 ? await resolveOutlineItems(item.items) : [];
+      const entry: OutlineEntry = { title: item.title, children };
+      if (page !== null) {
+        outlinePageMap.set(entry, page);
+      }
+      entries.push(entry);
+    }
+    return entries;
+  }
 
   interface CanvasRenderResult {
     task: RenderTask;
@@ -222,6 +255,20 @@ export function createPdfRenderer(onError?: (err: unknown) => void): ContentRend
     },
     get positionLabel() {
       return `Page ${_currentPage} / ${_pageCount}`;
+    },
+
+    async getOutline(): Promise<OutlineEntry[]> {
+      if (!pdfDoc) return [];
+      const outline = await pdfDoc.getOutline();
+      if (!outline || outline.length === 0) return [];
+      return resolveOutlineItems(outline as PdfOutlineItem[]);
+    },
+
+    async goToOutlineEntry(entry: OutlineEntry): Promise<void> {
+      const page = outlinePageMap.get(entry);
+      if (page === undefined) return;
+      _currentPage = page;
+      await renderPage(page);
     },
 
     destroy(): void {

--- a/print/src/viewer/shell.ts
+++ b/print/src/viewer/shell.ts
@@ -12,6 +12,7 @@ import {
   saveReadingPosition,
 } from "../reading-position.js";
 import { renderSearchSection, initSearch } from "./search.js";
+import { renderOutlineSection, initOutline } from "./outline.js";
 
 function renderTags(tags: Record<string, string>): string {
   const entries = Object.entries(tags);
@@ -40,6 +41,7 @@ export function renderViewerShell(item: MediaItem): string {
           <button class="viewer-spread-toggle spread-hidden" aria-label="Toggle spread view" aria-pressed="false">&#9783;</button>
         </div>
         ${renderSearchSection()}
+        ${renderOutlineSection()}
         <div class="viewer-meta">
           <h3 class="viewer-title">${escapeHtml(item.title)}</h3>
           <p class="viewer-type"><span class="media-badge">${escapeHtml(item.mediaType)}</span></p>
@@ -232,6 +234,7 @@ export function initViewer(
   }
 
   let searchCleanup: (() => void) | null = null;
+  let outlineCleanup: (() => void) | null = null;
   let spreadToggleCleanup: (() => void) | null = null;
   let spreadEnabled = false;
   let spreads: Spread[] = [];
@@ -459,6 +462,7 @@ export function initViewer(
       }
     }
     searchCleanup = initSearch(viewer, renderer, () => updateNav());
+    outlineCleanup = initOutline(viewer, renderer, () => updateNav());
     updateNav();
   })().catch((err) => {
     reportError(new Error("Viewer initialization failed", { cause: err }));
@@ -481,6 +485,7 @@ export function initViewer(
     zoomOutBtn.removeEventListener("click", handleZoomOut);
     zoomResetBtn.removeEventListener("click", handleZoomReset);
     searchCleanup?.();
+    outlineCleanup?.();
     spreadToggleCleanup?.();
     if (spreadResizeObserver) spreadResizeObserver.disconnect();
     if (spreadResizeTimer) clearTimeout(spreadResizeTimer);

--- a/print/src/viewer/types.ts
+++ b/print/src/viewer/types.ts
@@ -16,6 +16,11 @@ export interface SearchResult {
   readonly matchLength: number;
 }
 
+export interface OutlineEntry {
+  readonly title: string;
+  readonly children: readonly OutlineEntry[];
+}
+
 export interface ContentRenderer {
   init(container: HTMLElement, source: string | ArrayBuffer, initialPosition?: string): Promise<void>;
   goToPage(page: number): Promise<void>;
@@ -38,6 +43,9 @@ export interface ContentRenderer {
   search?(query: string): Promise<SearchResult[]>;
   goToResult?(result: SearchResult): Promise<void>;
   clearSearch?(): void;
+  /** Renderers implementing getOutline must also implement goToOutlineEntry. */
+  getOutline?(): Promise<OutlineEntry[]>;
+  goToOutlineEntry?(entry: OutlineEntry): Promise<void>;
   destroy(): void;
 }
 

--- a/print/src/viewer/types.ts
+++ b/print/src/viewer/types.ts
@@ -16,6 +16,7 @@ export interface SearchResult {
   readonly matchLength: number;
 }
 
+/** A node in a document's table of contents tree. */
 export interface OutlineEntry {
   readonly title: string;
   readonly children: readonly OutlineEntry[];

--- a/print/test/viewer/outline.test.ts
+++ b/print/test/viewer/outline.test.ts
@@ -44,7 +44,6 @@ describe("initOutline", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    vi.useFakeTimers();
     container = createContainer();
     if (typeof globalThis.reportError !== "function") {
       globalThis.reportError = () => {};
@@ -53,7 +52,6 @@ describe("initOutline", () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.mocked(globalThis.reportError).mockRestore();
   });
 
@@ -71,15 +69,13 @@ describe("initOutline", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null when outline is empty", async () => {
+  it("stays hidden when outline is empty", async () => {
     const renderer = makeOutlineRenderer({
       getOutline: vi.fn().mockResolvedValue([]),
     });
-    const cleanup = initOutline(container, renderer, vi.fn());
+    initOutline(container, renderer, vi.fn());
     await flushInit();
 
-    // cleanup is a function (not null) because the renderer has both methods,
-    // but the section stays hidden when entries are empty
     const section = container.querySelector(".viewer-outline") as HTMLElement;
     expect(section.classList.contains("outline-hidden")).toBe(true);
   });

--- a/print/test/viewer/outline.test.ts
+++ b/print/test/viewer/outline.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderOutlineSection, initOutline } from "../../src/viewer/outline";
+import type { ContentRenderer, OutlineEntry } from "../../src/viewer/types";
+import { makeMockRenderer } from "./mock-renderer";
+
+function makeEntry(title: string, children: OutlineEntry[] = []): OutlineEntry {
+  return { title, children };
+}
+
+function makeOutlineRenderer(overrides: Partial<ContentRenderer> = {}): ContentRenderer {
+  return makeMockRenderer({
+    getOutline: vi.fn().mockResolvedValue([]),
+    goToOutlineEntry: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  });
+}
+
+function createContainer(): HTMLElement {
+  const el = document.createElement("div");
+  el.innerHTML = renderOutlineSection();
+  return el;
+}
+
+async function flushInit(): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("renderOutlineSection", () => {
+  it("contains .viewer-outline with outline-hidden class", () => {
+    const html = renderOutlineSection();
+    expect(html).toContain('class="viewer-outline outline-hidden"');
+  });
+
+  it("contains .viewer-outline-list with role='tree'", () => {
+    const html = renderOutlineSection();
+    expect(html).toContain('class="viewer-outline-list"');
+    expect(html).toContain('role="tree"');
+  });
+});
+
+describe("initOutline", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = createContainer();
+    if (typeof globalThis.reportError !== "function") {
+      globalThis.reportError = () => {};
+    }
+    vi.spyOn(globalThis, "reportError").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.mocked(globalThis.reportError).mockRestore();
+  });
+
+  it("returns null when renderer lacks getOutline", () => {
+    const renderer = makeMockRenderer();
+    const result = initOutline(container, renderer, vi.fn());
+    expect(result).toBeNull();
+  });
+
+  it("returns null when renderer has getOutline but lacks goToOutlineEntry", () => {
+    const renderer = makeMockRenderer({
+      getOutline: vi.fn().mockResolvedValue([]),
+    });
+    const result = initOutline(container, renderer, vi.fn());
+    expect(result).toBeNull();
+  });
+
+  it("returns null when outline is empty", async () => {
+    const renderer = makeOutlineRenderer({
+      getOutline: vi.fn().mockResolvedValue([]),
+    });
+    const cleanup = initOutline(container, renderer, vi.fn());
+    await flushInit();
+
+    // cleanup is a function (not null) because the renderer has both methods,
+    // but the section stays hidden when entries are empty
+    const section = container.querySelector(".viewer-outline") as HTMLElement;
+    expect(section.classList.contains("outline-hidden")).toBe(true);
+  });
+
+  it("removes outline-hidden when outline has entries", async () => {
+    const entries = [makeEntry("Chapter 1"), makeEntry("Chapter 2")];
+    const renderer = makeOutlineRenderer({
+      getOutline: vi.fn().mockResolvedValue(entries),
+    });
+    initOutline(container, renderer, vi.fn());
+    await flushInit();
+
+    const section = container.querySelector(".viewer-outline") as HTMLElement;
+    expect(section.classList.contains("outline-hidden")).toBe(false);
+  });
+
+  it("renders flat TOC entries as list items with correct titles", async () => {
+    const entries = [makeEntry("Introduction"), makeEntry("Conclusion")];
+    const renderer = makeOutlineRenderer({
+      getOutline: vi.fn().mockResolvedValue(entries),
+    });
+    initOutline(container, renderer, vi.fn());
+    await flushInit();
+
+    const list = container.querySelector(".viewer-outline-list") as HTMLUListElement;
+    const items = list.querySelectorAll(":scope > .viewer-outline-item");
+    expect(items.length).toBe(2);
+
+    const firstAnchor = items[0]!.querySelector(".viewer-outline-entry") as HTMLElement;
+    const secondAnchor = items[1]!.querySelector(".viewer-outline-entry") as HTMLElement;
+    expect(firstAnchor.textContent).toBe("Introduction");
+    expect(secondAnchor.textContent).toBe("Conclusion");
+  });
+
+  it("renders nested TOC entries with toggle buttons", async () => {
+    const entries = [
+      makeEntry("Part 1", [makeEntry("Chapter 1"), makeEntry("Chapter 2")]),
+    ];
+    const renderer = makeOutlineRenderer({
+      getOutline: vi.fn().mockResolvedValue(entries),
+    });
+    initOutline(container, renderer, vi.fn());
+    await flushInit();
+
+    const list = container.querySelector(".viewer-outline-list") as HTMLUListElement;
+    const topItem = list.querySelector(".viewer-outline-item") as HTMLElement;
+    const toggle = topItem.querySelector(".viewer-outline-toggle") as HTMLButtonElement;
+    expect(toggle).not.toBeNull();
+    expect(toggle.textContent).toBe("\u25b6");
+
+    const children = topItem.querySelector(".viewer-outline-children") as HTMLElement;
+    expect(children).not.toBeNull();
+    const childItems = children.querySelectorAll(":scope > .viewer-outline-item");
+    expect(childItems.length).toBe(2);
+  });
+
+  it("click on entry calls goToOutlineEntry with correct entry and then onNavigate", async () => {
+    const entry1 = makeEntry("Chapter 1");
+    const entry2 = makeEntry("Chapter 2");
+    const goToOutlineEntry = vi.fn().mockResolvedValue(undefined);
+    const onNavigate = vi.fn();
+    const renderer = makeOutlineRenderer({
+      getOutline: vi.fn().mockResolvedValue([entry1, entry2]),
+      goToOutlineEntry,
+    });
+    initOutline(container, renderer, onNavigate);
+    await flushInit();
+
+    const list = container.querySelector(".viewer-outline-list") as HTMLUListElement;
+    const secondEntry = list.querySelectorAll(".viewer-outline-entry")[1] as HTMLElement;
+    secondEntry.click();
+
+    // goToOutlineEntry called with the matching entry
+    expect(goToOutlineEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Chapter 2" }),
+    );
+
+    // onNavigate called in the .then() -- flush microtasks
+    await flushInit();
+    expect(onNavigate).toHaveBeenCalled();
+  });
+
+  it("click on toggle expands nested list", async () => {
+    const entries = [
+      makeEntry("Part 1", [makeEntry("Chapter 1")]),
+    ];
+    const renderer = makeOutlineRenderer({
+      getOutline: vi.fn().mockResolvedValue(entries),
+    });
+    initOutline(container, renderer, vi.fn());
+    await flushInit();
+
+    const toggle = container.querySelector(".viewer-outline-toggle") as HTMLButtonElement;
+    const children = container.querySelector(".viewer-outline-children") as HTMLElement;
+
+    // Initially collapsed
+    expect(children.classList.contains("outline-collapsed")).toBe(true);
+    expect(toggle.textContent).toBe("\u25b6");
+
+    // Click to expand
+    toggle.click();
+
+    expect(children.classList.contains("outline-collapsed")).toBe(false);
+    expect(toggle.textContent).toBe("\u25bc");
+  });
+
+  it("click toggle again collapses nested list", async () => {
+    const entries = [
+      makeEntry("Part 1", [makeEntry("Chapter 1")]),
+    ];
+    const renderer = makeOutlineRenderer({
+      getOutline: vi.fn().mockResolvedValue(entries),
+    });
+    initOutline(container, renderer, vi.fn());
+    await flushInit();
+
+    const toggle = container.querySelector(".viewer-outline-toggle") as HTMLButtonElement;
+    const children = container.querySelector(".viewer-outline-children") as HTMLElement;
+
+    // Expand
+    toggle.click();
+    expect(children.classList.contains("outline-collapsed")).toBe(false);
+    expect(toggle.textContent).toBe("\u25bc");
+
+    // Collapse again
+    toggle.click();
+    expect(children.classList.contains("outline-collapsed")).toBe(true);
+    expect(toggle.textContent).toBe("\u25b6");
+  });
+
+  it("cleanup function removes event listeners", async () => {
+    const goToOutlineEntry = vi.fn().mockResolvedValue(undefined);
+    const entries = [makeEntry("Chapter 1")];
+    const renderer = makeOutlineRenderer({
+      getOutline: vi.fn().mockResolvedValue(entries),
+      goToOutlineEntry,
+    });
+    const cleanup = initOutline(container, renderer, vi.fn())!;
+    await flushInit();
+
+    cleanup();
+
+    // Click after cleanup should not call goToOutlineEntry
+    const entry = container.querySelector(".viewer-outline-entry") as HTMLElement;
+    entry.click();
+    await flushInit();
+
+    expect(goToOutlineEntry).not.toHaveBeenCalled();
+  });
+});

--- a/print/test/viewer/shell.test.ts
+++ b/print/test/viewer/shell.test.ts
@@ -152,6 +152,12 @@ describe("renderViewerShell", () => {
     expect(html).toContain('class="viewer-search search-hidden"');
   });
 
+  it("contains .viewer-outline with outline-hidden class", () => {
+    const html = renderViewerShell(makeMediaItem());
+
+    expect(html).toContain('class="viewer-outline outline-hidden"');
+  });
+
   it("escapes HTML in title", () => {
     const html = renderViewerShell(
       makeMediaItem({ title: "<script>alert(1)</script>" }),


### PR DESCRIPTION
## Summary

- Add `OutlineEntry` type and optional `getOutline`/`goToOutlineEntry` methods to `ContentRenderer` interface
- PDF renderer resolves outline destinations to page numbers via pdfjs-dist outline API
- EPUB renderer maps epubjs `navigation.toc` NavItems to outline entries
- New `outline.ts` module renders TOC as a collapsible nested list in the info panel between search and metadata sections
- Section hidden when renderer returns no outline (image archives, PDFs without bookmarks)

Closes #522