### PR TITLE
dispatch: skip help-wanted issues that already have a local worktree

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -97,7 +97,9 @@ an existing worktree) or `name` (create a new one; fires the `WorktreeCreate` ho
     ```
     (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.)
   - **Queue-selected (no argument)** → another session already owns this worktree.
-    Report the conflict (name the worktree path and issue `<N>`) and **stop**; do not
+    The queue scan skips worktree'd issues, so this arises only when Step 2
+    leaf-tracing retargets to a blocker or sub-issue that has one. Report the
+    conflict (name the worktree path and issue `<N>`) and **stop**; do not
     `EnterWorktree`.
 - **No existing worktree** → generate a sanitized branch name `<issue>-<slug>`:
   lowercase the issue title, replace non-alphanumeric runs with `-`, collapse repeated

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -45,7 +45,7 @@ with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
   given. `/dispatch #123` run from inside worktree-456 still targets 123.
 
   Priority order it implements (highest first; within a tier, oldest PR wins; PRs
-  with a local worktree are skipped; `waiting`-phase PRs are skipped entirely):
+  and `help wanted` issues with a local worktree are skipped; `waiting`-phase PRs are skipped entirely):
   oldest `ready` PR → oldest `security` PR → oldest `review` PR → oldest
   `simplify` PR → oldest `verify` PR → oldest `help wanted` issue → oldest `qa`
   PR → `empty`. Non-QA PRs are ranked closest-to-done first; `help wanted` issues
@@ -88,12 +88,17 @@ an existing worktree) or `name` (create a new one; fires the `WorktreeCreate` ho
   (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.) Then go
   straight to creating the marker below.
 - **An existing worktree matches** `<issue>-*` (parse `git worktree list --porcelain`
-  as blank-line-delimited records) → `EnterWorktree` with `path:` set to that path.
-  After entering, re-sync issue context from the worktree:
-  ```bash
-  .claude/skills/ref-pr-workflow/scripts/sync-issue-context <N>
-  ```
-  (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.)
+  as blank-line-delimited records):
+  - **Named by an explicit `/dispatch` argument** (recycle-after-completion case) →
+    `EnterWorktree` with `path:` set to that path. After entering, re-sync issue
+    context from the worktree:
+    ```bash
+    .claude/skills/ref-pr-workflow/scripts/sync-issue-context <N>
+    ```
+    (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.)
+  - **Queue-selected (no argument)** → another session already owns this worktree.
+    Report the conflict (name the worktree path and issue `<N>`) and **stop**; do not
+    `EnterWorktree`.
 - **No existing worktree** → generate a sanitized branch name `<issue>-<slug>`:
   lowercase the issue title, replace non-alphanumeric runs with `-`, collapse repeated
   `-`, strip leading/trailing `-`, and truncate so the full branch name is ≤ 32

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -15,10 +15,11 @@
 #   3. Oldest "review"   PR (draft + dispatch:refactored)
 #   4. Oldest "simplify" PR (draft + dispatch:qa-done)
 #   5. Oldest "verify"   PR (draft, CI completed and failed)
-#   6. Oldest open help-wanted issue
+#   6. Oldest open help-wanted issue with no local git worktree
 #   7. Oldest "qa"       PR (draft, CI green, no dispatch:* label)
 #
-# PRs with a local git worktree are skipped (a session is actively working them).
+# PRs and help-wanted issues with a local git worktree are skipped (a session is
+# actively working them).
 # "done" (non-draft) PRs are skipped entirely.
 # "waiting" PRs (draft, CI still running/queued/not started) are skipped entirely.
 #
@@ -72,6 +73,17 @@ has_worktree() {
   local b
   for b in "${WORKTREE_BRANCHES[@]}"; do
     if [[ "$b" == "$branch" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+issue_has_worktree() {
+  local num="$1"
+  local b
+  for b in "${WORKTREE_BRANCHES[@]}"; do
+    if [[ "$b" == "$num-"* ]]; then
       return 0
     fi
   done
@@ -193,9 +205,18 @@ if [[ -n "$VERIFY_PR_NUM" ]]; then
   exit 0
 fi
 
-# Fetch oldest help-wanted issue.
+# Fetch help-wanted issues oldest-first; pick the oldest with no local worktree.
 ISSUE_LIST=$(gh issue list --label "help wanted" --state open --json number,createdAt)
-ISSUE_NUM=$(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[0].number // empty')
+ISSUE_NUM=""
+while IFS= read -r issue_num; do
+  [[ -z "$issue_num" ]] && continue
+  # Skip issues whose <N>-* worktree exists (a session is working them).
+  if issue_has_worktree "$issue_num"; then
+    continue
+  fi
+  ISSUE_NUM="$issue_num"
+  break
+done < <(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[].number')
 
 if [[ -n "$ISSUE_NUM" ]]; then
   echo "issue $ISSUE_NUM"

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -207,6 +207,9 @@ fi
 
 # Fetch help-wanted issues oldest-first; pick the oldest with no local worktree.
 ISSUE_LIST=$(gh issue list --label "help wanted" --state open --json number,createdAt)
+# Sort into a variable first so a jq failure aborts here (set -e + pipefail);
+# a process substitution would swallow it as empty input. Mirrors PR_SORTED.
+ISSUE_NUMS_SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[].number')
 ISSUE_NUM=""
 while IFS= read -r issue_num; do
   [[ -z "$issue_num" ]] && continue
@@ -216,7 +219,7 @@ while IFS= read -r issue_num; do
   fi
   ISSUE_NUM="$issue_num"
   break
-done < <(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[].number')
+done <<< "$ISSUE_NUMS_SORTED"
 
 if [[ -n "$ISSUE_NUM" ]]; then
   echo "issue $ISSUE_NUM"

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -723,6 +723,59 @@ result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
 assert_eq "--qa mode from issue worktree → normal QA scan (pr 20 20-qa-me)" "pr 20 20-qa-me" "$result"
 teardown
 
+# 21. Help-wanted issue with a worktree is skipped; the next-oldest issue is chosen.
+echo "Test: issue with worktree skipped; next-oldest issue chosen"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo '[]' > "$STUB_DIR/pr-list-brief.json"
+# Issue 55 is older, issue 66 is newer. Issue 55 has a 55-* worktree.
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"},{"number":66,"createdAt":"2024-01-02T00:00:00Z"}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/55-some-feature\nHEAD def456\nbranch refs/heads/55-some-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "issue with worktree skipped; next issue 66 chosen" "issue 66" "$result"
+teardown
+
+# 22. A lone help-wanted issue that has a worktree → empty (nothing else queued).
+echo "Test: lone worktree'd issue → empty"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo '[]' > "$STUB_DIR/pr-list-brief.json"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/55-some-feature\nHEAD def456\nbranch refs/heads/55-some-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "lone worktree'd issue → empty" "empty" "$result"
+teardown
+
+# 23. Worktree'd issue skipped; QA PR is next in line.
+echo "Test: worktree'd issue skipped → QA PR selected"
+setup
+FULL='['"$(make_pr 20 "20-qa" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 20 "20-qa" "2024-01-01T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+# The help-wanted issue would normally beat the QA PR, but it has a worktree.
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/55-some-feature\nHEAD def456\nbranch refs/heads/55-some-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "worktree'd issue skipped → QA PR returned" "pr 20 20-qa" "$result"
+teardown
+
+# 24. Prefix disambiguation: issue 6 is NOT masked by an unrelated worktree on branch 60-foo.
+echo "Test: issue 6 not masked by worktree on branch 60-foo"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo '[]' > "$STUB_DIR/pr-list-brief.json"
+printf '[{"number":6,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+# Worktree exists for 60-foo, not for 6-*.
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/60-foo\nHEAD def456\nbranch refs/heads/60-foo\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "issue 6 not masked by 60-foo worktree" "issue 6" "$result"
+teardown
+
 # ============================================================================
 # dispatch-trace-leaf tests
 # ============================================================================


### PR DESCRIPTION
Closes #661

## Problem

`dispatch-select-target` skipped open PRs that already had a local worktree
("a session is working them"), but applied no such check to `help wanted`
issues — the issue scan simply took the oldest open one. So a no-argument
`/dispatch` could select an issue whose `<N>-*` worktree already existed, and
SKILL.md Step 3 would `EnterWorktree` into it — placing a second session on a
worktree another session already owns.

## Fix

- **`dispatch-select-target`** — adds `issue_has_worktree()`; the `help wanted`
  scan now walks issues oldest-first and skips any whose `<N>-*` worktree
  exists, matching the existing PR behavior. The `<N>-` prefix match mirrors
  `dispatch-phase`, so issue `6` is not masked by an unrelated worktree on
  branch `60-foo`.
- **`SKILL.md` Step 3** — re-using an existing worktree now applies *only* when
  the target was named by an explicit `/dispatch` argument (the
  recycle-after-completion case). A queue-selected target that already has a
  worktree is treated as a conflict — reported and stopped, never entered.
- **`test-dispatch-scripts.sh`** — +4 tests: issue-with-worktree skipped,
  lone worktree'd issue → `empty`, worktree'd issue skipped → QA PR, and
  `60-foo` prefix disambiguation.

## Verification

`bash .claude/skills/dispatch/scripts/test-dispatch-scripts.sh` — 45/45 pass
(was 41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)