### PR TITLE
office-hours: migrate OFFICE_HOURS_MEMBER_EMAILS to defineSecret (Secret Manager only)

### DIFF
--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -32,20 +32,19 @@ jobs:
       # syncOfficeHours's non-secret defineString params come from repository
       # Variables, written into the dotenv firebase-tools reads at deploy time.
       # Unset Variables yield empty values, which deploy the function dormant.
-      # The private key is the only secret and lives in Secret Manager, not here.
+      # The App private key and member emails are both secrets in Secret Manager;
+      # neither flows through this workflow.
       - name: Write office-hours function config
         env:
           OFFICE_HOURS_GITHUB_APP_ID: ${{ vars.OFFICE_HOURS_GITHUB_APP_ID }}
           OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID: ${{ vars.OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID }}
           OFFICE_HOURS_GROUP_REPO: ${{ vars.OFFICE_HOURS_GROUP_REPO }}
-          OFFICE_HOURS_MEMBER_EMAILS: ${{ vars.OFFICE_HOURS_MEMBER_EMAILS }}
           OFFICE_HOURS_FIRESTORE_NAMESPACE: ${{ vars.OFFICE_HOURS_FIRESTORE_NAMESPACE || 'office-hours/prod' }}
         run: |
           cat > functions/.env.commons-systems <<EOF
           OFFICE_HOURS_GITHUB_APP_ID=${OFFICE_HOURS_GITHUB_APP_ID}
           OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID=${OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID}
           OFFICE_HOURS_GROUP_REPO=${OFFICE_HOURS_GROUP_REPO}
-          OFFICE_HOURS_MEMBER_EMAILS=${OFFICE_HOURS_MEMBER_EMAILS}
           OFFICE_HOURS_FIRESTORE_NAMESPACE=${OFFICE_HOURS_FIRESTORE_NAMESPACE}
           EOF
       - name: Deploy functions

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -54,13 +54,12 @@ jobs:
           OFFICE_HOURS_GITHUB_APP_ID: ${{ vars.OFFICE_HOURS_GITHUB_APP_ID }}
           OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID: ${{ vars.OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID }}
           OFFICE_HOURS_GROUP_REPO: ${{ vars.OFFICE_HOURS_GROUP_REPO }}
-          OFFICE_HOURS_MEMBER_EMAILS: ${{ vars.OFFICE_HOURS_MEMBER_EMAILS }}
         run: |
           if git diff --name-only origin/main...HEAD | grep -q '^functions/'; then
             .claude/skills/dispatch-propagate/scripts/npm-ci-with-retry.sh
             npm run -w functions build
-            printf 'OFFICE_HOURS_GITHUB_APP_ID=%s\nOFFICE_HOURS_GITHUB_APP_INSTALLATION_ID=%s\nOFFICE_HOURS_GROUP_REPO=%s\nOFFICE_HOURS_MEMBER_EMAILS=%s\nOFFICE_HOURS_FIRESTORE_NAMESPACE=office-hours/prod\n' \
-              "$OFFICE_HOURS_GITHUB_APP_ID" "$OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID" "$OFFICE_HOURS_GROUP_REPO" "$OFFICE_HOURS_MEMBER_EMAILS" \
+            printf 'OFFICE_HOURS_GITHUB_APP_ID=%s\nOFFICE_HOURS_GITHUB_APP_INSTALLATION_ID=%s\nOFFICE_HOURS_GROUP_REPO=%s\nOFFICE_HOURS_FIRESTORE_NAMESPACE=office-hours/prod\n' \
+              "$OFFICE_HOURS_GITHUB_APP_ID" "$OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID" "$OFFICE_HOURS_GROUP_REPO" \
               > functions/.env
             npx firebase-tools deploy --only functions --force --project "$FIREBASE_PROJECT_ID"
           fi

--- a/functions/.env.commons-systems
+++ b/functions/.env.commons-systems
@@ -11,10 +11,15 @@
 # the fallback for an unconfigured environment (and for a manual local deploy):
 # an empty OFFICE_HOURS_GROUP_REPO trips the function's first runtime guard, so
 # syncOfficeHours deploys dormant and skips every run (one cheap log line, no GitHub
-# API calls). The private key is the only secret and lives in Secret Manager:
+# API calls). Two values are secrets resolved from Secret Manager at runtime, not
+# from this file — they never enter git. Each is set once out-of-band via:
 #   firebase functions:secrets:set OFFICE_HOURS_GITHUB_APP_PRIVATE_KEY
+#   firebase functions:secrets:set OFFICE_HOURS_MEMBER_EMAILS
+# OFFICE_HOURS_MEMBER_EMAILS must NOT be declared here: as a defineSecret param it
+# would overlap a non-secret env var of the same name and the Cloud Run deploy
+# would reject it ("Secret environment variable overlaps non secret environment
+# variable").
 OFFICE_HOURS_GITHUB_APP_ID=
 OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID=
 OFFICE_HOURS_GROUP_REPO=
-OFFICE_HOURS_MEMBER_EMAILS=
 OFFICE_HOURS_FIRESTORE_NAMESPACE=office-hours/prod

--- a/functions/src/office-hours-sync.ts
+++ b/functions/src/office-hours-sync.ts
@@ -8,11 +8,13 @@
 // reminder. The GitHub project's `Due` field is not used.
 //
 // Authentication — GitHub App, not a personal access token:
-//   - The App's private key (PEM) is the only Functions secret. It does not
-//     expire, so there is no token to rotate on a cadence. Set it once per
-//     project via the interactive prompt (paste the full PEM):
+//   - There are two Functions secrets, each set once per project via the
+//     interactive prompt. Neither ever flows through CI or `.env` files.
+//     App private key (paste the full PEM):
 //         firebase functions:secrets:set OFFICE_HOURS_GITHUB_APP_PRIVATE_KEY
-//   - On each run the function signs a short-lived JWT with that key and
+//     Member emails (comma-separated PII list of member email addresses):
+//         firebase functions:secrets:set OFFICE_HOURS_MEMBER_EMAILS
+//   - On each run the function signs a short-lived JWT with the private key and
 //     exchanges it for a ~1-hour installation access token, which it uses to
 //     call the GitHub API. The installation token self-expires; nothing
 //     long-lived is stored.
@@ -21,7 +23,6 @@
 //         OFFICE_HOURS_GITHUB_APP_ID=123456
 //         OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID=87654321
 //         OFFICE_HOURS_GROUP_REPO=natb1/office-hours-nate
-//         OFFICE_HOURS_MEMBER_EMAILS=owner@example.com
 //         OFFICE_HOURS_FIRESTORE_NAMESPACE=office-hours/prod
 //     The App must be installed on the `natb1/office-hours-nate` repo with read-only
 //     `Issues` permission.
@@ -39,7 +40,7 @@ const GH_APP_PRIVATE_KEY = defineSecret("OFFICE_HOURS_GITHUB_APP_PRIVATE_KEY");
 const GH_APP_ID = defineString("OFFICE_HOURS_GITHUB_APP_ID");
 const GH_APP_INSTALLATION_ID = defineString("OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID");
 const GROUP_REPO = defineString("OFFICE_HOURS_GROUP_REPO");
-const MEMBER_EMAILS = defineString("OFFICE_HOURS_MEMBER_EMAILS");
+const MEMBER_EMAILS = defineSecret("OFFICE_HOURS_MEMBER_EMAILS");
 const NAMESPACE = defineString("OFFICE_HOURS_FIRESTORE_NAMESPACE", { default: "office-hours/prod" });
 
 const adminApp = getApps().length > 0 ? getApps()[0] : initializeApp();
@@ -324,7 +325,7 @@ export async function fetchOpenJitIssuesLive(
 export const syncOfficeHours = onSchedule(
   {
     schedule: "every 30 minutes",
-    secrets: [GH_APP_PRIVATE_KEY],
+    secrets: [GH_APP_PRIVATE_KEY, MEMBER_EMAILS],
     timeoutSeconds: 120,
   },
   async () => {


### PR DESCRIPTION
Closes #1257

## Summary

`OFFICE_HOURS_MEMBER_EMAILS` is a comma-separated PII list of member email
addresses. It was a non-secret `defineString` param stored as a GitHub
repository **Variable**, written verbatim into `functions/.env*` on every CI
deploy, and visible unmasked in workflow logs — any user with repo read access
could enumerate it.

This PR migrates the value to a `defineSecret` param resolved from Google
Secret Manager at runtime, mirroring the existing
`OFFICE_HOURS_GITHUB_APP_PRIVATE_KEY` precedent in the same file.

## Changes

- `functions/src/office-hours-sync.ts`: `MEMBER_EMAILS` is now
  `defineSecret("OFFICE_HOURS_MEMBER_EMAILS")` (was `defineString`) and is bound
  to the `syncOfficeHours` function's `secrets: [...]` array. The doc comment now
  documents two Functions secrets (private key + member emails), each set once
  via `firebase functions:secrets:set`, and drops the member-emails line from the
  `.env` example block.
- `.github/workflows/functions-deploy.yml` and `.github/workflows/pr-checks.yml`:
  removed the `OFFICE_HOURS_MEMBER_EMAILS` env reference and its `.env`-generation
  line from both. The value no longer flows through any CI env, `.env` file, or
  GitHub Variable. `grep -rn "OFFICE_HOURS_MEMBER_EMAILS" .github/` returns
  nothing.

## ⚠️ Operational prerequisite (owner, before merge)

`defineSecret` params resolve from Secret Manager at deploy time. Like the
Firestore-rules serialization hazard, the deploy that runs on merge needs the
secret to **already exist**, or the non-interactive deploy will fail. Before
merging:

1. Set the secret in Secret Manager:
   ```
   firebase functions:secrets:set OFFICE_HOURS_MEMBER_EMAILS
   ```
2. Delete the now-unused GitHub repository **Variable**
   `OFFICE_HOURS_MEMBER_EMAILS` (Settings → Actions → Variables).

## Note for reviewers: intentional divergence from acceptance criteria #2/#3

The issue's criteria #2/#3 ask that the workflows pass the value via `secrets.*`.
This PR instead **removes the CI reference entirely** (Design A, owner-confirmed
on the issue). That is strictly stronger for PII protection: rather than routing
the value through CI as a masked secret, the value never touches CI at all —
exactly like `OFFICE_HOURS_GITHUB_APP_PRIVATE_KEY`, which is also set once
out-of-band in Secret Manager and referenced by neither workflow. Criteria #1,
#4 (no `vars.*`), #5 (function `secrets:` array), and #6 (never printed in logs)
are satisfied; #2/#3 are superseded by this stronger single-source-of-truth
design. Please don't flag the absent `secrets.*` reference as a miss.
