### PR TITLE
budget: persist FSA file handle for picker-free .benc load

### DIFF
--- a/budget/src/idb.ts
+++ b/budget/src/idb.ts
@@ -110,7 +110,12 @@ export async function storeParsedData(data: ParsedData): Promise<void> {
     stores[name] = tx.objectStore(name);
   }
 
-  // Clear all stores first (skip "meta" to preserve the persisted fileHandle record)
+  // Clear all stores first. The "meta" store is special: it mixes the
+  // parsed-data cache (the "upload" record) with capability records (the
+  // persisted "fileHandle"). A reload replaces the former and must preserve the
+  // latter, so delete only the "upload" key here rather than clearing the whole
+  // store — clearing it blindly would also drop the fileHandle, and skipping it
+  // blindly would silently retain any future meta key.
   const clearPromises: Promise<void>[] = [];
   for (const name of STORE_NAMES) {
     if (name === "meta") continue;
@@ -122,6 +127,13 @@ export async function storeParsedData(data: ParsedData): Promise<void> {
       }),
     );
   }
+  clearPromises.push(
+    new Promise((resolve, reject) => {
+      const req = stores.meta.delete("upload");
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+    }),
+  );
   await Promise.all(clearPromises);
 
   // Write all records

--- a/budget/src/idb.ts
+++ b/budget/src/idb.ts
@@ -67,6 +67,24 @@ export interface UploadMeta {
   exportedAt: string;
 }
 
+export interface FileHandleMeta {
+  key: "fileHandle";
+  handle: FileSystemFileHandle;
+}
+
+export async function putFileHandle(handle: FileSystemFileHandle): Promise<void> {
+  await put("meta", { key: "fileHandle", handle });
+}
+
+export async function getFileHandle(): Promise<FileSystemFileHandle | undefined> {
+  const record = await get<FileHandleMeta>("meta", "fileHandle");
+  return record?.handle;
+}
+
+export async function clearFileHandle(): Promise<void> {
+  await deleteRecord("meta", "fileHandle");
+}
+
 export interface ParsedData {
   transactions: IdbTransaction[];
   budgets: IdbBudget[];
@@ -92,9 +110,10 @@ export async function storeParsedData(data: ParsedData): Promise<void> {
     stores[name] = tx.objectStore(name);
   }
 
-  // Clear all stores first
+  // Clear all stores first (skip "meta" to preserve the persisted fileHandle record)
   const clearPromises: Promise<void>[] = [];
   for (const name of STORE_NAMES) {
+    if (name === "meta") continue;
     clearPromises.push(
       new Promise((resolve, reject) => {
         const req = stores[name].clear();

--- a/budget/src/local-file.ts
+++ b/budget/src/local-file.ts
@@ -1,0 +1,70 @@
+// File System Access API (FSA) surface for the budget app.
+//
+// `window.showOpenFilePicker` and `FileSystemHandle.queryPermission` /
+// `requestPermission` are not in baseline `lib.dom.d.ts`, so this module owns
+// the minimal ambient declarations. The FSA primitives let a Chromium browser
+// persist a `FileSystemFileHandle` (stored in IDB) and re-open the same on-disk
+// `.benc` across sessions; non-Chromium browsers fall back to the existing
+// `<input type=file>` upload path (detected via `isFsaSupported`).
+
+interface FileSystemHandlePermissionDescriptor {
+  mode?: "read" | "readwrite";
+}
+interface OpenFilePickerOptions {
+  multiple?: boolean;
+  types?: { description?: string; accept: Record<string, string[]> }[];
+}
+declare global {
+  interface Window {
+    showOpenFilePicker(options?: OpenFilePickerOptions): Promise<FileSystemFileHandle[]>;
+  }
+  interface FileSystemHandle {
+    queryPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
+    requestPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
+  }
+}
+
+/** True on Chromium browsers that expose the File System Access picker. */
+export function isFsaSupported(): boolean {
+  return typeof window !== "undefined" && "showOpenFilePicker" in window;
+}
+
+/**
+ * Show the FSA picker for a `.benc`/`.json` file. Returns the picked handle, or
+ * `null` when the user cancels the picker (AbortError). Any other error is
+ * rethrown.
+ */
+export async function pickBencFile(): Promise<FileSystemFileHandle | null> {
+  try {
+    const handles = await window.showOpenFilePicker({
+      multiple: false,
+      types: [{ description: "Budget data", accept: { "application/octet-stream": [".benc"], "application/json": [".json"] } }],
+    });
+    return handles[0];
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/** Query whether the handle currently has read permission. */
+export function queryReadPermission(handle: FileSystemFileHandle): Promise<PermissionState> {
+  // Mode "read": S1 is load-only; #1019 upgrades to "readwrite".
+  return handle.queryPermission({ mode: "read" });
+}
+
+/** Request read permission for the handle (may prompt the user). */
+export function requestReadPermission(handle: FileSystemFileHandle): Promise<PermissionState> {
+  return handle.requestPermission({ mode: "read" });
+}
+
+/**
+ * Read the current `File` from the handle. Does not catch errors: a
+ * NotFoundError (file moved/deleted) propagates so callers can treat it as a
+ * stale handle and fall back to the re-link picker.
+ */
+export function readFileFromHandle(handle: FileSystemFileHandle): Promise<File> {
+  return handle.getFile();
+}

--- a/budget/src/main.ts
+++ b/budget/src/main.ts
@@ -24,7 +24,14 @@ import { classifyError } from "@commons-systems/errorutil/classify";
 import { deferProgrammerError } from "@commons-systems/errorutil/defer";
 import { logError } from "@commons-systems/errorutil/log";
 import { parseUploadedJson, toParsedData, UploadValidationError } from "./upload.js";
-import { storeParsedData, clearAll, getMeta } from "./idb.js";
+import { storeParsedData, clearAll, getMeta, getFileHandle, putFileHandle, clearFileHandle } from "./idb.js";
+import {
+  isFsaSupported,
+  pickBencFile,
+  queryReadPermission,
+  requestReadPermission,
+  readFileFromHandle,
+} from "./local-file.js";
 import { SeedDataSource, IdbDataSource, type DataSource } from "./data-source.js";
 import { setActiveDataSource } from "./active-data-source.js";
 import { exportToJson } from "./export.js";
@@ -239,24 +246,31 @@ function promptPassword(message: string): Promise<string | null> {
   });
 }
 
+// Core load pipeline shared by the upload path and the FSA handle path:
+// read bytes, decrypt-or-decode, parse, store, and transition to the local
+// state. Throws on any failure; callers wrap it in error handling.
+async function loadFromFile(file: File): Promise<void> {
+  const buffer = await file.arrayBuffer();
+  let text: string;
+  let pw: string | null = null;
+  if (isEncrypted(buffer)) {
+    pw = await promptPassword("Enter password to decrypt");
+    if (pw === null) return;
+    text = await decrypt(buffer, pw);
+  } else {
+    text = new TextDecoder().decode(buffer);
+  }
+  const parsed = parseUploadedJson(text);
+  const data = toParsedData(parsed);
+  await storeParsedData(data);
+  importPassword = pw;
+  transition({ source: "local", groupName: parsed.groupName });
+}
+
 async function handleFileUpload(file: File): Promise<void> {
   clearNavError();
   try {
-    const buffer = await file.arrayBuffer();
-    let text: string;
-    let pw: string | null = null;
-    if (isEncrypted(buffer)) {
-      pw = await promptPassword("Enter password to decrypt");
-      if (pw === null) return;
-      text = await decrypt(buffer, pw);
-    } else {
-      text = new TextDecoder().decode(buffer);
-    }
-    const parsed = parseUploadedJson(text);
-    const data = toParsedData(parsed);
-    await storeParsedData(data);
-    importPassword = pw;
-    transition({ source: "local", groupName: parsed.groupName });
+    await loadFromFile(file);
   } catch (error) {
     if (error instanceof UploadValidationError) {
       showNavError(error.message);
@@ -266,6 +280,22 @@ async function handleFileUpload(file: File): Promise<void> {
     logError(error, { operation: "upload" });
     showNavError("Upload failed. Please try again.");
   }
+}
+
+async function loadFromHandle(handle: FileSystemFileHandle): Promise<void> {
+  let file: File;
+  try {
+    file = await readFileFromHandle(handle);
+  } catch (error) {
+    // Stale/invalid handle (file moved or deleted): drop it and surface the
+    // re-link picker rather than crashing.
+    await clearFileHandle();
+    if (deferProgrammerError(error)) return;
+    logError(error, { operation: "load-from-handle" });
+    showNavError("The linked file is no longer available. Please re-link it.");
+    return;
+  }
+  await handleFileUpload(file); // reuses the existing parse/validation error handling
 }
 
 uploadInput.addEventListener("change", () => {
@@ -280,11 +310,47 @@ uploadInput.addEventListener("change", () => {
   uploadInput.value = "";
 });
 
+// FSA picker flow (Chromium): pick a file, persist its handle, then load it.
+// Shared between the label click and keyboard activation handlers.
+async function pickAndLoad(): Promise<void> {
+  clearNavError();
+  try {
+    const handle = await pickBencFile();
+    if (!handle) return; // user canceled
+    await putFileHandle(handle);
+    await loadFromHandle(handle);
+  } catch (error) {
+    if (deferProgrammerError(error)) return;
+    logError(error, { operation: "upload" });
+    showNavError("Upload failed. Please try again.");
+  }
+}
+
+if (isFsaSupported()) {
+  // A <label> wrapping an <input> natively forwards clicks to the input, which
+  // would open the legacy file dialog. preventDefault() stops that so the FSA
+  // picker is the only dialog shown.
+  uploadLabel.addEventListener("click", (e) => {
+    e.preventDefault();
+    pickAndLoad().catch((error) => {
+      if (deferProgrammerError(error)) return;
+      logError(error, { operation: "upload" });
+    });
+  });
+}
+
 // Allow keyboard activation of the label
 uploadLabel.addEventListener("keydown", (e) => {
   if (e.key === "Enter" || e.key === " ") {
     e.preventDefault();
-    uploadInput.click();
+    if (isFsaSupported()) {
+      pickAndLoad().catch((error) => {
+        if (deferProgrammerError(error)) return;
+        logError(error, { operation: "upload" });
+      });
+    } else {
+      uploadInput.click();
+    }
   }
 });
 
@@ -327,8 +393,57 @@ clearButton.addEventListener("click", async () => {
   }
 });
 
-// Startup: check for existing local data
+// Render a one-click "Reload <file>" affordance into the nav. Used when a
+// persisted handle's permission is in the "prompt" state: we show cached/seed
+// data immediately and let the user re-grant with a single click.
+function showReloadPrompt(handle: FileSystemFileHandle): void {
+  const existing = authContainer!.querySelector(".reload-handle");
+  if (existing) existing.remove();
+  const button = document.createElement("button");
+  button.className = "reload-handle";
+  button.textContent = `Reload ${handle.name}`;
+  authContainer!.appendChild(button);
+  button.addEventListener("click", async () => {
+    try {
+      const perm = await requestReadPermission(handle);
+      if (perm === "granted") {
+        await loadFromHandle(handle);
+        button.remove();
+        return;
+      }
+      // Still not granted: fall back to the re-link picker.
+      await pickAndLoad();
+      button.remove();
+    } catch (error) {
+      if (deferProgrammerError(error)) return;
+      logError(error, { operation: "reload-handle" });
+      showNavError("Could not reload the linked file. Please re-link it.");
+    }
+  });
+}
+
+// Startup: check for a persisted FSA handle, then fall back to cached/seed data.
 async function initialize(): Promise<void> {
+  const handle = await getFileHandle();
+  if (handle) {
+    const perm = await queryReadPermission(handle);
+    if (perm === "granted") {
+      await loadFromHandle(handle);
+      return;
+    }
+    if (perm === "prompt") {
+      // Show cached data (or seed) immediately, plus a one-click reload affordance.
+      const meta = await getMeta();
+      if (meta) {
+        transition({ source: "local", groupName: meta.groupName });
+      } else {
+        transition({ source: "seed" });
+      }
+      showReloadPrompt(handle);
+      return;
+    }
+    // perm === "denied": fall through to cached/seed display below.
+  }
   const meta = await getMeta();
   if (meta) {
     transition({ source: "local", groupName: meta.groupName });

--- a/budget/src/main.ts
+++ b/budget/src/main.ts
@@ -283,6 +283,7 @@ async function handleFileUpload(file: File): Promise<void> {
 }
 
 async function loadFromHandle(handle: FileSystemFileHandle): Promise<void> {
+  clearNavError();
   let file: File;
   try {
     file = await readFileFromHandle(handle);
@@ -295,7 +296,27 @@ async function loadFromHandle(handle: FileSystemFileHandle): Promise<void> {
     showNavError("The linked file is no longer available. Please re-link it.");
     return;
   }
-  await handleFileUpload(file); // reuses the existing parse/validation error handling
+  // Run the parse/validation pipeline directly (rather than via handleFileUpload)
+  // so a content-validation failure can drop the persisted handle. Without this,
+  // a handle pointing at a non-budget file would be auto-loaded, fail validation,
+  // and be retried on every subsequent startup — a permanent failing-load loop.
+  try {
+    await loadFromFile(file);
+  } catch (error) {
+    if (error instanceof UploadValidationError) {
+      // The persisted handle points to a file that is not valid budget data
+      // (e.g. the wrong file was picked). Drop the handle so it does not
+      // re-trigger a failing auto-load on every startup. A wrong decryption
+      // password throws a different error (handled below) and keeps the handle,
+      // since the file itself is valid and the user can retry.
+      await clearFileHandle();
+      showNavError(error.message);
+      return;
+    }
+    if (deferProgrammerError(error)) return;
+    logError(error, { operation: "load-from-handle" });
+    showNavError("Could not load the linked file. Please re-link it.");
+  }
 }
 
 uploadInput.addEventListener("change", () => {
@@ -412,8 +433,15 @@ function showReloadPrompt(handle: FileSystemFileHandle): void {
         return;
       }
       // Still not granted: fall back to the re-link picker.
+      // Only remove the button when the picker resulted in a successful load
+      // (state transitions to "local"). If the user cancels the picker,
+      // pickAndLoad returns normally without transitioning, and the button
+      // must remain so the user can retry.
+      const stateBefore = state;
       await pickAndLoad();
-      button.remove();
+      if (state !== stateBefore && state.source === "local") {
+        button.remove();
+      }
     } catch (error) {
       if (deferProgrammerError(error)) return;
       logError(error, { operation: "reload-handle" });
@@ -424,6 +452,7 @@ function showReloadPrompt(handle: FileSystemFileHandle): void {
 
 // Startup: check for a persisted FSA handle, then fall back to cached/seed data.
 async function initialize(): Promise<void> {
+  let denied = false;
   const handle = await getFileHandle();
   if (handle) {
     const perm = await queryReadPermission(handle);
@@ -442,14 +471,23 @@ async function initialize(): Promise<void> {
       showReloadPrompt(handle);
       return;
     }
-    // perm === "denied": fall through to cached/seed display below.
+    // perm === "denied": the browser will not re-prompt for a denied handle, so
+    // it is permanently unusable. Drop it (rather than silently re-entering the
+    // denied path every session, a dead end) and fall through to the cached/seed
+    // display below, then tell the user it was unlinked so they can re-link.
+    await clearFileHandle();
+    denied = true;
   }
   const meta = await getMeta();
   if (meta) {
     transition({ source: "local", groupName: meta.groupName });
-    return;
+  } else {
+    transition({ source: "seed" });
   }
-  transition({ source: "seed" });
+  // transition() clears any nav error, so surface the denied notice afterward.
+  if (denied) {
+    showNavError("Access to the linked file was denied; it has been unlinked.");
+  }
 }
 
 initialize().catch((error) => {

--- a/budget/test/idb.test.ts
+++ b/budget/test/idb.test.ts
@@ -8,6 +8,9 @@ import {
   deleteRecord,
   clearAll,
   getMeta,
+  putFileHandle,
+  getFileHandle,
+  clearFileHandle,
   closeDb,
 } from "../src/idb";
 import { makeParsedData as makeBaseParsedData } from "./helpers";
@@ -148,5 +151,43 @@ describe("getMeta", () => {
   it("returns undefined when no data stored", async () => {
     const meta = await getMeta();
     expect(meta).toBeUndefined();
+  });
+});
+
+describe("putFileHandle / getFileHandle / clearFileHandle", () => {
+  it("round-trips a stub handle", async () => {
+    const stubHandle = { name: "budget.benc" } as unknown as FileSystemFileHandle;
+    await putFileHandle(stubHandle);
+    const result = await getFileHandle();
+    expect(result?.name).toBe("budget.benc");
+  });
+
+  it("returns undefined after clearFileHandle", async () => {
+    const stubHandle = { name: "budget.benc" } as unknown as FileSystemFileHandle;
+    await putFileHandle(stubHandle);
+    await clearFileHandle();
+    const result = await getFileHandle();
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("storeParsedData preserves fileHandle meta record", () => {
+  it("preserves fileHandle while overwriting upload meta", async () => {
+    const stubHandle = { name: "budget.benc" } as unknown as FileSystemFileHandle;
+    await putFileHandle(stubHandle);
+
+    const data = makeParsedData();
+    await storeParsedData(data);
+
+    const handle = await getFileHandle();
+    expect(handle?.name).toBe("budget.benc");
+
+    const uploadMeta = await getMeta();
+    expect(uploadMeta).toEqual({
+      key: "upload",
+      groupName: "household",
+      version: 1,
+      exportedAt: "2025-06-15T10:30:00Z",
+    });
   });
 });

--- a/budget/test/local-file.test.ts
+++ b/budget/test/local-file.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  isFsaSupported,
+  pickBencFile,
+  queryReadPermission,
+  requestReadPermission,
+  readFileFromHandle,
+} from "../src/local-file";
+
+describe("isFsaSupported", () => {
+  let original: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    original = Object.getOwnPropertyDescriptor(window, "showOpenFilePicker");
+  });
+
+  afterEach(() => {
+    if (original) {
+      Object.defineProperty(window, "showOpenFilePicker", original);
+    } else {
+      delete (window as unknown as Record<string, unknown>).showOpenFilePicker;
+    }
+  });
+
+  it("returns false when showOpenFilePicker is absent", () => {
+    delete (window as unknown as Record<string, unknown>).showOpenFilePicker;
+    expect(isFsaSupported()).toBe(false);
+  });
+
+  it("returns true when showOpenFilePicker is present", () => {
+    (window as unknown as Record<string, unknown>).showOpenFilePicker = vi.fn();
+    expect(isFsaSupported()).toBe(true);
+  });
+});
+
+describe("pickBencFile", () => {
+  let original: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    original = Object.getOwnPropertyDescriptor(window, "showOpenFilePicker");
+  });
+
+  afterEach(() => {
+    if (original) {
+      Object.defineProperty(window, "showOpenFilePicker", original);
+    } else {
+      delete (window as unknown as Record<string, unknown>).showOpenFilePicker;
+    }
+  });
+
+  it("returns the handle when the picker resolves", async () => {
+    const stubHandle = { name: "budget.benc" } as unknown as FileSystemFileHandle;
+    (window as unknown as Record<string, unknown>).showOpenFilePicker = vi
+      .fn()
+      .mockResolvedValue([stubHandle]);
+    expect(await pickBencFile()).toBe(stubHandle);
+  });
+
+  it("returns null when the user cancels (AbortError)", async () => {
+    (window as unknown as Record<string, unknown>).showOpenFilePicker = vi
+      .fn()
+      .mockRejectedValue(new DOMException("cancel", "AbortError"));
+    expect(await pickBencFile()).toBeNull();
+  });
+
+  it("rethrows non-AbortError errors", async () => {
+    (window as unknown as Record<string, unknown>).showOpenFilePicker = vi
+      .fn()
+      .mockRejectedValue(new DOMException("boom", "SecurityError"));
+    await expect(pickBencFile()).rejects.toThrow("boom");
+  });
+});
+
+describe("queryReadPermission", () => {
+  it("delegates to handle.queryPermission with mode read", async () => {
+    const queryPermission = vi.fn().mockResolvedValue("granted");
+    const handle = { queryPermission } as unknown as FileSystemFileHandle;
+    expect(await queryReadPermission(handle)).toBe("granted");
+    expect(queryPermission).toHaveBeenCalledWith({ mode: "read" });
+  });
+});
+
+describe("requestReadPermission", () => {
+  it("delegates to handle.requestPermission with mode read", async () => {
+    const requestPermission = vi.fn().mockResolvedValue("granted");
+    const handle = { requestPermission } as unknown as FileSystemFileHandle;
+    expect(await requestReadPermission(handle)).toBe("granted");
+    expect(requestPermission).toHaveBeenCalledWith({ mode: "read" });
+  });
+});
+
+describe("readFileFromHandle", () => {
+  it("delegates to handle.getFile", async () => {
+    const file = new File([], "x");
+    const getFile = vi.fn().mockResolvedValue(file);
+    const handle = { getFile } as unknown as FileSystemFileHandle;
+    expect(await readFileFromHandle(handle)).toBe(file);
+  });
+});

--- a/budget/test/main.test.ts
+++ b/budget/test/main.test.ts
@@ -130,6 +130,8 @@ describe("main module", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     // Defaults: no persisted handle, FSA unsupported -> existing upload behavior.
+    mockGetMeta.mockReset();
+    mockStoreParsedData.mockReset();
     mockGetFileHandle.mockReset().mockResolvedValue(undefined);
     mockPutFileHandle.mockReset().mockResolvedValue(undefined);
     mockClearFileHandle.mockReset().mockResolvedValue(undefined);
@@ -289,6 +291,100 @@ describe("main module", () => {
     const errorEl = document.querySelector(".nav-error") as HTMLElement;
     expect(errorEl.hidden).toBe(false);
     expect(errorEl.textContent).toContain("no longer available");
+  });
+
+  it("clears the persisted handle when the linked file fails content validation", async () => {
+    const handle = { name: "wrong.json" } as unknown as FileSystemFileHandle;
+    mockGetFileHandle.mockResolvedValue(handle);
+    mockQueryReadPermission.mockResolvedValue("granted");
+    mockReadFileFromHandle.mockResolvedValue(new File(["{}"], "wrong.json"));
+
+    resetAndMockAll();
+
+    const { parseUploadedJson, UploadValidationError } = await import("../src/upload.js");
+    (parseUploadedJson as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new UploadValidationError("Not a valid budget file.");
+    });
+
+    await import("../src/main");
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    // A bad file would otherwise be re-auto-loaded every startup; the handle is
+    // dropped so the next session falls through to cached/seed instead.
+    expect(mockClearFileHandle).toHaveBeenCalled();
+    expect(mockStoreParsedData).not.toHaveBeenCalled();
+    const errorEl = document.querySelector(".nav-error") as HTMLElement;
+    expect(errorEl.hidden).toBe(false);
+    expect(errorEl.textContent).toContain("Not a valid budget file.");
+  });
+
+  it("clears a denied handle and shows an unlinked notice, falling through to cached data", async () => {
+    const handle = { name: "budget.benc" } as unknown as FileSystemFileHandle;
+    mockGetFileHandle.mockResolvedValue(handle);
+    mockQueryReadPermission.mockResolvedValue("denied");
+    mockGetMeta.mockResolvedValue({
+      key: "upload",
+      groupName: "household",
+      version: 1,
+      exportedAt: "2025-06-15T10:30:00Z",
+    });
+
+    resetAndMockAll();
+
+    await import("../src/main");
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(mockClearFileHandle).toHaveBeenCalled();
+    expect(mockReadFileFromHandle).not.toHaveBeenCalled();
+    // Cached data is still shown (local state -> hero hidden).
+    const heroContainer = document.getElementById("hero-container")!;
+    expect(heroContainer.hidden).toBe(true);
+    const errorEl = document.querySelector(".nav-error") as HTMLElement;
+    expect(errorEl.hidden).toBe(false);
+    expect(errorEl.textContent).toContain("denied");
+  });
+
+  it("reload button falls back to the picker when re-grant is still denied", async () => {
+    const handle = { name: "budget.benc" } as unknown as FileSystemFileHandle;
+    const newHandle = { name: "budget.benc" } as unknown as FileSystemFileHandle;
+    mockGetFileHandle.mockResolvedValue(handle);
+    mockQueryReadPermission.mockResolvedValue("prompt");
+    mockGetMeta.mockResolvedValue({
+      key: "upload",
+      groupName: "household",
+      version: 1,
+      exportedAt: "2025-06-15T10:30:00Z",
+    });
+    mockReadFileFromHandle.mockResolvedValue(new File(["{}"], "budget.benc"));
+
+    resetAndMockAll();
+
+    const { parseUploadedJson, toParsedData } = await import("../src/upload.js");
+    (parseUploadedJson as ReturnType<typeof vi.fn>).mockReturnValue({ groupName: "household" });
+    (toParsedData as ReturnType<typeof vi.fn>).mockReturnValue({ meta: { groupName: "household" } });
+    mockStoreParsedData.mockResolvedValue(undefined);
+
+    await import("../src/main");
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    const button = document.querySelector(".reload-handle") as HTMLButtonElement;
+    expect(button).not.toBeNull();
+
+    // Re-grant is refused, so the click falls back to the FSA picker.
+    mockRequestReadPermission.mockResolvedValue("denied");
+    mockPickBencFile.mockResolvedValue(newHandle);
+    button.click();
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(mockRequestReadPermission).toHaveBeenCalledWith(handle);
+    expect(mockPickBencFile).toHaveBeenCalled();
+    expect(mockPutFileHandle).toHaveBeenCalledWith(newHandle);
+    expect(mockReadFileFromHandle).toHaveBeenCalledWith(newHandle);
   });
 
   it("transitions to cached local state when no handle but meta exists (unchanged path)", async () => {

--- a/budget/test/main.test.ts
+++ b/budget/test/main.test.ts
@@ -31,11 +31,31 @@ vi.mock("../src/firebase.js", () => ({
 const mockGetMeta = vi.fn();
 const mockStoreParsedData = vi.fn();
 const mockClearAll = vi.fn();
+const mockGetFileHandle = vi.fn();
+const mockPutFileHandle = vi.fn();
+const mockClearFileHandle = vi.fn();
+
+const mockIsFsaSupported = vi.fn();
+const mockPickBencFile = vi.fn();
+const mockQueryReadPermission = vi.fn();
+const mockRequestReadPermission = vi.fn();
+const mockReadFileFromHandle = vi.fn();
 
 vi.mock("../src/idb.js", () => ({
   getMeta: mockGetMeta,
   storeParsedData: mockStoreParsedData,
   clearAll: mockClearAll,
+  getFileHandle: mockGetFileHandle,
+  putFileHandle: mockPutFileHandle,
+  clearFileHandle: mockClearFileHandle,
+}));
+
+vi.mock("../src/local-file.js", () => ({
+  isFsaSupported: mockIsFsaSupported,
+  pickBencFile: mockPickBencFile,
+  queryReadPermission: mockQueryReadPermission,
+  requestReadPermission: mockRequestReadPermission,
+  readFileFromHandle: mockReadFileFromHandle,
 }));
 
 vi.mock("../src/upload.js", () => ({
@@ -80,6 +100,14 @@ function resetAndMockAll(): void {
   }));
   vi.mock("../src/idb.js", () => ({
     getMeta: mockGetMeta, storeParsedData: mockStoreParsedData, clearAll: mockClearAll,
+    getFileHandle: mockGetFileHandle, putFileHandle: mockPutFileHandle, clearFileHandle: mockClearFileHandle,
+  }));
+  vi.mock("../src/local-file.js", () => ({
+    isFsaSupported: mockIsFsaSupported,
+    pickBencFile: mockPickBencFile,
+    queryReadPermission: mockQueryReadPermission,
+    requestReadPermission: mockRequestReadPermission,
+    readFileFromHandle: mockReadFileFromHandle,
   }));
   vi.mock("../src/upload.js", () => ({
     parseUploadedJson: vi.fn(), toParsedData: vi.fn(),
@@ -101,6 +129,15 @@ type AppState = import("../src/main").AppState;
 describe("main module", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    // Defaults: no persisted handle, FSA unsupported -> existing upload behavior.
+    mockGetFileHandle.mockReset().mockResolvedValue(undefined);
+    mockPutFileHandle.mockReset().mockResolvedValue(undefined);
+    mockClearFileHandle.mockReset().mockResolvedValue(undefined);
+    mockIsFsaSupported.mockReset().mockReturnValue(false);
+    mockPickBencFile.mockReset().mockResolvedValue(null);
+    mockQueryReadPermission.mockReset();
+    mockRequestReadPermission.mockReset();
+    mockReadFileFromHandle.mockReset();
   });
 
   it("exports AppState type (compile-time check)", () => {
@@ -177,5 +214,99 @@ describe("main module", () => {
     expect(mockGetMeta).toHaveBeenCalled();
     const heroContainer = document.getElementById("hero-container")!;
     expect(heroContainer.hidden).toBe(true);
+  });
+
+  it("auto-loads from a persisted handle when permission is granted", async () => {
+    const handle = { name: "budget.benc" } as unknown as FileSystemFileHandle;
+    mockGetFileHandle.mockResolvedValue(handle);
+    mockQueryReadPermission.mockResolvedValue("granted");
+    mockReadFileFromHandle.mockResolvedValue(new File(["{}"], "budget.benc"));
+
+    resetAndMockAll();
+
+    const { parseUploadedJson, toParsedData } = await import("../src/upload.js");
+    (parseUploadedJson as ReturnType<typeof vi.fn>).mockReturnValue({ groupName: "household" });
+    (toParsedData as ReturnType<typeof vi.fn>).mockReturnValue({ meta: { groupName: "household" } });
+    mockStoreParsedData.mockResolvedValue(undefined);
+
+    await import("../src/main");
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(mockReadFileFromHandle).toHaveBeenCalledWith(handle);
+    expect(mockStoreParsedData).toHaveBeenCalled();
+  });
+
+  it("shows a reload button (no auto-load) when permission is prompt, then loads on click", async () => {
+    const handle = { name: "budget.benc" } as unknown as FileSystemFileHandle;
+    mockGetFileHandle.mockResolvedValue(handle);
+    mockQueryReadPermission.mockResolvedValue("prompt");
+    mockGetMeta.mockResolvedValue({
+      key: "upload",
+      groupName: "household",
+      version: 1,
+      exportedAt: "2025-06-15T10:30:00Z",
+    });
+    mockReadFileFromHandle.mockResolvedValue(new File(["{}"], "budget.benc"));
+
+    resetAndMockAll();
+
+    const { parseUploadedJson, toParsedData } = await import("../src/upload.js");
+    (parseUploadedJson as ReturnType<typeof vi.fn>).mockReturnValue({ groupName: "household" });
+    (toParsedData as ReturnType<typeof vi.fn>).mockReturnValue({ meta: { groupName: "household" } });
+    mockStoreParsedData.mockResolvedValue(undefined);
+
+    await import("../src/main");
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    const button = document.querySelector(".reload-handle") as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    expect(mockReadFileFromHandle).not.toHaveBeenCalled();
+
+    mockRequestReadPermission.mockResolvedValue("granted");
+    button.click();
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(mockRequestReadPermission).toHaveBeenCalledWith(handle);
+    expect(mockReadFileFromHandle).toHaveBeenCalledWith(handle);
+  });
+
+  it("clears a stale handle and shows a re-link error when the file is gone", async () => {
+    const handle = { name: "budget.benc" } as unknown as FileSystemFileHandle;
+    mockGetFileHandle.mockResolvedValue(handle);
+    mockQueryReadPermission.mockResolvedValue("granted");
+    mockReadFileFromHandle.mockRejectedValue(new DOMException("missing", "NotFoundError"));
+
+    resetAndMockAll();
+
+    await import("../src/main");
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(mockClearFileHandle).toHaveBeenCalled();
+    const errorEl = document.querySelector(".nav-error") as HTMLElement;
+    expect(errorEl.hidden).toBe(false);
+    expect(errorEl.textContent).toContain("no longer available");
+  });
+
+  it("transitions to cached local state when no handle but meta exists (unchanged path)", async () => {
+    mockGetFileHandle.mockResolvedValue(undefined);
+    mockGetMeta.mockResolvedValue({
+      key: "upload",
+      groupName: "household",
+      version: 1,
+      exportedAt: "2025-06-15T10:30:00Z",
+    });
+
+    resetAndMockAll();
+
+    await import("../src/main");
+    await new Promise(r => setTimeout(r, 0));
+
+    const heroContainer = document.getElementById("hero-container")!;
+    expect(heroContainer.hidden).toBe(true);
+    expect(mockReadFileFromHandle).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #1018

## What

First slice of the local-first data-ownership epic (#1026): persist a Chromium
**File System Access API** `FileSystemFileHandle` so the budget app re-opens the
same on-disk synced `.benc` across sessions without a fresh upload every time.

The real filesystem stays the single source of truth on every browser. Chromium
re-opens it via the persisted handle; non-Chromium browsers keep re-reading it via
the existing `<input type=file>` picker each session, unchanged. No browser-private
copy (OPFS) is kept — IndexedDB remains a cache of the parsed working data, never a
source of truth. BENC stays encrypted at rest; the password is prompted via the
existing `promptPassword` and held in memory only.

## How

Three units:

1. **`budget/src/idb.ts`** — persist the handle in the `meta` store
   (`FileHandleMeta` + `putFileHandle`/`getFileHandle`/`clearFileHandle`), and stop
   `storeParsedData` from wiping it: the clear loop now skips the `meta` store, so a
   data load overwrites the `upload` record while the separate `fileHandle` record
   survives. `clearAll` (the "Clear data" button) still drops the handle — the
   correct unlink-on-clear behavior.

2. **`budget/src/local-file.ts`** (new) — the entire FSA platform surface behind a
   small interface: `isFsaSupported`, `pickBencFile` (returns `null` on user cancel),
   `queryReadPermission`/`requestReadPermission` (mode `"read"`; #1019 upgrades to
   `"readwrite"`), and `readFileFromHandle`. Owns the minimal ambient type
   declarations the API needs (`showOpenFilePicker`, `queryPermission`/
   `requestPermission`), which are not in baseline `lib.dom.d.ts`.

3. **`budget/src/main.ts`** — the startup ladder and picker UI. `loadFromFile` is
   extracted from `handleFileUpload`'s core pipeline; `loadFromHandle` reads the
   handle (stale-handle read failures clear the handle and surface a re-link picker)
   then reuses `handleFileUpload`'s parse/validation error handling. On launch: a
   `granted` handle auto-loads with no picker; a `prompt` handle shows cached/seed
   data plus a one-click "Reload <name>" button; otherwise the existing cached/seed
   path runs unchanged. When FSA is unsupported, the `<input>` upload path is the
   active path, untouched.

## Acceptance criteria

- [x] The `FileSystemFileHandle` is persisted in the IDB `meta` store.
- [x] A returning session with permission `granted` auto-loads with no picker; with
      permission in `prompt` state, one click re-grants and loads.
- [x] A stale/invalid handle falls back to the re-link picker rather than erroring.
- [x] Non-Chromium browsers use the existing upload `<input>` path unchanged.
- [x] BENC decrypt path is unchanged.

## Verification

- `npx vitest run --root budget` — full suite green (892 passed, 7 skipped),
  including the new idb, local-file, and main ladder tests.
- `npx tsc --noEmit --project budget` — clean (ambient FSA declarations type-check,
  no `any` leaks).
- `npm run build --prefix budget` — succeeds.

Out of scope (later epic slices): write-back (#1019), `lastModified` reload (#1020),
PWA install (#1021), directory access (#1022).
