### PR TITLE
budget: make updateJournalLegCleared atomic

### DIFF
--- a/budget/src/firestore.ts
+++ b/budget/src/firestore.ts
@@ -1,4 +1,4 @@
-import { collection, doc, getDoc, getDocs, query, setDoc, updateDoc, where, increment, writeBatch, Timestamp, deleteDoc, type QueryDocumentSnapshot, type DocumentData } from "firebase/firestore";
+import { collection, doc, getDoc, getDocs, query, runTransaction, setDoc, updateDoc, where, increment, writeBatch, Timestamp, deleteDoc, type QueryDocumentSnapshot, type DocumentData } from "firebase/firestore";
 import { nsCollectionPath } from "@commons-systems/firestoreutil/namespace";
 import { requireOneOf } from "@commons-systems/firestoreutil/validate";
 
@@ -482,9 +482,11 @@ export async function updateJournalLegCleared(legId: string, cleared: boolean): 
   requireDocId(legId, "journal leg");
   const path = nsCollectionPath(NAMESPACE, "journal-legs");
   const ref = doc(db, path, legId);
-  const snap = await getDoc(ref);
-  if (!snap.exists()) throw new Error(`Journal leg ${legId} not found`);
-  const leg = parseFirestoreJournalLeg(snap as QueryDocumentSnapshot<DocumentData, DocumentData>);
-  assertLegStateTransition(leg, cleared);
-  await updateDoc(ref, { cleared });
+  await runTransaction(db, async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists()) throw new Error(`Journal leg ${legId} not found`);
+    const leg = parseFirestoreJournalLeg(snap as QueryDocumentSnapshot<DocumentData, DocumentData>);
+    assertLegStateTransition(leg, cleared);
+    tx.update(ref, { cleared });
+  });
 }

--- a/budget/test/firestore.test.ts
+++ b/budget/test/firestore.test.ts
@@ -18,6 +18,14 @@ const mockWriteBatch = vi.fn(() => ({
   update: (...args: unknown[]) => mockBatchUpdate(...args),
   commit: (...args: unknown[]) => mockBatchCommit(...args),
 }));
+const mockTxGet = vi.fn();
+const mockTxUpdate = vi.fn();
+const mockRunTransaction = vi.fn(async (_db: unknown, fn: (tx: unknown) => Promise<unknown>) =>
+  fn({
+    get: (...args: unknown[]) => mockTxGet(...args),
+    update: (...args: unknown[]) => mockTxUpdate(...args),
+  }),
+);
 
 vi.mock("firebase/firestore", () => ({
   collection: (...args: unknown[]) => mockCollection(...args),
@@ -30,6 +38,7 @@ vi.mock("firebase/firestore", () => ({
   deleteDoc: (...args: unknown[]) => mockDeleteDoc(...args),
   setDoc: (...args: unknown[]) => mockSetDoc(...args),
   writeBatch: (...args: unknown[]) => mockWriteBatch(...args),
+  runTransaction: (...args: unknown[]) => mockRunTransaction(args[0], args[1] as (tx: unknown) => Promise<unknown>),
   increment: (n: number) => mockIncrement(n),
   Timestamp: class Timestamp {
     _date: Date;
@@ -46,7 +55,7 @@ vi.mock("../src/firebase.js", () => ({
 }));
 
 import { Timestamp } from "firebase/firestore";
-import { getTransactions, updateTransaction, updateBudget, updateBudgetPeriod, adjustBudgetPeriodTotal, getBudgets, getBudgetPeriods, getGroupMembers, createJournalEntry, assertLegStateTransition } from "../src/firestore";
+import { getTransactions, updateTransaction, updateBudget, updateBudgetPeriod, adjustBudgetPeriodTotal, getBudgets, getBudgetPeriods, getGroupMembers, createJournalEntry, assertLegStateTransition, updateJournalLegCleared } from "../src/firestore";
 
 describe("getTransactions", () => {
   beforeEach(() => {
@@ -1114,5 +1123,57 @@ describe("assertLegStateTransition", () => {
     const reconciledAt = Timestamp.fromDate(new Date("2025-03-15"));
     expect(() => assertLegStateTransition({ cleared: true, reconciledAt }, true)).toThrow(/reconciled/i);
     expect(() => assertLegStateTransition({ cleared: true, reconciledAt }, false)).toThrow(/reconciled/i);
+  });
+});
+
+describe("updateJournalLegCleared", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDoc.mockReturnValue("mock-leg-ref");
+  });
+
+  const makeSnap = (data: Record<string, unknown>, id = "leg-1") => ({
+    id,
+    exists: () => true,
+    data: () => ({
+      entryId: "entry-1",
+      accountId: "acct-1",
+      debit: 10,
+      credit: 0,
+      timestamp: Timestamp.fromDate(new Date("2025-01-01")),
+      ...data,
+    }),
+  });
+
+  it("commits the cleared update for an unreconciled leg (happy path)", async () => {
+    mockTxGet.mockResolvedValue(makeSnap({ cleared: false, reconciledAt: null }));
+
+    await expect(updateJournalLegCleared("leg-1", true)).resolves.toBeUndefined();
+
+    expect(mockTxUpdate).toHaveBeenCalledTimes(1);
+    expect(mockTxUpdate).toHaveBeenCalledWith("mock-leg-ref", { cleared: true });
+  });
+
+  it("rejects clearing a reconciled leg and never calls update", async () => {
+    const reconciledAt = Timestamp.fromDate(new Date("2025-03-15"));
+    mockTxGet.mockResolvedValue(makeSnap({ cleared: true, reconciledAt }));
+
+    await expect(updateJournalLegCleared("leg-1", false)).rejects.toThrow(/reconciled/i);
+
+    expect(mockTxUpdate).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the leg does not exist and never calls update", async () => {
+    mockTxGet.mockResolvedValue({
+      id: "leg-missing",
+      exists: () => false,
+      data: () => ({}),
+    });
+
+    await expect(updateJournalLegCleared("leg-missing", true)).rejects.toThrow(
+      "Journal leg leg-missing not found",
+    );
+
+    expect(mockTxUpdate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #897
Closes #743

## Summary

`updateJournalLegCleared` in `budget/src/firestore.ts` performed a non-atomic read-modify-write: a `getDoc` to read `reconciledAt`, an `assertLegStateTransition` guard, and an `updateDoc` to set `cleared`. Between the read and the write, a concurrent reconciliation can set `reconciledAt` on the same leg, so the subsequent `updateDoc` flips `cleared` on a now-reconciled leg — violating the "reconciled is terminal" invariant that `assertLegStateTransition` enforces but Firestore rules do not.

This PR wraps the read + guard + write in `runTransaction(db, async (tx) => { ... })` using `tx.get` and `tx.update`, so the guard re-runs against the value Firestore actually commits against. The existing error messages and call sites are preserved.

## Scope

- `budget/src/firestore.ts` — add `runTransaction` to the `firebase/firestore` import; rewrite `updateJournalLegCleared`'s body inside a transaction.
- `budget/test/firestore.test.ts` — mock `runTransaction` (passing a `tx` exposing `get` / `update`); add three tests: happy path, reconciled-leg rejection, missing-leg rejection.

Out of scope: the IDB sibling (`budget/src/data-source.ts`) — IDB is single-threaded in-process, so no TOCTOU exists there. Firestore security rules — adding rule-level enforcement of the reconciled-is-terminal invariant is a separate follow-up.