### PR TITLE
Update landing hero slogan to "Learn to run without"

### DIFF
--- a/landing/e2e/app-showcase.spec.ts
+++ b/landing/e2e/app-showcase.spec.ts
@@ -11,7 +11,7 @@ test.describe("app showcase", () => {
     await page.goto("/");
 
     const headline = page.locator(".landing-hero-band .landing-hero-band-headline");
-    await expect(headline).toHaveText("Build with commons.systems. Run without.");
+    await expect(headline).toHaveText("Build with commons.systems. Learn to run without.");
 
     const subline = page.locator(".landing-hero-band .landing-hero-band-subline");
     await expect(subline).toHaveText(

--- a/landing/e2e/hero.spec.ts
+++ b/landing/e2e/hero.spec.ts
@@ -65,7 +65,7 @@ test.describe("hero band", () => {
     await page.goto("/");
 
     await expect(page.locator(".landing-hero-band")).toContainText(
-      "Build with commons.systems. Run without.",
+      "Build with commons.systems. Learn to run without.",
     );
     await expect(page.locator("a.app-card")).toHaveCount(3);
   });

--- a/landing/src/showcase-render.ts
+++ b/landing/src/showcase-render.ts
@@ -13,7 +13,7 @@ export function renderShowcase(apps: AppCard[]): string {
   const cards = apps.map(renderCard).join("\n        ");
   return `<section class="landing-hero app-showcase" aria-label="Featured apps">
       <div class="landing-hero-band">
-        <p class="landing-hero-band-headline">Build with commons.systems. Run without.</p>
+        <p class="landing-hero-band-headline">Build with commons.systems. Learn to run without.</p>
         <p class="landing-hero-band-subline">Code you understand. Data you control. A roadmap you set.</p>
       </div>
       <div class="landing-hero-grid">

--- a/landing/test/showcase-render.test.ts
+++ b/landing/test/showcase-render.test.ts
@@ -28,7 +28,7 @@ const APPS: AppCard[] = [
 describe("renderShowcase", () => {
   it("contains the hero band headline", () => {
     const html = renderShowcase(APPS);
-    expect(html).toContain("Build with commons.systems. Run without.");
+    expect(html).toContain("Build with commons.systems. Learn to run without.");
   });
 
   it("contains exactly one <a class=\"app-card\" per app", () => {


### PR DESCRIPTION
Closes #631

Updates the landing hero band headline from "Build with commons.systems. Run without." to "Build with commons.systems. Learn to run without." Framing detachment as a learned practice reinforces the charter's gift-not-dependency principle.

Three tests assert the headline verbatim and are updated to match: the two e2e specs `landing/e2e/hero.spec.ts` and `landing/e2e/app-showcase.spec.ts` (named in the issue), plus the `landing/test/showcase-render.test.ts` unit test (not in the issue scope — caught by CI and fixed in the verify loop; see PR comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)