### PR TITLE
productivity-tui: show worktree name when launched from subdir

### DIFF
--- a/productivity-tui/internal/app/app.go
+++ b/productivity-tui/internal/app/app.go
@@ -238,10 +238,19 @@ func tick() tea.Cmd {
 	})
 }
 
-// displayName renders the worktree name for a session's working dir. For
-// root or single-component paths (where Dir is "/", ".", or empty), the full
-// path is returned to avoid a confusing relabel.
+// displayName renders the worktree name for a session's working dir. When the
+// path has a `worktrees/` ancestor (the convention used in this repo), the
+// segment immediately below it is returned so sessions launched from a
+// subdirectory still display the worktree name. For root or single-component
+// paths (where Dir is "/", ".", or empty), the full path is returned to avoid
+// a confusing relabel.
 func displayName(p string) string {
+	parts := strings.Split(filepath.Clean(p), string(filepath.Separator))
+	for i, part := range parts {
+		if part == "worktrees" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
 	switch filepath.Dir(p) {
 	case "/", ".", "":
 		return p

--- a/productivity-tui/internal/app/app_test.go
+++ b/productivity-tui/internal/app/app_test.go
@@ -112,6 +112,33 @@ func TestViewEdgeCasePaths(t *testing.T) {
 	}
 }
 
+func TestDisplayName(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"worktree root", "/Users/n8/natb1/commons.systems/worktrees/main", "main"},
+		{"subdir under worktree", "/Users/n8/natb1/commons.systems/worktrees/main/productivity-tui", "main"},
+		{"deeper subdir", "/Users/n8/natb1/commons.systems/worktrees/main/internal/app", "main"},
+		{"no worktrees ancestor (worktrees-like)", "/Users/n8/worktrees-like-but-not/foo", "foo"},
+		{"no worktrees ancestor (plain)", "/Users/n8/projects/myrepo", "myrepo"},
+		{"root", "/", "/"},
+		{"single-component-no-slash", "foo", "foo"},
+		{"single-component-with-slash", "/foo", "/foo"},
+		{"empty", "", ""},
+		{"worktrees at leaf", "/a/b/worktrees", "worktrees"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := displayName(tc.path)
+			if got != tc.want {
+				t.Errorf("displayName(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestViewEmptySessions(t *testing.T) {
 	m := New("/dev/null", "/dev/null")
 	m.width = 80


### PR DESCRIPTION
Closes #580

## Summary
- `displayName()` walks up the path for a `worktrees/` ancestor and returns the segment immediately below it
- Falls back to `filepath.Base` when no `worktrees/` ancestor is present (no regression for non-worktree paths)
- Edge cases (`/`, `.`, empty, single-component) preserve the full-path behavior introduced in #565
- Table-driven `TestDisplayName` covers worktree root, subdirs, non-worktree paths, and edge cases

## Test plan
- [x] `go test ./internal/app/...` passes
- [x] `go build ./...` clean
- [ ] Manual smoke test: rebuild binary, start a Claude session from a worktree subdir, confirm session list shows the worktree name