### PR TITLE
dispatch: rename the simplify phase to code-review

### DIFF
--- a/.claude/skills/code-review-fix/SKILL.md
+++ b/.claude/skills/code-review-fix/SKILL.md
@@ -1,21 +1,22 @@
 ---
-name: simplify-fix
-description: Simplify phase — merge origin/main, run the generic /simplify, commit and push the fixes, defer out-of-scope findings as tracking issues, post a PR comment, and apply the dispatch:refactored label
+name: code-review-fix
+description: Code-review phase — merge origin/main, run the generic /code-review, commit and push the fixes, defer out-of-scope findings as tracking issues, post a PR comment, and apply the dispatch:code-reviewed label
 ---
 
-# Simplify and Fix
+# Code Review and Fix
 
-The `simplify` phase of the issue workflow, dispatched by `/dispatch`. This is the
-dispatch-specific wrapper around the generic built-in `/simplify` skill.
-`/simplify` applies in-scope fixes to the working tree and produces findings; it
+The `code-review` phase of the issue workflow, dispatched by `/dispatch`. This is the
+dispatch-specific wrapper around the generic built-in `/code-review` skill.
+`/code-review` applies in-scope fixes to the working tree and surfaces findings with the
+skill's own (fixed vs skipped) disposition; it
 does not commit, push, post a summary, or carry follow-up actions beyond the
-current PR. This skill wraps it: merge current `main`, run `/simplify`, commit
+current PR. This skill wraps it: merge current `main`, run `/code-review`, commit
 and push the fixes, defer important out-of-scope findings to tracking issues via
-`/file-issue` subagents, post a PR comment, and apply the `dispatch:refactored`
+`/file-issue` subagents, post a PR comment, and apply the `dispatch:code-reviewed`
 label.
 
 This skill runs in the **caller's thread** — it has no `context:` key — so it can
-fork `/commit-merge-push`, invoke the built-in `/simplify`, and launch
+fork `/commit-merge-push`, invoke the built-in `/code-review`, and launch
 `/file-issue` subagents.
 
 ## Idempotency preamble
@@ -33,7 +34,7 @@ echo "$PR_JSON" | jq -r '.labels[].name'
 `PR_NUM` is carried through to Steps 5, 6, and 7 — do not re-resolve. The PR body
 stays in `PR_JSON` (`echo "$PR_JSON" | jq -r .body`); Step 5 parses its
 `Closes #N` line(s) to resolve the issue(s) this PR implements. If the PR
-already carries the `dispatch:refactored` label — an interrupted prior run —
+already carries the `dispatch:code-reviewed` label — an interrupted prior run —
 **skip Steps 1–7 entirely** and return; the label is the wrapper's terminal
 action and is already applied, so re-entry is a true no-op. Otherwise run all
 steps in order.
@@ -43,23 +44,24 @@ steps in order.
 1. **Merge `origin/main` first.** Fork `/commit-merge-push` via the Agent tool to
    merge current `main` into the branch. This first invocation runs with no
    pending working-tree changes — `/commit-merge-push` tolerates that: it creates
-   no commit and only fetches, merges `origin/main`, and pushes. Simplifying
+   no commit and only fetches, merges `origin/main`, and pushes. Reviewing
    against current `main` avoids re-reviewing code `main` has already changed.
 
-2. **Run `/simplify`.** Invoke the built-in `/simplify` skill via the Skill tool.
+2. **Run `/code-review max`.** Invoke the built-in `/code-review` skill via the
+   Skill tool with the `max` effort level — the highest thoroughness available.
    It applies in-scope fixes to the working tree and surfaces findings with the
    skill's own (fixed vs skipped) disposition. Any "final reply" / "nothing
-   else" wording in `/simplify`'s prompt scopes only to its findings
+   else" wording in `/code-review`'s prompt scopes only to its findings
    deliverable — once it returns, continue to Step 3.
 
-3. **Classify every finding into the 4-way disposition.** `/simplify` produces a
+3. **Classify every finding into the 4-way disposition.** `/code-review` produces a
    2-way split (fixed vs skipped). The wrapper extends each skipped finding into
    one of three buckets — Informational, Disregarded, or Deferred — using the
-   table in **Finding classification** below. The caller of `/simplify-fix`
-   makes this call; `/simplify` itself does not.
+   table in **Finding classification** below. The caller of `/code-review-fix`
+   makes this call; `/code-review` itself does not.
 
 4. **Commit and push the fixes.** Fork `/commit-merge-push` via the Agent tool to
-   commit the Step 2 edits and push. If `/simplify` produced no code changes,
+   commit the Step 2 edits and push. If `/code-review` produced no code changes,
    this invocation runs with no pending changes — `/commit-merge-push` tolerates
    that and creates no commit. Capture the resulting fix commit SHA (or note the
    no-op) for the Step 6 report.
@@ -138,31 +140,31 @@ steps in order.
    .claude/skills/dispatch/scripts/post-pr-comment.sh "$PR_NUM" tmp/<file>
    ```
 
-7. **Apply the `dispatch:refactored` label** via `dispatch-complete-phase` (use
+7. **Apply the `dispatch:code-reviewed` label** via `dispatch-complete-phase` (use
    `dangerouslyDisableSandbox: true` — the script calls `gh`):
 
    ```bash
-   .claude/skills/dispatch/scripts/dispatch-complete-phase "$PR_NUM" simplify
+   .claude/skills/dispatch/scripts/dispatch-complete-phase "$PR_NUM" code-review
    ```
 
-   This skill **owns** its `dispatch:refactored` label — parallel to how
+   This skill **owns** its `dispatch:code-reviewed` label — parallel to how
    `/review-fix` owns `dispatch:reviewed` and `/security-review-fix` owns
    `dispatch:security-reviewed` — so `/dispatch` does not apply the label after
    this skill returns.
 
 ## Finding classification
 
-Every `/simplify` finding lands in exactly one of four buckets:
+Every `/code-review` finding lands in exactly one of four buckets:
 
 | Bucket | Meaning |
 |---|---|
-| Fixed | Implemented in Step 2 by `/simplify`. |
+| Fixed | Implemented in Step 2 by `/code-review`. |
 | Informational | Surfaced for human reference; no action recommended. |
 | Disregarded | False positive or trivially wrong; explicitly rejected with a one-line rationale. |
 | Deferred | Important and actionable but out of scope for this PR; a `/file-issue` subagent filed a tracking issue in Step 5. |
 
-`/simplify` itself produces only the 2-way split (fixed vs skipped). The caller
-of `/simplify-fix` extends the skipped findings into the three non-fixed buckets
+`/code-review` itself produces only the 2-way split (fixed vs skipped). The caller
+of `/code-review-fix` extends the skipped findings into the three non-fixed buckets
 in Step 3 — that classification is the wrapper's responsibility, not the
 generic skill's.
 
@@ -172,12 +174,12 @@ Fixed and implement it — full stop — regardless of how trivial the diff is.
 Disregarded is for false positives, trivially wrong findings, or style
 preferences that are not actual improvements; smallness alone never qualifies
 (out-of-scope items go to Deferred, not Disregarded).
-If `/simplify` skipped a small in-scope improvement in Step 2, implement it
+If `/code-review` skipped a small in-scope improvement in Step 2, implement it
 yourself before moving on (working-tree edit only; Step 4's
 `/commit-merge-push` picks it up).
 
 ## Notes
 
-The skill is idempotent: a re-invocation with `dispatch:refactored` already on
+The skill is idempotent: a re-invocation with `dispatch:code-reviewed` already on
 the PR skips Steps 1–7 and returns. The label is the wrapper's terminal action
 and is already applied, so re-entry is a true no-op.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -200,7 +200,7 @@ merge and push are no-ops when local main already equals `origin/main`.
   Within each category the ladder is (highest first; within a tier, oldest PR
   wins; PRs and `help wanted` issues with a local worktree are skipped;
   `waiting`-phase PRs are skipped entirely): oldest `security` PR → oldest
-  `review` PR → oldest `simplify` PR → oldest `verify` PR → oldest `help wanted`
+  `review` PR → oldest `code-review` PR → oldest `verify` PR → oldest `help wanted`
   issue → oldest `qa` PR. Non-QA PRs are ranked closest-to-done first —
   `security` is the closest-to-done non-QA tier; `help wanted` issues rank below
   all non-QA PRs but above QA PRs. A queue with no topic-labeled items resolves
@@ -228,6 +228,7 @@ merge and push are no-ops when local main already equals `origin/main`.
   the lock (see *Releasing the lock*); summarize the likely cause, report it,
   and **stop**. Once a PR that fixes main exists the normal ladder picks it up
   (verify/ready) — this gate only blocks starting new, unrelated work.
+
 
 ## 3. Trace to an Open Leaf
 
@@ -349,8 +350,8 @@ Map the phase:
 | `verify` | draft PR, CI completed and failed | `/verify-pr` |
 | `waiting` | draft PR, CI in progress (running/queued/not started) | monitor CI to completion with a `sonnet` subagent, then re-derive the phase and dispatch it (Step 6) |
 | `qa` | draft PR, CI green, no `dispatch:*` label | `/dispatch-qa` |
-| `simplify` | draft PR + `dispatch:qa-done` | `/simplify-fix` (applies `dispatch:refactored` itself) |
-| `review` | draft PR + `dispatch:refactored` | `/review-fix` (applies `dispatch:reviewed` itself) |
+| `code-review` | draft PR + `dispatch:qa-done` | `/code-review-fix` (applies `dispatch:code-reviewed` itself) |
+| `review` | draft PR + `dispatch:code-reviewed` | `/review-fix` (applies `dispatch:reviewed` itself) |
 | `security` | draft PR + `dispatch:reviewed` (or `dispatch:security-reviewed` — re-entry; `/security-review-fix` is idempotent) | `/security-review-fix` (applies `dispatch:security-reviewed` and marks ready itself) |
 | `done` | non-draft (ready) PR | already complete — report and skip |
 
@@ -380,14 +381,14 @@ Invoke the one mapped phase skill via the Skill tool. Run exactly one phase per
   3. After the subagent returns, re-run Step 5 (`dispatch-phase`) to re-derive
      the phase from the now-complete CI, then dispatch the resolved phase per
      this step — `/verify-pr` if any check failed, otherwise the green-CI
-     phases (`qa` / `simplify` / `review` / `security` / `ready`).
+     phases (`qa` / `code-review` / `review` / `security` / `ready`).
   4. If the re-derived phase is still `waiting` (CI never registered any check),
      report it and **stop** — do not loop.
 - **`qa`** — invoke `/dispatch-qa`. It owns and applies `dispatch:qa-done` itself on
   a clean pass; `/dispatch` applies no label.
-- **`simplify`** — invoke `/simplify-fix`. It runs `/simplify`, applies the
+- **`code-review`** — invoke `/code-review-fix`. It runs `/code-review max`, applies the
   recommended fixes, defers important out-of-scope findings to tracking issues,
-  posts a PR comment, and applies the `dispatch:refactored` label itself —
+  posts a PR comment, and applies the `dispatch:code-reviewed` label itself —
   `/dispatch` applies no label.
 - **`review`** — invoke `/review-fix`. It runs `/review`, applies the recommended
   fixes, posts a PR comment, and applies the `dispatch:reviewed` label itself —
@@ -409,9 +410,9 @@ so `/dispatch` cannot launch it.
 ### Applying the progress label
 
 The `dispatch:*` labels are the accumulating progress markers across the full
-workflow. `/dispatch-qa`, `/simplify-fix`, `/review-fix`, and
+workflow. `/dispatch-qa`, `/code-review-fix`, `/review-fix`, and
 `/security-review-fix` each own and apply their own label — `dispatch:qa-done`,
-`dispatch:refactored`, `dispatch:reviewed`, and `dispatch:security-reviewed`
+`dispatch:code-reviewed`, `dispatch:reviewed`, and `dispatch:security-reviewed`
 respectively — so `/dispatch` applies no `dispatch:*` label after any phase.
 
 ## 7. Pre-Implementation Relevance Review

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -232,7 +232,6 @@ It is a no-op when local `main` already equals `origin/main`.
   and **stop**. Once a PR that fixes main exists the normal ladder picks it up
   (verify/ready) — this gate only blocks starting new, unrelated work.
 
-
 ## 3. Trace to an Open Leaf
 
 This step runs **only for an explicit `/dispatch <N>` argument**. A queue-selected

--- a/.claude/skills/dispatch/scripts/dispatch-complete-phase
+++ b/.claude/skills/dispatch/scripts/dispatch-complete-phase
@@ -11,7 +11,7 @@
 #
 # Phase → label:
 #   qa       → dispatch:qa-done
-#   simplify → dispatch:refactored
+#   code-review → dispatch:code-reviewed
 #   review   → dispatch:reviewed
 #   security → dispatch:security-reviewed
 #
@@ -27,12 +27,12 @@ if [[ -z "$PR_NUM" || -z "$PHASE" ]]; then
 fi
 
 case "$PHASE" in
-  qa)       LABEL="dispatch:qa-done" ;;
-  simplify) LABEL="dispatch:refactored" ;;
-  review)   LABEL="dispatch:reviewed" ;;
-  security) LABEL="dispatch:security-reviewed" ;;
+  qa)           LABEL="dispatch:qa-done" ;;
+  code-review)  LABEL="dispatch:code-reviewed" ;;
+  review)       LABEL="dispatch:reviewed" ;;
+  security)     LABEL="dispatch:security-reviewed" ;;
   *)
-    echo "error: unknown phase: $PHASE (expected qa, simplify, review, or security)" >&2
+    echo "error: unknown phase: $PHASE (expected qa, code-review, review, or security)" >&2
     exit 1
     ;;
 esac

--- a/.claude/skills/dispatch/scripts/dispatch-complete-phase
+++ b/.claude/skills/dispatch/scripts/dispatch-complete-phase
@@ -10,10 +10,10 @@
 # create metadata (color and description).
 #
 # Phase → label:
-#   qa       → dispatch:qa-done
+#   qa          → dispatch:qa-done
 #   code-review → dispatch:code-reviewed
-#   review   → dispatch:reviewed
-#   security → dispatch:security-reviewed
+#   review      → dispatch:reviewed
+#   security    → dispatch:security-reviewed
 #
 # Missing args or an unknown phase is a clear error, not a fallback.
 set -euo pipefail

--- a/.claude/skills/dispatch/scripts/dispatch-phase
+++ b/.claude/skills/dispatch/scripts/dispatch-phase
@@ -3,7 +3,7 @@
 # Usage: dispatch-phase <issue-num|branch>
 #
 # Prints exactly one phase name to stdout:
-#   implement | verify | waiting | qa | simplify | review | security | done
+#   implement | verify | waiting | qa | code-review | review | security | done
 #
 # Argument resolution:
 #   - All-digit arg: treated as an issue number. The matching PR is the one
@@ -133,7 +133,7 @@ if [[ "$ALL_PASSING" != "true" ]]; then
 fi
 
 # CI is green — map the highest dispatch:* label to the next phase.
-# Label chain: qa-done < refactored < reviewed < security-reviewed.
+# Label chain: qa-done < code-reviewed < reviewed < security-reviewed.
 # dispatch:security-reviewed is a /security-review-fix re-entry marker — it maps
 # back to "security"; the skill is idempotent and just finishes "gh pr ready".
 LABELS=$(printf '%s' "$PR" | jq -r '[.labels[].name | select(startswith("dispatch:"))] | join(" ")')
@@ -142,10 +142,10 @@ if echo "$LABELS" | grep -qF "dispatch:security-reviewed"; then
   echo "security"
 elif echo "$LABELS" | grep -qF "dispatch:reviewed"; then
   echo "security"
-elif echo "$LABELS" | grep -qF "dispatch:refactored"; then
+elif echo "$LABELS" | grep -qF "dispatch:code-reviewed"; then
   echo "review"
 elif echo "$LABELS" | grep -qF "dispatch:qa-done"; then
-  echo "simplify"
+  echo "code-review"
 else
   echo "qa"
 fi

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -39,8 +39,8 @@
 #
 # Within each category, default-mode priority (oldest PR wins within a tier):
 #   1. Oldest "security" PR (draft + dispatch:reviewed or dispatch:security-reviewed)
-#   2. Oldest "review"   PR (draft + dispatch:refactored)
-#   3. Oldest "simplify" PR (draft + dispatch:qa-done)
+#   2. Oldest "review"      PR (draft + dispatch:code-reviewed)
+#   3. Oldest "code-review" PR (draft + dispatch:qa-done)
 #   4. Oldest "verify"   PR (draft, CI completed and failed)
 #   5. Oldest open help-wanted issue with no local git worktree, resolved to a
 #      startable open leaf (an issue whose entire open-leaf subtree is
@@ -253,7 +253,7 @@ declare -A FIRST_PR
 declare -A FIRST_ISSUE
 
 # Within-category phase ladder, highest priority first.
-PHASE_PRIORITY=(security review simplify verify)
+PHASE_PRIORITY=(security review code-review verify)
 
 while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   [[ -z "$pr_num" ]] && continue

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -38,14 +38,14 @@
 # highest-priority topic among its own labels, else "other".
 #
 # Within each category, default-mode priority (oldest PR wins within a tier):
-#   1. Oldest "security" PR (draft + dispatch:reviewed or dispatch:security-reviewed)
+#   1. Oldest "security"    PR (draft + dispatch:reviewed or dispatch:security-reviewed)
 #   2. Oldest "review"      PR (draft + dispatch:code-reviewed)
 #   3. Oldest "code-review" PR (draft + dispatch:qa-done)
-#   4. Oldest "verify"   PR (draft, CI completed and failed)
+#   4. Oldest "verify"      PR (draft, CI completed and failed)
 #   5. Oldest open help-wanted issue with no local git worktree, resolved to a
 #      startable open leaf (an issue whose entire open-leaf subtree is
 #      worktree-conflicted is skipped, exactly as a direct worktree is)
-#   6. Oldest "qa"       PR (draft, CI green, no dispatch:* label)
+#   6. Oldest "qa"          PR (draft, CI green, no dispatch:* label)
 #
 # PRs and help-wanted issues with a local git worktree are skipped (a session is
 # actively working them).

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -406,22 +406,22 @@ result=$("$TMPDIR_TEST/dispatch-phase" "42")
 assert_eq "draft + green + no label → qa" "qa" "$result"
 teardown
 
-# 6. Draft + green + dispatch:qa-done → simplify
-echo "Test: draft + green + dispatch:qa-done → simplify"
+# 6. Draft + green + dispatch:qa-done → code-review
+echo "Test: draft + green + dispatch:qa-done → code-review"
 setup
 printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" '[{"name":"dispatch:qa-done"}]' "$GREEN_ROLLUP")" \
   > "$STUB_DIR/pr-list-full.json"
 result=$("$TMPDIR_TEST/dispatch-phase" "42")
-assert_eq "draft + green + dispatch:qa-done → simplify" "simplify" "$result"
+assert_eq "draft + green + dispatch:qa-done → code-review" "code-review" "$result"
 teardown
 
-# 7. Draft + green + dispatch:refactored → review
-echo "Test: draft + green + dispatch:refactored → review"
+# 7. Draft + green + dispatch:code-reviewed → review
+echo "Test: draft + green + dispatch:code-reviewed → review"
 setup
-printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" '[{"name":"dispatch:refactored"}]' "$GREEN_ROLLUP")" \
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" '[{"name":"dispatch:code-reviewed"}]' "$GREEN_ROLLUP")" \
   > "$STUB_DIR/pr-list-full.json"
 result=$("$TMPDIR_TEST/dispatch-phase" "42")
-assert_eq "draft + green + dispatch:refactored → review" "review" "$result"
+assert_eq "draft + green + dispatch:code-reviewed → review" "review" "$result"
 teardown
 
 # 8. Draft + green + dispatch:reviewed → security
@@ -706,15 +706,15 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "done PRs skipped; help-wanted issue returned" "issue 33" "$result"
 teardown
 
-# 8. security is the top non-QA tier: it beats review, simplify, and verify.
-echo "Test: security beats review/simplify/verify"
+# 8. security is the top non-QA tier: it beats review, code-review, and verify.
+echo "Test: security beats review/code-review/verify"
 setup
 SECURITY_LABELS='[{"name":"dispatch:reviewed"}]'
-REVIEW_LABELS='[{"name":"dispatch:refactored"}]'
-SIMPLIFY_LABELS='[{"name":"dispatch:qa-done"}]'
+REVIEW_LABELS='[{"name":"dispatch:code-reviewed"}]'
+CODE_REVIEW_LABELS='[{"name":"dispatch:qa-done"}]'
 UNION='['
 UNION+="$(make_pr_union 10 "10-verify" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','
-UNION+="$(make_pr_union 20 "20-simplify" "2024-01-02T00:00:00Z" "true" "$SIMPLIFY_LABELS" "$GREEN_ROLLUP")"','
+UNION+="$(make_pr_union 20 "20-code-review" "2024-01-02T00:00:00Z" "true" "$CODE_REVIEW_LABELS" "$GREEN_ROLLUP")"','
 UNION+="$(make_pr_union 30 "30-review" "2024-01-03T00:00:00Z" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"','
 UNION+="$(make_pr_union 40 "40-security" "2024-01-04T00:00:00Z" "true" "$SECURITY_LABELS" "$GREEN_ROLLUP")"
 UNION+=']'
@@ -722,14 +722,14 @@ setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "security beats review/simplify/verify" "pr 40 40-security security" "$result"
+assert_eq "security beats review/code-review/verify" "pr 40 40-security security" "$result"
 teardown
 
 # 9. Within one phase, the oldest PR wins.
 echo "Test: within same phase, oldest PR wins"
 setup
 # Two review-phase PRs; PR 30 is older.
-REVIEW_LABELS='[{"name":"dispatch:refactored"}]'
+REVIEW_LABELS='[{"name":"dispatch:code-reviewed"}]'
 UNION='['
 UNION+="$(make_pr_union 30 "30-review-a" "2024-01-01T00:00:00Z" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"','
 UNION+="$(make_pr_union 31 "31-review-b" "2024-01-02T00:00:00Z" "true" "$REVIEW_LABELS" "$GREEN_ROLLUP")"
@@ -1090,16 +1090,16 @@ count=$(wc -l < "$STUB_DIR/gh-pr-list-calls.log" | tr -d ' ')
 assert_eq "exactly one gh pr list call regardless of PR count" "1" "$count"
 teardown
 
-# 22. A simplify-phase PR winning emits the simplify phase on the result line.
-echo "Test: simplify PR winner → pr <n> <branch> simplify"
+# 22. A code-review-phase PR winning emits the code-review phase on the result line.
+echo "Test: code-review PR winner → pr <n> <branch> code-review"
 setup
-SIMPLIFY_LABELS='[{"name":"dispatch:qa-done"}]'
-UNION='['"$(make_pr_union 25 "25-simplify-me" "2024-01-01T00:00:00Z" "true" "$SIMPLIFY_LABELS" "$GREEN_ROLLUP")"']'
+CODE_REVIEW_LABELS='[{"name":"dispatch:qa-done"}]'
+UNION='['"$(make_pr_union 25 "25-code-review-me" "2024-01-01T00:00:00Z" "true" "$CODE_REVIEW_LABELS" "$GREEN_ROLLUP")"']'
 setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "simplify PR winner emits phase" "pr 25 25-simplify-me simplify" "$result"
+assert_eq "code-review PR winner emits phase" "pr 25 25-code-review-me code-review" "$result"
 teardown
 
 # 23. A lone QA PR with no help-wanted issue emits the qa phase on the result line.
@@ -1487,12 +1487,12 @@ assert_eq "qa applies dispatch:qa-done" \
 assert_eq "qa: no gh label create when label exists" "absent" "$(label_create_state)"
 teardown
 
-echo "Test: simplify → dispatch:refactored (apply only, no label create)"
+echo "Test: code-review → dispatch:code-reviewed (apply only, no label create)"
 setup
-"$TMPDIR_TEST/dispatch-complete-phase" 25 simplify
-assert_eq "simplify applies dispatch:refactored" \
-  "pr edit 25 --add-label dispatch:refactored" "$(cat "$STUB_DIR/gh-pr-edit.log")"
-assert_eq "simplify: no gh label create when label exists" "absent" "$(label_create_state)"
+"$TMPDIR_TEST/dispatch-complete-phase" 25 code-review
+assert_eq "code-review applies dispatch:code-reviewed" \
+  "pr edit 25 --add-label dispatch:code-reviewed" "$(cat "$STUB_DIR/gh-pr-edit.log")"
+assert_eq "code-review: no gh label create when label exists" "absent" "$(label_create_state)"
 teardown
 
 echo "Test: review → dispatch:reviewed (apply only, no label create)"

--- a/.claude/skills/ref-ready/SKILL.md
+++ b/.claude/skills/ref-ready/SKILL.md
@@ -178,7 +178,7 @@ area and are orthogonal to the `dispatch:*` phase labels, which mark workflow
 progress. Apply **at most one** topic label.
 
 - **`dispatch`** — concerns the `/dispatch` workflow, one of its phase skills
-  (`/plan-implement`, `/verify-pr`, `/dispatch-qa`, `/simplify-fix`,
+  (`/plan-implement`, `/verify-pr`, `/dispatch-qa`, `/code-review-fix`,
   `/review-fix`, `/security-review-fix`), a `ref-*` reference skill those
   skills use (`ref-ready`, `ref-memory-management`, `ref-github-issues`,
   `ref-write-instructions`), or a `dispatch-*` script under

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -124,7 +124,7 @@ Cross-iteration memory lives entirely in `tmp/verify-summary.md` (see
         the issue(s) this PR implements. For **each** tracked issue, record a
         `blocked_by` dependency **on that tracked issue, targeting the flake issue
         `<N>`** — the PR's own work is blocked by the unrelated flake. Note the
-        direction: this is the **reverse** of `/review-fix` and `/simplify-fix`,
+        direction: this is the **reverse** of `/review-fix` and `/code-review-fix`,
         which record `blocked_by` on the *new* issue; here the new flake issue is
         the *blocker* and the PR's existing tracked issue is the *blocked* one.
         Use the `ref-github-issues` dependencies API (database-ID resolution with

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ This repository serves as a monorepo for Nate's agentic coding workflows and pro
 | verify | Draft PR, CI failed | [verify-pr](.claude/skills/verify-pr/SKILL.md) |
 | waiting | Draft PR, CI in progress | (nothing — wait) |
 | qa | Draft PR, CI green | [dispatch-qa](.claude/skills/dispatch-qa/SKILL.md) |
-| simplify | Post-QA code quality | `/simplify` (built-in) |
-| review | Post-simplify review | `/review` (built-in) |
+| code-review | Post-QA code quality | `/code-review` (built-in) |
+| review | Post-code-review pass | `/review` (built-in) |
 | security | Post-review security | `/security-review` (built-in) |
 | ready | All reviews complete | flip draft PR to ready |
 
@@ -61,7 +61,7 @@ Entry points               Dispatcher                    Phase skills
 /dispatch     ──────────>  dispatch        ──────────>  plan-implement  (implement)
 (re-invoked                (derives phase               verify-pr       (verify)
  each phase)               from PR/CI                   dispatch-qa     (qa)
-                           ground truth)                simplify        (simplify)
+                           ground truth)                code-review     (code-review)
                                                         review          (review)
                                                         security-review (security)
                                                         gh pr ready     (ready)
@@ -75,8 +75,8 @@ Entry points               Dispatcher                    Phase skills
 2. Draft PR + CI failed → `verify`
 3. Draft PR + CI running → `waiting`
 4. Draft PR + CI green + no label → `qa`
-5. Draft PR + `dispatch:qa-done` label → `simplify`
-6. Draft PR + `dispatch:refactored` label → `review`
+5. Draft PR + `dispatch:qa-done` label → `code-review`
+6. Draft PR + `dispatch:code-reviewed` label → `review`
 7. Draft PR + `dispatch:reviewed` label → `security`
 8. Draft PR + `dispatch:security-reviewed` label → `ready`
 9. Non-draft (ready) PR → `done`


### PR DESCRIPTION
Closes #728

Claude Code v2.1.146 renamed the built-in `/simplify` skill to `/code-review`
(with an effort-level argument). This renames the dispatch `simplify` phase, its
wrapper skill, and its progress label to match — one atomic PR, since any
partial state leaves `/dispatch` unable to derive or complete the phase.

Mapping applied everywhere:
- phase identifier `simplify` → `code-review`
- wrapper skill `simplify-fix` → `code-review-fix`
- progress label `dispatch:refactored` → `dispatch:code-reviewed`
- built-in invocation `/simplify` → `/code-review max` (highest review thoroughness)

The built-in `/review` and the `review` phase / `/review-fix` wrapper are
unchanged — out of scope.

## Commits
1. Rename the wrapper skill `simplify-fix` → `code-review-fix`; Step 2 now
   invokes `/code-review max`.
2. Rename the phase identifier `simplify` → `code-review` and the label
   `dispatch:refactored` → `dispatch:code-reviewed` across the dispatch scripts;
   `test-dispatch-scripts.sh` passes 187/187.
3. Update `dispatch/SKILL.md`, `README.md`, and stray `/simplify-fix` references
   in `verify-pr` / `ref-ready`.

A repo-wide `git grep` for `simplify` and `dispatch:refactored` returns no
matches.

## After merge: rename the GitHub label in place

The label rename is not a code change and must run immediately after merge so
the live label matches the merged code. Renaming in place keeps the label on
any in-flight PR that already carries it:

```
gh label edit dispatch:refactored --name dispatch:code-reviewed --description "dispatch workflow: code-review phase complete"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)