### PR TITLE
Remove unused Firebase preconnect hints

### DIFF
--- a/audio/index.html
+++ b/audio/index.html
@@ -5,10 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />
     <meta name="description" content="Audio library and web player" />
-    <link rel="preconnect" href="https://www.googleapis.com" crossorigin />
-    <link rel="preconnect" href="https://firebaseinstallations.googleapis.com" crossorigin />
-    <link rel="preconnect" href="https://apis.google.com" crossorigin />
-    <link rel="preconnect" href="https://firestore.googleapis.com" crossorigin />
+    <link rel="preconnect" href="https://firebaseinstallations.googleapis.com" />
     <title>Audio</title>
     <link
       rel="stylesheet"

--- a/audio/test/preconnect.test.ts
+++ b/audio/test/preconnect.test.ts
@@ -10,14 +10,19 @@ const indexPath = join(
 const html = readFileSync(indexPath, "utf-8");
 
 describe("audio preconnect links", () => {
+  it("preconnects to firebaseinstallations.googleapis.com (SDK init)", () => {
+    expect(html).toContain(
+      `<link rel="preconnect" href="https://firebaseinstallations.googleapis.com" />`,
+    );
+  });
+
   it.each([
     "www.googleapis.com",
-    "firebaseinstallations.googleapis.com",
     "apis.google.com",
     "firestore.googleapis.com",
-  ])("preconnects to %s", (host) => {
-    expect(html).toContain(
-      `<link rel="preconnect" href="https://${host}" crossorigin`,
+  ])("does not preconnect to %s (not used on initial load)", (host) => {
+    expect(html).not.toContain(
+      `<link rel="preconnect" href="https://${host}"`,
     );
   });
 });

--- a/budget/index.html
+++ b/budget/index.html
@@ -5,10 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />
     <meta name="description" content="Personal finance tracking and budget visualization" />
-    <link rel="preconnect" href="https://www.googleapis.com" crossorigin />
-    <link rel="preconnect" href="https://firebaseinstallations.googleapis.com" crossorigin />
-    <link rel="preconnect" href="https://apis.google.com" crossorigin />
-    <link rel="preconnect" href="https://firestore.googleapis.com" crossorigin />
+    <link rel="preconnect" href="https://firebaseinstallations.googleapis.com" />
     <title>Budget</title>
     <link
       rel="stylesheet"

--- a/budget/test/preconnect.test.ts
+++ b/budget/test/preconnect.test.ts
@@ -10,14 +10,19 @@ const indexPath = join(
 const html = readFileSync(indexPath, "utf-8");
 
 describe("budget preconnect links", () => {
+  it("preconnects to firebaseinstallations.googleapis.com (SDK init)", () => {
+    expect(html).toContain(
+      `<link rel="preconnect" href="https://firebaseinstallations.googleapis.com" />`,
+    );
+  });
+
   it.each([
     "www.googleapis.com",
-    "firebaseinstallations.googleapis.com",
     "apis.google.com",
     "firestore.googleapis.com",
-  ])("preconnects to %s", (host) => {
-    expect(html).toContain(
-      `<link rel="preconnect" href="https://${host}" crossorigin`,
+  ])("does not preconnect to %s (not used on initial load)", (host) => {
+    expect(html).not.toContain(
+      `<link rel="preconnect" href="https://${host}"`,
     );
   });
 });

--- a/fellspiral/e2e/build-time-content.spec.ts
+++ b/fellspiral/e2e/build-time-content.spec.ts
@@ -169,11 +169,6 @@ test.describe("build-time blog content", () => {
         els.map((el) => el.getAttribute("href")).filter(Boolean),
       );
 
-    expect(hrefs).toContain("https://www.googleapis.com");
-    expect(hrefs).toContain(
-      "https://firebaseinstallations.googleapis.com",
-    );
-    expect(hrefs).toContain("https://apis.google.com");
-    expect(hrefs).toContain("https://firestore.googleapis.com");
+    expect(hrefs).toEqual(["https://firebaseinstallations.googleapis.com"]);
   });
 });

--- a/fellspiral/index.html
+++ b/fellspiral/index.html
@@ -5,10 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light" />
     <meta name="description" content="A TTRPG game blog by Nate. Nate likes games about social role play." />
-    <link rel="preconnect" href="https://www.googleapis.com" crossorigin />
     <link rel="preconnect" href="https://firebaseinstallations.googleapis.com" />
-    <link rel="preconnect" href="https://apis.google.com" />
-    <link rel="preconnect" href="https://firestore.googleapis.com" />
     <title>fellspiral</title>
     <link rel="alternate" type="application/rss+xml" title="fellspiral" href="/feed.xml">
   </head>

--- a/fellspiral/test/preconnect.test.ts
+++ b/fellspiral/test/preconnect.test.ts
@@ -10,20 +10,19 @@ const indexPath = join(
 const html = readFileSync(indexPath, "utf-8");
 
 describe("fellspiral preconnect links", () => {
-  it("preconnects to www.googleapis.com with crossorigin (auth uses CORS)", () => {
+  it("preconnects to firebaseinstallations.googleapis.com (SDK init)", () => {
     expect(html).toContain(
-      `<link rel="preconnect" href="https://www.googleapis.com" crossorigin`,
+      `<link rel="preconnect" href="https://firebaseinstallations.googleapis.com" />`,
     );
   });
 
   it.each([
-    "firebaseinstallations.googleapis.com",
+    "www.googleapis.com",
     "apis.google.com",
     "firestore.googleapis.com",
-  ])("preconnects to %s without crossorigin", (host) => {
-    expect(html).toContain(`<link rel="preconnect" href="https://${host}" />`);
+  ])("does not preconnect to %s (not used on initial load)", (host) => {
     expect(html).not.toContain(
-      `<link rel="preconnect" href="https://${host}" crossorigin`,
+      `<link rel="preconnect" href="https://${host}"`,
     );
   });
 });

--- a/landing/e2e/preconnect.spec.ts
+++ b/landing/e2e/preconnect.spec.ts
@@ -12,11 +12,6 @@ test.describe("landing preconnect links", () => {
         els.map((el) => el.getAttribute("href")).filter(Boolean),
       );
 
-    expect(hrefs).toContain("https://www.googleapis.com");
-    expect(hrefs).toContain(
-      "https://firebaseinstallations.googleapis.com",
-    );
-    expect(hrefs).toContain("https://apis.google.com");
-    expect(hrefs).toContain("https://firestore.googleapis.com");
+    expect(hrefs).toEqual(["https://firebaseinstallations.googleapis.com"]);
   });
 });

--- a/landing/index.html
+++ b/landing/index.html
@@ -7,10 +7,7 @@
     <meta name="description" content="Nate's agentic coding workflow. A monorepo for proof-of-concept apps built with Claude Code — personal finance, print media, game blogs. Fork it, argue with it, discard the parts that don't serve you." />
     <title>commons.systems</title>
     <link rel="alternate" type="application/rss+xml" title="commons.systems" href="/feed.xml">
-    <link rel="preconnect" href="https://www.googleapis.com" crossorigin />
-    <link rel="preconnect" href="https://firebaseinstallations.googleapis.com" crossorigin />
-    <link rel="preconnect" href="https://apis.google.com" crossorigin />
-    <link rel="preconnect" href="https://firestore.googleapis.com" crossorigin />
+    <link rel="preconnect" href="https://firebaseinstallations.googleapis.com" />
   </head>
   <body>
     <div class="page">

--- a/landing/test/preconnect.test.ts
+++ b/landing/test/preconnect.test.ts
@@ -10,14 +10,19 @@ const indexPath = join(
 const html = readFileSync(indexPath, "utf-8");
 
 describe("landing preconnect links", () => {
+  it("preconnects to firebaseinstallations.googleapis.com (SDK init)", () => {
+    expect(html).toContain(
+      `<link rel="preconnect" href="https://firebaseinstallations.googleapis.com" />`,
+    );
+  });
+
   it.each([
     "www.googleapis.com",
-    "firebaseinstallations.googleapis.com",
     "apis.google.com",
     "firestore.googleapis.com",
-  ])("preconnects to %s", (host) => {
-    expect(html).toContain(
-      `<link rel="preconnect" href="https://${host}" crossorigin`,
+  ])("does not preconnect to %s (not used on initial load)", (host) => {
+    expect(html).not.toContain(
+      `<link rel="preconnect" href="https://${host}"`,
     );
   });
 });

--- a/print/index.html
+++ b/print/index.html
@@ -5,10 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />
     <meta name="description" content="Print media reader and digital library" />
-    <link rel="preconnect" href="https://www.googleapis.com" crossorigin />
-    <link rel="preconnect" href="https://firebaseinstallations.googleapis.com" crossorigin />
-    <link rel="preconnect" href="https://apis.google.com" crossorigin />
-    <link rel="preconnect" href="https://firestore.googleapis.com" crossorigin />
+    <link rel="preconnect" href="https://firebaseinstallations.googleapis.com" />
     <title>Print</title>
     <link
       rel="stylesheet"

--- a/print/test/preconnect.test.ts
+++ b/print/test/preconnect.test.ts
@@ -10,14 +10,19 @@ const indexPath = join(
 const html = readFileSync(indexPath, "utf-8");
 
 describe("print preconnect links", () => {
+  it("preconnects to firebaseinstallations.googleapis.com (SDK init)", () => {
+    expect(html).toContain(
+      `<link rel="preconnect" href="https://firebaseinstallations.googleapis.com" />`,
+    );
+  });
+
   it.each([
     "www.googleapis.com",
-    "firebaseinstallations.googleapis.com",
     "apis.google.com",
     "firestore.googleapis.com",
-  ])("preconnects to %s", (host) => {
-    expect(html).toContain(
-      `<link rel="preconnect" href="https://${host}" crossorigin`,
+  ])("does not preconnect to %s (not used on initial load)", (host) => {
+    expect(html).not.toContain(
+      `<link rel="preconnect" href="https://${host}"`,
     );
   });
 });


### PR DESCRIPTION
## Summary
- After PR #526 deployed the crossorigin fix for fellspiral, PageSpeed still flagged 3 of 4 origins as "Unused preconnect": `www.googleapis.com`, `apis.google.com`, `firestore.googleapis.com`. They are only hit during auth flows or later-phase firestore queries — not on initial page load.
- `firebaseinstallations.googleapis.com` is used unconditionally by the Firebase SDK init, so the hint stays.
- Apply the same cleanup to `landing`, `audio`, `budget`, `print` (identical preconnect blocks). Scaffolding template has no preconnect tags, so no scaffold change.

Follow-up to #429.

## Test plan
- [x] `vitest` — all 5 app `preconnect.test.ts` files pass
- [ ] Playwright e2e (landing, fellspiral) pass
- [ ] PageSpeed re-run on fellspiral production shows zero unused preconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)