### PR TITLE
dispatch: phase-skill deviation detection writes the office-hours reason file

### DIFF
--- a/.claude/skills/code-review-fix/SKILL.md
+++ b/.claude/skills/code-review-fix/SKILL.md
@@ -171,20 +171,39 @@ steps in order.
    `dispatch:security-reviewed` — so `/dispatch-propagate` does not apply the label after
    this skill returns.
 
-8. **Write the phase-completed marker, then stop.** The Stop hook
-   (`.claude/hooks/dispatch-stop.sh`) reads this to decide propagate vs park.
-   Atomic via tempfile + mv. `CLAUDE_JOB_DIR` unset = interactive run; skip.
+8. **Check for deviation, then write the marker (or reason) and stop.**
 
-   ```bash
-   if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
-     printf 'phase=code-review\npr=%s\n' "$PR_NUM" \
-       > "$CLAUDE_JOB_DIR/phase-completed.tmp"
-     mv "$CLAUDE_JOB_DIR/phase-completed.tmp" \
-        "$CLAUDE_JOB_DIR/phase-completed"
-   fi
-   ```
+   **Deviation criterion:** the Deferred bucket dominated — nearly all findings
+   were Deferred and none were Fixed.
 
-   Then **stop**. The Stop hook reads the marker and advances the chain.
+   - **Deviation fires** → do NOT write `phase-completed`. Instead write a
+     one-line reason so the Stop hook can surface it in the office-hours
+     comment. The Stop hook reads marker-absence as Branch A and applies
+     `dispatch:office-hours` to the issue, parking it for human review.
+
+     ```bash
+     if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
+       printf '%s\n' "/code-review-fix: findings dominated by Deferred (out-of-scope) items; none fixed" \
+         > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
+       mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" \
+          "$CLAUDE_JOB_DIR/office-hours-reason"
+     fi
+     ```
+
+   - **No deviation** → write the `phase-completed` marker as normal.
+     Atomic via tempfile + mv. `CLAUDE_JOB_DIR` unset = interactive run; skip.
+
+     ```bash
+     if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
+       printf 'phase=code-review\npr=%s\n' "$PR_NUM" \
+         > "$CLAUDE_JOB_DIR/phase-completed.tmp"
+       mv "$CLAUDE_JOB_DIR/phase-completed.tmp" \
+          "$CLAUDE_JOB_DIR/phase-completed"
+     fi
+     ```
+
+   Then **stop**. The Stop hook reads the marker (or its absence) and either
+   advances the chain or parks the issue.
 
 ## Finding classification
 

--- a/.claude/skills/code-review-fix/SKILL.md
+++ b/.claude/skills/code-review-fix/SKILL.md
@@ -31,7 +31,7 @@ PR_NUM=$(echo "$PR_JSON" | jq -r .number)
 echo "$PR_JSON" | jq -r '.labels[].name'
 ```
 
-`PR_NUM` is carried through to Steps 5, 6, and 7 — do not re-resolve. The PR body
+`PR_NUM` is carried through to Steps 5, 6, 7, and 8 — do not re-resolve. The PR body
 stays in `PR_JSON` (`echo "$PR_JSON" | jq -r .body`); Step 5 parses its
 `Closes #N` line(s) to resolve the issue(s) this PR implements. If the PR
 already carries the `dispatch:code-reviewed` label — an interrupted prior run —

--- a/.claude/skills/dispatch-qa/SKILL.md
+++ b/.claude/skills/dispatch-qa/SKILL.md
@@ -256,6 +256,18 @@ The QA pass covers **public data only** — documents present in both the QA ser
       so the bug-fix path parks for human review until the fix is QA'd
       again on the next `/dispatch` tick.
 
+      Write a one-line reason to `$CLAUDE_JOB_DIR/office-hours-reason` so the
+      office-hours why-comment names the criterion that fired:
+
+      ```bash
+      if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
+        printf '%s\n' "/dispatch-qa: QA found a bug, fixed in-session; parking for re-QA on the next tick" \
+          > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
+        mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" \
+           "$CLAUDE_JOB_DIR/office-hours-reason"
+      fi
+      ```
+
       The skill ends here — Steps 6 and 7 already ran
       inline in sub-step 1, and Step 8 does not run on the bug-fix path.
 

--- a/.claude/skills/plan-implement/SKILL.md
+++ b/.claude/skills/plan-implement/SKILL.md
@@ -72,11 +72,35 @@ The body has one `Closes #N` line per issue implemented in this PR — the prima
 issue plus any implemented sub-issues or blockers. This draft PR is the
 implement→verify transition marker.
 
-### 4. Write the phase-completed marker, then stop
+### 4. Check for deviation, then write the marker (or skip it), then stop
 
-Write the phase-completed marker as the final action so the Stop hook
-(`.claude/hooks/dispatch-stop.sh`) can read it and propagate the dispatch
-chain. Atomic via tempfile + mv so the hook never sees a partial file.
+Before writing the marker, judge whether the implementation deviated from the
+approved plan — scope shifted mid-implementation, or the plan could not be
+fully implemented as approved. Base this on the `/implement-unit` outcomes
+observed in Step 2.
+
+**Deviation fires** — skip the `phase-completed` marker. Instead write a
+one-line deviation reason to `$CLAUDE_JOB_DIR/office-hours-reason`, atomic via
+tempfile + mv, under the same `CLAUDE_JOB_DIR` guard. The draft PR opened in
+Step 3 stays open. The Stop hook reads marker-absence as Branch A, applies
+`dispatch:office-hours` to the issue (surfacing this reason in the
+why-comment), and parks the issue for human review.
+
+```bash
+if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
+  printf '%s\n' "/plan-implement: implementation deviated from the approved plan" \
+    > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
+  mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" \
+     "$CLAUDE_JOB_DIR/office-hours-reason"
+fi
+```
+
+Use the default phrasing above, or make it more specific when the nature of
+the shift is clear (e.g. `/plan-implement: unit 3 scope expanded to cover
+auth; approved plan did not include auth changes`).
+
+**No deviation** — write the `phase-completed` marker as the final action.
+Atomic via tempfile + mv so the hook never sees a partial file.
 `CLAUDE_JOB_DIR` unset = interactive run; skip.
 
 ```bash

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -29,7 +29,7 @@ PR_NUM=$(echo "$PR_JSON" | jq -r .number)
 echo "$PR_JSON" | jq -r '.labels[].name'
 ```
 
-`PR_NUM` is reused in Steps 3, 7, and 8 — do not re-resolve. The PR body stays in
+`PR_NUM` is reused in Steps 3, 7, 8, and 11 — do not re-resolve. The PR body stays in
 `PR_JSON` (`echo "$PR_JSON" | jq -r .body`); Step 5 parses its `Closes #N`
 line(s) to resolve the issue(s) this PR implements. If the printed labels include
 `dispatch:reviewed` — an interrupted prior run — **skip Steps 1–10 entirely** and
@@ -220,7 +220,9 @@ already applied, so re-entry is a true no-op. Otherwise run all steps in order.
     only), then stop.** The Stop hook (`.claude/hooks/dispatch-stop.sh`) reads
     this to decide propagate vs park. `CLAUDE_JOB_DIR` unset = interactive run;
     the write is a no-op and the skill simply stops (which is correct —
-    interactive Step 10 just ran).
+    interactive Step 10 just ran). On idempotent re-entry (Steps 1–10 were
+    skipped), the Step 3 bucket data is not in context — treat the deviation
+    criterion as not met and write the phase-completed marker.
 
     **Deviation criterion:** the Deferred bucket dominated — nearly all findings
     were Deferred and none were Fixed.

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -216,22 +216,43 @@ already applied, so re-entry is a true no-op. Otherwise run all steps in order.
     `/commit-merge-push` to commit and push it, and document it on the PR with
     a comment using Step 7's mechanism.
 
-11. **Write the phase-completed marker (autonomous path only), then stop.**
-    The Stop hook (`.claude/hooks/dispatch-stop.sh`) reads this to decide
-    propagate vs park. Atomic via tempfile + mv. `CLAUDE_JOB_DIR` unset =
-    interactive run; the marker write is a no-op and the skill simply stops
-    (which is correct — interactive Step 10 just ran).
+11. **Write the phase-completed marker or deviation reason (autonomous path
+    only), then stop.** The Stop hook (`.claude/hooks/dispatch-stop.sh`) reads
+    this to decide propagate vs park. `CLAUDE_JOB_DIR` unset = interactive run;
+    the write is a no-op and the skill simply stops (which is correct —
+    interactive Step 10 just ran).
 
-    ```bash
-    if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
-      printf 'phase=review\npr=%s\n' "$PR_NUM" \
-        > "$CLAUDE_JOB_DIR/phase-completed.tmp"
-      mv "$CLAUDE_JOB_DIR/phase-completed.tmp" \
-         "$CLAUDE_JOB_DIR/phase-completed"
-    fi
-    ```
+    **Deviation criterion:** the Deferred bucket dominated — nearly all findings
+    were Deferred and none were Fixed.
 
-    Then **stop**. The Stop hook reads the marker and advances the chain.
+    - **Deviation fires** — do NOT write `phase-completed`. Instead write a
+      one-line reason to `$CLAUDE_JOB_DIR/office-hours-reason`, atomic via
+      tempfile + mv. The Stop hook reads marker-absence as Branch A and applies
+      `dispatch:office-hours` to the issue, parking it for human review.
+
+      ```bash
+      if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
+        printf '%s\n' "/review-fix: findings dominated by Deferred (out-of-scope) items; none fixed" \
+          > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
+        mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" \
+           "$CLAUDE_JOB_DIR/office-hours-reason"
+      fi
+      ```
+
+    - **No deviation** — write the `phase-completed` marker exactly as before,
+      atomic via tempfile + mv.
+
+      ```bash
+      if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
+        printf 'phase=review\npr=%s\n' "$PR_NUM" \
+          > "$CLAUDE_JOB_DIR/phase-completed.tmp"
+        mv "$CLAUDE_JOB_DIR/phase-completed.tmp" \
+           "$CLAUDE_JOB_DIR/phase-completed"
+      fi
+      ```
+
+    Then **stop**. The Stop hook reads the marker (or its absence) and advances
+    or parks the chain.
 
 ## Autonomous vs. attended
 

--- a/.claude/skills/security-review-fix/SKILL.md
+++ b/.claude/skills/security-review-fix/SKILL.md
@@ -260,7 +260,7 @@ ready. Otherwise run all steps in order.
    The Stop hook (`.claude/hooks/dispatch-stop.sh`) reads marker-absence as
    Branch A and applies `dispatch:office-hours` to the issue, surfacing the
    reason in the why-comment, so the parked item explains which criterion
-   fired. Do not call `gh pr edit --add-label dispatch:office-hours` — the
+   fired. Do not apply the `dispatch:office-hours` label inline — the
    Stop hook owns label application.
 
    **No deviation** (all high-confidence `required` findings resolved, or none

--- a/.claude/skills/security-review-fix/SKILL.md
+++ b/.claude/skills/security-review-fix/SKILL.md
@@ -242,7 +242,9 @@ ready. Otherwise run all steps in order.
    Check for deviation first: if any finding classified `required` with
    Confidence `high` remains unresolved after the Step 3 fix pass, the
    deviation criterion fires. `CLAUDE_JOB_DIR` unset = interactive run; skip
-   both branches.
+   both branches. On idempotent re-entry (Steps 1–6 were skipped), the Step 3
+   finding set is not in context — treat the deviation criterion as not met and
+   write the marker.
 
    **Deviation fires** (a high-confidence `required` finding is still
    unresolved) — skip the phase-completed marker. Write a one-line reason
@@ -322,4 +324,7 @@ goes ready — the per-phase PR-comment summaries are the audit trail. This is a
 intentional trade-off for an autonomous `/dispatch-propagate` background-job run.
 
 The skill is idempotent: a re-invocation with `dispatch:security-reviewed` already
-on the PR skips Steps 1–6 and only ensures the PR is ready (Step 7).
+on the PR skips Steps 1–6, ensures the PR is ready (Step 7), and then runs the
+deviation check at Step 8. On re-entry the Step 3 finding set is not in context;
+treat the deviation criterion as not met (no unresolved findings visible) and
+write the phase-completed marker.

--- a/.claude/skills/security-review-fix/SKILL.md
+++ b/.claude/skills/security-review-fix/SKILL.md
@@ -237,9 +237,34 @@ ready. Otherwise run all steps in order.
 
    This is the workflow's terminal PR-state action.
 
-8. **Write the phase-completed marker, then stop.** The Stop hook
-   (`.claude/hooks/dispatch-stop.sh`) reads this to decide propagate vs park.
-   Atomic via tempfile + mv. `CLAUDE_JOB_DIR` unset = interactive run; skip.
+8. **Write the phase-completed marker (or park on deviation), then stop.**
+
+   Check for deviation first: if any finding classified `required` with
+   Confidence `high` remains unresolved after the Step 3 fix pass, the
+   deviation criterion fires. `CLAUDE_JOB_DIR` unset = interactive run; skip
+   both branches.
+
+   **Deviation fires** (a high-confidence `required` finding is still
+   unresolved) — skip the phase-completed marker. Write a one-line reason
+   instead, atomic via tempfile + mv:
+
+   ```bash
+   if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
+     printf '%s\n' "/security-review-fix: high-confidence required finding(s) left unresolved after fixes" \
+       > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
+     mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" \
+        "$CLAUDE_JOB_DIR/office-hours-reason"
+   fi
+   ```
+
+   The Stop hook (`.claude/hooks/dispatch-stop.sh`) reads marker-absence as
+   Branch A and applies `dispatch:office-hours` to the issue, surfacing the
+   reason in the why-comment, so the parked item explains which criterion
+   fired. Do not call `gh pr edit --add-label dispatch:office-hours` — the
+   Stop hook owns label application.
+
+   **No deviation** (all high-confidence `required` findings resolved, or none
+   existed) — write the phase-completed marker, atomic via tempfile + mv:
 
    ```bash
    if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
@@ -251,8 +276,9 @@ ready. Otherwise run all steps in order.
    ```
 
    Then **stop**. The Stop hook reads the marker and advances the chain.
-   `gh pr ready` (Step 7) is still the workflow's terminal *PR-state* action,
-   but the marker write is the dispatch chain's hand-off cue.
+   `gh pr ready` (Step 7) is still the workflow's terminal *PR-state* action
+   and runs regardless of deviation — only the marker is skipped when the
+   deviation criterion fires.
 
 ## Per-finding schema
 


### PR DESCRIPTION
Closes #826

Wires a per-skill deviation criterion into each of the five dispatch phase
skills. On deviation a skill skips the `$CLAUDE_JOB_DIR/phase-completed` marker
and writes a one-line reason to `$CLAUDE_JOB_DIR/office-hours-reason`; the Stop
hook (`dispatch-stop.sh`, #868) reads marker-absence and applies
`dispatch:office-hours` to the issue via `dispatch-apply-office-hours` (#909),
surfacing the reason in the why-comment. No skill applies the label inline.

Per-skill criteria:

- `/plan-implement` — implementation deviated from the approved plan.
- `/dispatch-qa` — QA found a bug, fixed in-session; parks for re-QA (reason
  added to the pre-existing marker-skip path).
- `/code-review-fix` — the Deferred bucket dominated the findings; none fixed.
- `/review-fix` — analogous Deferred-dominated criterion.
- `/security-review-fix` — a high-confidence required finding left unresolved
  after fixes.

`/verify-pr` is out of scope — #831 folded its non-advancement invariant into
the Stop hook's Branch D.

Markdown-only changes to five sibling SKILL.md files, one commit each.

## Test plan

- [ ] Static audit: \`grep -rn \"add-label dispatch:office-hours\"\` across the five skills returns zero matches.
- [ ] Each of the five SKILL.md files writes \`office-hours-reason\` on its deviation branch.
- [ ] Each non-deviation branch still writes the \`phase-completed\` marker.
- [ ] End-to-end (live dispatch chain): a run that fires a criterion ends with \`dispatch:office-hours\` on the issue and an office-hours comment naming the criterion.