### PR TITLE
dispatch: emit recover unit WorkingDirectory= unquoted so OnFailure recovery loads

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -823,9 +823,12 @@ ensure_recover_unit() {
   # git/jq/claude. The caller carries the full nix-store PATH, so baking it into
   # the unit at write time makes the unit self-sufficient.
   #
-  # The path-bearing directives are double-quoted: systemd unescapes C-style
-  # quotes, so a path containing spaces is parsed as a single token rather than
-  # split into an executable + spurious arguments.
+  # ExecStart= and Environment= are double-quoted: systemd unescapes C-style
+  # quotes for these two directives, so a path containing spaces is parsed as a
+  # single token rather than split into an executable + spurious arguments.
+  # WorkingDirectory= is the exception — it does NOT unescape quotes; a leading
+  # `"` makes the path non-absolute and systemd rejects the unit (bad-setting),
+  # so it takes the bare path (safe here: the worktree path has no spaces).
   #
   # Deliberately NO OnFailure= on this unit — the recover handler must not chain
   # to itself, or a failing recovery would recurse.
@@ -838,7 +841,7 @@ Description=Dispatch chain continuation recovery (OnFailure handler)
 Type=oneshot
 Environment="PATH=$safe_path"
 ExecStart="$RECOVER_SCRIPT"
-WorkingDirectory="$main_worktree"
+WorkingDirectory=$main_worktree
 EOF
 )
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -20494,6 +20494,40 @@ unset DISPATCH_TARGET_WORKERS_RATE_LIMITS_PATH DISPATCH_TARGET_WORKERS_NOW
 rr_teardown
 
 # ============================================================================
+# ensure_recover_unit: WorkingDirectory= is unquoted and absolute (#1203)
+# ============================================================================
+echo ""
+echo "=== ensure_recover_unit WorkingDirectory= quoting ==="
+# Regression: systemd's WorkingDirectory= does not unescape quotes; a quoted
+# value makes the path non-absolute and the unit loads as bad-setting, so the
+# OnFailure= recovery never fires. Assert the emitted line is bare + absolute.
+eru_tmp=$(mktemp -d)
+mkdir -p "$eru_tmp/bin"
+cat > "$eru_tmp/bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$eru_tmp/bin/systemctl"
+(
+  export DISPATCH_RECOVER_UNIT_DIR="$eru_tmp/systemd-user"
+  export DISPATCH_RECOVER_SYSTEMCTL_CMD="$eru_tmp/bin/systemctl"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_recover_unit "$eru_tmp/main-worktree"
+)
+eru_unit="$eru_tmp/systemd-user/dispatch-tick-recover.service"
+eru_wd_line=$(grep '^WorkingDirectory=' "$eru_unit")
+assert_eq "WorkingDirectory= is the bare absolute path (no quotes)" \
+  "WorkingDirectory=$eru_tmp/main-worktree" "$eru_wd_line"
+# Guard the specific defect: no leading double-quote after the '='.
+TOTAL=$((TOTAL + 1))
+if [[ "$eru_wd_line" != 'WorkingDirectory="'* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: WorkingDirectory= value is not double-quoted"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: WorkingDirectory= value is double-quoted: $eru_wd_line"
+fi
+rm -rf "$eru_tmp"
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -20503,27 +20503,36 @@ echo "=== ensure_recover_unit WorkingDirectory= quoting ==="
 # OnFailure= recovery never fires. Assert the emitted line is bare + absolute.
 eru_tmp=$(mktemp -d)
 mkdir -p "$eru_tmp/bin"
+mkdir -p "$eru_tmp/main-worktree"
 cat > "$eru_tmp/bin/systemctl" <<'STUB'
 #!/usr/bin/env bash
 exit 0
 STUB
 chmod +x "$eru_tmp/bin/systemctl"
-(
+if (
   export DISPATCH_RECOVER_UNIT_DIR="$eru_tmp/systemd-user"
   export DISPATCH_RECOVER_SYSTEMCTL_CMD="$eru_tmp/bin/systemctl"
   source "$SCRIPT_DIR/lib.sh"
   ensure_recover_unit "$eru_tmp/main-worktree"
-)
-eru_unit="$eru_tmp/systemd-user/dispatch-tick-recover.service"
-eru_wd_line=$(grep '^WorkingDirectory=' "$eru_unit")
-assert_eq "WorkingDirectory= is the bare absolute path (no quotes)" \
-  "WorkingDirectory=$eru_tmp/main-worktree" "$eru_wd_line"
-# Guard the specific defect: no leading double-quote after the '='.
-TOTAL=$((TOTAL + 1))
-if [[ "$eru_wd_line" != 'WorkingDirectory="'* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: WorkingDirectory= value is not double-quoted"
+); then
+  eru_unit="$eru_tmp/systemd-user/dispatch-tick-recover.service"
+  if eru_wd_line=$(grep '^WorkingDirectory=' "$eru_unit" 2>/dev/null); then
+    assert_eq "WorkingDirectory= is the bare absolute path (no quotes)" \
+      "WorkingDirectory=$eru_tmp/main-worktree" "$eru_wd_line"
+    # Guard the specific defect: no leading double-quote after the '='.
+    TOTAL=$((TOTAL + 1))
+    if [[ "$eru_wd_line" != 'WorkingDirectory="'* ]]; then
+      PASS=$((PASS + 1)); echo "  PASS: WorkingDirectory= value is not double-quoted"
+    else
+      FAIL=$((FAIL + 1)); echo "  FAIL: WorkingDirectory= value is double-quoted: $eru_wd_line"
+    fi
+  else
+    TOTAL=$((TOTAL + 2)); FAIL=$((FAIL + 2))
+    echo "  FAIL: unit file missing or lacks WorkingDirectory= line: $eru_unit"
+  fi
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: WorkingDirectory= value is double-quoted: $eru_wd_line"
+  TOTAL=$((TOTAL + 2)); FAIL=$((FAIL + 2))
+  echo "  FAIL: ensure_recover_unit returned non-zero"
 fi
 rm -rf "$eru_tmp"
 


### PR DESCRIPTION
Closes #1203

## Problem

`dispatch-spawn-tick` and `dispatch-schedule-reseed` register
`--property=OnFailure=dispatch-tick-recover.service` so an abnormally-exiting
tick re-seeds the chain. That recovery unit is installed by `ensure_recover_unit`
in `lib.sh`, which emitted its path directives double-quoted, including:

```
WorkingDirectory="$main_worktree"
```

systemd's `WorkingDirectory=` does **not** unescape a quoted value the way
`ExecStart=`/`Environment=` do. The literal leading `"` makes the path
non-absolute, so the unit is rejected at load:

```
dispatch-tick-recover.service:8: WorkingDirectory= path is not absolute: "/.../worktrees/main"
Unit configuration has fatal error, unit will not be started.
```

`systemctl --user status` reported `Loaded: bad-setting`. Because the unit never
loaded, the `OnFailure=` recovery both launchers depend on **never fired** — a
failed tick did not re-seed, so the chain could wedge with nothing to recover it.

## Fix

- Emit `WorkingDirectory=$main_worktree` bare (unquoted) in `ensure_recover_unit`.
  The worktree path has no spaces and `WorkingDirectory=` takes the bare path as a
  single value. `Environment=`/`ExecStart=` stay double-quoted — those directives
  *do* unescape C-style quotes and are correct.
- Rescope the preceding comment so the quote-unescaping claim no longer covers
  `WorkingDirectory=`, and note the exception explicitly.
- Add a regression test to `test-dispatch-scripts.sh` asserting the emitted unit
  has an unquoted, absolute `WorkingDirectory=` line.

## Verification

`test-dispatch-scripts.sh` (shell only, no build): `Results: 1909/1909 passed, 0 failed`,
including the two new `ensure_recover_unit WorkingDirectory=` assertions.
