### PR TITLE
dispatch: re-check done at the spawn boundary so a worker is never dispatched onto a ready PR

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -239,8 +239,16 @@ process_one_target() {
   # target. dispatch-phase prints `done` for a non-draft PR regardless of CI; a
   # draft with pending CI exits 3 (no stdout) and any non-`done` phase falls
   # through to normal processing — this gate catches `done` only, it does not
-  # re-gate CI (the router owns that).
-  PHASE=$("$SCRIPT_DIR/dispatch-phase" "$n" 2>/dev/null) || PHASE=""
+  # re-gate CI (the router owns that). Exit 3 is the ONLY non-zero we tolerate:
+  # any other failure (gh/jq error) is genuine and must surface, not silently
+  # fall through onto a possibly-`done` PR — a hard return 2, like every other
+  # tool failure in this function.
+  PHASE_RC=0
+  PHASE=$("$SCRIPT_DIR/dispatch-phase" "$n" 2>/dev/null) || PHASE_RC=$?
+  if [[ "$PHASE_RC" -ne 0 && "$PHASE_RC" -ne 3 ]]; then
+    echo "dispatch-materialize-spawn: dispatch-phase failed (exit $PHASE_RC) for #$n" >&2
+    return 2
+  fi
   if [[ "$PHASE" == "done" ]]; then
     echo "target #$n is done (ready PR); not dispatching"
     OUTCOME=target-done

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -36,6 +36,16 @@
 #   notify target-blocked  explicit target is closed or has an open blocker; the
 #                          issue is parked via dispatch-apply-office-hours and
 #                          the lock released at the guard.
+#   notify target-done     explicit spawn-boundary done re-check (#1109): the
+#                          resolved target's PR went ready (non-draft) before the
+#                          worker booted — no phase to run. A user-facing
+#                          notification; no worker spawned. The lock is released
+#                          right after process_one_target returns (this is a
+#                          pre-spawn soft return).
+#   drain target-done      autonomous single-target (gap<=1) spawn-boundary done
+#                          re-check (#1109): same as above but the next tick
+#                          proceeds to the next priority. Lock released after the
+#                          return.
 #   notify spawn-failed    dispatch-spawn-worker exited non-zero; lock released
 #                          after the failed spawn returns. ALSO emitted on the
 #                          single-target merge-conflict path when the
@@ -75,6 +85,11 @@
 #                          processed target parked/skipped, or the queue emptied
 #                          before any spawn). Same detail/summary lines precede
 #                          it. Parked issues are visible via dispatch:office-hours.
+#                          A fan-out target found done at the spawn boundary
+#                          (#1109) is recorded as `propagate: skipped #<n>
+#                          (target-done)` and the loop continues to the next
+#                          distinct target — a normal terminal state, not a
+#                          failure.
 #
 # Lock-release points (#945): the lock is held THROUGH the spawn so the next
 # tick cannot re-select the target during the worker's boot gap. In a fan-out
@@ -177,8 +192,9 @@ CONFLICT_WORKTREE=""
 WAITING_N=""
 
 # process_one_target <issue-N> <explicit|queue>
-# Runs the per-target sequence (Step 4 guards, Step 5 resolve, Step 5b merge,
-# recovery marker, Step 6a explicit-only readiness gate, Step 6b spawn) for ONE
+# Runs the per-target sequence (Step 4 guards, the #1109 spawn-boundary done
+# re-check, Step 5 resolve, Step 5b merge, recovery marker, Step 6a
+# explicit-only readiness gate, Step 6b spawn) for ONE
 # target. Does NOT
 # release the lock and does NOT exit — the caller owns lock release and process
 # exit. Sets the global OUTCOME on every soft path and returns 0; returns 2 on a
@@ -186,7 +202,7 @@ WAITING_N=""
 process_one_target() {
   local n="$1" mode="$2"
   local PR LEAF ISSUE_STATE BLOCKERS WT_DECISION WT_ACTION WT_REST
-  local WORKTREE_PATH BRANCH PROJECT_ROOT MERGE_RC rc wt_basename
+  local WORKTREE_PATH BRANCH PROJECT_ROOT MERGE_RC rc wt_basename PHASE
 
   # --- Step 4: explicit-path guards (skipped entirely in queue mode) ---------
   # Queue rows were already vetted by dispatch-select-target (leaf, blockers,
@@ -237,6 +253,24 @@ process_one_target() {
       echo "dispatch-materialize-spawn: dispatch-check-blockers failed (exit $rc) for #$n" >&2
       return 2
     fi
+  fi
+
+  # --- Spawn-boundary done re-check (#1109) — both modes ----------------------
+  # Selection (dispatch-select-target) and the explicit leaf trace both ran
+  # against a possibly-stale PR state; a draft `review` PR can flip to ready
+  # (non-draft) in the worker boot gap. A worker spawned onto a done (ready) PR
+  # has no phase to run — it would route `STOP done` and trigger a spurious
+  # dispatch:office-hours flag. Re-derive the resolved target's phase HERE,
+  # before any worktree resolution / merge / spawn work, and refuse a done
+  # target. dispatch-phase prints `done` for a non-draft PR regardless of CI; a
+  # draft with pending CI exits 3 (no stdout) and any non-`done` phase falls
+  # through to normal processing — this gate catches `done` only, it does not
+  # re-gate CI (the router owns that).
+  PHASE=$("$SCRIPT_DIR/dispatch-phase" "$n" 2>/dev/null) || PHASE=""
+  if [[ "$PHASE" == "done" ]]; then
+    echo "target #$n is done (ready PR); not dispatching"
+    OUTCOME=target-done
+    return 0
   fi
 
   # --- Step 5: resolve the worktree ------------------------------------------
@@ -365,6 +399,18 @@ if [[ "$MODE" == "explicit" ]] || (( GAP <= 1 )); then
   case "$OUTCOME" in
     spawned)           echo "propagate" ;;
     target-blocked)    echo "notify target-blocked" ;;
+    target-done)
+      # Spawn-boundary done re-check (#1109): the resolved target's PR went ready
+      # before the worker booted — no phase to run. Explicit dispatch emits a
+      # user-facing notification; an autonomous single-target (gap<=1) drains so the
+      # next tick proceeds to the next priority. Both tokens pass through
+      # dispatch-tick's `notify *` / `drain *` routing unchanged.
+      if [[ "$MODE" == "explicit" ]]; then
+        echo "notify target-done"
+      else
+        echo "drain target-done"
+      fi
+      ;;
     merge-conflict)
       # Spawn a /dispatch-resolve-conflict bg job that resolves or escalates in
       # its own session (#982); the lock is already released above. spawned or
@@ -447,6 +493,12 @@ while :; do
       fi
       ;;
     target-blocked)     echo "propagate: parked #$cur_n ($OUTCOME)" ;;
+    target-done)
+      # Spawn-boundary done re-check (#1109): the resolved target went ready before
+      # spawn — no phase to run. Record a skip and continue filling the gap from the
+      # next distinct target. A normal terminal state, not a failure.
+      echo "propagate: skipped #$cur_n (target-done)"
+      ;;
     *)
       echo "propagate: skipped #$cur_n ($OUTCOME)"
       # ci-waiting never occurs in fan-out: the readiness gate is explicit-only

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-phase
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-phase
@@ -12,6 +12,12 @@
 # dispatch-ci-ready first — only invoke dispatch-phase for a target that
 # dispatch-ci-ready reports as `ready`.
 #
+# Exception — the spawn-boundary done re-check (dispatch-materialize-spawn,
+# #1109) deliberately does NOT gate on dispatch-ci-ready: it asks only "is this
+# PR done?" and relies on the exit-3/no-stdout contract above to let a draft
+# with pending CI fall through (the router owns the CI gate). Such a caller must
+# treat exit 3 as the sole tolerated non-zero and surface any other failure.
+#
 # Argument resolution:
 #   - All-digit arg: treated as an issue number. The matching PR is the one
 #     whose headRefName starts with "<issue>-".

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -16003,6 +16003,57 @@ esac
 assert_eq "gap-unbounded-removed: usage error exit 2" "ok" "$status"
 mat_teardown
 
+# --- spawn-boundary done re-check (#1109): explicit done → notify target-done --
+# A target selected while its PR was a draft `review` PR can flip to ready
+# (non-draft) before the worker boots. The spawn boundary re-derives the phase
+# (dispatch-phase) before any worktree/spawn work and refuses a done target:
+# explicit dispatch emits a user-facing `notify target-done` and spawns no
+# worker. MAT_PR set so the realistic done path runs (a PR exists and went ready).
+echo "Test: materialize-spawn explicit done re-check → notify target-done, no spawn (#1109)"
+mat_setup
+export MAT_PR=665
+export MAT_PHASE=done
+out=$(run_mat 839 explicit)
+assert_eq "explicit-done: terminal token" "notify target-done" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "explicit-done: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+assert_eq "explicit-done: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "explicit-done: no office-hours park" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/apply-office-hours.log" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- spawn-boundary done re-check (#1109): queue single-target done → drain ----
+# An autonomous single-target (gap<=1) found done at the spawn boundary drains so
+# the next tick proceeds to the next priority; no worker is spawned.
+echo "Test: materialize-spawn queue single-target done re-check → drain target-done, no spawn (#1109)"
+mat_setup
+export MAT_PHASE=done
+out=$(run_mat 839 queue)
+assert_eq "queue-done: terminal token" "drain target-done" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "queue-done: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+assert_eq "queue-done: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+mat_teardown
+
+# --- spawn-boundary done re-check (#1109): fan-out done → skip each, drain ------
+# MAT_PHASE is global, so every fan-out target reads done: each is recorded as a
+# `propagate: skipped #<n> (target-done)` and the loop continues to the next
+# distinct target until the queue drains. Nothing spawns → terminal `drain`.
+echo "Test: materialize-spawn fan-out done re-check → skip each, drain, no spawn (#1109)"
+mat_setup
+export MAT_PHASE=done
+export MAT_QUEUE="840 841"
+out=$(run_mat 839 queue --gap 3)
+assert_eq "fanout-done: skipped detail per target (839,840,841)" "3" \
+  "$(printf '%s\n' "$out" | grep -c 'skipped #.* (target-done)')"
+assert_eq "fanout-done: zero spawns in summary" "1" \
+  "$(printf '%s\n' "$out" | grep -c 'spawned 0 of gap 3')"
+assert_eq "fanout-done: terminal token" "drain" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "fanout-done: no spawn" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+assert_eq "fanout-done: lock released at end" "" "$(cat "$DISPATCH_LOCK_FILE")"
+mat_teardown
+
 echo "=== print_remote_access_block ==="
 
 # All four emulators

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -55,7 +55,7 @@ Act on the one directive:
 | `INVOKE /review-fix` | 0 | draft PR + `dispatch:qa-done` (or `dispatch:reviewed` re-entry) | invoke `/review-fix` |
 | `INVOKE /dispatch-resolve-conflict` | 0 | provisioning hit an `origin/main` merge conflict | invoke `/dispatch-resolve-conflict` (see below) |
 | `RELEVANCE-REVIEW` | 0 | no PR on the target (`implement`) | run the Step 2 relevance review, then dispatch its verdict |
-| `STOP done` | 0 | non-draft (ready) PR | stop without invoking a phase skill |
+| `STOP done` | 0 | non-draft (ready) PR — should-never-happen; spawn boundary (#1109) prevents it upstream | stop without invoking a phase skill |
 | `STOP waiting` | 0 | draft PR's CI has no verdict yet | print the verbatim message below and stop |
 | `STOP provision-failed` | 0 | `direnv`/merge provisioning failed (non-conflict) | stop with no marker (reason already written) |
 | `STOP wrong-worktree` | non-zero | spawn cwd / branch did not match `<N>` / `<worktree-path>` | stop |
@@ -132,10 +132,14 @@ on `dispatch:office-hours`.
 Stop without invoking a phase skill and without writing a marker. The Stop hook
 reads marker-absence and applies `dispatch:office-hours` to the issue. For `done`
 (a non-draft PR), no phase skill ran and the slip-past sweep (#843) flags this PR
-for office-hours review. For `wrong-worktree`, the spawn was incoherent — the
-branch-name sanity check rejected the spawn cwd, or the positional
-`<worktree-path>` disagreed with `git rev-parse --show-toplevel`; see
-`reference.md`.
+for office-hours review. Since #1109 the spawn boundary
+(`dispatch-materialize-spawn`) re-checks done before spawning and refuses to
+dispatch a done target, so `STOP done` is now a defensive guard for the
+sub-millisecond residual window between that re-check and worker boot — the
+normal-case done PR is caught upstream and no worker is spawned. For
+`wrong-worktree`, the spawn was incoherent — the branch-name sanity check
+rejected the spawn cwd, or the positional `<worktree-path>` disagreed with `git
+rev-parse --show-toplevel`; see `reference.md`.
 
 ## 2. Pre-Implementation Relevance Review
 


### PR DESCRIPTION
Closes #1109

## Problem

A `dispatch-worker` must never run on a "done" (non-draft, ready) PR — there is no phase to execute. The autonomous selector (`dispatch-select-target`) already skips done PRs, but the **spawn boundary did not re-check**. `dispatch-materialize-spawn`'s Step 6a readiness gate re-validated only *CI*, and only for `explicit` targets. So a target selected while its PR was a draft `review` PR could flip to ready (non-draft) in the ~80s worker-boot gap (observed on #1087 / PR #1099). The worker then routed `STOP done`, ran no phase, and the Stop hook flagged the issue `dispatch:office-hours` — spurious human-review noise for a normal terminal state.

## Change

Make the spawn boundary authoritative for done-detection.

- **`dispatch-materialize-spawn`** — `process_one_target` now re-derives the resolved target's phase via `dispatch-phase` **before** any worktree resolution / merge / spawn work, in **both** `explicit` and `queue` modes, and refuses a done target. `dispatch-phase` prints `done` for any non-draft PR regardless of CI; a draft with pending CI exits 3 (no stdout) and any non-`done` phase falls through — so the gate catches `done` only and does not re-gate CI (the router owns that). Routing:
  - explicit + done → `notify target-done` (user-facing notification; no worker)
  - autonomous single-target (gap≤1) + done → `drain target-done` (next tick proceeds to the next priority)
  - fan-out + done → `propagate: skipped #<n> (target-done)` and continue to the next distinct target
  Both new tokens ride `dispatch-tick`'s existing `notify *` / `drain *` passthrough, so no tick change was needed.

- **`dispatch-worker/SKILL.md`** — demotes `STOP done` to a defensive should-never-happen guard for the sub-millisecond residual window between the spawn-boundary re-check and worker boot; the normal-case done PR is now caught upstream and no worker is spawned.

- **`test-dispatch-scripts.sh`** — three new tests in the materialize-spawn section (explicit done → `notify target-done`; queue single-target done → `drain target-done`; fan-out done → per-target skip + `drain`), each asserting no worker spawned and the lock released. Full suite: 1560/1560.

## Out of scope

- `dispatch-select-target`'s existing done-skip (correct; this adds a second, authoritative check).
- The sub-millisecond residual race between the re-check and worker boot.
- Reworking the live-session / daemon liveness query (#738).