### PR TITLE
Replace Playwright storageState seeding with an addInitScript fixture

### DIFF
--- a/audio/e2e/auth.spec.ts
+++ b/audio/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import { signIn } from "@commons-systems/authutil/e2e/sign-in";
 
 test.describe("auth", () => {

--- a/audio/e2e/cache.spec.ts
+++ b/audio/e2e/cache.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("audio cache", () => {
   test("cache and replay from IndexedDB", async ({ page }) => {

--- a/audio/e2e/home.spec.ts
+++ b/audio/e2e/home.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import { signIn } from "@commons-systems/authutil/e2e/sign-in";
 
 test.describe("home page content", () => {

--- a/audio/e2e/meta-description.spec.ts
+++ b/audio/e2e/meta-description.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("meta description", () => {
   test("home page has meta description @smoke", async ({ page }) => {

--- a/audio/e2e/navigation.spec.ts
+++ b/audio/e2e/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("navigation", () => {
   test("page loads without JS errors @smoke", async ({ page }) => {

--- a/audio/e2e/responsive.spec.ts
+++ b/audio/e2e/responsive.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("responsive layout", () => {
   test("main content is visible", async ({ page }) => {

--- a/audio/e2e/robots-txt.spec.ts
+++ b/audio/e2e/robots-txt.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("robots.txt", () => {
   test("GET /robots.txt returns valid robots.txt, not HTML", async ({

--- a/audio/e2e/theme.spec.ts
+++ b/audio/e2e/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect, type Page } from "-systems/config/playwright-test";
 
 async function expectDarkBackground(page: Page) {
   const bg = await page.evaluate(() =>

--- a/audio/e2e/theme.spec.ts
+++ b/audio/e2e/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "-systems/config/playwright-test";
+import { test, expect, type Page } from "@commons-systems/config/playwright-test";
 
 async function expectDarkBackground(page: Page) {
   const bg = await page.evaluate(() =>

--- a/authutil/e2e/sign-in.ts
+++ b/authutil/e2e/sign-in.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import type { Page } from "@commons-systems/config/playwright-test";
 
 export async function signIn(
   page: Page,

--- a/budget/e2e/accounts-charts.spec.ts
+++ b/budget/e2e/accounts-charts.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("accounts charts", () => {
   test.beforeEach(async ({ page }) => {

--- a/budget/e2e/accounts-income-statement.spec.ts
+++ b/budget/e2e/accounts-income-statement.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import { uploadIncomeStatementFixture } from "./helpers";
 
 test.describe("accounts income statement", () => {

--- a/budget/e2e/accounts-reconcile.spec.ts
+++ b/budget/e2e/accounts-reconcile.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("accounts reconcile view", () => {
   test("navigating from accounts page reaches the reconcile view with query prefilled", async ({ page }) => {

--- a/budget/e2e/auth.spec.ts
+++ b/budget/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("auth", () => {
   test("Load data button visible on page load", async ({ page }) => {

--- a/budget/e2e/budgets-pie-chart.spec.ts
+++ b/budget/e2e/budgets-pie-chart.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("budgets pie chart", () => {
   test.beforeEach(async ({ page }) => {

--- a/budget/e2e/budgets-trend-charts.spec.ts
+++ b/budget/e2e/budgets-trend-charts.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("budgets trend charts", () => {
   test.beforeEach(async ({ page }) => {

--- a/budget/e2e/budgets.spec.ts
+++ b/budget/e2e/budgets.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("budgets", () => {
   test("Firestore connectivity @smoke", async ({ page }) => {

--- a/budget/e2e/export.spec.ts
+++ b/budget/e2e/export.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import { uploadFixture, uploadEncryptedFixture, triggerExportDownload } from "./helpers";
 
 test.describe("export", () => {

--- a/budget/e2e/helpers.ts
+++ b/budget/e2e/helpers.ts
@@ -2,7 +2,7 @@ import path from "path";
 import fs from "node:fs";
 import crypto from "node:crypto";
 import { fileURLToPath } from "url";
-import type { Download, Page } from "@playwright/test";
+import type { Download, Page } from "@commons-systems/config/playwright-test";
 import { SALT_LEN, IV_LEN, PBKDF2_ITERATIONS, KEY_LEN } from "../src/crypto-core.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/budget/e2e/hero.spec.ts
+++ b/budget/e2e/hero.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("hero", () => {
   test("hero section visible on landing page @smoke", async ({ page }) => {

--- a/budget/e2e/home-scroll.spec.ts
+++ b/budget/e2e/home-scroll.spec.ts
@@ -69,6 +69,46 @@ async function waitForTable(page: Page): Promise<void> {
   await expect(page.locator("#transactions-table")).toBeVisible({ timeout: 15000 });
 }
 
+/**
+ * Scroll the sentinel into view repeatedly until the row count grows past the
+ * baseline. Re-scroll on every poll iteration so the IntersectionObserver keeps
+ * firing as each loaded batch pushes the sentinel further down. The threshold
+ * adds the current hidden-row count so a filtered table still detects a newly
+ * loaded batch even when every new row is filtered out of view.
+ */
+async function scrollUntilMoreRows(page: Page, baselineVisible: number): Promise<void> {
+  const hiddenRows = page.locator('#transactions-table .txn-row[style*="display: none"]');
+  await expect(async () => {
+    await page.locator("#scroll-sentinel").scrollIntoViewIfNeeded();
+    const totalRows = await page.locator("#transactions-table .txn-row").count();
+    expect(totalRows).toBeGreaterThan(baselineVisible + (await hiddenRows.count()));
+  }).toPass({ timeout: 30000 });
+}
+
+/**
+ * Poll until every visible row's `dataset[key]` satisfies `predicate`.
+ * Scroll-loaded rows are appended as raw HTML and only hidden once the
+ * TRANSACTIONS_APPENDED_EVENT re-runs the table filter, so a single read can
+ * catch the transient window before the new rows have been filtered.
+ */
+async function expectVisibleRowsSettle(
+  page: Page,
+  key: "category" | "budgetName",
+  predicate: (value: string | undefined) => boolean,
+): Promise<void> {
+  const visibleRows = page.locator('#transactions-table .txn-row:not([style*="display: none"])');
+  await expect.poll(
+    async () => {
+      const values = await visibleRows.evaluateAll(
+        (rows, k) => rows.map((r) => (r as HTMLElement).dataset[k]),
+        key,
+      );
+      return values.every(predicate);
+    },
+    { timeout: 10000 },
+  ).toBe(true);
+}
+
 test.describe("home page infinite scroll", () => {
   test.describe("seed data — all transactions loaded without scroll", () => {
     test("seed data loads all transactions without scroll sentinel", async ({ page }) => {
@@ -166,68 +206,31 @@ test.describe("home page infinite scroll", () => {
     });
 
     test("category filter applies to scroll-loaded rows", async ({ page }) => {
-      // Set category filter to "Food:Groceries"
       const categoryInput = page.locator("#sankey-category-filter");
       await categoryInput.fill("Food:Groceries");
       await categoryInput.blur();
 
-      // Verify initial rows are filtered
-      const visibleRows = page.locator("#transactions-table .txn-row:visible");
-      const hiddenRows = page.locator('#transactions-table .txn-row[style*="display: none"]');
-      const initialVisible = await visibleRows.count();
-      expect(initialVisible).toBeGreaterThan(0);
-
-      // Scroll repeatedly until more rows load — re-scroll on every iteration so
-      // the IntersectionObserver keeps firing as new batches push the sentinel down.
-      await expect(async () => {
-        await page.locator("#scroll-sentinel").scrollIntoViewIfNeeded();
-        const totalRows = await page.locator("#transactions-table .txn-row").count();
-        expect(totalRows).toBeGreaterThan(initialVisible + await hiddenRows.count());
-      }).toPass({ timeout: 30000 });
-
-      // Verify ALL visible rows match the category filter
-      const allVisible = page.locator('#transactions-table .txn-row:not([style*="display: none"])');
-      const categories = await allVisible.evaluateAll(rows =>
-        rows.map(r => (r as HTMLElement).dataset.category)
-      );
-      for (const cat of categories) {
-        expect(cat).toMatch(/^Food/);
-      }
-    });
-
-    test("budget filter applies to scroll-loaded rows", async ({ page }) => {
-      // Set budget filter to "Groceries"
-      const budgetInput = page.locator("#sankey-budget-filter");
-      await budgetInput.fill("Groceries");
-      await budgetInput.blur();
-
-      // Verify initial rows are filtered
       const allVisible = page.locator('#transactions-table .txn-row:not([style*="display: none"])');
       const initialVisible = await allVisible.count();
       expect(initialVisible).toBeGreaterThan(0);
 
-      // Scroll repeatedly until more rows load — re-scroll on every iteration so
-      // the IntersectionObserver keeps firing as new batches push the sentinel down.
-      const hiddenRows = page.locator('#transactions-table .txn-row[style*="display: none"]');
-      await expect(async () => {
-        await page.locator("#scroll-sentinel").scrollIntoViewIfNeeded();
-        const totalRows = await page.locator("#transactions-table .txn-row").count();
-        expect(totalRows).toBeGreaterThan(initialVisible + await hiddenRows.count());
-      }).toPass({ timeout: 30000 });
+      await scrollUntilMoreRows(page, initialVisible);
 
-      // Verify ALL visible rows match the budget filter. Scroll-loaded rows are
-      // appended as raw HTML and only hidden once the TRANSACTIONS_APPENDED_EVENT
-      // re-runs the filter, so re-poll until every visible row has settled on the
-      // filtered budget rather than reading once during that transient window.
-      await expect.poll(
-        async () => {
-          const budgets = await allVisible.evaluateAll(rows =>
-            rows.map(r => (r as HTMLElement).dataset.budgetName)
-          );
-          return budgets.every(b => b === "Groceries");
-        },
-        { timeout: 10000 },
-      ).toBe(true);
+      await expectVisibleRowsSettle(page, "category", (c) => c?.startsWith("Food") ?? false);
+    });
+
+    test("budget filter applies to scroll-loaded rows", async ({ page }) => {
+      const budgetInput = page.locator("#sankey-budget-filter");
+      await budgetInput.fill("Groceries");
+      await budgetInput.blur();
+
+      const allVisible = page.locator('#transactions-table .txn-row:not([style*="display: none"])');
+      const initialVisible = await allVisible.count();
+      expect(initialVisible).toBeGreaterThan(0);
+
+      await scrollUntilMoreRows(page, initialVisible);
+
+      await expectVisibleRowsSettle(page, "budgetName", (b) => b === "Groceries");
     });
   });
 });

--- a/budget/e2e/home-scroll.spec.ts
+++ b/budget/e2e/home-scroll.spec.ts
@@ -177,12 +177,13 @@ test.describe("home page infinite scroll", () => {
       const initialVisible = await visibleRows.count();
       expect(initialVisible).toBeGreaterThan(0);
 
-      // Scroll to load more
-      await page.locator("#scroll-sentinel").scrollIntoViewIfNeeded();
+      // Scroll repeatedly until more rows load — re-scroll on every iteration so
+      // the IntersectionObserver keeps firing as new batches push the sentinel down.
       await expect(async () => {
+        await page.locator("#scroll-sentinel").scrollIntoViewIfNeeded();
         const totalRows = await page.locator("#transactions-table .txn-row").count();
         expect(totalRows).toBeGreaterThan(initialVisible + await hiddenRows.count());
-      }).toPass({ timeout: 10000 });
+      }).toPass({ timeout: 30000 });
 
       // Verify ALL visible rows match the category filter
       const allVisible = page.locator('#transactions-table .txn-row:not([style*="display: none"])');
@@ -205,13 +206,14 @@ test.describe("home page infinite scroll", () => {
       const initialVisible = await allVisible.count();
       expect(initialVisible).toBeGreaterThan(0);
 
-      // Scroll to load more
-      await page.locator("#scroll-sentinel").scrollIntoViewIfNeeded();
+      // Scroll repeatedly until more rows load — re-scroll on every iteration so
+      // the IntersectionObserver keeps firing as new batches push the sentinel down.
       const hiddenRows = page.locator('#transactions-table .txn-row[style*="display: none"]');
       await expect(async () => {
+        await page.locator("#scroll-sentinel").scrollIntoViewIfNeeded();
         const totalRows = await page.locator("#transactions-table .txn-row").count();
         expect(totalRows).toBeGreaterThan(initialVisible + await hiddenRows.count());
-      }).toPass({ timeout: 10000 });
+      }).toPass({ timeout: 30000 });
 
       // Verify ALL visible rows match the budget filter. Scroll-loaded rows are
       // appended as raw HTML and only hidden once the TRANSACTIONS_APPENDED_EVENT

--- a/budget/e2e/home-scroll.spec.ts
+++ b/budget/e2e/home-scroll.spec.ts
@@ -213,13 +213,19 @@ test.describe("home page infinite scroll", () => {
         expect(totalRows).toBeGreaterThan(initialVisible + await hiddenRows.count());
       }).toPass({ timeout: 10000 });
 
-      // Verify ALL visible rows match the budget filter
-      const budgets = await allVisible.evaluateAll(rows =>
-        rows.map(r => (r as HTMLElement).dataset.budgetName)
-      );
-      for (const b of budgets) {
-        expect(b).toBe("Groceries");
-      }
+      // Verify ALL visible rows match the budget filter. Scroll-loaded rows are
+      // appended as raw HTML and only hidden once the TRANSACTIONS_APPENDED_EVENT
+      // re-runs the filter, so re-poll until every visible row has settled on the
+      // filtered budget rather than reading once during that transient window.
+      await expect.poll(
+        async () => {
+          const budgets = await allVisible.evaluateAll(rows =>
+            rows.map(r => (r as HTMLElement).dataset.budgetName)
+          );
+          return budgets.every(b => b === "Groceries");
+        },
+        { timeout: 10000 },
+      ).toBe(true);
     });
   });
 });

--- a/budget/e2e/home-scroll.spec.ts
+++ b/budget/e2e/home-scroll.spec.ts
@@ -70,18 +70,18 @@ async function waitForTable(page: Page): Promise<void> {
 }
 
 /**
- * Scroll the sentinel into view repeatedly until the row count grows past the
- * baseline. Re-scroll on every poll iteration so the IntersectionObserver keeps
- * firing as each loaded batch pushes the sentinel further down. The threshold
- * adds the current hidden-row count so a filtered table still detects a newly
- * loaded batch even when every new row is filtered out of view.
+ * Scroll the sentinel into view repeatedly until the count of visible (non-hidden)
+ * rows grows past the baseline. Re-scroll on every poll iteration so the
+ * IntersectionObserver keeps firing as each loaded batch pushes the sentinel
+ * further down the page. A scroll-loaded batch whose rows are all filtered out
+ * of view does not advance the count — callers must use seed data that yields
+ * matching rows on scroll.
  */
 async function scrollUntilMoreRows(page: Page, baselineVisible: number): Promise<void> {
-  const hiddenRows = page.locator('#transactions-table .txn-row[style*="display: none"]');
+  const visibleRows = page.locator('#transactions-table .txn-row:not([style*="display: none"])');
   await expect(async () => {
     await page.locator("#scroll-sentinel").scrollIntoViewIfNeeded();
-    const totalRows = await page.locator("#transactions-table .txn-row").count();
-    expect(totalRows).toBeGreaterThan(baselineVisible + (await hiddenRows.count()));
+    expect(await visibleRows.count()).toBeGreaterThan(baselineVisible);
   }).toPass({ timeout: 30000 });
 }
 

--- a/budget/e2e/home-scroll.spec.ts
+++ b/budget/e2e/home-scroll.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page } from "@commons-systems/config/playwright-test";
 
 /**
  * Build a fixture JSON buffer with transactions spread over 30 weeks from today.

--- a/budget/e2e/meta-description.spec.ts
+++ b/budget/e2e/meta-description.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("meta description", () => {
   test("home page has meta description @smoke", async ({ page }) => {

--- a/budget/e2e/navigation.spec.ts
+++ b/budget/e2e/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("navigation", () => {
   test("page loads without JS errors @smoke", async ({ page }) => {

--- a/budget/e2e/normalization.spec.ts
+++ b/budget/e2e/normalization.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import {
   canonicalDescription,
   primaryAmount,

--- a/budget/e2e/prerender.spec.ts
+++ b/budget/e2e/prerender.spec.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import { uploadFixture } from "./helpers";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/budget/e2e/responsive.spec.ts
+++ b/budget/e2e/responsive.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("responsive layout", () => {
   test("main content is visible", async ({ page }) => {

--- a/budget/e2e/robots-txt.spec.ts
+++ b/budget/e2e/robots-txt.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("robots.txt", () => {
   test("GET /robots.txt returns valid robots.txt, not HTML", async ({

--- a/budget/e2e/rules.spec.ts
+++ b/budget/e2e/rules.spec.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { fileURLToPath } from "url";
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixturePath = path.join(__dirname, "fixtures", "test-budget.json");

--- a/budget/e2e/theme.spec.ts
+++ b/budget/e2e/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect, type Page } from "-systems/config/playwright-test";
 
 async function expectDarkBackground(page: Page) {
   const bg = await page.evaluate(() =>

--- a/budget/e2e/theme.spec.ts
+++ b/budget/e2e/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "-systems/config/playwright-test";
+import { test, expect, type Page } from "@commons-systems/config/playwright-test";
 
 async function expectDarkBackground(page: Page) {
   const bg = await page.evaluate(() =>

--- a/budget/e2e/transactions.spec.ts
+++ b/budget/e2e/transactions.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("transactions", () => {
   test("Firestore connectivity @smoke", async ({ page }) => {

--- a/budget/e2e/upload.spec.ts
+++ b/budget/e2e/upload.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import { uploadFixture, uploadEncryptedFixture } from "./helpers";
 
 test.describe("upload", () => {

--- a/config/cache-headers-smoke.ts
+++ b/config/cache-headers-smoke.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./playwright-test";
 
 export function describeCacheHeadersSmoke(appName: string): void {
   test.describe(`${appName} cache headers smoke`, () => {

--- a/config/package.json
+++ b/config/package.json
@@ -16,6 +16,7 @@
     "./playwright": "./playwright.js",
     "./firebase-headers.test-helper": "./firebase-headers.test-helper.ts",
     "./cache-headers-smoke": "./cache-headers-smoke.ts",
-    "./security-headers-smoke": "./security-headers-smoke.ts"
+    "./security-headers-smoke": "./security-headers-smoke.ts",
+    "./playwright-test": "./playwright-test.ts"
   }
 }

--- a/config/playwright-test.ts
+++ b/config/playwright-test.ts
@@ -1,0 +1,21 @@
+import { test as base, expect } from "@playwright/test";
+
+// Must match STORAGE_KEY in analyticsutil/src/index.ts (a non-exported const).
+const STORAGE_KEY = "analytics_traffic_type";
+
+export const test = base.extend({
+  context: async ({ context }, use) => {
+    await context.addInitScript((key: string) => {
+      try {
+        localStorage.setItem(key, "internal");
+      } catch {
+        // Opaque origins (the initial about:blank) have no accessible
+        // localStorage; the flag seeds on the first real navigation.
+      }
+    }, STORAGE_KEY);
+    await use(context);
+  },
+});
+
+export { expect };
+export type { Page, Download } from "@playwright/test";

--- a/config/playwright.js
+++ b/config/playwright.js
@@ -5,20 +5,6 @@ export default defineConfig({
   testDir: ".", // resolves relative to the consuming config file's directory
   use: {
     baseURL: process.env.BASE_URL || "http://localhost:5173",
-    // Pre-seed localStorage with the internal-traffic flag before any page loads
-    // so initAnalytics sets traffic_type=internal on the GA4 client.
-    // Storage key must match STORAGE_KEY in analyticsutil/src/index.ts.
-    storageState: {
-      cookies: [],
-      origins: [
-        {
-          origin: process.env.BASE_URL || "http://localhost:5173",
-          localStorage: [
-            { name: "analytics_traffic_type", value: "internal" },
-          ],
-        },
-      ],
-    },
   },
   projects: [
     {

--- a/config/security-headers-smoke.ts
+++ b/config/security-headers-smoke.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./playwright-test";
 
 const expectedHeaders: {
   header: string;

--- a/fellspiral/e2e/admin.spec.ts
+++ b/fellspiral/e2e/admin.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import { signIn } from "@commons-systems/authutil/e2e/sign-in";
 
 test.describe("admin", () => {

--- a/fellspiral/e2e/auth.spec.ts
+++ b/fellspiral/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import { signIn } from "@commons-systems/authutil/e2e/sign-in";
 
 test.describe("auth", () => {

--- a/fellspiral/e2e/blog.spec.ts
+++ b/fellspiral/e2e/blog.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 // Blog post content is inlined at build time by the vite blog-posts plugin.
 // No route interception is needed -- content comes from the build output.

--- a/fellspiral/e2e/build-time-content.spec.ts
+++ b/fellspiral/e2e/build-time-content.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 // These tests verify that build-time inlined blog content is present in the
 // served HTML without requiring async fetches. No route interception is used --

--- a/fellspiral/e2e/cache-headers-smoke.spec.ts
+++ b/fellspiral/e2e/cache-headers-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import { describeCacheHeadersSmoke } from "@commons-systems/config/cache-headers-smoke";
 
 describeCacheHeadersSmoke("fellspiral");

--- a/fellspiral/e2e/cls.spec.ts
+++ b/fellspiral/e2e/cls.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 interface ShiftEntry {
   value: number;

--- a/fellspiral/e2e/console-errors.spec.ts
+++ b/fellspiral/e2e/console-errors.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("console errors", () => {
   test("no atom-strategy-fetch errors on page load @smoke", async ({

--- a/fellspiral/e2e/css-loading.spec.ts
+++ b/fellspiral/e2e/css-loading.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("CSS loading", () => {
   test("critical CSS is inlined in the head @smoke", async ({ page }) => {

--- a/fellspiral/e2e/font-smoke.spec.ts
+++ b/fellspiral/e2e/font-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("font smoke", () => {
   test("no external Google Fonts requests @smoke", async ({ page }) => {

--- a/fellspiral/e2e/image-optimization.spec.ts
+++ b/fellspiral/e2e/image-optimization.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 // Verify that blog post images are optimized: WebP format, explicit dimensions,
 // fetchpriority on the LCP image, and lazy loading on below-fold images.

--- a/fellspiral/e2e/image-smoke.spec.ts
+++ b/fellspiral/e2e/image-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 const IMAGE_PATHS = [
   "/woman-with-a-flower-head.webp",

--- a/fellspiral/e2e/info-panel.spec.ts
+++ b/fellspiral/e2e/info-panel.spec.ts
@@ -107,18 +107,15 @@ test.describe("info panel — header alignment", () => {
     await page.goto("/");
     await page.waitForSelector("main h2", { timeout: 30000 });
 
-    // The header and main column-1 left edges are governed by identical CSS grid
-    // templates, but a late font load or stylesheet application can shift the
-    // header by ~1 filigree width before layout settles. Re-measure both boxes
-    // until they agree; a genuine misalignment still fails at the timeout.
-    await expect.poll(
-      async () => {
-        const headerBox = await page.locator("header").boundingBox();
-        const mainBox = await page.locator("main").boundingBox();
-        if (!headerBox || !mainBox) return Number.NaN;
-        return Math.abs(headerBox.x - mainBox.x);
-      },
-      { timeout: 10000 },
-    ).toBeLessThanOrEqual(2);
+    // `layout.css` pins `.content-grid > main` to its grid column start
+    // (`max-inline-size: none; margin-inline: 0`), so main's left edge no longer
+    // depends on font-metric-derived widths. The header and main left edges
+    // therefore coincide regardless of whether the web font or the fallback font
+    // is active — the alignment is deterministic, so a direct assertion suffices.
+    const headerBox = await page.locator("header").boundingBox();
+    const mainBox = await page.locator("main").boundingBox();
+    expect(headerBox).not.toBeNull();
+    expect(mainBox).not.toBeNull();
+    expect(Math.abs(headerBox!.x - mainBox!.x)).toBeLessThanOrEqual(2);
   });
 });

--- a/fellspiral/e2e/info-panel.spec.ts
+++ b/fellspiral/e2e/info-panel.spec.ts
@@ -107,11 +107,9 @@ test.describe("info panel — header alignment", () => {
     await page.goto("/");
     await page.waitForSelector("main h2", { timeout: 30000 });
 
-    // `layout.css` pins `.content-grid > main` to its grid column start
-    // (`max-inline-size: none; margin-inline: 0`), so main's left edge no longer
-    // depends on font-metric-derived widths. The header and main left edges
-    // therefore coincide regardless of whether the web font or the fallback font
-    // is active — the alignment is deterministic, so a direct assertion suffices.
+    // `layout.css` pins `.content-grid > main` to its grid column start, so
+    // header/main left-edge alignment no longer depends on which font loads —
+    // it is deterministic, and a direct assertion suffices (no font-load wait).
     const headerBox = await page.locator("header").boundingBox();
     const mainBox = await page.locator("main").boundingBox();
     expect(headerBox).not.toBeNull();

--- a/fellspiral/e2e/info-panel.spec.ts
+++ b/fellspiral/e2e/info-panel.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("info panel — desktop", () => {
   test("aside is visible with core sections", async ({ page }, testInfo) => {

--- a/fellspiral/e2e/info-panel.spec.ts
+++ b/fellspiral/e2e/info-panel.spec.ts
@@ -107,11 +107,18 @@ test.describe("info panel — header alignment", () => {
     await page.goto("/");
     await page.waitForSelector("main h2", { timeout: 30000 });
 
-    const headerBox = await page.locator("header").boundingBox();
-    const mainBox = await page.locator("main").boundingBox();
-
-    expect(headerBox).not.toBeNull();
-    expect(mainBox).not.toBeNull();
-    expect(Math.abs(headerBox!.x - mainBox!.x)).toBeLessThanOrEqual(2);
+    // The header and main column-1 left edges are governed by identical CSS grid
+    // templates, but a late font load or stylesheet application can shift the
+    // header by ~1 filigree width before layout settles. Re-measure both boxes
+    // until they agree; a genuine misalignment still fails at the timeout.
+    await expect.poll(
+      async () => {
+        const headerBox = await page.locator("header").boundingBox();
+        const mainBox = await page.locator("main").boundingBox();
+        if (!headerBox || !mainBox) return Number.NaN;
+        return Math.abs(headerBox.x - mainBox.x);
+      },
+      { timeout: 10000 },
+    ).toBeLessThanOrEqual(2);
   });
 });

--- a/fellspiral/e2e/navigation.spec.ts
+++ b/fellspiral/e2e/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("navigation", () => {
   test("page loads without JS errors @smoke", async ({ page }) => {

--- a/fellspiral/e2e/og-meta-smoke.spec.ts
+++ b/fellspiral/e2e/og-meta-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("og meta smoke", () => {
   test("home page has meta description @smoke", async ({ page }) => {

--- a/fellspiral/e2e/og-meta.spec.ts
+++ b/fellspiral/e2e/og-meta.spec.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
-function getMeta(page: import("@playwright/test").Page, selector: string) {
+function getMeta(page: import("@commons-systems/config/playwright-test").Page, selector: string) {
   return page.evaluate(
     (sel) => document.querySelector(sel)?.getAttribute("content") ?? null,
     selector,

--- a/fellspiral/e2e/responsive.spec.ts
+++ b/fellspiral/e2e/responsive.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("responsive layout", () => {
   test("main content is visible", async ({ page }) => {

--- a/fellspiral/e2e/robots-txt.spec.ts
+++ b/fellspiral/e2e/robots-txt.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("robots.txt", () => {
   test("GET /robots.txt returns valid robots.txt, not HTML", async ({

--- a/fellspiral/e2e/rss-feed-smoke.spec.ts
+++ b/fellspiral/e2e/rss-feed-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("rss feed smoke", () => {
   test("GET /feed.xml returns RSS XML @smoke", async ({ page }) => {

--- a/fellspiral/e2e/rss-feed.spec.ts
+++ b/fellspiral/e2e/rss-feed.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("rss feed", () => {
   test("GET /feed.xml returns valid RSS 2.0", async ({ page }) => {

--- a/fellspiral/e2e/scroll-indicator.spec.ts
+++ b/fellspiral/e2e/scroll-indicator.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("scroll indicator", () => {
   test("scroll indicator repositions on viewport resize", async ({ page }, testInfo) => {

--- a/fellspiral/e2e/security-headers.spec.ts
+++ b/fellspiral/e2e/security-headers.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("security headers", () => {
   test("content-security-policy includes key directives", async ({ page }) => {

--- a/fellspiral/e2e/theme.spec.ts
+++ b/fellspiral/e2e/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "-systems/config/playwright-test";
+import { test, expect, type Page } from "@commons-systems/config/playwright-test";
 
 async function expectLightBackground(page: Page) {
   const bg = await page.evaluate(() =>

--- a/fellspiral/e2e/theme.spec.ts
+++ b/fellspiral/e2e/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect, type Page } from "-systems/config/playwright-test";
 
 async function expectLightBackground(page: Page) {
   const bg = await page.evaluate(() =>

--- a/landing/e2e/admin.spec.ts
+++ b/landing/e2e/admin.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import { signIn } from "@commons-systems/authutil/e2e/sign-in";
 
 test.describe("admin", () => {

--- a/landing/e2e/app-showcase-seo.spec.ts
+++ b/landing/e2e/app-showcase-seo.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 const APPS = [
   {
@@ -22,7 +22,7 @@ const APPS = [
 ];
 
 async function getSoftwareApplicationJsonLd(
-  page: import("@playwright/test").Page,
+  page: import("@commons-systems/config/playwright-test").Page,
 ) {
   const scripts = await page
     .locator('script[type="application/ld+json"]')

--- a/landing/e2e/app-showcase.spec.ts
+++ b/landing/e2e/app-showcase.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 const APP_HREFS = [
   "https://budget.commons.systems",

--- a/landing/e2e/auth.spec.ts
+++ b/landing/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import { signIn } from "@commons-systems/authutil/e2e/sign-in";
 
 test.describe("auth", () => {

--- a/landing/e2e/blog-smoke.spec.ts
+++ b/landing/e2e/blog-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 // Smoke tests run against a deployed preview URL via run-smoke-tests.sh
 // (--grep @smoke). They verify the meta description tag and that the

--- a/landing/e2e/blog.spec.ts
+++ b/landing/e2e/blog.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 // Blog post content is inlined at build time by the vite blog-posts plugin.
 // No route interception is needed -- content comes from the build output.

--- a/landing/e2e/css-loading.spec.ts
+++ b/landing/e2e/css-loading.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("CSS loading", () => {
   test("critical CSS is inlined in the head @smoke", async ({ page }) => {

--- a/landing/e2e/font-smoke.spec.ts
+++ b/landing/e2e/font-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("font smoke", () => {
   test("no external Google Fonts requests @smoke", async ({ page }) => {

--- a/landing/e2e/hero.spec.ts
+++ b/landing/e2e/hero.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("hero band", () => {
   test("H1 and tagline render above the fold", async ({ page }) => {

--- a/landing/e2e/info-panel.spec.ts
+++ b/landing/e2e/info-panel.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.beforeEach(async ({ page }) => {
   await page.route("https://raw.githubusercontent.com/**", (route) =>

--- a/landing/e2e/navigation.spec.ts
+++ b/landing/e2e/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("navigation", () => {
   test("page loads without JS errors @smoke", async ({ page }) => {

--- a/landing/e2e/og-meta.spec.ts
+++ b/landing/e2e/og-meta.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("og meta", () => {
   test("post page renders with history-mode URL", async ({ page }) => {

--- a/landing/e2e/preconnect.spec.ts
+++ b/landing/e2e/preconnect.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("landing preconnect links", () => {
   test("preconnect links are present for Google API domains", async ({

--- a/landing/e2e/responsive.spec.ts
+++ b/landing/e2e/responsive.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("responsive layout", () => {
   test("main content is visible", async ({ page }) => {

--- a/landing/e2e/robots-txt.spec.ts
+++ b/landing/e2e/robots-txt.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("robots.txt", () => {
   test("GET /robots.txt returns valid robots.txt, not HTML", async ({

--- a/landing/e2e/seo.spec.ts
+++ b/landing/e2e/seo.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 const SITE_URL = "https://commons.systems";
 
-async function getJsonLd(page: import("@playwright/test").Page, type: string) {
+async function getJsonLd(page: import("@commons-systems/config/playwright-test").Page, type: string) {
   const scripts = await page.locator('script[type="application/ld+json"]').all();
   for (const s of scripts) {
     const text = await s.textContent();

--- a/landing/e2e/theme.spec.ts
+++ b/landing/e2e/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect, type Page } from "-systems/config/playwright-test";
 
 async function expectDarkBackground(page: Page) {
   const bg = await page.evaluate(() =>

--- a/landing/e2e/theme.spec.ts
+++ b/landing/e2e/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "-systems/config/playwright-test";
+import { test, expect, type Page } from "@commons-systems/config/playwright-test";
 
 async function expectDarkBackground(page: Page) {
   const bg = await page.evaluate(() =>

--- a/print/e2e/auth.spec.ts
+++ b/print/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import { signIn } from "@commons-systems/authutil/e2e/sign-in";
 
 test.describe("auth", () => {

--- a/print/e2e/media.spec.ts
+++ b/print/e2e/media.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("media", () => {
   test("Firestore connectivity @smoke", async ({ page }) => {

--- a/print/e2e/meta-description.spec.ts
+++ b/print/e2e/meta-description.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("meta description", () => {
   test("home page has meta description @smoke", async ({ page }) => {

--- a/print/e2e/navigation.spec.ts
+++ b/print/e2e/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("navigation", () => {
   test("page loads without JS errors @smoke", async ({ page }) => {

--- a/print/e2e/responsive.spec.ts
+++ b/print/e2e/responsive.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("responsive layout", () => {
   test("main content is visible", async ({ page }) => {

--- a/print/e2e/robots-txt.spec.ts
+++ b/print/e2e/robots-txt.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("robots.txt", () => {
   test("GET /robots.txt returns valid robots.txt, not HTML", async ({

--- a/print/e2e/theme.spec.ts
+++ b/print/e2e/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect, type Page } from "-systems/config/playwright-test";
 
 async function expectDarkBackground(page: Page) {
   const bg = await page.evaluate(() =>

--- a/print/e2e/theme.spec.ts
+++ b/print/e2e/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "-systems/config/playwright-test";
+import { test, expect, type Page } from "@commons-systems/config/playwright-test";
 
 async function expectDarkBackground(page: Page) {
   const bg = await page.evaluate(() =>

--- a/print/e2e/viewer.spec.ts
+++ b/print/e2e/viewer.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("viewer", () => {
   // Public seed items (by addedAt desc):

--- a/scaffolding/firebase/templates/app/e2e/auth.spec.ts
+++ b/scaffolding/firebase/templates/app/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 import { signIn } from "@commons-systems/authutil/e2e/sign-in";
 
 test.describe("auth", () => {

--- a/scaffolding/firebase/templates/app/e2e/messages.spec.ts.tmpl
+++ b/scaffolding/firebase/templates/app/e2e/messages.spec.ts.tmpl
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("messages", () => {
   test("Firestore connectivity @smoke", async ({ page }) => {

--- a/scaffolding/firebase/templates/app/e2e/navigation.spec.ts.tmpl
+++ b/scaffolding/firebase/templates/app/e2e/navigation.spec.ts.tmpl
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("navigation", () => {
   test("page loads without JS errors @smoke", async ({ page }) => {

--- a/scaffolding/firebase/templates/app/e2e/responsive.spec.ts
+++ b/scaffolding/firebase/templates/app/e2e/responsive.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("responsive layout", () => {
   test("main content is visible", async ({ page }) => {

--- a/scaffolding/firebase/templates/app/e2e/robots-txt.spec.ts
+++ b/scaffolding/firebase/templates/app/e2e/robots-txt.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("robots.txt", () => {
   test("GET /robots.txt returns valid robots.txt, not HTML", async ({

--- a/scaffolding/firebase/templates/app/e2e/theme.spec.ts
+++ b/scaffolding/firebase/templates/app/e2e/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect, type Page } from "-systems/config/playwright-test";
 
 async function expectDarkBackground(page: Page) {
   const bg = await page.evaluate(() =>

--- a/scaffolding/firebase/templates/app/e2e/theme.spec.ts
+++ b/scaffolding/firebase/templates/app/e2e/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "-systems/config/playwright-test";
+import { test, expect, type Page } from "@commons-systems/config/playwright-test";
 
 async function expectDarkBackground(page: Page) {
   const bg = await page.evaluate(() =>

--- a/style/layout.css
+++ b/style/layout.css
@@ -5,6 +5,24 @@
   contain: layout style;
 }
 
+/*
+ * missing.css sets `main { max-inline-size: var(--eff-line-length); inline-size: 100%;
+ * margin-inline: auto }`, which self-centers a top-level `main` in the viewport. Inside
+ * `.content-grid` we own the column layout, so pin `main` to the grid column start.
+ * Without this override, whenever the grid column resolves wider than `--eff-line-length`,
+ * `main` caps at `--eff-line-length` and auto-centers within its column — its left edge
+ * drifts right of the header's. The column width depends on a `25ch` sidebar value whose
+ * px equivalent shifts with font metrics; under `font-display: optional` the web font may
+ * miss its block period on a cold load and the fallback font's metrics apply for the page
+ * lifetime, so the misalignment is environment-specific (warm caches hide it locally).
+ * Removing the cap and zeroing the margins makes `main` fill the column from its start
+ * regardless of which font is active, so header and main left edges always coincide.
+ */
+.content-grid > main {
+  max-inline-size: none;
+  margin-inline: 0;
+}
+
 @media (min-width: 768px) {
   .content-grid {
     grid-template-columns: 1fr var(--sidebar-width, 16rem);


### PR DESCRIPTION
Closes #632

## Problem

Playwright smoke tests flaked during browser context setup. `config/playwright.js` seeded the `analytics_traffic_type=internal` localStorage key via `storageState.origins`. Because localStorage is origin-scoped, Playwright honored `storageState` by navigating to the deployed site during every `browser.newContext` — waiting for the full `load` event — purely to write one key. With a fresh context per test, the suite performed that heavy navigation once per spec on top of each test's own `page.goto`. One context-setup navigation against a slow cold URL exceeded the 30s test timeout.

## Fix

Seed the flag with `context.addInitScript` instead. An init script runs in the page before any page script, with no navigation of its own — leaving each test's existing `page.goto` as the only navigation. This makes the `browser.newContext … navigating to …` failure mode structurally impossible and roughly halves the suite's total navigations. No retry logic is added — the goal is for the failure mode to be impossible, not retried.

## Changes

- **`config/playwright-test.ts`** (new) — extends Playwright's base `test`, overriding the `context` fixture to register a `context.addInitScript` that sets the `analytics_traffic_type` localStorage key to `internal` (guarded with try/catch for opaque origins like the initial `about:blank`). Re-exports `expect` and the `Page`/`Download` types.
- **`config/package.json`** — adds the `"./playwright-test"` export entry.
- **`config/playwright.js`** — removes the `storageState` block.
- **85 test-defining files repointed** — app `e2e/` specs (audio, budget, fellspiral, landing, print), `authutil/e2e/`, the two `config/*-smoke.ts` helpers, and the scaffolding template e2e specs now import `test`/`expect` from the new fixture module instead of `@playwright/test`.

### Test-stability follow-ons

Dropping the `storageState` context navigation shifts e2e timing, which surfaced two latent flakes. Both are fixed here rather than in a separate PR because they only reproduce once that navigation is gone:

- **`style/layout.css`** (production CSS change to the shared `style` package) — pins `.content-grid > main` to its grid column start (`max-inline-size: none; margin-inline: 0`), overriding missing.css's self-centering of a top-level `main`. When the grid column resolves wider than `--eff-line-length`, `main` previously capped at `--eff-line-length` and auto-centered, drifting its left edge right of the header's — an environment-specific misalignment under `font-display: optional` cold loads. The override makes header/main left-edge alignment deterministic, which the fellspiral/landing `info-panel.spec.ts` alignment assertions now rely on (the prior font-load wait is dropped).
- **`budget/e2e/home-scroll.spec.ts`** — extracts `scrollUntilMoreRows` and `expectVisibleRowsSettle` helpers and hardens the category/budget scroll-filter tests against an IntersectionObserver race: the sentinel is re-scrolled into view on every poll iteration so the observer keeps firing, and `expect.poll` covers the transient window before scroll-loaded raw-HTML rows are filtered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
