### PR TITLE
dispatch: headless rate-limit telemetry refresh for dispatch-tick

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-refresh-rate-limits
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-refresh-rate-limits
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# dispatch-refresh-rate-limits — headless rate-limit telemetry probe for #1127.
+#
+# The autonomous dispatch chain runs headlessly. Its budget telemetry
+# (rate_limits.json) has historically had exactly ONE writer: the statusLine
+# hook (statusline.sh -> update-rate-limits.sh), which lifts the .rate_limits
+# field Claude Code passes on stdin when a session renders its status line.
+# When the chain fully pauses with zero live sessions and no interactive
+# session open, nothing renders a status line, so rate_limits.json freezes at
+# the cap-hit snapshot — and a reseed-fired tick re-reads that frozen file,
+# computes target 0, and stalls even though the budget has reopened.
+#
+# This probe gives the headless path its own telemetry source. It fetches the
+# unified rate-limit response headers from the Anthropic messages endpoint
+# (the same 5h/7d windows Claude Code forwards into the status-line hook) and
+# writes rate_limits.json in the existing schema (five_hour/seven_day ->
+# used_percentage, resets_at), reusing update-rate-limits.sh's atomic write.
+# The status-line hook remains a valid writer — no format divergence.
+#
+# FAIL-SAFE CONTRACT (per .claude/rules/code-style.md; AC #4 of #1127 makes the
+# fall-back-to-cache-and-log degradation an explicit requirement, NOT an
+# accidental fallback): every failure path logs exactly one stderr diagnostic,
+# exits non-zero, and never touches the cached file or echoes the access token
+# in output. Exit 0 ONLY on a successful write. A probe outage (network,
+# missing creds, expired token, missing/malformed headers) therefore degrades
+# to today's behavior — the tick keeps the cached telemetry — rather than
+# erroring the tick.
+#
+# Token refresh is out of scope: this uses the stored access token as-is and
+# degrades safely on expiry (logs and exits non-zero).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CREDS="${DISPATCH_REFRESH_RATE_LIMITS_CREDS:-$HOME/.claude/.credentials.json}"
+if [[ ! -r "$CREDS" ]]; then
+  echo "dispatch-refresh-rate-limits: credentials not found at $CREDS; keeping cached telemetry" >&2
+  exit 1
+fi
+
+TOKEN=$(jq -r '.claudeAiOauth.accessToken // empty' "$CREDS")
+EXPIRES_AT=$(jq -r '.claudeAiOauth.expiresAt // empty' "$CREDS")
+if [[ -z "$TOKEN" || -z "$EXPIRES_AT" ]]; then
+  echo "dispatch-refresh-rate-limits: access token or expiry missing from credentials; keeping cached telemetry" >&2
+  exit 1
+fi
+
+now_ms=$(( $(date +%s) * 1000 ))
+if [[ ! "$EXPIRES_AT" =~ ^[0-9]+$ ]] || (( EXPIRES_AT <= now_ms )); then
+  echo "dispatch-refresh-rate-limits: token expired; keeping cached telemetry" >&2
+  exit 1
+fi
+
+ENDPOINT="${DISPATCH_REFRESH_RATE_LIMITS_ENDPOINT:-https://api.anthropic.com/v1/messages}"
+MODEL="${DISPATCH_REFRESH_RATE_LIMITS_MODEL:-claude-haiku-4-5-20251001}"
+
+# TEST SEAM: read headers from a file instead of the network (no eval).
+if [[ -n "${DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE:-}" ]]; then
+  HEADERS="$(cat "$DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE")"
+else
+  HEADERS=$(curl -sS -D - -o /dev/null --connect-timeout 5 --max-time 10 \
+    -H "authorization: Bearer $TOKEN" \
+    -H "anthropic-version: 2023-06-01" \
+    -H "anthropic-beta: oauth-2025-04-20" \
+    -H "content-type: application/json" \
+    -d "{\"model\":\"$MODEL\",\"max_tokens\":1,\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}" \
+    "$ENDPOINT") || { echo "dispatch-refresh-rate-limits: probe request failed; keeping cached telemetry" >&2; exit 1; }
+fi
+
+# Parse a header value: case-insensitive name match, last occurrence wins,
+# strip the value of surrounding whitespace and a trailing CR.
+header_val() { printf '%s\n' "$HEADERS" | grep -i "^$1:" | tail -n1 | sed 's/^[^:]*://; s/[[:space:]]//g; s/\r$//'; }
+
+U5=$(header_val "anthropic-ratelimit-unified-5h-utilization")
+R5=$(header_val "anthropic-ratelimit-unified-5h-reset")
+U7=$(header_val "anthropic-ratelimit-unified-7d-utilization")
+R7=$(header_val "anthropic-ratelimit-unified-7d-reset")
+
+# Validate: utilization is a non-negative decimal; reset is an epoch integer.
+# A 429 still carries these headers, so status is irrelevant — only
+# missing/malformed values are a failure.
+if [[ ! "$U5" =~ ^[0-9]+(\.[0-9]+)?$ ]] || \
+   [[ ! "$U7" =~ ^[0-9]+(\.[0-9]+)?$ ]] || \
+   [[ ! "$R5" =~ ^[0-9]+$ ]] || \
+   [[ ! "$R7" =~ ^[0-9]+$ ]]; then
+  echo "dispatch-refresh-rate-limits: rate-limit headers missing or malformed; keeping cached telemetry" >&2
+  exit 1
+fi
+
+# Utilization is a fraction (0..1); convert to integer percent, rounded.
+P5=$(awk -v u="$U5" 'BEGIN{printf "%d", int(u*100 + 0.5)}')
+P7=$(awk -v u="$U7" 'BEGIN{printf "%d", int(u*100 + 0.5)}')
+
+PAYLOAD=$(printf '{"rate_limits":{"five_hour":{"used_percentage":%d,"resets_at":%d},"seven_day":{"used_percentage":%d,"resets_at":%d}}}' "$P5" "$R5" "$P7" "$R7")
+if ! printf '%s' "$PAYLOAD" | "$SCRIPT_DIR/update-rate-limits.sh" >/dev/null; then
+  echo "dispatch-refresh-rate-limits: atomic write via update-rate-limits.sh failed; cache may be unchanged" >&2
+  exit 1
+fi
+
+echo "dispatch-refresh-rate-limits: refreshed 5h=${P5}% 7d=${P7}%" >&2
+exit 0

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-refresh-rate-limits
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-refresh-rate-limits
@@ -45,6 +45,16 @@ if [[ -z "$TOKEN" || -z "$EXPIRES_AT" ]]; then
   exit 1
 fi
 
+# Validate the token's character set before placing it in an HTTP header. OAuth
+# access tokens are base64url/JWT (alnum plus . _ ~ + / = -); any other character
+# means a corrupted or tampered credentials file, and an embedded newline could
+# inject a header. Reject rather than send it. (Boundary check per
+# .claude/rules/code-style.md — input validation at a system edge, not a fallback.)
+if [[ ! "$TOKEN" =~ ^[A-Za-z0-9._~+/=-]+$ ]]; then
+  echo "dispatch-refresh-rate-limits: access token has unexpected characters; keeping cached telemetry" >&2
+  exit 1
+fi
+
 now_ms=$(( $(date +%s) * 1000 ))
 if [[ ! "$EXPIRES_AT" =~ ^[0-9]+$ ]] || (( EXPIRES_AT <= now_ms )); then
   echo "dispatch-refresh-rate-limits: token expired; keeping cached telemetry" >&2
@@ -54,10 +64,25 @@ fi
 ENDPOINT="${DISPATCH_REFRESH_RATE_LIMITS_ENDPOINT:-https://api.anthropic.com/v1/messages}"
 MODEL="${DISPATCH_REFRESH_RATE_LIMITS_MODEL:-claude-haiku-4-5-20251001}"
 
+# Validate the model name before interpolating it into the JSON request body.
+# Model IDs are alnum plus . _ - ; any other character (a quote, backslash, or
+# control char from a bad override) would produce malformed/injected JSON.
+if [[ ! "$MODEL" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "dispatch-refresh-rate-limits: model name has unexpected characters; keeping cached telemetry" >&2
+  exit 1
+fi
+
 # TEST SEAM: read headers from a file instead of the network (no eval).
 if [[ -n "${DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE:-}" ]]; then
   HEADERS="$(cat "$DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE")"
 else
+  # Never send the bearer token over a non-TLS endpoint: enforce https before the
+  # request leaves with the Authorization header. The default is https; a custom
+  # override (e.g. a fat-fingered http URL) must not silently leak credentials.
+  if [[ "$ENDPOINT" != https://* ]]; then
+    echo "dispatch-refresh-rate-limits: endpoint is not https; refusing to send credentials; keeping cached telemetry" >&2
+    exit 1
+  fi
   HEADERS=$(curl -sS -D - -o /dev/null --connect-timeout 5 --max-time 10 \
     -H "authorization: Bearer $TOKEN" \
     -H "anthropic-version: 2023-06-01" \
@@ -68,8 +93,8 @@ else
 fi
 
 # Parse a header value: case-insensitive name match, last occurrence wins,
-# strip the value of surrounding whitespace and a trailing CR.
-header_val() { printf '%s\n' "$HEADERS" | grep -i "^$1:" | tail -n1 | sed 's/^[^:]*://; s/[[:space:]]//g; s/\r$//'; }
+# strip the value of all whitespace (including any trailing CR from CRLF headers).
+header_val() { printf '%s\n' "$HEADERS" | grep -i "^$1:" | tail -n1 | sed 's/^[^:]*://; s/[[:space:]]//g'; }
 
 U5=$(header_val "anthropic-ratelimit-unified-5h-utilization")
 R5=$(header_val "anthropic-ratelimit-unified-5h-reset")

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -207,6 +207,21 @@ if [[ "$CLAUDE_CODE_SESSION_ID" == headless:* ]]; then
   fi
 fi
 
+# --- Step 0.5: refresh rate-limit telemetry (headless source) ----------------
+# The budget reads below (dispatch-select-tick -> dispatch-target-workers) consume
+# cached telemetry in rate_limits.json, whose ONLY status-line writer never runs in
+# the headless chain (no session renders a status line). When the chain fully pauses
+# and its reseed timer later fires, re-reading that frozen snapshot reports the
+# still-capped pre-reset state and nothing spawns — the budget reopened but the tick
+# cannot observe it (#1127). Refresh telemetry from a non-status-line source FIRST,
+# so every budget read this tick (and any reseed it arms) is computed against fresh
+# data. Fail-safe: a probe failure (network, expired token, malformed headers) logs
+# one note and the tick proceeds on the cached file — a probe outage degrades to the
+# prior behavior rather than erroring the tick.
+if ! "$SCRIPT_DIR/dispatch-refresh-rate-limits"; then
+  echo "dispatch-tick: rate-limit refresh probe failed; proceeding on cached telemetry (#1127)" >&2
+fi
+
 # --- Step 1: select the target ------------------------------------------------
 # Capture select-tick's full stdout and echo every line through (jit:/calendar:
 # passthrough AND the decision line) so journald and a live relay see it all.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -16447,6 +16447,7 @@ tick_setup() {
   cat > "$TMPDIR_TEST/dispatch-select-tick" <<FAKE
 #!/usr/bin/env bash
 echo "\$*" >> "$TMPDIR_TEST/logs/select-tick.log"
+echo "select" >> "$TMPDIR_TEST/logs/order.log"
 [[ -n "\${TICK_SEL_PRE:-}" ]] && printf '%s\n' "\$TICK_SEL_PRE"
 printf '%s\n' "\${TICK_DECISION:-empty}"
 exit \${TICK_SEL_RC:-0}
@@ -16468,9 +16469,19 @@ echo "\$*" >> "$TMPDIR_TEST/logs/spawn-job.log"
 echo "\${TICK_SPAWN_RESULT:-spawned}"
 exit 0
 FAKE
+  # Fake dispatch-refresh-rate-limits (#1127): records that it ran (to order.log
+  # for ordering assertions) and exits TICK_REFRESH_RC (default 0). The headless
+  # tick runs this before the budget read; tests assert it runs first and that a
+  # non-zero exit does not break the tick.
+  cat > "$TMPDIR_TEST/dispatch-refresh-rate-limits" <<FAKE
+#!/usr/bin/env bash
+echo refresh >> "$TMPDIR_TEST/logs/order.log"
+exit \${TICK_REFRESH_RC:-0}
+FAKE
   chmod +x "$TMPDIR_TEST/dispatch-select-tick" \
            "$TMPDIR_TEST/dispatch-materialize-spawn" \
-           "$TMPDIR_TEST/dispatch-spawn-job"
+           "$TMPDIR_TEST/dispatch-spawn-job" \
+           "$TMPDIR_TEST/dispatch-refresh-rate-limits"
 }
 
 tick_teardown() {
@@ -16478,7 +16489,7 @@ tick_teardown() {
   TMPDIR_TEST=""
   unset TICK_DECISION TICK_TOKEN TICK_SEL_RC TICK_MAT_RC \
     TICK_SEL_PRE TICK_MAT_PRE TICK_SPAWN_RESULT DISPATCH_TICK_MAIN_WORKTREE \
-    DISPATCH_LOCK_FILE
+    DISPATCH_LOCK_FILE TICK_REFRESH_RC
 }
 
 run_tick() { "$TMPDIR_TEST/dispatch-tick" "$@" 2>/dev/null; }
@@ -16863,6 +16874,26 @@ assert_eq "auto-cap: no materialize call" "0" \
   "$([ -f "$TMPDIR_TEST/logs/materialize.log" ] && echo 1 || echo 0)"
 assert_eq "auto-cap: no manual flag sent to select-tick" "0" \
   "$(grep -cF -- '--manual' "$TMPDIR_TEST/logs/select-tick.log" 2>/dev/null)"
+tick_teardown
+
+# --- #1127: refresh runs before select (budget read sees fresh telemetry) ----
+echo "Test: dispatch-tick refreshes telemetry before selecting (ordering)"
+tick_setup
+export TICK_DECISION="empty"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "refresh-ordering: exit 0" "0" "$rc"
+assert_eq "refresh-ordering: refresh runs before select" \
+  "$(printf 'refresh\nselect')" "$(cat "$TMPDIR_TEST/logs/order.log")"
+tick_teardown
+
+# --- #1127: probe failure is fail-safe — tick still routes its decision ------
+echo "Test: dispatch-tick refresh-probe failure does not break the tick"
+tick_setup
+export TICK_DECISION="empty" TICK_REFRESH_RC=1
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "refresh-failsafe: exit 0 despite probe failure" "0" "$rc"
+assert_eq "refresh-failsafe: tick still ran select after failed refresh" \
+  "$(printf 'refresh\nselect')" "$(cat "$TMPDIR_TEST/logs/order.log")"
 tick_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -18322,6 +18322,47 @@ assert_eq "malformed reset → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1
 assert_eq "malformed reset → no state file written" "1" "$([[ ! -e "$DISPATCH_RATE_LIMITS_STATE_FILE" ]] && echo 1 || echo 0)"
 rr_teardown
 
+# CASE 5c — tampered token: a token with characters outside the OAuth set
+# (a space) fails the charset guard before any header is placed → no write.
+rr_setup
+printf '{"claudeAiOauth":{"accessToken":"bad token","expiresAt":9999999999000}}\n' > "$TMPDIR_TEST/fix/creds.json"
+write_headers "$TMPDIR_TEST/fix/headers.txt" \
+  "$RR_H_5UTIL" "$RR_H_5RESET" "$RR_H_7UTIL" "$RR_H_7RESET"
+export DISPATCH_REFRESH_RATE_LIMITS_CREDS="$TMPDIR_TEST/fix/creds.json"
+export DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE="$TMPDIR_TEST/fix/headers.txt"
+if out=$("$TMPDIR_TEST/scripts/dispatch-refresh-rate-limits" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "tampered token → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "tampered token → no state file written" "1" "$([[ ! -e "$DISPATCH_RATE_LIMITS_STATE_FILE" ]] && echo 1 || echo 0)"
+rr_teardown
+
+# CASE 5d — bad model override: a model name with a quote fails the charset
+# guard before the JSON body is built → no write.
+rr_setup
+write_creds "$TMPDIR_TEST/fix/creds.json" 9999999999000
+write_headers "$TMPDIR_TEST/fix/headers.txt" \
+  "$RR_H_5UTIL" "$RR_H_5RESET" "$RR_H_7UTIL" "$RR_H_7RESET"
+export DISPATCH_REFRESH_RATE_LIMITS_CREDS="$TMPDIR_TEST/fix/creds.json"
+export DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE="$TMPDIR_TEST/fix/headers.txt"
+export DISPATCH_REFRESH_RATE_LIMITS_MODEL='haiku","injected":"x'
+if out=$("$TMPDIR_TEST/scripts/dispatch-refresh-rate-limits" 2>/dev/null); then rc=0; else rc=$?; fi
+unset DISPATCH_REFRESH_RATE_LIMITS_MODEL
+assert_eq "bad model override → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "bad model override → no state file written" "1" "$([[ ! -e "$DISPATCH_RATE_LIMITS_STATE_FILE" ]] && echo 1 || echo 0)"
+rr_teardown
+
+# CASE 5e — non-https endpoint: with the network branch taken (no headers seam),
+# a non-https ENDPOINT trips the TLS guard and exits before curl runs — the
+# bearer token is never sent in cleartext, and no state file is written.
+rr_setup
+write_creds "$TMPDIR_TEST/fix/creds.json" 9999999999000
+export DISPATCH_REFRESH_RATE_LIMITS_CREDS="$TMPDIR_TEST/fix/creds.json"
+export DISPATCH_REFRESH_RATE_LIMITS_ENDPOINT="http://127.0.0.1:9/never"
+if out=$("$TMPDIR_TEST/scripts/dispatch-refresh-rate-limits" 2>/dev/null); then rc=0; else rc=$?; fi
+unset DISPATCH_REFRESH_RATE_LIMITS_ENDPOINT
+assert_eq "non-https endpoint → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "non-https endpoint → no state file written" "1" "$([[ ! -e "$DISPATCH_RATE_LIMITS_STATE_FILE" ]] && echo 1 || echo 0)"
+rr_teardown
+
 # CASE 6 — refresh→budget regression for #1127. Seed a FROZEN pre-reset file
 # (used 95%, resets_at in the past); the probe overwrites it with reopened-window
 # telemetry; the REAL dispatch-target-workers then computes a positive target

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -18077,6 +18077,152 @@ assert_eq "open-pr: dedup primary → exactly one Closes #1119 line" "1" "$(grep
 assert_eq "open-pr: dedup primary → close set is 1119 1120" "$(printf '1119\n1120')" "$(cat "$TMPDIR_TEST/close-set.txt")"
 open_pr_teardown
 
+echo ""
+echo "=== dispatch-refresh-rate-limits ==="
+
+# Headless telemetry probe for #1127. The network fetch is replaced by the
+# DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE seam — tests NEVER make a real
+# request. update-rate-limits.sh's writer-path override
+# (DISPATCH_RATE_LIMITS_STATE_FILE) points the atomic write at a temp file.
+
+rr_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/state" "$TMPDIR_TEST/fix"
+  cp "$SCRIPT_DIR/dispatch-refresh-rate-limits" "$TMPDIR_TEST/scripts/"
+  cp "$SCRIPT_DIR/update-rate-limits.sh" "$TMPDIR_TEST/scripts/"
+  cp "$SCRIPT_DIR/dispatch-target-workers" "$TMPDIR_TEST/scripts/"
+  cp "$SCRIPT_DIR/dispatch-config-load" "$TMPDIR_TEST/scripts/"
+  cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-refresh-rate-limits" \
+           "$TMPDIR_TEST/scripts/update-rate-limits.sh" \
+           "$TMPDIR_TEST/scripts/dispatch-target-workers" \
+           "$TMPDIR_TEST/scripts/dispatch-config-load"
+  export DISPATCH_RATE_LIMITS_STATE_FILE="$TMPDIR_TEST/state/rate_limits.json"
+}
+rr_teardown() {
+  rm -rf "$TMPDIR_TEST"; TMPDIR_TEST=""
+  unset DISPATCH_RATE_LIMITS_STATE_FILE DISPATCH_REFRESH_RATE_LIMITS_CREDS \
+    DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE
+}
+write_creds() {  # $1=file $2=expiresAt-ms
+  printf '{"claudeAiOauth":{"accessToken":"test-token","expiresAt":%s}}\n' "$2" > "$1"
+}
+write_headers() {  # $1=file ; remaining args are literal header lines
+  local f="$1"; : > "$f"; shift; for line in "$@"; do printf '%s\n' "$line" >> "$f"; done
+}
+
+# Canonical valid headers reused across cases.
+RR_H_5UTIL="anthropic-ratelimit-unified-5h-utilization: 0.22"
+RR_H_5RESET="anthropic-ratelimit-unified-5h-reset: 1780611000"
+RR_H_7UTIL="anthropic-ratelimit-unified-7d-utilization: 0.54"
+RR_H_7RESET="anthropic-ratelimit-unified-7d-reset: 1780880400"
+
+# CASE 1 — success: valid creds + valid headers → exit 0, canonical telemetry.
+rr_setup
+write_creds "$TMPDIR_TEST/fix/creds.json" 9999999999000
+write_headers "$TMPDIR_TEST/fix/headers.txt" \
+  "$RR_H_5UTIL" "$RR_H_5RESET" "$RR_H_7UTIL" "$RR_H_7RESET"
+export DISPATCH_REFRESH_RATE_LIMITS_CREDS="$TMPDIR_TEST/fix/creds.json"
+export DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE="$TMPDIR_TEST/fix/headers.txt"
+if out=$("$TMPDIR_TEST/scripts/dispatch-refresh-rate-limits" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "refresh success → exit 0" "0" "$rc"
+got=$(jq -S . "$DISPATCH_RATE_LIMITS_STATE_FILE")
+want=$(printf '%s' '{"five_hour":{"used_percentage":22,"resets_at":1780611000},"seven_day":{"used_percentage":54,"resets_at":1780880400}}' | jq -S .)
+assert_eq "refresh success → canonical telemetry" "$want" "$got"
+rr_teardown
+
+# CASE 2 — expired token: past expiresAt → non-zero exit, no write.
+rr_setup
+write_creds "$TMPDIR_TEST/fix/creds.json" 1
+write_headers "$TMPDIR_TEST/fix/headers.txt" \
+  "$RR_H_5UTIL" "$RR_H_5RESET" "$RR_H_7UTIL" "$RR_H_7RESET"
+export DISPATCH_REFRESH_RATE_LIMITS_CREDS="$TMPDIR_TEST/fix/creds.json"
+export DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE="$TMPDIR_TEST/fix/headers.txt"
+if out=$("$TMPDIR_TEST/scripts/dispatch-refresh-rate-limits" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "expired token → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "expired token → no state file written" "1" "$([[ ! -e "$DISPATCH_RATE_LIMITS_STATE_FILE" ]] && echo 1 || echo 0)"
+rr_teardown
+
+# CASE 3 — missing creds: nonexistent path → non-zero exit, no write.
+rr_setup
+write_headers "$TMPDIR_TEST/fix/headers.txt" \
+  "$RR_H_5UTIL" "$RR_H_5RESET" "$RR_H_7UTIL" "$RR_H_7RESET"
+export DISPATCH_REFRESH_RATE_LIMITS_CREDS="/nonexistent/creds.json"
+export DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE="$TMPDIR_TEST/fix/headers.txt"
+if out=$("$TMPDIR_TEST/scripts/dispatch-refresh-rate-limits" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "missing creds → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "missing creds → no state file written" "1" "$([[ ! -e "$DISPATCH_RATE_LIMITS_STATE_FILE" ]] && echo 1 || echo 0)"
+rr_teardown
+
+# CASE 4 — missing headers: rate-limit headers absent → non-zero exit, no write.
+rr_setup
+write_creds "$TMPDIR_TEST/fix/creds.json" 9999999999000
+write_headers "$TMPDIR_TEST/fix/headers.txt" \
+  "HTTP/2 401" "content-type: application/json"
+export DISPATCH_REFRESH_RATE_LIMITS_CREDS="$TMPDIR_TEST/fix/creds.json"
+export DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE="$TMPDIR_TEST/fix/headers.txt"
+if out=$("$TMPDIR_TEST/scripts/dispatch-refresh-rate-limits" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "missing headers → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "missing headers → no state file written" "1" "$([[ ! -e "$DISPATCH_RATE_LIMITS_STATE_FILE" ]] && echo 1 || echo 0)"
+rr_teardown
+
+# CASE 5a — malformed utilization: 5h-utilization "abc" → non-zero exit, no write.
+rr_setup
+write_creds "$TMPDIR_TEST/fix/creds.json" 9999999999000
+write_headers "$TMPDIR_TEST/fix/headers.txt" \
+  "anthropic-ratelimit-unified-5h-utilization: abc" \
+  "$RR_H_5RESET" "$RR_H_7UTIL" "$RR_H_7RESET"
+export DISPATCH_REFRESH_RATE_LIMITS_CREDS="$TMPDIR_TEST/fix/creds.json"
+export DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE="$TMPDIR_TEST/fix/headers.txt"
+if out=$("$TMPDIR_TEST/scripts/dispatch-refresh-rate-limits" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "malformed utilization → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "malformed utilization → no state file written" "1" "$([[ ! -e "$DISPATCH_RATE_LIMITS_STATE_FILE" ]] && echo 1 || echo 0)"
+rr_teardown
+
+# CASE 5b — malformed reset: 5h-reset "12.5" (non-integer) → non-zero exit, no write.
+rr_setup
+write_creds "$TMPDIR_TEST/fix/creds.json" 9999999999000
+write_headers "$TMPDIR_TEST/fix/headers.txt" \
+  "$RR_H_5UTIL" \
+  "anthropic-ratelimit-unified-5h-reset: 12.5" \
+  "$RR_H_7UTIL" "$RR_H_7RESET"
+export DISPATCH_REFRESH_RATE_LIMITS_CREDS="$TMPDIR_TEST/fix/creds.json"
+export DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE="$TMPDIR_TEST/fix/headers.txt"
+if out=$("$TMPDIR_TEST/scripts/dispatch-refresh-rate-limits" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "malformed reset → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "malformed reset → no state file written" "1" "$([[ ! -e "$DISPATCH_RATE_LIMITS_STATE_FILE" ]] && echo 1 || echo 0)"
+rr_teardown
+
+# CASE 6 — refresh→budget regression for #1127. Seed a FROZEN pre-reset file
+# (used 95%, resets_at in the past); the probe overwrites it with reopened-window
+# telemetry; the REAL dispatch-target-workers then computes a positive target
+# from the refreshed file — the end-to-end self-resume the issue requires.
+rr_setup
+printf '{"five_hour":{"used_percentage":95,"resets_at":1},"seven_day":{"used_percentage":95,"resets_at":1}}\n' > "$DISPATCH_RATE_LIMITS_STATE_FILE"
+write_creds "$TMPDIR_TEST/fix/creds.json" 9999999999000
+RR_R7=$(tw_resets_for_x 0.5)         # mid-week 7d reset
+RR_R5=$((TW_NOW + 18000))            # 5h reset comfortably in the future
+write_headers "$TMPDIR_TEST/fix/headers.txt" \
+  "anthropic-ratelimit-unified-5h-utilization: 0.05" \
+  "anthropic-ratelimit-unified-5h-reset: $RR_R5" \
+  "anthropic-ratelimit-unified-7d-utilization: 0.10" \
+  "anthropic-ratelimit-unified-7d-reset: $RR_R7"
+export DISPATCH_REFRESH_RATE_LIMITS_CREDS="$TMPDIR_TEST/fix/creds.json"
+export DISPATCH_REFRESH_RATE_LIMITS_HEADERS_FILE="$TMPDIR_TEST/fix/headers.txt"
+if out=$("$TMPDIR_TEST/scripts/dispatch-refresh-rate-limits" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "regression: probe refreshed reopened window → exit 0" "0" "$rc"
+export DISPATCH_TARGET_WORKERS_RATE_LIMITS_PATH="$DISPATCH_RATE_LIMITS_STATE_FILE"
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+target=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+TOTAL=$((TOTAL + 1))
+if [[ "$target" =~ ^[0-9]+$ && "$target" -ge 1 ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: regression: reopened window → target >= 1 (got $target)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: regression: reopened window → target >= 1 (got '$target')"
+fi
+unset DISPATCH_TARGET_WORKERS_RATE_LIMITS_PATH DISPATCH_TARGET_WORKERS_NOW
+rr_teardown
+
 # ============================================================================
 # summary
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/update-rate-limits.sh
+++ b/.claude/skills/dispatch-propagate/scripts/update-rate-limits.sh
@@ -3,8 +3,8 @@
 # Prints a single status line to stdout (e.g. "5h: 5% · 7d: 1%") when data is present.
 set -euo pipefail
 
-STATE_DIR="$HOME/.local/share/commons-dispatch"
-STATE_FILE="$STATE_DIR/rate_limits.json"
+STATE_FILE="${DISPATCH_RATE_LIMITS_STATE_FILE:-$HOME/.local/share/commons-dispatch/rate_limits.json}"
+STATE_DIR="$(dirname "$STATE_FILE")"
 
 HOOK_INPUT="$(cat)"
 


### PR DESCRIPTION
Closes #1127

## Problem

The autonomous dispatch chain runs headlessly: `dispatch-tick` (pure bash,
launched by systemd timers and worker Stop hooks) computes the budget via
`dispatch-target-workers`, which reads cached telemetry in
`~/.local/share/commons-dispatch/rate_limits.json`. That file has **exactly one
writer**: the `statusLine` hook (`statusline.sh` → `update-rate-limits.sh`),
which lifts the `.rate_limits` payload Claude Code passes on stdin **only when a
session renders its status line**.

When the chain fully pauses — the last worker exits, the tick arms a one-shot
reseed timer at the cap's `resets_at`, and no live sessions remain — and no
interactive session is open, nothing renders a status line, so
`rate_limits.json` freezes at the cap-hit snapshot. The reseed timer then fires
at `resets_at`, but the tick re-reads the *frozen* file: `dispatch-target-workers`
returns 0, nothing spawns. The budget has reopened but the chain can't observe
it — it stalls until a human opens a session. Observed live 2026-06-04: a 5h cap
reopened at 13:10, but the chain sat idle ~3h until an unrelated interactive
session refreshed telemetry.

A retry can't fix this — re-reading a frozen file yields the same stale answer.
The chain needs a telemetry source independent of status-line renders.

## Fix

Give the headless path its own rate-limit telemetry refresh, run at the start of
the tick before any budget read.

- **`dispatch-refresh-rate-limits`** (new) — a probe that reads the stored OAuth
  access token from `~/.claude/.credentials.json`, fetches the unified
  rate-limit response headers from the Anthropic messages endpoint
  (`anthropic-ratelimit-unified-{5h,7d}-{utilization,reset}` — the same data
  Claude Code forwards into `.rate_limits`), and writes `rate_limits.json` in the
  existing `five_hour`/`seven_day` schema by piping a `{"rate_limits":{…}}`
  payload through `update-rate-limits.sh`, reusing its atomic write. The schema is
  byte-identical to today's file: `used_percentage = round(utilization*100)`,
  `resets_at = <window>-reset` verbatim.

- **`update-rate-limits.sh`** — the output path is now overridable via
  `DISPATCH_RATE_LIMITS_STATE_FILE` (default unchanged), so the probe and tests
  can redirect the write. Its behavior as the status-line writer is unchanged, so
  there is no format divergence — the hook remains a valid writer.

- **`dispatch-tick`** — runs the probe as Step 0.5, before
  `dispatch-select-tick` / `dispatch-target-workers`, so every budget read this
  tick (and any reseed it arms) is computed against fresh telemetry.

**Fail-safe contract.** Every probe failure path — missing/unreadable
credentials, missing/expired token, probe request failure, missing/malformed
headers — logs exactly one stderr diagnostic, exits non-zero, and leaves the
cached file untouched; the access token is never echoed. The tick treats a
non-zero probe exit as log-and-proceed, so a probe outage degrades to the prior
cached-file behavior rather than erroring the tick. Header parsing is
status-independent: a 429 cap response still carries the unified headers and is
consumed, so the capped state is recorded too.

**Out of scope.** OAuth token refresh — the probe uses the stored access token
as-is. Hand-rolling refresh would race Claude Code's own credential writes
(rotating refresh tokens → auth corruption) and exceeds the small-helper scope.
An expired token degrades safely (fall back to cache + log), which the
fail-safe contract permits.

## Tests

`test-dispatch-scripts.sh` gains a `=== dispatch-refresh-rate-limits ===` group
and two `dispatch-tick` tests:

- **probe:** success writes the canonical telemetry; expired token, missing
  creds, missing headers, and malformed values each fail safe with no write.
- **refresh→budget regression (the reported stall, end-to-end with real
  scripts):** seed a *frozen pre-reset* `rate_limits.json` (5h used ≥ target,
  `resets_at` in the past), run the probe with headers showing the **reopened**
  window, then run the **real** `dispatch-target-workers` against the refreshed
  file — target is `>= 1`. Frozen → refresh → reopened budget observed, no
  interactive session needed.
- **tick wiring:** the refresh runs *before* select (ordering), and a probe
  failure still lets the tick route its decision and exit 0 (fail-safe).

Full suite: 1655/1655 passing.
