### PR TITLE
budget-etl: emit balanced journal entries with transfer pairing

### DIFF
--- a/budget-etl/internal/budget/budget.go
+++ b/budget-etl/internal/budget/budget.go
@@ -42,6 +42,7 @@ type TransactionData struct {
 	Category      string // set by categorization rules; preserved across re-imports
 	Budget        string // set by budget assignment rules; preserved across re-imports
 	Virtual       bool   // true for ETL-generated virtual transactions
+	IsCreditCard  bool   // true when the source statement is a credit-card OFX statement
 }
 
 // NormTxn is a read-only view of a transaction used by normalization rules.

--- a/budget-etl/internal/journal/journal.go
+++ b/budget-etl/internal/journal/journal.go
@@ -72,12 +72,24 @@ type tentative struct {
 // Build computes the double-entry records for a batch of parsed transactions.
 // window is the maximum timestamp delta for transfer-pair detection; pass
 // DefaultPairWindow for the default.
-func Build(txns []budget.TransactionData, window time.Duration) Result {
+//
+// docIDs, if non-nil, must be a parallel slice of pre-computed document IDs (one
+// per transaction). When provided, Build uses docIDs[i] directly instead of
+// calling budget.TransactionDocID(txn.StatementID, txn.TransactionID). This is
+// required when transactions are reconstructed from an existing budget.json, where
+// TransactionID already holds the hashed document ID rather than the original FITID.
+func Build(txns []budget.TransactionData, docIDs []string, window time.Duration) Result {
 	tents := make([]*tentative, 0, len(txns))
 	for i := range txns {
 		txn := txns[i]
+		var docID string
+		if docIDs != nil {
+			docID = docIDs[i]
+		} else {
+			docID = budget.TransactionDocID(txn.StatementID, txn.TransactionID)
+		}
 		t := &tentative{
-			docID:      budget.TransactionDocID(txn.StatementID, txn.TransactionID),
+			docID:      docID,
 			txn:        txn,
 			acctID:     accountID(txn.Institution, txn.Account),
 			isTransfer: isTransfer(txn.Category),

--- a/budget-etl/internal/journal/journal.go
+++ b/budget-etl/internal/journal/journal.go
@@ -1,0 +1,345 @@
+// Package journal turns parsed bank transactions into balanced double-entry
+// records — JournalEntry, JournalLeg, and Account — for emission into
+// budget.json. It is a pure computation package: no IO, no mutable globals.
+//
+// Each imported line first becomes a tentative two-leg entry: one leg on the
+// imported bank account and a balancing counter leg on a placeholder account
+// (Uncategorized Expense / Uncategorized Income, or Unresolved Transfers for
+// Transfer:* lines). After per-line emission, the batch is scanned for transfer
+// pairs — opposite-sign amounts on different accounts within a time window —
+// and each matched pair is merged into a single entry that debits the
+// destination account and credits the source account, dropping the placeholders.
+package journal
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/natb1/commons.systems/budget-etl/internal/budget"
+	"github.com/natb1/commons.systems/budget-etl/internal/export"
+)
+
+// DefaultPairWindow is the default maximum timestamp delta between two lines to
+// be considered a transfer pair.
+const DefaultPairWindow = 3 * 24 * time.Hour
+
+// Placeholder counter-account ids and types, matching the seed chart of accounts
+// (budget/seeds/firestore.ts).
+const (
+	acctUncategorizedExpense = "Budget_Uncategorized Expense"
+	acctUncategorizedIncome  = "Budget_Uncategorized Income"
+	acctUnresolvedTransfers  = "Budget_Unresolved Transfers"
+
+	placeholderInstitution = "Budget"
+)
+
+// centTolerance is the magnitude (in cents) within which two amounts are
+// considered equal-and-opposite for pair detection, and within which an entry's
+// debits and credits are considered balanced.
+const centTolerance = 1
+
+// Result holds the double-entry records derived from an import batch.
+type Result struct {
+	Entries        []export.JournalEntry
+	Legs           []export.JournalLeg
+	Accounts       []export.Account
+	EntryIDByDocID map[string]string // docID -> journalEntryId
+}
+
+// accountID composes the account document id from institution and account,
+// matching the seed/app convention "{institution}_{account}".
+func accountID(institution, account string) string {
+	return institution + "_" + account
+}
+
+// isTransfer reports whether a category marks the line as a transfer.
+func isTransfer(category string) bool {
+	return strings.HasPrefix(category, "Transfer:")
+}
+
+// tentative holds the per-line state needed for pair detection and final
+// emission.
+type tentative struct {
+	docID      string
+	txn        budget.TransactionData
+	acctID     string // imported bank-account id
+	counterID  string // placeholder counter-account id
+	isTransfer bool
+	paired     bool
+}
+
+// Build computes the double-entry records for a batch of parsed transactions.
+// window is the maximum timestamp delta for transfer-pair detection; pass
+// DefaultPairWindow for the default.
+func Build(txns []budget.TransactionData, window time.Duration) Result {
+	tents := make([]*tentative, 0, len(txns))
+	for i := range txns {
+		txn := txns[i]
+		t := &tentative{
+			docID:      budget.TransactionDocID(txn.StatementID, txn.TransactionID),
+			txn:        txn,
+			acctID:     accountID(txn.Institution, txn.Account),
+			isTransfer: isTransfer(txn.Category),
+		}
+		switch {
+		case t.isTransfer:
+			t.counterID = acctUnresolvedTransfers
+		case txn.Amount > 0: // spending
+			t.counterID = acctUncategorizedExpense
+		default: // income / credit (amount <= 0)
+			t.counterID = acctUncategorizedIncome
+		}
+		tents = append(tents, t)
+	}
+
+	pairs := detectPairs(tents, window)
+
+	entries := []export.JournalEntry{}
+	legs := []export.JournalLeg{}
+	entryIDByDocID := map[string]string{}
+	// referencedAccounts collects every account id touched by an emitted leg,
+	// so the placeholder accounts emitted are exactly those referenced.
+	referencedAccounts := map[string]bool{}
+
+	// Merged pairs first.
+	for _, p := range pairs {
+		a, b := tents[p.i], tents[p.j]
+		// Destination = inflow (amount < 0); source = outflow (amount > 0).
+		dst, src := a, b
+		if a.txn.Amount > 0 {
+			dst, src = b, a
+		}
+		entryID := mergedEntryID(a.docID, b.docID)
+		amount := dollarsAbs(dst.txn.Amount)
+		// Description from the source (outflow) line.
+		entry := export.JournalEntry{
+			ID:          entryID,
+			Timestamp:   export.FormatTimestamp(src.txn.Timestamp),
+			Description: src.txn.Description,
+			Note:        nil,
+			LegCount:    2,
+		}
+		debitLeg := newLeg(entryID+"-d", entryID, dst.acctID, amount, 0, entry.Timestamp)
+		creditLeg := newLeg(entryID+"-c", entryID, src.acctID, 0, amount, entry.Timestamp)
+
+		entries = append(entries, entry)
+		legs = append(legs, debitLeg, creditLeg)
+		referencedAccounts[dst.acctID] = true
+		referencedAccounts[src.acctID] = true
+		entryIDByDocID[a.docID] = entryID
+		entryIDByDocID[b.docID] = entryID
+	}
+
+	// Unpaired lines: tentative single-line entries.
+	for _, t := range tents {
+		if t.paired {
+			continue
+		}
+		entryID := "je-" + t.docID
+		amount := dollarsAbs(t.txn.Amount)
+		ts := export.FormatTimestamp(t.txn.Timestamp)
+		entry := export.JournalEntry{
+			ID:          entryID,
+			Timestamp:   ts,
+			Description: t.txn.Description,
+			Note:        nil,
+			LegCount:    2,
+		}
+
+		var debitLeg, creditLeg export.JournalLeg
+		if t.txn.Amount > 0 {
+			// Spending: credit the imported account, debit the counter account.
+			debitLeg = newLeg(entryID+"-d", entryID, t.counterID, amount, 0, ts)
+			creditLeg = newLeg(entryID+"-c", entryID, t.acctID, 0, amount, ts)
+		} else {
+			// Income / credit: debit the imported account, credit the counter account.
+			debitLeg = newLeg(entryID+"-d", entryID, t.acctID, amount, 0, ts)
+			creditLeg = newLeg(entryID+"-c", entryID, t.counterID, 0, amount, ts)
+		}
+
+		entries = append(entries, entry)
+		legs = append(legs, debitLeg, creditLeg)
+		referencedAccounts[t.acctID] = true
+		referencedAccounts[t.counterID] = true
+		entryIDByDocID[t.docID] = entryID
+	}
+
+	accounts := buildAccounts(tents, referencedAccounts)
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].ID < entries[j].ID })
+	sort.Slice(legs, func(i, j int) bool { return legs[i].ID < legs[j].ID })
+	sort.Slice(accounts, func(i, j int) bool { return accounts[i].ID < accounts[j].ID })
+
+	return Result{
+		Entries:        entries,
+		Legs:           legs,
+		Accounts:       accounts,
+		EntryIDByDocID: entryIDByDocID,
+	}
+}
+
+// newLeg constructs a JournalLeg with the new-import defaults: uncleared, no
+// reconciliation linkage, no statement item.
+func newLeg(id, entryID, accountID string, debit, credit float64, timestamp string) export.JournalLeg {
+	return export.JournalLeg{
+		ID:                id,
+		EntryID:           entryID,
+		AccountID:         accountID,
+		Debit:             debit,
+		Credit:            credit,
+		Timestamp:         timestamp,
+		Cleared:           false,
+		ReconciledAt:      nil,
+		ReconciledEventID: nil,
+		StatementItemID:   nil,
+	}
+}
+
+// dollarsAbs returns the absolute dollar value of a signed cents amount.
+func dollarsAbs(cents int64) float64 {
+	if cents < 0 {
+		cents = -cents
+	}
+	return budget.DollarAmount(cents)
+}
+
+// mergedEntryID returns the deterministic, order-independent id for a merged
+// transfer pair.
+func mergedEntryID(docA, docB string) string {
+	if docB < docA {
+		docA = docB
+	}
+	return "je-" + docA
+}
+
+// pair identifies two tentative lines, by index, that form a transfer pair.
+type pair struct {
+	i, j int
+}
+
+// detectPairs finds transfer pairs via greedy nearest-time matching. A
+// candidate pair has different (institution, account), opposite-sign amounts
+// equal within a one-cent tolerance, and |Δtimestamp| <= window. Candidates are
+// consumed in ascending timestamp-delta order, skipping lines already taken, so
+// two pairs in one window match to their nearest partner. Marks matched
+// tentatives as paired and returns the chosen pairs.
+func detectPairs(tents []*tentative, window time.Duration) []pair {
+	type candidate struct {
+		i, j  int
+		delta time.Duration
+	}
+	var cands []candidate
+	for i := 0; i < len(tents); i++ {
+		a := tents[i]
+		for j := i + 1; j < len(tents); j++ {
+			b := tents[j]
+			if a.acctID == b.acctID {
+				continue
+			}
+			// Opposite sign.
+			if (a.txn.Amount > 0) == (b.txn.Amount > 0) {
+				continue
+			}
+			// Equal magnitude within tolerance.
+			if absInt64(a.txn.Amount+b.txn.Amount) > centTolerance {
+				continue
+			}
+			delta := a.txn.Timestamp.Sub(b.txn.Timestamp)
+			if delta < 0 {
+				delta = -delta
+			}
+			if delta > window {
+				continue
+			}
+			cands = append(cands, candidate{i: i, j: j, delta: delta})
+		}
+	}
+
+	// Greedy nearest-time: smallest delta first. Ties broken by indices for
+	// determinism.
+	sort.Slice(cands, func(x, y int) bool {
+		if cands[x].delta != cands[y].delta {
+			return cands[x].delta < cands[y].delta
+		}
+		if cands[x].i != cands[y].i {
+			return cands[x].i < cands[y].i
+		}
+		return cands[x].j < cands[y].j
+	})
+
+	var pairs []pair
+	for _, c := range cands {
+		if tents[c.i].paired || tents[c.j].paired {
+			continue
+		}
+		tents[c.i].paired = true
+		tents[c.j].paired = true
+		pairs = append(pairs, pair{i: c.i, j: c.j})
+	}
+	return pairs
+}
+
+func absInt64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// buildAccounts emits one Account per real (institution, account) touched, with
+// accountType derived from IsCreditCard, plus the placeholder accounts actually
+// referenced by an emitted leg.
+func buildAccounts(tents []*tentative, referenced map[string]bool) []export.Account {
+	type realAcct struct {
+		institution string
+		account     string
+		liability   bool
+	}
+	reals := map[string]*realAcct{}
+	for _, t := range tents {
+		ra, ok := reals[t.acctID]
+		if !ok {
+			ra = &realAcct{institution: t.txn.Institution, account: t.txn.Account}
+			reals[t.acctID] = ra
+		}
+		if t.txn.IsCreditCard {
+			ra.liability = true
+		}
+	}
+
+	accounts := []export.Account{}
+	for id, ra := range reals {
+		acctType := "asset"
+		if ra.liability {
+			acctType = "liability"
+		}
+		accounts = append(accounts, export.Account{
+			ID:          id,
+			Institution: ra.institution,
+			Account:     ra.account,
+			AccountType: acctType,
+		})
+	}
+
+	// Placeholder accounts: emit only those referenced by an emitted leg.
+	for _, ph := range []struct {
+		id, account, acctType string
+	}{
+		{acctUncategorizedExpense, "Uncategorized Expense", "expense"},
+		{acctUncategorizedIncome, "Uncategorized Income", "income"},
+		{acctUnresolvedTransfers, "Unresolved Transfers", "asset"},
+	} {
+		if !referenced[ph.id] {
+			continue
+		}
+		accounts = append(accounts, export.Account{
+			ID:          ph.id,
+			Institution: placeholderInstitution,
+			Account:     ph.account,
+			AccountType: ph.acctType,
+		})
+	}
+
+	return accounts
+}

--- a/budget-etl/internal/journal/journal_test.go
+++ b/budget-etl/internal/journal/journal_test.go
@@ -334,6 +334,28 @@ func TestCreditCardLiabilityDerivation(t *testing.T) {
 	if ids["Example Bank_Credit Card"] != "liability" {
 		t.Errorf("credit-card account should be liability, got %q", ids["Example Bank_Credit Card"])
 	}
+
+	assertBalanced(t, r.Legs)
+
+	// A positive (spending) charge on a credit card credits the liability
+	// account and debits the expense placeholder.
+	byEntry := legsByEntry(r.Legs)
+	legs := byEntry[r.Entries[0].ID]
+	var card, expense export.JournalLeg
+	for _, l := range legs {
+		switch l.AccountID {
+		case "Example Bank_Credit Card":
+			card = l
+		case acctUncategorizedExpense:
+			expense = l
+		}
+	}
+	if card.Credit != 45.00 || card.Debit != 0 {
+		t.Errorf("credit-card leg should be credit 45.00, got debit=%v credit=%v", card.Debit, card.Credit)
+	}
+	if expense.Debit != 45.00 || expense.Credit != 0 {
+		t.Errorf("expense leg should be debit 45.00, got debit=%v credit=%v", expense.Debit, expense.Credit)
+	}
 }
 
 func TestPairWindowExcludesFarApart(t *testing.T) {

--- a/budget-etl/internal/journal/journal_test.go
+++ b/budget-etl/internal/journal/journal_test.go
@@ -1,0 +1,429 @@
+package journal
+
+import (
+	"math"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/natb1/commons.systems/budget-etl/internal/budget"
+	"github.com/natb1/commons.systems/budget-etl/internal/export"
+)
+
+func ts(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// legsByEntry indexes legs by their entry id.
+func legsByEntry(legs []export.JournalLeg) map[string][]export.JournalLeg {
+	m := map[string][]export.JournalLeg{}
+	for _, l := range legs {
+		m[l.EntryID] = append(m[l.EntryID], l)
+	}
+	return m
+}
+
+// assertBalanced checks that an entry's legs have equal total debits and
+// credits within a cent.
+func assertBalanced(t *testing.T, legs []export.JournalLeg) {
+	t.Helper()
+	var debit, credit float64
+	for _, l := range legs {
+		debit += l.Debit
+		credit += l.Credit
+	}
+	if math.Abs(debit-credit) > 0.01 {
+		t.Fatalf("entry not balanced: debits=%v credits=%v", debit, credit)
+	}
+}
+
+// accountIDs returns the set of emitted account ids.
+func accountIDs(accts []export.Account) map[string]string {
+	m := map[string]string{}
+	for _, a := range accts {
+		m[a.ID] = a.AccountType
+	}
+	return m
+}
+
+func TestExpenseLine(t *testing.T) {
+	txns := []budget.TransactionData{
+		{
+			Institution:   "Example Bank",
+			Account:       "Checking",
+			Description:   "Grocery Store",
+			Amount:        8450, // spending
+			Timestamp:     ts("2025-02-05"),
+			StatementID:   "stmt-1",
+			TransactionID: "txn-1",
+			Category:      "Groceries",
+		},
+	}
+	r := Build(txns, DefaultPairWindow)
+
+	if len(r.Entries) != 1 || len(r.Legs) != 2 {
+		t.Fatalf("expected 1 entry / 2 legs, got %d / %d", len(r.Entries), len(r.Legs))
+	}
+	assertBalanced(t, r.Legs)
+
+	byEntry := legsByEntry(r.Legs)
+	entryID := r.Entries[0].ID
+	legs := byEntry[entryID]
+	// Spending: credit Checking, debit Uncategorized Expense.
+	var checking, expense export.JournalLeg
+	for _, l := range legs {
+		switch l.AccountID {
+		case "Example Bank_Checking":
+			checking = l
+		case acctUncategorizedExpense:
+			expense = l
+		}
+	}
+	if checking.Credit != 84.50 || checking.Debit != 0 {
+		t.Errorf("checking leg should be credit 84.50, got debit=%v credit=%v", checking.Debit, checking.Credit)
+	}
+	if expense.Debit != 84.50 || expense.Credit != 0 {
+		t.Errorf("expense leg should be debit 84.50, got debit=%v credit=%v", expense.Debit, expense.Credit)
+	}
+
+	// journalEntryId mapping.
+	docID := budget.TransactionDocID("stmt-1", "txn-1")
+	if r.EntryIDByDocID[docID] != entryID {
+		t.Errorf("EntryIDByDocID[%s]=%q, want %q", docID, r.EntryIDByDocID[docID], entryID)
+	}
+
+	// Account records: real account is asset, placeholder is expense.
+	ids := accountIDs(r.Accounts)
+	if ids["Example Bank_Checking"] != "asset" {
+		t.Errorf("Checking should be asset, got %q", ids["Example Bank_Checking"])
+	}
+	if ids[acctUncategorizedExpense] != "expense" {
+		t.Errorf("Uncategorized Expense should be expense, got %q", ids[acctUncategorizedExpense])
+	}
+	if _, ok := ids[acctUncategorizedIncome]; ok {
+		t.Errorf("Uncategorized Income should not be emitted (unreferenced)")
+	}
+
+	// New-leg defaults.
+	for _, l := range r.Legs {
+		if l.Cleared || l.ReconciledAt != nil || l.ReconciledEventID != nil || l.StatementItemID != nil {
+			t.Errorf("leg %s should carry new-import defaults", l.ID)
+		}
+	}
+}
+
+func TestIncomeLine(t *testing.T) {
+	txns := []budget.TransactionData{
+		{
+			Institution:   "Example Bank",
+			Account:       "Checking",
+			Description:   "Payroll Deposit",
+			Amount:        -240000, // income
+			Timestamp:     ts("2025-02-14"),
+			StatementID:   "stmt-1",
+			TransactionID: "txn-2",
+			Category:      "Income",
+		},
+	}
+	r := Build(txns, DefaultPairWindow)
+	assertBalanced(t, r.Legs)
+
+	byEntry := legsByEntry(r.Legs)
+	legs := byEntry[r.Entries[0].ID]
+	var checking, income export.JournalLeg
+	for _, l := range legs {
+		switch l.AccountID {
+		case "Example Bank_Checking":
+			checking = l
+		case acctUncategorizedIncome:
+			income = l
+		}
+	}
+	// Income: debit Checking, credit Uncategorized Income.
+	if checking.Debit != 2400 || checking.Credit != 0 {
+		t.Errorf("checking leg should be debit 2400, got debit=%v credit=%v", checking.Debit, checking.Credit)
+	}
+	if income.Credit != 2400 || income.Debit != 0 {
+		t.Errorf("income leg should be credit 2400, got debit=%v credit=%v", income.Debit, income.Credit)
+	}
+
+	ids := accountIDs(r.Accounts)
+	if ids[acctUncategorizedIncome] != "income" {
+		t.Errorf("Uncategorized Income should be income, got %q", ids[acctUncategorizedIncome])
+	}
+}
+
+func TestMatchingPairMerge(t *testing.T) {
+	txns := []budget.TransactionData{
+		{ // outflow from Checking (source)
+			Institution:   "Example Bank",
+			Account:       "Checking",
+			Description:   "Transfer to Savings",
+			Amount:        30000,
+			Timestamp:     ts("2025-02-18"),
+			StatementID:   "stmt-chk",
+			TransactionID: "out-1",
+			Category:      "Transfer:Savings",
+		},
+		{ // inflow to Savings (destination)
+			Institution:   "Example Credit Union",
+			Account:       "Savings",
+			Description:   "Transfer from Checking",
+			Amount:        -30000,
+			Timestamp:     ts("2025-02-19"),
+			StatementID:   "stmt-sav",
+			TransactionID: "in-1",
+			Category:      "Transfer:Savings",
+		},
+	}
+	r := Build(txns, DefaultPairWindow)
+
+	if len(r.Entries) != 1 {
+		t.Fatalf("expected 1 merged entry, got %d", len(r.Entries))
+	}
+	if len(r.Legs) != 2 {
+		t.Fatalf("expected 2 legs, got %d", len(r.Legs))
+	}
+	assertBalanced(t, r.Legs)
+
+	legs := legsByEntry(r.Legs)[r.Entries[0].ID]
+	var dst, src export.JournalLeg
+	for _, l := range legs {
+		switch l.AccountID {
+		case "Example Credit Union_Savings":
+			dst = l
+		case "Example Bank_Checking":
+			src = l
+		}
+	}
+	if dst.Debit != 300 || dst.Credit != 0 {
+		t.Errorf("destination (Savings) should be debit 300, got debit=%v credit=%v", dst.Debit, dst.Credit)
+	}
+	if src.Credit != 300 || src.Debit != 0 {
+		t.Errorf("source (Checking) should be credit 300, got debit=%v credit=%v", src.Debit, src.Credit)
+	}
+
+	// Placeholder counter legs dropped.
+	ids := accountIDs(r.Accounts)
+	if _, ok := ids[acctUnresolvedTransfers]; ok {
+		t.Errorf("Unresolved Transfers should not be emitted for a matched pair")
+	}
+
+	// Both docIDs map to the merged entry.
+	docOut := budget.TransactionDocID("stmt-chk", "out-1")
+	docIn := budget.TransactionDocID("stmt-sav", "in-1")
+	if r.EntryIDByDocID[docOut] != r.Entries[0].ID || r.EntryIDByDocID[docIn] != r.Entries[0].ID {
+		t.Errorf("both docIDs should map to merged entry")
+	}
+	// Merged id is order-independent min.
+	want := mergedEntryID(docOut, docIn)
+	if r.Entries[0].ID != want {
+		t.Errorf("merged entry id = %q, want %q", r.Entries[0].ID, want)
+	}
+}
+
+func TestUnmatchedTransferFallback(t *testing.T) {
+	txns := []budget.TransactionData{
+		{
+			Institution:   "Example Bank",
+			Account:       "Checking",
+			Description:   "Transfer to Savings",
+			Amount:        30000,
+			Timestamp:     ts("2025-02-18"),
+			StatementID:   "stmt-chk",
+			TransactionID: "lonely",
+			Category:      "Transfer:Savings",
+		},
+	}
+	r := Build(txns, DefaultPairWindow)
+	assertBalanced(t, r.Legs)
+
+	legs := legsByEntry(r.Legs)[r.Entries[0].ID]
+	var foundUnresolved bool
+	for _, l := range legs {
+		if l.AccountID == acctUnresolvedTransfers {
+			foundUnresolved = true
+		}
+	}
+	if !foundUnresolved {
+		t.Errorf("lone transfer line should land a leg on Unresolved Transfers")
+	}
+	ids := accountIDs(r.Accounts)
+	if ids[acctUnresolvedTransfers] != "asset" {
+		t.Errorf("Unresolved Transfers should be a clearing asset, got %q", ids[acctUnresolvedTransfers])
+	}
+}
+
+func TestTwoCandidatePairsNearestTime(t *testing.T) {
+	// Two outflows from Checking and two inflows to Savings, all same amount,
+	// within the window. Greedy nearest-time should pair each outflow to its
+	// closest inflow, not cross-pair.
+	txns := []budget.TransactionData{
+		{ // out A
+			Institution: "Example Bank", Account: "Checking",
+			Description: "out-A", Amount: 10000, Timestamp: ts("2025-02-01"),
+			StatementID: "s", TransactionID: "outA", Category: "Transfer:Savings",
+		},
+		{ // in A (nearest to out A)
+			Institution: "Example Credit Union", Account: "Savings",
+			Description: "in-A", Amount: -10000, Timestamp: ts("2025-02-01"),
+			StatementID: "s", TransactionID: "inA", Category: "Transfer:Savings",
+		},
+		{ // out B
+			Institution: "Example Bank", Account: "Checking",
+			Description: "out-B", Amount: 10000, Timestamp: ts("2025-02-03"),
+			StatementID: "s", TransactionID: "outB", Category: "Transfer:Savings",
+		},
+		{ // in B (nearest to out B)
+			Institution: "Example Credit Union", Account: "Savings",
+			Description: "in-B", Amount: -10000, Timestamp: ts("2025-02-03"),
+			StatementID: "s", TransactionID: "inB", Category: "Transfer:Savings",
+		},
+	}
+	r := Build(txns, DefaultPairWindow)
+
+	if len(r.Entries) != 2 {
+		t.Fatalf("expected 2 merged entries, got %d", len(r.Entries))
+	}
+	for _, e := range r.Entries {
+		assertBalanced(t, legsByEntry(r.Legs)[e.ID])
+	}
+
+	docOutA := budget.TransactionDocID("s", "outA")
+	docInA := budget.TransactionDocID("s", "inA")
+	docOutB := budget.TransactionDocID("s", "outB")
+	docInB := budget.TransactionDocID("s", "inB")
+
+	// outA must pair with inA (same day), not inB.
+	if r.EntryIDByDocID[docOutA] != r.EntryIDByDocID[docInA] {
+		t.Errorf("outA should pair with inA")
+	}
+	if r.EntryIDByDocID[docOutB] != r.EntryIDByDocID[docInB] {
+		t.Errorf("outB should pair with inB")
+	}
+	if r.EntryIDByDocID[docOutA] == r.EntryIDByDocID[docOutB] {
+		t.Errorf("the two pairs must be distinct entries")
+	}
+
+	// No Unresolved Transfers (both pairs matched).
+	if _, ok := accountIDs(r.Accounts)[acctUnresolvedTransfers]; ok {
+		t.Errorf("no Unresolved Transfers expected when all transfers pair")
+	}
+}
+
+func TestCreditCardLiabilityDerivation(t *testing.T) {
+	txns := []budget.TransactionData{
+		{
+			Institution:   "Example Bank",
+			Account:       "Credit Card",
+			Description:   "Hardware Store",
+			Amount:        4500,
+			Timestamp:     ts("2025-02-10"),
+			StatementID:   "stmt-cc",
+			TransactionID: "cc-1",
+			Category:      "Home",
+			IsCreditCard:  true,
+		},
+	}
+	r := Build(txns, DefaultPairWindow)
+	ids := accountIDs(r.Accounts)
+	if ids["Example Bank_Credit Card"] != "liability" {
+		t.Errorf("credit-card account should be liability, got %q", ids["Example Bank_Credit Card"])
+	}
+}
+
+func TestPairWindowExcludesFarApart(t *testing.T) {
+	// Opposite-sign matching amounts on different accounts but timestamps
+	// beyond the window must NOT pair.
+	txns := []budget.TransactionData{
+		{
+			Institution: "Example Bank", Account: "Checking",
+			Description: "out", Amount: 10000, Timestamp: ts("2025-02-01"),
+			StatementID: "s", TransactionID: "out", Category: "Transfer:Savings",
+		},
+		{
+			Institution: "Example Credit Union", Account: "Savings",
+			Description: "in", Amount: -10000, Timestamp: ts("2025-02-20"),
+			StatementID: "s", TransactionID: "in", Category: "Transfer:Savings",
+		},
+	}
+	r := Build(txns, DefaultPairWindow)
+	if len(r.Entries) != 2 {
+		t.Fatalf("expected 2 unmerged entries, got %d", len(r.Entries))
+	}
+	// Both fall back to Unresolved Transfers.
+	if accountIDs(r.Accounts)[acctUnresolvedTransfers] != "asset" {
+		t.Errorf("expected Unresolved Transfers for unpaired transfers")
+	}
+}
+
+func TestIdempotency(t *testing.T) {
+	txns := []budget.TransactionData{
+		{
+			Institution: "Example Bank", Account: "Checking",
+			Description: "Grocery", Amount: 8450, Timestamp: ts("2025-02-05"),
+			StatementID: "s", TransactionID: "a", Category: "Groceries",
+		},
+		{
+			Institution: "Example Bank", Account: "Checking",
+			Description: "Payroll", Amount: -240000, Timestamp: ts("2025-02-14"),
+			StatementID: "s", TransactionID: "b", Category: "Income",
+		},
+		{
+			Institution: "Example Bank", Account: "Checking",
+			Description: "out", Amount: 30000, Timestamp: ts("2025-02-18"),
+			StatementID: "s", TransactionID: "out", Category: "Transfer:Savings",
+		},
+		{
+			Institution: "Example Credit Union", Account: "Savings",
+			Description: "in", Amount: -30000, Timestamp: ts("2025-02-19"),
+			StatementID: "s", TransactionID: "in", Category: "Transfer:Savings",
+		},
+	}
+	r1 := Build(txns, DefaultPairWindow)
+	r2 := Build(txns, DefaultPairWindow)
+
+	if !reflect.DeepEqual(r1.Entries, r2.Entries) {
+		t.Errorf("entries differ across runs")
+	}
+	if !reflect.DeepEqual(r1.Legs, r2.Legs) {
+		t.Errorf("legs differ across runs")
+	}
+	if !reflect.DeepEqual(r1.Accounts, r2.Accounts) {
+		t.Errorf("accounts differ across runs")
+	}
+	if !reflect.DeepEqual(r1.EntryIDByDocID, r2.EntryIDByDocID) {
+		t.Errorf("EntryIDByDocID differs across runs")
+	}
+
+	// Sorted by id.
+	for i := 1; i < len(r1.Entries); i++ {
+		if r1.Entries[i-1].ID >= r1.Entries[i].ID {
+			t.Errorf("entries not sorted by id")
+		}
+	}
+	for i := 1; i < len(r1.Legs); i++ {
+		if r1.Legs[i-1].ID >= r1.Legs[i].ID {
+			t.Errorf("legs not sorted by id")
+		}
+	}
+	for i := 1; i < len(r1.Accounts); i++ {
+		if r1.Accounts[i-1].ID >= r1.Accounts[i].ID {
+			t.Errorf("accounts not sorted by id")
+		}
+	}
+}
+
+func TestEmptyInputNonNilSlices(t *testing.T) {
+	r := Build(nil, DefaultPairWindow)
+	if r.Entries == nil || r.Legs == nil || r.Accounts == nil {
+		t.Errorf("slices must be non-nil so they serialize as [] not null")
+	}
+	if len(r.Entries) != 0 || len(r.Legs) != 0 || len(r.Accounts) != 0 {
+		t.Errorf("expected empty result")
+	}
+}

--- a/budget-etl/internal/journal/journal_test.go
+++ b/budget-etl/internal/journal/journal_test.go
@@ -63,7 +63,7 @@ func TestExpenseLine(t *testing.T) {
 			Category:      "Groceries",
 		},
 	}
-	r := Build(txns, DefaultPairWindow)
+	r := Build(txns, nil, DefaultPairWindow)
 
 	if len(r.Entries) != 1 || len(r.Legs) != 2 {
 		t.Fatalf("expected 1 entry / 2 legs, got %d / %d", len(r.Entries), len(r.Legs))
@@ -129,7 +129,7 @@ func TestIncomeLine(t *testing.T) {
 			Category:      "Income",
 		},
 	}
-	r := Build(txns, DefaultPairWindow)
+	r := Build(txns, nil, DefaultPairWindow)
 	assertBalanced(t, r.Legs)
 
 	byEntry := legsByEntry(r.Legs)
@@ -180,7 +180,7 @@ func TestMatchingPairMerge(t *testing.T) {
 			Category:      "Transfer:Savings",
 		},
 	}
-	r := Build(txns, DefaultPairWindow)
+	r := Build(txns, nil, DefaultPairWindow)
 
 	if len(r.Entries) != 1 {
 		t.Fatalf("expected 1 merged entry, got %d", len(r.Entries))
@@ -239,7 +239,7 @@ func TestUnmatchedTransferFallback(t *testing.T) {
 			Category:      "Transfer:Savings",
 		},
 	}
-	r := Build(txns, DefaultPairWindow)
+	r := Build(txns, nil, DefaultPairWindow)
 	assertBalanced(t, r.Legs)
 
 	legs := legsByEntry(r.Legs)[r.Entries[0].ID]
@@ -284,7 +284,7 @@ func TestTwoCandidatePairsNearestTime(t *testing.T) {
 			StatementID: "s", TransactionID: "inB", Category: "Transfer:Savings",
 		},
 	}
-	r := Build(txns, DefaultPairWindow)
+	r := Build(txns, nil, DefaultPairWindow)
 
 	if len(r.Entries) != 2 {
 		t.Fatalf("expected 2 merged entries, got %d", len(r.Entries))
@@ -329,7 +329,7 @@ func TestCreditCardLiabilityDerivation(t *testing.T) {
 			IsCreditCard:  true,
 		},
 	}
-	r := Build(txns, DefaultPairWindow)
+	r := Build(txns, nil, DefaultPairWindow)
 	ids := accountIDs(r.Accounts)
 	if ids["Example Bank_Credit Card"] != "liability" {
 		t.Errorf("credit-card account should be liability, got %q", ids["Example Bank_Credit Card"])
@@ -351,7 +351,7 @@ func TestPairWindowExcludesFarApart(t *testing.T) {
 			StatementID: "s", TransactionID: "in", Category: "Transfer:Savings",
 		},
 	}
-	r := Build(txns, DefaultPairWindow)
+	r := Build(txns, nil, DefaultPairWindow)
 	if len(r.Entries) != 2 {
 		t.Fatalf("expected 2 unmerged entries, got %d", len(r.Entries))
 	}
@@ -384,8 +384,8 @@ func TestIdempotency(t *testing.T) {
 			StatementID: "s", TransactionID: "in", Category: "Transfer:Savings",
 		},
 	}
-	r1 := Build(txns, DefaultPairWindow)
-	r2 := Build(txns, DefaultPairWindow)
+	r1 := Build(txns, nil, DefaultPairWindow)
+	r2 := Build(txns, nil, DefaultPairWindow)
 
 	if !reflect.DeepEqual(r1.Entries, r2.Entries) {
 		t.Errorf("entries differ across runs")
@@ -419,7 +419,7 @@ func TestIdempotency(t *testing.T) {
 }
 
 func TestEmptyInputNonNilSlices(t *testing.T) {
-	r := Build(nil, DefaultPairWindow)
+	r := Build(nil, nil, DefaultPairWindow)
 	if r.Entries == nil || r.Legs == nil || r.Accounts == nil {
 		t.Errorf("slices must be non-nil so they serialize as [] not null")
 	}

--- a/budget-etl/internal/parse/ofx.go
+++ b/budget-etl/internal/parse/ofx.go
@@ -101,5 +101,6 @@ func parseOFX(path string) (ParseResult, error) {
 		}
 	}
 
-	return ParseResult{Transactions: txns, Balance: balance, BalanceDate: balanceDate}, nil
+	isCreditCard := len(doc.CCTxns) > 0 && len(doc.BankTxns) == 0
+	return ParseResult{Transactions: txns, Balance: balance, BalanceDate: balanceDate, IsCreditCard: isCreditCard}, nil
 }

--- a/budget-etl/internal/parse/ofx.go
+++ b/budget-etl/internal/parse/ofx.go
@@ -101,6 +101,6 @@ func parseOFX(path string) (ParseResult, error) {
 		}
 	}
 
-	isCreditCard := len(doc.CCTxns) > 0 && len(doc.BankTxns) == 0
+	isCreditCard := len(doc.CCTxns) > 0
 	return ParseResult{Transactions: txns, Balance: balance, BalanceDate: balanceDate, IsCreditCard: isCreditCard}, nil
 }

--- a/budget-etl/internal/parse/parse.go
+++ b/budget-etl/internal/parse/parse.go
@@ -215,6 +215,7 @@ type ParseResult struct {
 	BalanceDate  time.Time // date the balance was observed; zero if absent. OFX: LEDGERBAL DTASOF. CSV: toDate.
 	Skipped      bool
 	SkipReason   string
+	IsCreditCard bool // true when the statement is a credit-card statement (OFX CREDITCARDMSGSRSV1)
 }
 
 // InferPeriod returns a YYYY-MM period derived from document data. Prefers

--- a/budget-etl/main.go
+++ b/budget-etl/main.go
@@ -177,7 +177,7 @@ func runOutputJSON(allTxns []budget.TransactionData, allStmts []budget.Statement
 
 	exportStmts := buildExportStatements(allStmts)
 
-	result := journal.Build(allTxns, journal.DefaultPairWindow)
+	result := journal.Build(allTxns, nil, journal.DefaultPairWindow)
 	for i := range exportTxns {
 		if id, ok := result.EntryIDByDocID[exportTxns[i].ID]; ok {
 			idCopy := id
@@ -358,6 +358,15 @@ func runInputJSON(input fileOpts, output fileOpts) error {
 		return err
 	}
 
+	// Build a set of account IDs that were classified as liabilities in the prior run.
+	// IsCreditCard is not stored in export.Transaction, so we recover it from Accounts.
+	priorLiabilities := make(map[string]bool, len(inp.Accounts))
+	for _, a := range inp.Accounts {
+		if a.AccountType == "liability" {
+			priorLiabilities[a.ID] = true
+		}
+	}
+
 	// Convert transactions to budget.TransactionData for categorization/budget assignment.
 	// Skip virtual transactions — they are regenerated fresh each run.
 	var allTxns []budget.TransactionData
@@ -370,6 +379,7 @@ func runInputJSON(input fileOpts, output fileOpts) error {
 		if err != nil {
 			return fmt.Errorf("transaction %s: invalid timestamp %q: %w", t.ID, t.Timestamp, err)
 		}
+		acctID := t.Institution + "_" + t.Account
 		allTxns = append(allTxns, budget.TransactionData{
 			Institution:   t.Institution,
 			Account:       t.Account,
@@ -378,6 +388,7 @@ func runInputJSON(input fileOpts, output fileOpts) error {
 			Timestamp:     ts,
 			StatementID:   t.StatementID,
 			TransactionID: t.ID,
+			IsCreditCard:  priorLiabilities[acctID],
 		})
 		txnDocIDs = append(txnDocIDs, t.ID)
 	}
@@ -441,7 +452,7 @@ func runInputJSON(input fileOpts, output fileOpts) error {
 	// Append pet budget if virtual Synchrony transactions exist
 	budgets := appendPetBudgetIfNeeded(inp.Budgets, vsr.transactions)
 
-	result := journal.Build(allTxns, journal.DefaultPairWindow)
+	result := journal.Build(allTxns, txnDocIDs, journal.DefaultPairWindow)
 	for i := range exportTxns {
 		if id, ok := result.EntryIDByDocID[exportTxns[i].ID]; ok {
 			idCopy := id
@@ -1055,6 +1066,15 @@ func runMerge(input fileOpts, dir, groupName string, disc parse.DiscoverOpts, ou
 		inputByID[t.ID] = t
 	}
 
+	// Build a set of account IDs that were classified as liabilities in the prior run.
+	// IsCreditCard is not stored in export.Transaction, so we recover it from Accounts.
+	priorLiabilities := make(map[string]bool, len(inp.Accounts))
+	for _, a := range inp.Accounts {
+		if a.AccountType == "liability" {
+			priorLiabilities[a.ID] = true
+		}
+	}
+
 	// Build TransactionData from dir, tracking which input IDs are covered.
 	// parseAndClassify does not return a transaction count, so pass 0 — the
 	// only cost is losing the pre-allocation capacity hint.
@@ -1081,6 +1101,7 @@ func runMerge(input fileOpts, dir, groupName string, disc parse.DiscoverOpts, ou
 		if err != nil {
 			return fmt.Errorf("transaction %s: invalid timestamp %q: %w", t.ID, t.Timestamp, err)
 		}
+		acctID := t.Institution + "_" + t.Account
 		allTxns = append(allTxns, budget.TransactionData{
 			Institution:   t.Institution,
 			Account:       t.Account,
@@ -1089,6 +1110,7 @@ func runMerge(input fileOpts, dir, groupName string, disc parse.DiscoverOpts, ou
 			Timestamp:     ts,
 			StatementID:   t.StatementID,
 			TransactionID: t.ID,
+			IsCreditCard:  priorLiabilities[acctID],
 		})
 		allDocIDs = append(allDocIDs, t.ID)
 		editsMap[t.ID] = txnEdits{
@@ -1144,7 +1166,7 @@ func runMerge(input fileOpts, dir, groupName string, disc parse.DiscoverOpts, ou
 	// Append pet budget if virtual Synchrony transactions exist
 	budgets := appendPetBudgetIfNeeded(inp.Budgets, vsr.transactions)
 
-	result := journal.Build(allTxns, journal.DefaultPairWindow)
+	result := journal.Build(allTxns, allDocIDs, journal.DefaultPairWindow)
 	for i := range exportTxns {
 		if id, ok := result.EntryIDByDocID[exportTxns[i].ID]; ok {
 			idCopy := id

--- a/budget-etl/main.go
+++ b/budget-etl/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/natb1/commons.systems/budget-etl/internal/budget"
 	"github.com/natb1/commons.systems/budget-etl/internal/export"
+	"github.com/natb1/commons.systems/budget-etl/internal/journal"
 	"github.com/natb1/commons.systems/budget-etl/internal/parse"
 	"github.com/natb1/commons.systems/budget-etl/internal/password"
 	"github.com/natb1/commons.systems/budget-etl/internal/rules"
@@ -176,6 +177,14 @@ func runOutputJSON(allTxns []budget.TransactionData, allStmts []budget.Statement
 
 	exportStmts := buildExportStatements(allStmts)
 
+	result := journal.Build(allTxns, journal.DefaultPairWindow)
+	for i := range exportTxns {
+		if id, ok := result.EntryIDByDocID[exportTxns[i].ID]; ok {
+			idCopy := id
+			exportTxns[i].JournalEntryID = &idCopy
+		}
+	}
+
 	out := export.Output{
 		Version:            1,
 		ExportedAt:         export.FormatTimestamp(time.Now()),
@@ -187,12 +196,16 @@ func runOutputJSON(allTxns []budget.TransactionData, allStmts []budget.Statement
 		Rules:              []export.Rule{},
 		NormalizationRules: []export.NormalizationRule{},
 		WeeklyAggregates:   []export.WeeklyAggregate{},
+		JournalEntries:     result.Entries,
+		JournalLegs:        result.Legs,
+		Accounts:           result.Accounts,
 	}
 
 	if err := export.WriteFile(output.path, out, output.password); err != nil {
 		return fmt.Errorf("writing output file: %w", err)
 	}
-	log.Printf("wrote %d transactions, %d statements to %s", len(exportTxns), len(exportStmts), output.path)
+	log.Printf("wrote %d transactions, %d statements, %d journal entries, %d legs, %d accounts to %s",
+		len(exportTxns), len(exportStmts), len(result.Entries), len(result.Legs), len(result.Accounts), output.path)
 	return nil
 }
 
@@ -428,6 +441,14 @@ func runInputJSON(input fileOpts, output fileOpts) error {
 	// Append pet budget if virtual Synchrony transactions exist
 	budgets := appendPetBudgetIfNeeded(inp.Budgets, vsr.transactions)
 
+	result := journal.Build(allTxns, journal.DefaultPairWindow)
+	for i := range exportTxns {
+		if id, ok := result.EntryIDByDocID[exportTxns[i].ID]; ok {
+			idCopy := id
+			exportTxns[i].JournalEntryID = &idCopy
+		}
+	}
+
 	return writeOutputAndLog(output, export.Output{
 		Version:            inp.Version,
 		ExportedAt:         export.FormatTimestamp(time.Now()),
@@ -440,6 +461,9 @@ func runInputJSON(input fileOpts, output fileOpts) error {
 		Rules:              inp.Rules,
 		NormalizationRules: inp.NormalizationRules,
 		WeeklyAggregates:   weeklyAggregates,
+		JournalEntries:     result.Entries,
+		JournalLegs:        result.Legs,
+		Accounts:           result.Accounts,
 	})
 }
 
@@ -711,8 +735,9 @@ func writeOutputAndLog(output fileOpts, out export.Output) error {
 			normalized++
 		}
 	}
-	log.Printf("wrote %d transactions (%d categorized, %d budgeted, %d non-primary normalized), %d budget periods to %s",
-		len(out.Transactions), categorized, budgeted, normalized, len(out.BudgetPeriods), output.path)
+	log.Printf("wrote %d transactions (%d categorized, %d budgeted, %d non-primary normalized), %d budget periods, %d journal entries, %d legs, %d accounts to %s",
+		len(out.Transactions), categorized, budgeted, normalized, len(out.BudgetPeriods),
+		len(out.JournalEntries), len(out.JournalLegs), len(out.Accounts), output.path)
 	return nil
 }
 
@@ -1119,6 +1144,14 @@ func runMerge(input fileOpts, dir, groupName string, disc parse.DiscoverOpts, ou
 	// Append pet budget if virtual Synchrony transactions exist
 	budgets := appendPetBudgetIfNeeded(inp.Budgets, vsr.transactions)
 
+	result := journal.Build(allTxns, journal.DefaultPairWindow)
+	for i := range exportTxns {
+		if id, ok := result.EntryIDByDocID[exportTxns[i].ID]; ok {
+			idCopy := id
+			exportTxns[i].JournalEntryID = &idCopy
+		}
+	}
+
 	return writeOutputAndLog(output, export.Output{
 		Version:            inp.Version,
 		ExportedAt:         export.FormatTimestamp(time.Now()),
@@ -1131,6 +1164,9 @@ func runMerge(input fileOpts, dir, groupName string, disc parse.DiscoverOpts, ou
 		Rules:              inp.Rules,
 		NormalizationRules: inp.NormalizationRules,
 		WeeklyAggregates:   weeklyAggregates,
+		JournalEntries:     result.Entries,
+		JournalLegs:        result.Legs,
+		Accounts:           result.Accounts,
 	})
 }
 

--- a/budget-etl/main.go
+++ b/budget-etl/main.go
@@ -832,6 +832,7 @@ func parseAndClassify(input *export.Output, dir string, disc parse.DiscoverOpts)
 				Timestamp:     t.Date,
 				StatementID:   pf.sf.StatementID(),
 				TransactionID: t.TransactionID,
+				IsCreditCard:  pf.result.IsCreditCard,
 			})
 			newDocIDs = append(newDocIDs, docID)
 		}

--- a/budget-etl/pipeline.go
+++ b/budget-etl/pipeline.go
@@ -92,6 +92,7 @@ func buildTransactions(
 				Timestamp:     t.Date,
 				StatementID:   pf.sf.StatementID(),
 				TransactionID: t.TransactionID,
+				IsCreditCard:  pf.result.IsCreditCard,
 			})
 			allDocIDs = append(allDocIDs, docID)
 			if visit != nil {


### PR DESCRIPTION
Closes #555

Makes `budget-etl` compute and emit double-entry journal entries into
`budget.json`, alongside the existing single-entry `Transaction` rows.

## What changed

- **Unit 1** — surface the OFX credit-card message-set signal as
  `IsCreditCard` on `budget.TransactionData`, so emitted `Account` records can
  be labeled `liability` (credit cards) vs `asset` (bank accounts).
- **Unit 2** — new pure package `internal/journal`. `journal.Build` turns a
  batch of parsed transactions into balanced `JournalEntry`/`JournalLeg`/
  `Account` records:
  - Per-line tentative 2-leg entry, signed from the bank amount, with a
    placeholder counter-account (`Budget_Uncategorized Expense`/`Income`, or
    `Budget_Unresolved Transfers` for `Transfer:*` lines).
  - Transfer-pair detection (same group, different account, opposite-sign
    amounts within 1c, timestamps within a 3-day window) with greedy
    nearest-time matching; matched pairs merge into one entry debiting the
    destination and crediting the source.
  - Unmatched transfer lines fall back to the `Unresolved Transfers` clearing
    account.
  - Deterministic ids derived from transaction docIDs for idempotent re-runs.
- **Unit 3** — wire `journal.Build` into the output/input/merge entry points;
  attach the three arrays to `export.Output` and back-fill `journalEntryId` on
  each transaction.

## Testing

- `go build`/`go vet`/`go test ./...` pass in `budget-etl`.
- Unit tests cover per-line emission (expense & income), matching-pair merge,
  unmatched-transfer fallback, two pairs in one window, `liability` derivation,
  and idempotency.
- End-to-end smoke check on the multi-account fixtures: two runs on the same
  input produce byte-identical `journalEntries`/`journalLegs`/`accounts`; every
  entry balances within a cent; every `leg.accountId` resolves to an emitted
  account; every transaction's `journalEntryId` references an emitted entry.