### PR TITLE
Fix /dispatch placing a second session on an occupied worktree

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -45,7 +45,8 @@ with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
   given. `/dispatch #123` run from inside worktree-456 still targets 123.
 
   Priority order it implements (highest first; within a tier, oldest PR wins; PRs
-  with a local worktree are skipped; `waiting`-phase PRs are skipped entirely):
+  and `help wanted` issues with a local worktree are skipped; `waiting`-phase PRs
+  are skipped entirely):
   oldest `ready` PR → oldest `security` PR → oldest `review` PR → oldest
   `simplify` PR → oldest `verify` PR → oldest `help wanted` issue → oldest `qa`
   PR → `empty`. Non-QA PRs are ranked closest-to-done first; `help wanted` issues
@@ -88,12 +89,21 @@ an existing worktree) or `name` (create a new one; fires the `WorktreeCreate` ho
   (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.) Then go
   straight to creating the marker below.
 - **An existing worktree matches** `<issue>-*` (parse `git worktree list --porcelain`
-  as blank-line-delimited records) → `EnterWorktree` with `path:` set to that path.
-  After entering, re-sync issue context from the worktree:
+  as blank-line-delimited records) **and the target was named by an explicit
+  `/dispatch` argument** → re-use it: the prior session has finished and the
+  worktree is being recycled. `EnterWorktree` with `path:` set to that path. After
+  entering, re-sync issue context from the worktree:
   ```bash
   .claude/skills/ref-pr-workflow/scripts/sync-issue-context <N>
   ```
   (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.)
+
+  A **queue-selected** target (no argument given) must never reach this case:
+  `dispatch-select-target` skips every PR and `help wanted` issue that already has
+  a worktree, because an existing worktree means another session owns it. If a
+  queue-selected target nevertheless has a worktree, treat it as a conflict —
+  report it and **stop** rather than entering the worktree and creating a second
+  session on it.
 - **No existing worktree** → generate a sanitized branch name `<issue>-<slug>`:
   lowercase the issue title, replace non-alphanumeric runs with `-`, collapse repeated
   `-`, strip leading/trailing `-`, and truncate so the full branch name is ≤ 32

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -18,7 +18,10 @@
 #   6. Oldest open help-wanted issue
 #   7. Oldest "qa"       PR (draft, CI green, no dispatch:* label)
 #
-# PRs with a local git worktree are skipped (a session is actively working them).
+# PRs and help-wanted issues with a local git worktree are skipped — an existing
+# worktree means a session is (or was) assigned to it, and the queue must never
+# hand the same worktree to a second session. Re-using such a worktree requires
+# an explicit `/dispatch <issue|pr>` argument, which bypasses this scan.
 # "done" (non-draft) PRs are skipped entirely.
 # "waiting" PRs (draft, CI still running/queued/not started) are skipped entirely.
 #
@@ -72,6 +75,20 @@ has_worktree() {
   local b
   for b in "${WORKTREE_BRANCHES[@]}"; do
     if [[ "$b" == "$branch" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# True when issue N has a local worktree — any worktree branch named
+# "<N>-<slug>". Mirrors dispatch-phase's issue→branch matching ("<N>-" prefix),
+# so issue 6 is not masked by an unrelated worktree on branch "60-foo".
+issue_has_worktree() {
+  local issue="$1"
+  local b
+  for b in "${WORKTREE_BRANCHES[@]}"; do
+    if [[ "$b" == "$issue"-* ]]; then
       return 0
     fi
   done
@@ -193,9 +210,19 @@ if [[ -n "$VERIFY_PR_NUM" ]]; then
   exit 0
 fi
 
-# Fetch oldest help-wanted issue.
+# Pick the oldest open help-wanted issue with no local worktree. An issue whose
+# worktree already exists is owned by another session; the queue must not hand
+# it to a second one. Re-using that worktree is reachable only via an explicit
+# `/dispatch <issue>` argument, which bypasses this scan.
 ISSUE_LIST=$(gh issue list --label "help wanted" --state open --json number,createdAt)
-ISSUE_NUM=$(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[0].number // empty')
+ISSUE_NUM=""
+while IFS= read -r candidate; do
+  [[ -z "$candidate" ]] && continue
+  if ! issue_has_worktree "$candidate"; then
+    ISSUE_NUM="$candidate"
+    break
+  fi
+done < <(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[].number')
 
 if [[ -n "$ISSUE_NUM" ]]; then
   echo "issue $ISSUE_NUM"

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -595,6 +595,57 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "help-wanted issue beats QA PR" "issue 55" "$result"
 teardown
 
+# 11c. A help-wanted issue with a local worktree is skipped; next issue chosen.
+echo "Test: help-wanted issue with worktree skipped; next issue chosen"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo '[]' > "$STUB_DIR/pr-list-brief.json"
+printf '[{"number":50,"createdAt":"2024-01-01T00:00:00Z"},{"number":51,"createdAt":"2024-01-02T00:00:00Z"}]\n' \
+  > "$STUB_DIR/issue-list.json"
+# Worktree exists for issue 50 (branch 50-some-slug) — a session owns it.
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/50-some-slug\nHEAD def456\nbranch refs/heads/50-some-slug\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "issue 50 (has worktree) skipped; issue 51 chosen" "issue 51" "$result"
+teardown
+
+# 11d. The only help-wanted issue has a worktree → empty (not selected).
+echo "Test: lone help-wanted issue with worktree → empty"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo '[]' > "$STUB_DIR/pr-list-brief.json"
+printf '[{"number":50,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/50-some-slug\nHEAD def456\nbranch refs/heads/50-some-slug\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "lone help-wanted issue with worktree → empty" "empty" "$result"
+teardown
+
+# 11e. A help-wanted issue with a worktree is skipped in favor of a QA PR.
+echo "Test: help-wanted issue with worktree skipped → QA PR chosen"
+setup
+FULL='['"$(make_pr 20 "20-qa" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 20 "20-qa" "2024-01-02T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+printf '[{"number":50,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/50-some-slug\nHEAD def456\nbranch refs/heads/50-some-slug\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "help-wanted issue with worktree skipped → QA PR" "pr 20 20-qa" "$result"
+teardown
+
+# 11f. Worktree prefix disambiguation: branch 60-foo does not mask issue 6.
+echo "Test: worktree 60-foo does not mask help-wanted issue 6"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo '[]' > "$STUB_DIR/pr-list-brief.json"
+printf '[{"number":6,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/60-foo\nHEAD def456\nbranch refs/heads/60-foo\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "worktree 60-foo does not mask issue 6" "issue 6" "$result"
+teardown
+
 # 12. --qa mode returns only the oldest QA PR (ignores non-QA PRs).
 echo "Test: --qa mode ignores non-QA PRs and returns oldest QA PR"
 setup


### PR DESCRIPTION
## Problem

`dispatch-select-target` skipped open PRs that already had a local worktree
("a session is working them"), but applied no such check to `help wanted`
issues — the issue scan simply took the oldest open one. So a no-argument
`/dispatch` could select an issue whose `<N>-*` worktree already existed, and
SKILL.md Step 3 would `EnterWorktree` into it — placing a second session on a
worktree another session already owns.

## Fix

- **`dispatch-select-target`** — add `issue_has_worktree()`; the `help wanted`
  scan now skips any issue whose `<N>-*` worktree exists, matching the existing
  PR behavior. The `<N>-` prefix match mirrors `dispatch-phase`, so issue `6` is
  not masked by an unrelated worktree on branch `60-foo`.
- **`SKILL.md` Step 3** — re-using an existing worktree now applies *only* when
  the target was named by an explicit `/dispatch` argument (the
  recycle-after-completion case). A queue-selected target that already has a
  worktree is treated as a conflict — report and stop, never enter.
- **`test-dispatch-scripts.sh`** — +4 tests: issue-with-worktree skipped,
  lone worktree'd issue → `empty`, worktree'd issue skipped → QA PR, and
  `60-foo` prefix disambiguation.

## Verification

`bash .claude/skills/dispatch/scripts/test-dispatch-scripts.sh` — 45/45 pass
(was 41).

## Related

Follow-up issues filed against the same files — sequence to avoid conflicts:
#656 (`dispatch-resolve-worktree` script), #657 (`dispatch-select-target`
tidy + `dispatch-complete-phase`), #660 (`origin/main` health gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
