### PR TITLE
dispatch: extract worktree resolution into dispatch-resolve-worktree

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -101,41 +101,42 @@ If a named target issue is **closed**, report it and **stop**.
 
 ## 3. Resolve the Worktree
 
-Resolve or create the final target's worktree via `EnterWorktree`, matching
-`pr-workflow` Sections 2–3. `EnterWorktree` accepts exactly one of `path` (switch to
-an existing worktree) or `name` (create a new one; fires the `WorktreeCreate` hook).
+Run the worktree-resolution script, matching `pr-workflow` Sections 2–3. Pass
+`explicit` when the target was named by an explicit `/dispatch` argument,
+otherwise `queue`:
 
-- **Already in the target's worktree** (current branch starts with `<issue>-`) → no
+```bash
+.claude/skills/dispatch/scripts/dispatch-resolve-worktree <N> <explicit|queue>
+```
+
+It prints exactly one decision line — act on it. `EnterWorktree` accepts exactly
+one of `path` (switch to an existing worktree) or `name` (create a new one).
+
+- **`here`** → the current branch already is the target's worktree; no
   `EnterWorktree` needed. Re-sync issue context:
   ```bash
   .claude/skills/ref-pr-workflow/scripts/sync-issue-context <N>
   ```
-  (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.) Then go
-  straight to creating the marker below.
-- **An existing worktree matches** `<issue>-*` (parse `git worktree list --porcelain`
-  as blank-line-delimited records):
-  - **Named by an explicit `/dispatch` argument** (recycle-after-completion case) →
-    `EnterWorktree` with `path:` set to that path. After entering, re-sync issue
-    context from the worktree:
-    ```bash
-    .claude/skills/ref-pr-workflow/scripts/sync-issue-context <N>
-    ```
-    (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.)
-  - **Queue-selected (no argument)** → another session already owns this worktree.
-    The queue scan skips worktree'd issues, so this arises only when Step 2
-    leaf-tracing retargets to a blocker or sub-issue that has one. Report the
-    conflict (name the worktree path and issue `<N>`) and **stop**; do not
-    `EnterWorktree`.
-- **No existing worktree** → generate a sanitized branch name `<issue>-<slug>`:
-  lowercase the issue title, replace non-alphanumeric runs with `-`, collapse repeated
-  `-`, strip leading/trailing `-`, and truncate so the full branch name is ≤ 32
-  characters. `EnterWorktree` with `name:` set to that branch name.
+  (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.)
+- **`enter <path>`** → re-use an existing `<issue>-*` worktree (the
+  recycle-after-completion case, reached only for an explicit argument).
+  `EnterWorktree` with `path:` set to `<path>`. After entering, re-sync issue
+  context from the worktree:
+  ```bash
+  .claude/skills/ref-pr-workflow/scripts/sync-issue-context <N>
+  ```
+  (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.)
+- **`create <branch>`** → no worktree exists. `EnterWorktree` with `name:` set to
+  `<branch>`. This fires the `WorktreeCreate` hook, which runs `sync-issue-context`
+  and populates `CLAUDE.local.md` with full issue context.
+- **`conflict <path>`** → a queue-selected target already has a worktree, so
+  another session owns it. (The queue scan skips worktree'd issues, so this arises
+  only when Step 2 leaf-tracing retargets to a blocker or sub-issue that has one.)
+  Report the conflict (name `<path>` and issue `<N>`) and **stop**; do not
+  `EnterWorktree`.
 
-Creating via `name:` fires the `WorktreeCreate` hook, which runs `sync-issue-context`
-and populates `CLAUDE.local.md` with full issue context.
-
-As the **last action of this step on every path** — before any phase skill runs —
-create the recovery marker:
+As the **last action of this step on every non-`conflict` path** — before any
+phase skill runs — create the recovery marker:
 
 ```bash
 mkdir -p tmp && touch tmp/dispatch-worktree

--- a/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Resolve the worktree action for a dispatch target issue.
+# Usage: dispatch-resolve-worktree <issue-num> <explicit|queue>
+#
+# Prints exactly one decision line to stdout:
+#   here            — the current branch already is <issue>-*; no EnterWorktree
+#                     is needed.
+#   enter <path>    — an existing <issue>-* worktree should be re-used;
+#                     EnterWorktree with path: <path>.
+#   create <branch> — no worktree exists; <branch> is the sanitized name,
+#                     EnterWorktree with name: <branch>.
+#   conflict <path> — a queue-selected target already has a worktree (another
+#                     session owns it); /dispatch reports <path> and stops.
+#
+# The mode argument decides what an existing <issue>-* worktree means:
+#   explicit — the target was named by an explicit /dispatch argument
+#              (recycle-after-completion); an existing worktree yields `enter`.
+#   queue    — the target was queue-selected; an existing worktree belongs to
+#              another session and yields `conflict`.
+# The `here` check is mode-independent and fires before the worktree scan.
+#
+# The branch name printed by `create` matches the WorktreeCreate hook's
+# accepted form ^[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$, full name <= 32 characters.
+#
+# A bad argument or a failed `gh issue view` is a clear error, not a fallback.
+set -euo pipefail
+
+ISSUE="${1:-}"
+MODE="${2:-}"
+
+if [[ ! "$ISSUE" =~ ^[1-9][0-9]*$ ]] || [[ "$MODE" != "explicit" && "$MODE" != "queue" ]]; then
+  echo "error: usage: dispatch-resolve-worktree <issue-num> <explicit|queue>" >&2
+  exit 1
+fi
+
+# `here` — the current branch already is the target's branch. Mode-independent,
+# checked before the worktree scan.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" == "$ISSUE"-* ]]; then
+  echo "here"
+  exit 0
+fi
+
+# `enter` / `conflict` — scan local worktrees for a <issue>-* branch. git
+# worktree list --porcelain emits blank-line-delimited records; each opens with
+# a "worktree <path>" line and (for a branch checkout) carries a
+# "branch refs/heads/<name>" line. Use the first matching record.
+WORKTREE_PATH=""
+while IFS= read -r line; do
+  if [[ "$line" == worktree\ * ]]; then
+    WORKTREE_PATH="${line#worktree }"
+  elif [[ "$line" == branch\ * ]]; then
+    branch="${line#branch }"
+    branch="${branch#refs/heads/}"
+    if [[ "$branch" == "$ISSUE"-* ]]; then
+      if [[ "$MODE" == "explicit" ]]; then
+        echo "enter $WORKTREE_PATH"
+      else
+        echo "conflict $WORKTREE_PATH"
+      fi
+      exit 0
+    fi
+  fi
+done < <(git worktree list --porcelain)
+
+# `create` — no worktree matched. Build a sanitized <issue>-<slug> branch name
+# from the issue title.
+if ! TITLE=$(gh issue view "$ISSUE" --json title | jq -r '.title'); then
+  echo "error: failed to fetch title for issue $ISSUE" >&2
+  exit 1
+fi
+
+# Lowercase, then collapse non-alphanumeric runs to single dashes and strip
+# leading/trailing dashes.
+slug=$(printf '%s' "$TITLE" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')
+
+# Truncate so the full <issue>-<slug> name is <= 32 chars, then drop a trailing
+# `-` the cut may have left (runs were already collapsed, so at most one).
+slug="${slug:0:$((32 - ${#ISSUE} - 1))}"
+slug="${slug%-}"
+
+if [[ -z "$slug" ]]; then
+  echo "error: issue $ISSUE title produced an empty branch slug: '$TITLE'" >&2
+  exit 1
+fi
+
+echo "create $ISSUE-$slug"

--- a/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
@@ -64,8 +64,9 @@ while IFS= read -r line; do
 done < <(git worktree list --porcelain)
 
 # `create` — no worktree matched. Build a sanitized <issue>-<slug> branch name
-# from the issue title.
-if ! TITLE=$(gh issue view "$ISSUE" --json title | jq -r '.title'); then
+# from the issue title. `jq -e` exits non-zero on a null/missing .title, so the
+# guard catches a malformed response instead of slugging the literal "null".
+if ! TITLE=$(gh issue view "$ISSUE" --json title | jq -er '.title'); then
   echo "error: failed to fetch title for issue $ISSUE" >&2
   exit 1
 fi

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Unit-test suite for dispatch-phase, dispatch-select-target, dispatch-trace-leaf,
-# dispatch-complete-phase. Uses PATH shims to fake gh and git — no network required.
+# dispatch-complete-phase, dispatch-resolve-worktree. Uses PATH shims to fake gh
+# and git — no network required.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -50,10 +51,12 @@ setup() {
   cp "$SCRIPT_DIR/dispatch-select-target" "$TMPDIR_TEST/dispatch-select-target"
   cp "$SCRIPT_DIR/dispatch-trace-leaf" "$TMPDIR_TEST/dispatch-trace-leaf"
   cp "$SCRIPT_DIR/dispatch-complete-phase" "$TMPDIR_TEST/dispatch-complete-phase"
+  cp "$SCRIPT_DIR/dispatch-resolve-worktree" "$TMPDIR_TEST/dispatch-resolve-worktree"
   chmod +x "$TMPDIR_TEST/dispatch-phase" \
            "$TMPDIR_TEST/dispatch-select-target" \
            "$TMPDIR_TEST/dispatch-trace-leaf" \
-           "$TMPDIR_TEST/dispatch-complete-phase"
+           "$TMPDIR_TEST/dispatch-complete-phase" \
+           "$TMPDIR_TEST/dispatch-resolve-worktree"
 
   # dispatch-select-target calls dispatch-phase as "$SCRIPT_DIR/dispatch-phase".
   # Since we copied them all to TMPDIR_TEST, SCRIPT_DIR inside each copy will
@@ -105,6 +108,15 @@ case "$args" in
       cat "$STUB_DIR/issue-${num}.json"
     else
       echo "{\"title\":\"Issue $num\",\"body\":\"\",\"comments\":[],\"number\":$num,\"state\":\"OPEN\"}"
+    fi
+    ;;
+  issue\ view\ *\ --json\ title)
+    # dispatch-resolve-worktree create case: gh issue view <num> --json title
+    num=$(echo "$args" | awk '{print $3}')
+    if [[ -f "$STUB_DIR/issue-title-${num}.json" ]]; then
+      cat "$STUB_DIR/issue-title-${num}.json"
+    else
+      echo "{\"title\":\"Issue $num\"}"
     fi
     ;;
   api\ */dependencies/blocked_by)
@@ -1096,6 +1108,128 @@ echo "Test: missing args → non-zero exit"
 setup
 if "$TMPDIR_TEST/dispatch-complete-phase" 25 2>/dev/null; then rc=0; else rc=$?; fi
 assert_eq "missing phase arg exits non-zero" "1" "$rc"
+teardown
+
+# ============================================================================
+# dispatch-resolve-worktree tests
+# ============================================================================
+echo ""
+echo "=== dispatch-resolve-worktree ==="
+
+# A two-record worktree list: the main worktree on `main`, plus a 42-* worktree.
+WORKTREE_LIST_42='worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /worktrees/42-my-feature
+HEAD def456
+branch refs/heads/42-my-feature
+
+'
+
+# 1. Current branch is <N>-* → here (mode-independent).
+echo "Test: current branch <N>-* → here (both modes)"
+setup
+echo "42-my-feature" > "$STUB_DIR/current-branch.txt"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
+assert_eq "current branch <N>-* → here (explicit)" "here" "$result"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
+assert_eq "current branch <N>-* → here (queue)" "here" "$result"
+teardown
+
+# 2. explicit mode + an existing <N>-* worktree → enter <path>.
+echo "Test: explicit + existing <N>-* worktree → enter"
+setup
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
+assert_eq "explicit + existing worktree → enter <path>" \
+  "enter /worktrees/42-my-feature" "$result"
+teardown
+
+# 3. queue mode + the same worktree setup → conflict <path>. Acceptance
+#    criterion 3: same target, explicit → enter, queue → conflict.
+echo "Test: queue + existing <N>-* worktree → conflict"
+setup
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
+assert_eq "queue + existing worktree → conflict <path>" \
+  "conflict /worktrees/42-my-feature" "$result"
+teardown
+
+# 4. No matching worktree → create <N>-<slug> from the issue title.
+echo "Test: no worktree → create <N>-<slug>"
+setup
+echo '{"title":"Add a feature"}' > "$STUB_DIR/issue-title-42.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
+assert_eq "no worktree → create <N>-<slug>" "create 42-add-a-feature" "$result"
+teardown
+
+# 5. Sanitization: uppercase, punctuation, and leading/trailing spaces collapse
+#    to a lowercase dash-joined slug.
+echo "Test: title sanitization → create"
+setup
+printf '{"title":"  Fix: The Foo/Bar Widget!  "}' > "$STUB_DIR/issue-title-7.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 7 explicit)
+assert_eq "messy title sanitized → create" "create 7-fix-the-foo-bar-widget" "$result"
+teardown
+
+# 6. Truncation: a long title yields a branch <= 32 chars matching the
+#    WorktreeCreate hook form (acceptance criterion 2).
+echo "Test: long title truncated to <= 32-char branch → create"
+setup
+echo '{"title":"Extract the worktree resolution logic into a dedicated script"}' \
+  > "$STUB_DIR/issue-title-656.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 656 explicit)
+assert_eq "long title truncated → exact create line" \
+  "create 656-extract-the-worktree-resolut" "$result"
+branch="${result#create }"
+TOTAL=$((TOTAL + 1))
+if [[ "${#branch}" -le 32 ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: truncated branch <= 32 chars"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: truncated branch <= 32 chars (${#branch})"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ "$branch" =~ ^[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: truncated branch matches WorktreeCreate form"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: truncated branch matches WorktreeCreate form"
+fi
+teardown
+
+# 7. here precedence: current branch <N>-* wins even when a matching worktree
+#    also exists — the here check fires before the worktree scan.
+echo "Test: here precedence over a matching worktree"
+setup
+echo "42-my-feature" > "$STUB_DIR/current-branch.txt"
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
+assert_eq "here wins over a matching worktree" "here" "$result"
+teardown
+
+# 8. A non-matching worktree (different issue) → create.
+echo "Test: only a non-matching worktree → create"
+setup
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/99-other\nHEAD def456\nbranch refs/heads/99-other\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+echo '{"title":"My Task"}' > "$STUB_DIR/issue-title-42.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
+assert_eq "non-matching worktree → create" "create 42-my-task" "$result"
+teardown
+
+# 9. Argument validation: missing args, non-numeric issue, bad mode → exit 1.
+echo "Test: argument validation → non-zero exit"
+setup
+if "$TMPDIR_TEST/dispatch-resolve-worktree" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "missing both args exits non-zero" "1" "$rc"
+if "$TMPDIR_TEST/dispatch-resolve-worktree" 42 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "missing mode arg exits non-zero" "1" "$rc"
+if "$TMPDIR_TEST/dispatch-resolve-worktree" abc explicit 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "non-numeric issue exits non-zero" "1" "$rc"
+if "$TMPDIR_TEST/dispatch-resolve-worktree" 0 explicit 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "issue zero exits non-zero" "1" "$rc"
+if "$TMPDIR_TEST/dispatch-resolve-worktree" 42 bogus 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "bad mode exits non-zero" "1" "$rc"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1232,6 +1232,14 @@ if "$TMPDIR_TEST/dispatch-resolve-worktree" 42 bogus 2>/dev/null; then rc=0; els
 assert_eq "bad mode exits non-zero" "1" "$rc"
 teardown
 
+# 10. A title with no alphanumerics sanitizes to an empty slug → exit 1.
+echo "Test: title with no alphanumerics → empty-slug error"
+setup
+echo '{"title":"!!!"}' > "$STUB_DIR/issue-title-42.json"
+if "$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "empty-slug title exits non-zero" "1" "$rc"
+teardown
+
 # ============================================================================
 # summary
 # ============================================================================


### PR DESCRIPTION
## Summary

`/dispatch` Step 3 ran ~35 lines of SKILL.md prose the agent re-executed every
invocation: parse `git worktree list --porcelain`, match the `<issue>-<slug>`
branch convention, generate a sanitized branch name, and branch four ways. All
of it is deterministic string/list processing — and the branch-slug rules were
effectively duplicated against the `WorktreeCreate` hook regex.

This extracts that logic into `dispatch-resolve-worktree <issue> <explicit|queue>`,
which prints exactly one decision line:

- `here` — current branch already is `<issue>-*`; no `EnterWorktree` needed
- `enter <path>` — re-use an existing `<issue>-*` worktree
- `create <branch>` — no worktree; `<branch>` is the sanitized name
- `conflict <path>` — a queue-selected target already has a worktree

The `here` check is mode-independent and fires before the worktree scan. An
existing `<issue>-*` worktree yields `enter` in `explicit` mode and `conflict`
in `queue` mode. Generated branch names match the `WorktreeCreate` hook form
`^[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$`, full name ≤ 32 chars.

SKILL.md Step 3 collapses to: run the script, act on its single line. The
`EnterWorktree` call, the `sync-issue-context` re-syncs, the
`tmp/dispatch-worktree` marker, and the `restore-dispatch-skill.sh` recovery
paragraph stay with the agent.

## Changes

- **New** `.claude/skills/dispatch/scripts/dispatch-resolve-worktree`.
- `test-dispatch-scripts.sh` gains a `dispatch-resolve-worktree` section
  covering each output case, sanitization, truncation, `here` precedence, and
  argument validation (70 → 86 tests, all passing).
- `dispatch/SKILL.md` Step 3 rewritten to call the script.

## Testing

- `bash .claude/skills/dispatch/scripts/test-dispatch-scripts.sh` → 86/86 pass.
- Smoke from this worktree: `dispatch-resolve-worktree 656 explicit` → `here`.

Closes #656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)