### PR TITLE
dispatch: prioritize queue selection by topic category

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -168,12 +168,23 @@ merge and push are no-ops when local main already equals `origin/main`.
   script, and therefore its current-worktree detection, runs only when no argument is
   given. `/dispatch #123` run from inside worktree-456 still targets 123.
 
-  Priority order it implements (highest first; within a tier, oldest PR wins; PRs
-  and `help wanted` issues with a local worktree are skipped; `waiting`-phase PRs are skipped entirely):
-  oldest `security` PR → oldest `review` PR → oldest `simplify` PR → oldest
-  `verify` PR → oldest `help wanted` issue → oldest `qa` PR → `empty`. Non-QA PRs
-  are ranked closest-to-done first — `security` is the closest-to-done non-QA
-  tier; `help wanted` issues rank below all non-QA PRs but above QA PRs.
+  Priority order it implements is two-tier: a topic **category** nests outside
+  the phase **ladder**. Categories, highest priority first: `bug` → `testing
+  infrastructure` → `dispatch` → `other`. A PR's category is the highest-priority
+  topic among the labels of every issue it closes; an issue's category is the
+  highest-priority topic among its own labels; anything with no topic label is
+  `other`. The selector exhausts one category's whole ladder before moving to
+  the next.
+
+  Within each category the ladder is (highest first; within a tier, oldest PR
+  wins; PRs and `help wanted` issues with a local worktree are skipped;
+  `waiting`-phase PRs are skipped entirely): oldest `security` PR → oldest
+  `review` PR → oldest `simplify` PR → oldest `verify` PR → oldest `help wanted`
+  issue → oldest `qa` PR. Non-QA PRs are ranked closest-to-done first —
+  `security` is the closest-to-done non-QA tier; `help wanted` issues rank below
+  all non-QA PRs but above QA PRs. A queue with no topic-labeled items resolves
+  entirely to `other`, reproducing the flat ladder; `empty` when no category
+  yields a task.
 
   On `empty` → release the lock (see *Releasing the lock*), then report that
   the queue is empty and **stop**.

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -26,7 +26,17 @@
 # --qa mode omits the <phase> field — there it is always "qa":
 #   pr <num> <branch>           — the QA PR to work on
 #
-# Default mode priority (highest first; within a tier, oldest PR wins):
+# Selection is two-tier: a topic *category* nests outside the phase *ladder*.
+# Categories, highest priority first:
+#   bug → testing infrastructure → dispatch → other
+# The selector exhausts every tier of one category before moving to the next.
+#
+# A PR's category is the highest-priority topic among the labels of every issue
+# it closes (closingIssuesReferences); a PR that closes no issue, or whose
+# closing issues carry no topic label, is "other". An issue's category is the
+# highest-priority topic among its own labels, else "other".
+#
+# Within each category, default-mode priority (oldest PR wins within a tier):
 #   1. Oldest "security" PR (draft + dispatch:reviewed or dispatch:security-reviewed)
 #   2. Oldest "review"   PR (draft + dispatch:refactored)
 #   3. Oldest "simplify" PR (draft + dispatch:qa-done)
@@ -38,9 +48,11 @@
 # actively working them).
 # "done" (non-draft) PRs are skipped entirely.
 # "waiting" PRs (draft, CI still running/queued/not started) are skipped entirely.
+# A queue with no topic-labeled items resolves entirely to "other", reproducing
+# the flat ladder exactly.
 #
 # --qa mode priority:
-#   1. Oldest QA PR with no local git worktree
+#   1. Oldest QA PR in the highest-priority category that has one
 #   2. empty
 set -euo pipefail
 
@@ -177,18 +189,68 @@ issue_has_worktree() {
 # Fetch all open PRs once, with the union of fields this script and
 # dispatch-phase need. Each per-PR dispatch-phase call below reuses it
 # (passed as DISPATCH_PR_LIST) instead of re-running gh pr list.
-PR_LIST=$(gh pr list --state open --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels)
-PR_SORTED=$(printf '%s' "$PR_LIST" | jq -r 'sort_by(.createdAt) | .[] | [.number, .createdAt, .headRefName] | @tsv')
+# closingIssuesReferences drives topic-category resolution: a PR inherits the
+# highest-priority topic among the labels of every issue it closes.
+PR_LIST=$(gh pr list --state open --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels,closingIssuesReferences)
+PR_SORTED=$(printf '%s' "$PR_LIST" | jq -r 'sort_by(.createdAt) | .[] | [.number, .createdAt, .headRefName, (.closingIssuesReferences | tojson)] | @tsv')
 
-# First-seen PR per phase: key = phase name, value = "<num> <branch>". The PR
-# list is pre-sorted oldest-first, so the first PR captured for a phase is
-# always the oldest in that phase.
+# Fetch every open issue once, carrying labels. This single list serves two
+# roles: filtered client-side to "help wanted" it is the issue queue; indexed
+# number → labels it is the map that resolves each PR's topic category from its
+# closing issues. --limit 300 covers the full open-issue set (gh's default of
+# 30 would silently truncate a ~30-item queue).
+ISSUE_LIST=$(gh issue list --state open --limit 300 --json number,createdAt,labels)
+
+# number → labels-JSON map, built from the open-issue list above. Assigned to a
+# variable first so a jq failure aborts here (set -e + pipefail); mirrors
+# PR_SORTED.
+declare -A ISSUE_LABELS
+ISSUE_LABEL_ROWS=$(printf '%s' "$ISSUE_LIST" | jq -r '.[] | [.number, ((.labels // []) | tojson)] | @tsv')
+while IFS=$'\t' read -r _inum _ilabels; do
+  [[ -z "$_inum" ]] && continue
+  ISSUE_LABELS["$_inum"]="$_ilabels"
+done <<< "$ISSUE_LABEL_ROWS"
+
+# Topic categories, highest priority first. A category tier nests *outside* the
+# phase ladder: the selector exhausts every phase of "bug" before considering
+# "testing infrastructure", and so on.
+CATEGORIES=(bug "testing infrastructure" dispatch other)
+
+# Highest-priority topic category among a JSON array of {name:...} label
+# objects. Exact name match, so the phase label "dispatch:reviewed" never reads
+# as topic "dispatch". A labels array with no topic label resolves to "other".
+category_of_labels() {
+  printf '%s' "$1" | jq -r '
+    [(.[] | .name)] as $names
+    | if   ($names | index("bug")) then "bug"
+      elif ($names | index("testing infrastructure")) then "testing infrastructure"
+      elif ($names | index("dispatch")) then "dispatch"
+      else "other" end'
+}
+
+# Topic category of a PR, from the union of its closing issues' labels. A PR
+# that closes no issue — or whose closing issues carry no topic label —
+# resolves to "other".
+pr_category() {
+  local closing="$1" combined='[]' n lbls
+  for n in $(printf '%s' "$closing" | jq -r '.[].number'); do
+    lbls="${ISSUE_LABELS[$n]:-[]}"
+    combined=$(jq -nc --argjson a "$combined" --argjson b "$lbls" '$a + $b')
+  done
+  category_of_labels "$combined"
+}
+
+# First-seen PR per (category, phase): key = "<category>|<phase>", value =
+# "<num> <branch>". Both lists are pre-sorted oldest-first, so the first PR
+# captured for a key is the oldest in that category+phase.
 declare -A FIRST_PR
+# First-seen help-wanted issue per category: key = category, value = "<num>".
+declare -A FIRST_ISSUE
 
-# Default-mode selection order among PR phases (highest priority first).
+# Within-category phase ladder, highest priority first.
 PHASE_PRIORITY=(security review simplify verify)
 
-while IFS=$'\t' read -r pr_num _created pr_branch; do
+while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   [[ -z "$pr_num" ]] && continue
 
   # Skip PRs with a local worktree.
@@ -204,54 +266,66 @@ while IFS=$'\t' read -r pr_num _created pr_branch; do
     done|waiting) continue ;;
   esac
 
-  # Record the oldest PR seen in this phase. The :- guard keeps the unset-key
-  # read from aborting under set -u.
-  [[ -z "${FIRST_PR[$phase]:-}" ]] && FIRST_PR[$phase]="$pr_num $pr_branch"
+  # Record the oldest PR seen in this category+phase. The :- guard keeps the
+  # unset-key read from aborting under set -u.
+  pr_cat=$(pr_category "$pr_closing")
+  pr_key="$pr_cat|$phase"
+  [[ -z "${FIRST_PR[$pr_key]:-}" ]] && FIRST_PR[$pr_key]="$pr_num $pr_branch"
 done <<< "$PR_SORTED"
 
-if [[ "$QA_MODE" == "true" ]]; then
-  # --qa mode: only return QA PRs, without the <phase> field.
-  if [[ -n "${FIRST_PR[qa]:-}" ]]; then
-    echo "pr ${FIRST_PR[qa]}"
-  else
-    echo "empty"
-  fi
-  exit 0
-fi
-
-# Default mode: security → review → simplify → verify →
-#               help-wanted issue → qa → empty.
-for phase in "${PHASE_PRIORITY[@]}"; do
-  if [[ -n "${FIRST_PR[$phase]:-}" ]]; then
-    echo "pr ${FIRST_PR[$phase]} $phase"
-    exit 0
-  fi
-done
-
-# Fetch help-wanted issues oldest-first; pick the oldest with no local worktree.
-ISSUE_LIST=$(gh issue list --label "help wanted" --state open --json number,createdAt)
-# Sort into a variable first so a jq failure aborts here (set -e + pipefail);
-# a process substitution would swallow it as empty input. Mirrors PR_SORTED.
-ISSUE_NUMS_SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[].number')
-ISSUE_NUM=""
-while IFS= read -r issue_num; do
+# First-seen help-wanted issue per category. The queue is the open-issue list
+# filtered client-side to "help wanted"; issues whose <N>-* worktree exists
+# (a session is working them) are skipped, exactly as before.
+ISSUE_SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r '
+  sort_by(.createdAt) | .[]
+  | select((.labels // []) | any(.name == "help wanted"))
+  | [.number, ((.labels // []) | tojson)] | @tsv')
+while IFS=$'\t' read -r issue_num issue_labels; do
   [[ -z "$issue_num" ]] && continue
   # Skip issues whose <N>-* worktree exists (a session is working them).
   if issue_has_worktree "$issue_num"; then
     continue
   fi
-  ISSUE_NUM="$issue_num"
-  break
-done <<< "$ISSUE_NUMS_SORTED"
+  issue_cat=$(category_of_labels "$issue_labels")
+  [[ -z "${FIRST_ISSUE[$issue_cat]:-}" ]] && FIRST_ISSUE[$issue_cat]="$issue_num"
+done <<< "$ISSUE_SORTED"
 
-if [[ -n "$ISSUE_NUM" ]]; then
-  echo "issue $ISSUE_NUM"
+if [[ "$QA_MODE" == "true" ]]; then
+  # --qa mode: oldest QA PR in the highest-priority category that has one,
+  # without the <phase> field.
+  for category in "${CATEGORIES[@]}"; do
+    qa_key="$category|qa"
+    if [[ -n "${FIRST_PR[$qa_key]:-}" ]]; then
+      echo "pr ${FIRST_PR[$qa_key]}"
+      exit 0
+    fi
+  done
+  echo "empty"
   exit 0
 fi
 
-if [[ -n "${FIRST_PR[qa]:-}" ]]; then
-  echo "pr ${FIRST_PR[qa]} qa"
-  exit 0
-fi
+# Default mode: iterate categories outermost; within each, the ladder
+# security → review → simplify → verify → help-wanted issue → qa. The first
+# category with any eligible task wins.
+for category in "${CATEGORIES[@]}"; do
+  for phase in "${PHASE_PRIORITY[@]}"; do
+    pr_key="$category|$phase"
+    if [[ -n "${FIRST_PR[$pr_key]:-}" ]]; then
+      echo "pr ${FIRST_PR[$pr_key]} $phase"
+      exit 0
+    fi
+  done
+
+  if [[ -n "${FIRST_ISSUE[$category]:-}" ]]; then
+    echo "issue ${FIRST_ISSUE[$category]}"
+    exit 0
+  fi
+
+  qa_key="$category|qa"
+  if [[ -n "${FIRST_PR[$qa_key]:-}" ]]; then
+    echo "pr ${FIRST_PR[$qa_key]} qa"
+    exit 0
+  fi
+done
 
 echo "empty"

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -204,48 +204,50 @@ PR_SORTED=$(printf '%s' "$PR_LIST" | jq -r 'sort_by(.createdAt) | .[] | [.number
 # 30 would silently truncate a ~30-item queue).
 ISSUE_LIST=$(gh issue list --state open --limit 300 --json number,createdAt,labels)
 
-# number → labels-JSON map, built from the open-issue list above. Assigned to a
-# variable first so a jq failure aborts here (set -e + pipefail); mirrors
-# PR_SORTED.
-declare -A ISSUE_LABELS
-ISSUE_LABEL_ROWS=$(printf '%s' "$ISSUE_LIST" | jq -r '.[] | [.number, ((.labels // []) | tojson)] | @tsv')
-while IFS=$'\t' read -r _inum _ilabels; do
-  [[ -z "$_inum" ]] && continue
-  ISSUE_LABELS["$_inum"]="$_ilabels"
-done <<< "$ISSUE_LABEL_ROWS"
+# number → labels-array map as a JSON object, built once from the open-issue
+# list above. pr_category indexes it to resolve each PR's closing issues'
+# labels. Assigned to a variable first so a jq failure aborts here (set -e +
+# pipefail); mirrors PR_SORTED.
+ISSUE_LABELS_JSON=$(printf '%s' "$ISSUE_LIST" \
+  | jq -c 'reduce .[] as $i ({}; .[$i.number | tostring] = ($i.labels // []))')
 
-# Topic categories, highest priority first. A category tier nests *outside* the
-# phase ladder: the selector exhausts every phase of "bug" before considering
-# "testing infrastructure", and so on.
-CATEGORIES=(bug "testing infrastructure" dispatch other)
+# Topic categories in priority order; "other" is the implicit fallback for any
+# label set with no topic label. A category tier nests *outside* the phase
+# ladder: the selector exhausts every phase of "bug" before considering
+# "testing infrastructure", and so on. TOPIC_CATEGORIES is the single source of
+# the ordering — category_of_labels resolves against it and the default-mode
+# loop iterates CATEGORIES. The companion classifier that *applies* these
+# labels is ref-ready SKILL.md Step 6; keep the two label sets in sync.
+TOPIC_CATEGORIES=(bug "testing infrastructure" dispatch)
+CATEGORIES=("${TOPIC_CATEGORIES[@]}" other)
+# Same priority list as a JSON array, for category_of_labels' jq filter.
+TOPIC_CATEGORIES_JSON=$(printf '%s\n' "${TOPIC_CATEGORIES[@]}" | jq -Rcn '[inputs]')
 
 # Highest-priority topic category among a JSON array of {name:...} label
-# objects. Exact name match, so the phase label "dispatch:reviewed" never reads
-# as topic "dispatch". A labels array with no topic label resolves to "other".
+# objects — the first TOPIC_CATEGORIES entry that appears as an exact label
+# name, else "other". Exact match, so the phase label "dispatch:reviewed" never
+# reads as topic "dispatch".
 category_of_labels() {
-  printf '%s' "$1" | jq -r '
-    [(.[] | .name)] as $names
-    | if   ($names | index("bug")) then "bug"
-      elif ($names | index("testing infrastructure")) then "testing infrastructure"
-      elif ($names | index("dispatch")) then "dispatch"
-      else "other" end'
+  printf '%s' "$1" | jq -r --argjson cats "$TOPIC_CATEGORIES_JSON" '
+    [.[].name] as $names
+    | first($cats[] | select(. as $c | $names | index($c))) // "other"'
 }
 
-# Topic category of a PR, from the union of its closing issues' labels. A PR
-# that closes no issue — or whose closing issues carry no topic label —
-# resolves to "other".
+# Topic category of a PR: the union of its closing issues' labels, resolved by
+# category_of_labels. A PR that closes no issue — or whose closing issues carry
+# no topic label — resolves to "other".
 pr_category() {
-  local closing="$1" combined='[]' n lbls
-  for n in $(printf '%s' "$closing" | jq -r '.[].number'); do
-    lbls="${ISSUE_LABELS[$n]:-[]}"
-    combined=$(jq -nc --argjson a "$combined" --argjson b "$lbls" '$a + $b')
-  done
+  local combined
+  combined=$(printf '%s' "$1" | jq -c --argjson map "$ISSUE_LABELS_JSON" \
+    '[.[].number | tostring as $n | $map[$n] // [] | .[]]')
   category_of_labels "$combined"
 }
 
 # First-seen PR per (category, phase): key = "<category>|<phase>", value =
-# "<num> <branch>". Both lists are pre-sorted oldest-first, so the first PR
-# captured for a key is the oldest in that category+phase.
+# "<num> <branch>". The "|" separator is collision-free — phase names are fixed
+# identifiers and no TOPIC_CATEGORIES name contains "|". Both lists are
+# pre-sorted oldest-first, so the first PR captured for a key is the oldest in
+# that category+phase.
 declare -A FIRST_PR
 # First-seen help-wanted issue per category: key = category, value = "<num>".
 declare -A FIRST_ISSUE
@@ -330,9 +332,8 @@ while IFS=$'\t' read -r issue_num issue_labels; do
   fi
 done <<< "$ISSUE_SORTED"
 
-# Default mode: iterate categories outermost; within each, the ladder
-# security → review → simplify → verify → help-wanted issue → qa. The first
-# category with any eligible task wins.
+# Default mode: the first category with an eligible task wins (see the header
+# for the full two-tier order).
 for category in "${CATEGORIES[@]}"; do
   for phase in "${PHASE_PRIORITY[@]}"; do
     pr_key="$category|$phase"

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -195,7 +195,7 @@ issue_has_worktree() {
 # closingIssuesReferences drives topic-category resolution: a PR inherits the
 # highest-priority topic among the labels of every issue it closes.
 PR_LIST=$(gh pr list --state open --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels,closingIssuesReferences)
-PR_SORTED=$(printf '%s' "$PR_LIST" | jq -r 'sort_by(.createdAt) | .[] | [.number, .createdAt, .headRefName, (.closingIssuesReferences | tojson)] | @tsv')
+PR_SORTED=$(printf '%s' "$PR_LIST" | jq -r 'sort_by(.createdAt) | .[] | [.number, .createdAt, .headRefName, (.closingIssuesReferences // [] | tojson)] | @tsv')
 
 # Fetch every open issue once, carrying labels. This single list serves two
 # roles: filtered client-side to "help wanted" it is the issue queue; indexed

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -88,7 +88,7 @@ case "$args" in
       echo "[]"
     fi
     ;;
-  "pr list --state open --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels")
+  "pr list --state open --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels,closingIssuesReferences")
     echo "pr list" >> "$STUB_DIR/gh-pr-list-calls.log"
     if [[ -f "$STUB_DIR/pr-list-union.json" ]]; then
       cat "$STUB_DIR/pr-list-union.json"
@@ -96,7 +96,7 @@ case "$args" in
       echo "[]"
     fi
     ;;
-  "issue list --label help wanted --state open --json number,createdAt")
+  "issue list --state open --limit 300 --json number,createdAt,labels")
     if [[ -f "$STUB_DIR/issue-list.json" ]]; then
       cat "$STUB_DIR/issue-list.json"
     else
@@ -298,11 +298,13 @@ make_pr() {
 
 # Helper to build a PR JSON entry for the single union PR list that
 # dispatch-select-target fetches and exports to dispatch-phase. Carries the
-# union of fields both scripts need.
+# union of fields both scripts need. The 7th arg, closing_json, is the
+# closingIssuesReferences array; it defaults to [] (PR closes no issue), so
+# existing 6-arg call sites keep working unchanged.
 make_pr_union() {
-  local num="$1" branch="$2" created="$3" is_draft="$4" labels_json="$5" rollup_json="$6"
-  printf '{"number":%s,"createdAt":"%s","headRefName":"%s","isDraft":%s,"labels":%s,"statusCheckRollup":%s}' \
-    "$num" "$created" "$branch" "$is_draft" "$labels_json" "$rollup_json"
+  local num="$1" branch="$2" created="$3" is_draft="$4" labels_json="$5" rollup_json="$6" closing_json="${7:-[]}"
+  printf '{"number":%s,"createdAt":"%s","headRefName":"%s","isDraft":%s,"labels":%s,"statusCheckRollup":%s,"closingIssuesReferences":%s}' \
+    "$num" "$created" "$branch" "$is_draft" "$labels_json" "$rollup_json" "$closing_json"
 }
 
 # Green rollup (two passing check runs).
@@ -523,7 +525,7 @@ setup
 # PR 10 in verify phase (no CI green), PR 20 in qa phase (CI green, no label).
 UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr_union 20 "20-qa-me" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
 setup_union_pr_list "$UNION"
-printf '[{"number":99,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":99,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
 # No worktrees for these branches.
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -547,7 +549,7 @@ teardown
 echo "Test: no eligible PR → help-wanted issue"
 setup
 echo '[]' > "$STUB_DIR/pr-list-union.json"
-printf '[{"number":55,"createdAt":"2024-03-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":55,"createdAt":"2024-03-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "no PR → help-wanted issue" "issue 55" "$result"
@@ -578,7 +580,7 @@ teardown
 echo "Test: --qa mode with no QA PR → empty"
 setup
 echo '[]' > "$STUB_DIR/pr-list-union.json"
-printf '[{"number":77,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":77,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
 assert_eq "--qa mode no QA PR → empty" "empty" "$result"
@@ -589,7 +591,7 @@ echo "Test: all PRs done → help-wanted issue"
 setup
 UNION='['"$(make_pr_union 10 "10-done-pr" "2024-01-01T00:00:00Z" "false" "$NO_LABELS" "$GREEN_ROLLUP")"']'
 setup_union_pr_list "$UNION"
-printf '[{"number":33,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":33,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "done PRs skipped; help-wanted issue returned" "issue 33" "$result"
@@ -639,7 +641,7 @@ UNION+="$(make_pr_union 10 "10-verify" "2024-01-01T00:00:00Z" "true" "$NO_LABELS
 UNION+="$(make_pr_union 20 "20-qa" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"
 UNION+=']'
 setup_union_pr_list "$UNION"
-printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "verify PR beats issue (non-QA > issue > qa)" "pr 10 10-verify verify" "$result"
@@ -650,7 +652,7 @@ echo "Test: help-wanted issue beats QA PR"
 setup
 UNION='['"$(make_pr_union 20 "20-qa" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
 setup_union_pr_list "$UNION"
-printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "help-wanted issue beats QA PR" "issue 55" "$result"
@@ -678,7 +680,7 @@ setup
 # PR 10 in waiting phase (pending CI); no other PRs.
 UNION='['"$(make_pr_union 10 "10-waiting" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP")"']'
 setup_union_pr_list "$UNION"
-printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "waiting PR skipped; help-wanted issue returned" "issue 55" "$result"
@@ -803,7 +805,7 @@ setup
 # Seed a verify PR + help-wanted issue — both must be ignored once the gate trips.
 UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
 setup_union_pr_list "$UNION"
-printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
 printf '{"check_runs":[{"status":"completed","conclusion":"failure"}]}' \
@@ -1007,7 +1009,7 @@ echo "Test: issue with worktree skipped; next-oldest issue chosen"
 setup
 setup_union_pr_list '[]'
 # Issue 55 is older, issue 66 is newer. Issue 55 has a 55-* worktree.
-printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"},{"number":66,"createdAt":"2024-01-02T00:00:00Z"}]\n' \
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":66,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
   > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/55-some-feature\nHEAD def456\nbranch refs/heads/55-some-feature\n\n' \
   > "$STUB_DIR/worktree-list.txt"
@@ -1019,7 +1021,7 @@ teardown
 echo "Test: lone worktree'd issue → empty"
 setup
 setup_union_pr_list '[]'
-printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/55-some-feature\nHEAD def456\nbranch refs/heads/55-some-feature\n\n' \
   > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -1032,7 +1034,7 @@ setup
 UNION='['"$(make_pr_union 20 "20-qa" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
 setup_union_pr_list "$UNION"
 # The help-wanted issue would normally beat the QA PR, but it has a worktree.
-printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/55-some-feature\nHEAD def456\nbranch refs/heads/55-some-feature\n\n' \
   > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -1043,12 +1045,65 @@ teardown
 echo "Test: issue 6 not masked by worktree on branch 60-foo"
 setup
 setup_union_pr_list '[]'
-printf '[{"number":6,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":6,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
 # Worktree exists for 60-foo, not for 6-*.
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/60-foo\nHEAD def456\nbranch refs/heads/60-foo\n\n' \
   > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "issue 6 not masked by 60-foo worktree" "issue 6" "$result"
+teardown
+
+# --- topic-category prioritization (issue #707) -----------------------------
+# A topic category (bug → testing infrastructure → dispatch → other) nests
+# outside the phase ladder. A PR's category is resolved from the labels of the
+# issues it closes; an issue's category from its own labels.
+
+# 28. A PR closing a `bug` issue outranks a PR closing a `dispatch` issue, even
+#     when the dispatch PR is older — category beats age.
+echo "Test: PR closing a bug issue beats PR closing a dispatch issue"
+setup
+# PR 20 (older) closes dispatch issue 200; PR 10 (newer) closes bug issue 100.
+UNION='['
+UNION+="$(make_pr_union 20 "20-dispatch-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
+UNION+="$(make_pr_union 10 "10-bug-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100}]')"
+UNION+=']'
+setup_union_pr_list "$UNION"
+# Issues 100/200 are the closing issues — they carry the topic label that the
+# PRs inherit. No "help wanted" label, so they are not themselves queue items.
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]},{"number":200,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"dispatch"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "bug-closing PR beats dispatch-closing PR" "pr 10 10-bug-pr verify" "$result"
+teardown
+
+# 29. A help-wanted issue labeled `testing infrastructure` outranks a help-wanted
+#     issue with no topic label, even when the topic-labeled issue is newer.
+echo "Test: testing-infrastructure issue beats issue with no topic label"
+setup
+setup_union_pr_list '[]'
+# Issue 400 (older) has no topic label; issue 300 (newer) is testing infrastructure.
+printf '[{"number":400,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":300,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"testing infrastructure"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "testing-infrastructure issue beats untopiced issue" "issue 300" "$result"
+teardown
+
+# 30. A PR that closes no issue resolves to the `other` category — so a
+#     help-wanted `bug` issue outranks it, even though within one category a
+#     verify PR would beat the issue.
+echo "Test: PR closing no issue ranks in 'other'"
+setup
+# PR 10 is verify-phase and closes no issue (make_pr_union's closing arg
+# defaults to []). Issue 500 is a help-wanted bug.
+UNION='['"$(make_pr_union 10 "10-no-closing" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":500,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"bug"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "PR with no closing issue is 'other'; bug issue wins" "issue 500" "$result"
 teardown
 
 # ============================================================================


### PR DESCRIPTION
Adds a topic-category tier above `dispatch-select-target`'s phase ladder.
The selector iterates four categories — `bug` → `testing infrastructure`
→ `dispatch` → `other` — and applies the existing
security/review/simplify/verify/issue/qa ladder within each.

A PR's category is the highest-priority topic among the labels of every
issue it closes (`closingIssuesReferences`); an issue's category is the
highest-priority topic among its own labels; anything with no topic
label is `other`, so a queue with no topic-labeled items reproduces the
flat ladder exactly.

Closes #707