### PR TITLE
dispatch: self-close worker session when early CI-ready gate fires with a completed marker (#1060)

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -190,10 +190,8 @@ fi
 if ! "$SCRIPTS/dispatch-ci-ready" "$ISSUE_NUM" >/dev/null 2>&1; then
   spawn_tick
   if [ -n "$MARKER_PHASE" ]; then
-    # A valid phase-completed marker is present: the phase did its job
-    # (marker written, label applied, fix pushed) — only CI is still
-    # running. Self-close the session; the spawned tick re-gates the issue
-    # once CI concludes and continues the chain in a fresh session.
+    # Marker present (see the block above): the phase completed and only CI
+    # is still running — self-close so the session does not leak idle.
     self_close
   fi
   # No marker: a genuine mid-phase exit during a CI restart — hand back to

--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -10,13 +10,20 @@
 # leak — the harness fires Stop unconditionally at session end, regardless of
 # the model's last visible action.
 #
-# Early not-ready gate (marker-independent): when dispatch-ci-ready reports the
-# target's PR CI is back in progress (a push restarted CI between selection and
-# session end — the TOCTOU race), there is no actionable verdict for any branch
-# below to act on. Hand the issue back to the router and exit 0 rather than
-# parking it on a human; the next tick re-gates it and picks it up once CI
-# concludes. (Office-hours would not self-heal: the dispatch queue skips
-# office-hours issues and nothing strips the label.) The router owns the CI gate.
+# Early not-ready gate (marker-dependent disposition): when dispatch-ci-ready
+# reports the target's PR CI is back in progress, there is no actionable verdict
+# for any branch below to act on. Spawn the next tick (it re-gates the issue once
+# CI concludes), then decide by marker:
+#   - Marker present: the phase already completed (marker written, label applied,
+#     fix pushed) and only CI is still running — the common case, since a draft
+#     PR's CI runs for minutes after the model work finishes in seconds.
+#     Self-close the session so it does not leak idle on a held daemon slot.
+#   - Marker absent: a genuine mid-phase exit during a CI restart (a push
+#     restarted CI between selection and session end — the TOCTOU race). Hand the
+#     issue back to the router and exit 0 without parking it on a human or
+#     self-closing; the next tick picks it up once CI concludes. (Office-hours
+#     would not self-heal: the dispatch queue skips office-hours issues and
+#     nothing strips the label.) The router owns the CI gate.
 #
 # Branches (driven by marker presence + CURRENT_PHASE relative to MARKER_PHASE):
 #   R. conflict-resolver job (#982) — a /dispatch-resolve-conflict session is
@@ -152,23 +159,6 @@ DISPATCH_PR_LIST=$(gh pr list --state open \
   || DISPATCH_PR_LIST=""
 export DISPATCH_PR_LIST
 
-# Early not-ready gate (marker-independent). If the target's PR CI is back in
-# progress (no verdict available), hand the issue back to the tick without
-# parking or self-closing — the next tick re-gates it once CI concludes. This
-# covers the TOCTOU case where a push restarted CI between selection and session
-# end. The gate runs BEFORE dispatch-phase so CURRENT_PHASE is only derived for a
-# target confirmed ready: without this early gate, a pending dispatch-phase would
-# exit 3, leave CURRENT_PHASE="" via the `|| CURRENT_PHASE=""` fallback below, and
-# drive a spurious Branch D office-hours park.
-if ! "$SCRIPTS/dispatch-ci-ready" "$ISSUE_NUM" >/dev/null 2>&1; then
-  spawn_tick
-  exit 0
-fi
-
-# Resolve current phase (used to compare against MARKER_PHASE). Called after the
-# readiness gate so CI is confirmed ready and dispatch-phase will not exit 3.
-CURRENT_PHASE=$("$SCRIPTS/dispatch-phase" "$ISSUE_NUM" 2>/dev/null) || CURRENT_PHASE=""
-
 # Read marker (presence drives branch selection; content is for diagnostics).
 # Validate against the known phase set — a corrupt or unknown value falls
 # through to Branch A (treat as absent) rather than driving Branch B's
@@ -182,6 +172,38 @@ if [ -f "$MARKER_FILE" ]; then
     *) MARKER_PHASE="" ;;
   esac
 fi
+
+# Early not-ready gate. If the target's PR CI is back in progress (no verdict
+# available), spawn the next tick and decide disposition by marker:
+#   - Marker present: the phase already did its job (marker written, label
+#     applied, fix pushed) — only CI is still running. Self-close the session;
+#     the spawned tick re-gates the issue once CI concludes and continues the
+#     chain in a fresh session. (Without this, the session leaks: idle, holding
+#     a daemon slot, even though its phase completed.)
+#   - Marker absent: a genuine mid-phase exit during a CI restart (the TOCTOU
+#     case where a push restarted CI between selection and session end). Hand the
+#     issue back to the tick without parking or self-closing — the next tick
+#     re-gates it once CI concludes. Parking is avoided because the gate runs
+#     BEFORE dispatch-phase: a pending dispatch-phase would exit 3, leave
+#     CURRENT_PHASE="" via the `|| CURRENT_PHASE=""` fallback below, and drive a
+#     spurious Branch D office-hours park.
+if ! "$SCRIPTS/dispatch-ci-ready" "$ISSUE_NUM" >/dev/null 2>&1; then
+  spawn_tick
+  if [ -n "$MARKER_PHASE" ]; then
+    # A valid phase-completed marker is present: the phase did its job
+    # (marker written, label applied, fix pushed) — only CI is still
+    # running. Self-close the session; the spawned tick re-gates the issue
+    # once CI concludes and continues the chain in a fresh session.
+    self_close
+  fi
+  # No marker: a genuine mid-phase exit during a CI restart — hand back to
+  # the router without parking or self-closing (TOCTOU protection).
+  exit 0
+fi
+
+# Resolve current phase (used to compare against MARKER_PHASE). Called after the
+# readiness gate so CI is confirmed ready and dispatch-phase will not exit 3.
+CURRENT_PHASE=$("$SCRIPTS/dispatch-phase" "$ISSUE_NUM" 2>/dev/null) || CURRENT_PHASE=""
 
 if [ -z "$MARKER_PHASE" ]; then
   # Branch A — marker absent.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -10361,16 +10361,18 @@ else
 fi
 stop_teardown
 
-# --- Test 5c: early gate fires even with a present marker (marker-independent) -
+# --- Test 5c: early gate + present marker → spawn tick AND self-close ---------
 
-echo "Test: stop hook + marker present + dispatch-ci-ready not-ready → early gate: spawn only, no self-close"
+echo "Test: stop hook + marker present + dispatch-ci-ready not-ready → early gate: marker present → self-close after spawning tick"
 stop_setup
 echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
 echo "456" > "$STUB_DIR/find-pr-output"
 echo "verify" > "$STUB_DIR/current-phase.txt"
-# Marker present and a would-be advance (verify != implement), but CI is back in
-# progress: the marker-independent early gate short-circuits BEFORE any branch,
-# so no self-close and no office-hours park.
+# Marker present but CI is back in progress: the phase already did its job
+# (marker written, label applied, fix pushed) and only the draft PR's CI is
+# still running. The early gate spawns the next tick (which re-gates once CI
+# concludes) and self-closes the session so it does not leak idle — no
+# office-hours park, no strip.
 echo "0" > "$STUB_DIR/ci-ready.txt"
 echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
 echo "phase=implement" > "$TMPDIR_TEST/jobs/abcd1234/phase-completed"
@@ -10387,12 +10389,8 @@ else
 fi
 spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
 assert_eq "stop not-ready-marker: spawn invoked exactly once" "1" "$spawn_calls"
-TOTAL=$((TOTAL + 1))
-if [[ ! -e "$STUB_DIR/self-close-calls.log" ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: stop not-ready-marker: self-close not invoked (early gate beat Branch B)"
-else
-  FAIL=$((FAIL + 1)); echo "  FAIL: stop not-ready-marker: self-close not invoked (early gate beat Branch B)"
-fi
+self_close_calls=$(wc -l < "$STUB_DIR/self-close-calls.log" 2>/dev/null || echo 0)
+assert_eq "stop not-ready-marker: self-close invoked exactly once (marker present → self-close after spawning tick)" "1" "$self_close_calls"
 stop_teardown
 
 # --- Test 6: CLAUDE_JOB_DIR unset → no-op ------------------------------------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -10333,9 +10333,10 @@ stop_setup
 echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
 echo "456" > "$STUB_DIR/find-pr-output"
 # Marker absent + readiness predicate reports not-ready: a push restarted CI
-# between selection and session end (TOCTOU). The marker-independent early gate
-# hands the issue back to the router without parking it on a human. Readiness is
-# driven via dispatch-ci-ready, NOT via a `waiting` phase value.
+# between selection and session end (TOCTOU). No marker means a genuine
+# mid-phase exit — the early gate hands the issue back to the router without
+# parking it on a human and without self-closing. Readiness is driven via
+# dispatch-ci-ready, NOT via a `waiting` phase value.
 echo "0" > "$STUB_DIR/ci-ready.txt"
 echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
 # No phase-completed marker.


### PR DESCRIPTION
Closes #1060

## Problem

`/dispatch-worker` sessions run as managed background jobs. When a worker
finishes its phase it writes `$CLAUDE_JOB_DIR/phase-completed` and the `Stop`
hook (`.claude/hooks/dispatch-stop.sh`) self-closes the session on a clean
advance (Branch B).

The hook had a marker-independent **early CI-ready gate** that ran *before* the
marker was read. When `dispatch-ci-ready` reported the target's draft-PR CI was
still in progress, the gate spawned a fresh tick and did a bare `exit 0` — no
self-close. This is the common path, not a rare edge: a draft PR stays in draft
through every pre-security phase while its CI runs for minutes after the model
work finishes in seconds. So on nearly every commit-pushing worker, the early
gate fired *after* the marker was already written, and the bare `exit 0` skipped
the self-close. The session leaked (idle, holding a daemon slot) even though it
had done its job — marker written, label applied, fix pushed.

## Fix

Make the early gate's disposition depend on the marker. The phase-completed
marker is now read *before* the gate. When a valid marker is present, the gate
**self-closes** the session after spawning the tick (the tick re-gates the issue
once CI concludes and continues the chain in a fresh session). The no-marker
case is unchanged — spawn a tick and `exit 0` with no park and no self-close,
preserving the existing TOCTOU protection against a spurious office-hours park
during a CI restart.

## Tests

Test 5c in `test-dispatch-scripts.sh` is updated to assert the marker-present
self-close (spawn once, self-close once, no office-hours apply/strip). Test 5b
(no-marker branch) is unchanged and asserts the preserved behavior. Suite stays
green at 1276/1276.