### PR TITLE
/dispatch: continue the current issue when run inside its worktree

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -12,8 +12,9 @@ then stops. Re-invoke `/dispatch` (or `/loop /dispatch`) to advance to the next 
 `/dispatch` takes an **optional issue-number argument** (leading `#` optional). With
 an argument, it targets that issue and skips the queue scan.
 
-Run `/dispatch` from the **main worktree**. Step 3 switches into the target's
-worktree via `EnterWorktree`; the phase skill runs there.
+Run `/dispatch` from the **main worktree**, or from inside an issue worktree to
+continue that issue. Step 3 switches into the target's worktree via `EnterWorktree`;
+the phase skill runs there.
 
 Run `gh` and git-index-writing commands (`git add`, `gh pr ready`, `gh label create`)
 with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
@@ -31,7 +32,17 @@ with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
   It prints exactly one line:
   - `pr <num> <branch>` — a PR to work on
   - `issue <num>` — a `help wanted` issue to implement
+  - `worktree <N> <branch>` — run from inside an issue worktree; target is `<N>`,
+    queue scan already skipped
+  - `worktree-closed <N> <branch>` — run from inside a worktree whose issue is
+    closed or unrecognized → report that the current worktree belongs to
+    closed/unrecognized issue `<N>` and **stop** (consistent with the named-target
+    "closed → report and stop" rule in Step 2)
   - `empty` — nothing eligible
+
+  An **explicit issue argument overrides current-worktree detection** — the selection
+  script, and therefore its current-worktree detection, runs only when no argument is
+  given. `/dispatch #123` run from inside worktree-456 still targets 123.
 
   Priority order it implements (highest first; within a tier, oldest PR wins; PRs
   with a local worktree are skipped; `waiting`-phase PRs are skipped entirely):
@@ -54,9 +65,12 @@ When the resolved target is an **open issue with no PR** — whether queue-selec
 It walks open blockers and sub-issues to an open leaf and prints one issue number.
 Retarget to that leaf.
 
-Skip leaf tracing once a PR exists for the target (the `pr <num> <branch>` selection
-result, or an explicit issue argument that already has a PR) — implementation is
-already underway.
+Skip leaf tracing when:
+- A PR exists for the target (`pr <num> <branch>` result, or an explicit issue
+  argument that already has a PR) — implementation is already underway.
+- The target was current-worktree detected (`worktree <N>` result) — the worktree
+  is the already-committed unit of work; retargeting to a sub-issue or blocker
+  would be wrong.
 
 If a named target issue is **closed**, report it and **stop**.
 
@@ -67,9 +81,19 @@ Resolve or create the final target's worktree via `EnterWorktree`, matching
 an existing worktree) or `name` (create a new one; fires the `WorktreeCreate` hook).
 
 - **Already in the target's worktree** (current branch starts with `<issue>-`) → no
-  `EnterWorktree` needed; go straight to creating the marker below.
+  `EnterWorktree` needed. Re-sync issue context:
+  ```bash
+  .claude/skills/ref-pr-workflow/scripts/sync-issue-context <N>
+  ```
+  (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.) Then go
+  straight to creating the marker below.
 - **An existing worktree matches** `<issue>-*` (parse `git worktree list --porcelain`
   as blank-line-delimited records) → `EnterWorktree` with `path:` set to that path.
+  After entering, re-sync issue context from the worktree:
+  ```bash
+  .claude/skills/ref-pr-workflow/scripts/sync-issue-context <N>
+  ```
+  (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.)
 - **No existing worktree** → generate a sanitized branch name `<issue>-<slug>`:
   lowercase the issue title, replace non-alphanumeric runs with `-`, collapse repeated
   `-`, strip leading/trailing `-`, and truncate so the full branch name is ≤ 32

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -3,9 +3,11 @@
 # Usage: dispatch-select-target [--qa]
 #
 # Output: exactly one line:
-#   pr <num> <branch>   — a PR to work on
-#   issue <num>         — a help-wanted issue to implement
-#   empty               — nothing eligible
+#   pr <num> <branch>           — a PR to work on
+#   issue <num>                 — a help-wanted issue to implement
+#   empty                       — nothing eligible
+#   worktree <N> <branch>       — the current worktree's own open issue (short-circuits the queue scan)
+#   worktree-closed <N> <branch>— the current worktree's issue is closed or unknown
 #
 # Default mode priority (highest first; within a tier, oldest PR wins):
 #   1. Oldest "ready"    PR (draft + dispatch:security-reviewed)
@@ -34,6 +36,26 @@ for arg in "$@"; do
     *) echo "error: unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
+
+# Current-worktree detection (default mode only): if the current branch matches
+# the worktree convention <issue-num>-<slug>, short-circuit before the queue scan
+# and target that worktree's own issue directly.
+if [[ "$QA_MODE" == "false" ]]; then
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  if [[ "$CURRENT_BRANCH" =~ ^([0-9]+)- ]]; then
+    N="${BASH_REMATCH[1]}"
+    if STATE=$(gh issue view "$N" --json state 2>/dev/null | jq -r '.state'); then
+      if [[ "$STATE" == "OPEN" ]]; then
+        echo "worktree $N $CURRENT_BRANCH"
+      else
+        echo "worktree-closed $N $CURRENT_BRANCH"
+      fi
+    else
+      echo "worktree-closed $N $CURRENT_BRANCH"
+    fi
+    exit 0
+  fi
+fi
 
 # Collect branches that already have a local worktree (a session is working them).
 WORKTREE_BRANCHES=()

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -85,6 +85,15 @@ case "$args" in
       echo "[]"
     fi
     ;;
+  issue\ view\ *\ --json\ state)
+    # dispatch-select-target worktree detection: gh issue view <num> --json state
+    num=$(echo "$args" | awk '{print $3}')
+    if [[ -f "$STUB_DIR/issue-state-${num}.json" ]]; then
+      cat "$STUB_DIR/issue-state-${num}.json"
+    else
+      exit 1
+    fi
+    ;;
   issue\ view\ *\ --json\ title,body,comments,number,state)
     # issue-blocking / issue-sub-issues call: gh issue view <num> --json ...
     num=$(echo "$args" | awk '{print $3}')
@@ -135,7 +144,11 @@ case "$args" in
     fi
     ;;
   "rev-parse --abbrev-ref HEAD")
-    echo "main"
+    if [[ -f "$STUB_DIR/current-branch.txt" ]]; then
+      cat "$STUB_DIR/current-branch.txt"
+    else
+      echo "main"
+    fi
     ;;
   *)
     echo "git stub: unknown invocation: $args" >&2
@@ -640,6 +653,76 @@ echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "lone waiting PR → empty" "empty" "$result"
+teardown
+
+# 16. Open issue worktree → worktree output, queue scan skipped.
+echo "Test: open issue worktree → worktree <N> <branch>, scan skipped"
+setup
+# Seed a verify PR that would normally be selected — proves the scan is skipped.
+FULL='['"$(make_pr 10 "10-verify-me" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 10 "10-verify-me" "2024-01-01T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
+printf '{"state":"OPEN"}' > "$STUB_DIR/issue-state-42.json"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "open issue worktree → worktree 42 42-some-slug" "worktree 42 42-some-slug" "$result"
+teardown
+
+# 17. Closed issue worktree → worktree-closed.
+echo "Test: closed issue worktree → worktree-closed <N> <branch>"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo '[]' > "$STUB_DIR/pr-list-brief.json"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
+printf '{"state":"CLOSED"}' > "$STUB_DIR/issue-state-42.json"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "closed issue worktree → worktree-closed 42 42-some-slug" "worktree-closed 42 42-some-slug" "$result"
+teardown
+
+# 18. Unknown issue worktree (no state file → gh fails) → worktree-closed.
+echo "Test: unknown issue worktree → worktree-closed <N> <branch>"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo '[]' > "$STUB_DIR/pr-list-brief.json"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '999-gone' > "$STUB_DIR/current-branch.txt"
+# No issue-state-999.json — gh stub exits 1, models a nonexistent issue.
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "unknown issue worktree → worktree-closed 999 999-gone" "worktree-closed 999 999-gone" "$result"
+teardown
+
+# 19. main branch → queue scan unchanged, normal result returned.
+echo "Test: main branch → queue scan runs normally"
+setup
+FULL='['"$(make_pr 10 "10-verify-me" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 10 "10-verify-me" "2024-01-01T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf 'main' > "$STUB_DIR/current-branch.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "main branch → normal scan result (verify PR)" "pr 10 10-verify-me" "$result"
+teardown
+
+# 20. --qa mode from an issue worktree → detection skipped, QA PR returned.
+echo "Test: --qa mode from issue worktree → detection skipped, QA PR returned"
+setup
+# QA-phase PR: draft + green + no label.
+FULL='['"$(make_pr 20 "20-qa-me" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 20 "20-qa-me" "2024-01-01T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+# Current branch looks like an issue worktree, but --qa skips detection.
+printf '42-x' > "$STUB_DIR/current-branch.txt"
+printf '{"state":"OPEN"}' > "$STUB_DIR/issue-state-42.json"
+result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
+assert_eq "--qa mode from issue worktree → normal QA scan (pr 20 20-qa-me)" "pr 20 20-qa-me" "$result"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -673,8 +673,7 @@ teardown
 # 17. Closed issue worktree → worktree-closed.
 echo "Test: closed issue worktree → worktree-closed <N> <branch>"
 setup
-echo '[]' > "$STUB_DIR/pr-list-full.json"
-echo '[]' > "$STUB_DIR/pr-list-brief.json"
+setup_both_pr_lists '[]' '[]'
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
@@ -686,8 +685,7 @@ teardown
 # 18. Unknown issue worktree (no state file → gh fails) → worktree-closed.
 echo "Test: unknown issue worktree → worktree-closed <N> <branch>"
 setup
-echo '[]' > "$STUB_DIR/pr-list-full.json"
-echo '[]' > "$STUB_DIR/pr-list-brief.json"
+setup_both_pr_lists '[]' '[]'
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 printf '999-gone' > "$STUB_DIR/current-branch.txt"


### PR DESCRIPTION
Closes #644

Makes `/dispatch` worktree-aware. Run with no argument from inside an issue
worktree, it now continues that issue instead of skipping it.

- `dispatch-select-target`: in default mode, when the current branch matches the
  `<issue-num>-<slug>` worktree convention, the script checks the issue state and
  short-circuits before the queue scan — printing `worktree <N> <branch>` (open)
  or `worktree-closed <N> <branch>` (closed/unknown). `--qa` mode is unchanged.
- `dispatch/SKILL.md`: Step 1 handles the two new selection results; Step 2 skips
  leaf-tracing for a worktree-detected target; Step 3 re-syncs `CLAUDE.local.md`
  via `sync-issue-context` on any pre-existing worktree; opening note updated.
- `test-dispatch-scripts.sh`: git/gh stub support plus 5 new cases. Suite: 41/41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)