### PR TITLE
dispatch: reconcile remote state and pass resume hints to skill

### DIFF
--- a/.claude/skills/dispatch-implement/SKILL.md
+++ b/.claude/skills/dispatch-implement/SKILL.md
@@ -9,6 +9,10 @@ Invoked by `./dispatch/bin/dispatch <issue-num>` as the opening message. The dis
 
 **The main thread never edits files.** It plans, delegates implementation to subagents via the Agent tool, and forks `/commit-merge-push` after each unit. Every code change happens in a subagent.
 
+## Resume hints from the dispatcher
+
+The dispatcher may include a free-form resume instruction in the opening message after the slash command. When present, follow it: it names the step to start at and the already-completed work to assume. Skip earlier steps when the hint says they're done.
+
 ## Steps
 
 1. **Plan.** Before entering plan mode, seed the dispatcher state file if it does not yet exist — this is what the `SessionStart:clear` hook (`.claude/hooks/restore-dispatch-skill.sh`) watches for when the user accepts a plan and clears the context:

--- a/dispatch/bin/dispatch
+++ b/dispatch/bin/dispatch
@@ -35,6 +35,90 @@ make_slug() {
   printf '%s-%s\n' "$num" "$slug"
 }
 
+# --- diagnose_state ---------------------------------------------------------
+# Diagnose the worktree's resume mode against ground truth (open PR, commits
+# ahead of origin/main, merged PR). Echoes one of: fresh | audit-and-pr |
+# verify | done. For `done`, also echoes the PR number on a second line.
+# Args: $1 = branch, $2 = state file path (absolute), $3 = issue num
+diagnose_state() {
+  local branch="$1" state_file="$2" issue_num="$3"
+  local pr_json pr_state pr_number stderr_file rc commits_ahead
+
+  git fetch --quiet origin main 2>/dev/null || \
+    echo "[dispatch] warning: git fetch origin main failed; using local refs" >&2
+
+  stderr_file=$(mktemp)
+  set +e
+  pr_json=$(gh pr view "$branch" --json number,state 2>"$stderr_file")
+  rc=$?
+  set -e
+  if [[ $rc -ne 0 ]]; then
+    if grep -q "no pull requests found" "$stderr_file"; then
+      rm -f "$stderr_file"
+      commits_ahead=$(git rev-list --count origin/main..HEAD)
+      if [[ "$commits_ahead" -eq 0 ]]; then
+        echo "fresh"
+      else
+        echo "audit-and-pr"
+      fi
+      return 0
+    fi
+    cat "$stderr_file" >&2
+    rm -f "$stderr_file"
+    return 1
+  fi
+  rm -f "$stderr_file"
+
+  pr_state=$(jq -r '.state' <<<"$pr_json")
+  pr_number=$(jq -r '.number' <<<"$pr_json")
+  if [[ "$pr_state" == "MERGED" ]]; then
+    echo "done"
+    echo "$pr_number"
+  else
+    echo "verify"
+  fi
+  return 0
+}
+
+# --- reconcile_phase_signal -------------------------------------------------
+# Drop a stale phase_signal so the watcher doesn't fire at launch.
+# Args: $1 = scope (local-only | both), $2 = state file path (absolute),
+#       $3 = issue number (defaults to $DISPATCH_ISSUE_NUM)
+reconcile_phase_signal() {
+  local scope="$1" state_file="$2"
+  local issue_num="${3:-${DISPATCH_ISSUE_NUM:-}}"
+  local tmp_file repo_root read_script write_script remote_json rc
+
+  if [[ "$scope" == "local-only" ]]; then
+    if [[ -f "$state_file" ]] && jq -e '.state.phase_signal' "$state_file" >/dev/null 2>&1; then
+      tmp_file=$(mktemp)
+      jq 'if .state then .state |= del(.phase_signal) else . end' "$state_file" >"$tmp_file"
+      mv "$tmp_file" "$state_file"
+    fi
+    return 0
+  fi
+
+  if [[ "$scope" == "both" ]]; then
+    repo_root="$(git rev-parse --show-toplevel)"
+    read_script="$repo_root/.claude/skills/ref-pr-workflow/scripts/issue-state-read"
+    write_script="$repo_root/.claude/skills/ref-pr-workflow/scripts/issue-state-write"
+    set +e
+    remote_json=$("$read_script" "$issue_num" 2>/dev/null)
+    rc=$?
+    set -e
+    if [[ $rc -ne 0 ]]; then
+      reconcile_phase_signal local-only "$state_file" "$issue_num"
+      return 0
+    fi
+    remote_json=$(jq 'del(.phase_signal)' <<<"$remote_json")
+    "$write_script" "$issue_num" <<<"$remote_json"
+    return 0
+  fi
+
+  echo "error: reconcile_phase_signal: unknown scope '$scope'" >&2
+  return 1
+}
+
 # --- main -------------------------------------------------------------------
 main() {
   local ISSUE_NUM="${1:-}"
@@ -73,6 +157,38 @@ main() {
   PROJECT_ROOT="$(dirname "$GIT_COMMON_DIR")"
   WORKTREE_PATH="$PROJECT_ROOT/worktrees/$BRANCH"
   STATE_FILE="$WORKTREE_PATH/tmp/dispatch-${ISSUE_NUM}.json"
+
+  # Diagnose worktree state against ground truth (PR existence, commits ahead,
+  # PR merge status). Reconcile stale phase_signal in local cache + Firestore
+  # when needed, and select a resume instruction to pass to the skill.
+  local DIAGNOSIS MODE PR_NUM="" RESUME_INSTRUCTION=""
+  DIAGNOSIS=$(diagnose_state "$BRANCH" "$STATE_FILE" "$ISSUE_NUM") || {
+    echo "error: diagnose_state failed" >&2
+    exit 1
+  }
+  MODE=$(printf '%s\n' "$DIAGNOSIS" | head -n1)
+  PR_NUM=$(printf '%s\n' "$DIAGNOSIS" | sed -n '2p')
+  case "$MODE" in
+    fresh)
+      reconcile_phase_signal local-only "$STATE_FILE" "$ISSUE_NUM"
+      ;;
+    audit-and-pr)
+      reconcile_phase_signal both "$STATE_FILE" "$ISSUE_NUM"
+      RESUME_INSTRUCTION="Audit the diff against acceptance criteria; fix any gaps; then proceed to Step 2.5 to create the PR."
+      ;;
+    verify)
+      reconcile_phase_signal both "$STATE_FILE" "$ISSUE_NUM"
+      RESUME_INSTRUCTION="An open PR exists for this branch. Skip planning and Step 2; resume at Step 2.5.2 (monitor checks). If all green, run phase-complete."
+      ;;
+    done)
+      echo "[dispatch] issue #${ISSUE_NUM} already shipped via PR #${PR_NUM}" >&2
+      exit 0
+      ;;
+    *)
+      echo "error: diagnose_state returned unexpected mode: '$MODE'" >&2
+      exit 1
+      ;;
+  esac
 
   # Export handoff env for the Claude session and phase skills.
   # STATE_FILE is absolute (used by the watcher here); DISPATCH_STATE_FILE is
@@ -122,7 +238,9 @@ main() {
   # no backgrounding, no stdin redirection, full interactive access.
   local CLAUDE_ARGS=(-w "$BRANCH")
   [[ -n "$MODEL" ]] && CLAUDE_ARGS+=(--model "$MODEL")
-  CLAUDE_ARGS+=("/dispatch-implement #${ISSUE_NUM}")
+  CLAUDE_ARGS+=("/dispatch-implement #${ISSUE_NUM}${RESUME_INSTRUCTION:+
+
+${RESUME_INSTRUCTION}}")
   echo "[dispatch] launching claude -w $BRANCH${MODEL:+ --model $MODEL}..." >&2
   exec claude "${CLAUDE_ARGS[@]}"
 }

--- a/dispatch/bin/dispatch
+++ b/dispatch/bin/dispatch
@@ -39,24 +39,21 @@ make_slug() {
 # Diagnose the worktree's resume mode against ground truth (open PR, commits
 # ahead of origin/main, merged PR). Echoes one of: fresh | audit-and-pr |
 # verify | done. For `done`, also echoes the PR number on a second line.
-# Args: $1 = branch, $2 = state file path (absolute), $3 = issue num
+# Args: $1 = branch
 diagnose_state() {
-  local branch="$1" state_file="$2" issue_num="$3"
-  local pr_json pr_state pr_number stderr_file rc commits_ahead
+  local branch="$1"
+  local gh_output pr_state pr_number rc commits_ahead
 
   git fetch --quiet origin main 2>/dev/null || \
     echo "[dispatch] warning: git fetch origin main failed; using local refs" >&2
 
-  stderr_file=$(mktemp)
   set +e
-  pr_json=$(gh pr view "$branch" --json number,state 2>"$stderr_file")
+  gh_output=$(gh pr view "$branch" --json number,state 2>&1)
   rc=$?
   set -e
 
   if [[ $rc -eq 0 ]]; then
-    rm -f "$stderr_file"
-    pr_state=$(jq -r '.state' <<<"$pr_json")
-    pr_number=$(jq -r '.number' <<<"$pr_json")
+    { read -r pr_state; read -r pr_number; } < <(jq -r '.state, .number' <<<"$gh_output")
     case "$pr_state" in
       MERGED)
         echo "done"
@@ -76,31 +73,21 @@ diagnose_state() {
         return 1
         ;;
     esac
-  elif grep -q "no pull requests found" "$stderr_file"; then
-    rm -f "$stderr_file"
-  else
-    cat "$stderr_file" >&2
-    rm -f "$stderr_file"
+  elif [[ "$gh_output" != *"no pull requests found"* ]]; then
+    echo "$gh_output" >&2
     return 1
   fi
 
-  # Count commits ahead on the branch ref. dispatch typically runs from the
-  # project root (it's on devShell PATH), so HEAD points at main; we must
-  # use the branch ref explicitly. The ref is shared across worktrees, so
-  # this resolves correctly without cd-ing into the worktree. On a truly
-  # fresh issue the local branch ref doesn't exist yet → 0 commits ahead.
-  if git show-ref --verify --quiet "refs/heads/$branch"; then
-    commits_ahead=$(git rev-list --count "origin/main..$branch")
-  else
-    commits_ahead=0
-  fi
+  # dispatch runs from the project root with HEAD on main, so we use the
+  # branch ref explicitly. On a truly fresh issue the ref doesn't exist yet
+  # — rev-list errors silently → 0.
+  commits_ahead=$(git rev-list --count "origin/main..$branch" 2>/dev/null || echo 0)
 
   if [[ "$commits_ahead" -eq 0 ]]; then
     echo "fresh"
   else
     echo "audit-and-pr"
   fi
-  return 0
 }
 
 # --- reconcile_phase_signal -------------------------------------------------
@@ -189,7 +176,7 @@ main() {
   # PR merge status). Reconcile stale phase_signal in local cache + Firestore
   # when needed, and select a resume instruction to pass to the skill.
   local DIAGNOSIS MODE PR_NUM="" RESUME_INSTRUCTION=""
-  DIAGNOSIS=$(diagnose_state "$BRANCH" "$STATE_FILE" "$ISSUE_NUM") || {
+  DIAGNOSIS=$(diagnose_state "$BRANCH") || {
     echo "error: diagnose_state failed" >&2
     exit 1
   }

--- a/dispatch/bin/dispatch
+++ b/dispatch/bin/dispatch
@@ -70,7 +70,6 @@ diagnose_state() {
       CLOSED)
         # Closed-not-merged PR: user abandoned this PR. Fall through to the
         # no-PR logic below — fresh or audit-and-pr based on commits ahead.
-        # The skill's Step 2.5.1 will create a new PR.
         ;;
       *)
         echo "error: gh pr view returned unexpected state: '$pr_state'" >&2
@@ -194,8 +193,7 @@ main() {
     echo "error: diagnose_state failed" >&2
     exit 1
   }
-  MODE=$(printf '%s\n' "$DIAGNOSIS" | head -n1)
-  PR_NUM=$(printf '%s\n' "$DIAGNOSIS" | sed -n '2p')
+  { read -r MODE; read -r PR_NUM || PR_NUM=""; } <<<"$DIAGNOSIS"
   case "$MODE" in
     fresh)
       reconcile_phase_signal local-only "$STATE_FILE" "$ISSUE_NUM"

--- a/dispatch/bin/dispatch
+++ b/dispatch/bin/dispatch
@@ -52,30 +52,54 @@ diagnose_state() {
   pr_json=$(gh pr view "$branch" --json number,state 2>"$stderr_file")
   rc=$?
   set -e
-  if [[ $rc -ne 0 ]]; then
-    if grep -q "no pull requests found" "$stderr_file"; then
-      rm -f "$stderr_file"
-      commits_ahead=$(git rev-list --count origin/main..HEAD)
-      if [[ "$commits_ahead" -eq 0 ]]; then
-        echo "fresh"
-      else
-        echo "audit-and-pr"
-      fi
-      return 0
-    fi
+
+  if [[ $rc -eq 0 ]]; then
+    rm -f "$stderr_file"
+    pr_state=$(jq -r '.state' <<<"$pr_json")
+    pr_number=$(jq -r '.number' <<<"$pr_json")
+    case "$pr_state" in
+      MERGED)
+        echo "done"
+        echo "$pr_number"
+        return 0
+        ;;
+      OPEN)
+        echo "verify"
+        return 0
+        ;;
+      CLOSED)
+        # Closed-not-merged PR: user abandoned this PR. Fall through to the
+        # no-PR logic below — fresh or audit-and-pr based on commits ahead.
+        # The skill's Step 2.5.1 will create a new PR.
+        ;;
+      *)
+        echo "error: gh pr view returned unexpected state: '$pr_state'" >&2
+        return 1
+        ;;
+    esac
+  elif grep -q "no pull requests found" "$stderr_file"; then
+    rm -f "$stderr_file"
+  else
     cat "$stderr_file" >&2
     rm -f "$stderr_file"
     return 1
   fi
-  rm -f "$stderr_file"
 
-  pr_state=$(jq -r '.state' <<<"$pr_json")
-  pr_number=$(jq -r '.number' <<<"$pr_json")
-  if [[ "$pr_state" == "MERGED" ]]; then
-    echo "done"
-    echo "$pr_number"
+  # Count commits ahead on the branch ref. dispatch typically runs from the
+  # project root (it's on devShell PATH), so HEAD points at main; we must
+  # use the branch ref explicitly. The ref is shared across worktrees, so
+  # this resolves correctly without cd-ing into the worktree. On a truly
+  # fresh issue the local branch ref doesn't exist yet → 0 commits ahead.
+  if git show-ref --verify --quiet "refs/heads/$branch"; then
+    commits_ahead=$(git rev-list --count "origin/main..$branch")
   else
-    echo "verify"
+    commits_ahead=0
+  fi
+
+  if [[ "$commits_ahead" -eq 0 ]]; then
+    echo "fresh"
+  else
+    echo "audit-and-pr"
   fi
   return 0
 }
@@ -112,6 +136,10 @@ reconcile_phase_signal() {
     fi
     remote_json=$(jq 'del(.phase_signal)' <<<"$remote_json")
     "$write_script" "$issue_num" <<<"$remote_json"
+    # issue-state-write mirrors only into the cache resolved via its CWD's
+    # git toplevel (the project root), not the worktree. Clear the worktree
+    # state file directly so the watcher doesn't fire on stale local state.
+    reconcile_phase_signal local-only "$state_file" "$issue_num"
     return 0
   fi
 

--- a/dispatch/test/test-diagnose.sh
+++ b/dispatch/test/test-diagnose.sh
@@ -59,6 +59,10 @@ case "${STUB_GH_OUTCOME:-}" in
     printf '{"number":99,"state":"MERGED"}\n'
     exit 0
     ;;
+  closed-pr)
+    printf '{"number":7,"state":"CLOSED"}\n'
+    exit 0
+    ;;
   auth-error)
     echo "authentication required" >&2
     exit 1
@@ -75,12 +79,18 @@ GHSTUB
 
 # Initialize a fresh git repo in $1 with one commit on `main`. Sets up a
 # bare clone at $1.git as `origin`, so `git fetch origin main` works.
-# Optional: `local_extra_commits` env var (default 0) adds N additional
-# commits on top of `main` AFTER the bare clone is created — these end up
-# ahead of origin/main.
+# Args:
+#   $1 (repo): repo path
+#   $2 (extra): N additional commits beyond the initial one (default 0)
+#   $3 (extra_branch): branch the extras live on (default "main"); when
+#     non-main, the branch is created from main, the extras are added to
+#     it, and the worktree is checked back out to main afterwards. This
+#     simulates the production case where dispatch runs from the project
+#     root with HEAD on main while the issue branch has unmerged commits.
 init_test_repo() {
   local repo="$1"
   local extra="${2:-0}"
+  local extra_branch="${3:-main}"
 
   mkdir -p "$repo"
   (
@@ -106,12 +116,18 @@ init_test_repo() {
   if [[ "$extra" -gt 0 ]]; then
     (
       cd "$repo"
+      if [[ "$extra_branch" != "main" ]]; then
+        git checkout --quiet -b "$extra_branch"
+      fi
       local i
       for ((i = 1; i <= extra; i++)); do
         echo "extra-$i" >>file.txt
         git add file.txt
         git commit --quiet -m "extra commit $i"
       done
+      if [[ "$extra_branch" != "main" ]]; then
+        git checkout --quiet main
+      fi
     )
   fi
 }
@@ -183,9 +199,15 @@ PATH="$ORIGINAL_PATH"
 rm -rf "$TEST_ROOT" "$STUB_DIR"
 
 # --- case 2: audit-and-pr + reconcile both ---------------------------------
+# HEAD is on `main` (in sync with origin/main); the issue branch has commits
+# ahead. This mirrors production, where dispatch runs from the project root
+# rather than inside the worktree. STUB_LOCAL_CACHE_FILE is set to a path
+# distinct from STATE_FILE so the test exercises the dispatcher's direct
+# clear of $state_file (issue-state-write's CWD-relative mirror would land
+# on the wrong file in production).
 TEST_ROOT=$(mktemp -d)
 REPO="$TEST_ROOT/repo"
-init_test_repo "$REPO" 1
+init_test_repo "$REPO" 1 "stub-branch"
 install_state_stubs "$REPO"
 STUB_DIR=$(make_gh_stub_dir)
 PATH="$STUB_DIR:$ORIGINAL_PATH"
@@ -194,20 +216,22 @@ STATE_FILE="$REPO/state.json"
 echo '{"state":{"phase_signal":"complete"}}' >"$STATE_FILE"
 export STUB_FIRESTORE_FILE="$TEST_ROOT/firestore.json"
 echo '{"phase_signal":"complete"}' >"$STUB_FIRESTORE_FILE"
-export STUB_LOCAL_CACHE_FILE="$STATE_FILE"
+# Distinct path: simulates issue-state-write resolving REPO_ROOT to a
+# directory whose tmp/ does not contain the worktree's state file.
+export STUB_LOCAL_CACHE_FILE="$TEST_ROOT/wrong-cache.json"
 
 pushd "$REPO" >/dev/null
 ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || true)
-assert_eq "audit-and-pr: 1 commit ahead, no PR -> 'audit-and-pr'" "audit-and-pr" "$ACTUAL"
+assert_eq "audit-and-pr: HEAD on main, branch 1 commit ahead, no PR -> 'audit-and-pr'" "audit-and-pr" "$ACTUAL"
 
 reconcile_phase_signal both "$STATE_FILE" "569"
 popd >/dev/null
 
 # Local cache: phase_signal removed; .state still present.
 LOCAL_HAS_SIGNAL=$(jq 'has("state") and (.state | has("phase_signal"))' "$STATE_FILE")
-assert_eq "audit-and-pr: local cache phase_signal removed" "false" "$LOCAL_HAS_SIGNAL"
+assert_eq "audit-and-pr: worktree state_file phase_signal removed" "false" "$LOCAL_HAS_SIGNAL"
 LOCAL_HAS_STATE=$(jq 'has("state")' "$STATE_FILE")
-assert_eq "audit-and-pr: local cache .state preserved" "true" "$LOCAL_HAS_STATE"
+assert_eq "audit-and-pr: worktree state_file .state preserved" "true" "$LOCAL_HAS_STATE"
 
 # Firestore fixture: phase_signal removed.
 REMOTE_HAS_SIGNAL=$(jq 'has("phase_signal")' "$STUB_FIRESTORE_FILE")
@@ -220,7 +244,7 @@ rm -rf "$TEST_ROOT" "$STUB_DIR"
 # --- case 3: verify --------------------------------------------------------
 TEST_ROOT=$(mktemp -d)
 REPO="$TEST_ROOT/repo"
-init_test_repo "$REPO" 1
+init_test_repo "$REPO" 1 "stub-branch"
 STUB_DIR=$(make_gh_stub_dir)
 PATH="$STUB_DIR:$ORIGINAL_PATH"
 export STUB_GH_OUTCOME=open-pr
@@ -272,7 +296,42 @@ unset STUB_GH_OUTCOME
 PATH="$ORIGINAL_PATH"
 rm -rf "$TEST_ROOT" "$STUB_DIR"
 
-# --- case 6: reconcile local-only is no-op when key absent ----------------
+# --- case 6a: closed PR + 0 commits ahead -> 'fresh' -----------------------
+# `gh pr view` returns the most recent PR for a branch regardless of state.
+# A CLOSED (non-merged) PR must NOT route to verify — that would let the
+# skill mark the issue done off stale checks on an abandoned PR.
+TEST_ROOT=$(mktemp -d)
+REPO="$TEST_ROOT/repo"
+init_test_repo "$REPO" 0
+STUB_DIR=$(make_gh_stub_dir)
+PATH="$STUB_DIR:$ORIGINAL_PATH"
+export STUB_GH_OUTCOME=closed-pr
+pushd "$REPO" >/dev/null
+STATE_FILE="$REPO/state.json"
+ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || true)
+popd >/dev/null
+assert_eq "closed PR + 0 commits ahead -> 'fresh'" "fresh" "$ACTUAL"
+unset STUB_GH_OUTCOME
+PATH="$ORIGINAL_PATH"
+rm -rf "$TEST_ROOT" "$STUB_DIR"
+
+# --- case 6b: closed PR + commits ahead -> 'audit-and-pr' ------------------
+TEST_ROOT=$(mktemp -d)
+REPO="$TEST_ROOT/repo"
+init_test_repo "$REPO" 1 "stub-branch"
+STUB_DIR=$(make_gh_stub_dir)
+PATH="$STUB_DIR:$ORIGINAL_PATH"
+export STUB_GH_OUTCOME=closed-pr
+pushd "$REPO" >/dev/null
+STATE_FILE="$REPO/state.json"
+ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || true)
+popd >/dev/null
+assert_eq "closed PR + 1 commit ahead -> 'audit-and-pr'" "audit-and-pr" "$ACTUAL"
+unset STUB_GH_OUTCOME
+PATH="$ORIGINAL_PATH"
+rm -rf "$TEST_ROOT" "$STUB_DIR"
+
+# --- case 7: reconcile local-only is no-op when key absent ----------------
 TEST_ROOT=$(mktemp -d)
 STATE_FILE="$TEST_ROOT/state.json"
 ORIGINAL_CONTENT='{"state":{"other":"value"}}'

--- a/dispatch/test/test-diagnose.sh
+++ b/dispatch/test/test-diagnose.sh
@@ -191,7 +191,7 @@ PATH="$STUB_DIR:$ORIGINAL_PATH"
 export STUB_GH_OUTCOME=no-pr
 pushd "$REPO" >/dev/null
 STATE_FILE="$REPO/state.json"
-ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || true)
+ACTUAL=$(diagnose_state "stub-branch" 2>/dev/null || true)
 popd >/dev/null
 assert_eq "fresh: 0 commits ahead, no PR -> 'fresh'" "fresh" "$ACTUAL"
 unset STUB_GH_OUTCOME
@@ -221,7 +221,7 @@ echo '{"phase_signal":"complete"}' >"$STUB_FIRESTORE_FILE"
 export STUB_LOCAL_CACHE_FILE="$TEST_ROOT/wrong-cache.json"
 
 pushd "$REPO" >/dev/null
-ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || true)
+ACTUAL=$(diagnose_state "stub-branch" 2>/dev/null || true)
 assert_eq "audit-and-pr: HEAD on main, branch 1 commit ahead, no PR -> 'audit-and-pr'" "audit-and-pr" "$ACTUAL"
 
 reconcile_phase_signal both "$STATE_FILE" "569"
@@ -250,7 +250,7 @@ PATH="$STUB_DIR:$ORIGINAL_PATH"
 export STUB_GH_OUTCOME=open-pr
 pushd "$REPO" >/dev/null
 STATE_FILE="$REPO/state.json"
-ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || true)
+ACTUAL=$(diagnose_state "stub-branch" 2>/dev/null || true)
 popd >/dev/null
 assert_eq "verify: open PR -> 'verify' (no second line)" "verify" "$ACTUAL"
 unset STUB_GH_OUTCOME
@@ -266,7 +266,7 @@ PATH="$STUB_DIR:$ORIGINAL_PATH"
 export STUB_GH_OUTCOME=merged-pr
 pushd "$REPO" >/dev/null
 STATE_FILE="$REPO/state.json"
-ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || true)
+ACTUAL=$(diagnose_state "stub-branch" 2>/dev/null || true)
 popd >/dev/null
 EXPECTED=$'done\n99'
 assert_eq "done: merged PR -> 'done' + PR number on second line" "$EXPECTED" "$ACTUAL"
@@ -288,8 +288,7 @@ PATH="$STUB_DIR:$ORIGINAL_PATH"
 export STUB_GH_OUTCOME=no-pr
 pushd "$REPO" >/dev/null
 STATE_FILE="$REPO/state.json"
-# Capture both stdout (mode) and ensure the function exits 0 despite fetch failure.
-ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || echo "FAILED")
+ACTUAL=$(diagnose_state "stub-branch" 2>/dev/null || echo "FAILED")
 popd >/dev/null
 assert_eq "fetch failure non-fatal: still returns 'fresh'" "fresh" "$ACTUAL"
 unset STUB_GH_OUTCOME
@@ -308,7 +307,7 @@ PATH="$STUB_DIR:$ORIGINAL_PATH"
 export STUB_GH_OUTCOME=closed-pr
 pushd "$REPO" >/dev/null
 STATE_FILE="$REPO/state.json"
-ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || true)
+ACTUAL=$(diagnose_state "stub-branch" 2>/dev/null || true)
 popd >/dev/null
 assert_eq "closed PR + 0 commits ahead -> 'fresh'" "fresh" "$ACTUAL"
 unset STUB_GH_OUTCOME
@@ -324,7 +323,7 @@ PATH="$STUB_DIR:$ORIGINAL_PATH"
 export STUB_GH_OUTCOME=closed-pr
 pushd "$REPO" >/dev/null
 STATE_FILE="$REPO/state.json"
-ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || true)
+ACTUAL=$(diagnose_state "stub-branch" 2>/dev/null || true)
 popd >/dev/null
 assert_eq "closed PR + 1 commit ahead -> 'audit-and-pr'" "audit-and-pr" "$ACTUAL"
 unset STUB_GH_OUTCOME

--- a/dispatch/test/test-diagnose.sh
+++ b/dispatch/test/test-diagnose.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# Unit tests for diagnose_state and reconcile_phase_signal in dispatch.
+#
+# These tests use PATH-injected stubs for `gh` and per-test temp git repos
+# (with a bare clone serving as `origin`) so they never touch the real
+# `gh`, real Firestore, or real `origin/main`. Stub `issue-state-read` /
+# `issue-state-write` scripts are placed under
+# `<temp-repo>/.claude/skills/ref-pr-workflow/scripts/` because
+# `reconcile_phase_signal` resolves them by absolute path via
+# `git rev-parse --show-toplevel` rather than via PATH lookup.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DISPATCH="$SCRIPT_DIR/../bin/dispatch"
+
+# shellcheck disable=SC1090
+source "$DISPATCH"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected: '$expected'"
+    echo "    actual:   '$actual'"
+  fi
+}
+
+# --- helpers ---------------------------------------------------------------
+
+# Create a stub directory with a `gh` script driven by STUB_GH_OUTCOME.
+# Echoes the stub directory path to stdout.
+make_gh_stub_dir() {
+  local stub_dir
+  stub_dir=$(mktemp -d)
+  cat >"$stub_dir/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+# Test stub for `gh`. Driven by STUB_GH_OUTCOME env var.
+# Recognized invocations: `gh pr view <branch> --json number,state`.
+case "${STUB_GH_OUTCOME:-}" in
+  no-pr)
+    # Mimic real gh's stderr message for missing PR.
+    echo 'no pull requests found for branch "stub-branch"' >&2
+    exit 1
+    ;;
+  open-pr)
+    printf '{"number":42,"state":"OPEN"}\n'
+    exit 0
+    ;;
+  merged-pr)
+    printf '{"number":99,"state":"MERGED"}\n'
+    exit 0
+    ;;
+  auth-error)
+    echo "authentication required" >&2
+    exit 1
+    ;;
+  *)
+    echo "stub gh: unknown STUB_GH_OUTCOME='${STUB_GH_OUTCOME:-}'" >&2
+    exit 2
+    ;;
+esac
+GHSTUB
+  chmod +x "$stub_dir/gh"
+  printf '%s\n' "$stub_dir"
+}
+
+# Initialize a fresh git repo in $1 with one commit on `main`. Sets up a
+# bare clone at $1.git as `origin`, so `git fetch origin main` works.
+# Optional: `local_extra_commits` env var (default 0) adds N additional
+# commits on top of `main` AFTER the bare clone is created — these end up
+# ahead of origin/main.
+init_test_repo() {
+  local repo="$1"
+  local extra="${2:-0}"
+
+  mkdir -p "$repo"
+  (
+    cd "$repo"
+    git init --quiet --initial-branch=main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    git config commit.gpgsign false
+    echo "initial" >file.txt
+    git add file.txt
+    git commit --quiet -m "initial"
+  )
+
+  # Create the bare clone serving as `origin`.
+  git clone --quiet --bare "$repo" "$repo.git" >/dev/null
+  (
+    cd "$repo"
+    git remote add origin "$repo.git"
+    git fetch --quiet origin main
+    git branch --quiet --set-upstream-to=origin/main main || true
+  )
+
+  if [[ "$extra" -gt 0 ]]; then
+    (
+      cd "$repo"
+      local i
+      for ((i = 1; i <= extra; i++)); do
+        echo "extra-$i" >>file.txt
+        git add file.txt
+        git commit --quiet -m "extra commit $i"
+      done
+    )
+  fi
+}
+
+# Set up stub `issue-state-read`/`issue-state-write` scripts inside
+# `<repo>/.claude/skills/ref-pr-workflow/scripts/`. They read/write a
+# fixture JSON file at $STUB_FIRESTORE_FILE.
+install_state_stubs() {
+  local repo="$1"
+  local scripts_dir="$repo/.claude/skills/ref-pr-workflow/scripts"
+  mkdir -p "$scripts_dir"
+
+  cat >"$scripts_dir/issue-state-read" <<'READSTUB'
+#!/usr/bin/env bash
+# Stub: print contents of $STUB_FIRESTORE_FILE, or fail if missing/unset.
+set -euo pipefail
+if [[ -z "${STUB_FIRESTORE_FILE:-}" || ! -f "$STUB_FIRESTORE_FILE" ]]; then
+  echo "stub issue-state-read: STUB_FIRESTORE_FILE missing" >&2
+  exit 1
+fi
+cat "$STUB_FIRESTORE_FILE"
+READSTUB
+  chmod +x "$scripts_dir/issue-state-read"
+
+  cat >"$scripts_dir/issue-state-write" <<'WRITESTUB'
+#!/usr/bin/env bash
+# Stub: read JSON from stdin, write to $STUB_FIRESTORE_FILE. Also mirror
+# the new state into $STUB_LOCAL_CACHE_FILE under a `.state` wrapper, to
+# mimic the real script's behavior of keeping the local cache in sync.
+set -euo pipefail
+if [[ -z "${STUB_FIRESTORE_FILE:-}" ]]; then
+  echo "stub issue-state-write: STUB_FIRESTORE_FILE unset" >&2
+  exit 1
+fi
+input=$(cat)
+printf '%s' "$input" >"$STUB_FIRESTORE_FILE"
+if [[ -n "${STUB_LOCAL_CACHE_FILE:-}" ]]; then
+  # Mirror the state into the local cache. If the cache exists, replace
+  # only the `.state` field; else seed a minimal wrapper.
+  if [[ -f "$STUB_LOCAL_CACHE_FILE" ]]; then
+    tmp=$(mktemp)
+    jq --argjson s "$input" '.state = $s' "$STUB_LOCAL_CACHE_FILE" >"$tmp"
+    mv "$tmp" "$STUB_LOCAL_CACHE_FILE"
+  else
+    jq -n --argjson s "$input" '{state: $s}' >"$STUB_LOCAL_CACHE_FILE"
+  fi
+fi
+WRITESTUB
+  chmod +x "$scripts_dir/issue-state-write"
+}
+
+# Save and restore PATH around tests.
+ORIGINAL_PATH="$PATH"
+
+# --- case 1: fresh ---------------------------------------------------------
+TEST_ROOT=$(mktemp -d)
+REPO="$TEST_ROOT/repo"
+init_test_repo "$REPO" 0
+STUB_DIR=$(make_gh_stub_dir)
+PATH="$STUB_DIR:$ORIGINAL_PATH"
+export STUB_GH_OUTCOME=no-pr
+pushd "$REPO" >/dev/null
+STATE_FILE="$REPO/state.json"
+ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || true)
+popd >/dev/null
+assert_eq "fresh: 0 commits ahead, no PR -> 'fresh'" "fresh" "$ACTUAL"
+unset STUB_GH_OUTCOME
+PATH="$ORIGINAL_PATH"
+rm -rf "$TEST_ROOT" "$STUB_DIR"
+
+# --- case 2: audit-and-pr + reconcile both ---------------------------------
+TEST_ROOT=$(mktemp -d)
+REPO="$TEST_ROOT/repo"
+init_test_repo "$REPO" 1
+install_state_stubs "$REPO"
+STUB_DIR=$(make_gh_stub_dir)
+PATH="$STUB_DIR:$ORIGINAL_PATH"
+export STUB_GH_OUTCOME=no-pr
+STATE_FILE="$REPO/state.json"
+echo '{"state":{"phase_signal":"complete"}}' >"$STATE_FILE"
+export STUB_FIRESTORE_FILE="$TEST_ROOT/firestore.json"
+echo '{"phase_signal":"complete"}' >"$STUB_FIRESTORE_FILE"
+export STUB_LOCAL_CACHE_FILE="$STATE_FILE"
+
+pushd "$REPO" >/dev/null
+ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || true)
+assert_eq "audit-and-pr: 1 commit ahead, no PR -> 'audit-and-pr'" "audit-and-pr" "$ACTUAL"
+
+reconcile_phase_signal both "$STATE_FILE" "569"
+popd >/dev/null
+
+# Local cache: phase_signal removed; .state still present.
+LOCAL_HAS_SIGNAL=$(jq 'has("state") and (.state | has("phase_signal"))' "$STATE_FILE")
+assert_eq "audit-and-pr: local cache phase_signal removed" "false" "$LOCAL_HAS_SIGNAL"
+LOCAL_HAS_STATE=$(jq 'has("state")' "$STATE_FILE")
+assert_eq "audit-and-pr: local cache .state preserved" "true" "$LOCAL_HAS_STATE"
+
+# Firestore fixture: phase_signal removed.
+REMOTE_HAS_SIGNAL=$(jq 'has("phase_signal")' "$STUB_FIRESTORE_FILE")
+assert_eq "audit-and-pr: firestore phase_signal removed" "false" "$REMOTE_HAS_SIGNAL"
+
+unset STUB_GH_OUTCOME STUB_FIRESTORE_FILE STUB_LOCAL_CACHE_FILE
+PATH="$ORIGINAL_PATH"
+rm -rf "$TEST_ROOT" "$STUB_DIR"
+
+# --- case 3: verify --------------------------------------------------------
+TEST_ROOT=$(mktemp -d)
+REPO="$TEST_ROOT/repo"
+init_test_repo "$REPO" 1
+STUB_DIR=$(make_gh_stub_dir)
+PATH="$STUB_DIR:$ORIGINAL_PATH"
+export STUB_GH_OUTCOME=open-pr
+pushd "$REPO" >/dev/null
+STATE_FILE="$REPO/state.json"
+ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || true)
+popd >/dev/null
+assert_eq "verify: open PR -> 'verify' (no second line)" "verify" "$ACTUAL"
+unset STUB_GH_OUTCOME
+PATH="$ORIGINAL_PATH"
+rm -rf "$TEST_ROOT" "$STUB_DIR"
+
+# --- case 4: done (merged PR) ----------------------------------------------
+TEST_ROOT=$(mktemp -d)
+REPO="$TEST_ROOT/repo"
+init_test_repo "$REPO" 0
+STUB_DIR=$(make_gh_stub_dir)
+PATH="$STUB_DIR:$ORIGINAL_PATH"
+export STUB_GH_OUTCOME=merged-pr
+pushd "$REPO" >/dev/null
+STATE_FILE="$REPO/state.json"
+ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || true)
+popd >/dev/null
+EXPECTED=$'done\n99'
+assert_eq "done: merged PR -> 'done' + PR number on second line" "$EXPECTED" "$ACTUAL"
+unset STUB_GH_OUTCOME
+PATH="$ORIGINAL_PATH"
+rm -rf "$TEST_ROOT" "$STUB_DIR"
+
+# --- case 5: fetch failure non-fatal --------------------------------------
+TEST_ROOT=$(mktemp -d)
+REPO="$TEST_ROOT/repo"
+init_test_repo "$REPO" 0
+# Break the origin URL so `git fetch --quiet origin main` fails.
+(
+  cd "$REPO"
+  git remote set-url origin "/nonexistent/path/to/repo.git"
+)
+STUB_DIR=$(make_gh_stub_dir)
+PATH="$STUB_DIR:$ORIGINAL_PATH"
+export STUB_GH_OUTCOME=no-pr
+pushd "$REPO" >/dev/null
+STATE_FILE="$REPO/state.json"
+# Capture both stdout (mode) and ensure the function exits 0 despite fetch failure.
+ACTUAL=$(diagnose_state "stub-branch" "$STATE_FILE" "569" 2>/dev/null || echo "FAILED")
+popd >/dev/null
+assert_eq "fetch failure non-fatal: still returns 'fresh'" "fresh" "$ACTUAL"
+unset STUB_GH_OUTCOME
+PATH="$ORIGINAL_PATH"
+rm -rf "$TEST_ROOT" "$STUB_DIR"
+
+# --- case 6: reconcile local-only is no-op when key absent ----------------
+TEST_ROOT=$(mktemp -d)
+STATE_FILE="$TEST_ROOT/state.json"
+ORIGINAL_CONTENT='{"state":{"other":"value"}}'
+echo "$ORIGINAL_CONTENT" >"$STATE_FILE"
+EXPECTED_BYTES=$(wc -c <"$STATE_FILE")
+EXPECTED_HASH=$(shasum "$STATE_FILE" | awk '{print $1}')
+
+reconcile_phase_signal local-only "$STATE_FILE" "569"
+
+ACTUAL_HASH=$(shasum "$STATE_FILE" | awk '{print $1}')
+ACTUAL_BYTES=$(wc -c <"$STATE_FILE")
+assert_eq "reconcile local-only no-op: file content unchanged (sha)" "$EXPECTED_HASH" "$ACTUAL_HASH"
+assert_eq "reconcile local-only no-op: file content unchanged (bytes)" "$EXPECTED_BYTES" "$ACTUAL_BYTES"
+rm -rf "$TEST_ROOT"
+
+# --- report -----------------------------------------------------------------
+echo ""
+echo "================================"
+echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+echo "================================"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #569

## Summary

The dispatcher now diagnoses worktree state against ground truth (open PR, commits ahead of `origin/main`, merged PR) before launching Claude, reconciles any stale Firestore `phase_signal=complete` against that diagnosis, and passes a free-form English resume instruction in the slash command's opening message. This fixes the "dispatch terminates immediately on a worktree with stale phase_signal but no PR yet" bug while preserving the local↔remote mirror invariant established by commit ae5292d.

## Resume modes

- **fresh** — no commits ahead, no PR → default plan + implement flow.
- **audit-and-pr** — commits ahead, no PR → audit diff against acceptance criteria, fix gaps, proceed to Step 2.5 (PR creation).
- **verify** — open PR exists → skip planning + Step 2; resume at Step 2.5.2 (monitor checks).
- **done** — PR is merged → exit 0 with "issue #N already shipped via PR #M"; do not launch Claude.

## Test plan

- [x] \`bash dispatch/test/test-slug.sh\` — 9/9 passed (regression).
- [x] \`bash dispatch/test/test-diagnose.sh\` — 10/10 passed (new).
- [ ] Re-run \`./dispatch/bin/dispatch <issue-num>\` on a worktree where work is pushed but no PR exists; confirm Claude resumes at Step 2.5 instead of being SIGTERMed.
- [ ] Re-run on a worktree with an open draft PR; confirm Claude resumes at Step 2.5.2.
- [ ] Re-run on a worktree whose PR has merged; confirm dispatch prints the shipped message and exits 0.
- [ ] Fresh dispatch on a new issue still enters plan mode normally.