### PR TITLE
dispatch-find-pr: retry + cross-check for gh silent-empty flakes

### DIFF
--- a/.claude/skills/dispatch/scripts/dispatch-find-pr
+++ b/.claude/skills/dispatch/scripts/dispatch-find-pr
@@ -28,6 +28,8 @@
 #     a self-issued gh pr list. Must include at least number,headRefName; a
 #     superset list (e.g. the one dispatch-phase needs) is also accepted.
 #     The retry (step 1) is skipped when this is set — the caller owns the list.
+#     The cross-check (step 2) still runs regardless — it uses a different gh
+#     endpoint that the caller cannot pre-supply.
 #   DISPATCH_FIND_PR_RETRY_DELAY — delay in seconds before the retry fetch
 #     (default: 1). Set to 0 in tests to avoid sleeps.
 set -euo pipefail
@@ -63,8 +65,11 @@ if [[ -z "${DISPATCH_PR_LIST:-}" ]]; then
 fi
 
 # Cross-check via the issue's own closedByPullRequestsReferences.
-CLOSING=$(gh issue view "$ARG" --json closedByPullRequestsReferences)
-printf '%s' "$CLOSING" \
-  | jq -r '.closedByPullRequestsReferences
-           | map(select(.state == "OPEN"))
-           | .[0].number // empty'
+# gh issue view exits non-zero if the issue was deleted, transferred, or the
+# network failed — suppress that so the script returns empty instead of aborting.
+if CLOSING=$(gh issue view "$ARG" --json closedByPullRequestsReferences 2>/dev/null); then
+  printf '%s' "$CLOSING" \
+    | jq -r '.closedByPullRequestsReferences
+             | map(select(.state == "OPEN"))
+             | .[0].number // empty'
+fi

--- a/.claude/skills/dispatch/scripts/dispatch-find-pr
+++ b/.claude/skills/dispatch/scripts/dispatch-find-pr
@@ -7,12 +7,29 @@
 # gh queries. The only correct correlation is the branch-name prefix
 # convention: the PR whose headRefName starts with "<issue>-".
 #
+# Empty-result handling (defense-in-depth):
+#   When the prefix filter finds no match, the script does not immediately
+#   return empty. It applies two further checks before accepting "no PR":
+#
+#   1. Retry (self-fetch path only): re-issues gh pr list after a short
+#      delay (default 1 s, override via DISPATCH_FIND_PR_RETRY_DELAY) to
+#      catch transient gh flakes (rate-limit / auth-race / ECONNRESET
+#      surfacing as exit 0 + empty array).
+#
+#   2. Cross-check via closedByPullRequestsReferences: fetches the issue's
+#      own list of closing PRs and returns any OPEN reference. This catches
+#      the branch-renamed-away case and provides a second authority on the
+#      "no PR" question regardless of which path resolved PR_LIST.
+#
 # Environment:
-#   DISPATCH_PR_LIST — optional. A JSON array of open PRs supplied by the
-#     caller (dispatch-select-target passes it to avoid a redundant
+#   DISPATCH_PR_LIST           — optional. A JSON array of open PRs supplied
+#     by the caller (dispatch-select-target passes it to avoid a redundant
 #     gh pr list per script). When set and non-empty, it is used in place of
 #     a self-issued gh pr list. Must include at least number,headRefName; a
 #     superset list (e.g. the one dispatch-phase needs) is also accepted.
+#     The retry (step 1) is skipped when this is set — the caller owns the list.
+#   DISPATCH_FIND_PR_RETRY_DELAY — delay in seconds before the retry fetch
+#     (default: 1). Set to 0 in tests to avoid sleeps.
 set -euo pipefail
 
 ARG="${1:-}"
@@ -20,6 +37,11 @@ if [[ -z "$ARG" || ! "$ARG" =~ ^[0-9]+$ ]]; then
   echo "error: usage: dispatch-find-pr <issue-num>" >&2
   exit 1
 fi
+
+prefix_match() {
+  printf '%s' "$1" | jq -r --arg num "${ARG}-" \
+    'map(select(.headRefName | startswith($num))) | .[0].number // empty'
+}
 
 # Use the caller-supplied open-PR list when DISPATCH_PR_LIST is set.
 # Otherwise fetch the list ourselves — standalone callers rely on this path.
@@ -29,6 +51,20 @@ else
   PR_LIST=$(gh pr list --state open --json number,headRefName)
 fi
 
-# Find the PR whose headRefName starts with "<issue>-" and print its number.
-printf '%s' "$PR_LIST" | jq -r --arg num "${ARG}-" \
-  'map(select(.headRefName | startswith($num))) | .[0].number // empty'
+RESULT=$(prefix_match "$PR_LIST")
+if [[ -n "$RESULT" ]]; then echo "$RESULT"; exit 0; fi
+
+# Retry-on-empty (self-fetch path only).
+if [[ -z "${DISPATCH_PR_LIST:-}" ]]; then
+  sleep "${DISPATCH_FIND_PR_RETRY_DELAY:-1}"
+  PR_LIST=$(gh pr list --state open --json number,headRefName)
+  RESULT=$(prefix_match "$PR_LIST")
+  if [[ -n "$RESULT" ]]; then echo "$RESULT"; exit 0; fi
+fi
+
+# Cross-check via the issue's own closedByPullRequestsReferences.
+CLOSING=$(gh issue view "$ARG" --json closedByPullRequestsReferences)
+printf '%s' "$CLOSING" \
+  | jq -r '.closedByPullRequestsReferences
+           | map(select(.state == "OPEN"))
+           | .[0].number // empty'

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -116,7 +116,8 @@ case "$args" in
   "pr list --state open --json number,headRefName")
     # dispatch-find-pr self-fetch: only the two correlation fields.
     echo "pr list" >> "$STUB_DIR/gh-pr-list-calls.log"
-    call_count=$(wc -l < "$STUB_DIR/gh-pr-list-calls.log")
+    echo "pr list" >> "$STUB_DIR/gh-find-pr-calls.log"
+    call_count=$(wc -l < "$STUB_DIR/gh-find-pr-calls.log")
     if [[ "$call_count" -ge 2 && -f "$STUB_DIR/pr-list-retry.json" ]]; then
       cat "$STUB_DIR/pr-list-retry.json"
     elif [[ -f "$STUB_DIR/pr-list-full.json" ]]; then

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -667,6 +667,27 @@ result=$("$TMPDIR_TEST/dispatch-find-pr" "822")
 assert_eq "genuine empty → empty" "" "$result"
 teardown
 
+# 10. DISPATCH_PR_LIST supplied without matching branch; cross-check resolves PR.
+# The retry (step 1) is skipped when DISPATCH_PR_LIST is set — the caller owns
+# the list. The cross-check (step 2) still runs regardless, using a different gh
+# endpoint that the caller cannot pre-supply.
+echo "Test: DISPATCH_PR_LIST no match + cross-check OPEN reference → PR number"
+setup
+printf '[{"number":850,"headRefName":"999-unrelated"}]\n' > "$STUB_DIR/pr-list-full.json"
+printf '{"closedByPullRequestsReferences":[{"number":851,"state":"OPEN"}]}\n' \
+  > "$STUB_DIR/issue-closing-prs-822.json"
+result=$(DISPATCH_PR_LIST='[{"number":850,"headRefName":"999-unrelated"}]' \
+  "$TMPDIR_TEST/dispatch-find-pr" "822")
+assert_eq "DISPATCH_PR_LIST no prefix match; cross-check finds OPEN PR → PR number" "851" "$result"
+# Verify no self-fetch: gh pr list --state open --json number,headRefName was not called.
+if [[ -f "$STUB_DIR/gh-find-pr-calls.log" ]]; then
+  call_count=$(wc -l < "$STUB_DIR/gh-find-pr-calls.log")
+else
+  call_count=0
+fi
+assert_eq "no self-fetch gh pr list calls when DISPATCH_PR_LIST set" "0" "$call_count"
+teardown
+
 # ============================================================================
 # dispatch-resolve-arg tests
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -80,6 +80,7 @@ setup() {
   # dispatch-select-target test stays green.
   mkdir -p "$TMPDIR_TEST/config"
   export DISPATCH_CONFIG_DIR="$TMPDIR_TEST/config"
+  export DISPATCH_FIND_PR_RETRY_DELAY=0
 
   # Default no-op dispatch-sweep stub: silent, exit 0 (no orphan to adopt).
   # dispatch-select-target invokes "$SCRIPT_DIR/dispatch-sweep" in default mode
@@ -115,7 +116,10 @@ case "$args" in
   "pr list --state open --json number,headRefName")
     # dispatch-find-pr self-fetch: only the two correlation fields.
     echo "pr list" >> "$STUB_DIR/gh-pr-list-calls.log"
-    if [[ -f "$STUB_DIR/pr-list-full.json" ]]; then
+    call_count=$(wc -l < "$STUB_DIR/gh-pr-list-calls.log")
+    if [[ "$call_count" -ge 2 && -f "$STUB_DIR/pr-list-retry.json" ]]; then
+      cat "$STUB_DIR/pr-list-retry.json"
+    elif [[ -f "$STUB_DIR/pr-list-full.json" ]]; then
       cat "$STUB_DIR/pr-list-full.json"
     else
       echo "[]"
@@ -161,6 +165,15 @@ case "$args" in
       cat "$STUB_DIR/issue-title-${num}.json"
     else
       echo "{\"title\":\"Issue $num\"}"
+    fi
+    ;;
+  issue\ view\ *\ --json\ closedByPullRequestsReferences)
+    # dispatch-find-pr cross-check fallback: gh issue view <num> --json closedByPullRequestsReferences
+    num=$(echo "$args" | awk '{print $3}')
+    if [[ -f "$STUB_DIR/issue-closing-prs-${num}.json" ]]; then
+      cat "$STUB_DIR/issue-closing-prs-${num}.json"
+    else
+      echo '{"closedByPullRequestsReferences":[]}'
     fi
     ;;
   api\ */dependencies/blocked_by)
@@ -389,6 +402,7 @@ teardown() {
   STUB_DIR=""
   export PATH="$SAVED_PATH"
   unset DISPATCH_CONFIG_DIR
+  unset DISPATCH_FIND_PR_RETRY_DELAY
 }
 trap '[ -n "${TMPDIR_TEST:-}" ] && rm -rf "$TMPDIR_TEST"' EXIT
 
@@ -605,6 +619,51 @@ setup
 printf '[{"number":10,"headRefName":"60-foo"}]\n' > "$STUB_DIR/pr-list-full.json"
 result=$("$TMPDIR_TEST/dispatch-find-pr" "6")
 assert_eq "issue 6 does not match branch 60-foo → empty" "" "$result"
+teardown
+
+# 6. Flake recovery: first pr list call is empty, second returns the PR.
+# Models gh pr list flaking (exit 0 + []) on call 1 and returning the real list
+# on call 2. The retry-on-empty should produce the PR number.
+echo "Test: flake recovery — empty first call, PR on retry → PR number"
+setup
+printf '[]\n' > "$STUB_DIR/pr-list-full.json"
+printf '[{"number":820,"headRefName":"820-x"}]\n' > "$STUB_DIR/pr-list-retry.json"
+result=$("$TMPDIR_TEST/dispatch-find-pr" "820")
+assert_eq "flake recovery → PR number" "820" "$result"
+teardown
+
+# 7. Cross-check fallback: pr list yields empty on both attempts, but the
+# issue's closedByPullRequestsReferences lists an OPEN PR. This covers the
+# case where the branch was renamed away from the <issue>- convention.
+echo "Test: cross-check fallback — issue references an OPEN PR → PR number"
+setup
+printf '[]\n' > "$STUB_DIR/pr-list-full.json"
+printf '{"closedByPullRequestsReferences":[{"number":830,"state":"OPEN"}]}\n' \
+  > "$STUB_DIR/issue-closing-prs-822.json"
+result=$("$TMPDIR_TEST/dispatch-find-pr" "822")
+assert_eq "cross-check OPEN reference → PR number" "830" "$result"
+teardown
+
+# 8. Cross-check ignores non-OPEN references. The script's contract is "open
+# PR for issue N or empty"; a MERGED reference must not be reported.
+echo "Test: cross-check ignores MERGED reference → empty"
+setup
+printf '[]\n' > "$STUB_DIR/pr-list-full.json"
+printf '{"closedByPullRequestsReferences":[{"number":840,"state":"MERGED"}]}\n' \
+  > "$STUB_DIR/issue-closing-prs-822.json"
+result=$("$TMPDIR_TEST/dispatch-find-pr" "822")
+assert_eq "cross-check MERGED reference → empty" "" "$result"
+teardown
+
+# 9. Genuine empty: pr list empty on both attempts AND issue references no
+# PR. Output stays empty, exit 0 — the "no PR exists" answer.
+echo "Test: genuine empty (no PR, no references) → empty"
+setup
+printf '[]\n' > "$STUB_DIR/pr-list-full.json"
+printf '{"closedByPullRequestsReferences":[]}\n' \
+  > "$STUB_DIR/issue-closing-prs-822.json"
+result=$("$TMPDIR_TEST/dispatch-find-pr" "822")
+assert_eq "genuine empty → empty" "" "$result"
 teardown
 
 # ============================================================================


### PR DESCRIPTION
Closes #822

## Summary

`dispatch-find-pr <N>` returned empty stdout under two structurally
different conditions: (a) genuine "no PR exists" and (b) `gh pr list`
flaked (exit 0 + empty array). SKILL.md Step 6 treated every empty as
case (a) and routed the dispatch tick to `implement`, causing the
"looping on implement" stall observed in worktree 814 on 2026-05-27.

Two fallbacks now run before an empty result is accepted as the truth:

1. **Retry-on-empty (self-fetch path only).** When `DISPATCH_PR_LIST`
   was not set and the prefix filter yielded empty, the script sleeps
   `DISPATCH_FIND_PR_RETRY_DELAY` seconds (default 1) and re-issues
   `gh pr list`. Skipped when `DISPATCH_PR_LIST` is set — the caller
   owns that list.
2. **`closedByPullRequestsReferences` cross-check.** When the prefix
   filter is still empty, the script calls `gh issue view <N> --json
   closedByPullRequestsReferences` and returns the first referenced PR
   with `state == "OPEN"`. CLOSED/MERGED references are ignored. Runs
   on both the self-fetch and `DISPATCH_PR_LIST` paths, since it
   consults a different authority (the issue itself) and catches the
   case where the branch was renamed away from the `<N>-` convention.

A `gh` failure in the cross-check surfaces via `set -euo pipefail` —
no silent fallback, consistent with `.claude/rules/code-style.md`. The
script's contract — "prints PR number or empty" — is unchanged, so
callers in SKILL.md need no changes.

## Test plan

- [x] All existing `dispatch-find-pr` tests pass without modification
  (tests 1–5).
- [x] Four new tests cover the new paths (tests 6–9): flake recovery,
  cross-check fallback on an OPEN reference, cross-check ignores
  MERGED references, genuine empty when nothing matches.
- [x] Full suite: 371/371 passed, 0 failed.