### PR TITLE
dispatch: dispatch-open-pr — scripted draft-PR creation with close-set verification

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-open-pr
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-open-pr
@@ -154,7 +154,10 @@ if [[ -n "$CLOSES_RAW" ]]; then
   # Normalize: strip '#', split on whitespace and commas.
   normalized="${CLOSES_RAW//,/ }"
   normalized="${normalized//\#/}"
-  for entry in $normalized; do
+  # Use read -ra to split without glob expansion (unquoted $var expansion would
+  # expand shell globs like '*' to filenames in the current directory).
+  read -ra _closes_entries <<< "$normalized"
+  for entry in "${_closes_entries[@]}"; do
     if [[ ! "$entry" =~ ^[0-9]+$ ]]; then
       echo "dispatch-open-pr: --closes entry must be numeric: $entry" >&2
       usage
@@ -253,7 +256,7 @@ while :; do
   # contains #E, so a whole-body substitution targeting #E is safe.
   while IFS= read -r E; do
     [[ -z "$E" ]] && continue
-    perl -i -pe 's/(?:'"$KEYWORD_RE"')[ \t]*:?[ \t]*(?=#\Q'"$E"'\E\b)//gi' "$BODY_FILE"
+    perl -i -pe 's/\b(?:'"$KEYWORD_RE"')[ \t]*:?[ \t]*(?=#\Q'"$E"'\E\b)//gi' "$BODY_FILE"
   done <<< "$EXTRA"
 
   gh pr edit "$PR_NUM" --body-file "$BODY_FILE" >/dev/null

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-open-pr
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-open-pr
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# dispatch-open-pr — create a draft PR with a verified close set.
+#
+# Usage:
+#   dispatch-open-pr <primary-issue> --title <title> [--closes "<N ...>"] [--body-file <path>]
+#
+# Creates a draft PR whose body opens with one `Closes #N` line per intended
+# close, then verifies — via gh's parsed closingIssuesReferences — that the PR
+# closes EXACTLY the intended set. This removes the per-run reconstruction of
+# the `gh pr create` + close-set-verify loop from /plan-implement Step 3, which
+# runs in a skill-less post-clear build session.
+#
+# Arguments:
+#   <primary-issue>     REQUIRED positional, numeric. Always first in the close
+#                       set.
+#   --title <t>         REQUIRED. The PR title.
+#   --closes "<N ...>"  OPTIONAL. Additional issues to close. Whitespace- or
+#                       comma-separated, each with an optional leading `#`.
+#                       Normalized, validated numeric, unioned with the primary,
+#                       deduped, primary-first order preserved.
+#   --body-file <path>  OPTIONAL descriptive prose. If absent, prose is read
+#                       from STDIN when stdin is not a TTY; otherwise empty.
+#
+# Behavior:
+#   1. The body is composed as one `Closes #N` line per intended entry (in
+#      order), then — if prose is non-empty — a blank line and the prose.
+#   2. The draft PR is created. gh's parsed closingIssuesReferences is compared
+#      to the intended set.
+#      - Exact match → the PR number is echoed and the script exits 0.
+#      - EXTRA closed numbers (a stray closing keyword in prose) → the offending
+#        keyword before `#E` is stripped from the body, the body is re-applied
+#        via `gh pr edit --body-file`, and the PR is re-verified. Bounded to two
+#        correction passes; an extra surviving past that exits non-zero.
+#      - MISSING numbers (intended but not closed) → exit non-zero immediately
+#        with a diagnostic naming the missing number(s). Per
+#        .claude/rules/code-style.md, this signals an unexpected condition and
+#        fails loudly rather than retrying.
+#
+# Close-set verification honors .claude/rules/issue-references.md: only the
+# deliberate `Closes #N` lines may carry a closing keyword; a closing keyword
+# adjacent to any other `#N` in the prose fires GitHub's parser and is corrected
+# (or reported) here.
+#
+# Output: the ONLY stdout output, ever, is the bare PR number on success. All
+# diagnostics go to stderr.
+#
+# Requires dangerouslyDisableSandbox: true — this script calls `gh`, whose TLS
+# validation the sandbox blocks. See .claude/rules/sandbox.md.
+#
+# Exit codes:
+#   0   PR created and close set verified; PR number on stdout.
+#   2   bad arguments.
+#   1   close-set verification failed (extra survived correction, or missing).
+set -euo pipefail
+
+usage() {
+  echo "usage: dispatch-open-pr <primary-issue> --title <title> [--closes \"<N ...>\"] [--body-file <path>]" >&2
+}
+
+# The closing keywords GitHub recognizes (.claude/rules/issue-references.md).
+# Used both for stripping a stray keyword before an extra number.
+KEYWORD_RE='close[sd]?|fix(?:e[sd])?|resolve[sd]?'
+
+# --- argument parsing ---------------------------------------------------------
+
+PRIMARY=""
+TITLE=""
+TITLE_SET=0
+CLOSES_RAW=""
+BODY_FILE_ARG=""
+BODY_FILE_SET=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)
+      if [[ $# -lt 2 ]]; then
+        echo "dispatch-open-pr: --title requires a value" >&2
+        usage
+        exit 2
+      fi
+      TITLE="$2"
+      TITLE_SET=1
+      shift 2
+      ;;
+    --closes)
+      if [[ $# -lt 2 ]]; then
+        echo "dispatch-open-pr: --closes requires a value" >&2
+        usage
+        exit 2
+      fi
+      CLOSES_RAW="$2"
+      shift 2
+      ;;
+    --body-file)
+      if [[ $# -lt 2 ]]; then
+        echo "dispatch-open-pr: --body-file requires a value" >&2
+        usage
+        exit 2
+      fi
+      BODY_FILE_ARG="$2"
+      BODY_FILE_SET=1
+      shift 2
+      ;;
+    -*)
+      echo "dispatch-open-pr: unknown flag: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      if [[ -n "$PRIMARY" ]]; then
+        echo "dispatch-open-pr: unexpected extra argument: $1" >&2
+        usage
+        exit 2
+      fi
+      PRIMARY="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$PRIMARY" ]]; then
+  echo "dispatch-open-pr: missing required <primary-issue>" >&2
+  usage
+  exit 2
+fi
+if [[ ! "$PRIMARY" =~ ^[0-9]+$ ]]; then
+  echo "dispatch-open-pr: primary issue must be numeric: $PRIMARY" >&2
+  usage
+  exit 2
+fi
+if [[ "$TITLE_SET" -ne 1 ]]; then
+  echo "dispatch-open-pr: missing required --title" >&2
+  usage
+  exit 2
+fi
+if [[ "$BODY_FILE_SET" -eq 1 && ! -f "$BODY_FILE_ARG" ]]; then
+  echo "dispatch-open-pr: --body-file path does not exist: $BODY_FILE_ARG" >&2
+  usage
+  exit 2
+fi
+
+# --- build the intended close set (primary-first, deduped) --------------------
+
+declare -a INTENDED=("$PRIMARY")
+intended_has() {
+  local n
+  for n in "${INTENDED[@]}"; do
+    [[ "$n" == "$1" ]] && return 0
+  done
+  return 1
+}
+
+if [[ -n "$CLOSES_RAW" ]]; then
+  # Normalize: strip '#', split on whitespace and commas.
+  normalized="${CLOSES_RAW//,/ }"
+  normalized="${normalized//\#/}"
+  for entry in $normalized; do
+    if [[ ! "$entry" =~ ^[0-9]+$ ]]; then
+      echo "dispatch-open-pr: --closes entry must be numeric: $entry" >&2
+      usage
+      exit 2
+    fi
+    if ! intended_has "$entry"; then
+      INTENDED+=("$entry")
+    fi
+  done
+fi
+
+# --- read prose ---------------------------------------------------------------
+
+PROSE=""
+if [[ "$BODY_FILE_SET" -eq 1 ]]; then
+  PROSE="$(cat "$BODY_FILE_ARG")"
+elif [[ ! -t 0 ]]; then
+  PROSE="$(cat)"
+fi
+
+# --- compose the body ---------------------------------------------------------
+
+BODY_FILE="$(mktemp)"
+trap 'rm -f "$BODY_FILE"' EXIT
+
+{
+  for n in "${INTENDED[@]}"; do
+    echo "Closes #$n"
+  done
+  if [[ -n "$PROSE" ]]; then
+    echo ""
+    printf '%s\n' "$PROSE"
+  fi
+} > "$BODY_FILE"
+
+# --- create the draft PR ------------------------------------------------------
+
+URL="$(gh pr create --draft --title "$TITLE" --body-file "$BODY_FILE")"
+PR_NUM="$(basename "$URL")"
+if [[ ! "$PR_NUM" =~ ^[0-9]+$ ]]; then
+  echo "dispatch-open-pr: could not parse PR number from gh output: $URL" >&2
+  exit 1
+fi
+
+# --- intended set, sorted-unique, for comparison ------------------------------
+
+INTENDED_SORTED="$(printf '%s\n' "${INTENDED[@]}" | sort -n -u)"
+
+# --- verify / correct loop (bounded to 2 correction passes) -------------------
+
+MAX_PASSES=2
+pass=0
+while :; do
+  PARSED="$(gh pr view "$PR_NUM" --json closingIssuesReferences \
+    -q '.closingIssuesReferences[].number' | sort -n -u)"
+
+  if [[ "$PARSED" == "$INTENDED_SORTED" ]]; then
+    echo "$PR_NUM"
+    exit 0
+  fi
+
+  # Compute set differences by membership (not `comm`, which requires
+  # lexically-sorted input while ours is numeric-sorted).
+  # EXTRA: numbers parsed but not intended. MISSING: intended but not parsed.
+  EXTRA=""
+  while IFS= read -r p; do
+    [[ "$p" =~ ^[0-9]+$ ]] || continue
+    if ! intended_has "$p"; then
+      EXTRA+="$p"$'\n'
+    fi
+  done <<< "$PARSED"
+  EXTRA="${EXTRA%$'\n'}"
+
+  MISSING=""
+  for n in "${INTENDED[@]}"; do
+    if ! grep -qxF "$n" <<< "$PARSED"; then
+      MISSING+="$n"$'\n'
+    fi
+  done
+  MISSING="${MISSING%$'\n'}"
+
+  if [[ -n "$MISSING" ]]; then
+    echo "dispatch-open-pr: PR #$PR_NUM is missing intended close(s): $(echo "$MISSING" | tr '\n' ' ')" >&2
+    echo "dispatch-open-pr: canonical 'Closes' lines should always parse; aborting." >&2
+    exit 1
+  fi
+
+  # Only extras remain. If we've exhausted our correction budget, fail.
+  if [[ "$pass" -ge "$MAX_PASSES" ]]; then
+    echo "dispatch-open-pr: PR #$PR_NUM still closes unintended issue(s) after $MAX_PASSES correction pass(es): $(echo "$EXTRA" | tr '\n' ' ')" >&2
+    exit 1
+  fi
+
+  # Strip the stray closing keyword preceding each extra number, throughout the
+  # body. Since E is not in INTENDED, the canonical `Closes #N` block never
+  # contains #E, so a whole-body substitution targeting #E is safe.
+  while IFS= read -r E; do
+    [[ -z "$E" ]] && continue
+    perl -i -pe 's/(?:'"$KEYWORD_RE"')[ \t]*:?[ \t]*(?=#\Q'"$E"'\E\b)//gi' "$BODY_FILE"
+  done <<< "$EXTRA"
+
+  gh pr edit "$PR_NUM" --body-file "$BODY_FILE" >/dev/null
+  pass=$((pass + 1))
+done

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -17674,6 +17674,7 @@ assert_eq "open-pr: stray fixes #999 → stdout PR number" "1500" "$out"
 assert_eq "open-pr: stray fixes #999 → rc 0" "0" "$rc"
 assert_eq "open-pr: stray fixes #999 → an edit occurred" "1" "$([[ -s "$TMPDIR_TEST/edit-calls.log" ]] && echo 1 || echo 0)"
 assert_eq "open-pr: stray fixes #999 → final close set is just 1119" "1119" "$(cat "$TMPDIR_TEST/close-set.txt")"
+assert_eq "open-pr: stray fixes #999 → keyword stripped from corrected body" "0" "$(grep -cE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[ \t]*:?[ \t]*#999' "$TMPDIR_TEST/last-body.txt" || true)"
 open_pr_teardown
 
 # CASE 4 — force-extra=777: an extra the script cannot strip (no keyword in body
@@ -17710,6 +17711,18 @@ out=$("$TMPDIR_TEST/scripts/dispatch-open-pr" --title t 2>/dev/null) && rc=0 || 
 assert_eq "open-pr: missing primary → rc non-zero" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
 out=$("$TMPDIR_TEST/scripts/dispatch-open-pr" abc --title t 2>/dev/null) && rc=0 || rc=$?
 assert_eq "open-pr: non-numeric primary → rc non-zero" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+out=$("$TMPDIR_TEST/scripts/dispatch-open-pr" 1119 2>/dev/null) && rc=0 || rc=$?
+assert_eq "open-pr: missing --title → rc non-zero" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+open_pr_teardown
+
+# CASE 8 — primary repeated in --closes is deduped to a single Closes line.
+open_pr_setup
+echo "Body prose." > "$TMPDIR_TEST/body.txt"
+out=$("$TMPDIR_TEST/scripts/dispatch-open-pr" 1119 --title "t" --closes "1119 1120" --body-file "$TMPDIR_TEST/body.txt" 2>/dev/null) && rc=0 || rc=$?
+assert_eq "open-pr: dedup primary → stdout PR number" "1500" "$out"
+assert_eq "open-pr: dedup primary → rc 0" "0" "$rc"
+assert_eq "open-pr: dedup primary → exactly one Closes #1119 line" "1" "$(grep -cxF 'Closes #1119' "$TMPDIR_TEST/last-body.txt")"
+assert_eq "open-pr: dedup primary → close set is 1119 1120" "$(printf '1119\n1120')" "$(cat "$TMPDIR_TEST/close-set.txt")"
 open_pr_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -17553,6 +17553,166 @@ assert_eq "followup-exists: codeql alert-number prefix collision (#5 vs #50) →
 followup_exists_teardown
 
 # ============================================================================
+# === dispatch-open-pr ===
+# ============================================================================
+
+echo "Test: dispatch-open-pr"
+
+# Dedicated setup/teardown modeled on followup_exists_setup/teardown. Builds a
+# temp tree with the script under test and a gh stub on PATH. The gh stub
+# EMULATES GitHub's close parser: it reads the body passed to `pr create` /
+# `pr edit`, extracts every `<keyword> #N`, and writes the resulting close set
+# to $TREE/close-set.txt — which `pr view` then echoes back. The force-extra /
+# force-drop knobs override the parsed set deterministically.
+open_pr_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/bin"
+
+  cp "$SCRIPT_DIR/dispatch-open-pr" "$TMPDIR_TEST/scripts/dispatch-open-pr"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-open-pr"
+
+  cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+# gh stub emulating GitHub's close parser for dispatch-open-pr tests.
+TREE="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Locate the value following --body-file in the argument list.
+body_file=""
+prev=""
+for a in "$@"; do
+  if [[ "$prev" == "--body-file" ]]; then
+    body_file="$a"
+  fi
+  prev="$a"
+done
+
+# Parse the close set from a body file the same way GitHub does, then apply the
+# force-extra / force-drop knobs and write the sorted-unique result.
+write_close_set() {
+  local bf="$1"
+  local set=""
+  if [[ -n "$bf" && -f "$bf" ]]; then
+    # Extract "<keyword> [:] #N" → bare N, case-insensitive.
+    set="$(grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[ \t]*:?[ \t]*#[0-9]+' "$bf" \
+      | grep -oE '#[0-9]+' | tr -d '#' || true)"
+  fi
+  # force-extra: add a number.
+  if [[ -f "$TREE/force-extra" ]]; then
+    set="$set
+$(cat "$TREE/force-extra")"
+  fi
+  # force-drop: remove a number.
+  if [[ -f "$TREE/force-drop" ]]; then
+    local drop
+    drop="$(cat "$TREE/force-drop")"
+    set="$(printf '%s\n' "$set" | grep -vxF "$drop" || true)"
+  fi
+  printf '%s\n' "$set" | grep -E '^[0-9]+$' | sort -n -u > "$TREE/close-set.txt" || true
+}
+
+case "$1 $2" in
+  "pr create")
+    cp "$body_file" "$TREE/last-body.txt"
+    write_close_set "$body_file"
+    echo "https://github.com/natb1/commons.systems/pull/1500"
+    ;;
+  "pr edit")
+    cp "$body_file" "$TREE/last-body.txt"
+    write_close_set "$body_file"
+    echo "edit" >> "$TREE/edit-calls.log"
+    echo "https://github.com/natb1/commons.systems/pull/1500"
+    ;;
+  "pr view")
+    if [[ -f "$TREE/close-set.txt" ]]; then
+      cat "$TREE/close-set.txt"
+    fi
+    ;;
+  *)
+    echo "gh stub: unknown invocation: $*" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/gh"
+
+  SAVED_PATH_OP="$PATH"
+  export PATH="$TMPDIR_TEST/bin:$PATH"
+}
+
+open_pr_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  export PATH="$SAVED_PATH_OP"
+}
+
+# CASE 1 — clean single close: prose-only body file, no --closes.
+open_pr_setup
+echo "Some descriptive prose." > "$TMPDIR_TEST/body.txt"
+out=$("$TMPDIR_TEST/scripts/dispatch-open-pr" 1119 --title "t" --body-file "$TMPDIR_TEST/body.txt" 2>/dev/null) && rc=0 || rc=$?
+assert_eq "open-pr: clean single close → stdout PR number" "1500" "$out"
+assert_eq "open-pr: clean single close → rc 0" "0" "$rc"
+open_pr_teardown
+
+# CASE 2 — multi-close + normalization ("1120, #1121").
+open_pr_setup
+echo "Body prose." > "$TMPDIR_TEST/body.txt"
+out=$("$TMPDIR_TEST/scripts/dispatch-open-pr" 1119 --title "t" --closes "1120, #1121" --body-file "$TMPDIR_TEST/body.txt" 2>/dev/null) && rc=0 || rc=$?
+assert_eq "open-pr: multi-close → stdout PR number" "1500" "$out"
+assert_eq "open-pr: multi-close → rc 0" "0" "$rc"
+close_set="$(cat "$TMPDIR_TEST/close-set.txt")"
+assert_eq "open-pr: multi-close → close set is the three numbers" "$(printf '1119\n1120\n1121')" "$close_set"
+assert_eq "open-pr: multi-close → body has Closes #1119" "1" "$(grep -cxF 'Closes #1119' "$TMPDIR_TEST/last-body.txt")"
+assert_eq "open-pr: multi-close → body has Closes #1120" "1" "$(grep -cxF 'Closes #1120' "$TMPDIR_TEST/last-body.txt")"
+assert_eq "open-pr: multi-close → body has Closes #1121" "1" "$(grep -cxF 'Closes #1121' "$TMPDIR_TEST/last-body.txt")"
+open_pr_teardown
+
+# CASE 3 — stray "fixes #999" in prose → corrected via edit.
+open_pr_setup
+printf 'This change also fixes #999 in passing.\n' > "$TMPDIR_TEST/body.txt"
+out=$("$TMPDIR_TEST/scripts/dispatch-open-pr" 1119 --title "t" --body-file "$TMPDIR_TEST/body.txt" 2>/dev/null) && rc=0 || rc=$?
+assert_eq "open-pr: stray fixes #999 → stdout PR number" "1500" "$out"
+assert_eq "open-pr: stray fixes #999 → rc 0" "0" "$rc"
+assert_eq "open-pr: stray fixes #999 → an edit occurred" "1" "$([[ -s "$TMPDIR_TEST/edit-calls.log" ]] && echo 1 || echo 0)"
+assert_eq "open-pr: stray fixes #999 → final close set is just 1119" "1119" "$(cat "$TMPDIR_TEST/close-set.txt")"
+open_pr_teardown
+
+# CASE 4 — force-extra=777: an extra the script cannot strip (no keyword in body
+# produces it) → correction fails, rc non-zero, stderr names 777.
+open_pr_setup
+echo "Body prose." > "$TMPDIR_TEST/body.txt"
+echo 777 > "$TMPDIR_TEST/force-extra"
+out=$("$TMPDIR_TEST/scripts/dispatch-open-pr" 1119 --title "t" --body-file "$TMPDIR_TEST/body.txt" 2>"$TMPDIR_TEST/err.txt") && rc=0 || rc=$?
+assert_eq "open-pr: unresolvable extra → rc non-zero" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "open-pr: unresolvable extra → stderr names 777" "1" "$(grep -c '777' "$TMPDIR_TEST/err.txt")"
+open_pr_teardown
+
+# CASE 5 — force-drop=1119: an intended number missing → rc non-zero, stderr
+# names 1119.
+open_pr_setup
+echo "Body prose." > "$TMPDIR_TEST/body.txt"
+echo 1119 > "$TMPDIR_TEST/force-drop"
+out=$("$TMPDIR_TEST/scripts/dispatch-open-pr" 1119 --title "t" --body-file "$TMPDIR_TEST/body.txt" 2>"$TMPDIR_TEST/err.txt") && rc=0 || rc=$?
+assert_eq "open-pr: missing intended → rc non-zero" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "open-pr: missing intended → stderr names 1119" "1" "$(grep -c '1119' "$TMPDIR_TEST/err.txt")"
+open_pr_teardown
+
+# CASE 6 — prose via stdin (no --body-file).
+open_pr_setup
+out=$(echo "some prose" | "$TMPDIR_TEST/scripts/dispatch-open-pr" 1119 --title t 2>/dev/null) && rc=0 || rc=$?
+assert_eq "open-pr: stdin prose → stdout PR number" "1500" "$out"
+assert_eq "open-pr: stdin prose → rc 0" "0" "$rc"
+assert_eq "open-pr: stdin prose → close set is 1119" "1119" "$(cat "$TMPDIR_TEST/close-set.txt")"
+open_pr_teardown
+
+# CASE 7 — usage errors.
+open_pr_setup
+out=$("$TMPDIR_TEST/scripts/dispatch-open-pr" --title t 2>/dev/null) && rc=0 || rc=$?
+assert_eq "open-pr: missing primary → rc non-zero" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+out=$("$TMPDIR_TEST/scripts/dispatch-open-pr" abc --title t 2>/dev/null) && rc=0 || rc=$?
+assert_eq "open-pr: non-numeric primary → rc non-zero" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+open_pr_teardown
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/plan-implement/SKILL.md
+++ b/.claude/skills/plan-implement/SKILL.md
@@ -56,9 +56,9 @@ and recovers from merge / pre-commit / push errors. This is a normal in-session 
 
 ### 3. Open the draft PR
 
-After every unit is committed and pushed, open the draft PR with
-`dispatch-open-pr` (use `dangerouslyDisableSandbox: true` — the script calls
-`gh`, which needs network):
+After every unit is committed and pushed, write the PR body prose to
+`tmp/pr-body.md`, then open the draft PR with `dispatch-open-pr` (use
+`dangerouslyDisableSandbox: true` — the script calls `gh`, which needs network):
 
 ```bash
 PR_NUM=$(.claude/skills/dispatch-propagate/scripts/dispatch-open-pr \

--- a/.claude/skills/plan-implement/SKILL.md
+++ b/.claude/skills/plan-implement/SKILL.md
@@ -56,46 +56,33 @@ and recovers from merge / pre-commit / push errors. This is a normal in-session 
 
 ### 3. Open the draft PR
 
-After every unit is committed and pushed, create the draft PR (use
-`dangerouslyDisableSandbox: true` — `gh` needs network):
+After every unit is committed and pushed, open the draft PR with
+`dispatch-open-pr` (use `dangerouslyDisableSandbox: true` — the script calls
+`gh`, which needs network):
 
 ```bash
-URL=$(gh pr create --draft --title "<short summary>" --body "$(cat <<'EOF'
-Closes #<primary-issue>
-Closes #<sub-issue-or-blocker>   # repeat for each implemented issue
-EOF
-)")
-PR_NUM=$(basename "$URL")
+PR_NUM=$(.claude/skills/dispatch-propagate/scripts/dispatch-open-pr \
+  <primary-issue> \
+  --title "<short summary>" \
+  --closes "<sub-issue-or-blocker> ..." \
+  --body-file tmp/pr-body.md)
 ```
 
-The body has one `Closes #N` line per issue implemented in this PR — the primary
-issue plus any implemented sub-issues or blockers. This draft PR is the
-implement→verify transition marker.
+`<primary-issue>` is the issue this PR primarily implements; `--closes` lists
+any additional implemented sub-issues or blockers (whitespace- or
+comma-separated, with or without a leading `#`). The script writes one
+`Closes #N` line per issue, appends the prose from `--body-file` (omit the flag
+to read prose from stdin), and echoes the created PR number — the only thing it
+prints on stdout. This draft PR is the implement→verify transition marker.
 
-Then verify GitHub parsed exactly the intended close set — narrative prose in
-the body can carry a stray closing keyword that GitHub reads as an extra close
-directive (see `.claude/rules/issue-references.md`). Compare the parsed set to
-the `Closes #N` lines you deliberately wrote (`gh` still needs
-`dangerouslyDisableSandbox: true`):
-
-```bash
-gh pr view "$PR_NUM" --json closingIssuesReferences \
-  -q '.closingIssuesReferences[].number' | sort -n
-```
-
-If the parsed set does not exactly match the intended set, fix it and re-run
-until it does:
-
-- **Extra number (parsed but not intended):** the body contains a stray
-  `<keyword> #N` in narrative prose. Find it, rewrite it to a bare `#N`
-  (drop the preceding closing keyword — e.g. `Closes #905` → `#905`,
-  `resolved #905` → `#905`). Write the corrected body to a temp file under
-  `tmp/` and apply it with `gh pr edit "$PR_NUM" --body-file tmp/<file>` —
-  never interpolate the body inline into the command, since it may carry
-  shell metacharacters from issue-sourced text.
-- **Missing number (intended but not parsed):** a `Closes #N` line was not
-  recognized — check that it appears on its own line, outside any code block,
-  with no leading spaces. Re-edit the body to restore the canonical form.
+The script then verifies GitHub parsed exactly the intended close set, per
+`.claude/rules/issue-references.md`: narrative prose can carry a stray closing
+keyword that GitHub reads as an extra close directive. On an extra, the script
+strips the stray keyword and re-applies the body (bounded retries); on a number
+intended-but-missing, or an extra it cannot resolve, it exits non-zero with a
+diagnostic naming the offending number. If it exits non-zero, read the
+diagnostic and fix the body or `--closes` set rather than opening the PR by
+hand.
 
 ### 4. Check for deviation, then write the marker (or skip it), then stop
 


### PR DESCRIPTION
Closes #1119

Adds `.claude/skills/dispatch-propagate/scripts/dispatch-open-pr`: a script that
creates a draft PR with a deterministic `Closes #N` block and verifies, against
GitHub's parsed `closingIssuesReferences`, that the PR closes exactly the
intended set — auto-correcting a stray closing keyword in prose (bounded
retries) or failing loudly with a diagnostic naming the offending number.

This moves the `gh pr create` + close-set-verify loop out of `/plan-implement`
Step 3, which runs in the skill-less post-clear build session where the model
otherwise reconstructs the incantations from memory each run.

- New executable `dispatch-open-pr` mirroring the conventions of sibling
  dispatch scripts; only stdout is the bare PR number.
- `test-dispatch-scripts.sh`: a new `open-pr` section (21 assertions) with a gh
  stub emulating GitHub's close parser plus force-extra / force-drop knobs.
- `/plan-implement` Step 3 rewired to invoke the script.

Sub-issue 1 of epic #1118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)