### PR TITLE
functions deploy: classify OFFICE_HOURS_GROUP_REPO / OFFICE_HOURS_MEMBER_EMAILS as vars.* in both workflows

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -53,8 +53,8 @@ jobs:
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           OFFICE_HOURS_GITHUB_APP_ID: ${{ vars.OFFICE_HOURS_GITHUB_APP_ID }}
           OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID: ${{ vars.OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID }}
-          OFFICE_HOURS_GROUP_REPO: ${{ secrets.OFFICE_HOURS_GROUP_REPO }}
-          OFFICE_HOURS_MEMBER_EMAILS: ${{ secrets.OFFICE_HOURS_MEMBER_EMAILS }}
+          OFFICE_HOURS_GROUP_REPO: ${{ vars.OFFICE_HOURS_GROUP_REPO }}
+          OFFICE_HOURS_MEMBER_EMAILS: ${{ vars.OFFICE_HOURS_MEMBER_EMAILS }}
         run: |
           if git diff --name-only origin/main...HEAD | grep -q '^functions/'; then
             .claude/skills/dispatch-propagate/scripts/npm-ci-with-retry.sh


### PR DESCRIPTION
Closes #1113

## Problem

Two CI workflows referenced the same two office-hours config values from
different GitHub Actions stores:

- `.github/workflows/functions-deploy.yml` (production deploy) read
  `OFFICE_HOURS_GROUP_REPO` and `OFFICE_HOURS_MEMBER_EMAILS` from `vars.*`
  (repository Variables).
- `.github/workflows/pr-checks.yml` (PR preview deploy) read the same two values
  from `secrets.*` (repository Secrets).

That split cannot be correct in both places. The consuming function settles the
classification authoritatively: `functions/src/office-hours-sync.ts` defines
`OFFICE_HOURS_GROUP_REPO` and `OFFICE_HOURS_MEMBER_EMAILS` via `defineString`
(non-secret config params); only `OFFICE_HOURS_GITHUB_APP_PRIVATE_KEY` is a
`defineSecret`. The values are stored as repository Variables. So the `secrets.*`
references in `pr-checks.yml` resolved to **empty strings**, tripping the
function's empty-config guard — the PR-check functions deploy silently ran the
sync function dormant while still reporting success.

## Fix

Align `pr-checks.yml` to `vars.*` for both values, matching `functions-deploy.yml`
and the function's own `defineString` classification. The two app-ID params in the
same `env:` block were already `vars.*`, so all four office-hours `defineString`
params now read from repository Variables consistently.

The PII concern raised for `OFFICE_HOURS_MEMBER_EMAILS` does not change this: the
function consumes it as a plaintext `defineString` written into a dotenv either
way, so routing the CI reference through Secrets would not protect the value at
the function boundary — it would only mismatch the function's design and the
actual storage state.

No GitHub repository settings change is required: the values already exist as
Variables.

## Scope

Two-line edit in `.github/workflows/pr-checks.yml`. The `FIREBASE_*` / `VITE_*` /
`GITHUB_TOKEN` references (genuinely secrets) are unchanged; `functions-deploy.yml`
was already correct and is untouched.

## Verification

No unit/Playwright suite covers Actions var/secret resolution. The real
end-to-end check is a subsequent PR touching `functions/` that deploys the sync
function with populated config rather than tripping the empty-config guard —
observable in the PR-check deploy logs, not in this PR.

Pre-existing before the office-hours rename (was `vars.AGENDA_*` vs
`secrets.AGENDA_*`); PR #1102 only renamed the identifiers and preserved the
mismatch verbatim. Surfaced during review of #1102.
