### PR TITLE
productivity-tui: visualize Claude rate-limit usage

### DIFF
--- a/.claude/hooks/statusline.sh
+++ b/.claude/hooks/statusline.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Project-level Claude Code status line.
+# Side effect: writes ~/.local/share/productivity-tui/rate_limits.json so the
+# productivity-tui rate-limits header has data to render.
+# Visible output: identical to the user's global statusLine (model | cwd | tokens).
+
+input=$(cat)
+
+# Side effect — write rate_limits.json. Discard stdout (its summary line) and
+# any errors so the status line still renders if the hook fails.
+printf '%s' "$input" \
+  | "$CLAUDE_PROJECT_DIR/productivity-tui/hooks/update-rate-limits.sh" \
+  >/dev/null 2>&1 || true
+
+# Visible status line — matches ~/.claude/settings.json statusLine.command.
+model=$(echo "$input" | jq -r '.model.display_name')
+cwd=$(echo "$input" | jq -r '.workspace.current_dir' | sed "s|^$HOME|~|")
+usage=$(echo "$input" | jq '.context_window.current_usage')
+ctx_size=$(echo "$input" | jq -r '.context_window.context_window_size')
+if [ "$usage" != "null" ]; then
+  current=$(echo "$usage" | jq '.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens')
+  pct=$((current * 100 / ctx_size))
+  printf "\033[36m%s\033[0m | \033[33m%s\033[0m | \033[35m%dk/%dk tokens (%d%%)\033[0m" \
+    "$model" "$cwd" "$((current/1000))" "$((ctx_size/1000))" "$pct"
+else
+  printf "\033[36m%s\033[0m | \033[33m%s\033[0m" "$model" "$cwd"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -155,6 +155,10 @@
       }
     ]
   },
+  "statusLine": {
+    "type": "command",
+    "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/statusline.sh"
+  },
   "enabledPlugins": {
     "security-guidance@claude-plugins-official": true,
     "marketing@knowledge-work-plugins": false

--- a/productivity-tui/hooks/update-rate-limits.sh
+++ b/productivity-tui/hooks/update-rate-limits.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Claude Code statusLine hook — reads stdin JSON and atomically writes rate_limits.json.
+# Prints a single status line to stdout (e.g. "5h: 5% · 7d: 1%") when data is present.
+set -euo pipefail
+
+STATE_DIR="$HOME/.local/share/productivity-tui"
+STATE_FILE="$STATE_DIR/rate_limits.json"
+
+HOOK_INPUT="$(cat)"
+
+# Build a filtered payload: extract .rate_limits and drop any null inner windows.
+PAYLOAD="$(printf '%s' "$HOOK_INPUT" | jq -c '(.rate_limits // {}) | with_entries(select(.value != null))')"
+
+# If rate_limits was absent/null or all inner windows were null, exit cleanly.
+if [ "$PAYLOAD" = "{}" ]; then
+  exit 0
+fi
+
+mkdir -p "$STATE_DIR"
+
+tmp="$(mktemp "$STATE_DIR/rate_limits.XXXXXX")"
+trap 'status=$?; [ $status -ne 0 ] && echo "update-rate-limits: unexpected error (exit $status)" >&2; rm -f "$tmp"' EXIT
+
+printf '%s\n' "$PAYLOAD" > "$tmp"
+mv "$tmp" "$STATE_FILE"
+
+# Print status line: "5h: <n>% · 7d: <n>%" with only present windows.
+printf '%s' "$PAYLOAD" | jq -r '
+  [
+    (.five_hour | select(.) | "5h: \(.used_percentage)%"),
+    (.seven_day | select(.) | "7d: \(.used_percentage)%")
+  ] | join(" · ")
+'

--- a/productivity-tui/internal/app/app.go
+++ b/productivity-tui/internal/app/app.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/natb1/commons.systems/productivity-tui/internal/ratelimits"
 	"github.com/natb1/commons.systems/productivity-tui/internal/session"
 )
 
@@ -25,6 +26,11 @@ var (
 
 	separatorStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("8"))
+
+	// labelStyle uses the same bold blue as titleStyle for rate-limit row labels.
+	labelStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("12"))
 )
 
 const idleIndicator = "✳"
@@ -32,22 +38,26 @@ const idleIndicator = "✳"
 type tickMsg time.Time
 
 type Model struct {
-	sessions      map[string]session.Session
-	stateFilePath string
-	width         int
-	height        int
-	err           error
+	sessions       map[string]session.Session
+	stateFilePath  string
+	width          int
+	height         int
+	err            error
+	rateLimits     ratelimits.RateLimits
+	rateLimitsPath string
+	rateLimitsErr  error
 }
 
-func New(stateFilePath string) Model {
+func New(sessionsPath, rateLimitsPath string) Model {
 	return Model{
-		sessions:      map[string]session.Session{},
-		stateFilePath: stateFilePath,
+		sessions:       map[string]session.Session{},
+		stateFilePath:  sessionsPath,
+		rateLimitsPath: rateLimitsPath,
 	}
 }
 
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(tick(), loadSessions(m.stateFilePath))
+	return tea.Batch(tick(), loadSessions(m.stateFilePath), loadRateLimits(m.rateLimitsPath))
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -61,7 +71,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 	case tickMsg:
-		return m, tea.Batch(tick(), loadSessions(m.stateFilePath))
+		return m, tea.Batch(tick(), loadSessions(m.stateFilePath), loadRateLimits(m.rateLimitsPath))
 	case sessionsMsg:
 		if msg.err != nil {
 			m.err = msg.err
@@ -70,12 +80,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = nil
 			m.sessions = msg.sessions
 		}
+	case rateLimitsMsg:
+		m.rateLimits = msg.rl
+		m.rateLimitsErr = msg.err
 	}
 	return m, nil
 }
 
 func (m Model) View() string {
 	var b strings.Builder
+
+	// Render rate-limits header when data is available and no error occurred.
+	if m.rateLimitsErr == nil && (m.rateLimits.FiveHour != nil || m.rateLimits.SevenDay != nil) {
+		now := time.Now()
+		if m.rateLimits.FiveHour != nil {
+			b.WriteString(renderRateLimitRow("5h", m.rateLimits.FiveHour, now))
+			b.WriteString("\n")
+		}
+		if m.rateLimits.SevenDay != nil {
+			b.WriteString(renderRateLimitRow("7d", m.rateLimits.SevenDay, now))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
 
 	b.WriteString(titleStyle.Render("Claude Sessions"))
 	b.WriteString("\n")
@@ -107,6 +134,57 @@ func (m Model) View() string {
 	return b.String()
 }
 
+// renderRateLimitRow renders a single rate-limit row:
+//
+//	  5h  ████▌                       18%  resets in 0h 32m
+func renderRateLimitRow(label string, w *ratelimits.Window, now time.Time) string {
+	pct := w.UsedPercentage
+	if pct < 0 {
+		pct = 0
+	}
+	if pct > 100 {
+		pct = 100
+	}
+
+	// 28 cells wide bar; 2 half-cell units per cell → 56 units total.
+	units := pct * 56 / 100
+	full := units / 2
+	half := units % 2
+
+	filledStr := strings.Repeat("█", full)
+	if half == 1 {
+		filledStr += "▌"
+	}
+	// Pad to 28 visible cells (full blocks + optional half block already counted).
+	emptyCount := 28 - full - half
+	barStr := activeStyle.Render(filledStr) + strings.Repeat(" ", emptyCount)
+
+	pctStr := fmt.Sprintf("%3d%%", w.UsedPercentage)
+
+	countdown := formatCountdown(w.ResetIn(now))
+
+	return fmt.Sprintf("  %s  %s  %s  %s",
+		labelStyle.Render(label),
+		barStr,
+		pctStr,
+		countdown,
+	)
+}
+
+func formatCountdown(d time.Duration) string {
+	if d <= 0 {
+		return "resets now"
+	}
+	if d >= 24*time.Hour {
+		days := int(d / (24 * time.Hour))
+		hours := int((d % (24 * time.Hour)) / time.Hour)
+		return fmt.Sprintf("resets in %dd %dh", days, hours)
+	}
+	hours := int(d / time.Hour)
+	minutes := int((d % time.Hour) / time.Minute)
+	return fmt.Sprintf("resets in %dh %dm", hours, minutes)
+}
+
 func (m Model) Sessions() map[string]session.Session {
 	return m.sessions
 }
@@ -115,9 +193,18 @@ func (m Model) Err() error {
 	return m.err
 }
 
+func (m Model) RateLimits() ratelimits.RateLimits {
+	return m.rateLimits
+}
+
 type sessionsMsg struct {
 	sessions map[string]session.Session
 	err      error
+}
+
+type rateLimitsMsg struct {
+	rl  ratelimits.RateLimits
+	err error
 }
 
 func loadSessions(path string) tea.Cmd {
@@ -127,6 +214,16 @@ func loadSessions(path string) tea.Cmd {
 			return sessionsMsg{err: err}
 		}
 		return sessionsMsg{sessions: session.FilterLive(sessions)}
+	}
+}
+
+func loadRateLimits(path string) tea.Cmd {
+	return func() tea.Msg {
+		rl, err := ratelimits.ReadRateLimits(path)
+		if err != nil {
+			return rateLimitsMsg{err: err}
+		}
+		return rateLimitsMsg{rl: rl}
 	}
 }
 

--- a/productivity-tui/internal/app/app.go
+++ b/productivity-tui/internal/app/app.go
@@ -139,7 +139,7 @@ func (m Model) View() string {
 
 // renderRateLimitRow renders a single rate-limit row across two lines:
 //
-//	  5h  ████▌                       18%
+//	  5h  ████▌                       17%
 //	        resets in 0h 32m
 func renderRateLimitRow(label string, w *ratelimits.Window, now time.Time) string {
 	pct := w.UsedPercentage
@@ -163,7 +163,7 @@ func renderRateLimitRow(label string, w *ratelimits.Window, now time.Time) strin
 	emptyCount := 28 - full - half
 	barStr := activeStyle.Render(filledStr) + strings.Repeat(" ", emptyCount)
 
-	pctStr := fmt.Sprintf("%3d%%", w.UsedPercentage)
+	pctStr := fmt.Sprintf("%3d%%", pct)
 
 	countdown := formatCountdown(w.ResetIn(now))
 

--- a/productivity-tui/internal/app/app.go
+++ b/productivity-tui/internal/app/app.go
@@ -97,6 +97,9 @@ func (m Model) View() string {
 			b.WriteString(renderRateLimitRow("5h", m.rateLimits.FiveHour, now))
 			b.WriteString("\n")
 		}
+		if m.rateLimits.FiveHour != nil && m.rateLimits.SevenDay != nil {
+			b.WriteString("\n")
+		}
 		if m.rateLimits.SevenDay != nil {
 			b.WriteString(renderRateLimitRow("7d", m.rateLimits.SevenDay, now))
 			b.WriteString("\n")
@@ -134,9 +137,10 @@ func (m Model) View() string {
 	return b.String()
 }
 
-// renderRateLimitRow renders a single rate-limit row:
+// renderRateLimitRow renders a single rate-limit row across two lines:
 //
-//	  5h  ████▌                       18%  resets in 0h 32m
+//	  5h  ████▌                       18%
+//	        resets in 0h 32m
 func renderRateLimitRow(label string, w *ratelimits.Window, now time.Time) string {
 	pct := w.UsedPercentage
 	if pct < 0 {
@@ -163,7 +167,7 @@ func renderRateLimitRow(label string, w *ratelimits.Window, now time.Time) strin
 
 	countdown := formatCountdown(w.ResetIn(now))
 
-	return fmt.Sprintf("  %s  %s  %s  %s",
+	return fmt.Sprintf("  %s  %s  %s\n        %s",
 		labelStyle.Render(label),
 		barStr,
 		pctStr,

--- a/productivity-tui/internal/app/app_test.go
+++ b/productivity-tui/internal/app/app_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +13,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/natb1/commons.systems/productivity-tui/internal/ratelimits"
 	"github.com/natb1/commons.systems/productivity-tui/internal/session"
 )
 
@@ -19,7 +21,7 @@ import (
 const mismatchedStart = "Thu Jan  1 00:00:00 1970"
 
 func TestQuitKeyQ(t *testing.T) {
-	m := New("/dev/null")
+	m := New("/dev/null", "/dev/null")
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
 	if cmd == nil {
 		t.Error("expected quit command for 'q' key")
@@ -27,7 +29,7 @@ func TestQuitKeyQ(t *testing.T) {
 }
 
 func TestQuitKeyCtrlC(t *testing.T) {
-	m := New("/dev/null")
+	m := New("/dev/null", "/dev/null")
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 	if cmd == nil {
 		t.Error("expected quit command for ctrl+c")
@@ -35,14 +37,14 @@ func TestQuitKeyCtrlC(t *testing.T) {
 }
 
 func TestInitialState(t *testing.T) {
-	m := New("/dev/null")
+	m := New("/dev/null", "/dev/null")
 	if len(m.Sessions()) != 0 {
 		t.Errorf("expected empty sessions, got %d", len(m.Sessions()))
 	}
 }
 
 func TestWindowSizeUpdate(t *testing.T) {
-	m := New("/dev/null")
+	m := New("/dev/null", "/dev/null")
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	model := updated.(Model)
 	if model.width != 80 || model.height != 24 {
@@ -51,7 +53,7 @@ func TestWindowSizeUpdate(t *testing.T) {
 }
 
 func TestSessionsMsg(t *testing.T) {
-	m := New("/dev/null")
+	m := New("/dev/null", "/dev/null")
 	sessions := map[string]session.Session{
 		"sess_1": {WorkingDir: "/tmp/a", Idle: false, LastActivity: time.Now()},
 		"sess_2": {WorkingDir: "/tmp/b", Idle: true, LastActivity: time.Now()},
@@ -64,7 +66,7 @@ func TestSessionsMsg(t *testing.T) {
 }
 
 func TestViewIdleIndicator(t *testing.T) {
-	m := New("/dev/null")
+	m := New("/dev/null", "/dev/null")
 	m.width = 80
 	m.height = 24
 	m.sessions = map[string]session.Session{
@@ -84,7 +86,7 @@ func TestViewIdleIndicator(t *testing.T) {
 }
 
 func TestViewEmptySessions(t *testing.T) {
-	m := New("/dev/null")
+	m := New("/dev/null", "/dev/null")
 	m.width = 80
 	output := m.View()
 	if !strings.Contains(output, "No active sessions") {
@@ -151,9 +153,120 @@ func TestTickReloadsSessions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := New(path)
+	m := New(path, "/dev/null")
 	_, cmd := m.Update(tickMsg(time.Now()))
 	if cmd == nil {
 		t.Error("expected batch command from tick")
+	}
+}
+
+// --- Rate-limits header tests ---
+
+func TestViewRateLimitsHeader_BothWindows(t *testing.T) {
+	m := New("/dev/null", "/dev/null")
+	m.width = 80
+	future := time.Now().Add(32 * time.Minute).Unix()
+	m.rateLimits = ratelimits.RateLimits{
+		FiveHour: &ratelimits.Window{UsedPercentage: 5, ResetsAt: future},
+		SevenDay: &ratelimits.Window{UsedPercentage: 1, ResetsAt: future},
+	}
+	output := m.View()
+	if !strings.Contains(output, "5h") {
+		t.Error("expected '5h' label in output")
+	}
+	if !strings.Contains(output, "7d") {
+		t.Error("expected '7d' label in output")
+	}
+	if !strings.Contains(output, "5%") {
+		t.Error("expected '5%' in output")
+	}
+	if !strings.Contains(output, "resets in") {
+		t.Error("expected 'resets in' countdown in output")
+	}
+}
+
+func TestViewRateLimitsHeader_FiveHourOnly(t *testing.T) {
+	m := New("/dev/null", "/dev/null")
+	m.width = 80
+	future := time.Now().Add(1 * time.Hour).Unix()
+	m.rateLimits = ratelimits.RateLimits{
+		FiveHour: &ratelimits.Window{UsedPercentage: 18, ResetsAt: future},
+	}
+	output := m.View()
+	if !strings.Contains(output, "5h") {
+		t.Error("expected '5h' label in output")
+	}
+	if strings.Contains(output, "7d") {
+		t.Error("expected '7d' to be absent when SevenDay is nil")
+	}
+}
+
+func TestViewRateLimitsHeader_OmittedWhenAbsent(t *testing.T) {
+	m := New("/dev/null", "/dev/null")
+	m.width = 80
+	// Both windows nil (zero value) — header must be omitted.
+	output := m.View()
+	// Verify no header rows: neither label should appear.
+	// Use a check that won't false-positive on countdown text (which uses 'h' and 'd').
+	if strings.Contains(output, "  5h  ") {
+		t.Error("expected no 5h row when FiveHour is nil")
+	}
+	if strings.Contains(output, "  7d  ") {
+		t.Error("expected no 7d row when SevenDay is nil")
+	}
+}
+
+func TestViewRateLimitsHeader_ResetsNow(t *testing.T) {
+	m := New("/dev/null", "/dev/null")
+	m.width = 80
+	// Timestamp in the past → resets now.
+	m.rateLimits = ratelimits.RateLimits{
+		FiveHour: &ratelimits.Window{UsedPercentage: 50, ResetsAt: 1},
+	}
+	output := m.View()
+	if !strings.Contains(output, "resets now") {
+		t.Error("expected 'resets now' for past ResetsAt timestamp")
+	}
+}
+
+func TestViewRateLimitsHeader_OmittedOnError(t *testing.T) {
+	m := New("/dev/null", "/dev/null")
+	m.width = 80
+	m.rateLimitsErr = errors.New("boom")
+	// Set windows too — they should be ignored when err is set.
+	m.rateLimits = ratelimits.RateLimits{
+		FiveHour: &ratelimits.Window{UsedPercentage: 50, ResetsAt: time.Now().Add(time.Hour).Unix()},
+	}
+	output := m.View()
+	if strings.Contains(output, "  5h  ") {
+		t.Error("expected header to be omitted when rateLimitsErr is set")
+	}
+}
+
+func TestLoadRateLimitsMissingFile(t *testing.T) {
+	msg := loadRateLimits("/nonexistent/path/rate_limits.json")()
+	rlMsg, ok := msg.(rateLimitsMsg)
+	if !ok {
+		t.Fatalf("expected rateLimitsMsg, got %T", msg)
+	}
+	if rlMsg.err != nil {
+		t.Errorf("expected no error for missing file, got: %v", rlMsg.err)
+	}
+	if rlMsg.rl.FiveHour != nil || rlMsg.rl.SevenDay != nil {
+		t.Error("expected zero-value RateLimits for missing file")
+	}
+}
+
+func TestLoadRateLimitsMessageDispatch(t *testing.T) {
+	m := New("/dev/null", "/dev/null")
+	fiveHour := &ratelimits.Window{UsedPercentage: 42, ResetsAt: time.Now().Add(time.Hour).Unix()}
+	updated, _ := m.Update(rateLimitsMsg{rl: ratelimits.RateLimits{FiveHour: fiveHour}})
+	model := updated.(Model)
+	rl := model.RateLimits()
+	if rl.FiveHour == nil {
+		t.Fatal("expected FiveHour to be set after rateLimitsMsg dispatch")
+	}
+	if rl.FiveHour.UsedPercentage != 42 {
+		t.Errorf("expected UsedPercentage 42, got %d", rl.FiveHour.UsedPercentage)
 	}
 }

--- a/productivity-tui/internal/app/app_test.go
+++ b/productivity-tui/internal/app/app_test.go
@@ -243,6 +243,40 @@ func TestViewRateLimitsHeader_OmittedOnError(t *testing.T) {
 	}
 }
 
+func TestViewRateLimitsHeader_CountdownOnSecondLine(t *testing.T) {
+	m := New("/dev/null", "/dev/null")
+	m.width = 80
+	future := time.Now().Add(32 * time.Minute).Unix()
+	m.rateLimits = ratelimits.RateLimits{
+		FiveHour: &ratelimits.Window{UsedPercentage: 18, ResetsAt: future},
+	}
+	output := m.View()
+	lines := strings.Split(output, "\n")
+
+	var labelIdx = -1
+	for i, line := range lines {
+		if strings.Contains(line, "5h") {
+			labelIdx = i
+			break
+		}
+	}
+	if labelIdx == -1 {
+		t.Fatal("expected a line containing '5h'")
+	}
+	if !strings.Contains(lines[labelIdx], "%") {
+		t.Errorf("expected '%%' on the same line as '5h', got: %q", lines[labelIdx])
+	}
+	if strings.Contains(lines[labelIdx], "resets in") {
+		t.Errorf("expected 'resets in' NOT on the bar line, got: %q", lines[labelIdx])
+	}
+	if labelIdx+1 >= len(lines) {
+		t.Fatalf("expected a line after the bar line for the countdown")
+	}
+	if !strings.Contains(lines[labelIdx+1], "resets in") {
+		t.Errorf("expected 'resets in' on the line after the bar, got: %q", lines[labelIdx+1])
+	}
+}
+
 func TestLoadRateLimitsMissingFile(t *testing.T) {
 	msg := loadRateLimits("/nonexistent/path/rate_limits.json")()
 	rlMsg, ok := msg.(rateLimitsMsg)

--- a/productivity-tui/internal/ratelimits/ratelimits.go
+++ b/productivity-tui/internal/ratelimits/ratelimits.go
@@ -1,0 +1,56 @@
+package ratelimits
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type Window struct {
+	UsedPercentage int   `json:"used_percentage"`
+	ResetsAt       int64 `json:"resets_at"` // unix seconds
+}
+
+type RateLimits struct {
+	FiveHour *Window `json:"five_hour,omitempty"`
+	SevenDay *Window `json:"seven_day,omitempty"`
+}
+
+// StateFilePath returns the path to the rate limits state file.
+// Shell hooks in productivity-tui/hooks/ hardcode the same path independently.
+func StateFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".local", "share", "productivity-tui", "rate_limits.json"), nil
+}
+
+// ReadRateLimits reads the rate limits state file at path. Returns a zero-value
+// RateLimits if the file is missing or empty — this is the expected state before
+// any hook has written the file or when rate limits are unavailable.
+func ReadRateLimits(path string) (RateLimits, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return RateLimits{}, nil
+		}
+		return RateLimits{}, fmt.Errorf("reading rate limits file: %w", err)
+	}
+	if len(data) == 0 {
+		return RateLimits{}, nil
+	}
+	var rl RateLimits
+	if err := json.Unmarshal(data, &rl); err != nil {
+		return RateLimits{}, fmt.Errorf("parsing rate limits file: %w", err)
+	}
+	return rl, nil
+}
+
+// ResetIn returns the duration until this window resets relative to now.
+func (w *Window) ResetIn(now time.Time) time.Duration {
+	return time.Unix(w.ResetsAt, 0).Sub(now)
+}

--- a/productivity-tui/internal/ratelimits/ratelimits_test.go
+++ b/productivity-tui/internal/ratelimits/ratelimits_test.go
@@ -1,0 +1,132 @@
+package ratelimits
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestReadRateLimits_FullData(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rate_limits.json")
+	data := `{"five_hour": {"used_percentage": 5, "resets_at": 1746140400}, "seven_day": {"used_percentage": 1, "resets_at": 1746406800}}`
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rl, err := ReadRateLimits(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rl.FiveHour == nil {
+		t.Fatal("expected FiveHour to be non-nil")
+	}
+	if rl.SevenDay == nil {
+		t.Fatal("expected SevenDay to be non-nil")
+	}
+	if rl.FiveHour.UsedPercentage != 5 {
+		t.Errorf("expected FiveHour.UsedPercentage 5, got %d", rl.FiveHour.UsedPercentage)
+	}
+	if rl.FiveHour.ResetsAt != 1746140400 {
+		t.Errorf("expected FiveHour.ResetsAt 1746140400, got %d", rl.FiveHour.ResetsAt)
+	}
+	if rl.SevenDay.UsedPercentage != 1 {
+		t.Errorf("expected SevenDay.UsedPercentage 1, got %d", rl.SevenDay.UsedPercentage)
+	}
+	if rl.SevenDay.ResetsAt != 1746406800 {
+		t.Errorf("expected SevenDay.ResetsAt 1746406800, got %d", rl.SevenDay.ResetsAt)
+	}
+}
+
+func TestReadRateLimits_FiveHourOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rate_limits.json")
+	data := `{"five_hour": {"used_percentage": 42, "resets_at": 1746140400}}`
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rl, err := ReadRateLimits(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rl.FiveHour == nil {
+		t.Fatal("expected FiveHour to be non-nil")
+	}
+	if rl.SevenDay != nil {
+		t.Errorf("expected SevenDay to be nil, got %+v", rl.SevenDay)
+	}
+}
+
+func TestReadRateLimits_SevenDayOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rate_limits.json")
+	data := `{"seven_day": {"used_percentage": 17, "resets_at": 1746406800}}`
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rl, err := ReadRateLimits(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rl.FiveHour != nil {
+		t.Errorf("expected FiveHour to be nil, got %+v", rl.FiveHour)
+	}
+	if rl.SevenDay == nil {
+		t.Fatal("expected SevenDay to be non-nil")
+	}
+}
+
+func TestReadRateLimits_MissingFile(t *testing.T) {
+	rl, err := ReadRateLimits("/nonexistent/path/rate_limits.json")
+	if err != nil {
+		t.Fatalf("unexpected error for missing file: %v", err)
+	}
+	if rl.FiveHour != nil || rl.SevenDay != nil {
+		t.Errorf("expected zero value, got %+v", rl)
+	}
+}
+
+func TestReadRateLimits_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rate_limits.json")
+	if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rl, err := ReadRateLimits(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rl.FiveHour != nil || rl.SevenDay != nil {
+		t.Errorf("expected zero value, got %+v", rl)
+	}
+}
+
+func TestReadRateLimits_MalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rate_limits.json")
+	if err := os.WriteFile(path, []byte("{bad json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ReadRateLimits(path)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestWindow_ResetIn(t *testing.T) {
+	resetsAt := int64(1746140400)
+	w := &Window{UsedPercentage: 5, ResetsAt: resetsAt}
+
+	now := time.Unix(1746140400-1932, 0) // 32 minutes and 12 seconds before reset
+	got := w.ResetIn(now)
+	want := time.Duration(1932) * time.Second
+
+	if got != want {
+		t.Errorf("ResetIn returned %v, want %v", got, want)
+	}
+}

--- a/productivity-tui/main.go
+++ b/productivity-tui/main.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/natb1/commons.systems/productivity-tui/internal/app"
+	"github.com/natb1/commons.systems/productivity-tui/internal/ratelimits"
 	"github.com/natb1/commons.systems/productivity-tui/internal/session"
 )
 
@@ -38,7 +39,12 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	m := app.New(stateFile)
+	rateLimitsFile, err := ratelimits.StateFilePath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	m := app.New(stateFile, rateLimitsFile)
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)


### PR DESCRIPTION
Closes #568

## Summary

Adds a Claude Code statusLine hook that captures rate-limit windows from stdin JSON, plus a TUI header that renders progress bars + reset countdowns above the session list.

- New `productivity-tui/internal/ratelimits/` package — read-side of `~/.local/share/productivity-tui/rate_limits.json`.
- New `productivity-tui/hooks/update-rate-limits.sh` — atomic-write hook, no-op when `rate_limits` absent or all windows null. Prints `5h: N% · 7d: M%` summary line for `statusLine`.
- TUI loads rate limits each tick alongside sessions; header omitted entirely when no data or on read error.

## Test plan

- [x] `go test ./...` passes from `productivity-tui/`
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] Hook smoke-tested manually for 6 input shapes (both, single, absent, null, empty, all-null inner)
- [ ] CI checks pass on this PR