### PR TITLE
dispatch: propagate / notify / drain terminal dispositions (#853)

### DIFF
--- a/.claude/skills/dispatch-diagnose-main/SKILL.md
+++ b/.claude/skills/dispatch-diagnose-main/SKILL.md
@@ -1,15 +1,18 @@
 ---
 name: dispatch-diagnose-main
-description: Diagnose origin/main's failing CI when /dispatch detects a red main; enumerates failing checks, fetches logs, summarizes likely cause, releases the dispatch lock, and stops.
+description: Diagnose origin/main's failing CI when /dispatch detects a red main; enumerates failing checks, fetches logs, summarizes likely cause, releases the dispatch lock, and returns so the caller can apply notify main-broken.
 ---
 
 # Dispatch: Diagnose Main
 
 Invoked by `/dispatch` Step 3 when `dispatch-select-target` reports
 `main-broken <sha>` — `origin/main` itself is red, so no new work is safe to
-start. Diagnose main, release the dispatch lock, and stop the tick. On this skill's return, the caller (`/dispatch` Step 3)
-proceeds to Step 9 (early-stop). The skill does **not** run the sweep, create
-a worktree, branch, PR, or invoke any phase skill.
+start. Diagnose main, release the dispatch lock, and return. On this skill's
+return, the caller (`/dispatch` Step 3) proceeds to Step 7 with `notify
+main-broken` — the session stays in `claude agents` until the user closes it,
+so the diagnosis remains visible rather than buried in a closed transcript.
+The skill does **not** run the sweep, create a worktree, branch, PR, or
+invoke any phase skill.
 
 Takes `<sha>` as its single argument — the broken `origin/main` HEAD commit.
 
@@ -49,7 +52,7 @@ As the action immediately before the final report:
 ## 4. Summarize and stop
 
 Summarize the likely cause from the logs and check-run details, report it,
-and return. The caller proceeds to Step 9 (early-stop).
+and return. The caller proceeds to Step 7 with `notify main-broken`.
 
 Include only the failing check/step name and a high-level error category
 (e.g. "test assertion failed", "lint error", "type error"). Do not reproduce

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -265,8 +265,11 @@ daemon over a socket; see `.claude/rules/sandbox.md`):
 ```
 
 The worker spawns a `/dispatch` router, not another worker — the router will
-select the next target and spawn its worker. The script prints `spawned` or
-`deduped` and exits 0 on success; exits non-zero when a job was spawned but
+select the next target and spawn its worker. The script prints `spawned` (a
+router was started) or `deduped` (another `dispatch-*` session is already
+live in `worktrees/main`, or the session registry could not be queried — the
+chain is in-flight or assumed-in-flight, so this worker does not need to
+push it) and exits 0 on success; exits non-zero when a job was spawned but
 did not register.
 
 Print the completion report — the phase that ran and its outcome.

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -42,8 +42,9 @@ case "$ACTUAL_BRANCH" in
 esac
 ```
 
-If the assertion fails, proceed to Step 4 with `notify worker-wrong-cwd` —
-do not derive a phase or run a phase skill.
+The bash above exits 1 to signal the wrong-cwd disposition. When that exit
+fires, proceed to Step 4 with `notify worker-wrong-cwd` — do not derive a
+phase or run a phase skill.
 
 ## 1. Derive the Phase
 
@@ -232,18 +233,20 @@ the action.
 
 The dispatch-chain terminal-disposition invariant is stated in `/dispatch`
 Step 7 and applies equally here — every disposition other than `propagate`
-on success emits a user-visible report before any tool action; a silent
+on success emits a user-visible report before the session ends (before
+`dispatch-self-close` for `drain` and `propagate`; before this turn's text
+output completes for `notify`, which does not self-close); a silent
 `notify` or silent `drain` is a defect.
 
 The worker reaches Step 4 with one of these dispositions:
 
 | Disposition | Source |
 |---|---|
-| `propagate` (silent on success; falls through to `notify spawn-failed` / `notify deviation` / `notify phase-non-advancement` per the priority below) | Step 2 — phase skill ran to completion |
+| `propagate` (silent on success; may fall through to `notify spawn-failed` / `notify deviation` / `notify phase-non-advancement` per the priority below) | Step 2 — phase skill ran to completion |
 | `notify worker-wrong-cwd` | Step 0 — cwd verification failed |
 | `notify already-done` | Step 2 — `done` phase (non-draft PR slipped past sweep) |
 | `notify implement-stop` | Step 3 — relevance verdict `stop` |
-| `drain waiting` | Step 2 — `waiting` phase stayed `waiting` after the CI subagent returned |
+| `drain waiting` | Step 2 — re-derived phase is still `waiting` after the CI subagent returned (CI registered no checks) |
 
 The worker was born in its target worktree and never entered another
 worktree mid-session — there is nothing to exit. The router (`/dispatch`)
@@ -317,7 +320,9 @@ The disposition then resolves in this priority order:
    ```
 
    If the re-derived phase **differs** from the phase that just ran, the
-   workflow advanced — fall through to the silent propagate-success bullet.
+   workflow advanced — fall through to the propagate-success bullet (silent
+   self-close; the completion report above already surfaced the phase
+   outcome to the user).
 
    If the re-derived phase **equals** the phase that just ran, the workflow
    did not advance. Apply the verify-phase exemption: `/verify-pr` does not
@@ -333,8 +338,9 @@ The disposition then resolves in this priority order:
      --jq '[.labels[].name | capture("^dispatch:verify-attempt-(?<n>[0-9]+)$").n | tonumber] | max // 0')
    ```
 
-   When `N < 3`, fall through to the silent propagate-success bullet (the
-   chain retries on the next router tick). When `N >= 3` — or for any
+   When `N < 3`, fall through to the propagate-success bullet (silent
+   self-close; the completion report above stays as the diagnostic record;
+   the chain retries on the next router tick). When `N >= 3` — or for any
    non-`verify` phase that did not advance — apply `dispatch:office-hours`
    to the PR (same apply-first / create-on-"not found" idiom as `notify
    deviation` above), report that the loop was broken, and stop (no
@@ -352,10 +358,11 @@ The disposition then resolves in this priority order:
 ### `notify worker-wrong-cwd`
 
 Step 0 detected that the worker was spawned into the wrong cwd. No phase
-ran and no PR is typically resolvable. Print the Step 0 diagnostic to
-stderr, report the variance to the user, and stop (no self-close) — the
-session stays in `claude agents` until the user closes it, so the wrong-cwd
-spawn is visible rather than buried in a closed transcript.
+ran and no PR is typically resolvable. Step 0's bash already echoed the
+stderr diagnostic; emit a user-visible chat report of the variance and
+stop (no self-close) — the session stays in `claude agents` until the user
+closes it, so the wrong-cwd spawn is visible rather than buried in a
+closed transcript.
 
 ### `notify already-done`
 
@@ -365,7 +372,10 @@ worker, so this is a real variance. Resolve the PR with
 `.claude/skills/dispatch/scripts/dispatch-find-pr <N>` and apply
 `dispatch:office-hours` to it with the same apply-first / create-on-"not
 found" idiom as `notify deviation` above so the slip is queued for human
-review. Report the variance and stop (no self-close).
+review. If `dispatch-find-pr` prints nothing (e.g. a transient `gh` failure
+or branch-prefix edge case), print a clear diagnostic to stderr without
+applying the label; the disposition still proceeds. Report the variance
+and stop (no self-close).
 
 ### `notify implement-stop`
 
@@ -400,10 +410,8 @@ Step 4 does not stop the user's live conversation.
 
 ### The #725 daily restart
 
-The #725 daily 9 AM dispatch restart is the workflow's restart-from-zero
-mechanism. It re-seeds the chain when the prior day ended without an
-in-flight worker — covering the cumulative end-of-day drain (every `drain
-waiting` that ended a tick), rate-limit cap reached (#845), predecessor
-crash, and missed ticks (e.g. a WSL shutdown). It is not tied to any one
-disposition; every terminal state, including `notify` paths whose sessions
-the user closes without manual restart, falls within its scope.
+See `/dispatch` Step 7's *The #725 daily restart* subsection — the worker's
+relationship to the daily restart is the same as the router's. Every
+terminal state the worker reaches, including `drain waiting` and every
+`notify <reason>` whose session the user closes without manual restart,
+falls within #725's restart-from-zero scope.

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -42,8 +42,8 @@ case "$ACTUAL_BRANCH" in
 esac
 ```
 
-If the assertion fails, **proceed to Step 4 (early-stop)** — do not derive a
-phase or run a phase skill.
+If the assertion fails, proceed to Step 4 with `notify worker-wrong-cwd` —
+do not derive a phase or run a phase skill.
 
 ## 1. Derive the Phase
 
@@ -74,7 +74,7 @@ Map the phase:
 | `code-review` | draft PR + `dispatch:qa-done` | `/code-review-fix` (applies `dispatch:code-reviewed` itself) |
 | `review` | draft PR + `dispatch:code-reviewed` | `/review-fix` (applies `dispatch:reviewed` itself) |
 | `security` | draft PR + `dispatch:reviewed` (or `dispatch:security-reviewed` — re-entry; `/security-review-fix` is idempotent) | `/security-review-fix` (applies `dispatch:security-reviewed` and marks ready itself) |
-| `done` | non-draft (ready) PR | already complete — report, then Step 4 (early-stop) |
+| `done` | non-draft (ready) PR | already complete — proceed to Step 4 with `notify already-done` |
 
 ## 2. Dispatch One Phase, Then Hand Off
 
@@ -103,8 +103,8 @@ Invoke the one mapped phase skill via the Skill tool. Run exactly one phase per
      the phase from the now-complete CI, then dispatch the resolved phase per
      this step — `/verify-pr` if any check failed, otherwise the green-CI
      phases (`qa` / `code-review` / `review` / `security` / `ready`).
-  4. If the re-derived phase is still `waiting` (CI never registered any check),
-     report it, then **proceed to Step 4** (early-stop) — do not loop.
+  4. If the re-derived phase is still `waiting` (CI never registered any
+     check), proceed to Step 4 with `drain waiting` — do not loop.
 - **`qa`** — invoke `/dispatch-qa`. It owns and applies `dispatch:qa-done`
   itself on a clean pass; `/dispatch-worker` applies no label.
 - **`code-review`** — invoke `/code-review-fix`. It runs `/code-review max`,
@@ -120,15 +120,15 @@ Invoke the one mapped phase skill via the Skill tool. Run exactly one phase per
   CodeQL alerts — then applies the required fixes, posts a PR comment, applies
   the `dispatch:security-reviewed` label, and marks the PR ready. It is
   idempotent on re-entry — `/dispatch-worker` applies no label.
-- **`done`** — report that the PR is already ready, then **proceed to Step 4**
-  (early-stop). No phase skill ran.
+- **`done`** — proceed to Step 4 with `notify already-done`. No phase skill
+  ran; the slip past sweep (#843) flags this PR for office-hours review.
 
 The PR stays a **draft** through every phase; the `security` phase's
 `/security-review-fix` flips it to ready as the workflow's terminal action.
 
-After the one phase skill has run to completion, **proceed to Step 4**
-(phase-completed) — do not advance to the next phase here; Step 4 hands off and
-ends the job.
+After the one phase skill has run to completion, proceed to Step 4 with the
+`propagate` disposition — do not advance to the next phase here; Step 4 hands
+off and ends the job.
 
 `/ultrareview` is intentionally **never** invoked: it is user-triggered and
 billed, so `/dispatch-worker` cannot launch it.
@@ -222,139 +222,188 @@ always owns the verdict.
   understanding, then `/plan-implement`.
 - **`stop`** — codebase has moved past the need; report what changed and
   recommend closing the issue or re-running `/ready`. Do **not** invoke
-  `/plan-implement`; **proceed to Step 4** (early-stop).
+  `/plan-implement`; proceed to Step 4 with `notify implement-stop`.
 
 ## 4. Hand off and self-close
 
 Every Step 0–3 termination routes here — Step 4 is the single way a
-`/dispatch-worker` job ends. A worker that just finished a phase passes the
-baton to a fresh `/dispatch` (router) job and self-closes; that hand-off keeps
-the dispatch chain moving.
+`/dispatch-worker` job ends. The disposition that routed it here determines
+the action.
 
-Each termination reaches Step 4 with one of two dispositions, named by the step
-that routed here:
+The dispatch-chain terminal-disposition invariant is stated in `/dispatch`
+Step 7 and applies equally here — every disposition other than `propagate`
+on success emits a user-visible report before any tool action; a silent
+`notify` or silent `drain` is a defect.
 
-- **phase-completed** — a phase skill (`/plan-implement`, `/verify-pr`,
-  `/dispatch-qa`, `/code-review-fix`, `/review-fix`, or `/security-review-fix`)
-  ran to completion. Only the Step 2 post-dispatch hand-off arrives this way.
-- **early-stop** — the job stopped before any phase skill completed: a Step 0
-  cwd-verification failure, a `done` phase, a `waiting` phase that stayed
-  `waiting`, or an `implement` relevance verdict of `stop`.
+The worker reaches Step 4 with one of these dispositions:
 
-Run these in order.
+| Disposition | Source |
+|---|---|
+| `propagate` (silent on success; falls through to `notify spawn-failed` / `notify deviation` / `notify phase-non-advancement` per the priority below) | Step 2 — phase skill ran to completion |
+| `notify worker-wrong-cwd` | Step 0 — cwd verification failed |
+| `notify already-done` | Step 2 — `done` phase (non-draft PR slipped past sweep) |
+| `notify implement-stop` | Step 3 — relevance verdict `stop` |
+| `drain waiting` | Step 2 — `waiting` phase stayed `waiting` after the CI subagent returned |
 
-**1. No worktree to exit.** The worker was born in its target worktree and
-never entered another worktree mid-session — there is nothing to exit. The
-router (`/dispatch`) is what runs in `worktrees/main`; this worker's lifetime
-ends here, in its target worktree.
+The worker was born in its target worktree and never entered another
+worktree mid-session — there is nothing to exit. The router (`/dispatch`)
+is what runs in `worktrees/main`; this worker's lifetime ends here, in its
+target worktree.
 
-**2. Pass the baton.** On the **phase-completed** disposition only, spawn a
-fresh `/dispatch` (router) job back in `worktrees/main` (run with
-`dangerouslyDisableSandbox: true` — the script reaches the local Claude daemon
-over a socket; see `.claude/rules/sandbox.md`):
+### `propagate`
+
+The phase skill ran to completion; the chain moves forward. Spawn a fresh
+`/dispatch` (router) job back in `worktrees/main`
+(`dangerouslyDisableSandbox: true` — the script reaches the local Claude
+daemon over a socket; see `.claude/rules/sandbox.md`):
 
 ```bash
 .claude/skills/dispatch/scripts/dispatch-spawn-router
 ```
 
 The worker spawns a `/dispatch` router, not another worker — the router will
-select the next target and spawn its worker. The script prints `spawned` (a
-successor was started) or `deduped` (another `dispatch-*` job is already
-running, so none was needed) and exits 0; it exits non-zero when a job was
-spawned but did not register. **early-stop** dispositions skip this step —
-they spawn no successor; the #725 heartbeat re-seeds the chain if it has
-drained.
+select the next target and spawn its worker. The script prints `spawned` or
+`deduped` and exits 0 on success; exits non-zero when a job was spawned but
+did not register.
 
-**3. Print the completion report.** State what this job did: the phase that
-ran and its outcome, or the reason it stopped early.
+Print the completion report — the phase that ran and its outcome.
 
-**4. Terminal disposition.** Take exactly one of the following, in this
-priority:
+The disposition then resolves in this priority order:
 
-- **`dispatch-spawn-router` failed** — a phase-completed run whose step-2 spawn
-  exited non-zero. Do **not** self-close. Report the failed baton-pass and
-  stop, leaving this job open so the failure is visible and the spawn can be
-  retried.
+1. **`notify spawn-failed`** — `dispatch-spawn-router` exited non-zero. Do
+   **not** self-close. Report the failed baton-pass and stop, leaving this
+   job open so the failure is visible and the spawn can be retried.
 
-- **The report surfaces a deviation** — a phase-completed run whose step-2
-  spawn succeeded, but whose completion report surfaces a deviation from the
-  approved plan, or a result that does not fully satisfy the issue's acceptance
-  criteria. Do **not** self-close — self-closing would bury the deviation in a
-  closed job's transcript. The baton was already passed in step 2, so the chain
-  keeps moving; route this item to the office-hours queue for human review.
-  Resolve the PR for the target with
-  `.claude/skills/dispatch/scripts/dispatch-find-pr <N>` and apply the
-  `dispatch:office-hours` label to it (`gh`, `dangerouslyDisableSandbox: true`):
+2. **`notify deviation`** — spawn succeeded, but the completion report
+   surfaces a deviation from the approved plan, or a result that does not
+   fully satisfy the issue's acceptance criteria. Self-closing would bury
+   the deviation in a closed job's transcript; instead, route the item to
+   the office-hours queue for human review. Resolve the PR for the target
+   with `.claude/skills/dispatch/scripts/dispatch-find-pr <N>` and apply
+   the `dispatch:office-hours` label (`gh`,
+   `dangerouslyDisableSandbox: true`):
 
-  ```bash
-  gh pr edit <pr-num> --add-label dispatch:office-hours
-  ```
+   ```bash
+   gh pr edit <pr-num> --add-label dispatch:office-hours
+   ```
 
-  If that fails because the label does not exist yet, create it and retry —
-  the same apply-first / create-on-"not found" idiom `dispatch-complete-phase`
-  uses:
+   If that fails because the label does not exist yet, create it and retry —
+   the same apply-first / create-on-"not found" idiom `dispatch-complete-phase`
+   uses:
 
-  ```bash
-  gh label create dispatch:office-hours \
-    --description "dispatch workflow: blocked on a human — awaiting input or review"
-  gh pr edit <pr-num> --add-label dispatch:office-hours
-  ```
+   ```bash
+   gh label create dispatch:office-hours \
+     --description "dispatch workflow: blocked on a human — awaiting input or review"
+   gh pr edit <pr-num> --add-label dispatch:office-hours
+   ```
 
-  Pass no `--color`: `dispatch-complete-phase` is the single source of the
-  `dispatch:*` label-colour metadata, and #757 owns `dispatch:office-hours`'s
-  canonical definition — Step 4 only needs the label to exist.
-  `dispatch:office-hours` is the office-hours queue's marker, shared with #757,
-  whose input-block detection hooks are the label's other writer; whichever
-  writer runs first creates it. Then stop — report that the item is parked in
-  the office-hours queue for human review.
+   Pass no `--color`: `dispatch-complete-phase` is the single source of the
+   `dispatch:*` label-colour metadata, and #757 owns `dispatch:office-hours`'s
+   canonical definition — this step only needs the label to exist.
+   `dispatch:office-hours` is the office-hours queue's marker, shared with
+   #757, whose input-block detection hooks are the label's other writer;
+   whichever writer runs first creates it. Then report that the item is
+   parked in the office-hours queue for human review, and stop (no
+   self-close).
 
-- **Phase did not advance** — a phase-completed run whose step-2 spawn
-  succeeded, but where the phase skill returned success without flipping its
-  workflow marker. Without this check, the next router tick re-derives the
-  same phase, spawns a worker, runs the same phase skill, and loops forever —
-  nothing observable has changed. Re-derive the phase against current PR/CI
-  ground truth:
+3. **`notify phase-non-advancement`** — spawn succeeded, but the phase skill
+   returned success without flipping its workflow marker. Without this
+   check, the next router tick would re-derive the same phase, spawn a
+   worker, run the same phase skill, and loop forever — nothing observable
+   has changed. Re-derive the phase against current PR/CI ground truth:
 
-  ```bash
-  .claude/skills/dispatch/scripts/dispatch-phase <N>
-  ```
+   ```bash
+   .claude/skills/dispatch/scripts/dispatch-phase <N>
+   ```
 
-  If the re-derived phase **differs** from the phase that just ran, the
-  workflow advanced — skip this bullet and fall through to the next one.
+   If the re-derived phase **differs** from the phase that just ran, the
+   workflow advanced — fall through to the silent propagate-success bullet.
 
-  If the re-derived phase **equals** the phase that just ran, the workflow did
-  not advance. Apply the verify-phase exemption: `/verify-pr` does not flip a
-  marker on a single pass (CI re-runs in the background and either flips the
-  PR back to `qa` or stays in `verify`), and is allowed up to 3 cumulative
-  attempts. For a non-advanced `verify` phase, read the highest extant
-  `dispatch:verify-attempt-<n>` label on the PR
-  (`dangerouslyDisableSandbox: true` — `gh`):
+   If the re-derived phase **equals** the phase that just ran, the workflow
+   did not advance. Apply the verify-phase exemption: `/verify-pr` does not
+   flip a marker on a single pass (CI re-runs in the background and either
+   flips the PR back to `qa` or stays in `verify`), and is allowed up to 3
+   cumulative attempts. For a non-advanced `verify` phase, read the highest
+   extant `dispatch:verify-attempt-<n>` label on the PR
+   (`dangerouslyDisableSandbox: true` — `gh`):
 
-  ```bash
-  PR_NUM=$(.claude/skills/dispatch/scripts/dispatch-find-pr <N>)
-  N=$(gh pr view "$PR_NUM" --json labels \
-    --jq '[.labels[].name | capture("^dispatch:verify-attempt-(?<n>[0-9]+)$").n | tonumber] | max // 0')
-  ```
+   ```bash
+   PR_NUM=$(.claude/skills/dispatch/scripts/dispatch-find-pr <N>)
+   N=$(gh pr view "$PR_NUM" --json labels \
+     --jq '[.labels[].name | capture("^dispatch:verify-attempt-(?<n>[0-9]+)$").n | tonumber] | max // 0')
+   ```
 
-  When `N < 3`, fall through to the clean-completion bullet (the chain
-  retries on the next router tick). When `N >= 3` — or for any non-`verify`
-  phase that did not advance — apply `dispatch:office-hours` to the PR (same
-  apply-first / create-on-"not found" idiom as the deviation bullet above)
-  and stop. Do **not** self-close; the parked job's transcript is the
-  diagnostic record of the loop the chain just escaped.
+   When `N < 3`, fall through to the silent propagate-success bullet (the
+   chain retries on the next router tick). When `N >= 3` — or for any
+   non-`verify` phase that did not advance — apply `dispatch:office-hours`
+   to the PR (same apply-first / create-on-"not found" idiom as `notify
+   deviation` above), report that the loop was broken, and stop (no
+   self-close). The parked job's transcript is the diagnostic record of the
+   loop the chain just escaped.
 
-- **Clean completion or early-stop** — an early-stop, or a phase-completed run
-  whose `dispatch-spawn-router` succeeded and whose report surfaces nothing that needs
-  the user. Self-close (`dangerouslyDisableSandbox: true`):
+4. **propagate-success (silent)** — spawn succeeded, no deviation, phase
+   advanced. This is the only silent terminal path. Self-close
+   (`dangerouslyDisableSandbox: true`):
 
-  ```bash
-  .claude/skills/dispatch/scripts/dispatch-self-close
-  ```
+   ```bash
+   .claude/skills/dispatch/scripts/dispatch-self-close
+   ```
 
-  The script stops the managed background job by its job-id (the basename of
-  `$CLAUDE_JOB_DIR`, which is what `claude stop` expects — not the conversation
-  session UUID, not the registry's `.sessionId`). It is a no-op when
-  `CLAUDE_JOB_DIR` is unset (the session is interactive, not a managed
-  background job) — so an interactive `/dispatch-worker` reaching Step 4 does
-  not stop the user's live conversation. The job ends; the router it spawned —
-  or, for an early-stop, the #725 heartbeat — carries the workflow forward.
+### `notify worker-wrong-cwd`
+
+Step 0 detected that the worker was spawned into the wrong cwd. No phase
+ran and no PR is typically resolvable. Print the Step 0 diagnostic to
+stderr, report the variance to the user, and stop (no self-close) — the
+session stays in `claude agents` until the user closes it, so the wrong-cwd
+spawn is visible rather than buried in a closed transcript.
+
+### `notify already-done`
+
+Step 2 found a non-draft (ready) PR (`done` phase) that slipped past the
+sweep — `dispatch-sweep` (#843) is meant to adopt these before they reach a
+worker, so this is a real variance. Resolve the PR with
+`.claude/skills/dispatch/scripts/dispatch-find-pr <N>` and apply
+`dispatch:office-hours` to it with the same apply-first / create-on-"not
+found" idiom as `notify deviation` above so the slip is queued for human
+review. Report the variance and stop (no self-close).
+
+### `notify implement-stop`
+
+Step 3's relevance verdict was `stop` — the codebase has moved past the
+issue's need. No PR exists yet for an `implement`-phase target, so there is
+nothing to label. Print the Step 3 drift report (what changed, the
+recommendation to close the issue or re-run `/ready`), and stop (no
+self-close).
+
+### `drain waiting`
+
+Step 2's CI subagent returned but the re-derived phase is still `waiting`
+because CI registered no checks. Print a **mandatory** user-visible report
+("CI registered no checks for issue `<N>`'s draft PR; closing — #725
+restart will re-check at 9 AM"), then self-close
+(`dangerouslyDisableSandbox: true`):
+
+```bash
+.claude/skills/dispatch/scripts/dispatch-self-close
+```
+
+A silent `drain` is a defect.
+
+---
+
+`dispatch-self-close` stops the managed background job by its job-id (the
+basename of `$CLAUDE_JOB_DIR`, which is what `claude stop` expects — not
+the conversation session UUID, not the registry's `.sessionId`). It is a
+no-op when `CLAUDE_JOB_DIR` is unset (the session is interactive, not a
+managed background job) — so an interactive `/dispatch-worker` reaching
+Step 4 does not stop the user's live conversation.
+
+### The #725 daily restart
+
+The #725 daily 9 AM dispatch restart is the workflow's restart-from-zero
+mechanism. It re-seeds the chain when the prior day ended without an
+in-flight worker — covering the cumulative end-of-day drain (every `drain
+waiting` that ended a tick), rate-limit cap reached (#845), predecessor
+crash, and missed ticks (e.g. a WSL shutdown). It is not tied to any one
+disposition; every terminal state, including `notify` paths whose sessions
+the user closes without manual restart, falls within its scope.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -511,8 +511,10 @@ the action.
 **Invariant**: the only silent terminal path is `propagate` on success.
 Every other terminal disposition — `propagate` falling through to `notify
 spawn-failed` on a failed spawn, every `notify <reason>` variance, every
-`drain <reason>` no-work case — emits a user-visible report before any tool
-action. A silent `notify` or silent `drain` is a defect.
+`drain <reason>` no-work case — emits a user-visible report before the
+session ends (before `dispatch-self-close` for `drain` and `propagate`;
+before this turn's text output completes for `notify`, which does not
+self-close). A silent `notify` or silent `drain` is a defect.
 
 The three dispositions:
 

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -79,6 +79,10 @@ command:
   Stop paths fire before the marker is written, so the strict
   `CLAUDE_CODE_SESSION_ID`-match branch applies.
 
+The `main-broken` stop path is the one exception: `/dispatch-diagnose-main`
+runs `--release` itself as its Step 3, so `/dispatch` Step 3's `main-broken`
+branch must not call `--release` again.
+
 Both calls need `dangerouslyDisableSandbox: true` (same reason as Step 0); no
 elevated timeout is needed — `--release` returns immediately. They print
 `released` or `noop`; both are fine — `noop` is a no-op when the lock is
@@ -548,10 +552,8 @@ The three dispositions:
 - **`drain <reason>`** — `drain empty-queue` (Step 3, queue empty) or
   `drain worktree-conflict` (Step 5, target's worktree is owned by another
   live session). The call site has already printed a **mandatory**
-  user-visible report stating the reason and the recovery path ("queue
-  empty — closing; #725 restart will re-check at 9 AM" / "worktree at
-  `<path>` owned by another live session for issue `<N>`; closing — #725
-  restart will re-check at 9 AM"). Then self-close
+  user-visible report stating the reason and the recovery path (templates
+  live at the Step 3 and Step 5 call sites). Then self-close
   (`dangerouslyDisableSandbox: true`):
 
   ```bash

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -14,8 +14,9 @@ Each `/dispatch` is a `claude --bg` background job (#725) rooted in
 `worktrees/main`. The router selects, spawns a worker, and exits. The worker
 runs one phase in its target worktree, then spawns a fresh `/dispatch` router
 back in `worktrees/main` and self-deletes. That router → worker → router
-chain advances the workflow; the #725 heartbeat re-seeds it when no job is
-running.
+chain advances the workflow; the #725 daily 9 AM restart-from-zero re-seeds
+it when the prior day ended without an in-flight worker (see Step 7's
+*The #725 daily restart* subsection).
 
 `/dispatch` takes an **optional issue-or-PR-number argument** (leading `#`
 optional). With an argument, it targets that issue and skips the queue scan; a
@@ -56,9 +57,9 @@ Route on `$LOCK`:
 - **`acquired`** → this `/dispatch` holds the lock; proceed to Step 1.
 - **`busy`** → the wait timeout elapsed without acquiring — a wedged selection
   in another `/dispatch`. The script's **stderr** carries a one-line diagnostic
-  naming the wait duration and the holding sessionId; report those then **proceed
-  to Step 7** (early-stop) — run no sync, no health gate, no sweep, no selection,
-  and no phase skill.
+  naming the wait duration and the holding sessionId; report those, then proceed
+  to Step 7 with `notify busy-lock-timeout` (subsumes #850) — run no sync, no
+  health gate, no sweep, no selection, and no phase skill.
 
 ### Releasing the lock
 
@@ -73,7 +74,7 @@ command:
   `tmp/dispatch-worktree` marker (see *Step 5* and the marker paragraph below)
   and execs `dispatch-acquire-lock --release` in one step.
 - **Every Steps 1-5 stop path** — immediately before reporting the stop reason
-  and proceeding to Step 7 (early-stop), run
+  and proceeding to Step 7, run
   `.claude/skills/dispatch/scripts/dispatch-acquire-lock --release` directly.
   Stop paths fire before the marker is written, so the strict
   `CLAUDE_CODE_SESSION_ID`-match branch applies.
@@ -157,8 +158,8 @@ It is a no-op when local `main` already equals `origin/main`.
 
 - If `git fetch` fails, or `git merge --ff-only` rejects a non-fast-forward (local
   `main` has diverged with unexpected commits), release the lock (see *Releasing
-  the lock*), surface the error, then **proceed to Step 7** (early-stop) — do
-  not proceed to target selection.
+  the lock*), surface the error, then proceed to Step 7 with `notify sync-failed`
+  — do not proceed to target selection.
 
 ## 2. Run the JIT Engine
 
@@ -201,11 +202,10 @@ continue to target selection.
   - **Exit 0** → `$TARGET` is the target issue number; that issue is the target.
     Skip the queue scan.
   - **Non-zero exit** → release the lock (see *Releasing the lock*), report the
-    script's stderr message, then **proceed to Step 7** (early-stop); create no
-    worktree. This covers a PR
-    that closes no issue, a PR that closes more than one issue, and an argument
-    that is neither an issue nor a PR — consistent with the other Steps 1-5 stop
-    paths.
+    script's stderr message, then proceed to Step 7 with `notify resolver-failed`;
+    create no worktree. This covers a PR that closes no issue, a PR that closes
+    more than one issue, and an argument that is neither an issue nor a PR —
+    consistent with the other Steps 1-5 stop paths.
 
 - **No argument** → run target selection. A single invocation decides every
   Step 3 outcome: current-worktree continuation, JIT, main-broken gate, sweep
@@ -226,8 +226,9 @@ continue to target selection.
   - `worktree-closed <N> <branch>` — the current branch is `<N>-…` and issue
     `<N>` is closed or unrecognized. Release the lock (see *Releasing the
     lock*), report that the current worktree belongs to closed/unrecognized
-    issue `<N>`, then **proceed to Step 7** (early-stop) (consistent with the
-    named-target "closed → report and stop" rule in Step 4).
+    issue `<N>`, then proceed to Step 7 with `notify worktree-closed`
+    (consistent with the named-target "closed → report and stop" rule in
+    Step 4).
   - `worktree-adopted <N> <branch>` — `dispatch-sweep` adopted an orphaned
     worktree elsewhere on disk. Skip Step 4 and proceed to Step 5 with `<N>` and
     mode `explicit` — treat the adoption like an explicit `/dispatch <N>`.
@@ -250,9 +251,12 @@ continue to target selection.
     for routing here. Treat the returned line as a fresh `$SELECTED` and route
     on it as above. This is the only sweep path that can destroy
     potentially-unmerged code.
-  - `main-broken <sha>` — invoke `/dispatch-diagnose-main <sha>`, then
-    **proceed to Step 7** (early-stop). The skill owns the failing-check
-    enumeration, log-fetch, summary, lock-release, and stop.
+  - `main-broken <sha>` — invoke `/dispatch-diagnose-main <sha>`, then proceed
+    to Step 7 with `notify main-broken`. The skill owns the failing-check
+    enumeration, log-fetch, summary, and lock-release; the caller-side
+    `notify main-broken` disposition keeps the session in `claude agents`
+    until the user closes it, so the diagnosis stays visible rather than
+    being buried in a closed transcript.
   - `jit-reminder <repo> <num> <project> <item-id>` — invoke
     `/dispatch-jit-reminder <repo> <num> <project> <item-id>`, then stop the
     tick directly (the skill is a Step 7 bypass — its user-visible summary must
@@ -260,7 +264,9 @@ continue to target selection.
     + lock-release + summarize + stop sequence; Steps 4, 5, and 6 are all
     skipped.
   - `empty` — nothing eligible. Release the lock (see *Releasing the lock*),
-    report that the queue is empty, then **proceed to Step 7** (early-stop).
+    then proceed to Step 7 with `drain empty-queue` — the user-visible report
+    is mandatory there ("queue empty — closing; #725 restart will re-check at
+    9 AM"), not optional.
 
   An **explicit issue argument overrides current-worktree detection** — the
   selection script, and therefore its current-worktree detection, runs only
@@ -335,12 +341,45 @@ Skip leaf tracing when:
 
 If the resolved target issue `<N>` has any **open** blocker — run
 `issue-blocking <N>` and check for any entry with `state` `OPEN` — release the
-lock (see *Releasing the lock*), report the open blocker, then **proceed to
-Step 7** (early-stop). This guard applies even when a PR exists; closed blockers
-do not gate.
+lock (see *Releasing the lock*), report the open blocker, apply
+`dispatch:office-hours` to the target's PR if one exists (see *Applying
+`dispatch:office-hours`* below), then proceed to Step 7 with
+`notify target-blocked`. This guard applies even when a PR exists; closed
+blockers do not gate.
 
 If a named target issue is **closed**, release the lock (see *Releasing the
-lock*), report it, then **proceed to Step 7** (early-stop).
+lock*), report it, apply `dispatch:office-hours` to the target's PR if one
+exists (see *Applying `dispatch:office-hours`* below), then proceed to Step 7
+with `notify target-blocked`.
+
+### Applying `dispatch:office-hours`
+
+`notify target-blocked` queues the target for human review by applying
+`dispatch:office-hours` to its PR when one exists. Resolve the PR with
+`.claude/skills/dispatch/scripts/dispatch-find-pr <N>`; if it prints a PR
+number, apply the label with the apply-first / create-on-"not found" idiom
+(`gh`, `dangerouslyDisableSandbox: true`):
+
+```bash
+gh pr edit <pr-num> --add-label dispatch:office-hours
+```
+
+If the first call fails because the label does not exist yet, create it and
+retry — the same idiom `dispatch-complete-phase` uses:
+
+```bash
+gh label create dispatch:office-hours \
+  --description "dispatch workflow: blocked on a human — awaiting input or review"
+gh pr edit <pr-num> --add-label dispatch:office-hours
+```
+
+Pass no `--color`: `dispatch-complete-phase` is the single source of the
+`dispatch:*` label-colour metadata, and #757 owns `dispatch:office-hours`'s
+canonical definition — this call site only needs the label to exist.
+
+If `dispatch-find-pr` prints nothing, print a clear diagnostic to stderr
+without applying the label; the disposition still proceeds to Step 7 as
+`notify target-blocked` and the session stays open in `claude agents`.
 
 ## 5. Resolve the Worktree
 
@@ -409,9 +448,11 @@ worktree path that Step 6 will pass to `dispatch-spawn-worker`.
   another session owns it. (`dispatch-select-target` resolves the `help wanted`
   tier to a leaf with no worktree, so for a queue selection this arises only from
   a race — another session created the worktree between selection and worktree
-  resolution.) Release the lock (see *Releasing the lock*), then report the
-  conflict (name `<path>` and issue `<N>`), then **proceed to Step 7**
-  (early-stop); do not spawn a worker.
+  resolution.) Release the lock (see *Releasing the lock*), then proceed to
+  Step 7 with `drain worktree-conflict` — the user-visible report is mandatory
+  there ("worktree at `<path>` owned by another live session for issue `<N>`;
+  closing — #725 restart will re-check at 9 AM"), not optional. Do not spawn a
+  worker.
 
 On every non-`conflict` path, before the worker is spawned, create the recovery
 marker **inside the target worktree** (`$WORKTREE_PATH`):
@@ -432,7 +473,7 @@ in-skill defense for the `here` path and for any code path that bypasses the
 hook. The router itself never writes the marker
 into its own cwd (`worktrees/main`), so a `SessionStart:clear` there is a
 no-op — correct, since the router is short-lived and re-seeded by the #725
-heartbeat. The marker is an empty boolean flag with no payload; it persists
+daily restart. The marker is an empty boolean flag with no payload; it persists
 for the worktree's life and needs no cleanup — `tmp/` is git-ignored, and
 removing the worktree removes it.
 
@@ -464,33 +505,78 @@ After the spawn returns, **proceed to Step 7** (terminal disposition).
 
 ## 7. Terminal Disposition
 
-The router's tick ends here. There are two dispositions:
+The router's tick ends here. The disposition that routed it here determines
+the action.
 
-- **spawn-failed** — the Step 6 `dispatch-spawn-worker` call exited non-zero
-  (a worker was spawned but did not register). Do **not** self-close. Report
-  the failed spawn and stop, leaving this router job open so the failure is
-  visible and the spawn can be retried.
+**Invariant**: the only silent terminal path is `propagate` on success.
+Every other terminal disposition — `propagate` falling through to `notify
+spawn-failed` on a failed spawn, every `notify <reason>` variance, every
+`drain <reason>` no-work case — emits a user-visible report before any tool
+action. A silent `notify` or silent `drain` is a defect.
 
-- **clean completion or early-stop** — every other terminal path:
-  - Step 6 returned `spawned` or `deduped` (clean completion).
-  - A Steps 0–5 stop path (busy lock, sync failure, empty queue, `main-broken`,
-    resolver failure, `worktree-closed`, closed-issue target, open-blocker
-    gate, `worktree` conflict, jit-reminder summary). The jit-reminder
-    summary is an exception that **does not self-close** — it bypasses Step 7
-    entirely, per the jit-reminder handler in Step 3.
+The three dispositions:
 
-  Self-close (`dangerouslyDisableSandbox: true`):
+- **`propagate`** — Step 6's `dispatch-spawn-worker` returned `spawned` or
+  `deduped`. The chain moved forward. Self-close
+  (`dangerouslyDisableSandbox: true`):
 
   ```bash
   .claude/skills/dispatch/scripts/dispatch-self-close
   ```
 
-  The script removes the managed background job by its job-id (the basename of
-  `$CLAUDE_JOB_DIR`). It is a no-op when `CLAUDE_JOB_DIR` is unset (the
-  session is interactive, not a managed background job) — so an interactive
-  `/dispatch` reaching Step 7 does not stop the user's live conversation.
+- **`notify <reason>`** — `notify spawn-failed` (Step 6's spawn exited
+  non-zero) or any Steps 0–5 variance. The call site has already printed a
+  user-visible report; for `notify target-blocked` it has also applied
+  `dispatch:office-hours` to the target's PR when one is resolvable (see
+  Step 4's *Applying `dispatch:office-hours`* subsection). Do **not**
+  self-close — the session stays in `claude agents` until the user closes
+  it, so the variance is visible rather than buried in a closed transcript.
+
+  The Steps 0–5 `notify` variances and their sources:
+
+  | Disposition | Source |
+  |---|---|
+  | `notify busy-lock-timeout` | Step 0 — wait timeout while another router holds the lock (subsumes #850) |
+  | `notify sync-failed` | Step 1 — `git fetch` failed or `git merge --ff-only` rejected a non-fast-forward |
+  | `notify resolver-failed` | Step 3 — `dispatch-resolve-arg` non-zero (PR closes ≠1 issue, bad argument) |
+  | `notify worktree-closed` | Step 3 — current worktree belongs to a closed or unrecognized issue |
+  | `notify main-broken` | Step 3 — `/dispatch-diagnose-main` ran and returned (`origin/main` is red) |
+  | `notify target-blocked` | Step 4 — named target is closed or has an open blocker |
+
+- **`drain <reason>`** — `drain empty-queue` (Step 3, queue empty) or
+  `drain worktree-conflict` (Step 5, target's worktree is owned by another
+  live session). The call site has already printed a **mandatory**
+  user-visible report stating the reason and the recovery path ("queue
+  empty — closing; #725 restart will re-check at 9 AM" / "worktree at
+  `<path>` owned by another live session for issue `<N>`; closing — #725
+  restart will re-check at 9 AM"). Then self-close
+  (`dangerouslyDisableSandbox: true`):
+
+  ```bash
+  .claude/skills/dispatch/scripts/dispatch-self-close
+  ```
+
+`dispatch-self-close` removes the managed background job by its job-id (the
+basename of `$CLAUDE_JOB_DIR`). It is a no-op when `CLAUDE_JOB_DIR` is unset
+(the session is interactive, not a managed background job) — so an
+interactive `/dispatch` reaching Step 7 does not stop the user's live
+conversation.
+
+Step 3's `jit-reminder` and `cleanup-unknown` outcomes do not reach Step 7.
+`jit-reminder` is a deliberate bypass — its user-visible summary must stay
+open in the transcript for a human to read, so the skill stops the tick
+directly. `cleanup-unknown` returns to Step 3's routing.
 
 The router does **not** spawn a successor `/dispatch` itself — the worker
-spawned in Step 6 will spawn a fresh router back in `worktrees/main` when its
-phase completes (`/dispatch-worker` Step 4). For early-stop dispositions, no
-worker was spawned; the #725 heartbeat re-seeds the chain if it has drained.
+spawned in Step 6 spawns a fresh router back in `worktrees/main` when its
+phase completes (`/dispatch-worker` Step 4).
+
+### The #725 daily restart
+
+The #725 daily 9 AM dispatch restart is the workflow's restart-from-zero
+mechanism. It re-seeds the chain when the prior day ended without an
+in-flight worker — covering the cumulative end-of-day drain (every `drain`
+disposition that ended a tick), rate-limit cap reached (#845), predecessor
+crash, and missed ticks (e.g. a WSL shutdown). It is not tied to any one
+disposition; every terminal state, including `notify` paths whose sessions
+the user closes without manual restart, falls within its scope.


### PR DESCRIPTION
## Summary

Reclassifies every dispatch-chain terminal stop path in the router and worker SKILL.md files into one of three dispositions:

- **`propagate`** — the chain moved forward (silent on success; the only silent terminal path).
- **`notify <reason>`** — a real variance. User-visible report, apply `dispatch:office-hours` to the target's PR if resolvable, do **not** self-close (session stays in `claude agents` until the user closes it).
- **`drain <reason>`** — no work currently available. **Mandatory** user-visible report stating the reason and the recovery path, then self-close.

Closes the silent-self-close-on-variance leak documented in #853: a sandboxed merge failure or wedged lock no longer disappears into a closed transcript.

### Call-site mapping

| Step | Disposition |
|---|---|
| Router Step 0 — busy-lock timeout | `notify busy-lock-timeout` (subsumes #850) |
| Router Step 1 — sync failed | `notify sync-failed` |
| Router Step 3 — resolver failed | `notify resolver-failed` |
| Router Step 3 — worktree-closed | `notify worktree-closed` |
| Router Step 3 — main-broken (post-/dispatch-diagnose-main) | `notify main-broken` |
| Router Step 3 — empty queue | `drain empty-queue` |
| Router Step 4 — closed target / open blocker | `notify target-blocked` |
| Router Step 5 — worktree conflict | `drain worktree-conflict` |
| Router Step 6 — spawn-worker failed | `notify spawn-failed` |
| Router Step 6 — spawn-worker success | `propagate` |
| Worker Step 0 — wrong cwd | `notify worker-wrong-cwd` |
| Worker Step 2 — `done` phase | `notify already-done` |
| Worker Step 2 — `waiting` stays `waiting` | `drain waiting` |
| Worker Step 3 — implement-stop verdict | `notify implement-stop` |
| Worker Step 4 — phase completed | `propagate` (falls through to `notify spawn-failed` / `notify deviation` / `notify phase-non-advancement` on the priority ladder) |

### Invariant

The only silent terminal path is `propagate` on success. Every other disposition — `propagate` falling through to `notify spawn-failed`, every `notify <reason>` variance, every `drain <reason>` no-work case — emits a user-visible report before any tool action. Stated in `/dispatch` Step 7; `/dispatch-worker` Step 4 references it rather than restating.

### #725 prose

The #725 daily 9 AM dispatch restart is reframed across both SKILL.md files as the daily restart-from-zero mechanism — covers cumulative end-of-day drain, rate-limit cap reached (#845), predecessor crash, and missed ticks. No longer tied to a specific disposition.

## Test plan

- [ ] End-to-end manual repro: trigger a sandboxed `git merge` failure in router Step 1 and verify the session produces a user-visible report, applies `dispatch:office-hours` if a PR is resolvable, and stays in `claude agents` until the user closes it.
- [ ] End-to-end manual repro: trigger router Step 3 `empty` and verify the mandatory drain report ("queue empty — closing; #725 restart will re-check at 9 AM") appears before self-close.
- [ ] End-to-end manual repro: trigger worker Step 2 `waiting`-stays-`waiting` and verify the mandatory drain report appears before self-close.
- [ ] Verify `/dispatch-diagnose-main` invocation results in `notify main-broken` and the session stays open in `claude agents`.

Closes #853.

🤖 Generated with [Claude Code](https://claude.com/claude-code)