### PR TITLE
dispatch: add shared claude agents --json session-liveness helper

### DIFF
--- a/.claude/rules/sandbox.md
+++ b/.claude/rules/sandbox.md
@@ -52,6 +52,19 @@ Sandboxed Bash calls run in an isolated network namespace. Servers started with
 Use `dangerouslyDisableSandbox: true` on Bash calls that check local server
 connectivity (e.g., `curl http://localhost:*`, `ss -tlnp`, readiness polls).
 
+## claude agents --json
+
+`claude agents --json` lists live Claude sessions. It reaches the local Claude
+daemon over a Unix socket, which the sandbox's network-namespace isolation
+blocks. A sandboxed call does not error — it returns an empty `[]`,
+indistinguishable from a genuine "no live sessions" result. A caller that
+trusts that `[]` would wrongly conclude a worktree is free.
+
+Use `dangerouslyDisableSandbox: true` on every Bash call that runs
+`claude agents --json` directly, or that runs a script sourcing
+`.claude/skills/dispatch/scripts/lib-claude-agents.sh` (whose
+`claude_sessions_under` / `worktree_has_live_session` helpers shell out to it).
+
 ## pass / GPG pinentry
 
 `pass show <path>` decrypts a GPG-encrypted secret store entry. GPG cannot

--- a/.claude/skills/dispatch/scripts/lib-claude-agents.sh
+++ b/.claude/skills/dispatch/scripts/lib-claude-agents.sh
@@ -59,31 +59,32 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
       return 1
     fi
 
-    # Capture stdout and exit code separately — `local out=$(...)` would mask
-    # the exit code. 2>/dev/null drops daemon noise; only the exit code and a
-    # well-formed JSON array on stdout are trusted.
-    local out rc
-    out=$("${CLAUDE_AGENTS_CMD:-claude}" agents --json --cwd "$path" 2>/dev/null)
-    rc=$?
-    if [[ "$rc" -ne 0 ]]; then
-      # Non-zero exit: `claude` missing (127), the daemon unreachable, or any
-      # other failure. The session state cannot be determined — unknown.
+    # 2>/dev/null drops daemon noise; only the exit code and a well-formed
+    # JSON array on stdout are trusted. A non-zero exit — `claude` missing
+    # (127), the daemon unreachable, or any other failure — means the session
+    # state cannot be determined: unknown.
+    local out
+    if ! out=$("${CLAUDE_AGENTS_CMD:-claude}" agents --json --cwd "$path" 2>/dev/null); then
       return 1
     fi
 
-    # A zero exit must still yield a JSON array. Anything else — empty output,
-    # an object, malformed JSON — is unknown, not a definite "no sessions".
-    if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$out"; then
+    # A zero exit with empty (or whitespace-only) output is unknown too — not a
+    # definite "no sessions".
+    if [[ -z "${out//[[:space:]]/}" ]]; then
       return 1
     fi
 
-    # Valid array (including `[]`): one TSV line per session. Capture first so
-    # a degenerate array (e.g. of non-objects) that makes jq fail extraction
-    # yields unknown (return 1) rather than partial output.
+    # One jq pass validates the JSON is an array and extracts the TSV. A
+    # non-array — object, scalar, or malformed JSON — hits `error`; a degenerate
+    # element that breaks extraction errors mid-pass; either way jq exits
+    # non-zero and the result is unknown. Capture first so partial output from
+    # a mid-stream error is discarded rather than emitted.
     local lines
-    lines=$(jq -r '.[] | [.sessionId, .pid, .status, .name] | @tsv' <<<"$out" 2>/dev/null)
-    rc=$?
-    if [[ "$rc" -ne 0 ]]; then
+    if ! lines=$(jq -r '
+      if type == "array"
+      then .[] | [.sessionId, .pid, .status, .name] | @tsv
+      else error("claude agents --json output is not a JSON array")
+      end' <<<"$out" 2>/dev/null); then
       return 1
     fi
     # `[]` → empty $lines → emit nothing (zero session lines), still return 0.

--- a/.claude/skills/dispatch/scripts/lib-claude-agents.sh
+++ b/.claude/skills/dispatch/scripts/lib-claude-agents.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# lib-claude-agents.sh — sourceable helper for Claude session liveness.
+#
+# /dispatch must know whether a git worktree currently has a live Claude
+# session in it, so it never opens a second session on a worktree another
+# session owns. This helper answers that against `claude agents --json`, the
+# daemon-backed registry of live sessions (Claude Code >= 2.1.146), replacing
+# the brittle /proc-walk previously duplicated across dispatch scripts.
+#
+# Usage: source this file, then call:
+#   claude_sessions_under   <worktree-path>
+#   worktree_has_live_session <worktree-path>
+#
+# claude_sessions_under <path>
+#   The low-level primitive. Runs `claude agents --json --cwd <path>`, which
+#   filters server-side to sessions started under <path>.
+#     return 0 — daemon queried successfully. Stdout carries one tab-separated
+#               line per live session: sessionId<TAB>pid<TAB>status<TAB>name.
+#               Zero sessions (`[]`) → return 0 with empty stdout: this is a
+#               definite "no sessions", NOT a failure.
+#     return 1 — UNKNOWN. The daemon could not be queried: `claude` missing,
+#               non-zero exit, or output that is not a JSON array. Stdout is
+#               empty. Callers MUST treat unknown as occupied/active, never as
+#               free — a `[]` from a down daemon is indistinguishable from a
+#               `[]` of genuinely no sessions, so the detectable failures fail
+#               safe here and the rest is mitigated operationally (see below).
+#
+# worktree_has_live_session <path>
+#   The ergonomic fail-safe predicate. Folds unknown into the occupied branch:
+#     return 0 — occupied OR unknown: do NOT start a session under <path>.
+#     return 1 — definitely no live session under <path>.
+#   `if worktree_has_live_session <path>` is fail-safe by construction.
+#
+# Test override: CLAUDE_AGENTS_CMD replaces the `claude` invocation with an
+# arbitrary command (e.g. an absolute path to a fake script), so the helper is
+# testable with no real daemon. Default: `claude`.
+#
+# Sandbox: `claude agents --json` reaches the local daemon over a Unix socket;
+# a sandboxed call returns `[]` indistinguishable from "no sessions". Callers
+# must run this helper with `dangerouslyDisableSandbox: true` — see
+# `.claude/rules/sandbox.md`.
+#
+# Safe to source multiple times. Does NOT use set -e (must return, not exit).
+#
+# Side effect: sourcing this file once sets `-u` and `-o pipefail` in the
+# caller shell. New callers should be aware before sourcing.
+
+if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
+  _LIB_CLAUDE_AGENTS_LOADED=1
+
+  set -uo pipefail
+
+  # claude_sessions_under <path> — emit live sessions under <path> as TSV.
+  # See the header comment for the return-code contract.
+  claude_sessions_under() {
+    local path="${1:-}"
+    if [[ -z "$path" ]]; then
+      printf 'lib-claude-agents: claude_sessions_under requires a <path> argument\n' >&2
+      return 1
+    fi
+
+    # Capture stdout and exit code separately — `local out=$(...)` would mask
+    # the exit code. 2>/dev/null drops daemon noise; only the exit code and a
+    # well-formed JSON array on stdout are trusted.
+    local out rc
+    out=$("${CLAUDE_AGENTS_CMD:-claude}" agents --json --cwd "$path" 2>/dev/null)
+    rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+      # Non-zero exit: `claude` missing (127), the daemon unreachable, or any
+      # other failure. The session state cannot be determined — unknown.
+      return 1
+    fi
+
+    # A zero exit must still yield a JSON array. Anything else — empty output,
+    # an object, malformed JSON — is unknown, not a definite "no sessions".
+    if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$out"; then
+      return 1
+    fi
+
+    # Valid array (including `[]`): one TSV line per session. Capture first so
+    # a degenerate array (e.g. of non-objects) that makes jq fail extraction
+    # yields unknown (return 1) rather than partial output.
+    local lines
+    lines=$(jq -r '.[] | [.sessionId, .pid, .status, .name] | @tsv' <<<"$out" 2>/dev/null)
+    rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+      return 1
+    fi
+    # `[]` → empty $lines → emit nothing (zero session lines), still return 0.
+    if [[ -n "$lines" ]]; then
+      printf '%s\n' "$lines"
+    fi
+    return 0
+  }
+
+  # worktree_has_live_session <path> — fail-safe liveness predicate.
+  # See the header comment for the return-code contract.
+  worktree_has_live_session() {
+    local path="${1:-}"
+    local sessions
+    if ! sessions=$(claude_sessions_under "$path"); then
+      # Unknown — the daemon could not be queried. Fail safe: occupied.
+      return 0
+    fi
+    if [[ -n "$sessions" ]]; then
+      # The daemon reported one or more live sessions under <path>.
+      return 0
+    fi
+    # The daemon was queried successfully and reported zero sessions.
+    return 1
+  }
+
+fi

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2683,6 +2683,26 @@ if worktree_has_live_session "$CA_DIR"; then live=occupied; else live=free; fi
 assert_eq "empty-output: worktree_has_live_session reports occupied" "occupied" "$live"
 ca_teardown
 
+# --- Test 9: claude_sessions_under invokes `claude` with --cwd <path> -------
+
+echo "Test: claude_sessions_under invokes claude with --cwd <path>"
+ca_setup
+# A fake claude that records its argv to a file, then prints a valid empty
+# registry. write_fake_claude ignores argv, so verifying the server-side
+# --cwd filter is actually passed through needs a bespoke fake.
+cat > "$CA_FAKE" <<FAKE
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$CA_DIR/argv"
+echo '[]'
+FAKE
+chmod +x "$CA_FAKE"
+CLAUDE_AGENTS_CMD="$CA_FAKE"
+if claude_sessions_under "$CA_DIR" >/dev/null; then rc=0; else rc=$?; fi
+assert_eq "cwd-arg: claude_sessions_under exits 0" "0" "$rc"
+assert_eq "cwd-arg: claude invoked as 'agents --json --cwd <path>'" \
+  "$(printf 'agents\n--json\n--cwd\n%s' "$CA_DIR")" "$(cat "$CA_DIR/argv")"
+ca_teardown
+
 # ============================================================================
 # summary
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2495,6 +2495,124 @@ assert_eq "spare-ancestor walk records the session PID, not the spare daemon" \
 lock_teardown
 
 # ============================================================================
+# lib-claude-agents.sh tests
+# ============================================================================
+echo "=== lib-claude-agents.sh ==="
+#
+# claude_sessions_under / worktree_has_live_session are sourced directly from
+# the helper and exercised against a fake `claude` — a small temp script that
+# CLAUDE_AGENTS_CMD points at by absolute path, so no real daemon is needed.
+# The helper functions return non-zero on the "unknown" path; the test shell
+# runs under `set -e`, so every call is wrapped in an `if` to capture the code.
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib-claude-agents.sh"
+
+CA_DIR=""
+CA_FAKE=""
+
+ca_setup() {
+  CA_DIR=$(mktemp -d)
+  CA_FAKE="$CA_DIR/fake-claude"
+}
+
+ca_teardown() {
+  rm -rf "$CA_DIR"
+  CA_DIR=""
+  CA_FAKE=""
+  unset CLAUDE_AGENTS_CMD
+}
+
+# write_fake_claude <stdout-payload> <exit-code> — install a fake `claude` that
+# prints <stdout-payload> verbatim and exits <exit-code>, ignoring its args,
+# and point CLAUDE_AGENTS_CMD at it.
+write_fake_claude() {
+  local payload="$1" exit_code="$2"
+  printf '%s' "$payload" > "$CA_DIR/payload.json"
+  cat > "$CA_FAKE" <<FAKE
+#!/usr/bin/env bash
+cat "$CA_DIR/payload.json"
+exit $exit_code
+FAKE
+  chmod +x "$CA_FAKE"
+  CLAUDE_AGENTS_CMD="$CA_FAKE"
+}
+
+# --- Test 1: a live session is reported by both helpers ----------------------
+
+echo "Test: a live session is reported by both helpers"
+ca_setup
+write_fake_claude '[{"sessionId":"sess-1","pid":4242,"status":"busy","name":"task-one"}]' 0
+if out=$(claude_sessions_under "$CA_DIR"); then rc=0; else rc=$?; fi
+assert_eq "live: claude_sessions_under exits 0" "0" "$rc"
+assert_eq "live: claude_sessions_under prints the session TSV line" \
+  "$(printf 'sess-1\t4242\tbusy\ttask-one')" "$out"
+if worktree_has_live_session "$CA_DIR"; then live=occupied; else live=free; fi
+assert_eq "live: worktree_has_live_session reports occupied" "occupied" "$live"
+ca_teardown
+
+# --- Test 2: an empty registry means no live session ------------------------
+
+echo "Test: an empty registry means no live session"
+ca_setup
+write_fake_claude '[]' 0
+if worktree_has_live_session "$CA_DIR"; then live=occupied; else live=free; fi
+assert_eq "empty: worktree_has_live_session reports free" "free" "$live"
+ca_teardown
+
+# --- Test 3: an empty [] is success with no lines, distinct from unknown ----
+
+echo "Test: an empty [] is a successful no-sessions result, not unknown"
+ca_setup
+write_fake_claude '[]' 0
+if out=$(claude_sessions_under "$CA_DIR"); then rc=0; else rc=$?; fi
+assert_eq "empty: claude_sessions_under exits 0 (success, not unknown)" "0" "$rc"
+assert_eq "empty: claude_sessions_under prints no session lines" "" "$out"
+ca_teardown
+
+# --- Test 4: a non-zero claude exit is unknown, folded to occupied ----------
+
+echo "Test: a daemon-query failure is unknown and folds to occupied"
+ca_setup
+write_fake_claude '' 1
+if out=$(claude_sessions_under "$CA_DIR"); then rc=0; else rc=$?; fi
+assert_eq "daemon-fail: claude_sessions_under exits non-zero (unknown)" "1" "$rc"
+if worktree_has_live_session "$CA_DIR"; then live=occupied; else live=free; fi
+assert_eq "daemon-fail: worktree_has_live_session reports occupied" "occupied" "$live"
+ca_teardown
+
+# --- Test 5: a missing claude binary is unknown, folded to occupied ---------
+
+echo "Test: a missing claude binary is unknown and folds to occupied"
+ca_setup
+CLAUDE_AGENTS_CMD="$CA_DIR/no-such-claude"
+if out=$(claude_sessions_under "$CA_DIR"); then rc=0; else rc=$?; fi
+assert_eq "missing-claude: claude_sessions_under exits non-zero (unknown)" "1" "$rc"
+if worktree_has_live_session "$CA_DIR"; then live=occupied; else live=free; fi
+assert_eq "missing-claude: worktree_has_live_session reports occupied" "occupied" "$live"
+ca_teardown
+
+# --- Test 6: non-array output is unknown, not no-sessions -------------------
+
+echo "Test: non-array output is unknown, not a no-sessions result"
+ca_setup
+write_fake_claude '{}' 0
+if out=$(claude_sessions_under "$CA_DIR"); then rc=0; else rc=$?; fi
+assert_eq "non-array: claude_sessions_under exits non-zero (unknown)" "1" "$rc"
+ca_teardown
+
+# --- Test 7: a multi-session array yields one TSV line per session ----------
+
+echo "Test: a multi-session array yields one TSV line per session"
+ca_setup
+write_fake_claude '[{"sessionId":"s-a","pid":11,"status":"busy","name":"alpha"},{"sessionId":"s-b","pid":22,"status":"idle","name":"beta"}]' 0
+if out=$(claude_sessions_under "$CA_DIR"); then rc=0; else rc=$?; fi
+assert_eq "multi: claude_sessions_under exits 0" "0" "$rc"
+assert_eq "multi: claude_sessions_under prints both session TSV lines" \
+  "$(printf 's-a\t11\tbusy\talpha\ns-b\t22\tidle\tbeta')" "$out"
+ca_teardown
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2672,6 +2672,17 @@ assert_eq "multi: claude_sessions_under prints both session TSV lines" \
   "$(printf 's-a\t11\tbusy\talpha\ns-b\t22\tidle\tbeta')" "$out"
 ca_teardown
 
+# --- Test 8: a zero exit with empty output is unknown, not no-sessions ------
+
+echo "Test: a zero exit with empty output is unknown, not a no-sessions result"
+ca_setup
+write_fake_claude '' 0
+if out=$(claude_sessions_under "$CA_DIR"); then rc=0; else rc=$?; fi
+assert_eq "empty-output: claude_sessions_under exits non-zero (unknown)" "1" "$rc"
+if worktree_has_live_session "$CA_DIR"; then live=occupied; else live=free; fi
+assert_eq "empty-output: worktree_has_live_session reports occupied" "occupied" "$live"
+ca_teardown
+
 # ============================================================================
 # summary
 # ============================================================================


### PR DESCRIPTION
Closes #739

Sub-issue 1 of #738 — the foundation. Adds the shared session-liveness
helper only; sub-issues 2-4 later migrate the consuming scripts onto it.

## What

`lib-claude-agents.sh` — a sourceable bash helper backed by
`claude agents --json` (Claude Code >= 2.1.146), mirroring the
`lib-worktree-in-sync.sh` sibling. It exposes two functions:

- `claude_sessions_under <path>` — the low-level primitive. Emits one
  tab-separated line per live session under `<path>`
  (`sessionId<TAB>pid<TAB>status<TAB>name`), or signals **unknown**
  (return 1) for the failures it can detect: `claude` missing, non-zero
  exit, or output that is not a JSON array. An empty `[]` is a
  successful no-sessions result (return 0, no lines) — distinct from
  unknown.
- `worktree_has_live_session <path>` — the fail-safe predicate. Folds
  unknown into the occupied branch, so a caller can never green-light a
  second session on a worktree it could not query.

## Tests

A new `lib-claude-agents.sh` section in `test-dispatch-scripts.sh`
covers a live session, no session, an empty `[]`, a daemon-query
failure, a missing `claude` binary, non-array output, and
multi-session parsing — via a `CLAUDE_AGENTS_CMD` override that injects
a fake `claude` with no real daemon. Full suite: 200/200 passing.

## Docs

`sandbox.md` gains a `claude agents --json` section: the command
reaches the daemon over a Unix socket, so a sandboxed call returns an
empty `[]` indistinguishable from "no sessions" — callers must use
`dangerouslyDisableSandbox: true`.

## Scope

Per acceptance criterion #5, no consuming script (`dispatch-sweep`,
`dispatch-acquire-lock`, `dispatch-resolve-worktree`,
`dispatch-trace-leaf`) is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)