### PR TITLE
Poll for text-layer content in rapid-navigation regression test

### DIFF
--- a/print/e2e/viewer.spec.ts
+++ b/print/e2e/viewer.spec.ts
@@ -775,8 +775,11 @@ test.describe("viewer", () => {
     const position = page.locator(".viewer-position");
     await expect(position).not.toContainText("Navigation failed", { timeout: 5000 });
     await expect(position).toContainText(/[1-3] \/ 3/, { timeout: 15000 });
-    await expect(page.locator(".textLayer span").first()).toBeAttached({ timeout: 15000 });
-    const text = await page.locator(".textLayer").textContent();
-    expect((text ?? "").trim().length).toBeGreaterThan(0);
+    await expect
+      .poll(
+        async () => ((await page.locator(".textLayer").textContent()) ?? "").trim().length,
+        { timeout: 15000 },
+      )
+      .toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Closes #1208

## Problem

The `acceptance` CI check intermittently fails on the print viewer's
rapid-navigation regression test (`print/e2e/viewer.spec.ts:762`,
`"rapid page navigation never surfaces a navigation error"`). PR #1151 added
this test to guard the #1146 render race (concurrent PDF renders); that fix is
sound. The flake is in the test's **own** final content assertion racing the
async text-layer render.

The test asserted the first `.textLayer span` was *attached*, then immediately
read `.textLayer` text content once and asserted it was non-empty:

```ts
await expect(page.locator(".textLayer span").first()).toBeAttached({ timeout: 15000 });
const text = await page.locator(".textLayer").textContent();
expect((text ?? "").trim().length).toBeGreaterThan(0);
```

pdf.js populates span *text* asynchronously **after** the span node attaches.
Under CI load the one-shot read lands in the gap between span attachment and
text fill (or during a brief re-render that clears the layer), yielding an empty
string and a failed `toBeGreaterThan(0)`. No "Navigation failed" state appears —
this is a test-resilience gap, not a recurrence of the #1146 fetch race. First
re-observed on PR #1184 (#1006), which touches only `office-hours/` and no
`print/` code.

## Change

Replace the attach-then-read-once tail with a polled assertion that waits for
the same condition the original checked — trimmed text-layer content longer than
zero — with a bounded 15 s timeout (matching the file's existing text-layer wait
convention):

```ts
await expect
  .poll(
    async () => ((await page.locator(".textLayer").textContent()) ?? "").trim().length,
    { timeout: 15000 },
  )
  .toBeGreaterThan(0);
```

`expect.poll` re-reads the locator's text on each tick until the predicate
passes or the timeout elapses. A non-empty `.textLayer` text content implies a
span is attached, so the poll subsumes the redundant `toBeAttached` check.

## Scope

- **Only** `print/e2e/viewer.spec.ts` — no production viewer code changes, so the
  viewer's render behavior is unchanged.
- The `.viewer-position` / "Navigation failed" assertions are left unchanged,
  preserving the #1146 race guard: the test still fails if a "Navigation failed"
  state appears during the rapid click burst.
- The synchronous click-burst harness is unchanged — the race it provokes is
  exactly what the test must keep exercising.
- The similar read-once pattern in the separate `"PDF text layer updates on page
  navigation"` test is not touched (not named by #1208).

## Acceptance criteria

- [x] The final assertion no longer reads `.textLayer` content before the text
  layer has populated — it polls for non-empty trimmed content with a bounded
  15 s timeout.
- [x] No regression to the #1146 race guard — the `.viewer-position` /
  "Navigation failed" assertions are unchanged, so the test still fails on a
  "Navigation failed" state.
- [ ] The test passes deterministically across repeated runs — verified by the
  `acceptance` CI check on this PR.
