### PR TITLE
dispatch: consolidate router steps into two orchestrator scripts (#919)

### DIFF
--- a/.claude/skills/dispatch-propagate/SKILL.md
+++ b/.claude/skills/dispatch-propagate/SKILL.md
@@ -10,473 +10,123 @@ background job rooted in `worktrees/main`: it selects the single most pressing
 task, resolves its worktree, spawns a `/dispatch-worker <N>` background job to
 run one phase there, and exits. The worker runs that phase, then spawns a fresh
 router and self-deletes (see reference.md *Chain mechanics*). The router runs no
-phase skill itself — it is a thin selection-and-spawn loop.
+phase skill itself.
 
-`/dispatch-propagate` takes an **optional issue-or-PR-number argument** (leading `#`
-optional). With an argument, it targets that issue and skips the queue scan; a
-PR number is resolved to the issue that PR closes (see Step 3).
+`/dispatch-propagate` takes an **optional issue-or-PR-number argument** (leading
+`#` optional). With an argument it targets that issue and skips the queue scan;
+a PR number resolves to the issue that PR closes.
+
+A tick is two scripted orchestrator calls with one model-decision seam between
+them:
+
+1. `dispatch-select-tick` — acquires the lock, syncs `main`, runs the JIT
+   engine, and selects the target. Emits one **decision line**.
+2. The model routes on that line (Table 1). Only three outcomes need the model:
+   a `main-broken` / `jit-reminder` sub-skill invocation, or — for a real
+   target — a call to `dispatch-materialize-spawn`.
+3. `dispatch-materialize-spawn` — runs the explicit-path guards, resolves the
+   worktree, releases the lock, gates on CI and the concurrency budget, and
+   spawns the worker. Emits one **terminal token** (Table 2).
 
 Run `/dispatch-propagate` from any worktree; selection ignores cwd. The router
-never enters a worktree; it materializes the target worktree (if needed) and
-spawns the worker into it. Run `gh` commands (`gh label create`, `gh pr edit`,
-and the scripts that invoke `gh`) with `dangerouslyDisableSandbox: true` — see
-`.claude/rules/sandbox.md`.
+never enters a worktree. Run **every** Bash call here with
+`dangerouslyDisableSandbox: true` — the orchestrators call `gh`, query the
+Claude daemon over a Unix socket, and write tmp state (see
+`.claude/rules/sandbox.md`).
 
-## 0. Acquire the Dispatch Lock
-
-Run this as the **very first action** — before sync, JIT, the health gate,
-selection, and worktree resolution. Runs unconditionally, whether or not an
-issue-or-PR-number argument was given.
+## 1. Select the target
 
 ```bash
-LOCK=$(.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock --wait)
+.claude/skills/dispatch-propagate/scripts/dispatch-select-tick [<issue-or-PR-number>]
 ```
 
-Run this Bash call with **both** `dangerouslyDisableSandbox: true` (lock write +
-`claude agents --json` socket query; see `.claude/rules/sandbox.md`) and an
-elevated `timeout: 600000` (ms) (`--wait` blocks on contention up to
-`DISPATCH_LOCK_WAIT_TIMEOUT`, default 300 s, exceeding the default Bash timeout).
+Run with `dangerouslyDisableSandbox: true` **and** `timeout: 600000` (ms) — the
+script's lock acquisition uses `--wait`, which blocks on contention up to
+`DISPATCH_LOCK_WAIT_TIMEOUT` (default 300 s), exceeding the default Bash
+timeout.
 
-Route on `$LOCK`:
+The script passes through any JIT `created`/`skipped`/`debounced` lines
+(prefixed `jit: `) and prints the decision as its **last** line. Report any
+`jit:` lines, then route on the decision (Table 1).
 
-- **`acquired`** → this `/dispatch-propagate` holds the lock; proceed to Step 1.
-- **`busy`** → the wait timeout elapsed without acquiring — a wedged selection
-  in another `/dispatch-propagate`. The script's **stderr** carries a one-line
-  diagnostic naming the wait duration and the holding sessionId; report those,
-  then proceed to Step 7 with `notify busy-lock-timeout` (subsumes #850) — run no
-  sync, no health gate, no selection, no phase skill. The user-visible report is
-  mandatory (a silent stop would hide the wedge). Recommend the user verify the
-  recorded holder is still live with:
+The **lock disposition is the script's responsibility**: it holds the lock on
+the four target lines plus `main-broken`/`jit-reminder`, releases it on
+`empty`/`sync-failed`/`resolver-failed`, and never touches it on `busy`. The
+model never releases the lock for a select-tick outcome.
 
-  ```
-  claude agents --json | jq '.[] | select(.sessionId == "<holder>")'
-  ```
+### Table 1 — routing the select-tick decision line
 
-### Releasing the lock
+| Decision line | Do this | Disposition |
+|---|---|---|
+| `busy` | The wait timeout elapsed — another tick holds the lock. The script's **stderr** names the elapsed time and the holding sessionId; report them (mandatory — a silent stop would hide the wedge). | `notify busy-lock-timeout` |
+| `sync-failed` | `git fetch` / `merge --ff-only` failed on `main`; report the error. | `notify sync-failed` |
+| `resolver-failed` | The explicit argument did not resolve to one issue; report the script's stderr. | `notify resolver-failed` |
+| `empty` | Nothing eligible. Report verbatim: "queue empty — closing; the office-hours queue or a new issue will re-seed the chain". | `drain empty-queue` |
+| `main-broken <sha>` | Invoke `/dispatch-diagnose-main <sha>` — it enumerates the failing checks, fetches logs, summarizes the likely cause, and releases the lock itself. | `notify main-broken` |
+| `jit-reminder <repo> <num> <project> <item-id>` | Invoke `/dispatch-jit-reminder <repo> <num> <project> <item-id>`. The sub-skill claims the item, releases the lock, summarizes for the user, and stops the tick — a terminal-disposition bypass. | **Stop here**: no materialize-spawn, no self-close |
+| `explicit <num>` | `dispatch-materialize-spawn <num> explicit` | route on Table 2 |
+| `pr <num> <branch> <phase>` | Set `N=${branch%%-*}` (the issue the PR closes — never the PR `<num>`), then `dispatch-materialize-spawn <N> queue` | route on Table 2 |
+| `issue <num>` | `dispatch-materialize-spawn <num> queue` | route on Table 2 |
 
-The lock covers **Steps 0-5 only**; Step 6 (the worker spawn) runs with the lock
-**released**. Release happens at exactly two kinds of point:
+For a `busy` stop, recommend the user verify the recorded holder is still live:
 
-- **Proceed path** — as the final action of Step 5, run
-  `dispatch-finalize-selection "$WORKTREE_PATH"`. The wrapper takes the target
-  worktree path as its one required argument, `cd`s into it, writes the
-  `tmp/dispatch-worktree` marker (see *Step 5* and the marker paragraph below),
-  and execs `dispatch-acquire-lock --release` in one step. The `cd`-first
-  contract is why the router never accidentally writes the marker into its
-  own cwd — the wrapper is the sole Step-5 marker writer on the proceed path.
-- **Every Steps 1-5 stop path** — immediately before reporting the stop reason
-  and proceeding to Step 7, run
-  `.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock --release` directly.
+    claude agents --json | jq '.[] | select(.sessionId == "<holder>")'
 
-The `main-broken` stop path is the one exception: `/dispatch-diagnose-main`
-runs `--release` itself, so `/dispatch-propagate` Step 3's `main-broken` branch
-must not call `--release` again.
+## 2. Materialize and spawn
 
-Both calls need `dangerouslyDisableSandbox: true` (same reason as Step 0); they
-print `released` or `noop`, both fine, so the skill does not branch on the output.
-
-Releasing after Step 5 is safe, and the `tmp/dispatch-worktree` marker is the
-canonical post-Step-5 reclaim signal; see reference.md (*Releasing the lock*
-and *Per-worktree invariant*) for the safety argument, marker/reclaim
-semantics, and the two orthogonal lock scopes. Later steps cross-reference
-*Releasing the lock* rather than repeating these commands.
-
-## 1. Sync local main with `origin/main`
-
-Run this step **only when the current branch is `main`**. From an issue worktree,
-skip this step — the worker's phase skills already merge `origin/main` into the
-issue branch at their own entry points.
-
-Fast-forward local `main` to `origin/main` — no push (a no-op when already equal):
+For a real target, call (with `dangerouslyDisableSandbox: true`):
 
 ```bash
-git fetch origin main && git merge --ff-only origin/main
+.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn <N> <explicit|queue>
 ```
 
-- If `git fetch` fails, or `git merge --ff-only` rejects a non-fast-forward,
-  release the lock (see *Releasing the lock*), surface the error, then proceed to
-  Step 7 with `notify sync-failed` — do not proceed to target selection.
-
-## 2. Run the JIT Engine
-
-Generate any due just-in-time (JIT) issues before selecting a target. The JIT
-engine reads `dispatch.config/jit.json` and creates the recurring issues it
-configures.
-
-Run this **after** the `origin/main` sync and **before** the health gate (so
-jits fire even when `main` is red). It runs unconditionally — on `main` and from
-inside an issue worktree alike; its debounce makes frequent re-runs cheap.
-
-    .claude/skills/dispatch-propagate/scripts/dispatch-jit-engine
-
-Run this Bash call with `dangerouslyDisableSandbox: true` (tmp-state write + `gh`;
-see `.claude/rules/sandbox.md`).
-
-With no `dispatch.config/jit.json` present the engine is a no-op and prints
-nothing. Otherwise it prints one line per configured jit — `<key>: created #<n>`,
-`<key>: skipped (<reason>)`, or `<key>: debounced`. Report what it created.
-
-JIT generation is best-effort — on a non-zero exit, report the engine's stderr
-but do not stop; continue to target selection.
-
-## 3. Select the Target
-
-- **Issue or PR argument given** → strip any leading `#`, then normalize the
-  number to a target issue via the resolver script (`dangerouslyDisableSandbox:
-  true` — it calls `gh`):
-
-  ```bash
-  TARGET=$(.claude/skills/dispatch-propagate/scripts/dispatch-resolve-arg <arg>)
-  ```
-
-  An issue number passes through unchanged; a PR number resolves to the single
-  issue that PR closes (GitHub's `Closes #N` closing-issue references). Route on
-  the exit code:
-
-  - **Exit 0** → `$TARGET` is the target issue number; that issue is the target.
-    Skip the queue scan.
-  - **Non-zero exit** → release the lock (see *Releasing the lock*), report the
-    script's stderr message, then proceed to Step 7 with `notify resolver-failed`;
-    create no worktree. (Covers a PR that closes ≠1 issue, or an argument that is
-    neither an issue nor a PR.)
-
-- **No argument** → run target selection. A single invocation decides every
-  Step 3 outcome (JIT, main-broken gate, queue ladder all internal) and emits
-  the result on its one output line.
-
-  ```bash
-  SELECTED=$(.claude/skills/dispatch-propagate/scripts/dispatch-select-target)
-  ```
-
-  (`dangerouslyDisableSandbox: true` — it calls `gh` and queries the local Claude daemon over a Unix socket.)
-
-  Route on `$SELECTED`:
-
-  - `pr <num> <branch> <phase>` — a PR to work on; `<num>` is the **PR** number
-    and `<phase>` is pre-derived by the selection scan, so Step 6 reuses it
-    instead of re-deriving. The worktree-resolution key is the **issue** the PR
-    closes, not the PR number: set `N=${branch%%-*}` (the branch's `<issue>-`
-    prefix, mirroring `dispatch-select-target`'s own `${pr_branch%%-*}`) and use
-    that `N` — never the PR `<num>` — for Steps 5 and 6. Proceed to Step 5 with
-    mode `queue`.
-  - `issue <num>` — a `help wanted` issue to implement, pre-resolved by the
-    selection scan to a startable open leaf (not necessarily the top-level
-    `help wanted` issue). Proceed to Step 5 with mode `queue`.
-  - `main-broken <sha>` — invoke `/dispatch-diagnose-main <sha>`, then proceed
-    to Step 7 with `notify main-broken`. The skill owns the failing-check
-    enumeration, log-fetch, summary, and lock-release.
-  - `jit-reminder <repo> <num> <project> <item-id>` — invoke
-    `/dispatch-jit-reminder <repo> <num> <project> <item-id>`, then stop the
-    tick directly (a Step 7 bypass). The skill owns the claim + lock-release +
-    summarize + stop sequence; Steps 4, 5, and 6 are all skipped.
-  - `empty` — nothing eligible. Release the lock (see *Releasing the lock*),
-    then proceed to Step 7 with `drain empty-queue` — the user-visible report
-    is mandatory there ("queue empty — closing; the office-hours queue or a
-    new issue will re-seed the chain"), not optional.
-
-  The router acts only on the emitted line. The internal priority order (JIT →
-  `origin/main` health gate → topic-category × priority × phase ladder) and the
-  ladder mechanics are in reference.md (*Selection-ladder mechanics*).
-
-## 4. Trace to an Open Leaf
-
-This step runs **only for an explicit `/dispatch-propagate <N>` argument**; a
-queue-selected `issue <num>` is already a resolved startable open leaf.
-
-When the resolved target is an **explicitly-named open issue with no PR**, trace
-to its open leaf in `explicit` mode:
-
-```bash
-.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf <N> explicit
-```
-
-It walks open blockers and sub-issues to an open leaf and prints one issue number.
-Retarget to that leaf.
-
-Skip leaf tracing when:
-- The target was queue-selected (`issue <num>`) — `dispatch-select-target` already
-  resolved it to a startable open leaf.
-- A PR exists for the target — check with:
-  ```bash
-  .claude/skills/dispatch-propagate/scripts/dispatch-find-pr <N>
-  ```
-  If it prints a PR number, skip leaf tracing (whether the target arrived as a
-  `pr <num> <branch> <phase>` queue result or as an explicit issue argument).
-  **Do not infer PR existence from title search or other ad-hoc `gh` queries** —
-  `dispatch-find-pr` is the only correct check (see Step 5).
-
-Check the resolved target issue `<N>` for open blockers
-(`dangerouslyDisableSandbox: true` — the script calls `gh`):
-
-```bash
-.claude/skills/dispatch-propagate/scripts/dispatch-check-blockers <N>
-```
-
-Route on its exit code:
-
-- **Exit 0** (no output) — no open blockers. Continue.
-- **Exit 2** (prints `blocked:<num>[,<num>…]`) — the target has open blockers.
-  Release the lock (see *Releasing the lock*), report the listed blocker(s),
-  park the issue with
-
-  ```bash
-  .claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours <N> "target has an open blocker"
-  ```
-
-  (see *Applying `dispatch:office-hours`* below), then proceed to Step 7 with
-  `notify target-blocked`.
-
-This guard applies even when a PR exists; closed blockers do not gate.
-`dispatch-check-blockers` routes through `count_open_blockers` — the same helper
-the queue path (`dispatch-select-target`) uses — so the explicit and queue paths
-agree on what counts as "blocked".
-
-If a named target issue is **closed**, release the lock (see *Releasing the
-lock*), report it, park the issue with
-
-```bash
-.claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours <N> "named target issue is closed"
-```
-
-(see *Applying `dispatch:office-hours`* below), then proceed to Step 7 with
-`notify target-blocked`.
-
-### Applying `dispatch:office-hours`
-
-`notify target-blocked` queues the target for human review.
-`dispatch-apply-office-hours <N> <reason>` is the single write path: it applies
-the label to the **issue** (never a PR), creates the label on first use with
-the canonical color and description, is idempotent (a second call posts no
-duplicate comment), and posts a why-comment carrying the reason. Run it with
-`dangerouslyDisableSandbox: true` — `gh` needs network.
-
-No PR resolution is needed to park a target; the label always lands on the
-issue, where the office-hours queue readers anchor their skip.
-
-## 5. Resolve the Worktree
-
-Run the worktree-resolution script. Pass `explicit` when the target was named by
-an explicit `/dispatch-propagate` argument, otherwise `queue`:
-
-```bash
-.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree <N> <explicit|queue>
-```
-
-Here `<N>` is always the **issue** number, never a PR number. For a `pr` row it
-is the branch-prefix `N` set in Step 3, not the row's PR `<num>`;
-`dispatch-resolve-worktree` rejects a PR number with a clear error rather than
-fabricate a stray `<pr-num>-*` worktree from `origin/main` (#926).
-
-It prints exactly one decision line — act on it. Each branch resolves a
-worktree path that Step 6 passes to `dispatch-spawn-worker`.
-
-- **`enter <path>`** → re-use an existing `<issue>-*` worktree
-  (recycle-after-completion for an explicit argument, or recycle of an orphan
-  worktree — on disk, no live session — for a queue selection, #905). A reused
-  worktree whose checked-out branch differs from the target PR's head branch
-  (resolved by `dispatch-find-pr`) is re-pointed to the PR head branch by the
-  resolver before it emits `enter` — lossless, since the case where the existing
-  branch carries commits not on the PR head yields `conflict` instead (#913).
-  Set `WORKTREE_PATH=<path>` for Step 6. Re-sync issue context from the worktree
-  (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`):
-  ```bash
-  (cd <path> && .claude/skills/dispatch-propagate/scripts/sync-issue-context <N>)
-  ```
-
-- **`create <branch>`** → no worktree exists; the router materializes it
-  explicitly (the `WorktreeCreate` hook does not fire here, so this step takes
-  over its responsibilities):
-
-  1. Resolve the worktree path (project root is the parent of `--git-common-dir`):
-     ```bash
-     GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
-     PROJECT_ROOT=$(dirname "$GIT_COMMON_DIR")
-     WORKTREE_PATH="$PROJECT_ROOT/worktrees/<branch>"
-     ```
-  2. Create the worktree from `origin/main` (sandbox-allowed under `worktrees/`;
-     see `.claude/rules/sandbox.md`):
-     ```bash
-     git worktree add -b <branch> "$WORKTREE_PATH" origin/main
-     ```
-  3. Authorize and pre-evaluate `.envrc` for the new tree
-     (`dangerouslyDisableSandbox: true` — direnv writes its on-disk cache):
-     ```bash
-     direnv allow "$WORKTREE_PATH"
-     direnv exec "$WORKTREE_PATH" true
-     ```
-     `direnv allow` whitelists the `.envrc`; `direnv exec` warms the cache so the
-     worker's Bash calls pick up the flake env (`node`, `npm`, `npx`, `tsc`).
-  4. Populate `CLAUDE.local.md` with full issue context
-     (`dangerouslyDisableSandbox: true` — `sync-issue-context` calls `gh`):
-     ```bash
-     (cd "$WORKTREE_PATH" && .claude/skills/dispatch-propagate/scripts/sync-issue-context <N>)
-     ```
-
-- **`conflict <path>`** → the worktree at `<path>` cannot be safely entered.
-  Either a queue-selected target already has a worktree another live session
-  owns (`dispatch-select-target` resolves the `help wanted` tier to a leaf with
-  no worktree, so for a queue selection this arises only from a race — another
-  session created the worktree between selection and worktree resolution), or
-  the reused `<issue>-*` worktree's checked-out branch carries commits not on
-  the target PR's head branch, so re-pointing it would discard work (#913).
-  Release the lock (see *Releasing the lock*), then proceed to
-  Step 7 with `notify worktree-conflict` — the user-visible report is mandatory
-  there. The message depends on which conflict case fired:
-  - Live-session race: "worktree at `<path>` owned by another live session for
-    issue `<N>`; closing — the next baton-pass or office-hours hand-off will
-    re-seed"
-  - Unique-commits branch mismatch: "worktree at `<path>` for issue `<N>` is
-    on a branch with commits not on the PR head branch; manual inspection needed
-    before re-entry"
-
-  Not optional. Do not spawn a worker.
-
-As the **final action of this step on every non-`conflict` (proceed) path** —
-before Step 6 — run `dispatch-finalize-selection "$WORKTREE_PATH"`. The
-wrapper `cd`s into the target worktree, writes the recovery marker
-**inside the target worktree** (`$WORKTREE_PATH/tmp/dispatch-worktree`), and
-releases the lock in one step (see *Releasing the lock*). The worker in Step 6
-onward runs lock-free.
-
-The marker is the canonical "Step 5 completed" signal used by the lock script's
-post-Step-5 reclaim path; see reference.md (*Step 5 marker deep dive*).
-
-## 6. Spawn the Worker
-
-Spawn a `/dispatch-worker <N> <worktree-path>` background job.
-`dispatch-spawn-worker` runs from the router's cwd (`worktrees/main`) but spawns
-`claude --bg` with cwd = `<worktree-path>`, so the worker is born in its target
-worktree (see reference.md *Step 6 spawn-cwd trade-off*).
-
-Before anything else in this step, run the **CI-status gate**. Derive the
-target's phase with `dispatch-phase <N>` (`dangerouslyDisableSandbox: true` —
-it calls `gh`):
-
-```bash
-.claude/skills/dispatch-propagate/scripts/dispatch-phase <N>
-```
-
-- If it returns `waiting` — the target's CI is still in progress — **skip the
-  spawn for this tick**. Do not consult the concurrency budgeter and do not run
-  `dispatch-spawn-worker`. Do **not** release the lock: it is already released
-  at the end of Step 5, so — exactly like the concurrency-cap gate — this gate
-  is lock-free. Print the mandatory user-visible report verbatim:
-
-  ```
-  #<N>: CI in progress; the next router tick will re-evaluate.
-  ```
-
-  Then proceed to Step 7 with disposition `drain ci-waiting`.
-- Otherwise — any non-`waiting` phase — fall through to the concurrency-budget
-  gate and the spawn below.
-
-Before spawning, consult the concurrency budgeter (see reference.md
-*Concurrency budgeting*); if the live worker count already meets the target,
-**skip the spawn** for this tick. Run with `dangerouslyDisableSandbox: true`
-(budgeter + `lib-claude-agents.sh` socket query; see `.claude/rules/sandbox.md`):
-
-```bash
-source .claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh
-TARGET_N=$(.claude/skills/dispatch-propagate/scripts/dispatch-target-workers)
-if LIVE_COUNT=$(claude_agents_count_by_name_prefix dispatch-worker-); then
-  if (( LIVE_COUNT >= TARGET_N )); then
-    echo "router: skipping spawn — $LIVE_COUNT live worker(s) >= target $TARGET_N (drain concurrency-cap)"
-    # drain concurrency-cap: schedule the cap-keyed re-seed (see Step 7), then go to Step 7.
-    .claude/skills/dispatch-propagate/scripts/dispatch-schedule-reseed
-  else
-    .claude/skills/dispatch-propagate/scripts/dispatch-spawn-worker <N> "$WORKTREE_PATH"
-  fi
-else
-  # UNKNOWN — daemon query failed. Fail open; dispatch-spawn-worker's dedup is the last-line defense.
-  .claude/skills/dispatch-propagate/scripts/dispatch-spawn-worker <N> "$WORKTREE_PATH"
-fi
-```
-
-On the skip path, `dispatch-schedule-reseed` re-seeds the chain when the cap
-window reopens (see *The #725 cap-keyed re-seed* below).
-
-`dispatch-spawn-worker` prints `spawned` or `deduped` (per-worktree invariant —
-see reference.md *Per-worktree invariant*) and exits 0; it exits non-zero when a
-worker was spawned but did not register. The router never derives the phase,
-runs a phase skill, or invokes the pre-implementation relevance review — those
-are the worker's responsibilities (`/dispatch-worker` Steps 1–3).
-
-After the spawn (or skip) returns, **proceed to Step 7** (terminal disposition).
-The budgeter's pace-relative pipeline, tunables, and missing-telemetry
-fallback are detailed in reference.md (*Concurrency budgeting*).
-
-## 7. Terminal Disposition
-
-The router's tick ends here. The disposition that routed it here determines
-the action.
-
-**Invariant**: the only silent terminal path is `propagate` on success. Every
-other terminal disposition emits a user-visible report before the session ends
-(before `dispatch-self-close` for `drain` and `propagate`; before this turn's
-text output completes for `notify`, which does not self-close). A silent
-`notify` or silent `drain` is a defect.
-
-The three dispositions:
-
-- **`propagate`** — Step 6's `dispatch-spawn-worker` returned `spawned` or
-  `deduped`. The chain moved forward. Self-close
+`<N>` is always the **issue** number (for a `pr` row, the branch-prefix `N`
+derived above — never the PR number). The script prints supporting detail (a
+path, a blocker list, the CI line) and the **terminal token** as its last line.
+The lock disposition is again the script's responsibility — it releases the lock
+at every stop and via `dispatch-finalize-selection` on the proceed path. Route
+on the token (Table 2).
+
+### Table 2 — routing the materialize-spawn terminal token
+
+| Terminal token | User-visible report (the model emits it) | Disposition |
+|---|---|---|
+| `propagate` | none — the chain moved forward silently | `propagate` |
+| `notify target-blocked` | The named target is closed or has an open blocker (the script printed which and already applied `dispatch:office-hours` to the issue). | `notify` |
+| `notify spawn-failed` | `dispatch-spawn-worker` exited non-zero — a worker was spawned but did not register. | `notify` |
+| `drain worktree-conflict` | The target worktree cannot be safely entered (the script printed the `path:` detail): "worktree at `<path>` for issue `<N>` cannot be entered; closing — the next baton-pass or office-hours hand-off will re-seed". | `drain` |
+| `drain ci-waiting` | The target PR's CI is still in progress (the script printed the `#<N>:` line); echo it. | `drain` |
+| `drain concurrency-cap` | The live worker count already meets the budget; a cap-keyed re-seed is scheduled (see reference.md *The #725 cap-keyed re-seed*). | `drain` |
+
+## 3. Terminal disposition
+
+The tick ends with one of three disposition **kinds**. The **only** silent path
+is `propagate`; every other disposition emits a user-visible report first (a
+silent `notify` or `drain` is a defect).
+
+- **`propagate`** — the chain advanced. Self-close
   (`dangerouslyDisableSandbox: true`):
 
-  ```bash
-  .claude/skills/dispatch-propagate/scripts/dispatch-self-close
-  ```
+      .claude/skills/dispatch-propagate/scripts/dispatch-self-close
 
-- **`notify <reason>`** — `notify spawn-failed` (Step 6's spawn exited
-  non-zero) or any Steps 0–5 variance. The call site has already printed a
-  user-visible report; for `notify target-blocked` it has also applied
-  `dispatch:office-hours` to the target's **issue** via
-  `dispatch-apply-office-hours` (see Step 4's *Applying
-  `dispatch:office-hours`* subsection). Do **not**
-  self-close — the session stays in `claude agents` until the user closes
-  it, so the variance is visible rather than buried in a closed transcript.
+- **`notify <reason>`** — report the variance, then **do not self-close**. The
+  session stays in `claude agents` until the user closes it, so the variance is
+  visible rather than buried in a closed transcript. For `notify target-blocked`
+  the script already parked the issue with `dispatch:office-hours`.
 
-  The Steps 0–5 `notify` variances and their sources:
+- **`drain <reason>`** — emit the mandatory report, then self-close (same
+  command as `propagate`).
 
-  | Disposition | Source |
-  |---|---|
-  | `notify busy-lock-timeout` | Step 0 — wait timeout while another router holds the lock (subsumes #850) |
-  | `notify sync-failed` | Step 1 — `git fetch` failed or `git merge --ff-only` rejected a non-fast-forward |
-  | `notify resolver-failed` | Step 3 — `dispatch-resolve-arg` non-zero (PR closes ≠1 issue, bad argument) |
-  | `notify main-broken` | Step 3 — `/dispatch-diagnose-main` ran and returned (`origin/main` is red) |
-  | `notify target-blocked` | Step 4 — named target is closed or has an open blocker |
-
-- **`drain <reason>`** — `drain empty-queue` (Step 3, queue empty),
-  `drain worktree-conflict` (Step 5, target's worktree cannot be safely
-  entered — either a live session owns it, or the worktree's branch carries
-  commits not on the PR head branch; see the `conflict` case in Step 5),
-  `drain ci-waiting` (Step 6, the target PR's CI is still in progress —
-  `dispatch-phase` returned `waiting`; unlike `drain concurrency-cap` this
-  schedules no re-seed — the chain re-evaluates the PR on the next router tick
-  from an existing source: a worker's Stop hook, the #725 cap-keyed timer, or a
-  manual `/dispatch`), or `drain concurrency-cap` (Step 6, `live_count >=
-  target_N` — the chain re-seeds when the cap-keyed timer fires at the next
-  rate-limit window reset; see *The #725 cap-keyed re-seed* below). The call site has already printed a **mandatory** user-visible
-  report stating the reason and the recovery path (templates live at the
-  Step 3, Step 5, and Step 6 call sites). Then self-close
-  (`dangerouslyDisableSandbox: true`):
-
-  ```bash
-  .claude/skills/dispatch-propagate/scripts/dispatch-self-close
-  ```
-
-`dispatch-self-close` removes the managed background job by its job-id; it is a
+`dispatch-self-close` removes the managed background job by job-id; it is a
 no-op when `CLAUDE_JOB_DIR` is unset (interactive session), so an interactive
-`/dispatch-propagate` reaching Step 7 does not stop the user's conversation.
+`/dispatch-propagate` reaching a terminal disposition does not stop the user's
+conversation.
 
-Step 3's `jit-reminder` outcome does not reach Step 7 — it stops the tick
-directly. The router does **not** spawn a successor `/dispatch-propagate` itself;
-the worker's Stop hook (`.claude/hooks/dispatch-stop.sh`) spawns a fresh router
-back in `worktrees/main` when the worker session ends.
+The `jit-reminder` outcome (Table 1) does not reach this section — the sub-skill
+stops the tick directly. The router does **not** spawn a successor itself; the
+worker's Stop hook (`.claude/hooks/dispatch-stop.sh`) spawns a fresh router back
+in `worktrees/main` when the worker session ends.
 
-### The #725 cap-keyed re-seed
-
-The chain's resume-from-cap-stall mechanism: when Step 6 skips the spawn at a
-rate-limit cap, `dispatch-schedule-reseed` writes a transient `systemd.user`
-timer keyed on the blocking window's `resets_at` to re-seed the chain when the
-cap reopens. See reference.md (*The #725 cap-keyed re-seed*) for the full
-mechanism, idempotency, and the office-hours fallback for non-cap stalls.
+Deep "why" — chain mechanics, the lock's two scopes and marker-based reclaim,
+the selection ladder, the Step-5 marker, the spawn-cwd trade-off, concurrency
+budgeting, and the #725 cap-keyed re-seed — lives in reference.md.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -97,8 +97,14 @@ if [[ "$MODE" == "explicit" ]]; then
     fi
   fi
 
-  # Closed-target guard. gh issue view returns OPEN/CLOSED (uppercase).
-  ISSUE_STATE=$(gh issue view "$N" --json state -q .state 2>/dev/null) || ISSUE_STATE=""
+  # Closed-target guard. gh issue view returns OPEN/CLOSED (uppercase). A gh
+  # failure must not fail open (silently dispatching to a possibly-closed
+  # issue) — surface it as a hard error and release the lock.
+  ISSUE_STATE=$(gh issue view "$N" --json state -q .state 2>/dev/null) || {
+    release_lock
+    echo "dispatch-materialize-spawn: failed to fetch state for issue #$N" >&2
+    exit 2
+  }
   if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
     release_lock
     "$SCRIPT_DIR/dispatch-apply-office-hours" "$N" "named target issue is closed" 1>&2 || true
@@ -141,10 +147,18 @@ case "$WT_ACTION" in
     ;;
   create)
     BRANCH="$WT_REST"
-    GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
+    GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir) || {
+      release_lock
+      echo "dispatch-materialize-spawn: git rev-parse --git-common-dir failed for #$N" >&2
+      exit 2
+    }
     PROJECT_ROOT=$(dirname "$GIT_COMMON_DIR")
     WORKTREE_PATH="$PROJECT_ROOT/worktrees/$BRANCH"
-    git worktree add -b "$BRANCH" "$WORKTREE_PATH" origin/main 1>&2
+    if ! git worktree add -b "$BRANCH" "$WORKTREE_PATH" origin/main 1>&2; then
+      release_lock
+      echo "dispatch-materialize-spawn: git worktree add failed for $BRANCH" >&2
+      exit 2
+    fi
     direnv allow "$WORKTREE_PATH" 1>&2 || true
     direnv exec "$WORKTREE_PATH" true 1>&2 || true
     ( cd "$WORKTREE_PATH" && "$SCRIPT_DIR/sync-issue-context" "$N" ) 1>&2 || true
@@ -164,7 +178,13 @@ esac
 
 # Write the recovery marker into the target worktree and release the lock in one
 # step. Lock-free from here. Its stdout (released/noop) goes to stderr.
-"$SCRIPT_DIR/dispatch-finalize-selection" "$WORKTREE_PATH" 1>&2
+if ! "$SCRIPT_DIR/dispatch-finalize-selection" "$WORKTREE_PATH" 1>&2; then
+  # finalize-selection failed before its --release step, so the lock is still
+  # held — release it explicitly so a stuck holder does not wedge the next tick.
+  release_lock
+  echo "dispatch-materialize-spawn: dispatch-finalize-selection failed for $WORKTREE_PATH" >&2
+  exit 2
+fi
 
 # --- Step 6a: waiting-CI gate (#906) -----------------------------------------
 PHASE=$("$SCRIPT_DIR/dispatch-phase" "$N") || PHASE=""

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# dispatch-materialize-spawn — the /dispatch-propagate router's
+# materialize-and-spawn orchestrator (the deterministic Steps 4-6 of the old
+# SKILL.md, bundled into one script).
+#
+# Usage: dispatch-materialize-spawn <issue-N> <explicit|queue> [--bypass-cap]
+#
+# Picks up after dispatch-select-tick has chosen a target. Runs the explicit-
+# path guards (leaf trace, closed-target, open-blocker), resolves the target
+# worktree (entering or creating it), writes the recovery marker + releases the
+# lock via dispatch-finalize-selection, runs the waiting-CI gate, consults the
+# concurrency budgeter, and spawns the worker. Prints exactly ONE terminal
+# token as its LAST stdout line; supporting detail (a path, a blocker list, the
+# CI line) precedes the token.
+#
+# <issue-N> is always the ISSUE number (the model derives N=${branch%%-*} for a
+# `pr` row before calling). The two literal `[branch phase]` positionals the
+# queue selection carries are dropped — no sub-script consumes them; the CI gate
+# re-derives the phase via dispatch-phase.
+#
+# Terminal tokens (the last stdout line is always exactly one of):
+#   propagate              the worker spawned (or deduped); the chain advances.
+#                          Lock already released by finalize-selection.
+#   notify target-blocked  explicit target is closed or has an open blocker; the
+#                          issue is parked via dispatch-apply-office-hours and
+#                          the lock released at the guard.
+#   notify spawn-failed    dispatch-spawn-worker exited non-zero. Lock already
+#                          released by finalize-selection.
+#   drain worktree-conflict  the target worktree cannot be safely entered; the
+#                          lock is released at the guard. The conflict path
+#                          precedes this token.
+#   drain ci-waiting       the target PR's CI is still in progress; no spawn this
+#                          tick. Lock already released by finalize-selection.
+#   drain concurrency-cap  the live worker count already meets the budget; a
+#                          cap-keyed re-seed is scheduled. Lock already released.
+#
+# Lock-release points: `notify target-blocked` and `drain worktree-conflict`
+# release explicitly at the guard (the marker does not exist yet on these
+# pre-finalize stop paths). `propagate` / `notify spawn-failed` /
+# `drain ci-waiting` / `drain concurrency-cap` are all reached AFTER
+# dispatch-finalize-selection has released the lock, so they do not re-release.
+#
+# Requires `dangerouslyDisableSandbox: true` — sub-scripts call `gh`, query the
+# Claude daemon over a Unix socket, and write tmp state; `git worktree add` and
+# `direnv` write to disk. See .claude/rules/sandbox.md.
+#
+# Exit code: 0 on every terminal token; 2 on a usage / internal error surfaced
+# on stderr.
+#
+# NOT set -e: exits are handled explicitly (matching the sibling dispatch
+# scripts).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+N="${1:-}"
+MODE="${2:-}"
+BYPASS_CAP=0
+if [[ "${3:-}" == "--bypass-cap" ]]; then
+  BYPASS_CAP=1
+elif [[ -n "${3:-}" ]]; then
+  echo "dispatch-materialize-spawn: unexpected argument '$3'" >&2
+  exit 2
+fi
+
+if [[ ! "$N" =~ ^[1-9][0-9]*$ ]] || { [[ "$MODE" != "explicit" && "$MODE" != "queue" ]]; }; then
+  echo "dispatch-materialize-spawn: usage: dispatch-materialize-spawn <issue-N> <explicit|queue> [--bypass-cap]" >&2
+  exit 2
+fi
+
+release_lock() {
+  "$SCRIPT_DIR/dispatch-acquire-lock" --release >/dev/null 2>&1 || true
+}
+
+# --- Step 4: explicit-path guards (skipped entirely in queue mode) -----------
+# Queue rows were already vetted by dispatch-select-target (leaf, blockers,
+# liveness), so the guards run only when the target was explicitly named.
+if [[ "$MODE" == "explicit" ]]; then
+  # Leaf trace, unless a PR already exists for the target (then the PR is the
+  # unit of work and the issue tree is irrelevant).
+  PR=$("$SCRIPT_DIR/dispatch-find-pr" "$N" 2>/dev/null) || PR=""
+  if [[ -z "$PR" ]]; then
+    if LEAF=$("$SCRIPT_DIR/dispatch-trace-leaf" "$N" explicit); then
+      N="$LEAF"
+    fi
+  fi
+
+  # Closed-target guard. gh issue view returns OPEN/CLOSED (uppercase).
+  ISSUE_STATE=$(gh issue view "$N" --json state -q .state 2>/dev/null) || ISSUE_STATE=""
+  if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
+    release_lock
+    "$SCRIPT_DIR/dispatch-apply-office-hours" "$N" "named target issue is closed" 1>&2 || true
+    echo "target #$N is closed"
+    echo "notify target-blocked"
+    exit 0
+  fi
+
+  # Open-blocker guard. Exit 2 → blocked:<nums> on stdout.
+  if BLOCKERS=$("$SCRIPT_DIR/dispatch-check-blockers" "$N"); then
+    : # exit 0, no open blockers
+  else
+    rc=$?
+    if [[ "$rc" -eq 2 ]]; then
+      release_lock
+      "$SCRIPT_DIR/dispatch-apply-office-hours" "$N" "target has an open blocker" 1>&2 || true
+      echo "$BLOCKERS"
+      echo "notify target-blocked"
+      exit 0
+    fi
+    echo "dispatch-materialize-spawn: dispatch-check-blockers failed (exit $rc) for #$N" >&2
+    exit 2
+  fi
+fi
+
+# --- Step 5: resolve the worktree --------------------------------------------
+WT_DECISION=$("$SCRIPT_DIR/dispatch-resolve-worktree" "$N" "$MODE") || {
+  echo "dispatch-materialize-spawn: dispatch-resolve-worktree failed for #$N ($MODE)" >&2
+  exit 2
+}
+WT_ACTION="${WT_DECISION%% *}"
+WT_REST="${WT_DECISION#* }"
+
+case "$WT_ACTION" in
+  enter)
+    WORKTREE_PATH="$WT_REST"
+    ( cd "$WORKTREE_PATH" && "$SCRIPT_DIR/sync-issue-context" "$N" ) 1>&2 || true
+    ;;
+  create)
+    BRANCH="$WT_REST"
+    GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
+    PROJECT_ROOT=$(dirname "$GIT_COMMON_DIR")
+    WORKTREE_PATH="$PROJECT_ROOT/worktrees/$BRANCH"
+    git worktree add -b "$BRANCH" "$WORKTREE_PATH" origin/main 1>&2
+    direnv allow "$WORKTREE_PATH" 1>&2 || true
+    direnv exec "$WORKTREE_PATH" true 1>&2 || true
+    ( cd "$WORKTREE_PATH" && "$SCRIPT_DIR/sync-issue-context" "$N" ) 1>&2 || true
+    ;;
+  conflict)
+    release_lock
+    echo "path: $WT_REST"
+    echo "drain worktree-conflict"
+    exit 0
+    ;;
+  *)
+    echo "dispatch-materialize-spawn: dispatch-resolve-worktree emitted unexpected '$WT_DECISION'" >&2
+    exit 2
+    ;;
+esac
+
+# Write the recovery marker into the target worktree and release the lock in one
+# step. Lock-free from here. Its stdout (released/noop) goes to stderr.
+"$SCRIPT_DIR/dispatch-finalize-selection" "$WORKTREE_PATH" 1>&2
+
+# --- Step 6a: waiting-CI gate (#906) -----------------------------------------
+PHASE=$("$SCRIPT_DIR/dispatch-phase" "$N") || PHASE=""
+if [[ "$PHASE" == "waiting" ]]; then
+  echo "#$N: CI in progress; the next router tick will re-evaluate."
+  echo "drain ci-waiting"
+  exit 0
+fi
+
+# --- Step 6b: concurrency gate (skipped under --bypass-cap) ------------------
+if (( ! BYPASS_CAP )); then
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/lib-claude-agents.sh"
+  TARGET_N=$("$SCRIPT_DIR/dispatch-target-workers")
+  if LIVE_COUNT=$(claude_agents_count_by_name_prefix dispatch-worker-); then
+    if (( LIVE_COUNT >= TARGET_N )); then
+      "$SCRIPT_DIR/dispatch-schedule-reseed" 1>&2 || true
+      echo "router: $LIVE_COUNT live worker(s) >= target $TARGET_N"
+      echo "drain concurrency-cap"
+      exit 0
+    fi
+    # under cap → fall through to spawn
+  fi
+  # daemon UNKNOWN (if-condition false) → fail open → fall through to spawn;
+  # dispatch-spawn-worker's per-worktree dedup is the last-line defense.
+fi
+
+# --- Step 6c: spawn the worker -----------------------------------------------
+if "$SCRIPT_DIR/dispatch-spawn-worker" "$N" "$WORKTREE_PATH" 1>&2; then
+  echo "propagate"
+  exit 0
+fi
+echo "notify spawn-failed"
+exit 0

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -39,6 +39,9 @@
 # pre-finalize stop paths). `propagate` / `notify spawn-failed` /
 # `drain ci-waiting` / `drain concurrency-cap` are all reached AFTER
 # dispatch-finalize-selection has released the lock, so they do not re-release.
+# An internal `exit 2` failure before dispatch-finalize-selection (a hard
+# trace-leaf / check-blockers / resolve-worktree error) also releases the lock
+# so a stuck holder does not wedge the next tick.
 #
 # Requires `dangerouslyDisableSandbox: true` — sub-scripts call `gh`, query the
 # Claude daemon over a Unix socket, and write tmp state; `git worktree add` and
@@ -82,6 +85,15 @@ if [[ "$MODE" == "explicit" ]]; then
   if [[ -z "$PR" ]]; then
     if LEAF=$("$SCRIPT_DIR/dispatch-trace-leaf" "$N" explicit); then
       N="$LEAF"
+    else
+      # explicit-mode dispatch-trace-leaf exits non-zero only on a hard
+      # sibling-gh failure (its exit 1) — never "no work". Per its contract the
+      # caller must not swallow it and dispatch the un-traced N; release the
+      # lock and surface the error (mirrors dispatch-select-target's exit-1
+      # propagation in queue mode).
+      release_lock
+      echo "dispatch-materialize-spawn: dispatch-trace-leaf failed for #$N (explicit)" >&2
+      exit 2
     fi
   fi
 
@@ -107,6 +119,7 @@ if [[ "$MODE" == "explicit" ]]; then
       echo "notify target-blocked"
       exit 0
     fi
+    release_lock
     echo "dispatch-materialize-spawn: dispatch-check-blockers failed (exit $rc) for #$N" >&2
     exit 2
   fi
@@ -114,6 +127,7 @@ fi
 
 # --- Step 5: resolve the worktree --------------------------------------------
 WT_DECISION=$("$SCRIPT_DIR/dispatch-resolve-worktree" "$N" "$MODE") || {
+  release_lock
   echo "dispatch-materialize-spawn: dispatch-resolve-worktree failed for #$N ($MODE)" >&2
   exit 2
 }
@@ -142,6 +156,7 @@ case "$WT_ACTION" in
     exit 0
     ;;
   *)
+    release_lock
     echo "dispatch-materialize-spawn: dispatch-resolve-worktree emitted unexpected '$WT_DECISION'" >&2
     exit 2
     ;;

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# dispatch-select-tick — the /dispatch-propagate router's selection orchestrator
+# (the deterministic Steps 0-3 of the old SKILL.md, bundled into one script).
+#
+# Usage: dispatch-select-tick [<issue-or-PR-number>]
+#
+# Runs the lock acquisition, origin/main sync (only on `main`), the JIT engine,
+# and target selection as one deterministic sequence and prints exactly ONE
+# decision line as its LAST stdout line. Any JIT `created`/`skipped`/`debounced`
+# lines are passed through first, each prefixed `jit: `. The router (SKILL.md)
+# routes on the final decision line; a model-decision seam (`main-broken` /
+# `jit-reminder`) and the worktree materialization (`dispatch-materialize-spawn`)
+# live on the other side of the seam, not here.
+#
+# Decision lines (the last stdout line is always exactly one of):
+#   busy             lock held by another tick; nothing acquired, nothing released.
+#   sync-failed      git fetch / merge --ff-only failed on `main`; lock released.
+#   resolver-failed  explicit arg did not resolve to one issue; lock released.
+#   explicit <num>   explicit arg resolved to issue <num>; lock HELD.
+#   pr <num> <branch> <phase>   queue selected a PR; lock HELD.
+#   issue <num>      queue selected a help-wanted leaf; lock HELD.
+#   main-broken <sha>   origin/main is red; lock HELD (the sub-skill releases).
+#   jit-reminder <repo> <num> <project> <item-id>   a JIT reminder is due; lock
+#                    HELD (the sub-skill releases).
+#   empty            nothing eligible; lock released.
+#
+# Lock invariant (the three guards): HOLD on pr/issue/explicit/main-broken/
+# jit-reminder; RELEASE on empty/sync-failed/resolver-failed; NEVER release on
+# busy (nothing was acquired).
+#
+# Requires `dangerouslyDisableSandbox: true` — sub-scripts write tmp state, call
+# `gh`, and query the local Claude daemon over a Unix socket. The `--wait` lock
+# acquisition needs an elevated Bash `timeout` (see SKILL.md Step 0).
+# See .claude/rules/sandbox.md.
+#
+# Exit code: 0 on every decision line; 2 on an internal/usage error surfaced on
+# stderr.
+#
+# NOT set -e: exits are handled explicitly (matching the sibling dispatch
+# scripts).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ARG="${1:-}"
+ARG="${ARG#\#}"
+
+if [[ $# -gt 1 ]]; then
+  echo "dispatch-select-tick: unexpected extra arguments after <number>" >&2
+  exit 2
+fi
+
+release_lock() {
+  "$SCRIPT_DIR/dispatch-acquire-lock" --release >/dev/null 2>&1 || true
+}
+
+# --- Step 0: acquire the dispatch lock ---------------------------------------
+# Let acquire-lock's stderr holder-diagnostic flow through on `busy`.
+LOCK=$("$SCRIPT_DIR/dispatch-acquire-lock" --wait) || true
+if [[ "$LOCK" == busy ]]; then
+  echo "busy"
+  exit 0
+fi
+if [[ "$LOCK" != acquired ]]; then
+  echo "dispatch-select-tick: dispatch-acquire-lock returned unexpected '$LOCK'" >&2
+  exit 2
+fi
+
+# --- Step 1: sync local main with origin/main (only on the main branch) -------
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [[ "$BRANCH" == "main" ]]; then
+  # Redirect git's own chatter to stderr so stdout stays the decision channel.
+  if ! git fetch origin main 1>&2 || ! git merge --ff-only origin/main 1>&2; then
+    release_lock
+    echo "sync-failed"
+    exit 0
+  fi
+fi
+
+# --- Step 2: run the JIT engine (best-effort) --------------------------------
+# Pass its stdout lines through, prefixed; let stderr flow on a non-zero exit.
+JIT_OUT=$("$SCRIPT_DIR/dispatch-jit-engine") || true
+if [[ -n "$JIT_OUT" ]]; then
+  while IFS= read -r jit_line; do
+    [[ -n "$jit_line" ]] && echo "jit: $jit_line"
+  done <<< "$JIT_OUT"
+fi
+
+# --- Step 3: select the target -----------------------------------------------
+if [[ -n "$ARG" ]]; then
+  if TARGET=$("$SCRIPT_DIR/dispatch-resolve-arg" "$ARG"); then
+    echo "explicit $TARGET"
+    exit 0
+  fi
+  release_lock
+  echo "resolver-failed"
+  exit 0
+fi
+
+SELECTED=$("$SCRIPT_DIR/dispatch-select-target") || true
+case "$SELECTED" in
+  pr\ *|issue\ *|main-broken\ *|jit-reminder\ *)
+    # Hold the lock; pass the selection line through verbatim. For main-broken
+    # and jit-reminder the invoked sub-skill releases the lock at its own exit.
+    echo "$SELECTED"
+    ;;
+  empty)
+    release_lock
+    echo "empty"
+    ;;
+  *)
+    release_lock
+    echo "dispatch-select-tick: dispatch-select-target emitted unexpected '$SELECTED'" >&2
+    exit 2
+    ;;
+esac

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -10241,6 +10241,72 @@ case "$err" in *"unexpected argument"*"EXIT=2") s3=ok ;; *) s3="bad: $err" ;; es
 assert_eq "unexpected 3rd arg → usage error, exit 2" "ok" "$s3"
 mat_teardown
 
+# --- create-path git worktree add failure → exit 2 + lock released -----------
+# git worktree add runs unchecked under `set -uo pipefail` (no -e); a non-zero
+# exit must release the lock, else the holder wedges every subsequent tick (the
+# lock never frees). Regression for the unchecked-exit lock-leak.
+echo "Test: materialize-spawn git worktree add failure → exit 2 + lock released"
+mat_setup
+cat > "$TMPDIR_TEST/bin/git" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/git.log"
+case "\$*" in
+  "rev-parse --path-format=absolute --git-common-dir") echo "$TMPDIR_TEST/project/.bare" ;;
+  "worktree add -b "*) echo "fatal: branch already checked out" >&2; exit 128 ;;
+  *) : ;;
+esac
+STUB
+chmod +x "$TMPDIR_TEST/bin/git"
+out=$(run_mat 839 queue) && rc=0 || rc=$?
+assert_eq "wt-add fail: exit 2" "2" "$rc"
+assert_eq "wt-add fail: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "wt-add fail: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- finalize-selection failure (worktree path missing) → exit 2 + lock released
+# dispatch-finalize-selection cd's into the target worktree; if that path does
+# not exist its cd fails (exit 2). The caller must release the lock rather than
+# proceed lock-held into the spawn. Here git worktree add "succeeds" but does NOT
+# create the directory, so finalize's cd fails. Regression for the unchecked
+# finalize exit.
+echo "Test: materialize-spawn finalize-selection failure → exit 2 + lock released"
+mat_setup
+cat > "$TMPDIR_TEST/bin/git" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/git.log"
+case "\$*" in
+  "rev-parse --path-format=absolute --git-common-dir") echo "$TMPDIR_TEST/project/.bare" ;;
+  "worktree add -b "*) : ;;
+  *) : ;;
+esac
+STUB
+chmod +x "$TMPDIR_TEST/bin/git"
+out=$(run_mat 839 queue) && rc=0 || rc=$?
+assert_eq "finalize fail: exit 2" "2" "$rc"
+assert_eq "finalize fail: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "finalize fail: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- explicit closed-check gh failure → exit 2 + lock released ---------------
+# The closed-target guard must not fail open on a gh error (silently dispatching
+# to a possibly-closed issue). A gh failure is a hard error: release + exit 2.
+echo "Test: materialize-spawn explicit gh issue view failure → exit 2 + lock released"
+mat_setup
+cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "gh: simulated failure" >&2
+exit 1
+STUB
+chmod +x "$TMPDIR_TEST/bin/gh"
+out=$(run_mat 839 explicit) && rc=0 || rc=$?
+assert_eq "gh fail: exit 2" "2" "$rc"
+assert_eq "gh fail: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "gh fail: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+mat_teardown
+
 # ============================================================================
 # summary
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -9837,6 +9837,23 @@ assert_eq "busy: foreign holder untouched (not released)" "other-live-session" \
   "$(cat "$DISPATCH_LOCK_FILE")"
 sel_tick_teardown
 
+# --- unexpected select-target line → release + exit 2 ------------------------
+echo "Test: select-tick unexpected select-target line → exit 2, lock released"
+sel_tick_setup
+cat > "$TMPDIR_TEST/dispatch-select-target" <<'FAKE'
+#!/usr/bin/env bash
+echo "garbage unexpected line"
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
+err=$("$TMPDIR_TEST/dispatch-select-tick" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err" in
+  *"emitted unexpected"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err" ;;
+esac
+assert_eq "unexpected select-target → error + exit 2" "ok" "$status"
+assert_eq "unexpected select-target: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
 # --- extra arguments → usage error, exit 2 -----------------------------------
 echo "Test: select-tick extra arguments → exit 2"
 sel_tick_setup
@@ -10191,6 +10208,23 @@ export MAT_SPAWN_RC=1
 out=$(run_mat 839 queue)
 assert_eq "spawn-failed: terminal token" "notify spawn-failed" \
   "$(printf '%s\n' "$out" | tail -n 1)"
+# spawn-failed is post-finalize: dispatch-finalize-selection already released
+# the lock before the spawn attempt, so the lock must be empty here.
+assert_eq "spawn-failed: lock already released by finalize" "" \
+  "$(cat "$DISPATCH_LOCK_FILE")"
+mat_teardown
+
+# --- unexpected resolve-worktree line → release + exit 2 ---------------------
+echo "Test: materialize-spawn unexpected resolve-worktree line → exit 2, lock released"
+mat_setup
+export MAT_WT_DECISION="bogus unexpected"
+err=$("$TMPDIR_TEST/dispatch-materialize-spawn" 839 queue 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err" in
+  *"emitted unexpected"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err" ;;
+esac
+assert_eq "unexpected resolve-worktree → error + exit 2" "ok" "$status"
+assert_eq "unexpected resolve-worktree: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
 # --- usage errors → exit 2 ---------------------------------------------------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -9723,6 +9723,328 @@ assert_eq "extra args → usage error, exit 2" "ok" "$status"
 sel_tick_teardown
 
 # ============================================================================
+# dispatch-materialize-spawn tests (#919)
+# ============================================================================
+# Runs against the REAL dispatch-materialize-spawn / dispatch-finalize-selection
+# / dispatch-acquire-lock (so the marker-write + lock-release are genuine and
+# asserted via DISPATCH_LOCK_FILE and the on-disk marker) and FAKE sub-scripts
+# for every guard / resolve / phase / budget / spawn step (so each terminal
+# token is driven deterministically). git/direnv/gh are PATH-shimmed.
+echo ""
+echo "=== dispatch-materialize-spawn ==="
+
+mat_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  STUB_DIR="$TMPDIR_TEST/stub"
+  mkdir -p "$STUB_DIR" "$TMPDIR_TEST/bin" "$TMPDIR_TEST/logs"
+
+  for s in dispatch-materialize-spawn dispatch-finalize-selection dispatch-acquire-lock; do
+    cp "$SCRIPT_DIR/$s" "$TMPDIR_TEST/$s"
+    chmod +x "$TMPDIR_TEST/$s"
+  done
+
+  # Real lock under our control; we hold it so finalize-selection / release do a
+  # strict self-release.
+  export DISPATCH_LOCK_FILE="$STUB_DIR/dispatch.lock"
+  export CLAUDE_CODE_SESSION_ID="mat-session"
+  printf '%s\n' "mat-session" > "$DISPATCH_LOCK_FILE"
+  cat > "$TMPDIR_TEST/fake-claude" <<'FAKE'
+#!/usr/bin/env bash
+echo '[{"sessionId":"mat-session","pid":1,"status":"busy","name":"x","cwd":""}]'
+FAKE
+  chmod +x "$TMPDIR_TEST/fake-claude"
+  export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/fake-claude"
+
+  # Fake sub-scripts (defaults; per-test overrides via MAT_* env vars).
+  cat > "$TMPDIR_TEST/dispatch-find-pr" <<'FAKE'
+#!/usr/bin/env bash
+[[ -n "${MAT_PR:-}" ]] && echo "$MAT_PR"
+exit 0
+FAKE
+  cat > "$TMPDIR_TEST/dispatch-trace-leaf" <<FAKE
+#!/usr/bin/env bash
+echo "trace \$*" >> "$TMPDIR_TEST/logs/trace-leaf.log"
+echo "\${MAT_LEAF:-\$1}"
+FAKE
+  cat > "$TMPDIR_TEST/dispatch-check-blockers" <<'FAKE'
+#!/usr/bin/env bash
+if [[ -n "${MAT_BLOCKED:-}" ]]; then echo "blocked:$MAT_BLOCKED"; exit 2; fi
+exit 0
+FAKE
+  cat > "$TMPDIR_TEST/dispatch-apply-office-hours" <<FAKE
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/apply-office-hours.log"
+exit 0
+FAKE
+  cat > "$TMPDIR_TEST/dispatch-resolve-worktree" <<FAKE
+#!/usr/bin/env bash
+echo "\${MAT_WT_DECISION:-create \$1-test}"
+FAKE
+  cat > "$TMPDIR_TEST/dispatch-phase" <<'FAKE'
+#!/usr/bin/env bash
+echo "${MAT_PHASE:-implement}"
+FAKE
+  cat > "$TMPDIR_TEST/dispatch-target-workers" <<'FAKE'
+#!/usr/bin/env bash
+echo "${MAT_TARGET_N:-1}"
+FAKE
+  cat > "$TMPDIR_TEST/dispatch-schedule-reseed" <<FAKE
+#!/usr/bin/env bash
+echo called >> "$TMPDIR_TEST/logs/schedule-reseed.log"
+exit 0
+FAKE
+  cat > "$TMPDIR_TEST/dispatch-spawn-worker" <<FAKE
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/spawn-worker.log"
+echo spawned
+exit \${MAT_SPAWN_RC:-0}
+FAKE
+  cat > "$TMPDIR_TEST/sync-issue-context" <<FAKE
+#!/usr/bin/env bash
+echo "cwd=\$PWD argv=\$*" >> "$TMPDIR_TEST/logs/sync-issue-context.log"
+FAKE
+  # Sourced helper: provides claude_agents_count_by_name_prefix.
+  cat > "$TMPDIR_TEST/lib-claude-agents.sh" <<'FAKE'
+claude_agents_count_by_name_prefix() {
+  [[ -n "${MAT_LIVE_COUNT_FAIL:-}" ]] && return 1
+  echo "${MAT_LIVE_COUNT:-0}"
+}
+FAKE
+  chmod +x "$TMPDIR_TEST"/dispatch-find-pr "$TMPDIR_TEST"/dispatch-trace-leaf \
+    "$TMPDIR_TEST"/dispatch-check-blockers "$TMPDIR_TEST"/dispatch-apply-office-hours \
+    "$TMPDIR_TEST"/dispatch-resolve-worktree "$TMPDIR_TEST"/dispatch-phase \
+    "$TMPDIR_TEST"/dispatch-target-workers "$TMPDIR_TEST"/dispatch-schedule-reseed \
+    "$TMPDIR_TEST"/dispatch-spawn-worker "$TMPDIR_TEST"/sync-issue-context
+
+  mkdir -p "$TMPDIR_TEST/project/.bare" "$TMPDIR_TEST/project/worktrees"
+  cat > "$TMPDIR_TEST/bin/git" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/git.log"
+case "\$*" in
+  "rev-parse --path-format=absolute --git-common-dir") echo "$TMPDIR_TEST/project/.bare" ;;
+  "worktree add -b "*) mkdir -p "\$5" ;;
+  *) : ;;
+esac
+STUB
+  cat > "$TMPDIR_TEST/bin/direnv" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/direnv.log"
+STUB
+  cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+# Only the explicit closed-check uses gh here.
+echo "${MAT_ISSUE_STATE:-OPEN}"
+STUB
+  chmod +x "$TMPDIR_TEST/bin/git" "$TMPDIR_TEST/bin/direnv" "$TMPDIR_TEST/bin/gh"
+  export PATH="$TMPDIR_TEST/bin:$SAVED_PATH"
+}
+
+mat_teardown() {
+  export PATH="$SAVED_PATH"
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST="" ; STUB_DIR=""
+  unset DISPATCH_LOCK_FILE CLAUDE_CODE_SESSION_ID CLAUDE_AGENTS_CMD \
+    MAT_PR MAT_LEAF MAT_BLOCKED MAT_WT_DECISION MAT_PHASE MAT_TARGET_N \
+    MAT_LIVE_COUNT MAT_LIVE_COUNT_FAIL MAT_SPAWN_RC MAT_ISSUE_STATE
+}
+
+run_mat() { "$TMPDIR_TEST/dispatch-materialize-spawn" "$@" 2>/dev/null; }
+
+# --- queue happy path → propagate (spawn called, lock released) --------------
+echo "Test: materialize-spawn queue happy path → propagate"
+mat_setup
+out=$(run_mat 839 queue) ; rc=$?
+assert_eq "queue happy: exit 0" "0" "$rc"
+assert_eq "queue happy: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "queue happy: spawn-worker called with issue + worktree" \
+  "839 $TMPDIR_TEST/project/worktrees/839-test" \
+  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
+assert_eq "queue happy: lock released by finalize" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "queue happy: marker written into target worktree" "1" \
+  "$([ -f "$TMPDIR_TEST/project/worktrees/839-test/tmp/dispatch-worktree" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- queue mode skips guards (CLOSED issue still proceeds) -------------------
+echo "Test: materialize-spawn queue mode skips guards (closed state ignored)"
+mat_setup
+export MAT_ISSUE_STATE=CLOSED
+export MAT_BLOCKED="999"
+out=$(run_mat 839 queue)
+assert_eq "queue skips guards: terminal token" "propagate" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "queue skips guards: no office-hours park" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/apply-office-hours.log" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- explicit happy path → propagate -----------------------------------------
+echo "Test: materialize-spawn explicit happy path → propagate"
+mat_setup
+out=$(run_mat 839 explicit)
+assert_eq "explicit happy: terminal token" "propagate" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+mat_teardown
+
+# --- explicit closed target → notify target-blocked --------------------------
+echo "Test: materialize-spawn explicit closed target → notify target-blocked"
+mat_setup
+export MAT_ISSUE_STATE=CLOSED
+out=$(run_mat 839 explicit)
+assert_eq "explicit closed: terminal token" "notify target-blocked" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "explicit closed: office-hours park reason" "839 named target issue is closed" \
+  "$(cat "$TMPDIR_TEST/logs/apply-office-hours.log")"
+assert_eq "explicit closed: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "explicit closed: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- explicit open blocker → notify target-blocked ---------------------------
+echo "Test: materialize-spawn explicit open blocker → notify target-blocked"
+mat_setup
+export MAT_BLOCKED="777,888"
+out=$(run_mat 839 explicit)
+assert_eq "explicit blocked: detail line" "blocked:777,888" \
+  "$(printf '%s\n' "$out" | grep '^blocked:')"
+assert_eq "explicit blocked: terminal token" "notify target-blocked" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "explicit blocked: office-hours park reason" "839 target has an open blocker" \
+  "$(cat "$TMPDIR_TEST/logs/apply-office-hours.log")"
+assert_eq "explicit blocked: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+mat_teardown
+
+# --- explicit leaf-trace retargets N (no PR) ---------------------------------
+echo "Test: materialize-spawn explicit leaf-trace retargets the spawn issue"
+mat_setup
+export MAT_LEAF=901
+out=$(run_mat 839 explicit)
+assert_eq "explicit leaf: terminal token" "propagate" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "explicit leaf: spawn-worker keyed on the leaf 901" \
+  "901 $TMPDIR_TEST/project/worktrees/901-test" \
+  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
+mat_teardown
+
+# --- explicit PR exists → leaf trace skipped ---------------------------------
+echo "Test: materialize-spawn explicit with a PR skips leaf trace"
+mat_setup
+export MAT_PR=665
+export MAT_LEAF=99999   # would retarget if trace ran
+out=$(run_mat 839 explicit)
+assert_eq "explicit PR: terminal token" "propagate" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "explicit PR: leaf trace not consulted" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/trace-leaf.log" ] && echo 1 || echo 0)"
+assert_eq "explicit PR: spawn keyed on original 839" \
+  "839 $TMPDIR_TEST/project/worktrees/839-test" \
+  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
+mat_teardown
+
+# --- enter path → sync-issue-context runs in the worktree --------------------
+echo "Test: materialize-spawn enter path syncs context + spawns"
+mat_setup
+EXISTING_WT="$TMPDIR_TEST/existing-wt"
+mkdir -p "$EXISTING_WT"
+export MAT_WT_DECISION="enter $EXISTING_WT"
+out=$(run_mat 839 queue)
+assert_eq "enter: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "enter: sync-issue-context ran in the worktree" "cwd=$EXISTING_WT argv=839" \
+  "$(cat "$TMPDIR_TEST/logs/sync-issue-context.log")"
+assert_eq "enter: marker written into the entered worktree" "1" \
+  "$([ -f "$EXISTING_WT/tmp/dispatch-worktree" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- conflict → drain worktree-conflict --------------------------------------
+echo "Test: materialize-spawn conflict → drain worktree-conflict"
+mat_setup
+export MAT_WT_DECISION="conflict $TMPDIR_TEST/some/path"
+out=$(run_mat 839 queue)
+assert_eq "conflict: path detail line" "path: $TMPDIR_TEST/some/path" \
+  "$(printf '%s\n' "$out" | grep '^path:')"
+assert_eq "conflict: terminal token" "drain worktree-conflict" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "conflict: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "conflict: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- waiting CI → drain ci-waiting -------------------------------------------
+echo "Test: materialize-spawn waiting CI → drain ci-waiting"
+mat_setup
+export MAT_PHASE=waiting
+out=$(run_mat 839 queue)
+assert_eq "ci-waiting: CI line present" "#839: CI in progress; the next router tick will re-evaluate." \
+  "$(printf '%s\n' "$out" | grep '^#839:')"
+assert_eq "ci-waiting: terminal token" "drain ci-waiting" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "ci-waiting: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+assert_eq "ci-waiting: lock already released by finalize" "" "$(cat "$DISPATCH_LOCK_FILE")"
+mat_teardown
+
+# --- concurrency cap → drain concurrency-cap, schedule-reseed called ---------
+echo "Test: materialize-spawn live count >= target → drain concurrency-cap"
+mat_setup
+export MAT_LIVE_COUNT=2
+export MAT_TARGET_N=1
+out=$(run_mat 839 queue)
+assert_eq "concurrency-cap: terminal token" "drain concurrency-cap" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "concurrency-cap: reseed scheduled" "called" \
+  "$(cat "$TMPDIR_TEST/logs/schedule-reseed.log")"
+assert_eq "concurrency-cap: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- --bypass-cap skips the concurrency gate (spawns even over budget) -------
+echo "Test: materialize-spawn --bypass-cap spawns even when live count >= target"
+mat_setup
+export MAT_LIVE_COUNT=5
+export MAT_TARGET_N=1
+out=$(run_mat 839 queue --bypass-cap)
+assert_eq "bypass-cap: terminal token" "propagate" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "bypass-cap: spawn called despite over budget" \
+  "839 $TMPDIR_TEST/project/worktrees/839-test" \
+  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
+assert_eq "bypass-cap: no reseed scheduled" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-reseed.log" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- daemon UNKNOWN → fail open and spawn ------------------------------------
+echo "Test: materialize-spawn daemon-query failure fails open and spawns"
+mat_setup
+export MAT_LIVE_COUNT_FAIL=1
+out=$(run_mat 839 queue)
+assert_eq "fail-open: terminal token" "propagate" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "fail-open: spawn called" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- spawn failure → notify spawn-failed -------------------------------------
+echo "Test: materialize-spawn spawn failure → notify spawn-failed"
+mat_setup
+export MAT_SPAWN_RC=1
+out=$(run_mat 839 queue)
+assert_eq "spawn-failed: terminal token" "notify spawn-failed" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+mat_teardown
+
+# --- usage errors → exit 2 ---------------------------------------------------
+echo "Test: materialize-spawn bad/missing args → exit 2"
+mat_setup
+err=$("$TMPDIR_TEST/dispatch-materialize-spawn" 839 bogus 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err" in *"usage:"*"EXIT=2") s1=ok ;; *) s1="bad: $err" ;; esac
+assert_eq "bad mode → usage error, exit 2" "ok" "$s1"
+err=$("$TMPDIR_TEST/dispatch-materialize-spawn" abc queue 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err" in *"usage:"*"EXIT=2") s2=ok ;; *) s2="bad: $err" ;; esac
+assert_eq "non-numeric issue → usage error, exit 2" "ok" "$s2"
+err=$("$TMPDIR_TEST/dispatch-materialize-spawn" 839 queue --nope 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err" in *"unexpected argument"*"EXIT=2") s3=ok ;; *) s3="bad: $err" ;; esac
+assert_eq "unexpected 3rd arg → usage error, exit 2" "ok" "$s3"
+mat_teardown
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -9479,6 +9479,250 @@ assert_eq "gh blocked_by failure → no output" "" "$stdout"
 teardown
 
 # ============================================================================
+# dispatch-select-tick tests (#919)
+# ============================================================================
+# The orchestrator runs against the REAL dispatch-acquire-lock (so lock-file
+# state is genuine and the three-guard lock invariant is asserted directly via
+# DISPATCH_LOCK_FILE) and against FAKE sub-scripts for jit-engine / resolve-arg
+# / select-target (so each decision line is driven deterministically). git is
+# PATH-shimmed to control the branch and the main-sync result.
+echo ""
+echo "=== dispatch-select-tick ==="
+
+sel_tick_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  STUB_DIR="$TMPDIR_TEST/stub"
+  mkdir -p "$STUB_DIR" "$TMPDIR_TEST/bin"
+
+  cp "$SCRIPT_DIR/dispatch-select-tick" "$TMPDIR_TEST/dispatch-select-tick"
+  cp "$SCRIPT_DIR/dispatch-acquire-lock" "$TMPDIR_TEST/dispatch-acquire-lock"
+  chmod +x "$TMPDIR_TEST/dispatch-select-tick" "$TMPDIR_TEST/dispatch-acquire-lock"
+
+  export DISPATCH_LOCK_FILE="$STUB_DIR/dispatch.lock"
+  export CLAUDE_CODE_SESSION_ID="select-tick-session"
+  # Fake `claude agents --json`: our own session is live → first acquisition
+  # succeeds and a strict self-release works.
+  cat > "$TMPDIR_TEST/fake-claude" <<'FAKE'
+#!/usr/bin/env bash
+echo '[{"sessionId":"select-tick-session","pid":1,"status":"busy","name":"x","cwd":""}]'
+FAKE
+  chmod +x "$TMPDIR_TEST/fake-claude"
+  export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/fake-claude"
+  # Single-shot --wait so a busy test never blocks the suite.
+  export DISPATCH_LOCK_WAIT_TIMEOUT=0
+  export DISPATCH_LOCK_WAIT_INTERVAL=1
+
+  # Default fake sub-scripts (overridable per test) — land in TMPDIR_TEST so the
+  # orchestrator's SCRIPT_DIR resolution finds them.
+  cat > "$TMPDIR_TEST/dispatch-jit-engine" <<'FAKE'
+#!/usr/bin/env bash
+exit 0
+FAKE
+  cat > "$TMPDIR_TEST/dispatch-resolve-arg" <<'FAKE'
+#!/usr/bin/env bash
+echo "$1"
+FAKE
+  cat > "$TMPDIR_TEST/dispatch-select-target" <<'FAKE'
+#!/usr/bin/env bash
+echo empty
+FAKE
+  chmod +x "$TMPDIR_TEST/dispatch-jit-engine" \
+           "$TMPDIR_TEST/dispatch-resolve-arg" \
+           "$TMPDIR_TEST/dispatch-select-target"
+
+  # PATH-shimmed git: branch defaults to main; fetch/merge succeed unless a
+  # FAKE_GIT_*_FAIL env var is set.
+  cat > "$TMPDIR_TEST/bin/git" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  "rev-parse --abbrev-ref HEAD") echo "${FAKE_GIT_BRANCH:-main}" ;;
+  "fetch origin main") [[ -n "${FAKE_GIT_FETCH_FAIL:-}" ]] && exit 1 ; exit 0 ;;
+  "merge --ff-only origin/main") [[ -n "${FAKE_GIT_MERGE_FAIL:-}" ]] && exit 1 ; exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/git"
+  export PATH="$TMPDIR_TEST/bin:$SAVED_PATH"
+}
+
+sel_tick_teardown() {
+  export PATH="$SAVED_PATH"
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST="" ; STUB_DIR=""
+  unset DISPATCH_LOCK_FILE CLAUDE_CODE_SESSION_ID CLAUDE_AGENTS_CMD \
+    DISPATCH_LOCK_WAIT_TIMEOUT DISPATCH_LOCK_WAIT_INTERVAL \
+    FAKE_GIT_BRANCH FAKE_GIT_FETCH_FAIL FAKE_GIT_MERGE_FAIL
+}
+
+# Run the orchestrator, capturing full stdout; the decision is the last line.
+run_sel_tick() {
+  "$TMPDIR_TEST/dispatch-select-tick" "$@" 2>/dev/null
+}
+
+# --- empty queue → release + empty ------------------------------------------
+echo "Test: select-tick empty queue → empty, lock released"
+sel_tick_setup
+out=$(run_sel_tick) ; rc=$?
+assert_eq "empty: exit 0" "0" "$rc"
+assert_eq "empty: decision line" "empty" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "empty: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- pr selection → passthrough + lock HELD ----------------------------------
+echo "Test: select-tick pr selection → passthrough, lock held"
+sel_tick_setup
+cat > "$TMPDIR_TEST/dispatch-select-target" <<'FAKE'
+#!/usr/bin/env bash
+echo "pr 660 660-some-branch code-review"
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
+out=$(run_sel_tick)
+assert_eq "pr: decision line" "pr 660 660-some-branch code-review" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "pr: lock held (our session)" "select-tick-session" \
+  "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- issue selection → passthrough + lock HELD -------------------------------
+echo "Test: select-tick issue selection → passthrough, lock held"
+sel_tick_setup
+cat > "$TMPDIR_TEST/dispatch-select-target" <<'FAKE'
+#!/usr/bin/env bash
+echo "issue 707"
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
+out=$(run_sel_tick)
+assert_eq "issue: decision line" "issue 707" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "issue: lock held" "select-tick-session" "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- main-broken → passthrough + lock HELD (sub-skill releases) --------------
+echo "Test: select-tick main-broken → passthrough, lock held"
+sel_tick_setup
+cat > "$TMPDIR_TEST/dispatch-select-target" <<'FAKE'
+#!/usr/bin/env bash
+echo "main-broken abc1234"
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
+out=$(run_sel_tick)
+assert_eq "main-broken: decision line" "main-broken abc1234" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "main-broken: lock held" "select-tick-session" \
+  "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- jit-reminder → passthrough + lock HELD ----------------------------------
+echo "Test: select-tick jit-reminder → passthrough, lock held"
+sel_tick_setup
+cat > "$TMPDIR_TEST/dispatch-select-target" <<'FAKE'
+#!/usr/bin/env bash
+echo "jit-reminder owner/repo 42 PVT_x ITEM_y"
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
+out=$(run_sel_tick)
+assert_eq "jit-reminder: decision line" "jit-reminder owner/repo 42 PVT_x ITEM_y" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "jit-reminder: lock held" "select-tick-session" \
+  "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- explicit arg resolves → explicit <num> + lock HELD ----------------------
+echo "Test: select-tick explicit arg → explicit <num>, lock held"
+sel_tick_setup
+out=$(run_sel_tick 55)
+assert_eq "explicit: decision line" "explicit 55" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "explicit: lock held" "select-tick-session" "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- explicit arg leading '#' is stripped ------------------------------------
+echo "Test: select-tick explicit arg strips leading '#'"
+sel_tick_setup
+out=$(run_sel_tick '#88')
+assert_eq "explicit '#': decision line" "explicit 88" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+sel_tick_teardown
+
+# --- resolver failure (garbage arg) → release + resolver-failed --------------
+echo "Test: select-tick resolver failure → resolver-failed, lock released"
+sel_tick_setup
+cat > "$TMPDIR_TEST/dispatch-resolve-arg" <<'FAKE'
+#!/usr/bin/env bash
+echo "error: bad arg" >&2
+exit 1
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-resolve-arg"
+out=$(run_sel_tick abc)
+assert_eq "resolver-failed: decision line" "resolver-failed" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "resolver-failed: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- sync failure on main → release + sync-failed ----------------------------
+echo "Test: select-tick sync failure on main → sync-failed, lock released"
+sel_tick_setup
+export FAKE_GIT_FETCH_FAIL=1
+out=$(run_sel_tick)
+assert_eq "sync-failed: decision line" "sync-failed" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "sync-failed: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- off-main: main-sync skipped (fetch-fail does NOT trigger sync-failed) ----
+echo "Test: select-tick off main skips sync (fetch-fail ignored)"
+sel_tick_setup
+export FAKE_GIT_BRANCH="707-some-branch"
+export FAKE_GIT_FETCH_FAIL=1
+out=$(run_sel_tick)
+assert_eq "off-main: reaches selection (empty, not sync-failed)" "empty" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+sel_tick_teardown
+
+# --- JIT created lines are passed through, prefixed --------------------------
+echo "Test: select-tick passes JIT output through prefixed"
+sel_tick_setup
+cat > "$TMPDIR_TEST/dispatch-jit-engine" <<'FAKE'
+#!/usr/bin/env bash
+echo "weekly-review: created #42"
+echo "standup: debounced"
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-jit-engine"
+out=$(run_sel_tick)
+assert_eq "jit passthrough: created line prefixed" "1" \
+  "$(printf '%s\n' "$out" | grep -cF 'jit: weekly-review: created #42')"
+assert_eq "jit passthrough: debounced line prefixed" "1" \
+  "$(printf '%s\n' "$out" | grep -cF 'jit: standup: debounced')"
+assert_eq "jit passthrough: decision still last" "empty" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+sel_tick_teardown
+
+# --- busy lock → busy, nothing acquired, nothing released --------------------
+echo "Test: select-tick busy lock → busy, foreign holder untouched"
+sel_tick_setup
+# Pre-fill the lock with a DIFFERENT, live session so --wait gives up as busy.
+printf '%s\n' "other-live-session" > "$DISPATCH_LOCK_FILE"
+cat > "$TMPDIR_TEST/fake-claude" <<'FAKE'
+#!/usr/bin/env bash
+echo '[{"sessionId":"other-live-session","pid":2,"status":"busy","name":"x","cwd":""}]'
+FAKE
+chmod +x "$TMPDIR_TEST/fake-claude"
+out=$(run_sel_tick)
+assert_eq "busy: decision line" "busy" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "busy: foreign holder untouched (not released)" "other-live-session" \
+  "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- extra arguments → usage error, exit 2 -----------------------------------
+echo "Test: select-tick extra arguments → exit 2"
+sel_tick_setup
+err=$("$TMPDIR_TEST/dispatch-select-tick" 1 2 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err" in
+  *"unexpected extra arguments"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err" ;;
+esac
+assert_eq "extra args → usage error, exit 2" "ok" "$status"
+sel_tick_teardown
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -10065,6 +10065,43 @@ assert_eq "explicit PR: spawn keyed on original 839" \
   "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
 mat_teardown
 
+# --- explicit trace-leaf hard failure → exit 2, lock released, no spawn -------
+# dispatch-trace-leaf's exit 1 is a hard sibling-gh failure the caller must NOT
+# swallow as "no work" (its documented contract). A swallowed failure would
+# dispatch the un-traced N; instead the script releases the lock and exits 2.
+echo "Test: materialize-spawn explicit trace-leaf hard failure → exit 2 + lock released"
+mat_setup
+cat > "$TMPDIR_TEST/dispatch-trace-leaf" <<'STUB'
+#!/usr/bin/env bash
+echo "trace-leaf gh failure" >&2
+exit 1
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-trace-leaf"
+out=$(run_mat 839 explicit) && rc=0 || rc=$?
+assert_eq "trace-leaf fail: exit 2" "2" "$rc"
+assert_eq "trace-leaf fail: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "trace-leaf fail: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- resolve-worktree internal failure → exit 2, lock released, no spawn ------
+# An internal sub-script failure before dispatch-finalize-selection must release
+# the lock so a stuck holder does not wedge the next tick.
+echo "Test: materialize-spawn resolve-worktree failure → exit 2 + lock released"
+mat_setup
+cat > "$TMPDIR_TEST/dispatch-resolve-worktree" <<'STUB'
+#!/usr/bin/env bash
+echo "resolve-worktree gh failure" >&2
+exit 1
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-resolve-worktree"
+out=$(run_mat 839 queue) && rc=0 || rc=$?
+assert_eq "resolve-wt fail: exit 2" "2" "$rc"
+assert_eq "resolve-wt fail: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "resolve-wt fail: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+mat_teardown
+
 # --- enter path → sync-issue-context runs in the worktree --------------------
 echo "Test: materialize-spawn enter path syncs context + spawns"
 mat_setup

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -5,15 +5,21 @@ description: Manual override for the dispatch chain — runs /dispatch-propagate
 
 # Dispatch (manual override)
 
-Run `/dispatch-propagate`'s instructions exactly, with one change: Step 6
-spawns unconditionally. Skip the `dispatch-target-workers` gate — do not
-query the live worker count, do not emit `drain concurrency-cap`, always
-call `dispatch-spawn-worker` and proceed to Step 7.
+Run `/dispatch-propagate`'s instructions exactly, with one change: when you
+reach the materialize-and-spawn call (Section 2), pass `--bypass-cap`:
 
-Use this when you want to dispatch work *now*, ignoring rate-limit pacing.
-You typed `/dispatch` because you accepted the cost; the gate that paces the
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn <N> <explicit|queue> --bypass-cap
+```
+
+`--bypass-cap` skips the `dispatch-target-workers` concurrency gate entirely —
+the script does not query the live worker count, never emits `drain
+concurrency-cap`, and always calls `dispatch-spawn-worker`.
+
+Use this when you want to dispatch work *now*, ignoring rate-limit pacing. You
+typed `/dispatch` because you accepted the cost; the gate that paces the
 autonomous chain does not apply to a manual run.
 
-The Selection lock (`dispatch-acquire-lock`) is shared with
-`/dispatch-propagate`, so a manual run cannot select the same target as an
-in-flight chain tick.
+The selection lock (`dispatch-acquire-lock`, acquired inside
+`dispatch-select-tick`) is shared with `/dispatch-propagate`, so a manual run
+cannot select the same target as an in-flight chain tick.


### PR DESCRIPTION
## Summary

Part B of #919. Moves the `/dispatch-propagate` router's per-tick orchestration
out of ~483 lines of SKILL.md prose + ~8 sequential Bash round-trips and into
two scripts split at the one model-decision seam, so a chain tick runs ~2
orchestrator calls and routes on their output.

- **`dispatch-select-tick`** (NEW) — bundles old Steps 0-3: acquire lock, sync
  `main`, run the JIT engine, select the target. Emits one decision line
  (`busy` / `sync-failed` / `resolver-failed` / `empty` / `explicit <num>` /
  `pr <num> <branch> <phase>` / `issue <num>` / `main-broken <sha>` /
  `jit-reminder …`). Owns the three-guard lock invariant: hold on the targets +
  `main-broken`/`jit-reminder`, release on `empty`/`sync-failed`/
  `resolver-failed`, never touch on `busy`.
- **`dispatch-materialize-spawn`** (NEW) — bundles old Steps 4-6: explicit-path
  guards (leaf trace, closed-target, open-blocker), worktree resolution,
  `dispatch-finalize-selection` (marker + lock release), the waiting-CI gate,
  the concurrency-cap gate, and the worker spawn. Emits one terminal token
  (`propagate` / `notify target-blocked` / `notify spawn-failed` /
  `drain worktree-conflict` / `drain ci-waiting` / `drain concurrency-cap`).
  `--bypass-cap` skips the concurrency gate for the manual `/dispatch` shim.
- **SKILL.md** collapses (~483 → 132 lines) to a short intro, the two-call flow,
  and two routing tables mapping each script's output line to a prose-report
  template + terminal disposition. The model only routes, invokes the
  `main-broken`/`jit-reminder` sub-skills, and self-closes per the
  propagate/notify/drain semantics.
- **`/dispatch` shim** now passes `--bypass-cap` to `dispatch-materialize-spawn`
  rather than describing a per-step Step-6 gate bypass.

Pure refactor: same dispositions, same lock semantics (now enforced inside the
scripts rather than by prose), same recovery. `reference.md` is left as the
deep-why sink, unchanged.

### Clarifications vs. the issue body

- The issue was written before #906 (the waiting-CI gate) landed.
  `dispatch-materialize-spawn` follows the *current* SKILL.md ordering —
  finalize-selection (marker + release) → CI gate → concurrency gate → spawn —
  not the issue's pre-#906 sketch, preserving the lock-free post-finalize tail.
- `dispatch-materialize-spawn` takes the **issue number** as its first
  positional, always. The model derives `N=${branch%%-*}` for `pr` rows (as the
  old SKILL.md already instructed); the queue row's literal `[branch phase]`
  positionals are dropped — no sub-script consumes them, and the CI gate
  re-derives the phase via `dispatch-phase`.

## Test plan

- [x] `bash test-dispatch-scripts.sh` — 826/826 pass (new cases: every
  select-tick decision line + lock disposition + JIT passthrough + busy-no-
  release + off-main skip + bad arg; every materialize-spawn terminal token +
  the three guards + marker-in-worktree + `--bypass-cap` + fail-open +
  spawn-failure + usage).
- [x] `bash -n` on both new scripts; both `chmod +x`.
- [x] AC audit: SKILL.md is the two-table routing form; the shim passes
  `--bypass-cap`.
- [ ] End-to-end is naturally exercised when the dispatch chain next runs a real
  tick (out of scope for this PR's verify phase).

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)