### PR TITLE
dispatch-implement: post-implementation verify loop + plan-accept reload

### DIFF
--- a/.claude/hooks/restore-dispatch-skill.sh
+++ b/.claude/hooks/restore-dispatch-skill.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Context-clear recovery hook: if this is a dispatched session, emit a reload instruction.
+# Called by hooks.json on SessionStart/clear events.
+# Always exits 0 — never blocks session recovery.
+set -uo pipefail
+trap 'echo "[restore-dispatch-skill] WARNING: unexpected error on line $LINENO" >&2; exit 0' ERR
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || {
+  echo "[restore-dispatch-skill] WARNING: cannot resolve script directory" >&2
+  exit 0
+}
+
+# Extract issue number from branch name (e.g., "566-extend-dispatch-implement-wi" → "566")
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+ISSUE_NUM=$(printf '%s\n' "$BRANCH" | grep -oE '^[0-9]+') || exit 0
+
+# Detect dispatched session by checking for the state file
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+[ -f "$REPO_ROOT/tmp/dispatch-${ISSUE_NUM}.json" ] || exit 0
+
+# Emit reload instruction so Claude reloads the dispatch-implement skill
+printf 'COMPACTION RECOVERY: Reload skill: /dispatch-implement #%s\n' "$ISSUE_NUM"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -136,6 +136,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/clear-skill-state.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/restore-dispatch-skill.sh"
           }
         ]
       }

--- a/.claude/skills/dispatch-implement/SKILL.md
+++ b/.claude/skills/dispatch-implement/SKILL.md
@@ -11,7 +11,15 @@ Invoked by `./dispatch/bin/dispatch <issue-num>` as the opening message. The dis
 
 ## Steps
 
-1. **Plan.** Invoke `EnterPlanMode` and produce a plan whose implementation section is an ordered list of **logical units of work**. Each unit specifies:
+1. **Plan.** Before entering plan mode, seed the dispatcher state file if it does not yet exist — this is what the `SessionStart:clear` hook (`.claude/hooks/restore-dispatch-skill.sh`) watches for when the user accepts a plan and clears the context:
+
+   ```bash
+   [ -f "$DISPATCH_STATE_FILE" ] || { mkdir -p "$(dirname "$DISPATCH_STATE_FILE")" && printf '{}' > "$DISPATCH_STATE_FILE"; }
+   ```
+
+   Then invoke `EnterPlanMode` and produce a plan whose implementation section is an ordered list of **logical units of work**. Each unit specifies:
+
+   If an approved plan for this dispatch is already present in context (typical after `showClearContextOnPlanAccept` fires — the user accepted a plan and then cleared the context, causing this skill to be re-invoked), skip this step and proceed to Step 2. The plan file persists on disk across context clears, so the unit list remains visible even though the planning conversation is gone.
 
    1. **Scope.** What files/behavior change, what is explicitly out of scope.
    2. **Implementation model.** `opus` or `sonnet`, chosen per the heuristic below.

--- a/.claude/skills/dispatch-implement/SKILL.md
+++ b/.claude/skills/dispatch-implement/SKILL.md
@@ -33,6 +33,77 @@ Invoked by `./dispatch/bin/dispatch <issue-num>` as the opening message. The dis
       - **Pre-commit hook failure** → launch another implementation subagent with the sonnet model to fix the underlying issue (do not `--amend`; create a new commit), then re-invoke `/commit-merge-push`.
       - **Push rejection** (non-fast-forward, server hook) → surface to user; do not force-push.
 
+2.5. **Verify loop.** After all units are committed and pushed, enter the post-implementation verify loop. Each iteration re-checks CI; on failure, reproduce locally and fix before continuing. Exit the loop only when all PR checks pass.
+
+   **2.5.1 — Ensure a draft PR exists.** On the first iteration only, create a draft PR (use `dangerouslyDisableSandbox: true` — `gh` needs network):
+
+   ```
+   gh pr create --draft --title "<short summary>" --body "$(cat <<'EOF'
+   Closes #<primary-issue>
+   Closes #<sub-issue-or-blocker>   # repeat for each implemented issue
+   EOF
+   )"
+   ```
+
+   Body follows the `Closes #N` pattern: one `Closes #N` line per issue (primary + any implemented sub-issues/blockers). Do NOT fork another skill. On subsequent iterations the PR already exists; skip this sub-step.
+
+   **2.5.2 — Monitor PR checks.** Launch a **sonnet** subagent via the Agent tool. The subagent runs:
+
+   ```
+   .claude/skills/ref-pr-workflow/scripts/run-pr-checks-wait.sh <pr-num>
+   ```
+
+   with `dangerouslyDisableSandbox: true`. It returns a structured summary: per check — name, conclusion (pass/fail/skip), and for any failing check a short excerpt of the failure log.
+
+   **2.5.3 — Dispatch on result.**
+
+   - **All checks pass:**
+     - Main thread assembles a summary of every prior-iteration failure and its "why not caught locally" diagnosis from in-session context.
+     - Write the summary to `tmp/verify-summary.md`. If no failures occurred (clean first pass), write: `All PR checks passed on the first verify iteration — no failures to diagnose.`
+     - Post via (use `dangerouslyDisableSandbox: true`):
+       ```
+       .claude/skills/ref-pr-workflow/scripts/post-pr-comment.sh <pr-num> tmp/verify-summary.md
+       ```
+     - Proceed to Step 3 (phase-complete). Exit the verify loop.
+
+   - **One or more checks fail:** continue to 2.5.4.
+
+   **2.5.4 — Reproduce locally.** Launch a **sonnet** subagent with the failing check name and failure excerpt. The subagent:
+   - Maps the failing check to a local reproduce command:
+     - Unit test check → `.claude/skills/ref-pr-workflow/scripts/run-unit-tests.sh`
+     - Lint check → `.claude/skills/ref-pr-workflow/scripts/run-lint.sh`
+     - Acceptance test check → `.claude/skills/ref-pr-workflow/scripts/run-acceptance-tests.sh`
+     - Type-check → `npx tsc --noEmit --project <pkg>`
+     - Other → best-effort map from the failing workflow name
+   - Runs the command (use `dangerouslyDisableSandbox: true` when network or npm cache is needed).
+   - Returns: `{ reproduced: bool, reproduce_command, failure_excerpt, why_not_caught }`. `why_not_caught` is a free-text diagnosis (missing test, disabled rule, skipped hook, env drift, flake, etc.).
+
+   **No-repro branch:** if `reproduced == false`, main thread surfaces the no-repro result (check name, reproduce command attempted, hypothesis) to the user and **halts the verify loop**. Do NOT push a speculative fix.
+
+   **Reproduced:** continue to 2.5.5.
+
+   **2.5.5 — Fix and verify locally.** Main thread picks the fix-subagent model using the **same heuristic as Step 1**:
+   - **`sonnet`** for mechanical fixes: lint errors, clear type errors, obvious test expectation updates.
+   - **`opus`** for judgment-heavy fixes: logic bugs, cross-cutting breakage, unfamiliar subsystem.
+   - If unsure, pick `opus`.
+
+   Launch the fix subagent with the reproduce command and failure excerpt. The subagent:
+   - Edits the working tree to fix the root cause.
+   - Re-runs the reproduce command until it passes locally.
+   - Must NOT commit or push.
+   - Returns only after the local reproduction is green.
+
+   If the subagent returns with a still-failing check, main thread launches another fix subagent.
+
+   **2.5.6 — Commit, merge, push.** Main thread invokes `/commit-merge-push` via the Agent tool (fork subagent; its frontmatter sets `model: sonnet` — do not override). Error recovery mirrors existing Step 2:
+   - **Merge conflict** → launch another implementation subagent (opus) to resolve, then re-invoke `/commit-merge-push`.
+   - **Pre-commit hook failure** → launch another implementation subagent (sonnet) to fix (new commit — never `--amend`), then re-invoke `/commit-merge-push`.
+   - **Push rejection** (non-fast-forward, server hook) → surface to user. Do not force-push.
+
+   **2.5.7 — Loop back.** After a successful push, return to 2.5.2 (monitor checks). Do NOT re-enter the per-unit implementation loop from Step 2.
+
+   > **Iteration history** is retained in the main thread's conversation context — no external file is needed beyond `tmp/verify-summary.md`. Step 2.5.3's all-pass summary reads the per-iteration failure records (check name, reproduce command, failure excerpt, why_not_caught, fix commit) directly from this context.
+
 3. Run `./dispatch/bin/phase-complete` with `dangerouslyDisableSandbox: true` — the script calls `issue-state-write` which uses tsx and requires network access for Firestore. The dispatcher SIGTERMs this session shortly after.
 
 4. Stop.


### PR DESCRIPTION
## Summary

Extends `dispatch-implement` with a post-implementation verify loop and makes the skill re-loadable after a plan-accept context clear.

- **Verify loop (Step 2.5).** After all units are committed, open a draft PR, monitor CI via a sonnet subagent running `run-pr-checks-wait.sh`, reproduce any failing check locally via a sonnet subagent (records `why_not_caught`), fix via a subagent chosen by the Step 1 sonnet/opus heuristic, fork `/commit-merge-push`, and loop back to check-monitoring. No-repro halts without pushing a speculative fix. All-pass posts a summary of every iteration's "why not caught locally" diagnosis to the PR before proceeding to `phase-complete`.
- **Plan-accept reload.** New `SessionStart:clear` hook `restore-dispatch-skill.sh` detects a dispatched session via `tmp/dispatch-<n>.json` and emits a `/dispatch-implement` reload instruction. Step 1 now seeds that state file before entering plan mode (so the file exists when the user clears context after accepting the plan) and opens with a resume clause: if an approved plan for this dispatch is already present in context, skip Step 1 and proceed to Step 2.

Closes #566