### PR TITLE
dispatch: add continuation guard to security-review-fix and review-fix Step 2

### DIFF
--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -25,7 +25,9 @@ implementation subagents.
    current `main` avoids re-reviewing code `main` has already changed.
 
 2. **Run `/review`.** Invoke the built-in `/review` skill via the Skill tool — the
-   generic PR review. It produces findings; it applies no fixes.
+   generic PR review. It produces findings; it applies no fixes. Any "final
+   reply" / "nothing else" wording in `/review`'s prompt scopes only to its
+   findings deliverable — once it returns, continue to Step 3.
 
 3. **Implement the recommended changes — without prompting the user.** A
    "recommended change" is a finding `/review` presents as an actionable code

--- a/.claude/skills/security-review-fix/SKILL.md
+++ b/.claude/skills/security-review-fix/SKILL.md
@@ -44,7 +44,9 @@ steps in order.
 
 2. **Run `/security-review`.** Invoke the built-in `/security-review` skill via
    the Skill tool — the generic security review. It produces findings; it applies
-   no fixes.
+   no fixes. Any "final reply" / "nothing else" wording in `/security-review`'s
+   prompt scopes only to its findings deliverable — once it returns, continue to
+   Step 3.
 
 3. **Apply the recommended changes.** Implement fixes for the findings
    `/security-review` flags as actionable vulnerabilities — launch implementation


### PR DESCRIPTION
## Summary

- `/security-review-fix` (security phase) and `/review-fix` (review phase) each invoke a generic built-in skill (`/security-review` and `/review`) in Step 2. The generic skills end with terminal-output instructions ("Your final reply must contain ... and nothing else.") that a literal-following model treats as terminal for the entire wrapper chain, skipping Steps 3-7 (apply fixes, commit/push, post PR comment, apply dispatch label, and -- for security -- mark the PR ready).
- Observed on PR #666 (issue #656): `/security-review` returned "No findings.", and the wrapper stopped before posting the comment, applying `dispatch:security-reviewed`, or flipping the PR to ready.
- Fix: add a one-sentence continuation guard to each wrapper's Step 2 clarifying that the generic skill's "final reply" constraint scopes only to its own findings deliverable, not to the surrounding wrapper. Documentation-only change to two SKILL.md files.

## Test plan

- [ ] Re-run `/dispatch` on a PR that reaches the `review` phase; confirm `/review-fix` completes Steps 3-6 (or Steps 4-7 in the no-findings path) and applies `dispatch:reviewed`.
- [ ] Re-run `/dispatch` on a PR that reaches the `security` phase; confirm `/security-review-fix` completes Steps 3-7, posts the no-findings PR comment, applies `dispatch:security-reviewed`, and flips the PR to ready.

Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)