### PR TITLE
dispatch-select-target: rank priority label above topic category

### DIFF
--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -127,20 +127,21 @@ acts on the script's one output line; the mechanics below are reference, not
 per-tick action.
 
 Priority order the script implements, top to bottom: JIT scan →
-`origin/main` CI health gate → topic-category × priority × phase ladder.
+`origin/main` CI health gate → priority × topic-category × phase ladder.
 A jit-reminder surfaces even when `origin/main` is red because the JIT scan
 precedes the main-broken gate.
 
-The topic-category × phase ladder is three-tier: a topic **category** nests
-outside a **priority bit**, which nests outside the phase **ladder**.
-Categories, highest first: `bug` → `testing infrastructure` → `dispatch` →
-`other`. Within each category, items carrying the `priority` label rank above
-items without it; the label is human-applied — `/ready` never applies it
-automatically. A PR's category is the highest-priority topic among the labels
-of every issue it closes; an issue's category is the highest-priority topic
-among its own labels; anything with no topic label is `other`. The selector
-exhausts one `(category, priority)` bucket's whole ladder before moving to
-the next.
+The priority × topic-category × phase ladder is three-tier: the **priority
+bit** is the outermost axis, a topic **category** nests inside it, and the
+phase **ladder** runs innermost. The selector exhausts the entire `priority=1`
+tier — every topic category, every phase — before considering any `priority=0`
+item, so a `priority` item in a low-ranked topic outranks every non-priority
+item in a higher-ranked topic. Within one priority level, categories run
+highest first: `bug` → `testing infrastructure` → `dispatch` → `other`. The
+`priority` label is human-applied — `/ready` never applies it automatically.
+A PR's category is the highest-priority topic among the labels of every issue
+it closes; an issue's category is the highest-priority topic among its own
+labels; anything with no topic label is `other`.
 
 Within each category the ladder is (highest first; within a tier, oldest PR
 wins; PRs and `help wanted` issues with a local worktree are skipped; a PR

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -21,7 +21,7 @@
 # Default-mode priority, top to bottom:
 #   1. JIT scan (jit-reminder)
 #   2. origin/main CI health gate (main-broken)
-#   3. the topic-category × priority × phase ladder over open PRs and
+#   3. the priority × topic-category × phase ladder over open PRs and
 #      help-wanted issues
 #
 # --health-only mode runs the JIT scan and the origin/main CI health gate, then
@@ -37,15 +37,14 @@
 # --qa mode omits the <phase> field — there it is always "qa":
 #   pr <num> <branch>           — the QA PR to work on
 #
-# Selection is three-tier: topic *category* nests outside a *priority* sub-axis,
-# which nests outside the phase *ladder*. Topic categories, highest priority
-# first:
+# Selection is three-tier: the `priority` label is the *outermost* axis, topic
+# *category* nests inside it, and the phase *ladder* runs innermost. The
+# selector exhausts the entire `priority=1` tier — every topic category, every
+# phase — before considering any `priority=0` item, so a `priority` item in a
+# low-ranked topic still outranks every non-priority item in a higher-ranked
+# topic. Within one priority level, topic categories run highest priority first:
 #   bug → testing infrastructure → dispatch → other
-# Within each topic category, items carrying the `priority` label rank above
-# items without it; the phase ladder runs innermost. The selector exhausts the
-# `(priority=1, phase ladder)` sub-tier of one topic category, then the
-# `(priority=0, phase ladder)` sub-tier of the same topic, before moving to the
-# next topic category.
+# and within each (priority, topic) bucket the phase ladder runs innermost.
 #
 # A PR's category is the highest-priority topic among the labels of every issue
 # it closes (closingIssuesReferences); a PR that closes no issue, or whose
@@ -54,7 +53,7 @@
 # bit is 1 if the union of its closing issues' labels carries `priority`, else
 # 0; an issue's priority bit is 1 if its own labels carry `priority`, else 0.
 #
-# Within each (topic, priority) bucket, default-mode priority (oldest PR wins
+# Within each (priority, topic) bucket, default-mode priority (oldest PR wins
 # within a tier):
 #   1. Oldest "security"    PR (draft + dispatch:reviewed or dispatch:security-reviewed)
 #   2. Oldest "review"      PR (draft + dispatch:code-reviewed)
@@ -86,9 +85,9 @@
 # the flat ladder exactly.
 #
 # --qa mode priority:
-#   1. Oldest QA PR in the highest-priority (topic, priority) bucket that has
-#      one — same outer iteration as default mode (topic category, then
-#      priority sub-axis), restricted to the qa phase
+#   1. Oldest QA PR in the highest-priority (priority, topic) bucket that has
+#      one — same outer iteration as default mode (priority axis outermost,
+#      then topic category), restricted to the qa phase
 #   2. empty
 set -euo pipefail
 
@@ -424,16 +423,16 @@ ${GQL_FIELDS}  }
 fi
 
 # Topic categories in priority order; "other" is the implicit fallback for any
-# label set with no topic label. A topic-category tier nests *outside* the
-# phase ladder, and a `priority` sub-axis nests *between* them: within each
-# topic category, items carrying `priority` rank above items without it, and
-# the phase ladder runs innermost. TOPIC_CATEGORIES is the single source of the
-# topic ordering — category_of_labels resolves against it and the default-mode
-# loop iterates CATEGORIES. `priority` is an orthogonal escalation sub-axis
-# nested inside each topic category, derived alongside the category via the
-# has_priority_in_labels helper rather than competing with it for the top
-# slot. The companion classifier that *applies* these labels is ref-ready
-# SKILL.md Step 6; keep the two label sets in sync.
+# label set with no topic label. The `priority` label is the *outermost* axis:
+# every `priority` item ranks above every non-priority item, regardless of
+# topic. Topic category nests *inside* the priority axis, and the phase ladder
+# runs innermost. TOPIC_CATEGORIES is the single source of the topic ordering —
+# category_of_labels resolves against it and the default-mode loop iterates
+# CATEGORIES within each priority level. `priority` is derived alongside the
+# category via the has_priority_in_labels helper; topic category is the
+# tie-break among items at the same priority level. The companion classifier
+# that *applies* these labels is ref-ready SKILL.md Step 6; keep the two label
+# sets in sync.
 TOPIC_CATEGORIES=(bug "testing infrastructure" dispatch)
 CATEGORIES=("${TOPIC_CATEGORIES[@]}" other)
 # Same priority list as a JSON array, for category_of_labels' jq filter.
@@ -531,11 +530,12 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
 done <<< "$PR_SORTED"
 
 if [[ "$QA_MODE" == "true" ]]; then
-  # --qa mode: oldest QA PR in the highest-priority (topic, priority) bucket
-  # that has one, without the <phase> field. The issue queue is irrelevant
+  # --qa mode: oldest QA PR in the highest-priority (priority, topic) bucket
+  # that has one — priority is the outermost axis (1 then 0), topic category
+  # nested inside — without the <phase> field. The issue queue is irrelevant
   # here, so the leaf-resolution loop below is skipped entirely.
-  for category in "${CATEGORIES[@]}"; do
-    for pri in 1 0; do
+  for pri in 1 0; do
+    for category in "${CATEGORIES[@]}"; do
       qa_key="$category|$pri|qa"
       if [[ -n "${FIRST_PR[$qa_key]:-}" ]]; then
         echo "pr ${FIRST_PR[$qa_key]}"
@@ -607,13 +607,14 @@ while IFS=$'\t' read -r issue_num issue_labels; do
   fi
 done <<< "$ISSUE_SORTED"
 
-# Default mode: the first (topic-category, priority-bit) bucket with an
-# eligible task wins (see the header for the full three-tier order). Within
-# each topic category, the priority sub-axis (1 then 0) runs above the phase
-# ladder; within each (category, priority) bucket, the phase ladder runs
-# innermost.
-for category in "${CATEGORIES[@]}"; do
-  for pri in 1 0; do
+# Default mode: priority is the outermost axis (1 then 0), topic category nests
+# inside it, and the phase ladder runs innermost (see the header for the full
+# three-tier order). The entire priority=1 tier — every topic category, every
+# phase — is exhausted before any priority=0 item is considered; within one
+# priority level topic category is the tie-break, and within each
+# (priority, category) bucket the phase ladder runs innermost.
+for pri in 1 0; do
+  for category in "${CATEGORIES[@]}"; do
     for phase in "${PHASE_PRIORITY[@]}"; do
       pr_key="$category|$pri|$phase"
       if [[ -n "${FIRST_PR[$pr_key]:-}" ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1460,9 +1460,11 @@ assert_eq "issue 6 not masked by 60-foo worktree" "issue 6" "$result"
 teardown
 
 # --- topic-category prioritization (issue #707) -----------------------------
-# A topic category (priority → bug → testing infrastructure → dispatch → other) nests
-# outside the phase ladder. A PR's category is resolved from the labels of the
-# issues it closes; an issue's category from its own labels.
+# The `priority` label is the outermost axis: every `priority` item ranks above
+# every non-priority item, regardless of topic. Topic category
+# (bug → testing infrastructure → dispatch → other) nests inside the priority
+# axis, and the phase ladder runs innermost. A PR's category is resolved from
+# the labels of the issues it closes; an issue's category from its own labels.
 
 # 28. A PR closing a `bug` issue outranks a PR closing a `dispatch` issue, even
 #     when the dispatch PR is older — category beats age.
@@ -1512,11 +1514,11 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "PR with no closing issue is 'other'; bug issue wins" "issue 500" "$result"
 teardown
 
-# 30b. A PR closing a plain `bug` issue outranks a PR closing a `priority`-only
-#      issue — `priority` is a sub-axis nested inside each topic category, not
-#      a top-level category. A `priority`-only issue resolves to topic `other`,
-#      which ranks below `bug`. The older bug-closing PR wins.
-echo "Test: PR closing a bug issue beats PR closing a priority-only issue"
+# 30b. A PR closing a `priority`-only issue outranks a PR closing a plain `bug`
+#      issue — `priority` is the outermost axis, so a `priority` item in topic
+#      `other` ranks above a non-priority `bug` item. The priority-only-closing
+#      PR wins even though it is newer and its topic (`other`) is lower-ranked.
+echo "Test: PR closing a priority-only issue beats PR closing a bug issue"
 setup
 # PR 20 (older) closes bug issue 200; PR 10 (newer) closes priority-only issue 100.
 UNION='['
@@ -1530,12 +1532,13 @@ printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"pri
   > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "bug-closing PR beats priority-only-closing PR" "pr 20 20-bug-pr verify" "$result"
+assert_eq "priority-only-closing PR beats bug-closing PR" "pr 10 10-priority-pr verify" "$result"
 teardown
 
 # 30c. A PR closing a `(bug, priority)` issue outranks a PR closing a plain
-#      `bug` issue, even when the plain-bug PR is older — within the `bug`
-#      topic category, `priority` items rank above non-`priority` items.
+#      `bug` issue, even when the plain-bug PR is older — `priority` is the
+#      outermost axis, so both PRs share topic `bug` and the `priority` one
+#      wins. Topic category is the tie-break only within one priority level.
 echo "Test: PR closing a (bug, priority) issue beats PR closing a plain bug issue"
 setup
 # PR 20 (older) closes plain bug issue 200; PR 10 (newer) closes (bug, priority) issue 100.
@@ -1552,10 +1555,11 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "(bug, priority)-closing PR beats plain-bug-closing PR" "pr 10 10-bug-priority-pr verify" "$result"
 teardown
 
-# 30d. A PR closing a `(dispatch, priority)` issue ranks below every PR closing
-#      a plain `bug` issue — `priority` is a sub-axis nested inside each topic
-#      category, so it does not cross topic boundaries. The bug-closing PR wins.
-echo "Test: PR closing a plain bug issue beats PR closing a (dispatch, priority) issue"
+# 30d. A PR closing a `(dispatch, priority)` issue outranks a PR closing a plain
+#      `bug` issue — `priority` is the outermost axis, so it crosses topic
+#      boundaries: a `priority` item in topic `dispatch` lifts above a
+#      non-priority `bug` item. The (dispatch, priority)-closing PR wins.
+echo "Test: PR closing a (dispatch, priority) issue beats PR closing a plain bug issue"
 setup
 # PR 10 (older) closes (dispatch, priority) issue 100; PR 20 (newer) closes plain bug issue 200.
 UNION='['
@@ -1568,7 +1572,7 @@ printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"dis
   > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "plain-bug PR beats (dispatch, priority) PR — priority does not cross topics" "pr 20 20-bug-pr verify" "$result"
+assert_eq "(dispatch, priority) PR beats plain-bug PR — priority crosses topics" "pr 10 10-dispatch-priority-pr verify" "$result"
 teardown
 
 # 30e. The 2026-05-29 reproduction (#905). A queue of bug+priority PRs, all but

--- a/.claude/skills/ref-ready/SKILL.md
+++ b/.claude/skills/ref-ready/SKILL.md
@@ -324,7 +324,7 @@ topic label.
 
 - **`priority`** — a separate axis from the topic labels above. A
   human-applied escalation marker that routes the issue (or any PR closing it)
-  ahead of non-priority items within its own topic category in `/dispatch-propagate` queue selection. Apply only
+  ahead of non-priority items across all topic categories in `/dispatch-propagate` queue selection. Apply only
   when a human explicitly asks to escalate; `/ready` never applies it
   automatically. May be combined with any topic label.
 


### PR DESCRIPTION
Closes #970

Invert the dispatch-queue nesting from topic → priority → phase to
priority → topic → phase by swapping the two outer selection loops at
both selection sites (default and --qa mode). Keys are unchanged
(`category|pri|phase`); only iteration order changes.

A `priority` item now escalates across all topics instead of being
confined within its own topic bucket — a `(dispatch, priority)` PR now
outranks a plain `bug` PR, while `(bug, priority)` still outranks
`(dispatch, priority)` since topic is the tie-break within one priority
level. A queue with no `priority` items selects identically to before.

Test suite: 949/949 passing. Tests 30b and 30d flip to the new ordering;
30c and 30e are unchanged.