### PR TITLE
dispatch: file security follow-ups for out-of-scope CodeQL/npm findings

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-security-followup
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-security-followup
@@ -51,7 +51,7 @@ jq --arg pr "$pr" '
           identifier: ("CodeQL " + .rule_id + " alert #" + (.alert_number | tostring)),
           location: .location,
           severity: .security_severity_level,
-          urlline: ("Location: " + .location),
+          urlline: ("URL: " + .html_url),
           desc: .description
         }
       else

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-security-followup
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-security-followup
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Compose security follow-up issues from classified security-review findings.
+# Usage: printf '%s' '<json-array>' | dispatch-security-followup <pr-number>
+#
+# Reads a JSON array of classified security findings on stdin. Writes a JSON
+# array of follow-ups to stdout, each object exactly:
+#   { "identifier": ..., "title": ..., "body": ... }
+# Emits [] when nothing qualifies. Qualifying findings are emitted in input
+# order.
+#
+# The PR number ($1) is used ONLY in the body provenance line — this script
+# makes NO network/git/gh calls. Pure stdin → stdout classification via jq.
+#
+# Per-finding input fields:
+#   classification — required | out-of-scope | false-positive
+#   source         — codeql | npm (anything else is ignored)
+#   CodeQL: rule_id, alert_number, security_severity_level
+#           (critical|high|medium|low|null), description, location, html_url
+#   npm:    advisory_id, severity (critical|high|moderate|low),
+#           introduced_by_diff (bool), package, title, url
+#
+# Meaningfulness predicate (a follow-up is emitted ONLY when ALL hold):
+#   CodeQL: classification == "out-of-scope" AND
+#           security_severity_level in {high, medium}
+#   npm:    classification == "out-of-scope" AND severity in {high, critical}
+#           AND introduced_by_diff == false
+#   required and false-positive are always excluded.
+#
+# Stable identifier (embedded verbatim in the title for /file-issue dedup):
+#   CodeQL: CodeQL <rule_id> alert #<alert_number>
+#   npm:    npm advisory <advisory_id>
+set -euo pipefail
+
+pr="$1"
+
+jq --arg pr "$pr" '
+  [ .[]
+    | select(
+        (.source == "codeql"
+          and .classification == "out-of-scope"
+          and (.security_severity_level == "high" or .security_severity_level == "medium"))
+        or
+        (.source == "npm"
+          and .classification == "out-of-scope"
+          and (.severity == "high" or .severity == "critical")
+          and (.introduced_by_diff == false))
+      )
+    | if .source == "codeql" then
+        {
+          source: "codeql",
+          identifier: ("CodeQL " + .rule_id + " alert #" + (.alert_number | tostring)),
+          location: .location,
+          severity: .security_severity_level,
+          urlline: ("Location: " + .location),
+          desc: .description
+        }
+      else
+        {
+          source: "npm",
+          identifier: ("npm advisory " + .advisory_id),
+          location: .package,
+          severity: .severity,
+          urlline: ("URL: " + .url),
+          desc: .title
+        }
+      end
+    | {
+        identifier: .identifier,
+        title: ("security: " + .identifier + " in " + .location),
+        body: ([
+          ("Identifier: " + .identifier),
+          ("Source: " + .source),
+          ("Severity: " + .severity),
+          .urlline,
+          ("Description: " + .desc),
+          ("Pre-existing out-of-scope finding surfaced during the security review of PR #" + $pr + ".")
+        ] | join("\n"))
+      }
+  ]
+' </dev/stdin

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-security-followup
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-security-followup
@@ -21,7 +21,7 @@
 #
 # Meaningfulness predicate (a follow-up is emitted ONLY when ALL hold):
 #   CodeQL: classification == "out-of-scope" AND
-#           security_severity_level in {high, medium}
+#           security_severity_level in {critical, high, medium}
 #   npm:    classification == "out-of-scope" AND severity in {high, critical}
 #           AND introduced_by_diff == false
 #   required and false-positive are always excluded.
@@ -38,7 +38,7 @@ jq --arg pr "$pr" '
     | select(
         (.source == "codeql"
           and .classification == "out-of-scope"
-          and (.security_severity_level == "high" or .security_severity_level == "medium"))
+          and (.security_severity_level == "critical" or .security_severity_level == "high" or .security_severity_level == "medium"))
         or
         (.source == "npm"
           and .classification == "out-of-scope"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -13506,10 +13506,15 @@ out=$(printf '%s' '[{"source":"npm","classification":"out-of-scope","advisory_id
 assert_eq "followup: npm out-of-scope high introduced-by-diff → 0" "0" "$(printf '%s' "$out" | jq -r 'length')"
 
 # 11a. CodeQL stable identifier embedded verbatim in title
-out=$(printf '%s' '[{"source":"codeql","classification":"out-of-scope","rule_id":"js/sql-injection","alert_number":42,"security_severity_level":"high","description":"sqli","location":"src/db.ts","html_url":"http://x"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+out=$(printf '%s' '[{"source":"codeql","classification":"out-of-scope","rule_id":"js/sql-injection","alert_number":42,"security_severity_level":"high","description":"sqli","location":"src/db.ts","html_url":"https://github.com/org/repo/security/code-scanning/42"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
 title=$(printf '%s' "$out" | jq -r '.[0].title')
 case "$title" in *"CodeQL js/sql-injection alert #42"*) hit=yes ;; *) hit=no ;; esac
 assert_eq "followup: codeql identifier embedded in title" "yes" "$hit"
+
+# 11c. CodeQL html_url is included in body for traceability
+body=$(printf '%s' "$out" | jq -r '.[0].body')
+case "$body" in *"https://github.com/org/repo/security/code-scanning/42"*) hit=yes ;; *) hit=no ;; esac
+assert_eq "followup: codeql html_url in body" "yes" "$hit"
 
 # 11b. npm stable identifier embedded verbatim in title
 out=$(printf '%s' '[{"source":"npm","classification":"out-of-scope","advisory_id":"GHSA-xxxx-yyyy","severity":"critical","introduced_by_diff":false,"package":"react","title":"xss","url":"http://npm"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -13631,6 +13631,10 @@ assert_eq "followup: codeql out-of-scope high → 1" "1" "$(printf '%s' "$out" |
 out=$(printf '%s' '[{"source":"codeql","classification":"out-of-scope","rule_id":"js/xss","alert_number":7,"security_severity_level":"medium","description":"xss","location":"src/y.ts","html_url":"http://y"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
 assert_eq "followup: codeql out-of-scope medium → 1" "1" "$(printf '%s' "$out" | jq -r 'length')"
 
+# CodeQL out-of-scope critical → length 1
+out=$(printf '%s' '[{"source":"codeql","classification":"out-of-scope","rule_id":"js/crit","alert_number":99,"security_severity_level":"critical","description":"crit","location":"src/c.ts","html_url":"http://c"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: codeql out-of-scope critical → 1" "1" "$(printf '%s' "$out" | jq -r 'length')"
+
 # 3. CodeQL out-of-scope low → length 0
 out=$(printf '%s' '[{"source":"codeql","classification":"out-of-scope","rule_id":"js/low","alert_number":1,"security_severity_level":"low","description":"low","location":"src/z.ts","html_url":"http://z"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
 assert_eq "followup: codeql out-of-scope low → 0" "0" "$(printf '%s' "$out" | jq -r 'length')"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -13062,6 +13062,85 @@ deps=false
 app_or_rules=false" "$out"
 
 # ============================================================================
+# === dispatch-security-followup ===
+# ============================================================================
+
+echo "Test: dispatch-security-followup"
+
+# 1. CodeQL out-of-scope high → length 1
+out=$(printf '%s' '[{"source":"codeql","classification":"out-of-scope","rule_id":"js/sqli","alert_number":42,"security_severity_level":"high","description":"sqli","location":"src/db.ts:10","html_url":"http://x"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: codeql out-of-scope high → 1" "1" "$(printf '%s' "$out" | jq -r 'length')"
+
+# 2. CodeQL out-of-scope medium → length 1
+out=$(printf '%s' '[{"source":"codeql","classification":"out-of-scope","rule_id":"js/xss","alert_number":7,"security_severity_level":"medium","description":"xss","location":"src/y.ts","html_url":"http://y"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: codeql out-of-scope medium → 1" "1" "$(printf '%s' "$out" | jq -r 'length')"
+
+# 3. CodeQL out-of-scope low → length 0
+out=$(printf '%s' '[{"source":"codeql","classification":"out-of-scope","rule_id":"js/low","alert_number":1,"security_severity_level":"low","description":"low","location":"src/z.ts","html_url":"http://z"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: codeql out-of-scope low → 0" "0" "$(printf '%s' "$out" | jq -r 'length')"
+
+# 4. CodeQL out-of-scope null security_severity_level → length 0
+out=$(printf '%s' '[{"source":"codeql","classification":"out-of-scope","rule_id":"js/null","alert_number":2,"security_severity_level":null,"description":"n","location":"src/n.ts","html_url":"http://n"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: codeql out-of-scope null sev → 0" "0" "$(printf '%s' "$out" | jq -r 'length')"
+
+# 5. CodeQL required (high) → length 0
+out=$(printf '%s' '[{"source":"codeql","classification":"required","rule_id":"js/req","alert_number":3,"security_severity_level":"high","description":"r","location":"src/r.ts","html_url":"http://r"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: codeql required high → 0" "0" "$(printf '%s' "$out" | jq -r 'length')"
+
+# 6. CodeQL false-positive (high) → length 0
+out=$(printf '%s' '[{"source":"codeql","classification":"false-positive","rule_id":"js/fp","alert_number":4,"security_severity_level":"high","description":"fp","location":"src/fp.ts","html_url":"http://fp"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: codeql false-positive high → 0" "0" "$(printf '%s' "$out" | jq -r 'length')"
+
+# 7. npm out-of-scope high, introduced_by_diff=false → length 1
+out=$(printf '%s' '[{"source":"npm","classification":"out-of-scope","advisory_id":"GHSA-aaaa","severity":"high","introduced_by_diff":false,"package":"lodash","title":"proto pollution","url":"http://npm"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: npm out-of-scope high not-diff → 1" "1" "$(printf '%s' "$out" | jq -r 'length')"
+
+# 8. npm out-of-scope critical, introduced_by_diff=false → length 1
+out=$(printf '%s' '[{"source":"npm","classification":"out-of-scope","advisory_id":"GHSA-bbbb","severity":"critical","introduced_by_diff":false,"package":"axios","title":"ssrf","url":"http://npm2"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: npm out-of-scope critical not-diff → 1" "1" "$(printf '%s' "$out" | jq -r 'length')"
+
+# 9. npm out-of-scope moderate → length 0
+out=$(printf '%s' '[{"source":"npm","classification":"out-of-scope","advisory_id":"GHSA-cccc","severity":"moderate","introduced_by_diff":false,"package":"qs","title":"dos","url":"http://npm3"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: npm out-of-scope moderate → 0" "0" "$(printf '%s' "$out" | jq -r 'length')"
+
+# 10. npm out-of-scope high but introduced_by_diff=true → length 0
+out=$(printf '%s' '[{"source":"npm","classification":"out-of-scope","advisory_id":"GHSA-dddd","severity":"high","introduced_by_diff":true,"package":"minimist","title":"proto","url":"http://npm4"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: npm out-of-scope high introduced-by-diff → 0" "0" "$(printf '%s' "$out" | jq -r 'length')"
+
+# 11a. CodeQL stable identifier embedded verbatim in title
+out=$(printf '%s' '[{"source":"codeql","classification":"out-of-scope","rule_id":"js/sql-injection","alert_number":42,"security_severity_level":"high","description":"sqli","location":"src/db.ts","html_url":"http://x"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+title=$(printf '%s' "$out" | jq -r '.[0].title')
+case "$title" in *"CodeQL js/sql-injection alert #42"*) hit=yes ;; *) hit=no ;; esac
+assert_eq "followup: codeql identifier embedded in title" "yes" "$hit"
+
+# 11b. npm stable identifier embedded verbatim in title
+out=$(printf '%s' '[{"source":"npm","classification":"out-of-scope","advisory_id":"GHSA-xxxx-yyyy","severity":"critical","introduced_by_diff":false,"package":"react","title":"xss","url":"http://npm"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+title=$(printf '%s' "$out" | jq -r '.[0].title')
+case "$title" in *"npm advisory GHSA-xxxx-yyyy"*) hit=yes ;; *) hit=no ;; esac
+assert_eq "followup: npm identifier embedded in title" "yes" "$hit"
+
+# 12. Mixed interleaved array → only qualifying subset in input order
+out=$(printf '%s' '[
+  {"source":"codeql","classification":"out-of-scope","rule_id":"js/a","alert_number":1,"security_severity_level":"high","description":"a","location":"a.ts","html_url":"http://a"},
+  {"source":"codeql","classification":"required","rule_id":"js/b","alert_number":2,"security_severity_level":"high","description":"b","location":"b.ts","html_url":"http://b"},
+  {"source":"npm","classification":"out-of-scope","advisory_id":"GHSA-c","severity":"critical","introduced_by_diff":false,"package":"c","title":"c","url":"http://c"},
+  {"source":"npm","classification":"out-of-scope","advisory_id":"GHSA-d","severity":"moderate","introduced_by_diff":false,"package":"d","title":"d","url":"http://d"},
+  {"source":"codeql","classification":"out-of-scope","rule_id":"js/e","alert_number":5,"security_severity_level":"medium","description":"e","location":"e.ts","html_url":"http://e"}
+]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: mixed array → 3 qualifying" "3" "$(printf '%s' "$out" | jq -r 'length')"
+assert_eq "followup: mixed array → identifiers in input order" "CodeQL js/a alert #1
+npm advisory GHSA-c
+CodeQL js/e alert #5" "$(printf '%s' "$out" | jq -r '.[].identifier')"
+
+# 13. Empty input [] → length 0
+out=$(printf '%s' '[]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: empty input → 0" "0" "$(printf '%s' "$out" | jq -r 'length')"
+
+# 14. Unknown/missing source → ignored
+out=$(printf '%s' '[{"source":"sonarqube","classification":"out-of-scope","security_severity_level":"high"},{"classification":"out-of-scope","severity":"critical"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
+assert_eq "followup: unknown/missing source → 0" "0" "$(printf '%s' "$out" | jq -r 'length')"
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/security-review-fix/SKILL.md
+++ b/.claude/skills/security-review-fix/SKILL.md
@@ -263,7 +263,7 @@ ready. Otherwise run all steps in order.
    **Meaningfulness threshold** (documented to keep follow-up noise low):
 
    - CodeQL: an alert classified `out-of-scope` with `security_severity_level`
-     of `high` or `medium`.
+     of `critical`, `high`, or `medium`.
    - npm: a pre-existing advisory classified `out-of-scope` rated `high` or
      `critical` and not introduced by the diff (`introduced_by_diff=false`).
    - `required` and `false-positive` findings are never filed.

--- a/.claude/skills/security-review-fix/SKILL.md
+++ b/.claude/skills/security-review-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-review-fix
-description: Security phase — classify the diff's changed surface, then fan out only the relevant security subagents (skip entirely for docs-only diffs), run CodeQL and the dependency audit inline when relevant, classify findings, apply the required fixes, post a PR comment, apply the dispatch:security-reviewed label, and mark the PR ready
+description: Security phase — classify the diff's changed surface, then fan out only the relevant security subagents (skip entirely for docs-only diffs), run CodeQL and the dependency audit inline when relevant, classify findings, file security follow-ups for meaningful out-of-scope findings, apply the required fixes, post a PR comment, apply the dispatch:security-reviewed label, and mark the PR ready
 ---
 
 # Security Review and Fix
@@ -180,12 +180,19 @@ ready. Otherwise run all steps in order.
      > "$AUDIT_DIR/audit-baseline.json"
    ```
 
-   Report only advisories whose advisory ID appears in
-   `$AUDIT_DIR/audit-head.json` but not in `$AUDIT_DIR/audit-baseline.json` —
-   these are CVEs the PR's dependency changes newly expose. Also flag any
-   dependency the PR adds or upgrades whose resolved version skips a published
-   security-patch release for that package. Normalize each into the
-   **Per-finding schema**.
+   Advisories whose ID appears in `$AUDIT_DIR/audit-head.json` but **not** in
+   `$AUDIT_DIR/audit-baseline.json` are CVEs the PR's dependency changes newly
+   expose — normalize each into the **Per-finding schema** with
+   `introduced_by_diff=true`; these are in-scope and classify `required`. Also
+   flag any dependency the PR adds or upgrades whose resolved version skips a
+   published security-patch release.
+
+   Advisories whose ID appears in **both** head and baseline rated `high` or
+   `critical` are pre-existing — the diff did not introduce them. Normalize each
+   into the **Per-finding schema** with `introduced_by_diff=false` and classify
+   `out-of-scope`: they feed the follow-up-filing step below, not the PR's
+   required-fix set. Pre-existing advisories rated `moderate` or `low` are below
+   the meaningfulness threshold — do not surface them.
 
    ### CodeQL alerts (inline, when `surface=code`)
 
@@ -245,6 +252,61 @@ ready. Otherwise run all steps in order.
    The classified finding set is the input to Step 2 and the audit trail for
    the Step 4 PR comment.
 
+   ### File follow-ups for meaningful out-of-scope findings
+
+   Meaningful out-of-scope CodeQL alerts and pre-existing npm advisories are
+   filed as `security`-labeled follow-up issues — otherwise they evaporate when
+   the PR merges. The PR's own required-fix set stays scoped to the diff
+   (unchanged); this only files trackers for genuine findings the diff did not
+   introduce.
+
+   **Meaningfulness threshold** (documented to keep follow-up noise low):
+
+   - CodeQL: an alert classified `out-of-scope` with `security_severity_level`
+     of `high` or `medium`.
+   - npm: a pre-existing advisory classified `out-of-scope` rated `high` or
+     `critical` and not introduced by the diff (`introduced_by_diff=false`).
+   - `required` and `false-positive` findings are never filed.
+
+   Serialize the classified `codeql` and `npm` findings to a JSON array under
+   `tmp/` — one object per finding carrying `classification`, `source`, and the
+   source's fields (CodeQL: `rule_id`, `alert_number`, `security_severity_level`,
+   `description`, `location`, `html_url`; npm: `advisory_id`, `severity`,
+   `introduced_by_diff`, `package`, `title`, `url`), all already captured during
+   normalization. Findings from other sources carry no stable ID and are omitted.
+   Pipe the array through `dispatch-security-followup` with `PR_NUM` (pure — no
+   network/git/gh, so it runs sandboxed-fine):
+
+   ```bash
+   .claude/skills/dispatch-propagate/scripts/dispatch-security-followup "$PR_NUM" \
+     < tmp/security-findings.json
+   ```
+
+   It applies the threshold and emits a JSON array of `{identifier, title, body}`
+   follow-ups (empty when none qualify). Each `identifier` — CodeQL `rule.id` +
+   alert number, or the npm advisory ID — is embedded in the `title`, so
+   `/file-issue`'s title-keyword dedup prevents re-filing the same alert across
+   repeated runs or multiple PRs.
+
+   For each emitted follow-up, fork a subagent (`subagent_type: general-purpose`,
+   `model: sonnet`); run them in parallel (multiple Agent calls in one message).
+   Each subagent:
+
+   1. Invokes `/file-issue` with the follow-up's `title` on the first line and
+      its `body` after. `/file-issue` owns duplicate detection, creation, `@me`
+      assignment, and the `help wanted` label; it prints `CREATED <N>` or
+      `EXISTING <N>` on its own line — parse `<N>`.
+   2. Applies the topic and type labels (use `dangerouslyDisableSandbox: true` —
+      `gh` needs network):
+
+      ```bash
+      gh issue edit <N> --add-label security --add-label bug
+      ```
+
+   3. Returns `<N>` mapped to the follow-up's `identifier`.
+
+   Capture each `<N>` against its source finding for the Step 4 comment.
+
 2. **Apply the required fixes.** Implement fixes for the findings classified
    `required` in Step 1 — launch implementation subagent(s) via the Agent tool,
    constrained to **working-tree edits only — no commits, no pushes**. Choose
@@ -265,7 +327,9 @@ ready. Otherwise run all steps in order.
    summarizes **every** finding from Step 1 and its disposition — fixed (with
    the fix's commit SHA) or not fixed (with the reason). CodeQL-sourced findings
    are identified by their `rule.id` and alert `number`, linked via their
-   `html_url`; there is no separate CodeQL listing. The body file **must** live
+   `html_url`; there is no separate CodeQL listing. Each out-of-scope finding
+   filed as a follow-up in Step 1 links its follow-up issue `#<N>` alongside its
+   disposition. The body file **must** live
    under `tmp/` because `post-pr-comment.sh` restricts paths to that directory.
    Then post it (use `dangerouslyDisableSandbox: true` — the script invokes
    `gh`):


### PR DESCRIPTION
Closes #985

Wires meaningful out-of-scope security findings into the issue queue as `security`-labeled follow-ups, so pre-existing CodeQL alerts and npm advisories the diff did not introduce are tracked rather than evaporating once the PR merges. The PR's own required-fix set stays scoped to its diff.

## Changes

- **New script** `dispatch-security-followup` (`.claude/skills/dispatch-propagate/scripts/`): a pure `jq` stdin→stdout classifier that owns the deterministic follow-up logic — the meaningfulness threshold, the stable identifier, and the issue title/body composition. Reads classified findings, emits `{identifier, title, body}` follow-ups for qualifying findings only.
- **`security-review-fix/SKILL.md`**: surfaces pre-existing high/critical npm advisories (present in both head and baseline) as `out-of-scope`; adds a "File follow-ups for meaningful out-of-scope findings" subsection to Step 1 that files one `security`+`bug` follow-up per qualifying finding via `/file-issue`; links each follow-up `#N` in the Step 4 PR comment; documents the meaningfulness threshold.
- **`test-dispatch-scripts.sh`**: new `dispatch-security-followup` block covering the threshold branches, the stable-identifier dedup contract, input-order preservation, and empty/unknown-source handling.

## Meaningfulness threshold

- CodeQL: `out-of-scope` alert with `security_severity_level` of `high` or `medium`.
- npm: `out-of-scope` advisory rated `high`/`critical`, not introduced by the diff.

Stable identifier (CodeQL `rule.id` + alert number, or npm advisory ID) is embedded in the follow-up title so `/file-issue` dedup prevents re-filing across runs/PRs.

## Test plan

- [x] `bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` — full suite passes (1137/1137).