### PR TITLE
dispatch: binary weekly-pace gate + linear 5-hour worker ramp

### DIFF
--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -294,19 +294,22 @@ nothing (fail-safe). Later #1044 sub-issues build on this ledger: #1046 extends
 provisioning out of the held-lock loop; #1048 releases the lock after
 reserve+spawn rather than after registration.
 
-`dispatch-target-workers` runs a sequential four-stage pace-relative pipeline
-(W → F → N) to decide how many concurrent busy workers should run; the live
-count used for the `busy_workers` addend is `claude_agents_count_busy_workers`
-— busy sessions whose name matches the real worker shape `^[0-9]+-` (NOT a
-`dispatch-worker-*` prefix, which never existed in production — that was the
-Defect-B bug this issue fixed). Instead of a
-flat weekly cap, the weekly budget follows a
-**cumulative-pace curve** keyed to how far through the weekly rate-limit window
-we are (in 5-hour-window terms), so token spend spreads smoothly across the
-week rather than bursting early and idling. The controller is intentionally
-more conservative early-week than a flat-cap design — it throttles whenever
-actual usage runs ahead of the curve, even when the weekly total is far below
-the cap.
+`dispatch-target-workers` decides how many concurrent busy workers should run
+through a three-stage pipeline: Stage 1 computes the weekly pace curve W;
+Stage 2 applies a binary weekly gate; Stage 3 applies a linear 5h ramp. The
+live count used for the `busy_workers` addend is
+`claude_agents_count_busy_workers` — busy sessions whose name matches the real
+worker shape `^[0-9]+-` (NOT a `dispatch-worker-*` prefix, which never existed
+in production — that was the Defect-B bug this issue fixed). Instead of a flat
+weekly cap, the weekly budget follows a **cumulative-pace curve** keyed to how
+far through the weekly rate-limit window we are (in 5-hour-window terms), so
+token spend spreads smoothly across the week rather than bursting early and
+idling. The controller is intentionally more conservative early-week than a
+flat-cap design — it throttles whenever actual usage runs ahead of the curve,
+even when the weekly total is far below the cap.
+
+Weekly pace decides *whether* to spend (binary gate); the 5h ramp decides
+*how many*.
 
 ```
 WEEK_SECONDS = 604800
@@ -319,13 +322,15 @@ end = floor + (p+1)*(target_weekly/T - floor)                # solve so W(1)=tar
 end = min(end, cap)                                          # per-window hard ceiling
 W   = T*( floor*x + (end-floor)*x^(p+1)/(p+1) )              # cumulative target now
 
-# Stage 2 — 5h target F (% of 5h limit)
+# Stage 2 — binary weekly gate
 hw = W - used_weekly
-F  = (hw <= 0) ? 0 : floor5 + (ceil5-floor5)*clamp(hw/Hw, 0, 1)
+if hw <= 0: N = 0   (pause)        # at/over pace
 
-# Stage 3 — workers N
-h5 = F - used_5h
-N  = (h5 <= 0) ? 0 : clamp(round(max_workers * h5/H5), 1, max_workers)
+# Stage 3 — 5h ramp (gate open)
+span = ceil5 - floor5
+h5   = ceil5 - used_5h
+N = (h5 <= 0) ? 0 : (span <= 0) ? max_workers
+                                : clamp(round(max_workers * h5/span), 1, max_workers)
 print N
 ```
 
@@ -336,11 +341,10 @@ print N
   terminal `W(1)` below `target_weekly` (a deliberate hard ceiling), so at the
   defaults `W(1)=90` only because the solved increment `end≈4.3` stays under
   the `cap=10`.
-- `F=0` when ahead of pace (`used_weekly >= W`); the `floor5..ceil5` band opens
-  with weekly headroom.
-- `N=0` only at/over the 5h target F (includes the `F=0` ahead-of-pace pause);
-  `1..max_workers` below. No `0 >= 0` router deadlock during healthy
-  under-budget operation.
+- Gate closed (`hw <= 0`, at or over pace) → N=0 regardless of `used_5h`.
+- Gate open (`hw > 0`) → N is a pure function of `used_5h`: max workers at/below
+  `floor5`, 0 at/above `ceil5`. The clamp keeps N≥1 for any `used_5h` strictly
+  below `ceil5`. No router deadlock during healthy under-budget operation.
 
 **Table A — weekly curve vs. elapsed** (defaults; `used_weekly=0`, `used_5h=0`):
 
@@ -352,22 +356,22 @@ print N
 | 0.90 | 76 | 8 |
 | ~1.0 | 90 | 8 |
 
-At these defaults, `W >= Hw=20` for `x >= 0.5`, so `F=ceil5=80` and
-`h5=80 > H5=15`, giving `N=max_workers=8`. At `x=0.25`, `W=12 < Hw=20`,
-so `F=68` and `N=8` (h5=68 still exceeds H5=15 × max_workers threshold).
+At these defaults, `used_5h=0` and `hw > 0` at every row, so the gate is open
+and `h5 = ceil5 - 0 = 80 > 0`, giving `N=max_workers=8` across the board.
 
-**Table B — 5h target and workers at mid-week** (defaults; `x=0.5`, `W=31`):
+**Table B — binary gate + 5h ramp at mid-week** (defaults; `x=0.5`, `W=31`):
 
-| used_weekly (%) | hw (=W−used_weekly) | F | used_5h (%) | target_N |
-|---:|---:|---:|---:|---:|
-| 11 | 20 | 80 |  0 | 8 |
-| 11 | 20 | 80 | 65 | 8 |
-| 11 | 20 | 80 | 80 | 0 |
-| 21 | 10 | 65 |  0 | 8 |
-| 21 | 10 | 65 | 50 | 8 |
-| 21 | 10 | 65 | 58 | 4 |
-| 31 |  0 |  0 |  0 | 0 (at pace) |
-| 40 | −9 |  0 |  0 | 0 (ahead of pace) |
+| used_weekly (%) | hw (=W−used_weekly) | gate | used_5h (%) | target_N |
+|---:|---:|:---:|---:|---:|
+| 20 | 11 | open | 50 | 8 |
+| 20 | 11 | open | 55 | 7 |
+| 20 | 11 | open | 60 | 5 |
+| 20 | 11 | open | 65 | 4 |
+| 20 | 11 | open | 70 | 3 |
+| 20 | 11 | open | 75 | 1 |
+| 20 | 11 | open | 80 | 0 |
+| 31 |  0 | closed | 0 | 0 (at pace) |
+| 40 | −9 | closed | 0 | 0 (over pace) |
 
 Tunables (each optional in `dispatch.config/target-workers.json`; defaults
 baked into the script):
@@ -378,18 +382,17 @@ baked into the script):
 | `weekly_increment_floor_pct` | 1 | per-window floor |
 | `weekly_increment_cap_pct` | 10 | per-window hard ceiling |
 | `weekly_curve_power` (`p`) | 1 | convexity; >1 back-loads spend later in the week |
-| `weekly_headroom_taper_pct` (`Hw`) | 20 | weekly headroom earning full F ceiling |
-| `five_hour_target_floor_pct` (`floor5`) | 50 | F band floor |
-| `five_hour_target_ceiling_pct` (`ceil5`) | 80 | F band ceiling |
-| `five_hour_headroom_taper_pct` (`H5`) | 15 | 5h headroom → max workers |
+| `five_hour_target_floor_pct` (`floor5`) | 50 | `used_5h` % at which workers reach max (gate open) |
+| `five_hour_target_ceiling_pct` (`ceil5`) | 80 | `used_5h` % at which workers reach zero (gate open) |
 | `max_concurrent_workers` | 8 | max worker count |
 
 Recalibration: raise `weekly_curve_power` to back-load spend later in the
 week (a higher `p` makes the curve concave up, so `W` grows slowly early and
 accelerates toward the end). `weekly_increment_cap_pct` hard-caps any single
 5h window's share regardless of curve shape — raise it only if early spending
-is acceptable. Raise `max_concurrent_workers` for more parallelism when
-headroom is comfortable.
+is acceptable. Raise `max_concurrent_workers` for more parallelism when under
+pace. Adjust `five_hour_target_floor_pct` and `five_hour_target_ceiling_pct`
+to shift where the 5h ramp starts and ends.
 
 Keep `weekly_increment_floor_pct <= target_weekly_usage_pct / T` (with `T=34`
 five-hour windows, i.e. `target_weekly_usage_pct >= 34 * floor`). Below that the
@@ -410,7 +413,7 @@ or the `seven_day` block is absent (missing `used_weekly` or `resets_at_weekly`,
 or a malformed `now`), `dispatch-target-workers` prints `1` and writes a
 one-line note to stderr — the chain degrades to "spawn one per tick". When only
 `five_hour` is absent while `seven_day` is present, Stages 1–3 run with
-`used_5h` treated as 0 (N scales from F alone). Non-numeric `used_*` values
+`used_5h` treated as 0 — gate-open → max workers. Non-numeric `used_*` values
 are treated as missing (fail-closed). The stdout contract — a single integer —
 and the router gate `LIVE_COUNT >= TARGET_N` are unchanged.
 
@@ -430,14 +433,13 @@ the telemetry, identifies the earliest blocking `resets_at`, and arms the
 timer there.
 
 **Pace-curve pause** — `used_weekly >= W(x)` (usage running ahead of the
-smooth cumulative curve — the `F=0 ahead-of-pace` row in Stage 2; see the
-*Concurrency budgeting* section). The 5h target band collapses to `F=0` so
-the target is 0, even when `used_weekly` is far below the absolute weekly cap.
-This stall is **transient and self-clearing**: `W` rises monotonically over
-time while `used_weekly` stays flat (no workers spending), so the budget
-reopens on its own at the curve-crossing epoch where `W(x) = used_weekly`.
-When no absolute cap is hit but weekly telemetry is present,
-`dispatch-schedule-reseed` consults `dispatch-target-workers --reopen-at`,
+smooth cumulative curve; see the *Concurrency budgeting* section). The binary
+weekly gate closes (`hw <= 0`), driving N=0 even when `used_weekly` is far
+below the absolute weekly cap. This stall is **transient and self-clearing**:
+`W` rises monotonically over time while `used_weekly` stays flat (no workers
+spending), so the budget reopens on its own at the curve-crossing epoch where
+`W(x) = used_weekly`. When no absolute cap is hit but weekly telemetry is
+present, `dispatch-schedule-reseed` consults `dispatch-target-workers --reopen-at`,
 which solves `W(x) = used_weekly` by bisection over the monotonic Stage-1
 curve and returns the curve-crossing epoch. The reseed arms a
 `dispatch-reseed-<fire>` timer at that crossing. `--reopen-at` returns `none`

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
@@ -130,7 +130,7 @@
 #
 # Top-level object with optional tunables for `dispatch-target-workers`. Each
 # field must be a number when present; absent fields fall back to the
-# defaults baked into `dispatch-target-workers`. The eight percentage fields
+# defaults baked into `dispatch-target-workers`. The six percentage fields
 # must be in (0, 100]; weekly_curve_power and max_concurrent_workers must be
 # > 0 with no upper bound. When both members of a pair are present, two
 # cross-field ordering checks apply: weekly_increment_floor_pct <=
@@ -142,10 +142,10 @@
 #   weekly_increment_floor_pct     default 1    per-window floor
 #   weekly_increment_cap_pct       default 10   per-window hard ceiling
 #   weekly_curve_power             default 1    convexity; >1 back-loads
-#   weekly_headroom_taper_pct      default 20   weekly headroom earning full F
-#   five_hour_target_floor_pct     default 50   F band floor
-#   five_hour_target_ceiling_pct   default 80   F band ceiling
-#   five_hour_headroom_taper_pct   default 15   5h headroom -> max workers
+#   five_hour_target_floor_pct     default 50   used_5h % at/below which workers
+#                                               are max
+#   five_hour_target_ceiling_pct   default 80   used_5h % at/above which workers
+#                                               are zero
 #   max_concurrent_workers         default 8
 #
 # Example (see target-workers.example.json):
@@ -155,10 +155,8 @@
 #     "weekly_increment_floor_pct": 1,
 #     "weekly_increment_cap_pct": 10,
 #     "weekly_curve_power": 1,
-#     "weekly_headroom_taper_pct": 20,
 #     "five_hour_target_floor_pct": 50,
 #     "five_hour_target_ceiling_pct": 80,
-#     "five_hour_headroom_taper_pct": 15,
 #     "max_concurrent_workers": 8
 #   }
 set -euo pipefail
@@ -354,7 +352,7 @@ case "$CONFIG_TYPE" in
     # top-level value must be an object; all tunables are optional numbers.
     # `dispatch-target-workers` substitutes a baked-in default for any field
     # absent here, so absence is silent — only the type of present fields is
-    # checked. The eight percentage fields carry an additional `<= 100` bound;
+    # checked. The six percentage fields carry an additional `<= 100` bound;
     # weekly_curve_power and max_concurrent_workers have no upper bound.
     ERRORS=$(jq -r '
       if type != "object" then
@@ -364,8 +362,8 @@ case "$CONFIG_TYPE" in
         (["target_weekly_usage_pct","weekly_terminal_pct",
           "weekly_increment_floor_pct",
           "weekly_increment_cap_pct","weekly_curve_power",
-          "weekly_headroom_taper_pct","five_hour_target_floor_pct",
-          "five_hour_target_ceiling_pct","five_hour_headroom_taper_pct",
+          "five_hour_target_floor_pct",
+          "five_hour_target_ceiling_pct",
           "max_concurrent_workers"] |
          .[] |
          . as $field |
@@ -373,9 +371,9 @@ case "$CONFIG_TYPE" in
          # unbounded above.
          ([ "target_weekly_usage_pct","weekly_terminal_pct",
             "weekly_increment_floor_pct",
-            "weekly_increment_cap_pct","weekly_headroom_taper_pct",
-            "five_hour_target_floor_pct","five_hour_target_ceiling_pct",
-            "five_hour_headroom_taper_pct" ] | index($field)) as $is_pct |
+            "weekly_increment_cap_pct",
+            "five_hour_target_floor_pct","five_hour_target_ceiling_pct" ]
+            | index($field)) as $is_pct |
          if ($cfg | has($field)) | not then
            empty
          elif ($cfg[$field] | type) != "number" then

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # dispatch-target-workers — print the desired concurrent worker count.
 #
-# Runs a sequential four-stage pace-relative pipeline W -> F -> N to gate
-# router-side worker spawning. Instead of a flat weekly cap, the weekly budget
-# follows a cumulative-pace CURVE keyed to how far through the weekly window we
-# are (in 5-hour-window terms), so spend spreads smoothly across the week
-# rather than burning early and idling. It is intentionally more conservative
-# early-week than a flat-cap controller — it throttles whenever actual usage
-# runs ahead of the curve, even far below the weekly cap.
+# Computes a worker target from two decoupled controls: a weekly pace curve W
+# used as a BINARY gate, then a linear 5-hour worker ramp N. Weekly pace decides
+# WHETHER to spend (usage at/over the curve → pause); the 5h ramp decides HOW
+# MANY. Instead of a flat weekly cap, the weekly budget follows a cumulative-pace
+# CURVE keyed to how far through the weekly window we are (in 5-hour-window
+# terms), so spend spreads smoothly across the week rather than burning early and
+# idling. It is intentionally more conservative early-week than a flat-cap
+# controller — it pauses whenever actual usage runs ahead of the curve, even far
+# below the weekly cap.
 #
 # The two `used_*` telemetry fields stay in their own denominators
 # (used_weekly = % of weekly limit; used_5h = % of 5h limit). They couple only
@@ -69,10 +71,10 @@
 #   weekly_increment_floor_pct     default 1    per-window floor
 #   weekly_increment_cap_pct       default 10   per-window hard ceiling
 #   weekly_curve_power             default 1    convexity; >1 back-loads
-#   weekly_headroom_taper_pct      default 20   weekly headroom earning full F
-#   five_hour_target_floor_pct     default 50   F band floor
-#   five_hour_target_ceiling_pct   default 80   F band ceiling
-#   five_hour_headroom_taper_pct   default 15   5h headroom -> max workers
+#   five_hour_target_floor_pct     default 50   used_5h % at/below which workers
+#                                               are max
+#   five_hour_target_ceiling_pct   default 80   used_5h % at/above which workers
+#                                               are zero
 #   max_concurrent_workers         default 8
 #
 # ---- The algorithm ----------------------------------------------------------
@@ -89,13 +91,15 @@
 #   r   = remaining / 18000                                      # windows left
 #   W   = max(W, weekly_terminal - cap*r)                        # terminal envelope
 #
-#   # Stage 2 — 5h target F (% of 5h limit, absolute)
+#   # Stage 2 — binary weekly gate
 #   hw = W - used_weekly
-#   F  = (hw <= 0) ? 0 : floor5 + (ceil5-floor5)*clamp(hw/Hw, 0, 1)
+#   if hw <= 0: print 0; exit              # at/over pace → pause
 #
-#   # Stage 3 — workers N
-#   h5 = F - used_5h
-#   N  = (h5 <= 0) ? 0 : clamp(round(max_workers * h5/H5), 1, max_workers)
+#   # Stage 3 — workers N from the 5h ramp
+#   span = ceil5 - floor5
+#   h5   = ceil5 - used_5h
+#   N = (h5 <= 0) ? 0 : (span <= 0) ? max_workers
+#                                   : clamp(round(max_workers * h5/span), 1, max_workers)
 #   print N
 #
 # - The weekly increment d(x)=floor+(end-floor)*x^p rises from the floor toward
@@ -108,15 +112,17 @@
 #   (term = 80 at r=2 [smooth 81.5 wins], 90 at r=1, 100 at r=0 with defaults;
 #   envelope takes over at r≈1.7). Mid-week r is large, the term is negative,
 #   and the smooth curve is unchanged.
-# - F=0 when ahead of pace (used_weekly >= W); the floor5..ceil5 band opens
-#   with weekly headroom.
-# - N=0 only at/over the 5h target F (includes the F=0 ahead-of-pace pause);
-#   1..max below. No `0 >= 0` router deadlock during healthy under-budget
-#   operation.
+# - Gate closed (hw <= 0, used_weekly at/over W) → 0 workers regardless of 5h
+#   usage. The weekly pace curve simply pauses spending.
+# - Gate open (hw > 0) → N is a pure function of used_5h: max_workers at/below
+#   floor5, ramping linearly to 0 at/above ceil5. The clamp floor keeps N >= 1
+#   for any used_5h strictly under ceil5, so there is no `0 >= 0` router
+#   deadlock during healthy under-pace operation.
 #
 #   # Reopen crossing (--reopen-at mode)
-#   A pace-curve pause (F=0 from used_weekly >= W) is transient: W(t) rises over
-#   time to meet the flat (no workers spending) used_weekly, so the budget
+#   A pace-curve pause (the binary gate closing, hw<=0, from used_weekly >= W) is
+#   transient: W(t) rises over time to meet the flat (no workers spending)
+#   used_weekly, so the budget
 #   reopens on its own. Reopen mode reports WHEN. The Stage-1 curve is factored
 #   into an awk function W_of(t) returning the cumulative curve value at a
 #   candidate epoch t. With hw = W_of(now) - used_weekly:
@@ -125,7 +131,8 @@
 #     hw <= 0 → solve W_of(t) = used_weekly for the earliest t in (now,
 #               resets_weekly] by bisection. W_of is monotonic increasing in t,
 #               so the bisection converges for any weekly_curve_power.
-#   Reopen mode computes only Stage 1; it never runs Stage 2 (F) or Stage 3 (N).
+#   Reopen mode computes only Stage 1; it never runs the binary gate or the 5h
+#   ramp.
 #
 # ---- Missing-telemetry fallback --------------------------------------------
 #
@@ -133,8 +140,8 @@
 #   (count mode) / `none` (reopen mode).
 # - Weekly anchor absent (missing used_weekly OR resets_at_weekly OR a
 #   malformed now) → print 1 (count mode) / `none` (reopen mode).
-# - Only `five_hour` missing → run Stages 1-3 with used_5h treated as 0
-#   (N scales from F alone). Irrelevant to reopen mode (Stage 1 only).
+# - Only `five_hour` missing → under pace, used_5h is treated as 0 → max workers
+#   from the 5h ramp. Irrelevant to reopen mode (Stage 1 only).
 set -euo pipefail
 
 # ---- Step 0: mode argument --------------------------------------------------
@@ -161,10 +168,8 @@ WEEKLY_TERMINAL=100
 WEEKLY_INCREMENT_FLOOR=1
 WEEKLY_INCREMENT_CAP=10
 WEEKLY_CURVE_POWER=1
-WEEKLY_HEADROOM_TAPER=20
 FIVEH_TARGET_FLOOR=50
 FIVEH_TARGET_CEILING=80
-FIVEH_HEADROOM_TAPER=15
 MAX_WORKERS=8
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -193,14 +198,10 @@ if [[ -n "$CONFIG_JSON" ]]; then
   [[ -n "$val" ]] && WEEKLY_INCREMENT_CAP="$val"
   val=$(jq -r '.weekly_curve_power // empty' <<<"$CONFIG_JSON")
   [[ -n "$val" ]] && WEEKLY_CURVE_POWER="$val"
-  val=$(jq -r '.weekly_headroom_taper_pct // empty' <<<"$CONFIG_JSON")
-  [[ -n "$val" ]] && WEEKLY_HEADROOM_TAPER="$val"
   val=$(jq -r '.five_hour_target_floor_pct // empty' <<<"$CONFIG_JSON")
   [[ -n "$val" ]] && FIVEH_TARGET_FLOOR="$val"
   val=$(jq -r '.five_hour_target_ceiling_pct // empty' <<<"$CONFIG_JSON")
   [[ -n "$val" ]] && FIVEH_TARGET_CEILING="$val"
-  val=$(jq -r '.five_hour_headroom_taper_pct // empty' <<<"$CONFIG_JSON")
-  [[ -n "$val" ]] && FIVEH_HEADROOM_TAPER="$val"
   val=$(jq -r '.max_concurrent_workers // empty' <<<"$CONFIG_JSON")
   [[ -n "$val" ]] && MAX_WORKERS="$val"
 fi
@@ -308,10 +309,10 @@ if (( WEEKLY_PRESENT == 0 )); then
   exit 0
 fi
 
-# ---- Step 3: the four-stage pace pipeline -----------------------------------
+# ---- Step 3: the pace pipeline (weekly gate + 5h ramp) ----------------------
 #
 # All arithmetic is delegated to a single awk invocation. awk's printf handles
-# both float math (the curve and linear bands) and integer rounding
+# both float math (the curve and linear ramp) and integer rounding
 # (int(x + 0.5)); `^` is exponentiation. awk is POSIX-ubiquitous on the dev
 # machines (bc is not).
 
@@ -330,10 +331,8 @@ awk -v mode="$MODE" \
     -v wfloor="$WEEKLY_INCREMENT_FLOOR" \
     -v wcap="$WEEKLY_INCREMENT_CAP" \
     -v p="$WEEKLY_CURVE_POWER" \
-    -v hw_taper="$WEEKLY_HEADROOM_TAPER" \
     -v floor5="$FIVEH_TARGET_FLOOR" \
     -v ceil5="$FIVEH_TARGET_CEILING" \
-    -v h5_taper="$FIVEH_HEADROOM_TAPER" \
     -v max_workers="$MAX_WORKERS" \
     'function clamp(v, lo, hi) {
        v = v + 0
@@ -410,20 +409,24 @@ awk -v mode="$MODE" \
 
        W = W_of(now)
 
-       # ---- Stage 2: 5h target F (% of 5h limit, absolute) ----
+       # ---- Stage 2: binary weekly gate ----
+       # Weekly usage at/over the pace curve → pause (0 workers) regardless of
+       # 5h headroom. Otherwise the gate is open and the 5h ramp decides N.
        hw = W - (used_weekly + 0)
-       if (hw <= 0) {
-         F = 0
-       } else {
-         F = (floor5 + 0) + ((ceil5 + 0) - (floor5 + 0)) * clamp(hw / (hw_taper + 0), 0, 1)
-       }
+       if (hw <= 0) { print 0; exit }
 
-       # ---- Stage 3: workers N ----
-       h5 = F - (used_5h + 0)
+       # ---- Stage 3: workers N from the 5h ramp ----
+       # max_workers at/below floor5, ramping linearly to 0 at/above ceil5.
+       span = (ceil5 + 0) - (floor5 + 0)
+       h5 = (ceil5 + 0) - (used_5h + 0)
        if (h5 <= 0) {
          N = 0
+       } else if (span <= 0) {
+         # Zero-width ramp (floor5 == ceil5, validator allows equal). Below
+         # ceil5 the limit is max_workers; dividing by span=0 would crash awk.
+         N = (max_workers + 0)
        } else {
-         N = int((max_workers + 0) * h5 / (h5_taper + 0) + 0.5)
+         N = int((max_workers + 0) * h5 / span + 0.5)
          N = clamp(N, 1, max_workers + 0)
        }
 

--- a/.claude/skills/dispatch-propagate/scripts/target-workers.example.json
+++ b/.claude/skills/dispatch-propagate/scripts/target-workers.example.json
@@ -4,9 +4,7 @@
   "weekly_increment_floor_pct": 1,
   "weekly_increment_cap_pct": 10,
   "weekly_curve_power": 1,
-  "weekly_headroom_taper_pct": 20,
   "five_hour_target_floor_pct": 50,
   "five_hour_target_ceiling_pct": 80,
-  "five_hour_headroom_taper_pct": 15,
   "max_concurrent_workers": 8
 }

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6935,21 +6935,21 @@ out_compact=$(printf '%s' "$out" | jq -c '.')
 assert_eq "empty object prints {}" "{}" "$out_compact"
 config_teardown
 
-# --- Test 12: weekly_headroom_taper_pct: 0 is rejected (must be > 0) --------
+# --- Test 12: five_hour_target_floor_pct: 0 is rejected (must be > 0) --------
 
-echo "Test: weekly_headroom_taper_pct: 0 exits 1 and stderr says must be > 0"
+echo "Test: five_hour_target_floor_pct: 0 exits 1 and stderr says must be > 0"
 config_setup
 cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
-{"weekly_headroom_taper_pct": 0}
+{"five_hour_target_floor_pct": 0}
 EOF
 rc=0
 err=$("$TMPDIR_TEST/scripts/dispatch-config-load" target-workers 2>&1 1>/dev/null) || rc=$?
-assert_eq "weekly_headroom_taper_pct 0 exits 1" "1" "$rc"
+assert_eq "five_hour_target_floor_pct 0 exits 1" "1" "$rc"
 TOTAL=$((TOTAL + 1))
-if [[ "$err" == *"weekly_headroom_taper_pct"* && "$err" == *"must be > 0"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: weekly_headroom_taper_pct 0 stderr says must be > 0"
+if [[ "$err" == *"five_hour_target_floor_pct"* && "$err" == *"must be > 0"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: five_hour_target_floor_pct 0 stderr says must be > 0"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: weekly_headroom_taper_pct 0 stderr says must be > 0"
+  FAIL=$((FAIL + 1)); echo "  FAIL: five_hour_target_floor_pct 0 stderr says must be > 0"
   echo "    stderr: $err"
 fi
 config_teardown
@@ -7152,9 +7152,9 @@ config_teardown
 # All telemetry inputs are env-overridable; tests rely on the overrides rather
 # than fixture files when shape matters more than the file path. The script
 # defaults are baked in (target_weekly=90, weekly_increment_floor=1,
-# weekly_increment_cap=10, weekly_curve_power=1, weekly_headroom_taper=20,
+# weekly_increment_cap=10, weekly_curve_power=1,
 # five_hour_target_floor=50, five_hour_target_ceiling=80,
-# five_hour_headroom_taper=15, max_workers=8); tests that vary tunables write a
+# max_workers=8); tests that vary tunables write a
 # target-workers.json into the config dir.
 #
 # The pace curve needs the elapsed fraction x of the weekly window. With
@@ -7242,15 +7242,15 @@ echo "Test: weekly curve reaches terminal only at week end (W < terminal mid-wee
 tw_setup
 # Mid-week (envelope-inactive x), the cumulative curve W is well below the
 # week-end terminal, so used_weekly just below the terminal is far ahead of
-# pace → F=0 → N=0. Only at week end does W reach the terminal and let that
-# used_weekly come under pace. Probe with used_weekly = 89 at several x.
+# pace → gate closed → N=0. Only at week end does W reach the terminal and let
+# that used_weekly come under pace. Probe with used_weekly = 89 at several x.
 # (The terminal envelope lifts W to weekly_terminal=100 in the final windows;
 # this test deliberately picks envelope-INACTIVE mid-week x so it isolates the
 # smooth curve's "below terminal until the end" shape — the envelope's
 # week-end lift is covered by the dedicated envelope test below.)
-#   x=0.5  → W=31    → used_weekly=89 is far ahead of pace → F=0 → N=0
-#   x=0.75 → W=57    → used_weekly=89 still ahead of pace  → F=0 → N=0
-#   x=1.0  → env→100 → used_weekly=89 → hw=11 → F>0 → N>=1 (only now under pace)
+#   x=0.5  → W=31    → used_weekly=89 is far ahead of pace → gate closed → N=0
+#   x=0.75 → W=57    → used_weekly=89 still ahead of pace  → gate closed → N=0
+#   x=1.0  → env→100 → used_weekly=89 → hw=11>0 → gate open → N>=1 (under pace)
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 for spec in "0.5:0" "0.75:0" "1.0:ge1"; do
   x="${spec%%:*}"; want="${spec##*:}"
@@ -7272,10 +7272,10 @@ tw_teardown
 
 # --- Test 2: W matches the canonical curve at x=0.5 -------------------------
 
-echo "Test: weekly curve value W(0.5)=31 gates F=0 at the boundary"
+echo "Test: weekly curve value W(0.5)=31 closes the gate at the boundary"
 tw_setup
-# x=0.5 → W=31. used_weekly=31 → hw=0 → F=0 → N=0 (exactly at pace).
-# used_weekly=30 → hw=1 → F>0 → N>=1 (just under pace).
+# x=0.5 → W=31. used_weekly=31 → hw=0 → gate closed → N=0 (exactly at pace).
+# used_weekly=30 → hw=1 → gate open → N>=1 (just under pace).
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 r=$(tw_resets_for_x 0.5)
 write_rl "rl.json" 31 "$r" 0 99999999
@@ -7300,7 +7300,7 @@ tw_setup
 # and W(0.5) = 34*(0.5 + 2*0.25/2) = 34*(0.5+0.25) = 25.5 mid-week. To isolate
 # the smooth term from the terminal envelope, set weekly_terminal_pct=1 so the
 # envelope (env = 1 - 3*r) stays deeply negative mid-week and never lifts W.
-# At x=0.5: used_weekly=26 (> 25.5) is ahead of the clamped pace → F=0 → N=0;
+# At x=0.5: used_weekly=26 (> 25.5) is ahead of the clamped pace → gate closed → N=0;
 # used_weekly=25 (< 25.5) is under pace → N>=1. This proves the cap hard-ceils
 # the smooth curve below target. (The default terminal=100 envelope would
 # otherwise dominate this low-cap curve everywhere — the dedicated envelope
@@ -7368,69 +7368,75 @@ out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
 assert_eq "remaining<0 → 0" "0" "$out"
 tw_teardown
 
-# --- Test 6: F = 0 when used_weekly >= W (ahead of pace) → N=0 --------------
+# --- Test 6: binary gate closed when used_weekly >= W (at/over pace) → N=0 ---
 
-echo "Test: F=0 ahead-of-pace pause yields N=0 even with 5h headroom"
+echo "Test: binary gate closed (at/over pace) yields N=0 regardless of 5h usage"
 tw_setup
-# x=0.5 → W=31. used_weekly=40 (>31) → hw<0 → F=0. used_5h=0 (full 5h
-# headroom) but h5 = 0 - 0 = 0 → N=0. The ahead-of-pace pause overrides 5h
-# headroom — this is the intentional early-week throttle.
+# x=0.5 → W=31. used_weekly=40 (>31) → hw<0 → gate closed → N=0, regardless of
+# the 5-hour ramp. The over-pace pause overrides 5h headroom — this is the
+# intentional weekly-pace throttle.
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 r=$(tw_resets_for_x 0.5)
+# Full 5h headroom (used_5h=0) — gate still closed.
 write_rl "rl.json" 40 "$r" 0 99999999
 out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
-assert_eq "ahead of pace (used_weekly=40 > W=31) → F=0 → N=0" "0" "$out"
+assert_eq "over pace (used_weekly=40 > W=31), used_5h=0 → gate closed → N=0" "0" "$out"
+# Low non-zero 5h usage (used_5h=10, deep in the max-workers band) — gate still
+# closed, so the open-gate ramp value is irrelevant.
+write_rl "rl.json" 40 "$r" 10 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "over pace (used_weekly=40 > W=31), used_5h=10 → gate closed → N=0" "0" "$out"
 tw_teardown
 
-# --- Test 7: F linear band floor5..ceil5 over weekly headroom Hw ------------
+# --- Test 7: binary gate is magnitude-independent over weekly headroom hw ----
 
-echo "Test: F scales floor5..ceil5 over weekly headroom Hw (observed via N)"
+echo "Test: open gate gives the same N for any positive hw; at-pace gives 0"
 tw_setup
-# x=0.5 → W=31, defaults floor5=50, ceil5=80, Hw=20.
-#   used_weekly=11 → hw=20 (>=Hw) → F=80 (ceiling)
-#   used_weekly=21 → hw=10        → F=50+(30)*(10/20)=65
-#   used_weekly=26 → hw=5         → F=50+(30)*(5/20)=57.5
-#   used_weekly=31 → hw=0         → F=0
-# Observe F through N with used_5h chosen so N tracks the band. Hold used_5h=65:
-#   F=80   → h5=15 → N=clamp(round(8*15/15),1,8)=8
-#   F=65   → h5=0  → N=0
-#   F=57.5 → h5<0  → N=0
-# That only distinguishes ceiling vs below-65; to see the full F linear band,
-# read F at the ceiling boundary (hw>=Hw → F=80) vs interior (hw=15 → F=72.5):
-#   used_weekly=11 → hw=20 → F=80,   used_5h=72 → h5=8  → N=round(8*8/15)=4
-#   used_weekly=16 → hw=15 → F=72.5, used_5h=72 → h5=0.5→ N=round(8*.5/15)=1
-#   used_weekly=21 → hw=10 → F=65,   used_5h=72 → h5<0 → N=0
+# The weekly gate is binary: any hw>0 opens it and the 5-hour ramp alone decides
+# N — the headroom magnitude does NOT scale N. x=0.5 → W=31, defaults floor5=50,
+# ceil5=80, span=30. Hold used_5h=65 → h5=80-65=15 → N=round(8*15/30)=4 whenever
+# the gate is open.
+#   used_weekly=11 → hw=20 (open) → N=4
+#   used_weekly=21 → hw=10 (open) → N=4   (same N — magnitude-independent)
+#   used_weekly=31 → hw=0  (at pace) → gate closed → N=0
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 r=$(tw_resets_for_x 0.5)
-write_rl "rl.json" 11 "$r" 72 99999999
+write_rl "rl.json" 11 "$r" 65 99999999
 out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
-assert_eq "F-band hw=20 → F=80, used_5h=72 → N=4" "4" "$out"
-write_rl "rl.json" 16 "$r" 72 99999999
+assert_eq "gate open hw=20, used_5h=65 → N=4" "4" "$out"
+write_rl "rl.json" 21 "$r" 65 99999999
 out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
-assert_eq "F-band hw=15 → F=72.5, used_5h=72 → N=1" "1" "$out"
-write_rl "rl.json" 21 "$r" 72 99999999
+assert_eq "gate open hw=10, used_5h=65 → N=4 (magnitude-independent)" "4" "$out"
+write_rl "rl.json" 31 "$r" 65 99999999
 out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
-assert_eq "F-band hw=10 → F=65, used_5h=72 ahead → N=0" "0" "$out"
+assert_eq "at pace hw=0, used_5h=65 → gate closed → N=0" "0" "$out"
 tw_teardown
 
-# --- Test 8: N=0 when used_5h >= F; floor(1)/ceiling(max) over H5 -----------
+# --- Test 8 (AC): linear 5h ramp under pace; floor(1)/ceiling(max) endpoints --
 
-echo "Test: N floor/ceiling over five_hour_headroom_taper, F held at 80"
+echo "Test: under pace, N is a linear ramp on used_5h over [floor5,ceil5]"
 tw_setup
-# x=0.5, used_weekly=11 → hw=20 → F=80 (ceiling). H5=15, max_workers=8.
-# Sweep used_5h; h5 = 80 - used_5h:
-#   used_5h=80 → h5=0  → N=0          (at target)
-#   used_5h=79 → h5=1  → N=clamp(round(8*1/15),1,8)=1   (floor)
-#   used_5h=71 → h5=9  → N=round(8*9/15)=5
-#   used_5h=65 → h5=15 → N=8          (ceiling)
-#   used_5h=50 → h5=30 → N=8          (clamped at ceiling)
+# Under pace (gate open) the 5-hour ramp alone decides N. Defaults floor5=50,
+# ceil5=80, span=30, max_workers=8; h5 = ceil5 - used_5h;
+# N = clamp(round(8*h5/30),1,8). x=0.5, used_weekly=11 → hw=20>0 → gate open.
+# Canonical curve:
+#   used_5h=50 → h5=30 → N=8     (at floor → max)
+#   used_5h=55 → h5=25 → N=round(6.67)=7
+#   used_5h=60 → h5=20 → N=round(5.33)=5
+#   used_5h=65 → h5=15 → N=4
+#   used_5h=70 → h5=10 → N=round(2.67)=3
+#   used_5h=75 → h5=5  → N=round(1.33)=1
+#   used_5h=80 → h5=0  → N=0     (at ceiling → zero)
+# Plus endpoints:
+#   used_5h=40 → h5=40 → N=clamp(round(10.67),1,8)=8  (below floor → max)
+#   used_5h=79 → h5=1  → N=clamp(round(0.27),1,8)=1   (rounds to 0 but clamps ≥1)
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 r=$(tw_resets_for_x 0.5)
-declare -A n_expected=([80]=0 [79]=1 [71]=5 [65]=8 [50]=8)
-for u5 in 80 79 71 65 50; do
+declare -A n_expected=([40]=8 [50]=8 [55]=7 [60]=5 [65]=4 [70]=3 [75]=1 [79]=1 [80]=0)
+for u5 in 40 50 55 60 65 70 75 79 80; do
   write_rl "nsweep.json" 11 "$r" "$u5" 99999999
   result=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
-  assert_eq "N-sweep F=80 used_5h=$u5 → ${n_expected[$u5]}" "${n_expected[$u5]}" "$result"
+  assert_eq "ramp under pace used_5h=$u5 → ${n_expected[$u5]}" "${n_expected[$u5]}" "$result"
 done
 unset n_expected
 tw_teardown
@@ -7474,15 +7480,15 @@ tw_teardown
 
 # --- Test 11: only seven_day present → 5h gate uses used_5h=0 ---------------
 
-echo "Test: missing-five-hour treats used_5h=0; N scales from F alone"
+echo "Test: missing-five-hour treats used_5h=0 → ramp gives max workers"
 tw_setup
-# seven_day only at x=0.5 (W=31): used_weekly=11 → hw=20 → F=80. 5h block absent
-# → used_5h treated as 0 → h5=80 → N=8.
+# seven_day only at x=0.5 (W=31): used_weekly=11 → hw=20>0 → gate open. 5h block
+# absent → used_5h treated as 0 → 0 <= floor5=50 → ramp gives max workers = 8.
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 r=$(tw_resets_for_x 0.5)
 write_rl "rl.json" 11 "$r" absent absent
 out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
-assert_eq "five_hour absent; F=80 used_5h=0 → N=8" "8" "$out"
+assert_eq "five_hour absent; under pace + used_5h=0 → max workers N=8" "8" "$out"
 tw_teardown
 
 # --- Test 12: config-file tunables are honored ------------------------------
@@ -7492,8 +7498,8 @@ tw_setup
 cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
 {"max_concurrent_workers": 16}
 EOF
-# x=0.5, used_weekly=11 → F=80, used_5h=0 → h5=80 → N=clamp(round(16*80/15),1,16)
-# = clamp(85,1,16) = 16.
+# x=0.5, used_weekly=11 → hw=20>0 → gate open. used_5h=0 <= floor5=50 → ramp
+# gives max workers = 16.
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 r=$(tw_resets_for_x 0.5)
 write_rl "rl.json" 11 "$r" 0 99999999
@@ -7501,20 +7507,22 @@ out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
 assert_eq "config max_concurrent_workers=16 → 16" "16" "$out"
 tw_teardown
 
-# --- Test 13: config five_hour_headroom_taper widens the N ramp -------------
+# --- Test 13: config five_hour_target_floor_pct widens the ramp span --------
 
-echo "Test: config five_hour_headroom_taper_pct scales the N ramp"
+echo "Test: config five_hour_target_floor_pct widens the ramp span"
 tw_setup
-# H5=30 (default 15). x=0.5, used_weekly=11 → F=80, used_5h=72 → h5=8.
-# N=clamp(round(8*8/30),1,8)=clamp(round(2.13),1,8)=2 (vs N=4 at default H5=15).
+# Raising floor5 from 50 to 60 narrows the span (ceil5 - floor5 = 80-60 = 20),
+# steepening the ramp. x=0.5, used_weekly=11 → hw=20>0 → gate open. used_5h=72 →
+# h5 = 80-72 = 8 → N=clamp(round(8*8/20),1,8)=round(3.2)=3 (vs default span=30 →
+# round(8*8/30)=round(2.13)=2).
 cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
-{"five_hour_headroom_taper_pct": 30}
+{"five_hour_target_floor_pct": 60}
 EOF
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 r=$(tw_resets_for_x 0.5)
 write_rl "rl.json" 11 "$r" 72 99999999
 out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
-assert_eq "H5=30; F=80 used_5h=72 h5=8 → N=2" "2" "$out"
+assert_eq "floor5=60 span=20; under pace used_5h=72 h5=8 → N=3" "3" "$out"
 tw_teardown
 
 # --- Test 14: per-field env override wins over file -------------------------
@@ -7523,8 +7531,8 @@ echo "Test: per-field env override wins over rate_limits.json"
 tw_setup
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 r=$(tw_resets_for_x 0.5)
-# File says used_5h=99 (over F → N=0); env override replaces with used_5h=0.
-# used_weekly=11 → F=80, used_5h=0 → h5=80 → N=8.
+# File says used_5h=99 (over ceil5 → N=0); env override replaces with used_5h=0.
+# used_weekly=11 → hw=20>0 → gate open. used_5h=0 <= floor5 → ramp → N=8.
 write_rl "rl.json" 11 "$r" 99 99999999
 export DISPATCH_TARGET_WORKERS_USED_5H=0
 out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
@@ -7536,7 +7544,7 @@ tw_teardown
 echo "Test: per-field env override of resets_at_weekly drives the curve"
 tw_setup
 # File supplies used_weekly; env override supplies resets_at_weekly to place
-# x=0.5. used_weekly=31 = W(0.5) → at pace → F=0 → N=0.
+# x=0.5. used_weekly=31 = W(0.5) → hw=0 → at pace → gate closed → N=0.
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 write_rl "rl.json" 31 99999999 0 99999999
 export DISPATCH_TARGET_WORKERS_RESETS_AT_WEEKLY=$(tw_resets_for_x 0.5)
@@ -7549,17 +7557,32 @@ tw_teardown
 echo "Test: out-of-range config field rejected; baked-in defaults used"
 tw_setup
 cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
-{"weekly_headroom_taper_pct": 0}
+{"five_hour_target_ceiling_pct": 0}
 EOF
-# weekly_headroom_taper_pct=0 is rejected by dispatch-config-load (must be > 0).
-# dispatch-target-workers silently ignores a failed config-load and uses the
-# baked-in defaults (Hw=20). x=0.5, used_weekly=11 → hw=20 → F=80, used_5h=0 →
-# N=8.
+# five_hour_target_ceiling_pct=0 is rejected by dispatch-config-load (must be
+# > 0). dispatch-target-workers silently ignores a failed config-load and uses
+# the baked-in defaults (floor5=50, ceil5=80). x=0.5, used_weekly=11 → hw=20>0 →
+# gate open. used_5h=0 <= floor5 → ramp → N=8.
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 r=$(tw_resets_for_x 0.5)
 write_rl "rl.json" 11 "$r" 0 99999999
 out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
 assert_eq "rejected config → defaults → N=8" "8" "$out"
+tw_teardown
+
+# --- Test 16b: just-under-pace + high 5h usage → ramp decides N --------------
+
+echo "Test: gate barely open (hw≈1) + high 5h usage → ramp value, not 0"
+tw_setup
+# x=0.5 → W=31. used_weekly=30 → hw=1 (>0) → gate just barely open. With the gate
+# open the 5-hour ramp alone sets N: used_5h=70 → h5=80-70=10 →
+# N=clamp(round(8*10/30),1,8)=round(2.67)=3. The thin weekly headroom does NOT
+# pull N down — this is the key behavior change from the old coupled model.
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+r=$(tw_resets_for_x 0.5)
+write_rl "rl.json" 30 "$r" 70 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "just under pace (hw=1), used_5h=70 → ramp N=3" "3" "$out"
 tw_teardown
 
 # --- Test 17: non-numeric used_weekly sanitized fail-closed → 1 -------------
@@ -7647,8 +7670,8 @@ tw_teardown
 echo "Test: early-week AC smoke used_weekly=20, used_5h=2 → N>=1 (no stall)"
 tw_setup
 # Issue AC: at x≈0.5 (mid-week) with used_weekly=20, used_5h=2, the chain must
-# not stall. x=0.5 → W=31, hw=11 → F=50+(30)*(11/20)=66.5, h5=66.5-2=64.5 →
-# N=clamp(round(8*64.5/15),1,8)=8 (>=1).
+# not stall. x=0.5 → W=31, hw=11>0 → gate open. used_5h=2 <= floor5=50 → ramp
+# gives max workers = 8 (>=1).
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 r=$(tw_resets_for_x 0.5)
 write_rl "rl.json" 20 "$r" 2 99999999
@@ -7670,7 +7693,7 @@ tw_setup
 # with defaults (terminal=100, cap=10) it evaluates to 80 at r=2, 90 at r=1,
 # 100 at r=0 (r = remaining_seconds / 18000). Place x by remaining-window count
 # (resets_at = NOW + r*18000) and hold used_5h=0 so 5h headroom is full and
-# N>=1 whenever F>0. The r=1 and r=0 lower probes are DISCRIMINATING: the
+# N>=1 whenever the gate is open. The r=1 and r=0 lower probes are DISCRIMINATING: the
 # pre-envelope smooth curve (W=85.7 at r=1, W=90 at r=0) would have gated N=0.
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 
@@ -7780,7 +7803,7 @@ tw_teardown
 
 echo "Test: --reopen-at pace pause → numeric crossing strictly inside the window"
 tw_setup
-# x=0.5 → W=31. used_weekly=35 > 31 → pace pause (F=0, target 0) while still far
+# x=0.5 → W=31. used_weekly=35 > 31 → pace pause (gate closed, target 0) while still far
 # below the absolute weekly cap (35 < 90). The reopen epoch is where W rises to
 # meet used_weekly=35, which is later than NOW but before the weekly reset.
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -7658,9 +7658,9 @@ out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
 assert_eq "config max_concurrent_workers=16 → 16" "16" "$out"
 tw_teardown
 
-# --- Test 13: config five_hour_target_floor_pct widens the ramp span --------
+# --- Test 13: config five_hour_target_floor_pct narrows the ramp span --------
 
-echo "Test: config five_hour_target_floor_pct widens the ramp span"
+echo "Test: config five_hour_target_floor_pct narrows the ramp span"
 tw_setup
 # Raising floor5 from 50 to 60 narrows the span (ceil5 - floor5 = 80-60 = 20),
 # steepening the ramp. x=0.5, used_weekly=11 → hw=20>0 → gate open. used_5h=72 →


### PR DESCRIPTION
Closes #1125

Replaces the magnitude-coupled weekly→F→N pace pipeline in `dispatch-target-workers` with two decoupled controls:

- **Weekly pace is a binary gate.** `hw = W - used_weekly`; `hw <= 0` (usage at/over the pace curve) → 0 workers (pause), regardless of 5-hour usage. Otherwise the gate is open.
- **When open, worker count is a pure function of 5-hour usage.** `span = ceil5 - floor5`; `h5 = ceil5 - used_5h`; `N = clamp(round(max_workers * h5/span), 1, max_workers)` — `max_concurrent_workers` at/below `floor5` (50%), ramping linearly to 0 at/above `ceil5` (80%). A `span <= 0` guard returns the ramp's limit instead of dividing by zero (the validator allows `floor5 == ceil5`).

Weekly pace decides *whether* to spend; the 5-hour ramp decides *how many*.

Ramp at defaults (8 / 50 / 80): used_5h ≤50→8, 55→7, 60→5, 65→4, 70→3, 75→1, ≥80→0; used_5h strictly under `ceil5` that rounds below 1 still clamps to ≥1 (79→1).

### Removed knobs

`weekly_headroom_taper_pct` and `five_hour_headroom_taper_pct` are gone — the gate no longer scales by weekly-headroom magnitude and the ramp width is now `ceil5 - floor5`. Removed from `dispatch-target-workers`, `dispatch-config-load` (schema + validation), `reference.md`, and `target-workers.example.json`. The `floor5 <= ceil5` ordering check is retained; `--reopen-at` is unchanged (it already computed the `hw=0` crossing).

### Behavior change

Telemetry that yields 0 workers today (thin weekly headroom) now yields workers per the 5-hour ramp whenever under pace. Intended.

### Commits

1. Algorithm rewrite + knob removal (scripts/config/example)
2. Test suite rewritten for the new gate/ramp model
3. Reference doc updated

Full dispatch test suite: 1623/1623 passing.