### PR TITLE
dispatch: extract explicit-path blocker check into dispatch-check-blockers

### DIFF
--- a/.claude/skills/dispatch-propagate/SKILL.md
+++ b/.claude/skills/dispatch-propagate/SKILL.md
@@ -201,17 +201,31 @@ Skip leaf tracing when:
   **Do not infer PR existence from title search or other ad-hoc `gh` queries** —
   `dispatch-find-pr` is the only correct check (see Step 5).
 
-If the resolved target issue `<N>` has any **open** blocker — run
-`issue-blocking <N>` and check for any entry with `state` `OPEN` — release the
-lock (see *Releasing the lock*), report the open blocker, park the issue with
+Check the resolved target issue `<N>` for open blockers
+(`dangerouslyDisableSandbox: true` — the script calls `gh`):
 
 ```bash
-.claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours <N> "target has an open blocker"
+.claude/skills/dispatch-propagate/scripts/dispatch-check-blockers <N>
 ```
 
-(see *Applying `dispatch:office-hours`* below), then proceed to Step 7 with
-`notify target-blocked`. This guard applies even when a PR exists; closed
-blockers do not gate.
+Route on its exit code:
+
+- **Exit 0** (no output) — no open blockers. Continue.
+- **Exit 2** (prints `blocked:<num>[,<num>…]`) — the target has open blockers.
+  Release the lock (see *Releasing the lock*), report the listed blocker(s),
+  park the issue with
+
+  ```bash
+  .claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours <N> "target has an open blocker"
+  ```
+
+  (see *Applying `dispatch:office-hours`* below), then proceed to Step 7 with
+  `notify target-blocked`.
+
+This guard applies even when a PR exists; closed blockers do not gate.
+`dispatch-check-blockers` routes through `count_open_blockers` — the same helper
+the queue path (`dispatch-select-target`) uses — so the explicit and queue paths
+agree on what counts as "blocked".
 
 If a named target issue is **closed**, release the lock (see *Releasing the
 lock*), report it, park the issue with

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-check-blockers
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-check-blockers
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Explicit-path open-blocker gate for /dispatch-propagate Step 4.
+# Usage: dispatch-check-blockers <issue-num>
+#
+# Exit 0, no output         — target <N> has no open blockers; dispatch may proceed.
+# Exit 2, "blocked:<n>[,<n>…]" on stdout — target has one or more open blockers.
+# Exit 1                    — usage error or gh/API failure.
+#
+# The gate decision routes through count_open_blockers (lib.sh) — the same
+# helper the queue path (dispatch-select-target) uses — so the explicit and
+# queue paths can never diverge on what counts as "blocked". Closed blockers do
+# not gate; count_open_blockers already filters them out.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+ARG="${1:-}"
+if [[ -z "$ARG" || ! "$ARG" =~ ^[0-9]+$ ]]; then
+  echo "error: usage: dispatch-check-blockers <issue-num>" >&2
+  exit 1
+fi
+
+count=$(count_open_blockers "$ARG")
+if [[ "$count" -eq 0 ]]; then
+  exit 0
+fi
+
+# Blocked: name the open blockers for the caller's report. Same endpoint and
+# open-state filter count_open_blockers uses, so the listed numbers agree with
+# the gate decision.
+nums=$(gh_api_array "/repos/{owner}/{repo}/issues/$ARG/dependencies/blocked_by" \
+  '[.[] | select(.state == "open" or .state == "OPEN") | .number] | join(",")')
+echo "blocked:$nums"
+exit 2

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -52,6 +52,7 @@ setup() {
   cp "$SCRIPT_DIR/dispatch-resolve-arg" "$TMPDIR_TEST/dispatch-resolve-arg"
   cp "$SCRIPT_DIR/dispatch-select-target" "$TMPDIR_TEST/dispatch-select-target"
   cp "$SCRIPT_DIR/dispatch-trace-leaf" "$TMPDIR_TEST/dispatch-trace-leaf"
+  cp "$SCRIPT_DIR/dispatch-check-blockers" "$TMPDIR_TEST/dispatch-check-blockers"
   cp "$SCRIPT_DIR/dispatch-complete-phase" "$TMPDIR_TEST/dispatch-complete-phase"
   cp "$SCRIPT_DIR/dispatch-apply-office-hours" "$TMPDIR_TEST/dispatch-apply-office-hours"
   cp "$SCRIPT_DIR/dispatch-resolve-worktree" "$TMPDIR_TEST/dispatch-resolve-worktree"
@@ -74,6 +75,7 @@ setup() {
            "$TMPDIR_TEST/dispatch-resolve-arg" \
            "$TMPDIR_TEST/dispatch-select-target" \
            "$TMPDIR_TEST/dispatch-trace-leaf" \
+           "$TMPDIR_TEST/dispatch-check-blockers" \
            "$TMPDIR_TEST/dispatch-complete-phase" \
            "$TMPDIR_TEST/dispatch-apply-office-hours" \
            "$TMPDIR_TEST/dispatch-resolve-worktree" \
@@ -182,6 +184,14 @@ case "$args" in
   api\ */dependencies/blocked_by)
     path=$(echo "$args" | awk '{print $2}')
     num=$(echo "$path" | grep -oE '[0-9]+' | tail -1)
+    # Failure injection: a marker file models a transient gh API failure on this
+    # issue's blocked_by lookup (mirrors the issue-blocking fake's contract), so
+    # count_open_blockers callers (e.g. dispatch-check-blockers) can exercise the
+    # gh_api_array failure path.
+    if [[ -f "$STUB_DIR/gh-fail-blocked_by-${num}" ]]; then
+      echo "gh: API error on issues/${num}/dependencies/blocked_by" >&2
+      exit 1
+    fi
     if [[ -f "$STUB_DIR/blockers-${num}.json" ]]; then
       cat "$STUB_DIR/blockers-${num}.json"
     else
@@ -9307,6 +9317,79 @@ for relpath in "${!CHAIN_GUARD_EXPECTED[@]}"; do
   assert_eq "chain-guard: $relpath: EnterWorktree/ExitWorktree count" \
     "$expected" "$actual"
 done
+
+# ============================================================================
+# dispatch-check-blockers tests
+# ============================================================================
+echo ""
+echo "=== dispatch-check-blockers ==="
+
+# No open blockers (no fixture → stub returns []) → exit 0, no output.
+echo "Test: no blockers → exit 0, silent"
+setup
+stdout=$("$TMPDIR_TEST/dispatch-check-blockers" 100 2>/dev/null) && rc=0 || rc=$?
+assert_eq "no blockers → exit 0" "0" "$rc"
+assert_eq "no blockers → no output" "" "$stdout"
+teardown
+
+# Only closed blockers do not gate → exit 0, no output.
+echo "Test: closed-only blockers → exit 0, silent"
+setup
+printf '[{"number":888,"state":"closed"}]\n' > "$STUB_DIR/blockers-100.json"
+stdout=$("$TMPDIR_TEST/dispatch-check-blockers" 100 2>/dev/null) && rc=0 || rc=$?
+assert_eq "closed-only blockers → exit 0" "0" "$rc"
+assert_eq "closed-only blockers → no output" "" "$stdout"
+teardown
+
+# One open blocker → exit 2, prints blocked:<num>.
+echo "Test: one open blocker → exit 2, blocked:<num>"
+setup
+printf '[{"number":999,"state":"open"}]\n' > "$STUB_DIR/blockers-100.json"
+stdout=$("$TMPDIR_TEST/dispatch-check-blockers" 100 2>/dev/null) && rc=0 || rc=$?
+assert_eq "one open blocker → exit 2" "2" "$rc"
+assert_eq "one open blocker → blocked:999" "blocked:999" "$stdout"
+teardown
+
+# Multiple open blockers → exit 2, comma-joined numbers; closed ones excluded.
+echo "Test: mixed blockers → exit 2, only open numbers"
+setup
+printf '[{"number":999,"state":"open"},{"number":888,"state":"closed"},{"number":777,"state":"OPEN"}]\n' \
+  > "$STUB_DIR/blockers-100.json"
+stdout=$("$TMPDIR_TEST/dispatch-check-blockers" 100 2>/dev/null) && rc=0 || rc=$?
+assert_eq "mixed blockers → exit 2" "2" "$rc"
+assert_eq "mixed blockers → blocked:999,777" "blocked:999,777" "$stdout"
+teardown
+
+# Missing arg → usage error on stderr, exit 1.
+echo "Test: missing arg → usage error, exit 1"
+setup
+err_out=$("$TMPDIR_TEST/dispatch-check-blockers" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err_out" in
+  *"usage:"*"EXIT=1") status="ok" ;;
+  *) status="bad: $err_out" ;;
+esac
+assert_eq "missing arg → usage error, exit 1" "ok" "$status"
+teardown
+
+# Non-numeric arg → usage error, exit 1.
+echo "Test: non-numeric arg → usage error, exit 1"
+setup
+err_out=$("$TMPDIR_TEST/dispatch-check-blockers" abc 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err_out" in
+  *"usage:"*"EXIT=1") status="ok" ;;
+  *) status="bad: $err_out" ;;
+esac
+assert_eq "non-numeric arg → usage error, exit 1" "ok" "$status"
+teardown
+
+# gh failure on the blocked_by lookup → hard error (exit 1), never a false "clear".
+echo "Test: gh blocked_by failure → exit 1"
+setup
+: > "$STUB_DIR/gh-fail-blocked_by-100"
+stdout=$("$TMPDIR_TEST/dispatch-check-blockers" 100 2>/dev/null) && rc=0 || rc=$?
+assert_eq "gh blocked_by failure → exit 1" "1" "$rc"
+assert_eq "gh blocked_by failure → no output" "" "$stdout"
+teardown
 
 # ============================================================================
 # summary


### PR DESCRIPTION
## Summary
- Extract the explicit-path open-blocker guard from `dispatch-propagate` SKILL.md Step 4 prose into a script, `dispatch-check-blockers <N>`, that routes on exit code (mirroring `dispatch-find-pr` / `dispatch-resolve-worktree`).
- The script gates through `count_open_blockers` (lib.sh) — the same helper the queue path (`dispatch-select-target`) uses — so the explicit and queue paths can no longer diverge on what counts as "blocked".
- Contract: **exit 0** silent when clear; **exit 2** + `blocked:<num>[,<num>…]` when open blockers exist; **exit 1** on usage/gh failure. Closed blockers do not gate.

## Scope
- Blocker check only. Office-hours application stays in SKILL.md prose (centralized separately under #909). The closed-target guard is left untouched.
- Gives #919 (`dispatch-materialize-spawn`) a ready building block to call rather than re-implement.

## Test plan
- [x] `bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` → **732/732 pass**, including 7 new `dispatch-check-blockers` cases (no/closed-only/single/mixed blockers, missing + non-numeric args, gh failure).
- [x] Taught the gh stub's `blocked_by` branch to honor the `gh-fail-blocked_by-<num>` sentinel so `count_open_blockers`' failure path is exercised.
- [x] Script syntax + usage-error paths verified standalone.

Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)