### PR TITLE
dispatch: skip help-wanted issues with no startable leaf instead of halting

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -113,7 +113,9 @@ merge and push are no-ops when local main already equals `origin/main`.
   It prints exactly one line:
   - `pr <num> <branch> <phase>` — a PR to work on; `<phase>` is pre-derived by the
     selection scan, so Step 5 reuses it instead of re-deriving
-  - `issue <num>` — a `help wanted` issue to implement
+  - `issue <num>` — a `help wanted` issue to implement, pre-resolved by the
+    selection scan to a startable open leaf (not necessarily the top-level
+    `help wanted` issue)
   - `worktree <N> <branch>` — run from inside an issue worktree; target is `<N>`,
     queue scan already skipped
   - `worktree-closed <N> <branch>` — run from inside a worktree whose issue is
@@ -136,6 +138,12 @@ merge and push are no-ops when local main already equals `origin/main`.
   are ranked closest-to-done first — `security` is the closest-to-done non-QA
   tier; `help wanted` issues rank below all non-QA PRs but above QA PRs.
 
+  A `help wanted` issue is also skipped when its entire open-leaf subtree is
+  worktree-conflicted — every reachable open leaf already has a worktree owned by
+  another session — exactly as a directly-worktree'd issue is skipped; selection
+  falls through to the next tier. The tier emits the resolved startable leaf, so
+  a queue-selected `issue <num>` is always a directly-startable target.
+
   On `empty` → report that the queue is empty and **stop**.
 
   **main-broken handler.** `origin/main` itself is red, so no new work is safe
@@ -151,26 +159,23 @@ merge and push are no-ops when local main already equals `origin/main`.
 
 ## 3. Trace to an Open Leaf
 
-When the resolved target is an **open issue with no PR** — whether queue-selected
-(`issue <num>`) or named by argument — trace to its open leaf. Pass the mode that
-matches Step 4's resolve call: `queue` if queue-selected, `explicit` if named by
-an explicit `/dispatch` argument:
+This step runs **only for an explicit `/dispatch <N>` argument**. A queue-selected
+`issue <num>` is already a resolved startable open leaf — `dispatch-select-target`
+traced it during selection — so re-tracing would just return the same leaf.
+
+When the resolved target is an **explicitly-named open issue with no PR**, trace
+to its open leaf in `explicit` mode:
 
 ```bash
-.claude/skills/dispatch/scripts/dispatch-trace-leaf <N> <queue|explicit>
+.claude/skills/dispatch/scripts/dispatch-trace-leaf <N> explicit
 ```
 
 It walks open blockers and sub-issues to an open leaf and prints one issue number.
 Retarget to that leaf.
 
-In `queue` mode the descent is worktree-aware: children whose `<N>-*` branch is
-an existing local worktree (owned by another session) are skipped, and the trace
-falls back to the next ready sibling. If every reachable open leaf in the subtree
-is worktree-conflicted, the script exits non-zero with a message on stderr —
-report "subtree fully blocked — all open leaves have worktrees owned by other
-sessions" (name `<N>`) and **stop**; do not dispatch.
-
 Skip leaf tracing when:
+- The target was queue-selected (`issue <num>`) — `dispatch-select-target` already
+  resolved it to a startable open leaf.
 - A PR exists for the target — check with:
   ```bash
   .claude/skills/dispatch/scripts/dispatch-find-pr <N>
@@ -216,10 +221,11 @@ one of `path` (switch to an existing worktree) or `name` (create a new one).
   `<branch>`. This fires the `WorktreeCreate` hook, which runs `sync-issue-context`
   and populates `CLAUDE.local.md` with full issue context.
 - **`conflict <path>`** → a queue-selected target already has a worktree, so
-  another session owns it. (The queue scan skips worktree'd issues, so this arises
-  only when Step 3 leaf-tracing retargets to a blocker or sub-issue that has one.)
-  Report the conflict (name `<path>` and issue `<N>`) and **stop**; do not
-  `EnterWorktree`.
+  another session owns it. (`dispatch-select-target` resolves the `help wanted`
+  tier to a leaf with no worktree, so for a queue selection this arises only from
+  a race — another session created the worktree between selection and worktree
+  resolution.) Report the conflict (name `<path>` and issue `<N>`) and **stop**;
+  do not `EnterWorktree`.
 
 As the **last action of this step on every non-`conflict` path** — before any
 phase skill runs — create the recovery marker:
@@ -240,8 +246,8 @@ When the target is a **queue-selected PR** (`pr <num> <branch> <phase>` from Ste
 the phase is already on the result line — use it directly and skip the script below.
 
 On every other path — an explicit issue argument, a `worktree <N>` result, or a
-queue-selected `issue <num>` (after leaf tracing in Step 3) — run the phase script
-against the final target (issue number or branch):
+queue-selected `issue <num>` — run the phase script against the final target
+(issue number or branch):
 
 ```bash
 .claude/skills/dispatch/scripts/dispatch-phase <target>

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -4,7 +4,8 @@
 #
 # Output: exactly one line:
 #   pr <num> <branch> <phase>   — a PR to work on, with its already-derived phase
-#   issue <num>                 — a help-wanted issue to implement
+#   issue <num>                 — a help-wanted issue, resolved to a startable
+#                                 open leaf (may differ from the top-level issue)
 #   empty                       — nothing eligible
 #   worktree <N> <branch>       — the current worktree's own open issue (short-circuits the queue scan)
 #   worktree-closed <N> <branch>— the current worktree's issue is closed or unknown
@@ -31,7 +32,9 @@
 #   2. Oldest "review"   PR (draft + dispatch:refactored)
 #   3. Oldest "simplify" PR (draft + dispatch:qa-done)
 #   4. Oldest "verify"   PR (draft, CI completed and failed)
-#   5. Oldest open help-wanted issue with no local git worktree
+#   5. Oldest open help-wanted issue with no local git worktree, resolved to a
+#      startable open leaf (an issue whose entire open-leaf subtree is
+#      worktree-conflicted is skipped, exactly as a direct worktree is)
 #   6. Oldest "qa"       PR (draft, CI green, no dispatch:* label)
 #
 # PRs and help-wanted issues with a local git worktree are skipped (a session is
@@ -228,24 +231,42 @@ for phase in "${PHASE_PRIORITY[@]}"; do
   fi
 done
 
-# Fetch help-wanted issues oldest-first; pick the oldest with no local worktree.
+# Fetch help-wanted issues oldest-first; pick the oldest with no local worktree
+# and a startable open leaf.
 ISSUE_LIST=$(gh issue list --label "help wanted" --state open --json number,createdAt)
 # Sort into a variable first so a jq failure aborts here (set -e + pipefail);
 # a process substitution would swallow it as empty input. Mirrors PR_SORTED.
 ISSUE_NUMS_SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[].number')
-ISSUE_NUM=""
+LEAF_NUM=""
 while IFS= read -r issue_num; do
   [[ -z "$issue_num" ]] && continue
   # Skip issues whose <N>-* worktree exists (a session is working them).
   if issue_has_worktree "$issue_num"; then
     continue
   fi
-  ISSUE_NUM="$issue_num"
-  break
+  # Resolve a startable open leaf within the issue's subtree. dispatch-trace-leaf
+  # in queue mode descends open blockers and sub-issues, skipping any child whose
+  # <N>-* branch is an existing local worktree (owned by another session):
+  #   exit 0 — a startable open leaf was found; select it.
+  #   exit 2 — every reachable open leaf is worktree-conflicted. Skip this issue
+  #            exactly as a direct worktree is skipped; continue the ladder so
+  #            selection never emits a dead-end target.
+  #   exit 1 — usage error; propagate as a hard failure, never swallow as a skip.
+  # The `if cmd=$(...); then ... else status=$?; ... fi` form captures the exit
+  # code without tripping set -e.
+  if leaf=$("$SCRIPT_DIR/dispatch-trace-leaf" "$issue_num" queue); then
+    LEAF_NUM="$leaf"
+    break
+  else
+    trace_status=$?
+    [[ "$trace_status" == 2 ]] && continue
+    echo "error: dispatch-trace-leaf $issue_num queue failed (exit $trace_status)" >&2
+    exit 1
+  fi
 done <<< "$ISSUE_NUMS_SORTED"
 
-if [[ -n "$ISSUE_NUM" ]]; then
-  echo "issue $ISSUE_NUM"
+if [[ -n "$LEAF_NUM" ]]; then
+  echo "issue $LEAF_NUM"
   exit 0
 fi
 

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -252,14 +252,12 @@ while IFS= read -r issue_num; do
   #            exactly as a direct worktree is skipped; continue the ladder so
   #            selection never emits a dead-end target.
   #   exit 1 — usage error; propagate as a hard failure, never swallow as a skip.
-  # The `if cmd=$(...); then ... else status=$?; ... fi` form captures the exit
-  # code without tripping set -e.
   if leaf=$("$SCRIPT_DIR/dispatch-trace-leaf" "$issue_num" queue); then
     LEAF_NUM="$leaf"
     break
   else
     trace_status=$?
-    [[ "$trace_status" == 2 ]] && continue
+    [[ "$trace_status" -eq 2 ]] && continue
     echo "error: dispatch-trace-leaf $issue_num queue failed (exit $trace_status)" >&2
     exit 1
   fi

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1051,6 +1051,95 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "issue 6 not masked by 60-foo worktree" "issue 6" "$result"
 teardown
 
+# --- help-wanted leaf reachability (issue #715) -----------------------------
+# dispatch-select-target runs dispatch-trace-leaf <N> queue for each help-wanted
+# candidate and skips any whose subtree is fully worktree-conflicted (trace
+# exits 2), exactly as a direct worktree is skipped. Sub-issue 5500 sits on
+# branch 5500-blocked, which does NOT prefix-match 55-, so issue 55 is never
+# falsely flagged as directly worktree'd.
+
+# 28. A help-wanted issue with a fully worktree-conflicted subtree is skipped;
+#     the next help-wanted issue is selected.
+echo "Test: subtree-blocked help-wanted issue skipped → next issue chosen"
+setup
+setup_union_pr_list '[]'
+# Issue 55 (older) has open sub-issue 5500; issue 66 (newer) has no children.
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"},{"number":66,"createdAt":"2024-01-02T00:00:00Z"}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf '[{"number":5500}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-5500.json"
+# Sub-issue 5500's worktree exists (owned by another session) → trace 55 exits 2.
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/5500-blocked\nHEAD def456\nbranch refs/heads/5500-blocked\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "subtree-blocked issue 55 skipped → issue 66 chosen" "issue 66" "$result"
+teardown
+
+# 29. Every help-wanted issue is subtree-blocked → falls through to a QA PR.
+echo "Test: all help-wanted issues subtree-blocked → QA PR selected"
+setup
+UNION='['"$(make_pr_union 20 "20-qa" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":5500}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-5500.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/5500-blocked\nHEAD def456\nbranch refs/heads/5500-blocked\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "subtree-blocked issue 55 → falls through to QA PR" "pr 20 20-qa qa" "$result"
+teardown
+
+# 30. Every help-wanted issue is subtree-blocked and no QA PR → empty.
+echo "Test: all help-wanted issues subtree-blocked, no QA PR → empty"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":5500}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-5500.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/5500-blocked\nHEAD def456\nbranch refs/heads/5500-blocked\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "subtree-blocked issue 55, no QA PR → empty" "empty" "$result"
+teardown
+
+# 31. A help-wanted issue with a startable open leaf emits the resolved leaf
+#     number (which differs from the top-level issue).
+echo "Test: help-wanted issue resolves to its startable leaf"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":5500}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-5500.json"
+# No worktree for 5500 — the leaf is startable.
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "help-wanted issue 55 resolves to leaf 5500" "issue 5500" "$result"
+teardown
+
+# 32. dispatch-trace-leaf exit 1 (usage error) is a hard failure, never a skip.
+echo "Test: dispatch-trace-leaf exit 1 → dispatch-select-target hard-fails"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+# Replace the copied leaf-trace script with a stub that always exits 1.
+cat > "$TMPDIR_TEST/dispatch-trace-leaf" <<'STUB'
+#!/usr/bin/env bash
+echo "error: usage" >&2
+exit 1
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-trace-leaf"
+if result=$("$TMPDIR_TEST/dispatch-select-target" 2>/dev/null); then rc=0; else rc=$?; fi
+[[ "$rc" -ne 0 ]] && rc_nonzero=yes || rc_nonzero=no
+assert_eq "dispatch-trace-leaf exit 1 → select-target exits non-zero" "yes" "$rc_nonzero"
+[[ "$result" != issue* ]] && no_issue=yes || no_issue=no
+assert_eq "dispatch-trace-leaf exit 1 → no issue line emitted" "yes" "$no_issue"
+teardown
+
 # ============================================================================
 # dispatch-trace-leaf tests
 # ============================================================================


### PR DESCRIPTION
Closes #715

`dispatch-select-target`'s `help wanted` tier now folds leaf-reachability into its eligibility filter: for each oldest-first candidate (already filtered for a direct worktree) it runs `dispatch-trace-leaf <N> queue` and resolves a startable open leaf itself.

- **exit 0** → emit `issue <leaf-N>` (the resolved leaf, not necessarily the top-level issue).
- **exit 2** → the subtree is fully worktree-conflicted; skip the issue exactly as a directly-worktree'd issue is skipped, and continue the ladder — next `help wanted` issue, then the `qa` PR tier, then `empty`.
- **exit 1** → usage error; hard failure, never swallowed as a skip.

Selection now only ever emits a directly-startable target, so `SKILL.md`'s queue-mode leaf trace is redundant. Step 3 leaf tracing runs only for an explicit `/dispatch <N>` argument; the queue-mode "subtree fully blocked — report and stop" halt is removed. Step 2's priority order, Step 4's `conflict` parenthetical, and Step 5's cross-reference are updated to match.

Fixes the autonomous-loop stall: previously a single higher-priority `help wanted` issue with a fully-claimed subtree halted every `/loop /dispatch` iteration until another session freed a worktree.

`test-dispatch-scripts.sh` gains 5 cases (subtree-blocked issue skipped → next issue; all blocked → falls through to `qa`; all blocked + no `qa` → `empty`; startable leaf → emits leaf number; trace exit 1 → hard failure). All 156 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)