### PR TITLE
fellspiral: apply SEO building blocks from #543

### DIFF
--- a/fellspiral/public/robots.txt
+++ b/fellspiral/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://fellspiral.commons.systems/sitemap.xml

--- a/fellspiral/scripts/prerender.ts
+++ b/fellspiral/scripts/prerender.ts
@@ -1,14 +1,23 @@
 import { dirname, join } from "node:path";
 import { prerenderPosts } from "@commons-systems/blog/prerender";
 import { generateFeedXml } from "@commons-systems/blog/feed";
+import { generateSitemapXml } from "@commons-systems/blog/sitemap";
 import { FEED_REGISTRY } from "@commons-systems/blog/blog-roll/feed-registry";
 import appSeed from "../seeds/firestore.js";
-import { NAV_LINKS, INFO_PANEL_LINK_SECTIONS, SITE_DEFAULTS } from "../src/site-config.js";
+import {
+  NAV_LINKS,
+  INFO_PANEL_LINK_SECTIONS,
+  SITE_DEFAULTS,
+  SITE_URL,
+  ORGANIZATION,
+  AUTHOR,
+  REL_ME,
+} from "../src/site-config.js";
 
 const distDir = join(dirname(new URL(import.meta.url).pathname), "..", "dist");
 
 await prerenderPosts({
-  siteUrl: "https://fellspiral.commons.systems",
+  siteUrl: SITE_URL,
   titleSuffix: "Fellspiral",
   distDir,
   seed: appSeed,
@@ -21,11 +30,20 @@ await prerenderPosts({
     opmlUrl: "/blogroll.opml",
   },
   siteDefaults: SITE_DEFAULTS,
+  organization: ORGANIZATION,
+  author: AUTHOR,
+  relMe: REL_ME,
 });
 
 generateFeedXml({
   title: "fellspiral",
-  siteUrl: "https://fellspiral.commons.systems",
+  siteUrl: SITE_URL,
+  distDir,
+  seed: appSeed,
+});
+
+generateSitemapXml({
+  siteUrl: SITE_URL,
   distDir,
   seed: appSeed,
 });

--- a/fellspiral/src/main.ts
+++ b/fellspiral/src/main.ts
@@ -14,13 +14,14 @@ import buildTimeContent from "virtual:blog-post-content";
 import buildTimeMetadata from "virtual:blog-post-metadata";
 import { createFetchPost } from "@commons-systems/blog/github";
 import { updateOgMeta } from "@commons-systems/blog/og-meta";
+import { updateCanonical } from "@commons-systems/blog/canonical";
 import { getPosts, type PostMeta } from "@commons-systems/blog/firestore";
 import { initPanelToggle } from "@commons-systems/style/panel-toggle";
 import { initScrollIndicator } from "@commons-systems/style/scroll-indicator";
 import "@commons-systems/style/components/nav";
 import type { AppNavElement } from "@commons-systems/style/components/nav";
 import { createStrategies, BLOG_ROLL_ENTRIES } from "./blog-roll/config.js";
-import { INFO_PANEL_LINK_SECTIONS, SITE_DEFAULTS } from "./site-config.js";
+import { INFO_PANEL_LINK_SECTIONS, SITE_DEFAULTS, SITE_URL } from "./site-config.js";
 import { signIn, signOut, onAuthStateChanged } from "./auth.js";
 import { isInGroup, ADMIN_GROUP_ID } from "@commons-systems/authutil/groups";
 import { db, NAMESPACE, trackPageView, initAppCheck } from "./firebase.js";
@@ -52,7 +53,7 @@ let lastSkippedCount = 0;
 let lastRenderedPosts: PostMeta[] | undefined;
 const strategies = createStrategies();
 const boundFetchPost = createFetchPost("fellspiral/post");
-const RSS_CONFIG = { title: "fellspiral", siteUrl: "https://fellspiral.commons.systems" };
+const RSS_CONFIG = { title: "fellspiral", siteUrl: SITE_URL };
 // Skip the very first innerHTML replacement when pre-rendered content exists.
 // The pre-render script (prerender.ts) already injected identical panel markup,
 // so replacing it would cause a needless DOM teardown that can trigger CLS.
@@ -148,6 +149,7 @@ const router = createHistoryRouter(
         const slug = path.startsWith("/post/") ? path.slice(6) : undefined;
         hydrateHome(outlet, cachedPosts, boundFetchPost, slug);
         updateOgMeta(RSS_CONFIG.siteUrl, slug ? cachedPosts.find((p) => p.id === slug) : undefined, "Fellspiral", SITE_DEFAULTS);
+        updateCanonical(RSS_CONFIG.siteUrl, slug);
         updateInfoPanel();
       },
     },

--- a/fellspiral/src/site-config.ts
+++ b/fellspiral/src/site-config.ts
@@ -1,6 +1,9 @@
 import type { LinkSection } from "@commons-systems/blog/components/info-panel";
 import type { NavLink } from "@commons-systems/blog/prerender";
 import type { SiteDefaults } from "@commons-systems/blog/og-meta";
+import type { Organization, Author } from "@commons-systems/blog/seo";
+
+export const SITE_URL = "https://fellspiral.commons.systems";
 
 export const NAV_LINKS: NavLink[] = [{ href: "/", label: "Home" }];
 
@@ -9,6 +12,20 @@ export const SITE_DEFAULTS: SiteDefaults = {
   description: "A TTRPG game blog by Nate. Nate likes games about social role play.",
   image: "/tile10-armadillo-crag.webp",
 };
+
+export const ORGANIZATION: Organization = {
+  name: "fellspiral",
+  url: SITE_URL,
+  logo: `${SITE_URL}/tile10-armadillo-crag.webp`,
+  sameAs: ["https://github.com/natb1"],
+};
+
+export const AUTHOR: Author = {
+  name: "Nathan Buesgens",
+  url: "https://github.com/natb1",
+};
+
+export const REL_ME: string[] = ["https://github.com/natb1"];
 
 export const INFO_PANEL_LINK_SECTIONS: LinkSection[] = [
   {


### PR DESCRIPTION
## Summary

Wire fellspiral into the shared SEO helpers added in #543 — canonical tags, Organization/BlogPosting JSON-LD, sitemap.xml, rel=me. No changes to `@commons-systems/blog`; all helpers already exist and are unit-tested.

- **site-config**: add `SITE_URL`, `ORGANIZATION`, `AUTHOR`, `REL_ME` exports (mirrors landing's config, `sameAs`/`REL_ME` limited to the GitHub profile).
- **prerender**: pass `organization`/`author`/`relMe` to `prerenderPosts` and call `generateSitemapXml`; replace hardcoded URL with imported `SITE_URL`.
- **main**: call `updateCanonical` in the home/post `afterRender` alongside `updateOgMeta`; `RSS_CONFIG.siteUrl` uses imported `SITE_URL`.
- **robots.txt**: reference `https://fellspiral.commons.systems/sitemap.xml`.

## Test plan

- [x] `npx tsc --noEmit --project fellspiral` — clean
- [x] `npm run build --prefix fellspiral` — succeeds
- [x] Lint — `run-lint.sh` passes on fellspiral + blog + landing
- [x] `dist/sitemap.xml` — lists `/` plus 3 published posts with `lastmod`
- [x] `dist/robots.txt` — contains `Sitemap:` line
- [x] `dist/index.html` — `<link rel="canonical">`, Organization JSON-LD, `<link rel="me">`
- [x] `dist/post/<slug>/index.html` — canonical, `BlogPosting` JSON-LD (verified type via node), rel=me
- [ ] Runtime SPA nav — verify canonical href updates between `/` and `/post/<slug>` in DevTools
- [ ] Post-deploy — spot-check one preview URL with Google's Rich Results Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)