### PR TITLE
Add /dispatch skill to orchestrate the issue workflow

### DIFF
--- a/.claude/skills/dispatch-qa/SKILL.md
+++ b/.claude/skills/dispatch-qa/SKILL.md
@@ -5,7 +5,16 @@ description: Post-implementation user-acceptance QA — single pass, no wiggum-l
 
 # Dispatch: User-Acceptance QA
 
-Invoked by `./dispatch/bin/dispatch <issue-num>` after the implementation phase reports `phase_signal=complete`. The dispatcher launched Claude with `claude -w <branch> "/dispatch-qa #<issue-num>"`, so the WorktreeCreate hook has already placed the session in the correct worktree, written `CLAUDE.local.md`, and exported `DISPATCH_ISSUE_NUM` and `DISPATCH_STATE_FILE`.
+Runs a single user-acceptance QA pass on an implemented PR. Invoked three ways:
+
+- By the `/dispatch` skill — the session is already inside the target worktree.
+- Standalone with no argument — `/dispatch-qa` self-selects the highest-priority
+  QA-phase PR.
+- Standalone, or via the legacy `./dispatch/bin/dispatch` dispatcher, with an
+  explicit `#<issue>` argument.
+
+**Step 0** resolves the target issue and its worktree for all three paths. The
+remaining steps use the Step-0-resolved issue number `<N>`.
 
 This skill is a **single user-acceptance pass**. It does not iterate, does not enter plan mode, does not modify code, and does not commit. The recovery path for any bug found is "re-dispatch the original issue" — this skill records and continues.
 
@@ -17,6 +26,43 @@ This skill is a **single user-acceptance pass**. It does not iterate, does not e
 - **No code changes, commits, or pushes.**
 
 ## Steps
+
+0. **Target resolution.**
+
+   Establish the target issue number `<N>` and ensure the session is in the
+   target's worktree. Precedence:
+
+   1. **An issue/PR number argument is given** (leading `#` optional) → that issue
+      is the target.
+   2. **Else the current branch matches `<issue>-*`** (the session is already inside
+      a target worktree) → use that issue number.
+   3. **Else** (standalone: no argument, not in a target worktree) → run:
+      ```bash
+      .claude/skills/dispatch/scripts/dispatch-select-target --qa
+      ```
+      It prints `pr <num> <branch>` (the highest-priority QA-phase PR) or `empty`.
+      On `empty`, report that there is no QA-phase work and **stop**. Otherwise the
+      printed PR's issue number is the target.
+
+   Then, **when the session is not already in the target's worktree**, resolve or
+   create it via `EnterWorktree`, matching `/dispatch` Step 3. `EnterWorktree`
+   accepts exactly one of `path` (switch to an existing worktree) or `name`
+   (create a new one):
+
+   - **Already in the target's worktree** (current branch starts with `<issue>-`) →
+     proceed to Step 1.
+   - **An existing worktree matches** `<issue>-*` (parse `git worktree list
+     --porcelain` as blank-line-delimited records) → `EnterWorktree` with `path:`
+     set to that path.
+   - **No existing worktree** → generate a sanitized branch name `<issue>-<slug>`:
+     lowercase the issue title, replace non-alphanumeric runs with `-`, collapse
+     repeated `-`, strip leading/trailing `-`, and truncate so the full branch name
+     is ≤ 32 characters. `EnterWorktree` with `name:` set to that branch name.
+     Creating via `name:` fires the `WorktreeCreate` hook, which runs
+     `sync-issue-context` and populates `CLAUDE.local.md` with full issue context.
+
+   Step 0 establishes the issue number `<N>` that the remaining steps use for their
+   `tmp/` filenames.
 
 1. **Detect whether the implementation has a browser component.**
 
@@ -92,7 +138,7 @@ This skill is a **single user-acceptance pass**. It does not iterate, does not e
             - On interaction failure: retry once, then record **SKIP** and continue.
             - 3 consecutive SKIPs → stop the walkthrough early.
             - Stay on the App URL domain — do not follow external links.
-      8. Stop GIF recording: `gif_creator` with `action: "stop_recording"`. Export to `tmp/dispatch-qa-walkthrough-<n>.gif` (where `<n>` is `$DISPATCH_ISSUE_NUM`).
+      8. Stop GIF recording: `gif_creator` with `action: "stop_recording"`. Export to `tmp/dispatch-qa-walkthrough-<n>.gif` (where `<n>` is the Step-0-resolved issue number `<N>`).
       9. Write per-item results (PASS/FAIL/SKIP, console errors, network failures, summary counts) to `tmp/dispatch-qa-results-<n>.txt`.
 
 4. **Non-browser path.**
@@ -117,7 +163,7 @@ This skill is a **single user-acceptance pass**. It does not iterate, does not e
    ```
    where `$BRANCH` is the current branch (`git rev-parse --abbrev-ref HEAD`).
 
-   Write a markdown summary to `tmp/dispatch-qa-summary-<n>.md` (where `<n>` is `$DISPATCH_ISSUE_NUM`). Include:
+   Write a markdown summary to `tmp/dispatch-qa-summary-<n>.md` (where `<n>` is the Step-0-resolved issue number `<N>`). Include:
    - Items walked.
    - PASS / FAIL / SKIP counts.
    - List of bugs reported (if any), each with the item title and the user's report.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: dispatch
+description: Orchestrate the issue workflow — select the next task, derive its phase, and dispatch exactly one phase skill
+---
+
+# Dispatch
+
+Selects the single most pressing task, resolves its worktree, derives the current
+workflow phase from PR/issue status, and dispatches **exactly one phase skill** —
+then stops. Re-invoke `/dispatch` (or `/loop /dispatch`) to advance to the next phase.
+
+`/dispatch` takes an **optional issue-number argument** (leading `#` optional). With
+an argument, it targets that issue and skips the queue scan.
+
+Run `/dispatch` from the **main worktree**. Step 3 switches into the target's
+worktree via `EnterWorktree`; the phase skill runs there.
+
+Run `gh` and git-index-writing commands (`git add`, `gh pr ready`, `gh label create`)
+with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
+
+## 1. Select the Target
+
+- **Issue argument given** → strip any leading `#`; that issue is the target.
+  Skip the queue scan.
+- **No argument** → run the selection script:
+
+  ```bash
+  .claude/skills/dispatch/scripts/dispatch-select-target
+  ```
+
+  It prints exactly one line:
+  - `pr <num> <branch>` — a PR to work on
+  - `issue <num>` — a `help wanted` issue to implement
+  - `empty` — nothing eligible
+
+  Priority order it implements: oldest non-QA-phase open PR with no local worktree →
+  oldest open `help wanted` issue → oldest QA-phase open PR with no local worktree →
+  `empty`.
+
+  On `empty` → report that the queue is empty and **stop**.
+
+## 2. Trace to an Open Leaf
+
+When the resolved target is an **open issue with no PR** — whether queue-selected
+(`issue <num>`) or named by argument — trace to its open leaf:
+
+```bash
+.claude/skills/dispatch/scripts/dispatch-trace-leaf <N>
+```
+
+It walks open blockers and sub-issues to an open leaf and prints one issue number.
+Retarget to that leaf.
+
+Skip leaf tracing once a PR exists for the target (the `pr <num> <branch>` selection
+result, or an explicit issue argument that already has a PR) — implementation is
+already underway.
+
+If a named target issue is **closed**, report it and **stop**.
+
+## 3. Resolve the Worktree
+
+Resolve or create the final target's worktree via `EnterWorktree`, matching
+`pr-workflow` Sections 2–3. `EnterWorktree` accepts exactly one of `path` (switch to
+an existing worktree) or `name` (create a new one; fires the `WorktreeCreate` hook).
+
+- **Already in the target's worktree** (current branch starts with `<issue>-`) →
+  proceed to Step 4.
+- **An existing worktree matches** `<issue>-*` (parse `git worktree list --porcelain`
+  as blank-line-delimited records) → `EnterWorktree` with `path:` set to that path.
+- **No existing worktree** → generate a sanitized branch name `<issue>-<slug>`:
+  lowercase the issue title, replace non-alphanumeric runs with `-`, collapse repeated
+  `-`, strip leading/trailing `-`, and truncate so the full branch name is ≤ 32
+  characters. `EnterWorktree` with `name:` set to that branch name.
+
+Creating via `name:` fires the `WorktreeCreate` hook, which runs `sync-issue-context`
+and populates `CLAUDE.local.md` with full issue context.
+
+## 4. Derive the Phase
+
+Run the phase script against the final target (issue number or branch):
+
+```bash
+.claude/skills/dispatch/scripts/dispatch-phase <target>
+```
+
+It prints exactly one phase name. CI status is checked **before** labels — a draft PR
+with non-green CI is always `verify`, regardless of which `dispatch:*` labels are
+present. Map the phase:
+
+| Phase | Meaning | Next action |
+|---|---|---|
+| `implement` | no PR on the target | relevance review (Step 6), then `/dispatch-implement` |
+| `verify` | draft PR, CI not green (failing, pending, or empty rollup) | `/dispatch-implement` with a resume hint → its verify loop |
+| `qa` | draft PR, CI green, no `dispatch:*` label | `/dispatch-qa` → then label `dispatch:qa-done` |
+| `simplify` | draft PR + `dispatch:qa-done` | `/simplify` → then label `dispatch:refactored` |
+| `review` | draft PR + `dispatch:refactored` | `/review` → then label `dispatch:reviewed` |
+| `security` | draft PR + `dispatch:reviewed` | `/security-review` → then label `dispatch:security-reviewed` |
+| `ready` | draft PR + `dispatch:security-reviewed` | `gh pr ready <pr>` — flip draft to ready, workflow complete |
+| `done` | non-draft (ready) PR | already complete — report and skip |
+
+## 5. Dispatch One Phase, Then Stop
+
+Invoke the one mapped phase skill via the Skill tool. Run exactly one phase per
+`/dispatch` invocation.
+
+- **`implement`** — run the Step 6 relevance review first. If it passes, invoke
+  `/dispatch-implement` (see the bridge note below). The draft PR's existence plus
+  its CI status is its own marker — `/dispatch-implement` gets **no** `dispatch:*`
+  label.
+- **`verify`** — invoke `/dispatch-implement` (see the bridge note below) with a
+  resume hint that tells it to resume at the post-implementation verify loop
+  (Step 2.5). No label.
+- **`qa` / `simplify` / `review` / `security`** — invoke the mapped skill
+  (`/dispatch-qa`, `/simplify`, `/review`, `/security-review`). After it **returns**,
+  apply the accumulating `dispatch:*` label to the PR (see below).
+- **`ready`** — run `gh pr ready <pr-num>` to flip the draft to ready-for-review.
+  The workflow is complete.
+- **`done`** — report that the PR is already ready and skip.
+
+The PR stays a **draft** through every phase; only the `ready` phase flips it.
+
+After dispatching the one phase and applying any label, **STOP** — do not advance to
+the next phase.
+
+`/ultrareview` is intentionally **never** invoked: it is user-triggered and billed,
+so `/dispatch` cannot launch it.
+
+### Applying the progress label
+
+The four `dispatch:*` labels — `dispatch:qa-done`, `dispatch:refactored`,
+`dispatch:reviewed`, `dispatch:security-reviewed` — are the accumulating progress
+markers. Apply a label only **after** the corresponding phase skill returns
+successfully; this keeps the generic `/simplify`, `/review`, and `/security-review`
+skills dispatch-unaware.
+
+Before applying, ensure the labels exist idempotently — run this for each of the four
+names (safe on forks where the labels do not yet exist):
+
+```bash
+gh label create "dispatch:<name>" --color BFD4F2 --description "<phase> phase complete" 2>/dev/null || true
+```
+
+Then apply the label for the completed phase:
+
+```bash
+gh pr edit <pr-num> --add-label "dispatch:<name>"
+```
+
+## 6. Pre-Implementation Relevance Review
+
+Before invoking `/dispatch-implement` on an `implement`-phase (no-PR) issue, run the
+`ref-ready` Step 3e relevance check against the current codebase: has the codebase
+evolved to make the issue obsolete, or are any requirements already addressed by
+existing code?
+
+- **Still relevant** → proceed to invoke `/dispatch-implement`.
+- **Obsolete or already addressed** → **stop** and report to the user what made the
+  issue obsolete or what already exists, and recommend closing the issue or
+  re-running `/ready`. Do **not** invoke `/dispatch-implement`.
+
+This review is **skipped** for the `verify` resume case — a PR already exists and
+implementation is underway.
+
+## `/dispatch-implement` env-var bridge
+
+`/dispatch-implement` expects the legacy dispatcher's `DISPATCH_ISSUE_NUM` and
+`DISPATCH_STATE_FILE` env vars, which are not set when `/dispatch` invokes it as a
+skill. When invoking `/dispatch-implement` (the `implement` and `verify` rows):
+
+1. Treat the resolved issue number `<N>` as `DISPATCH_ISSUE_NUM`, and
+   `tmp/dispatch-<N>.json` as `DISPATCH_STATE_FILE`.
+2. Seed the state file first so the `restore-dispatch-skill.sh` recovery hook still
+   works through `/dispatch-implement`'s plan-mode context clear:
+
+   ```bash
+   [ -f tmp/dispatch-<N>.json ] || { mkdir -p tmp && printf '{}' > tmp/dispatch-<N>.json; }
+   ```
+
+3. Invoke `/dispatch-implement` with argument `#<N>`.
+4. For the `verify` row, also pass a free-form resume hint instructing it to resume
+   at the post-implementation verify loop (Step 2.5).
+
+Fully decoupling `/dispatch-implement` from this legacy plumbing is a tracked
+follow-up — out of scope here.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -33,9 +33,11 @@ with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
   - `issue <num>` — a `help wanted` issue to implement
   - `empty` — nothing eligible
 
-  Priority order it implements: oldest non-QA-phase open PR with no local worktree →
-  oldest open `help wanted` issue → oldest QA-phase open PR with no local worktree →
-  `empty`.
+  Priority order it implements (highest first; within a tier, oldest PR wins; PRs
+  with a local worktree are skipped): oldest `ready` PR → oldest `security` PR →
+  oldest `review` PR → oldest `simplify` PR → oldest `verify` PR → oldest `help
+  wanted` issue → oldest `qa` PR → `empty`. Non-QA PRs are ranked closest-to-done
+  first; `help wanted` issues rank below all non-QA PRs but above QA PRs.
 
   On `empty` → report that the queue is empty and **stop**.
 

--- a/.claude/skills/dispatch/scripts/dispatch-phase
+++ b/.claude/skills/dispatch/scripts/dispatch-phase
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Print the current workflow phase for an issue or branch.
+# Usage: dispatch-phase <issue-num|branch>
+#
+# Prints exactly one phase name to stdout:
+#   implement | verify | qa | simplify | review | security | ready | done
+#
+# Argument resolution:
+#   - All-digit arg: treated as an issue number. The matching PR is the one
+#     whose headRefName starts with "<issue>-".
+#   - Otherwise: treated as a branch name. Matched exactly.
+set -euo pipefail
+
+ARG="${1:-}"
+if [[ -z "$ARG" ]]; then
+  echo "error: usage: dispatch-phase <issue-num|branch>" >&2
+  exit 1
+fi
+
+# Fetch all open PRs with the fields we need.
+PR_LIST=$(gh pr list --state open --json number,headRefName,isDraft,statusCheckRollup,labels)
+
+# Find the matching PR.
+if [[ "$ARG" =~ ^[0-9]+$ ]]; then
+  # Issue number: find PR whose headRefName starts with "<num>-"
+  ISSUE_NUM="$ARG"
+  PR=$(printf '%s' "$PR_LIST" | jq --arg num "${ISSUE_NUM}-" \
+    'map(select(.headRefName | startswith($num))) | .[0] // empty')
+else
+  # Branch name: exact match
+  PR=$(printf '%s' "$PR_LIST" | jq --arg branch "$ARG" \
+    'map(select(.headRefName == $branch)) | .[0] // empty')
+fi
+
+# No matching PR → implement.
+if [[ -z "$PR" || "$PR" == "null" ]]; then
+  echo "implement"
+  exit 0
+fi
+
+IS_DRAFT=$(printf '%s' "$PR" | jq -r '.isDraft')
+
+# Non-draft (ready-for-review) PR → done.
+if [[ "$IS_DRAFT" == "false" ]]; then
+  echo "done"
+  exit 0
+fi
+
+# Draft PR — check CI via statusCheckRollup.
+ROLLUP=$(printf '%s' "$PR" | jq '.statusCheckRollup')
+ROLLUP_LEN=$(printf '%s' "$ROLLUP" | jq 'length')
+
+# Empty rollup is NOT green.
+if [[ "$ROLLUP_LEN" -eq 0 ]]; then
+  echo "verify"
+  exit 0
+fi
+
+# Check for any pending entries (check runs not yet COMPLETED, or status
+# contexts with state PENDING/EXPECTED).
+PENDING=$(printf '%s' "$ROLLUP" | jq '
+  map(
+    if has("conclusion") then
+      # Check run: pending if status != COMPLETED
+      .status != "COMPLETED"
+    else
+      # Status context: pending if state is PENDING or EXPECTED
+      (.state == "PENDING" or .state == "EXPECTED")
+    end
+  ) | any
+')
+
+if [[ "$PENDING" == "true" ]]; then
+  echo "verify"
+  exit 0
+fi
+
+# Check for any failing entries.
+FAILING=$(printf '%s' "$ROLLUP" | jq '
+  map(
+    if has("conclusion") then
+      # Check run: failing conclusions
+      (.conclusion // "") as $c |
+      ($c == "FAILURE" or $c == "TIMED_OUT" or $c == "CANCELLED" or
+       $c == "ACTION_REQUIRED" or $c == "STARTUP_FAILURE" or $c == "STALE")
+    else
+      # Status context: failing states
+      (.state // "") as $s |
+      ($s == "FAILURE" or $s == "ERROR")
+    end
+  ) | any
+')
+
+if [[ "$FAILING" == "true" ]]; then
+  echo "verify"
+  exit 0
+fi
+
+# All entries are passing — check that all passing conditions hold.
+# An entry passes if: check run with conclusion in {SUCCESS,NEUTRAL,SKIPPED},
+# or status context with state SUCCESS.
+ALL_PASSING=$(printf '%s' "$ROLLUP" | jq '
+  map(
+    if has("conclusion") then
+      (.conclusion // "") as $c |
+      ($c == "SUCCESS" or $c == "NEUTRAL" or $c == "SKIPPED")
+    else
+      (.state // "") == "SUCCESS"
+    end
+  ) | all
+')
+
+if [[ "$ALL_PASSING" != "true" ]]; then
+  echo "verify"
+  exit 0
+fi
+
+# CI is green — map the highest dispatch:* label to the next phase.
+# Label chain: qa-done < refactored < reviewed < security-reviewed
+LABELS=$(printf '%s' "$PR" | jq -r '[.labels[].name | select(startswith("dispatch:"))] | join(" ")')
+
+if echo "$LABELS" | grep -qF "dispatch:security-reviewed"; then
+  echo "ready"
+elif echo "$LABELS" | grep -qF "dispatch:reviewed"; then
+  echo "security"
+elif echo "$LABELS" | grep -qF "dispatch:refactored"; then
+  echo "review"
+elif echo "$LABELS" | grep -qF "dispatch:qa-done"; then
+  echo "simplify"
+else
+  echo "qa"
+fi

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Select the single highest-priority task from the queue.
+# Usage: dispatch-select-target [--qa]
+#
+# Output: exactly one line:
+#   pr <num> <branch>   — a PR to work on
+#   issue <num>         — a help-wanted issue to implement
+#   empty               — nothing eligible
+#
+# Default mode priority:
+#   1. Oldest non-QA PR (phase: verify, simplify, review, security, ready)
+#      with no local git worktree
+#   2. Oldest open help-wanted issue
+#   3. Oldest QA PR with no local git worktree
+#
+# --qa mode priority:
+#   1. Oldest QA PR with no local git worktree
+#   2. empty
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+QA_MODE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --qa) QA_MODE=true ;;
+    *) echo "error: unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+# Collect branches that already have a local worktree (a session is working them).
+WORKTREE_BRANCHES=()
+while IFS= read -r line; do
+  # git worktree list --porcelain emits "branch refs/heads/<name>" lines.
+  if [[ "$line" == branch\ * ]]; then
+    branch_ref="${line#branch }"
+    WORKTREE_BRANCHES+=("${branch_ref#refs/heads/}")
+  fi
+done < <(git worktree list --porcelain)
+
+has_worktree() {
+  local branch="$1"
+  local b
+  for b in "${WORKTREE_BRANCHES[@]}"; do
+    if [[ "$b" == "$branch" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Fetch all open PRs sorted by createdAt ascending (oldest first).
+PR_LIST=$(gh pr list --state open --json number,createdAt,headRefName)
+PR_SORTED=$(printf '%s' "$PR_LIST" | jq -r 'sort_by(.createdAt) | .[] | [.number, .createdAt, .headRefName] | @tsv')
+
+NON_QA_PR_NUM=""
+NON_QA_PR_BRANCH=""
+QA_PR_NUM=""
+QA_PR_BRANCH=""
+
+while IFS=$'\t' read -r pr_num _created pr_branch; do
+  [[ -z "$pr_num" ]] && continue
+
+  # Skip PRs with a local worktree.
+  if has_worktree "$pr_branch"; then
+    continue
+  fi
+
+  # Determine phase for this PR.
+  phase=$("$SCRIPT_DIR/dispatch-phase" "$pr_branch")
+
+  case "$phase" in
+    done)
+      # Skip completed PRs.
+      continue
+      ;;
+    qa)
+      # First QA PR wins (list is oldest-first).
+      if [[ -z "$QA_PR_NUM" ]]; then
+        QA_PR_NUM="$pr_num"
+        QA_PR_BRANCH="$pr_branch"
+      fi
+      ;;
+    *)
+      # verify, simplify, review, security, ready — non-QA bucket.
+      # First non-QA PR wins.
+      if [[ -z "$NON_QA_PR_NUM" ]]; then
+        NON_QA_PR_NUM="$pr_num"
+        NON_QA_PR_BRANCH="$pr_branch"
+      fi
+      ;;
+  esac
+done <<< "$PR_SORTED"
+
+if [[ "$QA_MODE" == "true" ]]; then
+  # --qa mode: only return QA PRs.
+  if [[ -n "$QA_PR_NUM" ]]; then
+    echo "pr $QA_PR_NUM $QA_PR_BRANCH"
+  else
+    echo "empty"
+  fi
+  exit 0
+fi
+
+# Default mode: non-QA PR → help-wanted issue → QA PR → empty.
+if [[ -n "$NON_QA_PR_NUM" ]]; then
+  echo "pr $NON_QA_PR_NUM $NON_QA_PR_BRANCH"
+  exit 0
+fi
+
+# Fetch oldest help-wanted issue.
+ISSUE_LIST=$(gh issue list --label "help wanted" --state open --json number,createdAt)
+ISSUE_NUM=$(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[0].number // empty')
+
+if [[ -n "$ISSUE_NUM" ]]; then
+  echo "issue $ISSUE_NUM"
+  exit 0
+fi
+
+if [[ -n "$QA_PR_NUM" ]]; then
+  echo "pr $QA_PR_NUM $QA_PR_BRANCH"
+  exit 0
+fi
+
+echo "empty"

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -7,11 +7,17 @@
 #   issue <num>         — a help-wanted issue to implement
 #   empty               — nothing eligible
 #
-# Default mode priority:
-#   1. Oldest non-QA PR (phase: verify, simplify, review, security, ready)
-#      with no local git worktree
-#   2. Oldest open help-wanted issue
-#   3. Oldest QA PR with no local git worktree
+# Default mode priority (highest first; within a tier, oldest PR wins):
+#   1. Oldest "ready"    PR (draft + dispatch:security-reviewed)
+#   2. Oldest "security" PR (draft + dispatch:reviewed)
+#   3. Oldest "review"   PR (draft + dispatch:refactored)
+#   4. Oldest "simplify" PR (draft + dispatch:qa-done)
+#   5. Oldest "verify"   PR (draft, CI not green)
+#   6. Oldest open help-wanted issue
+#   7. Oldest "qa"       PR (draft, CI green, no dispatch:* label)
+#
+# PRs with a local git worktree are skipped (a session is actively working them).
+# "done" (non-draft) PRs are skipped entirely.
 #
 # --qa mode priority:
 #   1. Oldest QA PR with no local git worktree
@@ -53,8 +59,18 @@ has_worktree() {
 PR_LIST=$(gh pr list --state open --json number,createdAt,headRefName)
 PR_SORTED=$(printf '%s' "$PR_LIST" | jq -r 'sort_by(.createdAt) | .[] | [.number, .createdAt, .headRefName] | @tsv')
 
-NON_QA_PR_NUM=""
-NON_QA_PR_BRANCH=""
+# One "first-seen" variable per phase (list is pre-sorted oldest-first, so first
+# capture of a phase is always the oldest PR in that phase).
+READY_PR_NUM=""
+READY_PR_BRANCH=""
+SECURITY_PR_NUM=""
+SECURITY_PR_BRANCH=""
+REVIEW_PR_NUM=""
+REVIEW_PR_BRANCH=""
+SIMPLIFY_PR_NUM=""
+SIMPLIFY_PR_BRANCH=""
+VERIFY_PR_NUM=""
+VERIFY_PR_BRANCH=""
 QA_PR_NUM=""
 QA_PR_BRANCH=""
 
@@ -74,19 +90,40 @@ while IFS=$'\t' read -r pr_num _created pr_branch; do
       # Skip completed PRs.
       continue
       ;;
+    ready)
+      if [[ -z "$READY_PR_NUM" ]]; then
+        READY_PR_NUM="$pr_num"
+        READY_PR_BRANCH="$pr_branch"
+      fi
+      ;;
+    security)
+      if [[ -z "$SECURITY_PR_NUM" ]]; then
+        SECURITY_PR_NUM="$pr_num"
+        SECURITY_PR_BRANCH="$pr_branch"
+      fi
+      ;;
+    review)
+      if [[ -z "$REVIEW_PR_NUM" ]]; then
+        REVIEW_PR_NUM="$pr_num"
+        REVIEW_PR_BRANCH="$pr_branch"
+      fi
+      ;;
+    simplify)
+      if [[ -z "$SIMPLIFY_PR_NUM" ]]; then
+        SIMPLIFY_PR_NUM="$pr_num"
+        SIMPLIFY_PR_BRANCH="$pr_branch"
+      fi
+      ;;
+    verify)
+      if [[ -z "$VERIFY_PR_NUM" ]]; then
+        VERIFY_PR_NUM="$pr_num"
+        VERIFY_PR_BRANCH="$pr_branch"
+      fi
+      ;;
     qa)
-      # First QA PR wins (list is oldest-first).
       if [[ -z "$QA_PR_NUM" ]]; then
         QA_PR_NUM="$pr_num"
         QA_PR_BRANCH="$pr_branch"
-      fi
-      ;;
-    *)
-      # verify, simplify, review, security, ready — non-QA bucket.
-      # First non-QA PR wins.
-      if [[ -z "$NON_QA_PR_NUM" ]]; then
-        NON_QA_PR_NUM="$pr_num"
-        NON_QA_PR_BRANCH="$pr_branch"
       fi
       ;;
   esac
@@ -102,9 +139,30 @@ if [[ "$QA_MODE" == "true" ]]; then
   exit 0
 fi
 
-# Default mode: non-QA PR → help-wanted issue → QA PR → empty.
-if [[ -n "$NON_QA_PR_NUM" ]]; then
-  echo "pr $NON_QA_PR_NUM $NON_QA_PR_BRANCH"
+# Default mode: ready → security → review → simplify → verify →
+#               help-wanted issue → qa → empty.
+if [[ -n "$READY_PR_NUM" ]]; then
+  echo "pr $READY_PR_NUM $READY_PR_BRANCH"
+  exit 0
+fi
+
+if [[ -n "$SECURITY_PR_NUM" ]]; then
+  echo "pr $SECURITY_PR_NUM $SECURITY_PR_BRANCH"
+  exit 0
+fi
+
+if [[ -n "$REVIEW_PR_NUM" ]]; then
+  echo "pr $REVIEW_PR_NUM $REVIEW_PR_BRANCH"
+  exit 0
+fi
+
+if [[ -n "$SIMPLIFY_PR_NUM" ]]; then
+  echo "pr $SIMPLIFY_PR_NUM $SIMPLIFY_PR_BRANCH"
+  exit 0
+fi
+
+if [[ -n "$VERIFY_PR_NUM" ]]; then
+  echo "pr $VERIFY_PR_NUM $VERIFY_PR_BRANCH"
   exit 0
 fi
 

--- a/.claude/skills/dispatch/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch/scripts/dispatch-trace-leaf
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Trace from issue N to the deepest open leaf (no open children).
+# Usage: dispatch-trace-leaf <issue-num>
+#
+# Walks open blockers and open sub-issues depth-first, visiting the
+# lowest-numbered open child first, to find the lowest-numbered reachable
+# open leaf. Prints one issue number.
+#
+# Falls back to printing N if cycles block every path to a leaf.
+#
+# Uses sibling scripts:
+#   issue-blocking   — prints JSON for each open blocker (gh issue view output)
+#   issue-sub-issues — prints JSON for each sub-issue (gh issue view output)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# issue-blocking and issue-sub-issues live alongside load-context etc.
+REF_SCRIPTS_DIR="$(cd "$SCRIPT_DIR/../../ref-pr-workflow/scripts" && pwd)"
+
+ISSUE_NUM="${1:-}"
+if [[ -z "$ISSUE_NUM" || ! "$ISSUE_NUM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: usage: dispatch-trace-leaf <issue-num>" >&2
+  exit 1
+fi
+
+# Collect open children of an issue: open blockers union open sub-issues.
+# Outputs sorted unique issue numbers, one per line, lowest first.
+open_children() {
+  local n="$1"
+  local children=()
+
+  # Gather open blockers.
+  local blocker_json
+  blocker_json=$("$REF_SCRIPTS_DIR/issue-blocking" "$n" 2>/dev/null) || blocker_json=""
+  if [[ -n "$blocker_json" ]]; then
+    while IFS= read -r num; do
+      [[ -n "$num" ]] && children+=("$num")
+    done < <(printf '%s' "$blocker_json" | jq -r 'select(.state == "OPEN" or .state == "open") | .number' 2>/dev/null || true)
+  fi
+
+  # Gather open sub-issues.
+  local sub_json
+  sub_json=$("$REF_SCRIPTS_DIR/issue-sub-issues" "$n" 2>/dev/null) || sub_json=""
+  if [[ -n "$sub_json" ]]; then
+    while IFS= read -r num; do
+      [[ -n "$num" ]] && children+=("$num")
+    done < <(printf '%s' "$sub_json" | jq -r 'select(.state == "OPEN" or .state == "open") | .number' 2>/dev/null || true)
+  fi
+
+  # Print unique numbers sorted ascending (lowest first).
+  if [[ ${#children[@]} -gt 0 ]]; then
+    printf '%s\n' "${children[@]}" | sort -un
+  fi
+}
+
+# Depth-first search for the lowest-numbered reachable open leaf.
+# Args: $1 = current issue number
+# Uses global VISITED associative array for cycle protection.
+# Returns 0 and prints the leaf number on success.
+# Returns 1 if all paths lead to cycles (no leaf reachable).
+declare -A VISITED=()
+
+find_leaf() {
+  local n="$1"
+
+  if [[ -n "${VISITED[$n]+x}" ]]; then
+    # Cycle detected — no leaf reachable via this path.
+    return 1
+  fi
+  VISITED["$n"]=1
+
+  local kids
+  kids=$(open_children "$n")
+
+  if [[ -z "$kids" ]]; then
+    # No open children — n is a leaf.
+    echo "$n"
+    return 0
+  fi
+
+  # Descend into children lowest-numbered first; return the first leaf found.
+  local kid
+  while IFS= read -r kid; do
+    [[ -z "$kid" ]] && continue
+    local leaf
+    if leaf=$(find_leaf "$kid"); then
+      echo "$leaf"
+      return 0
+    fi
+  done <<< "$kids"
+
+  # All children led to cycles.
+  return 1
+}
+
+LEAF=$(find_leaf "$ISSUE_NUM") || LEAF=""
+
+if [[ -z "$LEAF" ]]; then
+  # Cycle blocked every path — fall back to N.
+  echo "$ISSUE_NUM"
+else
+  echo "$LEAF"
+fi

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -465,6 +465,134 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "done PRs skipped; help-wanted issue returned" "issue 33" "$result"
 teardown
 
+# 8. ready beats security beats review beats simplify beats verify.
+echo "Test: ready beats security beats review beats simplify beats verify"
+setup
+# Five PRs, each in a different phase. verify (PR 10) is oldest, ready (PR 50) is newest.
+# The ready-phase PR must be chosen regardless of age.
+READY_LABELS='[{"name":"dispatch:security-reviewed"}]'
+SECURITY_LABELS='[{"name":"dispatch:reviewed"}]'
+REVIEW_LABELS='[{"name":"dispatch:refactored"}]'
+SIMPLIFY_LABELS='[{"name":"dispatch:qa-done"}]'
+FULL='['
+FULL+="$(make_pr 10 "10-verify" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','
+FULL+="$(make_pr 20 "20-simplify" "true" "$SIMPLIFY_LABELS" "$GREEN_ROLLUP")"','
+FULL+="$(make_pr 30 "30-review" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"','
+FULL+="$(make_pr 40 "40-security" "true" "$SECURITY_LABELS" "$GREEN_ROLLUP")"','
+FULL+="$(make_pr 50 "50-ready" "true" "$READY_LABELS" "$GREEN_ROLLUP")"
+FULL+=']'
+BRIEF='['
+BRIEF+="$(make_pr_brief 10 "10-verify" "2024-01-01T00:00:00Z")"','
+BRIEF+="$(make_pr_brief 20 "20-simplify" "2024-01-02T00:00:00Z")"','
+BRIEF+="$(make_pr_brief 30 "30-review" "2024-01-03T00:00:00Z")"','
+BRIEF+="$(make_pr_brief 40 "40-security" "2024-01-04T00:00:00Z")"','
+BRIEF+="$(make_pr_brief 50 "50-ready" "2024-01-05T00:00:00Z")"
+BRIEF+=']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "ready beats security/review/simplify/verify" "pr 50 50-ready" "$result"
+teardown
+
+# 9. security beats review beats simplify beats verify (no ready PR).
+echo "Test: security beats review/simplify/verify"
+setup
+SECURITY_LABELS='[{"name":"dispatch:reviewed"}]'
+REVIEW_LABELS='[{"name":"dispatch:refactored"}]'
+SIMPLIFY_LABELS='[{"name":"dispatch:qa-done"}]'
+FULL='['
+FULL+="$(make_pr 10 "10-verify" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','
+FULL+="$(make_pr 20 "20-simplify" "true" "$SIMPLIFY_LABELS" "$GREEN_ROLLUP")"','
+FULL+="$(make_pr 30 "30-review" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"','
+FULL+="$(make_pr 40 "40-security" "true" "$SECURITY_LABELS" "$GREEN_ROLLUP")"
+FULL+=']'
+BRIEF='['
+BRIEF+="$(make_pr_brief 10 "10-verify" "2024-01-01T00:00:00Z")"','
+BRIEF+="$(make_pr_brief 20 "20-simplify" "2024-01-02T00:00:00Z")"','
+BRIEF+="$(make_pr_brief 30 "30-review" "2024-01-03T00:00:00Z")"','
+BRIEF+="$(make_pr_brief 40 "40-security" "2024-01-04T00:00:00Z")"
+BRIEF+=']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "security beats review/simplify/verify" "pr 40 40-security" "$result"
+teardown
+
+# 10. Within one phase, the oldest PR wins.
+echo "Test: within same phase, oldest PR wins"
+setup
+# Two review-phase PRs; PR 30 is older.
+REVIEW_LABELS='[{"name":"dispatch:refactored"}]'
+FULL='['
+FULL+="$(make_pr 30 "30-review-a" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"','
+FULL+="$(make_pr 31 "31-review-b" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"
+FULL+=']'
+BRIEF='['
+BRIEF+="$(make_pr_brief 30 "30-review-a" "2024-01-01T00:00:00Z")"','
+BRIEF+="$(make_pr_brief 31 "31-review-b" "2024-01-02T00:00:00Z")"
+BRIEF+=']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "oldest review PR wins within phase" "pr 30 30-review-a" "$result"
+teardown
+
+# 11. Any non-QA PR beats a help-wanted issue; help-wanted issue beats a QA PR.
+echo "Test: verify PR beats issue; issue beats QA PR"
+setup
+# verify PR (10), QA PR (20), help-wanted issue (55).
+FULL='['
+FULL+="$(make_pr 10 "10-verify" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','
+FULL+="$(make_pr 20 "20-qa" "true" "$NO_LABELS" "$GREEN_ROLLUP")"
+FULL+=']'
+BRIEF='['
+BRIEF+="$(make_pr_brief 10 "10-verify" "2024-01-01T00:00:00Z")"','
+BRIEF+="$(make_pr_brief 20 "20-qa" "2024-01-02T00:00:00Z")"
+BRIEF+=']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "verify PR beats issue (non-QA > issue > qa)" "pr 10 10-verify" "$result"
+teardown
+
+# 11b. No non-QA PR: help-wanted issue beats QA PR.
+echo "Test: help-wanted issue beats QA PR"
+setup
+FULL='['"$(make_pr 20 "20-qa" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 20 "20-qa" "2024-01-02T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "help-wanted issue beats QA PR" "issue 55" "$result"
+teardown
+
+# 12. --qa mode returns only the oldest QA PR (ignores non-QA PRs).
+echo "Test: --qa mode ignores non-QA PRs and returns oldest QA PR"
+setup
+SECURITY_LABELS='[{"name":"dispatch:reviewed"}]'
+FULL='['
+FULL+="$(make_pr 10 "10-security" "true" "$SECURITY_LABELS" "$GREEN_ROLLUP")"','
+FULL+="$(make_pr 20 "20-qa-old" "true" "$NO_LABELS" "$GREEN_ROLLUP")"','
+FULL+="$(make_pr 30 "30-qa-new" "true" "$NO_LABELS" "$GREEN_ROLLUP")"
+FULL+=']'
+# Brief list sorted oldest-first: 10, 20, 30.
+BRIEF='['
+BRIEF+="$(make_pr_brief 10 "10-security" "2024-01-01T00:00:00Z")"','
+BRIEF+="$(make_pr_brief 20 "20-qa-old" "2024-01-02T00:00:00Z")"','
+BRIEF+="$(make_pr_brief 30 "30-qa-new" "2024-01-03T00:00:00Z")"
+BRIEF+=']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
+assert_eq "--qa returns oldest QA PR (ignores security PR)" "pr 20 20-qa-old" "$result"
+teardown
+
 # ============================================================================
 # dispatch-trace-leaf tests
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1,0 +1,557 @@
+#!/usr/bin/env bash
+# Unit-test suite for dispatch-phase, dispatch-select-target, dispatch-trace-leaf.
+# Uses PATH shims to fake gh and git — no network required.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# --- test helpers -----------------------------------------------------------
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected: '$expected'"
+    echo "    actual:   '$actual'"
+  fi
+}
+
+report_results() {
+  echo ""
+  echo "================================"
+  echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+  echo "================================"
+  [[ "$FAIL" -eq 0 ]]
+}
+
+# --- harness ----------------------------------------------------------------
+
+SAVED_PATH="$PATH"
+TMPDIR_TEST=""
+STUB_DIR=""
+
+setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  STUB_DIR="$TMPDIR_TEST/stub"
+  mkdir -p "$TMPDIR_TEST/bin" "$STUB_DIR"
+
+  # Copy the scripts under test into the tmp dir so they can call each other
+  # via SCRIPT_DIR resolution without relying on the real filesystem PATH.
+  cp "$SCRIPT_DIR/dispatch-phase" "$TMPDIR_TEST/dispatch-phase"
+  cp "$SCRIPT_DIR/dispatch-select-target" "$TMPDIR_TEST/dispatch-select-target"
+  cp "$SCRIPT_DIR/dispatch-trace-leaf" "$TMPDIR_TEST/dispatch-trace-leaf"
+  chmod +x "$TMPDIR_TEST/dispatch-phase" \
+           "$TMPDIR_TEST/dispatch-select-target" \
+           "$TMPDIR_TEST/dispatch-trace-leaf"
+
+  # dispatch-select-target calls dispatch-phase as "$SCRIPT_DIR/dispatch-phase".
+  # Since we copied them all to TMPDIR_TEST, SCRIPT_DIR inside each copy will
+  # resolve to TMPDIR_TEST correctly.
+
+  # stub gh
+  cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
+# Reconstruct full args string for matching.
+args="$*"
+case "$args" in
+  "pr list --state open --json number,headRefName,isDraft,statusCheckRollup,labels")
+    if [[ -f "$STUB_DIR/pr-list-full.json" ]]; then
+      cat "$STUB_DIR/pr-list-full.json"
+    else
+      echo "[]"
+    fi
+    ;;
+  "pr list --state open --json number,createdAt,headRefName")
+    if [[ -f "$STUB_DIR/pr-list-brief.json" ]]; then
+      cat "$STUB_DIR/pr-list-brief.json"
+    else
+      echo "[]"
+    fi
+    ;;
+  "issue list --label help wanted --state open --json number,createdAt")
+    if [[ -f "$STUB_DIR/issue-list.json" ]]; then
+      cat "$STUB_DIR/issue-list.json"
+    else
+      echo "[]"
+    fi
+    ;;
+  issue\ view\ *\ --json\ title,body,comments,number,state)
+    # issue-blocking / issue-sub-issues call: gh issue view <num> --json ...
+    num=$(echo "$args" | awk '{print $3}')
+    if [[ -f "$STUB_DIR/issue-${num}.json" ]]; then
+      cat "$STUB_DIR/issue-${num}.json"
+    else
+      echo "{\"title\":\"Issue $num\",\"body\":\"\",\"comments\":[],\"number\":$num,\"state\":\"OPEN\"}"
+    fi
+    ;;
+  api\ */dependencies/blocked_by)
+    path=$(echo "$args" | awk '{print $2}')
+    num=$(echo "$path" | grep -oE '[0-9]+' | tail -1)
+    if [[ -f "$STUB_DIR/blockers-${num}.json" ]]; then
+      cat "$STUB_DIR/blockers-${num}.json"
+    else
+      echo "[]"
+    fi
+    ;;
+  api\ */sub_issues)
+    path=$(echo "$args" | awk '{print $2}')
+    num=$(echo "$path" | grep -oE '[0-9]+' | tail -1)
+    if [[ -f "$STUB_DIR/subissues-${num}.json" ]]; then
+      cat "$STUB_DIR/subissues-${num}.json"
+    else
+      echo "[]"
+    fi
+    ;;
+  *)
+    echo "gh stub: unknown invocation: $args" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/gh"
+
+  # stub git
+  cat > "$TMPDIR_TEST/bin/git" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
+args="$*"
+case "$args" in
+  "worktree list --porcelain")
+    if [[ -f "$STUB_DIR/worktree-list.txt" ]]; then
+      cat "$STUB_DIR/worktree-list.txt"
+    else
+      # Default: one worktree entry for the main worktree (no branch for bare)
+      printf 'worktree /repo\nHEAD abc123\n\n'
+    fi
+    ;;
+  "rev-parse --abbrev-ref HEAD")
+    echo "main"
+    ;;
+  *)
+    echo "git stub: unknown invocation: $args" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/git"
+
+  # Make a fake issue-blocking script that the trace-leaf script can call.
+  # dispatch-trace-leaf resolves REF_SCRIPTS_DIR relative to SCRIPT_DIR
+  # (two levels up, then ref-pr-workflow/scripts). Inside TMPDIR_TEST the
+  # copied scripts have SCRIPT_DIR = TMPDIR_TEST, so REF_SCRIPTS_DIR would
+  # be "$TMPDIR_TEST/../../ref-pr-workflow/scripts" which is wrong.
+  # Instead, create fake issue-blocking and issue-sub-issues in a fake
+  # ref-pr-workflow/scripts dir alongside TMPDIR_TEST.
+  mkdir -p "$TMPDIR_TEST/ref-pr-workflow/scripts"
+
+  # We need to patch the copied dispatch-trace-leaf so REF_SCRIPTS_DIR
+  # points at our fake scripts. Use a wrapper approach: write a thin wrapper
+  # that sets the env and calls the real script with a patched path.
+  cat > "$TMPDIR_TEST/ref-pr-workflow/scripts/issue-blocking" <<'FAKE'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")/../../stub" && pwd)"
+num="${1:-}"
+# Strip leading # if present.
+num="${num#\#}"
+# issue-blocking calls lib.sh resolve_issue_number then gh api + gh issue view.
+# Our fake: just read a stub file.
+blocker_nums=""
+if [[ -f "$STUB_DIR/blockers-${num}.json" ]]; then
+  blocker_nums=$(cat "$STUB_DIR/blockers-${num}.json" | jq -r '.[].number' 2>/dev/null || true)
+fi
+for dep in $blocker_nums; do
+  if [[ -f "$STUB_DIR/issue-${dep}.json" ]]; then
+    cat "$STUB_DIR/issue-${dep}.json"
+  else
+    echo "{\"title\":\"Issue $dep\",\"body\":\"\",\"comments\":[],\"number\":$dep,\"state\":\"OPEN\"}"
+  fi
+done
+FAKE
+  chmod +x "$TMPDIR_TEST/ref-pr-workflow/scripts/issue-blocking"
+
+  cat > "$TMPDIR_TEST/ref-pr-workflow/scripts/issue-sub-issues" <<'FAKE'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")/../../stub" && pwd)"
+num="${1:-}"
+num="${num#\#}"
+sub_nums=""
+if [[ -f "$STUB_DIR/subissues-${num}.json" ]]; then
+  sub_nums=$(cat "$STUB_DIR/subissues-${num}.json" | jq -r '.[].number' 2>/dev/null || true)
+fi
+for sub in $sub_nums; do
+  if [[ -f "$STUB_DIR/issue-${sub}.json" ]]; then
+    cat "$STUB_DIR/issue-${sub}.json"
+  else
+    echo "{\"title\":\"Issue $sub\",\"body\":\"\",\"comments\":[],\"number\":$sub,\"state\":\"OPEN\"}"
+  fi
+done
+FAKE
+  chmod +x "$TMPDIR_TEST/ref-pr-workflow/scripts/issue-sub-issues"
+
+  # Patch the copied dispatch-trace-leaf to use our fake ref-pr-workflow dir.
+  # Replace the REF_SCRIPTS_DIR line so it points into TMPDIR_TEST.
+  # We do this by writing a wrapper script.
+  mv "$TMPDIR_TEST/dispatch-trace-leaf" "$TMPDIR_TEST/dispatch-trace-leaf.real"
+  cat > "$TMPDIR_TEST/dispatch-trace-leaf" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+# Override REF_SCRIPTS_DIR to point at fake scripts.
+export _DISPATCH_TRACE_LEAF_REF_OVERRIDE="$TMPDIR_TEST/ref-pr-workflow/scripts"
+exec "$TMPDIR_TEST/dispatch-trace-leaf.real" "\$@"
+WRAPPER
+  chmod +x "$TMPDIR_TEST/dispatch-trace-leaf"
+
+  # Patch the real script to honour the override env var.
+  # Re-write the REF_SCRIPTS_DIR line in the .real copy.
+  # Use a sed in-place to replace the REF_SCRIPTS_DIR assignment.
+  sed -i 's|REF_SCRIPTS_DIR="$(cd "\$SCRIPT_DIR/\.\./\.\./ref-pr-workflow/scripts" && pwd)"|REF_SCRIPTS_DIR="${_DISPATCH_TRACE_LEAF_REF_OVERRIDE:-$(cd "\$SCRIPT_DIR/../../ref-pr-workflow/scripts" \&\& pwd)}"|' \
+    "$TMPDIR_TEST/dispatch-trace-leaf.real"
+
+  export PATH="$TMPDIR_TEST/bin:$PATH"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  STUB_DIR=""
+  export PATH="$SAVED_PATH"
+}
+trap '[ -n "${TMPDIR_TEST:-}" ] && rm -rf "$TMPDIR_TEST"' EXIT
+
+# Helper to build a PR JSON entry for the full PR list (dispatch-phase).
+make_pr() {
+  local num="$1" branch="$2" is_draft="$3" labels_json="$4" rollup_json="$5"
+  printf '{"number":%s,"headRefName":"%s","isDraft":%s,"labels":%s,"statusCheckRollup":%s}' \
+    "$num" "$branch" "$is_draft" "$labels_json" "$rollup_json"
+}
+
+# Helper to build a PR JSON entry for the brief PR list (dispatch-select-target).
+make_pr_brief() {
+  local num="$1" branch="$2" created="$3"
+  printf '{"number":%s,"headRefName":"%s","createdAt":"%s"}' "$num" "$branch" "$created"
+}
+
+# Green rollup (two passing check runs).
+GREEN_ROLLUP='[{"status":"COMPLETED","conclusion":"SUCCESS"},{"status":"COMPLETED","conclusion":"NEUTRAL"}]'
+# Failing rollup.
+FAILING_ROLLUP='[{"status":"COMPLETED","conclusion":"FAILURE"}]'
+# Pending rollup (one check not yet complete).
+PENDING_ROLLUP='[{"status":"IN_PROGRESS","conclusion":null}]'
+# Empty rollup.
+EMPTY_ROLLUP='[]'
+# No labels.
+NO_LABELS='[]'
+
+# ============================================================================
+# dispatch-phase tests
+# ============================================================================
+echo "=== dispatch-phase ==="
+
+# 1. No PR → implement
+echo "Test: no PR → implement"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "no PR → implement" "implement" "$result"
+teardown
+
+# 2. Draft + failing CI → verify
+echo "Test: draft + failing CI → verify"
+setup
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" "$NO_LABELS" "$FAILING_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "draft + failing CI → verify" "verify" "$result"
+teardown
+
+# 3. Draft + pending CI → verify
+echo "Test: draft + pending CI → verify"
+setup
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" "$NO_LABELS" "$PENDING_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "draft + pending CI → verify" "verify" "$result"
+teardown
+
+# 4. Draft + empty rollup → verify
+echo "Test: draft + empty rollup → verify"
+setup
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" "$NO_LABELS" "$EMPTY_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "draft + empty rollup → verify" "verify" "$result"
+teardown
+
+# 5. Draft + green + no label → qa
+echo "Test: draft + green + no label → qa"
+setup
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" "$NO_LABELS" "$GREEN_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "draft + green + no label → qa" "qa" "$result"
+teardown
+
+# 6. Draft + green + dispatch:qa-done → simplify
+echo "Test: draft + green + dispatch:qa-done → simplify"
+setup
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" '[{"name":"dispatch:qa-done"}]' "$GREEN_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "draft + green + dispatch:qa-done → simplify" "simplify" "$result"
+teardown
+
+# 7. Draft + green + dispatch:refactored → review
+echo "Test: draft + green + dispatch:refactored → review"
+setup
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" '[{"name":"dispatch:refactored"}]' "$GREEN_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "draft + green + dispatch:refactored → review" "review" "$result"
+teardown
+
+# 8. Draft + green + dispatch:reviewed → security
+echo "Test: draft + green + dispatch:reviewed → security"
+setup
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" '[{"name":"dispatch:reviewed"}]' "$GREEN_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "draft + green + dispatch:reviewed → security" "security" "$result"
+teardown
+
+# 9. Draft + green + dispatch:security-reviewed → ready
+echo "Test: draft + green + dispatch:security-reviewed → ready"
+setup
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" '[{"name":"dispatch:security-reviewed"}]' "$GREEN_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "draft + green + dispatch:security-reviewed → ready" "ready" "$result"
+teardown
+
+# 10. Non-draft PR → done
+echo "Test: non-draft PR → done"
+setup
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "false" "$NO_LABELS" "$GREEN_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "non-draft PR → done" "done" "$result"
+teardown
+
+# 11. Branch arg exact match
+echo "Test: branch arg → qa"
+setup
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" "$NO_LABELS" "$GREEN_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42-my-feature")
+assert_eq "branch arg exact match → qa" "qa" "$result"
+teardown
+
+# 12. Issue prefix disambiguation: issue 6 should not match branch "60-foo"
+echo "Test: issue 6 does not match branch 60-foo"
+setup
+printf '[%s]\n' "$(make_pr 10 "60-foo" "true" "$NO_LABELS" "$GREEN_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "6")
+assert_eq "issue 6 does not match branch 60-foo" "implement" "$result"
+teardown
+
+# ============================================================================
+# dispatch-select-target tests
+# ============================================================================
+echo ""
+echo "=== dispatch-select-target ==="
+
+# For dispatch-select-target we need both the brief PR list (for enumeration)
+# and the full PR list (for dispatch-phase calls).
+
+setup_both_pr_lists() {
+  local full_json="$1"
+  local brief_json="$2"
+  printf '%s\n' "$full_json" > "$STUB_DIR/pr-list-full.json"
+  printf '%s\n' "$brief_json" > "$STUB_DIR/pr-list-brief.json"
+}
+
+# 1. A non-QA PR is chosen over a QA PR and a help-wanted issue.
+echo "Test: non-QA PR beats QA PR and issue"
+setup
+# PR 10 in verify phase (no CI green), PR 20 in qa phase (CI green, no label).
+FULL='['"$(make_pr 10 "10-verify-me" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr 20 "20-qa-me" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 10 "10-verify-me" "2024-01-01T00:00:00Z")"','"$(make_pr_brief 20 "20-qa-me" "2024-01-02T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+printf '[{"number":99,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+# No worktrees for these branches.
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "non-QA PR (verify) chosen first" "pr 10 10-verify-me" "$result"
+teardown
+
+# 2. PR with a local worktree is skipped.
+echo "Test: PR whose branch has a worktree is skipped"
+setup
+FULL='['"$(make_pr 10 "10-active-branch" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr 20 "20-other" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 10 "10-active-branch" "2024-01-01T00:00:00Z")"','"$(make_pr_brief 20 "20-other" "2024-01-02T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+# Worktree exists for branch 10-active-branch.
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/10-active-branch\n\nworktree /worktrees/10-active-branch\nHEAD def456\nbranch refs/heads/10-active-branch\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "PR with worktree skipped; next PR returned" "pr 20 20-other" "$result"
+teardown
+
+# 3. When no eligible PR exists, a help-wanted issue is chosen.
+echo "Test: no eligible PR → help-wanted issue"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo '[]' > "$STUB_DIR/pr-list-brief.json"
+printf '[{"number":55,"createdAt":"2024-03-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "no PR → help-wanted issue" "issue 55" "$result"
+teardown
+
+# 4. --qa mode returns only QA PRs.
+echo "Test: --qa mode returns QA PR"
+setup
+FULL='['"$(make_pr 10 "10-verify-me" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr 20 "20-qa-me" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 20 "20-qa-me" "2024-01-02T00:00:00Z")"','"$(make_pr_brief 10 "10-verify-me" "2024-01-01T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
+assert_eq "--qa mode returns QA PR" "pr 20 20-qa-me" "$result"
+teardown
+
+# 5. Nothing eligible → empty.
+echo "Test: nothing eligible → empty"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo '[]' > "$STUB_DIR/pr-list-brief.json"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "nothing eligible → empty" "empty" "$result"
+teardown
+
+# 6. --qa mode with no QA PR → empty (ignores help-wanted issues).
+echo "Test: --qa mode with no QA PR → empty"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo '[]' > "$STUB_DIR/pr-list-brief.json"
+printf '[{"number":77,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
+assert_eq "--qa mode no QA PR → empty" "empty" "$result"
+teardown
+
+# 7. All PRs done → falls through to help-wanted issue.
+echo "Test: all PRs done → help-wanted issue"
+setup
+FULL='['"$(make_pr 10 "10-done-pr" "false" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 10 "10-done-pr" "2024-01-01T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+printf '[{"number":33,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "done PRs skipped; help-wanted issue returned" "issue 33" "$result"
+teardown
+
+# ============================================================================
+# dispatch-trace-leaf tests
+# ============================================================================
+echo ""
+echo "=== dispatch-trace-leaf ==="
+
+# 1. No children → prints self.
+echo "Test: no children → prints self"
+setup
+# No stub files means no blockers and no sub-issues.
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "100")
+assert_eq "no children → self (100)" "100" "$result"
+teardown
+
+# 2. Single blocker chain: 100 → 101 → 102 (leaf).
+echo "Test: single blocker chain → deepest leaf"
+setup
+printf '[{"number":101}]\n' > "$STUB_DIR/blockers-100.json"
+printf '[{"number":102}]\n' > "$STUB_DIR/blockers-101.json"
+# 102 has no blockers or sub-issues → leaf.
+printf '{"title":"Issue 101","body":"","comments":[],"number":101,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-101.json"
+printf '{"title":"Issue 102","body":"","comments":[],"number":102,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-102.json"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "100")
+assert_eq "blocker chain 100→101→102 → leaf 102" "102" "$result"
+teardown
+
+# 3. Multiple children → lowest-numbered leaf.
+echo "Test: multiple children → lowest-numbered leaf"
+setup
+# 100 has sub-issues 200 and 201. 200 has no children (leaf), 201 has no children (leaf).
+printf '[{"number":200},{"number":201}]\n' > "$STUB_DIR/subissues-100.json"
+printf '{"title":"Issue 200","body":"","comments":[],"number":200,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-200.json"
+printf '{"title":"Issue 201","body":"","comments":[],"number":201,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-201.json"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "100")
+assert_eq "multiple children → lowest leaf (200)" "200" "$result"
+teardown
+
+# 4. Closed children are ignored.
+echo "Test: closed children are ignored"
+setup
+# 100 has sub-issues 300 (closed) and 301 (open).
+printf '[{"number":300},{"number":301}]\n' > "$STUB_DIR/subissues-100.json"
+printf '{"title":"Issue 300","body":"","comments":[],"number":300,"state":"CLOSED"}\n' \
+  > "$STUB_DIR/issue-300.json"
+printf '{"title":"Issue 301","body":"","comments":[],"number":301,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-301.json"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "100")
+assert_eq "closed children ignored → open leaf 301" "301" "$result"
+teardown
+
+# 5. All children closed → issue itself is a leaf.
+echo "Test: all children closed → prints self"
+setup
+printf '[{"number":400}]\n' > "$STUB_DIR/subissues-100.json"
+printf '{"title":"Issue 400","body":"","comments":[],"number":400,"state":"CLOSED"}\n' \
+  > "$STUB_DIR/issue-400.json"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "100")
+assert_eq "all children closed → self (100)" "100" "$result"
+teardown
+
+# 6. Cycle → falls back to N.
+echo "Test: cycle → falls back to N"
+setup
+# 100 → sub 500, 500 → sub 100 (cycle).
+printf '[{"number":500}]\n' > "$STUB_DIR/subissues-100.json"
+printf '[{"number":100}]\n' > "$STUB_DIR/subissues-500.json"
+printf '{"title":"Issue 500","body":"","comments":[],"number":500,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-500.json"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "100")
+assert_eq "cycle → fallback to N (100)" "100" "$result"
+teardown
+
+# 7. Sub-issues via issue-sub-issues path.
+echo "Test: sub-issues chain"
+setup
+printf '[{"number":601}]\n' > "$STUB_DIR/subissues-600.json"
+printf '{"title":"Issue 601","body":"","comments":[],"number":601,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-601.json"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "600")
+assert_eq "sub-issues chain 600→601 → leaf 601" "601" "$result"
+teardown
+
+# ============================================================================
+# summary
+# ============================================================================
+report_results


### PR DESCRIPTION
Closes #629

Replaces the out-of-process `dispatch/bin/dispatch` orchestration with a `/dispatch` skill.

- **New helper scripts** (`.claude/skills/dispatch/scripts/`): `dispatch-phase` (classify the workflow phase from PR/issue status), `dispatch-select-target` (phase-priority queue selection), `dispatch-trace-leaf` (walk blockers/sub-issues to an open leaf), plus a 26-case bash test suite.
- **New `/dispatch` skill** (`.claude/skills/dispatch/SKILL.md`): selects the next task, traces to an open leaf, resolves the worktree via `EnterWorktree`, derives the phase, and dispatches exactly one phase skill — then stops.
- **`/dispatch-qa` update**: a new Step 0 lets it self-select the highest-priority QA-phase PR when invoked standalone; the legacy `/dispatch-qa #N` in-worktree path is preserved.

Removing the legacy `dispatch/bin/dispatch` script and decoupling `/dispatch-implement` from its `phase_signal` plumbing are tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
