### PR TITLE
Add a project rule for issue and PR references in conversational output

### DIFF
--- a/.claude/rules/issue-references.md
+++ b/.claude/rules/issue-references.md
@@ -1,0 +1,19 @@
+# Issue and PR References
+
+## Conversational output: use full URLs
+
+When mentioning a GitHub issue or PR in conversational responses to the user
+— status updates, summaries, explanations — reference it by full GitHub URL,
+not a bare `#N`. In the terminal `#N` is unclickable plain text; a URL renders
+as a clickable link the user can open directly.
+
+URL formats:
+
+- Issue: `https://github.com/natb1/commons.systems/issues/<N>`
+- PR: `https://github.com/natb1/commons.systems/pull/<N>`
+
+## GitHub-rendered artifacts: keep `#N`
+
+Commit messages, PR bodies, and issue bodies keep the bare `#N` form. GitHub
+auto-links `#N` in those contexts, and `Closes #N` drives GitHub's auto-close
+behavior — see `.claude/skills/ref-create-pr/SKILL.md`.

--- a/.claude/rules/issue-references.md
+++ b/.claude/rules/issue-references.md
@@ -1,19 +1,32 @@
 # Issue and PR References
 
-## Conversational output: use full URLs
+## Conversational output: append URLs
 
-When mentioning a GitHub issue or PR in conversational responses to the user
-— status updates, summaries, explanations — reference it by full GitHub URL,
-not a bare `#N`. In the terminal `#N` is unclickable plain text; a URL renders
-as a clickable link the user can open directly.
+In conversational responses to the user — status updates, summaries,
+explanations — keep the inline reference as `#N`. When a response refers to one
+or more issues or PRs, append their GitHub URLs at the end under a `References:`
+header, one labeled entry per distinct number:
+
+```
+...status text mentioning #659 and PR #665...
+
+References:
+- #659: https://github.com/natb1/commons.systems/issues/659
+- #665: https://github.com/natb1/commons.systems/pull/665
+```
+
+Deduplicate: list each number once, regardless of how often it appears. A bare
+`#N` is unclickable plain text in the terminal; the appended URL renders as a
+clickable link the user can open directly.
 
 URL formats:
 
 - Issue: `https://github.com/natb1/commons.systems/issues/<N>`
 - PR: `https://github.com/natb1/commons.systems/pull/<N>`
 
-## GitHub-rendered artifacts: keep `#N`
+## GitHub-rendered artifacts: keep `#N`, append nothing
 
-Commit messages, PR bodies, and issue bodies keep the bare `#N` form. GitHub
-auto-links `#N` in those contexts, and `Closes #N` drives GitHub's auto-close
-behavior — see `.claude/skills/ref-create-pr/SKILL.md`.
+Commit messages, PR bodies, and issue bodies keep the bare `#N` form and append
+no `References:` list. GitHub auto-links `#N` in those contexts, and `Closes #N`
+drives GitHub's auto-close behavior — see
+`.claude/skills/ref-create-pr/SKILL.md`.


### PR DESCRIPTION
## Summary

Adds `.claude/rules/issue-references.md`, a one-concern project rule directing Claude to reference GitHub issues and PRs by full URL in conversational/terminal output (where a bare `#N` is unclickable plain text), while keeping the `#N` form in commit messages, PR bodies, and issue bodies (where GitHub auto-links it and `Closes #N` drives auto-close).

The rule documents both URL formats and cross-references `.claude/skills/ref-create-pr/SKILL.md` for the `Closes #N` convention, so it does not contradict existing rules.

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)