### PR TITLE
dispatch: fan-out exclusion — re-surfaced targets no longer halt the loop (#1062)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -388,13 +388,22 @@ if [[ "$MODE" == "explicit" ]] || (( GAP <= 1 )); then
 fi
 
 # Fan out: fill up to GAP slots in one held-lock run. Target 1 is the passed-in
-# N; targets 2..GAP come from successive dispatch-select-target calls. Each
-# spawned worker registers before the next selection (#945/#905), so the next
-# dispatch-select-target skips its now-live-owned worktree and yields a distinct
-# target. A SEEN guard additionally stops the run if selection ever returns an
-# already-processed target (a non-spawning outcome that did not remove the
-# target from the queue), bounding the loop. Per-target park/skip outcomes are
-# recorded and the loop continues; the lock is released ONCE at the end.
+# N; targets 2..GAP come from successive dispatch-select-target calls. The loop
+# passes its SEEN set as `--exclude` to dispatch-select-target so selection
+# yields the NEXT distinct target instead of re-returning an already-processed
+# one (#1062). A re-return would otherwise happen via two mechanisms: (1)
+# registration-visibility lag — a just-spawned worker is verified-registered but
+# not yet visible to the next selection's liveness query (#945/#905), so its
+# leaf re-surfaces; or (2) a fast self-close leaving an orphan worktree, which
+# selection treats as a reuse signal (not a conflict) and does not skip. The
+# exclusion defeats both: an excluded target is filtered during the queue scan
+# (and threaded into the leaf trace), so the loop advances to the next distinct
+# startable leaf. The loop stops only on a genuine `empty`, a deferred selection
+# (main-broken / jit-reminder), or a hard error — plus a defensive backstop if
+# selection ever re-returns a SEEN target despite the exclusion (a selector
+# contract violation), to prevent an infinite loop. Per-target park/skip
+# outcomes are recorded and the loop continues; the lock is released ONCE at the
+# end.
 declare -A SEEN=()
 spawned=0
 stop_reason="gap filled"
@@ -437,7 +446,9 @@ while :; do
       ;;
   esac
   (( spawned >= GAP )) && break
-  SELECTED=$("$SCRIPT_DIR/dispatch-select-target") || true
+  exclude_args=()
+  (( ${#SEEN[@]} > 0 )) && exclude_args=(--exclude "${!SEEN[@]}")
+  SELECTED=$("$SCRIPT_DIR/dispatch-select-target" "${exclude_args[@]}") || true
   case "$SELECTED" in
     pr\ *)
       # Extract the branch from "pr <pr_num> <branch> <phase>" without clobbering $@.
@@ -451,8 +462,14 @@ while :; do
        echo "dispatch-materialize-spawn: dispatch-select-target emitted unexpected '$SELECTED' in fan-out" >&2
        exit 2 ;;
   esac
+  # Defensive backstop (#1062): the loop passes SEEN as --exclude, so
+  # dispatch-select-target must never return an already-processed target. If it
+  # somehow does, that is a selector contract violation — break rather than spin
+  # forever. This stop is unreachable in normal operation; the loop's real
+  # terminators are `empty`, a deferred selection, and hard errors above.
   if [[ -n "${SEEN[$cur_n]:-}" ]]; then
-    stop_reason="no further distinct targets"
+    echo "dispatch-materialize-spawn: dispatch-select-target re-returned already-processed target #$cur_n despite --exclude (contract violation); stopping fan-out to avoid an infinite loop" >&2
+    stop_reason="selection re-returned an excluded target (unexpected)"
     break
   fi
 done

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -136,8 +136,8 @@ fi
 
 # Build the leaf-trace passthrough once: the excluded numbers thread into
 # dispatch-trace-leaf (#1062) so a multi-leaf subtree descends past an excluded
-# leaf. Only constructed when non-empty so "${EXCLUDE_ARGS[@]}" expands to
-# nothing under set -u when no exclusion was requested.
+# leaf. Only constructed when non-empty so the call site passes no --exclude
+# flag at all when no exclusion was requested.
 EXCLUDE_ARGS=()
 (( ${#EXCLUDED[@]} > 0 )) && EXCLUDE_ARGS=(--exclude "${!EXCLUDED[@]}")
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 # Select the single highest-priority task from the queue.
-# Usage: dispatch-select-target [--qa | --health-only]
+# Usage: dispatch-select-target [--qa | --health-only] [--exclude <n>...]
+#
+# --exclude <n>... names issue numbers the caller has already processed (the
+# fan-out loop's SEEN set, #1062); the selector never returns an excluded target
+# and instead surfaces the next distinct one. The exclusion is applied during
+# the queue scan, not as a post-selection output filter: a PR row is filtered by
+# its branch issue-prefix (<N>-<slug>) before FIRST_PR is recorded, so the
+# next-oldest PR in an already-tapped bucket surfaces; and the exclusion is
+# threaded into the leaf trace for issue rows, so a multi-leaf subtree whose
+# first leaf was already processed descends to its next startable leaf. Coexists
+# with --qa / --health-only — those flags start with `-`, so the integer-run
+# consumption stops at them.
 #
 # Selection is a pure function of GitHub state plus local-worktree existence.
 # The router's cwd carries no priority signal; invoking this script from any
@@ -101,11 +112,19 @@ source "$SCRIPT_DIR/lib.sh"
 source "$SCRIPT_DIR/lib-claude-agents.sh"
 QA_MODE=false
 HEALTH_ONLY=false
+declare -A EXCLUDED=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --qa) QA_MODE=true; shift ;;
     --health-only) HEALTH_ONLY=true; shift ;;
+    --exclude)
+      shift
+      while [[ $# -gt 0 && "$1" =~ ^[0-9]+$ ]]; do
+        EXCLUDED["$1"]=1
+        shift
+      done
+      ;;
     *) echo "error: unknown argument: $1" >&2; exit 1 ;;
   esac
 done
@@ -114,6 +133,13 @@ if [[ "$QA_MODE" == "true" && "$HEALTH_ONLY" == "true" ]]; then
   echo "error: --qa and --health-only are mutually exclusive" >&2
   exit 1
 fi
+
+# Build the leaf-trace passthrough once: the excluded numbers thread into
+# dispatch-trace-leaf (#1062) so a multi-leaf subtree descends past an excluded
+# leaf. Only constructed when non-empty so "${EXCLUDE_ARGS[@]}" expands to
+# nothing under set -u when no exclusion was requested.
+EXCLUDE_ARGS=()
+(( ${#EXCLUDED[@]} > 0 )) && EXCLUDE_ARGS=(--exclude "${!EXCLUDED[@]}")
 
 # Print origin/main's HEAD SHA if its CI has a failing check; print nothing if
 # main is healthy or only has in-progress checks. main's CI state spans two
@@ -519,6 +545,13 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   # lives on the issue (issue #909), so resolve the issue number from the PR's
   # branch prefix (<N>-<slug>) and check the issue's labels in ISSUE_LABELS_JSON.
   pr_issue_num="${pr_branch%%-*}"
+  # Skip a PR whose issue is in the --exclude set (#1062): the fan-out caller has
+  # already processed this target. Applied during the scan, before FIRST_PR is
+  # populated, so the next-oldest PR in an already-tapped bucket surfaces. The
+  # number matches what the fan-out loop records in SEEN for a pr row
+  # (${pr_branch%%-*}). Shared loop ⇒ also covers --qa selection — harmless and
+  # consistent.
+  [[ -n "$pr_issue_num" && -n "${EXCLUDED[$pr_issue_num]:-}" ]] && continue
   if [[ -n "$pr_issue_num" ]] && printf '%s' "$ISSUE_LABELS_JSON" \
       | jq -e --arg n "$pr_issue_num" \
         '(.[$n] // []) | any(.name == "dispatch:office-hours")' >/dev/null; then
@@ -614,13 +647,17 @@ while IFS=$'\t' read -r issue_num issue_labels; do
   # Resolve a startable open leaf within the issue's subtree. dispatch-trace-leaf
   # in queue mode descends open blockers and sub-issues, skipping any child whose
   # <N>-* worktree is owned by a live session (#914) — an orphan child worktree
-  # stays descendable:
+  # stays descendable. The --exclude set (#1062) is threaded in so a leaf the
+  # fan-out caller already processed — including this help-wanted issue itself as
+  # the trace root, and a multi-leaf subtree's first leaf that self-closed and
+  # left an orphan worktree (not live-skipped) — is descended past to the next
+  # startable leaf, rather than re-returned:
   #   exit 0 — a startable open leaf was found; record it for this bucket.
-  #   exit 2 — every reachable open leaf is owned by a live session. Skip this
-  #            issue exactly as a direct live-owned worktree is skipped; a later
-  #            issue in the same bucket may still fill the slot.
+  #   exit 2 — every reachable open leaf is owned by a live session or excluded.
+  #            Skip this issue exactly as a direct live-owned worktree is skipped;
+  #            a later issue in the same bucket may still fill the slot.
   #   exit 1 — usage error; propagate as a hard failure, never swallow as a skip.
-  if leaf=$("$SCRIPT_DIR/dispatch-trace-leaf" "$issue_num" queue); then
+  if leaf=$("$SCRIPT_DIR/dispatch-trace-leaf" "$issue_num" queue "${EXCLUDE_ARGS[@]}"); then
     FIRST_ISSUE[$issue_bucket]="$leaf"
   else
     trace_status=$?

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
@@ -89,6 +89,10 @@ if [[ $# -gt 0 ]]; then
     EXCLUDED["$1"]=1
     shift
   done
+  if [[ $# -gt 0 ]]; then
+    echo "error: usage: dispatch-trace-leaf <issue-num> <queue|explicit> [--exclude <n>...]" >&2
+    exit 1
+  fi
 fi
 
 # In queue mode, map each issue-number prefix to the on-disk path(s) of its

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
 # Trace from issue N to the deepest open leaf (no open children).
-# Usage: dispatch-trace-leaf <issue-num> <queue|explicit>
+# Usage: dispatch-trace-leaf <issue-num> <queue|explicit> [--exclude <n>...]
 #
 # Walks open blockers and open sub-issues depth-first, visiting the
 # lowest-numbered open child first, to find the lowest-numbered reachable
 # open leaf. Prints one issue number.
+#
+# The optional --exclude <n>... argument names already-processed leaves the
+# trace must never return (#1062). It is the fan-out caller's running SEEN set:
+# a multi-leaf subtree whose first leaf was already spawned (and whose worktree
+# is now an orphan, not a live session — so the liveness filter below does not
+# skip it) would otherwise re-return that same leaf and stall the fan-out. An
+# excluded leaf is treated exactly like a live-owned/parked child — never
+# returned, descended past — so the trace advances to the next startable leaf
+# in the same subtree. The flag consumes the run of integer tokens following it
+# (stops at the next --flag or end of args). Passed only in queue mode; explicit
+# mode never receives it, so explicit behavior is unchanged.
 #
 # The mode argument controls worktree-awareness during the descent:
 #   explicit — descent is not worktree-aware. An existing <N>-* worktree on a
@@ -40,8 +51,8 @@
 #   0 — a leaf was found and printed to stdout
 #   1 — usage error, or a sibling gh script (issue-blocking / issue-sub-issues)
 #       failed — a hard failure the caller must not treat as "no work"
-#   2 — queue mode only: every reachable open leaf is owned by a live session
-#       or parked on dispatch:office-hours
+#   2 — queue mode only: every reachable open leaf is owned by a live session,
+#       parked on dispatch:office-hours, or in the --exclude set
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -56,8 +67,28 @@ ISSUE_NUM="${1:-}"
 MODE="${2:-}"
 if [[ -z "$ISSUE_NUM" || ! "$ISSUE_NUM" =~ ^[1-9][0-9]*$ ]] \
    || [[ "$MODE" != "queue" && "$MODE" != "explicit" ]]; then
-  echo "error: usage: dispatch-trace-leaf <issue-num> <queue|explicit>" >&2
+  echo "error: usage: dispatch-trace-leaf <issue-num> <queue|explicit> [--exclude <n>...]" >&2
   exit 1
+fi
+
+# Optional --exclude <n>...: a run of integer tokens naming already-processed
+# leaves the trace must never return (#1062). The topological-leaf branch in
+# find_leaf refuses to return any number in EXCLUDED, so the descent advances
+# past it. Consume the run of integer tokens following the flag (stops at the
+# next --flag or end of args), matching the variadic wire format the fan-out
+# caller uses to expand its SEEN set directly.
+declare -A EXCLUDED=()
+shift 2
+if [[ $# -gt 0 ]]; then
+  if [[ "$1" != "--exclude" ]]; then
+    echo "error: usage: dispatch-trace-leaf <issue-num> <queue|explicit> [--exclude <n>...]" >&2
+    exit 1
+  fi
+  shift
+  while [[ $# -gt 0 && "$1" =~ ^[0-9]+$ ]]; do
+    EXCLUDED["$1"]=1
+    shift
+  done
 fi
 
 # In queue mode, map each issue-number prefix to the on-disk path(s) of its
@@ -195,9 +226,19 @@ find_leaf() {
   fi
 
   if [[ -z "$kids" ]]; then
-    # Topological leaf — a valid leaf. Live-session-owned children are filtered
-    # before recursion (see the descent loop below), so a queue-mode leaf
-    # reached here is never itself live-owned.
+    # Topological leaf. An excluded leaf (#1062) — already processed by the
+    # fan-out caller — is treated exactly like a live-owned/parked child: never
+    # returned. return 1 (no valid leaf here) so the descent advances past it to
+    # the next startable sibling/leaf, or bubbles up to the exit-2 surface when
+    # the whole subtree is excluded. This single check covers both the root
+    # (passed directly to find_leaf) and every descended leaf — no separate root
+    # guard is needed.
+    if [[ -n "${EXCLUDED[$n]:-}" ]]; then
+      return 1
+    fi
+    # A valid leaf. Live-session-owned children are filtered before recursion
+    # (see the descent loop below), so a queue-mode leaf reached here is never
+    # itself live-owned.
     echo "$n"
     return 0
   fi
@@ -254,8 +295,9 @@ if [[ "$trace_rc" -eq 3 ]]; then
 fi
 
 # In queue mode, no valid leaf is reachable — every reachable open leaf is owned
-# by a live session or parked on dispatch:office-hours (#1011) (or cycles block
-# every path); orphan worktrees were descended through. Surface this so
+# by a live session, parked on dispatch:office-hours (#1011), or in the
+# --exclude set (#1062) (or cycles block every path); orphan worktrees were
+# descended through. Surface this so
 # /dispatch-propagate can stop with a clear message instead of dispatching on a
 # conflict. The "worktree-conflicted" token is retained for the pattern-matcher
 # in test-dispatch-scripts.sh that keys on it (dispatch-select-target only checks

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2070,6 +2070,73 @@ assert_eq "dispatch-trace-leaf exit 1 → select-target exits non-zero" "yes" "$
 assert_eq "dispatch-trace-leaf exit 1 → no issue line emitted" "yes" "$no_issue"
 teardown
 
+# --- --exclude set (#1062) ----------------------------------------------------
+# The fan-out caller passes its SEEN set as --exclude so the selector never
+# re-returns an already-processed target; it surfaces the next distinct one. The
+# harness copies the REAL dispatch-trace-leaf into TMPDIR_TEST, so these run end
+# to end through the Unit-1 trace.
+
+# 39a. A help-wanted issue in the --exclude set is skipped via the trace root;
+#      the next help-wanted issue is selected. Issue 55 (older) is excluded, so
+#      the trace exits 2 for it and issue 66 (newer) surfaces.
+echo "Test: excluded help-wanted issue skipped → next issue chosen"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":66,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --exclude 55)
+assert_eq "excluded issue 55 skipped → issue 66 chosen" "issue 66" "$result"
+teardown
+
+# 39b. A multi-leaf subtree whose first leaf is excluded descends to the next
+#      startable leaf (AC (b)): the exclusion threads into the trace. Issue 55
+#      has sub-issues 5500 and 5501, neither worktree'd nor parked; --exclude
+#      5500 must yield 5501, not skip the whole subtree.
+echo "Test: excluded first leaf → next startable leaf in subtree selected"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":5500},{"number":5501}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-5500.json"
+printf '{"title":"Issue 5501","body":"","comments":[],"number":5501,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-5501.json"
+# No worktrees — only the exclusion distinguishes the leaves.
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --exclude 5500)
+assert_eq "excluded leaf 5500 → leaf 5501 selected" "issue 5501" "$result"
+teardown
+
+# 39c. A whole-frontier exclusion drains to empty: the only help-wanted issue's
+#      only leaf is excluded and there is no QA PR, so the selector returns
+#      empty (a genuine empty, not a re-selection).
+echo "Test: whole frontier excluded, no QA PR → empty"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":5500}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-5500.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --exclude 5500)
+assert_eq "whole frontier excluded → empty" "empty" "$result"
+teardown
+
+# 39d. A PR row whose issue is excluded is filtered during the scan (before
+#      FIRST_PR), so a single ready PR on branch 20-feature plus --exclude 20
+#      and an empty issue list yields empty — the excluded PR is not selected and
+#      nothing else exists.
+echo "Test: excluded PR row filtered during scan → empty"
+setup
+UNION='['"$(make_pr_union 20 "20-feature" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --exclude 20)
+assert_eq "excluded PR 20 filtered → empty" "empty" "$result"
+teardown
+
 # --- ready-PR gate (#920) ---
 # An open help-wanted issue whose closing PR is non-draft (ready) is excluded
 # from the issue queue. The gate uses closingIssuesReferences from PR_LIST —

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3186,6 +3186,79 @@ result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "explicit")
 assert_eq "explicit: parked root leaf 700 returned unchanged" "700" "$result"
 teardown
 
+# 22. Queue mode: --exclude names an already-processed leaf; the trace refuses to
+#     return it and descends past it to the next startable sibling (#1062). 700
+#     has open sub-issues 701 and 702, neither with a worktree, so only the
+#     exclusion distinguishes them. Without --exclude the lowest leaf 701 would
+#     be returned; with --exclude 701 the trace yields 702.
+echo "Test: queue mode → --exclude leaf skipped, returns next startable sibling"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue" --exclude 701)
+assert_eq "queue: --exclude 701 → next startable leaf 702" "702" "$result"
+teardown
+
+# 23. Queue mode: the only reachable leaf is excluded → exit 2 with the
+#     worktree-conflicted stderr surface, exactly as an all-live-owned subtree
+#     (#1062 reuses the #914/#1011 no-startable-leaf path). 700 → single sub 701
+#     (leaf); --exclude 701 leaves nothing startable.
+echo "Test: queue mode → single leaf excluded, exits 2"
+setup
+printf '[{"number":701}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+err_out=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue" --exclude 701 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err_out" in
+  *"worktree-conflicted"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err_out" ;;
+esac
+assert_eq "queue: single leaf excluded → exit 2 with stderr message" "ok" "$status"
+teardown
+
+# 24. Queue mode: --exclude covers every reachable leaf (variadic integer run) →
+#     exit 2 (#1062). Exercises the multi-token --exclude 701 702 parse and the
+#     whole-frontier-excluded bubble-up.
+echo "Test: queue mode → all leaves excluded (variadic), exits 2"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+err_out=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue" --exclude 701 702 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err_out" in
+  *"worktree-conflicted"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err_out" ;;
+esac
+assert_eq "queue: all leaves excluded → exit 2 with stderr message" "ok" "$status"
+teardown
+
+# 25. Queue mode: a multi-leaf subtree whose FIRST leaf is excluded drains to the
+#     next startable leaf in the same subtree (#1062 AC (b)). Parent 700 has two
+#     leaf sub-issues 701 and 702; excluding 701 (an already-spawned leaf whose
+#     worktree is an orphan, not live-owned, so the liveness filter does not skip
+#     it) must still advance to the parent's other startable leaf 702 rather than
+#     abandon the subtree.
+echo "Test: queue mode → multi-leaf subtree, first leaf excluded drains to next leaf"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+# 701's worktree exists but no live session owns it → orphan, descendable; only
+# the --exclude set removes it from the startable frontier.
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+select_target_fake_claude
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue" --exclude 701)
+assert_eq "queue: multi-leaf subtree, --exclude 701 (orphan) → next leaf 702" "702" "$result"
+teardown
+
 # ============================================================================
 # dispatch-complete-phase tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -15080,6 +15080,126 @@ assert_eq "distinct: worktrees all unique" "3" \
   "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
 mat_teardown
 
+# --- fan-out exclusion (#1062): the loop passes its SEEN set as --exclude so ---
+# dispatch-select-target yields the NEXT distinct target instead of re-returning
+# an already-processed one. Each of the following tests overrides the default
+# (arg-ignoring) select-target fake with an EXCLUDE-HONORING fake that returns
+# the first MAT_QUEUE entry NOT in the passed --exclude set. WITHOUT --exclude
+# this fake returns the queue HEAD on every call — re-surfacing an already-
+# spawned target — the exact scenario the loop's exclusion must defeat. The
+# helper below writes that fake into the live TMPDIR_TEST.
+write_exclude_honoring_select_target() {
+  cat > "$TMPDIR_TEST/dispatch-select-target" <<FAKE
+#!/usr/bin/env bash
+# Exclude-honoring fake (#1062): returns the first MAT_QUEUE entry NOT in the
+# passed --exclude set, modelling a real selector yielding the next distinct
+# target. WITHOUT --exclude it returns the first entry every call — re-surfacing
+# an already-spawned target (registration lag / orphan self-close), the exact
+# scenario the loop's exclusion must defeat.
+declare -A EX=()
+while [[ \$# -gt 0 ]]; do
+  case "\$1" in
+    --exclude) shift; while [[ \$# -gt 0 && "\$1" =~ ^[0-9]+\$ ]]; do EX["\$1"]=1; shift; done ;;
+    *) shift ;;
+  esac
+done
+read -r -a Q <<< "\${MAT_QUEUE:-}"
+echo "called exclude=\${!EX[*]:-}" >> "$TMPDIR_TEST/logs/select-target.log"
+for n in "\${Q[@]}"; do
+  if [[ -z "\${EX[\$n]:-}" ]]; then echo "issue \$n"; exit 0; fi
+done
+echo empty
+FAKE
+  chmod +x "$TMPDIR_TEST/dispatch-select-target"
+}
+
+# (a) lagged-live re-surface: queue HEAD 839 is the already-spawned arg, re-
+# surfacing because its live ownership is not yet visible to the next selection
+# (mechanism 1). Without the loop's --exclude the fake would re-return 839 every
+# call and the run would stall at 1 spawn. With it, selection advances 720, 508.
+echo "Test: materialize-spawn fan-out excludes lagged-live re-surfaced target (#1062)"
+mat_setup
+write_exclude_honoring_select_target
+export MAT_QUEUE="839 720 508"
+out=$(run_mat 839 queue --gap 3)
+assert_eq "fanout-lag: spawn count" "3" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+assert_eq "fanout-lag: distinct worktrees" "3" \
+  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
+assert_eq "fanout-lag: summary 3 of gap 3" "1" "$(printf '%s\n' "$out" | grep -c 'spawned 3 of gap 3')"
+assert_eq "fanout-lag: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "fanout-lag: no 'no further distinct targets' stop" "0" \
+  "$(printf '%s\n' "$out" | grep -c 'no further distinct targets')"
+mat_teardown
+
+# (a') orphan (self-closed) re-surface: 720 re-surfaces because it self-closed
+# fast, leaving an orphan worktree selection does not skip (mechanism 2). The
+# duplicate 720 in the queue is spawned once; the exclusion carries it past.
+echo "Test: materialize-spawn fan-out excludes orphan self-closed re-surfaced target (#1062)"
+mat_setup
+write_exclude_honoring_select_target
+export MAT_QUEUE="720 720 508"
+out=$(run_mat 839 queue --gap 3)
+assert_eq "fanout-orphan: spawn count" "3" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+assert_eq "fanout-orphan: distinct worktrees (839,720,508)" "3" \
+  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
+assert_eq "fanout-orphan: summary 3 of gap 3" "1" "$(printf '%s\n' "$out" | grep -c 'spawned 3 of gap 3')"
+assert_eq "fanout-orphan: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "fanout-orphan: no 'no further distinct targets' stop" "0" \
+  "$(printf '%s\n' "$out" | grep -c 'no further distinct targets')"
+mat_teardown
+
+# (b) multi-leaf subtree, first leaf excluded drains to the next: the exclusion
+# threads into the leaf trace, so a subtree whose first startable leaf (5500) was
+# already processed advances to its sibling (5501) rather than abandoning the
+# parent's remaining leaves.
+echo "Test: materialize-spawn fan-out drains multi-leaf subtree past excluded first leaf (#1062)"
+mat_setup
+write_exclude_honoring_select_target
+export MAT_QUEUE="5500 5501"
+out=$(run_mat 5500 queue --gap 2)
+assert_eq "fanout-subtree: spawn count" "2" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+assert_eq "fanout-subtree: distinct worktrees (5500,5501)" "2" \
+  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
+assert_eq "fanout-subtree: summary 2 of gap 2" "1" "$(printf '%s\n' "$out" | grep -c 'spawned 2 of gap 2')"
+assert_eq "fanout-subtree: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+mat_teardown
+
+# (c) genuinely empty frontier: once 839 is excluded the queue has nothing left,
+# so selection returns `empty` and the loop stops cleanly on a real empty — not
+# on a re-selection.
+echo "Test: materialize-spawn fan-out stops cleanly on a genuinely empty frontier (#1062)"
+mat_setup
+write_exclude_honoring_select_target
+export MAT_QUEUE=""
+out=$(run_mat 839 queue --gap 5)
+assert_eq "fanout-empty: spawn count" "1" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+assert_eq "fanout-empty: summary 1 of gap 5 (queue exhausted)" "1" \
+  "$(printf '%s\n' "$out" | grep -c 'spawned 1 of gap 5 (queue exhausted)')"
+assert_eq "fanout-empty: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "fanout-empty: no 'no further distinct targets' stop" "0" \
+  "$(printf '%s\n' "$out" | grep -c 'no further distinct targets')"
+mat_teardown
+
+# (backstop) contract violation: dispatch-select-target ALWAYS returns 839 (the
+# already-processed arg) regardless of --exclude. The loop's defensive backstop
+# (#1062) must break rather than spin forever: it records SEEN[839] for target 1,
+# the fake re-returns 839, SEEN[839] is set → backstop fires.
+echo "Test: materialize-spawn fan-out backstop breaks on selector contract violation (#1062)"
+mat_setup
+cat > "$TMPDIR_TEST/dispatch-select-target" <<'FAKE'
+#!/usr/bin/env bash
+echo "issue 839"
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
+out=$("$TMPDIR_TEST/dispatch-materialize-spawn" 839 queue --gap 5 2>"$TMPDIR_TEST/logs/mat-stderr.log")
+assert_eq "backstop: spawn count (only the arg)" "1" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+assert_eq "backstop: summary 1 of gap 5 (unexpected re-selection)" "1" \
+  "$(printf '%s\n' "$out" | grep -c 'spawned 1 of gap 5 (selection re-returned an excluded target (unexpected))')"
+assert_eq "backstop: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "backstop: stderr names the contract violation" "1" \
+  "$(grep -c 'contract violation' "$TMPDIR_TEST/logs/mat-stderr.log")"
+mat_teardown
+
 # --- --gap unbounded is removed → usage error exit 2 -------------------------
 # The unbounded fan-out machinery is gone (#1061): a manual /dispatch now spawns
 # exactly one gate-exempt worker (arriving as --gap 1, the single-target path),


### PR DESCRIPTION
Closes #1062

## Problem

The autonomous fan-out loop in `dispatch-materialize-spawn` fills `gap` slots by
calling the stateless `dispatch-select-target` once per iteration. A `SEEN` guard
stopped the **entire** loop the moment selection re-returned any already-processed
target. Because `dispatch-select-target` is stateless and deterministic — it
always returns the single highest-priority target and cannot be told to exclude
one — a target that re-surfaces ended the whole fan-out even when distinct
startable leaves remained lower in the priority order.

A target re-surfaces via two common mechanisms, and the fix is agnostic to which:

1. **Registration-visibility lag** — a just-spawned worker is verified-registered
   but not yet reflected in the next selection's `worktree_has_live_session`
   daemon query, so its leaf re-surfaces.
2. **Fast self-close leaving an orphan worktree** — a worker whose phase completes
   in seconds self-closes before the next selection. Its worktree is now an orphan
   (on disk, no live session), which by design is a reuse signal, not a conflict —
   so its target re-surfaces.

## Fix

Turn the `SEEN` set into a true **exclusion** mechanism. The loop passes its
already-processed target numbers to `dispatch-select-target`, which threads them
into its queue scan and into `dispatch-trace-leaf`, so selection returns the
*next* distinct target instead of re-returning a seen one. The loop then stops
only on a genuine `empty` (or a deferred selection / hard error), never on a
re-selection.

The exclusion wire format is variadic integers (`--exclude 839 720 508`), so the
caller expands `--exclude "${!SEEN[@]}"` directly.

### Unit 1 — `dispatch-trace-leaf`
Accepts `--exclude <n>...`; the topological-leaf branch refuses to return an
excluded leaf, so the descent advances past it to the next startable
sibling/leaf. One change point covers both the root and every descended leaf.

### Unit 2 — `dispatch-select-target`
Accepts `--exclude <n>...`; applies it during the queue scan **before** bucket
recording (PR rows filtered by their branch issue-prefix before `FIRST_PR` is
populated, so the next-oldest PR in an already-tapped bucket surfaces) and threads
it into the leaf trace (so a multi-leaf subtree whose first leaf is excluded
advances to the next startable leaf).

### Unit 3 — `dispatch-materialize-spawn`
The fan-out loop passes its `SEEN` set as `--exclude`. The `no further distinct
targets` normal stop is removed; in its place is a defensive backstop that breaks
only if selection re-returns a `SEEN` target despite the exclusion (a selector
contract violation) — unreachable in normal operation, present to prevent an
infinite loop.

## Tests

`test-dispatch-scripts.sh` covers, across all three scripts:
- a fan-out where selection would otherwise re-return an already-spawned target —
  via a lagged-live worktree and via an orphan (self-closed) worktree — instead
  continues to the next distinct leaf and fills the gap;
- a multi-leaf subtree whose first leaf is excluded drains to the next startable
  leaf;
- the loop terminates cleanly on a genuinely empty frontier;
- the defensive backstop fires (no hang) if the selector violates its contract;
- the `no further distinct targets` string never appears on any path.

Full suite: 1394/1394 passing.