### PR TITLE
ci: extend go-tests to cover all Go modules

### DIFF
--- a/.claude/skills/dispatch/scripts/detect-changes.sh
+++ b/.claude/skills/dispatch/scripts/detect-changes.sh
@@ -32,13 +32,10 @@ fi
 if echo "$CHANGED" | grep -qE '^(firestore\.rules$|storage\.rules$|rules-test/|\.claude/skills/dispatch/scripts/|firebase\.json$|package\.json$|package-lock\.json$)'; then
   echo "rules=true" >> "$GITHUB_OUTPUT"
 fi
-# go-tests needs the Go toolchain. Set go=true when any file under a Go module
-# changed. Module roots are discovered from go.mod locations, so a new Go
-# module needs no edit here.
-GO_MODULE_PREFIXES=$(
-  find . -name go.mod -not -path './node_modules/*' \
-    -exec dirname {} \; | sed 's|^\./||; s|$|/|'
-)
+# go-tests needs the Go toolchain. Set go=true when a changed file is under a
+# discovered Go module. list-go-modules.sh discovers module roots from go.mod
+# locations, so a new Go module needs no edit here.
+GO_MODULE_PREFIXES=$("$(dirname "$0")/list-go-modules.sh" | sed 's|$|/|')
 if [ -n "$GO_MODULE_PREFIXES" ]; then
   GO_REGEX=$(printf '%s\n' "$GO_MODULE_PREFIXES" | paste -sd'|' -)
   if echo "$CHANGED" | grep -qE "^($GO_REGEX)"; then

--- a/.claude/skills/dispatch/scripts/detect-changes.sh
+++ b/.claude/skills/dispatch/scripts/detect-changes.sh
@@ -32,8 +32,16 @@ fi
 if echo "$CHANGED" | grep -qE '^(firestore\.rules$|storage\.rules$|rules-test/|\.claude/skills/dispatch/scripts/|firebase\.json$|package\.json$|package-lock\.json$)'; then
   echo "rules=true" >> "$GITHUB_OUTPUT"
 fi
-# go-tests needs the Go toolchain. The budget-etl module is not a package.json
-# workspace, so set go=true when anything in budget-etl/ changed.
-if echo "$CHANGED" | grep -qE '^budget-etl/'; then
-  echo "go=true" >> "$GITHUB_OUTPUT"
+# go-tests needs the Go toolchain. Set go=true when any file under a Go module
+# changed. Module roots are discovered from go.mod locations, so a new Go
+# module needs no edit here.
+GO_MODULE_PREFIXES=$(
+  find . -name go.mod -not -path './node_modules/*' \
+    -exec dirname {} \; | sed 's|^\./||; s|$|/|'
+)
+if [ -n "$GO_MODULE_PREFIXES" ]; then
+  GO_REGEX=$(printf '%s\n' "$GO_MODULE_PREFIXES" | paste -sd'|' -)
+  if echo "$CHANGED" | grep -qE "^($GO_REGEX)"; then
+    echo "go=true" >> "$GITHUB_OUTPUT"
+  fi
 fi

--- a/.claude/skills/dispatch/scripts/list-go-modules.sh
+++ b/.claude/skills/dispatch/scripts/list-go-modules.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Print each Go module's directory (one per go.mod found in the repo),
+# relative to the repo root, sorted. The go-tests CI job and detect-changes.sh
+# both consume this, so the change gate and the test runner agree on the
+# module set from a single definition — adding a Go module needs no edit here.
+cd "$(git rev-parse --show-toplevel)"
+find . -name go.mod -not -path './node_modules/*' \
+  -exec dirname {} \; | sed 's|^\./||' | sort

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -121,9 +121,17 @@ jobs:
         if: steps.changes.outputs.go == 'true'
         run: |
           set -euo pipefail
+          # Capture the module list first: a discovery failure aborts under
+          # set -e, and an empty result fails explicitly — feeding the loop
+          # via process substitution would instead pass the job silently.
+          modules=$(.claude/skills/dispatch/scripts/list-go-modules.sh)
+          if [ -z "$modules" ]; then
+            echo "::error::No Go modules discovered by list-go-modules.sh"
+            exit 1
+          fi
           failed=0
           while IFS= read -r dir; do
             echo "=== go test: $dir ==="
             (cd "$dir" && go test ./...) || failed=1
-          done < <(.claude/skills/dispatch/scripts/list-go-modules.sh)
+          done <<< "$modules"
           exit "$failed"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Detect changed file categories
         id: changes
         run: .claude/skills/dispatch/scripts/detect-changes.sh
-      - name: Set up Go
+      - name: Set up Go (if Go files changed)
         if: steps.changes.outputs.go == 'true'
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
@@ -122,9 +122,8 @@ jobs:
         run: |
           set -euo pipefail
           failed=0
-          while IFS= read -r modfile; do
-            dir=$(dirname "$modfile")
+          while IFS= read -r dir; do
             echo "=== go test: $dir ==="
             (cd "$dir" && go test ./...) || failed=1
-          done < <(find . -name go.mod -not -path './node_modules/*' | sort)
+          done < <(.claude/skills/dispatch/scripts/list-go-modules.sh)
           exit "$failed"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -112,12 +112,19 @@ jobs:
       - name: Detect changed file categories
         id: changes
         run: .claude/skills/dispatch/scripts/detect-changes.sh
-      - name: Set up Go (if budget-etl changed)
+      - name: Set up Go
         if: steps.changes.outputs.go == 'true'
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version-file: budget-etl/go.mod
+          go-version: stable
       - name: Run Go tests
         if: steps.changes.outputs.go == 'true'
-        run: go test ./...
-        working-directory: budget-etl
+        run: |
+          set -euo pipefail
+          failed=0
+          while IFS= read -r modfile; do
+            dir=$(dirname "$modfile")
+            echo "=== go test: $dir ==="
+            (cd "$dir" && go test ./...) || failed=1
+          done < <(find . -name go.mod -not -path './node_modules/*' | sort)
+          exit "$failed"


### PR DESCRIPTION
Closes #514

## Summary

The `go-tests` CI job in `unit-tests.yml` and the `go=true` detection in
`detect-changes.sh` were both hardcoded to the `budget-etl` module. Changes to
the repo's other two Go modules — `scaffolding/firebase` and `productivity-tui`,
each with its own `go.mod` and passing test suite — never ran `go test` in CI
and could break silently.

## Changes

- **`detect-changes.sh`** — discovers Go module roots from `go.mod` locations
  and sets `go=true` when a changed path is prefixed by any module root, not
  only `budget-etl/`.
- **`unit-tests.yml`** — the `go-tests` job sets up a single Go toolchain
  (`go-version: stable`, satisfying all modules' `go` directives) and runs
  `go test ./...` in every discovered `go.mod` module, printing a per-module
  header and failing the job if any module fails.

Modules are discovered from `go.mod` locations, so a future Go module needs no
CI edit.

## Verification

All three modules' `go test ./...` pass locally:
- `budget-etl` — green
- `scaffolding/firebase` — green
- `productivity-tui` — green