### PR TITLE
budget: reconciliation mismatch resolution with opt-in adjustment entry (#554)

### DIFF
--- a/budget/e2e/accounts-reconcile.spec.ts
+++ b/budget/e2e/accounts-reconcile.spec.ts
@@ -89,4 +89,122 @@ test.describe("accounts reconcile view", () => {
       await expect(reconciledCheckboxes.nth(i)).toBeChecked();
     }
   });
+
+  test("manual-resolve path: mismatch, adjust cleared selections, then match", async ({ page }) => {
+    // Upload mode is writable; seed mode would throw "Seed data is read-only"
+    // on the reconcile write. The fixture seeds a `Test Bank` / `Checking`
+    // asset account with three uncleared legs in `2025-03` totalling 250.
+    await page.goto("/transactions");
+    await expect(page.locator("#seed-data-notice")).toBeVisible({ timeout: 15000 });
+    await uploadFixture(page);
+    await expect(page.locator("#transactions-table")).toBeVisible({ timeout: 10000 });
+    await expect(page.locator(".local-group-name")).toHaveText("Test Household", { timeout: 10000 });
+
+    await page.goto(
+      "/accounts/reconcile?institution=Test%20Bank&account=Checking&period=2025-03",
+    );
+    await expect(page.locator("#reconcile-container")).toBeVisible({ timeout: 10000 });
+
+    const legRows = page.locator("#reconcile-leg-list .reconcile-leg");
+    await expect(legRows).toHaveCount(3);
+
+    // Check index 0 (+100) and index 1 (+200). Cleared balance = 300.
+    const checkboxes = page.locator("#reconcile-leg-list .reconcile-cleared-checkbox");
+    for (let i = 0; i < 2; i++) {
+      await checkboxes.nth(i).check();
+      await expect(legRows.nth(i)).toHaveAttribute("data-cleared-saved", "true", { timeout: 5000 });
+    }
+    await expect(page.locator(".reconcile-cleared-balance")).toContainText("300");
+
+    // Open dialog; bank-balance input defaults to statement balance (250).
+    await page.locator("#reconcile-open-dialog").click();
+    const dialog = page.locator("#reconcile-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(page.locator("#reconcile-bank-balance-input")).toHaveValue("250");
+
+    // Submit — mismatch: cleared 300 vs bank 250, difference +50.
+    await page.locator("#reconcile-submit").click();
+    await expect(dialog).toBeVisible();
+    await expect(page.locator("#reconcile-mismatch-actions")).toBeVisible();
+    await expect(page.locator("#reconcile-difference-display")).toContainText("50");
+
+    // Click "Adjust cleared selections" — dialog closes, returns to leg list.
+    await page.locator("#reconcile-adjust-selections").click();
+    await expect(dialog).toBeHidden();
+
+    // Check index 2 (the -50 leg). Cleared balance = 300 - 50 = 250.
+    await checkboxes.nth(2).check();
+    await expect(legRows.nth(2)).toHaveAttribute("data-cleared-saved", "true", { timeout: 5000 });
+    await expect(page.locator(".reconcile-cleared-balance")).toContainText("250");
+
+    // Reopen dialog and submit — now a match (cleared 250 vs bank 250).
+    await page.locator("#reconcile-open-dialog").click();
+    await expect(dialog).toBeVisible();
+    await page.locator("#reconcile-submit").click();
+
+    // On match the dialog closes and the page finalizes with one past reconciliation.
+    await expect(dialog).toBeHidden();
+    await expect(page.locator("#reconcile-past .reconcile-past-event")).toHaveCount(1);
+    // No adjustment was created, so no adjustment indicator.
+    await expect(page.locator(".reconcile-adjustment-indicator")).toHaveCount(0);
+  });
+
+  test("adjustment-entry path: mismatch, create adjustment entry, finalizes with non-zero adjustment", async ({ page }) => {
+    // Upload mode is writable; seed mode would throw "Seed data is read-only"
+    // on the reconcile write. The fixture seeds a `Test Bank` / `Checking`
+    // asset account with three uncleared legs in `2025-03` totalling 250.
+    await page.goto("/transactions");
+    await expect(page.locator("#seed-data-notice")).toBeVisible({ timeout: 15000 });
+    await uploadFixture(page);
+    await expect(page.locator("#transactions-table")).toBeVisible({ timeout: 10000 });
+    await expect(page.locator(".local-group-name")).toHaveText("Test Household", { timeout: 10000 });
+
+    await page.goto(
+      "/accounts/reconcile?institution=Test%20Bank&account=Checking&period=2025-03",
+    );
+    await expect(page.locator("#reconcile-container")).toBeVisible({ timeout: 10000 });
+
+    const legRows = page.locator("#reconcile-leg-list .reconcile-leg");
+    await expect(legRows).toHaveCount(3);
+
+    // Check all three legs (+100, +200, -50). Cleared balance = 250.
+    const checkboxes = page.locator("#reconcile-leg-list .reconcile-cleared-checkbox");
+    for (let i = 0; i < 3; i++) {
+      await checkboxes.nth(i).check();
+      await expect(legRows.nth(i)).toHaveAttribute("data-cleared-saved", "true", { timeout: 5000 });
+    }
+    await expect(page.locator(".reconcile-cleared-balance")).toContainText("250");
+
+    // Open dialog; fill bank balance with 240 to force a mismatch (difference +10).
+    await page.locator("#reconcile-open-dialog").click();
+    const dialog = page.locator("#reconcile-dialog");
+    await expect(dialog).toBeVisible();
+    await page.locator("#reconcile-bank-balance-input").fill("240");
+
+    // Submit — mismatch: cleared 250 vs bank 240, difference +10.
+    await page.locator("#reconcile-submit").click();
+    await expect(dialog).toBeVisible();
+    await expect(page.locator("#reconcile-mismatch-actions")).toBeVisible();
+    await expect(page.locator("#reconcile-difference-display")).toContainText("10");
+
+    // Click "Create adjustment entry" — writes a balanced two-leg entry and finalizes.
+    await page.locator("#reconcile-create-adjustment").click();
+
+    // Dialog closes and the page finalizes with one past reconciliation that
+    // has a non-zero adjustment, indicated by .reconcile-adjustment-indicator.
+    await expect(dialog).toBeHidden();
+    await expect(page.locator("#reconcile-past .reconcile-past-event")).toHaveCount(1);
+    await expect(page.locator(".reconcile-adjustment-indicator")).toBeVisible();
+
+    // The adjustment adds one reconciling leg on Test Bank_Checking (period end
+    // timestamp, so it falls in 2025-03). The leg list now has 4 entries, all
+    // checked and disabled (reconciled state is terminal).
+    await expect(page.locator("#reconcile-leg-list .reconcile-leg")).toHaveCount(4);
+    const reconciledCheckboxes = page.locator("#reconcile-leg-list .reconcile-cleared-checkbox");
+    await expect(reconciledCheckboxes).toHaveCount(4);
+    for (let i = 0; i < 4; i++) {
+      await expect(reconciledCheckboxes.nth(i)).toBeChecked();
+      await expect(reconciledCheckboxes.nth(i)).toBeDisabled();
+    }
+  });
 });

--- a/budget/e2e/fixtures/test-budget.json
+++ b/budget/e2e/fixtures/test-budget.json
@@ -87,7 +87,8 @@
   "accounts": [
     {"id": "Test Bank_Checking", "institution": "Test Bank", "account": "Checking", "accountType": "asset", "openingBalance": 0, "openingBalanceDate": "2025-03-01T00:00:00Z"},
     {"id": "Budget_Uncategorized Income", "institution": "Budget", "account": "Uncategorized Income", "accountType": "income"},
-    {"id": "Budget_Uncategorized Expense", "institution": "Budget", "account": "Uncategorized Expense", "accountType": "expense"}
+    {"id": "Budget_Uncategorized Expense", "institution": "Budget", "account": "Uncategorized Expense", "accountType": "expense"},
+    {"id": "Budget_Adjustment Suspense", "institution": "Budget", "account": "Adjustment Suspense", "accountType": "equity"}
   ],
   "journalEntries": [
     {"id": "fixture-je-deposit-1", "timestamp": "2025-03-05T00:00:00Z", "description": "Opening Deposit", "legCount": 2},

--- a/budget/src/data-source.ts
+++ b/budget/src/data-source.ts
@@ -61,6 +61,21 @@ export interface ReconciliationNoteFields {
  */
 export type ReconciliationEventFields = Omit<IdbReconciliationEvent, "id" | "legIds">;
 
+/** Fields for a new journal entry; the document `id` is generated on write. */
+export interface JournalEntryFields {
+  timestampMs: number;
+  description: string;
+  note?: string | null;
+}
+
+/** Fields for a new journal leg; the document `id` is generated on write. */
+export interface JournalLegFields {
+  accountId: string;
+  debit: number;
+  credit: number;
+  cleared: boolean;
+}
+
 export interface DataSource {
   getTransactions(query?: TransactionQuery): Promise<Transaction[]>;
   getStatements(): Promise<Statement[]>;
@@ -84,6 +99,11 @@ export interface DataSource {
   deleteReconciliationNote(entityType: ReconciliationEntityType, entityId: string): Promise<void>;
   updateJournalLegCleared(legId: string, cleared: boolean): Promise<void>;
   createReconciliationEvent(fields: ReconciliationEventFields, legIds: string[]): Promise<ReconciliationEvent>;
+  /**
+   * Creates a balanced journal entry with its legs in one operation.
+   * `legIds[i]` in the result corresponds to `legs[i]` (same order).
+   */
+  createJournalEntry(entry: JournalEntryFields, legs: JournalLegFields[]): Promise<{ entryId: string; legIds: string[] }>;
   updateBudget(
     id: BudgetId,
     fields: Partial<Pick<Budget, "name" | "allowance" | "allowancePeriod" | "rollover">>,
@@ -163,6 +183,9 @@ export class SeedDataSource implements DataSource {
     throw new Error("Seed data is read-only");
   }
   async createReconciliationEvent(): Promise<ReconciliationEvent> {
+    throw new Error("Seed data is read-only");
+  }
+  async createJournalEntry(): Promise<{ entryId: string; legIds: string[] }> {
     throw new Error("Seed data is read-only");
   }
   async updateBudget(): Promise<void> {
@@ -340,6 +363,46 @@ export class IdbDataSource implements DataSource {
       ),
     );
     return idbToReconciliationEvent(record);
+  }
+
+  async createJournalEntry(
+    entry: JournalEntryFields,
+    legs: JournalLegFields[],
+  ): Promise<{ entryId: string; legIds: string[] }> {
+    if (legs.length < 2) throw new Error("A journal entry requires at least 2 legs");
+    const totalDebit = legs.reduce((s, l) => s + l.debit, 0);
+    const totalCredit = legs.reduce((s, l) => s + l.credit, 0);
+    if (Math.abs(totalDebit - totalCredit) > 0.005) {
+      throw new Error(`Unbalanced journal entry: debits ${totalDebit} != credits ${totalCredit}`);
+    }
+    const entryId = crypto.randomUUID();
+    const entryRecord: IdbJournalEntry = {
+      id: entryId,
+      timestampMs: entry.timestampMs,
+      description: entry.description,
+      note: entry.note ?? null,
+      legCount: legs.length,
+    };
+    await put("journalEntries", entryRecord as unknown as Record<string, unknown>);
+    const legIds: string[] = [];
+    for (const leg of legs) {
+      const legId = crypto.randomUUID();
+      legIds.push(legId);
+      const legRecord: IdbJournalLeg = {
+        id: legId,
+        entryId,
+        accountId: leg.accountId,
+        debit: leg.debit,
+        credit: leg.credit,
+        timestampMs: entry.timestampMs,
+        cleared: leg.cleared,
+        reconciledAtMs: null,
+        reconciledEventId: null,
+        statementItemId: null,
+      };
+      await put("journalLegs", legRecord as unknown as Record<string, unknown>);
+    }
+    return { entryId, legIds };
   }
 
   async updateBudget(

--- a/budget/src/pages/accounts-reconcile-hydrate.ts
+++ b/budget/src/pages/accounts-reconcile-hydrate.ts
@@ -1,9 +1,11 @@
 import { getActiveDataSource } from "../active-data-source.js";
 import type { ReconciliationEventFields } from "../data-source.js";
-import { balancesMatch } from "../reconciliation.js";
+import { balancesMatch, buildAdjustmentEntry } from "../reconciliation.js";
 import { formatCurrency } from "../format.js";
 import { deferProgrammerError } from "@commons-systems/errorutil/defer";
 import { logError } from "@commons-systems/errorutil/log";
+import { accountDocId } from "../entities/account.js";
+import type { AccountType } from "../schema/enums.js";
 import { parseReconcileQuery, parseReconcilePeriod } from "./accounts-reconcile.js";
 
 function replaceQueryParam(name: string, value: string | null): void {
@@ -141,10 +143,15 @@ export function hydrateAccountsReconcile(container: HTMLElement): void {
 
   const dialog = container.querySelector<HTMLDialogElement>("#reconcile-dialog");
 
-  // Reconcile button opens the dialog.
+  // Reconcile button opens the dialog. Reset the mismatch state so a reopened
+  // dialog starts clean.
   const openButton = container.querySelector<HTMLButtonElement>("#reconcile-open-dialog");
   if (openButton && dialog) {
     openButton.addEventListener("click", () => {
+      const mismatchActions = container.querySelector<HTMLElement>("#reconcile-mismatch-actions");
+      if (mismatchActions) mismatchActions.hidden = true;
+      const differenceDisplay = container.querySelector<HTMLElement>("#reconcile-difference-display");
+      if (differenceDisplay) differenceDisplay.textContent = "";
       dialog.showModal();
     });
   }
@@ -154,6 +161,23 @@ export function hydrateAccountsReconcile(container: HTMLElement): void {
   if (cancelButton && dialog) {
     cancelButton.addEventListener("click", () => {
       dialog.close();
+    });
+  }
+
+  // Mismatch primary action: close the dialog and return the user to the leg
+  // list. The container-level change listener keeps handling further toggles.
+  const adjustSelectionsButton = container.querySelector<HTMLButtonElement>("#reconcile-adjust-selections");
+  if (adjustSelectionsButton && dialog) {
+    adjustSelectionsButton.addEventListener("click", () => {
+      dialog.close();
+    });
+  }
+
+  // Mismatch escape-hatch action: generate a balanced adjustment entry.
+  const createAdjustmentButton = container.querySelector<HTMLButtonElement>("#reconcile-create-adjustment");
+  if (createAdjustmentButton && dialog) {
+    createAdjustmentButton.addEventListener("click", () => {
+      void handleCreateAdjustment(container, dialog);
     });
   }
 
@@ -186,31 +210,126 @@ async function handleReconcileSubmit(container: HTMLElement, dialog: HTMLDialogE
   const cleared = clearedBalanceFromDom(container);
 
   if (!balancesMatch(bankBalance, cleared)) {
-    // Mismatch: surface the signed difference (cleared − bank) and keep the
-    // dialog open. Mismatch-resolution UX is sibling issue #554.
+    // Mismatch: surface the signed difference (cleared − bank) and reveal the
+    // mismatch-resolution actions while keeping the dialog open.
     const difference = cleared - bankBalance;
     if (differenceDisplay) {
       differenceDisplay.textContent = `Difference: ${formatCurrency(difference)}`;
     }
+    const mismatchActions = container.querySelector<HTMLElement>("#reconcile-mismatch-actions");
+    if (mismatchActions) mismatchActions.hidden = false;
     return;
   }
+
+  await finalizeReconciliation(container, dialog, {
+    adjustment: 0,
+    adjustmentEntryId: null,
+    extraLegIds: [],
+  });
+}
+
+/**
+ * Escape-hatch path: generate a balanced two-leg adjustment entry that closes
+ * the reconciliation difference, then finalize the reconciliation with the
+ * signed difference recorded as the event's `adjustment`.
+ */
+async function handleCreateAdjustment(container: HTMLElement, dialog: HTMLDialogElement): Promise<void> {
+  const bankInput = container.querySelector<HTMLInputElement>("#reconcile-bank-balance-input");
+  const differenceDisplay = container.querySelector<HTMLElement>("#reconcile-difference-display");
+  if (!bankInput) throw new Error("#reconcile-bank-balance-input not found");
+
+  const bankInputRaw = bankInput.value.trim();
+  const bankBalance = Number(bankInputRaw);
+  if (bankInputRaw === "" || !Number.isFinite(bankBalance)) {
+    if (differenceDisplay) differenceDisplay.textContent = "Enter a valid bank balance.";
+    return;
+  }
+
+  const cleared = clearedBalanceFromDom(container);
+  const difference = cleared - bankBalance;
 
   const query = parseReconcileQuery(location.search);
   if (!query.institution || !query.account || !query.period) {
     throw new Error("Reconcile submit requires institution, account, and period query params");
   }
 
-  const legIds = clearedLegIds(container);
+  const accountType = container.dataset.accountType;
+  if (!accountType) {
+    throw new Error("Reconcile container is missing data-account-type");
+  }
+  const suspenseAccountId = container.dataset.suspenseAccountId;
+  if (!suspenseAccountId) {
+    if (differenceDisplay) {
+      differenceDisplay.textContent =
+        "No Adjustment Suspense account is available — cannot create an adjustment entry.";
+    }
+    return;
+  }
+
+  try {
+    const { entry, legs } = buildAdjustmentEntry({
+      difference,
+      reconcilingAccountId: accountDocId(query.institution, query.account),
+      reconcilingAccountType: accountType as AccountType,
+      suspenseAccountId,
+      accountLabel: query.account,
+      throughDateMs: periodEndMs(query.period),
+    });
+    const { entryId, legIds } = await getActiveDataSource().createJournalEntry(entry, legs);
+    await finalizeReconciliation(container, dialog, {
+      adjustment: difference,
+      adjustmentEntryId: entryId,
+      extraLegIds: [legIds[0]],
+    });
+  } catch (error) {
+    if (deferProgrammerError(error)) return;
+    if (differenceDisplay) {
+      differenceDisplay.textContent = "Adjustment entry failed — please try again.";
+    }
+    logError(error, { operation: "reconcile-create-adjustment" });
+  }
+}
+
+/**
+ * Writes the `reconciliation-events` record and stamps the cleared legs as
+ * reconciled. `clearedBalance` is the pre-adjustment cleared total; the design
+ * guarantees `clearedBalance − adjustment === bankBalance`.
+ */
+async function finalizeReconciliation(
+  container: HTMLElement,
+  dialog: HTMLDialogElement,
+  options: { adjustment: number; adjustmentEntryId: string | null; extraLegIds: string[] },
+): Promise<void> {
+  const bankInput = container.querySelector<HTMLInputElement>("#reconcile-bank-balance-input");
+  const differenceDisplay = container.querySelector<HTMLElement>("#reconcile-difference-display");
+  if (!bankInput) throw new Error("#reconcile-bank-balance-input not found");
+
+  // The caller has already validated the input is non-empty and finite; this
+  // is a defensive guard for a clear error rather than a silent fallback.
+  const bankBalance = Number(bankInput.value.trim());
+  if (!Number.isFinite(bankBalance)) {
+    throw new Error("finalizeReconciliation requires a finite bank balance");
+  }
+
+  // Pre-adjustment cleared total — the value the match path records.
+  const cleared = clearedBalanceFromDom(container);
+
+  const query = parseReconcileQuery(location.search);
+  if (!query.institution || !query.account || !query.period) {
+    throw new Error("Reconcile submit requires institution, account, and period query params");
+  }
+
+  const legIds = [...clearedLegIds(container), ...options.extraLegIds];
   const fields: ReconciliationEventFields = {
     institution: query.institution,
     account: query.account,
     reconciledThroughDateMs: periodEndMs(query.period),
     bankBalance,
     clearedBalance: cleared,
-    adjustment: 0,
+    adjustment: options.adjustment,
     reconciledBy: "local",
     reconciledAtMs: Date.now(),
-    adjustmentEntryId: null,
+    adjustmentEntryId: options.adjustmentEntryId,
   };
 
   try {

--- a/budget/src/pages/accounts-reconcile-hydrate.ts
+++ b/budget/src/pages/accounts-reconcile-hydrate.ts
@@ -234,6 +234,12 @@ async function handleReconcileSubmit(container: HTMLElement, dialog: HTMLDialogE
  * signed difference recorded as the event's `adjustment`.
  */
 async function handleCreateAdjustment(container: HTMLElement, dialog: HTMLDialogElement): Promise<void> {
+  const createButton = container.querySelector<HTMLButtonElement>("#reconcile-create-adjustment");
+  // Re-entrancy guard. Once the button is disabled below, the browser stops
+  // dispatching its click events — this catches a second click that was
+  // already queued before the disable took effect.
+  if (createButton?.disabled) return;
+
   const bankInput = container.querySelector<HTMLInputElement>("#reconcile-bank-balance-input");
   const differenceDisplay = container.querySelector<HTMLElement>("#reconcile-difference-display");
   if (!bankInput) throw new Error("#reconcile-bank-balance-input not found");
@@ -247,6 +253,16 @@ async function handleCreateAdjustment(container: HTMLElement, dialog: HTMLDialog
 
   const cleared = clearedBalanceFromDom(container);
   const difference = cleared - bankBalance;
+
+  // The user can edit the bank balance to match the cleared total after the
+  // mismatch actions appear. Refuse to write a zero-amount adjustment entry —
+  // the user should submit the dialog instead.
+  if (balancesMatch(bankBalance, cleared)) {
+    if (differenceDisplay) {
+      differenceDisplay.textContent = "Balances match — submit to reconcile without an adjustment.";
+    }
+    return;
+  }
 
   const query = parseReconcileQuery(location.search);
   if (!query.institution || !query.account || !query.period) {
@@ -266,6 +282,7 @@ async function handleCreateAdjustment(container: HTMLElement, dialog: HTMLDialog
     return;
   }
 
+  if (createButton) createButton.disabled = true;
   try {
     const { entry, legs } = buildAdjustmentEntry({
       difference,
@@ -287,6 +304,8 @@ async function handleCreateAdjustment(container: HTMLElement, dialog: HTMLDialog
       differenceDisplay.textContent = "Adjustment entry failed — please try again.";
     }
     logError(error, { operation: "reconcile-create-adjustment" });
+  } finally {
+    if (createButton) createButton.disabled = false;
   }
 }
 

--- a/budget/src/pages/accounts-reconcile-hydrate.ts
+++ b/budget/src/pages/accounts-reconcile-hydrate.ts
@@ -194,6 +194,11 @@ export function hydrateAccountsReconcile(container: HTMLElement): void {
 }
 
 async function handleReconcileSubmit(container: HTMLElement, dialog: HTMLDialogElement): Promise<void> {
+  const submitButton = container.querySelector<HTMLButtonElement>("#reconcile-submit");
+  // Re-entrancy guard: drop a queued second click that arrived before the
+  // disable below took effect.
+  if (submitButton?.disabled) return;
+
   const bankInput = container.querySelector<HTMLInputElement>("#reconcile-bank-balance-input");
   const differenceDisplay = container.querySelector<HTMLElement>("#reconcile-difference-display");
   if (!bankInput) throw new Error("#reconcile-bank-balance-input not found");
@@ -211,7 +216,8 @@ async function handleReconcileSubmit(container: HTMLElement, dialog: HTMLDialogE
 
   if (!balancesMatch(bankBalance, cleared)) {
     // Mismatch: surface the signed difference (cleared − bank) and reveal the
-    // mismatch-resolution actions while keeping the dialog open.
+    // mismatch-resolution actions while keeping the dialog open. Do NOT disable
+    // the submit button — the user must be able to edit the input and resubmit.
     const difference = cleared - bankBalance;
     if (differenceDisplay) {
       differenceDisplay.textContent = `Difference: ${formatCurrency(difference)}`;
@@ -221,11 +227,16 @@ async function handleReconcileSubmit(container: HTMLElement, dialog: HTMLDialogE
     return;
   }
 
-  await finalizeReconciliation(container, dialog, {
-    adjustment: 0,
-    adjustmentEntryId: null,
-    extraLegIds: [],
-  });
+  if (submitButton) submitButton.disabled = true;
+  try {
+    await finalizeReconciliation(container, dialog, {
+      adjustment: 0,
+      adjustmentEntryId: null,
+      extraLegIds: [],
+    });
+  } finally {
+    if (submitButton) submitButton.disabled = false;
+  }
 }
 
 /**
@@ -283,6 +294,7 @@ async function handleCreateAdjustment(container: HTMLElement, dialog: HTMLDialog
   }
 
   if (createButton) createButton.disabled = true;
+  let entryCreated = false;
   try {
     const { entry, legs } = buildAdjustmentEntry({
       difference,
@@ -293,10 +305,14 @@ async function handleCreateAdjustment(container: HTMLElement, dialog: HTMLDialog
       throughDateMs: periodEndMs(query.period),
     });
     const { entryId, legIds } = await getActiveDataSource().createJournalEntry(entry, legs);
+    // Both legs (reconciling + suspense) must be stamped as reconciled. Once
+    // the entry exists, keep the button disabled regardless of what
+    // finalizeReconciliation does — preventing duplicate orphan entries on retry.
+    entryCreated = true;
     await finalizeReconciliation(container, dialog, {
       adjustment: difference,
       adjustmentEntryId: entryId,
-      extraLegIds: [legIds[0]],
+      extraLegIds: [...legIds],
     });
   } catch (error) {
     if (deferProgrammerError(error)) return;
@@ -305,7 +321,9 @@ async function handleCreateAdjustment(container: HTMLElement, dialog: HTMLDialog
     }
     logError(error, { operation: "reconcile-create-adjustment" });
   } finally {
-    if (createButton) createButton.disabled = false;
+    // Only re-enable if the journal entry was never written — once an entry
+    // exists, disallow retry to prevent orphan accumulation.
+    if (!entryCreated && createButton) createButton.disabled = false;
   }
 }
 

--- a/budget/src/pages/accounts-reconcile.ts
+++ b/budget/src/pages/accounts-reconcile.ts
@@ -3,7 +3,7 @@ import { type RenderPageOptions, renderPageNotices, renderLoadError } from "./re
 import type { Account, JournalEntry, JournalLeg, ReconciliationEvent, Statement } from "../firestore.js";
 import { formatCurrency } from "../format.js";
 import { accountDocId } from "../entities/account.js";
-import { buildReconcileRows, clearedBalance, isAged } from "../reconciliation.js";
+import { buildReconcileRows, clearedBalance, isAged, ADJUSTMENT_SUSPENSE_ACCOUNT_ID } from "../reconciliation.js";
 
 interface ReconcileQuery {
   institution: string | null;
@@ -165,6 +165,11 @@ function renderDialog(statementBalance: number | null): string {
                value="${escapeHtml(defaultValue)}">
       </label>
       <p id="reconcile-difference-display" class="reconcile-difference-display"></p>
+      <div id="reconcile-mismatch-actions" hidden>
+        <button type="button" id="reconcile-adjust-selections">Adjust cleared selections</button>
+        <button type="button" id="reconcile-create-adjustment">Create adjustment entry</button>
+        <small class="reconcile-escape-hatch-note">Use only for small, unexplained differences.</small>
+      </div>
       <div class="reconcile-dialog-actions">
         <button type="submit" id="reconcile-submit">Reconcile</button>
         <button type="button" id="reconcile-cancel">Cancel</button>
@@ -185,9 +190,13 @@ function renderPastReconciliations(events: ReconciliationEvent[], institution: s
   }
   const rows = matching.map((e) => {
     const through = formatDateShort(e.reconciledThroughDate.toMillis());
+    const adjustmentIndicator = Math.round(e.adjustment * 100) !== 0
+      ? `<span class="reconcile-adjustment-indicator" data-adjustment-entry-id="${escapeHtml(e.adjustmentEntryId ?? "")}">${escapeHtml(formatCurrency(e.adjustment))}</span>`
+      : "";
     return `<li class="reconcile-past-event" data-event-id="${escapeHtml(e.id)}">
       <span class="reconcile-date">${escapeHtml(through)}</span>
       <span class="reconcile-amount">${escapeHtml(formatCurrency(e.clearedBalance))}</span>
+      ${adjustmentIndicator}
     </li>`;
   }).join("");
   return `<section id="reconcile-past" class="reconcile-past">
@@ -239,8 +248,12 @@ export function renderReconcileHtml(ctx: RenderReconcileContext): string {
   const cleared = clearedBalance(filteredLegs, account.accountType);
   const statementBalance = statementEndingBalance(statements, query.institution, query.account, query.period);
   const statementAttr = statementBalance !== null ? ` data-statement-balance="${statementBalance}"` : "";
+  const accountTypeAttr = ` data-account-type="${escapeHtml(account.accountType)}"`;
+  const suspenseAttr = accounts.some((a) => a.id === ADJUSTMENT_SUSPENSE_ACCOUNT_ID)
+    ? ` data-suspense-account-id="${escapeHtml(ADJUSTMENT_SUSPENSE_ACCOUNT_ID)}"`
+    : "";
 
-  return `<div id="reconcile-container"${statementAttr}>
+  return `<div id="reconcile-container"${statementAttr}${accountTypeAttr}${suspenseAttr}>
     ${controls}
     ${renderHeader(cleared, statementBalance)}
     ${renderLegList(rows)}

--- a/budget/src/reconciliation.ts
+++ b/budget/src/reconciliation.ts
@@ -1,5 +1,6 @@
 import type { JournalEntry, JournalLeg } from "./firestore.js";
 import type { AccountType } from "./schema/enums.js";
+import type { JournalEntryFields, JournalLegFields } from "./data-source.js";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -95,4 +96,72 @@ export function clearedBalance(legs: JournalLeg[], accountType: AccountType): nu
  */
 export function balancesMatch(a: number, b: number): boolean {
   return Math.round(a * 100) === Math.round(b * 100);
+}
+
+// ── Adjustment-entry generation ──────────────────────────────────────────────────
+
+/**
+ * Deterministic `{institution}_{account}` document id of the `Adjustment Suspense`
+ * equity account seeded by #552. Adjustment-entry generation offsets against it.
+ */
+export const ADJUSTMENT_SUSPENSE_ACCOUNT_ID = "Budget_Adjustment Suspense";
+
+export interface BuildAdjustmentEntryInput {
+  /** Signed reconciliation difference: clearedBalance − bankBalance. Must be non-zero. */
+  readonly difference: number;
+  readonly reconcilingAccountId: string;
+  readonly reconcilingAccountType: AccountType;
+  readonly suspenseAccountId: string;
+  /** Human-readable account label for the entry description. */
+  readonly accountLabel: string;
+  /** Reconciled-through date, ms since epoch — used as the entry timestamp. */
+  readonly throughDateMs: number;
+}
+
+/**
+ * Builds a balanced two-leg adjustment journal entry that closes the reconciliation
+ * difference. The reconciling leg's signed amount (per `signedLegAmount`) equals
+ * `−difference`, bringing the cleared balance exactly to the bank balance.
+ *
+ * Returns the entry fields and an ordered pair of legs: [reconcilingLeg, suspenseLeg].
+ * Both legs are marked `cleared: true`.
+ */
+export function buildAdjustmentEntry(
+  input: BuildAdjustmentEntryInput,
+): { entry: JournalEntryFields; legs: [JournalLegFields, JournalLegFields] } {
+  const amount = Math.abs(input.difference);
+  // The reconciling leg's signed amount must equal -difference so that including
+  // this leg in the cleared set moves clearedBalance exactly to bankBalance.
+  const signedTarget = -input.difference;
+
+  // asset/expense are debit-positive: signed = debit - credit, so debit when signedTarget > 0.
+  // liability/equity/income are credit-positive: signed = credit - debit, so debit when signedTarget < 0.
+  const debitPositive =
+    input.reconcilingAccountType === "asset" || input.reconcilingAccountType === "expense";
+  const reconcilingIsDebit = debitPositive ? signedTarget > 0 : signedTarget < 0;
+
+  const reconcilingLeg: JournalLegFields = {
+    accountId: input.reconcilingAccountId,
+    debit: reconcilingIsDebit ? amount : 0,
+    credit: reconcilingIsDebit ? 0 : amount,
+    cleared: true,
+  };
+
+  const suspenseLeg: JournalLegFields = {
+    accountId: input.suspenseAccountId,
+    debit: reconcilingIsDebit ? 0 : amount,
+    credit: reconcilingIsDebit ? amount : 0,
+    cleared: true,
+  };
+
+  const dateStr = new Date(input.throughDateMs).toISOString().slice(0, 10);
+  const description = `Reconciliation adjustment — ${input.accountLabel} through ${dateStr}`;
+
+  const entry: JournalEntryFields = {
+    timestampMs: input.throughDateMs,
+    description,
+    note: null,
+  };
+
+  return { entry, legs: [reconcilingLeg, suspenseLeg] };
 }

--- a/budget/test/data-source.test.ts
+++ b/budget/test/data-source.test.ts
@@ -178,6 +178,86 @@ describe("IdbDataSource", () => {
     expect(rules).toHaveLength(0);
   });
 
+  describe("createJournalEntry", () => {
+    it("writes the entry and legs, returns parallel legIds", async () => {
+      await storeParsedData(makeParsedData());
+      const ds = new IdbDataSource();
+      const result = await ds.createJournalEntry(
+        { timestampMs: 1700000000000, description: "Test entry", note: null },
+        [
+          { accountId: "acct-a", debit: 50, credit: 0, cleared: true },
+          { accountId: "acct-b", debit: 0, credit: 50, cleared: true },
+        ],
+      );
+      expect(typeof result.entryId).toBe("string");
+      expect(result.legIds).toHaveLength(2);
+
+      const entries = await ds.getJournalEntries();
+      expect(entries).toHaveLength(1);
+      const entry = entries.find((e) => e.id === result.entryId);
+      expect(entry).toBeDefined();
+      expect(entry!.description).toBe("Test entry");
+      expect(entry!.legCount).toBe(2);
+
+      const legs = await ds.getJournalLegs();
+      expect(legs).toHaveLength(2);
+
+      const leg0 = legs.find((l) => l.id === result.legIds[0]);
+      expect(leg0).toBeDefined();
+      expect(leg0!.accountId).toBe("acct-a");
+      expect(leg0!.debit).toBe(50);
+      expect(leg0!.cleared).toBe(true);
+      expect(leg0!.entryId).toBe(result.entryId);
+      expect(leg0!.reconciledAt).toBeNull();
+
+      const leg1 = legs.find((l) => l.id === result.legIds[1]);
+      expect(leg1).toBeDefined();
+      expect(leg1!.accountId).toBe("acct-b");
+      expect(leg1!.credit).toBe(50);
+      expect(leg1!.entryId).toBe(result.entryId);
+      expect(leg1!.reconciledAt).toBeNull();
+    });
+
+    it("rejects fewer than 2 legs", async () => {
+      await storeParsedData(makeParsedData());
+      const ds = new IdbDataSource();
+      await expect(
+        ds.createJournalEntry(
+          { timestampMs: 1, description: "x" },
+          [{ accountId: "a", debit: 10, credit: 0, cleared: false }],
+        ),
+      ).rejects.toThrow(/at least 2 legs/);
+    });
+
+    it("rejects unbalanced legs", async () => {
+      await storeParsedData(makeParsedData());
+      const ds = new IdbDataSource();
+      await expect(
+        ds.createJournalEntry(
+          { timestampMs: 1, description: "x" },
+          [
+            { accountId: "a", debit: 50, credit: 0, cleared: false },
+            { accountId: "b", debit: 0, credit: 40, cleared: false },
+          ],
+        ),
+      ).rejects.toThrow(/[Uu]nbalanced/);
+    });
+
+    it("accepts a balanced entry within 0.005 tolerance", async () => {
+      await storeParsedData(makeParsedData());
+      const ds = new IdbDataSource();
+      const result = await ds.createJournalEntry(
+        { timestampMs: 1700000000000, description: "Near-balanced" },
+        [
+          { accountId: "a", debit: 50.004, credit: 0, cleared: false },
+          { accountId: "b", debit: 0, credit: 50, cleared: false },
+        ],
+      );
+      expect(result.entryId).toBeTruthy();
+      expect(result.legIds).toHaveLength(2);
+    });
+  });
+
   describe("getTransactions with query params", () => {
     const T1 = 1000;
     const T2 = 2000;
@@ -284,6 +364,7 @@ describe("SeedDataSource", () => {
     await expect(ds.createNormalizationRule()).rejects.toThrow("Seed data is read-only");
     await expect(ds.updateNormalizationRule()).rejects.toThrow("Seed data is read-only");
     await expect(ds.deleteNormalizationRule()).rejects.toThrow("Seed data is read-only");
+    await expect(ds.createJournalEntry()).rejects.toThrow("Seed data is read-only");
   });
 
   it("getTransactions returns all seed transactions with Timestamp objects", async () => {

--- a/budget/test/helpers.ts
+++ b/budget/test/helpers.ts
@@ -143,6 +143,7 @@ export function createMockDataSource(overrides: Partial<DataSource> = {}): DataS
     deleteReconciliationNote: vi.fn(),
     updateJournalLegCleared: vi.fn(),
     createReconciliationEvent: vi.fn(),
+    createJournalEntry: vi.fn(),
     updateBudget: vi.fn(),
     updateBudgetOverrides: vi.fn(),
     adjustBudgetPeriodTotal: vi.fn(),

--- a/budget/test/pages/accounts-reconcile.test.ts
+++ b/budget/test/pages/accounts-reconcile.test.ts
@@ -263,6 +263,59 @@ describe("renderReconcileHtml", () => {
     expect(() => renderReconcileHtml(ctx({ accounts: [] }))).toThrow(/not found/);
   });
 
+  it("carries the account type on the container", () => {
+    const html = renderReconcileHtml(ctx());
+    expect(html).toContain('data-account-type="asset"');
+  });
+
+  it("carries the suspense account id when one is present", () => {
+    const html = renderReconcileHtml(ctx({
+      accounts: [
+        account(),
+        account({
+          id: "Budget_Adjustment Suspense",
+          institution: "Budget",
+          account: "Adjustment Suspense",
+          accountType: "equity",
+        }),
+      ],
+    }));
+    expect(html).toContain('data-suspense-account-id="Budget_Adjustment Suspense"');
+  });
+
+  it("omits the suspense account id when no suspense account exists", () => {
+    const html = renderReconcileHtml(ctx());
+    expect(html).not.toContain("data-suspense-account-id");
+  });
+
+  it("renders the hidden mismatch actions in the dialog", () => {
+    const html = renderReconcileHtml(ctx());
+    expect(html).toContain('id="reconcile-mismatch-actions"');
+    expect(html).toContain('id="reconcile-adjust-selections"');
+    expect(html).toContain('id="reconcile-create-adjustment"');
+    expect(html).toContain("Adjust cleared selections");
+    expect(html).toContain("Create adjustment entry");
+    expect(html).toContain("Use only for small, unexplained differences.");
+    const idx = html.indexOf('id="reconcile-mismatch-actions"');
+    const markup = html.slice(idx, idx + 60);
+    expect(markup).toContain("hidden");
+  });
+
+  it("renders an adjustment indicator for a past reconciliation with a non-zero adjustment", () => {
+    const html = renderReconcileHtml(ctx({
+      reconciliationEvents: [event({ adjustment: 25, adjustmentEntryId: "adj-entry-1" })],
+    }));
+    expect(html).toContain("reconcile-adjustment-indicator");
+    expect(html).toContain('data-adjustment-entry-id="adj-entry-1"');
+  });
+
+  it("renders no adjustment indicator for a past reconciliation with a zero adjustment", () => {
+    const html = renderReconcileHtml(ctx({
+      reconciliationEvents: [event()],
+    }));
+    expect(html).not.toContain("reconcile-adjustment-indicator");
+  });
+
   it("does not render any three-column markup", () => {
     const html = renderReconcileHtml(ctx({
       journalEntries: [entry({ id: "e-1" })],

--- a/budget/test/reconciliation.test.ts
+++ b/budget/test/reconciliation.test.ts
@@ -10,6 +10,8 @@ import {
   buildReconcileRows,
   clearedBalance,
   balancesMatch,
+  buildAdjustmentEntry,
+  ADJUSTMENT_SUSPENSE_ACCOUNT_ID,
 } from "../src/reconciliation";
 import type { JournalEntry, JournalLeg } from "../src/firestore";
 
@@ -150,5 +152,135 @@ describe("balancesMatch", () => {
   });
   it("returns false for a difference of a cent or more", () => {
     expect(balancesMatch(100.0, 100.01)).toBe(false);
+  });
+});
+
+describe("buildAdjustmentEntry", () => {
+  const reconcilingAccountId = "Budget_Checking";
+  const suspenseAccountId = ADJUSTMENT_SUSPENSE_ACCOUNT_ID;
+  const throughDateMs = Date.UTC(2025, 2, 31); // 2025-03-31
+
+  it("asset account, positive difference (cleared > bank): reconciling leg is credit, suspense is debit", () => {
+    const { entry, legs } = buildAdjustmentEntry({
+      difference: 50,
+      reconcilingAccountId,
+      reconcilingAccountType: "asset",
+      suspenseAccountId,
+      accountLabel: "Checking",
+      throughDateMs,
+    });
+    const [reconcilingLeg, suspenseLeg] = legs;
+    // signedTarget = -50; asset is debit-positive → debit when signedTarget > 0, so credit here
+    expect(reconcilingLeg.debit).toBe(0);
+    expect(reconcilingLeg.credit).toBe(50);
+    // debit - credit === -50 (equals signedTarget)
+    expect(reconcilingLeg.debit - reconcilingLeg.credit).toBe(-50);
+    expect(suspenseLeg.debit).toBe(50);
+    expect(suspenseLeg.credit).toBe(0);
+    // entry fields
+    expect(entry.timestampMs).toBe(throughDateMs);
+    expect(entry.note).toBeNull();
+  });
+
+  it("asset account, negative difference (cleared < bank): reconciling leg is debit, suspense is credit", () => {
+    const { legs } = buildAdjustmentEntry({
+      difference: -30,
+      reconcilingAccountId,
+      reconcilingAccountType: "asset",
+      suspenseAccountId,
+      accountLabel: "Checking",
+      throughDateMs,
+    });
+    const [reconcilingLeg, suspenseLeg] = legs;
+    // signedTarget = 30; asset is debit-positive → debit
+    expect(reconcilingLeg.debit).toBe(30);
+    expect(reconcilingLeg.credit).toBe(0);
+    expect(suspenseLeg.debit).toBe(0);
+    expect(suspenseLeg.credit).toBe(30);
+  });
+
+  it("liability account, positive difference: reconciling leg is debit, suspense is credit", () => {
+    const { legs } = buildAdjustmentEntry({
+      difference: 20,
+      reconcilingAccountId,
+      reconcilingAccountType: "liability",
+      suspenseAccountId,
+      accountLabel: "Credit Card",
+      throughDateMs,
+    });
+    const [reconcilingLeg, suspenseLeg] = legs;
+    // signedTarget = -20; liability is credit-positive → debit when signedTarget < 0
+    expect(reconcilingLeg.debit).toBe(20);
+    expect(reconcilingLeg.credit).toBe(0);
+    expect(suspenseLeg.debit).toBe(0);
+    expect(suspenseLeg.credit).toBe(20);
+  });
+
+  it("entry balances: total debits equal total credits", () => {
+    const { legs } = buildAdjustmentEntry({
+      difference: 75,
+      reconcilingAccountId,
+      reconcilingAccountType: "asset",
+      suspenseAccountId,
+      accountLabel: "Checking",
+      throughDateMs,
+    });
+    const [reconcilingLeg, suspenseLeg] = legs;
+    const totalDebits = reconcilingLeg.debit + suspenseLeg.debit;
+    const totalCredits = reconcilingLeg.credit + suspenseLeg.credit;
+    expect(totalDebits).toBe(totalCredits);
+  });
+
+  it("both legs are cleared", () => {
+    const { legs } = buildAdjustmentEntry({
+      difference: 10,
+      reconcilingAccountId,
+      reconcilingAccountType: "asset",
+      suspenseAccountId,
+      accountLabel: "Checking",
+      throughDateMs,
+    });
+    expect(legs[0].cleared).toBe(true);
+    expect(legs[1].cleared).toBe(true);
+  });
+
+  it("description format matches the expected string with em dash", () => {
+    const { entry } = buildAdjustmentEntry({
+      difference: 10,
+      reconcilingAccountId,
+      reconcilingAccountType: "asset",
+      suspenseAccountId,
+      accountLabel: "Checking",
+      throughDateMs,
+    });
+    expect(entry.description).toBe(
+      "Reconciliation adjustment — Checking through 2025-03-31",
+    );
+  });
+
+  it("legs are ordered: reconciling first, suspense second", () => {
+    const { legs } = buildAdjustmentEntry({
+      difference: 10,
+      reconcilingAccountId,
+      reconcilingAccountType: "asset",
+      suspenseAccountId,
+      accountLabel: "Checking",
+      throughDateMs,
+    });
+    expect(legs[0].accountId).toBe(reconcilingAccountId);
+    expect(legs[1].accountId).toBe(suspenseAccountId);
+  });
+
+  it("entry timestampMs equals throughDateMs and note is null", () => {
+    const { entry } = buildAdjustmentEntry({
+      difference: 10,
+      reconcilingAccountId,
+      reconcilingAccountType: "asset",
+      suspenseAccountId,
+      accountLabel: "Checking",
+      throughDateMs,
+    });
+    expect(entry.timestampMs).toBe(throughDateMs);
+    expect(entry.note).toBeNull();
   });
 });

--- a/budget/test/smoke/accounts-reconcile.smoke.test.ts
+++ b/budget/test/smoke/accounts-reconcile.smoke.test.ts
@@ -157,6 +157,37 @@ describe("accounts-reconcile page smoke", () => {
     expect(html).toContain('data-event-id="Example Bank_Checking_2025-02-28"');
   });
 
+  it("renders the mismatch actions and the account type attribute", async () => {
+    const html = await renderAccountsReconcile(seedOptions({
+      getAccounts: vi.fn().mockResolvedValue([account()]),
+      getJournalEntries: vi.fn().mockResolvedValue([entry()]),
+      getJournalLegs: vi.fn().mockResolvedValue([leg()]),
+      getReconciliationEvents: vi.fn().mockResolvedValue([]),
+      getStatements: vi.fn().mockResolvedValue([stmt()]),
+    }));
+    expect(html).toContain('id="reconcile-mismatch-actions"');
+    expect(html).toContain('data-account-type="asset"');
+  });
+
+  it("carries the suspense account id when a suspense account is present", async () => {
+    const html = await renderAccountsReconcile(seedOptions({
+      getAccounts: vi.fn().mockResolvedValue([
+        account(),
+        account({
+          id: "Budget_Adjustment Suspense",
+          institution: "Budget",
+          account: "Adjustment Suspense",
+          accountType: "equity",
+        }),
+      ]),
+      getJournalEntries: vi.fn().mockResolvedValue([entry()]),
+      getJournalLegs: vi.fn().mockResolvedValue([leg()]),
+      getReconciliationEvents: vi.fn().mockResolvedValue([]),
+      getStatements: vi.fn().mockResolvedValue([stmt()]),
+    }));
+    expect(html).toContain('data-suspense-account-id="Budget_Adjustment Suspense"');
+  });
+
   it("renders seed-data notice when not authorized", async () => {
     const html = await renderAccountsReconcile(seedOptions({
       getAccounts: vi.fn().mockResolvedValue([account()]),


### PR DESCRIPTION
## Summary

Extends the balance-matching reconciliation UX (#553) with a **mismatch path**.
Before this change, submitting the reconcile dialog with a cleared balance that
did not equal the bank's balance was a dead end — the dialog showed the signed
difference and returned.

Now a mismatch surfaces two actions:

- **Adjust cleared selections** (primary) — closes the dialog so the user can
  keep toggling cleared legs or add missing entries, then reopen and resubmit.
  This is the correct default: it keeps unexplained differences visible.
- **Create adjustment entry** (secondary, labeled an escape hatch) — generates a
  balanced two-leg `JournalEntry`: a cleared leg on the reconciling account
  sized to close the difference, offset by a cleared leg on the
  `Adjustment Suspense` equity account. The reconciliation event then records
  the signed `adjustment` and the new `adjustmentEntryId`.

Past reconciliations with a non-zero adjustment render a visual indicator.

## Changes

Built as four commits:

1. **Data layer** — `DataSource.createJournalEntry(entry, legs)`, a balanced
   journal-entry writer. `IdbDataSource` guards against fewer than two legs and
   unbalanced legs; `SeedDataSource` rejects as read-only.
2. **Domain logic** — `buildAdjustmentEntry`, a pure function that produces the
   balanced two-leg adjustment entry from the signed difference and the
   reconciling account's type, plus the `ADJUSTMENT_SUSPENSE_ACCOUNT_ID`
   constant.
3. **Mismatch UX** — the reconcile dialog's mismatch actions, the container
   `data-account-type` / `data-suspense-account-id` attributes, the
   adjustment-entry flow, the past-reconciliation indicator, and a shared
   `finalizeReconciliation` helper extracted from the match path.
4. **e2e** — Playwright specs for the manual-resolve path and the
   adjustment-entry path.

Invariant the event records satisfy: `clearedBalance − adjustment === bankBalance`.

No `firestore.rules` change is needed — the reconcile write path is IndexedDB
only; the `journal-entries` / `reconciliation-events` rules already shipped with
#716.

## Scope

The issue's "Audit surface" section also mentions a journal-entries-view filter
for "adjustment entries only" and a hyperlink to the adjustment entry. **No
journal-entries view/route exists** in the budget app (only `/accounts/reconcile`),
and neither item is in the issue's acceptance criteria — building that view is a
separate feature. This PR implements all 8 acceptance criteria. The
past-reconciliation indicator carries a `data-adjustment-entry-id` attribute so a
future journal-entries view can wire the link without further renderer changes.

## Testing

- `npx vitest run --root budget` — 854 passed, 7 skipped.
- `npx tsc --noEmit --project budget` — clean.
- `run-lint.sh` — PASS.
- Playwright specs run on CI (local browser version differs from the pinned one).

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)
