### PR TITLE
fix stale worktree cleanup: prune, ps-grep, zsh-safe loops

### DIFF
--- a/.claude/skills/ref-pr-workflow/scripts/lib.sh
+++ b/.claude/skills/ref-pr-workflow/scripts/lib.sh
@@ -360,15 +360,15 @@ kill_worktree_processes() {
   local exclude_pids
   exclude_pids=$(_ancestor_pids)
 
-  local pid
-  for pid in $pids; do
+  while IFS= read -r pid; do
+    [ -z "$pid" ] && continue
     if [[ "$exclude_pids" == *" $pid "* ]]; then
       continue
     fi
     kill -0 "$pid" 2>/dev/null || continue
     echo "Killing worktree process: PID $pid"
     kill_tree "$pid"
-  done
+  done <<< "$pids"
 }
 
 # Kill processes belonging to worktrees that no longer exist.
@@ -383,6 +383,10 @@ cleanup_stale_worktree_processes() {
   }
   # Resolve to absolute path; worktrees live as siblings of the git common dir
   worktree_root="$(cd "$git_common_dir/.." && pwd)/worktrees"
+
+  # Prune admin entries for worktrees whose directories no longer exist, so
+  # the subsequent list reflects only worktrees that are actually on disk.
+  git worktree prune 2>/dev/null || true
 
   # Build set of active worktree paths
   local active_paths=""
@@ -401,15 +405,16 @@ cleanup_stale_worktree_processes() {
   fi
 
   # Find PIDs with this repo's worktree root in their command args
-  local pids
-  pids=$(pgrep -f "$worktree_root/" 2>/dev/null) || true
+  local ps_output pids
+  ps_output=$(ps -axo pid=,args= 2>/dev/null) || true
+  pids=$(printf '%s\n' "$ps_output" | grep -F "$worktree_root/" | awk '{print $1}') || true
   [ -z "$pids" ] && return 0
 
   local exclude_pids
   exclude_pids=$(_ancestor_pids)
 
-  local pid
-  for pid in $pids; do
+  while IFS= read -r pid; do
+    [ -z "$pid" ] && continue
     [[ "$exclude_pids" == *" $pid "* ]] && continue
 
     # Extract the worktree path from this process's command line
@@ -426,7 +431,7 @@ cleanup_stale_worktree_processes() {
       echo "Stale worktree process: PID $pid (worktree: $wt_path)"
       kill_tree "$pid"
     fi
-  done
+  done <<< "$pids"
 }
 
 # Find N available TCP ports by binding to port 0 simultaneously.

--- a/.claude/skills/ref-pr-workflow/scripts/lib.sh
+++ b/.claude/skills/ref-pr-workflow/scripts/lib.sh
@@ -170,11 +170,12 @@ _ancestor_pids() {
 # Output: one PID per line, leaves first (children listed before their parent)
 _collect_tree_pids() {
   local pid="$1"
-  local children
+  local children child
   children=$(pgrep -P "$pid" 2>/dev/null) || true
-  for child in $children; do
+  while IFS= read -r child; do
+    [ -z "$child" ] && continue
     _collect_tree_pids "$child"
-  done
+  done <<< "$children"
   echo "$pid"
 }
 
@@ -189,17 +190,19 @@ kill_tree() {
 
   # SIGTERM pass
   local p
-  for p in $pids; do
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
     kill "$p" 2>/dev/null || true
-  done
+  done <<< "$pids"
 
   # Grace period, then SIGKILL survivors
   sleep 2
-  for p in $pids; do
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
     if kill -0 "$p" 2>/dev/null; then
       kill -9 "$p" 2>/dev/null || true
     fi
-  done
+  done <<< "$pids"
 }
 
 # Resolve which apps are affected by a set of changed files.
@@ -345,6 +348,14 @@ cleanup_stale_hub() {
   fi
 }
 
+# Print PIDs whose command-line args contain the given fixed-string substring.
+# Uses ps + grep -F instead of `pgrep -f` so it works under the macOS sandbox
+# (which blocks pgrep's sysmond IPC). Output: one PID per line; empty if none.
+_pids_matching_arg() {
+  local needle="${1:?_pids_matching_arg requires a substring}"
+  ps -axo pid=,args= 2>/dev/null | grep -F "$needle" | awk '{print $1}' || true
+}
+
 # Kill all processes whose command-line args contain the given worktree path.
 # Uses fixed-string substring matching on process args.
 # Excludes the current process and its ancestors to avoid self-termination.
@@ -352,9 +363,8 @@ cleanup_stale_hub() {
 kill_worktree_processes() {
   local wt_path="${1:?kill_worktree_processes requires a worktree path}"
 
-  local ps_output pids
-  ps_output=$(ps -axo pid=,args= 2>/dev/null) || true
-  pids=$(printf '%s\n' "$ps_output" | grep -F "$wt_path/" | awk '{print $1}') || true
+  local pids
+  pids=$(_pids_matching_arg "$wt_path/")
   [ -z "$pids" ] && return 0
 
   local exclude_pids
@@ -384,8 +394,7 @@ cleanup_stale_worktree_processes() {
   # Resolve to absolute path; worktrees live as siblings of the git common dir
   worktree_root="$(cd "$git_common_dir/.." && pwd)/worktrees"
 
-  # Prune admin entries for worktrees whose directories no longer exist, so
-  # the subsequent list reflects only worktrees that are actually on disk.
+  # Prune stale admin entries so the list below reflects on-disk worktrees only.
   git worktree prune 2>/dev/null || true
 
   # Build set of active worktree paths
@@ -405,9 +414,8 @@ cleanup_stale_worktree_processes() {
   fi
 
   # Find PIDs with this repo's worktree root in their command args
-  local ps_output pids
-  ps_output=$(ps -axo pid=,args= 2>/dev/null) || true
-  pids=$(printf '%s\n' "$ps_output" | grep -F "$worktree_root/" | awk '{print $1}') || true
+  local pids
+  pids=$(_pids_matching_arg "$worktree_root/")
   [ -z "$pids" ] && return 0
 
   local exclude_pids

--- a/.claude/skills/ref-pr-workflow/scripts/lib.sh
+++ b/.claude/skills/ref-pr-workflow/scripts/lib.sh
@@ -353,9 +353,16 @@ cleanup_stale_hub() {
 # returns nothing. These helpers use `ps` instead. Output: one PID per line.
 
 # Print PIDs whose command-line args contain the given fixed-string substring.
+# Matches against the args column only, so a numeric needle cannot collide with
+# the PID column.
 _pids_matching_arg() {
   local needle="${1:?_pids_matching_arg requires a substring}"
-  ps -axo pid=,args= 2>/dev/null | grep -F "$needle" | awk '{print $1}' || true
+  local pid args
+  ps -axo pid=,args= 2>/dev/null | while read -r pid args; do
+    case "$args" in
+      *"$needle"*) echo "$pid" ;;
+    esac
+  done || true
 }
 
 # Print PIDs whose parent PID equals the given PID.

--- a/.claude/skills/ref-pr-workflow/scripts/lib.sh
+++ b/.claude/skills/ref-pr-workflow/scripts/lib.sh
@@ -171,7 +171,7 @@ _ancestor_pids() {
 _collect_tree_pids() {
   local pid="$1"
   local children child
-  children=$(pgrep -P "$pid" 2>/dev/null) || true
+  children=$(_pids_with_parent "$pid")
   while IFS= read -r child; do
     [ -z "$child" ] && continue
     _collect_tree_pids "$child"
@@ -348,12 +348,20 @@ cleanup_stale_hub() {
   fi
 }
 
+# Sandbox-safe replacements for `pgrep -f` and `pgrep -P`. The macOS sandbox
+# Claude Code runs under blocks pgrep's sysmond IPC, so any pgrep variant
+# returns nothing. These helpers use `ps` instead. Output: one PID per line.
+
 # Print PIDs whose command-line args contain the given fixed-string substring.
-# Uses ps + grep -F instead of `pgrep -f` so it works under the macOS sandbox
-# (which blocks pgrep's sysmond IPC). Output: one PID per line; empty if none.
 _pids_matching_arg() {
   local needle="${1:?_pids_matching_arg requires a substring}"
   ps -axo pid=,args= 2>/dev/null | grep -F "$needle" | awk '{print $1}' || true
+}
+
+# Print PIDs whose parent PID equals the given PID.
+_pids_with_parent() {
+  local parent="${1:?_pids_with_parent requires a parent PID}"
+  ps -axo pid=,ppid= 2>/dev/null | awk -v p="$parent" '$2 == p {print $1}' || true
 }
 
 # Kill all processes whose command-line args contain the given worktree path.

--- a/.claude/skills/ref-pr-workflow/scripts/lib.sh
+++ b/.claude/skills/ref-pr-workflow/scripts/lib.sh
@@ -429,15 +429,17 @@ cleanup_stale_worktree_processes() {
   local exclude_pids
   exclude_pids=$(_ancestor_pids)
 
+  # Declared once, before the loop: re-running `local` inside the loop makes
+  # zsh display the parameter on every iteration after the first.
+  local cmdline wt_path
+
   while IFS= read -r pid; do
     [ -z "$pid" ] && continue
     [[ "$exclude_pids" == *" $pid "* ]] && continue
 
     # Extract the worktree path from this process's command line
-    local cmdline
     cmdline=$(ps -o args= -p "$pid" 2>/dev/null) || continue
 
-    local wt_path
     wt_path=$(printf '%s' "$cmdline" | grep -oE '/[^ ]*worktrees/[^/ ]+' | head -1) || continue
     [ -z "$wt_path" ] && continue
 

--- a/.claude/skills/ref-pr-workflow/scripts/test-pid-cleanup.sh
+++ b/.claude/skills/ref-pr-workflow/scripts/test-pid-cleanup.sh
@@ -228,6 +228,63 @@ echo "=== Test: cleanup_stale_hub keeps live hub file ==="
   rm -f "$hub_file"
 )
 
+echo ""
+echo "=== Test: cleanup_stale_worktree_processes prunes before listing ==="
+(
+  source "$SCRIPT_DIR/lib.sh"
+
+  # Simulate a worktree whose directory was deleted but whose git admin entry still exists.
+  # We mock `git worktree prune` (no-op) and `git worktree list --porcelain` so the test
+  # controls exactly what the active-worktree set looks like, isolating the prune-before-list
+  # logic from filesystem and sandbox constraints.
+  #
+  # The mock returns two states depending on call order:
+  #   1st list call (before prune in cleanup): includes the stale path (prunable)
+  #   After prune: list excludes the stale path
+  # We simulate this by having the mock check a sentinel file left by the prune call.
+
+  STALE_WT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)/worktrees/612-prune-test-fixture-$$"
+  REAL_WT="$(git rev-parse --show-toplevel)"
+  PRUNE_CALLED_MARKER="${TEST_TMPDIR}/prune_called_$$"
+
+  git() {
+    local subcmd="$1"
+    if [ "$subcmd" = "worktree" ]; then
+      local action="$2"
+      if [ "$action" = "prune" ]; then
+        touch "$PRUNE_CALLED_MARKER"
+        return 0
+      elif [ "$action" = "list" ]; then
+        if [ -f "$PRUNE_CALLED_MARKER" ]; then
+          printf 'worktree %s\nHEAD abc123\nbranch refs/heads/main\n\n' "$REAL_WT"
+        else
+          printf 'worktree %s\nHEAD abc123\nbranch refs/heads/main\n\n' "$REAL_WT"
+          printf 'worktree %s\nHEAD def456\nbranch refs/heads/612-prune-test\nprunable gitdir file points to non-existent location\n\n' "$STALE_WT"
+        fi
+        return 0
+      fi
+    elif [ "$subcmd" = "rev-parse" ]; then
+      command git rev-parse "${@:2}"
+      return $?
+    fi
+    command git "$@"
+  }
+
+  perl -e 'sleep 300' -- "$STALE_WT/sentinel" &
+  FIXTURE_PID=$!
+  trap 'kill -9 $FIXTURE_PID 2>/dev/null || true' EXIT
+  sleep 0.3
+
+  cleanup_stale_worktree_processes
+
+  if kill -0 "$FIXTURE_PID" 2>/dev/null; then
+    fail "cleanup_stale_worktree_processes left fixture alive (prune-before-list not working)"
+    kill -9 "$FIXTURE_PID" 2>/dev/null || true
+  else
+    pass "cleanup_stale_worktree_processes kills process from deleted-but-not-pruned worktree"
+  fi
+)
+
 FINAL_PASS=$(cat "$PASS_FILE")
 FINAL_FAIL=$(cat "$FAIL_FILE")
 

--- a/.claude/skills/ref-pr-workflow/scripts/test-pid-cleanup.sh
+++ b/.claude/skills/ref-pr-workflow/scripts/test-pid-cleanup.sh
@@ -233,39 +233,24 @@ echo "=== Test: cleanup_stale_worktree_processes prunes before listing ==="
 (
   source "$SCRIPT_DIR/lib.sh"
 
-  # Simulate a worktree whose directory was deleted but whose git admin entry still exists.
-  # We mock `git worktree prune` (no-op) and `git worktree list --porcelain` so the test
-  # controls exactly what the active-worktree set looks like, isolating the prune-before-list
-  # logic from filesystem and sandbox constraints.
-  #
-  # The mock returns two states depending on call order:
-  #   1st list call (before prune in cleanup): includes the stale path (prunable)
-  #   After prune: list excludes the stale path
-  # We simulate this by having the mock check a sentinel file left by the prune call.
-
+  # Mock `git worktree list` so its output flips based on whether prune ran first:
+  # without the prune call, list reports the stale path as still-active and the
+  # orphan would survive. The test passes only if the production code prunes first.
   STALE_WT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)/worktrees/612-prune-test-fixture-$$"
   REAL_WT="$(git rev-parse --show-toplevel)"
   PRUNE_CALLED_MARKER="${TEST_TMPDIR}/prune_called_$$"
+  REAL_ENTRY=$(printf 'worktree %s\nHEAD abc123\nbranch refs/heads/main\n\n' "$REAL_WT")
+  STALE_ENTRY=$(printf 'worktree %s\nHEAD def456\nbranch refs/heads/612-prune-test\nprunable gitdir file points to non-existent location\n\n' "$STALE_WT")
 
   git() {
-    local subcmd="$1"
-    if [ "$subcmd" = "worktree" ]; then
-      local action="$2"
-      if [ "$action" = "prune" ]; then
-        touch "$PRUNE_CALLED_MARKER"
-        return 0
-      elif [ "$action" = "list" ]; then
-        if [ -f "$PRUNE_CALLED_MARKER" ]; then
-          printf 'worktree %s\nHEAD abc123\nbranch refs/heads/main\n\n' "$REAL_WT"
-        else
-          printf 'worktree %s\nHEAD abc123\nbranch refs/heads/main\n\n' "$REAL_WT"
-          printf 'worktree %s\nHEAD def456\nbranch refs/heads/612-prune-test\nprunable gitdir file points to non-existent location\n\n' "$STALE_WT"
-        fi
-        return 0
-      fi
-    elif [ "$subcmd" = "rev-parse" ]; then
-      command git rev-parse "${@:2}"
-      return $?
+    if [ "$1" = "worktree" ] && [ "$2" = "prune" ]; then
+      touch "$PRUNE_CALLED_MARKER"
+      return 0
+    fi
+    if [ "$1" = "worktree" ] && [ "$2" = "list" ]; then
+      printf '%s\n' "$REAL_ENTRY"
+      [ -f "$PRUNE_CALLED_MARKER" ] || printf '%s\n' "$STALE_ENTRY"
+      return 0
     fi
     command git "$@"
   }

--- a/.claude/skills/ref-pr-workflow/scripts/test-pid-cleanup.sh
+++ b/.claude/skills/ref-pr-workflow/scripts/test-pid-cleanup.sh
@@ -270,6 +270,50 @@ echo "=== Test: cleanup_stale_worktree_processes prunes before listing ==="
   fi
 )
 
+echo ""
+echo "=== Test: cleanup_stale_worktree_processes kills child processes ==="
+(
+  source "$SCRIPT_DIR/lib.sh"
+
+  # Spawn a parent that matches the stale-worktree path filter, with a child
+  # whose own args do NOT match. The child is reachable only through tree-walk;
+  # if `_collect_tree_pids` cannot enumerate children (sandbox-blocked pgrep),
+  # the parent dies but the child is orphaned.
+  STALE_WT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)/worktrees/612-tree-test-fixture-$$"
+  REAL_WT="$(git rev-parse --show-toplevel)"
+  REAL_ENTRY=$(printf 'worktree %s\nHEAD abc123\nbranch refs/heads/main\n\n' "$REAL_WT")
+
+  git() {
+    case "$1 $2" in
+      "worktree prune") return 0 ;;
+      "worktree list") printf '%s\n' "$REAL_ENTRY"; return 0 ;;
+    esac
+    command git "$@"
+  }
+
+  perl -e 'my $kid = fork(); if ($kid == 0) { exec("sleep", "300"); } sleep 300;' -- "$STALE_WT/sentinel" &
+  PARENT_PID=$!
+  CHILD_PID=""
+  trap 'kill -9 $PARENT_PID 2>/dev/null || true; [ -n "$CHILD_PID" ] && kill -9 $CHILD_PID 2>/dev/null || true' EXIT
+  sleep 0.5
+
+  CHILD_PID=$(ps -axo pid=,ppid= | awk -v p="$PARENT_PID" '$2 == p {print $1; exit}')
+
+  if [ -z "$CHILD_PID" ]; then
+    fail "could not locate child of fixture parent $PARENT_PID"
+  else
+    cleanup_stale_worktree_processes
+
+    if kill -0 "$PARENT_PID" 2>/dev/null; then
+      fail "cleanup did not kill fixture parent $PARENT_PID"
+    elif kill -0 "$CHILD_PID" 2>/dev/null; then
+      fail "cleanup killed parent but orphaned child $CHILD_PID (tree-walk missed it)"
+    else
+      pass "cleanup_stale_worktree_processes kills parent and child"
+    fi
+  fi
+)
+
 FINAL_PASS=$(cat "$PASS_FILE")
 FINAL_FAIL=$(cat "$FAIL_FILE")
 


### PR DESCRIPTION
Closes #612

## Summary

Three independent bugs combined to make `cleanup_stale_worktree_processes` a silent no-op on the orphans it exists to kill. A 2026-05-02 audit found 8 such processes from 3 long-deleted worktrees, the oldest running 25 days.

- Run `git worktree prune` before reading `git worktree list --porcelain` so deleted-but-not-pruned worktrees are correctly recognized as stale (Bug 1).
- Replace sandbox-blocked `pgrep -f`/`pgrep -P` with `ps`-based helpers (`_pids_matching_arg`, `_pids_with_parent`), used by both `cleanup_stale_worktree_processes` and the sibling `kill_worktree_processes` (Bug 2).
- Replace `for pid in $pids` with `while IFS= read -r pid <<< "$pids"` in both helpers so PID lists word-split correctly under both bash and zsh (Bug 3).

## Test plan

- [x] `bash .claude/skills/ref-pr-workflow/scripts/test-pid-cleanup.sh` — 10 passed, 0 failed (8 pre-existing + 2 new tests: prune-before-list and parent/child tree-walk)
- [x] zsh source check confirms `while IFS` pattern present after source
- [x] CI: unit tests pass on PR
