### PR TITLE
dispatch: session-scope the tmp/dispatch-worktree marker (#928)

### DIFF
--- a/.claude/skills/dispatch-propagate/SKILL.md
+++ b/.claude/skills/dispatch-propagate/SKILL.md
@@ -60,10 +60,11 @@ The lock covers **Steps 0-5 only**; Step 6 (the worker spawn) runs with the lock
 - **Proceed path** — as the final action of Step 5, run
   `dispatch-finalize-selection "$WORKTREE_PATH"`. The wrapper takes the target
   worktree path as its one required argument, `cd`s into it, writes the
-  `tmp/dispatch-worktree` marker (see *Step 5* and the marker paragraph below),
-  and execs `dispatch-acquire-lock --release` in one step. The `cd`-first
-  contract is why the router never accidentally writes the marker into its
-  own cwd — the wrapper is the sole Step-5 marker writer on the proceed path.
+  `tmp/dispatch-worktree` marker carrying the finalizing holder's
+  `CLAUDE_CODE_SESSION_ID` (see *Step 5* and the marker paragraph below), and
+  execs `dispatch-acquire-lock --release` in one step. The `cd`-first contract
+  is why the router never accidentally writes the marker into its own cwd —
+  the wrapper is the sole Step-5 marker writer on the proceed path.
 - **Every Steps 1-5 stop path** — immediately before reporting the stop reason
   and proceeding to Step 7, run
   `.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock --release` directly.
@@ -76,10 +77,16 @@ Both calls need `dangerouslyDisableSandbox: true` (same reason as Step 0); they
 print `released` or `noop`, both fine, so the skill does not branch on the output.
 
 Releasing after Step 5 is safe, and the `tmp/dispatch-worktree` marker is the
-canonical post-Step-5 reclaim signal; see reference.md (*Releasing the lock*
-and *Per-worktree invariant*) for the safety argument, marker/reclaim
-semantics, and the two orthogonal lock scopes. Later steps cross-reference
-*Releasing the lock* rather than repeating these commands.
+canonical post-Step-5 reclaim signal. The marker is session-scoped: a later
+tick reclaims a foreign holder via the marker **only** when the marker's
+content equals the recorded holder's `CLAUDE_CODE_SESSION_ID`. A marker naming
+an older, since-finalized session — or an empty marker (the `touch` stamped by
+`.claude/hooks/worktree-create.sh` on every worktree creation) — never reclaims
+a live mid-selection holder, so a stale marker cannot defeat the lock for
+co-located sessions. See reference.md (*Releasing the lock* and *Per-worktree
+invariant*) for the safety argument, marker/reclaim semantics, and the two
+orthogonal lock scopes. Later steps cross-reference *Releasing the lock* rather
+than repeating these commands.
 
 ## 1. Sync local main with `origin/main`
 
@@ -311,12 +318,16 @@ worktree path that Step 6 passes to `dispatch-spawn-worker`.
 As the **final action of this step on every non-`conflict` (proceed) path** —
 before Step 6 — run `dispatch-finalize-selection "$WORKTREE_PATH"`. The
 wrapper `cd`s into the target worktree, writes the recovery marker
-**inside the target worktree** (`$WORKTREE_PATH/tmp/dispatch-worktree`), and
-releases the lock in one step (see *Releasing the lock*). The worker in Step 6
-onward runs lock-free.
+**inside the target worktree** (`$WORKTREE_PATH/tmp/dispatch-worktree`) with the
+finalizing holder's `CLAUDE_CODE_SESSION_ID` as its content, and releases the
+lock in one step (see *Releasing the lock*). The worker in Step 6 onward runs
+lock-free.
 
 The marker is the canonical "Step 5 completed" signal used by the lock script's
-post-Step-5 reclaim path; see reference.md (*Step 5 marker deep dive*).
+post-Step-5 reclaim path. It is session-scoped: reclaim fires only when the
+marker's content equals the recorded holder's sessionId, so a stale or empty
+marker never reclaims a live holder. See reference.md (*Step 5 marker deep
+dive*).
 
 ## 6. Spawn the Worker
 

--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -35,17 +35,27 @@ the spawn boundary, so only one worker starts. (An orphan worktree, on disk
 with no live session, no longer blocks selection — so (b) is what closes the
 lock-release-to-worker-registration window, not (a).)
 
-The `tmp/dispatch-worktree` marker is the canonical post-Step-5 reclaim signal:
-a recorded holder whose worktree carries the marker is past Step 5, so its
-lock is reclaimable by any subsequent tick regardless of session-id provenance.
-The acquire path skips the busy branch when the foreign holder's cwd has the
-marker, and `--release` succeeds (truncates and prints `released`) when EITHER
-the caller's sessionId matches the holder OR the holder's cwd has the marker.
-This closes the silent-`noop` failure mode for any post-Step-5 caller whose
-`CLAUDE_CODE_SESSION_ID` was re-derived from a different context (a subagent
-or hook). Pre-marker callers — Steps 1-4 stop paths and the Step 5 `conflict`
-stop — keep strict sessionId-match semantics by construction because the
-marker is absent.
+The `tmp/dispatch-worktree` marker is the canonical post-Step-5 reclaim signal,
+and it is **session-scoped**: `dispatch-finalize-selection` stamps the
+finalizing holder's `CLAUDE_CODE_SESSION_ID` into the marker, and the lock
+reclaims a foreign holder via the marker **only** when the marker's content
+equals the recorded holder's sessionId. The acquire path skips the busy branch
+when the foreign holder's cwd has a marker naming that recorded holder, and
+`--release` succeeds (truncates and prints `released`) when EITHER the caller's
+sessionId matches the holder OR the holder's cwd has a marker naming the
+recorded holder. This closes the silent-`noop` failure mode for any post-Step-5
+caller whose `CLAUDE_CODE_SESSION_ID` was re-derived from a different context (a
+subagent or hook) — the marker still names the recorded holder, so reclaim
+fires.
+
+The content-match guard is what prevents a stale marker from reclaiming a
+**live, mid-selection** holder. An empty marker (the `touch` stamped by
+`.claude/hooks/worktree-create.sh` on every worktree creation) names no session,
+and a marker naming an older, since-finalized session names the wrong session;
+neither matches the recorded holder, so neither reclaims a live holder that
+happens to share that worktree. Pre-marker callers — Steps 1-4 stop paths and
+the Step 5 `conflict` stop — keep strict sessionId-match semantics by
+construction because the marker is absent.
 
 The lock is scoped to selection and self-healing. The recorded sessionId
 (`CLAUDE_CODE_SESSION_ID`) outlives any single Bash call within a tick: if a
@@ -137,16 +147,21 @@ recovery does **not** read it: `restore-dispatch-skill.sh` (bound to
 `SessionStart:clear`) keys on the session's `--name` shape (`<N>-<slug>` for
 workers) and emits `/dispatch-worker <N> <worktree-path>` so the worker
 re-derives the phase from PR/CI ground truth.
-`.claude/hooks/worktree-create.sh` also writes the marker as its final action
-on every successful worktree creation, so a fresh worktree is marker-bearing
-the moment the hook returns — the router's explicit marker write here is the
-in-skill defense for any code path that bypasses the hook. The router itself
-never writes the marker into its own cwd (`worktrees/main`), so a
+`.claude/hooks/worktree-create.sh` also stamps the marker (an empty `touch`) as
+its final action on every successful worktree creation, so a fresh worktree
+carries a content-less marker the moment the hook returns. That empty marker is
+**inert** for reclaim: it names no session, so it never matches a recorded
+holder and never reclaims a live holder co-located in that worktree. Only
+`dispatch-finalize-selection`'s session-scoped write — the finalizing holder's
+`CLAUDE_CODE_SESSION_ID` — is a reclaim-capable marker. The router itself never
+writes the marker into its own cwd (`worktrees/main`), so a
 `SessionStart:clear` there is a no-op — correct, since the router is
 short-lived and re-seeded by the #725 cap-keyed re-seed when a cap stall ends
-the chain. The marker is an empty
-boolean flag with no payload; it persists for the worktree's life and needs no
-cleanup — `tmp/` is git-ignored, and removing the worktree removes it.
+the chain. The marker's content is the finalizing holder's sessionId; it
+persists for the worktree's life and needs no cleanup — `tmp/` is git-ignored,
+and removing the worktree removes it. A stale marker naming an older session
+cannot reclaim a different live holder, so no active cleanup is required to
+keep the lock correct.
 
 ## Step 6 spawn-cwd trade-off
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
@@ -192,7 +192,9 @@ marker_names_holder() {
   local cwd="$1" sid="$2" marker content=""
   [[ -n "$cwd" ]] || return 1
   marker="$cwd/tmp/dispatch-worktree"
-  [[ -e "$marker" ]] || return 1
+  # Require a regular file: a FIFO or device node at this path would block the
+  # read below indefinitely while the flock is held, deadlocking all routing.
+  [[ -f "$marker" ]] || return 1
   IFS= read -r content <"$marker" 2>/dev/null || true
   [[ -n "$content" && "$content" == "$sid" ]]
 }

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
@@ -45,17 +45,26 @@
 # Marker-based reclaim. The dispatch lock covers Steps 0–5 of /dispatch-propagate only
 # (target selection + worktree resolution); phase skills run lock-free. The
 # marker file `tmp/dispatch-worktree` is written in the selected worktree at
-# the end of Step 5 on every proceed path, so its presence in the recorded
-# holder's cwd authoritatively means "Step 5 completed — past the lock-
-# covered region". Both acquire and `--release` honor this signal:
-#   - Acquire reclaims a marker-bearing foreign holder regardless of session
-#     liveness (the holder is past Step 5; the lock no longer serves it).
+# the end of Step 5 by dispatch-finalize-selection, which stamps the finalizing
+# holder's CLAUDE_CODE_SESSION_ID into it. The marker is session-scoped: it
+# reclaims a live foreign holder ONLY when the marker's content equals the
+# RECORDED HOLDER's sessionId (see marker_names_holder). Both acquire and
+# `--release` honor this signal:
+#   - Acquire reclaims a foreign holder regardless of session liveness when the
+#     holder's cwd carries a marker naming that recorded holder (it is past
+#     Step 5; the lock no longer serves it).
 #   - `--release` succeeds for any caller when the recorded holder's cwd
-#     carries the marker, in addition to the strict self-release branch.
+#     carries a marker naming that recorded holder, in addition to the strict
+#     self-release branch.
 # This closes the silent-noop leak when a child context's
-# CLAUDE_CODE_SESSION_ID differs from the recorded holder. Pre-marker stop
-# paths (Steps 1–4 stop, Step 5 `conflict`) fire before the marker exists, so
-# the lenient branch correctly does not engage and strict semantics apply.
+# CLAUDE_CODE_SESSION_ID differs from the recorded holder, while a content-match
+# guard prevents a stale marker from reclaiming a LIVE mid-selection holder.
+# An empty marker — the `touch` stamped by .claude/hooks/worktree-create.sh on
+# every worktree creation — names no session and is inert. A marker naming an
+# older, since-finalized session likewise does not reclaim a different live
+# holder. Pre-marker stop paths (Steps 1–4 stop, Step 5 `conflict`) fire before
+# the marker exists, so the lenient branch does not engage and strict semantics
+# apply.
 #
 # Usage:
 #   dispatch-acquire-lock            — single-shot: print "acquired" or "busy".
@@ -174,6 +183,20 @@ resolve_holder_state() {
   return 0
 }
 
+# marker_names_holder <cwd> <sid> — 0 iff <cwd> is non-empty, carries the
+# tmp/dispatch-worktree marker, and the marker's first line equals <sid>.
+# Empty cwd, missing/empty marker, or a marker naming any other session → 1
+# (no reclaim): a stale empty marker (worktree-create.sh) or a marker naming
+# an older finalized session never reclaims a live mid-selection holder.
+marker_names_holder() {
+  local cwd="$1" sid="$2" marker content=""
+  [[ -n "$cwd" ]] || return 1
+  marker="$cwd/tmp/dispatch-worktree"
+  [[ -e "$marker" ]] || return 1
+  IFS= read -r content <"$marker" 2>/dev/null || true
+  [[ -n "$content" && "$content" == "$sid" ]]
+}
+
 # ---- Step 1: resolve the lock file ------------------------------------------
 # An explicit DISPATCH_LOCK_FILE is authoritative and bypasses the git lookup —
 # tests rely on this. Otherwise the lock lives at the shared project-root tmp/
@@ -219,17 +242,19 @@ try_acquire() {            # 0 = acquired, 1 = contended; sets CONTENDED_SID
     local recorded="" cwd="" live=0
     IFS= read -r recorded <"$LOCK_FILE" 2>/dev/null || true
     # Busy iff a different sessionId is recorded AND it is still a live
-    # session per `claude agents --json` AND its cwd does NOT carry the
-    # tmp/dispatch-worktree marker (i.e. it is still in the lock-covered
-    # Steps 0–5 region). Otherwise — no record, a stale record (sessionId
-    # not in the registry), our own session re-entering, or a marker-bearing
-    # foreign holder past Step 5 — we claim the lock. An empty cwd on a
-    # live return (opaque-failure path) skips the marker check → stay strict.
+    # session per `claude agents --json` AND its cwd does NOT carry a
+    # tmp/dispatch-worktree marker naming the recorded holder (i.e. it is
+    # still in the lock-covered Steps 0–5 region). Otherwise — no record, a
+    # stale record (sessionId not in the registry), our own session
+    # re-entering, or a foreign holder past Step 5 whose marker names it — we
+    # claim the lock. An empty cwd on a live return (opaque-failure path), an
+    # empty marker (worktree-create.sh's touch), or a marker naming an older
+    # session all fail marker_names_holder → stay strict (BUSY).
     if [[ -n "$recorded" && "$recorded" != "$SESSION_ID" ]]; then
       if cwd=$(resolve_holder_state "$recorded"); then
         live=1
       fi
-      if (( live )) && [[ -z "$cwd" || ! -e "$cwd/tmp/dispatch-worktree" ]]; then
+      if (( live )) && ! marker_names_holder "$cwd" "$recorded"; then
         printf 'BUSY %s' "$recorded"
       else
         printf '%s\n' "$SESSION_ID" >"$LOCK_FILE"
@@ -274,12 +299,13 @@ case "$MODE" in
   release)
     # Re-read the recorded sessionId under flock and clear it when EITHER
     # (a) it is our own session (strict self-release), OR (b) the recorded
-    # holder's cwd carries the tmp/dispatch-worktree marker (lenient post-
-    # Step-5 release — closes the silent-noop leak when a child context's
-    # CLAUDE_CODE_SESSION_ID differs from the recorded holder). A not-live
-    # foreign holder without a marker stays a noop; its lock will be
-    # reclaimed by the next acquire anyway. Truncate with `:` rather than
-    # `rm` — `rm` would orphan a concurrent acquire's already-open fd.
+    # holder's cwd carries a tmp/dispatch-worktree marker naming that recorded
+    # holder (lenient post-Step-5 release — closes the silent-noop leak when a
+    # child context's CLAUDE_CODE_SESSION_ID differs from the recorded holder).
+    # A not-live foreign holder without a holder-naming marker stays a noop; its
+    # lock will be reclaimed by the next acquire anyway. Truncate with `:`
+    # rather than `rm` — `rm` would orphan a concurrent acquire's already-open
+    # fd.
     result=$(
       exec 9>>"$LOCK_FILE"
       flock 9
@@ -290,12 +316,13 @@ case "$MODE" in
       if [[ -n "$recorded" && "$recorded" == "$SESSION_ID" ]]; then
         should_release=1
       elif [[ -n "$recorded" && "$recorded" != "$SESSION_ID" ]]; then
-        # Foreign holder: lenient release iff its cwd carries the marker.
-        # A not-live holder (resolve_holder_state returns 1, empty cwd) or
-        # an opaque-failure holder (returns 0 with empty cwd) stays strict —
-        # the marker check fails on empty cwd, so should_release stays 0.
+        # Foreign holder: lenient release iff its cwd carries a marker naming
+        # the recorded holder. A not-live holder (resolve_holder_state returns
+        # 1, empty cwd) or an opaque-failure holder (returns 0 with empty cwd)
+        # stays strict — marker_names_holder fails on empty cwd. An empty or
+        # mismatched marker likewise fails, so should_release stays 0.
         if cwd=$(resolve_holder_state "$recorded"); then
-          if [[ -n "$cwd" && -e "$cwd/tmp/dispatch-worktree" ]]; then
+          if marker_names_holder "$cwd" "$recorded"; then
             should_release=1
           fi
         fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-finalize-selection
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-finalize-selection
@@ -7,6 +7,14 @@
 # exit code is the release call's exit code. The cd-first contract ensures the
 # marker lands in the target worktree, not the caller's cwd. See
 # `.claude/skills/dispatch-propagate/SKILL.md` Step 5 and Step 0 "Releasing the lock".
+#
+# The marker carries the finalizing (holder) session's CLAUDE_CODE_SESSION_ID,
+# not an empty flag: dispatch-acquire-lock reclaims a live foreign holder via
+# the marker ONLY when the marker's content equals the recorded holder's
+# sessionId. Writing our own session id here is what makes the marker name the
+# recorded holder (this script runs in the holder's own context). An empty
+# marker — e.g. the `touch` stamped by .claude/hooks/worktree-create.sh on
+# every worktree creation — never reclaims a live mid-selection holder.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -30,6 +38,17 @@ cd "$WORKTREE" || {
   exit 2
 }
 
+# The marker is session-scoped: it names the finalizing holder so the lock can
+# distinguish "THIS recorded holder finished Step 5" from a stale empty marker.
+# An unset CLAUDE_CODE_SESSION_ID is a misconfigured environment — fail clear
+# rather than write an inert empty marker; the exec'd --release would fail on
+# the same unset value anyway.
+SESSION_ID="${CLAUDE_CODE_SESSION_ID:-}"
+[[ -n "$SESSION_ID" ]] || {
+  echo "dispatch-finalize-selection: CLAUDE_CODE_SESSION_ID is unset" >&2
+  exit 2
+}
+
 mkdir -p tmp
-touch tmp/dispatch-worktree
+printf '%s\n' "$SESSION_ID" > tmp/dispatch-worktree
 exec "$SCRIPT_DIR/dispatch-acquire-lock" --release

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -4187,6 +4187,31 @@ assert_eq "empty-marker holder blocks: lock file unchanged" \
   "sess-2525-foreign" "$lock_contents"
 lock_teardown
 
+# --- Test 25b: live foreign holder with FIFO marker → busy (no deadlock) -----
+#
+# marker_names_holder reads the marker's content; a non-regular file (here a
+# FIFO) at that path would block the read indefinitely while the flock is held,
+# deadlocking all routing. The regular-file guard must reject it and stay busy
+# rather than reclaim or hang. A `timeout` bounds the call so a regression
+# (reverting to a blocking read) surfaces as a hang, not a silent pass.
+
+echo "Test: live foreign holder with FIFO marker → busy (no deadlock)"
+lock_setup
+printf '%s\n' "sess-25b-foreign" > "$DISPATCH_LOCK_FILE"
+export CLAUDE_CODE_SESSION_ID="sess-25b-self"
+foreign_cwd="$TMPDIR_TEST/foreign-worktree-fifo-marker"
+mkdir -p "$foreign_cwd/tmp"
+mkfifo "$foreign_cwd/tmp/dispatch-worktree"
+lock_fake_claude_sessions "sess-25b-foreign=$foreign_cwd" "sess-25b-self=$TMPDIR_TEST"
+out=$(timeout 10 "$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+assert_eq "fifo-marker holder blocks: exits 0 (no timeout/hang)" "0" "$rc"
+assert_eq "fifo-marker holder blocks: prints busy" "busy" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "fifo-marker holder blocks: lock file unchanged" \
+  "sess-25b-foreign" "$lock_contents"
+rm -f "$foreign_cwd/tmp/dispatch-worktree"
+lock_teardown
+
 # --- Test 26: --release with MISMATCHED marker → noop (#928) -----------------
 #
 # Symmetry with Test 24: a lenient --release must not fire when the marker

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3921,7 +3921,8 @@ export CLAUDE_CODE_SESSION_ID="sess-2020-self"
 # Build the foreign holder's marker-bearing cwd inside the test tmp tree.
 foreign_cwd="$TMPDIR_TEST/foreign-worktree"
 mkdir -p "$foreign_cwd/tmp"
-touch "$foreign_cwd/tmp/dispatch-worktree"
+# The marker names the recorded holder (sess-2020-foreign) → reclaim.
+printf '%s\n' "sess-2020-foreign" > "$foreign_cwd/tmp/dispatch-worktree"
 lock_fake_claude_sessions "sess-2020-foreign=$foreign_cwd" "sess-2020-self=$TMPDIR_TEST"
 out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
 assert_eq "past-Step-5 holder reclaim exits 0" "0" "$rc"
@@ -3964,7 +3965,8 @@ printf '%s\n' "sess-2222-foreign" > "$DISPATCH_LOCK_FILE"
 export CLAUDE_CODE_SESSION_ID="sess-2222-self"
 foreign_cwd="$TMPDIR_TEST/foreign-worktree-with-marker"
 mkdir -p "$foreign_cwd/tmp"
-touch "$foreign_cwd/tmp/dispatch-worktree"
+# The marker names the recorded holder (sess-2222-foreign) → lenient release.
+printf '%s\n' "sess-2222-foreign" > "$foreign_cwd/tmp/dispatch-worktree"
 lock_fake_claude_sessions "sess-2222-foreign=$foreign_cwd" "sess-2222-self=$TMPDIR_TEST"
 out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" --release 2>/dev/null); rc=$?
 assert_eq "lenient --release exits 0" "0" "$rc"
@@ -3992,6 +3994,74 @@ assert_eq "pre-marker --release prints noop" "noop" "$out"
 lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
 assert_eq "pre-marker --release leaves the lock file unchanged" \
   "sess-2323-foreign" "$lock_contents"
+lock_teardown
+
+# --- Test 24: live foreign holder with MISMATCHED marker → busy (#928) -------
+#
+# The marker exists but names a DIFFERENT (older, since-finalized) session, not
+# the recorded holder. A live mid-selection holder launched from a previously-
+# marked worktree must NOT have its lock reclaimed: marker_names_holder rejects
+# the content mismatch, so acquire stays busy.
+
+echo "Test: live foreign holder with mismatched marker → busy (#928)"
+lock_setup
+printf '%s\n' "sess-2424-foreign" > "$DISPATCH_LOCK_FILE"
+export CLAUDE_CODE_SESSION_ID="sess-2424-self"
+foreign_cwd="$TMPDIR_TEST/foreign-worktree-stale-marker"
+mkdir -p "$foreign_cwd/tmp"
+# Marker names an unrelated, older session — not the recorded holder.
+printf '%s\n' "sess-2424-some-older-session" > "$foreign_cwd/tmp/dispatch-worktree"
+lock_fake_claude_sessions "sess-2424-foreign=$foreign_cwd" "sess-2424-self=$TMPDIR_TEST"
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+assert_eq "mismatched-marker holder blocks: exits 0" "0" "$rc"
+assert_eq "mismatched-marker holder blocks: prints busy" "busy" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "mismatched-marker holder blocks: lock file unchanged" \
+  "sess-2424-foreign" "$lock_contents"
+lock_teardown
+
+# --- Test 25: live foreign holder with EMPTY marker → busy (#928) ------------
+#
+# An empty marker is the shape stamped by .claude/hooks/worktree-create.sh's
+# `touch` on every worktree creation. It names no session, so it must never
+# reclaim a live holder co-located in that worktree.
+
+echo "Test: live foreign holder with empty (touch) marker → busy (#928)"
+lock_setup
+printf '%s\n' "sess-2525-foreign" > "$DISPATCH_LOCK_FILE"
+export CLAUDE_CODE_SESSION_ID="sess-2525-self"
+foreign_cwd="$TMPDIR_TEST/foreign-worktree-empty-marker"
+mkdir -p "$foreign_cwd/tmp"
+# The hook's shape: a content-less marker.
+touch "$foreign_cwd/tmp/dispatch-worktree"
+lock_fake_claude_sessions "sess-2525-foreign=$foreign_cwd" "sess-2525-self=$TMPDIR_TEST"
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+assert_eq "empty-marker holder blocks: exits 0" "0" "$rc"
+assert_eq "empty-marker holder blocks: prints busy" "busy" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "empty-marker holder blocks: lock file unchanged" \
+  "sess-2525-foreign" "$lock_contents"
+lock_teardown
+
+# --- Test 26: --release with MISMATCHED marker → noop (#928) -----------------
+#
+# Symmetry with Test 24: a lenient --release must not fire when the marker
+# names a session other than the recorded holder. The lock stays intact.
+
+echo "Test: --release with mismatched marker → noop (#928)"
+lock_setup
+printf '%s\n' "sess-2626-foreign" > "$DISPATCH_LOCK_FILE"
+export CLAUDE_CODE_SESSION_ID="sess-2626-self"
+foreign_cwd="$TMPDIR_TEST/foreign-worktree-mismatch-release"
+mkdir -p "$foreign_cwd/tmp"
+printf '%s\n' "sess-2626-some-older-session" > "$foreign_cwd/tmp/dispatch-worktree"
+lock_fake_claude_sessions "sess-2626-foreign=$foreign_cwd" "sess-2626-self=$TMPDIR_TEST"
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" --release 2>/dev/null); rc=$?
+assert_eq "mismatched --release exits 0" "0" "$rc"
+assert_eq "mismatched --release prints noop" "noop" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "mismatched --release leaves the lock file unchanged" \
+  "sess-2626-foreign" "$lock_contents"
 lock_teardown
 
 # ============================================================================
@@ -8443,6 +8513,11 @@ cd "$FIN_ORIG_PWD"
 assert_eq "happy path: exit 0" "0" "$finalize_exit"
 assert_eq "happy path: marker in target worktree" "1" \
   "$([ -f "$TARGET_WT/tmp/dispatch-worktree" ] && echo 1 || echo 0)"
+# #928: the marker is session-scoped — it carries the finalizing holder's
+# CLAUDE_CODE_SESSION_ID, not an empty flag.
+assert_eq "happy path: marker content names the finalizing session" \
+  "$CLAUDE_CODE_SESSION_ID" \
+  "$(cat "$TARGET_WT/tmp/dispatch-worktree")"
 # Regression for #896: the wrapper must not write the marker into the
 # caller's cwd. This is the load-bearing assertion.
 assert_eq "happy path: no marker in caller cwd" "0" \

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -8892,6 +8892,32 @@ assert_eq "flag arg: no marker created in $TMPDIR_TEST" "" \
   "$(find "$TMPDIR_TEST" -name dispatch-worktree -print 2>/dev/null)"
 lock_teardown
 
+# ----- Test F (unset CLAUDE_CODE_SESSION_ID) ---------------------------------
+# #928: the marker is session-scoped, so an unset CLAUDE_CODE_SESSION_ID is a
+# misconfigured environment — the wrapper must fail clear (exit 2) rather than
+# write an inert empty marker that could never reclaim a live holder. Mirrors
+# dispatch-acquire-lock's Test 6b guard.
+echo "Test: dispatch-finalize-selection with unset CLAUDE_CODE_SESSION_ID exits 2"
+lock_setup
+UNSET_WT="$TMPDIR_TEST/unset-wt"
+mkdir -p "$UNSET_WT"
+# `set -e` is in effect: capture the exit code with an if/else. env -u strips
+# CLAUDE_CODE_SESSION_ID for just this invocation.
+if ( env -u CLAUDE_CODE_SESSION_ID \
+       "$FINALIZE_SCRIPT" "$UNSET_WT" ) > "$TMPDIR_TEST/unset.out" 2> "$TMPDIR_TEST/unset.err"; then
+  unset_exit=0
+else
+  unset_exit=$?
+fi
+assert_eq "unset session: exit 2" "2" "$unset_exit"
+assert_eq "unset session: stderr names script and 'is unset'" "1" \
+  "$(grep -c 'dispatch-finalize-selection.*CLAUDE_CODE_SESSION_ID is unset' "$TMPDIR_TEST/unset.err")"
+# The guard fires after the cd but before the marker write — no inert empty
+# marker must land in the target worktree.
+assert_eq "unset session: no marker created in target worktree" "0" \
+  "$([ -f "$UNSET_WT/tmp/dispatch-worktree" ] && echo 1 || echo 0)"
+lock_teardown
+
 # ============================================================================
 # restore-dispatch-skill tests (#903)
 # ============================================================================


### PR DESCRIPTION
Closes #928

The dispatch selection lock's marker-reclaim path let any contender reclaim a
live foreign holder's lock whenever the holder's launch cwd carried a
content-less `tmp/dispatch-worktree` marker. That marker was stamped by both
`dispatch-finalize-selection` and `worktree-create.sh` and never removed, so
co-located sessions defeated the lock entirely — observed 2026-05-30 when five
`/dispatch` sessions launched from one marked worktree each acquired the lock
while a prior holder was still live.

## Fix

The marker is now session-scoped:

- `dispatch-finalize-selection` writes the finalizing holder's
  `CLAUDE_CODE_SESSION_ID` into the marker (was an empty `touch`), and fails
  clear if that id is unset.
- `dispatch-acquire-lock` reclaims via the marker — in both the acquire branch
  and the `--release` lenient branch — only when the marker's content equals
  the recorded holder's sessionId (new `marker_names_holder` helper). An empty
  marker (`worktree-create.sh`'s `touch`) or one naming an older session is
  inert, so a live mid-selection holder is never reclaimed.

Dead-holder self-heal is unchanged. `worktree-create.sh` is intentionally
untouched — its empty marker is now correctly inert.

## Tests

`test-dispatch-scripts.sh` covers mismatched marker → busy, empty marker →
busy, `--release` mismatched marker → noop, matching marker → reclaim, and the
session-scoped finalize content. Full suite: 711/711 pass.