### PR TITLE
dispatch: rank budget topic in dispatch-select-target ladder

### DIFF
--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -169,7 +169,7 @@ tier — every topic category, every phase — before considering any `priority=
 item, so a `priority` item in a low-ranked topic outranks every non-priority
 item in a higher-ranked topic. Within one priority level, categories run
 highest first: `security` → `bug` → `testing infrastructure` → `dispatch` →
-`other`. The
+`budget` → `other`. The
 `priority` label is human-applied — `/ready` never applies it automatically.
 A PR's category is the highest-priority topic among the labels of every issue
 it closes; an issue's category is the highest-priority topic among its own

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -446,7 +446,7 @@ fi
 #      marker, not a topic.
 # A bare `security` label means topic; only PHASE_PRIORITY reads it as a phase,
 # and only the `dispatch:`-prefixed form is a phase label.
-TOPIC_CATEGORIES=(security bug "testing infrastructure" dispatch)
+TOPIC_CATEGORIES=(security bug "testing infrastructure" dispatch budget)
 CATEGORIES=("${TOPIC_CATEGORIES[@]}" other)
 # Same priority list as a JSON array, for category_of_labels' jq filter.
 TOPIC_CATEGORIES_JSON=$(printf '%s\n' "${TOPIC_CATEGORIES[@]}" | jq -Rcn '[inputs]')

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -43,7 +43,7 @@
 # phase — before considering any `priority=0` item, so a `priority` item in a
 # low-ranked topic still outranks every non-priority item in a higher-ranked
 # topic. Within one priority level, topic categories run highest priority first:
-#   security → bug → testing infrastructure → dispatch → other
+#   security → bug → testing infrastructure → dispatch → budget → other
 # and within each (priority, topic) bucket the phase ladder runs innermost.
 #
 # A PR's category is the highest-priority topic among the labels of every issue

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1633,7 +1633,7 @@ teardown
 # --- topic-category prioritization (issue #707) -----------------------------
 # The `priority` label is the outermost axis: every `priority` item ranks above
 # every non-priority item, regardless of topic. Topic category
-# (security → bug → testing infrastructure → dispatch → other) nests inside the priority
+# (security → bug → testing infrastructure → dispatch → budget → other) nests inside the priority
 # axis, and the phase ladder runs innermost. A PR's category is resolved from
 # the labels of the issues it closes; an issue's category from its own labels.
 
@@ -1842,6 +1842,38 @@ printf '[{"number":400,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"hel
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "security issue beats bug issue" "issue 300" "$result"
+teardown
+
+# 30j. A PR closing a `dispatch` issue outranks a PR closing a `budget` issue,
+#      even when the budget PR is newer — `dispatch` ranks above `budget` in
+#      the topic ladder (category beats age).
+echo "Test: PR closing a dispatch issue beats PR closing a budget issue"
+setup
+# PR 20 (older) closes budget issue 200; PR 10 (newer) closes dispatch issue 100.
+UNION='['
+UNION+="$(make_pr_union 20 "20-budget-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
+UNION+="$(make_pr_union 10 "10-dispatch-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100}]')"
+UNION+=']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"dispatch"}]},{"number":200,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"budget"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "dispatch-closing PR beats budget-closing PR" "pr 10 10-dispatch-pr verify" "$result"
+teardown
+
+# 30k. A help-wanted `budget` issue outranks a help-wanted issue with no topic
+#      label, even when the budget issue is newer — `budget` ranks above the
+#      `other` fallback.
+echo "Test: budget issue beats issue with no topic label"
+setup
+setup_union_pr_list '[]'
+# Issue 400 (older) has no topic label (resolves to `other`); issue 300 (newer) is budget.
+printf '[{"number":400,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":300,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"budget"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "budget issue beats untopiced (other) issue" "issue 300" "$result"
 teardown
 
 # --- blocked-issue PR skip (issue #786) -------------------------------------

--- a/.claude/skills/ref-ready/SKILL.md
+++ b/.claude/skills/ref-ready/SKILL.md
@@ -315,7 +315,8 @@ area and are orthogonal to the `dispatch:*` phase labels, which mark workflow
 progress. The topic axis is also orthogonal to the `bug`/`enhancement` type
 axis above: a vulnerability follow-up is `bug` type **and** `security` topic.
 Apply **at most one** topic label. The 'at most one' rule applies
-only to the topic axis — `security`, `dispatch`, and `testing infrastructure`.
+only to the topic axis — `security`, `dispatch`, `testing infrastructure`,
+and `budget`.
 `priority` is a separate axis (an escalation marker) and may be applied
 alongside a topic label.
 
@@ -346,6 +347,12 @@ alongside a topic label.
   signals: "CI", "unit test", "acceptance test", "Vitest", "Playwright",
   "fixture", "seed data", "test runner".
 
+- **`budget`** — concerns the budget app: the `budget/` frontend or the
+  `budget-etl/` pipeline. Ranks last among the topic categories in
+  `dispatch-select-target` queue selection (below `dispatch`), above the
+  `other` fallback. Keyword signals: "budget", "budget-etl", "QFX/OFX",
+  "bank statement", "categorization", "budget.json".
+
 - **`priority`** — a separate axis from the topic labels above. A
   human-applied escalation marker that routes the issue (or any PR closing it)
   ahead of non-priority items across all topic categories in `/dispatch-propagate` queue selection. Apply only
@@ -353,7 +360,7 @@ alongside a topic label.
   automatically. May be combined with any topic label.
 
 - **Neither** — apply no topic label. Most product and
-  landing/budget/print/fellspiral feature work matches neither topic. There is
+  landing/print/fellspiral feature work matches neither topic. There is
   no "other" sentinel label.
 
 When an issue matches `security` plus another topic, apply `security` — it is


### PR DESCRIPTION
Closes #1025

Ranks the new `budget` topic label in `dispatch-select-target`'s topic ladder, between `dispatch` and the `other` fallback. Resulting order: security → bug → testing infrastructure → dispatch → budget → other.

- `dispatch-select-target`: append `budget` to `TOPIC_CATEGORIES` (the single source of the ordering).
- `ref-ready` SKILL.md Step 6: document the `budget` topic — add it to the at-most-one enumeration, add a topic bullet, and drop `budget` from the now-stale "Neither" example.
- `test-dispatch-scripts.sh`: update the ladder comment and add bucket-ordering tests 30j (a `dispatch`-closing PR beats a `budget`-closing PR) and 30k (a `budget` issue beats an untopiced issue).