### PR TITLE
dispatch: run review-fix on Sonnet with fix-authoring on an Opus subagent

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -35,8 +35,8 @@
 # queue selection carries are still dropped — no sub-script consumes them. The
 # spawn does consult the phase, but the #1109-recomputed PHASE (Step 5), not the
 # carried positional: it maps PHASE → worker model via dispatch-phase-model so
-# the qa phase launches on Sonnet (#1171); every other phase yields no --model
-# and inherits the session default (Opus).
+# the qa and review phases launch on Sonnet (#1171, #1172); every other phase
+# yields no --model and inherits the session default (Opus).
 #
 # Terminal tokens (the last stdout line is always exactly one of):
 #   propagate              the worker spawned (or deduped); the chain advances.
@@ -351,10 +351,11 @@ process_one_target() {
   if ! reservation_write "$wt_basename" "$n" "${CLAUDE_CODE_SESSION_ID:-}" 1>&2; then
     echo "dispatch-materialize-spawn: reservation_write failed for $wt_basename; spawning without a ledger entry (budget may undercount this slot)" >&2
   fi
-  # Resolve the worker model from the #1109-recomputed PHASE (#1171): the
+  # Resolve the worker model from the #1109-recomputed PHASE (#1171, #1172): the
   # phase→model map (dispatch-phase-model) returns a non-empty model only for
-  # mapped phases (qa → claude-sonnet-4-6); every other phase yields empty, so
-  # no --model is forwarded and the worker inherits the session default (Opus).
+  # mapped phases (qa, review → claude-sonnet-4-6); every other phase yields
+  # empty, so no --model is forwarded and the worker inherits the session
+  # default (Opus).
   # The [[ -n "$PHASE" ]] guard avoids calling dispatch-phase-model with an empty
   # arg (its usage error) in the defensive case where dispatch-phase exited 3
   # (pending CI); in normal operation PHASE is non-empty here — queue targets are

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-phase-model
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-phase-model
@@ -40,10 +40,7 @@ fi
 PHASE="$1"
 
 case "$PHASE" in
-  qa)
-    echo "claude-sonnet-4-6"
-    ;;
-  review)
+  qa|review)
     echo "claude-sonnet-4-6"
     ;;
   *)

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-phase-model
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-phase-model
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # dispatch-phase-model — emit the claude model override for a given dispatch phase.
 #
-# Phase → model map (#1171):
-#   qa    → claude-sonnet-4-6   (no product-code authoring; machine-verifiable
-#                                checks + browser automation + summary writing)
-#   *     → (empty)             unmapped phases inherit the session default (Opus)
+# Phase → model map:
+#   qa     → claude-sonnet-4-6   (#1171: no product-code authoring; machine-verifiable
+#                                 checks + browser automation + summary writing)
+#   review → claude-sonnet-4-6   (#1172: the review-fix orchestrator authors no fixes —
+#                                 findings detection is on Sonnet review subagents and
+#                                 fix-authoring is delegated to an Opus subagent, so the
+#                                 orchestrator main chain runs on Sonnet)
+#   *      → (empty)             unmapped phases inherit the session default (Opus)
 #
 # Contract:
 #   EMPTY stdout means "omit the --model flag, inherit the session default (Opus)".
@@ -37,6 +41,9 @@ PHASE="$1"
 
 case "$PHASE" in
   qa)
+    echo "claude-sonnet-4-6"
+    ;;
+  review)
     echo "claude-sonnet-4-6"
     ;;
   *)

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -10911,8 +10911,13 @@ if pm_out=$("$SCRIPT_DIR/dispatch-phase-model" qa 2>/dev/null); then pm_rc=0; el
 assert_eq "phase-model: qa exits 0" "0" "$pm_rc"
 assert_eq "phase-model: qa → claude-sonnet-4-6" "claude-sonnet-4-6" "$pm_out"
 
+echo "Test: dispatch-phase-model maps review → claude-sonnet-4-6 (#1172)"
+if pm_out=$("$SCRIPT_DIR/dispatch-phase-model" review 2>/dev/null); then pm_rc=0; else pm_rc=$?; fi
+assert_eq "phase-model: review exits 0" "0" "$pm_rc"
+assert_eq "phase-model: review → claude-sonnet-4-6" "claude-sonnet-4-6" "$pm_out"
+
 echo "Test: dispatch-phase-model maps unmapped phases → empty (default → Opus, no override)"
-for ph in implement verify review done; do
+for ph in implement verify done; do
   if pm_out=$("$SCRIPT_DIR/dispatch-phase-model" "$ph" 2>/dev/null); then pm_rc=0; else pm_rc=$?; fi
   assert_eq "phase-model: $ph exits 0" "0" "$pm_rc"
   assert_eq "phase-model: $ph → empty (no --model, inherit Opus)" "" "$pm_out"
@@ -10925,6 +10930,22 @@ assert_eq "phase-model: no-arg → exit 2" "2" "$pm_rc"
 echo "Test: dispatch-phase-model with an empty-string arg exits 2"
 if "$SCRIPT_DIR/dispatch-phase-model" "" 2>/dev/null; then pm_rc=0; else pm_rc=$?; fi
 assert_eq "phase-model: empty-string-arg → exit 2" "2" "$pm_rc"
+
+# --- review-fix/SKILL.md model-tiering content guards (#1172) -----------------
+# The review-fix orchestrator runs on Sonnet; fix-authoring is delegated to an
+# Opus subagent and its /code-review pass is detection-only. Guard both facts so
+# a regression that re-introduces Sonnet-authored fixes (or a --fix /code-review)
+# is caught here.
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+RF_SKILL="$REPO_ROOT/.claude/skills/review-fix/SKILL.md"
+
+echo "Test: review-fix/SKILL.md pins fix-authoring to Opus (model: opus present)"
+if grep -q 'model: opus' "$RF_SKILL"; then rf_opus=yes; else rf_opus=no; fi
+assert_eq "review-fix: Opus fix-authoring pinned" "yes" "$rf_opus"
+
+echo "Test: review-fix/SKILL.md runs /code-review detection-only (no --fix)"
+if grep -q -- '/code-review max --fix' "$RF_SKILL"; then rf_fix=yes; else rf_fix=no; fi
+assert_eq "review-fix: no /code-review max --fix invocation" "no" "$rf_fix"
 
 # ============================================================================
 # dispatch-spawn-worker tests
@@ -18402,6 +18423,22 @@ assert_eq "implement-model: exit 0" "0" "$rc"
 assert_eq "implement-model: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "implement-model: spawn-worker argv has no --model flag" \
   "839 $TMPDIR_TEST/project/worktrees/839-test" \
+  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
+mat_teardown
+
+# --- phase→model integration: review phase → --model claude-sonnet-4-6 forwarded
+# When the recomputed PHASE is review, dispatch-materialize-spawn calls the real
+# dispatch-phase-model which emits claude-sonnet-4-6 (the review-fix orchestrator
+# runs on Sonnet; fix-authoring is delegated to an Opus subagent), so the
+# spawn-worker invocation must include --model claude-sonnet-4-6.
+echo "Test: materialize-spawn review phase → spawn-worker receives --model claude-sonnet-4-6 (#1172)"
+mat_setup
+export MAT_PHASE=review
+out=$(run_mat 839 queue) ; rc=$?
+assert_eq "review-model: exit 0" "0" "$rc"
+assert_eq "review-model: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "review-model: spawn-worker argv contains --model claude-sonnet-4-6" \
+  "--model claude-sonnet-4-6 839 $TMPDIR_TEST/project/worktrees/839-test" \
   "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
 mat_teardown
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -387,7 +387,11 @@ finding (from `/code-review` and `/review`) and every `required`-bucket finding
 from the security pass.
 
 For each such finding, launch an implementation subagent via the Agent tool,
-constrained to **working-tree edits only — no commits, no pushes**. **Pin these
+constrained to **working-tree edits only — no commits, no pushes** (when there
+are multiple findings to apply, these implementation subagents may be fanned out
+in parallel — multiple Agent calls in one message — but only when they touch
+disjoint files; group findings that edit the same file into one subagent to
+avoid write conflicts). **Pin these
 implementation subagents to `model: opus`** (#1172): writing a correct fix is
 code generation, where Opus has the edge, so all fix-authoring is concentrated on
 Opus while the orchestrator chain and detection run on Sonnet. Informational,
@@ -695,10 +699,10 @@ through to the unified set in Step 2 — has these fields:
 - **Recommended fix** — the concrete change that resolves the finding.
 - **Disposition** — the unified bucket from the **Disposition table**, set by the
   Step 2 unification subagent. Security sources additionally carry the underlying
-  `required` / `out-of-scope` / `false-positive` classification; code-review/review
-  sources carry the `fixed` / `skipped` disposition `/code-review` emitted, which
-  the unification subagent extends into Fixed / Informational / Dismissed /
-  Deferred.
+  `required` / `out-of-scope` / `false-positive` classification; code-review
+  findings (detection-only, per Step 1a) and review findings both carry
+  `skipped`, which the unification subagent extends into Fixed / Informational /
+  Dismissed / Deferred.
 
 ## Edge cases
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-fix
-description: Review phase — the workflow's single terminal review pass. Run /code-review max --fix, /review, and the full surface-gated security fan-out as direct subagents over the same diff, unify and de-duplicate the findings, apply the in-scope fixes via one /commit-merge-push, file meaningful out-of-scope findings as blocked_by follow-ups, post one PR comment covering every finding, apply the dispatch:reviewed label, and mark the PR ready
+description: Review phase — the workflow's single terminal review pass. Run /code-review max, /review, and the full surface-gated security fan-out as direct subagents over the same diff, unify and de-duplicate the findings, apply the in-scope fixes via one /commit-merge-push, file meaningful out-of-scope findings as blocked_by follow-ups, post one PR comment covering every finding, apply the dispatch:reviewed label, and mark the PR ready
 ---
 
 # Review and Fix
@@ -83,31 +83,30 @@ review source (e.g. `tmp/findings-code-review.json`, `tmp/findings-review.json`,
 `tmp/findings-security.json`). See **Context-budget discipline** below for why
 this serialization is not optional.
 
-#### 1a. `/code-review max --fix` — a single NON-ISOLATED subagent
+#### 1a. `/code-review max` — a findings-only subagent
 
 Fork a subagent via the Agent tool (`subagent_type: general-purpose`,
 `model: sonnet`) that invokes the built-in `/code-review` skill via the Skill
-tool with the `max` effort argument (the highest thoroughness available) and the
-`--fix` flag inside the subagent. It applies in-scope fixes to the working tree
-and surfaces findings with the skill's own (fixed vs skipped) disposition.
+tool with the `max` effort argument (the highest thoroughness available) inside
+the subagent — **without** the `--fix` flag. It produces findings; it applies no
+fixes. Detection stays on Sonnet; all fix-authoring is concentrated in Step 5's
+Opus-pinned implementation subagents (#1172), so `/code-review` here is
+findings-only, exactly like `/review` (1b).
 
 The subagent boundary is the control-flow guarantee: the parent never sees the
 inner Skill's prompt template, so it remains on this step when the Agent call
-returns. The subagent inherits the parent's worktree filesystem — working-tree
-edits made by `/code-review` inside the subagent surface on disk for Step 5's
-`/commit-merge-push` with no additional plumbing. **Do not set `isolation:` on
-this subagent: an isolated worktree would silently capture `/code-review`'s edits
-in a discarded copy, leaving the commit step with nothing to commit.** The
-subagent passes the inner skill no output contract and returns its natural output
-as-is. Keep the "once it returns, continue" wording inside the **subagent's**
-prompt as defense-in-depth for the inner Skill invocation; any "final reply" /
-"nothing else" wording in `/code-review`'s prompt scopes only to its findings
-deliverable.
+returns. `/code-review` is built-in and uneditable: the subagent passes the inner
+skill no output contract and returns its natural output as-is. Keep the "once it
+returns, continue" wording inside the **subagent's** prompt as defense-in-depth
+for the inner Skill invocation; any "final reply" / "nothing else" wording in
+`/code-review`'s prompt scopes only to its findings deliverable. The subagent
+stays non-isolated for consistency with the other findings-only subagents; it
+writes nothing to the working tree, so isolation would change nothing either way.
 
-Normalize the subagent's output to the **Per-finding schema** — each finding
-carries its `disposition` of `fixed` (applied to the working tree by
-`/code-review`) or `skipped` (the wrapper classifies it in Step 2) — and serialize
-the finding set to `tmp/findings-code-review.json`.
+Normalize the subagent's output to the **Per-finding schema** — code-review emits
+no fixes, so every finding is `skipped` (the wrapper classifies each into the
+disposition table in Step 2) — and serialize the finding set to
+`tmp/findings-code-review.json`.
 
 #### 1b. `/review` — a findings-only subagent
 
@@ -342,7 +341,7 @@ code-review/review `Fixed` / `Informational` / `Dismissed` / `Deferred` axis.
 
 | Bucket | Source vocabulary | Meaning |
 |---|---|---|
-| Fixed | code-review/review | A concrete, in-scope code change applicable to this PR. Code-review findings already `fixed` by `/code-review` in Step 1a land here; review/code-review findings the wrapper decides to implement also land here (applied in Step 5). |
+| Fixed | code-review/review | A concrete, in-scope code change applicable to this PR — the in-scope code-review/review findings the wrapper decides to implement. All are applied in Step 5 (no finding is pre-applied). |
 | Required | security | A real vulnerability or weakness in the changed code that should be fixed (applied in Step 5). |
 | Informational | code-review/review | FYIs, notes, observations surfaced for human reference; no change required. |
 | Dismissed | code-review/review | Nits, incorrect findings, or not applicable; no change, each with a one-line rationale. |
@@ -382,25 +381,27 @@ than the stacked ~138k that would trip auto-compaction.
 
 ### 5. Apply the required/Fixed fixes, then one commit-merge-push
 
-`/code-review max --fix` (Step 1a) already applied its own fixes to the working
-tree. This step applies the **remaining** required/Fixed fixes — the Fixed-bucket
-findings from `/review` and the `required`-bucket findings from the security pass
-that are not already on disk.
+This step authors **all** in-scope fixes — no finding is pre-applied, because
+Step 1a's `/code-review` runs detection-only. It applies every Fixed-bucket
+finding (from `/code-review` and `/review`) and every `required`-bucket finding
+from the security pass.
 
 For each such finding, launch an implementation subagent via the Agent tool,
-constrained to **working-tree edits only — no commits, no pushes**. Choose each
-subagent's model per `/implement-unit`'s model-selection heuristic (see that
-skill — it is the canonical home; do not restate it here). Informational,
+constrained to **working-tree edits only — no commits, no pushes**. **Pin these
+implementation subagents to `model: opus`** (#1172): writing a correct fix is
+code generation, where Opus has the edge, so all fix-authoring is concentrated on
+Opus while the orchestrator chain and detection run on Sonnet. Informational,
 Dismissed, false-positive, Deferred, and out-of-scope findings are **not**
-implemented here. If there are no remaining required/Fixed findings to apply,
-skip the implementation subagents.
+implemented here. If there are no Fixed/required findings to apply, skip the
+implementation subagents.
 
-Then fork **one** `/commit-merge-push` to commit every pending working-tree change —
-`/code-review`'s Step 1a edits plus these implementation edits — and push. Issue an
-Agent tool call with `subagent_type: general-purpose` and `model: sonnet` whose
-prompt invokes `/commit-merge-push` via the Skill tool, the canonical fork recipe
+Then fork **one** `/commit-merge-push` to commit every pending working-tree
+change — the implementation subagents' edits — and push. Issue an Agent tool call
+with `subagent_type: general-purpose` and `model: sonnet` whose prompt invokes
+`/commit-merge-push` via the Skill tool, the canonical fork recipe
 `/implement-unit` Step 2 documents (`subagent_type` is `general-purpose`, never the
-skill name). If there were no code changes at all, `/commit-merge-push`
+skill name). The `/commit-merge-push` fork stays on `model: sonnet`: it is
+orchestration (commit/merge/push), not fix-authoring. If there were no code changes at all, `/commit-merge-push`
 tolerates the no-op and creates no commit. Even on that no-op it pushes `origin
 HEAD`, so it carries any pending local merge (left by `dispatch-merge-main` /
 `/dispatch-resolve-conflict`) to origin; Step 8's flush guard is the
@@ -731,3 +732,14 @@ The skill is idempotent: a re-invocation with `dispatch:reviewed` already on the
 PR skips Steps 1–7 and runs Step 8, which flushes any unpushed commits, ensures
 the PR is ready, and writes the phase-completed marker (the unified finding set
 is not in context on re-entry, so the deviation criterion is treated as not met).
+
+**Model split (#1172).** The dispatch chain runs this `review` phase orchestrator
+on **Sonnet** (via `dispatch-phase-model`, which maps `review →
+claude-sonnet-4-6`). Findings detection is unchanged — it stays on the **Sonnet**
+review subagents (Step 1's `/code-review`, `/review`, and the security fan-out).
+**Fix-authoring is pinned to an Opus subagent** (Step 5's implementation
+subagents, `model: opus`), so the Sonnet orchestrator authors no product code.
+When #890 ports this fan-out to a Workflow pipeline, that port carries the same
+tiering as per-`agent()` `model:` settings (finders + orchestrator Sonnet,
+fix-authoring Opus) so fix-authoring stays pinned to Opus **exactly once** — there
+is no double model-tiering.


### PR DESCRIPTION
Closes #1172

## What

Run the `review-fix` dispatch worker's **orchestration** on Sonnet while keeping
**fix-authoring** on Opus.

The `review-fix` worker (the dispatch chain's terminal `review` phase) launched on
Opus. Its review *findings* already come from Sonnet subagents, but token-usage
analysis (Jun 4–6, 2026) found its Opus main chain also **authored product-code
fixes inline** (~49 code-file edits, ~30% of its Edit/Write calls). A straight
model swap to Sonnet would trade away fix-authoring quality, so the fix is
structural:

- **Orchestration** (unify/dedup/classify findings, PR comment, `dispatch:reviewed`,
  `/commit-merge-push` fork, ready-flip) runs on **Sonnet**.
- **Findings detection** stays on the existing **Sonnet** review subagents
  (`/code-review`, `/review`, the security fan-out) — unchanged.
- **Fix-authoring** (applying findings to source) is pinned to an **Opus**
  subagent — no code-quality regression.

This reuses the per-phase model mechanism landed by #1178/#1171
(`dispatch-phase-model`, a phase→model map). This issue adds the `review` arm plus
a SKILL.md delegation refactor.

## Changes

1. **`dispatch-phase-model`** — add `review → claude-sonnet-4-6` to the phase→model
   `case` map (the documented single opt-in point). The downstream wiring
   (`dispatch-materialize-spawn` → `dispatch-spawn-worker` → `claude --bg --model`)
   already forwards the value opaquely — no change there.

2. **`review-fix/SKILL.md`** — concentrate all fix-authoring in one Opus-pinned
   place:
   - Step 1a's `/code-review` becomes **detection-only** (drops `--fix`), exactly
     like the `/review` subagent. It edits nothing; every finding is normalized and
     classified in Step 2.
   - Step 5's implementation subagents are pinned to **`model: opus`** and now
     author **all** Fixed-bucket (code-review + review) and Required-bucket
     (security) findings.
   - The `/commit-merge-push` fork stays `model: sonnet` (orchestration, not
     fix-authoring).
   - Adds a "Model split" note plus the #890 reconciliation pointer.

3. **`test-dispatch-scripts.sh`** — cover `dispatch-phase-model review →
   claude-sonnet-4-6`, the materialize-spawn `review` phase forwarding
   `--model claude-sonnet-4-6`, and `review-fix/SKILL.md` content guards (Opus
   fix-authoring pinned; `/code-review max --fix` absent).

## #890 reconciliation

#890 (open) ports the review-fix fan-out to a Workflow pipeline; its body already
records that the port must pin fix-authoring to Opus *exactly once*. So this issue
proceeds as the independent minimal refactor — no edit to #890 is needed. Whichever
lands second reconciles the two so fix-authoring runs on Opus exactly once.

## Verification

`test-dispatch-scripts.sh` passes 1907/1907. Spot-check: `dispatch-phase-model
review` → `claude-sonnet-4-6`, `dispatch-phase-model implement` → empty.
