### PR TITLE
dispatch: greenfield router/worker split

### DIFF
--- a/.claude/hooks/restore-dispatch-skill.sh
+++ b/.claude/hooks/restore-dispatch-skill.sh
@@ -19,8 +19,10 @@ REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 
 [ -f "$REPO_ROOT/tmp/dispatch-worktree" ] || exit 0
 
-# Emit reload instruction so Claude reloads /dispatch — it re-derives the phase
-# from PR/CI ground truth, so recovery is correct after a /clear in any phase.
-printf 'COMPACTION RECOVERY: Reload skill: /dispatch #%s\n' "$ISSUE_NUM"
+# Emit reload instruction so Claude reloads /dispatch-worker — the marker only
+# exists in worker worktrees (the router never writes it), so this recovery
+# always restores a worker. /dispatch-worker re-derives the phase from PR/CI
+# ground truth, so recovery is correct after a /clear in any phase.
+printf 'COMPACTION RECOVERY: Reload skill: /dispatch-worker %s\n' "$ISSUE_NUM"
 
 exit 0

--- a/.claude/skills/dispatch-qa/SKILL.md
+++ b/.claude/skills/dispatch-qa/SKILL.md
@@ -5,15 +5,14 @@ description: Post-implementation user-acceptance QA — single self-verifying pa
 
 # Dispatch: User-Acceptance QA
 
-Runs a single user-acceptance QA pass on an implemented PR. Invoked three ways:
+Runs a single user-acceptance QA pass on an implemented PR. Invoked two ways:
 
-- By the `/dispatch` skill — the session is already inside the target worktree.
-- Standalone with no argument — `/dispatch-qa` self-selects the highest-priority
-  QA-phase PR.
-- Standalone with an explicit `#<issue>` argument.
+- By the `/dispatch-worker` skill — the session is already inside the target
+  worktree (cwd set by `dispatch-spawn-worker` at spawn time).
+- Standalone from inside a target worktree with an optional `#<issue>` argument.
 
-**Step 0** resolves the target issue and its worktree for all three paths. The
-remaining steps use the Step-0-resolved issue number `<N>`.
+**Step 0** verifies the current worktree and derives the target issue number
+`<N>`. The remaining steps use that issue number.
 
 This skill is a **single QA pass** — the QA walkthrough runs once, with no
 iteration. (Step 5's bug-fix build loop iterates over plan units; that is a
@@ -49,41 +48,43 @@ The QA pass covers **public data only** — documents present in both the QA ser
 
 0. **Target resolution.**
 
-   Establish the target issue number `<N>` and ensure the session is in the
-   target's worktree. Precedence:
+   `/dispatch-qa` operates in place — the **current worktree dictates the target**.
+   The session must be in a target worktree: the current branch is `<N>-…`,
+   where `<N>` is the issue number. The router (`/dispatch`) is responsible
+   for entering a target worktree; this skill never switches.
 
-   1. **An issue/PR number argument is given** (leading `#` optional) → that issue
-      is the target. This overrides the `dispatch-select-target --qa`
-      prioritization below.
-   2. **Else the current branch matches `<issue>-*`** (the session is already inside
-      a target worktree) → use that issue number.
-   3. **Else** (standalone: no argument, not in a target worktree) → run:
-      ```bash
-      .claude/skills/dispatch/scripts/dispatch-select-target --qa
-      ```
-      It prints `pr <num> <branch>` (the highest-priority QA-phase PR) or `empty`.
-      On `empty`, report that there is no QA-phase work and **stop**. Otherwise the
-      printed PR's issue number is the target.
+   Verify the worktree and derive the issue number `<N>`:
 
-   Then, **when the session is not already in the target's worktree**, resolve or
-   create it via `EnterWorktree`, matching `/dispatch` Step 4. `EnterWorktree`
-   accepts exactly one of `path` (switch to an existing worktree) or `name`
-   (create a new one):
+   ```bash
+   BRANCH=$(basename "$(git rev-parse --show-toplevel)")
+   case "$BRANCH" in
+     [0-9]*-*) N="${BRANCH%%-*}" ;;
+     *)
+       echo "/dispatch-qa: current branch '$BRANCH' is not a target worktree (expected '<N>-…')" >&2
+       echo "Run '/dispatch <issue>' first to enter a target worktree." >&2
+       exit 1
+       ;;
+   esac
+   ```
 
-   - **Already in the target's worktree** (current branch starts with `<issue>-`) →
-     proceed to Step 0.5.
-   - **An existing worktree matches** `<issue>-*` (parse `git worktree list
-     --porcelain` as blank-line-delimited records) → `EnterWorktree` with `path:`
-     set to that path.
-   - **No existing worktree** → generate a sanitized branch name `<issue>-<slug>`:
-     lowercase the issue title, replace non-alphanumeric runs with `-`, collapse
-     repeated `-`, strip leading/trailing `-`, and truncate so the full branch name
-     is ≤ 32 characters. `EnterWorktree` with `name:` set to that branch name.
-     Creating via `name:` fires the `WorktreeCreate` hook, which runs
-     `sync-issue-context` and populates `CLAUDE.local.md` with full issue context.
+   If an `#<issue>` argument was given, confirm it matches the cwd:
 
-   Step 0 establishes the issue number `<N>` that the remaining steps use for their
-   `tmp/` filenames.
+   ```bash
+   # When $ARG is set (the argument, stripped of any leading '#'):
+   if [[ -n "${ARG:-}" && "$ARG" != "$N" ]]; then
+     echo "/dispatch-qa: argument '#$ARG' does not match current worktree's issue '#$N'" >&2
+     exit 1
+   fi
+   ```
+
+   If no argument was given and the current branch is not in a worktree
+   (the cwd assertion above already covered this), the skill bails out.
+   To pick a QA target without specifying one, run `/dispatch` from
+   `worktrees/main` — it selects the next QA-phase target and enters its
+   worktree, then dispatches this skill.
+
+   `<N>` is the issue number used by the remaining steps for their `tmp/`
+   filenames.
 
 0.5. **Merge `origin/main` into the working branch.**
 

--- a/.claude/skills/dispatch-qa/SKILL.md
+++ b/.claude/skills/dispatch-qa/SKILL.md
@@ -27,8 +27,8 @@ planning and `/implement-unit`'s build procedure.
 **Idempotency guard — check this first.** If an approved bug-fix plan for this
 dispatch is already present in context (typical after
 `showClearContextOnPlanAccept` fires — the user accepted the bug-fix plan and the
-context was cleared, causing `restore-dispatch-skill.sh` to re-enter `/dispatch`
-→ `/dispatch-qa`), **skip the QA walkthrough** — Step 0.5 and Steps 1–4 — and
+context was cleared, causing `restore-dispatch-skill.sh` to re-enter
+`/dispatch-worker` → `/dispatch-qa`), **skip the QA walkthrough** — Step 0.5 and Steps 1–4 — and
 resume directly at the build loop (Step 5, sub-step 3: build each unit via
 `/implement-unit`). Step 0 (target resolution) still runs: it re-establishes the
 issue number `<N>` and confirms the worktree from the current branch. The plan

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -254,7 +254,7 @@ fresh `/dispatch` (router) job back in `worktrees/main` (run with
 over a socket; see `.claude/rules/sandbox.md`):
 
 ```bash
-.claude/skills/dispatch/scripts/dispatch-spawn
+.claude/skills/dispatch/scripts/dispatch-spawn-router
 ```
 
 The worker spawns a `/dispatch` router, not another worker — the router will
@@ -271,7 +271,7 @@ ran and its outcome, or the reason it stopped early.
 **4. Terminal disposition.** Take exactly one of the following, in this
 priority:
 
-- **`dispatch-spawn` failed** — a phase-completed run whose step-2 spawn
+- **`dispatch-spawn-router` failed** — a phase-completed run whose step-2 spawn
   exited non-zero. Do **not** self-close. Report the failed baton-pass and
   stop, leaving this job open so the failure is visible and the spawn can be
   retried.
@@ -309,7 +309,7 @@ priority:
   the office-hours queue for human review.
 
 - **Clean completion or early-stop** — an early-stop, or a phase-completed run
-  whose `dispatch-spawn` succeeded and whose report surfaces nothing that needs
+  whose `dispatch-spawn-router` succeeded and whose report surfaces nothing that needs
   the user. Self-close (`dangerouslyDisableSandbox: true`):
 
   ```bash

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: dispatch-worker
+description: Worker for the dispatch chain — runs one phase skill in its target worktree, then hands off to a fresh `/dispatch` router
+---
+
+# Dispatch Worker
+
+The worker is the per-worktree execution half of the dispatch chain. The other
+half — `/dispatch` — is the router: it selects a target, resolves its worktree,
+and spawns this worker with `cwd=<worktree-path>`. The worker then derives the
+phase, runs exactly one phase skill, and hands off.
+
+The worker is born in the target worktree. It never calls `EnterWorktree` or
+`ExitWorktree`. Its cwd is anchored to the target worktree for its entire
+lifetime. That means `SessionStart`-derived attributes (title, restored skill
+set) and per-worktree sandbox concerns all naturally key on the right worktree
+— no mid-session cwd switch is needed.
+
+The worker takes an `<N>` argument — the issue number — and ends after one
+phase. The router is the one who decides what to work on next; the worker just
+executes.
+
+Run `gh` commands (`gh label create`, `gh pr edit`, and the scripts that invoke
+`gh`) with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
+
+## 0. Verify the Worker's Worktree
+
+The worker must be born in the target worktree. The spawn primitive
+(`dispatch-spawn-worker`) sets the worker's cwd at spawn time; this step is the
+worker's contract enforcement.
+
+```bash
+EXPECTED="<N>-"
+ACTUAL_BRANCH=$(basename "$(git rev-parse --show-toplevel)")
+case "$ACTUAL_BRANCH" in
+  ${EXPECTED}*) ;;
+  *)
+    echo "dispatch-worker invoked with wrong cwd: expected branch '${EXPECTED}…' under worktrees/, got '${ACTUAL_BRANCH}'" >&2
+    echo "The worker must be spawned with cwd already set to the target worktree." >&2
+    exit 1
+    ;;
+esac
+```
+
+If the assertion fails, **proceed to Step 4 (early-stop)** — do not derive a
+phase or run a phase skill.
+
+## 1. Derive the Phase
+
+Derive the phase via `dispatch-phase <N>`:
+
+```bash
+.claude/skills/dispatch/scripts/dispatch-phase <N>
+```
+
+It prints exactly one phase name. CI status is checked **before** labels — a
+draft PR with non-green CI is always `verify`, regardless of which `dispatch:*`
+labels are present.
+
+**Do not infer the phase from hand-rolled `gh` queries.** `dispatch-phase` is
+the only valid phase-derivation path. PR existence in particular **must not** be
+checked via title search (e.g. `gh pr list --search "<N> in:title"`) — a PR's
+title may not contain the issue number. The only correct PR-existence check is
+`dispatch-find-pr <N>`, which uses the `<issue>-` branch-prefix convention.
+
+Map the phase:
+
+| Phase | Meaning | Next action |
+|---|---|---|
+| `implement` | no PR on the target | relevance review (Step 3), then dispatch its verdict |
+| `verify` | draft PR, CI completed and failed | `/verify-pr` |
+| `waiting` | draft PR, CI in progress (running/queued/not started) | monitor CI to completion with a `sonnet` subagent, then re-derive the phase and dispatch it (Step 2) |
+| `qa` | draft PR, CI green, no `dispatch:*` label | `/dispatch-qa` |
+| `code-review` | draft PR + `dispatch:qa-done` | `/code-review-fix` (applies `dispatch:code-reviewed` itself) |
+| `review` | draft PR + `dispatch:code-reviewed` | `/review-fix` (applies `dispatch:reviewed` itself) |
+| `security` | draft PR + `dispatch:reviewed` (or `dispatch:security-reviewed` — re-entry; `/security-review-fix` is idempotent) | `/security-review-fix` (applies `dispatch:security-reviewed` and marks ready itself) |
+| `done` | non-draft (ready) PR | already complete — report, then Step 4 (early-stop) |
+
+## 2. Dispatch One Phase, Then Hand Off
+
+Invoke the one mapped phase skill via the Skill tool. Run exactly one phase per
+`/dispatch-worker` invocation.
+
+- **`implement`** — run the Step 3 relevance review and dispatch the verdict it
+  returns (`proceed` / `adjust` / `stop` — see Step 3). The draft PR's existence
+  plus its CI status is its own marker — `/plan-implement` gets **no**
+  `dispatch:*` label.
+- **`verify`** — invoke `/verify-pr`. It runs a single pass: fix one set of
+  failed CI checks, record the outcome, post it, stop. No label.
+- **`waiting`** — CI checks are still running or queued. Monitor them to
+  completion, then re-derive and dispatch the resolved phase within this same
+  `/dispatch-worker` invocation:
+  1. Resolve the draft PR number for the target.
+  2. Spawn a subagent via the Agent tool (`subagent_type: general-purpose`,
+     `model: sonnet`) that:
+     - first waits for CI to register at least one check — a freshly-pushed
+       branch can briefly have an empty check rollup;
+     - then runs `.claude/skills/dispatch/scripts/run-pr-checks-wait.sh
+       <pr-num>` with `dangerouslyDisableSandbox: true`, which blocks until
+       every check concludes;
+     - returns once all checks have completed.
+  3. After the subagent returns, re-run Step 1 (`dispatch-phase`) to re-derive
+     the phase from the now-complete CI, then dispatch the resolved phase per
+     this step — `/verify-pr` if any check failed, otherwise the green-CI
+     phases (`qa` / `code-review` / `review` / `security` / `ready`).
+  4. If the re-derived phase is still `waiting` (CI never registered any check),
+     report it, then **proceed to Step 4** (early-stop) — do not loop.
+- **`qa`** — invoke `/dispatch-qa`. It owns and applies `dispatch:qa-done`
+  itself on a clean pass; `/dispatch-worker` applies no label.
+- **`code-review`** — invoke `/code-review-fix`. It runs `/code-review max`,
+  applies the recommended fixes, defers important out-of-scope findings to
+  tracking issues, posts a PR comment, and applies the `dispatch:code-reviewed`
+  label itself — `/dispatch-worker` applies no label.
+- **`review`** — invoke `/review-fix`. It runs `/review`, applies the
+  recommended fixes, posts a PR comment, and applies the `dispatch:reviewed`
+  label itself — `/dispatch-worker` applies no label.
+- **`security`** — invoke `/security-review-fix`. Its Step 2 directly fans out
+  9 parallel subagents — 6 security domains, a red team, the built-in
+  `/security-review` scan (subagent-wrapped Skill invocation), and the PR's
+  CodeQL alerts — then applies the required fixes, posts a PR comment, applies
+  the `dispatch:security-reviewed` label, and marks the PR ready. It is
+  idempotent on re-entry — `/dispatch-worker` applies no label.
+- **`done`** — report that the PR is already ready, then **proceed to Step 4**
+  (early-stop). No phase skill ran.
+
+The PR stays a **draft** through every phase; the `security` phase's
+`/security-review-fix` flips it to ready as the workflow's terminal action.
+
+After the one phase skill has run to completion, **proceed to Step 4**
+(phase-completed) — do not advance to the next phase here; Step 4 hands off and
+ends the job.
+
+`/ultrareview` is intentionally **never** invoked: it is user-triggered and
+billed, so `/dispatch-worker` cannot launch it.
+
+### Applying the progress label
+
+The `dispatch:*` labels are the accumulating progress markers across the full
+workflow. `/dispatch-qa`, `/code-review-fix`, `/review-fix`, and
+`/security-review-fix` each own and apply their own label — `dispatch:qa-done`,
+`dispatch:code-reviewed`, `dispatch:reviewed`, and `dispatch:security-reviewed`
+respectively — so `/dispatch-worker` applies no `dispatch:*` label after any
+phase.
+
+When a phase skill runs `dispatch-complete-phase <pr-num> <phase>`, the PR
+number is expected to differ from the worktree's `<issue>-…` branch issue
+number; the PR↔issue linkage was established earlier by the router. The
+dispatching session must **not** pause to re-confirm — this is the expected
+shape of every phase-skill label apply.
+
+## 3. Pre-Implementation Relevance Review
+
+This step runs **only** for the `implement` phase — a no-PR target. Every phase
+with an existing PR (`verify` onward) skips it: implementation is already
+underway. It is the implementation-time counterpart of `ref-ready`'s Step 3e
+relevance check; the two are deliberately separate — Step 3e is creation-time
+and `$BASELINE_BRANCH`-anchored, this step is pre-implementation and
+`createdAt`-anchored.
+
+Before invoking `/plan-implement` on an `implement`-phase issue, confirm no PR
+exists for the target by running:
+
+```bash
+.claude/skills/dispatch/scripts/dispatch-find-pr <N>
+```
+
+If it prints a PR number, **skip this relevance review** and advance directly to
+Step 1 of this skill — a PR already exists and implementation is underway.
+
+If `dispatch-find-pr` prints nothing, run a creation-date-anchored drift
+analysis. First, fetch the issue's creation timestamp
+(`dangerouslyDisableSandbox: true` — `gh` needs network):
+
+```bash
+gh issue view <N> --json createdAt -q .createdAt
+```
+
+Then gather evidence of drift since that timestamp across the paths, references,
+and conventions the issue body names.
+
+### Drift-analysis inputs
+
+Inputs 1, 3, and 4 are independent — issue them in parallel (one message,
+multiple tool calls), together with input 2's initial list call. Input 2 then
+has a dependent per-PR follow-up once that list returns.
+
+1. **Commits since creation** — one `git log --since=<createdAt> -- <path1> <path2>
+   ...` across every file path the issue body names. Relevant commits indicate the
+   area is actively changing and may have shifted the issue's assumptions.
+
+2. **Merged PRs since creation that touched the same files** — list merged PRs in
+   the window (`dangerouslyDisableSandbox: true` — `gh` needs network):
+   ```bash
+   gh pr list --state merged --search "merged:>=<createdAt>" --limit 100
+   ```
+   If the result hits the limit, the drift window is too wide to analyze cheaply
+   — report that and recommend re-running `/ready` instead. Otherwise, for the
+   PRs whose titles plausibly relate to the issue's domain, fetch their changed
+   files and keep the ones overlapping the paths the issue names. Titles and
+   descriptions often surface whether the overlap is incidental or substantive.
+
+3. **Named-reference validity** — one `grep`/`rg` with all names alternated as a
+   single pattern. Names include any file paths, module names, function names, CLI
+   commands, env vars, or npm scripts the issue body cites. Flag anything renamed,
+   moved, or removed since the issue was created.
+
+4. **Convention drift** — re-read `CLAUDE.md` and any `.claude/rules/*.md` whose
+   domain the issue touches. Flag approaches the issue assumes that no longer match
+   current conventions (e.g. a deprecated pattern, a renamed package, a changed
+   config shape).
+
+Input 4 stays with the dispatching session. Inputs 1-3 may be handed to a
+one-shot subagent that returns a structured drift summary — decide this before
+the parallel dispatch so the calls are not run twice. The dispatching session
+always owns the verdict.
+
+### Three-way verdict
+
+- **`proceed`** — drift absent or cosmetic; invoke `/plan-implement`.
+- **`adjust`** — issue still wanted but references, conventions, or scope have
+  shifted; invoke `/new-requirement` with the drift findings as the revised
+  understanding, then `/plan-implement`.
+- **`stop`** — codebase has moved past the need; report what changed and
+  recommend closing the issue or re-running `/ready`. Do **not** invoke
+  `/plan-implement`; **proceed to Step 4** (early-stop).
+
+## 4. Hand off and self-close
+
+Every Step 0–3 termination routes here — Step 4 is the single way a
+`/dispatch-worker` job ends. A worker that just finished a phase passes the
+baton to a fresh `/dispatch` (router) job and self-closes; that hand-off keeps
+the dispatch chain moving.
+
+Each termination reaches Step 4 with one of two dispositions, named by the step
+that routed here:
+
+- **phase-completed** — a phase skill (`/plan-implement`, `/verify-pr`,
+  `/dispatch-qa`, `/code-review-fix`, `/review-fix`, or `/security-review-fix`)
+  ran to completion. Only the Step 2 post-dispatch hand-off arrives this way.
+- **early-stop** — the job stopped before any phase skill completed: a Step 0
+  cwd-verification failure, a `done` phase, a `waiting` phase that stayed
+  `waiting`, or an `implement` relevance verdict of `stop`.
+
+Run these in order.
+
+**1. No worktree to exit.** The worker was born in its target worktree and
+never entered another worktree mid-session — there is nothing to exit. The
+router (`/dispatch`) is what runs in `worktrees/main`; this worker's lifetime
+ends here, in its target worktree.
+
+**2. Pass the baton.** On the **phase-completed** disposition only, spawn a
+fresh `/dispatch` (router) job back in `worktrees/main` (run with
+`dangerouslyDisableSandbox: true` — the script reaches the local Claude daemon
+over a socket; see `.claude/rules/sandbox.md`):
+
+```bash
+.claude/skills/dispatch/scripts/dispatch-spawn
+```
+
+The worker spawns a `/dispatch` router, not another worker — the router will
+select the next target and spawn its worker. The script prints `spawned` (a
+successor was started) or `deduped` (another `dispatch-*` job is already
+running, so none was needed) and exits 0; it exits non-zero when a job was
+spawned but did not register. **early-stop** dispositions skip this step —
+they spawn no successor; the #725 heartbeat re-seeds the chain if it has
+drained.
+
+**3. Print the completion report.** State what this job did: the phase that
+ran and its outcome, or the reason it stopped early.
+
+**4. Terminal disposition.** Take exactly one of the following, in this
+priority:
+
+- **`dispatch-spawn` failed** — a phase-completed run whose step-2 spawn
+  exited non-zero. Do **not** self-close. Report the failed baton-pass and
+  stop, leaving this job open so the failure is visible and the spawn can be
+  retried.
+
+- **The report surfaces a deviation** — a phase-completed run whose step-2
+  spawn succeeded, but whose completion report surfaces a deviation from the
+  approved plan, or a result that does not fully satisfy the issue's acceptance
+  criteria. Do **not** self-close — self-closing would bury the deviation in a
+  closed job's transcript. The baton was already passed in step 2, so the chain
+  keeps moving; route this item to the office-hours queue for human review.
+  Resolve the PR for the target with
+  `.claude/skills/dispatch/scripts/dispatch-find-pr <N>` and apply the
+  `dispatch:office-hours` label to it (`gh`, `dangerouslyDisableSandbox: true`):
+
+  ```bash
+  gh pr edit <pr-num> --add-label dispatch:office-hours
+  ```
+
+  If that fails because the label does not exist yet, create it and retry —
+  the same apply-first / create-on-"not found" idiom `dispatch-complete-phase`
+  uses:
+
+  ```bash
+  gh label create dispatch:office-hours \
+    --description "dispatch workflow: blocked on a human — awaiting input or review"
+  gh pr edit <pr-num> --add-label dispatch:office-hours
+  ```
+
+  Pass no `--color`: `dispatch-complete-phase` is the single source of the
+  `dispatch:*` label-colour metadata, and #757 owns `dispatch:office-hours`'s
+  canonical definition — Step 4 only needs the label to exist.
+  `dispatch:office-hours` is the office-hours queue's marker, shared with #757,
+  whose input-block detection hooks are the label's other writer; whichever
+  writer runs first creates it. Then stop — report that the item is parked in
+  the office-hours queue for human review.
+
+- **Clean completion or early-stop** — an early-stop, or a phase-completed run
+  whose `dispatch-spawn` succeeded and whose report surfaces nothing that needs
+  the user. Self-close (`dangerouslyDisableSandbox: true`):
+
+  ```bash
+  .claude/skills/dispatch/scripts/dispatch-self-close
+  ```
+
+  The script stops the managed background job by its job-id (the basename of
+  `$CLAUDE_JOB_DIR`, which is what `claude stop` expects — not the conversation
+  session UUID, not the registry's `.sessionId`). It is a no-op when
+  `CLAUDE_JOB_DIR` is unset (the session is interactive, not a managed
+  background job) — so an interactive `/dispatch-worker` reaching Step 4 does
+  not stop the user's live conversation. The job ends; the router it spawned —
+  or, for an early-stop, the #725 heartbeat — carries the workflow forward.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -1,24 +1,29 @@
 ---
 name: dispatch
-description: Orchestrate the issue workflow — select the next task, derive its phase, and dispatch exactly one phase skill
+description: Orchestrate the issue workflow router — select the next task, resolve its worktree, and spawn a /dispatch-worker to run one phase
 ---
 
 # Dispatch
 
-Selects the single most pressing task, resolves its worktree, derives the current
-workflow phase from PR/issue status, and dispatches **exactly one phase skill** —
-then stops. Each `/dispatch` is a `claude --bg` background job (#725): a job
-advances one phase, passes the baton to a fresh `/dispatch` job, then
-self-deletes (`claude rm`). That self-perpetuating chain advances the
-workflow; the #725 heartbeat re-seeds it when no job is running.
+The dispatch router. Selects the single most pressing task, resolves its
+worktree, and spawns a `/dispatch-worker <N>` background job to run one phase
+in that worktree. The router itself runs no phase skill — it is a thin
+selection-and-spawn loop.
+
+Each `/dispatch` is a `claude --bg` background job (#725) rooted in
+`worktrees/main`. The router selects, spawns a worker, and exits. The worker
+runs one phase in its target worktree, then spawns a fresh `/dispatch` router
+back in `worktrees/main` and self-deletes. That router → worker → router
+chain advances the workflow; the #725 heartbeat re-seeds it when no job is
+running.
 
 `/dispatch` takes an **optional issue-or-PR-number argument** (leading `#`
 optional). With an argument, it targets that issue and skips the queue scan; a
 PR number is resolved to the issue that PR closes (see Step 3).
 
 Run `/dispatch` from the **main worktree**, or from inside an issue worktree to
-continue that issue. Step 5 switches into the target's worktree via `EnterWorktree`;
-the phase skill runs there.
+continue that issue. The router never enters a worktree; it materializes the
+target worktree (if needed) and spawns the worker into it.
 
 Run `gh` commands (`gh label create`, `gh pr edit`, and the scripts that invoke
 `gh`) with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
@@ -52,14 +57,13 @@ Route on `$LOCK`:
 - **`busy`** → the wait timeout elapsed without acquiring — a wedged selection
   in another `/dispatch`. The script's **stderr** carries a one-line diagnostic
   naming the wait duration and the holding sessionId; report those then **proceed
-  to Step 9** (early-stop) — run no sync, no health gate, no sweep, no selection,
+  to Step 7** (early-stop) — run no sync, no health gate, no sweep, no selection,
   and no phase skill.
 
 ### Releasing the lock
 
 The lock covers **Steps 0-5 only** — target selection and worktree resolution.
-Steps 6-9 (the phase skill, the pre-implementation relevance review, and the
-hand-off) run with the lock **released**.
+Step 6 (the worker spawn) runs with the lock **released**.
 
 Release the lock by running:
 
@@ -77,7 +81,7 @@ Release happens at exactly two kinds of point:
 - **Proceed path** — as the final action of Step 5, after the
   `tmp/dispatch-worktree` marker is written, before Step 6.
 - **Every Steps 1-5 stop path** — immediately before reporting the stop reason
-  and proceeding to Step 9 (early-stop).
+  and proceeding to Step 7 (early-stop).
 
 Releasing after Step 5 is safe because the session then owns a worktree (or has
 stopped), and the selection scan skips worktree'd targets — no other tick can
@@ -96,8 +100,8 @@ sessionId matches the re-entering session's own `CLAUDE_CODE_SESSION_ID`.
 ## 1. Sync local main with `origin/main`
 
 Run this step **only when the current branch is `main`**. From an issue worktree,
-skip this step — phase skills (`/verify-pr`, `/security-review-fix`) already merge
-`origin/main` into the issue branch at their own entry points.
+skip this step — the worker's phase skills already merge `origin/main` into the
+issue branch at their own entry points.
 
 Fast-forward local `main` to `origin/main` — no push:
 
@@ -109,7 +113,7 @@ It is a no-op when local `main` already equals `origin/main`.
 
 - If `git fetch` fails, or `git merge --ff-only` rejects a non-fast-forward (local
   `main` has diverged with unexpected commits), release the lock (see *Releasing
-  the lock*), surface the error, then **proceed to Step 9** (early-stop) — do
+  the lock*), surface the error, then **proceed to Step 7** (early-stop) — do
   not proceed to target selection.
 
 ## 2. Run the JIT Engine
@@ -153,7 +157,7 @@ continue to target selection.
   - **Exit 0** → `$TARGET` is the target issue number; that issue is the target.
     Skip the queue scan.
   - **Non-zero exit** → release the lock (see *Releasing the lock*), report the
-    script's stderr message, then **proceed to Step 9** (early-stop); create no
+    script's stderr message, then **proceed to Step 7** (early-stop); create no
     worktree. This covers a PR
     that closes no issue, a PR that closes more than one issue, and an argument
     that is neither an issue nor a PR — consistent with the other Steps 1-5 stop
@@ -178,7 +182,7 @@ continue to target selection.
   - `worktree-closed <N> <branch>` — the current branch is `<N>-…` and issue
     `<N>` is closed or unrecognized. Release the lock (see *Releasing the
     lock*), report that the current worktree belongs to closed/unrecognized
-    issue `<N>`, then **proceed to Step 9** (early-stop) (consistent with the
+    issue `<N>`, then **proceed to Step 7** (early-stop) (consistent with the
     named-target "closed → report and stop" rule in Step 4).
   - `worktree-adopted <N> <branch>` — `dispatch-sweep` adopted an orphaned
     worktree elsewhere on disk. Skip Step 4 and proceed to Step 5 with `<N>` and
@@ -208,7 +212,7 @@ continue to target selection.
   - `jit-reminder <repo> <num> <project> <item-id>` — see the **jit-reminder
     handler** at the end of this step.
   - `empty` — nothing eligible. Release the lock (see *Releasing the lock*),
-    report that the queue is empty, then **proceed to Step 9** (early-stop).
+    report that the queue is empty, then **proceed to Step 7** (early-stop).
 
   An **explicit issue argument overrides current-worktree detection** — the
   selection script, and therefore its current-worktree detection, runs only
@@ -259,7 +263,7 @@ continue to target selection.
   the check-runs response. These diagnostic `gh` calls run before the stop —
   keep them. Then, as the action immediately before the final report, release
   the lock (see *Releasing the lock*); summarize the likely cause, report it,
-  then **proceed to Step 9** (early-stop). Once a PR that fixes main exists the
+  then **proceed to Step 7** (early-stop). Once a PR that fixes main exists the
   normal ladder picks it up
   (verify/ready) — this gate only blocks starting new, unrelated work.
 
@@ -297,9 +301,9 @@ continue to target selection.
      reminder, framed as the most-overdue / soonest-due JIT reminder the scan
      surfaced. The `jit-reminder` line carries no due timestamp — do not state a
      precise computed due time.
-  4. **Stop the tick — bypass Step 9.** The handler stops directly without
-     routing through Step 9: the summary just printed must stay open in the
-     transcript for a human to read, and Step 9's terminal disposition would
+  4. **Stop the tick — bypass Step 7.** The handler stops directly without
+     routing through Step 7: the summary just printed must stay open in the
+     transcript for a human to read, and Step 7's terminal disposition would
      self-close the job and hide it. The `In Progress` status the claim wrote
      stops a later `/dispatch` tick from re-selecting this issue.
 
@@ -344,11 +348,11 @@ Skip leaf tracing when:
 If the resolved target issue `<N>` has any **open** blocker — run
 `issue-blocking <N>` and check for any entry with `state` `OPEN` — release the
 lock (see *Releasing the lock*), report the open blocker, then **proceed to
-Step 9** (early-stop). This guard applies even when a PR exists; closed blockers
+Step 7** (early-stop). This guard applies even when a PR exists; closed blockers
 do not gate.
 
 If a named target issue is **closed**, release the lock (see *Releasing the
-lock*), report it, then **proceed to Step 9** (early-stop).
+lock*), report it, then **proceed to Step 7** (early-stop).
 
 ## 5. Resolve the Worktree
 
@@ -359,35 +363,63 @@ an explicit `/dispatch` argument, otherwise `queue`:
 .claude/skills/dispatch/scripts/dispatch-resolve-worktree <N> <explicit|queue>
 ```
 
-It prints exactly one decision line — act on it. `EnterWorktree` accepts exactly
-one of `path` (switch to an existing worktree) or `name` (create a new one).
+It prints exactly one decision line — act on it. Each branch resolves to a
+worktree path that Step 6 will pass to `dispatch-spawn-worker`.
 
-- **`here`** → the current branch already is the target's worktree; no
-  `EnterWorktree` needed. Re-sync issue context:
+- **`here`** → the current branch already is the target's worktree. Set
+  `WORKTREE_PATH="$(git rev-parse --show-toplevel)"` for Step 6. Re-sync issue
+  context (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls
+  `gh`):
   ```bash
   .claude/skills/dispatch/scripts/sync-issue-context <N>
   ```
-  (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.)
+
 - **`enter <path>`** → re-use an existing `<issue>-*` worktree (the
-  recycle-after-completion case, reached only for an explicit argument).
-  `EnterWorktree` with `path:` set to `<path>`. After entering, re-sync issue
-  context from the worktree:
+  recycle-after-completion case, reached only for an explicit argument). Set
+  `WORKTREE_PATH=<path>` for Step 6. Re-sync issue context from the worktree
+  (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`):
   ```bash
-  .claude/skills/dispatch/scripts/sync-issue-context <N>
+  (cd <path> && .claude/skills/dispatch/scripts/sync-issue-context <N>)
   ```
-  (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`.)
-- **`create <branch>`** → no worktree exists. `EnterWorktree` with `name:` set to
-  `<branch>`. This fires the `WorktreeCreate` hook, which runs `sync-issue-context`
-  and populates `CLAUDE.local.md` with full issue context.
+
+- **`create <branch>`** → no worktree exists. The router materializes it
+  explicitly. The `WorktreeCreate` hook does not fire on this path; this step
+  takes over the hook's responsibilities for the dispatch-chain case.
+
+  1. Resolve the worktree path. The project root is the parent of
+     `--git-common-dir` (same idiom `dispatch-acquire-lock` and the hook use):
+     ```bash
+     GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
+     PROJECT_ROOT=$(dirname "$GIT_COMMON_DIR")
+     WORKTREE_PATH="$PROJECT_ROOT/worktrees/<branch>"
+     ```
+  2. Create the worktree from `origin/main` so the new branch is current:
+     ```bash
+     git worktree add -b <branch> "$WORKTREE_PATH" origin/main
+     ```
+     This is sandbox-allowed under `worktrees/` and `.bare/worktrees/` — see
+     `.claude/rules/sandbox.md`.
+  3. Authorize `.envrc` for the new tree
+     (`dangerouslyDisableSandbox: true` — direnv writes to its on-disk cache
+     outside the sandbox-allowlist):
+     ```bash
+     direnv allow "$WORKTREE_PATH"
+     ```
+  4. Populate `CLAUDE.local.md` with full issue context
+     (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`):
+     ```bash
+     (cd "$WORKTREE_PATH" && .claude/skills/dispatch/scripts/sync-issue-context <N>)
+     ```
+
 - **`conflict <path>`** → a queue-selected target already has a worktree, so
   another session owns it. (`dispatch-select-target` resolves the `help wanted`
   tier to a leaf with no worktree, so for a queue selection this arises only from
   a race — another session created the worktree between selection and worktree
   resolution.) Release the lock (see *Releasing the lock*), then report the
-  conflict (name `<path>` and issue `<N>`), then **proceed to Step 9**
-  (early-stop); do not `EnterWorktree`.
+  conflict (name `<path>` and issue `<N>`), then **proceed to Step 7**
+  (early-stop); do not spawn a worker.
 
-On every non-`conflict` path, before any phase skill runs, create the recovery
+On every non-`conflict` path, before the worker is spawned, create the recovery
 marker:
 
 ```bash
@@ -402,299 +434,59 @@ git-ignored, and removing the worktree removes it.
 
 As the **final action of this step on every non-`conflict` (proceed) path** —
 after the marker is written, before Step 6 — release the lock (see *Releasing
-the lock*). The phase skill in Step 6 onward runs lock-free.
+the lock*). The worker in Step 6 onward runs lock-free.
 
-## 6. Derive the Phase
+## 6. Spawn the Worker
 
-When the target is a **queue-selected PR** (`pr <num> <branch> <phase>` from Step 3),
-the phase is already on the result line — use it directly and skip the script below.
-
-On every other path — an explicit issue argument, a `worktree <N>` result, or a
-queue-selected `issue <num>` — run the phase script against the final target
-(issue number or branch):
-
-```bash
-.claude/skills/dispatch/scripts/dispatch-phase <target>
-```
-
-It prints exactly one phase name. CI status is checked **before** labels — a draft PR
-with non-green CI is always `verify`, regardless of which `dispatch:*` labels are
-present.
-
-**Do not infer the phase from hand-rolled `gh` queries.** `dispatch-phase` is the
-only valid phase-derivation path (or the pre-derived `<phase>` field from
-`dispatch-select-target` for queue-selected PRs). PR existence in particular
-**must not** be checked via title search (e.g. `gh pr list --search "<N> in:title"`)
-— a PR's title may not contain the issue number. The only correct PR-existence check
-is `dispatch-find-pr <N>`, which uses the `<issue>-` branch-prefix convention.
-
-Map the phase:
-
-| Phase | Meaning | Next action |
-|---|---|---|
-| `implement` | no PR on the target | relevance review (Step 8), then dispatch its verdict |
-| `verify` | draft PR, CI completed and failed | `/verify-pr` |
-| `waiting` | draft PR, CI in progress (running/queued/not started) | monitor CI to completion with a `sonnet` subagent, then re-derive the phase and dispatch it (Step 7) |
-| `qa` | draft PR, CI green, no `dispatch:*` label | `/dispatch-qa` |
-| `code-review` | draft PR + `dispatch:qa-done` | `/code-review-fix` (applies `dispatch:code-reviewed` itself) |
-| `review` | draft PR + `dispatch:code-reviewed` | `/review-fix` (applies `dispatch:reviewed` itself) |
-| `security` | draft PR + `dispatch:reviewed` (or `dispatch:security-reviewed` — re-entry; `/security-review-fix` is idempotent) | `/security-review-fix` (applies `dispatch:security-reviewed` and marks ready itself) |
-| `done` | non-draft (ready) PR | already complete — report, then Step 9 (early-stop) |
-
-## 7. Dispatch One Phase, Then Stop
-
-Invoke the one mapped phase skill via the Skill tool. Run exactly one phase per
-`/dispatch` invocation.
-
-- **`implement`** — run the Step 8 relevance review and dispatch the verdict it
-  returns (`proceed` / `adjust` / `stop` — see Step 8). The draft PR's existence
-  plus its CI status is its own marker — `/plan-implement` gets **no**
-  `dispatch:*` label.
-- **`verify`** — invoke `/verify-pr`. It runs a single pass: fix one set of failed
-  CI checks, record the outcome, post it, stop. No label.
-- **`waiting`** — CI checks are still running or queued. Monitor them to
-  completion, then re-derive and dispatch the resolved phase within this same
-  `/dispatch` invocation:
-  1. Resolve the draft PR number for the target.
-  2. Spawn a subagent via the Agent tool (`subagent_type: general-purpose`,
-     `model: sonnet`) that:
-     - first waits for CI to register at least one check — a freshly-pushed
-       branch can briefly have an empty check rollup;
-     - then runs `.claude/skills/dispatch/scripts/run-pr-checks-wait.sh
-       <pr-num>` with `dangerouslyDisableSandbox: true`, which blocks until
-       every check concludes;
-     - returns once all checks have completed.
-  3. After the subagent returns, re-run Step 6 (`dispatch-phase`) to re-derive
-     the phase from the now-complete CI, then dispatch the resolved phase per
-     this step — `/verify-pr` if any check failed, otherwise the green-CI
-     phases (`qa` / `code-review` / `review` / `security` / `ready`).
-  4. If the re-derived phase is still `waiting` (CI never registered any check),
-     report it, then **proceed to Step 9** (early-stop) — do not loop.
-- **`qa`** — invoke `/dispatch-qa`. It owns and applies `dispatch:qa-done` itself on
-  a clean pass; `/dispatch` applies no label.
-- **`code-review`** — invoke `/code-review-fix`. It runs `/code-review max`, applies the
-  recommended fixes, defers important out-of-scope findings to tracking issues,
-  posts a PR comment, and applies the `dispatch:code-reviewed` label itself —
-  `/dispatch` applies no label.
-- **`review`** — invoke `/review-fix`. It runs `/review`, applies the recommended
-  fixes, posts a PR comment, and applies the `dispatch:reviewed` label itself —
-  `/dispatch` applies no label.
-- **`security`** — invoke `/security-review-fix`. Its Step 2 directly fans out
-  9 parallel subagents — 6 security domains, a red team, the built-in
-  `/security-review` scan (subagent-wrapped Skill invocation), and the PR's
-  CodeQL alerts — then applies the required fixes, posts a PR comment, applies
-  the `dispatch:security-reviewed` label, and marks the PR ready. It is
-  idempotent on re-entry — `/dispatch` applies no label.
-- **`done`** — report that the PR is already ready, then **proceed to Step 9**
-  (early-stop). No phase skill ran, so Step 9 spawns no successor and
-  self-closes.
-
-The PR stays a **draft** through every phase; the `security` phase's
-`/security-review-fix` flips it to ready as the workflow's terminal action.
-
-After the one phase skill has run to completion, **proceed to Step 9**
-(phase-completed) — do not advance to the next phase here; Step 9 hands off and
-ends the job.
-
-`/ultrareview` is intentionally **never** invoked: it is user-triggered and billed,
-so `/dispatch` cannot launch it.
-
-### Applying the progress label
-
-The `dispatch:*` labels are the accumulating progress markers across the full
-workflow. `/dispatch-qa`, `/code-review-fix`, `/review-fix`, and
-`/security-review-fix` each own and apply their own label — `dispatch:qa-done`,
-`dispatch:code-reviewed`, `dispatch:reviewed`, and `dispatch:security-reviewed`
-respectively — so `/dispatch` applies no `dispatch:*` label after any phase.
-
-When a phase skill runs `dispatch-complete-phase <pr-num> <phase>`, the PR
-number is expected to differ from the worktree's `<issue>-…` branch issue
-number; the PR↔issue linkage was established earlier in the tick by
-`dispatch-resolve-arg`, `dispatch-find-pr`, or `dispatch-select-target`'s
-`pr <num> <branch> <phase>` selection result. The dispatching session must
-**not** pause to re-confirm — this is the expected shape of every
-phase-skill label apply.
-
-## 8. Pre-Implementation Relevance Review
-
-This step runs **only** for the `implement` phase — a no-PR target. Every phase
-with an existing PR (`verify` onward) skips it: implementation is already
-underway. It is the implementation-time counterpart of `ref-ready`'s Step 3e
-relevance check; the two are deliberately separate — Step 3e is creation-time
-and `$BASELINE_BRANCH`-anchored, this step is pre-implementation and
-`createdAt`-anchored.
-
-Before invoking `/plan-implement` on an `implement`-phase issue, confirm no PR
-exists for the target by running:
-
-```bash
-.claude/skills/dispatch/scripts/dispatch-find-pr <N>
-```
-
-If it prints a PR number, **skip this relevance review** and advance directly to
-phase derivation (Step 6) — a PR already exists and implementation is underway.
-
-If `dispatch-find-pr` prints nothing, run a creation-date-anchored drift
-analysis. First, fetch the issue's creation timestamp
-(`dangerouslyDisableSandbox: true` — `gh` needs network):
-
-```bash
-gh issue view <N> --json createdAt -q .createdAt
-```
-
-Then gather evidence of drift since that timestamp across the paths, references, and
-conventions the issue body names.
-
-### Drift-analysis inputs
-
-Inputs 1, 3, and 4 are independent — issue them in parallel (one message,
-multiple tool calls), together with input 2's initial list call. Input 2 then
-has a dependent per-PR follow-up once that list returns.
-
-1. **Commits since creation** — one `git log --since=<createdAt> -- <path1> <path2>
-   ...` across every file path the issue body names. Relevant commits indicate the
-   area is actively changing and may have shifted the issue's assumptions.
-
-2. **Merged PRs since creation that touched the same files** — list merged PRs in
-   the window (`dangerouslyDisableSandbox: true` — `gh` needs network):
-   ```bash
-   gh pr list --state merged --search "merged:>=<createdAt>" --limit 100
-   ```
-   If the result hits the limit, the drift window is too wide to analyze cheaply
-   — report that and recommend re-running `/ready` instead. Otherwise, for the
-   PRs whose titles plausibly relate to the issue's domain, fetch their changed
-   files and keep the ones overlapping the paths the issue names. Titles and
-   descriptions often surface whether the overlap is incidental or substantive.
-
-3. **Named-reference validity** — one `grep`/`rg` with all names alternated as a
-   single pattern. Names include any file paths, module names, function names, CLI
-   commands, env vars, or npm scripts the issue body cites. Flag anything renamed,
-   moved, or removed since the issue was created.
-
-4. **Convention drift** — re-read `CLAUDE.md` and any `.claude/rules/*.md` whose
-   domain the issue touches. Flag approaches the issue assumes that no longer match
-   current conventions (e.g. a deprecated pattern, a renamed package, a changed
-   config shape).
-
-Input 4 stays with the dispatching session. Inputs 1-3 may be handed to a
-one-shot subagent that returns a structured drift summary — decide this before
-the parallel dispatch so the calls are not run twice. The dispatching session
-always owns the verdict.
-
-### Three-way verdict
-
-- **`proceed`** — drift absent or cosmetic; invoke `/plan-implement`.
-- **`adjust`** — issue still wanted but references, conventions, or scope have
-  shifted; invoke `/new-requirement` with the drift findings as the revised
-  understanding, then `/plan-implement`.
-- **`stop`** — codebase has moved past the need; report what changed and recommend
-  closing the issue or re-running `/ready`. Do **not** invoke `/plan-implement`;
-  **proceed to Step 9** (early-stop).
-
-## 9. Hand off and self-close
-
-Every Step 0–8 termination routes here — Step 9 is the single way a `/dispatch`
-job ends. A job that just finished a phase passes the baton to a fresh
-`/dispatch` job and self-closes; that self-perpetuating chain, re-seeded by the
-#725 heartbeat, is what advances the workflow.
-
-The one documented exception is the **jit-reminder handler** in Step 3: by
-design it bypasses Step 9 and stops directly, because its user-visible summary
-must stay open in the transcript for a human to read — self-closing the job
-would hide it. See the jit summary session note at the end of Step 3.
-
-Each termination reaches Step 9 with one of two dispositions, named by the step
-that routed here:
-
-- **phase-completed** — a phase skill (`/plan-implement`, `/verify-pr`,
-  `/dispatch-qa`, `/code-review-fix`, `/review-fix`, or `/security-review-fix`)
-  ran to completion. Only the Step 7 post-dispatch hand-off arrives this way.
-- **early-stop** — the job stopped before any phase skill ran: a busy lock, a
-  fetch / non-fast-forward failure, an empty queue, `main-broken`, a resolver
-  failure, a `worktree-closed` or closed-issue target, a worktree `conflict`, a
-  `waiting` phase that stayed `waiting`, a `done` PR, or an `implement`
-  relevance verdict of `stop`.
-
-Run these in order.
-
-**1. Return to the main worktree.** If this job entered an issue worktree via
-`EnterWorktree` in Step 5 (the `enter` and `create` outcomes), call
-`ExitWorktree` with `action: "keep"`: return to the main worktree and leave the
-issue worktree on disk as an adoptable orphan. This must run **before** the
-step-2 spawn, so the successor's selection scan does not misread this
-still-finishing job as a live session owning the issue worktree. `ExitWorktree`
-is a no-op when `EnterWorktree` was not called this session, so it is harmless
-on the early stops that never reached a worktree.
-
-**2. Pass the baton.** On the **phase-completed** disposition only, spawn the
-successor `/dispatch` job (run with `dangerouslyDisableSandbox: true` — the
+Spawn a `/dispatch-worker <N>` background job with `cwd=$WORKTREE_PATH` (the
+path resolved in Step 5). Run with `dangerouslyDisableSandbox: true` — the
 script reaches the local Claude daemon over a socket; see
-`.claude/rules/sandbox.md`):
+`.claude/rules/sandbox.md`:
 
 ```bash
-.claude/skills/dispatch/scripts/dispatch-spawn
+.claude/skills/dispatch/scripts/dispatch-spawn-worker <N> "$WORKTREE_PATH"
 ```
 
-It prints `spawned` (a successor was started) or `deduped` (another `dispatch-*`
-job is already running, so none was needed) and exits 0; it exits non-zero when
-a job was spawned but did not register. **early-stop** dispositions skip this
-step — they spawn no successor; the #725 heartbeat re-seeds the chain if it has
-drained.
+It prints `spawned` (a worker was started) or `deduped` (another `dispatch-*`
+session is already live at `$WORKTREE_PATH` — the per-worktree invariant
+prevents two workers from racing on the same worktree) and exits 0; it exits
+non-zero when a worker was spawned but did not register.
 
-**3. Print the completion report.** State what this job did: the phase that ran
-and its outcome, or the reason it stopped early.
+The router never derives the phase, runs a phase skill, or invokes the
+pre-implementation relevance review — those are the worker's responsibilities
+(`/dispatch-worker` Steps 1–3).
 
-**4. Terminal disposition.** Take exactly one of the following, in this
-priority:
+After the spawn returns, **proceed to Step 7** (terminal disposition).
 
-- **`dispatch-spawn` failed** — a phase-completed run whose step-2 spawn exited
-  non-zero. Do **not** self-close. Report the failed baton-pass and stop,
-  leaving this job open so the failure is visible and the spawn can be retried.
+## 7. Terminal Disposition
 
-- **The report surfaces a deviation** — a phase-completed run whose step-2
-  spawn succeeded, but whose completion report surfaces a deviation from the
-  approved plan, or a result that does not fully satisfy the issue's acceptance
-  criteria. Do **not** self-close — self-closing would bury the deviation in a
-  closed job's transcript. The baton was already passed in step 2, so the chain
-  keeps moving; route this item to the office-hours queue for human review.
-  Resolve the PR for the target with
-  `.claude/skills/dispatch/scripts/dispatch-find-pr <N>` and apply the
-  `dispatch:office-hours` label to it (`gh`, `dangerouslyDisableSandbox: true`):
+The router's tick ends here. There are two dispositions:
 
-  ```bash
-  gh pr edit <pr-num> --add-label dispatch:office-hours
-  ```
+- **spawn-failed** — the Step 6 `dispatch-spawn-worker` call exited non-zero
+  (a worker was spawned but did not register). Do **not** self-close. Report
+  the failed spawn and stop, leaving this router job open so the failure is
+  visible and the spawn can be retried.
 
-  If that fails because the label does not exist yet, create it and retry —
-  the same apply-first / create-on-"not found" idiom `dispatch-complete-phase`
-  uses:
+- **clean completion or early-stop** — every other terminal path:
+  - Step 6 returned `spawned` or `deduped` (clean completion).
+  - A Steps 0–5 stop path (busy lock, sync failure, empty queue, `main-broken`,
+    resolver failure, `worktree-closed`, closed-issue target, open-blocker
+    gate, `worktree` conflict, jit-reminder summary). The jit-reminder
+    summary is an exception that **does not self-close** — it bypasses Step 7
+    entirely, per the jit-reminder handler in Step 3.
 
-  ```bash
-  gh label create dispatch:office-hours \
-    --description "dispatch workflow: blocked on a human — awaiting input or review"
-  gh pr edit <pr-num> --add-label dispatch:office-hours
-  ```
-
-  Pass no `--color`: `dispatch-complete-phase` is the single source of the
-  `dispatch:*` label-colour metadata, and #757 owns `dispatch:office-hours`'s
-  canonical definition — Step 9 only needs the label to exist.
-  `dispatch:office-hours` is the office-hours queue's marker, shared with #757,
-  whose input-block detection hooks are the label's other writer; whichever
-  writer runs first creates it. Then stop — report that the item is parked in
-  the office-hours queue for human review.
-
-- **Clean completion or early-stop** — an early-stop, or a phase-completed run
-  whose `dispatch-spawn` succeeded and whose report surfaces nothing that needs
-  the user. Self-delete (`dangerouslyDisableSandbox: true`):
+  Self-close (`dangerouslyDisableSandbox: true`):
 
   ```bash
   .claude/skills/dispatch/scripts/dispatch-self-close
   ```
 
-  The script deletes the managed background job by its job-id (the basename of
-  `$CLAUDE_JOB_DIR`, which is what `claude rm` expects — not the conversation
-  session UUID, not the registry's `.sessionId`). It is a no-op when
-  `CLAUDE_JOB_DIR` is unset (the session is interactive, not a managed
-  background job) — so an interactive `/dispatch` reaching Step 9 does not delete
-  the user's live conversation. The job ends; the successor it spawned — or,
-  for an early-stop, the #725 heartbeat — carries the workflow forward.
+  The script removes the managed background job by its job-id (the basename of
+  `$CLAUDE_JOB_DIR`). It is a no-op when `CLAUDE_JOB_DIR` is unset (the
+  session is interactive, not a managed background job) — so an interactive
+  `/dispatch` reaching Step 7 does not stop the user's live conversation.
+
+The router does **not** spawn a successor `/dispatch` itself — the worker
+spawned in Step 6 will spawn a fresh router back in `worktrees/main` when its
+phase completes (`/dispatch-worker` Step 4). For early-stop dispositions, no
+worker was spawned; the #725 heartbeat re-seeds the chain if it has drained.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -83,10 +83,12 @@ Release happens at exactly two kinds of point:
 - **Every Steps 1-5 stop path** — immediately before reporting the stop reason
   and proceeding to Step 7 (early-stop).
 
-Releasing after Step 5 is safe because the session then owns a worktree (or has
-stopped), and the selection scan skips worktree'd targets — no other tick can
-select the same issue. Later steps cross-reference *Releasing the lock* rather
-than repeating this command.
+Releasing after Step 5 is safe because (a) the session then owns a worktree
+(or has stopped) and the selection scan skips worktree'd targets, so no other
+router can select the same issue; and (b) Step 6's `dispatch-spawn-worker`
+enforces per-worktree dedup at the spawn boundary, so even if a race let two
+routers reach Step 6 with the same target, only one worker would start. Later
+steps cross-reference *Releasing the lock* rather than repeating this command.
 
 The lock is scoped to selection and self-healing. The recorded sessionId
 (`CLAUDE_CODE_SESSION_ID`) outlives any single Bash call within a tick: if a
@@ -96,6 +98,34 @@ and a `--wait` waiter re-checks holder liveness every poll, so a dead holder's
 lock is reclaimed automatically. Same-session re-entry (e.g. after a context
 clear that re-invokes `/dispatch`) re-acquires cleanly because the recorded
 sessionId matches the re-entering session's own `CLAUDE_CODE_SESSION_ID`.
+
+### Per-worktree invariant
+
+The selection lock above is **per-repo** and serializes the router's selection
+step (so two routers cannot race on the same target). It is one of two
+mechanisms; the other is per-worktree and enforced elsewhere.
+
+The **per-worktree invariant**: at most one live `dispatch-*` agent per issue
+worktree. The router's Step 6 spawn primitive (`dispatch-spawn-worker`)
+enforces this at the spawn boundary by querying
+`claude agents --json --cwd <worktree-path>` (the `claude_sessions_under`
+helper in `lib-claude-agents.sh`). If any live `dispatch-*` agent is already
+under `<worktree-path>`, the spawn is `deduped` and no new worker starts. The
+worker is born in the target worktree and dies there; per-worktree dedup
+naturally serializes per-issue work without the selection lock having to.
+
+The two mechanisms have orthogonal scopes:
+
+- **Selection lock** (this section) — per-repo, held by the router for the
+  duration of Steps 1–5. Prevents two routers from selecting the same target.
+- **Per-worktree dedup** (`dispatch-spawn-worker`) — per-worktree-path,
+  enforced at every router-to-worker spawn. Prevents two workers from racing
+  on the same issue.
+
+N concurrent issues in flight = N concurrent workers, each in its own
+worktree, each advancing its own issue's phase without contention. Only the
+router selection step is serialized; the worker execution path is per-
+worktree-parallel.
 
 ## 1. Sync local main with `origin/main`
 

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -429,12 +429,18 @@ worktree path that Step 6 will pass to `dispatch-spawn-worker`.
      ```
      This is sandbox-allowed under `worktrees/` and `.bare/worktrees/` — see
      `.claude/rules/sandbox.md`.
-  3. Authorize `.envrc` for the new tree
+  3. Authorize and pre-evaluate `.envrc` for the new tree
      (`dangerouslyDisableSandbox: true` — direnv writes to its on-disk cache
      outside the sandbox-allowlist):
      ```bash
      direnv allow "$WORKTREE_PATH"
+     direnv exec "$WORKTREE_PATH" true
      ```
+     `direnv allow` whitelists the `.envrc`; `direnv exec` pre-evaluates it so
+     direnv's on-disk cache is populated. Without this cache-warming step,
+     non-interactive subshells in the worker session (Bash tool calls) cannot
+     pick up the flake environment — `node`, `npm`, `npx`, and the TypeScript
+     compiler are missing from `PATH`.
   4. Populate `CLAUDE.local.md` with full issue context
      (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`):
      ```bash
@@ -450,17 +456,20 @@ worktree path that Step 6 will pass to `dispatch-spawn-worker`.
   (early-stop); do not spawn a worker.
 
 On every non-`conflict` path, before the worker is spawned, create the recovery
-marker:
+marker **inside the target worktree** (`$WORKTREE_PATH`):
 
 ```bash
-mkdir -p tmp && touch tmp/dispatch-worktree
+(cd "$WORKTREE_PATH" && mkdir -p tmp && touch tmp/dispatch-worktree)
 ```
 
 `restore-dispatch-skill.sh` (bound to `SessionStart:clear`) keys context-clear
-recovery on this marker — when present, it re-invokes `/dispatch` so the phase is
-re-derived from PR/CI ground truth. The marker is an empty boolean flag with no
-payload; it persists for the worktree's life and needs no cleanup — `tmp/` is
-git-ignored, and removing the worktree removes it.
+recovery on this marker — when present, it re-invokes `/dispatch-worker <N>`
+so the worker re-derives the phase from PR/CI ground truth. The router never
+writes this marker, so a `SessionStart:clear` in `worktrees/main` is a no-op —
+correct, since the router is short-lived and re-seeded by the #725 heartbeat.
+The marker is an empty boolean flag with no payload; it persists for the
+worktree's life and needs no cleanup — `tmp/` is git-ignored, and removing the
+worktree removes it.
 
 As the **final action of this step on every non-`conflict` (proceed) path** —
 after the marker is written, before Step 6 — release the lock (see *Releasing

--- a/.claude/skills/dispatch/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch/scripts/dispatch-acquire-lock
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 # dispatch-acquire-lock — acquire/release the process-level /dispatch lock.
 #
-# /dispatch mutates shared state (fetches origin/main, creates/removes
-# worktrees, flips gh labels and PR draft status). Its per-target guards assume
-# serial execution within a tick; two concurrent invocations can race. This
-# script serializes them with a session-id-stamped lock file.
+# This lock is the dispatch ROUTER's selection lock — held only across the
+# router's selection step (origin/main sync, JIT engine, dispatch-select-
+# target, leaf trace, worktree resolution). The worker (`/dispatch-worker`)
+# holds no selection lock; its phase skill runs lock-free and concurrent
+# workers advance their own issues' phases without contention. See
+# `.claude/skills/dispatch/SKILL.md` Step 0 (Acquire / Releasing / Per-
+# worktree invariant) for the full scoping story.
+#
+# The lock serializes two routers racing on the same target selection — two
+# concurrent routers can pick the same `help wanted` issue or the same PR if
+# selection isn't serialized. It does not (and should not) cover phase
+# execution: per-worktree dedup at `dispatch-spawn-worker` is what serializes
+# per-issue work.
 #
 # An fd-based `flock` cannot serialize /dispatch: the skill runs as many
 # separate Bash tool calls, each a fresh shell, so an fd flock would release

--- a/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
@@ -3,12 +3,12 @@
 # Usage: dispatch-resolve-worktree <issue-num> <explicit|queue>
 #
 # Prints exactly one decision line to stdout:
-#   here            — the current branch already is <issue>-*; no EnterWorktree
-#                     is needed.
-#   enter <path>    — an existing <issue>-* worktree should be re-used;
-#                     EnterWorktree with path: <path>.
-#   create <branch> — no worktree exists; <branch> is the sanitized name,
-#                     EnterWorktree with name: <branch>.
+#   here            — the current branch already is <issue>-*; the caller
+#                     uses the current worktree path.
+#   enter <path>    — an existing <issue>-* worktree exists; the caller
+#                     uses <path>.
+#   create <branch> — no <issue>-* worktree exists; the caller materializes
+#                     <branch> and uses its path.
 #   conflict <path> — a queue-selected target already has a worktree (another
 #                     session owns it); /dispatch reports <path> and stops.
 #

--- a/.claude/skills/dispatch/scripts/dispatch-self-close
+++ b/.claude/skills/dispatch/scripts/dispatch-self-close
@@ -13,8 +13,8 @@
 #                            exit with that command's status.
 #   $CLAUDE_JOB_DIR unset  → diagnostic to stderr, exit 0 (no-op).
 #
-# Environment override for testability (mirroring dispatch-spawn's
-# DISPATCH_SPAWN_CLAUDE_CMD):
+# Environment override for testability (mirroring dispatch-spawn-router's
+# DISPATCH_SPAWN_ROUTER_CLAUDE_CMD):
 #   DISPATCH_SELF_CLOSE_CLAUDE_CMD  The `claude` command. Default: `claude`.
 #
 # Sandbox: `claude rm` reaches the local Claude daemon over a Unix socket;

--- a/.claude/skills/dispatch/scripts/dispatch-self-close
+++ b/.claude/skills/dispatch/scripts/dispatch-self-close
@@ -30,4 +30,4 @@ if [[ -z "$JOB_ID" || "$JOB_ID" == "." ]]; then
   exit 0
 fi
 
-exec "$CLAUDE_CMD" rm "$JOB_ID"
+exec "$CLAUDE_CMD" rm -- "$JOB_ID"

--- a/.claude/skills/dispatch/scripts/dispatch-spawn-router
+++ b/.claude/skills/dispatch/scripts/dispatch-spawn-router
@@ -135,7 +135,7 @@ prune_stopped_dispatch_agents() {
       *) continue ;;
     esac
     job_id=$(basename "$dir")
-    if ! "$CLAUDE_CMD" rm "$job_id" >/dev/null 2>&1; then
+    if ! "$CLAUDE_CMD" rm -- "$job_id" >/dev/null 2>&1; then
       echo "dispatch-spawn-router: prune: 'claude rm $job_id' failed; continuing" >&2
     fi
   done

--- a/.claude/skills/dispatch/scripts/dispatch-spawn-router
+++ b/.claude/skills/dispatch/scripts/dispatch-spawn-router
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# dispatch-spawn — spawn the next /dispatch background job (the baton pass).
+# dispatch-spawn-router — spawn the next /dispatch (router) background job (the worker→router baton pass).
 #
-# /dispatch runs one workflow phase per invocation and then stops. The
-# background-job chain (#755) is what keeps the workflow moving: a job that
-# finishes a phase spawns the next /dispatch job, then self-closes. This script
-# is that spawn primitive — /dispatch SKILL.md Step 9 invokes it on the
-# phase-completed path.
+# /dispatch-worker runs one workflow phase per invocation and then stops. The
+# background-job chain (#755) is what keeps the workflow moving: a worker that
+# finishes a phase spawns the next /dispatch (router) job, then self-closes.
+# This script is the worker → router spawn primitive — /dispatch-worker SKILL.md
+# Step 4 invokes it on the phase-completed path. Its sibling primitive,
+# dispatch-spawn-worker, spawns a worker into a specific issue worktree (the
+# router → worker direction).
 #
 # Behavior, in order:
 #   1. Prune    — remove stale stopped dispatch-* agents (`claude rm`).
@@ -34,23 +36,23 @@
 #   0  deduped or spawned (stdout disambiguates).
 #   1  the successor never registered in 'claude agents --json' — see stderr.
 #   2  the script cannot operate — an unexpected command-line argument, or not
-#      in a git repo with DISPATCH_SPAWN_MAIN_WORKTREE unset.
+#      in a git repo with DISPATCH_SPAWN_ROUTER_MAIN_WORKTREE unset.
 #
 # Environment overrides for testability (mirroring dispatch-acquire-lock's
 # DISPATCH_LOCK_* and lib-claude-agents.sh's CLAUDE_AGENTS_CMD):
-#   DISPATCH_SPAWN_CLAUDE_CMD     The `claude` command. The script's own
-#                                 `claude --bg` / `claude rm` / `claude agents`
-#                                 calls use it, and it is exported as
-#                                 CLAUDE_AGENTS_CMD so the sourced
-#                                 lib-claude-agents.sh helper is faked
-#                                 consistently. Default: `claude`.
-#   DISPATCH_SPAWN_SESSION_ID     This session's id, for the dedup self-
-#                                 exclusion. Default: $CLAUDE_CODE_SESSION_ID.
-#   DISPATCH_SPAWN_MAIN_WORKTREE  The main worktree path. When set, the script
-#                                 does NOT require a git repo. Default:
-#                                 <project-root>/worktrees/main.
-#   DISPATCH_SPAWN_JOBS_DIR       The Claude jobs ledger directory walked for
-#                                 the prune step. Default: ~/.claude/jobs.
+#   DISPATCH_SPAWN_ROUTER_CLAUDE_CMD     The `claude` command. The script's own
+#                                        `claude --bg` / `claude rm` / `claude agents`
+#                                        calls use it, and it is exported as
+#                                        CLAUDE_AGENTS_CMD so the sourced
+#                                        lib-claude-agents.sh helper is faked
+#                                        consistently. Default: `claude`.
+#   DISPATCH_SPAWN_ROUTER_SESSION_ID     This session's id, for the dedup self-
+#                                        exclusion. Default: $CLAUDE_CODE_SESSION_ID.
+#   DISPATCH_SPAWN_ROUTER_MAIN_WORKTREE  The main worktree path. When set, the script
+#                                        does NOT require a git repo. Default:
+#                                        <project-root>/worktrees/main.
+#   DISPATCH_SPAWN_ROUTER_JOBS_DIR       The Claude jobs ledger directory walked for
+#                                        the prune step. Default: ~/.claude/jobs.
 #
 # Sandbox: every `claude` call here reaches the local Claude daemon over a Unix
 # socket; callers must invoke this script with `dangerouslyDisableSandbox:
@@ -70,17 +72,17 @@ set -uo pipefail
 
 # ---- Step 0: reject unexpected arguments ------------------------------------
 if [[ $# -gt 0 ]]; then
-  echo "dispatch-spawn: unknown argument '$1'" >&2
+  echo "dispatch-spawn-router: unknown argument '$1'" >&2
   exit 2
 fi
 
 # ---- Step 1: resolve config -------------------------------------------------
-CLAUDE_CMD="${DISPATCH_SPAWN_CLAUDE_CMD:-claude}"
+CLAUDE_CMD="${DISPATCH_SPAWN_ROUTER_CLAUDE_CMD:-claude}"
 # The sourced helper reads CLAUDE_AGENTS_CMD for its own `claude agents --json`
 # call; point it at the same command so a faked `claude` fakes every path.
 export CLAUDE_AGENTS_CMD="$CLAUDE_CMD"
 
-SESSION_ID="${DISPATCH_SPAWN_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
+SESSION_ID="${DISPATCH_SPAWN_ROUTER_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
@@ -88,15 +90,15 @@ source "$SCRIPT_DIR/lib-claude-agents.sh"
 
 # Every /dispatch job is started from the main worktree, so that is the cwd of
 # a spawned successor and the path the dedup/verify queries filter on. An
-# explicit DISPATCH_SPAWN_MAIN_WORKTREE is authoritative and bypasses the git
+# explicit DISPATCH_SPAWN_ROUTER_MAIN_WORKTREE is authoritative and bypasses the git
 # lookup — tests rely on this. Otherwise the parent of --git-common-dir is the
 # project root in both classic (.git) and bare (.bare) layouts, same idiom as
 # dispatch-acquire-lock / dispatch-sweep.
-if [[ -n "${DISPATCH_SPAWN_MAIN_WORKTREE:-}" ]]; then
-  MAIN_WORKTREE="$DISPATCH_SPAWN_MAIN_WORKTREE"
+if [[ -n "${DISPATCH_SPAWN_ROUTER_MAIN_WORKTREE:-}" ]]; then
+  MAIN_WORKTREE="$DISPATCH_SPAWN_ROUTER_MAIN_WORKTREE"
 else
   GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
-    || { echo "dispatch-spawn: not in a git repo and DISPATCH_SPAWN_MAIN_WORKTREE is unset" >&2; exit 2; }
+    || { echo "dispatch-spawn-router: not in a git repo and DISPATCH_SPAWN_ROUTER_MAIN_WORKTREE is unset" >&2; exit 2; }
   PROJECT_ROOT=$(dirname "$GIT_COMMON_DIR")
   MAIN_WORKTREE="$PROJECT_ROOT/worktrees/main"
 fi
@@ -115,7 +117,7 @@ fi
 #     it expects — not the registry's `.sessionId`.
 # A stat / parse / rm failure logs to stderr and continues — pruning must
 # never abort the spawn.
-JOBS_DIR="${DISPATCH_SPAWN_JOBS_DIR:-$HOME/.claude/jobs}"
+JOBS_DIR="${DISPATCH_SPAWN_ROUTER_JOBS_DIR:-$HOME/.claude/jobs}"
 prune_stopped_dispatch_agents() {
   local dir job_id state name
   [[ -d "$JOBS_DIR" ]] || return 0
@@ -124,7 +126,7 @@ prune_stopped_dispatch_agents() {
     [[ -f "$dir/state.json" ]] || continue
     if ! IFS=$'\t' read -r state name < <(jq -r \
         '"\(.state // "")\t\(.name // "")"' "$dir/state.json" 2>/dev/null); then
-      echo "dispatch-spawn: prune: '${dir}state.json' not parseable; continuing" >&2
+      echo "dispatch-spawn-router: prune: '${dir}state.json' not parseable; continuing" >&2
       continue
     fi
     [[ "$name" == dispatch-* ]] || continue
@@ -134,7 +136,7 @@ prune_stopped_dispatch_agents() {
     esac
     job_id=$(basename "$dir")
     if ! "$CLAUDE_CMD" rm "$job_id" >/dev/null 2>&1; then
-      echo "dispatch-spawn: prune: 'claude rm $job_id' failed; continuing" >&2
+      echo "dispatch-spawn-router: prune: 'claude rm $job_id' failed; continuing" >&2
     fi
   done
 }
@@ -195,8 +197,8 @@ if [[ -n "$registered" ]]; then
   exit 0
 fi
 if [[ -n "${spawn_output//[[:space:]]/}" ]]; then
-  echo "dispatch-spawn: '$AGENT_NAME' did not register in 'claude agents --json' after 'claude --bg'; output: $spawn_output" >&2
+  echo "dispatch-spawn-router: '$AGENT_NAME' did not register in 'claude agents --json' after 'claude --bg'; output: $spawn_output" >&2
 else
-  echo "dispatch-spawn: '$AGENT_NAME' did not register in 'claude agents --json' after 'claude --bg'" >&2
+  echo "dispatch-spawn-router: '$AGENT_NAME' did not register in 'claude agents --json' after 'claude --bg'" >&2
 fi
 exit 1

--- a/.claude/skills/dispatch/scripts/dispatch-spawn-worker
+++ b/.claude/skills/dispatch/scripts/dispatch-spawn-worker
@@ -9,9 +9,8 @@
 # worktree basename — resolving #825 as a natural consequence of the split.
 #
 # The sibling primitive for the reverse direction (worker → router) is
-# dispatch-spawn, which spawns `/dispatch` back in worktrees/main. Unit 5 of
-# issue #839 will rename dispatch-spawn to dispatch-spawn-router; until then
-# call it by its current name.
+# dispatch-spawn-router, spawned with cwd at `worktrees/main` (not the target
+# worktree, which is where this script spawns the worker).
 #
 # Usage: dispatch-spawn-worker <issue-num> <worktree-path>
 #
@@ -51,8 +50,8 @@
 #   1  the successor never registered in 'claude agents --json' — see stderr.
 #   2  the script cannot operate — wrong number of command-line arguments.
 #
-# Environment overrides for testability (mirroring dispatch-spawn's
-# DISPATCH_SPAWN_* pattern):
+# Environment overrides for testability (mirroring dispatch-spawn-router's
+# DISPATCH_SPAWN_ROUTER_* pattern):
 #   DISPATCH_SPAWN_WORKER_CLAUDE_CMD    The `claude` command. The script's own
 #                                       `claude --bg` / `claude rm` / `claude
 #                                       agents` calls use it, and it is exported

--- a/.claude/skills/dispatch/scripts/dispatch-spawn-worker
+++ b/.claude/skills/dispatch/scripts/dispatch-spawn-worker
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# dispatch-spawn-worker — spawn a /dispatch-worker background job for a target
+# worktree (the router → worker spawn primitive).
+#
+# /dispatch (the router) selects an issue, resolves its worktree, and then
+# delegates phase execution to a dedicated worker session via this script.
+# The worker session is started with cwd = the target worktree, so the worker's
+# SessionStart fires in the right context and session-title hooks reflect the
+# worktree basename — resolving #825 as a natural consequence of the split.
+#
+# The sibling primitive for the reverse direction (worker → router) is
+# dispatch-spawn, which spawns `/dispatch` back in worktrees/main. Unit 5 of
+# issue #839 will rename dispatch-spawn to dispatch-spawn-router; until then
+# call it by its current name.
+#
+# Usage: dispatch-spawn-worker <issue-num> <worktree-path>
+#
+# Arguments (both required):
+#   <issue-num>     The issue number N. The spawned agent is named
+#                   dispatch-<N>-<short-id> and is invoked as
+#                   `/dispatch-worker <N>`.
+#   <worktree-path> Absolute path to the target worktree. The spawn subshell
+#                   cd's here, so the worker session starts with cwd = this
+#                   path (not worktrees/main).
+#
+# Behavior, in order:
+#   1. Prune    — remove stale stopped dispatch-* agents (`claude rm`).
+#                 Best-effort: a prune failure logs to stderr and continues.
+#   2. Dedup    — if another live dispatch-* session is already running under
+#                 <worktree-path> (excluding this one), spawn nothing. Fail-safe:
+#                 if the session registry cannot be queried, also spawn nothing —
+#                 a dispatch agent may be running; the #725 heartbeat re-seeds
+#                 the chain if it actually dropped.
+#   3. Spawn    — `claude --bg --name dispatch-<N>-<short-id> --permission-mode
+#                 auto "/dispatch-worker <N>"`, cwd = <worktree-path>.
+#   4. Verify   — re-query the registry under <worktree-path> and confirm the
+#                 new agent registered.
+#
+# (In-script `# ---- Step N: ... ----` markers offset by 2 — arg validation
+# and config resolution come first as Steps 0 and 1.)
+#
+# Stdout protocol (exactly one word):
+#   deduped   another dispatch-* agent is running under <worktree-path>, or the
+#             registry could not be queried — nothing was spawned.
+#   spawned   a new dispatch-* /dispatch-worker job was spawned and verified.
+# A spawn that does not verify prints nothing to stdout, writes a diagnostic to
+# stderr, and exits non-zero.
+#
+# Exit codes:
+#   0  deduped or spawned (stdout disambiguates).
+#   1  the successor never registered in 'claude agents --json' — see stderr.
+#   2  the script cannot operate — wrong number of command-line arguments.
+#
+# Environment overrides for testability (mirroring dispatch-spawn's
+# DISPATCH_SPAWN_* pattern):
+#   DISPATCH_SPAWN_WORKER_CLAUDE_CMD    The `claude` command. The script's own
+#                                       `claude --bg` / `claude rm` / `claude
+#                                       agents` calls use it, and it is exported
+#                                       as CLAUDE_AGENTS_CMD so the sourced
+#                                       lib-claude-agents.sh helper is faked
+#                                       consistently. Default: `claude`.
+#   DISPATCH_SPAWN_WORKER_SESSION_ID    This session's id, for the dedup self-
+#                                       exclusion. Default: $CLAUDE_CODE_SESSION_ID.
+#   DISPATCH_SPAWN_WORKER_JOBS_DIR      The Claude jobs ledger directory walked
+#                                       for the prune step. Default: ~/.claude/jobs.
+#
+# Note: there is no DISPATCH_SPAWN_WORKER_MAIN_WORKTREE override — the worktree
+# path is passed in as the positional argument and does not need an env-override.
+#
+# Sandbox: every `claude` call here reaches the local Claude daemon over a Unix
+# socket; callers must invoke this script with `dangerouslyDisableSandbox:
+# true` — see `.claude/rules/sandbox.md § claude agents --json`.
+#
+# Build-time note (Claude Code 2.1.147): the prune step reads the on-disk
+# ledger under ~/.claude/jobs/<id>/state.json — `claude agents --json` lists
+# only LIVE sessions, so a stopped agent isn't visible there and the registry
+# is the wrong source for a stopped-agent reaper. `claude rm <id>` and
+# `claude stop <id>` both take the job-id (the basename of the ledger
+# directory), not the registry's `.sessionId`. `claude --bg` / `claude rm` are
+# the #725-coordinated background-job verbs; #725 may refine the exact flags.
+#
+# NOT set -e: exits are handled explicitly (matching dispatch-acquire-lock /
+# dispatch-sweep).
+set -uo pipefail
+
+# ---- Step 0: reject unexpected arguments ------------------------------------
+if [[ $# -lt 2 ]]; then
+  echo "dispatch-spawn-worker: expected 2 arguments: <issue-num> <worktree-path>" >&2
+  exit 2
+fi
+if [[ $# -gt 2 ]]; then
+  echo "dispatch-spawn-worker: unexpected argument '$3'" >&2
+  exit 2
+fi
+
+ISSUE_NUM="$1"
+WORKTREE_PATH="$2"
+
+# ---- Step 1: resolve config -------------------------------------------------
+CLAUDE_CMD="${DISPATCH_SPAWN_WORKER_CLAUDE_CMD:-claude}"
+# The sourced helper reads CLAUDE_AGENTS_CMD for its own `claude agents --json`
+# call; point it at the same command so a faked `claude` fakes every path.
+export CLAUDE_AGENTS_CMD="$CLAUDE_CMD"
+
+SESSION_ID="${DISPATCH_SPAWN_WORKER_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib-claude-agents.sh"
+
+# ---- Step 2: prune stale stopped dispatch-* agents --------------------------
+# Best-effort. A stopped dispatch-* agent left behind by a crashed or
+# self-closed job is removed with `claude rm`. `claude agents --json` lists
+# only LIVE sessions, so the on-disk ledger under ~/.claude/jobs/ is the source
+# of truth for stopped ones. For each <id>/state.json:
+#   - filter on the recorded --name starting with `dispatch-` so the prune
+#     never touches non-dispatch agents;
+#   - filter on a terminal `state` value ("stopped", "done", or "failed");
+#     "working" is live, "blocked" is alive waiting for input — neither is
+#     prunable;
+#   - pass the *directory basename* (the job-id) to `claude rm`, which is what
+#     it expects — not the registry's `.sessionId`.
+# A stat / parse / rm failure logs to stderr and continues — pruning must
+# never abort the spawn.
+JOBS_DIR="${DISPATCH_SPAWN_WORKER_JOBS_DIR:-$HOME/.claude/jobs}"
+prune_stopped_dispatch_agents() {
+  local dir job_id state name
+  [[ -d "$JOBS_DIR" ]] || return 0
+  for dir in "$JOBS_DIR"/*/; do
+    [[ -d "$dir" ]] || continue
+    [[ -f "$dir/state.json" ]] || continue
+    if ! IFS=$'\t' read -r state name < <(jq -r \
+        '"\(.state // "")\t\(.name // "")"' "$dir/state.json" 2>/dev/null); then
+      echo "dispatch-spawn-worker: prune: '${dir}state.json' not parseable; continuing" >&2
+      continue
+    fi
+    [[ "$name" == dispatch-* ]] || continue
+    case "$state" in
+      stopped|done|failed) ;;
+      *) continue ;;
+    esac
+    job_id=$(basename "$dir")
+    if ! "$CLAUDE_CMD" rm "$job_id" >/dev/null 2>&1; then
+      echo "dispatch-spawn-worker: prune: 'claude rm $job_id' failed; continuing" >&2
+    fi
+  done
+}
+prune_stopped_dispatch_agents
+
+# ---- Step 3: dedup guard ----------------------------------------------------
+# Spawn nothing if another live dispatch-* session is already under the target
+# worktree. The query is filtered to <worktree-path> — per-worktree invariant:
+# at most one live dispatch-* agent per issue worktree. Fail safe: an unknown
+# (unqueryable) registry is treated as "a dispatch agent may be running", so
+# nothing is spawned. A TOCTOU window exists between this query and the spawn
+# below — two concurrent router invocations could each pass the guard and each
+# spawn a worker. The per-worktree invariant and #755 absorb this: the next
+# selection scan will detect the duplicate, so the extra cost is one wasted
+# tick, not lost work.
+if ! sessions=$(claude_sessions_under "$WORKTREE_PATH"); then
+  echo deduped
+  exit 0
+fi
+while IFS=$'\t' read -r sid _ status name; do
+  [[ -z "$sid" ]] && continue
+  [[ "$name" == dispatch-* ]] || continue    # not a dispatch job
+  # Defensive: `claude agents --json` only lists live sessions, so a "stopped"
+  # row should not appear here in normal operation. The check survives a
+  # registry that nonetheless surfaces a terminal status.
+  [[ "$status" == "stopped" ]] && continue
+  [[ "$sid" == "$SESSION_ID" ]] && continue  # this very session — not "another"
+  # Another live dispatch-* session already owns the worktree; spawn nothing.
+  echo deduped
+  exit 0
+done <<<"$sessions"
+
+# ---- Step 4: spawn the worker -----------------------------------------------
+# dispatch-<N>-<short-id> — the issue number prefix makes per-worktree worker
+# sessions distinguishable in `claude agents`, and the short token keeps the
+# name unique among concurrently-registered agents. $RANDOM is dependency-free
+# (openssl is not installed on the dev image); the dedup guard above already
+# ensures at most one new dispatch worker per worktree at a time, so ~30 bits
+# is ample.
+SHORT_ID=$(printf '%04x%04x' "$RANDOM" "$RANDOM")
+AGENT_NAME="dispatch-${ISSUE_NUM}-${SHORT_ID}"
+# Capture the spawn's combined output so a failure diagnostic can surface why
+# (`cd` failed, `claude` missing, `--bg` rejected). `|| true` keeps a non-zero
+# spawn from aborting the script — Step 5's registry check is the source of
+# truth for whether the agent actually came up.
+spawn_output=$( ( cd "$WORKTREE_PATH" && "$CLAUDE_CMD" --bg --name "$AGENT_NAME" \
+    --permission-mode auto "/dispatch-worker $ISSUE_NUM" ) 2>&1 ) || true
+
+# ---- Step 5: verify the new agent registered --------------------------------
+registered=""
+if sessions=$(claude_sessions_under "$WORKTREE_PATH"); then
+  while IFS=$'\t' read -r _ _ _ name; do
+    if [[ "$name" == "$AGENT_NAME" ]]; then
+      registered=1
+      break
+    fi
+  done <<<"$sessions"
+fi
+if [[ -n "$registered" ]]; then
+  echo spawned
+  exit 0
+fi
+if [[ -n "${spawn_output//[[:space:]]/}" ]]; then
+  echo "dispatch-spawn-worker: '$AGENT_NAME' did not register in 'claude agents --json' after 'claude --bg'; output: $spawn_output" >&2
+else
+  echo "dispatch-spawn-worker: '$AGENT_NAME' did not register in 'claude agents --json' after 'claude --bg'" >&2
+fi
+exit 1

--- a/.claude/skills/dispatch/scripts/dispatch-spawn-worker
+++ b/.claude/skills/dispatch/scripts/dispatch-spawn-worker
@@ -95,6 +95,11 @@ fi
 ISSUE_NUM="$1"
 WORKTREE_PATH="$2"
 
+if [[ ! "$ISSUE_NUM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "dispatch-spawn-worker: invalid issue number '$ISSUE_NUM' (expected a positive integer)" >&2
+  exit 2
+fi
+
 # ---- Step 1: resolve config -------------------------------------------------
 CLAUDE_CMD="${DISPATCH_SPAWN_WORKER_CLAUDE_CMD:-claude}"
 # The sourced helper reads CLAUDE_AGENTS_CMD for its own `claude agents --json`
@@ -139,7 +144,7 @@ prune_stopped_dispatch_agents() {
       *) continue ;;
     esac
     job_id=$(basename "$dir")
-    if ! "$CLAUDE_CMD" rm "$job_id" >/dev/null 2>&1; then
+    if ! "$CLAUDE_CMD" rm -- "$job_id" >/dev/null 2>&1; then
       echo "dispatch-spawn-worker: prune: 'claude rm $job_id' failed; continuing" >&2
     fi
   done

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -5508,8 +5508,9 @@ export PATH="$SAVED_PATH"
 #   WORKTREE_PATH="$PROJECT_ROOT/worktrees/<branch>"
 #   git worktree add -b <branch> "$WORKTREE_PATH" origin/main
 #   direnv allow "$WORKTREE_PATH"
+#   direnv exec "$WORKTREE_PATH" true
 #   (cd "$WORKTREE_PATH" && sync-issue-context <N>)
-#   mkdir -p tmp && touch tmp/dispatch-worktree
+#   (cd "$WORKTREE_PATH" && mkdir -p tmp && touch tmp/dispatch-worktree)
 #   dispatch-spawn-worker <N> "$WORKTREE_PATH"
 echo ""
 echo "=== /dispatch router smoke (Step 5 create + Step 6 spawn) ==="
@@ -5587,11 +5588,14 @@ GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
 PROJECT_ROOT=$(dirname "$GIT_COMMON_DIR")
 WORKTREE_PATH="$PROJECT_ROOT/worktrees/$BRANCH"
 # The fake `git worktree add` does not actually create the directory, so make
-# it here so the subshell `cd "$WORKTREE_PATH"` for sync-issue-context succeeds.
+# it here so the subshell `cd "$WORKTREE_PATH"` for sync-issue-context and the
+# recovery marker creation succeed.
 mkdir -p "$WORKTREE_PATH"
 git worktree add -b "$BRANCH" "$WORKTREE_PATH" origin/main
 direnv allow "$WORKTREE_PATH"
+direnv exec "$WORKTREE_PATH" true
 (cd "$WORKTREE_PATH" && sync-issue-context "$ISSUE_NUM")
+(cd "$WORKTREE_PATH" && mkdir -p tmp && touch tmp/dispatch-worktree)
 dispatch-spawn-worker "$ISSUE_NUM" "$WORKTREE_PATH"
 
 # Assertions: each fake binary's log captures one expected invocation.
@@ -5600,7 +5604,12 @@ assert_eq "git worktree add args" \
   "$(grep '^worktree add' "$TMPDIR_TEST/logs/git.log")"
 assert_eq "direnv allow args" \
   "allow $WORKTREE_PATH" \
-  "$(cat "$TMPDIR_TEST/logs/direnv.log")"
+  "$(grep '^allow' "$TMPDIR_TEST/logs/direnv.log")"
+assert_eq "direnv exec args" \
+  "exec $WORKTREE_PATH true" \
+  "$(grep '^exec' "$TMPDIR_TEST/logs/direnv.log")"
+assert_eq "recovery marker created in target worktree" "1" \
+  "$([ -f "$WORKTREE_PATH/tmp/dispatch-worktree" ] && echo 1 || echo 0)"
 assert_eq "sync-issue-context cwd + arg" \
   "cwd=$WORKTREE_PATH argv=839" \
   "$(cat "$TMPDIR_TEST/logs/sync-issue-context.log")"

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -4220,56 +4220,56 @@ assert_eq "writer change is visible via the reader" "In Progress" "$status"
 proj_teardown
 
 # ============================================================================
-# dispatch-spawn tests
+# dispatch-spawn-router tests
 # ============================================================================
-echo "=== dispatch-spawn ==="
+echo "=== dispatch-spawn-router ==="
 #
-# dispatch-spawn is exercised against a fake `claude` — a multi-subcommand
-# temp script DISPATCH_SPAWN_CLAUDE_CMD points at by absolute path, so no real
-# daemon is needed. The same fake also backs the sourced lib-claude-agents.sh
-# helper (dispatch-spawn exports CLAUDE_AGENTS_CMD to it).
+# dispatch-spawn-router is exercised against a fake `claude` — a multi-subcommand
+# temp script DISPATCH_SPAWN_ROUTER_CLAUDE_CMD points at by absolute path, so no
+# real daemon is needed. The same fake also backs the sourced lib-claude-agents.sh
+# helper (dispatch-spawn-router exports CLAUDE_AGENTS_CMD to it).
 #
 # Each test gets a fresh tmp tree:
-#   $TMPDIR_TEST/scripts/        copies of dispatch-spawn + lib-claude-agents.sh
+#   $TMPDIR_TEST/scripts/        copies of dispatch-spawn-router + lib-claude-agents.sh
 #   $TMPDIR_TEST/worktrees/main/ the main worktree (the spawn subshell cd's here)
 #   $TMPDIR_TEST/fake-claude     the multi-subcommand fake `claude`
 #   $TMPDIR_TEST/registry.json   the `claude agents --json` fixture
-#   $TMPDIR_TEST/jobs/           the on-disk jobs ledger (DISPATCH_SPAWN_JOBS_DIR)
+#   $TMPDIR_TEST/jobs/           the on-disk jobs ledger (DISPATCH_SPAWN_ROUTER_JOBS_DIR)
 #   $TMPDIR_TEST/bg-argv         recorded argv of each `claude --bg` call
 #   $TMPDIR_TEST/rm-log          recorded job-ids of each `claude rm` call
 #   $TMPDIR_TEST/stop-log        recorded job-ids of each `claude stop` call
 #
-# The test shell runs under `set -e`; dispatch-spawn can exit non-zero, so
+# The test shell runs under `set -e`; dispatch-spawn-router can exit non-zero, so
 # every invocation is wrapped in an `if`/`|| rc=$?` to capture the code.
 
-SPAWN_REGISTRY=""
-SPAWN_JOBS_DIR=""
-SPAWN_BG_ARGV=""
-SPAWN_RM_LOG=""
-SPAWN_STOP_LOG=""
+SPAWN_ROUTER_REGISTRY=""
+SPAWN_ROUTER_JOBS_DIR=""
+SPAWN_ROUTER_BG_ARGV=""
+SPAWN_ROUTER_RM_LOG=""
+SPAWN_ROUTER_STOP_LOG=""
 
-# write_fake_spawn_claude — install the multi-subcommand fake `claude`.
+# write_fake_spawn_router_claude — install the multi-subcommand fake `claude`.
 # Dispatches on $1:
 #   agents   — print the registry fixture verbatim. The fake ignores --cwd:
 #              claude_sessions_under does no client-side path filtering — it
 #              trusts server-side `--cwd` filtering — so every fixture session
 #              is returned. Fine here: each fixture holds only sessions a test
-#              means dispatch-spawn to see.
+#              means dispatch-spawn-router to see.
 #   --bg     — record full argv to bg-argv; when SPAWN_BG_REGISTERS=1 (default)
 #              parse --name and jq-append the new agent to the fixture so the
 #              verify step finds it.
 #   rm       — append $2 (the job-id) to rm-log.
 #   stop     — append $2 (the job-id) to stop-log.
-write_fake_spawn_claude() {
+write_fake_spawn_router_claude() {
   cat > "$TMPDIR_TEST/fake-claude" <<FAKE
 #!/usr/bin/env bash
 set -uo pipefail
 case "\${1:-}" in
   agents)
-    cat "$SPAWN_REGISTRY"
+    cat "$SPAWN_ROUTER_REGISTRY"
     ;;
   --bg)
-    printf '%s\n' "\$@" > "$SPAWN_BG_ARGV"
+    printf '%s\n' "\$@" > "$SPAWN_ROUTER_BG_ARGV"
     if [[ "\${SPAWN_BG_REGISTERS:-1}" == "1" ]]; then
       name=""
       while [[ \$# -gt 0 ]]; do
@@ -4279,67 +4279,67 @@ case "\${1:-}" in
       tmp=\$(mktemp)
       jq --arg name "\$name" \
         '. + [{"sessionId":("sess-"+\$name),"pid":9999,"cwd":"/main","kind":"background","status":"busy","name":\$name}]' \
-        "$SPAWN_REGISTRY" > "\$tmp" && mv "\$tmp" "$SPAWN_REGISTRY"
+        "$SPAWN_ROUTER_REGISTRY" > "\$tmp" && mv "\$tmp" "$SPAWN_ROUTER_REGISTRY"
     fi
     ;;
   rm)
-    printf '%s\n' "\${2:-}" >> "$SPAWN_RM_LOG"
+    printf '%s\n' "\${2:-}" >> "$SPAWN_ROUTER_RM_LOG"
     ;;
   stop)
-    printf '%s\n' "\${2:-}" >> "$SPAWN_STOP_LOG"
+    printf '%s\n' "\${2:-}" >> "$SPAWN_ROUTER_STOP_LOG"
     ;;
 esac
 FAKE
   chmod +x "$TMPDIR_TEST/fake-claude"
 }
 
-spawn_setup() {
+spawn_router_setup() {
   TMPDIR_TEST=$(mktemp -d)
   mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/worktrees/main" \
     "$TMPDIR_TEST/jobs"
 
-  # dispatch-spawn sources lib-claude-agents.sh from its own directory, so the
+  # dispatch-spawn-router sources lib-claude-agents.sh from its own directory, so the
   # helper must sit alongside the copy. It is sourced, not executed — no chmod.
-  cp "$SCRIPT_DIR/dispatch-spawn" "$TMPDIR_TEST/scripts/dispatch-spawn"
+  cp "$SCRIPT_DIR/dispatch-spawn-router" "$TMPDIR_TEST/scripts/dispatch-spawn-router"
   cp "$SCRIPT_DIR/lib-claude-agents.sh" "$TMPDIR_TEST/scripts/lib-claude-agents.sh"
-  chmod +x "$TMPDIR_TEST/scripts/dispatch-spawn"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-spawn-router"
 
-  SPAWN_REGISTRY="$TMPDIR_TEST/registry.json"
-  SPAWN_JOBS_DIR="$TMPDIR_TEST/jobs"
-  SPAWN_BG_ARGV="$TMPDIR_TEST/bg-argv"
-  SPAWN_RM_LOG="$TMPDIR_TEST/rm-log"
-  SPAWN_STOP_LOG="$TMPDIR_TEST/stop-log"
-  printf '[]' > "$SPAWN_REGISTRY"
+  SPAWN_ROUTER_REGISTRY="$TMPDIR_TEST/registry.json"
+  SPAWN_ROUTER_JOBS_DIR="$TMPDIR_TEST/jobs"
+  SPAWN_ROUTER_BG_ARGV="$TMPDIR_TEST/bg-argv"
+  SPAWN_ROUTER_RM_LOG="$TMPDIR_TEST/rm-log"
+  SPAWN_ROUTER_STOP_LOG="$TMPDIR_TEST/stop-log"
+  printf '[]' > "$SPAWN_ROUTER_REGISTRY"
 
-  export DISPATCH_SPAWN_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
-  export DISPATCH_SPAWN_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
-  export DISPATCH_SPAWN_SESSION_ID="sess-self"
-  export DISPATCH_SPAWN_JOBS_DIR="$SPAWN_JOBS_DIR"
+  export DISPATCH_SPAWN_ROUTER_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+  export DISPATCH_SPAWN_ROUTER_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+  export DISPATCH_SPAWN_ROUTER_SESSION_ID="sess-self"
+  export DISPATCH_SPAWN_ROUTER_JOBS_DIR="$SPAWN_ROUTER_JOBS_DIR"
 }
 
-spawn_teardown() {
+spawn_router_teardown() {
   rm -rf "$TMPDIR_TEST"
   TMPDIR_TEST=""
-  SPAWN_REGISTRY=""
-  SPAWN_JOBS_DIR=""
-  SPAWN_BG_ARGV=""
-  SPAWN_RM_LOG=""
-  SPAWN_STOP_LOG=""
-  unset DISPATCH_SPAWN_MAIN_WORKTREE DISPATCH_SPAWN_CLAUDE_CMD \
-    DISPATCH_SPAWN_SESSION_ID DISPATCH_SPAWN_JOBS_DIR SPAWN_BG_REGISTERS
+  SPAWN_ROUTER_REGISTRY=""
+  SPAWN_ROUTER_JOBS_DIR=""
+  SPAWN_ROUTER_BG_ARGV=""
+  SPAWN_ROUTER_RM_LOG=""
+  SPAWN_ROUTER_STOP_LOG=""
+  unset DISPATCH_SPAWN_ROUTER_MAIN_WORKTREE DISPATCH_SPAWN_ROUTER_CLAUDE_CMD \
+    DISPATCH_SPAWN_ROUTER_SESSION_ID DISPATCH_SPAWN_ROUTER_JOBS_DIR SPAWN_BG_REGISTERS
 }
 
 # --- Test 1: spawn success ---------------------------------------------------
 
 echo "Test: an empty registry spawns one /dispatch background job"
-spawn_setup
-write_fake_spawn_claude
-if out=$("$TMPDIR_TEST/scripts/dispatch-spawn" 2>/dev/null); then rc=0; else rc=$?; fi
-assert_eq "spawn: dispatch-spawn exits 0" "0" "$rc"
+spawn_router_setup
+write_fake_spawn_router_claude
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-router" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "spawn: dispatch-spawn-router exits 0" "0" "$rc"
 assert_eq "spawn: stdout is 'spawned'" "spawned" "$out"
 # The recorded argv must be exactly: --bg --name dispatch-<id> \
 #   --permission-mode auto /dispatch
-mapfile -t bg_argv < "$SPAWN_BG_ARGV"
+mapfile -t bg_argv < "$SPAWN_ROUTER_BG_ARGV"
 assert_eq "spawn: argv[0] is --bg" "--bg" "${bg_argv[0]:-}"
 assert_eq "spawn: argv[1] is --name" "--name" "${bg_argv[1]:-}"
 case "${bg_argv[2]:-}" in
@@ -4350,57 +4350,57 @@ assert_eq "spawn: argv[2] is a dispatch-* agent name" "yes" "$name_ok"
 assert_eq "spawn: argv[3] is --permission-mode" "--permission-mode" "${bg_argv[3]:-}"
 assert_eq "spawn: argv[4] is auto" "auto" "${bg_argv[4]:-}"
 assert_eq "spawn: argv[5] is /dispatch" "/dispatch" "${bg_argv[5]:-}"
-spawn_teardown
+spawn_router_teardown
 
 # --- Test 2: dedup -----------------------------------------------------------
 
 echo "Test: another live dispatch-* session deduplicates the spawn"
-spawn_setup
+spawn_router_setup
 printf '%s' \
   '[{"sessionId":"sess-other","pid":4242,"cwd":"/main","kind":"background","status":"busy","name":"dispatch-aaaa1111"}]' \
-  > "$SPAWN_REGISTRY"
-write_fake_spawn_claude
-if out=$("$TMPDIR_TEST/scripts/dispatch-spawn" 2>/dev/null); then rc=0; else rc=$?; fi
-assert_eq "dedup: dispatch-spawn exits 0" "0" "$rc"
+  > "$SPAWN_ROUTER_REGISTRY"
+write_fake_spawn_router_claude
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-router" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "dedup: dispatch-spawn-router exits 0" "0" "$rc"
 assert_eq "dedup: stdout is 'deduped'" "deduped" "$out"
 # No --bg invocation was recorded — nothing was spawned.
 TOTAL=$((TOTAL + 1))
-if [[ ! -e "$SPAWN_BG_ARGV" ]]; then
+if [[ ! -e "$SPAWN_ROUTER_BG_ARGV" ]]; then
   PASS=$((PASS + 1)); echo "  PASS: dedup: no 'claude --bg' invocation recorded"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: dedup: no 'claude --bg' invocation recorded"
-  echo "    bg-argv: $(cat "$SPAWN_BG_ARGV")"
+  echo "    bg-argv: $(cat "$SPAWN_ROUTER_BG_ARGV")"
 fi
-spawn_teardown
+spawn_router_teardown
 
 # --- Test 3: self-exclusion --------------------------------------------------
 
 echo "Test: a dispatch-* session that is this session does not deduplicate"
-spawn_setup
+spawn_router_setup
 # The only dispatch-* session in the registry IS this session (sess-self).
 printf '%s' \
   '[{"sessionId":"sess-self","pid":4242,"cwd":"/main","kind":"background","status":"busy","name":"dispatch-self0000"}]' \
-  > "$SPAWN_REGISTRY"
-write_fake_spawn_claude
-if out=$("$TMPDIR_TEST/scripts/dispatch-spawn" 2>/dev/null); then rc=0; else rc=$?; fi
-assert_eq "self-exclude: dispatch-spawn exits 0" "0" "$rc"
+  > "$SPAWN_ROUTER_REGISTRY"
+write_fake_spawn_router_claude
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-router" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "self-exclude: dispatch-spawn-router exits 0" "0" "$rc"
 assert_eq "self-exclude: stdout is 'spawned' (own session is not 'another')" \
   "spawned" "$out"
-spawn_teardown
+spawn_router_teardown
 
 # --- Test 4: spawn failure ---------------------------------------------------
 
 echo "Test: a spawned job that never registers exits non-zero with a diagnostic"
-spawn_setup
-write_fake_spawn_claude
+spawn_router_setup
+write_fake_spawn_router_claude
 export SPAWN_BG_REGISTERS=0
 rc=0
-err=$("$TMPDIR_TEST/scripts/dispatch-spawn" 2>&1 1>/dev/null) || rc=$?
+err=$("$TMPDIR_TEST/scripts/dispatch-spawn-router" 2>&1 1>/dev/null) || rc=$?
 TOTAL=$((TOTAL + 1))
 if [[ "$rc" -ne 0 ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: spawn-fail: dispatch-spawn exits non-zero"
+  PASS=$((PASS + 1)); echo "  PASS: spawn-fail: dispatch-spawn-router exits non-zero"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-fail: dispatch-spawn exits non-zero (rc=$rc)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-fail: dispatch-spawn-router exits non-zero (rc=$rc)"
 fi
 TOTAL=$((TOTAL + 1))
 if [[ "$err" == *"did not register"* ]]; then
@@ -4409,30 +4409,30 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: spawn-fail: stderr reports the unregistered agent"
   echo "    stderr: $err"
 fi
-spawn_teardown
+spawn_router_teardown
 
 # --- Test 5: prune -----------------------------------------------------------
 
 echo "Test: stopped dispatch-* agents in the jobs ledger are pruned via 'claude rm'"
-spawn_setup
+spawn_router_setup
 # Seed the on-disk ledger with three entries:
 #   abcd1234  — stopped dispatch-* (the rm target)
 #   ef015678  — stopped non-dispatch (must NOT be pruned)
 #   9999cccc  — live (working) dispatch-* (must NOT be pruned)
-mkdir -p "$SPAWN_JOBS_DIR/abcd1234" "$SPAWN_JOBS_DIR/ef015678" \
-  "$SPAWN_JOBS_DIR/9999cccc"
+mkdir -p "$SPAWN_ROUTER_JOBS_DIR/abcd1234" "$SPAWN_ROUTER_JOBS_DIR/ef015678" \
+  "$SPAWN_ROUTER_JOBS_DIR/9999cccc"
 printf '%s' '{"name":"dispatch-dead0000","state":"stopped"}' \
-  > "$SPAWN_JOBS_DIR/abcd1234/state.json"
+  > "$SPAWN_ROUTER_JOBS_DIR/abcd1234/state.json"
 printf '%s' '{"name":"manual-session","state":"stopped"}' \
-  > "$SPAWN_JOBS_DIR/ef015678/state.json"
+  > "$SPAWN_ROUTER_JOBS_DIR/ef015678/state.json"
 printf '%s' '{"name":"dispatch-live0000","state":"working"}' \
-  > "$SPAWN_JOBS_DIR/9999cccc/state.json"
-write_fake_spawn_claude
-if out=$("$TMPDIR_TEST/scripts/dispatch-spawn" 2>/dev/null); then rc=0; else rc=$?; fi
-assert_eq "prune: dispatch-spawn exits 0" "0" "$rc"
+  > "$SPAWN_ROUTER_JOBS_DIR/9999cccc/state.json"
+write_fake_spawn_router_claude
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-router" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "prune: dispatch-spawn-router exits 0" "0" "$rc"
 assert_eq "prune: stdout is 'spawned' (stopped agent does not dedup)" \
   "spawned" "$out"
-rm_log=$(cat "$SPAWN_RM_LOG" 2>/dev/null || true)
+rm_log=$(cat "$SPAWN_ROUTER_RM_LOG" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$rm_log" == *"abcd1234"* ]]; then
   PASS=$((PASS + 1)); echo "  PASS: prune: 'claude rm abcd1234' (directory basename, not sessionId) was invoked"
@@ -4454,30 +4454,30 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: prune: live dispatch-* agent '9999cccc' was not pruned"
   echo "    rm-log: $rm_log"
 fi
-spawn_teardown
+spawn_router_teardown
 
 # --- Test 6: unqueryable registry fails safe ---------------------------------
 
 echo "Test: an unparseable session registry fails safe — spawns nothing"
-spawn_setup
+spawn_router_setup
 # A registry that is not a JSON array: lib-claude-agents.sh's
-# claude_sessions_under cannot parse it and returns 1 (unknown). dispatch-spawn
+# claude_sessions_under cannot parse it and returns 1 (unknown). dispatch-spawn-router
 # must treat unknown as "a dispatch agent may be running" and spawn nothing —
 # the documented fail-safe in the script's Step 3 dedup guard.
-printf '%s' 'not-a-json-array' > "$SPAWN_REGISTRY"
-write_fake_spawn_claude
-if out=$("$TMPDIR_TEST/scripts/dispatch-spawn" 2>/dev/null); then rc=0; else rc=$?; fi
-assert_eq "unknown-registry: dispatch-spawn exits 0" "0" "$rc"
+printf '%s' 'not-a-json-array' > "$SPAWN_ROUTER_REGISTRY"
+write_fake_spawn_router_claude
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-router" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "unknown-registry: dispatch-spawn-router exits 0" "0" "$rc"
 assert_eq "unknown-registry: stdout is 'deduped'" "deduped" "$out"
 # No --bg invocation was recorded — nothing was spawned.
 TOTAL=$((TOTAL + 1))
-if [[ ! -e "$SPAWN_BG_ARGV" ]]; then
+if [[ ! -e "$SPAWN_ROUTER_BG_ARGV" ]]; then
   PASS=$((PASS + 1)); echo "  PASS: unknown-registry: no 'claude --bg' invocation recorded"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: unknown-registry: no 'claude --bg' invocation recorded"
-  echo "    bg-argv: $(cat "$SPAWN_BG_ARGV")"
+  echo "    bg-argv: $(cat "$SPAWN_ROUTER_BG_ARGV")"
 fi
-spawn_teardown
+spawn_router_teardown
 
 # ============================================================================
 # dispatch-spawn-worker tests
@@ -4805,16 +4805,16 @@ selfclose_setup() {
   cp "$SCRIPT_DIR/dispatch-self-close" "$TMPDIR_TEST/scripts/dispatch-self-close"
   chmod +x "$TMPDIR_TEST/scripts/dispatch-self-close"
 
-  # Reuse the dispatch-spawn fake `claude` writer: it already dispatches on
-  # `rm` and appends $2 to SPAWN_RM_LOG. The unused SPAWN_REGISTRY /
-  # SPAWN_BG_ARGV / SPAWN_STOP_LOG paths still need to be set because the writer
-  # interpolates them into the fake-claude script body.
-  SPAWN_REGISTRY="$TMPDIR_TEST/registry.json"
-  SPAWN_BG_ARGV="$TMPDIR_TEST/bg-argv"
-  SPAWN_RM_LOG="$TMPDIR_TEST/rm-log"
-  SPAWN_STOP_LOG="$TMPDIR_TEST/stop-log"
-  printf '[]' > "$SPAWN_REGISTRY"
-  write_fake_spawn_claude
+  # Reuse the dispatch-spawn-router fake `claude` writer: it already dispatches on
+  # `rm` and appends $2 to SPAWN_ROUTER_RM_LOG. The unused SPAWN_ROUTER_REGISTRY /
+  # SPAWN_ROUTER_BG_ARGV / SPAWN_ROUTER_STOP_LOG paths still need to be set because
+  # the writer interpolates them into the fake-claude script body.
+  SPAWN_ROUTER_REGISTRY="$TMPDIR_TEST/registry.json"
+  SPAWN_ROUTER_BG_ARGV="$TMPDIR_TEST/bg-argv"
+  SPAWN_ROUTER_RM_LOG="$TMPDIR_TEST/rm-log"
+  SPAWN_ROUTER_STOP_LOG="$TMPDIR_TEST/stop-log"
+  printf '[]' > "$SPAWN_ROUTER_REGISTRY"
+  write_fake_spawn_router_claude
 
   export DISPATCH_SELF_CLOSE_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
 }
@@ -4822,10 +4822,10 @@ selfclose_setup() {
 selfclose_teardown() {
   rm -rf "$TMPDIR_TEST"
   TMPDIR_TEST=""
-  SPAWN_REGISTRY=""
-  SPAWN_BG_ARGV=""
-  SPAWN_RM_LOG=""
-  SPAWN_STOP_LOG=""
+  SPAWN_ROUTER_REGISTRY=""
+  SPAWN_ROUTER_BG_ARGV=""
+  SPAWN_ROUTER_RM_LOG=""
+  SPAWN_ROUTER_STOP_LOG=""
   unset DISPATCH_SELF_CLOSE_CLAUDE_CMD CLAUDE_JOB_DIR
 }
 
@@ -4837,7 +4837,7 @@ mkdir -p "$TMPDIR_TEST/jobs/abcd1234"
 export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 if out=$("$TMPDIR_TEST/scripts/dispatch-self-close" 2>/dev/null); then rc=0; else rc=$?; fi
 assert_eq "self-close: dispatch-self-close exits 0" "0" "$rc"
-rm_log=$(cat "$SPAWN_RM_LOG" 2>/dev/null || true)
+rm_log=$(cat "$SPAWN_ROUTER_RM_LOG" 2>/dev/null || true)
 assert_eq "self-close: 'claude rm abcd1234' was invoked (basename, not full path)" \
   "abcd1234" "$rm_log"
 selfclose_teardown
@@ -4858,11 +4858,11 @@ else
   echo "    stderr: $err"
 fi
 TOTAL=$((TOTAL + 1))
-if [[ ! -e "$SPAWN_RM_LOG" ]]; then
+if [[ ! -e "$SPAWN_ROUTER_RM_LOG" ]]; then
   PASS=$((PASS + 1)); echo "  PASS: interactive: no 'claude rm' invocation recorded"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: interactive: no 'claude rm' invocation recorded"
-  echo "    rm-log: $(cat "$SPAWN_RM_LOG")"
+  echo "    rm-log: $(cat "$SPAWN_ROUTER_RM_LOG")"
 fi
 selfclose_teardown
 
@@ -5519,7 +5519,7 @@ router_smoke_setup() {
   mkdir -p "$TMPDIR_TEST/bin" "$TMPDIR_TEST/logs"
 
   # Faked PROJECT_ROOT — mock the layout `git rev-parse --git-common-dir`
-  # would return (parent is the project root by the same idiom dispatch-spawn /
+  # would return (parent is the project root by the same idiom dispatch-spawn-router /
   # dispatch-acquire-lock use).
   mkdir -p "$TMPDIR_TEST/project/.bare" "$TMPDIR_TEST/project/worktrees"
 

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -5611,6 +5611,51 @@ assert_eq "dispatch-spawn-worker args" \
 router_smoke_teardown
 
 # ============================================================================
+# dispatch chain: no EnterWorktree/ExitWorktree mid-session (ratchet for #839)
+# ============================================================================
+echo "=== dispatch chain: no EnterWorktree/ExitWorktree mid-session ==="
+#
+# Regression guard for #839: the dispatch chain — router /dispatch and the
+# skills the worker (/dispatch-worker) invokes — must not call EnterWorktree
+# or ExitWorktree. The worker is born in its target worktree (cwd set by
+# dispatch-spawn-worker); any mid-session worktree switch is at best a no-op
+# and at worst an error. The router runs in worktrees/main and materializes
+# the target worktree explicitly (git worktree add).
+#
+# Allowed exception: dispatch-worker/SKILL.md mentions the words in its
+# preamble contract: "It never calls EnterWorktree or ExitWorktree."
+
+PROJECT_ROOT_FOR_GUARD=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+
+# Map of chain-skill SKILL.md → allowed count of EnterWorktree+ExitWorktree
+# substring mentions (grep -oE counts each occurrence, not each line).
+declare -A CHAIN_GUARD_EXPECTED=(
+  [".claude/skills/dispatch/SKILL.md"]=0
+  [".claude/skills/dispatch-worker/SKILL.md"]=2
+  [".claude/skills/dispatch-qa/SKILL.md"]=0
+  [".claude/skills/plan-implement/SKILL.md"]=0
+  [".claude/skills/code-review-fix/SKILL.md"]=0
+  [".claude/skills/review-fix/SKILL.md"]=0
+  [".claude/skills/security-review-fix/SKILL.md"]=0
+  [".claude/skills/verify-pr/SKILL.md"]=0
+  [".claude/skills/implement-unit/SKILL.md"]=0
+  [".claude/skills/commit-merge-push/SKILL.md"]=0
+)
+
+for relpath in "${!CHAIN_GUARD_EXPECTED[@]}"; do
+  abspath="$PROJECT_ROOT_FOR_GUARD/$relpath"
+  expected="${CHAIN_GUARD_EXPECTED[$relpath]}"
+  if [[ ! -f "$abspath" ]]; then
+    TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+    echo "  FAIL: chain-guard: file missing: $relpath"
+    continue
+  fi
+  actual=$({ grep -oE 'EnterWorktree|ExitWorktree' "$abspath" || true; } | wc -l | tr -d ' ')
+  assert_eq "chain-guard: $relpath: EnterWorktree/ExitWorktree count" \
+    "$expected" "$actual"
+done
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -4383,7 +4383,9 @@ case "\${1:-}" in
     fi
     ;;
   rm)
-    printf '%s\n' "\${2:-}" >> "$SPAWN_ROUTER_RM_LOG"
+    shift
+    [[ "\${1:-}" == "--" ]] && shift
+    printf '%s\n' "\${1:-}" >> "$SPAWN_ROUTER_RM_LOG"
     ;;
   stop)
     printf '%s\n' "\${2:-}" >> "$SPAWN_ROUTER_STOP_LOG"
@@ -4649,7 +4651,9 @@ case "\${1:-}" in
     fi
     ;;
   rm)
-    printf '%s\n' "\${2:-}" >> "$SPAWN_WORKER_RM_LOG"
+    shift
+    [[ "\${1:-}" == "--" ]] && shift
+    printf '%s\n' "\${1:-}" >> "$SPAWN_WORKER_RM_LOG"
     ;;
 esac
 FAKE
@@ -4885,6 +4889,10 @@ assert_eq "missing-args-worker: only <N> given → exit 2" "2" "$sw_rc_b"
 # Sub-case C: three args given (extra argument)
 if "$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" extra 2>/dev/null; then sw_rc_c=0; else sw_rc_c=$?; fi
 assert_eq "missing-args-worker: three args → exit 2" "2" "$sw_rc_c"
+
+# Sub-case D: non-integer issue number rejected
+if "$TMPDIR_TEST/scripts/dispatch-spawn-worker" "not-a-number" "$WORKER_TARGET_WORKTREE" 2>/dev/null; then sw_rc_d=0; else sw_rc_d=$?; fi
+assert_eq "missing-args-worker: non-integer <N> → exit 2" "2" "$sw_rc_d"
 
 spawn_worker_teardown
 

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -4480,6 +4480,315 @@ fi
 spawn_teardown
 
 # ============================================================================
+# dispatch-spawn-worker tests
+# ============================================================================
+echo "=== dispatch-spawn-worker ==="
+#
+# dispatch-spawn-worker is exercised against a fake `claude` — a multi-subcommand
+# temp script DISPATCH_SPAWN_WORKER_CLAUDE_CMD points at by absolute path, so
+# no real daemon is needed. The same fake also backs the sourced
+# lib-claude-agents.sh helper (dispatch-spawn-worker exports CLAUDE_AGENTS_CMD
+# to it).
+#
+# Each test gets a fresh tmp tree:
+#   $TMPDIR_TEST/scripts/dispatch-spawn-worker  copy of the script under test
+#   $TMPDIR_TEST/scripts/lib-claude-agents.sh   sourced helper (not chmod'd)
+#   $TMPDIR_TEST/worktrees/main/                backdrop only (not used by script)
+#   $TMPDIR_TEST/worktrees/839-test-worker/     the target worktree path (arg 2)
+#   $TMPDIR_TEST/fake-claude                    the multi-subcommand fake `claude`
+#   $TMPDIR_TEST/registry.json                  `claude agents --json` fixture
+#   $TMPDIR_TEST/jobs/                          on-disk jobs ledger
+#   $TMPDIR_TEST/bg-argv                        recorded argv of each `claude --bg` call
+#   $TMPDIR_TEST/pwd-log                        new: records the spawn subshell's $PWD
+#                                               so Test 2 can assert the script
+#                                               cd'd into the worktree path.
+#   $TMPDIR_TEST/rm-log                         recorded job-ids of each `claude rm` call
+#
+# The test shell runs under `set -e`; dispatch-spawn-worker can exit non-zero,
+# so every invocation is wrapped in an `if`/`|| rc=$?` to capture the code.
+
+SPAWN_WORKER_REGISTRY=""
+SPAWN_WORKER_JOBS_DIR=""
+SPAWN_WORKER_BG_ARGV=""
+SPAWN_WORKER_PWD_LOG=""
+SPAWN_WORKER_RM_LOG=""
+WORKER_TARGET_WORKTREE=""
+
+# write_fake_spawn_worker_claude — install the multi-subcommand fake `claude`.
+# Dispatches on $1:
+#   agents   — print the registry fixture verbatim. The fake ignores --cwd:
+#              claude_sessions_under does no client-side path filtering — it
+#              trusts server-side `--cwd` filtering — so every fixture session
+#              is returned. Fine here: each fixture holds only sessions a test
+#              means dispatch-spawn-worker to see.
+#   --bg     — record full argv to bg-argv AND record $PWD to pwd-log; when
+#              SPAWN_BG_REGISTERS=1 (default) parse --name and jq-append the
+#              new agent to the fixture so the verify step finds it.
+#   rm       — append $2 (the job-id) to rm-log.
+write_fake_spawn_worker_claude() {
+  cat > "$TMPDIR_TEST/fake-claude" <<FAKE
+#!/usr/bin/env bash
+set -uo pipefail
+case "\${1:-}" in
+  agents)
+    cat "$SPAWN_WORKER_REGISTRY"
+    ;;
+  --bg)
+    pwd >> "$SPAWN_WORKER_PWD_LOG"
+    printf '%s\n' "\$@" > "$SPAWN_WORKER_BG_ARGV"
+    if [[ "\${SPAWN_BG_REGISTERS:-1}" == "1" ]]; then
+      name=""
+      while [[ \$# -gt 0 ]]; do
+        if [[ "\$1" == "--name" ]]; then name="\${2:-}"; shift 2; continue; fi
+        shift
+      done
+      tmp=\$(mktemp)
+      jq --arg name "\$name" \
+        '. + [{"sessionId":("sess-"+\$name),"pid":9999,"cwd":"/worker","kind":"background","status":"busy","name":\$name}]' \
+        "$SPAWN_WORKER_REGISTRY" > "\$tmp" && mv "\$tmp" "$SPAWN_WORKER_REGISTRY"
+    fi
+    ;;
+  rm)
+    printf '%s\n' "\${2:-}" >> "$SPAWN_WORKER_RM_LOG"
+    ;;
+esac
+FAKE
+  chmod +x "$TMPDIR_TEST/fake-claude"
+}
+
+spawn_worker_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/scripts" \
+    "$TMPDIR_TEST/worktrees/main" \
+    "$TMPDIR_TEST/worktrees/839-test-worker" \
+    "$TMPDIR_TEST/jobs"
+
+  # dispatch-spawn-worker sources lib-claude-agents.sh from its own directory,
+  # so the helper must sit alongside the copy. It is sourced, not executed —
+  # no chmod.
+  cp "$SCRIPT_DIR/dispatch-spawn-worker" "$TMPDIR_TEST/scripts/dispatch-spawn-worker"
+  cp "$SCRIPT_DIR/lib-claude-agents.sh" "$TMPDIR_TEST/scripts/lib-claude-agents.sh"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-spawn-worker"
+
+  SPAWN_WORKER_REGISTRY="$TMPDIR_TEST/registry.json"
+  SPAWN_WORKER_JOBS_DIR="$TMPDIR_TEST/jobs"
+  SPAWN_WORKER_BG_ARGV="$TMPDIR_TEST/bg-argv"
+  SPAWN_WORKER_PWD_LOG="$TMPDIR_TEST/pwd-log"
+  SPAWN_WORKER_RM_LOG="$TMPDIR_TEST/rm-log"
+  WORKER_TARGET_WORKTREE="$TMPDIR_TEST/worktrees/839-test-worker"
+  printf '[]' > "$SPAWN_WORKER_REGISTRY"
+
+  export DISPATCH_SPAWN_WORKER_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+  export DISPATCH_SPAWN_WORKER_SESSION_ID="sess-self"
+  export DISPATCH_SPAWN_WORKER_JOBS_DIR="$SPAWN_WORKER_JOBS_DIR"
+}
+
+spawn_worker_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  SPAWN_WORKER_REGISTRY=""
+  SPAWN_WORKER_JOBS_DIR=""
+  SPAWN_WORKER_BG_ARGV=""
+  SPAWN_WORKER_PWD_LOG=""
+  SPAWN_WORKER_RM_LOG=""
+  WORKER_TARGET_WORKTREE=""
+  unset DISPATCH_SPAWN_WORKER_CLAUDE_CMD DISPATCH_SPAWN_WORKER_SESSION_ID \
+    DISPATCH_SPAWN_WORKER_JOBS_DIR SPAWN_BG_REGISTERS
+}
+
+# --- Test 1: spawn success ---------------------------------------------------
+
+echo "Test: an empty registry spawns one /dispatch-worker background job"
+spawn_worker_setup
+write_fake_spawn_worker_claude
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "spawn-worker: dispatch-spawn-worker exits 0" "0" "$rc"
+assert_eq "spawn-worker: stdout is 'spawned'" "spawned" "$out"
+# The recorded argv must be exactly: --bg --name dispatch-839-<id>
+#   --permission-mode auto /dispatch-worker 839
+mapfile -t sw_bg_argv < "$SPAWN_WORKER_BG_ARGV"
+assert_eq "spawn-worker: argv[0] is --bg" "--bg" "${sw_bg_argv[0]:-}"
+assert_eq "spawn-worker: argv[1] is --name" "--name" "${sw_bg_argv[1]:-}"
+case "${sw_bg_argv[2]:-}" in
+  dispatch-839-*) sw_name_ok=yes ;;
+  *)              sw_name_ok="no: ${sw_bg_argv[2]:-}" ;;
+esac
+assert_eq "spawn-worker: argv[2] is a dispatch-839-* agent name" "yes" "$sw_name_ok"
+assert_eq "spawn-worker: argv[3] is --permission-mode" "--permission-mode" "${sw_bg_argv[3]:-}"
+assert_eq "spawn-worker: argv[4] is auto" "auto" "${sw_bg_argv[4]:-}"
+assert_eq "spawn-worker: argv[5] is /dispatch-worker 839" "/dispatch-worker 839" "${sw_bg_argv[5]:-}"
+spawn_worker_teardown
+
+# --- Test 2: cwd assertion ---------------------------------------------------
+
+echo "Test: the spawn subshell cd's into the target worktree path"
+spawn_worker_setup
+write_fake_spawn_worker_claude
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "spawn-worker-cwd: exits 0" "0" "$rc"
+# Read the first line of the pwd-log and compare it (via realpath) to the
+# target worktree. mktemp -d on Linux does not add a /private/ prefix, but
+# realpath is robust on all platforms.
+sw_pwd_line=$(head -1 "$SPAWN_WORKER_PWD_LOG" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$(realpath "$sw_pwd_line" 2>/dev/null)" == "$(realpath "$WORKER_TARGET_WORKTREE")" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: spawn-worker-cwd: spawn subshell ran in the target worktree"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-worker-cwd: spawn subshell ran in the target worktree"
+  echo "    pwd-log:  '$sw_pwd_line'"
+  echo "    expected: '$WORKER_TARGET_WORKTREE'"
+fi
+spawn_worker_teardown
+
+# --- Test 3: per-worktree dedup ----------------------------------------------
+
+echo "Test: another live dispatch-* session under the worktree deduplicates the spawn"
+spawn_worker_setup
+printf '%s' \
+  '[{"sessionId":"sess-other","pid":4242,"cwd":"/worker","kind":"background","status":"busy","name":"dispatch-839-aaaa1111"}]' \
+  > "$SPAWN_WORKER_REGISTRY"
+write_fake_spawn_worker_claude
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "dedup-worker: dispatch-spawn-worker exits 0" "0" "$rc"
+assert_eq "dedup-worker: stdout is 'deduped'" "deduped" "$out"
+# No --bg invocation was recorded — nothing was spawned.
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$SPAWN_WORKER_BG_ARGV" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: dedup-worker: no 'claude --bg' invocation recorded"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: dedup-worker: no 'claude --bg' invocation recorded"
+  echo "    bg-argv: $(cat "$SPAWN_WORKER_BG_ARGV")"
+fi
+spawn_worker_teardown
+
+# --- Test 4: self-exclusion --------------------------------------------------
+
+echo "Test: a dispatch-* session that is this session does not deduplicate"
+spawn_worker_setup
+# The only dispatch-* session in the registry IS this session (sess-self).
+printf '%s' \
+  '[{"sessionId":"sess-self","pid":4242,"cwd":"/worker","kind":"background","status":"busy","name":"dispatch-839-self0000"}]' \
+  > "$SPAWN_WORKER_REGISTRY"
+write_fake_spawn_worker_claude
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "self-exclude-worker: dispatch-spawn-worker exits 0" "0" "$rc"
+assert_eq "self-exclude-worker: stdout is 'spawned' (own session is not 'another')" \
+  "spawned" "$out"
+spawn_worker_teardown
+
+# --- Test 5: spawn failure ---------------------------------------------------
+
+echo "Test: a spawned worker job that never registers exits non-zero with a diagnostic"
+spawn_worker_setup
+write_fake_spawn_worker_claude
+export SPAWN_BG_REGISTERS=0
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>&1 1>/dev/null) || rc=$?
+TOTAL=$((TOTAL + 1))
+if [[ "$rc" -ne 0 ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: spawn-worker-fail: dispatch-spawn-worker exits non-zero"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-worker-fail: dispatch-spawn-worker exits non-zero (rc=$rc)"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"did not register"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: spawn-worker-fail: stderr reports the unregistered agent"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-worker-fail: stderr reports the unregistered agent"
+  echo "    stderr: $err"
+fi
+spawn_worker_teardown
+
+# --- Test 6: prune -----------------------------------------------------------
+
+echo "Test: stopped dispatch-* agents in the jobs ledger are pruned via 'claude rm'"
+spawn_worker_setup
+# Seed the on-disk ledger with three entries:
+#   abcd1234  — stopped dispatch-* (the rm target)
+#   ef015678  — stopped non-dispatch (must NOT be pruned)
+#   9999cccc  — live (working) dispatch-* (must NOT be pruned)
+mkdir -p "$SPAWN_WORKER_JOBS_DIR/abcd1234" "$SPAWN_WORKER_JOBS_DIR/ef015678" \
+  "$SPAWN_WORKER_JOBS_DIR/9999cccc"
+printf '%s' '{"name":"dispatch-dead0000","state":"stopped"}' \
+  > "$SPAWN_WORKER_JOBS_DIR/abcd1234/state.json"
+printf '%s' '{"name":"manual-session","state":"stopped"}' \
+  > "$SPAWN_WORKER_JOBS_DIR/ef015678/state.json"
+printf '%s' '{"name":"dispatch-live0000","state":"working"}' \
+  > "$SPAWN_WORKER_JOBS_DIR/9999cccc/state.json"
+write_fake_spawn_worker_claude
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "prune-worker: dispatch-spawn-worker exits 0" "0" "$rc"
+assert_eq "prune-worker: stdout is 'spawned' (stopped agent does not dedup)" \
+  "spawned" "$out"
+sw_rm_log=$(cat "$SPAWN_WORKER_RM_LOG" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$sw_rm_log" == *"abcd1234"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: prune-worker: 'claude rm abcd1234' (directory basename) was invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: prune-worker: 'claude rm abcd1234' (directory basename) was invoked"
+  echo "    rm-log: $sw_rm_log"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ "$sw_rm_log" != *"ef015678"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: prune-worker: non-dispatch agent 'ef015678' was not pruned"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: prune-worker: non-dispatch agent 'ef015678' was not pruned"
+  echo "    rm-log: $sw_rm_log"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ "$sw_rm_log" != *"9999cccc"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: prune-worker: live dispatch-* agent '9999cccc' was not pruned"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: prune-worker: live dispatch-* agent '9999cccc' was not pruned"
+  echo "    rm-log: $sw_rm_log"
+fi
+spawn_worker_teardown
+
+# --- Test 7: unqueryable registry fails safe ---------------------------------
+
+echo "Test: an unparseable session registry fails safe — spawns nothing"
+spawn_worker_setup
+# A registry that is not a JSON array: lib-claude-agents.sh's
+# claude_sessions_under cannot parse it and returns 1 (unknown).
+# dispatch-spawn-worker must treat unknown as "a dispatch agent may be running"
+# and spawn nothing — the documented fail-safe in the script's Step 3 dedup
+# guard.
+printf '%s' 'not-a-json-array' > "$SPAWN_WORKER_REGISTRY"
+write_fake_spawn_worker_claude
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "unknown-registry-worker: dispatch-spawn-worker exits 0" "0" "$rc"
+assert_eq "unknown-registry-worker: stdout is 'deduped'" "deduped" "$out"
+# No --bg invocation was recorded — nothing was spawned.
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$SPAWN_WORKER_BG_ARGV" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: unknown-registry-worker: no 'claude --bg' invocation recorded"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: unknown-registry-worker: no 'claude --bg' invocation recorded"
+  echo "    bg-argv: $(cat "$SPAWN_WORKER_BG_ARGV")"
+fi
+spawn_worker_teardown
+
+# --- Test 8: missing args ----------------------------------------------------
+
+echo "Test: missing arguments exit 2"
+spawn_worker_setup
+write_fake_spawn_worker_claude
+
+# Sub-case A: no args at all
+if "$TMPDIR_TEST/scripts/dispatch-spawn-worker" 2>/dev/null; then sw_rc_a=0; else sw_rc_a=$?; fi
+assert_eq "missing-args-worker: no args → exit 2" "2" "$sw_rc_a"
+
+# Sub-case B: only <N> given (no <worktree-path>)
+if "$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 2>/dev/null; then sw_rc_b=0; else sw_rc_b=$?; fi
+assert_eq "missing-args-worker: only <N> given → exit 2" "2" "$sw_rc_b"
+
+# Sub-case C: three args given (extra argument)
+if "$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" extra 2>/dev/null; then sw_rc_c=0; else sw_rc_c=$?; fi
+assert_eq "missing-args-worker: three args → exit 2" "2" "$sw_rc_c"
+
+spawn_worker_teardown
+
+# ============================================================================
 # dispatch-self-close tests
 # ============================================================================
 echo "=== dispatch-self-close ==="

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -5492,6 +5492,125 @@ STUB_DIR=""
 export PATH="$SAVED_PATH"
 
 # ============================================================================
+# /dispatch router smoke (Step 5 create + Step 6 spawn)
+# ============================================================================
+# Pin the shell sequence documented in /dispatch SKILL.md Step 5's `create`
+# branch and Step 6, by faking every external binary the sequence calls and
+# asserting each fake was invoked with the expected arguments. This is a
+# documentation-pinning test, not a behaviour test of the router itself: it
+# catches the case where someone edits Step 5/6 in SKILL.md and forgets to
+# update the spawn call, or where the documented shell sequence drifts from
+# what the script expects.
+#
+# Tested sequence (matches /dispatch SKILL.md Step 5 create + Step 6):
+#   GIT_COMMON_DIR=...                                       # faked git
+#   PROJECT_ROOT=...
+#   WORKTREE_PATH="$PROJECT_ROOT/worktrees/<branch>"
+#   git worktree add -b <branch> "$WORKTREE_PATH" origin/main
+#   direnv allow "$WORKTREE_PATH"
+#   (cd "$WORKTREE_PATH" && sync-issue-context <N>)
+#   mkdir -p tmp && touch tmp/dispatch-worktree
+#   dispatch-spawn-worker <N> "$WORKTREE_PATH"
+echo ""
+echo "=== /dispatch router smoke (Step 5 create + Step 6 spawn) ==="
+
+router_smoke_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/bin" "$TMPDIR_TEST/logs"
+
+  # Faked PROJECT_ROOT — mock the layout `git rev-parse --git-common-dir`
+  # would return (parent is the project root by the same idiom dispatch-spawn /
+  # dispatch-acquire-lock use).
+  mkdir -p "$TMPDIR_TEST/project/.bare" "$TMPDIR_TEST/project/worktrees"
+
+  # Fake `git` — only supports the two subcommands the Step 5 create sequence
+  # calls: `rev-parse --git-common-dir` (used for resolving PROJECT_ROOT) and
+  # `worktree add -b <branch> <path> origin/main`. Each invocation appends its
+  # full argv to a per-binary log. The rev-parse path returns the faked
+  # .bare/ absolute path.
+  cat > "$TMPDIR_TEST/bin/git" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/git.log"
+case "\$*" in
+  "rev-parse --path-format=absolute --git-common-dir")
+    echo "$TMPDIR_TEST/project/.bare"
+    ;;
+  "worktree add -b "*)
+    # No-op; the smoke test does not need a real worktree on disk.
+    ;;
+  *)
+    echo "fake git: unexpected invocation: \$*" >&2
+    exit 99
+    ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/git"
+
+  # Fake `direnv` — record its argv only.
+  cat > "$TMPDIR_TEST/bin/direnv" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/direnv.log"
+STUB
+  chmod +x "$TMPDIR_TEST/bin/direnv"
+
+  # Fake `sync-issue-context` — record cwd + argv.
+  cat > "$TMPDIR_TEST/bin/sync-issue-context" <<STUB
+#!/usr/bin/env bash
+echo "cwd=\$PWD argv=\$*" >> "$TMPDIR_TEST/logs/sync-issue-context.log"
+STUB
+  chmod +x "$TMPDIR_TEST/bin/sync-issue-context"
+
+  # Fake `dispatch-spawn-worker` — record argv only.
+  cat > "$TMPDIR_TEST/bin/dispatch-spawn-worker" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/dispatch-spawn-worker.log"
+echo spawned
+STUB
+  chmod +x "$TMPDIR_TEST/bin/dispatch-spawn-worker"
+
+  export PATH="$TMPDIR_TEST/bin:$SAVED_PATH"
+}
+
+router_smoke_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  export PATH="$SAVED_PATH"
+}
+
+echo "Test: Step 5 create + Step 6 sequence invokes git, direnv, sync, and spawn-worker with the right args"
+router_smoke_setup
+
+# Run the documented shell sequence inline. The variable names match SKILL.md.
+BRANCH="839-test"
+ISSUE_NUM="839"
+GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
+PROJECT_ROOT=$(dirname "$GIT_COMMON_DIR")
+WORKTREE_PATH="$PROJECT_ROOT/worktrees/$BRANCH"
+# The fake `git worktree add` does not actually create the directory, so make
+# it here so the subshell `cd "$WORKTREE_PATH"` for sync-issue-context succeeds.
+mkdir -p "$WORKTREE_PATH"
+git worktree add -b "$BRANCH" "$WORKTREE_PATH" origin/main
+direnv allow "$WORKTREE_PATH"
+(cd "$WORKTREE_PATH" && sync-issue-context "$ISSUE_NUM")
+dispatch-spawn-worker "$ISSUE_NUM" "$WORKTREE_PATH"
+
+# Assertions: each fake binary's log captures one expected invocation.
+assert_eq "git worktree add args" \
+  "worktree add -b 839-test $WORKTREE_PATH origin/main" \
+  "$(grep '^worktree add' "$TMPDIR_TEST/logs/git.log")"
+assert_eq "direnv allow args" \
+  "allow $WORKTREE_PATH" \
+  "$(cat "$TMPDIR_TEST/logs/direnv.log")"
+assert_eq "sync-issue-context cwd + arg" \
+  "cwd=$WORKTREE_PATH argv=839" \
+  "$(cat "$TMPDIR_TEST/logs/sync-issue-context.log")"
+assert_eq "dispatch-spawn-worker args" \
+  "839 $WORKTREE_PATH" \
+  "$(cat "$TMPDIR_TEST/logs/dispatch-spawn-worker.log")"
+
+router_smoke_teardown
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results


### PR DESCRIPTION
Closes #839

## Summary

Split monolithic `/dispatch` along its natural seam between *selection* and
*execution* into a router + worker pair. One session per worktree, plus a thin
router that selects work and spawns the per-worktree sessions.

- **`/dispatch`** (router; lives in `worktrees/main`): acquires the per-repo
  selection lock, syncs `origin/main`, runs JIT, selects a target, materializes
  the worktree (`git worktree add` + `direnv allow` + `sync-issue-context`),
  spawns `/dispatch-worker <N>` with `cwd=<worktree-path>`, then exits or
  self-closes. The router never enters a worktree.
- **`/dispatch-worker <N>`** (worker; lives in `worktrees/<N>-…`): verifies
  cwd, derives phase via `dispatch-phase`, runs exactly one phase skill, then
  spawns a fresh `/dispatch` router back in `worktrees/main` (or parks on
  `dispatch:office-hours`) and self-closes. The worker never selects another
  target.

The selection lock stays per-repo and serializes router selection only. The
execution path is per-worktree: N issues in flight = N concurrent workers,
each in its own worktree, advancing their own issues' phases without
contention. Per-worktree dedup is enforced at the spawn boundary by
`dispatch-spawn-worker`'s `claude_sessions_under <worktree-path>` query.

Resolves #825 for free: the worker is born with `cwd=<worktree-path>`, so
`.claude/hooks/session-title.sh` titles each worker as `<N>-…` instead of
`main`. No platform feature needed; the existing in-repo hook just works in
the new architecture.

## Migration (six dependency-ordered commits)

1. Introduce `/dispatch-worker` skill as the per-worktree execution half.
2. Add `dispatch-spawn-worker` primitive with per-worktree dedup + 8 tests.
3. Rewrite `/dispatch` as the router (700 → 492 lines; drop phase mapping,
   relevance review, 4-step handoff, `EnterWorktree`/`ExitWorktree`).
4. Drop `EnterWorktree`/`ExitWorktree` from the dispatch chain; rewrite
   `/dispatch-qa` Step 0 to operate in place; add ratchet test that fails if
   the strings reappear in any of 10 chain-skill SKILL.md files.
5. Rename `dispatch-spawn` → `dispatch-spawn-router` for call-site
   symmetry with `dispatch-spawn-worker`; rename env-var prefix.
6. Rescope lock documentation: per-repo selection lock (Steps 1–5) and
   per-worktree dedup are two orthogonal mechanisms.

## Test plan

- [x] `bash .claude/skills/dispatch/scripts/test-dispatch-scripts.sh` — 416/416
  passing (was 387 before; +29 net: 8 new dispatch-spawn-worker tests, 4 router
  smoke assertions, 10 chain-guard ratchet assertions, 7 self-close test
  updates for renamed helpers).
- [x] Visual: `rg 'EnterWorktree|ExitWorktree' .claude/skills/` returns only
  the 2 documented preamble lines in `dispatch-worker/SKILL.md`.
- [x] Visual: `rg 'dispatch-spawn' .claude/` returns only the two renamed
  primitives (no bare `dispatch-spawn`).
- [ ] CI `pr-checks` passes.
- [ ] Real-world: invoke `/dispatch` against the queue; confirm router exits
  with `spawned`, worker session appears with cwd at target worktree, worker
  invokes phase skill, on completion a fresh router appears in `worktrees/main`
  and the original worker self-closes.
- [ ] Real-world: concurrent workers — two `/dispatch` invocations against two
  distinct issues both come up without lock contention.
- [ ] Real-world: per-worktree dedup — with a worker live in `worktrees/<N>-…`,
  invoke `/dispatch <N>`; confirm `dispatch-spawn-worker` reports `deduped`
  and the router exits without spawning.