### PR TITLE
Dedupe redundant programmer-error rethrows; defer at async-callback sites

### DIFF
--- a/audio/src/pages/home.ts
+++ b/audio/src/pages/home.ts
@@ -1,6 +1,6 @@
 import { escapeHtml } from "@commons-systems/htmlutil";
 import { logError } from "@commons-systems/errorutil/log";
-import { classifyError } from "@commons-systems/errorutil/classify";
+import { deferProgrammerError } from "@commons-systems/errorutil/defer";
 import type { User } from "../auth.js";
 import { DataIntegrityError } from "@commons-systems/firestoreutil/errors";
 import { getPublicMedia, getAllAccessibleMedia } from "../firestore.js";
@@ -52,8 +52,7 @@ export async function renderHome(user: User | null): Promise<string> {
     mediaHtml = renderMediaList(items);
   } catch (error) {
     if (error instanceof DataIntegrityError) throw error;
-    if (classifyError(error) === "programmer") throw error;
-    logError(error, { operation: "load-media" });
+    if (!deferProgrammerError(error)) logError(error, { operation: "load-media" });
     mediaHtml = '<p id="media-error">Could not load audio library.</p>';
   }
 

--- a/audio/src/player.ts
+++ b/audio/src/player.ts
@@ -1,5 +1,5 @@
 import { escapeHtml } from "@commons-systems/htmlutil";
-import { classifyError } from "@commons-systems/errorutil/classify";
+import { deferProgrammerError } from "@commons-systems/errorutil/defer";
 import { logError } from "@commons-systems/errorutil/log";
 import { resolveAudioSource } from "./storage.js";
 import type { AudioItem } from "./types.js";
@@ -70,12 +70,12 @@ export function initPlayer(
         currentObjectUrl = url;
         audioEl.src = url;
         audioEl.play().catch((err) => {
-          if (classifyError(err) === "programmer") throw err;
+          if (deferProgrammerError(err)) return;
           logError(err, { operation: "audio-play" });
         });
       })
       .catch((err) => {
-        if (classifyError(err) === "programmer") throw err;
+        if (deferProgrammerError(err)) return;
         logError(err, { operation: "audio-source-resolve", storagePath: item.storagePath });
         advanceOrStop(index);
       });

--- a/blog/src/components/info-panel.ts
+++ b/blog/src/components/info-panel.ts
@@ -1,5 +1,5 @@
 import { escapeHtml } from "@commons-systems/htmlutil";
-import { classifyError } from "@commons-systems/errorutil/classify";
+import { deferProgrammerError } from "@commons-systems/errorutil/defer";
 import { logError } from "@commons-systems/errorutil/log";
 import { formatUtcDate, monthName } from "../date.ts";
 import { isPublished, type PostMeta, type PublishedPost } from "../post-types.ts";
@@ -241,7 +241,7 @@ export function hydrateInfoPanel(
     })
     // Intentional silent degradation — user sees build-time content rather than an error.
     .catch((err) => {
-      if (classifyError(err) === "programmer") throw err;
+      if (deferProgrammerError(err)) return;
       logError(err, { operation: "hydrate-blogroll" });
     });
 }

--- a/budget/src/main.ts
+++ b/budget/src/main.ts
@@ -262,7 +262,7 @@ async function handleFileUpload(file: File): Promise<void> {
       showNavError(error.message);
       return;
     }
-    if (classifyError(error) === "programmer") throw error;
+    if (deferProgrammerError(error)) return;
     logError(error, { operation: "upload" });
     showNavError("Upload failed. Please try again.");
   }
@@ -309,7 +309,7 @@ exportButton.addEventListener("click", async () => {
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
   } catch (error) {
-    if (classifyError(error) === "programmer") throw error;
+    if (deferProgrammerError(error)) return;
     logError(error, { operation: "export" });
     showNavError(error instanceof Error ? error.message : "Export failed. Please try again.");
   }
@@ -321,7 +321,7 @@ clearButton.addEventListener("click", async () => {
     importPassword = null;
     transition({ source: "seed" });
   } catch (error) {
-    if (classifyError(error) === "programmer") throw error;
+    if (deferProgrammerError(error)) return;
     logError(error, { operation: "clear-data" });
     showNavError("Failed to clear data. Try closing other tabs or refreshing the page.");
   }
@@ -338,7 +338,7 @@ async function initialize(): Promise<void> {
 }
 
 initialize().catch((error) => {
-  if (classifyError(error) === "programmer") throw error;
+  if (deferProgrammerError(error)) return;
   logError(error, { operation: "initialization" });
   showNavError("Could not load saved data. You may need to re-upload your file.");
   transition({ source: "seed" });

--- a/budget/src/pages/accounts-reconcile-hydrate.ts
+++ b/budget/src/pages/accounts-reconcile-hydrate.ts
@@ -5,7 +5,6 @@ import type {
   StatementItemId,
   TransactionId,
 } from "../firestore.js";
-import { classifyError } from "@commons-systems/errorutil/classify";
 import { deferProgrammerError } from "@commons-systems/errorutil/defer";
 import { logError } from "@commons-systems/errorutil/log";
 
@@ -80,7 +79,6 @@ export function hydrateAccountsReconcile(container: HTMLElement): void {
       .catch((error) => {
         target.disabled = false;
         if (deferProgrammerError(error)) return;
-        if (classifyError(error) === "programmer") throw error;
         logError(error, { operation: "reconcile-confirm-match" });
       });
   });
@@ -122,7 +120,6 @@ async function persistClassification(select: HTMLSelectElement): Promise<void> {
     });
   } catch (error) {
     if (deferProgrammerError(error)) return;
-    if (classifyError(error) === "programmer") throw error;
     logError(error, { operation: "reconcile-classify" });
   }
 }
@@ -147,7 +144,6 @@ async function persistNote(input: HTMLInputElement): Promise<void> {
     });
   } catch (error) {
     if (deferProgrammerError(error)) return;
-    if (classifyError(error) === "programmer") throw error;
     logError(error, { operation: "reconcile-note" });
   }
 }

--- a/budget/src/pages/home-hydrate.ts
+++ b/budget/src/pages/home-hydrate.ts
@@ -159,9 +159,9 @@ async function syncPeriodOnReimbursementChange(
   }
 }
 
-/** Handle an error from adjustBudgetPeriodTotal: rethrow programmer errors, log others, clear balance, and set tooltip. */
+/** Handle an error from adjustBudgetPeriodTotal: defer programmer errors, log others, clear balance, and set tooltip. */
 function handlePeriodSyncError(row: HTMLElement, error: unknown): void {
-  if (classifyError(error) === "programmer") throw error;
+  if (deferProgrammerError(error)) return;
   logError(error, { operation: "update-period-totals" });
   clearBalanceDisplay(row);
   const balanceEl = row.querySelector(".budget-balance") as HTMLElement | null;

--- a/fellspiral/src/main.ts
+++ b/fellspiral/src/main.ts
@@ -108,11 +108,15 @@ async function loadPosts(): Promise<string> {
     return renderHomeHtml(cachedPosts, "/post/", buildTimeContent);
   } catch (error) {
     const kind = classifyError(error);
-    if (kind === "programmer") throw error;
-    logError(error, { operation: "load-posts" });
-    const msg = kind === "permission-denied"
-      ? "Permission denied loading posts."
-      : "Could not load posts. Try refreshing the page.";
+    const fallbackMsg = "Could not load posts. Try refreshing the page.";
+    let msg: string;
+    if (kind === "programmer") {
+      deferProgrammerError(error);
+      msg = fallbackMsg;
+    } else {
+      logError(error, { operation: "load-posts" });
+      msg = kind === "permission-denied" ? "Permission denied loading posts." : fallbackMsg;
+    }
     return `
     <h2>Home</h2>
     <p id="posts-error">${msg}</p>
@@ -159,8 +163,7 @@ const router = createHistoryRouter(
           const admin = await isInGroup(db, NAMESPACE, currentUser, ADMIN_GROUP_ID);
           return renderAdmin(currentUser, admin, lastSkippedCount);
         } catch (error) {
-          if (classifyError(error) === "programmer") throw error;
-          logError(error, { operation: "admin-group-check" });
+          if (!deferProgrammerError(error)) logError(error, { operation: "admin-group-check" });
           return `<h2>Admin</h2><p>Could not verify admin access. Try refreshing the page.</p>`;
         }
       },

--- a/landing/src/main.ts
+++ b/landing/src/main.ts
@@ -90,11 +90,15 @@ async function loadPosts(): Promise<string> {
     return renderHomeHtml(cachedPosts, "/post/", buildTimeContent);
   } catch (error) {
     const kind = classifyError(error);
-    if (kind === "programmer") throw error;
-    reportError(new Error(`Failed to load posts: ${error instanceof Error ? error.message : error}`));
-    const msg = kind === "permission-denied"
-      ? "Permission denied loading posts."
-      : "Could not load posts. Try refreshing the page.";
+    const fallbackMsg = "Could not load posts. Try refreshing the page.";
+    let msg: string;
+    if (kind === "programmer") {
+      deferProgrammerError(error);
+      msg = fallbackMsg;
+    } else {
+      reportError(new Error(`Failed to load posts: ${error instanceof Error ? error.message : error}`));
+      msg = kind === "permission-denied" ? "Permission denied loading posts." : fallbackMsg;
+    }
     return `
     <h2>Home</h2>
     <p id="posts-error">${msg}</p>
@@ -125,8 +129,7 @@ const router = createHistoryRouter(
           const admin = await isInGroup(db, NAMESPACE, currentUser, ADMIN_GROUP_ID);
           return renderAdmin(currentUser, admin, lastSkippedCount);
         } catch (error) {
-          if (classifyError(error) === "programmer") throw error;
-          logError(error, { operation: "admin-group-check" });
+          if (!deferProgrammerError(error)) logError(error, { operation: "admin-group-check" });
           return `<h2>Admin</h2><p>Could not verify admin access. Try refreshing the page.</p>`;
         }
       },


### PR DESCRIPTION
Closes #593

Two programmer-error handling cleanups in application catch blocks.

## 1. Dead rethrows removed

`budget/src/pages/accounts-reconcile-hydrate.ts` had three
`if (classifyError(error) === "programmer") throw error;` lines, each
immediately after a `deferProgrammerError(error)` early-return. The defer call
already handles programmer errors and returns early, so each rethrow was
unreachable. Removed all three, plus the now-unused `classifyError` import.

## 2. Async-callback rethrows converted to `deferProgrammerError`

At the async-callback catch sites listed in #593 — across `budget/src/main.ts`,
`budget/src/pages/home-hydrate.ts`, `audio/src/player.ts`,
`audio/src/pages/home.ts`, `blog/src/components/info-panel.ts`,
`landing/src/main.ts`, and `fellspiral/src/main.ts` — a raw `throw` inside a
void-discarded promise's catch becomes an unhandled promise rejection that may
not surface reliably. `deferProgrammerError` re-throws via `setTimeout` so the
global error handler always sees it.

### Behavior change in `loadPosts`

The `loadPosts` catch in `landing/src/main.ts` and `fellspiral/src/main.ts` —
the two blog frontends, which have parallel structure — is the non-mechanical
conversion. Previously a programmer error inside `loadPosts` rethrew, failing
the surrounding render. Now it defers via `setTimeout` and the function returns
the generic "Could not load posts" fallback HTML. The deferred error still
reaches `window.onerror`, but the page paints the fallback instead of failing
render. Each handler classifies the error once, branches on the kind, and names
the shared fallback string.

Out of scope (per #593): sync sites that throw to a sync caller; inner catches
that rethrow up to an already-converted outer catch (`budget/src/crypto.ts`,
the `blog-roll` strategies); the build-time feed-fetch Vite plugin; and the
behavior of the error utilities themselves.

---

Re-scope note: this branch previously also bundled an unrelated "persistent
dispatch stage state" change against the `dispatch/bin/` orchestrator. That
orchestrator was removed by #637 (the `/dispatch` skill restructure), so the
bundled change was obsolete and has been dropped. The branch is now scoped to
#593 only and rebased onto current `main`.
