### PR TITLE
url-encode group IDs and path segments in upload-media-core (#697)

### DIFF
--- a/print/scripts/test-upload-media.sh
+++ b/print/scripts/test-upload-media.sh
@@ -77,6 +77,7 @@ for ((i=0; i<${#ARGS[@]}; i++)); do
     -d) HAS_DATA=true; echo "${ARGS[$((i+1))]}" > "$STUB_DIR/curl-body.json"; i=$((i+1)) ;;
     -o) RESP_FILE="${ARGS[$((i+1))]}"; i=$((i+1)) ;;
     --config) i=$((i+1)) ;;
+    https://*) echo "${ARGS[$i]}" >> "$STUB_DIR/curl-urls.log" ;;
   esac
 done
 
@@ -279,6 +280,14 @@ stderr=$(bash "$UPLOAD_SCRIPT" "$TMPDIR_TEST/stub/test-file.cbz" "Title" "epub" 
 assert_eq "exits 1" "1" "$exit_code"
 assert_contains "stderr mentions HTTP code" "HTTP 403" "$stderr"
 assert_contains "stderr mentions cleanup" "gsutil rm" "$stderr"
+teardown
+
+echo "Test 13: --group with slash -> group ID is percent-encoded in Firestore URL"
+setup
+output=$(bash "$UPLOAD_SCRIPT" "$TMPDIR_TEST/stub/test-file.cbz" "Private Item" "epub" --group 'has/slash' 2>&1)
+curl_urls=$(cat "$TMPDIR_TEST/stub/curl-urls.log")
+assert_contains "URL contains percent-encoded group ID" "groups/has%2Fslash" "$curl_urls"
+assert_not_contains "URL does not contain raw slash in group ID" "groups/has/slash" "$curl_urls"
 teardown
 
 echo ""

--- a/print/scripts/test-upload-media.sh
+++ b/print/scripts/test-upload-media.sh
@@ -70,12 +70,14 @@ STUB
 STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
 RESP_FILE=""
 HAS_DATA=false
-# Parse args to detect -d (POST) vs GET, and find -o target
+# Parse args: detect -d (POST) vs GET, find -o target, log request URLs.
+# Value-taking flags skip their value so it can't be mistaken for a URL.
 ARGS=("$@")
 for ((i=0; i<${#ARGS[@]}; i++)); do
   case "${ARGS[$i]}" in
     -d) HAS_DATA=true; echo "${ARGS[$((i+1))]}" > "$STUB_DIR/curl-body.json"; i=$((i+1)) ;;
     -o) RESP_FILE="${ARGS[$((i+1))]}"; i=$((i+1)) ;;
+    -w) i=$((i+1)) ;;
     --config) i=$((i+1)) ;;
     https://*) echo "${ARGS[$i]}" >> "$STUB_DIR/curl-urls.log" ;;
   esac
@@ -288,6 +290,15 @@ output=$(bash "$UPLOAD_SCRIPT" "$TMPDIR_TEST/stub/test-file.cbz" "Private Item" 
 curl_urls=$(cat "$TMPDIR_TEST/stub/curl-urls.log")
 assert_contains "URL contains percent-encoded group ID" "groups/has%2Fslash" "$curl_urls"
 assert_not_contains "URL does not contain raw slash in group ID" "groups/has/slash" "$curl_urls"
+teardown
+
+echo "Test 14: --group with slash, lookup fails -> error quotes the raw group ID"
+setup
+touch "$TMPDIR_TEST/stub/curl-group-fail"
+exit_code=0
+stderr=$(bash "$UPLOAD_SCRIPT" "$TMPDIR_TEST/stub/test-file.cbz" "Title" "pdf" --group 'has/slash' 2>&1) || exit_code=$?
+assert_eq "exits 1" "1" "$exit_code"
+assert_contains "error quotes original unencoded group ID" "group 'has/slash'" "$stderr"
 teardown
 
 echo ""

--- a/scaffolding/scripts/upload-media-core.sh
+++ b/scaffolding/scripts/upload-media-core.sh
@@ -65,13 +65,32 @@ core::get_auth_token() {
   printf '%s\n' "$token"
 }
 
+# Percent-encodes a single path segment (whole value). Use for document IDs
+# that must stay within one URL segment — e.g. group_id "foo/bar" -> "foo%2Fbar".
+core::url_encode_segment() {
+  jq -rn --arg s "$1" '$s | @uri'
+}
+
+# Percent-encodes each slash-delimited segment, preserving the separators.
+# Use for multi-segment paths like "audio/prod/groups" so the "/" structure
+# survives — "audio/prod/groups" stays "audio/prod/groups" but any reserved
+# characters within each segment are encoded.
+core::url_encode_path() {
+  jq -rn --arg s "$1" '$s | split("/") | map(@uri) | join("/")'
+}
+
 core::lookup_group_members() {
   local project="$1"
   local groups_path="$2"
   local group_id="$3"
   local token="$4"
 
-  local url="https://firestore.googleapis.com/v1/projects/${project}/databases/(default)/documents/${groups_path}/${group_id}"
+  local encoded_project encoded_groups_path encoded_group_id
+  encoded_project="$(core::url_encode_path "$project")"
+  encoded_groups_path="$(core::url_encode_path "$groups_path")"
+  encoded_group_id="$(core::url_encode_segment "$group_id")"
+
+  local url="https://firestore.googleapis.com/v1/projects/${encoded_project}/databases/(default)/documents/${encoded_groups_path}/${encoded_group_id}"
   local resp_file
   resp_file="$(mktemp)"
   core::register_temp_file "$resp_file"
@@ -146,7 +165,11 @@ core::create_firestore_doc() {
   local body_json="$4"
   local gcs_dest="$5"
 
-  local url="https://firestore.googleapis.com/v1/projects/${project}/databases/(default)/documents/${collection_path}"
+  local encoded_project encoded_collection_path
+  encoded_project="$(core::url_encode_path "$project")"
+  encoded_collection_path="$(core::url_encode_path "$collection_path")"
+
+  local url="https://firestore.googleapis.com/v1/projects/${encoded_project}/databases/(default)/documents/${encoded_collection_path}"
   local resp_file
   resp_file="$(mktemp)"
   core::register_temp_file "$resp_file"


### PR DESCRIPTION
Closes #697

`core::lookup_group_members` interpolated the operator-supplied `--group <id>`
argument straight into a Firestore REST URL. A `/`, `?`, or `#` in the value
escaped its document-path segment — at best a confusing 404, at worst a request
landing on an unintended document. `core::create_firestore_doc` had the same
latent exposure for its path arguments.

## Changes

- Add two helpers in `scaffolding/scripts/upload-media-core.sh`:
  - `core::url_encode_segment` — percent-encodes a whole value as one path
    segment, so an internal `/` becomes `%2F` (`foo/bar` → `foo%2Fbar`). Used
    for the operator-supplied group ID.
  - `core::url_encode_path` — percent-encodes each `/`-delimited segment,
    preserving the structural separators. Used for the multi-segment constants
    `project`, `groups_path`, `collection_path`.
- `core::lookup_group_members` builds its URL from encoded locals; both error
  messages still quote the original unencoded group ID so output matches what
  the operator typed.
- `core::create_firestore_doc` builds its URL from encoded locals.
- `print/scripts/test-upload-media.sh`: the `curl` stub now logs every
  `https://` URL to `curl-urls.log`; new Test 13 runs `--group 'has/slash'` and
  asserts the URL contains `groups/has%2Fslash` and no raw `groups/has/slash`.
  Test 14 runs the same group ID against a failing lookup and asserts the
  error message quotes the original unencoded `has/slash`.

## Verification

- `bash print/scripts/test-upload-media.sh` — 38/38 passed, 14 test blocks.
- `bash audio/scripts/test-upload-media.sh` — 43/43 passed, no regression.
- `bash -n scaffolding/scripts/upload-media-core.sh` — clean.
