### PR TITLE
dispatch: current-worktree continuation precedes sweep orphan adoption (#803)

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -189,12 +189,11 @@ continue to target selection.
     no inferable issue number. Use `AskUserQuestion` to ask whether to delete
     `<path>` — its history is only local. This is the only sweep path that can
     destroy potentially-unmerged code.
-    - **Yes** → run `.claude/skills/dispatch/scripts/dispatch-sweep
-      --cleanup-unknown <path>`
-      (`dangerouslyDisableSandbox: true`), then re-run `dispatch-select-target`
-      and route on its new output. If the new output is another
-      `cleanup-unknown` (a second unknown orphan), repeat — confirm the next
-      path with `AskUserQuestion`.
+    - **Yes** → re-run `dispatch-select-target --cleanup-confirm <path>` and
+      route on its new output. The script performs the cleanup and resumes
+      selection; if a second unknown orphan exists it halts again with
+      `cleanup-unknown <path2>` — confirm that path with a fresh
+      `AskUserQuestion`.
     - **No** → re-run `dispatch-select-target --no-sweep` and route on its new
       output. The flag bypasses the sweep so the next call doesn't immediately
       re-halt on the same unknown orphan.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -153,87 +153,75 @@ continue to target selection.
     that is neither an issue nor a PR — consistent with the other Steps 1-5 stop
     paths.
 
-- **No argument** → run the `origin/main` CI health gate first, then the
-  worktree sweep, then target selection. Both gh-calling scripts need
-  `dangerouslyDisableSandbox: true`.
-
-  The health gate must run **before** the sweep: a red main means no new work
-  is safe to start, and the sweep's gh calls are wasted in that case.
+- **No argument** → run target selection. A single invocation decides every
+  Step 3 outcome: current-worktree continuation, JIT, main-broken gate, sweep
+  orphan adoption, and the queue ladder are all internal to the script and
+  emitted on its one output line.
 
   ```bash
-  HEALTH=$(.claude/skills/dispatch/scripts/dispatch-select-target --health-only)
+  SELECTED=$(.claude/skills/dispatch/scripts/dispatch-select-target)
   ```
 
-  - **`main-broken <sha>`** → see the **main-broken handler** at the end of
-    this step. Do **not** run the sweep or selection.
-  - **`jit-reminder <repo> <num> <project> <item-id>`** → see the
-    **jit-reminder handler** at the end of this step. Do **not** run the sweep
-    or selection — the JIT scan precedes the main-broken health gate, so a jit
-    reminder is surfaced even when `origin/main` is red.
-  - **`ok`** → run the sweep (also needs `dangerouslyDisableSandbox: true` for
-    the `/proc` walk):
+  (`dangerouslyDisableSandbox: true` — it calls `gh` and walks `/proc`.)
 
-    ```bash
-    SWEEP_OUT=$(.claude/skills/dispatch/scripts/dispatch-sweep 2>tmp/dispatch-sweep-stderr)
-    SWEEP_EXIT=$?
-    ```
+  Route on `$SELECTED`:
 
-    Route on the sweep outcome:
-
-    - **Exit 0, empty stdout** → fall through to `dispatch-select-target`.
-    - **Exit 0, stdout `worktree <N> <branch>`** → an orphaned worktree was
-      adopted. Skip Step 4 and proceed to Step 5 with `<N>` and `explicit` —
-      treat the adoption like an explicit `/dispatch <N>`.
-    - **Non-zero exit, stderr `cleanup-unknown:<path>`** → the sweep found a
-      worktree with no open PR and no inferable issue number. Use
-      `AskUserQuestion` to ask whether to delete `<path>` — its history is
-      only local. This is the only sweep path that can destroy
-      potentially-unmerged code.
-      - **Yes** → run `dispatch-sweep --cleanup-unknown <path>`, then re-run
-        the default `dispatch-sweep`. Loop until it exits 0.
-      - **No** → fall through to `dispatch-select-target`.
-    - **Any other non-zero exit** → log the stderr contents to the conversation
-      as a diagnostic, then fall through to `dispatch-select-target` as
-      defense-in-depth. The sweep is best-effort; a malformed invocation or
-      transient `gh`/`git` failure should not stall the workflow.
-
-  ```bash
-  .claude/skills/dispatch/scripts/dispatch-select-target
-  ```
-
-  It prints exactly one line:
-  - `pr <num> <branch> <phase>` — a PR to work on; `<phase>` is pre-derived by the
-    selection scan, so Step 6 reuses it instead of re-deriving
+  - `worktree <N> <branch>` — the current branch is `<N>-…` and issue `<N>` is
+    open. Continue here; skip Step 4 and proceed to Step 5 with mode `queue`
+    (worktree resolution will print `here`).
+  - `worktree-closed <N> <branch>` — the current branch is `<N>-…` and issue
+    `<N>` is closed or unrecognized. Release the lock (see *Releasing the
+    lock*), report that the current worktree belongs to closed/unrecognized
+    issue `<N>`, and **stop** (consistent with the named-target "closed → report
+    and stop" rule in Step 4).
+  - `worktree-adopted <N> <branch>` — `dispatch-sweep` adopted an orphaned
+    worktree elsewhere on disk. Skip Step 4 and proceed to Step 5 with `<N>` and
+    mode `explicit` — treat the adoption like an explicit `/dispatch <N>`.
+  - `pr <num> <branch> <phase>` — a PR to work on; `<phase>` is pre-derived by
+    the selection scan, so Step 6 reuses it instead of re-deriving. Proceed to
+    Step 5 with mode `queue`.
   - `issue <num>` — a `help wanted` issue to implement, pre-resolved by the
     selection scan to a startable open leaf (not necessarily the top-level
-    `help wanted` issue)
-  - `worktree <N> <branch>` — run from inside an issue worktree; target is `<N>`,
-    queue scan already skipped
-  - `worktree-closed <N> <branch>` — run from inside a worktree whose issue is
-    closed or unrecognized → release the lock (see *Releasing the lock*), then
-    report that the current worktree belongs to closed/unrecognized issue `<N>`
-    and **stop** (consistent with the named-target "closed → report and stop"
-    rule in Step 4)
-  - `empty` — nothing eligible
-  - `main-broken <sha>` — `origin/main`'s HEAD CI has a failing check. The
-    pre-sweep gate above normally catches this first; this is the same gate
-    re-run as defense-in-depth. See the **main-broken handler** below.
-  - `jit-reminder <repo> <num> <project> <item-id>` — a JIT issue due for a
-    reminder. The `--health-only` call earlier in this step normally catches
-    this first (the JIT scan is deterministic); this is the same scan re-run as
-    defense-in-depth. See the **jit-reminder handler** below.
+    `help wanted` issue). Proceed to Step 5 with mode `queue`.
+  - `cleanup-unknown <path>` — the sweep found a worktree with no open PR and
+    no inferable issue number. Use `AskUserQuestion` to ask whether to delete
+    `<path>` — its history is only local. This is the only sweep path that can
+    destroy potentially-unmerged code.
+    - **Yes** → run `.claude/skills/dispatch/scripts/dispatch-sweep
+      --cleanup-unknown <path>`
+      (`dangerouslyDisableSandbox: true`), then re-run `dispatch-select-target`
+      and route on its new output. If the new output is another
+      `cleanup-unknown` (a second unknown orphan), repeat — confirm the next
+      path with `AskUserQuestion`.
+    - **No** → re-run `dispatch-select-target --no-sweep` and route on its new
+      output. The flag bypasses the sweep so the next call doesn't immediately
+      re-halt on the same unknown orphan.
+  - `main-broken <sha>` — see the **main-broken handler** at the end of this
+    step.
+  - `jit-reminder <repo> <num> <project> <item-id>` — see the **jit-reminder
+    handler** at the end of this step.
+  - `empty` — nothing eligible. Release the lock (see *Releasing the lock*),
+    then report that the queue is empty and **stop**.
 
-  An **explicit issue argument overrides current-worktree detection** — the selection
-  script, and therefore its current-worktree detection, runs only when no argument is
-  given. `/dispatch #123` run from inside worktree-456 still targets 123.
+  An **explicit issue argument overrides current-worktree detection** — the
+  selection script, and therefore its current-worktree detection, runs only
+  when no argument is given. `/dispatch #123` run from inside worktree-456
+  still targets 123.
 
-  Priority order it implements is two-tier: a topic **category** nests outside
-  the phase **ladder**. Categories, highest priority first: `bug` → `testing
-  infrastructure` → `dispatch` → `other`. A PR's category is the highest-priority
-  topic among the labels of every issue it closes; an issue's category is the
-  highest-priority topic among its own labels; anything with no topic label is
-  `other`. The selector exhausts one category's whole ladder before moving to
-  the next.
+  Priority order the script implements, top to bottom: current-worktree
+  continuation → JIT scan → `origin/main` CI health gate → sweep orphan
+  adoption → topic-category × phase ladder. A jit-reminder surfaces even when
+  `origin/main` is red because the JIT scan precedes the main-broken gate;
+  current-worktree continuation surfaces before either, so a session inside an
+  `<issue>-*` worktree always continues there.
+
+  The topic-category × phase ladder is two-tier: a topic **category** nests
+  outside the phase **ladder**. Categories, highest priority first: `bug` →
+  `testing infrastructure` → `dispatch` → `other`. A PR's category is the
+  highest-priority topic among the labels of every issue it closes; an issue's
+  category is the highest-priority topic among its own labels; anything with no
+  topic label is `other`. The selector exhausts one category's whole ladder
+  before moving to the next.
 
   Within each category the ladder is (highest first; within a tier, oldest PR
   wins; PRs and `help wanted` issues with a local worktree are skipped; a PR
@@ -251,9 +239,6 @@ continue to target selection.
   another session — exactly as a directly-worktree'd issue is skipped; selection
   falls through to the next tier. The tier emits the resolved startable leaf, so
   a queue-selected `issue <num>` is always a directly-startable target.
-
-  On `empty` → release the lock (see *Releasing the lock*), then report that
-  the queue is empty and **stop**.
 
   **main-broken handler.** `origin/main` itself is red, so no new work is safe
   to start. Do **not** run the sweep, create a worktree, branch, or phase skill.

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Select the single highest-priority task from the queue.
-# Usage: dispatch-select-target [--qa | --health-only] [--no-sweep]
+# Usage: dispatch-select-target [--qa | --health-only] [--no-sweep] [--cleanup-confirm <path>]
 #
 # Output: exactly one line:
 #   pr <num> <branch> <phase>   — a PR to work on, with its already-derived phase

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -53,6 +53,14 @@
 # SKILL.md uses this after the user declines a cleanup-unknown confirmation,
 # so the next call doesn't immediately re-halt on the same unknown orphan.
 #
+# --cleanup-confirm <path> (default mode only) executes the user-confirmed
+# cleanup of an unknown orphan, then resumes selection in the same call —
+# replacing the SKILL.md chain of "dispatch-sweep --cleanup-unknown <path>"
+# followed by a re-invocation of this script. On a successful cleanup the
+# script re-runs the internal sweep+route exactly as default mode does; if a
+# second unknown orphan exists it halts again with cleanup-unknown <path2>,
+# letting SKILL.md re-confirm with the user.
+#
 # Selection is two-tier: a topic *category* nests outside the phase *ladder*.
 # Categories, highest priority first:
 #   bug → testing infrastructure → dispatch → other
@@ -91,18 +99,29 @@ source "$SCRIPT_DIR/lib.sh"
 QA_MODE=false
 HEALTH_ONLY=false
 NO_SWEEP=false
+CLEANUP_CONFIRM_PATH=""
 
-for arg in "$@"; do
-  case "$arg" in
-    --qa) QA_MODE=true ;;
-    --health-only) HEALTH_ONLY=true ;;
-    --no-sweep) NO_SWEEP=true ;;
-    *) echo "error: unknown argument: $arg" >&2; exit 1 ;;
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --qa) QA_MODE=true; shift ;;
+    --health-only) HEALTH_ONLY=true; shift ;;
+    --no-sweep) NO_SWEEP=true; shift ;;
+    --cleanup-confirm)
+      if [[ -z "${2:-}" ]]; then
+        echo "error: --cleanup-confirm requires a <path> argument" >&2
+        exit 1
+      fi
+      CLEANUP_CONFIRM_PATH="$2"; shift 2 ;;
+    *) echo "error: unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
 if [[ "$QA_MODE" == "true" && "$HEALTH_ONLY" == "true" ]]; then
   echo "error: --qa and --health-only are mutually exclusive" >&2
+  exit 1
+fi
+if [[ -n "$CLEANUP_CONFIRM_PATH" ]] && [[ "$QA_MODE" == "true" || "$HEALTH_ONLY" == "true" ]]; then
+  echo "error: --cleanup-confirm is only valid in default mode" >&2
   exit 1
 fi
 
@@ -270,6 +289,40 @@ jit_scan() {
   echo "jit-reminder $winner"
 }
 
+# Run dispatch-sweep once and route its outcome. On a routed outcome
+# (worktree-adopted or cleanup-unknown) this exits the script directly; on a
+# fall-through outcome (empty stdout or a non-3 non-zero exit) it returns so
+# the caller can proceed to the topic-category × phase ladder. Used by both
+# default mode and --cleanup-confirm — they diverge only in whether they run
+# dispatch-sweep --cleanup-unknown first.
+sweep_and_route() {
+  local sweep_err sweep_out sweep_rc path
+  sweep_err=$(mktemp)
+  if sweep_out=$("$SCRIPT_DIR/dispatch-sweep" 2>"$sweep_err"); then
+    # Exit 0: empty stdout → fall through to the ladder; "worktree <N> <branch>"
+    # → adopted.
+    if [[ "$sweep_out" =~ ^worktree[[:space:]]+([0-9]+)[[:space:]]+(.+)$ ]]; then
+      echo "worktree-adopted ${BASH_REMATCH[1]} ${BASH_REMATCH[2]}"
+      rm -f "$sweep_err"
+      exit 0
+    fi
+  else
+    sweep_rc=$?
+    if [[ "$sweep_rc" -eq 3 ]] && grep -q '^cleanup-unknown:' "$sweep_err"; then
+      path=$(grep -m1 '^cleanup-unknown:' "$sweep_err" | sed 's/^cleanup-unknown://')
+      echo "cleanup-unknown $path"
+      rm -f "$sweep_err"
+      exit 0
+    fi
+    # Other non-zero exits: log diagnostic, fall through to the ladder.
+    # The sweep is best-effort; a malformed invocation or transient gh/git
+    # failure should not stall the workflow.
+    echo "warning: dispatch-sweep exited $sweep_rc; falling through to ladder" >&2
+    [[ -s "$sweep_err" ]] && cat "$sweep_err" >&2
+  fi
+  rm -f "$sweep_err"
+}
+
 if [[ "$HEALTH_ONLY" == "true" ]]; then
   if on_worktree_branch; then
     echo "ok"
@@ -324,32 +377,18 @@ if [[ "$QA_MODE" == "false" ]]; then
   # an unknown orphan. Runs after current-worktree continuation (above) so a
   # session inside an <issue>-* worktree always continues there. --no-sweep
   # skips this so a re-call after a declined cleanup-unknown doesn't re-halt
-  # on the same unknown orphan.
+  # on the same unknown orphan. --cleanup-confirm runs the user-confirmed
+  # cleanup first, then re-enters this same sweep+route block (so a second
+  # unknown orphan, if any, halts the script the same way).
+  if [[ -n "$CLEANUP_CONFIRM_PATH" ]]; then
+    # Cleanup itself is fail-loud: a non-zero exit (invalid path, registration
+    # race) propagates with stderr intact, matching the cleanup-unknown
+    # detection path's posture. SKILL.md prose stops and reports just like any
+    # other dispatch-script error.
+    "$SCRIPT_DIR/dispatch-sweep" --cleanup-unknown "$CLEANUP_CONFIRM_PATH"
+  fi
   if [[ "$NO_SWEEP" == "false" ]]; then
-    SWEEP_ERR=$(mktemp)
-    if SWEEP_OUT=$("$SCRIPT_DIR/dispatch-sweep" 2>"$SWEEP_ERR"); then
-      # Exit 0: empty stdout → fall through to the ladder; "worktree <N> <branch>"
-      # → adopted.
-      if [[ "$SWEEP_OUT" =~ ^worktree[[:space:]]+([0-9]+)[[:space:]]+(.+)$ ]]; then
-        echo "worktree-adopted ${BASH_REMATCH[1]} ${BASH_REMATCH[2]}"
-        rm -f "$SWEEP_ERR"
-        exit 0
-      fi
-    else
-      sweep_rc=$?
-      if [[ "$sweep_rc" -eq 3 ]] && grep -q '^cleanup-unknown:' "$SWEEP_ERR"; then
-        path=$(grep -m1 '^cleanup-unknown:' "$SWEEP_ERR" | sed 's/^cleanup-unknown://')
-        echo "cleanup-unknown $path"
-        rm -f "$SWEEP_ERR"
-        exit 0
-      fi
-      # Other non-zero exits: log diagnostic, fall through to the ladder.
-      # The sweep is best-effort; a malformed invocation or transient gh/git
-      # failure should not stall the workflow.
-      echo "warning: dispatch-sweep exited $sweep_rc; falling through to ladder" >&2
-      [[ -s "$SWEEP_ERR" ]] && cat "$SWEEP_ERR" >&2
-    fi
-    rm -f "$SWEEP_ERR"
+    sweep_and_route
   fi
 fi
 

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Select the single highest-priority task from the queue.
-# Usage: dispatch-select-target [--qa | --health-only]
+# Usage: dispatch-select-target [--qa | --health-only] [--no-sweep]
 #
 # Output: exactly one line:
 #   pr <num> <branch> <phase>   — a PR to work on, with its already-derived phase
@@ -9,6 +9,14 @@
 #   empty                       — nothing eligible
 #   worktree <N> <branch>       — the current worktree's own open issue (short-circuits the queue scan)
 #   worktree-closed <N> <branch>— the current worktree's issue is closed or unknown
+#   worktree-adopted <N> <branch>
+#                               — dispatch-sweep adopted an orphaned worktree
+#                                 elsewhere on disk; SKILL.md routes this exactly
+#                                 like an explicit /dispatch <N>
+#   cleanup-unknown <path>      — dispatch-sweep halted on an orphan worktree
+#                                 with no open PR and no inferable issue number;
+#                                 SKILL.md confirms with the user before destroying
+#                                 potentially-unmerged work
 #   jit-reminder <repo> <num> <project> <item-id>
 #                               — a configured JIT issue due for a reminder.
 #                                 Emitted before the main-broken gate, ahead of
@@ -16,14 +24,19 @@
 #                                 dispatch.config/jit.json is present.
 #   main-broken <sha>           — origin/main's HEAD CI has a failing check; no task selected
 #
-# Default mode runs a top-priority origin/main CI health gate before the ladder:
-# every queueable task builds on origin/main, so a failing check on main's HEAD
-# short-circuits the scan to "main-broken <sha>" and selects no task.
+# Default-mode priority, top to bottom — current-worktree continuation runs
+# first so a session inside an <issue>-* worktree always continues there, even
+# when the sweep finds an orphan elsewhere on disk:
+#   1. current-worktree continuation (worktree / worktree-closed)
+#   2. JIT scan (jit-reminder)
+#   3. origin/main CI health gate (main-broken)
+#   4. dispatch-sweep (worktree-adopted / cleanup-unknown), unless --no-sweep
+#   5. the topic-category × phase ladder over open PRs and help-wanted issues
 #
 # --health-only mode runs the pre-ladder bypasses (current-worktree continuation),
-# the JIT scan, and the origin/main CI health gate, then exits — no queue scan,
-# no PR/issue fetches. /dispatch SKILL.md uses it to gate the sweep on main's CI
-# health.
+# the JIT scan, and the origin/main CI health gate, then exits — no sweep,
+# no queue scan, no PR/issue fetches. /dispatch SKILL.md uses it to re-seed the
+# dispatch chain heartbeat cheaply.
 # Output is exactly one line:
 #   ok                          — safe to proceed (either main is healthy or the
 #                                 current branch is an <N>-* worktree that
@@ -35,6 +48,10 @@
 #
 # --qa mode omits the <phase> field — there it is always "qa":
 #   pr <num> <branch>           — the QA PR to work on
+#
+# --no-sweep (default mode only) skips the internal dispatch-sweep invocation.
+# SKILL.md uses this after the user declines a cleanup-unknown confirmation,
+# so the next call doesn't immediately re-halt on the same unknown orphan.
 #
 # Selection is two-tier: a topic *category* nests outside the phase *ladder*.
 # Categories, highest priority first:
@@ -73,11 +90,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
 QA_MODE=false
 HEALTH_ONLY=false
+NO_SWEEP=false
 
 for arg in "$@"; do
   case "$arg" in
     --qa) QA_MODE=true ;;
     --health-only) HEALTH_ONLY=true ;;
+    --no-sweep) NO_SWEEP=true ;;
     *) echo "error: unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
@@ -299,6 +318,38 @@ if [[ "$QA_MODE" == "false" ]]; then
   if [[ -n "$MAIN_BROKEN_SHA" ]]; then
     echo "main-broken $MAIN_BROKEN_SHA"
     exit 0
+  fi
+
+  # Internal sweep: adopt an orphaned worktree elsewhere on disk, or halt on
+  # an unknown orphan. Runs after current-worktree continuation (above) so a
+  # session inside an <issue>-* worktree always continues there. --no-sweep
+  # skips this so a re-call after a declined cleanup-unknown doesn't re-halt
+  # on the same unknown orphan.
+  if [[ "$NO_SWEEP" == "false" ]]; then
+    SWEEP_ERR=$(mktemp)
+    if SWEEP_OUT=$("$SCRIPT_DIR/dispatch-sweep" 2>"$SWEEP_ERR"); then
+      # Exit 0: empty stdout → fall through to the ladder; "worktree <N> <branch>"
+      # → adopted.
+      if [[ "$SWEEP_OUT" =~ ^worktree[[:space:]]+([0-9]+)[[:space:]]+(.+)$ ]]; then
+        echo "worktree-adopted ${BASH_REMATCH[1]} ${BASH_REMATCH[2]}"
+        rm -f "$SWEEP_ERR"
+        exit 0
+      fi
+    else
+      sweep_rc=$?
+      if [[ "$sweep_rc" -eq 3 ]] && grep -q '^cleanup-unknown:' "$SWEEP_ERR"; then
+        path=$(grep -m1 '^cleanup-unknown:' "$SWEEP_ERR" | sed 's/^cleanup-unknown://')
+        echo "cleanup-unknown $path"
+        rm -f "$SWEEP_ERR"
+        exit 0
+      fi
+      # Other non-zero exits: log diagnostic, fall through to the ladder.
+      # The sweep is best-effort; a malformed invocation or transient gh/git
+      # failure should not stall the workflow.
+      echo "warning: dispatch-sweep exited $sweep_rc; falling through to ladder" >&2
+      [[ -s "$SWEEP_ERR" ]] && cat "$SWEEP_ERR" >&2
+    fi
+    rm -f "$SWEEP_ERR"
   fi
 fi
 

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -124,6 +124,10 @@ if [[ -n "$CLEANUP_CONFIRM_PATH" ]] && [[ "$QA_MODE" == "true" || "$HEALTH_ONLY"
   echo "error: --cleanup-confirm is only valid in default mode" >&2
   exit 1
 fi
+if [[ -n "$CLEANUP_CONFIRM_PATH" ]] && [[ "$NO_SWEEP" == "true" ]]; then
+  echo "error: --cleanup-confirm and --no-sweep are mutually exclusive" >&2
+  exit 1
+fi
 
 # Print origin/main's HEAD SHA if its CI has a failing check; print nothing if
 # main is healthy or only has in-progress checks. main's CI state spans two

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1909,6 +1909,67 @@ result=$("$TMPDIR_TEST/dispatch-select-target" 2>/dev/null)
 assert_eq "sweep exit 2 → falls through to ladder result" "pr 10 10-verify-me verify" "$result"
 teardown
 
+# SR7. --cleanup-confirm <path> calls dispatch-sweep --cleanup-unknown <path>
+#      first, then re-runs the default sweep+route block. With a sweep stub
+#      that exits 0 / empty stdout on the second call, the script falls
+#      through to the ladder. Proves both calls happen and that routing after
+#      cleanup is identical to default mode.
+echo "Test: --cleanup-confirm <path> runs cleanup then resumes selection"
+setup
+UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf 'main' > "$STUB_DIR/current-branch.txt"
+# Sweep stub logs each invocation's args and is silent / exit 0 otherwise.
+cat > "$TMPDIR_TEST/dispatch-sweep" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$STUB_DIR/dispatch-sweep-calls.log"
+exit 0
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-sweep"
+result=$("$TMPDIR_TEST/dispatch-select-target" --cleanup-confirm "/tmp/some-orphan" 2>/dev/null)
+assert_eq "cleanup-confirm → falls through to ladder result" "pr 10 10-verify-me verify" "$result"
+assert_eq "dispatch-sweep called twice (cleanup + resume)" \
+  "2" "$(wc -l < "$STUB_DIR/dispatch-sweep-calls.log" | tr -d ' ')"
+assert_eq "first sweep call carries --cleanup-unknown <path>" \
+  "--cleanup-unknown /tmp/some-orphan" \
+  "$(sed -n '1p' "$STUB_DIR/dispatch-sweep-calls.log")"
+assert_eq "second sweep call carries no args" \
+  "" "$(sed -n '2p' "$STUB_DIR/dispatch-sweep-calls.log")"
+teardown
+
+# SR8. --cleanup-confirm <path> halts at the next unknown orphan: the
+#      post-cleanup sweep emits cleanup-unknown:<path2> on stderr and exits 3,
+#      and the script propagates cleanup-unknown <path2> on stdout. Proves
+#      multiple unknown orphans iterate one-at-a-time via repeated SKILL.md
+#      AskUserQuestion confirmations rather than being silently consumed.
+echo "Test: --cleanup-confirm <path> halts on the next unknown orphan"
+setup
+setup_union_pr_list '[]'
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf 'main' > "$STUB_DIR/current-branch.txt"
+# Sweep stub: first call (cleanup) exits 0; second call (resume) emits a new
+# unknown orphan on stderr and exits 3.
+cat > "$TMPDIR_TEST/dispatch-sweep" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$STUB_DIR/dispatch-sweep-calls.log"
+n=\$(wc -l < "$STUB_DIR/dispatch-sweep-calls.log" | tr -d ' ')
+if [[ "\$n" -eq 1 ]]; then
+  exit 0
+else
+  echo "cleanup-unknown:/tmp/second-orphan" >&2
+  exit 3
+fi
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-sweep"
+if result=$("$TMPDIR_TEST/dispatch-select-target" --cleanup-confirm "/tmp/first-orphan" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "second unknown orphan propagated to stdout" \
+  "cleanup-unknown /tmp/second-orphan" "$result"
+assert_eq "halting on next unknown orphan exits 0" "0" "$rc"
+teardown
+
 # ============================================================================
 # dispatch-trace-leaf tests
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -81,6 +81,18 @@ setup() {
   mkdir -p "$TMPDIR_TEST/config"
   export DISPATCH_CONFIG_DIR="$TMPDIR_TEST/config"
 
+  # Default no-op dispatch-sweep stub: silent, exit 0 (no orphan to adopt).
+  # dispatch-select-target invokes "$SCRIPT_DIR/dispatch-sweep" in default mode
+  # between the main-broken gate and the queue ladder; with this stub the call
+  # is inert and every existing default-mode test stays green. Tests that
+  # exercise sweep integration overwrite this stub before invoking
+  # dispatch-select-target.
+  cat > "$TMPDIR_TEST/dispatch-sweep" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/dispatch-sweep"
+
   # dispatch-select-target calls dispatch-phase as "$SCRIPT_DIR/dispatch-phase".
   # Since we copied them all to TMPDIR_TEST, SCRIPT_DIR inside each copy will
   # resolve to TMPDIR_TEST correctly.
@@ -882,6 +894,8 @@ assert_eq "lone waiting PR → empty" "empty" "$result"
 teardown
 
 # 16. Open issue worktree → worktree output, queue scan skipped.
+# The default no-op dispatch-sweep stub installed by setup() is in place but
+# unused — current-worktree continuation short-circuits before the sweep call.
 echo "Test: open issue worktree → worktree <N> <branch>, scan skipped"
 setup
 # Seed a verify PR that would normally be selected — proves the scan is skipped.
@@ -1776,6 +1790,123 @@ printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 if result=$("$TMPDIR_TEST/dispatch-select-target" 2>/dev/null); then rc=0; else rc=$?; fi
 [[ "$rc" -ne 0 ]] && rc_nonzero=yes || rc_nonzero=no
 assert_eq "invalid duration → exits non-zero" "yes" "$rc_nonzero"
+teardown
+
+# --- sweep routing (issue #803) ---------------------------------------------
+# dispatch-select-target invokes dispatch-sweep internally in default mode,
+# between the main-broken gate and the queue ladder. The sweep call comes
+# AFTER current-worktree continuation, so a session inside an <issue>-*
+# worktree always continues there even when an orphan exists elsewhere.
+# Tests below overwrite the default no-op sweep stub seeded by setup() to
+# exercise the routing branches.
+
+# SR1. (AC b) Inside an active <issue>-* worktree with an orphan elsewhere →
+#      still worktree <N> <branch>. The sweep stub would emit an adoption
+#      directive if invoked; the assert proves it never was.
+echo "Test: worktree continuation precedes sweep adoption (regression — #803)"
+setup
+setup_union_pr_list '[]'
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
+printf '{"state":"OPEN"}' > "$STUB_DIR/issue-state-42.json"
+# Sweep stub would adopt an orphan at issue 725 if invoked — proves the sweep
+# never ran (current-worktree continuation short-circuited first).
+cat > "$TMPDIR_TEST/dispatch-sweep" <<'STUB'
+#!/usr/bin/env bash
+echo "worktree 725 725-some-orphan"
+exit 0
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-sweep"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "worktree continuation beats sweep adoption" "worktree 42 42-some-slug" "$result"
+teardown
+
+# SR2. (AC c) Outside any worktree, orphan present → worktree-adopted.
+echo "Test: outside any worktree, orphan present → worktree-adopted"
+setup
+setup_union_pr_list '[]'
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf 'main' > "$STUB_DIR/current-branch.txt"
+cat > "$TMPDIR_TEST/dispatch-sweep" <<'STUB'
+#!/usr/bin/env bash
+echo "worktree 725 725-orphan"
+exit 0
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-sweep"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "sweep adoption → worktree-adopted 725 725-orphan" "worktree-adopted 725 725-orphan" "$result"
+teardown
+
+# SR3. (AC d) Outside any worktree, no orphan → ladder result.
+echo "Test: outside any worktree, no orphan → ladder result"
+setup
+UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf 'main' > "$STUB_DIR/current-branch.txt"
+# Default no-op sweep stub from setup() is unchanged → sweep falls through.
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "no orphan → ladder picks verify PR" "pr 10 10-verify-me verify" "$result"
+teardown
+
+# SR4. cleanup-unknown propagation: sweep exits 3 with stderr "cleanup-unknown:<path>".
+echo "Test: sweep exit 3 + cleanup-unknown stderr → cleanup-unknown <path>"
+setup
+setup_union_pr_list '[]'
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf 'main' > "$STUB_DIR/current-branch.txt"
+cat > "$TMPDIR_TEST/dispatch-sweep" <<'STUB'
+#!/usr/bin/env bash
+echo "cleanup-unknown:/tmp/some-orphan" >&2
+exit 3
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-sweep"
+if result=$("$TMPDIR_TEST/dispatch-select-target" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "cleanup-unknown propagated to stdout" "cleanup-unknown /tmp/some-orphan" "$result"
+assert_eq "cleanup-unknown route exits 0" "0" "$rc"
+teardown
+
+# SR5. --no-sweep bypasses the sweep call. A sweep stub that would adopt an
+#      orphan is installed; the flag must prove it was never invoked.
+echo "Test: --no-sweep bypasses the sweep call"
+setup
+UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf 'main' > "$STUB_DIR/current-branch.txt"
+# Stub would emit worktree-adopted-style adoption directive if invoked.
+cat > "$TMPDIR_TEST/dispatch-sweep" <<'STUB'
+#!/usr/bin/env bash
+echo "worktree 725 725-orphan"
+exit 0
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-sweep"
+result=$("$TMPDIR_TEST/dispatch-select-target" --no-sweep)
+assert_eq "--no-sweep skips adoption → ladder result" "pr 10 10-verify-me verify" "$result"
+teardown
+
+# SR6. A non-3 non-zero sweep exit logs a diagnostic but falls through to the
+#      ladder — defense-in-depth so a malformed sweep does not stall dispatch.
+echo "Test: sweep exit 2 (unrelated failure) → warning, fall through to ladder"
+setup
+UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf 'main' > "$STUB_DIR/current-branch.txt"
+cat > "$TMPDIR_TEST/dispatch-sweep" <<'STUB'
+#!/usr/bin/env bash
+echo "some unrelated sweep error" >&2
+exit 2
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-sweep"
+result=$("$TMPDIR_TEST/dispatch-select-target" 2>/dev/null)
+assert_eq "sweep exit 2 → falls through to ladder result" "pr 10 10-verify-me verify" "$result"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1970,6 +1970,38 @@ assert_eq "second unknown orphan propagated to stdout" \
 assert_eq "halting on next unknown orphan exits 0" "0" "$rc"
 teardown
 
+# SR9. --cleanup-confirm <path> with a failing dispatch-sweep --cleanup-unknown
+#      call propagates the non-zero exit code (set -e) instead of silently
+#      falling through to the ladder. Proves cleanup failures are fail-loud per
+#      the contract documented at the top of the sweep+route block.
+echo "Test: --cleanup-confirm with failing cleanup propagates non-zero exit"
+setup
+setup_union_pr_list '[]'
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf 'main' > "$STUB_DIR/current-branch.txt"
+cat > "$TMPDIR_TEST/dispatch-sweep" <<'STUB'
+#!/usr/bin/env bash
+echo "dispatch-sweep: invalid cleanup path" >&2
+exit 2
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-sweep"
+if result=$("$TMPDIR_TEST/dispatch-select-target" --cleanup-confirm "/tmp/bad" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "cleanup failure propagates exit 2" "2" "$rc"
+assert_eq "cleanup failure emits no stdout" "" "$result"
+teardown
+
+# SR10. --cleanup-confirm and --no-sweep are mutually exclusive: combining them
+#       would silently skip the post-cleanup sweep, violating the "resumes
+#       selection" contract.
+echo "Test: --cleanup-confirm + --no-sweep is rejected"
+setup
+if err=$("$TMPDIR_TEST/dispatch-select-target" --cleanup-confirm /tmp/x --no-sweep 2>&1 >/dev/null); then rc=0; else rc=$?; fi
+assert_eq "combining the flags exits 1" "1" "$rc"
+assert_eq "stderr names both flags" \
+  "error: --cleanup-confirm and --no-sweep are mutually exclusive" "$err"
+teardown
+
 # ============================================================================
 # dispatch-trace-leaf tests
 # ============================================================================


### PR DESCRIPTION
## Summary

- Move sweep + cleanup-unknown routing into `dispatch-select-target` so current-worktree continuation always runs **before** sweep orphan adoption.
- Reduce `SKILL.md` Step 3 (no-arg path) to a single `dispatch-select-target` invocation + a route table on its one output line.
- Add a `--no-sweep` flag for the user-declined-cleanup re-call path.

Fixes the regression where `/dispatch` invoked from inside an active `<issue>-*` worktree pivoted away to an unrelated orphan whenever the sweep found one on disk (observed for #742 → #725).

The script now owns the ordering of: current-worktree continuation → JIT scan → `origin/main` health gate → sweep adoption → topic-category × phase ladder. SKILL.md becomes a pure router. New output lines: `worktree-adopted <N> <branch>` and `cleanup-unknown <path>`.

Closes #803.

## Test plan

- [x] `test-dispatch-scripts.sh` passes (299/299 — 7 new assertions).
  - SR1 — inside an `<issue>-*` worktree with an orphan elsewhere, current-worktree continuation still wins (the #803 regression case).
  - SR2 — outside any worktree with an orphan → `worktree-adopted <N> <branch>`.
  - SR3 — outside any worktree, no orphan → ladder result.
  - SR4 — sweep exit 3 + `cleanup-unknown:` stderr → propagates to stdout.
  - SR5 — `--no-sweep` bypasses the sweep call.
  - SR6 — defense-in-depth: a non-3 non-zero sweep exit falls through to the ladder.
- [ ] CI green on push.
- [ ] Live verification deferred to the `verify` / `qa` phases of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)