### PR TITLE
ci: remove redundant PR-time prod functions deploy from pr-checks.yml

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -48,22 +48,6 @@ jobs:
         env:
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
         run: .github/scripts/firebase-auth.sh
-      - name: Deploy Cloud Functions (if changed)
-        env:
-          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-          OFFICE_HOURS_GITHUB_APP_ID: ${{ vars.OFFICE_HOURS_GITHUB_APP_ID }}
-          OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID: ${{ vars.OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID }}
-          OFFICE_HOURS_GROUP_REPO: ${{ vars.OFFICE_HOURS_GROUP_REPO }}
-          OFFICE_HOURS_MEMBER_EMAILS: ${{ vars.OFFICE_HOURS_MEMBER_EMAILS }}
-        run: |
-          if git diff --name-only origin/main...HEAD | grep -q '^functions/'; then
-            .claude/skills/dispatch-propagate/scripts/npm-ci-with-retry.sh
-            npm run -w functions build
-            printf 'OFFICE_HOURS_GITHUB_APP_ID=%s\nOFFICE_HOURS_GITHUB_APP_INSTALLATION_ID=%s\nOFFICE_HOURS_GROUP_REPO=%s\nOFFICE_HOURS_MEMBER_EMAILS=%s\nOFFICE_HOURS_FIRESTORE_NAMESPACE=office-hours/prod\n' \
-              "$OFFICE_HOURS_GITHUB_APP_ID" "$OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID" "$OFFICE_HOURS_GROUP_REPO" "$OFFICE_HOURS_MEMBER_EMAILS" \
-              > functions/.env
-            npx firebase-tools deploy --only functions --force --project "$FIREBASE_PROJECT_ID"
-          fi
       - name: Deploy previews and run smoke tests
         id: deploy
         env:


### PR DESCRIPTION
Closes #1256

## Problem

Firebase Functions v2 loads `functions/.env` (base) then the project-specific
`functions/.env.commons-systems` override; the override wins per key. The
committed `functions/.env.commons-systems` carries all five office-hours keys as
**empty** strings (deliberate — it deploys `syncOfficeHours` dormant for
unconfigured/local deploys).

`pr-checks.yml`'s "Deploy Cloud Functions (if changed)" step wrote the **base**
`functions/.env` from Actions config, then deployed to the prod `commons-systems`
project. But the committed empty `functions/.env.commons-systems` is loaded
afterward and its empty values win for every key. So a PR touching `functions/**`
deployed `syncOfficeHours` to **prod** with empty config — it deployed dormant,
the step reported success, and the config the workflow wrote was dead code.

This is the same base-vs-override precedence trap #1056 raised; commit `5eec7e45`
fixed it only for `functions-deploy.yml` (by writing the override file), leaving
`pr-checks.yml` writing the base file.

## Fix

Remove the "Deploy Cloud Functions (if changed)" step from `pr-checks.yml`
entirely. Deploying unmerged function code live to prod pre-merge is the deeper
smell; `.github/workflows/functions-deploy.yml` (push to `main`, which writes the
override `functions/.env.commons-systems`) is the canonical deploy. Removing the
redundant step eliminates the precedence trap by eliminating the redundant path.

This is the greenfield design the issue leads with, in preference to the
alternative (keep the PR-time deploy but write the override file) — the removal is
strictly simpler and removes the prod-safety smell.

## Scope

- Deletes only the one step from the `preview-and-smoke` job. The preceding
  `Authenticate with Firebase` step stays (the `Deploy previews and run smoke
  tests` step needs that auth), as do all other steps and the `acceptance` job.
- `functions/.env.commons-systems` stays committed and empty, byte-for-byte
  unchanged.
- `functions-deploy.yml` (the canonical deploy path) is unchanged.

## Acceptance criteria

- A PR touching `functions/**` no longer deploys `syncOfficeHours` to prod with
  config silently defeated — the redundant path is gone entirely.
- The two deploy paths agree on which dotenv file carries config — only one
  deploy path (`functions-deploy.yml`, writing the override) remains.
- The committed `functions/.env.commons-systems` stays empty in git — untouched.

Follow-up to #1056; builds on #1113 / #1251 (the `vars.*` classification already
merged to `main`).
