### PR TITLE
dispatch: explicit single-target /dispatch waits for in-progress CI

### DIFF
--- a/.claude/skills/dispatch-propagate/SKILL.md
+++ b/.claude/skills/dispatch-propagate/SKILL.md
@@ -109,7 +109,11 @@ for a fan-out run).
 | `resolve merge-conflict` | `origin/main` does not merge cleanly into the resolved worktree; `dispatch-merge-main` aborted the merge (tree left clean) and the script printed `issue:` / `worktree:` / `mode:` detail. Run the auto-resolve attempt (§2a). | `propagate` (resolved, after re-spawn) or `notify` (ambiguous) |
 | `notify spawn-failed` | `dispatch-spawn-worker` exited non-zero — a worker was spawned but did not register. | `notify` |
 | `drain worktree-conflict` | The target worktree cannot be safely entered (the script printed the `path:` detail): "worktree at `<path>` for issue `<N>` cannot be entered; closing — the next baton-pass or office-hours hand-off will re-seed". | `drain` |
-| `drain ci-waiting` | The target PR's CI is still in progress (the script printed the `#<N>:` line); echo it. | `drain` |
+| `drain ci-reseeded` | The target PR's CI is still in progress (the script printed the `#<N>:` line; echo it). A target-keyed reseed timer was scheduled, so the chain returns to `<N>` when its CI concludes: "waiting on #<N>'s CI; reseed scheduled". | `drain` |
+| `notify ci-wait-exhausted` | The CI-wait attempt cap was hit; the issue was parked on `dispatch:office-hours` and no further reseed will be scheduled: "#<N>'s CI did not conclude within the attempt cap; parked for review". | `notify` |
+
+> Fallback: if `dispatch-schedule-target-reseed` hard-fails, the single-target
+> path emits `drain ci-waiting` instead (route as `drain`); the reason is on stderr.
 
 #### Fan-out summary contract
 

--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -69,8 +69,10 @@ early-release window.
 
 `dispatch-materialize-spawn` releases at each terminal point: on the `propagate`
 path after `dispatch-spawn-worker` returns success (worker verified-registered),
-on `notify spawn-failed` after the failed spawn returns, and on `drain
-ci-waiting` at its stop.
+on `notify spawn-failed` after the failed spawn returns, and at the single-target
+CI-wait stop (now emitting `drain ci-reseeded` / `notify ci-wait-exhausted`, or
+`drain ci-waiting` on a scheduler hard-failure), which releases before scheduling
+the reseed.
 `dispatch-finalize-selection` writes the recovery marker but no longer releases.
 The pre-finalize stop paths — `notify target-blocked`, `resolve merge-conflict`,
 and `drain worktree-conflict`, plus the internal `exit 2` error paths — release
@@ -373,3 +375,22 @@ hand-off returns it to the dispatch chain and re-seeds from human action.
 A weekly fallback heartbeat for the edge case of a manual issue filed while
 the chain is stalled with no live session to receive it can be added in a
 follow-up if it matters in practice.
+
+## Target-keyed CI-wait reseed (#979)
+
+CI-wait handling splits on available queue size, not invocation mode. In a
+multi-item fan-out run (`--gap N>1`), a `ci-waiting` target is a `skipped`
+outcome: the loop moves on to the next ready priority, and other live workers'
+Stop-hooks bring the chain back to that target later. The single-target path —
+an explicit `/dispatch <N>`, or a `--gap 1` run whose only candidate is
+not-ready — has no "next". So instead of draining as a no-op, it calls
+`dispatch-schedule-target-reseed <N>`.
+
+That schedules a transient `systemd.user` timer
+(`dispatch-reseed-target-<N>-<fire>`) a short delay out that re-runs
+`dispatch-spawn-router <N>` → `/dispatch-propagate <N>`, returning the chain to
+N. A `dispatch:ci-wait-attempt-<n>` label on the PR counts the attempts; at the
+cap (default 3) the target is parked on `dispatch:office-hours` and no further
+reseed is scheduled. Because `dispatch-phase` returns `waiting` only for
+genuinely in-progress checks — a CI *failure* resolves to `verify`, an
+actionable phase — the wait terminates on its own when CI finishes.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -46,8 +46,22 @@
 #   drain worktree-conflict  the target worktree cannot be safely entered; the
 #                          lock is released at the guard. The conflict path
 #                          precedes this token.
-#   drain ci-waiting       the target PR's CI is still in progress; no spawn this
-#                          tick. Lock released at this stop.
+#   drain ci-reseeded      single-target path (#979): the target PR's CI is still
+#                          in progress; a target-keyed reseed timer was scheduled
+#                          via dispatch-schedule-target-reseed so the chain returns
+#                          to N when its CI concludes. Lock released at this stop
+#                          (before scheduling the reseed).
+#   notify ci-wait-exhausted single-target path (#979): the CI-wait attempt cap was
+#                          hit; the issue was parked on dispatch:office-hours and
+#                          no further reseed is scheduled. Lock released at this
+#                          stop.
+#   drain ci-waiting       single-target FALLBACK only: the target PR's CI is still
+#                          in progress but dispatch-schedule-target-reseed hard-
+#                          failed (or emitted unrecognized output), so the tick
+#                          drains as a no-op instead of wedging; the reason is on
+#                          stderr. Lock released at this stop. (In a fan-out run a
+#                          ci-waiting target is a `skipped` outcome — see below —
+#                          and the scheduler is never called.)
 #
 # Fan-out summary tokens (queue mode with --gap N>1; the last stdout line is one
 # of these instead of a per-target token):
@@ -70,7 +84,10 @@
 # release explicitly at the guard (the marker does not exist yet on these
 # pre-finalize stop paths). `propagate` and `notify spawn-failed` release AFTER
 # dispatch-spawn-worker returns (the worker is verified-registered on success).
-# `drain ci-waiting` releases at its stop. An internal `exit 2` failure before
+# The single-target ci-waiting stop (now `drain ci-reseeded` / `notify
+# ci-wait-exhausted`, or the fallback `drain ci-waiting` on a scheduler hard-
+# failure) releases the lock at its stop, BEFORE dispatch-schedule-target-reseed
+# is invoked. An internal `exit 2` failure before
 # dispatch-finalize-selection (a usage error, or a hard trace-leaf /
 # check-blockers / resolve-worktree error) also releases the lock so a stuck
 # holder does not wedge the next tick. Crash safety: a router that dies
@@ -134,6 +151,11 @@ OUTCOME=""
 CONFLICT_N=""
 CONFLICT_WORKTREE=""
 CONFLICT_MODE=""
+
+# Resolved ci-waiting target, surfaced by process_one_target when OUTCOME=ci-waiting.
+# The single-target driver passes it to dispatch-schedule-target-reseed — the
+# resolved `n` may differ from the passed-in `N` after an explicit leaf-trace.
+WAITING_N=""
 
 # process_one_target <issue-N> <explicit|queue>
 # Runs the per-target sequence (Step 4 guards, Step 5 resolve, Step 5b merge,
@@ -275,6 +297,7 @@ process_one_target() {
   PHASE=$("$SCRIPT_DIR/dispatch-phase" "$n") || PHASE=""
   if [[ "$PHASE" == "waiting" ]]; then
     echo "#$n: CI in progress; the next router tick will re-evaluate."
+    WAITING_N="$n"
     OUTCOME=ci-waiting
     return 0
   fi
@@ -309,7 +332,25 @@ if [[ "$MODE" == "explicit" ]] || (( GAP <= 1 )); then
       echo "resolve merge-conflict" ;;
     spawn-failed)      echo "notify spawn-failed" ;;
     worktree-conflict) echo "drain worktree-conflict" ;;
-    ci-waiting)        echo "drain ci-waiting" ;;
+    ci-waiting)
+      # Single-target path (#979): instead of draining as a no-op, schedule a
+      # target-keyed reseed so the chain returns to #$WAITING_N when its CI
+      # concludes — bounded by an attempt counter that dispatch-schedule-target-reseed
+      # escalates to dispatch:office-hours at the cap. The `#<N>: CI in progress`
+      # line was already printed inside process_one_target. A hard scheduler
+      # failure (or any unrecognized output) falls back to the plain `drain
+      # ci-waiting` so the tick never wedges; the reason is surfaced on stderr.
+      reseed_rc=0
+      reseed_out=$("$SCRIPT_DIR/dispatch-schedule-target-reseed" "$WAITING_N") || reseed_rc=$?
+      if (( reseed_rc == 0 )) && [[ "$reseed_out" == "escalated" ]]; then
+        echo "notify ci-wait-exhausted"
+      elif (( reseed_rc == 0 )) && [[ "$reseed_out" == reseeded\ * ]]; then
+        echo "drain ci-reseeded"
+      else
+        echo "dispatch-materialize-spawn: dispatch-schedule-target-reseed failed for #$WAITING_N (rc=$reseed_rc): $reseed_out" >&2
+        echo "drain ci-waiting"
+      fi
+      ;;
   esac
   exit 0
 fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-target-reseed
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-target-reseed
@@ -117,6 +117,15 @@ if [[ -z "$PR_NUM" ]]; then
   echo "error: dispatch-schedule-target-reseed: no PR found for issue #$N (this script is only valid for a ci-waiting target with a draft PR)" >&2
   exit 2
 fi
+# PR_NUM flows into the same `gh pr view/edit "$PR_NUM"` calls below that N is
+# guarded against above; a non-numeric, flag-like value would be parsed by gh as
+# an option rather than a PR number. find-pr emits a bare integer, so a
+# non-numeric result is a find-pr malfunction — fail closed rather than hand it
+# to gh.
+if [[ ! "$PR_NUM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: dispatch-schedule-target-reseed: dispatch-find-pr returned non-numeric PR '$PR_NUM' for issue #$N" >&2
+  exit 2
+fi
 
 # ---- Step 3: read the highest ci-wait-attempt counter -----------------------
 #

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-target-reseed
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-target-reseed
@@ -101,7 +101,7 @@ SYSTEMD_RUN_CMD="${DISPATCH_TARGET_RESEED_SYSTEMD_RUN_CMD:-systemd-run}"
 # Reject anything that is not a bare positive integer.
 
 N="${1:-}"
-if [[ -z "$N" || ! "$N" =~ ^[0-9]+$ ]]; then
+if [[ -z "$N" || ! "$N" =~ ^[1-9][0-9]*$ ]]; then
   echo "error: usage: dispatch-schedule-target-reseed <N> (N must be a positive integer)" >&2
   exit 2
 fi
@@ -262,6 +262,10 @@ err=$(cat "$RUN_STDERR")
 # substring rather than the full phrase.
 if [[ "$err" == *"already exists"* ]]; then
   echo "dispatch-schedule-target-reseed: $UNIT_NAME already scheduled; no-op" >&2
+  # Emit the same stdout token as a fresh schedule so the caller (dispatch-materialize-spawn)
+  # routes correctly: reseed_out matches "reseeded *" → "drain ci-reseeded" rather than
+  # falling through to the "drain ci-waiting" error fallback.
+  echo "reseeded $UNIT_NAME at $FIRE"
   exit 0
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-target-reseed
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-target-reseed
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# dispatch-schedule-target-reseed — schedule a target-keyed re-seed of the
+# /dispatch-propagate chain when an explicit single-target /dispatch <N> finds
+# its draft PR's CI still in progress.
+#
+# /dispatch <N> targets one explicit issue/PR — an effective queue of size one.
+# When N's PR has CI in progress, dispatch-phase returns `waiting` (an
+# in-progress, not-yet-actionable state). The multi-item queue handles this by
+# skipping the waiting PR and selecting the next ready priority — but the
+# single-target path has no "next", so skipping equals doing nothing and the
+# run silently drains. Instead of draining, this script schedules a transient
+# systemd.user timer that, after a short delay, re-runs `dispatch-spawn-router
+# <N>` — re-seeding `/dispatch-propagate <N>` so the chain returns to the target
+# when its CI completes (a CI *failure* resolves to `verify`, an actionable
+# phase, so the wait terminates on its own once CI concludes).
+#
+# The wait is bounded by an attempt counter — `dispatch:ci-wait-attempt-<n>`
+# labels on the PR — that escalates the target to `dispatch:office-hours` after
+# a cap, so a genuinely-hung CI does not reseed forever.
+#
+# Behavior, in order:
+#   1. Validate <N> is a positive integer (the ci-waiting target always has a
+#      draft PR). Reject empty / flag-like / non-numeric input → exit 2.
+#   2. Resolve the draft PR for N via dispatch-find-pr. No PR is a misuse for
+#      this script (the caller only invokes it for a ci-waiting target, which by
+#      definition has a draft PR) → stderr diagnostic + exit 2.
+#   3. Read the highest extant dispatch:ci-wait-attempt-<n> label on the PR →
+#      CUR (max // 0), via the verify-pr jq capture idiom.
+#   4. Cap check: if CUR >= CAP, park the ISSUE on dispatch:office-hours via
+#      dispatch-apply-office-hours, print `escalated`, schedule NO timer, exit 0.
+#   5. Otherwise (under cap): NEXT=CUR+1. Remove the prior counter label (if
+#      CUR>0) and apply dispatch:ci-wait-attempt-<NEXT> (apply-first /
+#      create-on-"not found"). A label failure warns but does NOT abort the
+#      reseed — the timer matters more than the bookkeeping label.
+#   6. Schedule a transient systemd.user timer at NOW+DELAY whose ExecStart is
+#      `dispatch-spawn-router <N>`. The unit name embeds N and the fire epoch —
+#      a repeated call with the same fire time collides on the unit name and
+#      systemd refuses to recreate, giving idempotency.
+#
+# Stdout protocol (exactly one line on the action paths):
+#   reseeded <unit> at <FIRE>   timer was scheduled.
+#   escalated                   cap hit; target parked on dispatch:office-hours.
+#
+# Exit codes:
+#   0  on a scheduled reseed, an escalate, or an idempotent already-exists no-op.
+#   2  on a bad <N>, a missing PR, or a bad env-integer override.
+#   non-zero — `systemd-run` failed for a reason other than the already-exists
+#              collision; the exit code is passed through.
+#
+# Environment overrides for testability:
+#
+#   DISPATCH_TARGET_RESEED_FIND_PR_CMD
+#     Override the dispatch-find-pr binary. Default: <script-dir>/dispatch-find-pr.
+#
+#   DISPATCH_TARGET_RESEED_GH_CMD
+#     Override the `gh` binary used for label reads/edits. Default: `gh`.
+#
+#   DISPATCH_TARGET_RESEED_OFFICE_HOURS_CMD
+#     Override the dispatch-apply-office-hours binary. Default:
+#     <script-dir>/dispatch-apply-office-hours.
+#
+#   DISPATCH_TARGET_RESEED_CAP
+#     Override the attempt cap (positive integer). Default: 3.
+#
+#   DISPATCH_TARGET_RESEED_NOW
+#     Override the current epoch seconds. Default: date +%s.
+#
+#   DISPATCH_TARGET_RESEED_DELAY
+#     Override the reseed delay in seconds. Default: 300.
+#
+#   DISPATCH_TARGET_RESEED_MAIN_WORKTREE
+#     Override the main worktree path. When set, the script does NOT require a
+#     git repo. Default: <project-root>/worktrees/main, where project-root is
+#     the parent of git --git-common-dir. Mirrors dispatch-schedule-reseed.
+#
+#   DISPATCH_TARGET_RESEED_SYSTEMD_RUN_CMD
+#     Override the `systemd-run` binary. Default: `systemd-run`.
+#
+# Sandbox: `systemd-run --user` talks to the user's systemd over D-Bus, and the
+# label reads/edits use `gh` (macOS Security-framework TLS); this script is not
+# sandbox-safe and callers must invoke it with `dangerouslyDisableSandbox: true`.
+
+set -uo pipefail
+
+# ---- Step 0: defaults & config ----------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+FIND_PR_CMD="${DISPATCH_TARGET_RESEED_FIND_PR_CMD:-$SCRIPT_DIR/dispatch-find-pr}"
+GH_CMD="${DISPATCH_TARGET_RESEED_GH_CMD:-gh}"
+OFFICE_HOURS_CMD="${DISPATCH_TARGET_RESEED_OFFICE_HOURS_CMD:-$SCRIPT_DIR/dispatch-apply-office-hours}"
+SYSTEMD_RUN_CMD="${DISPATCH_TARGET_RESEED_SYSTEMD_RUN_CMD:-systemd-run}"
+
+# ---- Step 1: validate <N> ---------------------------------------------------
+#
+# N is interpolated into the unit name, the ExecStart argv, and gh issue/PR
+# calls, and reaches `(( CUR >= CAP ))` indirectly only via the label read
+# below. A non-numeric, flag-like value (e.g. --repo other/repo) would be parsed
+# by gh as an option rather than an issue number, or by systemd as a flag.
+# Reject anything that is not a bare positive integer.
+
+N="${1:-}"
+if [[ -z "$N" || ! "$N" =~ ^[0-9]+$ ]]; then
+  echo "error: usage: dispatch-schedule-target-reseed <N> (N must be a positive integer)" >&2
+  exit 2
+fi
+
+# ---- Step 2: resolve the draft PR -------------------------------------------
+#
+# The caller only invokes this script for a ci-waiting target, which by
+# definition has a draft PR. An empty result is therefore a misuse, not a
+# recoverable condition — hard error.
+
+PR_NUM=$("$FIND_PR_CMD" "$N" 2>/dev/null || true)
+if [[ -z "$PR_NUM" ]]; then
+  echo "error: dispatch-schedule-target-reseed: no PR found for issue #$N (this script is only valid for a ci-waiting target with a draft PR)" >&2
+  exit 2
+fi
+
+# ---- Step 3: read the highest ci-wait-attempt counter -----------------------
+#
+# Same label-capture idiom as /verify-pr's verify-attempt counter, adapted to
+# the dispatch:ci-wait-attempt- prefix. `max // 0` yields 0 when no counter
+# label is present yet.
+
+CUR=$("$GH_CMD" pr view "$PR_NUM" --json labels \
+  --jq '[.labels[].name | capture("^dispatch:ci-wait-attempt-(?<n>[0-9]+)$").n | tonumber] | max // 0' \
+  2>/dev/null || true)
+
+# CUR feeds `(( CUR >= CAP ))` and `(( CUR > 0 ))` — bash arithmetic context
+# evaluates array-index command substitution, so any value entering `(( ))`
+# must be a literal integer. A label-read flake or tampered label set could
+# yield a non-integer; fail closed.
+if [[ ! "$CUR" =~ ^[0-9]+$ ]]; then
+  echo "error: dispatch-schedule-target-reseed: ci-wait attempt counter is not an integer, got '$CUR'; aborting" >&2
+  exit 2
+fi
+
+# ---- Step 4: cap check ------------------------------------------------------
+
+CAP="${DISPATCH_TARGET_RESEED_CAP:-3}"
+if [[ ! "$CAP" =~ ^[0-9]+$ ]] || (( CAP < 1 )); then
+  echo "error: dispatch-schedule-target-reseed: CAP must be a positive integer, got '$CAP'; aborting" >&2
+  exit 2
+fi
+
+if (( CUR >= CAP )); then
+  # Cap hit — park the ISSUE on a human and schedule no further reseed. A
+  # failure here is surfaced by dispatch-apply-office-hours (which warns and
+  # exits 0 on gh failures); we still report `escalated` since the wait is over.
+  "$OFFICE_HOURS_CMD" "$N" "CI has not concluded after $CAP reseed attempts" || true
+  echo "escalated"
+  exit 0
+fi
+
+# ---- Step 5: bump the attempt counter ---------------------------------------
+#
+# Apply-first / create-on-"not found" — the label may not exist yet on a fresh
+# repo. A gh label failure warns on stderr but does NOT abort the reseed: the
+# timer is the load-bearing side effect; the bookkeeping label is best-effort.
+
+NEXT=$(( CUR + 1 ))
+
+if (( CUR > 0 )); then
+  if ! rm_out=$("$GH_CMD" pr edit "$PR_NUM" --remove-label "dispatch:ci-wait-attempt-$CUR" 2>&1); then
+    echo "dispatch-schedule-target-reseed: warning: could not remove dispatch:ci-wait-attempt-$CUR from PR #$PR_NUM: $rm_out" >&2
+  fi
+fi
+
+if ! add_out=$("$GH_CMD" pr edit "$PR_NUM" --add-label "dispatch:ci-wait-attempt-$NEXT" 2>&1); then
+  if [[ "$add_out" != *"not found"* ]]; then
+    echo "dispatch-schedule-target-reseed: warning: could not apply dispatch:ci-wait-attempt-$NEXT to PR #$PR_NUM: $add_out" >&2
+  else
+    if ! create_out=$("$GH_CMD" label create "dispatch:ci-wait-attempt-$NEXT" \
+        --description "dispatch workflow: ci-wait reseed attempt $NEXT of $CAP" 2>&1); then
+      echo "dispatch-schedule-target-reseed: warning: could not create label dispatch:ci-wait-attempt-$NEXT: $create_out" >&2
+    elif ! retry_out=$("$GH_CMD" pr edit "$PR_NUM" --add-label "dispatch:ci-wait-attempt-$NEXT" 2>&1); then
+      echo "dispatch-schedule-target-reseed: warning: could not apply dispatch:ci-wait-attempt-$NEXT to PR #$PR_NUM after create: $retry_out" >&2
+    fi
+  fi
+fi
+
+# ---- Step 6: compute the fire time ------------------------------------------
+#
+# NOW and DELAY both reach `(( NOW + DELAY ))`; bash arithmetic context
+# evaluates array-index command substitution, so each must be a literal integer.
+# The defaults (`date +%s`, 300) are always safe; the env-override path is the
+# surface that requires validation.
+
+NOW="${DISPATCH_TARGET_RESEED_NOW:-$(date +%s)}"
+if [[ ! "$NOW" =~ ^[0-9]+$ ]]; then
+  echo "error: dispatch-schedule-target-reseed: NOW must be an integer epoch, got '$NOW'; aborting" >&2
+  exit 2
+fi
+
+DELAY="${DISPATCH_TARGET_RESEED_DELAY:-300}"
+if [[ ! "$DELAY" =~ ^[0-9]+$ ]]; then
+  echo "error: dispatch-schedule-target-reseed: DELAY must be an integer, got '$DELAY'; aborting" >&2
+  exit 2
+fi
+
+FIRE=$(( NOW + DELAY ))
+
+# ---- Step 7: resolve the main worktree --------------------------------------
+#
+# Same idiom as dispatch-schedule-reseed. The spawned re-seed runs from the
+# main worktree.
+
+if [[ -n "${DISPATCH_TARGET_RESEED_MAIN_WORKTREE:-}" ]]; then
+  MAIN_WORKTREE="$DISPATCH_TARGET_RESEED_MAIN_WORKTREE"
+else
+  PROJECT_ROOT=$(resolve_project_root) \
+    || { echo "dispatch-schedule-target-reseed: not in a git repo and DISPATCH_TARGET_RESEED_MAIN_WORKTREE is unset" >&2; exit 2; }
+  MAIN_WORKTREE="$PROJECT_ROOT/worktrees/main"
+fi
+
+# ---- Step 8: schedule the transient timer -----------------------------------
+#
+# The unit name embeds N and the epoch fire time — a repeated call with the same
+# (N, FIRE) collides, and systemd refuses to recreate the unit. That gives
+# idempotency without coordinating across callers.
+#
+# Persistent=true covers a WSL-down window that crosses fire time — a reseed
+# missed while WSL was down runs on the next start.
+#
+# ExecStart is dispatch-spawn-router with a trailing <N> arg — the optional
+# target that re-seeds `/dispatch-propagate <N>` so the chain returns to this
+# specific target when its CI completes.
+#
+# --setenv=PATH="$PATH" propagates the scheduling caller's PATH into the
+# transient unit. Without it the unit inherits the systemd user manager's
+# minimal default PATH, which omits the nix store — so on NixOS/WSL hosts
+# /usr/bin/env can't resolve bash (exit 127) and the router can't find
+# claude/git/jq. The caller (a /dispatch tick) always carries the full
+# nix-store PATH, so capturing it at schedule time makes the unit self-sufficient.
+
+UNIT_NAME="dispatch-reseed-target-${N}-${FIRE}"
+
+RUN_STDERR=$(mktemp)
+trap 'rm -f "$RUN_STDERR"' EXIT
+# Capture the exit code directly — after `if cmd; then ... fi`, `$?` is the
+# exit status of the `if` construct, NOT the exit code of `cmd`. Running `cmd`
+# outside an `if` and capturing `$?` immediately preserves the real exit code so
+# the "pass-through on unexpected failure" contract holds.
+"$SYSTEMD_RUN_CMD" --user \
+     --unit="$UNIT_NAME" \
+     --on-calendar="@$FIRE" \
+     --working-directory="$MAIN_WORKTREE" \
+     --timer-property=Persistent=true \
+     --setenv=PATH="$PATH" \
+     "$MAIN_WORKTREE/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-router" "$N" \
+     2>"$RUN_STDERR"
+RC=$?
+if (( RC == 0 )); then
+  echo "reseeded $UNIT_NAME at $FIRE"
+  exit 0
+fi
+
+err=$(cat "$RUN_STDERR")
+# systemd's already-exists message varies slightly across versions. Match on the
+# substring rather than the full phrase.
+if [[ "$err" == *"already exists"* ]]; then
+  echo "dispatch-schedule-target-reseed: $UNIT_NAME already scheduled; no-op" >&2
+  exit 0
+fi
+
+# Some other failure — surface stderr and pass the exit code through.
+echo "$err" >&2
+exit "$RC"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-router
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-router
@@ -17,8 +17,12 @@
 #                 re-seeds the chain if a rate-limit cap-stall actually
 #                 dropped it.
 #   2. Spawn    — `claude --bg --name dispatch-<short-id> --permission-mode
-#                 auto "/dispatch-propagate"`, cwd = the main worktree (where every
-#                 /dispatch-propagate job is started).
+#                 auto "/dispatch-propagate"` (or "/dispatch-propagate <N>" when an
+#                 optional target <N> is given), cwd = the main worktree (where every
+#                 /dispatch-propagate job is started). An optional first positional <N>
+#                 (a positive integer) makes the spawned router target-keyed — the
+#                 #979 CI-wait reseed timer's ExecStart passes <N> so the chain
+#                 returns to that specific target when its CI concludes.
 #   3. Verify   — re-query the registry with a bounded retry (5 × 200 ms via
 #                 `verify_agent_registered_under`) to absorb the async-
 #                 registration race; confirm the new agent registered.
@@ -36,8 +40,9 @@
 # Exit codes:
 #   0  deduped or spawned (stdout disambiguates).
 #   1  the successor never registered in 'claude agents --json' — see stderr.
-#   2  the script cannot operate — an unexpected command-line argument, or not
-#      in a git repo with DISPATCH_SPAWN_ROUTER_MAIN_WORKTREE unset.
+#   2  the script cannot operate — a malformed target argument (non-numeric, or
+#      more than one), or not in a git repo with DISPATCH_SPAWN_ROUTER_MAIN_WORKTREE
+#      unset.
 #
 # Environment overrides for testability (mirroring dispatch-acquire-lock's
 # DISPATCH_LOCK_* and lib-claude-agents.sh's CLAUDE_AGENTS_CMD):
@@ -61,10 +66,24 @@
 # dispatch-sweep).
 set -uo pipefail
 
-# ---- Step 0: reject unexpected arguments ------------------------------------
-if [[ $# -gt 0 ]]; then
-  echo "dispatch-spawn-router: unknown argument '$1'" >&2
+# ---- Step 0: parse the optional target argument -----------------------------
+# An optional first positional <N> (a positive integer) makes the spawned
+# router target-keyed: it runs "/dispatch-propagate <N>" instead of the bare
+# "/dispatch-propagate". The #979 CI-wait reseed timer's ExecStart passes <N>
+# so the chain returns to that specific target when its CI concludes. Reject a
+# non-numeric/flag-like value or any extra argument with exit 2 — a malformed
+# value would otherwise be interpolated into the spawned prompt.
+TARGET_N=""
+if [[ $# -gt 1 ]]; then
+  echo "dispatch-spawn-router: too many arguments (expected at most one target <N>)" >&2
   exit 2
+fi
+if [[ $# -eq 1 ]]; then
+  if [[ ! "$1" =~ ^[0-9]+$ ]]; then
+    echo "dispatch-spawn-router: target must be a positive integer, got '$1'" >&2
+    exit 2
+  fi
+  TARGET_N="$1"
 fi
 
 # ---- Step 1: resolve config -------------------------------------------------
@@ -126,12 +145,18 @@ done <<<"$sessions"
 # one new dispatch agent at a time, so ~30 bits is ample.
 SHORT_ID=$(printf '%04x%04x' "$RANDOM" "$RANDOM")
 AGENT_NAME="dispatch-$SHORT_ID"
+# Build the prompt — target-keyed when TARGET_N is set, bare otherwise.
+if [[ -n "$TARGET_N" ]]; then
+  PROPAGATE_PROMPT="/dispatch-propagate $TARGET_N"
+else
+  PROPAGATE_PROMPT="/dispatch-propagate"
+fi
 # Capture the spawn's combined output so a failure diagnostic can surface why
 # (`cd` failed, `claude` missing, `--bg` rejected). `|| true` keeps a non-zero
 # spawn from aborting the script — Step 4's registry check is the source of
 # truth for whether the agent actually came up.
 spawn_output=$( ( cd "$MAIN_WORKTREE" && "$CLAUDE_CMD" --bg --name "$AGENT_NAME" \
-    --permission-mode auto "/dispatch-propagate" ) 2>&1 ) || true
+    --permission-mode auto "$PROPAGATE_PROMPT" ) 2>&1 ) || true
 
 # ---- Step 4: verify the new agent registered -------------------------------
 if verify_agent_registered_under "$AGENT_NAME" "$MAIN_WORKTREE"; then

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-router
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-router
@@ -79,7 +79,7 @@ if [[ $# -gt 1 ]]; then
   exit 2
 fi
 if [[ $# -eq 1 ]]; then
-  if [[ ! "$1" =~ ^[0-9]+$ ]]; then
+  if [[ ! "$1" =~ ^[1-9][0-9]*$ ]]; then
     echo "dispatch-spawn-router: target must be a positive integer, got '$1'" >&2
     exit 2
   fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -12056,6 +12056,12 @@ echo "\$*" >> "$TMPDIR_TEST/logs/spawn-worker.log"
 echo spawned
 exit \${MAT_SPAWN_RC:-0}
 FAKE
+  cat > "$TMPDIR_TEST/dispatch-schedule-target-reseed" <<FAKE
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/schedule-target-reseed.log"
+printf '%s\n' "\${MAT_RESEED_OUT:-reseeded dispatch-reseed-target-\$1-10300 at 10300}"
+exit \${MAT_RESEED_RC:-0}
+FAKE
   cat > "$TMPDIR_TEST/sync-issue-context" <<FAKE
 #!/usr/bin/env bash
 echo "cwd=\$PWD argv=\$*" >> "$TMPDIR_TEST/logs/sync-issue-context.log"
@@ -12064,7 +12070,8 @@ FAKE
     "$TMPDIR_TEST"/dispatch-check-blockers "$TMPDIR_TEST"/dispatch-apply-office-hours \
     "$TMPDIR_TEST"/dispatch-resolve-worktree "$TMPDIR_TEST"/dispatch-merge-main \
     "$TMPDIR_TEST"/dispatch-phase "$TMPDIR_TEST"/dispatch-select-target \
-    "$TMPDIR_TEST"/dispatch-spawn-worker "$TMPDIR_TEST"/sync-issue-context
+    "$TMPDIR_TEST"/dispatch-spawn-worker "$TMPDIR_TEST"/dispatch-schedule-target-reseed \
+    "$TMPDIR_TEST"/sync-issue-context
 
   mkdir -p "$TMPDIR_TEST/project/.bare" "$TMPDIR_TEST/project/worktrees"
   cat > "$TMPDIR_TEST/bin/git" <<STUB
@@ -12095,7 +12102,8 @@ mat_teardown() {
   TMPDIR_TEST="" ; STUB_DIR=""
   unset DISPATCH_LOCK_FILE CLAUDE_CODE_SESSION_ID CLAUDE_AGENTS_CMD \
     MAT_PR MAT_LEAF MAT_BLOCKED MAT_WT_DECISION MAT_MERGE_RC MAT_PHASE \
-    MAT_SPAWN_RC MAT_ISSUE_STATE MAT_QUEUE MAT_MERGE_CONFLICT_N
+    MAT_SPAWN_RC MAT_ISSUE_STATE MAT_QUEUE MAT_MERGE_CONFLICT_N \
+    MAT_RESEED_OUT MAT_RESEED_RC
 }
 
 run_mat() { "$TMPDIR_TEST/dispatch-materialize-spawn" "$@" 2>/dev/null; }
@@ -12335,18 +12343,54 @@ assert_eq "merge clean: dispatch-merge-main was called" "1" \
   "$([ -f "$TMPDIR_TEST/logs/merge-main.log" ] && echo 1 || echo 0)"
 mat_teardown
 
-# --- waiting CI → drain ci-waiting -------------------------------------------
-echo "Test: materialize-spawn waiting CI → drain ci-waiting"
+# --- single-target waiting CI → reseed scheduled → drain ci-reseeded (#979) ---
+echo "Test: materialize-spawn single-target waiting CI → drain ci-reseeded (reseed scheduled)"
 mat_setup
 export MAT_PHASE=waiting
 out=$(run_mat 839 queue)
-assert_eq "ci-waiting: CI line present" "#839: CI in progress; the next router tick will re-evaluate." \
+assert_eq "ci-reseeded: CI line still present" "#839: CI in progress; the next router tick will re-evaluate." \
   "$(printf '%s\n' "$out" | grep '^#839:')"
-assert_eq "ci-waiting: terminal token" "drain ci-waiting" \
+assert_eq "ci-reseeded: terminal token" "drain ci-reseeded" \
   "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "ci-waiting: no spawn" "0" \
+assert_eq "ci-reseeded: scheduler called with target" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-target-reseed.log" ] && grep -qx '839' "$TMPDIR_TEST/logs/schedule-target-reseed.log" && echo 1 || echo 0)"
+assert_eq "ci-reseeded: no spawn" "0" \
   "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
-assert_eq "ci-waiting: lock released at ci-waiting stop" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "ci-reseeded: lock released at stop" "" "$(cat "$DISPATCH_LOCK_FILE")"
+mat_teardown
+
+# --- single-target waiting CI → attempt cap → notify ci-wait-exhausted (#979) -
+echo "Test: materialize-spawn single-target waiting CI at cap → notify ci-wait-exhausted"
+mat_setup
+export MAT_PHASE=waiting
+export MAT_RESEED_OUT=escalated
+out=$(run_mat 839 queue)
+assert_eq "ci-exhausted: terminal token" "notify ci-wait-exhausted" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "ci-exhausted: scheduler called with target" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-target-reseed.log" ] && grep -qx '839' "$TMPDIR_TEST/logs/schedule-target-reseed.log" && echo 1 || echo 0)"
+assert_eq "ci-exhausted: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+assert_eq "ci-exhausted: lock released at stop" "" "$(cat "$DISPATCH_LOCK_FILE")"
+mat_teardown
+
+# --- fan-out unchanged: ci-waiting target is skipped, scheduler NOT called -----
+# Multi-item fan-out (--gap N>1) must keep the pre-#979 behavior: a ci-waiting
+# target is a `skipped` outcome and the scheduler is never invoked (other live
+# workers' Stop-hooks bring the chain back to the target later).
+echo "Test: materialize-spawn fan-out ci-waiting target skipped, scheduler not called (#979)"
+mat_setup
+export MAT_PHASE=waiting
+export MAT_QUEUE="840 841"
+out=$(run_mat 839 queue --gap 3)
+assert_eq "fanout-ci-waiting: skip detail present" "1" \
+  "$(printf '%s\n' "$out" | grep -c 'skipped #839 (ci-waiting)')"
+assert_eq "fanout-ci-waiting: terminal token" "drain" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "fanout-ci-waiting: scheduler NOT called" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-target-reseed.log" ] && echo 1 || echo 0)"
+assert_eq "fanout-ci-waiting: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
 mat_teardown
 
 # --- --gap 1 → propagate (single target, default behavior) -------------------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6814,6 +6814,35 @@ else
 fi
 tr_teardown
 
+# --- Test 6: already-exists idempotency → exit 0, stdout 'reseeded …' ---------
+# A repeated call within the same fire-window produces the same UNIT_NAME; systemd
+# refuses to recreate it. The script must still print the 'reseeded' stdout line so
+# dispatch-materialize-spawn routes to 'drain ci-reseeded' and not the error fallback.
+
+echo "Test: already-exists collision → exit 0 and stdout 'reseeded ...'"
+tr_setup
+export FAKE_CUR_ATTEMPT=0
+# Replace the systemd-run stub with one that simulates the already-exists collision.
+cat > "$TMPDIR_TEST/bin/systemd-run" <<STUB
+#!/usr/bin/env bash
+echo "Unit dispatch-reseed-target-979-10300.timer already exists." >&2
+exit 1
+STUB
+chmod +x "$TMPDIR_TEST/bin/systemd-run"
+if out=$("$TMPDIR_TEST/scripts/dispatch-schedule-target-reseed" 979 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "already-exists: exits 0" "0" "$rc"
+assert_eq "already-exists: stdout is reseeded line" \
+  "reseeded dispatch-reseed-target-979-10300 at 10300" "$out"
+err=$(cat "$TMPDIR_TEST/stderr")
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"already scheduled"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: already-exists: stderr notes already-scheduled"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: already-exists: stderr notes already-scheduled"
+  echo "    stderr: $err"
+fi
+tr_teardown
+
 # ============================================================================
 # dispatch project-helper tests (item-add / status-read / status-write)
 # ============================================================================
@@ -12391,6 +12420,24 @@ assert_eq "fanout-ci-waiting: scheduler NOT called" "0" \
   "$([ -f "$TMPDIR_TEST/logs/schedule-target-reseed.log" ] && echo 1 || echo 0)"
 assert_eq "fanout-ci-waiting: no spawn" "0" \
   "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- single-target waiting CI → scheduler fails → fallback drain ci-waiting ----
+# When dispatch-schedule-target-reseed exits non-zero (e.g. systemd-run fails for
+# a reason other than 'already exists'), materialize-spawn must fall back to the
+# plain 'drain ci-waiting' token so the tick never wedges.
+echo "Test: materialize-spawn single-target waiting CI scheduler failure → drain ci-waiting fallback"
+mat_setup
+export MAT_PHASE=waiting
+export MAT_RESEED_RC=1
+out=$(run_mat 839 queue)
+assert_eq "ci-wait-fallback: terminal token is drain ci-waiting" "drain ci-waiting" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "ci-wait-fallback: scheduler was called" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-target-reseed.log" ] && grep -qx '839' "$TMPDIR_TEST/logs/schedule-target-reseed.log" && echo 1 || echo 0)"
+assert_eq "ci-wait-fallback: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+assert_eq "ci-wait-fallback: lock released at stop" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
 # --- --gap 1 → propagate (single target, default behavior) -------------------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -12388,6 +12388,24 @@ assert_eq "ci-reseeded: no spawn" "0" \
 assert_eq "ci-reseeded: lock released at stop" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
+# --- explicit-mode waiting CI → reseed scheduled → drain ci-reseeded (#979) ----
+# The headline `/dispatch <N>` path is MODE=explicit. The reseed test above runs
+# MODE=queue and so enters the single-target branch via the `GAP <= 1` disjunct;
+# this test exercises the other disjunct (`MODE == explicit`) directly, confirming
+# an explicit single target also schedules the target-keyed reseed.
+echo "Test: materialize-spawn explicit-mode waiting CI → drain ci-reseeded (reseed scheduled)"
+mat_setup
+export MAT_PHASE=waiting
+out=$(run_mat 839 explicit)
+assert_eq "explicit-ci-reseeded: terminal token" "drain ci-reseeded" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "explicit-ci-reseeded: scheduler called with target" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-target-reseed.log" ] && grep -qx '839' "$TMPDIR_TEST/logs/schedule-target-reseed.log" && echo 1 || echo 0)"
+assert_eq "explicit-ci-reseeded: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+assert_eq "explicit-ci-reseeded: lock released at stop" "" "$(cat "$DISPATCH_LOCK_FILE")"
+mat_teardown
+
 # --- single-target waiting CI → attempt cap → notify ci-wait-exhausted (#979) -
 echo "Test: materialize-spawn single-target waiting CI at cap → notify ci-wait-exhausted"
 mat_setup

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6814,6 +6814,25 @@ else
 fi
 tr_teardown
 
+# --- Test 5b: non-numeric PR from find-pr → exit 2, no timer ------------------
+# PR_NUM flows into the same `gh pr view/edit "$PR_NUM"` calls N is guarded
+# against; a flag-like find-pr result must fail closed rather than reach gh.
+
+echo "Test: non-numeric PR (find-pr returns a flag) exits 2 with no timer"
+tr_setup
+export FAKE_PR_NUM="--repo evil/repo"
+if out=$("$TMPDIR_TEST/scripts/dispatch-schedule-target-reseed" 979 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "non-numeric PR exits 2" "2" "$rc"
+err=$(cat "$TMPDIR_TEST/stderr")
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"non-numeric PR"* && ! -s "$TMPDIR_TEST/systemd-log" && ! -s "$TMPDIR_TEST/gh-edit-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-numeric PR; stderr diagnostic + no timer / no label edit"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-numeric PR; stderr diagnostic + no timer / no label edit"
+  echo "    stderr: $err"
+fi
+tr_teardown
+
 # --- Test 6: already-exists idempotency → exit 0, stdout 'reseeded …' ---------
 # A repeated call within the same fire-window produces the same UNIT_NAME; systemd
 # refuses to recreate it. The script must still print the 'reseeded' stdout line so

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -7159,6 +7159,48 @@ else
 fi
 spawn_router_teardown
 
+# --- Test 8: an explicit target makes the spawn target-keyed ------------------
+
+echo "Test: an explicit target <N> spawns '/dispatch-propagate <N>'"
+spawn_router_setup
+write_fake_spawn_router_claude
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-router" 979 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "target: dispatch-spawn-router exits 0" "0" "$rc"
+assert_eq "target: stdout is 'spawned'" "spawned" "$out"
+# The final argv element is the target-keyed prompt rather than the bare form.
+mapfile -t bg_argv < "$SPAWN_ROUTER_BG_ARGV"
+assert_eq "target: argv[5] is '/dispatch-propagate 979'" "/dispatch-propagate 979" "${bg_argv[5]:-}"
+spawn_router_teardown
+
+# --- Test 9: the no-arg path still spawns the bare prompt --------------------
+
+echo "Test: no target argument still spawns the bare '/dispatch-propagate'"
+spawn_router_setup
+write_fake_spawn_router_claude
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-router" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "no-target: dispatch-spawn-router exits 0" "0" "$rc"
+assert_eq "no-target: stdout is 'spawned'" "spawned" "$out"
+mapfile -t bg_argv < "$SPAWN_ROUTER_BG_ARGV"
+assert_eq "no-target: argv[5] is the bare '/dispatch-propagate'" "/dispatch-propagate" "${bg_argv[5]:-}"
+spawn_router_teardown
+
+# --- Test 10: a non-numeric target argument is rejected ----------------------
+
+echo "Test: a non-numeric target argument exits 2 and spawns nothing"
+spawn_router_setup
+write_fake_spawn_router_claude
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-spawn-router" --repo 2>&1 1>/dev/null) || rc=$?
+assert_eq "bad-target: dispatch-spawn-router exits 2" "2" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$SPAWN_ROUTER_BG_ARGV" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: bad-target: no 'claude --bg' invocation recorded"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: bad-target: no 'claude --bg' invocation recorded"
+  echo "    bg-argv: $(cat "$SPAWN_ROUTER_BG_ARGV")"
+fi
+spawn_router_teardown
+
 # ============================================================================
 # dispatch-spawn-worker tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6608,6 +6608,213 @@ fi
 sr_teardown
 
 # ============================================================================
+# dispatch-schedule-target-reseed tests
+# ============================================================================
+#
+# Exercises the target-keyed CI-wait reseed: under-cap reseed bumps the
+# dispatch:ci-wait-attempt counter and schedules a transient timer whose
+# ExecStart re-runs dispatch-spawn-router <N>; at-cap escalates to
+# dispatch:office-hours and schedules no timer; bad <N> / missing PR are misuse.
+#
+# Each test gets a fresh tmp tree:
+#   $TMPDIR_TEST/scripts/      copy of dispatch-schedule-target-reseed + lib.sh
+#   $TMPDIR_TEST/bin/          systemd-run stub
+#   $TMPDIR_TEST/systemd-log   recorded systemd-run argv (one line per call)
+#   $TMPDIR_TEST/gh-edit-log   recorded fake-gh pr-edit / label-create argv
+#   $TMPDIR_TEST/oh-log        recorded fake dispatch-apply-office-hours argv
+#   $TMPDIR_TEST/main/         a synthetic main worktree path
+echo ""
+echo "=== dispatch-schedule-target-reseed ==="
+
+tr_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/bin" "$TMPDIR_TEST/main"
+
+  cp "$SCRIPT_DIR/dispatch-schedule-target-reseed" \
+    "$TMPDIR_TEST/scripts/dispatch-schedule-target-reseed"
+  # The script sources lib.sh via its SCRIPT_DIR — so lib.sh must sit alongside.
+  cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/lib.sh"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-schedule-target-reseed"
+
+  export DISPATCH_TARGET_RESEED_MAIN_WORKTREE="$TMPDIR_TEST/main"
+  export DISPATCH_TARGET_RESEED_NOW=10000
+  export DISPATCH_TARGET_RESEED_DELAY=300
+  export DISPATCH_TARGET_RESEED_CAP=3
+
+  # systemd-run stub: records its argv (one line per call), exits 0.
+  cat > "$TMPDIR_TEST/bin/systemd-run" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/systemd-log"
+STUB
+  chmod +x "$TMPDIR_TEST/bin/systemd-run"
+  export DISPATCH_TARGET_RESEED_SYSTEMD_RUN_CMD="$TMPDIR_TEST/bin/systemd-run"
+
+  # fake gh: `pr view ... --jq ...` echoes the test-controlled current attempt
+  # count ($FAKE_CUR_ATTEMPT, default 0 — the script consumes the jq result as
+  # the integer counter). `pr edit` / `label create` record their argv to a log
+  # and exit 0.
+  cat > "$TMPDIR_TEST/bin/fake-gh" <<STUB
+#!/usr/bin/env bash
+if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
+  echo "\${FAKE_CUR_ATTEMPT:-0}"
+  exit 0
+fi
+echo "\$*" >> "$TMPDIR_TEST/gh-edit-log"
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/fake-gh"
+  export DISPATCH_TARGET_RESEED_GH_CMD="$TMPDIR_TEST/bin/fake-gh"
+
+  # fake dispatch-find-pr: echoes a fixed PR number.
+  cat > "$TMPDIR_TEST/bin/fake-find-pr" <<STUB
+#!/usr/bin/env bash
+# Default 1234 only when FAKE_PR_NUM is unset — a set-but-empty value echoes
+# nothing, modelling the no-PR case.
+echo "\${FAKE_PR_NUM-1234}"
+STUB
+  chmod +x "$TMPDIR_TEST/bin/fake-find-pr"
+  export DISPATCH_TARGET_RESEED_FIND_PR_CMD="$TMPDIR_TEST/bin/fake-find-pr"
+
+  # fake dispatch-apply-office-hours: records its argv to a log, exits 0.
+  cat > "$TMPDIR_TEST/bin/fake-oh" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/oh-log"
+STUB
+  chmod +x "$TMPDIR_TEST/bin/fake-oh"
+  export DISPATCH_TARGET_RESEED_OFFICE_HOURS_CMD="$TMPDIR_TEST/bin/fake-oh"
+}
+
+tr_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  unset DISPATCH_TARGET_RESEED_MAIN_WORKTREE
+  unset DISPATCH_TARGET_RESEED_NOW
+  unset DISPATCH_TARGET_RESEED_DELAY
+  unset DISPATCH_TARGET_RESEED_CAP
+  unset DISPATCH_TARGET_RESEED_SYSTEMD_RUN_CMD
+  unset DISPATCH_TARGET_RESEED_GH_CMD
+  unset DISPATCH_TARGET_RESEED_FIND_PR_CMD
+  unset DISPATCH_TARGET_RESEED_OFFICE_HOURS_CMD
+  unset FAKE_CUR_ATTEMPT
+  unset FAKE_PR_NUM
+}
+
+# --- Test 1: under-cap reseed (CUR=0 → 1) ------------------------------------
+
+echo "Test: under-cap reseed (CUR=0) schedules a timer and applies attempt-1"
+tr_setup
+export FAKE_CUR_ATTEMPT=0
+if out=$("$TMPDIR_TEST/scripts/dispatch-schedule-target-reseed" 979 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "under-cap reseed exits 0" "0" "$rc"
+assert_eq "under-cap reseed stdout names the unit + fire" \
+  "reseeded dispatch-reseed-target-979-10300 at 10300" "$out"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$log" == *"--unit=dispatch-reseed-target-979-10300"* \
+   && "$log" == *"--on-calendar=@10300"* \
+   && "$log" == *"--working-directory=$TMPDIR_TEST/main"* \
+   && "$log" == *"--setenv=PATH="* \
+   && "$log" == *"dispatch-spawn-router 979"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: under-cap systemd-run argv (unit + calendar + cwd + setenv + spawn-router 979)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: under-cap systemd-run argv (unit + calendar + cwd + setenv + spawn-router 979)"
+  echo "    log: $log"
+fi
+edits=$(cat "$TMPDIR_TEST/gh-edit-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$edits" == *"--add-label dispatch:ci-wait-attempt-1"* \
+   && "$edits" != *"--remove-label"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: under-cap applies attempt-1 with no remove (CUR was 0)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: under-cap applies attempt-1 with no remove (CUR was 0)"
+  echo "    edits: $edits"
+fi
+tr_teardown
+
+# --- Test 2: counter bump (CUR=1 → 2) ----------------------------------------
+
+echo "Test: counter bump (CUR=1) removes attempt-1, applies attempt-2, schedules timer"
+tr_setup
+export FAKE_CUR_ATTEMPT=1
+if out=$("$TMPDIR_TEST/scripts/dispatch-schedule-target-reseed" 979 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "counter-bump exits 0" "0" "$rc"
+assert_eq "counter-bump stdout names the unit + fire" \
+  "reseeded dispatch-reseed-target-979-10300 at 10300" "$out"
+edits=$(cat "$TMPDIR_TEST/gh-edit-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$edits" == *"--remove-label dispatch:ci-wait-attempt-1"* \
+   && "$edits" == *"--add-label dispatch:ci-wait-attempt-2"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: counter-bump removes attempt-1 and adds attempt-2"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: counter-bump removes attempt-1 and adds attempt-2"
+  echo "    edits: $edits"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ -s "$TMPDIR_TEST/systemd-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: counter-bump schedules a timer"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: counter-bump schedules a timer"
+fi
+tr_teardown
+
+# --- Test 3: at cap (CUR == CAP = 3) → escalate, no timer --------------------
+
+echo "Test: at cap (CUR==CAP) escalates to office-hours and schedules no timer"
+tr_setup
+export FAKE_CUR_ATTEMPT=3
+export DISPATCH_TARGET_RESEED_CAP=3
+if out=$("$TMPDIR_TEST/scripts/dispatch-schedule-target-reseed" 979 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "at-cap exits 0" "0" "$rc"
+assert_eq "at-cap stdout is 'escalated'" "escalated" "$out"
+oh=$(cat "$TMPDIR_TEST/oh-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$oh" == "979 "* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: at-cap office-hours fake records 979 as arg1"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: at-cap office-hours fake records 979 as arg1"
+  echo "    oh-log: $oh"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -s "$TMPDIR_TEST/systemd-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: at-cap schedules no timer"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: at-cap schedules no timer"
+  echo "    log: $(cat "$TMPDIR_TEST/systemd-log")"
+fi
+tr_teardown
+
+# --- Test 4: bad <N> (flag-like) → exit 2, no side effects -------------------
+
+echo "Test: flag-like <N> exits 2 with no timer and no side effects"
+tr_setup
+if out=$("$TMPDIR_TEST/scripts/dispatch-schedule-target-reseed" --repo 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "flag-like <N> exits 2" "2" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -s "$TMPDIR_TEST/systemd-log" && ! -s "$TMPDIR_TEST/gh-edit-log" && ! -s "$TMPDIR_TEST/oh-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: flag-like <N>; no timer / no label edit / no escalate"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: flag-like <N>; no timer / no label edit / no escalate"
+fi
+tr_teardown
+
+# --- Test 5: missing PR → exit 2, no timer -----------------------------------
+
+echo "Test: missing PR (find-pr empty) exits 2 with no timer"
+tr_setup
+export FAKE_PR_NUM=""
+if out=$("$TMPDIR_TEST/scripts/dispatch-schedule-target-reseed" 979 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "missing PR exits 2" "2" "$rc"
+err=$(cat "$TMPDIR_TEST/stderr")
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"no PR found for issue #979"* && ! -s "$TMPDIR_TEST/systemd-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: missing PR; stderr diagnostic + no timer"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: missing PR; stderr diagnostic + no timer"
+  echo "    stderr: $err"
+fi
+tr_teardown
+
+# ============================================================================
 # dispatch project-helper tests (item-add / status-read / status-write)
 # ============================================================================
 #


### PR DESCRIPTION
Closes #979

## Summary

`/dispatch <N>` targets one explicit issue/PR — an effective queue of size one. When that target's PR has CI in progress, `dispatch-phase <N>` returns `waiting` and the single-target driver emitted `drain ci-waiting`: the run self-closed without spawning a worker and nothing returned to the target (a silent no-op, reproduced on `/dispatch 961` and `/dispatch 829`). Multi-item queue mode already skips a `waiting` PR and picks the next ready priority — but the single-target path has no "next", so skipping equals doing nothing.

This makes the single-target path **wait** for its CI instead of draining: it schedules a target-keyed reseed timer that re-runs `/dispatch-propagate <N>` after a short delay, bounded by an attempt counter that escalates to `dispatch:office-hours` after a cap.

## Changes (three units)

- **Unit 1 — `dispatch-spawn-router`:** accepts an optional positive-integer target `<N>` and spawns `/dispatch-propagate <N>` (target-keyed) instead of the bare router. No-arg path unchanged.
- **Unit 2 — `dispatch-schedule-target-reseed <N>` (new):** resolves N's draft PR, reads/bumps a `dispatch:ci-wait-attempt-<n>` label, and schedules a transient `systemd.user` timer (`dispatch-reseed-target-<N>-<fire>`) whose ExecStart is `dispatch-spawn-router <N>` (`--setenv=PATH` + `--working-directory` mirror the #961 fix). At the cap (default 3) it parks the issue on `dispatch:office-hours` and prints `escalated`, scheduling no timer. Fail-closed input validation on every value reaching `(( ))` / `systemd-run` / `gh`.
- **Unit 3 — wire into `dispatch-materialize-spawn`:** the single-target driver (`MODE == explicit || GAP <= 1`) replaces `drain ci-waiting` with a call to the scheduler — `reseeded ...` maps to `drain ci-reseeded`, `escalated` to `notify ci-wait-exhausted`, and a hard scheduler failure falls back to `drain ci-waiting` (never wedges the tick). The fan-out path (`--gap N>1`) is unchanged: a `ci-waiting` target stays a skip. Updates `SKILL.md` Table 2 and `reference.md`.

## Test plan

- [x] `test-dispatch-scripts.sh` fully green (1049/1049): spawn-router target argv; schedule-target-reseed timer/counter-bump/escalation/bad-input; materialize-spawn single-target reseed → `drain ci-reseeded`, escalation → `notify ci-wait-exhausted`, and fan-out ci-waiting skip unchanged (scheduler not called).
- [x] `bash -n` clean on all changed/new scripts.
- [ ] Manual: `/dispatch <N>` against an in-progress-CI target schedules a reseed and reports it is waiting on N's CI (exercised structurally by the suite; full live run pending CI on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)