### PR TITLE
dispatch: emit phase from dispatch-select-target, add dispatch-complete-phase

### DIFF
--- a/.claude/skills/dispatch-qa/SKILL.md
+++ b/.claude/skills/dispatch-qa/SKILL.md
@@ -294,15 +294,14 @@ The QA pass covers **public data only** — documents present in both the QA ser
    First, **surface any unresolved SKIP items** to the user — list each SKIP item
    so the user can decide whether to accept it before the PR advances.
 
-   Then ensure the label exists and apply it to the PR. Run both `gh` commands with
-   `dangerouslyDisableSandbox: true` (per `.claude/rules/sandbox.md`):
+   Then apply the `dispatch:qa-done` label to the PR via `dispatch-complete-phase`
+   (run with `dangerouslyDisableSandbox: true` — it invokes `gh`):
 
    ```bash
-   gh label create "dispatch:qa-done" --color BFD4F2 --description "qa phase complete" 2>/dev/null || true
-   gh pr edit <pr-num> --add-label "dispatch:qa-done"
+   .claude/skills/dispatch/scripts/dispatch-complete-phase <pr-num> qa
    ```
 
-   The first command is idempotent — it is safe when the label already exists or on
-   forks where it does not.
+   The script applies the label, creating it first only if it does not yet exist
+   (e.g. on a fork where it has not been created).
 
    Then **stop**. `/loop /dispatch` advances to the next phase.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -67,8 +67,8 @@ It walks open blockers and sub-issues to an open leaf and prints one issue numbe
 Retarget to that leaf.
 
 Skip leaf tracing when:
-- A PR exists for the target (`pr <num> <branch>` result, or an explicit issue
-  argument that already has a PR) — implementation is already underway.
+- A PR exists for the target (`pr <num> <branch> <phase>` result, or an explicit
+  issue argument that already has a PR) — implementation is already underway.
 - The target was current-worktree detected (`worktree <N>` result) — the worktree
   is the already-committed unit of work; retargeting to a sub-issue or blocker
   would be wrong.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -188,10 +188,9 @@ on a clean pass. `/dispatch` applies the remaining three: `dispatch:refactored`,
 phase skill returns successfully. This keeps the generic `/simplify`, `/review`, and
 `/security-review` skills dispatch-unaware.
 
-`dispatch-complete-phase` maps the completed phase to its label, ensures that label
-exists idempotently (safe on forks where the labels do not yet exist), and applies it
-to the PR — one call, run with `dangerouslyDisableSandbox: true` since it invokes
-`gh`:
+`dispatch-complete-phase` maps the completed phase to its label and applies it to the
+PR, creating the label first only if it does not yet exist (e.g. on a fork) — one
+call, run with `dangerouslyDisableSandbox: true` since it invokes `gh`:
 
 ```bash
 .claude/skills/dispatch/scripts/dispatch-complete-phase <pr-num> <phase>

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -30,7 +30,8 @@ with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
   ```
 
   It prints exactly one line:
-  - `pr <num> <branch>` — a PR to work on
+  - `pr <num> <branch> <phase>` — a PR to work on; `<phase>` is pre-derived by the
+    selection scan, so Step 4 reuses it instead of re-deriving
   - `issue <num>` — a `help wanted` issue to implement
   - `worktree <N> <branch>` — run from inside an issue worktree; target is `<N>`,
     queue scan already skipped
@@ -119,7 +120,12 @@ worktree removes it.
 
 ## 4. Derive the Phase
 
-Run the phase script against the final target (issue number or branch):
+When the target is a **queue-selected PR** (`pr <num> <branch> <phase>` from Step 1),
+the phase is already on the result line — use it directly and skip the script below.
+
+On every other path — an explicit issue argument, a `worktree <N>` result, or a
+queue-selected `issue <num>` (after leaf tracing in Step 2) — run the phase script
+against the final target (issue number or branch):
 
 ```bash
 .claude/skills/dispatch/scripts/dispatch-phase <target>

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -163,8 +163,9 @@ Invoke the one mapped phase skill via the Skill tool. Run exactly one phase per
 - **`qa`** — invoke `/dispatch-qa`. It owns and applies `dispatch:qa-done` itself on
   a clean pass; `/dispatch` applies no label.
 - **`simplify` / `review` / `security`** — invoke the mapped skill (`/simplify`,
-  `/review`, `/security-review`). After it **returns**, apply the accumulating
-  `dispatch:*` label to the PR (see below).
+  `/review`, `/security-review`). After it **returns**, run
+  `dispatch-complete-phase <pr-num> <phase>` to apply the accumulating `dispatch:*`
+  label to the PR (see below).
 - **`ready`** — run `gh pr ready <pr-num>` to flip the draft to ready-for-review.
   The workflow is complete.
 - **`done`** — report that the PR is already ready and skip.
@@ -187,17 +188,13 @@ on a clean pass. `/dispatch` applies the remaining three: `dispatch:refactored`,
 phase skill returns successfully. This keeps the generic `/simplify`, `/review`, and
 `/security-review` skills dispatch-unaware.
 
-Before applying, ensure the three labels exist idempotently — run this for each
-(safe on forks where the labels do not yet exist):
+`dispatch-complete-phase` maps the completed phase to its label, ensures that label
+exists idempotently (safe on forks where the labels do not yet exist), and applies it
+to the PR — one call, run with `dangerouslyDisableSandbox: true` since it invokes
+`gh`:
 
 ```bash
-gh label create "dispatch:<name>" --color BFD4F2 --description "<phase> phase complete" 2>/dev/null || true
-```
-
-Then apply the label for the completed phase:
-
-```bash
-gh pr edit <pr-num> --add-label "dispatch:<name>"
+.claude/skills/dispatch/scripts/dispatch-complete-phase <pr-num> <phase>
 ```
 
 ## 6. Pre-Implementation Relevance Review

--- a/.claude/skills/dispatch/scripts/dispatch-complete-phase
+++ b/.claude/skills/dispatch/scripts/dispatch-complete-phase
@@ -3,11 +3,8 @@
 # Usage: dispatch-complete-phase <pr-num> <phase>
 #
 # Maps a completed phase to its accumulating dispatch:* progress label and
-# applies it to the PR. The apply (gh pr edit --add-label) runs FIRST: once
-# the label exists — the steady state — that single call is all that runs,
-# with no redundant gh label create. Only if the apply fails because the
-# label is missing does the script create the label and retry once. Any
-# other apply failure surfaces the underlying error and exits non-zero.
+# applies it to the PR. (Apply-first ordering and missing-label handling are
+# explained inline at the code below.)
 #
 # This script is the single source of truth for the dispatch:* label
 # create metadata (color and description).

--- a/.claude/skills/dispatch/scripts/dispatch-complete-phase
+++ b/.claude/skills/dispatch/scripts/dispatch-complete-phase
@@ -2,18 +2,23 @@
 # Mark a dispatch workflow phase complete on a PR.
 # Usage: dispatch-complete-phase <pr-num> <phase>
 #
-# Maps a completed phase to its accumulating dispatch:* progress label,
-# ensures that label exists (creating it if missing — idempotent, safe on
-# forks where the labels do not yet exist), then applies it to the PR.
+# Maps a completed phase to its accumulating dispatch:* progress label and
+# applies it to the PR. The apply (gh pr edit --add-label) runs FIRST: once
+# the label exists — the steady state — that single call is all that runs,
+# with no redundant gh label create. Only if the apply fails because the
+# label is missing does the script create the label and retry once. Any
+# other apply failure surfaces the underlying error and exits non-zero.
+#
+# This script is the single source of truth for the dispatch:* label
+# create metadata (color and description).
 #
 # Phase → label:
+#   qa       → dispatch:qa-done
 #   simplify → dispatch:refactored
 #   review   → dispatch:reviewed
 #   security → dispatch:security-reviewed
 #
-# /dispatch-qa owns dispatch:qa-done and applies it itself, so that phase is
-# intentionally not handled here. Missing args or an unknown phase is a clear
-# error, not a fallback.
+# Missing args or an unknown phase is a clear error, not a fallback.
 set -euo pipefail
 
 PR_NUM="${1:-}"
@@ -25,21 +30,31 @@ if [[ -z "$PR_NUM" || -z "$PHASE" ]]; then
 fi
 
 case "$PHASE" in
+  qa)       LABEL="dispatch:qa-done" ;;
   simplify) LABEL="dispatch:refactored" ;;
   review)   LABEL="dispatch:reviewed" ;;
   security) LABEL="dispatch:security-reviewed" ;;
   *)
-    echo "error: unknown phase: $PHASE (expected simplify, review, or security)" >&2
+    echo "error: unknown phase: $PHASE (expected qa, simplify, review, or security)" >&2
     exit 1
     ;;
 esac
 
+# Apply the label first. Once the label exists — the common case — this is the
+# only gh call that runs.
+if apply_output=$(gh pr edit "$PR_NUM" --add-label "$LABEL" 2>&1); then
+  exit 0
+fi
+
+# The apply failed. gh reports a missing label with a "not found" message; in
+# that case the label simply does not exist yet (e.g. on a fork) — create it
+# and retry once. Any other failure is real: surface it and exit non-zero.
+if [[ "$apply_output" != *"not found"* ]]; then
+  echo "$apply_output" >&2
+  exit 1
+fi
+
 SUFFIX="${LABEL#dispatch:}"
-
-# Ensure the label exists. A failure here is almost always "label already
-# exists" — that is the expected steady state, so swallow it.
 gh label create "$LABEL" --color BFD4F2 \
-  --description "dispatch workflow: $SUFFIX phase complete" 2>/dev/null || true
-
-# Apply the label to the PR.
+  --description "dispatch workflow: $SUFFIX phase complete"
 gh pr edit "$PR_NUM" --add-label "$LABEL"

--- a/.claude/skills/dispatch/scripts/dispatch-complete-phase
+++ b/.claude/skills/dispatch/scripts/dispatch-complete-phase
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Mark a dispatch workflow phase complete on a PR.
+# Usage: dispatch-complete-phase <pr-num> <phase>
+#
+# Maps a completed phase to its accumulating dispatch:* progress label,
+# ensures that label exists (creating it if missing — idempotent, safe on
+# forks where the labels do not yet exist), then applies it to the PR.
+#
+# Phase → label:
+#   simplify → dispatch:refactored
+#   review   → dispatch:reviewed
+#   security → dispatch:security-reviewed
+#
+# /dispatch-qa owns dispatch:qa-done and applies it itself, so that phase is
+# intentionally not handled here. Missing args or an unknown phase is a clear
+# error, not a fallback.
+set -euo pipefail
+
+PR_NUM="${1:-}"
+PHASE="${2:-}"
+
+if [[ -z "$PR_NUM" || -z "$PHASE" ]]; then
+  echo "error: usage: dispatch-complete-phase <pr-num> <phase>" >&2
+  exit 1
+fi
+
+case "$PHASE" in
+  simplify) LABEL="dispatch:refactored" ;;
+  review)   LABEL="dispatch:reviewed" ;;
+  security) LABEL="dispatch:security-reviewed" ;;
+  *)
+    echo "error: unknown phase: $PHASE (expected simplify, review, or security)" >&2
+    exit 1
+    ;;
+esac
+
+SUFFIX="${LABEL#dispatch:}"
+
+# Ensure the label exists. A failure here is almost always "label already
+# exists" — that is the expected steady state, so swallow it.
+gh label create "$LABEL" --color BFD4F2 \
+  --description "dispatch workflow: $SUFFIX phase complete" 2>/dev/null || true
+
+# Apply the label to the PR.
+gh pr edit "$PR_NUM" --add-label "$LABEL"

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -3,11 +3,14 @@
 # Usage: dispatch-select-target [--qa]
 #
 # Output: exactly one line:
-#   pr <num> <branch>           — a PR to work on
+#   pr <num> <branch> <phase>   — a PR to work on, with its already-derived phase
 #   issue <num>                 — a help-wanted issue to implement
 #   empty                       — nothing eligible
 #   worktree <N> <branch>       — the current worktree's own open issue (short-circuits the queue scan)
 #   worktree-closed <N> <branch>— the current worktree's issue is closed or unknown
+#
+# --qa mode omits the <phase> field — there it is always "qa":
+#   pr <num> <branch>           — the QA PR to work on
 #
 # Default mode priority (highest first; within a tier, oldest PR wins):
 #   1. Oldest "ready"    PR (draft + dispatch:security-reviewed)
@@ -51,6 +54,9 @@ if [[ "$QA_MODE" == "false" ]]; then
         echo "worktree-closed $N $CURRENT_BRANCH"
       fi
     else
+      # A failed `gh issue view` (a nonexistent issue, or a transient API/auth
+      # error) is intentionally conflated with a genuinely closed issue: both
+      # yield worktree-closed, and /dispatch reports and stops on either.
       echo "worktree-closed $N $CURRENT_BRANCH"
     fi
     exit 0
@@ -84,20 +90,13 @@ has_worktree() {
 PR_LIST=$(gh pr list --state open --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels)
 PR_SORTED=$(printf '%s' "$PR_LIST" | jq -r 'sort_by(.createdAt) | .[] | [.number, .createdAt, .headRefName] | @tsv')
 
-# One "first-seen" variable per phase (list is pre-sorted oldest-first, so first
-# capture of a phase is always the oldest PR in that phase).
-READY_PR_NUM=""
-READY_PR_BRANCH=""
-SECURITY_PR_NUM=""
-SECURITY_PR_BRANCH=""
-REVIEW_PR_NUM=""
-REVIEW_PR_BRANCH=""
-SIMPLIFY_PR_NUM=""
-SIMPLIFY_PR_BRANCH=""
-VERIFY_PR_NUM=""
-VERIFY_PR_BRANCH=""
-QA_PR_NUM=""
-QA_PR_BRANCH=""
+# First-seen PR per phase: key = phase name, value = "<num> <branch>". The PR
+# list is pre-sorted oldest-first, so the first PR captured for a phase is
+# always the oldest in that phase.
+declare -A FIRST_PR
+
+# Default-mode selection order among PR phases (highest priority first).
+PHASE_PRIORITY=(ready security review simplify verify)
 
 while IFS=$'\t' read -r pr_num _created pr_branch; do
   [[ -z "$pr_num" ]] && continue
@@ -110,58 +109,20 @@ while IFS=$'\t' read -r pr_num _created pr_branch; do
   # Determine phase for this PR, reusing the PR list fetched above.
   phase=$(DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-phase" "$pr_branch")
 
+  # "done" PRs are complete; "waiting" PRs have nothing actionable yet.
   case "$phase" in
-    done)
-      # Skip completed PRs.
-      continue
-      ;;
-    waiting)
-      # Skip PRs whose CI is still running — nothing actionable yet.
-      continue
-      ;;
-    ready)
-      if [[ -z "$READY_PR_NUM" ]]; then
-        READY_PR_NUM="$pr_num"
-        READY_PR_BRANCH="$pr_branch"
-      fi
-      ;;
-    security)
-      if [[ -z "$SECURITY_PR_NUM" ]]; then
-        SECURITY_PR_NUM="$pr_num"
-        SECURITY_PR_BRANCH="$pr_branch"
-      fi
-      ;;
-    review)
-      if [[ -z "$REVIEW_PR_NUM" ]]; then
-        REVIEW_PR_NUM="$pr_num"
-        REVIEW_PR_BRANCH="$pr_branch"
-      fi
-      ;;
-    simplify)
-      if [[ -z "$SIMPLIFY_PR_NUM" ]]; then
-        SIMPLIFY_PR_NUM="$pr_num"
-        SIMPLIFY_PR_BRANCH="$pr_branch"
-      fi
-      ;;
-    verify)
-      if [[ -z "$VERIFY_PR_NUM" ]]; then
-        VERIFY_PR_NUM="$pr_num"
-        VERIFY_PR_BRANCH="$pr_branch"
-      fi
-      ;;
-    qa)
-      if [[ -z "$QA_PR_NUM" ]]; then
-        QA_PR_NUM="$pr_num"
-        QA_PR_BRANCH="$pr_branch"
-      fi
-      ;;
+    done|waiting) continue ;;
   esac
+
+  # Record the oldest PR seen in this phase. The :- guard keeps the unset-key
+  # read from aborting under set -u.
+  [[ -z "${FIRST_PR[$phase]:-}" ]] && FIRST_PR[$phase]="$pr_num $pr_branch"
 done <<< "$PR_SORTED"
 
 if [[ "$QA_MODE" == "true" ]]; then
-  # --qa mode: only return QA PRs.
-  if [[ -n "$QA_PR_NUM" ]]; then
-    echo "pr $QA_PR_NUM $QA_PR_BRANCH"
+  # --qa mode: only return QA PRs, without the <phase> field.
+  if [[ -n "${FIRST_PR[qa]:-}" ]]; then
+    echo "pr ${FIRST_PR[qa]}"
   else
     echo "empty"
   fi
@@ -170,30 +131,12 @@ fi
 
 # Default mode: ready → security → review → simplify → verify →
 #               help-wanted issue → qa → empty.
-if [[ -n "$READY_PR_NUM" ]]; then
-  echo "pr $READY_PR_NUM $READY_PR_BRANCH"
-  exit 0
-fi
-
-if [[ -n "$SECURITY_PR_NUM" ]]; then
-  echo "pr $SECURITY_PR_NUM $SECURITY_PR_BRANCH"
-  exit 0
-fi
-
-if [[ -n "$REVIEW_PR_NUM" ]]; then
-  echo "pr $REVIEW_PR_NUM $REVIEW_PR_BRANCH"
-  exit 0
-fi
-
-if [[ -n "$SIMPLIFY_PR_NUM" ]]; then
-  echo "pr $SIMPLIFY_PR_NUM $SIMPLIFY_PR_BRANCH"
-  exit 0
-fi
-
-if [[ -n "$VERIFY_PR_NUM" ]]; then
-  echo "pr $VERIFY_PR_NUM $VERIFY_PR_BRANCH"
-  exit 0
-fi
+for phase in "${PHASE_PRIORITY[@]}"; do
+  if [[ -n "${FIRST_PR[$phase]:-}" ]]; then
+    echo "pr ${FIRST_PR[$phase]} $phase"
+    exit 0
+  fi
+done
 
 # Fetch oldest help-wanted issue.
 ISSUE_LIST=$(gh issue list --label "help wanted" --state open --json number,createdAt)
@@ -204,8 +147,8 @@ if [[ -n "$ISSUE_NUM" ]]; then
   exit 0
 fi
 
-if [[ -n "$QA_PR_NUM" ]]; then
-  echo "pr $QA_PR_NUM $QA_PR_BRANCH"
+if [[ -n "${FIRST_PR[qa]:-}" ]]; then
+  echo "pr ${FIRST_PR[qa]} qa"
   exit 0
 fi
 

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Unit-test suite for dispatch-phase, dispatch-select-target, dispatch-trace-leaf.
-# Uses PATH shims to fake gh and git — no network required.
+# Unit-test suite for dispatch-phase, dispatch-select-target, dispatch-trace-leaf,
+# dispatch-complete-phase. Uses PATH shims to fake gh and git — no network required.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -49,9 +49,11 @@ setup() {
   cp "$SCRIPT_DIR/dispatch-phase" "$TMPDIR_TEST/dispatch-phase"
   cp "$SCRIPT_DIR/dispatch-select-target" "$TMPDIR_TEST/dispatch-select-target"
   cp "$SCRIPT_DIR/dispatch-trace-leaf" "$TMPDIR_TEST/dispatch-trace-leaf"
+  cp "$SCRIPT_DIR/dispatch-complete-phase" "$TMPDIR_TEST/dispatch-complete-phase"
   chmod +x "$TMPDIR_TEST/dispatch-phase" \
            "$TMPDIR_TEST/dispatch-select-target" \
-           "$TMPDIR_TEST/dispatch-trace-leaf"
+           "$TMPDIR_TEST/dispatch-trace-leaf" \
+           "$TMPDIR_TEST/dispatch-complete-phase"
 
   # dispatch-select-target calls dispatch-phase as "$SCRIPT_DIR/dispatch-phase".
   # Since we copied them all to TMPDIR_TEST, SCRIPT_DIR inside each copy will
@@ -122,6 +124,14 @@ case "$args" in
     else
       echo "[]"
     fi
+    ;;
+  label\ create\ *)
+    # dispatch-complete-phase ensures the label exists.
+    echo "$args" >> "$STUB_DIR/gh-label-create.log"
+    ;;
+  pr\ edit\ *)
+    # dispatch-complete-phase applies the label to the PR.
+    echo "$args" >> "$STUB_DIR/gh-pr-edit.log"
     ;;
   *)
     echo "gh stub: unknown invocation: $args" >&2
@@ -821,6 +831,61 @@ printf '{"title":"Issue 601","body":"","comments":[],"number":601,"state":"OPEN"
   > "$STUB_DIR/issue-601.json"
 result=$("$TMPDIR_TEST/dispatch-trace-leaf" "600")
 assert_eq "sub-issues chain 600→601 → leaf 601" "601" "$result"
+teardown
+
+# ============================================================================
+# dispatch-complete-phase tests
+# ============================================================================
+echo ""
+echo "=== dispatch-complete-phase ==="
+
+# 1. simplify → dispatch:refactored.
+echo "Test: simplify → dispatch:refactored"
+setup
+"$TMPDIR_TEST/dispatch-complete-phase" 25 simplify
+logged=$(cat "$STUB_DIR/gh-pr-edit.log")
+assert_eq "simplify applies dispatch:refactored" \
+  "pr edit 25 --add-label dispatch:refactored" "$logged"
+teardown
+
+# 2. review → dispatch:reviewed.
+echo "Test: review → dispatch:reviewed"
+setup
+"$TMPDIR_TEST/dispatch-complete-phase" 30 review
+logged=$(cat "$STUB_DIR/gh-pr-edit.log")
+assert_eq "review applies dispatch:reviewed" \
+  "pr edit 30 --add-label dispatch:reviewed" "$logged"
+teardown
+
+# 3. security → dispatch:security-reviewed.
+echo "Test: security → dispatch:security-reviewed"
+setup
+"$TMPDIR_TEST/dispatch-complete-phase" 40 security
+logged=$(cat "$STUB_DIR/gh-pr-edit.log")
+assert_eq "security applies dispatch:security-reviewed" \
+  "pr edit 40 --add-label dispatch:security-reviewed" "$logged"
+teardown
+
+# 4. Unknown phase → non-zero exit, no label applied.
+echo "Test: unknown phase → non-zero exit"
+setup
+if "$TMPDIR_TEST/dispatch-complete-phase" 25 bogus 2>/dev/null; then
+  rc=0
+else
+  rc=$?
+fi
+assert_eq "unknown phase exits non-zero" "1" "$rc"
+teardown
+
+# 5. Missing phase arg → non-zero exit.
+echo "Test: missing args → non-zero exit"
+setup
+if "$TMPDIR_TEST/dispatch-complete-phase" 25 2>/dev/null; then
+  rc=0
+else
+  rc=$?
+fi
+assert_eq "missing phase arg exits non-zero" "1" "$rc"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -429,7 +429,7 @@ printf '[{"number":99,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue
 # No worktrees for these branches.
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "non-QA PR (verify) chosen first" "pr 10 10-verify-me" "$result"
+assert_eq "non-QA PR (verify) chosen first" "pr 10 10-verify-me verify" "$result"
 teardown
 
 # 2. PR with a local worktree is skipped.
@@ -442,7 +442,7 @@ echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/10-active-branch\n\nworktree /worktrees/10-active-branch\nHEAD def456\nbranch refs/heads/10-active-branch\n\n' \
   > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "PR with worktree skipped; next PR returned" "pr 20 20-other" "$result"
+assert_eq "PR with worktree skipped; next PR returned" "pr 20 20-other verify" "$result"
 teardown
 
 # 3. When no eligible PR exists, a help-wanted issue is chosen.
@@ -517,7 +517,7 @@ setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "ready beats security/review/simplify/verify" "pr 50 50-ready" "$result"
+assert_eq "ready beats security/review/simplify/verify" "pr 50 50-ready ready" "$result"
 teardown
 
 # 9. security beats review beats simplify beats verify (no ready PR).
@@ -536,7 +536,7 @@ setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "security beats review/simplify/verify" "pr 40 40-security" "$result"
+assert_eq "security beats review/simplify/verify" "pr 40 40-security security" "$result"
 teardown
 
 # 10. Within one phase, the oldest PR wins.
@@ -552,7 +552,7 @@ setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "oldest review PR wins within phase" "pr 30 30-review-a" "$result"
+assert_eq "oldest review PR wins within phase" "pr 30 30-review-a review" "$result"
 teardown
 
 # 11. Any non-QA PR beats a help-wanted issue; help-wanted issue beats a QA PR.
@@ -567,7 +567,7 @@ setup_union_pr_list "$UNION"
 printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "verify PR beats issue (non-QA > issue > qa)" "pr 10 10-verify" "$result"
+assert_eq "verify PR beats issue (non-QA > issue > qa)" "pr 10 10-verify verify" "$result"
 teardown
 
 # 11b. No non-QA PR: help-wanted issue beats QA PR.
@@ -618,7 +618,7 @@ setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "waiting PR skipped; verify PR returned" "pr 20 20-verify" "$result"
+assert_eq "waiting PR skipped; verify PR returned" "pr 20 20-verify verify" "$result"
 teardown
 
 # 15. A lone waiting PR (nothing else queued) yields empty.
@@ -679,7 +679,7 @@ echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 printf 'main' > "$STUB_DIR/current-branch.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "main branch → normal scan result (verify PR)" "pr 10 10-verify-me" "$result"
+assert_eq "main branch → normal scan result (verify PR)" "pr 10 10-verify-me verify" "$result"
 teardown
 
 # 20. --qa mode from an issue worktree → detection skipped, QA PR returned.
@@ -709,9 +709,32 @@ setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "select-target result over 3 PRs" "pr 10 10-verify" "$result"
+assert_eq "select-target result over 3 PRs" "pr 10 10-verify verify" "$result"
 count=$(wc -l < "$STUB_DIR/gh-pr-list-calls.log" | tr -d ' ')
 assert_eq "exactly one gh pr list call regardless of PR count" "1" "$count"
+teardown
+
+# 22. A simplify-phase PR winning emits the simplify phase on the result line.
+echo "Test: simplify PR winner → pr <n> <branch> simplify"
+setup
+SIMPLIFY_LABELS='[{"name":"dispatch:qa-done"}]'
+UNION='['"$(make_pr_union 25 "25-simplify-me" "2024-01-01T00:00:00Z" "true" "$SIMPLIFY_LABELS" "$GREEN_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "simplify PR winner emits phase" "pr 25 25-simplify-me simplify" "$result"
+teardown
+
+# 23. A lone QA PR with no help-wanted issue emits the qa phase on the result line.
+echo "Test: QA PR, no issue → pr <n> <branch> qa"
+setup
+UNION='['"$(make_pr_union 35 "35-qa-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "QA PR (no issue) emits qa phase" "pr 35 35-qa-me qa" "$result"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -126,12 +126,36 @@ case "$args" in
     fi
     ;;
   label\ create\ *)
-    # dispatch-complete-phase ensures the label exists.
+    # dispatch-complete-phase creates the label only when the apply reported
+    # it missing.
     echo "$args" >> "$STUB_DIR/gh-label-create.log"
     ;;
   pr\ edit\ *)
-    # dispatch-complete-phase applies the label to the PR.
-    echo "$args" >> "$STUB_DIR/gh-pr-edit.log"
+    # dispatch-complete-phase applies the label to the PR. $STUB_DIR/pr-edit-mode
+    # selects behavior (default: succeed and log the args).
+    mode="ok"
+    [[ -f "$STUB_DIR/pr-edit-mode" ]] && mode=$(cat "$STUB_DIR/pr-edit-mode")
+    case "$mode" in
+      label-missing)
+        # The label does not exist until gh label create runs: model gh's
+        # missing-label error until then, then succeed on the retry.
+        if [[ -f "$STUB_DIR/gh-label-create.log" ]]; then
+          echo "$args" >> "$STUB_DIR/gh-pr-edit.log"
+        else
+          label="${args##* }"
+          echo "failed to update: '$label' not found" >&2
+          exit 1
+        fi
+        ;;
+      other-failure)
+        # An apply failure unrelated to a missing label.
+        echo "GraphQL: Could not resolve to a PullRequest" >&2
+        exit 1
+        ;;
+      *)
+        echo "$args" >> "$STUB_DIR/gh-pr-edit.log"
+        ;;
+    esac
     ;;
   *)
     echo "gh stub: unknown invocation: $args" >&2
@@ -839,52 +863,79 @@ teardown
 echo ""
 echo "=== dispatch-complete-phase ==="
 
-# 1. simplify → dispatch:refactored.
-echo "Test: simplify → dispatch:refactored"
+# Reports whether the gh stub recorded a `gh label create` call.
+label_create_state() {
+  [[ -f "$STUB_DIR/gh-label-create.log" ]] && echo "present" || echo "absent"
+}
+
+# 1-4. Phase → label mapping. The label already exists (default stub mode), so
+# the script applies it with a single `gh pr edit` and issues no `gh label create`.
+echo "Test: qa → dispatch:qa-done (apply only, no label create)"
+setup
+"$TMPDIR_TEST/dispatch-complete-phase" 21 qa
+assert_eq "qa applies dispatch:qa-done" \
+  "pr edit 21 --add-label dispatch:qa-done" "$(cat "$STUB_DIR/gh-pr-edit.log")"
+assert_eq "qa: no gh label create when label exists" "absent" "$(label_create_state)"
+teardown
+
+echo "Test: simplify → dispatch:refactored (apply only, no label create)"
 setup
 "$TMPDIR_TEST/dispatch-complete-phase" 25 simplify
-logged=$(cat "$STUB_DIR/gh-pr-edit.log")
 assert_eq "simplify applies dispatch:refactored" \
-  "pr edit 25 --add-label dispatch:refactored" "$logged"
+  "pr edit 25 --add-label dispatch:refactored" "$(cat "$STUB_DIR/gh-pr-edit.log")"
+assert_eq "simplify: no gh label create when label exists" "absent" "$(label_create_state)"
 teardown
 
-# 2. review → dispatch:reviewed.
-echo "Test: review → dispatch:reviewed"
+echo "Test: review → dispatch:reviewed (apply only, no label create)"
 setup
 "$TMPDIR_TEST/dispatch-complete-phase" 30 review
-logged=$(cat "$STUB_DIR/gh-pr-edit.log")
 assert_eq "review applies dispatch:reviewed" \
-  "pr edit 30 --add-label dispatch:reviewed" "$logged"
+  "pr edit 30 --add-label dispatch:reviewed" "$(cat "$STUB_DIR/gh-pr-edit.log")"
+assert_eq "review: no gh label create when label exists" "absent" "$(label_create_state)"
 teardown
 
-# 3. security → dispatch:security-reviewed.
-echo "Test: security → dispatch:security-reviewed"
+echo "Test: security → dispatch:security-reviewed (apply only, no label create)"
 setup
 "$TMPDIR_TEST/dispatch-complete-phase" 40 security
-logged=$(cat "$STUB_DIR/gh-pr-edit.log")
 assert_eq "security applies dispatch:security-reviewed" \
-  "pr edit 40 --add-label dispatch:security-reviewed" "$logged"
+  "pr edit 40 --add-label dispatch:security-reviewed" "$(cat "$STUB_DIR/gh-pr-edit.log")"
+assert_eq "security: no gh label create when label exists" "absent" "$(label_create_state)"
 teardown
 
-# 4. Unknown phase → non-zero exit, no label applied.
+# 5. Label missing: the apply fails "not found", so the script creates the
+#    label (BFD4F2, "dispatch workflow: <suffix> phase complete") and retries.
+echo "Test: label missing → create then retry"
+setup
+echo "label-missing" > "$STUB_DIR/pr-edit-mode"
+"$TMPDIR_TEST/dispatch-complete-phase" 30 review
+assert_eq "label-missing: label created with workflow description" \
+  "label create dispatch:reviewed --color BFD4F2 --description dispatch workflow: reviewed phase complete" \
+  "$(cat "$STUB_DIR/gh-label-create.log")"
+assert_eq "label-missing: label applied on retry" \
+  "pr edit 30 --add-label dispatch:reviewed" "$(cat "$STUB_DIR/gh-pr-edit.log")"
+teardown
+
+# 6. An apply failure unrelated to a missing label exits non-zero and creates
+#    no label.
+echo "Test: other apply failure → non-zero exit, no label create"
+setup
+echo "other-failure" > "$STUB_DIR/pr-edit-mode"
+if "$TMPDIR_TEST/dispatch-complete-phase" 40 security 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "other apply failure exits non-zero" "1" "$rc"
+assert_eq "other failure: no spurious label create" "absent" "$(label_create_state)"
+teardown
+
+# 7. Unknown phase → non-zero exit.
 echo "Test: unknown phase → non-zero exit"
 setup
-if "$TMPDIR_TEST/dispatch-complete-phase" 25 bogus 2>/dev/null; then
-  rc=0
-else
-  rc=$?
-fi
+if "$TMPDIR_TEST/dispatch-complete-phase" 25 bogus 2>/dev/null; then rc=0; else rc=$?; fi
 assert_eq "unknown phase exits non-zero" "1" "$rc"
 teardown
 
-# 5. Missing phase arg → non-zero exit.
+# 8. Missing phase arg → non-zero exit.
 echo "Test: missing args → non-zero exit"
 setup
-if "$TMPDIR_TEST/dispatch-complete-phase" 25 2>/dev/null; then
-  rc=0
-else
-  rc=$?
-fi
+if "$TMPDIR_TEST/dispatch-complete-phase" 25 2>/dev/null; then rc=0; else rc=$?; fi
 assert_eq "missing phase arg exits non-zero" "1" "$rc"
 teardown
 


### PR DESCRIPTION
## Summary

Two small, independent simplifications to the `/dispatch` scripts found while
reviewing the selection flow.

**`dispatch-select-target` now emits the phase.** Each default-mode `pr` result
line carries the PR's already-derived phase (`pr <num> <branch> <phase>`), so
`/dispatch` Step 4 reuses it instead of re-running `dispatch-phase` on the queue
path. `--qa`-mode output is unchanged. Per-phase tracking collapses from 12
variables + a multi-arm `case` + 6 near-identical `if` blocks to one `declare -A`
keyed by phase plus a priority list — output and behavior unchanged. The
`worktree-closed` arm now documents that a failed `gh issue view` is intentionally
conflated with a genuinely closed issue.

**New `dispatch-complete-phase <pr> <phase>` script.** It maps a completed phase
to its accumulating `dispatch:*` label (`qa`, `simplify`, `review`, `security`)
and applies it. The apply (`gh pr edit --add-label`) runs *first* — once the label
exists, the steady state, that single call is all that runs. `gh label create`
runs only when the apply reports the label missing, after which the apply is
retried once; any other apply failure surfaces the underlying error and exits
non-zero. The script is the single source of truth for the `dispatch:*` label
create metadata. `/dispatch` Step 5 and `/dispatch-qa` Step 8 both call it in
place of their inline `gh label create … || true` + `gh pr edit --add-label`
pairs.

Full test suite (`test-dispatch-scripts.sh`): 60/60 passing.

Closes #657