### PR TITLE
dispatch: priority/main-broken bypass the worker-count gate, floored by token exhaustion

### DIFF
--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -385,6 +385,7 @@ baked into the script):
 | `five_hour_target_floor_pct` (`floor5`) | 50 | `used_5h` % at which workers reach max (gate open) |
 | `five_hour_target_ceiling_pct` (`ceil5`) | 80 | `used_5h` % at which workers reach zero (gate open) |
 | `max_concurrent_workers` | 8 | max worker count |
+| `exhaustion_threshold_pct` | 98 | used_% (either window) at/near 100, with resets_at in the future, treated as genuine token exhaustion — a hard stop even for priority/main-broken work |
 
 Recalibration: raise `weekly_curve_power` to back-load spend later in the
 week (a higher `p` makes the curve concave up, so `W` grows slowly early and
@@ -406,6 +407,13 @@ clamps the terminal `W(1)` below `target_weekly_usage_pct`. The config validator
 only cross-checks floor vs. cap when both appear in the same config file, so a
 floor raised against the baked-in cap default passes validation but still
 clamps.
+
+Keep `exhaustion_threshold_pct` above `five_hour_target_ceiling_pct` (default 98
+> 80) so the 5h ramp's zero-point and the exhaustion floor stay distinct: the
+band between them (80→98) is "paced to 0", which priority/main-broken work
+overrides, while only used_% at/above the threshold is genuine token exhaustion,
+a hard stop for all work. Setting the threshold at or below the ceiling would
+collapse that override band into a hard stop.
 
 **Missing-telemetry fallback.** When
 `~/.local/share/commons-dispatch/rate_limits.json` is missing or unreadable,

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
@@ -354,7 +354,7 @@ case "$CONFIG_TYPE" in
     # top-level value must be an object; all tunables are optional numbers.
     # `dispatch-target-workers` substitutes a baked-in default for any field
     # absent here, so absence is silent — only the type of present fields is
-    # checked. The six percentage fields carry an additional `<= 100` bound;
+    # checked. The seven percentage fields carry an additional `<= 100` bound;
     # weekly_curve_power and max_concurrent_workers have no upper bound.
     ERRORS=$(jq -r '
       if type != "object" then
@@ -408,6 +408,13 @@ case "$CONFIG_TYPE" in
             and ($cfg.five_hour_target_ceiling_pct | type) == "number"
             and ($cfg.five_hour_target_floor_pct > $cfg.five_hour_target_ceiling_pct)
          then "five_hour_target_floor_pct must be <= five_hour_target_ceiling_pct, got floor \($cfg.five_hour_target_floor_pct) > ceiling \($cfg.five_hour_target_ceiling_pct)"
+         else empty end),
+        (if ($cfg | has("exhaustion_threshold_pct"))
+            and ($cfg | has("five_hour_target_ceiling_pct"))
+            and ($cfg.exhaustion_threshold_pct | type) == "number"
+            and ($cfg.five_hour_target_ceiling_pct | type) == "number"
+            and ($cfg.exhaustion_threshold_pct <= $cfg.five_hour_target_ceiling_pct)
+         then "exhaustion_threshold_pct must be > five_hour_target_ceiling_pct (the override band collapses otherwise), got threshold \($cfg.exhaustion_threshold_pct) <= ceiling \($cfg.five_hour_target_ceiling_pct)"
          else empty end)
       end
     ' "$CONFIG_FILE")

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
@@ -130,7 +130,7 @@
 #
 # Top-level object with optional tunables for `dispatch-target-workers`. Each
 # field must be a number when present; absent fields fall back to the
-# defaults baked into `dispatch-target-workers`. The six percentage fields
+# defaults baked into `dispatch-target-workers`. The seven percentage fields
 # must be in (0, 100]; weekly_curve_power and max_concurrent_workers must be
 # > 0 with no upper bound. When both members of a pair are present, two
 # cross-field ordering checks apply: weekly_increment_floor_pct <=
@@ -147,6 +147,7 @@
 #   five_hour_target_ceiling_pct   default 80   used_5h % at/above which workers
 #                                               are zero
 #   max_concurrent_workers         default 8
+#   exhaustion_threshold_pct       default 98   used_% at/near 100 treated as genuine token exhaustion
 #
 # Example (see target-workers.example.json):
 #   {
@@ -157,7 +158,8 @@
 #     "weekly_curve_power": 1,
 #     "five_hour_target_floor_pct": 50,
 #     "five_hour_target_ceiling_pct": 80,
-#     "max_concurrent_workers": 8
+#     "max_concurrent_workers": 8,
+#     "exhaustion_threshold_pct": 98
 #   }
 set -euo pipefail
 
@@ -364,7 +366,8 @@ case "$CONFIG_TYPE" in
           "weekly_increment_cap_pct","weekly_curve_power",
           "five_hour_target_floor_pct",
           "five_hour_target_ceiling_pct",
-          "max_concurrent_workers"] |
+          "max_concurrent_workers",
+          "exhaustion_threshold_pct"] |
          .[] |
          . as $field |
          # The percentage fields are bounded (0, 100]; the other two are
@@ -372,7 +375,8 @@ case "$CONFIG_TYPE" in
          ([ "target_weekly_usage_pct","weekly_terminal_pct",
             "weekly_increment_floor_pct",
             "weekly_increment_cap_pct",
-            "five_hour_target_floor_pct","five_hour_target_ceiling_pct" ]
+            "five_hour_target_floor_pct","five_hour_target_ceiling_pct",
+            "exhaustion_threshold_pct" ]
             | index($field)) as $is_pct |
          if ($cfg | has($field)) | not then
            empty

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Select the single highest-priority task from the queue.
-# Usage: dispatch-select-target [--qa | --health-only | --main-broken-sha] [--exclude <n>...]
+# Usage: dispatch-select-target [--qa | --health-only | --main-broken-sha | --priority-only] [--exclude <n>...]
 #
 # --exclude <n>... names issue numbers the caller has already processed (the
 # fan-out loop's SEEN set, #1062); the selector never returns an excluded target
@@ -47,6 +47,20 @@
 #
 # --qa mode omits the <phase> field — there it is always "qa":
 #   pr <num> <branch>           — the QA PR to work on
+#
+# --priority-only mode is the at-cap bypass selector (#1134): it runs the
+# origin/main CI health gate, then scans ONLY the `priority=1` tier of the
+# PR/issue ladder, returning the single highest-priority priority item. The JIT
+# scan is suppressed (a reminder is not priority/main-broken fix work). Every
+# default-mode skip rule is preserved (worktree ownership/reservation,
+# blocked_by, ready-PR-closes-issue, not-ready PR). dispatch-select-tick consults
+# it when the autonomous tick is at the worker cap but not token-exhausted, to
+# spawn a priority/main-broken item as one gate-exempt worker.
+# Output is exactly one line:
+#   main-broken <sha>           — origin/main's HEAD CI has a failing check
+#   pr <num> <branch> <phase>   — the highest-priority priority=1 PR
+#   issue <num>                 — the highest-priority priority=1 help-wanted issue
+#   empty                       — no priority=1 item eligible
 #
 # Selection is three-tier: the `priority` label is the *outermost* axis, topic
 # *category* nests inside it, and the phase *ladder* runs innermost. The
@@ -116,6 +130,7 @@ source "$SCRIPT_DIR/lib-reservation-ledger.sh"
 QA_MODE=false
 HEALTH_ONLY=false
 MAIN_BROKEN_SHA_ONLY=false
+PRIORITY_ONLY=false
 declare -A EXCLUDED=()
 
 while [[ $# -gt 0 ]]; do
@@ -123,6 +138,7 @@ while [[ $# -gt 0 ]]; do
     --qa) QA_MODE=true; shift ;;
     --health-only) HEALTH_ONLY=true; shift ;;
     --main-broken-sha) MAIN_BROKEN_SHA_ONLY=true; shift ;;
+    --priority-only) PRIORITY_ONLY=true; shift ;;
     --exclude)
       shift
       while [[ $# -gt 0 && "$1" =~ ^[0-9]+$ ]]; do
@@ -136,6 +152,16 @@ done
 
 if [[ "$QA_MODE" == "true" && "$HEALTH_ONLY" == "true" ]]; then
   echo "error: --qa and --health-only are mutually exclusive" >&2
+  exit 1
+fi
+
+# --priority-only is a default-mode variant (main-broken gate + the priority=1
+# tier only); it has no meaning alongside the --qa / --health-only / --main-broken-sha
+# modes, which run their own selection or exit early. Reject the combination
+# rather than silently picking one.
+if [[ "$PRIORITY_ONLY" == "true" \
+      && ( "$QA_MODE" == "true" || "$HEALTH_ONLY" == "true" || "$MAIN_BROKEN_SHA_ONLY" == "true" ) ]]; then
+  echo "error: --priority-only cannot combine with --qa, --health-only, or --main-broken-sha" >&2
   exit 1
 fi
 
@@ -340,12 +366,18 @@ if [[ "$HEALTH_ONLY" == "true" ]]; then
   exit 0
 fi
 
-# Default mode: JIT scan, then the main-broken gate.
+# Default mode: JIT scan, then the main-broken gate. --priority-only suppresses
+# the JIT scan (a reminder is not priority/main-broken fix work) but still runs
+# the main-broken latch: a newly-red main outranks the priority queue, and once
+# the diagnose job has filed the dispatch:main-broken+priority issue the latch
+# stands down so that fix work flows through the priority scan below.
 if [[ "$QA_MODE" == "false" ]]; then
-  JIT_LINE=$(jit_scan)
-  if [[ -n "$JIT_LINE" ]]; then
-    echo "$JIT_LINE"
-    exit 0
+  if [[ "$PRIORITY_ONLY" == "false" ]]; then
+    JIT_LINE=$(jit_scan)
+    if [[ -n "$JIT_LINE" ]]; then
+      echo "$JIT_LINE"
+      exit 0
+    fi
   fi
 
   MAIN_BROKEN_SHA=$(main_broken_latch)
@@ -571,6 +603,15 @@ PHASE_PRIORITY=(review verify)
 while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   [[ -z "$pr_num" ]] && continue
 
+  # --priority-only scans only the priority=1 tier. Skip any PR whose
+  # closing-issue label union does not carry `priority` BEFORE the expensive
+  # per-PR dispatch-ci-ready / dispatch-phase gh calls — a non-priority PR is
+  # never selectable in this mode, so it pays nothing.
+  if [[ "$PRIORITY_ONLY" == "true" ]] \
+     && [[ "$(has_priority_in_labels "$(pr_combined_labels "$pr_closing")")" != "1" ]]; then
+    continue
+  fi
+
   # Skip a PR whose branch worktree is owned by a live session or reserved. An
   # orphan worktree (no session, no marker) does not skip — it is recycled at
   # dispatch-resolve-worktree (#905, #1046).
@@ -696,6 +737,9 @@ while IFS=$'\t' read -r issue_num issue_labels; do
   # remaining issues in it are skipped — including the expensive leaf trace.
   issue_cat=$(category_of_labels "$issue_labels")
   issue_pri=$(has_priority_in_labels "$issue_labels")
+  # --priority-only scans only the priority=1 tier — skip non-priority issues
+  # before the expensive dispatch-trace-leaf descent.
+  [[ "$PRIORITY_ONLY" == "true" && "$issue_pri" != "1" ]] && continue
   issue_bucket="$issue_cat|$issue_pri"
   [[ -n "${FIRST_ISSUE[$issue_bucket]:-}" ]] && continue
   # Resolve a startable open leaf within the issue's subtree. dispatch-trace-leaf

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -785,6 +785,12 @@ done <<< "$ISSUE_SORTED"
 # phase — is exhausted before any priority=0 item is considered; within one
 # priority level topic category is the tie-break, and within each
 # (priority, category) bucket the phase ladder runs innermost.
+#
+# In --priority-only mode the scan loops above already `continue` on every
+# priority=0 item, so FIRST_PR/FIRST_ISSUE hold only priority=1 keys; the pri=0
+# pass below is then a guaranteed no-op (every lookup misses). It is left in the
+# shared loop rather than special-cased — the empty-map iteration is harmless
+# and keeps the default and --priority-only output paths identical.
 for pri in 1 0; do
   for category in "${CATEGORIES[@]}"; do
     for phase in "${PHASE_PRIORITY[@]}"; do

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -19,7 +19,9 @@
 #   busy             lock held by another tick; nothing acquired, nothing released.
 #   sync-failed      git fetch / merge --ff-only failed on `main`; lock released.
 #   resolver-failed  explicit arg did not resolve to one issue; lock released.
-#   concurrency-cap  effective-live count (busy workers + outstanding reservations) >= target; #725 re-seed scheduled; lock released.
+#   concurrency-cap  effective-live count (busy workers + outstanding reservations) >= target,
+#                    AND no priority/main-broken item waits to bypass it (or the rate-limit
+#                    window is genuinely exhausted); #725 re-seed scheduled; lock released.
 #   explicit <num> <gap>   explicit arg resolved to issue <num>; lock HELD.
 #   pr <num> <branch> <phase> <gap>   queue selected a PR; lock HELD.
 #   issue <num> <gap>   queue selected a help-wanted leaf; lock HELD.
@@ -41,7 +43,10 @@
 # A `--manual` run (the bare human-typed `/dispatch` shim) ALSO skips the gate —
 # no live-count query, never emits `concurrency-cap` — and like the explicit path
 # emits <gap> = 1, spawning ONE gate-exempt worker. Fan-out is autonomous-only.
-# The autonomous no-arg queue path keeps the full gate.
+# The autonomous no-arg queue path keeps the full gate, but with a priority
+# bypass at cap (see the gate narrative below): a waiting priority/main-broken
+# item is still selected and spawned as ONE gate-exempt worker (<gap> = 1) even
+# at/over the worker budget. The only hard floor is genuine token exhaustion.
 #
 # Lock invariant (the three guards): HOLD on pr/issue/explicit; RELEASE on
 # empty/sync-failed/resolver-failed/concurrency-cap/main-broken/jit-reminder;
@@ -141,18 +146,40 @@ fi
 # never emit `concurrency-cap` — and keep GAP=1, spawning ONE gate-exempt worker
 # that is not paced by the autonomous concurrency budget. Fan-out is
 # autonomous-only.
-# On the autonomous queue path the gate is evaluated ONCE per run, before any
-# selection work, so a run already at the worker budget does no JIT/selection
-# traversal. Before counting, the gate sweeps stranded reservations
-# (reservation_sweep) so it reconciles the ledger first. LIVE_COUNT is then the
-# effective-live count, effective_live = busy_workers + outstanding_reservations
+# On the autonomous queue path the gate is evaluated ONCE per run. Before
+# counting, the gate sweeps stranded reservations (reservation_sweep) so it
+# reconciles the ledger first. LIVE_COUNT is then the effective-live count,
+# effective_live = busy_workers + outstanding_reservations
 # (claude_agents_count_busy_workers + reservation_count), not busy workers alone
 # — a reservation counts against the budget the instant it is written, with no
-# wait for worker registration. At cap: schedule the #725 cap-keyed re-seed,
-# release the lock, emit `concurrency-cap`. Under cap: GAP bounds how many workers
-# a fan-out run may spawn. Daemon UNKNOWN (the busy-worker read fails;
-# reservation_count never fails) → fail open (GAP=1); the per-worktree dedup in
-# dispatch-spawn-worker is the last-line defense.
+# wait for worker registration. Under cap: GAP bounds how many workers a fan-out
+# run may spawn, and normal selection (Step 3) already runs priority-first, so a
+# priority item under budget is handled there. Daemon UNKNOWN (the busy-worker
+# read fails; reservation_count never fails) → fail open (GAP=1); the
+# per-worktree dedup in dispatch-spawn-worker is the last-line defense.
+#
+# AT cap (LIVE_COUNT >= TARGET_N) the budget no longer hard-stops the run. The
+# budget paces only NON-priority autonomous fan-out; priority/main-broken work
+# bypasses it. There are three cases, evaluated in order:
+#   1. `dispatch-target-workers --exhausted` reports `exhausted` (the 5-hour or
+#      weekly window is genuinely ~100% used, reset still ahead) → HARD STOP for
+#      everything: release the lock, schedule the #725 re-seed, emit
+#      `concurrency-cap`. No probe, no spawn — launching workers with no tokens
+#      is pure noise. This is distinct from "paced to 0 / at cap", which the
+#      pace/ramp math can produce while tokens remain; --exhausted is computed
+#      from telemetry independently of that math.
+#   2. Otherwise `dispatch-select-target --priority-only` probes the priority
+#      tier (its main-broken health gate runs first, so a main that broke WHILE
+#      at cap is now surfaced — the old early-exit fired before any selection):
+#        - `main-broken <sha>` → release the lock, echo it (the lock-free
+#          diagnose bg job spawns downstream).
+#        - `pr ...` / `issue ...` → HOLD the lock, append GAP=1 — ONE
+#          gate-exempt worker, exactly like manual/explicit dispatch. It is
+#          still counted by claude_agents_count_busy_workers on later ticks, so
+#          it suppresses non-priority fan-out: it bypasses the GATE, not the
+#          COUNT.
+#   3. `empty` (no priority/main-broken item waiting) → the unchanged hard cap:
+#      release the lock, schedule the #725 re-seed, emit `concurrency-cap`.
 GAP=1
 if [[ -z "$MANUAL" && -z "$ARG" ]]; then
   # shellcheck source=/dev/null
@@ -167,11 +194,56 @@ if [[ -z "$MANUAL" && -z "$ARG" ]]; then
     RESV=$(reservation_count)
     LIVE_COUNT=$(( BUSY + RESV ))
     if (( LIVE_COUNT >= TARGET_N )); then
-      release_lock
-      "$SCRIPT_DIR/dispatch-schedule-reseed" 1>&2 || true
       echo "router: $LIVE_COUNT effective live ($BUSY busy + $RESV reserved) >= target $TARGET_N"
-      echo "concurrency-cap"
-      exit 0
+      # At the worker budget. The budget paces NON-priority autonomous fan-out;
+      # priority / main-broken work bypasses it (one gate-exempt worker, GAP=1),
+      # exactly like a manual or explicit-target run. The only hard stop is
+      # genuine token exhaustion: when the 5-hour or weekly window is actually
+      # out of tokens (~100% used, reset still ahead), spawn nothing — including
+      # the main-broken diagnose job. Distinguish "paced to 0 / at cap" (a
+      # self-imposed throttle priority overrides) from "out of tokens" via the
+      # telemetry-only --exhausted query.
+      EXHAUSTED=$("$SCRIPT_DIR/dispatch-target-workers" --exhausted 2>/dev/null) || EXHAUSTED="ok"
+      if [[ "$EXHAUSTED" == exhausted ]]; then
+        release_lock
+        "$SCRIPT_DIR/dispatch-schedule-reseed" 1>&2 || true
+        echo "router: rate-limit window exhausted; no priority bypass"
+        echo "concurrency-cap"
+        exit 0
+      fi
+      # Not exhausted: probe the priority tier only (JIT output suppressed). The
+      # main-broken health gate runs first inside --priority-only, so a main that
+      # broke WHILE at cap is now surfaced (the old early-exit fired before any
+      # selection ran).
+      PRIO=$("$SCRIPT_DIR/dispatch-select-target" --priority-only) || PRIO="empty"
+      case "$PRIO" in
+        main-broken\ *)
+          # Spawned as its own lock-free bg job — release the lock here.
+          release_lock
+          echo "$PRIO"
+          exit 0
+          ;;
+        pr\ *|issue\ *)
+          # One gate-exempt worker, exactly like manual / explicit dispatch:
+          # hold the lock, append GAP=1. Counted by
+          # claude_agents_count_busy_workers on later ticks, so it suppresses
+          # non-priority fan-out — it bypasses the GATE, not the COUNT.
+          echo "$PRIO 1"
+          exit 0
+          ;;
+        empty)
+          # No priority/main-broken item waiting → hard cap as before.
+          release_lock
+          "$SCRIPT_DIR/dispatch-schedule-reseed" 1>&2 || true
+          echo "concurrency-cap"
+          exit 0
+          ;;
+        *)
+          release_lock
+          echo "dispatch-select-tick: dispatch-select-target --priority-only emitted unexpected '$PRIO'" >&2
+          exit 2
+          ;;
+      esac
     fi
     GAP=$(( TARGET_N - LIVE_COUNT ))
   fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
@@ -28,6 +28,9 @@
 #   dispatch-target-workers --reopen-at  reopen mode: print the earliest epoch
 #                                        at which the worker target next becomes
 #                                        >= 1, or `none`.
+#   dispatch-target-workers --exhausted  exhausted mode: print `exhausted` when
+#                                        the weekly OR 5-hour window is genuinely
+#                                        out of tokens, else `ok`.
 #
 # Stdout protocol:
 #   count mode (default):
@@ -38,9 +41,23 @@
 #     none        when the pace curve is not the blocker (target already >= 1,
 #                 or the 0 comes from an absolute cap / transient 5h fill rather
 #                 than a pace-curve pause), or the weekly anchor is absent.
+#   exhausted mode (--exhausted):
+#     exhausted   the weekly OR 5-hour window is GENUINELY out of tokens — its
+#                 used_% is at/near 100 (>= exhaustion_threshold_pct) with
+#                 resets_at still in the future. A hard stop even for
+#                 priority/main-broken work.
+#     ok          otherwise, INCLUDING missing/unreadable/invalid telemetry.
+#                 Exhausted mode fails OPEN: unknown usage is not genuine
+#                 exhaustion, so priority work is never suppressed on absent
+#                 data — the OPPOSITE posture from count mode's fallback-to-1.
+#                 This mode reads telemetry directly and never runs the
+#                 pace/ramp math, so "paced to 0" (a self-imposed throttle
+#                 priority work overrides) is reported as `ok`, distinct from
+#                 genuine `exhausted`.
 #
 # Exit codes:
-#   0  the script prints a number (count mode) or epoch/`none` (reopen mode).
+#   0  the script prints a number (count mode), epoch/`none` (reopen mode), or
+#      `exhausted`/`ok` (exhausted mode).
 #   2  unrecognized mode argument.
 #
 # Inputs (env-var overrides for tests; otherwise read from telemetry/config):
@@ -76,6 +93,13 @@
 #   five_hour_target_ceiling_pct   default 80   used_5h % at/above which workers
 #                                               are zero
 #   max_concurrent_workers         default 8
+#   exhaustion_threshold_pct       default 98   used_% (either window) at/near
+#                                               100 treated as genuine token
+#                                               exhaustion (--exhausted mode);
+#                                               above the 5h ramp's 80% zero-
+#                                               point so the 80→98 band stays a
+#                                               priority override, not a hard
+#                                               stop
 #
 # ---- The algorithm ----------------------------------------------------------
 #
@@ -155,8 +179,9 @@ MODE="count"
 case "${1:-}" in
   "")           MODE="count" ;;
   --reopen-at)  MODE="reopen" ;;
+  --exhausted)  MODE="exhausted" ;;
   *)
-    echo "dispatch-target-workers: unrecognized argument '$1' (expected --reopen-at or none)" >&2
+    echo "dispatch-target-workers: unrecognized argument '$1' (expected --reopen-at, --exhausted, or none)" >&2
     exit 2
     ;;
 esac
@@ -171,6 +196,7 @@ WEEKLY_CURVE_POWER=1
 FIVEH_TARGET_FLOOR=50
 FIVEH_TARGET_CEILING=80
 MAX_WORKERS=8
+EXHAUSTION_THRESHOLD=98
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -204,6 +230,8 @@ if [[ -n "$CONFIG_JSON" ]]; then
   [[ -n "$val" ]] && FIVEH_TARGET_CEILING="$val"
   val=$(jq -r '.max_concurrent_workers // empty' <<<"$CONFIG_JSON")
   [[ -n "$val" ]] && MAX_WORKERS="$val"
+  val=$(jq -r '.exhaustion_threshold_pct // empty' <<<"$CONFIG_JSON")
+  [[ -n "$val" ]] && EXHAUSTION_THRESHOLD="$val"
 fi
 
 # ---- Step 1: load telemetry -------------------------------------------------
@@ -278,6 +306,54 @@ fi
 if [[ -n "$WEEKLY_RESETS" && ! "$WEEKLY_RESETS" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
   echo "dispatch-target-workers: WEEKLY_RESETS has non-numeric value '$WEEKLY_RESETS'; treating as missing" >&2
   WEEKLY_RESETS=""
+fi
+
+# ---- Exhausted mode: telemetry-only genuine-exhaustion query ----------------
+#
+# Exhausted mode answers a different question from the pace/ramp math: is a
+# window GENUINELY out of tokens (used_% at/near 100 with a reset still in the
+# future), as opposed to merely PACED to zero by the self-imposed weekly gate or
+# 5h ramp? Priority/main-broken dispatch overrides a paced-zero but must still
+# hard-stop on genuine exhaustion. It is computed directly from telemetry,
+# independent of the curve.
+#
+# Fail open: missing/unreadable/invalid telemetry → `ok`. Unknown is not genuine
+# exhaustion, so priority work is never suppressed on absent data — the OPPOSITE
+# posture from count mode's fallback-to-1. A window is exhausted iff
+# used_% >= EXHAUSTION_THRESHOLD AND resets_at > now; print `exhausted` if EITHER
+# window is, else `ok`.
+if [[ "$MODE" == "exhausted" ]]; then
+  # FIVEH_RESETS is not sanitized above (count/reopen never read the 5h reset),
+  # so sanitize it here as count mode sanitizes WEEKLY_RESETS: a malformed value
+  # drops the 5h reset → that window cannot be "exhausted" (fail open).
+  if [[ -n "$FIVEH_RESETS" && ! "$FIVEH_RESETS" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+    echo "dispatch-target-workers: FIVEH_RESETS has non-numeric value '$FIVEH_RESETS'; treating as missing" >&2
+    FIVEH_RESETS=""
+  fi
+  # A missing/invalid NOW means we cannot compare resets_at to the present →
+  # fail open (`ok`). awk coerces an empty -v to 0, so guard on NOW != "".
+  if [[ -z "$NOW" ]]; then
+    echo ok
+    exit 0
+  fi
+  awk -v now="$NOW" \
+      -v used_weekly="$WEEKLY_USED" -v resets_weekly="$WEEKLY_RESETS" \
+      -v used_5h="$FIVEH_USED" -v resets_5h="$FIVEH_RESETS" \
+      -v threshold="$EXHAUSTION_THRESHOLD" \
+      'function exhausted(used, resets) {
+         # A window is genuinely exhausted only when its usage is at/near 100
+         # AND the reset is still in the future. Empty used/resets → not
+         # exhausted (fail open: a non-numeric stays empty and is skipped here,
+         # never coerced to a usage of 0 that could read as "exhausted").
+         if (used == "" || resets == "") return 0
+         return ((used + 0) >= (threshold + 0) && (resets + 0) > (now + 0))
+       }
+       BEGIN {
+         ex = (exhausted(used_weekly, resets_weekly) \
+               || exhausted(used_5h, resets_5h))
+         print (ex ? "exhausted" : "ok")
+       }'
+  exit 0
 fi
 
 # The weekly anchor requires BOTH used_weekly AND resets_at_weekly AND a valid

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -37,6 +37,30 @@
 #   (the highest-priority queue target), never emitting `concurrency-cap`. Fan-out
 #   is the autonomous chain's behavior only.
 #
+#   Exhaustion hard floor (autonomous path only): when the 5-hour or weekly
+#   rate-limit window is at/near 100% used with `resets_at` still in the future,
+#   `dispatch-target-workers --exhausted` reports `exhausted`. In that state the
+#   tick emits `concurrency-cap`, arms a reseed at the window reset, and spawns
+#   nothing — even a waiting `priority` or `dispatch:main-broken` item. This is a
+#   hard stop on genuine token exhaustion, not the self-imposed pacing throttle
+#   that the priority bypass is meant to override.
+#
+#   Priority/main-broken bypass (autonomous path, at-cap, not exhausted): when
+#   `LIVE_COUNT >= TARGET_N` but `--exhausted` reports `ok`, the tick does NOT
+#   immediately emit `concurrency-cap`. Instead it runs
+#   `dispatch-select-target --priority-only`, which checks the main-broken health
+#   gate first, then scans only the `priority=1` queue tier. If a
+#   `priority`-labeled PR or help-wanted issue (including any `dispatch:main-broken`
+#   issue) is found, the tick holds the lock and spawns exactly ONE gate-exempt
+#   worker (`GAP=1`) — the same treatment as a manual `dispatch`. This also closes
+#   the gap where a main that breaks while at the worker cap was previously
+#   suppressed: the old pre-selection gate exited before the main-broken health
+#   check ran; the bypass now runs that check first, so `main-broken <sha>` can
+#   surface and spawn the diagnose job even at cap. Priority/main-broken workers
+#   still count toward `LIVE_COUNT` and suppress non-priority fan-out on later
+#   ticks. If `--priority-only` returns `empty`, the tick falls back to the normal
+#   `concurrency-cap` disposition and reseed.
+#
 #   Selection lock: the selection lock (`dispatch-acquire-lock`, acquired inside
 #   `dispatch-select-tick`) is shared with the autonomous chain, so a manual run
 #   cannot select the same target as an in-flight tick. Merge conflicts are handled
@@ -50,6 +74,12 @@
 #        busy / sync-failed / resolver-failed / empty / concurrency-cap
 #                          → log a one-line note; exit 0. (select-tick already
 #                            released the lock / scheduled any reseed.)
+#        NOTE: on the autonomous no-arg path, `concurrency-cap` is emitted by
+#        select-tick only after the priority/main-broken bypass runs (see above):
+#        at-cap + exhausted → concurrency-cap immediately;
+#        at-cap + not exhausted + no priority/main-broken item → concurrency-cap;
+#        at-cap + not exhausted + priority/main-broken item found → pr/issue/main-broken
+#        decision instead, spawned as one gate-exempt worker (GAP=1).
 #        main-broken <sha> → spawn /dispatch-diagnose-main <sha> as a bg job via
 #                            dispatch-spawn-job (--name diagnose-main); exit 0.
 #        jit-reminder ...  → spawn /dispatch-jit-reminder ... as a bg job via

--- a/.claude/skills/dispatch-propagate/scripts/target-workers.example.json
+++ b/.claude/skills/dispatch-propagate/scripts/target-workers.example.json
@@ -6,5 +6,6 @@
   "weekly_curve_power": 1,
   "five_hour_target_floor_pct": 50,
   "five_hour_target_ceiling_pct": 80,
-  "max_concurrent_workers": 8
+  "max_concurrent_workers": 8,
+  "exhaustion_threshold_pct": 98
 }

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2841,11 +2841,25 @@ result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
 assert_eq "--priority-only JIT suppressed → priority issue returned" "issue 400" "$result"
 teardown
 
-# PO6. --priority-only rejects combination with the other modes.
+# PO6. --priority-only rejects combination with the other modes. The guard
+# condition covers all three sibling modes, so exercise each arm: --qa,
+# --health-only, and --main-broken-sha must each be rejected with exit 1.
 echo "Test: --priority-only + --qa → error exit"
 setup
 result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only --qa 2>/dev/null) && rc=0 || rc=$?
 assert_eq "--priority-only --qa → exit 1" "1" "$rc"
+teardown
+
+echo "Test: --priority-only + --health-only → error exit"
+setup
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only --health-only 2>/dev/null) && rc=0 || rc=$?
+assert_eq "--priority-only --health-only → exit 1" "1" "$rc"
+teardown
+
+echo "Test: --priority-only + --main-broken-sha → error exit"
+setup
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only --main-broken-sha 2>/dev/null) && rc=0 || rc=$?
+assert_eq "--priority-only --main-broken-sha → exit 1" "1" "$rc"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2736,6 +2736,118 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "green draft PR selected by PR queue as qa" "pr 10 55-feature qa" "$result"
 teardown
 
+# --- --priority-only mode (#1134) -------------------------------------------
+# --priority-only runs the main-broken health gate, then scans ONLY the
+# priority=1 tier. The JIT scan is suppressed. It is the at-cap bypass selector:
+# dispatch-select-tick consults it when the autonomous tick is at the worker cap
+# but not token-exhausted, to spawn a priority/main-broken item as one
+# gate-exempt worker. Output is one of: main-broken <sha> | pr <num> <branch>
+# <phase> | issue <num> | empty.
+
+# PO1. A priority PR (its closing issue carries `priority`) is returned over a
+#      non-priority PR — the non-priority PR is skipped wholesale by the
+#      priority-tier guard, never reaching the per-PR gh calls.
+echo "Test: --priority-only returns the priority PR, skips the non-priority PR"
+setup
+# PR 10 (older) closes plain bug issue 200; PR 20 (newer) closes priority issue 100.
+UNION='['
+UNION+="$(make_pr_union 10 "10-bug-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
+UNION+="$(make_pr_union 20 "20-priority-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100}]')"
+UNION+=']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]},{"number":200,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only returns priority PR" "pr 20 20-priority-pr verify" "$result"
+teardown
+
+# PO2. A priority help-wanted issue is returned over a non-priority help-wanted
+#      issue — the non-priority issue is skipped before the leaf trace.
+echo "Test: --priority-only returns the priority issue, skips the non-priority issue"
+setup
+setup_union_pr_list '[]'
+# Issue 300 (older, no priority) and issue 400 (newer, priority); both help-wanted.
+printf '[{"number":300,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"bug"}]},{"number":400,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only returns priority issue" "issue 400" "$result"
+teardown
+
+# PO3. main is red and no latch issue open → main-broken fires first, before the
+#      priority scan (the gate runs ahead of the ladder, same as default mode).
+echo "Test: --priority-only — main red, no latch → main-broken (gate first)"
+setup
+# Seed a priority PR that would otherwise be selected; the gate must preempt it.
+UNION='['"$(make_pr_union 20 "20-priority-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '{"sha":"mainhead0"}' > "$STUB_DIR/main-commit.json"
+printf '{"check_runs":[{"status":"completed","conclusion":"failure"}]}' \
+  > "$STUB_DIR/main-check-runs.json"
+printf '[]' > "$STUB_DIR/main-run-list.json"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only main red → main-broken first" "main-broken mainhead0" "$result"
+teardown
+
+# PO4. Only non-priority items in the queue → empty (the priority tier is empty,
+#      and the pri=0 iteration of the selection loop finds nothing).
+echo "Test: --priority-only — only non-priority items → empty"
+setup
+UNION='['"$(make_pr_union 10 "10-bug-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":200,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]},{"number":300,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"bug"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only no priority items → empty" "empty" "$result"
+teardown
+
+# PO5. A due JIT is configured but --priority-only suppresses the JIT scan — the
+#      reminder is NOT emitted; the priority result is returned instead. (The
+#      same JIT fixture emits a jit-reminder in default mode, see JS4.)
+echo "Test: --priority-only suppresses the JIT scan (reminder not emitted)"
+setup
+# Self-contained one-project catalog (the shared JIT_PROJECTS_JSON is defined
+# later in the JIT-scan section).
+cat > "$DISPATCH_CONFIG_DIR/projects.json" <<'EOF'
+{ "projects": [
+  { "key": "household", "owner": "natb1", "number": 5,
+    "statusField": "Status", "statusInProgress": "In Progress",
+    "statusDone": "Done" }
+] }
+EOF
+cat > "$DISPATCH_CONFIG_DIR/jit.json" <<'EOF'
+{ "jits": [
+  { "key": "email-review", "repo": "natb1/household", "label": "jit:email-review",
+    "title": "Email review", "body": "Review the inbox.",
+    "project": "household", "dueAfterCreate": "48h" }
+] }
+EOF
+printf '[{"number":77,"createdAt":"2026-05-01T00:00:00Z"}]\n' \
+  > "$STUB_DIR/jit-issues-open-jit_email-review.json"
+printf '{"items":[{"id":"PVTI_077","content":{"url":"https://github.com/natb1/household/issues/77"},"status":"Todo"}]}\n' \
+  > "$STUB_DIR/project-item-list.json"
+# A priority help-wanted issue waits in the queue; --priority-only must return it
+# rather than the suppressed JIT reminder.
+setup_union_pr_list '[]'
+printf '[{"number":400,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only JIT suppressed → priority issue returned" "issue 400" "$result"
+teardown
+
+# PO6. --priority-only rejects combination with the other modes.
+echo "Test: --priority-only + --qa → error exit"
+setup
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only --qa 2>/dev/null) && rc=0 || rc=$?
+assert_eq "--priority-only --qa → exit 1" "1" "$rc"
+teardown
+
 # ============================================================================
 # --- JIT scan ---
 # dispatch-select-target's JIT scan runs before the main-broken health gate.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -7291,6 +7291,38 @@ else
 fi
 config_teardown
 
+# --- Test 13i: exhaustion_threshold_pct: valid round-trip -------------------
+
+echo "Test: exhaustion_threshold_pct: 95 accepted and round-trips"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
+{"exhaustion_threshold_pct": 95}
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" target-workers 2>/dev/null); rc=$?
+assert_eq "exhaustion_threshold_pct 95 exits 0" "0" "$rc"
+tw_exh=$(printf '%s' "$out" | jq -r '.exhaustion_threshold_pct')
+assert_eq "exhaustion_threshold_pct 95 preserved" "95" "$tw_exh"
+config_teardown
+
+# --- Test 13j: exhaustion_threshold_pct: 101 rejected (must be <= 100) -------
+
+echo "Test: exhaustion_threshold_pct: 101 exits 1 and stderr says must be <= 100"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
+{"exhaustion_threshold_pct": 101}
+EOF
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" target-workers 2>&1 1>/dev/null) || rc=$?
+assert_eq "exhaustion_threshold_pct 101 exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"exhaustion_threshold_pct"* && "$err" == *"<= 100"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: exhaustion_threshold_pct 101 stderr says <= 100"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: exhaustion_threshold_pct 101 stderr says <= 100"
+  echo "    stderr: $err"
+fi
+config_teardown
+
 # ============================================================================
 # dispatch-target-workers tests
 # ============================================================================
@@ -7944,6 +7976,87 @@ if (( out >= 1 )); then
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: mid-week used_weekly=30 expected N>=1, got $out"
 fi
+tw_teardown
+
+# --- Test 24: --exhausted — 5h window at 100% with future reset → exhausted --
+#
+# Exhausted mode reads telemetry directly and reports `exhausted` when EITHER
+# window is at/near 100% used (>= exhaustion_threshold_pct, default 98) with
+# resets_at in the future, else `ok`. It is independent of the pace/ramp math
+# and fails OPEN on missing/invalid telemetry.
+
+echo "Test: --exhausted 5h used=100, resets in future → exhausted"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+# 5h pinned at 100%, weekly comfortably under; both resets in the future.
+write_rl "exh.json" 30 $((TW_NOW + 302400)) 100 $((TW_NOW + 3600))
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" --exhausted 2>/dev/null)
+assert_eq "--exhausted: 5h=100 future reset → exhausted" "exhausted" "$out"
+tw_teardown
+
+# --- Test 25: --exhausted — weekly used=99 (>=98) future reset → exhausted ---
+
+echo "Test: --exhausted weekly used=99, resets in future → exhausted"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+write_rl "exh.json" 99 $((TW_NOW + 302400)) 30 $((TW_NOW + 3600))
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" --exhausted 2>/dev/null)
+assert_eq "--exhausted: weekly=99 future reset → exhausted" "exhausted" "$out"
+tw_teardown
+
+# --- Test 26: --exhausted — both windows used=50 → ok -----------------------
+
+echo "Test: --exhausted both windows used=50 → ok"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+write_rl "exh.json" 50 $((TW_NOW + 302400)) 50 $((TW_NOW + 3600))
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" --exhausted 2>/dev/null)
+assert_eq "--exhausted: both=50 → ok" "ok" "$out"
+tw_teardown
+
+# --- Test 27: --exhausted — 5h used=100 but resets_at <= now → ok ------------
+#
+# A window already past its reset is not "out of tokens" — the window has
+# refilled. resets_at in the past must NOT count as exhausted.
+
+echo "Test: --exhausted 5h used=100 but window already reset → ok"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+# 5h reset is in the PAST (<= now); weekly under pace with a future reset.
+write_rl "exh.json" 30 $((TW_NOW + 302400)) 100 $((TW_NOW - 1))
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" --exhausted 2>/dev/null)
+assert_eq "--exhausted: 5h=100 past reset → ok" "ok" "$out"
+tw_teardown
+
+# --- Test 28: --exhausted — missing rate_limits.json → ok (fail open) -------
+#
+# The OPPOSITE of count mode's fallback-to-1: unknown usage is not genuine
+# exhaustion, so priority work is never suppressed on absent telemetry.
+
+echo "Test: --exhausted missing rate_limits.json → ok (fail open)"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+# tw_setup points RATE_LIMITS_PATH at an absent file by default; no write_rl.
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" --exhausted 2>/dev/null)
+assert_eq "--exhausted: missing telemetry → ok" "ok" "$out"
+tw_teardown
+
+# --- Test 29: --exhausted — threshold from config (95): 96→exhausted, 94→ok -
+
+echo "Test: --exhausted exhaustion_threshold_pct config 95 gates at 95"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+cat > "$DISPATCH_CONFIG_DIR/target-workers.json" <<'EOF'
+{"exhaustion_threshold_pct": 95}
+EOF
+# used=96 (>= 95) with a future reset → exhausted.
+write_rl "exh.json" 96 $((TW_NOW + 302400)) 30 $((TW_NOW + 3600))
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" --exhausted 2>/dev/null)
+assert_eq "--exhausted: threshold 95, weekly=96 → exhausted" "exhausted" "$out"
+# used=94 (< 95) → ok.
+write_rl "exh.json" 94 $((TW_NOW + 302400)) 30 $((TW_NOW + 3600))
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" --exhausted 2>/dev/null)
+assert_eq "--exhausted: threshold 95, weekly=94 → ok" "ok" "$out"
 tw_teardown
 
 # --- Test: --reopen-at pace-curve crossing (#1050) --------------------------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6324,6 +6324,23 @@ assert_eq "no-match: exits 0" "0" "$rc"
 assert_eq "no-match: prints 0" "0" "$out"
 ca_teardown
 
+# --- Test 11b: priority/main-broken workers are still counted (#1134) -------
+# The #1134 priority bypass exempts priority/main-broken work from the worker
+# GATE, not the COUNT: a gate-exempt priority worker is named `<N>-slug` like any
+# worker, so claude_agents_count_busy_workers must still count it. This guards
+# that no priority carve-out leaked into counting — priority workers must keep
+# inflating LIVE_COUNT and suppressing non-priority fan-out on later ticks.
+echo "Test: claude_agents_count_busy_workers counts a priority/main-broken worker"
+ca_setup
+write_fake_claude '[
+  {"sessionId":"a","pid":1,"status":"busy","name":"1134-priority-fix"},
+  {"sessionId":"b","pid":2,"status":"busy","name":"720-bar"}
+]' 0
+if out=$(claude_agents_count_busy_workers); then rc=0; else rc=$?; fi
+assert_eq "priority-count: exits 0" "0" "$rc"
+assert_eq "priority-count: priority-named worker counted (2 total)" "2" "$out"
+ca_teardown
+
 # --- Test 12: claude_agents_count_busy_workers reports UNKNOWN on failure --
 
 echo "Test: claude_agents_count_busy_workers returns rc 1 on daemon failure"
@@ -15279,12 +15296,25 @@ echo "$1"
 FAKE
   cat > "$TMPDIR_TEST/dispatch-select-target" <<FAKE
 #!/usr/bin/env bash
+# --priority-only probe (the at-cap bypass): logged separately so a test can
+# assert whether the priority probe ran, and driven by SEL_PRIORITY_ONLY.
+if [[ "\$1" == "--priority-only" ]]; then
+  echo called >> "$TMPDIR_TEST/logs/select-target-priority.log"
+  echo "\${SEL_PRIORITY_ONLY:-empty}"
+  exit 0
+fi
 echo called >> "$TMPDIR_TEST/logs/select-target.log"
 echo empty
 FAKE
   # Run-scoped concurrency gate fakes (overridable per test via SEL_* env vars).
+  # Arg-aware: --exhausted reports the rate-limit exhaustion floor (SEL_EXHAUSTED,
+  # default ok); the no-arg query returns the worker target (SEL_TARGET_N).
   cat > "$TMPDIR_TEST/dispatch-target-workers" <<'FAKE'
 #!/usr/bin/env bash
+if [[ "$1" == "--exhausted" ]]; then
+  echo "${SEL_EXHAUSTED:-ok}"
+  exit 0
+fi
 echo "${SEL_TARGET_N:-1}"
 FAKE
   cat > "$TMPDIR_TEST/dispatch-schedule-reseed" <<FAKE
@@ -15366,6 +15396,7 @@ sel_tick_teardown() {
     DISPATCH_LOCK_WAIT_TIMEOUT DISPATCH_LOCK_WAIT_INTERVAL \
     FAKE_GIT_BRANCH FAKE_GIT_FETCH_FAIL FAKE_GIT_MERGE_FAIL \
     SEL_TARGET_N SEL_LIVE_COUNT SEL_LIVE_COUNT_FAIL \
+    SEL_EXHAUSTED SEL_PRIORITY_ONLY \
     DISPATCH_RESERVATION_DIR SEL_AGENTS_TSV SEL_AGENTS_LIST_FAIL
 }
 
@@ -15611,15 +15642,21 @@ esac
 assert_eq "extra args → usage error, exit 2" "ok" "$status"
 sel_tick_teardown
 
-# --- gate at cap → concurrency-cap, no selection work ------------------------
-echo "Test: select-tick at cap → concurrency-cap, no selection work"
+# --- gate at cap, not exhausted, no priority item → concurrency-cap ----------
+# At cap the gate no longer hard-stops blindly: it first checks --exhausted (ok
+# here) then probes --priority-only (empty here). Empty priority tier → the
+# unchanged hard cap. The normal no-arg selection (select-target.log) still does
+# NOT run, but the priority-only probe (select-target-priority.log) DOES.
+echo "Test: select-tick at cap, not exhausted, no priority item → concurrency-cap"
 sel_tick_setup
-export SEL_LIVE_COUNT=2 SEL_TARGET_N=1
+export SEL_LIVE_COUNT=2 SEL_TARGET_N=1 SEL_EXHAUSTED=ok SEL_PRIORITY_ONLY=empty
 out=$(run_sel_tick)
 assert_eq "cap: decision line" "concurrency-cap" "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "cap: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 assert_eq "cap: reseed scheduled" "called" "$(cat "$TMPDIR_TEST/logs/schedule-reseed.log" 2>/dev/null)"
-assert_eq "cap: no selection work (select-target not called)" "0" \
+assert_eq "cap: priority-only probe ran (returned empty)" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/select-target-priority.log" ] && echo 1 || echo 0)"
+assert_eq "cap: normal no-arg selection did NOT run" "0" \
   "$([ -f "$TMPDIR_TEST/logs/select-target.log" ] && echo 1 || echo 0)"
 sel_tick_teardown
 
@@ -15691,8 +15728,10 @@ assert_eq "effective-cap: reseed scheduled" "called" \
   "$(cat "$TMPDIR_TEST/logs/schedule-reseed.log" 2>/dev/null)"
 assert_eq "effective-cap: router message surfaces the busy/reserved split" "1" \
   "$(printf '%s\n' "$out" | grep -cF 'effective live (1 busy + 1 reserved)')"
-assert_eq "effective-cap: no selection work (select-target not called)" "0" \
+assert_eq "effective-cap: normal no-arg selection did NOT run" "0" \
   "$([ -f "$TMPDIR_TEST/logs/select-target.log" ] && echo 1 || echo 0)"
+assert_eq "effective-cap: priority-only probe ran (returned empty)" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/select-target-priority.log" ] && echo 1 || echo 0)"
 sel_tick_teardown
 
 # --- empty ledger is behavior-preserving (gap == pre-ledger gate) ------------
@@ -15796,18 +15835,87 @@ assert_eq "manual-overcap: pace-curve dispatch-target-workers NOT invoked (gate 
   "$([ -f "$TMPDIR_TEST/logs/target-workers.log" ] && echo 1 || echo 0)"
 sel_tick_teardown
 
-# --- autonomous no-arg with LIVE_COUNT >= TARGET_N → concurrency-cap (unchanged) ---
-# The exemption is --manual only. An autonomous no-arg tick with LIVE_COUNT >= TARGET_N
-# still gates on the pace curve and emits concurrency-cap — unchanged behavior.
-echo "Test: select-tick autonomous no-arg LIVE_COUNT >= TARGET_N → concurrency-cap (unchanged)"
+# --- autonomous no-arg at cap, not exhausted, no priority item → concurrency-cap ---
+# The exemption is --manual only. An autonomous no-arg tick at the budget with no
+# priority/main-broken item waiting still emits concurrency-cap — unchanged hard
+# cap — but the priority-only probe now runs (and returns empty) before it.
+echo "Test: select-tick autonomous no-arg at cap, no priority item → concurrency-cap"
 sel_tick_setup
-export SEL_LIVE_COUNT=3 SEL_TARGET_N=0
+export SEL_LIVE_COUNT=3 SEL_TARGET_N=0 SEL_EXHAUSTED=ok SEL_PRIORITY_ONLY=empty
 out=$(run_sel_tick)
 assert_eq "autonomous-cap: decision line is concurrency-cap" "concurrency-cap" \
   "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "autonomous-cap: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 assert_eq "autonomous-cap: reseed scheduled" "called" \
   "$(cat "$TMPDIR_TEST/logs/schedule-reseed.log" 2>/dev/null)"
+assert_eq "autonomous-cap: priority-only probe ran (returned empty)" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/select-target-priority.log" ] && echo 1 || echo 0)"
+sel_tick_teardown
+
+# --- at cap, not exhausted, priority PR waiting → spawned as ONE gate-exempt worker ---
+# The core #1134 bypass: at/over the worker budget, a waiting priority PR is
+# selected and spawned with GAP=1 (one gate-exempt worker, exactly like manual /
+# explicit dispatch). Lock HELD, no reseed, no concurrency-cap.
+echo "Test: select-tick at cap, priority PR → pr line w/ gap 1, lock held, no reseed"
+sel_tick_setup
+export SEL_LIVE_COUNT=3 SEL_TARGET_N=1 SEL_EXHAUSTED=ok
+export SEL_PRIORITY_ONLY="pr 50 50-foo verify"
+out=$(run_sel_tick)
+assert_eq "cap-prio-pr: decision line w/ gap 1" "pr 50 50-foo verify 1" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "cap-prio-pr: lock held" "select-tick-session" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "cap-prio-pr: no reseed scheduled" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-reseed.log" ] && echo 1 || echo 0)"
+assert_eq "cap-prio-pr: no concurrency-cap emitted" "0" \
+  "$(printf '%s\n' "$out" | grep -cF 'concurrency-cap')"
+sel_tick_teardown
+
+# --- at cap, not exhausted, priority issue waiting → spawned as ONE gate-exempt worker ---
+echo "Test: select-tick at cap, priority issue → issue line w/ gap 1, lock held"
+sel_tick_setup
+export SEL_LIVE_COUNT=3 SEL_TARGET_N=1 SEL_EXHAUSTED=ok
+export SEL_PRIORITY_ONLY="issue 60"
+out=$(run_sel_tick)
+assert_eq "cap-prio-issue: decision line w/ gap 1" "issue 60 1" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "cap-prio-issue: lock held" "select-tick-session" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "cap-prio-issue: no reseed scheduled" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-reseed.log" ] && echo 1 || echo 0)"
+sel_tick_teardown
+
+# --- at cap, not exhausted, main-broken waiting → main-broken line, lock RELEASED ---
+# A main that breaks WHILE at cap is now surfaced (the old early-exit fired before
+# any selection ran). The diagnose bg job spawns lock-free downstream, so the lock
+# is released here. No reseed.
+echo "Test: select-tick at cap, main-broken → main-broken line, lock released, no reseed"
+sel_tick_setup
+export SEL_LIVE_COUNT=3 SEL_TARGET_N=1 SEL_EXHAUSTED=ok
+export SEL_PRIORITY_ONLY="main-broken deadbeef"
+out=$(run_sel_tick)
+assert_eq "cap-mainbroken: decision line" "main-broken deadbeef" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "cap-mainbroken: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "cap-mainbroken: no reseed scheduled" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-reseed.log" ] && echo 1 || echo 0)"
+sel_tick_teardown
+
+# --- at cap, EXHAUSTED → hard stop: concurrency-cap, no priority probe -------
+# Genuine token exhaustion is the one hard floor: even with a priority item
+# waiting, nothing spawns. The --priority-only probe is NOT consulted, the lock is
+# released, the reseed is armed at the window reset, and the decision is
+# concurrency-cap.
+echo "Test: select-tick at cap, exhausted → concurrency-cap, priority probe NOT consulted"
+sel_tick_setup
+export SEL_LIVE_COUNT=3 SEL_TARGET_N=1 SEL_EXHAUSTED=exhausted
+export SEL_PRIORITY_ONLY="pr 50 50-foo verify"
+out=$(run_sel_tick)
+assert_eq "cap-exhausted: decision line" "concurrency-cap" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "cap-exhausted: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "cap-exhausted: reseed scheduled" "called" \
+  "$(cat "$TMPDIR_TEST/logs/schedule-reseed.log" 2>/dev/null)"
+assert_eq "cap-exhausted: priority-only probe NOT consulted" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/select-target-priority.log" ] && echo 1 || echo 0)"
 sel_tick_teardown
 
 # --- --manual cannot be combined with an explicit <number> → exit 2 ----------


### PR DESCRIPTION
Closes #1134

## What

`priority`-labeled work — including `dispatch:main-broken` issues, which are
already filed with the `priority` label — now bypasses the worker-count gate on
the autonomous dispatch path, exactly like a manual `/dispatch`. The one hard
stop is genuine token exhaustion.

Before this change, the autonomous tick computed `TARGET_N` from
`dispatch-target-workers` (the binary weekly-pace gate + linear 5-hour ramp from
#1130) and, when `LIVE_COUNT >= TARGET_N`, emitted `concurrency-cap` and exited
*before any selection work*. A waiting priority item was throttled by the pacing
budget, and a main that broke while at the cap was never surfaced — the early
exit fired before the main-broken health gate ran.

## How

Four units, one commit each:

1. **`dispatch-target-workers --exhausted`** — a telemetry-only query that prints
   `exhausted` when the 5-hour or weekly window is at/near 100% used
   (`used_percentage >= exhaustion_threshold_pct`, default 98) with `resets_at`
   still in the future, else `ok`. Missing/unreadable telemetry → `ok` (fail
   open). This distinguishes "paced to 0" (a self-imposed throttle priority work
   overrides) from "genuinely out of tokens" (a hard stop), computed
   independently of the pace/ramp math. Adds the `exhaustion_threshold_pct`
   config knob (validated as a `(0,100]` percentage).

2. **`dispatch-select-target --priority-only`** — a selection mode that returns
   the main-broken health-gate result if any, else the highest-priority
   `priority=1` PR or help-wanted issue, else `empty`. JIT scan suppressed; every
   existing skip rule (worktree ownership/reservation, `blocked_by`,
   ready-PR-closes-issue, not-ready PR) preserved. Non-priority items are skipped
   wholesale before the expensive per-item `gh` calls.

3. **At-cap three-way bypass in `dispatch-select-tick`** — on the autonomous
   no-arg path, when `LIVE_COUNT >= TARGET_N`:
   - exhausted → hard stop: release the lock, arm the reseed at the window reset,
     emit `concurrency-cap`, spawn nothing.
   - else a priority/main-broken item → `main-broken <sha>` (release lock, the
     lock-free diagnose job spawns) or `pr …`/`issue …` (hold the lock, append
     `GAP=1` — one gate-exempt worker, exactly like manual dispatch).
   - else `empty` → `concurrency-cap` + reseed, unchanged.

   This also closes the latent gap where a newly-red main at the cap was never
   diagnosed.

4. **`dispatch-tick` header doc** — documents the third gate-bypass case and the
   exhaustion hard floor. Doc-only.

Priority/main-broken workers are named `<N>-slug` like any worker, so
`claude_agents_count_busy_workers` still counts them — they suppress
non-priority fan-out on later ticks. The count is no longer a *gate* on selecting
them, but they still *count* toward the budget that paces non-priority dispatch.
The `--manual` and explicit `dispatch <N>` paths are untouched (they already skip
the gate).

## Testing

`test-dispatch-scripts.sh`: 1706/1706 pass. New coverage: `--exhausted`
ok/exhausted (incl. past-reset and missing-telemetry fail-open, config
threshold); `--priority-only` (priority PR, priority issue, main-broken gate,
empty, JIT-suppressed, mutual-exclusion guard); at-cap priority PR/issue spawn
(`GAP=1`, lock held, no reseed); at-cap main-broken (lock released); at-cap
exhausted hard stop (probe not consulted); at-cap empty → `concurrency-cap` +
reseed; and the worker-count regression (a priority-named busy worker is still
counted).
