### PR TITLE
budget: cleared-state auto-suggest from statement-item signal (#556)

### DIFF
--- a/budget/src/pages/accounts-reconcile-hydrate.ts
+++ b/budget/src/pages/accounts-reconcile-hydrate.ts
@@ -130,6 +130,12 @@ export function hydrateAccountsReconcile(container: HTMLElement): void {
       .then(() => {
         // Signal a settled write — lets tests wait for persistence deterministically.
         row.dataset.clearedSaved = String(nextChecked);
+        // When the user confirms a suggestion by checking it, promote the row
+        // from suggested to fully confirmed by removing the visual hint.
+        if (nextChecked && row.classList.contains("reconcile-suggested")) {
+          row.classList.remove("reconcile-suggested");
+          row.querySelector(".reconcile-suggested-badge")?.remove();
+        }
       })
       .catch((error: unknown) => {
         target.checked = !nextChecked;
@@ -138,6 +144,14 @@ export function hydrateAccountsReconcile(container: HTMLElement): void {
         logError(error, { operation: "reconcile-toggle-cleared" });
       });
   });
+
+  // Confirm-all button: bulk-promote every suggested row to user-confirmed cleared.
+  const confirmAllButton = container.querySelector<HTMLButtonElement>("#reconcile-confirm-all");
+  if (confirmAllButton) {
+    confirmAllButton.addEventListener("click", () => {
+      void handleConfirmAll(container);
+    });
+  }
 
   const dialog = container.querySelector<HTMLDialogElement>("#reconcile-dialog");
 
@@ -167,6 +181,48 @@ export function hydrateAccountsReconcile(container: HTMLElement): void {
       void handleReconcileSubmit(container, dialog);
     });
   }
+}
+
+/**
+ * Bulk-confirm all suggested legs: check each checkbox, persist via the data
+ * source, and remove the suggestion styling. On any persist failure, revert
+ * that row's visual state and log the error.
+ */
+async function handleConfirmAll(container: HTMLElement): Promise<void> {
+  const suggestedRows = Array.from(
+    container.querySelectorAll<HTMLElement>(".reconcile-leg.reconcile-suggested"),
+  );
+  if (suggestedRows.length === 0) return;
+
+  // Optimistically mark all rows checked and update the header before any
+  // async work, matching the pattern used by the per-row change handler.
+  for (const row of suggestedRows) {
+    const checkbox = row.querySelector<HTMLInputElement>(".reconcile-cleared-checkbox");
+    if (checkbox) checkbox.checked = true;
+  }
+  updateHeaderTotals(container);
+
+  // Persist each leg. Run all in parallel; revert individual rows that fail.
+  await Promise.all(
+    suggestedRows.map(async (row) => {
+      const legId = row.dataset.legId;
+      if (!legId) return;
+      const checkbox = row.querySelector<HTMLInputElement>(".reconcile-cleared-checkbox");
+      try {
+        await getActiveDataSource().updateJournalLegCleared(legId, true);
+        // Promote: remove suggestion styling from successfully-persisted rows.
+        row.classList.remove("reconcile-suggested");
+        row.querySelector(".reconcile-suggested-badge")?.remove();
+        if (checkbox) row.dataset.clearedSaved = "true";
+      } catch (error: unknown) {
+        // Revert this row on failure.
+        if (checkbox) checkbox.checked = false;
+        updateHeaderTotals(container);
+        if (deferProgrammerError(error)) return;
+        logError(error, { operation: "reconcile-confirm-all" });
+      }
+    }),
+  );
 }
 
 async function handleReconcileSubmit(container: HTMLElement, dialog: HTMLDialogElement): Promise<void> {

--- a/budget/src/pages/accounts-reconcile-hydrate.ts
+++ b/budget/src/pages/accounts-reconcile-hydrate.ts
@@ -130,9 +130,10 @@ export function hydrateAccountsReconcile(container: HTMLElement): void {
       .then(() => {
         // Signal a settled write — lets tests wait for persistence deterministically.
         row.dataset.clearedSaved = String(nextChecked);
-        // When the user confirms a suggestion by checking it, promote the row
-        // from suggested to fully confirmed by removing the visual hint.
-        if (nextChecked && row.classList.contains("reconcile-suggested")) {
+        // Any explicit toggle dismisses the suggestion — checking confirms it,
+        // unchecking rejects it. Either way the row leaves the suggested pool
+        // so a later Confirm-all click cannot re-clear a rejection.
+        if (row.classList.contains("reconcile-suggested")) {
           row.classList.remove("reconcile-suggested");
           row.querySelector(".reconcile-suggested-badge")?.remove();
         }

--- a/budget/src/pages/accounts-reconcile.ts
+++ b/budget/src/pages/accounts-reconcile.ts
@@ -1,9 +1,10 @@
 import { escapeHtml } from "@commons-systems/htmlutil";
 import { type RenderPageOptions, renderPageNotices, renderLoadError } from "./render-options.js";
-import type { Account, JournalEntry, JournalLeg, ReconciliationEvent, Statement } from "../firestore.js";
+import type { Account, JournalEntry, JournalLeg, ReconciliationEvent, Statement, StatementItem } from "../firestore.js";
 import { formatCurrency } from "../format.js";
 import { accountDocId } from "../entities/account.js";
 import { buildReconcileRows, clearedBalance, isAged } from "../reconciliation.js";
+import { suggestClearedLegs, SUGGESTION_TOLERANCE_DAYS } from "../reconcile-hints.js";
 
 interface ReconcileQuery {
   institution: string | null;
@@ -114,24 +115,30 @@ function statementEndingBalance(
   return mostRecent.balance;
 }
 
-function renderLegList(rows: ReturnType<typeof buildReconcileRows>): string {
+function renderLegList(rows: ReturnType<typeof buildReconcileRows>, suggestedIds: Set<string>): string {
   if (rows.length === 0) {
     return `<p class="reconcile-empty">No journal legs for this account and period.</p>`;
   }
   const items = rows.map((row) => {
     const { leg } = row;
     const reconciled = leg.reconciledEventId !== null || leg.reconciledAt !== null;
+    const suggested = !leg.cleared && !reconciled && suggestedIds.has(leg.id);
     const checkedAttr = leg.cleared ? " checked" : "";
     const disabledAttr = reconciled ? " disabled" : "";
     const aging = !leg.cleared && isAged(row.ageDays)
       ? ` <span class="reconcile-aging" data-age-days="${Math.floor(row.ageDays)}">${Math.floor(row.ageDays)}d</span>`
       : "";
-    return `<li class="reconcile-leg" data-leg-id="${escapeHtml(leg.id)}" data-signed-amount="${row.signedAmount}">
+    const suggestedBadge = suggested
+      ? ` <span class="reconcile-suggested-badge">Bank reported</span>`
+      : "";
+    const suggestedClass = suggested ? " reconcile-suggested" : "";
+    const suggestedAttr = suggested ? " data-suggested" : "";
+    return `<li class="reconcile-leg${suggestedClass}" data-leg-id="${escapeHtml(leg.id)}" data-signed-amount="${row.signedAmount}"${suggestedAttr}>
       <label class="reconcile-cleared">
         <input type="checkbox" class="reconcile-cleared-checkbox"${checkedAttr}${disabledAttr}>
       </label>
       <span class="reconcile-date">${escapeHtml(formatDateShort(leg.timestamp.toMillis()))}</span>
-      <span class="reconcile-description">${escapeHtml(row.description)}${aging}</span>
+      <span class="reconcile-description">${escapeHtml(row.description)}${aging}${suggestedBadge}</span>
       <span class="reconcile-amount">${escapeHtml(formatCurrency(row.signedAmount))}</span>
       <span class="reconcile-running-balance">${escapeHtml(formatCurrency(row.runningBalance))}</span>
     </li>`;
@@ -139,17 +146,21 @@ function renderLegList(rows: ReturnType<typeof buildReconcileRows>): string {
   return `<ul id="reconcile-leg-list" class="reconcile-list">${items}</ul>`;
 }
 
-function renderHeader(cleared: number, statementBalance: number | null): string {
+function renderHeader(cleared: number, statementBalance: number | null, hasSuggestions: boolean): string {
   const statementRow = statementBalance !== null
     ? `<span class="reconcile-statement-balance">Statement-ending balance: ${escapeHtml(formatCurrency(statementBalance))}</span>`
     : "";
   const difference = statementBalance !== null
     ? `<span class="reconcile-difference">Difference: ${escapeHtml(formatCurrency(cleared - statementBalance))}</span>`
     : "";
+  const confirmAllButton = hasSuggestions
+    ? `<button id="reconcile-confirm-all" type="button">Confirm all suggestions</button>`
+    : "";
   return `<div id="reconcile-header" class="reconcile-header">
     <span class="reconcile-cleared-balance">Cleared balance: ${escapeHtml(formatCurrency(cleared))}</span>
     ${statementRow}
     ${difference}
+    ${confirmAllButton}
     <button id="reconcile-open-dialog" type="button">Reconcile</button>
   </div>`;
 }
@@ -202,13 +213,14 @@ export interface RenderReconcileContext {
   reconciliationEvents: ReconciliationEvent[];
   accounts: Account[];
   statements: Statement[];
+  statementItems: StatementItem[];
   query: ReconcileQuery;
   nowMs?: number;
 }
 
 /** Pure HTML renderer, extracted for testability. */
 export function renderReconcileHtml(ctx: RenderReconcileContext): string {
-  const { journalLegs, journalEntries, reconciliationEvents, accounts, statements, query } = ctx;
+  const { journalLegs, journalEntries, reconciliationEvents, accounts, statements, statementItems, query } = ctx;
 
   const controls = renderControls(query, accounts, journalLegs);
 
@@ -232,6 +244,15 @@ export function renderReconcileHtml(ctx: RenderReconcileContext): string {
     return ms >= startMs && ms < endMs;
   });
 
+  const filteredStatementItems = statementItems.filter(
+    (item) =>
+      item.institution === query.institution &&
+      item.account === query.account &&
+      item.period === query.period,
+  );
+
+  const suggestedIds = suggestClearedLegs(filteredLegs, filteredStatementItems, SUGGESTION_TOLERANCE_DAYS);
+
   const entriesById = new Map<string, JournalEntry>();
   for (const entry of journalEntries) entriesById.set(entry.id, entry);
 
@@ -242,8 +263,8 @@ export function renderReconcileHtml(ctx: RenderReconcileContext): string {
 
   return `<div id="reconcile-container"${statementAttr}>
     ${controls}
-    ${renderHeader(cleared, statementBalance)}
-    ${renderLegList(rows)}
+    ${renderHeader(cleared, statementBalance, suggestedIds.size > 0)}
+    ${renderLegList(rows, suggestedIds)}
     ${renderDialog(statementBalance)}
     ${renderPastReconciliations(reconciliationEvents, query.institution, query.account)}
   </div>`;
@@ -255,12 +276,13 @@ export async function renderAccountsReconcile(options: RenderPageOptions): Promi
 
   let body: string;
   try {
-    const [journalLegs, journalEntries, reconciliationEvents, accounts, statements] = await Promise.all([
+    const [journalLegs, journalEntries, reconciliationEvents, accounts, statements, statementItems] = await Promise.all([
       dataSource.getJournalLegs(),
       dataSource.getJournalEntries(),
       dataSource.getReconciliationEvents(),
       dataSource.getAccounts(),
       dataSource.getStatements(),
+      dataSource.getStatementItems(),
     ]);
     body = renderReconcileHtml({
       journalLegs,
@@ -268,6 +290,7 @@ export async function renderAccountsReconcile(options: RenderPageOptions): Promi
       reconciliationEvents,
       accounts,
       statements,
+      statementItems,
       query,
     });
   } catch (error) {

--- a/budget/src/reconcile-hints.ts
+++ b/budget/src/reconcile-hints.ts
@@ -1,0 +1,52 @@
+import type { JournalLeg } from "./entities/journal-leg.js";
+import type { StatementItem } from "./entities/statement-item.js";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Default tolerance window for proximity matching between legs and statement items. */
+export const SUGGESTION_TOLERANCE_DAYS = 3;
+
+/**
+ * Returns the set of JournalLeg ids that should be visually suggested as cleared.
+ *
+ * A leg is suggested if it is not already cleared and meets any of:
+ * - Explicit signal: the leg has a non-null statementItemId (ETL linked it to a bank record).
+ * - Proximity signal: any statement item matches by absolute amount (cent-tolerant) and
+ *   date within toleranceDays.
+ *
+ * No greedy one-to-one assignment — statement items may match multiple legs.
+ */
+export function suggestClearedLegs(
+  legs: JournalLeg[],
+  statementItems: StatementItem[],
+  toleranceDays: number,
+): Set<string> {
+  const suggested = new Set<string>();
+
+  for (const leg of legs) {
+    if (leg.cleared) continue;
+
+    if (leg.statementItemId !== null) {
+      suggested.add(leg.id);
+      continue;
+    }
+
+    const legMagnitude = Math.max(leg.debit, leg.credit);
+    const legMs = leg.timestamp.toMillis();
+    const windowMs = toleranceDays * MS_PER_DAY;
+
+    for (const item of statementItems) {
+      const itemMagnitude = Math.abs(item.amount);
+      const amountMatch = Math.round(legMagnitude * 100) === Math.round(itemMagnitude * 100);
+      if (!amountMatch) continue;
+
+      const dateMatch = Math.abs(legMs - item.timestamp.toMillis()) <= windowMs;
+      if (!dateMatch) continue;
+
+      suggested.add(leg.id);
+      break;
+    }
+  }
+
+  return suggested;
+}

--- a/budget/src/style/theme.css
+++ b/budget/src/style/theme.css
@@ -684,3 +684,22 @@ svg [aria-label="tip"] text { fill: #222; }
 .variance-neutral {
   opacity: 0.6;
 }
+
+/* --- Reconcile suggested-cleared hints --- */
+
+.reconcile-suggested-badge {
+  display: inline-block;
+  font-size: 0.7em;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+  color: var(--fg);
+  opacity: 0.7;
+  margin-left: 0.5em;
+  vertical-align: middle;
+}
+
+.reconcile-suggested .reconcile-cleared-checkbox {
+  outline: 2px dotted currentColor;
+  outline-offset: 2px;
+}

--- a/budget/test/pages/accounts-reconcile-hydrate.test.ts
+++ b/budget/test/pages/accounts-reconcile-hydrate.test.ts
@@ -1,0 +1,250 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { timestampMockFactory, ts } from "../helpers";
+
+vi.mock("firebase/firestore", () => timestampMockFactory());
+
+const mockDataSource = {
+  updateJournalLegCleared: vi.fn(),
+};
+vi.mock("../../src/active-data-source.js", () => ({
+  getActiveDataSource: () => mockDataSource,
+}));
+vi.mock("@commons-systems/errorutil/log", () => ({
+  logError: vi.fn(),
+  registerErrorSink: vi.fn(),
+}));
+vi.mock("@commons-systems/errorutil/defer", () => ({
+  deferProgrammerError: vi.fn().mockReturnValue(false),
+}));
+
+import { renderReconcileHtml } from "../../src/pages/accounts-reconcile";
+import { hydrateAccountsReconcile } from "../../src/pages/accounts-reconcile-hydrate";
+import type {
+  Account,
+  JournalEntry,
+  JournalLeg,
+  ReconciliationEvent,
+  Statement,
+  StatementItem,
+} from "../../src/firestore";
+
+/** Wait for all pending microtasks and one macrotask cycle. */
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+// ---- Builder helpers (mirrors accounts-reconcile.test.ts) ----
+
+function account(overrides: Partial<Account> = {}): Account {
+  return {
+    id: "Bank_Checking",
+    institution: "Bank",
+    account: "Checking",
+    accountType: "asset",
+    openingBalance: null,
+    openingBalanceDate: null,
+    groupId: null,
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<JournalEntry> = {}): JournalEntry {
+  return {
+    id: "entry-1",
+    timestamp: ts("2025-02-10"),
+    description: "Entry",
+    note: null,
+    legCount: 2,
+    groupId: null,
+    ...overrides,
+  };
+}
+
+function leg(overrides: Partial<JournalLeg> = {}): JournalLeg {
+  return {
+    id: "leg-1",
+    entryId: "entry-1",
+    accountId: "Bank_Checking",
+    debit: 0,
+    credit: 0,
+    timestamp: ts("2025-02-10"),
+    cleared: false,
+    reconciledAt: null,
+    reconciledEventId: null,
+    statementItemId: null,
+    groupId: null,
+    ...overrides,
+  };
+}
+
+function statementItem(overrides: Partial<StatementItem> = {}): StatementItem {
+  return {
+    id: "si-1",
+    statementItemId: "si-1" as any,
+    statementId: "stmt-1" as any,
+    institution: "Bank",
+    account: "Checking",
+    period: "2025-02",
+    amount: -50,
+    timestamp: ts("2025-02-10"),
+    description: "Purchase",
+    fitid: "fitid-1",
+    groupId: null,
+    ...overrides,
+  };
+}
+
+function ctx(overrides: Partial<Parameters<typeof renderReconcileHtml>[0]> = {}) {
+  return {
+    journalLegs: [] as JournalLeg[],
+    journalEntries: [] as JournalEntry[],
+    reconciliationEvents: [] as ReconciliationEvent[],
+    accounts: [account()],
+    statements: [] as Statement[],
+    statementItems: [] as StatementItem[],
+    query: { institution: "Bank", account: "Checking", period: "2025-02" },
+    ...overrides,
+  };
+}
+
+/** Render a full reconcile page into the DOM and hydrate it. Returns the container element. */
+function renderAndHydrate(ctxOverrides: Partial<Parameters<typeof renderReconcileHtml>[0]> = {}): HTMLElement {
+  const html = renderReconcileHtml(ctx(ctxOverrides));
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = html;
+  document.body.appendChild(wrapper);
+  const container = wrapper.querySelector<HTMLElement>("#reconcile-container")!;
+  // hydrateAccountsReconcile expects to find selects/buttons inside the passed
+  // element; pass wrapper so #reconcile-confirm-all (inside the container) is
+  // findable as well.
+  hydrateAccountsReconcile(wrapper);
+  return wrapper;
+}
+
+describe("hydrateAccountsReconcile — confirm-all", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDataSource.updateJournalLegCleared.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("confirm-all click persists each suggested leg, removes badges, and updates header", async () => {
+    // Two suggested legs (one via statementItemId, one via proximity) and one non-suggested leg.
+    const wrapper = renderAndHydrate({
+      journalEntries: [
+        entry({ id: "e-1", description: "Purchase A" }),
+        entry({ id: "e-2", description: "Purchase B" }),
+        entry({ id: "e-3", description: "Purchase C" }),
+      ],
+      journalLegs: [
+        // Explicit signal: non-null statementItemId → suggested
+        leg({ id: "leg-a", entryId: "e-1", debit: 50, cleared: false, statementItemId: "si-1" as any, timestamp: ts("2025-02-10") }),
+        // Proximity signal: amount+date match → suggested
+        leg({ id: "leg-b", entryId: "e-2", debit: 30, cleared: false, statementItemId: null, timestamp: ts("2025-02-12") }),
+        // No signal → not suggested
+        leg({ id: "leg-c", entryId: "e-3", debit: 20, cleared: false, statementItemId: null, timestamp: ts("2025-02-15") }),
+      ],
+      statementItems: [
+        statementItem({ id: "si-1", amount: -50, timestamp: ts("2025-02-10") }),
+        // proximity match for leg-b: same amount, date within tolerance
+        statementItem({ id: "si-2", statementItemId: "si-2" as any, amount: -30, timestamp: ts("2025-02-13") }),
+      ],
+    });
+
+    const confirmAllBtn = wrapper.querySelector<HTMLButtonElement>("#reconcile-confirm-all");
+    expect(confirmAllBtn).not.toBeNull();
+
+    confirmAllBtn!.click();
+    await flush();
+
+    // Both suggested legs should have been persisted as cleared=true.
+    expect(mockDataSource.updateJournalLegCleared).toHaveBeenCalledWith("leg-a", true);
+    expect(mockDataSource.updateJournalLegCleared).toHaveBeenCalledWith("leg-b", true);
+    expect(mockDataSource.updateJournalLegCleared).toHaveBeenCalledTimes(2);
+
+    // Both suggested rows should now have their checkbox checked.
+    const rowA = wrapper.querySelector<HTMLElement>('[data-leg-id="leg-a"]')!;
+    const rowB = wrapper.querySelector<HTMLElement>('[data-leg-id="leg-b"]')!;
+    const rowC = wrapper.querySelector<HTMLElement>('[data-leg-id="leg-c"]')!;
+
+    const checkboxA = rowA.querySelector<HTMLInputElement>(".reconcile-cleared-checkbox")!;
+    const checkboxB = rowB.querySelector<HTMLInputElement>(".reconcile-cleared-checkbox")!;
+    const checkboxC = rowC.querySelector<HTMLInputElement>(".reconcile-cleared-checkbox")!;
+
+    expect(checkboxA.checked).toBe(true);
+    expect(checkboxB.checked).toBe(true);
+
+    // Suggested class and badge removed from confirmed rows.
+    expect(rowA.classList.contains("reconcile-suggested")).toBe(false);
+    expect(rowB.classList.contains("reconcile-suggested")).toBe(false);
+    expect(rowA.querySelector(".reconcile-suggested-badge")).toBeNull();
+    expect(rowB.querySelector(".reconcile-suggested-badge")).toBeNull();
+
+    // Non-suggested row untouched.
+    expect(checkboxC.checked).toBe(false);
+    expect(rowC.classList.contains("reconcile-suggested")).toBe(false);
+
+    // Header cleared-balance reflects the newly-cleared legs (leg-a=50, leg-b=30).
+    const clearedEl = wrapper.querySelector<HTMLElement>(".reconcile-cleared-balance");
+    expect(clearedEl?.textContent).toContain("$80.00");
+  });
+
+  it("single suggested-checkbox toggle to true removes the suggestion styling", async () => {
+    const wrapper = renderAndHydrate({
+      journalEntries: [entry({ id: "e-1", description: "Coffee" })],
+      journalLegs: [
+        leg({ id: "leg-x", entryId: "e-1", debit: 5, cleared: false, statementItemId: "si-x" as any, timestamp: ts("2025-02-10") }),
+      ],
+      statementItems: [
+        statementItem({ id: "si-x", statementItemId: "si-x" as any, amount: -5, timestamp: ts("2025-02-10") }),
+      ],
+    });
+
+    const row = wrapper.querySelector<HTMLElement>('[data-leg-id="leg-x"]')!;
+    expect(row.classList.contains("reconcile-suggested")).toBe(true);
+    expect(row.querySelector(".reconcile-suggested-badge")).not.toBeNull();
+
+    const checkbox = row.querySelector<HTMLInputElement>(".reconcile-cleared-checkbox")!;
+    // Simulate the user clicking the checkbox — set checked then fire change.
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+    await flush();
+
+    expect(mockDataSource.updateJournalLegCleared).toHaveBeenCalledWith("leg-x", true);
+
+    expect(row.classList.contains("reconcile-suggested")).toBe(false);
+    expect(row.querySelector(".reconcile-suggested-badge")).toBeNull();
+  });
+
+  it("toggling a confirmed cleared row back to false uses the existing path without errors", async () => {
+    // Render a leg that is already cleared (confirmed, not suggested).
+    const wrapper = renderAndHydrate({
+      journalEntries: [entry({ id: "e-1", description: "Already cleared" })],
+      journalLegs: [
+        leg({ id: "leg-y", entryId: "e-1", debit: 100, cleared: true, statementItemId: null, timestamp: ts("2025-02-10") }),
+      ],
+      statementItems: [],
+    });
+
+    const row = wrapper.querySelector<HTMLElement>('[data-leg-id="leg-y"]')!;
+    expect(row.classList.contains("reconcile-suggested")).toBe(false);
+
+    const checkbox = row.querySelector<HTMLInputElement>(".reconcile-cleared-checkbox")!;
+    expect(checkbox.checked).toBe(true);
+
+    // Simulate unchecking.
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+    await flush();
+
+    expect(mockDataSource.updateJournalLegCleared).toHaveBeenCalledWith("leg-y", false);
+    // Row should remain without the suggested class (it was never suggested).
+    expect(row.classList.contains("reconcile-suggested")).toBe(false);
+    // No badge either.
+    expect(row.querySelector(".reconcile-suggested-badge")).toBeNull();
+  });
+});

--- a/budget/test/pages/accounts-reconcile-hydrate.test.ts
+++ b/budget/test/pages/accounts-reconcile-hydrate.test.ts
@@ -220,6 +220,34 @@ describe("hydrateAccountsReconcile — confirm-all", () => {
     expect(row.querySelector(".reconcile-suggested-badge")).toBeNull();
   });
 
+  it("unchecking a suggested checkbox dismisses the suggestion styling", async () => {
+    const wrapper = renderAndHydrate({
+      journalEntries: [entry({ id: "e-1", description: "Coffee" })],
+      journalLegs: [
+        leg({ id: "leg-x", entryId: "e-1", debit: 5, cleared: false, statementItemId: "si-x" as any, timestamp: ts("2025-02-10") }),
+      ],
+      statementItems: [
+        statementItem({ id: "si-x", statementItemId: "si-x" as any, amount: -5, timestamp: ts("2025-02-10") }),
+      ],
+    });
+
+    const row = wrapper.querySelector<HTMLElement>('[data-leg-id="leg-x"]')!;
+    expect(row.classList.contains("reconcile-suggested")).toBe(true);
+    expect(row.querySelector(".reconcile-suggested-badge")).not.toBeNull();
+
+    const checkbox = row.querySelector<HTMLInputElement>(".reconcile-cleared-checkbox")!;
+    // Reject the suggestion: uncheck and fire change.
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+    await flush();
+
+    expect(mockDataSource.updateJournalLegCleared).toHaveBeenCalledWith("leg-x", false);
+
+    // Rejection dismisses the badge so Confirm-all cannot re-clear the row.
+    expect(row.classList.contains("reconcile-suggested")).toBe(false);
+    expect(row.querySelector(".reconcile-suggested-badge")).toBeNull();
+  });
+
   it("toggling a confirmed cleared row back to false uses the existing path without errors", async () => {
     // Render a leg that is already cleared (confirmed, not suggested).
     const wrapper = renderAndHydrate({

--- a/budget/test/pages/accounts-reconcile.test.ts
+++ b/budget/test/pages/accounts-reconcile.test.ts
@@ -10,6 +10,7 @@ import type {
   JournalLeg,
   ReconciliationEvent,
   Statement,
+  StatementItem,
 } from "../../src/firestore";
 
 function account(overrides: Partial<Account> = {}): Account {
@@ -88,6 +89,23 @@ function event(overrides: Partial<ReconciliationEvent> = {}): ReconciliationEven
   };
 }
 
+function statementItem(overrides: Partial<StatementItem> = {}): StatementItem {
+  return {
+    id: "si-1",
+    statementItemId: "si-1" as any,
+    statementId: "stmt-1" as any,
+    institution: "Bank",
+    account: "Checking",
+    period: "2025-02",
+    amount: -50,
+    timestamp: ts("2025-02-10"),
+    description: "Purchase",
+    fitid: "fitid-1",
+    groupId: null,
+    ...overrides,
+  };
+}
+
 function ctx(overrides: Partial<Parameters<typeof renderReconcileHtml>[0]> = {}) {
   return {
     journalLegs: [] as JournalLeg[],
@@ -95,6 +113,7 @@ function ctx(overrides: Partial<Parameters<typeof renderReconcileHtml>[0]> = {})
     reconciliationEvents: [] as ReconciliationEvent[],
     accounts: [account()],
     statements: [] as Statement[],
+    statementItems: [] as StatementItem[],
     query: { institution: "Bank", account: "Checking", period: "2025-02" },
     ...overrides,
   };
@@ -271,5 +290,87 @@ describe("renderReconcileHtml", () => {
     expect(html).not.toContain("reconcile-columns");
     expect(html).not.toContain("reconcile-column-");
     expect(html).not.toContain("reconcile-match-");
+  });
+
+  it("renders reconcile-suggested class and Bank reported badge for a leg with a non-null statementItemId", () => {
+    const html = renderReconcileHtml(ctx({
+      journalEntries: [entry({ id: "e-1" })],
+      journalLegs: [
+        leg({ id: "leg-a", entryId: "e-1", debit: 50, cleared: false, statementItemId: "si-1" as any, timestamp: ts("2025-02-10") }),
+      ],
+      statementItems: [],
+    }));
+    expect(html).toContain("reconcile-suggested");
+    expect(html).toContain("Bank reported");
+    expect(html).toContain("data-suggested");
+  });
+
+  it("does not render the suggested treatment for a leg with no statementItemId and no matching statement item", () => {
+    const html = renderReconcileHtml(ctx({
+      journalEntries: [entry({ id: "e-1" })],
+      journalLegs: [
+        leg({ id: "leg-a", entryId: "e-1", debit: 75, cleared: false, statementItemId: null, timestamp: ts("2025-02-10") }),
+      ],
+      statementItems: [],
+    }));
+    expect(html).not.toContain("reconcile-suggested");
+    expect(html).not.toContain("Bank reported");
+  });
+
+  it("renders the Confirm-all button when at least one leg is suggested", () => {
+    const html = renderReconcileHtml(ctx({
+      journalEntries: [entry({ id: "e-1" })],
+      journalLegs: [
+        leg({ id: "leg-a", entryId: "e-1", debit: 50, cleared: false, statementItemId: "si-1" as any, timestamp: ts("2025-02-10") }),
+      ],
+      statementItems: [],
+    }));
+    expect(html).toContain('id="reconcile-confirm-all"');
+  });
+
+  it("does not render the Confirm-all button when no legs are suggested", () => {
+    const html = renderReconcileHtml(ctx({
+      journalEntries: [entry({ id: "e-1" })],
+      journalLegs: [
+        leg({ id: "leg-a", entryId: "e-1", debit: 50, cleared: false, statementItemId: null, timestamp: ts("2025-02-10") }),
+      ],
+      statementItems: [],
+    }));
+    expect(html).not.toContain('id="reconcile-confirm-all"');
+  });
+
+  it("does not render the suggested treatment for a cleared leg even with a non-null statementItemId", () => {
+    const html = renderReconcileHtml(ctx({
+      journalEntries: [entry({ id: "e-1" })],
+      journalLegs: [
+        leg({ id: "leg-a", entryId: "e-1", debit: 50, cleared: true, statementItemId: "si-1" as any, timestamp: ts("2025-02-10") }),
+      ],
+      statementItems: [],
+    }));
+    expect(html).not.toContain("reconcile-suggested");
+    expect(html).not.toContain("Bank reported");
+    expect(html).not.toContain('id="reconcile-confirm-all"');
+  });
+
+  it("does not render the suggested treatment for a reconciled leg even with a non-null statementItemId", () => {
+    const html = renderReconcileHtml(ctx({
+      journalEntries: [entry({ id: "e-1" })],
+      journalLegs: [
+        leg({
+          id: "leg-a",
+          entryId: "e-1",
+          debit: 50,
+          cleared: true,
+          statementItemId: "si-1" as any,
+          reconciledEventId: "Bank_Checking_2025-02-28",
+          reconciledAt: ts("2025-02-28"),
+          timestamp: ts("2025-02-10"),
+        }),
+      ],
+      statementItems: [],
+    }));
+    expect(html).not.toContain("reconcile-suggested");
+    expect(html).not.toContain("Bank reported");
+    expect(html).not.toContain('id="reconcile-confirm-all"');
   });
 });

--- a/budget/test/reconcile-hints.test.ts
+++ b/budget/test/reconcile-hints.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { timestampMockFactory, ts } from "./helpers";
+
+vi.mock("firebase/firestore", () => timestampMockFactory());
+
+import { suggestClearedLegs, SUGGESTION_TOLERANCE_DAYS } from "../src/reconcile-hints";
+import type { JournalLeg } from "../src/entities/journal-leg";
+import type { StatementItem } from "../src/entities/statement-item";
+import type { StatementItemId } from "../src/entities/statement-item";
+import type { StatementId } from "../src/entities/statement";
+
+function leg(overrides: Partial<JournalLeg> = {}): JournalLeg {
+  return {
+    id: "leg-1",
+    entryId: "entry-1",
+    accountId: "acct-1",
+    debit: 0,
+    credit: 0,
+    timestamp: ts("2025-02-10"),
+    cleared: false,
+    reconciledAt: null,
+    reconciledEventId: null,
+    statementItemId: null,
+    groupId: null,
+    ...overrides,
+  };
+}
+
+function statementItem(overrides: Partial<StatementItem> = {}): StatementItem {
+  return {
+    id: "si-1",
+    statementItemId: "si-fitid-1" as StatementItemId,
+    statementId: "stmt-1" as StatementId,
+    institution: "bank",
+    account: "1234",
+    period: "2025-02",
+    amount: -50,
+    timestamp: ts("2025-02-10"),
+    description: "Purchase",
+    fitid: "fitid-1",
+    groupId: null,
+    ...overrides,
+  };
+}
+
+describe("suggestClearedLegs", () => {
+  it("suggests a leg with a non-null statementItemId (explicit signal)", () => {
+    const legs = [leg({ id: "leg-a", statementItemId: "si-fitid-1" })];
+    const result = suggestClearedLegs(legs, [], SUGGESTION_TOLERANCE_DAYS);
+    expect(result.has("leg-a")).toBe(true);
+  });
+
+  it("suggests a leg matching a statement item by amount and date within tolerance", () => {
+    const legs = [leg({ id: "leg-b", debit: 50, credit: 0, timestamp: ts("2025-02-10") })];
+    const items = [statementItem({ amount: -50, timestamp: ts("2025-02-11") })];
+    const result = suggestClearedLegs(legs, items, SUGGESTION_TOLERANCE_DAYS);
+    expect(result.has("leg-b")).toBe(true);
+  });
+
+  it("does not suggest a leg whose date is beyond tolerance", () => {
+    const legs = [leg({ id: "leg-c", debit: 50, credit: 0, timestamp: ts("2025-02-10") })];
+    // 5 days apart, tolerance is 3
+    const items = [statementItem({ amount: -50, timestamp: ts("2025-02-15") })];
+    const result = suggestClearedLegs(legs, items, SUGGESTION_TOLERANCE_DAYS);
+    expect(result.has("leg-c")).toBe(false);
+  });
+
+  it("does not suggest a leg with amount mismatch", () => {
+    const legs = [leg({ id: "leg-d", debit: 50, credit: 0, timestamp: ts("2025-02-10") })];
+    const items = [statementItem({ amount: -75, timestamp: ts("2025-02-10") })];
+    const result = suggestClearedLegs(legs, items, SUGGESTION_TOLERANCE_DAYS);
+    expect(result.has("leg-d")).toBe(false);
+  });
+
+  it("does not suggest an already-cleared leg even when statementItemId is set and amount/date matches", () => {
+    const legs = [
+      leg({
+        id: "leg-e",
+        cleared: true,
+        statementItemId: "si-fitid-1",
+        debit: 50,
+        credit: 0,
+        timestamp: ts("2025-02-10"),
+      }),
+    ];
+    const items = [statementItem({ amount: -50, timestamp: ts("2025-02-10") })];
+    const result = suggestClearedLegs(legs, items, SUGGESTION_TOLERANCE_DAYS);
+    expect(result.has("leg-e")).toBe(false);
+  });
+});


### PR DESCRIPTION
Surfaces ETL-link and proximity-match hints as confirmable suggestions in the
balance-matching reconcile UI. During reconciliation, the user toggles a
"cleared" flag on each leg the bank also reported. Legs imported by the ETL
already carry a non-null `statementItemId`, so they are known-bank-reported and
strong cleared candidates. This PR surfaces those legs (plus amount/date
proximity matches) as suggestions the user explicitly confirms — never
auto-cleared.

Builds on #553 (balance-matching reconciliation UX, merged via #774).

## What changes

**`budget/src/reconcile-hints.ts`** (new) — pure hint generator
`suggestClearedLegs(legs, statementItems, toleranceDays): Set<string>`. An
uncleared leg is suggested when its `statementItemId` is non-null (the ETL link
is itself the evidence), or when an absolute-amount cent-tolerant match exists
against any statement item within `toleranceDays` of the leg's timestamp.
Already-`cleared` legs are never suggested. Exports
`SUGGESTION_TOLERANCE_DAYS = 3`.

**`budget/src/pages/accounts-reconcile.ts`** — renderer extensions.
`renderAccountsReconcile` now fetches `statementItems` via
`DataSource.getStatementItems()`. `renderReconcileHtml` filters them by
institution/account/period and builds the suggestion set. For each
suggested-but-uncleared, unreconciled leg, the row gains a `reconcile-suggested`
class, a `data-suggested` attribute, and a "Bank reported" badge — the checkbox
stays unchecked (data is still `cleared: false`). `renderHeader` renders a
`#reconcile-confirm-all` "Confirm all suggestions" button when the suggestion
set is non-empty.

**`budget/src/style/theme.css`** — minimal additions: a muted
`.reconcile-suggested-badge` style and a dotted-border treatment on the
suggested checkbox so it is visibly distinct from a confirmed-cleared one.

**`budget/src/pages/accounts-reconcile-hydrate.ts`** — interactions.
`#reconcile-confirm-all`'s click optimistically checks each `.reconcile-suggested`
checkbox, persists `updateJournalLegCleared(legId, true)` in parallel, removes
the suggested class and badge, and refreshes the header totals. The existing
cleared-checkbox `change` handler also drops the `reconcile-suggested` marker
on a successful per-row confirmation, so a single click on a suggested checkbox
promotes it cleanly. Override to uncleared works through the unchanged
change-handler path.

## Tests

- `budget/test/reconcile-hints.test.ts` (new) — 5 cases: explicit
  `statementItemId` link → suggested; amount+date within tolerance → suggested;
  date beyond tolerance → not suggested; amount mismatch → not suggested;
  already-`cleared` leg → not suggested.
- `budget/test/pages/accounts-reconcile.test.ts` — extended to cover the badge
  rendering, the confirm-all button gating, and the cleared/reconciled
  exclusions.
- `budget/test/pages/accounts-reconcile-hydrate.test.ts` (new) — bulk confirm,
  single-suggestion confirm, override-to-uncleared.

## Acceptance criteria

- [x] `suggestClearedLegs` returns the set of `JournalLeg.id` values that should
  be visually suggested as cleared
- [x] Suggested-cleared legs render with a "Bank reported" badge and a
  distinguishable unconfirmed-but-suggested checkbox state
- [x] "Confirm all suggestions" button promotes the full suggested set to
  user-confirmed cleared
- [x] User can override a suggestion by toggling the checkbox to uncleared
- [x] Unit tests cover: explicit `statementItemId` link → suggested; amount+date
  match within tolerance → suggested; mismatch beyond tolerance → not suggested

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)
