### PR TITLE
budget: poll-until-settled in the Sankey-node-click category-filter e2e test

### DIFF
--- a/budget/e2e/transactions.spec.ts
+++ b/budget/e2e/transactions.spec.ts
@@ -287,9 +287,11 @@ test.describe("transactions", () => {
     const filterInput = page.locator("#sankey-category-filter");
     await expect(filterInput).not.toHaveValue("");
     const filterValue = await filterInput.inputValue();
+    // count() is a one-shot snapshot with no auto-wait; poll until the
+    // click-triggered category-filter re-render settles before reading the count.
+    await expect.poll(async () => visibleRows.count()).toBeLessThan(countBefore);
     const countAfter = await visibleRows.count();
     expect(countAfter).toBeGreaterThan(0);
-    expect(countAfter).toBeLessThanOrEqual(countBefore);
     for (let i = 0; i < countAfter; i++) {
       const category = await visibleRows.nth(i).getAttribute("data-category");
       expect(category).toMatch(new RegExp(`^${filterValue}`));


### PR DESCRIPTION
Closes #1067

## Summary

The e2e test `"clicking a Sankey node text label sets the category filter"` in
`budget/e2e/transactions.spec.ts` read the post-filter visible row count via
Playwright's one-shot `locator.count()` immediately after asserting the
category-filter input was populated — with no poll for the row-visibility DOM
update to settle. The filter input populating does not guarantee the `.txn-row`
visibility has re-rendered, so under CI load `countAfter` could still reflect the
full pre-filter set (118 seed rows) and the per-row `data-category` regex loop
would then check rows of other categories — a flaky failure.

This is the same race class fixed for the blur-triggered budget-filter tests in
PR #1028 (commit `53a82753`). This change applies the same poll-until-settled
pattern.

## Change

In the test body, before the `const countAfter = await visibleRows.count();`
read:

- Add an auto-retrying
  `await expect.poll(async () => visibleRows.count()).toBeLessThan(countBefore)`
  poll, which lets the click-triggered filter re-render settle before the count
  is snapshotted.
- Remove the now-redundant immediate
  `expect(countAfter).toBeLessThanOrEqual(countBefore)` assertion — the poll
  establishes the strict reduction (the 118-transaction fixture always narrows
  to a strict subset for a single category).

`expect(countAfter).toBeGreaterThan(0)` and the per-row regex loop are unchanged.
Test-only change — no production code is touched.

## Verification

- Diff touches only the one test block in `budget/e2e/transactions.spec.ts`.
- The `expect` / `expect.poll` API comes from the shared
  `@commons-systems/config/playwright-test` import already at the top of the
  file; the budget acceptance suite runs in CI.
