### PR TITLE
dispatch: marker-based lock reclaim closes silent --release noop leak (#814)

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -81,4 +81,7 @@ ISSUE_NUM="${BRANCH%%-*}"
 (cd "$NEW_PATH" && "$(cd "$(dirname "$0")" && pwd)/../skills/dispatch/scripts/sync-issue-context" "$ISSUE_NUM") >&3 2>&1 \
   || { echo "[worktree-create] ERROR: sync-issue-context failed for issue $ISSUE_NUM" >&2; exit 1; }
 
+mkdir -p "$NEW_PATH/tmp" && touch "$NEW_PATH/tmp/dispatch-worktree" \
+  || { echo "[worktree-create] ERROR: failed to write dispatch marker at $NEW_PATH/tmp/dispatch-worktree" >&2; exit 1; }
+
 echo "$NEW_PATH"

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -61,28 +61,41 @@ The lock covers **Steps 0-5 only** — target selection and worktree resolution.
 Steps 6-9 (the phase skill, the pre-implementation relevance review, and the
 hand-off) run with the lock **released**.
 
-Release the lock by running:
+Release happens at exactly two kinds of point, each with its own canonical
+command:
 
-```bash
-.claude/skills/dispatch/scripts/dispatch-acquire-lock --release
-```
-
-This needs `dangerouslyDisableSandbox: true` (same reason as Step 0); no
-elevated timeout is needed — `--release` returns immediately. It prints
-`released` or `noop`; both are fine — it is a no-op when the lock is already
-released or held by another session, so the skill does not branch on its output.
-
-Release happens at exactly two kinds of point:
-
-- **Proceed path** — as the final action of Step 5, after the
-  `tmp/dispatch-worktree` marker is written, before Step 6.
+- **Proceed path** — as the final action of Step 5, run
+  `dispatch-finalize-selection`. The wrapper writes the
+  `tmp/dispatch-worktree` marker (see *Step 5* and the marker paragraph below)
+  and execs `dispatch-acquire-lock --release` in one step.
 - **Every Steps 1-5 stop path** — immediately before reporting the stop reason
-  and proceeding to Step 9 (early-stop).
+  and proceeding to Step 9 (early-stop), run
+  `.claude/skills/dispatch/scripts/dispatch-acquire-lock --release` directly.
+  Stop paths fire before the marker is written, so the strict
+  `CLAUDE_CODE_SESSION_ID`-match branch applies.
+
+Both calls need `dangerouslyDisableSandbox: true` (same reason as Step 0); no
+elevated timeout is needed — `--release` returns immediately. They print
+`released` or `noop`; both are fine — `noop` is a no-op when the lock is
+already released or recorded against a different session whose worktree has no
+marker, so the skill does not branch on the output.
 
 Releasing after Step 5 is safe because the session then owns a worktree (or has
 stopped), and the selection scan skips worktree'd targets — no other tick can
 select the same issue. Later steps cross-reference *Releasing the lock* rather
-than repeating this command.
+than repeating these commands.
+
+The `tmp/dispatch-worktree` marker is the canonical post-Step-5 reclaim signal:
+a recorded holder whose worktree carries the marker is past Step 5, so its
+lock is reclaimable by any subsequent tick regardless of session-id provenance.
+The acquire path skips the busy branch when the foreign holder's cwd has the
+marker, and `--release` succeeds (truncates and prints `released`) when EITHER
+the caller's sessionId matches the holder OR the holder's cwd has the marker.
+This closes the silent-`noop` failure mode for any post-Step-5 caller whose
+`CLAUDE_CODE_SESSION_ID` was re-derived from a different context (a subagent
+or hook). Pre-marker callers — Steps 1-4 stop paths and the Step 5 `conflict`
+stop — keep strict sessionId-match semantics by construction because the
+marker is absent.
 
 The lock is scoped to selection and self-healing. The recorded sessionId
 (`CLAUDE_CODE_SESSION_ID`) outlives any single Bash call within a tick: if a
@@ -400,22 +413,30 @@ one of `path` (switch to an existing worktree) or `name` (create a new one).
   conflict (name `<path>` and issue `<N>`), then **proceed to Step 9**
   (early-stop); do not `EnterWorktree`.
 
-On every non-`conflict` path, before any phase skill runs, create the recovery
-marker:
+As the **final action of this step on every non-`conflict` (proceed) path** —
+before Step 6 — run:
 
 ```bash
-mkdir -p tmp && touch tmp/dispatch-worktree
+.claude/skills/dispatch/scripts/dispatch-finalize-selection
 ```
 
-`restore-dispatch-skill.sh` (bound to `SessionStart:clear`) keys context-clear
-recovery on this marker — when present, it re-invokes `/dispatch` so the phase is
-re-derived from PR/CI ground truth. The marker is an empty boolean flag with no
-payload; it persists for the worktree's life and needs no cleanup — `tmp/` is
-git-ignored, and removing the worktree removes it.
+The wrapper writes the `tmp/dispatch-worktree` marker and releases the lock
+(see *Releasing the lock*) in one step. The phase skill in Step 6 onward runs
+lock-free. The wrapper needs `dangerouslyDisableSandbox: true` (same reason as
+the underlying `dispatch-acquire-lock --release` — see *Releasing the lock*).
 
-As the **final action of this step on every non-`conflict` (proceed) path** —
-after the marker is written, before Step 6 — release the lock (see *Releasing
-the lock*). The phase skill in Step 6 onward runs lock-free.
+The marker is the canonical "Step 5 completed" signal. Two consumers read it:
+`restore-dispatch-skill.sh` (bound to `SessionStart:clear`) keys context-clear
+recovery on it — when present, it re-invokes `/dispatch` so the phase is
+re-derived from PR/CI ground truth — and the lock script keys post-Step-5
+reclaim on it (see *Releasing the lock*). `.claude/hooks/worktree-create.sh`
+also writes the marker as its final action on every successful WorktreeCreate,
+so a fresh (or re-entered) worktree is marker-bearing the moment
+`EnterWorktree` returns — `dispatch-finalize-selection`'s marker write is the
+in-skill defense for the `here` path and for any code path that bypasses the
+hook. The marker is an empty boolean flag with no payload; it persists for the
+worktree's life and needs no cleanup — `tmp/` is git-ignored, and removing the
+worktree removes it.
 
 ## 6. Derive the Phase
 

--- a/.claude/skills/dispatch/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch/scripts/dispatch-acquire-lock
@@ -31,6 +31,21 @@
 # the recorded sessionId without waiting for self-healing to notice the
 # session has moved on.
 #
+# Marker-based reclaim. The dispatch lock covers Steps 0–5 of /dispatch only
+# (target selection + worktree resolution); phase skills run lock-free. The
+# marker file `tmp/dispatch-worktree` is written in the selected worktree at
+# the end of Step 5 on every proceed path, so its presence in the recorded
+# holder's cwd authoritatively means "Step 5 completed — past the lock-
+# covered region". Both acquire and `--release` honor this signal:
+#   - Acquire reclaims a marker-bearing foreign holder regardless of session
+#     liveness (the holder is past Step 5; the lock no longer serves it).
+#   - `--release` succeeds for any caller when the recorded holder's cwd
+#     carries the marker, in addition to the strict self-release branch.
+# This closes the silent-noop leak when a child context's
+# CLAUDE_CODE_SESSION_ID differs from the recorded holder. Pre-marker stop
+# paths (Steps 1–4 stop, Step 5 `conflict`) fire before the marker exists, so
+# the lenient branch correctly does not engage and strict semantics apply.
+#
 # Usage:
 #   dispatch-acquire-lock            — single-shot: print "acquired" or "busy".
 #   dispatch-acquire-lock --wait     — poll until acquired or the wait timeout
@@ -92,16 +107,23 @@ fi
 WAIT_TIMEOUT="${DISPATCH_LOCK_WAIT_TIMEOUT:-300}"
 WAIT_INTERVAL="${DISPATCH_LOCK_WAIT_INTERVAL:-5}"
 
-# is_live_session <sessionId> — true if <sessionId> appears in the daemon's
-# live-session registry. Covers the same failure modes that
-# lib-claude-agents.sh::claude_sessions_under treats as UNKNOWN (binary
-# missing, non-zero exit, whitespace-only output, non-array JSON, jq failure),
-# but inverts the return convention: this function returns 0 (LIVE — keep the
-# lock) instead of 1 (unknown — caller folds to occupied). The helper's
-# question is "is anything running under this path?"; ours is "is THIS
-# sessionId still alive?", and the global registry has no --cwd filter. A
-# zero-exit, valid `[]` is a definite "no live sessions anywhere" and returns
-# 1 (reclaim); only opaque failures fail safe to LIVE.
+# resolve_holder_state <sessionId> — query the daemon's live-session registry
+# for <sessionId> and report both liveness and cwd. Covers the same failure
+# modes that lib-claude-agents.sh::claude_sessions_under treats as UNKNOWN
+# (binary missing, non-zero exit, whitespace-only output, non-array JSON, jq
+# failure), but inverts the return convention: this function returns 0 (LIVE
+# — keep the lock) instead of 1 (unknown — caller folds to occupied). The
+# helper's question is "is anything running under this path?"; ours is "is
+# THIS sessionId still alive, and where?", and the global registry has no
+# --cwd filter. A zero-exit, valid `[]` is a definite "no live sessions
+# anywhere" and returns 1 (reclaim); only opaque failures fail safe to LIVE.
+#
+# Stdout: the holder's cwd on a single line if the registry exposed it.
+#         Empty if either the holder is not live OR the daemon query was
+#         opaque (failed/non-array/parse error). Callers treat an empty cwd
+#         on a "live" return as "marker check cannot proceed → stay strict."
+# Return: 0 = live (or opaque failure → fail-safe live)
+#         1 = definitely not live (reclaim)
 #
 # The `9>&-` redirection closes fd 9 (the flock fd, opened by the caller's
 # subshell) in the `claude` child. flock is on the open file description and
@@ -109,22 +131,33 @@ WAIT_INTERVAL="${DISPATCH_LOCK_WAIT_INTERVAL:-5}"
 # any background helper `claude` ever spawns would inherit fd 9 and hold the
 # flock past our subshell's exit. Today `claude agents --json` is a query-and-
 # exit client, but the cost of defending against a future fork is one redir.
-is_live_session() {
-  local sid="$1" out sids
+resolve_holder_state() {
+  local sid="$1" out rows match
   if ! out=$("${CLAUDE_AGENTS_CMD:-claude}" agents --json 2>/dev/null 9>&-); then
     return 0
   fi
   if [[ -z "${out//[[:space:]]/}" ]]; then
     return 0
   fi
-  if ! sids=$(jq -r '
+  # One TSV row per session: <sessionId>\t<cwd>. `// ""` keeps both fields as
+  # strings even when absent, so the tab-split below always has two slots.
+  if ! rows=$(jq -r '
     if type == "array"
-    then .[] | .sessionId // empty
+    then .[] | "\(.sessionId // "")\t\(.cwd // "")"
     else error("not a JSON array")
     end' <<<"$out" 2>/dev/null); then
     return 0
   fi
-  printf '%s\n' "$sids" | grep -qxF -- "$sid"
+  # grep -F to keep the sessionId literal; the trailing tab anchors the match
+  # to the sessionId field exclusively, so a sessionId that happens to appear
+  # inside another row's cwd cannot match.
+  if ! match=$(printf '%s\n' "$rows" | grep -F -- "${sid}"$'\t' | head -n1); then
+    # Definitely not live: registry parsed cleanly and our sid isn't in it.
+    return 1
+  fi
+  # Strip the leading "<sid>\t" prefix to leave the cwd on stdout.
+  printf '%s\n' "${match#*$'\t'}"
+  return 0
 }
 
 # ---- Step 1: resolve the lock file ------------------------------------------
@@ -169,15 +202,25 @@ try_acquire() {            # 0 = acquired, 1 = contended; sets CONTENDED_SID
   result=$(
     exec 9>>"$LOCK_FILE"
     flock 9                # blocking — a short mutex over the read-check-write
-    local recorded=""
+    local recorded="" cwd="" live=0
     IFS= read -r recorded <"$LOCK_FILE" 2>/dev/null || true
     # Busy iff a different sessionId is recorded AND it is still a live
-    # session per `claude agents --json`. Otherwise — no record, a stale
-    # record (sessionId not in the registry), or our own session re-entering —
-    # we claim the lock.
-    if [[ -n "$recorded" && "$recorded" != "$SESSION_ID" ]] \
-         && is_live_session "$recorded"; then
-      printf 'BUSY %s' "$recorded"
+    # session per `claude agents --json` AND its cwd does NOT carry the
+    # tmp/dispatch-worktree marker (i.e. it is still in the lock-covered
+    # Steps 0–5 region). Otherwise — no record, a stale record (sessionId
+    # not in the registry), our own session re-entering, or a marker-bearing
+    # foreign holder past Step 5 — we claim the lock. An empty cwd on a
+    # live return (opaque-failure path) skips the marker check → stay strict.
+    if [[ -n "$recorded" && "$recorded" != "$SESSION_ID" ]]; then
+      if cwd=$(resolve_holder_state "$recorded"); then
+        live=1
+      fi
+      if (( live )) && ! { [[ -n "$cwd" && -e "$cwd/tmp/dispatch-worktree" ]]; }; then
+        printf 'BUSY %s' "$recorded"
+      else
+        printf '%s\n' "$SESSION_ID" >"$LOCK_FILE"
+        printf 'OK'
+      fi
     else
       printf '%s\n' "$SESSION_ID" >"$LOCK_FILE"
       printf 'OK'
@@ -215,16 +258,35 @@ case "$MODE" in
     ;;
 
   release)
-    # Re-read the recorded sessionId under flock and clear it ONLY if it is
-    # our own session. Truncate with `:` rather than `rm` — `rm` would orphan
-    # a concurrent acquire's already-open fd. A no-op when the lock is unheld
-    # or held by another session.
+    # Re-read the recorded sessionId under flock and clear it when EITHER
+    # (a) it is our own session (strict self-release), OR (b) the recorded
+    # holder's cwd carries the tmp/dispatch-worktree marker (lenient post-
+    # Step-5 release — closes the silent-noop leak when a child context's
+    # CLAUDE_CODE_SESSION_ID differs from the recorded holder). A not-live
+    # foreign holder without a marker stays a noop; its lock will be
+    # reclaimed by the next acquire anyway. Truncate with `:` rather than
+    # `rm` — `rm` would orphan a concurrent acquire's already-open fd.
     result=$(
       exec 9>>"$LOCK_FILE"
       flock 9
       recorded=""    # plain var: this subshell runs at script top level
+      cwd=""
+      should_release=0
       IFS= read -r recorded <"$LOCK_FILE" 2>/dev/null || true
       if [[ -n "$recorded" && "$recorded" == "$SESSION_ID" ]]; then
+        should_release=1
+      elif [[ -n "$recorded" && "$recorded" != "$SESSION_ID" ]]; then
+        # Foreign holder: lenient release iff its cwd carries the marker.
+        # A not-live holder (resolve_holder_state returns 1, empty cwd) or
+        # an opaque-failure holder (returns 0 with empty cwd) stays strict —
+        # the marker check fails on empty cwd, so should_release stays 0.
+        if cwd=$(resolve_holder_state "$recorded"); then
+          if [[ -n "$cwd" && -e "$cwd/tmp/dispatch-worktree" ]]; then
+            should_release=1
+          fi
+        fi
+      fi
+      if (( should_release )); then
         : >"$LOCK_FILE"
         printf 'RELEASED'
       else

--- a/.claude/skills/dispatch/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch/scripts/dispatch-acquire-lock
@@ -218,7 +218,7 @@ try_acquire() {            # 0 = acquired, 1 = contended; sets CONTENDED_SID
       if cwd=$(resolve_holder_state "$recorded"); then
         live=1
       fi
-      if (( live )) && ! { [[ -n "$cwd" && -e "$cwd/tmp/dispatch-worktree" ]]; }; then
+      if (( live )) && [[ -z "$cwd" || ! -e "$cwd/tmp/dispatch-worktree" ]]; then
         printf 'BUSY %s' "$recorded"
       else
         printf '%s\n' "$SESSION_ID" >"$LOCK_FILE"

--- a/.claude/skills/dispatch/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch/scripts/dispatch-acquire-lock
@@ -148,10 +148,13 @@ resolve_holder_state() {
     end' <<<"$out" 2>/dev/null); then
     return 0
   fi
-  # grep -F to keep the sessionId literal; the trailing tab anchors the match
-  # to the sessionId field exclusively, so a sessionId that happens to appear
-  # inside another row's cwd cannot match.
-  if ! match=$(printf '%s\n' "$rows" | grep -F -- "${sid}"$'\t' | head -n1); then
+  # Exact-match $1 against sid via awk: a true field equality (not a literal-
+  # substring match), so a sessionId that prefixes or suffixes another row's
+  # sessionId cannot cross-match. Also avoids `grep -F | head -n1`, whose
+  # pipefail+SIGPIPE interaction can collapse a contended-but-live match into
+  # a non-zero exit and trigger a wrong reclaim.
+  match=$(printf '%s\n' "$rows" | awk -F'\t' -v sid="$sid" '$1 == sid {print; exit}')
+  if [[ -z "$match" ]]; then
     # Definitely not live: registry parsed cleanly and our sid isn't in it.
     return 1
   fi

--- a/.claude/skills/dispatch/scripts/dispatch-finalize-selection
+++ b/.claude/skills/dispatch/scripts/dispatch-finalize-selection
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# dispatch-finalize-selection — canonical Step 5 proceed-path exit. Writes the
+# tmp/dispatch-worktree marker that signals "Step 5 completed" (the lock script
+# reads it on subsequent ticks to reclaim a marker-bearing foreign holder), then
+# execs dispatch-acquire-lock --release so the wrapper's exit code is the
+# release call's exit code. See `.claude/skills/dispatch/SKILL.md` Step 5 and
+# Step 0 "Releasing the lock".
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+mkdir -p tmp && touch tmp/dispatch-worktree
+exec "$SCRIPT_DIR/dispatch-acquire-lock" --release

--- a/.claude/skills/dispatch/scripts/dispatch-finalize-selection
+++ b/.claude/skills/dispatch/scripts/dispatch-finalize-selection
@@ -9,5 +9,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-mkdir -p tmp && touch tmp/dispatch-worktree
+mkdir -p tmp
+touch tmp/dispatch-worktree
 exec "$SCRIPT_DIR/dispatch-acquire-lock" --release

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2913,12 +2913,26 @@ lock_teardown() {
 # JSON array of session objects carrying the given sessionIds (and exits 0).
 # Points CLAUDE_AGENTS_CMD at the fake. Call with zero args to simulate an
 # empty registry (`[]`). Safe to re-invoke mid-test: regenerates the fake.
+#
+# Each argument is either a bare sessionId or a `sid=cwd` entry. A bare sid
+# emits `"cwd":""`; a `sid=/path` entry emits `"cwd":"/path"`. The cwd field
+# feeds the marker-based reclaim path in dispatch-acquire-lock — tests that
+# do not care about cwd can keep passing bare sessionIds unchanged.
 lock_fake_claude_sessions() {
   local fake="$TMPDIR_TEST/fake/claude"
-  local payload="[" sid first=1
-  for sid in "$@"; do
+  local payload="[" entry sid cwd first=1
+  for entry in "$@"; do
+    if [[ "$entry" == *=* ]]; then
+      sid="${entry%%=*}"
+      cwd="${entry#*=}"
+    else
+      sid="$entry"
+      cwd=""
+    fi
     if (( first )); then first=0; else payload+=","; fi
-    payload+="{\"sessionId\":\"$sid\",\"pid\":1,\"status\":\"busy\",\"name\":\"x\"}"
+    # Test paths under $TMPDIR_TEST never contain quotes or backslashes, so
+    # raw interpolation is sufficient (no JSON-escaping needed).
+    payload+="{\"sessionId\":\"$sid\",\"pid\":1,\"status\":\"busy\",\"name\":\"x\",\"cwd\":\"$cwd\"}"
   done
   payload+="]"
   printf '%s' "$payload" > "$TMPDIR_TEST/fake/payload.json"
@@ -3361,6 +3375,98 @@ fi
 lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
 assert_eq "--release missing-session-id leaves the foreign lock intact" \
   "sess-6c-foreign" "$lock_contents"
+lock_teardown
+
+# --- Test 20: live foreign holder with marker → reclaim ----------------------
+#
+# A foreign holder's session is still live AND its cwd carries the
+# tmp/dispatch-worktree marker, meaning it has completed Step 5. acquire must
+# reclaim the lock (lenient branch) rather than block.
+
+echo "Test: live foreign holder with marker → reclaim"
+lock_setup
+printf '%s\n' "sess-2020-foreign" > "$DISPATCH_LOCK_FILE"
+export CLAUDE_CODE_SESSION_ID="sess-2020-self"
+# Build the foreign holder's marker-bearing cwd inside the test tmp tree.
+foreign_cwd="$TMPDIR_TEST/foreign-worktree"
+mkdir -p "$foreign_cwd/tmp"
+touch "$foreign_cwd/tmp/dispatch-worktree"
+lock_fake_claude_sessions "sess-2020-foreign=$foreign_cwd" "sess-2020-self=$TMPDIR_TEST"
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+assert_eq "past-Step-5 holder reclaim exits 0" "0" "$rc"
+assert_eq "past-Step-5 holder reclaim prints acquired" "acquired" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "past-Step-5 holder reclaim rewrites lock to caller's sessionId" \
+  "sess-2020-self" "$lock_contents"
+lock_teardown
+
+# --- Test 21: live foreign holder WITHOUT marker → busy (regression) ---------
+#
+# Today's strict blocking behavior on an in-flight Step 0–5 holder MUST be
+# preserved: a live foreign holder whose cwd has no marker is still in
+# selection and the lock must hold it.
+
+echo "Test: live foreign holder without marker → busy (in-flight)"
+lock_setup
+printf '%s\n' "sess-2121-foreign" > "$DISPATCH_LOCK_FILE"
+export CLAUDE_CODE_SESSION_ID="sess-2121-self"
+foreign_cwd="$TMPDIR_TEST/foreign-worktree-no-marker"
+mkdir -p "$foreign_cwd"   # cwd exists but marker file does NOT
+lock_fake_claude_sessions "sess-2121-foreign=$foreign_cwd" "sess-2121-self=$TMPDIR_TEST"
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+assert_eq "in-flight holder blocks: exits 0" "0" "$rc"
+assert_eq "in-flight holder blocks: prints busy" "busy" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "in-flight holder blocks: lock file unchanged" \
+  "sess-2121-foreign" "$lock_contents"
+lock_teardown
+
+# --- Test 22: --release with marker present → released (lenient) ------------
+#
+# A caller whose CLAUDE_CODE_SESSION_ID differs from the recorded holder can
+# still --release when the holder's cwd carries the marker. Closes the silent
+# `noop` leak that today blocks subsequent /dispatch ticks.
+
+echo "Test: --release with marker present from a different-sessionId caller → released"
+lock_setup
+printf '%s\n' "sess-2222-foreign" > "$DISPATCH_LOCK_FILE"
+export CLAUDE_CODE_SESSION_ID="sess-2222-self"
+foreign_cwd="$TMPDIR_TEST/foreign-worktree-with-marker"
+mkdir -p "$foreign_cwd/tmp"
+touch "$foreign_cwd/tmp/dispatch-worktree"
+lock_fake_claude_sessions "sess-2222-foreign=$foreign_cwd" "sess-2222-self=$TMPDIR_TEST"
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" --release 2>/dev/null); rc=$?
+assert_eq "lenient --release exits 0" "0" "$rc"
+assert_eq "lenient --release prints released" "released" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ -z "$lock_contents" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: lenient --release empties the lock file"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: lenient --release empties the lock file"
+  echo "    lock file: '$lock_contents'"
+fi
+lock_teardown
+
+# --- Test 23: --release with NO marker → noop (strict pre-marker) -----------
+#
+# Refinement of Test 12: the marker is what flips the verdict to released.
+# Without a marker, a different-sessionId caller's --release stays a noop and
+# the lock file is left intact for the in-flight holder.
+
+echo "Test: --release with foreign holder and NO marker → noop (pre-marker stop path)"
+lock_setup
+printf '%s\n' "sess-2323-foreign" > "$DISPATCH_LOCK_FILE"
+export CLAUDE_CODE_SESSION_ID="sess-2323-self"
+foreign_cwd="$TMPDIR_TEST/foreign-worktree-no-marker-release"
+mkdir -p "$foreign_cwd"   # no marker
+lock_fake_claude_sessions "sess-2323-foreign=$foreign_cwd" "sess-2323-self=$TMPDIR_TEST"
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" --release 2>/dev/null); rc=$?
+assert_eq "pre-marker --release exits 0" "0" "$rc"
+assert_eq "pre-marker --release prints noop" "noop" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "pre-marker --release leaves the lock file unchanged" \
+  "sess-2323-foreign" "$lock_contents"
 lock_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -3764,13 +3764,7 @@ out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" --release 2>/dev/null); rc=$?
 assert_eq "lenient --release exits 0" "0" "$rc"
 assert_eq "lenient --release prints released" "released" "$out"
 lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
-TOTAL=$((TOTAL + 1))
-if [[ -z "$lock_contents" ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: lenient --release empties the lock file"
-else
-  FAIL=$((FAIL + 1)); echo "  FAIL: lenient --release empties the lock file"
-  echo "    lock file: '$lock_contents'"
-fi
+assert_eq "lenient --release empties the lock file" "" "$lock_contents"
 lock_teardown
 
 # --- Test 23: --release with NO marker → noop (strict pre-marker) -----------


### PR DESCRIPTION
## Summary

`/dispatch` can leak `tmp/dispatch.lock` indefinitely when `dispatch-acquire-lock --release` runs from a calling context whose `CLAUDE_CODE_SESSION_ID` does not match the recorded holder's sessionId. The script returns `noop`, SKILL.md does not branch on `noop` (both `released` and `noop` were documented as fine), and the lock stays held — but the holder is past Step 5, so the lock no longer serves its purpose. A `claude agents --json` live foreign holder (e.g. a spare-pool daemon) then blocks every subsequent `/dispatch` tick.

This change promotes `tmp/dispatch-worktree` (the marker already written at end of Step 5 for `restore-dispatch-skill.sh`'s context-clear recovery) to the canonical "Step 5 completed" reclaim signal. A recorded holder whose worktree carries the marker is past Step 5 and its lock is reclaimable regardless of session-id provenance. Acquire and `--release` both gain a marker-aware lenient branch; pre-marker stop paths (Steps 1-4 and Step 5 `conflict`) keep strict sessionId-match semantics by construction — the marker is absent.

Four commits, one per planned unit:

1. `2170b12` — `WorktreeCreate` hook writes the marker after `sync-issue-context` succeeds. Guarantees the marker is present the moment a fresh worktree is fully populated, even if the skill body crashes before its explicit marker write.
2. `892571b` — `dispatch-acquire-lock` gains marker-aware acquire and lenient `--release`. `is_live_session` becomes `resolve_holder_state`, which carries the holder's cwd via the jq pipeline. Four new test cases land alongside the change; all 13 existing lock tests pass unchanged.
3. `1d68eb1` — new `dispatch-finalize-selection` wrapper writes the marker and execs `dispatch-acquire-lock --release` as one canonical Step 5 proceed-path exit.
4. `046ad4e` — SKILL.md Step 5 proceed-path tail collapses to one call to the wrapper; Step 0 "Releasing the lock" documents the marker as the canonical post-Step-5 reclaim signal.

## Acceptance criteria

- [x] `dispatch-acquire-lock`'s acquire path reclaims when the recorded holder's `claude agents --json` cwd contains `tmp/dispatch-worktree`, even when the holder's session is still live (Test 20).
- [x] `dispatch-acquire-lock --release` succeeds (truncates the file, prints `released`) when the holder's cwd has the marker, regardless of caller's `CLAUDE_CODE_SESSION_ID` (Test 22).
- [x] Pre-marker stop-path `--release` calls remain strict: a mismatched sessionId without marker still prints `noop` and leaves the file untouched (Test 23, plus existing Test 12).
- [x] `.claude/hooks/worktree-create.sh` writes `tmp/dispatch-worktree` in the new worktree as its final step before exit (after `sync-issue-context`).
- [x] New script `.claude/skills/dispatch/scripts/dispatch-finalize-selection` writes the marker and calls `dispatch-acquire-lock --release`. Executable.
- [x] `.claude/skills/dispatch/SKILL.md` Step 5 proceed-path tail is one instruction (call `dispatch-finalize-selection`) instead of two (marker write, then release). Stop paths still call `dispatch-acquire-lock --release` directly. The "Releasing the lock" section in Step 0 documents the marker as the canonical post-Step-5 reclaim signal.
- [x] `.claude/skills/dispatch/scripts/test-dispatch-scripts.sh` adds four lock test cases: (a) past-Step-5 holder reclaim, (b) in-flight holder still blocks (regression), (c) lenient `--release` from a different-sessionId caller succeeds when marker exists, (d) strict `--release` still returns `noop` pre-marker.
- [x] All 13 existing `dispatch-acquire-lock` tests pass without modification.
- [x] Manual end-to-end smoke (in tmp dir with fake claude): foreign holder + marker → `acquired`; foreign holder + no marker → `busy`; `--release` from holder cwd → `released`.

Full test suite: 358/358 passing.

## Test plan

- [x] `.claude/skills/dispatch/scripts/test-dispatch-scripts.sh` passes locally (358/358).
- [ ] CI green on the draft PR.
- [ ] End-to-end smoke once merged: an actual `/dispatch` tick that hits a pre-existing marker-bearing foreign holder reclaims correctly.

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)