### PR TITLE
productivity: Firestore data model and shared types (#460)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,6 +16,14 @@ service cloud.firestore {
         && memberEmails == group.members;
     }
 
+    // Productivity group member: verify actual membership via groups collection
+    function isProductivityGroupMember(env, groupId, memberEmails) {
+      let group = get(/databases/$(database)/documents/productivity/$(env)/groups/$(groupId)).data;
+      return request.auth != null
+        && request.auth.token.email in group.members
+        && memberEmails == group.members;
+    }
+
     // Groups are readable only by their members (email-based membership).
     // Uses resource.data directly instead of isGroupMember() because getUserGroups
     // performs a list query (where + getDocs) and Firestore cannot resolve get()
@@ -329,6 +337,134 @@ service cloud.firestore {
     match /audio/{env}/errors/{errorId} {
       allow create: if isValidErrorLog();
       allow read, update, delete: if false;
+    }
+
+    // Groups are readable only by their members (email-based membership).
+    match /productivity/{env}/groups/{groupId} {
+      allow read: if request.auth != null && request.auth.token.email in resource.data.members;
+      allow write: if false;
+    }
+
+    // Validates agenda item field types and constraints on both create and update.
+    function isValidAgendaItemData() {
+      return request.resource.data.title is string
+        && request.resource.data.title.size() > 0
+        && request.resource.data.notes is string
+        && (!('scheduledAt' in request.resource.data) || request.resource.data.scheduledAt is timestamp || request.resource.data.scheduledAt == null)
+        && request.resource.data.status in ["todo", "done"]
+        && request.resource.data.createdAt is timestamp
+        && request.resource.data.keys().hasOnly(['title', 'notes', 'scheduledAt', 'status', 'createdAt', 'groupId', 'memberEmails']);
+    }
+
+    // Agenda items are scoped to group members via a denormalized `memberEmails` field.
+    // CRUD operations require membership. groupId, memberEmails, and createdAt are immutable on update.
+    match /productivity/{env}/agenda-items/{itemId} {
+      allow read: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails;
+      allow create: if isProductivityGroupMember(env, request.resource.data.groupId, request.resource.data.memberEmails)
+        && isValidAgendaItemData();
+      allow update: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails
+        && request.resource.data.groupId == resource.data.groupId
+        && request.resource.data.memberEmails == resource.data.memberEmails
+        && request.resource.data.createdAt == resource.data.createdAt
+        && isValidAgendaItemData();
+      allow delete: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails;
+    }
+
+    // Validates feed entry field types and constraints on both create and update.
+    function isValidFeedEntryData() {
+      return request.resource.data.source in ["rss", "hackernews", "reddit"]
+        && request.resource.data.sourceKey is string
+        && request.resource.data.title is string
+        && request.resource.data.url is string
+        && request.resource.data.snippet is string
+        && request.resource.data.publishedAt is timestamp
+        && request.resource.data.read is bool
+        && request.resource.data.saved is bool
+        && request.resource.data.createdAt is timestamp
+        && request.resource.data.keys().hasOnly(['source', 'sourceKey', 'title', 'url', 'snippet', 'publishedAt', 'read', 'saved', 'createdAt', 'groupId', 'memberEmails']);
+    }
+
+    // Feed entries are scoped to group members via a denormalized `memberEmails` field.
+    // CRUD operations require membership. groupId, memberEmails, and createdAt are immutable on update.
+    match /productivity/{env}/feed-entries/{entryId} {
+      allow read: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails;
+      allow create: if isProductivityGroupMember(env, request.resource.data.groupId, request.resource.data.memberEmails)
+        && isValidFeedEntryData();
+      allow update: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails
+        && request.resource.data.groupId == resource.data.groupId
+        && request.resource.data.memberEmails == resource.data.memberEmails
+        && request.resource.data.createdAt == resource.data.createdAt
+        && isValidFeedEntryData();
+      allow delete: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails;
+    }
+
+    // Validates message field types and constraints on both create and update.
+    function isValidMessageData() {
+      return request.resource.data.source in ["discord", "email", "claude-session"]
+        && request.resource.data.sourceKey is string
+        && request.resource.data.sender is string
+        && request.resource.data.body is string
+        && request.resource.data.sentAt is timestamp
+        && request.resource.data.read is bool
+        && request.resource.data.actioned is bool
+        && request.resource.data.createdAt is timestamp
+        && request.resource.data.keys().hasOnly(['source', 'sourceKey', 'sender', 'body', 'sentAt', 'read', 'actioned', 'createdAt', 'groupId', 'memberEmails']);
+    }
+
+    // Messages are scoped to group members via a denormalized `memberEmails` field.
+    // CRUD operations require membership. groupId, memberEmails, and createdAt are immutable on update.
+    match /productivity/{env}/messages/{messageId} {
+      allow read: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails;
+      allow create: if isProductivityGroupMember(env, request.resource.data.groupId, request.resource.data.memberEmails)
+        && isValidMessageData();
+      allow update: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails
+        && request.resource.data.groupId == resource.data.groupId
+        && request.resource.data.memberEmails == resource.data.memberEmails
+        && request.resource.data.createdAt == resource.data.createdAt
+        && isValidMessageData();
+      allow delete: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails;
+    }
+
+    // Validates goal field types and constraints on both create and update.
+    // priority must be non-negative; progress must be in [0, 100].
+    function isValidGoalData() {
+      return request.resource.data.title is string
+        && request.resource.data.title.size() > 0
+        && request.resource.data.horizon in ["weekly", "quarterly", "yearly"]
+        && request.resource.data.priority is number
+        && request.resource.data.priority >= 0
+        && request.resource.data.status in ["active", "done", "dropped"]
+        && request.resource.data.progress is number
+        && request.resource.data.progress >= 0
+        && request.resource.data.progress <= 100
+        && request.resource.data.createdAt is timestamp
+        && request.resource.data.keys().hasOnly(['title', 'horizon', 'priority', 'status', 'progress', 'createdAt', 'groupId', 'memberEmails']);
+    }
+
+    // Goals are scoped to group members via a denormalized `memberEmails` field.
+    // CRUD operations require membership. groupId, memberEmails, and createdAt are immutable on update.
+    match /productivity/{env}/goals/{goalId} {
+      allow read: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails;
+      allow create: if isProductivityGroupMember(env, request.resource.data.groupId, request.resource.data.memberEmails)
+        && isValidGoalData();
+      allow update: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails
+        && request.resource.data.groupId == resource.data.groupId
+        && request.resource.data.memberEmails == resource.data.memberEmails
+        && request.resource.data.createdAt == resource.data.createdAt
+        && isValidGoalData();
+      allow delete: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails;
     }
 
     // SCAFFOLD MARKER: deny-all catch-all. Do not edit or move this comment.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "idbutil",
         "landing",
         "print",
+        "productivityutil",
         "router",
         "rssutil",
         "style",
@@ -60,6 +61,7 @@
         "@commons-systems/firebaseutil": "file:../firebaseutil",
         "@commons-systems/firestoreutil": "file:../firestoreutil",
         "@commons-systems/htmlutil": "file:../htmlutil",
+        "@commons-systems/idbutil": "file:../idbutil",
         "@commons-systems/router": "file:../router",
         "@commons-systems/style": "file:../style",
         "firebase": "^12.9.0",
@@ -70,6 +72,7 @@
         "@eslint/js": "^9.19.0",
         "@playwright/test": "1.58.2",
         "eslint": "^9.19.0",
+        "fake-indexeddb": "^6.0.0",
         "happy-dom": "^20.8.9",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.22.0",
@@ -248,6 +251,10 @@
     },
     "node_modules/@commons-systems/idbutil": {
       "resolved": "idbutil",
+      "link": true
+    },
+    "node_modules/@commons-systems/productivityutil": {
+      "resolved": "productivityutil",
       "link": true
     },
     "node_modules/@commons-systems/router": {
@@ -9453,6 +9460,14 @@
       },
       "devDependencies": {
         "fake-indexeddb": "^6.2.5"
+      }
+    },
+    "productivityutil": {
+      "name": "@commons-systems/productivityutil",
+      "version": "0.0.0",
+      "dependencies": {
+        "@commons-systems/authutil": "*",
+        "@commons-systems/firestoreutil": "*"
       }
     },
     "router": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "idbutil",
     "landing",
     "print",
+    "productivityutil",
     "router",
     "rssutil",
     "style",

--- a/productivityutil/eslint.config.js
+++ b/productivityutil/eslint.config.js
@@ -1,0 +1,1 @@
+export { default } from "@commons-systems/config/eslint";

--- a/productivityutil/package.json
+++ b/productivityutil/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@commons-systems/productivityutil",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    "./namespace": "./src/namespace.ts",
+    "./agenda-items": "./src/agenda-items.ts",
+    "./feed-entries": "./src/feed-entries.ts",
+    "./messages": "./src/messages.ts",
+    "./goals": "./src/goals.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@commons-systems/authutil": "*",
+    "@commons-systems/firestoreutil": "*"
+  }
+}

--- a/productivityutil/src/agenda-items.ts
+++ b/productivityutil/src/agenda-items.ts
@@ -1,0 +1,43 @@
+import type { Timestamp } from "firebase/firestore";
+import type { Brand } from "@commons-systems/firestoreutil/brand";
+import type { GroupId } from "@commons-systems/authutil/groups";
+import { requireString, requireOneOf } from "@commons-systems/firestoreutil/validate";
+import {
+  optionalTimestamp,
+  requireTimestamp,
+  requireGroupId,
+  requireMemberEmails,
+} from "./validate.js";
+
+export type AgendaItemId = Brand<"AgendaItemId">;
+
+export const AGENDA_ITEM_STATUSES = ["todo", "done"] as const;
+export type AgendaItemStatus = (typeof AGENDA_ITEM_STATUSES)[number];
+
+export interface AgendaItem {
+  readonly id: AgendaItemId;
+  readonly title: string;
+  readonly notes: string;
+  readonly scheduledAt: Timestamp | null;
+  readonly status: AgendaItemStatus;
+  readonly groupId: GroupId;
+  readonly memberEmails: readonly string[];
+  readonly createdAt: Timestamp;
+}
+
+export function requireAgendaItem(id: string, data: unknown): AgendaItem {
+  if (data == null || typeof data !== "object") {
+    throw new TypeError(`Expected object for agenda item ${id}, got ${typeof data}`);
+  }
+  const d = data as Record<string, unknown>;
+  return {
+    id: id as AgendaItemId,
+    title: requireString(d.title, "title"),
+    notes: requireString(d.notes, "notes"),
+    scheduledAt: optionalTimestamp(d.scheduledAt, "scheduledAt"),
+    status: requireOneOf(d.status, AGENDA_ITEM_STATUSES, "status"),
+    groupId: requireGroupId(d.groupId, "groupId"),
+    memberEmails: requireMemberEmails(d.memberEmails),
+    createdAt: requireTimestamp(d.createdAt, "createdAt"),
+  };
+}

--- a/productivityutil/src/feed-entries.ts
+++ b/productivityutil/src/feed-entries.ts
@@ -1,0 +1,54 @@
+import type { Timestamp } from "firebase/firestore";
+import type { Brand } from "@commons-systems/firestoreutil/brand";
+import type { GroupId } from "@commons-systems/authutil/groups";
+import {
+  requireString,
+  requireBoolean,
+  requireOneOf,
+} from "@commons-systems/firestoreutil/validate";
+import {
+  requireTimestamp,
+  requireGroupId,
+  requireMemberEmails,
+} from "./validate.js";
+
+export type FeedEntryId = Brand<"FeedEntryId">;
+
+export const FEED_SOURCES = ["rss", "hackernews", "reddit"] as const;
+export type FeedSource = (typeof FEED_SOURCES)[number];
+
+export interface FeedEntry {
+  readonly id: FeedEntryId;
+  readonly source: FeedSource;
+  readonly sourceKey: string;
+  readonly title: string;
+  readonly url: string;
+  readonly snippet: string;
+  readonly publishedAt: Timestamp;
+  readonly read: boolean;
+  readonly saved: boolean;
+  readonly groupId: GroupId;
+  readonly memberEmails: readonly string[];
+  readonly createdAt: Timestamp;
+}
+
+export function requireFeedEntry(id: string, data: unknown): FeedEntry {
+  if (data == null || typeof data !== "object") {
+    throw new TypeError(`Expected object for feed entry ${id}, got ${typeof data}`);
+  }
+  const d = data as Record<string, unknown>;
+  return {
+    id: id as FeedEntryId,
+    source: requireOneOf(d.source, FEED_SOURCES, "source"),
+    sourceKey: requireString(d.sourceKey, "sourceKey"),
+    title: requireString(d.title, "title"),
+    url: requireString(d.url, "url"),
+    snippet: requireString(d.snippet, "snippet"),
+    publishedAt: requireTimestamp(d.publishedAt, "publishedAt"),
+    read: requireBoolean(d.read, "read"),
+    saved: requireBoolean(d.saved, "saved"),
+    groupId: requireGroupId(d.groupId, "groupId"),
+    memberEmails: requireMemberEmails(d.memberEmails),
+    createdAt: requireTimestamp(d.createdAt, "createdAt"),
+  };
+}

--- a/productivityutil/src/goals.ts
+++ b/productivityutil/src/goals.ts
@@ -1,0 +1,54 @@
+import type { Timestamp } from "firebase/firestore";
+import type { Brand } from "@commons-systems/firestoreutil/brand";
+import type { GroupId } from "@commons-systems/authutil/groups";
+import {
+  requireString,
+  requireNonNegativeNumber,
+  requireOneOf,
+} from "@commons-systems/firestoreutil/validate";
+import {
+  requireTimestamp,
+  requireGroupId,
+  requireMemberEmails,
+  requireBoundedNumber,
+} from "./validate.js";
+
+export type GoalId = Brand<"GoalId">;
+
+export const GOAL_HORIZONS = ["weekly", "quarterly", "yearly"] as const;
+export type GoalHorizon = (typeof GOAL_HORIZONS)[number];
+
+export const GOAL_STATUSES = ["active", "done", "dropped"] as const;
+export type GoalStatus = (typeof GOAL_STATUSES)[number];
+
+export interface Goal {
+  readonly id: GoalId;
+  readonly title: string;
+  readonly horizon: GoalHorizon;
+  /** Lower value = higher priority. Non-negative. */
+  readonly priority: number;
+  readonly status: GoalStatus;
+  /** Percentage in [0, 100]. */
+  readonly progress: number;
+  readonly groupId: GroupId;
+  readonly memberEmails: readonly string[];
+  readonly createdAt: Timestamp;
+}
+
+export function requireGoal(id: string, data: unknown): Goal {
+  if (data == null || typeof data !== "object") {
+    throw new TypeError(`Expected object for goal ${id}, got ${typeof data}`);
+  }
+  const d = data as Record<string, unknown>;
+  return {
+    id: id as GoalId,
+    title: requireString(d.title, "title"),
+    horizon: requireOneOf(d.horizon, GOAL_HORIZONS, "horizon"),
+    priority: requireNonNegativeNumber(d.priority, "priority"),
+    status: requireOneOf(d.status, GOAL_STATUSES, "status"),
+    progress: requireBoundedNumber(d.progress, "progress", 0, 100),
+    groupId: requireGroupId(d.groupId, "groupId"),
+    memberEmails: requireMemberEmails(d.memberEmails),
+    createdAt: requireTimestamp(d.createdAt, "createdAt"),
+  };
+}

--- a/productivityutil/src/messages.ts
+++ b/productivityutil/src/messages.ts
@@ -1,0 +1,52 @@
+import type { Timestamp } from "firebase/firestore";
+import type { Brand } from "@commons-systems/firestoreutil/brand";
+import type { GroupId } from "@commons-systems/authutil/groups";
+import {
+  requireString,
+  requireBoolean,
+  requireOneOf,
+} from "@commons-systems/firestoreutil/validate";
+import {
+  requireTimestamp,
+  requireGroupId,
+  requireMemberEmails,
+} from "./validate.js";
+
+export type MessageId = Brand<"MessageId">;
+
+export const MESSAGE_SOURCES = ["discord", "email", "claude-session"] as const;
+export type MessageSource = (typeof MESSAGE_SOURCES)[number];
+
+export interface Message {
+  readonly id: MessageId;
+  readonly source: MessageSource;
+  readonly sourceKey: string;
+  readonly sender: string;
+  readonly body: string;
+  readonly sentAt: Timestamp;
+  readonly read: boolean;
+  readonly actioned: boolean;
+  readonly groupId: GroupId;
+  readonly memberEmails: readonly string[];
+  readonly createdAt: Timestamp;
+}
+
+export function requireMessage(id: string, data: unknown): Message {
+  if (data == null || typeof data !== "object") {
+    throw new TypeError(`Expected object for message ${id}, got ${typeof data}`);
+  }
+  const d = data as Record<string, unknown>;
+  return {
+    id: id as MessageId,
+    source: requireOneOf(d.source, MESSAGE_SOURCES, "source"),
+    sourceKey: requireString(d.sourceKey, "sourceKey"),
+    sender: requireString(d.sender, "sender"),
+    body: requireString(d.body, "body"),
+    sentAt: requireTimestamp(d.sentAt, "sentAt"),
+    read: requireBoolean(d.read, "read"),
+    actioned: requireBoolean(d.actioned, "actioned"),
+    groupId: requireGroupId(d.groupId, "groupId"),
+    memberEmails: requireMemberEmails(d.memberEmails),
+    createdAt: requireTimestamp(d.createdAt, "createdAt"),
+  };
+}

--- a/productivityutil/src/namespace.ts
+++ b/productivityutil/src/namespace.ts
@@ -1,0 +1,1 @@
+export const PRODUCTIVITY_APP_NAME = "productivity";

--- a/productivityutil/src/validate.ts
+++ b/productivityutil/src/validate.ts
@@ -1,0 +1,44 @@
+import { Timestamp } from "firebase/firestore";
+import { DataIntegrityError } from "@commons-systems/firestoreutil/errors";
+import { requireString } from "@commons-systems/firestoreutil/validate";
+import type { GroupId } from "@commons-systems/authutil/groups";
+
+export function optionalTimestamp(value: unknown, field: string): Timestamp | null {
+  if (value == null) return null;
+  if (!(value instanceof Timestamp)) {
+    throw new DataIntegrityError(`Expected Timestamp for ${field}, got ${typeof value}`);
+  }
+  return value;
+}
+
+export function requireTimestamp(value: unknown, field: string): Timestamp {
+  const ts = optionalTimestamp(value, field);
+  if (ts === null) throw new DataIntegrityError(`Expected Timestamp for ${field}, got null`);
+  return ts;
+}
+
+export function requireGroupId(value: unknown, field: string): GroupId {
+  return requireString(value, field) as GroupId;
+}
+
+export function requireMemberEmails(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    throw new DataIntegrityError(`Expected array for memberEmails, got ${typeof value}`);
+  }
+  return value.map((item, i) => {
+    if (typeof item !== "string") {
+      throw new DataIntegrityError(`Expected string at memberEmails[${i}], got ${typeof item}`);
+    }
+    return item;
+  });
+}
+
+export function requireBoundedNumber(value: unknown, field: string, min: number, max: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new DataIntegrityError(`Expected finite number for ${field}, got ${value}`);
+  }
+  if (value < min || value > max) {
+    throw new DataIntegrityError(`${field} must be in [${min}, ${max}], got ${value}`);
+  }
+  return value;
+}

--- a/productivityutil/test/agenda-items.test.ts
+++ b/productivityutil/test/agenda-items.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("firebase/firestore", () => ({
+  Timestamp: class Timestamp {
+    _date: Date;
+    constructor(d: Date) { this._date = d; }
+    toDate() { return this._date; }
+    toMillis() { return this._date.getTime(); }
+    static fromDate(d: Date) { return new Timestamp(d); }
+  },
+}));
+
+import { Timestamp } from "firebase/firestore";
+import { requireAgendaItem } from "../src/agenda-items";
+import { DataIntegrityError } from "@commons-systems/firestoreutil/errors";
+
+const createdAt = Timestamp.fromDate(new Date("2026-04-17T00:00:00Z"));
+const scheduledAt = Timestamp.fromDate(new Date("2026-04-18T09:00:00Z"));
+
+const base = {
+  title: "Write plan",
+  notes: "",
+  scheduledAt,
+  status: "todo",
+  groupId: "household",
+  memberEmails: ["alice@example.com", "bob@example.com"],
+  createdAt,
+};
+
+describe("requireAgendaItem", () => {
+  it("returns typed AgendaItem for valid data", () => {
+    const item = requireAgendaItem("item-1", base);
+    expect(item.id).toBe("item-1");
+    expect(item.title).toBe("Write plan");
+    expect(item.status).toBe("todo");
+    expect(item.groupId).toBe("household");
+    expect(item.memberEmails).toEqual(["alice@example.com", "bob@example.com"]);
+    expect(item.scheduledAt).toBe(scheduledAt);
+    expect(item.createdAt).toBe(createdAt);
+  });
+
+  it("accepts null scheduledAt", () => {
+    const item = requireAgendaItem("item-2", { ...base, scheduledAt: null });
+    expect(item.scheduledAt).toBeNull();
+  });
+
+  it("accepts 'done' status", () => {
+    const item = requireAgendaItem("item-3", { ...base, status: "done" });
+    expect(item.status).toBe("done");
+  });
+
+  it("throws on missing title", () => {
+    expect(() => requireAgendaItem("item-4", { ...base, title: undefined })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on invalid status", () => {
+    expect(() => requireAgendaItem("item-5", { ...base, status: "archived" })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on missing createdAt", () => {
+    expect(() => requireAgendaItem("item-6", { ...base, createdAt: null })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on non-Timestamp scheduledAt", () => {
+    expect(() => requireAgendaItem("item-7", { ...base, scheduledAt: "2026-04-18" })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on non-array memberEmails", () => {
+    expect(() => requireAgendaItem("item-8", { ...base, memberEmails: "alice@example.com" })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on non-string entry in memberEmails", () => {
+    expect(() => requireAgendaItem("item-9", { ...base, memberEmails: ["alice@example.com", 42] })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on non-object data", () => {
+    expect(() => requireAgendaItem("item-10", null)).toThrow(TypeError);
+  });
+});

--- a/productivityutil/test/feed-entries.test.ts
+++ b/productivityutil/test/feed-entries.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("firebase/firestore", () => ({
+  Timestamp: class Timestamp {
+    _date: Date;
+    constructor(d: Date) { this._date = d; }
+    toDate() { return this._date; }
+    toMillis() { return this._date.getTime(); }
+    static fromDate(d: Date) { return new Timestamp(d); }
+  },
+}));
+
+import { Timestamp } from "firebase/firestore";
+import { requireFeedEntry } from "../src/feed-entries";
+import { DataIntegrityError } from "@commons-systems/firestoreutil/errors";
+
+const publishedAt = Timestamp.fromDate(new Date("2026-04-15T12:00:00Z"));
+const createdAt = Timestamp.fromDate(new Date("2026-04-15T12:05:00Z"));
+
+const base = {
+  source: "rss",
+  sourceKey: "overreacted",
+  title: "A post",
+  url: "https://overreacted.io/a-post",
+  snippet: "...",
+  publishedAt,
+  read: false,
+  saved: false,
+  groupId: "household",
+  memberEmails: ["alice@example.com"],
+  createdAt,
+};
+
+describe("requireFeedEntry", () => {
+  it("returns typed FeedEntry for valid data", () => {
+    const entry = requireFeedEntry("entry-1", base);
+    expect(entry.id).toBe("entry-1");
+    expect(entry.source).toBe("rss");
+    expect(entry.sourceKey).toBe("overreacted");
+    expect(entry.read).toBe(false);
+    expect(entry.saved).toBe(false);
+  });
+
+  it("accepts hackernews source", () => {
+    expect(requireFeedEntry("e", { ...base, source: "hackernews" }).source).toBe("hackernews");
+  });
+
+  it("accepts reddit source", () => {
+    expect(requireFeedEntry("e", { ...base, source: "reddit" }).source).toBe("reddit");
+  });
+
+  it("throws on unknown source", () => {
+    expect(() => requireFeedEntry("e", { ...base, source: "mastodon" })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on non-boolean read", () => {
+    expect(() => requireFeedEntry("e", { ...base, read: "false" })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on non-Timestamp publishedAt", () => {
+    expect(() => requireFeedEntry("e", { ...base, publishedAt: null })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on missing url", () => {
+    expect(() => requireFeedEntry("e", { ...base, url: undefined })).toThrow(DataIntegrityError);
+  });
+});

--- a/productivityutil/test/goals.test.ts
+++ b/productivityutil/test/goals.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("firebase/firestore", () => ({
+  Timestamp: class Timestamp {
+    _date: Date;
+    constructor(d: Date) { this._date = d; }
+    toDate() { return this._date; }
+    toMillis() { return this._date.getTime(); }
+    static fromDate(d: Date) { return new Timestamp(d); }
+  },
+}));
+
+import { Timestamp } from "firebase/firestore";
+import { requireGoal } from "../src/goals";
+import { DataIntegrityError } from "@commons-systems/firestoreutil/errors";
+
+const createdAt = Timestamp.fromDate(new Date("2026-04-01T00:00:00Z"));
+
+const base = {
+  title: "Ship productivity MVP",
+  horizon: "quarterly",
+  priority: 1,
+  status: "active",
+  progress: 25,
+  groupId: "household",
+  memberEmails: ["alice@example.com"],
+  createdAt,
+};
+
+describe("requireGoal", () => {
+  it("returns typed Goal for valid data", () => {
+    const g = requireGoal("goal-1", base);
+    expect(g.id).toBe("goal-1");
+    expect(g.title).toBe("Ship productivity MVP");
+    expect(g.horizon).toBe("quarterly");
+    expect(g.priority).toBe(1);
+    expect(g.progress).toBe(25);
+  });
+
+  it("accepts weekly and yearly horizons", () => {
+    expect(requireGoal("g", { ...base, horizon: "weekly" }).horizon).toBe("weekly");
+    expect(requireGoal("g", { ...base, horizon: "yearly" }).horizon).toBe("yearly");
+  });
+
+  it("accepts done and dropped statuses", () => {
+    expect(requireGoal("g", { ...base, status: "done" }).status).toBe("done");
+    expect(requireGoal("g", { ...base, status: "dropped" }).status).toBe("dropped");
+  });
+
+  it("accepts progress at bounds", () => {
+    expect(requireGoal("g", { ...base, progress: 0 }).progress).toBe(0);
+    expect(requireGoal("g", { ...base, progress: 100 }).progress).toBe(100);
+  });
+
+  it("throws on progress below 0", () => {
+    expect(() => requireGoal("g", { ...base, progress: -1 })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on progress above 100", () => {
+    expect(() => requireGoal("g", { ...base, progress: 101 })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on negative priority", () => {
+    expect(() => requireGoal("g", { ...base, priority: -1 })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on unknown horizon", () => {
+    expect(() => requireGoal("g", { ...base, horizon: "monthly" })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on unknown status", () => {
+    expect(() => requireGoal("g", { ...base, status: "paused" })).toThrow(DataIntegrityError);
+  });
+});

--- a/productivityutil/test/messages.test.ts
+++ b/productivityutil/test/messages.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("firebase/firestore", () => ({
+  Timestamp: class Timestamp {
+    _date: Date;
+    constructor(d: Date) { this._date = d; }
+    toDate() { return this._date; }
+    toMillis() { return this._date.getTime(); }
+    static fromDate(d: Date) { return new Timestamp(d); }
+  },
+}));
+
+import { Timestamp } from "firebase/firestore";
+import { requireMessage } from "../src/messages";
+import { DataIntegrityError } from "@commons-systems/firestoreutil/errors";
+
+const sentAt = Timestamp.fromDate(new Date("2026-04-10T08:00:00Z"));
+const createdAt = Timestamp.fromDate(new Date("2026-04-10T08:01:00Z"));
+
+const base = {
+  source: "discord",
+  sourceKey: "#general",
+  sender: "alice",
+  body: "hi there",
+  sentAt,
+  read: false,
+  actioned: false,
+  groupId: "household",
+  memberEmails: ["alice@example.com"],
+  createdAt,
+};
+
+describe("requireMessage", () => {
+  it("returns typed Message for valid data", () => {
+    const m = requireMessage("msg-1", base);
+    expect(m.id).toBe("msg-1");
+    expect(m.source).toBe("discord");
+    expect(m.sender).toBe("alice");
+    expect(m.body).toBe("hi there");
+  });
+
+  it("accepts email source", () => {
+    expect(requireMessage("m", { ...base, source: "email" }).source).toBe("email");
+  });
+
+  it("accepts claude-session source", () => {
+    expect(requireMessage("m", { ...base, source: "claude-session" }).source).toBe("claude-session");
+  });
+
+  it("throws on unknown source", () => {
+    expect(() => requireMessage("m", { ...base, source: "sms" })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on non-boolean actioned", () => {
+    expect(() => requireMessage("m", { ...base, actioned: 1 })).toThrow(DataIntegrityError);
+  });
+
+  it("throws on missing sender", () => {
+    expect(() => requireMessage("m", { ...base, sender: undefined })).toThrow(DataIntegrityError);
+  });
+});

--- a/productivityutil/tsconfig.json
+++ b/productivityutil/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@commons-systems/config/tsconfig.lib.json",
+  "include": ["src", "test"]
+}

--- a/rules-test/test/firestore/productivity.test.ts
+++ b/rules-test/test/firestore/productivity.test.ts
@@ -1,0 +1,487 @@
+import { describe, it, beforeAll, beforeEach } from "vitest";
+import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
+import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
+import {
+  doc,
+  getDoc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  Timestamp,
+} from "firebase/firestore";
+import {
+  getTestEnv,
+  authenticatedContext,
+  unauthenticatedContext,
+  adminSetDoc,
+  setupCleanup,
+  describeGroupsCollection,
+} from "../setup.js";
+
+const ENV = "test";
+const MEMBERS = ["member@test.com", "other@test.com"];
+const GROUP = "group1";
+
+const CREATED_AT = Timestamp.fromDate(new Date("2026-04-17T00:00:00Z"));
+
+describeGroupsCollection("productivity");
+
+const baseAgendaItem = {
+  title: "Daily review",
+  notes: "",
+  scheduledAt: Timestamp.fromDate(new Date("2026-04-18T09:00:00Z")),
+  status: "todo",
+  createdAt: CREATED_AT,
+  groupId: GROUP,
+  memberEmails: MEMBERS,
+};
+
+describe("productivity agenda-items", () => {
+  let env: RulesTestEnvironment;
+
+  beforeAll(async () => {
+    env = await getTestEnv();
+  });
+
+  setupCleanup();
+
+  beforeEach(async () => {
+    await adminSetDoc(env, `productivity/${ENV}/groups/${GROUP}`, { members: MEMBERS });
+    await adminSetDoc(env, `productivity/${ENV}/agenda-items/item1`, baseAgendaItem);
+  });
+
+  describe("read", () => {
+    it("allows member to read", async () => {
+      const db = authenticatedContext(env, "member@test.com").firestore();
+      await assertSucceeds(getDoc(doc(db, `productivity/${ENV}/agenda-items/item1`)));
+    });
+
+    it("denies non-member read", async () => {
+      const db = authenticatedContext(env, "stranger@test.com").firestore();
+      await assertFails(getDoc(doc(db, `productivity/${ENV}/agenda-items/item1`)));
+    });
+
+    it("denies unauthenticated read", async () => {
+      const db = unauthenticatedContext(env).firestore();
+      await assertFails(getDoc(doc(db, `productivity/${ENV}/agenda-items/item1`)));
+    });
+  });
+
+  describe("create", () => {
+    it("allows member to create with valid data", async () => {
+      const db = authenticatedContext(env, "member@test.com").firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `productivity/${ENV}/agenda-items/item2`), baseAgendaItem),
+      );
+    });
+
+    it("accepts null scheduledAt", async () => {
+      const db = authenticatedContext(env, "member@test.com").firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `productivity/${ENV}/agenda-items/item3`), {
+          ...baseAgendaItem,
+          scheduledAt: null,
+        }),
+      );
+    });
+
+    it("denies empty title", async () => {
+      const db = authenticatedContext(env, "member@test.com").firestore();
+      await assertFails(
+        setDoc(doc(db, `productivity/${ENV}/agenda-items/item4`), {
+          ...baseAgendaItem,
+          title: "",
+        }),
+      );
+    });
+
+    it("denies invalid status", async () => {
+      const db = authenticatedContext(env, "member@test.com").firestore();
+      await assertFails(
+        setDoc(doc(db, `productivity/${ENV}/agenda-items/item5`), {
+          ...baseAgendaItem,
+          status: "archived",
+        }),
+      );
+    });
+
+    it("denies mismatched memberEmails", async () => {
+      const db = authenticatedContext(env, "member@test.com").firestore();
+      await assertFails(
+        setDoc(doc(db, `productivity/${ENV}/agenda-items/item6`), {
+          ...baseAgendaItem,
+          memberEmails: ["member@test.com"],
+        }),
+      );
+    });
+
+    it("denies non-member create", async () => {
+      const db = authenticatedContext(env, "stranger@test.com").firestore();
+      await assertFails(
+        setDoc(doc(db, `productivity/${ENV}/agenda-items/item7`), baseAgendaItem),
+      );
+    });
+
+    it("denies extra fields", async () => {
+      const db = authenticatedContext(env, "member@test.com").firestore();
+      await assertFails(
+        setDoc(doc(db, `productivity/${ENV}/agenda-items/item8`), {
+          ...baseAgendaItem,
+          extraField: "nope",
+        }),
+      );
+    });
+  });
+
+  describe("update", () => {
+    it("allows updating mutable fields", async () => {
+      const db = authenticatedContext(env, "member@test.com").firestore();
+      await assertSucceeds(
+        updateDoc(doc(db, `productivity/${ENV}/agenda-items/item1`), {
+          title: "Updated",
+          notes: "Added a note",
+          status: "done",
+        }),
+      );
+    });
+
+    it("denies changing groupId", async () => {
+      const db = authenticatedContext(env, "member@test.com").firestore();
+      await assertFails(
+        updateDoc(doc(db, `productivity/${ENV}/agenda-items/item1`), {
+          groupId: "group2",
+        }),
+      );
+    });
+
+    it("denies changing memberEmails", async () => {
+      const db = authenticatedContext(env, "member@test.com").firestore();
+      await assertFails(
+        updateDoc(doc(db, `productivity/${ENV}/agenda-items/item1`), {
+          memberEmails: ["member@test.com"],
+        }),
+      );
+    });
+
+    it("denies changing createdAt", async () => {
+      const db = authenticatedContext(env, "member@test.com").firestore();
+      await assertFails(
+        updateDoc(doc(db, `productivity/${ENV}/agenda-items/item1`), {
+          createdAt: Timestamp.fromDate(new Date("2025-01-01T00:00:00Z")),
+        }),
+      );
+    });
+
+    it("denies non-member update", async () => {
+      const db = authenticatedContext(env, "stranger@test.com").firestore();
+      await assertFails(
+        updateDoc(doc(db, `productivity/${ENV}/agenda-items/item1`), {
+          title: "HACK",
+        }),
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("allows member to delete", async () => {
+      const db = authenticatedContext(env, "member@test.com").firestore();
+      await assertSucceeds(
+        deleteDoc(doc(db, `productivity/${ENV}/agenda-items/item1`)),
+      );
+    });
+
+    it("denies non-member delete", async () => {
+      const db = authenticatedContext(env, "stranger@test.com").firestore();
+      await assertFails(
+        deleteDoc(doc(db, `productivity/${ENV}/agenda-items/item1`)),
+      );
+    });
+  });
+});
+
+const baseFeedEntry = {
+  source: "rss",
+  sourceKey: "overreacted",
+  title: "A post",
+  url: "https://overreacted.io/a-post",
+  snippet: "...",
+  publishedAt: Timestamp.fromDate(new Date("2026-04-15T12:00:00Z")),
+  read: false,
+  saved: false,
+  createdAt: CREATED_AT,
+  groupId: GROUP,
+  memberEmails: MEMBERS,
+};
+
+describe("productivity feed-entries", () => {
+  let env: RulesTestEnvironment;
+
+  beforeAll(async () => {
+    env = await getTestEnv();
+  });
+
+  setupCleanup();
+
+  beforeEach(async () => {
+    await adminSetDoc(env, `productivity/${ENV}/groups/${GROUP}`, { members: MEMBERS });
+    await adminSetDoc(env, `productivity/${ENV}/feed-entries/entry1`, baseFeedEntry);
+  });
+
+  it("allows member read", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertSucceeds(getDoc(doc(db, `productivity/${ENV}/feed-entries/entry1`)));
+  });
+
+  it("denies non-member read", async () => {
+    const db = authenticatedContext(env, "stranger@test.com").firestore();
+    await assertFails(getDoc(doc(db, `productivity/${ENV}/feed-entries/entry1`)));
+  });
+
+  it("allows member create with valid data", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertSucceeds(
+      setDoc(doc(db, `productivity/${ENV}/feed-entries/entry2`), baseFeedEntry),
+    );
+  });
+
+  it("denies unknown source", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertFails(
+      setDoc(doc(db, `productivity/${ENV}/feed-entries/entry3`), {
+        ...baseFeedEntry,
+        source: "mastodon",
+      }),
+    );
+  });
+
+  it("denies non-boolean read flag", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertFails(
+      setDoc(doc(db, `productivity/${ENV}/feed-entries/entry4`), {
+        ...baseFeedEntry,
+        read: "false",
+      }),
+    );
+  });
+
+  it("allows updating read flag", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertSucceeds(
+      updateDoc(doc(db, `productivity/${ENV}/feed-entries/entry1`), { read: true }),
+    );
+  });
+
+  it("denies changing groupId on update", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertFails(
+      updateDoc(doc(db, `productivity/${ENV}/feed-entries/entry1`), { groupId: "group2" }),
+    );
+  });
+
+  it("allows member delete", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertSucceeds(
+      deleteDoc(doc(db, `productivity/${ENV}/feed-entries/entry1`)),
+    );
+  });
+
+  it("denies non-member delete", async () => {
+    const db = authenticatedContext(env, "stranger@test.com").firestore();
+    await assertFails(
+      deleteDoc(doc(db, `productivity/${ENV}/feed-entries/entry1`)),
+    );
+  });
+});
+
+const baseMessage = {
+  source: "discord",
+  sourceKey: "#general",
+  sender: "alice",
+  body: "hi there",
+  sentAt: Timestamp.fromDate(new Date("2026-04-10T08:00:00Z")),
+  read: false,
+  actioned: false,
+  createdAt: CREATED_AT,
+  groupId: GROUP,
+  memberEmails: MEMBERS,
+};
+
+describe("productivity messages", () => {
+  let env: RulesTestEnvironment;
+
+  beforeAll(async () => {
+    env = await getTestEnv();
+  });
+
+  setupCleanup();
+
+  beforeEach(async () => {
+    await adminSetDoc(env, `productivity/${ENV}/groups/${GROUP}`, { members: MEMBERS });
+    await adminSetDoc(env, `productivity/${ENV}/messages/msg1`, baseMessage);
+  });
+
+  it("allows member read", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertSucceeds(getDoc(doc(db, `productivity/${ENV}/messages/msg1`)));
+  });
+
+  it("denies non-member read", async () => {
+    const db = authenticatedContext(env, "stranger@test.com").firestore();
+    await assertFails(getDoc(doc(db, `productivity/${ENV}/messages/msg1`)));
+  });
+
+  it("allows member create with valid data", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertSucceeds(
+      setDoc(doc(db, `productivity/${ENV}/messages/msg2`), baseMessage),
+    );
+  });
+
+  it("denies unknown source", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertFails(
+      setDoc(doc(db, `productivity/${ENV}/messages/msg3`), {
+        ...baseMessage,
+        source: "sms",
+      }),
+    );
+  });
+
+  it("allows updating actioned flag", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertSucceeds(
+      updateDoc(doc(db, `productivity/${ENV}/messages/msg1`), { actioned: true }),
+    );
+  });
+
+  it("denies changing memberEmails on update", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertFails(
+      updateDoc(doc(db, `productivity/${ENV}/messages/msg1`), {
+        memberEmails: ["member@test.com"],
+      }),
+    );
+  });
+
+  it("allows member delete", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertSucceeds(deleteDoc(doc(db, `productivity/${ENV}/messages/msg1`)));
+  });
+});
+
+const baseGoal = {
+  title: "Ship MVP",
+  horizon: "quarterly",
+  priority: 1,
+  status: "active",
+  progress: 25,
+  createdAt: CREATED_AT,
+  groupId: GROUP,
+  memberEmails: MEMBERS,
+};
+
+describe("productivity goals", () => {
+  let env: RulesTestEnvironment;
+
+  beforeAll(async () => {
+    env = await getTestEnv();
+  });
+
+  setupCleanup();
+
+  beforeEach(async () => {
+    await adminSetDoc(env, `productivity/${ENV}/groups/${GROUP}`, { members: MEMBERS });
+    await adminSetDoc(env, `productivity/${ENV}/goals/goal1`, baseGoal);
+  });
+
+  it("allows member read", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertSucceeds(getDoc(doc(db, `productivity/${ENV}/goals/goal1`)));
+  });
+
+  it("denies non-member read", async () => {
+    const db = authenticatedContext(env, "stranger@test.com").firestore();
+    await assertFails(getDoc(doc(db, `productivity/${ENV}/goals/goal1`)));
+  });
+
+  it("allows member create with valid data", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertSucceeds(
+      setDoc(doc(db, `productivity/${ENV}/goals/goal2`), baseGoal),
+    );
+  });
+
+  it("denies progress below 0", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertFails(
+      setDoc(doc(db, `productivity/${ENV}/goals/goal3`), {
+        ...baseGoal,
+        progress: -1,
+      }),
+    );
+  });
+
+  it("denies progress above 100", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertFails(
+      setDoc(doc(db, `productivity/${ENV}/goals/goal4`), {
+        ...baseGoal,
+        progress: 101,
+      }),
+    );
+  });
+
+  it("denies negative priority", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertFails(
+      setDoc(doc(db, `productivity/${ENV}/goals/goal5`), {
+        ...baseGoal,
+        priority: -1,
+      }),
+    );
+  });
+
+  it("denies unknown horizon", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertFails(
+      setDoc(doc(db, `productivity/${ENV}/goals/goal6`), {
+        ...baseGoal,
+        horizon: "monthly",
+      }),
+    );
+  });
+
+  it("denies unknown status", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertFails(
+      setDoc(doc(db, `productivity/${ENV}/goals/goal7`), {
+        ...baseGoal,
+        status: "paused",
+      }),
+    );
+  });
+
+  it("allows updating progress and status", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertSucceeds(
+      updateDoc(doc(db, `productivity/${ENV}/goals/goal1`), {
+        progress: 75,
+        status: "done",
+      }),
+    );
+  });
+
+  it("denies changing createdAt on update", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertFails(
+      updateDoc(doc(db, `productivity/${ENV}/goals/goal1`), {
+        createdAt: Timestamp.fromDate(new Date("2025-01-01T00:00:00Z")),
+      }),
+    );
+  });
+
+  it("allows member delete", async () => {
+    const db = authenticatedContext(env, "member@test.com").firestore();
+    await assertSucceeds(deleteDoc(doc(db, `productivity/${ENV}/goals/goal1`)));
+  });
+});


### PR DESCRIPTION
## Summary

Introduces the shared data model for the productivity dashboard (sub-issue of #456). Adds a new workspace package `@commons-systems/productivityutil` and five Firestore rule blocks under `/productivity/{env}/...`, unblocking the follow-up PRs that build the agenda (#459), web scaffold (#461), goals (#462), and feed aggregation (#463).

- **`productivityutil/`** — types + runtime converters for `AgendaItem`, `FeedEntry`, `Message`, `Goal`. Branded IDs, readonly interfaces, and `require*()` converters that coerce Firestore `DocumentData` into typed models.
- **Firestore rules** — group-scoped access via denormalized `memberEmails`, following the `budget/normalization-rules` pattern. Members get full CRUD; `groupId`, `memberEmails`, and `createdAt` are immutable on update. Each collection has an `isValid*Data()` shape validator.
- **Test coverage** — 32 converter unit tests + 48 rules tests against the Firestore emulator.

## Design decisions

- **Group-scoped access** (not user-scoped) to match `budget/`, `landing/`, `audio/` conventions and leave room for collaboration.
- **Full CRUD from the start** (not lockdown-then-relax), since each downstream feature PR needs client writes.
- **`Timestamp` from `firebase/firestore`** (client SDK) — structurally compatible with `firebase-admin` for Functions consumers.

Closes #460

## Test plan

- [x] `productivityutil` lint + typecheck + unit tests (32 tests)
- [x] Full workspace vitest run (1817 tests passing)
- [x] Firestore rules syntax check
- [x] `rules-test` emulator suite (48 new productivity tests, 303 total passing)

Per `.claude/rules/firestore.md`, a standalone rules-only PR follows this one once QA passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)