### PR TITLE
Flaky CI: cache + retry for npm ci (#807)

### DIFF
--- a/.claude/skills/dispatch/scripts/lib.sh
+++ b/.claude/skills/dispatch/scripts/lib.sh
@@ -112,7 +112,28 @@ ensure_deps() {
     return 1
   fi
   if [ ! -d "$REPO_ROOT/node_modules" ]; then
-    (cd "$REPO_ROOT" && npm ci)
+    (
+      cd "$REPO_ROOT"
+      export npm_config_fetch_retries=5
+      export npm_config_fetch_retry_mintimeout=20000
+      export npm_config_fetch_retry_maxtimeout=120000
+      export npm_config_fetch_timeout=600000
+      attempt=1
+      while [ "$attempt" -le 3 ]; do
+        if [ "$attempt" -gt 1 ]; then
+          echo "ensure_deps: npm ci attempt $attempt/3" >&2
+        fi
+        if npm ci; then
+          exit 0
+        fi
+        case "$attempt" in
+          1) sleep 5 ;;
+          2) sleep 15 ;;
+        esac
+        attempt=$((attempt + 1))
+      done
+      exit 1
+    )
   fi
 }
 

--- a/.claude/skills/dispatch/scripts/lib.sh
+++ b/.claude/skills/dispatch/scripts/lib.sh
@@ -132,6 +132,7 @@ ensure_deps() {
         esac
         attempt=$((attempt + 1))
       done
+      echo "ensure_deps: npm ci failed after 3 attempts" >&2
       exit 1
     )
   fi

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -4283,6 +4283,108 @@ assert_eq "idempotency run 2 made no second issue create" \
 jit_teardown
 
 # ============================================================================
+# ensure_deps (lib.sh) retry tests
+# ============================================================================
+echo ""
+echo "=== ensure_deps retry ==="
+
+# These tests use a fresh TMPDIR_TEST with a STUB_DIR holding npm and sleep
+# shims on PATH. lib.sh is sourced from SCRIPT_DIR (not the TMPDIR_TEST copy)
+# so ensure_deps resolves directly. REPO_ROOT is a fresh tmpdir with no
+# node_modules — forcing the install branch every time.
+
+# 1. ensure_deps retries and succeeds on attempt 3.
+echo "Test: ensure_deps retries and succeeds on attempt 3"
+TMPDIR_TEST=$(mktemp -d)
+STUB_DIR="$TMPDIR_TEST/stub"
+mkdir -p "$STUB_DIR"
+REPO_ROOT_TEST=$(mktemp -d)
+
+# npm stub: fail on calls 1 and 2; succeed on call 3.
+cat > "$STUB_DIR/npm" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")" && pwd)"
+count_file="$STUB_DIR/npm-count"
+count=0
+[ -f "$count_file" ] && count=$(cat "$count_file")
+count=$((count + 1))
+echo "$count" > "$count_file"
+if [ "$count" -lt 3 ]; then
+  exit 1
+fi
+exit 0
+STUB
+chmod +x "$STUB_DIR/npm"
+
+# sleep stub: no-op.
+cat > "$STUB_DIR/sleep" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$STUB_DIR/sleep"
+
+export PATH="$STUB_DIR:$SAVED_PATH"
+rc=0
+( export REPO_ROOT="$REPO_ROOT_TEST"; source "$SCRIPT_DIR/lib.sh"; ensure_deps ) || rc=$?
+assert_eq "ensure_deps succeeds on attempt 3 (exit code)" "0" "$rc"
+npm_count=0
+[ -f "$STUB_DIR/npm-count" ] && npm_count=$(cat "$STUB_DIR/npm-count")
+assert_eq "ensure_deps called npm exactly 3 times" "3" "$npm_count"
+
+rm -rf "$TMPDIR_TEST" "$REPO_ROOT_TEST"
+TMPDIR_TEST=""
+STUB_DIR=""
+export PATH="$SAVED_PATH"
+
+# 2. ensure_deps fails after exhausting all 3 attempts.
+echo "Test: ensure_deps fails after exhausting all 3 attempts"
+TMPDIR_TEST=$(mktemp -d)
+STUB_DIR="$TMPDIR_TEST/stub"
+mkdir -p "$STUB_DIR"
+REPO_ROOT_TEST=$(mktemp -d)
+
+# npm stub: always fails.
+cat > "$STUB_DIR/npm" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")" && pwd)"
+count_file="$STUB_DIR/npm-count"
+count=0
+[ -f "$count_file" ] && count=$(cat "$count_file")
+count=$((count + 1))
+echo "$count" > "$count_file"
+exit 1
+STUB
+chmod +x "$STUB_DIR/npm"
+
+# sleep stub: no-op.
+cat > "$STUB_DIR/sleep" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$STUB_DIR/sleep"
+
+export PATH="$STUB_DIR:$SAVED_PATH"
+rc=0
+( export REPO_ROOT="$REPO_ROOT_TEST"; source "$SCRIPT_DIR/lib.sh"; ensure_deps ) || rc=$?
+TOTAL=$((TOTAL + 1))
+if [ "$rc" -ne 0 ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: ensure_deps returns non-zero after 3 failed attempts"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: ensure_deps returns non-zero after 3 failed attempts"
+  echo "    expected non-zero, got 0"
+fi
+npm_count=0
+[ -f "$STUB_DIR/npm-count" ] && npm_count=$(cat "$STUB_DIR/npm-count")
+assert_eq "ensure_deps tried npm exactly 3 times before giving up" "3" "$npm_count"
+
+rm -rf "$TMPDIR_TEST" "$REPO_ROOT_TEST"
+TMPDIR_TEST=""
+STUB_DIR=""
+export PATH="$SAVED_PATH"
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .node-version
+          cache: 'npm'
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: "temurin"
@@ -42,6 +43,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .node-version
+          cache: 'npm'
       - name: Authenticate with Firebase
         env:
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .node-version
+          cache: 'npm'
       - name: Run unit tests
         run: .claude/skills/dispatch/scripts/run-unit-tests.sh
 
@@ -54,6 +55,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .node-version
+          cache: 'npm'
       - name: Run lint
         run: .claude/skills/dispatch/scripts/run-lint.sh
 
@@ -66,6 +68,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .node-version
+          cache: 'npm'
       - name: Run typecheck
         run: .claude/skills/dispatch/scripts/run-typecheck.sh
 
@@ -98,6 +101,7 @@ jobs:
         if: steps.changes.outputs.nix == 'true' || steps.changes.outputs.playwright == 'true'
         with:
           node-version-file: .node-version
+          cache: 'npm'
       - name: Install workspace dependencies
         if: steps.changes.outputs.nix == 'true' || steps.changes.outputs.playwright == 'true'
         run: npm ci


### PR DESCRIPTION
## Summary

Mitigates the transient `npm error code ECONNRESET` failure that broke PR #792's `acceptance` check by stacking two independent layers around every `npm ci` in the PR-check workflows:

- **Caching.** `cache: 'npm'` added to every `actions/setup-node@…` step in `pr-checks.yml` (`acceptance`, `preview-and-smoke`) and `unit-tests.yml` (`unit-tests`, `lint`, `typecheck`, `playwright-version-sync`). With the cache hot and `package-lock.json` unchanged, `npm ci` restores from `~/.npm/_cacache` and never hits `registry.npmjs.org`.
- **Retry.** `ensure_deps()` in `.claude/skills/dispatch/scripts/lib.sh` now sets per-invocation `npm_config_fetch_retries=5` (plus longer fetch timeouts) and wraps `npm ci` in a 3-attempt shell loop with 5s/15s backoff. Final-attempt failure still returns non-zero, preserving the `set -euo pipefail` contract for callers.

Together: cache reduces how often the install path needs the registry; retry backstops the residual transient failures that slip through (e.g. cold cache after a lockfile change).

The `hook-tests` job is intentionally untouched — it does not call `setup-node` or `npm ci`. Deploy workflows (firestore/storage/functions/prod) have the same exposure but a different blast radius and are deferred per the plan; scope here is PR checks only.

Closes #807.

## Test plan

- [ ] `acceptance`, `unit-tests`, `lint`, `typecheck`, `preview-and-smoke`, `playwright-version-sync` all pass on this PR (cold cache — first run).
- [ ] After a no-op push, the same checks pass with materially faster `npm ci` step durations (warm cache).
- [ ] `hook-tests` exercises `ensure_deps`'s new retry branch via 2 new tests in `test-dispatch-scripts.sh` (322/322 pass locally).