### PR TITLE
dispatch: correct the /loop /dispatch documentation in the dispatch skill files

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -7,7 +7,10 @@ description: Orchestrate the issue workflow — select the next task, derive its
 
 Selects the single most pressing task, resolves its worktree, derives the current
 workflow phase from PR/issue status, and dispatches **exactly one phase skill** —
-then stops. Re-invoke `/dispatch` (or `/loop /dispatch`) to advance to the next phase.
+then stops. Each `/dispatch` is a `claude --bg` background job (#725): a job
+advances one phase, passes the baton to a fresh `/dispatch` job, then
+self-closes (`claude stop`). That self-perpetuating chain advances the
+workflow; the #725 heartbeat re-seeds it when no job is running.
 
 `/dispatch` takes an **optional issue-or-PR-number argument** (leading `#`
 optional). With an argument, it targets that issue and skips the queue scan; a

--- a/.claude/skills/plan-implement/SKILL.md
+++ b/.claude/skills/plan-implement/SKILL.md
@@ -73,7 +73,7 @@ implement→verify transition marker.
 
 ### 4. Stop
 
-Stop. `/loop /dispatch` advances to the `verify` phase.
+Stop. The next `/dispatch` background job advances to the `verify` phase.
 
 ## Requirement changes mid-session
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -206,10 +206,10 @@ already applied, so re-entry is a true no-op. Otherwise run all steps in order.
 
 ## Autonomous vs. attended
 
-Under `/loop /dispatch` there is no user to drive Step 10 — the skill applies
-the `dispatch:reviewed` label (Step 8) and stops; the Step 9 4-section report
-is informational. The label is applied regardless of whether any fixes were
-made, so `/dispatch` can always advance to the next phase.
+In an autonomous `/dispatch` background job there is no user to drive Step 10 —
+the skill applies the `dispatch:reviewed` label (Step 8) and stops; the Step 9
+4-section report is informational. The label is applied regardless of whether
+any fixes were made, so `/dispatch` can always advance to the next phase.
 
 ## Notes
 

--- a/.claude/skills/security-review-fix/SKILL.md
+++ b/.claude/skills/security-review-fix/SKILL.md
@@ -105,7 +105,7 @@ steps in order.
 Marking the PR ready is the workflow's terminal action. After this change the
 dispatch workflow has no human checkpoint before a PR goes ready — the per-phase
 PR-comment summaries are the audit trail. This is an intentional trade-off for an
-autonomous `/loop /dispatch` run.
+autonomous `/dispatch` background-job run.
 
 The skill is idempotent: a re-invocation with `dispatch:security-reviewed` already
 on the PR skips Steps 1–6 and only ensures the PR is ready (Step 7).

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -8,7 +8,7 @@ description: Verify phase — single pass that reproduces and fixes one set of f
 The `verify` phase of the issue workflow, dispatched by `/dispatch` only when a
 draft PR has **completed-and-failed** CI. This skill is **single-pass — it has no
 internal loop**. It fixes one round of failed checks, records the outcome, posts it,
-and stops. `/loop /dispatch` drives iteration: each subsequent failure is a fresh
+and stops. The `/dispatch` background-job chain drives iteration: each subsequent
 `/dispatch` → `/verify-pr` invocation.
 
 This skill runs in the **caller's thread** — it has no `context:` key — so it can
@@ -157,9 +157,9 @@ Cross-iteration memory lives entirely in `tmp/verify-summary.md` (see
    .claude/skills/dispatch/scripts/post-pr-comment.sh <pr-num> tmp/verify-summary.md
    ```
 
-8. **Stop.** `/loop /dispatch` drives the next iteration — the next `/dispatch` run
-   re-derives the phase from CI ground truth and re-invokes `/verify-pr` if checks
-   still fail.
+8. **Stop.** The `/dispatch` background-job chain drives the next iteration —
+   the next `/dispatch` job re-derives the phase from CI ground truth and
+   re-invokes `/verify-pr` if checks still fail.
 
 ## Accumulator
 

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -9,7 +9,7 @@ The `verify` phase of the issue workflow, dispatched by `/dispatch` only when a
 draft PR has **completed-and-failed** CI. This skill is **single-pass — it has no
 internal loop**. It fixes one round of failed checks, records the outcome, posts it,
 and stops. The `/dispatch` background-job chain drives iteration: each subsequent
-`/dispatch` → `/verify-pr` invocation.
+failure is a fresh `/dispatch` → `/verify-pr` invocation.
 
 This skill runs in the **caller's thread** — it has no `context:` key — so it can
 launch subagents and invoke `/implement-unit`.


### PR DESCRIPTION
Corrects the `/loop /dispatch` references in the dispatch skill files. The
documentation claimed `/loop /dispatch` "drives iteration" / "advances to the
next phase" — that is wrong.

The real execution model (#725, designed in #755) is per-task `claude --bg`
background jobs: each `/dispatch` is its own background job that advances one
phase, passes the baton to a fresh `/dispatch` job, then self-closes; the #725
heartbeat re-seeds the chain when no job is running. There is no `/loop`.

Six `/loop /dispatch` references across five files are rewritten to describe
that background-job baton-pass chain:

- `.claude/skills/dispatch/SKILL.md`
- `.claude/skills/verify-pr/SKILL.md` (two references)
- `.claude/skills/plan-implement/SKILL.md`
- `.claude/skills/review-fix/SKILL.md`
- `.claude/skills/security-review-fix/SKILL.md`

The remaining `/loop /dispatch` reference in `.claude/skills/dispatch-qa/SKILL.md`
is intentionally out of scope — it is removed wholesale when `/dispatch-qa` is
retired in sibling sub-issue #758.

Documentation-only — no code or behavior change.

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)
