### PR TITLE
dispatch-target-workers: terminal-sprint envelope drives weekly usage to 100% at week end

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
@@ -99,8 +99,8 @@
 # weekly_increment_cap_pct and five_hour_target_floor_pct <=
 # five_hour_target_ceiling_pct.
 #
-#   target_weekly_usage_pct        default 90   curve terminal W(1)
-#   weekly_terminal_pct            default 100  cumulative terminal W(1)
+#   target_weekly_usage_pct        default 90   smooth-curve terminal
+#   weekly_terminal_pct            default 100  envelope terminal W(1)
 #   weekly_increment_floor_pct     default 1    per-window floor
 #   weekly_increment_cap_pct       default 10   per-window hard ceiling
 #   weekly_curve_power             default 1    convexity; >1 back-loads

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
@@ -92,7 +92,7 @@
 #
 # Top-level object with optional tunables for `dispatch-target-workers`. Each
 # field must be a number when present; absent fields fall back to the
-# defaults baked into `dispatch-target-workers`. The seven percentage fields
+# defaults baked into `dispatch-target-workers`. The eight percentage fields
 # must be in (0, 100]; weekly_curve_power and max_concurrent_workers must be
 # > 0 with no upper bound. When both members of a pair are present, two
 # cross-field ordering checks apply: weekly_increment_floor_pct <=
@@ -100,6 +100,7 @@
 # five_hour_target_ceiling_pct.
 #
 #   target_weekly_usage_pct        default 90   curve terminal W(1)
+#   weekly_terminal_pct            default 100  cumulative terminal W(1)
 #   weekly_increment_floor_pct     default 1    per-window floor
 #   weekly_increment_cap_pct       default 10   per-window hard ceiling
 #   weekly_curve_power             default 1    convexity; >1 back-loads
@@ -112,6 +113,7 @@
 # Example (see target-workers.example.json):
 #   {
 #     "target_weekly_usage_pct": 90,
+#     "weekly_terminal_pct": 100,
 #     "weekly_increment_floor_pct": 1,
 #     "weekly_increment_cap_pct": 10,
 #     "weekly_curve_power": 1,
@@ -261,14 +263,15 @@ case "$CONFIG_TYPE" in
     # top-level value must be an object; all tunables are optional numbers.
     # `dispatch-target-workers` substitutes a baked-in default for any field
     # absent here, so absence is silent — only the type of present fields is
-    # checked. The seven percentage fields carry an additional `<= 100` bound;
+    # checked. The eight percentage fields carry an additional `<= 100` bound;
     # weekly_curve_power and max_concurrent_workers have no upper bound.
     ERRORS=$(jq -r '
       if type != "object" then
         "top-level value must be a JSON object, got \(type)"
       else
         . as $cfg |
-        (["target_weekly_usage_pct","weekly_increment_floor_pct",
+        (["target_weekly_usage_pct","weekly_terminal_pct",
+          "weekly_increment_floor_pct",
           "weekly_increment_cap_pct","weekly_curve_power",
           "weekly_headroom_taper_pct","five_hour_target_floor_pct",
           "five_hour_target_ceiling_pct","five_hour_headroom_taper_pct",
@@ -277,7 +280,8 @@ case "$CONFIG_TYPE" in
          . as $field |
          # The percentage fields are bounded (0, 100]; the other two are
          # unbounded above.
-         ([ "target_weekly_usage_pct","weekly_increment_floor_pct",
+         ([ "target_weekly_usage_pct","weekly_terminal_pct",
+            "weekly_increment_floor_pct",
             "weekly_increment_cap_pct","weekly_headroom_taper_pct",
             "five_hour_target_floor_pct","five_hour_target_ceiling_pct",
             "five_hour_headroom_taper_pct" ] | index($field)) as $is_pct |

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
@@ -69,7 +69,7 @@
 #   remaining = resets_at_weekly - now;   if remaining <= 0: print 0; exit
 #   x   = clamp((WEEK_SECONDS - remaining) / WEEK_SECONDS, 0, 1)  # elapsed frac
 #   T   = round(WEEK_SECONDS / 18000)                            # ~34 windows
-#   end = floor + (p+1)*(target_weekly/T - floor)                # W(1)=target
+#   end = floor + (p+1)*(target_weekly/T - floor)                # smooth W(1)=target_weekly
 #   end = min(end, cap)                                          # hard ceiling
 #   W   = T*( floor*x + (end-floor)*x^(p+1)/(p+1) )              # cumulative now
 #   r   = remaining / 18000                                      # windows left
@@ -90,9 +90,10 @@
 #   below target_weekly and idle the final stretch of the week. The terminal
 #   envelope floors W from the end — spending at most cap per remaining window
 #   still reaches weekly_terminal — so W reaches weekly_terminal at week end
-#   (W(1)=weekly_terminal) and the envelope dominates the final ~2 windows
-#   (term = 80 at r=2, 90 at r=1, 100 at r=0 with defaults). Mid-week r is
-#   large, the term is negative, and the smooth curve is unchanged.
+#   (W(1)=weekly_terminal) and the envelope lifts W in the final ~1.7 windows
+#   (term = 80 at r=2 [smooth 81.5 wins], 90 at r=1, 100 at r=0 with defaults;
+#   envelope takes over at r≈1.7). Mid-week r is large, the term is negative,
+#   and the smooth curve is unchanged.
 # - F=0 when ahead of pace (used_weekly >= W); the floor5..ceil5 band opens
 #   with weekly headroom.
 # - N=0 only at/over the 5h target F (includes the F=0 ahead-of-pace pause);

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
@@ -311,7 +311,8 @@ awk -v now="$NOW" \
        # from the end so spending at most wcap per remaining window still
        # reaches terminal. Mid-week `rem_windows` is large and the term is
        # deeply negative, so the smooth curve dominates unchanged; it only
-       # lifts the final ~2 windows (term = 80 at r=2, 90 at r=1, 100 at r=0).
+       # lifts the final ~1.7 windows (envelope takes over at r≈1.7; term =
+       # 80 at r=2 [smooth 81.5 wins], 90 at r=1, 100 at r=0 with defaults).
        rem_windows = remaining / 18000
        envelope = (terminal + 0) - (wcap + 0) * rem_windows
        if (W < envelope) W = envelope

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
@@ -50,7 +50,8 @@
 #
 # Config (read via dispatch-config-load target-workers; all optional):
 #
-#   target_weekly_usage_pct        default 90   curve terminal W(1)
+#   target_weekly_usage_pct        default 90   smooth-curve terminal
+#   weekly_terminal_pct            default 100  envelope terminal W(1)
 #   weekly_increment_floor_pct     default 1    per-window floor
 #   weekly_increment_cap_pct       default 10   per-window hard ceiling
 #   weekly_curve_power             default 1    convexity; >1 back-loads
@@ -71,6 +72,8 @@
 #   end = floor + (p+1)*(target_weekly/T - floor)                # W(1)=target
 #   end = min(end, cap)                                          # hard ceiling
 #   W   = T*( floor*x + (end-floor)*x^(p+1)/(p+1) )              # cumulative now
+#   r   = remaining / 18000                                      # windows left
+#   W   = max(W, weekly_terminal - cap*r)                        # terminal envelope
 #
 #   # Stage 2 — 5h target F (% of 5h limit, absolute)
 #   hw = W - used_weekly
@@ -82,9 +85,14 @@
 #   print N
 #
 # - The weekly increment d(x)=floor+(end-floor)*x^p rises from the floor toward
-#   (but clamped at) the cap; W reaches target_weekly at x=1 (week end) and
-#   stays below it for every x<1 — except when wcap clamps the per-window
-#   increment, which deliberately holds W(1) below target_weekly.
+#   (but clamped at) the cap; the smooth power term tops out at target_weekly
+#   and, with wcap clamping the per-window increment, would otherwise hold W
+#   below target_weekly and idle the final stretch of the week. The terminal
+#   envelope floors W from the end — spending at most cap per remaining window
+#   still reaches weekly_terminal — so W reaches weekly_terminal at week end
+#   (W(1)=weekly_terminal) and the envelope dominates the final ~2 windows
+#   (term = 80 at r=2, 90 at r=1, 100 at r=0 with defaults). Mid-week r is
+#   large, the term is negative, and the smooth curve is unchanged.
 # - F=0 when ahead of pace (used_weekly >= W); the floor5..ceil5 band opens
 #   with weekly headroom.
 # - N=0 only at/over the 5h target F (includes the F=0 ahead-of-pace pause);
@@ -103,6 +111,7 @@ set -euo pipefail
 # ---- Step 0: defaults & config ----------------------------------------------
 
 TARGET_WEEKLY=90
+WEEKLY_TERMINAL=100
 WEEKLY_INCREMENT_FLOOR=1
 WEEKLY_INCREMENT_CAP=10
 WEEKLY_CURVE_POWER=1
@@ -130,6 +139,8 @@ fi
 if [[ -n "$CONFIG_JSON" ]]; then
   val=$(jq -r '.target_weekly_usage_pct // empty' <<<"$CONFIG_JSON")
   [[ -n "$val" ]] && TARGET_WEEKLY="$val"
+  val=$(jq -r '.weekly_terminal_pct // empty' <<<"$CONFIG_JSON")
+  [[ -n "$val" ]] && WEEKLY_TERMINAL="$val"
   val=$(jq -r '.weekly_increment_floor_pct // empty' <<<"$CONFIG_JSON")
   [[ -n "$val" ]] && WEEKLY_INCREMENT_FLOOR="$val"
   val=$(jq -r '.weekly_increment_cap_pct // empty' <<<"$CONFIG_JSON")
@@ -262,6 +273,7 @@ awk -v now="$NOW" \
     -v used_weekly="$WEEKLY_USED" \
     -v used_5h="$FIVEH_USED_FOR_AWK" \
     -v target_weekly="$TARGET_WEEKLY" \
+    -v terminal="$WEEKLY_TERMINAL" \
     -v wfloor="$WEEKLY_INCREMENT_FLOOR" \
     -v wcap="$WEEKLY_INCREMENT_CAP" \
     -v p="$WEEKLY_CURVE_POWER" \
@@ -293,6 +305,15 @@ awk -v now="$NOW" \
 
        W = T * ((wfloor + 0) * x \
                 + (end - (wfloor + 0)) * (x ^ ((p + 0) + 1)) / ((p + 0) + 1))
+
+       # Terminal "you-can-still-make-it" envelope: floor the cumulative curve
+       # from the end so spending at most wcap per remaining window still
+       # reaches terminal. Mid-week `rem_windows` is large and the term is
+       # deeply negative, so the smooth curve dominates unchanged; it only
+       # lifts the final ~2 windows (term = 80 at r=2, 90 at r=1, 100 at r=0).
+       rem_windows = remaining / 18000
+       envelope = (terminal + 0) - (wcap + 0) * rem_windows
+       if (W < envelope) W = envelope
 
        # ---- Stage 2: 5h target F (% of 5h limit, absolute) ----
        hw = W - (used_weekly + 0)

--- a/.claude/skills/dispatch-propagate/scripts/target-workers.example.json
+++ b/.claude/skills/dispatch-propagate/scripts/target-workers.example.json
@@ -1,5 +1,6 @@
 {
   "target_weekly_usage_pct": 90,
+  "weekly_terminal_pct": 100,
   "weekly_increment_floor_pct": 1,
   "weekly_increment_cap_pct": 10,
   "weekly_curve_power": 1,

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -5329,19 +5329,23 @@ write_rl() {
   export DISPATCH_TARGET_WORKERS_RATE_LIMITS_PATH="$path"
 }
 
-# --- Test 1: curve reaches target_weekly only at x=1 ------------------------
+# --- Test 1: curve reaches its terminal only at week end --------------------
 
-echo "Test: weekly curve reaches target only at week end (W < target for x<1)"
+echo "Test: weekly curve reaches terminal only at week end (W < terminal mid-week)"
 tw_setup
-# At x<1 the cumulative curve W is below target_weekly=90, so used_weekly just
-# under the curve value yields F>0/N>=1, while used_weekly just over the
-# week-end target only stays under-pace once x reaches 1. Probe by setting
-# used_weekly = 89 (just below the 90 terminal) at several x:
-#   x=0.5  → W=31  → used_weekly=89 is far ahead of pace → F=0 → N=0
-#   x=0.99 → W=88.5→ used_weekly=89 still ahead of pace  → F=0 → N=0
-#   x=1.0  → W=90  → used_weekly=89 → hw=1 → F>0 → N>=1   (only now under pace)
+# Mid-week (envelope-inactive x), the cumulative curve W is well below the
+# week-end terminal, so used_weekly just below the terminal is far ahead of
+# pace → F=0 → N=0. Only at week end does W reach the terminal and let that
+# used_weekly come under pace. Probe with used_weekly = 89 at several x.
+# (The terminal envelope lifts W to weekly_terminal=100 in the final windows;
+# this test deliberately picks envelope-INACTIVE mid-week x so it isolates the
+# smooth curve's "below terminal until the end" shape — the envelope's
+# week-end lift is covered by the dedicated envelope test below.)
+#   x=0.5  → W=31    → used_weekly=89 is far ahead of pace → F=0 → N=0
+#   x=0.75 → W=57    → used_weekly=89 still ahead of pace  → F=0 → N=0
+#   x=1.0  → env→100 → used_weekly=89 → hw=11 → F>0 → N>=1 (only now under pace)
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
-for spec in "0.5:0" "0.99:0" "1.0:ge1"; do
+for spec in "0.5:0" "0.75:0" "1.0:ge1"; do
   x="${spec%%:*}"; want="${spec##*:}"
   r=$(tw_resets_for_x "$x")
   write_rl "curve.json" 89 "$r" 0 99999999
@@ -5380,29 +5384,35 @@ else
 fi
 tw_teardown
 
-# --- Test 3: increment cap clamp lowers the terminal W(1) -------------------
+# --- Test 3: increment cap clamp lowers the smooth curve --------------------
 
-echo "Test: weekly_increment_cap_pct clamp makes W(1) < target_weekly"
+echo "Test: weekly_increment_cap_pct clamp holds the smooth curve below target"
 tw_setup
-# With cap=3: end = clamp(1+2*(90/34-1), .., 3) = 3, so W(1) = 34*(1*1 +
-# (3-1)*1/2) = 34*2 = 68 < target_weekly=90. At x=1, used_weekly=69 (> 68) is
-# ahead of the clamped pace → F=0 → N=0; used_weekly=67 (< 68) is under pace →
-# N>=1. This proves the cap hard-ceils the curve below target.
+# With cap=3: end = clamp(1+2*(90/34-1), .., 3) = 3, so the smooth term reaches
+# only W(1) = 34*(1*1 + (3-1)*1/2) = 34*2 = 68 < target_weekly=90 at week end,
+# and W(0.5) = 34*(0.5 + 2*0.25/2) = 34*(0.5+0.25) = 25.5 mid-week. To isolate
+# the smooth term from the terminal envelope, set weekly_terminal_pct=1 so the
+# envelope (env = 1 - 3*r) stays deeply negative mid-week and never lifts W.
+# At x=0.5: used_weekly=26 (> 25.5) is ahead of the clamped pace → F=0 → N=0;
+# used_weekly=25 (< 25.5) is under pace → N>=1. This proves the cap hard-ceils
+# the smooth curve below target. (The default terminal=100 envelope would
+# otherwise dominate this low-cap curve everywhere — the dedicated envelope
+# test below covers that week-end lift.)
 cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
-{"weekly_increment_cap_pct": 3}
+{"weekly_increment_cap_pct": 3, "weekly_terminal_pct": 1}
 EOF
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
-r=$(tw_resets_for_x 1.0)
-write_rl "rl.json" 69 "$r" 0 99999999
+r=$(tw_resets_for_x 0.5)
+write_rl "rl.json" 26 "$r" 0 99999999
 out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
-assert_eq "cap=3 → W(1)=68; used_weekly=69 ahead → N=0" "0" "$out"
-write_rl "rl.json" 67 "$r" 0 99999999
+assert_eq "cap=3 → W(0.5)=25.5; used_weekly=26 ahead → N=0" "0" "$out"
+write_rl "rl.json" 25 "$r" 0 99999999
 out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
 TOTAL=$((TOTAL + 1))
 if (( out >= 1 )); then
-  PASS=$((PASS + 1)); echo "  PASS: cap=3 W(1)=68; used_weekly=67 under pace → N=$out (>=1)"
+  PASS=$((PASS + 1)); echo "  PASS: cap=3 W(0.5)=25.5; used_weekly=25 under pace → N=$out (>=1)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: cap=3 used_weekly=67 expected N>=1, got $out"
+  FAIL=$((FAIL + 1)); echo "  FAIL: cap=3 used_weekly=25 expected N>=1, got $out"
 fi
 tw_teardown
 
@@ -5741,6 +5751,89 @@ if (( out >= 1 )); then
   PASS=$((PASS + 1)); echo "  PASS: early-week smoke used_weekly=20 used_5h=2 → N=$out (>=1)"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: early-week smoke expected N>=1, got $out"
+fi
+tw_teardown
+
+# --- Test 22: terminal envelope floors W in the final windows ---------------
+
+echo "Test: terminal envelope pins W to weekly_terminal across the final windows"
+tw_setup
+# The terminal "you-can-still-make-it" envelope floors W from the end:
+#   W = max(smooth_curve, weekly_terminal - cap*remaining_windows)
+# with defaults (terminal=100, cap=10) it evaluates to 80 at r=2, 90 at r=1,
+# 100 at r=0 (r = remaining_seconds / 18000). Place x by remaining-window count
+# (resets_at = NOW + r*18000) and hold used_5h=0 so 5h headroom is full and
+# N>=1 whenever F>0. The r=1 and r=0 lower probes are DISCRIMINATING: the
+# pre-envelope smooth curve (W=85.7 at r=1, W=90 at r=0) would have gated N=0.
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+
+# r=2: smooth W=81.51 wins (>=80). used_weekly=80 under pace → N>=1;
+# used_weekly=82 ahead → N=0. Asserts W>=80 at r=2.
+write_rl "env.json" 80 $((TW_NOW + 2 * 18000)) 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+TOTAL=$((TOTAL + 1))
+if (( out >= 1 )); then
+  PASS=$((PASS + 1)); echo "  PASS: r=2 W=81.5; used_weekly=80 under pace → N=$out (>=1)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: r=2 used_weekly=80 expected N>=1, got $out"
+fi
+write_rl "env.json" 82 $((TW_NOW + 2 * 18000)) 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "r=2 W=81.5; used_weekly=82 ahead → N=0" "0" "$out"
+
+# r=1: envelope lifts W to 90 (smooth=85.7). used_weekly=88 under pace → N>=1
+# (DISCRIMINATING: pre-envelope W=85.7 would give N=0); used_weekly=90 at the
+# envelope target → N=0. Together pin W=90 at r=1.
+write_rl "env.json" 88 $((TW_NOW + 1 * 18000)) 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+TOTAL=$((TOTAL + 1))
+if (( out >= 1 )); then
+  PASS=$((PASS + 1)); echo "  PASS: r=1 envelope W=90; used_weekly=88 under pace → N=$out (>=1)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: r=1 used_weekly=88 expected N>=1 (envelope W=90), got $out"
+fi
+write_rl "env.json" 90 $((TW_NOW + 1 * 18000)) 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "r=1 envelope W=90; used_weekly=90 at target → N=0" "0" "$out"
+
+# r=0: envelope lifts W to ~100 (smooth=90). used_weekly=95 under pace → N>=1
+# (DISCRIMINATING: pre-envelope W=90 would give N=0); used_weekly=100 at the
+# envelope target → N=0. Together pin W~=100 at r=0. Use tw_resets_for_x 1.0
+# (remaining=1s) so Stage 1 does NOT take the remaining<=0 early-exit.
+r=$(tw_resets_for_x 1.0)
+write_rl "env.json" 95 "$r" 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+TOTAL=$((TOTAL + 1))
+if (( out >= 1 )); then
+  PASS=$((PASS + 1)); echo "  PASS: r=0 envelope W~=100; used_weekly=95 under pace → N=$out (>=1)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: r=0 used_weekly=95 expected N>=1 (envelope W~=100), got $out"
+fi
+write_rl "env.json" 100 "$r" 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "r=0 envelope W~=100; used_weekly=100 at target → N=0" "0" "$out"
+tw_teardown
+
+# --- Test 23: mid-week tick unchanged from the smooth curve -----------------
+
+echo "Test: mid-week tick is byte-identical to the pre-envelope smooth curve"
+tw_setup
+# At x=0.5 the remaining is 302400s → r=16.8 → envelope = 100 - 10*16.8 = -68,
+# deeply negative, so the envelope is inactive and the smooth curve dominates
+# unchanged. The gating boundary must match the canonical W(0.5)=31 (Test 2):
+# used_weekly=31 → hw=0 → N=0 (at pace); used_weekly=30 → hw=1 → N>=1.
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+r=$(tw_resets_for_x 0.5)
+write_rl "midweek.json" 31 "$r" 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "mid-week W(0.5)=31 unchanged; used_weekly=31 at pace → N=0" "0" "$out"
+write_rl "midweek.json" 30 "$r" 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+TOTAL=$((TOTAL + 1))
+if (( out >= 1 )); then
+  PASS=$((PASS + 1)); echo "  PASS: mid-week W(0.5)=31 unchanged; used_weekly=30 under pace → N=$out (>=1)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: mid-week used_weekly=30 expected N>=1, got $out"
 fi
 tw_teardown
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -5182,6 +5182,57 @@ else
 fi
 config_teardown
 
+# --- Test 13f: weekly_terminal_pct: 100 accepted and round-trips -------------
+
+echo "Test: weekly_terminal_pct: 100 accepted and round-trips"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
+{"weekly_terminal_pct": 100}
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" target-workers 2>/dev/null); rc=$?
+assert_eq "weekly_terminal_pct 100 exits 0" "0" "$rc"
+tw_terminal=$(printf '%s' "$out" | jq -r '.weekly_terminal_pct')
+assert_eq "weekly_terminal_pct 100 round-trips" "100" "$tw_terminal"
+config_teardown
+
+# --- Test 13g: weekly_terminal_pct: 150 rejected (must be <= 100) ------------
+
+echo "Test: weekly_terminal_pct: 150 exits 1 and stderr says must be <= 100"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
+{"weekly_terminal_pct": 150}
+EOF
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" target-workers 2>&1 1>/dev/null) || rc=$?
+assert_eq "weekly_terminal_pct 150 exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"weekly_terminal_pct"* && "$err" == *"<= 100"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: weekly_terminal_pct 150 stderr says <= 100"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: weekly_terminal_pct 150 stderr says <= 100"
+  echo "    stderr: $err"
+fi
+config_teardown
+
+# --- Test 13h: weekly_terminal_pct: 0 rejected (must be > 0) ----------------
+
+echo "Test: weekly_terminal_pct: 0 exits 1 and stderr says must be > 0"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
+{"weekly_terminal_pct": 0}
+EOF
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" target-workers 2>&1 1>/dev/null) || rc=$?
+assert_eq "weekly_terminal_pct 0 exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"weekly_terminal_pct"* && "$err" == *"must be > 0"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: weekly_terminal_pct 0 stderr says must be > 0"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: weekly_terminal_pct 0 stderr says must be > 0"
+  echo "    stderr: $err"
+fi
+config_teardown
+
 # ============================================================================
 # dispatch-target-workers tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -5982,6 +5982,34 @@ out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
 assert_eq "r=0 envelope W~=100; used_weekly=100 at target → N=0" "0" "$out"
 tw_teardown
 
+# --- Test 22b: non-default weekly_terminal_pct flows through end-to-end ------
+
+echo "Test: non-default weekly_terminal_pct=95 caps the envelope target at 95"
+tw_setup
+# The envelope target is the configurable weekly_terminal_pct, not a baked-in
+# 100. With weekly_terminal_pct=95 (cap=10), at r=0 the envelope = 95 - 10*0 =
+# 95 and the smooth curve W(1)=90, so W=95. used_weekly=93 under pace → N>=1;
+# used_weekly=97 ahead of the 95 target → N=0. The used_weekly=97 probe is
+# DISCRIMINATING: the default terminal=100 would lift W to 100, putting
+# used_weekly=97 under pace (N>=1) — so N=0 confirms the knob value is honored.
+cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
+{"weekly_terminal_pct": 95}
+EOF
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+r=$(tw_resets_for_x 1.0)
+write_rl "term95.json" 93 "$r" 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+TOTAL=$((TOTAL + 1))
+if (( out >= 1 )); then
+  PASS=$((PASS + 1)); echo "  PASS: terminal=95 r=0 W=95; used_weekly=93 under pace → N=$out (>=1)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: terminal=95 used_weekly=93 expected N>=1 (W=95), got $out"
+fi
+write_rl "term95.json" 97 "$r" 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "terminal=95 r=0 W=95; used_weekly=97 ahead of 95 target → N=0" "0" "$out"
+tw_teardown
+
 # --- Test 23: mid-week tick unchanged from the smooth curve -----------------
 
 echo "Test: mid-week tick is byte-identical to the pre-envelope smooth curve"


### PR DESCRIPTION
Closes #962

## Summary

`dispatch-target-workers` Stage 1's smooth power curve tops out at `target_weekly_usage_pct` (default 90) and, with the per-window increment clamped at `weekly_increment_cap_pct`, never drove weekly usage to 100% near week end — it idled the final stretch below the cap, leaving weekly budget unspent.

This adds a terminal "you-can-still-make-it" envelope that floors the cumulative curve from the end:

    W = max(smooth_curve, weekly_terminal_pct - weekly_increment_cap_pct * remaining_windows)

The envelope term is deeply negative mid-week (smooth curve dominates, output unchanged) and only lifts the final ~2 windows — 80 at r=2, 90 at r=1, 100 at r=0 — so the closing windows sprint weekly usage to `weekly_terminal_pct`. Live `used_weekly` remains the backstop.

- **Unit 1** (ea62778): add `weekly_terminal_pct` knob (default 100, validated in (0,100]) to the `target-workers` config schema, example, and config-load tests.
- **Unit 2** (86f9243): consume the knob in the controller's Stage 1 awk; update the header-comment algorithm/`W(1)` invariant; add envelope-floor + mid-week-unchanged tests.

## Test plan

- [ ] `bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` — all tests pass (963/963 locally)
- [ ] Envelope-floor test pins W to 80/90/100 at remaining windows r=2/1/0 (discriminating probes vs. the pre-envelope curve)
- [ ] Mid-week tick (x=0.5) gating boundary is unchanged from the smooth curve

🤖 Generated with [Claude Code](https://claude.com/claude-code)