### PR TITLE
dispatch: route priority label ahead of all topic categories

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -223,12 +223,14 @@ continue to target selection.
   `<issue>-*` worktree always continues there.
 
   The topic-category × phase ladder is two-tier: a topic **category** nests
-  outside the phase **ladder**. Categories, highest priority first: `bug` →
-  `testing infrastructure` → `dispatch` → `other`. A PR's category is the
-  highest-priority topic among the labels of every issue it closes; an issue's
-  category is the highest-priority topic among its own labels; anything with no
-  topic label is `other`. The selector exhausts one category's whole ladder
-  before moving to the next.
+  outside the phase **ladder**. Categories, highest priority first:
+  `priority` → `bug` → `testing infrastructure` → `dispatch` → `other`. A
+  `priority`-labelled issue (or a PR closing one) outranks every other
+  category; the label is human-applied — `/ready` never applies it
+  automatically. A PR's category is the highest-priority topic among the
+  labels of every issue it closes; an issue's category is the highest-priority
+  topic among its own labels; anything with no topic label is `other`. The
+  selector exhausts one category's whole ladder before moving to the next.
 
   Within each category the ladder is (highest first; within a tier, oldest PR
   wins; PRs and `help wanted` issues with a local worktree are skipped; a PR

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -63,7 +63,7 @@
 #
 # Selection is two-tier: a topic *category* nests outside the phase *ladder*.
 # Categories, highest priority first:
-#   bug → testing infrastructure → dispatch → other
+#   priority → bug → testing infrastructure → dispatch → other
 # The selector exhausts every tier of one category before moving to the next.
 #
 # A PR's category is the highest-priority topic among the labels of every issue

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -452,12 +452,15 @@ ISSUE_LABELS_JSON=$(printf '%s' "$ISSUE_LIST" \
 
 # Topic categories in priority order; "other" is the implicit fallback for any
 # label set with no topic label. A category tier nests *outside* the phase
-# ladder: the selector exhausts every phase of "bug" before considering
-# "testing infrastructure", and so on. TOPIC_CATEGORIES is the single source of
-# the ordering — category_of_labels resolves against it and the default-mode
-# loop iterates CATEGORIES. The companion classifier that *applies* these
-# labels is ref-ready SKILL.md Step 6; keep the two label sets in sync.
-TOPIC_CATEGORIES=(bug "testing infrastructure" dispatch)
+# ladder: the selector exhausts every phase of "priority" before considering
+# "bug", and so on. TOPIC_CATEGORIES is the single source of the ordering —
+# category_of_labels resolves against it and the default-mode loop iterates
+# CATEGORIES. "priority" is an orthogonal escalation axis applied alongside a
+# topic label; the first-match resolution in category_of_labels means an issue
+# carrying both `priority` and `bug` resolves to `priority`. The companion
+# classifier that *applies* these labels is ref-ready SKILL.md Step 6; keep
+# the two label sets in sync.
+TOPIC_CATEGORIES=(priority bug "testing infrastructure" dispatch)
 CATEGORIES=("${TOPIC_CATEGORIES[@]}" other)
 # Same priority list as a JSON array, for category_of_labels' jq filter.
 TOPIC_CATEGORIES_JSON=$(printf '%s\n' "${TOPIC_CATEGORIES[@]}" | jq -Rcn '[inputs]')

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1292,6 +1292,26 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "PR with no closing issue is 'other'; bug issue wins" "issue 500" "$result"
 teardown
 
+# 30b. A PR closing a `priority`-labelled issue outranks a PR closing a `bug`
+#      issue, even when the bug PR is older — `priority` is the new top of the
+#      category ladder. Mirrors test 28 with priority swapped in for bug.
+echo "Test: PR closing a priority issue beats PR closing a bug issue"
+setup
+# PR 20 (older) closes bug issue 200; PR 10 (newer) closes priority issue 100.
+UNION='['
+UNION+="$(make_pr_union 20 "20-bug-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
+UNION+="$(make_pr_union 10 "10-priority-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100}]')"
+UNION+=']'
+setup_union_pr_list "$UNION"
+# Issues 100/200 are the closing issues — they carry the topic label that the
+# PRs inherit. No "help wanted" label, so they are not themselves queue items.
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]},{"number":200,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "priority-closing PR beats bug-closing PR" "pr 10 10-priority-pr verify" "$result"
+teardown
+
 # --- blocked-issue PR skip (issue #786) -------------------------------------
 # dispatch-select-target skips a PR from every PR-ladder tier when any issue it
 # closes is blocked_by an open issue; a closing issue blocked only by

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1240,7 +1240,7 @@ assert_eq "issue 6 not masked by 60-foo worktree" "issue 6" "$result"
 teardown
 
 # --- topic-category prioritization (issue #707) -----------------------------
-# A topic category (bug → testing infrastructure → dispatch → other) nests
+# A topic category (priority → bug → testing infrastructure → dispatch → other) nests
 # outside the phase ladder. A PR's category is resolved from the labels of the
 # issues it closes; an issue's category from its own labels.
 

--- a/.claude/skills/ref-ready/SKILL.md
+++ b/.claude/skills/ref-ready/SKILL.md
@@ -175,7 +175,10 @@ one topic label. Classification is identical in both input modes; only the
 
 Classify the issue's topic from its title and body. Topic labels mark subject
 area and are orthogonal to the `dispatch:*` phase labels, which mark workflow
-progress. Apply **at most one** topic label.
+progress. Apply **at most one** topic label. The 'at most one' rule applies
+only to the topic axis — `dispatch` and `testing infrastructure`. `priority`
+is a separate axis (an escalation marker) and may be applied alongside a
+topic label.
 
 - **`dispatch`** — concerns the `/dispatch` workflow, one of its phase skills
   (`/plan-implement`, `/verify-pr`, `/dispatch-qa`, `/code-review-fix`,
@@ -194,6 +197,12 @@ progress. Apply **at most one** topic label.
   `run-acceptance-tests.sh`, `run-lint.sh`, `run-typecheck.sh`). Keyword
   signals: "CI", "unit test", "acceptance test", "Vitest", "Playwright",
   "fixture", "seed data", "test runner".
+
+- **`priority`** — a separate axis from the topic labels above. A
+  human-applied escalation marker that routes the issue (or any PR closing it)
+  ahead of every topic category in `/dispatch` queue selection. Apply only
+  when a human explicitly asks to escalate; `/ready` never applies it
+  automatically. May be combined with any topic label.
 
 - **Neither** — apply no topic label. Most product and
   landing/budget/print/fellspiral feature work matches neither topic. There is


### PR DESCRIPTION
Closes #832

## Summary

Add `priority` as the new first entry of `TOPIC_CATEGORIES` in `dispatch-select-target`. Resolved order:

```
priority → bug → testing infrastructure → dispatch → other
```

`priority` is orthogonal to topic labels — an issue may carry it alongside `bug`/`dispatch`/`testing infrastructure`. The existing `category_of_labels` first-match resolution makes a `(priority, bug)` issue resolve to `priority` with no further code change. A PR closing a `priority`-labelled issue inherits the category automatically; no PR-side label is needed.

The override is queue-selection-only; explicit `/dispatch <N>` already short-circuits the queue and is unaffected.

## Changes

- `dispatch-select-target`: prepend `priority` to `TOPIC_CATEGORIES`; update companion comment to name the new order.
- `dispatch/SKILL.md` Step 3: extend the topic-category ladder and add one sentence noting `priority` is human-applied (not auto-applied by `/ready`).
- `ref-ready/SKILL.md` Step 6: add a `priority` bullet (separate axis, human-applied escalation marker) and clarify that the 'at most one topic label' rule applies only to the topic axis.
- `test-dispatch-scripts.sh`: new test #30b — a PR closing a `priority`-labelled issue beats a PR closing a `bug` issue even when the bug PR is older.
- Operationally created the `priority` label on the repo (orange `#d93f0b`).

## Test plan

- [x] `.claude/skills/dispatch/scripts/test-dispatch-scripts.sh` — 368/368 passing locally, including new test #30b.
- [x] `gh label list | grep '^priority'` — label exists on remote.
- [ ] CI `pr-checks` passes.