### PR TITLE
dispatch: guarantee a chain continuation on abnormal tick exit (OnFailure recovery)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-reseed
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-reseed
@@ -368,6 +368,14 @@ else
   MAIN_WORKTREE="$PROJECT_ROOT/worktrees/main"
 fi
 
+# Install the OnFailure recovery unit (dispatch-tick-recover.service) before
+# scheduling the transient reseed timer. Best-effort: OnFailure= resolves
+# lazily at failure time, so a failure here is non-fatal — a missing target
+# only logs an error if the reseed unit ever fails. We still pass OnFailure=
+# unconditionally below so an abnormal reseed exit is guaranteed a chain
+# continuation (#1150).
+ensure_recover_unit "$MAIN_WORKTREE" || true
+
 # ---- Step 6: schedule the transient timer -----------------------------------
 #
 # The unit name embeds the epoch resets_at — a repeated call with the same
@@ -392,6 +400,18 @@ fi
 # claude/git/jq. The caller (a dispatch tick) always carries the full
 # nix-store PATH, so capturing it at schedule time makes the unit
 # self-sufficient when the timer later fires.
+#
+# --collect makes systemd garbage-collect the transient unit after it finishes
+# OR FAILS, so a failed reseed tick does not linger in systemd's `failed`
+# state (mirrors dispatch-spawn-tick). Without it a non-zero dispatch-tick exit
+# would leave a lingering failed unit behind.
+#
+# --property=OnFailure=dispatch-tick-recover.service (#1150): if the reseed
+# unit fails abnormally, systemd fires the recovery handler (edge-triggered,
+# owned by systemd, unskippable by a crashing tick) so the chain still gets a
+# continuation. ensure_recover_unit (above) installs that handler best-effort;
+# OnFailure= resolves lazily at failure time, so passing it is safe even when
+# the install failed.
 
 SYSTEMD_RUN_CMD="${DISPATCH_SCHEDULE_RESEED_SYSTEMD_RUN_CMD:-systemd-run}"
 UNIT_NAME="dispatch-reseed-${RESEED_AT}"
@@ -406,6 +426,8 @@ trap 'rm -f "$RUN_STDERR"' EXIT
 "$SYSTEMD_RUN_CMD" --user \
      --unit="$UNIT_NAME" \
      --on-calendar="@$RESEED_AT" \
+     --collect \
+     --property=OnFailure=dispatch-tick-recover.service \
      --working-directory="$MAIN_WORKTREE" \
      --timer-property=Persistent=true \
      --setenv=PATH="$PATH" \

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-tick
@@ -27,6 +27,17 @@
 #   dispatch-tick exit would leave a lingering failed unit and the next
 #   `--unit=dispatch-tick` would collide forever — wedging all future ticks.
 #
+# OnFailure recovery (#1150):
+#   Before launching, ensure_recover_unit (lib.sh) idempotently installs the
+#   static dispatch-tick-recover.service unit (best-effort — a failure is
+#   non-fatal). Each transient tick unit then carries
+#   --property=OnFailure=dispatch-tick-recover.service. systemd fires that
+#   handler exactly when the tick unit fails abnormally (edge-triggered, owned
+#   by systemd, unskippable by a crashing tick), guaranteeing a chain
+#   continuation even when the tick aborts before producing a Stop-hook
+#   handoff or an armed reseed timer. OnFailure= resolves lazily at failure
+#   time, so passing it is safe even if ensure_recover_unit failed.
+#
 # Unlike dispatch-schedule-reseed (which schedules an --on-calendar TIMER), this
 # script runs the unit IMMEDIATELY: a transient .service, no --on-calendar /
 # --timer-property. The transient unit is itself the detachment — systemd runs
@@ -107,6 +118,13 @@ else
   MAIN_WORKTREE="$PROJECT_ROOT/worktrees/main"
 fi
 
+# Install the OnFailure recovery unit (dispatch-tick-recover.service) before
+# launching the transient tick. Best-effort: OnFailure= resolves lazily at
+# failure time, so a failure here is non-fatal — a missing target only logs an
+# error if the tick ever fails. We still pass OnFailure= unconditionally below
+# so an abnormal tick exit is guaranteed a chain continuation (#1150).
+ensure_recover_unit "$MAIN_WORKTREE" || true
+
 SYSTEMD_RUN_CMD="${DISPATCH_SPAWN_TICK_SYSTEMD_RUN_CMD:-systemd-run}"
 TICK_PATH="$MAIN_WORKTREE/.claude/skills/dispatch-propagate/scripts/dispatch-tick"
 
@@ -129,6 +147,7 @@ if [[ -n "$TARGET_N" ]]; then
   "$SYSTEMD_RUN_CMD" --user \
        --unit="$UNIT_NAME" \
        --collect \
+       --property=OnFailure=dispatch-tick-recover.service \
        --working-directory="$MAIN_WORKTREE" \
        --setenv=PATH="$PATH" \
        "$TICK_PATH" "$TARGET_N" \
@@ -138,6 +157,7 @@ else
   "$SYSTEMD_RUN_CMD" --user \
        --unit="$UNIT_NAME" \
        --collect \
+       --property=OnFailure=dispatch-tick-recover.service \
        --working-directory="$MAIN_WORKTREE" \
        --setenv=PATH="$PATH" \
        "$TICK_PATH" \

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover
@@ -112,9 +112,22 @@ RESET_WINDOW="${DISPATCH_TICK_RECOVER_RESET_WINDOW:-3600}"
 CAP="${DISPATCH_TICK_RECOVER_CAP:-3}"
 BASE="${DISPATCH_TICK_RECOVER_BASE_BACKOFF:-300}"
 MAX="${DISPATCH_TICK_RECOVER_MAX_BACKOFF:-3600}"
-for var in RESET_WINDOW CAP BASE MAX; do
+for var in BASE MAX; do
   if ! [[ "${!var}" =~ ^[0-9]+$ ]]; then
     echo "dispatch-tick-recover: $var must be a non-negative integer, got '${!var}'; aborting" >&2
+    exit 2
+  fi
+done
+# CAP and RESET_WINDOW must be positive integers (>= 1), not merely
+# non-negative. CAP=0 would escalate on the very first failure with no retry.
+# RESET_WINDOW=0 would treat every failure as a fresh episode (NOW -
+# last_failure > 0 is almost always true), so the consecutive count never
+# reaches the cap and escalation never fires — an unbounded retry loop. Both
+# are almost certainly misconfigurations; reject them rather than silently
+# defeat the cap.
+for var in CAP RESET_WINDOW; do
+  if ! [[ "${!var}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "dispatch-tick-recover: $var must be a positive integer (>= 1), got '${!var}'; aborting" >&2
     exit 2
   fi
 done
@@ -216,6 +229,14 @@ continuation_present() {
   return 1
 }
 
+# Read state before the continuation check so that write_state in the
+# continuation branch has the real last_failure value from the file.
+# Without this, STATE_LAST_FAILURE is its initial value (0), and a
+# continuation resets last_failure to 0 — causing the NEXT episode to always
+# look "old" (NOW - 0 > RESET_WINDOW), defeating the consecutive-failure cap
+# for patterns with brief continuations.
+read_state
+
 if continuation_present; then
   write_state 0 "$STATE_LAST_FAILURE" || true
   echo "dispatch-tick-recover: continuation present; no-op" >&2
@@ -224,7 +245,6 @@ fi
 
 # ---- Step 3: no continuation — load + advance the failure state -------------
 
-read_state
 COUNT="$STATE_COUNT"
 LAST_FAILURE="$STATE_LAST_FAILURE"
 
@@ -314,7 +334,11 @@ fi
 # on the launchers, and the recover unit must not chain to itself.
 
 BACKOFF=$(( BASE * (1 << (COUNT - 1)) ))
-if (( BACKOFF > MAX )); then
+# A very high COUNT (only reachable with a large CAP) overflows the 64-bit
+# signed left-shift to a negative value, which the `> MAX` guard alone would
+# let through — yielding a past/negative RESEED_AT that fires the timer
+# immediately and defeats the backoff. Clamp non-positive and over-max alike.
+if (( BACKOFF <= 0 || BACKOFF > MAX )); then
   BACKOFF="$MAX"
 fi
 RESEED_AT=$(( NOW + BACKOFF ))

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+# dispatch-tick-recover — guarantee a dispatch-chain continuation after an
+# abnormal tick exit. Wired as the `OnFailure=dispatch-tick-recover.service`
+# handler on the transient tick / reseed units (dispatch-spawn-tick,
+# dispatch-schedule-reseed). systemd fires it edge-triggered, exactly when a
+# unit fails — unskippable by a crashing tick. It is the chain's safety net:
+# the headless tick otherwise carries the chain only via a spawned worker's
+# Stop hook or an armed dispatch-reseed* timer, both produced ONLY after a
+# successful selection. A tick that aborts early (e.g. a transient GitHub 504
+# in the selection path) leaves neither — and #1010's continuation invariant
+# (dispatch-self-close) no-ops for a systemd-run unit. This handler closes that
+# gap. See #1150 / #1148.
+#
+# Behavior, in order:
+#   1. NOW = env override or `date +%s` (validated as an integer epoch).
+#   2. Continuation detection: the chain is already carried iff EITHER a
+#      pending `dispatch-reseed*` timer exists OR a live busy worker exists.
+#      A daemon UNKNOWN (busy-worker query fails) is treated as NO worker —
+#      we fail toward GUARANTEEING a continuation. A redundant reseed is
+#      harmless: dispatch's per-worktree dedup + the run-scoped concurrency
+#      gate absorb it. If a continuation exists → reset the consecutive-failure
+#      count to 0 and no-op.
+#   3. No continuation: load the consecutive-failure state. A failure older
+#      than RESET_WINDOW starts a fresh episode (count reset to 0). Then
+#      count += 1.
+#   4. Cap check: count > CAP → ESCALATE rather than retry. Find-or-create one
+#      open `dispatch:chain-stalled` latch issue (one at a time), naming the
+#      failed unit / exit status and the `dispatch` resume hint. No reseed.
+#   5. Otherwise arm a bounded-backoff reseed at now + min(BASE*2^(count-1),
+#      MAX), via systemd-run --on-calendar, with the `dispatch-reseed-<epoch>`
+#      unit name so the armed timer is itself recognized as a continuation by
+#      step 2 (and is idempotent by epoch). The reseed runs a NO-ARG
+#      dispatch-tick (re-evaluate the whole queue — more robust than re-keying
+#      the failed target).
+#
+# Its decision is driven by LIVE system state (pending timer + live workers),
+# NOT by which unit failed. It reads systemd's $MONITOR_UNIT /
+# $MONITOR_EXIT_STATUS (which systemd >= 256 injects into an OnFailure=-activated
+# unit) only for context in the escalation issue body.
+#
+# Environment overrides for testability:
+#
+#   DISPATCH_TICK_RECOVER_MAIN_WORKTREE
+#     Override the main worktree path. When set, the script does NOT require a
+#     git repo. Default: <project-root>/worktrees/main, via resolve_project_root
+#     (lib.sh). Mirrors dispatch-spawn-tick's idiom.
+#
+#   DISPATCH_TICK_RECOVER_NOW
+#     Override the current epoch seconds. Default: date +%s.
+#
+#   DISPATCH_TICK_RECOVER_STATE_PATH
+#     Override the consecutive-failure state JSON path. Default:
+#     ~/.local/share/commons-dispatch/recover-state.json (same dir as
+#     dispatch-schedule-reseed's rate_limits.json). Shape:
+#     {"count": N, "last_failure": EPOCH}.
+#
+#   DISPATCH_TICK_RECOVER_RESET_WINDOW
+#     Seconds since the last failure beyond which a new failure starts a fresh
+#     episode (count reset to 0). Non-negative integer. Default: 3600.
+#
+#   DISPATCH_TICK_RECOVER_CAP
+#     Consecutive-failure cap. count > CAP escalates instead of retrying.
+#     Positive integer. Default: 3.
+#
+#   DISPATCH_TICK_RECOVER_BASE_BACKOFF
+#     Base backoff seconds for attempt 1. Positive integer. Default: 300.
+#
+#   DISPATCH_TICK_RECOVER_MAX_BACKOFF
+#     Backoff ceiling in seconds. Positive integer. Default: 3600.
+#
+#   DISPATCH_TICK_RECOVER_SYSTEMCTL_CMD
+#     The `systemctl` binary (used for the pending-timer query). Default:
+#     `systemctl`.
+#
+#   DISPATCH_TICK_RECOVER_SYSTEMD_RUN_CMD
+#     The `systemd-run` binary (used to arm the reseed). Default: `systemd-run`.
+#
+#   DISPATCH_TICK_RECOVER_GH_CMD
+#     The `gh` binary (used for the escalation latch issue). Default: `gh`.
+#
+#   CLAUDE_AGENTS_CMD
+#     Replaces the `claude` invocation in lib-claude-agents.sh's
+#     claude_agents_count_busy_workers. Default: `claude`.
+#
+# Sandbox: this runs as a systemd `OnFailure=` unit OUTSIDE Claude's Bash
+# sandbox. `systemd-run --user` / `systemctl --user` talk to the user's systemd
+# over D-Bus, `claude agents --json` reaches the local daemon over a Unix
+# socket, and `gh` needs network/TLS — all blocked by the sandbox. A Bash-tool
+# caller must invoke this with `dangerouslyDisableSandbox: true`. See
+# `.claude/rules/sandbox.md`.
+#
+# NOT set -e: exits are handled explicitly (matching dispatch-schedule-reseed /
+# dispatch-spawn-tick).
+set -uo pipefail
+
+# ---- Step 0: config, sourced helpers, MAIN_WORKTREE -------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+source "$SCRIPT_DIR/lib-claude-agents.sh"
+
+STATE_PATH="${DISPATCH_TICK_RECOVER_STATE_PATH:-$HOME/.local/share/commons-dispatch/recover-state.json}"
+SYSTEMCTL_CMD="${DISPATCH_TICK_RECOVER_SYSTEMCTL_CMD:-systemctl}"
+SYSTEMD_RUN_CMD="${DISPATCH_TICK_RECOVER_SYSTEMD_RUN_CMD:-systemd-run}"
+GH_CMD="${DISPATCH_TICK_RECOVER_GH_CMD:-gh}"
+
+# Integer tunables. Validate before any value reaches a `(( ))` arithmetic
+# context — bash arithmetic evaluates array-index command substitution (e.g.
+# `a[$(touch /tmp/pwn)]`), so a hostile env override must be rejected as a
+# literal-integer check first (mirrors dispatch-schedule-reseed:~160-179).
+RESET_WINDOW="${DISPATCH_TICK_RECOVER_RESET_WINDOW:-3600}"
+CAP="${DISPATCH_TICK_RECOVER_CAP:-3}"
+BASE="${DISPATCH_TICK_RECOVER_BASE_BACKOFF:-300}"
+MAX="${DISPATCH_TICK_RECOVER_MAX_BACKOFF:-3600}"
+for var in RESET_WINDOW CAP BASE MAX; do
+  if ! [[ "${!var}" =~ ^[0-9]+$ ]]; then
+    echo "dispatch-tick-recover: $var must be a non-negative integer, got '${!var}'; aborting" >&2
+    exit 2
+  fi
+done
+
+# Resolve the main worktree — same idiom as dispatch-spawn-tick. An explicit
+# override is authoritative and bypasses the git lookup (tests rely on this).
+if [[ -n "${DISPATCH_TICK_RECOVER_MAIN_WORKTREE:-}" ]]; then
+  MAIN_WORKTREE="$DISPATCH_TICK_RECOVER_MAIN_WORKTREE"
+else
+  PROJECT_ROOT=$(resolve_project_root) \
+    || { echo "dispatch-tick-recover: not in a git repo and DISPATCH_TICK_RECOVER_MAIN_WORKTREE is unset" >&2; exit 2; }
+  MAIN_WORKTREE="$PROJECT_ROOT/worktrees/main"
+fi
+
+# ---- Step 1: NOW ------------------------------------------------------------
+
+NOW="${DISPATCH_TICK_RECOVER_NOW:-$(date +%s)}"
+# NOW reaches `(( NOW - last_failure > RESET_WINDOW ))` and `(( reseed_at = NOW
+# + backoff ))`; the default (date +%s) is always safe, the env-override path is
+# the surface that requires validation. (See dispatch-schedule-reseed:~172-179.)
+if ! [[ "$NOW" =~ ^[0-9]+$ ]]; then
+  echo "dispatch-tick-recover: NOW must be an integer epoch, got '$NOW'; aborting" >&2
+  exit 2
+fi
+
+# ---- State read/write helpers -----------------------------------------------
+#
+# State JSON lives in the same dir as dispatch-schedule-reseed's rate_limits.json
+# (~/.local/share/commons-dispatch/). Read defensively (missing/empty/unparseable
+# → defaults count=0, last_failure=0). Write atomically (tmp + mv) into the dir,
+# creating it with `mkdir -p` — mirroring how the sibling scripts manage JSON.
+
+STATE_COUNT=0
+STATE_LAST_FAILURE=0
+
+read_state() {
+  STATE_COUNT=0
+  STATE_LAST_FAILURE=0
+  [[ -r "$STATE_PATH" ]] || return 0
+  local parsed
+  parsed=$(jq -r '"\(.count // 0)|\(.last_failure // 0)"' "$STATE_PATH" 2>/dev/null) || return 0
+  local c="${parsed%%|*}"
+  local lf="${parsed#*|}"
+  # Sanitize before either value enters a `(( ))` context.
+  [[ "$c" =~ ^[0-9]+$ ]] && STATE_COUNT="$c"
+  [[ "$lf" =~ ^[0-9]+$ ]] && STATE_LAST_FAILURE="$lf"
+  return 0
+}
+
+# write_state <count> <last_failure>
+write_state() {
+  local count="$1" last_failure="$2"
+  local dir
+  dir="$(dirname "$STATE_PATH")"
+  mkdir -p "$dir" || { echo "dispatch-tick-recover: mkdir -p $dir failed" >&2; return 1; }
+  local tmp
+  tmp=$(mktemp "$dir/.recover-state.json.XXXXXX") || {
+    echo "dispatch-tick-recover: could not create temp file in $dir" >&2; return 1
+  }
+  if ! jq -n --argjson count "$count" --argjson last_failure "$last_failure" \
+       '{count: $count, last_failure: $last_failure}' > "$tmp"; then
+    echo "dispatch-tick-recover: failed to write $tmp" >&2
+    rm -f "$tmp"
+    return 1
+  fi
+  mv "$tmp" "$STATE_PATH" || { echo "dispatch-tick-recover: failed to install $STATE_PATH" >&2; rm -f "$tmp"; return 1; }
+  return 0
+}
+
+# ---- Step 2: continuation detection -----------------------------------------
+#
+# The chain is already carried iff EITHER a pending dispatch-reseed* timer
+# exists OR a live busy worker exists. If so, reset the consecutive-failure
+# count and no-op — the failed unit was not the chain's only carrier.
+
+continuation_present() {
+  # (a) Pending dispatch-reseed* timer. `list-units --type=timer --all` with the
+  # glob restricts the listing; a row whose unit column matches
+  # dispatch-reseed-*.timer means a reseed is armed (and an armed reseed unit is
+  # exactly what step 5 produces, so this is self-consistent).
+  local units
+  if units=$("$SYSTEMCTL_CMD" --user list-units --type=timer --all --no-legend 'dispatch-reseed*' 2>/dev/null); then
+    if grep -Eq '(^|[[:space:]])dispatch-reseed-[^[:space:]]*\.timer([[:space:]]|$)' <<<"$units"; then
+      return 0
+    fi
+  fi
+
+  # (b) Live busy worker. claude_agents_count_busy_workers returns 0 with a
+  # numeric count on success; non-zero on UNKNOWN (daemon unreachable). On
+  # UNKNOWN we treat it as NO worker — fail toward guaranteeing a continuation
+  # (a redundant reseed is absorbed by dispatch's dedup + concurrency gate).
+  local busy
+  if busy=$(claude_agents_count_busy_workers); then
+    if [[ "$busy" =~ ^[0-9]+$ ]] && (( busy > 0 )); then
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+if continuation_present; then
+  write_state 0 "$STATE_LAST_FAILURE" || true
+  echo "dispatch-tick-recover: continuation present; no-op" >&2
+  exit 0
+fi
+
+# ---- Step 3: no continuation — load + advance the failure state -------------
+
+read_state
+COUNT="$STATE_COUNT"
+LAST_FAILURE="$STATE_LAST_FAILURE"
+
+# A failure older than RESET_WINDOW starts a fresh episode.
+if (( NOW - LAST_FAILURE > RESET_WINDOW )); then
+  COUNT=0
+fi
+COUNT=$(( COUNT + 1 ))
+
+# ---- Step 4: cap check — escalate instead of retry --------------------------
+#
+# Past the cap, looping a reseed would mask a persistent failure. Escalate
+# visibly via a find-or-create dispatch:chain-stalled latch issue (one open at a
+# time) and do NOT arm a reseed. Mirrors dispatch-diagnose-main's
+# apply-first/create-on-not-found label bootstrap.
+
+if (( COUNT > CAP )); then
+  # One open latch issue at a time: if one is already open, no-op the create.
+  existing=$("$GH_CMD" issue list --label dispatch:chain-stalled --state open \
+    --json number -q '.[0].number' 2>/dev/null) || existing=""
+
+  if [[ -n "$existing" ]]; then
+    echo "dispatch-tick-recover: chain-stalled latch issue #$existing already open; not retrying (count=$COUNT > cap=$CAP)" >&2
+  else
+    body_file=$(mktemp) || { echo "dispatch-tick-recover: could not create temp file for issue body" >&2; exit 2; }
+    trap 'rm -f "$body_file"' EXIT
+    {
+      echo "The dispatch chain has had ${CAP} consecutive tick failures that each left no"
+      echo "continuation (no pending \`dispatch-reseed*\` timer, no live busy worker)."
+      echo "Auto-retry is now stopped to avoid masking a persistent failure."
+      echo
+      echo "Most recent failing unit (from systemd OnFailure context):"
+      echo "- unit: \`${MONITOR_UNIT:-unknown}\`"
+      echo "- exit status: \`${MONITOR_EXIT_STATUS:-unknown}\`"
+      echo
+      echo "Resume the chain manually once the underlying cause is addressed:"
+      echo
+      echo '```'
+      echo "dispatch"
+      echo '```'
+    } > "$body_file"
+
+    # apply-first / create-on-not-found: the dispatch:chain-stalled label may
+    # not exist yet. Try the create; if it fails because the label is "not
+    # found", create the label ONCE (no --color — single-sourced elsewhere) and
+    # retry. bug + priority already exist and sort the fix to the top.
+    create_err=$(mktemp) || { echo "dispatch-tick-recover: could not create temp file" >&2; exit 2; }
+    if ! "$GH_CMD" issue create \
+         --title "dispatch chain stalled: ${CAP} consecutive tick failures left no continuation" \
+         --body-file "$body_file" \
+         --label dispatch:chain-stalled --label bug --label priority \
+         2>"$create_err"; then
+      if grep -qi "not found" "$create_err"; then
+        "$GH_CMD" label create dispatch:chain-stalled \
+          --description "dispatch workflow: the chain stalled with no continuation past the recover cap" 2>/dev/null || true
+        "$GH_CMD" issue create \
+          --title "dispatch chain stalled: ${CAP} consecutive tick failures left no continuation" \
+          --body-file "$body_file" \
+          --label dispatch:chain-stalled --label bug --label priority \
+          >&2 || echo "dispatch-tick-recover: chain-stalled issue create failed after label bootstrap" >&2
+      else
+        cat "$create_err" >&2
+        echo "dispatch-tick-recover: chain-stalled issue create failed" >&2
+      fi
+    fi
+    rm -f "$create_err"
+    echo "dispatch-tick-recover: escalated (count=$COUNT > cap=$CAP); no reseed armed" >&2
+  fi
+
+  # Keep the count (do not reset) so a subsequent recovery sees we are still
+  # over the cap; record this failure's time.
+  write_state "$COUNT" "$NOW" || true
+  exit 0
+fi
+
+# ---- Step 5: arm a bounded-backoff reseed -----------------------------------
+#
+# backoff = min(BASE * 2^(count-1), MAX); reseed_at = NOW + backoff. The unit is
+# named dispatch-reseed-<reseed_at> so the armed timer is itself recognized as a
+# continuation by step 2 and is idempotent by epoch. Arm a NO-ARG dispatch-tick
+# (re-evaluate the whole queue — more robust than re-keying the failed target).
+#
+# The systemd-run flag style mirrors dispatch-schedule-reseed's Step-6 call
+# exactly, plus --collect (so a failed reseed unit does not linger — Unit 3
+# adds the same flag to dispatch-schedule-reseed). Deliberately NO OnFailure=
+# here: arming the recover handler on a recover-armed reseed is Unit 3's concern
+# on the launchers, and the recover unit must not chain to itself.
+
+BACKOFF=$(( BASE * (1 << (COUNT - 1)) ))
+if (( BACKOFF > MAX )); then
+  BACKOFF="$MAX"
+fi
+RESEED_AT=$(( NOW + BACKOFF ))
+UNIT_NAME="dispatch-reseed-${RESEED_AT}"
+
+RUN_STDERR=$(mktemp)
+trap 'rm -f "$RUN_STDERR"' EXIT
+# Capture the exit code directly — after `if cmd; then ... fi`, `$?` is the exit
+# status of the `if`, NOT of `cmd`. Run outside an `if` and capture `$?` at once.
+"$SYSTEMD_RUN_CMD" --user \
+     --unit="$UNIT_NAME" \
+     --collect \
+     --on-calendar="@$RESEED_AT" \
+     --working-directory="$MAIN_WORKTREE" \
+     --timer-property=Persistent=true \
+     --setenv=PATH="$PATH" \
+     "$MAIN_WORKTREE/.claude/skills/dispatch-propagate/scripts/dispatch-tick" \
+     2>"$RUN_STDERR"
+RC=$?
+
+if (( RC == 0 )); then
+  write_state "$COUNT" "$NOW" || true
+  echo "dispatch-tick-recover: armed reseed at $RESEED_AT (attempt $COUNT/$CAP)" >&2
+  exit 0
+fi
+
+err=$(cat "$RUN_STDERR")
+# systemd's already-exists message varies across versions; match the substring
+# (mirrors dispatch-schedule-reseed:~424). A collision means a reseed for this
+# exact epoch is already armed — the continuation is already guaranteed.
+if [[ "$err" == *"already exists"* ]]; then
+  write_state "$COUNT" "$NOW" || true
+  echo "dispatch-tick-recover: $UNIT_NAME already armed; no-op (attempt $COUNT/$CAP)" >&2
+  exit 0
+fi
+
+# Some other failure — surface stderr and pass the exit code through. Record the
+# failure state anyway so the consecutive-failure count stays accurate.
+write_state "$COUNT" "$NOW" || true
+echo "$err" >&2
+exit "$RC"

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -730,3 +730,76 @@ print_remote_access_block() {
   echo "========================================"
   echo ""
 }
+
+# Install the static `dispatch-tick-recover.service` unit file so the tick and
+# reseed launchers can attach `OnFailure=dispatch-tick-recover.service`.
+# OnFailure= references a LOADABLE unit file, not a script — and dispatch
+# otherwise uses only transient `systemd-run` units, so no such file exists
+# until we write one. This helper writes it idempotently.
+#
+# Best-effort: a failure here must not abort the caller (a tick/reseed
+# launcher), so we warn to stderr and return non-zero — never `exit`. A missing
+# recover unit just means a crashing tick falls back to the prior behavior.
+# Args: $1 = main worktree path
+ensure_recover_unit() {
+  local main_worktree="$1"
+  local RECOVER_SCRIPT="$main_worktree/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover"
+  local UNIT_DIR="${DISPATCH_RECOVER_UNIT_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user}"
+  local UNIT_PATH="$UNIT_DIR/dispatch-tick-recover.service"
+  local SYSTEMCTL_CMD="${DISPATCH_RECOVER_SYSTEMCTL_CMD:-systemctl}"
+
+  # Environment=PATH=$PATH captures the launching caller's PATH at write time,
+  # for the same reason dispatch-spawn-tick passes --setenv=PATH: the systemd
+  # user manager's minimal default PATH omits the nix store, so on NixOS/WSL
+  # hosts /usr/bin/env can't resolve bash and the recover script can't find
+  # git/jq/claude. The caller carries the full nix-store PATH, so baking it into
+  # the unit at write time makes the unit self-sufficient.
+  #
+  # Deliberately NO OnFailure= on this unit — the recover handler must not chain
+  # to itself, or a failing recovery would recurse.
+  local desired
+  desired=$(cat <<EOF
+[Unit]
+Description=Dispatch chain continuation recovery (OnFailure handler)
+
+[Service]
+Type=oneshot
+Environment=PATH=$PATH
+ExecStart=$RECOVER_SCRIPT
+WorkingDirectory=$main_worktree
+EOF
+)
+
+  # Steady-state hot path: if the installed unit already matches byte-for-byte,
+  # skip the write and the daemon-reload entirely (a single content compare).
+  if [ -f "$UNIT_PATH" ] && [ "$(cat "$UNIT_PATH")" = "$desired" ]; then
+    return 0
+  fi
+
+  if ! mkdir -p "$UNIT_DIR"; then
+    echo "WARNING: ensure_recover_unit: mkdir -p $UNIT_DIR failed; OnFailure recovery unavailable" >&2
+    return 1
+  fi
+
+  # Write atomically: temp file in the same dir, then mv into place.
+  local tmp
+  tmp=$(mktemp "$UNIT_DIR/.dispatch-tick-recover.service.XXXXXX") || {
+    echo "WARNING: ensure_recover_unit: could not create temp file in $UNIT_DIR; OnFailure recovery unavailable" >&2
+    return 1
+  }
+  if ! printf '%s\n' "$desired" > "$tmp"; then
+    echo "WARNING: ensure_recover_unit: failed to write $tmp; OnFailure recovery unavailable" >&2
+    rm -f "$tmp"
+    return 1
+  fi
+  if ! mv "$tmp" "$UNIT_PATH"; then
+    echo "WARNING: ensure_recover_unit: failed to install $UNIT_PATH; OnFailure recovery unavailable" >&2
+    rm -f "$tmp"
+    return 1
+  fi
+
+  if ! "$SYSTEMCTL_CMD" --user daemon-reload; then
+    echo "WARNING: ensure_recover_unit: systemctl --user daemon-reload failed; OnFailure recovery may be stale" >&2
+    return 1
+  fi
+}

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -743,17 +743,38 @@ print_remote_access_block() {
 # Args: $1 = main worktree path
 ensure_recover_unit() {
   local main_worktree="$1"
+
+  # A systemd unit file is line-structured: each line is an independent
+  # directive. An embedded newline in any value we interpolate below would land
+  # as an attacker-controlled extra directive in the [Service] section. The
+  # main worktree path comes from git output or a test override and never
+  # legitimately contains a newline; reject it rather than emit a malformed
+  # unit (best-effort: warn + return per this helper's contract — never exit).
+  if [[ "$main_worktree" == *$'\n'* ]]; then
+    echo "WARNING: ensure_recover_unit: main worktree path contains a newline; refusing to write unit; OnFailure recovery unavailable" >&2
+    return 1
+  fi
+
   local RECOVER_SCRIPT="$main_worktree/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover"
   local UNIT_DIR="${DISPATCH_RECOVER_UNIT_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user}"
   local UNIT_PATH="$UNIT_DIR/dispatch-tick-recover.service"
   local SYSTEMCTL_CMD="${DISPATCH_RECOVER_SYSTEMCTL_CMD:-systemctl}"
 
-  # Environment=PATH=$PATH captures the launching caller's PATH at write time,
+  # Strip any stray newline from the captured PATH for the same line-structure
+  # reason; a newline in PATH is a broken environment, not a value we should
+  # propagate into a unit directive.
+  local safe_path="${PATH//$'\n'/}"
+
+  # Environment=PATH=... captures the launching caller's PATH at write time,
   # for the same reason dispatch-spawn-tick passes --setenv=PATH: the systemd
   # user manager's minimal default PATH omits the nix store, so on NixOS/WSL
   # hosts /usr/bin/env can't resolve bash and the recover script can't find
   # git/jq/claude. The caller carries the full nix-store PATH, so baking it into
   # the unit at write time makes the unit self-sufficient.
+  #
+  # The path-bearing directives are double-quoted: systemd unescapes C-style
+  # quotes, so a path containing spaces is parsed as a single token rather than
+  # split into an executable + spurious arguments.
   #
   # Deliberately NO OnFailure= on this unit — the recover handler must not chain
   # to itself, or a failing recovery would recurse.
@@ -764,9 +785,9 @@ Description=Dispatch chain continuation recovery (OnFailure handler)
 
 [Service]
 Type=oneshot
-Environment=PATH=$PATH
-ExecStart=$RECOVER_SCRIPT
-WorkingDirectory=$main_worktree
+Environment="PATH=$safe_path"
+ExecStart="$RECOVER_SCRIPT"
+WorkingDirectory="$main_worktree"
 EOF
 )
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -10240,6 +10240,54 @@ fi
 assert_eq "reset-window: state count == 1 (fresh episode)" "1" "$(tr_state_count)"
 tr_teardown
 
+# --- Test 7: CAP=0 is rejected (would escalate with zero retries) ------------
+
+echo "Test: CAP=0 is rejected (exit 2, no reseed, no escalation)"
+tr_setup
+export DISPATCH_TICK_RECOVER_CAP=0
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "cap-zero: dispatch-tick-recover exits 2" "2" "$rc"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+assert_eq "cap-zero: no reseed armed (systemd-run log empty)" "" "$log"
+ghlog=$(cat "$TMPDIR_TEST/gh-log" 2>/dev/null || true)
+assert_eq "cap-zero: no escalation issue (gh log empty)" "" "$ghlog"
+tr_teardown
+
+# --- Test 8: RESET_WINDOW=0 is rejected (would defeat the cap) ---------------
+
+echo "Test: RESET_WINDOW=0 is rejected (exit 2, no reseed) — it would reset the count every call"
+tr_setup
+export DISPATCH_TICK_RECOVER_RESET_WINDOW=0
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "reset-window-zero: dispatch-tick-recover exits 2" "2" "$rc"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+assert_eq "reset-window-zero: no reseed armed (systemd-run log empty)" "" "$log"
+tr_teardown
+
+# --- Test 9: a high failure count whose backoff overflows is clamped to MAX ---
+
+echo "Test: an overflowing backoff is clamped to MAX (never a past/immediate epoch)"
+tr_setup
+# A large CAP lets COUNT climb high before escalation. Seed count=55 (→56):
+# BASE * (1 << 55) overflows the 64-bit signed left-shift to a negative value,
+# which the bare `> MAX` guard would pass through as a past RESEED_AT (firing
+# the timer immediately). The clamp must instead pin BACKOFF to MAX (3600) →
+# reseed_at = NOW + 3600 = 1003600.
+export DISPATCH_TICK_RECOVER_CAP=100
+tr_seed_state 55 999500
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "overflow-clamp: dispatch-tick-recover exits 0" "0" "$rc"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$log" == *"--on-calendar=@1003600"* \
+   && "$log" == *"--unit=dispatch-reseed-1003600"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: overflow-clamp: backoff clamped to MAX, reseed at NOW + 3600"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: overflow-clamp: backoff clamped to MAX, reseed at NOW + 3600"
+  echo "    log: $log"
+fi
+tr_teardown
+
 # ============================================================================
 # dispatch-spawn-worker tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -8450,6 +8450,18 @@ echo "\$*" >> "$TMPDIR_TEST/systemd-log"
 STUB
   chmod +x "$TMPDIR_TEST/bin/systemd-run"
   export DISPATCH_SCHEDULE_RESEED_SYSTEMD_RUN_CMD="$TMPDIR_TEST/bin/systemd-run"
+
+  # dispatch-schedule-reseed now calls ensure_recover_unit (lib.sh), which
+  # without isolation would write to the real ~/.config/systemd/user/ and run a
+  # real `systemctl --user daemon-reload`. Redirect the unit dir into the tmp
+  # tree and point its systemctl at a no-op stub so daemon-reload is harmless.
+  cat > "$TMPDIR_TEST/bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/systemctl"
+  export DISPATCH_RECOVER_UNIT_DIR="$TMPDIR_TEST/systemd-user"
+  export DISPATCH_RECOVER_SYSTEMCTL_CMD="$TMPDIR_TEST/bin/systemctl"
 }
 
 sr_teardown() {
@@ -8467,6 +8479,7 @@ sr_teardown() {
   unset DISPATCH_SCHEDULE_RESEED_SYSTEMD_RUN_CMD
   unset DISPATCH_SCHEDULE_RESEED_TARGET_WORKERS_CMD
   unset DISPATCH_SCHEDULE_RESEED_SHORT_DELAY
+  unset DISPATCH_RECOVER_UNIT_DIR DISPATCH_RECOVER_SYSTEMCTL_CMD
 }
 
 # sr_write_rl <file-name> <used_weekly> <resets_weekly> <used_5h> <resets_5h>
@@ -8509,12 +8522,14 @@ log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--unit=dispatch-reseed-20000"* \
    && "$log" == *"--on-calendar=@20000"* \
+   && "$log" == *"--collect"* \
+   && "$log" == *"--property=OnFailure=dispatch-tick-recover.service"* \
    && "$log" == *"--working-directory=$TMPDIR_TEST/main"* \
    && "$log" == *"--setenv=PATH="* \
    && "$log" == *"$TMPDIR_TEST/main/.claude/skills/dispatch-propagate/scripts/dispatch-tick"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: weekly cap-hit systemd-run argv (unit + calendar + cwd + setenv + exec)"
+  PASS=$((PASS + 1)); echo "  PASS: weekly cap-hit systemd-run argv (unit + calendar + collect + OnFailure + cwd + setenv + exec)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: weekly cap-hit systemd-run argv (unit + calendar + cwd + setenv + exec)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: weekly cap-hit systemd-run argv (unit + calendar + collect + OnFailure + cwd + setenv + exec)"
   echo "    log: $log"
 fi
 sr_teardown
@@ -9715,6 +9730,18 @@ STUB
 
   export DISPATCH_SPAWN_TICK_SYSTEMD_RUN_CMD="$TMPDIR_TEST/bin/systemd-run"
   export DISPATCH_SPAWN_TICK_MAIN_WORKTREE="$TMPDIR_TEST/main"
+
+  # dispatch-spawn-tick now calls ensure_recover_unit (lib.sh), which without
+  # isolation would write to the real ~/.config/systemd/user/ and run a real
+  # `systemctl --user daemon-reload`. Redirect the unit dir into the tmp tree
+  # and point its systemctl at a no-op stub so daemon-reload is harmless.
+  cat > "$TMPDIR_TEST/bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/systemctl"
+  export DISPATCH_RECOVER_UNIT_DIR="$TMPDIR_TEST/systemd-user"
+  export DISPATCH_RECOVER_SYSTEMCTL_CMD="$TMPDIR_TEST/bin/systemctl"
 }
 
 st_teardown() {
@@ -9722,6 +9749,7 @@ st_teardown() {
   TMPDIR_TEST=""
   unset DISPATCH_SPAWN_TICK_SYSTEMD_RUN_CMD
   unset DISPATCH_SPAWN_TICK_MAIN_WORKTREE
+  unset DISPATCH_RECOVER_UNIT_DIR DISPATCH_RECOVER_SYSTEMCTL_CMD
 }
 
 # --- Test 1: no-arg launch → spawned, exit 0, correct argv -------------------
@@ -9735,12 +9763,13 @@ log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--unit=dispatch-tick"* \
    && "$log" == *"--collect"* \
+   && "$log" == *"--property=OnFailure=dispatch-tick-recover.service"* \
    && "$log" == *"--working-directory=$TMPDIR_TEST/main"* \
    && "$log" == *"--setenv=PATH="* \
    && "$log" == *"$TMPDIR_TEST/main/.claude/skills/dispatch-propagate/scripts/dispatch-tick"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: no-arg systemd-run argv (unit + collect + cwd + setenv + exec)"
+  PASS=$((PASS + 1)); echo "  PASS: no-arg systemd-run argv (unit + collect + OnFailure + cwd + setenv + exec)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: no-arg systemd-run argv (unit + collect + cwd + setenv + exec)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: no-arg systemd-run argv (unit + collect + OnFailure + cwd + setenv + exec)"
   echo "    log: $log"
 fi
 # No trailing numeric arg in the no-arg case: the exec path must be the LAST
@@ -9765,10 +9794,11 @@ assert_eq "target: stdout is 'spawned'" "spawned" "$out"
 log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--unit=dispatch-tick-979"* \
+   && "$log" == *"--property=OnFailure=dispatch-tick-recover.service"* \
    && "$log" == *"$TMPDIR_TEST/main/.claude/skills/dispatch-propagate/scripts/dispatch-tick 979"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: target systemd-run argv (unit=dispatch-tick-979 + exec path 979)"
+  PASS=$((PASS + 1)); echo "  PASS: target systemd-run argv (unit=dispatch-tick-979 + OnFailure + exec path 979)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: target systemd-run argv (unit=dispatch-tick-979 + exec path 979)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: target systemd-run argv (unit=dispatch-tick-979 + OnFailure + exec path 979)"
   echo "    log: $log"
 fi
 st_teardown
@@ -9829,6 +9859,265 @@ else
   echo "    log: $(cat "$TMPDIR_TEST/systemd-log")"
 fi
 st_teardown
+
+# ============================================================================
+# dispatch-tick-recover tests (#1150)
+# ============================================================================
+echo ""
+echo "=== dispatch-tick-recover ==="
+#
+# dispatch-tick-recover is the OnFailure= handler that guarantees a chain
+# continuation after an abnormal tick/reseed exit. It is exercised entirely
+# against fakes wired through its env-override contract — no real systemd,
+# systemctl, gh, or claude daemon is needed:
+#
+#   $TMPDIR_TEST/bin/systemd-run   records its argv (one line per call) to
+#                                  $TMPDIR_TEST/systemd-log, exits 0.
+#   $TMPDIR_TEST/bin/systemctl     `list-units` prints the contents of
+#                                  $TMPDIR_TEST/timer-units (empty by default →
+#                                  no pending dispatch-reseed* timer).
+#   $TMPDIR_TEST/bin/claude        `agents --json` prints the contents of
+#                                  $TMPDIR_TEST/agents.json (`[]` by default →
+#                                  0 busy workers). Backs CLAUDE_AGENTS_CMD.
+#   $TMPDIR_TEST/bin/gh            logs its argv to $TMPDIR_TEST/gh-log; an
+#                                  `issue list ... -q '.[0].number'` prints the
+#                                  contents of $TMPDIR_TEST/gh-existing (empty by
+#                                  default → no open latch issue).
+#
+# Each test seeds state by writing the JSON state file first (where needed),
+# invokes the REAL dispatch-tick-recover with the section env, then asserts on
+# the systemd-run log / gh log / resulting state file (count read via jq).
+#
+# The test shell runs under `set -e`; dispatch-tick-recover always exits 0 on
+# these paths, but each invocation is still wrapped to capture the code.
+
+tr_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/bin" "$TMPDIR_TEST/main"
+
+  # systemd-run fake: record argv, exit 0.
+  cat > "$TMPDIR_TEST/bin/systemd-run" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/systemd-log"
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/systemd-run"
+
+  # systemctl fake: `list-units` prints \$TMPDIR_TEST/timer-units (default empty
+  # → no pending dispatch-reseed* timer). Any other subcommand is a no-op exit 0.
+  : > "$TMPDIR_TEST/timer-units"
+  cat > "$TMPDIR_TEST/bin/systemctl" <<STUB
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [[ "\$a" == "list-units" ]]; then
+    cat "$TMPDIR_TEST/timer-units"
+    exit 0
+  fi
+done
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/systemctl"
+
+  # claude fake (backs CLAUDE_AGENTS_CMD via lib-claude-agents.sh): `agents --json`
+  # prints \$TMPDIR_TEST/agents.json (default `[]` → 0 busy workers).
+  echo '[]' > "$TMPDIR_TEST/agents.json"
+  cat > "$TMPDIR_TEST/bin/claude" <<STUB
+#!/usr/bin/env bash
+cat "$TMPDIR_TEST/agents.json"
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/claude"
+
+  # gh fake: log argv; an `issue list ... -q '.[0].number'` prints
+  # \$TMPDIR_TEST/gh-existing (default empty → no open latch issue). Other
+  # subcommands (issue create, label create) just log and exit 0.
+  : > "$TMPDIR_TEST/gh-existing"
+  cat > "$TMPDIR_TEST/bin/gh" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/gh-log"
+if [[ "\$1" == "issue" && "\$2" == "list" ]]; then
+  cat "$TMPDIR_TEST/gh-existing"
+fi
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/gh"
+
+  export DISPATCH_TICK_RECOVER_SYSTEMD_RUN_CMD="$TMPDIR_TEST/bin/systemd-run"
+  export DISPATCH_TICK_RECOVER_SYSTEMCTL_CMD="$TMPDIR_TEST/bin/systemctl"
+  export DISPATCH_TICK_RECOVER_GH_CMD="$TMPDIR_TEST/bin/gh"
+  export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/bin/claude"
+  export DISPATCH_TICK_RECOVER_MAIN_WORKTREE="$TMPDIR_TEST/main"
+  export DISPATCH_TICK_RECOVER_STATE_PATH="$TMPDIR_TEST/recover-state.json"
+  export DISPATCH_TICK_RECOVER_NOW=1000000
+  # Pin every tunable so the backoff/cap/reset arithmetic is deterministic.
+  export DISPATCH_TICK_RECOVER_CAP=3
+  export DISPATCH_TICK_RECOVER_BASE_BACKOFF=300
+  export DISPATCH_TICK_RECOVER_MAX_BACKOFF=3600
+  export DISPATCH_TICK_RECOVER_RESET_WINDOW=3600
+}
+
+tr_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  unset DISPATCH_TICK_RECOVER_SYSTEMD_RUN_CMD
+  unset DISPATCH_TICK_RECOVER_SYSTEMCTL_CMD
+  unset DISPATCH_TICK_RECOVER_GH_CMD
+  unset CLAUDE_AGENTS_CMD
+  unset DISPATCH_TICK_RECOVER_MAIN_WORKTREE
+  unset DISPATCH_TICK_RECOVER_STATE_PATH
+  unset DISPATCH_TICK_RECOVER_NOW
+  unset DISPATCH_TICK_RECOVER_CAP
+  unset DISPATCH_TICK_RECOVER_BASE_BACKOFF
+  unset DISPATCH_TICK_RECOVER_MAX_BACKOFF
+  unset DISPATCH_TICK_RECOVER_RESET_WINDOW
+}
+
+# tr_seed_state <count> <last_failure> — write the consecutive-failure state.
+tr_seed_state() {
+  printf '{"count":%s,"last_failure":%s}\n' "$1" "$2" > "$TMPDIR_TEST/recover-state.json"
+}
+
+# tr_busy_worker — make the claude fake report one busy real worker.
+tr_busy_worker() {
+  echo '[{"sessionId":"a","pid":1,"status":"busy","name":"824-foo"}]' \
+    > "$TMPDIR_TEST/agents.json"
+}
+
+# tr_state_count — print the count field of the resulting state file (or "none").
+tr_state_count() {
+  if [[ -r "$TMPDIR_TEST/recover-state.json" ]]; then
+    jq -r '.count' "$TMPDIR_TEST/recover-state.json"
+  else
+    echo none
+  fi
+}
+
+# --- Test 1: first failure, no continuation → arms a reseed ------------------
+
+echo "Test: first failure with no continuation arms a bounded-backoff reseed"
+tr_setup
+# No state file, empty timer list, 0 busy workers → fresh episode, count 0→1,
+# backoff = BASE * 2^0 = 300, reseed_at = NOW + 300 = 1000300.
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "first-fail: dispatch-tick-recover exits 0" "0" "$rc"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$log" == *"--on-calendar=@1000300"* \
+   && "$log" == *"--unit=dispatch-reseed-1000300"* \
+   && "$log" == *"--collect"* \
+   && "$log" == *"$TMPDIR_TEST/main/.claude/skills/dispatch-propagate/scripts/dispatch-tick"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: first-fail systemd-run argv (calendar + unit + collect + exec)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: first-fail systemd-run argv (calendar + unit + collect + exec)"
+  echo "    log: $log"
+fi
+assert_eq "first-fail: state count == 1" "1" "$(tr_state_count)"
+tr_teardown
+
+# --- Test 2: continuation present (busy worker) → no reseed, count reset -----
+
+echo "Test: a live busy worker is a continuation → no reseed, count reset to 0"
+tr_setup
+tr_busy_worker
+tr_seed_state 2 999000
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "busy-worker: dispatch-tick-recover exits 0" "0" "$rc"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+assert_eq "busy-worker: no reseed armed (systemd-run log empty)" "" "$log"
+assert_eq "busy-worker: state count reset to 0" "0" "$(tr_state_count)"
+tr_teardown
+
+# --- Test 3: continuation present (pending dispatch-reseed* timer) → no reseed -
+
+echo "Test: a pending dispatch-reseed* timer is a continuation → no reseed armed"
+tr_setup
+# A pending reseed timer row drives the continuation signal; 0 busy workers.
+printf 'dispatch-reseed-1234.timer  active  waiting  Dispatch reseed\n' \
+  > "$TMPDIR_TEST/timer-units"
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "pending-timer: dispatch-tick-recover exits 0" "0" "$rc"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+assert_eq "pending-timer: no reseed armed (systemd-run log empty)" "" "$log"
+tr_teardown
+
+# --- Test 4: cap reached → escalate, not retry -------------------------------
+
+echo "Test: count past the cap escalates (files a chain-stalled latch issue), no reseed"
+tr_setup
+# Seed count == CAP (3) with a recent last_failure (within RESET_WINDOW so no
+# reset) → count 3→4 > cap=3 → escalate. No existing latch issue (gh-existing
+# empty) → an issue create fires.
+tr_seed_state 3 999500
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "cap: dispatch-tick-recover exits 0" "0" "$rc"
+ghlog=$(cat "$TMPDIR_TEST/gh-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$ghlog" == *"issue create"* && "$ghlog" == *"--label dispatch:chain-stalled"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: cap: gh issue create with --label dispatch:chain-stalled"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: cap: gh issue create with --label dispatch:chain-stalled"
+  echo "    gh-log: $ghlog"
+fi
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+assert_eq "cap: no reseed armed (systemd-run log empty)" "" "$log"
+
+# --- Test 4b: cap reached with an existing latch → no-op create --------------
+echo "Test: count past the cap with an open latch issue does NOT create a second"
+tr_teardown
+tr_setup
+tr_seed_state 3 999500
+echo "742" > "$TMPDIR_TEST/gh-existing"   # an open latch already exists
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "cap-latched: dispatch-tick-recover exits 0" "0" "$rc"
+ghlog=$(cat "$TMPDIR_TEST/gh-log" 2>/dev/null || true)
+assert_eq "cap-latched: no issue create (latch already open)" \
+  "0" "$([[ "$ghlog" != *"issue create"* ]] && echo 0 || echo 1)"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+assert_eq "cap-latched: no reseed armed (systemd-run log empty)" "" "$log"
+tr_teardown
+
+# --- Test 5: backoff grows with the consecutive-failure count ----------------
+
+echo "Test: backoff doubles with the failure count (count 1→2 → BASE*2 = 600)"
+tr_setup
+# Seed count == 1 with a recent last_failure → no reset, count 1→2, backoff =
+# BASE * 2^(2-1) = 600, reseed_at = NOW + 600 = 1000600.
+tr_seed_state 1 999500
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "backoff: dispatch-tick-recover exits 0" "0" "$rc"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$log" == *"--on-calendar=@1000600"* \
+   && "$log" == *"--unit=dispatch-reseed-1000600"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: backoff: reseed armed at NOW + 600 (calendar + unit)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: backoff: reseed armed at NOW + 600 (calendar + unit)"
+  echo "    log: $log"
+fi
+assert_eq "backoff: state count == 2" "2" "$(tr_state_count)"
+tr_teardown
+
+# --- Test 6: reset window — a stale last_failure starts a fresh episode -------
+
+echo "Test: a last_failure older than RESET_WINDOW resets the count to a fresh episode"
+tr_setup
+# last_failure = NOW - 4000 (= 996000); NOW - last_failure = 4000 > RESET_WINDOW
+# (3600) → fresh episode: count reset 2→0, then +1 = 1, backoff = BASE*2^0 = 300,
+# reseed_at = NOW + 300 = 1000300.
+tr_seed_state 2 996000
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "reset-window: dispatch-tick-recover exits 0" "0" "$rc"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$log" == *"--on-calendar=@1000300"* \
+   && "$log" == *"--unit=dispatch-reseed-1000300"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: reset-window: fresh episode armed at NOW + 300"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: reset-window: fresh episode armed at NOW + 300"
+  echo "    log: $log"
+fi
+assert_eq "reset-window: state count == 1 (fresh episode)" "1" "$(tr_state_count)"
+tr_teardown
 
 # ============================================================================
 # dispatch-spawn-worker tests


### PR DESCRIPTION
Closes #1150

## Summary

The headless dispatch tick carries the chain forward only via (1) a spawned
worker's Stop hook or (2) an armed `dispatch-reseed*` timer — both produced
**only after a successful selection**. A tick that aborts before that point
(e.g. the 2026-06-05 transient GitHub 504 in the selection path) leaves no
continuation and no visible signal. The #1010 continuation invariant lives in
`dispatch-self-close`, which no-ops for a `systemd-run` unit (no
`CLAUDE_JOB_DIR`), so it never protected the headless tick.

This adds the systemd-native guarantee: an **edge-triggered `OnFailure=`
handler** on the tick/reseed `systemd-run` units. `OnFailure=` is owned by
systemd and fires exactly when a unit fails — unskippable by a crashing tick,
with zero steady-state cost (the periodic-heartbeat alternative was rejected in
#1010).

## What changed

- **`lib.sh`: `ensure_recover_unit <main-worktree>`** — `OnFailure=` references a
  loadable unit file, but dispatch uses only transient `systemd-run` units. This
  best-effort helper idempotently installs a static
  `dispatch-tick-recover.service` (write-if-changed + `daemon-reload` only on
  change; the steady-state hot path is one content compare). No `OnFailure=` on
  the recover unit itself — avoids recovery recursion.

- **`dispatch-tick-recover` (new)** — the handler. Its decision is driven by
  **live system state**, not which unit failed:
  - If a continuation already exists (a pending `dispatch-reseed*` timer **or** a
    live busy worker), reset the consecutive-failure count and no-op. A daemon
    UNKNOWN is treated as no worker — fail toward *guaranteeing* a continuation;
    a redundant reseed is absorbed by dispatch's per-worktree dedup + concurrency
    gate.
  - Otherwise arm a bounded-backoff reseed at `now + min(BASE·2^(count-1), MAX)`,
    named `dispatch-reseed-<epoch>` so it is itself recognized as a continuation
    and is idempotent by epoch. It arms a **no-arg** `dispatch-tick`
    (re-evaluates the whole queue, rather than re-keying the failed target).
  - Past a cap (default 3) consecutive failures, **escalate instead of looping**:
    find-or-create one open `dispatch:chain-stalled` latch issue (labels
    `dispatch:chain-stalled` + `bug` + `priority`), naming the failed unit /
    exit status from systemd's `$MONITOR_UNIT` / `$MONITOR_EXIT_STATUS` and the
    `dispatch` resume hint. A stale `last_failure` (older than `RESET_WINDOW`,
    default 3600s) starts a fresh episode.

- **Launchers** — `dispatch-spawn-tick` (both `systemd-run` branches) and
  `dispatch-schedule-reseed` now launch their transient unit with
  `--property=OnFailure=dispatch-tick-recover.service`, calling
  `ensure_recover_unit` first (best-effort; `OnFailure=` resolves lazily at
  failure time, so passing it is safe even if the ensure failed). Also adds
  `--collect` to `dispatch-schedule-reseed` so a failed reseed unit does not
  linger in systemd's `failed` state (mirroring `dispatch-spawn-tick`).

- **Tests** — a new `dispatch-tick-recover` section covers: arms a reseed on
  first failure with no continuation; no-ops + resets when a continuation is
  present (busy worker, and pending `dispatch-reseed*` timer); cap reached →
  escalate via the latch issue (and no second create when one is already open);
  backoff growth; reset-window fresh episode. Existing launcher tests now assert
  `OnFailure=` on both launchers and `--collect` on the reseed launcher, and are
  isolated from real systemd via the `DISPATCH_RECOVER_*` env stubs. Full suite:
  1743/1743 passing.

## Acceptance criteria

- [x] `dispatch-spawn-tick` + `dispatch-schedule-reseed` launch with
  `OnFailure=dispatch-tick-recover.service`.
- [x] Tick fails, no pending `dispatch-reseed*` timer + no live busy worker →
  recover arms a bounded-backoff reseed.
- [x] Consecutive failures past the cap (default 3) → escalate, stop auto-retry.
- [x] `dispatch-schedule-reseed`'s `systemd-run` passes `--collect`.
- [x] `test-dispatch-scripts.sh` covers arm-on-first-failure, cap→escalate,
  `--collect` present.

The fakes exercise the argv/decision logic; the live `OnFailure=` firing is a
runtime-only behavior the unit tests deliberately don't drive.
