### PR TITLE
dispatch: dispatch-mark-complete / dispatch-mark-deviation — scripted terminal marker write

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-mark-complete
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-mark-complete
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# dispatch-mark-complete — scripted terminal phase-completed marker write.
+#
+# Usage: dispatch-mark-complete --phase <phase> --pr <pr-num>
+#
+# Writes the dispatch phase-completed marker that dispatch-stop.sh reads to
+# decide the chain's next disposition. The marker is written atomically
+# (tempfile + mv) under the $CLAUDE_JOB_DIR guard, exactly as the four phase
+# skills (/plan-implement, /qa-fix, /review-fix, /verify-pr) previously did
+# inline at their Step-4 terminus. Reconstructing that atomic write from model
+# memory in the post-clear, skill-less build session was the structural
+# fragility behind the #824 trailing-step leak; a one-token script call is far
+# more reliable.
+#
+# Marker contents (byte format MUST be preserved — read by dispatch-stop.sh):
+#
+#   phase=<phase>
+#   pr=<pr-num>
+#
+# <phase> is one of: implement, verify, qa, review.
+#
+# When CLAUDE_JOB_DIR is unset/empty or not a directory the script is running
+# interactively (not under a dispatch job): it prints a diagnostic and no-ops
+# (exit 0), so the same Step-4 call is harmless in an interactive run.
+#
+# A missing argument, missing flag value, or unknown phase is a clear error,
+# not a fallback (exit 2).
+set -euo pipefail
+
+PHASE=""
+PR_NUM=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --phase)
+      if [[ $# -lt 2 ]]; then
+        echo "dispatch-mark-complete: --phase requires a value" >&2
+        echo "usage: dispatch-mark-complete --phase <phase> --pr <pr-num>" >&2
+        exit 2
+      fi
+      PHASE="$2"
+      shift 2
+      ;;
+    --pr)
+      if [[ $# -lt 2 ]]; then
+        echo "dispatch-mark-complete: --pr requires a value" >&2
+        echo "usage: dispatch-mark-complete --phase <phase> --pr <pr-num>" >&2
+        exit 2
+      fi
+      PR_NUM="$2"
+      shift 2
+      ;;
+    *)
+      echo "dispatch-mark-complete: unexpected argument: $1" >&2
+      echo "usage: dispatch-mark-complete --phase <phase> --pr <pr-num>" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$PHASE" || -z "$PR_NUM" ]]; then
+  echo "dispatch-mark-complete: --phase and --pr are both required" >&2
+  echo "usage: dispatch-mark-complete --phase <phase> --pr <pr-num>" >&2
+  exit 2
+fi
+
+case "$PHASE" in
+  implement|verify|qa|review) ;;
+  *)
+    echo "dispatch-mark-complete: unknown phase: $PHASE (expected implement, verify, qa, or review)" >&2
+    exit 2
+    ;;
+esac
+
+# CLAUDE_JOB_DIR guard: an interactive run (no dispatch job) is a no-op.
+if [[ -z "${CLAUDE_JOB_DIR:-}" || ! -d "$CLAUDE_JOB_DIR" ]]; then
+  echo "dispatch-mark-complete: CLAUDE_JOB_DIR unset or not a directory; interactive run, skipping marker write" >&2
+  exit 0
+fi
+
+# Atomic write: tempfile + mv. The exact byte format is read by dispatch-stop.sh.
+f="$CLAUDE_JOB_DIR/phase-completed"
+printf 'phase=%s\npr=%s\n' "$PHASE" "$PR_NUM" > "$f.tmp"
+mv "$f.tmp" "$f"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-mark-complete
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-mark-complete
@@ -64,6 +64,12 @@ if [[ -z "$PHASE" || -z "$PR_NUM" ]]; then
   exit 2
 fi
 
+if [[ ! "$PR_NUM" =~ ^[0-9]+$ ]]; then
+  echo "dispatch-mark-complete: --pr must be a positive integer, got: $PR_NUM" >&2
+  echo "usage: dispatch-mark-complete --phase <phase> --pr <pr-num>" >&2
+  exit 2
+fi
+
 case "$PHASE" in
   implement|verify|qa|review) ;;
   *)

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# dispatch-mark-deviation — scripted terminal office-hours-reason marker write.
+#
+# Usage: dispatch-mark-deviation "<reason>"
+#
+# Writes the dispatch office-hours-reason marker that dispatch-stop.sh's
+# resolve_office_hours_reason() reads to park an issue into office-hours with a
+# context-specific reason. The marker is written atomically (tempfile + mv)
+# under the $CLAUDE_JOB_DIR guard, exactly as the phase skills previously did
+# inline at their Step-4 terminus when a phase deviates and needs user review.
+# A one-token script call is more reliable than re-deriving the atomic write in
+# the post-clear, skill-less build session.
+#
+# Marker contents (byte format MUST be preserved — read by dispatch-stop.sh):
+#
+#   <reason>
+#
+# When CLAUDE_JOB_DIR is unset/empty or not a directory the script is running
+# interactively (not under a dispatch job): it prints a diagnostic and no-ops
+# (exit 0), so the same Step-4 call is harmless in an interactive run.
+#
+# Exactly one non-empty reason argument is required; zero args, extra args, or
+# an empty reason is a clear error, not a fallback (exit 2).
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "dispatch-mark-deviation: exactly one reason argument is required" >&2
+  echo "usage: dispatch-mark-deviation \"<reason>\"" >&2
+  exit 2
+fi
+
+REASON="$1"
+
+if [[ -z "$REASON" ]]; then
+  echo "dispatch-mark-deviation: reason must be non-empty" >&2
+  echo "usage: dispatch-mark-deviation \"<reason>\"" >&2
+  exit 2
+fi
+
+# CLAUDE_JOB_DIR guard: an interactive run (no dispatch job) is a no-op.
+if [[ -z "${CLAUDE_JOB_DIR:-}" || ! -d "$CLAUDE_JOB_DIR" ]]; then
+  echo "dispatch-mark-deviation: CLAUDE_JOB_DIR unset or not a directory; interactive run, skipping marker write" >&2
+  exit 0
+fi
+
+# Atomic write: tempfile + mv. The exact byte format is read by dispatch-stop.sh.
+f="$CLAUDE_JOB_DIR/office-hours-reason"
+printf '%s\n' "$REASON" > "$f.tmp"
+mv "$f.tmp" "$f"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -17552,6 +17552,70 @@ out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "CodeQL js/sql-injection a
 assert_eq "followup-exists: codeql alert-number prefix collision (#5 vs #50) → empty" "" "$out"
 followup_exists_teardown
 
+echo ""
+echo "=== dispatch-mark-complete / dispatch-mark-deviation ==="
+
+MARK_COMPLETE="$SCRIPT_DIR/dispatch-mark-complete"
+MARK_DEVIATION="$SCRIPT_DIR/dispatch-mark-deviation"
+
+# ----- mark-complete: writes exact marker contents -----
+mc_dir=$(mktemp -d)
+if CLAUDE_JOB_DIR="$mc_dir" "$MARK_COMPLETE" --phase implement --pr 42; then mc_ec=0; else mc_ec=$?; fi
+assert_eq "mark-complete: exit 0 on happy path" "0" "$mc_ec"
+assert_eq "mark-complete: writes exact phase-completed contents" \
+  "$(printf 'phase=implement\npr=42\n')" "$(cat "$mc_dir/phase-completed")"
+rm -rf "$mc_dir"
+
+# ----- mark-complete: unknown phase → exit 2, no file -----
+mc_dir=$(mktemp -d)
+if CLAUDE_JOB_DIR="$mc_dir" "$MARK_COMPLETE" --phase bogus --pr 7 2>/dev/null; then mc_ec=0; else mc_ec=$?; fi
+assert_eq "mark-complete: unknown phase exit 2" "2" "$mc_ec"
+assert_eq "mark-complete: unknown phase writes no file" "0" \
+  "$([ -f "$mc_dir/phase-completed" ] && echo 1 || echo 0)"
+rm -rf "$mc_dir"
+
+# ----- mark-complete: missing --pr → exit 2 -----
+mc_dir=$(mktemp -d)
+if CLAUDE_JOB_DIR="$mc_dir" "$MARK_COMPLETE" --phase qa 2>/dev/null; then mc_ec=0; else mc_ec=$?; fi
+assert_eq "mark-complete: missing --pr exit 2" "2" "$mc_ec"
+rm -rf "$mc_dir"
+
+# ----- mark-complete: missing flag value → exit 2 -----
+mc_dir=$(mktemp -d)
+if CLAUDE_JOB_DIR="$mc_dir" "$MARK_COMPLETE" --phase qa --pr 2>/dev/null; then mc_ec=0; else mc_ec=$?; fi
+assert_eq "mark-complete: missing flag value exit 2" "2" "$mc_ec"
+rm -rf "$mc_dir"
+
+# ----- mark-complete: CLAUDE_JOB_DIR unset → exit 0, no file, stderr diagnostic -----
+mc_err=$( (unset CLAUDE_JOB_DIR; "$MARK_COMPLETE" --phase implement --pr 42) 2>&1 1>/dev/null ) && mc_ec=0 || mc_ec=$?
+assert_eq "mark-complete: unset CLAUDE_JOB_DIR exit 0" "0" "$mc_ec"
+assert_eq "mark-complete: unset CLAUDE_JOB_DIR emits diagnostic" "1" \
+  "$([ -n "$mc_err" ] && echo 1 || echo 0)"
+
+# ----- mark-deviation: writes exact one-line reason -----
+md_dir=$(mktemp -d)
+if CLAUDE_JOB_DIR="$md_dir" "$MARK_DEVIATION" "some reason text"; then md_ec=0; else md_ec=$?; fi
+assert_eq "mark-deviation: exit 0 on happy path" "0" "$md_ec"
+assert_eq "mark-deviation: writes exact office-hours-reason contents" \
+  "$(printf 'some reason text\n')" "$(cat "$md_dir/office-hours-reason")"
+rm -rf "$md_dir"
+
+# ----- mark-deviation: no arg → exit 2 -----
+md_dir=$(mktemp -d)
+if CLAUDE_JOB_DIR="$md_dir" "$MARK_DEVIATION" 2>/dev/null; then md_ec=0; else md_ec=$?; fi
+assert_eq "mark-deviation: no arg exit 2" "2" "$md_ec"
+rm -rf "$md_dir"
+
+# ----- mark-deviation: empty-string arg → exit 2 -----
+md_dir=$(mktemp -d)
+if CLAUDE_JOB_DIR="$md_dir" "$MARK_DEVIATION" "" 2>/dev/null; then md_ec=0; else md_ec=$?; fi
+assert_eq "mark-deviation: empty arg exit 2" "2" "$md_ec"
+rm -rf "$md_dir"
+
+# ----- mark-deviation: CLAUDE_JOB_DIR unset → exit 0, no file -----
+( unset CLAUDE_JOB_DIR; "$MARK_DEVIATION" "x" ) >/dev/null 2>&1 && md_ec=0 || md_ec=$?
+assert_eq "mark-deviation: unset CLAUDE_JOB_DIR exit 0" "0" "$md_ec"
+
 # ============================================================================
 # summary
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -17964,9 +17964,43 @@ if CLAUDE_JOB_DIR="$md_dir" "$MARK_DEVIATION" "" 2>/dev/null; then md_ec=0; else
 assert_eq "mark-deviation: empty arg exit 2" "2" "$md_ec"
 rm -rf "$md_dir"
 
-# ----- mark-deviation: CLAUDE_JOB_DIR unset → exit 0, no file -----
-( unset CLAUDE_JOB_DIR; "$MARK_DEVIATION" "x" ) >/dev/null 2>&1 && md_ec=0 || md_ec=$?
+# ----- mark-deviation: CLAUDE_JOB_DIR unset → exit 0, no file, stderr diagnostic -----
+md_err=$( (unset CLAUDE_JOB_DIR; "$MARK_DEVIATION" "x") 2>&1 1>/dev/null ) && md_ec=0 || md_ec=$?
 assert_eq "mark-deviation: unset CLAUDE_JOB_DIR exit 0" "0" "$md_ec"
+assert_eq "mark-deviation: unset CLAUDE_JOB_DIR emits diagnostic" "1" \
+  "$( [[ -n "$md_err" ]] && echo 1 || echo 0 )"
+
+# ----- mark-deviation: extra arg → exit 2 -----
+md_dir=$(mktemp -d)
+if CLAUDE_JOB_DIR="$md_dir" "$MARK_DEVIATION" "reason1" "reason2" 2>/dev/null; then md_ec=0; else md_ec=$?; fi
+assert_eq "mark-deviation: extra arg exit 2" "2" "$md_ec"
+rm -rf "$md_dir"
+
+# ----- mark-complete: missing --phase only (--pr present) → exit 2 -----
+mc_dir=$(mktemp -d)
+if CLAUDE_JOB_DIR="$mc_dir" "$MARK_COMPLETE" --pr 42 2>/dev/null; then mc_ec=0; else mc_ec=$?; fi
+assert_eq "mark-complete: missing --phase exit 2" "2" "$mc_ec"
+rm -rf "$mc_dir"
+
+# ----- mark-complete: non-numeric --pr → exit 2, no file -----
+mc_dir=$(mktemp -d)
+if CLAUDE_JOB_DIR="$mc_dir" "$MARK_COMPLETE" --phase qa --pr bogus 2>/dev/null; then mc_ec=0; else mc_ec=$?; fi
+assert_eq "mark-complete: non-numeric --pr exit 2" "2" "$mc_ec"
+assert_eq "mark-complete: non-numeric --pr writes no file" "0" \
+  "$(ls "$mc_dir" | wc -l | tr -d ' ')"
+rm -rf "$mc_dir"
+
+# ----- mark-complete: CLAUDE_JOB_DIR set to a file (not a dir) → exit 0, no write -----
+mc_file=$(mktemp)
+if CLAUDE_JOB_DIR="$mc_file" "$MARK_COMPLETE" --phase implement --pr 42 2>/dev/null; then mc_ec=0; else mc_ec=$?; fi
+assert_eq "mark-complete: CLAUDE_JOB_DIR is a file exit 0" "0" "$mc_ec"
+rm -f "$mc_file"
+
+# ----- mark-deviation: CLAUDE_JOB_DIR set to a file (not a dir) → exit 0, no write -----
+md_file=$(mktemp)
+if CLAUDE_JOB_DIR="$md_file" "$MARK_DEVIATION" "reason" 2>/dev/null; then md_ec=0; else md_ec=$?; fi
+assert_eq "mark-deviation: CLAUDE_JOB_DIR is a file exit 0" "0" "$md_ec"
+rm -f "$md_file"
 
 # ============================================================================
 # === dispatch-open-pr ===

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -130,20 +130,15 @@ Run `git push origin HEAD` to flush them. This is sandbox-safe: it uses HTTPS
 to `github.com`, an allowlisted host, so no `dangerouslyDisableSandbox` is
 needed.
 
-Then write a one-line reason to `$CLAUDE_JOB_DIR/office-hours-reason` using the
-atomic tempfile + mv pattern (only when `CLAUDE_JOB_DIR` is set and exists —
-match the pattern used in review-fix Step 8 / implement-unit), then stop with
+Then call `dispatch-mark-deviation` with a one-line reason, then stop with
 no marker. The push heals the `CONFLICTING` PR; stopping without a marker means
 the Stop hook applies `dispatch:office-hours`, surfacing the unexpected
 late-skip for a human.
 
 ```bash
 git push origin HEAD
-if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
-  printf '%s\n' "/dispatch-worker: PUSH-STRANDED — pushed unpushed local commits a done PR left behind; parking for review" \
-    > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
-  mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" "$CLAUDE_JOB_DIR/office-hours-reason"
-fi
+.claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+  "/dispatch-worker: PUSH-STRANDED — pushed unpushed local commits a done PR left behind; parking for review"
 ```
 
 Note: with the `/review-fix` terminal-flush guard (#1105 Unit 1) in place, this

--- a/.claude/skills/implement-unit/SKILL.md
+++ b/.claude/skills/implement-unit/SKILL.md
@@ -60,19 +60,15 @@ The caller supplies:
        a leftover `<<<<<<<`/`=======`/`>>>>>>>` line) — if any remain, treat the
        verdict as **`ambiguous`** instead. Otherwise re-fork `/commit-merge-push`.
      - **`ambiguous <reason>`** (the subagent made **no** edits; `<reason>` is a
-       one-line explanation) → write `<reason>` to
-       `$CLAUDE_JOB_DIR/office-hours-reason` (atomic, under the `CLAUDE_JOB_DIR`
-       guard), **skip** the caller's `phase-completed` marker, and **stop**. The
+       one-line explanation) → call `dispatch-mark-deviation` with `<reason>`,
+       **skip** the caller's `phase-completed` marker, and **stop**. The
        Stop hook (`dispatch-stop.sh`, Branch A) reads the marker-absence, applies
        `dispatch:office-hours` to the issue, and surfaces `<reason>` in the
        why-comment — so do **not** call `gh` / `dispatch-apply-office-hours` here.
 
        ```bash
        # Set REASON to the one-line reason from the subagent's "ambiguous <reason>" verdict.
-       if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
-         printf '%s\n' "$REASON" > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
-         mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" "$CLAUDE_JOB_DIR/office-hours-reason"
-       fi
+       .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation "$REASON"
        ```
    - **Pre-commit hook failure** → launch a `sonnet` subagent to fix the underlying
      issue with a **new commit — never `--amend`** — then re-fork `/commit-merge-push`.

--- a/.claude/skills/plan-implement/SKILL.md
+++ b/.claude/skills/plan-implement/SKILL.md
@@ -104,37 +104,28 @@ approved plan — scope shifted mid-implementation, or the plan could not be
 fully implemented as approved. Base this on the `/implement-unit` outcomes
 observed in Step 2.
 
-**Deviation fires** — skip the `phase-completed` marker. Instead write a
-one-line deviation reason to `$CLAUDE_JOB_DIR/office-hours-reason`, atomic via
-tempfile + mv, under the same `CLAUDE_JOB_DIR` guard. The draft PR opened in
-Step 3 stays open. The Stop hook reads marker-absence as Branch A, applies
-`dispatch:office-hours` to the issue (surfacing this reason in the
+**Deviation fires** — skip the `phase-completed` marker. Instead call
+`dispatch-mark-deviation` to write the office-hours-reason atomically. The draft
+PR opened in Step 3 stays open. The Stop hook reads marker-absence as Branch A,
+applies `dispatch:office-hours` to the issue (surfacing this reason in the
 why-comment), and parks the issue for human review.
 
 ```bash
-if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
-  printf '%s\n' "/plan-implement: implementation deviated from the approved plan" \
-    > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
-  mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" \
-     "$CLAUDE_JOB_DIR/office-hours-reason"
-fi
+.claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+  "/plan-implement: implementation deviated from the approved plan"
 ```
 
 Use the default phrasing above, or make it more specific when the nature of
 the shift is clear (e.g. `/plan-implement: unit 3 scope expanded to cover
 auth; approved plan did not include auth changes`).
 
-**No deviation** — write the `phase-completed` marker as the final action.
-Atomic via tempfile + mv so the hook never sees a partial file.
-`CLAUDE_JOB_DIR` unset = interactive run; skip.
+**No deviation** — call `dispatch-mark-complete` as the final action.
+`CLAUDE_JOB_DIR` unset = interactive run; the script no-ops with a clear
+diagnostic.
 
 ```bash
-if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
-  printf 'phase=implement\npr=%s\n' "$PR_NUM" \
-    > "$CLAUDE_JOB_DIR/phase-completed.tmp"
-  mv "$CLAUDE_JOB_DIR/phase-completed.tmp" \
-     "$CLAUDE_JOB_DIR/phase-completed"
-fi
+.claude/skills/dispatch-propagate/scripts/dispatch-mark-complete \
+  --phase implement --pr "$PR_NUM"
 ```
 
 Stop. The Stop hook reads the marker, spawns the next `/dispatch-propagate`

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -244,16 +244,12 @@ Otherwise run all steps in order.
    `/review-fix` owns `dispatch:reviewed` — so `/dispatch-propagate`
    does not apply the label after this skill returns.
 
-   Then write the `phase-completed` marker as the final action. Atomic via
-   tempfile + mv. `CLAUDE_JOB_DIR` unset = interactive run; skip.
+   Then call `dispatch-mark-complete` as the final action. `CLAUDE_JOB_DIR`
+   unset = interactive run; the script no-ops with a clear diagnostic.
 
    ```bash
-   if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
-     printf 'phase=qa\npr=%s\n' "$PR_NUM" \
-       > "$CLAUDE_JOB_DIR/phase-completed.tmp"
-     mv "$CLAUDE_JOB_DIR/phase-completed.tmp" \
-        "$CLAUDE_JOB_DIR/phase-completed"
-   fi
+   .claude/skills/dispatch-propagate/scripts/dispatch-mark-complete \
+     --phase qa --pr "$PR_NUM"
    ```
 
    Then **stop**. The Stop hook reads the marker and advances the chain.
@@ -273,18 +269,15 @@ Otherwise run all steps in order.
 ## Escalation
 
 On a user-input blocker, do **not** write the `phase-completed` marker. Instead
-write a one-line reason so the Stop hook can surface it in the office-hours
-comment. The Stop hook (`.claude/hooks/dispatch-stop.sh`) reads marker-absence as
-Branch A and applies `dispatch:office-hours` to the **issue**, parking it for the
-office-hours queue (`/office-hours` runs the user-input residue).
+call `dispatch-mark-deviation` so the Stop hook can surface the reason in the
+office-hours comment. The Stop hook (`.claude/hooks/dispatch-stop.sh`) reads
+marker-absence as Branch A and applies `dispatch:office-hours` to the **issue**,
+parking it for the office-hours queue (`/office-hours` runs the user-input
+residue).
 
 ```bash
-if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
-  printf '%s\n' "/qa-fix: QA needs a human (judgment item, bug, or failed pre-QA check); escalating to office-hours" \
-    > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
-  mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" \
-     "$CLAUDE_JOB_DIR/office-hours-reason"
-fi
+.claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+  "/qa-fix: QA needs a human (judgment item, bug, or failed pre-QA check); escalating to office-hours"
 ```
 
 Tailor the reason text to the blocker that actually fired (judgment item, machine

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -642,16 +642,11 @@ treat the deviation criterion as not met and write the marker.
 Confidence `high` remains unresolved after the Step 5 fix pass.
 
 **Deviation fires** (a high-confidence `required` finding is still unresolved) —
-skip the phase-completed marker. Write a one-line reason instead, atomic via
-tempfile + mv:
+skip the phase-completed marker. Call `dispatch-mark-deviation` instead:
 
 ```bash
-if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
-  printf '%s\n' "/review-fix: high-confidence required security finding(s) left unresolved after fixes" \
-    > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
-  mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" \
-     "$CLAUDE_JOB_DIR/office-hours-reason"
-fi
+.claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+  "/review-fix: high-confidence required security finding(s) left unresolved after fixes"
 ```
 
 The Stop hook reads marker-absence as Branch A and applies `dispatch:office-hours`
@@ -660,15 +655,12 @@ which criterion fired. Do not apply the `dispatch:office-hours` label inline —
 Stop hook owns label application.
 
 **No deviation** (all high-confidence `required` findings resolved, or none
-existed) — write the phase-completed marker, atomic via tempfile + mv:
+existed) — call `dispatch-mark-complete`. `CLAUDE_JOB_DIR` unset = interactive
+run; the script no-ops with a clear diagnostic.
 
 ```bash
-if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
-  printf 'phase=review\npr=%s\n' "$PR_NUM" \
-    > "$CLAUDE_JOB_DIR/phase-completed.tmp"
-  mv "$CLAUDE_JOB_DIR/phase-completed.tmp" \
-     "$CLAUDE_JOB_DIR/phase-completed"
-fi
+.claude/skills/dispatch-propagate/scripts/dispatch-mark-complete \
+  --phase review --pr "$PR_NUM"
 ```
 
 Then **stop**. The Stop hook reads the marker and advances the chain. `gh pr ready`

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -93,15 +93,11 @@ Cross-iteration memory lives entirely in `tmp/verify-summary.md` (see
         .claude/skills/dispatch-propagate/scripts/post-pr-comment.sh <pr-num> tmp/verify-summary.md
         ```
 
-     3. **Write `office-hours-reason`** atomically (tempfile + mv), under the
-        `CLAUDE_JOB_DIR` guard — the same shape as `/plan-implement` Step 4's
-        deviation block:
+     3. **Write `office-hours-reason`** via `dispatch-mark-deviation`:
 
         ```bash
-        if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
-          printf '%s\n' "/verify-pr: <required_action>" > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
-          mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" "$CLAUDE_JOB_DIR/office-hours-reason"
-        fi
+        .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+          "/verify-pr: <required_action>"
         ```
 
      4. **Do NOT write the `phase=verify` marker** (do not run Step 9).
@@ -248,15 +244,12 @@ Cross-iteration memory lives entirely in `tmp/verify-summary.md` (see
 9. **Write the phase-completed marker, then stop.** Reached by every outcome
    **except** needs-human (which stopped in Step 4 without a marker). The Stop hook
    (`.claude/hooks/dispatch-stop.sh`) reads this to decide propagate vs park.
-   Atomic via tempfile + mv. `CLAUDE_JOB_DIR` unset = interactive run; skip.
+   `CLAUDE_JOB_DIR` unset = interactive run; the script no-ops with a clear
+   diagnostic.
 
    ```bash
-   if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
-     printf 'phase=verify\npr=%s\n' "$PR_NUM" \
-       > "$CLAUDE_JOB_DIR/phase-completed.tmp"
-     mv "$CLAUDE_JOB_DIR/phase-completed.tmp" \
-        "$CLAUDE_JOB_DIR/phase-completed"
-   fi
+   .claude/skills/dispatch-propagate/scripts/dispatch-mark-complete \
+     --phase verify --pr "$PR_NUM"
    ```
 
    Then **stop**. The `/dispatch-propagate` background-job chain drives the


### PR DESCRIPTION
Adds two scripts that own the atomic terminal marker-file writes previously inlined — and reconstructed from model memory — across the Step-4 terminus of the four phase skills. The reconstruction in the post-clear, skill-less build session was the structural fragility behind the #824 trailing-step leak; a one-token script call is far more reliable.

## What changed

- `dispatch-mark-complete --phase <p> --pr <N>` — writes `phase=<p>\npr=<N>` to `$CLAUDE_JOB_DIR/phase-completed` atomically (tempfile + `mv`). No-ops with a clear diagnostic when `CLAUDE_JOB_DIR` is unset (interactive run). Exits 2 on bad args or an unknown phase (`implement|verify|qa|review`).
- `dispatch-mark-deviation "<reason>"` — writes `<reason>` to `$CLAUDE_JOB_DIR/office-hours-reason` atomically under the same guard. Exits 2 on zero/extra args or an empty reason.
- `/plan-implement`, `/qa-fix`, `/review-fix`, `/verify-pr` Step 4 now call these scripts instead of inline `if [[ … ]]; then printf … > …tmp; mv …; fi` blocks. The script owns the `CLAUDE_JOB_DIR` guard, so the `if` wrapper is gone; the explanatory prose is preserved.
- `test-dispatch-scripts.sh` covers both scripts (argument validation, exact marker byte format, unset-`CLAUDE_JOB_DIR` no-op).

## Reconciliation with existing scripts

`dispatch-complete-phase` (applies the `dispatch:*` progress label) and `dispatch-handoff` (self-close) are distinct concerns from the marker-file write. The new scripts reuse their conventions — `dispatch-*` naming, `set -euo pipefail`, clear-error-not-fallback arg handling, a usage diagnostic on misuse — not their bodies.

## No behavior change to the Stop hook

`dispatch-stop.sh` is unchanged. The marker byte formats are preserved exactly: `phase-completed` is `printf 'phase=%s\npr=%s\n'` (the hook reads only the `phase=` line), and `office-hours-reason` is `printf '%s\n'`.

Closes #1120