### PR TITLE
testing: scope deployed smoke tests to hosting-edge verification

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/run-smoke-tests.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-smoke-tests.sh
@@ -41,4 +41,4 @@ if [ -z "${PLAYWRIGHT_BROWSERS_PATH:-}" ]; then
 fi
 
 # Run smoke tests
-BASE_URL="$BASE_URL" npx playwright test --config e2e/playwright.config.ts --grep @smoke
+BASE_URL="$BASE_URL" npx playwright test --config e2e/playwright.config.ts --grep @hosting --project=desktop

--- a/audio/e2e/reachability-smoke.spec.ts
+++ b/audio/e2e/reachability-smoke.spec.ts
@@ -1,0 +1,2 @@
+import { describeReachabilitySmoke } from "@commons-systems/config/reachability-smoke";
+describeReachabilitySmoke("audio", { staticAssetPath: "/robots.txt" });

--- a/budget/e2e/reachability-smoke.spec.ts
+++ b/budget/e2e/reachability-smoke.spec.ts
@@ -1,0 +1,2 @@
+import { describeReachabilitySmoke } from "@commons-systems/config/reachability-smoke";
+describeReachabilitySmoke("budget", { staticAssetPath: "/robots.txt" });

--- a/config/cache-headers-smoke.ts
+++ b/config/cache-headers-smoke.ts
@@ -1,30 +1,19 @@
 import { test, expect } from "./playwright-test";
+import { getEntryAsset } from "./hosting-smoke-helpers";
 
-export function describeCacheHeadersSmoke(appName: string): void {
+export function describeCacheHeadersSmoke(
+  appName: string,
+  options?: { imagePath?: string },
+): void {
   test.describe(`${appName} cache headers smoke`, () => {
-    test("hashed assets have immutable cache-control @smoke @hosting", async ({
-      page,
+    test("hashed assets have immutable cache-control @hosting", async ({
+      request,
     }) => {
-      const response = await page.goto("/");
-      expect(response).not.toBeNull();
-      expect(response!.status()).toBe(200);
+      const { entryAssetUrl } = await getEntryAsset(request);
 
-      const assetUrl = await page.evaluate(() => {
-        const el =
-          document.querySelector('script[src^="/assets/"]') ??
-          document.querySelector('link[rel="stylesheet"][href^="/assets/"]');
-        if (!el) return null;
-        return el.getAttribute("src") ?? el.getAttribute("href");
-      });
-      expect(
-        assetUrl,
-        "No script[src^='/assets/'] or stylesheet[href^='/assets/'] found on page",
-      ).not.toBeNull();
-
-      const assetResponse = await page.goto(assetUrl!);
-      expect(assetResponse).not.toBeNull();
-      expect(assetResponse!.status()).toBe(200);
-      const cacheControl = assetResponse!.headers()["cache-control"];
+      const assetResponse = await request.head(entryAssetUrl);
+      expect(assetResponse.status()).toBe(200);
+      const cacheControl = assetResponse.headers()["cache-control"];
       expect(
         cacheControl,
         "cache-control header missing from asset response",
@@ -32,30 +21,18 @@ export function describeCacheHeadersSmoke(appName: string): void {
       expect(cacheControl).toContain("public, max-age=31536000, immutable");
     });
 
-    test("images have yearly cache-control @smoke @hosting", async ({ page }) => {
-      const response = await page.goto("/");
-      expect(response).not.toBeNull();
-      expect(response!.status()).toBe(200);
-
-      const imageUrl = await page.evaluate(() => {
-        const img = document.querySelector('img[src^="/"]');
-        if (!img) return null;
-        return img.getAttribute("src");
+    if (options?.imagePath) {
+      const imagePath = options.imagePath;
+      test("images have yearly cache-control @hosting", async ({ request }) => {
+        const imageResponse = await request.head(imagePath);
+        expect(imageResponse.status()).toBe(200);
+        const imgCacheControl = imageResponse.headers()["cache-control"];
+        expect(
+          imgCacheControl,
+          "cache-control header missing from image response",
+        ).toBeDefined();
+        expect(imgCacheControl).toContain("public, max-age=31536000");
       });
-      test.skip(
-        !imageUrl,
-        "No <img src='/...'> element on page -- nothing to verify",
-      );
-
-      const imageResponse = await page.goto(imageUrl!);
-      expect(imageResponse).not.toBeNull();
-      expect(imageResponse!.status()).toBe(200);
-      const imgCacheControl = imageResponse!.headers()["cache-control"];
-      expect(
-        imgCacheControl,
-        "cache-control header missing from image response",
-      ).toBeDefined();
-      expect(imgCacheControl).toContain("public, max-age=31536000");
-    });
+    }
   });
 }

--- a/config/hosting-smoke-helpers.ts
+++ b/config/hosting-smoke-helpers.ts
@@ -1,0 +1,35 @@
+import type { APIRequestContext, APIResponse } from "@playwright/test";
+
+/**
+ * Discover the content-hashed entry asset from the deployed index HTML.
+ *
+ * The hashed asset filename is unknowable from the URL, so this performs the
+ * one unavoidable small-body GET of `/`. The index response is returned so
+ * callers can reuse it (e.g. to assert the index's own headers) without a
+ * second fetch.
+ */
+export async function getEntryAsset(
+  request: APIRequestContext,
+): Promise<{ indexResponse: APIResponse; entryAssetUrl: string }> {
+  const indexResponse = await request.get("/");
+  if (indexResponse.status() !== 200) {
+    throw new Error(
+      `GET / returned status ${indexResponse.status()}, expected 200`,
+    );
+  }
+
+  const html = await indexResponse.text();
+
+  const scriptMatch = html.match(/src="(\/assets\/[^"]+\.js)"/);
+  const styleMatch = html.match(/href="(\/assets\/[^"]+\.css)"/);
+  const entryAssetUrl = scriptMatch?.[1] ?? styleMatch?.[1];
+
+  if (!entryAssetUrl) {
+    throw new Error(
+      'No content-hashed entry asset found in index HTML: searched for a ' +
+        'script src="/assets/*.js" then a stylesheet href="/assets/*.css"',
+    );
+  }
+
+  return { indexResponse, entryAssetUrl };
+}

--- a/config/package.json
+++ b/config/package.json
@@ -17,6 +17,8 @@
     "./firebase-headers.test-helper": "./firebase-headers.test-helper.ts",
     "./cache-headers-smoke": "./cache-headers-smoke.ts",
     "./security-headers-smoke": "./security-headers-smoke.ts",
+    "./reachability-smoke": "./reachability-smoke.ts",
+    "./hosting-smoke-helpers": "./hosting-smoke-helpers.ts",
     "./playwright-test": "./playwright-test.ts"
   }
 }

--- a/config/reachability-smoke.ts
+++ b/config/reachability-smoke.ts
@@ -12,7 +12,6 @@ export function describeReachabilitySmoke(
   test.describe(`${appName} reachability smoke`, () => {
     test("key paths are reachable @hosting", async ({ request }) => {
       const { indexResponse, entryAssetUrl } = await getEntryAsset(request);
-      expect(indexResponse.status()).toBe(200);
       expect(indexResponse.headers()["content-type"]).toContain("text/html");
 
       const assetResponse = await request.head(entryAssetUrl);

--- a/config/reachability-smoke.ts
+++ b/config/reachability-smoke.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "./playwright-test";
+import { getEntryAsset } from "./hosting-smoke-helpers";
+
+export function describeReachabilitySmoke(
+  appName: string,
+  options?: {
+    staticAssetPath?: string;
+    staticAssetContentType?: string;
+    feedXml?: boolean;
+  },
+): void {
+  test.describe(`${appName} reachability smoke`, () => {
+    test("key paths are reachable @hosting", async ({ request }) => {
+      const { indexResponse, entryAssetUrl } = await getEntryAsset(request);
+      expect(indexResponse.status()).toBe(200);
+      expect(indexResponse.headers()["content-type"]).toContain("text/html");
+
+      const assetResponse = await request.head(entryAssetUrl);
+      expect(assetResponse.status()).toBe(200);
+      expect(assetResponse.headers()["content-type"]).toContain("javascript");
+
+      if (options?.staticAssetPath) {
+        const staticResponse = await request.head(options.staticAssetPath);
+        expect(staticResponse.status()).toBe(200);
+        expect(staticResponse.headers()["content-type"]).toContain(
+          options.staticAssetContentType ?? "text/plain",
+        );
+      }
+
+      if (options?.feedXml) {
+        const feedResponse = await request.head("/feed.xml");
+        expect(feedResponse.status()).toBe(200);
+        expect(feedResponse.headers()["content-type"]).toContain("xml");
+      }
+    });
+  });
+}

--- a/config/security-headers-smoke.ts
+++ b/config/security-headers-smoke.ts
@@ -9,6 +9,7 @@ const expectedHeaders: {
     assert: (v) => {
       expect(v).toContain("default-src");
       expect(v).toContain("script-src");
+      expect(v).toContain("frame-ancestors");
     },
   },
   {
@@ -34,14 +35,17 @@ const expectedHeaders: {
 
 export function describeSecurityHeadersSmoke(appName: string): void {
   test.describe(`${appName} security headers smoke`, () => {
-    for (const { header, assert } of expectedHeaders) {
-      test(`page response includes ${header} @smoke @hosting`, async ({ page }) => {
-        const response = await page.goto("/");
-        expect(response).not.toBeNull();
-        const value = response!.headers()[header];
+    test(`response includes security headers @hosting`, async ({ request }) => {
+      const response = await request.head("/");
+      expect(response).toBeTruthy();
+      expect(response.status()).toBe(200);
+
+      const headers = response.headers();
+      for (const { header, assert } of expectedHeaders) {
+        const value = headers[header];
         expect(value, `${header} header missing`).toBeDefined();
         assert(value);
-      });
-    }
+      }
+    });
   });
 }

--- a/config/security-headers-smoke.ts
+++ b/config/security-headers-smoke.ts
@@ -37,7 +37,6 @@ export function describeSecurityHeadersSmoke(appName: string): void {
   test.describe(`${appName} security headers smoke`, () => {
     test(`response includes security headers @hosting`, async ({ request }) => {
       const response = await request.head("/");
-      expect(response).toBeTruthy();
       expect(response.status()).toBe(200);
 
       const headers = response.headers();

--- a/fellspiral/e2e/cache-headers-smoke.spec.ts
+++ b/fellspiral/e2e/cache-headers-smoke.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from "@commons-systems/config/playwright-test";
 import { describeCacheHeadersSmoke } from "@commons-systems/config/cache-headers-smoke";
 
-describeCacheHeadersSmoke("fellspiral");
+describeCacheHeadersSmoke("fellspiral", { imagePath: "/blog-map-color.webp" });
 
 test.describe("fellspiral extra cache headers smoke", () => {
-  test("fonts have yearly cache-control @smoke @hosting", async ({ request }) => {
-    const fontResponse = await request.get(
+  test("fonts have yearly cache-control @hosting", async ({ request }) => {
+    const fontResponse = await request.head(
       "/fonts/eb-garamond-latin-400-normal.woff2",
     );
     expect(

--- a/fellspiral/e2e/reachability-smoke.spec.ts
+++ b/fellspiral/e2e/reachability-smoke.spec.ts
@@ -1,0 +1,2 @@
+import { describeReachabilitySmoke } from "@commons-systems/config/reachability-smoke";
+describeReachabilitySmoke("fellspiral", { staticAssetPath: "/robots.txt", feedXml: true });

--- a/fellspiral/e2e/security-headers.spec.ts
+++ b/fellspiral/e2e/security-headers.spec.ts
@@ -1,51 +1,6 @@
 import { test, expect } from "@commons-systems/config/playwright-test";
 
 test.describe("security headers", () => {
-  test("content-security-policy includes key directives @hosting", async ({ page }) => {
-    const response = await page.goto("/");
-    expect(response).not.toBeNull();
-    expect(response!.status()).toBe(200);
-
-    const csp = response!.headers()["content-security-policy"];
-    expect(csp, "content-security-policy header missing from response").toBeDefined();
-    expect(csp).toContain("default-src");
-    expect(csp).toContain("script-src");
-    expect(csp).toContain("frame-ancestors");
-  });
-
-  test("cross-origin-opener-policy is same-origin @hosting", async ({ page }) => {
-    const response = await page.goto("/");
-    expect(response).not.toBeNull();
-    expect(response!.status()).toBe(200);
-
-    const coop = response!.headers()["cross-origin-opener-policy"];
-    expect(coop, "cross-origin-opener-policy header missing from response").toBeDefined();
-    expect(coop).toBe("same-origin");
-  });
-
-  test("x-frame-options is DENY @hosting", async ({ page }) => {
-    const response = await page.goto("/");
-    expect(response).not.toBeNull();
-    expect(response!.status()).toBe(200);
-
-    const xfo = response!.headers()["x-frame-options"];
-    expect(xfo, "x-frame-options header missing from response").toBeDefined();
-    expect(xfo).toBe("DENY");
-  });
-
-  test("strict-transport-security includes includeSubDomains and preload @hosting", async ({
-    page,
-  }) => {
-    const response = await page.goto("/");
-    expect(response).not.toBeNull();
-    expect(response!.status()).toBe(200);
-
-    const hsts = response!.headers()["strict-transport-security"];
-    expect(hsts, "strict-transport-security header missing from response").toBeDefined();
-    expect(hsts).toContain("includeSubDomains");
-    expect(hsts).toContain("preload");
-  });
-
   test("no CSP violation errors in console", async ({ page }) => {
     const cspViolations: string[] = [];
     // The emulator connects to localhost for Firestore and Auth, which

--- a/landing/e2e/cache-headers-smoke.spec.ts
+++ b/landing/e2e/cache-headers-smoke.spec.ts
@@ -1,3 +1,3 @@
 import { describeCacheHeadersSmoke } from "@commons-systems/config/cache-headers-smoke";
 
-describeCacheHeadersSmoke("landing");
+describeCacheHeadersSmoke("landing", { imagePath: "/og-card.png" });

--- a/landing/e2e/reachability-smoke.spec.ts
+++ b/landing/e2e/reachability-smoke.spec.ts
@@ -1,0 +1,2 @@
+import { describeReachabilitySmoke } from "@commons-systems/config/reachability-smoke";
+describeReachabilitySmoke("landing", { staticAssetPath: "/robots.txt", feedXml: true });

--- a/office-hours/e2e/reachability-smoke.spec.ts
+++ b/office-hours/e2e/reachability-smoke.spec.ts
@@ -1,0 +1,2 @@
+import { describeReachabilitySmoke } from "@commons-systems/config/reachability-smoke";
+describeReachabilitySmoke("office-hours");

--- a/print/e2e/reachability-smoke.spec.ts
+++ b/print/e2e/reachability-smoke.spec.ts
@@ -1,0 +1,2 @@
+import { describeReachabilitySmoke } from "@commons-systems/config/reachability-smoke";
+describeReachabilitySmoke("print", { staticAssetPath: "/robots.txt" });


### PR DESCRIPTION
Closes #1159

## What

Scope the **deployed** smoke run (Playwright against Firebase Hosting preview/prod
URLs) down to the only thing that requires the deployed URL: **edge integration** —
confirming the deploy reached the CDN and the real edge honors the configured
headers and rewrites. The deployed run now executes a body-less `@hosting` edge set
on a single project instead of re-running the full `@smoke` suite across three
viewport projects.

Functional `@smoke` coverage does not disappear — the **emulator** acceptance run
(`run-acceptance-tests.sh`, no grep filter) already runs every `@smoke` and
`@hosting` test against the same built artifact with the same `firebase.json`
headers/rewrites, at zero egress. The deployed run was paying real CDN egress to
re-verify what the emulator already verifies. Egress per app drops from MBs to KBs.

## How

Three units:

1. **Shared `config/` describers, body-less and single-fetch.**
   - `security-headers-smoke.ts` — one `request.head("/")`, all five headers
     asserted off that single response (was a five-iteration `page.goto("/")` loop).
     Absorbs fellspiral's unique `frame-ancestors` check.
   - `cache-headers-smoke.ts` — immutable-asset and image `cache-control` verified
     via `request.head(...)`, no body downloaded. New `options.imagePath` gates the
     image test (apps without a deterministic static image omit it).
   - New `reachability-smoke.ts` — one `@hosting` test confirming `/`, the hashed
     entry asset, an optional static asset, and `feed.xml` (where present) return
     200 with the expected content-type, via HEAD.
   - New `hosting-smoke-helpers.ts` — `getEntryAsset()` does the one unavoidable
     small-body `GET /` to discover the content-hashed asset name (unknowable from
     the URL), and returns the index response for reuse.
   - All `@hosting`-tagged (dropped `@smoke`); `@hosting` is matched by both the
     deployed `--grep @hosting` run and the unfiltered emulator run.

2. **Per-app spec wiring.** A `reachability-smoke.spec.ts` in every app; `imagePath`
   passed for landing (`/og-card.png`) and fellspiral (`/blog-map-color.webp`);
   fellspiral's font cache check made body-less (HEAD); fellspiral's four redundant
   full-page `@hosting` header tests removed (now covered by the shared HEAD
   describer). The emulator-only "no CSP violation errors in console" functional
   test is kept. Functional `@smoke` specs are untouched.

3. **Deployed runner.** `run-smoke-tests.sh` now runs
   `--grep @hosting --project=desktop` instead of `--grep @smoke` — the edge set,
   once, not the full suite 3×.

## Verifiability tradeoff

The deployed run stops exercising app *function* end-to-end through a real browser
against the CDN. That coverage is preserved on the emulator acceptance run against
the same built artifact and `firebase.json`. The deployed run keeps the integration
guarantee that the deploy published and the real edge honors its config. No loss of
`@hosting` edge coverage (immutable-asset cache-control, yearly image/font
cache-control, CSP/HSTS/X-Frame-Options/COOP/nosniff) against the deployed URL.

## Verification

- Config package and changed apps type-check (local gate; full Playwright
  acceptance can't run locally — Nix chromium version mismatch).
- CI is the integration gate: the acceptance job runs the full suite (incl. all
  `@hosting` + reachability) against the emulator, confirming the rewritten HEAD
  describers pass against superstatic and functional `@smoke` coverage is intact;
  the preview-deploy-smoke job runs the reduced deployed set against the live
  preview URL at KB-scale egress.
