### PR TITLE
dispatch: centralize dispatch:office-hours writes (issue-only target + why-comment)

### DIFF
--- a/.claude/hooks/dispatch-input-block.sh
+++ b/.claude/hooks/dispatch-input-block.sh
@@ -10,11 +10,10 @@
 # Fires only for a dispatch-* background job. On fire:
 #   1. resolves the issue number from the current branch name
 #      (the <N>-* prefix idiom restore-dispatch-skill.sh already uses);
-#   2. resolves a PR (via dispatch-find-pr) or falls back to the issue;
-#   3. applies dispatch:office-hours, creating the label on first use with the
-#      canonical color/description (this script is the single source of those
-#      defaults);
-#   4. spawns the next /dispatch-propagate via dispatch-spawn-router, so the chain keeps moving
+#   2. parks the ISSUE on a human via dispatch-apply-office-hours — the single
+#      write path for dispatch:office-hours. It applies the label to the issue
+#      (never a PR), creates the label on first use, and posts a why-comment;
+#   3. spawns the next /dispatch-propagate via dispatch-spawn-router, so the chain keeps moving
 #      around the blocked item.
 #
 # Never blocks the session — every failure logs to stderr and the script exits
@@ -70,31 +69,13 @@ ISSUE_NUM=$(printf '%s\n' "$BRANCH" | grep -oE '^[0-9]+') || exit 0
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 0
 SCRIPTS="$SCRIPT_DIR/../skills/dispatch-propagate/scripts"
 
-# Resolve PR for this issue; fall back to the issue itself when no PR exists
-# (the implement phase has no PR yet).
-PR_NUM=$("$SCRIPTS/dispatch-find-pr" "$ISSUE_NUM" 2>/dev/null) || PR_NUM=""
-
-apply_label() {
-  if [ -n "$PR_NUM" ]; then
-    gh pr edit "$PR_NUM" --add-label dispatch:office-hours 2>&1
-  else
-    gh issue edit "$ISSUE_NUM" --add-label dispatch:office-hours 2>&1
-  fi
-}
-
-# Apply-first / create-on-"not found" idiom (mirrors dispatch-complete-phase).
-if apply_output=$(apply_label); then
-  :
-elif [[ "$apply_output" == *"not found"* ]]; then
-  gh label create dispatch:office-hours --color FBCA04 \
-    --description "dispatch workflow: blocked on a human — awaiting input or review" \
-    >/dev/null 2>&1 \
-    || echo "[dispatch-input-block] WARNING: gh label create dispatch:office-hours failed" >&2
-  apply_label >/dev/null 2>&1 \
-    || echo "[dispatch-input-block] WARNING: gh apply dispatch:office-hours (retry) failed" >&2
-else
-  echo "[dispatch-input-block] WARNING: gh apply dispatch:office-hours failed: $apply_output" >&2
-fi
+# Park the issue on a human via the single write path. This hook fires on four
+# event kinds (ExitPlanMode / AskUserQuestion / permission_prompt / elicitation)
+# and does not branch on which fired, so one static reason naming all four is
+# correct. dispatch-apply-office-hours owns the issue target, create-on-first-use,
+# idempotency, and the why-comment.
+"$SCRIPTS/dispatch-apply-office-hours" "$ISSUE_NUM" "blocked on user input (ExitPlanMode / AskUserQuestion / permission prompt / elicitation)" \
+  || echo "[dispatch-input-block] WARNING: dispatch-apply-office-hours failed" >&2
 
 # Pass the baton so the chain keeps moving. dispatch-spawn-router is dedup-guarded —
 # safe whether or not another dispatch-* session is live.

--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -88,11 +88,17 @@ fi
 resolve_office_hours_reason() {
   local default_reason="$1"
   local reason_file="$CLAUDE_JOB_DIR/office-hours-reason"
+  local file_reason
   if [ -n "${CLAUDE_JOB_DIR:-}" ] && [ -s "$reason_file" ]; then
-    cat "$reason_file"
-  else
-    printf '%s' "$default_reason"
+    # Command substitution strips trailing newlines; a file that contains only
+    # whitespace/newlines produces an empty string — fall through to the default.
+    file_reason="$(cat "$reason_file")"
+    if [ -n "$file_reason" ]; then
+      printf '%s' "$file_reason"
+      return
+    fi
   fi
+  printf '%s' "$default_reason"
 }
 
 # Strip targets both the PR (if any) and the issue, since this runs from either

--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -11,8 +11,9 @@
 #
 # Branches (driven by marker presence + CURRENT_PHASE relative to MARKER_PHASE):
 #   A. marker absent — phase skill did not run to completion (mid-phase exit
-#      or context compaction). Apply dispatch:office-hours to the ISSUE, spawn
-#      router, exit 0 — session parks "stopped" for human review.
+#      or context compaction). Park the ISSUE on a human via
+#      dispatch-apply-office-hours (label + why-comment), spawn router, exit 0 —
+#      session parks "stopped" for human review.
 #   B. marker present + CURRENT_PHASE non-empty + MARKER_PHASE != CURRENT_PHASE
 #      — phase advanced. Strip dispatch:office-hours from BOTH the PR (if any)
 #      and the ISSUE, spawn router, self-close. Empty CURRENT_PHASE (e.g.
@@ -22,8 +23,9 @@
 #      counter < 3 — CI re-runs still possible. Spawn router, exit 0 (no label,
 #      no self-close — session parks "stopped"; transcript is the diagnostic).
 #   D. marker present + same phase + NOT (verify AND counter < 3) — true
-#      non-advancement (or a hypothetical same-phase non-verify case). Apply
-#      dispatch:office-hours to the ISSUE, spawn router, exit 0.
+#      non-advancement (or a hypothetical same-phase non-verify case). Park the
+#      ISSUE on a human via dispatch-apply-office-hours (label + why-comment),
+#      spawn router, exit 0.
 #
 # Discriminator: only acts for a /dispatch-worker job. Skipped when
 # CLAUDE_JOB_DIR is unset (interactive session), state.json is missing, or the
@@ -81,30 +83,22 @@ if [ -f "$MARKER_FILE" ]; then
   esac
 fi
 
-apply_office_hours_to_issue() {
-  gh issue edit "$ISSUE_NUM" --add-label dispatch:office-hours 2>&1
-}
-
-# Apply targets the issue only — a PR may not exist yet (implement phase exits
-# before /plan-implement opens the draft). Strip targets both, since the
-# UserPromptSubmit hook may run from either an implement-phase or a
-# post-implement worktree and the label could be on either side.
-apply_office_hours_label() {
-  local apply_output
-  if apply_output=$(apply_office_hours_to_issue); then
-    :
-  elif [[ "$apply_output" == *"not found"* ]]; then
-    gh label create dispatch:office-hours --color FBCA04 \
-      --description "dispatch workflow: blocked on a human — awaiting input or review" \
-      >/dev/null 2>&1 \
-      || echo "[dispatch-stop] WARNING: gh label create dispatch:office-hours failed" >&2
-    apply_office_hours_to_issue >/dev/null 2>&1 \
-      || echo "[dispatch-stop] WARNING: gh apply dispatch:office-hours (retry) failed" >&2
+# Resolve the why-comment reason. The #826 enrichment hook may write a
+# context-specific reason to $CLAUDE_JOB_DIR/office-hours-reason; when present
+# and non-empty it wins over the caller-supplied branch default.
+resolve_office_hours_reason() {
+  local default_reason="$1"
+  local reason_file="$CLAUDE_JOB_DIR/office-hours-reason"
+  if [ -n "${CLAUDE_JOB_DIR:-}" ] && [ -s "$reason_file" ]; then
+    cat "$reason_file"
   else
-    echo "[dispatch-stop] WARNING: gh apply dispatch:office-hours failed: $apply_output" >&2
+    printf '%s' "$default_reason"
   fi
 }
 
+# Strip targets both the PR (if any) and the issue, since this runs from either
+# an implement-phase or a post-implement worktree and the label could be on
+# either side. (Apply is issue-only, via dispatch-apply-office-hours.)
 strip_office_hours_label() {
   if [ -n "$PR_NUM" ]; then
     gh pr edit "$PR_NUM" --remove-label dispatch:office-hours >/dev/null 2>&1 \
@@ -126,7 +120,9 @@ self_close() {
 
 if [ -z "$MARKER_PHASE" ]; then
   # Branch A — marker absent.
-  apply_office_hours_label
+  "$SCRIPTS/dispatch-apply-office-hours" "$ISSUE_NUM" \
+    "$(resolve_office_hours_reason "phase exited before completion (mid-phase exit or context compaction)")" \
+    || echo "[dispatch-stop] WARNING: dispatch-apply-office-hours failed" >&2
   spawn_router
   exit 0
 fi
@@ -151,6 +147,8 @@ if [ "$CURRENT_PHASE" = "verify" ] && [ -n "$PR_NUM" ]; then
 fi
 
 # Branch D — true non-advancement.
-apply_office_hours_label
+"$SCRIPTS/dispatch-apply-office-hours" "$ISSUE_NUM" \
+  "$(resolve_office_hours_reason "phase ran but did not advance")" \
+  || echo "[dispatch-stop] WARNING: dispatch-apply-office-hours failed" >&2
 spawn_router
 exit 0

--- a/.claude/skills/dispatch-propagate/SKILL.md
+++ b/.claude/skills/dispatch-propagate/SKILL.md
@@ -324,45 +324,37 @@ Skip leaf tracing when:
 
 If the resolved target issue `<N>` has any **open** blocker — run
 `issue-blocking <N>` and check for any entry with `state` `OPEN` — release the
-lock (see *Releasing the lock*), report the open blocker, apply
-`dispatch:office-hours` to the target's PR if one exists (see *Applying
-`dispatch:office-hours`* below), then proceed to Step 7 with
+lock (see *Releasing the lock*), report the open blocker, park the issue with
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours <N> "target has an open blocker"
+```
+
+(see *Applying `dispatch:office-hours`* below), then proceed to Step 7 with
 `notify target-blocked`. This guard applies even when a PR exists; closed
 blockers do not gate.
 
 If a named target issue is **closed**, release the lock (see *Releasing the
-lock*), report it, apply `dispatch:office-hours` to the target's PR if one
-exists (see *Applying `dispatch:office-hours`* below), then proceed to Step 7
-with `notify target-blocked`.
+lock*), report it, park the issue with
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours <N> "named target issue is closed"
+```
+
+(see *Applying `dispatch:office-hours`* below), then proceed to Step 7 with
+`notify target-blocked`.
 
 ### Applying `dispatch:office-hours`
 
-`notify target-blocked` queues the target for human review by applying
-`dispatch:office-hours` to its PR when one exists. Resolve the PR with
-`.claude/skills/dispatch-propagate/scripts/dispatch-find-pr <N>`; if it prints a PR
-number, apply the label with the apply-first / create-on-"not found" idiom
-(`gh`, `dangerouslyDisableSandbox: true`):
+`notify target-blocked` queues the target for human review.
+`dispatch-apply-office-hours <N> <reason>` is the single write path: it applies
+the label to the **issue** (never a PR), creates the label on first use with
+the canonical color and description, is idempotent (a second call posts no
+duplicate comment), and posts a why-comment carrying the reason. Run it with
+`dangerouslyDisableSandbox: true` — `gh` needs network.
 
-```bash
-gh pr edit <pr-num> --add-label dispatch:office-hours
-```
-
-If the first call fails because the label does not exist yet, create it and
-retry — the same idiom `dispatch-complete-phase` uses:
-
-```bash
-gh label create dispatch:office-hours \
-  --description "dispatch workflow: blocked on a human — awaiting input or review"
-gh pr edit <pr-num> --add-label dispatch:office-hours
-```
-
-Pass no `--color`: `dispatch-complete-phase` is the single source of the
-`dispatch:*` label-colour metadata, and #757 owns `dispatch:office-hours`'s
-canonical definition — this call site only needs the label to exist.
-
-If `dispatch-find-pr` prints nothing, print a clear diagnostic to stderr
-without applying the label; the disposition still proceeds to Step 7 as
-`notify target-blocked` and the session stays open in `claude agents`.
+No PR resolution is needed to park a target; the label always lands on the
+issue, where the office-hours queue readers anchor their skip.
 
 ## 5. Resolve the Worktree
 

--- a/.claude/skills/dispatch-propagate/SKILL.md
+++ b/.claude/skills/dispatch-propagate/SKILL.md
@@ -607,8 +607,9 @@ The three dispositions:
 - **`notify <reason>`** — `notify spawn-failed` (Step 6's spawn exited
   non-zero) or any Steps 0–5 variance. The call site has already printed a
   user-visible report; for `notify target-blocked` it has also applied
-  `dispatch:office-hours` to the target's PR when one is resolvable (see
-  Step 4's *Applying `dispatch:office-hours`* subsection). Do **not**
+  `dispatch:office-hours` to the target's **issue** via
+  `dispatch-apply-office-hours` (see Step 4's *Applying
+  `dispatch:office-hours`* subsection). Do **not**
   self-close — the session stays in `claude agents` until the user closes
   it, so the variance is visible rather than buried in a closed transcript.
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Park a dispatch unit of work on a human: apply dispatch:office-hours + post why.
+# Usage: dispatch-apply-office-hours <issue-num> <reason>
+#
+# Purpose: the single write path for the dispatch:office-hours label. Both
+# writers (the PreToolUse/Notification input-block hook and the Stop hook) route
+# through here so the target and the accompanying why-comment never diverge.
+#
+# Issue-only target: the label ALWAYS lands on the ISSUE, never a PR. Queue
+# readers anchor their skip on the issue, so a PR-side label would be invisible
+# to them and the parked item could be re-selected.
+#
+# This script is the single source of truth for the dispatch:office-hours label
+# create metadata (color FBCA04 and description).
+#
+# Idempotency: if the issue already carries dispatch:office-hours, the script is
+# a no-op — it neither re-applies the label nor posts a second why-comment, so a
+# repeatedly-firing hook leaves exactly one comment.
+#
+# Why-comment: a fresh apply posts an issue comment containing "Reason: <reason>"
+# so a human reading the parked issue sees what blocked the workflow.
+#
+# Never blocks a hook: only a missing-argument check is a hard error (a clear
+# misuse, not a fallback). Every gh failure after that warns on stderr and exits
+# 0 — a hook must never be torn down because a label edit or comment failed. Run
+# WITHOUT `set -e` so a guarded gh failure does not abort the script.
+set -uo pipefail
+
+ISSUE_NUM="${1:-}"
+REASON="${2:-}"
+
+LABEL="dispatch:office-hours"
+LABEL_COLOR="FBCA04"
+LABEL_DESC="dispatch workflow: blocked on a human — awaiting input or review"
+
+# Missing args are a clear misuse, not a recoverable condition — hard error.
+if [[ -z "$ISSUE_NUM" || -z "$REASON" ]]; then
+  echo "error: usage: dispatch-apply-office-hours <issue-num> <reason>" >&2
+  exit 1
+fi
+
+# Idempotency gate: if the issue already carries the label, do nothing. A gh
+# read failure here is non-fatal — warn and bail out without parking, since we
+# cannot tell whether a comment was already posted.
+if labels_json=$(gh issue view "$ISSUE_NUM" --json labels 2>&1); then
+  if printf '%s' "$labels_json" \
+      | jq -e --arg l "$LABEL" '.labels[]? | select(.name == $l)' >/dev/null 2>&1; then
+    # Label already present — no-op, no duplicate comment.
+    exit 0
+  fi
+else
+  echo "dispatch-apply-office-hours: warning: could not read labels for issue #$ISSUE_NUM: $labels_json" >&2
+  exit 0
+fi
+
+# Apply the label to the ISSUE first. Once the label exists in the repo — the
+# common case — this is the only edit call that runs.
+if ! apply_output=$(gh issue edit "$ISSUE_NUM" --add-label "$LABEL" 2>&1); then
+  # The edit failed. gh reports a missing *label* (not a missing issue) with a
+  # "not found" message; in that case the label simply does not exist yet —
+  # create it with the canonical metadata and retry once. Any other failure is
+  # real: warn and exit 0 (never block a hook), and post no comment.
+  if [[ "$apply_output" != *"not found"* ]]; then
+    echo "dispatch-apply-office-hours: warning: could not apply $LABEL to issue #$ISSUE_NUM: $apply_output" >&2
+    exit 0
+  fi
+  if ! create_output=$(gh label create "$LABEL" --color "$LABEL_COLOR" --description "$LABEL_DESC" 2>&1); then
+    echo "dispatch-apply-office-hours: warning: could not create label $LABEL: $create_output" >&2
+    exit 0
+  fi
+  if ! retry_output=$(gh issue edit "$ISSUE_NUM" --add-label "$LABEL" 2>&1); then
+    echo "dispatch-apply-office-hours: warning: could not apply $LABEL to issue #$ISSUE_NUM after create: $retry_output" >&2
+    exit 0
+  fi
+fi
+
+# The label is now on the issue. Post the why-comment. A comment failure is
+# non-fatal (the label still landed) — warn and exit 0.
+if ! comment_output=$(gh issue comment "$ISSUE_NUM" --body "Parked on \`$LABEL\`. Reason: $REASON" 2>&1); then
+  echo "dispatch-apply-office-hours: warning: could not post why-comment on issue #$ISSUE_NUM: $comment_output" >&2
+  exit 0
+fi
+
+exit 0

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours
@@ -39,6 +39,15 @@ if [[ -z "$ISSUE_NUM" || -z "$REASON" ]]; then
   exit 1
 fi
 
+# ISSUE_NUM is interpolated as the first positional argument to gh issue
+# view/edit/comment. A non-numeric, flag-like value (e.g. --repo other/repo)
+# would be parsed by gh as an option rather than an issue number, redirecting
+# those writes. Reject anything that is not a bare positive integer.
+if [[ ! "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
+  echo "error: dispatch-apply-office-hours: issue-num must be a positive integer, got '${ISSUE_NUM}'" >&2
+  exit 1
+fi
+
 # Idempotency gate: if the issue already carries the label, do nothing. A gh
 # read failure here is non-fatal — warn and bail out without parking, since we
 # cannot tell whether a comment was already posted.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-handoff
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-handoff
@@ -1,39 +1,22 @@
 #!/usr/bin/env bash
-# dispatch-handoff — scripted terminal disposition for /dispatch-worker phase completions
-# and /dispatch router early-stop paths.
+# dispatch-handoff — scripted terminal disposition for /dispatch router early-stop paths.
 #
-# Two invocation forms:
-#
-#   dispatch-handoff <N> --phase-completed
-#     Phase skill completed cleanly. Spawn the next /dispatch router via
-#     dispatch-spawn-router. On spawn failure: print stderr, exit non-zero, no
-#     self-close (leave the session open so the failure is visible). On spawn
-#     success: resolve the PR via dispatch-find-pr <N> and read its labels —
-#     if dispatch:office-hours is present, exit 0 without self-closing (the
-#     phase skill flagged a deviation; session stays open for human review).
-#     Otherwise exec dispatch-self-close.
+# Invocation form:
 #
 #   dispatch-handoff --early-stop
 #     Router early-stop path. No spawn — the chain re-seeds via the #725
 #     cap-keyed timer when a rate-limit window reopens, or via office-hours
 #     engagement when a parked item is picked up. Exec dispatch-self-close.
 #
-# Both forms require dangerouslyDisableSandbox: true — this script calls gh,
-# dispatch-self-close (which calls `claude rm`), and dispatch-spawn-router
-# (which calls `claude agents`). See .claude/rules/sandbox.md.
+# Requires dangerouslyDisableSandbox: true — this script calls dispatch-self-close
+# (which calls `claude rm`). See .claude/rules/sandbox.md.
 #
 # Environment overrides for testability:
 #   DISPATCH_HANDOFF_SELF_CLOSE_CMD  The dispatch-self-close command. Default:
 #                                    resolved relative to this script.
-#   DISPATCH_HANDOFF_SPAWN_CMD       The dispatch-spawn-router command. Default:
-#                                    resolved relative to this script.
-#   DISPATCH_HANDOFF_GH_CMD          The gh command. Default: gh.
-#   DISPATCH_HANDOFF_FIND_PR_CMD     The dispatch-find-pr command. Default:
-#                                    resolved relative to this script.
 #
 # Exit codes:
-#   0   self-close was exec'd (or deviation branch: no self-close, exit 0).
-#   1   spawn failed (--phase-completed path only).
+#   0   self-close was exec'd.
 #   2   bad arguments.
 #
 # NOT set -e: exits are handled explicitly.
@@ -42,14 +25,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 SELF_CLOSE_CMD="${DISPATCH_HANDOFF_SELF_CLOSE_CMD:-$SCRIPT_DIR/dispatch-self-close}"
-SPAWN_CMD="${DISPATCH_HANDOFF_SPAWN_CMD:-$SCRIPT_DIR/dispatch-spawn-router}"
-GH_CMD="${DISPATCH_HANDOFF_GH_CMD:-gh}"
-FIND_PR_CMD="${DISPATCH_HANDOFF_FIND_PR_CMD:-$SCRIPT_DIR/dispatch-find-pr}"
 
 # --- argument parsing ---------------------------------------------------------
-
-MODE=""
-ISSUE_NUM=""
 
 case "${1:-}" in
   --early-stop)
@@ -57,61 +34,15 @@ case "${1:-}" in
       echo "dispatch-handoff: --early-stop takes no arguments" >&2
       exit 2
     fi
-    MODE="early-stop"
-    ;;
-  --phase-completed)
-    echo "dispatch-handoff: --phase-completed requires an issue number: dispatch-handoff <N> --phase-completed" >&2
-    exit 2
-    ;;
-  "")
-    echo "dispatch-handoff: usage: dispatch-handoff <N> --phase-completed | dispatch-handoff --early-stop" >&2
-    exit 2
     ;;
   *)
-    # Expect: dispatch-handoff <N> --phase-completed
-    ISSUE_NUM="${1#\#}"  # strip leading # if present
-    if [[ $# -ne 2 || "${2:-}" != "--phase-completed" ]]; then
-      echo "dispatch-handoff: usage: dispatch-handoff <N> --phase-completed | dispatch-handoff --early-stop" >&2
-      exit 2
-    fi
-    if [[ -z "$ISSUE_NUM" || ! "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
-      echo "dispatch-handoff: issue number must be a positive integer, got '${1}'" >&2
-      exit 2
-    fi
-    MODE="phase-completed"
+    echo "dispatch-handoff: usage: dispatch-handoff --early-stop" >&2
+    exit 2
     ;;
 esac
 
 # --- early-stop path ----------------------------------------------------------
 
-if [[ "$MODE" == "early-stop" ]]; then
-  exec "$SELF_CLOSE_CMD"
-  # exec replaces the process; the line below is unreachable.
-  exit 1
-fi
-
-# --- phase-completed path -----------------------------------------------------
-
-# Step 1: spawn the next /dispatch router.
-spawn_output=$("$SPAWN_CMD" 2>&1)
-spawn_exit=$?
-
-if [[ $spawn_exit -ne 0 ]]; then
-  echo "dispatch-handoff: dispatch-spawn-router failed (exit $spawn_exit): $spawn_output" >&2
-  exit 1
-fi
-
-# Step 2: check for dispatch:office-hours on the PR.
-PR_NUM=$("$FIND_PR_CMD" "$ISSUE_NUM" 2>/dev/null || true)
-
-if [[ -n "$PR_NUM" ]]; then
-  labels=$("$GH_CMD" pr view "$PR_NUM" --json labels --jq '[.labels[].name] | join("\n")' 2>/dev/null || true)
-  if echo "$labels" | grep -qx "dispatch:office-hours"; then
-    # Deviation detected — session stays open for human review.
-    exit 0
-  fi
-fi
-
-# Step 3: clean completion — self-close.
 exec "$SELF_CLOSE_CMD"
+# exec replaces the process; the line below is unreachable.
 exit 1

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -322,13 +322,13 @@ issue_has_worktree() {
 # closingIssuesReferences drives topic-category resolution: a PR inherits the
 # highest-priority topic among the labels of every issue it closes.
 PR_LIST=$(gh pr list --state open --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels,closingIssuesReferences)
-# Skip PRs carrying dispatch:office-hours — the item is parked for human review
-# (either an input-block recorded by dispatch-input-block.sh, or a phase that
-# completed but surfaced a deviation, recorded by /dispatch-propagate Step 7). A later
-# UserPromptSubmit clears the label and the item re-enters the queue.
+# The office-hours skip is ISSUE-anchored (issue #909): dispatch:office-hours
+# lives on the issue, not the PR, so it is not filtered here on PR labels.
+# Instead the main PR loop below resolves each candidate PR's issue from its
+# branch prefix (<N>-<slug>) and skips the PR when that issue carries the label.
+# A later strip clears the label and the item re-enters the queue.
 PR_SORTED=$(printf '%s' "$PR_LIST" | jq -r '
   sort_by(.createdAt) | .[]
-  | select((.labels // []) | any(.name == "dispatch:office-hours") | not)
   | [.number, .createdAt, .headRefName, (.closingIssuesReferences // [] | tojson)] | @tsv')
 
 # Fetch every open issue once, carrying labels. This single list serves two
@@ -414,6 +414,16 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   case "$phase" in
     done|waiting) continue ;;
   esac
+
+  # Skip PRs whose ISSUE is parked on a human (dispatch:office-hours). The label
+  # lives on the issue (issue #909), so resolve the issue number from the PR's
+  # branch prefix (<N>-<slug>) and check the issue's labels in ISSUE_LABELS_JSON.
+  pr_issue_num="${pr_branch%%-*}"
+  if [[ -n "$pr_issue_num" ]] && printf '%s' "$ISSUE_LABELS_JSON" \
+      | jq -e --arg n "$pr_issue_num" \
+        '(.[$n] // []) | any(.name == "dispatch:office-hours")' >/dev/null; then
+    continue
+  fi
 
   # Skip PRs gated by an open blocker. Placed after the done/waiting filter so
   # PRs that would be discarded anyway don't pay the per-closing-issue gh-api

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6650,13 +6650,14 @@ echo "=== dispatch-input-block ==="
 #
 # The hook discriminates on CLAUDE_JOB_DIR/state.json {.name} starting with
 # "dispatch-"; resolves the issue number from the current branch (the <N>-*
-# prefix); resolves a PR via dispatch-find-pr; applies dispatch:office-hours
-# with the apply-first / create-on-"not found" idiom; runs dispatch-spawn.
+# prefix); parks the ISSUE via dispatch-apply-office-hours (the single write
+# path — issue target, create-on-first-use, why-comment); runs dispatch-spawn.
 # Always exits 0.
 #
 # Each test gets a fresh tmp tree:
 #   $TMPDIR_TEST/hooks/dispatch-input-block.sh     — the hook under test
-#   $TMPDIR_TEST/skills/dispatch-propagate/scripts/          — fakes for dispatch-find-pr,
+#   $TMPDIR_TEST/skills/dispatch-propagate/scripts/  — fakes for
+#                                                    dispatch-apply-office-hours,
 #                                                    dispatch-spawn
 #   $TMPDIR_TEST/bin/{gh,git}                      — PATH shims
 #   $TMPDIR_TEST/jobs/<id>/state.json              — fake CLAUDE_JOB_DIR ledger
@@ -6676,14 +6677,15 @@ ib_setup() {
     "$TMPDIR_TEST/hooks/dispatch-input-block.sh"
   chmod +x "$TMPDIR_TEST/hooks/dispatch-input-block.sh"
 
-  # Fake dispatch-find-pr: prints contents of $STUB_DIR/find-pr-output if
-  # present, else nothing (no PR exists).
-  cat > "$TMPDIR_TEST/skills/dispatch-propagate/scripts/dispatch-find-pr" <<'FAKE'
+  # Fake dispatch-apply-office-hours: log argv to apply-office-hours.log so
+  # tests can assert the issue target + reason the hook passed. The hook routes
+  # every dispatch:office-hours apply through this single write path.
+  cat > "$TMPDIR_TEST/skills/dispatch-propagate/scripts/dispatch-apply-office-hours" <<'FAKE'
 #!/usr/bin/env bash
-[[ -f "$STUB_DIR/find-pr-output" ]] && cat "$STUB_DIR/find-pr-output"
+echo "$*" >> "$STUB_DIR/apply-office-hours.log"
 exit 0
 FAKE
-  chmod +x "$TMPDIR_TEST/skills/dispatch-propagate/scripts/dispatch-find-pr"
+  chmod +x "$TMPDIR_TEST/skills/dispatch-propagate/scripts/dispatch-apply-office-hours"
 
   # Fake dispatch-spawn-router: log invocations to spawn-calls.log.
   cat > "$TMPDIR_TEST/skills/dispatch-propagate/scripts/dispatch-spawn-router" <<'FAKE'
@@ -6764,9 +6766,9 @@ ib_teardown() {
   unset CLAUDE_JOB_DIR
 }
 
-# --- Test 1: dispatch-* job + PR exists → label PR, spawn baton --------------
+# --- Test 1: dispatch-* job + PR exists → still parks the ISSUE, spawn baton --
 
-echo "Test: dispatch-* job + branch <N>-* + PR exists → label PR, spawn baton"
+echo "Test: dispatch-* job + branch <N>-* + PR exists → park ISSUE via apply-office-hours, spawn baton"
 ib_setup
 echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
 echo "456" > "$STUB_DIR/find-pr-output"
@@ -6775,71 +6777,46 @@ export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 "$TMPDIR_TEST/hooks/dispatch-input-block.sh" < /dev/null >/dev/null 2>&1
 rc=$?
 assert_eq "input-block: hook exits 0" "0" "$rc"
-pr_edit_log=$(cat "$STUB_DIR/gh-pr-edit.log" 2>/dev/null || true)
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
 TOTAL=$((TOTAL + 1))
-if [[ "$pr_edit_log" == *"pr edit 456 --add-label dispatch:office-hours"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: input-block: 'gh pr edit 456 --add-label dispatch:office-hours' was invoked"
+if [[ "$apply_issue" == "123" && -n "$apply_reason" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: input-block: dispatch-apply-office-hours invoked with issue 123 + non-empty reason (issue target even with a PR)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: input-block: 'gh pr edit 456 --add-label dispatch:office-hours' was invoked"
-  echo "    pr-edit-log: $pr_edit_log"
+  FAIL=$((FAIL + 1)); echo "  FAIL: input-block: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+  echo "    apply-log: $apply_log"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/gh-pr-edit.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: input-block: no PR-targeted gh edit (apply is issue-only)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: input-block: no PR-targeted gh edit (apply is issue-only)"
 fi
 spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
 assert_eq "input-block: dispatch-spawn invoked exactly once" "1" "$spawn_calls"
 ib_teardown
 
-# --- Test 2: dispatch-* job + no PR → label issue, spawn baton ---------------
+# --- Test 2: dispatch-* job + no PR → park the ISSUE, spawn baton ------------
 
-echo "Test: dispatch-* job + branch <N>-* + no PR → label issue (implement phase)"
+echo "Test: dispatch-* job + branch <N>-* + no PR → park ISSUE (implement phase)"
 ib_setup
 echo "789-bare" > "$STUB_DIR/current-branch.txt"
-# No find-pr-output → dispatch-find-pr prints nothing → fall back to issue.
 echo '{"name":"dispatch-test001"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
 export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 "$TMPDIR_TEST/hooks/dispatch-input-block.sh" < /dev/null >/dev/null 2>&1
 rc=$?
 assert_eq "input-block (no PR): hook exits 0" "0" "$rc"
-issue_edit_log=$(cat "$STUB_DIR/gh-issue-edit.log" 2>/dev/null || true)
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
 TOTAL=$((TOTAL + 1))
-if [[ "$issue_edit_log" == *"issue edit 789 --add-label dispatch:office-hours"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: input-block (no PR): 'gh issue edit 789 --add-label dispatch:office-hours' was invoked"
+if [[ "$apply_issue" == "789" && -n "$apply_reason" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: input-block (no PR): dispatch-apply-office-hours invoked with issue 789 + non-empty reason"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: input-block (no PR): 'gh issue edit 789 --add-label dispatch:office-hours' was invoked"
-  echo "    issue-edit-log: $issue_edit_log"
+  FAIL=$((FAIL + 1)); echo "  FAIL: input-block (no PR): dispatch-apply-office-hours invoked with issue 789 + non-empty reason"
+  echo "    apply-log: $apply_log"
 fi
-ib_teardown
-
-# --- Test 3: label missing → create + retry, canonical color/description -----
-
-echo "Test: label-missing → 'gh label create dispatch:office-hours' (canonical color/description) then retry"
-ib_setup
-echo "123-foo" > "$STUB_DIR/current-branch.txt"
-echo "456" > "$STUB_DIR/find-pr-output"
-echo "label-missing" > "$STUB_DIR/pr-edit-mode"
-echo '{"name":"dispatch-test001"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
-export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
-"$TMPDIR_TEST/hooks/dispatch-input-block.sh" < /dev/null >/dev/null 2>&1
-rc=$?
-assert_eq "label-missing: hook exits 0" "0" "$rc"
-label_create_log=$(cat "$STUB_DIR/gh-label-create.log" 2>/dev/null || true)
-TOTAL=$((TOTAL + 1))
-if [[ "$label_create_log" == *"--color FBCA04"* ]] \
-   && [[ "$label_create_log" == *"dispatch:office-hours"* ]] \
-   && [[ "$label_create_log" == *"blocked on a human"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: label-missing: label created with canonical color (FBCA04) and description"
-else
-  FAIL=$((FAIL + 1)); echo "  FAIL: label-missing: label created with canonical color (FBCA04) and description"
-  echo "    label-create-log: $label_create_log"
-fi
-pr_edit_log=$(cat "$STUB_DIR/gh-pr-edit.log" 2>/dev/null || true)
-TOTAL=$((TOTAL + 1))
-if [[ "$pr_edit_log" == *"pr edit 456 --add-label dispatch:office-hours"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: label-missing: PR apply retried after label create"
-else
-  FAIL=$((FAIL + 1)); echo "  FAIL: label-missing: PR apply retried after label create"
-  echo "    pr-edit-log: $pr_edit_log"
-fi
-spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
-assert_eq "label-missing: dispatch-spawn invoked exactly once after recovery" "1" "$spawn_calls"
 ib_teardown
 
 # --- Test 4: CLAUDE_JOB_DIR unset → no-op (no label, no spawn) ---------------
@@ -6853,10 +6830,10 @@ unset CLAUDE_JOB_DIR
 rc=$?
 assert_eq "no-job-dir: hook exits 0" "0" "$rc"
 TOTAL=$((TOTAL + 1))
-if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: no-job-dir: no gh label apply was invoked"
+if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: no-job-dir: no office-hours apply was invoked"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: no-job-dir: no gh label apply was invoked"
+  FAIL=$((FAIL + 1)); echo "  FAIL: no-job-dir: no office-hours apply was invoked"
 fi
 TOTAL=$((TOTAL + 1))
 if [[ ! -e "$STUB_DIR/spawn-calls.log" ]]; then
@@ -6878,10 +6855,10 @@ export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 rc=$?
 assert_eq "non-dispatch: hook exits 0" "0" "$rc"
 TOTAL=$((TOTAL + 1))
-if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: non-dispatch: no gh label apply was invoked"
+if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-dispatch: no office-hours apply was invoked"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: non-dispatch: no gh label apply was invoked"
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-dispatch: no office-hours apply was invoked"
 fi
 TOTAL=$((TOTAL + 1))
 if [[ ! -e "$STUB_DIR/spawn-calls.log" ]]; then
@@ -6904,10 +6881,10 @@ printf '%s' '{"notification_type":"session_complete"}' \
 rc=$?
 assert_eq "non-permission-prompt: hook exits 0" "0" "$rc"
 TOTAL=$((TOTAL + 1))
-if [[ ! -e "$STUB_DIR/gh-pr-edit.log" ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: non-permission-prompt: no gh label apply was invoked"
+if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-permission-prompt: no office-hours apply was invoked"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: non-permission-prompt: no gh label apply was invoked"
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-permission-prompt: no office-hours apply was invoked"
 fi
 ib_teardown
 
@@ -6922,10 +6899,10 @@ export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 rc=$?
 assert_eq "non-issue-branch: hook exits 0" "0" "$rc"
 TOTAL=$((TOTAL + 1))
-if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: non-issue-branch: no gh label apply was invoked"
+if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-issue-branch: no office-hours apply was invoked"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: non-issue-branch: no gh label apply was invoked"
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-issue-branch: no office-hours apply was invoked"
 fi
 TOTAL=$((TOTAL + 1))
 if [[ ! -e "$STUB_DIR/spawn-calls.log" ]]; then
@@ -7080,7 +7057,8 @@ echo "=== dispatch-stop ==="
 #
 # Each test gets a fresh tmp tree:
 #   $TMPDIR_TEST/hooks/dispatch-stop.sh               — hook under test
-#   $TMPDIR_TEST/skills/dispatch-propagate/scripts/             — fakes for find-pr,
+#   $TMPDIR_TEST/skills/dispatch-propagate/scripts/   — fakes for find-pr,
+#                                                       apply-office-hours,
 #                                                       phase, spawn-router,
 #                                                       self-close
 #   $TMPDIR_TEST/bin/{gh,git}                         — PATH shims
@@ -7108,6 +7086,18 @@ stop_setup() {
 exit 0
 FAKE
   chmod +x "$TMPDIR_TEST/skills/dispatch-propagate/scripts/dispatch-find-pr"
+
+  # Fake dispatch-apply-office-hours: log argv to apply-office-hours.log and a
+  # "label-apply" marker to order.log (the ordering test asserts spawn runs
+  # after the apply). The Stop hook routes every dispatch:office-hours apply
+  # through this single write path.
+  cat > "$TMPDIR_TEST/skills/dispatch-propagate/scripts/dispatch-apply-office-hours" <<'FAKE'
+#!/usr/bin/env bash
+echo "$*" >> "$STUB_DIR/apply-office-hours.log"
+echo "label-apply" >> "$STUB_DIR/order.log"
+exit 0
+FAKE
+  chmod +x "$TMPDIR_TEST/skills/dispatch-propagate/scripts/dispatch-apply-office-hours"
 
   # Fake dispatch-phase: prints contents of $STUB_DIR/current-phase.txt if
   # present, else "implement".
@@ -7310,13 +7300,15 @@ export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 "$TMPDIR_TEST/hooks/dispatch-stop.sh" < /dev/null >/dev/null 2>&1
 rc=$?
 assert_eq "stop verify-exhausted: hook exits 0" "0" "$rc"
-issue_edit_log=$(cat "$STUB_DIR/gh-issue-edit.log" 2>/dev/null || true)
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
 TOTAL=$((TOTAL + 1))
-if [[ "$issue_edit_log" == *"issue edit 123 --add-label dispatch:office-hours"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: stop verify-exhausted: issue --add-label invoked"
+if [[ "$apply_issue" == "123" && -n "$apply_reason" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop verify-exhausted: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: stop verify-exhausted: issue --add-label invoked"
-  echo "    issue-edit-log: $issue_edit_log"
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop verify-exhausted: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+  echo "    apply-log: $apply_log"
 fi
 TOTAL=$((TOTAL + 1))
 if [[ ! -e "$STUB_DIR/gh-pr-edit.log" ]]; then
@@ -7347,13 +7339,15 @@ export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 "$TMPDIR_TEST/hooks/dispatch-stop.sh" < /dev/null >/dev/null 2>&1
 rc=$?
 assert_eq "stop same-phase non-verify: hook exits 0" "0" "$rc"
-issue_edit_log=$(cat "$STUB_DIR/gh-issue-edit.log" 2>/dev/null || true)
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
 TOTAL=$((TOTAL + 1))
-if [[ "$issue_edit_log" == *"issue edit 123 --add-label dispatch:office-hours"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: stop same-phase non-verify: issue --add-label invoked"
+if [[ "$apply_issue" == "123" && -n "$apply_reason" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop same-phase non-verify: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: stop same-phase non-verify: issue --add-label invoked"
-  echo "    issue-edit-log: $issue_edit_log"
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop same-phase non-verify: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+  echo "    apply-log: $apply_log"
 fi
 TOTAL=$((TOTAL + 1))
 if [[ ! -e "$STUB_DIR/gh-pr-edit.log" ]]; then
@@ -7384,13 +7378,15 @@ export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 "$TMPDIR_TEST/hooks/dispatch-stop.sh" < /dev/null >/dev/null 2>&1
 rc=$?
 assert_eq "stop marker-absent: hook exits 0" "0" "$rc"
-issue_edit_log=$(cat "$STUB_DIR/gh-issue-edit.log" 2>/dev/null || true)
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
 TOTAL=$((TOTAL + 1))
-if [[ "$issue_edit_log" == *"issue edit 123 --add-label dispatch:office-hours"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: stop marker-absent: issue --add-label invoked"
+if [[ "$apply_issue" == "123" && -n "$apply_reason" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop marker-absent: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: stop marker-absent: issue --add-label invoked"
-  echo "    issue-edit-log: $issue_edit_log"
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop marker-absent: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+  echo "    apply-log: $apply_log"
 fi
 TOTAL=$((TOTAL + 1))
 if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-pr-remove.log" \
@@ -7472,39 +7468,31 @@ else
 fi
 stop_teardown
 
-# --- Test 8: label create-on-"not found" idiom -------------------------------
+# --- Test 8: $CLAUDE_JOB_DIR/office-hours-reason overrides the branch default -
 
-echo "Test: stop hook + marker absent + label missing → create label, retry apply"
+echo "Test: stop hook branch A + office-hours-reason file present → its contents pass as the reason"
 stop_setup
 echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
 echo "implement" > "$STUB_DIR/current-phase.txt"
-echo "label-missing" > "$STUB_DIR/issue-edit-mode"
 echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
-# No phase-completed marker → branch A.
+# No phase-completed marker → branch A. Enrichment-hook reason override present.
+printf '%s' "enriched: tool denied by policy" > "$TMPDIR_TEST/jobs/abcd1234/office-hours-reason"
 export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 "$TMPDIR_TEST/hooks/dispatch-stop.sh" < /dev/null >/dev/null 2>&1
 rc=$?
-assert_eq "stop label-missing: hook exits 0" "0" "$rc"
-label_create_log=$(cat "$STUB_DIR/gh-label-create.log" 2>/dev/null || true)
+assert_eq "stop reason-override: hook exits 0" "0" "$rc"
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
 TOTAL=$((TOTAL + 1))
-if [[ "$label_create_log" == *"--color FBCA04"* ]] \
-   && [[ "$label_create_log" == *"dispatch:office-hours"* ]] \
-   && [[ "$label_create_log" == *"blocked on a human"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: stop label-missing: label created with canonical color and description"
+if [[ "$apply_issue" == "123" && "$apply_reason" == "enriched: tool denied by policy" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop reason-override: office-hours-reason contents passed as the reason"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: stop label-missing: label created with canonical color and description"
-  echo "    label-create-log: $label_create_log"
-fi
-issue_edit_log=$(cat "$STUB_DIR/gh-issue-edit.log" 2>/dev/null || true)
-TOTAL=$((TOTAL + 1))
-if [[ "$issue_edit_log" == *"issue edit 123 --add-label dispatch:office-hours"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: stop label-missing: issue apply retried after label create"
-else
-  FAIL=$((FAIL + 1)); echo "  FAIL: stop label-missing: issue apply retried after label create"
-  echo "    issue-edit-log: $issue_edit_log"
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop reason-override: office-hours-reason contents passed as the reason"
+  echo "    apply-log: $apply_log"
 fi
 spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
-assert_eq "stop label-missing: spawn invoked exactly once after recovery" "1" "$spawn_calls"
+assert_eq "stop reason-override: spawn invoked exactly once" "1" "$spawn_calls"
 stop_teardown
 
 # --- Test 9: spawn-last ordering (branch D) ----------------------------------
@@ -7551,13 +7539,15 @@ export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 "$TMPDIR_TEST/hooks/dispatch-stop.sh" < /dev/null >/dev/null 2>&1
 rc=$?
 assert_eq "stop empty-phase: hook exits 0" "0" "$rc"
-issue_edit_log=$(cat "$STUB_DIR/gh-issue-edit.log" 2>/dev/null || true)
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
 TOTAL=$((TOTAL + 1))
-if [[ "$issue_edit_log" == *"issue edit 123 --add-label dispatch:office-hours"* ]]; then
+if [[ "$apply_issue" == "123" && -n "$apply_reason" ]]; then
   PASS=$((PASS + 1)); echo "  PASS: stop empty-phase: office-hours applied to issue (Branch D, not false Branch B)"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: stop empty-phase: office-hours applied to issue (Branch D, not false Branch B)"
-  echo "    issue-edit-log: $issue_edit_log"
+  echo "    apply-log: $apply_log"
 fi
 TOTAL=$((TOTAL + 1))
 if [[ ! -e "$STUB_DIR/self-close-calls.log" ]]; then
@@ -7589,13 +7579,15 @@ export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 "$TMPDIR_TEST/hooks/dispatch-stop.sh" < /dev/null >/dev/null 2>&1
 rc=$?
 assert_eq "stop unknown-phase: hook exits 0" "0" "$rc"
-issue_edit_log=$(cat "$STUB_DIR/gh-issue-edit.log" 2>/dev/null || true)
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
 TOTAL=$((TOTAL + 1))
-if [[ "$issue_edit_log" == *"issue edit 123 --add-label dispatch:office-hours"* ]]; then
+if [[ "$apply_issue" == "123" && -n "$apply_reason" ]]; then
   PASS=$((PASS + 1)); echo "  PASS: stop unknown-phase: office-hours applied to issue (Branch A, not false Branch B)"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: stop unknown-phase: office-hours applied to issue (Branch A, not false Branch B)"
-  echo "    issue-edit-log: $issue_edit_log"
+  echo "    apply-log: $apply_log"
 fi
 TOTAL=$((TOTAL + 1))
 if [[ ! -e "$STUB_DIR/self-close-calls.log" ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6960,7 +6960,7 @@ else
 fi
 ib_teardown
 
-# --- Test 4: CLAUDE_JOB_DIR unset → no-op (no label, no spawn) ---------------
+# --- Test 3: CLAUDE_JOB_DIR unset → no-op (no label, no spawn) ---------------
 
 echo "Test: CLAUDE_JOB_DIR unset → no-op (interactive session is excluded)"
 ib_setup
@@ -6984,7 +6984,7 @@ else
 fi
 ib_teardown
 
-# --- Test 5: non-dispatch job name → no-op -----------------------------------
+# --- Test 4: non-dispatch job name → no-op -----------------------------------
 
 echo "Test: state.json name is not 'dispatch-*' → no-op (other background jobs excluded)"
 ib_setup
@@ -7009,7 +7009,7 @@ else
 fi
 ib_teardown
 
-# --- Test 6: non-permission-prompt notification → silent pass-through --------
+# --- Test 5: non-permission-prompt notification → silent pass-through --------
 
 echo "Test: Notification with non-permission-prompt type → no-op (passes through silently)"
 ib_setup
@@ -7029,7 +7029,7 @@ else
 fi
 ib_teardown
 
-# --- Test 7: non-issue branch with dispatch job → no-op ----------------------
+# --- Test 6: non-issue branch with dispatch job → no-op ----------------------
 
 echo "Test: non-issue branch (main) + dispatch-* job → no-op (no label, no spawn)"
 ib_setup

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -53,6 +53,7 @@ setup() {
   cp "$SCRIPT_DIR/dispatch-select-target" "$TMPDIR_TEST/dispatch-select-target"
   cp "$SCRIPT_DIR/dispatch-trace-leaf" "$TMPDIR_TEST/dispatch-trace-leaf"
   cp "$SCRIPT_DIR/dispatch-complete-phase" "$TMPDIR_TEST/dispatch-complete-phase"
+  cp "$SCRIPT_DIR/dispatch-apply-office-hours" "$TMPDIR_TEST/dispatch-apply-office-hours"
   cp "$SCRIPT_DIR/dispatch-resolve-worktree" "$TMPDIR_TEST/dispatch-resolve-worktree"
   # dispatch-select-target's JIT scan calls dispatch-config-load and
   # dispatch-project-status-read as "$SCRIPT_DIR/<name>". SCRIPT_DIR resolves to
@@ -74,6 +75,7 @@ setup() {
            "$TMPDIR_TEST/dispatch-select-target" \
            "$TMPDIR_TEST/dispatch-trace-leaf" \
            "$TMPDIR_TEST/dispatch-complete-phase" \
+           "$TMPDIR_TEST/dispatch-apply-office-hours" \
            "$TMPDIR_TEST/dispatch-resolve-worktree" \
            "$TMPDIR_TEST/dispatch-config-load" \
            "$TMPDIR_TEST/dispatch-project-status-read"
@@ -213,9 +215,46 @@ case "$args" in
     fi
     ;;
   label\ create\ *)
-    # dispatch-complete-phase creates the label only when the apply reported
-    # it missing.
+    # dispatch-complete-phase / dispatch-apply-office-hours create the label only
+    # when the apply reported it missing.
     echo "$args" >> "$STUB_DIR/gh-label-create.log"
+    ;;
+  issue\ view\ *\ --json\ labels)
+    # dispatch-apply-office-hours idempotency read: gh issue view <num> --json labels.
+    # $STUB_DIR/issue-labels-<num>.json supplies the labels object; absence means
+    # the issue carries no labels.
+    num=$(echo "$args" | awk '{print $3}')
+    if [[ -f "$STUB_DIR/issue-labels-${num}.json" ]]; then
+      cat "$STUB_DIR/issue-labels-${num}.json"
+    else
+      echo '{"labels":[]}'
+    fi
+    ;;
+  issue\ edit\ *)
+    # dispatch-apply-office-hours applies the label to the ISSUE.
+    # $STUB_DIR/issue-edit-mode selects behavior (default: succeed and log args).
+    mode="ok"
+    [[ -f "$STUB_DIR/issue-edit-mode" ]] && mode=$(cat "$STUB_DIR/issue-edit-mode")
+    case "$mode" in
+      label-missing)
+        # The label does not exist until gh label create runs: model gh's
+        # missing-label error until then, then succeed on the retry.
+        if [[ -f "$STUB_DIR/gh-label-create.log" ]]; then
+          echo "$args" >> "$STUB_DIR/gh-issue-edit.log"
+        else
+          label="${args##* }"
+          echo "failed to update: '$label' not found" >&2
+          exit 1
+        fi
+        ;;
+      *)
+        echo "$args" >> "$STUB_DIR/gh-issue-edit.log"
+        ;;
+    esac
+    ;;
+  issue\ comment\ *)
+    # dispatch-apply-office-hours posts the why-comment to the ISSUE.
+    echo "$args" >> "$STUB_DIR/gh-issue-comment.log"
     ;;
   pr\ edit\ *)
     # dispatch-complete-phase applies the label to the PR. $STUB_DIR/pr-edit-mode
@@ -2233,6 +2272,104 @@ matches=$(grep -rl 'BFD4F2' "$REPO_ROOT/.claude" \
 assert_eq "only dispatch-complete-phase owns BFD4F2" \
   ".claude/skills/dispatch-propagate/scripts/dispatch-complete-phase" \
   "$matches"
+
+# ============================================================================
+# dispatch-apply-office-hours tests
+# ============================================================================
+echo ""
+echo "=== dispatch-apply-office-hours ==="
+
+# Reports whether the gh stub recorded a given call log (present/absent).
+log_state() {
+  [[ -f "$STUB_DIR/$1" ]] && echo "present" || echo "absent"
+}
+
+# Happy path: the issue carries no office-hours label, so the script applies it
+# to the ISSUE and posts a why-comment containing the reason text.
+echo "Test: label absent → apply to issue + post why-comment"
+setup
+"$TMPDIR_TEST/dispatch-apply-office-hours" 42 "phase exited before completion"
+assert_eq "applies dispatch:office-hours to the issue" \
+  "issue edit 42 --add-label dispatch:office-hours" "$(cat "$STUB_DIR/gh-issue-edit.log")"
+assert_eq "happy path: no gh label create when label exists" \
+  "absent" "$(log_state gh-label-create.log)"
+TOTAL=$((TOTAL + 1))
+if grep -q "Reason: phase exited before completion" "$STUB_DIR/gh-issue-comment.log"; then
+  PASS=$((PASS + 1)); echo "  PASS: why-comment contains the reason"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: why-comment contains the reason"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q "^issue comment 42 " "$STUB_DIR/gh-issue-comment.log"; then
+  PASS=$((PASS + 1)); echo "  PASS: comment targets the issue"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: comment targets the issue"
+fi
+teardown
+
+# Idempotent: the issue already carries the label → no re-apply, no duplicate
+# comment.
+echo "Test: label already present → no edit, no duplicate comment"
+setup
+echo '{"labels":[{"name":"dispatch:office-hours"}]}' > "$STUB_DIR/issue-labels-42.json"
+"$TMPDIR_TEST/dispatch-apply-office-hours" 42 "phase ran but did not advance"
+assert_eq "idempotent: no label edit" "absent" "$(log_state gh-issue-edit.log)"
+assert_eq "idempotent: no duplicate comment" "absent" "$(log_state gh-issue-comment.log)"
+teardown
+
+# Missing reason (only an issue number) → non-zero exit, no edit, no comment.
+echo "Test: missing reason → non-zero exit, no edit, no comment"
+setup
+if "$TMPDIR_TEST/dispatch-apply-office-hours" 42 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "missing reason exits non-zero" "1" "$rc"
+assert_eq "missing reason: no label edit" "absent" "$(log_state gh-issue-edit.log)"
+assert_eq "missing reason: no comment" "absent" "$(log_state gh-issue-comment.log)"
+teardown
+
+# Empty reason → same as missing reason.
+echo "Test: empty reason → non-zero exit, no edit, no comment"
+setup
+if "$TMPDIR_TEST/dispatch-apply-office-hours" 42 "" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "empty reason exits non-zero" "1" "$rc"
+assert_eq "empty reason: no label edit" "absent" "$(log_state gh-issue-edit.log)"
+teardown
+
+# Missing both args → non-zero exit.
+echo "Test: missing both args → non-zero exit"
+setup
+if "$TMPDIR_TEST/dispatch-apply-office-hours" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "missing both args exits non-zero" "1" "$rc"
+teardown
+
+# Create-on-first-use: the apply fails "not found" (the *label* does not exist
+# in the repo yet), so the script creates it with the canonical FBCA04 color and
+# retries the edit, then posts the comment.
+echo "Test: label not found → create (FBCA04) then retry + comment"
+setup
+echo "label-missing" > "$STUB_DIR/issue-edit-mode"
+"$TMPDIR_TEST/dispatch-apply-office-hours" 42 "phase exited before completion"
+TOTAL=$((TOTAL + 1))
+if grep -q "^label create dispatch:office-hours --color FBCA04 " "$STUB_DIR/gh-label-create.log"; then
+  PASS=$((PASS + 1)); echo "  PASS: label created with FBCA04 color"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: label created with FBCA04 color"
+fi
+assert_eq "create-on-first-use: label applied on retry" \
+  "issue edit 42 --add-label dispatch:office-hours" "$(cat "$STUB_DIR/gh-issue-edit.log")"
+assert_eq "create-on-first-use: why-comment posted" \
+  "present" "$(log_state gh-issue-comment.log)"
+teardown
+
+# dispatch-apply-office-hours owns the FBCA04 hex. (A single-source-of-truth
+# guard that excludes the two writer hooks is deferred to the unit that routes
+# them through this script and removes their inline FBCA04 references.)
+echo "Test: dispatch-apply-office-hours contains the FBCA04 hex"
+TOTAL=$((TOTAL + 1))
+if grep -q 'FBCA04' "$SCRIPT_DIR/dispatch-apply-office-hours"; then
+  PASS=$((PASS + 1)); echo "  PASS: dispatch-apply-office-hours owns FBCA04"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: dispatch-apply-office-hours owns FBCA04"
+fi
 
 # ============================================================================
 # dispatch-resolve-worktree tests

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2456,6 +2456,17 @@ if "$TMPDIR_TEST/dispatch-apply-office-hours" 2>/dev/null; then rc=0; else rc=$?
 assert_eq "missing both args exits non-zero" "1" "$rc"
 teardown
 
+# Non-numeric, flag-like issue number → hard error, no gh calls. Guards against a
+# flag-like first arg (e.g. --repo other/repo) being argument-injected into the
+# gh issue view/edit/comment calls.
+echo "Test: non-numeric issue number → non-zero exit, no edit/comment"
+setup
+if "$TMPDIR_TEST/dispatch-apply-office-hours" "--repo other/repo" "a reason" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "non-numeric issue number exits non-zero" "1" "$rc"
+assert_eq "non-numeric issue number: no label edit" "absent" "$(log_state gh-issue-edit.log)"
+assert_eq "non-numeric issue number: no comment" "absent" "$(log_state gh-issue-comment.log)"
+teardown
+
 # Create-on-first-use: the apply fails "not found" (the *label* does not exist
 # in the repo yet), so the script creates it with the canonical FBCA04 color and
 # retries the edit, then posts the comment.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -850,6 +850,25 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "PR with worktree skipped; next PR returned" "pr 20 20-other verify" "$result"
 teardown
 
+# 2b. A PR whose ISSUE carries dispatch:office-hours is skipped (issue #909).
+# The label lives on the issue, not the PR — the skip resolves the issue number
+# from the PR's branch prefix (<N>-) and reads the issue's labels. PR 10's branch
+# is 10-parked → issue #10, which is parked; PR 20's branch is 20-other → issue
+# #20, which is not. Neither PR itself carries the label.
+echo "Test: PR whose issue carries dispatch:office-hours is skipped"
+setup
+UNION='['"$(make_pr_union 10 "10-parked" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr_union 20 "20-other" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+# Issue #10 is parked (dispatch:office-hours); issue #20 is not. Neither carries
+# "help wanted", so neither competes in the issue queue — they exist here only as
+# the office-hours-label source the PR loop reads via ISSUE_LABELS_JSON.
+printf '[{"number":10,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"dispatch:office-hours"}]},{"number":20,"createdAt":"2024-01-02T00:00:00Z","labels":[]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "PR with parked issue skipped; unparked sibling returned" "pr 20 20-other verify" "$result"
+teardown
+
 # 3. When no eligible PR exists, a help-wanted issue is chosen.
 echo "Test: no eligible PR → help-wanted issue"
 setup
@@ -1914,21 +1933,10 @@ if result=$("$TMPDIR_TEST/dispatch-select-target" 2>/dev/null); then rc=0; else 
 assert_eq "invalid duration → exits non-zero" "yes" "$rc_nonzero"
 teardown
 
-# OH1. A PR carrying dispatch:office-hours is skipped (parked for human review).
-echo "Test: PR with dispatch:office-hours is skipped"
-setup
-# Two verify PRs; the older one (PR 10) is parked.
-OFFICE_HOURS_LABELS='[{"name":"dispatch:office-hours"}]'
-UNION='['
-UNION+="$(make_pr_union 10 "10-parked" "2024-01-01T00:00:00Z" "true" "$OFFICE_HOURS_LABELS" "$FAILING_ROLLUP")"','
-UNION+="$(make_pr_union 20 "20-active" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"
-UNION+=']'
-setup_union_pr_list "$UNION"
-echo '[]' > "$STUB_DIR/issue-list.json"
-printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
-result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "parked PR skipped; next PR returned" "pr 20 20-active verify" "$result"
-teardown
+# OH1. The PR-phase office-hours skip is issue-anchored (issue #909): see the
+# "PR whose issue carries dispatch:office-hours is skipped" test in the
+# dispatch-select-target section above. The label lives on the issue, never the
+# PR, so there is no PR-label filter here.
 
 # OH2. A help-wanted issue carrying dispatch:office-hours is skipped.
 echo "Test: help-wanted issue with dispatch:office-hours is skipped"
@@ -1943,22 +1951,24 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "parked issue skipped; next help-wanted issue returned" "issue 66" "$result"
 teardown
 
-# OH3. A PR with dispatch:office-hours that has a worktree on disk is not
-#      selected — the PR-ladder worktree-skip keeps it out regardless of the
-#      label, but the label alone is also sufficient. This test codifies the
-#      no-regression claim: the old sweep-adoption mechanism would have picked
-#      such a PR; without it the labeled-and-worktree'd PR stays out.
+# OH3. A PR whose issue is parked (dispatch:office-hours) and that also has a
+#      worktree on disk is not selected — the PR-ladder worktree-skip keeps it
+#      out regardless of the label. This test codifies the no-regression claim:
+#      the old sweep-adoption mechanism would have picked such a PR; without it
+#      the worktree'd PR stays out.
 echo "Test: office-hours PR with worktree on disk is not selected"
 setup
-# PR 10 is parked (dispatch:office-hours) and also has a worktree on disk.
-# PR 20 is the second eligible verify PR with no labels and no worktree.
-OFFICE_HOURS_LABELS='[{"name":"dispatch:office-hours"}]'
+# PR 10's issue (#10) is parked (dispatch:office-hours) and PR 10 also has a
+# worktree on disk. PR 20 is the second eligible verify PR with no parked issue
+# and no worktree.
 UNION='['
-UNION+="$(make_pr_union 10 "10-oh-parked" "2024-01-01T00:00:00Z" "true" "$OFFICE_HOURS_LABELS" "$FAILING_ROLLUP")"','
+UNION+="$(make_pr_union 10 "10-oh-parked" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','
 UNION+="$(make_pr_union 20 "20-active" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"
 UNION+=']'
 setup_union_pr_list "$UNION"
-echo '[]' > "$STUB_DIR/issue-list.json"
+# Issue #10 is parked (the office-hours label lives on the issue, issue #909).
+printf '[{"number":10,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"dispatch:office-hours"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
 # Worktree exists on disk for 10-oh-parked (what the old adoption mechanism would
 # have targeted); no worktree for 20-active.
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/10-oh-parked\nHEAD def456\nbranch refs/heads/10-oh-parked\n\n' \
@@ -7851,8 +7861,6 @@ handoff_setup() {
   HTMPDIR=$(mktemp -d)
   HSELF_CLOSE_LOG="$HTMPDIR/self-close.log"
   HSPAWN_LOG="$HTMPDIR/spawn.log"
-  HGH_LOG="$HTMPDIR/gh.log"
-  HFIND_PR_LOG="$HTMPDIR/find-pr.log"
 
   # Default fake dispatch-self-close: records the call, exits 0.
   cat > "$HTMPDIR/fake-self-close" <<'FAKE'
@@ -7862,51 +7870,18 @@ exit 0
 FAKE
   # Inject HSELF_CLOSE_LOG into the fake via env at call time.
   chmod +x "$HTMPDIR/fake-self-close"
-
-  # Default fake dispatch-spawn-router: records the call, exits 0, prints "spawned".
-  cat > "$HTMPDIR/fake-spawn" <<'FAKE'
-#!/usr/bin/env bash
-echo "spawn called" >> "$HSPAWN_LOG"
-echo "spawned"
-exit 0
-FAKE
-  chmod +x "$HTMPDIR/fake-spawn"
-
-  # Default fake gh: records invocation, prints no labels.
-  cat > "$HTMPDIR/fake-gh" <<'FAKE'
-#!/usr/bin/env bash
-echo "gh $*" >> "$HGH_LOG"
-# pr view <N> --json labels --jq ...  → return empty label list
-echo ""
-exit 0
-FAKE
-  chmod +x "$HTMPDIR/fake-gh"
-
-  # Default fake dispatch-find-pr: prints PR number 99.
-  cat > "$HTMPDIR/fake-find-pr" <<'FAKE'
-#!/usr/bin/env bash
-echo "find-pr $*" >> "$HFIND_PR_LOG"
-echo "99"
-exit 0
-FAKE
-  chmod +x "$HTMPDIR/fake-find-pr"
 }
 
 handoff_teardown() {
   rm -rf "$HTMPDIR"
-  unset HTMPDIR HSELF_CLOSE_LOG HSPAWN_LOG HGH_LOG HFIND_PR_LOG
+  unset HTMPDIR HSELF_CLOSE_LOG HSPAWN_LOG
 }
 
 # Run dispatch-handoff with fake commands injected via env.
 run_handoff() {
   DISPATCH_HANDOFF_SELF_CLOSE_CMD="$HTMPDIR/fake-self-close" \
-  DISPATCH_HANDOFF_SPAWN_CMD="$HTMPDIR/fake-spawn" \
-  DISPATCH_HANDOFF_GH_CMD="$HTMPDIR/fake-gh" \
-  DISPATCH_HANDOFF_FIND_PR_CMD="$HTMPDIR/fake-find-pr" \
   HSELF_CLOSE_LOG="$HSELF_CLOSE_LOG" \
   HSPAWN_LOG="$HSPAWN_LOG" \
-  HGH_LOG="$HGH_LOG" \
-  HFIND_PR_LOG="$HFIND_PR_LOG" \
     "$HANDOFF_SCRIPT" "$@"
 }
 
@@ -7924,73 +7899,7 @@ assert_eq "--early-stop self-close called" "self-close called" "$(cat "$HSELF_CL
 assert_eq "--early-stop no spawn" "" "$(cat "$HSPAWN_LOG" 2>/dev/null || echo '')"
 handoff_teardown
 
-# ----- 2. --phase-completed happy path: spawn + self-close, exits 0 ----------
-echo "Test: dispatch-handoff <N> --phase-completed happy path"
-handoff_setup
-run_handoff 42 --phase-completed
-phase_exit=$?
-assert_eq "--phase-completed exit code" "0" "$phase_exit"
-assert_eq "--phase-completed spawn called" "spawn called" "$(cat "$HSPAWN_LOG" 2>/dev/null || echo '')"
-assert_eq "--phase-completed self-close called" "self-close called" "$(cat "$HSELF_CLOSE_LOG" 2>/dev/null || echo '')"
-# gh must be called with the PR number returned by fake-find-pr (99).
-TOTAL=$((TOTAL + 1))
-if grep -q "gh pr view 99 " "$HGH_LOG" 2>/dev/null; then
-  PASS=$((PASS + 1)); echo "  PASS: --phase-completed gh called with PR 99"
-else
-  FAIL=$((FAIL + 1)); echo "  FAIL: --phase-completed gh called with PR 99"
-  echo "    gh log: $(cat "$HGH_LOG" 2>/dev/null || echo '<empty>')"
-fi
-handoff_teardown
-
-# ----- 3. --phase-completed with spawn failure: no self-close, exits 1 -------
-echo "Test: dispatch-handoff --phase-completed spawn failure → no self-close, exit 1"
-handoff_setup
-# Override spawn to fail.
-cat > "$HTMPDIR/fake-spawn" <<'FAKE'
-#!/usr/bin/env bash
-echo "spawn called" >> "$HSPAWN_LOG"
-echo "agent did not register" >&2
-exit 1
-FAKE
-chmod +x "$HTMPDIR/fake-spawn"
-# Use if/else to capture the exit code without triggering set -e.
-if run_handoff 42 --phase-completed 2>/dev/null; then spawn_fail_exit=0; else spawn_fail_exit=$?; fi
-assert_eq "--phase-completed spawn-failed exit code" "1" "$spawn_fail_exit"
-assert_eq "--phase-completed spawn-failed: spawn was called" "spawn called" "$(cat "$HSPAWN_LOG" 2>/dev/null || echo '')"
-# self-close must NOT have been called.
-assert_eq "--phase-completed spawn-failed: no self-close" "" "$(cat "$HSELF_CLOSE_LOG" 2>/dev/null || echo '')"
-handoff_teardown
-
-# ----- 4. --phase-completed with dispatch:office-hours → no self-close, exit 0
-echo "Test: dispatch-handoff --phase-completed with dispatch:office-hours → no self-close"
-handoff_setup
-# Override gh to return the office-hours label.
-cat > "$HTMPDIR/fake-gh" <<'FAKE'
-#!/usr/bin/env bash
-echo "gh $*" >> "$HGH_LOG"
-echo "dispatch:office-hours"
-exit 0
-FAKE
-chmod +x "$HTMPDIR/fake-gh"
-run_handoff 42 --phase-completed
-office_exit=$?
-assert_eq "--phase-completed office-hours exit code" "0" "$office_exit"
-assert_eq "--phase-completed office-hours: spawn called" "spawn called" "$(cat "$HSPAWN_LOG" 2>/dev/null || echo '')"
-# self-close must NOT have been called (session stays open for human review).
-assert_eq "--phase-completed office-hours: no self-close" "" "$(cat "$HSELF_CLOSE_LOG" 2>/dev/null || echo '')"
-handoff_teardown
-
-# ----- 5. Missing issue number → exit 2 with diagnostic ----------------------
-echo "Test: dispatch-handoff --phase-completed missing issue number → exit 2"
-handoff_setup
-# Use if/else to capture exit code without triggering set -e.
-if run_handoff --phase-completed 2>/dev/null; then missing_exit=0; else missing_exit=$?; fi
-assert_eq "--phase-completed missing issue: exit 2" "2" "$missing_exit"
-assert_eq "--phase-completed missing issue: no spawn" "" "$(cat "$HSPAWN_LOG" 2>/dev/null || echo '')"
-assert_eq "--phase-completed missing issue: no self-close" "" "$(cat "$HSELF_CLOSE_LOG" 2>/dev/null || echo '')"
-handoff_teardown
-
-# ----- 6. No arguments → exit 2 -----------------------------------------------
+# ----- 2. No arguments → exit 2 -----------------------------------------------
 echo "Test: dispatch-handoff with no arguments → exit 2"
 handoff_setup
 # Use if/else to capture exit code without triggering set -e.
@@ -7998,7 +7907,7 @@ if run_handoff 2>/dev/null; then no_args_exit=0; else no_args_exit=$?; fi
 assert_eq "no arguments: exit 2" "2" "$no_args_exit"
 handoff_teardown
 
-# ----- 7. CLAUDE_JOB_DIR unset: self-close is a no-op (interactive session) --
+# ----- 3. CLAUDE_JOB_DIR unset: self-close is a no-op (interactive session) --
 echo "Test: dispatch-handoff --early-stop with CLAUDE_JOB_DIR unset: self-close no-op, exits 0"
 handoff_setup
 # The real dispatch-self-close is a no-op when CLAUDE_JOB_DIR is unset.


### PR DESCRIPTION
Closes #909

Centralizes every `dispatch:office-hours` write through one script so the label
always lands on the **issue** with a why-comment, and re-anchors the readers on
the issue.

## Changes

- **New `dispatch-apply-office-hours <issue-num> <reason>`** — the single write
  path. Issue-only target (never a PR), create-on-first-use of the canonical
  label metadata (`FBCA04` + description), idempotent (no duplicate comment when
  already present), posts a `Reason: <reason>` why-comment, and never blocks a
  hook (exits 0 on any gh failure after the arg check).
- **Re-routed all three writers** through it:
  - `dispatch-input-block.sh` — dropped the `dispatch-find-pr` PR-vs-issue fork
    and inline create idiom for a single issue-target call.
  - `dispatch-stop.sh` Branch A/D — drop the inline apply/create helpers; call
    the script with a branch-default reason, overridden by
    `$CLAUDE_JOB_DIR/office-hours-reason` when the #826 enrichment hook wrote
    one. The both-sides strip path is unchanged.
  - `dispatch/SKILL.md` — both `notify target-blocked` call sites and the
    Applying section now invoke the script with issue-target reasons.
- **Re-anchored `dispatch-select-target`** — removed the stale PR-label filter;
  the PR loop now resolves each candidate's issue from its branch prefix and
  skips the PR when that **issue** carries `dispatch:office-hours`.
- **Deleted `dispatch-handoff --phase-completed`** — no caller after #868 routed
  all worker disposition through the Stop hook; only `--early-stop` remains,
  removing the last PR-side office-hours read.

## Tests

`test-dispatch-scripts.sh` — new `dispatch-apply-office-hours` section; updated
stop/input-block assertions to verify the issue-target apply via a logging fake;
new issue-anchored select-target skip test; deleted the four `--phase-completed`
handoff tests. Full suite green (593/593).

## Audits

- `grep -rn "add-label dispatch:office-hours" .claude/hooks .claude/skills` —
  every match is inside the script or the test file; no hook/SKILL.md writer
  targets a PR.
- `grep -n "phase-completed" .claude/skills/dispatch/scripts/dispatch-handoff` —
  zero matches.

## Note for reviewer

A live smoke test against a throwaway issue was not run from this background job
(it would mutate GitHub state); the gh-stubbed unit tests cover the behavior.