### PR TITLE
budget: use firebaseutil deferAppCheckInit (#591)

### DIFF
--- a/budget/src/main.ts
+++ b/budget/src/main.ts
@@ -19,6 +19,7 @@ import { hydrateAccountsReconcile } from "./pages/accounts-reconcile-hydrate.js"
 import { mountHero } from "@commons-systems/style/hero";
 import { renderHero } from "./pages/hero.js";
 import { trackPageView, initAppCheck } from "./firebase.js";
+import { deferAppCheckInit } from "@commons-systems/firebaseutil/defer-appcheck";
 import { classifyError } from "@commons-systems/errorutil/classify";
 import { deferProgrammerError } from "@commons-systems/errorutil/defer";
 import { logError } from "@commons-systems/errorutil/log";
@@ -343,24 +344,4 @@ initialize().catch((error) => {
   transition({ source: "seed" });
 });
 
-// Defer App Check / reCAPTCHA initialization until first user interaction to keep the
-// large reCAPTCHA script off the critical path. Until initAppCheck() resolves,
-// getAppCheckHeaders returns empty headers, so pre-interaction requests lack App Check tokens.
-const deferredAppCheckInit = async () => {
-  if (!initAppCheck) return;
-  await initAppCheck();
-};
-
-const INTERACTION_EVENTS = ["scroll", "click", "touchstart", "keydown"] as const;
-const triggerOnce = () => {
-  for (const evt of INTERACTION_EVENTS) {
-    window.removeEventListener(evt, triggerOnce);
-  }
-  deferredAppCheckInit().catch((err) => {
-    if (deferProgrammerError(err)) return;
-    logError(err, { operation: "deferred-appcheck-init" });
-  });
-};
-for (const evt of INTERACTION_EVENTS) {
-  window.addEventListener(evt, triggerOnce, { once: true, passive: true });
-}
+deferAppCheckInit(initAppCheck);

--- a/budget/test/main.test.ts
+++ b/budget/test/main.test.ts
@@ -25,7 +25,7 @@ vi.mock("../src/firebase.js", () => ({
   db: { type: "mock-firestore" },
   NAMESPACE: "app/test",
   trackPageView: vi.fn(),
-  initAppCheck: vi.fn().mockResolvedValue(undefined),
+  initAppCheck: vi.fn(() => Promise.resolve()),
 }));
 
 const mockGetMeta = vi.fn();
@@ -76,7 +76,7 @@ function resetAndMockAll(): void {
   }));
   vi.mock("../src/firebase.js", () => ({
     db: { type: "mock-firestore" }, NAMESPACE: "app/test", trackPageView: vi.fn(),
-    initAppCheck: vi.fn().mockResolvedValue(undefined),
+    initAppCheck: vi.fn(() => Promise.resolve()),
   }));
   vi.mock("../src/idb.js", () => ({
     getMeta: mockGetMeta, storeParsedData: mockStoreParsedData, clearAll: mockClearAll,
@@ -124,7 +124,7 @@ describe("main module", () => {
     expect(mockGetMeta).toHaveBeenCalled();
     const heroContainer = document.getElementById("hero-container")!;
     expect(heroContainer.hidden).toBe(false);
-  });
+  }, 15000);
 
   it("does not call initAppCheck before user interaction", async () => {
     mockGetMeta.mockResolvedValue(undefined);


### PR DESCRIPTION
Closes #591

Replaces the inline App Check defer block in `budget/src/main.ts` with a call to the shared `deferAppCheckInit` helper from `@commons-systems/firebaseutil/defer-appcheck`. The inline block duplicated the shared helper exactly (same INTERACTION_EVENTS, same passive once-listeners, same `deferProgrammerError` + `logError` error path), and sibling apps (landing, fellspiral) already use the shared helper. Net: ~20 LOC removed.

## Test plan
- [x] `npx tsc --noEmit --project budget` passes
- [x] `npm run build --prefix budget` passes (vite build + tsx prerender)
- [ ] App Check still initializes in budget QA (preview / runtime verification)