### PR TITLE
dispatch: KillMode=process on transient tick/reseed units so cgroup-kill spares the bg fleet

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-reseed
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-reseed
@@ -412,6 +412,19 @@ ensure_recover_unit "$MAIN_WORKTREE" || true
 # continuation. ensure_recover_unit (above) installs that handler best-effort;
 # OnFailure= resolves lazily at failure time, so passing it is safe even when
 # the install failed.
+#
+# --property=KillMode=process (#1196): Claude Code's per-user bg supervisor
+# daemon is spawned on demand by the first `claude` call inside the reseed
+# unit — the `claude agents --json` liveness checks in lib-claude-agents.sh
+# are called during the tick that the reseed timer fires. That means the
+# daemon and its --bg-spare / --bg-pty-host worker children are born inside
+# this transient unit's cgroup. systemd's default KillMode=control-group
+# SIGTERMs the entire cgroup when the reseed tick finishes, reaping the
+# daemon and every running worker. The bg hosts are spawned detached: true
+# (setsid) to outlive their launcher, but setsid only changes the
+# session/process-group, not the cgroup, so cgroup-kill ignores it.
+# KillMode=process confines the kill to the dispatch-tick process itself;
+# the detached bg hosts survive as init orphans across reseed cycles.
 
 SYSTEMD_RUN_CMD="${DISPATCH_SCHEDULE_RESEED_SYSTEMD_RUN_CMD:-systemd-run}"
 UNIT_NAME="dispatch-reseed-${RESEED_AT}"
@@ -428,6 +441,7 @@ trap 'rm -f "$RUN_STDERR"' EXIT
      --on-calendar="@$RESEED_AT" \
      --collect \
      --property=OnFailure=dispatch-tick-recover.service \
+     --property=KillMode=process \
      --working-directory="$MAIN_WORKTREE" \
      --timer-property=Persistent=true \
      --setenv=PATH="$PATH" \

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-tick
@@ -38,6 +38,22 @@
 #   handoff or an armed reseed timer. OnFailure= resolves lazily at failure
 #   time, so passing it is safe even if ensure_recover_unit failed.
 #
+# KillMode=process — cgroup-reaping stop-gap (#1196):
+#   Claude Code's per-user bg supervisor daemon is spawned on demand by the
+#   first `claude` call inside a tick unit (the --bg worker kick in
+#   dispatch-spawn-job, or the `claude agents --json` liveness checks). That
+#   means the daemon — and the --bg-spare / --bg-pty-host children that host
+#   each worker — is born inside this transient unit's cgroup. systemd's
+#   default KillMode=control-group SIGTERMs the entire cgroup when the tick
+#   finishes, reaping the daemon and every running worker. The bg hosts are
+#   spawned detached: true (setsid) to outlive their launcher, but setsid
+#   only changes the session/process-group, not the cgroup, so cgroup-kill
+#   ignores it. Passing --property=KillMode=process makes a finishing tick
+#   kill only its own dispatch-tick process; the detached bg hosts survive as
+#   init orphans — exactly what detached: true is designed for. The durable
+#   daemon-ownership design is tracked in #1197; this is the minimal correct
+#   stop-gap.
+#
 # Unlike dispatch-schedule-reseed (which schedules an --on-calendar TIMER), this
 # script runs the unit IMMEDIATELY: a transient .service, no --on-calendar /
 # --timer-property. The transient unit is itself the detachment — systemd runs
@@ -148,6 +164,7 @@ if [[ -n "$TARGET_N" ]]; then
        --unit="$UNIT_NAME" \
        --collect \
        --property=OnFailure=dispatch-tick-recover.service \
+       --property=KillMode=process \
        --working-directory="$MAIN_WORKTREE" \
        --setenv=PATH="$PATH" \
        "$TICK_PATH" "$TARGET_N" \
@@ -158,6 +175,7 @@ else
        --unit="$UNIT_NAME" \
        --collect \
        --property=OnFailure=dispatch-tick-recover.service \
+       --property=KillMode=process \
        --working-directory="$MAIN_WORKTREE" \
        --setenv=PATH="$PATH" \
        "$TICK_PATH" \

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -9258,12 +9258,13 @@ if [[ "$log" == *"--unit=dispatch-reseed-20000"* \
    && "$log" == *"--on-calendar=@20000"* \
    && "$log" == *"--collect"* \
    && "$log" == *"--property=OnFailure=dispatch-tick-recover.service"* \
+   && "$log" == *"--property=KillMode=process"* \
    && "$log" == *"--working-directory=$TMPDIR_TEST/main"* \
    && "$log" == *"--setenv=PATH="* \
    && "$log" == *"$TMPDIR_TEST/main/.claude/skills/dispatch-propagate/scripts/dispatch-tick"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: weekly cap-hit systemd-run argv (unit + calendar + collect + OnFailure + cwd + setenv + exec)"
+  PASS=$((PASS + 1)); echo "  PASS: weekly cap-hit systemd-run argv (unit + calendar + collect + OnFailure + KillMode + cwd + setenv + exec)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: weekly cap-hit systemd-run argv (unit + calendar + collect + OnFailure + cwd + setenv + exec)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: weekly cap-hit systemd-run argv (unit + calendar + collect + OnFailure + KillMode + cwd + setenv + exec)"
   echo "    log: $log"
 fi
 sr_teardown
@@ -10498,12 +10499,13 @@ TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--unit=dispatch-tick"* \
    && "$log" == *"--collect"* \
    && "$log" == *"--property=OnFailure=dispatch-tick-recover.service"* \
+   && "$log" == *"--property=KillMode=process"* \
    && "$log" == *"--working-directory=$TMPDIR_TEST/main"* \
    && "$log" == *"--setenv=PATH="* \
    && "$log" == *"$TMPDIR_TEST/main/.claude/skills/dispatch-propagate/scripts/dispatch-tick"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: no-arg systemd-run argv (unit + collect + OnFailure + cwd + setenv + exec)"
+  PASS=$((PASS + 1)); echo "  PASS: no-arg systemd-run argv (unit + collect + OnFailure + KillMode + cwd + setenv + exec)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: no-arg systemd-run argv (unit + collect + OnFailure + cwd + setenv + exec)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: no-arg systemd-run argv (unit + collect + OnFailure + KillMode + cwd + setenv + exec)"
   echo "    log: $log"
 fi
 # No trailing numeric arg in the no-arg case: the exec path must be the LAST
@@ -10529,10 +10531,11 @@ log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--unit=dispatch-tick-979"* \
    && "$log" == *"--property=OnFailure=dispatch-tick-recover.service"* \
+   && "$log" == *"--property=KillMode=process"* \
    && "$log" == *"$TMPDIR_TEST/main/.claude/skills/dispatch-propagate/scripts/dispatch-tick 979"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: target systemd-run argv (unit=dispatch-tick-979 + OnFailure + exec path 979)"
+  PASS=$((PASS + 1)); echo "  PASS: target systemd-run argv (unit=dispatch-tick-979 + OnFailure + KillMode + exec path 979)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: target systemd-run argv (unit=dispatch-tick-979 + OnFailure + exec path 979)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: target systemd-run argv (unit=dispatch-tick-979 + OnFailure + KillMode + exec path 979)"
   echo "    log: $log"
 fi
 st_teardown

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -9282,10 +9282,11 @@ assert_eq "5h cap-hit stdout names the 5h reset unit" \
 log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--unit=dispatch-reseed-15000"* \
-   && "$log" == *"--on-calendar=@15000"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: 5h cap-hit systemd-run argv (unit + calendar)"
+   && "$log" == *"--on-calendar=@15000"* \
+   && "$log" == *"--property=KillMode=process"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: 5h cap-hit systemd-run argv (unit + calendar + KillMode)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: 5h cap-hit systemd-run argv (unit + calendar)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5h cap-hit systemd-run argv (unit + calendar + KillMode)"
   echo "    log: $log"
 fi
 sr_teardown
@@ -9686,10 +9687,11 @@ assert_eq "pace pause schedules crossing" \
 log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--unit=dispatch-reseed-12345"* \
-   && "$log" == *"--on-calendar=@12345"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: pace pause systemd-run argv (unit + calendar)"
+   && "$log" == *"--on-calendar=@12345"* \
+   && "$log" == *"--property=KillMode=process"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: pace pause systemd-run argv (unit + calendar + KillMode)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: pace pause systemd-run argv (unit + calendar)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: pace pause systemd-run argv (unit + calendar + KillMode)"
   echo "    log: $log"
 fi
 sr_teardown
@@ -9746,10 +9748,11 @@ assert_eq "past crossing → short-delay floor" \
 log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--unit=dispatch-reseed-10300"* \
-   && "$log" == *"--on-calendar=@10300"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: past crossing short-delay systemd-run argv (unit + calendar)"
+   && "$log" == *"--on-calendar=@10300"* \
+   && "$log" == *"--property=KillMode=process"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: past crossing short-delay systemd-run argv (unit + calendar + KillMode)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: past crossing short-delay systemd-run argv (unit + calendar)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: past crossing short-delay systemd-run argv (unit + calendar + KillMode)"
   echo "    log: $log"
 fi
 sr_teardown
@@ -9778,10 +9781,11 @@ assert_eq "crossing==NOW → short-delay floor" \
 log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--unit=dispatch-reseed-10300"* \
-   && "$log" == *"--on-calendar=@10300"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: crossing==NOW short-delay systemd-run argv (unit + calendar)"
+   && "$log" == *"--on-calendar=@10300"* \
+   && "$log" == *"--property=KillMode=process"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: crossing==NOW short-delay systemd-run argv (unit + calendar + KillMode)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: crossing==NOW short-delay systemd-run argv (unit + calendar)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: crossing==NOW short-delay systemd-run argv (unit + calendar + KillMode)"
   echo "    log: $log"
 fi
 sr_teardown


### PR DESCRIPTION
Closes #1196

## Problem

`/dispatch`'s autonomous chain launches every tick and reseed as a
`systemd-run --user` transient unit (`dispatch-spawn-tick`,
`dispatch-schedule-reseed`). These units run with systemd's default
`KillMode=control-group`.

Claude Code's per-user bg supervisor daemon is spawned on demand by the first
`claude` call that needs one. In the autonomous chain (no human `claude agents`
view open) that first call comes from inside a tick/reseed unit — so the daemon,
and the `--bg-spare` / `--bg-pty-host` children hosting each agent, is born
**inside the transient unit's cgroup**. When the short tick finishes and the unit
deactivates, `KillMode=control-group` makes systemd SIGTERM the entire cgroup:
daemon plus every worker. The next reseed re-spawns into a fresh cgroup and is
reaped again — a self-perpetuating crash loop.

The bg hosts are spawned `detached: true` (setsid), but setsid changes only the
session/process-group, not the cgroup, so cgroup-kill ignores it.

## Fix

Pass `--property=KillMode=process` to the `systemd-run --user` invocations so a
finishing tick kills only its own `dispatch-tick` process and leaves the detached
bg hosts running as init orphans (what `detached: true` is designed for). A later
tick attaches to the surviving daemon via the existing lock.

This is the minimal correct stop-gap; the greenfield durable daemon-ownership
design is tracked separately in #1197.

## Changes

- **`dispatch-spawn-tick`** — `--property=KillMode=process` added to both
  `systemd-run --user` invocations (target-keyed branch and no-target `else`
  branch), adjacent to the existing `--property=OnFailure=...` line; header
  rationale block added.
- **`dispatch-schedule-reseed`** — `--property=KillMode=process` added to the
  single `systemd-run --user` invocation, adjacent to `--property=OnFailure=...`;
  Step-6 comment block extended with the rationale.
- **`test-dispatch-scripts.sh`** — the three launcher argv-assertion blocks
  (no-arg spawn-tick, target-keyed spawn-tick, weekly cap-hit reseed) now also
  require `--property=KillMode=process`, with `KillMode` in their PASS/FAIL
  labels.

## Verification

`test-dispatch-scripts.sh` passes (1907/1907), including the three extended
KillMode assertions. The runtime end-to-end check — an autonomous reseed chain
running ≥2 cycles with no `shutting down` / `adopted=0 dead=N` churn — is left to
the QA phase.
