### PR TITLE
dispatch: park router on no-continuation instead of self-closing into a dead chain

### DIFF
--- a/.claude/skills/dispatch-propagate/SKILL.md
+++ b/.claude/skills/dispatch-propagate/SKILL.md
@@ -218,6 +218,20 @@ no-op when `CLAUDE_JOB_DIR` is unset (interactive session), so an interactive
 `/dispatch-propagate` reaching a terminal disposition does not stop the user's
 conversation.
 
+**Continuation invariant (router sessions only).** Before self-closing, a
+router tick (name matching `dispatch-*`) checks that a continuation exists —
+defined as: at least one pending `dispatch-reseed*` systemd timer, OR at least
+one live worker (name `^[0-9]+-`) that is not parked on `dispatch:office-hours`.
+Workers and legacy callers keep their unconditional self-close; the gate applies
+only to router sessions. If no continuation exists, the router **parks** instead
+of closing: it stays alive, emits a one-line reason to the user, and skips
+`claude rm`. If the Claude daemon is unqueryable, the check fails safe toward
+self-close. A parked router is surfaced by the office-hours entry point:
+`office-hours-select-target` emits a `parked-router <sessionId> <name>` line
+(after labeled items, before `empty`); a human resumes it by re-engaging that
+session and re-running `/dispatch-propagate` inside it. No
+`dispatch:office-hours` label is involved.
+
 The `main-broken` and `jit-reminder` outcomes (Table 1) reach this section as
 `drain` dispositions: spawn the bg job via `dispatch-spawn-job`, report the
 spawn result, then self-close. The router does **not** spawn a successor itself;

--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -373,9 +373,14 @@ This mechanism only covers the cap-stall class of stall. **Empty-queue and
 all-parked stalls** are handled by the office-hours queue (#755 / #757 /
 #758): when a human engages an `office-hours`-labeled item, the Step 4
 hand-off returns it to the dispatch chain and re-seeds from human action.
-A weekly fallback heartbeat for the edge case of a manual issue filed while
-the chain is stalled with no live session to receive it can be added in a
-follow-up if it matters in practice.
+The targeted alternative to a silent periodic heartbeat — adopted in #1010 —
+is the continuation invariant enforced at `dispatch-self-close`: a router tick
+that leaves no continuation (no worker spawned, no pending `dispatch-reseed*`
+timer, no live busy worker) parks instead of self-closing, emitting a one-line
+reason and staying visible in `claude agents`. The `office-hours-select-target`
+script surfaces the parked router via a `parked-router` line, so a human can
+resume it. This makes a stalled chain visible rather than silently losing it to
+a missed heartbeat window.
 
 ## Target-keyed CI-wait reseed (#979)
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-self-close
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-self-close
@@ -12,26 +12,114 @@
 # doubles as the foreground-safe gate: an interactive session reaching this
 # script is a no-op — the user's live conversation is not deleted.
 #
+# Continuation invariant (#1010):
+#   /dispatch-propagate is a self-perpetuating chain carried forward only by
+#   (1) a worker's Stop hook (dispatch-stop.sh → spawn_router) or (2) a
+#   `dispatch-reseed*` systemd timer. A ROUTER's own self-close carries
+#   nothing — the Stop hook is a no-op for router sessions (their name does
+#   not match `^[0-9]+-`). Several terminal `drain` dispositions route through
+#   this script having spawned no worker and scheduled no reseed, so the chain
+#   could silently die with work still queued (e.g. when the only live worker
+#   is parked on `dispatch:office-hours` and never fires its Stop hook).
+#
+#   To make that structurally impossible, a ROUTER tick may self-close only
+#   if it leaves a continuation:
+#     - a pending `dispatch-reseed*` systemd timer (armed / waiting), OR
+#     - >=1 live BUSY worker (`claude_agents_count_busy_workers` >= 1 —
+#       "busy" is precisely "actively progressing, not parked on office-hours",
+#       since office-hours-parked workers are waiting/idle, never busy).
+#   Otherwise the router PARKS: it stays alive (does NOT call `claude rm`) and
+#   emits a one-line reason, so the stall is visible and resumable by
+#   office-hours.
+#
+#   The invariant is gated to ROUTER sessions only (state.json `.name` matches
+#   `dispatch-*`). It is intentionally NOT applied to:
+#     - workers (name `^[0-9]+-`): the worker Stop-hook self-close always calls
+#       `spawn_router` first, so it already leaves a continuation.
+#     - empty/missing name, or absent state.json: legacy / non-router callers
+#       (dispatch-handoff, the interactive gate, plain managed jobs) keep their
+#       existing unconditional behavior, which also keeps existing tests green.
+#
 # Behavior:
-#   $CLAUDE_JOB_DIR set    → `claude rm $(basename "$CLAUDE_JOB_DIR")`,
-#                            exit with that command's status.
-#   $CLAUDE_JOB_DIR unset  → diagnostic to stderr, exit 0 (no-op).
+#   $CLAUDE_JOB_DIR unset           → diagnostic to stderr, exit 0 (no-op).
+#   $CLAUDE_JOB_DIR set, non-router → `claude rm $(basename "$CLAUDE_JOB_DIR")`.
+#   $CLAUDE_JOB_DIR set, router with continuation → `claude rm ...` (self-close).
+#   $CLAUDE_JOB_DIR set, router with NO continuation → park: print reason, exit 0
+#                                                      WITHOUT `claude rm`.
 #
-# Environment override for testability (mirroring dispatch-spawn-router's
+# Environment overrides for testability (mirroring dispatch-spawn-router's
 # DISPATCH_SPAWN_ROUTER_CLAUDE_CMD):
-#   DISPATCH_SELF_CLOSE_CLAUDE_CMD  The `claude` command. Default: `claude`.
+#   DISPATCH_SELF_CLOSE_CLAUDE_CMD     The `claude` command. Default: `claude`.
+#   DISPATCH_SELF_CLOSE_SYSTEMCTL_CMD  The `systemctl` command used to probe for
+#                                      a pending `dispatch-reseed*` timer.
+#                                      Default: `systemctl`.
+#   CLAUDE_AGENTS_CMD                  Honored by the sourced lib-claude-agents.sh
+#                                      for its `claude agents --json` query.
 #
-# Sandbox: `claude rm` reaches the local Claude daemon over a Unix socket;
-# callers must invoke this script with `dangerouslyDisableSandbox: true` —
-# see `.claude/rules/sandbox.md § claude agents --json`.
+# Sandbox: `claude rm` and `claude agents --json` reach the local Claude daemon
+# over a Unix socket; callers must invoke this script with
+# `dangerouslyDisableSandbox: true` — see
+# `.claude/rules/sandbox.md § claude agents --json`.
 set -uo pipefail
 
 CLAUDE_CMD="${DISPATCH_SELF_CLOSE_CLAUDE_CMD:-claude}"
+SYSTEMCTL="${DISPATCH_SELF_CLOSE_SYSTEMCTL_CMD:-systemctl}"
 JOB_ID=$(basename "${CLAUDE_JOB_DIR:-}")
 
 if [[ -z "$JOB_ID" || "$JOB_ID" == "." ]]; then
   echo "dispatch-self-close: not a managed background job (CLAUDE_JOB_DIR unset); skipping self-close" >&2
   exit 0
+fi
+
+# Read this session's name from its job state. A missing file, missing jq, or a
+# missing `.name` all collapse to an empty name — which falls through to the
+# legacy unconditional self-close path below.
+STATE_JSON="$CLAUDE_JOB_DIR/state.json"
+SESSION_NAME=""
+if [[ -f "$STATE_JSON" ]]; then
+  SESSION_NAME=$(jq -r '.name // ""' "$STATE_JSON" 2>/dev/null) || SESSION_NAME=""
+fi
+
+# Continuation invariant applies only to ROUTER sessions (name `dispatch-*`).
+# Everything else — workers (`^[0-9]+-`), empty/missing name — self-closes
+# unconditionally as before.
+if [[ "$SESSION_NAME" == dispatch-* ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/lib-claude-agents.sh"
+
+  continuation=0
+
+  # Continuation 1: a pending `dispatch-reseed*` systemd timer. Treat as present
+  # iff an armed (sub-state `waiting`) reseed timer line is reported. A permissive
+  # grep tolerates systemctl's column formatting across versions.
+  if "$SYSTEMCTL" --user list-units --type=timer --all --no-legend 'dispatch-reseed*' 2>/dev/null \
+      | grep -E 'dispatch-reseed' | grep -q 'waiting'; then
+    continuation=1
+  fi
+
+  # Continuation 2: >=1 live BUSY worker. A "busy" worker is actively
+  # progressing (not parked on office-hours), so its Stop hook will eventually
+  # re-seed the chain. CRITICAL fail-safe: if the helper returns non-zero
+  # (UNKNOWN — daemon unqueryable), fail toward SELF-CLOSE (treat continuation
+  # as present). A spurious park is noisy and wedges routing; the invariant only
+  # needs to catch the *definite* no-continuation case, so when the daemon
+  # cannot be queried we let the tick self-close as it did before #1010.
+  if [[ "$continuation" -eq 0 ]]; then
+    if busy_count=$(claude_agents_count_busy_workers); then
+      [[ "$busy_count" -ge 1 ]] && continuation=1
+    else
+      # UNKNOWN: daemon unqueryable → fail safe toward self-close.
+      continuation=1
+    fi
+  fi
+
+  if [[ "$continuation" -eq 0 ]]; then
+    msg="dispatch-self-close: parking — no continuation (no worker spawned, no pending reseed timer, no live busy worker); router stays alive for office-hours resume"
+    echo "$msg"
+    echo "$msg" >&2
+    exit 0
+  fi
 fi
 
 exec "$CLAUDE_CMD" rm "$JOB_ID"

--- a/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
@@ -16,7 +16,17 @@
 #               this: implement → plan-approval residue; qa → QA walkthrough
 #               residue; anything past qa → deviation-review.
 #     <pr-or-dash> — the issue's open PR number, or `-` when none exists.
-# Prints `empty` when no sessionless labeled item exists.
+#   parked-router <sessionId> <name>
+#     A target-less parked /dispatch-propagate router (#1010). When no labeled
+#     sessionless item exists, this fallback surfaces a live, idle/waiting
+#     `dispatch-*` router session rooted under worktrees/main — the artifact the
+#     continuation invariant in `dispatch-self-close` keeps alive rather than
+#     orphaning the chain. A parked router has no issue/PR and so no
+#     dispatch:office-hours label; the human resumes it by re-engaging that exact
+#     session (re-running /dispatch-propagate inside it). A `busy` router is
+#     actively ticking and is NOT surfaced.
+# Prints `empty` when neither a sessionless labeled item nor a parked router
+# exists.
 #
 # Reuses dispatch-phase and dispatch-find-pr (passed a shared open-PR list to
 # avoid redundant gh calls), and the lib.sh / lib-claude-agents.sh worktree
@@ -84,5 +94,34 @@ while IFS= read -r issue_num; do
   printf 'office-hours %s %s %s\n' "$issue_num" "$phase" "${pr:--}"
   exit 0
 done <<< "$SORTED"
+
+# No sessionless labeled item. Fall back to surfacing a target-less parked
+# router (#1010): a live, idle/waiting `dispatch-*` router session rooted under
+# worktrees/main, kept alive by dispatch-self-close's continuation invariant. It
+# carries no issue/PR, so no label anchors it — discover it directly by cwd +
+# state. The human resumes it by re-engaging that exact session.
+MAIN_WORKTREE="${DISPATCH_OFFICE_HOURS_MAIN_WORKTREE:-}"
+if [[ -z "$MAIN_WORKTREE" ]]; then
+  if ! project_root="$(resolve_project_root)"; then
+    echo "office-hours-select-target: cannot resolve project root (not in a git repo?)" >&2
+    exit 1
+  fi
+  MAIN_WORKTREE="$project_root/worktrees/main"
+fi
+
+# claude_sessions_under honors the UNKNOWN contract: a non-zero return means the
+# daemon could not be queried, so we must NOT fabricate a parked router — skip
+# the block (the `if rows=...; then` capture leaves rows unscanned) and fall
+# through to `empty`. On a successful query, scan for the first idle/waiting
+# `dispatch-*` router.
+if rows=$(claude_sessions_under "$MAIN_WORKTREE"); then
+  while IFS=$'\t' read -r session_id _ status name; do
+    [[ -z "$name" ]] && continue
+    # A `dispatch-*` router that is NOT busy — parked/idle, not actively ticking.
+    [[ "$name" == dispatch-* && "$status" != "busy" ]] || continue
+    printf 'parked-router %s %s\n' "$session_id" "$name"
+    exit 0
+  done <<< "$rows"
+fi
 
 echo "empty"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -8554,6 +8554,25 @@ assert_eq "worker-named: 'claude rm abcd1234' was invoked (invariant skipped)" \
   "abcd1234" "$rm_log"
 selfclose_teardown
 
+# --- Test 8: router + UNKNOWN daemon + no reseed timer → SELF-CLOSE (#1010) ---
+
+echo "Test: router with UNKNOWN daemon (unqueryable) and no reseed timer self-closes (fail-safe)"
+selfclose_setup
+mkdir -p "$TMPDIR_TEST/jobs/abcd1234"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+selfclose_write_state "dispatch-abcd1234"
+# Model UNKNOWN: point CLAUDE_AGENTS_CMD at a non-existent binary so
+# claude_agents_count_busy_workers returns non-zero (daemon unqueryable).
+export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/no-such-claude"
+selfclose_set_no_timer
+rc=0
+"$TMPDIR_TEST/scripts/dispatch-self-close" >/dev/null 2>&1 || rc=$?
+assert_eq "unknown-daemon: router self-close exits 0" "0" "$rc"
+rm_log=$(cat "$SPAWN_ROUTER_RM_LOG" 2>/dev/null || true)
+assert_eq "unknown-daemon: 'claude rm abcd1234' was invoked (fail-safe toward self-close)" \
+  "abcd1234" "$rm_log"
+selfclose_teardown
+
 # ============================================================================
 # dispatch-jit-engine tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -8113,6 +8113,10 @@ selfclose_setup() {
   mkdir -p "$TMPDIR_TEST/scripts"
   cp "$SCRIPT_DIR/dispatch-self-close" "$TMPDIR_TEST/scripts/dispatch-self-close"
   chmod +x "$TMPDIR_TEST/scripts/dispatch-self-close"
+  # The router-only continuation invariant (#1010) sources lib-claude-agents.sh
+  # from its own dir for claude_agents_count_busy_workers, so the helper must sit
+  # alongside the copied script. Sourced, not executed — no chmod.
+  cp "$SCRIPT_DIR/lib-claude-agents.sh" "$TMPDIR_TEST/scripts/lib-claude-agents.sh"
 
   # Reuse the dispatch-spawn-router fake `claude` writer: it already dispatches on
   # `rm` and appends $2 to SPAWN_ROUTER_RM_LOG. The unused SPAWN_ROUTER_REGISTRY /
@@ -8126,6 +8130,69 @@ selfclose_setup() {
   write_fake_spawn_router_claude
 
   export DISPATCH_SELF_CLOSE_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+
+  # Continuation-check fakes (#1010), all defaulting to "no continuation":
+  #   - The daemon query (claude_agents_count_busy_workers, via CLAUDE_AGENTS_CMD)
+  #     defaults to a successful query reporting zero busy workers.
+  #   - The systemctl probe (DISPATCH_SELF_CLOSE_SYSTEMCTL_CMD) defaults to
+  #     emitting no reseed timer.
+  # Helpers below let a test flip either to a continuation-present state.
+  export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/fake-agents"
+  export DISPATCH_SELF_CLOSE_SYSTEMCTL_CMD="$TMPDIR_TEST/fake-systemctl"
+  selfclose_set_workers   # default: no workers
+  selfclose_set_no_timer  # default: no reseed timer
+}
+
+# selfclose_write_state <name> — write a state.json with the given .name into the
+# fake CLAUDE_JOB_DIR (exported by the caller as CLAUDE_JOB_DIR).
+selfclose_write_state() {
+  local name="$1"
+  printf '{"name":"%s"}\n' "$name" > "$CLAUDE_JOB_DIR/state.json"
+}
+
+# selfclose_set_workers [session-spec...] — install the fake `claude agents`
+# command. Each spec is `name:status`. With zero specs it emits an empty array.
+# Always exits 0 (a successfully-queried daemon).
+selfclose_set_workers() {
+  local payload="["
+  local first=1 spec name status
+  for spec in "$@"; do
+    name="${spec%%:*}"
+    status="${spec#*:}"
+    [[ $first -eq 1 ]] || payload+=","
+    first=0
+    payload+="{\"sessionId\":\"s-$name\",\"pid\":1,\"status\":\"$status\",\"name\":\"$name\",\"cwd\":\"\"}"
+  done
+  payload+="]"
+  cat > "$TMPDIR_TEST/fake-agents" <<FAKE
+#!/usr/bin/env bash
+# Fake \`claude\`: only the \`agents --json\` query is exercised here.
+if [[ "\${1:-}" == "agents" ]]; then
+  printf '%s\n' '$payload'
+  exit 0
+fi
+exit 0
+FAKE
+  chmod +x "$TMPDIR_TEST/fake-agents"
+}
+
+# selfclose_set_timer — fake systemctl emits an armed (waiting) reseed timer line.
+selfclose_set_timer() {
+  cat > "$TMPDIR_TEST/fake-systemctl" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' 'dispatch-reseed.timer loaded active waiting Dispatch reseed timer'
+exit 0
+FAKE
+  chmod +x "$TMPDIR_TEST/fake-systemctl"
+}
+
+# selfclose_set_no_timer — fake systemctl emits nothing (no reseed timer).
+selfclose_set_no_timer() {
+  cat > "$TMPDIR_TEST/fake-systemctl" <<'FAKE'
+#!/usr/bin/env bash
+exit 0
+FAKE
+  chmod +x "$TMPDIR_TEST/fake-systemctl"
 }
 
 selfclose_teardown() {
@@ -8135,7 +8202,8 @@ selfclose_teardown() {
   SPAWN_ROUTER_BG_ARGV=""
   SPAWN_ROUTER_RM_LOG=""
   SPAWN_ROUTER_STOP_LOG=""
-  unset DISPATCH_SELF_CLOSE_CLAUDE_CMD CLAUDE_JOB_DIR
+  unset DISPATCH_SELF_CLOSE_CLAUDE_CMD CLAUDE_JOB_DIR \
+    CLAUDE_AGENTS_CMD DISPATCH_SELF_CLOSE_SYSTEMCTL_CMD
 }
 
 # --- Test 1: managed-job → deletes itself -------------------------------------
@@ -8173,6 +8241,113 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: interactive: no 'claude rm' invocation recorded"
   echo "    rm-log: $(cat "$SPAWN_ROUTER_RM_LOG")"
 fi
+selfclose_teardown
+
+# --- Test 3: router + no continuation → PARK (#1010) --------------------------
+
+echo "Test: router with no continuation (no busy worker, no reseed timer) parks"
+selfclose_setup
+mkdir -p "$TMPDIR_TEST/jobs/abcd1234"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+selfclose_write_state "dispatch-abcd1234"
+selfclose_set_workers   # no workers
+selfclose_set_no_timer
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-self-close" 2>"$TMPDIR_TEST/park-err") || rc=$?
+err=$(cat "$TMPDIR_TEST/park-err")
+assert_eq "park: router no-continuation exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$SPAWN_ROUTER_RM_LOG" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: park: no 'claude rm' invocation recorded"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: park: no 'claude rm' invocation recorded"
+  echo "    rm-log: $(cat "$SPAWN_ROUTER_RM_LOG")"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"parking — no continuation"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: park: parking reason on stderr"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: park: parking reason on stderr"
+  echo "    stderr: $err"
+fi
+selfclose_teardown
+
+# --- Test 4: router + live busy worker → SELF-CLOSE (#1010) -------------------
+
+echo "Test: router with a live busy ^[0-9]+- worker self-closes"
+selfclose_setup
+mkdir -p "$TMPDIR_TEST/jobs/abcd1234"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+selfclose_write_state "dispatch-abcd1234"
+selfclose_set_workers "824-foo:busy"
+selfclose_set_no_timer
+rc=0
+"$TMPDIR_TEST/scripts/dispatch-self-close" >/dev/null 2>&1 || rc=$?
+assert_eq "busy-worker: router self-close exits 0" "0" "$rc"
+rm_log=$(cat "$SPAWN_ROUTER_RM_LOG" 2>/dev/null || true)
+assert_eq "busy-worker: 'claude rm abcd1234' was invoked" "abcd1234" "$rm_log"
+selfclose_teardown
+
+# --- Test 5: router + pending reseed timer → SELF-CLOSE (#1010) ---------------
+
+echo "Test: router with a pending dispatch-reseed timer self-closes"
+selfclose_setup
+mkdir -p "$TMPDIR_TEST/jobs/abcd1234"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+selfclose_write_state "dispatch-abcd1234"
+selfclose_set_workers   # no workers
+selfclose_set_timer     # armed reseed timer
+rc=0
+"$TMPDIR_TEST/scripts/dispatch-self-close" >/dev/null 2>&1 || rc=$?
+assert_eq "reseed-timer: router self-close exits 0" "0" "$rc"
+rm_log=$(cat "$SPAWN_ROUTER_RM_LOG" 2>/dev/null || true)
+assert_eq "reseed-timer: 'claude rm abcd1234' was invoked" "abcd1234" "$rm_log"
+selfclose_teardown
+
+# --- Test 6: router + only a non-busy worker → PARK (#1010) -------------------
+
+echo "Test: router whose only worker is non-busy (waiting) parks"
+selfclose_setup
+mkdir -p "$TMPDIR_TEST/jobs/abcd1234"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+selfclose_write_state "dispatch-abcd1234"
+selfclose_set_workers "824-foo:waiting"   # idle/waiting → not busy
+selfclose_set_no_timer
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-self-close" 2>"$TMPDIR_TEST/park-err") || rc=$?
+err=$(cat "$TMPDIR_TEST/park-err")
+assert_eq "non-busy-worker: router parks, exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$SPAWN_ROUTER_RM_LOG" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-busy-worker: no 'claude rm' invocation recorded"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-busy-worker: no 'claude rm' invocation recorded"
+  echo "    rm-log: $(cat "$SPAWN_ROUTER_RM_LOG")"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"parking — no continuation"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-busy-worker: parking reason on stderr"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-busy-worker: parking reason on stderr"
+  echo "    stderr: $err"
+fi
+selfclose_teardown
+
+# --- Test 7: worker-named session → invariant skipped, SELF-CLOSE (#1010) -----
+
+echo "Test: worker-named session (123-foo) self-closes (invariant skipped)"
+selfclose_setup
+mkdir -p "$TMPDIR_TEST/jobs/abcd1234"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+selfclose_write_state "123-foo"
+selfclose_set_workers   # no continuation at all
+selfclose_set_no_timer
+rc=0
+"$TMPDIR_TEST/scripts/dispatch-self-close" >/dev/null 2>&1 || rc=$?
+assert_eq "worker-named: self-close exits 0" "0" "$rc"
+rm_log=$(cat "$SPAWN_ROUTER_RM_LOG" 2>/dev/null || true)
+assert_eq "worker-named: 'claude rm abcd1234' was invoked (invariant skipped)" \
+  "abcd1234" "$rm_log"
 selfclose_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2363,15 +2363,20 @@ result=$("$TMPDIR_TEST/office-hours-select-target")
 assert_eq "live-session item skipped; next labeled item selected" "office-hours 99 implement -" "$result"
 teardown
 
-# OHST4. An empty office-hours queue prints `empty`.
-echo "Test: empty office-hours queue → empty"
+# OHST4. An empty office-hours queue with no parked router prints `empty`. The
+# fall-through reaches the parked-router block: point it at a controlled
+# main-worktree path (the stub git does not implement the rev-parse the real
+# resolve_project_root needs) where the fake daemon reports no router.
+echo "Test: empty office-hours queue, no parked router → empty"
 setup
 echo '[]' > "$STUB_DIR/oh-issue-list.json"
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
-select_target_fake_claude
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+select_target_fake_claude   # `[]`: no sessions under main, no parked router
 result=$("$TMPDIR_TEST/office-hours-select-target")
-assert_eq "empty queue prints empty" "empty" "$result"
+assert_eq "empty queue, no parked router prints empty" "empty" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 
 # OHST5. Unknown daemon (UNKNOWN liveness) folds to occupied → the item with a
@@ -2387,6 +2392,92 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktre
 # setup's default CLAUDE_AGENTS_CMD points at a non-existent binary (UNKNOWN).
 result=$("$TMPDIR_TEST/office-hours-select-target")
 assert_eq "UNKNOWN-liveness worktree item skipped; worktree-free item selected" "office-hours 99 implement -" "$result"
+teardown
+
+# Install a fake `claude` whose `agents --json` returns a controllable session
+# payload (sessionId/pid/status/name per row) so the parked-router fallback can
+# be exercised: a `dispatch-*` router rooted under worktrees/main with a chosen
+# status. Each argument is a "name:status" pair. The fake ignores --cwd and
+# returns the full payload (matching the real daemon path, where the script
+# points claude_sessions_under at DISPATCH_OFFICE_HOURS_MAIN_WORKTREE).
+parked_router_fake_claude() {
+  local payload="[" pair name status first=1
+  for pair in "$@"; do
+    name="${pair%%:*}"; status="${pair#*:}"
+    if (( first )); then first=0; else payload+=","; fi
+    payload+="{\"sessionId\":\"s-$name\",\"pid\":1,\"status\":\"$status\",\"name\":\"$name\",\"cwd\":\"\"}"
+  done
+  payload+="]"
+  printf '%s' "$payload" > "$TMPDIR_TEST/claude-payload.json"
+  cat > "$TMPDIR_TEST/bin/claude" <<'FAKE'
+#!/usr/bin/env bash
+# Ignore all args (including --cwd); return the full payload.
+cat "$(cd "$(dirname "$0")/.." && pwd)/claude-payload.json"
+exit 0
+FAKE
+  chmod +x "$TMPDIR_TEST/bin/claude"
+  export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/bin/claude"
+}
+
+# OHST6. No labeled item + an idle/`waiting` dispatch-* router under main →
+# parked-router. The continuation invariant kept the router alive; the office
+# hours reader surfaces it directly, label-free.
+echo "Test: no labeled item + idle dispatch-* router under main → parked-router"
+setup
+echo '[]' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+parked_router_fake_claude "dispatch-abc123:waiting"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "idle dispatch-* router surfaced as parked-router" "parked-router s-dispatch-abc123 dispatch-abc123" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
+teardown
+
+# OHST7. No labeled item + a `busy` dispatch-* router under main → empty. A busy
+# router is actively ticking and must NOT be surfaced.
+echo "Test: no labeled item + busy dispatch-* router under main → empty (not surfaced)"
+setup
+echo '[]' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+parked_router_fake_claude "dispatch-abc123:busy"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "busy dispatch-* router not surfaced; empty" "empty" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
+teardown
+
+# OHST8. A sessionless labeled item AND a parked dispatch-* router both present →
+# the labeled item wins; the parked-router fallback runs only when no labeled
+# item exists.
+echo "Test: labeled item present alongside parked router → labeled item wins"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+# The fake reports no worker session named 42-* (so the labeled item is
+# sessionless) plus a parked dispatch-* router under main.
+parked_router_fake_claude "dispatch-abc123:waiting"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "labeled item selected over parked router" "office-hours 42 implement -" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
+teardown
+
+# OHST9. UNKNOWN daemon query (claude_sessions_under returns non-zero) → empty:
+# no parked router is fabricated from a failed query.
+echo "Test: no labeled item + UNKNOWN daemon → empty (no fabricated parked router)"
+setup
+echo '[]' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+# setup's default CLAUDE_AGENTS_CMD points at a non-existent binary → claude
+# exits non-zero → claude_sessions_under returns 1 (UNKNOWN).
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "UNKNOWN daemon does not fabricate a parked router; empty" "empty" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 
 # ============================================================================

--- a/.claude/skills/office-hours/SKILL.md
+++ b/.claude/skills/office-hours/SKILL.md
@@ -53,6 +53,14 @@ hand-off and no Stop-hook action — the Stop hook ignores non-`<N>-` session na
    - `office-hours <N> <phase> <pr-or-dash>` — the selected issue `<N>`, its
      phase, and its PR number (or `-`). Carry `<N>`, `<phase>`, and the PR
      through the rest of the skill.
+   - `parked-router <sessionId> <name>` — the dispatch chain has a target-less
+     parked router (#1010): a router tick left no continuation, so the
+     `dispatch-self-close` continuation invariant kept the session alive rather
+     than orphaning the chain. There is **no** `dispatch:office-hours` label
+     involved — the parked artifact is the router session itself, not an
+     issue/PR. Resume it by re-engaging that exact session: re-run
+     `/dispatch-propagate` inside the `<name>` session (`<sessionId>`). Report
+     that and **stop**.
 
    **Enter the item's worktree.** If the current branch is already `<N>-…`, you
    are in place — proceed. Otherwise resolve the worktree (use


### PR DESCRIPTION
Closes #1010

## Summary

`/dispatch-propagate` is a self-perpetuating chain of background jobs carried
forward only by a worker's Stop hook or a reseed systemd timer. The router's own
self-close carries nothing (the Stop hook is a no-op for router sessions), so
several terminal `drain` dispositions could self-close having spawned no worker
and scheduled no reseed — silently killing the chain with work still queued.

This enforces a continuation invariant at the single self-close chokepoint and
surfaces the resulting parked routers to office-hours.

- **Unit 1 — continuation invariant in `dispatch-self-close`.** Gated to router
  sessions only (state.json name `dispatch-*`). A router tick may self-close only
  if it leaves a continuation: a pending `dispatch-reseed*` systemd timer OR >=1
  live busy worker. Otherwise it **parks** — stays alive, emits a one-line
  reason, does not `claude rm`. Daemon-unqueryable fails safe toward self-close.
  Workers (`^[0-9]+-`) and legacy callers keep their unconditional self-close.
- **Unit 2 — office-hours surfaces parked routers.** A parked router has no
  issue/PR and so no `dispatch:office-hours` label; `office-hours-select-target`
  now discovers live idle/waiting `dispatch-*` router sessions under
  `worktrees/main` directly and emits a `parked-router <sessionId> <name>` line
  (after labeled items, before `empty`). `office-hours/SKILL.md` instructs the
  human to resume by re-engaging that session.
- **Unit 3 — documentation.** Records the invariant in the dispatch-propagate
  SKILL.md terminal-disposition section and reference.md (as the adopted
  alternative to the deferred weekly fallback heartbeat).

## Test plan

- [x] `test-dispatch-scripts.sh` full suite passes (1131/1131), covering
  park-vs-self-close across router/worker and continuation states, and the new
  `parked-router` office-hours cases.
- [x] `bash -n` on both modified scripts.
- [ ] CI green.