### PR TITLE
dispatch-select-target: gate priority-1 continuation on other-session liveness

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -272,7 +272,11 @@ continue to target selection.
   adoption → topic-category × phase ladder. A jit-reminder surfaces even when
   `origin/main` is red because the JIT scan precedes the main-broken gate;
   current-worktree continuation surfaces before either, so a session inside an
-  `<issue>-*` worktree always continues there.
+  `<issue>-*` worktree always continues there. Current-worktree continuation
+  requires the worktree to have no *other* live Claude session — consistent
+  with the queue-mode liveness dedup landed in #741 and the explicit-mode case
+  tracked in #837; when another session owns the worktree, the selector falls
+  through to the rest of the ladder.
 
   The topic-category × phase ladder is two-tier: a topic **category** nests
   outside the phase **ladder**. Categories, highest priority first:

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -27,7 +27,9 @@
 # Default-mode priority, top to bottom — current-worktree continuation runs
 # first so a session inside an <issue>-* worktree always continues there, even
 # when the sweep finds an orphan elsewhere on disk:
-#   1. current-worktree continuation (worktree / worktree-closed)
+#   1. current-worktree continuation (worktree / worktree-closed), gated on no
+#      *other* live session under the worktree; when another session owns the
+#      worktree the selector falls through rather than mis-claim it
 #   2. JIT scan (jit-reminder)
 #   3. origin/main CI health gate (main-broken)
 #   4. dispatch-sweep (worktree-adopted / cleanup-unknown), unless --no-sweep
@@ -96,6 +98,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
+source "$SCRIPT_DIR/lib-claude-agents.sh"
 QA_MODE=false
 HEALTH_ONLY=false
 NO_SWEEP=false
@@ -350,19 +353,33 @@ fi
 if [[ "$QA_MODE" == "false" ]]; then
   if on_worktree_branch; then
     N="${BASH_REMATCH[1]}"
-    if STATE=$(gh issue view "$N" --json state 2>/dev/null | jq -r '.state'); then
-      if [[ "$STATE" == "OPEN" ]]; then
-        echo "worktree $N $CURRENT_BRANCH"
+    WT_PATH=$(git rev-parse --show-toplevel)
+    # Gate the priority-1 emission on liveness. When another live Claude
+    # session is already under this worktree (the dispatching router is a
+    # background job, hook-spawned, or a sibling of an interactive session),
+    # current-worktree continuation should NOT fire — the spawn-side dedup
+    # would catch the race, but the upstream selection was wrong and the tick
+    # would be wasted. Fall through to the rest of the ladder instead.
+    # Fail-safe: `other_live_sessions_under` returns "occupied" on any
+    # uncertainty (daemon unreachable, missing $CLAUDE_CODE_SESSION_ID), so
+    # ambiguous environments fall through rather than mis-claim.
+    if ! other_live_sessions_under "$WT_PATH"; then
+      if STATE=$(gh issue view "$N" --json state 2>/dev/null | jq -r '.state'); then
+        if [[ "$STATE" == "OPEN" ]]; then
+          echo "worktree $N $CURRENT_BRANCH"
+        else
+          echo "worktree-closed $N $CURRENT_BRANCH"
+        fi
       else
+        # A failed `gh issue view` (nonexistent issue, transient API/auth error)
+        # is intentionally conflated with a genuinely closed issue: both yield
+        # worktree-closed, and /dispatch reports and stops on either.
         echo "worktree-closed $N $CURRENT_BRANCH"
       fi
-    else
-      # A failed `gh issue view` (nonexistent issue, transient API/auth error)
-      # is intentionally conflated with a genuinely closed issue: both yield
-      # worktree-closed, and /dispatch reports and stops on either.
-      echo "worktree-closed $N $CURRENT_BRANCH"
+      exit 0
     fi
-    exit 0
+    # Another live session owns this worktree; fall through to the rest of
+    # the ladder so the router picks up real work elsewhere.
   fi
 
   JIT_LINE=$(jit_scan)

--- a/.claude/skills/dispatch/scripts/lib-claude-agents.sh
+++ b/.claude/skills/dispatch/scripts/lib-claude-agents.sh
@@ -8,8 +8,9 @@
 # the brittle /proc-walk previously duplicated across dispatch scripts.
 #
 # Usage: source this file, then call:
-#   claude_sessions_under   <worktree-path>
-#   worktree_has_live_session <worktree-path>
+#   claude_sessions_under        <worktree-path>
+#   worktree_has_live_session    <worktree-path>
+#   other_live_sessions_under    <worktree-path>
 #
 # claude_sessions_under <path>
 #   The low-level primitive. Runs `claude agents --json --cwd <path>`, which
@@ -30,6 +31,20 @@
 #     return 0 — occupied OR unknown: do NOT start a session under <path>.
 #     return 1 — definitely no live session under <path>.
 #   `if worktree_has_live_session <path>` is fail-safe by construction.
+#
+# other_live_sessions_under <path>
+#   Self-filtering predicate: answers "are there live sessions under <path>
+#   besides the current session?" Filters rows whose sessionId matches
+#   $CLAUDE_CODE_SESSION_ID before deciding. Fail-safe semantics match
+#   worktree_has_live_session — any uncertainty returns "occupied" so the
+#   caller falls through rather than mis-claiming the worktree:
+#     return 0 — another session is present, OR unknown (daemon unreachable),
+#               OR $CLAUDE_CODE_SESSION_ID is empty (cannot filter self, so
+#               the rows might include foreign sessions misattributed to "me").
+#               In all three cases the worktree should be treated as occupied.
+#     return 1 — the daemon was queried successfully AND the only session(s)
+#               present belong to the current session (or there are none).
+#   `if other_live_sessions_under <path>` is fail-safe by construction.
 #
 # Test override: CLAUDE_AGENTS_CMD replaces the `claude` invocation with an
 # arbitrary command (e.g. an absolute path to a fake script), so the helper is
@@ -109,6 +124,27 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
     fi
     # The daemon was queried successfully and reported zero sessions.
     return 1
+  }
+
+  # other_live_sessions_under <path> — self-filtering fail-safe predicate.
+  # See the header comment for the return-code contract.
+  other_live_sessions_under() {
+    local path="${1:-}"
+    local sessions
+    if ! sessions=$(claude_sessions_under "$path"); then
+      return 0   # unknown → fail-safe occupied
+    fi
+    if [[ -z "$sessions" ]]; then
+      return 1   # daemon confirmed zero sessions
+    fi
+    local self="${CLAUDE_CODE_SESSION_ID:-}"
+    if [[ -z "$self" ]]; then
+      return 0   # cannot filter self → fail-safe occupied
+    fi
+    # claude_sessions_under emits sessionId<TAB>pid<TAB>status<TAB>name.
+    local other
+    other=$(printf '%s\n' "$sessions" | awk -F'\t' -v self="$self" '$1 != self')
+    [[ -n "$other" ]]
   }
 
 fi

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -4056,6 +4056,78 @@ assert_eq "cwd-arg: claude invoked as 'agents --json --cwd <path>'" \
   "$(printf 'agents\n--json\n--cwd\n%s' "$CA_DIR")" "$(cat "$CA_DIR/argv")"
 ca_teardown
 
+# --- Test 10: other_live_sessions_under — self only → free ------------------
+
+echo "Test: other_live_sessions_under — self only → free (return 1)"
+ca_setup
+write_fake_claude '[{"sessionId":"sess-self","pid":1234,"status":"active","name":"x"}]' 0
+export CLAUDE_CODE_SESSION_ID=sess-self
+if other_live_sessions_under "$CA_DIR"; then rc=0; else rc=$?; fi
+assert_eq "other_live_sessions_under: self only → return 1 (free)" "1" "$rc"
+unset CLAUDE_CODE_SESSION_ID
+ca_teardown
+
+# --- Test 11: other_live_sessions_under — self plus other → occupied --------
+
+echo "Test: other_live_sessions_under — self plus other → occupied (return 0)"
+ca_setup
+write_fake_claude '[{"sessionId":"sess-self","pid":1234,"status":"active","name":"x"},{"sessionId":"sess-other","pid":5678,"status":"active","name":"y"}]' 0
+export CLAUDE_CODE_SESSION_ID=sess-self
+if other_live_sessions_under "$CA_DIR"; then rc=0; else rc=$?; fi
+assert_eq "other_live_sessions_under: self + other → return 0 (occupied)" "0" "$rc"
+unset CLAUDE_CODE_SESSION_ID
+ca_teardown
+
+# --- Test 12: other_live_sessions_under — other only → occupied -------------
+
+echo "Test: other_live_sessions_under — other only → occupied (return 0)"
+ca_setup
+write_fake_claude '[{"sessionId":"sess-other","pid":5678,"status":"active","name":"y"}]' 0
+export CLAUDE_CODE_SESSION_ID=sess-self
+if other_live_sessions_under "$CA_DIR"; then rc=0; else rc=$?; fi
+assert_eq "other_live_sessions_under: other only → return 0 (occupied)" "0" "$rc"
+unset CLAUDE_CODE_SESSION_ID
+ca_teardown
+
+# --- Test 13: other_live_sessions_under — empty registry → free -------------
+
+echo "Test: other_live_sessions_under — empty registry → free (return 1)"
+ca_setup
+write_fake_claude '[]' 0
+export CLAUDE_CODE_SESSION_ID=sess-self
+if other_live_sessions_under "$CA_DIR"; then rc=0; else rc=$?; fi
+assert_eq "other_live_sessions_under: empty registry → return 1 (free)" "1" "$rc"
+unset CLAUDE_CODE_SESSION_ID
+ca_teardown
+
+# --- Test 14: other_live_sessions_under — daemon failure → occupied ----------
+
+echo "Test: other_live_sessions_under — daemon failure → occupied (return 0)"
+ca_setup
+# Inline fake that exits 1 to model a daemon unreachable scenario.
+cat > "$CA_FAKE" <<'FAKE'
+#!/usr/bin/env bash
+exit 1
+FAKE
+chmod +x "$CA_FAKE"
+CLAUDE_AGENTS_CMD="$CA_FAKE"
+export CLAUDE_CODE_SESSION_ID=sess-self
+if other_live_sessions_under "$CA_DIR"; then rc=0; else rc=$?; fi
+assert_eq "other_live_sessions_under: daemon failure → return 0 (fail-safe occupied)" "0" "$rc"
+unset CLAUDE_CODE_SESSION_ID
+ca_teardown
+
+# --- Test 15: other_live_sessions_under — CLAUDE_CODE_SESSION_ID unset → occupied
+
+echo "Test: other_live_sessions_under — CLAUDE_CODE_SESSION_ID unset → occupied (return 0)"
+ca_setup
+write_fake_claude '[{"sessionId":"sess-other","pid":5678,"status":"active","name":"y"}]' 0
+unset CLAUDE_CODE_SESSION_ID
+if other_live_sessions_under "$CA_DIR"; then rc=0; else rc=$?; fi
+assert_eq "other_live_sessions_under: CLAUDE_CODE_SESSION_ID unset → return 0 (fail-safe occupied)" "0" "$rc"
+unset CLAUDE_CODE_SESSION_ID
+ca_teardown
+
 # ============================================================================
 # dispatch-config-load tests
 # ============================================================================

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -65,6 +65,9 @@ setup() {
   # SCRIPT_DIR, which resolves to TMPDIR_TEST for these copies — so lib.sh must
   # sit alongside them. It is sourced, not executed, so it needs no chmod +x.
   cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/lib.sh"
+  # dispatch-select-target sources lib-claude-agents.sh via its SCRIPT_DIR
+  # (TMPDIR_TEST under test). Sourced, not executed — no chmod +x needed.
+  cp "$SCRIPT_DIR/lib-claude-agents.sh" "$TMPDIR_TEST/lib-claude-agents.sh"
   chmod +x "$TMPDIR_TEST/dispatch-phase" \
            "$TMPDIR_TEST/dispatch-find-pr" \
            "$TMPDIR_TEST/dispatch-resolve-arg" \
@@ -81,6 +84,21 @@ setup() {
   mkdir -p "$TMPDIR_TEST/config"
   export DISPATCH_CONFIG_DIR="$TMPDIR_TEST/config"
   export DISPATCH_FIND_PR_RETRY_DELAY=0
+
+  # Default fake `claude`: emits an empty JSON array on stdout, exits 0.
+  # lib-claude-agents.sh `claude_sessions_under` reads `[]` as a successful
+  # "zero sessions" response; `other_live_sessions_under` then returns 1
+  # (definite "no other sessions"). This keeps every existing
+  # dispatch-select-target test (including the on-worktree #16/17/18/27 cases)
+  # transparent to the priority-1 liveness gate. Per-test overrides — written
+  # to this same path — make the new gate tests assert against a non-empty
+  # registry. Installed in $TMPDIR_TEST/bin so it sits on PATH alongside the
+  # gh and git stubs.
+  cat > "$TMPDIR_TEST/bin/claude" <<'STUB'
+#!/usr/bin/env bash
+echo "[]"
+STUB
+  chmod +x "$TMPDIR_TEST/bin/claude"
 
   # Default no-op dispatch-sweep stub: silent, exit 0 (no orphan to adopt).
   # dispatch-select-target invokes "$SCRIPT_DIR/dispatch-sweep" in default mode
@@ -326,6 +344,16 @@ case "$args" in
       echo "main"
     fi
     ;;
+  "rev-parse --show-toplevel")
+    # dispatch-select-target's priority-1 branch passes this path to
+    # other_live_sessions_under. Default to /repo so it matches the default
+    # worktree-list.txt entry; per-test overrides may write a different path.
+    if [[ -f "$STUB_DIR/worktree-toplevel.txt" ]]; then
+      cat "$STUB_DIR/worktree-toplevel.txt"
+    else
+      echo "/repo"
+    fi
+    ;;
   *)
     echo "git stub: unknown invocation: $args" >&2
     exit 1
@@ -404,6 +432,9 @@ teardown() {
   export PATH="$SAVED_PATH"
   unset DISPATCH_CONFIG_DIR
   unset DISPATCH_FIND_PR_RETRY_DELAY
+  # Per-test exports for the liveness gate must not leak across tests.
+  unset CLAUDE_AGENTS_CMD
+  unset CLAUDE_CODE_SESSION_ID
 }
 trap '[ -n "${TMPDIR_TEST:-}" ] && rm -rf "$TMPDIR_TEST"' EXIT
 
@@ -1012,6 +1043,82 @@ printf '999-gone' > "$STUB_DIR/current-branch.txt"
 # No issue-state-999.json — gh stub exits 1, models a nonexistent issue.
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "unknown issue worktree → worktree-closed 999 999-gone" "worktree-closed 999 999-gone" "$result"
+teardown
+
+# --- Priority-1 liveness gate (issue #866) ----------------------------------
+# The priority-1 branch (current-worktree continuation) emits worktree / worktree-closed
+# only when no OTHER live Claude session is under the worktree. When the
+# dispatching router itself is a background job or hook-spawned inside an
+# <N>-* worktree that already has a live session, the gate must fall through
+# to the rest of the priority ladder instead of mis-claiming the worktree.
+# `other_live_sessions_under` filters out the dispatching session by
+# $CLAUDE_CODE_SESSION_ID; the per-test fake `claude` injects the registry.
+
+# 18a. open issue worktree + only the dispatching session is live → worktree <N> emitted.
+echo "Test: open issue worktree + self-only session → worktree <N> <branch>"
+setup
+# Seed a verify PR that the ladder would otherwise pick — proves priority-1 fired.
+UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
+printf '{"state":"OPEN"}' > "$STUB_DIR/issue-state-42.json"
+# Fake `claude` reports one live session whose sessionId matches the
+# dispatching session — `other_live_sessions_under` filters it out and
+# returns "no other sessions".
+cat > "$TMPDIR_TEST/bin/claude" <<'STUB'
+#!/usr/bin/env bash
+echo '[{"sessionId":"sess-self","pid":1234,"status":"active","name":"x"}]'
+STUB
+chmod +x "$TMPDIR_TEST/bin/claude"
+export CLAUDE_CODE_SESSION_ID=sess-self
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "self-only session → worktree 42 42-some-slug emitted" "worktree 42 42-some-slug" "$result"
+teardown
+
+# 18b. open issue worktree + another live session under it → fall-through to queue ladder.
+echo "Test: open issue worktree + foreign session → fall-through to queue"
+setup
+# A selectable verify PR proves the script fell through to the queue ladder.
+UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
+printf '{"state":"OPEN"}' > "$STUB_DIR/issue-state-42.json"
+# Fake `claude` reports a foreign session that does NOT match
+# $CLAUDE_CODE_SESSION_ID — `other_live_sessions_under` returns "occupied"
+# and the priority-1 emission is skipped.
+cat > "$TMPDIR_TEST/bin/claude" <<'STUB'
+#!/usr/bin/env bash
+echo '[{"sessionId":"sess-foreign","pid":1234,"status":"active","name":"x"}]'
+STUB
+chmod +x "$TMPDIR_TEST/bin/claude"
+export CLAUDE_CODE_SESSION_ID=sess-self
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "foreign session → fall through to verify PR" "pr 10 10-verify-me verify" "$result"
+teardown
+
+# 18c. closed issue worktree + another live session → fall-through, NOT worktree-closed.
+# Both `worktree` and `worktree-closed` are gated: when a foreign session owns
+# the worktree, the router must not preempt it by reporting "closed and stop".
+echo "Test: closed issue worktree + foreign session → fall-through, not worktree-closed"
+setup
+UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
+printf '{"state":"CLOSED"}' > "$STUB_DIR/issue-state-42.json"
+cat > "$TMPDIR_TEST/bin/claude" <<'STUB'
+#!/usr/bin/env bash
+echo '[{"sessionId":"sess-foreign","pid":1234,"status":"active","name":"x"}]'
+STUB
+chmod +x "$TMPDIR_TEST/bin/claude"
+export CLAUDE_CODE_SESSION_ID=sess-self
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "closed issue + foreign session → fall through to verify PR" "pr 10 10-verify-me verify" "$result"
 teardown
 
 # 19. main branch → queue scan unchanged, normal result returned.


### PR DESCRIPTION
## Summary

- Adds `other_live_sessions_under <path>` to `lib-claude-agents.sh` — a self-filtering fail-safe predicate that excludes `$CLAUDE_CODE_SESSION_ID` from the liveness check, so the caller can ask "is anyone *else* under this worktree?" without false-positiving on itself.
- Gates `dispatch-select-target`'s priority-1 `worktree <N> <branch>` / `worktree-closed <N> <branch>` emissions on the new predicate. Background `/dispatch` routers spawned inside an `<N>-*` worktree that another live Claude session already owns (e.g. via #725's heartbeat, a hook, or a parent session in the same worktree) now fall through to the rest of the priority ladder rather than mis-claiming the worktree.
- Documents the gate in `dispatch/SKILL.md`'s Step 3 priority-order paragraph alongside the queue-mode liveness dedup from #741 and the explicit-mode case tracked in #837.

## Why

`on_worktree_branch` previously emitted priority-1 unconditionally, on the implicit assumption that the dispatching session was the worktree's session. The spawn-side dedup at `dispatch-spawn-worker` already caught the resulting race (returning `deduped`), but the upstream selection was wrong: the queue ladder was bypassed and the tick was wasted. This change closes the selection-side gap. The spawn-side belt remains via `dispatch-spawn-worker` (and #860's name-keyed hardening).

## Acceptance criteria (from #866)

- [x] `lib-claude-agents.sh` exposes a self-filtering predicate (`other_live_sessions_under`) that excludes `$CLAUDE_CODE_SESSION_ID` and preserves fail-safe semantics — daemon unreachable or missing self-id → "occupied".
- [x] `dispatch-select-target`'s `on_worktree_branch` branch calls the predicate before emitting `worktree <N> <branch>` or `worktree-closed <N> <branch>`. Both emissions are gated.
- [x] `.claude/skills/dispatch/SKILL.md` Step 3's priority-order paragraph notes the gate alongside #741 and #837.
- [x] `test-dispatch-scripts.sh` covers: (a) match + no other live session → `worktree <N>` emitted; (b) match + foreign live session → fall-through; (c) match + closed issue + foreign live session → fall-through (not `worktree-closed`).
- [x] Six new `lib-claude-agents.sh` tests for the predicate (self only, self + other, other only, empty, daemon failure, `$CLAUDE_CODE_SESSION_ID` unset).

## Test plan

- [x] `.claude/skills/dispatch/scripts/test-dispatch-scripts.sh` — 451/451 PASS (up from 448 before this branch).
- [ ] CI: dispatch hook + lint suite passes on push.
- [ ] Verify phase: `/dispatch` from a background context inside a foreign-session-occupied worktree falls through to the queue ladder rather than emitting `worktree <N>` (manual repro, not a committed test).

## Out of scope (per #866)

- Spawn-side dedup at `dispatch-spawn-worker` (already catches the race; #860 hardens further).
- `dispatch-resolve-worktree`'s `here` outcome — unchanged.
- Explicit-mode `enter <path>` liveness — tracked in #837.
- Removal of sweep adoption priority — tracked in #857.

Closes #866.

🤖 Generated with [Claude Code](https://claude.com/claude-code)