### PR TITLE
dispatch: the /digest skill and a skill-running jit-reminder path

### DIFF
--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -34,7 +34,11 @@ exists (cold start). Capture it as `<window-start>` for the next section.
 
 ## 2. Enumerate dispatch-queue work completed in the window
 
-Collect everything merged into `natb1/commons.systems` since the window start:
+Collect everything merged into `natb1/commons.systems` since the window start.
+The workspace repo is hardcoded here on purpose: dispatch-queue work always
+merges into `natb1/commons.systems`, whereas the `<repo>` argument names where
+the *digest issue itself* lives (`natb1/office-hours-nate` for the real digest
+jit) — a different repo. Do not substitute `<repo>` into this query.
 
 ```bash
 gh pr list --repo natb1/commons.systems --state merged \
@@ -121,11 +125,12 @@ Compose the summary:
 - per user-facing item: the live-demo outcome, or the numbered demo steps;
 - a list of the completed-but-internal items.
 
-Write the body to a temp file under this job's tmp dir (item titles may carry
-shell metacharacters, so do not inline the body), then post it:
+Write the body to a temp file under this job's tmp dir — use
+`$CLAUDE_JOB_DIR/tmp/digest-body.md` (item titles may carry shell
+metacharacters, so do not inline the body) — then post it:
 
 ```bash
-gh issue comment <num> --repo <repo> --body-file <tmp-file>
+gh issue comment <num> --repo <repo> --body-file "$CLAUDE_JOB_DIR/tmp/digest-body.md"
 ```
 
 Run this with `dangerouslyDisableSandbox: true` — it calls `gh`.

--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: digest
+description: Summarize all dispatch-queue work completed since the previous digest closed, demo every user-facing item with the user present, post the summary as a comment on the digest issue, and close it. Runs as an office-hours session, invoked by dispatch-jit-reminder for the digest jit.
+---
+
+# Digest
+
+Runs as an **office-hours session** with the user present — it cannot run
+unattended, because its demos are interactive (it drives the live browser apps).
+
+`dispatch-jit-reminder` invokes this skill after it claims the digest jit issue
+(sets the project `Status` → `In Progress`). This skill owns the rest of that
+session and produces its output for the user.
+
+Takes two arguments: `<repo> <num>` — the digest jit issue this run covers.
+
+Work each section in order. Run every `gh`-calling command with
+`dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
+
+## 1. Compute the digest window
+
+Find the window-start timestamp — the boundary before which work was already
+covered by a prior digest:
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-digest-window <repo> <num>
+```
+
+Run this with `dangerouslyDisableSandbox: true` — it calls `gh`.
+
+It prints an ISO-8601 timestamp: the previous closed digest issue's `closedAt`
+(steady state), or this issue's own `createdAt` when no prior closed digest
+exists (cold start). Capture it as `<window-start>` for the next section.
+
+## 2. Enumerate dispatch-queue work completed in the window
+
+Collect everything merged into `natb1/commons.systems` since the window start:
+
+```bash
+gh pr list --repo natb1/commons.systems --state merged \
+  --search "merged:>=<window-start>" \
+  --json number,title,mergedAt,labels,closingIssuesReferences
+```
+
+Run this with `dangerouslyDisableSandbox: true` — it calls `gh`.
+
+Each PR's `closingIssuesReferences` lists the issues it closed. Identify which
+PRs are dispatch-queue work via two signals — both stamped onto a PR as it
+advances through the chain:
+
+- **The `dispatch:*` labels** accumulated on the PR — `dispatch:security-reviewed`,
+  `dispatch:reviewed`, `dispatch:code-reviewed`, `dispatch:qa-done`. A PR that
+  rode the chain carries one or more of these.
+- **Membership on the commons.systems project board** — the dispatch chain
+  tracks its work there.
+
+A PR with neither signal is not dispatch-queue work; leave it out of the digest.
+The previous digest's own merge may show up in the window — that is fine; it is
+just one more completed item.
+
+## 3. Judge each completed item for user-facing functionality
+
+For each merged PR / closed issue, decide whether it delivered **user-facing
+functionality** — a change a user would observe — versus internal tooling,
+refactors, or dispatch plumbing.
+
+- User-facing: a new budget chart, a fellspiral interaction, a landing-page
+  section, a new `/budget` capability the user runs.
+- Not user-facing: a dispatch-script refactor, a test-only change, a CI fix, an
+  internal type cleanup.
+
+Only user-facing items get demoed in §4. List the rest in the summary as
+completed-but-internal so the user still sees the full scope of work.
+
+## 4. Demo every user-facing item with the user present
+
+For each user-facing item, pick the matching case.
+
+### Browser-app feature (apps `budget`, `fellspiral`, `landing`, `print`)
+
+Run an interactive live demo against the production app with the Claude Chrome
+extension, per `.claude/rules/chrome-extension.md`:
+
+1. Start the browser context (`tabs_context_mcp`) and confirm Chrome is
+   connected. If `list_connected_browsers` returns `[]`, ask the user to start
+   Chrome, then retry.
+2. Open a tab to the production app, navigate to the feature, drive it, and
+   narrate what the user is seeing as you go.
+
+Resolve the production URL from `.firebaserc` rather than trusting a hardcoded
+list — read `targets.commons-systems.hosting`, where each app maps to a hosting
+site id served at `https://<site-id>.web.app`, except `landing`, which is served
+at `https://commons.systems`. As of now the mapping is:
+
+| App | Production URL |
+|---|---|
+| budget | https://cs-budget-f920.web.app |
+| fellspiral | https://cs-fellspiral-4e12.web.app |
+| print | https://cs-print-00af.web.app |
+| landing | https://commons.systems |
+
+Per the chrome-extension rule, the first call to a gated browser tool for a new
+origin is denied before the approval popup surfaces — **retry the failed call
+once**, and the retry succeeds. If browser calls keep failing after that one
+retry, stop and ask the user rather than looping.
+
+### Non-browser user-facing functionality (a CLI such as `budget-etl`, or a slash-command skill)
+
+Do **not** execute it. Instead add **numbered demo steps** to the summary so the
+user can try it themselves — the exact command and what to expect. For example:
+
+1. Run `/budget ~/Downloads/statements/` in Claude Code.
+2. The `budget-etl` binary runs locally and writes `budget.json`.
+3. Upload it to the budget app to see the new view.
+
+## 5. Post the summary as a comment on the digest issue
+
+Compose the summary:
+
+- the window covered (window start → now);
+- per user-facing item: the live-demo outcome, or the numbered demo steps;
+- a list of the completed-but-internal items.
+
+Write the body to a temp file under this job's tmp dir (item titles may carry
+shell metacharacters, so do not inline the body), then post it:
+
+```bash
+gh issue comment <num> --repo <repo> --body-file <tmp-file>
+```
+
+Run this with `dangerouslyDisableSandbox: true` — it calls `gh`.
+
+This is a GitHub-rendered artifact: per `.claude/rules/issue-references.md`, keep
+bare `#N` references and append **no** `References:` list.
+
+## 6. Close the digest issue
+
+```bash
+gh issue close <num> --repo <repo>
+```
+
+Run this with `dangerouslyDisableSandbox: true` — it calls `gh`.
+
+Closing both records the digest and anchors the next cadence cycle: per the JIT
+engine, the next digest issue is created `remindAfterClose` (24h) after this
+`closedAt`. Then the session ends — the posted summary and the demos are the
+office-hours session's output for the user.

--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -37,8 +37,9 @@ exists (cold start). Capture it as `<window-start>` for the next section.
 Collect everything merged into `natb1/commons.systems` since the window start.
 The workspace repo is hardcoded here on purpose: dispatch-queue work always
 merges into `natb1/commons.systems`, whereas the `<repo>` argument names where
-the *digest issue itself* lives (`natb1/office-hours-nate` for the real digest
-jit) — a different repo. Do not substitute `<repo>` into this query.
+the *digest issue itself* lives (the repo configured in
+`dispatch.config/jit.json` for the real digest jit) — a different repo. Do not
+substitute `<repo>` into this query.
 
 ```bash
 gh pr list --repo natb1/commons.systems --state merged \

--- a/.claude/skills/dispatch-jit-reminder/SKILL.md
+++ b/.claude/skills/dispatch-jit-reminder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatch-jit-reminder
-description: Claim the earliest-due JIT issue, summarize it for the user as a reminder, and stop. Runs as a spawned bg job from /dispatch-propagate when the JIT scan surfaces a due reminder.
+description: Claim the earliest-due JIT issue, then either run a configured skill (for skill-running jits such as digest) or summarize it for the user and stop. Runs as a spawned bg job from /dispatch-propagate when the JIT scan surfaces a due reminder.
 ---
 
 # Dispatch: JIT Reminder
@@ -13,9 +13,10 @@ dispatch lock (the router released it before spawning this job).
 
 Takes four arguments: `<repo> <num> <project> <item-id>`.
 
-Claim the issue, summarize it for the user, and stop. The summary printed here
-must stay open in this job's transcript for a human to read — no worktree, no
-PR, no phase skill, no leaf trace.
+Claim the issue, then either run a configured skill (when the jit defines one)
+or summarize the issue for the user and stop. Either way the session output
+stays open in this job's transcript for a human to read — no worktree, no PR,
+no phase skill, no leaf trace.
 
 The per-item spawn-dedup name `jit-reminder-<num>` — assigned by the router's
 `dispatch-spawn-job` call — prevents a concurrent dispatch tick from
@@ -40,7 +41,28 @@ IN_PROGRESS=$(.claude/skills/dispatch-propagate/scripts/dispatch-config-load pro
 The `dispatch-project-status-write` call needs `dangerouslyDisableSandbox:
 true` — it calls `gh`.
 
-## 2. Summarize the issue for the user
+## 2. Resolve and run a configured skill
+
+After claiming, resolve whether this jit is configured to run a skill:
+
+```bash
+SKILL=$(.claude/skills/dispatch-propagate/scripts/dispatch-jit-skill <repo> <num>)
+```
+
+Run this with `dangerouslyDisableSandbox: true` — it calls `gh` (see
+`.claude/rules/sandbox.md`).
+
+If `$SKILL` is **non-empty**: invoke that skill via the **Skill tool** (skill
+name = the value of `$SKILL`), passing the issue's `<repo> <num>` as its
+arguments, and let that skill own the rest of this session. Do NOT then run
+the summarize-and-stop steps below — the configured skill produces the
+session's output and terminates it. A skill-running jit reminder is still an
+**office-hours session** (the skill runs with the user present).
+
+If `$SKILL` is **empty** (no `skill` configured, or no `jit.json`): fall
+through to the summarize-and-stop steps below, unchanged.
+
+## 3. Summarize the issue for the user
 
 Fetch the issue (`dangerouslyDisableSandbox: true` — `gh` needs network):
 
@@ -53,13 +75,13 @@ reminder, framed as the most-overdue / soonest-due JIT reminder the scan
 surfaced. The `jit-reminder` line carries no due timestamp — do not state a
 precise computed due time.
 
-## 3. Stop
+## 4. Stop
 
 The `In Progress` status the claim wrote stops a later `/dispatch-propagate` tick from
 re-selecting this issue.
 
-A `jit-reminder` run is a **jit summary session** — an office-hours session
-(#755): the summary is surfaced to the user for a human to read, not
-consumed as autonomous dispatch-chain work. #755's two-queue infrastructure
-is not yet built, so this skill is that documented intent plus the
-mechanical claim → release → summarize → stop branch above.
+A `jit-reminder` run is an **office-hours session** in the now-built
+two-queue model (#755): the summary (or the configured skill's output) is
+surfaced to the user for a human to read, not consumed as autonomous
+dispatch-chain work. Both the summarize-and-stop variant (§3–4) and the
+skill-running variant (§2) run as office-hours sessions with the user present.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
@@ -250,7 +250,7 @@ case "$CONFIG_TYPE" in
           else
             empty
           end),
-          # optional timing fields — must be strings if present
+          # optional string fields — must be strings if present
           (["remindAfterClose","dueAfterClose","dueAfterCreate","debounce","skill"] |
           .[] |
           . as $field |

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
@@ -258,6 +258,15 @@ case "$CONFIG_TYPE" in
             "jits[\($idx)]: \($field) must be a string if present, got \($item[$field] | type)"
           else
             empty
+          end),
+          # skill, if present, names a skill the jit-reminder path invokes via
+          # the Skill tool — constrain it to a skill-name slug so a malformed
+          # value is rejected at config load rather than reaching the caller.
+          (if ($item | has("skill")) and (($item.skill | type) == "string")
+              and (($item.skill | test("^[a-z][a-z0-9-]*$")) | not) then
+            "jits[\($idx)]: skill must be a lowercase skill-name slug (^[a-z][a-z0-9-]*$), got \"\($item.skill)\""
+          else
+            empty
           end)
         end
       end

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
@@ -77,6 +77,10 @@
 # Timing-field semantics (cadence vs check-script) are validated by the JIT
 # engine, not here. This loader only checks types.
 #
+#   skill   string — optional; names a skill to run when this jit's reminder
+#           is selected. Absent → the reminder is summarized and the job
+#           stops. Not a timing field.
+#
 # Example (see jit.example.json):
 #   {
 #     "jits": [
@@ -247,7 +251,7 @@ case "$CONFIG_TYPE" in
             empty
           end),
           # optional timing fields — must be strings if present
-          (["remindAfterClose","dueAfterClose","dueAfterCreate","debounce"] |
+          (["remindAfterClose","dueAfterClose","dueAfterCreate","debounce","skill"] |
           .[] |
           . as $field |
           if ($item | has($field)) and ($item[$field] | type) != "string" then

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-digest-window
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-digest-window
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# dispatch-digest-window — print the window-start ISO-8601 timestamp for a
+# digest jit issue: the closedAt of the most-recent prior closed issue carrying
+# the same jit: label (steady state), or the digest issue's own createdAt when
+# no prior closed issue exists (cold start).
+#
+# Usage:
+#   dispatch-digest-window <repo> <num>
+#
+#   <repo>   GitHub repo in "owner/repo" form.
+#   <num>    Digest issue number (digits only).
+#
+# Stdout protocol:
+#   <iso-8601 timestamp>   the window-start time.
+#
+# Exit codes:
+#   0  window start printed.
+#   1  the issue carries no jit: label — it is not a jit issue.
+#   2  usage error (missing or invalid arguments).
+#   non-zero   propagated from gh on hard error.
+#
+# Note: callers invoke this with dangerouslyDisableSandbox: true — it calls
+# gh (see .claude/rules/sandbox.md).
+
+set -euo pipefail
+
+# ---- Step 0: parse arguments ------------------------------------------------
+
+REPO="${1:-}"
+NUM="${2:-}"
+
+if [[ -z "$REPO" || -z "$NUM" ]]; then
+  echo "error: usage: dispatch-digest-window <repo> <num>" >&2
+  exit 2
+fi
+
+if [[ ! "$NUM" =~ ^[0-9]+$ ]]; then
+  echo "error: usage: dispatch-digest-window <repo> <num> — <num> must be digits" >&2
+  exit 2
+fi
+
+# ---- Step 1: fetch the digest issue's label and createdAt -------------------
+
+ISSUE_JSON=$(gh issue view "$NUM" --repo "$REPO" --json createdAt,labels)
+
+JIT_LABEL=$(printf '%s' "$ISSUE_JSON" \
+  | jq -r '.labels[].name | select(startswith("jit:"))' \
+  | head -n1)
+
+if [[ -z "$JIT_LABEL" ]]; then
+  echo "error: issue $REPO#$NUM carries no jit: label — not a jit issue" >&2
+  exit 1
+fi
+
+CREATED_AT=$(printf '%s' "$ISSUE_JSON" | jq -r '.createdAt')
+
+# ---- Step 2: find the newest prior closed issue with the same jit label -----
+# Exclude <num> itself: a digest issue may be closed mid-run, but it must never
+# anchor the window on its own closedAt. Guard the empty list so jq yields the
+# empty string rather than the literal "null".
+
+CLOSED_JSON=$(gh issue list --repo "$REPO" --label "$JIT_LABEL" \
+  --state closed --json number,closedAt)
+
+PRIOR_CLOSED_AT=$(printf '%s' "$CLOSED_JSON" \
+  | jq -r --arg num "$NUM" \
+    'map(select(.number != ($num | tonumber)))
+     | (max_by(.closedAt) // {}) | .closedAt // empty')
+
+# ---- Step 3: print the window start -----------------------------------------
+
+if [[ -n "$PRIOR_CLOSED_AT" ]]; then
+  printf '%s\n' "$PRIOR_CLOSED_AT"   # steady state
+else
+  printf '%s\n' "$CREATED_AT"        # cold start
+fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-digest-window
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-digest-window
@@ -34,6 +34,11 @@ if [[ -z "$REPO" || -z "$NUM" ]]; then
   exit 2
 fi
 
+if [[ ! "$REPO" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+  echo "error: usage: dispatch-digest-window <repo> <num> — <repo> must be owner/repo" >&2
+  exit 2
+fi
+
 if [[ ! "$NUM" =~ ^[0-9]+$ ]]; then
   echo "error: usage: dispatch-digest-window <repo> <num> — <num> must be digits" >&2
   exit 2

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-digest-window
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-digest-window
@@ -58,9 +58,15 @@ CREATED_AT=$(printf '%s' "$ISSUE_JSON" | jq -r '.createdAt')
 # Exclude <num> itself: a digest issue may be closed mid-run, but it must never
 # anchor the window on its own closedAt. Guard the empty list so jq yields the
 # empty string rather than the literal "null".
+#
+# --limit 100 lifts gh's default 30-result cap so a long jit history cannot
+# silently truncate the list before max_by sees the actual newest entry.
+# max_by(.closedAt) is a lexicographic compare, which equals chronological order
+# here: GitHub returns closedAt as zero-padded UTC ISO-8601 (e.g.
+# 2026-05-25T12:00:00Z), so string order is time order — no fromdate needed.
 
 CLOSED_JSON=$(gh issue list --repo "$REPO" --label "$JIT_LABEL" \
-  --state closed --json number,closedAt)
+  --state closed --limit 100 --json number,closedAt)
 
 PRIOR_CLOSED_AT=$(printf '%s' "$CLOSED_JSON" \
   | jq -r --arg num "$NUM" \

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-jit-skill
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-jit-skill
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# dispatch-jit-skill — print the configured skill name for the jit that owns
+# an issue, or nothing if no skill is configured / no matching jit exists.
+#
+# Usage:
+#   dispatch-jit-skill <repo> <num>
+#
+#   <repo>   GitHub repo in "owner/repo" form.
+#   <num>    Issue number (digits only).
+#
+# Stdout protocol:
+#   <skill-name>   the configured skill for the jit that owns the issue.
+#   (empty)        no jit.json config present, no matching jit, or the matched
+#                  jit defines no skill field.
+#
+# Exit codes:
+#   0  any found/not-found resolution — skill printed or nothing printed.
+#   2  usage error (missing or invalid arguments).
+#   non-zero   propagated from gh or dispatch-config-load on hard error.
+#
+# Note: callers invoke this with dangerouslyDisableSandbox: true — it calls
+# gh (see .claude/rules/sandbox.md).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---- Step 0: parse arguments ------------------------------------------------
+
+REPO="${1:-}"
+NUM="${2:-}"
+
+if [[ -z "$REPO" || -z "$NUM" ]]; then
+  echo "error: usage: dispatch-jit-skill <repo> <num>" >&2
+  exit 2
+fi
+
+if [[ ! "$NUM" =~ ^[0-9]+$ ]]; then
+  echo "error: usage: dispatch-jit-skill <repo> <num> — <num> must be digits" >&2
+  exit 2
+fi
+
+# ---- Step 1: load jit config -------------------------------------------------
+
+CONFIG=$("$SCRIPT_DIR/dispatch-config-load" jit)
+if [[ "$CONFIG" == "no-config" ]]; then
+  exit 0
+fi
+
+# ---- Step 2: fetch the issue's labels and find the jit: label ---------------
+
+LABELS_JSON=$(gh issue view "$NUM" --repo "$REPO" --json labels)
+JIT_LABEL=$(printf '%s' "$LABELS_JSON" \
+  | jq -r '.labels[].name | select(startswith("jit:"))' \
+  | head -n1)
+
+if [[ -z "$JIT_LABEL" ]]; then
+  exit 0
+fi
+
+# ---- Step 3: match the label to a jit and print its skill -------------------
+
+printf '%s' "$CONFIG" \
+  | jq -r --arg lbl "$JIT_LABEL" \
+    '.jits[] | select(.label == $lbl) | .skill // empty' \
+  | head -n1

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-jit-skill
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-jit-skill
@@ -35,6 +35,11 @@ if [[ -z "$REPO" || -z "$NUM" ]]; then
   exit 2
 fi
 
+if [[ ! "$REPO" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+  echo "error: usage: dispatch-jit-skill <repo> <num> — <repo> must be owner/repo" >&2
+  exit 2
+fi
+
 if [[ ! "$NUM" =~ ^[0-9]+$ ]]; then
   echo "error: usage: dispatch-jit-skill <repo> <num> — <num> must be digits" >&2
   exit 2
@@ -59,8 +64,20 @@ if [[ -z "$JIT_LABEL" ]]; then
 fi
 
 # ---- Step 3: match the label to a jit and print its skill -------------------
+# The caller invokes the printed name via the Skill tool, so guard the emitted
+# value against the skill-name slug here too — defense in depth at the emission
+# boundary, in addition to dispatch-config-load's schema check.
 
-printf '%s' "$CONFIG" \
+SKILL=$(printf '%s' "$CONFIG" \
   | jq -r --arg lbl "$JIT_LABEL" \
     '.jits[] | select(.label == $lbl) | .skill // empty' \
-  | head -n1
+  | head -n1)
+
+if [[ -n "$SKILL" && ! "$SKILL" =~ ^[a-z][a-z0-9-]*$ ]]; then
+  echo "error: jit for label $JIT_LABEL defines a malformed skill name: $SKILL" >&2
+  exit 1
+fi
+
+if [[ -n "$SKILL" ]]; then
+  printf '%s\n' "$SKILL"
+fi

--- a/.claude/skills/dispatch-propagate/scripts/jit.example.json
+++ b/.claude/skills/dispatch-propagate/scripts/jit.example.json
@@ -10,6 +10,18 @@
       "remindAfterClose": "12h",
       "dueAfterClose": "24h",
       "debounce": "1h"
+    },
+    {
+      "key": "digest",
+      "repo": "example-owner/example-repo",
+      "label": "jit:digest",
+      "title": "Digest",
+      "body": "Recurring digest checkpoint. Summarizes dispatch-queue work completed since the previous digest closed, then closes to anchor the next cycle.",
+      "project": "example-project",
+      "remindAfterClose": "24h",
+      "dueAfterClose": "48h",
+      "debounce": "1h",
+      "skill": "digest"
     }
   ]
 }

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -5679,6 +5679,65 @@ jit_label=$(printf '%s' "$out" | jq -r '.jits[0].label')
 assert_eq "valid jit.json label" "jit:test-chore" "$jit_label"
 config_teardown
 
+# --- Test 2a: jit.json with a string skill field validates -------------------
+
+echo "Test: jit.json with a string skill field validates"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/jit.json" <<'EOF'
+{
+  "jits": [
+    {
+      "key": "digest",
+      "repo": "test-owner/test-repo",
+      "label": "jit:digest",
+      "title": "Digest",
+      "body": "Recurring digest checkpoint.",
+      "project": "test-project",
+      "remindAfterClose": "24h",
+      "dueAfterClose": "48h",
+      "debounce": "1h",
+      "skill": "digest"
+    }
+  ]
+}
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" jit 2>/dev/null); rc=$?
+assert_eq "jit.json string skill exits 0" "0" "$rc"
+skill=$(printf '%s' "$out" | jq -r '.jits[0].skill')
+assert_eq "jit.json string skill value" "digest" "$skill"
+config_teardown
+
+# --- Test 2b: jit.json with a non-string skill field is rejected -------------
+
+echo "Test: jit.json with a non-string skill field is rejected"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/jit.json" <<'EOF'
+{
+  "jits": [
+    {
+      "key": "digest",
+      "repo": "test-owner/test-repo",
+      "label": "jit:digest",
+      "title": "Digest",
+      "body": "Recurring digest checkpoint.",
+      "project": "test-project",
+      "skill": 123
+    }
+  ]
+}
+EOF
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" jit 2>&1 1>/dev/null) || rc=$?
+assert_eq "jit.json non-string skill exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"must be a string if present"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-string skill stderr mentions 'must be a string if present'"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-string skill stderr mentions 'must be a string if present'"
+  echo "    stderr: $err"
+fi
+config_teardown
+
 # --- Test 3: absent file prints no-config and exits 0 ------------------------
 
 echo "Test: absent file prints no-config and exits 0"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -5738,6 +5738,37 @@ else
 fi
 config_teardown
 
+# --- Test 2c: jit.json with a malformed (non-slug) skill field is rejected ---
+
+echo "Test: jit.json with a malformed (non-slug) skill field is rejected"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/jit.json" <<'EOF'
+{
+  "jits": [
+    {
+      "key": "digest",
+      "repo": "test-owner/test-repo",
+      "label": "jit:digest",
+      "title": "Digest",
+      "body": "Recurring digest checkpoint.",
+      "project": "test-project",
+      "skill": "Digest; rm -rf /"
+    }
+  ]
+}
+EOF
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" jit 2>&1 1>/dev/null) || rc=$?
+assert_eq "jit.json malformed skill exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"must be a lowercase skill-name slug"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: malformed skill stderr mentions 'must be a lowercase skill-name slug'"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: malformed skill stderr mentions 'must be a lowercase skill-name slug'"
+  echo "    stderr: $err"
+fi
+config_teardown
+
 # --- Test 3: absent file prints no-config and exits 0 ------------------------
 
 echo "Test: absent file prints no-config and exits 0"
@@ -14877,6 +14908,22 @@ assert_eq "dispatch-jit-skill: unmatched jit label exits 0" "0" "$rc"
 assert_eq "dispatch-jit-skill: unmatched jit label prints nothing" "" "$out"
 jit_skill_teardown
 
+# --- Test: dispatch-jit-skill rejects a <repo> that is not owner/repo ---------
+
+echo "Test: dispatch-jit-skill rejects a malformed <repo> argument"
+jit_skill_setup
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-jit-skill" "--config /tmp/evil" 42 2>&1 1>/dev/null) || rc=$?
+assert_eq "dispatch-jit-skill: malformed repo exits 2" "2" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"must be owner/repo"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: malformed repo stderr mentions 'must be owner/repo'"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: malformed repo stderr mentions 'must be owner/repo'"
+  echo "    stderr: $err"
+fi
+jit_skill_teardown
+
 # dispatch-digest-window tests
 # ============================================================================
 #
@@ -14991,6 +15038,22 @@ EOF
 out=$("$TMPDIR_TEST/scripts/dispatch-digest-window" some-owner/some-repo 50 2>/dev/null) && rc=0 || rc=$?
 assert_eq "dispatch-digest-window: no jit:* label exits 1" "1" "$rc"
 assert_eq "dispatch-digest-window: no jit:* label prints nothing on stdout" "" "$out"
+digest_window_teardown
+
+# --- Test: rejects a <repo> that is not owner/repo ---
+
+echo "Test: dispatch-digest-window rejects a malformed <repo> argument"
+digest_window_setup
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-digest-window" "--config /tmp/evil" 30 2>&1 1>/dev/null) || rc=$?
+assert_eq "dispatch-digest-window: malformed repo exits 2" "2" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"must be owner/repo"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: malformed repo stderr mentions 'must be owner/repo'"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: malformed repo stderr mentions 'must be owner/repo'"
+  echo "    stderr: $err"
+fi
 digest_window_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -14685,6 +14685,166 @@ assert_eq "followup: empty input → 0" "0" "$(printf '%s' "$out" | jq -r 'lengt
 out=$(printf '%s' '[{"source":"sonarqube","classification":"out-of-scope","security_severity_level":"high"},{"classification":"out-of-scope","severity":"critical"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
 assert_eq "followup: unknown/missing source → 0" "0" "$(printf '%s' "$out" | jq -r 'length')"
 
+# dispatch-jit-skill tests
+# ============================================================================
+#
+# Each test gets a fresh tmp tree:
+#   $TMPDIR_TEST/scripts/   copies of dispatch-jit-skill, dispatch-config-load, lib.sh
+#   $TMPDIR_TEST/config/    synthetic config directory (DISPATCH_CONFIG_DIR)
+#   $TMPDIR_TEST/bin/       gh stub (prepended to PATH)
+#
+# DISPATCH_CONFIG_DIR is exported so dispatch-config-load never touches the
+# real dispatch.config/ directory and does not require a git repo.
+
+jit_skill_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/config" "$TMPDIR_TEST/bin"
+
+  cp "$SCRIPT_DIR/dispatch-jit-skill" "$TMPDIR_TEST/scripts/dispatch-jit-skill"
+  cp "$SCRIPT_DIR/dispatch-config-load" "$TMPDIR_TEST/scripts/dispatch-config-load"
+  # dispatch-config-load sources lib.sh via its SCRIPT_DIR — sits alongside it.
+  cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/lib.sh"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-jit-skill" \
+           "$TMPDIR_TEST/scripts/dispatch-config-load"
+
+  # gh stub: handles `issue view <num> --repo <repo> --json labels`.
+  # Reads the labels fixture from $TMPDIR_TEST/labels.json; defaults to empty.
+  # Unknown invocations → stderr + exit 1.
+  cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+TREE="$(cd "$(dirname "$0")/.." && pwd)"
+case "$args" in
+  issue\ view\ *\ --repo\ *\ --json\ labels)
+    if [[ -f "$TREE/labels.json" ]]; then
+      cat "$TREE/labels.json"
+    else
+      echo '{"labels":[]}'
+    fi
+    ;;
+  *)
+    echo "gh stub: unknown invocation: $args" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/gh"
+
+  SAVED_PATH_JIT="$PATH"
+  export PATH="$TMPDIR_TEST/bin:$PATH"
+  export DISPATCH_CONFIG_DIR="$TMPDIR_TEST/config"
+}
+
+jit_skill_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  export PATH="$SAVED_PATH_JIT"
+  unset DISPATCH_CONFIG_DIR
+}
+
+# --- Test: dispatch-jit-skill returns the configured skill for a matching jit label ---
+
+echo "Test: dispatch-jit-skill returns the configured skill for a matching jit label"
+jit_skill_setup
+cat > "$TMPDIR_TEST/config/jit.json" <<'EOF'
+{
+  "jits": [
+    {
+      "key": "digest",
+      "repo": "some-owner/some-repo",
+      "label": "jit:digest",
+      "title": "Digest",
+      "body": "Recurring digest checkpoint.",
+      "project": "example-project",
+      "remindAfterClose": "24h",
+      "dueAfterClose": "48h",
+      "debounce": "1h",
+      "skill": "digest"
+    }
+  ]
+}
+EOF
+cat > "$TMPDIR_TEST/labels.json" <<'EOF'
+{"labels":[{"name":"jit:digest"},{"name":"help wanted"}]}
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-jit-skill" some-owner/some-repo 42); rc=$?
+assert_eq "dispatch-jit-skill: matched jit with skill exits 0" "0" "$rc"
+assert_eq "dispatch-jit-skill: matched jit prints skill name" "digest" "$out"
+jit_skill_teardown
+
+# --- Test: dispatch-jit-skill prints nothing when the matched jit defines no skill ---
+
+echo "Test: dispatch-jit-skill prints nothing when the matched jit defines no skill"
+jit_skill_setup
+cat > "$TMPDIR_TEST/config/jit.json" <<'EOF'
+{
+  "jits": [
+    {
+      "key": "plain",
+      "repo": "some-owner/some-repo",
+      "label": "jit:plain",
+      "title": "Plain reminder",
+      "body": "A plain jit with no skill field.",
+      "project": "example-project",
+      "remindAfterClose": "12h",
+      "dueAfterClose": "24h",
+      "debounce": "1h"
+    }
+  ]
+}
+EOF
+cat > "$TMPDIR_TEST/labels.json" <<'EOF'
+{"labels":[{"name":"jit:plain"}]}
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-jit-skill" some-owner/some-repo 7); rc=$?
+assert_eq "dispatch-jit-skill: matched jit without skill exits 0" "0" "$rc"
+assert_eq "dispatch-jit-skill: matched jit without skill prints nothing" "" "$out"
+jit_skill_teardown
+
+# --- Test: dispatch-jit-skill prints nothing with no jit.json (no-config) ---
+
+echo "Test: dispatch-jit-skill prints nothing with no jit.json (no-config)"
+jit_skill_setup
+# No jit.json written into config/ — dispatch-config-load returns "no-config".
+# The labels fixture is present but should never be consulted.
+cat > "$TMPDIR_TEST/labels.json" <<'EOF'
+{"labels":[{"name":"jit:digest"}]}
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-jit-skill" some-owner/some-repo 99); rc=$?
+assert_eq "dispatch-jit-skill: no-config exits 0" "0" "$rc"
+assert_eq "dispatch-jit-skill: no-config prints nothing" "" "$out"
+jit_skill_teardown
+
+# --- Test: dispatch-jit-skill prints nothing when the issue has no jit:* label ---
+
+echo "Test: dispatch-jit-skill prints nothing when issue has no jit:* label"
+jit_skill_setup
+cat > "$TMPDIR_TEST/config/jit.json" <<'EOF'
+{
+  "jits": [
+    {
+      "key": "digest",
+      "repo": "some-owner/some-repo",
+      "label": "jit:digest",
+      "title": "Digest",
+      "body": "Recurring digest checkpoint.",
+      "project": "example-project",
+      "remindAfterClose": "24h",
+      "dueAfterClose": "48h",
+      "debounce": "1h",
+      "skill": "digest"
+    }
+  ]
+}
+EOF
+cat > "$TMPDIR_TEST/labels.json" <<'EOF'
+{"labels":[{"name":"help wanted"},{"name":"bug"}]}
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-jit-skill" some-owner/some-repo 55); rc=$?
+assert_eq "dispatch-jit-skill: no jit:* label exits 0" "0" "$rc"
+assert_eq "dispatch-jit-skill: no jit:* label prints nothing" "" "$out"
+jit_skill_teardown
+
 # ============================================================================
 # summary
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -14845,6 +14845,38 @@ assert_eq "dispatch-jit-skill: no jit:* label exits 0" "0" "$rc"
 assert_eq "dispatch-jit-skill: no jit:* label prints nothing" "" "$out"
 jit_skill_teardown
 
+# --- Test: dispatch-jit-skill prints nothing when the jit:* label matches no jit entry ---
+
+echo "Test: dispatch-jit-skill prints nothing when the jit:* label matches no jit entry"
+jit_skill_setup
+cat > "$TMPDIR_TEST/config/jit.json" <<'EOF'
+{
+  "jits": [
+    {
+      "key": "digest",
+      "repo": "some-owner/some-repo",
+      "label": "jit:digest",
+      "title": "Digest",
+      "body": "Recurring digest checkpoint.",
+      "project": "example-project",
+      "remindAfterClose": "24h",
+      "dueAfterClose": "48h",
+      "debounce": "1h",
+      "skill": "digest"
+    }
+  ]
+}
+EOF
+# The issue carries jit:stale, which no jit entry defines — the jq select emits
+# nothing and the script exits 0 with empty output.
+cat > "$TMPDIR_TEST/labels.json" <<'EOF'
+{"labels":[{"name":"jit:stale"},{"name":"help wanted"}]}
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-jit-skill" some-owner/some-repo 66); rc=$?
+assert_eq "dispatch-jit-skill: unmatched jit label exits 0" "0" "$rc"
+assert_eq "dispatch-jit-skill: unmatched jit label prints nothing" "" "$out"
+jit_skill_teardown
+
 # dispatch-digest-window tests
 # ============================================================================
 #
@@ -14854,7 +14886,7 @@ jit_skill_teardown
 #
 # The gh stub handles the two queries dispatch-digest-window issues:
 #   issue view <num> --repo <repo> --json createdAt,labels  → cat issue.json
-#   issue list --repo <repo> --label <label> --state closed --json number,closedAt
+#   issue list --repo <repo> --label <label> --state closed --limit <n> --json number,closedAt
 #                                                            → cat closed.json
 # Fixtures default to a minimal jit issue and an empty closed list.
 
@@ -14877,7 +14909,7 @@ case "$args" in
       echo '{"createdAt":"2026-01-01T00:00:00Z","labels":[{"name":"jit:digest"}]}'
     fi
     ;;
-  issue\ list\ --repo\ *\ --label\ *\ --state\ closed\ --json\ number,closedAt)
+  issue\ list\ --repo\ *\ --label\ *\ --state\ closed\ --limit\ *\ --json\ number,closedAt)
     if [[ -f "$TREE/closed.json" ]]; then
       cat "$TREE/closed.json"
     else
@@ -14945,6 +14977,20 @@ EOF
 out=$("$TMPDIR_TEST/scripts/dispatch-digest-window" some-owner/some-repo 30); rc=$?
 assert_eq "dispatch-digest-window: exclude-self exits 0" "0" "$rc"
 assert_eq "dispatch-digest-window: exclude-self ignores own closedAt" "2026-05-15T00:00:00Z" "$out"
+digest_window_teardown
+
+# --- Test: exits 1 when the issue carries no jit:* label ---
+
+echo "Test: dispatch-digest-window exits 1 when the issue carries no jit:* label"
+digest_window_setup
+cat > "$TMPDIR_TEST/issue.json" <<'EOF'
+{"createdAt":"2026-05-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"bug"}]}
+EOF
+# Capture with the set -e-safe pattern: a bare `cmd; rc=$?` would abort the
+# suite when the command exits nonzero.
+out=$("$TMPDIR_TEST/scripts/dispatch-digest-window" some-owner/some-repo 50 2>/dev/null) && rc=0 || rc=$?
+assert_eq "dispatch-digest-window: no jit:* label exits 1" "1" "$rc"
+assert_eq "dispatch-digest-window: no jit:* label prints nothing on stdout" "" "$out"
 digest_window_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -14845,6 +14845,108 @@ assert_eq "dispatch-jit-skill: no jit:* label exits 0" "0" "$rc"
 assert_eq "dispatch-jit-skill: no jit:* label prints nothing" "" "$out"
 jit_skill_teardown
 
+# dispatch-digest-window tests
+# ============================================================================
+#
+# Each test gets a fresh tmp tree:
+#   $TMPDIR_TEST/scripts/   copy of dispatch-digest-window
+#   $TMPDIR_TEST/bin/       gh stub (prepended to PATH)
+#
+# The gh stub handles the two queries dispatch-digest-window issues:
+#   issue view <num> --repo <repo> --json createdAt,labels  → cat issue.json
+#   issue list --repo <repo> --label <label> --state closed --json number,closedAt
+#                                                            → cat closed.json
+# Fixtures default to a minimal jit issue and an empty closed list.
+
+digest_window_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/bin"
+
+  cp "$SCRIPT_DIR/dispatch-digest-window" "$TMPDIR_TEST/scripts/dispatch-digest-window"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-digest-window"
+
+  cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+TREE="$(cd "$(dirname "$0")/.." && pwd)"
+case "$args" in
+  issue\ view\ *\ --repo\ *\ --json\ createdAt,labels)
+    if [[ -f "$TREE/issue.json" ]]; then
+      cat "$TREE/issue.json"
+    else
+      echo '{"createdAt":"2026-01-01T00:00:00Z","labels":[{"name":"jit:digest"}]}'
+    fi
+    ;;
+  issue\ list\ --repo\ *\ --label\ *\ --state\ closed\ --json\ number,closedAt)
+    if [[ -f "$TREE/closed.json" ]]; then
+      cat "$TREE/closed.json"
+    else
+      echo '[]'
+    fi
+    ;;
+  *)
+    echo "gh stub: unknown invocation: $args" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/gh"
+
+  SAVED_PATH_DIGEST="$PATH"
+  export PATH="$TMPDIR_TEST/bin:$PATH"
+}
+
+digest_window_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  export PATH="$SAVED_PATH_DIGEST"
+}
+
+# --- Test: prints the prior closed digest closedAt (steady state) ---
+
+echo "Test: dispatch-digest-window prints the prior closed digest closedAt (steady state)"
+digest_window_setup
+cat > "$TMPDIR_TEST/issue.json" <<'EOF'
+{"createdAt":"2026-05-01T00:00:00Z","labels":[{"name":"jit:digest"}]}
+EOF
+cat > "$TMPDIR_TEST/closed.json" <<'EOF'
+[{"number":10,"closedAt":"2026-05-20T00:00:00Z"},{"number":11,"closedAt":"2026-05-25T12:00:00Z"}]
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-digest-window" some-owner/some-repo 30); rc=$?
+assert_eq "dispatch-digest-window: steady state exits 0" "0" "$rc"
+assert_eq "dispatch-digest-window: steady state prints max prior closedAt" "2026-05-25T12:00:00Z" "$out"
+digest_window_teardown
+
+# --- Test: falls back to createdAt on cold start (no prior closed) ---
+
+echo "Test: dispatch-digest-window falls back to createdAt on cold start (no prior closed)"
+digest_window_setup
+cat > "$TMPDIR_TEST/issue.json" <<'EOF'
+{"createdAt":"2026-06-01T09:00:00Z","labels":[{"name":"jit:digest"}]}
+EOF
+# No closed.json — the stub's default empty list applies.
+out=$("$TMPDIR_TEST/scripts/dispatch-digest-window" some-owner/some-repo 40); rc=$?
+assert_eq "dispatch-digest-window: cold start exits 0" "0" "$rc"
+assert_eq "dispatch-digest-window: cold start prints createdAt" "2026-06-01T09:00:00Z" "$out"
+digest_window_teardown
+
+# --- Test: excludes the issue's own closedAt ---
+
+echo "Test: dispatch-digest-window excludes the issue's own closedAt"
+digest_window_setup
+cat > "$TMPDIR_TEST/issue.json" <<'EOF'
+{"createdAt":"2026-05-01T00:00:00Z","labels":[{"name":"jit:digest"}]}
+EOF
+# Issue 30 is itself closed with a later closedAt than the real prior (20).
+# The script must ignore its own entry and anchor on the prior digest's closedAt.
+cat > "$TMPDIR_TEST/closed.json" <<'EOF'
+[{"number":20,"closedAt":"2026-05-15T00:00:00Z"},{"number":30,"closedAt":"2026-05-28T00:00:00Z"}]
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-digest-window" some-owner/some-repo 30); rc=$?
+assert_eq "dispatch-digest-window: exclude-self exits 0" "0" "$rc"
+assert_eq "dispatch-digest-window: exclude-self ignores own closedAt" "2026-05-15T00:00:00Z" "$out"
+digest_window_teardown
+
 # ============================================================================
 # summary
 # ============================================================================

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Local `dispatch.config/jit.json` declares recurring "just-in-time" issues. The e
 2. Open-issue guard — skip if the previous jit issue for that key is still open.
 3. Create the next issue when its `remindAfterClose` (or `dueAfterCreate`) cadence has elapsed.
 
-Every jit issue carries a `jit:<key>` label and is tracked in its configured GitHub project. Jit-reminders that produce dispatch-queue work surface ahead of the queue ladder; jit-reminders that run as office-hours sessions are covered in the [Office Hours Queue](#office-hours-queue) spine. See #769.
+Every jit issue carries a `jit:<key>` label and is tracked in its configured GitHub project. Jit-reminders that produce dispatch-queue work surface ahead of the queue ladder; jit-reminders that run as office-hours sessions are covered in the [Office Hours Queue](#office-hours-queue) spine. A jit may carry an optional `skill` field: when selected, the reminder job runs that named skill as an office-hours session instead of only summarizing; absent → summarize-and-stop (unchanged). See #769.
 
 With no `dispatch.config/jit.json` present the engine is a no-op.
 


### PR DESCRIPTION
Closes #769

Adds the first **skill-running** jit — `digest` — and the generic capability it needs: a jit whose reminder runs a configured skill when selected, instead of only being summarized.

## What changed

**Unit 1 — optional `skill` field in the jit schema.** `dispatch-config-load` now type-checks an optional `skill` field on each jit (must be a string if present); documented in the script header, in `jit.example.json` (a `digest` entry), and in the README JIT section.

**Unit 2 — skill-running reminder branch.** New `dispatch-jit-skill <repo> <num>` resolves the configured skill for a claimed jit issue by matching its `jit:<key>` label to `jit.json`; prints nothing when no skill is configured, no `jit.json` exists, or no jit matches. `dispatch-jit-reminder/SKILL.md` gains a step after the claim: when a skill is configured it invokes that skill via the Skill tool and lets it own the session; otherwise it falls through to the unchanged summarize-and-stop path. The stale "#755 not yet built" note is refreshed — both variants run as office-hours sessions in the now-built two-queue model.

**Unit 3 — the `/digest` skill + window script.** New `dispatch-digest-window <repo> <num>` prints a digest issue's window start: the prior closed digest's `closedAt` (steady state) or the issue's `createdAt` (cold start), excluding the issue's own `closedAt`. New `.claude/skills/digest/SKILL.md` is the office-hours skill `dispatch-jit-reminder` runs for the digest jit — it computes the window, enumerates dispatch-queue work merged since, judges each item user-facing vs internal, demos user-facing items (browser apps live via the Chrome extension, non-browser via numbered steps), posts the summary as a comment on the digest issue, and closes it to anchor the next cadence cycle.

## Tests

`test-dispatch-scripts.sh` covers the new `skill`-field validation, the `dispatch-jit-skill` resolution paths, and `dispatch-digest-window`'s steady-state / cold-start / exclude-self cases. The interactive browser demo is verified in QA, not in the script suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)