### PR TITLE
Aggregate CodeQL code-scanning alerts into the security-review phase

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -392,10 +392,10 @@ Invoke the one mapped phase skill via the Skill tool. Run exactly one phase per
 - **`review`** — invoke `/review-fix`. It runs `/review`, applies the recommended
   fixes, posts a PR comment, and applies the `dispatch:reviewed` label itself —
   `/dispatch` applies no label.
-- **`security`** — invoke `/security-review-fix`. It runs `/security-review`,
-  applies the recommended fixes, posts a PR comment, applies the
-  `dispatch:security-reviewed` label, and marks the PR ready. It is idempotent on
-  re-entry — `/dispatch` applies no label.
+- **`security`** — invoke `/security-review-fix`. It runs `/security-review` and
+  gathers the PR's CodeQL code-scanning alerts, applies the recommended fixes,
+  posts a PR comment, applies the `dispatch:security-reviewed` label, and marks
+  the PR ready. It is idempotent on re-entry — `/dispatch` applies no label.
 - **`done`** — report that the PR is already ready and skip.
 
 The PR stays a **draft** through every phase; the `security` phase's

--- a/.claude/skills/security-review-fix/SKILL.md
+++ b/.claude/skills/security-review-fix/SKILL.md
@@ -60,12 +60,13 @@ steps in order.
    ```
 
    `<pr-num>` is the PR number resolved in the idempotency preamble. `--paginate`
-   covers repos with many alerts; `state=open` filters to open alerts; the `ref`
-   filter scopes to the PR — this includes pre-existing alerts in code the PR did
-   not change. Capture per alert: the alert `number`, `rule.id`,
-   `rule.security_severity_level`, `most_recent_instance.location` (path and
-   lines), and `html_url`. An empty array means no CodeQL findings — proceed with
-   the `/security-review` findings alone; it is not an error.
+   covers repos with many alerts; the `ref` filter scopes to the PR — this
+   includes pre-existing alerts in code the PR did not change. Capture per alert:
+   the alert `number`, `rule.id`, `rule.severity` (`note`/`warning`/`error` —
+   always present), `rule.security_severity_level` (`low`/`medium`/`high`/
+   `critical`, null for non-security rules), `most_recent_instance.location`
+   (path and lines), and `html_url`. An empty array means no CodeQL findings —
+   proceed with the `/security-review` findings alone; it is not an error.
 
    Combine both sources into one finding set for Step 3.
 

--- a/.claude/skills/security-review-fix/SKILL.md
+++ b/.claude/skills/security-review-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-review-fix
-description: Security phase — merge origin/main, run the generic /security-review, apply the fixes, post a PR comment, apply the dispatch:security-reviewed label, and mark the PR ready
+description: Security phase — merge origin/main, gather findings from /security-review and the PR's CodeQL code-scanning alerts, apply the fixes, post a PR comment, apply the dispatch:security-reviewed label, and mark the PR ready
 ---
 
 # Security Review and Fix
@@ -9,8 +9,9 @@ The `security` phase of the issue workflow, dispatched by `/dispatch`. This is t
 dispatch-specific wrapper around the generic built-in `/security-review` skill.
 `/security-review` only produces findings — it applies no fixes, commits nothing,
 and posts no summary. This skill wraps it: merge current `main`, run
-`/security-review`, implement the recommended fixes, commit and push, post a PR
-comment, apply the `dispatch:security-reviewed` label, and mark the PR ready.
+`/security-review` and gather the PR's CodeQL code-scanning alerts, implement the
+recommended fixes, commit and push, post a PR comment, apply the
+`dispatch:security-reviewed` label, and mark the PR ready.
 
 This is the workflow's **terminal actionable phase** — it marks the PR ready
 itself, so there is no separate `ready` phase after it.
@@ -42,19 +43,40 @@ steps in order.
    no commit and only fetches, merges `origin/main`, and pushes. Reviewing against
    current `main` avoids re-reviewing code `main` has already changed.
 
-2. **Run `/security-review`.** Invoke the built-in `/security-review` skill via
+2. **Gather findings from both sources.** The finding set carried into Step 3
+   combines two sources, gathered **independently**:
+
+   **(a) `/security-review`.** Invoke the built-in `/security-review` skill via
    the Skill tool — the generic security review. It produces findings; it applies
    no fixes. Any "final reply" / "nothing else" wording in `/security-review`'s
-   prompt scopes only to its findings deliverable — once it returns, continue to
-   Step 3.
+   prompt scopes only to its findings deliverable — once it returns, continue.
 
-3. **Apply the recommended changes.** Implement fixes for the findings
-   `/security-review` flags as actionable vulnerabilities — launch implementation
-   subagent(s) via the Agent tool, constrained to **working-tree edits only — no
-   commits, no pushes**. Choose each subagent's model per `/implement-unit`'s
-   model-selection heuristic (see that skill — it is the canonical home; do not
-   restate it here). Findings not changed are still carried to the Step 5 PR
-   comment with their disposition.
+   **(b) CodeQL code-scanning alerts.** Fetch the PR ref's open code-scanning
+   alerts from GitHub Advanced Security (use `dangerouslyDisableSandbox: true` —
+   `gh` needs network):
+
+   ```bash
+   gh api --paginate "repos/{owner}/{repo}/code-scanning/alerts?state=open&ref=refs/pull/<pr-num>/head"
+   ```
+
+   `<pr-num>` is the PR number resolved in the idempotency preamble. `--paginate`
+   covers repos with many alerts; `state=open` filters to open alerts; the `ref`
+   filter scopes to the PR — this includes pre-existing alerts in code the PR did
+   not change. Capture per alert: the alert `number`, `rule.id`,
+   `rule.security_severity_level`, `most_recent_instance.location` (path and
+   lines), and `html_url`. An empty array means no CodeQL findings — proceed with
+   the `/security-review` findings alone; it is not an error.
+
+   Combine both sources into one finding set for Step 3.
+
+3. **Apply the recommended changes.** The findings to triage are the **combined**
+   set from Step 2 — the `/security-review` findings *and* the open CodeQL alerts.
+   Implement fixes for the items, from either source, that are actionable
+   vulnerabilities — launch implementation subagent(s) via the Agent tool,
+   constrained to **working-tree edits only — no commits, no pushes**. Choose each
+   subagent's model per `/implement-unit`'s model-selection heuristic (see that
+   skill — it is the canonical home; do not restate it here). Items not changed
+   are still carried to the Step 5 PR comment with their disposition.
 
 4. **Commit and push the fixes.** Fork `/commit-merge-push` via the Agent tool to
    commit the Step 3 fixes and push. If Step 3 produced no code changes (no
@@ -70,11 +92,12 @@ steps in order.
    ```
 
    Write the comment body to a file under the repo's `tmp/` directory. The body
-   summarizes **every** security-review finding and its disposition — fixed (with
-   the fix's commit SHA) or not fixed (with the reason). The body file **must**
-   live under `tmp/` because `post-pr-comment.sh` restricts paths to that
-   directory. Then post it (use `dangerouslyDisableSandbox: true` — the script
-   invokes `gh`):
+   summarizes **every** finding from **both** Step 2 sources and its disposition —
+   fixed (with the fix's commit SHA) or not fixed (with the reason). Identify each
+   CodeQL alert by its `rule.id` and alert `number`, linked via its `html_url`.
+   The body file **must** live under `tmp/` because `post-pr-comment.sh` restricts
+   paths to that directory. Then post it (use `dangerouslyDisableSandbox: true` —
+   the script invokes `gh`):
 
    ```bash
    .claude/skills/dispatch/scripts/post-pr-comment.sh <pr-num> tmp/<file>


### PR DESCRIPTION
## Summary

Extends `/security-review-fix` so the `security` phase of `/dispatch` folds
GitHub Advanced Security findings into the security review alongside the generic
`/security-review` skill.

Step 2 now gathers two finding sources **independently**:

- **(a)** the built-in `/security-review` skill
- **(b)** the PR ref's open CodeQL code-scanning alerts via
  `gh api --paginate "repos/{owner}/{repo}/code-scanning/alerts?state=open&ref=refs/pull/<pr-num>/head"`

Steps 3 (apply fixes) and 5 (PR comment) operate on the combined two-source
finding set. This catches warning- and note-severity CodeQL alerts that leave
the CodeQL check green — and so never reach the security review today.

## Changes

- `.claude/skills/security-review-fix/SKILL.md` — frontmatter description, intro,
  Step 2 (two-source gather), Step 3 (combined input set), Step 5 (combined
  PR-comment summary)
- `.claude/skills/dispatch/SKILL.md` — `security` phase bullet updated to match

## Out of scope

- Failing CodeQL checks — already caught by the `verify` phase
- Adding a CodeQL workflow file — GitHub default setup is already active

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)