### PR TITLE
dispatch: skip office-hours-parked leaves in dispatch-trace-leaf queue descent

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
@@ -222,7 +222,16 @@ find_leaf() {
   return 1
 }
 
-if LEAF=$(find_leaf "$ISSUE_NUM"); then
+# In queue mode the root issue is filtered exactly like a descended child
+# (#1011): if the starting issue is itself a parked topological leaf, the
+# descent loop never gets a chance to skip it, so guard it here before the
+# trace. This keeps dispatch-trace-leaf's standalone contract — "queue mode
+# never returns a leaf carrying dispatch:office-hours" — true for the root, not
+# just for children. Force the no-startable-leaf path (rc 2) so it flows into
+# the exit-2 surface below, matching the all-children-parked case.
+if [[ "$MODE" == "queue" ]] && child_is_office_hours_parked "$ISSUE_NUM"; then
+  trace_rc=2
+elif LEAF=$(find_leaf "$ISSUE_NUM"); then
   trace_rc=0
 else
   trace_rc=$?
@@ -249,7 +258,7 @@ fi
 # in test-dispatch-scripts.sh that keys on it (dispatch-select-target only checks
 # the exit code, not the message text).
 if [[ "$MODE" == "queue" ]]; then
-  echo "error: all open leaves reachable from $ISSUE_NUM are worktree-conflicted (owned by a live session)" >&2
+  echo "error: all open leaves reachable from $ISSUE_NUM are worktree-conflicted (owned by a live session or parked on dispatch:office-hours)" >&2
   exit 2
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
@@ -86,9 +86,12 @@ fi
 # mirroring WORKTREE_PATHS_BY_NUM above, so child_is_office_hours_parked is a map
 # lookup with no per-child gh round-trip. A gh failure here is a hard error, not
 # an empty set — silently returning a parked leaf is the very bug being fixed.
+# --limit 300 matches dispatch-select-target's open-issue cap: the parked set is
+# a subset of open issues, so the default limit of 30 could silently truncate it
+# and let a parked leaf past position 30 be returned as startable.
 declare -A OFFICE_HOURS_PARKED=()
 if [[ "$MODE" == "queue" ]]; then
-  parked_json=$(gh issue list --state open --label "dispatch:office-hours" --json number) \
+  parked_json=$(gh issue list --state open --label "dispatch:office-hours" --limit 300 --json number) \
     || { echo "error: dispatch-trace-leaf $ISSUE_NUM: gh issue list for the dispatch:office-hours parked set failed; aborting rather than risk returning a parked leaf" >&2; exit 1; }
   while IFS= read -r parked_num; do
     [[ -n "$parked_num" ]] && OFFICE_HOURS_PARKED["$parked_num"]=1

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
@@ -16,13 +16,18 @@
 #              LIVE Claude session (#914). An orphan <N>-* worktree (on disk, no
 #              session) stays descendable — it is a reuse signal, not a skip,
 #              matching the direct-row liveness fix in dispatch-select-target
-#              (#905). A child with no worktree at all is never filtered. If a
-#              node has open children but every one is live-owned, the descent
-#              bubbles up too — that subtree has no ready work. If every
-#              reachable open leaf in the subtree is owned by a live session,
-#              the script exits non-zero with a clear message on stderr so the
-#              /dispatch-propagate caller can stop instead of dispatching on a
-#              conflict.
+#              (#905). A child with no worktree at all is never filtered.
+#              Queue mode also filters out a child parked on
+#              dispatch:office-hours (#1011): the label parks an item for human
+#              review and must remove it from autonomous selection (#757), so a
+#              parked child is treated exactly like a live-session-owned one —
+#              neither descended into nor returned as a startable leaf. If a
+#              node has open children but every one is live-owned or parked, the
+#              descent bubbles up too — that subtree has no ready work. If every
+#              reachable open leaf in the subtree is owned by a live session or
+#              parked, the script exits non-zero with a clear message on stderr
+#              so the /dispatch-propagate caller can stop instead of dispatching
+#              on a conflict.
 #
 # Falls back to printing N in `explicit` mode if cycles block every path to a
 # leaf (preserves historical behavior).
@@ -36,6 +41,7 @@
 #   1 — usage error, or a sibling gh script (issue-blocking / issue-sub-issues)
 #       failed — a hard failure the caller must not treat as "no work"
 #   2 — queue mode only: every reachable open leaf is owned by a live session
+#       or parked on dispatch:office-hours
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -72,6 +78,23 @@ if [[ "$MODE" == "queue" ]]; then
   done < <(list_worktree_records)
 fi
 
+# In queue mode, gather the set of open issues parked on dispatch:office-hours
+# (#1011), keyed by issue number. The label parks an item for human review and
+# must remove it from autonomous selection (#757); dispatch-select-target
+# already filters it on top-level queue issues, but a parked leaf reachable from
+# an unparked parent slipped through this descent. Gathered once up front,
+# mirroring WORKTREE_PATHS_BY_NUM above, so child_is_office_hours_parked is a map
+# lookup with no per-child gh round-trip. A gh failure here is a hard error, not
+# an empty set — silently returning a parked leaf is the very bug being fixed.
+declare -A OFFICE_HOURS_PARKED=()
+if [[ "$MODE" == "queue" ]]; then
+  parked_json=$(gh issue list --state open --label "dispatch:office-hours" --json number) \
+    || { echo "error: dispatch-trace-leaf $ISSUE_NUM: gh issue list for the dispatch:office-hours parked set failed; aborting rather than risk returning a parked leaf" >&2; exit 1; }
+  while IFS= read -r parked_num; do
+    [[ -n "$parked_num" ]] && OFFICE_HOURS_PARKED["$parked_num"]=1
+  done < <(printf '%s' "$parked_json" | jq -r '.[].number')
+fi
+
 # True when a live Claude session owns any <num>-* worktree. No such worktree →
 # fast-path miss (return 1), no daemon round-trip. Several matches → owned if any
 # one is live. A faithful copy of dispatch-select-target's issue_has_live_worktree
@@ -89,6 +112,17 @@ child_has_live_worktree() {
     fi
   done <<< "$paths"
   return 1
+}
+
+# True when the given issue number is parked on dispatch:office-hours (#1011).
+# A parked node is filtered from queue-mode descent exactly like a
+# live-session-owned child (child_has_live_worktree, #914): neither descended
+# into nor returned as a startable leaf. The descent then falls through to the
+# next startable sibling, or bubbles up (exit 2) when every reachable open leaf
+# is parked or live-owned. Map lookup against OFFICE_HOURS_PARKED, populated
+# once in queue mode above.
+child_is_office_hours_parked() {
+  [[ -n "${OFFICE_HOURS_PARKED[$1]:-}" ]]
 }
 
 # Collect open children of an issue: open blockers union open sub-issues.
@@ -167,12 +201,14 @@ find_leaf() {
 
   # Descend into children lowest-numbered first; return the first leaf found.
   # In queue mode, skip any child whose <N>-* worktree is owned by a live
-  # session (#914) — an orphan child worktree stays descendable. If every child
-  # is skipped the loop finds nothing and we bubble up.
+  # session (#914) — an orphan child worktree stays descendable — and any child
+  # parked on dispatch:office-hours (#1011). If every child is skipped the loop
+  # finds nothing and we bubble up.
   local kid leaf
   while IFS= read -r kid; do
     [[ -z "$kid" ]] && continue
     [[ "$MODE" == "queue" ]] && child_has_live_worktree "$kid" && continue
+    [[ "$MODE" == "queue" ]] && child_is_office_hours_parked "$kid" && continue
     # Capture the status explicitly (set -e is disabled here) so a hard error
     # (rc 3) is distinguishable from "no leaf in this subtree" (rc 1).
     leaf=$(find_leaf "$kid"); rc=$?
@@ -206,11 +242,12 @@ if [[ "$trace_rc" -eq 3 ]]; then
 fi
 
 # In queue mode, no valid leaf is reachable — every reachable open leaf is owned
-# by a live session (or cycles block every path); orphan worktrees were
-# descended through. Surface this so /dispatch-propagate can stop with a clear
-# message instead of dispatching on a conflict. The "worktree-conflicted" token
-# is retained for the pattern-matcher in test-dispatch-scripts.sh that keys on it
-# (dispatch-select-target only checks the exit code, not the message text).
+# by a live session or parked on dispatch:office-hours (#1011) (or cycles block
+# every path); orphan worktrees were descended through. Surface this so
+# /dispatch-propagate can stop with a clear message instead of dispatching on a
+# conflict. The "worktree-conflicted" token is retained for the pattern-matcher
+# in test-dispatch-scripts.sh that keys on it (dispatch-select-target only checks
+# the exit code, not the message text).
 if [[ "$MODE" == "queue" ]]; then
   echo "error: all open leaves reachable from $ISSUE_NUM are worktree-conflicted (owned by a live session)" >&2
   exit 2

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -155,7 +155,7 @@ case "$args" in
       echo "[]"
     fi
     ;;
-  "issue list --state open --label dispatch:office-hours --json number")
+  "issue list --state open --label dispatch:office-hours --limit 300 --json number")
     # dispatch-trace-leaf queue-mode parked set (#1011): open issues carrying
     # dispatch:office-hours. $STUB_DIR/trace-parked.json supplies the parked
     # numbers; absence means nothing is parked (default empty), so every

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2770,6 +2770,32 @@ result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "explicit")
 assert_eq "explicit: parked leaf 701 returned unchanged" "701" "$result"
 teardown
 
+# 20. Queue mode: the ROOT issue is itself a parked topological leaf (#1011).
+#     700 has no children, so the descent loop never runs and cannot skip it;
+#     the root guard before the trace must catch it and exit 2 rather than
+#     return the parked root. This is the standalone-contract edge case — the
+#     descent child-skip alone leaves the root unguarded.
+echo "Test: queue mode → parked ROOT leaf guarded, exits 2"
+setup
+# No subissues-700.json → 700 is a topological leaf.
+printf '{"title":"Issue 700","body":"","comments":[],"number":700,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-700.json"
+printf '[{"number":700}]\n' > "$STUB_DIR/trace-parked.json"
+err_out=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue" 2>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+assert_eq "queue: parked root leaf → exit 2, no leaf on stdout" "EXIT=2" "$err_out"
+teardown
+
+# 21. Explicit mode: a parked ROOT leaf is returned unchanged (#1011 scopes the
+#     root guard to queue mode, mirroring the descent child-skip scoping).
+echo "Test: explicit mode → parked ROOT leaf returned (no guard)"
+setup
+printf '{"title":"Issue 700","body":"","comments":[],"number":700,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-700.json"
+printf '[{"number":700}]\n' > "$STUB_DIR/trace-parked.json"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "explicit")
+assert_eq "explicit: parked root leaf 700 returned unchanged" "700" "$result"
+teardown
+
 # ============================================================================
 # dispatch-complete-phase tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -155,6 +155,17 @@ case "$args" in
       echo "[]"
     fi
     ;;
+  "issue list --state open --label dispatch:office-hours --json number")
+    # dispatch-trace-leaf queue-mode parked set (#1011): open issues carrying
+    # dispatch:office-hours. $STUB_DIR/trace-parked.json supplies the parked
+    # numbers; absence means nothing is parked (default empty), so every
+    # pre-existing trace-leaf test stays green.
+    if [[ -f "$STUB_DIR/trace-parked.json" ]]; then
+      cat "$STUB_DIR/trace-parked.json"
+    else
+      echo "[]"
+    fi
+    ;;
   issue\ view\ *\ --json\ state)
     # dispatch-select-target worktree detection: gh issue view <num> --json state
     num=$(echo "$args" | awk '{print $3}')
@@ -1834,6 +1845,29 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "help-wanted issue 55 resolves to leaf 5500" "issue 5500" "$result"
 teardown
 
+# 38a. A help-wanted issue whose lowest open leaf is parked on
+#      dispatch:office-hours resolves to the next startable (unparked) leaf, not
+#      the parked one (#1011). Issue 55 has sub-issues 5500 (parked) and 5501
+#      (unparked), neither worktree'd; the selector must emit 5501. This is the
+#      end-to-end form of the wedged-queue bug — a parked leaf under an unparked
+#      help-wanted parent previously occupied its bucket and starved the queue.
+echo "Test: help-wanted issue's parked leaf skipped → next leaf selected"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":5500},{"number":5501}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-5500.json"
+printf '{"title":"Issue 5501","body":"","comments":[],"number":5501,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-5501.json"
+# No worktrees — only the office-hours label distinguishes the leaves.
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+# 5500 is parked on dispatch:office-hours.
+printf '[{"number":5500}]\n' > "$STUB_DIR/trace-parked.json"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "parked leaf 5500 skipped → leaf 5501 selected" "issue 5501" "$result"
+teardown
+
 # 39. dispatch-trace-leaf exit 1 (usage error) is a hard failure, never a skip.
 echo "Test: dispatch-trace-leaf exit 1 → dispatch-select-target hard-fails"
 setup
@@ -2681,6 +2715,59 @@ printf '[{"number":801}]\n' > "$STUB_DIR/subissues-800.json"
 stdout=$("$TMPDIR_TEST/dispatch-trace-leaf" "800" "queue" 2>/dev/null) && rc=0 || rc=$?
 assert_eq "deep gh failure → exit 1" "1" "$rc"
 assert_eq "deep gh failure → no leaf on stdout" "" "$stdout"
+teardown
+
+# 17. Queue mode: a topological leaf parked on dispatch:office-hours is skipped
+#     in favor of an unparked sibling leaf (#1011). 700 has open sub-issues 701
+#     (parked) and 702 (unparked); neither has a worktree, so only the label
+#     distinguishes them. Without the skip, the lowest leaf 701 would be
+#     returned — this is the wedged-queue repro.
+echo "Test: queue mode → office-hours-parked leaf skipped, returns unparked sibling"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+# 701 is parked on dispatch:office-hours; 702 is not.
+printf '[{"number":701}]\n' > "$STUB_DIR/trace-parked.json"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
+assert_eq "queue: parked leaf 701 skipped → unparked sibling 702" "702" "$result"
+teardown
+
+# 18. Queue mode: every reachable open leaf is parked on dispatch:office-hours →
+#     exit 2 with the worktree-conflicted stderr message, exactly as the
+#     all-live-owned case (#1011 mirrors #914).
+echo "Test: queue mode → all leaves office-hours-parked, exits 2"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/trace-parked.json"
+err_out=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err_out" in
+  *"worktree-conflicted"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err_out" ;;
+esac
+assert_eq "queue: all leaves parked → exit 2 with stderr message" "ok" "$status"
+teardown
+
+# 19. Explicit mode: the office-hours skip does not apply — a parked leaf is
+#     returned unchanged (#1011 scopes the skip to queue mode). The parked-set
+#     gh query runs only in queue mode, so trace-parked.json is irrelevant here;
+#     explicit descent returns the lowest leaf 701 regardless of its label.
+echo "Test: explicit mode → office-hours-parked leaf returned (no skip)"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+printf '[{"number":701}]\n' > "$STUB_DIR/trace-parked.json"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "explicit")
+assert_eq "explicit: parked leaf 701 returned unchanged" "701" "$result"
 teardown
 
 # ============================================================================


### PR DESCRIPTION
## Summary

`dispatch-trace-leaf` queue-mode descent filtered out children whose `<N>-*`
worktree is owned by a live Claude session (#914) but applied no equivalent
filter for `dispatch:office-hours`. A parked leaf reachable from an unparked
parent was therefore returned as a startable leaf, wedging queue selection: the
parked leaf occupied the top `priority`+`bug` bucket and was re-selected every
tick, starving the rest of the queue (#1011).

This extends the #914 live-session filter to office-hours parking — the same
skip #757 already applies to top-level queue issues in `dispatch-select-target`,
now applied during leaf resolution:

- Gather the open `dispatch:office-hours` set once up front (mirroring the
  worktree-path map), so the check is a map lookup with no per-child gh call.
  A gh failure is a hard error, not an empty set.
- Filter a parked child from the descent exactly like a live-owned one: neither
  descended into nor returned as a startable leaf.
- A subtree whose every reachable open leaf is parked or live-owned now exits 2,
  so `dispatch-select-target` falls through to the next candidate.
- Queue-mode only; explicit-mode descent is unchanged.

## Test plan

- [ ] `test-dispatch-scripts.sh` passes (1119 → 1123 tests)
- [ ] queue mode: a parked topological leaf is skipped in favor of an unparked
      sibling leaf
- [ ] queue mode: a subtree whose every open leaf is parked yields exit 2
- [ ] explicit mode: a parked leaf is still returned (skip is queue-only)
- [ ] end-to-end: `dispatch-select-target` resolves a help-wanted issue's parked
      leaf to the next unparked leaf

Closes #1011