### PR TITLE
office-hours: one selector for resume/select/empty

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours
@@ -1,85 +1,66 @@
 #!/usr/bin/env bash
 # office-hours — the single user entry point to the office-hours queue (#759).
 #
-# The office-hours queue is "open issues carrying the dispatch:office-hours
-# label" (the label is issue-anchored, #868/#909). The user runs this command
-# during their office hours; it either RESUMES a blocked session that is still
-# live, or STARTS a fresh /office-hours session for a sessionless labeled item.
+# A thin dispatcher over office-hours-select-target, which is the single source
+# of truth for the queue: it enumerates the open dispatch:office-hours issues and
+# their <N>-* worktrees once, makes one per-item liveness call, and emits exactly
+# one disposition. This script reads that disposition and acts on it — it does no
+# enumeration or liveness checking of its own.
 #
-# This is the deliberate complement to office-hours-select-target, which selects
-# the oldest labeled item whose <N>-* worktree has NO live session and skips any
-# item that still has one — naming "the office-hours entry-point script (#759)"
-# as the piece responsible for resuming those skipped live-session items.
+# Dispositions and the action each triggers:
+#   resume <sessionId>            → exec `claude --resume <sessionId>`: the user
+#                                   supplies the pending input to a still-live
+#                                   blocked session. No skill is loaded.
+#   parked-router <sessionId> ... → exec `claude --resume <sessionId>`: re-engage
+#                                   a target-less parked dispatch router (#1010),
+#                                   the artifact dispatch-self-close's continuation
+#                                   invariant keeps alive. No skill is loaded.
+#   office-hours <N> <phase> <pr> → exec `claude "/office-hours <N> <phase> <pr>"`:
+#                                   a fresh interactive session running the
+#                                   /office-hours skill, with the already-selected
+#                                   target passed as arguments so the skill skips
+#                                   re-selection. A Claude session + skill context
+#                                   is loaded only on this path — only when there
+#                                   is actual residue work.
+#   empty                         → print a queue-empty message and exit WITHOUT
+#                                   launching Claude. The empty queue is handled
+#                                   entirely in bash; no session is booted.
 #
-# Behavior, in order:
-#   1. List open issues carrying dispatch:office-hours, sorted oldest-first by
-#      createdAt — the same gh query office-hours-select-target uses.
-#   2. For each labeled issue (oldest-first), for each of its <N>-* worktree
-#      paths, ask claude_sessions_with_name "$(basename "$path")" whether a live
-#      session owns that worktree (liveness keys on session name = worktree
-#      basename, #872 — NOT cwd). The first live session found wins: take the
-#      sessionId (the first TSV field) and `exec claude --resume <sessionId>` so
-#      the user supplies the pending input. Resume wins over fresh whenever any
-#      labeled item is live.
-#   3. If no labeled item has a live session anywhere, `exec claude /office-hours`
-#      — a fresh interactive session running the /office-hours skill, which picks
-#      up a sessionless labeled item. An empty queue naturally lands here too.
+# Liveness now lives entirely in the selector, under a single UNKNOWN→skip
+# fail-safe convention — the old entry-vs-selector dual-convention coordination
+# (this script treating UNKNOWN as not-resumable while the selector treated it as
+# occupied) is gone, because the enumeration is no longer duplicated.
 #
-# A non-zero return from claude_sessions_with_name (UNKNOWN daemon) or empty
-# output means "nothing resumable here" → fall through to the next path/issue,
-# and ultimately to the fresh /office-hours session. This mirrors
-# office-hours-select-target's fail-safe convention from the other direction:
-# select-target treats UNKNOWN as occupied (left for resume); here UNKNOWN is
-# treated as not-resumable (fall through to fresh), so the two paths never both
-# claim an item whose liveness cannot be determined.
-#
-# Sandbox: the liveness check shells out to `claude agents --json` (via
+# Sandbox: the selector shells out to `claude agents --json` (via
 # lib-claude-agents.sh), which reaches the local daemon over a Unix socket — run
 # this script with `dangerouslyDisableSandbox: true`. See `.claude/rules/sandbox.md`.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/lib.sh"
-source "$SCRIPT_DIR/lib-claude-agents.sh"
 
+# Launch target only. The selector reads CLAUDE_AGENTS_CMD from the environment
+# for its own liveness queries (default `claude`); this script does not set it.
 CLAUDE_CMD="${OFFICE_HOURS_CLAUDE_CMD:-claude}"
-# The sourced helper reads CLAUDE_AGENTS_CMD for its own `claude agents --json`
-# call; point it at the same command so a single fake covers both the liveness
-# query and the launch.
-export CLAUDE_AGENTS_CMD="$CLAUDE_CMD"
 
-# Open issues carrying dispatch:office-hours, with their creation times — the
-# same query office-hours-select-target uses.
-ISSUE_LIST=$(gh issue list --label dispatch:office-hours --state open --json number,createdAt)
-
-# Map each registered <N>-* worktree to its on-disk path(s), keyed by issue
-# number — identical construction to office-hours-select-target.
-declare -A WORKTREE_PATHS_BY_NUM=()
-while IFS= read -r wt_record; do
-  split_worktree_record "$wt_record"
-  [[ -z "$WT_PATH" ]] && continue
-  if [[ -n "$WT_NUM" ]]; then
-    WORKTREE_PATHS_BY_NUM["$WT_NUM"]="${WORKTREE_PATHS_BY_NUM[$WT_NUM]:-}$WT_PATH"$'\n'
-  fi
-done < <(list_worktree_records)
-
-# Oldest-first: the first live session found wins.
-SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[].number')
-while IFS= read -r issue_num; do
-  [[ -z "$issue_num" ]] && continue
-  paths="${WORKTREE_PATHS_BY_NUM[$issue_num]:-}"
-  [[ -z "$paths" ]] && continue
-  while IFS= read -r path; do
-    [[ -z "$path" ]] && continue
-    # A non-zero return (UNKNOWN daemon) or empty output = "nothing resumable
-    # here" → continue to the next path/issue.
-    if sessions=$(claude_sessions_with_name "$(basename "$path")") && [[ -n "$sessions" ]]; then
-      # The sessionId is the first TSV field of the first line.
-      session_id=$(printf '%s\n' "$sessions" | head -n 1 | cut -f1)
-      exec "$CLAUDE_CMD" --resume "$session_id"
-    fi
-  done <<< "$paths"
-done <<< "$SORTED"
-
-# No labeled item has a live session (or the queue is empty): start fresh.
-exec "$CLAUDE_CMD" "/office-hours"
+# One call to the single source of truth; dispatch on the returned verb.
+directive=$("$SCRIPT_DIR/office-hours-select-target")
+read -r verb a b c <<< "$directive"
+case "$verb" in
+  resume|parked-router)
+    # a = the live worker / parked-router sessionId.
+    exec "$CLAUDE_CMD" --resume "$a"
+    ;;
+  office-hours)
+    # a b c = <N> <phase> <pr-or-dash>, passed through so /office-hours Step 0
+    # uses them and skips re-selection.
+    exec "$CLAUDE_CMD" "/office-hours $a $b $c"
+    ;;
+  empty)
+    echo "office-hours: queue is empty — nothing to resume or start."
+    exit 0
+    ;;
+  *)
+    echo "office-hours: unexpected directive from office-hours-select-target: $directive" >&2
+    exit 1
+    ;;
+esac

--- a/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
-# office-hours-select-target — select one office-hours item for /office-hours.
+# office-hours-select-target — emit a complete disposition for the office-hours
+# queue. This selector is the single source of truth: it enumerates the queue
+# once and the thin `office-hours` entry-script dispatcher and the /office-hours
+# skill consume its verb without re-enumerating.
 #
 # The office-hours queue is "open issues carrying the dispatch:office-hours
-# label" (the label is issue-anchored, #868/#909). This script selects the
-# oldest such issue whose <N>-* worktree has NO live Claude session — a
-# sessionless item that /office-hours can pick up fresh. An item that still
-# has a live session is left for the `office-hours` entry-point script (#759)
-# to resume; it is not selected here.
+# label" (the label is issue-anchored, #868/#909). The selector enumerates those
+# issues oldest-first, makes ONE per-item liveness call against each item's
+# <N>-* worktree, and emits exactly one of four dispositions, in this priority:
 #
-# Output (one line on success):
+#   resume <sessionId>
+#     The oldest labeled item whose <N>-* worktree has a live Claude session.
+#     Resume wins over fresh: if any labeled item is live, its session is
+#     resumed in preference to picking up a sessionless sibling fresh.
 #   office-hours <issue> <phase> <pr-or-dash>
+#     The oldest labeled item with NO live session — a sessionless item that
+#     /office-hours picks up fresh.
 #     <issue> — the selected issue number.
 #     <phase> — implement | qa | code-review | review | security | verify |
 #               waiting | done. `waiting` comes from dispatch-ci-ready (draft PR
@@ -20,15 +26,22 @@
 #     <pr-or-dash> — the issue's open PR number, or `-` when none exists.
 #   parked-router <sessionId> <name>
 #     A target-less parked /dispatch-propagate router (#1010). When no labeled
-#     sessionless item exists, this fallback surfaces a live, idle/waiting
+#     item is resumable or sessionless, this fallback surfaces a live, idle/waiting
 #     `dispatch-*` router session rooted under worktrees/main — the artifact the
 #     continuation invariant in `dispatch-self-close` keeps alive rather than
 #     orphaning the chain. A parked router has no issue/PR and so no
 #     dispatch:office-hours label; the human resumes it by re-engaging that exact
 #     session (re-running /dispatch-propagate inside it). A `busy` router is
 #     actively ticking and is NOT surfaced.
-# Prints `empty` when neither a sessionless labeled item nor a parked router
-# exists.
+#   empty
+#     None of the above exists.
+#
+# Single fail-safe convention: UNKNOWN → skip. When an item's liveness cannot be
+# determined (the daemon could not be queried for some worktree, and no worktree
+# was found live), the item is skipped entirely — neither resumed nor picked up
+# fresh. Skipping avoids a double-claim: a single source of truth no longer needs
+# the opposite-convention coordination that the entry script and this selector
+# previously split between them.
 #
 # Reuses dispatch-phase and dispatch-find-pr (passed a shared open-PR list to
 # avoid redundant gh calls), and the lib.sh / lib-claude-agents.sh worktree
@@ -42,9 +55,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
-# worktree_has_live_session is fail-safe: an unqueryable daemon counts as
-# occupied, so an item whose liveness cannot be determined is left for the
-# resume path rather than double-claimed by a fresh /office-hours session.
 source "$SCRIPT_DIR/lib-claude-agents.sh"
 
 # Open issues carrying dispatch:office-hours, with their creation times.
@@ -62,49 +72,75 @@ while IFS= read -r wt_record; do
   fi
 done < <(list_worktree_records)
 
-# True when a live session owns any <num>-* worktree. No such worktree →
-# fast-path miss (return 1). Several matches → owned if any one is live.
-issue_has_live_worktree() {
-  local num="$1" p
+# Returns the sessionId of a live <num>-* worktree on stdout (rc 0), rc 1 if the
+# item is sessionless (no worktree, or every worktree queried clean), or rc 2 if
+# liveness is UNKNOWN for some worktree (daemon unqueryable) and none was live.
+# Single per-item liveness call; name-keyed via claude_sessions_with_name, the
+# same primitive worktree_has_live_session delegates to.
+issue_live_session_id() {
+  local num="$1" p sessions sid saw_unknown=0
   local paths="${WORKTREE_PATHS_BY_NUM[$num]:-}"
   [[ -z "$paths" ]] && return 1
   while IFS= read -r p; do
     [[ -z "$p" ]] && continue
-    if worktree_has_live_session "$p"; then
-      return 0
+    if sessions=$(claude_sessions_with_name "$(basename "$p")"); then
+      if [[ -n "$sessions" ]]; then
+        sid=$(printf '%s\n' "$sessions" | head -n 1 | cut -f1)
+        printf '%s' "$sid"
+        return 0
+      fi
+    else
+      saw_unknown=1
     fi
   done <<< "$paths"
+  (( saw_unknown )) && return 2
   return 1
 }
 
-# One shared open-PR list for the per-issue dispatch-phase / dispatch-find-pr
-# calls (mirrors dispatch-select-target passing DISPATCH_PR_LIST). The field
-# set is dispatch-phase's superset; dispatch-find-pr accepts it too.
-PR_LIST=$(gh pr list --state open --json number,headRefName,isDraft,statusCheckRollup,labels)
-
-# Oldest-first: the first sessionless labeled issue wins.
+# Single oldest-first enumeration with one per-item liveness call. RESUME wins
+# over FRESH: a live item is resumed in preference to any sessionless sibling.
 SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[].number')
+FRESH_NUM=""
+RESUME_ID=""
 while IFS= read -r issue_num; do
   [[ -z "$issue_num" ]] && continue
-  # Skip an item whose <N>-* worktree is owned by a live session — that one is
-  # resumed by the entry point, not picked up fresh here.
-  if issue_has_live_worktree "$issue_num"; then
-    continue
+  if sid=$(issue_live_session_id "$issue_num"); then
+    RESUME_ID="$sid"
+    break
+  else
+    rc=$?
+    [[ "$rc" -eq 2 ]] && continue            # UNKNOWN → skip
+    [[ -z "$FRESH_NUM" ]] && FRESH_NUM="$issue_num"   # rc 1 → sessionless
   fi
+done <<< "$SORTED"
+
+# Priority 1: resume the oldest live item.
+if [[ -n "$RESUME_ID" ]]; then
+  printf 'resume %s\n' "$RESUME_ID"
+  exit 0
+fi
+
+# Priority 2: pick up the oldest sessionless item fresh. The open-PR list is
+# fetched lazily here — only the fresh path needs it, so the resume path makes
+# no `gh pr list` call. The field set is dispatch-phase's superset;
+# dispatch-find-pr accepts it too (mirrors dispatch-select-target's
+# DISPATCH_PR_LIST).
+if [[ -n "$FRESH_NUM" ]]; then
+  PR_LIST=$(gh pr list --state open --json number,headRefName,isDraft,statusCheckRollup,labels)
   # Readiness gate: dispatch-phase no longer emits `waiting`; check CI readiness
   # first. A not-ready draft PR (exit non-zero) maps to phase=waiting, preserving
   # the byte-identical output contract callers expect.
-  if ! DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-ci-ready" "$issue_num" >/dev/null; then
+  if ! DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-ci-ready" "$FRESH_NUM" >/dev/null; then
     phase="waiting"
   else
-    phase=$(DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-phase" "$issue_num")
+    phase=$(DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-phase" "$FRESH_NUM")
   fi
-  pr=$(DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-find-pr" "$issue_num")
-  printf 'office-hours %s %s %s\n' "$issue_num" "$phase" "${pr:--}"
+  pr=$(DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-find-pr" "$FRESH_NUM")
+  printf 'office-hours %s %s %s\n' "$FRESH_NUM" "$phase" "${pr:--}"
   exit 0
-done <<< "$SORTED"
+fi
 
-# No sessionless labeled item. Fall back to surfacing a target-less parked
+# No resumable or sessionless labeled item. Fall back to surfacing a target-less parked
 # router (#1010): a live, idle/waiting `dispatch-*` router session rooted under
 # worktrees/main, kept alive by dispatch-self-close's continuation invariant. It
 # carries no issue/PR, so no label anchors it — discover it directly by cwd +

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1375,8 +1375,9 @@ FAKE
 # a live session row (sessionId `s-<name>`). The fake branches on its first arg:
 # `agents` returns the JSON payload (the liveness query); any other invocation —
 # `--resume <id>` or `/office-hours` — prints `LAUNCH: $*` so a test can assert
-# which launch fired. Wired via OFFICE_HOURS_CLAUDE_CMD (the script exports it as
-# CLAUDE_AGENTS_CMD, so a single fake covers both the query and the launch).
+# which launch fired. Wires both OFFICE_HOURS_CLAUDE_CMD (the entry script's
+# launch target) and CLAUDE_AGENTS_CMD (the selector subprocess's liveness query)
+# at the same fake, so a single binary serves both the query and the launch.
 office_hours_fake_claude() {
   local payload="[" name first=1
   for name in "$@"; do
@@ -1399,6 +1400,10 @@ exit 0
 FAKE
   chmod +x "$TMPDIR_TEST/bin/claude"
   export OFFICE_HOURS_CLAUDE_CMD="$TMPDIR_TEST/bin/claude"
+  # The entry script no longer queries liveness itself; the selector subprocess
+  # it invokes does. Point CLAUDE_AGENTS_CMD at the same fake so a single binary
+  # serves the selector's `agents` query and the entry script's launch.
+  export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/bin/claude"
 }
 
 # 1. A non-QA PR is chosen over a QA PR and a help-wanted issue.
@@ -3302,12 +3307,16 @@ teardown
 echo ""
 echo "=== office-hours (entry point) ==="
 #
-# The single user entry point to the office-hours queue (#759). Resumes a still-
-# live blocked session (`claude --resume <sessionId>`) if any labeled item has
-# one; otherwise starts a fresh `/office-hours` session. office_hours_fake_claude
-# serves the liveness payload on `agents` and prints `LAUNCH: $*` on launch, so
-# each case asserts which launch fired. The fake's sessionId convention is
-# `s-<worktree-basename>`.
+# The single user entry point to the office-hours queue (#759). It is now a thin
+# dispatcher: it calls office-hours-select-target once and switches on the verb —
+# resume / parked-router (exec `claude --resume <sessionId>`), fresh-with-args
+# (exec `claude "/office-hours <N> <phase> <pr>"`), or empty (print a queue-empty
+# message and exit WITHOUT launching). These are therefore entry+selector
+# integration tests: setup copies the real selector into TMPDIR_TEST, the
+# selector emits the disposition, and office_hours_fake_claude serves the
+# selector's `agents` liveness query and prints `LAUNCH: $*` on launch so each
+# case asserts which launch fired (or that none did). The fake's sessionId
+# convention is `s-<worktree-basename>`.
 
 # OH1. One labeled item whose <N>-* worktree has a live session → resume it.
 echo "Test: live-session labeled item → resume its session"
@@ -3332,8 +3341,11 @@ result=$("$TMPDIR_TEST/office-hours")
 assert_eq "resumes the oldest live item's session" "LAUNCH: --resume s-42-x" "$result"
 teardown
 
-# OH3. Labeled items but none with a live session → start fresh /office-hours.
-echo "Test: labeled items, none live → fresh /office-hours"
+# OH3. Labeled items but none with a live session → start fresh /office-hours,
+# with the selected target's <N> <phase> <pr> passed through as arguments. The
+# selector emits `office-hours 42 implement -`; the entry execs
+# `/office-hours 42 implement -`.
+echo "Test: labeled items, none live → fresh /office-hours with passed args"
 setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdAt":"2024-02-01T00:00:00Z"}]\n' \
   > "$STUB_DIR/oh-issue-list.json"
@@ -3341,17 +3353,20 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktre
   > "$STUB_DIR/worktree-list.txt"
 office_hours_fake_claude   # orphan world: no live sessions
 result=$("$TMPDIR_TEST/office-hours")
-assert_eq "no live session → fresh /office-hours" "LAUNCH: /office-hours" "$result"
+assert_eq "no live session → fresh /office-hours with args" "LAUNCH: /office-hours 42 implement -" "$result"
 teardown
 
-# OH4. Empty office-hours queue → start fresh /office-hours.
-echo "Test: empty queue → fresh /office-hours"
+# OH4. Empty office-hours queue → selector emits `empty` → the entry script prints
+# the queue-empty message and exits WITHOUT launching Claude.
+echo "Test: empty queue → queue-empty message, no launch"
 setup
 echo '[]' > "$STUB_DIR/oh-issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
-office_hours_fake_claude
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+office_hours_fake_claude   # `[]`: no sessions under main, no parked router
 result=$("$TMPDIR_TEST/office-hours")
-assert_eq "empty queue → fresh /office-hours" "LAUNCH: /office-hours" "$result"
+assert_eq "empty queue → queue-empty message, no launch" "office-hours: queue is empty — nothing to resume or start." "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 
 # OH5. Mixed: an older sessionless item + a newer live-session item → resume the
@@ -3368,28 +3383,25 @@ result=$("$TMPDIR_TEST/office-hours")
 assert_eq "resume wins over fresh whenever any labeled item is live" "LAUNCH: --resume s-99-y" "$result"
 teardown
 
-# OH6. UNKNOWN daemon (claude unqueryable) → fall through to fresh /office-hours.
-# This is the entry-point's deliberate asymmetry with office-hours-select-target:
-# select-target (OHST5) treats UNKNOWN as occupied (left for resume); the entry
-# point treats UNKNOWN as not-resumable (fall through to fresh), so the two paths
-# never both claim an item whose liveness cannot be determined.
-echo "Test: UNKNOWN daemon → not-resumable, fall through to fresh /office-hours"
+# OH6. UNKNOWN daemon (claude unqueryable). Under the single fail-safe convention
+# the only labeled item (42) is UNKNOWN → skipped by the selector, and the
+# parked-router fallback also reads UNKNOWN → no router, so the selector emits
+# `empty`. The entry script prints the queue-empty message and does not launch.
+# (The old entry-vs-selector asymmetry — entry treating UNKNOWN as not-resumable
+# and falling through to a fresh session — is gone; UNKNOWN is occupied
+# everywhere now that the enumeration is no longer duplicated.)
+echo "Test: UNKNOWN daemon → selector empty → queue-empty message, no launch"
 setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
   > "$STUB_DIR/worktree-list.txt"
-# OFFICE_HOURS_CLAUDE_CMD must be set so the script has a launch target and so
-# CLAUDE_AGENTS_CMD is overridden to a command that reports UNKNOWN (non-zero
-# exit). Re-use the office_hours_fake_claude stub but wire it with no live
-# sessions, then make the agents call fail to exercise the UNKNOWN path.
-office_hours_fake_claude   # sets OFFICE_HOURS_CLAUDE_CMD=TMPDIR_TEST/bin/claude
-# Override the claude binary so agents query always exits 1 (UNKNOWN daemon),
-# but launch invocations still print "LAUNCH: $*" so the test can assert which
-# launch fired.
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+office_hours_fake_claude   # sets OFFICE_HOURS_CLAUDE_CMD + CLAUDE_AGENTS_CMD
+# Override the claude binary so the `agents` query always exits 1 (UNKNOWN
+# daemon), while launch invocations still print "LAUNCH: $*".
 cat > "$TMPDIR_TEST/bin/claude" <<'FAKE'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "agents" ]]; then
-  # Simulate an unqueryable daemon: non-zero exit, no output.
   exit 1
 fi
 echo "LAUNCH: $*"
@@ -3397,7 +3409,34 @@ exit 0
 FAKE
 chmod +x "$TMPDIR_TEST/bin/claude"
 result=$("$TMPDIR_TEST/office-hours")
-assert_eq "UNKNOWN daemon → not-resumable → fresh /office-hours" "LAUNCH: /office-hours" "$result"
+assert_eq "UNKNOWN daemon → selector empty → queue-empty message, no launch" "office-hours: queue is empty — nothing to resume or start." "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
+teardown
+
+# OH7. The selector emits `parked-router <sessionId> <name>` (a target-less
+# parked dispatch router, #1010) → the entry script resumes that session. The
+# entry script gains the parked-router handling the selector already had.
+echo "Test: parked-router directive → entry resumes the router session"
+setup
+echo '[]' > "$STUB_DIR/oh-issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+office_hours_fake_claude   # sets OFFICE_HOURS_CLAUDE_CMD + CLAUDE_AGENTS_CMD
+# A live, idle `dispatch-*` router under main on the `agents` query; launch
+# invocations still print "LAUNCH: $*".
+cat > "$TMPDIR_TEST/bin/claude" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "agents" ]]; then
+  printf '%s' '[{"sessionId":"s-dispatch-abc123","pid":1,"status":"waiting","name":"dispatch-abc123","cwd":""}]'
+  exit 0
+fi
+echo "LAUNCH: $*"
+exit 0
+FAKE
+chmod +x "$TMPDIR_TEST/bin/claude"
+result=$("$TMPDIR_TEST/office-hours")
+assert_eq "parked-router directive resumes the router session" "LAUNCH: --resume s-dispatch-abc123" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3051,18 +3051,47 @@ result=$("$TMPDIR_TEST/office-hours-select-target")
 assert_eq "qa item selected with its PR number" "office-hours 50 qa 7" "$result"
 teardown
 
-# OHST3. A labeled item whose <N>-* worktree has a live session is skipped; the
-# next labeled item wins.
-echo "Test: labeled item with a live session is skipped"
+# OHST3. The oldest labeled item whose <N>-* worktree has a live session is
+# RESUMED — resume wins over a sessionless newer sibling.
+echo "Test: oldest live-session item is resumed (resume wins over fresh sibling)"
 setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdAt":"2024-02-01T00:00:00Z"}]\n' \
   > "$STUB_DIR/oh-issue-list.json"
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
   > "$STUB_DIR/worktree-list.txt"
-select_target_fake_claude "42-x"   # 42's worktree has a live session
+select_target_fake_claude "42-x"   # 42's worktree has a live session; 99 sessionless
 result=$("$TMPDIR_TEST/office-hours-select-target")
-assert_eq "live-session item skipped; next labeled item selected" "office-hours 99 implement -" "$result"
+assert_eq "live item resumed over sessionless sibling 99" "resume s-42-x" "$result"
+teardown
+
+# OHST3b. Two labeled items both live → resume the oldest one's session
+# (mirrors OH2 on the entry-point side).
+echo "Test: two live items → oldest resumed"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdAt":"2024-02-01T00:00:00Z"}]\n' \
+  > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\nworktree /worktrees/99-y\nHEAD aaa111\nbranch refs/heads/99-y\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+select_target_fake_claude "42-x" "99-y"   # both worktrees live
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "oldest of two live items resumed" "resume s-42-x" "$result"
+teardown
+
+# OHST3c. Older sessionless item + newer live item → resume the live one
+# (mirrors OH5: resume wins regardless of age order).
+echo "Test: older sessionless + newer live → resume the live one"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdAt":"2024-02-01T00:00:00Z"}]\n' \
+  > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+# 42 (older) has no worktree at all → sessionless; 99 (newer) has a live worktree.
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/99-y\nHEAD aaa111\nbranch refs/heads/99-y\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+select_target_fake_claude "99-y"   # only 99's worktree is live
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "live item resumed regardless of age order" "resume s-99-y" "$result"
 teardown
 
 # OHST4. An empty office-hours queue with no parked router prints `empty`. The

--- a/.claude/skills/office-hours/SKILL.md
+++ b/.claude/skills/office-hours/SKILL.md
@@ -40,19 +40,38 @@ hand-off and no Stop-hook action — the Stop hook ignores non-`<N>-` session na
 
 0. **Select and locate the target.**
 
-   Run the selection script (use `dangerouslyDisableSandbox: true` — it queries
-   `gh` and `claude agents --json`):
+   **Args-first (normal dispatched path).** When ARGUMENTS contains `<N> <phase>
+   <pr>` — passed by the `office-hours` entry script, which already ran the
+   selector before launching this skill — take `<N>`, `<phase>`, and `<pr>`
+   directly from ARGUMENTS and skip selection entirely:
+
+   ```bash
+   read -r N PHASE PR <<<"$ARGUMENTS"
+   ```
+
+   The selector has already chosen this target; re-running it would re-enumerate
+   the same state inside this freshly-booted session, exactly the waste this
+   design removes. Go straight to "Enter the item's worktree" below.
+
+   **Bare-invocation fallback (human typing `/office-hours` in an existing
+   session).** When ARGUMENTS is empty, run the selector (use
+   `dangerouslyDisableSandbox: true` — it queries `gh` and `claude agents
+   --json`):
 
    ```bash
    .claude/skills/dispatch-propagate/scripts/office-hours-select-target
    ```
 
-   It prints one line:
+   It prints one line — one of four dispositions:
 
-   - `empty` — no sessionless office-hours item exists. Report that and **stop**.
    - `office-hours <N> <phase> <pr-or-dash>` — the selected issue `<N>`, its
-     phase, and its PR number (or `-`). Carry `<N>`, `<phase>`, and the PR
-     through the rest of the skill.
+     phase, and its PR number (or `-`). Carry `<N>`, `<phase>`, and `<pr>`
+     through the rest of the skill (same as the args-first path above). Proceed
+     to "Enter the item's worktree" below.
+   - `resume <sessionId>` — a labeled item whose `<N>-*` worktree has a live
+     session. This skill cannot resume a session from within an already-running
+     session. Report the session ID and tell the user to run
+     `claude --resume <sessionId>` to re-engage it. **Stop.**
    - `parked-router <sessionId> <name>` — the dispatch chain has a target-less
      parked router (#1010): a router tick left no continuation, so the
      `dispatch-self-close` continuation invariant kept the session alive rather
@@ -61,10 +80,12 @@ hand-off and no Stop-hook action — the Stop hook ignores non-`<N>-` session na
      issue/PR. Resume it by re-engaging that exact session: re-run
      `/dispatch-propagate` inside the `<name>` session (`<sessionId>`). Report
      that and **stop**.
+   - `empty` — no item to resume or start. Report that and **stop**.
 
-   **Enter the item's worktree.** If the current branch is already `<N>-…`, you
-   are in place — proceed. Otherwise resolve the worktree (use
-   `dangerouslyDisableSandbox: true`):
+   **Enter the item's worktree.** Both the args-first path and the bare
+   `office-hours` verb arrive here with `<N>` in hand. If the current branch is
+   already `<N>-…`, you are in place — proceed. Otherwise resolve the worktree
+   (use `dangerouslyDisableSandbox: true`):
 
    ```bash
    .claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree <N> explicit

--- a/nix/packages/office-hours.nix
+++ b/nix/packages/office-hours.nix
@@ -1,8 +1,10 @@
 { pkgs }:
 
 # Foreground wrapper that execs the in-repo office-hours entry script.
-# Resume-vs-fresh behavior is unchanged (the script itself execs
-# `claude --resume` or `claude /office-hours`).
+# The entry script is a thin dispatcher over office-hours-select-target's
+# disposition: resume / parked-router (exec `claude --resume <sessionId>`),
+# fresh-with-args (exec `claude "/office-hours <N> <phase> <pr>"`), or empty
+# (print a queue-empty message and exit without launching).
 # Execs the in-repo checkout script rather than vendoring it into the Nix store,
 # because office-hours calls sibling scripts via $SCRIPT_DIR and needs gh,
 # the local Claude daemon, and tmp state from the checkout.


### PR DESCRIPTION
Closes #1104

## What

The office-hours queue had two scripts enumerating the same ground truth — the
`office-hours` entry script (resume-vs-fresh) and `office-hours-select-target`
(pick the sessionless item / parked-router / empty). On the fresh path the entry
script enumerated, found no live session, and booted `claude /office-hours`,
whose Step 0 then re-ran the selector — re-enumerating the same state inside a
freshly-booted session that had already paid to load the large SKILL.md. The
empty-queue case booted a full session whose only output was "queue is empty".
The two scripts also ran opposite UNKNOWN-daemon fail-safe conventions purely to
keep the duplicated enumerations from double-claiming an item.

This makes one selector the single source of truth, the entry script a thin
dispatcher, and the skill args-first.

## Changes (one commit per unit)

1. **`office-hours-select-target`** emits a complete disposition —
   `resume <sessionId>` / `office-hours <N> <phase> <pr>` /
   `parked-router <sessionId> <name>` / `empty` — from one oldest-first
   enumeration with a single per-item liveness check and one UNKNOWN→skip
   fail-safe. Resume wins over fresh. The fresh branch fetches the open-PR list
   lazily so the resume path makes no `gh pr list` call.
2. **`office-hours` entry script** is now a thin dispatcher: it calls the
   selector once and switches on the verb — resume/parked-router exec
   `claude --resume <id>`; office-hours execs `claude "/office-hours <N> <phase>
   <pr>"` (passing the selected target so the skill skips re-selection); empty
   prints a message and exits without launching Claude. The entry script gains
   the #1010 parked-router handling that only the selector had. The old
   dual-convention coordination is gone.
3. **`/office-hours` Step 0** is args-first: it uses the passed
   `<N> <phase> <pr>` and skips selection; only a bare `/office-hours` (a human
   typing it inside an existing session) runs the selector, which now documents
   all four verbs including `resume`.

Net effect: a Claude session + skill context loads only when there is actual
residue work; empty and resume are handled entirely in bash; the selector runs
once.

## Tests

`test-dispatch-scripts.sh` covers the new `resume` verb from the selector
(OHST3 rewritten + two new oldest-of-two-live / older-sessionless-plus-newer-live
cases) and the entry script's empty / resume / fresh-with-args / parked-router
dispatch (OH3 passes args through, OH4/OH6 become no-launch empty, OH7 adds
parked-router dispatch). Suite: 1620/1620 passed.