### PR TITLE
/dispatch: gate the queue scan on origin/main CI health

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -70,11 +70,12 @@ with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
   start. Do **not** create a worktree, branch, or phase skill. Diagnose main
   instead: enumerate the failing checks on `<sha>` by aggregating
   `gh run list --branch main` and
-  `gh api repos/{owner}/{repo}/commits/<sha>/check-runs`, fetch the failing
-  workflow run's logs with `gh run view <databaseId> --log-failed`, summarize the
-  likely cause, report it, and **stop**. Once a PR that fixes main exists the
-  normal ladder picks it up (verify/ready) — this gate only blocks starting new,
-  unrelated work.
+  `gh api repos/{owner}/{repo}/commits/<sha>/check-runs`. For a failing workflow
+  run, fetch its logs with `gh run view <databaseId> --log-failed`; for a failing
+  CodeQL check-run (which has no workflow-run id), open its `details_url` from the
+  check-runs response. Summarize the likely cause, report it, and **stop**. Once a
+  PR that fixes main exists the normal ladder picks it up (verify/ready) — this
+  gate only blocks starting new, unrelated work.
 
 ## 2. Trace to an Open Leaf
 

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -39,10 +39,23 @@ with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
     closed/unrecognized issue `<N>` and **stop** (consistent with the named-target
     "closed → report and stop" rule in Step 2)
   - `empty` — nothing eligible
+  - `main-broken <sha>` — `origin/main`'s HEAD CI has a failing check; the queue
+    scan was short-circuited (see the `main-broken` handling block below)
 
   An **explicit issue argument overrides current-worktree detection** — the selection
   script, and therefore its current-worktree detection, runs only when no argument is
   given. `/dispatch #123` run from inside worktree-456 still targets 123.
+
+  Before the priority ladder, the script runs a **top-priority `origin/main` CI
+  health gate**. Every queueable task builds on `origin/main` — branches fork
+  from it and merge it — so a failing check on main's HEAD means nothing is safe
+  to start. The gate aggregates main's HEAD CI from two sources (CodeQL
+  check-runs and Actions workflow runs); a failing conclusion short-circuits the
+  scan to `main-broken <sha>` and the priority ladder is not evaluated.
+  In-progress (not-yet-concluded) checks do **not** trip the gate. The gate is
+  bypassed by an explicit `/dispatch <issue|pr>` argument (the queue scan is not
+  run at all) and by current-worktree continuation (a session continues its own
+  in-progress work regardless of main's state).
 
   Priority order it implements (highest first; within a tier, oldest PR wins; PRs
   with a local worktree are skipped; `waiting`-phase PRs are skipped entirely):
@@ -52,6 +65,16 @@ with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
   rank below all non-QA PRs but above QA PRs.
 
   On `empty` → report that the queue is empty and **stop**.
+
+  On `main-broken <sha>` → `origin/main` itself is red, so no new work is safe to
+  start. Do **not** create a worktree, branch, or phase skill. Diagnose main
+  instead: enumerate the failing checks on `<sha>` by aggregating
+  `gh run list --branch main` and
+  `gh api repos/{owner}/{repo}/commits/<sha>/check-runs`, fetch the failing
+  workflow run's logs with `gh run view <databaseId> --log-failed`, summarize the
+  likely cause, report it, and **stop**. Once a PR that fixes main exists the
+  normal ladder picks it up (verify/ready) — this gate only blocks starting new,
+  unrelated work.
 
 ## 2. Trace to an Open Leaf
 

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -51,18 +51,23 @@ done
 # for commits that have no classic statuses.
 main_broken_sha() {
   local sha cr_fail wf_fail
+  # CI conclusions that count as a failing check; both gh sources below report
+  # conclusions in lowercase.
+  local fail='["failure","timed_out","cancelled","action_required","startup_failure","stale"]'
   sha=$(gh api "repos/{owner}/{repo}/commits/main" | jq -r '.sha')
 
-  cr_fail=$(gh api "repos/{owner}/{repo}/commits/$sha/check-runs" | jq '
-    [.check_runs[] | select(.conclusion as $c |
-      ["failure","timed_out","cancelled","action_required","startup_failure","stale"]
-      | index($c))] | length')
+  cr_fail=$(gh api "repos/{owner}/{repo}/commits/$sha/check-runs" \
+    | jq --argjson fail "$fail" \
+        '[.check_runs[] | select(.conclusion as $c | $fail | index($c))] | length')
 
-  wf_fail=$(gh run list --branch main \
-    --json databaseId,headSha,conclusion,status,workflowName | jq --arg sha "$sha" '
-    [.[] | select(.headSha == $sha) | select(.conclusion as $c |
-      ["failure","timed_out","cancelled","action_required","startup_failure","stale"]
-      | index($c))] | length')
+  # --commit scopes the query to main's HEAD (the default 20-run window could
+  # otherwise miss it); the headSha filter is a defense-in-depth guard so a
+  # stale run can never trip the gate.
+  wf_fail=$(gh run list --branch main --commit "$sha" \
+    --json databaseId,headSha,conclusion,status,workflowName \
+    | jq --arg sha "$sha" --argjson fail "$fail" \
+        '[.[] | select(.headSha == $sha)
+              | select(.conclusion as $c | $fail | index($c))] | length')
 
   if [[ "$cr_fail" -gt 0 || "$wf_fail" -gt 0 ]]; then
     echo "$sha"

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -8,6 +8,11 @@
 #   empty                       — nothing eligible
 #   worktree <N> <branch>       — the current worktree's own open issue (short-circuits the queue scan)
 #   worktree-closed <N> <branch>— the current worktree's issue is closed or unknown
+#   main-broken <sha>           — origin/main's HEAD CI has a failing check; no task selected
+#
+# Default mode runs a top-priority origin/main CI health gate before the ladder:
+# every queueable task builds on origin/main, so a failing check on main's HEAD
+# short-circuits the scan to "main-broken <sha>" and selects no task.
 #
 # Default mode priority (highest first; within a tier, oldest PR wins):
 #   1. Oldest "ready"    PR (draft + dispatch:security-reviewed)
@@ -37,6 +42,33 @@ for arg in "$@"; do
   esac
 done
 
+# Print origin/main's HEAD SHA if its CI has a failing check; print nothing if
+# main is healthy or only has in-progress checks. main's CI state spans two
+# sources that must both be aggregated:
+#   - check-runs    (CodeQL default-setup analyses)      — /commits/{sha}/check-runs
+#   - workflow runs (Production Deploy, Firestore rules) — gh run list --branch main
+# The legacy combined-status API is intentionally not used: it reports "pending"
+# for commits that have no classic statuses.
+main_broken_sha() {
+  local sha cr_fail wf_fail
+  sha=$(gh api "repos/{owner}/{repo}/commits/main" | jq -r '.sha')
+
+  cr_fail=$(gh api "repos/{owner}/{repo}/commits/$sha/check-runs" | jq '
+    [.check_runs[] | select(.conclusion as $c |
+      ["failure","timed_out","cancelled","action_required","startup_failure","stale"]
+      | index($c))] | length')
+
+  wf_fail=$(gh run list --branch main \
+    --json databaseId,headSha,conclusion,status,workflowName | jq --arg sha "$sha" '
+    [.[] | select(.headSha == $sha) | select(.conclusion as $c |
+      ["failure","timed_out","cancelled","action_required","startup_failure","stale"]
+      | index($c))] | length')
+
+  if [[ "$cr_fail" -gt 0 || "$wf_fail" -gt 0 ]]; then
+    echo "$sha"
+  fi
+}
+
 # Current-worktree detection (default mode only): if the current branch matches
 # the worktree convention <issue-num>-<slug>, short-circuit before the queue scan
 # and target that worktree's own issue directly.
@@ -53,6 +85,16 @@ if [[ "$QA_MODE" == "false" ]]; then
     else
       echo "worktree-closed $N $CURRENT_BRANCH"
     fi
+    exit 0
+  fi
+
+  # Top-priority gate: every queueable task builds on origin/main, so a failing
+  # check on main's HEAD means nothing is safe to start — short-circuit to
+  # main-broken and let /dispatch Step 1 diagnose. In-progress checks do not trip
+  # the gate. --qa mode and current-worktree continuation never reach here.
+  MAIN_BROKEN_SHA=$(main_broken_sha)
+  if [[ -n "$MAIN_BROKEN_SHA" ]]; then
+    echo "main-broken $MAIN_BROKEN_SHA"
     exit 0
   fi
 fi

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -64,7 +64,7 @@ main_broken_sha() {
   # otherwise miss it); the headSha filter is a defense-in-depth guard so a
   # stale run can never trip the gate.
   wf_fail=$(gh run list --branch main --commit "$sha" \
-    --json databaseId,headSha,conclusion,status,workflowName \
+    --json headSha,conclusion \
     | jq --arg sha "$sha" --argjson fail "$fail" \
         '[.[] | select(.headSha == $sha)
               | select(.conclusion as $c | $fail | index($c))] | length')

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -758,7 +758,7 @@ printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
 printf '{"check_runs":[{"status":"completed","conclusion":"success"}]}' \
   > "$STUB_DIR/main-check-runs.json"
-printf '[{"databaseId":900,"headSha":"mainhead0","conclusion":"success","status":"completed","workflowName":"Production Deploy"}]' \
+printf '[{"headSha":"mainhead0","conclusion":"success"}]' \
   > "$STUB_DIR/main-run-list.json"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "main green → normal selection (verify PR)" "pr 10 10-verify-me" "$result"
@@ -791,7 +791,7 @@ echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
 printf '{"check_runs":[]}' > "$STUB_DIR/main-check-runs.json"
-printf '[{"databaseId":901,"headSha":"mainhead0","conclusion":"failure","status":"completed","workflowName":"Production Deploy"}]' \
+printf '[{"headSha":"mainhead0","conclusion":"failure"}]' \
   > "$STUB_DIR/main-run-list.json"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "main failing workflow run → main-broken" "main-broken mainhead0" "$result"
@@ -808,7 +808,7 @@ printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
 printf '{"check_runs":[{"status":"in_progress","conclusion":null}]}' \
   > "$STUB_DIR/main-check-runs.json"
-printf '[{"databaseId":902,"headSha":"mainhead0","conclusion":null,"status":"in_progress","workflowName":"Production Deploy"}]' \
+printf '[{"headSha":"mainhead0","conclusion":null}]' \
   > "$STUB_DIR/main-run-list.json"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "main in-progress → normal selection (verify PR)" "pr 10 10-verify-me" "$result"
@@ -824,7 +824,7 @@ echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
 printf '{"check_runs":[]}' > "$STUB_DIR/main-check-runs.json"
-printf '[{"databaseId":903,"headSha":"oldsha99","conclusion":"failure","status":"completed","workflowName":"Production Deploy"}]' \
+printf '[{"headSha":"oldsha99","conclusion":"failure"}]' \
   > "$STUB_DIR/main-run-list.json"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "main failing run on stale SHA → normal selection (verify PR)" "pr 10 10-verify-me" "$result"

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -131,7 +131,7 @@ case "$args" in
     if [[ -f "$STUB_DIR/main-check-runs.json" ]]; then cat "$STUB_DIR/main-check-runs.json"
     else echo '{"check_runs":[]}'; fi
     ;;
-  "run list --branch main --json databaseId,headSha,conclusion,status,workflowName")
+  run\ list\ --branch\ main\ *)
     # main_broken_sha: Actions workflow runs on main. Default: none.
     if [[ -f "$STUB_DIR/main-run-list.json" ]]; then cat "$STUB_DIR/main-run-list.json"
     else echo '[]'; fi

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -121,6 +121,21 @@ case "$args" in
       echo "[]"
     fi
     ;;
+  "api repos/{owner}/{repo}/commits/main")
+    # main_broken_sha: resolve origin/main's HEAD SHA. Default: healthy main.
+    if [[ -f "$STUB_DIR/main-commit.json" ]]; then cat "$STUB_DIR/main-commit.json"
+    else echo '{"sha":"mainhead0"}'; fi
+    ;;
+  api\ repos/*/commits/*/check-runs)
+    # main_broken_sha: CodeQL check-runs for main's HEAD. Default: none.
+    if [[ -f "$STUB_DIR/main-check-runs.json" ]]; then cat "$STUB_DIR/main-check-runs.json"
+    else echo '{"check_runs":[]}'; fi
+    ;;
+  "run list --branch main --json databaseId,headSha,conclusion,status,workflowName")
+    # main_broken_sha: Actions workflow runs on main. Default: none.
+    if [[ -f "$STUB_DIR/main-run-list.json" ]]; then cat "$STUB_DIR/main-run-list.json"
+    else echo '[]'; fi
+    ;;
   *)
     echo "gh stub: unknown invocation: $args" >&2
     exit 1
@@ -721,6 +736,130 @@ printf '42-x' > "$STUB_DIR/current-branch.txt"
 printf '{"state":"OPEN"}' > "$STUB_DIR/issue-state-42.json"
 result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
 assert_eq "--qa mode from issue worktree → normal QA scan (pr 20 20-qa-me)" "pr 20 20-qa-me" "$result"
+teardown
+
+# --- origin/main CI health gate (issue #660) --------------------------------
+# The gate runs before the priority ladder in default mode. It aggregates main's
+# HEAD CI from check-runs (CodeQL) and Actions workflow runs; a failing
+# conclusion short-circuits to "main-broken <sha>".
+#
+# The explicit-`/dispatch <issue|pr>` bypass is structural and not script-
+# testable here: an explicit argument skips the queue scan entirely (SKILL.md
+# Step 1), so dispatch-select-target is never invoked on that path.
+
+# 21. main green (explicit success checks) → normal selection.
+echo "Test: main green → normal selection"
+setup
+FULL='['"$(make_pr 10 "10-verify-me" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 10 "10-verify-me" "2024-01-01T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
+printf '{"check_runs":[{"status":"completed","conclusion":"success"}]}' \
+  > "$STUB_DIR/main-check-runs.json"
+printf '[{"databaseId":900,"headSha":"mainhead0","conclusion":"success","status":"completed","workflowName":"Production Deploy"}]' \
+  > "$STUB_DIR/main-run-list.json"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "main green → normal selection (verify PR)" "pr 10 10-verify-me" "$result"
+teardown
+
+# 22. main failing check-run → main-broken; priority ladder skipped.
+echo "Test: main failing check-run → main-broken"
+setup
+# Seed a verify PR + help-wanted issue — both must be ignored once the gate trips.
+FULL='['"$(make_pr 10 "10-verify-me" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 10 "10-verify-me" "2024-01-01T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
+printf '{"check_runs":[{"status":"completed","conclusion":"failure"}]}' \
+  > "$STUB_DIR/main-check-runs.json"
+printf '[]' > "$STUB_DIR/main-run-list.json"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "main failing check-run → main-broken (ladder skipped)" "main-broken mainhead0" "$result"
+teardown
+
+# 23. main failing workflow run → main-broken.
+echo "Test: main failing workflow run → main-broken"
+setup
+FULL='['"$(make_pr 10 "10-verify-me" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 10 "10-verify-me" "2024-01-01T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
+printf '{"check_runs":[]}' > "$STUB_DIR/main-check-runs.json"
+printf '[{"databaseId":901,"headSha":"mainhead0","conclusion":"failure","status":"completed","workflowName":"Production Deploy"}]' \
+  > "$STUB_DIR/main-run-list.json"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "main failing workflow run → main-broken" "main-broken mainhead0" "$result"
+teardown
+
+# 24. main in-progress checks → gate not tripped, normal selection.
+echo "Test: main in-progress checks → not tripped"
+setup
+FULL='['"$(make_pr 10 "10-verify-me" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 10 "10-verify-me" "2024-01-01T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
+printf '{"check_runs":[{"status":"in_progress","conclusion":null}]}' \
+  > "$STUB_DIR/main-check-runs.json"
+printf '[{"databaseId":902,"headSha":"mainhead0","conclusion":null,"status":"in_progress","workflowName":"Production Deploy"}]' \
+  > "$STUB_DIR/main-run-list.json"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "main in-progress → normal selection (verify PR)" "pr 10 10-verify-me" "$result"
+teardown
+
+# 25. Failing workflow run on a stale SHA → gate not tripped (headSha filter).
+echo "Test: main failing run on stale SHA → not tripped"
+setup
+FULL='['"$(make_pr 10 "10-verify-me" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 10 "10-verify-me" "2024-01-01T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
+printf '{"check_runs":[]}' > "$STUB_DIR/main-check-runs.json"
+printf '[{"databaseId":903,"headSha":"oldsha99","conclusion":"failure","status":"completed","workflowName":"Production Deploy"}]' \
+  > "$STUB_DIR/main-run-list.json"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "main failing run on stale SHA → normal selection (verify PR)" "pr 10 10-verify-me" "$result"
+teardown
+
+# 26. --qa mode bypasses the gate even when main is broken.
+echo "Test: --qa mode bypasses the main-CI gate"
+setup
+FULL='['"$(make_pr 20 "20-qa-me" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+BRIEF='['"$(make_pr_brief 20 "20-qa-me" "2024-01-01T00:00:00Z")"']'
+setup_both_pr_lists "$FULL" "$BRIEF"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
+printf '{"check_runs":[{"status":"completed","conclusion":"failure"}]}' \
+  > "$STUB_DIR/main-check-runs.json"
+printf '[]' > "$STUB_DIR/main-run-list.json"
+result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
+assert_eq "--qa mode bypasses gate → QA PR returned" "pr 20 20-qa-me" "$result"
+teardown
+
+# 27. Current-worktree continuation bypasses the gate even when main is broken.
+echo "Test: worktree continuation bypasses the main-CI gate"
+setup
+setup_both_pr_lists '[]' '[]'
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
+printf '{"state":"OPEN"}' > "$STUB_DIR/issue-state-42.json"
+printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
+printf '{"check_runs":[{"status":"completed","conclusion":"failure"}]}' \
+  > "$STUB_DIR/main-check-runs.json"
+printf '[]' > "$STUB_DIR/main-run-list.json"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "worktree continuation bypasses gate → worktree 42 42-some-slug" "worktree 42 42-some-slug" "$result"
 teardown
 
 # ============================================================================


### PR DESCRIPTION
## Summary

`/dispatch`'s no-argument queue scan hands out the highest-priority PR or
`help wanted` issue. Every task it can select is built on `origin/main` — new
branches fork from main and merge it, inheriting its CI state. If `origin/main`
itself is red, starting new work wastes effort and blurs pre-existing breakage
against new regressions. When main is broken, the only pressing task is
diagnosing main.

This adds a **top-priority gate** to the bare queue scan: before the priority
ladder, `dispatch-select-target` checks `origin/main`'s HEAD CI; a failing
conclusion short-circuits to a new `main-broken <sha>` result. `/dispatch`
SKILL.md Step 1 maps that to: diagnose main — enumerate the failing checks,
fetch the failing run's logs, summarize the cause, report, and stop. No
worktree, branch, or phase skill is created.

main's CI state spans two sources, both aggregated:
- **check-runs** (`/commits/{sha}/check-runs`) — CodeQL default-setup analyses
- **workflow runs** (`gh run list --branch main`) — `Production Deploy`,
  `Firestore — Deploy Rules`

In-progress (not-yet-concluded) checks do not trip the gate. The gate is
bypassed by an explicit `/dispatch <issue|pr>` argument (the queue scan is not
run at all) and by current-worktree continuation (a session continues its own
in-progress work regardless of main's state).

## Changes

- `dispatch-select-target` — new `main_broken_sha` function plus the gate call,
  inside the default-mode block after current-worktree detection and before the
  priority ladder.
- `SKILL.md` Step 1 — documents the `main-broken <sha>` output token, the gate,
  its bypass scope, and the diagnosis flow.
- `test-dispatch-scripts.sh` — 7 new tests: main green, failing check-run,
  failing workflow run, in-progress, stale SHA, `--qa` bypass, worktree bypass.
  48/48 tests pass.

Closes #660