### PR TITLE
firestore.rules: clamp reading-position writes and close the read existence oracle

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -256,14 +256,20 @@ service cloud.firestore {
     }
 
     // Reading positions are private per-user documents keyed by {uid}_{mediaId}.
-    // Only the owning user may read or write their own position.
+    // Reads are authorized by docId prefix (the requester's own uid), not by
+    // resource.data.uid — this returns the same answer whether or not the doc
+    // exists, closing the cross-user existence oracle while keeping first-visit
+    // getDoc() on the user's own doc working. Writes are clamped to exactly the
+    // three expected fields, each type-checked.
     match /print/{env}/reading-position/{docId} {
       allow read: if request.auth != null
-        // resource == null allows getDoc() on a non-existent doc (first visit)
-        && (resource == null || request.auth.uid == resource.data.uid);
+        && docId.split("_")[0] == request.auth.uid;
       allow write: if request.auth != null
         && request.auth.uid == request.resource.data.uid
-        && request.resource.data.keys().hasAll(['uid', 'mediaId', 'position'])
+        && request.resource.data.keys().hasOnly(['uid', 'mediaId', 'position'])
+        && request.resource.data.uid is string
+        && request.resource.data.mediaId is string
+        && request.resource.data.position is string
         && docId == request.auth.uid + "_" + request.resource.data.mediaId;
     }
 

--- a/rules-test/test/firestore/print.test.ts
+++ b/rules-test/test/firestore/print.test.ts
@@ -63,6 +63,14 @@ describe("print reading-position", () => {
       );
     });
 
+    it("denies reading another user's non-existent position (no existence oracle)", async () => {
+      const ctx = env.authenticatedContext("other-user");
+      const db = ctx.firestore();
+      await assertFails(
+        getDoc(doc(db, `print/${ENV}/reading-position/${UID}_nonexistent`)),
+      );
+    });
+
     it("denies unauthenticated read", async () => {
       const ctx = unauthenticatedContext(env);
       const db = ctx.firestore();
@@ -82,7 +90,7 @@ describe("print reading-position", () => {
         setDoc(doc(db, `print/${ENV}/reading-position/${newDocId}`), {
           uid: UID,
           mediaId: newMediaId,
-          position: 0,
+          position: "0",
         }),
       );
     });
@@ -92,7 +100,44 @@ describe("print reading-position", () => {
       const db = ctx.firestore();
       await assertSucceeds(
         updateDoc(doc(db, `print/${ENV}/reading-position/${DOC_ID}`), {
-          position: 100,
+          position: "100",
+        }),
+      );
+    });
+
+    it("denies write with an extra field (hasOnly)", async () => {
+      const ctx = env.authenticatedContext(UID);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `print/${ENV}/reading-position/${DOC_ID}`), {
+          uid: UID,
+          mediaId: MEDIA_ID,
+          position: "0",
+          extra: "x",
+        }),
+      );
+    });
+
+    it("denies write with a non-string position", async () => {
+      const ctx = env.authenticatedContext(UID);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `print/${ENV}/reading-position/${DOC_ID}`), {
+          uid: UID,
+          mediaId: MEDIA_ID,
+          position: 5,
+        }),
+      );
+    });
+
+    it("denies write with a non-string mediaId", async () => {
+      const ctx = env.authenticatedContext(UID);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `print/${ENV}/reading-position/${UID}_123`), {
+          uid: UID,
+          mediaId: 123,
+          position: "0",
         }),
       );
     });
@@ -104,7 +149,7 @@ describe("print reading-position", () => {
         setDoc(doc(db, `print/${ENV}/reading-position/${DOC_ID}`), {
           uid: "wrong-uid",
           mediaId: MEDIA_ID,
-          position: 0,
+          position: "0",
         }),
       );
     });
@@ -116,7 +161,7 @@ describe("print reading-position", () => {
         setDoc(doc(db, `print/${ENV}/reading-position/wrong_doc`), {
           uid: UID,
           mediaId: MEDIA_ID,
-          position: 0,
+          position: "0",
         }),
       );
     });
@@ -139,7 +184,7 @@ describe("print reading-position", () => {
         setDoc(doc(db, `print/${ENV}/reading-position/${DOC_ID}`), {
           uid: "other-user",
           mediaId: MEDIA_ID,
-          position: 0,
+          position: "0",
         }),
       );
     });


### PR DESCRIPTION
Closes #1297

Fixes two security defects in the `match /print/{env}/reading-position/{docId}`
Firestore rule.

## Read — close the cross-user existence oracle

The old read rule

```
allow read: if request.auth != null
  && (resource == null || request.auth.uid == resource.data.uid);
```

let any authed user probe `getDoc("print/prod/reading-position/{victimUid}_{mediaId}")`:
success (`resource == null`) meant the doc was absent, permission-denied meant it
was present — leaking whether another user had opened a specific media item.

The read rule now authorizes by **docId prefix** (the requester's own uid),
without touching `resource`:

```
allow read: if request.auth != null
  && docId.split("_")[0] == request.auth.uid;
```

Firebase uids are alphanumeric (no `_`), so the prefix before the first `_` is
exactly the owner uid. This returns the same answer whether or not the doc
exists — closing the oracle — and keeps first-visit `getDoc()` on the user's own
`{uid}_{mediaId}` doc working.

## Write — clamp keys and type-check fields

The old write rule used `hasAll(['uid','mediaId','position'])` with no `hasOnly`
clamp and no type validation, so an authed user could store arbitrary extra
fields under their own key. This was the only client-writable collection lacking
a `hasOnly` clamp. The write rule now adds `hasOnly` plus `is string` checks on
`uid`, `mediaId`, and `position` (the `is string` checks also enforce presence,
so `hasAll` is dropped). `position` is a string per
`print/src/reading-position.ts`. The existing uid-match and docId-format
constraints are unchanged.

## Tests

`rules-test/test/firestore/print.test.ts` covers both: a new test proves another
user is now denied reading a non-existent victim-prefixed docId (the oracle), and
three new write tests cover the `hasOnly` clamp and non-string `position` /
`mediaId` rejection. Existing client-write tests were updated to send string
positions to match the new type check. All 23 print reading-position tests pass
locally (`rules-test` is not in CI — run manually).

Rules deploy automatically on merge to `main` via `firestore-deploy.yml`.
