### PR TITLE
dispatch-sweep: replace /proc walk with claude agents --json helper

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -216,7 +216,7 @@ continue to target selection.
   SELECTED=$(.claude/skills/dispatch/scripts/dispatch-select-target)
   ```
 
-  (`dangerouslyDisableSandbox: true` — it calls `gh` and walks `/proc`.)
+  (`dangerouslyDisableSandbox: true` — it calls `gh` and queries the local Claude daemon over a Unix socket.)
 
   Route on `$SELECTED`:
 

--- a/.claude/skills/dispatch/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch/scripts/dispatch-sweep
@@ -16,10 +16,12 @@
 #      the main worktree and detached HEADs.
 #   3. For each worktree whose branch is in the merged map and which is in sync
 #      (clean tree + zero unpushed commits), remove it and its branch.
-#   4. Classify the remaining worktrees as active vs orphaned by walking
-#      $DISPATCH_SWEEP_PROC_ROOT (default /proc): any /proc/<pid> with a comm
-#      starting with ".claude" whose resolved cwd lives inside a worktree path
-#      marks that worktree active.
+#   4. Classify the remaining worktrees as active vs orphaned by calling
+#      claude_sessions_under (from lib-claude-agents.sh) per surviving worktree.
+#      A worktree with at least one live session is ACTIVE; one with zero live
+#      sessions is ORPHANED. If the daemon cannot be queried (UNKNOWN), the
+#      worktree is classified ACTIVE so nothing is adopted or cleaned on an
+#      unknown signal (fail-safe).
 #   5. Among orphans, separate those eligible for adoption (an open PR OR an
 #      inferable issue number ^[0-9]+-) from "unknown" orphans (no PR + no
 #      inferable issue number) — the latter halt the sweep with exit 3 and a
@@ -30,7 +32,8 @@
 #      the existing resume-worktree flow.
 #
 # Environment overrides for testability:
-#   DISPATCH_SWEEP_PROC_ROOT  Root of the /proc walk. Default: /proc.
+#   CLAUDE_AGENTS_CMD         Override the `claude` invocation (e.g. a fake script
+#                             that prints a JSON array). Default: `claude`.
 #   DISPATCH_SWEEP_LOG_FILE   Override log path. Default: <root>/tmp/dispatch-sweep.log.
 #   DISPATCH_SWEEP_NOW        Override UTC timestamp source (deterministic tests).
 #
@@ -51,6 +54,8 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # shellcheck source=./lib-worktree-in-sync.sh
 source "$SCRIPT_DIR/lib-worktree-in-sync.sh"
+# shellcheck source=./lib-claude-agents.sh
+source "$SCRIPT_DIR/lib-claude-agents.sh"
 # shellcheck source=./lib.sh
 source "$SCRIPT_DIR/lib.sh"
 
@@ -224,54 +229,13 @@ while [[ $i -lt ${#WT_PATHS[@]} ]]; do
 done
 
 # ---- Step 4: classify remaining worktrees as active vs orphaned -------------
-# Walk $DISPATCH_SWEEP_PROC_ROOT. A worktree is active when at least one PID's
-# comm starts with ".claude" (e.g. ".claude-unwrapp" on NixOS — the comm field
-# is already a basename so a prefix test is enough) AND its resolved cwd lies
-# inside that worktree's path. /proc may yield transient or unreadable PIDs;
-# treat any read failure as "no signal" rather than aborting.
-PROC_ROOT="${DISPATCH_SWEEP_PROC_ROOT:-/proc}"
-
-# Initialise the active-pid map for every surviving worktree to empty.
-declare -A ACTIVE_PID=()
-for wt_path in "${SURVIVING_PATHS[@]}"; do
-  ACTIVE_PID["$wt_path"]=""
-done
-
-# Precompute "path/" forms for cheap case-glob containment checks.
-if [[ -d "$PROC_ROOT" ]]; then
-  for entry in "$PROC_ROOT"/*; do
-    pid="${entry##*/}"
-    [[ "$pid" =~ ^[0-9]+$ ]] || continue
-
-    comm_file="$entry/comm"
-    [[ -r "$comm_file" ]] || continue
-    comm=""
-    IFS= read -r comm <"$comm_file" 2>/dev/null || comm=""
-    [[ "$comm" == .claude* ]] || continue
-
-    # cwd is a symlink; readlink follows it, realpath -e canonicalises.
-    cwd_link="$entry/cwd"
-    cwd=$(readlink -f "$cwd_link" 2>/dev/null) || cwd=""
-    [[ -n "$cwd" ]] || continue
-
-    for wt_path in "${SURVIVING_PATHS[@]}"; do
-      case "$cwd/" in
-        "$wt_path/"*)
-          # Record the first PID we see for this worktree; later overlapping
-          # claudes don't change the classification.
-          if [[ -z "${ACTIVE_PID[$wt_path]:-}" ]]; then
-            ACTIVE_PID["$wt_path"]="$pid"
-          fi
-          break
-          ;;
-      esac
-    done
-  done
-else
-  log "PROC_ROOT_MISSING: '$PROC_ROOT' is not a directory — all surviving worktrees will classify as orphaned"
-fi
-
-# Now log ACTIVE / ORPHANED per surviving worktree and collect the orphans.
+# For each surviving worktree, call claude_sessions_under (lib-claude-agents.sh)
+# to ask the daemon whether any live session is running there.
+#   Exit 0 + non-empty output → at least one live session → ACTIVE.
+#   Exit 0 + empty output    → daemon queried, zero sessions → ORPHANED.
+#   Exit non-zero (UNKNOWN)  → daemon unreachable → classify ACTIVE (fail-safe).
+# The fail-safe ensures no orphan adoption or merged-cleanup is emitted on a
+# tick where the daemon cannot be reached.
 ORPHAN_PATHS=()
 ORPHAN_BRANCHES=()
 i=0
@@ -280,13 +244,24 @@ while [[ $i -lt ${#SURVIVING_PATHS[@]} ]]; do
   wt_branch="${SURVIVING_BRANCHES[$i]}"
   i=$((i + 1))
 
-  pid="${ACTIVE_PID[$wt_path]:-}"
-  if [[ -n "$pid" ]]; then
-    log "ACTIVE: '$wt_path' branch=$wt_branch pid=$pid"
+  sessions=""
+  if sessions=$(claude_sessions_under "$wt_path"); then
+    # Daemon queried successfully.
+    if [[ -n "$sessions" ]]; then
+      # At least one live session — extract the first line for diagnostics.
+      first_line=$(printf '%s\n' "$sessions" | head -n1)
+      sid="" pid="" status="" name=""
+      IFS=$'\t' read -r sid pid status name <<< "$first_line"
+      log "ACTIVE: '$wt_path' branch=$wt_branch sessionId=$sid name=$name status=$status"
+    else
+      # Zero sessions — eligible orphan.
+      log "ORPHANED: '$wt_path' branch=$wt_branch"
+      ORPHAN_PATHS+=("$wt_path")
+      ORPHAN_BRANCHES+=("$wt_branch")
+    fi
   else
-    log "ORPHANED: '$wt_path' branch=$wt_branch"
-    ORPHAN_PATHS+=("$wt_path")
-    ORPHAN_BRANCHES+=("$wt_branch")
+    # UNKNOWN — daemon unreachable or query failed. Fail safe: classify ACTIVE.
+    log "ACTIVE: '$wt_path' branch=$wt_branch liveness=unknown"
   fi
 done
 

--- a/.claude/skills/dispatch/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch/scripts/dispatch-sweep
@@ -191,7 +191,7 @@ flush_record
 # in sync remove the worktree + delete the local branch. Not-in-sync merged
 # worktrees stay on the surviving list with a SKIP log line so the user can
 # investigate; they're explicitly NOT auto-adoption candidates (the unpushed
-# work may belong to a live session whose comm we missed).
+# work may belong to a live session the daemon did not report).
 SURVIVING_PATHS=()
 SURVIVING_BRANCHES=()
 
@@ -250,8 +250,8 @@ while [[ $i -lt ${#SURVIVING_PATHS[@]} ]]; do
     if [[ -n "$sessions" ]]; then
       # At least one live session — extract the first line for diagnostics.
       first_line=$(printf '%s\n' "$sessions" | head -n1)
-      sid="" pid="" status="" name=""
-      IFS=$'\t' read -r sid pid status name <<< "$first_line"
+      sid="" status="" name=""
+      IFS=$'\t' read -r sid _ status name <<< "$first_line"
       log "ACTIVE: '$wt_path' branch=$wt_branch sessionId=$sid name=$name status=$status"
     else
       # Zero sessions — eligible orphan.

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2666,7 +2666,7 @@ echo "=== dispatch-sweep ==="
 #   project/.bare/                fake git common dir (parent = project/)
 #   project/worktrees/<n>-<slug>/ fake worktrees
 #   project/tmp/                  sweep log default dir
-#   proc/                         synthetic /proc tree (overridden per test)
+#   fake/                         fake `claude` script (CLAUDE_AGENTS_CMD target)
 #   stub/                         per-test JSON + record files (calls, gh out)
 #
 # Shims:

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2686,10 +2686,11 @@ sweep_setup() {
   STUB_DIR="$TMPDIR_TEST/stub"
   mkdir -p "$TMPDIR_TEST/bin" "$STUB_DIR" "$TMPDIR_TEST/scripts" \
            "$TMPDIR_TEST/project/.bare" "$TMPDIR_TEST/project/worktrees" \
-           "$TMPDIR_TEST/project/tmp" "$TMPDIR_TEST/proc"
+           "$TMPDIR_TEST/project/tmp" "$TMPDIR_TEST/fake"
 
   cp "$SCRIPT_DIR/dispatch-sweep" "$TMPDIR_TEST/scripts/dispatch-sweep"
   cp "$SCRIPT_DIR/lib-worktree-in-sync.sh" "$TMPDIR_TEST/scripts/lib-worktree-in-sync.sh"
+  cp "$SCRIPT_DIR/lib-claude-agents.sh" "$TMPDIR_TEST/scripts/lib-claude-agents.sh"
   cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/lib.sh"
   chmod +x "$TMPDIR_TEST/scripts/dispatch-sweep"
 
@@ -2807,8 +2808,18 @@ STUB
 
   export PATH="$TMPDIR_TEST/bin:$PATH"
 
+  # Default fake `claude` — prints `[]` and exits 0 (no live sessions).
+  # All tests that do not override this get "everything orphaned" semantics.
+  local default_fake="$TMPDIR_TEST/fake/claude"
+  cat > "$default_fake" <<'FAKE'
+#!/usr/bin/env bash
+printf '[]'
+exit 0
+FAKE
+  chmod +x "$default_fake"
+
   # Defaults for dispatch-sweep env overrides.
-  export DISPATCH_SWEEP_PROC_ROOT="$TMPDIR_TEST/proc"
+  export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/fake/claude"
   export DISPATCH_SWEEP_LOG_FILE="$STUB_DIR/sweep.log"
   export DISPATCH_SWEEP_NOW="2026-01-01T00:00:00Z"
 }
@@ -2818,7 +2829,7 @@ sweep_teardown() {
   TMPDIR_TEST=""
   STUB_DIR=""
   export PATH="$SAVED_PATH"
-  unset DISPATCH_SWEEP_PROC_ROOT DISPATCH_SWEEP_LOG_FILE DISPATCH_SWEEP_NOW
+  unset CLAUDE_AGENTS_CMD DISPATCH_SWEEP_LOG_FILE DISPATCH_SWEEP_NOW
 }
 
 # Helper: register a worktree in the porcelain list AND create its directory.
@@ -2836,14 +2847,51 @@ sweep_register_main() {
     "$TMPDIR_TEST/project/worktrees/main" >> "$STUB_DIR/worktree-list.txt"
 }
 
-# Helper: write a synthetic /proc/<pid> entry with comm and cwd symlink.
-sweep_proc_pid() {
-  local pid="$1" comm="$2" cwd="$3"
-  local pid_dir="$DISPATCH_SWEEP_PROC_ROOT/$pid"
-  mkdir -p "$pid_dir"
-  printf '%s\n' "$comm" > "$pid_dir/comm"
-  # cwd is a symlink; readlink -f resolves it.
-  ln -s "$cwd" "$pid_dir/cwd"
+# Helper: install a fake `claude` whose `agents --json --cwd <path>` invocation
+# returns only the sessions whose cwd starts with the requested <path>.
+# Overwrites $TMPDIR_TEST/fake/claude and re-exports CLAUDE_AGENTS_CMD.
+# Each argument must be in `sid=cwd` form; the name, status, and pid fields are
+# fixed (name=x, status=busy, pid=1) since sweep tests only care about cwd
+# for session-detection and sessionId/name/status for the ACTIVE log line.
+# The fake honours the --cwd filter (matching how the real daemon filters
+# server-side) so each worktree's query only sees its own sessions.
+sweep_fake_claude_sessions() {
+  local fake="$TMPDIR_TEST/fake/claude"
+  # Write the full session list as a JSON array to payload.json.
+  local all_payload="[" entry sid cwd first=1
+  for entry in "$@"; do
+    sid="${entry%%=*}"
+    cwd="${entry#*=}"
+    if (( first )); then first=0; else all_payload+=","; fi
+    all_payload+="{\"sessionId\":\"$sid\",\"pid\":1,\"status\":\"busy\",\"name\":\"x\",\"cwd\":\"$cwd\"}"
+  done
+  all_payload+="]"
+  printf '%s' "$all_payload" > "$TMPDIR_TEST/fake/payload.json"
+  # The fake script filters the full payload by the --cwd argument using jq,
+  # matching sessions whose cwd starts with the requested path (same as the
+  # real daemon's server-side filter). This ensures each worktree query only
+  # returns sessions that are actually in that worktree.
+  cat > "$fake" <<'FAKE'
+#!/usr/bin/env bash
+# Parse `agents --json --cwd <path>` args; find --cwd value.
+requested_cwd=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--cwd" && -n "${2:-}" ]]; then
+    requested_cwd="$2"; shift 2
+  else
+    shift
+  fi
+done
+payload_file="$(cd "$(dirname "$0")" && pwd)/payload.json"
+if [[ -n "$requested_cwd" ]]; then
+  jq --arg cwd "$requested_cwd" '[.[] | select(.cwd | startswith($cwd))]' "$payload_file"
+else
+  cat "$payload_file"
+fi
+exit 0
+FAKE
+  chmod +x "$fake"
+  export CLAUDE_AGENTS_CMD="$fake"
 }
 
 # Convenience: convert an absolute path to the status/revlist/headct key
@@ -2897,9 +2945,9 @@ else
 fi
 sweep_teardown
 
-# --- Test 2: active vs orphaned via synthetic /proc --------------------------
+# --- Test 2: active vs orphaned via claude agents --json ---------------------
 
-echo "Test: /proc walk distinguishes active vs orphaned worktrees"
+echo "Test: claude agents --json distinguishes active vs orphaned worktrees"
 sweep_setup
 ACTIVE_WT="$TMPDIR_TEST/project/worktrees/50-active"
 ORPHAN_WT="$TMPDIR_TEST/project/worktrees/51-orphan"
@@ -2911,25 +2959,19 @@ sweep_register_wt "$ORPHAN_WT" "51-orphan"
 ORPHAN_KEY=$(sweep_path_key "$ORPHAN_WT")
 echo "1700000000" > "$STUB_DIR/headct${ORPHAN_KEY}.txt"
 
-# Synthetic /proc:
-#   pid 1001: .claude-unwrapp cwd inside ACTIVE_WT → marks 50-active active.
-#   pid 1002: bash (non-claude comm) — proves comm filter is required.
-#   pid 1003: .claude with cwd elsewhere — proves cwd check classifies, not comm.
-sweep_proc_pid 1001 ".claude-unwrapp" "$ACTIVE_WT"
-sweep_proc_pid 1002 "bash" "$ACTIVE_WT"
-mkdir -p "$TMPDIR_TEST/elsewhere"
-sweep_proc_pid 1003 ".claude" "$TMPDIR_TEST/elsewhere"
+# One live session in ACTIVE_WT, none in ORPHAN_WT.
+sweep_fake_claude_sessions "abc=$ACTIVE_WT"
 
 out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
 assert_eq "active/orphan sweep exits 0" "0" "$rc"
 assert_eq "only orphan adopted" "worktree 51 51-orphan" "$out"
 
-# Log: ACTIVE for 50, ORPHANED for 51, ADOPT for 51.
+# Log: ACTIVE for 50 with session fields, ORPHANED for 51, ADOPT for 51.
 TOTAL=$((TOTAL + 1))
-if grep -q "ACTIVE: '$ACTIVE_WT' branch=50-active pid=1001" "$DISPATCH_SWEEP_LOG_FILE"; then
-  PASS=$((PASS + 1)); echo "  PASS: ACTIVE log line for 50-active with pid 1001"
+if grep -q "ACTIVE: '$ACTIVE_WT' branch=50-active sessionId=abc name=x status=busy" "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: ACTIVE log line for 50-active with sessionId=abc name=x status=busy"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: ACTIVE log line for 50-active with pid 1001"
+  FAIL=$((FAIL + 1)); echo "  FAIL: ACTIVE log line for 50-active with sessionId=abc name=x status=busy"
   sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE"
 fi
 TOTAL=$((TOTAL + 1))
@@ -2946,6 +2988,51 @@ else
 fi
 sweep_teardown
 
+# --- Test 2b: daemon-query failure classifies all surviving as active ---------
+
+echo "Test: daemon-query failure classifies all surviving worktrees as active"
+sweep_setup
+WT_A="$TMPDIR_TEST/project/worktrees/54-alpha"
+WT_B="$TMPDIR_TEST/project/worktrees/55-beta"
+sweep_register_wt "$WT_A" "54-alpha"
+sweep_register_wt "$WT_B" "55-beta"
+
+# Install a failing fake `claude` (exits non-zero, prints nothing).
+cat > "$TMPDIR_TEST/fake/claude" <<'FAKE'
+#!/usr/bin/env bash
+exit 1
+FAKE
+chmod +x "$TMPDIR_TEST/fake/claude"
+# CLAUDE_AGENTS_CMD is already pointing at $TMPDIR_TEST/fake/claude from sweep_setup.
+
+err_file="$TMPDIR_TEST/stderr-daemon-fail.txt"
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>"$err_file"); rc=$?
+assert_eq "daemon-failure sweep exits 0" "0" "$rc"
+assert_eq "daemon-failure emits no stdout (no adoption)" "" "$out"
+
+# Each worktree must log ACTIVE with liveness=unknown.
+TOTAL=$((TOTAL + 1))
+if grep -q "ACTIVE: '$WT_A' branch=54-alpha liveness=unknown" "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: ACTIVE liveness=unknown for 54-alpha"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: ACTIVE liveness=unknown for 54-alpha"
+  sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q "ACTIVE: '$WT_B' branch=55-beta liveness=unknown" "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: ACTIVE liveness=unknown for 55-beta"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: ACTIVE liveness=unknown for 55-beta"
+fi
+# No ADOPT_ORPHAN line should be present.
+TOTAL=$((TOTAL + 1))
+if ! grep -q "ADOPT_ORPHAN" "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: no ADOPT_ORPHAN on daemon failure"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: unexpected ADOPT_ORPHAN on daemon failure"
+fi
+sweep_teardown
+
 # --- Test 3: oldest-orphan tiebreaker ----------------------------------------
 
 echo "Test: oldest orphan wins by HEAD commit time"
@@ -2958,7 +3045,7 @@ OLD_KEY=$(sweep_path_key "$OLD_WT")
 NEW_KEY=$(sweep_path_key "$NEW_WT")
 echo "1000" > "$STUB_DIR/headct${OLD_KEY}.txt"
 echo "2000" > "$STUB_DIR/headct${NEW_KEY}.txt"
-# Empty /proc → both orphans.
+# Default fake claude (no live sessions) → both orphans.
 
 out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
 assert_eq "oldest-orphan sweep exits 0" "0" "$rc"

--- a/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch/scripts/test-dispatch-scripts.sh
@@ -2991,7 +2991,12 @@ while [[ $# -gt 0 ]]; do
 done
 payload_file="$(cd "$(dirname "$0")" && pwd)/payload.json"
 if [[ -n "$requested_cwd" ]]; then
-  jq --arg cwd "$requested_cwd" '[.[] | select(.cwd | startswith($cwd))]' "$payload_file"
+  # Directory-boundary match: cwd == path OR cwd starts with path + "/".
+  # `startswith` alone would mis-attribute /foo/worktrees/500-other to a query
+  # for /foo/worktrees/50, which the real daemon's --cwd filter does not.
+  jq --arg cwd "$requested_cwd" \
+    '[.[] | select(.cwd == $cwd or (.cwd | startswith($cwd + "/")))]' \
+    "$payload_file"
 else
   cat "$payload_file"
 fi


### PR DESCRIPTION
Closes #740

Replaces `dispatch-sweep` Step 4's `/proc` walk with the shared
`claude_sessions_under` helper from `lib-claude-agents.sh` (merged in #768) —
so the sweep's liveness signal shares one source of truth with the lock
(#742) and the resolver (#741), and the `ACTIVE` log lines carry diagnosable
`sessionId`/`name`/`status` instead of a bare PID.

This is a detection-mechanism swap only. Step-3 merged-cleanup, Step-5 ready-PR
/ closed-issue / blocker gates, the `--cleanup-unknown` halt, and the
one-orphan-per-tick adoption cadence are unchanged.

Daemon-query failure (UNKNOWN) classifies every surviving worktree ACTIVE and
adopts nothing on that tick, per the helper's fail-safe contract.

Tests: `test-dispatch-scripts.sh` Test 2 retitled and updated to drive the
fake-`claude` override; a new Test 2b covers the daemon-failure /
no-adoption path. Full suite passes (447/447).