### PR TITLE
dispatch: latch the main-broken gate so a diagnosed red main stops blocking queue selection

### DIFF
--- a/.claude/skills/dispatch-diagnose-main/SKILL.md
+++ b/.claude/skills/dispatch-diagnose-main/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatch-diagnose-main
-description: Diagnose origin/main's failing CI when /dispatch-propagate detects a red main; runs as a spawned bg job that enumerates failing checks, fetches logs, and produces the likely-cause summary in its own transcript.
+description: Diagnose origin/main's failing CI when /dispatch-propagate detects a red main; runs as a spawned bg job that enumerates failing checks, fetches logs, and files the redacted likely-cause summary as a find-or-create dispatch:main-broken issue.
 ---
 
 # Dispatch: Diagnose Main
@@ -8,9 +8,13 @@ description: Diagnose origin/main's failing CI when /dispatch-propagate detects 
 Runs as its own `claude --bg` job (session name `diagnose-main`) spawned by
 `/dispatch-propagate` when `dispatch-select-target` reports `main-broken <sha>`
 — `origin/main` itself is red, so no new work is safe to start. The diagnosis
-lives in this job's own transcript. This job holds no dispatch lock (the router
-released it before spawning this job). The skill does **not** run the sweep,
-create a worktree, branch, PR, or invoke any phase skill.
+is recorded as a find-or-create `dispatch:main-broken` GitHub issue — one open
+at a time — a durable, dispatchable work item that also latches the
+main-broken gate (#1085) so the dispatch queue can flow while main is still
+red, rather than living only in this job's transcript. This job holds no
+dispatch lock (the router released it before spawning this job). The skill does
+**not** run the sweep, create a worktree, branch, PR, or invoke any phase
+skill.
 
 Takes `<sha>` as its single argument — the broken `origin/main` HEAD commit.
 
@@ -37,18 +41,61 @@ Both calls need `dangerouslyDisableSandbox: true`.
 - For a failing **CodeQL check-run** (which has no workflow-run id), surface
   its `details_url` from the check-runs response.
 
-## 3. Summarize and stop
+## 3. File the diagnosis as a dispatch:main-broken issue
 
-Summarize the likely cause from the logs and check-run details, report it,
-and stop. This job's transcript is the surface for the diagnosis.
+Compose the likely cause from the logs and check-run details as the issue
+body. Record the broken HEAD `<sha>` as prose (e.g. `origin/main HEAD <sha>`);
+keep it a bare reference and never place a closing keyword next to a `#N`, so
+the body closes no issue.
 
 Include only the failing check/step name and a high-level error category
 (e.g. "test assertion failed", "lint error", "type error"). Do not reproduce
 raw log lines, environment-variable values, file paths beyond the immediate
 failing module, or any string that looks like a token, credential, or other
 secret — even if GitHub Actions has already partially masked it. The
-`--log-failed` output may inadvertently surface CI internals; the summary is
-for the user, not a copy of the log.
+`--log-failed` output may inadvertently surface CI internals; the body is for
+the user, not a copy of the log.
 
-Once a PR that fixes main exists, the normal ladder picks it up
-(verify/ready) — this gate only blocks starting new, unrelated work.
+Write the body to a temp file under `$CLAUDE_JOB_DIR/tmp` and pass it with
+`--body-file`. Never interpolate the diagnosis inline into the `gh` command —
+log-sourced text may carry shell metacharacters.
+
+Find an existing open latch issue first:
+
+```bash
+existing=$(gh issue list --label dispatch:main-broken --state open --json number -q '.[0].number')
+```
+
+If `$existing` is non-empty, edit its body — a re-run during the same red
+episode updates rather than duplicates:
+
+```bash
+gh issue edit "$existing" --body-file <body-file>
+```
+
+Otherwise create one — a concise title naming the broken `<sha>`; `bug` +
+`priority` sort the fix to the top of the dispatch ladder; `dispatch:main-broken`
+is the latch label:
+
+```bash
+gh issue create --title "main broken at <sha>" --body-file <body-file> \
+  --label dispatch:main-broken --label bug --label priority
+```
+
+The `dispatch:main-broken` label may not exist yet. Apply-first /
+create-on-not-found, as `dispatch-complete-phase` does (lines 36-53): if the
+create or edit fails because the label does not exist (gh reports a "not found"
+error), create it once and retry. `bug` and `priority` already exist.
+
+```bash
+gh label create dispatch:main-broken --color BFD4F2 \
+  --description "dispatch workflow: origin/main HEAD CI is red (gate latch)"
+```
+
+All `gh` calls here need `dangerouslyDisableSandbox: true`.
+
+Once the issue exists it latches the gate so the queue flows again, and it is
+itself the priority fix item the normal ladder picks up (verify/ready). When
+`origin/main` goes green, `dispatch-select-tick` closes the issue, re-arming
+the gate for the next episode. The skill creates no worktree, branch, or PR —
+it files or updates the issue and stops.

--- a/.claude/skills/dispatch-diagnose-main/SKILL.md
+++ b/.claude/skills/dispatch-diagnose-main/SKILL.md
@@ -46,7 +46,12 @@ Both calls need `dangerouslyDisableSandbox: true`.
 Compose the likely cause from the logs and check-run details as the issue
 body. Record the broken HEAD `<sha>` as prose (e.g. `origin/main HEAD <sha>`);
 keep it a bare reference and never place a closing keyword next to a `#N`, so
-the body closes no issue.
+the body closes no issue. This applies to log-sourced text too: if a failing
+check, step, or test name carries a closing keyword followed by a `#N` (e.g. a
+test named `closes #5 regression`), GitHub would read it as a directive and
+auto-close that unrelated issue when this issue is opened — neutralize it
+(drop the `#`, or reword) before it reaches the body. See
+`.claude/rules/issue-references.md` for the full keyword set.
 
 Include only the failing check/step name and a high-level error category
 (e.g. "test assertion failed", "lint error", "type error"). Do not reproduce

--- a/.claude/skills/dispatch-diagnose-main/SKILL.md
+++ b/.claude/skills/dispatch-diagnose-main/SKILL.md
@@ -88,9 +88,11 @@ create or edit fails because the label does not exist (gh reports a "not found"
 error), create it once and retry. `bug` and `priority` already exist.
 
 ```bash
-gh label create dispatch:main-broken --color BFD4F2 \
+gh label create dispatch:main-broken \
   --description "dispatch workflow: origin/main HEAD CI is red (gate latch)"
 ```
+
+The `--color` flag is intentionally omitted — the dispatch-label color hex is single-sourced in `dispatch-complete-phase` and must not be duplicated here.
 
 All `gh` calls here need `dangerouslyDisableSandbox: true`.
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -110,12 +110,14 @@ source "$SCRIPT_DIR/lib.sh"
 source "$SCRIPT_DIR/lib-claude-agents.sh"
 QA_MODE=false
 HEALTH_ONLY=false
+MAIN_BROKEN_SHA_ONLY=false
 declare -A EXCLUDED=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --qa) QA_MODE=true; shift ;;
     --health-only) HEALTH_ONLY=true; shift ;;
+    --main-broken-sha) MAIN_BROKEN_SHA_ONLY=true; shift ;;
     --exclude)
       shift
       while [[ $# -gt 0 && "$1" =~ ^[0-9]+$ ]]; do
@@ -169,6 +171,22 @@ main_broken_sha() {
   if [[ "$cr_fail" -gt 0 || "$wf_fail" -gt 0 ]]; then
     echo "$sha"
   fi
+}
+
+# Latched broken-SHA: print origin/main's broken HEAD SHA only on FIRST detection
+# of a red episode — i.e. when no open dispatch:main-broken issue yet exists. Once
+# such an issue is open (the diagnose job filed it, #1085), the gate stands down so
+# the queue can flow while main is still red; the issue itself sorts to the top of
+# the ladder as the priority fix item. Pure gh reads, so the selector stays a pure
+# function of GitHub state. Green main → nothing (no gate).
+main_broken_latch() {
+  local sha open
+  sha=$(main_broken_sha)
+  [[ -z "$sha" ]] && return 0           # green → no gate
+  open=$(gh issue list --label "dispatch:main-broken" --state open \
+    --json number | jq 'length')
+  [[ "$open" -gt 0 ]] && return 0       # already latched → fall through
+  echo "$sha"
 }
 
 # Convert a duration string ("12h", "7d", "30m") to whole seconds. Units:
@@ -294,13 +312,21 @@ jit_scan() {
   echo "jit-reminder $winner"
 }
 
+# --main-broken-sha: print the raw (pre-latch) broken SHA and exit — exposes
+# main_broken_sha to dispatch-select-tick's latch re-arm step (#1085) without
+# duplicating the two-source CI aggregation. Empty when main is green.
+if [[ "$MAIN_BROKEN_SHA_ONLY" == "true" ]]; then
+  main_broken_sha
+  exit 0
+fi
+
 if [[ "$HEALTH_ONLY" == "true" ]]; then
   JIT_LINE=$(jit_scan)
   if [[ -n "$JIT_LINE" ]]; then
     echo "$JIT_LINE"
     exit 0
   fi
-  MAIN_BROKEN_SHA=$(main_broken_sha)
+  MAIN_BROKEN_SHA=$(main_broken_latch)
   if [[ -n "$MAIN_BROKEN_SHA" ]]; then
     echo "main-broken $MAIN_BROKEN_SHA"
   else
@@ -317,7 +343,7 @@ if [[ "$QA_MODE" == "false" ]]; then
     exit 0
   fi
 
-  MAIN_BROKEN_SHA=$(main_broken_sha)
+  MAIN_BROKEN_SHA=$(main_broken_latch)
   if [[ -n "$MAIN_BROKEN_SHA" ]]; then
     echo "main-broken $MAIN_BROKEN_SHA"
     exit 0

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Select the single highest-priority task from the queue.
-# Usage: dispatch-select-target [--qa | --health-only] [--exclude <n>...]
+# Usage: dispatch-select-target [--qa | --health-only | --main-broken-sha] [--exclude <n>...]
 #
 # --exclude <n>... names issue numbers the caller has already processed (the
 # fan-out loop's SEEN set, #1062); the selector never returns an excluded target

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -108,6 +108,24 @@ if [[ "$BRANCH" == "main" ]]; then
   fi
 fi
 
+# --- Step 1c: re-arm the main-broken latch when main has recovered -----------
+# A diagnosed red episode leaves an open dispatch:main-broken issue — the gate's
+# per-episode latch (#1085). Once origin/main goes green again, close it so the
+# next red episode re-fires the gate on first detection. Closing an issue is a
+# side effect, so it lives here in the lock-holding orchestrator, not in the pure
+# selector. The open-issue query is cheap and gates the extra CI read (via
+# dispatch-select-target --main-broken-sha) to the red/recovering window only;
+# this runs every tick — independent of the local branch — including a capped
+# tick, so recovery is observed even when no worker is spawned.
+OPEN_MB=$(gh issue list --label "dispatch:main-broken" --state open \
+  --json number -q '.[].number')
+if [[ -n "$OPEN_MB" && -z "$("$SCRIPT_DIR/dispatch-select-target" --main-broken-sha)" ]]; then
+  for n in $OPEN_MB; do
+    gh issue close "$n" \
+      --comment "origin/main is green again; closing the main-broken latch (re-arming the gate)." 1>&2 || true
+  done
+fi
+
 # --- Step 1b: run-scoped concurrency gate (autonomous no-arg queue path only) -
 # Runs ONLY on the autonomous no-arg queue path. The explicit-target run (a
 # positional <number> was given) and the `--manual` run (the bare human-typed

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -119,11 +119,19 @@ fi
 # tick, so recovery is observed even when no worker is spawned.
 OPEN_MB=$(gh issue list --label "dispatch:main-broken" --state open \
   --json number -q '.[].number')
-if [[ -n "$OPEN_MB" && -z "$("$SCRIPT_DIR/dispatch-select-target" --main-broken-sha)" ]]; then
-  for n in $OPEN_MB; do
-    gh issue close "$n" \
-      --comment "origin/main is green again; closing the main-broken latch (re-arming the gate)." 1>&2 || true
-  done
+if [[ -n "$OPEN_MB" ]]; then
+  # Use explicit exit-code capture: a failed --main-broken-sha would produce empty
+  # output, which -z would treat as "green" and incorrectly close the latch.
+  MB_SHA=""
+  if ! MB_SHA=$("$SCRIPT_DIR/dispatch-select-target" --main-broken-sha); then
+    MB_SHA="UNKNOWN"
+  fi
+  if [[ -z "$MB_SHA" ]]; then
+    for n in $OPEN_MB; do
+      gh issue close "$n" \
+        --comment "origin/main is green again; closing the main-broken latch (re-arming the gate)." 1>&2 || true
+    done
+  fi
 fi
 
 # --- Step 1b: run-scoped concurrency gate (autonomous no-arg queue path only) -

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -14825,6 +14825,32 @@ case "$*" in
 esac
 STUB
   chmod +x "$TMPDIR_TEST/bin/git"
+
+  # PATH-shimmed gh for the Step 1c latch re-arm (#1085). The open-latch query
+  # reads main-broken-open.txt (one issue number per line; absent → no open
+  # latch, the re-arm short-circuits). `issue close` is logged to
+  # gh-issue-close.log so a test can assert whether the latch was closed.
+  cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
+args="$*"
+case "$args" in
+  issue\ list\ *dispatch:main-broken*)
+    if [[ -f "$STUB_DIR/main-broken-open.txt" ]]; then
+      cat "$STUB_DIR/main-broken-open.txt"
+    fi
+    ;;
+  issue\ close\ *)
+    echo "$args" >> "$STUB_DIR/gh-issue-close.log"
+    ;;
+  *)
+    echo "gh stub (sel-tick): unknown invocation: $args" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/gh"
+
   export PATH="$TMPDIR_TEST/bin:$SAVED_PATH"
 }
 
@@ -14897,6 +14923,58 @@ assert_eq "main-broken: decision line" "main-broken abc1234" \
   "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "main-broken: lock released" "" \
   "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- Step 1c latch re-arm: green main + open latch issue → close (#1085) ------
+echo "Test: select-tick re-arm closes open latch issue when main is green"
+sel_tick_setup
+# Fake select-target: green for --main-broken-sha (prints nothing), else `empty`.
+cat > "$TMPDIR_TEST/dispatch-select-target" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "$1" == "--main-broken-sha" ]]; then exit 0; fi
+echo empty
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
+printf '99\n' > "$STUB_DIR/main-broken-open.txt"
+out=$(run_sel_tick)
+assert_eq "re-arm green+open: decision line" "empty" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "re-arm green+open: latch issue closed" "issue close 99 --comment origin/main is green again; closing the main-broken latch (re-arming the gate)." \
+  "$(cat "$STUB_DIR/gh-issue-close.log" 2>/dev/null || echo MISSING)"
+sel_tick_teardown
+
+# --- Step 1c latch re-arm: red main + open latch issue → NOT closed -----------
+echo "Test: select-tick re-arm leaves open latch issue while main is still red"
+sel_tick_setup
+# Fake select-target: red for --main-broken-sha (prints a sha), else `empty`.
+cat > "$TMPDIR_TEST/dispatch-select-target" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "$1" == "--main-broken-sha" ]]; then echo "redsha1"; exit 0; fi
+echo empty
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
+printf '99\n' > "$STUB_DIR/main-broken-open.txt"
+out=$(run_sel_tick)
+assert_eq "re-arm red+open: decision line" "empty" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "re-arm red+open: latch issue NOT closed" "absent" \
+  "$([[ -e "$STUB_DIR/gh-issue-close.log" ]] && echo present || echo absent)"
+sel_tick_teardown
+
+# --- Step 1c latch re-arm: green main + NO open latch issue → no-op -----------
+echo "Test: select-tick re-arm is a no-op when no latch issue is open"
+sel_tick_setup
+# Fake select-target green for --main-broken-sha; no main-broken-open.txt fixture
+# means the open-latch query returns empty, so the re-arm short-circuits before
+# the CI read.
+cat > "$TMPDIR_TEST/dispatch-select-target" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "$1" == "--main-broken-sha" ]]; then exit 0; fi
+echo empty
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
+out=$(run_sel_tick)
+assert_eq "re-arm green+no-issue: decision line" "empty" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "re-arm green+no-issue: no close attempted" "absent" \
+  "$([[ -e "$STUB_DIR/gh-issue-close.log" ]] && echo present || echo absent)"
 sel_tick_teardown
 
 # --- jit-reminder → passthrough + lock RELEASED (spawned as a bg job) --------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -171,6 +171,16 @@ case "$args" in
       echo "[]"
     fi
     ;;
+  "issue list --label dispatch:main-broken --state open --json number")
+    # main_broken_latch: the per-episode latch read (#1085). Default [] (no open
+    # latch issue → gate fires); a main-broken-issue-list.json fixture models an
+    # already-open latch issue (gate falls through).
+    if [[ -f "$STUB_DIR/main-broken-issue-list.json" ]]; then
+      cat "$STUB_DIR/main-broken-issue-list.json"
+    else
+      echo "[]"
+    fi
+    ;;
   "issue list --label dispatch:office-hours --state open --json number,createdAt")
     # office-hours-select-target: the office-hours queue (labeled open issues).
     if [[ -f "$STUB_DIR/oh-issue-list.json" ]]; then
@@ -1697,6 +1707,49 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "main failing workflow run → main-broken" "main-broken mainhead0" "$result"
 teardown
 
+# 23b. main red + an OPEN dispatch:main-broken latch issue → gate stands down,
+#      normal selection proceeds (#1085). Same red-main setup as test 22, but the
+#      latch issue is already open, so the queue flows instead of re-preempting.
+echo "Test: main red + open latch issue → falls through to normal selection"
+setup
+UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
+printf '{"check_runs":[{"status":"completed","conclusion":"failure"}]}' \
+  > "$STUB_DIR/main-check-runs.json"
+printf '[]' > "$STUB_DIR/main-run-list.json"
+printf '[{"number":99}]' > "$STUB_DIR/main-broken-issue-list.json"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "main red + open latch → normal selection (verify PR)" "pr 10 10-verify-me verify" "$result"
+teardown
+
+# 23c. --main-broken-sha flag prints the RAW broken SHA (pre-latch) and exits 0.
+#      Green main → empty; red main → the SHA, regardless of any latch issue.
+echo "Test: --main-broken-sha green → empty"
+setup
+printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
+printf '{"check_runs":[{"status":"completed","conclusion":"success"}]}' \
+  > "$STUB_DIR/main-check-runs.json"
+printf '[{"headSha":"mainhead0","conclusion":"success"}]' \
+  > "$STUB_DIR/main-run-list.json"
+if result=$("$TMPDIR_TEST/dispatch-select-target" --main-broken-sha); then rc=0; else rc=$?; fi
+assert_eq "--main-broken-sha green → empty" "" "$result"
+assert_eq "--main-broken-sha green → exit 0" "0" "$rc"
+teardown
+
+echo "Test: --main-broken-sha red → sha"
+setup
+printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
+printf '{"check_runs":[{"status":"completed","conclusion":"failure"}]}' \
+  > "$STUB_DIR/main-check-runs.json"
+printf '[]' > "$STUB_DIR/main-run-list.json"
+if result=$("$TMPDIR_TEST/dispatch-select-target" --main-broken-sha); then rc=0; else rc=$?; fi
+assert_eq "--main-broken-sha red → mainhead0" "mainhead0" "$result"
+assert_eq "--main-broken-sha red → exit 0" "0" "$rc"
+teardown
+
 # 24. main in-progress checks → gate not tripped, normal selection.
 echo "Test: main in-progress checks → not tripped"
 setup
@@ -1779,6 +1832,25 @@ printf '[]' > "$STUB_DIR/main-run-list.json"
 if result=$("$TMPDIR_TEST/dispatch-select-target" --health-only); then rc=0; else rc=$?; fi
 assert_eq "--health-only main red → main-broken mainhead0" "main-broken mainhead0" "$result"
 assert_eq "--health-only main red → exit 0" "0" "$rc"
+teardown
+
+# 27b-latch. --health-only, main red + an OPEN dispatch:main-broken latch issue →
+#      "ok" (the latch stands the gate down so the heartbeat reseed keeps the chain
+#      processing other issues, #1085).
+echo "Test: --health-only + main red + open latch issue → ok"
+setup
+echo '[]' > "$STUB_DIR/pr-list-union.json"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf 'main' > "$STUB_DIR/current-branch.txt"
+printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
+printf '{"check_runs":[{"status":"completed","conclusion":"failure"}]}' \
+  > "$STUB_DIR/main-check-runs.json"
+printf '[]' > "$STUB_DIR/main-run-list.json"
+printf '[{"number":99}]' > "$STUB_DIR/main-broken-issue-list.json"
+if result=$("$TMPDIR_TEST/dispatch-select-target" --health-only); then rc=0; else rc=$?; fi
+assert_eq "--health-only main red + open latch → ok" "ok" "$result"
+assert_eq "--health-only main red + open latch → exit 0" "0" "$rc"
 teardown
 
 # 27c. --health-only + <N>-* current branch + red main → main-broken (no bypass).


### PR DESCRIPTION
Closes #1085

## What

The `main-broken` gate in `dispatch-select-target` was a persistent block, not a one-shot: a pure read of `origin/main`'s HEAD CI re-emitted `main-broken <sha>` on every tick while main stayed red, re-preempting the whole dispatch queue on a diagnosis that already happened. This adds a durable per-episode latch so diagnosing main preempts on first detection only, then stands down while the queue flows.

The latch is a GitHub artifact — one open `dispatch:main-broken` issue — so selection stays a pure function of GitHub state with no drift-prone side file, and the issue doubles as a high-priority, dispatchable fix item.

## Units

1. **`dispatch-select-target`** — new `main_broken_latch()` helper emits the broken SHA only when main is red AND no open `dispatch:main-broken` issue exists; red+open falls through to normal selection (`--health-only` returns `ok`). Wired into both gate sites. New `--main-broken-sha` flag prints the raw pre-latch SHA for the tick re-arm.
2. **`dispatch-select-tick`** — new Step 1c re-arms the latch: when `origin/main` is green again and a `dispatch:main-broken` issue is still open, it closes the issue (a side effect, so it lives in the lock-holding orchestrator). The cheap open-issue query gates the extra CI read to the red/recovering window.
3. **`dispatch-diagnose-main/SKILL.md`** — the bg job now files its redacted diagnosis as a find-or-create `dispatch:main-broken` issue (labels `bug` + `priority` so the fix sorts to the top of the ladder), instead of leaving it only in the transcript. Label created on first use via the apply-first / create-on-not-found idiom.

## Tests

`test-dispatch-scripts.sh` covers the latch dispositions in both default and `--health-only` modes (gate fires with no open issue, falls through when one is open), the `--main-broken-sha` flag, and the tick re-arm (green+open closes, red+open leaves, green+no-issue no-op). Full suite: 1566/1566 passing.