### PR TITLE
dispatch: dispatch:office-hours label and input-block detection hooks

### DIFF
--- a/.claude/hooks/dispatch-input-block.sh
+++ b/.claude/hooks/dispatch-input-block.sh
@@ -29,23 +29,6 @@
 set -uo pipefail
 trap 'echo "[dispatch-input-block] WARNING: unexpected error on line $LINENO" >&2; exit 0' ERR
 
-# Consume the payload (defensive — some events pass JSON on stdin). We do not
-# branch on its contents for PreToolUse / Elicitation; for Notification we
-# self-filter on notification_type below. Read with a timeout so a wired event
-# that delivers no stdin doesn't hang the session.
-PAYLOAD=""
-if read -t 1 -d '' PAYLOAD; then :; fi
-
-# Notification self-filter: only act on permission_prompt notifications.
-# Other notification_type values (e.g. session_complete) reach this hook and
-# must pass through silently. Empty payload (other events) skips the filter.
-if [ -n "$PAYLOAD" ]; then
-  NOTIFICATION_TYPE=$(printf '%s' "$PAYLOAD" | jq -r '.notification_type // empty' 2>/dev/null) || NOTIFICATION_TYPE=""
-  if [ -n "$NOTIFICATION_TYPE" ] && [ "$NOTIFICATION_TYPE" != "permission_prompt" ]; then
-    exit 0
-  fi
-fi
-
 # Discriminator 1: managed background job.
 if [ -z "${CLAUDE_JOB_DIR:-}" ]; then
   exit 0
@@ -62,6 +45,22 @@ case "$JOB_NAME" in
   dispatch-*) ;;
   *) exit 0 ;;
 esac
+
+# Consume the payload (defensive — some events pass JSON on stdin). Only
+# dispatch-* jobs reach this point; we read so the Notification filter below
+# can act. Read with a timeout so a wired event without stdin doesn't hang.
+PAYLOAD=""
+if read -t 1 -d '' PAYLOAD; then :; fi
+
+# Notification self-filter: only act on permission_prompt notifications.
+# Other notification_type values (e.g. session_complete) reach this hook and
+# must pass through silently. Empty payload (other events) skips the filter.
+if [ -n "$PAYLOAD" ]; then
+  NOTIFICATION_TYPE=$(printf '%s' "$PAYLOAD" | jq -r '.notification_type // empty' 2>/dev/null) || NOTIFICATION_TYPE=""
+  if [ -n "$NOTIFICATION_TYPE" ] && [ "$NOTIFICATION_TYPE" != "permission_prompt" ]; then
+    exit 0
+  fi
+fi
 
 # Resolve issue number from the current branch (<N>-<slug>).
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0

--- a/.claude/hooks/dispatch-input-block.sh
+++ b/.claude/hooks/dispatch-input-block.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# dispatch-input-block: dispatch-session input-block handler.
+#
+# Wired to three harness events through which a session can block on user
+# input:
+#   PreToolUse  matching ExitPlanMode and AskUserQuestion
+#   Notification with notification_type "permission_prompt"
+#   Elicitation
+#
+# Fires only for a dispatch-* background job. On fire:
+#   1. resolves the issue number from the current branch name
+#      (the <N>-* prefix idiom restore-dispatch-skill.sh already uses);
+#   2. resolves a PR (via dispatch-find-pr) or falls back to the issue;
+#   3. applies dispatch:office-hours, creating the label on first use with the
+#      canonical color/description (this script is the single source of those
+#      defaults);
+#   4. spawns the next /dispatch via dispatch-spawn, so the chain keeps moving
+#      around the blocked item.
+#
+# Never blocks the session — every failure logs to stderr and the script exits
+# 0. The blocked session stays parked; the dispatch:office-hours label is the
+# durable record so the office-hours queue survives the session ending.
+#
+# Discriminator: this is a hook on a generic harness event. We only act when:
+#   - CLAUDE_JOB_DIR is set (so this is a managed background job), AND
+#   - the recorded --name in $CLAUDE_JOB_DIR/state.json starts with "dispatch-".
+# That precisely targets a dispatch-* job. Interactive user sessions running
+# /dispatch (no CLAUDE_JOB_DIR) and other background jobs are excluded.
+set -uo pipefail
+trap 'echo "[dispatch-input-block] WARNING: unexpected error on line $LINENO" >&2; exit 0' ERR
+
+# Consume the payload (defensive — some events pass JSON on stdin). We do not
+# branch on its contents for PreToolUse / Elicitation; for Notification we
+# self-filter on notification_type below. Read with a timeout so a wired event
+# that delivers no stdin doesn't hang the session.
+PAYLOAD=""
+if read -t 1 -d '' PAYLOAD; then :; fi
+
+# Notification self-filter: only act on permission_prompt notifications.
+# Other notification_type values (e.g. session_complete) reach this hook and
+# must pass through silently. Empty payload (other events) skips the filter.
+if [ -n "$PAYLOAD" ]; then
+  NOTIFICATION_TYPE=$(printf '%s' "$PAYLOAD" | jq -r '.notification_type // empty' 2>/dev/null) || NOTIFICATION_TYPE=""
+  if [ -n "$NOTIFICATION_TYPE" ] && [ "$NOTIFICATION_TYPE" != "permission_prompt" ]; then
+    exit 0
+  fi
+fi
+
+# Discriminator 1: managed background job.
+if [ -z "${CLAUDE_JOB_DIR:-}" ]; then
+  exit 0
+fi
+
+STATE_FILE="$CLAUDE_JOB_DIR/state.json"
+if [ ! -f "$STATE_FILE" ]; then
+  exit 0
+fi
+
+# Discriminator 2: this job is a dispatch-* job.
+JOB_NAME=$(jq -r '.name // empty' "$STATE_FILE" 2>/dev/null) || JOB_NAME=""
+case "$JOB_NAME" in
+  dispatch-*) ;;
+  *) exit 0 ;;
+esac
+
+# Resolve issue number from the current branch (<N>-<slug>).
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+ISSUE_NUM=$(printf '%s\n' "$BRANCH" | grep -oE '^[0-9]+') || exit 0
+[ -n "$ISSUE_NUM" ] || exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 0
+SCRIPTS="$SCRIPT_DIR/../skills/dispatch/scripts"
+
+# Resolve PR for this issue; fall back to the issue itself when no PR exists
+# (the implement phase has no PR yet).
+PR_NUM=$("$SCRIPTS/dispatch-find-pr" "$ISSUE_NUM" 2>/dev/null) || PR_NUM=""
+
+apply_label() {
+  if [ -n "$PR_NUM" ]; then
+    gh pr edit "$PR_NUM" --add-label dispatch:office-hours 2>&1
+  else
+    gh issue edit "$ISSUE_NUM" --add-label dispatch:office-hours 2>&1
+  fi
+}
+
+# Apply-first / create-on-"not found" idiom (mirrors dispatch-complete-phase).
+if apply_output=$(apply_label); then
+  :
+elif [[ "$apply_output" == *"not found"* ]]; then
+  gh label create dispatch:office-hours --color FBCA04 \
+    --description "dispatch workflow: blocked on a human — awaiting input or review" \
+    >/dev/null 2>&1 \
+    || echo "[dispatch-input-block] WARNING: gh label create dispatch:office-hours failed" >&2
+  apply_label >/dev/null 2>&1 \
+    || echo "[dispatch-input-block] WARNING: gh apply dispatch:office-hours (retry) failed" >&2
+else
+  echo "[dispatch-input-block] WARNING: gh apply dispatch:office-hours failed: $apply_output" >&2
+fi
+
+# Pass the baton so the chain keeps moving. dispatch-spawn is dedup-guarded —
+# safe whether or not another dispatch-* session is live.
+"$SCRIPTS/dispatch-spawn" >/dev/null 2>&1 \
+  || echo "[dispatch-input-block] WARNING: dispatch-spawn failed" >&2
+
+exit 0

--- a/.claude/hooks/dispatch-input-block.sh
+++ b/.claude/hooks/dispatch-input-block.sh
@@ -14,7 +14,7 @@
 #   3. applies dispatch:office-hours, creating the label on first use with the
 #      canonical color/description (this script is the single source of those
 #      defaults);
-#   4. spawns the next /dispatch via dispatch-spawn, so the chain keeps moving
+#   4. spawns the next /dispatch via dispatch-spawn-router, so the chain keeps moving
 #      around the blocked item.
 #
 # Never blocks the session — every failure logs to stderr and the script exits
@@ -97,9 +97,9 @@ else
   echo "[dispatch-input-block] WARNING: gh apply dispatch:office-hours failed: $apply_output" >&2
 fi
 
-# Pass the baton so the chain keeps moving. dispatch-spawn is dedup-guarded —
+# Pass the baton so the chain keeps moving. dispatch-spawn-router is dedup-guarded —
 # safe whether or not another dispatch-* session is live.
-"$SCRIPTS/dispatch-spawn" >/dev/null 2>&1 \
-  || echo "[dispatch-input-block] WARNING: dispatch-spawn failed" >&2
+"$SCRIPTS/dispatch-spawn-router" >/dev/null 2>&1 \
+  || echo "[dispatch-input-block] WARNING: dispatch-spawn-router failed" >&2
 
 exit 0

--- a/.claude/hooks/dispatch-office-hours-strip.sh
+++ b/.claude/hooks/dispatch-office-hours-strip.sh
@@ -29,12 +29,16 @@ SCRIPTS="$SCRIPT_DIR/../skills/dispatch/scripts"
 
 PR_NUM=$("$SCRIPTS/dispatch-find-pr" "$ISSUE_NUM" 2>/dev/null) || PR_NUM=""
 
+# Strip from both the PR and the issue. The resolution rule guarantees only one
+# carries the label at a time, so the call to the unlabeled target is a no-op.
+# Stripping from both prevents a stale label when the PR was opened between the
+# input-block (which labeled the issue) and the user's engagement (which now
+# sees the PR). gh --remove-label is a no-op when the label is absent.
 if [ -n "$PR_NUM" ]; then
   gh pr edit "$PR_NUM" --remove-label dispatch:office-hours >/dev/null 2>&1 \
     || echo "[dispatch-office-hours-strip] WARNING: gh pr edit --remove-label failed for PR #$PR_NUM" >&2
-else
-  gh issue edit "$ISSUE_NUM" --remove-label dispatch:office-hours >/dev/null 2>&1 \
-    || echo "[dispatch-office-hours-strip] WARNING: gh issue edit --remove-label failed for issue #$ISSUE_NUM" >&2
 fi
+gh issue edit "$ISSUE_NUM" --remove-label dispatch:office-hours >/dev/null 2>&1 \
+  || echo "[dispatch-office-hours-strip] WARNING: gh issue edit --remove-label failed for issue #$ISSUE_NUM" >&2
 
 exit 0

--- a/.claude/hooks/dispatch-office-hours-strip.sh
+++ b/.claude/hooks/dispatch-office-hours-strip.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# dispatch-office-hours-strip: clear dispatch:office-hours when the user
+# engages an issue worktree.
+#
+# Wired to UserPromptSubmit. When the user submits a prompt inside an <N>-*
+# worktree, remove dispatch:office-hours from that worktree's PR (or issue if
+# no PR exists). A human is now driving the item, so the office-hours marker
+# is no longer accurate — clearing it makes the item dispatch-eligible again
+# (and stops dispatch-select-target from skipping it).
+#
+# No discriminator on CLAUDE_JOB_DIR — a human submitting a prompt is the
+# engagement signal regardless of session type.
+#
+# Always exits 0 — must not block prompt submission. gh's --remove-label is
+# a no-op when the label is not present, so removing an absent label is fine.
+set -uo pipefail
+trap 'echo "[dispatch-office-hours-strip] WARNING: unexpected error on line $LINENO" >&2; exit 0' ERR
+
+# Consume the payload (UserPromptSubmit delivers JSON on stdin; we do not read
+# any field, but consuming the stdin avoids upstream pipe deadlocks).
+if read -t 1 -d '' _PAYLOAD; then :; fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+ISSUE_NUM=$(printf '%s\n' "$BRANCH" | grep -oE '^[0-9]+') || exit 0
+[ -n "$ISSUE_NUM" ] || exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 0
+SCRIPTS="$SCRIPT_DIR/../skills/dispatch/scripts"
+
+PR_NUM=$("$SCRIPTS/dispatch-find-pr" "$ISSUE_NUM" 2>/dev/null) || PR_NUM=""
+
+if [ -n "$PR_NUM" ]; then
+  gh pr edit "$PR_NUM" --remove-label dispatch:office-hours >/dev/null 2>&1 \
+    || echo "[dispatch-office-hours-strip] WARNING: gh pr edit --remove-label failed for PR #$PR_NUM" >&2
+else
+  gh issue edit "$ISSUE_NUM" --remove-label dispatch:office-hours >/dev/null 2>&1 \
+    || echo "[dispatch-office-hours-strip] WARNING: gh issue edit --remove-label failed for issue #$ISSUE_NUM" >&2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,6 +63,35 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/approve-workflow-commands.sh"
           }
         ]
+      },
+      {
+        "matcher": "^(ExitPlanMode|AskUserQuestion)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/dispatch-input-block.sh"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/dispatch-input-block.sh"
+          }
+        ]
+      }
+    ],
+    "Elicitation": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/dispatch-input-block.sh"
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [
@@ -71,6 +100,14 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/productivity-tui/hooks/on-active.sh"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/dispatch-office-hours-strip.sh"
           }
         ]
       }

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -340,7 +340,14 @@ issue_has_worktree() {
 # closingIssuesReferences drives topic-category resolution: a PR inherits the
 # highest-priority topic among the labels of every issue it closes.
 PR_LIST=$(gh pr list --state open --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels,closingIssuesReferences)
-PR_SORTED=$(printf '%s' "$PR_LIST" | jq -r 'sort_by(.createdAt) | .[] | [.number, .createdAt, .headRefName, (.closingIssuesReferences // [] | tojson)] | @tsv')
+# Skip PRs carrying dispatch:office-hours — the item is parked for human review
+# (either an input-block recorded by dispatch-input-block.sh, or a phase that
+# completed but surfaced a deviation, recorded by /dispatch Step 9). A later
+# UserPromptSubmit clears the label and the item re-enters the queue.
+PR_SORTED=$(printf '%s' "$PR_LIST" | jq -r '
+  sort_by(.createdAt) | .[]
+  | select((.labels // []) | any(.name == "dispatch:office-hours") | not)
+  | [.number, .createdAt, .headRefName, (.closingIssuesReferences // [] | tojson)] | @tsv')
 
 # Fetch every open issue once, carrying labels. This single list serves two
 # roles: filtered client-side to "help wanted" it is the issue queue; indexed
@@ -464,6 +471,7 @@ fi
 ISSUE_SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r '
   sort_by(.createdAt) | .[]
   | select((.labels // []) | any(.name == "help wanted"))
+  | select((.labels // []) | any(.name == "dispatch:office-hours") | not)
   | [.number, ((.labels // []) | tojson)] | @tsv')
 while IFS=$'\t' read -r issue_num issue_labels; do
   [[ -z "$issue_num" ]] && continue

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -6018,6 +6018,8 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: label-missing: PR apply retried after label create"
   echo "    pr-edit-log: $pr_edit_log"
 fi
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "label-missing: dispatch-spawn invoked exactly once after recovery" "1" "$spawn_calls"
 ib_teardown
 
 # --- Test 4: CLAUDE_JOB_DIR unset → no-op (no label, no spawn) ---------------
@@ -6086,6 +6088,30 @@ if [[ ! -e "$STUB_DIR/gh-pr-edit.log" ]]; then
   PASS=$((PASS + 1)); echo "  PASS: non-permission-prompt: no gh label apply was invoked"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: non-permission-prompt: no gh label apply was invoked"
+fi
+ib_teardown
+
+# --- Test 7: non-issue branch with dispatch job → no-op ----------------------
+
+echo "Test: non-issue branch (main) + dispatch-* job → no-op (no label, no spawn)"
+ib_setup
+echo "main" > "$STUB_DIR/current-branch.txt"
+echo '{"name":"dispatch-test001"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+"$TMPDIR_TEST/hooks/dispatch-input-block.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "non-issue-branch: hook exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-issue-branch: no gh label apply was invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-issue-branch: no gh label apply was invoked"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/spawn-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-issue-branch: dispatch-spawn was not invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-issue-branch: dispatch-spawn was not invoked"
 fi
 ib_teardown
 

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1778,6 +1778,35 @@ if result=$("$TMPDIR_TEST/dispatch-select-target" 2>/dev/null); then rc=0; else 
 assert_eq "invalid duration → exits non-zero" "yes" "$rc_nonzero"
 teardown
 
+# OH1. A PR carrying dispatch:office-hours is skipped (parked for human review).
+echo "Test: PR with dispatch:office-hours is skipped"
+setup
+# Two verify PRs; the older one (PR 10) is parked.
+OFFICE_HOURS_LABELS='[{"name":"dispatch:office-hours"}]'
+UNION='['
+UNION+="$(make_pr_union 10 "10-parked" "2024-01-01T00:00:00Z" "true" "$OFFICE_HOURS_LABELS" "$FAILING_ROLLUP")"','
+UNION+="$(make_pr_union 20 "20-active" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"
+UNION+=']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "parked PR skipped; next PR returned" "pr 20 20-active verify" "$result"
+teardown
+
+# OH2. A help-wanted issue carrying dispatch:office-hours is skipped.
+echo "Test: help-wanted issue with dispatch:office-hours is skipped"
+setup
+echo '[]' > "$STUB_DIR/pr-list-union.json"
+# Issue 55 is parked; issue 66 is the next eligible help-wanted issue.
+printf '%s\n' \
+  '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"dispatch:office-hours"}]},{"number":66,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "parked issue skipped; next help-wanted issue returned" "issue 66" "$result"
+teardown
+
 # ============================================================================
 # dispatch-trace-leaf tests
 # ============================================================================
@@ -4754,6 +4783,394 @@ creates_after=0
 assert_eq "idempotency run 2 made no second issue create" \
   "$creates_before" "$creates_after"
 jit_teardown
+
+# ============================================================================
+# dispatch-input-block hook tests
+# ============================================================================
+echo ""
+echo "=== dispatch-input-block ==="
+#
+# The hook discriminates on CLAUDE_JOB_DIR/state.json {.name} starting with
+# "dispatch-"; resolves the issue number from the current branch (the <N>-*
+# prefix); resolves a PR via dispatch-find-pr; applies dispatch:office-hours
+# with the apply-first / create-on-"not found" idiom; runs dispatch-spawn.
+# Always exits 0.
+#
+# Each test gets a fresh tmp tree:
+#   $TMPDIR_TEST/hooks/dispatch-input-block.sh     — the hook under test
+#   $TMPDIR_TEST/skills/dispatch/scripts/          — fakes for dispatch-find-pr,
+#                                                    dispatch-spawn
+#   $TMPDIR_TEST/bin/{gh,git}                      — PATH shims
+#   $TMPDIR_TEST/jobs/<id>/state.json              — fake CLAUDE_JOB_DIR ledger
+#   $TMPDIR_TEST/stub/{gh,git,spawn}-calls.log     — recorded invocations
+#
+# HOOK_SCRIPT_DIR — the project hooks directory the test copies from. SCRIPT_DIR
+# here is .claude/skills/dispatch/scripts; the hooks live at .claude/hooks.
+HOOK_SCRIPT_DIR="$SCRIPT_DIR/../../../hooks"
+
+ib_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  STUB_DIR="$TMPDIR_TEST/stub"
+  mkdir -p "$TMPDIR_TEST/hooks" "$TMPDIR_TEST/skills/dispatch/scripts" \
+    "$TMPDIR_TEST/bin" "$STUB_DIR" "$TMPDIR_TEST/jobs/abcd1234"
+
+  cp "$HOOK_SCRIPT_DIR/dispatch-input-block.sh" \
+    "$TMPDIR_TEST/hooks/dispatch-input-block.sh"
+  chmod +x "$TMPDIR_TEST/hooks/dispatch-input-block.sh"
+
+  # Fake dispatch-find-pr: prints contents of $STUB_DIR/find-pr-output if
+  # present, else nothing (no PR exists).
+  cat > "$TMPDIR_TEST/skills/dispatch/scripts/dispatch-find-pr" <<'FAKE'
+#!/usr/bin/env bash
+[[ -f "$STUB_DIR/find-pr-output" ]] && cat "$STUB_DIR/find-pr-output"
+exit 0
+FAKE
+  chmod +x "$TMPDIR_TEST/skills/dispatch/scripts/dispatch-find-pr"
+
+  # Fake dispatch-spawn: log invocations to spawn-calls.log.
+  cat > "$TMPDIR_TEST/skills/dispatch/scripts/dispatch-spawn" <<'FAKE'
+#!/usr/bin/env bash
+echo "spawn" >> "$STUB_DIR/spawn-calls.log"
+echo "spawned"
+exit 0
+FAKE
+  chmod +x "$TMPDIR_TEST/skills/dispatch/scripts/dispatch-spawn"
+
+  # gh PATH stub. pr-edit-mode/issue-edit-mode select behavior (default: ok and
+  # log args). "label-missing" models the first apply failing with a missing-
+  # label error; the create-then-retry idiom then succeeds on the second call.
+  cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
+args="$*"
+case "$args" in
+  pr\ edit\ *)
+    mode="ok"
+    [[ -f "$STUB_DIR/pr-edit-mode" ]] && mode=$(cat "$STUB_DIR/pr-edit-mode")
+    case "$mode" in
+      label-missing)
+        if [[ -f "$STUB_DIR/gh-label-create.log" ]]; then
+          echo "$args" >> "$STUB_DIR/gh-pr-edit.log"
+        else
+          echo "failed to update: 'dispatch:office-hours' not found" >&2
+          exit 1
+        fi
+        ;;
+      *)
+        echo "$args" >> "$STUB_DIR/gh-pr-edit.log"
+        ;;
+    esac
+    ;;
+  issue\ edit\ *)
+    echo "$args" >> "$STUB_DIR/gh-issue-edit.log"
+    ;;
+  label\ create\ *)
+    echo "$args" >> "$STUB_DIR/gh-label-create.log"
+    ;;
+  *)
+    echo "gh stub: unknown invocation: $args" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/gh"
+
+  # git PATH stub. The hook reads `rev-parse --abbrev-ref HEAD` to derive the
+  # issue number. current-branch.txt is the per-test fixture.
+  cat > "$TMPDIR_TEST/bin/git" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
+args="$*"
+case "$args" in
+  "rev-parse --abbrev-ref HEAD")
+    if [[ -f "$STUB_DIR/current-branch.txt" ]]; then
+      cat "$STUB_DIR/current-branch.txt"
+    else
+      echo "main"
+    fi
+    ;;
+  *) echo "git stub: unknown invocation: $args" >&2; exit 1 ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/git"
+
+  export PATH="$TMPDIR_TEST/bin:$PATH"
+  export STUB_DIR  # fakes resolve STUB_DIR from env
+}
+
+ib_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  STUB_DIR=""
+  export PATH="$SAVED_PATH"
+  unset CLAUDE_JOB_DIR
+}
+
+# --- Test 1: dispatch-* job + PR exists → label PR, spawn baton --------------
+
+echo "Test: dispatch-* job + branch <N>-* + PR exists → label PR, spawn baton"
+ib_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "456" > "$STUB_DIR/find-pr-output"
+echo '{"name":"dispatch-test001"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+"$TMPDIR_TEST/hooks/dispatch-input-block.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "input-block: hook exits 0" "0" "$rc"
+pr_edit_log=$(cat "$STUB_DIR/gh-pr-edit.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$pr_edit_log" == *"pr edit 456 --add-label dispatch:office-hours"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: input-block: 'gh pr edit 456 --add-label dispatch:office-hours' was invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: input-block: 'gh pr edit 456 --add-label dispatch:office-hours' was invoked"
+  echo "    pr-edit-log: $pr_edit_log"
+fi
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "input-block: dispatch-spawn invoked exactly once" "1" "$spawn_calls"
+ib_teardown
+
+# --- Test 2: dispatch-* job + no PR → label issue, spawn baton ---------------
+
+echo "Test: dispatch-* job + branch <N>-* + no PR → label issue (implement phase)"
+ib_setup
+echo "789-bare" > "$STUB_DIR/current-branch.txt"
+# No find-pr-output → dispatch-find-pr prints nothing → fall back to issue.
+echo '{"name":"dispatch-test001"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+"$TMPDIR_TEST/hooks/dispatch-input-block.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "input-block (no PR): hook exits 0" "0" "$rc"
+issue_edit_log=$(cat "$STUB_DIR/gh-issue-edit.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$issue_edit_log" == *"issue edit 789 --add-label dispatch:office-hours"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: input-block (no PR): 'gh issue edit 789 --add-label dispatch:office-hours' was invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: input-block (no PR): 'gh issue edit 789 --add-label dispatch:office-hours' was invoked"
+  echo "    issue-edit-log: $issue_edit_log"
+fi
+ib_teardown
+
+# --- Test 3: label missing → create + retry, canonical color/description -----
+
+echo "Test: label-missing → 'gh label create dispatch:office-hours' (canonical color/description) then retry"
+ib_setup
+echo "123-foo" > "$STUB_DIR/current-branch.txt"
+echo "456" > "$STUB_DIR/find-pr-output"
+echo "label-missing" > "$STUB_DIR/pr-edit-mode"
+echo '{"name":"dispatch-test001"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+"$TMPDIR_TEST/hooks/dispatch-input-block.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "label-missing: hook exits 0" "0" "$rc"
+label_create_log=$(cat "$STUB_DIR/gh-label-create.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$label_create_log" == *"--color FBCA04"* ]] \
+   && [[ "$label_create_log" == *"dispatch:office-hours"* ]] \
+   && [[ "$label_create_log" == *"blocked on a human"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: label-missing: label created with canonical color (FBCA04) and description"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: label-missing: label created with canonical color (FBCA04) and description"
+  echo "    label-create-log: $label_create_log"
+fi
+pr_edit_log=$(cat "$STUB_DIR/gh-pr-edit.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$pr_edit_log" == *"pr edit 456 --add-label dispatch:office-hours"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: label-missing: PR apply retried after label create"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: label-missing: PR apply retried after label create"
+  echo "    pr-edit-log: $pr_edit_log"
+fi
+ib_teardown
+
+# --- Test 4: CLAUDE_JOB_DIR unset → no-op (no label, no spawn) ---------------
+
+echo "Test: CLAUDE_JOB_DIR unset → no-op (interactive session is excluded)"
+ib_setup
+echo "123-foo" > "$STUB_DIR/current-branch.txt"
+echo "456" > "$STUB_DIR/find-pr-output"
+unset CLAUDE_JOB_DIR
+"$TMPDIR_TEST/hooks/dispatch-input-block.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "no-job-dir: hook exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: no-job-dir: no gh label apply was invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: no-job-dir: no gh label apply was invoked"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/spawn-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: no-job-dir: dispatch-spawn was not invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: no-job-dir: dispatch-spawn was not invoked"
+fi
+ib_teardown
+
+# --- Test 5: non-dispatch job name → no-op -----------------------------------
+
+echo "Test: state.json name is not 'dispatch-*' → no-op (other background jobs excluded)"
+ib_setup
+echo "123-foo" > "$STUB_DIR/current-branch.txt"
+echo "456" > "$STUB_DIR/find-pr-output"
+echo '{"name":"manual-session"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+"$TMPDIR_TEST/hooks/dispatch-input-block.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "non-dispatch: hook exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-dispatch: no gh label apply was invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-dispatch: no gh label apply was invoked"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/spawn-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-dispatch: dispatch-spawn was not invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-dispatch: dispatch-spawn was not invoked"
+fi
+ib_teardown
+
+# --- Test 6: non-permission-prompt notification → silent pass-through --------
+
+echo "Test: Notification with non-permission-prompt type → no-op (passes through silently)"
+ib_setup
+echo "123-foo" > "$STUB_DIR/current-branch.txt"
+echo "456" > "$STUB_DIR/find-pr-output"
+echo '{"name":"dispatch-test001"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+printf '%s' '{"notification_type":"session_complete"}' \
+  | "$TMPDIR_TEST/hooks/dispatch-input-block.sh" >/dev/null 2>&1
+rc=$?
+assert_eq "non-permission-prompt: hook exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/gh-pr-edit.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-permission-prompt: no gh label apply was invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-permission-prompt: no gh label apply was invoked"
+fi
+ib_teardown
+
+# ============================================================================
+# dispatch-office-hours-strip hook tests
+# ============================================================================
+echo ""
+echo "=== dispatch-office-hours-strip ==="
+#
+# UserPromptSubmit hook that removes dispatch:office-hours from the worktree's
+# PR (or issue if no PR exists). No CLAUDE_JOB_DIR discriminator — a human
+# submitting a prompt is the engagement signal regardless of session type.
+
+ohs_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  STUB_DIR="$TMPDIR_TEST/stub"
+  mkdir -p "$TMPDIR_TEST/hooks" "$TMPDIR_TEST/skills/dispatch/scripts" \
+    "$TMPDIR_TEST/bin" "$STUB_DIR"
+
+  cp "$HOOK_SCRIPT_DIR/dispatch-office-hours-strip.sh" \
+    "$TMPDIR_TEST/hooks/dispatch-office-hours-strip.sh"
+  chmod +x "$TMPDIR_TEST/hooks/dispatch-office-hours-strip.sh"
+
+  cat > "$TMPDIR_TEST/skills/dispatch/scripts/dispatch-find-pr" <<'FAKE'
+#!/usr/bin/env bash
+[[ -f "$STUB_DIR/find-pr-output" ]] && cat "$STUB_DIR/find-pr-output"
+exit 0
+FAKE
+  chmod +x "$TMPDIR_TEST/skills/dispatch/scripts/dispatch-find-pr"
+
+  cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
+args="$*"
+case "$args" in
+  pr\ edit\ *) echo "$args" >> "$STUB_DIR/gh-pr-edit.log" ;;
+  issue\ edit\ *) echo "$args" >> "$STUB_DIR/gh-issue-edit.log" ;;
+  *) echo "gh stub: unknown invocation: $args" >&2; exit 1 ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/gh"
+
+  cat > "$TMPDIR_TEST/bin/git" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
+args="$*"
+case "$args" in
+  "rev-parse --abbrev-ref HEAD")
+    if [[ -f "$STUB_DIR/current-branch.txt" ]]; then
+      cat "$STUB_DIR/current-branch.txt"
+    else
+      echo "main"
+    fi
+    ;;
+  *) echo "git stub: unknown invocation: $args" >&2; exit 1 ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/git"
+
+  export PATH="$TMPDIR_TEST/bin:$PATH"
+  export STUB_DIR
+}
+
+ohs_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  STUB_DIR=""
+  export PATH="$SAVED_PATH"
+}
+
+# --- Test 1: branch <N>-* + PR exists → strip from PR ------------------------
+
+echo "Test: strip hook on <N>-* branch with PR → 'gh pr edit --remove-label dispatch:office-hours'"
+ohs_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "456" > "$STUB_DIR/find-pr-output"
+"$TMPDIR_TEST/hooks/dispatch-office-hours-strip.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "strip: hook exits 0" "0" "$rc"
+pr_edit_log=$(cat "$STUB_DIR/gh-pr-edit.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$pr_edit_log" == *"pr edit 456 --remove-label dispatch:office-hours"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: strip: 'gh pr edit 456 --remove-label dispatch:office-hours' was invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: strip: 'gh pr edit 456 --remove-label dispatch:office-hours' was invoked"
+  echo "    pr-edit-log: $pr_edit_log"
+fi
+ohs_teardown
+
+# --- Test 2: branch <N>-* + no PR → strip from issue -------------------------
+
+echo "Test: strip hook on <N>-* branch with no PR → 'gh issue edit --remove-label dispatch:office-hours'"
+ohs_setup
+echo "789-bare" > "$STUB_DIR/current-branch.txt"
+# No find-pr-output → fall back to issue.
+"$TMPDIR_TEST/hooks/dispatch-office-hours-strip.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "strip (no PR): hook exits 0" "0" "$rc"
+issue_edit_log=$(cat "$STUB_DIR/gh-issue-edit.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$issue_edit_log" == *"issue edit 789 --remove-label dispatch:office-hours"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: strip (no PR): 'gh issue edit 789 --remove-label dispatch:office-hours' was invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: strip (no PR): 'gh issue edit 789 --remove-label dispatch:office-hours' was invoked"
+  echo "    issue-edit-log: $issue_edit_log"
+fi
+ohs_teardown
+
+# --- Test 3: branch is not <N>-* → no-op -------------------------------------
+
+echo "Test: strip hook on non-issue branch (main) → no-op (no gh call)"
+ohs_setup
+echo "main" > "$STUB_DIR/current-branch.txt"
+"$TMPDIR_TEST/hooks/dispatch-office-hours-strip.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "strip (non-issue): hook exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: strip (non-issue): no gh call was invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: strip (non-issue): no gh call was invoked"
+fi
+ohs_teardown
 
 # ============================================================================
 # summary

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -5865,14 +5865,14 @@ exit 0
 FAKE
   chmod +x "$TMPDIR_TEST/skills/dispatch/scripts/dispatch-find-pr"
 
-  # Fake dispatch-spawn: log invocations to spawn-calls.log.
-  cat > "$TMPDIR_TEST/skills/dispatch/scripts/dispatch-spawn" <<'FAKE'
+  # Fake dispatch-spawn-router: log invocations to spawn-calls.log.
+  cat > "$TMPDIR_TEST/skills/dispatch/scripts/dispatch-spawn-router" <<'FAKE'
 #!/usr/bin/env bash
 echo "spawn" >> "$STUB_DIR/spawn-calls.log"
 echo "spawned"
 exit 0
 FAKE
-  chmod +x "$TMPDIR_TEST/skills/dispatch/scripts/dispatch-spawn"
+  chmod +x "$TMPDIR_TEST/skills/dispatch/scripts/dispatch-spawn-router"
 
   # gh PATH stub. pr-edit-mode/issue-edit-mode select behavior (default: ok and
   # log args). "label-missing" models the first apply failing with a missing-
@@ -6156,9 +6156,11 @@ ohs_teardown() {
   export PATH="$SAVED_PATH"
 }
 
-# --- Test 1: branch <N>-* + PR exists → strip from PR ------------------------
+# --- Test 1: branch <N>-* + PR exists → strip from both PR and issue ----------
+# The hook strips from both targets so a stale issue label (applied before the PR
+# was opened) is also cleared. gh --remove-label is a no-op when the label is absent.
 
-echo "Test: strip hook on <N>-* branch with PR → 'gh pr edit --remove-label dispatch:office-hours'"
+echo "Test: strip hook on <N>-* branch with PR → strips from both PR and issue"
 ohs_setup
 echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
 echo "456" > "$STUB_DIR/find-pr-output"
@@ -6172,6 +6174,14 @@ if [[ "$pr_edit_log" == *"pr edit 456 --remove-label dispatch:office-hours"* ]];
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: strip: 'gh pr edit 456 --remove-label dispatch:office-hours' was invoked"
   echo "    pr-edit-log: $pr_edit_log"
+fi
+issue_edit_log=$(cat "$STUB_DIR/gh-issue-edit.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$issue_edit_log" == *"issue edit 123 --remove-label dispatch:office-hours"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: strip: 'gh issue edit 123 --remove-label dispatch:office-hours' also invoked (clears stale issue label)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: strip: 'gh issue edit 123 --remove-label dispatch:office-hours' also invoked (clears stale issue label)"
+  echo "    issue-edit-log: $issue_edit_log"
 fi
 ohs_teardown
 


### PR DESCRIPTION
## Summary

Closes #757. Delivers the input-block writer for `dispatch:office-hours` —
the other half of the office-hours queue infrastructure begun in #790 (which
added the deviation writer in /dispatch Step 9).

When a `/dispatch` background job hits a user-input point (`/plan-implement`
plan approval, a `qa` plan, a permission prompt), the run now applies
`dispatch:office-hours` and passes the baton so the dispatch chain keeps
moving around the parked item. When the user engages the worktree (any prompt
submission), the label is cleared and the item re-enters the queue.

## Changes

- `.claude/hooks/dispatch-input-block.sh` — wired to PreToolUse
  (ExitPlanMode, AskUserQuestion), Notification (filtered to
  `permission_prompt`), and Elicitation. Discriminates on
  `CLAUDE_JOB_DIR/state.json` `{.name}` starting with `dispatch-`. Applies
  `dispatch:office-hours` with apply-first / create-on-"not found" idiom
  (canonical color FBCA04 + description). Always exits 0.
- `.claude/hooks/dispatch-office-hours-strip.sh` — UserPromptSubmit hook
  that strips the label when a human is driving the worktree.
- `.claude/settings.json` — wires the 4 new hook entries (3 input-block, 1
  strip).
- `.claude/skills/dispatch/scripts/dispatch-select-target` — adds
  `dispatch:office-hours` skip clauses in the PR and issue scans.
- `.claude/skills/dispatch/scripts/test-dispatch-scripts.sh` — 14 new tests:
  hook label-apply / fallback / label-create-on-missing / negative
  discriminator cases; select-target skip for PR and issue.

The same label is the office-hours queue marker shared with the
deviation-writer in /dispatch Step 9 (#790); the skip clause covers both
writers.

## Test plan

- [x] `test-dispatch-scripts.sh` passes (370/370)
- [ ] CI green
- [ ] /dispatch background job hitting AskUserQuestion or ExitPlanMode receives
      `dispatch:office-hours` and successor /dispatch spawns
- [ ] /dispatch tick skips a labeled PR / issue
- [ ] User prompt submission in an `<N>-*` worktree clears the label