### PR TITLE
dispatch: scope the process lock to selection and queue waiters

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -27,23 +27,60 @@ resolution. Runs unconditionally, whether or not an issue-number argument was
 given.
 
 ```bash
-LOCK=$(.claude/skills/dispatch/scripts/dispatch-acquire-lock)
+LOCK=$(.claude/skills/dispatch/scripts/dispatch-acquire-lock --wait)
 ```
 
-Requires `dangerouslyDisableSandbox: true` — the script writes
-`$PROJECT_ROOT/tmp/dispatch.lock`, which is outside the sandbox write-allowlist
-(same reason `dispatch-sweep` runs that way; see `.claude/rules/sandbox.md`).
+Run this Bash call with **both** `dangerouslyDisableSandbox: true` and an
+elevated `timeout: 600000` (ms):
+
+- `dangerouslyDisableSandbox: true` — the script writes
+  `$PROJECT_ROOT/tmp/dispatch.lock`, which is outside the sandbox write-allowlist
+  (same reason `dispatch-sweep` runs that way; see `.claude/rules/sandbox.md`).
+- `timeout: 600000` — `--wait` blocks on contention until it acquires the lock
+  or `DISPATCH_LOCK_WAIT_TIMEOUT` (default 300 s) elapses, which exceeds the
+  default Bash-call timeout.
 
 Route on `$LOCK`:
 
 - **`acquired`** → this `/dispatch` holds the lock; proceed to Step 1.
-- **`busy`** → another `/dispatch` is active; report "another /dispatch is
-  running — stopping" and **stop** — run no sync, no health gate, no sweep, no
-  selection, and no phase skill.
+- **`busy`** → the wait timeout elapsed without acquiring — a wedged selection
+  in another `/dispatch`. The script's **stderr** carries a one-line diagnostic
+  naming the wait duration and the holding PID; report those and **stop** — run
+  no sync, no health gate, no sweep, no selection, and no phase skill.
 
-The lock is session-scoped and self-healing: when a tick's session ends —
-normally, by crash, or by kill — its PID dies and the next invocation detects
-the stale record and proceeds. A crashed tick never wedges the queue. Same-session
+### Releasing the lock
+
+The lock covers **Steps 0-4 only** — target selection and worktree resolution.
+Steps 5-7 (the phase skill and the pre-implementation relevance review) run with
+the lock **released**.
+
+Release the lock by running:
+
+```bash
+.claude/skills/dispatch/scripts/dispatch-acquire-lock --release
+```
+
+This needs `dangerouslyDisableSandbox: true` (same reason as Step 0); no
+elevated timeout is needed — `--release` returns immediately. It prints
+`released` or `noop`; both are fine — it is a no-op when the lock is already
+released or held by another session, so the skill does not branch on its output.
+
+Release happens at exactly two kinds of point:
+
+- **Proceed path** — as the final action of Step 4, after the
+  `tmp/dispatch-worktree` marker is written, before Step 5.
+- **Every Step 1-4 stop path** — immediately before reporting the stop reason
+  and stopping.
+
+Releasing after Step 4 is safe because the session then owns a worktree (or has
+stopped), and the selection scan skips worktree'd targets — no other tick can
+select the same issue. Later steps cross-reference *Releasing the lock* rather
+than repeating this command.
+
+The lock is scoped to selection and self-healing. The recorded PID is
+session-keyed: if a tick dies before its explicit release, the next tick detects
+the stale record and proceeds, and a `--wait` waiter re-checks holder liveness
+every poll, so it reclaims a dead holder's lock automatically. Same-session
 re-entry (e.g. after a context clear that re-invokes `/dispatch`) re-acquires
 cleanly because the recorded PID matches the re-entering session's own PID.
 
@@ -59,8 +96,9 @@ merge and push are no-ops when local main already equals `origin/main`.
 
 - If the working tree is dirty, stash before invoking — `/commit-merge-push` would
   otherwise commit pending changes directly to `main`.
-- If `/commit-merge-push` reports a merge conflict or push rejection, **stop** and
-  surface the error — do not proceed to target selection.
+- If `/commit-merge-push` reports a merge conflict or push rejection, release the
+  lock (see *Releasing the lock*), then **stop** and surface the error — do not
+  proceed to target selection.
 
 ## 2. Select the Target
 
@@ -117,9 +155,10 @@ merge and push are no-ops when local main already equals `origin/main`.
   - `worktree <N> <branch>` — run from inside an issue worktree; target is `<N>`,
     queue scan already skipped
   - `worktree-closed <N> <branch>` — run from inside a worktree whose issue is
-    closed or unrecognized → report that the current worktree belongs to
-    closed/unrecognized issue `<N>` and **stop** (consistent with the named-target
-    "closed → report and stop" rule in Step 3)
+    closed or unrecognized → release the lock (see *Releasing the lock*), then
+    report that the current worktree belongs to closed/unrecognized issue `<N>`
+    and **stop** (consistent with the named-target "closed → report and stop"
+    rule in Step 3)
   - `empty` — nothing eligible
   - `main-broken <sha>` — `origin/main`'s HEAD CI has a failing check. The
     pre-sweep gate above normally catches this first; this is the same gate
@@ -136,7 +175,8 @@ merge and push are no-ops when local main already equals `origin/main`.
   are ranked closest-to-done first — `security` is the closest-to-done non-QA
   tier; `help wanted` issues rank below all non-QA PRs but above QA PRs.
 
-  On `empty` → report that the queue is empty and **stop**.
+  On `empty` → release the lock (see *Releasing the lock*), then report that
+  the queue is empty and **stop**.
 
   **main-broken handler.** `origin/main` itself is red, so no new work is safe
   to start. Do **not** run the sweep, create a worktree, branch, or phase skill.
@@ -145,9 +185,11 @@ merge and push are no-ops when local main already equals `origin/main`.
   `gh api repos/{owner}/{repo}/commits/<sha>/check-runs`. For a failing workflow
   run, fetch its logs with `gh run view <databaseId> --log-failed`; for a failing
   CodeQL check-run (which has no workflow-run id), open its `details_url` from
-  the check-runs response. Summarize the likely cause, report it, and **stop**.
-  Once a PR that fixes main exists the normal ladder picks it up (verify/ready)
-  — this gate only blocks starting new, unrelated work.
+  the check-runs response. These diagnostic `gh` calls run before the stop —
+  keep them. Then, as the action immediately before the final report, release
+  the lock (see *Releasing the lock*); summarize the likely cause, report it,
+  and **stop**. Once a PR that fixes main exists the normal ladder picks it up
+  (verify/ready) — this gate only blocks starting new, unrelated work.
 
 ## 3. Trace to an Open Leaf
 
@@ -167,8 +209,9 @@ In `queue` mode the descent is worktree-aware: children whose `<N>-*` branch is
 an existing local worktree (owned by another session) are skipped, and the trace
 falls back to the next ready sibling. If every reachable open leaf in the subtree
 is worktree-conflicted, the script exits non-zero with a message on stderr —
-report "subtree fully blocked — all open leaves have worktrees owned by other
-sessions" (name `<N>`) and **stop**; do not dispatch.
+release the lock (see *Releasing the lock*), then report "subtree fully blocked
+— all open leaves have worktrees owned by other sessions" (name `<N>`) and
+**stop**; do not dispatch.
 
 Skip leaf tracing when:
 - A PR exists for the target — check with:
@@ -184,7 +227,8 @@ Skip leaf tracing when:
   is the already-committed unit of work; retargeting to a sub-issue or blocker
   would be wrong.
 
-If a named target issue is **closed**, report it and **stop**.
+If a named target issue is **closed**, release the lock (see *Releasing the
+lock*), then report it and **stop**.
 
 ## 4. Resolve the Worktree
 
@@ -218,11 +262,11 @@ one of `path` (switch to an existing worktree) or `name` (create a new one).
 - **`conflict <path>`** → a queue-selected target already has a worktree, so
   another session owns it. (The queue scan skips worktree'd issues, so this arises
   only when Step 3 leaf-tracing retargets to a blocker or sub-issue that has one.)
-  Report the conflict (name `<path>` and issue `<N>`) and **stop**; do not
-  `EnterWorktree`.
+  Release the lock (see *Releasing the lock*), then report the conflict (name
+  `<path>` and issue `<N>`) and **stop**; do not `EnterWorktree`.
 
-As the **last action of this step on every non-`conflict` path** — before any
-phase skill runs — create the recovery marker:
+On every non-`conflict` path, before any phase skill runs, create the recovery
+marker:
 
 ```bash
 mkdir -p tmp && touch tmp/dispatch-worktree
@@ -233,6 +277,10 @@ recovery on this marker — when present, it re-invokes `/dispatch` so the phase
 re-derived from PR/CI ground truth. The marker is an empty boolean flag with no
 payload; it persists for the worktree's life and needs no cleanup — `tmp/` is
 git-ignored, and removing the worktree removes it.
+
+As the **final action of this step on every non-`conflict` (proceed) path** —
+after the marker is written, before Step 5 — release the lock (see *Releasing
+the lock*). The phase skill in Step 5 onward runs lock-free.
 
 ## 5. Derive the Phase
 

--- a/.claude/skills/dispatch/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch/scripts/dispatch-acquire-lock
@@ -52,8 +52,9 @@
 # Exit codes:
 #   0  acquired/busy/released/noop (all are normal outcomes; stdout
 #      disambiguates).
-#   2  misconfiguration — not in a git repo and DISPATCH_LOCK_FILE is unset, or
-#      an unknown/extra command-line argument.
+#   2  the script cannot operate — not in a git repo and DISPATCH_LOCK_FILE is
+#      unset, an unknown/extra command-line argument, or an unexpected internal
+#      sentinel from a flock subshell (a should-never-happen guard).
 #
 # NOT set -e: exits are handled explicitly (matching the sibling dispatch-sweep).
 set -uo pipefail
@@ -177,14 +178,15 @@ try_acquire() {            # 0 = acquired, 1 = contended; sets CONTENDED_PID
   case "$result" in
     OK)       return 0 ;;
     'BUSY '*) CONTENDED_PID="${result#BUSY }"; return 1 ;;
-    *)        return 1 ;;
+    *) echo "dispatch-acquire-lock: try_acquire — unexpected subshell output '$result'" >&2
+       exit 2 ;;
   esac
 }
 
 # ---- dispatch the mode ------------------------------------------------------
 case "$MODE" in
   acquire)
-    # Single-shot — byte-identical to the pre-#719 behavior.
+    # Single-shot: one read-check-write attempt, no polling.
     try_acquire && echo acquired || echo busy
     exit 0
     ;;
@@ -223,7 +225,9 @@ case "$MODE" in
     )
     case "$result" in
       RELEASED) echo released ;;
-      *)        echo noop ;;
+      NOOP)     echo noop ;;
+      *) echo "dispatch-acquire-lock: --release — unexpected subshell output '$result'" >&2
+         exit 2 ;;
     esac
     exit 0
     ;;

--- a/.claude/skills/dispatch/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch/scripts/dispatch-acquire-lock
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# dispatch-acquire-lock — acquire the process-level /dispatch lock once per tick.
+# dispatch-acquire-lock — acquire/release the process-level /dispatch lock.
 #
 # /dispatch mutates shared state (fetches origin/main, creates/removes
 # worktrees, flips gh labels and PR draft status). Its per-target guards assume
@@ -10,33 +10,71 @@
 # separate Bash tool calls, each a fresh shell, so an fd flock would release
 # the instant its Bash call exits. The lock therefore keys on the Claude
 # *session* process — the nearest ancestor whose comm starts with ".claude" —
-# whose lifetime spans the whole tick. The recorded PID is the lock holder;
-# release is implicit and self-healing: when the session dies its PID stops
-# being a live ".claude" process, and the next tick reclaims the lock.
+# whose lifetime spans the whole tick. The recorded PID is the lock holder.
+#
+# Release is implicit and self-healing: when the session dies its PID stops
+# being a live ".claude" process, so the next tick's read-check-write reclaims
+# the lock automatically. `--release` is an explicit optional fast-path that
+# the lock holder can call to release immediately — clearing the recorded PID
+# without waiting for self-healing to notice the session has moved on.
 #
 # Usage:
-#   dispatch-acquire-lock        — print "acquired" or "busy" on stdout.
+#   dispatch-acquire-lock            — single-shot: print "acquired" or "busy".
+#   dispatch-acquire-lock --wait     — poll until acquired or the wait timeout
+#                                      elapses; print "acquired" or "busy".
+#   dispatch-acquire-lock --release  — clear our own recorded PID from the lock
+#                                      file; print "released" or "noop".
 #
 # Environment overrides for testability:
-#   DISPATCH_LOCK_FILE        Override the lock-file path. When set, the script
-#                             does NOT require a git repo. Default:
-#                             <project-root>/tmp/dispatch.lock.
-#   DISPATCH_LOCK_SESSION_PID Override the session PID, skipping the /proc
-#                             ancestry walk. Most tests set this; one leaves
-#                             it unset to exercise the walk.
-#   DISPATCH_LOCK_PROC_ROOT   Root of the /proc walk + liveness check.
-#                             Default: /proc.
+#   DISPATCH_LOCK_FILE          Override the lock-file path. When set, the
+#                               script does NOT require a git repo. Default:
+#                               <project-root>/tmp/dispatch.lock.
+#   DISPATCH_LOCK_SESSION_PID   Override the session PID, skipping the /proc
+#                               ancestry walk. Most tests set this; one leaves
+#                               it unset to exercise the walk.
+#   DISPATCH_LOCK_PROC_ROOT     Root of the /proc walk + liveness check.
+#                               Default: /proc.
+#   DISPATCH_LOCK_WAIT_TIMEOUT  --wait: max wall-clock seconds to poll before
+#                               giving up. 0 is valid (one attempt only).
+#                               Default: 300.
+#   DISPATCH_LOCK_WAIT_INTERVAL --wait: poll gap in seconds (fractional
+#                               allowed). Default: 5.
 #
 # Stdout protocol (exactly one word):
 #   acquired  this /dispatch holds the lock — proceed with the tick.
-#   busy      another /dispatch is running — stop cleanly, no side effects.
+#   busy      another /dispatch holds the lock — stop cleanly, no side effects.
+#             Under --wait this means the wait timeout elapsed; a one-line
+#             diagnostic (elapsed time + holding PID) is written to stderr.
+#   released  --release: our own recorded PID was cleared from the lock file.
+#   noop      --release: nothing to release — the lock was unheld or held by
+#             another session, so the file was left untouched.
 #
 # Exit codes:
-#   0  acquired or busy (both are normal outcomes; stdout disambiguates).
-#   2  misconfiguration — not in a git repo and DISPATCH_LOCK_FILE is unset.
+#   0  acquired/busy/released/noop (all are normal outcomes; stdout
+#      disambiguates).
+#   2  misconfiguration — not in a git repo and DISPATCH_LOCK_FILE is unset, or
+#      an unknown/extra command-line argument.
 #
 # NOT set -e: exits are handled explicitly (matching the sibling dispatch-sweep).
 set -uo pipefail
+
+# ---- Step 0: parse the mode -------------------------------------------------
+# Done before any side effect so an unknown argument exits 2 cleanly: no lock
+# file resolved, no /proc walk, no file touched.
+MODE="acquire"
+if [[ $# -gt 0 ]]; then
+  case "$1" in
+    --wait)    MODE="wait" ;;
+    --release) MODE="release" ;;
+    *) echo "dispatch-acquire-lock: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+  if [[ $# -gt 1 ]]; then
+    echo "dispatch-acquire-lock: unknown argument '$2'" >&2; exit 2
+  fi
+fi
+
+WAIT_TIMEOUT="${DISPATCH_LOCK_WAIT_TIMEOUT:-300}"
+WAIT_INTERVAL="${DISPATCH_LOCK_WAIT_INTERVAL:-5}"
 
 PROC_ROOT="${DISPATCH_LOCK_PROC_ROOT:-/proc}"
 
@@ -103,30 +141,90 @@ else
   [[ -n "$SESSION_PID" ]] || SESSION_PID="$PPID"
 fi
 
-# ---- Step 3: lock + atomic read-check-write ---------------------------------
-# Open the lock file append-mode (>>) so opening does not truncate a recorded
-# PID, then take a BLOCKING flock — a short mutex making the read-check-write
-# below atomic within this single script run. (This is a correct use of flock:
-# the fd lives only for this script's lifetime, which is all the mutex needs.)
+# The lock-file directory must exist before the first `exec 9>>` open.
 mkdir -p "$(dirname "$LOCK_FILE")" 2>/dev/null || true
-exec {lockfd}>>"$LOCK_FILE"
-flock "$lockfd"
 
-# ---- Step 4: read the recorded PID ------------------------------------------
-# First line of the lock file. The Step 3 `>>` open created the file if it was
-# absent, so it always exists here; it may still be empty — read defensively.
-recorded=""
-IFS= read -r recorded <"$LOCK_FILE" 2>/dev/null || true
+# ---- try_acquire — one atomic, flock-bounded read-check-write ---------------
+# Returns 0 (acquired) or 1 (contended); on contention sets the global
+# CONTENDED_PID to the live foreign holder's PID.
+#
+# The flock MUST be released between polls so a --wait loop does not block
+# other sessions. The brace-group `{ ...; } {fd}>>FILE` idiom does NOT release
+# the lock (and hides the fd var from the body). A command-substitution
+# subshell with a fixed numeric fd does: fd 9 closes when the subshell exits,
+# releasing the flock. The subshell prints a sentinel the parent decodes.
+CONTENDED_PID=""
+try_acquire() {            # 0 = acquired, 1 = contended; sets CONTENDED_PID
+  CONTENDED_PID=""
+  local result
+  result=$(
+    exec 9>>"$LOCK_FILE"
+    flock 9                # blocking — a short mutex over the read-check-write
+    local recorded=""
+    IFS= read -r recorded <"$LOCK_FILE" 2>/dev/null || true
+    # Busy iff a different PID is recorded AND it is still a live .claude
+    # process. Otherwise — no record, a stale record (dead PID, or a PID
+    # recycled by a non-.claude process), or our own session re-entering — we
+    # claim the lock.
+    if [[ -n "$recorded" && "$recorded" != "$SESSION_PID" ]] \
+         && is_live_claude "$recorded"; then
+      printf 'BUSY %s' "$recorded"
+    else
+      printf '%s\n' "$SESSION_PID" >"$LOCK_FILE"
+      printf 'OK'
+    fi
+  )
+  case "$result" in
+    OK)       return 0 ;;
+    'BUSY '*) CONTENDED_PID="${result#BUSY }"; return 1 ;;
+    *)        return 1 ;;
+  esac
+}
 
-# ---- Step 5: decide ---------------------------------------------------------
-# Busy iff a different PID is recorded AND it is still a live .claude process.
-# Otherwise — no record, a stale record (dead PID, or a PID recycled by a
-# non-.claude process), or our own session re-entering — we claim the lock.
-if [[ -n "$recorded" && "$recorded" != "$SESSION_PID" ]] && is_live_claude "$recorded"; then
-  echo "busy"
-  exit 0
-fi
+# ---- dispatch the mode ------------------------------------------------------
+case "$MODE" in
+  acquire)
+    # Single-shot — byte-identical to the pre-#719 behavior.
+    try_acquire && echo acquired || echo busy
+    exit 0
+    ;;
 
-printf '%s\n' "$SESSION_PID" >"$LOCK_FILE"
-echo "acquired"
-exit 0
+  wait)
+    # Poll until acquired or the wall-clock timeout elapses. try_acquire runs
+    # first each iteration, so WAIT_TIMEOUT=0 still makes one real attempt.
+    SECONDS=0
+    while true; do
+      if try_acquire; then echo acquired; exit 0; fi
+      if (( SECONDS >= WAIT_TIMEOUT )); then
+        echo busy
+        echo "dispatch-acquire-lock: gave up after ${SECONDS}s; held by PID ${CONTENDED_PID:-unknown}" >&2
+        exit 0
+      fi
+      sleep "$WAIT_INTERVAL"
+    done
+    ;;
+
+  release)
+    # Re-read the recorded PID under flock and clear it ONLY if it is our own
+    # session. Truncate with `:` rather than `rm` — `rm` would orphan a
+    # concurrent acquire's already-open fd. A no-op when the lock is unheld or
+    # held by another session.
+    result=$(
+      exec 9>>"$LOCK_FILE"
+      flock 9
+      recorded=""    # plain var: this subshell runs at script top level
+      IFS= read -r recorded <"$LOCK_FILE" 2>/dev/null || true
+      if [[ -n "$recorded" && "$recorded" == "$SESSION_PID" ]]; then
+        : >"$LOCK_FILE"
+        printf 'RELEASED'
+      else
+        printf 'NOOP'
+      fi
+    )
+    case "$result" in
+      RELEASED) echo released ;;
+      *)        echo noop ;;
+    esac
+    exit 0
+    ;;
+esac

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1919,7 +1919,8 @@ lock_teardown() {
   rm -rf "$TMPDIR_TEST"
   TMPDIR_TEST=""
   STUB_DIR=""
-  unset DISPATCH_LOCK_FILE DISPATCH_LOCK_SESSION_PID DISPATCH_LOCK_PROC_ROOT
+  unset DISPATCH_LOCK_FILE DISPATCH_LOCK_SESSION_PID DISPATCH_LOCK_PROC_ROOT \
+    DISPATCH_LOCK_WAIT_INTERVAL DISPATCH_LOCK_WAIT_TIMEOUT
 }
 
 # Helper: write a synthetic <proc>/<pid>/comm file with the given comm string.
@@ -2063,6 +2064,121 @@ assert_eq "proc-walk prints acquired" "acquired" "$out"
 lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
 assert_eq "proc-walk records the .claude ancestor PID, not \$PPID" \
   "$claude_pid" "$lock_contents"
+lock_teardown
+
+# --- Test 8: --wait with an own-session record acquires immediately ----------
+#
+# An own-session PID is recorded. --wait must NOT poll — try_acquire claims it
+# on iteration 1. WAIT_TIMEOUT=0 proves no wait happened: a real wait would
+# have to time out, which 0 cannot survive.
+
+echo "Test: --wait with an own-session record acquires immediately"
+lock_setup
+printf '%s\n' 800800 > "$DISPATCH_LOCK_FILE"
+lock_proc_pid 800800 ".claude-unwrapp"
+export DISPATCH_LOCK_SESSION_PID=800800
+export DISPATCH_LOCK_WAIT_TIMEOUT=0
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" --wait 2>/dev/null); rc=$?
+assert_eq "--wait own-session exits 0" "0" "$rc"
+assert_eq "--wait own-session prints acquired" "acquired" "$out"
+lock_teardown
+
+# --- Test 9: --wait against a live foreign holder times out → busy -----------
+#
+# The recorded PID is a live foreign .claude session that never goes away. The
+# --wait loop polls until WAIT_TIMEOUT elapses, then prints busy and exits 0.
+
+echo "Test: --wait against a live foreign holder times out and prints busy"
+lock_setup
+printf '%s\n' 900900 > "$DISPATCH_LOCK_FILE"
+lock_proc_pid 900900 ".claude-unwrapp"          # live foreign holder
+export DISPATCH_LOCK_SESSION_PID=900901
+lock_proc_pid 900901 ".claude-unwrapp"          # our own session
+export DISPATCH_LOCK_WAIT_TIMEOUT=1
+export DISPATCH_LOCK_WAIT_INTERVAL=0.2
+# `set -e` is in effect: capture the exit code with an if/else.
+if out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" --wait 2>/dev/null); then
+  rc=0
+else
+  rc=$?
+fi
+assert_eq "--wait timeout exits 0" "0" "$rc"
+assert_eq "--wait timeout prints busy" "busy" "$out"
+lock_teardown
+
+# --- Test 10: --wait acquires once a contended holder goes stale -------------
+#
+# The recorded PID is a live foreign holder when --wait starts. Mid-wait its
+# synthetic /proc entry is removed, so the next poll's liveness check fails and
+# the waiter reclaims the lock — recording its own session PID.
+
+echo "Test: --wait acquires once a contended holder goes stale"
+lock_setup
+printf '%s\n' 101010 > "$DISPATCH_LOCK_FILE"
+lock_proc_pid 101010 ".claude-unwrapp"          # live foreign holder
+export DISPATCH_LOCK_SESSION_PID=101011
+lock_proc_pid 101011 ".claude-unwrapp"          # our own session
+export DISPATCH_LOCK_WAIT_INTERVAL=0.1
+export DISPATCH_LOCK_WAIT_TIMEOUT=10
+( "$TMPDIR_TEST/scripts/dispatch-acquire-lock" --wait ) >"$STUB_DIR/out10" 2>&1 &
+wait_pid=$!
+sleep 0.5
+# Holder goes away — next poll's liveness check fails, waiter reclaims.
+rm -rf "$DISPATCH_LOCK_PROC_ROOT/101010"
+wait "$wait_pid"
+out=$(cat "$STUB_DIR/out10" 2>/dev/null || true)
+assert_eq "--wait reclaim prints acquired" "acquired" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "--wait reclaim records our session PID" "101011" "$lock_contents"
+lock_teardown
+
+# --- Test 11: --release with an own-session record → released, file emptied --
+
+echo "Test: --release with an own-session record clears the lock file"
+lock_setup
+printf '%s\n' 111100 > "$DISPATCH_LOCK_FILE"
+lock_proc_pid 111100 ".claude-unwrapp"
+export DISPATCH_LOCK_SESSION_PID=111100
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" --release 2>/dev/null); rc=$?
+assert_eq "--release own-session exits 0" "0" "$rc"
+assert_eq "--release own-session prints released" "released" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ -z "$lock_contents" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: --release empties the lock file"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: --release empties the lock file"
+  echo "    lock file: '$lock_contents'"
+fi
+lock_teardown
+
+# --- Test 12: --release with a foreign PID recorded → noop, file unchanged ---
+
+echo "Test: --release with a foreign PID recorded is a no-op"
+lock_setup
+printf '%s\n' 121200 > "$DISPATCH_LOCK_FILE"
+lock_proc_pid 121200 ".claude-unwrapp"          # live foreign holder
+export DISPATCH_LOCK_SESSION_PID=121201
+lock_proc_pid 121201 ".claude-unwrapp"          # our own session
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" --release 2>/dev/null); rc=$?
+assert_eq "--release foreign exits 0" "0" "$rc"
+assert_eq "--release foreign prints noop" "noop" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "--release foreign leaves the lock file unchanged" \
+  "121200" "$lock_contents"
+lock_teardown
+
+# --- Test 13: unknown argument exits 2 ---------------------------------------
+
+echo "Test: an unknown argument exits 2"
+lock_setup
+# `set -e` is in effect: capture the exit code with an if/else.
+if ( "$TMPDIR_TEST/scripts/dispatch-acquire-lock" --bogus ) 2>/dev/null; then
+  rc=0
+else
+  rc=$?
+fi
+assert_eq "unknown argument exits 2" "2" "$rc"
 lock_teardown
 
 # ============================================================================


### PR DESCRIPTION
Closes #719

`/dispatch` Step 0 acquired a process-level lock and held it for the **entire
tick** — Step 0 through the phase skill. The lock guards only *target selection
and worktree resolution* (two ticks racing to pick the same task or adopt the
same worktree); once a session owns an issue worktree, that worktree is its
claim and per-issue phase work is already serialized by worktree ownership.
Holding the lock through the multi-minute phase skill needlessly serialized that
work, and contention *stopped* the losing tick instead of queueing it.

This turns the lock into a short-lived **selection queue**.

## Unit 1 — `dispatch-acquire-lock`: `--wait` and `--release` modes

- `--wait` polls the lock (re-running the atomic read-check-write each
  iteration) until acquired or `DISPATCH_LOCK_WAIT_TIMEOUT` (default 300s)
  elapses, instead of returning `busy` immediately. On a timeout it prints
  `busy` and writes a wait-duration + holding-PID diagnostic to stderr. Poll gap
  is `DISPATCH_LOCK_WAIT_INTERVAL` (default 5s).
- `--release` clears the recorded PID from the lock file only when it is the
  current session's own — printing `released`, else `noop`. Truncates rather
  than `rm` so a concurrent acquire's open fd is never orphaned.
- The flock + read-check-write is refactored into a `try_acquire` function using
  a command-substitution subshell with a fixed numeric fd, so the flock is
  released between polls. The no-arg `acquire` path routes through the same
  function — behavior is byte-identical to before.
- Tests 8-13 cover the new modes; the 7 original lock tests are unchanged. Full
  suite: 163/163.

## Unit 2 — `SKILL.md`: scope the lock to Steps 0-4

- Step 0 calls `dispatch-acquire-lock --wait`, so a `/dispatch` that loses the
  selection race queues behind the holder rather than bailing.
- A new "Releasing the lock" subsection states the lock covers **Steps 0-4
  only**. The lock is released via `--release` at the Step 4→5 proceed boundary
  (after the `tmp/dispatch-worktree` marker) and before every Step 1-4 stop
  path. Steps 5-7 — the phase skill and relevance review — run lock-free.

## Out of scope

The currently-wedged production `tmp/dispatch.lock` (a stale PID recorded by a
pre-#719 tick) needs a one-time manual clear before a normal `/dispatch` loop
runs clean — this PR fixes future ticks, not the existing stale record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)