### PR TITLE
dispatch: route verify failures to the right disposition (#1108)

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -43,12 +43,28 @@
 #      dispatch-phase network failure) is treated as "undetermined" and falls
 #      through to Branch D rather than triggering a false self-close.
 #   C. marker present + same phase + CURRENT_PHASE == verify + verify-attempt
-#      counter < 3 — CI re-runs still possible. Spawn router, exit 0 (no label,
-#      no self-close — session parks "stopped"; transcript is the diagnostic).
+#      counter < 3 — transient no-push verify outcome. CI has already concluded
+#      and nothing is pending: a verify pass that pushes a fix restarts CI, and
+#      the early not-ready gate above already intercepts and self-closes that
+#      in-progress case when the marker is present, so by the time control
+#      reaches Branch C, CI is concluded and not re-running. Spawn router,
+#      self-close (so the session does not leak idle holding its worktree); the
+#      next tick re-runs verify or escalates at the cap. The needs-human verify
+#      failure never reaches Branch C — /verify-pr skips the marker for it, so it
+#      lands in Branch A (marker absent → park the issue on office-hours on the
+#      first run).
 #   D. marker present + same phase + NOT (verify AND counter < 3) — true
 #      non-advancement (or a hypothetical same-phase non-verify case). Park the
 #      ISSUE on a human via dispatch-apply-office-hours (label + why-comment),
 #      spawn router, exit 0.
+#
+# CLOSING NOTE (post-#1108): NO worker branch self-parks idle waiting on pending
+# work. The early not-ready gate self-closes its concluded-CI marker-present case
+# and hands back its in-progress marker-absent case; Branch C self-closes its
+# concluded no-push case. The remaining exit-0-without-self-close branches —
+# Branch A and Branch D office-hours parks, and the early-gate marker-absent
+# TOCTOU hand-back — are deliberate human-review parks or router hand-backs, not
+# idle waiters.
 #
 # Discriminator: only acts for a /dispatch-worker job. Skipped when
 # CLAUDE_JOB_DIR is unset (interactive session), state.json is missing, or the
@@ -225,8 +241,11 @@ if [ "$CURRENT_PHASE" = "verify" ] && [ -n "$PR_NUM" ]; then
   N=$(gh pr view "$PR_NUM" --json labels --jq '[.labels[].name | capture("^dispatch:verify-attempt-(?<n>[0-9]+)$").n | tonumber] | max // 0' 2>/dev/null) || N=0
   [ -z "$N" ] && N=0
   if [ "$N" -lt 3 ]; then
-    # Branch C — verify retry still possible.
+    # Branch C — transient no-push verify outcome; CI concluded, nothing
+    # pending. Self-close so the session does not leak idle holding its
+    # worktree; the next tick re-runs verify or escalates at the cap.
     spawn_tick
+    self_close
     exit 0
   fi
 fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -11762,9 +11762,9 @@ else
 fi
 stop_teardown
 
-# --- Test 2: marker present, same phase, verify, counter < 3 → spawn only ----
+# --- Test 2: marker present, same phase, verify, counter < 3 → transient no-push verify outcome → spawn + self-close ----
 
-echo "Test: stop hook + same phase + verify + counter<3 → spawn only (silent variance)"
+echo "Test: stop hook + same phase + verify + counter<3 → transient no-push verify outcome → spawn + self-close"
 stop_setup
 echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
 echo "456" > "$STUB_DIR/find-pr-output"
@@ -11783,14 +11783,44 @@ if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" \
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: stop verify-retry: no label add or remove invoked"
 fi
-TOTAL=$((TOTAL + 1))
-if [[ ! -e "$STUB_DIR/self-close-calls.log" ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: stop verify-retry: self-close not invoked"
-else
-  FAIL=$((FAIL + 1)); echo "  FAIL: stop verify-retry: self-close not invoked"
-fi
+self_close_calls=$(wc -l < "$STUB_DIR/self-close-calls.log" 2>/dev/null || echo 0)
+assert_eq "stop verify-retry: self-close invoked exactly once" "1" "$self_close_calls"
 spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
 assert_eq "stop verify-retry: spawn invoked exactly once" "1" "$spawn_calls"
+stop_teardown
+
+# --- Test 2b: verify + PR present + marker absent + office-hours-reason → Branch A (needs-human)
+
+echo "Test: stop hook + verify phase + PR present + marker absent + office-hours-reason present → Branch A parks issue with the reason (needs-human verify escalation)"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "456" > "$STUB_DIR/find-pr-output"
+echo "verify" > "$STUB_DIR/current-phase.txt"
+# verify-pr's needs-human path writes office-hours-reason and SKIPS the marker.
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+printf '%s' "/verify-pr: provision the renamed GCP secret and grant the deploy SA access" > "$TMPDIR_TEST/jobs/abcd1234/office-hours-reason"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+"$TMPDIR_TEST/hooks/dispatch-stop.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "stop needs-human: hook exits 0" "0" "$rc"
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
+TOTAL=$((TOTAL + 1))
+if [[ "$apply_issue" == "123" && "$apply_reason" == "/verify-pr: provision the renamed GCP secret and grant the deploy SA access" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop needs-human: office-hours applied to issue 123 with the office-hours-reason contents (Branch A)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop needs-human: office-hours applied to issue 123 with the office-hours-reason contents (Branch A)"
+  echo "    apply-log: $apply_log"
+fi
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "stop needs-human: spawn invoked exactly once" "1" "$spawn_calls"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/self-close-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop needs-human: self-close not invoked (Branch A park, not advance)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop needs-human: self-close not invoked (Branch A park, not advance)"
+fi
 stop_teardown
 
 # --- Test 3: marker present, same phase, verify, counter >= 3 → branch D -----

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -11906,6 +11906,13 @@ if [[ ! -e "$STUB_DIR/self-close-calls.log" ]]; then
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: stop needs-human: self-close not invoked (Branch A park, not advance)"
 fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" \
+   && ! -e "$STUB_DIR/gh-pr-remove.log" && ! -e "$STUB_DIR/gh-issue-remove.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop needs-human: no verify-attempt label add or remove invoked (Branch A only parks via office-hours)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop needs-human: no verify-attempt label add or remove invoked (Branch A only parks via office-hours)"
+fi
 stop_teardown
 
 # --- Test 3: marker present, same phase, verify, counter >= 3 → branch D -----

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -19,49 +19,16 @@ Cross-iteration memory lives entirely in `tmp/verify-summary.md` (see
 
 ## Steps
 
-1. **Increment the verify-attempt counter.** Resolve the draft PR for the target.
-   Read the PR's labels and find the highest extant `dispatch:verify-attempt-<n>` label
+1. **Resolve the draft PR.** Resolve the draft PR for the target into `PR_NUM`
    (`dangerouslyDisableSandbox: true` — `gh`):
 
    ```bash
    PR_NUM=$(.claude/skills/dispatch-propagate/scripts/dispatch-find-pr <issue-N>)
-   N=$(gh pr view "$PR_NUM" --json labels \
-     --jq '[.labels[].name | capture("^dispatch:verify-attempt-(?<n>[0-9]+)$").n | tonumber] | max // 0')
-   NEXT=$(( N < 3 ? N + 1 : 3 ))
    ```
 
-   The cap at 3 means a fourth entry still leaves the label at `dispatch:verify-attempt-3`.
-   Step 4 of `/dispatch-worker` reads this counter: when the re-derived phase is still
-   `verify` and the counter is `>= 3`, it escalates to `dispatch:office-hours` instead
-   of self-closing.
-
-   Remove the prior label if one exists, then apply the new one. Use the apply-first /
-   create-on-"not found" idiom — the label may not exist yet on a fresh repo
-   (`dangerouslyDisableSandbox: true` on all `gh` calls):
-
-   ```bash
-   # Remove the previous counter label (skip if N=0 — none existed)
-   if [[ "$N" -gt 0 ]]; then
-     gh pr edit "$PR_NUM" --remove-label "dispatch:verify-attempt-$N"
-   fi
-
-   # Apply the new label; create it if missing, then retry
-   if ! gh pr edit "$PR_NUM" --add-label "dispatch:verify-attempt-$NEXT" 2>/dev/null; then
-     gh label create "dispatch:verify-attempt-$NEXT" \
-       --description "dispatch workflow: verify-pr attempt $NEXT of 3"
-     gh pr edit "$PR_NUM" --add-label "dispatch:verify-attempt-$NEXT"
-   fi
-   ```
-
-   Pass no `--color` — same convention as `dispatch:office-hours` (no colour metadata
-   here; label colour is owned by the canonical definition, not the writer).
-
-   Note: `dispatch-complete-phase` is not the right vehicle for this label — it handles
-   only the two canonical phase-complete labels (`dispatch:qa-done`, `dispatch:reviewed`).
-   The verify-attempt label is local to `/verify-pr`.
-
-   The PR number resolved here is also used in Steps 3, 4 (the Flake sub-path's
-   `gh pr view <pr-num>` body read), and 7 — carry it forward.
+   The PR number resolved here is used in Steps 3, 4 (the Flake sub-path's
+   `gh pr view <pr-num>` body read), 5 (the verify-attempt label edit), and 8 —
+   carry it forward.
 
 2. **Read the accumulator.** Read `tmp/verify-summary.md` if it exists — it holds the
    prior iterations' records. On the first verify pass the file does not yet exist;
@@ -77,9 +44,10 @@ Cross-iteration memory lives entirely in `tmp/verify-summary.md` (see
    complete-and-failed — so this returns immediately with a per-check summary:
    name, conclusion, and a failure-log excerpt for each failing check.
 
-4. **Reproduce locally.** Launch a `sonnet` subagent with the failing check name and
-   failure excerpt. The subagent maps the check to a local reproduce command and runs
-   it (use `dangerouslyDisableSandbox: true` when network or npm cache is needed):
+4. **Reproduce locally and classify.** Launch a `sonnet` subagent with the failing
+   check name and failure excerpt. The subagent maps the check to a local reproduce
+   command and runs it (use `dangerouslyDisableSandbox: true` when network or npm
+   cache is needed):
 
    - Unit test check → `.claude/skills/dispatch-propagate/scripts/run-unit-tests.sh`
    - Lint check → `.claude/skills/dispatch-propagate/scripts/run-lint.sh`
@@ -88,28 +56,70 @@ Cross-iteration memory lives entirely in `tmp/verify-summary.md` (see
    - Other → best-effort map from the failing workflow name
 
    The subagent returns `{ reproduced: bool, reproduce_command, failure_excerpt,
-   why_not_caught, is_flake: bool }`. `why_not_caught` is a free-text diagnosis
-   (missing test, disabled rule, skipped hook, env drift, flake, etc.) —
-   human-readable context, not a structured branch key. `is_flake` is the
-   **structured branch key**: the subagent sets it
-   `true` only when it diagnoses the failure as a **flake** — a non-deterministic
-   failure unrelated to the PR's own changes (a pre-existing flaky test, a
-   CI-infrastructure hiccup, an upstream timing race). The flake branch below
-   reads `is_flake`; it never string-matches `why_not_caught`.
+   why_not_caught, is_flake: bool, needs_human: bool, required_action: string }`.
+   `why_not_caught` is a free-text diagnosis (missing test, disabled rule, skipped
+   hook, env drift, flake, etc.) — human-readable context, not a structured branch
+   key. `is_flake` and `needs_human` are the **structured branch keys** — never
+   string-matched from `why_not_caught`:
 
-   **If the failure does NOT reproduce** (`reproduced == false`), there are three
-   mutually exclusive outcomes. `is_flake` is the discriminator: when
-   `is_flake == true` the outcome is **Flake**; when `is_flake == false` it is
-   **Main already fixed it** or **Generic no-repro**. Never push a speculative
-   fix — an unverified fix is still never pushed.
+   - `is_flake` is set `true` only when the subagent diagnoses the failure as a
+     **flake** — a non-deterministic failure unrelated to the PR's own changes (a
+     pre-existing flaky test, a CI-infrastructure hiccup, an upstream timing race).
+   - `needs_human` is set `true` only when the subagent diagnoses a **real failure
+     unfixable in code** — a deploy/infra/permissions error where no code change
+     resolves it (secret/IAM/SA; canonical case a deploy-time GCP Secret Manager
+     403 on a renamed secret). `required_action` then names what an owner must do
+     (provision the secret, grant the deploy SA access, etc.).
 
-   - **Generic no-repro** — `is_flake == false` and the failure simply does not
-     reproduce, with no identified cause. Record it in the accumulator (Step 6),
-     post the accumulator (Step 7), and stop. Push nothing.
-   - **Main already fixed it** — `is_flake == false` and the `why_not_caught`
-     diagnosis is that `origin/main` (merged into this worktree by the router
-     before spawning this worker) already resolved the failure. Record it in the
-     accumulator (Step 6), post the accumulator (Step 7), and then push that
+   The branch logic reads these structured keys; it never string-matches
+   `why_not_caught`.
+
+   **If the failure does NOT reproduce** (`reproduced == false`), there are four
+   mutually exclusive outcomes, in this precedence: `needs_human` → `is_flake` →
+   **Main already fixed it** → **Generic no-repro**. Never push a speculative fix —
+   an unverified fix is still never pushed.
+
+   - **Needs human / infra** — `needs_human == true`: the failure is real but cannot
+     be fixed in code (a deploy/infra/permissions blocker — e.g. a GCP Secret Manager
+     403 on a renamed secret). This outcome is **terminal here** and **never touches
+     the verify-attempt counter** — retrying verify is pointless, so a human must be
+     reached on the **first** run. Push nothing. Do these inline and stop:
+
+     1. **Append the accumulator record** with outcome `needs-human` and a **Required
+        action** field naming `required_action` (see [Accumulator](#accumulator)).
+     2. **Post the accumulator** — the same `post-pr-comment.sh` command as Step 8:
+
+        ```bash
+        .claude/skills/dispatch-propagate/scripts/post-pr-comment.sh <pr-num> tmp/verify-summary.md
+        ```
+
+     3. **Write `office-hours-reason`** atomically (tempfile + mv), under the
+        `CLAUDE_JOB_DIR` guard — the same shape as `/plan-implement` Step 4's
+        deviation block:
+
+        ```bash
+        if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
+          printf '%s\n' "/verify-pr: <required_action>" > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
+          mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" "$CLAUDE_JOB_DIR/office-hours-reason"
+        fi
+        ```
+
+     4. **Do NOT write the `phase=verify` marker** (do not run Step 9).
+     5. **Stop.** With the marker absent and `office-hours-reason` present, the Stop
+        hook (`.claude/hooks/dispatch-stop.sh`) takes **Branch A** and parks the issue
+        on `dispatch:office-hours` on the **first** verify run — no verify-attempt
+        cycling, no re-diagnosis. This is the same skip-marker + `office-hours-reason`
+        pattern the other phase skills use for a known human-required outcome.
+
+     Every **other** outcome continues to Step 5.
+
+   - **Generic no-repro** — `is_flake == false`, `needs_human == false`, and the
+     failure simply does not reproduce, with no identified cause. Record it in the
+     accumulator (Step 7), post the accumulator (Step 8), and stop. Push nothing.
+   - **Main already fixed it** — `is_flake == false`, `needs_human == false`, and the
+     `why_not_caught` diagnosis is that `origin/main` (merged into this worktree by
+     the router before spawning this worker) already resolved the failure. Record it
+     in the accumulator (Step 7), post the accumulator (Step 8), and then push that
      merge commit **alone** — no fix — so CI re-runs against the merged state.
      What gets pushed is the already-completed, deterministic merge of `main`,
      not a fix. Without this push the stale failed CI keeps routing
@@ -159,30 +169,84 @@ Cross-iteration memory lives entirely in `tmp/verify-summary.md` (see
         the flake issue is already present, so a re-run against the same
         fingerprint does not re-add the dependency or error.
      4. **Record a flake iteration in the accumulator** (the skill's top-level
-        Step 6) — see [Accumulator](#accumulator); a flake entry is visually
+        Step 7) — see [Accumulator](#accumulator); a flake entry is visually
         distinct from a generic no-repro one.
-     5. **Post the accumulator (Step 7) and stop (Step 8). Push nothing** — the
+     5. **Post the accumulator (Step 8) and stop (Step 9). Push nothing** — the
         same terminal behavior as the generic no-repro outcome. On the next
         `/dispatch-propagate` run the PR's tracked issue carries a `blocked_by` against the
         flake issue; `/dispatch-propagate`'s queue scan skips blocked issues, so the PR is
         no longer re-routed to the `verify` phase. The flake issue stands on its
         own in the queue for independent triage.
 
-5. **Fix the failure.** If reproduced, fix it by invoking `/implement-unit` via the
-   Skill tool — pass `model` (chosen per `/implement-unit`'s heuristic), `scope` (the
-   fix), `context` (the failing check and reproduce command), and `commit_intent`.
-   `/implement-unit` builds the fix, commits, merges, and pushes it.
+   Of the no-repro outcomes, **needs-human** is the only one that does its
+   accumulator-append + post + `office-hours-reason` write **inline and stops before
+   Step 5**. The other three (generic, main-fixed, flake) set their own push
+   disposition here and then fall through to the shared tail Steps 7→9.
 
-6. **Append a record to the accumulator.** Append one `## Iteration <n>` section to
+5. **Increment the verify-attempt counter.** Read the PR's labels and find the highest
+   extant `dispatch:verify-attempt-<n>` label (`dangerouslyDisableSandbox: true` —
+   `gh`):
+
+   ```bash
+   N=$(gh pr view "$PR_NUM" --json labels \
+     --jq '[.labels[].name | capture("^dispatch:verify-attempt-(?<n>[0-9]+)$").n | tonumber] | max // 0')
+   NEXT=$(( N < 3 ? N + 1 : 3 ))
+   ```
+
+   This step runs for the `fixed`, `main-fixed`, `flake`, and `generic` outcomes —
+   the ones that consume the retry budget. The needs-human outcome already stopped in
+   Step 4 and never applies a verify-attempt label.
+
+   The cap at 3 means a fourth entry still leaves the label at `dispatch:verify-attempt-3`.
+   Step 4 of `/dispatch-worker` reads this counter: when the re-derived phase is still
+   `verify` and the counter is `>= 3`, it escalates to `dispatch:office-hours` instead
+   of self-closing.
+
+   Remove the prior label if one exists, then apply the new one. Use the apply-first /
+   create-on-"not found" idiom — the label may not exist yet on a fresh repo
+   (`dangerouslyDisableSandbox: true` on all `gh` calls):
+
+   ```bash
+   # Remove the previous counter label (skip if N=0 — none existed)
+   if [[ "$N" -gt 0 ]]; then
+     gh pr edit "$PR_NUM" --remove-label "dispatch:verify-attempt-$N"
+   fi
+
+   # Apply the new label; create it if missing, then retry
+   if ! gh pr edit "$PR_NUM" --add-label "dispatch:verify-attempt-$NEXT" 2>/dev/null; then
+     gh label create "dispatch:verify-attempt-$NEXT" \
+       --description "dispatch workflow: verify-pr attempt $NEXT of 3"
+     gh pr edit "$PR_NUM" --add-label "dispatch:verify-attempt-$NEXT"
+   fi
+   ```
+
+   Pass no `--color` — same convention as `dispatch:office-hours` (no colour metadata
+   here; label colour is owned by the canonical definition, not the writer).
+
+   Note: `dispatch-complete-phase` is not the right vehicle for this label — it handles
+   only the two canonical phase-complete labels (`dispatch:qa-done`, `dispatch:reviewed`).
+   The verify-attempt label is local to `/verify-pr`.
+
+6. **Apply the outcome's action.** If the failure reproduced, fix it by invoking
+   `/implement-unit` via the Skill tool — pass `model` (chosen per
+   `/implement-unit`'s heuristic), `scope` (the fix), `context` (the failing check and
+   reproduce command), and `commit_intent`. `/implement-unit` builds the fix, commits,
+   merges, and pushes it. For the no-repro outcomes that reached this step
+   (generic, main-fixed, flake), the push disposition was already set by the Step 4
+   classification — generic and flake push nothing, main-fixed pushed the merge
+   commit — so there is nothing more to do here.
+
+7. **Append a record to the accumulator.** Append one `## Iteration <n>` section to
    `tmp/verify-summary.md` (see [Accumulator](#accumulator)).
 
-7. **Post the accumulator as a PR comment** (use `dangerouslyDisableSandbox: true`):
+8. **Post the accumulator as a PR comment** (use `dangerouslyDisableSandbox: true`):
 
    ```bash
    .claude/skills/dispatch-propagate/scripts/post-pr-comment.sh <pr-num> tmp/verify-summary.md
    ```
 
-8. **Write the phase-completed marker, then stop.** The Stop hook
+9. **Write the phase-completed marker, then stop.** Reached by every outcome
+   **except** needs-human (which stopped in Step 4 without a marker). The Stop hook
    (`.claude/hooks/dispatch-stop.sh`) reads this to decide propagate vs park.
    Atomic via tempfile + mv. `CLAUDE_JOB_DIR` unset = interactive run; skip.
 
@@ -206,9 +270,9 @@ Cross-iteration memory lives entirely in `tmp/verify-summary.md` (see
 - **First write** — create the file with a header (e.g. `# Verify summary — PR #<n>`).
 - **Every invocation** — append a `## Iteration <n>` section containing:
   - **Failed checks** — the check names CI reported failing.
-  - **Outcome** — one of `fixed`, `generic-no-repro`, `main-fixed`, or `flake`.
-    This field is what makes a flake iteration visually distinct from a generic
-    no-repro one.
+  - **Outcome** — one of `fixed`, `generic-no-repro`, `main-fixed`, `flake`, or
+    `needs-human`. This field is what makes a flake iteration visually distinct
+    from a generic no-repro one.
   - **Reproduced** — `yes` or `no`.
   - **Reproduce command** — the command the subagent ran.
   - **Failure excerpt** — a short excerpt of the failure log.
@@ -221,6 +285,9 @@ Cross-iteration memory lives entirely in `tmp/verify-summary.md` (see
   - **Fingerprint** — *`flake` outcome only* — the dedupe key computed in the
     Flake sub-path (the failing check name plus the stable identifier). Omit for
     every other outcome.
+  - **Required action** — *`needs-human` outcome only* — the owner/infra action
+    the subagent reported (the `required_action` string, e.g. provision the
+    secret, grant the deploy SA access). Omit for every other outcome.
 
 `tmp/` is git-ignored, so the accumulator never enters a commit; it persists for the
 worktree's life.


### PR DESCRIPTION
Closes #1108

Partitions the verify no-repro space and fixes the Branch C session leak.

## verify-pr/SKILL.md — new needs-human/infra outcome

Adds a fourth no-repro classification. The reproduce-and-classify step now
returns structured `needs_human` / `required_action` keys (parallel to
`is_flake`), and classification (Step 4) is reordered to precede the
verify-attempt counter (Step 5). A real-but-unfixable-in-code failure
(deploy/infra/permissions — e.g. a GCP Secret Manager 403 on a renamed secret)
is terminal in Step 4: it appends the accumulator, posts it, writes
`office-hours-reason`, and skips the `phase=verify` marker — so it never
consumes the retry budget. The transient/flake/main-fixed outcomes still write
the marker and cycle the cap as before.

## dispatch-stop.sh — Branch C self-close

Branch C (transient no-push verify outcome) now self-closes the worker after
spawning the next tick, instead of parking it idle holding its `<N>-<slug>`
worktree. CI has already concluded by the time control reaches Branch C — the
early not-ready gate already intercepts and self-closes the in-progress
pushed-a-fix case — so there is nothing pending to wait on. The needs-human
failure skips the marker and lands in Branch A, which parks the issue on
`dispatch:office-hours` on the first run.

The header is reconciled and a closing note documents that post-#1108 no worker
branch self-parks idle waiting on pending work.

## Tests

`test-dispatch-scripts.sh`: flipped the verify+counter<3 test to assert
self-close fires once; added a needs-human Branch A test (verify phase, PR
present, marker absent, `office-hours-reason` present → office-hours applied
with the reason contents, no self-close). Full suite: 1547/1547 pass.