### PR TITLE
dispatch: scale concurrent /dispatch-worker count to a target rate-limit-window usage

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -517,6 +517,13 @@ many concurrent `dispatch-worker-*` sessions should run:
   | 1h (3600s)     | 0.8             | 40%    |
   | 0              | 1.0             | 50%    |
 
+  At window-start, `cap_5h = 0` and the gate condition `used_5h >= cap_5h`
+  evaluates as `0 >= 0`, so spawning is briefly paused for the first slice of
+  every 5h window. This is intentional — the linear schedule enforces the
+  per-window ceiling from second zero. The blackout clears as soon as `cap_5h`
+  rises above the current `used_5h`; if `used_5h` was 0 at refresh, this
+  happens within seconds.
+
 Tunables (each optional in `dispatch.config/target-workers.json`; defaults
 baked into the script):
 

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -442,25 +442,102 @@ the lock*). The worker in Step 6 onward runs lock-free.
 
 ## 6. Spawn the Worker
 
-Spawn a `/dispatch-worker <N>` background job with `cwd=$WORKTREE_PATH` (the
-path resolved in Step 5). Run with `dangerouslyDisableSandbox: true` — the
-script reaches the local Claude daemon over a socket; see
-`.claude/rules/sandbox.md`:
+Before spawning, consult the concurrency budgeter (see *Concurrency
+budgeting* below). If the live worker count already meets the target,
+**skip the spawn** for this tick — the chain re-seeds on the next router
+tick when budget reopens. Run with `dangerouslyDisableSandbox: true` — both
+the budgeter and `lib-claude-agents.sh` reach the local Claude daemon over a
+socket; see `.claude/rules/sandbox.md`:
 
 ```bash
-.claude/skills/dispatch/scripts/dispatch-spawn-worker <N> "$WORKTREE_PATH"
+source .claude/skills/dispatch/scripts/lib-claude-agents.sh
+TARGET_N=$(.claude/skills/dispatch/scripts/dispatch-target-workers)
+if LIVE_COUNT=$(claude_agents_count_by_name_prefix dispatch-worker-); then
+  if (( LIVE_COUNT >= TARGET_N )); then
+    echo "router: skipping spawn — $LIVE_COUNT live worker(s) >= target $TARGET_N"
+    # Skip-over-cap is a clean completion; proceed to Step 7.
+  else
+    .claude/skills/dispatch/scripts/dispatch-spawn-worker <N> "$WORKTREE_PATH"
+  fi
+else
+  # UNKNOWN — daemon query failed. Fail open and proceed to spawn; the
+  # per-worktree dedup inside dispatch-spawn-worker is the last-line
+  # defense if a worker is already there.
+  .claude/skills/dispatch/scripts/dispatch-spawn-worker <N> "$WORKTREE_PATH"
+fi
 ```
 
-It prints `spawned` (a worker was started) or `deduped` (another `dispatch-*`
-session is already live at `$WORKTREE_PATH` — the per-worktree invariant
-prevents two workers from racing on the same worktree) and exits 0; it exits
-non-zero when a worker was spawned but did not register.
+`dispatch-spawn-worker` prints `spawned` (a worker was started) or `deduped`
+(another `dispatch-*` session is already live at `$WORKTREE_PATH` — the
+per-worktree invariant prevents two workers from racing on the same worktree)
+and exits 0; it exits non-zero when a worker was spawned but did not register.
 
 The router never derives the phase, runs a phase skill, or invokes the
 pre-implementation relevance review — those are the worker's responsibilities
 (`/dispatch-worker` Steps 1–3).
 
-After the spawn returns, **proceed to Step 7** (terminal disposition).
+After the spawn (or skip) returns, **proceed to Step 7** (terminal disposition).
+
+### Concurrency budgeting
+
+`dispatch-target-workers` composes two open-loop schedules that decide how
+many concurrent `dispatch-worker-*` sessions should run:
+
+- **Weekly ramp** (sets the magnitude) — drives target_N
+  conservative-early/aggressive-late toward `target_weekly_usage_pct` by the
+  weekly window's `resets_at`. The shape is
+  `(tau / (remaining_weekly + tau)) ^ k`; smaller `tau` and larger `k` mean
+  more deferred consumption.
+
+  | remaining_weekly | ramp_weekly | candidate target_N |
+  |------------------|------------:|-------------------:|
+  | 7 days (604800s) | 0.0156      | 0                  |
+  | 3 days (259200s) | 0.0625      | 1                  |
+  | 1 day (86400s)   | 0.25        | 2                  |
+  | 6 hours (21600s) | 0.64        | 5                  |
+  | 1 hour (3600s)   | 0.922       | 7                  |
+  | 0                | 1.0         | 8                  |
+
+- **5-hour linear cap** (binary gate) — over each 5-hour window, the cap on
+  `used_5h` rises linearly from `0` at window-start to
+  `target_five_hour_usage_pct` at window-end. When `used_5h >= cap_5h`, the
+  budgeter prints `0` regardless of the weekly ramp's otherwise-positive
+  output, pausing spawning until either the window resets or the cap rises
+  enough to clear it.
+
+  | remaining_5h   | elapsed_5h_frac | cap_5h |
+  |----------------|----------------:|-------:|
+  | 5h (18000s)    | 0.0             | 0%     |
+  | 4h (14400s)    | 0.2             | 10%    |
+  | 2.5h (9000s)   | 0.5             | 25%    |
+  | 1h (3600s)     | 0.8             | 40%    |
+  | 0              | 1.0             | 50%    |
+
+Tunables (each optional in `dispatch.config/target-workers.json`; defaults
+baked into the script):
+
+| Field | Default | Meaning |
+|---|---|---|
+| `target_weekly_usage_pct` | 90 | Weekly ramp's terminal target. |
+| `target_five_hour_usage_pct` | 50 | 5-hour cap's terminal ceiling. |
+| `max_concurrent_workers` | 8 | Absolute cap on `target_N`. |
+| `ramp_tau_seconds` | 86400 | Weekly ramp time-constant. |
+| `ramp_shape_k` | 2 | Weekly ramp concavity. |
+| `five_hour_window_seconds` | 18000 | 5-hour window length (for cap-slope only). |
+
+Recalibration: if mid-week idleness is too long, try `ramp_tau_seconds=172800`
+(2 days) or `ramp_shape_k=1` (less concave). If the 5-hour cap is too tight,
+raise `target_five_hour_usage_pct`. If you need more headroom for parallel
+work, raise `max_concurrent_workers`.
+
+**Missing-telemetry fallback.** When
+`~/.local/share/productivity-tui/rate_limits.json` is missing or unreadable,
+`dispatch-target-workers` prints `1` and writes a one-line note to stderr —
+the gate's first comparison (`0 >= 1` is false on a typical fresh router
+tick) is a no-op, so the chain degrades to today's "spawn one per tick"
+behavior. The same fallback applies when the `seven_day` block is absent
+(no weekly ramp anchor); a missing `five_hour` block alone disables the
+5-hour gate but the weekly ramp still applies.
 
 ## 7. Terminal Disposition
 
@@ -473,6 +550,9 @@ The router's tick ends here. There are two dispositions:
 
 - **clean completion or early-stop** — every other terminal path:
   - Step 6 returned `spawned` or `deduped` (clean completion).
+  - Step 6 skipped the spawn because `live_count >= target_N` (the
+    concurrency gate skip-over-cap path). The chain re-seeds on the next
+    router tick when budget reopens.
   - A Steps 0–5 stop path (busy lock, sync failure, empty queue, `main-broken`,
     resolver failure, `worktree-closed`, closed-issue target, open-blocker
     gate, `worktree` conflict, jit-reminder summary). The jit-reminder

--- a/.claude/skills/dispatch/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch/scripts/dispatch-config-load
@@ -260,8 +260,12 @@ case "$CONFIG_TYPE" in
          "five_hour_window_seconds"] |
         .[] |
         . as $field |
-        if ($cfg | has($field)) and ($cfg[$field] | type) != "number" then
+        if ($cfg | has($field)) | not then
+          empty
+        elif ($cfg[$field] | type) != "number" then
           "\($field) must be a number if present, got \($cfg[$field] | type)"
+        elif $cfg[$field] <= 0 then
+          "\($field) must be > 0 if present, got \($cfg[$field])"
         else
           empty
         end

--- a/.claude/skills/dispatch/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch/scripts/dispatch-config-load
@@ -7,7 +7,7 @@
 # the normalized result to stdout.
 #
 # Usage:
-#   dispatch-config-load <projects|jit>
+#   dispatch-config-load <projects|jit|target-workers>
 #
 # Config files live in <project-root>/dispatch.config/. The project root is
 # the parent of git --git-common-dir (same idiom as dispatch-acquire-lock).
@@ -87,15 +87,38 @@
 #         "remindAfterClose": "12h", "dueAfterClose": "24h", "debounce": "1h" }
 #     ]
 #   }
+#
+# ---- Schema: target-workers.json -------------------------------------------
+#
+# Top-level object with optional tunables for `dispatch-target-workers`. Each
+# field must be a number when present; absent fields fall back to the
+# defaults baked into `dispatch-target-workers`.
+#
+#   target_weekly_usage_pct      default 90
+#   target_five_hour_usage_pct   default 50
+#   max_concurrent_workers       default 8
+#   ramp_tau_seconds             default 86400
+#   ramp_shape_k                 default 2
+#   five_hour_window_seconds     default 18000
+#
+# Example (see target-workers.example.json):
+#   {
+#     "target_weekly_usage_pct": 90,
+#     "target_five_hour_usage_pct": 50,
+#     "max_concurrent_workers": 8,
+#     "ramp_tau_seconds": 86400,
+#     "ramp_shape_k": 2,
+#     "five_hour_window_seconds": 18000
+#   }
 set -euo pipefail
 
 # ---- Step 0: parse arguments ------------------------------------------------
 
 CONFIG_TYPE="${1:-}"
 case "$CONFIG_TYPE" in
-  projects|jit) ;;
+  projects|jit|target-workers) ;;
   *)
-    echo "error: usage: dispatch-config-load <projects|jit>" >&2
+    echo "error: usage: dispatch-config-load <projects|jit|target-workers>" >&2
     exit 2
     ;;
 esac
@@ -218,6 +241,29 @@ case "$CONFIG_TYPE" in
           else
             empty
           end)
+        end
+      end
+    ' "$CONFIG_FILE")
+    ;;
+  target-workers)
+    # top-level value must be an object; all tunables are optional numbers.
+    # `dispatch-target-workers` substitutes a baked-in default for any field
+    # absent here, so absence is silent — only the type of present fields is
+    # checked.
+    ERRORS=$(jq -r '
+      if type != "object" then
+        "top-level value must be a JSON object, got \(type)"
+      else
+        . as $cfg |
+        ["target_weekly_usage_pct","target_five_hour_usage_pct",
+         "max_concurrent_workers","ramp_tau_seconds","ramp_shape_k",
+         "five_hour_window_seconds"] |
+        .[] |
+        . as $field |
+        if ($cfg | has($field)) and ($cfg[$field] | type) != "number" then
+          "\($field) must be a number if present, got \($cfg[$field] | type)"
+        else
+          empty
         end
       end
     ' "$CONFIG_FILE")

--- a/.claude/skills/dispatch/scripts/dispatch-target-workers
+++ b/.claude/skills/dispatch/scripts/dispatch-target-workers
@@ -209,6 +209,9 @@ awk -v used_weekly="$WEEKLY_USED" \
     -v now="$NOW" \
     -v fiveh_enabled="$FIVEH_ENABLED" \
     'BEGIN {
+       # + 0 throughout: explicit numeric coercion; awk treats any unset/empty
+       # var as "" in numeric contexts and silently breaks comparisons without it.
+
        # Step 1: weekly target reached → 0.
        if (used_weekly + 0 >= target_weekly + 0) { print 0; exit }
 

--- a/.claude/skills/dispatch/scripts/dispatch-target-workers
+++ b/.claude/skills/dispatch/scripts/dispatch-target-workers
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# dispatch-target-workers — print the desired concurrent worker count.
+#
+# Composes two open-loop schedules to gate router-side worker spawning:
+#
+#   weekly ramp     — conservative-early/aggressive-late ramp toward a
+#                     target usage by the weekly window's resets_at. Drives
+#                     target_N's magnitude.
+#   5-hour cap      — a linear schedule that rises from 0% at window-start
+#                     to target_5h at window-end; binary gate when used_5h
+#                     crosses it.
+#
+# Telemetry is read from ~/.local/share/productivity-tui/rate_limits.json
+# (written by productivity-tui/hooks/update-rate-limits.sh on every
+# statusline render). The path is overridable for tests.
+#
+# When telemetry is missing or unreadable, the script prints `1` (today's
+# "spawn one per tick" default) and writes a one-line note to stderr — the
+# algorithm is opt-in by telemetry presence.
+#
+# Stdout protocol:
+#   <integer>   non-negative concurrent-worker target (0..max_workers).
+#
+# Exit codes:
+#   0  always — the script prints a number on every code path.
+#
+# Inputs (env-var overrides for tests; otherwise read from telemetry/config):
+#
+#   DISPATCH_TARGET_WORKERS_RATE_LIMITS_PATH
+#     Override the rate_limits.json path. Default:
+#     ~/.local/share/productivity-tui/rate_limits.json.
+#
+#   DISPATCH_TARGET_WORKERS_NOW
+#     Override the current epoch seconds. Default: date +%s.
+#
+#   DISPATCH_TARGET_WORKERS_USED_WEEKLY
+#   DISPATCH_TARGET_WORKERS_RESETS_AT_WEEKLY
+#   DISPATCH_TARGET_WORKERS_USED_5H
+#   DISPATCH_TARGET_WORKERS_RESETS_AT_5H
+#     Override each individual telemetry field. When set, they win over the
+#     value parsed from the rate_limits.json file. The override is per-field,
+#     so a test can supply some fields and let the file supply the rest.
+#
+# Config (read via dispatch-config-load target-workers; all optional):
+#
+#   target_weekly_usage_pct       default 90
+#   target_five_hour_usage_pct    default 50
+#   max_concurrent_workers        default 8
+#   ramp_tau_seconds              default 86400  (1 day)
+#   ramp_shape_k                  default 2
+#   five_hour_window_seconds      default 18000  (5 hours)
+#
+# ---- The algorithm ----------------------------------------------------------
+#
+#   1. If used_weekly >= target_weekly → print 0.
+#   2. remaining_weekly = resets_at_weekly - now. If <= 0 → print 0.
+#   3. remaining_5h = max(0, resets_at_5h - now),
+#      elapsed_5h_frac = clamp((five_hour_window_seconds - remaining_5h)
+#                              / five_hour_window_seconds, 0, 1),
+#      cap_5h = target_5h * elapsed_5h_frac.
+#   4. If used_5h >= cap_5h → print 0.
+#   5. ramp_weekly = (tau_seconds / (remaining_weekly + tau_seconds)) ** k.
+#   6. target_N = round(max_workers * ramp_weekly).
+#   7. Clamp target_N to [0, max_workers].
+#   8. Print target_N.
+#
+# ---- Missing-telemetry fallback --------------------------------------------
+#
+# - File missing/unreadable, or both telemetry blocks missing → print 1.
+# - Only `seven_day` missing → print 1 (no weekly ramp anchor).
+# - Only `five_hour` missing → run the weekly ramp; skip the 5h gate.
+set -euo pipefail
+
+# ---- Step 0: defaults & config ----------------------------------------------
+
+TARGET_WEEKLY=90
+TARGET_5H=50
+MAX_WORKERS=8
+TAU_SECONDS=86400
+K=2
+FIVE_HOUR_WINDOW_SECONDS=18000
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Pull tunables from dispatch-config-load target-workers when present. Each
+# field is optional; only override the baked-in default when the field is
+# present. Use jq -r with // to express "field present" vs "field absent or
+# null" (// only fires on null, not absent — but absent fields jq returns as
+# null, so // covers both).
+CONFIG_JSON=""
+if CONFIG_OUT=$("$SCRIPT_DIR/dispatch-config-load" target-workers 2>/dev/null); then
+  if [[ "$CONFIG_OUT" != "no-config" ]]; then
+    CONFIG_JSON="$CONFIG_OUT"
+  fi
+fi
+
+if [[ -n "$CONFIG_JSON" ]]; then
+  val=$(jq -r '.target_weekly_usage_pct // empty' <<<"$CONFIG_JSON")
+  [[ -n "$val" ]] && TARGET_WEEKLY="$val"
+  val=$(jq -r '.target_five_hour_usage_pct // empty' <<<"$CONFIG_JSON")
+  [[ -n "$val" ]] && TARGET_5H="$val"
+  val=$(jq -r '.max_concurrent_workers // empty' <<<"$CONFIG_JSON")
+  [[ -n "$val" ]] && MAX_WORKERS="$val"
+  val=$(jq -r '.ramp_tau_seconds // empty' <<<"$CONFIG_JSON")
+  [[ -n "$val" ]] && TAU_SECONDS="$val"
+  val=$(jq -r '.ramp_shape_k // empty' <<<"$CONFIG_JSON")
+  [[ -n "$val" ]] && K="$val"
+  val=$(jq -r '.five_hour_window_seconds // empty' <<<"$CONFIG_JSON")
+  [[ -n "$val" ]] && FIVE_HOUR_WINDOW_SECONDS="$val"
+fi
+
+# ---- Step 1: load telemetry -------------------------------------------------
+
+RL_PATH="${DISPATCH_TARGET_WORKERS_RATE_LIMITS_PATH:-$HOME/.local/share/productivity-tui/rate_limits.json}"
+NOW="${DISPATCH_TARGET_WORKERS_NOW:-$(date +%s)}"
+
+# Parse the file if it exists and is readable; otherwise WEEKLY_USED/etc stay
+# empty and the per-field env overrides have the last word.
+WEEKLY_USED=""
+WEEKLY_RESETS=""
+FIVEH_USED=""
+FIVEH_RESETS=""
+FILE_OK=0
+
+if [[ -r "$RL_PATH" ]]; then
+  # Each field's `// "" | tostring` lives inside its own parens — `|` binds
+  # looser than `,` in jq, so without the parens the `| tostring` would apply
+  # to the whole array stream instead of each per-element filter.
+  #
+  # Each field is followed by a trailing `|`. Without a sentinel:
+  #   - `@tsv` with leading-empty cells gets collapsed by `read -r IFS=$'\t'`
+  #     because tab is IFS whitespace.
+  #   - One field per line ends up with trailing-blank lines that command
+  #     substitution `$(...)` strips, so absent five_hour fields would
+  #     vanish.
+  # The `|` sentinel anchors every field unambiguously.
+  if PARSED=$(jq -r '
+      "\(.seven_day.used_percentage // "")|",
+      "\(.seven_day.resets_at // "")|",
+      "\(.five_hour.used_percentage // "")|",
+      "\(.five_hour.resets_at // "")|"
+    ' "$RL_PATH" 2>/dev/null); then
+    {
+      IFS= read -r line; WEEKLY_USED="${line%|}"
+      IFS= read -r line; WEEKLY_RESETS="${line%|}"
+      IFS= read -r line; FIVEH_USED="${line%|}"
+      IFS= read -r line; FIVEH_RESETS="${line%|}"
+    } <<<"$PARSED"
+    FILE_OK=1
+  fi
+fi
+
+# Per-field env overrides (test-injectable).
+[[ -n "${DISPATCH_TARGET_WORKERS_USED_WEEKLY:-}" ]] && WEEKLY_USED="$DISPATCH_TARGET_WORKERS_USED_WEEKLY"
+[[ -n "${DISPATCH_TARGET_WORKERS_RESETS_AT_WEEKLY:-}" ]] && WEEKLY_RESETS="$DISPATCH_TARGET_WORKERS_RESETS_AT_WEEKLY"
+[[ -n "${DISPATCH_TARGET_WORKERS_USED_5H:-}" ]] && FIVEH_USED="$DISPATCH_TARGET_WORKERS_USED_5H"
+[[ -n "${DISPATCH_TARGET_WORKERS_RESETS_AT_5H:-}" ]] && FIVEH_RESETS="$DISPATCH_TARGET_WORKERS_RESETS_AT_5H"
+
+# Whether each block is present after env-override merge.
+WEEKLY_PRESENT=0
+FIVEH_PRESENT=0
+[[ -n "$WEEKLY_USED" && -n "$WEEKLY_RESETS" ]] && WEEKLY_PRESENT=1
+[[ -n "$FIVEH_USED" && -n "$FIVEH_RESETS" ]] && FIVEH_PRESENT=1
+
+# ---- Step 2: missing-telemetry fallback -------------------------------------
+#
+# The weekly ramp's anchor is required. Without it (or without the whole file
+# and no env overrides), fall back to "spawn one per tick".
+
+if (( WEEKLY_PRESENT == 0 )); then
+  if (( FILE_OK == 0 )); then
+    echo "dispatch-target-workers: rate_limits.json missing or unreadable at $RL_PATH; using fallback (1)" >&2
+  else
+    echo "dispatch-target-workers: seven_day telemetry absent in $RL_PATH; using fallback (1)" >&2
+  fi
+  echo 1
+  exit 0
+fi
+
+# ---- Step 3: the algorithm --------------------------------------------------
+#
+# All arithmetic is delegated to a single awk invocation. awk's printf
+# handles both float math (the ramp) and integer rounding (%.0f), and is
+# POSIX-ubiquitous on the dev machines (bc is not).
+
+# When the 5-hour block is absent, set sentinels that disable the 5h gate.
+# `used_5h=0` and `cap_5h=1` make `used_5h < cap_5h` trivially true.
+FIVEH_USED_FOR_AWK="$FIVEH_USED"
+FIVEH_RESETS_FOR_AWK="$FIVEH_RESETS"
+FIVEH_ENABLED=1
+if (( FIVEH_PRESENT == 0 )); then
+  FIVEH_USED_FOR_AWK=0
+  FIVEH_RESETS_FOR_AWK=0
+  FIVEH_ENABLED=0
+fi
+
+awk -v used_weekly="$WEEKLY_USED" \
+    -v resets_weekly="$WEEKLY_RESETS" \
+    -v used_5h="$FIVEH_USED_FOR_AWK" \
+    -v resets_5h="$FIVEH_RESETS_FOR_AWK" \
+    -v target_weekly="$TARGET_WEEKLY" \
+    -v target_5h="$TARGET_5H" \
+    -v max_workers="$MAX_WORKERS" \
+    -v tau="$TAU_SECONDS" \
+    -v k="$K" \
+    -v window_5h="$FIVE_HOUR_WINDOW_SECONDS" \
+    -v now="$NOW" \
+    -v fiveh_enabled="$FIVEH_ENABLED" \
+    'BEGIN {
+       # Step 1: weekly target reached → 0.
+       if (used_weekly + 0 >= target_weekly + 0) { print 0; exit }
+
+       # Step 2: weekly refresh already passed → 0.
+       remaining_weekly = resets_weekly + 0 - (now + 0)
+       if (remaining_weekly <= 0) { print 0; exit }
+
+       # Step 3: 5h linear cap.
+       if (fiveh_enabled + 0 == 1) {
+         remaining_5h = resets_5h + 0 - (now + 0)
+         if (remaining_5h < 0) remaining_5h = 0
+         elapsed_frac = (window_5h + 0 - remaining_5h) / (window_5h + 0)
+         if (elapsed_frac < 0) elapsed_frac = 0
+         if (elapsed_frac > 1) elapsed_frac = 1
+         cap_5h = (target_5h + 0) * elapsed_frac
+
+         # Step 4: 5h cap tripped → 0.
+         if (used_5h + 0 >= cap_5h) { print 0; exit }
+       }
+
+       # Step 5: weekly ramp.
+       ramp = (tau + 0) / (remaining_weekly + (tau + 0))
+       ramp = ramp ^ (k + 0)
+
+       # Step 6: round to nearest int.
+       target_n = max_workers + 0
+       target_n = target_n * ramp
+       # printf %.0f does banker-half-to-even on some awks; add 0.5 truncate
+       # for stable round-half-up. Clamp negative to 0 before the round step.
+       if (target_n < 0) target_n = 0
+       target_n_rounded = int(target_n + 0.5)
+
+       # Step 7: clamp to [0, max_workers].
+       if (target_n_rounded < 0) target_n_rounded = 0
+       if (target_n_rounded > max_workers + 0) target_n_rounded = max_workers + 0
+
+       # Step 8: print.
+       print target_n_rounded
+     }'

--- a/.claude/skills/dispatch/scripts/dispatch-target-workers
+++ b/.claude/skills/dispatch/scripts/dispatch-target-workers
@@ -60,9 +60,10 @@
 #      cap_5h = target_5h * elapsed_5h_frac.
 #   4. If used_5h >= cap_5h → print 0.
 #   5. ramp_weekly = (tau_seconds / (remaining_weekly + tau_seconds)) ** k.
-#   6. target_N = round(max_workers * ramp_weekly).
-#   7. Clamp target_N to [0, max_workers].
-#   8. Print target_N.
+#   6. target_N = round(max_workers * ramp_weekly). ramp_weekly is in (0, 1]
+#      for remaining_weekly > 0 (gated by Step 2), so target_N falls in
+#      [0, max_workers] by construction — no post-rounding clamp.
+#   7. Print target_N.
 #
 # ---- Missing-telemetry fallback --------------------------------------------
 #
@@ -84,9 +85,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Pull tunables from dispatch-config-load target-workers when present. Each
 # field is optional; only override the baked-in default when the field is
-# present. Use jq -r with // to express "field present" vs "field absent or
-# null" (// only fires on null, not absent — but absent fields jq returns as
-# null, so // covers both).
+# present. Use jq -r with `// empty` to express "field present" vs "field
+# absent or null" — jq's // also fires on `false`, but every tunable here is
+# numeric so that does not matter; if a boolean tunable is added later, the
+# schema-validator in dispatch-config-load must catch it before this loop.
 CONFIG_JSON=""
 if CONFIG_OUT=$("$SCRIPT_DIR/dispatch-config-load" target-workers 2>/dev/null); then
   if [[ "$CONFIG_OUT" != "no-config" ]]; then
@@ -231,18 +233,15 @@ awk -v used_weekly="$WEEKLY_USED" \
        ramp = (tau + 0) / (remaining_weekly + (tau + 0))
        ramp = ramp ^ (k + 0)
 
-       # Step 6: round to nearest int.
+       # Step 6: round to nearest int. printf %.0f does banker-half-to-even on
+       # some awks; `int(x + 0.5)` gives stable round-half-up. The math above
+       # guarantees target_n in [0, max_workers] (ramp in (0,1) for
+       # remaining_weekly > 0, gated by Step 2), so no post-rounding clamp is
+       # needed.
        target_n = max_workers + 0
        target_n = target_n * ramp
-       # printf %.0f does banker-half-to-even on some awks; add 0.5 truncate
-       # for stable round-half-up. Clamp negative to 0 before the round step.
-       if (target_n < 0) target_n = 0
        target_n_rounded = int(target_n + 0.5)
 
-       # Step 7: clamp to [0, max_workers].
-       if (target_n_rounded < 0) target_n_rounded = 0
-       if (target_n_rounded > max_workers + 0) target_n_rounded = max_workers + 0
-
-       # Step 8: print.
+       # Step 7: print.
        print target_n_rounded
      }'

--- a/.claude/skills/dispatch/scripts/lib-claude-agents.sh
+++ b/.claude/skills/dispatch/scripts/lib-claude-agents.sh
@@ -31,6 +31,18 @@
 #     return 1 — definitely no live session under <path>.
 #   `if worktree_has_live_session <path>` is fail-safe by construction.
 #
+# claude_agents_count_by_name_prefix <prefix>
+#   Counts live sessions whose `name` starts with `<prefix>`, repo-wide (no
+#   `--cwd` filter). Used by the dispatch router's concurrency gate to count
+#   live `dispatch-worker-*` sessions before deciding whether to spawn one
+#   more. Same UNKNOWN contract as `claude_sessions_under`: a count of `0` is
+#   a definite "no matches", non-zero return is "could not determine".
+#     return 0 — daemon queried successfully. Stdout is a single integer (>=0)
+#               line: the count of matching sessions.
+#     return 1 — UNKNOWN. Stdout is empty. Callers that gate on the count
+#               should fail open (proceed to spawn) — the per-worktree dedup
+#               inside `dispatch-spawn-worker` is the last-line defense.
+#
 # Test override: CLAUDE_AGENTS_CMD replaces the `claude` invocation with an
 # arbitrary command (e.g. an absolute path to a fake script), so the helper is
 # testable with no real daemon. Default: `claude`.
@@ -109,6 +121,39 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
     fi
     # The daemon was queried successfully and reported zero sessions.
     return 1
+  }
+
+  # claude_agents_count_by_name_prefix <prefix> — emit the count of live
+  # sessions whose `name` starts with <prefix>. See the header comment.
+  claude_agents_count_by_name_prefix() {
+    local prefix="${1:-}"
+    if [[ -z "$prefix" ]]; then
+      printf 'lib-claude-agents: claude_agents_count_by_name_prefix requires a <prefix> argument\n' >&2
+      return 1
+    fi
+
+    # No --cwd here: the router needs a repo-wide count of live workers, not a
+    # per-path filter. 2>/dev/null drops daemon noise.
+    local out
+    if ! out=$("${CLAUDE_AGENTS_CMD:-claude}" agents --json 2>/dev/null); then
+      return 1
+    fi
+    if [[ -z "${out//[[:space:]]/}" ]]; then
+      return 1
+    fi
+
+    # One jq pass validates the array shape and counts matches. Non-array
+    # input errors out and the result is UNKNOWN.
+    local count
+    if ! count=$(jq -r --arg prefix "$prefix" '
+      if type == "array"
+      then [ .[] | select(.name | type == "string" and startswith($prefix)) ] | length
+      else error("claude agents --json output is not a JSON array")
+      end' <<<"$out" 2>/dev/null); then
+      return 1
+    fi
+    printf '%s\n' "$count"
+    return 0
   }
 
 fi

--- a/.claude/skills/dispatch/scripts/lib-claude-agents.sh
+++ b/.claude/skills/dispatch/scripts/lib-claude-agents.sh
@@ -33,11 +33,15 @@
 #   `if worktree_has_live_session <path>` is fail-safe by construction.
 #
 # claude_agents_count_by_name_prefix <prefix>
-#   Counts live sessions whose `name` starts with `<prefix>`, repo-wide (no
-#   `--cwd` filter). Used by the dispatch router's concurrency gate to count
-#   live `dispatch-worker-*` sessions before deciding whether to spawn one
-#   more. Same UNKNOWN contract as `claude_sessions_under`: a count of `0` is
-#   a definite "no matches", non-zero return is "could not determine".
+#   Counts live sessions whose `name` starts with `<prefix>`, machine-wide (no
+#   `--cwd` filter). On a single dev machine this is acceptable; if two separate
+#   checkouts run in parallel, their `dispatch-worker-*` sessions are counted
+#   together, inflating the count and gating spawning too aggressively —
+#   fail-safe (errs toward fewer workers). Used by the dispatch router's
+#   concurrency gate to count live `dispatch-worker-*` sessions before deciding
+#   whether to spawn one more. Same UNKNOWN contract as `claude_sessions_under`:
+#   a count of `0` is a definite "no matches", non-zero return is "could not
+#   determine".
 #     return 0 — daemon queried successfully. Stdout is a single integer (>=0)
 #               line: the count of matching sessions.
 #     return 1 — UNKNOWN. Stdout is empty. Callers that gate on the count
@@ -147,8 +151,10 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
       return 1
     fi
 
-    # No --cwd here: the router needs a repo-wide count of live workers, not a
-    # per-path filter. 2>/dev/null drops daemon noise.
+    # No --cwd here: the router needs a machine-wide count of live workers, not
+    # a per-path filter. Two checkouts on the same machine share this count —
+    # cross-repo inflation is fail-safe (gates spawning conservatively).
+    # 2>/dev/null drops daemon noise.
     local out
     if ! out=$("${CLAUDE_AGENTS_CMD:-claude}" agents --json 2>/dev/null); then
       return 1

--- a/.claude/skills/dispatch/scripts/target-workers.example.json
+++ b/.claude/skills/dispatch/scripts/target-workers.example.json
@@ -1,0 +1,8 @@
+{
+  "target_weekly_usage_pct": 90,
+  "target_five_hour_usage_pct": 50,
+  "max_concurrent_workers": 8,
+  "ramp_tau_seconds": 86400,
+  "ramp_shape_k": 2,
+  "five_hour_window_seconds": 18000
+}

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -4820,6 +4820,22 @@ out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
 assert_eq "env override clears 5h gate; late-week ramp → 7" "7" "$out"
 tw_teardown
 
+# --- Test 13: ramp_tau_seconds=0 disables spawning --------------------------
+
+echo "Test: ramp_tau_seconds=0 disables spawning (documents tau=0 behavior)"
+tw_setup
+cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
+{"ramp_tau_seconds": 0}
+EOF
+# Late-week regime: default tau=86400 would yield target_N=7 here (same as
+# Test 12 baseline).  With tau=0, ramp = 0/(3600+0) = 0, so target_N=0.
+export DISPATCH_TARGET_WORKERS_NOW=10000
+# remaining_weekly=3600s (1h), remaining_5h=3600s (mid-window 5h gate clear)
+write_rl "rl.json" 50 13600 0 13600
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "ramp_tau_seconds=0 disables spawning → 0" "0" "$out"
+tw_teardown
+
 # ============================================================================
 # dispatch project-helper tests (item-add / status-read / status-write)
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -4569,6 +4569,44 @@ out_compact=$(printf '%s' "$out" | jq -c '.')
 assert_eq "empty object prints {}" "{}" "$out_compact"
 config_teardown
 
+# --- Test 12: five_hour_window_seconds: 0 is rejected (must be > 0) ----------
+
+echo "Test: five_hour_window_seconds: 0 exits 1 and stderr says must be > 0"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
+{"five_hour_window_seconds": 0}
+EOF
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" target-workers 2>&1 1>/dev/null) || rc=$?
+assert_eq "five_hour_window_seconds 0 exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"five_hour_window_seconds"* && "$err" == *"must be > 0"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: five_hour_window_seconds 0 stderr says must be > 0"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: five_hour_window_seconds 0 stderr says must be > 0"
+  echo "    stderr: $err"
+fi
+config_teardown
+
+# --- Test 13: max_concurrent_workers: -1 is rejected (must be > 0) -----------
+
+echo "Test: max_concurrent_workers: -1 exits 1 and stderr says must be > 0"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
+{"max_concurrent_workers": -1}
+EOF
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" target-workers 2>&1 1>/dev/null) || rc=$?
+assert_eq "max_concurrent_workers -1 exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"max_concurrent_workers"* && "$err" == *"must be > 0"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: max_concurrent_workers -1 stderr says must be > 0"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: max_concurrent_workers -1 stderr says must be > 0"
+  echo "    stderr: $err"
+fi
+config_teardown
+
 # ============================================================================
 # dispatch-target-workers tests
 # ============================================================================
@@ -4820,20 +4858,23 @@ out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
 assert_eq "env override clears 5h gate; late-week ramp → 7" "7" "$out"
 tw_teardown
 
-# --- Test 13: ramp_tau_seconds=0 disables spawning --------------------------
+# --- Test 13: ramp_tau_seconds=0 is rejected; dispatch-target-workers uses defaults ----
 
-echo "Test: ramp_tau_seconds=0 disables spawning (documents tau=0 behavior)"
+echo "Test: ramp_tau_seconds=0 rejected by config validator; dispatch-target-workers uses defaults"
 tw_setup
 cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
 {"ramp_tau_seconds": 0}
 EOF
-# Late-week regime: default tau=86400 would yield target_N=7 here (same as
-# Test 12 baseline).  With tau=0, ramp = 0/(3600+0) = 0, so target_N=0.
+# ramp_tau_seconds=0 is rejected by dispatch-config-load (must be > 0).
+# dispatch-target-workers silently ignores a failed config-load and uses
+# the baked-in default tau=86400. Late-week regime (remaining_weekly=3600)
+# with 5h gate clear (used_5h=0, elapsed_5h_frac=0.8 → cap=40 > 0) yields
+# target_N=7.
 export DISPATCH_TARGET_WORKERS_NOW=10000
 # remaining_weekly=3600s (1h), remaining_5h=3600s (mid-window 5h gate clear)
 write_rl "rl.json" 50 13600 0 13600
 out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
-assert_eq "ramp_tau_seconds=0 disables spawning → 0" "0" "$out"
+assert_eq "ramp_tau_seconds=0 rejected; defaults used → 7" "7" "$out"
 tw_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -4056,6 +4056,111 @@ assert_eq "cwd-arg: claude invoked as 'agents --json --cwd <path>'" \
   "$(printf 'agents\n--json\n--cwd\n%s' "$CA_DIR")" "$(cat "$CA_DIR/argv")"
 ca_teardown
 
+# --- Test 10: claude_agents_count_by_name_prefix counts prefix-matching ----
+
+echo "Test: claude_agents_count_by_name_prefix matches 2 of 3 sessions"
+ca_setup
+write_fake_claude '[
+  {"sessionId":"a","pid":1,"status":"busy","name":"dispatch-worker-845-foo"},
+  {"sessionId":"b","pid":2,"status":"busy","name":"dispatch-worker-720-bar"},
+  {"sessionId":"c","pid":3,"status":"idle","name":"dispatch-router-baz"}
+]' 0
+if out=$(claude_agents_count_by_name_prefix dispatch-worker-); then rc=0; else rc=$?; fi
+assert_eq "count: exits 0" "0" "$rc"
+assert_eq "count: 2 of 3 match dispatch-worker-" "2" "$out"
+ca_teardown
+
+# --- Test 11: claude_agents_count_by_name_prefix returns 0 for no matches --
+
+echo "Test: claude_agents_count_by_name_prefix returns 0 for no matches"
+ca_setup
+write_fake_claude '[{"sessionId":"a","pid":1,"status":"busy","name":"other-thing"}]' 0
+if out=$(claude_agents_count_by_name_prefix dispatch-worker-); then rc=0; else rc=$?; fi
+assert_eq "no-match: exits 0" "0" "$rc"
+assert_eq "no-match: prints 0" "0" "$out"
+ca_teardown
+
+# --- Test 12: claude_agents_count_by_name_prefix reports UNKNOWN on failure-
+
+echo "Test: claude_agents_count_by_name_prefix returns rc 1 on daemon failure"
+ca_setup
+write_fake_claude '' 1
+if out=$(claude_agents_count_by_name_prefix dispatch-worker-); then rc=0; else rc=$?; fi
+assert_eq "daemon-fail: exits non-zero (UNKNOWN)" "1" "$rc"
+assert_eq "daemon-fail: prints nothing" "" "$out"
+ca_teardown
+
+# --- Test 13: claude_agents_count_by_name_prefix rejects non-array output --
+
+echo "Test: claude_agents_count_by_name_prefix returns rc 1 on non-array output"
+ca_setup
+write_fake_claude '{}' 0
+if out=$(claude_agents_count_by_name_prefix dispatch-worker-); then rc=0; else rc=$?; fi
+assert_eq "non-array: exits non-zero (UNKNOWN)" "1" "$rc"
+ca_teardown
+
+# --- Test 14: router concurrency gate — skip when live >= target ----------
+
+echo "Test: router gate skips spawn when live_count >= target_N"
+ca_setup
+# Three live dispatch-worker-* agents, target = 2 → skip branch.
+write_fake_claude '[
+  {"sessionId":"a","pid":1,"status":"busy","name":"dispatch-worker-1"},
+  {"sessionId":"b","pid":2,"status":"busy","name":"dispatch-worker-2"},
+  {"sessionId":"c","pid":3,"status":"busy","name":"dispatch-worker-3"}
+]' 0
+TARGET_N=2
+ROUTE=""
+if LIVE_COUNT=$(claude_agents_count_by_name_prefix dispatch-worker-); then
+  if (( LIVE_COUNT >= TARGET_N )); then
+    ROUTE="skip"
+  else
+    ROUTE="spawn"
+  fi
+else
+  ROUTE="spawn-failopen"
+fi
+assert_eq "router-gate: 3 live >= target 2 → skip" "skip" "$ROUTE"
+ca_teardown
+
+# --- Test 15: router concurrency gate — spawn when live < target ----------
+
+echo "Test: router gate spawns when live_count < target_N"
+ca_setup
+write_fake_claude '[{"sessionId":"a","pid":1,"status":"busy","name":"dispatch-worker-1"}]' 0
+TARGET_N=2
+ROUTE=""
+if LIVE_COUNT=$(claude_agents_count_by_name_prefix dispatch-worker-); then
+  if (( LIVE_COUNT >= TARGET_N )); then
+    ROUTE="skip"
+  else
+    ROUTE="spawn"
+  fi
+else
+  ROUTE="spawn-failopen"
+fi
+assert_eq "router-gate: 1 live < target 2 → spawn" "spawn" "$ROUTE"
+ca_teardown
+
+# --- Test 16: router concurrency gate — fail open when daemon UNKNOWN -----
+
+echo "Test: router gate fails open to spawn when daemon UNKNOWN"
+ca_setup
+write_fake_claude '' 1
+TARGET_N=2
+ROUTE=""
+if LIVE_COUNT=$(claude_agents_count_by_name_prefix dispatch-worker-); then
+  if (( LIVE_COUNT >= TARGET_N )); then
+    ROUTE="skip"
+  else
+    ROUTE="spawn"
+  fi
+else
+  ROUTE="spawn-failopen"
+fi
+assert_eq "router-gate: daemon UNKNOWN → spawn-failopen" "spawn-failopen" "$ROUTE"
+ca_teardown
+
 # ============================================================================
 # dispatch-config-load tests
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -4226,6 +4226,316 @@ else
 fi
 config_teardown
 
+# --- Test 8: valid target-workers.json prints normalized JSON ---------------
+
+echo "Test: valid target-workers.json prints normalized JSON"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
+{
+  "target_weekly_usage_pct": 85,
+  "ramp_tau_seconds": 172800,
+  "ramp_shape_k": 1
+}
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" target-workers 2>/dev/null); rc=$?
+assert_eq "valid target-workers.json exits 0" "0" "$rc"
+tw_target=$(printf '%s' "$out" | jq -r '.target_weekly_usage_pct')
+assert_eq "valid target-workers.json target_weekly_usage_pct" "85" "$tw_target"
+tw_tau=$(printf '%s' "$out" | jq -r '.ramp_tau_seconds')
+assert_eq "valid target-workers.json ramp_tau_seconds" "172800" "$tw_tau"
+config_teardown
+
+# --- Test 9: absent target-workers.json prints no-config and exits 0 --------
+
+echo "Test: absent target-workers.json prints no-config and exits 0"
+config_setup
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" target-workers 2>/dev/null); rc=$?
+assert_eq "absent target-workers.json exits 0" "0" "$rc"
+assert_eq "absent target-workers.json prints no-config" "no-config" "$out"
+config_teardown
+
+# --- Test 10: target-workers.json with a non-number field exits 1 -----------
+
+echo "Test: target-workers.json with non-number field exits 1 and stderr names it"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
+{"target_weekly_usage_pct": "ninety"}
+EOF
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" target-workers 2>&1 1>/dev/null) || rc=$?
+assert_eq "non-number tunable exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"target_weekly_usage_pct"* && "$err" == *"number"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-number tunable stderr names the field and type"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-number tunable stderr names the field and type"
+  echo "    stderr: $err"
+fi
+config_teardown
+
+# --- Test 11: empty object is accepted (every tunable is optional) ----------
+
+echo "Test: empty object target-workers.json is accepted"
+config_setup
+echo '{}' > "$DISPATCH_CONFIG_DIR/target-workers.json"
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" target-workers 2>/dev/null); rc=$?
+assert_eq "empty object exits 0" "0" "$rc"
+# jq normalizes "{}" to "{}".
+out_compact=$(printf '%s' "$out" | jq -c '.')
+assert_eq "empty object prints {}" "{}" "$out_compact"
+config_teardown
+
+# ============================================================================
+# dispatch-target-workers tests
+# ============================================================================
+#
+# Each test gets a fresh tmp tree:
+#   $TMPDIR_TEST/scripts/   copies of dispatch-target-workers + dispatch-config-load
+#   $TMPDIR_TEST/config/    synthetic config directory (DISPATCH_CONFIG_DIR)
+#   $TMPDIR_TEST/rl/        synthetic rate_limits.json directory
+#
+# All telemetry inputs are env-overridable; tests rely on the overrides rather
+# than fixture files when shape matters more than the file path. The script
+# defaults are baked in (target_weekly=90, target_5h=50, max_workers=8,
+# tau=86400, k=2, five_hour_window=18000); tests that vary tunables write a
+# target-workers.json into the config dir.
+echo ""
+echo "=== dispatch-target-workers ==="
+
+tw_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/config" "$TMPDIR_TEST/rl"
+
+  cp "$SCRIPT_DIR/dispatch-target-workers" "$TMPDIR_TEST/scripts/dispatch-target-workers"
+  cp "$SCRIPT_DIR/dispatch-config-load" "$TMPDIR_TEST/scripts/dispatch-config-load"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-target-workers" \
+           "$TMPDIR_TEST/scripts/dispatch-config-load"
+
+  export DISPATCH_CONFIG_DIR="$TMPDIR_TEST/config"
+  # Default: point at an absent file so tests without explicit telemetry get
+  # the missing-telemetry fallback unless they override env vars.
+  export DISPATCH_TARGET_WORKERS_RATE_LIMITS_PATH="$TMPDIR_TEST/rl/missing.json"
+}
+
+tw_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  unset DISPATCH_CONFIG_DIR
+  unset DISPATCH_TARGET_WORKERS_RATE_LIMITS_PATH
+  unset DISPATCH_TARGET_WORKERS_NOW
+  unset DISPATCH_TARGET_WORKERS_USED_WEEKLY
+  unset DISPATCH_TARGET_WORKERS_RESETS_AT_WEEKLY
+  unset DISPATCH_TARGET_WORKERS_USED_5H
+  unset DISPATCH_TARGET_WORKERS_RESETS_AT_5H
+}
+
+# write_rl <file-name> <used_weekly> <resets_weekly> <used_5h> <resets_5h>
+#   Write a rate_limits.json with the four telemetry fields. Set any of the
+#   four to the literal string "absent" to omit the surrounding block.
+write_rl() {
+  local name="$1" uw="$2" rw="$3" u5="$4" r5="$5"
+  local path="$TMPDIR_TEST/rl/$name"
+  local seven=""
+  local five=""
+  if [[ "$uw" != "absent" && "$rw" != "absent" ]]; then
+    seven="\"seven_day\":{\"used_percentage\":$uw,\"resets_at\":$rw}"
+  fi
+  if [[ "$u5" != "absent" && "$r5" != "absent" ]]; then
+    five="\"five_hour\":{\"used_percentage\":$u5,\"resets_at\":$r5}"
+  fi
+  local parts=()
+  [[ -n "$five" ]] && parts+=("$five")
+  [[ -n "$seven" ]] && parts+=("$seven")
+  local joined
+  joined=$(IFS=,; printf '%s' "${parts[*]}")
+  printf '{%s}\n' "$joined" > "$path"
+  export DISPATCH_TARGET_WORKERS_RATE_LIMITS_PATH="$path"
+}
+
+# --- Test 1: weekly target reached → 0 --------------------------------------
+
+echo "Test: weekly-target-reached pause prints 0"
+tw_setup
+# used_weekly=90 == target_weekly=90 → trip step 1.
+export DISPATCH_TARGET_WORKERS_NOW=1000
+write_rl "rl.json" 90 2000 0 2000
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "weekly target reached → 0" "0" "$out"
+tw_teardown
+
+# --- Test 2: weekly refresh already passed → 0 ------------------------------
+
+echo "Test: weekly-refresh-passed pause prints 0"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW=5000
+# resets_at_weekly already passed (= 4000 < now).
+write_rl "rl.json" 10 4000 0 9000
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "weekly refresh passed → 0" "0" "$out"
+tw_teardown
+
+# --- Test 3: 5h cap tripped pauses spawning ---------------------------------
+
+echo "Test: 5h-cap-tripped pause prints 0 despite positive weekly ramp"
+tw_setup
+# Late-week regime: remaining_weekly = 1h, ramp ~= 0.92, otherwise → 7 workers.
+# Force the 5h gate: remaining_5h = 1h, elapsed_5h_frac = 0.8, cap_5h = 40.
+# used_5h = 45 → trips. Expect 0.
+export DISPATCH_TARGET_WORKERS_NOW=10000
+write_rl "rl.json" 50 13600 45 13600
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "5h cap tripped → 0" "0" "$out"
+tw_teardown
+
+# --- Test 4: both gates clear → positive ramp value -------------------------
+
+echo "Test: both-clear-spawn prints the rounded ramp value"
+tw_setup
+# Same late-week regime, but used_5h=30 < cap_5h=40 → gate passes.
+# ramp_weekly = (86400/(3600+86400))^2 ≈ 0.9216, target_N = round(8*0.9216) = 7.
+export DISPATCH_TARGET_WORKERS_NOW=10000
+write_rl "rl.json" 50 13600 30 13600
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "both gates clear; late-week ramp → 7" "7" "$out"
+tw_teardown
+
+# --- Test 5: missing rate_limits.json file → 1 + stderr note ----------------
+
+echo "Test: missing-telemetry-fallback prints 1 with a stderr note"
+tw_setup
+# Default rate-limits path points at a non-existent file.
+export DISPATCH_TARGET_WORKERS_NOW=10000
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>"$TMPDIR_TEST/stderr")
+err=$(cat "$TMPDIR_TEST/stderr")
+assert_eq "missing rate_limits.json → 1" "1" "$out"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"dispatch-target-workers"* && "$err" == *"fallback"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: missing rate_limits.json stderr has fallback note"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: missing rate_limits.json stderr has fallback note"
+  echo "    stderr: $err"
+fi
+tw_teardown
+
+# --- Test 6: only five_hour present → fallback (no weekly anchor) -----------
+
+echo "Test: missing-seven-day-fallback prints 1"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW=10000
+# seven_day omitted.
+write_rl "rl.json" absent absent 30 13600
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>"$TMPDIR_TEST/stderr")
+assert_eq "seven_day absent → fallback 1" "1" "$out"
+err=$(cat "$TMPDIR_TEST/stderr")
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"seven_day"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: seven_day-absent stderr names seven_day"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: seven_day-absent stderr names seven_day"
+  echo "    stderr: $err"
+fi
+tw_teardown
+
+# --- Test 7: only seven_day present → 5h gate skipped, weekly ramp applies --
+
+echo "Test: missing-five-hour-skips-cap applies the weekly ramp"
+tw_setup
+# Late-week regime (remaining_weekly=1h) but no 5h gate input — would otherwise
+# trip on cap_5h=0 if the 5h block were treated as present-with-zero. Expect
+# the ramp-only result (7), proving the 5h gate is skipped when its block is
+# absent.
+export DISPATCH_TARGET_WORKERS_NOW=10000
+write_rl "rl.json" 50 13600 absent absent
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "five_hour absent; weekly ramp → 7" "7" "$out"
+tw_teardown
+
+# --- Test 8: absolute cap clamps to max_workers -----------------------------
+
+echo "Test: absolute-cap clamps to max_workers"
+tw_setup
+# remaining_weekly = 1 second → ramp ≈ 1.0 → target = max_workers (default 8).
+export DISPATCH_TARGET_WORKERS_NOW=10000
+write_rl "rl.json" 10 10001 0 13500
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "ramp saturates → clamped to 8" "8" "$out"
+tw_teardown
+
+# --- Test 9: weekly ramp sweep is non-decreasing as remaining_weekly drops --
+
+echo "Test: weekly-ramp-sweep is non-decreasing as remaining_weekly drops"
+tw_setup
+# Hold the 5h gate open (remaining_5h mid-window, used_5h=0). Walk
+# remaining_weekly through the issue body's example table values:
+#   7d→0, 3d→1, 1d→2, 6h→5, 1h→7, 0→0 (window expired).
+# The 0 endpoint trips Step 2 (weekly-refresh-passed), so the sweep covers the
+# strictly-positive tail and asserts monotonic non-decreasing.
+NOW=10000
+export DISPATCH_TARGET_WORKERS_NOW="$NOW"
+prev=-1
+for remaining in 604800 259200 86400 21600 3600 1; do
+  resets=$((NOW + remaining))
+  # Mid-window 5h gate with cap_5h=25 and used_5h=0 so the gate never trips.
+  write_rl "sweep.json" 10 "$resets" 0 $((NOW + 9000))
+  result=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+  TOTAL=$((TOTAL + 1))
+  if (( result >= prev )); then
+    PASS=$((PASS + 1)); echo "  PASS: weekly-ramp-sweep remaining=$remaining → $result (>= prev $prev)"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: weekly-ramp-sweep remaining=$remaining → $result < prev $prev"
+  fi
+  prev="$result"
+done
+tw_teardown
+
+# --- Test 10: 5h-cap sweep drops to 0 once used_5h crosses cap_5h -----------
+
+echo "Test: 5h-cap-sweep drops to 0 once used_5h crosses cap_5h"
+tw_setup
+# Hold remaining_weekly in the late-week ramp regime (1h → ramp 0.922 → 7).
+# Fix elapsed_5h_frac = 0.8 (remaining_5h = 3600), so cap_5h = 40.
+# Walk used_5h from 0 → 50; assert target_N is 7 below the cap and 0 at/above.
+NOW=10000
+export DISPATCH_TARGET_WORKERS_NOW="$NOW"
+RESETS_WEEKLY=$((NOW + 3600))
+RESETS_5H=$((NOW + 3600))   # remaining_5h = 3600 → elapsed = 0.8 → cap = 40
+for used in 0 20 39 40 41 50; do
+  write_rl "cap-sweep.json" 50 "$RESETS_WEEKLY" "$used" "$RESETS_5H"
+  result=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+  if (( used < 40 )); then
+    assert_eq "5h-cap-sweep used=$used (< cap 40) → 7" "7" "$result"
+  else
+    assert_eq "5h-cap-sweep used=$used (>= cap 40) → 0" "0" "$result"
+  fi
+done
+tw_teardown
+
+# --- Test 11: config tunable max_concurrent_workers raises the cap ---------
+
+echo "Test: config max_concurrent_workers tunable raises the absolute cap"
+tw_setup
+cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
+{"max_concurrent_workers": 16}
+EOF
+# Saturate the ramp so target tracks the cap.
+export DISPATCH_TARGET_WORKERS_NOW=10000
+write_rl "rl.json" 10 10001 0 13500
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "config max_concurrent_workers=16 → 16" "16" "$out"
+tw_teardown
+
+# --- Test 12: per-field env override wins over file ------------------------
+
+echo "Test: per-field env override wins over rate_limits.json"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW=10000
+# File says 5h gate already tripped; env override says used_5h=0 → gate clears.
+write_rl "rl.json" 50 13600 99 13600
+export DISPATCH_TARGET_WORKERS_USED_5H=0
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "env override clears 5h gate; late-week ramp → 7" "7" "$out"
+tw_teardown
+
 # ============================================================================
 # dispatch project-helper tests (item-add / status-read / status-write)
 # ============================================================================


### PR DESCRIPTION
## Summary

Adds a router-side concurrency budgeter that drives the live
`dispatch-worker-*` count toward a target weekly usage while never
exceeding a 5-hour budget schedule. The router now consults
`dispatch-target-workers` and the live worker count before spawning;
when `live_count >= target_N` the spawn is skipped and the chain
re-seeds on the next tick.

Closes #845.

## What's in this PR

- **`dispatch-target-workers`** — pure script implementing the two
  composed schedules. Reads
  `~/.local/share/productivity-tui/rate_limits.json` (already
  maintained by the productivity-tui statusline hook). All six
  tunables are optional; defaults baked in match the issue spec
  (`target_weekly=90`, `target_5h=50`, `max_workers=8`, `tau=86400`,
  `k=2`, `five_hour_window=18000`).
- **`dispatch-config-load target-workers`** — schema validator for
  the optional `dispatch.config/target-workers.json` tunable file.
- **`claude_agents_count_by_name_prefix`** — new helper in
  `lib-claude-agents.sh` that counts live sessions whose `name`
  starts with a given prefix. Same UNKNOWN-on-daemon-failure contract
  as `claude_sessions_under`.
- **Router Step 6 gate** — two-line bash composition in
  `dispatch/SKILL.md` that short-circuits the spawn when the live
  worker count meets the target. Step 7 recognizes the skip-over-cap
  outcome as a clean completion. Fails open on daemon UNKNOWN; the
  per-worktree dedup inside `dispatch-spawn-worker` is the last-line
  defense.
- **`dispatch/SKILL.md` documentation** — a new Concurrency Budgeting
  subsection with both math tables, every tunable's default, and
  recalibration notes.

## Test plan

- [x] `bash .claude/skills/dispatch/scripts/test-dispatch-scripts.sh`
      — 485/485 passing.
- [x] New `dispatch-target-workers` tests cover: weekly-target reached,
      weekly-refresh passed, 5h-cap tripped, both-clear spawn, missing
      telemetry, seven_day-absent fallback, five_hour-absent (no cap),
      absolute cap, weekly-ramp monotonic sweep, 5h-cap sweep across
      the threshold, config tunable override, and per-field env
      override.
- [x] New `dispatch-config-load target-workers` tests cover: valid
      schema, absent file, non-number rejection, empty-object accepted.
- [x] New `claude_agents_count_by_name_prefix` tests cover:
      prefix-matching, no-match, daemon-failure UNKNOWN, non-array
      UNKNOWN.
- [x] New router-gate composition tests cover: live>=target skip,
      live<target spawn, daemon UNKNOWN fail-open.
- [x] Spot-checked against the real `rate_limits.json` on the dev box:
      target_N=0 (5h cap is the binding constraint at 21% used vs.
      ~17% cap), gate routes to skip with live_count=0 since 0>=0.