### PR TITLE
dispatch: accept a PR number, resolving it to the issue it closes

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -9,8 +9,9 @@ Selects the single most pressing task, resolves its worktree, derives the curren
 workflow phase from PR/issue status, and dispatches **exactly one phase skill** —
 then stops. Re-invoke `/dispatch` (or `/loop /dispatch`) to advance to the next phase.
 
-`/dispatch` takes an **optional issue-number argument** (leading `#` optional). With
-an argument, it targets that issue and skips the queue scan.
+`/dispatch` takes an **optional issue-or-PR-number argument** (leading `#`
+optional). With an argument, it targets that issue and skips the queue scan; a
+PR number is resolved to the issue that PR closes (see Step 2).
 
 Run `/dispatch` from the **main worktree**, or from inside an issue worktree to
 continue that issue. Step 4 switches into the target's worktree via `EnterWorktree`;
@@ -102,8 +103,26 @@ merge and push are no-ops when local main already equals `origin/main`.
 
 ## 2. Select the Target
 
-- **Issue argument given** → strip any leading `#`; that issue is the target.
-  Skip the queue scan.
+- **Issue or PR argument given** → strip any leading `#`, then normalize the
+  number to a target issue via the resolver script (`dangerouslyDisableSandbox:
+  true` — it calls `gh`):
+
+  ```bash
+  TARGET=$(.claude/skills/dispatch/scripts/dispatch-resolve-arg <arg>)
+  ```
+
+  An issue number passes through unchanged; a PR number resolves to the single
+  issue that PR closes (GitHub's `Closes #N` closing-issue references). Route on
+  the exit code:
+
+  - **Exit 0** → `$TARGET` is the target issue number; that issue is the target.
+    Skip the queue scan.
+  - **Non-zero exit** → release the lock (see *Releasing the lock*), report the
+    script's stderr message, and **stop**; create no worktree. This covers a PR
+    that closes no issue, a PR that closes more than one issue, and an argument
+    that is neither an issue nor a PR — consistent with the other Step 1-4 stop
+    paths.
+
 - **No argument** → run the `origin/main` CI health gate first, then the
   worktree sweep, then target selection. Both gh-calling scripts need
   `dangerouslyDisableSandbox: true`.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -24,8 +24,8 @@ Run `gh` commands (`gh label create`, `gh pr edit`, and the scripts that invoke
 
 Run this as the **very first action** — before the `origin/main` sync, the
 `origin/main` health gate, the worktree sweep, target selection, and worktree
-resolution. Runs unconditionally, whether or not an issue-number argument was
-given.
+resolution. Runs unconditionally, whether or not an issue-or-PR-number argument
+was given.
 
 ```bash
 LOCK=$(.claude/skills/dispatch/scripts/dispatch-acquire-lock --wait)

--- a/.claude/skills/dispatch/scripts/dispatch-resolve-arg
+++ b/.claude/skills/dispatch/scripts/dispatch-resolve-arg
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Resolve a /dispatch argument (issue or PR number) to an issue number.
+# Usage: dispatch-resolve-arg <number>
+#
+# Accepts a bare integer or one with a leading '#' (stripped). Validates that
+# the result is a positive integer. On success, prints the resolved issue number
+# to stdout and exits 0.
+#
+# Discrimination: the REST issues endpoint (gh api repos/{owner}/{repo}/issues/<N>)
+# returns both issues and PRs. A PR's JSON carries a "pull_request" key; an
+# issue's JSON does not. This key is the canonical discriminator — it is more
+# reliable than branch-name conventions or gh pr view success/failure alone.
+#
+# When the number is a PR, the closing issue is resolved via:
+#   gh pr view <N> --json closingIssuesReferences
+# which returns the issues linked by "Closes #N" keywords in the PR body.
+#
+# Exit codes:
+#   0 — success; resolved issue number on stdout
+#   1 — usage error (non-numeric argument, missing argument)
+#   2 — the number is neither an open issue nor a PR (HTTP 404)
+#   3 — the number is a PR but it has no closing-issue reference (no "Closes #N")
+#   4 — the number is a PR that closes more than one issue; user must specify
+set -euo pipefail
+
+ARG="${1:-}"
+
+# Strip a single leading '#'.
+ARG="${ARG#\#}"
+
+# Validate: must be a positive integer.
+if [[ -z "$ARG" || ! "$ARG" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: usage: dispatch-resolve-arg <number> (got: '${1:-}')" >&2
+  exit 1
+fi
+
+N="$ARG"
+
+# Fetch the issue/PR metadata from the REST issues endpoint.
+# The issues endpoint returns PRs too; the "pull_request" key distinguishes them.
+# A 404 means the number is neither an issue nor a PR.
+if issue_json=$(gh api "repos/{owner}/{repo}/issues/$N" 2>/dev/null); then
+  :
+else
+  echo "error: #$N is neither an issue nor a PR (not found in this repository)" >&2
+  exit 2
+fi
+
+# Determine whether it is a PR or an issue.
+if echo "$issue_json" | jq -e 'has("pull_request")' > /dev/null 2>&1; then
+  # It is a PR — resolve to the closing issue.
+  closing_json=$(gh pr view "$N" --json closingIssuesReferences)
+  count=$(echo "$closing_json" | jq '.closingIssuesReferences | length')
+
+  if [[ "$count" -eq 0 ]]; then
+    echo "error: PR #$N has no closing-issue reference (no 'Closes #N' keyword found)" >&2
+    exit 3
+  fi
+
+  if [[ "$count" -gt 1 ]]; then
+    closing_nums=$(echo "$closing_json" | jq -r '.closingIssuesReferences[].number' | tr '\n' ' ' | sed 's/ $//')
+    echo "error: PR #$N closes multiple issues ($closing_nums); pass the specific issue number instead" >&2
+    exit 4
+  fi
+
+  # Exactly one closing issue — print it.
+  echo "$closing_json" | jq -r '.closingIssuesReferences[0].number'
+else
+  # It is an issue — pass through.
+  echo "$N"
+fi

--- a/.claude/skills/dispatch/scripts/dispatch-resolve-arg
+++ b/.claude/skills/dispatch/scripts/dispatch-resolve-arg
@@ -17,18 +17,16 @@
 #
 # Exit codes:
 #   0 — success; resolved issue number on stdout
-#   1 — usage error (non-numeric argument, missing argument)
+#   1 — usage error (bad argument), or the issue/PR lookup failed for a
+#       non-404 reason (auth, network)
 #   2 — the number is neither an open issue nor a PR (HTTP 404)
 #   3 — the number is a PR but it has no closing-issue reference (no "Closes #N")
 #   4 — the number is a PR that closes more than one issue; user must specify
 set -euo pipefail
 
 ARG="${1:-}"
-
-# Strip a single leading '#'.
 ARG="${ARG#\#}"
 
-# Validate: must be a positive integer.
 if [[ -z "$ARG" || ! "$ARG" =~ ^[1-9][0-9]*$ ]]; then
   echo "error: usage: dispatch-resolve-arg <number> (got: '${1:-}')" >&2
   exit 1
@@ -36,21 +34,21 @@ fi
 
 N="$ARG"
 
-# Fetch the issue/PR metadata from the REST issues endpoint.
-# The issues endpoint returns PRs too; the "pull_request" key distinguishes them.
-# A 404 means the number is neither an issue nor a PR.
-if issue_json=$(gh api "repos/{owner}/{repo}/issues/$N" 2>/dev/null); then
-  :
-else
-  echo "error: #$N is neither an issue nor a PR (not found in this repository)" >&2
-  exit 2
+# A 404 means the number is neither an issue nor a PR; any other gh failure
+# (auth, network) is surfaced as a distinct error rather than misreported as
+# "not found".
+if ! issue_json=$(gh api "repos/{owner}/{repo}/issues/$N" 2>&1); then
+  if [[ "$issue_json" == *404* || "$issue_json" == *"Not Found"* ]]; then
+    echo "error: #$N is neither an issue nor a PR (not found in this repository)" >&2
+    exit 2
+  fi
+  echo "error: failed to look up #$N: $issue_json" >&2
+  exit 1
 fi
 
-# Determine whether it is a PR or an issue.
-if echo "$issue_json" | jq -e 'has("pull_request")' > /dev/null 2>&1; then
-  # It is a PR — resolve to the closing issue.
+if printf '%s' "$issue_json" | jq -e 'has("pull_request")' > /dev/null 2>&1; then
   closing_json=$(gh pr view "$N" --json closingIssuesReferences)
-  count=$(echo "$closing_json" | jq '.closingIssuesReferences | length')
+  count=$(printf '%s' "$closing_json" | jq '.closingIssuesReferences | length')
 
   if [[ "$count" -eq 0 ]]; then
     echo "error: PR #$N has no closing-issue reference (no 'Closes #N' keyword found)" >&2
@@ -58,14 +56,12 @@ if echo "$issue_json" | jq -e 'has("pull_request")' > /dev/null 2>&1; then
   fi
 
   if [[ "$count" -gt 1 ]]; then
-    closing_nums=$(echo "$closing_json" | jq -r '.closingIssuesReferences[].number' | tr '\n' ' ' | sed 's/ $//')
+    closing_nums=$(printf '%s' "$closing_json" | jq -r '[.closingIssuesReferences[].number] | join(" ")')
     echo "error: PR #$N closes multiple issues ($closing_nums); pass the specific issue number instead" >&2
     exit 4
   fi
 
-  # Exactly one closing issue — print it.
-  echo "$closing_json" | jq -r '.closingIssuesReferences[0].number'
+  printf '%s' "$closing_json" | jq -r '.closingIssuesReferences[0].number'
 else
-  # It is an issue — pass through.
   echo "$N"
 fi

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -153,11 +153,15 @@ case "$args" in
   api\ repos/*/issues/*)
     # dispatch-resolve-arg discriminator: gh api repos/{owner}/{repo}/issues/<N>.
     # The REST issues endpoint returns PRs too; a PR's JSON carries a
-    # "pull_request" key. The fixture file decides issue-vs-PR; absence of a
-    # fixture models a 404 (the number is neither an issue nor a PR).
+    # "pull_request" key. The fixture file decides issue-vs-PR; an arg-issue-<N>.err
+    # fixture models a non-404 gh failure; absence of either fixture models a 404
+    # (the number is neither an issue nor a PR).
     num="${args##*/}"
     if [[ -f "$STUB_DIR/arg-issue-${num}.json" ]]; then
       cat "$STUB_DIR/arg-issue-${num}.json"
+    elif [[ -f "$STUB_DIR/arg-issue-${num}.err" ]]; then
+      cat "$STUB_DIR/arg-issue-${num}.err" >&2
+      exit 1
     else
       echo "gh: Not Found (HTTP 404)" >&2
       exit 1
@@ -590,6 +594,21 @@ echo "Test: non-numeric argument → exit 1"
 setup
 if ( "$TMPDIR_TEST/dispatch-resolve-arg" "abc" ) >/dev/null 2>&1; then rc=0; else rc=$?; fi
 assert_eq "non-numeric argument → exit 1" "1" "$rc"
+teardown
+
+# 8. Missing argument → exit 1.
+echo "Test: missing argument → exit 1"
+setup
+if ( "$TMPDIR_TEST/dispatch-resolve-arg" ) >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "missing argument → exit 1" "1" "$rc"
+teardown
+
+# 9. Non-404 gh failure (auth/network) → exit 1, not misreported as exit 2.
+echo "Test: non-404 lookup failure → exit 1"
+setup
+printf 'gh: HTTP 503: Service unavailable\n' > "$STUB_DIR/arg-issue-998.err"
+if ( "$TMPDIR_TEST/dispatch-resolve-arg" "998" ) >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "non-404 lookup failure → exit 1" "1" "$rc"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -49,12 +49,14 @@ setup() {
   # via SCRIPT_DIR resolution without relying on the real filesystem PATH.
   cp "$SCRIPT_DIR/dispatch-phase" "$TMPDIR_TEST/dispatch-phase"
   cp "$SCRIPT_DIR/dispatch-find-pr" "$TMPDIR_TEST/dispatch-find-pr"
+  cp "$SCRIPT_DIR/dispatch-resolve-arg" "$TMPDIR_TEST/dispatch-resolve-arg"
   cp "$SCRIPT_DIR/dispatch-select-target" "$TMPDIR_TEST/dispatch-select-target"
   cp "$SCRIPT_DIR/dispatch-trace-leaf" "$TMPDIR_TEST/dispatch-trace-leaf"
   cp "$SCRIPT_DIR/dispatch-complete-phase" "$TMPDIR_TEST/dispatch-complete-phase"
   cp "$SCRIPT_DIR/dispatch-resolve-worktree" "$TMPDIR_TEST/dispatch-resolve-worktree"
   chmod +x "$TMPDIR_TEST/dispatch-phase" \
            "$TMPDIR_TEST/dispatch-find-pr" \
+           "$TMPDIR_TEST/dispatch-resolve-arg" \
            "$TMPDIR_TEST/dispatch-select-target" \
            "$TMPDIR_TEST/dispatch-trace-leaf" \
            "$TMPDIR_TEST/dispatch-complete-phase" \
@@ -146,6 +148,28 @@ case "$args" in
       cat "$STUB_DIR/subissues-${num}.json"
     else
       echo "[]"
+    fi
+    ;;
+  api\ repos/*/issues/*)
+    # dispatch-resolve-arg discriminator: gh api repos/{owner}/{repo}/issues/<N>.
+    # The REST issues endpoint returns PRs too; a PR's JSON carries a
+    # "pull_request" key. The fixture file decides issue-vs-PR; absence of a
+    # fixture models a 404 (the number is neither an issue nor a PR).
+    num="${args##*/}"
+    if [[ -f "$STUB_DIR/arg-issue-${num}.json" ]]; then
+      cat "$STUB_DIR/arg-issue-${num}.json"
+    else
+      echo "gh: Not Found (HTTP 404)" >&2
+      exit 1
+    fi
+    ;;
+  pr\ view\ *\ --json\ closingIssuesReferences)
+    # dispatch-resolve-arg PR branch: gh pr view <N> --json closingIssuesReferences.
+    num=$(echo "$args" | awk '{print $3}')
+    if [[ -f "$STUB_DIR/arg-closing-${num}.json" ]]; then
+      cat "$STUB_DIR/arg-closing-${num}.json"
+    else
+      echo '{"closingIssuesReferences":[]}'
     fi
     ;;
   label\ create\ *)
@@ -500,6 +524,72 @@ setup
 printf '[{"number":10,"headRefName":"60-foo"}]\n' > "$STUB_DIR/pr-list-full.json"
 result=$("$TMPDIR_TEST/dispatch-find-pr" "6")
 assert_eq "issue 6 does not match branch 60-foo → empty" "" "$result"
+teardown
+
+# ============================================================================
+# dispatch-resolve-arg tests
+# ============================================================================
+echo ""
+echo "=== dispatch-resolve-arg ==="
+
+# 1. Issue argument → stdout is the number unchanged, exit 0.
+echo "Test: issue number → passes through unchanged"
+setup
+printf '{"number":736,"state":"open"}\n' > "$STUB_DIR/arg-issue-736.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-arg" "736")
+assert_eq "issue number → passes through" "736" "$result"
+teardown
+
+# 2. Leading '#' is tolerated → same resolution as bare number.
+echo "Test: leading '#' is stripped and resolves correctly"
+setup
+printf '{"number":736,"state":"open"}\n' > "$STUB_DIR/arg-issue-736.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-arg" "#736")
+assert_eq "leading '#' stripped → issue number" "736" "$result"
+teardown
+
+# 3. PR closing exactly one issue → stdout is the closing issue number.
+# PR 717 closes issue 715.
+echo "Test: PR closing one issue → that issue number"
+setup
+printf '{"number":717,"pull_request":{}}\n' > "$STUB_DIR/arg-issue-717.json"
+printf '{"closingIssuesReferences":[{"number":715}]}\n' > "$STUB_DIR/arg-closing-717.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-arg" "717")
+assert_eq "PR closing one issue → closing issue number" "715" "$result"
+teardown
+
+# 4. PR closing zero issues → exit 3.
+# arg-closing-718.json explicitly carries an empty array to model zero references.
+echo "Test: PR with no closing issue → exit 3"
+setup
+printf '{"number":718,"pull_request":{}}\n' > "$STUB_DIR/arg-issue-718.json"
+printf '{"closingIssuesReferences":[]}\n' > "$STUB_DIR/arg-closing-718.json"
+if ( "$TMPDIR_TEST/dispatch-resolve-arg" "718" ) >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "PR closing zero issues → exit 3" "3" "$rc"
+teardown
+
+# 5. PR closing multiple issues → exit 4.
+echo "Test: PR closing multiple issues → exit 4"
+setup
+printf '{"number":719,"pull_request":{}}\n' > "$STUB_DIR/arg-issue-719.json"
+printf '{"closingIssuesReferences":[{"number":700},{"number":701}]}\n' > "$STUB_DIR/arg-closing-719.json"
+if ( "$TMPDIR_TEST/dispatch-resolve-arg" "719" ) >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "PR closing multiple issues → exit 4" "4" "$rc"
+teardown
+
+# 6. Number is neither an issue nor a PR (no fixture → stub 404s) → exit 2.
+echo "Test: unknown number → exit 2"
+setup
+# No arg-issue-999.json: the stub returns 404.
+if ( "$TMPDIR_TEST/dispatch-resolve-arg" "999" ) >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "neither issue nor PR → exit 2" "2" "$rc"
+teardown
+
+# 7. Non-numeric argument → exit 1.
+echo "Test: non-numeric argument → exit 1"
+setup
+if ( "$TMPDIR_TEST/dispatch-resolve-arg" "abc" ) >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "non-numeric argument → exit 1" "1" "$rc"
 teardown
 
 # ============================================================================


### PR DESCRIPTION
Closes #736

`/dispatch` documents its optional argument as an issue number, but every
downstream `dispatch-*` script keys on the `<issue>-<slug>` branch convention.
Passing a PR number silently misbehaved — `dispatch-find-pr` found no branch,
`dispatch-phase` derived `implement`, and `dispatch-resolve-worktree` created a
fresh empty worktree on a wrong `<pr#>-…` branch.

This adds a `dispatch-resolve-arg` helper that normalizes the `/dispatch`
argument before any downstream script runs:

- An issue number passes through unchanged.
- A PR number resolves to the single issue it closes, via GitHub's `Closes #N`
  closing-issue references (`gh pr view --json closingIssuesReferences`).
- Issue vs PR is discriminated by the `pull_request` key on the REST issues
  endpoint (which returns PRs too).
- A PR closing zero issues, a PR closing multiple issues, or a number that is
  neither each stop `/dispatch` with a clear error and create no worktree.

`SKILL.md` Step 2's argument branch is wired to the new script; the no-argument
queue path is untouched. `test-dispatch-scripts.sh` gains gh-stub arms and a
7-case section covering issue pass-through, leading-`#` tolerance, PR→issue
resolution, and the zero/multiple/not-found/non-numeric error paths.