### PR TITLE
budget: personal income statement and cash flow view

### DIFF
--- a/budget/e2e/accounts-income-statement.spec.ts
+++ b/budget/e2e/accounts-income-statement.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "@playwright/test";
+import { uploadIncomeStatementFixture } from "./helpers";
+
+test.describe("accounts income statement", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/transactions");
+    // Wait for the seed data notice so the upload input is ready.
+    await expect(page.locator("#seed-data-notice")).toBeVisible({ timeout: 15000 });
+    await uploadIncomeStatementFixture(page);
+    // Upload replaces seed data — wait for the notice to clear before navigating.
+    await expect(page.locator("#seed-data-notice")).toHaveCount(0, { timeout: 15000 });
+    await page.goto("/accounts");
+    await expect(page.locator("#accounts-table")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("income statement section is visible", async ({ page }) => {
+    await expect(page.locator("#accounts-income-statement")).toBeVisible();
+  });
+
+  test("income statement table has current, prior, and YoY column headers", async ({ page }) => {
+    const headers = page.locator("#accounts-income-table thead");
+    await expect(headers).toBeVisible();
+    const headerText = await headers.textContent();
+    // Expect three "Mon YYYY" month labels to appear in the header row.
+    const matches = headerText?.match(/\b[A-Z][a-z]{2} \d{4}\b/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("income statement includes income and expense categories from fixture", async ({ page }) => {
+    await expect(page.locator("#accounts-income-table tbody")).toContainText("Income");
+    await expect(page.locator("#accounts-expenses-table tbody")).toContainText("Food");
+    await expect(page.locator("#accounts-expenses-table tbody")).toContainText("Housing");
+  });
+
+  test("transfer categories do not appear as income or expense rows", async ({ page }) => {
+    await expect(page.locator("#accounts-income-table tbody")).not.toContainText("Transfer");
+    await expect(page.locator("#accounts-expenses-table tbody")).not.toContainText("Transfer");
+  });
+
+  test("cash flow summary section is visible with operating, transfers, and net change rows", async ({ page }) => {
+    await expect(page.locator("#accounts-cash-flow-summary")).toBeVisible();
+    const tbody = page.locator("#accounts-cash-flow-table tbody");
+    await expect(tbody).toContainText("Operating");
+    await expect(tbody).toContainText("Transfers");
+    await expect(tbody).toContainText("Net change");
+  });
+
+  test("savings rate row is visible", async ({ page }) => {
+    const tbody = page.locator("#accounts-net-income-table tbody");
+    await expect(tbody).toContainText("Savings rate");
+    const text = await tbody.textContent();
+    expect(text).toMatch(/\d+\.\d%/);
+  });
+
+  test("income statement renders above the charts", async ({ page }) => {
+    const isBox = await page.locator("#accounts-income-statement").boundingBox();
+    const chartBox = await page.locator("#accounts-trend-chart").boundingBox();
+    expect(isBox).not.toBeNull();
+    expect(chartBox).not.toBeNull();
+    expect(isBox!.y).toBeLessThan(chartBox!.y);
+  });
+});

--- a/budget/e2e/helpers.ts
+++ b/budget/e2e/helpers.ts
@@ -75,16 +75,18 @@ export async function uploadEncryptedFixture(page: Page, password: string): Prom
  * the same current month one year earlier (YoY). This lets the income
  * statement + cash flow summary renderers exercise all three periods.
  *
- * The month selection matches `mostRecentCompleteMonth` in
- * `src/income-statement.ts`, which is the calendar month immediately
- * preceding the month containing `Date.now()`.
+ * Placing transactions in the calendar month immediately preceding
+ * `Date.now()` guarantees that month is the latest-with-data month selected
+ * by `mostRecentMonthWithData` in `src/income-statement.ts` (which scans
+ * for the most recent includable transaction strictly before the current
+ * calendar month).
  */
 function buildIncomeStatementFixtureBuffer(): Buffer {
   const now = new Date(Date.now());
   const nowYear = now.getUTCFullYear();
   const nowMonth0 = now.getUTCMonth();
 
-  // mostRecentCompleteMonth: month immediately preceding the current calendar month (UTC).
+  // Month immediately preceding the current calendar month (UTC).
   const currentYear = nowMonth0 === 0 ? nowYear - 1 : nowYear;
   const currentMonth0 = nowMonth0 === 0 ? 11 : nowMonth0 - 1;
 

--- a/budget/e2e/helpers.ts
+++ b/budget/e2e/helpers.ts
@@ -68,3 +68,189 @@ export async function uploadEncryptedFixture(page: Page, password: string): Prom
     buffer: encrypted,
   });
 }
+
+/**
+ * Builds a synthetic fixture whose transactions span three months: the
+ * most-recent-complete month (current), the month before that (prior), and
+ * the same current month one year earlier (YoY). This lets the income
+ * statement + cash flow summary renderers exercise all three periods.
+ *
+ * The month selection matches `mostRecentCompleteMonth` in
+ * `src/income-statement.ts`, which is the calendar month immediately
+ * preceding the month containing `Date.now()`.
+ */
+function buildIncomeStatementFixtureBuffer(): Buffer {
+  const now = new Date(Date.now());
+  const nowYear = now.getUTCFullYear();
+  const nowMonth0 = now.getUTCMonth();
+
+  // mostRecentCompleteMonth: month immediately preceding the current calendar month (UTC).
+  const currentYear = nowMonth0 === 0 ? nowYear - 1 : nowYear;
+  const currentMonth0 = nowMonth0 === 0 ? 11 : nowMonth0 - 1;
+
+  // priorMonth: month before currentMonth.
+  const priorYear = currentMonth0 === 0 ? currentYear - 1 : currentYear;
+  const priorMonth0 = currentMonth0 === 0 ? 11 : currentMonth0 - 1;
+
+  // yoYMonth: currentMonth one year earlier.
+  const yoYYear = currentYear - 1;
+  const yoYMonth0 = currentMonth0;
+
+  const currentMonthDate = new Date(Date.UTC(currentYear, currentMonth0, 15));
+  const priorMonthDate = new Date(Date.UTC(priorYear, priorMonth0, 15));
+  const yearAgoDate = new Date(Date.UTC(yoYYear, yoYMonth0, 15));
+
+  const periodString = (year: number, month0: number): string => {
+    const mm = String(month0 + 1).padStart(2, "0");
+    return `${year}-${mm}`;
+  };
+
+  // Three periods: current, prior, yoY. For each: 1 income (negative amount),
+  // 2 expense, 1 transfer. Transfer rows must be filtered out of the income
+  // and expense tables by the renderer.
+  const makeTxns = (dateIso: string, period: "current" | "prior" | "yoy") => {
+    const incomeAmount = period === "yoy" ? -4800 : -5000;
+    const groceriesAmount = period === "current" ? 400 : period === "prior" ? 500 : 350;
+    return [
+      {
+        id: `txn-income-${period}`,
+        institution: "bankone",
+        account: "1234",
+        description: "EMPLOYER DIRECT DEP",
+        amount: incomeAmount,
+        timestamp: dateIso,
+        statementId: `bankone-1234-${period}`,
+        category: "Income:Salary",
+        budget: null,
+        note: "",
+        reimbursement: 0,
+        normalizedId: null,
+        normalizedPrimary: true,
+        normalizedDescription: null,
+      },
+      {
+        id: `txn-groceries-${period}`,
+        institution: "bankone",
+        account: "1234",
+        description: "KROGER #1234",
+        amount: groceriesAmount,
+        timestamp: dateIso,
+        statementId: `bankone-1234-${period}`,
+        category: "Food:Groceries",
+        budget: null,
+        note: "",
+        reimbursement: 0,
+        normalizedId: null,
+        normalizedPrimary: true,
+        normalizedDescription: null,
+      },
+      {
+        id: `txn-rent-${period}`,
+        institution: "bankone",
+        account: "1234",
+        description: "RENT PAYMENT",
+        amount: 1500,
+        timestamp: dateIso,
+        statementId: `bankone-1234-${period}`,
+        category: "Housing:Rent",
+        budget: null,
+        note: "",
+        reimbursement: 0,
+        normalizedId: null,
+        normalizedPrimary: true,
+        normalizedDescription: null,
+      },
+      {
+        id: `txn-transfer-${period}`,
+        institution: "banktwo",
+        account: "4444",
+        description: "CARD PAYMENT",
+        amount: 200,
+        timestamp: dateIso,
+        statementId: `banktwo-4444-${period}`,
+        category: "Transfer:CardPayment",
+        budget: null,
+        note: "",
+        reimbursement: 0,
+        normalizedId: null,
+        normalizedPrimary: true,
+        normalizedDescription: null,
+      },
+    ];
+  };
+
+  const transactions = [
+    ...makeTxns(currentMonthDate.toISOString(), "current"),
+    ...makeTxns(priorMonthDate.toISOString(), "prior"),
+    ...makeTxns(yearAgoDate.toISOString(), "yoy"),
+  ];
+
+  // Two statements per account spanning the fixture range so
+  // computeDerivedBalances has data to work with.
+  const statements = [
+    {
+      id: "stmt-bankone-1234-yoy",
+      statementId: `bankone-1234-${periodString(yoYYear, yoYMonth0)}`,
+      institution: "bankone",
+      account: "1234",
+      balance: 1000,
+      period: periodString(yoYYear, yoYMonth0),
+    },
+    {
+      id: "stmt-bankone-1234-current",
+      statementId: `bankone-1234-${periodString(currentYear, currentMonth0)}`,
+      institution: "bankone",
+      account: "1234",
+      balance: 1500,
+      period: periodString(currentYear, currentMonth0),
+    },
+    {
+      id: "stmt-banktwo-4444-yoy",
+      statementId: `banktwo-4444-${periodString(yoYYear, yoYMonth0)}`,
+      institution: "banktwo",
+      account: "4444",
+      balance: -100,
+      period: periodString(yoYYear, yoYMonth0),
+    },
+    {
+      id: "stmt-banktwo-4444-current",
+      statementId: `banktwo-4444-${periodString(currentYear, currentMonth0)}`,
+      institution: "banktwo",
+      account: "4444",
+      balance: -200,
+      period: periodString(currentYear, currentMonth0),
+    },
+  ];
+
+  const fixture = {
+    version: 1,
+    exportedAt: new Date(Date.now()).toISOString(),
+    groupId: "test-group",
+    groupName: "Test Household",
+    transactions,
+    statements,
+    budgets: [],
+    budgetPeriods: [],
+    rules: [],
+    normalizationRules: [],
+    weeklyAggregates: [],
+  };
+
+  return Buffer.from(JSON.stringify(fixture));
+}
+
+/**
+ * Uploads a synthetic fixture with transactions spanning the most-recent
+ * complete month, the prior month, and the same month one year earlier.
+ * Use this instead of `uploadFixture` when exercising features that render
+ * multi-period comparisons (e.g. the income statement and cash flow
+ * summary on /accounts).
+ */
+export async function uploadIncomeStatementFixture(page: Page): Promise<void> {
+  const fileInput = page.locator(".upload-input");
+  await fileInput.setInputFiles({
+    name: "income-statement-fixture.json",
+    mimeType: "application/json",
+    buffer: buildIncomeStatementFixtureBuffer(),
+  });
+}

--- a/budget/src/income-statement.ts
+++ b/budget/src/income-statement.ts
@@ -7,8 +7,8 @@ export interface CategoryLine {
 }
 
 export interface MonthlyIncomeStatement {
-  readonly income: CategoryLine[];
-  readonly expenses: CategoryLine[];
+  readonly income: readonly CategoryLine[];
+  readonly expenses: readonly CategoryLine[];
   readonly totalIncome: number;
   readonly totalExpenses: number;
   readonly netIncome: number;
@@ -45,16 +45,16 @@ export interface SavingsRateTriplet {
 
 export interface CashFlowTriplet {
   readonly current: CashFlowSummary;
-  readonly prior: CashFlowSummary;
-  readonly yoY: CashFlowSummary;
+  readonly prior: CashFlowSummary | null;
+  readonly yoY: CashFlowSummary | null;
 }
 
 export interface IncomeStatementReport {
   readonly currentLabel: string;
   readonly priorLabel: string;
   readonly yoYLabel: string;
-  readonly incomeRows: VarianceRow[];
-  readonly expenseRows: VarianceRow[];
+  readonly incomeRows: readonly VarianceRow[];
+  readonly expenseRows: readonly VarianceRow[];
   readonly totalIncome: PeriodVariance;
   readonly totalExpenses: PeriodVariance;
   readonly netIncome: PeriodVariance;
@@ -83,7 +83,11 @@ export function monthRange({ year, monthIdx0 }: YearMonth): { startMs: number; e
   return { startMs, endMs };
 }
 
-/** The calendar month immediately preceding the month containing `nowMs`. */
+/**
+ * The calendar month immediately preceding the month containing `nowMs`.
+ * Kept exported for tests and e2e fixtures; production selects the current
+ * month via `mostRecentMonthWithData`.
+ */
 export function mostRecentCompleteMonth(nowMs: number): YearMonth {
   const d = new Date(nowMs);
   const year = d.getUTCFullYear();
@@ -93,10 +97,8 @@ export function mostRecentCompleteMonth(nowMs: number): YearMonth {
 }
 
 /**
- * The most recent complete calendar month containing at least one transaction.
- * Scans from the end of `mostRecentCompleteMonth(nowMs)` backwards, so the
- * current partial month is never selected. Returns null when no transaction
- * falls at or before that ceiling.
+ * The most recent calendar month strictly before the month containing `nowMs`
+ * that contains at least one includable transaction. Returns null if none exists.
  */
 export function mostRecentMonthWithData(
   transactions: readonly Transaction[],
@@ -131,7 +133,10 @@ export function formatMonthLabel({ year, monthIdx0 }: YearMonth): string {
   return `${MONTH_LABELS[monthIdx0]} ${year}`;
 }
 
-/** Transactions valid for inclusion: has a timestamp and is not a non-primary normalized duplicate. */
+/**
+ * Normalized-duplicate detection keeps one primary copy per normalizedId; non-primary
+ * copies are skipped to avoid double-counting. Null timestamps cannot be windowed.
+ */
 function isIncludable(t: Transaction): boolean {
   if (t.timestamp === null) return false;
   if (t.normalizedId !== null && !t.normalizedPrimary) return false;
@@ -140,13 +145,6 @@ function isIncludable(t: Transaction): boolean {
 
 function netAmount(t: Transaction): number {
   return computeNetAmount(t.amount, t.reimbursement);
-}
-
-function compareCategoryDesc(a: CategoryLine, b: CategoryLine): number {
-  if (b.amount !== a.amount) return b.amount - a.amount;
-  if (a.category < b.category) return -1;
-  if (a.category > b.category) return 1;
-  return 0;
 }
 
 export function computeMonthlyIncomeStatement(
@@ -173,12 +171,18 @@ export function computeMonthlyIncomeStatement(
     }
   }
 
+  const byAmountDescThenName = (a: CategoryLine, b: CategoryLine): number => {
+    if (b.amount !== a.amount) return b.amount - a.amount;
+    if (a.category < b.category) return -1;
+    if (a.category > b.category) return 1;
+    return 0;
+  };
   const income: CategoryLine[] = [...incomeByCategory.entries()]
     .map(([category, amount]) => ({ category, amount }))
-    .sort(compareCategoryDesc);
+    .sort(byAmountDescThenName);
   const expenses: CategoryLine[] = [...expenseByCategory.entries()]
     .map(([category, amount]) => ({ category, amount }))
-    .sort(compareCategoryDesc);
+    .sort(byAmountDescThenName);
 
   const totalIncome = income.reduce((s, l) => s + l.amount, 0);
   const totalExpenses = expenses.reduce((s, l) => s + l.amount, 0);
@@ -218,10 +222,11 @@ export function computeCashFlowSummary(
   return { operating, transfers, netChange };
 }
 
-function monthAmount(statement: MonthlyIncomeStatement, side: "income" | "expenses", category: string): number {
+function amountsByCategory(statement: MonthlyIncomeStatement, side: "income" | "expenses"): Map<string, number> {
   const rows = side === "income" ? statement.income : statement.expenses;
-  const found = rows.find((l) => l.category === category);
-  return found ? found.amount : 0;
+  const m = new Map<string, number>();
+  for (const r of rows) m.set(r.category, r.amount);
+  return m;
 }
 
 function buildVariance(current: number, prior: number | null, yoY: number | null): PeriodVariance {
@@ -254,11 +259,6 @@ export function computeIncomeStatementReport(
   const priorRange = monthRange(priorMo);
   const yoYRange = monthRange(yoYMo);
 
-  // Only render the report when the current period has data.
-  if (!hasAnyTransactionInMonth(transactions, currentRange.startMs, currentRange.endMs)) {
-    return null;
-  }
-
   const current = computeMonthlyIncomeStatement(transactions, currentRange.startMs, currentRange.endMs);
   const priorHas = hasAnyTransactionInMonth(transactions, priorRange.startMs, priorRange.endMs);
   const yoYHas = hasAnyTransactionInMonth(transactions, yoYRange.startMs, yoYRange.endMs);
@@ -266,10 +266,9 @@ export function computeIncomeStatementReport(
   const yoY = yoYHas ? computeMonthlyIncomeStatement(transactions, yoYRange.startMs, yoYRange.endMs) : null;
 
   const currentCash = computeCashFlowSummary(transactions, currentRange.startMs, currentRange.endMs);
-  const priorCash = computeCashFlowSummary(transactions, priorRange.startMs, priorRange.endMs);
-  const yoYCash = computeCashFlowSummary(transactions, yoYRange.startMs, yoYRange.endMs);
+  const priorCash = priorHas ? computeCashFlowSummary(transactions, priorRange.startMs, priorRange.endMs) : null;
+  const yoYCash = yoYHas ? computeCashFlowSummary(transactions, yoYRange.startMs, yoYRange.endMs) : null;
 
-  // Build the union of top-level categories seen in any of the three periods, per side.
   function unionCategories(side: "income" | "expenses"): string[] {
     const s = new Set<string>();
     for (const statement of [current, prior, yoY]) {
@@ -277,18 +276,20 @@ export function computeIncomeStatementReport(
       const rows = side === "income" ? statement.income : statement.expenses;
       for (const r of rows) s.add(r.category);
     }
-    return [...s].sort();
+    return [...s];
   }
 
   function buildRows(side: "income" | "expenses"): VarianceRow[] {
+    const currentMap = amountsByCategory(current, side);
+    const priorMap = prior === null ? null : amountsByCategory(prior, side);
+    const yoYMap = yoY === null ? null : amountsByCategory(yoY, side);
     const cats = unionCategories(side);
     const rows = cats.map((category) => {
-      const cur = monthAmount(current, side, category);
-      const pr = prior === null ? null : monthAmount(prior, side, category);
-      const yy = yoY === null ? null : monthAmount(yoY, side, category);
+      const cur = currentMap.get(category) ?? 0;
+      const pr = priorMap === null ? null : (priorMap.get(category) ?? 0);
+      const yy = yoYMap === null ? null : (yoYMap.get(category) ?? 0);
       return { category, variance: buildVariance(cur, pr, yy) };
     });
-    // Sort by current amount descending, stable by category name on ties.
     rows.sort((a, b) => {
       if (b.variance.current !== a.variance.current) return b.variance.current - a.variance.current;
       if (a.category < b.category) return -1;

--- a/budget/src/income-statement.ts
+++ b/budget/src/income-statement.ts
@@ -1,0 +1,303 @@
+import type { Transaction } from "./firestore.js";
+import { computeNetAmount } from "./balance.js";
+
+export interface CategoryLine {
+  readonly category: string;
+  readonly amount: number;
+}
+
+export interface MonthlyIncomeStatement {
+  readonly income: CategoryLine[];
+  readonly expenses: CategoryLine[];
+  readonly totalIncome: number;
+  readonly totalExpenses: number;
+  readonly netIncome: number;
+  /** null when totalIncome is 0 (undefined ratio). */
+  readonly savingsRate: number | null;
+}
+
+export interface CashFlowSummary {
+  readonly operating: number;
+  readonly transfers: number;
+  readonly netChange: number;
+}
+
+export interface PeriodVariance {
+  readonly current: number;
+  readonly prior: number | null;
+  readonly priorVarianceAbs: number | null;
+  readonly priorVariancePct: number | null;
+  readonly yoY: number | null;
+  readonly yoYVarianceAbs: number | null;
+  readonly yoYVariancePct: number | null;
+}
+
+export interface VarianceRow {
+  readonly category: string;
+  readonly variance: PeriodVariance;
+}
+
+export interface SavingsRateTriplet {
+  readonly current: number | null;
+  readonly prior: number | null;
+  readonly yoY: number | null;
+}
+
+export interface CashFlowTriplet {
+  readonly current: CashFlowSummary;
+  readonly prior: CashFlowSummary;
+  readonly yoY: CashFlowSummary;
+}
+
+export interface IncomeStatementReport {
+  readonly currentLabel: string;
+  readonly priorLabel: string;
+  readonly yoYLabel: string;
+  readonly incomeRows: VarianceRow[];
+  readonly expenseRows: VarianceRow[];
+  readonly totalIncome: PeriodVariance;
+  readonly totalExpenses: PeriodVariance;
+  readonly netIncome: PeriodVariance;
+  readonly savingsRate: SavingsRateTriplet;
+  readonly cashFlow: CashFlowTriplet;
+}
+
+export interface YearMonth {
+  readonly year: number;
+  /** 0-based month index (0 = January). */
+  readonly monthIdx0: number;
+}
+
+export function topLevelCategory(category: string): string {
+  const idx = category.indexOf(":");
+  return idx === -1 ? category : category.substring(0, idx);
+}
+
+export function isTransferCategory(category: string): boolean {
+  return category === "Transfer" || category.startsWith("Transfer:");
+}
+
+export function monthRange({ year, monthIdx0 }: YearMonth): { startMs: number; endMs: number } {
+  const startMs = Date.UTC(year, monthIdx0, 1);
+  const endMs = Date.UTC(year, monthIdx0 + 1, 1);
+  return { startMs, endMs };
+}
+
+/** The calendar month immediately preceding the month containing `nowMs`. */
+export function mostRecentCompleteMonth(nowMs: number): YearMonth {
+  const d = new Date(nowMs);
+  const year = d.getUTCFullYear();
+  const monthIdx0 = d.getUTCMonth();
+  if (monthIdx0 === 0) return { year: year - 1, monthIdx0: 11 };
+  return { year, monthIdx0: monthIdx0 - 1 };
+}
+
+export function priorMonth({ year, monthIdx0 }: YearMonth): YearMonth {
+  if (monthIdx0 === 0) return { year: year - 1, monthIdx0: 11 };
+  return { year, monthIdx0: monthIdx0 - 1 };
+}
+
+export function yearAgoMonth({ year, monthIdx0 }: YearMonth): YearMonth {
+  return { year: year - 1, monthIdx0 };
+}
+
+const MONTH_LABELS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+export function formatMonthLabel({ year, monthIdx0 }: YearMonth): string {
+  return `${MONTH_LABELS[monthIdx0]} ${year}`;
+}
+
+/** Transactions valid for inclusion: has a timestamp and is not a non-primary normalized duplicate. */
+function isIncludable(t: Transaction): boolean {
+  if (t.timestamp === null) return false;
+  if (t.normalizedId !== null && !t.normalizedPrimary) return false;
+  return true;
+}
+
+function netAmount(t: Transaction): number {
+  return computeNetAmount(t.amount, t.reimbursement);
+}
+
+function compareCategoryDesc(a: CategoryLine, b: CategoryLine): number {
+  if (b.amount !== a.amount) return b.amount - a.amount;
+  if (a.category < b.category) return -1;
+  if (a.category > b.category) return 1;
+  return 0;
+}
+
+export function computeMonthlyIncomeStatement(
+  transactions: Transaction[],
+  startMs: number,
+  endMs: number,
+): MonthlyIncomeStatement {
+  const incomeByCategory = new Map<string, number>();
+  const expenseByCategory = new Map<string, number>();
+
+  for (const t of transactions) {
+    if (!isIncludable(t)) continue;
+    const tMs = t.timestamp!.toMillis();
+    if (tMs < startMs || tMs >= endMs) continue;
+    if (isTransferCategory(t.category)) continue;
+
+    const net = netAmount(t);
+    const top = topLevelCategory(t.category);
+    if (net < 0) {
+      // Credit / income (flip sign so it's positive in the statement)
+      incomeByCategory.set(top, (incomeByCategory.get(top) ?? 0) + (-net));
+    } else if (net > 0) {
+      expenseByCategory.set(top, (expenseByCategory.get(top) ?? 0) + net);
+    }
+  }
+
+  const income: CategoryLine[] = [...incomeByCategory.entries()]
+    .map(([category, amount]) => ({ category, amount }))
+    .sort(compareCategoryDesc);
+  const expenses: CategoryLine[] = [...expenseByCategory.entries()]
+    .map(([category, amount]) => ({ category, amount }))
+    .sort(compareCategoryDesc);
+
+  const totalIncome = income.reduce((s, l) => s + l.amount, 0);
+  const totalExpenses = expenses.reduce((s, l) => s + l.amount, 0);
+  const netIncome = totalIncome - totalExpenses;
+  const savingsRate = totalIncome === 0 ? null : netIncome / totalIncome;
+
+  return { income, expenses, totalIncome, totalExpenses, netIncome, savingsRate };
+}
+
+export function computeCashFlowSummary(
+  transactions: Transaction[],
+  startMs: number,
+  endMs: number,
+): CashFlowSummary {
+  let operatingCredits = 0;
+  let operatingDebits = 0;
+  let transfers = 0;
+
+  for (const t of transactions) {
+    if (!isIncludable(t)) continue;
+    const tMs = t.timestamp!.toMillis();
+    if (tMs < startMs || tMs >= endMs) continue;
+
+    const net = netAmount(t);
+    if (isTransferCategory(t.category)) {
+      // Flip sign: positive net is spending (leaves accounts), negative is credit (enters).
+      transfers += -net;
+    } else if (net < 0) {
+      operatingCredits += -net;
+    } else if (net > 0) {
+      operatingDebits += net;
+    }
+  }
+
+  const operating = operatingCredits - operatingDebits;
+  const netChange = operating + transfers;
+  return { operating, transfers, netChange };
+}
+
+function monthAmount(statement: MonthlyIncomeStatement, side: "income" | "expenses", category: string): number {
+  const rows = side === "income" ? statement.income : statement.expenses;
+  const found = rows.find((l) => l.category === category);
+  return found ? found.amount : 0;
+}
+
+function buildVariance(current: number, prior: number | null, yoY: number | null): PeriodVariance {
+  const priorVarianceAbs = prior === null ? null : current - prior;
+  const priorVariancePct = prior === null || prior === 0 ? null : ((current - prior) / Math.abs(prior)) * 100;
+  const yoYVarianceAbs = yoY === null ? null : current - yoY;
+  const yoYVariancePct = yoY === null || yoY === 0 ? null : ((current - yoY) / Math.abs(yoY)) * 100;
+  return { current, prior, priorVarianceAbs, priorVariancePct, yoY, yoYVarianceAbs, yoYVariancePct };
+}
+
+function hasAnyTransactionInMonth(transactions: Transaction[], startMs: number, endMs: number): boolean {
+  for (const t of transactions) {
+    if (!isIncludable(t)) continue;
+    const tMs = t.timestamp!.toMillis();
+    if (tMs >= startMs && tMs < endMs) return true;
+  }
+  return false;
+}
+
+export function computeIncomeStatementReport(
+  transactions: Transaction[],
+  nowMs: number,
+): IncomeStatementReport | null {
+  const currentMonth = mostRecentCompleteMonth(nowMs);
+  const priorMo = priorMonth(currentMonth);
+  const yoYMo = yearAgoMonth(currentMonth);
+
+  const currentRange = monthRange(currentMonth);
+  const priorRange = monthRange(priorMo);
+  const yoYRange = monthRange(yoYMo);
+
+  // Only render the report when the current period has data.
+  if (!hasAnyTransactionInMonth(transactions, currentRange.startMs, currentRange.endMs)) {
+    return null;
+  }
+
+  const current = computeMonthlyIncomeStatement(transactions, currentRange.startMs, currentRange.endMs);
+  const priorHas = hasAnyTransactionInMonth(transactions, priorRange.startMs, priorRange.endMs);
+  const yoYHas = hasAnyTransactionInMonth(transactions, yoYRange.startMs, yoYRange.endMs);
+  const prior = priorHas ? computeMonthlyIncomeStatement(transactions, priorRange.startMs, priorRange.endMs) : null;
+  const yoY = yoYHas ? computeMonthlyIncomeStatement(transactions, yoYRange.startMs, yoYRange.endMs) : null;
+
+  const currentCash = computeCashFlowSummary(transactions, currentRange.startMs, currentRange.endMs);
+  const priorCash = computeCashFlowSummary(transactions, priorRange.startMs, priorRange.endMs);
+  const yoYCash = computeCashFlowSummary(transactions, yoYRange.startMs, yoYRange.endMs);
+
+  // Build the union of top-level categories seen in any of the three periods, per side.
+  function unionCategories(side: "income" | "expenses"): string[] {
+    const s = new Set<string>();
+    for (const statement of [current, prior, yoY]) {
+      if (!statement) continue;
+      const rows = side === "income" ? statement.income : statement.expenses;
+      for (const r of rows) s.add(r.category);
+    }
+    return [...s].sort();
+  }
+
+  function buildRows(side: "income" | "expenses"): VarianceRow[] {
+    const cats = unionCategories(side);
+    const rows = cats.map((category) => {
+      const cur = monthAmount(current, side, category);
+      const pr = prior === null ? null : monthAmount(prior, side, category);
+      const yy = yoY === null ? null : monthAmount(yoY, side, category);
+      return { category, variance: buildVariance(cur, pr, yy) };
+    });
+    // Sort by current amount descending, stable by category name on ties.
+    rows.sort((a, b) => {
+      if (b.variance.current !== a.variance.current) return b.variance.current - a.variance.current;
+      if (a.category < b.category) return -1;
+      if (a.category > b.category) return 1;
+      return 0;
+    });
+    return rows;
+  }
+
+  const incomeRows = buildRows("income");
+  const expenseRows = buildRows("expenses");
+
+  const totalIncome = buildVariance(current.totalIncome, prior?.totalIncome ?? null, yoY?.totalIncome ?? null);
+  const totalExpenses = buildVariance(current.totalExpenses, prior?.totalExpenses ?? null, yoY?.totalExpenses ?? null);
+  const netIncome = buildVariance(current.netIncome, prior?.netIncome ?? null, yoY?.netIncome ?? null);
+
+  return {
+    currentLabel: formatMonthLabel(currentMonth),
+    priorLabel: formatMonthLabel(priorMo),
+    yoYLabel: formatMonthLabel(yoYMo),
+    incomeRows,
+    expenseRows,
+    totalIncome,
+    totalExpenses,
+    netIncome,
+    savingsRate: {
+      current: current.savingsRate,
+      prior: prior?.savingsRate ?? null,
+      yoY: yoY?.savingsRate ?? null,
+    },
+    cashFlow: {
+      current: currentCash,
+      prior: priorCash,
+      yoY: yoYCash,
+    },
+  };
+}

--- a/budget/src/income-statement.ts
+++ b/budget/src/income-statement.ts
@@ -92,6 +92,30 @@ export function mostRecentCompleteMonth(nowMs: number): YearMonth {
   return { year, monthIdx0: monthIdx0 - 1 };
 }
 
+/**
+ * The most recent complete calendar month containing at least one transaction.
+ * Scans from the end of `mostRecentCompleteMonth(nowMs)` backwards, so the
+ * current partial month is never selected. Returns null when no transaction
+ * falls at or before that ceiling.
+ */
+export function mostRecentMonthWithData(
+  transactions: readonly Transaction[],
+  nowMs: number,
+): YearMonth | null {
+  const d = new Date(nowMs);
+  const ceilingExclusiveMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1);
+
+  let latestMs = -Infinity;
+  for (const t of transactions) {
+    if (!isIncludable(t)) continue;
+    const tMs = t.timestamp!.toMillis();
+    if (tMs < ceilingExclusiveMs && tMs > latestMs) latestMs = tMs;
+  }
+  if (latestMs === -Infinity) return null;
+  const latest = new Date(latestMs);
+  return { year: latest.getUTCFullYear(), monthIdx0: latest.getUTCMonth() };
+}
+
 export function priorMonth({ year, monthIdx0 }: YearMonth): YearMonth {
   if (monthIdx0 === 0) return { year: year - 1, monthIdx0: 11 };
   return { year, monthIdx0: monthIdx0 - 1 };
@@ -221,7 +245,8 @@ export function computeIncomeStatementReport(
   transactions: Transaction[],
   nowMs: number,
 ): IncomeStatementReport | null {
-  const currentMonth = mostRecentCompleteMonth(nowMs);
+  const currentMonth = mostRecentMonthWithData(transactions, nowMs);
+  if (!currentMonth) return null;
   const priorMo = priorMonth(currentMonth);
   const yoYMo = yearAgoMonth(currentMonth);
 

--- a/budget/src/pages/accounts.ts
+++ b/budget/src/pages/accounts.ts
@@ -3,6 +3,7 @@ import { type RenderPageOptions, renderPageNotices, renderLoadError } from "./re
 import type { Transaction, Statement } from "../firestore.js";
 import { formatCurrency } from "../format.js";
 import { accountKey, splitAccountKey, computeAggregateTrend, computeNetWorth, computeCashFlow, computeDerivedBalances, type AggregatePoint, type NetWorthPoint, type CashFlowPoint, type DerivedAccountBalance } from "../balance.js";
+import { computeIncomeStatementReport, type IncomeStatementReport, type PeriodVariance, type VarianceRow, type CashFlowSummary } from "../income-statement.js";
 import { classifyError } from "@commons-systems/errorutil/classify";
 import { logError } from "@commons-systems/errorutil/log";
 
@@ -131,6 +132,168 @@ function serializeData(data: readonly AggregatePoint[] | readonly NetWorthPoint[
   return escapeHtml(JSON.stringify(data));
 }
 
+function formatSignedCurrency(n: number): string {
+  if (n === 0) return formatCurrency(0);
+  if (n > 0) return `+${formatCurrency(n)}`;
+  return `\u2212${formatCurrency(-n)}`;
+}
+
+function formatSignedPercent(p: number): string {
+  const rounded = Math.round(p * 10) / 10;
+  if (rounded === 0) return "0.0%";
+  if (rounded > 0) return `+${rounded.toFixed(1)}%`;
+  return `\u2212${Math.abs(rounded).toFixed(1)}%`;
+}
+
+function formatPercent(ratio: number | null): string {
+  if (ratio === null) return "—";
+  return `${(ratio * 100).toFixed(1)}%`;
+}
+
+function varianceClass(value: number | null): string {
+  if (value === null || value === 0) return "variance-neutral";
+  return value > 0 ? "variance-positive" : "variance-negative";
+}
+
+function renderAmountCell(n: number): string {
+  return `<td class="num">${escapeHtml(formatCurrency(n))}</td>`;
+}
+
+function renderNullableAmountCell(n: number | null): string {
+  if (n === null) return `<td class="num">—</td>`;
+  return `<td class="num">${escapeHtml(formatCurrency(n))}</td>`;
+}
+
+function renderVarianceAbsCell(n: number | null): string {
+  if (n === null) return `<td class="num variance-neutral">—</td>`;
+  return `<td class="num ${varianceClass(n)}">${escapeHtml(formatSignedCurrency(n))}</td>`;
+}
+
+function renderVariancePctCell(p: number | null): string {
+  if (p === null) return `<td class="num variance-neutral">—</td>`;
+  return `<td class="num ${varianceClass(p)}">${escapeHtml(formatSignedPercent(p))}</td>`;
+}
+
+function renderVarianceRow(label: string, variance: PeriodVariance, labelClass = "", rowClass = ""): string {
+  const labelAttr = labelClass ? ` class="${labelClass}"` : "";
+  const rowAttr = rowClass ? ` class="${rowClass}"` : "";
+  return `<tr${rowAttr}>
+    <td${labelAttr}>${escapeHtml(label)}</td>
+    ${renderAmountCell(variance.current)}
+    ${renderNullableAmountCell(variance.prior)}
+    ${renderVarianceAbsCell(variance.priorVarianceAbs)}
+    ${renderVariancePctCell(variance.priorVariancePct)}
+    ${renderNullableAmountCell(variance.yoY)}
+    ${renderVarianceAbsCell(variance.yoYVarianceAbs)}
+    ${renderVariancePctCell(variance.yoYVariancePct)}
+  </tr>`;
+}
+
+function renderIncomeStatementTable(
+  title: string,
+  tableId: string,
+  rows: VarianceRow[],
+  totalLabel: string,
+  totalVariance: PeriodVariance,
+  report: IncomeStatementReport,
+): string {
+  const bodyRows = rows.length > 0
+    ? rows.map((row) => renderVarianceRow(row.category, row.variance)).join("\n")
+    : `<tr><td colspan="8" class="empty-row">No ${title.toLowerCase()} this period.</td></tr>`;
+  return `<table id="${tableId}" class="income-statement-table">
+    <caption>${escapeHtml(title)}</caption>
+    <thead>
+      <tr>
+        <th>Category</th>
+        <th class="num">${escapeHtml(report.currentLabel)}</th>
+        <th class="num">${escapeHtml(report.priorLabel)}</th>
+        <th class="num">Δ$</th>
+        <th class="num">Δ%</th>
+        <th class="num">${escapeHtml(report.yoYLabel)}</th>
+        <th class="num">Δ$</th>
+        <th class="num">Δ%</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${bodyRows}
+      ${renderVarianceRow(totalLabel, totalVariance, "total-label", "total-row")}
+    </tbody>
+  </table>`;
+}
+
+function renderIncomeStatement(report: IncomeStatementReport): string {
+  const incomeTable = renderIncomeStatementTable(
+    "Income",
+    "accounts-income-table",
+    report.incomeRows,
+    "Total income",
+    report.totalIncome,
+    report,
+  );
+  const expenseTable = renderIncomeStatementTable(
+    "Expenses",
+    "accounts-expenses-table",
+    report.expenseRows,
+    "Total expenses",
+    report.totalExpenses,
+    report,
+  );
+  const netTable = `<table id="accounts-net-income-table" class="income-statement-table">
+    <tbody>
+      ${renderVarianceRow("Net income", report.netIncome, "total-label", "total-row")}
+      <tr class="savings-rate-row">
+        <td class="total-label">Savings rate</td>
+        <td class="num">${escapeHtml(formatPercent(report.savingsRate.current))}</td>
+        <td class="num">${escapeHtml(formatPercent(report.savingsRate.prior))}</td>
+        <td class="num variance-neutral"></td>
+        <td class="num variance-neutral"></td>
+        <td class="num">${escapeHtml(formatPercent(report.savingsRate.yoY))}</td>
+        <td class="num variance-neutral"></td>
+        <td class="num variance-neutral"></td>
+      </tr>
+    </tbody>
+  </table>`;
+  return `<section id="accounts-income-statement">
+    <h3>Income statement</h3>
+    ${incomeTable}
+    ${expenseTable}
+    ${netTable}
+  </section>`;
+}
+
+function renderCashFlowRow(label: string, field: keyof CashFlowSummary, report: IncomeStatementReport): string {
+  const current = report.cashFlow.current[field];
+  const prior = report.cashFlow.prior[field];
+  const yoY = report.cashFlow.yoY[field];
+  return `<tr>
+    <td>${escapeHtml(label)}</td>
+    <td class="num ${varianceClass(current)}">${escapeHtml(formatSignedCurrency(current))}</td>
+    <td class="num ${varianceClass(prior)}">${escapeHtml(formatSignedCurrency(prior))}</td>
+    <td class="num ${varianceClass(yoY)}">${escapeHtml(formatSignedCurrency(yoY))}</td>
+  </tr>`;
+}
+
+function renderCashFlowSummary(report: IncomeStatementReport): string {
+  return `<section id="accounts-cash-flow-summary">
+    <h3>Cash flow summary</h3>
+    <table id="accounts-cash-flow-table" class="cash-flow-summary-table">
+      <thead>
+        <tr>
+          <th>Activity</th>
+          <th class="num">${escapeHtml(report.currentLabel)}</th>
+          <th class="num">${escapeHtml(report.priorLabel)}</th>
+          <th class="num">${escapeHtml(report.yoYLabel)}</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${renderCashFlowRow("Operating", "operating", report)}
+        ${renderCashFlowRow("Transfers", "transfers", report)}
+        ${renderCashFlowRow("Net change", "netChange", report)}
+      </tbody>
+    </table>
+  </section>`;
+}
+
 function renderDivergenceWarning(derivedBalances: DerivedAccountBalance[]): string {
   const discrepancies = derivedBalances.filter(d => Math.abs(d.discrepancy) > 0.01);
   if (discrepancies.length === 0) return "";
@@ -163,6 +326,8 @@ export async function renderAccounts(options: RenderPageOptions): Promise<string
 
   let tableHtml: string;
   let chartHtml = "";
+  let incomeStatementHtml = "";
+  let cashFlowSummaryHtml = "";
   try {
     const [transactions, statements, periods] = await Promise.all([
       dataSource.getTransactions()
@@ -175,6 +340,12 @@ export async function renderAccounts(options: RenderPageOptions): Promise<string
     const derivedBalances = computeDerivedBalances(transactions, statements);
     const rows = buildAccountRows(transactions, statements, derivedBalances);
     tableHtml = renderAccountsTable(rows);
+
+    const report = computeIncomeStatementReport(transactions, Date.now());
+    if (report !== null) {
+      incomeStatementHtml = renderIncomeStatement(report);
+      cashFlowSummaryHtml = renderCashFlowSummary(report);
+    }
 
     try {
       const aggregateTrend = computeAggregateTrend(periods, transactions);
@@ -197,6 +368,8 @@ export async function renderAccounts(options: RenderPageOptions): Promise<string
   return `
     <h2>Accounts</h2>
     ${renderPageNotices(options, "accounts")}
+    ${incomeStatementHtml}
+    ${cashFlowSummaryHtml}
     ${chartHtml}
     ${tableHtml}
   `;

--- a/budget/src/pages/accounts.ts
+++ b/budget/src/pages/accounts.ts
@@ -150,85 +150,98 @@ function formatPercent(ratio: number | null): string {
   return `${(ratio * 100).toFixed(1)}%`;
 }
 
-function varianceClass(value: number | null): string {
+type VarianceSide = "income" | "expense";
+
+interface PeriodLabels {
+  readonly currentLabel: string;
+  readonly priorLabel: string;
+  readonly yoYLabel: string;
+}
+
+function varianceClass(value: number | null, side: VarianceSide = "income"): string {
   if (value === null || value === 0) return "variance-neutral";
-  return value > 0 ? "variance-positive" : "variance-negative";
+  const isPositive = side === "expense" ? value < 0 : value > 0;
+  return isPositive ? "variance-positive" : "variance-negative";
 }
 
-function renderAmountCell(n: number): string {
-  return `<td class="num">${escapeHtml(formatCurrency(n))}</td>`;
-}
-
-function renderNullableAmountCell(n: number | null): string {
+function renderAmountCell(n: number | null): string {
   if (n === null) return `<td class="num">—</td>`;
   return `<td class="num">${escapeHtml(formatCurrency(n))}</td>`;
 }
 
-function renderVarianceAbsCell(n: number | null): string {
-  if (n === null) return `<td class="num variance-neutral">—</td>`;
-  return `<td class="num ${varianceClass(n)}">${escapeHtml(formatSignedCurrency(n))}</td>`;
+function renderVarianceCell(value: number | null, format: (n: number) => string, side: VarianceSide): string {
+  if (value === null) return `<td class="num variance-neutral">—</td>`;
+  return `<td class="num ${varianceClass(value, side)}">${escapeHtml(format(value))}</td>`;
 }
 
-function renderVariancePctCell(p: number | null): string {
-  if (p === null) return `<td class="num variance-neutral">—</td>`;
-  return `<td class="num ${varianceClass(p)}">${escapeHtml(formatSignedPercent(p))}</td>`;
-}
-
-function renderVarianceRow(label: string, variance: PeriodVariance, labelClass = "", rowClass = ""): string {
+function renderVarianceRow(
+  label: string,
+  variance: PeriodVariance,
+  side: VarianceSide,
+  labelClass = "",
+  rowClass = "",
+): string {
   const labelAttr = labelClass ? ` class="${labelClass}"` : "";
   const rowAttr = rowClass ? ` class="${rowClass}"` : "";
   return `<tr${rowAttr}>
     <td${labelAttr}>${escapeHtml(label)}</td>
     ${renderAmountCell(variance.current)}
-    ${renderNullableAmountCell(variance.prior)}
-    ${renderVarianceAbsCell(variance.priorVarianceAbs)}
-    ${renderVariancePctCell(variance.priorVariancePct)}
-    ${renderNullableAmountCell(variance.yoY)}
-    ${renderVarianceAbsCell(variance.yoYVarianceAbs)}
-    ${renderVariancePctCell(variance.yoYVariancePct)}
+    ${renderAmountCell(variance.prior)}
+    ${renderVarianceCell(variance.priorVarianceAbs, formatSignedCurrency, side)}
+    ${renderVarianceCell(variance.priorVariancePct, formatSignedPercent, side)}
+    ${renderAmountCell(variance.yoY)}
+    ${renderVarianceCell(variance.yoYVarianceAbs, formatSignedCurrency, side)}
+    ${renderVarianceCell(variance.yoYVariancePct, formatSignedPercent, side)}
   </tr>`;
 }
 
 function renderIncomeStatementTable(
   title: string,
   tableId: string,
-  rows: VarianceRow[],
+  rows: readonly VarianceRow[],
   totalLabel: string,
   totalVariance: PeriodVariance,
-  report: IncomeStatementReport,
+  labels: PeriodLabels,
+  side: VarianceSide,
 ): string {
   const bodyRows = rows.length > 0
-    ? rows.map((row) => renderVarianceRow(row.category, row.variance)).join("\n")
+    ? rows.map((row) => renderVarianceRow(row.category, row.variance, side)).join("\n")
     : `<tr><td colspan="8" class="empty-row">No ${title.toLowerCase()} this period.</td></tr>`;
   return `<table id="${tableId}" class="income-statement-table">
     <caption>${escapeHtml(title)}</caption>
     <thead>
       <tr>
         <th>Category</th>
-        <th class="num">${escapeHtml(report.currentLabel)}</th>
-        <th class="num">${escapeHtml(report.priorLabel)}</th>
+        <th class="num">${escapeHtml(labels.currentLabel)}</th>
+        <th class="num">${escapeHtml(labels.priorLabel)}</th>
         <th class="num">Δ$</th>
         <th class="num">Δ%</th>
-        <th class="num">${escapeHtml(report.yoYLabel)}</th>
+        <th class="num">${escapeHtml(labels.yoYLabel)}</th>
         <th class="num">Δ$</th>
         <th class="num">Δ%</th>
       </tr>
     </thead>
     <tbody>
       ${bodyRows}
-      ${renderVarianceRow(totalLabel, totalVariance, "total-label", "total-row")}
+      ${renderVarianceRow(totalLabel, totalVariance, side, "total-label", "total-row")}
     </tbody>
   </table>`;
 }
 
 function renderIncomeStatement(report: IncomeStatementReport): string {
+  const labels: PeriodLabels = {
+    currentLabel: report.currentLabel,
+    priorLabel: report.priorLabel,
+    yoYLabel: report.yoYLabel,
+  };
   const incomeTable = renderIncomeStatementTable(
     "Income",
     "accounts-income-table",
     report.incomeRows,
     "Total income",
     report.totalIncome,
-    report,
+    labels,
+    "income",
   );
   const expenseTable = renderIncomeStatementTable(
     "Expenses",
@@ -236,20 +249,22 @@ function renderIncomeStatement(report: IncomeStatementReport): string {
     report.expenseRows,
     "Total expenses",
     report.totalExpenses,
-    report,
+    labels,
+    "expense",
   );
+  const emDashCell = `<td class="num variance-neutral">—</td>`;
   const netTable = `<table id="accounts-net-income-table" class="income-statement-table">
     <tbody>
-      ${renderVarianceRow("Net income", report.netIncome, "total-label", "total-row")}
+      ${renderVarianceRow("Net income", report.netIncome, "income", "total-label", "total-row")}
       <tr class="savings-rate-row">
         <td class="total-label">Savings rate</td>
         <td class="num">${escapeHtml(formatPercent(report.savingsRate.current))}</td>
         <td class="num">${escapeHtml(formatPercent(report.savingsRate.prior))}</td>
-        <td class="num variance-neutral"></td>
-        <td class="num variance-neutral"></td>
+        ${emDashCell}
+        ${emDashCell}
         <td class="num">${escapeHtml(formatPercent(report.savingsRate.yoY))}</td>
-        <td class="num variance-neutral"></td>
-        <td class="num variance-neutral"></td>
+        ${emDashCell}
+        ${emDashCell}
       </tr>
     </tbody>
   </table>`;
@@ -262,14 +277,18 @@ function renderIncomeStatement(report: IncomeStatementReport): string {
 }
 
 function renderCashFlowRow(label: string, field: keyof CashFlowSummary, report: IncomeStatementReport): string {
-  const current = report.cashFlow.current[field];
-  const prior = report.cashFlow.prior[field];
-  const yoY = report.cashFlow.yoY[field];
+  const neutral = field === "transfers";
+  const renderCell = (summary: CashFlowSummary | null): string => {
+    if (summary === null) return `<td class="num">—</td>`;
+    const value = summary[field];
+    const cls = neutral ? "" : ` ${varianceClass(value)}`;
+    return `<td class="num${cls}">${escapeHtml(formatSignedCurrency(value))}</td>`;
+  };
   return `<tr>
     <td>${escapeHtml(label)}</td>
-    <td class="num ${varianceClass(current)}">${escapeHtml(formatSignedCurrency(current))}</td>
-    <td class="num ${varianceClass(prior)}">${escapeHtml(formatSignedCurrency(prior))}</td>
-    <td class="num ${varianceClass(yoY)}">${escapeHtml(formatSignedCurrency(yoY))}</td>
+    ${renderCell(report.cashFlow.current)}
+    ${renderCell(report.cashFlow.prior)}
+    ${renderCell(report.cashFlow.yoY)}
   </tr>`;
 }
 

--- a/budget/src/style/theme.css
+++ b/budget/src/style/theme.css
@@ -525,3 +525,81 @@
 .virtual-txn {
   opacity: 0.75;
 }
+
+/* --- Income statement & cash flow summary --- */
+
+#accounts-income-statement,
+#accounts-cash-flow-summary {
+  margin-block: 1.5rem;
+}
+
+#accounts-income-statement h3,
+#accounts-cash-flow-summary h3 {
+  margin-block-end: 0.5rem;
+}
+
+.income-statement-table,
+.cash-flow-summary-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+  margin-block-end: 1rem;
+}
+
+.income-statement-table caption {
+  text-align: start;
+  font-weight: bold;
+  padding-block: 0.5rem;
+}
+
+.income-statement-table th,
+.income-statement-table td,
+.cash-flow-summary-table th,
+.cash-flow-summary-table td {
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.income-statement-table th,
+.cash-flow-summary-table th {
+  text-align: start;
+  font-weight: bold;
+  border-bottom: 2px solid var(--border);
+}
+
+.income-statement-table td.num,
+.income-statement-table th.num,
+.cash-flow-summary-table td.num,
+.cash-flow-summary-table th.num {
+  text-align: end;
+  white-space: nowrap;
+}
+
+.income-statement-table .total-row,
+.income-statement-table .savings-rate-row {
+  font-weight: bold;
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+}
+
+.income-statement-table .total-label,
+.cash-flow-summary-table tbody tr:last-child td:first-child {
+  font-weight: bold;
+}
+
+.income-statement-table .empty-row {
+  text-align: center;
+  opacity: 0.6;
+  font-style: italic;
+}
+
+.variance-positive {
+  color: #2ca02c;
+}
+
+.variance-negative {
+  color: var(--error, #e15759);
+}
+
+.variance-neutral {
+  opacity: 0.6;
+}

--- a/budget/src/style/theme.css
+++ b/budget/src/style/theme.css
@@ -4,6 +4,7 @@
 
 :root {
   color-scheme: dark;
+  --variance-positive: #2ca02c;
 }
 
 .content-grid {
@@ -593,7 +594,7 @@
 }
 
 .variance-positive {
-  color: #2ca02c;
+  color: var(--variance-positive);
 }
 
 .variance-negative {

--- a/budget/test/income-statement.test.ts
+++ b/budget/test/income-statement.test.ts
@@ -1,0 +1,601 @@
+import { describe, it, expect } from "vitest";
+import {
+  topLevelCategory,
+  isTransferCategory,
+  mostRecentCompleteMonth,
+  priorMonth,
+  yearAgoMonth,
+  monthRange,
+  formatMonthLabel,
+  computeMonthlyIncomeStatement,
+  computeCashFlowSummary,
+  computeIncomeStatementReport,
+} from "../src/income-statement";
+import type { Transaction } from "../src/firestore";
+import { ts } from "./helpers";
+
+function makeTxn(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: "txn-1" as any,
+    institution: "Bank",
+    account: "Checking",
+    description: "Test",
+    amount: 50,
+    note: "",
+    category: "Food:Groceries",
+    reimbursement: 0,
+    budget: null,
+    timestamp: ts("2025-02-15"),
+    statementId: null,
+    groupId: null,
+    normalizedId: null,
+    normalizedPrimary: true,
+    normalizedDescription: null,
+    virtual: false,
+    ...overrides,
+  };
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+describe("topLevelCategory", () => {
+  it("returns a flat category unchanged", () => {
+    expect(topLevelCategory("Food")).toBe("Food");
+  });
+
+  it("returns the segment before the first colon", () => {
+    expect(topLevelCategory("Food:Groceries")).toBe("Food");
+  });
+
+  it("returns only the first segment for deeply nested categories", () => {
+    expect(topLevelCategory("Food:Groceries:Organic")).toBe("Food");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(topLevelCategory("")).toBe("");
+  });
+
+  it("returns empty string when the string starts with a colon", () => {
+    expect(topLevelCategory(":Leading")).toBe("");
+  });
+});
+
+describe("isTransferCategory", () => {
+  it("returns true for exact 'Transfer'", () => {
+    expect(isTransferCategory("Transfer")).toBe(true);
+  });
+
+  it("returns true for 'Transfer:CardPayment'", () => {
+    expect(isTransferCategory("Transfer:CardPayment")).toBe(true);
+  });
+
+  it("returns true for 'Transfer:Savings'", () => {
+    expect(isTransferCategory("Transfer:Savings")).toBe(true);
+  });
+
+  it("returns true for nested Transfer subcategory", () => {
+    expect(isTransferCategory("Transfer:CardPayment:Chase")).toBe(true);
+  });
+
+  it("returns false for unrelated categories", () => {
+    expect(isTransferCategory("Food")).toBe(false);
+  });
+
+  it("returns false for categories with 'Transfer' as a prefix substring only", () => {
+    expect(isTransferCategory("Transferrable")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isTransferCategory("")).toBe(false);
+  });
+});
+
+describe("mostRecentCompleteMonth", () => {
+  it("returns the prior month for a mid-month timestamp", () => {
+    expect(mostRecentCompleteMonth(Date.UTC(2025, 1, 15))).toEqual({ year: 2025, monthIdx0: 0 });
+  });
+
+  it("returns the prior month for a timestamp at the first of the month", () => {
+    expect(mostRecentCompleteMonth(Date.UTC(2025, 1, 1))).toEqual({ year: 2025, monthIdx0: 0 });
+  });
+
+  it("rolls back to December of the prior year from January", () => {
+    expect(mostRecentCompleteMonth(Date.UTC(2025, 0, 10))).toEqual({ year: 2024, monthIdx0: 11 });
+  });
+});
+
+describe("monthRange", () => {
+  it("returns UTC start and end for February 2025", () => {
+    const { startMs, endMs } = monthRange({ year: 2025, monthIdx0: 1 });
+    expect(startMs).toBe(Date.UTC(2025, 1, 1));
+    expect(endMs).toBe(Date.UTC(2025, 2, 1));
+  });
+
+  it("produces a 29-day span for leap February 2024", () => {
+    const { startMs, endMs } = monthRange({ year: 2024, monthIdx0: 1 });
+    expect((endMs - startMs) / MS_PER_DAY).toBe(29);
+  });
+
+  it("rolls endMs to the next January for December", () => {
+    const { endMs } = monthRange({ year: 2024, monthIdx0: 11 });
+    expect(endMs).toBe(Date.UTC(2025, 0, 1));
+  });
+});
+
+describe("priorMonth", () => {
+  it("shifts March 2025 back to February 2025", () => {
+    expect(priorMonth({ year: 2025, monthIdx0: 2 })).toEqual({ year: 2025, monthIdx0: 1 });
+  });
+
+  it("shifts January 2025 back to December 2024", () => {
+    expect(priorMonth({ year: 2025, monthIdx0: 0 })).toEqual({ year: 2024, monthIdx0: 11 });
+  });
+});
+
+describe("yearAgoMonth", () => {
+  it("shifts February 2025 back to February 2024", () => {
+    expect(yearAgoMonth({ year: 2025, monthIdx0: 1 })).toEqual({ year: 2024, monthIdx0: 1 });
+  });
+});
+
+describe("formatMonthLabel", () => {
+  it("formats February 2025", () => {
+    expect(formatMonthLabel({ year: 2025, monthIdx0: 1 })).toBe("Feb 2025");
+  });
+
+  it("formats December 2024", () => {
+    expect(formatMonthLabel({ year: 2024, monthIdx0: 11 })).toBe("Dec 2024");
+  });
+});
+
+describe("computeMonthlyIncomeStatement", () => {
+  const febStart = Date.UTC(2025, 1, 1);
+  const febEnd = Date.UTC(2025, 2, 1);
+
+  it("returns zeroed results for an empty transaction list", () => {
+    const stmt = computeMonthlyIncomeStatement([], febStart, febEnd);
+    expect(stmt.totalIncome).toBe(0);
+    expect(stmt.totalExpenses).toBe(0);
+    expect(stmt.netIncome).toBe(0);
+    expect(stmt.savingsRate).toBeNull();
+    expect(stmt.income).toEqual([]);
+    expect(stmt.expenses).toEqual([]);
+  });
+
+  it("records a single expense under its top-level category", () => {
+    const txns = [makeTxn({ amount: 50, category: "Food:Groceries", timestamp: ts("2025-02-10") })];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.expenses).toEqual([{ category: "Food", amount: 50 }]);
+    expect(stmt.totalExpenses).toBe(50);
+    expect(stmt.totalIncome).toBe(0);
+    expect(stmt.netIncome).toBe(-50);
+    expect(stmt.savingsRate).toBeNull();
+  });
+
+  it("records a single income (negative amount) as a positive category line", () => {
+    const txns = [makeTxn({ amount: -2000, category: "Income:Salary", timestamp: ts("2025-02-05") })];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.income).toEqual([{ category: "Income", amount: 2000 }]);
+    expect(stmt.totalIncome).toBe(2000);
+  });
+
+  it("excludes Transfer categories", () => {
+    const txns = [
+      makeTxn({ id: "txn-1" as any, amount: 300, category: "Transfer:CardPayment", timestamp: ts("2025-02-05") }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.expenses).toEqual([]);
+    expect(stmt.income).toEqual([]);
+    expect(stmt.totalExpenses).toBe(0);
+    expect(stmt.totalIncome).toBe(0);
+  });
+
+  it("excludes transactions before the start of the window", () => {
+    const txns = [makeTxn({ amount: 50, category: "Food:Groceries", timestamp: ts("2025-01-31") })];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.totalExpenses).toBe(0);
+  });
+
+  it("excludes transactions at or after the end of the window", () => {
+    const txns = [makeTxn({ amount: 50, category: "Food:Groceries", timestamp: ts("2025-03-01") })];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.totalExpenses).toBe(0);
+  });
+
+  it("includes a transaction at exactly startMs (half-open lower bound)", () => {
+    const txns = [
+      makeTxn({
+        amount: 50,
+        category: "Food:Groceries",
+        timestamp: { toDate: () => new Date(febStart), toMillis: () => febStart } as any,
+      }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.totalExpenses).toBe(50);
+  });
+
+  it("excludes a transaction at exactly endMs (half-open upper bound)", () => {
+    const txns = [
+      makeTxn({
+        amount: 50,
+        category: "Food:Groceries",
+        timestamp: { toDate: () => new Date(febEnd), toMillis: () => febEnd } as any,
+      }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.totalExpenses).toBe(0);
+  });
+
+  it("drops transactions with null timestamp", () => {
+    const txns = [makeTxn({ amount: 50, category: "Food:Groceries", timestamp: null })];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.totalExpenses).toBe(0);
+  });
+
+  it("drops non-primary normalized duplicates", () => {
+    const txns = [
+      makeTxn({
+        amount: 50,
+        category: "Food:Groceries",
+        normalizedId: "norm-1",
+        normalizedPrimary: false,
+      }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.totalExpenses).toBe(0);
+  });
+
+  it("includes normalized primary duplicates", () => {
+    const txns = [
+      makeTxn({
+        amount: 50,
+        category: "Food:Groceries",
+        normalizedId: "norm-1",
+        normalizedPrimary: true,
+      }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.totalExpenses).toBe(50);
+  });
+
+  it("applies reimbursement to the recorded amount", () => {
+    const txns = [
+      makeTxn({ amount: 100, reimbursement: 50, category: "Food:Groceries", timestamp: ts("2025-02-10") }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.expenses).toEqual([{ category: "Food", amount: 50 }]);
+    expect(stmt.totalExpenses).toBe(50);
+  });
+
+  it("groups subcategories by their top-level parent", () => {
+    const txns = [
+      makeTxn({ id: "t1" as any, amount: 30, category: "Food:Groceries", timestamp: ts("2025-02-05") }),
+      makeTxn({ id: "t2" as any, amount: 20, category: "Food:Dining", timestamp: ts("2025-02-06") }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.expenses).toEqual([{ category: "Food", amount: 50 }]);
+    expect(stmt.totalExpenses).toBe(50);
+  });
+
+  it("sorts expense rows by amount descending", () => {
+    const txns = [
+      makeTxn({ id: "t1" as any, amount: 30, category: "Food:Groceries", timestamp: ts("2025-02-05") }),
+      makeTxn({ id: "t2" as any, amount: 1500, category: "Housing:Rent", timestamp: ts("2025-02-06") }),
+      makeTxn({ id: "t3" as any, amount: 100, category: "Transport:Gas", timestamp: ts("2025-02-07") }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.expenses.map((l) => l.category)).toEqual(["Housing", "Transport", "Food"]);
+  });
+
+  it("sorts income rows by amount descending", () => {
+    const txns = [
+      makeTxn({ id: "t1" as any, amount: -500, category: "Income:Bonus", timestamp: ts("2025-02-05") }),
+      makeTxn({ id: "t2" as any, amount: -5000, category: "Salary:Base", timestamp: ts("2025-02-06") }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.income.map((l) => l.category)).toEqual(["Salary", "Income"]);
+  });
+
+  it("computes savingsRate as netIncome / totalIncome when income is positive", () => {
+    const txns = [
+      makeTxn({ id: "t1" as any, amount: -1000, category: "Income:Salary", timestamp: ts("2025-02-01") }),
+      makeTxn({ id: "t2" as any, amount: 400, category: "Food:Groceries", timestamp: ts("2025-02-10") }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.totalIncome).toBe(1000);
+    expect(stmt.totalExpenses).toBe(400);
+    expect(stmt.netIncome).toBe(600);
+    expect(stmt.savingsRate).toBeCloseTo(0.6);
+  });
+});
+
+describe("computeCashFlowSummary", () => {
+  const febStart = Date.UTC(2025, 1, 1);
+  const febEnd = Date.UTC(2025, 2, 1);
+
+  it("returns zeroed results for an empty transaction list", () => {
+    const cash = computeCashFlowSummary([], febStart, febEnd);
+    expect(cash.operating).toBe(0);
+    expect(cash.transfers).toBe(0);
+    expect(cash.netChange).toBe(0);
+  });
+
+  it("computes operating from income and expenses only", () => {
+    const txns = [
+      makeTxn({ id: "t1" as any, amount: -1000, category: "Income:Salary", timestamp: ts("2025-02-01") }),
+      makeTxn({ id: "t2" as any, amount: 400, category: "Food:Groceries", timestamp: ts("2025-02-10") }),
+    ];
+    const cash = computeCashFlowSummary(txns, febStart, febEnd);
+    expect(cash.operating).toBe(600);
+    expect(cash.transfers).toBe(0);
+    expect(cash.netChange).toBe(600);
+  });
+
+  it("treats a positive-amount Transfer as money leaving accounts", () => {
+    const txns = [
+      makeTxn({ amount: 500, category: "Transfer:CardPayment", timestamp: ts("2025-02-05") }),
+    ];
+    const cash = computeCashFlowSummary(txns, febStart, febEnd);
+    expect(cash.operating).toBe(0);
+    expect(cash.transfers).toBe(-500);
+    expect(cash.netChange).toBe(-500);
+  });
+
+  it("treats a negative-amount Transfer as money entering accounts", () => {
+    const txns = [
+      makeTxn({ amount: -500, category: "Transfer:Savings", timestamp: ts("2025-02-05") }),
+    ];
+    const cash = computeCashFlowSummary(txns, febStart, febEnd);
+    expect(cash.operating).toBe(0);
+    expect(cash.transfers).toBe(500);
+    expect(cash.netChange).toBe(500);
+  });
+
+  it("sums operating and transfers correctly in a mixed month", () => {
+    const txns = [
+      makeTxn({ id: "t1" as any, amount: -1000, category: "Income:Salary", timestamp: ts("2025-02-01") }),
+      makeTxn({ id: "t2" as any, amount: 400, category: "Food:Groceries", timestamp: ts("2025-02-10") }),
+      makeTxn({ id: "t3" as any, amount: 200, category: "Transfer:CardPayment", timestamp: ts("2025-02-12") }),
+    ];
+    const cash = computeCashFlowSummary(txns, febStart, febEnd);
+    expect(cash.operating).toBe(600);
+    expect(cash.transfers).toBe(-200);
+    expect(cash.netChange).toBe(400);
+  });
+
+  it("handles a transfer-only month with zero operating", () => {
+    const txns = [
+      makeTxn({ id: "t1" as any, amount: 200, category: "Transfer:CardPayment", timestamp: ts("2025-02-05") }),
+      makeTxn({ id: "t2" as any, amount: -300, category: "Transfer:Savings", timestamp: ts("2025-02-06") }),
+    ];
+    const cash = computeCashFlowSummary(txns, febStart, febEnd);
+    expect(cash.operating).toBe(0);
+    expect(cash.transfers).toBe(100);
+    expect(cash.netChange).toBe(100);
+  });
+
+  it("applies reimbursement to transfer amounts", () => {
+    const txns = [
+      makeTxn({
+        amount: 400,
+        reimbursement: 50,
+        category: "Transfer:CardPayment",
+        timestamp: ts("2025-02-05"),
+      }),
+    ];
+    const cash = computeCashFlowSummary(txns, febStart, febEnd);
+    expect(cash.transfers).toBe(-200);
+  });
+
+  it("excludes non-primary normalized duplicates", () => {
+    const txns = [
+      makeTxn({
+        amount: 500,
+        category: "Transfer:CardPayment",
+        normalizedId: "norm-1",
+        normalizedPrimary: false,
+      }),
+    ];
+    const cash = computeCashFlowSummary(txns, febStart, febEnd);
+    expect(cash.transfers).toBe(0);
+  });
+
+  it("excludes transactions with null timestamps", () => {
+    const txns = [makeTxn({ amount: 400, category: "Food:Groceries", timestamp: null })];
+    const cash = computeCashFlowSummary(txns, febStart, febEnd);
+    expect(cash.operating).toBe(0);
+  });
+
+  it("excludes transactions outside the window", () => {
+    const txns = [
+      makeTxn({ amount: 400, category: "Food:Groceries", timestamp: ts("2025-01-31") }),
+      makeTxn({ amount: 500, category: "Transfer:CardPayment", timestamp: ts("2025-03-01") }),
+    ];
+    const cash = computeCashFlowSummary(txns, febStart, febEnd);
+    expect(cash.operating).toBe(0);
+    expect(cash.transfers).toBe(0);
+  });
+});
+
+describe("computeIncomeStatementReport", () => {
+  it("returns null when given no transactions", () => {
+    expect(computeIncomeStatementReport([], Date.UTC(2025, 2, 15))).toBeNull();
+  });
+
+  it("returns null when no transactions fall in the most recent complete month", () => {
+    // nowMs = mid-March 2025, current month = Feb 2025. Only a January txn.
+    const txns = [makeTxn({ amount: 100, category: "Food:Groceries", timestamp: ts("2025-01-15") })];
+    expect(computeIncomeStatementReport(txns, Date.UTC(2025, 2, 15))).toBeNull();
+  });
+
+  it("builds a report across current/prior/YoY months with labels, totals, and variance", () => {
+    const nowMs = Date.UTC(2025, 2, 15); // mid-March 2025
+    const txns: Transaction[] = [
+      // Feb 2025 (current)
+      makeTxn({ id: "f-sal" as any, amount: -5000, category: "Income:Salary", timestamp: ts("2025-02-01") }),
+      makeTxn({ id: "f-gro" as any, amount: 400, category: "Food:Groceries", timestamp: ts("2025-02-05") }),
+      makeTxn({ id: "f-rent" as any, amount: 1500, category: "Housing:Rent", timestamp: ts("2025-02-03") }),
+      makeTxn({ id: "f-xfer" as any, amount: 200, category: "Transfer:CardPayment", timestamp: ts("2025-02-10") }),
+      // Jan 2025 (prior)
+      makeTxn({ id: "j-sal" as any, amount: -5000, category: "Income:Salary", timestamp: ts("2025-01-01") }),
+      makeTxn({ id: "j-gro" as any, amount: 500, category: "Food:Groceries", timestamp: ts("2025-01-05") }),
+      makeTxn({ id: "j-rent" as any, amount: 1500, category: "Housing:Rent", timestamp: ts("2025-01-03") }),
+      // Feb 2024 (YoY)
+      makeTxn({ id: "y-sal" as any, amount: -4800, category: "Income:Salary", timestamp: ts("2024-02-01") }),
+      makeTxn({ id: "y-gro" as any, amount: 350, category: "Food:Groceries", timestamp: ts("2024-02-05") }),
+      makeTxn({ id: "y-rent" as any, amount: 1500, category: "Housing:Rent", timestamp: ts("2024-02-03") }),
+    ];
+
+    const report = computeIncomeStatementReport(txns, nowMs);
+    expect(report).not.toBeNull();
+    if (!report) return;
+
+    expect(report.currentLabel).toBe("Feb 2025");
+    expect(report.priorLabel).toBe("Jan 2025");
+    expect(report.yoYLabel).toBe("Feb 2024");
+
+    // totalIncome
+    expect(report.totalIncome.current).toBe(5000);
+    expect(report.totalIncome.prior).toBe(5000);
+    expect(report.totalIncome.yoY).toBe(4800);
+    expect(report.totalIncome.priorVarianceAbs).toBe(0);
+    expect(report.totalIncome.priorVariancePct).toBe(0);
+    expect(report.totalIncome.yoYVarianceAbs).toBe(200);
+    expect(report.totalIncome.yoYVariancePct).toBeCloseTo(4.1666667, 4);
+
+    // totalExpenses
+    expect(report.totalExpenses.current).toBe(1900);
+    expect(report.totalExpenses.prior).toBe(2000);
+    expect(report.totalExpenses.yoY).toBe(1850);
+
+    // netIncome
+    expect(report.netIncome.current).toBe(3100);
+    expect(report.netIncome.prior).toBe(3000);
+    expect(report.netIncome.yoY).toBe(2950);
+
+    // savingsRate
+    expect(report.savingsRate.current).toBeCloseTo(0.62);
+    expect(report.savingsRate.prior).toBeCloseTo(0.6);
+    expect(report.savingsRate.yoY).toBeCloseTo(0.6145833, 4);
+
+    // cashFlow.current
+    expect(report.cashFlow.current.operating).toBe(3100);
+    expect(report.cashFlow.current.transfers).toBe(-200);
+    expect(report.cashFlow.current.netChange).toBe(2900);
+
+    // income rows contain an Income row with expected current amount
+    const incomeRow = report.incomeRows.find((r) => r.category === "Income");
+    expect(incomeRow).toBeDefined();
+    expect(incomeRow?.variance.current).toBe(5000);
+    expect(incomeRow?.variance.prior).toBe(5000);
+    expect(incomeRow?.variance.yoY).toBe(4800);
+
+    // expense rows include both Food and Housing
+    const expenseCats = report.expenseRows.map((r) => r.category);
+    expect(expenseCats).toContain("Food");
+    expect(expenseCats).toContain("Housing");
+  });
+
+  it("handles year rollover when nowMs is in February", () => {
+    // nowMs = mid-Feb 2026 → current = Jan 2026, prior = Dec 2025, YoY = Jan 2025
+    const nowMs = Date.UTC(2026, 1, 15);
+    const txns = [
+      makeTxn({ amount: 100, category: "Food:Groceries", timestamp: ts("2026-01-10") }),
+    ];
+    const report = computeIncomeStatementReport(txns, nowMs);
+    expect(report).not.toBeNull();
+    if (!report) return;
+    expect(report.currentLabel).toBe("Jan 2026");
+    expect(report.priorLabel).toBe("Dec 2025");
+    expect(report.yoYLabel).toBe("Jan 2025");
+  });
+
+  it("leaves YoY fields null when there are no YoY transactions", () => {
+    const nowMs = Date.UTC(2025, 2, 15); // current = Feb 2025, yoY = Feb 2024
+    const txns = [
+      // Feb 2025 only
+      makeTxn({ id: "f-sal" as any, amount: -5000, category: "Income:Salary", timestamp: ts("2025-02-01") }),
+      makeTxn({ id: "f-gro" as any, amount: 400, category: "Food:Groceries", timestamp: ts("2025-02-05") }),
+      // Jan 2025 prior
+      makeTxn({ id: "j-sal" as any, amount: -5000, category: "Income:Salary", timestamp: ts("2025-01-01") }),
+      makeTxn({ id: "j-gro" as any, amount: 500, category: "Food:Groceries", timestamp: ts("2025-01-05") }),
+    ];
+
+    const report = computeIncomeStatementReport(txns, nowMs);
+    expect(report).not.toBeNull();
+    if (!report) return;
+
+    expect(report.totalIncome.yoY).toBeNull();
+    expect(report.totalIncome.yoYVarianceAbs).toBeNull();
+    expect(report.totalIncome.yoYVariancePct).toBeNull();
+    expect(report.totalIncome.prior).toBe(5000);
+    expect(report.totalIncome.priorVarianceAbs).toBe(0);
+    expect(report.savingsRate.yoY).toBeNull();
+  });
+
+  it("leaves priorVariancePct null when prior total is zero but keeps priorVarianceAbs as current", () => {
+    const nowMs = Date.UTC(2025, 2, 15); // current = Feb 2025, prior = Jan 2025
+    const txns = [
+      // Feb 2025 — salary present (current income = 5000)
+      makeTxn({ id: "f-sal" as any, amount: -5000, category: "Income:Salary", timestamp: ts("2025-02-01") }),
+      // Jan 2025 — expenses only, no income (prior income = 0)
+      makeTxn({ id: "j-gro" as any, amount: 500, category: "Food:Groceries", timestamp: ts("2025-01-05") }),
+    ];
+
+    const report = computeIncomeStatementReport(txns, nowMs);
+    expect(report).not.toBeNull();
+    if (!report) return;
+
+    expect(report.totalIncome.current).toBe(5000);
+    expect(report.totalIncome.prior).toBe(0);
+    expect(report.totalIncome.priorVarianceAbs).toBe(5000);
+    expect(report.totalIncome.priorVariancePct).toBeNull();
+  });
+
+  it("emits a row for each category seen in any period, zero-filling the missing periods", () => {
+    const nowMs = Date.UTC(2025, 2, 15); // current = Feb 2025, prior = Jan 2025
+    const txns = [
+      // Current has Food (expense) only; seed Income so the report is non-null and well-formed
+      makeTxn({ id: "f-sal" as any, amount: -1000, category: "Income:Salary", timestamp: ts("2025-02-01") }),
+      makeTxn({ id: "f-gro" as any, amount: 200, category: "Food:Groceries", timestamp: ts("2025-02-05") }),
+      // Prior has Entertainment only, plus some income so prior has at least one txn
+      makeTxn({ id: "j-sal" as any, amount: -1000, category: "Income:Salary", timestamp: ts("2025-01-01") }),
+      makeTxn({ id: "j-ent" as any, amount: 80, category: "Entertainment:Movies", timestamp: ts("2025-01-05") }),
+    ];
+
+    const report = computeIncomeStatementReport(txns, nowMs);
+    expect(report).not.toBeNull();
+    if (!report) return;
+
+    const expenseCats = report.expenseRows.map((r) => r.category);
+    expect(expenseCats).toContain("Food");
+    expect(expenseCats).toContain("Entertainment");
+
+    const foodRow = report.expenseRows.find((r) => r.category === "Food");
+    const entRow = report.expenseRows.find((r) => r.category === "Entertainment");
+    expect(foodRow?.variance.current).toBe(200);
+    expect(foodRow?.variance.prior).toBe(0);
+    expect(entRow?.variance.current).toBe(0);
+    expect(entRow?.variance.prior).toBe(80);
+  });
+
+  it("sorts rows by current amount descending", () => {
+    const nowMs = Date.UTC(2025, 2, 15); // current = Feb 2025
+    const txns = [
+      makeTxn({ id: "f-sal" as any, amount: -5000, category: "Income:Salary", timestamp: ts("2025-02-01") }),
+      makeTxn({ id: "f-gro" as any, amount: 200, category: "Food:Groceries", timestamp: ts("2025-02-05") }),
+      makeTxn({ id: "f-rent" as any, amount: 1500, category: "Housing:Rent", timestamp: ts("2025-02-03") }),
+      makeTxn({ id: "f-gas" as any, amount: 600, category: "Transport:Gas", timestamp: ts("2025-02-07") }),
+    ];
+
+    const report = computeIncomeStatementReport(txns, nowMs);
+    expect(report).not.toBeNull();
+    if (!report) return;
+
+    const orderedCurrent = report.expenseRows.map((r) => r.variance.current);
+    const sorted = [...orderedCurrent].sort((a, b) => b - a);
+    expect(orderedCurrent).toEqual(sorted);
+    // And specifically in this fixture:
+    expect(report.expenseRows.map((r) => r.category)).toEqual(["Housing", "Transport", "Food"]);
+  });
+});

--- a/budget/test/income-statement.test.ts
+++ b/budget/test/income-statement.test.ts
@@ -3,6 +3,7 @@ import {
   topLevelCategory,
   isTransferCategory,
   mostRecentCompleteMonth,
+  mostRecentMonthWithData,
   priorMonth,
   yearAgoMonth,
   monthRange,
@@ -101,6 +102,69 @@ describe("mostRecentCompleteMonth", () => {
 
   it("rolls back to December of the prior year from January", () => {
     expect(mostRecentCompleteMonth(Date.UTC(2025, 0, 10))).toEqual({ year: 2024, monthIdx0: 11 });
+  });
+});
+
+describe("mostRecentMonthWithData", () => {
+  it("returns the month of the latest transaction before the ceiling", () => {
+    // nowMs = mid-March 2025; ceiling exclusive = start of March 2025.
+    const txns = [
+      makeTxn({ id: "a" as any, timestamp: ts("2025-01-10") }),
+      makeTxn({ id: "b" as any, timestamp: ts("2025-02-05") }),
+    ];
+    expect(mostRecentMonthWithData(txns, Date.UTC(2025, 2, 15))).toEqual({ year: 2025, monthIdx0: 1 });
+  });
+
+  it("returns null for an empty transaction list", () => {
+    expect(mostRecentMonthWithData([], Date.UTC(2025, 2, 15))).toBeNull();
+  });
+
+  it("returns null when all transactions are in the current partial month", () => {
+    const txns = [makeTxn({ timestamp: ts("2025-03-10") })];
+    expect(mostRecentMonthWithData(txns, Date.UTC(2025, 2, 15))).toBeNull();
+  });
+
+  it("excludes a transaction on day 1 of the nowMs month (partial-month boundary)", () => {
+    const monthStartMs = Date.UTC(2025, 2, 1);
+    const txns = [
+      makeTxn({
+        id: "a" as any,
+        timestamp: { toDate: () => new Date(monthStartMs), toMillis: () => monthStartMs } as any,
+      }),
+      makeTxn({ id: "b" as any, timestamp: ts("2025-02-20") }),
+    ];
+    expect(mostRecentMonthWithData(txns, Date.UTC(2025, 2, 15))).toEqual({ year: 2025, monthIdx0: 1 });
+  });
+
+  it("picks the latest month even when older months carry more volume", () => {
+    const txns = [
+      makeTxn({ id: "big1" as any, amount: 9999, timestamp: ts("2024-12-01") }),
+      makeTxn({ id: "big2" as any, amount: 9999, timestamp: ts("2024-12-15") }),
+      makeTxn({ id: "small" as any, amount: 1, timestamp: ts("2025-02-28") }),
+    ];
+    expect(mostRecentMonthWithData(txns, Date.UTC(2025, 2, 15))).toEqual({ year: 2025, monthIdx0: 1 });
+  });
+
+  it("returns a December latest month when nowMs is in early January", () => {
+    const txns = [makeTxn({ timestamp: ts("2024-12-20") })];
+    expect(mostRecentMonthWithData(txns, Date.UTC(2025, 0, 10))).toEqual({ year: 2024, monthIdx0: 11 });
+  });
+
+  it("counts transfer-only months as having data", () => {
+    const txns = [makeTxn({ category: "Transfer:CardPayment", amount: 200, timestamp: ts("2025-02-05") })];
+    expect(mostRecentMonthWithData(txns, Date.UTC(2025, 2, 15))).toEqual({ year: 2025, monthIdx0: 1 });
+  });
+
+  it("skips non-primary normalized duplicates", () => {
+    const txns = [
+      makeTxn({
+        id: "dup" as any,
+        timestamp: ts("2025-02-10"),
+        normalizedId: "n1",
+        normalizedPrimary: false,
+      }),
+    ];
+    expect(mostRecentMonthWithData(txns, Date.UTC(2025, 2, 15))).toBeNull();
   });
 });
 
@@ -422,9 +486,21 @@ describe("computeIncomeStatementReport", () => {
     expect(computeIncomeStatementReport([], Date.UTC(2025, 2, 15))).toBeNull();
   });
 
-  it("returns null when no transactions fall in the most recent complete month", () => {
-    // nowMs = mid-March 2025, current month = Feb 2025. Only a January txn.
+  it("selects the latest month with data when the calendar-current month is empty", () => {
+    // nowMs = mid-March 2025; only a January txn exists. Feb 2025 is empty, so
+    // 'current' falls back to Jan 2025 (the latest complete month with data).
     const txns = [makeTxn({ amount: 100, category: "Food:Groceries", timestamp: ts("2025-01-15") })];
+    const report = computeIncomeStatementReport(txns, Date.UTC(2025, 2, 15));
+    expect(report).not.toBeNull();
+    if (!report) return;
+    expect(report.currentLabel).toBe("Jan 2025");
+    expect(report.priorLabel).toBe("Dec 2024");
+    expect(report.yoYLabel).toBe("Jan 2024");
+  });
+
+  it("returns null when all transactions are in the current partial month", () => {
+    // nowMs = mid-March 2025; only a March txn exists (partial current month).
+    const txns = [makeTxn({ amount: 100, category: "Food:Groceries", timestamp: ts("2025-03-05") })];
     expect(computeIncomeStatementReport(txns, Date.UTC(2025, 2, 15))).toBeNull();
   });
 

--- a/budget/test/income-statement.test.ts
+++ b/budget/test/income-statement.test.ts
@@ -166,6 +166,11 @@ describe("mostRecentMonthWithData", () => {
     ];
     expect(mostRecentMonthWithData(txns, Date.UTC(2025, 2, 15))).toBeNull();
   });
+
+  it("returns null when all transactions have null timestamps", () => {
+    const txns = [makeTxn({ id: "a" as any, timestamp: null }), makeTxn({ id: "b" as any, timestamp: null })];
+    expect(mostRecentMonthWithData(txns, Date.UTC(2025, 2, 15))).toBeNull();
+  });
 });
 
 describe("monthRange", () => {
@@ -322,7 +327,25 @@ describe("computeMonthlyIncomeStatement", () => {
     expect(stmt.totalExpenses).toBe(50);
   });
 
-  it("applies reimbursement to the recorded amount", () => {
+  it("applies 25% reimbursement: amount 200 becomes expense 150", () => {
+    const txns = [
+      makeTxn({ amount: 200, reimbursement: 25, category: "Food:Groceries", timestamp: ts("2025-02-10") }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.expenses).toEqual([{ category: "Food", amount: 150 }]);
+    expect(stmt.totalExpenses).toBe(150);
+  });
+
+  it("100% reimbursement contributes nothing to expenses", () => {
+    const txns = [
+      makeTxn({ amount: 200, reimbursement: 100, category: "Food:Groceries", timestamp: ts("2025-02-10") }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.expenses).toEqual([]);
+    expect(stmt.totalExpenses).toBe(0);
+  });
+
+  it("applies 50% reimbursement to the recorded amount", () => {
     const txns = [
       makeTxn({ amount: 100, reimbursement: 50, category: "Food:Groceries", timestamp: ts("2025-02-10") }),
     ];
@@ -370,6 +393,33 @@ describe("computeMonthlyIncomeStatement", () => {
     expect(stmt.totalExpenses).toBe(400);
     expect(stmt.netIncome).toBe(600);
     expect(stmt.savingsRate).toBeCloseTo(0.6);
+  });
+
+  it("computes a negative savingsRate when expenses exceed income", () => {
+    const txns = [
+      makeTxn({ id: "t1" as any, amount: -1000, category: "Income:Salary", timestamp: ts("2025-02-01") }),
+      makeTxn({ id: "t2" as any, amount: 1500, category: "Food:Groceries", timestamp: ts("2025-02-10") }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, febStart, febEnd);
+    expect(stmt.totalIncome).toBe(1000);
+    expect(stmt.totalExpenses).toBe(1500);
+    expect(stmt.netIncome).toBe(-500);
+    expect(stmt.savingsRate).toBe(-0.5);
+  });
+
+  it("includes a Feb 29 transaction in the leap-year Feb window", () => {
+    const feb2024Start = Date.UTC(2024, 1, 1);
+    const feb2024End = Date.UTC(2024, 2, 1);
+    const feb29Ms = Date.UTC(2024, 1, 29);
+    const txns = [
+      makeTxn({
+        amount: 100,
+        category: "Food:Groceries",
+        timestamp: { toDate: () => new Date(feb29Ms), toMillis: () => feb29Ms } as any,
+      }),
+    ];
+    const stmt = computeMonthlyIncomeStatement(txns, feb2024Start, feb2024End);
+    expect(stmt.totalExpenses).toBe(100);
   });
 });
 
@@ -478,6 +528,17 @@ describe("computeCashFlowSummary", () => {
     const cash = computeCashFlowSummary(txns, febStart, febEnd);
     expect(cash.operating).toBe(0);
     expect(cash.transfers).toBe(0);
+  });
+
+  it("produces negative operating and netChange when expenses exceed income with no transfers", () => {
+    const txns = [
+      makeTxn({ id: "t1" as any, amount: -200, category: "Income:Salary", timestamp: ts("2025-02-01") }),
+      makeTxn({ id: "t2" as any, amount: 600, category: "Food:Groceries", timestamp: ts("2025-02-10") }),
+    ];
+    const cash = computeCashFlowSummary(txns, febStart, febEnd);
+    expect(cash.operating).toBe(-400);
+    expect(cash.transfers).toBe(0);
+    expect(cash.netChange).toBe(-400);
   });
 });
 
@@ -653,6 +714,46 @@ describe("computeIncomeStatementReport", () => {
     expect(foodRow?.variance.prior).toBe(0);
     expect(entRow?.variance.current).toBe(0);
     expect(entRow?.variance.prior).toBe(80);
+  });
+
+  it("uses Math.abs(prior) in variance pct so a negative-prior netIncome stays positive when current improves", () => {
+    const nowMs = Date.UTC(2025, 2, 15); // current = Feb 2025
+    const txns = [
+      // Current Feb 2025: positive netIncome = 3000
+      makeTxn({ id: "f-sal" as any, amount: -5000, category: "Income:Salary", timestamp: ts("2025-02-01") }),
+      makeTxn({ id: "f-rent" as any, amount: 2000, category: "Housing:Rent", timestamp: ts("2025-02-05") }),
+      // Prior Jan 2025: negative netIncome = -1000
+      makeTxn({ id: "j-sal" as any, amount: -1000, category: "Income:Salary", timestamp: ts("2025-01-01") }),
+      makeTxn({ id: "j-rent" as any, amount: 2000, category: "Housing:Rent", timestamp: ts("2025-01-05") }),
+      // YoY Feb 2024: negative netIncome = -500
+      makeTxn({ id: "y-sal" as any, amount: -1500, category: "Income:Salary", timestamp: ts("2024-02-01") }),
+      makeTxn({ id: "y-rent" as any, amount: 2000, category: "Housing:Rent", timestamp: ts("2024-02-05") }),
+    ];
+    const report = computeIncomeStatementReport(txns, nowMs);
+    expect(report).not.toBeNull();
+    if (!report) return;
+
+    expect(report.netIncome.current).toBe(3000);
+    expect(report.netIncome.prior).toBe(-1000);
+    expect(report.netIncome.yoY).toBe(-500);
+    expect(report.netIncome.priorVarianceAbs).toBe(4000);
+    expect(report.netIncome.priorVariancePct).toBeGreaterThan(0);
+    expect(report.netIncome.yoYVarianceAbs).toBe(3500);
+    expect(report.netIncome.yoYVariancePct).toBeGreaterThan(0);
+  });
+
+  it("returns a report with zero income/expense and non-zero cash flow when the current month only has transfers", () => {
+    const nowMs = Date.UTC(2025, 2, 15); // current = Feb 2025
+    const txns = [
+      makeTxn({ amount: 200, category: "Transfer:CardPayment", timestamp: ts("2025-02-05") }),
+    ];
+    const report = computeIncomeStatementReport(txns, nowMs);
+    expect(report).not.toBeNull();
+    if (!report) return;
+
+    expect(report.totalIncome.current).toBe(0);
+    expect(report.totalExpenses.current).toBe(0);
+    expect(report.cashFlow.current.netChange).not.toBe(0);
   });
 
   it("sorts rows by current amount descending", () => {

--- a/budget/test/smoke/accounts-income-statement.smoke.test.ts
+++ b/budget/test/smoke/accounts-income-statement.smoke.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { timestampMockFactory, ts, createMockDataSource } from "../helpers";
+import type { DataSource } from "../../src/data-source";
+import type { Transaction, Statement } from "../../src/firestore";
+
+vi.mock("firebase/firestore", () => timestampMockFactory());
+
+import { renderAccounts } from "../../src/pages/accounts";
+
+function txn(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: "txn-1" as any,
+    institution: "Bank",
+    account: "Checking",
+    description: "Test",
+    amount: 50,
+    note: "",
+    category: "Food",
+    reimbursement: 0,
+    budget: null,
+    timestamp: ts("2025-02-15"),
+    statementId: null,
+    groupId: null,
+    normalizedId: null,
+    normalizedPrimary: true,
+    normalizedDescription: null,
+    virtual: false,
+    ...overrides,
+  };
+}
+
+function stmt(overrides: Partial<Statement> = {}): Statement {
+  return {
+    id: "stmt-1",
+    statementId: "Bank-Checking-2025-02" as any,
+    institution: "Bank",
+    account: "Checking",
+    balance: 1000,
+    period: "2025-02",
+    balanceDate: null,
+    lastTransactionDate: null,
+    groupId: null,
+    virtual: false,
+    ...overrides,
+  };
+}
+
+function seedOptions(dsOverrides: Partial<DataSource> = {}) {
+  return { authorized: false, groupName: "", dataSource: createMockDataSource(dsOverrides) };
+}
+
+describe("accounts page smoke — income statement and cash flow summary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-03-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders income statement section with category rows and totals", async () => {
+    const transactions = [
+      // Feb 2025 — current complete month
+      txn({ id: "t-cur-inc" as any, timestamp: ts("2025-02-10"), amount: -5000, category: "Income:Salary" }),
+      txn({ id: "t-cur-food" as any, timestamp: ts("2025-02-12"), amount: 400, category: "Food:Groceries" }),
+      txn({ id: "t-cur-rent" as any, timestamp: ts("2025-02-01"), amount: 1500, category: "Housing:Rent" }),
+      txn({ id: "t-cur-xfer" as any, timestamp: ts("2025-02-20"), amount: 200, category: "Transfer:CardPayment" }),
+      // Jan 2025 — prior
+      txn({ id: "t-pri-inc" as any, timestamp: ts("2025-01-10"), amount: -5000, category: "Income:Salary" }),
+      txn({ id: "t-pri-food" as any, timestamp: ts("2025-01-12"), amount: 500, category: "Food:Groceries" }),
+      txn({ id: "t-pri-rent" as any, timestamp: ts("2025-01-01"), amount: 1500, category: "Housing:Rent" }),
+      // Feb 2024 — YoY
+      txn({ id: "t-yoy-inc" as any, timestamp: ts("2024-02-10"), amount: -4800, category: "Income:Salary" }),
+      txn({ id: "t-yoy-food" as any, timestamp: ts("2024-02-12"), amount: 350, category: "Food:Groceries" }),
+      txn({ id: "t-yoy-rent" as any, timestamp: ts("2024-02-01"), amount: 1500, category: "Housing:Rent" }),
+    ];
+
+    const statements = [
+      stmt({ period: "2025-02", balance: 3500, lastTransactionDate: ts("2025-02-20") }),
+    ];
+
+    const html = await renderAccounts(seedOptions({
+      getTransactions: vi.fn().mockResolvedValue(transactions),
+      getStatements: vi.fn().mockResolvedValue(statements),
+    }));
+
+    expect(html).toContain('id="accounts-income-statement"');
+    expect(html).toContain("<h3>Income statement</h3>");
+
+    // Top-level category names
+    expect(html).toContain("Income");
+    expect(html).toContain("Food");
+    expect(html).toContain("Housing");
+
+    // Transfers should not appear as rows in the income or expense tables.
+    const incomeTableStart = html.indexOf('id="accounts-income-table"');
+    const expensesTableStart = html.indexOf('id="accounts-expenses-table"');
+    const netTableStart = html.indexOf('id="accounts-net-income-table"');
+    expect(incomeTableStart).toBeGreaterThan(-1);
+    expect(expensesTableStart).toBeGreaterThan(-1);
+    expect(netTableStart).toBeGreaterThan(-1);
+
+    const incomeTableHtml = html.slice(incomeTableStart, expensesTableStart);
+    const expensesTableHtml = html.slice(expensesTableStart, netTableStart);
+    // Transfer category must not be emitted as a row in either table.
+    // Category appears in <td>Transfer</td> form (the top-level name).
+    expect(incomeTableHtml).not.toContain("<td>Transfer</td>");
+    expect(expensesTableHtml).not.toContain("<td>Transfer</td>");
+
+    // Formatted amounts
+    expect(html).toContain("$5,000.00");
+    expect(html).toContain("$400.00");
+    expect(html).toContain("$1,500.00");
+
+    // Column headers for the three periods
+    expect(html).toContain("Feb 2025");
+    expect(html).toContain("Jan 2025");
+    expect(html).toContain("Feb 2024");
+
+    // Totals and summary row labels
+    expect(html).toContain("Total income");
+    expect(html).toContain("Total expenses");
+    expect(html).toContain("Net income");
+    expect(html).toContain("Savings rate");
+
+    // Cash flow summary section
+    expect(html).toContain('id="accounts-cash-flow-summary"');
+    expect(html).toContain("<h3>Cash flow summary</h3>");
+    expect(html).toContain("Operating");
+    expect(html).toContain("Transfers");
+    expect(html).toContain("Net change");
+  });
+
+  it("renders above charts and above the accounts table", async () => {
+    const transactions = [
+      txn({ id: "t1" as any, timestamp: ts("2025-02-10"), amount: -1000, category: "Income:Salary" }),
+      txn({ id: "t2" as any, timestamp: ts("2025-02-15"), amount: 250, category: "Food:Groceries" }),
+    ];
+    const statements = [
+      stmt({ period: "2025-02", balance: 1000, lastTransactionDate: ts("2025-02-15") }),
+    ];
+
+    const html = await renderAccounts(seedOptions({
+      getTransactions: vi.fn().mockResolvedValue(transactions),
+      getStatements: vi.fn().mockResolvedValue(statements),
+    }));
+
+    const incomeStatementIdx = html.indexOf('id="accounts-income-statement"');
+    const trendChartIdx = html.indexOf('id="accounts-trend-chart"');
+    const tableIdx = html.indexOf('id="accounts-table"');
+
+    expect(incomeStatementIdx).toBeGreaterThan(-1);
+    expect(trendChartIdx).toBeGreaterThan(-1);
+    expect(tableIdx).toBeGreaterThan(-1);
+
+    expect(incomeStatementIdx).toBeLessThan(trendChartIdx);
+    expect(trendChartIdx).toBeLessThan(tableIdx);
+  });
+
+  it("returns no income statement section when there are no transactions in current month", async () => {
+    const transactions = [
+      txn({ id: "t-old-1" as any, timestamp: ts("2023-05-01"), amount: -1000, category: "Income:Salary" }),
+      txn({ id: "t-old-2" as any, timestamp: ts("2023-06-15"), amount: 300, category: "Food:Groceries" }),
+    ];
+    const statements = [
+      stmt({ period: "2023-06", balance: 500, lastTransactionDate: ts("2023-06-15") }),
+    ];
+
+    const html = await renderAccounts(seedOptions({
+      getTransactions: vi.fn().mockResolvedValue(transactions),
+      getStatements: vi.fn().mockResolvedValue(statements),
+    }));
+
+    expect(html).not.toContain('id="accounts-income-statement"');
+    expect(html).not.toContain('id="accounts-cash-flow-summary"');
+    // The accounts table still renders.
+    expect(html).toContain('id="accounts-table"');
+  });
+
+  it("renders report with only current-month data (variance cells show em dash)", async () => {
+    const transactions = [
+      txn({ id: "t-cur-inc" as any, timestamp: ts("2025-02-10"), amount: -2000, category: "Income:Salary" }),
+      txn({ id: "t-cur-food" as any, timestamp: ts("2025-02-12"), amount: 300, category: "Food:Groceries" }),
+    ];
+    const statements = [
+      stmt({ period: "2025-02", balance: 1700, lastTransactionDate: ts("2025-02-12") }),
+    ];
+
+    const html = await renderAccounts(seedOptions({
+      getTransactions: vi.fn().mockResolvedValue(transactions),
+      getStatements: vi.fn().mockResolvedValue(statements),
+    }));
+
+    expect(html).toContain('id="accounts-income-statement"');
+
+    // Current-month amounts are rendered
+    expect(html).toContain("$2,000.00");
+    expect(html).toContain("$300.00");
+
+    // Em dash appears in variance cells when prior and YoY are missing.
+    const emDashCount = (html.match(/\u2014/g) ?? []).length;
+    expect(emDashCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("only-transfer month: income and expense tables empty, cash flow shows transfers", async () => {
+    const transactions = [
+      txn({ id: "t-x1" as any, timestamp: ts("2025-02-05"), amount: 200, category: "Transfer:CardPayment" }),
+      txn({ id: "t-x2" as any, timestamp: ts("2025-02-12"), amount: 150, category: "Transfer:CardPayment" }),
+      txn({ id: "t-x3" as any, timestamp: ts("2025-02-20"), amount: -100, category: "Transfer:CardPayment" }),
+    ];
+    const statements = [
+      stmt({ period: "2025-02", balance: 2000, lastTransactionDate: ts("2025-02-20") }),
+    ];
+
+    const html = await renderAccounts(seedOptions({
+      getTransactions: vi.fn().mockResolvedValue(transactions),
+      getStatements: vi.fn().mockResolvedValue(statements),
+    }));
+
+    expect(html).toContain('id="accounts-income-statement"');
+    expect(html).toContain('id="accounts-cash-flow-summary"');
+
+    // Empty-row placeholders for income and expenses.
+    expect(html).toContain("No income this period.");
+    expect(html).toContain("No expenses this period.");
+
+    // Totals all zero
+    expect(html).toContain("$0.00");
+
+    // Transfers row in cash flow contains a signed currency.
+    const cashFlowStart = html.indexOf('id="accounts-cash-flow-table"');
+    expect(cashFlowStart).toBeGreaterThan(-1);
+    const cashFlowHtml = html.slice(cashFlowStart);
+    // Either "+$" (positive) or "\u2212$" (minus, U+2212) should appear for transfers.
+    const hasSignedCurrency = cashFlowHtml.includes("+$") || cashFlowHtml.includes("\u2212$");
+    expect(hasSignedCurrency).toBe(true);
+  });
+
+  it("excludes non-primary normalized duplicates from income/expense totals", async () => {
+    const transactions = [
+      txn({
+        id: "t-prim" as any,
+        timestamp: ts("2025-02-10"),
+        amount: 100,
+        category: "Food",
+        normalizedId: "norm-1" as any,
+        normalizedPrimary: true,
+      }),
+      txn({
+        id: "t-dup" as any,
+        timestamp: ts("2025-02-11"),
+        amount: 100,
+        category: "Food",
+        normalizedId: "norm-1" as any,
+        normalizedPrimary: false,
+      }),
+    ];
+    const statements = [
+      stmt({ period: "2025-02", balance: 900, lastTransactionDate: ts("2025-02-11") }),
+    ];
+
+    const html = await renderAccounts(seedOptions({
+      getTransactions: vi.fn().mockResolvedValue(transactions),
+      getStatements: vi.fn().mockResolvedValue(statements),
+    }));
+
+    expect(html).toContain('id="accounts-income-statement"');
+    // The primary transaction is counted.
+    expect(html).toContain("$100.00");
+    // The duplicate is NOT counted, so no Food expense total of $200.00 should appear.
+    expect(html).not.toContain("$200.00");
+  });
+});

--- a/budget/test/smoke/accounts-income-statement.smoke.test.ts
+++ b/budget/test/smoke/accounts-income-statement.smoke.test.ts
@@ -159,13 +159,15 @@ describe("accounts page smoke — income statement and cash flow summary", () =>
     expect(trendChartIdx).toBeLessThan(tableIdx);
   });
 
-  it("returns no income statement section when there are no transactions in current month", async () => {
+  it("hides sections when all transactions are in the current partial month", async () => {
+    // nowMs = 2025-03-15; only March transactions exist (the current partial
+    // month is excluded), so no complete month has data.
     const transactions = [
-      txn({ id: "t-old-1" as any, timestamp: ts("2023-05-01"), amount: -1000, category: "Income:Salary" }),
-      txn({ id: "t-old-2" as any, timestamp: ts("2023-06-15"), amount: 300, category: "Food:Groceries" }),
+      txn({ id: "t-new-1" as any, timestamp: ts("2025-03-01"), amount: -1000, category: "Income:Salary" }),
+      txn({ id: "t-new-2" as any, timestamp: ts("2025-03-10"), amount: 300, category: "Food:Groceries" }),
     ];
     const statements = [
-      stmt({ period: "2023-06", balance: 500, lastTransactionDate: ts("2023-06-15") }),
+      stmt({ period: "2025-03", balance: 700, lastTransactionDate: ts("2025-03-10") }),
     ];
 
     const html = await renderAccounts(seedOptions({
@@ -236,6 +238,38 @@ describe("accounts page smoke — income statement and cash flow summary", () =>
     // Either "+$" (positive) or "\u2212$" (minus, U+2212) should appear for transfers.
     const hasSignedCurrency = cashFlowHtml.includes("+$") || cashFlowHtml.includes("\u2212$");
     expect(hasSignedCurrency).toBe(true);
+  });
+
+  it("renders sections against stale fixture data (nowMs well after latest transaction)", async () => {
+    // Simulate seed data that has not been refreshed: 'current' should still
+    // fall back to the latest complete month with data (Feb 2025), not hide.
+    vi.setSystemTime(new Date("2026-04-15T12:00:00Z"));
+
+    const transactions = [
+      // Feb 2025 — latest month with data
+      txn({ id: "t-cur-inc" as any, timestamp: ts("2025-02-10"), amount: -5000, category: "Income:Salary" }),
+      txn({ id: "t-cur-food" as any, timestamp: ts("2025-02-12"), amount: 400, category: "Food:Groceries" }),
+      // Jan 2025 — prior
+      txn({ id: "t-pri-inc" as any, timestamp: ts("2025-01-10"), amount: -5000, category: "Income:Salary" }),
+      txn({ id: "t-pri-food" as any, timestamp: ts("2025-01-12"), amount: 500, category: "Food:Groceries" }),
+      // Feb 2024 — YoY
+      txn({ id: "t-yoy-inc" as any, timestamp: ts("2024-02-10"), amount: -4800, category: "Income:Salary" }),
+      txn({ id: "t-yoy-food" as any, timestamp: ts("2024-02-12"), amount: 350, category: "Food:Groceries" }),
+    ];
+    const statements = [
+      stmt({ period: "2025-02", balance: 3500, lastTransactionDate: ts("2025-02-12") }),
+    ];
+
+    const html = await renderAccounts(seedOptions({
+      getTransactions: vi.fn().mockResolvedValue(transactions),
+      getStatements: vi.fn().mockResolvedValue(statements),
+    }));
+
+    expect(html).toContain('id="accounts-income-statement"');
+    expect(html).toContain('id="accounts-cash-flow-summary"');
+    expect(html).toContain("Feb 2025");
+    expect(html).toContain("Jan 2025");
+    expect(html).toContain("Feb 2024");
   });
 
   it("excludes non-primary normalized duplicates from income/expense totals", async () => {

--- a/budget/test/smoke/accounts-income-statement.smoke.test.ts
+++ b/budget/test/smoke/accounts-income-statement.smoke.test.ts
@@ -202,8 +202,37 @@ describe("accounts page smoke — income statement and cash flow summary", () =>
     expect(html).toContain("$300.00");
 
     // Em dash appears in variance cells when prior and YoY are missing.
-    const emDashCount = (html.match(/\u2014/g) ?? []).length;
+    // Scope the count to the income table so unrelated em dashes (e.g.,
+    // savings-rate row, cash flow null cells) do not inflate the total.
+    const incomeTableStart = html.indexOf('id="accounts-income-table"');
+    const expensesTableStart = html.indexOf('id="accounts-expenses-table"');
+    expect(incomeTableStart).toBeGreaterThan(-1);
+    expect(expensesTableStart).toBeGreaterThan(incomeTableStart);
+    const incomeTableHtml = html.slice(incomeTableStart, expensesTableStart);
+    const emDashCount = (incomeTableHtml.match(/\u2014/g) ?? []).length;
     expect(emDashCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders negative netChange with U+2212 minus and variance-negative class", async () => {
+    const transactions = [
+      // Feb 2025 — current month: expenses > income, producing negative operating + netChange
+      txn({ id: "t-cur-inc" as any, timestamp: ts("2025-02-10"), amount: -500, category: "Income:Salary" }),
+      txn({ id: "t-cur-food" as any, timestamp: ts("2025-02-12"), amount: 1000, category: "Food:Groceries" }),
+    ];
+    const statements = [
+      stmt({ period: "2025-02", balance: -500, lastTransactionDate: ts("2025-02-12") }),
+    ];
+
+    const html = await renderAccounts(seedOptions({
+      getTransactions: vi.fn().mockResolvedValue(transactions),
+      getStatements: vi.fn().mockResolvedValue(statements),
+    }));
+
+    const cashFlowStart = html.indexOf('id="accounts-cash-flow-table"');
+    expect(cashFlowStart).toBeGreaterThan(-1);
+    const cashFlowHtml = html.slice(cashFlowStart);
+    expect(cashFlowHtml).toContain("\u2212$");
+    expect(cashFlowHtml).toContain("variance-negative");
   });
 
   it("only-transfer month: income and expense tables empty, cash flow shows transfers", async () => {

--- a/budget/test/smoke/accounts.smoke.test.ts
+++ b/budget/test/smoke/accounts.smoke.test.ts
@@ -75,8 +75,11 @@ describe("accounts page smoke — multi-account aggregation", () => {
 
     expect(html).toContain('id="accounts-table"');
 
-    // 3 accounts → 3 <tr> rows in <tbody>
-    const tbody = html.slice(html.indexOf("<tbody>"), html.indexOf("</tbody>"));
+    // 3 accounts → 3 <tr> rows in the accounts-table <tbody>
+    const accountsTableStart = html.indexOf('id="accounts-table"');
+    const accountsTableTbodyStart = html.indexOf("<tbody>", accountsTableStart);
+    const accountsTableTbodyEnd = html.indexOf("</tbody>", accountsTableTbodyStart);
+    const tbody = html.slice(accountsTableTbodyStart, accountsTableTbodyEnd);
     const rowCount = (tbody.match(/<tr[\s>]/g) ?? []).length;
     expect(rowCount).toBe(3);
 


### PR DESCRIPTION
## Summary

Adds a structured monthly income statement and cash flow summary to the accounts page. Adapts the financial-statements practice from anthropics/knowledge-work-plugins/finance to the personal-finance context.

- **Income statement** groups transactions by top-level category (colon-separated hierarchy). Three periods: most recent complete calendar month, prior month, same month last year. Dollar and percentage variance columns for each comparison.
- **Cash flow summary** splits net change in account balances into operating (non-transfer) and transfer activity. Any category starting with `Transfer:` is treated as non-operating.
- **Savings rate** and net income render in the summary rows.
- New sections render above the existing trend, net worth, and cash flow charts on /accounts.

Core logic lives in new pure module `budget/src/income-statement.ts`. Reuses `computeNetAmount` and the normalized-primary filtering discipline from `balance.ts`. No change to `balance.ts`.

Closes #454

## Test plan

- [x] 57 unit tests in `budget/test/income-statement.test.ts` covering helpers, month boundaries (leap Feb, year rollover, half-open windows), reimbursement, transfer exclusion, variance null-handling, and three-period report assembly.
- [x] 6 smoke tests in `budget/test/smoke/accounts-income-statement.smoke.test.ts` verify rendered HTML structure, placement above charts, empty / transfer-only / normalized-duplicate edge cases.
- [ ] 7 Playwright acceptance tests in `budget/e2e/accounts-income-statement.spec.ts` cover section visibility, column headers, category presence, transfer exclusion, savings rate, and layout ordering. New `uploadIncomeStatementFixture` helper synthesizes a multi-month fixture relative to today.
- [ ] QA on preview deploy: confirm income statement + cash flow summary render correctly with real fixture data; verify variance columns and savings rate percentages.