### PR TITLE
dispatch: extract a shared git worktree porcelain parser into lib.sh

### DIFF
--- a/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
@@ -33,6 +33,9 @@ if [[ ! "$ISSUE" =~ ^[1-9][0-9]*$ ]] || [[ "$MODE" != "explicit" && "$MODE" != "
   exit 1
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
 # `here` — the current branch already is the target's branch. Mode-independent,
 # checked before the worktree scan.
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -41,27 +44,19 @@ if [[ "$CURRENT_BRANCH" == "$ISSUE"-* ]]; then
   exit 0
 fi
 
-# `enter` / `conflict` — scan local worktrees for a <issue>-* branch. git
-# worktree list --porcelain emits blank-line-delimited records; each opens with
-# a "worktree <path>" line and (for a branch checkout) carries a
-# "branch refs/heads/<name>" line. Use the first matching record.
-WORKTREE_PATH=""
-while IFS= read -r line; do
-  if [[ "$line" == worktree\ * ]]; then
-    WORKTREE_PATH="${line#worktree }"
-  elif [[ "$line" == branch\ * ]]; then
-    branch="${line#branch }"
-    branch="${branch#refs/heads/}"
-    if [[ "$branch" == "$ISSUE"-* ]]; then
-      if [[ "$MODE" == "explicit" ]]; then
-        echo "enter $WORKTREE_PATH"
-      else
-        echo "conflict $WORKTREE_PATH"
-      fi
-      exit 0
+# `enter` / `conflict` — scan local worktrees for one whose branch carries the
+# <issue>-* prefix, via the shared list_worktree_records helper (lib.sh). Records
+# arrive in `git worktree list` order, so the first matching record wins.
+while IFS=$'\t' read -r num path branch; do
+  if [[ "$num" == "$ISSUE" ]]; then
+    if [[ "$MODE" == "explicit" ]]; then
+      echo "enter $path"
+    else
+      echo "conflict $path"
     fi
+    exit 0
   fi
-done < <(git worktree list --porcelain)
+done < <(list_worktree_records)
 
 # `create` — no worktree matched. Build a sanitized <issue>-<slug> branch name
 # from the issue title. `jq -e` exits non-zero on a null/missing .title, so the

--- a/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
@@ -46,9 +46,7 @@ fi
 
 # `enter` / `conflict` — scan local worktrees for one whose branch carries the
 # <issue>-* prefix, via the shared list_worktree_records helper (lib.sh).
-# split_worktree_record splits each line into WT_NUM / WT_PATH / WT_BRANCH
-# (trim-safe — see lib.sh). Records arrive in `git worktree list` order, so the
-# first matching record wins.
+# Records arrive in `git worktree list` order, so the first matching record wins.
 while IFS= read -r line; do
   split_worktree_record "$line"
   if [[ "$WT_NUM" == "$ISSUE" ]]; then

--- a/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
@@ -45,14 +45,17 @@ if [[ "$CURRENT_BRANCH" == "$ISSUE"-* ]]; then
 fi
 
 # `enter` / `conflict` — scan local worktrees for one whose branch carries the
-# <issue>-* prefix, via the shared list_worktree_records helper (lib.sh). Records
-# arrive in `git worktree list` order, so the first matching record wins.
-while IFS=$'\t' read -r num path branch; do
-  if [[ "$num" == "$ISSUE" ]]; then
+# <issue>-* prefix, via the shared list_worktree_records helper (lib.sh).
+# split_worktree_record splits each line into WT_NUM / WT_PATH / WT_BRANCH
+# (trim-safe — see lib.sh). Records arrive in `git worktree list` order, so the
+# first matching record wins.
+while IFS= read -r line; do
+  split_worktree_record "$line"
+  if [[ "$WT_NUM" == "$ISSUE" ]]; then
     if [[ "$MODE" == "explicit" ]]; then
-      echo "enter $path"
+      echo "enter $WT_PATH"
     else
-      echo "conflict $path"
+      echo "conflict $WT_PATH"
     fi
     exit 0
   fi

--- a/.claude/skills/dispatch/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch/scripts/dispatch-trace-leaf
@@ -33,6 +33,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
 
 ISSUE_NUM="${1:-}"
 MODE="${2:-}"
@@ -43,21 +44,14 @@ if [[ -z "$ISSUE_NUM" || ! "$ISSUE_NUM" =~ ^[1-9][0-9]*$ ]] \
 fi
 
 # In queue mode, build the set of issue-number prefixes that own a local
-# worktree. Same porcelain-record parser as dispatch-resolve-worktree: records
-# are blank-line-delimited; each opens with "worktree <path>" and a branch
-# checkout carries "branch refs/heads/<name>". The number prefix is the leading
-# digits up to the first "-".
+# worktree. list_worktree_records (lib.sh) does the shared porcelain parse; each
+# record's first tab-separated field is the branch's issue-number prefix, empty
+# for non-issue / branchless worktrees.
 declare -A CONFLICTED=()
 if [[ "$MODE" == "queue" ]]; then
-  while IFS= read -r line; do
-    if [[ "$line" == branch\ * ]]; then
-      branch="${line#branch }"
-      branch="${branch#refs/heads/}"
-      if [[ "$branch" =~ ^([1-9][0-9]*)- ]]; then
-        CONFLICTED["${BASH_REMATCH[1]}"]=1
-      fi
-    fi
-  done < <(git worktree list --porcelain)
+  while IFS=$'\t' read -r num path branch; do
+    [[ -n "$num" ]] && CONFLICTED["$num"]=1
+  done < <(list_worktree_records)
 fi
 
 # Collect open children of an issue: open blockers union open sub-issues.

--- a/.claude/skills/dispatch/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch/scripts/dispatch-trace-leaf
@@ -48,8 +48,7 @@ fi
 # worktree. list_worktree_records (lib.sh) does the shared porcelain parse;
 # split_worktree_record splits each line into WT_NUM / WT_PATH / WT_BRANCH —
 # WT_NUM is the branch's issue-number prefix, empty for non-issue / branchless
-# worktrees. (A plain `IFS=$'\t' read` would mis-parse those empty-prefix
-# records — see split_worktree_record in lib.sh.)
+# worktrees.
 declare -A CONFLICTED=()
 if [[ "$MODE" == "queue" ]]; then
   while IFS= read -r line; do

--- a/.claude/skills/dispatch/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch/scripts/dispatch-trace-leaf
@@ -44,13 +44,16 @@ if [[ -z "$ISSUE_NUM" || ! "$ISSUE_NUM" =~ ^[1-9][0-9]*$ ]] \
 fi
 
 # In queue mode, build the set of issue-number prefixes that own a local
-# worktree. list_worktree_records (lib.sh) does the shared porcelain parse; each
-# record's first tab-separated field is the branch's issue-number prefix, empty
-# for non-issue / branchless worktrees.
+# worktree. list_worktree_records (lib.sh) does the shared porcelain parse;
+# split_worktree_record splits each line into WT_NUM / WT_PATH / WT_BRANCH —
+# WT_NUM is the branch's issue-number prefix, empty for non-issue / branchless
+# worktrees. (A plain `IFS=$'\t' read` would mis-parse those empty-prefix
+# records — see split_worktree_record in lib.sh.)
 declare -A CONFLICTED=()
 if [[ "$MODE" == "queue" ]]; then
-  while IFS=$'\t' read -r num path branch; do
-    [[ -n "$num" ]] && CONFLICTED["$num"]=1
+  while IFS= read -r line; do
+    split_worktree_record "$line"
+    [[ -n "$WT_NUM" ]] && CONFLICTED["$WT_NUM"]=1
   done < <(list_worktree_records)
 fi
 

--- a/.claude/skills/dispatch/scripts/lib.sh
+++ b/.claude/skills/dispatch/scripts/lib.sh
@@ -396,6 +396,58 @@ kill_worktree_processes() {
   done <<< "$pids"
 }
 
+# Emit one tab-separated `<issue-number>\t<path>\t<branch>` record.
+# Args: $1 = worktree path, $2 = branch name (empty for detached-HEAD/bare).
+# A blank path is a no-op — nothing has been collected yet.
+_emit_worktree_record() {
+  local wt_path="$1" branch="$2" num=""
+  [ -z "$wt_path" ] && return 0
+  if [[ "$branch" =~ ^([1-9][0-9]*)- ]]; then
+    num="${BASH_REMATCH[1]}"
+  fi
+  printf '%s\t%s\t%s\n' "$num" "$wt_path" "$branch"
+}
+
+# Parse `git worktree list --porcelain` into tab-separated records.
+# Emits one `<issue-number>\t<path>\t<branch>` line per registered worktree —
+# including detached-HEAD, bare, and non-issue worktrees:
+#   <issue-number> — leading-digits prefix of the branch (^[1-9][0-9]*-);
+#                    empty when the branch has no such prefix or there is no
+#                    branch line.
+#   <path>         — always present.
+#   <branch>       — branch name with refs/heads/ stripped; empty for
+#                    detached-HEAD / bare worktrees (no `branch` line).
+# This is the single shared porcelain record-walk: callers no longer each
+# re-implement the blank-line-delimited walk or the <issue-number>-<slug>
+# branch-naming convention. Callers that want only issue worktrees skip records
+# whose issue-number field is empty. A `git worktree list` failure surfaces as a
+# clear error (per .claude/rules/code-style.md) rather than an invented fallback.
+list_worktree_records() {
+  local porcelain
+  porcelain=$(git worktree list --porcelain) || {
+    echo "error: git worktree list --porcelain failed" >&2
+    return 1
+  }
+
+  local line wt_path="" branch=""
+  while IFS= read -r line; do
+    if [ -z "$line" ]; then
+      # A blank line closes the current record.
+      _emit_worktree_record "$wt_path" "$branch"
+      wt_path=""
+      branch=""
+    elif [[ "$line" == worktree\ * ]]; then
+      wt_path="${line#worktree }"
+    elif [[ "$line" == branch\ * ]]; then
+      branch="${line#branch }"
+      branch="${branch#refs/heads/}"
+    fi
+  done <<< "$porcelain"
+  # Flush the final record: command substitution strips the porcelain stream's
+  # trailing blank line, so the last record reaches EOF with no closing blank.
+  _emit_worktree_record "$wt_path" "$branch"
+}
+
 # Kill processes belonging to worktrees that no longer exist.
 # Scopes the search to this repo's worktree directory (derived from git
 # common dir) to avoid killing processes from unrelated repositories.
@@ -412,16 +464,14 @@ cleanup_stale_worktree_processes() {
   # Prune stale admin entries so the list below reflects on-disk worktrees only.
   git worktree prune 2>/dev/null || true
 
-  # Build set of active worktree paths
+  # Build set of active worktree paths — the <path> field of every registered
+  # worktree record (issue-prefixed or not, branch or detached).
   local active_paths=""
-  local line
-  while IFS= read -r line; do
-    case "$line" in
-      worktree\ *)
-        active_paths+="${line#worktree } "
-        ;;
-    esac
-  done < <(git worktree list --porcelain 2>/dev/null)
+  local rec_num rec_path rec_branch
+  while IFS=$'\t' read -r rec_num rec_path rec_branch; do
+    [ -z "$rec_path" ] && continue
+    active_paths+="$rec_path "
+  done < <(list_worktree_records)
 
   if [ -z "$active_paths" ]; then
     echo "WARNING: git worktree list returned no entries; skipping stale cleanup" >&2

--- a/.claude/skills/dispatch/scripts/lib.sh
+++ b/.claude/skills/dispatch/scripts/lib.sh
@@ -448,6 +448,26 @@ list_worktree_records() {
   _emit_worktree_record "$wt_path" "$branch"
 }
 
+# Split one list_worktree_records line into the globals WT_NUM / WT_PATH /
+# WT_BRANCH.
+#
+# Do NOT parse list_worktree_records output with `IFS=$'\t' read -r num path
+# branch`: tab is an IFS *whitespace* character, so `read` trims a leading or
+# trailing tab and collapses consecutive tabs. list_worktree_records leaves the
+# issue-number field empty for bare / detached-HEAD / non-issue worktrees, so
+# those records begin with a tab — `read` strips it and every field shifts one
+# position left (the path lands in `num`, the branch in `path`). Parameter
+# expansion does no trimming or run-collapsing, so it preserves empty fields
+# exactly. Every record has exactly two tabs (three fields), so the split below
+# is unambiguous.
+split_worktree_record() {
+  local line="$1"
+  WT_NUM="${line%%$'\t'*}"      # field 1: before the first tab
+  local rest="${line#*$'\t'}"  # everything after the first tab
+  WT_PATH="${rest%%$'\t'*}"    # field 2: before the second tab
+  WT_BRANCH="${rest#*$'\t'}"   # field 3: after the second tab
+}
+
 # Kill processes belonging to worktrees that no longer exist.
 # Scopes the search to this repo's worktree directory (derived from git
 # common dir) to avoid killing processes from unrelated repositories.
@@ -465,12 +485,15 @@ cleanup_stale_worktree_processes() {
   git worktree prune 2>/dev/null || true
 
   # Build set of active worktree paths — the <path> field of every registered
-  # worktree record (issue-prefixed or not, branch or detached).
+  # worktree record (issue-prefixed or not, branch or detached). split_worktree_record
+  # is trim-safe: non-issue / detached worktrees have an empty leading issue-number
+  # field, which `IFS=$'\t' read` would strip — shifting the path out of WT_PATH.
   local active_paths=""
-  local rec_num rec_path rec_branch
-  while IFS=$'\t' read -r rec_num rec_path rec_branch; do
-    [ -z "$rec_path" ] && continue
-    active_paths+="$rec_path "
+  local line
+  while IFS= read -r line; do
+    split_worktree_record "$line"
+    [ -z "$WT_PATH" ] && continue
+    active_paths+="$WT_PATH "
   done < <(list_worktree_records)
 
   if [ -z "$active_paths" ]; then

--- a/.claude/skills/dispatch/scripts/lib.sh
+++ b/.claude/skills/dispatch/scripts/lib.sh
@@ -417,11 +417,7 @@ _emit_worktree_record() {
 #   <path>         — always present.
 #   <branch>       — branch name with refs/heads/ stripped; empty for
 #                    detached-HEAD / bare worktrees (no `branch` line).
-# This is the single shared porcelain record-walk: callers no longer each
-# re-implement the blank-line-delimited walk or the <issue-number>-<slug>
-# branch-naming convention. Callers that want only issue worktrees skip records
-# whose issue-number field is empty. A `git worktree list` failure surfaces as a
-# clear error (per .claude/rules/code-style.md) rather than an invented fallback.
+# Callers that want only issue worktrees skip empty-<issue-number> records.
 list_worktree_records() {
   local porcelain
   porcelain=$(git worktree list --porcelain) || {
@@ -449,23 +445,16 @@ list_worktree_records() {
 }
 
 # Split one list_worktree_records line into the globals WT_NUM / WT_PATH /
-# WT_BRANCH.
-#
-# Do NOT parse list_worktree_records output with `IFS=$'\t' read -r num path
-# branch`: tab is an IFS *whitespace* character, so `read` trims a leading or
-# trailing tab and collapses consecutive tabs. list_worktree_records leaves the
-# issue-number field empty for bare / detached-HEAD / non-issue worktrees, so
-# those records begin with a tab — `read` strips it and every field shifts one
-# position left (the path lands in `num`, the branch in `path`). Parameter
-# expansion does no trimming or run-collapsing, so it preserves empty fields
-# exactly. Every record has exactly two tabs (three fields), so the split below
-# is unambiguous.
+# WT_BRANCH. Uses parameter expansion, not `IFS=$'\t' read`: tab is an IFS
+# whitespace character, so `read` would trim the empty leading issue-number
+# field of a non-issue / detached / bare record and shift every field left.
+# Parameter expansion preserves empty fields exactly.
 split_worktree_record() {
   local line="$1"
-  WT_NUM="${line%%$'\t'*}"      # field 1: before the first tab
-  local rest="${line#*$'\t'}"  # everything after the first tab
-  WT_PATH="${rest%%$'\t'*}"    # field 2: before the second tab
-  WT_BRANCH="${rest#*$'\t'}"   # field 3: after the second tab
+  WT_NUM="${line%%$'\t'*}"
+  local rest="${line#*$'\t'}"
+  WT_PATH="${rest%%$'\t'*}"
+  WT_BRANCH="${rest#*$'\t'}"
 }
 
 # Kill processes belonging to worktrees that no longer exist.
@@ -485,9 +474,7 @@ cleanup_stale_worktree_processes() {
   git worktree prune 2>/dev/null || true
 
   # Build set of active worktree paths — the <path> field of every registered
-  # worktree record (issue-prefixed or not, branch or detached). split_worktree_record
-  # is trim-safe: non-issue / detached worktrees have an empty leading issue-number
-  # field, which `IFS=$'\t' read` would strip — shifting the path out of WT_PATH.
+  # worktree record, issue-prefixed or not.
   local active_paths=""
   local line
   while IFS= read -r line; do

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -54,6 +54,10 @@ setup() {
   cp "$SCRIPT_DIR/dispatch-trace-leaf" "$TMPDIR_TEST/dispatch-trace-leaf"
   cp "$SCRIPT_DIR/dispatch-complete-phase" "$TMPDIR_TEST/dispatch-complete-phase"
   cp "$SCRIPT_DIR/dispatch-resolve-worktree" "$TMPDIR_TEST/dispatch-resolve-worktree"
+  # dispatch-trace-leaf and dispatch-resolve-worktree `source` lib.sh via their
+  # SCRIPT_DIR, which resolves to TMPDIR_TEST for these copies — so lib.sh must
+  # sit alongside them. It is sourced, not executed, so it needs no chmod +x.
+  cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/lib.sh"
   chmod +x "$TMPDIR_TEST/dispatch-phase" \
            "$TMPDIR_TEST/dispatch-find-pr" \
            "$TMPDIR_TEST/dispatch-resolve-arg" \
@@ -1692,6 +1696,59 @@ setup
 echo '{"title":"!!!"}' > "$STUB_DIR/issue-title-42.json"
 if "$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit 2>/dev/null; then rc=0; else rc=$?; fi
 assert_eq "empty-slug title exits non-zero" "1" "$rc"
+teardown
+
+# ============================================================================
+# list_worktree_records (lib.sh) tests
+# ============================================================================
+echo ""
+echo "=== list_worktree_records ==="
+
+# list_worktree_records emits one tab-separated <issue-number>\t<path>\t<branch>
+# line per registered worktree. Each test sources the lib.sh copy and runs the
+# function in a subshell; the git stub serves the porcelain fixture written to
+# worktree-list.txt.
+
+# 1. Normal worktrees with issue-prefixed branches → issue-number populated.
+echo "Test: issue-prefixed branches → number populated"
+setup
+printf 'worktree /worktrees/42-my-feature\nHEAD def456\nbranch refs/heads/42-my-feature\n\nworktree /worktrees/100-another\nHEAD ghi789\nbranch refs/heads/100-another\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$( source "$TMPDIR_TEST/lib.sh"; list_worktree_records )
+expected=$(printf '42\t/worktrees/42-my-feature\t42-my-feature\n100\t/worktrees/100-another\t100-another')
+assert_eq "issue-prefixed branches → records with number" "$expected" "$result"
+teardown
+
+# 2. A worktree with no branch line (detached HEAD) → empty number and branch.
+#    This is the case cleanup_stale_worktree_processes depends on.
+echo "Test: no branch line → empty number and branch"
+setup
+printf 'worktree /worktrees/detached\nHEAD abc123\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$( source "$TMPDIR_TEST/lib.sh"; list_worktree_records )
+expected=$(printf '\t/worktrees/detached\t')
+assert_eq "detached HEAD → empty number, empty branch" "$expected" "$result"
+teardown
+
+# 3. A non-issue branch name (main) → empty number, branch populated.
+echo "Test: non-issue branch → empty number, branch populated"
+setup
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$( source "$TMPDIR_TEST/lib.sh"; list_worktree_records )
+expected=$(printf '\t/repo\tmain')
+assert_eq "non-issue branch → empty number, branch kept" "$expected" "$result"
+teardown
+
+# 4. Mixed fixture (non-issue + bare + issue-prefixed + detached + non-issue) →
+#    every record emitted in git worktree list input order.
+echo "Test: mixed fixture → all records in input order"
+setup
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /repo/.bare\nbare\n\nworktree /worktrees/42-my-feature\nHEAD def456\nbranch refs/heads/42-my-feature\n\nworktree /worktrees/detached\nHEAD aaa111\n\nworktree /worktrees/feature-x\nHEAD bbb222\nbranch refs/heads/feature-x\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$( source "$TMPDIR_TEST/lib.sh"; list_worktree_records )
+expected=$(printf '\t/repo\tmain\n\t/repo/.bare\t\n42\t/worktrees/42-my-feature\t42-my-feature\n\t/worktrees/detached\t\n\t/worktrees/feature-x\tfeature-x')
+assert_eq "mixed fixture → all records, input order" "$expected" "$result"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1752,6 +1752,66 @@ assert_eq "mixed fixture → all records, input order" "$expected" "$result"
 teardown
 
 # ============================================================================
+# split_worktree_record (lib.sh) tests
+# ============================================================================
+echo ""
+echo "=== split_worktree_record ==="
+
+# split_worktree_record splits one list_worktree_records line into the globals
+# WT_NUM / WT_PATH / WT_BRANCH via parameter expansion — preserving the empty
+# leading/trailing fields that `IFS=$'\t' read` would trim. The function is
+# pure (no git), so each test sources lib.sh in a subshell directly.
+
+# 1. Issue-prefixed record → all three fields populated.
+echo "Test: issue-prefixed record → all fields"
+result=$( source "$SCRIPT_DIR/lib.sh"
+          split_worktree_record $'42\t/wt/42-x\t42-x'
+          printf '%s|%s|%s' "$WT_NUM" "$WT_PATH" "$WT_BRANCH" )
+assert_eq "issue-prefixed record split" "42|/wt/42-x|42-x" "$result"
+
+# 2. Non-issue branch record (empty leading issue-number field) → WT_NUM empty,
+#    WT_PATH and WT_BRANCH intact. This is the record the IFS=$'\t' read idiom
+#    mis-parsed: the leading tab was trimmed, shifting the path into WT_NUM.
+echo "Test: non-issue record → empty WT_NUM, path intact"
+result=$( source "$SCRIPT_DIR/lib.sh"
+          split_worktree_record $'\t/repo\tmain'
+          printf '%s|%s|%s' "$WT_NUM" "$WT_PATH" "$WT_BRANCH" )
+assert_eq "non-issue record split" "|/repo|main" "$result"
+
+# 3. Detached-HEAD / bare record (empty leading and trailing fields) → only
+#    WT_PATH populated.
+echo "Test: detached/bare record → only WT_PATH"
+result=$( source "$SCRIPT_DIR/lib.sh"
+          split_worktree_record $'\t/wt/detached\t'
+          printf '%s|%s|%s' "$WT_NUM" "$WT_PATH" "$WT_BRANCH" )
+assert_eq "detached/bare record split" "|/wt/detached|" "$result"
+
+# 4. Consumer regression: cleanup_stale_worktree_processes' active-set loop.
+#    A non-issue worktree (main) must contribute its FULL PATH to active_paths.
+#    Pre-fix, the `IFS=$'\t' read -r rec_num rec_path rec_branch` loop trimmed
+#    the empty leading issue-number field and recorded the bare branch name
+#    `main` instead of `/repo` — so a process under that worktree failed the
+#    active-set test and was killed as "stale". This test mirrors the loop and
+#    fails on the pre-fix code.
+echo "Test: non-issue worktree path reaches the active set"
+setup
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\nworktree /worktrees/detached\nHEAD ghi789\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+result=$(
+  source "$TMPDIR_TEST/lib.sh"
+  active_paths=""
+  while IFS= read -r line; do
+    split_worktree_record "$line"
+    [ -z "$WT_PATH" ] && continue
+    active_paths+="$WT_PATH "
+  done < <(list_worktree_records)
+  printf '%s' "$active_paths"
+)
+assert_eq "active_paths holds every full worktree path" \
+  "/repo /worktrees/42-x /worktrees/detached " "$result"
+teardown
+
+# ============================================================================
 # dispatch-sweep tests
 # ============================================================================
 echo ""

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1830,8 +1830,7 @@ result=$( source "$SCRIPT_DIR/lib.sh"
 assert_eq "issue-prefixed record split" "42|/wt/42-x|42-x" "$result"
 
 # 2. Non-issue branch record (empty leading issue-number field) → WT_NUM empty,
-#    WT_PATH and WT_BRANCH intact. This is the record the IFS=$'\t' read idiom
-#    mis-parsed: the leading tab was trimmed, shifting the path into WT_NUM.
+#    WT_PATH and WT_BRANCH intact.
 echo "Test: non-issue record → empty WT_NUM, path intact"
 result=$( source "$SCRIPT_DIR/lib.sh"
           split_worktree_record $'\t/repo\tmain'
@@ -1846,13 +1845,10 @@ result=$( source "$SCRIPT_DIR/lib.sh"
           printf '%s|%s|%s' "$WT_NUM" "$WT_PATH" "$WT_BRANCH" )
 assert_eq "detached/bare record split" "|/wt/detached|" "$result"
 
-# 4. Consumer regression: cleanup_stale_worktree_processes' active-set loop.
-#    A non-issue worktree (main) must contribute its FULL PATH to active_paths.
-#    Pre-fix, the `IFS=$'\t' read -r rec_num rec_path rec_branch` loop trimmed
-#    the empty leading issue-number field and recorded the bare branch name
-#    `main` instead of `/repo` — so a process under that worktree failed the
-#    active-set test and was killed as "stale". This test mirrors the loop and
-#    fails on the pre-fix code.
+# 4. Integration: mirrors cleanup_stale_worktree_processes' active-set loop.
+#    Every worktree path, including a non-issue worktree like `main`, must reach
+#    active_paths intact — split_worktree_record must not let the bare branch
+#    name `main` land there in place of the path `/repo`.
 echo "Test: non-issue worktree path reaches the active set"
 setup
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\nworktree /worktrees/detached\nHEAD ghi789\n\n' \


### PR DESCRIPTION
Centralizes the duplicated `git worktree list --porcelain` parsing that
three dispatch scripts each re-implemented (`dispatch-trace-leaf`,
`dispatch-resolve-worktree`, and `lib.sh`'s `cleanup_stale_worktree_processes`).

## Change

- Add `list_worktree_records` to `lib.sh` — one porcelain record-walk
  that emits a tab-separated `<issue-number>\t<path>\t<branch>` line per
  registered worktree.
- The helper emits **every** worktree, with `<issue-number>` empty for
  non-issue branches and `<branch>` empty for detached-HEAD / bare
  worktrees. This keeps `cleanup_stale_worktree_processes` behavior
  unchanged — it depends on seeing every worktree path — while
  `dispatch-trace-leaf` and `dispatch-resolve-worktree` simply skip
  empty-issue-number records. (The issue's AC1/AC2 wording — skip
  non-issue/detached worktrees — conflicts with AC5's "behavior
  unchanged"; emitting all records resolves the conflict.)
- Refactor all three call sites onto the helper.

No behavior change intended.

## Verification

- `test-dispatch-scripts.sh` — 191/191 pass (187 pre-existing + 4 new
  `list_worktree_records` tests covering issue-prefixed, branchless,
  non-issue, and mixed fixtures).
- `test-pid-cleanup.sh` — 10/10 pass, confirming the
  `cleanup_stale_worktree_processes` refactor preserved behavior.

Closes #710