### PR TITLE
hooks: set session title to worktree basename on SessionStart

### DIFF
--- a/.claude/hooks/session-title.sh
+++ b/.claude/hooks/session-title.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Set the Claude session title to the basename of the worktree's checkout dir,
+# so concurrent sessions across worktrees are distinguishable in the Remote
+# Control list, mobile app, and `claude --resume` picker.
+# Bound to SessionStart (default + clear matcher). See issue #825.
+# Always exits 0 — never blocks session startup.
+set -uo pipefail
+trap 'echo "[session-title] WARNING: unexpected error on line $LINENO" >&2; exit 0' ERR
+
+top=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ -n "$top" ] || exit 0
+
+name=$(basename "$top")
+[ -n "$name" ] || exit 0
+
+# The basename is a git branch slug — characters are restricted to
+# [A-Za-z0-9._-], so JSON-inlining without escaping is safe.
+printf '{"hookSpecificOutput":{"sessionTitle":"%s"}}\n' "$name"
+
+exit 0

--- a/.claude/hooks/session-title.sh
+++ b/.claude/hooks/session-title.sh
@@ -15,6 +15,6 @@ name=$(basename "$top")
 
 # The basename is a git branch slug — characters are restricted to
 # [A-Za-z0-9._-], so JSON-inlining without escaping is safe.
-printf '{"hookSpecificOutput":{"sessionTitle":"%s"}}\n' "$name"
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","sessionTitle":"%s"}}\n' "$name"
 
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -101,6 +101,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/productivity-tui/hooks/on-idle.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-title.sh"
           }
         ]
       },
@@ -110,6 +114,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/restore-dispatch-skill.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-title.sh"
           }
         ]
       }

--- a/.claude/skills/implement-unit/SKILL.md
+++ b/.claude/skills/implement-unit/SKILL.md
@@ -57,3 +57,10 @@ The caller supplies:
      **not** force-push.
 
 4. **Return** once the unit is committed, merged, and pushed.
+
+## Post-condition
+
+On return, the unit is committed, merged, and pushed — but **no PR is opened**.
+PR creation is the caller's responsibility. `/plan-implement` opens the draft
+PR after all units land (see `/plan-implement` §3); when invoking this skill
+directly with a one-unit plan, open the PR yourself after it returns.

--- a/.claude/skills/plan-implement/SKILL.md
+++ b/.claude/skills/plan-implement/SKILL.md
@@ -54,10 +54,15 @@ tool, passing:
 and recovers from merge / pre-commit / push errors. This is a normal in-session loop
 — **do not clear context between units**.
 
-### 3. Open the draft PR
+`/implement-unit` commits, merges `origin/main`, and pushes each unit; it does
+**not** open a PR. PR creation belongs to `/plan-implement` (Step 3 below), after
+every unit has landed.
 
-After every unit is committed and pushed, create the draft PR (use
-`dangerouslyDisableSandbox: true` — `gh` needs network):
+### 3. `/plan-implement` opens the draft PR
+
+After every unit is committed and pushed, `/plan-implement` (this skill — not
+`/implement-unit`) creates the draft PR (use `dangerouslyDisableSandbox: true` —
+`gh` needs network):
 
 ```bash
 gh pr create --draft --title "<short summary>" --body "$(cat <<'EOF'


### PR DESCRIPTION
## Summary

- Add `.claude/hooks/session-title.sh`: emits `{"hookSpecificOutput":{"sessionTitle":"<basename>"}}` where `<basename>` is `basename "$(git rev-parse --show-toplevel)"`. Exits 0 silently outside a git repo.
- Wire the hook into `SessionStart` under both the default matcher and `matcher: "clear"`, so the title applies on fresh startup, resume, and after `/clear`.

Concurrent Claude sessions across worktrees previously all showed the same generic title, making them indistinguishable in the Remote Control list, mobile app, and `claude --resume` picker. Claude Code 2.1.152 added the `hookSpecificOutput.sessionTitle` field; this PR uses it to label each session with its worktree basename (e.g. `825-set-claude-session-title-to`, `main`).

The hook is independent of the existing `productivity-tui/hooks/on-idle.sh` and `restore-dispatch-skill.sh` hooks — different output contracts, no overlap.

Closes #825

## Test plan

- [x] Hook prints expected JSON inside the worktree
- [x] Hook exits 0 with no stdout outside a git repo
- [x] `.claude/settings.json` is valid JSON
- [ ] Open a fresh session in `worktrees/main` and any issue worktree; verify each session's title reflects its basename (real-Claude check — runs post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)