### PR TITLE
dispatch: dispatch-select-target skips reserved worktrees (#1046)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -108,6 +108,11 @@ source "$SCRIPT_DIR/lib.sh"
 # when a live Claude session owns the matching worktree (#905). Sourced here so
 # the queue-scan loops below can ask the liveness question.
 source "$SCRIPT_DIR/lib-claude-agents.sh"
+# reservation_exists — a worktree-bearing row is ALSO skipped when its worktree
+# carries a reservation marker (#1046), even before a live session owns it: a
+# reserved-but-not-yet-registered target must not be re-selected, racing the
+# reservation. Load-guarded; re-sources lib.sh / lib-claude-agents.sh harmlessly.
+source "$SCRIPT_DIR/lib-reservation-ledger.sh"
 QA_MODE=false
 HEALTH_ONLY=false
 declare -A EXCLUDED=()
@@ -369,6 +374,35 @@ issue_has_live_worktree() {
   return 1
 }
 
+# True when the <branch> worktree is CLAIMED — a live session owns it (#905) OR
+# it carries a reservation marker (#1046). Both close the spawn-gap re-selection
+# race: a reserved-but-not-yet-registered target must not be re-selected. An
+# orphan worktree (on disk, no live session, no marker) is NOT claimed — it stays
+# a reuse signal for dispatch-resolve-worktree. The reserved check is a fast-path
+# file stat keyed on the worktree basename, no daemon round-trip.
+pr_branch_worktree_claimed() {
+  local branch="$1"
+  pr_branch_has_live_worktree "$branch" && return 0
+  local path="${WORKTREE_PATH_BY_BRANCH[$branch]:-}"
+  [[ -z "$path" ]] && return 1
+  reservation_exists "$(basename "$path")"
+}
+
+# True when any <num>-* worktree is CLAIMED — live-owned (#905) OR reserved
+# (#1046). Several matches → claimed if any one is live or reserved. Orphan
+# worktrees (no session, no marker) stay reuse signals, not skips.
+issue_worktree_claimed() {
+  local num="$1" p
+  issue_has_live_worktree "$num" && return 0
+  local paths="${WORKTREE_PATHS_BY_NUM[$num]:-}"
+  [[ -z "$paths" ]] && return 1
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    reservation_exists "$(basename "$p")" && return 0
+  done <<< "$paths"
+  return 1
+}
+
 # Fetch all open PRs once, with the union of fields this script and
 # dispatch-phase need. Each per-PR dispatch-phase call below reuses it
 # (passed as DISPATCH_PR_LIST) instead of re-running gh pr list.
@@ -511,9 +545,10 @@ PHASE_PRIORITY=(review verify)
 while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   [[ -z "$pr_num" ]] && continue
 
-  # Skip a PR whose branch worktree is owned by a live session. An orphan
-  # worktree does not skip — it is recycled at dispatch-resolve-worktree (#905).
-  if pr_branch_has_live_worktree "$pr_branch"; then
+  # Skip a PR whose branch worktree is owned by a live session or reserved. An
+  # orphan worktree (no session, no marker) does not skip — it is recycled at
+  # dispatch-resolve-worktree (#905, #1046).
+  if pr_branch_worktree_claimed "$pr_branch"; then
     continue
   fi
 
@@ -624,10 +659,10 @@ while IFS=$'\t' read -r issue_num issue_labels; do
   [[ -z "$issue_num" ]] && continue
   # Skip an open issue already closed by a non-draft (ready) PR (#920).
   [[ -n "${READY_PR_CLOSED_ISSUES[$issue_num]:-}" ]] && continue
-  # Skip an issue whose <N>-* worktree is owned by a live session. An orphan
-  # <N>-* worktree does not skip — it is recycled at dispatch-resolve-worktree
-  # (#905).
-  if issue_has_live_worktree "$issue_num"; then
+  # Skip an issue whose <N>-* worktree is owned by a live session or reserved.
+  # An orphan <N>-* worktree (no session, no marker) does not skip — it is
+  # recycled at dispatch-resolve-worktree (#905, #1046).
+  if issue_worktree_claimed "$issue_num"; then
     continue
   fi
   # Category is the top-level help-wanted issue's own labels. Priority bit is

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
@@ -264,9 +264,9 @@ find_leaf() {
     if [[ -n "${EXCLUDED[$n]:-}" ]]; then
       return 1
     fi
-    # A valid leaf. Live-session-owned children are filtered before recursion
-    # (see the descent loop below), so a queue-mode leaf reached here is never
-    # itself live-owned.
+    # A valid leaf. Descended children are filtered before recursion (see the
+    # descent loop below, and the root guard above), so a queue-mode leaf
+    # reached here is never itself live-owned, reserved, or parked.
     echo "$n"
     return 0
   fi
@@ -296,13 +296,12 @@ find_leaf() {
 }
 
 # In queue mode the root issue is filtered exactly like a descended child
-# (#1011): if the starting issue is itself a parked topological leaf, the
-# descent loop never gets a chance to skip it, so guard it here before the
-# trace. This keeps dispatch-trace-leaf's standalone contract — "queue mode
-# never returns a leaf carrying dispatch:office-hours" — true for the root, not
-# just for children. Force the no-startable-leaf path (rc 2) so it flows into
-# the exit-2 surface below, matching the all-children-parked case.
-if [[ "$MODE" == "queue" ]] && child_is_office_hours_parked "$ISSUE_NUM"; then
+# (#1011, #1046): if the starting issue is itself a topological leaf that is
+# parked or claimed (reserved/live-owned), the descent loop never gets a chance
+# to skip it, so guard it here before the trace. Force the no-startable-leaf
+# path (rc 2) so it flows into the exit-2 surface below, matching the
+# all-children-skipped case.
+if [[ "$MODE" == "queue" ]] && { child_is_office_hours_parked "$ISSUE_NUM" || child_worktree_claimed "$ISSUE_NUM"; }; then
   trace_rc=2
 elif LEAF=$(find_leaf "$ISSUE_NUM"); then
   trace_rc=0

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
@@ -24,10 +24,11 @@
 #              for the recycle-after-completion case, or `conflict` if a live
 #              session still owns the worktree — #837).
 #   queue    — descent filters out children whose <N>-* worktree is owned by a
-#              LIVE Claude session (#914). An orphan <N>-* worktree (on disk, no
-#              session) stays descendable — it is a reuse signal, not a skip,
-#              matching the direct-row liveness fix in dispatch-select-target
-#              (#905). A child with no worktree at all is never filtered.
+#              LIVE Claude session (#914) or carries a reservation marker
+#              (#1046). An orphan <N>-* worktree (on disk, no session, no marker)
+#              stays descendable — it is a reuse signal, not a skip, matching the
+#              direct-row claimed-skip in dispatch-select-target (#905, #1046). A
+#              child with no worktree at all is never filtered.
 #              Queue mode also filters out a child parked on
 #              dispatch:office-hours (#1011): the label parks an item for human
 #              review and must remove it from autonomous selection (#757), so a
@@ -62,6 +63,11 @@ source "$SCRIPT_DIR/lib.sh"
 # ask the liveness question; it sets -uo pipefail (not -e), preserving this
 # script's set -euo pipefail above.
 source "$SCRIPT_DIR/lib-claude-agents.sh"
+# reservation_exists — queue-mode descent ALSO skips a child whose <N>-* worktree
+# carries a reservation marker (#1046), mirroring the selector's reserved-skip
+# applied to subtree children. Load-guarded; re-sources lib.sh /
+# lib-claude-agents.sh harmlessly.
+source "$SCRIPT_DIR/lib-reservation-ledger.sh"
 
 ISSUE_NUM="${1:-}"
 MODE="${2:-}"
@@ -148,6 +154,24 @@ child_has_live_worktree() {
     if worktree_has_live_session "$p"; then
       return 0
     fi
+  done <<< "$paths"
+  return 1
+}
+
+# True when any <num>-* child worktree is CLAIMED — live-owned (#914) OR reserved
+# (#1046). Mirrors dispatch-select-target's issue_worktree_claimed, applied to
+# subtree children: a reserved-but-not-yet-registered child must not be descended
+# into nor returned. An orphan child (no session, no marker) stays descendable.
+# The reserved check is a fast-path file stat keyed on the worktree basename, no
+# daemon round-trip.
+child_worktree_claimed() {
+  local num="$1" p
+  child_has_live_worktree "$num" && return 0
+  local paths="${WORKTREE_PATHS_BY_NUM[$num]:-}"
+  [[ -z "$paths" ]] && return 1
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    reservation_exists "$(basename "$p")" && return 0
   done <<< "$paths"
   return 1
 }
@@ -249,13 +273,14 @@ find_leaf() {
 
   # Descend into children lowest-numbered first; return the first leaf found.
   # In queue mode, skip any child whose <N>-* worktree is owned by a live
-  # session (#914) — an orphan child worktree stays descendable — and any child
-  # parked on dispatch:office-hours (#1011). If every child is skipped the loop
-  # finds nothing and we bubble up.
+  # session (#914) or carries a reservation marker (#1046) — an orphan child
+  # worktree (no session, no marker) stays descendable — and any child parked on
+  # dispatch:office-hours (#1011). If every child is skipped the loop finds
+  # nothing and we bubble up.
   local kid leaf
   while IFS= read -r kid; do
     [[ -z "$kid" ]] && continue
-    [[ "$MODE" == "queue" ]] && child_has_live_worktree "$kid" && continue
+    [[ "$MODE" == "queue" ]] && child_worktree_claimed "$kid" && continue
     [[ "$MODE" == "queue" ]] && child_is_office_hours_parked "$kid" && continue
     # Capture the status explicitly (set -e is disabled here) so a hard error
     # (rc 3) is distinguishable from "no leaf in this subtree" (rc 1).

--- a/.claude/skills/dispatch-propagate/scripts/lib-reservation-ledger.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-reservation-ledger.sh
@@ -24,6 +24,7 @@
 #   reservation_dir
 #   reservation_write   <worktree-basename> <issue-N> <session-id>
 #   reservation_clear   <worktree-basename>
+#   reservation_exists  <worktree-basename>
 #   reservation_count
 #   reservation_sweep
 #
@@ -62,6 +63,18 @@
 #     return 0 — file absent after the call (removed, or never existed, or no
 #               ledger).
 #     return 1 — missing or unsafe argument only.
+#
+# reservation_exists <worktree-basename>
+#   Fast-path membership test: return 0 if a reservation marker named exactly
+#   <worktree-basename> exists in the ledger dir, 1 otherwise. No daemon
+#   round-trip — a single stat. The basename arg is required and must pass the
+#   same path-safety guard as reservation_write/_clear (missing/unsafe → 1). An
+#   unresolvable/absent ledger dir → 1 (nothing reserved). The dot/.tmp in-flight
+#   tempfile is never matched (callers pass a clean basename; the guard rejects
+#   names with separators anyway).
+#     return 0 — a marker named <worktree-basename> exists.
+#     return 1 — a missing/unsafe argument, an unresolvable ledger dir, or no
+#               such marker.
 #
 # reservation_count
 #   Print the integer count of outstanding marker files to stdout. NEVER fails —
@@ -212,6 +225,28 @@ if [[ -z "${_LIB_RESERVATION_LEDGER_LOADED:-}" ]]; then
     dir=$(reservation_dir) || return 0
     rm -f "$dir/$wt_name" 2>/dev/null || true
     return 0
+  }
+
+  # reservation_exists <worktree-basename> — fast-path marker membership test.
+  # See the header comment for the return-code contract.
+  reservation_exists() {
+    local wt_name="${1:-}"
+    if [[ -z "$wt_name" ]]; then
+      printf 'lib-reservation-ledger: reservation_exists requires a <worktree-basename> argument\n' >&2
+      return 1
+    fi
+    # Same path guard as reservation_write/_clear — never let an unsafe name
+    # stat outside the ledger dir.
+    case "$wt_name" in
+      *..*|*/*|*[[:cntrl:]]*)
+        printf 'lib-reservation-ledger: reservation_exists: unsafe worktree-basename %q\n' "$wt_name" >&2
+        return 1
+        ;;
+    esac
+    local dir
+    # Unresolvable ledger dir → nothing reserved.
+    dir=$(reservation_dir) || return 1
+    [[ -e "$dir/$wt_name" ]]
   }
 
   # reservation_count — print the count of outstanding marker files. Never fails.

--- a/.claude/skills/dispatch-propagate/scripts/lib-reservation-ledger.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-reservation-ledger.sh
@@ -246,7 +246,7 @@ if [[ -z "${_LIB_RESERVATION_LEDGER_LOADED:-}" ]]; then
     local dir
     # Unresolvable ledger dir → nothing reserved.
     dir=$(reservation_dir) || return 1
-    [[ -e "$dir/$wt_name" ]]
+    [[ -f "$dir/$wt_name" ]]
   }
 
   # reservation_count — print the count of outstanding marker files. Never fails.
@@ -319,18 +319,18 @@ if [[ -z "${_LIB_RESERVATION_LEDGER_LOADED:-}" ]]; then
         reservation_clear "$bn"
         printf 'lib-reservation-ledger: reclaimed reservation %s (live-worker-redundant)\n' "$bn" >&2
       elif [[ -z "$marker_sid" ]]; then
-        # A marker with no readable `session=` line is malformed (truncation
+        # (b) A marker with no readable `session=` line is malformed (truncation
         # cannot happen via the atomic write, so this means external tampering or
         # corruption). Reclaiming on an empty session id would conflate "no
         # session" with "dead session" and could delete a still-valid slot — KEEP
         # it and flag it instead (fail safe, matching the sweep's conservatism).
         printf 'lib-reservation-ledger: keeping malformed reservation %s (no session= line)\n' "$bn" >&2
       elif [[ -z "${live_ids[$marker_sid]:-}" ]]; then
-        # (b) The reserving session is not live and never converted — stranded.
+        # (c) The reserving session is not live and never converted — stranded.
         reservation_clear "$bn"
         printf 'lib-reservation-ledger: reclaimed reservation %s (dead-session-stranded)\n' "$bn" >&2
       fi
-      # (c) reserving session alive, no live worker yet → in-flight → KEEP.
+      # (d) reserving session alive, no live worker yet → in-flight → KEEP.
     done
     (( had_nullglob )) || shopt -u nullglob
     return 0

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3769,6 +3769,25 @@ err_out=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue" 2>/dev/null && echo "
 assert_eq "queue: parked root leaf → exit 2, no leaf on stdout" "EXIT=2" "$err_out"
 teardown
 
+# 20-r. Queue mode: the ROOT issue is itself a RESERVED topological leaf
+#       (#1046). 700 has no children, so the descent loop never runs; the root
+#       guard before the trace must catch the reservation and exit 2 rather than
+#       returning the reserved root. Mirrors the parked-root guard in test 20.
+echo "Test: queue mode → reserved ROOT leaf guarded, exits 2"
+setup
+# No subissues-700.json → 700 is a topological leaf.
+printf '{"title":"Issue 700","body":"","comments":[],"number":700,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-700.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/700-feature\nHEAD def456\nbranch refs/heads/700-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+# No live sessions; reservation marker for the root's worktree → root is claimed.
+select_target_fake_claude
+mkdir -p "$DISPATCH_RESERVATION_DIR"
+printf 'session=resv-sess\nissue=700\ntimestamp=2026-01-01T00:00:00Z\n' > "$DISPATCH_RESERVATION_DIR/700-feature"
+err_out=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue" 2>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+assert_eq "queue: reserved root leaf → exit 2, no leaf on stdout" "EXIT=2" "$err_out"
+teardown
+
 # 21. Explicit mode: a parked ROOT leaf is returned unchanged (#1011 scopes the
 #     root guard to queue mode, mirroring the descent child-skip scoping).
 echo "Test: explicit mode → parked ROOT leaf returned (no guard)"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -74,6 +74,10 @@ setup() {
   # dispatch-select-target sources lib-claude-agents.sh via its SCRIPT_DIR
   # (TMPDIR_TEST under test). Sourced, not executed — no chmod +x needed.
   cp "$SCRIPT_DIR/lib-claude-agents.sh" "$TMPDIR_TEST/lib-claude-agents.sh"
+  # dispatch-select-target and dispatch-trace-leaf source lib-reservation-ledger.sh
+  # via their SCRIPT_DIR (#1046), to skip a reserved-but-not-yet-live target.
+  # Sourced, not executed — no chmod +x needed.
+  cp "$SCRIPT_DIR/lib-reservation-ledger.sh" "$TMPDIR_TEST/lib-reservation-ledger.sh"
   chmod +x "$TMPDIR_TEST/dispatch-phase" \
            "$TMPDIR_TEST/dispatch-ci-ready" \
            "$TMPDIR_TEST/dispatch-find-pr" \
@@ -123,6 +127,12 @@ STUB
   # no test reaches the real `claude` daemon. Per-test calls to
   # select_target_fake_claude override this to model live or orphan worktrees.
   export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/no-such-claude"
+
+  # Point the reservation ledger (#1046) at a scratch dir that is absent by
+  # default — no marker files, so reservation_exists is false for every row and
+  # the reserved-skip is inert. Every existing select-target / trace-leaf test
+  # stays green; a reserved-skip test creates a marker file here to opt in.
+  export DISPATCH_RESERVATION_DIR="$TMPDIR_TEST/reservations"
 
   # dispatch-select-target calls dispatch-phase as "$SCRIPT_DIR/dispatch-phase".
   # Since we copied them all to TMPDIR_TEST, SCRIPT_DIR inside each copy will
@@ -572,6 +582,8 @@ teardown() {
   # Per-test exports for the liveness gate must not leak across tests.
   unset CLAUDE_AGENTS_CMD
   unset CLAUDE_CODE_SESSION_ID
+  # The reservation-ledger override (#1046) must not leak across tests either.
+  unset DISPATCH_RESERVATION_DIR
 }
 trap '[ -n "${TMPDIR_TEST:-}" ] && rm -rf "$TMPDIR_TEST"' EXIT
 
@@ -1435,6 +1447,42 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "PR with orphan worktree is selected, not skipped" "pr 10 10-active-branch verify" "$result"
 teardown
 
+# 2c. A PR whose branch worktree is RESERVED — on disk, no live session, but a
+#     reservation marker present — is skipped, even though no live session owns
+#     it yet (#1046). Closes the spawn-gap re-selection race before registration.
+echo "Test: PR whose branch worktree is reserved (no live session) is skipped"
+setup
+UNION='['"$(make_pr_union 10 "10-active-branch" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr_union 20 "20-other" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/10-active-branch\nHEAD def456\nbranch refs/heads/10-active-branch\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+# No live sessions: 10-active-branch's worktree is sessionless. But a reservation
+# marker named by the worktree basename is present in the ledger.
+select_target_fake_claude
+mkdir -p "$DISPATCH_RESERVATION_DIR"
+printf 'session=resv-sess\nissue=10\ntimestamp=2026-01-01T00:00:00Z\n' > "$DISPATCH_RESERVATION_DIR/10-active-branch"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "PR with reserved worktree skipped; next PR returned" "pr 20 20-other verify" "$result"
+teardown
+
+# 2d. A PR whose branch worktree is an orphan with NO reservation marker is NOT
+#     skipped — reserved is gated strictly on the marker (#1046). Guards that the
+#     reserved-skip never broadens the orphan-recycle path.
+echo "Test: PR whose orphan worktree has no reservation marker is not skipped"
+setup
+UNION='['"$(make_pr_union 10 "10-active-branch" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr_union 20 "20-other" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/10-active-branch\nHEAD def456\nbranch refs/heads/10-active-branch\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+# No live session and an empty ledger (default): 10-active-branch is a recyclable
+# orphan, not a skip.
+select_target_fake_claude
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "PR with orphan worktree and no marker is selected" "pr 10 10-active-branch verify" "$result"
+teardown
+
 # 2b. A PR whose ISSUE carries dispatch:office-hours is skipped (issue #909).
 # The label lives on the issue, not the PR — the skip resolves the issue number
 # from the PR's branch prefix (<N>-) and reads the issue's labels. PR 10's branch
@@ -1882,6 +1930,26 @@ printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/55-some-feature\nHEAD
 select_target_fake_claude
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "issue with orphan worktree selected, not skipped" "issue 55" "$result"
+teardown
+
+# 24c. Help-wanted issue whose <N>-* worktree is RESERVED — on disk, no live
+#      session, but a reservation marker present — is skipped in favor of the
+#      next-oldest issue (#1046). The reserved-but-not-yet-registered target must
+#      not be re-selected, racing the reservation.
+echo "Test: issue with reserved worktree (no live session) skipped; next-oldest chosen"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":66,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/55-some-feature\nHEAD def456\nbranch refs/heads/55-some-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+# No live sessions: 55's worktree is sessionless. But a reservation marker named
+# by the worktree basename is present → 55 is claimed and skipped.
+select_target_fake_claude
+mkdir -p "$DISPATCH_RESERVATION_DIR"
+printf 'session=resv-sess\nissue=55\ntimestamp=2026-01-01T00:00:00Z\n' > "$DISPATCH_RESERVATION_DIR/55-some-feature"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "issue with reserved worktree skipped; next issue 66 chosen" "issue 66" "$result"
 teardown
 
 # 25. A lone help-wanted issue whose worktree has a live session → empty

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3575,6 +3575,46 @@ result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
 assert_eq "queue: live-owned child 701 skipped → sibling 702" "702" "$result"
 teardown
 
+# 12b-r. Queue mode: a child whose <N>-* worktree is RESERVED — on disk, no live
+#        session, but a reservation marker present — is skipped during descent, so
+#        the sibling 702 is returned (#1046). Mirrors the live-owned skip applied
+#        to subtree children.
+echo "Test: queue mode → reserved child skipped, returns sibling"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+# No live sessions: 701's worktree is sessionless. But a reservation marker named
+# by the worktree basename is present → 701 is claimed and skipped during descent.
+select_target_fake_claude
+mkdir -p "$DISPATCH_RESERVATION_DIR"
+printf 'session=resv-sess\nissue=701\ntimestamp=2026-01-01T00:00:00Z\n' > "$DISPATCH_RESERVATION_DIR/701-feature"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
+assert_eq "queue: reserved child 701 skipped → sibling 702" "702" "$result"
+teardown
+
+# 12b-o. Queue mode: a child whose <N>-* worktree is an orphan with NO reservation
+#        marker stays descendable, so the lowest leaf 701 is returned (#1046).
+#        Guards that the reserved-skip is gated strictly on the marker.
+echo "Test: queue mode → orphan child with no marker is descendable"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+# No live session and an empty ledger (default): 701 is a recyclable orphan.
+select_target_fake_claude
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
+assert_eq "queue: orphan child 701 with no marker descendable → leaf 701" "701" "$result"
+teardown
+
 # 12c. Queue mode: every child's <N>-* worktree is live-owned → exit 2 with the
 #      worktree-conflicted stderr message (#914).
 echo "Test: queue mode → all leaves live-owned, exits 2"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6445,6 +6445,30 @@ else
 fi
 rl_teardown
 
+# --- Test 13: reservation_exists tracks write/clear and guards its arg --------
+
+echo "Test: reservation_exists is true after write, false after clear, and guards its argument"
+rl_setup
+# Absent ledger (never written) → not reserved.
+if reservation_exists "990-slug"; then rc=0; else rc=$?; fi
+assert_eq "rl-exists: absent ledger → return 1" "1" "$rc"
+reservation_write "990-slug" "990" "sess-e"
+if reservation_exists "990-slug"; then rc=0; else rc=$?; fi
+assert_eq "rl-exists: true after write (return 0)" "0" "$rc"
+# A different basename with no marker → not reserved.
+if reservation_exists "991-other"; then rc=0; else rc=$?; fi
+assert_eq "rl-exists: unrelated basename → return 1" "1" "$rc"
+reservation_clear "990-slug"
+if reservation_exists "990-slug"; then rc=0; else rc=$?; fi
+assert_eq "rl-exists: false after clear (return 1)" "1" "$rc"
+# Empty arg → return 1.
+if reservation_exists ""; then rc=0; else rc=$?; fi
+assert_eq "rl-exists: empty arg → return 1" "1" "$rc"
+# Unsafe basename → return 1 (path-safety guard).
+if reservation_exists "../escape"; then rc=0; else rc=$?; fi
+assert_eq "rl-exists: unsafe basename → return 1" "1" "$rc"
+rl_teardown
+
 # ============================================================================
 # dispatch-config-load tests
 # ============================================================================


### PR DESCRIPTION
## Summary

Part of the #1044 reservation-ledger epic. The reservation ledger (#1045) now
maintains a directory of marker files named by worktree basename, written under
the selection lock the instant a target is claimed — before its worker spawns or
registers. This PR makes selection honor those markers.

Before this change `dispatch-select-target` skipped a target's worktree only when
a **live** Claude session owned it (#905), mirrored into `dispatch-trace-leaf`'s
queue-mode descent (#914). A target that was **reserved but whose worker had not
yet registered** was still re-selectable, racing the reservation. This PR closes
that gap: selection skips a worktree that is **claimed** — live-owned OR reserved.

## Units

1. **`reservation_exists` ledger primitive** — fast-path membership test (a single
   stat, no daemon round-trip) keyed on the worktree basename, with the same
   arg/path-safety guards as the sibling primitives.
2. **`dispatch-select-target` honors reservations** — `pr_branch_worktree_claimed`
   / `issue_worktree_claimed` wrap the unchanged live predicates, adding a
   `reservation_exists` check. Both call sites (PR loop, help-wanted loop) swap to
   the combined predicate.
3. **`dispatch-trace-leaf` honors reservations in descent** —
   `child_worktree_claimed` wraps the unchanged `child_has_live_worktree`, so a
   reserved deeper leaf is descended past during queue-mode subtree descent.

An orphan worktree (on disk, no live session, **no** marker) is unchanged — it
stays a reuse signal for `dispatch-resolve-worktree`. Reserved is a new condition
gated strictly on marker presence.

## Tests

`test-dispatch-scripts.sh` covers `reservation_exists`, the select-target PR and
help-wanted reserved-skips plus paired orphan-not-reserved guards, and the
trace-leaf descent reserved-skip plus its orphan guard. All 1559 tests pass.

Closes #1046