### PR TITLE
dispatch: fix pr-row worktree resolution keying on PR number instead of issue number

### DIFF
--- a/.claude/skills/dispatch-propagate/SKILL.md
+++ b/.claude/skills/dispatch-propagate/SKILL.md
@@ -152,9 +152,13 @@ but do not stop; continue to target selection.
 
   Route on `$SELECTED`:
 
-  - `pr <num> <branch> <phase>` — a PR to work on; `<phase>` is pre-derived by
-    the selection scan, so Step 6 reuses it instead of re-deriving. Proceed to
-    Step 5 with mode `queue`.
+  - `pr <num> <branch> <phase>` — a PR to work on; `<num>` is the **PR** number
+    and `<phase>` is pre-derived by the selection scan, so Step 6 reuses it
+    instead of re-deriving. The worktree-resolution key is the **issue** the PR
+    closes, not the PR number: set `N=${branch%%-*}` (the branch's `<issue>-`
+    prefix, mirroring `dispatch-select-target`'s own `${pr_branch%%-*}`) and use
+    that `N` — never the PR `<num>` — for Steps 5 and 6. Proceed to Step 5 with
+    mode `queue`.
   - `issue <num>` — a `help wanted` issue to implement, pre-resolved by the
     selection scan to a startable open leaf (not necessarily the top-level
     `help wanted` issue). Proceed to Step 5 with mode `queue`.
@@ -243,6 +247,11 @@ an explicit `/dispatch-propagate` argument, otherwise `queue`:
 ```bash
 .claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree <N> <explicit|queue>
 ```
+
+Here `<N>` is always the **issue** number, never a PR number. For a `pr` row it
+is the branch-prefix `N` set in Step 3, not the row's PR `<num>`;
+`dispatch-resolve-worktree` rejects a PR number with a clear error rather than
+fabricate a stray `<pr-num>-*` worktree from `origin/main` (#926).
 
 It prints exactly one decision line — act on it. Each branch resolves a
 worktree path that Step 6 passes to `dispatch-spawn-worker`.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
@@ -37,6 +37,12 @@
 # accepted form ^[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$, full name <= 32 characters.
 #
 # A bad argument or a failed `gh issue view` is a clear error, not a fallback.
+#
+# This script is issue-keyed. A PR number passed as `<issue-num>` is rejected up
+# front (#926): the REST issues endpoint serves PRs too, and a PR's JSON carries
+# a "pull_request" key (the same discriminator dispatch-resolve-arg uses). Caller
+# must pass the PR's closing-issue number, not the PR number — otherwise the
+# create path would fabricate a stray <pr-num>-* worktree from origin/main.
 set -euo pipefail
 
 ISSUE="${1:-}"
@@ -44,6 +50,14 @@ MODE="${2:-}"
 
 if [[ ! "$ISSUE" =~ ^[1-9][0-9]*$ ]] || [[ "$MODE" != "explicit" && "$MODE" != "queue" ]]; then
   echo "error: usage: dispatch-resolve-worktree <issue-num> <explicit|queue>" >&2
+  exit 1
+fi
+
+# Reject a PR number passed as the issue key (#926). The gh call's stderr is
+# suppressed and a gh failure (404 / network) falls through to downstream
+# handling — only a definitive "pull_request" key trips the guard.
+if gh api "repos/{owner}/{repo}/issues/$ISSUE" 2>/dev/null | jq -e 'has("pull_request")' > /dev/null; then
+  echo "error: #$ISSUE is a PR, not an issue; pass the PR's closing-issue number to dispatch-resolve-worktree" >&2
   exit 1
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2802,6 +2802,46 @@ checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && echo yes || echo no)
 assert_eq "PR + injection-shaped headRefName → no checkout" "no" "$checkout_logged"
 teardown
 
+# ----------------------------------------------------------------------------
+# PR-number-as-issue-key rejection (#926). The REST issues endpoint serves PRs
+# too; a PR's JSON carries a "pull_request" key (the same discriminator
+# dispatch-resolve-arg uses). A PR number passed as the issue key must be
+# rejected up front — never slugged into a stray <pr-num>-* worktree. The #922
+# scenario: PR 922 lives on branch 918-dispatch-move and closes issue 918, so
+# PR number and closing-issue number differ.
+# ----------------------------------------------------------------------------
+
+# 19a. PR number passed as the issue key → reject before the create-path slug.
+#      arg-issue-922.json carries "pull_request"; an issue-title-922.json is also
+#      seeded so the test proves the guard fires *before* the create path (no
+#      decision line despite a usable title fixture).
+echo "Test: PR number as issue key → reject (no stray <pr-num>-* worktree)"
+setup
+echo '{"number":922,"pull_request":{"url":"https://api.github.com/repos/o/r/pulls/922"}}' \
+  > "$STUB_DIR/arg-issue-922.json"
+echo '{"title":"some pr title"}' > "$STUB_DIR/issue-title-922.json"
+if result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 922 queue 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "PR number as issue key → exit 1" "1" "$rc"
+assert_eq "PR number as issue key → no decision line" "" "$result"
+teardown
+
+# 19b. The PR's closing-issue number (918) resolves the real <issue>-* worktree.
+#      arg-issue-918.json has NO "pull_request" key, so the guard is skipped; the
+#      orphan 918-dispatch-move worktree is entered (PR 922's headRefName matches
+#      the worktree branch, so reconciliation is a no-op).
+echo "Test: PR closing-issue number → enter the real <issue>-* worktree"
+setup
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/918-dispatch-move\nHEAD def456\nbranch refs/heads/918-dispatch-move\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+select_target_fake_claude   # orphan: no live session owns the worktree
+echo '{"number":918}' > "$STUB_DIR/arg-issue-918.json"
+printf '[{"number":922,"headRefName":"918-dispatch-move"}]\n' > "$STUB_DIR/pr-list-full.json"
+echo '{"headRefName":"918-dispatch-move"}' > "$STUB_DIR/pr-headref-922.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 918 queue)
+assert_eq "PR closing-issue number → enter real worktree" \
+  "enter /worktrees/918-dispatch-move" "$result"
+teardown
+
 # ============================================================================
 # list_worktree_records (lib.sh) tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2842,6 +2842,22 @@ assert_eq "PR closing-issue number → enter real worktree" \
   "enter /worktrees/918-dispatch-move" "$result"
 teardown
 
+# 19c. PR number passed as issue key with a stale <pr-num>-* worktree on disk.
+#      The guard fires BEFORE the worktree scan, so the stale 922-* worktree is
+#      never entered — this is the main correctness rationale for placing the guard
+#      before the scan rather than only before the create path.
+echo "Test: PR number as issue key + stale stray worktree → reject (no enter)"
+setup
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/922-stray\nHEAD fff999\nbranch refs/heads/922-stray\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+echo '{"number":922,"pull_request":{"url":"https://api.github.com/repos/o/r/pulls/922"}}' \
+  > "$STUB_DIR/arg-issue-922.json"
+select_target_fake_claude   # orphan: no live session (liveness is irrelevant — guard fires first)
+if result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 922 queue 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "PR number + stale stray worktree → exit 1" "1" "$rc"
+assert_eq "PR number + stale stray worktree → no decision line" "" "$result"
+teardown
+
 # ============================================================================
 # list_worktree_records (lib.sh) tests
 # ============================================================================


### PR DESCRIPTION
Closes #926

For a queue `pr <num> <branch> <phase>` row, the only number is the PR number, but `/dispatch-propagate` Step 5 passed it to the issue-keyed `dispatch-resolve-worktree`. Since the REST issues endpoint silently serves PRs too, the create path slugged a stray `<pr-num>-*` branch from `origin/main`, stranding the PR's real `<issue>-*` worktree and mis-deriving the phase as `implement`.

## Changes (all under `.claude/skills/dispatch-propagate/`)

- **SKILL.md** — router keys Step 5/6 on the issue the PR closes (`N=${branch%%-*}`, mirroring `dispatch-select-target`'s `${pr_branch%%-*}`), never the PR number. Step 5 intro documents that `<N>` is always an issue number.
- **scripts/dispatch-resolve-worktree** — fail-loud guard rejecting an argument GitHub resolves to a PR, via the `has("pull_request")` discriminator already used by `dispatch-resolve-arg`. A gh failure (404/network) falls through; only a definitive `pull_request` key trips it.
- **scripts/test-dispatch-scripts.sh** — regression test 19(a)/(b) covering the #922 scenario where PR number (922) and closing-issue number (918) differ.

## Test plan

- [ ] `bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` — 704/704 pass, including new 19(a)/(b)