### PR TITLE
dispatch-sweep: gate orphan adoption on PR draft state (#843)

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -183,8 +183,10 @@ continue to target selection.
   - `worktree-adopted <N> <branch>` — `dispatch-sweep` adopted an orphaned
     worktree elsewhere on disk. Skip Step 4 and proceed to Step 5 with `<N>` and
     mode `explicit` — treat the adoption like an explicit `/dispatch <N>`.
-    (Step 4's closed-issue and open-blocker gates have already been enforced by
-    `dispatch-sweep` itself before emitting this directive.)
+    (Step 4's closed-issue, open-blocker, and ready-PR gates have already been
+    enforced by `dispatch-sweep` itself before emitting this directive — a
+    `done`-phase orphan whose PR is non-draft and awaiting human merge is not
+    adopted and instead falls through to the queue-ladder on the next tick.)
   - `pr <num> <branch> <phase>` — a PR to work on; `<phase>` is pre-derived by
     the selection scan, so Step 6 reuses it instead of re-deriving. Proceed to
     Step 5 with mode `queue`.

--- a/.claude/skills/dispatch/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch/scripts/dispatch-sweep
@@ -326,6 +326,22 @@ while [[ $i -lt ${#ORPHAN_PATHS[@]} ]]; do
     continue
   fi
 
+  # Ready-PR gate. A `done`-phase orphan whose PR has been flipped to ready
+  # (e.g. by /security-review-fix) is awaiting human merge — adopting it
+  # short-circuits the queue-ladder and the chain drains on the early-stop in
+  # /dispatch Step 9. Skip so the ladder gets to pick real queued work.
+  # No-PR orphans and open-draft-PR orphans still fall through to adoption.
+  #
+  # Runs BEFORE the gh-dependent closed-issue/blocker gates so a transient
+  # `gh issue view` failure cannot exit 1 on a ready-PR orphan that needs no
+  # adoption anyway — the gate uses the already-fetched DRAFT_BY_BRANCH map
+  # (populated from the single `gh pr list` at the top of the script, which
+  # degrades to an empty map on failure rather than exiting).
+  if [[ -n "$open_pr" && "${DRAFT_BY_BRANCH[$wt_branch]:-}" == "false" ]]; then
+    log "SKIP_ORPHAN_READY_PR: '$wt_path' branch=$wt_branch issue=$issue_num pr=#$open_pr"
+    continue
+  fi
+
   # Closed-issue gate. Fetch state with one gh call; fail loud on error —
   # no silent fallback to "open" (would cause stale-orphan adoption). Let gh's
   # stderr surface to the operator (matches the blocker gate, whose
@@ -360,16 +376,6 @@ while [[ $i -lt ${#ORPHAN_PATHS[@]} ]]; do
   fi
   if [[ "$n_blockers" -gt 0 ]]; then
     log "SKIP_ORPHAN_BLOCKED: '$wt_path' branch=$wt_branch issue=$issue_num blockers=$n_blockers"
-    continue
-  fi
-
-  # Ready-PR gate. A `done`-phase orphan whose PR has been flipped to ready
-  # (e.g. by /security-review-fix) is awaiting human merge — adopting it
-  # short-circuits the queue-ladder and the chain drains on the early-stop in
-  # /dispatch Step 9. Skip so the ladder gets to pick real queued work.
-  # No-PR orphans and open-draft-PR orphans still fall through to adoption.
-  if [[ -n "$open_pr" && "${DRAFT_BY_BRANCH[$wt_branch]:-}" == "false" ]]; then
-    log "SKIP_ORPHAN_READY_PR: '$wt_path' branch=$wt_branch issue=$issue_num pr=#$open_pr"
     continue
   fi
 

--- a/.claude/skills/dispatch/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch/scripts/dispatch-sweep
@@ -126,18 +126,22 @@ fi
 # One gh call covers both states. Failure (network, sandbox, missing creds)
 # collapses to an empty map so the rest of the sweep still runs (classification
 # + adoption of issue-number-prefixed orphans still works without PR data).
-PRS_JSON=$(gh pr list --state all --json number,headRefName,state --limit 200 2>/dev/null) \
+PRS_JSON=$(gh pr list --state all --json number,headRefName,state,isDraft --limit 200 2>/dev/null) \
   || PRS_JSON='[]'
 
 declare -A MERGED_BY_BRANCH=()
 declare -A OPEN_BY_BRANCH=()
-while IFS=$'\t' read -r state br n; do
+declare -A DRAFT_BY_BRANCH=()
+while IFS=$'\t' read -r state br n is_draft; do
   [[ -z "$br" ]] && continue
   case "$state" in
     MERGED) MERGED_BY_BRANCH["$br"]="$n" ;;
-    OPEN)   OPEN_BY_BRANCH["$br"]="$n" ;;
+    OPEN)
+      OPEN_BY_BRANCH["$br"]="$n"
+      DRAFT_BY_BRANCH["$br"]="$is_draft"
+      ;;
   esac
-done < <(printf '%s' "$PRS_JSON" | jq -r '.[] | [.state, .headRefName, .number] | @tsv' 2>/dev/null)
+done < <(printf '%s' "$PRS_JSON" | jq -r '.[] | [.state, .headRefName, .number, (.isDraft|tostring)] | @tsv' 2>/dev/null)
 
 # ---- Step 2: enumerate registered worktrees ---------------------------------
 # git worktree list --porcelain records are blank-line-delimited; each record
@@ -356,6 +360,16 @@ while [[ $i -lt ${#ORPHAN_PATHS[@]} ]]; do
   fi
   if [[ "$n_blockers" -gt 0 ]]; then
     log "SKIP_ORPHAN_BLOCKED: '$wt_path' branch=$wt_branch issue=$issue_num blockers=$n_blockers"
+    continue
+  fi
+
+  # Ready-PR gate. A `done`-phase orphan whose PR has been flipped to ready
+  # (e.g. by /security-review-fix) is awaiting human merge — adopting it
+  # short-circuits the queue-ladder and the chain drains on the early-stop in
+  # /dispatch Step 9. Skip so the ladder gets to pick real queued work.
+  # No-PR orphans and open-draft-PR orphans still fall through to adoption.
+  if [[ -n "$open_pr" && "${DRAFT_BY_BRANCH[$wt_branch]:-}" == "false" ]]; then
+    log "SKIP_ORPHAN_READY_PR: '$wt_path' branch=$wt_branch issue=$issue_num pr=#$open_pr"
     continue
   fi
 

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2702,7 +2702,7 @@ sweep_setup() {
 STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
 args="$*"
 case "$args" in
-  "pr list --state all --json number,headRefName,state --limit 200")
+  "pr list --state all --json number,headRefName,state,isDraft --limit 200")
     cat "$STUB_DIR/gh-pr-list-all.json"
     ;;
   issue\ view\ *\ --json\ state\ -q\ .state)

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2671,8 +2671,11 @@ echo "=== dispatch-sweep ==="
 #
 # Shims:
 #   gh   — gh-pr-list-all.json drives `pr list --state all`; each entry carries
-#          {state, headRefName, number}, partitioned by the script into
-#          MERGED_BY_BRANCH / OPEN_BY_BRANCH.
+#          {state, headRefName, number, isDraft}, partitioned by the script into
+#          MERGED_BY_BRANCH / OPEN_BY_BRANCH / DRAFT_BY_BRANCH (the last for
+#          OPEN entries only). isDraft is required on OPEN entries — the
+#          SKIP_ORPHAN_READY_PR gate reads DRAFT_BY_BRANCH and an OPEN stub
+#          missing isDraft will silently bypass the gate.
 #   git  — knows worktree list/remove/prune, branch -D, -C <p> status,
 #          -C <p> rev-list --count, -C <p> log -1 --format=%ct, and
 #          rev-parse --path-format=absolute --git-common-dir.
@@ -3198,6 +3201,122 @@ if grep -q "ADOPT_ORPHAN" "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null; then
   FAIL=$((FAIL + 1)); echo "  FAIL: ADOPT_ORPHAN must NOT appear when issue is closed"
 else
   PASS=$((PASS + 1)); echo "  PASS: ADOPT_ORPHAN absent for closed-issue orphan"
+fi
+sweep_teardown
+
+# --- Test 12: open non-draft (ready) PR → orphan is skipped -------------------
+
+echo "Test: open non-draft (ready) PR orphan is skipped"
+sweep_setup
+WT_PATH="$TMPDIR_TEST/project/worktrees/63-ready-pr"
+sweep_register_wt "$WT_PATH" "63-ready-pr"
+KEY=$(sweep_path_key "$WT_PATH")
+echo "1500000004" > "$STUB_DIR/headct${KEY}.txt"
+# Register an open, non-draft PR for this branch.
+echo '[{"number":200,"headRefName":"63-ready-pr","state":"OPEN","isDraft":false}]' \
+  > "$STUB_DIR/gh-pr-list-all.json"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "ready-pr sweep exits 0" "0" "$rc"
+assert_eq "ready-pr stdout is empty" "" "$out"
+
+TOTAL=$((TOTAL + 1))
+if grep -q "SKIP_ORPHAN_READY_PR: '$WT_PATH' branch=63-ready-pr issue=63 pr=#200" "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: SKIP_ORPHAN_READY_PR log line for 63-ready-pr"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: SKIP_ORPHAN_READY_PR log line for 63-ready-pr"
+  sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q "ADOPT_ORPHAN" "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: ADOPT_ORPHAN must NOT appear for ready-PR orphan"
+else
+  PASS=$((PASS + 1)); echo "  PASS: ADOPT_ORPHAN absent for ready-PR orphan"
+fi
+sweep_teardown
+
+# --- Test 13: open draft PR → orphan still adopts -----------------------------
+
+echo "Test: open draft PR orphan still adopts (gate only skips non-draft)"
+sweep_setup
+WT_PATH="$TMPDIR_TEST/project/worktrees/64-draft-pr"
+sweep_register_wt "$WT_PATH" "64-draft-pr"
+KEY=$(sweep_path_key "$WT_PATH")
+echo "1500000005" > "$STUB_DIR/headct${KEY}.txt"
+echo '[{"number":201,"headRefName":"64-draft-pr","state":"OPEN","isDraft":true}]' \
+  > "$STUB_DIR/gh-pr-list-all.json"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "draft-pr sweep exits 0" "0" "$rc"
+assert_eq "draft-pr orphan adopted" "worktree 64 64-draft-pr" "$out"
+
+TOTAL=$((TOTAL + 1))
+if grep -q "SKIP_ORPHAN_READY_PR" "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: SKIP_ORPHAN_READY_PR must NOT fire for draft PR"
+else
+  PASS=$((PASS + 1)); echo "  PASS: SKIP_ORPHAN_READY_PR absent for draft-PR orphan"
+fi
+sweep_teardown
+
+# --- Test 14: ready-PR gate fires even when gh issue view fails ---------------
+#
+# Regression guard for the ordering of the orphan-classification gates: the
+# ready-PR gate uses the already-fetched DRAFT_BY_BRANCH map and must run
+# BEFORE the gh-dependent closed-issue gate. Otherwise a transient
+# `gh issue view` failure on a ready-PR orphan would exit 1 instead of
+# logging SKIP_ORPHAN_READY_PR — adoption was never warranted anyway, since
+# the PR is awaiting human merge.
+
+echo "Test: ready-PR gate fires even when gh issue view fails"
+sweep_setup
+WT_PATH="$TMPDIR_TEST/project/worktrees/65-ready-pr-gh-fail"
+sweep_register_wt "$WT_PATH" "65-ready-pr-gh-fail"
+KEY=$(sweep_path_key "$WT_PATH")
+echo "1500000006" > "$STUB_DIR/headct${KEY}.txt"
+echo '[{"number":202,"headRefName":"65-ready-pr-gh-fail","state":"OPEN","isDraft":false}]' \
+  > "$STUB_DIR/gh-pr-list-all.json"
+# Replace the gh shim so `issue view ... --json state -q .state` exits 1 —
+# simulating a transient gh failure for the issue-state fetch. `pr list` still
+# succeeds (uses the gh-pr-list-all.json fixture above).
+cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
+args="$*"
+case "$args" in
+  "pr list --state all --json number,headRefName,state,isDraft --limit 200")
+    cat "$STUB_DIR/gh-pr-list-all.json"
+    ;;
+  issue\ view\ *\ --json\ state\ -q\ .state)
+    echo "gh: simulated transient failure" >&2
+    exit 1
+    ;;
+  api\ */dependencies/blocked_by)
+    echo "[]"
+    ;;
+  *)
+    echo "gh sweep stub: unknown invocation: $args" >&2
+    exit 1
+    ;;
+esac
+STUB
+chmod +x "$TMPDIR_TEST/bin/gh"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "ready-pr-gh-fail sweep exits 0" "0" "$rc"
+assert_eq "ready-pr-gh-fail stdout is empty" "" "$out"
+
+TOTAL=$((TOTAL + 1))
+if grep -q "SKIP_ORPHAN_READY_PR: '$WT_PATH' branch=65-ready-pr-gh-fail issue=65 pr=#202" "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: SKIP_ORPHAN_READY_PR fires before failing issue-state gh call"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: SKIP_ORPHAN_READY_PR fires before failing issue-state gh call"
+  sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q "ERROR_ISSUE_STATE_FETCH" "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: ERROR_ISSUE_STATE_FETCH must NOT appear (ready-PR gate ran first)"
+else
+  PASS=$((PASS + 1)); echo "  PASS: ERROR_ISSUE_STATE_FETCH absent (closed-issue gate skipped)"
 fi
 sweep_teardown
 


### PR DESCRIPTION
## Summary

- `dispatch-sweep` adopted any orphan worktree whose issue was open and unblocked, even when the PR had already been flipped to ready by `/security-review-fix`. The repeated adoption short-circuited the topic-category × phase ladder and the chain drained on the derived `done`-phase early-stop.
- Add a third orphan-classification gate after the open-blocker check: when the branch has an open, non-draft PR, log `SKIP_ORPHAN_READY_PR` and skip. No-PR orphans and open-draft-PR orphans still adopt unchanged. The merged-cleanup pass still removes the worktree once the PR squash-merges.
- Step 3's `worktree-adopted` parenthetical in `dispatch/SKILL.md` now lists all three pre-emission gates and notes the intentional fall-through for `done`-phase orphans.

## Test plan

- [ ] Sandbox-disabled `dispatch-sweep` runs end-to-end (exit 0, log shape unchanged for ACTIVE/ORPHANED/ADOPT entries).
- [ ] With a ready-PR orphan present on disk, the log shows `SKIP_ORPHAN_READY_PR` for that worktree and no `ADOPT_ORPHAN` line for the same path.
- [ ] With a draft-PR orphan or a no-PR (issue-number-prefix only) orphan present, adoption proceeds as before.
- [ ] After the relevant PR squash-merges, the next sweep tick removes the worktree via the existing merged-cleanup pass.

Closes #843