### PR TITLE
dispatch: run main-broken diagnose and jit-reminder as spawned bg jobs

### DIFF
--- a/.claude/skills/dispatch-diagnose-main/SKILL.md
+++ b/.claude/skills/dispatch-diagnose-main/SKILL.md
@@ -1,23 +1,21 @@
 ---
 name: dispatch-diagnose-main
-description: Diagnose origin/main's failing CI when /dispatch-propagate detects a red main; enumerates failing checks, fetches logs, summarizes likely cause, releases the dispatch lock, and returns so the caller can apply notify main-broken.
+description: Diagnose origin/main's failing CI when /dispatch-propagate detects a red main; runs as a spawned bg job that enumerates failing checks, fetches logs, and produces the likely-cause summary in its own transcript.
 ---
 
 # Dispatch: Diagnose Main
 
-Invoked by `/dispatch-propagate` Step 3 when `dispatch-select-target` reports
-`main-broken <sha>` — `origin/main` itself is red, so no new work is safe to
-start. Diagnose main, release the dispatch lock, and return. On this skill's
-return, the caller (`/dispatch-propagate` Step 3) proceeds to Step 7 with `notify
-main-broken` — the session stays in `claude agents` until the user closes it,
-so the diagnosis remains visible rather than buried in a closed transcript.
-The skill does **not** run the sweep, create a worktree, branch, PR, or
-invoke any phase skill.
+Runs as its own `claude --bg` job (session name `diagnose-main`) spawned by
+`/dispatch-propagate` when `dispatch-select-target` reports `main-broken <sha>`
+— `origin/main` itself is red, so no new work is safe to start. The diagnosis
+lives in this job's own transcript. This job holds no dispatch lock (the router
+released it before spawning this job). The skill does **not** run the sweep,
+create a worktree, branch, PR, or invoke any phase skill.
 
 Takes `<sha>` as its single argument — the broken `origin/main` HEAD commit.
 
-Run `gh` commands and the lock-release with `dangerouslyDisableSandbox: true`
-— see `.claude/rules/sandbox.md`.
+Run `gh` commands with `dangerouslyDisableSandbox: true` — see
+`.claude/rules/sandbox.md`.
 
 ## 1. Enumerate failing checks
 
@@ -39,20 +37,10 @@ Both calls need `dangerouslyDisableSandbox: true`.
 - For a failing **CodeQL check-run** (which has no workflow-run id), surface
   its `details_url` from the check-runs response.
 
-These diagnostic `gh` calls run before the lock-release — keep them.
-
-## 3. Release the dispatch lock
-
-As the action immediately before the final report:
-
-```bash
-.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock --release
-```
-
-## 4. Summarize and stop
+## 3. Summarize and stop
 
 Summarize the likely cause from the logs and check-run details, report it,
-and return. The caller proceeds to Step 7 with `notify main-broken`.
+and stop. This job's transcript is the surface for the diagnosis.
 
 Include only the failing check/step name and a high-level error category
 (e.g. "test assertion failed", "lint error", "type error"). Do not reproduce

--- a/.claude/skills/dispatch-jit-reminder/SKILL.md
+++ b/.claude/skills/dispatch-jit-reminder/SKILL.md
@@ -1,31 +1,33 @@
 ---
 name: dispatch-jit-reminder
-description: Claim the earliest-due JIT issue, release the dispatch lock, summarize the issue for the user as a reminder, and stop the tick. Invoked by /dispatch-propagate when the JIT scan surfaces a due reminder.
+description: Claim the earliest-due JIT issue, summarize it for the user as a reminder, and stop. Runs as a spawned bg job from /dispatch-propagate when the JIT scan surfaces a due reminder.
 ---
 
 # Dispatch: JIT Reminder
 
-Invoked by `/dispatch-propagate` Step 3 when `dispatch-select-target` reports
+Runs as its own `claude --bg` job (session name `jit-reminder-<num>`) spawned by
+`/dispatch-propagate` when `dispatch-select-target` reports
 `jit-reminder <repo> <num> <project> <item-id>` — the JIT scan selected
-`<num>` in `<repo>` as the earliest-due open JIT issue.
+`<num>` in `<repo>` as the earliest-due open JIT issue. This job holds no
+dispatch lock (the router released it before spawning this job).
 
 Takes four arguments: `<repo> <num> <project> <item-id>`.
 
-Claim the issue, release the dispatch lock, summarize the issue for the
-user, and stop. The skill stops the tick directly — the summary printed here
-must stay open in the transcript for a human to read. Steps 4, 5, and 6-7 of
-`/dispatch-propagate` are all skipped — no worktree, no PR, no phase skill, no leaf
-trace.
+Claim the issue, summarize it for the user, and stop. The summary printed here
+must stay open in this job's transcript for a human to read — no worktree, no
+PR, no phase skill, no leaf trace.
+
+The per-item spawn-dedup name `jit-reminder-<num>` — assigned by the router's
+`dispatch-spawn-job` call — prevents a concurrent dispatch tick from
+double-spawning the same reminder while this claim is in flight; the In-Progress
+claim then prevents re-selection on later ticks.
 
 Run `gh`-calling commands with `dangerouslyDisableSandbox: true` — see
 `.claude/rules/sandbox.md`.
 
-## 1. Claim the issue inside the scoped lock window
+## 1. Claim the issue
 
-The lock is still held by the caller from `/dispatch-propagate` Step 0 — the reminder
-path is a Step 3 stop path and never reaches Step 5's proceed-path release,
-so the claim runs under the lock, exactly as the JIT engine does. Resolve
-the project's In-Progress status value from local config, then write it:
+Resolve the project's In-Progress status value from local config, then write it:
 
 ```bash
 IN_PROGRESS=$(.claude/skills/dispatch-propagate/scripts/dispatch-config-load projects \
@@ -38,18 +40,7 @@ IN_PROGRESS=$(.claude/skills/dispatch-propagate/scripts/dispatch-config-load pro
 The `dispatch-project-status-write` call needs `dangerouslyDisableSandbox:
 true` — it calls `gh`.
 
-## 2. Release the lock
-
-This is a Step 3 stop path — release the lock immediately after the claim,
-before the summary:
-
-```bash
-.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock --release
-```
-
-`dangerouslyDisableSandbox: true`.
-
-## 3. Summarize the issue for the user
+## 2. Summarize the issue for the user
 
 Fetch the issue (`dangerouslyDisableSandbox: true` — `gh` needs network):
 
@@ -62,7 +53,7 @@ reminder, framed as the most-overdue / soonest-due JIT reminder the scan
 surfaced. The `jit-reminder` line carries no due timestamp — do not state a
 precise computed due time.
 
-## 4. Stop the tick
+## 3. Stop
 
 The `In Progress` status the claim wrote stops a later `/dispatch-propagate` tick from
 re-selecting this issue.

--- a/.claude/skills/dispatch-propagate/SKILL.md
+++ b/.claude/skills/dispatch-propagate/SKILL.md
@@ -22,9 +22,10 @@ them:
 1. `dispatch-select-tick` — acquires the lock, syncs `main`, applies the
    run-scoped concurrency gate, runs the JIT engine and the Calendar JIT
    importer, and selects the target. Emits one **decision line**.
-2. The model routes on that line (Table 1). Only three outcomes need the model:
-   a `main-broken` / `jit-reminder` sub-skill invocation, or — for a real
-   target — a call to `dispatch-materialize-spawn`.
+2. The model routes on that line (Table 1). No sub-skill runs in the router's
+   own session: a `main-broken` / `jit-reminder` outcome spawns a bg job via
+   `dispatch-spawn-job`, then self-closes; a real target calls
+   `dispatch-materialize-spawn`.
 3. `dispatch-materialize-spawn` — runs the explicit-path guards, resolves the
    worktree, merges `origin/main` into it (so the worker reads up-to-date skill
    files), writes the recovery marker, gates on CI,
@@ -55,9 +56,10 @@ the decision as its **last** line. Report any `jit:` and `calendar:` lines, then
 route on the decision (Table 1).
 
 The **lock disposition is the script's responsibility**: it holds the lock on
-the four target lines plus `main-broken`/`jit-reminder`, releases it on
-`empty`/`sync-failed`/`resolver-failed`/`concurrency-cap`, and never touches it
-on `busy`. The model never releases the lock for a select-tick outcome.
+the target lines (`explicit`/`pr`/`issue`), releases it on
+`empty`/`sync-failed`/`resolver-failed`/`concurrency-cap`/`main-broken`/`jit-reminder`,
+and never touches it on `busy`. The model never releases the lock for a
+select-tick outcome.
 
 ### Table 1 — routing the select-tick decision line
 
@@ -68,8 +70,8 @@ on `busy`. The model never releases the lock for a select-tick outcome.
 | `resolver-failed` | The explicit argument did not resolve to one issue; report the script's stderr. | `notify resolver-failed` |
 | `empty` | Nothing eligible. Report verbatim: "queue empty — closing; the office-hours queue or a new issue will re-seed the chain". | `drain empty-queue` |
 | `concurrency-cap` | The live busy-worker count already meets the budget; a cap-keyed re-seed is scheduled (see reference.md *The #725 cap-keyed re-seed*). | `drain concurrency-cap` |
-| `main-broken <sha>` | Invoke `/dispatch-diagnose-main <sha>` — it enumerates the failing checks, fetches logs, summarizes the likely cause, and releases the lock itself. | `notify main-broken` |
-| `jit-reminder <repo> <num> <project> <item-id>` | Invoke `/dispatch-jit-reminder <repo> <num> <project> <item-id>`. The sub-skill claims the item, releases the lock, summarizes for the user, and stops the tick — a terminal-disposition bypass. | **Stop here**: no materialize-spawn, no self-close |
+| `main-broken <sha>` | Run (`dangerouslyDisableSandbox: true`) `.claude/skills/dispatch-propagate/scripts/dispatch-spawn-job --name diagnose-main --cwd "$PWD" "/dispatch-diagnose-main <sha>"` — it spawns the diagnosis as its own bg job whose transcript holds the human-facing summary. Report the spawn result (`spawned`/`deduped`), then self-close. | `drain main-broken` |
+| `jit-reminder <repo> <num> <project> <item-id>` | Run (`dangerouslyDisableSandbox: true`) `.claude/skills/dispatch-propagate/scripts/dispatch-spawn-job --name jit-reminder-<num> --cwd "$PWD" "/dispatch-jit-reminder <repo> <num> <project> <item-id>"` — the reminder surfaces from that bg job's transcript; the per-item spawn name `jit-reminder-<num>` prevents a concurrent tick double-spawning the same reminder. Report the spawn, then self-close. | `drain jit-reminder` |
 | `explicit <num> <gap>` | `dispatch-materialize-spawn <num> explicit --gap <gap>` | route on Table 2 |
 | `pr <num> <branch> <phase> <gap>` | Set `N=${branch%%-*}` (the issue the PR closes — never the PR `<num>`), then `dispatch-materialize-spawn <N> queue --gap <gap>` | route on Table 2 |
 | `issue <num> <gap>` | `dispatch-materialize-spawn <num> queue --gap <gap>` | route on Table 2 |
@@ -212,10 +214,11 @@ no-op when `CLAUDE_JOB_DIR` is unset (interactive session), so an interactive
 `/dispatch-propagate` reaching a terminal disposition does not stop the user's
 conversation.
 
-The `jit-reminder` outcome (Table 1) does not reach this section — the sub-skill
-stops the tick directly. The router does **not** spawn a successor itself; the
-worker's Stop hook (`.claude/hooks/dispatch-stop.sh`) spawns a fresh router back
-in `worktrees/main` when the worker session ends.
+The `main-broken` and `jit-reminder` outcomes (Table 1) reach this section as
+`drain` dispositions: spawn the bg job via `dispatch-spawn-job`, report the
+spawn result, then self-close. The router does **not** spawn a successor itself;
+the worker's Stop hook (`.claude/hooks/dispatch-stop.sh`) spawns a fresh router
+back in `worktrees/main` when the worker session ends.
 
 Deep "why" — chain mechanics, the lock's two scopes and marker-based reclaim,
 the selection ladder, the Step-5 marker, the spawn-cwd trade-off, concurrency

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -22,17 +22,18 @@
 #   explicit <num> <gap>   explicit arg resolved to issue <num>; lock HELD.
 #   pr <num> <branch> <phase> <gap>   queue selected a PR; lock HELD.
 #   issue <num> <gap>   queue selected a help-wanted leaf; lock HELD.
-#   main-broken <sha>   origin/main is red; lock HELD (the sub-skill releases).
+#   main-broken <sha>   origin/main is red; lock RELEASED (spawned as a bg job,
+#                    which runs lock-free).
 #   jit-reminder <repo> <num> <project> <item-id>   a JIT reminder is due; lock
-#                    HELD (the sub-skill releases).
+#                    RELEASED (spawned as a bg job, which runs lock-free).
 #   empty            nothing eligible; lock released.
 #
 # <gap> = max(1, TARGET_N − LIVE_COUNT) is the run-scoped spawn budget the
 # fan-out loop consumes (always >= 1 on a target line). --bypass-cap skips the
 # concurrency gate and forces <gap> = 1.
 #
-# Lock invariant (the three guards): HOLD on pr/issue/explicit/main-broken/
-# jit-reminder; RELEASE on empty/sync-failed/resolver-failed/concurrency-cap;
+# Lock invariant (the three guards): HOLD on pr/issue/explicit; RELEASE on
+# empty/sync-failed/resolver-failed/concurrency-cap/main-broken/jit-reminder;
 # NEVER release on busy (nothing was acquired).
 #
 # Requires `dangerouslyDisableSandbox: true` — sub-scripts write tmp state, call
@@ -155,7 +156,10 @@ case "$SELECTED" in
     echo "$SELECTED $GAP"
     ;;
   main-broken\ *|jit-reminder\ *)
-    # Hold the lock; the invoked sub-skill releases it at its own exit. No gap.
+    # Spawned as their own bg jobs (lock-free), so release the lock here — a
+    # fresh bg session could not release this session's lock anyway (strict
+    # self-release). No gap appended.
+    release_lock
     echo "$SELECTED"
     ;;
   empty)

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-job
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-job
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# dispatch-spawn-job — the generalized `claude --bg` spawn primitive.
+#
+# This is the dedup → spawn → verify core extracted from dispatch-spawn-worker,
+# parameterized by an arbitrary `--name <name>`, `--cwd <cwd>`, and a single
+# positional `<prompt>`. It spawns one `claude --bg` job that runs <prompt>,
+# born with cwd = <cwd> (via a subshell `cd`) so SessionStart-derived attributes
+# (title, restored skill set, sandbox allowlist) key on the right directory.
+#
+# Reused by:
+#   - dispatch-spawn-worker — the router → phase-worker spawn (--name is the
+#     target worktree basename, --cwd the worktree path, prompt the
+#     /dispatch-worker invocation). The worker-specific arg validation lives in
+#     that wrapper; this primitive stays generic.
+#   - the `main-broken` → /dispatch-diagnose-main and `jit-reminder` →
+#     /dispatch-jit-reminder bg-job spawns, which run those sub-skills in their
+#     own session rather than in the router's.
+#
+# Usage: dispatch-spawn-job --name <name> --cwd <cwd> <prompt>
+#
+# Arguments (all required):
+#   --name <name>   The spawned session's --name. Dedup keys on it directly:
+#                   another live session with the same name under <cwd> means
+#                   nothing is spawned.
+#   --cwd <cwd>     Existing directory the spawn subshell `cd`s into before
+#                   `claude --bg`, so the new job is born there and the daemon
+#                   registers it under that path. Must be an existing directory.
+#   <prompt>        The single positional prompt string passed to `claude --bg`.
+#
+# Behavior, in order:
+#   1. Dedup    — if another live session with name == <name> is already running
+#                 under <cwd>, spawn nothing. Fail-safe: if the registry cannot
+#                 be queried, also spawn nothing (a dispatch agent may be live).
+#   2. Spawn    — `claude --bg --name <name> --permission-mode auto "<prompt>"`,
+#                 from a subshell that `cd`s into <cwd> first.
+#   3. Verify   — re-query the registry under <cwd> (where the new job registers)
+#                 with a bounded retry (verify_agent_registered_under) to absorb
+#                 the async-registration race; confirm the new agent appears.
+#
+# Stdout protocol (exactly one word):
+#   deduped   another agent with the same name is running, or the registry
+#             could not be queried — nothing was spawned.
+#   spawned   a new job was spawned and verified.
+# A spawn that does not verify prints nothing to stdout, writes a diagnostic to
+# stderr, and exits non-zero.
+#
+# Exit codes:
+#   0  deduped or spawned (stdout disambiguates).
+#   1  the successor never registered in 'claude agents --json' — see stderr.
+#   2  the script cannot operate — usage / validation failed (missing or empty
+#      --name, --cwd, or <prompt>; an unexpected extra positional; or a --cwd
+#      that is not an existing directory).
+#
+# Environment overrides for testability:
+#   DISPATCH_SPAWN_JOB_CLAUDE_CMD   The `claude` command. The script's own
+#                                   `claude --bg` / `claude agents` calls use it,
+#                                   and it is exported as CLAUDE_AGENTS_CMD so
+#                                   the sourced lib-claude-agents.sh helper is
+#                                   faked consistently. Default: `claude`.
+#   DISPATCH_SPAWN_JOB_SESSION_ID   This session's id, for the dedup self-
+#                                   exclusion. Default: $CLAUDE_CODE_SESSION_ID.
+#
+# Sandbox: every `claude` call here reaches the local Claude daemon over a Unix
+# socket; callers must invoke this script with `dangerouslyDisableSandbox:
+# true` — see `.claude/rules/sandbox.md § claude agents --json`.
+#
+# NOT set -e: exits are handled explicitly (matching dispatch-spawn-worker /
+# dispatch-acquire-lock).
+set -uo pipefail
+
+# ---- Step 0: parse and validate arguments -----------------------------------
+NAME=""
+CWD=""
+positionals=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)
+      if [[ $# -lt 2 ]]; then
+        echo "dispatch-spawn-job: --name requires a value" >&2
+        exit 2
+      fi
+      NAME="$2"
+      shift 2
+      ;;
+    --cwd)
+      if [[ $# -lt 2 ]]; then
+        echo "dispatch-spawn-job: --cwd requires a value" >&2
+        exit 2
+      fi
+      CWD="$2"
+      shift 2
+      ;;
+    *)
+      positionals+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#positionals[@]} -ne 1 ]]; then
+  echo "dispatch-spawn-job: expected exactly one positional <prompt>; usage: dispatch-spawn-job --name <name> --cwd <cwd> <prompt>" >&2
+  exit 2
+fi
+PROMPT="${positionals[0]}"
+
+if [[ -z "$NAME" ]]; then
+  echo "dispatch-spawn-job: --name is required and must be non-empty" >&2
+  exit 2
+fi
+if [[ -z "$CWD" ]]; then
+  echo "dispatch-spawn-job: --cwd is required and must be non-empty" >&2
+  exit 2
+fi
+if [[ -z "$PROMPT" ]]; then
+  echo "dispatch-spawn-job: <prompt> must be non-empty" >&2
+  exit 2
+fi
+if [[ ! -d "$CWD" ]]; then
+  echo "dispatch-spawn-job: cwd '$CWD' does not exist or is not a directory" >&2
+  exit 2
+fi
+
+# ---- Step 1: resolve config -------------------------------------------------
+CLAUDE_CMD="${DISPATCH_SPAWN_JOB_CLAUDE_CMD:-claude}"
+# The sourced helper reads CLAUDE_AGENTS_CMD for its own `claude agents --json`
+# call; point it at the same command so a faked `claude` fakes every path.
+export CLAUDE_AGENTS_CMD="$CLAUDE_CMD"
+
+SESSION_ID="${DISPATCH_SPAWN_JOB_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib-claude-agents.sh"
+
+# The spawn subshell `cd`s into CWD before `claude --bg`, so the new job is
+# born there and the daemon registers it under that path. Dedup (Step 2) and
+# verify (Step 3) must query the registry under THIS path.
+SPAWN_CWD="$CWD"
+
+# ---- Step 2: dedup guard ----------------------------------------------------
+# If another live session already has name == <name>, spawn nothing. The
+# registry query filters by SPAWN_CWD (= CWD) because the spawn subshell `cd`s
+# there before `claude --bg`, so the new job registers under that path. Fail
+# safe: an unknown (unqueryable) registry is treated as "a dispatch agent may
+# be running", so nothing is spawned.
+if ! sessions=$(claude_sessions_under "$SPAWN_CWD"); then
+  echo deduped
+  exit 0
+fi
+while IFS=$'\t' read -r sid _ status name; do
+  [[ -z "$sid" ]] && continue
+  [[ "$name" == "$NAME" ]] || continue       # not a same-name job
+  # Defensive: `claude agents --json` only lists live sessions, so a "stopped"
+  # row should not appear here in normal operation. The check survives a
+  # registry that nonetheless surfaces a terminal status.
+  [[ "$status" == "stopped" ]] && continue
+  [[ "$sid" == "$SESSION_ID" ]] && continue   # this very session — not "another"
+  # Another live job already owns this name; spawn nothing.
+  echo deduped
+  exit 0
+done <<<"$sessions"
+
+# ---- Step 3: spawn the job --------------------------------------------------
+# The job is born with cwd = CWD via a subshell `cd` so SessionStart hooks key
+# on the right directory directly. The subshell `cd` is scoped — this script's
+# own cwd is untouched. Capture the spawn's combined output so a failure
+# diagnostic can surface why (`claude` missing, `--bg` rejected). `|| true`
+# keeps a non-zero spawn from aborting the script — Step 3's registry check is
+# the source of truth for whether the agent actually came up.
+spawn_output=$(
+  cd "$CWD" && "$CLAUDE_CMD" --bg --name "$NAME" \
+    --permission-mode auto "$PROMPT" 2>&1
+) || true
+
+# ---- Step 4: verify the new agent registered --------------------------------
+# Query under SPAWN_CWD (= CWD) — the new job's registered cwd. The bounded
+# retry in verify_agent_registered_under absorbs the async-registration race
+# between `claude --bg` returning and the daemon surfacing the new agent.
+if verify_agent_registered_under "$NAME" "$SPAWN_CWD"; then
+  echo spawned
+  exit 0
+fi
+if [[ -n "${spawn_output//[[:space:]]/}" ]]; then
+  echo "dispatch-spawn-job: '$NAME' did not register in 'claude agents --json' after 'claude --bg'; output: $spawn_output" >&2
+else
+  echo "dispatch-spawn-job: '$NAME' did not register in 'claude agents --json' after 'claude --bg'" >&2
+fi
+exit 1

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-job
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-job
@@ -132,18 +132,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/lib-claude-agents.sh"
 
-# The spawn subshell `cd`s into CWD before `claude --bg`, so the new job is
-# born there and the daemon registers it under that path. Dedup (Step 2) and
-# verify (Step 3) must query the registry under THIS path.
-SPAWN_CWD="$CWD"
-
 # ---- Step 2: dedup guard ----------------------------------------------------
 # If another live session already has name == <name>, spawn nothing. The
-# registry query filters by SPAWN_CWD (= CWD) because the spawn subshell `cd`s
-# there before `claude --bg`, so the new job registers under that path. Fail
-# safe: an unknown (unqueryable) registry is treated as "a dispatch agent may
-# be running", so nothing is spawned.
-if ! sessions=$(claude_sessions_under "$SPAWN_CWD"); then
+# registry query filters by CWD because the spawn subshell `cd`s there before
+# `claude --bg`, so the new job registers under that path. Fail safe: an
+# unknown (unqueryable) registry is treated as "a dispatch agent may be
+# running", so nothing is spawned.
+if ! sessions=$(claude_sessions_under "$CWD"); then
   echo deduped
   exit 0
 fi
@@ -165,7 +160,7 @@ done <<<"$sessions"
 # on the right directory directly. The subshell `cd` is scoped — this script's
 # own cwd is untouched. Capture the spawn's combined output so a failure
 # diagnostic can surface why (`claude` missing, `--bg` rejected). `|| true`
-# keeps a non-zero spawn from aborting the script — Step 3's registry check is
+# keeps a non-zero spawn from aborting the script — Step 4's registry check is
 # the source of truth for whether the agent actually came up.
 spawn_output=$(
   cd "$CWD" && "$CLAUDE_CMD" --bg --name "$NAME" \
@@ -173,10 +168,10 @@ spawn_output=$(
 ) || true
 
 # ---- Step 4: verify the new agent registered --------------------------------
-# Query under SPAWN_CWD (= CWD) — the new job's registered cwd. The bounded
+# Query under CWD — the new job's registered cwd. The bounded
 # retry in verify_agent_registered_under absorbs the async-registration race
 # between `claude --bg` returning and the daemon surfacing the new agent.
-if verify_agent_registered_under "$NAME" "$SPAWN_CWD"; then
+if verify_agent_registered_under "$NAME" "$CWD"; then
   echo spawned
   exit 0
 fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-worker
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-worker
@@ -2,86 +2,36 @@
 # dispatch-spawn-worker — spawn a /dispatch-worker background job for a target
 # worktree (the router → worker spawn primitive).
 #
-# /dispatch-propagate (the router) selects an issue, resolves its worktree, and then
-# delegates phase execution to a dedicated worker session via this script.
-# The worker session is spawned with cwd = <worktree-path> (via a subshell
-# `cd`) so SessionStart-derived attributes (title, restored skill set, sandbox
-# allowlist) key on the right worktree directly. Trade-off: the Claude daemon's
-# "+ new session" launcher default cwd will track the most-recent worker's
-# worktree path rather than staying anchored at worktrees/main. The worktree
-# path is passed in as the positional argument and is also the spawn cwd.
-#
-# The sibling primitive for the reverse direction (worker → router) is
-# dispatch-spawn-router, also spawned from the caller's cwd.
+# Thin wrapper: this script validates the worker-specific arguments
+# (<issue-num>, <worktree-path>) and then delegates the spawn / dedup / verify
+# mechanics to dispatch-spawn-job, the generalized `claude --bg` spawn primitive.
+# The worker's --name is the worktree basename (per-worktree name uniqueness is
+# automatic) and its --cwd is the worktree path, so the new worker is born in
+# its target worktree.
 #
 # Usage: dispatch-spawn-worker <issue-num> <worktree-path>
 #
 # Arguments (both required):
 #   <issue-num>     The issue number N. The worker is invoked as
 #                   `/dispatch-worker <N> <worktree-path>`.
-#   <worktree-path> Absolute path to the target worktree. The spawn subshell
-#                   `cd`s into this path before invoking `claude --bg`, so the
-#                   new worker is born in its target worktree. Passed through
-#                   to the worker as its second positional argument. The
-#                   basename of this path is the worker's --name, so per-
-#                   worktree name uniqueness is automatic.
+#   <worktree-path> Absolute path to the target worktree. Its basename is the
+#                   worker's --name; the path is the spawn --cwd and the
+#                   worker's second positional argument.
 #
-# Behavior, in order:
-#   1. Dedup    — if another live session with the same name (the worktree
-#                 basename) is already running, spawn nothing. Per-worktree
-#                 name uniqueness keys the dedup on
-#                 `name == basename "$WORKTREE_PATH"`. The query is filtered
-#                 to <worktree-path> — the new worker registers there because
-#                 the spawn subshell `cd`s in before `claude --bg`. Fail-safe:
-#                 if the session registry cannot be queried, also spawn nothing
-#                 — a dispatch agent may be running; the #725 cap-keyed re-seed
-#                 re-seeds the chain if a rate-limit cap-stall actually dropped
-#                 it.
-#   2. Spawn    — `claude --bg --name <worktree-basename> --permission-mode
-#                 auto "/dispatch-worker <N> <worktree-path>"`, run from a
-#                 subshell that `cd`s into <worktree-path> first so the new
-#                 worker is born in its target worktree.
-#   3. Verify   — re-query the registry under <worktree-path> (where the new
-#                 worker registers) with a bounded retry (via
-#                 `verify_agent_registered_under`) to absorb the async-
-#                 registration race; confirm the new agent appears.
+# Stdout / exit codes / sandbox: delegated to dispatch-spawn-job (`deduped` /
+# `spawned` on stdout; 0 = deduped or spawned, 1 = never registered, 2 = usage
+# / validation error). Callers must run with `dangerouslyDisableSandbox: true`
+# — see `.claude/rules/sandbox.md § claude agents --json`.
 #
-# (In-script `# ---- Step N: ... ----` markers offset by 2 — arg validation
-# and config resolution come first as Steps 0 and 1.)
+# Environment overrides for testability:
+#   DISPATCH_SPAWN_WORKER_CLAUDE_CMD    The `claude` command — translated into
+#                                       dispatch-spawn-job's
+#                                       DISPATCH_SPAWN_JOB_CLAUDE_CMD.
+#   DISPATCH_SPAWN_WORKER_SESSION_ID    This session's id — translated into
+#                                       dispatch-spawn-job's
+#                                       DISPATCH_SPAWN_JOB_SESSION_ID.
 #
-# Stdout protocol (exactly one word):
-#   deduped   another agent with the same worktree-basename name is running,
-#             or the registry could not be queried — nothing was spawned.
-#   spawned   a new /dispatch-worker job was spawned and verified.
-# A spawn that does not verify prints nothing to stdout, writes a diagnostic to
-# stderr, and exits non-zero.
-#
-# Exit codes:
-#   0  deduped or spawned (stdout disambiguates).
-#   1  the successor never registered in 'claude agents --json' — see stderr.
-#   2  the script cannot operate — argument validation failed (wrong count,
-#      non-integer <issue-num>, or non-existent <worktree-path>).
-#
-# Environment overrides for testability (mirroring dispatch-spawn-router's
-# DISPATCH_SPAWN_ROUTER_* pattern):
-#   DISPATCH_SPAWN_WORKER_CLAUDE_CMD    The `claude` command. The script's own
-#                                       `claude --bg` / `claude agents` calls use
-#                                       it, and it is exported as
-#                                       CLAUDE_AGENTS_CMD so the sourced
-#                                       lib-claude-agents.sh helper is faked
-#                                       consistently. Default: `claude`.
-#   DISPATCH_SPAWN_WORKER_SESSION_ID    This session's id, for the dedup self-
-#                                       exclusion. Default: $CLAUDE_CODE_SESSION_ID.
-#
-# Note: there is no DISPATCH_SPAWN_WORKER_MAIN_WORKTREE override — the worktree
-# path is passed in as the positional argument and does not need an env-override.
-#
-# Sandbox: every `claude` call here reaches the local Claude daemon over a Unix
-# socket; callers must invoke this script with `dangerouslyDisableSandbox:
-# true` — see `.claude/rules/sandbox.md § claude agents --json`.
-#
-# NOT set -e: exits are handled explicitly (matching dispatch-acquire-lock /
-# dispatch-sweep).
+# NOT set -e: exits are handled explicitly.
 set -uo pipefail
 
 # ---- Step 0: reject unexpected arguments ------------------------------------
@@ -118,85 +68,21 @@ if [[ ! "$WORKTREE_PATH" =~ ^[A-Za-z0-9/_.-]+$ ]]; then
   exit 2
 fi
 
-# ---- Step 1: resolve config -------------------------------------------------
-CLAUDE_CMD="${DISPATCH_SPAWN_WORKER_CLAUDE_CMD:-claude}"
-# The sourced helper reads CLAUDE_AGENTS_CMD for its own `claude agents --json`
-# call; point it at the same command so a faked `claude` fakes every path.
-export CLAUDE_AGENTS_CMD="$CLAUDE_CMD"
+# ---- Step 1: translate env overrides ----------------------------------------
+# Map the worker's DISPATCH_SPAWN_WORKER_* overrides onto dispatch-spawn-job's
+# DISPATCH_SPAWN_JOB_* overrides so existing callers/tests keep working.
+# Conditional export (via ${VAR+x}): an unset worker var stays unset so the
+# job's own defaults apply.
+if [[ -n "${DISPATCH_SPAWN_WORKER_CLAUDE_CMD+x}" ]]; then
+  export DISPATCH_SPAWN_JOB_CLAUDE_CMD="$DISPATCH_SPAWN_WORKER_CLAUDE_CMD"
+fi
+if [[ -n "${DISPATCH_SPAWN_WORKER_SESSION_ID+x}" ]]; then
+  export DISPATCH_SPAWN_JOB_SESSION_ID="$DISPATCH_SPAWN_WORKER_SESSION_ID"
+fi
 
-SESSION_ID="${DISPATCH_SPAWN_WORKER_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
-
+# ---- Step 2: delegate to the generalized spawn primitive --------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=/dev/null
-source "$SCRIPT_DIR/lib-claude-agents.sh"
-
-# The spawn subshell `cd`s into WORKTREE_PATH before `claude --bg`, so the
-# new worker is born there and the daemon registers it under that path.
-# Dedup (Step 2) and verify (Step 4) must query the registry under THIS path
-# — `claude agents --json --cwd <path>` filters server-side to sessions
-# started under <path>, and the new worker's start cwd is WORKTREE_PATH.
-SPAWN_CWD="$WORKTREE_PATH"
-
-# ---- Step 2: dedup guard ----------------------------------------------------
-# The worker's --name is the target worktree's basename, so per-worktree name
-# uniqueness reduces the dedup to a single name-equality check: if another
-# live session already has name == <worktree-basename>, spawn nothing. The
-# registry query filters by SPAWN_CWD (= WORKTREE_PATH) because the spawn
-# subshell `cd`s there before `claude --bg`, so the new worker registers
-# under the worktree path. Fail safe: an unknown (unqueryable) registry is
-# treated as "a dispatch agent may be running", so nothing is spawned. A
-# TOCTOU window exists between this query and the spawn below — two concurrent
-# router invocations could each pass the guard and each spawn a worker. The
-# per-worktree invariant and #755 absorb this: the next selection scan will
-# detect the duplicate, so the extra cost is one wasted tick, not lost work.
-AGENT_NAME="$(basename "$WORKTREE_PATH")"
-if ! sessions=$(claude_sessions_under "$SPAWN_CWD"); then
-  echo deduped
-  exit 0
-fi
-while IFS=$'\t' read -r sid _ status name; do
-  [[ -z "$sid" ]] && continue
-  [[ "$name" == "$AGENT_NAME" ]] || continue  # not a same-worktree worker
-  # Defensive: `claude agents --json` only lists live sessions, so a "stopped"
-  # row should not appear here in normal operation. The check survives a
-  # registry that nonetheless surfaces a terminal status.
-  [[ "$status" == "stopped" ]] && continue
-  [[ "$sid" == "$SESSION_ID" ]] && continue   # this very session — not "another"
-  # Another live worker already owns the worktree; spawn nothing.
-  echo deduped
-  exit 0
-done <<<"$sessions"
-
-# ---- Step 3: spawn the worker -----------------------------------------------
-# The worker's --name is the target worktree's basename (e.g.
-# `860-dispatch-spawn-worker-from-m`). The basename is unique per worktree, so
-# the name is unique per worker, and the dedup above keys on it directly. The
-# worker is born with cwd = <worktree-path> via a subshell `cd` so
-# SessionStart hooks key on the right worktree directly. The subshell `cd` is
-# scoped — this script's own cwd is untouched.
-# Capture the spawn's combined output so a failure diagnostic can surface why
-# (`claude` missing, `--bg` rejected). `|| true` keeps a non-zero spawn from
-# aborting the script — Step 4's registry check is the source of truth for
-# whether the agent actually came up.
-spawn_output=$(
-  cd "$WORKTREE_PATH" && "$CLAUDE_CMD" --bg --name "$AGENT_NAME" \
-    --permission-mode auto "/dispatch-worker $ISSUE_NUM $WORKTREE_PATH" 2>&1
-) || true
-
-# ---- Step 4: verify the new agent registered --------------------------------
-# Query under SPAWN_CWD (= WORKTREE_PATH) — the new worker's registered cwd.
-# The spawn subshell `cd`d into the worktree path, so the daemon registered
-# the worker there; the --cwd filter returns only sessions started under that
-# path. The bounded retry in `verify_agent_registered_under` absorbs the
-# async-registration race between `claude --bg` returning and the daemon
-# surfacing the new agent.
-if verify_agent_registered_under "$AGENT_NAME" "$SPAWN_CWD"; then
-  echo spawned
-  exit 0
-fi
-if [[ -n "${spawn_output//[[:space:]]/}" ]]; then
-  echo "dispatch-spawn-worker: '$AGENT_NAME' did not register in 'claude agents --json' after 'claude --bg'; output: $spawn_output" >&2
-else
-  echo "dispatch-spawn-worker: '$AGENT_NAME' did not register in 'claude agents --json' after 'claude --bg'" >&2
-fi
-exit 1
+exec "$SCRIPT_DIR/dispatch-spawn-job" \
+  --name "$(basename "$WORKTREE_PATH")" \
+  --cwd "$WORKTREE_PATH" \
+  "/dispatch-worker $ISSUE_NUM $WORKTREE_PATH"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -7677,14 +7677,16 @@ spawn_worker_teardown
 echo "Test: a pre-existing live session with the same name deduplicates the spawn"
 spawn_worker_setup
 # Prime the registry with a different sessionId whose name matches the name the
-# spawn would use. dispatch-spawn-job's dedup keys on name == <name>.
+# spawn would use. dispatch-spawn-job's dedup keys on name == <name>. cwd matches
+# SPAWN_JOB_CWD so the fixture models production: sessions_under(SPAWN_JOB_CWD)
+# returns this row (the fake ignores --cwd, but the fixture is accurate).
+SPAWN_JOB_CWD="$TMPDIR_TEST/worktrees/839-test-worker"
 printf '%s' \
-  '[{"sessionId":"sess-other","pid":4242,"cwd":"/job","kind":"background","status":"busy","name":"diagnose-main"}]' \
+  "[{\"sessionId\":\"sess-other\",\"pid\":4242,\"cwd\":\"$SPAWN_JOB_CWD\",\"kind\":\"background\",\"status\":\"busy\",\"name\":\"diagnose-main\"}]" \
   > "$SPAWN_WORKER_REGISTRY"
 write_fake_spawn_worker_claude
 export DISPATCH_SPAWN_JOB_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
 export DISPATCH_SPAWN_JOB_SESSION_ID="sess-self"
-SPAWN_JOB_CWD="$TMPDIR_TEST/worktrees/839-test-worker"
 if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-job" \
     --name diagnose-main --cwd "$SPAWN_JOB_CWD" "/dispatch-diagnose-main abc123" 2>/dev/null ); then rc=0; else rc=$?; fi
 assert_eq "spawn-job-dedup: dispatch-spawn-job exits 0" "0" "$rc"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -7260,12 +7260,15 @@ spawn_worker_setup() {
     "$TMPDIR_TEST/worktrees/main" \
     "$TMPDIR_TEST/worktrees/839-test-worker"
 
-  # dispatch-spawn-worker sources lib-claude-agents.sh from its own directory,
-  # so the helper must sit alongside the copy. It is sourced, not executed —
-  # no chmod.
+  # dispatch-spawn-worker sources lib-claude-agents.sh from its own directory
+  # and `exec`s dispatch-spawn-job (the generalized spawn primitive) from there
+  # too, so both must sit alongside the copy. lib-claude-agents.sh is sourced,
+  # not executed — no chmod; dispatch-spawn-job is exec'd, so it is chmod'd.
   cp "$SCRIPT_DIR/dispatch-spawn-worker" "$TMPDIR_TEST/scripts/dispatch-spawn-worker"
+  cp "$SCRIPT_DIR/dispatch-spawn-job" "$TMPDIR_TEST/scripts/dispatch-spawn-job"
   cp "$SCRIPT_DIR/lib-claude-agents.sh" "$TMPDIR_TEST/scripts/lib-claude-agents.sh"
   chmod +x "$TMPDIR_TEST/scripts/dispatch-spawn-worker"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-spawn-job"
 
   SPAWN_WORKER_REGISTRY="$TMPDIR_TEST/registry.json"
   SPAWN_WORKER_BG_ARGV="$TMPDIR_TEST/bg-argv"
@@ -7287,6 +7290,7 @@ spawn_worker_teardown() {
   SPAWN_WORKER_PENDING=""
   WORKER_TARGET_WORKTREE=""
   unset DISPATCH_SPAWN_WORKER_CLAUDE_CMD DISPATCH_SPAWN_WORKER_SESSION_ID \
+    DISPATCH_SPAWN_JOB_CLAUDE_CMD DISPATCH_SPAWN_JOB_SESSION_ID \
     SPAWN_BG_REGISTERS SPAWN_BG_REGISTER_AFTER_N \
     LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S
 }
@@ -7589,6 +7593,140 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: last-attempt-register-worker: no diagnostic on stderr"
   echo "    stderr: $err"
 fi
+spawn_worker_teardown
+
+# ============================================================================
+# dispatch-spawn-job tests
+# ============================================================================
+echo "=== dispatch-spawn-job ==="
+#
+# dispatch-spawn-job is the generalized `claude --bg` spawn primitive that
+# dispatch-spawn-worker `exec`s. It is exercised directly here against a fake
+# `claude`, reusing the same fake-claude harness shape as the spawn-worker
+# tests (a multi-subcommand temp script DISPATCH_SPAWN_JOB_CLAUDE_CMD points at,
+# which also backs the sourced lib-claude-agents.sh via CLAUDE_AGENTS_CMD).
+#
+# Each test gets a fresh tmp tree (reusing spawn_worker_setup, which already
+# stages dispatch-spawn-job + lib-claude-agents.sh into $TMPDIR_TEST/scripts):
+#   $TMPDIR_TEST/scripts/dispatch-spawn-job   copy of the script under test
+#   $TMPDIR_TEST/scripts/lib-claude-agents.sh sourced helper
+#   $TMPDIR_TEST/worktrees/839-test-worker/   a usable cwd for --cwd
+#   $TMPDIR_TEST/fake-claude                  the multi-subcommand fake `claude`
+#   $TMPDIR_TEST/registry.json                `claude agents --json` fixture
+#   $TMPDIR_TEST/bg-argv                      recorded argv of each --bg call
+#   $TMPDIR_TEST/pwd-log                      recorded spawn-subshell $PWD
+
+# --- Test 1: spawn success (diagnose-main) -----------------------------------
+
+echo "Test: dispatch-spawn-job spawns a /dispatch-diagnose-main background job"
+spawn_worker_setup
+write_fake_spawn_worker_claude
+# Point the job's own env override at the fake (the wrapper's env translation
+# is not in play here — the job is invoked directly).
+export DISPATCH_SPAWN_JOB_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+export DISPATCH_SPAWN_JOB_SESSION_ID="sess-self"
+SPAWN_JOB_CWD="$TMPDIR_TEST/worktrees/839-test-worker"
+SPAWN_CALLER_CWD="$TMPDIR_TEST/worktrees/main"
+if out=$( cd "$SPAWN_CALLER_CWD" && "$TMPDIR_TEST/scripts/dispatch-spawn-job" \
+    --name diagnose-main --cwd "$SPAWN_JOB_CWD" "/dispatch-diagnose-main abc123" 2>/dev/null ); then rc=0; else rc=$?; fi
+assert_eq "spawn-job: dispatch-spawn-job exits 0" "0" "$rc"
+assert_eq "spawn-job: stdout is 'spawned'" "spawned" "$out"
+mapfile -t sj_bg_argv < "$SPAWN_WORKER_BG_ARGV"
+assert_eq "spawn-job: argv[0] is --bg" "--bg" "${sj_bg_argv[0]:-}"
+assert_eq "spawn-job: argv[1] is --name" "--name" "${sj_bg_argv[1]:-}"
+assert_eq "spawn-job: argv[2] is the passed name" "diagnose-main" "${sj_bg_argv[2]:-}"
+assert_eq "spawn-job: argv[3] is --permission-mode" "--permission-mode" "${sj_bg_argv[3]:-}"
+assert_eq "spawn-job: argv[4] is auto" "auto" "${sj_bg_argv[4]:-}"
+assert_eq "spawn-job: argv[5] is the prompt" "/dispatch-diagnose-main abc123" "${sj_bg_argv[5]:-}"
+# The spawn subshell `cd`d into the passed --cwd, not the caller's cwd.
+sj_pwd_line=$(head -1 "$SPAWN_WORKER_PWD_LOG" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$(realpath "$sj_pwd_line" 2>/dev/null)" == "$(realpath "$SPAWN_JOB_CWD")" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: spawn-job: 'claude --bg' ran with cwd = the passed --cwd"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-job: 'claude --bg' ran with cwd = the passed --cwd"
+  echo "    pwd-log:  '$sj_pwd_line'"
+  echo "    expected: '$SPAWN_JOB_CWD'"
+fi
+spawn_worker_teardown
+
+# --- Test 2: spawn success (jit-reminder) ------------------------------------
+
+echo "Test: dispatch-spawn-job spawns a /dispatch-jit-reminder background job"
+spawn_worker_setup
+write_fake_spawn_worker_claude
+export DISPATCH_SPAWN_JOB_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+export DISPATCH_SPAWN_JOB_SESSION_ID="sess-self"
+SPAWN_JOB_CWD="$TMPDIR_TEST/worktrees/839-test-worker"
+jit_prompt="/dispatch-jit-reminder owner/repo 961 PVT_x ITEM_y"
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-job" \
+    --name jit-reminder-961 --cwd "$SPAWN_JOB_CWD" "$jit_prompt" 2>/dev/null ); then rc=0; else rc=$?; fi
+assert_eq "spawn-job-jit: dispatch-spawn-job exits 0" "0" "$rc"
+assert_eq "spawn-job-jit: stdout is 'spawned'" "spawned" "$out"
+mapfile -t sj_bg_argv < "$SPAWN_WORKER_BG_ARGV"
+assert_eq "spawn-job-jit: argv[0] is --bg" "--bg" "${sj_bg_argv[0]:-}"
+assert_eq "spawn-job-jit: argv[1] is --name" "--name" "${sj_bg_argv[1]:-}"
+assert_eq "spawn-job-jit: argv[2] is the passed name" "jit-reminder-961" "${sj_bg_argv[2]:-}"
+assert_eq "spawn-job-jit: argv[3] is --permission-mode" "--permission-mode" "${sj_bg_argv[3]:-}"
+assert_eq "spawn-job-jit: argv[4] is auto" "auto" "${sj_bg_argv[4]:-}"
+assert_eq "spawn-job-jit: argv[5] is the prompt" "$jit_prompt" "${sj_bg_argv[5]:-}"
+spawn_worker_teardown
+
+# --- Test 3: exact-name dedup ------------------------------------------------
+
+echo "Test: a pre-existing live session with the same name deduplicates the spawn"
+spawn_worker_setup
+# Prime the registry with a different sessionId whose name matches the name the
+# spawn would use. dispatch-spawn-job's dedup keys on name == <name>.
+printf '%s' \
+  '[{"sessionId":"sess-other","pid":4242,"cwd":"/job","kind":"background","status":"busy","name":"diagnose-main"}]' \
+  > "$SPAWN_WORKER_REGISTRY"
+write_fake_spawn_worker_claude
+export DISPATCH_SPAWN_JOB_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+export DISPATCH_SPAWN_JOB_SESSION_ID="sess-self"
+SPAWN_JOB_CWD="$TMPDIR_TEST/worktrees/839-test-worker"
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-job" \
+    --name diagnose-main --cwd "$SPAWN_JOB_CWD" "/dispatch-diagnose-main abc123" 2>/dev/null ); then rc=0; else rc=$?; fi
+assert_eq "spawn-job-dedup: dispatch-spawn-job exits 0" "0" "$rc"
+assert_eq "spawn-job-dedup: stdout is 'deduped' (name-keyed dedup hit)" "deduped" "$out"
+# No --bg invocation was recorded — nothing was spawned.
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$SPAWN_WORKER_BG_ARGV" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: spawn-job-dedup: no 'claude --bg' invocation recorded"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-job-dedup: no 'claude --bg' invocation recorded"
+  echo "    bg-argv: $(cat "$SPAWN_WORKER_BG_ARGV")"
+fi
+spawn_worker_teardown
+
+# --- Test 4: usage errors ----------------------------------------------------
+
+echo "Test: missing --name, --cwd, or <prompt> each exit 2"
+spawn_worker_setup
+write_fake_spawn_worker_claude
+export DISPATCH_SPAWN_JOB_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+SPAWN_JOB_CWD="$TMPDIR_TEST/worktrees/839-test-worker"
+
+# Sub-case A: missing --name
+if "$TMPDIR_TEST/scripts/dispatch-spawn-job" --cwd "$SPAWN_JOB_CWD" "/dispatch-diagnose-main abc" 2>/dev/null; then sj_rc_a=0; else sj_rc_a=$?; fi
+assert_eq "spawn-job-usage: missing --name → exit 2" "2" "$sj_rc_a"
+
+# Sub-case B: missing --cwd
+if "$TMPDIR_TEST/scripts/dispatch-spawn-job" --name diagnose-main "/dispatch-diagnose-main abc" 2>/dev/null; then sj_rc_b=0; else sj_rc_b=$?; fi
+assert_eq "spawn-job-usage: missing --cwd → exit 2" "2" "$sj_rc_b"
+
+# Sub-case C: missing <prompt>
+if "$TMPDIR_TEST/scripts/dispatch-spawn-job" --name diagnose-main --cwd "$SPAWN_JOB_CWD" 2>/dev/null; then sj_rc_c=0; else sj_rc_c=$?; fi
+assert_eq "spawn-job-usage: missing <prompt> → exit 2" "2" "$sj_rc_c"
+
+# Sub-case D: a --cwd that is not an existing directory
+if "$TMPDIR_TEST/scripts/dispatch-spawn-job" --name diagnose-main --cwd "$TMPDIR_TEST/worktrees/does-not-exist" "/dispatch-diagnose-main abc" 2>/dev/null; then sj_rc_d=0; else sj_rc_d=$?; fi
+assert_eq "spawn-job-usage: non-existent --cwd → exit 2" "2" "$sj_rc_d"
+
+# Sub-case E: an unexpected extra positional
+if "$TMPDIR_TEST/scripts/dispatch-spawn-job" --name diagnose-main --cwd "$SPAWN_JOB_CWD" "prompt-one" "prompt-two" 2>/dev/null; then sj_rc_e=0; else sj_rc_e=$?; fi
+assert_eq "spawn-job-usage: extra positional → exit 2" "2" "$sj_rc_e"
+
 spawn_worker_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -11650,8 +11650,8 @@ assert_eq "issue: decision line" "issue 707 1" "$(printf '%s\n' "$out" | tail -n
 assert_eq "issue: lock held" "select-tick-session" "$(cat "$DISPATCH_LOCK_FILE")"
 sel_tick_teardown
 
-# --- main-broken → passthrough + lock HELD (sub-skill releases) --------------
-echo "Test: select-tick main-broken → passthrough, lock held"
+# --- main-broken → passthrough + lock RELEASED (spawned as a bg job) ---------
+echo "Test: select-tick main-broken → passthrough, lock released"
 sel_tick_setup
 cat > "$TMPDIR_TEST/dispatch-select-target" <<FAKE
 #!/usr/bin/env bash
@@ -11662,12 +11662,12 @@ chmod +x "$TMPDIR_TEST/dispatch-select-target"
 out=$(run_sel_tick)
 assert_eq "main-broken: decision line" "main-broken abc1234" \
   "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "main-broken: lock held" "select-tick-session" \
+assert_eq "main-broken: lock released" "" \
   "$(cat "$DISPATCH_LOCK_FILE")"
 sel_tick_teardown
 
-# --- jit-reminder → passthrough + lock HELD ----------------------------------
-echo "Test: select-tick jit-reminder → passthrough, lock held"
+# --- jit-reminder → passthrough + lock RELEASED (spawned as a bg job) --------
+echo "Test: select-tick jit-reminder → passthrough, lock released"
 sel_tick_setup
 cat > "$TMPDIR_TEST/dispatch-select-target" <<FAKE
 #!/usr/bin/env bash
@@ -11678,7 +11678,7 @@ chmod +x "$TMPDIR_TEST/dispatch-select-target"
 out=$(run_sel_tick)
 assert_eq "jit-reminder: decision line" "jit-reminder owner/repo 42 PVT_x ITEM_y" \
   "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "jit-reminder: lock held" "select-tick-session" \
+assert_eq "jit-reminder: lock released" "" \
   "$(cat "$DISPATCH_LOCK_FILE")"
 sel_tick_teardown
 


### PR DESCRIPTION
Closes #981

Removes the last in-session model-decision seam from the `/dispatch-propagate`
router: the `main-broken` and `jit-reminder` outcomes now spawn their sub-skills
as their own `claude --bg` jobs instead of invoking them in the router's session.

## Unit 1 — generalized spawn primitive

New `dispatch-spawn-job --name <name> --cwd <cwd> <prompt>` extracts the
dedup → spawn → verify core of `dispatch-spawn-worker`, parameterized so it can
spawn any bg job. `dispatch-spawn-worker` becomes a thin validating wrapper that
`exec`s it (same `<issue-num> <worktree-path>` signature, all validation
retained, `DISPATCH_SPAWN_WORKER_*` env overrides translated to
`DISPATCH_SPAWN_JOB_*`). No behavior change on the worker path.

## Unit 2 — rewire the two outcomes

- `dispatch-select-tick` releases the dispatch lock on `main-broken` /
  `jit-reminder` (the spawned bg jobs run lock-free; the lock is strict
  self-release, so a fresh session could not release it anyway).
- SKILL.md Table 1: both rows now run `dispatch-spawn-job` (names `diagnose-main`
  and `jit-reminder-<num>`, chosen to avoid the `^[0-9]+-` busy-worker count
  shape and the `dispatch-*` router-dedup prefix) and self-close with `drain`
  dispositions — no in-session skill invocation remains.
- `dispatch-diagnose-main` / `dispatch-jit-reminder` reframed as spawned bg jobs;
  their lock-release steps removed. The `jit-reminder-<num>` per-item spawn name
  prevents a concurrent tick double-spawning; the In-Progress claim still
  prevents re-selection on later ticks.

## Tests

`test-dispatch-scripts.sh` covers the generalized spawn (success, exact-name
dedup, usage errors) for `diagnose-main` and `jit-reminder-961` prompts, the
wrapper→job delegation, and the select-tick lock-release on both outcomes. Full
suite: 1041/1041 green.