### PR TITLE
dispatch: router ignores cwd for selection (closes #869, supersedes #866)

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -445,12 +445,12 @@ keys post-Step-5 reclaim on it (see *Releasing the lock*).
 `.claude/hooks/worktree-create.sh` also writes the marker as its final action
 on every successful worktree creation, so a fresh worktree is marker-bearing
 the moment the hook returns — the router's explicit marker write here is the
-in-skill defense for any code path that bypasses the hook. The router itself never writes the marker
-into its own cwd (`worktrees/main`), so a `SessionStart:clear` there is a
-no-op — correct, since the router is short-lived and re-seeded by the #725
-daily restart. The marker is an empty boolean flag with no payload; it persists
-for the worktree's life and needs no cleanup — `tmp/` is git-ignored, and
-removing the worktree removes it.
+in-skill defense for any code path that bypasses the hook. The router itself
+never writes the marker into its own cwd (`worktrees/main`), so a
+`SessionStart:clear` there is a no-op — correct, since the router is
+short-lived and re-seeded by the #725 daily restart. The marker is an empty
+boolean flag with no payload; it persists for the worktree's life and needs no
+cleanup — `tmp/` is git-ignored, and removing the worktree removes it.
 
 As the **final action of this step on every non-`conflict` (proceed) path** —
 after the marker is written, before Step 6 — release the lock (see *Releasing

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -21,9 +21,9 @@ running.
 optional). With an argument, it targets that issue and skips the queue scan; a
 PR number is resolved to the issue that PR closes (see Step 3).
 
-Run `/dispatch` from the **main worktree**, or from inside an issue worktree to
-continue that issue. The router never enters a worktree; it materializes the
-target worktree (if needed) and spawns the worker into it.
+Run `/dispatch` from any worktree; selection ignores cwd. The router never
+enters a worktree; it materializes the target worktree (if needed) and spawns
+the worker into it.
 
 Run `gh` commands (`gh label create`, `gh pr edit`, and the scripts that invoke
 `gh`) with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
@@ -208,9 +208,8 @@ continue to target selection.
     paths.
 
 - **No argument** → run target selection. A single invocation decides every
-  Step 3 outcome: current-worktree continuation, JIT, main-broken gate, sweep
-  orphan adoption, and the queue ladder are all internal to the script and
-  emitted on its one output line.
+  Step 3 outcome: JIT, main-broken gate, sweep orphan adoption, and the queue
+  ladder are all internal to the script and emitted on its one output line.
 
   ```bash
   SELECTED=$(.claude/skills/dispatch/scripts/dispatch-select-target)
@@ -220,14 +219,6 @@ continue to target selection.
 
   Route on `$SELECTED`:
 
-  - `worktree <N> <branch>` — the current branch is `<N>-…` and issue `<N>` is
-    open. Continue here; skip Step 4 and proceed to Step 5 with mode `queue`
-    (worktree resolution will print `here`).
-  - `worktree-closed <N> <branch>` — the current branch is `<N>-…` and issue
-    `<N>` is closed or unrecognized. Release the lock (see *Releasing the
-    lock*), report that the current worktree belongs to closed/unrecognized
-    issue `<N>`, then **proceed to Step 7** (early-stop) (consistent with the
-    named-target "closed → report and stop" rule in Step 4).
   - `worktree-adopted <N> <branch>` — `dispatch-sweep` adopted an orphaned
     worktree elsewhere on disk. Skip Step 4 and proceed to Step 5 with `<N>` and
     mode `explicit` — treat the adoption like an explicit `/dispatch <N>`.
@@ -262,17 +253,10 @@ continue to target selection.
   - `empty` — nothing eligible. Release the lock (see *Releasing the lock*),
     report that the queue is empty, then **proceed to Step 7** (early-stop).
 
-  An **explicit issue argument overrides current-worktree detection** — the
-  selection script, and therefore its current-worktree detection, runs only
-  when no argument is given. `/dispatch #123` run from inside worktree-456
-  still targets 123.
-
-  Priority order the script implements, top to bottom: current-worktree
-  continuation → JIT scan → `origin/main` CI health gate → sweep orphan
-  adoption → topic-category × phase ladder. A jit-reminder surfaces even when
-  `origin/main` is red because the JIT scan precedes the main-broken gate;
-  current-worktree continuation surfaces before either, so a session inside an
-  `<issue>-*` worktree always continues there.
+  Priority order the script implements, top to bottom: JIT scan →
+  `origin/main` CI health gate → sweep orphan adoption → topic-category ×
+  phase ladder. A jit-reminder surfaces even when `origin/main` is red because
+  the JIT scan precedes the main-broken gate.
 
   The topic-category × phase ladder is two-tier: a topic **category** nests
   outside the phase **ladder**. Categories, highest priority first:
@@ -329,9 +313,6 @@ Skip leaf tracing when:
   result or as an explicit issue argument. **Do not infer PR existence from title
   search or other ad-hoc `gh` queries** — `dispatch-find-pr` is the only correct
   check (see Step 5).
-- The target was current-worktree detected (`worktree <N>` result) — the worktree
-  is the already-committed unit of work; retargeting to a sub-issue or blocker
-  would be wrong.
 
 If the resolved target issue `<N>` has any **open** blocker — run
 `issue-blocking <N>` and check for any entry with `state` `OPEN` — release the
@@ -353,14 +334,6 @@ an explicit `/dispatch` argument, otherwise `queue`:
 
 It prints exactly one decision line — act on it. Each branch resolves to a
 worktree path that Step 6 will pass to `dispatch-spawn-worker`.
-
-- **`here`** → the current branch already is the target's worktree. Set
-  `WORKTREE_PATH="$(git rev-parse --show-toplevel)"` for Step 6. Re-sync issue
-  context (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls
-  `gh`):
-  ```bash
-  .claude/skills/dispatch/scripts/sync-issue-context <N>
-  ```
 
 - **`enter <path>`** → re-use an existing `<issue>-*` worktree (the
   recycle-after-completion case, reached only for an explicit argument). Set
@@ -428,8 +401,7 @@ keys post-Step-5 reclaim on it (see *Releasing the lock*).
 `.claude/hooks/worktree-create.sh` also writes the marker as its final action
 on every successful worktree creation, so a fresh worktree is marker-bearing
 the moment the hook returns — the router's explicit marker write here is the
-in-skill defense for the `here` path and for any code path that bypasses the
-hook. The router itself never writes the marker
+in-skill defense for any code path that bypasses the hook. The router itself never writes the marker
 into its own cwd (`worktrees/main`), so a `SessionStart:clear` there is a
 no-op — correct, since the router is short-lived and re-seeded by the #725
 heartbeat. The marker is an empty boolean flag with no payload; it persists
@@ -474,8 +446,8 @@ The router's tick ends here. There are two dispositions:
 - **clean completion or early-stop** — every other terminal path:
   - Step 6 returned `spawned` or `deduped` (clean completion).
   - A Steps 0–5 stop path (busy lock, sync failure, empty queue, `main-broken`,
-    resolver failure, `worktree-closed`, closed-issue target, open-blocker
-    gate, `worktree` conflict, jit-reminder summary). The jit-reminder
+    resolver failure, closed-issue target, open-blocker gate, worktree
+    conflict, jit-reminder summary). The jit-reminder
     summary is an exception that **does not self-close** — it bypasses Step 7
     entirely, per the jit-reminder handler in Step 3.
 

--- a/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch/scripts/dispatch-resolve-worktree
@@ -3,8 +3,6 @@
 # Usage: dispatch-resolve-worktree <issue-num> <explicit|queue>
 #
 # Prints exactly one decision line to stdout:
-#   here            — the current branch already is <issue>-*; the caller
-#                     uses the current worktree path.
 #   enter <path>    — an existing <issue>-* worktree exists; the caller
 #                     uses <path>.
 #   create <branch> — no <issue>-* worktree exists; the caller materializes
@@ -17,7 +15,6 @@
 #              (recycle-after-completion); an existing worktree yields `enter`.
 #   queue    — the target was queue-selected; an existing worktree belongs to
 #              another session and yields `conflict`.
-# The `here` check is mode-independent and fires before the worktree scan.
 #
 # The branch name printed by `create` matches the WorktreeCreate hook's
 # accepted form ^[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$, full name <= 32 characters.
@@ -35,14 +32,6 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
-
-# `here` — the current branch already is the target's branch. Mode-independent,
-# checked before the worktree scan.
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [[ "$CURRENT_BRANCH" == "$ISSUE"-* ]]; then
-  echo "here"
-  exit 0
-fi
 
 # `enter` / `conflict` — scan local worktrees for one whose branch carries the
 # <issue>-* prefix, via the shared list_worktree_records helper (lib.sh).

--- a/.claude/skills/dispatch/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch/scripts/dispatch-select-target
@@ -2,13 +2,15 @@
 # Select the single highest-priority task from the queue.
 # Usage: dispatch-select-target [--qa | --health-only] [--no-sweep] [--cleanup-confirm <path>]
 #
+# Selection is a pure function of GitHub state plus local-worktree existence.
+# The router's cwd carries no priority signal; invoking this script from any
+# worktree (main, an issue worktree, or elsewhere) produces the same result.
+#
 # Output: exactly one line:
 #   pr <num> <branch> <phase>   — a PR to work on, with its already-derived phase
 #   issue <num>                 — a help-wanted issue, resolved to a startable
 #                                 open leaf (may differ from the top-level issue)
 #   empty                       — nothing eligible
-#   worktree <N> <branch>       — the current worktree's own open issue (short-circuits the queue scan)
-#   worktree-closed <N> <branch>— the current worktree's issue is closed or unknown
 #   worktree-adopted <N> <branch>
 #                               — dispatch-sweep adopted an orphaned worktree
 #                                 elsewhere on disk; SKILL.md routes this exactly
@@ -24,23 +26,17 @@
 #                                 dispatch.config/jit.json is present.
 #   main-broken <sha>           — origin/main's HEAD CI has a failing check; no task selected
 #
-# Default-mode priority, top to bottom — current-worktree continuation runs
-# first so a session inside an <issue>-* worktree always continues there, even
-# when the sweep finds an orphan elsewhere on disk:
-#   1. current-worktree continuation (worktree / worktree-closed)
-#   2. JIT scan (jit-reminder)
-#   3. origin/main CI health gate (main-broken)
-#   4. dispatch-sweep (worktree-adopted / cleanup-unknown), unless --no-sweep
-#   5. the topic-category × phase ladder over open PRs and help-wanted issues
+# Default-mode priority, top to bottom:
+#   1. JIT scan (jit-reminder)
+#   2. origin/main CI health gate (main-broken)
+#   3. dispatch-sweep (worktree-adopted / cleanup-unknown), unless --no-sweep
+#   4. the topic-category × phase ladder over open PRs and help-wanted issues
 #
-# --health-only mode runs the pre-ladder bypasses (current-worktree continuation),
-# the JIT scan, and the origin/main CI health gate, then exits — no sweep,
-# no queue scan, no PR/issue fetches. /dispatch SKILL.md uses it to re-seed the
-# dispatch chain heartbeat cheaply.
+# --health-only mode runs the JIT scan and the origin/main CI health gate, then
+# exits — no sweep, no queue scan, no PR/issue fetches. /dispatch SKILL.md uses
+# it to re-seed the dispatch chain heartbeat cheaply.
 # Output is exactly one line:
-#   ok                          — safe to proceed (either main is healthy or the
-#                                 current branch is an <N>-* worktree that
-#                                 bypasses the gate)
+#   ok                          — safe to proceed (main is healthy)
 #   jit-reminder <repo> <num> <project> <item-id>
 #                               — a configured JIT issue due for a reminder;
 #                                 emitted before the main-broken gate
@@ -159,15 +155,6 @@ main_broken_sha() {
   if [[ "$cr_fail" -gt 0 || "$wf_fail" -gt 0 ]]; then
     echo "$sha"
   fi
-}
-
-# Current branch shared by --health-only and default modes; computed once.
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
-# Current-worktree continuation bypasses the main-broken gate: a session
-# continuing its own in-progress work doesn't care about main's state.
-on_worktree_branch() {
-  [[ "$CURRENT_BRANCH" =~ ^([0-9]+)- ]]
 }
 
 # Convert a duration string ("12h", "7d", "30m") to whole seconds. Units:
@@ -328,10 +315,6 @@ sweep_and_route() {
 }
 
 if [[ "$HEALTH_ONLY" == "true" ]]; then
-  if on_worktree_branch; then
-    echo "ok"
-    exit 0
-  fi
   JIT_LINE=$(jit_scan)
   if [[ -n "$JIT_LINE" ]]; then
     echo "$JIT_LINE"
@@ -346,25 +329,8 @@ if [[ "$HEALTH_ONLY" == "true" ]]; then
   exit 0
 fi
 
-# Default mode: current-worktree detection first, then the main-broken gate.
+# Default mode: JIT scan, then the main-broken gate.
 if [[ "$QA_MODE" == "false" ]]; then
-  if on_worktree_branch; then
-    N="${BASH_REMATCH[1]}"
-    if STATE=$(gh issue view "$N" --json state 2>/dev/null | jq -r '.state'); then
-      if [[ "$STATE" == "OPEN" ]]; then
-        echo "worktree $N $CURRENT_BRANCH"
-      else
-        echo "worktree-closed $N $CURRENT_BRANCH"
-      fi
-    else
-      # A failed `gh issue view` (nonexistent issue, transient API/auth error)
-      # is intentionally conflated with a genuinely closed issue: both yield
-      # worktree-closed, and /dispatch reports and stops on either.
-      echo "worktree-closed $N $CURRENT_BRANCH"
-    fi
-    exit 0
-  fi
-
   JIT_LINE=$(jit_scan)
   if [[ -n "$JIT_LINE" ]]; then
     echo "$JIT_LINE"
@@ -378,12 +344,10 @@ if [[ "$QA_MODE" == "false" ]]; then
   fi
 
   # Internal sweep: adopt an orphaned worktree elsewhere on disk, or halt on
-  # an unknown orphan. Runs after current-worktree continuation (above) so a
-  # session inside an <issue>-* worktree always continues there. --no-sweep
-  # skips this so a re-call after a declined cleanup-unknown doesn't re-halt
-  # on the same unknown orphan. --cleanup-confirm runs the user-confirmed
-  # cleanup first, then re-enters this same sweep+route block (so a second
-  # unknown orphan, if any, halts the script the same way).
+  # an unknown orphan. --no-sweep skips this so a re-call after a declined
+  # cleanup-unknown doesn't re-halt on the same unknown orphan. --cleanup-confirm
+  # runs the user-confirmed cleanup first, then re-enters this same sweep+route
+  # block (so a second unknown orphan, if any, halts the script the same way).
   if [[ -n "$CLEANUP_CONFIRM_PATH" ]]; then
     # Cleanup itself is fail-loud: a non-zero exit (invalid path, registration
     # race) propagates with stderr intact, matching the cleanup-unknown

--- a/.claude/skills/dispatch/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch/scripts/dispatch-sweep
@@ -25,9 +25,9 @@
 #      inferable issue number) — the latter halt the sweep with exit 3 and a
 #      "cleanup-unknown:<path>" directive on stderr.
 #   6. From the eligible orphans pick the OLDEST by HEAD commit time and emit
-#      "worktree <N> <branch>" on stdout (the same directive shape dispatch-
-#      select-target uses for current-worktree mode); SKILL.md routes that to
-#      the existing resume-worktree flow.
+#      "worktree <N> <branch>" on stdout; dispatch-select-target wraps this as
+#      "worktree-adopted <N> <branch>" and SKILL.md routes that to the existing
+#      resume-worktree flow.
 #
 # Environment overrides for testability:
 #   DISPATCH_SWEEP_PROC_ROOT  Root of the /proc walk. Default: /proc.
@@ -319,8 +319,8 @@ while [[ $i -lt ${#ORPHAN_PATHS[@]} ]]; do
     exit 3
   fi
 
-  # Open PR but no leading issue number: we can't form the "worktree <N>
-  # <branch>" directive. Log and skip — the operator has the log to investigate.
+  # Open PR but no leading issue number: we can't form the adoption directive.
+  # Log and skip — the operator has the log to investigate.
   if [[ -z "$issue_num" ]]; then
     log "SKIP_ORPHAN_NO_ISSUE_NUM: '$wt_path' branch=$wt_branch pr=#$open_pr"
     continue

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -1843,9 +1843,9 @@ teardown
 # exercise the routing branches.
 
 # SR1. Selector invoked from an <issue>-* worktree returns the same queue-ladder
-#      result it would from main. A sweep stub that would adopt an orphan is
-#      installed; the assert proves it ran and produced worktree-adopted, not a
-#      cwd-derived line.
+#      result it would from main. The default no-op sweep stub is in place so the
+#      ladder runs; the assert proves a queue-ladder result (pr 999), not a
+#      cwd-derived line that old code would have emitted.
 echo "Test: selector from issue-branch cwd returns queue-ladder line (cwd ignored)"
 setup
 # Seed a verify PR as the expected queue-ladder output.
@@ -2425,9 +2425,10 @@ teardown
 
 # 7. explicit mode invoked from within <N>-* worktree (current-branch = <N>-*)
 #    AND matching worktree entry → enter <path> (no special-case `here`).
+#    current-branch.txt is not read by dispatch-resolve-worktree (the `here`
+#    check was removed); it is seeded here only to document the scenario intent.
 echo "Test: explicit from issue-branch cwd with matching worktree → enter (not here)"
 setup
-echo "42-my-feature" > "$STUB_DIR/current-branch.txt"
 printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
 assert_eq "explicit from issue-branch cwd, matching worktree → enter (not here)" \
@@ -2438,7 +2439,6 @@ teardown
 #     AND matching worktree entry → conflict <path> (worktree scan runs normally).
 echo "Test: queue from issue-branch cwd with matching worktree → conflict (not here)"
 setup
-echo "42-my-feature" > "$STUB_DIR/current-branch.txt"
 printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
 assert_eq "queue from issue-branch cwd, matching worktree → conflict (not here)" \

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -974,46 +974,6 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "lone waiting PR → empty" "empty" "$result"
 teardown
 
-# 16. Open issue worktree → worktree output, queue scan skipped.
-# The default no-op dispatch-sweep stub installed by setup() is in place but
-# unused — current-worktree continuation short-circuits before the sweep call.
-echo "Test: open issue worktree → worktree <N> <branch>, scan skipped"
-setup
-# Seed a verify PR that would normally be selected — proves the scan is skipped.
-UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
-setup_union_pr_list "$UNION"
-echo '[]' > "$STUB_DIR/issue-list.json"
-printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
-printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
-printf '{"state":"OPEN"}' > "$STUB_DIR/issue-state-42.json"
-result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "open issue worktree → worktree 42 42-some-slug" "worktree 42 42-some-slug" "$result"
-teardown
-
-# 17. Closed issue worktree → worktree-closed.
-echo "Test: closed issue worktree → worktree-closed <N> <branch>"
-setup
-setup_union_pr_list '[]'
-echo '[]' > "$STUB_DIR/issue-list.json"
-printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
-printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
-printf '{"state":"CLOSED"}' > "$STUB_DIR/issue-state-42.json"
-result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "closed issue worktree → worktree-closed 42 42-some-slug" "worktree-closed 42 42-some-slug" "$result"
-teardown
-
-# 18. Unknown issue worktree (no state file → gh fails) → worktree-closed.
-echo "Test: unknown issue worktree → worktree-closed <N> <branch>"
-setup
-setup_union_pr_list '[]'
-echo '[]' > "$STUB_DIR/issue-list.json"
-printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
-printf '999-gone' > "$STUB_DIR/current-branch.txt"
-# No issue-state-999.json — gh stub exits 1, models a nonexistent issue.
-result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "unknown issue worktree → worktree-closed 999 999-gone" "worktree-closed 999 999-gone" "$result"
-teardown
-
 # 19. main branch → queue scan unchanged, normal result returned.
 echo "Test: main branch → queue scan runs normally"
 setup
@@ -1026,25 +986,25 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "main branch → normal scan result (verify PR)" "pr 10 10-verify-me verify" "$result"
 teardown
 
-# 20. --qa mode from an issue worktree → detection skipped, QA PR returned.
-echo "Test: --qa mode from issue worktree → detection skipped, QA PR returned"
+# 20. --qa mode with a non-main current branch → normal QA PR returned.
+echo "Test: --qa mode with non-main current branch → QA PR returned"
 setup
 # QA-phase PR: draft + green + no label.
 UNION='['"$(make_pr_union 20 "20-qa-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
 setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
-# Current branch looks like an issue worktree, but --qa skips detection.
+# Non-main current branch: cwd does not affect --qa selection.
 printf '42-x' > "$STUB_DIR/current-branch.txt"
-printf '{"state":"OPEN"}' > "$STUB_DIR/issue-state-42.json"
 result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
-assert_eq "--qa mode from issue worktree → normal QA scan (pr 20 20-qa-me)" "pr 20 20-qa-me" "$result"
+assert_eq "--qa mode with non-main current branch → QA PR returned" "pr 20 20-qa-me" "$result"
 teardown
 
 # --- origin/main CI health gate (issue #660) --------------------------------
 # The gate runs before the priority ladder in default mode. It aggregates main's
 # HEAD CI from check-runs (CodeQL) and Actions workflow runs; a failing
-# conclusion short-circuits to "main-broken <sha>".
+# conclusion short-circuits to "main-broken <sha>". The gate is uniform —
+# there is no cwd-based bypass.
 #
 # The explicit-`/dispatch <issue|pr>` bypass is structural and not script-
 # testable here: an explicit argument skips the queue scan entirely (SKILL.md
@@ -1143,26 +1103,10 @@ result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
 assert_eq "--qa mode bypasses gate → QA PR returned" "pr 20 20-qa-me" "$result"
 teardown
 
-# 27. Current-worktree continuation bypasses the gate even when main is broken.
-echo "Test: worktree continuation bypasses the main-CI gate"
-setup
-setup_union_pr_list '[]'
-echo '[]' > "$STUB_DIR/issue-list.json"
-printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
-printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
-printf '{"state":"OPEN"}' > "$STUB_DIR/issue-state-42.json"
-printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
-printf '{"check_runs":[{"status":"completed","conclusion":"failure"}]}' \
-  > "$STUB_DIR/main-check-runs.json"
-printf '[]' > "$STUB_DIR/main-run-list.json"
-result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "worktree continuation bypasses gate → worktree 42 42-some-slug" "worktree 42 42-some-slug" "$result"
-teardown
-
 # --- --health-only mode (issue #683 AC: gate before sweep) ------------------
-# --health-only runs the pre-ladder bypasses and the gate, then exits without
-# the queue scan. /dispatch SKILL.md calls it before dispatch-sweep so the
-# sweep does not run while main is red.
+# --health-only runs the JIT scan and the gate, then exits without the queue
+# scan. /dispatch SKILL.md calls it before dispatch-sweep so the sweep does
+# not run while main is red.
 
 # 27a. --health-only, main green, not in a worktree → "ok", exit 0.
 echo "Test: --health-only + main green → ok"
@@ -1197,22 +1141,20 @@ assert_eq "--health-only main red → main-broken mainhead0" "main-broken mainhe
 assert_eq "--health-only main red → exit 0" "0" "$rc"
 teardown
 
-# 27c. --health-only, main red, current branch is <N>-foo with open issue <N>
-#      → "ok" (current-worktree bypass preserved).
-echo "Test: --health-only + worktree branch bypasses red main"
+# 27c. --health-only + <N>-* current branch + red main → main-broken (no bypass).
+echo "Test: --health-only + issue-branch cwd + red main → main-broken (cwd ignored)"
 setup
 echo '[]' > "$STUB_DIR/pr-list-union.json"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
-printf '{"state":"OPEN"}' > "$STUB_DIR/issue-state-42.json"
 printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
 printf '{"check_runs":[{"status":"completed","conclusion":"failure"}]}' \
   > "$STUB_DIR/main-check-runs.json"
 printf '[]' > "$STUB_DIR/main-run-list.json"
 if result=$("$TMPDIR_TEST/dispatch-select-target" --health-only); then rc=0; else rc=$?; fi
-assert_eq "--health-only worktree branch bypasses red main → ok" "ok" "$result"
-assert_eq "--health-only worktree branch → exit 0" "0" "$rc"
+assert_eq "--health-only issue-branch cwd, red main → main-broken mainhead0" "main-broken mainhead0" "$result"
+assert_eq "--health-only issue-branch cwd, red main → exit 0" "0" "$rc"
 teardown
 
 # 27d. --health-only --qa is mutually exclusive → exit non-zero, error on stderr.
@@ -1557,8 +1499,8 @@ teardown
 
 # ============================================================================
 # --- JIT scan ---
-# dispatch-select-target's JIT scan runs after current-worktree continuation
-# and before the main-broken health gate. It is inert with no jit.json.
+# dispatch-select-target's JIT scan runs before the main-broken health gate.
+# It is inert with no jit.json.
 # A JIT test seeds:
 #   $DISPATCH_CONFIG_DIR/jit.json       — the jit definitions
 #   $DISPATCH_CONFIG_DIR/projects.json  — the project catalog
@@ -1895,32 +1837,27 @@ teardown
 
 # --- sweep routing (issue #803) ---------------------------------------------
 # dispatch-select-target invokes dispatch-sweep internally in default mode,
-# between the main-broken gate and the queue ladder. The sweep call comes
-# AFTER current-worktree continuation, so a session inside an <issue>-*
-# worktree always continues there even when an orphan exists elsewhere.
+# between the main-broken gate and the queue ladder. Selection is a pure
+# function of GitHub state plus local-worktree existence — cwd is not consulted.
 # Tests below overwrite the default no-op sweep stub seeded by setup() to
 # exercise the routing branches.
 
-# SR1. (AC b) Inside an active <issue>-* worktree with an orphan elsewhere →
-#      still worktree <N> <branch>. The sweep stub would emit an adoption
-#      directive if invoked; the assert proves it never was.
-echo "Test: worktree continuation precedes sweep adoption (regression — #803)"
+# SR1. Selector invoked from an <issue>-* worktree returns the same queue-ladder
+#      result it would from main. A sweep stub that would adopt an orphan is
+#      installed; the assert proves it ran and produced worktree-adopted, not a
+#      cwd-derived line.
+echo "Test: selector from issue-branch cwd returns queue-ladder line (cwd ignored)"
 setup
-setup_union_pr_list '[]'
+# Seed a verify PR as the expected queue-ladder output.
+UNION='['"$(make_pr_union 999 "999-foo" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
 echo '[]' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+# Current branch is an issue branch — but cwd must not affect selection.
 printf '42-some-slug' > "$STUB_DIR/current-branch.txt"
-printf '{"state":"OPEN"}' > "$STUB_DIR/issue-state-42.json"
-# Sweep stub would adopt an orphan at issue 725 if invoked — proves the sweep
-# never ran (current-worktree continuation short-circuited first).
-cat > "$TMPDIR_TEST/dispatch-sweep" <<'STUB'
-#!/usr/bin/env bash
-echo "worktree 725 725-some-orphan"
-exit 0
-STUB
-chmod +x "$TMPDIR_TEST/dispatch-sweep"
+# Sweep is a no-op so the ladder runs.
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "worktree continuation beats sweep adoption" "worktree 42 42-some-slug" "$result"
+assert_eq "selector from issue-branch cwd → queue-ladder result (pr 999)" "pr 999 999-foo verify" "$result"
 teardown
 
 # SR2. (AC c) Outside any worktree, orphan present → worktree-adopted.
@@ -2426,17 +2363,7 @@ branch refs/heads/42-my-feature
 
 '
 
-# 1. Current branch is <N>-* → here (mode-independent).
-echo "Test: current branch <N>-* → here (both modes)"
-setup
-echo "42-my-feature" > "$STUB_DIR/current-branch.txt"
-result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
-assert_eq "current branch <N>-* → here (explicit)" "here" "$result"
-result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
-assert_eq "current branch <N>-* → here (queue)" "here" "$result"
-teardown
-
-# 2. explicit mode + an existing <N>-* worktree → enter <path>.
+# 1. explicit mode + an existing <N>-* worktree → enter <path>.
 echo "Test: explicit + existing <N>-* worktree → enter"
 setup
 printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
@@ -2496,14 +2423,26 @@ else
 fi
 teardown
 
-# 7. here precedence: current branch <N>-* wins even when a matching worktree
-#    also exists — the here check fires before the worktree scan.
-echo "Test: here precedence over a matching worktree"
+# 7. explicit mode invoked from within <N>-* worktree (current-branch = <N>-*)
+#    AND matching worktree entry → enter <path> (no special-case `here`).
+echo "Test: explicit from issue-branch cwd with matching worktree → enter (not here)"
 setup
 echo "42-my-feature" > "$STUB_DIR/current-branch.txt"
 printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
-assert_eq "here wins over a matching worktree" "here" "$result"
+assert_eq "explicit from issue-branch cwd, matching worktree → enter (not here)" \
+  "enter /worktrees/42-my-feature" "$result"
+teardown
+
+# 7b. queue mode invoked from within <N>-* worktree (current-branch = <N>-*)
+#     AND matching worktree entry → conflict <path> (worktree scan runs normally).
+echo "Test: queue from issue-branch cwd with matching worktree → conflict (not here)"
+setup
+echo "42-my-feature" > "$STUB_DIR/current-branch.txt"
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
+assert_eq "queue from issue-branch cwd, matching worktree → conflict (not here)" \
+  "conflict /worktrees/42-my-feature" "$result"
 teardown
 
 # 8. A non-matching worktree (different issue) → create.


### PR DESCRIPTION
Closes #869
Closes #866

## Summary

Removes the router's cwd-based shortcuts so selection becomes a pure function
of GitHub state plus local-worktree existence. A router invoked from
`worktrees/main` and one invoked from `worktrees/<N>-…` now produce the same
target.

After the router/worker split (#851, #860) the router runs no phase skill and
is always spawned from `worktrees/main`, so its cwd carries no signal about
which target to pick. The residual cwd-check hid real queue signal — priority
PRs, security-phase PRs, office-hours skips — behind cwd, and produced the
failure mode #866 documents: a router re-invoked inside `<N>-*` selecting
`<N>` even when another live session already owned it. **Supersedes #866** —
gating the cwd-check on a liveness predicate is no longer needed because the
cwd-check is gone.

## Changes

- **`dispatch-select-target`** — deleted the `on_worktree_branch` helper, the
  default-mode current-worktree branch that emitted
  `worktree <N> <branch>` / `worktree-closed <N> <branch>`, and the
  `--health-only` mode's current-worktree bypass. Updated header-comment
  output directives and priority-order narrative. Health is now checked
  uniformly; cwd is not.
- **`dispatch-resolve-worktree`** — deleted the `here` branch. The
  worktree-scan loop emits `enter` / `conflict` correctly for
  `CURRENT_BRANCH == <N>-*` when a matching worktree-list entry exists.
- **`dispatch-sweep`** — updated the comment that referenced the
  now-removed `dispatch-select-target` current-worktree mode to describe
  the actual directive shape on its own terms.
- **`/dispatch` SKILL.md** — top-of-file prose now says cwd is ignored.
  Step 3 drops the `worktree` / `worktree-closed` directive bullets and the
  "explicit argument overrides current-worktree detection" paragraph;
  priority order starts at the JIT scan. Step 4 drops the current-worktree
  skip-rule bullet. Step 5 drops the `here` decision-line case. Step 7
  drops `worktree-closed` from the stop-path enumeration.
- **`test-dispatch-scripts.sh`** — removed tests for the deleted behaviors
  (16, 17, 18, 27, 27c, SR1; resolve-worktree 1, 7) and added regression
  tests: selector invoked from a `<N>-*` worktree returns the same
  queue-ladder line it would from `main`; resolver explicit-mode from
  `worktrees/<N>-…` emits `enter <path>` (not `here`); resolver queue-mode
  from the same inputs emits `conflict <path>`. All 437 tests pass.

## Test plan

- [x] `bash -n` on every modified script — no syntax errors.
- [x] `.claude/skills/dispatch/scripts/test-dispatch-scripts.sh` — all
      437 tests pass.
- [ ] End-to-end (post-merge, exercised live): `/dispatch` invoked from
      `worktrees/<N>-…` runs the queue ladder; if the queue picks issue
      `M ≠ N`, the router creates / enters `worktrees/M-…` and spawns the
      worker there.