### PR TITLE
fix(dispatch): skip open issues already closed by a ready PR

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -61,9 +61,10 @@
 #   3. Oldest "code-review" PR (draft + dispatch:qa-done)
 #   4. Oldest "verify"      PR (draft, CI completed and failed)
 #   5. Oldest open help-wanted issue whose <N>-* worktree, if any, is not owned
-#      by a live Claude session, resolved to a startable open leaf (an issue
-#      whose entire open-leaf subtree is worktree-conflicted is skipped, exactly
-#      as a live-session-owned worktree is)
+#      by a live Claude session, and which is not already closed by a non-draft
+#      (ready) PR (#920), resolved to a startable open leaf (an issue whose
+#      entire open-leaf subtree is worktree-conflicted is skipped, exactly as a
+#      live-session-owned worktree is)
 #   6. Oldest "qa"          PR (draft, CI green, no dispatch:* label)
 #
 # A PR or help-wanted issue is skipped only when a live Claude session owns its
@@ -77,6 +78,10 @@
 # A PR is also skipped when an issue it closes is blocked_by an open issue.
 # "done" (non-draft) PRs are skipped entirely.
 # "waiting" PRs (draft, CI still running/queued/not started) are skipped entirely.
+# An open help-wanted issue is also skipped when a non-draft (ready) PR closes it
+# (#920). A *draft* closing PR does NOT gate the issue — a stalled/orphaned draft
+# is the normal in-flight dispatch state and must leave the issue selectable so
+# the chain can resume by recycling the worktree.
 # A queue with no topic-labeled items resolves entirely to "other", reproducing
 # the flat ladder exactly.
 #
@@ -482,6 +487,20 @@ if [[ "$QA_MODE" == "true" ]]; then
   exit 0
 fi
 
+# Issue numbers closed by a non-draft (ready) open PR (#920). Such an issue has
+# reached a ready PR — the dispatch chain has terminated for it (no live worker)
+# yet GitHub keeps it open + help-wanted until the PR merges. Re-selecting it only
+# spawns a worker that derives phase "done" and wastes a tick. A *draft* closing
+# PR is deliberately excluded: a stalled/orphaned draft must leave its issue
+# selectable so the chain can resume by recycling the worktree.
+declare -A READY_PR_CLOSED_ISSUES
+while IFS= read -r closed_num; do
+  [[ -z "$closed_num" ]] && continue
+  READY_PR_CLOSED_ISSUES["$closed_num"]=1
+done < <(printf '%s' "$PR_LIST" | jq -r '
+  .[] | select(.isDraft == false)
+  | (.closingIssuesReferences // [])[].number')
+
 # First-seen help-wanted issue per category. The queue is the open-issue list
 # filtered client-side to "help wanted"; issues whose <N>-* worktree is owned
 # by a live session are skipped. Each candidate is resolved to a
@@ -495,6 +514,8 @@ ISSUE_SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r '
   | [.number, ((.labels // []) | tojson)] | @tsv')
 while IFS=$'\t' read -r issue_num issue_labels; do
   [[ -z "$issue_num" ]] && continue
+  # Skip an open issue already closed by a non-draft (ready) PR (#920).
+  [[ -n "${READY_PR_CLOSED_ISSUES[$issue_num]:-}" ]] && continue
   # Skip an issue whose <N>-* worktree is owned by a live session. An orphan
   # <N>-* worktree does not skip — it is recycled at dispatch-resolve-worktree
   # (#905).

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2033,6 +2033,43 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "office-hours PR with worktree not selected; second PR chosen" "pr 20 20-active verify" "$result"
 teardown
 
+# --- ready-PR gate (issue #920) ---------------------------------------------
+# An open help-wanted issue whose only closing PR is non-draft (ready) is
+# excluded from the issue queue. A *draft* closing PR does NOT gate the issue.
+
+# R1. Excluded by ready PR.
+# Non-draft PR closes issue 55; issue 55 (older) and issue 66 (newer) are both
+# help-wanted. Without the gate the oldest (55) would win. Assert the result is
+# issue 66 — 55 is gated out.
+echo "Test: Excluded by ready PR."
+setup
+# Non-draft (ready) PR 100 with green rollup closes issue 55.
+UNION='['"$(make_pr_union 100 "55-ready-pr" "2024-01-01T00:00:00Z" "false" "$NO_LABELS" "$GREEN_ROLLUP" '[{"number":55}]')"']'
+setup_union_pr_list "$UNION"
+# Issue 55 is older (Jan 01), issue 66 is newer (Jan 02); both help-wanted.
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":66,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "ready PR closes issue 55; issue 66 chosen instead" "issue 66" "$result"
+teardown
+
+# R2. Draft PR does not gate.
+# A draft PR (isDraft=true, pending rollup → classified waiting, dropped from
+# the ladder) closes issue 55; issue 55 is help-wanted with no worktree. Assert
+# the result is issue 55 — the draft does not exclude its issue.
+echo "Test: Draft PR does not gate."
+setup
+# Draft (isDraft=true, pending rollup) PR 100 closes issue 55.
+UNION='['"$(make_pr_union 100 "55-draft-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP" '[{"number":55}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "draft PR does not gate issue 55; issue 55 chosen" "issue 55" "$result"
+teardown
+
 # ============================================================================
 # dispatch-trace-leaf tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1726,6 +1726,47 @@ assert_eq "dispatch-trace-leaf exit 1 → select-target exits non-zero" "yes" "$
 assert_eq "dispatch-trace-leaf exit 1 → no issue line emitted" "yes" "$no_issue"
 teardown
 
+# --- ready-PR gate (#920) ---
+# An open help-wanted issue whose closing PR is non-draft (ready) is excluded
+# from the issue queue. The gate uses closingIssuesReferences from PR_LIST —
+# no extra gh call. A *draft* closing PR must NOT gate the issue.
+
+# 40. An open issue closed by a non-draft (ready) PR is excluded from the issue
+#     queue. The non-draft PR itself is skipped at the phase level (done), but
+#     the issue must also be excluded so no worker is wasted deriving "done".
+echo "Test: open issue closed by non-draft PR is excluded from issue queue (#920)"
+setup
+# Non-draft PR 10 closes issue 55 (help-wanted). PR phase will be "done" and
+# skipped in the PR loop; issue 55 must also be gated out by READY_PR_CLOSED_ISSUES.
+# Issue 66 is also help-wanted and not closed by any PR — it should be selected.
+UNION='['"$(make_pr_union 10 "10-ready-pr" "2024-01-01T00:00:00Z" "false" "$NO_LABELS" "$GREEN_ROLLUP" '[{"number":55}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":66,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "issue closed by non-draft PR excluded; next issue selected" "issue 66" "$result"
+teardown
+
+# 41. A draft closing PR does NOT gate the issue — a stalled/orphaned draft is
+#     the normal in-flight dispatch state and must leave the issue selectable so
+#     the chain can resume by recycling the worktree.
+#     To observe the issue-queue path: the draft PR is in waiting phase (pending
+#     CI), so it is skipped in the PR loop, leaving only the issue queue.
+echo "Test: open issue closed only by a draft PR is still selected (#920)"
+setup
+# Draft PR 10 (pending CI → waiting phase, skipped) closes issue 55 (help-wanted).
+# isDraft=true → must NOT gate issue 55. Waiting phase skip clears the PR from
+# the ladder, so issue 55 is the only remaining candidate.
+UNION='['"$(make_pr_union 10 "10-draft-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP" '[{"number":55}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "issue closed only by draft PR is still selectable" "issue 55" "$result"
+teardown
+
 # ============================================================================
 # --- JIT scan ---
 # dispatch-select-target's JIT scan runs before the main-broken health gate.


### PR DESCRIPTION
Closes #920

`dispatch-select-target`'s issue-queue loop selected any open `help wanted`
issue, gated only by `dispatch:office-hours` and worktree-liveness — never
checking whether the issue already had a PR. A non-draft (ready) PR is dropped
from the PR ladder, but the underlying issue stays open + help-wanted until the
PR merges and GitHub auto-closes it. In that window the dispatch chain has
terminated (no live worker), so worktree-liveness returns false and the issue is
freely re-selectable; a router selects it, spawns a worker, derives phase `done`,
and wastes a tick (observed live: #896 / PR #898).

## Change

- Build a set of issue numbers closed by non-draft open PRs from the existing
  `PR_LIST` (`isDraft` + `closingIssuesReferences` — no new `gh` call), and skip
  those issues in the issue-queue loop.
- A *draft* closing PR deliberately does NOT gate: a stalled/orphaned draft is
  the normal in-flight state and must leave the issue selectable so the chain can
  resume by recycling the worktree.
- Header doc block updated to describe the ready-PR gate.

## Tests

Two new cases in `test-dispatch-scripts.sh`: an open issue with a non-draft
closing PR is excluded; the same issue with only a *draft* closing PR is still
selected. Suite: 670/670 passing.