### PR TITLE
dispatch: /implement skill — build from the persisted plan comment

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-read-plan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-read-plan
@@ -8,9 +8,9 @@
 # implement phase reads the plan from here in a fresh context. Exits non-zero
 # with a clear diagnostic when no plan comment exists.
 #
-# The repo is resolved from the git common dir so gh addresses the right
-# repository from any caller cwd. A missing arg or a non-numeric issue-num is a
-# clear error, not a fallback (exit 2).
+# The repo is resolved explicitly (GH_REPO from the common dir's remote.origin.url)
+# so gh addresses the right repository from any caller cwd. A missing arg or a
+# non-numeric issue-num is a clear error, not a fallback (exit 2).
 set -euo pipefail
 
 N="${1:-}"
@@ -27,7 +27,12 @@ fi
 
 common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || {
   echo "dispatch-read-plan: not inside a git repository" >&2; exit 1; }
-cd "$(dirname "$common_dir")"   # PROJECT_ROOT — so gh resolves the repo from any caller cwd
+url="$(git --git-dir="$common_dir" config --get remote.origin.url)"
+# Resolve owner/repo from the remote so gh addresses the repo independent of cwd
+# (dirname(common_dir) is not a working tree in the bare-repo + worktrees layout).
+# Handles https://github.com/<owner>/<repo>(.git) and git@github.com:<owner>/<repo>(.git).
+repo="${url%.git}"; repo="${repo#*github.com[:/]}"
+export GH_REPO="$repo"
 
 MARKER='<!-- dispatch:plan -->'
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-read-plan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-read-plan
@@ -27,11 +27,14 @@ fi
 
 common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || {
   echo "dispatch-read-plan: not inside a git repository" >&2; exit 1; }
-url="$(git --git-dir="$common_dir" config --get remote.origin.url)"
+url="$(git --git-dir="$common_dir" config --get remote.origin.url 2>/dev/null)" || {
+  echo "dispatch-read-plan: no remote.origin.url in git config at $common_dir" >&2; exit 1; }
 # Resolve owner/repo from the remote so gh addresses the repo independent of cwd
 # (dirname(common_dir) is not a working tree in the bare-repo + worktrees layout).
 # Handles https://github.com/<owner>/<repo>(.git) and git@github.com:<owner>/<repo>(.git).
 repo="${url%.git}"; repo="${repo#*github.com[:/]}"
+[[ -n "$repo" && "$repo" == */* ]] || {
+  echo "dispatch-read-plan: could not resolve owner/repo from remote.origin.url ('$url')" >&2; exit 1; }
 export GH_REPO="$repo"
 
 MARKER='<!-- dispatch:plan -->'

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-route
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-route
@@ -12,7 +12,7 @@
 #   INVOKE /qa-fix                  phase qa           (draft, CI green, no label)
 #   INVOKE /review-fix              phase review       (dispatch:qa-done / reviewed re-entry)
 #   INVOKE /budget-parse-job       phase plan         (no PR, unplanned, statements:<key> label) — parse-job issue
-#   INVOKE /plan-implement         phase implement    (no PR + dispatch:planned) — transitional bridge; #1201 → /implement
+#   INVOKE /implement              phase implement    (no PR + dispatch:planned)
 #   INVOKE /dispatch-resolve-conflict  provisioning hit an origin/main merge conflict
 #   RELEVANCE-REVIEW                phase plan         (no PR, unplanned) — routes to SKILL.md Step 2
 #   STOP done                       phase done         (non-draft PR)
@@ -174,11 +174,11 @@ case "$PHASE" in
     fi
     ;;
   implement)
-    # Transitional bridge: a planned (dispatch:planned) no-PR issue routes straight
-    # to the build skill — planning already happened in the plan phase, so no
-    # relevance review and no parse-job check (a planned issue is never a parse-job).
-    # #1201 changes this to `INVOKE /implement` (build from the persisted plan comment).
-    echo "INVOKE /plan-implement"
+    # A planned (dispatch:planned) no-PR issue routes straight to /implement, which
+    # builds from the persisted <!-- dispatch:plan --> comment — planning already
+    # happened in the plan phase, so no relevance review and no parse-job check (a
+    # planned issue is never a parse-job).
+    echo "INVOKE /implement"
     ;;
   verify)       echo "INVOKE /verify-pr" ;;
   qa)           echo "INVOKE /qa-fix" ;;

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-write-plan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-write-plan
@@ -11,9 +11,9 @@
 # lives as a comment, not in the issue body, so the machine-authored plan never
 # clobbers the human-authored acceptance criteria.
 #
-# The repo is resolved from the git common dir so gh addresses the right
-# repository from any caller cwd. A missing arg, a non-numeric issue-num, or
-# empty STDIN is a clear error, not a fallback (exit 2).
+# The repo is resolved explicitly (GH_REPO from the common dir's remote.origin.url)
+# so gh addresses the right repository from any caller cwd. A missing arg, a
+# non-numeric issue-num, or empty STDIN is a clear error, not a fallback (exit 2).
 set -euo pipefail
 
 N="${1:-}"
@@ -30,7 +30,12 @@ fi
 
 common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || {
   echo "dispatch-write-plan: not inside a git repository" >&2; exit 1; }
-cd "$(dirname "$common_dir")"   # PROJECT_ROOT — so gh resolves the repo from any caller cwd
+url="$(git --git-dir="$common_dir" config --get remote.origin.url)"
+# Resolve owner/repo from the remote so gh addresses the repo independent of cwd
+# (dirname(common_dir) is not a working tree in the bare-repo + worktrees layout).
+# Handles https://github.com/<owner>/<repo>(.git) and git@github.com:<owner>/<repo>(.git).
+repo="${url%.git}"; repo="${repo#*github.com[:/]}"
+export GH_REPO="$repo"
 
 MARKER='<!-- dispatch:plan -->'
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-write-plan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-write-plan
@@ -30,11 +30,14 @@ fi
 
 common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || {
   echo "dispatch-write-plan: not inside a git repository" >&2; exit 1; }
-url="$(git --git-dir="$common_dir" config --get remote.origin.url)"
+url="$(git --git-dir="$common_dir" config --get remote.origin.url 2>/dev/null)" || {
+  echo "dispatch-write-plan: no remote.origin.url in git config at $common_dir" >&2; exit 1; }
 # Resolve owner/repo from the remote so gh addresses the repo independent of cwd
 # (dirname(common_dir) is not a working tree in the bare-repo + worktrees layout).
 # Handles https://github.com/<owner>/<repo>(.git) and git@github.com:<owner>/<repo>(.git).
 repo="${url%.git}"; repo="${repo#*github.com[:/]}"
+[[ -n "$repo" && "$repo" == */* ]] || {
+  echo "dispatch-write-plan: could not resolve owner/repo from remote.origin.url ('$url')" >&2; exit 1; }
 export GH_REPO="$repo"
 
 MARKER='<!-- dispatch:plan -->'

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1100,19 +1100,18 @@ assert_eq "no PR, unplanned → RELEVANCE-REVIEW (directive)" "RELEVANCE-REVIEW"
 assert_eq "no PR, unplanned → RELEVANCE-REVIEW (exit 0)" "0" "$ROUTE_RC"
 teardown
 
-# 1b. No PR + dispatch:planned → INVOKE /plan-implement (implement phase). The
-# transitional build bridge: dispatch-phase reads dispatch:planned → implement,
-# and the implement arm routes straight to the build skill with no relevance
-# review and no parse-job check. #1201 swaps this directive to INVOKE /implement.
-echo "Test: no PR + dispatch:planned → INVOKE /plan-implement"
+# 1b. No PR + dispatch:planned → INVOKE /implement (implement phase). dispatch-phase
+# reads dispatch:planned → implement, and the implement arm routes straight to the
+# build skill with no relevance review and no parse-job check.
+echo "Test: no PR + dispatch:planned → INVOKE /implement"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
 printf '{"labels":[{"name":"dispatch:planned"}]}\n' > "$STUB_DIR/issue-labels-42.json"
 route_run 42 /wt/42-my-feature
-assert_eq "no PR + dispatch:planned → INVOKE /plan-implement (directive)" \
-  "INVOKE /plan-implement" "$ROUTE_OUT"
-assert_eq "no PR + dispatch:planned → INVOKE /plan-implement (exit 0)" "0" "$ROUTE_RC"
+assert_eq "no PR + dispatch:planned → INVOKE /implement (directive)" \
+  "INVOKE /implement" "$ROUTE_OUT"
+assert_eq "no PR + dispatch:planned → INVOKE /implement (exit 0)" "0" "$ROUTE_RC"
 teardown
 
 # 2. Draft + failing CI → INVOKE /verify-pr.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -21296,6 +21296,63 @@ else
   echo "    actual: '$read_err'"
 fi
 rm -rf "$wp_empty"
+
+# 5. bare+worktree repo resolution: from a worktree whose dirname(common_dir) is
+# NOT a git repo (the real bare-repo + worktrees layout), with GH_REPO unset, both
+# scripts must still resolve the repo for gh. This would FAIL against the pre-fix
+# `cd "$(dirname "$common_dir")"` version, which lands in the non-repo container and
+# leaves gh's {owner}/{repo} unresolvable (and GH_REPO unset). The fake gh below
+# requires GH_REPO and never reads cwd, so it stands in for that failure.
+bw_root=$(mktemp -d)
+git init --bare "$bw_root/.bare" >/dev/null 2>&1
+git --git-dir="$bw_root/.bare" config user.email "t@t" 2>/dev/null
+git --git-dir="$bw_root/.bare" config user.name "t" 2>/dev/null
+git --git-dir="$bw_root/.bare" remote add origin https://github.com/natb1/commons.systems.git
+# Seed one commit on the bare repo so `worktree add` works, then add the worktree.
+bw_seed=$(mktemp -d)
+git -C "$bw_seed" init -q
+git -C "$bw_seed" config user.email "t@t"; git -C "$bw_seed" config user.name "t"
+git -C "$bw_seed" commit -q --allow-empty -m seed
+git -C "$bw_seed" remote add bare "$bw_root/.bare"
+git -C "$bw_seed" push -q bare HEAD:refs/heads/main
+mkdir -p "$bw_root/worktrees"
+git --git-dir="$bw_root/.bare" worktree add -q "$bw_root/worktrees/42-foo" main 2>/dev/null
+rm -rf "$bw_seed"
+
+# Fake gh that requires GH_REPO (never reads cwd) over a fresh JSON store.
+mkdir -p "$bw_root/bin"
+BW_STORE="$bw_root/store.json"; BW_COUNTER="$bw_root/counter"
+echo '[]' > "$BW_STORE"; echo '0' > "$BW_COUNTER"
+cat > "$bw_root/bin/gh" <<BWGH
+#!/usr/bin/env bash
+set -uo pipefail
+if [[ -z "\${GH_REPO:-}" ]]; then
+  echo "fatal: not a git repository (GH_REPO unset, no cwd repo)" >&2; exit 1
+fi
+STORE="$BW_STORE"; COUNTER="$BW_COUNTER"
+BWGH
+# Reuse the same emulator body as the main fake gh (everything from method="GET" onward).
+sed -n '/^method="GET"/,$p' "$wp_root/bin/gh" >> "$bw_root/bin/gh"
+chmod +x "$bw_root/bin/gh"
+bash -n "$bw_root/bin/gh" || { FAIL=$((FAIL + 1)); echo "  FAIL: bare+worktree fake gh is not valid bash"; }
+
+# write from the worktree, GH_REPO unset
+if ( cd "$bw_root/worktrees/42-foo" && printf 'PLAN Z\n' | PATH="$bw_root/bin:$SAVED_PATH" env -u GH_REPO "$WP_WRITE" 42 ); then
+  bw_write_rc=0; else bw_write_rc=$?; fi
+assert_eq "write-plan: resolves repo in bare+worktree layout with GH_REPO unset (exit 0)" "0" "$bw_write_rc"
+
+bw_read_out=$( cd "$bw_root/worktrees/42-foo" && PATH="$bw_root/bin:$SAVED_PATH" env -u GH_REPO "$WP_READ" 42 ) && bw_read_rc=0 || bw_read_rc=$?
+assert_eq "read-plan: resolves repo in bare+worktree layout with GH_REPO unset (exit 0)" "0" "$bw_read_rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$bw_read_out" == *"PLAN Z"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: read-plan round-trips the plan in the bare+worktree layout"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: read-plan round-trips the plan in the bare+worktree layout"
+  echo "    actual: '$bw_read_out'"
+fi
+git --git-dir="$bw_root/.bare" worktree prune 2>/dev/null || true
+rm -rf "$bw_root"
+
 rm -rf "$wp_root"
 
 # ============================================================================

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -54,7 +54,7 @@ Act on the one directive:
 | `INVOKE /qa-fix` | 0 | draft PR, CI green, no `dispatch:*` label | invoke `/qa-fix` |
 | `INVOKE /review-fix` | 0 | draft PR + `dispatch:qa-done` (or `dispatch:reviewed` re-entry) | invoke `/review-fix` |
 | `INVOKE /budget-parse-job` | 0 | a statement parse-job issue (`statements:<key>` label, no PR) | invoke `/budget-parse-job` (see below) |
-| `INVOKE /plan-implement` | 0 | no PR + `dispatch:planned` (`implement` phase) — transitional bridge; #1201 → `/implement` | invoke `/plan-implement` (the generic INVOKE path below) |
+| `INVOKE /implement` | 0 | no PR + `dispatch:planned` (`implement` phase) | invoke `/implement` (the generic INVOKE path below) |
 | `INVOKE /dispatch-resolve-conflict` | 0 | provisioning hit an `origin/main` merge conflict | invoke `/dispatch-resolve-conflict` (see below) |
 | `RELEVANCE-REVIEW` | 0 | no PR, unplanned (`plan` phase) | run the Step 2 relevance review, then dispatch its verdict |
 | `STOP done` | 0 | non-draft (ready) PR — should-never-happen; spawn boundary (#1109) prevents it upstream | stop without invoking a phase skill |
@@ -84,13 +84,12 @@ applies none:
   findings as `blocked_by` follow-ups, posts one PR comment covering every
   finding, applies `dispatch:reviewed`, and marks the PR ready. It is idempotent
   on re-entry.
-- **`/plan-implement`** — the `implement`-phase build skill for a no-PR issue that
-  already carries `dispatch:planned` (an approved plan exists). This is a
-  **transitional bridge**: planning already happened in the `plan` phase, so the
-  worker runs no relevance review before it — `dispatch-route` routes the
-  `implement` phase straight here. #1201 swaps this directive to `/implement`,
-  which builds from the persisted `<!-- dispatch:plan -->` comment. No `dispatch:*`
-  label — the draft PR it opens is its own marker.
+- **`/implement`** — the `implement`-phase build skill for a no-PR issue carrying
+  `dispatch:planned`. It reads the plan persisted to the issue's
+  `<!-- dispatch:plan -->` comment, builds each unit via `/implement-unit`, and
+  opens a draft PR. Planning already happened in the `plan` phase, so the worker
+  runs no relevance review before it. No `dispatch:*` label — the draft PR it opens
+  is its own marker.
 
 After the phase skill returns, the worker session ends; the Stop hook reads the
 marker the phase skill wrote and propagates the chain. The worker does not advance

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -144,8 +144,8 @@ fully implemented as written. Base this on the `/implement-unit` outcomes
 observed in Step 2.
 
 **Deviation fires** — skip the `phase-completed` marker. Instead call
-`dispatch-mark-deviation` to write the office-hours-reason atomically. The draft
-PR opened in Step 3 stays open. The Stop hook reads marker-absence as Branch A,
+`dispatch-mark-deviation` to write the office-hours-reason atomically. If Step 3
+already opened a draft PR, it stays open. The Stop hook reads marker-absence as Branch A,
 applies `dispatch:office-hours` to the issue (surfacing this reason in the
 why-comment), and parks the issue for human review.
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: implement
+description: Implement phase — read the persisted plan from the issue's `<!-- dispatch:plan -->` comment, build each unit via /implement-unit, and open a draft PR.
+---
+
+# Implement
+
+The `implement` phase of the issue workflow, dispatched by `/dispatch-propagate`.
+Reads the plan persisted to the issue's `<!-- dispatch:plan -->` comment by the
+`plan` phase, builds each unit, and opens a draft PR. One draft PR with a
+`Closes #N` line is the implement→verify transition marker.
+
+**The main thread never edits files.** It delegates: every code change happens in
+a subagent. Each unit is built by `/implement-unit`, which launches an
+implementation subagent and forks `/commit-merge-push`.
+
+This skill runs in the **caller's thread** — it has no `context:` key — so it can
+fork `/commit-merge-push` and run subagents inline.
+
+## Sandbox
+
+Every `gh`/network call in this skill carries `dangerouslyDisableSandbox: true` —
+`gh` needs network and the sandbox blocks it. See `.claude/rules/sandbox.md`.
+
+## Idempotency preamble
+
+This skill's terminal artifact is the **draft PR** — there is no owned label.
+
+First resolve the target issue number `<N>` from the worktree branch. `/implement`
+operates in place — the **current worktree dictates the target**. The session must
+be in a target worktree: the current branch is `<N>-…`, where `<N>` is the issue
+number. The router (`/dispatch-propagate`) is responsible for entering a target
+worktree; this skill never switches.
+
+```bash
+BRANCH=$(basename "$(git rev-parse --show-toplevel)")
+case "$BRANCH" in
+  [0-9]*-*) N="${BRANCH%%-*}" ;;
+  *)
+    echo "/implement: current branch '$BRANCH' is not a target worktree (expected '<N>-…')" >&2
+    exit 1
+    ;;
+esac
+```
+
+`<N>` is the issue number used by the remaining steps for their `tmp/` filenames.
+
+Then resolve whether a draft PR already exists for the branch (use
+`dangerouslyDisableSandbox: true` — `gh` needs network). `$BRANCH` here is the
+basename resolved above (the `<N>-…` worktree branch name). `gh pr view` exits
+non-zero when no PR exists for the branch — tolerate that and treat it as "no PR":
+
+```bash
+PR_JSON=$(gh pr view "$BRANCH" --json number,state,isDraft 2>/dev/null) || PR_JSON=""
+if [ -n "$PR_JSON" ]; then
+  PR_NUM=$(jq -r .number <<<"$PR_JSON")
+fi
+```
+
+A here-string (`<<<`) is used, not `echo "$PR_JSON" | jq`, because zsh `echo`
+un-escapes `\t`/`\n` in the JSON and injects raw control chars `jq` rejects — see
+`.claude/rules/shell-json.md`.
+
+If a PR already exists, the build + PR already happened: capture its number as
+`PR_NUM`, **skip Steps 1–3**, and go straight to the Step 4 marker write (this
+covers a same-tick crash between PR-open and marker-write). If no PR exists, run
+all steps. (`dispatch-route` normally routes a PR-bearing issue to verify/qa/review,
+not implement, so this is a same-tick crash-recovery edge.)
+
+## Steps
+
+### 1. Read the plan
+
+Read the persisted plan from the issue's `<!-- dispatch:plan -->` comment. Invoke
+and capture stdout (use `dangerouslyDisableSandbox: true` — it calls `gh`):
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-read-plan <N>
+```
+
+The printed body is the ordered unit breakdown (scope + per-unit model +
+dependencies) that drives Step 2.
+
+Exit codes:
+- **exit 1** — no `<!-- dispatch:plan -->` comment on the issue. This
+  should-never-happen for a `dispatch:planned` issue. Escalate via
+  `dispatch-mark-deviation` (skip the `phase-completed` marker) and stop.
+- **exit 2** — non-numeric arg.
+
+`sync-issue-context` also renders this plan under `### Comments` in
+`CLAUDE.local.md`, so it is available as context too.
+
+### 2. Build each unit
+
+For each unit in the plan read in Step 1, in dependency order, invoke
+`/implement-unit` via the Skill tool, passing:
+
+- `model` — the unit's planned model.
+- `scope` — the unit's scope.
+- `context` — the plan and issue context the unit needs.
+- `commit_intent` — the "why" of this unit's change.
+
+`/implement-unit` launches the implementation subagent, forks `/commit-merge-push`,
+and recovers from merge / pre-commit / push errors. This is a normal in-session loop
+— **do not clear context between units**. The model is chosen per the
+model-selection heuristic in `/implement-unit` — see that skill for the heuristic
+(it is the canonical home; do not restate it here).
+
+### 3. Open the draft PR
+
+After every unit is committed and pushed, write the PR body prose to
+`tmp/pr-body.md`, then open the draft PR with `dispatch-open-pr` (use
+`dangerouslyDisableSandbox: true` — the script calls `gh`, which needs network):
+
+```bash
+PR_NUM=$(.claude/skills/dispatch-propagate/scripts/dispatch-open-pr \
+  <primary-issue> \
+  --title "<short summary>" \
+  --closes "<sub-issue-or-blocker> ..." \
+  --body-file tmp/pr-body.md)
+```
+
+`<primary-issue>` is the issue this PR primarily implements; `--closes` lists
+any additional implemented sub-issues or blockers (whitespace- or
+comma-separated, with or without a leading `#`). The script writes one
+`Closes #N` line per issue, appends the prose from `--body-file` (omit the flag
+to read prose from stdin), and echoes the created PR number — the only thing it
+prints on stdout. This draft PR is the implement→verify transition marker.
+
+The script then verifies GitHub parsed exactly the intended close set, per
+`.claude/rules/issue-references.md`: narrative prose can carry a stray closing
+keyword that GitHub reads as an extra close directive. On an extra, the script
+strips the stray keyword and re-applies the body (bounded retries); on a number
+intended-but-missing, or an extra it cannot resolve, it exits non-zero with a
+diagnostic naming the offending number. If it exits non-zero, read the
+diagnostic and fix the body or `--closes` set rather than opening the PR by
+hand.
+
+### 4. Check for deviation, then write the marker (or skip it), then stop
+
+Before writing the marker, judge whether the implementation deviated from the
+persisted plan — scope shifted mid-implementation, or the plan could not be
+fully implemented as written. Base this on the `/implement-unit` outcomes
+observed in Step 2.
+
+**Deviation fires** — skip the `phase-completed` marker. Instead call
+`dispatch-mark-deviation` to write the office-hours-reason atomically. The draft
+PR opened in Step 3 stays open. The Stop hook reads marker-absence as Branch A,
+applies `dispatch:office-hours` to the issue (surfacing this reason in the
+why-comment), and parks the issue for human review.
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+  "/implement: implementation deviated from the persisted plan"
+```
+
+Use the default phrasing above, or make it more specific when the nature of
+the shift is clear (e.g. `/implement: unit 3 scope expanded to cover
+auth; persisted plan did not include auth changes`).
+
+**No deviation** — call `dispatch-mark-complete` as the final action.
+`CLAUDE_JOB_DIR` unset = interactive run; the script no-ops with a clear
+diagnostic.
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-mark-complete \
+  --phase implement --pr "$PR_NUM"
+```
+
+Stop. The Stop hook reads the marker, spawns the next `/dispatch-propagate`
+router, strips `dispatch:office-hours` if present, and self-closes this job.
+
+## Requirement changes mid-session
+
+If the user revises a requirement during this session, invoke `/new-requirement` —
+it clarifies, updates remote issues, re-syncs `CLAUDE.local.md`, and revises this
+plan. Do not handle re-sync inline.


### PR DESCRIPTION
Closes #1201

## Summary

Adds the autonomous `implement` phase of the dispatch chain — the back half of
`/plan-implement`, run in a fresh worker that builds from the persisted plan
rather than from a plan-mode/seeded build greeting. Part of the plan/implement
phase-split epic (#1198), following the `plan` phase (#1200) that persists a plan
to the issue's `<!-- dispatch:plan -->` comment and applies `dispatch:planned`.

## What changed (three units)

**Unit 1 — the `/implement` skill** (`.claude/skills/implement/SKILL.md`, new).
Structured like the sibling autonomous phase skills `/qa-fix` and `/review-fix`:

- Step 0 (idempotency) — resolve `<N>` from the worktree branch; if a draft PR
  already exists for the branch, the build already happened — capture `PR_NUM`,
  skip Steps 1–3, and go straight to the marker write (covers a same-tick crash
  between PR-open and marker-write).
- Step 1 — read the plan via `dispatch-read-plan <N>` (exit 1 = no plan comment,
  escalate; exit 2 = bad arg).
- Step 2 — build each unit via `/implement-unit` in dependency order; no context
  clear between units.
- Step 3 — open the draft PR via `dispatch-open-pr` (the implement→verify marker).
- Step 4 — deviation check → `dispatch-mark-deviation`, else
  `dispatch-mark-complete --phase implement`; then stop. The Stop hook routes onward
  to `verify`.

No plan mode: the skill carries no `EnterPlanMode`/`ExitPlanMode`, no
`showClearContextOnPlanAccept` dependence, and no "plan logical units" step.

**Unit 2 — routing.** `dispatch-route` now routes the `implement` phase (no PR +
`dispatch:planned`) to `INVOKE /implement` instead of the transitional
`/plan-implement` bridge. Updated the header directive list, the `implement)` arm
comment, the `dispatch-worker` SKILL routing table row and prose bullet, and the
routing test.

**Unit 3 — repo-resolution fix.** `dispatch-read-plan` and `dispatch-write-plan`
anchored gh's `{owner}/{repo}` placeholder by `cd "$(dirname "$common_dir")"`,
which in the bare-repo + worktrees layout lands in the non-repo container of
`.bare/` and `worktrees/` — so gh died with `fatal: not a git repository`. Both
scripts now resolve `owner/repo` explicitly from the common dir's
`remote.origin.url` and export `GH_REPO`, independent of cwd. A regression test
exercises the bare+worktree path and would have caught the non-repo `cd`.

## Verification

- `test-dispatch-scripts.sh`: **1988/1988 pass**, including the updated
  `no PR + dispatch:planned → INVOKE /implement` routing test and the new
  bare+worktree repo-resolution regression test.
- `grep -rnE 'EnterPlanMode|ExitPlanMode|showClearContextOnPlanAccept' .claude/skills/implement`
  and `grep -rn 'plan-implement' .claude/skills/implement` both return nothing.
- Real-environment check: from inside a worktree with `GH_REPO` unset,
  `dispatch-read-plan 1201` now exits 0 and prints the plan (it exited 1 against
  the pre-fix `cd` version).

### Sync-renders-plan AC — satisfied by existing behavior, no code change

`sync-issue-context` renders every issue comment (including the
`<!-- dispatch:plan -->` plan) under `### Comments` in `CLAUDE.local.md`, and
`dispatch-materialize-spawn` calls it on **both** the `enter` (existing-worktree
re-entry, line 281) and `create` (line 299) branches. So the plan is re-synced
into the worker's context on existing-worktree re-entry with no change here.

## Scope boundary with #1202

This PR changes only the new skill plus the three routing sites. It deliberately
does **not** touch `restore-dispatch-skill.sh`, `office-hours`, `ref-ready`,
`ref-memory-management`, `dispatch-propagate/reference.md`, or remove the
`plan-implement` directory — that cutover is owned by #1202. Leaving
`restore-dispatch-skill.sh` pointed at `plan-implement` during the #1201→#1202
window is intentional and preserves current recovery behavior.
