### PR TITLE
dispatch: spawn worker from main with --name=worktree-basename

### DIFF
--- a/.claude/hooks/restore-dispatch-skill.sh
+++ b/.claude/hooks/restore-dispatch-skill.sh
@@ -44,6 +44,14 @@ fi
 [ -n "$ISSUE_NUM" ] || exit 0
 [ -n "$WORKTREE_BASENAME" ] || exit 0
 
+# WORKTREE_BASENAME comes from session --name or git branch name; reject
+# path-traversal characters before composing the absolute path below. Git
+# refnames already disallow `..`, so a slash or `..` here indicates a
+# malformed or hostile source.
+case "$WORKTREE_BASENAME" in
+  *..*|*/*) exit 0 ;;
+esac
+
 # Resolve the absolute worktree path. The project root is the parent of the
 # shared git common dir (.bare). git is run from the hook's cwd, which is some
 # worktree of the project — --git-common-dir always returns the shared path.

--- a/.claude/hooks/restore-dispatch-skill.sh
+++ b/.claude/hooks/restore-dispatch-skill.sh
@@ -23,25 +23,39 @@ case "$NAME" in
 esac
 
 ISSUE_NUM=""
+WORKTREE_BASENAME=""
 
-# Primary path: session --name matches worker shape ^[0-9]+-.
+# Primary path: session --name matches worker shape ^[0-9]+-. The name IS the
+# worktree basename for workers spawned by dispatch-spawn-worker.
 if printf '%s\n' "$NAME" | grep -qE '^[0-9]+-'; then
   ISSUE_NUM=$(printf '%s\n' "$NAME" | grep -oE '^[0-9]+')
+  WORKTREE_BASENAME="$NAME"
 else
   # Fallback: derive from the branch name (worktree basename).
   BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
   if printf '%s\n' "$BRANCH" | grep -qE '^[0-9]+-'; then
     ISSUE_NUM=$(printf '%s\n' "$BRANCH" | grep -oE '^[0-9]+')
+    WORKTREE_BASENAME="$BRANCH"
   else
     exit 0
   fi
 fi
 
 [ -n "$ISSUE_NUM" ] || exit 0
+[ -n "$WORKTREE_BASENAME" ] || exit 0
+
+# Resolve the absolute worktree path. The project root is the parent of the
+# shared git common dir (.bare). git is run from the hook's cwd, which is some
+# worktree of the project — --git-common-dir always returns the shared path.
+GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0
+PROJECT_ROOT=$(dirname "$GIT_COMMON_DIR")
+WORKTREE_PATH="$PROJECT_ROOT/worktrees/$WORKTREE_BASENAME"
 
 # Emit reload instruction so Claude reloads /dispatch-worker for this worker
 # session. /dispatch-worker re-derives the phase from PR/CI ground truth, so
-# recovery is correct after a /clear in any phase.
-printf 'COMPACTION RECOVERY: Reload skill: /dispatch-worker %s\n' "$ISSUE_NUM"
+# recovery is correct after a /clear in any phase. The worker requires
+# <N> <worktree-path> — its Step 0 cd's into the path itself.
+printf 'COMPACTION RECOVERY: Reload skill: /dispatch-worker %s %s\n' \
+  "$ISSUE_NUM" "$WORKTREE_PATH"
 
 exit 0

--- a/.claude/hooks/restore-dispatch-skill.sh
+++ b/.claude/hooks/restore-dispatch-skill.sh
@@ -1,28 +1,47 @@
 #!/usr/bin/env bash
-# Context-clear recovery hook: if this is a dispatch session, emit a reload instruction.
-# Bound to SessionStart:clear.
+# Context-clear recovery hook: if this is a dispatch worker session, emit a
+# reload instruction. Bound to SessionStart:clear.
 # Always exits 0 — never blocks session recovery.
 set -uo pipefail
 trap 'echo "[restore-dispatch-skill] WARNING: unexpected error on line $LINENO" >&2; exit 0' ERR
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || {
-  echo "[restore-dispatch-skill] WARNING: cannot resolve script directory" >&2
-  exit 0
-}
+STDIN_JSON=$(cat 2>/dev/null) || STDIN_JSON=""
+SESSION_ID=$(printf '%s' "$STDIN_JSON" | jq -r '.session_id // empty' 2>/dev/null) || SESSION_ID=""
 
-# Extract issue number from branch name (e.g., "566-extend-dispatch-implement-wi" → "566")
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
-ISSUE_NUM=$(printf '%s\n' "$BRANCH" | grep -oE '^[0-9]+') || exit 0
+# Query the running sessions to get the --name for this session.
+NAME=""
+if [ -n "$SESSION_ID" ]; then
+  NAME=$(claude agents --json 2>/dev/null | \
+    jq -r --arg sid "$SESSION_ID" '.[] | select(.sessionId == $sid) | .name' \
+    2>/dev/null) || NAME=""
+fi
 
-# Detect a dispatch session by checking for the worktree marker /dispatch creates.
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+# Router sessions (dispatch-<short-id>) restart via /dispatch, not skill
+# restoration — skip them explicitly.
+case "$NAME" in
+  dispatch-*) exit 0 ;;
+esac
 
-[ -f "$REPO_ROOT/tmp/dispatch-worktree" ] || exit 0
+ISSUE_NUM=""
 
-# Emit reload instruction so Claude reloads /dispatch-worker — the marker only
-# exists in worker worktrees (the router never writes it), so this recovery
-# always restores a worker. /dispatch-worker re-derives the phase from PR/CI
-# ground truth, so recovery is correct after a /clear in any phase.
+# Primary path: session --name matches worker shape ^[0-9]+-.
+if printf '%s\n' "$NAME" | grep -qE '^[0-9]+-'; then
+  ISSUE_NUM=$(printf '%s\n' "$NAME" | grep -oE '^[0-9]+')
+else
+  # Fallback: derive from the branch name (worktree basename).
+  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+  if printf '%s\n' "$BRANCH" | grep -qE '^[0-9]+-'; then
+    ISSUE_NUM=$(printf '%s\n' "$BRANCH" | grep -oE '^[0-9]+')
+  else
+    exit 0
+  fi
+fi
+
+[ -n "$ISSUE_NUM" ] || exit 0
+
+# Emit reload instruction so Claude reloads /dispatch-worker for this worker
+# session. /dispatch-worker re-derives the phase from PR/CI ground truth, so
+# recovery is correct after a /clear in any phase.
 printf 'COMPACTION RECOVERY: Reload skill: /dispatch-worker %s\n' "$ISSUE_NUM"
 
 exit 0

--- a/.claude/skills/dispatch-qa/SKILL.md
+++ b/.claude/skills/dispatch-qa/SKILL.md
@@ -8,7 +8,9 @@ description: Post-implementation user-acceptance QA — single self-verifying pa
 Runs a single user-acceptance QA pass on an implemented PR. Invoked two ways:
 
 - By the `/dispatch-worker` skill — the session is already inside the target
-  worktree (cwd set by `dispatch-spawn-worker` at spawn time).
+  worktree (the worker `cd`s into it in its own Step 0; `dispatch-spawn-worker`
+  itself spawns from `worktrees/main` and passes the path as the worker's
+  second positional argument).
 - Standalone from inside a target worktree with an optional `#<issue>` argument.
 
 **Step 0** verifies the current worktree and derives the target issue number

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -7,43 +7,60 @@ description: Worker for the dispatch chain — runs one phase skill in its targe
 
 The worker is the per-worktree execution half of the dispatch chain. The other
 half — `/dispatch` — is the router: it selects a target, resolves its worktree,
-and spawns this worker with `cwd=<worktree-path>`. The worker then derives the
-phase, runs exactly one phase skill, and hands off.
+and spawns this worker. The worker then enters the target worktree, derives
+the phase, runs exactly one phase skill, and hands off.
 
-The worker is born in the target worktree. It never calls `EnterWorktree` or
-`ExitWorktree`. Its cwd is anchored to the target worktree for its entire
-lifetime. That means `SessionStart`-derived attributes (title, restored skill
-set) and per-worktree sandbox concerns all naturally key on the right worktree
-— no mid-session cwd switch is needed.
+The worker is spawned from `worktrees/main` (the router's cwd) — not from the
+target worktree. Spawning from the target worktree would pollute the Claude
+daemon's "+ new session" launcher default cwd; spawning from `worktrees/main`
+keeps that default anchored at the router's worktree. The worker enters its
+target worktree as the first action of Step 0 by `cd`-ing into the
+`<worktree-path>` it receives as a positional argument. After that initial
+entry, the worker's cwd is anchored to the target worktree for its entire
+lifetime — it never calls `EnterWorktree` or `ExitWorktree`. That means
+`SessionStart`-derived attributes (title, restored skill set) and per-worktree
+sandbox concerns all naturally key on the right worktree once Step 0 runs.
 
-The worker takes an `<N>` argument — the issue number — and ends after one
-phase. The router is the one who decides what to work on next; the worker just
-executes.
+The worker takes `<N> <worktree-path>` arguments — the issue number and the
+absolute path to its target worktree — and ends after one phase. The router
+is the one who decides what to work on next; the worker just executes.
 
 Run `gh` commands (`gh label create`, `gh pr edit`, and the scripts that invoke
 `gh`) with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
 
-## 0. Verify the Worker's Worktree
+## 0. Enter the Worker's Worktree
 
-The worker must be born in the target worktree. The spawn primitive
-(`dispatch-spawn-worker`) sets the worker's cwd at spawn time; this step is the
-worker's contract enforcement.
+The worker is spawned from `worktrees/main` and `cd`s into its target
+worktree itself as the first action. `ARGUMENTS` has the shape
+`<N> <worktree-path>` (e.g. `860 /home/n8/natb1/commons.systems/worktrees/860-dispatch-spawn-worker-from-m`).
+Parse both, `cd` into the worktree, then run the branch-name sanity check —
+the assertion is the contract enforcement that the spawner passed a coherent
+worktree path for the named issue.
 
 ```bash
-EXPECTED="<N>-"
+read -r ISSUE_NUM WORKTREE_PATH <<<"$ARGUMENTS"
+if [[ -z "${ISSUE_NUM:-}" || -z "${WORKTREE_PATH:-}" ]]; then
+  echo "dispatch-worker: expected ARGUMENTS '<N> <worktree-path>', got '$ARGUMENTS'" >&2
+  exit 1
+fi
+if ! cd "$WORKTREE_PATH"; then
+  echo "dispatch-worker: cd to '$WORKTREE_PATH' failed" >&2
+  exit 1
+fi
+EXPECTED="${ISSUE_NUM}-"
 ACTUAL_BRANCH=$(basename "$(git rev-parse --show-toplevel)")
 case "$ACTUAL_BRANCH" in
   ${EXPECTED}*) ;;
   *)
-    echo "dispatch-worker invoked with wrong cwd: expected branch '${EXPECTED}…' under worktrees/, got '${ACTUAL_BRANCH}'" >&2
-    echo "The worker must be spawned with cwd already set to the target worktree." >&2
+    echo "dispatch-worker invoked with wrong worktree: expected branch '${EXPECTED}…' under worktrees/, got '${ACTUAL_BRANCH}'" >&2
+    echo "The spawner must pass <worktree-path> matching the issue number <N>." >&2
     exit 1
     ;;
 esac
 ```
 
-If the assertion fails, **proceed to Step 4 (early-stop)** — do not derive a
-phase or run a phase skill.
+If the cd or the assertion fails, **proceed to Step 4 (early-stop)** — do not
+derive a phase or run a phase skill.
 
 ## 1. Derive the Phase
 
@@ -238,15 +255,15 @@ that routed here:
   `/dispatch-qa`, `/code-review-fix`, `/review-fix`, or `/security-review-fix`)
   ran to completion. Only the Step 2 post-dispatch hand-off arrives this way.
 - **early-stop** — the job stopped before any phase skill completed: a Step 0
-  cwd-verification failure, a `done` phase, a `waiting` phase that stayed
+  worktree-entry failure, a `done` phase, a `waiting` phase that stayed
   `waiting`, or an `implement` relevance verdict of `stop`.
 
 Run these in order.
 
-**1. No worktree to exit.** The worker was born in its target worktree and
-never entered another worktree mid-session — there is nothing to exit. The
-router (`/dispatch`) is what runs in `worktrees/main`; this worker's lifetime
-ends here, in its target worktree.
+**1. No worktree to exit.** The worker `cd`'d into its target worktree in
+Step 0 and never entered another worktree mid-session — there is nothing to
+exit. The router (`/dispatch`) is what runs in `worktrees/main`; this
+worker's lifetime ends here, in its target worktree.
 
 **2. Pass the baton.** On the **phase-completed** disposition only, spawn a
 fresh `/dispatch` (router) job back in `worktrees/main` (run with

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -119,14 +119,18 @@ The selection lock above is **per-repo** and serializes the router's selection
 step (so two routers cannot race on the same target). It is one of two
 mechanisms; the other is per-worktree and enforced elsewhere.
 
-The **per-worktree invariant**: at most one live `dispatch-*` agent per issue
+The **per-worktree invariant**: at most one live worker agent per issue
 worktree. The router's Step 6 spawn primitive (`dispatch-spawn-worker`)
-enforces this at the spawn boundary by querying
-`claude agents --json --cwd <worktree-path>` (the `claude_sessions_under`
-helper in `lib-claude-agents.sh`). If any live `dispatch-*` agent is already
-under `<worktree-path>`, the spawn is `deduped` and no new worker starts. The
-worker is born in the target worktree and dies there; per-worktree dedup
-naturally serializes per-issue work without the selection lock having to.
+enforces this at the spawn boundary. Every worker is born with the target
+worktree's basename as its `--name` (the dispatch-spawn-worker script does not
+`cd` into the target worktree — it stays at the spawner's cwd, `worktrees/main`,
+to keep the daemon's launcher-default cwd anchored there), so per-worktree name
+uniqueness is automatic. The dedup query lists live sessions under the spawner
+cwd (where every worker registers) and checks for `name == <worktree-basename>`;
+if any other live worker matches, the spawn is `deduped` and no new worker
+starts. The worker `cd`s into its target worktree as its own Step 0 and dies
+there; per-worktree dedup naturally serializes per-issue work without the
+selection lock having to.
 
 The two mechanisms have orthogonal scopes:
 
@@ -420,11 +424,12 @@ marker **inside the target worktree** (`$WORKTREE_PATH`):
 (cd "$WORKTREE_PATH" && mkdir -p tmp && touch tmp/dispatch-worktree)
 ```
 
-The marker is the canonical "Step 5 completed" signal. Two consumers read it:
-`restore-dispatch-skill.sh` (bound to `SessionStart:clear`) keys context-clear
-recovery on it — when present, it re-invokes `/dispatch-worker <N>` so the
-worker re-derives the phase from PR/CI ground truth — and the lock script
-keys post-Step-5 reclaim on it (see *Releasing the lock*).
+The marker is the canonical "Step 5 completed" signal, read by the lock script
+as the post-Step-5 reclaim signal (see *Releasing the lock*). Context-clear
+recovery does **not** read it: `restore-dispatch-skill.sh` (bound to
+`SessionStart:clear`) keys on the session's `--name` shape (`<N>-<slug>` for
+workers) and emits `/dispatch-worker <N> <worktree-path>` so the worker
+re-derives the phase from PR/CI ground truth.
 `.claude/hooks/worktree-create.sh` also writes the marker as its final action
 on every successful worktree creation, so a fresh worktree is marker-bearing
 the moment the hook returns — the router's explicit marker write here is the
@@ -442,17 +447,19 @@ the lock*). The worker in Step 6 onward runs lock-free.
 
 ## 6. Spawn the Worker
 
-Spawn a `/dispatch-worker <N>` background job with `cwd=$WORKTREE_PATH` (the
-path resolved in Step 5). Run with `dangerouslyDisableSandbox: true` — the
-script reaches the local Claude daemon over a socket; see
-`.claude/rules/sandbox.md`:
+Spawn a `/dispatch-worker <N> <worktree-path>` background job. The spawn runs
+from the router's own cwd (`worktrees/main`) — `dispatch-spawn-worker` does
+**not** `cd` into the target worktree, so the daemon's launcher-default cwd
+stays anchored at the main worktree; the worker `cd`s into its target worktree
+as its own Step 0. Run with `dangerouslyDisableSandbox: true` — the script
+reaches the local Claude daemon over a socket; see `.claude/rules/sandbox.md`:
 
 ```bash
 .claude/skills/dispatch/scripts/dispatch-spawn-worker <N> "$WORKTREE_PATH"
 ```
 
-It prints `spawned` (a worker was started) or `deduped` (another `dispatch-*`
-session is already live at `$WORKTREE_PATH` — the per-worktree invariant
+It prints `spawned` (a worker was started) or `deduped` (another live worker
+already has the worktree-basename `--name` — the per-worktree invariant
 prevents two workers from racing on the same worktree) and exits 0; it exits
 non-zero when a worker was spawned but did not register.
 

--- a/.claude/skills/dispatch/scripts/dispatch-spawn-router
+++ b/.claude/skills/dispatch/scripts/dispatch-spawn-router
@@ -108,8 +108,9 @@ fi
 # self-closed job is removed with `claude rm`. `claude agents --json` lists
 # only LIVE sessions, so the on-disk ledger under ~/.claude/jobs/ is the source
 # of truth for stopped ones. For each <id>/state.json:
-#   - filter on the recorded --name starting with `dispatch-` so the prune
-#     never touches non-dispatch agents;
+#   - filter on the recorded --name starting with `dispatch-` or `<N>-`
+#     (router and worker name shapes) so the prune never touches non-dispatch
+#     agents;
 #   - filter on a terminal `state` value ("stopped", "done", or "failed");
 #     "working" is live, "blocked" is alive waiting for input — neither is
 #     prunable;
@@ -129,7 +130,7 @@ prune_stopped_dispatch_agents() {
       echo "dispatch-spawn-router: prune: '${dir}state.json' not parseable; continuing" >&2
       continue
     fi
-    [[ "$name" == dispatch-* ]] || continue
+    [[ "$name" =~ ^([0-9]+-|dispatch-) ]] || continue
     case "$state" in
       stopped|done|failed) ;;
       *) continue ;;

--- a/.claude/skills/dispatch/scripts/dispatch-spawn-worker
+++ b/.claude/skills/dispatch/scripts/dispatch-spawn-worker
@@ -31,26 +31,28 @@
 #   1. Prune    — remove stale stopped dispatch-* agents (`claude rm`).
 #                 Best-effort: a prune failure logs to stderr and continues.
 #   2. Dedup    — if another live session with the same name (the worktree
-#                 basename) is already running under <worktree-path>, spawn
-#                 nothing. Per-worktree name uniqueness keys the dedup on
-#                 `name == basename "$WORKTREE_PATH"`. Fail-safe: if the
-#                 session registry cannot be queried, also spawn nothing — a
-#                 dispatch agent may be running; the #725 heartbeat re-seeds
-#                 the chain if it actually dropped.
+#                 basename) is already running, spawn nothing. Per-worktree
+#                 name uniqueness keys the dedup on
+#                 `name == basename "$WORKTREE_PATH"`. The query is filtered
+#                 to the script's spawner cwd — every worker registers there
+#                 (Step 3 does not `cd`), so the filter is a scoping no-op
+#                 that still surfaces every worker. Fail-safe: if the session
+#                 registry cannot be queried, also spawn nothing — a dispatch
+#                 agent may be running; the #725 heartbeat re-seeds the chain
+#                 if it actually dropped.
 #   3. Spawn    — `claude --bg --name <worktree-basename> --permission-mode
 #                 auto "/dispatch-worker <N> <worktree-path>"`, run from the
 #                 script's inherited cwd (worktrees/main) — no `cd` into the
 #                 target worktree.
-#   4. Verify   — re-query the registry under <worktree-path> and confirm the
-#                 new agent registered.
+#   4. Verify   — re-query the registry under the spawner cwd (where the new
+#                 worker registers) and confirm the new agent appears.
 #
 # (In-script `# ---- Step N: ... ----` markers offset by 2 — arg validation
 # and config resolution come first as Steps 0 and 1.)
 #
 # Stdout protocol (exactly one word):
-#   deduped   another agent with the same worktree-basename name is running
-#             under <worktree-path>, or the registry could not be queried —
-#             nothing was spawned.
+#   deduped   another agent with the same worktree-basename name is running,
+#             or the registry could not be queried — nothing was spawned.
 #   spawned   a new /dispatch-worker job was spawned and verified.
 # A spawn that does not verify prints nothing to stdout, writes a diagnostic to
 # stderr, and exits non-zero.
@@ -122,6 +124,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/lib-claude-agents.sh"
 
+# The spawner's cwd at script entry is where Step 4's `claude --bg` will run
+# (no `cd` happens between here and there), so it is the cwd the daemon
+# registers the new worker under. Dedup (Step 3) and verify (Step 5) must
+# query the registry under THIS path — `claude agents --json --cwd <path>`
+# filters server-side to sessions started under <path>, and the new worker's
+# start cwd is here, not <worktree-path>.
+SPAWN_CWD="$(pwd)"
+
 # ---- Step 2: prune stale stopped dispatch-* agents --------------------------
 # Best-effort. A stopped dispatch-* agent left behind by a crashed or
 # self-closed job is removed with `claude rm`. `claude agents --json` lists
@@ -165,15 +175,18 @@ prune_stopped_dispatch_agents
 # ---- Step 3: dedup guard ----------------------------------------------------
 # The worker's --name is the target worktree's basename, so per-worktree name
 # uniqueness reduces the dedup to a single name-equality check: if another
-# live session under <worktree-path> already has name == <worktree-basename>,
-# spawn nothing. Fail safe: an unknown (unqueryable) registry is treated as
-# "a dispatch agent may be running", so nothing is spawned. A TOCTOU window
-# exists between this query and the spawn below — two concurrent router
-# invocations could each pass the guard and each spawn a worker. The
-# per-worktree invariant and #755 absorb this: the next selection scan will
-# detect the duplicate, so the extra cost is one wasted tick, not lost work.
+# live session already has name == <worktree-basename>, spawn nothing. The
+# registry query filters by SPAWN_CWD because that is where every worker
+# registers (Step 4 does not `cd`); a query under <worktree-path> would miss
+# the just-spawned worker entirely. Fail safe: an unknown (unqueryable)
+# registry is treated as "a dispatch agent may be running", so nothing is
+# spawned. A TOCTOU window exists between this query and the spawn below —
+# two concurrent router invocations could each pass the guard and each spawn
+# a worker. The per-worktree invariant and #755 absorb this: the next
+# selection scan will detect the duplicate, so the extra cost is one wasted
+# tick, not lost work.
 AGENT_NAME="$(basename "$WORKTREE_PATH")"
-if ! sessions=$(claude_sessions_under "$WORKTREE_PATH"); then
+if ! sessions=$(claude_sessions_under "$SPAWN_CWD"); then
   echo deduped
   exit 0
 fi
@@ -207,8 +220,11 @@ spawn_output=$("$CLAUDE_CMD" --bg --name "$AGENT_NAME" \
     --permission-mode auto "/dispatch-worker $ISSUE_NUM $WORKTREE_PATH" 2>&1) || true
 
 # ---- Step 5: verify the new agent registered --------------------------------
+# Query under SPAWN_CWD — the new worker's registered cwd. A query under
+# <worktree-path> would never find it because the daemon's --cwd filter
+# excludes sessions that started elsewhere.
 registered=""
-if sessions=$(claude_sessions_under "$WORKTREE_PATH"); then
+if sessions=$(claude_sessions_under "$SPAWN_CWD"); then
   while IFS=$'\t' read -r _ _ _ name; do
     if [[ "$name" == "$AGENT_NAME" ]]; then
       registered=1

--- a/.claude/skills/dispatch/scripts/dispatch-spawn-worker
+++ b/.claude/skills/dispatch/scripts/dispatch-spawn-worker
@@ -120,6 +120,14 @@ if [[ ! -d "$WORKTREE_PATH" ]]; then
   echo "dispatch-spawn-worker: worktree path '$WORKTREE_PATH' does not exist" >&2
   exit 2
 fi
+# Defense-in-depth: WORKTREE_PATH flows into the worker's --name (via basename)
+# and into the inline prompt string passed to `claude --bg`. Reject characters
+# that could split the prompt argument on the worker's `read -r` boundary or
+# affect downstream parsing.
+if [[ ! "$WORKTREE_PATH" =~ ^[A-Za-z0-9/_.-]+$ ]]; then
+  echo "dispatch-spawn-worker: worktree path '$WORKTREE_PATH' contains unsafe characters" >&2
+  exit 2
+fi
 
 # ---- Step 1: resolve config -------------------------------------------------
 CLAUDE_CMD="${DISPATCH_SPAWN_WORKER_CLAUDE_CMD:-claude}"

--- a/.claude/skills/dispatch/scripts/dispatch-spawn-worker
+++ b/.claude/skills/dispatch/scripts/dispatch-spawn-worker
@@ -127,8 +127,9 @@ source "$SCRIPT_DIR/lib-claude-agents.sh"
 # self-closed job is removed with `claude rm`. `claude agents --json` lists
 # only LIVE sessions, so the on-disk ledger under ~/.claude/jobs/ is the source
 # of truth for stopped ones. For each <id>/state.json:
-#   - filter on the recorded --name starting with `dispatch-` so the prune
-#     never touches non-dispatch agents;
+#   - filter on the recorded --name starting with `dispatch-` or `<N>-`
+#     (router and worker name shapes) so the prune never touches non-dispatch
+#     agents;
 #   - filter on a terminal `state` value ("stopped", "done", or "failed");
 #     "working" is live, "blocked" is alive waiting for input — neither is
 #     prunable;
@@ -148,7 +149,7 @@ prune_stopped_dispatch_agents() {
       echo "dispatch-spawn-worker: prune: '${dir}state.json' not parseable; continuing" >&2
       continue
     fi
-    [[ "$name" == dispatch-* ]] || continue
+    [[ "$name" =~ ^([0-9]+-|dispatch-) ]] || continue
     case "$state" in
       stopped|done|failed) ;;
       *) continue ;;

--- a/.claude/skills/dispatch/scripts/dispatch-spawn-worker
+++ b/.claude/skills/dispatch/scripts/dispatch-spawn-worker
@@ -60,7 +60,8 @@
 # Exit codes:
 #   0  deduped or spawned (stdout disambiguates).
 #   1  the successor never registered in 'claude agents --json' — see stderr.
-#   2  the script cannot operate — wrong number of command-line arguments.
+#   2  the script cannot operate — argument validation failed (wrong count,
+#      non-integer <issue-num>, or non-existent <worktree-path>).
 #
 # Environment overrides for testability (mirroring dispatch-spawn-router's
 # DISPATCH_SPAWN_ROUTER_* pattern):
@@ -109,6 +110,14 @@ WORKTREE_PATH="$2"
 
 if [[ ! "$ISSUE_NUM" =~ ^[1-9][0-9]*$ ]]; then
   echo "dispatch-spawn-worker: invalid issue number '$ISSUE_NUM' (expected a positive integer)" >&2
+  exit 2
+fi
+
+# The worker `cd`s into <worktree-path> as its Step 0; a missing path would
+# only surface there, after the spawn has already happened. Validate at the
+# system edge so the diagnostic names the spawner, not the worker.
+if [[ ! -d "$WORKTREE_PATH" ]]; then
+  echo "dispatch-spawn-worker: worktree path '$WORKTREE_PATH' does not exist" >&2
   exit 2
 fi
 

--- a/.claude/skills/dispatch/scripts/dispatch-spawn-worker
+++ b/.claude/skills/dispatch/scripts/dispatch-spawn-worker
@@ -4,34 +4,43 @@
 #
 # /dispatch (the router) selects an issue, resolves its worktree, and then
 # delegates phase execution to a dedicated worker session via this script.
-# The worker session is started with cwd = the target worktree, so the worker's
-# SessionStart fires in the right context and session-title hooks reflect the
-# worktree basename — resolving #825 as a natural consequence of the split.
+# The worker session is spawned from the caller's cwd (worktrees/main) — there
+# is no `cd` into the target worktree at spawn time. The Claude daemon treats
+# the most-recent `claude --bg` invocation's cwd as the default cwd for new
+# sessions launched from the `claude agents` TUI, so spawning from
+# worktrees/main avoids polluting the launcher default with the target
+# worktree path. The worker enters its target worktree itself as the first
+# action of its Step 0; the worktree path is passed in as its positional
+# argument.
 #
 # The sibling primitive for the reverse direction (worker → router) is
-# dispatch-spawn-router, spawned with cwd at `worktrees/main` (not the target
-# worktree, which is where this script spawns the worker).
+# dispatch-spawn-router, also spawned from the caller's cwd.
 #
 # Usage: dispatch-spawn-worker <issue-num> <worktree-path>
 #
 # Arguments (both required):
-#   <issue-num>     The issue number N. The spawned agent is named
-#                   dispatch-<N>-<short-id> and is invoked as
-#                   `/dispatch-worker <N>`.
-#   <worktree-path> Absolute path to the target worktree. The spawn subshell
-#                   cd's here, so the worker session starts with cwd = this
-#                   path (not worktrees/main).
+#   <issue-num>     The issue number N. The worker is invoked as
+#                   `/dispatch-worker <N> <worktree-path>`.
+#   <worktree-path> Absolute path to the target worktree. Passed through to
+#                   the worker as its second positional argument; the worker
+#                   `cd`s into it as the first action of its Step 0. The
+#                   basename of this path is the worker's --name, so per-
+#                   worktree name uniqueness is automatic.
 #
 # Behavior, in order:
 #   1. Prune    — remove stale stopped dispatch-* agents (`claude rm`).
 #                 Best-effort: a prune failure logs to stderr and continues.
-#   2. Dedup    — if another live dispatch-* session is already running under
-#                 <worktree-path> (excluding this one), spawn nothing. Fail-safe:
-#                 if the session registry cannot be queried, also spawn nothing —
-#                 a dispatch agent may be running; the #725 heartbeat re-seeds
+#   2. Dedup    — if another live session with the same name (the worktree
+#                 basename) is already running under <worktree-path>, spawn
+#                 nothing. Per-worktree name uniqueness keys the dedup on
+#                 `name == basename "$WORKTREE_PATH"`. Fail-safe: if the
+#                 session registry cannot be queried, also spawn nothing — a
+#                 dispatch agent may be running; the #725 heartbeat re-seeds
 #                 the chain if it actually dropped.
-#   3. Spawn    — `claude --bg --name dispatch-<N>-<short-id> --permission-mode
-#                 auto "/dispatch-worker <N>"`, cwd = <worktree-path>.
+#   3. Spawn    — `claude --bg --name <worktree-basename> --permission-mode
+#                 auto "/dispatch-worker <N> <worktree-path>"`, run from the
+#                 script's inherited cwd (worktrees/main) — no `cd` into the
+#                 target worktree.
 #   4. Verify   — re-query the registry under <worktree-path> and confirm the
 #                 new agent registered.
 #
@@ -39,9 +48,10 @@
 # and config resolution come first as Steps 0 and 1.)
 #
 # Stdout protocol (exactly one word):
-#   deduped   another dispatch-* agent is running under <worktree-path>, or the
-#             registry could not be queried — nothing was spawned.
-#   spawned   a new dispatch-* /dispatch-worker job was spawned and verified.
+#   deduped   another agent with the same worktree-basename name is running
+#             under <worktree-path>, or the registry could not be queried —
+#             nothing was spawned.
+#   spawned   a new /dispatch-worker job was spawned and verified.
 # A spawn that does not verify prints nothing to stdout, writes a diagnostic to
 # stderr, and exits non-zero.
 #
@@ -152,47 +162,48 @@ prune_stopped_dispatch_agents() {
 prune_stopped_dispatch_agents
 
 # ---- Step 3: dedup guard ----------------------------------------------------
-# Spawn nothing if another live dispatch-* session is already under the target
-# worktree. The query is filtered to <worktree-path> — per-worktree invariant:
-# at most one live dispatch-* agent per issue worktree. Fail safe: an unknown
-# (unqueryable) registry is treated as "a dispatch agent may be running", so
-# nothing is spawned. A TOCTOU window exists between this query and the spawn
-# below — two concurrent router invocations could each pass the guard and each
-# spawn a worker. The per-worktree invariant and #755 absorb this: the next
-# selection scan will detect the duplicate, so the extra cost is one wasted
-# tick, not lost work.
+# The worker's --name is the target worktree's basename, so per-worktree name
+# uniqueness reduces the dedup to a single name-equality check: if another
+# live session under <worktree-path> already has name == <worktree-basename>,
+# spawn nothing. Fail safe: an unknown (unqueryable) registry is treated as
+# "a dispatch agent may be running", so nothing is spawned. A TOCTOU window
+# exists between this query and the spawn below — two concurrent router
+# invocations could each pass the guard and each spawn a worker. The
+# per-worktree invariant and #755 absorb this: the next selection scan will
+# detect the duplicate, so the extra cost is one wasted tick, not lost work.
+AGENT_NAME="$(basename "$WORKTREE_PATH")"
 if ! sessions=$(claude_sessions_under "$WORKTREE_PATH"); then
   echo deduped
   exit 0
 fi
 while IFS=$'\t' read -r sid _ status name; do
   [[ -z "$sid" ]] && continue
-  [[ "$name" == dispatch-* ]] || continue    # not a dispatch job
+  [[ "$name" == "$AGENT_NAME" ]] || continue  # not a same-worktree worker
   # Defensive: `claude agents --json` only lists live sessions, so a "stopped"
   # row should not appear here in normal operation. The check survives a
   # registry that nonetheless surfaces a terminal status.
   [[ "$status" == "stopped" ]] && continue
-  [[ "$sid" == "$SESSION_ID" ]] && continue  # this very session — not "another"
-  # Another live dispatch-* session already owns the worktree; spawn nothing.
+  [[ "$sid" == "$SESSION_ID" ]] && continue   # this very session — not "another"
+  # Another live worker already owns the worktree; spawn nothing.
   echo deduped
   exit 0
 done <<<"$sessions"
 
 # ---- Step 4: spawn the worker -----------------------------------------------
-# dispatch-<N>-<short-id> — the issue number prefix makes per-worktree worker
-# sessions distinguishable in `claude agents`, and the short token keeps the
-# name unique among concurrently-registered agents. $RANDOM is dependency-free
-# (openssl is not installed on the dev image); the dedup guard above already
-# ensures at most one new dispatch worker per worktree at a time, so ~30 bits
-# is ample.
-SHORT_ID=$(printf '%04x%04x' "$RANDOM" "$RANDOM")
-AGENT_NAME="dispatch-${ISSUE_NUM}-${SHORT_ID}"
+# The worker's --name is the target worktree's basename (e.g.
+# `860-dispatch-spawn-worker-from-m`). The basename is unique per worktree, so
+# the name is unique per worker, and the dedup above keys on it directly. The
+# worker is born with cwd = this script's inherited cwd (worktrees/main, in
+# production) — no `cd` to the target worktree — and `cd`s into the worktree
+# itself as its Step 0. This keeps the Claude daemon's "+ new session"
+# launcher default cwd anchored at worktrees/main rather than drifting onto
+# the latest worker-target worktree.
 # Capture the spawn's combined output so a failure diagnostic can surface why
-# (`cd` failed, `claude` missing, `--bg` rejected). `|| true` keeps a non-zero
-# spawn from aborting the script — Step 5's registry check is the source of
-# truth for whether the agent actually came up.
-spawn_output=$( ( cd "$WORKTREE_PATH" && "$CLAUDE_CMD" --bg --name "$AGENT_NAME" \
-    --permission-mode auto "/dispatch-worker $ISSUE_NUM" ) 2>&1 ) || true
+# (`claude` missing, `--bg` rejected). `|| true` keeps a non-zero spawn from
+# aborting the script — Step 5's registry check is the source of truth for
+# whether the agent actually came up.
+spawn_output=$("$CLAUDE_CMD" --bg --name "$AGENT_NAME" \
+    --permission-mode auto "/dispatch-worker $ISSUE_NUM $WORKTREE_PATH" 2>&1) || true
 
 # ---- Step 5: verify the new agent registered --------------------------------
 registered=""

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -4636,14 +4636,17 @@ spawn_router_teardown
 
 echo "Test: stopped dispatch-* agents in the jobs ledger are pruned via 'claude rm'"
 spawn_router_setup
-# Seed the on-disk ledger with three entries:
-#   abcd1234  — stopped dispatch-* (the rm target)
+# Seed the on-disk ledger with four entries:
+#   abcd1234  — stopped dispatch-* router name (the rm target)
+#   feed5678  — stopped <N>-<slug> worker name (also an rm target)
 #   ef015678  — stopped non-dispatch (must NOT be pruned)
 #   9999cccc  — live (working) dispatch-* (must NOT be pruned)
-mkdir -p "$SPAWN_ROUTER_JOBS_DIR/abcd1234" "$SPAWN_ROUTER_JOBS_DIR/ef015678" \
-  "$SPAWN_ROUTER_JOBS_DIR/9999cccc"
+mkdir -p "$SPAWN_ROUTER_JOBS_DIR/abcd1234" "$SPAWN_ROUTER_JOBS_DIR/feed5678" \
+  "$SPAWN_ROUTER_JOBS_DIR/ef015678" "$SPAWN_ROUTER_JOBS_DIR/9999cccc"
 printf '%s' '{"name":"dispatch-dead0000","state":"stopped"}' \
   > "$SPAWN_ROUTER_JOBS_DIR/abcd1234/state.json"
+printf '%s' '{"name":"999-some-worker","state":"stopped"}' \
+  > "$SPAWN_ROUTER_JOBS_DIR/feed5678/state.json"
 printf '%s' '{"name":"manual-session","state":"stopped"}' \
   > "$SPAWN_ROUTER_JOBS_DIR/ef015678/state.json"
 printf '%s' '{"name":"dispatch-live0000","state":"working"}' \
@@ -4659,6 +4662,13 @@ if [[ "$rm_log" == *"abcd1234"* ]]; then
   PASS=$((PASS + 1)); echo "  PASS: prune: 'claude rm abcd1234' (directory basename, not sessionId) was invoked"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: prune: 'claude rm abcd1234' (directory basename) was invoked"
+  echo "    rm-log: $rm_log"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ "$rm_log" == *"feed5678"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: prune: stopped worker-name agent 'feed5678' (999-some-worker) was pruned"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: prune: stopped worker-name agent 'feed5678' (999-some-worker) was pruned"
   echo "    rm-log: $rm_log"
 fi
 TOTAL=$((TOTAL + 1))
@@ -4944,14 +4954,17 @@ spawn_worker_teardown
 
 echo "Test: stopped dispatch-* agents in the jobs ledger are pruned via 'claude rm'"
 spawn_worker_setup
-# Seed the on-disk ledger with three entries:
-#   abcd1234  — stopped dispatch-* (the rm target)
+# Seed the on-disk ledger with four entries:
+#   abcd1234  — stopped dispatch-* router name (the rm target)
+#   feed5678  — stopped <N>-<slug> worker name (also an rm target)
 #   ef015678  — stopped non-dispatch (must NOT be pruned)
 #   9999cccc  — live (working) dispatch-* (must NOT be pruned)
-mkdir -p "$SPAWN_WORKER_JOBS_DIR/abcd1234" "$SPAWN_WORKER_JOBS_DIR/ef015678" \
-  "$SPAWN_WORKER_JOBS_DIR/9999cccc"
+mkdir -p "$SPAWN_WORKER_JOBS_DIR/abcd1234" "$SPAWN_WORKER_JOBS_DIR/feed5678" \
+  "$SPAWN_WORKER_JOBS_DIR/ef015678" "$SPAWN_WORKER_JOBS_DIR/9999cccc"
 printf '%s' '{"name":"dispatch-dead0000","state":"stopped"}' \
   > "$SPAWN_WORKER_JOBS_DIR/abcd1234/state.json"
+printf '%s' '{"name":"999-some-worker","state":"stopped"}' \
+  > "$SPAWN_WORKER_JOBS_DIR/feed5678/state.json"
 printf '%s' '{"name":"manual-session","state":"stopped"}' \
   > "$SPAWN_WORKER_JOBS_DIR/ef015678/state.json"
 printf '%s' '{"name":"dispatch-live0000","state":"working"}' \
@@ -4967,6 +4980,13 @@ if [[ "$sw_rm_log" == *"abcd1234"* ]]; then
   PASS=$((PASS + 1)); echo "  PASS: prune-worker: 'claude rm abcd1234' (directory basename) was invoked"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: prune-worker: 'claude rm abcd1234' (directory basename) was invoked"
+  echo "    rm-log: $sw_rm_log"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ "$sw_rm_log" == *"feed5678"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: prune-worker: stopped worker-name agent 'feed5678' (999-some-worker) was pruned"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: prune-worker: stopped worker-name agent 'feed5678' (999-some-worker) was pruned"
   echo "    rm-log: $sw_rm_log"
 fi
 TOTAL=$((TOTAL + 1))

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -5232,6 +5232,15 @@ assert_eq "missing-args-worker: non-integer <N> → exit 2" "2" "$sw_rc_d"
 if "$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$TMPDIR_TEST/worktrees/does-not-exist" 2>/dev/null; then sw_rc_e=0; else sw_rc_e=$?; fi
 assert_eq "missing-args-worker: non-existent <worktree-path> → exit 2" "2" "$sw_rc_e"
 
+# Sub-case F: unsafe characters in <worktree-path> rejected (defense-in-depth
+# against shell-metacharacter / whitespace injection into the prompt string
+# passed to `claude --bg`). Path must exist so the `-d` check passes first,
+# isolating the new char-validation step.
+unsafe_path="$TMPDIR_TEST/worktrees/839 unsafe"
+mkdir -p "$unsafe_path"
+if "$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$unsafe_path" 2>/dev/null; then sw_rc_f=0; else sw_rc_f=$?; fi
+assert_eq "missing-args-worker: unsafe chars in <worktree-path> → exit 2" "2" "$sw_rc_f"
+
 spawn_worker_teardown
 
 # --- Test 9: dedup + verify query the spawner cwd, NOT the worktree path ----

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -4824,56 +4824,73 @@ spawn_worker_teardown() {
 echo "Test: an empty registry spawns one /dispatch-worker background job"
 spawn_worker_setup
 write_fake_spawn_worker_claude
-if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null); then rc=0; else rc=$?; fi
+# Run from a stable known cwd so Test 2 (and 1's name/positional-arg
+# assertions) can compare against it. The spawn must NOT cd into the target
+# worktree — it runs from the caller's cwd.
+SPAWN_CALLER_CWD="$TMPDIR_TEST/worktrees/main"
+if out=$( cd "$SPAWN_CALLER_CWD" && "$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null ); then rc=0; else rc=$?; fi
 assert_eq "spawn-worker: dispatch-spawn-worker exits 0" "0" "$rc"
 assert_eq "spawn-worker: stdout is 'spawned'" "spawned" "$out"
-# The recorded argv must be exactly: --bg --name dispatch-839-<id>
-#   --permission-mode auto /dispatch-worker 839
+# The recorded argv must be exactly:
+#   --bg --name <worktree-basename> --permission-mode auto
+#   "/dispatch-worker 839 <worktree-path>"
 mapfile -t sw_bg_argv < "$SPAWN_WORKER_BG_ARGV"
 assert_eq "spawn-worker: argv[0] is --bg" "--bg" "${sw_bg_argv[0]:-}"
 assert_eq "spawn-worker: argv[1] is --name" "--name" "${sw_bg_argv[1]:-}"
-case "${sw_bg_argv[2]:-}" in
-  dispatch-839-*) sw_name_ok=yes ;;
-  *)              sw_name_ok="no: ${sw_bg_argv[2]:-}" ;;
-esac
-assert_eq "spawn-worker: argv[2] is a dispatch-839-* agent name" "yes" "$sw_name_ok"
+assert_eq "spawn-worker: argv[2] is the worktree basename" \
+  "839-test-worker" "${sw_bg_argv[2]:-}"
 assert_eq "spawn-worker: argv[3] is --permission-mode" "--permission-mode" "${sw_bg_argv[3]:-}"
 assert_eq "spawn-worker: argv[4] is auto" "auto" "${sw_bg_argv[4]:-}"
-assert_eq "spawn-worker: argv[5] is /dispatch-worker 839" "/dispatch-worker 839" "${sw_bg_argv[5]:-}"
+assert_eq "spawn-worker: argv[5] is '/dispatch-worker 839 <worktree-path>'" \
+  "/dispatch-worker 839 $WORKER_TARGET_WORKTREE" "${sw_bg_argv[5]:-}"
 spawn_worker_teardown
 
-# --- Test 2: cwd assertion ---------------------------------------------------
+# --- Test 2: spawn cwd stays at caller's cwd --------------------------------
 
-echo "Test: the spawn subshell cd's into the target worktree path"
+echo "Test: dispatch-spawn-worker invokes 'claude --bg' from the caller's cwd, NOT the target worktree"
 spawn_worker_setup
 write_fake_spawn_worker_claude
-if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null); then rc=0; else rc=$?; fi
+SPAWN_CALLER_CWD="$TMPDIR_TEST/worktrees/main"
+if out=$( cd "$SPAWN_CALLER_CWD" && "$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null ); then rc=0; else rc=$?; fi
 assert_eq "spawn-worker-cwd: exits 0" "0" "$rc"
 # Read the first line of the pwd-log and compare it (via realpath) to the
-# target worktree. mktemp -d on Linux does not add a /private/ prefix, but
-# realpath is robust on all platforms.
+# caller's cwd. realpath is used to normalize platform-specific path
+# differences (e.g. macOS /private/ prefix on /tmp).
 sw_pwd_line=$(head -1 "$SPAWN_WORKER_PWD_LOG" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
-if [[ "$(realpath "$sw_pwd_line" 2>/dev/null)" == "$(realpath "$WORKER_TARGET_WORKTREE")" ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: spawn-worker-cwd: spawn subshell ran in the target worktree"
+if [[ "$(realpath "$sw_pwd_line" 2>/dev/null)" == "$(realpath "$SPAWN_CALLER_CWD")" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: spawn-worker-cwd: 'claude --bg' ran with cwd = caller's cwd (worktrees/main)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-worker-cwd: spawn subshell ran in the target worktree"
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-worker-cwd: 'claude --bg' ran with cwd = caller's cwd (worktrees/main)"
   echo "    pwd-log:  '$sw_pwd_line'"
-  echo "    expected: '$WORKER_TARGET_WORKTREE'"
+  echo "    expected: '$SPAWN_CALLER_CWD'"
+fi
+# Independently assert the cwd is NOT the target worktree — that is the
+# regression the issue prevents (cwd-pollution of the daemon's launcher
+# default).
+TOTAL=$((TOTAL + 1))
+if [[ "$(realpath "$sw_pwd_line" 2>/dev/null)" != "$(realpath "$WORKER_TARGET_WORKTREE")" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: spawn-worker-cwd: 'claude --bg' did NOT cd into the target worktree"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-worker-cwd: 'claude --bg' did NOT cd into the target worktree"
+  echo "    pwd-log: '$sw_pwd_line'"
 fi
 spawn_worker_teardown
 
 # --- Test 3: per-worktree dedup ----------------------------------------------
 
-echo "Test: another live dispatch-* session under the worktree deduplicates the spawn"
+echo "Test: another live same-name (worktree-basename) session deduplicates the spawn"
 spawn_worker_setup
+# The dedup is keyed on `name == <worktree-basename>` — i.e. `839-test-worker`
+# in this test fixture. Prime the registry with a different sessionId whose
+# name matches the worktree-basename the spawn would use.
 printf '%s' \
-  '[{"sessionId":"sess-other","pid":4242,"cwd":"/worker","kind":"background","status":"busy","name":"dispatch-839-aaaa1111"}]' \
+  '[{"sessionId":"sess-other","pid":4242,"cwd":"/worker","kind":"background","status":"busy","name":"839-test-worker"}]' \
   > "$SPAWN_WORKER_REGISTRY"
 write_fake_spawn_worker_claude
 if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null); then rc=0; else rc=$?; fi
 assert_eq "dedup-worker: dispatch-spawn-worker exits 0" "0" "$rc"
-assert_eq "dedup-worker: stdout is 'deduped'" "deduped" "$out"
+assert_eq "dedup-worker: stdout is 'deduped' (name-keyed dedup hit)" "deduped" "$out"
 # No --bg invocation was recorded — nothing was spawned.
 TOTAL=$((TOTAL + 1))
 if [[ ! -e "$SPAWN_WORKER_BG_ARGV" ]]; then
@@ -4886,11 +4903,12 @@ spawn_worker_teardown
 
 # --- Test 4: self-exclusion --------------------------------------------------
 
-echo "Test: a dispatch-* session that is this session does not deduplicate"
+echo "Test: a same-name session that is this session does not deduplicate"
 spawn_worker_setup
-# The only dispatch-* session in the registry IS this session (sess-self).
+# The only worker-named session in the registry IS this session (sess-self).
+# Self-exclusion makes name-keyed dedup ignore sessionId == DISPATCH_SPAWN_WORKER_SESSION_ID.
 printf '%s' \
-  '[{"sessionId":"sess-self","pid":4242,"cwd":"/worker","kind":"background","status":"busy","name":"dispatch-839-self0000"}]' \
+  '[{"sessionId":"sess-self","pid":4242,"cwd":"/worker","kind":"background","status":"busy","name":"839-test-worker"}]' \
   > "$SPAWN_WORKER_REGISTRY"
 write_fake_spawn_worker_claude
 if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null); then rc=0; else rc=$?; fi

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -5051,6 +5051,70 @@ assert_eq "missing-args-worker: non-integer <N> → exit 2" "2" "$sw_rc_d"
 
 spawn_worker_teardown
 
+# --- Test 9: dedup + verify query the spawner cwd, NOT the worktree path ----
+#
+# Regression guard: in production the daemon server-side-filters `agents
+# --json --cwd <path>` to sessions started under <path>. Since
+# dispatch-spawn-worker does NOT `cd` into the target worktree before
+# `claude --bg`, the new worker registers under the spawner cwd
+# (worktrees/main), not under WORKTREE_PATH. If Step 5 verify queries under
+# WORKTREE_PATH, the daemon excludes the new worker, `registered` stays
+# empty, and the script exits 1 — on every spawn in production.
+#
+# The default fake `claude` (write_fake_spawn_worker_claude) ignores --cwd,
+# so the existing Tests 1–8 do not exercise this filter and would not catch
+# the regression. This test installs a cwd-aware fake: its `agents` handler
+# filters its registry-emit by --cwd, and its --bg handler records the new
+# worker with cwd = $(pwd) at spawn time. With the fix, both queries pass
+# the spawner cwd and the worker is found. Without it, verify returns no
+# session and the script exits 1.
+echo "Test: dedup + verify query the spawner cwd, not the worktree path"
+spawn_worker_setup
+cat > "$TMPDIR_TEST/fake-claude" <<FAKE
+#!/usr/bin/env bash
+set -uo pipefail
+case "\${1:-}" in
+  agents)
+    shift
+    requested_cwd=""
+    while [[ \$# -gt 0 ]]; do
+      case "\$1" in
+        --cwd) requested_cwd="\${2:-}"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [[ -n "\$requested_cwd" ]]; then
+      jq --arg cwd "\$requested_cwd" '[.[] | select(.cwd == \$cwd)]' \
+        "$SPAWN_WORKER_REGISTRY"
+    else
+      cat "$SPAWN_WORKER_REGISTRY"
+    fi
+    ;;
+  --bg)
+    bg_cwd="\$(pwd)"
+    pwd >> "$SPAWN_WORKER_PWD_LOG"
+    printf '%s\n' "\$@" > "$SPAWN_WORKER_BG_ARGV"
+    name=""
+    while [[ \$# -gt 0 ]]; do
+      if [[ "\$1" == "--name" ]]; then name="\${2:-}"; shift 2; continue; fi
+      shift
+    done
+    tmp=\$(mktemp)
+    jq --arg name "\$name" --arg cwd "\$bg_cwd" \
+      '. + [{"sessionId":("sess-"+\$name),"pid":9999,"cwd":\$cwd,"kind":"background","status":"busy","name":\$name}]' \
+      "$SPAWN_WORKER_REGISTRY" > "\$tmp" && mv "\$tmp" "$SPAWN_WORKER_REGISTRY"
+    ;;
+  rm) ;;
+esac
+FAKE
+chmod +x "$TMPDIR_TEST/fake-claude"
+SPAWN_CALLER_CWD="$TMPDIR_TEST/worktrees/main"
+if out=$( cd "$SPAWN_CALLER_CWD" && "$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null ); then rc=0; else rc=$?; fi
+assert_eq "cwd-aware-spawn: exits 0" "0" "$rc"
+assert_eq "cwd-aware-spawn: stdout is 'spawned' (verify queried under spawner cwd, found the new worker)" \
+  "spawned" "$out"
+spawn_worker_teardown
+
 # ============================================================================
 # dispatch-self-close tests
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -5228,6 +5228,10 @@ assert_eq "missing-args-worker: three args → exit 2" "2" "$sw_rc_c"
 if "$TMPDIR_TEST/scripts/dispatch-spawn-worker" "not-a-number" "$WORKER_TARGET_WORKTREE" 2>/dev/null; then sw_rc_d=0; else sw_rc_d=$?; fi
 assert_eq "missing-args-worker: non-integer <N> → exit 2" "2" "$sw_rc_d"
 
+# Sub-case E: non-existent worktree path rejected at the spawner edge
+if "$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$TMPDIR_TEST/worktrees/does-not-exist" 2>/dev/null; then sw_rc_e=0; else sw_rc_e=$?; fi
+assert_eq "missing-args-worker: non-existent <worktree-path> → exit 2" "2" "$sw_rc_e"
+
 spawn_worker_teardown
 
 # --- Test 9: dedup + verify query the spawner cwd, NOT the worktree path ----


### PR DESCRIPTION
Closes #860
Closes #828

## Summary

PR #851 (greenfield router/worker split) spawned each worker with `cwd=target-worktree` by wrapping `claude --bg` in `( cd "$WORKTREE_PATH" && ... )`. That worked for the worker, but it polluted the Claude daemon's launcher-default cwd — after every dispatch spawn, the TUI's "+ new session" prompt defaulted to the worker's worktree instead of `worktrees/main`.

Spawn the worker from `worktrees/main` (no pollution) and have the worker `cd` into its target worktree as Step 0. Pass the worktree path positionally. Set `--name` authoritatively at spawn time via `basename "$WORKTREE_PATH"` (e.g. `860-dispatch-spawn-worker-from-m`) — this also subsumes the SessionStart-title hook proposed in #825.

## Commits

- **aaf73f3** — `dispatch-spawn-worker`: drop the `cd` subshell, set `--name` to the worktree basename, pass the worktree path as a positional argument, switch dedup to name-keyed (worktree-basename uniqueness gives a one-line dedup). Plus `dispatch-worker` Step 0 changes from assertion to action (\`cd\` into the worktree first).
- **7229181** — Broaden the prune regex to \`^([0-9]+-|dispatch-)\` in both \`dispatch-spawn-worker\` and \`dispatch-spawn-router\` so stopped workers under the new name shape get reaped.
- **8ee378b** — \`restore-dispatch-skill.sh\`: gate on the worker \`--name\` shape (queried via \`claude agents --json\` filtered by sessionId) instead of the \`tmp/dispatch-worktree\` marker. Routers are skipped; branch-name fallback covers interactive sessions. The marker writer (\`worktree-create.sh:84\`) is unchanged.

## Test plan

- [x] \`test-dispatch-scripts.sh\` — 445/445 pass (4 new spawn-worker assertions, 2 new prune assertions).
- [x] \`bash -n\` on every modified shell script.
- [x] Manual sanity test on \`restore-dispatch-skill.sh\` — fake SessionStart payload triggers \`COMPACTION RECOVERY: Reload skill: /dispatch-worker 860\` via the branch-name fallback path.
- [ ] End-to-end: from an interactive Claude in \`worktrees/main\`, invoke \`/dispatch\`. After it spawns a worker, confirm the \`claude agents\` TUI's "+ new session" default cwd stays \`worktrees/main\`.
- [ ] End-to-end: \`claude agents\` lists the spawned worker with name \`<N>-<slug>\` (e.g. \`860-dispatch-spawn-worker-from-m\`), not \`dispatch-<N>-<short>\`.
- [ ] End-to-end: after a worker self-closes, the next router-spawn reaps it via the broadened prune regex.