### PR TITLE
plan-implement Step 1: document the real re-prompt mechanism, carry anchors + terminal procedure forward

### DIFF
--- a/.claude/skills/plan-implement/SKILL.md
+++ b/.claude/skills/plan-implement/SKILL.md
@@ -28,8 +28,8 @@ source, and (b) embed the terminal procedure (Steps 3–4) in its preface. There
 re-entry into this skill to guard against.
 
 If a requirement term has multiple plausible readings that would change the plan,
-resolve it via `AskUserQuestion` **before** drafting — guessing risks a plan rejected
-over the term and a costly redraft.
+resolve it via `AskUserQuestion` **before** calling `EnterPlanMode` — guessing risks
+a plan rejected over the term and a costly redraft.
 
 Invoke `EnterPlanMode` and produce a plan whose implementation section is an
 **ordered list of logical units of work**. The plan lives in the `ExitPlanMode`
@@ -51,8 +51,10 @@ Planning Rule: the plan assumes execution in a clean context and records that th
 active workflow step is the `implement` phase of `/dispatch-propagate`. Because the
 build session runs without this skill body, the preface must also embed the terminal
 procedure (Steps 3–4) so the build can execute it from the plan text alone: the
-`dispatch-open-pr` invocation with its close set, and the
-`dispatch-mark-complete` / `dispatch-mark-deviation` marker write.
+`dispatch-open-pr` invocation with its close set (including the `PR_NUM=$()`
+stdout capture), and the `dispatch-mark-complete` / `dispatch-mark-deviation`
+marker write. Copy these script invocations verbatim from Steps 3–4 — do not
+paraphrase — so the build session has the exact arguments and sandbox annotations.
 
 ### 2. Build each unit
 
@@ -69,6 +71,10 @@ and recovers from merge / pre-commit / push errors. This is a normal in-session 
 — **do not clear context between units**.
 
 ### 3. Open the draft PR
+
+This `dispatch-open-pr` call (including the `PR_NUM=$()` capture) is also carried
+in the plan preface (Step 1), so the post-clear build session executes it even
+though this skill body is absent.
 
 After every unit is committed and pushed, write the PR body prose to
 `tmp/pr-body.md`, then open the draft PR with `dispatch-open-pr` (use
@@ -100,8 +106,9 @@ hand.
 
 ### 4. Check for deviation, then write the marker (or skip it), then stop
 
-This marker write is also carried in the plan preface (Step 1), so the post-clear
-build session executes it even though this skill body is absent.
+Both marker writes (deviation and completion) are also carried in the plan preface
+(Step 1), so the post-clear build session executes them even though this skill body
+is absent.
 
 Before writing the marker, judge whether the implementation deviated from the
 approved plan — scope shifted mid-implementation, or the plan could not be

--- a/.claude/skills/plan-implement/SKILL.md
+++ b/.claude/skills/plan-implement/SKILL.md
@@ -17,17 +17,27 @@ implementation subagent and forks `/commit-merge-push`.
 
 ### 1. Plan logical units
 
-**Idempotency guard — check this first.** If an approved plan for this dispatch is
-already present in context (typical after `showClearContextOnPlanAccept` fires — the
-user accepted a plan and then cleared the context, causing this skill to be
-re-invoked), skip planning and resume at Step 2. The plan persists across context
-clears, so the unit list remains visible even though the planning conversation is
-gone.
+**The build session never reloads this skill.** When the user accepts the plan via
+`ExitPlanMode`, `showClearContextOnPlanAccept` (set `true` in
+`.claude/settings.json`) clears context and starts a fresh build session seeded with
+`Implement the following plan: <plan>`. That session does **not** re-invoke
+`/plan-implement`, so Steps 2–4 of this skill body are absent — the build works from
+the plan text alone. The plan is therefore the only carrier of build instructions: it
+must (a) carry file anchors so the build delegates each unit without re-reading
+source, and (b) embed the terminal procedure (Steps 3–4) in its preface. There is no
+re-entry into this skill to guard against.
 
-Otherwise, invoke `EnterPlanMode` and produce a plan whose implementation section is
-an **ordered list of logical units of work**. Each unit specifies:
+If a requirement term has multiple plausible readings that would change the plan,
+resolve it via `AskUserQuestion` **before** drafting — guessing risks a plan rejected
+over the term and a costly redraft.
 
-1. **Scope.** What files/behavior change, what is explicitly out of scope.
+Invoke `EnterPlanMode` and produce a plan whose implementation section is an
+**ordered list of logical units of work**. The plan lives in the `ExitPlanMode`
+payload — do not write-edit-reread it on disk. Each unit specifies:
+
+1. **Scope.** What files/behavior change, what is explicitly out of scope. Name the
+   exact files and `path:line` anchors the unit touches, so the build delegates to
+   `/implement-unit` without the main thread re-reading source.
 2. **Model.** `opus` or `sonnet`, chosen per the model-selection heuristic in
    `/implement-unit` — see that skill for the heuristic (it is the canonical home;
    do not restate it here).
@@ -38,7 +48,11 @@ Each unit becomes one commit. The user reviews and approves the plan.
 
 The plan must include a **plan preface** per `ref-memory-management`'s Clean Context
 Planning Rule: the plan assumes execution in a clean context and records that the
-active workflow step is the `implement` phase of `/dispatch-propagate`.
+active workflow step is the `implement` phase of `/dispatch-propagate`. Because the
+build session runs without this skill body, the preface must also embed the terminal
+procedure (Steps 3–4) so the build can execute it from the plan text alone: the
+`dispatch-open-pr` invocation with its close set, and the
+`dispatch-mark-complete` / `dispatch-mark-deviation` marker write.
 
 ### 2. Build each unit
 
@@ -85,6 +99,9 @@ diagnostic and fix the body or `--closes` set rather than opening the PR by
 hand.
 
 ### 4. Check for deviation, then write the marker (or skip it), then stop
+
+This marker write is also carried in the plan preface (Step 1), so the post-clear
+build session executes it even though this skill body is absent.
 
 Before writing the marker, judge whether the implementation deviated from the
 approved plan — scope shifted mid-implementation, or the plan could not be


### PR DESCRIPTION
Closes #1121

## Summary

Overhauls Step 1 of `/plan-implement` (`.claude/skills/plan-implement/SKILL.md`)
to document the real post-accept re-prompt mechanism and to make the plan carry
everything the skill-less build session needs.

After plan-accept, `showClearContextOnPlanAccept` clears context and starts a
fresh build session seeded only with `Implement the following plan: <plan>` — it
does **not** re-invoke `/plan-implement`, so Steps 2–4 of the skill body are
absent there. The old Step 1 documented an idempotency re-entry path that never
executes, and the plan it produced carried no file anchors and no terminal
procedure, forcing the build to re-read source and reconstruct the PR-open /
marker-write steps from memory.

## Changes (all in `.claude/skills/plan-implement/SKILL.md`)

1. **Replaced the dead idempotency guard** with an accurate description of the
   real mechanism: `ExitPlanMode` accept → `showClearContextOnPlanAccept`
   (`true` in `.claude/settings.json`) clears context and seeds a fresh build
   session that does not reload this skill. No re-entry exists to guard.
2. **Added an ambiguous-term clarification step** before drafting: resolve a
   requirement term with multiple plausible readings via `AskUserQuestion`
   first, to avoid a plan rejected over the term and a costly redraft.
3. **Stated the plan lives in the `ExitPlanMode` payload**, not written-edited-
   reread on disk.
4. **Required file + `path:line` anchors in each unit's Scope**, so the build
   delegates to `/implement-unit` without the main thread re-reading source.
5. **Extended the plan-preface paragraph** to embed the terminal procedure —
   the `dispatch-open-pr` invocation and the
   `dispatch-mark-complete` / `dispatch-mark-deviation` marker write — so the
   skill-less build session can run Steps 3–4 from the plan text alone.
6. **Added a one-sentence Step 4 cross-reference** noting the marker write is
   also carried in the plan preface.

The two blocking sub-issues (`dispatch-open-pr` #1124, `dispatch-mark-complete` /
`dispatch-mark-deviation` #1129) already merged; their scripts exist and
Steps 3/4 already invoke them, so no script changes were needed. This is a single
Markdown instruction-file change — `test-dispatch-scripts.sh` is unaffected.

Closes #1121.
