### PR TITLE
dispatch: fix Branch C no-PR gap in dispatch-stop.sh for fix-* phases

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -43,29 +43,34 @@
 #      and the ISSUE, spawn router, self-close. Empty CURRENT_PHASE (e.g.
 #      dispatch-phase network failure) is treated as "undetermined" and falls
 #      through to Branch D rather than triggering a false self-close.
-#   C. marker present + same phase + CURRENT_PHASE is any fix-* phase +
-#      dispatch:<fix-phase>-attempt counter < 3 — transient no-push fix-* outcome.
-#      CI has already concluded and nothing is pending: a fix-* pass that pushes a
-#      fix restarts CI, and the early not-ready gate above already intercepts and
-#      self-closes that in-progress case when the marker is present, so by the time
-#      control reaches Branch C, CI is concluded and not re-running. Spawn router,
-#      self-close (so the session does not leak idle holding its worktree); the
-#      next tick re-runs the fix-* phase or escalates at the cap. The needs-human
-#      fix-* failure never reaches Branch C — the fix-* skill skips the marker for
-#      it, so it lands in Branch A (marker absent → park the issue on office-hours
-#      on the first run).
-#   D. marker present + same phase + NOT (fix-* AND counter < 3) — true
-#      non-advancement (or a hypothetical same-phase non-fix-* case). Park the
-#      ISSUE on a human via dispatch-apply-office-hours (label + why-comment),
-#      spawn router, exit 0.
+#   C. marker present + same phase + CURRENT_PHASE is any fix-* phase — transient
+#      no-push fix-* outcome. Two sub-cases:
+#      (a) PR_NUM set + dispatch:<fix-phase>-attempt counter < 3: CI has already
+#          concluded and nothing is pending. Spawn router, self-close (so the
+#          session does not leak idle holding its worktree); the next tick
+#          re-runs the fix-* phase or escalates at the cap. The needs-human
+#          fix-* failure never reaches Branch C — the fix-* skill skips the marker
+#          for it, so it lands in Branch A (marker absent → park the issue on
+#          office-hours on the first run).
+#      (b) PR_NUM empty (no-PR provisioning backstop, e.g. a fix-conflicts pass
+#          that ran during the implement phase before any PR existed): the attempt
+#          counter lives on a PR label and does not exist yet. Always self-close
+#          and re-seed the chain — the marker being present means the fix-* skill
+#          completed a resolvable conflict. The implement phase that opens the PR
+#          runs on the next tick.
+#   D. marker present + same phase + NOT Branch C (i.e. PR-present and attempt
+#      counter >= 3, or a hypothetical same-phase non-fix-* case) — true
+#      non-advancement. Park the ISSUE on a human via dispatch-apply-office-hours
+#      (label + why-comment), spawn router, exit 0.
 #
 # CLOSING NOTE (post-#1108): NO worker branch self-parks idle waiting on pending
 # work. The early not-ready gate self-closes its concluded-CI marker-present case
 # and hands back its in-progress marker-absent case; Branch C self-closes its
-# concluded no-push case. The remaining exit-0-without-self-close branches —
-# Branch A and Branch D office-hours parks, and the early-gate marker-absent
-# TOCTOU hand-back — are deliberate human-review parks or router hand-backs, not
-# idle waiters.
+# concluded no-push case (both the PR-present counter-below-cap sub-case and the
+# no-PR provisioning backstop sub-case). The remaining exit-0-without-self-close
+# branches — Branch A and Branch D office-hours parks, and the early-gate
+# marker-absent TOCTOU hand-back — are deliberate human-review parks or router
+# hand-backs, not idle waiters.
 #
 # Discriminator: only acts for a /dispatch-worker job. Skipped when
 # CLAUDE_JOB_DIR is unset (interactive session), state.json is missing, or the
@@ -246,6 +251,16 @@ case "$CURRENT_PHASE" in
         self_close
         exit 0
       fi
+      # counter at cap: fall through to Branch D (office-hours park)
+    else
+      # Branch C — no-PR provisioning backstop (e.g. a fix-conflicts pass that
+      # ran during the implement phase, before any PR existed). No attempt
+      # counter exists (it lives on a PR label), so always self-close and
+      # re-seed the chain rather than parking — the marker being present means
+      # the fix-* skill completed a resolvable conflict.
+      spawn_tick
+      self_close
+      exit 0
     fi
     ;;
 esac

--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -257,7 +257,7 @@ case "$CURRENT_PHASE" in
       # ran during the implement phase, before any PR existed). No attempt
       # counter exists (it lives on a PR label), so always self-close and
       # re-seed the chain rather than parking — the marker being present means
-      # the fix-* skill completed a resolvable conflict.
+      # the fix-* skill completed successfully.
       spawn_tick
       self_close
       exit 0

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -14919,6 +14919,13 @@ if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: stop fix-conflicts-no-pr-backstop: apply-office-hours not invoked (did not park on office-hours)"
 fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" \
+   && ! -e "$STUB_DIR/gh-pr-remove.log" && ! -e "$STUB_DIR/gh-issue-remove.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop fix-conflicts-no-pr-backstop: no label add or remove invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop fix-conflicts-no-pr-backstop: no label add or remove invoked"
+fi
 stop_teardown
 
 # --- Test FC2: fix-conflicts marker, same phase, counter >= 3 → Branch D (fuse)

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -14892,6 +14892,35 @@ spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
 assert_eq "stop fix-conflicts-retry: spawn invoked exactly once" "1" "$spawn_calls"
 stop_teardown
 
+# --- Test FC1b: fix-conflicts marker, same phase, no PR (no-PR backstop) → Branch C retry
+# A fix-conflicts pass spawned during the implement phase (before any PR exists)
+# writes phase=fix-conflicts but PR_NUM is empty — the attempt counter (which
+# lives on a PR label) does not exist. The no-PR else branch of Branch C always
+# self-closes and re-seeds the chain, bypassing the counter. Branch D (park on
+# office-hours) must NOT fire.
+echo "Test: stop hook + same phase + fix-conflicts + no PR (backstop) → Branch C retry → spawn + self-close"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+# OMIT find-pr-output → PR_NUM="" (no-PR provisioning backstop)
+echo "fix-conflicts" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+echo "phase=fix-conflicts" > "$TMPDIR_TEST/jobs/abcd1234/phase-completed"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+"$TMPDIR_TEST/hooks/dispatch-stop.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "stop fix-conflicts-no-pr-backstop: hook exits 0" "0" "$rc"
+self_close_calls=$(wc -l < "$STUB_DIR/self-close-calls.log" 2>/dev/null || echo 0)
+assert_eq "stop fix-conflicts-no-pr-backstop: self-close invoked exactly once" "1" "$self_close_calls"
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "stop fix-conflicts-no-pr-backstop: spawn invoked exactly once" "1" "$spawn_calls"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop fix-conflicts-no-pr-backstop: apply-office-hours not invoked (did not park on office-hours)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop fix-conflicts-no-pr-backstop: apply-office-hours not invoked (did not park on office-hours)"
+fi
+stop_teardown
+
 # --- Test FC2: fix-conflicts marker, same phase, counter >= 3 → Branch D (fuse)
 # A conflict that recurs three times blows the fuse: at attempt 3 the #831
 # invariant falls through to Branch D, parking the issue on dispatch:office-hours


### PR DESCRIPTION
Closes #1253

## Problem

When a `fix-conflicts` session completes in the provisioning backstop — spawned
during the `implement` phase before any PR exists — `dispatch-stop.sh`'s Branch C
self-close path is skipped, because the entire branch is gated by
`if [ -n "$PR_NUM" ]`. With `PR_NUM` empty, control falls through to **Branch D**,
which parks the issue on `dispatch:office-hours`. That blocks the `implement`
phase from ever running — and the implement phase is what would open the PR that
gives the attempt counter a home.

The marker being present means the `fix-*` skill resolved a conflict and wrote a
clean outcome; the chain should continue (self-close + re-seed), not park. The
no-PR backstop has no attempt counter (the counter lives on a PR label), so it
must bypass the counter entirely and always self-close.

## Fix

Restructure the Branch C guard in the `fix-*)` case of `dispatch-stop.sh`. The
existing PR-present arm is preserved byte-for-byte (counter `< 3` → self-close;
counter `>= 3` → fall through to Branch D). A new `else` branch handles the no-PR
provisioning backstop: with no PR (and therefore no attempt counter), always
self-close and re-seed the chain rather than parking.

The Branch C / Branch D header doc-comment is updated to document the two Branch C
sub-cases (PR-present counter-below-cap, and no-PR backstop) and to note that
Branch D is reached only in the PR-present at-cap case.

## Test

Adds stop-hook test **FC1b** to `test-dispatch-scripts.sh`, mirroring the
existing PR-present Branch C test FC1 but omitting `find-pr-output` (leaving
`PR_NUM` empty). It asserts the hook exits 0, self-closes once, spawns a tick
once, and does **not** park on `dispatch:office-hours`.

## Acceptance criteria

- [x] Branch C fires (self-close + spawn tick) when: `fix-*` marker present +
      `CURRENT_PHASE` matches + `PR_NUM` empty.
- [x] Branch D (office-hours park) is NOT triggered in the no-PR same-phase
      `fix-*` case.
- [x] Existing PR-present Branch C behavior unchanged (counter `< 3` → self-close;
      `>= 3` → Branch D park).
- [x] A stop-hook test covers fix-conflicts marker present + `CURRENT_PHASE=fix-conflicts`
      + empty `PR_NUM` → exit 0, spawns tick, does not park on office-hours.
