### PR TITLE
docs: fix README PR-control-flow row — verify-pr → fix-checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A reference workflow for individuals who want to fork and adapt an agentic codin
 |-------|---------|-------|
 | plan | No PR, unplanned issue | [plan-issue](.claude/skills/plan-issue/SKILL.md) |
 | implement | No PR, dispatch:planned | [implement](.claude/skills/implement/SKILL.md) |
-| verify | Draft PR, CI failed | [verify-pr](.claude/skills/verify-pr/SKILL.md) |
+| fix-checks | Draft PR, CI failed | [fix-checks](.claude/skills/fix-checks/SKILL.md) |
 | waiting | Draft PR, CI in progress | (nothing — wait) |
 | qa | Draft PR, CI green | [qa-fix](.claude/skills/qa-fix/SKILL.md) (autonomous) or [office-hours](.claude/skills/office-hours/SKILL.md) (human-driven; see #758) |
 | code-review | Post-QA code quality | [code-review-fix](.claude/skills/code-review-fix/SKILL.md) (wraps `/code-review`) |


### PR DESCRIPTION
Closes #1247

## Summary

PR #1245 renamed the `/verify-pr` dispatch phase skill to `/fix-checks`, moving
the skill directory from `.claude/skills/verify-pr/` to
`.claude/skills/fix-checks/`. That rename updated the skill files and the
dispatch scripts/tests but left one straggler in `README.md`.

The `### PR Control Flow` table row at `README.md:34` still read:

```
| verify | Draft PR, CI failed | [verify-pr](.claude/skills/verify-pr/SKILL.md) |
```

This fixes both problems on that row:

1. **Dead link** — the Skill-column link `[verify-pr](.claude/skills/verify-pr/SKILL.md)`
   pointed at a path that no longer exists. It now points at the current
   `.claude/skills/fix-checks/SKILL.md`.
2. **Stale phase label** — the Phase-column label `verify` no longer matched the
   renamed phase token `fix-checks` emitted by `dispatch-select-target`. Sibling
   rows keep the Phase column in sync with the phase name (e.g. `qa` → `qa-fix`,
   `code-review` → `code-review-fix`), so this row now reads `fix-checks`.

The row now reads:

```
| fix-checks | Draft PR, CI failed | [fix-checks](.claude/skills/fix-checks/SKILL.md) |
```

## Verification

- `git grep -n verify-pr -- README.md` returns no matches.
- The Skill-column link resolves to the existing `.claude/skills/fix-checks/SKILL.md`.
- The Phase column reads `fix-checks`, matching the renamed phase token and the
  sibling-row convention.
