### PR TITLE
dispatch: gate CI-waiting PRs at the router; remove worker babysitter

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -13,7 +13,12 @@
 #   A. marker absent — phase skill did not run to completion (mid-phase exit
 #      or context compaction). Park the ISSUE on a human via
 #      dispatch-apply-office-hours (label + why-comment), spawn router, exit 0 —
-#      session parks "stopped" for human review.
+#      session parks "stopped" for human review. EXCEPTION: when the re-derived
+#      CURRENT_PHASE is `waiting`, the phase is not worker-actionable — the
+#      router owns the CI gate. Skip office-hours and just spawn the router,
+#      handing the issue back to be re-gated; the worker only reaches `waiting`
+#      via the selection/derivation race. (Office-hours would not self-heal: the
+#      dispatch queue skips office-hours issues and nothing strips the label.)
 #   B. marker present + CURRENT_PHASE non-empty + MARKER_PHASE != CURRENT_PHASE
 #      — phase advanced. Strip dispatch:office-hours from BOTH the PR (if any)
 #      and the ISSUE, spawn router, self-close. Empty CURRENT_PHASE (e.g.
@@ -125,6 +130,17 @@ self_close() {
 
 if [ -z "$MARKER_PHASE" ]; then
   # Branch A — marker absent.
+  if [ "$CURRENT_PHASE" = "waiting" ]; then
+    # `waiting` is not worker-actionable: the router owns the CI gate (queue
+    # selection and the Step 6 gate both skip `waiting` PRs). A worker only ever
+    # reaches here through the TOCTOU race — a push restarts CI between router
+    # selection and the worker's phase derivation. Hand the issue back to the
+    # router rather than parking it on a human; the next tick re-gates it and
+    # picks it up once CI concludes. (Office-hours would not self-heal — the
+    # dispatch queue skips office-hours issues and nothing strips the label.)
+    spawn_router
+    exit 0
+  fi
   "$SCRIPTS/dispatch-apply-office-hours" "$ISSUE_NUM" \
     "$(resolve_office_hours_reason "phase exited before completion (mid-phase exit or context compaction)")" \
     || echo "[dispatch-stop] WARNING: dispatch-apply-office-hours failed" >&2

--- a/.claude/skills/dispatch-propagate/SKILL.md
+++ b/.claude/skills/dispatch-propagate/SKILL.md
@@ -470,7 +470,31 @@ default cwd tracks the most-recent worker's worktree rather than
 `worktrees/main` — a recoverable UI default, accepted in exchange for
 sessions whose cwd does not silently drift. The previous arrangement — where
 the worker `cd`'d in its own Step 0 — silently broke when subsequent `Bash` /
-`Skill` calls reset cwd back to the spawn cwd. Before spawning, consult the
+`Skill` calls reset cwd back to the spawn cwd.
+
+Before anything else in this step, run the **CI-status gate**. Derive the
+target's phase with `dispatch-phase <N>` (`dangerouslyDisableSandbox: true` —
+it calls `gh`, same as the other `gh`-calling script invocations):
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-phase <N>
+```
+
+- If it returns `waiting` — the target's CI is still in progress — **skip the
+  spawn for this tick**. Do not consult the concurrency budgeter and do not run
+  `dispatch-spawn-worker`. Do **not** release the lock: it is already released
+  at the end of Step 5 (#898), so — exactly like the concurrency-cap gate —
+  this gate is lock-free. Print the mandatory user-visible report verbatim:
+
+  ```
+  #<N>: CI in progress; the next router tick will re-evaluate.
+  ```
+
+  Then proceed to Step 7 with disposition `drain ci-waiting`.
+- Otherwise — any non-`waiting` phase — fall through to the concurrency-budget
+  gate and the spawn below, unchanged.
+
+Before spawning, consult the
 concurrency budgeter (see
 *Concurrency budgeting* below). If the live worker count already meets the
 target, **skip the spawn** for this tick — the chain re-seeds on the next
@@ -639,7 +663,9 @@ The three dispositions:
 
 - **`drain <reason>`** — `drain empty-queue` (Step 3, queue empty),
   `drain worktree-conflict` (Step 5, target's worktree is owned by another
-  live session), or `drain concurrency-cap` (Step 6, `live_count >=
+  live session), `drain ci-waiting` (Step 6, the target PR's CI is still in
+  progress — `dispatch-phase` returned `waiting`; the chain re-evaluates the
+  PR on the next router tick), or `drain concurrency-cap` (Step 6, `live_count >=
   target_N` — the chain re-seeds when the cap-keyed timer fires at the next
   rate-limit window reset; see *The #725 cap-keyed re-seed* above). The call site has already printed a **mandatory** user-visible
   report stating the reason and the recovery path (templates live at the

--- a/.claude/skills/dispatch-propagate/SKILL.md
+++ b/.claude/skills/dispatch-propagate/SKILL.md
@@ -450,8 +450,10 @@ The three dispositions:
   entered — either a live session owns it, or the worktree's branch carries
   commits not on the PR head branch; see the `conflict` case in Step 5),
   `drain ci-waiting` (Step 6, the target PR's CI is still in progress —
-  `dispatch-phase` returned `waiting`; the chain re-evaluates the PR on the
-  next router tick), or `drain concurrency-cap` (Step 6, `live_count >=
+  `dispatch-phase` returned `waiting`; unlike `drain concurrency-cap` this
+  schedules no re-seed — the chain re-evaluates the PR on the next router tick
+  from an existing source: a worker's Stop hook, the #725 cap-keyed timer, or a
+  manual `/dispatch`), or `drain concurrency-cap` (Step 6, `live_count >=
   target_N` — the chain re-seeds when the cap-keyed timer fires at the next
   rate-limit window reset; see *The #725 cap-keyed re-seed* below). The call site has already printed a **mandatory** user-visible
   report stating the reason and the recovery path (templates live at the

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -8141,6 +8141,37 @@ else
 fi
 stop_teardown
 
+# --- Test 5b: marker absent + CURRENT_PHASE waiting → spawn only, no office-hours
+
+echo "Test: stop hook + marker absent + phase waiting → spawn only, no office-hours (router-defer, not worker-actionable)"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "456" > "$STUB_DIR/find-pr-output"
+echo "waiting" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+# No phase-completed marker → branch A; CURRENT_PHASE waiting → exemption.
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+"$TMPDIR_TEST/hooks/dispatch-stop.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "stop waiting-exempt: hook exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/apply-office-hours.log" && ! -e "$STUB_DIR/gh-pr-edit.log" \
+   && ! -e "$STUB_DIR/gh-issue-edit.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop waiting-exempt: no office-hours apply (no add-label)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop waiting-exempt: no office-hours apply (no add-label)"
+  echo "    apply-log: $(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)"
+fi
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "stop waiting-exempt: spawn invoked exactly once" "1" "$spawn_calls"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/self-close-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop waiting-exempt: self-close not invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop waiting-exempt: self-close not invoked"
+fi
+stop_teardown
+
 # --- Test 6: CLAUDE_JOB_DIR unset → no-op ------------------------------------
 
 echo "Test: stop hook + CLAUDE_JOB_DIR unset → no-op (interactive session excluded)"

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -94,7 +94,6 @@ Map the phase:
 |---|---|---|
 | `implement` | no PR on the target | relevance review (Step 3), then dispatch its verdict |
 | `verify` | draft PR, CI completed and failed | `/verify-pr` |
-| `waiting` | draft PR, CI in progress (running/queued/not started) | monitor CI to completion with a `sonnet` subagent, then re-derive the phase and dispatch it (Step 2) |
 | `qa` | draft PR, CI green, no `dispatch:*` label | `/dispatch-qa` |
 | `code-review` | draft PR + `dispatch:qa-done` | `/code-review-fix` (applies `dispatch:code-reviewed` itself) |
 | `review` | draft PR + `dispatch:code-reviewed` | `/review-fix` (applies `dispatch:reviewed` itself) |
@@ -106,31 +105,20 @@ Map the phase:
 Invoke the one mapped phase skill via the Skill tool. Run exactly one phase per
 `/dispatch-worker` invocation.
 
+**Race-window check first.** If `dispatch-phase <N>` returns `waiting` — CI
+transitioned back to in-progress since the router selected this target (e.g. a
+new push between selection and worker derivation) — stop with no marker and
+print the user-visible report verbatim: `#<N>: CI transitioned back to waiting
+since router selection; next router tick will re-derive.` Apply no
+`dispatch:office-hours` and spawn no babysitter — the router's queue skips
+`waiting` PRs until CI concludes, and the Stop hook spawns a fresh router.
+
 - **`implement`** — run the Step 3 relevance review and dispatch the verdict it
   returns (`proceed` / `adjust` / `stop` — see Step 3). The draft PR's existence
   plus its CI status is its own marker — `/plan-implement` gets **no**
   `dispatch:*` label.
 - **`verify`** — invoke `/verify-pr`. It runs a single pass: fix one set of
   failed CI checks, record the outcome, post it, stop. No label.
-- **`waiting`** — CI checks are still running or queued. Monitor them to
-  completion, then re-derive and dispatch the resolved phase within this same
-  `/dispatch-worker` invocation:
-  1. Resolve the draft PR number for the target.
-  2. Spawn a subagent via the Agent tool (`subagent_type: general-purpose`,
-     `model: sonnet`) that:
-     - first waits for CI to register at least one check — a freshly-pushed
-       branch can briefly have an empty check rollup;
-     - then runs `.claude/skills/dispatch-propagate/scripts/run-pr-checks-wait.sh
-       <pr-num>` with `dangerouslyDisableSandbox: true`, which blocks until
-       every check concludes;
-     - returns once all checks have completed.
-  3. After the subagent returns, re-run Step 1 (`dispatch-phase`) to re-derive
-     the phase from the now-complete CI, then dispatch the resolved phase per
-     this step — `/verify-pr` if any check failed, otherwise the green-CI
-     phases (`qa` / `code-review` / `review` / `security` / `ready`).
-  4. If the re-derived phase is still `waiting` (CI never registered any
-     check), stop; the Stop hook applies `dispatch:office-hours` to the
-     issue because no marker was written. Do not loop.
 - **`qa`** — invoke `/dispatch-qa`. It owns and applies `dispatch:qa-done`
   itself on a clean pass; `/dispatch-worker` applies no label.
 - **`code-review`** — invoke `/code-review-fix`. It runs `/code-review max`,

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -110,8 +110,11 @@ transitioned back to in-progress since the router selected this target (e.g. a
 new push between selection and worker derivation) — stop with no marker and
 print the user-visible report verbatim: `#<N>: CI transitioned back to waiting
 since router selection; next router tick will re-derive.` Apply no
-`dispatch:office-hours` and spawn no babysitter — the router's queue skips
-`waiting` PRs until CI concludes, and the Stop hook spawns a fresh router.
+`dispatch:office-hours` and spawn no babysitter — `waiting` is not
+worker-actionable; the router owns the CI gate. The Stop hook's marker-absent
+branch recognizes a re-derived `waiting` phase and hands the issue back to the
+router (spawns a fresh router **without** applying `dispatch:office-hours`),
+which re-gates it and picks it up once CI concludes.
 
 - **`implement`** — run the Step 3 relevance review and dispatch the verdict it
   returns (`proceed` / `adjust` / `stop` — see Step 3). The draft PR's existence


### PR DESCRIPTION
Closes #906

Makes the CI-`waiting` condition a uniform router-side skip instead of a worker-side phase that spawns a sonnet babysitter holding a concurrency slot and worktree for the whole CI run.

## Changes

**Router (`.claude/skills/dispatch-propagate/SKILL.md`)**
- Step 6: new CI-status gate at the top of the step, before the concurrency-budget gate. Runs `dispatch-phase <N>`; if `waiting`, skips the spawn for the tick (does not consult the budgeter, does not run `dispatch-spawn-worker`, does not release the lock — already released at end of Step 5 per #898), prints `#<N>: CI in progress; the next router tick will re-evaluate.`, and proceeds to Step 7 with `drain ci-waiting`.
- Step 7: documents the new `drain ci-waiting` disposition.

**Worker (`.claude/skills/dispatch-worker/SKILL.md`)**
- Step 1: removed the `waiting` row from the phase-map table.
- Step 2: removed the `waiting` monitor-and-re-derive bullet and its "still waiting → apply office-hours" failsafe; added a one-line race-window defensive check that stops with no marker (and no `dispatch:office-hours`) when `dispatch-phase` returns `waiting` after router selection.

Net effect: no concurrency slot or worktree held for the duration of a CI run, and no office-hours mis-route for a condition that just needed time. The chain re-picks CI-completed PRs on the next router tick.

## Out of scope (unchanged, no regression)
`dispatch-select-target` (already skips `waiting`), `dispatch-phase` (still returns `waiting` for the three cases), `run-pr-checks-wait.sh` (still used by `/verify-pr`), the `/dispatch` shim, and `test-dispatch-scripts.sh`.

## Test plan
- [ ] `test-dispatch-scripts.sh` passes (701/701 locally)
- [ ] Explicit `/dispatch <N>` against a CI-pending PR exits without spawning a worker and emits `drain ci-waiting`
- [ ] A queue-selected chain with one CI-pending PR and no other work pauses with `drain empty-queue`; a later human `/dispatch` after CI goes green selects and dispatches it