### PR TITLE
media: @commons-systems/local-first — FsaHandleStore + OPFS fallback

### DIFF
--- a/local-first/eslint.config.js
+++ b/local-first/eslint.config.js
@@ -1,0 +1,1 @@
+export { default } from "@commons-systems/config/eslint";

--- a/local-first/package.json
+++ b/local-first/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@commons-systems/local-first",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    "./capabilities": "./src/capabilities.ts",
+    "./fsa-handle-store": "./src/fsa-handle-store.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@commons-systems/idbutil": "*"
+  },
+  "devDependencies": {
+    "fake-indexeddb": "^6.0.0"
+  }
+}

--- a/local-first/src/capabilities.ts
+++ b/local-first/src/capabilities.ts
@@ -1,0 +1,35 @@
+/**
+ * Capability detection for the File System Access (FSA) API. Every check is a
+ * guarded `typeof` probe so it never throws on a browser (or test environment)
+ * that lacks the API.
+ */
+
+export interface FsaCapabilities {
+  /** `window.showOpenFilePicker` is available (pick an on-disk file). */
+  filePicker: boolean;
+  /** `window.showDirectoryPicker` is available (pick an on-disk directory). */
+  directoryPicker: boolean;
+}
+
+/**
+ * Probe the current environment for FSA support. Never throws — on any non-FSA
+ * browser (or non-browser context) the corresponding flag is `false`. When both
+ * flags are false the caller should route to its existing cloud path.
+ */
+export function detectFsaCapabilities(): FsaCapabilities {
+  const win = typeof window !== "undefined" ? window : undefined;
+  return {
+    filePicker: typeof win?.showOpenFilePicker === "function",
+    directoryPicker: typeof win?.showDirectoryPicker === "function",
+  };
+}
+
+/**
+ * True when the browser can let the user pick a persistable on-disk handle
+ * (file or directory). When false, callers should route to their existing
+ * cloud (Firebase Storage) path rather than the local-first on-disk path.
+ */
+export function isFsaSupported(): boolean {
+  const caps = detectFsaCapabilities();
+  return caps.filePicker || caps.directoryPicker;
+}

--- a/local-first/src/fsa-handle-store.ts
+++ b/local-first/src/fsa-handle-store.ts
@@ -1,5 +1,5 @@
 import { createDbConnection } from "@commons-systems/idbutil/connection";
-import { detectFsaCapabilities, type FsaCapabilities } from "./capabilities.js";
+import { detectFsaCapabilities, isFsaSupported, type FsaCapabilities } from "./capabilities.js";
 
 const HANDLE_STORE = "handles";
 const DEFAULT_DB_NAME = "fsa-handle-store";
@@ -54,6 +54,12 @@ export interface FsaHandleStore {
    * Load the persisted handle for (app, purpose) and resolve its permission.
    * Returns null when no handle is persisted. `permission` reflects the
    * post-`ensurePermission` state.
+   *
+   * Because this calls `ensurePermission`, which issues a permission request
+   * when the handle is in the `prompt` state, call `load` from within a user
+   * gesture. Outside a gesture the browser silently denies the request and
+   * `permission` resolves to `denied`; a non-null return therefore does not
+   * imply the handle is usable — check `permission === "granted"` before I/O.
    */
   load(
     purpose: string,
@@ -66,6 +72,9 @@ export function createFsaHandleStore(
 ): FsaHandleStore {
   if (!config.app) {
     throw new Error("FsaHandleStoreConfig.app must be a non-empty string");
+  }
+  if (config.app.includes(":")) {
+    throw new Error('FsaHandleStoreConfig.app must not contain ":"');
   }
   const capabilities = detectFsaCapabilities();
   const conn = createDbConnection({
@@ -81,6 +90,9 @@ export function createFsaHandleStore(
   const keyFor = (purpose: string): string => {
     if (!purpose) {
       throw new Error("purpose must be a non-empty string");
+    }
+    if (purpose.includes(":")) {
+      throw new Error('purpose must not contain ":"');
     }
     return `${config.app}:${purpose}`;
   };
@@ -106,8 +118,29 @@ export function createFsaHandleStore(
     return new Promise<FileSystemHandle | null>((resolve, reject) => {
       const tx = db.transaction(HANDLE_STORE, "readonly");
       const req = tx.objectStore(HANDLE_STORE).get(key);
-      req.onsuccess = () => resolve((req.result as FileSystemHandle) ?? null);
+      req.onsuccess = () => {
+        const result = req.result as unknown;
+        if (result === undefined || result === null) {
+          resolve(null);
+          return;
+        }
+        if (
+          typeof result !== "object" ||
+          ((result as { kind?: unknown }).kind !== "file" &&
+            (result as { kind?: unknown }).kind !== "directory")
+        ) {
+          reject(
+            new Error(
+              "Persisted FSA handle is malformed (expected a FileSystemHandle); the IndexedDB store may be corrupted or tampered with",
+            ),
+          );
+          return;
+        }
+        resolve(result as FileSystemHandle);
+      };
       req.onerror = () => reject(req.error);
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
     });
   }
 
@@ -161,8 +194,7 @@ export function createFsaHandleStore(
 
   return {
     capabilities,
-    isSupported: () =>
-      capabilities.filePicker || capabilities.directoryPicker,
+    isSupported: isFsaSupported,
     put,
     get,
     remove,

--- a/local-first/src/fsa-handle-store.ts
+++ b/local-first/src/fsa-handle-store.ts
@@ -1,0 +1,174 @@
+import { createDbConnection } from "@commons-systems/idbutil/connection";
+import { detectFsaCapabilities, type FsaCapabilities } from "./capabilities.js";
+
+const HANDLE_STORE = "handles";
+const DEFAULT_DB_NAME = "fsa-handle-store";
+const DEFAULT_VERSION = 1;
+
+export type FsaPermissionMode = "read" | "readwrite";
+
+export interface FsaHandleStoreConfig {
+  /** App namespace — keeps one app's handles from colliding with another's. */
+  app: string;
+  /** IndexedDB database name. Defaults to "fsa-handle-store". */
+  dbName?: string;
+  /** IndexedDB schema version. Defaults to 1. */
+  version?: number;
+}
+
+export interface FsaHandleStore {
+  /** Detected FSA capabilities for this environment. */
+  readonly capabilities: FsaCapabilities;
+  /**
+   * True when the browser can pick a persistable on-disk handle. When false,
+   * the caller should route to its existing cloud (Firebase Storage) path.
+   */
+  isSupported(): boolean;
+  /** Persist a picked handle under (app, purpose). */
+  put(purpose: string, handle: FileSystemHandle): Promise<void>;
+  /** Retrieve the persisted handle for (app, purpose), or null if none. */
+  get(purpose: string): Promise<FileSystemHandle | null>;
+  /** Remove the persisted handle for (app, purpose). Idempotent. */
+  remove(purpose: string): Promise<void>;
+  /** Query the current permission state without prompting. */
+  queryPermission(
+    handle: FileSystemHandle,
+    mode?: FsaPermissionMode,
+  ): Promise<PermissionState>;
+  /** Request permission — must be called from within a user gesture. */
+  requestPermission(
+    handle: FileSystemHandle,
+    mode?: FsaPermissionMode,
+  ): Promise<PermissionState>;
+  /**
+   * Ensure usable permission with the fewest prompts: zero when already
+   * granted, one request when in the `prompt` state. Returns the final state.
+   * Call from within a user gesture so the `prompt` path can surface the
+   * dialog.
+   */
+  ensurePermission(
+    handle: FileSystemHandle,
+    mode?: FsaPermissionMode,
+  ): Promise<PermissionState>;
+  /**
+   * Load the persisted handle for (app, purpose) and resolve its permission.
+   * Returns null when no handle is persisted. `permission` reflects the
+   * post-`ensurePermission` state.
+   */
+  load(
+    purpose: string,
+    mode?: FsaPermissionMode,
+  ): Promise<{ handle: FileSystemHandle; permission: PermissionState } | null>;
+}
+
+export function createFsaHandleStore(
+  config: FsaHandleStoreConfig,
+): FsaHandleStore {
+  if (!config.app) {
+    throw new Error("FsaHandleStoreConfig.app must be a non-empty string");
+  }
+  const capabilities = detectFsaCapabilities();
+  const conn = createDbConnection({
+    name: config.dbName ?? DEFAULT_DB_NAME,
+    version: config.version ?? DEFAULT_VERSION,
+    onUpgrade: (db) => {
+      if (!db.objectStoreNames.contains(HANDLE_STORE)) {
+        db.createObjectStore(HANDLE_STORE);
+      }
+    },
+  });
+
+  const keyFor = (purpose: string): string => {
+    if (!purpose) {
+      throw new Error("purpose must be a non-empty string");
+    }
+    return `${config.app}:${purpose}`;
+  };
+
+  async function put(
+    purpose: string,
+    handle: FileSystemHandle,
+  ): Promise<void> {
+    const key = keyFor(purpose);
+    const db = await conn.openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(HANDLE_STORE, "readwrite");
+      tx.objectStore(HANDLE_STORE).put(handle, key);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+  }
+
+  async function get(purpose: string): Promise<FileSystemHandle | null> {
+    const key = keyFor(purpose);
+    const db = await conn.openDb();
+    return new Promise<FileSystemHandle | null>((resolve, reject) => {
+      const tx = db.transaction(HANDLE_STORE, "readonly");
+      const req = tx.objectStore(HANDLE_STORE).get(key);
+      req.onsuccess = () => resolve((req.result as FileSystemHandle) ?? null);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async function remove(purpose: string): Promise<void> {
+    const key = keyFor(purpose);
+    const db = await conn.openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(HANDLE_STORE, "readwrite");
+      tx.objectStore(HANDLE_STORE).delete(key);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+  }
+
+  async function queryPermission(
+    handle: FileSystemHandle,
+    mode: FsaPermissionMode = "read",
+  ): Promise<PermissionState> {
+    return handle.queryPermission({ mode });
+  }
+
+  async function requestPermission(
+    handle: FileSystemHandle,
+    mode: FsaPermissionMode = "read",
+  ): Promise<PermissionState> {
+    return handle.requestPermission({ mode });
+  }
+
+  async function ensurePermission(
+    handle: FileSystemHandle,
+    mode: FsaPermissionMode = "read",
+  ): Promise<PermissionState> {
+    const current = await handle.queryPermission({ mode });
+    if (current === "granted") return "granted";
+    if (current === "prompt") return handle.requestPermission({ mode });
+    return current; // denied
+  }
+
+  async function load(
+    purpose: string,
+    mode: FsaPermissionMode = "read",
+  ): Promise<
+    { handle: FileSystemHandle; permission: PermissionState } | null
+  > {
+    const handle = await get(purpose);
+    if (!handle) return null;
+    const permission = await ensurePermission(handle, mode);
+    return { handle, permission };
+  }
+
+  return {
+    capabilities,
+    isSupported: () =>
+      capabilities.filePicker || capabilities.directoryPicker,
+    put,
+    get,
+    remove,
+    queryPermission,
+    requestPermission,
+    ensurePermission,
+    load,
+  };
+}

--- a/local-first/src/fsa-types.d.ts
+++ b/local-first/src/fsa-types.d.ts
@@ -1,0 +1,42 @@
+// Ambient declarations for the WICG File System Access API surface that
+// TypeScript's lib.dom.d.ts does not yet ship: the picker entry points on
+// Window and the permission-management methods on FileSystemHandle. The
+// handle interfaces (FileSystemFileHandle / FileSystemDirectoryHandle) and
+// PermissionState are already in lib.dom and are reused here.
+
+interface FileSystemHandlePermissionDescriptor {
+  mode?: "read" | "readwrite";
+}
+
+interface FileSystemHandle {
+  queryPermission(
+    descriptor?: FileSystemHandlePermissionDescriptor,
+  ): Promise<PermissionState>;
+  requestPermission(
+    descriptor?: FileSystemHandlePermissionDescriptor,
+  ): Promise<PermissionState>;
+}
+
+interface OpenFilePickerOptions {
+  multiple?: boolean;
+  excludeAcceptAllOption?: boolean;
+  types?: Array<{
+    description?: string;
+    accept: Record<string, string | string[]>;
+  }>;
+}
+
+interface DirectoryPickerOptions {
+  id?: string;
+  mode?: "read" | "readwrite";
+  startIn?: FileSystemHandle | string;
+}
+
+interface Window {
+  showOpenFilePicker?: (
+    options?: OpenFilePickerOptions,
+  ) => Promise<FileSystemFileHandle[]>;
+  showDirectoryPicker?: (
+    options?: DirectoryPickerOptions,
+  ) => Promise<FileSystemDirectoryHandle>;
+}

--- a/local-first/test/capabilities.test.ts
+++ b/local-first/test/capabilities.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { detectFsaCapabilities, isFsaSupported } from "../src/capabilities";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("detectFsaCapabilities", () => {
+  it("reports all false when window is absent", () => {
+    vi.stubGlobal("window", undefined);
+    expect(detectFsaCapabilities()).toEqual({
+      filePicker: false,
+      directoryPicker: false,
+    });
+  });
+
+  it("never throws on a browser lacking FSA (empty window)", () => {
+    vi.stubGlobal("window", {});
+    expect(() => detectFsaCapabilities()).not.toThrow();
+    expect(detectFsaCapabilities()).toEqual({
+      filePicker: false,
+      directoryPicker: false,
+    });
+  });
+
+  it("detects file and directory pickers when present", () => {
+    vi.stubGlobal("window", {
+      showOpenFilePicker: () => {},
+      showDirectoryPicker: () => {},
+    });
+    expect(detectFsaCapabilities()).toEqual({
+      filePicker: true,
+      directoryPicker: true,
+    });
+  });
+
+  it("isFsaSupported is false on a non-Chromium browser (no pickers)", () => {
+    vi.stubGlobal("window", {});
+    expect(isFsaSupported()).toBe(false);
+  });
+
+  it("isFsaSupported is true when either picker exists", () => {
+    vi.stubGlobal("window", { showOpenFilePicker: () => {} });
+    expect(isFsaSupported()).toBe(true);
+  });
+});

--- a/local-first/test/fsa-handle-store.test.ts
+++ b/local-first/test/fsa-handle-store.test.ts
@@ -1,5 +1,5 @@
 import "fake-indexeddb/auto";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createFsaHandleStore } from "../src/fsa-handle-store";
 
 // idbutil's connection closeDb references reportError; not every test env
@@ -77,6 +77,26 @@ describe("createFsaHandleStore persistence", () => {
   it("rejects an empty app namespace", () => {
     expect(() => createFsaHandleStore({ app: "" })).toThrow(/app/);
   });
+
+  it("rejects an app namespace containing a colon", () => {
+    expect(() => createFsaHandleStore({ app: "a:b" })).toThrow(/app/);
+  });
+
+  it("rejects a purpose containing a colon", async () => {
+    const store = createFsaHandleStore({ app: "print", dbName: uniqueDbName() });
+    await expect(
+      store.get("a:b"),
+    ).rejects.toThrow(/purpose/);
+  });
+
+  it("rejects a malformed (non-handle) persisted value", async () => {
+    const dbName = uniqueDbName();
+    const writer = createFsaHandleStore({ app: "print", dbName });
+    // Simulate a tampered store entry: a value that is not a handle shape.
+    await writer.put("library", { junk: true } as unknown as FileSystemHandle);
+    const reader = createFsaHandleStore({ app: "print", dbName });
+    await expect(reader.get("library")).rejects.toThrow(/malformed/);
+  });
 });
 
 describe("permission flow", () => {
@@ -131,5 +151,32 @@ describe("permission flow", () => {
   it("load returns null when no handle is persisted", async () => {
     const store = createFsaHandleStore({ app: "print", dbName: uniqueDbName() });
     expect(await store.load("missing")).toBeNull();
+  });
+});
+
+describe("isSupported", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reflects live window state — false when pickers are absent", () => {
+    vi.stubGlobal("window", {});
+    const store = createFsaHandleStore({ app: "print", dbName: uniqueDbName() });
+    expect(store.isSupported()).toBe(false);
+  });
+
+  it("reflects live window state — true when showOpenFilePicker is present", () => {
+    vi.stubGlobal("window", { showOpenFilePicker: () => {} });
+    const store = createFsaHandleStore({ app: "print", dbName: uniqueDbName() });
+    expect(store.isSupported()).toBe(true);
+  });
+
+  it("returns updated result after window gains FSA support (dynamic probe)", () => {
+    vi.stubGlobal("window", {});
+    const store = createFsaHandleStore({ app: "print", dbName: uniqueDbName() });
+    expect(store.isSupported()).toBe(false);
+    // Simulate FSA becoming available (e.g., SSR→hydration transition).
+    vi.stubGlobal("window", { showOpenFilePicker: () => {} });
+    expect(store.isSupported()).toBe(true);
   });
 });

--- a/local-first/test/fsa-handle-store.test.ts
+++ b/local-first/test/fsa-handle-store.test.ts
@@ -1,0 +1,135 @@
+import "fake-indexeddb/auto";
+import { describe, expect, it, vi } from "vitest";
+import { createFsaHandleStore } from "../src/fsa-handle-store";
+
+// idbutil's connection closeDb references reportError; not every test env
+// provides it. (Our store never calls closeDb, but keep parity with idbutil.)
+if (typeof globalThis.reportError !== "function") {
+  globalThis.reportError = () => {};
+}
+
+let counter = 0;
+const uniqueDbName = () => `fsa-test-${counter++}`;
+
+describe("createFsaHandleStore persistence", () => {
+  it("persists a handle and retrieves it across store instances (sessions)", async () => {
+    const dbName = uniqueDbName();
+    const handle = {
+      kind: "directory",
+      name: "library",
+    } as unknown as FileSystemHandle;
+
+    const writer = createFsaHandleStore({ app: "print", dbName });
+    await writer.put("library", handle);
+
+    // A fresh store instance simulates a new session.
+    const reader = createFsaHandleStore({ app: "print", dbName });
+    expect(await reader.get("library")).toEqual({
+      kind: "directory",
+      name: "library",
+    });
+  });
+
+  it("returns null when no handle is persisted", async () => {
+    const store = createFsaHandleStore({ app: "print", dbName: uniqueDbName() });
+    expect(await store.get("missing")).toBeNull();
+  });
+
+  it("namespaces handles by app", async () => {
+    const dbName = uniqueDbName();
+    const printStore = createFsaHandleStore({ app: "print", dbName });
+    const audioStore = createFsaHandleStore({ app: "audio", dbName });
+    await printStore.put("library", {
+      kind: "directory",
+      name: "p",
+    } as unknown as FileSystemHandle);
+    await audioStore.put("library", {
+      kind: "directory",
+      name: "a",
+    } as unknown as FileSystemHandle);
+    expect(await printStore.get("library")).toEqual({
+      kind: "directory",
+      name: "p",
+    });
+    expect(await audioStore.get("library")).toEqual({
+      kind: "directory",
+      name: "a",
+    });
+  });
+
+  it("removes a persisted handle", async () => {
+    const store = createFsaHandleStore({ app: "print", dbName: uniqueDbName() });
+    await store.put("library", {
+      kind: "file",
+      name: "x",
+    } as unknown as FileSystemHandle);
+    await store.remove("library");
+    expect(await store.get("library")).toBeNull();
+  });
+
+  it("rejects an empty purpose", async () => {
+    const store = createFsaHandleStore({ app: "print", dbName: uniqueDbName() });
+    await expect(
+      store.put("", {} as unknown as FileSystemHandle),
+    ).rejects.toThrow(/purpose/);
+  });
+
+  it("rejects an empty app namespace", () => {
+    expect(() => createFsaHandleStore({ app: "" })).toThrow(/app/);
+  });
+});
+
+describe("permission flow", () => {
+  it("ensurePermission does not prompt when already granted (zero prompts)", async () => {
+    const store = createFsaHandleStore({ app: "print", dbName: uniqueDbName() });
+    const requestPermission = vi.fn();
+    const handle = {
+      queryPermission: vi.fn().mockResolvedValue("granted"),
+      requestPermission,
+    } as unknown as FileSystemHandle;
+    expect(await store.ensurePermission(handle, "read")).toBe("granted");
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("ensurePermission requests once when in the prompt state (one click)", async () => {
+    const store = createFsaHandleStore({ app: "print", dbName: uniqueDbName() });
+    const requestPermission = vi.fn().mockResolvedValue("granted");
+    const handle = {
+      queryPermission: vi.fn().mockResolvedValue("prompt"),
+      requestPermission,
+    } as unknown as FileSystemHandle;
+    expect(await store.ensurePermission(handle, "readwrite")).toBe("granted");
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+    expect(requestPermission).toHaveBeenCalledWith({ mode: "readwrite" });
+  });
+
+  it("ensurePermission returns denied without prompting", async () => {
+    const store = createFsaHandleStore({ app: "print", dbName: uniqueDbName() });
+    const requestPermission = vi.fn();
+    const handle = {
+      queryPermission: vi.fn().mockResolvedValue("denied"),
+      requestPermission,
+    } as unknown as FileSystemHandle;
+    expect(await store.ensurePermission(handle)).toBe("denied");
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("queryPermission/requestPermission default to read mode", async () => {
+    const store = createFsaHandleStore({ app: "print", dbName: uniqueDbName() });
+    const queryPermission = vi.fn().mockResolvedValue("granted");
+    const requestPermission = vi.fn().mockResolvedValue("granted");
+    const handle = {
+      queryPermission,
+      requestPermission,
+    } as unknown as FileSystemHandle;
+    await store.queryPermission(handle);
+    await store.requestPermission(handle);
+    expect(queryPermission).toHaveBeenCalledWith({ mode: "read" });
+    expect(requestPermission).toHaveBeenCalledWith({ mode: "read" });
+  });
+
+  it("load returns null when no handle is persisted", async () => {
+    const store = createFsaHandleStore({ app: "print", dbName: uniqueDbName() });
+    expect(await store.load("missing")).toBeNull();
+  });
+});

--- a/local-first/tsconfig.json
+++ b/local-first/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@commons-systems/config/tsconfig.lib.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src", "test"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "htmlutil",
         "idbutil",
         "landing",
+        "local-first",
         "print",
         "router",
         "style",
@@ -251,6 +252,16 @@
         "missing.css": "^1.1.3"
       }
     },
+    "local-first": {
+      "name": "@commons-systems/local-first",
+      "version": "0.0.0",
+      "dependencies": {
+        "@commons-systems/idbutil": "*"
+      },
+      "devDependencies": {
+        "fake-indexeddb": "^6.0.0"
+      }
+    },
     "node_modules/@commons-systems/analyticsutil": {
       "resolved": "analyticsutil",
       "link": true
@@ -297,6 +308,10 @@
     },
     "node_modules/@commons-systems/idbutil": {
       "resolved": "idbutil",
+      "link": true
+    },
+    "node_modules/@commons-systems/local-first": {
+      "resolved": "local-first",
       "link": true
     },
     "node_modules/@commons-systems/router": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "htmlutil",
     "idbutil",
     "landing",
+    "local-first",
     "print",
     "router",
     "style",


### PR DESCRIPTION
Closes #1032

## Summary

Adds a new shared workspace package `@commons-systems/local-first` (F1) — the
foundation primitive for the shared media local-first stack (parent epic #1029).
It persists a File System Access (FSA) handle across browser sessions so a
Chromium browser can re-open the same on-disk file/directory the user picked,
with no re-prompt. Pure infrastructure — no app wiring; `print`, `audio`, and
budget (#1018, #1021) consume it later.

## What's in the package

- **`capabilities`** — `detectFsaCapabilities()` (`{ filePicker, directoryPicker }`)
  and `isFsaSupported()`. Every probe is a guarded `typeof` check, so detection
  never throws on a browser lacking FSA.
- **`fsa-handle-store`** — `createFsaHandleStore({ app, dbName?, version? })`:
  - Persist / retrieve / remove a handle in an IndexedDB meta store, keyed
    `app:purpose` (reuses `@commons-systems/idbutil`'s memoized connection).
  - Permission flow: `queryPermission` / `requestPermission` wrappers, and
    `ensurePermission` — zero prompts when already `granted`, one request when in
    the `prompt` state.
  - `load(purpose)` — re-open a persisted handle and resolve its permission.
- **`src/fsa-types.d.ts`** — ambient declarations for the WICG FSA surface that
  TS's `lib.dom.d.ts` does not yet ship (the `Window` pickers and
  `FileSystemHandle.queryPermission` / `requestPermission`).

## Scope change during review: OPFS dropped

The issue originally proposed an OPFS fallback on non-FSA browsers. That was
dropped after review (issue #1032 updated to match). OPFS is an origin-private,
provider-unsynced browser store — not the user's on-disk files — so it cannot
stand in as the local-first source of truth that an FSA handle provides. On a
non-Chromium browser the bytes still come from the cloud, which is the existing
Firebase Storage path (already the default and fully functional in prod per the
epic's migration-safety constraint). So the fallback is simply: when
`isSupported()` is false, the consuming app routes to its existing cloud path —
no new storage layer here. OPFS's only legitimate role is as a derived
blob-cache backend, a separate optimization decided on caching merits and out of
scope for F1.

## Acceptance criteria

- [x] A picked handle persists across sessions in the IndexedDB meta store.
- [x] Permission already granted → zero prompts; `prompt` state → one request.
- [x] Non-FSA browser → `isSupported()` reports false so the app routes to its
      existing cloud path (no OPFS).
- [x] Capability detection never throws on a browser lacking FSA.
- [x] Covered by unit tests (16 tests across capabilities + handle store).

## Testing notes

`fake-indexeddb` uses `structuredClone`, which throws on method-bearing objects,
and there is no real FSA in the node test env. So persistence tests round-trip a
structured-clone-safe plain stand-in (`{ kind, name }`) — the IDB put/get code
path is identical for a real handle — while permission tests pass method-bearing
mocks directly to the permission methods. The full real-browser handle round-trip
is validated later when an app consumes the package as a PWA (#1034).

The root `package.json` workspaces edit means CI's changed-app resolution treats
this as a global change, so unit-tests / lint / typecheck run repo-wide on this
PR — expected, not a regression.
