### PR TITLE
dispatch: local config files and project helpers for the JIT engine

### DIFF
--- a/.claude/skills/dispatch/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch/scripts/dispatch-config-load
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# dispatch-config-load — load and validate a local dispatch config file.
+#
+# Reads non-version-controlled config from a project-root dispatch.config/
+# directory (outside every git worktree, shared across worktrees). Validates
+# the parsed JSON against the schema for the requested config type and prints
+# the normalized result to stdout.
+#
+# Usage:
+#   dispatch-config-load <projects|jit>
+#
+# Config files live in <project-root>/dispatch.config/. The project root is
+# the parent of git --git-common-dir (same idiom as dispatch-acquire-lock).
+#
+# Stdout protocol:
+#   <normalized JSON>   file present and valid — prints jq-normalized JSON.
+#   no-config           file absent — the feature is treated as inert.
+#
+# Exit codes:
+#   0  valid JSON printed, or file absent (no-config).
+#   1  file present but invalid JSON or fails schema validation.
+#   2  usage error or environment misconfiguration.
+#
+# Environment overrides for testability:
+#   DISPATCH_CONFIG_DIR   Override the config directory path. When set and
+#                         non-empty, the script does NOT require a git repo.
+#                         Default: <project-root>/dispatch.config/
+#
+# ---- Schema: projects.json --------------------------------------------------
+#
+# Top-level object with a required "projects" array. Each element is an object
+# with these required fields:
+#
+#   key             string (non-empty) — local identifier for the project.
+#   owner           string (non-empty) — GitHub org or user owning the project.
+#   number          number             — GitHub project number.
+#   statusField     string (non-empty) — name of the project's Status field.
+#   statusInProgress string (non-empty) — Status option name for "in progress".
+#   statusDone      string (non-empty) — Status option name for "done".
+#
+# Example (see projects.example.json):
+#   {
+#     "projects": [
+#       { "key": "example-project", "owner": "example-owner", "number": 1,
+#         "statusField": "Status", "statusInProgress": "In Progress",
+#         "statusDone": "Done" }
+#     ]
+#   }
+#
+# ---- Schema: jit.json -------------------------------------------------------
+#
+# Top-level object with a required "jits" array. Each element is an object
+# with these required fields:
+#
+#   key     string (non-empty) — unique identifier for the jit. Used as the
+#           label suffix: the engine stamps "jit:<key>" on created issues.
+#   repo    string (non-empty) — GitHub repo in "owner/repo" form.
+#   label   string (non-empty) — full label name, typically "jit:<key>".
+#   title   string (non-empty) — issue title.
+#   body    string (non-empty) — issue body.
+#   project string (non-empty) — "key" of an entry in projects.json.
+#
+# Optional timing fields (each must be a string if present):
+#
+#   remindAfterClose  duration string, e.g. "12h" — cadence jit: how long
+#                     after the last closed issue to create the next one.
+#   dueAfterClose     duration string, e.g. "24h" — cadence jit: due time
+#                     offset from the last closed issue's closedAt.
+#   dueAfterCreate    duration string — check-script jit: due time offset
+#                     from the issue's createdAt.
+#   debounce          duration string, e.g. "1h" — how often the jit engine
+#                     re-checks this jit (skips network calls within window).
+#   check             object with "script" (string) and optional "args" keys —
+#                     check-script jit: run this script to decide whether to
+#                     create an issue.
+#
+# Timing-field semantics (cadence vs check-script) are validated by the JIT
+# engine, not here. This loader only checks types.
+#
+# Example (see jit.example.json):
+#   {
+#     "jits": [
+#       { "key": "example-chore", "repo": "example-owner/example-repo",
+#         "label": "jit:example-chore", "title": "Example recurring chore",
+#         "body": "Recurring example chore. Close this issue when done.",
+#         "project": "example-project",
+#         "remindAfterClose": "12h", "dueAfterClose": "24h", "debounce": "1h" }
+#     ]
+#   }
+set -euo pipefail
+
+# ---- Step 0: parse arguments ------------------------------------------------
+
+CONFIG_TYPE="${1:-}"
+case "$CONFIG_TYPE" in
+  projects|jit) ;;
+  *)
+    echo "error: usage: dispatch-config-load <projects|jit>" >&2
+    exit 2
+    ;;
+esac
+
+# ---- Step 1: resolve the config directory -----------------------------------
+# An explicit DISPATCH_CONFIG_DIR is authoritative and bypasses the git lookup —
+# tests rely on this. Otherwise the config lives at the shared project-root
+# dispatch.config/ (not a per-worktree path) so all worktrees share one config.
+# The parent of --git-common-dir is the project root in both classic (.git) and
+# bare (.bare) layouts, same idiom as dispatch-acquire-lock.
+if [[ -n "${DISPATCH_CONFIG_DIR:-}" ]]; then
+  CONFIG_DIR="$DISPATCH_CONFIG_DIR"
+else
+  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
+    || { echo "error: not in a git repo and DISPATCH_CONFIG_DIR is unset" >&2; exit 2; }
+  PROJECT_ROOT=$(dirname "$GIT_COMMON_DIR")
+  CONFIG_DIR="$PROJECT_ROOT/dispatch.config"
+fi
+
+# ---- Step 2: locate the target file -----------------------------------------
+
+CONFIG_FILE="$CONFIG_DIR/${CONFIG_TYPE}.json"
+
+if [[ ! -e "$CONFIG_FILE" ]]; then
+  echo "no-config"
+  exit 0
+fi
+
+# ---- Step 3: parse and validate ---------------------------------------------
+
+# Validate JSON syntax first. jq exits non-zero on invalid JSON.
+# Capture stderr inline using a subshell to avoid temp files.
+PARSE_ERR=""
+if ! PARSED=$(jq '.' "$CONFIG_FILE" 2>&1); then
+  # jq merged stdout+stderr in the error case; split off the error message.
+  PARSE_ERR="$PARSED"
+  echo "error: $CONFIG_FILE: invalid JSON: $PARSE_ERR" >&2
+  exit 1
+fi
+
+# Run schema validation. The validator emits one error-description line per
+# problem and nothing when the config is valid.
+case "$CONFIG_TYPE" in
+  projects)
+    ERRORS=$(jq -r '
+      # top-level .projects must be an array
+      if (.projects | type) != "array" then
+        "top-level .projects must be an array, got \(.projects | type)"
+      else
+        .projects | to_entries[] |
+        .value as $item |
+        (.key + 1) as $idx |
+        if ($item | type) != "object" then
+          "projects[\($idx)]: must be an object, got \($item | type)"
+        else
+          # required string fields (non-empty)
+          (["key","owner","statusField","statusInProgress","statusDone"] |
+          .[] |
+          . as $field |
+          if ($item | has($field)) | not then
+            "projects[\($idx)]: missing required field \($field)"
+          elif ($item[$field] | type) != "string" then
+            "projects[\($idx)]: \($field) must be a string, got \($item[$field] | type)"
+          elif ($item[$field] | length) == 0 then
+            "projects[\($idx)]: \($field) must be a non-empty string"
+          else
+            empty
+          end),
+          # required number field
+          if ($item | has("number")) | not then
+            "projects[\($idx)]: missing required field number"
+          elif ($item["number"] | type) != "number" then
+            "projects[\($idx)]: number must be a number, got \($item["number"] | type)"
+          else
+            empty
+          end
+        end
+      end
+    ' "$CONFIG_FILE")
+    ;;
+  jit)
+    ERRORS=$(jq -r '
+      # top-level .jits must be an array
+      if (.jits | type) != "array" then
+        "top-level .jits must be an array, got \(.jits | type)"
+      else
+        .jits | to_entries[] |
+        .value as $item |
+        (.key + 1) as $idx |
+        if ($item | type) != "object" then
+          "jits[\($idx)]: must be an object, got \($item | type)"
+        else
+          # required string fields (non-empty)
+          (["key","repo","label","title","body","project"] |
+          .[] |
+          . as $field |
+          if ($item | has($field)) | not then
+            "jits[\($idx)]: missing required field \($field)"
+          elif ($item[$field] | type) != "string" then
+            "jits[\($idx)]: \($field) must be a string, got \($item[$field] | type)"
+          elif ($item[$field] | length) == 0 then
+            "jits[\($idx)]: \($field) must be a non-empty string"
+          else
+            empty
+          end),
+          # optional timing fields — must be strings if present
+          (["remindAfterClose","dueAfterClose","dueAfterCreate","debounce"] |
+          .[] |
+          . as $field |
+          if ($item | has($field)) and ($item[$field] | type) != "string" then
+            "jits[\($idx)]: \($field) must be a string if present, got \($item[$field] | type)"
+          else
+            empty
+          end)
+        end
+      end
+    ' "$CONFIG_FILE")
+    ;;
+esac
+
+if [[ -n "$ERRORS" ]]; then
+  while IFS= read -r line; do
+    echo "error: $CONFIG_FILE: $line" >&2
+  done <<< "$ERRORS"
+  exit 1
+fi
+
+# ---- Step 4: print normalized JSON ------------------------------------------
+
+printf '%s\n' "$PARSED"

--- a/.claude/skills/dispatch/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch/scripts/dispatch-config-load
@@ -126,13 +126,10 @@ fi
 
 # ---- Step 3: parse and validate ---------------------------------------------
 
-# Validate JSON syntax first. jq exits non-zero on invalid JSON.
-# Capture stderr inline using a subshell to avoid temp files.
-PARSE_ERR=""
+# Validate JSON syntax first. jq exits non-zero on invalid JSON; 2>&1 folds its
+# error message into $PARSED so it can be surfaced without a temp file.
 if ! PARSED=$(jq '.' "$CONFIG_FILE" 2>&1); then
-  # jq merged stdout+stderr in the error case; split off the error message.
-  PARSE_ERR="$PARSED"
-  echo "error: $CONFIG_FILE: invalid JSON: $PARSE_ERR" >&2
+  echo "error: $CONFIG_FILE: invalid JSON: $PARSED" >&2
   exit 1
 fi
 

--- a/.claude/skills/dispatch/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch/scripts/dispatch-config-load
@@ -133,13 +133,22 @@ if ! PARSED=$(jq '.' "$CONFIG_FILE" 2>&1); then
   exit 1
 fi
 
+# An empty or whitespace-only file produces zero JSON values: jq '.' prints
+# nothing and exits 0, leaving $PARSED empty. Treat that as malformed input.
+if [[ -z "$PARSED" ]]; then
+  echo "error: $CONFIG_FILE: file is empty or contains no JSON value" >&2
+  exit 1
+fi
+
 # Run schema validation. The validator emits one error-description line per
 # problem and nothing when the config is valid.
 case "$CONFIG_TYPE" in
   projects)
     ERRORS=$(jq -r '
-      # top-level .projects must be an array
-      if (.projects | type) != "array" then
+      # top-level value must be an object; .projects must be an array
+      if type != "object" then
+        "top-level value must be a JSON object, got \(type)"
+      elif (.projects | type) != "array" then
         "top-level .projects must be an array, got \(.projects | type)"
       else
         .projects | to_entries[] |
@@ -175,8 +184,10 @@ case "$CONFIG_TYPE" in
     ;;
   jit)
     ERRORS=$(jq -r '
-      # top-level .jits must be an array
-      if (.jits | type) != "array" then
+      # top-level value must be an object; .jits must be an array
+      if type != "object" then
+        "top-level value must be a JSON object, got \(type)"
+      elif (.jits | type) != "array" then
         "top-level .jits must be an array, got \(.jits | type)"
       else
         .jits | to_entries[] |

--- a/.claude/skills/dispatch/scripts/dispatch-project-item-add
+++ b/.claude/skills/dispatch/scripts/dispatch-project-item-add
@@ -64,4 +64,9 @@ NUMBER=$(printf '%s' "$PROJECT" | jq -r '.number')
 RESULT=$(gh project item-add "$NUMBER" --owner "$OWNER" --url "$ISSUE_URL" \
   --format json)
 
-printf '%s' "$RESULT" | jq -r '.id'
+ITEM_ID=$(printf '%s' "$RESULT" | jq -r '.id // empty')
+if [[ -z "$ITEM_ID" ]]; then
+  echo "error: gh project item-add returned no item id for $ISSUE_URL" >&2
+  exit 1
+fi
+printf '%s\n' "$ITEM_ID"

--- a/.claude/skills/dispatch/scripts/dispatch-project-item-add
+++ b/.claude/skills/dispatch/scripts/dispatch-project-item-add
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# dispatch-project-item-add — add a GitHub issue to a project.
+#
+# Resolves a project from the local dispatch config (via dispatch-config-load)
+# and adds the given issue to it, printing the new project item id.
+#
+# Usage:
+#   dispatch-project-item-add <project-key> <issue-url>
+#
+# Arguments:
+#   <project-key>  key of an entry in dispatch.config/projects.json.
+#   <issue-url>    full GitHub issue URL, e.g.
+#                  https://github.com/owner/repo/issues/42
+#
+# Stdout:
+#   The new project item id (e.g. PVTI_...) on success.
+#
+# Exit codes:
+#   0  issue added; item id printed.
+#   1  no config present, project key absent, or gh failure.
+#   2  usage error.
+#
+# Dependency: invokes the `gh` CLI. Per .claude/rules/sandbox.md, callers must
+# wrap this script with dangerouslyDisableSandbox — gh's TLS validation is
+# blocked by the sandbox. This script does not alter its behavior for the
+# sandbox; that is the caller's responsibility.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ---- Step 0: parse arguments ------------------------------------------------
+
+if [[ $# -ne 2 ]]; then
+  echo "error: usage: dispatch-project-item-add <project-key> <issue-url>" >&2
+  exit 2
+fi
+PROJECT_KEY="$1"
+ISSUE_URL="$2"
+if [[ -z "$PROJECT_KEY" || -z "$ISSUE_URL" ]]; then
+  echo "error: usage: dispatch-project-item-add <project-key> <issue-url>" >&2
+  exit 2
+fi
+
+# ---- Step 1: resolve the project from local config -------------------------
+
+PROJECTS=$("$SCRIPT_DIR/dispatch-config-load" projects)
+if [[ "$PROJECTS" == "no-config" ]]; then
+  echo "error: no projects.json config present; cannot resolve project '$PROJECT_KEY'" >&2
+  exit 1
+fi
+
+PROJECT=$(printf '%s' "$PROJECTS" | jq -c --arg key "$PROJECT_KEY" \
+  '.projects[] | select(.key == $key)')
+if [[ -z "$PROJECT" ]]; then
+  echo "error: project key '$PROJECT_KEY' not found in projects.json" >&2
+  exit 1
+fi
+
+OWNER=$(printf '%s' "$PROJECT" | jq -r '.owner')
+NUMBER=$(printf '%s' "$PROJECT" | jq -r '.number')
+
+# ---- Step 2: add the issue to the project ----------------------------------
+
+RESULT=$(gh project item-add "$NUMBER" --owner "$OWNER" --url "$ISSUE_URL" \
+  --format json)
+
+printf '%s' "$RESULT" | jq -r '.id'

--- a/.claude/skills/dispatch/scripts/dispatch-project-status-read
+++ b/.claude/skills/dispatch/scripts/dispatch-project-status-read
@@ -76,6 +76,10 @@ STATUS_KEY=$(printf '%s' "$STATUS_FIELD" | jq -rR '
 
 # ---- Step 2: locate the project item for the issue -------------------------
 
+# gh project item-list has no server-side filter for a specific issue URL, so
+# the matching item is found client-side below. --limit caps the fetch; 5000
+# covers any realistic project. A project larger than that would silently
+# truncate and the lookup could wrongly report the issue as absent.
 ITEMS=$(gh project item-list "$NUMBER" --owner "$OWNER" --limit 5000 \
   --format json)
 

--- a/.claude/skills/dispatch/scripts/dispatch-project-status-read
+++ b/.claude/skills/dispatch/scripts/dispatch-project-status-read
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# dispatch-project-status-read — read an issue's project item id and Status.
+#
+# Resolves a project from the local dispatch config (via dispatch-config-load),
+# finds the project item for the given issue, and prints its item id and the
+# value of the project's configured Status field.
+#
+# Usage:
+#   dispatch-project-status-read <project-key> <issue-url>
+#
+# Arguments:
+#   <project-key>  key of an entry in dispatch.config/projects.json.
+#   <issue-url>    full GitHub issue URL, e.g.
+#                  https://github.com/owner/repo/issues/42
+#
+# Stdout:
+#   A JSON object: {"itemId":"<id>","status":<value>} where <value> is the
+#   item's value for the configured statusField, or JSON null when unset.
+#
+# Exit codes:
+#   0  item found; JSON printed.
+#   1  no config present, project key absent, the issue is not on the project,
+#      or gh failure.
+#   2  usage error.
+#
+# Dependency: invokes the `gh` CLI. Per .claude/rules/sandbox.md, callers must
+# wrap this script with dangerouslyDisableSandbox — gh's TLS validation is
+# blocked by the sandbox. This script does not alter its behavior for the
+# sandbox; that is the caller's responsibility.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ---- Step 0: parse arguments ------------------------------------------------
+
+if [[ $# -ne 2 ]]; then
+  echo "error: usage: dispatch-project-status-read <project-key> <issue-url>" >&2
+  exit 2
+fi
+PROJECT_KEY="$1"
+ISSUE_URL="$2"
+if [[ -z "$PROJECT_KEY" || -z "$ISSUE_URL" ]]; then
+  echo "error: usage: dispatch-project-status-read <project-key> <issue-url>" >&2
+  exit 2
+fi
+
+# ---- Step 1: resolve the project from local config -------------------------
+
+PROJECTS=$("$SCRIPT_DIR/dispatch-config-load" projects)
+if [[ "$PROJECTS" == "no-config" ]]; then
+  echo "error: no projects.json config present; cannot resolve project '$PROJECT_KEY'" >&2
+  exit 1
+fi
+
+PROJECT=$(printf '%s' "$PROJECTS" | jq -c --arg key "$PROJECT_KEY" \
+  '.projects[] | select(.key == $key)')
+if [[ -z "$PROJECT" ]]; then
+  echo "error: project key '$PROJECT_KEY' not found in projects.json" >&2
+  exit 1
+fi
+
+OWNER=$(printf '%s' "$PROJECT" | jq -r '.owner')
+NUMBER=$(printf '%s' "$PROJECT" | jq -r '.number')
+STATUS_FIELD=$(printf '%s' "$PROJECT" | jq -r '.statusField')
+
+# gh exposes a project field's values under the lowerCamelCase form of its
+# name (e.g. "Status" -> "status", "My Field" -> "myField"). Derive that key.
+STATUS_KEY=$(printf '%s' "$STATUS_FIELD" | jq -rR '
+  ([splits(" +")] | map(select(length > 0))) as $words |
+  if ($words | length) == 0 then "" else
+    ($words | to_entries | map(
+      if .key == 0 then (.value[0:1] | ascii_downcase) + .value[1:]
+      else (.value[0:1] | ascii_upcase) + .value[1:] end
+    ) | join(""))
+  end')
+
+# ---- Step 2: locate the project item for the issue -------------------------
+
+ITEMS=$(gh project item-list "$NUMBER" --owner "$OWNER" --limit 5000 \
+  --format json)
+
+ITEM=$(printf '%s' "$ITEMS" | jq -c --arg url "$ISSUE_URL" \
+  '.items[] | select(.content.url == $url)')
+if [[ -z "$ITEM" ]]; then
+  echo "error: issue '$ISSUE_URL' is not on project '$PROJECT_KEY'" >&2
+  exit 1
+fi
+
+# ---- Step 3: print the item id and Status value ----------------------------
+
+printf '%s' "$ITEM" | jq -c --arg statusKey "$STATUS_KEY" \
+  '{itemId: .id, status: (.[$statusKey] // null)}'

--- a/.claude/skills/dispatch/scripts/dispatch-project-status-write
+++ b/.claude/skills/dispatch/scripts/dispatch-project-status-write
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# dispatch-project-status-write — set a project item's single-select Status.
+#
+# Resolves a project from the local dispatch config (via dispatch-config-load),
+# resolves the project node id, the Status field id, and the target option id,
+# locates the issue's project item (via dispatch-project-status-read), and
+# applies the new Status value.
+#
+# Usage:
+#   dispatch-project-status-write <project-key> <issue-url> <status-value>
+#
+# Arguments:
+#   <project-key>   key of an entry in dispatch.config/projects.json.
+#   <issue-url>     full GitHub issue URL, e.g.
+#                   https://github.com/owner/repo/issues/42
+#   <status-value>  the Status option name to set, e.g. "In Progress".
+#
+# Exit codes:
+#   0  Status applied.
+#   1  no config present, project key absent, the Status field or option is
+#      not found, the issue is not on the project, or gh failure.
+#   2  usage error.
+#
+# Dependency: invokes the `gh` CLI. Per .claude/rules/sandbox.md, callers must
+# wrap this script with dangerouslyDisableSandbox — gh's TLS validation is
+# blocked by the sandbox. This script does not alter its behavior for the
+# sandbox; that is the caller's responsibility.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ---- Step 0: parse arguments ------------------------------------------------
+
+if [[ $# -ne 3 ]]; then
+  echo "error: usage: dispatch-project-status-write <project-key> <issue-url> <status-value>" >&2
+  exit 2
+fi
+PROJECT_KEY="$1"
+ISSUE_URL="$2"
+STATUS_VALUE="$3"
+if [[ -z "$PROJECT_KEY" || -z "$ISSUE_URL" || -z "$STATUS_VALUE" ]]; then
+  echo "error: usage: dispatch-project-status-write <project-key> <issue-url> <status-value>" >&2
+  exit 2
+fi
+
+# ---- Step 1: resolve the project from local config -------------------------
+
+PROJECTS=$("$SCRIPT_DIR/dispatch-config-load" projects)
+if [[ "$PROJECTS" == "no-config" ]]; then
+  echo "error: no projects.json config present; cannot resolve project '$PROJECT_KEY'" >&2
+  exit 1
+fi
+
+PROJECT=$(printf '%s' "$PROJECTS" | jq -c --arg key "$PROJECT_KEY" \
+  '.projects[] | select(.key == $key)')
+if [[ -z "$PROJECT" ]]; then
+  echo "error: project key '$PROJECT_KEY' not found in projects.json" >&2
+  exit 1
+fi
+
+OWNER=$(printf '%s' "$PROJECT" | jq -r '.owner')
+NUMBER=$(printf '%s' "$PROJECT" | jq -r '.number')
+STATUS_FIELD=$(printf '%s' "$PROJECT" | jq -r '.statusField')
+
+# ---- Step 2: resolve the project node id -----------------------------------
+
+PROJECT_VIEW=$(gh project view "$NUMBER" --owner "$OWNER" --format json)
+PROJECT_NODE_ID=$(printf '%s' "$PROJECT_VIEW" | jq -r '.id')
+
+# ---- Step 3: resolve the Status field id and the target option id ----------
+
+FIELDS=$(gh project field-list "$NUMBER" --owner "$OWNER" --format json)
+
+FIELD=$(printf '%s' "$FIELDS" | jq -c --arg name "$STATUS_FIELD" \
+  '.fields[] | select(.name == $name)')
+if [[ -z "$FIELD" ]]; then
+  echo "error: Status field '$STATUS_FIELD' not found on project '$PROJECT_KEY'" >&2
+  exit 1
+fi
+FIELD_ID=$(printf '%s' "$FIELD" | jq -r '.id')
+
+OPTION_ID=$(printf '%s' "$FIELD" | jq -r --arg opt "$STATUS_VALUE" \
+  '(.options[]? | select(.name == $opt) | .id) // empty')
+if [[ -z "$OPTION_ID" ]]; then
+  echo "error: Status option '$STATUS_VALUE' not found in field '$STATUS_FIELD' on project '$PROJECT_KEY'" >&2
+  exit 1
+fi
+
+# ---- Step 4: resolve the item id via the status reader ---------------------
+# Propagates the reader's failure if the issue is not on the project.
+
+ITEM_JSON=$("$SCRIPT_DIR/dispatch-project-status-read" "$PROJECT_KEY" "$ISSUE_URL")
+ITEM_ID=$(printf '%s' "$ITEM_JSON" | jq -r '.itemId')
+
+# ---- Step 5: apply the new Status value ------------------------------------
+
+gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_NODE_ID" \
+  --field-id "$FIELD_ID" --single-select-option-id "$OPTION_ID" >/dev/null
+
+echo "set Status to '$STATUS_VALUE' for $ISSUE_URL"

--- a/.claude/skills/dispatch/scripts/dispatch-project-status-write
+++ b/.claude/skills/dispatch/scripts/dispatch-project-status-write
@@ -90,7 +90,11 @@ fi
 # Propagates the reader's failure if the issue is not on the project.
 
 ITEM_JSON=$("$SCRIPT_DIR/dispatch-project-status-read" "$PROJECT_KEY" "$ISSUE_URL")
-ITEM_ID=$(printf '%s' "$ITEM_JSON" | jq -r '.itemId')
+ITEM_ID=$(printf '%s' "$ITEM_JSON" | jq -r '.itemId // empty')
+if [[ -z "$ITEM_ID" ]]; then
+  echo "error: could not resolve a project item id for $ISSUE_URL" >&2
+  exit 1
+fi
 
 # ---- Step 5: apply the new Status value ------------------------------------
 

--- a/.claude/skills/dispatch/scripts/jit.example.json
+++ b/.claude/skills/dispatch/scripts/jit.example.json
@@ -1,0 +1,15 @@
+{
+  "jits": [
+    {
+      "key": "example-chore",
+      "repo": "example-owner/example-repo",
+      "label": "jit:example-chore",
+      "title": "Example recurring chore",
+      "body": "Recurring example chore. Close this issue when done.",
+      "project": "example-project",
+      "remindAfterClose": "12h",
+      "dueAfterClose": "24h",
+      "debounce": "1h"
+    }
+  ]
+}

--- a/.claude/skills/dispatch/scripts/projects.example.json
+++ b/.claude/skills/dispatch/scripts/projects.example.json
@@ -1,0 +1,12 @@
+{
+  "projects": [
+    {
+      "key": "example-project",
+      "owner": "example-owner",
+      "number": 1,
+      "statusField": "Status",
+      "statusInProgress": "In Progress",
+      "statusDone": "Done"
+    }
+  ]
+}

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2495,6 +2495,142 @@ assert_eq "spare-ancestor walk records the session PID, not the spare daemon" \
 lock_teardown
 
 # ============================================================================
+# dispatch-config-load tests
+# ============================================================================
+#
+# Each test gets a fresh tmp tree:
+#   $TMPDIR_TEST/scripts/   a copy of dispatch-config-load
+#   $TMPDIR_TEST/config/    synthetic config directory (DISPATCH_CONFIG_DIR)
+#
+# DISPATCH_CONFIG_DIR is exported so the script never touches the real
+# dispatch.config/ directory and does not require a git repo.
+
+config_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/config"
+
+  cp "$SCRIPT_DIR/dispatch-config-load" "$TMPDIR_TEST/scripts/dispatch-config-load"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-config-load"
+
+  export DISPATCH_CONFIG_DIR="$TMPDIR_TEST/config"
+}
+
+config_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  unset DISPATCH_CONFIG_DIR
+}
+
+# --- Test 1: valid projects.json prints normalized JSON ----------------------
+
+echo "Test: valid projects.json prints normalized JSON"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/projects.json" <<'EOF'
+{
+  "projects": [
+    {
+      "key": "test-project",
+      "owner": "test-owner",
+      "number": 42,
+      "statusField": "Status",
+      "statusInProgress": "In Progress",
+      "statusDone": "Done"
+    }
+  ]
+}
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" projects 2>/dev/null); rc=$?
+assert_eq "valid projects.json exits 0" "0" "$rc"
+key=$(printf '%s' "$out" | jq -r '.projects[0].key')
+assert_eq "valid projects.json key" "test-project" "$key"
+owner=$(printf '%s' "$out" | jq -r '.projects[0].owner')
+assert_eq "valid projects.json owner" "test-owner" "$owner"
+config_teardown
+
+# --- Test 2: valid jit.json prints normalized JSON ---------------------------
+
+echo "Test: valid jit.json prints normalized JSON"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/jit.json" <<'EOF'
+{
+  "jits": [
+    {
+      "key": "test-chore",
+      "repo": "test-owner/test-repo",
+      "label": "jit:test-chore",
+      "title": "Test recurring chore",
+      "body": "Test chore body.",
+      "project": "test-project",
+      "remindAfterClose": "12h",
+      "dueAfterClose": "24h",
+      "debounce": "1h"
+    }
+  ]
+}
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" jit 2>/dev/null); rc=$?
+assert_eq "valid jit.json exits 0" "0" "$rc"
+jit_key=$(printf '%s' "$out" | jq -r '.jits[0].key')
+assert_eq "valid jit.json key" "test-chore" "$jit_key"
+jit_label=$(printf '%s' "$out" | jq -r '.jits[0].label')
+assert_eq "valid jit.json label" "jit:test-chore" "$jit_label"
+config_teardown
+
+# --- Test 3: absent file prints no-config and exits 0 ------------------------
+
+echo "Test: absent file prints no-config and exits 0"
+config_setup
+# no file written — config dir is empty
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" projects 2>/dev/null); rc=$?
+assert_eq "absent file exits 0" "0" "$rc"
+assert_eq "absent file prints no-config" "no-config" "$out"
+config_teardown
+
+# --- Test 4: invalid JSON exits 1 with an error ------------------------------
+
+echo "Test: invalid JSON exits 1 and stderr mentions the cause"
+config_setup
+printf 'not valid json {{{' > "$DISPATCH_CONFIG_DIR/projects.json"
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" projects 2>&1 1>/dev/null) || rc=$?
+assert_eq "invalid JSON exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"invalid JSON"* || "$err" == *"parse error"* || "$err" == *"Invalid"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: invalid JSON stderr mentions the cause"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: invalid JSON stderr mentions the cause"
+  echo "    stderr: $err"
+fi
+config_teardown
+
+# --- Test 5: missing required field exits 1 and names the field --------------
+
+echo "Test: missing required field exits 1 and stderr names the field"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/projects.json" <<'EOF'
+{
+  "projects": [
+    {
+      "key": "test-project",
+      "owner": "test-owner",
+      "number": 1,
+      "statusInProgress": "In Progress",
+      "statusDone": "Done"
+    }
+  ]
+}
+EOF
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" projects 2>&1 1>/dev/null) || rc=$?
+assert_eq "missing required field exits 1" "1" "$rc"
+if [[ "$err" == *"statusField"* ]]; then
+  assert_eq "missing-field error names the field" "yes" "yes"
+else
+  assert_eq "missing-field error names the field" "yes" "no: $err"
+fi
+config_teardown
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2631,6 +2631,218 @@ fi
 config_teardown
 
 # ============================================================================
+# dispatch project-helper tests (item-add / status-read / status-write)
+# ============================================================================
+#
+# Each test gets a fresh tmp tree:
+#   $TMPDIR_TEST/scripts/   copies of the loader + the three project helpers
+#   $TMPDIR_TEST/config/    synthetic config directory (DISPATCH_CONFIG_DIR)
+#   $TMPDIR_TEST/stub/      gh stub fixtures (item-list / field-list / view)
+#   $TMPDIR_TEST/bin/       the gh PATH stub
+#
+# DISPATCH_CONFIG_DIR points at the synthetic config so the loader resolves the
+# catalog without a git repo. The helpers resolve each other and the loader via
+# SCRIPT_DIR, so all four scripts are co-located. The gh stub's item-edit case
+# mutates item-list.json so a follow-up item-list reflects the Status change.
+
+proj_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  STUB_DIR="$TMPDIR_TEST/stub"
+  mkdir -p "$STUB_DIR" "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/bin" \
+    "$TMPDIR_TEST/config"
+
+  cp "$SCRIPT_DIR/dispatch-config-load" "$TMPDIR_TEST/scripts/dispatch-config-load"
+  cp "$SCRIPT_DIR/dispatch-project-item-add" \
+    "$TMPDIR_TEST/scripts/dispatch-project-item-add"
+  cp "$SCRIPT_DIR/dispatch-project-status-read" \
+    "$TMPDIR_TEST/scripts/dispatch-project-status-read"
+  cp "$SCRIPT_DIR/dispatch-project-status-write" \
+    "$TMPDIR_TEST/scripts/dispatch-project-status-write"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-config-load" \
+           "$TMPDIR_TEST/scripts/dispatch-project-item-add" \
+           "$TMPDIR_TEST/scripts/dispatch-project-status-read" \
+           "$TMPDIR_TEST/scripts/dispatch-project-status-write"
+
+  # Config fixture: one project, key example-project.
+  cat > "$TMPDIR_TEST/config/projects.json" <<'EOF'
+{
+  "projects": [
+    {
+      "key": "example-project",
+      "owner": "example-owner",
+      "number": 1,
+      "statusField": "Status",
+      "statusInProgress": "In Progress",
+      "statusDone": "Done"
+    }
+  ]
+}
+EOF
+  export DISPATCH_CONFIG_DIR="$TMPDIR_TEST/config"
+
+  # gh stub fixtures.
+  cat > "$STUB_DIR/item-list.json" <<'EOF'
+{
+  "items": [
+    {
+      "id": "PVTI_item001",
+      "content": {
+        "type": "Issue",
+        "number": 42,
+        "repository": "https://github.com/example-owner/example-repo",
+        "url": "https://github.com/example-owner/example-repo/issues/42"
+      },
+      "status": "Todo"
+    }
+  ],
+  "totalCount": 1
+}
+EOF
+  cat > "$STUB_DIR/field-list.json" <<'EOF'
+{
+  "fields": [
+    { "id": "PVTF_title", "name": "Title", "type": "ProjectV2Field" },
+    {
+      "id": "PVTSSF_status",
+      "name": "Status",
+      "type": "ProjectV2SingleSelectField",
+      "options": [
+        { "id": "opt_todo", "name": "Todo" },
+        { "id": "opt_inprogress", "name": "In Progress" },
+        { "id": "opt_done", "name": "Done" }
+      ]
+    }
+  ],
+  "totalCount": 2
+}
+EOF
+  cat > "$STUB_DIR/project-view.json" <<'EOF'
+{ "id": "PVT_project001", "number": 1, "title": "Example Project" }
+EOF
+
+  # gh PATH stub.
+  cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
+args="$*"
+case "$args" in
+  "project item-add "*)
+    echo "$args" >> "$STUB_DIR/gh-item-add.log"
+    echo '{"id":"PVTI_added001","title":"Added issue","type":"Issue"}'
+    ;;
+  "project item-list "*)
+    cat "$STUB_DIR/item-list.json"
+    ;;
+  "project field-list "*)
+    cat "$STUB_DIR/field-list.json"
+    ;;
+  "project view "*)
+    cat "$STUB_DIR/project-view.json"
+    ;;
+  "project item-edit "*)
+    echo "$args" >> "$STUB_DIR/gh-item-edit.log"
+    # Parse --id and --single-select-option-id out of the args.
+    item_id=""
+    option_id=""
+    set -- $args
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --id) item_id="$2"; shift 2 ;;
+        --single-select-option-id) option_id="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    # Map the option id back to its option name via field-list.json.
+    option_name=$(jq -r --arg oid "$option_id" \
+      '.fields[] | .options[]? | select(.id == $oid) | .name' \
+      "$STUB_DIR/field-list.json")
+    # Set the matching item's status key so a follow-up item-list reflects it.
+    tmp=$(mktemp)
+    jq --arg iid "$item_id" --arg sname "$option_name" \
+      '.items |= map(if .id == $iid then .status = $sname else . end)' \
+      "$STUB_DIR/item-list.json" > "$tmp"
+    mv "$tmp" "$STUB_DIR/item-list.json"
+    ;;
+  *)
+    echo "gh stub: unknown invocation: $args" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/gh"
+  PATH="$TMPDIR_TEST/bin:$PATH"
+}
+
+proj_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  PATH="$SAVED_PATH"
+  TMPDIR_TEST=""
+  STUB_DIR=""
+  unset DISPATCH_CONFIG_DIR
+}
+
+# --- Test 1: adder adds an issue and prints the item id ----------------------
+
+echo "Test: dispatch-project-item-add adds an issue and prints the item id"
+proj_setup
+rc=0
+out=$("$TMPDIR_TEST/scripts/dispatch-project-item-add" example-project \
+  https://github.com/example-owner/example-repo/issues/99 2>/dev/null) || rc=$?
+assert_eq "adder exits 0" "0" "$rc"
+assert_eq "adder prints the new item id" "PVTI_added001" "$out"
+proj_teardown
+
+# --- Test 2: reader returns the item id and Status value ---------------------
+
+echo "Test: dispatch-project-status-read returns the item id and Status"
+proj_setup
+rc=0
+out=$("$TMPDIR_TEST/scripts/dispatch-project-status-read" example-project \
+  https://github.com/example-owner/example-repo/issues/42 2>/dev/null) || rc=$?
+assert_eq "reader exits 0" "0" "$rc"
+item_id=$(printf '%s' "$out" | jq -r '.itemId')
+assert_eq "reader returns the item id" "PVTI_item001" "$item_id"
+status=$(printf '%s' "$out" | jq -r '.status')
+assert_eq "reader returns the Status value" "Todo" "$status"
+proj_teardown
+
+# --- Test 3: reader fails when the issue is not on the project ---------------
+
+echo "Test: dispatch-project-status-read fails for an issue not on the project"
+proj_setup
+rc=0
+"$TMPDIR_TEST/scripts/dispatch-project-status-read" example-project \
+  https://github.com/example-owner/example-repo/issues/777 \
+  >/dev/null 2>&1 || rc=$?
+TOTAL=$((TOTAL + 1))
+if [[ "$rc" -ne 0 ]]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: reader exits non-zero for an absent issue"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: reader exits non-zero for an absent issue"
+  echo "    expected: non-zero, actual: 0"
+fi
+proj_teardown
+
+# --- Test 4: writer sets Status; change is visible via the reader ------------
+
+echo "Test: dispatch-project-status-write sets Status, visible via the reader"
+proj_setup
+rc=0
+"$TMPDIR_TEST/scripts/dispatch-project-status-write" example-project \
+  https://github.com/example-owner/example-repo/issues/42 "In Progress" \
+  >/dev/null 2>&1 || rc=$?
+assert_eq "writer exits 0" "0" "$rc"
+rc=0
+out=$("$TMPDIR_TEST/scripts/dispatch-project-status-read" example-project \
+  https://github.com/example-owner/example-repo/issues/42 2>/dev/null) || rc=$?
+assert_eq "reader after write exits 0" "0" "$rc"
+status=$(printf '%s' "$out" | jq -r '.status')
+assert_eq "writer change is visible via the reader" "In Progress" "$status"
+proj_teardown
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2690,6 +2690,40 @@ else
 fi
 config_teardown
 
+# --- Test 6: top-level array exits 1 with a clear error ----------------------
+
+echo "Test: top-level array exits 1 and stderr reports a clear error"
+config_setup
+printf '[1,2,3]' > "$DISPATCH_CONFIG_DIR/projects.json"
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" projects 2>&1 1>/dev/null) || rc=$?
+assert_eq "top-level array exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"error:"* && "$err" == *"projects.json"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: top-level array stderr has clear error: $err"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: top-level array stderr has clear error"
+  echo "    stderr: $err"
+fi
+config_teardown
+
+# --- Test 7: empty config file exits 1 with a clear error --------------------
+
+echo "Test: empty config file exits 1 and stderr reports a clear error"
+config_setup
+printf '' > "$DISPATCH_CONFIG_DIR/projects.json"
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" projects 2>&1 1>/dev/null) || rc=$?
+assert_eq "empty file exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"error:"* && "$err" == *"projects.json"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: empty file stderr has clear error: $err"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: empty file stderr has clear error"
+  echo "    stderr: $err"
+fi
+config_teardown
+
 # ============================================================================
 # dispatch project-helper tests (item-add / status-read / status-write)
 # ============================================================================


### PR DESCRIPTION
Sub-issue A of #726. Builds the foundation the JIT engine (#729) and due-date
prioritization (#730) both need: a way to read local, non-version-controlled
config, and helpers to add an issue to a GitHub project and read/write a
project item's Status.

- `dispatch-config-load <projects|jit>` — locates `<project-root>/dispatch.config/`
  (overridable via `DISPATCH_CONFIG_DIR`), validates the projects/jit schemas,
  prints `no-config` for an absent file, and reports clear errors on malformed
  config.
- `projects.example.json` / `jit.example.json` — committed schema examples with
  non-identifying placeholders.
- `dispatch-project-item-add` / `dispatch-project-status-read` /
  `dispatch-project-status-write` — GitHub-project helpers that resolve project
  metadata through the loader; the writer resolves field/option ids via
  `gh project field-list`.
- New `test-dispatch-scripts.sh` coverage with a mocked `gh` (208/208 pass).

`SKILL.md` is intentionally unchanged — this sub-issue ships scripts only.

Closes #727