### PR TITLE
dispatch: propagate PATH into reseed timer unit so it finds bash

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-reseed
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-reseed
@@ -291,6 +291,13 @@ fi
 # that dedup-guards, prunes stopped agents, and spawns
 # `claude --bg --name dispatch-<id> --permission-mode auto "/dispatch-propagate"`
 # from the main worktree.
+#
+# --setenv=PATH="$PATH" propagates the scheduling caller's PATH into the
+# transient unit. Without it the unit inherits the systemd user manager's
+# minimal default PATH, which omits the nix store — so on NixOS/WSL hosts
+# /usr/bin/env can't resolve bash (exit 127) and the router can't find
+# claude/git/jq. The caller (a /dispatch-propagate tick) always carries the
+# full nix-store PATH.
 
 SYSTEMD_RUN_CMD="${DISPATCH_SCHEDULE_RESEED_SYSTEMD_RUN_CMD:-systemd-run}"
 UNIT_NAME="dispatch-reseed-${RESEED_AT}"
@@ -307,6 +314,7 @@ trap 'rm -f "$RUN_STDERR"' EXIT
      --on-calendar="@$RESEED_AT" \
      --working-directory="$MAIN_WORKTREE" \
      --timer-property=Persistent=true \
+     --setenv=PATH="$PATH" \
      "$MAIN_WORKTREE/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-router" \
      2>"$RUN_STDERR"
 RC=$?

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-reseed
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-reseed
@@ -297,7 +297,8 @@ fi
 # minimal default PATH, which omits the nix store — so on NixOS/WSL hosts
 # /usr/bin/env can't resolve bash (exit 127) and the router can't find
 # claude/git/jq. The caller (a /dispatch-propagate tick) always carries the
-# full nix-store PATH.
+# full nix-store PATH, so capturing it at schedule time makes the unit
+# self-sufficient when the timer later fires.
 
 SYSTEMD_RUN_CMD="${DISPATCH_SCHEDULE_RESEED_SYSTEMD_RUN_CMD:-systemd-run}"
 UNIT_NAME="dispatch-reseed-${RESEED_AT}"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -5759,10 +5759,11 @@ TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--unit=dispatch-reseed-20000"* \
    && "$log" == *"--on-calendar=@20000"* \
    && "$log" == *"--working-directory=$TMPDIR_TEST/main"* \
+   && "$log" == *"--setenv=PATH="* \
    && "$log" == *"$TMPDIR_TEST/main/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-router"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: weekly cap-hit systemd-run argv (unit + calendar + cwd + exec)"
+  PASS=$((PASS + 1)); echo "  PASS: weekly cap-hit systemd-run argv (unit + calendar + cwd + setenv + exec)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: weekly cap-hit systemd-run argv (unit + calendar + cwd + exec)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: weekly cap-hit systemd-run argv (unit + calendar + cwd + setenv + exec)"
   echo "    log: $log"
 fi
 sr_teardown


### PR DESCRIPTION
Closes #961

The reseed `systemd-run --user` transient unit inherited the user manager's
minimal default PATH (no nix store), so `/usr/bin/env` couldn't resolve `bash`
and the unit exited 127. Add `--setenv=PATH="$PATH"` to carry the scheduling
caller's nix-store PATH into the unit, so `dispatch-spawn-router` and its
`claude`/`git`/`jq` calls resolve when the timer fires.

- `dispatch-schedule-reseed` — add `--setenv=PATH="$PATH"` to the `systemd-run --user` invocation.
- `test-dispatch-scripts.sh` — assert the recorded systemd-run argv carries `--setenv=PATH=`.