### PR TITLE
dispatch: release the selection lock after reserve+spawn, not after registration

### DIFF
--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -89,11 +89,11 @@ liveness skip and consumes a concurrency slot); the lock is released before the
 resolver job is spawned. Crash safety: a router that dies mid-spawn holding the lock is
 recovered by the lock's existing dead-holder reclaim (the recorded sessionId
 absent from `claude agents --json`) on the next `--wait`. Such a router also
-strands any reservation marker it wrote before dying; `reservation_sweep` (run
-at the start of the next tick) reclaims that marker via the same dead-session
-rule — a parallel, belt-and-suspenders reclaim path alongside the lock's
-dead-holder reclaim. The stranded marker is cheap to reclaim and leaves no
-half-built state.
+strands any reservation marker it wrote before dying; `reservation_sweep`
+reclaims that marker via the same dead-session rule once it has aged past the
+boot grace (i.e. on a subsequent tick after the grace elapses) — a parallel,
+belt-and-suspenders reclaim path alongside the lock's dead-holder reclaim. The
+stranded marker is cheap to reclaim and leaves no half-built state.
 
 The `tmp/dispatch-worktree` marker is the post-Step-5 reclaim signal for
 **dead** holders, and it is **session-scoped**: `dispatch-finalize-selection`
@@ -285,11 +285,15 @@ before `dispatch-spawn-worker` and clears it immediately after the spawn
 returns; a completed fan-out therefore leaves `effective_live == busy_workers`
 with no double-count and no leaked budget. `reservation_sweep` reclaims a
 marker when: (a) the worktree already has a live worker matching the marker
-basename (the reservation converted — redundant backstop), or (b) the reserving
-session is absent from `claude agents --json` and no live worker registered. A
-marker whose reserving session is still live but has no registered worker yet is
-kept as in-flight. If `claude agents --json` returns UNKNOWN, the sweep reclaims
-nothing (fail-safe). Later #1044 sub-issues build on this ledger: #1046 extends
+basename (the reservation converted — redundant backstop, at any age), or (b)
+the reserving session is absent from `claude agents --json` and no live worker
+registered AND the marker has aged past the boot grace. A marker younger than
+the boot grace (`DISPATCH_RESERVATION_BOOT_GRACE_S`, default 30s) is kept as
+in-flight regardless of the reserving session's liveness, so an async spawn whose
+router has exited while the worker is still booting is not reclaimed out from
+under it; a marker whose reserving session is still live but has no registered
+worker yet is likewise kept as in-flight. If `claude agents --json` returns
+UNKNOWN, the sweep reclaims nothing (fail-safe). Later #1044 sub-issues build on this ledger: #1046 extends
 `dispatch-select-target` to skip reserved worktrees; #1047 relocates
 provisioning out of the held-lock loop; #1048 releases the lock after
 reserve+spawn rather than after registration.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -12,16 +12,20 @@
 # for the worker's startup, per #1047 / #1044), writes the recovery marker via
 # dispatch-finalize-selection (which no longer releases the lock — #945), runs
 # the explicit-target readiness gate (dispatch-ci-ready), spawns the worker, and
-# releases the lock after the worker registers. Prints exactly ONE terminal
+# releases the lock after the worker spawn is kicked (the spawn is async — #1048;
+# the lock no longer spans registration). Prints exactly ONE terminal
 # token as its LAST stdout line;
 # supporting detail (a path, a blocker list, the CI line) precedes the token.
 #
 # With `--gap <N>` and `queue` mode, the script FANS OUT: it spawns up to N
 # workers in one held-lock run, selecting a distinct next target each iteration
 # via dispatch-select-target. The first target is the passed-in <issue-N>;
-# targets 2..N come from successive dispatch-select-target calls (each spawned
-# worker registers before the next selection — #945/#905 — so the next
-# selection skips its now-live-owned worktree and yields a distinct target).
+# targets 2..N come from successive dispatch-select-target calls. The worker no
+# longer registers synchronously (#1048), so the loop threads its SEEN set as
+# `--exclude` to dispatch-select-target AND the just-written reservation marker
+# makes dispatch-select-target's reserved-skip (#1046) skip the reserved
+# worktree — so the next selection yields a distinct target even though the prior
+# worker has not yet registered.
 # `explicit` mode and `--gap 1` process a single target (backward-compatible).
 # Fan-out (`--gap N` with N>1) is autonomous-only; a manual run arrives as
 # `--gap 1` and takes the single-target path.
@@ -33,8 +37,9 @@
 #
 # Terminal tokens (the last stdout line is always exactly one of):
 #   propagate              the worker spawned (or deduped); the chain advances.
-#                          Lock released AFTER dispatch-spawn-worker confirms the
-#                          worker registered under its <basename> (#945).
+#                          Lock released after dispatch-spawn-worker kicks the
+#                          (async) worker spawn (#1048); the reservation marker,
+#                          not registration, closes the spawn-gap race.
 #   notify target-blocked  explicit target is closed or has an open blocker; the
 #                          issue is parked via dispatch-apply-office-hours and
 #                          the lock released at the guard.
@@ -90,16 +95,18 @@
 #                          distinct target — a normal terminal state, not a
 #                          failure.
 #
-# Lock-release points (#945): the lock is held THROUGH the spawn so the next
-# tick cannot re-select the target during the worker's boot gap. In a fan-out
-# run the lock is held across the WHOLE loop and released ONCE at the end (or on
-# a hard `exit 2`); per-target park/skip outcomes do NOT release between
-# iterations.
+# Lock-release points (#1048): the lock is held THROUGH the reserve + spawn-KICK
+# (not through registration); after release the reservation marker closes the
+# spawn-gap re-selection race so the next tick cannot re-select the target during
+# the worker's boot gap. In a fan-out run the lock is held across the WHOLE loop
+# and released ONCE at the end (or on a hard `exit 2`); per-target park/skip
+# outcomes do NOT release between iterations.
 # dispatch-finalize-selection writes the recovery marker but no longer releases.
 # `notify target-blocked` and `drain worktree-conflict` release explicitly at the
 # guard (the marker does not exist yet on these pre-finalize stop paths).
 # `propagate` and `notify spawn-failed` release AFTER dispatch-spawn-worker
-# returns (the worker is verified-registered on success).
+# returns: on success the spawn was kicked async and the reservation marker is
+# left in place; on failure the marker is cleared.
 # The single-target ci-waiting stop (now `drain ci-reseeded` / `notify
 # ci-wait-exhausted`, or the fallback `drain ci-waiting` on a scheduler hard-
 # failure) releases the lock at its stop, BEFORE dispatch-schedule-target-reseed
@@ -171,8 +178,10 @@ WAITING_N=""
 # re-check, Step 5 resolve, recovery marker, Step 6a explicit-only readiness
 # gate, Step 6b spawn) for ONE target. Does NOT
 # release the lock and does NOT exit — the caller owns lock release and process
-# exit. Sets the global OUTCOME on every soft path and returns 0; returns 2 on a
-# hard error (the caller maps that to release_lock; exit 2).
+# exit. The Step 6b spawn-kick is async (#1048): on success the reservation
+# marker is left in place as the in-flight contribution; registration is not
+# awaited. Sets the global OUTCOME on every soft path and returns 0; returns 2 on
+# a hard error (the caller maps that to release_lock; exit 2).
 process_one_target() {
   local n="$1" mode="$2"
   local PR LEAF ISSUE_STATE BLOCKERS WT_DECISION WT_ACTION WT_REST
@@ -298,7 +307,8 @@ process_one_target() {
   esac
 
   # Write the recovery marker into the target worktree. The lock is STILL HELD
-  # from here through the spawn (#945) — the caller releases it after the loop.
+  # from here through the spawn-kick (#1048) — the caller releases it after the
+  # loop; registration is no longer awaited.
   if ! "$SCRIPT_DIR/dispatch-finalize-selection" "$WORKTREE_PATH" 1>&2; then
     echo "dispatch-materialize-spawn: dispatch-finalize-selection failed for $WORKTREE_PATH" >&2
     return 2
@@ -318,19 +328,19 @@ process_one_target() {
   fi
 
   # --- Step 6b: reserve, then spawn the worker -------------------------------
-  # The lock is still held here (#945). Write the reservation marker the instant
-  # before the spawn and clear it the instant the spawn returns: on success the
-  # worker has registered and is now counted by busy_workers; on failure no
-  # worker is coming. A completed fan-out therefore leaves effective_live == busy
-  # (no double-count, no leaked budget), identical to the pre-ledger gate. If the
-  # router dies between the write and the clear, the marker is stranded — the
-  # reservation sweeper (reservation_sweep, run at the next tick) reclaims it via
-  # the dead-session / live-worker-redundant rules.
+  # The lock is still held here. Write the reservation marker the instant before
+  # the (now async) spawn-kick and LEAVE it in place on success: registration is
+  # no longer awaited (#1048 — dispatch-spawn-worker passes --no-verify), so the
+  # marker, not registration timing, is this slot's in-flight budget/selection
+  # contribution and is what closes the spawn-gap re-selection race #945 closed.
+  # A concurrent acquirer's reserved-skip (#1046) and the budget gate (#1045)
+  # both key on the marker. reservation_sweep reclaims it on registration (rule
+  # (a)) or after the boot grace if the worker never comes up. On a failed kick
+  # no worker is coming, so the marker is cleared (no leaked budget).
   #
-  # dispatch-spawn-worker returns success only after the worker is
-  # verified-registered under its <basename>, at which point
-  # dispatch-select-target skips the now-owned worktree — so the next in-loop
-  # selection yields a distinct target. On a failed spawn no worker registered.
+  # The next in-loop selection yields a distinct target because the marker makes
+  # dispatch-select-target's reserved-skip (#1046) skip this worktree, and the
+  # loop threads its SEEN set as --exclude — neither depends on registration.
   wt_basename="$(basename "$WORKTREE_PATH")"
   # Best-effort, but surface a failure: a missing marker means the spawn proceeds
   # uncounted, so a silent swallow would hide a budget blind spot. The sweeper
@@ -339,10 +349,18 @@ process_one_target() {
     echo "dispatch-materialize-spawn: reservation_write failed for $wt_basename; spawning without a ledger entry (budget may undercount this slot)" >&2
   fi
   if "$SCRIPT_DIR/dispatch-spawn-worker" "$n" "$WORKTREE_PATH" 1>&2; then
-    reservation_clear "$wt_basename" 1>&2 || true
+    # Leave the marker in place (#1048): the spawn is async (dispatch-spawn-worker
+    # passes --no-verify), so the worker has not registered yet. The marker is the
+    # in-flight budget/selection contribution that a concurrent acquirer's
+    # reserved-skip (#1046) and the budget gate (#1045) rely on; reservation_sweep
+    # reclaims it once the worker goes live (rule (a)) or after the boot grace if
+    # the worker never comes up.
     OUTCOME=spawned
     return 0
   fi
+  # Failed kick: no worker is coming, so clear the marker (no leaked budget). A
+  # stranded marker would otherwise be reclaimed by the sweep anyway, but clearing
+  # here is immediate and precise.
   reservation_clear "$wt_basename" 1>&2 || true
   OUTCOME=spawn-failed
   return 0
@@ -398,11 +416,13 @@ fi
 # N; targets 2..GAP come from successive dispatch-select-target calls. The loop
 # passes its SEEN set as `--exclude` to dispatch-select-target so selection
 # yields the NEXT distinct target instead of re-returning an already-processed
-# one (#1062). A re-return would otherwise happen via two mechanisms: (1)
-# registration-visibility lag — a just-spawned worker is verified-registered but
-# not yet visible to the next selection's liveness query (#945/#905), so its
-# leaf re-surfaces; or (2) a fast self-close leaving an orphan worktree, which
-# selection treats as a reuse signal (not a conflict) and does not skip. The
+# one (#1062). The worker is no longer verified-registered (the spawn is async —
+# #1048), so within-loop de-confliction rests on the SEEN `--exclude` AND the
+# reservation marker (dispatch-select-target's reserved-skip, #1046), not on
+# registration visibility. A re-return would otherwise happen via two mechanisms:
+# (1) a target whose just-written reservation or SEEN membership is not honored;
+# or (2) a fast self-close leaving an orphan worktree, which selection treats as
+# a reuse signal (not a conflict) and does not skip. The
 # exclusion defeats both: an excluded target is filtered during the queue scan
 # (and threaded into the leaf trace), so the loop advances to the next distinct
 # startable leaf. The loop stops only on a genuine `empty`, a deferred selection

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-job
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-job
@@ -16,9 +16,9 @@
 #     /dispatch-jit-reminder bg-job spawns, which run those sub-skills in their
 #     own session rather than in the router's.
 #
-# Usage: dispatch-spawn-job --name <name> --cwd <cwd> <prompt>
+# Usage: dispatch-spawn-job [--no-verify] --name <name> --cwd <cwd> <prompt>
 #
-# Arguments (all required):
+# Arguments (--name, --cwd, <prompt> required; --no-verify optional):
 #   --name <name>   The spawned session's --name. Dedup keys on it directly:
 #                   another live session with the same name under <cwd> means
 #                   nothing is spawned.
@@ -26,27 +26,42 @@
 #                   `claude --bg`, so the new job is born there and the daemon
 #                   registers it under that path. Must be an existing directory.
 #   <prompt>        The single positional prompt string passed to `claude --bg`.
+#   --no-verify     Skip Step 4 (the registration wait). The script returns
+#                   `spawned`/exit 0 on a successful `claude --bg` kick — the
+#                   kick's own exit code is now the came-up signal — or exits 1
+#                   with a diagnostic on a non-zero kick. The worker fan-out
+#                   passes this: it is the budget path, reconciled by the
+#                   reservation ledger + sweep (#1045/#1048), so it opts out of
+#                   the registration wait. The unledgered one-off spawns
+#                   (main-broken / jit-reminder), which have no ledger/sweep
+#                   safety net, keep the default verify.
 #
 # Behavior, in order:
 #   1. Dedup    — if another live session with name == <name> is already running
 #                 under <cwd>, spawn nothing. Fail-safe: if the registry cannot
 #                 be queried, also spawn nothing (a dispatch agent may be live).
 #   2. Spawn    — `claude --bg --name <name> --permission-mode auto "<prompt>"`,
-#                 from a subshell that `cd`s into <cwd> first.
-#   3. Verify   — re-query the registry under <cwd> (where the new job registers)
-#                 with a bounded retry (verify_agent_registered_under) to absorb
-#                 the async-registration race; confirm the new agent appears.
+#                 from a subshell that `cd`s into <cwd> first; capture its exit
+#                 code.
+#   3. Verify   — only when --no-verify is absent: re-query the registry under
+#                 <cwd> (where the new job registers) with a bounded retry
+#                 (verify_agent_registered_under) to absorb the async-
+#                 registration race; confirm the new agent appears. With
+#                 --no-verify the kick exit code from Step 2 is the result.
 #
 # Stdout protocol (exactly one word):
 #   deduped   another agent with the same name is running, or the registry
 #             could not be queried — nothing was spawned.
-#   spawned   a new job was spawned and verified.
-# A spawn that does not verify prints nothing to stdout, writes a diagnostic to
-# stderr, and exits non-zero.
+#   spawned   a new job was spawned and verified (default), or kicked
+#             successfully (--no-verify).
+# A spawn that does not verify (default) or whose kick exits non-zero
+# (--no-verify) prints nothing to stdout, writes a diagnostic to stderr, and
+# exits non-zero.
 #
 # Exit codes:
 #   0  deduped or spawned (stdout disambiguates).
-#   1  the successor never registered in 'claude agents --json' — see stderr.
+#   1  default path: the successor never registered in 'claude agents --json';
+#      --no-verify path: the `claude --bg` kick exited non-zero — see stderr.
 #   2  the script cannot operate — usage / validation failed (missing or empty
 #      --name, --cwd, or <prompt>; an unexpected extra positional; or a --cwd
 #      that is not an existing directory).
@@ -71,9 +86,14 @@ set -uo pipefail
 # ---- Step 0: parse and validate arguments -----------------------------------
 NAME=""
 CWD=""
+NO_VERIFY=""
 positionals=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --no-verify)
+      NO_VERIFY=1
+      shift
+      ;;
     --name)
       if [[ $# -lt 2 ]]; then
         echo "dispatch-spawn-job: --name requires a value" >&2
@@ -158,14 +178,31 @@ done <<<"$sessions"
 # ---- Step 3: spawn the job --------------------------------------------------
 # The job is born with cwd = CWD via a subshell `cd` so SessionStart hooks key
 # on the right directory directly. The subshell `cd` is scoped — this script's
-# own cwd is untouched. Capture the spawn's combined output so a failure
-# diagnostic can surface why (`claude` missing, `--bg` rejected). `|| true`
-# keeps a non-zero spawn from aborting the script — Step 4's registry check is
-# the source of truth for whether the agent actually came up.
+# own cwd is untouched. Capture the spawn's combined output and exit code so a
+# failure diagnostic can surface why (`claude` missing, `--bg` rejected). On the
+# default path the rc is informational only — Step 4's registry check is the
+# source of truth; on the --no-verify path the rc is the came-up signal.
+spawn_rc=0
 spawn_output=$(
   cd "$CWD" && "$CLAUDE_CMD" --bg --name "$NAME" \
     --permission-mode auto "$PROMPT" 2>&1
-) || true
+) || spawn_rc=$?
+
+# ---- Step 3b: --no-verify early branch --------------------------------------
+# The budget-path fan-out opts out of the registration wait (#1048): the
+# reservation ledger + sweep reconcile the slot, so a successful kick is enough.
+if [[ -n "$NO_VERIFY" ]]; then
+  if [[ "$spawn_rc" -eq 0 ]]; then
+    echo spawned
+    exit 0
+  fi
+  if [[ -n "${spawn_output//[[:space:]]/}" ]]; then
+    echo "dispatch-spawn-job: 'claude --bg' kick for '$NAME' exited $spawn_rc; output: $spawn_output" >&2
+  else
+    echo "dispatch-spawn-job: 'claude --bg' kick for '$NAME' exited $spawn_rc" >&2
+  fi
+  exit 1
+fi
 
 # ---- Step 4: verify the new agent registered --------------------------------
 # Query under CWD — the new job's registered cwd. The bounded

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-worker
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-worker
@@ -3,8 +3,12 @@
 # worktree (the router → worker spawn primitive).
 #
 # Thin wrapper: this script validates the worker-specific arguments
-# (<issue-num>, <worktree-path>) and then delegates the spawn / dedup / verify
-# mechanics to dispatch-spawn-job, the generalized `claude --bg` spawn primitive.
+# (<issue-num>, <worktree-path>) and then delegates the spawn / dedup mechanics
+# to dispatch-spawn-job, the generalized `claude --bg` spawn primitive. It passes
+# --no-verify: the worker fan-out is the budget path, reconciled by the
+# reservation ledger + sweep (#1045/#1048), so the worker no longer waits for
+# registration. The reservation marker (not registration timing) closes the
+# spawn-gap re-selection race #945 closed.
 # The worker's --name is the worktree basename (per-worktree name uniqueness is
 # automatic) and its --cwd is the worktree path, so the new worker is born in
 # its target worktree.
@@ -19,9 +23,11 @@
 #                   worker's second positional argument.
 #
 # Stdout / exit codes / sandbox: delegated to dispatch-spawn-job (`deduped` /
-# `spawned` on stdout; 0 = deduped or spawned, 1 = never registered, 2 = usage
-# / validation error). Callers must run with `dangerouslyDisableSandbox: true`
-# — see `.claude/rules/sandbox.md § claude agents --json`.
+# `spawned` on stdout; 0 = deduped or spawned, 1 = failed kick, 2 = usage
+# / validation error). Because this passes --no-verify (#1048), exit 1 means the
+# `claude --bg` kick failed — not "never registered". Callers must run with
+# `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md § claude
+# agents --json`.
 #
 # Environment overrides for testability:
 #   DISPATCH_SPAWN_WORKER_CLAUDE_CMD    The `claude` command — translated into
@@ -83,6 +89,7 @@ fi
 # ---- Step 2: delegate to the generalized spawn primitive --------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec "$SCRIPT_DIR/dispatch-spawn-job" \
+  --no-verify \
   --name "$(basename "$WORKTREE_PATH")" \
   --cwd "$WORKTREE_PATH" \
   "/dispatch-worker $ISSUE_NUM $WORKTREE_PATH"

--- a/.claude/skills/dispatch-propagate/scripts/lib-reservation-ledger.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-reservation-ledger.sh
@@ -94,12 +94,20 @@
 #   reserved worktree name, `session=` line = reserving session id):
 #     a. marker basename ∈ live-session-names  → a LIVE worker already owns the
 #        worktree (counted by busy_workers); reclaim (redundant / crash-after-
-#        register backstop).
+#        register backstop). This is age-INDEPENDENT — it fires at ANY age.
 #     b. else the `session=` line is empty/absent (malformed marker) → KEEP and
 #        flag; an empty session id is not treated as "dead" so a corrupt or
 #        tampered marker never causes a still-valid slot to be reclaimed.
-#     c. else reserving session id ∉ live-session-ids → reserving session is DEAD
-#        and never converted; reclaim (stranded).
+#     (new) else the marker is younger than the boot grace
+#        (DISPATCH_RESERVATION_BOOT_GRACE_S, default 30s) → in-flight; KEEP,
+#        REGARDLESS of the reserving session's liveness. This covers an async
+#        spawn whose router (the reserving session) has already exited while the
+#        spawned worker is still booting and has not yet registered. A marker
+#        with an unparseable/absent timestamp has no age protection — it falls
+#        through to the session rules below (fail-safe to the pre-grace behavior).
+#     c. else reserving session id ∉ live-session-ids AND the marker has aged
+#        past the grace → reserving session is DEAD and never converted; reclaim
+#        (stranded).
 #     d. else (reserving session alive, no live worker yet) → in-flight; KEEP.
 #   Reclaim = `reservation_clear <basename>` plus a one-line stderr note
 #   distinguishing the two reasons (live-worker-redundant vs dead-session-
@@ -116,6 +124,15 @@
 #   DISPATCH_RESERVATION_NOW  Override the UTC timestamp stamped into a written
 #                             marker (deterministic tests). Default:
 #                             `date -u +%FT%TZ`.
+#   DISPATCH_RESERVATION_BOOT_GRACE_S
+#                             The boot-grace window in seconds (default 30); a
+#                             marker younger than this is kept as in-flight
+#                             regardless of the reserving session's liveness. A
+#                             non-numeric value falls back to 30.
+#   DISPATCH_RESERVATION_SWEEP_NOW_EPOCH
+#                             Override the sweep's "now" epoch (deterministic
+#                             grace-boundary tests). Default: `date -u +%s`. A
+#                             non-numeric value falls back to the default.
 #   CLAUDE_AGENTS_CMD         Inherited from lib-claude-agents.sh: replaces the
 #                             `claude` invocation in the sweep's liveness query
 #                             with an arbitrary command (testable with no daemon).
@@ -302,20 +319,39 @@ if [[ -z "${_LIB_RESERVATION_LEDGER_LOADED:-}" ]]; then
       done <<<"$agents"
     fi
 
+    # Compute "now" (epoch) and the boot grace ONCE before the loop. A
+    # non-numeric DISPATCH_RESERVATION_SWEEP_NOW_EPOCH / _BOOT_GRACE_S falls back
+    # to its default.
+    local now
+    if [[ "${DISPATCH_RESERVATION_SWEEP_NOW_EPOCH:-}" =~ ^[0-9]+$ ]]; then
+      now="$DISPATCH_RESERVATION_SWEEP_NOW_EPOCH"
+    else
+      now=$(date -u +%s)
+    fi
+    local grace="${DISPATCH_RESERVATION_BOOT_GRACE_S:-30}"
+    [[ "$grace" =~ ^[0-9]+$ ]] || grace=30
+
     local had_nullglob=0
     shopt -q nullglob && had_nullglob=1
     shopt -s nullglob
-    local f bn marker_sid
+    local f bn marker_sid marker_ts marker_epoch
     for f in "$dir"/*; do
       [[ -f "$f" ]] || continue
       bn=$(basename "$f")
       # Read the `session=` line robustly (first match wins); independent of
       # line ordering within the marker.
       marker_sid=$(sed -n 's/^session=//p' "$f" 2>/dev/null | head -n1)
+      # Read the `timestamp=` line and parse it to epoch. The markers store UTC
+      # ISO-8601 (e.g. 2026-01-01T00:00:00Z), which GNU `date -d` parses. This
+      # may fail (empty/non-numeric marker_epoch) on an absent/unparseable
+      # timestamp, in which case the marker gets no age protection (fail-safe).
+      marker_ts=$(sed -n 's/^timestamp=//p' "$f" 2>/dev/null | head -n1)
+      marker_epoch=$(date -d "$marker_ts" +%s 2>/dev/null)
 
       if [[ -n "${live_names[$bn]:-}" ]]; then
         # (a) A live worker already owns this worktree (its session name equals
         # the worktree basename) — redundant / crash-after-register backstop.
+        # Age-independent: fires at ANY age, ahead of the grace check.
         reservation_clear "$bn"
         printf 'lib-reservation-ledger: reclaimed reservation %s (live-worker-redundant)\n' "$bn" >&2
       elif [[ -z "$marker_sid" ]]; then
@@ -325,8 +361,17 @@ if [[ -z "${_LIB_RESERVATION_LEDGER_LOADED:-}" ]]; then
         # session" with "dead session" and could delete a still-valid slot — KEEP
         # it and flag it instead (fail safe, matching the sweep's conservatism).
         printf 'lib-reservation-ledger: keeping malformed reservation %s (no session= line)\n' "$bn" >&2
+      elif [[ "$marker_epoch" =~ ^[0-9]+$ ]] && (( now - marker_epoch < grace )); then
+        # (new) Boot grace: a marker younger than the grace is in-flight and KEPT
+        # regardless of the reserving session's liveness. This covers an async
+        # spawn whose reserving session (a short-lived router) has already exited
+        # while the spawned worker is still booting / not yet registered. A
+        # future-stamped marker (now - epoch < 0) is < grace, so it is kept too
+        # (the safe direction). KEEP — fall through to nothing.
+        :
       elif [[ -z "${live_ids[$marker_sid]:-}" ]]; then
-        # (c) The reserving session is not live and never converted — stranded.
+        # (c) The reserving session is not live, the marker has aged past the
+        # grace, and it never converted — stranded.
         reservation_clear "$bn"
         printf 'lib-reservation-ledger: reclaimed reservation %s (dead-session-stranded)\n' "$bn" >&2
       fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -15969,9 +15969,10 @@ if reservation_exists "839-test"; then
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: resv-success: reservation_exists after release (target stays reserved)"
 fi
-# The marker SURVIVES a fresh sweep: mat-session is reported live (rule (d) keeps
-# the in-flight marker; the boot grace would keep it anyway). The target remains
-# reserved across the full reserve→release→reacquire sequence.
+# The marker SURVIVES a fresh sweep: the marker is very recent (boot grace keeps
+# it as in-flight); additionally mat-session is reported live so rule (d) would
+# keep it too. The target remains reserved across the full
+# reserve→release→reacquire sequence.
 reservation_sweep 2>/dev/null
 assert_eq "resv-success: reservation survives a fresh reservation_sweep" "1" \
   "$([ -f "$DISPATCH_RESERVATION_DIR/839-test" ] && echo 1 || echo 0)"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6440,7 +6440,8 @@ rl_teardown() {
   rm -rf "$RL_DIR"
   RL_DIR=""
   RL_FAKE=""
-  unset DISPATCH_RESERVATION_DIR CLAUDE_AGENTS_CMD DISPATCH_RESERVATION_NOW
+  unset DISPATCH_RESERVATION_DIR CLAUDE_AGENTS_CMD DISPATCH_RESERVATION_NOW \
+    DISPATCH_RESERVATION_SWEEP_NOW_EPOCH DISPATCH_RESERVATION_BOOT_GRACE_S
 }
 
 # rl_write_fake_claude <json-array> — install a fake `claude` that prints the
@@ -6641,6 +6642,62 @@ if printf '%s' "$err" | grep -q 'malformed reservation'; then
   PASS=$((PASS + 1)); echo "  PASS: rl-sweep-malformed: note mentions malformed reservation"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: rl-sweep-malformed: note mentions malformed reservation"
+fi
+rl_teardown
+
+# --- Test A: sweep keeps a YOUNG marker even when reserving session is dead ----
+
+echo "Test: reservation_sweep keeps a young marker even when the reserving session is dead (boot grace; #1048 regression guard)"
+rl_setup
+# DISPATCH_RESERVATION_NOW is "2026-01-01T00:00:00Z" (set by rl_setup); its
+# epoch is 1767225600 (confirmed via `date -u -d 2026-01-01T00:00:00Z +%s`).
+reservation_write "990-slug" "990" "dead-sess"
+# Sweep clock 5s after the marker timestamp → within the 30s grace.
+export DISPATCH_RESERVATION_SWEEP_NOW_EPOCH=1767225605
+# A live session that is NEITHER the reserving session NOR a worker named by the
+# basename — without the grace this would be reclaimed as dead-session-stranded.
+rl_write_fake_claude '[{"sessionId":"other","pid":1,"status":"busy","name":"someworker"}]'
+reservation_sweep 2>/dev/null
+cnt=$(reservation_count)
+assert_eq "rl-sweep-young: young marker with dead session kept (count 1)" "1" "$cnt"
+rl_teardown
+
+# --- Test B: sweep reclaims an AGED marker whose reserving session is dead -----
+
+echo "Test: reservation_sweep reclaims an aged marker whose reserving session is dead (grace boundary)"
+rl_setup
+reservation_write "991-slug" "991" "dead-sess"
+# Sweep clock 31s after the marker timestamp → past the 30s grace.
+export DISPATCH_RESERVATION_SWEEP_NOW_EPOCH=1767225631
+rl_write_fake_claude '[{"sessionId":"other","pid":1,"status":"busy","name":"someworker"}]'
+err=$(reservation_sweep 2>&1 1>/dev/null)
+cnt=$(reservation_count)
+assert_eq "rl-sweep-aged: aged marker with dead session reclaimed (count 0)" "0" "$cnt"
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$err" | grep -q 'dead-session-stranded'; then
+  PASS=$((PASS + 1)); echo "  PASS: rl-sweep-aged: note mentions dead-session-stranded"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: rl-sweep-aged: note mentions dead-session-stranded"
+fi
+rl_teardown
+
+# --- Test C: live-worker-redundant reclaim is age-independent (rule (a)) -------
+
+echo "Test: reservation_sweep reclaims a live-worker-redundant marker regardless of age (rule (a) is age-independent)"
+rl_setup
+reservation_write "992-slug" "992" "whatever-sess"
+# YOUNG marker (sweep clock within grace) — but the worktree already has a live
+# worker, so rule (a) must reclaim it ahead of the grace check.
+export DISPATCH_RESERVATION_SWEEP_NOW_EPOCH=1767225605
+rl_write_fake_claude '[{"sessionId":"x","pid":1,"status":"busy","name":"992-slug"}]'
+err=$(reservation_sweep 2>&1 1>/dev/null)
+cnt=$(reservation_count)
+assert_eq "rl-sweep-redundant-young: live-worker-redundant reclaimed despite youth (count 0)" "0" "$cnt"
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$err" | grep -q 'live-worker-redundant'; then
+  PASS=$((PASS + 1)); echo "  PASS: rl-sweep-redundant-young: note mentions live-worker-redundant"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: rl-sweep-redundant-young: note mentions live-worker-redundant"
 fi
 rl_teardown
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -9716,28 +9716,49 @@ assert_eq "self-exclude-worker: stdout is 'spawned' (own session is not 'another
   "spawned" "$out"
 spawn_worker_teardown
 
-# --- Test 5: spawn failure ---------------------------------------------------
+# --- Test 5: --no-verify behavior (kick is the came-up signal) ---------------
+# The worker passes --no-verify (#1048), so the registration wait is gone. A
+# kick that never registers SUCCEEDS (the kick itself returns 0); only a
+# non-zero kick fails.
 
-echo "Test: a spawned worker job that never registers exits non-zero with a diagnostic"
+echo "Test: a kick that never registers still exits 0 (--no-verify, no registration wait)"
 spawn_worker_setup
 write_fake_spawn_worker_claude
+# SPAWN_BG_REGISTERS=0: the --bg handler returns 0 but never appends to the
+# registry. Under the old verify path this exited 1; with --no-verify the worker
+# exits 0 with stdout 'spawned' and no verify poll.
 export SPAWN_BG_REGISTERS=0
-# Skip the real inter-attempt sleeps — this test exercises the full exhaustion
-# path, which would otherwise add ~0.8 s of wall-clock sleep.
-export LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S=0
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "spawn-worker-noverify: a never-registering kick exits 0" "0" "$rc"
+assert_eq "spawn-worker-noverify: stdout is 'spawned'" "spawned" "$out"
+spawn_worker_teardown
+
+echo "Test: a non-zero 'claude --bg' kick exits 1 with a diagnostic (--no-verify)"
+spawn_worker_setup
+# Inline fake whose --bg branch exits non-zero. dedup (Step 2) queries `agents`
+# first, so that branch must print a parseable empty array.
+cat > "$TMPDIR_TEST/fake-claude" <<FAKE
+#!/usr/bin/env bash
+set -uo pipefail
+case "\${1:-}" in
+  agents) echo '[]' ;;
+  --bg) echo "boom" >&2; exit 3 ;;
+esac
+FAKE
+chmod +x "$TMPDIR_TEST/fake-claude"
 rc=0
 err=$("$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>&1 1>/dev/null) || rc=$?
 TOTAL=$((TOTAL + 1))
 if [[ "$rc" -ne 0 ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: spawn-worker-fail: dispatch-spawn-worker exits non-zero"
+  PASS=$((PASS + 1)); echo "  PASS: spawn-worker-failkick: dispatch-spawn-worker exits non-zero"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-worker-fail: dispatch-spawn-worker exits non-zero (rc=$rc)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-worker-failkick: dispatch-spawn-worker exits non-zero (rc=$rc)"
 fi
 TOTAL=$((TOTAL + 1))
-if [[ "$err" == *"did not register"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: spawn-worker-fail: stderr reports the unregistered agent"
+if [[ -n "${err//[[:space:]]/}" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: spawn-worker-failkick: stderr reports the failed kick"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-worker-fail: stderr reports the unregistered agent"
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-worker-failkick: stderr reports the failed kick"
   echo "    stderr: $err"
 fi
 spawn_worker_teardown
@@ -9803,25 +9824,24 @@ assert_eq "missing-args-worker: unsafe chars in <worktree-path> → exit 2" "2" 
 
 spawn_worker_teardown
 
-# --- Test 8: dedup + verify query the worktree path, not the spawner cwd ----
+# --- Test 8: dedup queries the worktree path, not the spawner cwd -----------
 #
 # Regression guard: in production the daemon server-side-filters `agents
 # --json --cwd <path>` to sessions started under <path>. Since
 # dispatch-spawn-worker `cd`s into the target worktree before `claude --bg`,
 # the new worker registers under <worktree-path>, not under the spawner cwd
-# (worktrees/main). Dedup and verify both query the worktree path so the new
-# worker is found. If they queried the spawner cwd instead, the daemon would
-# exclude the new worker, `registered` would stay empty, and the script would
-# exit 1 — on every spawn in production.
+# (worktrees/main). Under --no-verify (#1048) only DEDUP queries the worktree
+# path now (there is no verify step). If dedup queried the spawner cwd instead,
+# the fixture would still be correct here, but the dedup query is the path-keyed
+# query this test pins.
 #
 # The default fake `claude` (write_fake_spawn_worker_claude) ignores --cwd,
 # so the existing Tests 1–7 do not exercise this filter and would not catch
 # the regression. This test installs a cwd-aware fake: its `agents` handler
 # filters its registry-emit by --cwd, and its --bg handler records the new
-# worker with cwd = $(pwd) at spawn time. With the fix, both queries pass
-# the worktree path and the worker is found. Without it, verify returns no
-# session and the script exits 1.
-echo "Test: dedup + verify query the worktree path, not the spawner cwd"
+# worker with cwd = $(pwd) at spawn time. dedup finds nothing under the path,
+# so the worker is spawned and the kick succeeds.
+echo "Test: dedup queries the worktree path, not the spawner cwd"
 spawn_worker_setup
 cat > "$TMPDIR_TEST/fake-claude" <<FAKE
 #!/usr/bin/env bash
@@ -9864,59 +9884,8 @@ chmod +x "$TMPDIR_TEST/fake-claude"
 SPAWN_CALLER_CWD="$TMPDIR_TEST/worktrees/main"
 if out=$( cd "$SPAWN_CALLER_CWD" && "$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>/dev/null ); then rc=0; else rc=$?; fi
 assert_eq "cwd-aware-spawn: exits 0" "0" "$rc"
-assert_eq "cwd-aware-spawn: stdout is 'spawned' (verify queried under worktree path, found the new worker)" \
+assert_eq "cwd-aware-spawn: stdout is 'spawned' (dedup queried under worktree path; nothing found, so the worker is spawned)" \
   "spawned" "$out"
-spawn_worker_teardown
-
-# --- Test 9: delayed registration absorbed by verify retry -------------------
-
-echo "Test: a spawned worker that registers on the 2nd 'agents' call still exits 0"
-spawn_worker_setup
-write_fake_spawn_worker_claude
-# SPAWN_BG_REGISTER_AFTER_N=2 models the daemon's async-registration race:
-# the spawned worker first appears in the fake's registry on the 2nd
-# subsequent `agents` call. verify_agent_registered_under polls up to 5
-# times, so the 2nd attempt finds the worker and the script exits 0.
-export SPAWN_BG_REGISTER_AFTER_N=2
-SPAWN_CALLER_CWD="$TMPDIR_TEST/worktrees/main"
-err_file="$TMPDIR_TEST/stderr"
-if out=$( cd "$SPAWN_CALLER_CWD" && "$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>"$err_file" ); then rc=0; else rc=$?; fi
-err=$(cat "$err_file")
-assert_eq "delayed-register-worker: dispatch-spawn-worker exits 0" "0" "$rc"
-assert_eq "delayed-register-worker: stdout is 'spawned'" "spawned" "$out"
-TOTAL=$((TOTAL + 1))
-if [[ -z "${err//[[:space:]]/}" ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: delayed-register-worker: no diagnostic on stderr"
-else
-  FAIL=$((FAIL + 1)); echo "  FAIL: delayed-register-worker: no diagnostic on stderr"
-  echo "    stderr: $err"
-fi
-spawn_worker_teardown
-
-# --- Test 10: registration on the exact last attempt still exits 0 -----------
-
-echo "Test: a spawned worker that registers on the 5th (final) 'agents' call still exits 0"
-spawn_worker_setup
-write_fake_spawn_worker_claude
-# SPAWN_BG_REGISTER_AFTER_N=5 makes the worker first appear on the 5th
-# subsequent `agents` call — the last poll before verify_agent_registered_under
-# exhausts its 5-attempt budget. This pins the off-by-one in the retry loop:
-# the final attempt is honoured, so the script must still exit 0.
-export SPAWN_BG_REGISTER_AFTER_N=5
-export LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S=0
-SPAWN_CALLER_CWD="$TMPDIR_TEST/worktrees/main"
-err_file="$TMPDIR_TEST/stderr"
-if out=$( cd "$SPAWN_CALLER_CWD" && "$TMPDIR_TEST/scripts/dispatch-spawn-worker" 839 "$WORKER_TARGET_WORKTREE" 2>"$err_file" ); then rc=0; else rc=$?; fi
-err=$(cat "$err_file")
-assert_eq "last-attempt-register-worker: dispatch-spawn-worker exits 0" "0" "$rc"
-assert_eq "last-attempt-register-worker: stdout is 'spawned'" "spawned" "$out"
-TOTAL=$((TOTAL + 1))
-if [[ -z "${err//[[:space:]]/}" ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: last-attempt-register-worker: no diagnostic on stderr"
-else
-  FAIL=$((FAIL + 1)); echo "  FAIL: last-attempt-register-worker: no diagnostic on stderr"
-  echo "    stderr: $err"
-fi
 spawn_worker_teardown
 
 # ============================================================================
@@ -10053,6 +10022,118 @@ assert_eq "spawn-job-usage: non-existent --cwd → exit 2" "2" "$sj_rc_d"
 if "$TMPDIR_TEST/scripts/dispatch-spawn-job" --name diagnose-main --cwd "$SPAWN_JOB_CWD" "prompt-one" "prompt-two" 2>/dev/null; then sj_rc_e=0; else sj_rc_e=$?; fi
 assert_eq "spawn-job-usage: extra positional → exit 2" "2" "$sj_rc_e"
 
+spawn_worker_teardown
+
+# --- Test 5: --no-verify mode skips the registration wait (#1048) ------------
+# The budget-path fan-out passes --no-verify: a successful `claude --bg` kick is
+# enough (the ledger + sweep reconcile the slot), and a non-zero kick fails.
+
+echo "Test: --no-verify exits 0 on a kick that never registers (no registration poll)"
+spawn_worker_setup
+write_fake_spawn_worker_claude
+export DISPATCH_SPAWN_JOB_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+export DISPATCH_SPAWN_JOB_SESSION_ID="sess-self"
+SPAWN_JOB_CWD="$TMPDIR_TEST/worktrees/839-test-worker"
+# SPAWN_BG_REGISTERS=0: the --bg fake returns 0 but never appends to the
+# registry. Under the OLD verify path this would have exited 1; with --no-verify
+# the kick's own exit 0 is the came-up signal, so the script exits 0.
+export SPAWN_BG_REGISTERS=0
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-job" --no-verify \
+    --name diagnose-main --cwd "$SPAWN_JOB_CWD" "/dispatch-diagnose-main abc" 2>/dev/null ); then rc=0; else rc=$?; fi
+assert_eq "spawn-job-noverify: exits 0 despite an empty registry" "0" "$rc"
+assert_eq "spawn-job-noverify: stdout is 'spawned'" "spawned" "$out"
+# Prove no registration happened: the registry was never appended to.
+TOTAL=$((TOTAL + 1))
+if [[ "$(cat "$SPAWN_WORKER_REGISTRY")" == "[]" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: spawn-job-noverify: spawned without the worker ever registering"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-job-noverify: spawned without the worker ever registering"
+  echo "    registry: $(cat "$SPAWN_WORKER_REGISTRY")"
+fi
+spawn_worker_teardown
+
+echo "Test: --no-verify exits 1 on a non-zero 'claude --bg' kick with a diagnostic"
+spawn_worker_setup
+export DISPATCH_SPAWN_JOB_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+export DISPATCH_SPAWN_JOB_SESSION_ID="sess-self"
+SPAWN_JOB_CWD="$TMPDIR_TEST/worktrees/839-test-worker"
+# Inline fake whose --bg exits non-zero; `agents` prints [] so dedup passes.
+cat > "$TMPDIR_TEST/fake-claude" <<FAKE
+#!/usr/bin/env bash
+set -uo pipefail
+case "\${1:-}" in
+  agents) echo '[]' ;;
+  --bg) echo "boom" >&2; exit 3 ;;
+esac
+FAKE
+chmod +x "$TMPDIR_TEST/fake-claude"
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-spawn-job" --no-verify \
+    --name diagnose-main --cwd "$SPAWN_JOB_CWD" "/dispatch-diagnose-main abc" 2>&1 1>/dev/null) || rc=$?
+assert_eq "spawn-job-noverify-fail: a non-zero kick exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ -n "${err//[[:space:]]/}" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: spawn-job-noverify-fail: stderr reports the failed kick"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-job-noverify-fail: stderr reports the failed kick"
+  echo "    stderr: $err"
+fi
+spawn_worker_teardown
+
+# --- Test 6: default (verify) path absorbs delayed registration --------------
+# The unledgered one-off spawns (main-broken / jit-reminder) keep the default
+# verify, so the delayed-registration retry coverage lives here on the DEFAULT
+# path (no --no-verify), ported from the former worker Tests 9 & 10.
+
+echo "Test: a job that registers on the 2nd 'agents' call still exits 0 (default verify)"
+spawn_worker_setup
+write_fake_spawn_worker_claude
+export DISPATCH_SPAWN_JOB_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+export DISPATCH_SPAWN_JOB_SESSION_ID="sess-self"
+SPAWN_JOB_CWD="$TMPDIR_TEST/worktrees/839-test-worker"
+# SPAWN_BG_REGISTER_AFTER_N=2: the job first appears on the 2nd subsequent
+# `agents` call. verify_agent_registered_under polls up to 5 times, so the 2nd
+# attempt finds it and the script exits 0.
+export SPAWN_BG_REGISTER_AFTER_N=2
+err_file="$TMPDIR_TEST/stderr"
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-job" \
+    --name diagnose-main --cwd "$SPAWN_JOB_CWD" "/dispatch-diagnose-main abc" 2>"$err_file" ); then rc=0; else rc=$?; fi
+err=$(cat "$err_file")
+assert_eq "spawn-job-delayed: exits 0" "0" "$rc"
+assert_eq "spawn-job-delayed: stdout is 'spawned'" "spawned" "$out"
+TOTAL=$((TOTAL + 1))
+if [[ -z "${err//[[:space:]]/}" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: spawn-job-delayed: no diagnostic on stderr"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-job-delayed: no diagnostic on stderr"
+  echo "    stderr: $err"
+fi
+spawn_worker_teardown
+
+echo "Test: a job that registers on the 5th (final) 'agents' call still exits 0 (default verify)"
+spawn_worker_setup
+write_fake_spawn_worker_claude
+export DISPATCH_SPAWN_JOB_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+export DISPATCH_SPAWN_JOB_SESSION_ID="sess-self"
+SPAWN_JOB_CWD="$TMPDIR_TEST/worktrees/839-test-worker"
+# SPAWN_BG_REGISTER_AFTER_N=5: the job first appears on the last poll before
+# verify exhausts its 5-attempt budget. Pins the off-by-one — the final attempt
+# is honoured, so the script must still exit 0.
+export SPAWN_BG_REGISTER_AFTER_N=5
+export LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S=0
+err_file="$TMPDIR_TEST/stderr"
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-job" \
+    --name diagnose-main --cwd "$SPAWN_JOB_CWD" "/dispatch-diagnose-main abc" 2>"$err_file" ); then rc=0; else rc=$?; fi
+err=$(cat "$err_file")
+assert_eq "spawn-job-last-attempt: exits 0" "0" "$rc"
+assert_eq "spawn-job-last-attempt: stdout is 'spawned'" "spawned" "$out"
+TOTAL=$((TOTAL + 1))
+if [[ -z "${err//[[:space:]]/}" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: spawn-job-last-attempt: no diagnostic on stderr"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawn-job-last-attempt: no diagnostic on stderr"
+  echo "    stderr: $err"
+fi
 spawn_worker_teardown
 
 # ============================================================================
@@ -15732,13 +15813,14 @@ assert_eq "queue happy: marker written into target worktree" "1" \
   "$([ -f "$TMPDIR_TEST/project/worktrees/839-test/tmp/dispatch-worktree" ] && echo 1 || echo 0)"
 mat_teardown
 
-# --- #945 boot-gap: propagate releases the lock ONLY after spawn -------------
-# The headline #945 assertion: the lock must be HELD while dispatch-spawn-worker
-# runs (i.e. through the worker's boot/registration) and released only after it
-# returns. Override the spawn-worker fake to snapshot the live lock contents at
-# spawn time, then assert the snapshot equals the held session id AND the final
-# lock file is empty (released after spawn).
-echo "Test: materialize-spawn holds the lock during spawn, releases after (#945)"
+# --- #1048 boot-gap: propagate releases the lock ONLY after spawn ------------
+# The headline assertion: the lock must be HELD while dispatch-spawn-worker runs
+# (i.e. through the worker spawn-kick) and released only after it returns. The
+# spawn is async (#1048), so the lock spans the kick, not registration. Override
+# the spawn-worker fake to snapshot the live lock contents at spawn time, then
+# assert the snapshot equals the held session id AND the final lock file is empty
+# (released after the kick).
+echo "Test: materialize-spawn holds the lock during spawn, releases after (#1048)"
 mat_setup
 cat > "$TMPDIR_TEST/dispatch-spawn-worker" <<FAKE
 #!/usr/bin/env bash
@@ -15759,11 +15841,16 @@ assert_eq "boot-gap: lock held during spawn (== session id)" "mat-session" \
 assert_eq "boot-gap: lock released after spawn" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
-# --- reservation written before spawn, cleared after a successful spawn -------
-# Step 6b writes the marker the instant before dispatch-spawn-worker and clears
-# it the instant the spawn returns. Snapshot the marker presence AT spawn time
-# (must be present), then assert it is gone after a successful spawn.
-echo "Test: materialize-spawn writes the reservation before spawn, clears it after success"
+# --- reservation written before spawn, LEFT in place after success (#1048) ----
+# Step 6b writes the marker the instant before the (now async) spawn-kick and
+# LEAVES it in place on success: the spawn is async (dispatch-spawn-worker passes
+# --no-verify), so the worker has not registered yet. The marker is this slot's
+# in-flight budget/selection contribution; the sweep reclaims it on registration
+# (rule (a)) or after the boot grace. Snapshot the marker presence AT spawn time
+# (must be present), then assert it SURVIVES a successful spawn — AND survives the
+# lock release and a fresh reservation_sweep, the reserve→release→reacquire
+# no-double-select property the AC names (the reserved target stays skipped).
+echo "Test: materialize-spawn leaves the reservation in place after a successful async spawn (#1048)"
 mat_setup
 cat > "$TMPDIR_TEST/dispatch-spawn-worker" <<FAKE
 #!/usr/bin/env bash
@@ -15779,7 +15866,23 @@ assert_eq "resv-success: exit 0" "0" "$rc"
 assert_eq "resv-success: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "resv-success: reservation present AT spawn time" "present" \
   "$(cat "$TMPDIR_TEST/logs/resv-at-spawn.log")"
-assert_eq "resv-success: reservation cleared after a successful spawn" "0" \
+assert_eq "resv-success: reservation LEFT in place after a successful spawn" "1" \
+  "$([ -f "$DISPATCH_RESERVATION_DIR/839-test" ] && echo 1 || echo 0)"
+# Lock was released after the kick (the locked phase is fast).
+assert_eq "resv-success: lock released after the spawn-kick" "" "$(cat "$DISPATCH_LOCK_FILE")"
+# reserve→release→reacquire: with the lock released, the marker still exists, so
+# a concurrent acquirer's reserved-skip (#1046) keeps skipping the target.
+TOTAL=$((TOTAL + 1))
+if reservation_exists "839-test"; then
+  PASS=$((PASS + 1)); echo "  PASS: resv-success: reservation_exists after release (target stays reserved)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: resv-success: reservation_exists after release (target stays reserved)"
+fi
+# The marker SURVIVES a fresh sweep: mat-session is reported live (rule (d) keeps
+# the in-flight marker; the boot grace would keep it anyway). The target remains
+# reserved across the full reserve→release→reacquire sequence.
+reservation_sweep 2>/dev/null
+assert_eq "resv-success: reservation survives a fresh reservation_sweep" "1" \
   "$([ -f "$DISPATCH_RESERVATION_DIR/839-test" ] && echo 1 || echo 0)"
 mat_teardown
 


### PR DESCRIPTION
Closes #1048

## Summary

Drops the synchronous worker-registration wait from the `/dispatch-propagate`
fan-out's budget critical path and releases the selection lock after the reserve
+ async spawn-kick of each slot, rather than after the last worker registers
(superseding the lock-through-registration behavior of #945).

Now that the reservation ledger is the budget authority (#1045) and
`dispatch-select-target` skips reserved worktrees (#1046), the **reservation
marker** — not registration timing — closes the spawn-gap re-selection race. The
router can no longer be the one to clear the marker once the spawn is async (it
exits before the worker registers), so the marker stays in place as the in-flight
budget/selection contribution and the sweep reclaims it once the worker goes
live.

## Changes (two commits)

**Unit A — `reservation_sweep` boot grace** (prep; behaviorally inert today).
A reservation marker younger than `DISPATCH_RESERVATION_BOOT_GRACE_S` (default
30s) is kept as in-flight regardless of whether its reserving session is still
live. This is the safety net the async flip needs: the reserving session stamped
in a marker is the short-lived router (`CLAUDE_CODE_SESSION_ID`), so once the
router exits, an in-flight marker whose worker is still booting would otherwise
be misclassified as dead-session-stranded and reclaimed — reopening the race.
New rule order: (a) live-worker-redundant (any age) → reclaim; (b) malformed →
keep; (new) young marker → keep (in-flight); (c) reserving session dead **and**
aged past the grace → reclaim; (d) reserving session live → keep. An
unparseable/absent timestamp falls through to the session rules (fail-safe to
today's behavior). Adds the `DISPATCH_RESERVATION_SWEEP_NOW_EPOCH` test override.

**Unit B — async spawn + leave the reservation in-flight.**
- `dispatch-spawn-job` gains a `--no-verify` flag: it skips
  `verify_agent_registered_under` and returns `spawned`/exit 0 on a successful
  `claude --bg` kick, or exit 1 with a diagnostic on a non-zero kick. The
  default path keeps the verify — the unledgered `main-broken` / `jit-reminder`
  one-off spawns have no ledger/sweep safety net, so the verify stays their
  came-up check.
- `dispatch-spawn-worker` passes `--no-verify` (the worker fan-out is the budget
  path, reconciled by the ledger + sweep).
- `dispatch-materialize-spawn` Step 6b **leaves** the reservation marker in place
  on a successful async spawn; it clears the marker only on a failed kick (no
  worker coming → no leaked budget). Stale #945 "lock-through-registration"
  comments swept to the #1048 model. Lock-release points are unchanged
  (single-target releases right after `process_one_target`, which now returns at
  the kick; fan-out releases once after the loop).

## Acceptance criteria

- The fan-out does not block on `verify_agent_registered_under` inside the budget
  path — `dispatch-spawn-worker` passes `--no-verify`.
- The selection lock is released once the slot is reserved and the worker spawn
  is kicked, before the worker registers.
- The spawn-gap re-selection race #945 closed remains closed — the reservation
  marker is left in place and a concurrent acquirer's reserved-skip (#1046) sees
  it and skips the target; the boot grace keeps a still-booting in-flight marker
  even after the router exits.
- `test-dispatch-scripts.sh` covers lock-release timing, the boot grace, the
  async-spawn behavior, and the reserve → release → reacquire no-double-select
  property (1652/1652 passing).
