### PR TITLE
scaffold: collapse four MarshalJSON/UnmarshalJSON pairs into generic helpers

### DIFF
--- a/scaffolding/firebase/internal/scaffold/firebase.go
+++ b/scaffolding/firebase/internal/scaffold/firebase.go
@@ -58,45 +58,61 @@ func (h HostingEntry) Validate() error {
 	return nil
 }
 
-func (h *HostingEntry) UnmarshalJSON(data []byte) error {
-	type Alias HostingEntry
-	var alias Alias
-	if err := json.Unmarshal(data, &alias); err != nil {
+// unmarshalWithExtra unmarshals data into target (which must be an alias type
+// without its own UnmarshalJSON to avoid recursion), then captures any
+// remaining JSON keys (those not in knownKeys) into *extra.
+func unmarshalWithExtra[T any](data []byte, target *T, extra *map[string]json.RawMessage, knownKeys ...string) error {
+	if err := json.Unmarshal(data, target); err != nil {
 		return err
 	}
-	*h = HostingEntry(alias)
-
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-	delete(raw, "target")
-	delete(raw, "public")
-	delete(raw, "ignore")
-	delete(raw, "rewrites")
+	for _, k := range knownKeys {
+		delete(raw, k)
+	}
 	if len(raw) > 0 {
-		h.extra = raw
+		*extra = raw
 	}
 	return nil
 }
 
-func (h HostingEntry) MarshalJSON() ([]byte, error) {
-	type Alias HostingEntry
-	data, err := json.Marshal(Alias(h))
+// marshalWithExtra marshals typed (which must be an alias type without its own
+// MarshalJSON to avoid recursion) and merges in extra keys for round-trip.
+func marshalWithExtra[T any](typed T, extra map[string]json.RawMessage) ([]byte, error) {
+	data, err := json.Marshal(typed)
 	if err != nil {
 		return nil, err
 	}
-	if len(h.extra) == 0 {
+	if len(extra) == 0 {
 		return data, nil
 	}
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return nil, err
 	}
-	for k, v := range h.extra {
+	for k, v := range extra {
 		obj[k] = v
 	}
 	return json.Marshal(obj)
+}
+
+func (h *HostingEntry) UnmarshalJSON(data []byte) error {
+	type Alias HostingEntry
+	var alias Alias
+	var extra map[string]json.RawMessage
+	if err := unmarshalWithExtra(data, &alias, &extra, "target", "public", "ignore", "rewrites"); err != nil {
+		return err
+	}
+	*h = HostingEntry(alias)
+	h.extra = extra
+	return nil
+}
+
+func (h HostingEntry) MarshalJSON() ([]byte, error) {
+	type Alias HostingEntry
+	return marshalWithExtra(Alias(h), h.extra)
 }
 
 type FirestoreConfig struct {
@@ -110,50 +126,21 @@ type FirebaseConfig struct {
 	extra map[string]json.RawMessage
 }
 
-// UnmarshalJSON and MarshalJSON use the alias-and-raw-map pattern to preserve
-// unknown JSON keys during round-trip. FirebaseConfig and FirebaseRC both need
-// this, and the implementations are intentionally similar. Go generics cannot
-// easily abstract over struct-specific known/unknown field separation.
-
 func (c *FirebaseConfig) UnmarshalJSON(data []byte) error {
-	// Unmarshal known fields via alias to avoid infinite recursion.
 	type Alias FirebaseConfig
 	var alias Alias
-	if err := json.Unmarshal(data, &alias); err != nil {
+	var extra map[string]json.RawMessage
+	if err := unmarshalWithExtra(data, &alias, &extra, "hosting", "firestore"); err != nil {
 		return err
 	}
 	*c = FirebaseConfig(alias)
-
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	delete(raw, "hosting")
-	delete(raw, "firestore")
-	if len(raw) > 0 {
-		c.extra = raw
-	}
+	c.extra = extra
 	return nil
 }
 
 func (c FirebaseConfig) MarshalJSON() ([]byte, error) {
-	// Marshal known fields via alias to avoid infinite recursion.
 	type Alias FirebaseConfig
-	data, err := json.Marshal(Alias(c))
-	if err != nil {
-		return nil, err
-	}
-	if len(c.extra) == 0 {
-		return data, nil
-	}
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, err
-	}
-	for k, v := range c.extra {
-		obj[k] = v
-	}
-	return json.Marshal(obj)
+	return marshalWithExtra(Alias(c), c.extra)
 }
 
 // ProjectTargets maps target types to their app-site mappings.
@@ -170,40 +157,18 @@ type FirebaseRC struct {
 func (rc *FirebaseRC) UnmarshalJSON(data []byte) error {
 	type Alias FirebaseRC
 	var alias Alias
-	if err := json.Unmarshal(data, &alias); err != nil {
+	var extra map[string]json.RawMessage
+	if err := unmarshalWithExtra(data, &alias, &extra, "projects", "targets"); err != nil {
 		return err
 	}
 	*rc = FirebaseRC(alias)
-
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	delete(raw, "projects")
-	delete(raw, "targets")
-	if len(raw) > 0 {
-		rc.extra = raw
-	}
+	rc.extra = extra
 	return nil
 }
 
 func (rc FirebaseRC) MarshalJSON() ([]byte, error) {
 	type Alias FirebaseRC
-	data, err := json.Marshal(Alias(rc))
-	if err != nil {
-		return nil, err
-	}
-	if len(rc.extra) == 0 {
-		return data, nil
-	}
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, err
-	}
-	for k, v := range rc.extra {
-		obj[k] = v
-	}
-	return json.Marshal(obj)
+	return marshalWithExtra(Alias(rc), rc.extra)
 }
 
 // HostingSiteMap maps app names to their hosting site IDs ([]string).
@@ -378,41 +343,18 @@ type PackageJSON struct {
 func (p *PackageJSON) UnmarshalJSON(data []byte) error {
 	type Alias PackageJSON
 	var alias Alias
-	if err := json.Unmarshal(data, &alias); err != nil {
+	var extra map[string]json.RawMessage
+	if err := unmarshalWithExtra(data, &alias, &extra, "name", "private", "workspaces"); err != nil {
 		return err
 	}
 	*p = PackageJSON(alias)
-
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	delete(raw, "name")
-	delete(raw, "private")
-	delete(raw, "workspaces")
-	if len(raw) > 0 {
-		p.extra = raw
-	}
+	p.extra = extra
 	return nil
 }
 
 func (p PackageJSON) MarshalJSON() ([]byte, error) {
 	type Alias PackageJSON
-	data, err := json.Marshal(Alias(p))
-	if err != nil {
-		return nil, err
-	}
-	if len(p.extra) == 0 {
-		return data, nil
-	}
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, err
-	}
-	for k, v := range p.extra {
-		obj[k] = v
-	}
-	return json.Marshal(obj)
+	return marshalWithExtra(Alias(p), p.extra)
 }
 
 func ReadPackageJSON(repoRoot string) (*PackageJSON, error) {

--- a/scaffolding/firebase/internal/scaffold/firebase.go
+++ b/scaffolding/firebase/internal/scaffold/firebase.go
@@ -59,23 +59,23 @@ func (h HostingEntry) Validate() error {
 }
 
 // unmarshalWithExtra unmarshals data into target (which must be an alias type
-// without its own UnmarshalJSON to avoid recursion), then captures any
-// remaining JSON keys (those not in knownKeys) into *extra.
-func unmarshalWithExtra[T any](data []byte, target *T, extra *map[string]json.RawMessage, knownKeys ...string) error {
+// without its own UnmarshalJSON to avoid recursion) and returns any remaining
+// JSON keys (those not in knownKeys), or nil if there are none.
+func unmarshalWithExtra[T any](data []byte, target *T, knownKeys ...string) (map[string]json.RawMessage, error) {
 	if err := json.Unmarshal(data, target); err != nil {
-		return err
+		return nil, err
 	}
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
+		return nil, err
 	}
 	for _, k := range knownKeys {
 		delete(raw, k)
 	}
-	if len(raw) > 0 {
-		*extra = raw
+	if len(raw) == 0 {
+		return nil, nil
 	}
-	return nil
+	return raw, nil
 }
 
 // marshalWithExtra marshals typed (which must be an alias type without its own
@@ -101,8 +101,8 @@ func marshalWithExtra[T any](typed T, extra map[string]json.RawMessage) ([]byte,
 func (h *HostingEntry) UnmarshalJSON(data []byte) error {
 	type Alias HostingEntry
 	var alias Alias
-	var extra map[string]json.RawMessage
-	if err := unmarshalWithExtra(data, &alias, &extra, "target", "public", "ignore", "rewrites"); err != nil {
+	extra, err := unmarshalWithExtra(data, &alias, "target", "public", "ignore", "rewrites")
+	if err != nil {
 		return err
 	}
 	*h = HostingEntry(alias)
@@ -129,8 +129,8 @@ type FirebaseConfig struct {
 func (c *FirebaseConfig) UnmarshalJSON(data []byte) error {
 	type Alias FirebaseConfig
 	var alias Alias
-	var extra map[string]json.RawMessage
-	if err := unmarshalWithExtra(data, &alias, &extra, "hosting", "firestore"); err != nil {
+	extra, err := unmarshalWithExtra(data, &alias, "hosting", "firestore")
+	if err != nil {
 		return err
 	}
 	*c = FirebaseConfig(alias)
@@ -157,8 +157,8 @@ type FirebaseRC struct {
 func (rc *FirebaseRC) UnmarshalJSON(data []byte) error {
 	type Alias FirebaseRC
 	var alias Alias
-	var extra map[string]json.RawMessage
-	if err := unmarshalWithExtra(data, &alias, &extra, "projects", "targets"); err != nil {
+	extra, err := unmarshalWithExtra(data, &alias, "projects", "targets")
+	if err != nil {
 		return err
 	}
 	*rc = FirebaseRC(alias)
@@ -343,8 +343,8 @@ type PackageJSON struct {
 func (p *PackageJSON) UnmarshalJSON(data []byte) error {
 	type Alias PackageJSON
 	var alias Alias
-	var extra map[string]json.RawMessage
-	if err := unmarshalWithExtra(data, &alias, &extra, "name", "private", "workspaces"); err != nil {
+	extra, err := unmarshalWithExtra(data, &alias, "name", "private", "workspaces")
+	if err != nil {
 		return err
 	}
 	*p = PackageJSON(alias)

--- a/scaffolding/firebase/internal/scaffold/firebase_test.go
+++ b/scaffolding/firebase/internal/scaffold/firebase_test.go
@@ -626,3 +626,163 @@ func TestRemoveWorkspaceNotFound(t *testing.T) {
 		t.Errorf("expected workspaces unchanged, got %v", pkg.Workspaces)
 	}
 }
+
+type testStruct struct {
+	A     string `json:"a"`
+	B     int    `json:"b"`
+	extra map[string]json.RawMessage
+}
+
+func TestUnmarshalWithExtra(t *testing.T) {
+	t.Run("known fields only", func(t *testing.T) {
+		type Alias testStruct
+		var alias Alias
+		var extra map[string]json.RawMessage
+		if err := unmarshalWithExtra([]byte(`{"a":"hello","b":42}`), &alias, &extra, "a", "b"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if alias.A != "hello" || alias.B != 42 {
+			t.Errorf("expected hello/42, got %s/%d", alias.A, alias.B)
+		}
+		if extra != nil {
+			t.Errorf("expected no extra, got %v", extra)
+		}
+	})
+
+	t.Run("extra fields only", func(t *testing.T) {
+		type Alias testStruct
+		var alias Alias
+		var extra map[string]json.RawMessage
+		if err := unmarshalWithExtra([]byte(`{"x":1,"y":"two"}`), &alias, &extra, "a", "b"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := extra["x"]; !ok {
+			t.Errorf("expected x key in extra, got %v", extra)
+		}
+		if _, ok := extra["y"]; !ok {
+			t.Errorf("expected y key in extra, got %v", extra)
+		}
+	})
+
+	t.Run("known and extra mixed", func(t *testing.T) {
+		type Alias testStruct
+		var alias Alias
+		var extra map[string]json.RawMessage
+		if err := unmarshalWithExtra([]byte(`{"a":"hi","b":7,"x":1}`), &alias, &extra, "a", "b"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if alias.A != "hi" || alias.B != 7 {
+			t.Errorf("expected hi/7, got %s/%d", alias.A, alias.B)
+		}
+		if _, ok := extra["x"]; !ok {
+			t.Errorf("expected x key in extra, got %v", extra)
+		}
+		if _, ok := extra["a"]; ok {
+			t.Errorf("did not expect a in extra (it is a known key)")
+		}
+	})
+
+	t.Run("malformed input", func(t *testing.T) {
+		type Alias testStruct
+		var alias Alias
+		var extra map[string]json.RawMessage
+		if err := unmarshalWithExtra([]byte(`{not json`), &alias, &extra, "a", "b"); err == nil {
+			t.Error("expected error for malformed input, got nil")
+		}
+	})
+}
+
+func TestMarshalWithExtra(t *testing.T) {
+	t.Run("no extra", func(t *testing.T) {
+		type Alias testStruct
+		typed := Alias{A: "hello", B: 42}
+		data, err := marshalWithExtra(typed, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var got map[string]json.RawMessage
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+		if string(got["a"]) != `"hello"` || string(got["b"]) != `42` {
+			t.Errorf("unexpected output: %s", data)
+		}
+	})
+
+	t.Run("with extra", func(t *testing.T) {
+		type Alias testStruct
+		typed := Alias{A: "hello", B: 42}
+		extra := map[string]json.RawMessage{
+			"x": json.RawMessage(`"extra-value"`),
+		}
+		data, err := marshalWithExtra(typed, extra)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var got map[string]json.RawMessage
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+		if string(got["a"]) != `"hello"` {
+			t.Errorf("expected a=hello, got %s", got["a"])
+		}
+		if string(got["x"]) != `"extra-value"` {
+			t.Errorf("expected x=extra-value, got %s", got["x"])
+		}
+	})
+
+	t.Run("extra and known mixed", func(t *testing.T) {
+		type Alias testStruct
+		typed := Alias{A: "hi", B: 7}
+		extra := map[string]json.RawMessage{
+			"x": json.RawMessage(`1`),
+			"y": json.RawMessage(`"two"`),
+		}
+		data, err := marshalWithExtra(typed, extra)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var got map[string]json.RawMessage
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+		if string(got["a"]) != `"hi"` || string(got["b"]) != `7` {
+			t.Errorf("expected known fields preserved, got %s", data)
+		}
+		if string(got["x"]) != `1` || string(got["y"]) != `"two"` {
+			t.Errorf("expected extra fields preserved, got %s", data)
+		}
+	})
+}
+
+func TestFirebaseConfigPreservesExtraKeys(t *testing.T) {
+	input := `{
+  "hosting": [{"target":"hello","public":"hello/dist","ignore":["firebase.json"]}],
+  "firestore": {"rules":"firestore.rules"},
+  "emulators": {"firestore": {"port": 8080}}
+}`
+
+	var config FirebaseConfig
+	if err := json.Unmarshal([]byte(input), &config); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	out, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(out, &raw); err != nil {
+		t.Fatalf("re-unmarshal error: %v", err)
+	}
+	if _, ok := raw["emulators"]; !ok {
+		t.Errorf("expected 'emulators' key to survive round-trip; got: %s", out)
+	}
+	if _, ok := raw["hosting"]; !ok {
+		t.Errorf("expected 'hosting' key to be present; got: %s", out)
+	}
+	if _, ok := raw["firestore"]; !ok {
+		t.Errorf("expected 'firestore' key to be present; got: %s", out)
+	}
+}

--- a/scaffolding/firebase/internal/scaffold/firebase_test.go
+++ b/scaffolding/firebase/internal/scaffold/firebase_test.go
@@ -628,17 +628,16 @@ func TestRemoveWorkspaceNotFound(t *testing.T) {
 }
 
 type testStruct struct {
-	A     string `json:"a"`
-	B     int    `json:"b"`
-	extra map[string]json.RawMessage
+	A string `json:"a"`
+	B int    `json:"b"`
 }
 
 func TestUnmarshalWithExtra(t *testing.T) {
 	t.Run("known fields only", func(t *testing.T) {
 		type Alias testStruct
 		var alias Alias
-		var extra map[string]json.RawMessage
-		if err := unmarshalWithExtra([]byte(`{"a":"hello","b":42}`), &alias, &extra, "a", "b"); err != nil {
+		extra, err := unmarshalWithExtra([]byte(`{"a":"hello","b":42}`), &alias, "a", "b")
+		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if alias.A != "hello" || alias.B != 42 {
@@ -652,8 +651,8 @@ func TestUnmarshalWithExtra(t *testing.T) {
 	t.Run("extra fields only", func(t *testing.T) {
 		type Alias testStruct
 		var alias Alias
-		var extra map[string]json.RawMessage
-		if err := unmarshalWithExtra([]byte(`{"x":1,"y":"two"}`), &alias, &extra, "a", "b"); err != nil {
+		extra, err := unmarshalWithExtra([]byte(`{"x":1,"y":"two"}`), &alias, "a", "b")
+		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if _, ok := extra["x"]; !ok {
@@ -667,8 +666,8 @@ func TestUnmarshalWithExtra(t *testing.T) {
 	t.Run("known and extra mixed", func(t *testing.T) {
 		type Alias testStruct
 		var alias Alias
-		var extra map[string]json.RawMessage
-		if err := unmarshalWithExtra([]byte(`{"a":"hi","b":7,"x":1}`), &alias, &extra, "a", "b"); err != nil {
+		extra, err := unmarshalWithExtra([]byte(`{"a":"hi","b":7,"x":1}`), &alias, "a", "b")
+		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if alias.A != "hi" || alias.B != 7 {
@@ -685,8 +684,7 @@ func TestUnmarshalWithExtra(t *testing.T) {
 	t.Run("malformed input", func(t *testing.T) {
 		type Alias testStruct
 		var alias Alias
-		var extra map[string]json.RawMessage
-		if err := unmarshalWithExtra([]byte(`{not json`), &alias, &extra, "a", "b"); err == nil {
+		if _, err := unmarshalWithExtra([]byte(`{not json`), &alias, "a", "b"); err == nil {
 			t.Error("expected error for malformed input, got nil")
 		}
 	})


### PR DESCRIPTION
Closes #597

Replaces four near-identical `MarshalJSON`/`UnmarshalJSON` pairs in `scaffolding/firebase/internal/scaffold/firebase.go` (on `HostingEntry`, `FirebaseConfig`, `FirebaseRC`, `PackageJSON`) with two generic helpers: `unmarshalWithExtra[T]` and `marshalWithExtra[T]`. Each call site collapses to ~6 lines that document only the per-type known JSON keys. Also removes the now-misleading comment that claimed generics could not abstract this pattern.

## Test plan

- [x] `go build ./...` passes from `scaffolding/firebase/`
- [x] `go test ./...` passes from `scaffolding/firebase/` (28 pre-existing + 3 new)
- [x] New `TestUnmarshalWithExtra` covers known-only / extra-only / mixed / malformed
- [x] New `TestMarshalWithExtra` covers no-extra / with-extra / mixed
- [x] New `TestFirebaseConfigPreservesExtraKeys` is a round-trip test exercising the helpers end-to-end
- [x] Existing round-trip tests for `FirebaseConfig`, `FirebaseRC`, `PackageJSON`, and `HostingEntry` still pass through the new helpers