### PR TITLE
dispatch: clarify PR↔issue number mismatch at phase-skill label-apply

### DIFF
--- a/.claude/skills/code-review-fix/SKILL.md
+++ b/.claude/skills/code-review-fix/SKILL.md
@@ -160,6 +160,12 @@ steps in order.
    .claude/skills/dispatch/scripts/dispatch-complete-phase "$PR_NUM" code-review
    ```
 
+   The PR number passed here is **expected** to differ from the worktree's
+   `<issue>-…` branch issue number — the PR↔issue linkage was established
+   earlier in the tick (by `dispatch-resolve-arg`, `dispatch-find-pr`, or
+   `dispatch-select-target`), so the dispatching session must **not** pause to
+   re-confirm the mismatch.
+
    This skill **owns** its `dispatch:code-reviewed` label — parallel to how
    `/review-fix` owns `dispatch:reviewed` and `/security-review-fix` owns
    `dispatch:security-reviewed` — so `/dispatch` does not apply the label after

--- a/.claude/skills/dispatch-qa/SKILL.md
+++ b/.claude/skills/dispatch-qa/SKILL.md
@@ -294,6 +294,12 @@ The QA pass covers **public data only** — documents present in both the QA ser
    .claude/skills/dispatch/scripts/dispatch-complete-phase <pr-num> qa
    ```
 
+   The PR number passed here is **expected** to differ from the worktree's
+   `<issue>-…` branch issue number — the PR↔issue linkage was established
+   earlier in the tick (by `dispatch-resolve-arg`, `dispatch-find-pr`, or
+   `dispatch-select-target`), so the dispatching session must **not** pause to
+   re-confirm the mismatch.
+
    The script applies the label, creating it first only if it does not yet exist
    (e.g. on a fork where it has not been created).
 

--- a/.claude/skills/dispatch-qa/SKILL.md
+++ b/.claude/skills/dispatch-qa/SKILL.md
@@ -297,8 +297,9 @@ The QA pass covers **public data only** — documents present in both the QA ser
    The PR number passed here is **expected** to differ from the worktree's
    `<issue>-…` branch issue number — the PR↔issue linkage was established
    earlier in the tick (by `dispatch-resolve-arg`, `dispatch-find-pr`, or
-   `dispatch-select-target`), so the dispatching session must **not** pause to
-   re-confirm the mismatch.
+   `dispatch-select-target`), so this session must **not** pause to re-confirm
+   the mismatch. ("This session" covers all three invocation paths: the
+   `/dispatch`-invoked path and both standalone paths above.)
 
    The script applies the label, creating it first only if it does not yet exist
    (e.g. on a fork where it has not been created).

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -503,6 +503,14 @@ workflow. `/dispatch-qa`, `/code-review-fix`, `/review-fix`, and
 `dispatch:code-reviewed`, `dispatch:reviewed`, and `dispatch:security-reviewed`
 respectively — so `/dispatch` applies no `dispatch:*` label after any phase.
 
+When a phase skill runs `dispatch-complete-phase <pr-num> <phase>`, the PR
+number is expected to differ from the worktree's `<issue>-…` branch issue
+number; the PR↔issue linkage was established earlier in the tick by
+`dispatch-resolve-arg`, `dispatch-find-pr`, or `dispatch-select-target`'s
+`pr <num> <branch> <phase>` selection result. The dispatching session must
+**not** pause to re-confirm — this is the expected shape of every
+phase-skill label apply.
+
 ## 8. Pre-Implementation Relevance Review
 
 This step runs **only** for the `implement` phase — a no-PR target. Every phase

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -193,6 +193,12 @@ already applied, so re-entry is a true no-op. Otherwise run all steps in order.
    .claude/skills/dispatch/scripts/dispatch-complete-phase "$PR_NUM" review
    ```
 
+   The PR number passed here is **expected** to differ from the worktree's
+   `<issue>-…` branch issue number — the PR↔issue linkage was established
+   earlier in the tick (by `dispatch-resolve-arg`, `dispatch-find-pr`, or
+   `dispatch-select-target`), so the dispatching session must **not** pause to
+   re-confirm the mismatch.
+
    This skill **owns** its `dispatch:reviewed` label — unlike the generic
    `/review`, which `/dispatch` cannot make dispatch-aware — so `/dispatch`
    does not apply the label after this skill returns. The label is applied

--- a/.claude/skills/security-review-fix/SKILL.md
+++ b/.claude/skills/security-review-fix/SKILL.md
@@ -120,6 +120,12 @@ steps in order.
    .claude/skills/dispatch/scripts/dispatch-complete-phase <pr-num> security
    ```
 
+   The PR number passed here is **expected** to differ from the worktree's
+   `<issue>-…` branch issue number — the PR↔issue linkage was established
+   earlier in the tick (by `dispatch-resolve-arg`, `dispatch-find-pr`, or
+   `dispatch-select-target`), so the dispatching session must **not** pause to
+   re-confirm the mismatch.
+
    This skill **owns** its `dispatch:security-reviewed` label — unlike the generic
    `/security-review`, which `/dispatch` cannot make dispatch-aware — so
    `/dispatch` does not apply the label after this skill returns.


### PR DESCRIPTION
## Summary

Documentation-only edits. Adds a one-line clarification adjacent to every `dispatch-complete-phase` call-site so the dispatching session no longer pauses to re-confirm the expected PR↔issue number mismatch at phase-skill label apply.

- `.claude/skills/dispatch/SKILL.md` — Step 7 "Applying the progress label" subsection gets the meta-version (framed for the dispatching session that sees a phase skill's `dispatch-complete-phase` call).
- `.claude/skills/dispatch-qa/SKILL.md` — Step 8 label-apply step.
- `.claude/skills/code-review-fix/SKILL.md` — step 7 label-apply step.
- `.claude/skills/review-fix/SKILL.md` — step 8 label-apply step.
- `.claude/skills/security-review-fix/SKILL.md` — step 6 label-apply step.

The wording explicitly states: (a) the PR number is **expected** to differ from the worktree's `<issue>-…` branch issue number, (b) the PR↔issue linkage was established earlier in the tick (by `dispatch-resolve-arg`, `dispatch-find-pr`, or `dispatch-select-target`), and (c) the dispatching session must **not** pause to re-confirm.

No script or behavioural changes.

Closes #821.

## Test plan

- [x] Re-read each of the five files to confirm the clarification is adjacent to its `dispatch-complete-phase` call-site.
- [x] Wording across the four phase-skill files is consistent.
- [x] `bash .claude/skills/dispatch/scripts/test-dispatch-scripts.sh` — 367/367 pass (no regression; `dispatch-complete-phase` script is unchanged).
- [ ] Downstream signal: the next dispatch chain that exercises a phase-skill label apply does not pause on the PR↔issue mismatch (observable only in post-merge production runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)