### PR TITLE
dispatch: make trace-leaf queue-mode child-skip live-session-aware (#914)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -63,8 +63,9 @@
 #   5. Oldest open help-wanted issue whose <N>-* worktree, if any, is not owned
 #      by a live Claude session, and which is not already closed by a non-draft
 #      (ready) PR (#920), resolved to a startable open leaf (an issue whose
-#      entire open-leaf subtree is worktree-conflicted is skipped, exactly as a
-#      live-session-owned worktree is)
+#      entire open-leaf subtree is owned by live sessions is skipped, exactly as
+#      a live-session-owned direct worktree is — an orphan child worktree stays
+#      descendable, #914)
 #   6. Oldest "qa"          PR (draft, CI green, no dispatch:* label)
 #
 # A PR or help-wanted issue is skipped only when a live Claude session owns its
@@ -591,11 +592,12 @@ while IFS=$'\t' read -r issue_num issue_labels; do
   [[ -n "${FIRST_ISSUE[$issue_bucket]:-}" ]] && continue
   # Resolve a startable open leaf within the issue's subtree. dispatch-trace-leaf
   # in queue mode descends open blockers and sub-issues, skipping any child whose
-  # <N>-* branch is an existing local worktree (owned by another session):
+  # <N>-* worktree is owned by a live session (#914) — an orphan child worktree
+  # stays descendable:
   #   exit 0 — a startable open leaf was found; record it for this bucket.
-  #   exit 2 — every reachable open leaf is worktree-conflicted. Skip this issue
-  #            exactly as a direct worktree is skipped; a later issue in the
-  #            same bucket may still fill the slot.
+  #   exit 2 — every reachable open leaf is owned by a live session. Skip this
+  #            issue exactly as a direct live-owned worktree is skipped; a later
+  #            issue in the same bucket may still fill the slot.
   #   exit 1 — usage error; propagate as a hard failure, never swallow as a skip.
   if leaf=$("$SCRIPT_DIR/dispatch-trace-leaf" "$issue_num" queue); then
     FIRST_ISSUE[$issue_bucket]="$leaf"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
@@ -209,8 +209,8 @@ fi
 # by a live session (or cycles block every path); orphan worktrees were
 # descended through. Surface this so /dispatch-propagate can stop with a clear
 # message instead of dispatching on a conflict. The "worktree-conflicted" token
-# is retained for the matchers in dispatch-select-target and
-# test-dispatch-scripts.sh that key on it.
+# is retained for the pattern-matcher in test-dispatch-scripts.sh that keys on it
+# (dispatch-select-target only checks the exit code, not the message text).
 if [[ "$MODE" == "queue" ]]; then
   echo "error: all open leaves reachable from $ISSUE_NUM are worktree-conflicted (owned by a live session)" >&2
   exit 2

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
@@ -12,13 +12,17 @@
 #              dispatch-resolve-worktree's explicit mode, which yields `enter`
 #              for the recycle-after-completion case, or `conflict` if a live
 #              session still owns the worktree — #837).
-#   queue    — descent filters out children whose <N>-* branch is an existing
-#              local worktree (owned by another session). If a node has open
-#              children but every one is filtered out, the descent bubbles up
-#              too — that subtree has no ready work. If every reachable open
-#              leaf in the subtree is conflicted, the script exits non-zero
-#              with a clear message on stderr so the /dispatch-propagate caller can stop
-#              instead of dispatching on a conflict.
+#   queue    — descent filters out children whose <N>-* worktree is owned by a
+#              LIVE Claude session (#914). An orphan <N>-* worktree (on disk, no
+#              session) stays descendable — it is a reuse signal, not a skip,
+#              matching the direct-row liveness fix in dispatch-select-target
+#              (#905). A child with no worktree at all is never filtered. If a
+#              node has open children but every one is live-owned, the descent
+#              bubbles up too — that subtree has no ready work. If every
+#              reachable open leaf in the subtree is owned by a live session,
+#              the script exits non-zero with a clear message on stderr so the
+#              /dispatch-propagate caller can stop instead of dispatching on a
+#              conflict.
 #
 # Falls back to printing N in `explicit` mode if cycles block every path to a
 # leaf (preserves historical behavior).
@@ -31,11 +35,16 @@
 #   0 — a leaf was found and printed to stdout
 #   1 — usage error, or a sibling gh script (issue-blocking / issue-sub-issues)
 #       failed — a hard failure the caller must not treat as "no work"
-#   2 — queue mode only: every reachable open leaf is worktree-conflicted
+#   2 — queue mode only: every reachable open leaf is owned by a live session
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
+# worktree_has_live_session — queue-mode descent skips a child only when a live
+# Claude session owns its <N>-* worktree (#914). Sourced here so the descent can
+# ask the liveness question; it sets -uo pipefail (not -e), preserving this
+# script's set -euo pipefail above.
+source "$SCRIPT_DIR/lib-claude-agents.sh"
 
 ISSUE_NUM="${1:-}"
 MODE="${2:-}"
@@ -45,18 +54,42 @@ if [[ -z "$ISSUE_NUM" || ! "$ISSUE_NUM" =~ ^[1-9][0-9]*$ ]] \
   exit 1
 fi
 
-# In queue mode, build the set of issue-number prefixes that own a local
-# worktree. list_worktree_records (lib.sh) does the shared porcelain parse;
-# split_worktree_record splits each line into WT_NUM / WT_PATH / WT_BRANCH —
-# WT_NUM is the branch's issue-number prefix, empty for non-issue / branchless
-# worktrees.
-declare -A CONFLICTED=()
+# In queue mode, map each issue-number prefix to the on-disk path(s) of its
+# <N>-* worktree(s), so the descent can ask whether a live session owns one
+# (#914) rather than skipping on mere worktree existence. list_worktree_records
+# (lib.sh) does the shared porcelain parse; split_worktree_record splits each
+# line into WT_NUM / WT_PATH / WT_BRANCH — WT_NUM is the branch's issue-number
+# prefix, empty for non-issue / branchless worktrees. Mirrors the selector's
+# WORKTREE_PATHS_BY_NUM (newline-joined paths per number).
+declare -A WORKTREE_PATHS_BY_NUM=()
 if [[ "$MODE" == "queue" ]]; then
   while IFS= read -r line; do
     split_worktree_record "$line"
-    [[ -n "$WT_NUM" ]] && CONFLICTED["$WT_NUM"]=1
+    [[ -z "$WT_PATH" ]] && continue
+    if [[ -n "$WT_NUM" ]]; then
+      WORKTREE_PATHS_BY_NUM["$WT_NUM"]="${WORKTREE_PATHS_BY_NUM[$WT_NUM]:-}$WT_PATH"$'\n'
+    fi
   done < <(list_worktree_records)
 fi
+
+# True when a live Claude session owns any <num>-* worktree. No such worktree →
+# fast-path miss (return 1), no daemon round-trip. Several matches → owned if any
+# one is live. A faithful copy of dispatch-select-target's issue_has_live_worktree
+# (#905), applied here to subtree children (#914). worktree_has_live_session is
+# fail-safe: an unqueryable daemon counts as owned, so the child is skipped
+# rather than double-claimed.
+child_has_live_worktree() {
+  local num="$1" p
+  local paths="${WORKTREE_PATHS_BY_NUM[$num]:-}"
+  [[ -z "$paths" ]] && return 1
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    if worktree_has_live_session "$p"; then
+      return 0
+    fi
+  done <<< "$paths"
+  return 1
+}
 
 # Collect open children of an issue: open blockers union open sub-issues.
 # Outputs sorted unique issue numbers, one per line, lowest first.
@@ -100,7 +133,7 @@ open_children() {
 # Uses global VISITED associative array for cycle protection.
 # Returns 0 and prints the leaf number on success.
 # Returns 1 if no valid leaf is reachable through this subtree (cycles, or in
-# queue mode every reachable leaf is worktree-conflicted).
+# queue mode every reachable leaf is owned by a live session).
 # Returns 3 if a blocker/sub-issue lookup hit a hard error (gh API failure);
 # re-propagated through every recursive frame so the top level can map it to a
 # clean script-level abort instead of mis-selecting the issue as startable.
@@ -125,20 +158,21 @@ find_leaf() {
   fi
 
   if [[ -z "$kids" ]]; then
-    # Topological leaf — a valid leaf. Worktree-conflicted children are filtered
+    # Topological leaf — a valid leaf. Live-session-owned children are filtered
     # before recursion (see the descent loop below), so a queue-mode leaf
-    # reached here is never itself worktree-conflicted.
+    # reached here is never itself live-owned.
     echo "$n"
     return 0
   fi
 
   # Descend into children lowest-numbered first; return the first leaf found.
-  # In queue mode, skip any child that already has a worktree — if every child
+  # In queue mode, skip any child whose <N>-* worktree is owned by a live
+  # session (#914) — an orphan child worktree stays descendable. If every child
   # is skipped the loop finds nothing and we bubble up.
   local kid leaf
   while IFS= read -r kid; do
     [[ -z "$kid" ]] && continue
-    [[ "$MODE" == "queue" && -n "${CONFLICTED[$kid]+x}" ]] && continue
+    [[ "$MODE" == "queue" ]] && child_has_live_worktree "$kid" && continue
     # Capture the status explicitly (set -e is disabled here) so a hard error
     # (rc 3) is distinguishable from "no leaf in this subtree" (rc 1).
     leaf=$(find_leaf "$kid"); rc=$?
@@ -171,11 +205,14 @@ if [[ "$trace_rc" -eq 3 ]]; then
   exit 1
 fi
 
-# In queue mode, no valid leaf is reachable — every leaf is worktree-conflicted
-# (or cycles block every path). Surface this so /dispatch-propagate can stop with a clear
-# message instead of dispatching on a conflict.
+# In queue mode, no valid leaf is reachable — every reachable open leaf is owned
+# by a live session (or cycles block every path); orphan worktrees were
+# descended through. Surface this so /dispatch-propagate can stop with a clear
+# message instead of dispatching on a conflict. The "worktree-conflicted" token
+# is retained for the matchers in dispatch-select-target and
+# test-dispatch-scripts.sh that key on it.
 if [[ "$MODE" == "queue" ]]; then
-  echo "error: all open leaves reachable from $ISSUE_NUM are worktree-conflicted (owned by other sessions)" >&2
+  echo "error: all open leaves reachable from $ISSUE_NUM are worktree-conflicted (owned by a live session)" >&2
   exit 2
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2393,6 +2393,66 @@ esac
 assert_eq "invalid mode → usage error, exit 1" "ok" "$status"
 teardown
 
+# 12a. Queue mode: an orphan child worktree (on disk, no live session) is NOT
+#      skipped — it stays descendable, so the lowest leaf 701 is returned rather
+#      than the sibling 702 (#914). Tests 8/10 above rely on the default-UNKNOWN
+#      daemon (which folds to occupied); here select_target_fake_claude with no
+#      args models a live-session-free world so the worktree is a true orphan.
+echo "Test: queue mode → orphan child worktree is descendable (not skipped)"
+setup
+# 700 has two open sub-issues: 701 (orphan worktree on disk) and 702 (no worktree).
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+# 701's worktree exists but no session owns it; 702 has no worktree at all.
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+# No live sessions → 701's worktree is an orphan, descendable.
+select_target_fake_claude
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
+assert_eq "queue: orphan child 701 descendable → lowest leaf 701" "701" "$result"
+teardown
+
+# 12b. Queue mode: a child whose <N>-* worktree IS owned by a live session is
+#      skipped, so the sibling 702 is returned (#914).
+echo "Test: queue mode → live-owned child skipped, returns sibling"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+# A live session owns 701-feature → 701 is skipped.
+select_target_fake_claude "701-feature"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
+assert_eq "queue: live-owned child 701 skipped → sibling 702" "702" "$result"
+teardown
+
+# 12c. Queue mode: every child's <N>-* worktree is live-owned → exit 2 with the
+#      worktree-conflicted stderr message (#914).
+echo "Test: queue mode → all leaves live-owned, exits 2"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\nworktree /worktrees/702-feature\nHEAD ghi789\nbranch refs/heads/702-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+# Both children are owned by live sessions.
+select_target_fake_claude "701-feature" "702-feature"
+err_out=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err_out" in
+  *"worktree-conflicted"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err_out" ;;
+esac
+assert_eq "queue: all children live-owned → exit 2 with stderr message" "ok" "$status"
+teardown
+
 # 13. issue-blocking failure → hard error (exit 1), never emits N as a leaf.
 echo "Test: issue-blocking failure → exit 1, no leaf emitted"
 setup

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2460,6 +2460,25 @@ esac
 assert_eq "queue: all children live-owned → exit 2 with stderr message" "ok" "$status"
 teardown
 
+# 12d. Queue mode: a child with two <N>-* worktrees — one orphan, one live —
+#      is skipped (any live match counts as owned), exercising the multi-path
+#      branch of child_has_live_worktree's loop (#914).
+echo "Test: queue mode → child with orphan+live worktrees is skipped (multi-path)"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+# 701 has two worktrees: 701-feature (orphan) and 701-other (live-owned).
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\nworktree /worktrees/701-other\nHEAD def457\nbranch refs/heads/701-other\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+# Only 701-other is live; 701-feature is an orphan. Any live match → 701 skipped.
+select_target_fake_claude "701-other"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
+assert_eq "queue: child with one live worktree among many skipped → sibling 702" "702" "$result"
+teardown
+
 # 13. issue-blocking failure → hard error (exit 1), never emits N as a leaf.
 echo "Test: issue-blocking failure → exit 1, no leaf emitted"
 setup

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2321,20 +2321,24 @@ result=$("$TMPDIR_TEST/dispatch-trace-leaf" "600" "explicit")
 assert_eq "sub-issues chain 600→601 → leaf 601" "601" "$result"
 teardown
 
-# 8. Queue mode: conflicted child is skipped → sibling is returned.
-echo "Test: queue mode → skips conflicted child, returns sibling"
+# 8. Queue mode: child whose worktree exists and daemon is UNKNOWN (fail-safe → occupied)
+#    is skipped; sibling with no worktree is returned.
+#    The default CLAUDE_AGENTS_CMD points at a non-existent binary so the daemon
+#    is UNKNOWN, which worktree_has_live_session folds into occupied (fail-safe).
+#    Tests 12a/12b cover the true live-vs-orphan distinction.
+echo "Test: queue mode → skips child with worktree (daemon UNKNOWN → occupied), returns sibling"
 setup
-# 700 has two open sub-issues: 701 (worktree-owned) and 702 (clean).
+# 700 has two open sub-issues: 701 (worktree on disk, daemon unreachable) and 702 (no worktree).
 printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
 printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
   > "$STUB_DIR/issue-701.json"
 printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
   > "$STUB_DIR/issue-702.json"
-# Pretend another session owns 701's worktree on branch 701-feature.
+# 701's worktree exists; daemon is UNKNOWN (non-existent binary) → fail-safe → occupied.
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\n' \
   > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
-assert_eq "queue: conflicted child 701 skipped → sibling 702" "702" "$result"
+assert_eq "queue: child 701 (daemon UNKNOWN → occupied) skipped → sibling 702" "702" "$result"
 teardown
 
 # 9. Explicit mode: conflicted child returned unchanged (no worktree filtering).
@@ -2352,15 +2356,18 @@ result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "explicit")
 assert_eq "explicit: lowest leaf 701 unchanged" "701" "$result"
 teardown
 
-# 10. Queue mode: every child is worktree-conflicted → non-zero exit.
-echo "Test: queue mode → all leaves conflicted, exits non-zero"
+# 10. Queue mode: every child has a worktree and daemon is UNKNOWN (fail-safe → occupied)
+#     → exit 2 with the worktree-conflicted stderr message.
+#     The default CLAUDE_AGENTS_CMD is a non-existent binary; UNKNOWN folds to occupied.
+#     Tests 12c cover the true all-live-owned scenario.
+echo "Test: queue mode → all children have worktrees (daemon UNKNOWN → occupied), exits non-zero"
 setup
 printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
 printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
   > "$STUB_DIR/issue-701.json"
 printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
   > "$STUB_DIR/issue-702.json"
-# Both children's worktrees exist.
+# Both children's worktrees exist; daemon is UNKNOWN → both treated as occupied.
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\nworktree /worktrees/702-feature\nHEAD ghi789\nbranch refs/heads/702-feature\n\n' \
   > "$STUB_DIR/worktree-list.txt"
 err_out=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
@@ -2368,7 +2375,7 @@ case "$err_out" in
   *"worktree-conflicted"*"EXIT="[1-9]*) status="ok" ;;
   *) status="bad: $err_out" ;;
 esac
-assert_eq "queue: all blocked → non-zero with stderr message" "ok" "$status"
+assert_eq "queue: all children occupied (daemon UNKNOWN) → non-zero with stderr message" "ok" "$status"
 teardown
 
 # 11. Missing mode → arity error on stderr, exit 1.


### PR DESCRIPTION
Closes #914

Queue-mode leaf tracing in `dispatch-trace-leaf` was worktree-existence-based, not liveness-aware. PR #911 (issue #905) fixed the symmetric problem for direct PR-rows / issue-rows in `dispatch-select-target`; this applies the same fix one level down, in issue-subtree leaf resolution.

An orphan child worktree (registered on disk, no live session) was miscounted as a conflict; when every reachable open leaf was thus conflicted the script exited 2 and the selector skipped the parent help-wanted issue. Live repro (2026-05-30): a tick reported issues 452/755/963 as all-leaves worktree-conflicted and skipped all three, while only two worktrees had live sessions and ~51 orphans were miscounted.

## Changes

- `dispatch-trace-leaf`: sources `lib-claude-agents.sh`; replaces the existence-keyed `CONFLICTED` map with a path-bearing `WORKTREE_PATHS_BY_NUM` (queue mode only); adds `child_has_live_worktree` (mirror of the selector's `issue_has_live_worktree`) — no worktree → fast-path miss, else live-session check per path; descent skips a child only when a live session owns its `<N>-*` worktree. Comments and the exit-2 message updated to live-session semantics (the `worktree-conflicted` token is retained so existing matchers stay valid).
- `dispatch-select-target`: comment-only — header bullet and leaf-trace block now describe the child-skip as live-session-owned, orphan children descendable.
- `test-dispatch-scripts.sh`: three new queue-mode trace-leaf cases (orphan child descendable, live child skipped, all-leaves-live → exit 2).

## Test plan

- [x] `test-dispatch-scripts.sh` — 952/952 passing