### PR TITLE
dispatch: PID-backed sentinel so the selection lock serializes concurrent headless ticks (#1068)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
@@ -35,6 +35,20 @@
 #     the lock is never stolen from a possibly-held foreign holder when the
 #     daemon cannot be queried.
 #
+# Headless holders bypass the registry (#1068). The systemd-launched dispatch-
+# tick has no real Claude session, so it synthesizes a `headless:<token>` holder
+# id (token = INVOCATION_ID or PID) — a bash string that never appears in
+# `claude agents --json`. Resolving its liveness through that registry would
+# always classify it dead, letting a concurrent tick steal a LIVE headless
+# holder's lock mid-selection (the duplicate-spawn defect of #1068). Instead the
+# tick writes a PID sentinel — `<lock-file dir>/dispatch-tick-<slug>.live`
+# containing its own PID — for the tick's lifetime, and resolve_holder_state
+# treats a `headless:*` holder as live iff that sentinel exists AND its recorded
+# PID is still alive (`kill -0`). PID-in-sentinel (not bare existence) keeps the
+# self-healing reclaim: a SIGKILL leaves a stale sentinel whose PID is gone, so
+# the next tick reads it dead and reclaims. The sentinel sits in the lock file's
+# own directory, so a concurrent tick in any worktree resolves the same path.
+#
 # Release is implicit and self-healing: when the session ends its sessionId
 # stops appearing in `claude agents --json`, so the next tick's read-check-
 # write reclaims the lock automatically. `--release` is an explicit optional
@@ -153,6 +167,23 @@ WAIT_INTERVAL="${DISPATCH_LOCK_WAIT_INTERVAL:-5}"
 # exit client, but the cost of defending against a future fork is one redir.
 resolve_holder_state() {
   local sid="$1" out rows match
+  # Headless holders (the systemd-launched dispatch-tick's synthetic
+  # `headless:<token>` id) never appear in the `claude agents --json` registry —
+  # it tracks model sessions, not bash processes. Resolve their liveness through
+  # the PID sentinel the tick writes alongside the lock file (#1068): live iff
+  # the sentinel exists AND its recorded PID is still alive. A SIGKILL leaves a
+  # stale sentinel whose PID is gone, so it resolves DEAD and the lock self-heals.
+  # No cwd is emitted (matches the live-with-empty-cwd convention — marker check
+  # stays strict), and the daemon is never queried for these ids.
+  if [[ "$sid" == headless:* ]]; then
+    local sentinel pid=""
+    sentinel=$(headless_sentinel_path "$sid" "$LOCK_FILE")
+    [[ -f "$sentinel" ]] || return 1
+    IFS= read -r pid <"$sentinel" 2>/dev/null || true
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    kill -0 "$pid" 2>/dev/null || return 1
+    return 0
+  fi
   if ! out=$("${CLAUDE_AGENTS_CMD:-claude}" agents --json 2>/dev/null 9>&-); then
     return 0
   fi
@@ -200,18 +231,13 @@ marker_names_holder() {
 }
 
 # ---- Step 1: resolve the lock file ------------------------------------------
-# An explicit DISPATCH_LOCK_FILE is authoritative and bypasses the git lookup —
-# tests rely on this. Otherwise the lock lives at the shared project-root tmp/
-# (not a per-worktree tmp/) so concurrent ticks in different worktrees contend
-# on the same file. resolve_project_root (lib.sh) returns the project root in
-# both classic (.git) and bare (.bare) layouts.
-if [[ -n "${DISPATCH_LOCK_FILE:-}" ]]; then
-  LOCK_FILE="$DISPATCH_LOCK_FILE"
-else
-  PROJECT_ROOT=$(resolve_project_root) \
-    || { echo "ERROR: not in a git repo and DISPATCH_LOCK_FILE is unset" >&2; exit 2; }
-  LOCK_FILE="$PROJECT_ROOT/tmp/dispatch.lock"
-fi
+# dispatch_lock_file (lib.sh) honors an explicit DISPATCH_LOCK_FILE (tests rely
+# on this) and otherwise resolves the shared project-root tmp/dispatch.lock (not
+# a per-worktree tmp/) so concurrent ticks in different worktrees contend on the
+# same file. The tick's headless-liveness sentinel resolves through the same
+# helper, keeping the lock script and the tick on one lock-file directory (#1068).
+LOCK_FILE=$(dispatch_lock_file) \
+  || { echo "ERROR: not in a git repo and DISPATCH_LOCK_FILE is unset" >&2; exit 2; }
 
 # ---- Step 2: identify our own session ---------------------------------------
 # CLAUDE_CODE_SESSION_ID is set in every real .claude session's environment.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -132,11 +132,21 @@ fi
 # dispatch-acquire-lock, the materialize-spawn hold, and the release) sees one
 # consistent holder id across the acquire / hold / release of this tick. Derive
 # it from the systemd unit's INVOCATION_ID (set by systemd, identical across all
-# subprocesses of the unit and unique per tick), falling back to the dispatch-tick
-# PID ($$, unique per process, stable once exported) when neither is present. PID
-# is evaluated once at export time and frozen into the value, so all children see
-# the same fixed string regardless of how they check $$. Exported once so all
-# children agree.
+# subprocesses of the unit and unique per tick), falling back to a random token
+# (openssl rand -hex 16) when INVOCATION_ID is absent, with the dispatch-tick PID
+# ($$) as last resort if openssl is unavailable. The random token (or PID) is
+# evaluated once at export time and frozen into the value, so all children see
+# the same fixed string. Exported once so all children agree. (#1068)
+#
+# INVOCATION_ID validation (#1068, same-user threat model): under systemd
+# INVOCATION_ID is always 32 lowercase hex chars. A manually-set value containing
+# a newline would truncate the recorded holder in the lock file (causing a
+# self-release noop → one-tick lock stall); a backslash or control sequence could
+# mislead the `awk -F'\t'` comparison in dispatch-acquire-lock or corrupt the
+# sentinel path (dispatch-tick-<token>.live). Drop any non-conforming value so
+# the random-token fallback fires instead. Hex digits plus hyphen cover both the
+# standard 32-hex form and any UUID-style variant.
+[[ "${INVOCATION_ID:-}" =~ ^[0-9a-fA-F-]+$ ]] || INVOCATION_ID=""
 #
 # Headless-liveness sentinel (#1068). A synthetic `headless:*` id is a bash
 # string that never appears in `claude agents --json`, so dispatch-acquire-lock's
@@ -151,8 +161,8 @@ fi
 # resolved (not in a git repo and DISPATCH_LOCK_FILE unset), skip silently rather
 # than exit — the daemon path still governs real ids, and a headless tick that
 # cannot resolve the lock file also cannot acquire the lock. $$ is the tick PID,
-# frozen here to match the value baked into the synthetic id above.
-export CLAUDE_CODE_SESSION_ID="${CLAUDE_CODE_SESSION_ID:-headless:${INVOCATION_ID:-$$}}"
+# recorded in the sentinel content regardless of whether the id token uses it.
+export CLAUDE_CODE_SESSION_ID="${CLAUDE_CODE_SESSION_ID:-headless:${INVOCATION_ID:-$(openssl rand -hex 16 2>/dev/null || echo "$$")}}"
 if [[ "$CLAUDE_CODE_SESSION_ID" == headless:* ]]; then
   if SENTINEL_LOCK_FILE=$(dispatch_lock_file); then
     SENTINEL=$(headless_sentinel_path "$CLAUDE_CODE_SESSION_ID" "$SENTINEL_LOCK_FILE")

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -157,20 +157,35 @@ fi
 # file and install a single EXIT/INT/TERM trap to remove it; resolve_holder_state
 # treats the holder as live iff the sentinel exists and its PID is alive. Only a
 # synthesized id writes a sentinel — a real inherited session id is governed by
-# the daemon path and writes none. Best-effort: if the lock-file path cannot be
-# resolved (not in a git repo and DISPATCH_LOCK_FILE unset), skip silently rather
-# than exit — the daemon path still governs real ids, and a headless tick that
-# cannot resolve the lock file also cannot acquire the lock. $$ is the tick PID,
-# recorded in the sentinel content regardless of whether the id token uses it.
+# the daemon path and writes none. $$ is the tick PID, recorded in the sentinel
+# content regardless of whether the id token uses it.
+#
+# Two failure modes, two dispositions (#1068):
+#   - The lock-file path cannot be resolved (not in a git repo and
+#     DISPATCH_LOCK_FILE unset): skip the sentinel silently. The daemon path
+#     still governs real ids, and a headless tick that cannot resolve the lock
+#     file also cannot acquire the lock (dispatch-acquire-lock exits 2), so it
+#     never reaches selection — there is nothing to serialize.
+#   - The path resolves but the sentinel write fails (e.g. an over-long token
+#     yielding ENAMETOOLONG while the short dispatch.lock stays writable): fail
+#     clear with exit 2. Continuing here would let this tick acquire the lock
+#     with no liveness sentinel, so a concurrent tick reads this LIVE holder as
+#     dead and reclaims mid-selection — the exact duplicate-spawn defect #1068
+#     closes. Per .claude/rules/code-style.md, fail clear rather than degrade
+#     the concurrency guarantee silently; the chain self-heals on the next tick.
 export CLAUDE_CODE_SESSION_ID="${CLAUDE_CODE_SESSION_ID:-headless:${INVOCATION_ID:-$(openssl rand -hex 16 2>/dev/null || echo "$$")}}"
 if [[ "$CLAUDE_CODE_SESSION_ID" == headless:* ]]; then
   if SENTINEL_LOCK_FILE=$(dispatch_lock_file); then
     SENTINEL=$(headless_sentinel_path "$CLAUDE_CODE_SESSION_ID" "$SENTINEL_LOCK_FILE")
     mkdir -p "$(dirname "$SENTINEL")" 2>/dev/null || true
-    printf '%s\n' "$$" >"$SENTINEL" \
-      || echo "dispatch-tick: WARNING: failed to write headless sentinel '$SENTINEL'; liveness signaling disabled" >&2
-    # A single EXIT trap covers every `exit` below this point — intended.
+    # Install the trap before the write so it also clears any partial sentinel
+    # if the write fails and we abort. A single EXIT trap covers every `exit`
+    # below this point — intended.
     trap 'rm -f "$SENTINEL"' EXIT INT TERM
+    if ! printf '%s\n' "$$" >"$SENTINEL"; then
+      echo "dispatch-tick: ERROR: failed to write headless sentinel '$SENTINEL'; cannot signal liveness — aborting so a concurrent tick does not reclaim this lock mid-selection (#1068)" >&2
+      exit 2
+    fi
   fi
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -136,7 +136,31 @@ fi
 # is evaluated once at export time and frozen into the value, so all children see
 # the same fixed string regardless of how they check $$. Exported once so all
 # children agree.
+#
+# Headless-liveness sentinel (#1068). A synthetic `headless:*` id is a bash
+# string that never appears in `claude agents --json`, so dispatch-acquire-lock's
+# resolve_holder_state cannot resolve its liveness through the daemon registry —
+# a concurrent tick would read this LIVE holder as dead and reclaim the lock
+# mid-selection. To give the headless holder a daemon-independent liveness
+# signal, write a sentinel containing this tick's PID alongside the shared lock
+# file and install a single EXIT/INT/TERM trap to remove it; resolve_holder_state
+# treats the holder as live iff the sentinel exists and its PID is alive. Only a
+# synthesized id writes a sentinel — a real inherited session id is governed by
+# the daemon path and writes none. Best-effort: if the lock-file path cannot be
+# resolved (not in a git repo and DISPATCH_LOCK_FILE unset), skip silently rather
+# than exit — the daemon path still governs real ids, and a headless tick that
+# cannot resolve the lock file also cannot acquire the lock. $$ is the tick PID,
+# frozen here to match the value baked into the synthetic id above.
 export CLAUDE_CODE_SESSION_ID="${CLAUDE_CODE_SESSION_ID:-headless:${INVOCATION_ID:-$$}}"
+if [[ "$CLAUDE_CODE_SESSION_ID" == headless:* ]]; then
+  if SENTINEL_LOCK_FILE=$(dispatch_lock_file); then
+    SENTINEL=$(headless_sentinel_path "$CLAUDE_CODE_SESSION_ID" "$SENTINEL_LOCK_FILE")
+    mkdir -p "$(dirname "$SENTINEL")" 2>/dev/null || true
+    printf '%s\n' "$$" >"$SENTINEL"
+    # A single EXIT trap covers every `exit` below this point — intended.
+    trap 'rm -f "$SENTINEL"' EXIT INT TERM
+  fi
+fi
 
 # --- Step 1: select the target ------------------------------------------------
 # Capture select-tick's full stdout and echo every line through (jit:/calendar:

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -167,7 +167,8 @@ if [[ "$CLAUDE_CODE_SESSION_ID" == headless:* ]]; then
   if SENTINEL_LOCK_FILE=$(dispatch_lock_file); then
     SENTINEL=$(headless_sentinel_path "$CLAUDE_CODE_SESSION_ID" "$SENTINEL_LOCK_FILE")
     mkdir -p "$(dirname "$SENTINEL")" 2>/dev/null || true
-    printf '%s\n' "$$" >"$SENTINEL"
+    printf '%s\n' "$$" >"$SENTINEL" \
+      || echo "dispatch-tick: WARNING: failed to write headless sentinel '$SENTINEL'; liveness signaling disabled" >&2
     # A single EXIT trap covers every `exit` below this point — intended.
     trap 'rm -f "$SENTINEL"' EXIT INT TERM
   fi

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -243,6 +243,42 @@ resolve_project_root() {
   dirname "$common_dir"
 }
 
+# Print the canonical dispatch selection-lock file path to stdout. An explicit
+# DISPATCH_LOCK_FILE is authoritative and bypasses the git lookup (tests rely on
+# this). Otherwise the lock lives at the shared project-root tmp/ (not a per-
+# worktree tmp/) so concurrent ticks in different worktrees contend on the same
+# file. Returns non-zero (no output) when DISPATCH_LOCK_FILE is unset AND
+# resolve_project_root fails (not in a git repo); the caller supplies its own
+# error message. Mirrors dispatch-acquire-lock's Step-1 logic so the tick (which
+# writes the headless liveness sentinel) and the lock script resolve the same
+# lock-file directory. See #1068.
+dispatch_lock_file() {
+  local project_root
+  if [[ -n "${DISPATCH_LOCK_FILE:-}" ]]; then
+    printf '%s\n' "$DISPATCH_LOCK_FILE"
+    return 0
+  fi
+  project_root=$(resolve_project_root) || return 1
+  printf '%s\n' "$project_root/tmp/dispatch.lock"
+}
+
+# headless_sentinel_path <holder-id> <lock-file> — print the PID-sentinel path
+# for a `headless:<token>` holder id to stdout. The sentinel lives alongside the
+# lock file (same directory) so a concurrent tick in any worktree resolves the
+# same path. The filename is `dispatch-tick-<slug>.live`, where <slug> is the
+# token (everything after the `headless:` prefix) with every character outside
+# `[0-9A-Za-z._-]` replaced by `_`. Slugging is defense-in-depth (#1068): a
+# polluted INVOCATION_ID cannot escape the lock-file directory via path
+# separators. Fed via `printf '%s'` (no trailing newline) so `tr -c` appends no
+# spurious trailing `_`.
+headless_sentinel_path() {
+  local holder="$1" lock_file="$2" token slug dir
+  token="${holder#headless:}"
+  slug="$(printf '%s' "$token" | tr -c '0-9A-Za-z._-' '_')"
+  dir="$(dirname "$lock_file")"
+  printf '%s\n' "$dir/dispatch-tick-${slug}.live"
+}
+
 # Return the project ID for Firebase emulators.
 # Appends worktree name to prevent hub file collisions across worktrees.
 get_emulator_project_id() {

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -15307,14 +15307,46 @@ assert_eq "headless: synthetic id has headless: prefix (not a bare sentinel)" "1
   "$([[ "$sel_id" == headless:* ]] && echo 1 || echo 0)"
 
 # Companion: under systemd the id derives from INVOCATION_ID (the primary
-# headless path), not the bare-PID fallback the run above exercised. Set
-# INVOCATION_ID for one run and assert the synthesized id is exactly
-# headless:<INVOCATION_ID>. Fresh id logs so this run does not cross-contaminate.
+# headless path), not the random-token fallback the run above exercised. Use a
+# realistic 32-hex INVOCATION_ID (the form systemd always produces) and assert
+# the synthesized id is exactly headless:<INVOCATION_ID>. The validation guard
+# must pass hex digits — this exercises that path. (#1068)
 rm -f "$TMPDIR_TEST/logs/sel-id.log" "$TMPDIR_TEST/logs/mat-id.log"
-env -u CLAUDE_CODE_SESSION_ID INVOCATION_ID="inv-1054" \
+env -u CLAUDE_CODE_SESSION_ID INVOCATION_ID="0123456789abcdef0123456789abcdef" \
   "$TMPDIR_TEST/dispatch-tick" >/dev/null 2>&1
-assert_eq "headless: id derives from INVOCATION_ID when set (systemd path)" \
-  "headless:inv-1054" "$(cat "$TMPDIR_TEST/logs/sel-id.log")"
+assert_eq "headless: id derives from valid hex INVOCATION_ID (systemd path)" \
+  "headless:0123456789abcdef0123456789abcdef" "$(cat "$TMPDIR_TEST/logs/sel-id.log")"
+
+# Companion: polluted INVOCATION_ID — the #1068 validation guard drops a
+# non-hex value so it cannot truncate the recorded holder (via embedded newline),
+# mislead the awk -F'\t' comparison, or corrupt the sentinel path. The fallback
+# fires and the id must be single-line headless:<hex-or-pid>.
+rm -f "$TMPDIR_TEST/logs/sel-id.log" "$TMPDIR_TEST/logs/mat-id.log"
+env -u CLAUDE_CODE_SESSION_ID INVOCATION_ID="a/b" \
+  "$TMPDIR_TEST/dispatch-tick" >/dev/null 2>&1
+polluted_id=$(cat "$TMPDIR_TEST/logs/sel-id.log")
+assert_eq "headless: polluted INVOCATION_ID dropped — id has headless: prefix" "1" \
+  "$([[ "$polluted_id" == headless:* ]] && echo 1 || echo 0)"
+assert_eq "headless: polluted INVOCATION_ID dropped — id is single-line (no embedded newline)" "1" \
+  "$([[ "$polluted_id" != *$'\n'* ]] && echo 1 || echo 0)"
+assert_eq "headless: polluted INVOCATION_ID dropped — token is hex (guard rejected the slash)" "1" \
+  "$([[ "$polluted_id" =~ ^headless:[0-9a-f]+$ ]] && echo 1 || echo 0)"
+
+# Companion: INVOCATION_ID absent — the random-token fallback fires (openssl
+# rand -hex 16 when available; $$ as last resort). Assert the id is headless:-
+# prefixed, single-line, and its token matches hex (openssl path). (#1068)
+rm -f "$TMPDIR_TEST/logs/sel-id.log" "$TMPDIR_TEST/logs/mat-id.log"
+env -u CLAUDE_CODE_SESSION_ID -u INVOCATION_ID \
+  "$TMPDIR_TEST/dispatch-tick" >/dev/null 2>&1
+absent_id=$(cat "$TMPDIR_TEST/logs/sel-id.log")
+assert_eq "headless: absent INVOCATION_ID — id has headless: prefix" "1" \
+  "$([[ "$absent_id" == headless:* ]] && echo 1 || echo 0)"
+assert_eq "headless: absent INVOCATION_ID — id is non-empty" "1" \
+  "$([ -n "$absent_id" ] && echo 1 || echo 0)"
+assert_eq "headless: absent INVOCATION_ID — id is single-line" "1" \
+  "$([[ "$absent_id" != *$'\n'* ]] && echo 1 || echo 0)"
+assert_eq "headless: absent INVOCATION_ID — token is hex (random-token or PID fallback)" "1" \
+  "$([[ "$absent_id" =~ ^headless:[0-9a-f]+$ ]] && echo 1 || echo 0)"
 
 # Companion: a real session keeps its own id — the `:-` fallback never fires.
 # Fresh id logs so this run does not cross-contaminate the headless run above.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -12167,7 +12167,7 @@ lock_teardown
 echo "Test: headless holder with a live-PID sentinel is busy (not reclaimed)"
 lock_setup
 printf '%s\n' "headless:tok123" > "$DISPATCH_LOCK_FILE"
-headless_sentinel="$(dirname "$DISPATCH_LOCK_FILE")/dispatch-tick-tok123.live"
+headless_sentinel=$(source "$SCRIPT_DIR/lib.sh" 2>/dev/null; headless_sentinel_path "headless:tok123" "$DISPATCH_LOCK_FILE")
 printf '%s\n' "$$" > "$headless_sentinel"   # this test process is alive
 export CLAUDE_CODE_SESSION_ID="sess-headless-A"
 out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
@@ -12197,7 +12197,7 @@ lock_teardown
 echo "Test: headless holder with a dead-PID sentinel is reclaimed (acquired)"
 lock_setup
 printf '%s\n' "headless:tok123" > "$DISPATCH_LOCK_FILE"
-headless_sentinel="$(dirname "$DISPATCH_LOCK_FILE")/dispatch-tick-tok123.live"
+headless_sentinel=$(source "$SCRIPT_DIR/lib.sh" 2>/dev/null; headless_sentinel_path "headless:tok123" "$DISPATCH_LOCK_FILE")
 # A PID that is not running — a SIGKILL'd tick leaves this stale sentinel.
 printf '%s\n' "2147483647" > "$headless_sentinel"
 export CLAUDE_CODE_SESSION_ID="sess-headless-C"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -11302,6 +11302,63 @@ assert_eq "unset session: no marker created in target worktree" "0" \
   "$([ -f "$UNSET_WT/tmp/dispatch-worktree" ] && echo 1 || echo 0)"
 lock_teardown
 
+# ----- Headless-holder sentinel reclaim (#1068) ------------------------------
+# A synthetic `headless:<token>` holder never appears in `claude agents --json`,
+# so resolve_holder_state resolves its liveness through the PID sentinel the tick
+# writes alongside the lock file: live iff the sentinel exists AND its PID is
+# alive. These tests drive the real dispatch-acquire-lock against a lock file
+# recording a headless holder, with a different caller sessionId. No
+# CLAUDE_AGENTS_CMD fake is needed — the headless branch returns before the
+# daemon query. Sentinel path: <dirname $DISPATCH_LOCK_FILE>/dispatch-tick-<slug>.live
+# (slug for a simple token like `tok123` is unchanged).
+
+# --- Headless A: live PID in the sentinel → caller stays busy (no reclaim) ----
+echo "Test: headless holder with a live-PID sentinel is busy (not reclaimed)"
+lock_setup
+printf '%s\n' "headless:tok123" > "$DISPATCH_LOCK_FILE"
+headless_sentinel="$(dirname "$DISPATCH_LOCK_FILE")/dispatch-tick-tok123.live"
+printf '%s\n' "$$" > "$headless_sentinel"   # this test process is alive
+export CLAUDE_CODE_SESSION_ID="sess-headless-A"
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+assert_eq "headless-live exits 0" "0" "$rc"
+assert_eq "headless-live prints busy" "busy" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "headless-live lock file still holds the headless holder" \
+  "headless:tok123" "$lock_contents"
+rm -f "$headless_sentinel"
+lock_teardown
+
+# --- Headless B: no sentinel → caller reclaims (acquired) ---------------------
+echo "Test: headless holder with no sentinel is reclaimed (acquired)"
+lock_setup
+printf '%s\n' "headless:tok123" > "$DISPATCH_LOCK_FILE"
+# No sentinel file written → the headless holder reads dead.
+export CLAUDE_CODE_SESSION_ID="sess-headless-B"
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+assert_eq "headless-absent exits 0" "0" "$rc"
+assert_eq "headless-absent prints acquired" "acquired" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "headless-absent lock file rewritten to caller" \
+  "sess-headless-B" "$lock_contents"
+lock_teardown
+
+# --- Headless C: dead PID in the sentinel → caller reclaims (stale-after-kill) -
+echo "Test: headless holder with a dead-PID sentinel is reclaimed (acquired)"
+lock_setup
+printf '%s\n' "headless:tok123" > "$DISPATCH_LOCK_FILE"
+headless_sentinel="$(dirname "$DISPATCH_LOCK_FILE")/dispatch-tick-tok123.live"
+# A PID that is not running — a SIGKILL'd tick leaves this stale sentinel.
+printf '%s\n' "2147483647" > "$headless_sentinel"
+export CLAUDE_CODE_SESSION_ID="sess-headless-C"
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+assert_eq "headless-dead exits 0" "0" "$rc"
+assert_eq "headless-dead prints acquired" "acquired" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "headless-dead lock file rewritten to caller" \
+  "sess-headless-C" "$lock_contents"
+rm -f "$headless_sentinel"
+lock_teardown
+
 # ============================================================================
 # restore-dispatch-skill tests (#903)
 # ============================================================================
@@ -14164,6 +14221,10 @@ tick_setup() {
   # test's $PWD (dispatch-tick's resolve_project_root would otherwise resolve the
   # real project root). The fake spawn-job logs this value as its --cwd argv.
   export DISPATCH_TICK_MAIN_WORKTREE="$TMPDIR_TEST"
+  # Pin the shared lock file under TMPDIR_TEST so the headless-liveness sentinel
+  # (#1068) the tick writes resolves through dispatch_lock_file to a path inside
+  # the test tree (not the host repo's tmp/).
+  export DISPATCH_LOCK_FILE="$TMPDIR_TEST/dispatch.lock"
 
   # Fake dispatch-select-tick: echoes any TICK_SEL_PRE passthrough lines, then
   # the test-controlled decision line (TICK_DECISION) as the LAST line. Exits
@@ -14201,7 +14262,8 @@ tick_teardown() {
   rm -rf "$TMPDIR_TEST"
   TMPDIR_TEST=""
   unset TICK_DECISION TICK_TOKEN TICK_SEL_RC TICK_MAT_RC \
-    TICK_SEL_PRE TICK_MAT_PRE TICK_SPAWN_RESULT DISPATCH_TICK_MAIN_WORKTREE
+    TICK_SEL_PRE TICK_MAT_PRE TICK_SPAWN_RESULT DISPATCH_TICK_MAIN_WORKTREE \
+    DISPATCH_LOCK_FILE
 }
 
 run_tick() { "$TMPDIR_TEST/dispatch-tick" "$@" 2>/dev/null; }
@@ -14427,6 +14489,54 @@ export CLAUDE_CODE_SESSION_ID="sess-real-1054"
 assert_eq "real session: select-tick sees the inherited id, not a synthetic one" \
   "sess-real-1054" "$(cat "$TMPDIR_TEST/logs/sel-id.log")"
 unset CLAUDE_CODE_SESSION_ID DISPATCH_LOCK_FILE CLAUDE_AGENTS_CMD
+tick_teardown
+
+# --- headless tick writes a PID sentinel during the run, trap removes it after -
+# #1068: a synthetic headless holder is invisible to `claude agents --json`, so
+# the tick writes a PID sentinel alongside the shared lock file for its lifetime
+# and an EXIT trap removes it. resolve_holder_state resolves the headless
+# holder's liveness from that sentinel. This test observes the sentinel directly
+# (no acquire-lock needed): the fake select-tick globs the lock dir mid-run and
+# records the matched sentinel's existence + content, then after the tick returns
+# we assert (1) a sentinel existed mid-run, (2) it held a numeric PID, (3) the
+# trap left no dispatch-tick-*.live behind. The token is the tick's $$ (no
+# INVOCATION_ID, no inherited id), unknowable in advance — hence the glob.
+echo "Test: dispatch-tick headless writes a PID sentinel mid-run and removes it on exit"
+tick_setup
+LOCK_DIR="$(dirname "$DISPATCH_LOCK_FILE")"
+# Replace the select-tick fake: glob the lock dir for the sentinel mid-run and
+# log its presence (1/0) and contents, then print a decision line so the tick
+# routes to a normal exit. mkdir -p the lock dir defensively (the tick already
+# created it before writing the sentinel).
+cat > "$TMPDIR_TEST/dispatch-select-tick" <<FAKE
+#!/usr/bin/env bash
+shopt -s nullglob
+matches=( "$LOCK_DIR"/dispatch-tick-*.live )
+if (( \${#matches[@]} > 0 )); then
+  printf '1\n' > "$TMPDIR_TEST/logs/sentinel-midrun.log"
+  cat "\${matches[0]}" >> "$TMPDIR_TEST/logs/sentinel-midrun.log"
+else
+  printf '0\n' > "$TMPDIR_TEST/logs/sentinel-midrun.log"
+fi
+printf '%s\n' "empty"
+exit 0
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-tick"
+# Run headless with NO inherited id and NO INVOCATION_ID → token is the tick $$.
+env -u CLAUDE_CODE_SESSION_ID -u INVOCATION_ID \
+  "$TMPDIR_TEST/dispatch-tick" >/dev/null 2>&1 && rc=0 || rc=$?
+assert_eq "sentinel: tick exit 0" "0" "$rc"
+midrun_present=$(sed -n '1p' "$TMPDIR_TEST/logs/sentinel-midrun.log" 2>/dev/null)
+midrun_pid=$(sed -n '2p' "$TMPDIR_TEST/logs/sentinel-midrun.log" 2>/dev/null)
+assert_eq "sentinel: existed mid-run" "1" "$midrun_present"
+assert_eq "sentinel: mid-run content is a numeric PID" "1" \
+  "$([[ "$midrun_pid" =~ ^[0-9]+$ ]] && echo 1 || echo 0)"
+# The EXIT trap must have removed every sentinel from the lock dir.
+shopt -s nullglob
+leftover=( "$LOCK_DIR"/dispatch-tick-*.live )
+shopt -u nullglob
+assert_eq "sentinel: removed by the EXIT trap (no .live left behind)" "0" \
+  "${#leftover[@]}"
 tick_teardown
 
 # --- --manual is forwarded to select-tick, unbounded fan-out, never concurrency-cap ---

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -15406,6 +15406,41 @@ assert_eq "sentinel: removed by the EXIT trap (no .live left behind)" "0" \
   "${#leftover[@]}"
 tick_teardown
 
+# --- headless tick fails clear when the sentinel write fails (#1068) ----------
+# When the lock-file path resolves but the sentinel write fails (here forced via
+# an over-long-but-hex INVOCATION_ID → a >255-byte sentinel filename →
+# ENAMETOOLONG, while the short dispatch.lock stays writable), dispatch-tick must
+# exit 2 *before* selecting a target rather than warn-and-continue. Continuing
+# would acquire the lock with no liveness sentinel, so a concurrent tick reads
+# this LIVE holder as dead and reclaims mid-selection — the exact duplicate-spawn
+# defect #1068 closes. The select-tick fake drops a marker if it runs; the test
+# asserts the tick exited non-zero and never reached selection.
+echo "Test: dispatch-tick headless fails clear (exit 2, no selection) when the sentinel write fails"
+tick_setup
+LOCK_DIR="$(dirname "$DISPATCH_LOCK_FILE")"
+cat > "$TMPDIR_TEST/dispatch-select-tick" <<FAKE
+#!/usr/bin/env bash
+printf 'ran\n' > "$TMPDIR_TEST/logs/select-ran.log"
+printf '%s\n' "empty"
+exit 0
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-tick"
+rm -f "$TMPDIR_TEST/logs/select-ran.log"
+# 250 hex chars: passes the INVOCATION_ID guard, yields a sentinel filename
+# (dispatch-tick-<250>.live = 269 bytes) that exceeds NAME_MAX (255) → write fails.
+long_inv=$(printf 'a%.0s' {1..250})
+env -u CLAUDE_CODE_SESSION_ID INVOCATION_ID="$long_inv" \
+  "$TMPDIR_TEST/dispatch-tick" >/dev/null 2>&1 && rc=0 || rc=$?
+assert_eq "sentinel-write-fail: tick exits 2 (fail clear)" "2" "$rc"
+assert_eq "sentinel-write-fail: selection never ran (aborted before select-tick)" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/select-ran.log" ] && echo 1 || echo 0)"
+shopt -s nullglob
+leftover=( "$LOCK_DIR"/dispatch-tick-*.live )
+shopt -u nullglob
+assert_eq "sentinel-write-fail: no stale .live left behind (trap cleaned partial)" "0" \
+  "${#leftover[@]}"
+tick_teardown
+
 # --- --manual is forwarded to select-tick; one gate-exempt worker (gap=1) -----
 # A bare human-typed /dispatch passes --manual to dispatch-tick, which must
 # forward it to dispatch-select-tick. The fake select-tick records its argv.


### PR DESCRIPTION
Closes #1068

## Problem

PR #1057 made the headless `dispatch-tick` synthesize a stable holder id
(`headless:${INVOCATION_ID:-$$}`) so it can acquire the dispatch selection lock
under systemd. But `dispatch-acquire-lock`'s `resolve_holder_state` resolves a
recorded holder's liveness **only** through the `claude agents --json` daemon
registry, which tracks model sessions, not bash processes. A synthetic
`headless:*` id never appears there, so any other concurrent tick that reads a
**live** headless holder queries the registry, finds it absent, classifies the
holder **dead**, and reclaims the lock mid-selection. Two ticks can then both
pass the lock and select the same target — and for a fresh `help wanted` issue
with no worktree yet, duplicate-spawn. A human-typed `/dispatch` (real UUID, in
the registry) likewise reclaims a running headless tick's lock.

Same-user concurrency-correctness defect — no adversary, no trust boundary.

## Fix

**Unit 1 — PID-backed sentinel.** The headless tick maintains a sentinel file
containing its own PID for its lifetime; `resolve_holder_state` treats a
`headless:*` holder as live iff the sentinel exists **and** its stored PID is
still alive (`kill -0`). Storing the PID (rather than relying on bare existence)
means a `SIGKILL`-orphaned sentinel still resolves **dead**, preserving the
self-healing reclaim the daemon path already gives real sessions.

- `lib.sh`: two shared helpers so the tick and the lock derive identical paths
  from one source of truth — `dispatch_lock_file` (canonical lock-file path) and
  `headless_sentinel_path` (slugged `dispatch-tick-<token>.live` beside the lock).
- `dispatch-acquire-lock`: a leading `headless:*` branch in `resolve_holder_state`
  that resolves liveness via the sentinel; Step 1 now calls `dispatch_lock_file`.
- `dispatch-tick`: writes `$$` to the sentinel on start and installs a
  `trap … EXIT INT TERM` that removes it on clean exit or systemd stop.

**Unit 2 — synthetic-id hardening.** Validate `INVOCATION_ID` against the systemd
hex shape (`^[0-9a-fA-F-]+$`) before admitting it into the holder id — a polluted
value with a newline would truncate the recorded holder or break the
`awk -F'\t'` comparison and the sentinel path. Replace the low-entropy bare-PID
fallback with `openssl rand -hex 16` (PID remains the last-resort fallback).

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` passes
fully, including new acquire-lock headless-liveness cases (live PID → busy,
absent sentinel → acquired, dead PID → acquired) and tick-sentinel lifecycle
tests (written mid-run, removed by the trap after).
