### PR TITLE
landing: SEO — structured data, canonical, sitemap, rel=me

### DIFF
--- a/blog/package.json
+++ b/blog/package.json
@@ -22,6 +22,9 @@
     "./og-meta": "./src/og-meta.ts",
     "./prerender": "./src/prerender.ts",
     "./feed": "./src/feed.ts",
+    "./sitemap": "./src/sitemap.ts",
+    "./seo": "./src/seo.ts",
+    "./canonical": "./src/canonical.ts",
     "./vite-plugin-feed-xml": "./src/vite-plugin-feed-xml.ts",
     "./components/info-panel": "./src/components/info-panel.ts",
     "./blog.css": "./blog.css"

--- a/blog/src/canonical.ts
+++ b/blog/src/canonical.ts
@@ -1,5 +1,6 @@
-/** Sets or updates the <link rel="canonical"> in the document head. */
+/** Updates (or creates) the canonical link element. Slug is URI-encoded; omit for the homepage. Browser-only — relies on document.head. */
 export function updateCanonical(siteUrl: string, slug?: string): void {
+  if (!siteUrl) throw new Error("updateCanonical: siteUrl is required");
   const href = slug ? `${siteUrl}/post/${encodeURIComponent(slug)}` : `${siteUrl}/`;
   let el = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
   if (!el) {

--- a/blog/src/canonical.ts
+++ b/blog/src/canonical.ts
@@ -1,0 +1,11 @@
+/** Sets or updates the <link rel="canonical"> in the document head. */
+export function updateCanonical(siteUrl: string, slug?: string): void {
+  const href = slug ? `${siteUrl}/post/${encodeURIComponent(slug)}` : `${siteUrl}/`;
+  let el = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!el) {
+    el = document.createElement("link");
+    el.setAttribute("rel", "canonical");
+    document.head.appendChild(el);
+  }
+  el.setAttribute("href", href);
+}

--- a/blog/src/prerender.ts
+++ b/blog/src/prerender.ts
@@ -83,15 +83,23 @@ function injectNav(html: string, navHtml: string): string {
   return result;
 }
 
+function injectBeforeHead(html: string, block: string, context: string): string {
+  const result = html.replace("</head>", `    ${block}\n  </head>`);
+  if (result === html) throw new Error(`</head> marker not found in ${context}`);
+  return result;
+}
+
 function buildSeoHeadHtml(parts: string[]): string {
   return parts.filter((s) => s.length > 0).join("\n    ");
 }
 
 // Build-time counterpart of og-meta.ts. Generates per-post HTML files with
-// OG tags, <meta name="description">, and <title>, plus injects rendered blog
-// content, info panel, and nav — enabling crawlers to see full content without
-// executing JS. Each post page includes all published articles (matching the
-// root index) so the client hydrates without a visible content shift.
+// OG tags, <meta name="description">, <title>, canonical link, JSON-LD
+// structured data (Organization on the root, BlogPosting per post), and
+// optional rel=me links, plus injects rendered blog content, info panel, and
+// nav — enabling crawlers to see full content without executing JS. Each post
+// page includes all published articles (matching the root index) so the
+// client hydrates without a visible content shift.
 export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
   const {
     siteUrl,
@@ -143,15 +151,9 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
   if (siteDefaults) {
     rootHtml = rootHtml.replace(/\s*<meta name="description"[^>]*>/, "");
     const rootOgTags = ogTagsToHtml(siteDefaultOgEntries(siteUrl, siteDefaults));
-    const beforeOg = rootHtml;
-    rootHtml = rootHtml.replace("</head>", `    ${rootOgTags}\n  </head>`);
-    if (rootHtml === beforeOg) throw new Error("</head> marker not found in root template");
+    rootHtml = injectBeforeHead(rootHtml, rootOgTags, "root template");
   }
-  if (rootSeoHead) {
-    const beforeSeo = rootHtml;
-    rootHtml = rootHtml.replace("</head>", `    ${rootSeoHead}\n  </head>`);
-    if (rootHtml === beforeSeo) throw new Error("</head> marker not found in root template");
-  }
+  rootHtml = injectBeforeHead(rootHtml, rootSeoHead, "root template");
   writeFileSync(join(distDir, "index.html"), rootHtml);
   console.log("Pre-rendered: /index.html");
 
@@ -166,14 +168,8 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
     if (meta.previewDescription) {
       html = html.replace(/\s*<meta name="description"[^>]*>/, "");
     }
-    const beforeHead = html;
-    html = html.replace("</head>", `    ${ogBlock}\n  </head>`);
-    if (html === beforeHead) throw new Error(`</head> marker not found in template`);
-    if (postSeoHead) {
-      const beforeSeo = html;
-      html = html.replace("</head>", `    ${postSeoHead}\n  </head>`);
-      if (html === beforeSeo) throw new Error("</head> marker not found in post template");
-    }
+    html = injectBeforeHead(html, ogBlock, "post template");
+    html = injectBeforeHead(html, postSeoHead, "post template");
     const beforeTitle = html;
     html = html.replace(/<title>.*?<\/title>/, `<title>${escapeHtml(formatPageTitle(titleSuffix, meta.title))}</title>`);
     if (html === beforeTitle) throw new Error(`<title> tag not found in template`);

--- a/blog/src/prerender.ts
+++ b/blog/src/prerender.ts
@@ -9,6 +9,15 @@ import { formatPageTitle } from "./page-title.ts";
 import { renderInfoPanel } from "./components/info-panel.ts";
 import { createMarked, renderPostContents } from "./marked-config.ts";
 import { renderArticle } from "./pages/home.ts";
+import {
+  organizationJsonLd,
+  blogPostingJsonLd,
+  jsonLdScriptTag,
+  canonicalLinkTag,
+  relMeLinkTags,
+  type Organization,
+  type Author,
+} from "./seo.ts";
 
 export interface NavLink {
   readonly href: string;
@@ -24,6 +33,9 @@ export interface PrerenderConfig {
   navLinks: NavLink[];
   infoPanel: Omit<InfoPanelData, "topPosts">;
   siteDefaults?: SiteDefaults;
+  organization?: Organization;
+  author?: Author;
+  relMe?: string[];
 }
 
 function ogTagsToHtml(entries: OgTagEntry[]): string {
@@ -76,8 +88,24 @@ function injectNav(html: string, navHtml: string): string {
 // content, info panel, and nav — enabling crawlers to see full content without
 // executing JS. Each post page includes all published articles (matching the
 // root index) so the client hydrates without a visible content shift.
+function buildSeoHeadHtml(parts: string[]): string {
+  return parts.filter((s) => s.length > 0).join("\n    ");
+}
+
 export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
-  const { siteUrl, titleSuffix, distDir, seed, postDir, navLinks, infoPanel, siteDefaults } = config;
+  const {
+    siteUrl,
+    titleSuffix,
+    distDir,
+    seed,
+    postDir,
+    navLinks,
+    infoPanel,
+    siteDefaults,
+    organization,
+    author,
+    relMe,
+  } = config;
 
   const template = readFileSync(join(distDir, "index.html"), "utf-8");
   const marked = createMarked();
@@ -100,6 +128,12 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
   const panelHtml = renderInfoPanel({ ...infoPanel, topPosts });
   const navHtml = renderNavHtml(navLinks);
 
+  const rootSeoHead = buildSeoHeadHtml([
+    canonicalLinkTag(`${siteUrl}/`),
+    organization ? jsonLdScriptTag(organizationJsonLd(organization)) : "",
+    relMe && relMe.length > 0 ? relMeLinkTags(relMe) : "",
+  ]);
+
   const allArticlesHtml = rendered.map((p) => p.articleHtml).join("\n      <hr>\n      ");
   let rootHtml = injectMain(template, allArticlesHtml);
   rootHtml = injectInfoPanel(rootHtml, panelHtml);
@@ -111,11 +145,21 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
     rootHtml = rootHtml.replace("</head>", `    ${rootOgTags}\n  </head>`);
     if (rootHtml === beforeOg) throw new Error("</head> marker not found in root template");
   }
+  if (rootSeoHead) {
+    const beforeSeo = rootHtml;
+    rootHtml = rootHtml.replace("</head>", `    ${rootSeoHead}\n  </head>`);
+    if (rootHtml === beforeSeo) throw new Error("</head> marker not found in root template");
+  }
   writeFileSync(join(distDir, "index.html"), rootHtml);
   console.log("Pre-rendered: /index.html");
 
   for (const meta of published) {
     const ogBlock = ogTagsToHtml(postOgEntries(siteUrl, meta));
+    const postSeoHead = buildSeoHeadHtml([
+      canonicalLinkTag(`${siteUrl}/post/${encodeURIComponent(meta.id)}`),
+      author ? jsonLdScriptTag(blogPostingJsonLd(meta, siteUrl, author)) : "",
+      relMe && relMe.length > 0 ? relMeLinkTags(relMe) : "",
+    ]);
     let html = template;
     if (meta.previewDescription) {
       html = html.replace(/\s*<meta name="description"[^>]*>/, "");
@@ -123,6 +167,9 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
     const beforeHead = html;
     html = html.replace("</head>", `    ${ogBlock}\n  </head>`);
     if (html === beforeHead) throw new Error(`</head> marker not found in template`);
+    if (postSeoHead) {
+      html = html.replace("</head>", `    ${postSeoHead}\n  </head>`);
+    }
     const beforeTitle = html;
     html = html.replace(/<title>.*?<\/title>/, `<title>${escapeHtml(formatPageTitle(titleSuffix, meta.title))}</title>`);
     if (html === beforeTitle) throw new Error(`<title> tag not found in template`);

--- a/blog/src/prerender.ts
+++ b/blog/src/prerender.ts
@@ -83,15 +83,15 @@ function injectNav(html: string, navHtml: string): string {
   return result;
 }
 
+function buildSeoHeadHtml(parts: string[]): string {
+  return parts.filter((s) => s.length > 0).join("\n    ");
+}
+
 // Build-time counterpart of og-meta.ts. Generates per-post HTML files with
 // OG tags, <meta name="description">, and <title>, plus injects rendered blog
 // content, info panel, and nav — enabling crawlers to see full content without
 // executing JS. Each post page includes all published articles (matching the
 // root index) so the client hydrates without a visible content shift.
-function buildSeoHeadHtml(parts: string[]): string {
-  return parts.filter((s) => s.length > 0).join("\n    ");
-}
-
 export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
   const {
     siteUrl,
@@ -128,10 +128,12 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
   const panelHtml = renderInfoPanel({ ...infoPanel, topPosts });
   const navHtml = renderNavHtml(navLinks);
 
+  const relMeHtml = relMe && relMe.length > 0 ? relMeLinkTags(relMe) : "";
+
   const rootSeoHead = buildSeoHeadHtml([
     canonicalLinkTag(`${siteUrl}/`),
     organization ? jsonLdScriptTag(organizationJsonLd(organization)) : "",
-    relMe && relMe.length > 0 ? relMeLinkTags(relMe) : "",
+    relMeHtml,
   ]);
 
   const allArticlesHtml = rendered.map((p) => p.articleHtml).join("\n      <hr>\n      ");
@@ -158,7 +160,7 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
     const postSeoHead = buildSeoHeadHtml([
       canonicalLinkTag(`${siteUrl}/post/${encodeURIComponent(meta.id)}`),
       author ? jsonLdScriptTag(blogPostingJsonLd(meta, siteUrl, author)) : "",
-      relMe && relMe.length > 0 ? relMeLinkTags(relMe) : "",
+      relMeHtml,
     ]);
     let html = template;
     if (meta.previewDescription) {
@@ -168,7 +170,9 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
     html = html.replace("</head>", `    ${ogBlock}\n  </head>`);
     if (html === beforeHead) throw new Error(`</head> marker not found in template`);
     if (postSeoHead) {
+      const beforeSeo = html;
       html = html.replace("</head>", `    ${postSeoHead}\n  </head>`);
+      if (html === beforeSeo) throw new Error("</head> marker not found in post template");
     }
     const beforeTitle = html;
     html = html.replace(/<title>.*?<\/title>/, `<title>${escapeHtml(formatPageTitle(titleSuffix, meta.title))}</title>`);

--- a/blog/src/seo.ts
+++ b/blog/src/seo.ts
@@ -48,8 +48,8 @@ export function blogPostingJsonLd(
 }
 
 // Embedding JSON inside <script> requires escaping </script> sequences and
-// Unicode line separators that can break script parsing. JSON.stringify output
-// is safe otherwise — no need for full HTML escaping.
+// Unicode line separators that can break script parsing. Also escapes < > &
+// for defense-in-depth in case the JSON ends up in an unexpected context.
 export function jsonLdScriptTag(json: Record<string, unknown>): string {
   const safe = JSON.stringify(json)
     .replace(/</g, "\\u003c")

--- a/blog/src/seo.ts
+++ b/blog/src/seo.ts
@@ -1,0 +1,69 @@
+import { escapeHtml } from "@commons-systems/htmlutil";
+import type { PublishedPost } from "./post-types.ts";
+
+export interface Organization {
+  name: string;
+  url: string;
+  logo: string;
+  sameAs?: string[];
+}
+
+export interface Author {
+  name: string;
+  url?: string;
+}
+
+export function organizationJsonLd(org: Organization): Record<string, unknown> {
+  const json: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: org.name,
+    url: org.url,
+    logo: org.logo,
+  };
+  if (org.sameAs && org.sameAs.length > 0) json.sameAs = org.sameAs;
+  return json;
+}
+
+export function blogPostingJsonLd(
+  post: PublishedPost,
+  siteUrl: string,
+  author: Author,
+): Record<string, unknown> {
+  const postUrl = `${siteUrl}/post/${encodeURIComponent(post.id)}`;
+  const json: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    datePublished: post.publishedAt,
+    author: author.url
+      ? { "@type": "Person", name: author.name, url: author.url }
+      : { "@type": "Person", name: author.name },
+    url: postUrl,
+    mainEntityOfPage: { "@type": "WebPage", "@id": postUrl },
+  };
+  if (post.previewDescription) json.description = post.previewDescription;
+  if (post.previewImage) json.image = `${siteUrl}${post.previewImage}`;
+  return json;
+}
+
+// Embedding JSON inside <script> requires escaping </script> sequences and
+// Unicode line separators that can break script parsing. JSON.stringify output
+// is safe otherwise — no need for full HTML escaping.
+export function jsonLdScriptTag(json: Record<string, unknown>): string {
+  const safe = JSON.stringify(json)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+  return `<script type="application/ld+json">${safe}</script>`;
+}
+
+export function canonicalLinkTag(url: string): string {
+  return `<link rel="canonical" href="${escapeHtml(url)}">`;
+}
+
+export function relMeLinkTags(urls: string[]): string {
+  return urls.map((u) => `<link rel="me" href="${escapeHtml(u)}">`).join("\n    ");
+}

--- a/blog/src/sitemap.ts
+++ b/blog/src/sitemap.ts
@@ -7,7 +7,7 @@ import { validatePublishedPosts } from "./post-types.ts";
 export interface SitemapConfig {
   siteUrl: string;
   seed: Pick<SeedSpec, "collections">;
-  /** Paths to include in addition to posts — always includes "/" unless overridden. */
+  /** Static URL paths to include alongside post URLs. Defaults to ["/"]; the homepage is dropped if you supply a list without it. */
   staticPaths?: string[];
   postLinkPrefix?: string;
 }
@@ -28,7 +28,7 @@ function urlEntry(entry: UrlEntry): string {
   </url>`;
 }
 
-/** Returns sitemap XML string from seed data. Pure function used by the Vite dev plugin and prerender script. */
+/** Returns sitemap XML for published posts. Pure: no I/O. */
 export function buildSitemapXml(config: SitemapConfig): string {
   const { siteUrl, seed, staticPaths = ["/"], postLinkPrefix = "/post/" } = config;
 
@@ -56,7 +56,7 @@ ${urls}
 </urlset>`;
 }
 
-/** Builds sitemap XML and writes sitemap.xml to distDir. Called by prerender scripts. */
+/** Writes sitemap.xml to distDir. */
 export function generateSitemapXml(config: SitemapFileConfig): void {
   const xml = buildSitemapXml(config);
   writeFileSync(join(config.distDir, "sitemap.xml"), xml);

--- a/blog/src/sitemap.ts
+++ b/blog/src/sitemap.ts
@@ -1,0 +1,64 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { SeedSpec } from "@commons-systems/firestoreutil/seed";
+import { escapeHtml } from "@commons-systems/htmlutil";
+import { validatePublishedPosts } from "./post-types.ts";
+
+export interface SitemapConfig {
+  siteUrl: string;
+  seed: Pick<SeedSpec, "collections">;
+  /** Paths to include in addition to posts — always includes "/" unless overridden. */
+  staticPaths?: string[];
+  postLinkPrefix?: string;
+}
+
+export interface SitemapFileConfig extends SitemapConfig {
+  distDir: string;
+}
+
+interface UrlEntry {
+  loc: string;
+  lastmod?: string;
+}
+
+function urlEntry(entry: UrlEntry): string {
+  const lastmod = entry.lastmod ? `\n    <lastmod>${escapeHtml(entry.lastmod)}</lastmod>` : "";
+  return `  <url>
+    <loc>${escapeHtml(entry.loc)}</loc>${lastmod}
+  </url>`;
+}
+
+/** Returns sitemap XML string from seed data. Pure function used by the Vite dev plugin and prerender script. */
+export function buildSitemapXml(config: SitemapConfig): string {
+  const { siteUrl, seed, staticPaths = ["/"], postLinkPrefix = "/post/" } = config;
+
+  const published = validatePublishedPosts(seed);
+  published.sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+
+  const mostRecent = published[0]?.publishedAt;
+
+  const entries: UrlEntry[] = staticPaths.map((path) => ({
+    loc: `${siteUrl}${path}`,
+    lastmod: path === "/" ? mostRecent : undefined,
+  }));
+
+  for (const post of published) {
+    entries.push({
+      loc: `${siteUrl}${postLinkPrefix}${encodeURIComponent(post.id)}`,
+      lastmod: post.publishedAt,
+    });
+  }
+
+  const urls = entries.map(urlEntry).join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>`;
+}
+
+/** Builds sitemap XML and writes sitemap.xml to distDir. Called by prerender scripts. */
+export function generateSitemapXml(config: SitemapFileConfig): void {
+  const xml = buildSitemapXml(config);
+  writeFileSync(join(config.distDir, "sitemap.xml"), xml);
+  console.log("Generated: /sitemap.xml");
+}

--- a/blog/test/canonical.test.ts
+++ b/blog/test/canonical.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { updateCanonical } from "../src/canonical";
+
+describe("updateCanonical", () => {
+  beforeEach(() => {
+    document.head.querySelectorAll('link[rel="canonical"]').forEach((el) => el.remove());
+  });
+
+  it("adds a canonical link when none exists", () => {
+    updateCanonical("https://example.com");
+    const el = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+    expect(el).not.toBeNull();
+    expect(el!.getAttribute("href")).toBe("https://example.com/");
+  });
+
+  it("sets canonical to siteUrl/ for the homepage", () => {
+    updateCanonical("https://example.com");
+    const el = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+    expect(el!.getAttribute("href")).toBe("https://example.com/");
+  });
+
+  it("sets canonical to post URL when slug is provided", () => {
+    updateCanonical("https://example.com", "hello-world");
+    const el = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+    expect(el!.getAttribute("href")).toBe("https://example.com/post/hello-world");
+  });
+
+  it("updates existing canonical instead of duplicating", () => {
+    updateCanonical("https://example.com", "post-a");
+    updateCanonical("https://example.com", "post-b");
+    const all = document.querySelectorAll('link[rel="canonical"]');
+    expect(all).toHaveLength(1);
+    expect(all[0].getAttribute("href")).toBe("https://example.com/post/post-b");
+  });
+
+  it("navigating from post back to homepage resets canonical to homepage", () => {
+    updateCanonical("https://example.com", "post-a");
+    updateCanonical("https://example.com");
+    const el = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+    expect(el!.getAttribute("href")).toBe("https://example.com/");
+  });
+
+  it("encodes slugs with special characters", () => {
+    updateCanonical("https://example.com", "a b");
+    const el = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+    expect(el!.getAttribute("href")).toBe("https://example.com/post/a%20b");
+  });
+});

--- a/blog/test/canonical.test.ts
+++ b/blog/test/canonical.test.ts
@@ -45,4 +45,8 @@ describe("updateCanonical", () => {
     const el = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
     expect(el!.getAttribute("href")).toBe("https://example.com/post/a%20b");
   });
+
+  it("throws when siteUrl is empty", () => {
+    expect(() => updateCanonical("")).toThrow(/siteUrl is required/);
+  });
 });

--- a/blog/test/prerender.test.ts
+++ b/blog/test/prerender.test.ts
@@ -413,4 +413,97 @@ describe("prerenderPosts", () => {
     const html = rootCall![1] as string;
     expect(html).toContain("Archive");
   });
+
+  it("injects canonical link on homepage", async () => {
+    await prerenderPosts(makeConfig());
+    const rootCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      (c) => String(c[0]) === "/dist/index.html",
+    );
+    const html = rootCall![1] as string;
+    expect(html).toContain('<link rel="canonical" href="https://example.com/">');
+  });
+
+  it("injects canonical link on post pages", async () => {
+    await prerenderPosts(makeConfig());
+    const perPostCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      (c) => String(c[0]).includes("post/hello-world"),
+    );
+    const html = perPostCall![1] as string;
+    expect(html).toContain('<link rel="canonical" href="https://example.com/post/hello-world">');
+  });
+
+  it("injects Organization JSON-LD on homepage when organization provided", async () => {
+    await prerenderPosts(makeConfig({
+      organization: {
+        name: "Example Org",
+        url: "https://example.com",
+        logo: "https://example.com/logo.svg",
+        sameAs: ["https://github.com/example"],
+      },
+    }));
+    const rootCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      (c) => String(c[0]) === "/dist/index.html",
+    );
+    const html = rootCall![1] as string;
+    expect(html).toContain('<script type="application/ld+json">');
+    expect(html).toContain('"@type":"Organization"');
+    expect(html).toContain("Example Org");
+  });
+
+  it("omits Organization JSON-LD when organization not provided", async () => {
+    await prerenderPosts(makeConfig());
+    const rootCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      (c) => String(c[0]) === "/dist/index.html",
+    );
+    const html = rootCall![1] as string;
+    expect(html).not.toContain("Organization");
+  });
+
+  it("injects BlogPosting JSON-LD on post pages when author provided", async () => {
+    await prerenderPosts(makeConfig({ author: { name: "Alice" } }));
+    const perPostCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      (c) => String(c[0]).includes("post/hello-world"),
+    );
+    const html = perPostCall![1] as string;
+    expect(html).toContain('<script type="application/ld+json">');
+    expect(html).toContain('"@type":"BlogPosting"');
+    expect(html).toContain('"headline":"Hello World"');
+    expect(html).toContain("Alice");
+  });
+
+  it("omits BlogPosting JSON-LD when author not provided", async () => {
+    await prerenderPosts(makeConfig());
+    const perPostCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      (c) => String(c[0]).includes("post/hello-world"),
+    );
+    const html = perPostCall![1] as string;
+    expect(html).not.toContain("BlogPosting");
+  });
+
+  it("injects rel=me links on homepage when relMe provided", async () => {
+    await prerenderPosts(makeConfig({ relMe: ["https://github.com/alice"] }));
+    const rootCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      (c) => String(c[0]) === "/dist/index.html",
+    );
+    const html = rootCall![1] as string;
+    expect(html).toContain('<link rel="me" href="https://github.com/alice">');
+  });
+
+  it("injects rel=me links on post pages when relMe provided", async () => {
+    await prerenderPosts(makeConfig({ relMe: ["https://github.com/alice"] }));
+    const perPostCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      (c) => String(c[0]).includes("post/hello-world"),
+    );
+    const html = perPostCall![1] as string;
+    expect(html).toContain('<link rel="me" href="https://github.com/alice">');
+  });
+
+  it("omits rel=me when relMe not provided or empty", async () => {
+    await prerenderPosts(makeConfig({ relMe: [] }));
+    const rootCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      (c) => String(c[0]) === "/dist/index.html",
+    );
+    const html = rootCall![1] as string;
+    expect(html).not.toContain('rel="me"');
+  });
 });

--- a/blog/test/seo.test.ts
+++ b/blog/test/seo.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import {
+  organizationJsonLd,
+  blogPostingJsonLd,
+  jsonLdScriptTag,
+  canonicalLinkTag,
+  relMeLinkTags,
+} from "../src/seo";
+import type { PublishedPost } from "../src/post-types";
+
+const basePost: PublishedPost = {
+  id: "hello-world",
+  title: "Hello World",
+  published: true,
+  publishedAt: "2026-03-10T00:00:00Z",
+  filename: "hello-world.md",
+  previewDescription: "A first post.",
+  previewImage: "/hello.jpg",
+};
+
+describe("organizationJsonLd", () => {
+  it("returns required schema.org fields", () => {
+    const json = organizationJsonLd({
+      name: "Example Org",
+      url: "https://example.com",
+      logo: "https://example.com/logo.svg",
+      sameAs: ["https://github.com/example"],
+    });
+    expect(json["@context"]).toBe("https://schema.org");
+    expect(json["@type"]).toBe("Organization");
+    expect(json.name).toBe("Example Org");
+    expect(json.url).toBe("https://example.com");
+    expect(json.logo).toBe("https://example.com/logo.svg");
+    expect(json.sameAs).toEqual(["https://github.com/example"]);
+  });
+
+  it("omits sameAs when empty", () => {
+    const json = organizationJsonLd({
+      name: "Example",
+      url: "https://example.com",
+      logo: "https://example.com/logo.svg",
+    });
+    expect(json.sameAs).toBeUndefined();
+  });
+});
+
+describe("blogPostingJsonLd", () => {
+  it("includes headline, datePublished, author, url, mainEntityOfPage", () => {
+    const json = blogPostingJsonLd(basePost, "https://example.com", { name: "Alice" });
+    expect(json["@context"]).toBe("https://schema.org");
+    expect(json["@type"]).toBe("BlogPosting");
+    expect(json.headline).toBe("Hello World");
+    expect(json.datePublished).toBe("2026-03-10T00:00:00Z");
+    expect(json.author).toEqual({ "@type": "Person", name: "Alice" });
+    expect(json.url).toBe("https://example.com/post/hello-world");
+    expect(json.mainEntityOfPage).toEqual({
+      "@type": "WebPage",
+      "@id": "https://example.com/post/hello-world",
+    });
+  });
+
+  it("includes author url when provided", () => {
+    const json = blogPostingJsonLd(basePost, "https://example.com", {
+      name: "Alice",
+      url: "https://example.com/about",
+    });
+    expect(json.author).toEqual({
+      "@type": "Person",
+      name: "Alice",
+      url: "https://example.com/about",
+    });
+  });
+
+  it("includes description and image when available", () => {
+    const json = blogPostingJsonLd(basePost, "https://example.com", { name: "Alice" });
+    expect(json.description).toBe("A first post.");
+    expect(json.image).toBe("https://example.com/hello.jpg");
+  });
+
+  it("omits description and image when absent", () => {
+    const post: PublishedPost = { ...basePost, previewDescription: undefined, previewImage: undefined };
+    const json = blogPostingJsonLd(post, "https://example.com", { name: "Alice" });
+    expect(json.description).toBeUndefined();
+    expect(json.image).toBeUndefined();
+  });
+
+  it("encodes post id in url", () => {
+    const post: PublishedPost = { ...basePost, id: "a/b c" };
+    const json = blogPostingJsonLd(post, "https://example.com", { name: "Alice" });
+    expect(json.url).toBe("https://example.com/post/a%2Fb%20c");
+  });
+});
+
+describe("jsonLdScriptTag", () => {
+  it("wraps JSON in a script tag with correct type", () => {
+    const tag = jsonLdScriptTag({ a: 1 });
+    expect(tag).toMatch(/^<script type="application\/ld\+json">/);
+    expect(tag).toMatch(/<\/script>$/);
+  });
+
+  it("produces JSON parseable from script body", () => {
+    const tag = jsonLdScriptTag({ "@type": "Organization", name: "Test" });
+    const body = tag.replace(/^<script[^>]*>/, "").replace(/<\/script>$/, "");
+    const unescaped = body
+      .replace(/\\u003c/g, "<")
+      .replace(/\\u003e/g, ">")
+      .replace(/\\u0026/g, "&");
+    const parsed = JSON.parse(unescaped);
+    expect(parsed["@type"]).toBe("Organization");
+  });
+
+  it("escapes < > & to prevent breaking out of the script tag", () => {
+    const tag = jsonLdScriptTag({ evil: "</script><script>alert(1)</script>" });
+    expect(tag).not.toContain("</script><script>");
+    expect(tag).toContain("\\u003c/script\\u003e");
+  });
+});
+
+describe("canonicalLinkTag", () => {
+  it("returns link tag with rel=canonical and href", () => {
+    expect(canonicalLinkTag("https://example.com/")).toBe(
+      '<link rel="canonical" href="https://example.com/">',
+    );
+  });
+
+  it("escapes HTML special characters in href", () => {
+    expect(canonicalLinkTag('https://example.com/"><script>')).toContain("&quot;");
+    expect(canonicalLinkTag('https://example.com/"><script>')).not.toContain("<script>");
+  });
+});
+
+describe("relMeLinkTags", () => {
+  it("returns empty-join for empty array", () => {
+    expect(relMeLinkTags([])).toBe("");
+  });
+
+  it("produces one link per URL", () => {
+    const html = relMeLinkTags(["https://github.com/a", "https://github.com/b"]);
+    expect(html).toContain('<link rel="me" href="https://github.com/a">');
+    expect(html).toContain('<link rel="me" href="https://github.com/b">');
+  });
+
+  it("escapes HTML special characters in URL", () => {
+    expect(relMeLinkTags(['https://github.com/"evil'])).toContain("&quot;");
+  });
+});

--- a/blog/test/seo.test.ts
+++ b/blog/test/seo.test.ts
@@ -114,6 +114,14 @@ describe("jsonLdScriptTag", () => {
     expect(tag).not.toContain("</script><script>");
     expect(tag).toContain("\\u003c/script\\u003e");
   });
+
+  it("escapes U+2028 and U+2029 line separators", () => {
+    const tag = jsonLdScriptTag({ text: "a\u2028b\u2029c" });
+    expect(tag).not.toContain("\u2028");
+    expect(tag).not.toContain("\u2029");
+    expect(tag).toContain("\\u2028");
+    expect(tag).toContain("\\u2029");
+  });
 });
 
 describe("canonicalLinkTag", () => {

--- a/blog/test/sitemap.test.ts
+++ b/blog/test/sitemap.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildSitemapXml, generateSitemapXml, type SitemapConfig } from "../src/sitemap";
+
+function makeSeed(
+  docs: Array<{ id: string; data: Record<string, unknown> }> = [
+    {
+      id: "hello-world",
+      data: {
+        title: "Hello World",
+        published: true,
+        publishedAt: "2026-01-01T00:00:00Z",
+        filename: "hello-world.md",
+      },
+    },
+  ],
+) {
+  return { collections: [{ name: "posts", documents: docs }] };
+}
+
+function makeConfig(overrides: Partial<SitemapConfig> = {}): SitemapConfig {
+  return {
+    siteUrl: "https://example.com",
+    seed: makeSeed(),
+    ...overrides,
+  };
+}
+
+describe("buildSitemapXml", () => {
+  it("produces valid XML with declaration and urlset", () => {
+    const xml = buildSitemapXml(makeConfig());
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(xml).toContain("</urlset>");
+  });
+
+  it("includes homepage by default", () => {
+    const xml = buildSitemapXml(makeConfig());
+    expect(xml).toContain("<loc>https://example.com/</loc>");
+  });
+
+  it("includes all published posts", () => {
+    const xml = buildSitemapXml(
+      makeConfig({
+        seed: makeSeed([
+          {
+            id: "post-a",
+            data: {
+              title: "A",
+              published: true,
+              publishedAt: "2026-01-01T00:00:00Z",
+              filename: "a.md",
+            },
+          },
+          {
+            id: "post-b",
+            data: {
+              title: "B",
+              published: true,
+              publishedAt: "2026-02-01T00:00:00Z",
+              filename: "b.md",
+            },
+          },
+        ]),
+      }),
+    );
+    expect(xml).toContain("<loc>https://example.com/post/post-a</loc>");
+    expect(xml).toContain("<loc>https://example.com/post/post-b</loc>");
+  });
+
+  it("excludes unpublished posts", () => {
+    const xml = buildSitemapXml(
+      makeConfig({
+        seed: makeSeed([
+          {
+            id: "pub",
+            data: {
+              title: "Published",
+              published: true,
+              publishedAt: "2026-01-01T00:00:00Z",
+              filename: "pub.md",
+            },
+          },
+          {
+            id: "draft",
+            data: { title: "Draft", published: false, publishedAt: null, filename: "draft.md" },
+          },
+        ]),
+      }),
+    );
+    expect(xml).toContain("pub");
+    expect(xml).not.toContain("<loc>https://example.com/post/draft</loc>");
+  });
+
+  it("uses post publishedAt as lastmod", () => {
+    const xml = buildSitemapXml(makeConfig());
+    expect(xml).toContain("<lastmod>2026-01-01T00:00:00Z</lastmod>");
+  });
+
+  it("uses most recent post's publishedAt as homepage lastmod", () => {
+    const xml = buildSitemapXml(
+      makeConfig({
+        seed: makeSeed([
+          {
+            id: "older",
+            data: {
+              title: "Older",
+              published: true,
+              publishedAt: "2026-01-01T00:00:00Z",
+              filename: "older.md",
+            },
+          },
+          {
+            id: "newer",
+            data: {
+              title: "Newer",
+              published: true,
+              publishedAt: "2026-03-01T00:00:00Z",
+              filename: "newer.md",
+            },
+          },
+        ]),
+      }),
+    );
+    const homepageSection = xml.split("</url>")[0];
+    expect(homepageSection).toContain("<loc>https://example.com/</loc>");
+    expect(homepageSection).toContain("<lastmod>2026-03-01T00:00:00Z</lastmod>");
+  });
+
+  it("encodes post ids with special characters", () => {
+    const xml = buildSitemapXml(
+      makeConfig({
+        seed: makeSeed([
+          {
+            id: "a&b",
+            data: {
+              title: "A",
+              published: true,
+              publishedAt: "2026-01-01T00:00:00Z",
+              filename: "a.md",
+            },
+          },
+        ]),
+      }),
+    );
+    expect(xml).toContain("a%26b");
+  });
+
+  it("respects custom staticPaths", () => {
+    const xml = buildSitemapXml(makeConfig({ staticPaths: ["/", "/about"] }));
+    expect(xml).toContain("<loc>https://example.com/</loc>");
+    expect(xml).toContain("<loc>https://example.com/about</loc>");
+  });
+
+  it("throws when posts collection is missing", () => {
+    expect(() => buildSitemapXml(makeConfig({ seed: { collections: [] } }))).toThrow(
+      "No 'posts' collection found",
+    );
+  });
+
+  it("omits homepage lastmod when there are no published posts", () => {
+    const xml = buildSitemapXml(
+      makeConfig({
+        seed: makeSeed([
+          {
+            id: "draft",
+            data: { title: "Draft", published: false, publishedAt: null, filename: "d.md" },
+          },
+        ]),
+      }),
+    );
+    expect(xml).toContain("<loc>https://example.com/</loc>");
+    expect(xml).not.toContain("<lastmod>");
+  });
+});
+
+describe("generateSitemapXml", () => {
+  let tmpDir: string;
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes sitemap.xml to distDir", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "sitemap-test-"));
+    generateSitemapXml({ ...makeConfig(), distDir: tmpDir });
+    const content = readFileSync(join(tmpDir, "sitemap.xml"), "utf-8");
+    expect(content).toContain("<urlset");
+    expect(content).toContain("hello-world");
+  });
+});

--- a/blog/test/sitemap.test.ts
+++ b/blog/test/sitemap.test.ts
@@ -154,6 +154,24 @@ describe("buildSitemapXml", () => {
     expect(xml).toContain("<loc>https://example.com/about</loc>");
   });
 
+  it("drops homepage when staticPaths omits '/'", () => {
+    const xml = buildSitemapXml(makeConfig({ staticPaths: ["/about"] }));
+    expect(xml).not.toContain("<loc>https://example.com/</loc>");
+    expect(xml).toContain("<loc>https://example.com/about</loc>");
+  });
+
+  it("only includes post URLs when staticPaths is empty", () => {
+    const xml = buildSitemapXml(makeConfig({ staticPaths: [] }));
+    expect(xml).not.toContain("<loc>https://example.com/</loc>");
+    expect(xml).toContain("<loc>https://example.com/post/hello-world</loc>");
+  });
+
+  it("omits lastmod for non-homepage static paths", () => {
+    const xml = buildSitemapXml(makeConfig({ staticPaths: ["/", "/about"] }));
+    const aboutSection = xml.split("/about</loc>")[1].split("</url>")[0];
+    expect(aboutSection).not.toContain("<lastmod>");
+  });
+
   it("throws when posts collection is missing", () => {
     expect(() => buildSitemapXml(makeConfig({ seed: { collections: [] } }))).toThrow(
       "No 'posts' collection found",

--- a/landing/e2e/robots-txt.spec.ts
+++ b/landing/e2e/robots-txt.spec.ts
@@ -26,4 +26,10 @@ test.describe("robots.txt", () => {
     const body = await response!.text();
     expect(body).toContain("User-agent");
   });
+
+  test("robots.txt references sitemap @smoke", async ({ page }) => {
+    const response = await page.goto("/robots.txt");
+    const body = await response!.text();
+    expect(body).toMatch(/^Sitemap:\s*https:\/\/commons\.systems\/sitemap\.xml\s*$/m);
+  });
 });

--- a/landing/e2e/seo.spec.ts
+++ b/landing/e2e/seo.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "@playwright/test";
+
+const SITE_URL = "https://commons.systems";
+
+async function getJsonLd(page: import("@playwright/test").Page, type: string) {
+  const scripts = await page.locator('script[type="application/ld+json"]').all();
+  for (const s of scripts) {
+    const text = await s.textContent();
+    if (!text) continue;
+    const json = JSON.parse(text);
+    if (json["@type"] === type) return json;
+  }
+  return null;
+}
+
+test.describe("SEO: canonical, JSON-LD, rel=me", () => {
+  test("homepage has canonical link to site root @smoke", async ({ page }) => {
+    await page.goto("/");
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveAttribute("href", `${SITE_URL}/`);
+  });
+
+  test("homepage has Organization JSON-LD @smoke", async ({ page }) => {
+    await page.goto("/");
+    const org = await getJsonLd(page, "Organization");
+    expect(org).not.toBeNull();
+    expect(org["@context"]).toBe("https://schema.org");
+    expect(org.name).toBeTruthy();
+    expect(org.url).toBe(SITE_URL);
+    expect(org.logo).toBeTruthy();
+    expect(Array.isArray(org.sameAs)).toBe(true);
+    expect(org.sameAs).toContain("https://github.com/natb1");
+  });
+
+  test("homepage has rel=me link to GitHub profile @smoke", async ({ page }) => {
+    await page.goto("/");
+    const relMe = page.locator('link[rel="me"]');
+    await expect(relMe).toHaveAttribute("href", "https://github.com/natb1");
+  });
+
+  test("post page has canonical link to post URL", async ({ page }) => {
+    await page.route("https://raw.githubusercontent.com/**", (route) =>
+      route.fulfill({ body: "# Test\nContent." }),
+    );
+    await page.goto("/post/recovering-autonomy-with-coding-agents");
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveAttribute(
+      "href",
+      `${SITE_URL}/post/recovering-autonomy-with-coding-agents`,
+    );
+  });
+
+  test("post page has BlogPosting JSON-LD with required fields", async ({ page }) => {
+    await page.route("https://raw.githubusercontent.com/**", (route) =>
+      route.fulfill({ body: "# Test\nContent." }),
+    );
+    await page.goto("/post/recovering-autonomy-with-coding-agents");
+    const posting = await getJsonLd(page, "BlogPosting");
+    expect(posting).not.toBeNull();
+    expect(posting.headline).toBeTruthy();
+    expect(posting.datePublished).toBeTruthy();
+    expect(posting.author).toBeTruthy();
+    expect(posting.author.name).toBeTruthy();
+    expect(posting.url).toBe(
+      `${SITE_URL}/post/recovering-autonomy-with-coding-agents`,
+    );
+    expect(posting.mainEntityOfPage).toBeTruthy();
+    expect(posting.mainEntityOfPage["@id"]).toBe(
+      `${SITE_URL}/post/recovering-autonomy-with-coding-agents`,
+    );
+  });
+
+  test("canonical updates on SPA navigation from home to post", async ({ page }) => {
+    await page.route("https://raw.githubusercontent.com/**", (route) =>
+      route.fulfill({ body: "# Test\nContent." }),
+    );
+    await page.goto("/");
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", `${SITE_URL}/`);
+    await page
+      .locator('#post-recovering-autonomy-with-coding-agents a.post-link')
+      .click();
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      `${SITE_URL}/post/recovering-autonomy-with-coding-agents`,
+    );
+  });
+});
+
+test.describe("sitemap.xml", () => {
+  test("GET /sitemap.xml returns valid XML with urlset @smoke", async ({ page }) => {
+    const response = await page.goto("/sitemap.xml");
+    expect(response).not.toBeNull();
+    expect(response!.status()).toBe(200);
+    const contentType = response!.headers()["content-type"] ?? "";
+    expect(contentType).toMatch(/xml/);
+
+    const body = await response!.text();
+    expect(body).toContain("<?xml");
+    expect(body).toContain("<urlset");
+    expect(body).toContain("<url>");
+    expect(body).toContain("<loc>");
+  });
+
+  test("sitemap includes homepage and all published posts", async ({ page }) => {
+    const response = await page.goto("/sitemap.xml");
+    const body = await response!.text();
+    expect(body).toContain(`<loc>${SITE_URL}/</loc>`);
+    expect(body).toContain(
+      `<loc>${SITE_URL}/post/recovering-autonomy-with-coding-agents</loc>`,
+    );
+  });
+
+  test("sitemap excludes unpublished posts", async ({ page }) => {
+    const response = await page.goto("/sitemap.xml");
+    const body = await response!.text();
+    expect(body).not.toContain("draft-ideas");
+  });
+});

--- a/landing/public/robots.txt
+++ b/landing/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://commons.systems/sitemap.xml

--- a/landing/scripts/prerender.ts
+++ b/landing/scripts/prerender.ts
@@ -1,14 +1,23 @@
 import { dirname, join } from "node:path";
 import { prerenderPosts } from "@commons-systems/blog/prerender";
 import { generateFeedXml } from "@commons-systems/blog/feed";
+import { generateSitemapXml } from "@commons-systems/blog/sitemap";
 import appSeed from "../seeds/firestore.js";
 import { BLOG_ROLL_ENTRIES } from "../src/blog-roll/config.js";
-import { NAV_LINKS, INFO_PANEL_LINK_SECTIONS, SITE_DEFAULTS } from "../src/site-config.js";
+import {
+  NAV_LINKS,
+  INFO_PANEL_LINK_SECTIONS,
+  SITE_DEFAULTS,
+  SITE_URL,
+  ORGANIZATION,
+  AUTHOR,
+  REL_ME,
+} from "../src/site-config.js";
 
 const distDir = join(dirname(new URL(import.meta.url).pathname), "..", "dist");
 
 await prerenderPosts({
-  siteUrl: "https://commons.systems",
+  siteUrl: SITE_URL,
   titleSuffix: "commons.systems",
   distDir,
   seed: appSeed,
@@ -21,11 +30,20 @@ await prerenderPosts({
     opmlUrl: "/blogroll.opml",
   },
   siteDefaults: SITE_DEFAULTS,
+  organization: ORGANIZATION,
+  author: AUTHOR,
+  relMe: REL_ME,
 });
 
 generateFeedXml({
   title: "commons.systems",
-  siteUrl: "https://commons.systems",
+  siteUrl: SITE_URL,
+  distDir,
+  seed: appSeed,
+});
+
+generateSitemapXml({
+  siteUrl: SITE_URL,
   distDir,
   seed: appSeed,
 });

--- a/landing/src/main.ts
+++ b/landing/src/main.ts
@@ -20,7 +20,7 @@ import { initPanelToggle } from "@commons-systems/style/panel-toggle";
 import "@commons-systems/style/components/nav";
 import type { AppNavElement } from "@commons-systems/style/components/nav";
 import { BLOG_ROLL_ENTRIES, createStrategies } from "./blog-roll/config.js";
-import { INFO_PANEL_LINK_SECTIONS, SITE_DEFAULTS } from "./site-config.js";
+import { INFO_PANEL_LINK_SECTIONS, SITE_DEFAULTS, SITE_URL } from "./site-config.js";
 import { signIn, signOut, onAuthStateChanged } from "./auth.js";
 import { isInGroup, ADMIN_GROUP_ID } from "@commons-systems/authutil/groups";
 import { db, NAMESPACE, trackPageView, initAppCheck } from "./firebase.js";
@@ -48,7 +48,7 @@ let lastSkippedCount = 0;
 let lastRenderedPosts: PostMeta[] | undefined;
 const strategies = createStrategies();
 const boundFetchPost = createFetchPost("landing/post");
-const RSS_CONFIG = { title: "commons.systems", siteUrl: "https://commons.systems" };
+const RSS_CONFIG = { title: "commons.systems", siteUrl: SITE_URL };
 const updateInfoPanel = (): void => {
   if (cachedPosts === lastRenderedPosts) return;
 

--- a/landing/src/main.ts
+++ b/landing/src/main.ts
@@ -14,6 +14,7 @@ import buildTimeContent from "virtual:blog-post-content";
 import buildTimeMetadata from "virtual:blog-post-metadata";
 import { createFetchPost } from "@commons-systems/blog/github";
 import { updateOgMeta } from "@commons-systems/blog/og-meta";
+import { updateCanonical } from "@commons-systems/blog/canonical";
 import { getPosts, type PostMeta } from "@commons-systems/blog/firestore";
 import { initPanelToggle } from "@commons-systems/style/panel-toggle";
 import "@commons-systems/style/components/nav";
@@ -114,6 +115,7 @@ const router = createHistoryRouter(
         const slug = path.startsWith("/post/") ? path.slice(6) : undefined;
         hydrateHome(outlet, cachedPosts, boundFetchPost, slug);
         updateOgMeta(RSS_CONFIG.siteUrl, slug ? cachedPosts.find((p) => p.id === slug) : undefined, RSS_CONFIG.title, SITE_DEFAULTS);
+        updateCanonical(RSS_CONFIG.siteUrl, slug);
         updateInfoPanel();
       },
     },

--- a/landing/src/site-config.ts
+++ b/landing/src/site-config.ts
@@ -1,6 +1,9 @@
 import type { LinkSection } from "@commons-systems/blog/components/info-panel";
 import type { NavLink } from "@commons-systems/blog/prerender";
 import type { SiteDefaults } from "@commons-systems/blog/og-meta";
+import type { Organization, Author } from "@commons-systems/blog/seo";
+
+export const SITE_URL = "https://commons.systems";
 
 export const NAV_LINKS: NavLink[] = [{ href: "/", label: "Home" }];
 
@@ -9,6 +12,20 @@ export const SITE_DEFAULTS: SiteDefaults = {
   description: "Nate's agentic coding workflow. A monorepo for proof-of-concept apps built with Claude Code — personal finance, print media, game blogs. Fork it, argue with it, discard the parts that don't serve you.",
   image: "/icons/rss.svg",
 };
+
+export const ORGANIZATION: Organization = {
+  name: "commons.systems",
+  url: SITE_URL,
+  logo: `${SITE_URL}/icons/rss.svg`,
+  sameAs: ["https://github.com/natb1"],
+};
+
+export const AUTHOR: Author = {
+  name: "Nathan Buesgens",
+  url: "https://github.com/natb1",
+};
+
+export const REL_ME: string[] = ["https://github.com/natb1"];
 
 export const INFO_PANEL_LINK_SECTIONS: LinkSection[] = [
   {


### PR DESCRIPTION
## Summary

Add a reusable SEO surface in `@commons-systems/blog` and wire it into the landing app:
- Homepage: `<link rel="canonical">`, `Organization` JSON-LD, `<link rel="me">` to the GitHub profile.
- Post pages: `<link rel="canonical">`, `BlogPosting` JSON-LD (headline, datePublished, author, url, mainEntityOfPage, plus description/image when available), `<link rel="me">`.
- `sitemap.xml` generated at build time from seed data (homepage + published posts, with `lastmod` from `publishedAt`).
- `robots.txt` references the sitemap.
- SPA canonical stays correct on client-side navigation via a new `updateCanonical` helper paired with the existing `updateOgMeta` hook.

## Scope decisions

- `SoftwareApplication` JSON-LD is deferred to #531 (app showcase grid). The cards don't exist yet, so adding a `SoftwareApplication` stub here would duplicate data that #531 will own. Follow-up for #531: add `softwareApplicationJsonLd(app)` to `blog/src/seo.ts` and extend `PrerenderConfig` with `softwareApplications?`.
- Helpers live in `blog/` (matches existing `og-meta` / `feed` / `prerender`) so fellspiral can opt in later without copying code.
- `rel=me` uses `<link rel="me">` in `<head>` rather than a visible `<a>`. Valid for IndieWeb verification; no footer restructuring.
- `BlogPosting` author is passed as config (`Nathan Buesgens`), not derived from `PostMeta`. Single-author blog today.

## Test plan

- [x] Unit: `blog/test/seo.test.ts` (15), `sitemap.test.ts` (11), `canonical.test.ts` (6), plus 10 new assertions in `prerender.test.ts`. All 273 workspace unit tests pass.
- [x] Lint clean on blog and landing.
- [x] Build: `npm run build --prefix landing` produces `dist/sitemap.xml`, canonical + Organization JSON-LD + rel=me in `dist/index.html`, canonical + BlogPosting JSON-LD + rel=me in each post page.
- [ ] Acceptance: `landing/e2e/seo.spec.ts` — canonical on home + post, Organization JSON-LD, BlogPosting JSON-LD, rel=me, SPA canonical update, sitemap endpoint. `robots-txt.spec.ts` now also asserts the `Sitemap:` line.
- [ ] Smoke (tagged `@smoke`): `/sitemap.xml` returns XML; `/robots.txt` contains `Sitemap:`; homepage has canonical + Organization JSON-LD + rel=me.
- [ ] Post-merge manual: validate with Google's Rich Results Test.

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)