### PR TITLE
dispatch: surface direnv failure in dispatch-provision-worktree

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-provision-worktree
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-provision-worktree
@@ -20,7 +20,7 @@
 # Exit-code contract — identical to dispatch-merge-main, because step 3 `exec`s
 # into it (this script's exit code IS dispatch-merge-main's):
 #   0 — clean merge or already-up-to-date.
-#   1 — fetch failure, or a non-conflict merge failure.
+#   1 — fetch failure, a non-conflict merge failure, or a direnv warm-up failure.
 #   2 — usage error (missing/extra/flag-shaped arg). dispatch-merge-main also
 #       exits 2 for an un-cd-able path.
 #   3 — merge conflict; the merge has been aborted and the tree is left clean.
@@ -35,10 +35,11 @@
 # — and `direnv`/npm write the dependency cache. This mirrors dispatch-select-tick's
 # merge precedent. Callers must run it with `dangerouslyDisableSandbox: true`.
 #
-# The `|| true` swallow on both direnv steps is a behavior-preserving relocation
-# of the router's current create-path behavior (`direnv allow … || true` /
-# `direnv exec … true || true`). Surfacing direnv failures is #855's charter,
-# not this PR's; the two changes coordinate on this same create path.
+# Both direnv steps surface failures: each captures its combined output and exit
+# code, and on non-zero prints a diagnostic to stderr naming the worktree and the
+# direnv output, then exits 1. A failed warm-up leaves the cache unwarmed, so the
+# script aborts rather than proceeding to the merge with node/npm/npx unavailable
+# in the worker (#855).
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -58,10 +59,33 @@ fi
 
 WT="$1"
 
-# Provision the worktree's environment. The `|| true` swallow is preserved from
-# the router's prior create-path behavior — direnv-failure surfacing is #855.
-direnv allow "$WT" || true
-direnv exec "$WT" true || true
+# Provision the worktree's environment. A direnv failure leaves the worktree's
+# cache unwarmed (node/npm/npx would be "command not found" in the worker), so
+# surface it and exit 1 (the non-conflict-failure code dispatch-route maps to
+# STOP provision-failed) rather than swallowing it and proceeding (#855).
+allow_rc=0
+allow_err=$(direnv allow "$WT" 2>&1) || allow_rc=$?
+if [[ "$allow_rc" -ne 0 ]]; then
+  {
+    echo "dispatch-provision-worktree: 'direnv allow $WT' failed (exit $allow_rc)."
+    echo "The worktree's direnv cache is unwarmed; node/npm/npx would be 'command not found' in the worker."
+    echo "direnv output:"
+    printf '%s\n' "$allow_err"
+  } >&2
+  exit 1
+fi
+
+exec_rc=0
+exec_err=$(direnv exec "$WT" true 2>&1) || exec_rc=$?
+if [[ "$exec_rc" -ne 0 ]]; then
+  {
+    echo "dispatch-provision-worktree: 'direnv exec $WT true' failed (exit $exec_rc)."
+    echo "The worktree's direnv cache is unwarmed; node/npm/npx would be 'command not found' in the worker."
+    echo "direnv output:"
+    printf '%s\n' "$exec_err"
+  } >&2
+  exit 1
+fi
 
 # Merge origin/main into the worktree's branch. `exec` so this script's exit
 # code IS dispatch-merge-main's (0 clean / 1 fetch-or-other / 3 conflict).

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -16733,6 +16733,14 @@ FAKE
   cat > "$PROV_TMPDIR/bin/direnv" <<FAKE
 #!/usr/bin/env bash
 echo "\$*" >> "$PROV_DIRENV_LOG"
+if [[ "\$1" == "allow" ]]; then
+  [[ "\${DIRENV_ALLOW_RC:-0}" -ne 0 ]] && echo "fake-direnv-allow-stderr" >&2
+  exit "\${DIRENV_ALLOW_RC:-0}"
+fi
+if [[ "\$1" == "exec" ]]; then
+  [[ "\${DIRENV_EXEC_RC:-0}" -ne 0 ]] && echo "fake-direnv-exec-stderr" >&2
+  exit "\${DIRENV_EXEC_RC:-0}"
+fi
 exit 0
 FAKE
   chmod +x "$PROV_TMPDIR/bin/direnv"
@@ -16744,7 +16752,7 @@ FAKE
 prov_teardown() {
   export PATH="$SAVED_PATH"
   rm -rf "$PROV_TMPDIR"
-  unset PROV_TMPDIR PROV_SCRIPT PROV_DIRENV_LOG PROV_MERGE_LOG PROV_MERGE_RC
+  unset PROV_TMPDIR PROV_SCRIPT PROV_DIRENV_LOG PROV_MERGE_LOG PROV_MERGE_RC DIRENV_ALLOW_RC DIRENV_EXEC_RC
 }
 
 # direnv argv capture + worktree forwarded to dispatch-merge-main (happy run).
@@ -16795,6 +16803,30 @@ echo "Test: extra arg → exit 2"
 prov_setup
 "$PROV_SCRIPT" "/wt/a" extra >/dev/null 2>&1 && rc=0 || rc=$?
 assert_eq "extra arg → exit 2" "2" "$rc"
+prov_teardown
+
+# direnv warm-up failures surface and abort before merge (#855). A non-zero
+# `direnv exec`/`direnv allow` must make the script exit 1 with a diagnostic
+# naming the worktree, and must NOT proceed to exec dispatch-merge-main.
+echo "Test: direnv exec failure → exit 1, abort before merge"
+prov_setup
+WT="/home/n8/natb1/commons.systems/worktrees/77-example"
+out=$(DIRENV_EXEC_RC=1 "$PROV_SCRIPT" "$WT" 2>&1) && rc=0 || rc=$?
+assert_eq "direnv exec failure → exit 1" "1" "$rc"
+assert_eq "diagnostic names the worktree" "1" "$([[ "$out" == *"$WT"* ]] && echo 1 || echo 0)"
+assert_eq "diagnostic includes direnv stderr" "1" "$([[ "$out" == *"fake-direnv-exec-stderr"* ]] && echo 1 || echo 0)"
+assert_eq "merge-main not reached on exec failure" "0" "$([[ -s "$PROV_MERGE_LOG" ]] && echo 1 || echo 0)"
+prov_teardown
+
+echo "Test: direnv allow failure → exit 1, abort before exec and before merge"
+prov_setup
+WT="/home/n8/natb1/commons.systems/worktrees/77-example"
+out=$(DIRENV_ALLOW_RC=1 "$PROV_SCRIPT" "$WT" 2>&1) && rc=0 || rc=$?
+assert_eq "direnv allow failure → exit 1" "1" "$rc"
+assert_eq "diagnostic names the worktree" "1" "$([[ "$out" == *"$WT"* ]] && echo 1 || echo 0)"
+assert_eq "diagnostic includes direnv stderr" "1" "$([[ "$out" == *"fake-direnv-allow-stderr"* ]] && echo 1 || echo 0)"
+assert_eq "direnv log holds only the allow line" "allow $WT" "$(cat "$PROV_DIRENV_LOG")"
+assert_eq "merge-main not reached on allow failure" "0" "$([[ -s "$PROV_MERGE_LOG" ]] && echo 1 || echo 0)"
 prov_teardown
 
 # ============================================================================


### PR DESCRIPTION
Closes #855

## What

`dispatch-provision-worktree` warms a freshly-provisioned worktree's direnv
cache (`direnv allow "$WT"` then `direnv exec "$WT" true`) so non-interactive
subshells in the spawned worker pick up the flake environment (node, npm, npx).
Both direnv steps swallowed their exit code with `|| true` — a
deliberately-preserved placeholder the script's own header named as #855's
charter.

This PR removes the swallow. Each direnv step now captures its combined output
and exit code; on non-zero it prints a diagnostic to stderr naming the worktree
path and the underlying `direnv` output, then exits `1`.

## Why

With the swallow in place, a failed warm-up silently proceeded: the script went
on to merge `origin/main` and the worker derived its phase and ran a phase skill
against an **unwarmed** cache, where `node`/`npm`/`npx` later surfaced as
"command not found" — far from the real failure point. That is the buried-error
anti-pattern `.claude/rules/code-style.md` ("Prefer clear errors over defensive
fallbacks") warns against.

## How

The downstream abort plumbing already exists and needs no change:
`dispatch-route` maps any non-zero, non-`3` provision exit to the
`STOP provision-failed` directive, which writes an office-hours reason and parks
the issue. Exiting `1` (the script's documented non-conflict-failure code) flows
into that path automatically — so a failed direnv warm-up no longer proceeds to
the `origin/main` merge, phase derivation, or phase skill.

The exit-code contract's code `1` is broadened to read "fetch failure, a
non-conflict merge failure, or a direnv warm-up failure," and the header
placeholder comment is rewritten to describe the surface-and-exit-1 behavior.

## Tests

`test-dispatch-scripts.sh`: the fake `direnv` now honors optional
`DIRENV_ALLOW_RC` / `DIRENV_EXEC_RC` per-subcommand exit codes (defaulting to
succeed, so existing tests are unaffected) and emits a recognizable stderr
marker on failure. Two new failure-path tests assert:

- a non-zero `direnv exec` makes the script exit `1` with a diagnostic naming
  the worktree path and the direnv stderr, and aborts before exec-ing into
  `dispatch-merge-main`.
- a non-zero `direnv allow` exits `1` likewise and aborts before the `exec` step
  and before merge (the direnv argv log holds only the `allow` line).

Full suite: 1916/1916 pass.
