### PR TITLE
dispatch: fetch the open-PR list once for target selection

### DIFF
--- a/.claude/skills/dispatch/scripts/dispatch-phase
+++ b/.claude/skills/dispatch/scripts/dispatch-phase
@@ -9,6 +9,13 @@
 #   - All-digit arg: treated as an issue number. The matching PR is the one
 #     whose headRefName starts with "<issue>-".
 #   - Otherwise: treated as a branch name. Matched exactly.
+#
+# Environment:
+#   DISPATCH_PR_LIST — optional. A JSON array of open PRs supplied by the
+#     caller (dispatch-select-target exports it to avoid a redundant
+#     gh pr list per PR). When set and non-empty, it is used in place of a
+#     self-issued gh pr list. Must include the fields
+#     number,headRefName,isDraft,statusCheckRollup,labels.
 set -euo pipefail
 
 ARG="${1:-}"
@@ -17,8 +24,14 @@ if [[ -z "$ARG" ]]; then
   exit 1
 fi
 
-# Fetch all open PRs with the fields we need.
-PR_LIST=$(gh pr list --state open --json number,headRefName,isDraft,statusCheckRollup,labels)
+# Use the caller-supplied open-PR list when DISPATCH_PR_LIST is set
+# (dispatch-select-target exports it to avoid a redundant gh pr list per PR).
+# Otherwise fetch the list ourselves — standalone callers rely on this path.
+if [[ -n "${DISPATCH_PR_LIST:-}" ]]; then
+  PR_LIST="$DISPATCH_PR_LIST"
+else
+  PR_LIST=$(gh pr list --state open --json number,headRefName,isDraft,statusCheckRollup,labels)
+fi
 
 # Find the matching PR.
 if [[ "$ARG" =~ ^[0-9]+$ ]]; then

--- a/.claude/skills/dispatch/scripts/dispatch-phase
+++ b/.claude/skills/dispatch/scripts/dispatch-phase
@@ -12,7 +12,7 @@
 #
 # Environment:
 #   DISPATCH_PR_LIST — optional. A JSON array of open PRs supplied by the
-#     caller (dispatch-select-target exports it to avoid a redundant
+#     caller (dispatch-select-target passes it to avoid a redundant
 #     gh pr list per PR). When set and non-empty, it is used in place of a
 #     self-issued gh pr list. Must include the fields
 #     number,headRefName,isDraft,statusCheckRollup,labels.
@@ -24,8 +24,7 @@ if [[ -z "$ARG" ]]; then
   exit 1
 fi
 
-# Use the caller-supplied open-PR list when DISPATCH_PR_LIST is set
-# (dispatch-select-target exports it to avoid a redundant gh pr list per PR).
+# Use the caller-supplied open-PR list when DISPATCH_PR_LIST is set.
 # Otherwise fetch the list ourselves — standalone callers rely on this path.
 if [[ -n "${DISPATCH_PR_LIST:-}" ]]; then
   PR_LIST="$DISPATCH_PR_LIST"

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -78,8 +78,11 @@ has_worktree() {
   return 1
 }
 
-# Fetch all open PRs sorted by createdAt ascending (oldest first).
-PR_LIST=$(gh pr list --state open --json number,createdAt,headRefName)
+# Fetch all open PRs once, with the union of fields this script and
+# dispatch-phase need. Export via DISPATCH_PR_LIST so each per-PR
+# dispatch-phase call reuses it instead of re-running gh pr list.
+PR_LIST=$(gh pr list --state open --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels)
+export DISPATCH_PR_LIST="$PR_LIST"
 PR_SORTED=$(printf '%s' "$PR_LIST" | jq -r 'sort_by(.createdAt) | .[] | [.number, .createdAt, .headRefName] | @tsv')
 
 # One "first-seen" variable per phase (list is pre-sorted oldest-first, so first

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -79,10 +79,9 @@ has_worktree() {
 }
 
 # Fetch all open PRs once, with the union of fields this script and
-# dispatch-phase need. Export via DISPATCH_PR_LIST so each per-PR
-# dispatch-phase call reuses it instead of re-running gh pr list.
+# dispatch-phase need. Each per-PR dispatch-phase call below reuses it
+# (passed as DISPATCH_PR_LIST) instead of re-running gh pr list.
 PR_LIST=$(gh pr list --state open --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels)
-export DISPATCH_PR_LIST="$PR_LIST"
 PR_SORTED=$(printf '%s' "$PR_LIST" | jq -r 'sort_by(.createdAt) | .[] | [.number, .createdAt, .headRefName] | @tsv')
 
 # One "first-seen" variable per phase (list is pre-sorted oldest-first, so first
@@ -108,8 +107,8 @@ while IFS=$'\t' read -r pr_num _created pr_branch; do
     continue
   fi
 
-  # Determine phase for this PR.
-  phase=$("$SCRIPT_DIR/dispatch-phase" "$pr_branch")
+  # Determine phase for this PR, reusing the PR list fetched above.
+  phase=$(DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-phase" "$pr_branch")
 
   case "$phase" in
     done)

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -65,15 +65,17 @@ STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
 args="$*"
 case "$args" in
   "pr list --state open --json number,headRefName,isDraft,statusCheckRollup,labels")
+    echo "pr list" >> "$STUB_DIR/gh-pr-list-calls.log"
     if [[ -f "$STUB_DIR/pr-list-full.json" ]]; then
       cat "$STUB_DIR/pr-list-full.json"
     else
       echo "[]"
     fi
     ;;
-  "pr list --state open --json number,createdAt,headRefName")
-    if [[ -f "$STUB_DIR/pr-list-brief.json" ]]; then
-      cat "$STUB_DIR/pr-list-brief.json"
+  "pr list --state open --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels")
+    echo "pr list" >> "$STUB_DIR/gh-pr-list-calls.log"
+    if [[ -f "$STUB_DIR/pr-list-union.json" ]]; then
+      cat "$STUB_DIR/pr-list-union.json"
     else
       echo "[]"
     fi
@@ -248,10 +250,13 @@ make_pr() {
     "$num" "$branch" "$is_draft" "$labels_json" "$rollup_json"
 }
 
-# Helper to build a PR JSON entry for the brief PR list (dispatch-select-target).
-make_pr_brief() {
-  local num="$1" branch="$2" created="$3"
-  printf '{"number":%s,"headRefName":"%s","createdAt":"%s"}' "$num" "$branch" "$created"
+# Helper to build a PR JSON entry for the single union PR list that
+# dispatch-select-target fetches and exports to dispatch-phase. Carries the
+# union of fields both scripts need.
+make_pr_union() {
+  local num="$1" branch="$2" created="$3" is_draft="$4" labels_json="$5" rollup_json="$6"
+  printf '{"number":%s,"createdAt":"%s","headRefName":"%s","isDraft":%s,"labels":%s,"statusCheckRollup":%s}' \
+    "$num" "$created" "$branch" "$is_draft" "$labels_json" "$rollup_json"
 }
 
 # Green rollup (two passing check runs).
@@ -388,29 +393,38 @@ result=$("$TMPDIR_TEST/dispatch-phase" "6")
 assert_eq "issue 6 does not match branch 60-foo" "implement" "$result"
 teardown
 
+# 13. DISPATCH_PR_LIST is used in place of a self-issued gh pr list.
+echo "Test: DISPATCH_PR_LIST overrides self-fetch"
+setup
+# pr-list-full.json is empty: a self-fetch would yield implement. The verify
+# PR lives only in the env var, so a verify result proves the env var won.
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+ENV_LIST='['"$(make_pr 42 "42-verify" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+result=$(DISPATCH_PR_LIST="$ENV_LIST" "$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "DISPATCH_PR_LIST used over self-fetch → verify" "verify" "$result"
+teardown
+
 # ============================================================================
 # dispatch-select-target tests
 # ============================================================================
 echo ""
 echo "=== dispatch-select-target ==="
 
-# For dispatch-select-target we need both the brief PR list (for enumeration)
-# and the full PR list (for dispatch-phase calls).
+# dispatch-select-target fetches one union PR list and exports it via
+# DISPATCH_PR_LIST, so each per-PR dispatch-phase call reuses it. The harness
+# only needs to seed that single list.
 
-setup_both_pr_lists() {
-  local full_json="$1"
-  local brief_json="$2"
-  printf '%s\n' "$full_json" > "$STUB_DIR/pr-list-full.json"
-  printf '%s\n' "$brief_json" > "$STUB_DIR/pr-list-brief.json"
+setup_union_pr_list() {
+  local union_json="$1"
+  printf '%s\n' "$union_json" > "$STUB_DIR/pr-list-union.json"
 }
 
 # 1. A non-QA PR is chosen over a QA PR and a help-wanted issue.
 echo "Test: non-QA PR beats QA PR and issue"
 setup
 # PR 10 in verify phase (no CI green), PR 20 in qa phase (CI green, no label).
-FULL='['"$(make_pr 10 "10-verify-me" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr 20 "20-qa-me" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
-BRIEF='['"$(make_pr_brief 10 "10-verify-me" "2024-01-01T00:00:00Z")"','"$(make_pr_brief 20 "20-qa-me" "2024-01-02T00:00:00Z")"']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr_union 20 "20-qa-me" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+setup_union_pr_list "$UNION"
 printf '[{"number":99,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
 # No worktrees for these branches.
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
@@ -421,9 +435,8 @@ teardown
 # 2. PR with a local worktree is skipped.
 echo "Test: PR whose branch has a worktree is skipped"
 setup
-FULL='['"$(make_pr 10 "10-active-branch" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr 20 "20-other" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
-BRIEF='['"$(make_pr_brief 10 "10-active-branch" "2024-01-01T00:00:00Z")"','"$(make_pr_brief 20 "20-other" "2024-01-02T00:00:00Z")"']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['"$(make_pr_union 10 "10-active-branch" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr_union 20 "20-other" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 # Worktree exists for branch 10-active-branch.
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/10-active-branch\n\nworktree /worktrees/10-active-branch\nHEAD def456\nbranch refs/heads/10-active-branch\n\n' \
@@ -435,8 +448,7 @@ teardown
 # 3. When no eligible PR exists, a help-wanted issue is chosen.
 echo "Test: no eligible PR → help-wanted issue"
 setup
-echo '[]' > "$STUB_DIR/pr-list-full.json"
-echo '[]' > "$STUB_DIR/pr-list-brief.json"
+echo '[]' > "$STUB_DIR/pr-list-union.json"
 printf '[{"number":55,"createdAt":"2024-03-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -446,9 +458,8 @@ teardown
 # 4. --qa mode returns only QA PRs.
 echo "Test: --qa mode returns QA PR"
 setup
-FULL='['"$(make_pr 10 "10-verify-me" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr 20 "20-qa-me" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
-BRIEF='['"$(make_pr_brief 20 "20-qa-me" "2024-01-02T00:00:00Z")"','"$(make_pr_brief 10 "10-verify-me" "2024-01-01T00:00:00Z")"']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['"$(make_pr_union 20 "20-qa-me" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"','"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
@@ -458,8 +469,7 @@ teardown
 # 5. Nothing eligible → empty.
 echo "Test: nothing eligible → empty"
 setup
-echo '[]' > "$STUB_DIR/pr-list-full.json"
-echo '[]' > "$STUB_DIR/pr-list-brief.json"
+echo '[]' > "$STUB_DIR/pr-list-union.json"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -469,8 +479,7 @@ teardown
 # 6. --qa mode with no QA PR → empty (ignores help-wanted issues).
 echo "Test: --qa mode with no QA PR → empty"
 setup
-echo '[]' > "$STUB_DIR/pr-list-full.json"
-echo '[]' > "$STUB_DIR/pr-list-brief.json"
+echo '[]' > "$STUB_DIR/pr-list-union.json"
 printf '[{"number":77,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
@@ -480,9 +489,8 @@ teardown
 # 7. All PRs done → falls through to help-wanted issue.
 echo "Test: all PRs done → help-wanted issue"
 setup
-FULL='['"$(make_pr 10 "10-done-pr" "false" "$NO_LABELS" "$GREEN_ROLLUP")"']'
-BRIEF='['"$(make_pr_brief 10 "10-done-pr" "2024-01-01T00:00:00Z")"']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['"$(make_pr_union 10 "10-done-pr" "2024-01-01T00:00:00Z" "false" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+setup_union_pr_list "$UNION"
 printf '[{"number":33,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -498,21 +506,14 @@ READY_LABELS='[{"name":"dispatch:security-reviewed"}]'
 SECURITY_LABELS='[{"name":"dispatch:reviewed"}]'
 REVIEW_LABELS='[{"name":"dispatch:refactored"}]'
 SIMPLIFY_LABELS='[{"name":"dispatch:qa-done"}]'
-FULL='['
-FULL+="$(make_pr 10 "10-verify" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','
-FULL+="$(make_pr 20 "20-simplify" "true" "$SIMPLIFY_LABELS" "$GREEN_ROLLUP")"','
-FULL+="$(make_pr 30 "30-review" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"','
-FULL+="$(make_pr 40 "40-security" "true" "$SECURITY_LABELS" "$GREEN_ROLLUP")"','
-FULL+="$(make_pr 50 "50-ready" "true" "$READY_LABELS" "$GREEN_ROLLUP")"
-FULL+=']'
-BRIEF='['
-BRIEF+="$(make_pr_brief 10 "10-verify" "2024-01-01T00:00:00Z")"','
-BRIEF+="$(make_pr_brief 20 "20-simplify" "2024-01-02T00:00:00Z")"','
-BRIEF+="$(make_pr_brief 30 "30-review" "2024-01-03T00:00:00Z")"','
-BRIEF+="$(make_pr_brief 40 "40-security" "2024-01-04T00:00:00Z")"','
-BRIEF+="$(make_pr_brief 50 "50-ready" "2024-01-05T00:00:00Z")"
-BRIEF+=']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['
+UNION+="$(make_pr_union 10 "10-verify" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','
+UNION+="$(make_pr_union 20 "20-simplify" "2024-01-02T00:00:00Z" "true" "$SIMPLIFY_LABELS" "$GREEN_ROLLUP")"','
+UNION+="$(make_pr_union 30 "30-review" "2024-01-03T00:00:00Z" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"','
+UNION+="$(make_pr_union 40 "40-security" "2024-01-04T00:00:00Z" "true" "$SECURITY_LABELS" "$GREEN_ROLLUP")"','
+UNION+="$(make_pr_union 50 "50-ready" "2024-01-05T00:00:00Z" "true" "$READY_LABELS" "$GREEN_ROLLUP")"
+UNION+=']'
+setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -525,19 +526,13 @@ setup
 SECURITY_LABELS='[{"name":"dispatch:reviewed"}]'
 REVIEW_LABELS='[{"name":"dispatch:refactored"}]'
 SIMPLIFY_LABELS='[{"name":"dispatch:qa-done"}]'
-FULL='['
-FULL+="$(make_pr 10 "10-verify" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','
-FULL+="$(make_pr 20 "20-simplify" "true" "$SIMPLIFY_LABELS" "$GREEN_ROLLUP")"','
-FULL+="$(make_pr 30 "30-review" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"','
-FULL+="$(make_pr 40 "40-security" "true" "$SECURITY_LABELS" "$GREEN_ROLLUP")"
-FULL+=']'
-BRIEF='['
-BRIEF+="$(make_pr_brief 10 "10-verify" "2024-01-01T00:00:00Z")"','
-BRIEF+="$(make_pr_brief 20 "20-simplify" "2024-01-02T00:00:00Z")"','
-BRIEF+="$(make_pr_brief 30 "30-review" "2024-01-03T00:00:00Z")"','
-BRIEF+="$(make_pr_brief 40 "40-security" "2024-01-04T00:00:00Z")"
-BRIEF+=']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['
+UNION+="$(make_pr_union 10 "10-verify" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','
+UNION+="$(make_pr_union 20 "20-simplify" "2024-01-02T00:00:00Z" "true" "$SIMPLIFY_LABELS" "$GREEN_ROLLUP")"','
+UNION+="$(make_pr_union 30 "30-review" "2024-01-03T00:00:00Z" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"','
+UNION+="$(make_pr_union 40 "40-security" "2024-01-04T00:00:00Z" "true" "$SECURITY_LABELS" "$GREEN_ROLLUP")"
+UNION+=']'
+setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -549,15 +544,11 @@ echo "Test: within same phase, oldest PR wins"
 setup
 # Two review-phase PRs; PR 30 is older.
 REVIEW_LABELS='[{"name":"dispatch:refactored"}]'
-FULL='['
-FULL+="$(make_pr 30 "30-review-a" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"','
-FULL+="$(make_pr 31 "31-review-b" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"
-FULL+=']'
-BRIEF='['
-BRIEF+="$(make_pr_brief 30 "30-review-a" "2024-01-01T00:00:00Z")"','
-BRIEF+="$(make_pr_brief 31 "31-review-b" "2024-01-02T00:00:00Z")"
-BRIEF+=']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['
+UNION+="$(make_pr_union 30 "30-review-a" "2024-01-01T00:00:00Z" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"','
+UNION+="$(make_pr_union 31 "31-review-b" "2024-01-02T00:00:00Z" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"
+UNION+=']'
+setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -568,15 +559,11 @@ teardown
 echo "Test: verify PR beats issue; issue beats QA PR"
 setup
 # verify PR (10), QA PR (20), help-wanted issue (55).
-FULL='['
-FULL+="$(make_pr 10 "10-verify" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','
-FULL+="$(make_pr 20 "20-qa" "true" "$NO_LABELS" "$GREEN_ROLLUP")"
-FULL+=']'
-BRIEF='['
-BRIEF+="$(make_pr_brief 10 "10-verify" "2024-01-01T00:00:00Z")"','
-BRIEF+="$(make_pr_brief 20 "20-qa" "2024-01-02T00:00:00Z")"
-BRIEF+=']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['
+UNION+="$(make_pr_union 10 "10-verify" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','
+UNION+="$(make_pr_union 20 "20-qa" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"
+UNION+=']'
+setup_union_pr_list "$UNION"
 printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -586,9 +573,8 @@ teardown
 # 11b. No non-QA PR: help-wanted issue beats QA PR.
 echo "Test: help-wanted issue beats QA PR"
 setup
-FULL='['"$(make_pr 20 "20-qa" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
-BRIEF='['"$(make_pr_brief 20 "20-qa" "2024-01-02T00:00:00Z")"']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['"$(make_pr_union 20 "20-qa" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+setup_union_pr_list "$UNION"
 printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -599,18 +585,12 @@ teardown
 echo "Test: --qa mode ignores non-QA PRs and returns oldest QA PR"
 setup
 SECURITY_LABELS='[{"name":"dispatch:reviewed"}]'
-FULL='['
-FULL+="$(make_pr 10 "10-security" "true" "$SECURITY_LABELS" "$GREEN_ROLLUP")"','
-FULL+="$(make_pr 20 "20-qa-old" "true" "$NO_LABELS" "$GREEN_ROLLUP")"','
-FULL+="$(make_pr 30 "30-qa-new" "true" "$NO_LABELS" "$GREEN_ROLLUP")"
-FULL+=']'
-# Brief list sorted oldest-first: 10, 20, 30.
-BRIEF='['
-BRIEF+="$(make_pr_brief 10 "10-security" "2024-01-01T00:00:00Z")"','
-BRIEF+="$(make_pr_brief 20 "20-qa-old" "2024-01-02T00:00:00Z")"','
-BRIEF+="$(make_pr_brief 30 "30-qa-new" "2024-01-03T00:00:00Z")"
-BRIEF+=']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['
+UNION+="$(make_pr_union 10 "10-security" "2024-01-01T00:00:00Z" "true" "$SECURITY_LABELS" "$GREEN_ROLLUP")"','
+UNION+="$(make_pr_union 20 "20-qa-old" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"','
+UNION+="$(make_pr_union 30 "30-qa-new" "2024-01-03T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"
+UNION+=']'
+setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
@@ -621,9 +601,8 @@ teardown
 echo "Test: waiting PR skipped in favor of help-wanted issue"
 setup
 # PR 10 in waiting phase (pending CI); no other PRs.
-FULL='['"$(make_pr 10 "10-waiting" "true" "$NO_LABELS" "$PENDING_ROLLUP")"']'
-BRIEF='['"$(make_pr_brief 10 "10-waiting" "2024-01-01T00:00:00Z")"']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['"$(make_pr_union 10 "10-waiting" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
 printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -634,9 +613,8 @@ teardown
 echo "Test: waiting PR skipped in favor of verify PR"
 setup
 # PR 10 (older) in waiting phase, PR 20 (newer) in verify phase.
-FULL='['"$(make_pr 10 "10-waiting" "true" "$NO_LABELS" "$PENDING_ROLLUP")"','"$(make_pr 20 "20-verify" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
-BRIEF='['"$(make_pr_brief 10 "10-waiting" "2024-01-01T00:00:00Z")"','"$(make_pr_brief 20 "20-verify" "2024-01-02T00:00:00Z")"']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['"$(make_pr_union 10 "10-waiting" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP")"','"$(make_pr_union 20 "20-verify" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -646,9 +624,8 @@ teardown
 # 15. A lone waiting PR (nothing else queued) yields empty.
 echo "Test: lone waiting PR → empty"
 setup
-FULL='['"$(make_pr 10 "10-waiting" "true" "$NO_LABELS" "$PENDING_ROLLUP")"']'
-BRIEF='['"$(make_pr_brief 10 "10-waiting" "2024-01-01T00:00:00Z")"']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['"$(make_pr_union 10 "10-waiting" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -659,9 +636,8 @@ teardown
 echo "Test: open issue worktree → worktree <N> <branch>, scan skipped"
 setup
 # Seed a verify PR that would normally be selected — proves the scan is skipped.
-FULL='['"$(make_pr 10 "10-verify-me" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
-BRIEF='['"$(make_pr_brief 10 "10-verify-me" "2024-01-01T00:00:00Z")"']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
@@ -673,7 +649,7 @@ teardown
 # 17. Closed issue worktree → worktree-closed.
 echo "Test: closed issue worktree → worktree-closed <N> <branch>"
 setup
-setup_both_pr_lists '[]' '[]'
+setup_union_pr_list '[]'
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
@@ -685,7 +661,7 @@ teardown
 # 18. Unknown issue worktree (no state file → gh fails) → worktree-closed.
 echo "Test: unknown issue worktree → worktree-closed <N> <branch>"
 setup
-setup_both_pr_lists '[]' '[]'
+setup_union_pr_list '[]'
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 printf '999-gone' > "$STUB_DIR/current-branch.txt"
@@ -697,9 +673,8 @@ teardown
 # 19. main branch → queue scan unchanged, normal result returned.
 echo "Test: main branch → queue scan runs normally"
 setup
-FULL='['"$(make_pr 10 "10-verify-me" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
-BRIEF='['"$(make_pr_brief 10 "10-verify-me" "2024-01-01T00:00:00Z")"']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 printf 'main' > "$STUB_DIR/current-branch.txt"
@@ -711,9 +686,8 @@ teardown
 echo "Test: --qa mode from issue worktree → detection skipped, QA PR returned"
 setup
 # QA-phase PR: draft + green + no label.
-FULL='['"$(make_pr 20 "20-qa-me" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
-BRIEF='['"$(make_pr_brief 20 "20-qa-me" "2024-01-01T00:00:00Z")"']'
-setup_both_pr_lists "$FULL" "$BRIEF"
+UNION='['"$(make_pr_union 20 "20-qa-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 # Current branch looks like an issue worktree, but --qa skips detection.
@@ -721,6 +695,23 @@ printf '42-x' > "$STUB_DIR/current-branch.txt"
 printf '{"state":"OPEN"}' > "$STUB_DIR/issue-state-42.json"
 result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
 assert_eq "--qa mode from issue worktree → normal QA scan (pr 20 20-qa-me)" "pr 20 20-qa-me" "$result"
+teardown
+
+# 21. Selecting a target issues exactly one gh pr list call (down from 1 + N).
+echo "Test: dispatch-select-target fetches the open-PR list once"
+setup
+UNION='['
+UNION+="$(make_pr_union 10 "10-verify" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','
+UNION+="$(make_pr_union 20 "20-qa" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"','
+UNION+="$(make_pr_union 30 "30-waiting" "2024-01-03T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP")"
+UNION+=']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "select-target result over 3 PRs" "pr 10 10-verify" "$result"
+count=$(wc -l < "$STUB_DIR/gh-pr-list-calls.log" | tr -d ' ')
+assert_eq "exactly one gh pr list call regardless of PR count" "1" "$count"
 teardown
 
 # ============================================================================


### PR DESCRIPTION
## Summary

`dispatch-select-target` derived each open PR's workflow phase by calling
`dispatch-phase` once per PR, and every `dispatch-phase` invocation ran its own
`gh pr list --state open` — pulling the expensive `statusCheckRollup` field each
time. Selecting a target cost `1 + N` `gh pr list` calls for `N` open PRs.

`dispatch-select-target` now fetches the open-PR list **once** with the union of
fields both scripts need (`number,createdAt,headRefName,isDraft,statusCheckRollup,labels`)
and exports it via `DISPATCH_PR_LIST`. `dispatch-phase` uses that list when the
variable is set and non-empty, and falls back to its own `gh pr list` otherwise,
so standalone `dispatch-phase` (used by `/dispatch` Step 4) is unchanged.

## Acceptance criteria

- [x] `dispatch-phase` uses a caller-supplied PR list when given one and falls
  back to its own `gh pr list` when not; standalone `dispatch-phase` unchanged.
- [x] `dispatch-select-target` fetches the open-PR list once and reuses it for
  every `dispatch-phase` call — no `gh pr list` runs inside its PR loop.
- [x] Selecting a target issues exactly one `gh pr list` call regardless of the
  open-PR count (down from `1 + N`).
- [x] `bash .claude/skills/dispatch/scripts/test-dispatch-scripts.sh` passes
  (44/44), with the harness updated for the caller-supplied-list path.

## Test plan

`bash .claude/skills/dispatch/scripts/test-dispatch-scripts.sh` — 44/44 pass.
New coverage: `dispatch-phase` honors `DISPATCH_PR_LIST` over a self-fetch, and a
`dispatch-select-target` run over three PRs issues exactly one `gh pr list` call.

Closes #653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)