### PR TITLE
dispatch: propagate gh API failures in dispatch-trace-leaf as hard errors

### DIFF
--- a/.claude/skills/dispatch/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch/scripts/dispatch-trace-leaf
@@ -138,7 +138,7 @@ find_leaf() {
   # Descend into children lowest-numbered first; return the first leaf found.
   # In queue mode, skip any child that already has a worktree — if every child
   # is skipped the loop finds nothing and we bubble up.
-  local kid leaf rc
+  local kid leaf
   while IFS= read -r kid; do
     [[ -z "$kid" ]] && continue
     [[ "$MODE" == "queue" && -n "${CONFLICTED[$kid]+x}" ]] && continue

--- a/.claude/skills/dispatch/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch/scripts/dispatch-trace-leaf
@@ -28,7 +28,8 @@
 #
 # Exit codes:
 #   0 — a leaf was found and printed to stdout
-#   1 — usage error (bad issue number or missing/invalid mode)
+#   1 — usage error, or a sibling gh script (issue-blocking / issue-sub-issues)
+#       failed — a hard failure the caller must not treat as "no work"
 #   2 — queue mode only: every reachable open leaf is worktree-conflicted
 set -euo pipefail
 
@@ -66,18 +67,21 @@ open_children() {
   local n="$1"
   local children=()
 
-  # Gather open blockers.
+  # Gather open blockers. A non-zero exit from issue-blocking is a real gh API
+  # failure (empty output on success means genuinely no blockers) — propagate
+  # it as a hard error instead of collapsing it into "this issue has no
+  # children". No 2>/dev/null: let issue-blocking's stderr diagnostic surface.
   local blocker_json
-  blocker_json=$("$SCRIPT_DIR/issue-blocking" "$n" 2>/dev/null) || blocker_json=""
+  blocker_json=$("$SCRIPT_DIR/issue-blocking" "$n") || return 1
   if [[ -n "$blocker_json" ]]; then
     while IFS= read -r num; do
       [[ -n "$num" ]] && children+=("$num")
     done < <(printf '%s' "$blocker_json" | jq -r 'select(.state == "OPEN" or .state == "open") | .number' 2>/dev/null || true)
   fi
 
-  # Gather open sub-issues.
+  # Gather open sub-issues. Same hard-error contract as the blocker lookup.
   local sub_json
-  sub_json=$("$SCRIPT_DIR/issue-sub-issues" "$n" 2>/dev/null) || sub_json=""
+  sub_json=$("$SCRIPT_DIR/issue-sub-issues" "$n") || return 1
   if [[ -n "$sub_json" ]]; then
     while IFS= read -r num; do
       [[ -n "$num" ]] && children+=("$num")
@@ -88,6 +92,10 @@ open_children() {
   if [[ ${#children[@]} -gt 0 ]]; then
     printf '%s\n' "${children[@]}" | sort -un
   fi
+  # Explicit success: the function would otherwise fall off the end returning
+  # the [[ ]] test's exit status (1 when there are no children), which a
+  # caller checking $? cannot distinguish from a sibling-script failure.
+  return 0
 }
 
 # Depth-first search for the lowest-numbered reachable open leaf.
@@ -96,6 +104,9 @@ open_children() {
 # Returns 0 and prints the leaf number on success.
 # Returns 1 if no valid leaf is reachable through this subtree (cycles, or in
 # queue mode every reachable leaf is worktree-conflicted).
+# Returns 3 if a blocker/sub-issue lookup hit a hard error (gh API failure);
+# re-propagated through every recursive frame so the top level can map it to a
+# clean script-level abort instead of mis-selecting the issue as startable.
 declare -A VISITED=()
 
 find_leaf() {
@@ -107,8 +118,14 @@ find_leaf() {
   fi
   VISITED["$n"]=1
 
-  local kids
-  kids=$(open_children "$n")
+  # open_children returns non-zero only on a sibling gh-script failure. set -e
+  # is disabled here (find_leaf is always called from an `if` condition), so
+  # the status must be captured and checked explicitly.
+  local kids rc
+  kids=$(open_children "$n"); rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    return 3
+  fi
 
   if [[ -z "$kids" ]]; then
     # Topological leaf — a valid leaf. Worktree-conflicted children are filtered
@@ -121,23 +138,40 @@ find_leaf() {
   # Descend into children lowest-numbered first; return the first leaf found.
   # In queue mode, skip any child that already has a worktree — if every child
   # is skipped the loop finds nothing and we bubble up.
-  local kid
+  local kid leaf rc
   while IFS= read -r kid; do
     [[ -z "$kid" ]] && continue
     [[ "$MODE" == "queue" && -n "${CONFLICTED[$kid]+x}" ]] && continue
-    local leaf
-    if leaf=$(find_leaf "$kid"); then
+    # Capture the status explicitly (set -e is disabled here) so a hard error
+    # (rc 3) is distinguishable from "no leaf in this subtree" (rc 1).
+    leaf=$(find_leaf "$kid"); rc=$?
+    if [[ "$rc" -eq 0 ]]; then
       echo "$leaf"
       return 0
     fi
+    [[ "$rc" -eq 3 ]] && return 3
   done <<< "$kids"
 
   return 1
 }
 
 if LEAF=$(find_leaf "$ISSUE_NUM"); then
+  trace_rc=0
+else
+  trace_rc=$?
+fi
+
+if [[ "$trace_rc" -eq 0 ]]; then
   echo "$LEAF"
   exit 0
+fi
+
+# A hard error (gh API failure during blocker/sub-issue resolution) must not be
+# treated as "no work" — aborting is correct in both modes. In particular this
+# stops explicit mode from falling through to the print-N cycle fallback below.
+if [[ "$trace_rc" -eq 3 ]]; then
+  echo "error: dispatch-trace-leaf $ISSUE_NUM: a blocker/sub-issue lookup failed (gh API error); aborting rather than treating $ISSUE_NUM as startable" >&2
+  exit 1
 fi
 
 # In queue mode, no valid leaf is reachable — every leaf is worktree-conflicted

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1511,6 +1511,21 @@ assert_eq "issue-blocking failure (explicit) → exit 1" "1" "$rc"
 assert_eq "issue-blocking failure (explicit) → no N printed" "" "$stdout"
 teardown
 
+# 16. A failure one level deep is re-propagated through the recursive frame.
+#     Tests 13-15 inject the failure at the root issue, so find_leaf returns
+#     the rc-3 hard error from its first frame. Here 800 has sub-issue 801 and
+#     it is 801's blocker lookup that fails — exercising the `rc -eq 3` branch
+#     in find_leaf's descent loop, which must carry the hard error up rather
+#     than mask it as "no leaf in this subtree".
+echo "Test: gh failure one level deep → re-propagated, exit 1"
+setup
+printf '[{"number":801}]\n' > "$STUB_DIR/subissues-800.json"
+: > "$STUB_DIR/gh-fail-blocked_by-801"
+stdout=$("$TMPDIR_TEST/dispatch-trace-leaf" "800" "queue" 2>/dev/null) && rc=0 || rc=$?
+assert_eq "deep gh failure → exit 1" "1" "$rc"
+assert_eq "deep gh failure → no leaf on stdout" "" "$stdout"
+teardown
+
 # ============================================================================
 # dispatch-complete-phase tests
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1481,9 +1481,6 @@ assert_eq "invalid mode → usage error, exit 1" "ok" "$status"
 teardown
 
 # 13. issue-blocking failure → hard error (exit 1), never emits N as a leaf.
-#     Without the fix, the swallowed failure makes 800 look like a childless
-#     topological leaf and the script prints "800" — selecting a possibly
-#     blocked issue.
 echo "Test: issue-blocking failure → exit 1, no leaf emitted"
 setup
 # No stub files: 800 would otherwise resolve as a childless leaf. The injected
@@ -1505,8 +1502,7 @@ assert_eq "issue-sub-issues failure → no leaf on stdout" "" "$stdout"
 teardown
 
 # 15. issue-blocking failure in explicit mode → exit 1, NOT the cycle-fallback
-#     "print N". Guards the subtlest regression: a gh failure must not fall
-#     through to explicit mode's historical print-self behavior.
+#     "print N".
 echo "Test: issue-blocking failure (explicit) → exit 1, not cycle-fallback"
 setup
 : > "$STUB_DIR/gh-fail-blocked_by-800"

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -243,6 +243,14 @@ STUB_DIR="$(cd "$(dirname "$0")/stub" && pwd)"
 num="${1:-}"
 # Strip leading # if present.
 num="${num#\#}"
+# Failure injection: a marker file models a transient gh API failure on this
+# issue's blocked_by lookup. The real issue-blocking exits non-zero (with a
+# gh_api_array stderr diagnostic) on a genuine gh failure — the fake mirrors
+# that contract so dispatch-trace-leaf's failure handling can be exercised.
+if [[ -f "$STUB_DIR/gh-fail-blocked_by-${num}" ]]; then
+  echo "error: gh api call failed for issues/${num}/dependencies/blocked_by" >&2
+  exit 1
+fi
 # issue-blocking calls lib.sh resolve_issue_number then gh api + gh issue view.
 # Our fake: just read a stub file.
 blocker_nums=""
@@ -264,6 +272,12 @@ FAKE
 STUB_DIR="$(cd "$(dirname "$0")/stub" && pwd)"
 num="${1:-}"
 num="${num#\#}"
+# Failure injection — same contract as issue-blocking's, for the sub_issues
+# lookup.
+if [[ -f "$STUB_DIR/gh-fail-sub_issues-${num}" ]]; then
+  echo "error: gh api call failed for issues/${num}/sub_issues" >&2
+  exit 1
+fi
 sub_nums=""
 if [[ -f "$STUB_DIR/subissues-${num}.json" ]]; then
   sub_nums=$(cat "$STUB_DIR/subissues-${num}.json" | jq -r '.[].number' 2>/dev/null || true)
@@ -1300,6 +1314,41 @@ case "$err_out" in
   *) status="bad: $err_out" ;;
 esac
 assert_eq "invalid mode → usage error, exit 1" "ok" "$status"
+teardown
+
+# 13. issue-blocking failure → hard error (exit 1), never emits N as a leaf.
+#     Without the fix, the swallowed failure makes 800 look like a childless
+#     topological leaf and the script prints "800" — selecting a possibly
+#     blocked issue.
+echo "Test: issue-blocking failure → exit 1, no leaf emitted"
+setup
+# No stub files: 800 would otherwise resolve as a childless leaf. The injected
+# blocked_by failure must abort instead of mis-classifying 800 as startable.
+: > "$STUB_DIR/gh-fail-blocked_by-800"
+stdout=$("$TMPDIR_TEST/dispatch-trace-leaf" "800" "queue" 2>/dev/null) && rc=0 || rc=$?
+assert_eq "issue-blocking failure → exit 1" "1" "$rc"
+assert_eq "issue-blocking failure → no leaf on stdout" "" "$stdout"
+teardown
+
+# 14. issue-sub-issues failure → same hard error. issue-blocking succeeds
+#     (empty = no blockers), then the sub_issues lookup fails.
+echo "Test: issue-sub-issues failure → exit 1, no leaf emitted"
+setup
+: > "$STUB_DIR/gh-fail-sub_issues-800"
+stdout=$("$TMPDIR_TEST/dispatch-trace-leaf" "800" "queue" 2>/dev/null) && rc=0 || rc=$?
+assert_eq "issue-sub-issues failure → exit 1" "1" "$rc"
+assert_eq "issue-sub-issues failure → no leaf on stdout" "" "$stdout"
+teardown
+
+# 15. issue-blocking failure in explicit mode → exit 1, NOT the cycle-fallback
+#     "print N". Guards the subtlest regression: a gh failure must not fall
+#     through to explicit mode's historical print-self behavior.
+echo "Test: issue-blocking failure (explicit) → exit 1, not cycle-fallback"
+setup
+: > "$STUB_DIR/gh-fail-blocked_by-800"
+stdout=$("$TMPDIR_TEST/dispatch-trace-leaf" "800" "explicit" 2>/dev/null) && rc=0 || rc=$?
+assert_eq "issue-blocking failure (explicit) → exit 1" "1" "$rc"
+assert_eq "issue-blocking failure (explicit) → no N printed" "" "$stdout"
 teardown
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes a bug in `dispatch-trace-leaf` where a transient `gh` API failure during
blocker/sub-issue resolution was swallowed, causing `/dispatch` to mis-select a
blocked issue as startable.

`open_children()` resolved blockers via `issue-blocking` and sub-issues via
`issue-sub-issues`, both of which exit non-zero **only** on a real `gh` failure
(empty output on success means genuinely no children). The old `|| ...=""`
swallowed that exit, collapsing "API call failed" into "this issue has no
children" — so a blocked issue looked like a childless startable leaf. This is
how `/dispatch` mis-selected #556 (recorded `blocked_by` open issue #553).

## Changes

All in `.claude/skills/dispatch/scripts/dispatch-trace-leaf`:

- `open_children` propagates an `issue-blocking` / `issue-sub-issues` failure
  (`|| return 1`), drops `2>/dev/null` so the diagnostic surfaces, and adds an
  explicit `return 0` so a genuine no-children result is not misread as a
  failure once callers check `$?`.
- `find_leaf` captures `open_children`'s exit status explicitly (`set -e` is
  disabled inside an `if`-condition call) and returns internal code `3` on a
  hard error, re-propagated through every recursive frame.
- The top level maps code `3` to `exit 1` with a clear stderr message, in both
  `queue` and `explicit` mode (an explicit-mode failure no longer falls through
  to the historical print-N cycle fallback).

Regression tests in `test-dispatch-scripts.sh` cover an `issue-blocking`
failure, an `issue-sub-issues` failure, and an `issue-blocking` failure in
`explicit` mode, via fake-`gh` failure injection.

## Verification

- `test-dispatch-scripts.sh`: 181/181 pass. The 3 new tests fail against the
  pre-fix script, confirming they catch the bug.
- `dispatch-trace-leaf 556 queue` still exits 2 ("all open leaves
  worktree-conflicted") on the no-failure path — behavior unchanged.

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)
