### PR TITLE
dispatch: flush stranded local merges before a review-fix PR goes ready (#1105)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-route
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-route
@@ -12,6 +12,7 @@
 #   INVOKE /review-fix           phase review       (dispatch:qa-done / reviewed re-entry)
 #   RELEVANCE-REVIEW             phase implement    (no PR) — routes to SKILL.md Step 2
 #   STOP done                    phase done         (non-draft PR)
+#   PUSH-STRANDED                phase done, but worktree ahead of origin/<branch> — push then park
 #   STOP waiting                 dispatch-ci-ready reports not-ready (draft PR CI pending)
 #   STOP wrong-worktree          cross-check failed (diagnostic on stderr); exits non-zero
 #
@@ -88,7 +89,19 @@ case "$PHASE" in
   verify)       echo "INVOKE /verify-pr" ;;
   qa)           echo "INVOKE /qa-fix" ;;
   review)       echo "INVOKE /review-fix" ;;
-  done)         echo "STOP done" ;;
+  done)
+    # #1105: never park a `done` PR whose worktree is ahead of its remote branch —
+    # those unpushed dispatch-merge-main / resolve-conflict merges leave the PR
+    # permanently CONFLICTING with no later tick able to push them.
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    git fetch origin "$CURRENT_BRANCH" >/dev/null 2>&1 || true
+    AHEAD=$(git rev-list --count "origin/${CURRENT_BRANCH}..HEAD" 2>/dev/null || echo 0)
+    if [[ "$AHEAD" -ne 0 ]]; then
+      echo "PUSH-STRANDED"
+    else
+      echo "STOP done"
+    fi
+    ;;
   *)
     echo "dispatch-route: unexpected phase '$PHASE' for $N" >&2
     exit 1

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -461,6 +461,18 @@ case "$args" in
     # dispatch-resolve-worktree reconciliation: re-point to the PR head branch.
     echo "$args" >> "$STUB_DIR/git-checkout.log"
     ;;
+  fetch\ *)
+    # dispatch-route done-case: fetch the current branch from origin. No-op stub.
+    : ;;
+  rev-list\ --count\ *)
+    # dispatch-route done-case: commits the worktree is ahead of origin/<branch>.
+    # Default 0 (remote up to date → STOP done); route-ahead-count.txt overrides to N.
+    if [[ -f "$STUB_DIR/route-ahead-count.txt" ]]; then
+      cat "$STUB_DIR/route-ahead-count.txt"
+    else
+      echo "0"
+    fi
+    ;;
   *)
     echo "git stub: unknown invocation: $args" >&2
     exit 1
@@ -1050,6 +1062,18 @@ echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
 route_run 42 /wt/42-my-feature
 assert_eq "non-draft PR → STOP done (directive)" "STOP done" "$ROUTE_OUT"
 assert_eq "non-draft PR → STOP done (exit 0)" "0" "$ROUTE_RC"
+teardown
+
+# 8b. Non-draft PR, but the worktree is ahead of origin/<branch> → PUSH-STRANDED (#1105).
+echo "Test: non-draft PR ahead of remote → PUSH-STRANDED"
+setup
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "false" "$NO_LABELS" "$GREEN_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
+echo "2" > "$STUB_DIR/route-ahead-count.txt"
+route_run 42 /wt/42-my-feature
+assert_eq "non-draft PR ahead of remote → PUSH-STRANDED (directive)" "PUSH-STRANDED" "$ROUTE_OUT"
+assert_eq "non-draft PR ahead of remote → PUSH-STRANDED (exit 0)" "0" "$ROUTE_RC"
 teardown
 
 # 9. Draft + pending CI → STOP waiting (the dispatch-ci-ready not-ready path).

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1070,6 +1070,7 @@ setup
 printf '[%s]\n' "$(make_pr 10 "42-my-feature" "false" "$NO_LABELS" "$GREEN_ROLLUP")" \
   > "$STUB_DIR/pr-list-full.json"
 echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
+echo "42-my-feature" > "$STUB_DIR/current-branch.txt"
 echo "2" > "$STUB_DIR/route-ahead-count.txt"
 route_run 42 /wt/42-my-feature
 assert_eq "non-draft PR ahead of remote → PUSH-STRANDED (directive)" "PUSH-STRANDED" "$ROUTE_OUT"

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -50,6 +50,7 @@ Act on the one directive:
 | `INVOKE /review-fix` | 0 | draft PR + `dispatch:qa-done` (or `dispatch:reviewed` re-entry) | invoke `/review-fix` |
 | `RELEVANCE-REVIEW` | 0 | no PR on the target (`implement`) | run the Step 2 relevance review, then dispatch its verdict |
 | `STOP done` | 0 | non-draft (ready) PR | stop without invoking a phase skill |
+| `PUSH-STRANDED` | 0 | `done` PR, but the worktree has commits `origin/<branch>` hasn't seen | push `origin HEAD`, write an office-hours reason, stop with no marker |
 | `STOP waiting` | 0 | draft PR's CI has no verdict yet | print the verbatim message below and stop |
 | `STOP wrong-worktree` | non-zero | spawn cwd / branch did not match `<N>` / `<worktree-path>` | stop |
 
@@ -100,6 +101,35 @@ user-visible report verbatim:
 Apply no `dispatch:office-hours` and spawn no babysitter — a not-ready target is
 not worker-actionable; the router owns the CI gate. See `reference.md` for the
 Stop-hook re-gate rationale.
+
+### `PUSH-STRANDED` — push unpushed local commits, then park
+
+A `done` PR's worktree is ahead of its remote branch — unpushed
+`dispatch-merge-main` / `/dispatch-resolve-conflict` merge commits that, if
+left, keep the PR `CONFLICTING` with no later tick able to push them.
+
+Run `git push origin HEAD` to flush them. This is sandbox-safe: it uses HTTPS
+to `github.com`, an allowlisted host, so no `dangerouslyDisableSandbox` is
+needed.
+
+Then write a one-line reason to `$CLAUDE_JOB_DIR/office-hours-reason` using the
+atomic tempfile + mv pattern (only when `CLAUDE_JOB_DIR` is set and exists —
+match the pattern used in review-fix Step 8 / implement-unit), then stop with
+no marker. The push heals the `CONFLICTING` PR; stopping without a marker means
+the Stop hook applies `dispatch:office-hours`, surfacing the unexpected
+late-skip for a human.
+
+```bash
+git push origin HEAD
+if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
+  printf '%s\n' "/dispatch-worker: PUSH-STRANDED — pushed unpushed local commits a done PR left behind; parking for review" \
+    > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
+  mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" "$CLAUDE_JOB_DIR/office-hours-reason"
+fi
+```
+
+Note: with the `/review-fix` terminal-flush guard (#1105 Unit 1) in place, this
+path is a true backstop that should essentially never fire.
 
 ### `STOP done` / `STOP wrong-worktree` — stop with no marker
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -44,13 +44,12 @@ stays in `PR_JSON` (`echo "$PR_JSON" | jq -r .body`); Step 6 parses its
 `Closes #N` line(s) to resolve the issue(s) this PR implements.
 
 If the printed labels already include `dispatch:reviewed` — an interrupted prior
-run — **skip Steps 1–7 entirely**: ensure the PR is ready and then go straight to
-the deviation/marker step (Step 8). `dispatch:reviewed` is this skill's terminal
-action and is already applied, so re-entry is a true no-op beyond readying the PR:
-
-```bash
-gh pr ready "$PR_NUM"
-```
+run — **skip Steps 1–7** and go straight to Step 8, which flushes any unpushed
+commits, readies the PR, and writes the marker. `dispatch:reviewed` is this
+skill's terminal action and is already applied, so re-entry is a no-op beyond
+Step 8's terminal flush and readying the PR. Routing re-entry through Step 8
+(rather than readying the PR inline) means its flush guard also carries any
+commits an interrupted prior run left stranded.
 
 On this re-entry path the unified finding set is not in context — Step 8 treats
 the deviation criterion as not met and writes the phase-completed marker.
@@ -395,8 +394,11 @@ skip the implementation subagents.
 Then fork **one** `/commit-merge-push` via the Agent tool to commit every pending
 working-tree change — `/code-review`'s Step 1a edits plus these implementation
 edits — and push. If there were no code changes at all, `/commit-merge-push`
-tolerates the no-op and creates no commit. Capture the resulting fix commit
-SHA(s) for the Step 7 comment.
+tolerates the no-op and creates no commit. Even on that no-op it pushes `origin
+HEAD`, so it carries any pending local merge (left by `dispatch-merge-main` /
+`/dispatch-resolve-conflict`) to origin; Step 8's flush guard is the
+authoritative backstop when this fork is skipped entirely. Capture the resulting
+fix commit SHA(s) for the Step 7 comment.
 
 ### 6. File meaningful out-of-scope findings as blocked_by follow-ups
 
@@ -556,7 +558,35 @@ Then post it (use `dangerouslyDisableSandbox: true` — the script invokes `gh`)
 
 ### 8. Apply the terminal label, ready the PR, then write the marker (or park on deviation)
 
-Apply the `dispatch:reviewed` label via `dispatch-complete-phase` (use
+**First, flush any unpushed local commits — the terminal flush of the "never
+push a bare merge commit" contract.** `dispatch-merge-main` (pre-spawn) and
+`/dispatch-resolve-conflict` merge `origin/main` into this worktree **locally**
+and never push, relying on each phase skill's own push point to carry the merge
+to origin. `/review-fix` is the chain's **terminal phase**: once the PR is
+ready, every later tick routes `STOP done` and no push point ever fires again.
+So any local merge left behind must be carried to origin here, before the PR is
+readied — otherwise the remote branch stays behind local HEAD and GitHub reports
+the PR `CONFLICTING` permanently. This guard runs **unconditionally**,
+independent of whether any findings were fixed: on a zero-findings run Step 5's
+`/commit-merge-push` may be skipped entirely, so the readiness gate is the only
+place the flush is guaranteed and it cannot be reasoned away.
+
+`BRANCH` is captured in the idempotency preamble; it is in scope on both the
+normal path and the re-entry path. Git runs sandboxed here — `origin` is HTTPS
+to an allowlisted host, so **no `dangerouslyDisableSandbox`** (unlike the
+surrounding `gh` / `dispatch-complete-phase` calls in this step). The push is a
+no-op when Step 5 already pushed (HEAD `==` origin/$BRANCH) and fails safe: when
+the remote branch is up to date the count is `0` and nothing is pushed; it does
+real work only when no push point fired this run.
+
+```bash
+git fetch origin "$BRANCH"
+if [[ "$(git rev-list --count "origin/$BRANCH..HEAD")" -ne 0 ]]; then
+  git push origin HEAD
+fi
+```
+
+Then apply the `dispatch:reviewed` label via `dispatch-complete-phase` (use
 `dangerouslyDisableSandbox: true` — the script calls `gh`):
 
 ```bash
@@ -677,6 +707,6 @@ checkpoint before a PR goes ready — the single PR-comment summary is the audit
 trail. This is an intentional trade-off for an autonomous background-job run.
 
 The skill is idempotent: a re-invocation with `dispatch:reviewed` already on the
-PR skips Steps 1–7, ensures the PR is ready, and writes the phase-completed marker
-(the unified finding set is not in context on re-entry, so the deviation criterion
-is treated as not met).
+PR skips Steps 1–7 and runs Step 8, which flushes any unpushed commits, ensures
+the PR is ready, and writes the phase-completed marker (the unified finding set
+is not in context on re-entry, so the deviation criterion is treated as not met).

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -581,7 +581,8 @@ real work only when no push point fired this run.
 
 ```bash
 git fetch origin "$BRANCH"
-if [[ "$(git rev-list --count "origin/$BRANCH..HEAD")" -ne 0 ]]; then
+AHEAD=$(git rev-list --count "origin/$BRANCH..HEAD")
+if [[ "$AHEAD" -ne 0 ]]; then
   git push origin HEAD
 fi
 ```


### PR DESCRIPTION
Closes #1105

## Problem

The dispatch chain follows a "never push a bare merge commit" contract:
`dispatch-merge-main` and `/dispatch-resolve-conflict` merge `origin/main` into a
worktree locally and never push, relying on each phase skill's own push point to
carry the merge to origin. `/review-fix` is the terminal phase; its only push
point is the single `/commit-merge-push` in Step 5. On a zero-findings review the
worker can skip that fork, then still apply `dispatch:reviewed` + `gh pr ready`,
stranding any earlier local merge commit permanently — every later tick routes
`STOP done`, no push point fires again, and GitHub reports the PR `CONFLICTING`
forever. (Observed on PR #1004 / issue #776.)

## Fix

**Primary — `/review-fix` Step 8 terminal flush.** A guard runs unconditionally
as the first action of Step 8, before `gh pr ready`: it fetches the PR branch and
pushes `origin HEAD` whenever `origin/<branch>..HEAD` is non-empty. This is the
terminal flush of the contract — `/review-fix` is the chain's terminal phase, so
any local merge left behind must be carried to origin here. The guard cannot be
reasoned away on a zero-findings run. The `dispatch:reviewed` re-entry path now
routes through Step 8 rather than readying the PR inline, so the flush also covers
an interrupted prior run.

**Defensive — `dispatch-route` refuses to park stranded commits.** The `done`
case no longer emits a bare `STOP done`: it checks `origin/<branch>..HEAD` and
emits a new `PUSH-STRANDED` directive when the worktree is ahead. `/dispatch-worker`
handles `PUSH-STRANDED` by pushing `origin HEAD`, writing an office-hours reason,
and parking with no marker — healing the PR and surfacing the anomaly. Fails safe
to `STOP done` when the remote branch cannot be resolved. With the Step 8 guard in
place this is a true backstop that should essentially never fire.

## Tests

`test-dispatch-scripts.sh`: 1482/1482 pass, including the unchanged Test 8
(non-draft → `STOP done`) and the new Test 8b (non-draft + worktree ahead →
`PUSH-STRANDED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)