### PR TITLE
dispatch-resolve-worktree: reconcile a reused worktree's branch against the PR head branch

### DIFF
--- a/.claude/skills/dispatch-propagate/SKILL.md
+++ b/.claude/skills/dispatch-propagate/SKILL.md
@@ -381,8 +381,12 @@ worktree path that Step 6 will pass to `dispatch-spawn-worker`.
 
 - **`enter <path>`** → re-use an existing `<issue>-*` worktree
   (recycle-after-completion for an explicit argument, or recycle of an orphan
-  worktree — on disk, no live session — for a queue selection, #905). Set
-  `WORKTREE_PATH=<path>` for Step 6. Re-sync issue context from the worktree
+  worktree — on disk, no live session — for a queue selection, #905). A reused
+  worktree whose checked-out branch differs from the target PR's head branch
+  (resolved by `dispatch-find-pr`) is re-pointed to the PR head branch by the
+  resolver before it emits `enter` — lossless, since the case where the existing
+  branch carries commits not on the PR head yields `conflict` instead (#913).
+  Set `WORKTREE_PATH=<path>` for Step 6. Re-sync issue context from the worktree
   (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`):
   ```bash
   (cd <path> && .claude/skills/dispatch-propagate/scripts/sync-issue-context <N>)
@@ -423,11 +427,14 @@ worktree path that Step 6 will pass to `dispatch-spawn-worker`.
      (cd "$WORKTREE_PATH" && .claude/skills/dispatch-propagate/scripts/sync-issue-context <N>)
      ```
 
-- **`conflict <path>`** → a queue-selected target already has a worktree, so
-  another session owns it. (`dispatch-select-target` resolves the `help wanted`
-  tier to a leaf with no worktree, so for a queue selection this arises only from
-  a race — another session created the worktree between selection and worktree
-  resolution.) Release the lock (see *Releasing the lock*), then proceed to
+- **`conflict <path>`** → the worktree at `<path>` cannot be safely entered.
+  Either a queue-selected target already has a worktree another live session
+  owns (`dispatch-select-target` resolves the `help wanted` tier to a leaf with
+  no worktree, so for a queue selection this arises only from a race — another
+  session created the worktree between selection and worktree resolution), or
+  the reused `<issue>-*` worktree's checked-out branch carries commits not on
+  the target PR's head branch, so re-pointing it would discard work (#913).
+  Release the lock (see *Releasing the lock*), then proceed to
   Step 7 with `notify worktree-conflict` — the user-visible report is mandatory
   there ("worktree at `<path>` owned by another live session for issue `<N>`;
   closing — the next baton-pass or office-hours hand-off will re-seed"), not

--- a/.claude/skills/dispatch-propagate/SKILL.md
+++ b/.claude/skills/dispatch-propagate/SKILL.md
@@ -439,9 +439,15 @@ worktree path that Step 6 will pass to `dispatch-spawn-worker`.
   the target PR's head branch, so re-pointing it would discard work (#913).
   Release the lock (see *Releasing the lock*), then proceed to
   Step 7 with `notify worktree-conflict` — the user-visible report is mandatory
-  there ("worktree at `<path>` owned by another live session for issue `<N>`;
-  closing — the next baton-pass or office-hours hand-off will re-seed"), not
-  optional. Do not spawn a worker.
+  there. The message depends on which conflict case fired:
+  - Live-session race: "worktree at `<path>` owned by another live session for
+    issue `<N>`; closing — the next baton-pass or office-hours hand-off will
+    re-seed"
+  - Unique-commits branch mismatch: "worktree at `<path>` for issue `<N>` is
+    on a branch with commits not on the PR head branch; manual inspection needed
+    before re-entry"
+
+  Not optional. Do not spawn a worker.
 
 As the **final action of this step on every non-`conflict` (proceed) path** —
 before Step 6 — run `dispatch-finalize-selection "$WORKTREE_PATH"`. The
@@ -636,8 +642,10 @@ The three dispositions:
   | `notify target-blocked` | Step 4 — named target is closed or has an open blocker |
 
 - **`drain <reason>`** — `drain empty-queue` (Step 3, queue empty),
-  `drain worktree-conflict` (Step 5, target's worktree is owned by another
-  live session), or `drain concurrency-cap` (Step 6, `live_count >=
+  `drain worktree-conflict` (Step 5, target's worktree cannot be safely
+  entered — either a live session owns it, or the worktree's branch carries
+  commits not on the PR head branch; see the `conflict` case in Step 5), or
+  `drain concurrency-cap` (Step 6, `live_count >=
   target_N` — the chain re-seeds when the cap-keyed timer fires at the next
   rate-limit window reset; see *The #725 cap-keyed re-seed* above). The call site has already printed a **mandatory** user-visible
   report stating the reason and the recovery path (templates live at the

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
@@ -21,6 +21,18 @@
 #              (lib-claude-agents.sh), which is fail-safe: an unqueryable
 #              daemon counts as owned and yields `conflict`.
 #
+# Branch reconciliation on the `enter` path (#913): a reused <issue>-* worktree
+# is matched by branch-name prefix, but the target's PR (resolved by
+# dispatch-find-pr via GitHub closing-linkage) may live on a different
+# <issue>-* branch. Before entering, the worktree's checked-out branch is
+# reconciled against the PR head branch:
+#   - no PR for <issue> (the implement phase) → enter unchanged.
+#   - worktree already on the PR head branch → enter unchanged (no checkout).
+#   - worktree on a different branch with no commits unique to it → the
+#     worktree is re-pointed to the PR head branch (lossless), then `enter`.
+#   - worktree on a different branch carrying unique commits → `conflict`,
+#     rather than silently discarding them.
+#
 # The branch name printed by `create` matches the WorktreeCreate hook's
 # accepted form ^[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$, full name <= 32 characters.
 #
@@ -41,20 +53,37 @@ source "$SCRIPT_DIR/lib.sh"
 # worktree (conflict) from an orphan one (enter / recycle) (#905).
 source "$SCRIPT_DIR/lib-claude-agents.sh"
 
+# Reconcile a reused worktree's checked-out branch against the target PR's head
+# branch, then emit the `enter`/`conflict` decision (#913). Called on every
+# `enter`-bound path (explicit, and queue-orphan recycle).
+emit_enter_reconciled() {
+  local wt_path="$1" wt_branch="$2" pr pr_head unique
+  pr=$("$SCRIPT_DIR/dispatch-find-pr" "$ISSUE") || pr=""
+  if [[ -z "$pr" ]]; then echo "enter $wt_path"; return 0; fi   # no PR → unchanged
+  pr_head=$(gh pr view "$pr" --json headRefName | jq -r '.headRefName // empty')
+  if [[ -z "$pr_head" || "$pr_head" == "$wt_branch" ]]; then     # same branch → no-op
+    echo "enter $wt_path"; return 0
+  fi
+  git -C "$wt_path" fetch --quiet origin "$pr_head"
+  unique=$(git -C "$wt_path" rev-list --count "origin/${pr_head}..${wt_branch}")
+  if [[ "$unique" -ne 0 ]]; then echo "conflict $wt_path"; return 0; fi  # unique commits → conflict
+  git -C "$wt_path" checkout --quiet -B "$pr_head" "origin/${pr_head}"   # lossless re-point
+  echo "enter $wt_path"
+}
+
 # `enter` / `conflict` — scan local worktrees for one whose branch carries the
 # <issue>-* prefix, via the shared list_worktree_records helper (lib.sh).
 # Records arrive in `git worktree list` order, so the first matching record wins.
 while IFS= read -r line; do
   split_worktree_record "$line"
   if [[ "$WT_NUM" == "$ISSUE" ]]; then
-    if [[ "$MODE" == "explicit" ]]; then
-      echo "enter $WT_PATH"
-    elif worktree_has_live_session "$WT_PATH"; then
+    if [[ "$MODE" == "queue" ]] && worktree_has_live_session "$WT_PATH"; then
       # Queue target whose worktree a live session owns — a genuine race.
       echo "conflict $WT_PATH"
     else
-      # Queue target whose worktree is an orphan — recycle it as the target.
-      echo "enter $WT_PATH"
+      # explicit-enter, or queue-orphan recycle: reconcile the reused
+      # worktree's branch against the target PR's head branch before entering.
+      emit_enter_reconciled "$WT_PATH" "$WT_BRANCH"
     fi
     exit 0
   fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
@@ -64,7 +64,15 @@ emit_enter_reconciled() {
   fi
   if [[ -z "$pr" ]]; then echo "enter $wt_path"; return 0; fi   # no PR → unchanged
   pr_head=$(gh pr view "$pr" --json headRefName | jq -r '.headRefName // empty')
-  if [[ -z "$pr_head" || "$pr_head" == "$wt_branch" ]]; then     # same branch → no-op
+  # A PR was found, so an empty/malformed headRefName is a failed lookup, not a
+  # no-op — surfacing it as an error beats silently entering unreconciled. The
+  # format guard also blocks option/refspec injection (leading '-', '..') via
+  # this GitHub-sourced name before it reaches git fetch/rev-list/checkout.
+  if [[ -z "$pr_head" || "$pr_head" == -* || "$pr_head" == *..* || ! "$pr_head" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+    echo "error: PR #$pr returned an unusable head branch name '$pr_head' for issue $ISSUE" >&2
+    exit 1
+  fi
+  if [[ "$pr_head" == "$wt_branch" ]]; then     # already on PR head branch → no-op
     echo "enter $wt_path"; return 0
   fi
   git -C "$wt_path" fetch --quiet origin "$pr_head"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
@@ -58,7 +58,10 @@ source "$SCRIPT_DIR/lib-claude-agents.sh"
 # `enter`-bound path (explicit, and queue-orphan recycle).
 emit_enter_reconciled() {
   local wt_path="$1" wt_branch="$2" pr pr_head unique
-  pr=$("$SCRIPT_DIR/dispatch-find-pr" "$ISSUE") || pr=""
+  if ! pr=$("$SCRIPT_DIR/dispatch-find-pr" "$ISSUE"); then
+    echo "error: dispatch-find-pr failed for issue $ISSUE; cannot reconcile branch" >&2
+    exit 1
+  fi
   if [[ -z "$pr" ]]; then echo "enter $wt_path"; return 0; fi   # no PR → unchanged
   pr_head=$(gh pr view "$pr" --json headRefName | jq -r '.headRefName // empty')
   if [[ -z "$pr_head" || "$pr_head" == "$wt_branch" ]]; then     # same branch → no-op

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2616,6 +2616,34 @@ checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && echo yes || echo no)
 assert_eq "queue live-session + wrong branch → no checkout" "no" "$checkout_logged"
 teardown
 
+# 17. PR found but headRefName empty/unusable → error, not a silent enter. An
+#     empty headRefName once a PR exists is a failed lookup; entering
+#     unreconciled would defeat the reconciliation guard. The same check blocks
+#     option/refspec injection via the GitHub-sourced branch name.
+echo "Test: PR + empty headRefName → error (no silent enter, no checkout)"
+setup
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+printf '[{"number":100,"headRefName":"42-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
+echo '{"headRefName":""}' > "$STUB_DIR/pr-headref-100.json"
+if result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "PR + empty headRefName → exit 1" "1" "$rc"
+checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && echo yes || echo no)
+assert_eq "PR + empty headRefName → no checkout" "no" "$checkout_logged"
+teardown
+
+# 18. PR head branch carrying an option-injection name → error before any git
+#     call. Guards the GitHub-sourced headRefName at the external boundary.
+echo "Test: PR + injection-shaped headRefName → error (no checkout)"
+setup
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+printf '[{"number":100,"headRefName":"42-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
+echo '{"headRefName":"--upload-pack=evil"}' > "$STUB_DIR/pr-headref-100.json"
+if result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "PR + injection-shaped headRefName → exit 1" "1" "$rc"
+checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && echo yes || echo no)
+assert_eq "PR + injection-shaped headRefName → no checkout" "no" "$checkout_logged"
+teardown
+
 # ============================================================================
 # list_worktree_records (lib.sh) tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2598,6 +2598,24 @@ checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && grep -q -- "-B 42-pr-
 assert_eq "queue orphan + wrong branch → re-point checkout logged" "yes" "$checkout_logged"
 teardown
 
+# 16. queue live-session + wrong branch + PR → the live-session conflict
+#     short-circuits before reconciliation: conflict, no gh pr view, no checkout.
+#     Documents that live-session ownership takes precedence over branch identity.
+echo "Test: queue live-session + wrong branch → conflict (no reconciliation)"
+setup
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+select_target_fake_claude "42-my-feature"   # live session owns the worktree
+printf '[{"number":100,"headRefName":"42-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
+echo '{"headRefName":"42-pr-branch"}' > "$STUB_DIR/pr-headref-100.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
+assert_eq "queue live-session + wrong branch → conflict" \
+  "conflict /worktrees/42-my-feature" "$result"
+pr_view_called=$([[ -f "$STUB_DIR/gh-pr-view-headref.log" ]] && echo yes || echo no)
+assert_eq "queue live-session + wrong branch → gh pr view not called" "no" "$pr_view_called"
+checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && echo yes || echo no)
+assert_eq "queue live-session + wrong branch → no checkout" "no" "$checkout_logged"
+teardown
+
 # ============================================================================
 # list_worktree_records (lib.sh) tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -221,6 +221,16 @@ case "$args" in
       echo '{"closingIssuesReferences":[]}'
     fi
     ;;
+  pr\ view\ *\ --json\ headRefName)
+    # dispatch-resolve-worktree reconciliation: gh pr view <N> --json headRefName.
+    echo "pr view" >> "$STUB_DIR/gh-pr-view-headref.log"
+    num=$(echo "$args" | awk '{print $3}')
+    if [[ -f "$STUB_DIR/pr-headref-${num}.json" ]]; then
+      cat "$STUB_DIR/pr-headref-${num}.json"
+    else
+      echo '{"headRefName":""}'
+    fi
+    ;;
   label\ create\ *)
     # dispatch-complete-phase creates the label only when the apply reported
     # it missing.
@@ -332,6 +342,22 @@ case "$args" in
     else
       echo "/repo"
     fi
+    ;;
+  -C\ *\ fetch\ *)
+    # dispatch-resolve-worktree reconciliation: fetch the PR head branch.
+    : ;;
+  -C\ *\ rev-list\ --count\ *)
+    # dispatch-resolve-worktree reconciliation: commits unique to the worktree
+    # branch. Default 0 (lossless re-point); rev-list-count.txt overrides to N.
+    if [[ -f "$STUB_DIR/rev-list-count.txt" ]]; then
+      cat "$STUB_DIR/rev-list-count.txt"
+    else
+      echo "0"
+    fi
+    ;;
+  -C\ *\ checkout\ *)
+    # dispatch-resolve-worktree reconciliation: re-point to the PR head branch.
+    echo "$args" >> "$STUB_DIR/git-checkout.log"
     ;;
   *)
     echo "git stub: unknown invocation: $args" >&2
@@ -2495,6 +2521,81 @@ setup
 echo '{"title":"!!!"}' > "$STUB_DIR/issue-title-42.json"
 if "$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit 2>/dev/null; then rc=0; else rc=$?; fi
 assert_eq "empty-slug title exits non-zero" "1" "$rc"
+teardown
+
+# ----------------------------------------------------------------------------
+# Branch reconciliation on the `enter` path (#913). PR existence is driven via
+# pr-list-full.json (dispatch-find-pr's prefix match on headRefName); the PR
+# head branch is driven via pr-headref-<num>.json (gh pr view headRefName).
+# The git stub logs checkouts to git-checkout.log and reads the unique-commit
+# count from rev-list-count.txt (default 0).
+# ----------------------------------------------------------------------------
+
+# 11. Wrong branch + PR + no unique commits → re-point: enter AND checkout logged.
+echo "Test: reconcile wrong branch (no unique commits) → re-point + enter"
+setup
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+printf '[{"number":100,"headRefName":"42-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
+echo '{"headRefName":"42-pr-branch"}' > "$STUB_DIR/pr-headref-100.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
+assert_eq "wrong branch + no unique commits → enter" \
+  "enter /worktrees/42-my-feature" "$result"
+checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && grep -q -- "-B 42-pr-branch origin/42-pr-branch" "$STUB_DIR/git-checkout.log" && echo yes || echo no)
+assert_eq "wrong branch + no unique commits → re-point checkout logged" "yes" "$checkout_logged"
+teardown
+
+# 12. Worktree already on the PR head branch → enter, no redundant checkout.
+echo "Test: worktree already on PR branch → enter, no checkout"
+setup
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+printf '[{"number":100,"headRefName":"42-my-feature"}]\n' > "$STUB_DIR/pr-list-full.json"
+echo '{"headRefName":"42-my-feature"}' > "$STUB_DIR/pr-headref-100.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
+assert_eq "already on PR branch → enter" "enter /worktrees/42-my-feature" "$result"
+checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && echo yes || echo no)
+assert_eq "already on PR branch → no checkout" "no" "$checkout_logged"
+teardown
+
+# 13. Wrong branch + unique commits on the worktree branch → conflict.
+echo "Test: reconcile wrong branch (unique commits) → conflict"
+setup
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+printf '[{"number":100,"headRefName":"42-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
+echo '{"headRefName":"42-pr-branch"}' > "$STUB_DIR/pr-headref-100.json"
+echo "2" > "$STUB_DIR/rev-list-count.txt"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
+assert_eq "wrong branch + unique commits → conflict" \
+  "conflict /worktrees/42-my-feature" "$result"
+checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && echo yes || echo no)
+assert_eq "wrong branch + unique commits → no checkout" "no" "$checkout_logged"
+teardown
+
+# 14. No PR for the issue (implement phase) → enter unchanged: no gh pr view,
+#     no checkout.
+echo "Test: no PR → enter unchanged (no pr view, no checkout)"
+setup
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+# No pr-list-full.json: dispatch-find-pr finds no PR.
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
+assert_eq "no PR → enter" "enter /worktrees/42-my-feature" "$result"
+pr_view_called=$([[ -f "$STUB_DIR/gh-pr-view-headref.log" ]] && echo yes || echo no)
+assert_eq "no PR → gh pr view not called" "no" "$pr_view_called"
+checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && echo yes || echo no)
+assert_eq "no PR → no checkout" "no" "$checkout_logged"
+teardown
+
+# 15. queue-orphan + wrong branch + PR → reconciliation applies in queue mode too.
+echo "Test: queue orphan + wrong branch + PR → re-point + enter"
+setup
+printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
+select_target_fake_claude   # orphan: no live session owns the worktree
+printf '[{"number":100,"headRefName":"42-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
+echo '{"headRefName":"42-pr-branch"}' > "$STUB_DIR/pr-headref-100.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
+assert_eq "queue orphan + wrong branch → enter" \
+  "enter /worktrees/42-my-feature" "$result"
+checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && grep -q -- "-B 42-pr-branch origin/42-pr-branch" "$STUB_DIR/git-checkout.log" && echo yes || echo no)
+assert_eq "queue orphan + wrong branch → re-point checkout logged" "yes" "$checkout_logged"
 teardown
 
 # ============================================================================


### PR DESCRIPTION
## Summary

`dispatch-resolve-worktree` matched an existing worktree to a target purely by the issue-number prefix of its branch, while `dispatch-find-pr` resolves the target's PR through GitHub closing-linkage. When two `<issue>-*` branches exist for one issue, the worker could land on a stale branch with none of the PR's commits (observed 2026-05-29, issue #896 / PR #898: a pre-created title-slug worktree was reused for a `qa` tick, leaving `git diff origin/main...HEAD` empty).

This adds branch reconciliation to the resolver's `enter` path (explicit mode, and queue-mode orphan recycle):

- no PR for the issue (implement phase) → `enter` unchanged
- worktree already on the PR head branch → `enter` unchanged (no redundant checkout)
- worktree on a different branch with no unique commits → re-pointed losslessly to the PR head branch, then `enter`
- worktree on a different branch carrying unique commits → `conflict` (no silent discard)

The resolver's output vocabulary (`enter`/`create`/`conflict`) is unchanged, so the router and worker need no parsing changes.

## Changes

- `dispatch-resolve-worktree`: new `emit_enter_reconciled` helper on both `enter`-bound paths; restructured the match block so the queue live-session check still short-circuits to `conflict` first.
- `test-dispatch-scripts.sh`: gh stub for `pr view --json headRefName`; git stub for `-C fetch`/`rev-list --count`/`checkout`; five reconciliation tests (re-point, no-op, unique-commits conflict, no-PR unchanged, queue-mode orphan re-point).
- `SKILL.md`: documented reconciliation on the Step 5 `enter`/`conflict` bullets.

## Test plan

- [x] `.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` → 627/627 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)