### PR TITLE
roadmap: replace the retired productivity-app priority with the agenda app

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,13 +86,13 @@ When choosing a new domain, these criteria help identify where the author's prob
 - **Done when:** The author uses budget as their primary personal finance tool with these capabilities.
 - **Signal:** Author usage continuity.
 
-### 7. Daily productivity app — minimum daily-use core ([#456](https://github.com/natb1/commons.systems/issues/456))
+### 7. Agenda app — the JIT reminder queue ([#775](https://github.com/natb1/commons.systems/issues/775))
 
-- **Why:** Daily agenda and feed aggregation solve the author's own coordination problem. New domain where institutional dependency is painful and agentic coding has shifted the cost-benefit. Scoped narrowly so tier-1 validation of this domain can happen soon, rather than stalling behind a sprawling sub-issue tree.
+- **Why:** Recurring obligations — chores, periodic reviews, budget review — are the author's own coordination problem. The `/dispatch` JIT engine ([#726](https://github.com/natb1/commons.systems/issues/726)) turns them into due-dated reminder issues; the `agenda` app makes that queue legible, listing every reminder by how soon it is due or how overdue it is. New domain where institutional dependency on calendar and task platforms is painful and agentic coding has shifted the cost-benefit. Scoped narrowly — one view over the reminder queue — so tier-1 validation happens soon, rather than stalling behind a sprawling sub-issue tree.
 - **Validation tier:** Author.
-- **Distribution:** Becomes a distributable artifact only after the author validates it through daily use.
-- **Done when:** The author uses the minimum core (agenda with Google Calendar, RSS feed aggregation) daily. Message integration, goal views, Discord, TUI, and other sub-issues are follow-ons that ship only after the core is validated.
-- **Signal:** Author usage continuity on the minimum core.
+- **Distribution:** Follows the public-demo / private-data pattern — an unauthenticated visitor sees a working demo, so the app is a distribution asset even before the author validates it. Becomes a fuller distributable artifact once the author relies on it through daily use.
+- **Done when:** The author uses the agenda app daily to see which JIT reminders are due or overdue.
+- **Signal:** Author usage continuity on the agenda app.
 
 ### 8. Plugin distribution ([#440](https://github.com/natb1/commons.systems/issues/440))
 


### PR DESCRIPTION
Replaces ROADMAP priority 7 — "Daily productivity app" (#456, retired and closed not planned along with its sub-issue tree) — with the `agenda` app (#775), a Firebase view of the `/dispatch` JIT reminder queue. The priority schema (why / validation tier / distribution / done-when / signal) and the slot at 7 are preserved; priorities 8–10 are unchanged.

This also covers the ROADMAP portion of #776 (retire the orphaned productivity app code); #776 is being trimmed to drop its ROADMAP line.

Closes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)