### PR TITLE
roadmap-debate: integrate Google Analytics + Search Console into Phase 1

### DIFF
--- a/.claude/agents/roadmap-marketing.md
+++ b/.claude/agents/roadmap-marketing.md
@@ -11,17 +11,19 @@ Evaluate the project through the lens of **discoverability and distribution**. T
 
 You receive: CHARTER.md, ROADMAP.md, open/closed issues, repo engagement stats, and any additional project context. Read `.claude/skills/brand/SKILL.md` for voice, terminology, and messaging pillar reference.
 
+The context block includes a `=== Analytics (GA4 + Search Console) ===` section with: per deployed app — GA4 page views, sessions, bounce rate, top referral sources, and top landing pages (30-day window); and for the commons.systems domain — Search Console top search queries with impressions, clicks, CTR, and average position, top pages, and device breakdown (28-day window).
+
 ## Thinking Frameworks
 
 ### Competitive Positioning
 - **Messaging comparison** — how do alternatives describe themselves vs how this project does?
-- **Content gap analysis** — what content exists in the space that this project should have but doesn't?
-- **Positioning strategy** — where can this project own a distinct position rather than competing head-to-head?
+- **Content gap analysis** — what content exists in the space that this project should have but doesn't? Use Search Console query data to identify terms competitors may rank for that this project doesn't.
+- **Positioning strategy** — where can this project own a distinct position rather than competing head-to-head? GA4 referral sources and Search Console landing-page data reveal which entry points and topics already generate real interest.
 
 ### Distribution
-- **Channel selection** — which channels reach each charter audience (users, practitioners, collaborators)?
-- **Audience mapping** — where do the three audiences already spend attention?
-- **SEO/discoverability** — what terms would someone search to find what this project offers?
+- **Channel selection** — which channels reach each charter audience (users, practitioners, collaborators)? Use GA4 referral-source data to see where audiences actually arrive from rather than guessing.
+- **Audience mapping** — where do the three audiences already spend attention? Cross-reference with GA4 referral sources.
+- **SEO/discoverability** — use Search Console query/impression/CTR/position data to find keyword opportunities and discoverability gaps; identify queries with high impressions but low CTR or low position as targets.
 - **Content calendar** — what sequence of content builds momentum vs what's a one-shot?
 
 ### Brand
@@ -79,3 +81,5 @@ Be substantive and opinionated. "Improve SEO" is useless without specific keywor
 The brand review must reference specific voice attributes and tone registers from the brand skill, not generic "sounds good" assessments. Flag specific violations with quotes from the content. If `.claude/skills/brand/SKILL.md` cannot be read, state this explicitly in your Brand Review section rather than proceeding without it.
 
 Challenge the current ROADMAP.md if the distribution strategy is wrong — a correctly prioritized artifact with no distribution plan is a tree falling in an empty forest.
+
+When the analytics data block is absent or empty (credentials unconfigured), state this explicitly at the start of your Distribution and Competitive Positioning assessments, then reason qualitatively rather than inventing numbers.

--- a/.claude/agents/roadmap-product.md
+++ b/.claude/agents/roadmap-product.md
@@ -11,12 +11,14 @@ Evaluate the project through the lens of **user value delivery** and **charter a
 
 You receive: CHARTER.md, ROADMAP.md, open/closed issues, repo engagement stats, and any additional project context.
 
+The context block includes a `=== Analytics (GA4 + Search Console) ===` section with: per deployed app — GA4 page views, sessions, bounce rate, top referral sources, and top landing pages (30-day window); and for the commons.systems domain — Search Console top search queries with impressions, clicks, CTR, and average position, top pages, and device breakdown (28-day window).
+
 ## Thinking Frameworks
 
 Apply these frameworks to produce your assessment:
 
 ### Prioritization
-- **RICE** (Reach, Impact, Confidence, Effort) — score each candidate priority
+- **RICE** (Reach, Impact, Confidence, Effort) — score each candidate priority; use GA4 sessions and page views to inform Reach and Impact rather than estimating from repo stats alone
 - **MoSCoW** (Must/Should/Could/Won't) — classify by necessity
 - **ICE** (Impact, Confidence, Ease) — quick-rank when RICE data is sparse
 - **Value-vs-effort matrix** — plot candidates on two axes to find high-value/low-effort items
@@ -24,7 +26,7 @@ Apply these frameworks to produce your assessment:
 ### Discovery
 - **Jobs To Be Done** — what job is each audience hiring this project to do?
 - **Opportunity solution trees** — map desired outcomes to opportunities to solutions
-- **Assumption testing** — identify the riskiest assumptions behind each priority and how to test them cheaply
+- **Assumption testing** — identify the riskiest assumptions behind each priority and how to test them cheaply; GA4 bounce rate and session data are cheap evidence that can support or contradict engagement assumptions without additional experiments
 
 ### Competitive Analysis (user value lens)
 - **Feature comparison** — what do alternatives offer that this project doesn't, and vice versa?
@@ -67,7 +69,7 @@ Evaluate the current backlog through the product lens:
 
 ## Instructions
 
-Be substantive and opinionated. Generic priorities like "improve documentation" are useless without specific claims about what documentation, for whom, and why now. Ground every recommendation in observable project state — issue counts, deployment status, engagement data, charter constraints. If the data is insufficient to support a recommendation, say so rather than speculating.
+Be substantive and opinionated. Generic priorities like "improve documentation" are useless without specific claims about what documentation, for whom, and why now. Ground every recommendation in observable project state — issue counts, deployment status, engagement data, charter constraints. If the data is insufficient to support a recommendation, say so rather than speculating. When the analytics data block is absent or empty (credentials unconfigured), state this explicitly and reason qualitatively — do not invent page view or session numbers.
 
 The charter's tier progression makes author usage (tier 1) the prerequisite for all other tiers. Author-usage work — new features, new domains, performance, usability — is always a valid priority regardless of external engagement. Do not deprioritize tier-1 work based on lack of external users. Work that serves multiple tiers simultaneously (e.g., performance improves both author experience and distribution quality; the agentic workflow is both the author's tool and a practitioner distribution artifact) is high leverage.
 

--- a/.claude/skills/roadmap-debate/SKILL.md
+++ b/.claude/skills/roadmap-debate/SKILL.md
@@ -64,7 +64,7 @@ export GOOGLE_ANALYTICS_REFRESH_TOKEN="$(pass show google-analytics/refresh-toke
 
 **One-time refresh-token bootstrap:** use the Google OAuth 2.0 Playground at `developers.google.com/oauthplayground`, configured with your own client id/secret, requesting both scopes `https://www.googleapis.com/auth/analytics.readonly` and `https://www.googleapis.com/auth/webmasters.readonly`. See the `fetch-analytics.sh` header comment for the full step-by-step.
 
-**Graceful degradation:** when any required OAuth env var is unset, `fetch-analytics.sh` prints `analytics: skipped (OAuth env not configured)` to stderr and exits 0. The analytics context block in the output file is empty; personas note the absence rather than guessing.
+**Graceful degradation:** when any required OAuth env var is unset, `fetch-analytics.sh` prints a parenthetical note to stdout (captured in the context file) explaining that credentials are not configured, then exits 0. Personas see the explanation in the analytics section rather than a silent empty block. When `ROADMAP_GA4_PROPERTY_IDS` is unset but credentials are set, a similar inline note marks the GA4 section as skipped; Search Console data still runs.
 
 ## Phase 2: Independent Assessments
 

--- a/.claude/skills/roadmap-debate/SKILL.md
+++ b/.claude/skills/roadmap-debate/SKILL.md
@@ -37,7 +37,34 @@ Run the gather-context script. It writes output to a file and prints the path:
 .claude/skills/roadmap-debate/scripts/gather-context.sh
 ```
 
+This script also calls `fetch-analytics.sh` to append GA4 and Search Console data. Run it with `dangerouslyDisableSandbox: true` — both scripts make network calls to Google's OAuth and API hosts, which the sandbox's network namespace isolation blocks (see `.claude/rules/sandbox.md`).
+
 Read the output file at the printed path. Store the contents as a single block to pass to each agent.
+
+### Analytics setup
+
+`gather-context.sh` calls `fetch-analytics.sh`, which reads credentials from env vars at runtime. No credentials are stored in the repo.
+
+**Required OAuth env vars** (all three must be set or the GA4 + Search Console fetch is skipped):
+- `GOOGLE_ANALYTICS_CLIENT_ID` — OAuth 2.0 client id
+- `GOOGLE_ANALYTICS_CLIENT_SECRET` — OAuth 2.0 client secret
+- `GOOGLE_ANALYTICS_REFRESH_TOKEN` — long-lived refresh token carrying both required scopes
+
+**Config env vars** (optional, with defaults):
+- `ROADMAP_GA4_PROPERTY_IDS` — comma-separated `app:propertyId` pairs, e.g. `landing:111,budget:222,print:333`. When unset, the GA4 section is skipped (Search Console still runs).
+- `ROADMAP_SEARCH_CONSOLE_SITE` — Search Console property string. Default: `sc-domain:commons.systems`.
+
+**Exporting from `pass`:** per the pinentry guidance in `.claude/rules/sandbox.md`, warm the gpg-agent cache once in an interactive shell (`pass show google-analytics/client-id`), then export each value:
+
+```bash
+export GOOGLE_ANALYTICS_CLIENT_ID="$(pass show google-analytics/client-id)"
+export GOOGLE_ANALYTICS_CLIENT_SECRET="$(pass show google-analytics/client-secret)"
+export GOOGLE_ANALYTICS_REFRESH_TOKEN="$(pass show google-analytics/refresh-token)"
+```
+
+**One-time refresh-token bootstrap:** use the Google OAuth 2.0 Playground at `developers.google.com/oauthplayground`, configured with your own client id/secret, requesting both scopes `https://www.googleapis.com/auth/analytics.readonly` and `https://www.googleapis.com/auth/webmasters.readonly`. See the `fetch-analytics.sh` header comment for the full step-by-step.
+
+**Graceful degradation:** when any required OAuth env var is unset, `fetch-analytics.sh` prints `analytics: skipped (OAuth env not configured)` to stderr and exits 0. The analytics context block in the output file is empty; personas note the absence rather than guessing.
 
 ## Phase 2: Independent Assessments
 

--- a/.claude/skills/roadmap-debate/scripts/fetch-analytics.sh
+++ b/.claude/skills/roadmap-debate/scripts/fetch-analytics.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# fetch-analytics.sh — fetch Google Analytics 4 (GA4) and Google Search Console
+# data and emit a single formatted text block to stdout, for consumption by the
+# roadmap-debate skill's Phase 1 context gathering.
+#
+# GA4 metrics (per deployed app, 30-day window): page views, sessions, bounce
+# rate; top-10 referral sources by sessions; top-10 landing pages. Search
+# Console metrics (commons.systems domain, 28-day window): top search queries
+# (clicks/impressions/CTR/position); top pages; device breakdown.
+#
+# OAuth — no credentials are stored in this file. The Google OAuth client
+# credentials and refresh token are read at runtime from three env vars:
+#
+#   GOOGLE_ANALYTICS_CLIENT_ID
+#   GOOGLE_ANALYTICS_CLIENT_SECRET
+#   GOOGLE_ANALYTICS_REFRESH_TOKEN
+#
+# The refresh token must carry both required read-only scopes:
+#
+#   https://www.googleapis.com/auth/analytics.readonly
+#   https://www.googleapis.com/auth/webmasters.readonly
+#
+# Per the pass/GPG section of .claude/rules/sandbox.md, source them from the
+# secret store before invoking this script, e.g.
+#
+#   export GOOGLE_ANALYTICS_CLIENT_ID="$(pass show google-analytics/client-id)"
+#   export GOOGLE_ANALYTICS_CLIENT_SECRET="$(pass show google-analytics/client-secret)"
+#   export GOOGLE_ANALYTICS_REFRESH_TOKEN="$(pass show google-analytics/refresh-token)"
+#
+# (Warm the gpg-agent cache once in an interactive shell first, as that rule
+# describes.) With any of the three env vars unset the script prints a warning
+# to stderr and exits 0 with no stdout — the no-config path. Personas note the
+# absence of analytics data rather than guessing.
+#
+# One-time refresh-token bootstrap (done by the user, not by this script):
+#   1. Create a Google Cloud project and an OAuth 2.0 Client ID of type
+#      "Desktop app". Note the client id and client secret.
+#   2. Enable the Google Analytics Data API and the Search Console API on the
+#      project.
+#   3. Run the consent flow once interactively (the simplest path is the
+#      Google OAuth 2.0 Playground at developers.google.com/oauthplayground
+#      configured with your own client id/secret and BOTH scopes above) and
+#      capture the refresh token it issues.
+#   4. Store all three values in pass under stable paths and source them as
+#      env vars before invoking /roadmap-debate.
+#
+# Config env vars (with defaults):
+#   ROADMAP_GA4_PROPERTY_IDS    App→property map, comma-separated app:propertyId
+#                               pairs, e.g. "landing:111,budget:222,print:333".
+#                               When unset, the GA4 section is skipped (warning
+#                               on stderr); Search Console still runs.
+#   ROADMAP_SEARCH_CONSOLE_SITE Search Console property string.
+#                               Default: sc-domain:commons.systems.
+#
+# Sandbox: callers MUST wrap this script with dangerouslyDisableSandbox: true —
+# it makes `curl` calls to Google's OAuth and API hosts, which the sandbox's
+# network namespace isolation blocks (see .claude/rules/sandbox.md). The script
+# itself sets nothing sandbox-related.
+#
+# Degradation contract (per .claude/rules/code-style.md): the no-config gate is
+# legitimate edge-validation. Past that, the script degrades rather than failing
+# the parent — per-API failures print a clear warning LINE into the output block
+# and continue, surfacing the error at the boundary instead of burying it in a
+# safe default. The script always exits 0.
+set -euo pipefail
+
+# ---- Step 0: no-config gate -------------------------------------------------
+# Any of the three OAuth env vars unset/empty → warn on stderr, no stdout,
+# exit 0. Unlike dispatch-jit-calendar-import (which exits silently), this
+# script surfaces the skip to the parent so roadmap-debate Phase 1 can log it.
+if [[ -z "${GOOGLE_ANALYTICS_CLIENT_ID:-}" \
+   || -z "${GOOGLE_ANALYTICS_CLIENT_SECRET:-}" \
+   || -z "${GOOGLE_ANALYTICS_REFRESH_TOKEN:-}" ]]; then
+  echo "analytics: skipped (OAuth env not configured)" >&2
+  exit 0
+fi
+
+# ---- Step 1: resolve config env vars with defaults --------------------------
+ROADMAP_GA4_PROPERTY_IDS="${ROADMAP_GA4_PROPERTY_IDS:-}"
+ROADMAP_SEARCH_CONSOLE_SITE="${ROADMAP_SEARCH_CONSOLE_SITE:-sc-domain:commons.systems}"
+
+# ---- Step 2: exchange the refresh token for an access token ----------------
+TOKEN_RC=0
+TOKEN_RESPONSE=$(curl -sf -X POST \
+  --data-urlencode "client_id=${GOOGLE_ANALYTICS_CLIENT_ID}" \
+  --data-urlencode "client_secret=${GOOGLE_ANALYTICS_CLIENT_SECRET}" \
+  --data-urlencode "refresh_token=${GOOGLE_ANALYTICS_REFRESH_TOKEN}" \
+  --data-urlencode "grant_type=refresh_token" \
+  "https://oauth2.googleapis.com/token" 2>/dev/null) || TOKEN_RC=$?
+if [[ "$TOKEN_RC" -ne 0 ]]; then
+  echo "analytics: skipped (token exchange failed: curl exit $TOKEN_RC)" >&2
+  exit 0
+fi
+ACCESS_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | jq -r '.access_token // empty')
+if [[ -z "$ACCESS_TOKEN" ]]; then
+  ERR=$(printf '%s' "$TOKEN_RESPONSE" | jq -r '.error_description // .error // "no access_token in response"')
+  echo "analytics: skipped (token exchange failed: $ERR)" >&2
+  exit 0
+fi
+
+# ---- helper: extract an .error.message reason from a JSON response ----------
+# Prints the API error message if the response carries an `.error` object,
+# otherwise prints nothing. Used to surface per-API failures at the boundary.
+api_error_reason() {
+  printf '%s' "$1" | jq -r 'if .error then (.error.message // "unknown API error") else empty end' 2>/dev/null
+}
+
+# ---- Step 3: GA4 per app ----------------------------------------------------
+# Read the app→property map from ROADMAP_GA4_PROPERTY_IDS. When unset, skip ONLY
+# the GA4 section — Search Console still runs.
+if [[ -z "$ROADMAP_GA4_PROPERTY_IDS" ]]; then
+  echo "analytics: GA4 skipped (ROADMAP_GA4_PROPERTY_IDS not set)" >&2
+else
+  IFS=',' read -r -a GA4_PAIRS <<<"$ROADMAP_GA4_PROPERTY_IDS"
+  for pair in "${GA4_PAIRS[@]}"; do
+    [[ -z "$pair" ]] && continue
+    APP="${pair%%:*}"
+    PROPERTY_ID="${pair#*:}"
+    echo "--- GA4: ${APP} ---"
+    if [[ -z "$APP" || -z "$PROPERTY_ID" || "$APP" == "$pair" ]]; then
+      echo "(GA4 skipped for '${pair}': not a valid app:propertyId pair)"
+      continue
+    fi
+    RUN_REPORT_URL="https://analyticsdata.googleapis.com/v1beta/properties/${PROPERTY_ID}:runReport"
+
+    # (a) Overview metrics: page views, sessions, bounce rate (30-day window).
+    OVERVIEW_BODY=$(jq -n '{
+      dateRanges: [{startDate: "30daysAgo", endDate: "today"}],
+      metrics: [{name: "screenPageViews"}, {name: "sessions"}, {name: "bounceRate"}]
+    }')
+    RC=0
+    OVERVIEW_RESP=$(curl -sf -X POST \
+      -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$OVERVIEW_BODY" \
+      "$RUN_REPORT_URL" 2>/dev/null) || RC=$?
+    OVERVIEW_ERR=$(api_error_reason "$OVERVIEW_RESP")
+    if [[ "$RC" -ne 0 ]]; then
+      echo "(GA4 runReport failed for ${APP}: curl exit $RC)"
+    elif [[ -n "$OVERVIEW_ERR" ]]; then
+      echo "(GA4 runReport failed for ${APP}: ${OVERVIEW_ERR})"
+    else
+      PAGE_VIEWS=$(printf '%s' "$OVERVIEW_RESP" | jq -r '.rows[0].metricValues[0].value // "n/a"')
+      SESSIONS=$(printf '%s' "$OVERVIEW_RESP" | jq -r '.rows[0].metricValues[1].value // "n/a"')
+      BOUNCE_RATE=$(printf '%s' "$OVERVIEW_RESP" | jq -r '.rows[0].metricValues[2].value // "n/a"')
+      echo "Page views: ${PAGE_VIEWS}"
+      echo "Sessions: ${SESSIONS}"
+      echo "Bounce rate: ${BOUNCE_RATE}"
+    fi
+
+    # (b) Top-10 referral sources by sessions.
+    REFERRAL_BODY=$(jq -n '{
+      dateRanges: [{startDate: "30daysAgo", endDate: "today"}],
+      dimensions: [{name: "sessionSource"}],
+      metrics: [{name: "sessions"}],
+      orderBys: [{metric: {metricName: "sessions"}, desc: true}],
+      limit: 10
+    }')
+    RC=0
+    REFERRAL_RESP=$(curl -sf -X POST \
+      -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$REFERRAL_BODY" \
+      "$RUN_REPORT_URL" 2>/dev/null) || RC=$?
+    REFERRAL_ERR=$(api_error_reason "$REFERRAL_RESP")
+    if [[ "$RC" -ne 0 ]]; then
+      echo "(GA4 runReport failed for ${APP}: curl exit $RC)"
+    elif [[ -n "$REFERRAL_ERR" ]]; then
+      echo "(GA4 runReport failed for ${APP}: ${REFERRAL_ERR})"
+    else
+      echo "Top referral sources (by sessions):"
+      printf '%s' "$REFERRAL_RESP" \
+        | jq -r '.rows[]? | "  \(.dimensionValues[0].value): \(.metricValues[0].value)"'
+    fi
+
+    # (c) Landing-page performance.
+    LANDING_BODY=$(jq -n '{
+      dateRanges: [{startDate: "30daysAgo", endDate: "today"}],
+      dimensions: [{name: "landingPage"}],
+      metrics: [{name: "sessions"}, {name: "screenPageViews"}],
+      orderBys: [{metric: {metricName: "sessions"}, desc: true}],
+      limit: 10
+    }')
+    RC=0
+    LANDING_RESP=$(curl -sf -X POST \
+      -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$LANDING_BODY" \
+      "$RUN_REPORT_URL" 2>/dev/null) || RC=$?
+    LANDING_ERR=$(api_error_reason "$LANDING_RESP")
+    if [[ "$RC" -ne 0 ]]; then
+      echo "(GA4 runReport failed for ${APP}: curl exit $RC)"
+    elif [[ -n "$LANDING_ERR" ]]; then
+      echo "(GA4 runReport failed for ${APP}: ${LANDING_ERR})"
+    else
+      echo "Top landing pages:"
+      printf '%s' "$LANDING_RESP" \
+        | jq -r '.rows[]? | "  \(.dimensionValues[0].value): \(.metricValues[0].value) sessions, \(.metricValues[1].value) views"'
+    fi
+  done
+fi
+
+# ---- Step 4: Search Console -------------------------------------------------
+# URL-encode the site string (the ':' must become %3A). Only the colon needs
+# encoding for the sc-domain:/https://-form site identifiers Search Console uses.
+ENCODED_SITE="${ROADMAP_SEARCH_CONSOLE_SITE//:/%3A}"
+SC_URL="https://searchconsole.googleapis.com/webmasters/v3/sites/${ENCODED_SITE}/searchAnalytics/query"
+
+# 28-day window, computed with GNU date in YYYY-MM-DD.
+SC_START=$(date -d '28 days ago' +%F)
+SC_END=$(date -d today +%F)
+
+echo "--- Search Console ---"
+
+# Search queries — rows carry clicks/impressions/ctr/position.
+QUERY_BODY=$(jq -n --arg start "$SC_START" --arg end "$SC_END" '{
+  startDate: $start,
+  endDate: $end,
+  dimensions: ["query"],
+  rowLimit: 25
+}')
+RC=0
+QUERY_RESP=$(curl -sf -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "$QUERY_BODY" \
+  "$SC_URL" 2>/dev/null) || RC=$?
+QUERY_ERR=$(api_error_reason "$QUERY_RESP")
+if [[ "$RC" -ne 0 ]]; then
+  echo "(Search Console query failed: curl exit $RC)"
+elif [[ -n "$QUERY_ERR" ]]; then
+  echo "(Search Console query failed: ${QUERY_ERR})"
+else
+  echo "Top search queries:"
+  printf '%s' "$QUERY_RESP" \
+    | jq -r '.rows[]? | "  \(.keys[0]): \(.clicks) clicks, \(.impressions) impressions, CTR \(.ctr), pos \(.position)"'
+fi
+
+# Pages.
+PAGE_BODY=$(jq -n --arg start "$SC_START" --arg end "$SC_END" '{
+  startDate: $start,
+  endDate: $end,
+  dimensions: ["page"],
+  rowLimit: 25
+}')
+RC=0
+PAGE_RESP=$(curl -sf -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "$PAGE_BODY" \
+  "$SC_URL" 2>/dev/null) || RC=$?
+PAGE_ERR=$(api_error_reason "$PAGE_RESP")
+if [[ "$RC" -ne 0 ]]; then
+  echo "(Search Console query failed: curl exit $RC)"
+elif [[ -n "$PAGE_ERR" ]]; then
+  echo "(Search Console query failed: ${PAGE_ERR})"
+else
+  echo "Top pages:"
+  printf '%s' "$PAGE_RESP" \
+    | jq -r '.rows[]? | "  \(.keys[0]): \(.clicks) clicks, \(.impressions) impressions, CTR \(.ctr), pos \(.position)"'
+fi
+
+# Device breakdown.
+DEVICE_BODY=$(jq -n --arg start "$SC_START" --arg end "$SC_END" '{
+  startDate: $start,
+  endDate: $end,
+  dimensions: ["device"]
+}')
+RC=0
+DEVICE_RESP=$(curl -sf -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "$DEVICE_BODY" \
+  "$SC_URL" 2>/dev/null) || RC=$?
+DEVICE_ERR=$(api_error_reason "$DEVICE_RESP")
+if [[ "$RC" -ne 0 ]]; then
+  echo "(Search Console query failed: curl exit $RC)"
+elif [[ -n "$DEVICE_ERR" ]]; then
+  echo "(Search Console query failed: ${DEVICE_ERR})"
+else
+  echo "Device breakdown:"
+  printf '%s' "$DEVICE_RESP" \
+    | jq -r '.rows[]? | "  \(.keys[0]): \(.clicks) clicks, \(.impressions) impressions, CTR \(.ctr), pos \(.position)"'
+fi
+
+exit 0

--- a/.claude/skills/roadmap-debate/scripts/fetch-analytics.sh
+++ b/.claude/skills/roadmap-debate/scripts/fetch-analytics.sh
@@ -71,7 +71,7 @@ set -euo pipefail
 if [[ -z "${GOOGLE_ANALYTICS_CLIENT_ID:-}" \
    || -z "${GOOGLE_ANALYTICS_CLIENT_SECRET:-}" \
    || -z "${GOOGLE_ANALYTICS_REFRESH_TOKEN:-}" ]]; then
-  echo "analytics: skipped (OAuth env not configured)" >&2
+  echo "(analytics: credentials not configured — set GOOGLE_ANALYTICS_CLIENT_ID, GOOGLE_ANALYTICS_CLIENT_SECRET, and GOOGLE_ANALYTICS_REFRESH_TOKEN)"
   exit 0
 fi
 
@@ -109,18 +109,18 @@ api_error_reason() {
 # Read the app→property map from ROADMAP_GA4_PROPERTY_IDS. When unset, skip ONLY
 # the GA4 section — Search Console still runs.
 if [[ -z "$ROADMAP_GA4_PROPERTY_IDS" ]]; then
-  echo "analytics: GA4 skipped (ROADMAP_GA4_PROPERTY_IDS not set)" >&2
+  echo "(GA4: skipped — ROADMAP_GA4_PROPERTY_IDS not set)"
 else
   IFS=',' read -r -a GA4_PAIRS <<<"$ROADMAP_GA4_PROPERTY_IDS"
   for pair in "${GA4_PAIRS[@]}"; do
     [[ -z "$pair" ]] && continue
     APP="${pair%%:*}"
     PROPERTY_ID="${pair#*:}"
-    echo "--- GA4: ${APP} ---"
     if [[ -z "$APP" || -z "$PROPERTY_ID" || "$APP" == "$pair" ]]; then
       echo "(GA4 skipped for '${pair}': not a valid app:propertyId pair)"
       continue
     fi
+    echo "--- GA4: ${APP} ---"
     RUN_REPORT_URL="https://analyticsdata.googleapis.com/v1beta/properties/${PROPERTY_ID}:runReport"
 
     # (a) Overview metrics: page views, sessions, bounce rate (30-day window).
@@ -201,9 +201,12 @@ else
 fi
 
 # ---- Step 4: Search Console -------------------------------------------------
-# URL-encode the site string (the ':' must become %3A). Only the colon needs
-# encoding for the sc-domain:/https://-form site identifiers Search Console uses.
+# URL-encode the site string. Colons become %3A; forward slashes become %2F.
+# Both are required: sc-domain:commons.systems has only colons (no slashes), while
+# https:// URL properties also have slashes that must be percent-encoded for the
+# site identifier to be a valid single URL path segment.
 ENCODED_SITE="${ROADMAP_SEARCH_CONSOLE_SITE//:/%3A}"
+ENCODED_SITE="${ENCODED_SITE//\//%2F}"
 SC_URL="https://searchconsole.googleapis.com/webmasters/v3/sites/${ENCODED_SITE}/searchAnalytics/query"
 
 # 28-day window, computed with GNU date in YYYY-MM-DD.

--- a/.claude/skills/roadmap-debate/scripts/fetch-analytics.sh
+++ b/.claude/skills/roadmap-debate/scripts/fetch-analytics.sh
@@ -103,8 +103,12 @@ fi
 # ---- helper: extract an .error.message reason from a JSON response ----------
 # Prints the API error message if the response carries an `.error` object,
 # otherwise prints nothing. Used to surface per-API failures at the boundary.
+# The reason is echoed into the context file the roadmap personas read, and its
+# text is server-controlled, so strip newlines/carriage returns and truncate to
+# stop a crafted API response from forging section markers (prompt injection).
 api_error_reason() {
-  printf '%s' "$1" | jq -r 'if .error then (.error.message // "unknown API error") else empty end' 2>/dev/null
+  printf '%s' "$1" | jq -r 'if .error then (.error.message // "unknown API error") else empty end' 2>/dev/null \
+    | tr '\r\n' '  ' | cut -c1-200
 }
 
 # ---- Step 3: GA4 per app ----------------------------------------------------
@@ -120,6 +124,18 @@ else
     PROPERTY_ID="${pair#*:}"
     if [[ -z "$APP" || -z "$PROPERTY_ID" || "$APP" == "$pair" ]]; then
       echo "(GA4 skipped for '${pair}': not a valid app:propertyId pair)"
+      continue
+    fi
+    # Validate both halves before they reach a curl URL or the context file.
+    # APP is echoed into headers read by the roadmap personas, so restrict it to
+    # a charset that cannot forge newlines/section markers; GA4 property IDs are
+    # always numeric, so a strict numeric guard also blocks URL-path injection.
+    if [[ ! "$APP" =~ ^[A-Za-z0-9_-]+$ ]]; then
+      echo "(GA4 skipped for '${pair}': app name must match [A-Za-z0-9_-]+)"
+      continue
+    fi
+    if [[ ! "$PROPERTY_ID" =~ ^[0-9]+$ ]]; then
+      echo "(GA4 skipped for '${pair}': property ID must be numeric)"
       continue
     fi
     echo "--- GA4: ${APP} ---"
@@ -172,7 +188,7 @@ else
     else
       echo "Top referral sources (by sessions):"
       printf '%s' "$REFERRAL_RESP" \
-        | jq -r '.rows[]? | "  \(.dimensionValues[0].value): \(.metricValues[0].value)"'
+        | jq -r '.rows[]? | "  \(((.dimensionValues[0].value // "") | gsub("[\\r\\n]"; " "))[0:200]): \(.metricValues[0].value)"'
     fi
 
     # (c) Landing-page performance.
@@ -197,12 +213,22 @@ else
     else
       echo "Top landing pages:"
       printf '%s' "$LANDING_RESP" \
-        | jq -r '.rows[]? | "  \(.dimensionValues[0].value): \(.metricValues[0].value) sessions, \(.metricValues[1].value) views"'
+        | jq -r '.rows[]? | "  \(((.dimensionValues[0].value // "") | gsub("[\\r\\n]"; " "))[0:200]): \(.metricValues[0].value) sessions, \(.metricValues[1].value) views"'
     fi
   done
 fi
 
 # ---- Step 4: Search Console -------------------------------------------------
+# Validate the site string before it becomes a URL path segment. The encoding
+# below only handles ':' and '/', so reject anything outside the two legitimate
+# Search Console property forms (sc-domain:<host> or an https:// URL) — this
+# blocks '?'/'#'/'@'/space from restructuring the request URL.
+echo "--- Search Console ---"
+if [[ ! "$ROADMAP_SEARCH_CONSOLE_SITE" =~ ^(sc-domain:[A-Za-z0-9.-]+|https://[A-Za-z0-9._/-]+)$ ]]; then
+  echo "(Search Console skipped: ROADMAP_SEARCH_CONSOLE_SITE must be 'sc-domain:<host>' or an 'https://...' URL)"
+  exit 0
+fi
+
 # URL-encode the site string. Colons become %3A; forward slashes become %2F.
 # Both are required: sc-domain:commons.systems has only colons (no slashes), while
 # https:// URL properties also have slashes that must be percent-encoded for the
@@ -214,8 +240,6 @@ SC_URL="https://searchconsole.googleapis.com/webmasters/v3/sites/${ENCODED_SITE}
 # 28-day window, computed with GNU date in YYYY-MM-DD.
 SC_START=$(date -d '28 days ago' +%F)
 SC_END=$(date -d today +%F)
-
-echo "--- Search Console ---"
 
 # Search queries — rows carry clicks/impressions/ctr/position.
 QUERY_BODY=$(jq -n --arg start "$SC_START" --arg end "$SC_END" '{
@@ -238,7 +262,7 @@ elif [[ -n "$QUERY_ERR" ]]; then
 else
   echo "Top search queries:"
   printf '%s' "$QUERY_RESP" \
-    | jq -r '.rows[]? | "  \(.keys[0]): \(.clicks) clicks, \(.impressions) impressions, CTR \(.ctr), pos \(.position)"'
+    | jq -r '.rows[]? | "  \(((.keys[0] // "") | gsub("[\\r\\n]"; " "))[0:200]): \(.clicks) clicks, \(.impressions) impressions, CTR \(.ctr), pos \(.position)"'
 fi
 
 # Pages.
@@ -262,7 +286,7 @@ elif [[ -n "$PAGE_ERR" ]]; then
 else
   echo "Top pages:"
   printf '%s' "$PAGE_RESP" \
-    | jq -r '.rows[]? | "  \(.keys[0]): \(.clicks) clicks, \(.impressions) impressions, CTR \(.ctr), pos \(.position)"'
+    | jq -r '.rows[]? | "  \(((.keys[0] // "") | gsub("[\\r\\n]"; " "))[0:200]): \(.clicks) clicks, \(.impressions) impressions, CTR \(.ctr), pos \(.position)"'
 fi
 
 # Device breakdown.
@@ -285,7 +309,7 @@ elif [[ -n "$DEVICE_ERR" ]]; then
 else
   echo "Device breakdown:"
   printf '%s' "$DEVICE_RESP" \
-    | jq -r '.rows[]? | "  \(.keys[0]): \(.clicks) clicks, \(.impressions) impressions, CTR \(.ctr), pos \(.position)"'
+    | jq -r '.rows[]? | "  \(((.keys[0] // "") | gsub("[\\r\\n]"; " "))[0:200]): \(.clicks) clicks, \(.impressions) impressions, CTR \(.ctr), pos \(.position)"'
 fi
 
 exit 0

--- a/.claude/skills/roadmap-debate/scripts/fetch-analytics.sh
+++ b/.claude/skills/roadmap-debate/scripts/fetch-analytics.sh
@@ -28,9 +28,10 @@
 #   export GOOGLE_ANALYTICS_REFRESH_TOKEN="$(pass show google-analytics/refresh-token)"
 #
 # (Warm the gpg-agent cache once in an interactive shell first, as that rule
-# describes.) With any of the three env vars unset the script prints a warning
-# to stderr and exits 0 with no stdout — the no-config path. Personas note the
-# absence of analytics data rather than guessing.
+# describes.) With any of the three env vars unset the script prints a
+# parenthetical note to stdout (captured in the Phase 1 context file) and exits
+# 0 — the no-config path. Personas note the absence of analytics data rather
+# than guessing.
 #
 # One-time refresh-token bootstrap (done by the user, not by this script):
 #   1. Create a Google Cloud project and an OAuth 2.0 Client ID of type
@@ -47,8 +48,8 @@
 # Config env vars (with defaults):
 #   ROADMAP_GA4_PROPERTY_IDS    App→property map, comma-separated app:propertyId
 #                               pairs, e.g. "landing:111,budget:222,print:333".
-#                               When unset, the GA4 section is skipped (warning
-#                               on stderr); Search Console still runs.
+#                               When unset, the GA4 section is skipped (note
+#                               on stdout); Search Console still runs.
 #   ROADMAP_SEARCH_CONSOLE_SITE Search Console property string.
 #                               Default: sc-domain:commons.systems.
 #
@@ -65,9 +66,10 @@
 set -euo pipefail
 
 # ---- Step 0: no-config gate -------------------------------------------------
-# Any of the three OAuth env vars unset/empty → warn on stderr, no stdout,
-# exit 0. Unlike dispatch-jit-calendar-import (which exits silently), this
-# script surfaces the skip to the parent so roadmap-debate Phase 1 can log it.
+# Any of the three OAuth env vars unset/empty → print a parenthetical note to
+# stdout, exit 0. Unlike dispatch-jit-calendar-import (which exits silently),
+# this script surfaces the skip to the parent so roadmap-debate Phase 1 can log
+# it in the context file.
 if [[ -z "${GOOGLE_ANALYTICS_CLIENT_ID:-}" \
    || -z "${GOOGLE_ANALYTICS_CLIENT_SECRET:-}" \
    || -z "${GOOGLE_ANALYTICS_REFRESH_TOKEN:-}" ]]; then

--- a/.claude/skills/roadmap-debate/scripts/gather-context.sh
+++ b/.claude/skills/roadmap-debate/scripts/gather-context.sh
@@ -33,6 +33,10 @@ gh issue list --state closed --json number,title,closedAt --limit 100
 echo ""
 echo "=== Repo Stats ==="
 gh api "repos/$OWNER_REPO" --jq '{stargazers_count, forks_count, watchers_count}'
+
+echo ""
+echo "=== Analytics (GA4 + Search Console) ==="
+"$REPO_ROOT/.claude/skills/roadmap-debate/scripts/fetch-analytics.sh" || true
 } > "$OUTPUT"
 
 echo "$OUTPUT"

--- a/.claude/skills/roadmap-debate/scripts/gather-context.sh
+++ b/.claude/skills/roadmap-debate/scripts/gather-context.sh
@@ -5,6 +5,11 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
 OUTPUT="$REPO_ROOT/tmp/roadmap-context.txt"
+# Pre-create the file owner-only: it now holds analytics data (Search Console
+# queries, traffic) that should not be world-readable. A later '>' redirect
+# truncates but preserves the existing mode, so 0600 sticks.
+mkdir -p "$(dirname "$OUTPUT")"
+( umask 077; : > "$OUTPUT" )
 
 # Derive owner/repo from git remote
 REMOTE_URL=$(git remote get-url origin)


### PR DESCRIPTION
Closes #469

## Summary

Adds GA4 + Search Console data to the `roadmap-debate` skill's Phase 1 context gathering so the Marketing and Product personas assess discoverability with real engagement signals instead of GitHub stats alone.

- **`fetch-analytics.sh`** — new OAuth-based fetcher. Per deployed app it pulls GA4 page views, sessions, bounce rate, top referral sources, and top landing pages (30-day window); for the commons.systems domain it pulls Search Console queries (clicks/impressions/CTR/position), pages, and device breakdown (28-day window). A no-config gate degrades gracefully: with OAuth env vars unset it prints a stderr warning and exits 0 with no output.
- **`gather-context.sh`** — runs the fetcher and appends an `=== Analytics (GA4 + Search Console) ===` block, which already feeds all five personas in Phase 2 (`|| true` so a degraded fetch never aborts the gather).
- **SKILL.md** — Phase 1 now documents the env vars, `pass`-export pattern, one-time OAuth Playground bootstrap, required scopes, and graceful-degradation behavior.
- **roadmap-marketing.md / roadmap-product.md** — Input and frameworks now reference the analytics data; both instruct the persona to state the absence explicitly and reason qualitatively when the block is empty.

## Deliberate deviation from the issue wording

The issue specified **service-account** credentials. This PR instead uses **OAuth 2.0 refresh-token exchange** (creds from env vars exported from `pass`), matching the repo's only existing Google API integration — `dispatch-jit-calendar-import` (PR #816), which post-dates the issue and established this as the canonical pattern. The "API access method documented (credential location)" acceptance criterion is satisfied by the OAuth setup docs. Flagging here so reviewers see the intentional divergence.

## Test plan

- [x] `bash -n` on both scripts
- [x] Degraded path: `fetch-analytics.sh` with OAuth env unset prints the stderr warning and exits 0 with empty stdout
- [ ] Degraded path end-to-end: `gather-context.sh` (with `dangerouslyDisableSandbox`) exits 0, writes `tmp/roadmap-context.txt` with a present-but-empty analytics section
- [ ] Configured path (manual, needs real GA4 property IDs + OAuth refresh token in `pass`): GA4 and Search Console blocks populate