### PR TITLE
dispatch: exempt human-typed /dispatch from the autonomous bounds (#1052)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -3,7 +3,7 @@
 # materialize-and-spawn orchestrator (the deterministic Steps 4-6 of the old
 # SKILL.md, bundled into one script).
 #
-# Usage: dispatch-materialize-spawn <issue-N> <explicit|queue> [--gap <N>]
+# Usage: dispatch-materialize-spawn <issue-N> <explicit|queue> [--gap <N>|--gap unbounded]
 #
 # Picks up after dispatch-select-tick has chosen a target. Runs the explicit-
 # path guards (leaf trace, closed-target, open-blocker), resolves the target
@@ -21,6 +21,10 @@
 # worker registers before the next selection — #945/#905 — so the next
 # selection skips its now-live-owned worktree and yields a distinct target).
 # `explicit` mode and `--gap 1` process a single target (backward-compatible).
+# `--gap unbounded` is the manual ungated fan-out (the bare human-typed
+# `/dispatch`): it fans out one worker per eligible distinct target until the
+# queue is exhausted, bounded only by queue availability — never by a numeric
+# gap ceiling.
 #
 # <issue-N> is always the ISSUE number (the model derives N=${branch%%-*} for a
 # `pr` row before calling). The two literal `[branch phase]` positionals the
@@ -68,7 +72,9 @@
 #   propagate              the fan-out spawned at least one worker. Preceded by a
 #                          `propagate: spawned <k> of gap <G> [(<stop-reason>)]`
 #                          summary line and one `propagate: spawned/parked/skipped
-#                          #<n>` detail line per processed target.
+#                          #<n>` detail line per processed target. For a manual
+#                          ungated run (--gap unbounded) the summary line prints
+#                          `of gap unbounded` instead of a numeric gap.
 #   drain                  the gap could not be filled and NOTHING spawned (every
 #                          processed target parked/skipped, or the queue emptied
 #                          before any spawn). Same detail/summary lines precede
@@ -138,11 +144,15 @@ spawn_conflict_resolver() {
 N="${1:-}"
 MODE="${2:-}"
 GAP=1
+UNBOUNDED=0
 if [[ "${3:-}" == "--gap" ]]; then
   GAP="${4:-}"
-  if [[ ! "$GAP" =~ ^[1-9][0-9]*$ ]]; then
+  if [[ "$GAP" == "unbounded" ]]; then
+    UNBOUNDED=1
+    GAP=1
+  elif [[ ! "$GAP" =~ ^[1-9][0-9]*$ ]]; then
     release_lock
-    echo "dispatch-materialize-spawn: --gap requires a positive integer, got '${4:-}'" >&2
+    echo "dispatch-materialize-spawn: --gap requires a positive integer or 'unbounded', got '${4:-}'" >&2
     exit 2
   fi
 elif [[ -n "${3:-}" ]]; then
@@ -339,7 +349,7 @@ process_one_target() {
 # --- Driver ------------------------------------------------------------------
 # Single-target path: explicit targets and gap<=1 process exactly one target and
 # emit the per-target terminal token, byte-identical to the pre-fan-out script.
-if [[ "$MODE" == "explicit" ]] || (( GAP <= 1 )); then
+if (( UNBOUNDED == 0 )) && { [[ "$MODE" == "explicit" ]] || (( GAP <= 1 )); }; then
   process_one_target "$N" "$MODE" || { release_lock; exit 2; }
   release_lock
   case "$OUTCOME" in
@@ -434,7 +444,7 @@ while :; do
       esac
       ;;
   esac
-  (( spawned >= GAP )) && break
+  (( UNBOUNDED == 0 )) && (( spawned >= GAP )) && break
   SELECTED=$("$SCRIPT_DIR/dispatch-select-target") || true
   case "$SELECTED" in
     pr\ *)
@@ -455,10 +465,12 @@ while :; do
   fi
 done
 release_lock
+gap_label=$GAP
+(( UNBOUNDED == 1 )) && gap_label=unbounded
 if [[ "$stop_reason" == "gap filled" ]]; then
-  echo "propagate: spawned $spawned of gap $GAP"
+  echo "propagate: spawned $spawned of gap $gap_label"
 else
-  echo "propagate: spawned $spawned of gap $GAP ($stop_reason)"
+  echo "propagate: spawned $spawned of gap $gap_label ($stop_reason)"
 fi
 if (( spawned >= 1 )); then echo "propagate"; else echo "drain"; fi
 exit 0

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -2,7 +2,7 @@
 # dispatch-select-tick — the /dispatch-propagate router's selection orchestrator
 # (the deterministic Steps 0-3 of the old SKILL.md, bundled into one script).
 #
-# Usage: dispatch-select-tick [<issue-or-PR-number>]
+# Usage: dispatch-select-tick [--manual] [<issue-or-PR-number>]
 #
 # Runs the lock acquisition, origin/main sync (only on `main`), the run-scoped
 # concurrency gate, the JIT engine, the Calendar JIT importer, and target
@@ -32,7 +32,10 @@
 # fan-out loop consumes (always >= 1 on a target line). An explicit-target run
 # (a positional <number> is given) skips the concurrency gate entirely and forces
 # <gap> = 1 — a deliberately-named target is not paced by the autonomous budget.
-# The no-arg queue path keeps the full gate.
+# A `--manual` run (the bare human-typed `/dispatch` shim) ALSO skips the gate,
+# but UNLIKE the explicit path it emits <gap> = unbounded and fans out over the
+# whole queue — exempt from BOTH the pace curve and the MAX_WORKERS ceiling. The
+# autonomous no-arg queue path keeps the full gate.
 #
 # Lock invariant (the three guards): HOLD on pr/issue/explicit; RELEASE on
 # empty/sync-failed/resolver-failed/concurrency-cap/main-broken/jit-reminder;
@@ -53,8 +56,10 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 ARG=""
+MANUAL=""
 for a in "$@"; do
   case "$a" in
+    --manual) MANUAL=1 ;;
     --*) echo "dispatch-select-tick: unknown flag '$a'" >&2; exit 2 ;;
     *)
       if [[ -n "$ARG" ]]; then
@@ -65,6 +70,10 @@ for a in "$@"; do
       ;;
   esac
 done
+if [[ -n "$MANUAL" && -n "$ARG" ]]; then
+  echo "dispatch-select-tick: --manual cannot be combined with an explicit <number>" >&2
+  exit 2
+fi
 
 release_lock() {
   "$SCRIPT_DIR/dispatch-acquire-lock" --release >/dev/null 2>&1 || true
@@ -93,20 +102,26 @@ if [[ "$BRANCH" == "main" ]]; then
   fi
 fi
 
-# --- Step 1b: run-scoped concurrency gate (no-arg queue path only) -----------
-# Runs ONLY on the no-arg queue path. An explicit-target run (a positional
-# <number> was given) skips the gate entirely — no live-count query, never emits
-# `concurrency-cap`, and GAP stays 1: a deliberately-named target is not paced by
-# the autonomous concurrency budget.
-# On the queue path the gate is evaluated ONCE per run, before any selection
-# work, so a run already at the worker budget does no JIT/selection traversal.
-# Counts only busy workers (claude_agents_count_busy_workers). At cap: schedule
-# the #725 cap-keyed re-seed, release the lock, emit `concurrency-cap`. Under
-# cap: GAP bounds how many workers a fan-out run may spawn. Daemon UNKNOWN →
+# --- Step 1b: run-scoped concurrency gate (autonomous no-arg queue path only) -
+# Runs ONLY on the autonomous no-arg queue path. An explicit-target run (a
+# positional <number> was given) skips the gate entirely — no live-count query,
+# never emits `concurrency-cap`, and GAP stays 1: a deliberately-named target is
+# not paced by the autonomous concurrency budget. A `--manual` run (the bare
+# human-typed `/dispatch` shim) ALSO skips the gate entirely — no live-count
+# query, never emits `concurrency-cap` — but sets GAP=unbounded so the fan-out
+# is bounded only by queue availability, exempt from BOTH the pace curve and the
+# MAX_WORKERS ceiling (distinct from the explicit path's GAP=1).
+# On the autonomous queue path the gate is evaluated ONCE per run, before any
+# selection work, so a run already at the worker budget does no JIT/selection
+# traversal. Counts only busy workers (claude_agents_count_busy_workers). At cap:
+# schedule the #725 cap-keyed re-seed, release the lock, emit `concurrency-cap`.
+# Under cap: GAP bounds how many workers a fan-out run may spawn. Daemon UNKNOWN →
 # fail open (GAP=1); the per-worktree dedup in dispatch-spawn-worker is the
 # last-line defense.
 GAP=1
-if [[ -z "$ARG" ]]; then
+if [[ -n "$MANUAL" ]]; then
+  GAP=unbounded
+elif [[ -z "$ARG" ]]; then
   # shellcheck source=/dev/null
   source "$SCRIPT_DIR/lib-claude-agents.sh"
   TARGET_N=$("$SCRIPT_DIR/dispatch-target-workers")

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -2,7 +2,7 @@
 # dispatch-tick — the headless /dispatch-propagate tick: a thin bash sequencer
 # over dispatch-select-tick → dispatch-materialize-spawn, with NO model session.
 #
-# Usage: dispatch-tick [<issue-or-PR-number>]
+# Usage: dispatch-tick [--manual] [<issue-or-PR-number>]
 #
 # This is the scripted equivalent of the routing the dispatch-propagate SKILL.md
 # (Tables 1 and 2) used to describe for a model router session. Replacing that
@@ -16,8 +16,11 @@
 # self-close: where the model router would have called dispatch-self-close on a
 # `propagate`/`drain` disposition, dispatch-tick simply exits 0. The autonomous
 # tick is launched by systemd (the #725 heartbeat) and by the worker Stop-hook in
-# a later unit; a human-typed `/dispatch` is a thin shim that runs one tick and
-# relays its stdout for live UX. The audit record is this script's journal output
+# a later unit; it runs bare and keeps the concurrency gate. A human-typed
+# `/dispatch` is a thin shim that runs one tick and relays its stdout for live
+# UX; it passes `--manual` for the ungated unbounded fan-out (exempt from the
+# pace curve and the MAX_WORKERS ceiling), bounded only by queue availability.
+# The audit record is this script's journal output
 # (every captured stdout line is echoed through) plus the spawned workers'
 # transcripts plus durable GitHub side effects (PR comments, `dispatch:*`
 # labels) — so relay survives only on the human shim, not on the autonomous tick.
@@ -92,28 +95,37 @@ fi
 
 # --- Step 0: parse the single optional positional <N> ------------------------
 ARG=""
+MANUAL=""
 for a in "$@"; do
   case "$a" in
+    --manual) MANUAL=1 ;;
     --*)
       echo "dispatch-tick: unknown flag '$a'" >&2
-      echo "usage: dispatch-tick [<issue-or-PR-number>]" >&2
+      echo "usage: dispatch-tick [--manual] [<issue-or-PR-number>]" >&2
       exit 2
       ;;
     *)
       if [[ -n "$ARG" ]]; then
         echo "dispatch-tick: unexpected extra arguments after <number>" >&2
-        echo "usage: dispatch-tick [<issue-or-PR-number>]" >&2
+        echo "usage: dispatch-tick [--manual] [<issue-or-PR-number>]" >&2
         exit 2
       fi
       ARG="${a#\#}"
       ;;
   esac
 done
+if [[ -n "$MANUAL" && -n "$ARG" ]]; then
+  echo "dispatch-tick: --manual cannot be combined with an explicit <number>" >&2
+  echo "usage: dispatch-tick [--manual] [<issue-or-PR-number>]" >&2
+  exit 2
+fi
 
 # --- Step 1: select the target ------------------------------------------------
 # Capture select-tick's full stdout and echo every line through (jit:/calendar:
 # passthrough AND the decision line) so journald and a live relay see it all.
-if [[ -n "$ARG" ]]; then
+if [[ -n "$MANUAL" ]]; then
+  SEL_OUT=$("$SCRIPT_DIR/dispatch-select-tick" --manual)
+elif [[ -n "$ARG" ]]; then
   SEL_OUT=$("$SCRIPT_DIR/dispatch-select-tick" "$ARG")
 else
   SEL_OUT=$("$SCRIPT_DIR/dispatch-select-tick")

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -14106,10 +14106,10 @@ assert_eq "unbounded: terminal token" "propagate" "$(printf '%s\n' "$out" | tail
 assert_eq "unbounded: lock released at end" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
-# --- fan-out: --gap unbounded with empty queue → drain -----------------------
-# When the queue is empty on the first target's first selection pass, the
-# unbounded fan-out emits drain (nothing spawned), just like a bounded run.
-echo "Test: materialize-spawn --gap unbounded empty queue after first → drain"
+# --- fan-out: --gap unbounded first target spawned, queue then empty → propagate ---
+# When the first target (the passed-in N) is spawned and dispatch-select-target
+# then returns empty, the unbounded fan-out emits propagate (one spawn completed).
+echo "Test: materialize-spawn --gap unbounded first spawn then empty queue → propagate"
 mat_setup
 # MAT_QUEUE is unset → select-target returns empty immediately after first target.
 out=$(run_mat 839 queue --gap unbounded)
@@ -14353,12 +14353,12 @@ tick_teardown
 echo "Test: dispatch-tick --manual forwards --manual to select-tick"
 tick_setup
 export TICK_DECISION="issue 707 unbounded" TICK_TOKEN="propagate"
-out=$(run_tick --manual)
+out=$(run_tick --manual) && rc=0 || rc=$?
 assert_eq "manual-fwd: select-tick received --manual flag" "--manual" \
   "$(cat "$TMPDIR_TEST/logs/select-tick.log")"
 assert_eq "manual-fwd: materialize called with unbounded gap" "707 queue --gap unbounded" \
   "$(cat "$TMPDIR_TEST/logs/materialize.log")"
-assert_eq "manual-fwd: exit 0" "0" "$?"
+assert_eq "manual-fwd: exit 0" "0" "$rc"
 tick_teardown
 
 # --- --manual + explicit number → usage error, exit 2 -----------------------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -13274,6 +13274,8 @@ assert_eq "manual-pace0: decision line shows unbounded gap" "issue 707 unbounded
 assert_eq "manual-pace0: no reseed scheduled" "0" \
   "$([ -f "$TMPDIR_TEST/logs/schedule-reseed.log" ] && echo 1 || echo 0)"
 assert_eq "manual-pace0: lock held" "select-tick-session" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "manual-pace0: select-target invoked (selection ran)" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/select-target.log" ] && echo 1 || echo 0)"
 sel_tick_teardown
 
 # --- --manual with LIVE_COUNT >= MAX_WORKERS → no cap, unbounded gap ----------
@@ -13289,6 +13291,12 @@ echo called >> "$TMPDIR_TEST/logs/select-target.log"
 echo "issue 839"
 FAKE
 chmod +x "$TMPDIR_TEST/dispatch-select-target"
+cat > "$TMPDIR_TEST/dispatch-target-workers" <<FAKE
+#!/usr/bin/env bash
+echo called >> "$TMPDIR_TEST/logs/target-workers.log"
+echo "\${SEL_TARGET_N:-1}"
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-target-workers"
 out=$(run_sel_tick --manual)
 assert_eq "manual-overcap: no concurrency-cap emitted" "0" \
   "$(printf '%s\n' "$out" | grep -cF 'concurrency-cap')"
@@ -13296,6 +13304,8 @@ assert_eq "manual-overcap: decision line shows unbounded gap" "issue 839 unbound
   "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "manual-overcap: no reseed scheduled" "0" \
   "$([ -f "$TMPDIR_TEST/logs/schedule-reseed.log" ] && echo 1 || echo 0)"
+assert_eq "manual-overcap: pace-curve dispatch-target-workers NOT invoked (gate skipped)" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/target-workers.log" ] && echo 1 || echo 0)"
 sel_tick_teardown
 
 # --- autonomous no-arg with LIVE_COUNT >= TARGET_N → concurrency-cap (unchanged) ---

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -12958,6 +12958,76 @@ esac
 assert_eq "removed flag → unknown flag error, exit 2" "ok" "$status"
 sel_tick_teardown
 
+# --- --manual with TARGET_N=0 (pace pause) → no concurrency-cap, unbounded gap ---
+# A bare human-typed /dispatch is exempt from the pace-curve budget: even when
+# TARGET_N drops to 0 (budget pause) the --manual path skips the concurrency gate
+# entirely and emits an issue line with gap=unbounded, never emitting concurrency-cap.
+echo "Test: select-tick --manual with TARGET_N=0 → no concurrency-cap, unbounded gap"
+sel_tick_setup
+export SEL_LIVE_COUNT=3 SEL_TARGET_N=0
+cat > "$TMPDIR_TEST/dispatch-select-target" <<FAKE
+#!/usr/bin/env bash
+echo called >> "$TMPDIR_TEST/logs/select-target.log"
+echo "issue 707"
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
+out=$(run_sel_tick --manual)
+assert_eq "manual-pace0: no concurrency-cap emitted" "0" \
+  "$(printf '%s\n' "$out" | grep -cF 'concurrency-cap')"
+assert_eq "manual-pace0: decision line shows unbounded gap" "issue 707 unbounded" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "manual-pace0: no reseed scheduled" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-reseed.log" ] && echo 1 || echo 0)"
+assert_eq "manual-pace0: lock held" "select-tick-session" "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- --manual with LIVE_COUNT >= MAX_WORKERS → no cap, unbounded gap ----------
+# A bare human-typed /dispatch is also exempt from the MAX_WORKERS concurrency
+# ceiling: even when LIVE_COUNT exceeds the target the --manual path skips the
+# gate entirely.
+echo "Test: select-tick --manual with LIVE_COUNT >= MAX_WORKERS → no cap"
+sel_tick_setup
+export SEL_LIVE_COUNT=10 SEL_TARGET_N=1
+cat > "$TMPDIR_TEST/dispatch-select-target" <<FAKE
+#!/usr/bin/env bash
+echo called >> "$TMPDIR_TEST/logs/select-target.log"
+echo "issue 839"
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
+out=$(run_sel_tick --manual)
+assert_eq "manual-overcap: no concurrency-cap emitted" "0" \
+  "$(printf '%s\n' "$out" | grep -cF 'concurrency-cap')"
+assert_eq "manual-overcap: decision line shows unbounded gap" "issue 839 unbounded" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "manual-overcap: no reseed scheduled" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-reseed.log" ] && echo 1 || echo 0)"
+sel_tick_teardown
+
+# --- autonomous no-arg with LIVE_COUNT >= TARGET_N → concurrency-cap (unchanged) ---
+# The exemption is --manual only. An autonomous no-arg tick with LIVE_COUNT >= TARGET_N
+# still gates on the pace curve and emits concurrency-cap — unchanged behavior.
+echo "Test: select-tick autonomous no-arg LIVE_COUNT >= TARGET_N → concurrency-cap (unchanged)"
+sel_tick_setup
+export SEL_LIVE_COUNT=3 SEL_TARGET_N=0
+out=$(run_sel_tick)
+assert_eq "autonomous-cap: decision line is concurrency-cap" "concurrency-cap" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "autonomous-cap: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "autonomous-cap: reseed scheduled" "called" \
+  "$(cat "$TMPDIR_TEST/logs/schedule-reseed.log" 2>/dev/null)"
+sel_tick_teardown
+
+# --- --manual cannot be combined with an explicit <number> → exit 2 ----------
+echo "Test: select-tick --manual + explicit number → exit 2"
+sel_tick_setup
+err=$("$TMPDIR_TEST/dispatch-select-tick" --manual 707 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err" in
+  *"cannot be combined"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err" ;;
+esac
+assert_eq "--manual + number → usage error, exit 2" "ok" "$status"
+sel_tick_teardown
+
 # ============================================================================
 # dispatch-materialize-spawn tests (#919)
 # ============================================================================
@@ -13713,6 +13783,38 @@ assert_eq "distinct: worktrees all unique" "3" \
   "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
 mat_teardown
 
+# --- fan-out: --gap unbounded fans out over the entire queue, summary says 'unbounded' ---
+# The bare human-typed /dispatch passes --gap unbounded; materialize-spawn fans out
+# one worker per eligible target until the queue is exhausted, with no numeric cap.
+# The summary line prints 'of gap unbounded' and the terminal token is propagate.
+echo "Test: materialize-spawn --gap unbounded fans out over whole queue"
+mat_setup
+export MAT_QUEUE="720 508 991"
+out=$(run_mat 839 queue --gap unbounded)
+# 839 (first target) + 720 + 508 + 991 from the queue = 4 total spawns.
+assert_eq "unbounded: spawn count" "4" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+assert_eq "unbounded: summary shows 'of gap unbounded'" "1" \
+  "$(printf '%s\n' "$out" | grep -cF 'of gap unbounded')"
+assert_eq "unbounded: stop reason is queue exhausted" "1" \
+  "$(printf '%s\n' "$out" | grep -cF 'queue exhausted')"
+assert_eq "unbounded: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "unbounded: lock released at end" "" "$(cat "$DISPATCH_LOCK_FILE")"
+mat_teardown
+
+# --- fan-out: --gap unbounded with empty queue → drain -----------------------
+# When the queue is empty on the first target's first selection pass, the
+# unbounded fan-out emits drain (nothing spawned), just like a bounded run.
+echo "Test: materialize-spawn --gap unbounded empty queue after first → drain"
+mat_setup
+# MAT_QUEUE is unset → select-target returns empty immediately after first target.
+out=$(run_mat 839 queue --gap unbounded)
+# Only the first passed-in target (839) is spawned; select-target then returns empty.
+assert_eq "unbounded-exhaust: one spawn" "1" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+assert_eq "unbounded-exhaust: summary shows unbounded queue exhausted" "1" \
+  "$(printf '%s\n' "$out" | grep -cF 'of gap unbounded (queue exhausted)')"
+assert_eq "unbounded-exhaust: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+mat_teardown
+
 echo "=== print_remote_access_block ==="
 
 # All four emulators
@@ -13934,6 +14036,50 @@ export TICK_DECISION="explicit 88 1" TICK_TOKEN="propagate"
 out=$(run_tick '#88')
 assert_eq "arg forward: select-tick got the stripped arg" "88" \
   "$(cat "$TMPDIR_TEST/logs/select-tick.log")"
+tick_teardown
+
+# --- --manual is forwarded to select-tick, unbounded fan-out, never concurrency-cap ---
+# A bare human-typed /dispatch passes --manual to dispatch-tick, which must
+# forward it to dispatch-select-tick. The fake select-tick records its argv.
+# The decision line uses 'issue <N> unbounded' (from --manual → GAP=unbounded in
+# real select-tick); here the fake select-tick emits whatever TICK_DECISION says,
+# so we set it to 'issue 707 unbounded' to drive the materialize call as the
+# real path would.
+echo "Test: dispatch-tick --manual forwards --manual to select-tick"
+tick_setup
+export TICK_DECISION="issue 707 unbounded" TICK_TOKEN="propagate"
+out=$(run_tick --manual)
+assert_eq "manual-fwd: select-tick received --manual flag" "--manual" \
+  "$(cat "$TMPDIR_TEST/logs/select-tick.log")"
+assert_eq "manual-fwd: materialize called with unbounded gap" "707 queue --gap unbounded" \
+  "$(cat "$TMPDIR_TEST/logs/materialize.log")"
+assert_eq "manual-fwd: exit 0" "0" "$?"
+tick_teardown
+
+# --- --manual + explicit number → usage error, exit 2 -----------------------
+echo "Test: dispatch-tick --manual + explicit number → exit 2"
+tick_setup
+err=$("$TMPDIR_TEST/dispatch-tick" --manual 707 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err" in
+  *"cannot be combined"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err" ;;
+esac
+assert_eq "--manual + number → usage error, exit 2" "ok" "$status"
+tick_teardown
+
+# --- autonomous no-arg tick never emits concurrency-cap from dispatch-tick itself ---
+# The concurrency-cap decision is emitted by dispatch-select-tick on the autonomous
+# path; dispatch-tick routes it as a log-and-exit-0 disposition (no materialize).
+# This validates the autonomous routing is unchanged.
+echo "Test: dispatch-tick routes autonomous concurrency-cap → exit 0, no materialize"
+tick_setup
+export TICK_DECISION="concurrency-cap"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "auto-cap: exit 0" "0" "$rc"
+assert_eq "auto-cap: no materialize call" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/materialize.log" ] && echo 1 || echo 0)"
+assert_eq "auto-cap: no manual flag sent to select-tick" "0" \
+  "$(grep -cF -- '--manual' "$TMPDIR_TEST/logs/select-tick.log" 2>/dev/null)"
 tick_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatch
-description: Manual entry point for the dispatch chain — runs one headless dispatch-tick and relays its output live. `/dispatch <N>` targets one issue/PR and skips the concurrency gate; bare `/dispatch` runs the gated fan-out.
+description: Manual entry point for the dispatch chain — runs one headless dispatch-tick and relays its output live. `/dispatch <N>` targets one issue/PR and skips the concurrency gate; bare `/dispatch` runs an ungated fan-out, exempt from the autonomous bounds — it fans out over the eligible queue and is never capped.
 ---
 
 # Dispatch (manual shim)
@@ -8,7 +8,10 @@ description: Manual entry point for the dispatch chain — runs one headless dis
 Run the headless tick and relay its output live:
 
 ```bash
-.claude/skills/dispatch-propagate/scripts/dispatch-tick [<N>]
+# bare /dispatch (manual fan-out):
+.claude/skills/dispatch-propagate/scripts/dispatch-tick --manual
+# /dispatch <N> (explicit target):
+.claude/skills/dispatch-propagate/scripts/dispatch-tick <N>
 ```
 
 Run with `dangerouslyDisableSandbox: true` and `timeout: 600000` — the tick's
@@ -31,8 +34,11 @@ waiting (reseed scheduled), conflict-resolver job spawned, etc.
 processes that one target (gap=1). A human forcing a specific target is never
 paced by the autonomous budget.
 
-`/dispatch` (no argument): the tick runs the gated fan-out — gap = TARGET_N −
-live busy workers — respecting the autonomous pacing budget.
+`/dispatch` (no argument): a bare manual `/dispatch` is exempt from BOTH the
+pace-curve budget (`dispatch-target-workers`, which a budget pause can drop to 0)
+AND the `MAX_WORKERS` concurrency ceiling — it fans out one worker per eligible
+distinct target until the queue is exhausted and NEVER emits `concurrency-cap`.
+The only bound is queue availability.
 
 ## Selection lock
 


### PR DESCRIPTION
Closes #1052

A human typing bare `/dispatch` is a direct instruction to act *now*, but it was
being gated by the autonomous pace-curve budget (`dispatch-target-workers`) and
the `MAX_WORKERS` ceiling inside `dispatch-select-tick`. When `TARGET_N == 0`
(a budget pause) and `LIVE_COUNT >= TARGET_N`, the shim returned
`concurrency-cap` as a no-op — exactly the wrong behavior for a direct human
instruction. `/dispatch <N>` (explicit) already had this exemption; bare
`/dispatch` did not.

## Change

Thread a `--manual` flag from the `/dispatch` shim → `dispatch-tick` →
`dispatch-select-tick`. On the manual no-arg path, `dispatch-select-tick` skips
the concurrency gate entirely (no `dispatch-target-workers` query, no
`LIVE_COUNT` query, no reseed, never emits `concurrency-cap`) and emits an
`unbounded` gap. `dispatch-tick` relays that gap to `dispatch-materialize-spawn`,
which fans out one worker per eligible distinct target until the queue is
exhausted — bounded only by queue availability.

The autonomous launchers (the #725 heartbeat unit and the worker Stop-hook) run
bare and keep the pace-curve + `MAX_WORKERS` gate untouched.

## Scope

- `dispatch-select-tick` — parse `--manual`; skip the Step 1b gate and set
  `GAP=unbounded` on the manual path; reject `--manual` + explicit `<N>`.
- `dispatch-tick` — parse and forward `--manual`; reject `--manual` + explicit
  `<N>`.
- `dispatch-materialize-spawn` — accept `--gap unbounded`; route it to the
  fan-out driver with no numeric ceiling; print `of gap unbounded` in the
  summary.
- `dispatch/SKILL.md` — document that a bare `/dispatch` is exempt from both the
  pace curve and the `MAX_WORKERS` ceiling.
- `test-dispatch-scripts.sh` — cover manual fan-out under a 0 pace budget, manual
  fan-out with `LIVE_COUNT >= MAX_WORKERS` (asserting the pace-curve script is
  never invoked), autonomous gating unchanged, `--gap unbounded` materialize
  fan-out, and `--manual` forwarding through `dispatch-tick`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)