### PR TITLE
dev shell: add python3 so the security-guidance and workflow-command hooks run

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
                 nodejs_22
                 openjdk
                 go
+                python3
                 jq
                 fswatch
                 playwright-driver.browsers


### PR DESCRIPTION
Closes #1206

## Summary

The Nix dev shell (`flake.nix` `devShells.default`) shipped no Python 3
interpreter, but `.claude/settings.json` enables the
`security-guidance@claude-plugins-official` plugin and wires
`approve-workflow-commands.sh` as a `PreToolUse` hook — both of which need
`python3`. With none on `PATH`:

- the security-guidance hook failed with `security-guidance: no working Python 3
  interpreter found`;
- `approve-workflow-commands.sh` → `split-command.py` (`#!/usr/bin/env python3`)
  returned non-zero, so workflow commands fell through to manual permission
  prompts;
- the hook test suite (`test-approve-workflow-commands.sh`) couldn't run.

This adds the stock nixpkgs `python3` to the dev shell's `packages` list. Both
`split-command.py` and the plugin use only the Python standard library, so no pip
dependencies are needed.

## Change

- `flake.nix`: add `python3` to the `devShells.default` `packages` list, after
  `go` and before `jq`.

## Verification

Run via `nix develop --command` (resolves Python 3.13.13 from the dev shell):

- `which python3` → resolves to a nix-store path.
- `python3 --version` → `Python 3.13.13`.
- `printf 'a && b' | .claude/hooks/split-command.py` → exits 0, prints `a` / `b`.
- `.claude/hooks/test-approve-workflow-commands.sh` → `60 passed, 0 failed`.
