### PR TITLE
Fix preconnect crossorigin mismatch in fellspiral

### DIFF
--- a/fellspiral/index.html
+++ b/fellspiral/index.html
@@ -6,9 +6,9 @@
     <meta name="color-scheme" content="light" />
     <meta name="description" content="A TTRPG game blog by Nate. Nate likes games about social role play." />
     <link rel="preconnect" href="https://www.googleapis.com" crossorigin />
-    <link rel="preconnect" href="https://firebaseinstallations.googleapis.com" crossorigin />
-    <link rel="preconnect" href="https://apis.google.com" crossorigin />
-    <link rel="preconnect" href="https://firestore.googleapis.com" crossorigin />
+    <link rel="preconnect" href="https://firebaseinstallations.googleapis.com" />
+    <link rel="preconnect" href="https://apis.google.com" />
+    <link rel="preconnect" href="https://firestore.googleapis.com" />
     <title>fellspiral</title>
     <link rel="alternate" type="application/rss+xml" title="fellspiral" href="/feed.xml">
   </head>

--- a/fellspiral/test/preconnect.test.ts
+++ b/fellspiral/test/preconnect.test.ts
@@ -10,13 +10,19 @@ const indexPath = join(
 const html = readFileSync(indexPath, "utf-8");
 
 describe("fellspiral preconnect links", () => {
+  it("preconnects to www.googleapis.com with crossorigin (auth uses CORS)", () => {
+    expect(html).toContain(
+      `<link rel="preconnect" href="https://www.googleapis.com" crossorigin`,
+    );
+  });
+
   it.each([
-    "www.googleapis.com",
     "firebaseinstallations.googleapis.com",
     "apis.google.com",
     "firestore.googleapis.com",
-  ])("preconnects to %s", (host) => {
-    expect(html).toContain(
+  ])("preconnects to %s without crossorigin", (host) => {
+    expect(html).toContain(`<link rel="preconnect" href="https://${host}" />`);
+    expect(html).not.toContain(
       `<link rel="preconnect" href="https://${host}" crossorigin`,
     );
   });


### PR DESCRIPTION
## Summary
- Removes `crossorigin` from preconnect hints for `firebaseinstallations.googleapis.com`, `apis.google.com`, and `firestore.googleapis.com` — Firebase SDK requests to these origins are not CORS, so the CORS-mode connection was unused (PageSpeed flagged it).
- Keeps `crossorigin` on `www.googleapis.com` (Identity Toolkit legitimately uses CORS).
- Updates `preconnect.test.ts` to encode the attribute split.

Closes #429

## Test plan
- [x] `vitest` — `fellspiral/test/preconnect.test.ts` (4/4 pass)
- [ ] Preview deploy + PageSpeed confirms "Unused preconnect" no longer flags the three origins
- [ ] `www.googleapis.com` also not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)