### PR TITLE
dispatch: gate issue-queue on CI-ready, symmetric with PR-queue (#1106)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -651,6 +651,20 @@ while IFS=$'\t' read -r issue_num issue_labels; do
   #            a later issue in the same bucket may still fill the slot.
   #   exit 1 — usage error; propagate as a hard failure, never swallow as a skip.
   if leaf=$("$SCRIPT_DIR/dispatch-trace-leaf" "$issue_num" queue "${EXCLUDE_ARGS[@]}"); then
+    # Readiness gate, symmetric with the PR-loop gate above (#1106). A
+    # help-wanted issue can already carry a draft PR whose CI is in progress —
+    # a draft closing PR does not evict its issue from this queue (#920), so a
+    # stalled/orphaned draft is recyclable. Skip such a leaf: spawning a worker
+    # now would only hit dispatch-route's STOP-waiting re-gate, wasting a tick.
+    # A leaf with no PR (normal implement) or a concluded-CI draft reports
+    # ready and proceeds; a concluded-CI draft is owned by the PR queue
+    # (verify/qa), which precedes the issue within a bucket and recycles the
+    # orphan worktree via `enter` just as the issue path would. dispatch-ci-ready
+    # resolves the all-digit leaf to its PR by headRefName prefix. Reuses the
+    # PR list fetched above.
+    if ! DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-ci-ready" "$leaf" >/dev/null; then
+      continue
+    fi
     FIRST_ISSUE[$issue_bucket]="$leaf"
   else
     trace_status=$?

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2423,8 +2423,11 @@ teardown
 echo "Test: open issue closed only by a draft PR is still selected (#920)"
 setup
 # Draft PR 10 (pending CI → waiting phase, skipped) closes issue 55 (help-wanted).
-# isDraft=true → must NOT gate issue 55. Waiting phase skip clears the PR from
-# the ladder, so issue 55 is the only remaining candidate.
+# PR branch "10-draft-pr" does NOT match the "55-" prefix, so dispatch-ci-ready 55
+# finds no matching PR and returns ready — the #1106 CI gate does not fire. The
+# READY_PR_CLOSED_ISSUES gate also does not fire (isDraft=true is excluded).
+# Waiting phase skip clears the PR from the ladder, so issue 55 is the only
+# remaining candidate.
 UNION='['"$(make_pr_union 10 "10-draft-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP" '[{"number":55}]')"']'
 setup_union_pr_list "$UNION"
 printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2369,6 +2369,57 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "issue closed only by draft PR is still selectable" "issue 55" "$result"
 teardown
 
+# --- issue-queue CI-ready gate (#1106) ---
+# A help-wanted issue can carry a draft PR whose CI is in progress (#920 leaves
+# such an issue selectable). The issue loop now applies the same readiness gate
+# as the PR loop: an issue (or its resolved leaf) whose draft PR has pending CI
+# is skipped, so the autonomous tick selects the next-priority target instead of
+# spawning a worker that immediately hits dispatch-route's STOP-waiting re-gate.
+
+# 41a. A help-wanted issue whose draft PR has in-progress CI is skipped by the
+#      issue-queue gate; the next help-wanted issue (no PR) is selected. The PR
+#      is on the issue's own branch 55-feature so dispatch-ci-ready keys to it.
+#      The pending draft is also skipped in the PR loop (waiting phase), so only
+#      the issue queue remains; issue 55 is gated out, issue 66 is selected.
+echo "Test: issue with pending draft PR skipped → next issue selected (#1106)"
+setup
+UNION='['"$(make_pr_union 10 "55-feature" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP" '[{"number":55}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":66,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "issue 55 with pending draft PR skipped → issue 66 selected" "issue 66" "$result"
+teardown
+
+# 41b. Regression guard: a help-wanted issue with no PR is still selected for the
+#      implement phase. dispatch-ci-ready reports `ready` (no matching PR), so
+#      the gate does not skip it.
+echo "Test: help-wanted issue with no PR still selected (#1106 regression)"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "help-wanted issue 55 with no PR still selected" "issue 55" "$result"
+teardown
+
+# 41c. A draft PR with concluded (green) CI is NOT over-skipped by the new gate:
+#      dispatch-ci-ready reports `ready`, and within the shared (category,
+#      priority) bucket the PR queue selects it as qa before the issue line. A
+#      green draft with no dispatch:* labels resolves to qa (dispatch-phase).
+echo "Test: concluded green draft PR defers to PR queue as qa (#1106)"
+setup
+UNION='['"$(make_pr_union 10 "55-feature" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP" '[{"number":55}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "green draft PR selected by PR queue as qa" "pr 10 55-feature qa" "$result"
+teardown
+
 # ============================================================================
 # --- JIT scan ---
 # dispatch-select-target's JIT scan runs before the main-broken health gate.
@@ -2772,20 +2823,26 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "ready PR closes issue 55; issue 66 chosen instead" "issue 66" "$result"
 teardown
 
-# R2. Draft PR does not gate.
-# A draft PR (isDraft=true, pending rollup → classified waiting, dropped from
-# the ladder) closes issue 55; issue 55 is help-wanted with no worktree. Assert
-# the result is issue 55 — the draft does not exclude its issue.
-echo "Test: Draft PR does not gate."
+# R2. Draft PR does not permanently evict its issue (#920), but a draft PR on the
+# issue's own branch with PENDING CI is transiently skipped by the #1106
+# issue-queue readiness gate. A draft (isDraft=true, pending rollup → classified
+# waiting, dropped from the PR ladder) closes issue 55; the PR is on the issue's
+# own branch 55-draft-pr, so dispatch-ci-ready 55 reports `waiting` and the issue
+# loop skips it this tick. With no other candidate the selector returns empty;
+# the issue resurfaces on a later tick once CI concludes. (The #920 eviction
+# intent — that a draft does not *permanently* remove the issue from the
+# help-wanted queue — is still covered by the draft-on-a-non-matching-branch
+# test above, where the issue stays selectable.)
+echo "Test: Draft PR on issue's branch with pending CI transiently skipped (#1106)."
 setup
-# Draft (isDraft=true, pending rollup) PR 100 closes issue 55.
+# Draft (isDraft=true, pending rollup) PR 100 on the issue's own branch closes issue 55.
 UNION='['"$(make_pr_union 100 "55-draft-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP" '[{"number":55}]')"']'
 setup_union_pr_list "$UNION"
 printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
   > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "draft PR does not gate issue 55; issue 55 chosen" "issue 55" "$result"
+assert_eq "pending draft PR on issue's branch → issue skipped this tick (empty)" "empty" "$result"
 teardown
 
 # ============================================================================


### PR DESCRIPTION
Closes #1106

## Problem

The autonomous router's CI-ready gate (`dispatch-ci-ready`) was enforced in the **PR-queue** loop of `dispatch-select-target` but not in the **issue-queue** loop. Issues are normally pre-PR with no CI to gate — but by the #920 design a help-wanted issue can already carry a **draft PR with CI in progress** (a draft closing PR does not evict its issue from the help-wanted queue, so a stalled/orphaned draft can be recycled).

When such an issue is selected via the issue queue and routed through `dispatch-materialize-spawn` in non-explicit mode, Step 6a's readiness recheck is skipped — so a worker is spawned while the draft PR's CI is still running. The worker's own `dispatch-route` immediately returns `STOP waiting`: a wasted spawn + tick, repeated each tick until CI concludes (observed 2026-06-04, #1094 / PR #1098).

## Fix

Extend the existing PR-loop CI-ready gate to the issue loop, after `dispatch-trace-leaf` resolves the leaf and before recording it in `FIRST_ISSUE`, reusing the already-fetched in-memory `$PR_LIST` (no extra `gh pr list`):

```bash
if ! DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-ci-ready" "$leaf" >/dev/null; then
  continue
fi
```

A leaf with no PR (normal implement) or a concluded-CI draft reports ready and proceeds; a concluded-CI draft is owned by the PR queue (verify/qa), which precedes the issue within a bucket and recycles the orphan worktree via `enter` just as the issue path would — preserving #920's stall-recovery intent. The explicit `/dispatch <N>` path is unchanged (already correct via the #979 target-reseed timer).

## Tests

Adds three tests to `test-dispatch-scripts.sh` under a new `issue-queue CI-ready gate (#1106)` banner: issue-with-pending-draft-PR is skipped (next selected); issue-with-no-PR is still selected; concluded-green-draft defers to the PR queue as qa. Updates pre-existing test R2, whose setup (a pending draft on the issue's own branch) is exactly the scenario now skipped; the #920 permanent-eviction intent stays covered by the sibling test that places the draft on a non-matching branch. Full suite: 1483/1483 green.