### PR TITLE
security: idempotent security-followup filing across open and closed issues

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-followup-exists
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-followup-exists
@@ -37,9 +37,20 @@
 # MATCHING
 #   gh's --search is tokenized/fuzzy, so it only narrows the candidate set
 #   server-side (wrapping the identifier in literal double-quotes and adding the
-#   `in:title` qualifier). The authoritative match is the jq post-filter, which
-#   uses `contains($id)` — a LITERAL substring test — so a mere shared-token hit
-#   does NOT match. The first matching issue number is printed; nothing if none.
+#   `in:title` qualifier). The authoritative match is the jq post-filter.
+#
+#   The post-filter is BOUNDARY-AWARE, not a bare substring test. A title matches
+#   only when the identifier sits at a token boundary — it either ends the title
+#   (`endswith`) or is immediately followed by a space (`contains($id + " ")`).
+#   The emitter's titles are `security: <identifier>` (npm) and
+#   `security: <identifier> in <location>` (CodeQL), so the real identifier is
+#   always followed by end-of-title or a space. A bare `contains($id)` would
+#   false-match on a prefix collision — identifier `npm advisories in lodash`
+#   is a substring of title `... lodash-es`, and `CodeQL <rule> alert #5` is a
+#   substring of `... alert #50 ...` — silently suppressing a genuine follow-up
+#   for the shorter-named package or lower-numbered alert. The boundary check
+#   rejects those: the char after the candidate is `-` / `0`, not a space or
+#   end-of-string. The first matching issue number is printed; nothing if none.
 set -euo pipefail
 
 if [[ "$#" -lt 1 || -z "${1:-}" ]]; then
@@ -50,4 +61,5 @@ fi
 identifier="$1"
 
 gh issue list --search "\"$identifier\" in:title" --state all --json number,title --limit 100 \
-  | jq -r --arg id "$identifier" '[.[] | select(.title | contains($id))][0].number // empty'
+  | jq -r --arg id "$identifier" \
+      '[.[] | select((.title | endswith($id)) or (.title | contains($id + " ")))][0].number // empty'

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-followup-exists
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-followup-exists
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Print the number of the first issue whose title contains <identifier>, or
+# nothing if none exists.
+# Usage: dispatch-followup-exists <identifier>
+#
+# WHY THIS EXISTS
+#   This is a deterministic, state-spanning, exact-identifier existence check
+#   used by /review-fix Step 6b's security-followup filing path to make
+#   re-filing idempotent. Before filing each emitted follow-up, the caller
+#   probes for an issue already tracking the same stable identifier and skips
+#   filing when one exists.
+#
+#   It complements two other pieces and replaces neither:
+#     - The PURE `dispatch-security-followup` emitter, which derives the stable
+#       identifiers but must stay free of gh/network calls. The existence check
+#       lives here, out of that pure transform.
+#     - /file-issue's fuzzy keyword+judgment dedup, which is kept as
+#       defense-in-depth for free-text callers. This deterministic guard is
+#       specific to the machine-keyed security-followup path.
+#
+# STATE SCOPE
+#   The query deliberately spans `--state all` — open AND closed issues. gh's
+#   default issue list is open-only, which is exactly the leak this guard
+#   closes: once a tracking issue is resolved-and-closed, an open-only dedup
+#   re-files the same advisory on the next review.
+#
+# TRADEOFF
+#   Because it spans closed issues too, a CLOSED tracking issue — whether the
+#   advisory was already-resolved or already-rejected — suppresses re-filing of
+#   the same identifier. Re-filing is noise either way.
+#
+# IDENTIFIERS
+#   Keyed on the emitter's stable title tokens:
+#     - npm:    `npm advisories in <package>`
+#     - CodeQL: `CodeQL <rule_id> alert #<n>`
+#
+# MATCHING
+#   gh's --search is tokenized/fuzzy, so it only narrows the candidate set
+#   server-side (wrapping the identifier in literal double-quotes and adding the
+#   `in:title` qualifier). The authoritative match is the jq post-filter, which
+#   uses `contains($id)` — a LITERAL substring test — so a mere shared-token hit
+#   does NOT match. The first matching issue number is printed; nothing if none.
+set -euo pipefail
+
+if [[ "$#" -lt 1 || -z "${1:-}" ]]; then
+  echo "error: usage: dispatch-followup-exists <identifier>" >&2
+  exit 2
+fi
+
+identifier="$1"
+
+gh issue list --search "\"$identifier\" in:title" --state all --json number,title --limit 100 \
+  | jq -r --arg id "$identifier" '[.[] | select(.title | contains($id))][0].number // empty'

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -16822,13 +16822,16 @@ out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "npm advisories in lodash"
 assert_eq "followup-exists: open npm match → prints number" "1077" "$out"
 followup_exists_teardown
 
-# CASE 2 — CLOSED match (npm); state irrelevant to the script (--state all)
+# CASE 2 — Match from a fixture that includes a closed issue. The stub accepts
+# --state all (which is the flag the script passes), confirming the script doesn't
+# silently drop the flag. The stub is state-agnostic — it mirrors how gh returns
+# both open and closed issues when --state all is supplied; jq does the filtering.
 followup_exists_setup
 cat > "$TMPDIR_TEST/issues.json" <<'EOF'
 [{"number":1094,"title":"security: npm advisories in axios"}]
 EOF
 out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "npm advisories in axios")
-assert_eq "followup-exists: closed npm match → prints number" "1094" "$out"
+assert_eq "followup-exists: --state all fixture match → prints number" "1094" "$out"
 followup_exists_teardown
 
 # CASE 3 — CodeQL match
@@ -16849,15 +16852,50 @@ out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "npm advisories in lodash"
 assert_eq "followup-exists: no match → empty" "" "$out"
 followup_exists_teardown
 
-# CASE 5 — FUZZY token overlap but NOT an exact substring.
+# CASE 5 — FUZZY token overlap but NOT a boundary-anchored match.
 # Title "npm advisories in the lodash package" shares the leading tokens but
-# the intervening word "the" breaks the substring, so contains() is false.
+# the intervening word "the" breaks the substring, so neither endswith($id)
+# nor contains($id + " ") matches.
 followup_exists_setup
 cat > "$TMPDIR_TEST/issues.json" <<'EOF'
 [{"number":1200,"title":"security: npm advisories in the lodash package"}]
 EOF
 out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "npm advisories in lodash")
 assert_eq "followup-exists: fuzzy token overlap, no exact substring → empty" "" "$out"
+followup_exists_teardown
+
+# CASE 6 — MULTIPLE matches: script returns the FIRST issue number ([0]).
+followup_exists_setup
+cat > "$TMPDIR_TEST/issues.json" <<'EOF'
+[{"number":1050,"title":"security: npm advisories in lodash"},{"number":1077,"title":"security: npm advisories in lodash (duplicate)"}]
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "npm advisories in lodash")
+assert_eq "followup-exists: multiple matches → first issue number" "1050" "$out"
+followup_exists_teardown
+
+# CASE 7 — npm PREFIX COLLISION must NOT match. Identifier "npm advisories in
+# lodash" is a literal substring of title "...lodash-es", but the char after
+# the identifier is "-", not a space or end-of-title. A bare contains() would
+# false-match and silently suppress the genuine "lodash" follow-up; the
+# boundary-aware filter rejects it.
+followup_exists_setup
+cat > "$TMPDIR_TEST/issues.json" <<'EOF'
+[{"number":1300,"title":"security: npm advisories in lodash-es"}]
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "npm advisories in lodash")
+assert_eq "followup-exists: npm prefix collision (lodash vs lodash-es) → empty" "" "$out"
+followup_exists_teardown
+
+# CASE 8 — CodeQL alert-number PREFIX COLLISION must NOT match. Identifier
+# "CodeQL js/sql-injection alert #5" is a literal substring of title
+# "...alert #50 in ...", but the char after "#5" is "0", not a space. The
+# boundary-aware filter rejects it so alert #5 still files its own follow-up.
+followup_exists_setup
+cat > "$TMPDIR_TEST/issues.json" <<'EOF'
+[{"number":1301,"title":"security: CodeQL js/sql-injection alert #50 in src/db.ts"}]
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "CodeQL js/sql-injection alert #5")
+assert_eq "followup-exists: codeql alert-number prefix collision (#5 vs #50) → empty" "" "$out"
 followup_exists_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -16763,6 +16763,104 @@ assert_contains_local "dispatch-drift-scan: a legitimate sibling path still rend
 drift_scan_teardown
 
 # ============================================================================
+# === dispatch-followup-exists ===
+# ============================================================================
+
+echo "Test: dispatch-followup-exists"
+
+# Dedicated setup/teardown modeled on jit_skill_setup/teardown. Builds a temp
+# tree with the script under test and a gh stub on PATH. The stub returns the
+# WHOLE issues.json fixture array (no filtering of its own) so the script's jq
+# does the exact-substring filtering under test.
+followup_exists_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/bin"
+
+  cp "$SCRIPT_DIR/dispatch-followup-exists" "$TMPDIR_TEST/scripts/dispatch-followup-exists"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-followup-exists"
+
+  # gh stub: matches ONLY the exact invocation the script makes:
+  #   gh issue list --search "\"<id>\" in:title" --state all --json number,title --limit 100
+  # On match, cat the fixture $TREE/issues.json if present, else echo [].
+  # The stub does NOT filter — it returns the whole array; the script's jq filters.
+  cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+TREE="$(cd "$(dirname "$0")/.." && pwd)"
+case "$args" in
+  issue\ list\ *--state\ all\ --json\ number,title\ --limit\ 100)
+    if [[ -f "$TREE/issues.json" ]]; then
+      cat "$TREE/issues.json"
+    else
+      echo '[]'
+    fi
+    ;;
+  *)
+    echo "gh stub: unknown invocation: $args" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/gh"
+
+  SAVED_PATH_FE="$PATH"
+  export PATH="$TMPDIR_TEST/bin:$PATH"
+}
+
+followup_exists_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  export PATH="$SAVED_PATH_FE"
+}
+
+# CASE 1 — OPEN match (npm)
+followup_exists_setup
+cat > "$TMPDIR_TEST/issues.json" <<'EOF'
+[{"number":1077,"title":"security: npm advisories in lodash"}]
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "npm advisories in lodash")
+assert_eq "followup-exists: open npm match → prints number" "1077" "$out"
+followup_exists_teardown
+
+# CASE 2 — CLOSED match (npm); state irrelevant to the script (--state all)
+followup_exists_setup
+cat > "$TMPDIR_TEST/issues.json" <<'EOF'
+[{"number":1094,"title":"security: npm advisories in axios"}]
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "npm advisories in axios")
+assert_eq "followup-exists: closed npm match → prints number" "1094" "$out"
+followup_exists_teardown
+
+# CASE 3 — CodeQL match
+followup_exists_setup
+cat > "$TMPDIR_TEST/issues.json" <<'EOF'
+[{"number":1096,"title":"security: CodeQL js/sql-injection alert #42 in src/db.ts"}]
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "CodeQL js/sql-injection alert #42")
+assert_eq "followup-exists: codeql match → prints number" "1096" "$out"
+followup_exists_teardown
+
+# CASE 4 — NO match (empty fixture)
+followup_exists_setup
+cat > "$TMPDIR_TEST/issues.json" <<'EOF'
+[]
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "npm advisories in lodash")
+assert_eq "followup-exists: no match → empty" "" "$out"
+followup_exists_teardown
+
+# CASE 5 — FUZZY token overlap but NOT an exact substring.
+# Title "npm advisories in the lodash package" shares the leading tokens but
+# the intervening word "the" breaks the substring, so contains() is false.
+followup_exists_setup
+cat > "$TMPDIR_TEST/issues.json" <<'EOF'
+[{"number":1200,"title":"security: npm advisories in the lodash package"}]
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "npm advisories in lodash")
+assert_eq "followup-exists: fuzzy token overlap, no exact substring → empty" "" "$out"
+followup_exists_teardown
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -481,8 +481,9 @@ sandboxed-fine):
 
 It applies the threshold and emits a JSON array of `{identifier, title, body}`
 follow-ups (empty when none qualify). CodeQL emits one follow-up per alert; npm
-emits one follow-up per vulnerable package. Each `identifier` — CodeQL `rule.id` + alert number, or `npm advisories in
-<package>` — is embedded verbatim in the `title`. Before filing, the
+emits one follow-up per vulnerable package. Each `identifier` — CodeQL
+`rule.id` + alert number, or `npm advisories in <package>` — is embedded
+verbatim in the `title`. Before filing, the
 per-follow-up subagent runs `dispatch-followup-exists "<identifier>"`, a
 deterministic exact-identifier existence check spanning all issue states
 (`--state all`, open and closed), so the same alert or package is never re-filed

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -481,32 +481,52 @@ sandboxed-fine):
 
 It applies the threshold and emits a JSON array of `{identifier, title, body}`
 follow-ups (empty when none qualify). CodeQL emits one follow-up per alert; npm
-emits one follow-up per vulnerable package. Each `identifier` — CodeQL `rule.id`
-+ alert number, or `npm advisories in <package>` — is embedded in the `title`,
-so `/file-issue`'s title-keyword dedup prevents re-filing the same alert or
-package across repeated runs or multiple PRs.
+emits one follow-up per vulnerable package. Each `identifier` — CodeQL `rule.id` + alert number, or `npm advisories in
+<package>` — is embedded verbatim in the `title`. Before filing, the
+per-follow-up subagent runs `dispatch-followup-exists "<identifier>"`, a
+deterministic exact-identifier existence check spanning all issue states
+(`--state all`, open and closed), so the same alert or package is never re-filed
+across repeated runs or multiple PRs. This deterministic guard is specific to
+this machine-keyed security-followup path; `/file-issue`'s fuzzy
+keyword+judgment dedup stays in place as defense-in-depth for free-text callers.
 
 Tradeoff: because the npm dedup key is package-scoped, a newly disclosed
 advisory on an already-filed package won't auto-file a fresh issue — the
 existing "upgrade this package" issue already covers the remediation (one
-version bump resolves every advisory on that package node).
+version bump resolves every advisory on that package node). And because
+`dispatch-followup-exists` spans `--state all`, a closed tracking issue —
+already-resolved or already-rejected — suppresses re-filing of its identifier;
+re-filing is noise either way.
 
 For each emitted follow-up, fork a subagent (`subagent_type: general-purpose`,
 `model: sonnet`); run them in parallel (multiple Agent calls in one message). Each
 subagent:
 
-1. Invokes `/file-issue` with the follow-up's `title` on the first line and its
+1. Runs the deterministic existence check (use `dangerouslyDisableSandbox: true`
+   — `gh` needs network, see `.claude/rules/sandbox.md`), passing the follow-up's
+   `identifier`:
+
+   ```bash
+   .claude/skills/dispatch-propagate/scripts/dispatch-followup-exists "<identifier>"
+   ```
+
+   If it prints an issue number, an open or closed tracking issue already covers
+   this identifier — skip `/file-issue` entirely: do not file, do not re-label.
+   Record the follow-up as already-tracked, mapping its `identifier` to the
+   existing issue `#<N>` for the Step 7 comment, and return that `<N>`. Otherwise
+   proceed to the next step.
+2. Invokes `/file-issue` with the follow-up's `title` on the first line and its
    `body` after. `/file-issue` owns duplicate detection, creation, `@me`
    assignment, and the `help wanted` label; it prints `CREATED <N>` or
    `EXISTING <N>` on its own line — parse `<N>`.
-2. Applies the topic and type labels (use `dangerouslyDisableSandbox: true` —
+3. Applies the topic and type labels (use `dangerouslyDisableSandbox: true` —
    `gh` needs network):
 
    ```bash
    gh issue edit <N> --add-label security --add-label bug
    ```
 
-3. Returns `<N>` mapped to the follow-up's `identifier`.
+4. Returns `<N>` mapped to the follow-up's `identifier`.
 
 Capture each `<N>` against its source finding for the Step 7 comment.
 


### PR DESCRIPTION
Closes #1100

Add a deterministic, state-spanning exact-identifier existence check in front of
`/file-issue` on the `/review-fix` Step 6b security-followup filing path, so
pre-existing out-of-scope advisories are never re-filed across review runs.

## Problem

The security fan-out re-discovers pre-existing out-of-scope advisories on every
PR review and re-files them. The only dedup guard was `/file-issue`'s fuzzy
keyword+judgment check, scoped to open issues only. For the machine-stable
identifiers this path emits, that guard leaked even on exact-title matches (the
vitest advisory was filed 3×: #1077, #1094, #1096) and re-filed after a tracking
issue was closed.

#1087 collapsed N-advisories-per-package to one issue per package but left the
dedup mechanism and its open-only state scope unchanged. This closes that gap.

## Change

- New script `.claude/skills/dispatch-propagate/scripts/dispatch-followup-exists`:
  runs `gh issue list --search '"<identifier>" in:title' --state all` and
  post-filters with jq for exact substring containment, printing the first
  matching issue number (or nothing). Spans open and closed issues. The pure
  `dispatch-security-followup` emitter stays gh-free; this is its gh-calling
  companion.
- `/review-fix` Step 6b: the per-follow-up subagent runs `dispatch-followup-exists`
  before `/file-issue`; on a match (open or closed) it skips filing and maps the
  identifier to the existing issue. `/file-issue`'s fuzzy dedup stays as
  defense-in-depth for free-text callers.
- Tests in `test-dispatch-scripts.sh` cover open-match, closed-match,
  CodeQL-match suppression, no-match, and fuzzy-but-not-exact (exactness) cases.

## Tradeoff

Because the guard spans `--state all`, a closed tracking issue — already-resolved
or already-rejected — suppresses re-filing of its identifier. Re-filing is noise
either way. Documented in Step 6b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)