### PR TITLE
QA: dispatch-qa walkthroughs use public seed data only

### DIFF
--- a/.claude/skills/dispatch-qa/SKILL.md
+++ b/.claude/skills/dispatch-qa/SKILL.md
@@ -104,7 +104,7 @@ The QA pass covers **public data only** — documents present in both the QA ser
 
    The plan must NOT duplicate things already verified by unit tests, lint, or type-check. Do not include items like "type-check passes", "no lint errors", "renders without crashing", "no console errors on load". Those are CI's job.
 
-   Build the plan around public seed data (see [QA data policy](#qa-data-policy)). When target behavior is only reachable via `testOnly` or private data, do not create a walkthrough item for it — note the limitation in the plan and defer that coverage to the automated acceptance tests.
+   Build the plan around public seed data (see [QA data policy](#qa-data-policy)). When target behavior is only reachable via `testOnly` or private data, do not create a walkthrough item for it — note the limitation in the plan instead.
 
 3. **Browser feature path.** Skip to Step 4 if the non-browser path applies.
 

--- a/.claude/skills/dispatch-qa/SKILL.md
+++ b/.claude/skills/dispatch-qa/SKILL.md
@@ -24,6 +24,15 @@ This skill is a **single user-acceptance pass**. It does not iterate, does not e
 - **No iteration.** When the user reports a bug, record it and move to the next item. Do not attempt fixes.
 - **No code changes, commits, or pushes.**
 
+## QA data policy
+
+The QA pass covers **public data only** — documents present in both the QA server and production.
+
+- **Identify public seed items** from `<app>/seeds/firestore.ts`: documents in collection blocks **without** `testOnly: true`. The QA server seeds exactly these. Build the walkthrough around them.
+- **Never** run the QA server or any seed step with `SEED_TEST_ONLY=true`, and never re-seed `testOnly` collections by other means — that breaks QA/prod parity, letting QA pass against data absent from production. `testOnly` data exists for the Playwright acceptance tests, which CI's `acceptance` job already runs.
+- **Auth-gated and private-data flows are out of scope** for the automated walkthrough. If one must be verified, the user does so in a preview deployment — avoid this where possible.
+- When a change's behavior is only reachable via `testOnly` or private data, note in the QA plan that the walkthrough is limited to public data and defer that coverage to the automated acceptance tests.
+
 ## Steps
 
 0. **Target resolution.**
@@ -95,13 +104,15 @@ This skill is a **single user-acceptance pass**. It does not iterate, does not e
 
    The plan must NOT duplicate things already verified by unit tests, lint, or type-check. Do not include items like "type-check passes", "no lint errors", "renders without crashing", "no console errors on load". Those are CI's job.
 
+   Build the plan around public seed data (see [QA data policy](#qa-data-policy)). When target behavior is only reachable via `testOnly` or private data, do not create a walkthrough item for it — note the limitation in the plan and defer that coverage to the automated acceptance tests.
+
 3. **Browser feature path.** Skip to Step 4 if the non-browser path applies.
 
    a. **Start the QA server in the background.** Use a Bash tool call with `run_in_background: true`:
       ```bash
       .claude/skills/ref-pr-workflow/scripts/run-qa-server.sh <app-dir>
       ```
-      Capture the App URL printed to stdout.
+      Capture the App URL printed to stdout. The QA server seeds public data only — do not re-run it or any seed step with `SEED_TEST_ONLY=true` (see [QA data policy](#qa-data-policy)).
 
    b. **Wait for the server:**
       ```bash


### PR DESCRIPTION
Closes #639

## What

Adds a `## QA data policy` section to `.claude/skills/dispatch-qa/SKILL.md`
encoding the "public data only" QA policy, plus brief cross-references from
Step 2 (write the QA plan) and Step 3a (start the QA server).

The policy section states:

- The QA pass covers **public data only** — documents present in both the QA
  server and production.
- Identify public seed items from `<app>/seeds/firestore.ts`: documents in
  collection blocks **without** `testOnly: true`. The QA server seeds exactly
  these; build the walkthrough around them.
- Never run the QA server or any seed step with `SEED_TEST_ONLY=true`, and never
  re-seed `testOnly` collections — that breaks QA/prod parity. `testOnly` data is
  for the Playwright acceptance tests, which CI's `acceptance` job already runs.
- Auth-gated / private-data flows are out of scope for the automated walkthrough;
  the user verifies those in a preview deployment, avoided where possible.
- When behavior is only reachable via `testOnly` or private data, note the
  limitation in the QA plan and defer that coverage to the acceptance tests.

## Why

During QA of #600, `/dispatch-qa` built a walkthrough around
`/view/test-image-archive` — a `testOnly` seed document the QA server does not
seed — then worked around the gap by re-seeding with `SEED_TEST_ONLY=true`. That
breaks parity between QA and production. This policy prevents the recurrence.

## On the `/verify` acceptance criterion

Issue #639 also named `/verify` ("TBD; defined by the dispatch restructure in
#630"). #630 has since closed (landed as #637) — the resulting `verify` phase is
`/verify-pr`, a skill that reproduces and fixes failed CI checks. It has no QA
walkthrough and no seeding step, so the public-data policy has nothing to attach
to there. That criterion is **moot / N/A**. The issue anticipated this: "The
`/dispatch-qa` portion could land independently if preferred."

## Verification

Documentation-only change — no build or unit test applies. `git diff` is confined
to `.claude/skills/dispatch-qa/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)