### PR TITLE
dispatch: prevent PR-body prose from auto-closing unintended issues

### DIFF
--- a/.claude/rules/issue-references.md
+++ b/.claude/rules/issue-references.md
@@ -30,3 +30,25 @@ Commit messages, PR bodies, and issue bodies keep the bare `#N` form and append
 no `References:` list. GitHub auto-links `#N` in those contexts, and `Closes #N`
 drives GitHub's auto-close behavior — see
 `.claude/skills/plan-implement/SKILL.md`.
+
+### Closing keywords are reserved for the current PR's own issues
+
+`Closes #N` lines drive GitHub's auto-close behavior, but GitHub does not limit
+its parser to those lines — it scans the entire PR body for any closing keyword
+followed by `#N` and treats every match as a close directive for this PR,
+regardless of surrounding context. A keyword used as prose to narrate a
+*different* PR's effect is read as this PR's own directive.
+
+So a closing keyword may appear only on the deliberate `Closes #N` lines that
+name the issues this PR closes. Never place a closing keyword adjacent to a `#N`
+anywhere else in the body. The full keyword set GitHub recognizes:
+
+- `close`, `closes`, `closed`
+- `fix`, `fixes`, `fixed`
+- `resolve`, `resolves`, `resolved`
+
+The trap: paraphrasing does not help, because every form is a keyword. "PR #911
+(Closes #905)" and the obvious rewrite "PR #911 (which resolved #905)" both fire
+— `resolved` is a keyword too. The only safe way to narrate another PR's effect
+is a bare `#N` with no preceding keyword: `PR #911 (for #905)` or `PR #911,
+#905`.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6746,9 +6746,14 @@ else
   echo "    expected: '$DISPATCH_SPAWN_ROUTER_MAIN_WORKTREE'"
 fi
 # Independently assert the cwd is NOT the caller's cwd — that is the regression
-# the fix prevents (router born in the wrong worktree).
+# the fix prevents (router born in the wrong worktree). Only meaningful when
+# pwd-log is non-empty (i.e. --bg was actually called); an empty pwd-log would
+# make realpath "" return "" and the != comparison would silently pass.
 TOTAL=$((TOTAL + 1))
-if [[ "$(realpath "$sr_pwd_line" 2>/dev/null)" != "$(realpath "$SPAWN_ROUTER_CALLER_CWD")" ]]; then
+if [[ -z "$sr_pwd_line" ]]; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-router-cwd: 'claude --bg' did NOT run from the caller's cwd"
+  echo "    pwd-log is empty — 'claude --bg' was never called"
+elif [[ "$(realpath "$sr_pwd_line" 2>/dev/null)" != "$(realpath "$SPAWN_ROUTER_CALLER_CWD")" ]]; then
   PASS=$((PASS + 1)); echo "  PASS: spawn-router-cwd: 'claude --bg' did NOT run from the caller's cwd"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: spawn-router-cwd: 'claude --bg' did NOT run from the caller's cwd"

--- a/.claude/skills/plan-implement/SKILL.md
+++ b/.claude/skills/plan-implement/SKILL.md
@@ -89,7 +89,10 @@ until it does:
 - **Extra number (parsed but not intended):** the body contains a stray
   `<keyword> #N` in narrative prose. Find it, rewrite it to a bare `#N`
   (drop the preceding closing keyword — e.g. `Closes #905` → `#905`,
-  `resolved #905` → `#905`), update with `gh pr edit "$PR_NUM" --body ...`.
+  `resolved #905` → `#905`). Write the corrected body to a temp file under
+  `tmp/` and apply it with `gh pr edit "$PR_NUM" --body-file tmp/<file>` —
+  never interpolate the body inline into the command, since it may carry
+  shell metacharacters from issue-sourced text.
 - **Missing number (intended but not parsed):** a `Closes #N` line was not
   recognized — check that it appears on its own line, outside any code block,
   with no leading spaces. Re-edit the body to restore the canonical form.

--- a/.claude/skills/plan-implement/SKILL.md
+++ b/.claude/skills/plan-implement/SKILL.md
@@ -80,14 +80,19 @@ the `Closes #N` lines you deliberately wrote (`gh` still needs
 
 ```bash
 gh pr view "$PR_NUM" --json closingIssuesReferences \
-  -q '.closingIssuesReferences[].number' | sort
+  -q '.closingIssuesReferences[].number' | sort -n
 ```
 
-If a parsed number is not in your intended `Closes #N` set, the body contains a
-stray `<keyword> #N` in narrative prose. Find it, rewrite it to a bare `#N`
-(drop the preceding closing keyword — e.g. `Closes #905` → `#905`, `resolved
-#905` → `#905`), update the body with `gh pr edit "$PR_NUM" --body ...`, and
-re-run the check until the parsed set equals the intended set.
+If the parsed set does not exactly match the intended set, fix it and re-run
+until it does:
+
+- **Extra number (parsed but not intended):** the body contains a stray
+  `<keyword> #N` in narrative prose. Find it, rewrite it to a bare `#N`
+  (drop the preceding closing keyword — e.g. `Closes #905` → `#905`,
+  `resolved #905` → `#905`), update with `gh pr edit "$PR_NUM" --body ...`.
+- **Missing number (intended but not parsed):** a `Closes #N` line was not
+  recognized — check that it appears on its own line, outside any code block,
+  with no leading spaces. Re-edit the body to restore the canonical form.
 
 ### 4. Check for deviation, then write the marker (or skip it), then stop
 

--- a/.claude/skills/plan-implement/SKILL.md
+++ b/.claude/skills/plan-implement/SKILL.md
@@ -72,6 +72,23 @@ The body has one `Closes #N` line per issue implemented in this PR — the prima
 issue plus any implemented sub-issues or blockers. This draft PR is the
 implement→verify transition marker.
 
+Then verify GitHub parsed exactly the intended close set — narrative prose in
+the body can carry a stray closing keyword that GitHub reads as an extra close
+directive (see `.claude/rules/issue-references.md`). Compare the parsed set to
+the `Closes #N` lines you deliberately wrote (`gh` still needs
+`dangerouslyDisableSandbox: true`):
+
+```bash
+gh pr view "$PR_NUM" --json closingIssuesReferences \
+  -q '.closingIssuesReferences[].number' | sort
+```
+
+If a parsed number is not in your intended `Closes #N` set, the body contains a
+stray `<keyword> #N` in narrative prose. Find it, rewrite it to a bare `#N`
+(drop the preceding closing keyword — e.g. `Closes #905` → `#905`, `resolved
+#905` → `#905`), update the body with `gh pr edit "$PR_NUM" --body ...`, and
+re-run the check until the parsed set equals the intended set.
+
 ### 4. Check for deviation, then write the marker (or skip it), then stop
 
 Before writing the marker, judge whether the implementation deviated from the


### PR DESCRIPTION
Closes #968

The dispatch workflow auto-generates PR bodies that narrate prior work, often
quoting another PR's closing reference as prose. GitHub's auto-close parser
scans the entire body for a closing keyword followed by #N regardless of
context, so a quoted reference becomes a live close directive on merge.

This adds defense-in-depth:

- `.claude/rules/issue-references.md` — a new subsection stating closing
  keywords are reserved for the current PR's own `Closes #N` lines, enumerating
  the full keyword set, and documenting the rewrite trap (the obvious paraphrase
  using `resolved` followed by an issue number still fires, because `resolved`
  is itself a keyword; the only safe narration is a bare #N).
- `.claude/skills/plan-implement/SKILL.md` — a Step 3 guardrail that compares
  GitHub's parsed closingIssuesReferences against the intended close set after
  PR creation and rewrites any stray prose keyword to a bare #N on mismatch.