### PR TITLE
dispatch: skip orphans whose issue is closed or has an open blocker

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -183,7 +183,9 @@ continue to target selection.
     - **Exit 0, empty stdout** → fall through to `dispatch-select-target`.
     - **Exit 0, stdout `worktree <N> <branch>`** → an orphaned worktree was
       adopted. Skip Step 4 and proceed to Step 5 with `<N>` and `explicit` —
-      treat the adoption like an explicit `/dispatch <N>`.
+      treat the adoption like an explicit `/dispatch <N>`. (Step 4's closed-issue
+      and open-blocker gates have already been enforced by `dispatch-sweep`
+      itself before emitting this directive.)
     - **Non-zero exit, stderr `cleanup-unknown:<path>`** → the sweep found a
       worktree with no open PR and no inferable issue number. Use
       `AskUserQuestion` to ask whether to delete `<path>` — its history is

--- a/.claude/skills/dispatch/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch/scripts/dispatch-sweep
@@ -48,6 +48,8 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # shellcheck source=./lib-worktree-in-sync.sh
 source "$SCRIPT_DIR/lib-worktree-in-sync.sh"
+# shellcheck source=./lib.sh
+source "$SCRIPT_DIR/lib.sh"
 
 # Resolve project root + worktrees root from the git common dir. The parent of
 # --git-common-dir is the project root in both classic (.git) and bare (.bare)
@@ -314,6 +316,30 @@ while [[ $i -lt ${#ORPHAN_PATHS[@]} ]]; do
   # <branch>" directive. Log and skip — the operator has the log to investigate.
   if [[ -z "$issue_num" ]]; then
     log "SKIP_ORPHAN_NO_ISSUE_NUM: '$wt_path' branch=$wt_branch pr=#$open_pr"
+    continue
+  fi
+
+  # Closed-issue gate. Fetch state with one gh call; fail loud on error —
+  # no silent fallback to "open" (would cause stale-orphan adoption).
+  if ! issue_state=$(gh issue view "$issue_num" --json state -q .state 2>>"$LOG_FILE"); then
+    log "ERROR_ISSUE_STATE_FETCH: '$wt_path' branch=$wt_branch issue=#$issue_num"
+    echo "ERROR: failed to fetch state for issue #$issue_num" >&2
+    exit 1
+  fi
+  if [[ "$issue_state" == "CLOSED" ]]; then
+    log "SKIP_ORPHAN_CLOSED_ISSUE: '$wt_path' branch=$wt_branch issue=#$issue_num"
+    continue
+  fi
+
+  # Open-blocker gate. count_open_blockers (lib.sh) returns the integer
+  # count and exits non-zero on gh failure (gh_api_array writes its own
+  # descriptive stderr). Fail loud — no silent fallback to "not blocked".
+  if ! n_blockers=$(count_open_blockers "$issue_num"); then
+    log "ERROR_BLOCKER_COUNT: '$wt_path' branch=$wt_branch issue=#$issue_num"
+    exit 1
+  fi
+  if [[ "$n_blockers" -gt 0 ]]; then
+    log "SKIP_ORPHAN_BLOCKED: '$wt_path' branch=$wt_branch issue=#$issue_num blockers=$n_blockers"
     continue
   fi
 

--- a/.claude/skills/dispatch/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch/scripts/dispatch-sweep
@@ -37,6 +37,9 @@
 # Exit codes:
 #   0  normal sweep — may have emitted an adoption directive on stdout, or
 #      successfully completed --cleanup-unknown.
+#   1  gh API failure inside an orphan-classification gate (issue state or
+#      blocker count). Fail-loud per the gate-spec; SKILL.md's "Any other
+#      non-zero exit" branch falls through to dispatch-select-target.
 #   2  invalid invocation (not in a git repo, bad --cleanup-unknown path).
 #   3  halted on an unknown-orphan worktree; stderr carries the directive.
 #
@@ -320,26 +323,39 @@ while [[ $i -lt ${#ORPHAN_PATHS[@]} ]]; do
   fi
 
   # Closed-issue gate. Fetch state with one gh call; fail loud on error —
-  # no silent fallback to "open" (would cause stale-orphan adoption).
-  if ! issue_state=$(gh issue view "$issue_num" --json state -q .state 2>>"$LOG_FILE"); then
-    log "ERROR_ISSUE_STATE_FETCH: '$wt_path' branch=$wt_branch issue=#$issue_num"
+  # no silent fallback to "open" (would cause stale-orphan adoption). Let gh's
+  # stderr surface to the operator (matches the blocker gate, whose
+  # count_open_blockers / gh_api_array writes to stderr too).
+  if ! issue_state=$(gh issue view "$issue_num" --json state -q .state); then
+    log "ERROR_ISSUE_STATE_FETCH: '$wt_path' branch=$wt_branch issue=$issue_num"
     echo "ERROR: failed to fetch state for issue #$issue_num" >&2
     exit 1
   fi
-  if [[ "$issue_state" == "CLOSED" ]]; then
-    log "SKIP_ORPHAN_CLOSED_ISSUE: '$wt_path' branch=$wt_branch issue=#$issue_num"
-    continue
-  fi
+  # Default-deny on anything ≠ OPEN/CLOSED (case-insensitive — lib.sh's
+  # count_open_blockers accepts both casings for the same reason). Empty,
+  # whitespace, or future states fail loud rather than silently adopting.
+  case "$issue_state" in
+    OPEN|open) ;;
+    CLOSED|closed)
+      log "SKIP_ORPHAN_CLOSED_ISSUE: '$wt_path' branch=$wt_branch issue=$issue_num"
+      continue
+      ;;
+    *)
+      log "ERROR_ISSUE_STATE_INVALID: '$wt_path' branch=$wt_branch issue=$issue_num state='$issue_state'"
+      echo "ERROR: unexpected state for issue #$issue_num: '$issue_state'" >&2
+      exit 1
+      ;;
+  esac
 
   # Open-blocker gate. count_open_blockers (lib.sh) returns the integer
   # count and exits non-zero on gh failure (gh_api_array writes its own
   # descriptive stderr). Fail loud — no silent fallback to "not blocked".
   if ! n_blockers=$(count_open_blockers "$issue_num"); then
-    log "ERROR_BLOCKER_COUNT: '$wt_path' branch=$wt_branch issue=#$issue_num"
+    log "ERROR_BLOCKER_COUNT: '$wt_path' branch=$wt_branch issue=$issue_num"
     exit 1
   fi
   if [[ "$n_blockers" -gt 0 ]]; then
-    log "SKIP_ORPHAN_BLOCKED: '$wt_path' branch=$wt_branch issue=#$issue_num blockers=$n_blockers"
+    log "SKIP_ORPHAN_BLOCKED: '$wt_path' branch=$wt_branch issue=$issue_num blockers=$n_blockers"
     continue
   fi
 

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2831,7 +2831,7 @@ assert_eq "blocked-orphan sweep exits 0" "0" "$rc"
 assert_eq "blocked-orphan stdout is empty" "" "$out"
 
 TOTAL=$((TOTAL + 1))
-if grep -q "SKIP_ORPHAN_BLOCKED: '$WT_PATH' branch=61-blocked issue=#61 blockers=1" "$DISPATCH_SWEEP_LOG_FILE"; then
+if grep -q "SKIP_ORPHAN_BLOCKED: '$WT_PATH' branch=61-blocked issue=61 blockers=1" "$DISPATCH_SWEEP_LOG_FILE"; then
   PASS=$((PASS + 1)); echo "  PASS: SKIP_ORPHAN_BLOCKED log line for 61-blocked"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: SKIP_ORPHAN_BLOCKED log line for 61-blocked"
@@ -2862,7 +2862,7 @@ assert_eq "closed-issue sweep exits 0" "0" "$rc"
 assert_eq "closed-issue stdout is empty" "" "$out"
 
 TOTAL=$((TOTAL + 1))
-if grep -q "SKIP_ORPHAN_CLOSED_ISSUE: '$WT_PATH' branch=62-closed issue=#62" "$DISPATCH_SWEEP_LOG_FILE"; then
+if grep -q "SKIP_ORPHAN_CLOSED_ISSUE: '$WT_PATH' branch=62-closed issue=62" "$DISPATCH_SWEEP_LOG_FILE"; then
   PASS=$((PASS + 1)); echo "  PASS: SKIP_ORPHAN_CLOSED_ISSUE log line for 62-closed"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: SKIP_ORPHAN_CLOSED_ISSUE log line for 62-closed"

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2362,6 +2362,7 @@ sweep_setup() {
 
   cp "$SCRIPT_DIR/dispatch-sweep" "$TMPDIR_TEST/scripts/dispatch-sweep"
   cp "$SCRIPT_DIR/lib-worktree-in-sync.sh" "$TMPDIR_TEST/scripts/lib-worktree-in-sync.sh"
+  cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/lib.sh"
   chmod +x "$TMPDIR_TEST/scripts/dispatch-sweep"
 
   # Default empty gh output (each test may overwrite).
@@ -2378,6 +2379,25 @@ args="$*"
 case "$args" in
   "pr list --state all --json number,headRefName,state --limit 200")
     cat "$STUB_DIR/gh-pr-list-all.json"
+    ;;
+  issue\ view\ *\ --json\ state\ -q\ .state)
+    num=$(echo "$args" | awk '{print $3}')
+    f="$STUB_DIR/issue-state-${num}.txt"
+    if [[ -f "$f" ]]; then
+      cat "$f"
+    else
+      echo "OPEN"   # default: not closed (allows adoption)
+    fi
+    ;;
+  api\ */dependencies/blocked_by)
+    path=$(echo "$args" | awk '{print $2}')
+    num=$(echo "$path" | grep -oE '[0-9]+' | tail -1)
+    f="$STUB_DIR/blockers-${num}.json"
+    if [[ -f "$f" ]]; then
+      cat "$f"
+    else
+      echo "[]"     # default: no blockers (allows adoption)
+    fi
     ;;
   *)
     echo "gh sweep stub: unknown invocation: $args" >&2
@@ -2768,6 +2788,91 @@ if [[ "$err" == *"requires a path argument"* ]]; then
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: stderr explains missing path argument"
   echo "    stderr: $err"
+fi
+sweep_teardown
+
+# --- Test 9: open issue with no blockers → orphan is adopted ------------------
+
+echo "Test: open issue with no blockers is adopted (gates pass)"
+sweep_setup
+WT_PATH="$TMPDIR_TEST/project/worktrees/60-open-no-blockers"
+sweep_register_wt "$WT_PATH" "60-open-no-blockers"
+KEY=$(sweep_path_key "$WT_PATH")
+echo "1500000001" > "$STUB_DIR/headct${KEY}.txt"
+# No per-test fixtures: gh shim defaults to OPEN state + [] blockers.
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "open-no-blockers sweep exits 0" "0" "$rc"
+assert_eq "open-no-blockers orphan adopted" "worktree 60 60-open-no-blockers" "$out"
+
+TOTAL=$((TOTAL + 1))
+if grep -q "ADOPT_ORPHAN: '$WT_PATH' branch=60-open-no-blockers issue=60" "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: ADOPT_ORPHAN log line for open-no-blockers"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: ADOPT_ORPHAN log line for open-no-blockers"
+  sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE"
+fi
+sweep_teardown
+
+# --- Test 10: open issue with open blocker → orphan is skipped ----------------
+
+echo "Test: open issue with an open blocker is skipped"
+sweep_setup
+WT_PATH="$TMPDIR_TEST/project/worktrees/61-blocked"
+sweep_register_wt "$WT_PATH" "61-blocked"
+KEY=$(sweep_path_key "$WT_PATH")
+echo "1500000002" > "$STUB_DIR/headct${KEY}.txt"
+# Write a blockers fixture with one open-blocker entry.
+printf '[{"number":999,"state":"OPEN","title":"Blocking issue"}]\n' \
+  > "$STUB_DIR/blockers-61.json"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "blocked-orphan sweep exits 0" "0" "$rc"
+assert_eq "blocked-orphan stdout is empty" "" "$out"
+
+TOTAL=$((TOTAL + 1))
+if grep -q "SKIP_ORPHAN_BLOCKED: '$WT_PATH' branch=61-blocked issue=#61 blockers=1" "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: SKIP_ORPHAN_BLOCKED log line for 61-blocked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: SKIP_ORPHAN_BLOCKED log line for 61-blocked"
+  sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q "ADOPT_ORPHAN" "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: ADOPT_ORPHAN must NOT appear when blocked"
+else
+  PASS=$((PASS + 1)); echo "  PASS: ADOPT_ORPHAN absent for blocked orphan"
+fi
+sweep_teardown
+
+# --- Test 11: closed issue → orphan is skipped --------------------------------
+
+echo "Test: closed issue orphan is skipped"
+sweep_setup
+WT_PATH="$TMPDIR_TEST/project/worktrees/62-closed"
+sweep_register_wt "$WT_PATH" "62-closed"
+KEY=$(sweep_path_key "$WT_PATH")
+echo "1500000003" > "$STUB_DIR/headct${KEY}.txt"
+# Write the issue-state fixture for issue #62.
+printf 'CLOSED\n' > "$STUB_DIR/issue-state-62.txt"
+# No blockers fixture needed: closed-issue gate runs first.
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "closed-issue sweep exits 0" "0" "$rc"
+assert_eq "closed-issue stdout is empty" "" "$out"
+
+TOTAL=$((TOTAL + 1))
+if grep -q "SKIP_ORPHAN_CLOSED_ISSUE: '$WT_PATH' branch=62-closed issue=#62" "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: SKIP_ORPHAN_CLOSED_ISSUE log line for 62-closed"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: SKIP_ORPHAN_CLOSED_ISSUE log line for 62-closed"
+  sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q "ADOPT_ORPHAN" "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: ADOPT_ORPHAN must NOT appear when issue is closed"
+else
+  PASS=$((PASS + 1)); echo "  PASS: ADOPT_ORPHAN absent for closed-issue orphan"
 fi
 sweep_teardown
 


### PR DESCRIPTION
## Summary

Closes #791's gap on the sweep-adoption path. `SKILL.md` Step 3 instructs the orphan-adoption flow to "Skip Step 4 and proceed to Step 5" — which is where the closed-issue and open-blocker gates live. Apply the same gates inside `dispatch-sweep` itself so adoption is consistent with the PR-ladder and explicit-named paths that #791 already covers.

Two new per-orphan gates between issue-number inference and the `CAND_*` append:

- **Closed-issue gate** — `gh issue view <N> --json state -q .state`. Logs `SKIP_ORPHAN_CLOSED_ISSUE` and `continue`s.
- **Open-blocker gate** — `count_open_blockers <N>` (already exported from `lib.sh` since #791). Logs `SKIP_ORPHAN_BLOCKED` and `continue`s when the count is non-zero.

Both are non-destructive — the orphan stays on disk. When every candidate is skipped, the sweep exits 0 with empty stdout and `dispatch-select-target` runs normally. Both gates fail loud on `gh` error (no silent fallback to "open" / "not blocked") per `.claude/rules/code-style.md`.

Stale-orphan destructive cleanup (analogous to the existing `cleanup-unknown` flow) is out of scope; this skip-only fix leaves the orphan on disk awaiting human attention.

## Test plan

- [x] `bash .claude/skills/dispatch/scripts/test-dispatch-scripts.sh` — full suite passes (303/303), including three new sweep tests covering open-no-blockers (adopted), open-with-blocker (skipped), and closed (skipped).
- [x] `shellcheck .claude/skills/dispatch/scripts/dispatch-sweep` — no new warnings (only the matching SC1091 info note for the added `source "$SCRIPT_DIR/lib.sh"`, parallel to the existing one for `lib-worktree-in-sync.sh`).

Closes #799.