### PR TITLE
dispatch: base worktree-conflict detection on session liveness (#741)

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -244,10 +244,11 @@ continue to target selection.
   yields a task.
 
   A `help wanted` issue is also skipped when its entire open-leaf subtree is
-  worktree-conflicted — every reachable open leaf already has a worktree owned by
-  another session — exactly as a directly-worktree'd issue is skipped; selection
-  falls through to the next tier. The tier emits the resolved startable leaf, so
-  a queue-selected `issue <num>` is always a directly-startable target.
+  worktree-conflicted — every reachable open leaf already has a worktree with a
+  live Claude session — exactly as a directly-worktree'd issue is skipped;
+  selection falls through to the next tier. The tier emits the resolved
+  startable leaf, so a queue-selected `issue <num>` is always a directly-
+  startable target.
 
   **main-broken handler.** `origin/main` itself is red, so no new work is safe
   to start. Do **not** run the sweep, create a worktree, branch, or phase skill.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -377,13 +377,16 @@ one of `path` (switch to an existing worktree) or `name` (create a new one).
 - **`create <branch>`** → no worktree exists. `EnterWorktree` with `name:` set to
   `<branch>`. This fires the `WorktreeCreate` hook, which runs `sync-issue-context`
   and populates `CLAUDE.local.md` with full issue context.
-- **`conflict <path>`** → a queue-selected target already has a worktree, so
-  another session owns it. (`dispatch-select-target` resolves the `help wanted`
-  tier to a leaf with no worktree, so for a queue selection this arises only from
-  a race — another session created the worktree between selection and worktree
+- **`conflict <path>\t<sessionId>\t<name>`** → a queue-selected target already
+  has a worktree with a live Claude session, so another session owns it. The
+  fields after `<path>` are TAB-separated and identify the owning session
+  (`unknown\tunknown` when the session daemon could not be queried — fail-safe).
+  (`dispatch-select-target` resolves the `help wanted` tier to a leaf with no
+  live-session worktree, so for a queue selection this arises only from a race
+  — another session occupied the worktree between selection and worktree
   resolution.) Release the lock (see *Releasing the lock*), then report the
-  conflict (name `<path>` and issue `<N>`), then **proceed to Step 9**
-  (early-stop); do not `EnterWorktree`.
+  conflict (name `<path>`, the owning session's `<sessionId>` and `<name>`, and
+  issue `<N>`), then **proceed to Step 9** (early-stop); do not `EnterWorktree`.
 
 On every non-`conflict` path, before any phase skill runs, create the recovery
 marker:

--- a/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
@@ -9,14 +9,25 @@
 #                     EnterWorktree with path: <path>.
 #   create <branch> — no worktree exists; <branch> is the sanitized name,
 #                     EnterWorktree with name: <branch>.
-#   conflict <path> — a queue-selected target already has a worktree (another
-#                     session owns it); /dispatch reports <path> and stops.
+#   conflict <path>\t<sessionId>\t<name>
+#                   — a queue-selected target already has a worktree owned by
+#                     another live Claude session; /dispatch reports the path
+#                     and the owning session's id/name, then stops. The
+#                     sessionId and name fields are TAB-separated from <path>
+#                     because the name may contain spaces. When the session
+#                     daemon cannot be queried the helper signals unknown;
+#                     the script fails safe (treats unknown as occupied) and
+#                     emits the literal `unknown\tunknown` as the diagnostic
+#                     fields.
 #
 # The mode argument decides what an existing <issue>-* worktree means:
 #   explicit — the target was named by an explicit /dispatch argument
 #              (recycle-after-completion); an existing worktree yields `enter`.
-#   queue    — the target was queue-selected; an existing worktree belongs to
-#              another session and yields `conflict`.
+#   queue    — the target was queue-selected; an existing worktree with a
+#              live Claude session belongs to another session and yields
+#              `conflict`; an existing worktree with no live session is a
+#              potentially interrupted implementation task to be resumed and
+#              yields `enter` (same as explicit mode).
 # The `here` check is mode-independent and fires before the worktree scan.
 #
 # The branch name printed by `create` matches the WorktreeCreate hook's
@@ -35,6 +46,7 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
+source "$SCRIPT_DIR/lib-claude-agents.sh"
 
 # `here` — the current branch already is the target's branch. Mode-independent,
 # checked before the worktree scan.
@@ -52,9 +64,29 @@ while IFS= read -r line; do
   if [[ "$WT_NUM" == "$ISSUE" ]]; then
     if [[ "$MODE" == "explicit" ]]; then
       echo "enter $WT_PATH"
-    else
-      echo "conflict $WT_PATH"
+      exit 0
     fi
+    # Queue mode: gate conflict on session liveness. A sessionless <issue>-*
+    # worktree is a potentially interrupted implementation task to be resumed,
+    # not a conflict — fall through to `enter $WT_PATH` (the recycle behavior
+    # explicit mode already uses). claude_sessions_under returns 0 with TSV
+    # session rows when occupied, 0 with empty output when definitely free, and
+    # 1 (unknown) when the daemon cannot be queried — fold unknown into the
+    # conflict branch, matching worktree_has_live_session's fail-safe contract.
+    if sessions=$(claude_sessions_under "$WT_PATH"); then
+      if [[ -z "$sessions" ]]; then
+        echo "enter $WT_PATH"
+        exit 0
+      fi
+      # Pick the first session row for diagnostics.
+      IFS=$'\t' read -r sid _pid _status name <<<"$(printf '%s\n' "$sessions" | head -n1)"
+    else
+      # Unknown: daemon could not be queried. Fail safe (treat as occupied) and
+      # surface the unknown identity in the diagnostic fields.
+      sid="unknown"
+      name="unknown"
+    fi
+    printf 'conflict %s\t%s\t%s\n' "$WT_PATH" "$sid" "$name"
     exit 0
   fi
 done < <(list_worktree_records)

--- a/.claude/skills/dispatch/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch/scripts/dispatch-trace-leaf
@@ -11,13 +11,16 @@
 #              child is fine (the dispatch caller resolves it via
 #              dispatch-resolve-worktree's explicit mode, which yields `enter`
 #              for the recycle-after-completion case).
-#   queue    — descent filters out children whose <N>-* branch is an existing
-#              local worktree (owned by another session). If a node has open
+#   queue    — descent filters out children whose <N>-* branch has an existing
+#              local worktree with a live Claude session (owned by another
+#              session). A sessionless <N>-* worktree is a potentially
+#              interrupted implementation task to be resumed and is treated as
+#              a normal open child, not a conflict. If a node has open
 #              children but every one is filtered out, the descent bubbles up
 #              too — that subtree has no ready work. If every reachable open
-#              leaf in the subtree is conflicted, the script exits non-zero
-#              with a clear message on stderr so the /dispatch caller can stop
-#              instead of dispatching on a conflict.
+#              leaf in the subtree has a live-session worktree, the script
+#              exits non-zero with a clear message on stderr so the /dispatch
+#              caller can stop instead of dispatching on a conflict.
 #
 # Falls back to printing N in `explicit` mode if cycles block every path to a
 # leaf (preserves historical behavior).
@@ -35,6 +38,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
+source "$SCRIPT_DIR/lib-claude-agents.sh"
 
 ISSUE_NUM="${1:-}"
 MODE="${2:-}"
@@ -44,16 +48,26 @@ if [[ -z "$ISSUE_NUM" || ! "$ISSUE_NUM" =~ ^[1-9][0-9]*$ ]] \
   exit 1
 fi
 
-# In queue mode, build the set of issue-number prefixes that own a local
-# worktree. list_worktree_records (lib.sh) does the shared porcelain parse;
-# split_worktree_record splits each line into WT_NUM / WT_PATH / WT_BRANCH —
-# WT_NUM is the branch's issue-number prefix, empty for non-issue / branchless
-# worktrees.
+# In queue mode, build the set of issue-number prefixes that own a worktree
+# with a *live* Claude session. list_worktree_records (lib.sh) does the shared
+# porcelain parse; split_worktree_record splits each line into WT_NUM /
+# WT_PATH / WT_BRANCH — WT_NUM is the branch's issue-number prefix, empty for
+# non-issue / branchless worktrees.
+#
+# Liveness gate (#741): worktree_has_live_session returns 0 when the daemon
+# reports a live session under <WT_PATH> OR when the daemon cannot be queried
+# (unknown, fail-safe); returns 1 only when the daemon definitively reports
+# zero sessions. A sessionless <issue>-* worktree is a potentially interrupted
+# implementation task — not a conflict — so the descent treats that child as a
+# normal open child.
 declare -A CONFLICTED=()
 if [[ "$MODE" == "queue" ]]; then
   while IFS= read -r line; do
     split_worktree_record "$line"
-    [[ -n "$WT_NUM" ]] && CONFLICTED["$WT_NUM"]=1
+    [[ -z "$WT_NUM" ]] && continue
+    if worktree_has_live_session "$WT_PATH"; then
+      CONFLICTED["$WT_NUM"]=1
+    fi
   done < <(list_worktree_records)
 fi
 
@@ -124,9 +138,9 @@ find_leaf() {
   fi
 
   if [[ -z "$kids" ]]; then
-    # Topological leaf — a valid leaf. Worktree-conflicted children are filtered
-    # before recursion (see the descent loop below), so a queue-mode leaf
-    # reached here is never itself worktree-conflicted.
+    # Topological leaf — a valid leaf. Live-session-worktree children are
+    # filtered before recursion (see the descent loop below), so a queue-mode
+    # leaf reached here never itself has a live-session worktree.
     echo "$n"
     return 0
   fi
@@ -170,11 +184,11 @@ if [[ "$trace_rc" -eq 3 ]]; then
   exit 1
 fi
 
-# In queue mode, no valid leaf is reachable — every leaf is worktree-conflicted
-# (or cycles block every path). Surface this so /dispatch can stop with a clear
-# message instead of dispatching on a conflict.
+# In queue mode, no valid leaf is reachable — every leaf has a live-session
+# worktree (or cycles block every path). Surface this so /dispatch can stop
+# with a clear message instead of dispatching on a conflict.
 if [[ "$MODE" == "queue" ]]; then
-  echo "error: all open leaves reachable from $ISSUE_NUM are worktree-conflicted (owned by other sessions)" >&2
+  echo "error: all open leaves reachable from $ISSUE_NUM have worktrees with live sessions (owned by other sessions)" >&2
   exit 2
 fi
 

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -65,6 +65,7 @@ setup() {
   # SCRIPT_DIR, which resolves to TMPDIR_TEST for these copies — so lib.sh must
   # sit alongside them. It is sourced, not executed, so it needs no chmod +x.
   cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/lib.sh"
+  cp "$SCRIPT_DIR/lib-claude-agents.sh" "$TMPDIR_TEST/lib-claude-agents.sh"
   chmod +x "$TMPDIR_TEST/dispatch-phase" \
            "$TMPDIR_TEST/dispatch-find-pr" \
            "$TMPDIR_TEST/dispatch-resolve-arg" \
@@ -387,6 +388,7 @@ teardown() {
   rm -rf "$TMPDIR_TEST"
   TMPDIR_TEST=""
   STUB_DIR=""
+  unset CLAUDE_AGENTS_CMD
   export PATH="$SAVED_PATH"
   unset DISPATCH_CONFIG_DIR
 }
@@ -2325,6 +2327,40 @@ branch refs/heads/42-my-feature
 
 '
 
+# install_fake_claude_sessions <sessionId> <name> [...more (sid,name) pairs]
+# Install a fake `claude` script that prints a JSON array of the given
+# (sessionId, name) pairs and exits 0, and point CLAUDE_AGENTS_CMD at it.
+# Call with zero args for an empty registry (`[]`).
+install_fake_claude_sessions() {
+  local fake="$TMPDIR_TEST/bin/fake-claude"
+  local payload="[" first=1
+  while [[ $# -ge 2 ]]; do
+    if (( first )); then first=0; else payload+=","; fi
+    payload+="{\"sessionId\":\"$1\",\"pid\":1,\"status\":\"busy\",\"name\":\"$2\"}"
+    shift 2
+  done
+  payload+="]"
+  printf '%s' "$payload" > "$TMPDIR_TEST/fake-claude-payload.json"
+  cat > "$fake" <<FAKE
+#!/usr/bin/env bash
+cat "$TMPDIR_TEST/fake-claude-payload.json"
+exit 0
+FAKE
+  chmod +x "$fake"
+  export CLAUDE_AGENTS_CMD="$fake"
+}
+
+# Install a fake `claude` that exits non-zero (daemon unknown).
+install_fake_claude_failure() {
+  local fake="$TMPDIR_TEST/bin/fake-claude"
+  cat > "$fake" <<'FAKE'
+#!/usr/bin/env bash
+exit 1
+FAKE
+  chmod +x "$fake"
+  export CLAUDE_AGENTS_CMD="$fake"
+}
+
 # 1. Current branch is <N>-* → here (mode-independent).
 echo "Test: current branch <N>-* → here (both modes)"
 setup
@@ -2344,14 +2380,42 @@ assert_eq "explicit + existing worktree → enter <path>" \
   "enter /worktrees/42-my-feature" "$result"
 teardown
 
-# 3. queue mode + the same worktree setup → conflict <path>. Acceptance
-#    criterion 3: same target, explicit → enter, queue → conflict.
-echo "Test: queue + existing <N>-* worktree → conflict"
+# 3. queue mode + the same worktree setup, with a live session present →
+#    conflict <path>\t<sessionId>\t<name>. The new TAB-separated format carries
+#    the owning session's diagnostic fields.
+echo "Test: queue + live-session <N>-* worktree → conflict with sid/name"
 setup
 printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+install_fake_claude_sessions "sess-742-live" "owner-task"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
-assert_eq "queue + existing worktree → conflict <path>" \
-  "conflict /worktrees/42-my-feature" "$result"
+assert_eq "queue + live worktree → conflict TSV" \
+  "$(printf 'conflict /worktrees/42-my-feature\tsess-742-live\towner-task')" \
+  "$result"
+teardown
+
+# 3a. queue mode + sessionless <N>-* worktree → enter <path>. A worktree with
+#     no live Claude session is a potentially interrupted implementation task
+#     to be resumed, not a conflict — same recycle path explicit mode uses.
+echo "Test: queue + sessionless <N>-* worktree → enter"
+setup
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+install_fake_claude_sessions   # empty registry `[]`
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
+assert_eq "queue + sessionless worktree → enter" \
+  "enter /worktrees/42-my-feature" "$result"
+teardown
+
+# 3b. queue mode + daemon unknown (claude exits non-zero) → conflict with
+#     unknown/unknown diagnostics. Fail safe: an unknown daemon must not
+#     green-light entering a worktree that may be live.
+echo "Test: queue + daemon unknown → conflict (fail safe)"
+setup
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+install_fake_claude_failure
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
+assert_eq "queue + unknown daemon → conflict with unknown/unknown" \
+  "$(printf 'conflict /worktrees/42-my-feature\tunknown\tunknown')" \
+  "$result"
 teardown
 
 # 4. No matching worktree → create <N>-<slug> from the issue title.

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -394,6 +394,40 @@ teardown() {
 }
 trap '[ -n "${TMPDIR_TEST:-}" ] && rm -rf "$TMPDIR_TEST"' EXIT
 
+# install_fake_claude_sessions <sessionId> <name> [...more (sid,name) pairs]
+# Install a fake `claude` script that prints a JSON array of the given
+# (sessionId, name) pairs and exits 0, and point CLAUDE_AGENTS_CMD at it.
+# Call with zero args for an empty registry (`[]`).
+install_fake_claude_sessions() {
+  local fake="$TMPDIR_TEST/bin/fake-claude"
+  local payload="[" first=1
+  while [[ $# -ge 2 ]]; do
+    if (( first )); then first=0; else payload+=","; fi
+    payload+="{\"sessionId\":\"$1\",\"pid\":1,\"status\":\"busy\",\"name\":\"$2\"}"
+    shift 2
+  done
+  payload+="]"
+  printf '%s' "$payload" > "$TMPDIR_TEST/fake-claude-payload.json"
+  cat > "$fake" <<FAKE
+#!/usr/bin/env bash
+cat "$TMPDIR_TEST/fake-claude-payload.json"
+exit 0
+FAKE
+  chmod +x "$fake"
+  export CLAUDE_AGENTS_CMD="$fake"
+}
+
+# Install a fake `claude` that exits non-zero (daemon unknown).
+install_fake_claude_failure() {
+  local fake="$TMPDIR_TEST/bin/fake-claude"
+  cat > "$fake" <<'FAKE'
+#!/usr/bin/env bash
+exit 1
+FAKE
+  chmod +x "$fake"
+  export CLAUDE_AGENTS_CMD="$fake"
+}
+
 # Helper to build a PR JSON entry for the full PR list (dispatch-phase).
 make_pr() {
   local num="$1" branch="$2" is_draft="$3" labels_json="$4" rollup_json="$5"
@@ -1405,9 +1439,11 @@ printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help
 printf '[{"number":5500}]\n' > "$STUB_DIR/subissues-55.json"
 printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' \
   > "$STUB_DIR/issue-5500.json"
-# Sub-issue 5500's worktree exists (owned by another session) → trace 55 exits 2.
+# Sub-issue 5500's worktree exists AND has a live session (owned by another
+# session) → trace 55 exits 2 under the live-session-aware CONFLICTED gate (#741).
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/5500-blocked\nHEAD def456\nbranch refs/heads/5500-blocked\n\n' \
   > "$STUB_DIR/worktree-list.txt"
+install_fake_claude_sessions "sess-5500-live" "owner-task"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "subtree-blocked issue 55 skipped → issue 66 chosen" "issue 66" "$result"
 teardown
@@ -1423,6 +1459,7 @@ printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPE
   > "$STUB_DIR/issue-5500.json"
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/5500-blocked\nHEAD def456\nbranch refs/heads/5500-blocked\n\n' \
   > "$STUB_DIR/worktree-list.txt"
+install_fake_claude_sessions "sess-5500-live" "owner-task"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "subtree-blocked issue 55 → falls through to QA PR" "pr 20 20-qa qa" "$result"
 teardown
@@ -1437,6 +1474,7 @@ printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPE
   > "$STUB_DIR/issue-5500.json"
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/5500-blocked\nHEAD def456\nbranch refs/heads/5500-blocked\n\n' \
   > "$STUB_DIR/worktree-list.txt"
+install_fake_claude_sessions "sess-5500-live" "owner-task"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "subtree-blocked issue 55, no QA PR → empty" "empty" "$result"
 teardown
@@ -2114,10 +2152,10 @@ result=$("$TMPDIR_TEST/dispatch-trace-leaf" "600" "explicit")
 assert_eq "sub-issues chain 600→601 → leaf 601" "601" "$result"
 teardown
 
-# 8. Queue mode: conflicted child is skipped → sibling is returned.
-echo "Test: queue mode → skips conflicted child, returns sibling"
+# 8. Queue mode: a child with a live-session worktree is skipped → sibling is returned.
+echo "Test: queue mode → skips live-session child, returns sibling"
 setup
-# 700 has two open sub-issues: 701 (worktree-owned) and 702 (clean).
+# 700 has two open sub-issues: 701 (worktree-owned by a live session) and 702 (clean).
 printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
 printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
   > "$STUB_DIR/issue-701.json"
@@ -2126,8 +2164,25 @@ printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"
 # Pretend another session owns 701's worktree on branch 701-feature.
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\n' \
   > "$STUB_DIR/worktree-list.txt"
+install_fake_claude_sessions "sess-701-live" "live-task"
 result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
-assert_eq "queue: conflicted child 701 skipped → sibling 702" "702" "$result"
+assert_eq "queue: live-session child 701 skipped → sibling 702" "702" "$result"
+teardown
+
+# 8a. Queue mode: a sessionless <N>-* worktree no longer conflicts. The descent
+#     treats 701 as a normal open child, so the lowest-numbered leaf (701) wins.
+echo "Test: queue mode → sessionless worktree is a normal child"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+install_fake_claude_sessions   # empty registry — no live session under 701
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
+assert_eq "queue: sessionless 701 is a normal child → 701" "701" "$result"
 teardown
 
 # 9. Explicit mode: conflicted child returned unchanged (no worktree filtering).
@@ -2145,8 +2200,8 @@ result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "explicit")
 assert_eq "explicit: lowest leaf 701 unchanged" "701" "$result"
 teardown
 
-# 10. Queue mode: every child is worktree-conflicted → non-zero exit.
-echo "Test: queue mode → all leaves conflicted, exits non-zero"
+# 10. Queue mode: every child's worktree has a live session → non-zero exit.
+echo "Test: queue mode → all leaves live-session-owned, exits non-zero"
 setup
 printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
 printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
@@ -2156,12 +2211,72 @@ printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"
 # Both children's worktrees exist.
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\nworktree /worktrees/702-feature\nHEAD ghi789\nbranch refs/heads/702-feature\n\n' \
   > "$STUB_DIR/worktree-list.txt"
+# A live session under each — the fake ignores --cwd and returns the same
+# payload for every query, so both 701 and 702 enter CONFLICTED.
+install_fake_claude_sessions "sess-x" "live-task"
 err_out=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
 case "$err_out" in
-  *"worktree-conflicted"*"EXIT="[1-9]*) status="ok" ;;
+  *"have worktrees with live sessions"*"EXIT="[1-9]*) status="ok" ;;
   *) status="bad: $err_out" ;;
 esac
-assert_eq "queue: all blocked → non-zero with stderr message" "ok" "$status"
+assert_eq "queue: all live-session-owned → non-zero with stderr message" "ok" "$status"
+teardown
+
+# 10a. Queue mode: both children have worktrees but neither has a live session.
+#      No conflict; descent treats them as normal children and returns the
+#      lowest-numbered leaf (701).
+echo "Test: queue mode → both worktrees sessionless, returns 701"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\nworktree /worktrees/702-feature\nHEAD ghi789\nbranch refs/heads/702-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+install_fake_claude_sessions   # empty registry — neither worktree is live
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
+assert_eq "queue: both worktrees sessionless → lowest leaf 701" "701" "$result"
+teardown
+
+# 10b. Queue mode: 701's worktree has a live session, 702's does not. The
+#      live-session-aware filter skips 701; 702 is a normal child and wins.
+#      This test needs a per-path fake `claude` — install_fake_claude_sessions
+#      returns the same payload for every --cwd query.
+echo "Test: queue mode → mixed liveness, returns sessionless sibling"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\nworktree /worktrees/702-feature\nHEAD ghi789\nbranch refs/heads/702-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+# Per-path fake: a live session under 701-feature only.
+cat > "$TMPDIR_TEST/bin/fake-claude-mixed" <<'FAKE'
+#!/usr/bin/env bash
+# Args look like: agents --json --cwd <path>
+cwd=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cwd) cwd="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$cwd" in
+  */701-feature)
+    echo '[{"sessionId":"sess-701","pid":1,"status":"busy","name":"live"}]'
+    ;;
+  *)
+    echo '[]'
+    ;;
+esac
+exit 0
+FAKE
+chmod +x "$TMPDIR_TEST/bin/fake-claude-mixed"
+export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/bin/fake-claude-mixed"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
+assert_eq "queue: 701 live + 702 sessionless → 702" "702" "$result"
 teardown
 
 # 11. Missing mode → arity error on stderr, exit 1.
@@ -2346,40 +2461,6 @@ HEAD def456
 branch refs/heads/42-my-feature
 
 '
-
-# install_fake_claude_sessions <sessionId> <name> [...more (sid,name) pairs]
-# Install a fake `claude` script that prints a JSON array of the given
-# (sessionId, name) pairs and exits 0, and point CLAUDE_AGENTS_CMD at it.
-# Call with zero args for an empty registry (`[]`).
-install_fake_claude_sessions() {
-  local fake="$TMPDIR_TEST/bin/fake-claude"
-  local payload="[" first=1
-  while [[ $# -ge 2 ]]; do
-    if (( first )); then first=0; else payload+=","; fi
-    payload+="{\"sessionId\":\"$1\",\"pid\":1,\"status\":\"busy\",\"name\":\"$2\"}"
-    shift 2
-  done
-  payload+="]"
-  printf '%s' "$payload" > "$TMPDIR_TEST/fake-claude-payload.json"
-  cat > "$fake" <<FAKE
-#!/usr/bin/env bash
-cat "$TMPDIR_TEST/fake-claude-payload.json"
-exit 0
-FAKE
-  chmod +x "$fake"
-  export CLAUDE_AGENTS_CMD="$fake"
-}
-
-# Install a fake `claude` that exits non-zero (daemon unknown).
-install_fake_claude_failure() {
-  local fake="$TMPDIR_TEST/bin/fake-claude"
-  cat > "$fake" <<'FAKE'
-#!/usr/bin/env bash
-exit 1
-FAKE
-  chmod +x "$fake"
-  export CLAUDE_AGENTS_CMD="$fake"
-}
 
 # 1. Current branch is <N>-* → here (mode-independent).
 echo "Test: current branch <N>-* → here (both modes)"


### PR DESCRIPTION
## Summary

In queue mode, `dispatch-resolve-worktree` and `dispatch-trace-leaf` previously treated *any* existing `<issue>-*` git worktree as a conflict, regardless of whether a live Claude session occupied it. A crashed or hard-killed session left its worktree behind (`on-close.sh` does not fire on hard kills), so an abandoned worktree falsely and permanently blocked queue selection of its issue — including `dispatch-trace-leaf`'s `subtree fully blocked` hard stop — until `dispatch-sweep` happened to adopt it as the oldest orphan or a human removed it.

This PR gates the conflict check on session liveness via the shared `lib-claude-agents.sh` helper from #739/#768. A sessionless `<issue>-*` worktree is now treated as a potentially interrupted implementation task to be resumed, not a conflict.

- `dispatch-resolve-worktree` (queue mode): a `<issue>-*` worktree with a live session emits `conflict <path>\t<sessionId>\t<name>`; a sessionless worktree emits `enter <path>` — the same recycle path explicit mode already uses. The conflict line is now TAB-separated so the owning session's name (which may contain spaces) is preserved. When the daemon cannot be queried, fail safe: emit `conflict <path>\tunknown\tunknown`.
- `dispatch-trace-leaf` (queue mode): the `CONFLICTED` set excludes worktrees with no live session; `subtree fully blocked` (exit 2) fires only when every reachable open leaf has a *live*-session worktree.
- `dispatch/SKILL.md` Step 5 documents the new conflict-line format; the queue-tier paragraph says "live Claude session" instead of "owned by another session".
- Explicit-mode resolution is unchanged.

## Test plan

- [x] `.claude/skills/dispatch/scripts/test-dispatch-scripts.sh` — 373/373 pass (adds 6 new tests across both scripts; modifies 2; the 3 dispatch-select-target subtree-blocked help-wanted tests are updated to install a fake live session to match the new gate).
- [ ] CI: `dispatch-tests.yml` runs the same suite against the draft PR.
- [ ] /dispatch-qa: verify queue-mode behavior end-to-end — a sessionless `<issue>-*` worktree on disk no longer blocks selection of its issue.

## Acceptance criteria (from #741)

- [x] Queue-mode `dispatch-resolve-worktree`: live-session worktree → `conflict`, sessionless → `enter <path>`.
- [x] Queue-mode `dispatch-trace-leaf` `CONFLICTED` set excludes sessionless worktrees; `subtree fully blocked` fires only when every reachable leaf has a live-session worktree.
- [x] Conflict messages identify session by `name` and `sessionId`.
- [x] `dispatch/SKILL.md` Steps 3-4 updated so "owned by another session" denotes a live session.
- [x] `test-dispatch-scripts.sh` covers, for both scripts, a `<issue>-*` worktree with a live session and one with none.
- [x] Explicit-mode resolution is unchanged.

Closes #741.

🤖 Generated with [Claude Code](https://claude.com/claude-code)