### PR TITLE
budget-etl: enforce JournalLeg and Account invariants at serialization (#800)

### DIFF
--- a/budget-etl/internal/export/export.go
+++ b/budget-etl/internal/export/export.go
@@ -335,12 +335,18 @@ func ReadFile(path, password string) (Output, error) {
 	if out.Transactions == nil {
 		return Output{}, fmt.Errorf("parsing %s: missing required field 'transactions'", path)
 	}
+	// Note: ReadFile intentionally does not call out.Validate(). Validation is
+	// enforced at the serialization boundary (WriteFile) so that a file written
+	// by an older ETL version still loads; refusing to read it would strand the
+	// user with no migration path. Callers that re-emit a read Output go back
+	// through WriteFile, which re-validates before writing.
 	return out, nil
 }
 
 // Validate checks the double-entry invariants on the journal legs and accounts
 // before serialization, mirroring the TypeScript upload-path validation so the
-// two halves stay in lockstep.
+// two halves stay in lockstep. WriteFile calls Validate before serializing;
+// callers that only need the check can call Validate directly.
 func (o Output) Validate() error {
 	for i, l := range o.JournalLegs {
 		if err := l.Validate(); err != nil {

--- a/budget-etl/internal/export/export.go
+++ b/budget-etl/internal/export/export.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"time"
@@ -160,14 +161,46 @@ type Transaction struct {
 	JournalEntryID        *string `json:"journalEntryId"`
 }
 
+// AccountType is the kind of a financial account. Mirrors the TypeScript
+// ACCOUNT_TYPES enum in budget/src/schema/enums.ts.
+type AccountType string
+
+const (
+	AccountTypeAsset     AccountType = "asset"
+	AccountTypeLiability AccountType = "liability"
+	AccountTypeEquity    AccountType = "equity"
+	AccountTypeIncome    AccountType = "income"
+	AccountTypeExpense   AccountType = "expense"
+)
+
+var validAccountTypes = map[AccountType]bool{
+	AccountTypeAsset:     true,
+	AccountTypeLiability: true,
+	AccountTypeEquity:    true,
+	AccountTypeIncome:    true,
+	AccountTypeExpense:   true,
+}
+
+// Valid reports whether t is one of the recognized account types.
+func (t AccountType) Valid() bool { return validAccountTypes[t] }
+
 // Account is a financial account record in the JSON output.
 type Account struct {
-	ID                 string   `json:"id"`
-	Institution        string   `json:"institution"`
-	Account            string   `json:"account"`
-	AccountType        string   `json:"accountType"`
-	OpeningBalance     *float64 `json:"openingBalance"`
-	OpeningBalanceDate *string  `json:"openingBalanceDate"`
+	ID                 string      `json:"id"`
+	Institution        string      `json:"institution"`
+	Account            string      `json:"account"`
+	AccountType        AccountType `json:"accountType"`
+	OpeningBalance     *float64    `json:"openingBalance"`
+	OpeningBalanceDate *string     `json:"openingBalanceDate"`
+}
+
+// Validate checks the account-type enum invariant, mirroring the TypeScript
+// parseRawAccount enum check (requireUploadEnum against ACCOUNT_TYPES).
+func (a Account) Validate() error {
+	if !a.AccountType.Valid() {
+		return fmt.Errorf("account type %q is not one of asset, liability, equity, income, expense", a.AccountType)
+	}
+	return nil
 }
 
 // JournalEntry is a double-entry journal entry in the JSON output.
@@ -191,6 +224,23 @@ type JournalLeg struct {
 	ReconciledAt      *string `json:"reconciledAt"`
 	ReconciledEventID *string `json:"reconciledEventId"`
 	StatementItemID   *string `json:"statementItemId"`
+}
+
+// Validate checks the debit/credit invariants, mirroring the TypeScript
+// parseRawJournalLeg rules: both debit and credit must be finite,
+// non-negative numbers, and they cannot both be positive simultaneously.
+// Both-zero is allowed.
+func (l JournalLeg) Validate() error {
+	if math.IsNaN(l.Debit) || math.IsInf(l.Debit, 0) || l.Debit < 0 {
+		return fmt.Errorf("journal leg debit must be a non-negative finite number (got %v)", l.Debit)
+	}
+	if math.IsNaN(l.Credit) || math.IsInf(l.Credit, 0) || l.Credit < 0 {
+		return fmt.Errorf("journal leg credit must be a non-negative finite number (got %v)", l.Credit)
+	}
+	if l.Debit > 0 && l.Credit > 0 {
+		return fmt.Errorf("journal leg cannot have both a debit and a credit (debit=%v, credit=%v)", l.Debit, l.Credit)
+	}
+	return nil
 }
 
 // Budget is a budget definition in the JSON output.
@@ -288,9 +338,30 @@ func ReadFile(path, password string) (Output, error) {
 	return out, nil
 }
 
+// Validate checks the double-entry invariants on the journal legs and accounts
+// before serialization, mirroring the TypeScript upload-path validation so the
+// two halves stay in lockstep.
+func (o Output) Validate() error {
+	for i, l := range o.JournalLegs {
+		if err := l.Validate(); err != nil {
+			return fmt.Errorf("journalLegs[%d]: %w", i, err)
+		}
+	}
+	for i, a := range o.Accounts {
+		if err := a.Validate(); err != nil {
+			return fmt.Errorf("accounts[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
 // WriteFile marshals data as indented JSON and writes it atomically to path
 // via a temp file and rename. If password is non-empty, the output is encrypted.
 func WriteFile(path string, data Output, password string) error {
+	if err := data.Validate(); err != nil {
+		return fmt.Errorf("validating output: %w", err)
+	}
+
 	b, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling JSON: %w", err)

--- a/budget-etl/internal/export/export_test.go
+++ b/budget-etl/internal/export/export_test.go
@@ -3,6 +3,7 @@ package export
 import (
 	"encoding/json"
 	"flag"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1040,6 +1041,117 @@ func TestOutputCarriesJournalCollections(t *testing.T) {
 	if got.Transactions[0].JournalEntryID == nil || *got.Transactions[0].JournalEntryID != "je-001" {
 		t.Errorf("transactions[0].journalEntryId = %v, want je-001", got.Transactions[0].JournalEntryID)
 	}
+}
+
+func TestJournalLegValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		leg     JournalLeg
+		wantErr bool
+	}{
+		{"valid debit-only", JournalLeg{Debit: 52.30, Credit: 0}, false},
+		{"valid credit-only", JournalLeg{Debit: 0, Credit: 100.00}, false},
+		{"both zero", JournalLeg{Debit: 0, Credit: 0}, false},
+		{"both positive", JournalLeg{Debit: 10, Credit: 10}, true},
+		{"negative debit", JournalLeg{Debit: -1, Credit: 0}, true},
+		{"negative credit", JournalLeg{Debit: 0, Credit: -1}, true},
+		{"NaN debit", JournalLeg{Debit: math.NaN(), Credit: 0}, true},
+		{"+Inf credit", JournalLeg{Debit: 0, Credit: math.Inf(1)}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.leg.Validate()
+			if tt.wantErr && err == nil {
+				t.Errorf("Validate() = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestAccountValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		acctType AccountType
+		wantErr bool
+	}{
+		{"asset", AccountTypeAsset, false},
+		{"liability", AccountTypeLiability, false},
+		{"equity", AccountTypeEquity, false},
+		{"income", AccountTypeIncome, false},
+		{"expense", AccountTypeExpense, false},
+		{"unknown", AccountType("checking"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Account{ID: "a1", AccountType: tt.acctType}.Validate()
+			if tt.wantErr && err == nil {
+				t.Errorf("Validate() = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestWriteFileValidatesOutput(t *testing.T) {
+	validLeg := JournalLeg{
+		ID: "jl-001", EntryID: "je-001", AccountID: "acct-1",
+		Debit: 52.30, Credit: 0, Timestamp: "2025-06-10T00:00:00Z",
+	}
+	validAcct := Account{
+		ID: "acct-1", Institution: "bankone", Account: "1234",
+		AccountType: AccountTypeAsset,
+	}
+
+	t.Run("valid output round-trips", func(t *testing.T) {
+		out := minimalOutput("household")
+		out.JournalLegs = []JournalLeg{validLeg}
+		out.Accounts = []Account{validAcct}
+
+		path := filepath.Join(t.TempDir(), "budget.json")
+		if err := WriteFile(path, out, ""); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		got, err := ReadFile(path, "")
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		if len(got.JournalLegs) != 1 || len(got.Accounts) != 1 {
+			t.Fatalf("round-trip lost journal collections: legs=%d accounts=%d", len(got.JournalLegs), len(got.Accounts))
+		}
+	})
+
+	t.Run("invalid leg writes no file", func(t *testing.T) {
+		out := minimalOutput("household")
+		out.JournalLegs = []JournalLeg{{ID: "jl-bad", Debit: 10, Credit: 10}}
+		out.Accounts = []Account{validAcct}
+
+		path := filepath.Join(t.TempDir(), "budget.json")
+		if err := WriteFile(path, out, ""); err == nil {
+			t.Fatal("WriteFile: expected error for invalid leg")
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("file should not exist after validation failure, stat err = %v", err)
+		}
+	})
+
+	t.Run("invalid account writes no file", func(t *testing.T) {
+		out := minimalOutput("household")
+		out.JournalLegs = []JournalLeg{validLeg}
+		out.Accounts = []Account{{ID: "acct-bad", AccountType: AccountType("checking")}}
+
+		path := filepath.Join(t.TempDir(), "budget.json")
+		if err := WriteFile(path, out, ""); err == nil {
+			t.Fatal("WriteFile: expected error for invalid account")
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("file should not exist after validation failure, stat err = %v", err)
+		}
+	})
 }
 
 // TestWriteGoldenFile generates a BENC-encrypted golden file for cross-implementation

--- a/budget-etl/internal/export/export_test.go
+++ b/budget-etl/internal/export/export_test.go
@@ -1131,8 +1131,12 @@ func TestWriteFileValidatesOutput(t *testing.T) {
 		out.Accounts = []Account{validAcct}
 
 		path := filepath.Join(t.TempDir(), "budget.json")
-		if err := WriteFile(path, out, ""); err == nil {
+		err := WriteFile(path, out, "")
+		if err == nil {
 			t.Fatal("WriteFile: expected error for invalid leg")
+		}
+		if !strings.Contains(err.Error(), "journalLegs[0]") {
+			t.Errorf("error should name the offending leg index, got %v", err)
 		}
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Errorf("file should not exist after validation failure, stat err = %v", err)
@@ -1145,8 +1149,12 @@ func TestWriteFileValidatesOutput(t *testing.T) {
 		out.Accounts = []Account{{ID: "acct-bad", AccountType: AccountType("checking")}}
 
 		path := filepath.Join(t.TempDir(), "budget.json")
-		if err := WriteFile(path, out, ""); err == nil {
+		err := WriteFile(path, out, "")
+		if err == nil {
 			t.Fatal("WriteFile: expected error for invalid account")
+		}
+		if !strings.Contains(err.Error(), "accounts[0]") {
+			t.Errorf("error should name the offending account index, got %v", err)
 		}
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Errorf("file should not exist after validation failure, stat err = %v", err)

--- a/budget-etl/internal/journal/journal.go
+++ b/budget-etl/internal/journal/journal.go
@@ -322,9 +322,9 @@ func buildAccounts(tents []*tentative, referenced map[string]bool) []export.Acco
 
 	accounts := []export.Account{}
 	for id, ra := range reals {
-		acctType := "asset"
+		acctType := export.AccountTypeAsset
 		if ra.liability {
-			acctType = "liability"
+			acctType = export.AccountTypeLiability
 		}
 		accounts = append(accounts, export.Account{
 			ID:          id,
@@ -336,11 +336,12 @@ func buildAccounts(tents []*tentative, referenced map[string]bool) []export.Acco
 
 	// Placeholder accounts: emit only those referenced by an emitted leg.
 	for _, ph := range []struct {
-		id, account, acctType string
+		id, account string
+		acctType    export.AccountType
 	}{
-		{acctUncategorizedExpense, "Uncategorized Expense", "expense"},
-		{acctUncategorizedIncome, "Uncategorized Income", "income"},
-		{acctUnresolvedTransfers, "Unresolved Transfers", "asset"},
+		{acctUncategorizedExpense, "Uncategorized Expense", export.AccountTypeExpense},
+		{acctUncategorizedIncome, "Uncategorized Income", export.AccountTypeIncome},
+		{acctUnresolvedTransfers, "Unresolved Transfers", export.AccountTypeAsset},
 	} {
 		if !referenced[ph.id] {
 			continue

--- a/budget-etl/internal/journal/journal_test.go
+++ b/budget-etl/internal/journal/journal_test.go
@@ -45,7 +45,7 @@ func assertBalanced(t *testing.T, legs []export.JournalLeg) {
 func accountIDs(accts []export.Account) map[string]string {
 	m := map[string]string{}
 	for _, a := range accts {
-		m[a.ID] = a.AccountType
+		m[a.ID] = string(a.AccountType)
 	}
 	return m
 }

--- a/budget-etl/main.go
+++ b/budget-etl/main.go
@@ -362,7 +362,7 @@ func runInputJSON(input fileOpts, output fileOpts) error {
 	// IsCreditCard is not stored in export.Transaction, so we recover it from Accounts.
 	priorLiabilities := make(map[string]bool, len(inp.Accounts))
 	for _, a := range inp.Accounts {
-		if a.AccountType == "liability" {
+		if a.AccountType == export.AccountTypeLiability {
 			priorLiabilities[a.ID] = true
 		}
 	}
@@ -1070,7 +1070,7 @@ func runMerge(input fileOpts, dir, groupName string, disc parse.DiscoverOpts, ou
 	// IsCreditCard is not stored in export.Transaction, so we recover it from Accounts.
 	priorLiabilities := make(map[string]bool, len(inp.Accounts))
 	for _, a := range inp.Accounts {
-		if a.AccountType == "liability" {
+		if a.AccountType == export.AccountTypeLiability {
 			priorLiabilities[a.ID] = true
 		}
 	}


### PR DESCRIPTION
Closes #800

The Go double-entry export structs (`JournalLeg`, `Account`) in
`budget-etl/internal/export/export.go` had no construction-time validation, so
the ETL could write a `budget.json` that the budget app's TypeScript upload path
would later refuse to upload.

This adds, mirroring the TS rules:

- A typed `AccountType` enum (`asset`/`liability`/`equity`/`income`/`expense`)
  with a `Valid()` predicate, matching `ACCOUNT_TYPES` in
  `budget/src/schema/enums.ts`. `Account.AccountType` is now this type (JSON tag
  unchanged — still serializes as a string).
- `JournalLeg.Validate()` — rejects NaN/Inf/negative debit or credit and a
  both-positive leg; mirrors `parseRawJournalLeg`.
- `Account.Validate()` — rejects unrecognized account types; mirrors
  `parseRawAccount`.
- `Output.Validate()` — iterates `journalLegs` and `accounts`, wrapping each
  failure with its index.
- A `data.Validate()` call at the top of `export.WriteFile` — the Go analog of
  the TS upload boundary — so `budget-etl` never writes a rejectable file (no
  temp file is created on a validation failure).

The producer `journal.buildAccounts` is updated to use the typed constants.

Verification: `go test ./internal/export/... ./internal/journal/...`, `go vet
./...`, and `go build ./...` all pass.