### PR TITLE
functions: harden feed-proxy against SSRF redirect, error leakage, and unbounded body

### DIFF
--- a/functions/src/feed-proxy.ts
+++ b/functions/src/feed-proxy.ts
@@ -8,6 +8,10 @@ export { ALLOWED_FEED_URLS };
 
 const adminApp = getApps().length > 0 ? getApps()[0] : initializeApp();
 
+/** Caps the size of the proxied upstream body (~5 MB). Feeds are small; this
+ *  bound prevents a hostile upstream from inflating memory/egress. */
+const MAX_FEED_BYTES = 5 * 1024 * 1024;
+
 /** Verify the AppCheck token in the request. Always returns true in the emulator
  *  because the emulator does not issue or verify AppCheck tokens. */
 async function verifyAppCheck(req: Request): Promise<boolean> {
@@ -47,11 +51,21 @@ export async function handleFeedProxy(req: Request, res: Response) {
   try {
     upstream = await fetch(url, {
       headers: { "User-Agent": "commons-systems-feed-proxy/1.0" },
+      redirect: "manual",
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`Feed proxy: fetch failed for ${url}: ${message}`);
-    res.status(502).send(`Failed to fetch upstream feed: ${message}`);
+    res.status(502).send("Failed to fetch upstream feed");
+    return;
+  }
+
+  // With redirect: "manual", undici returns an opaque-redirect filtered
+  // response (type "opaqueredirect", status 0). Reject it before the !ok check
+  // so a redirect off the allowlist (SSRF) cannot reach an arbitrary URL.
+  if (upstream.type === "opaqueredirect") {
+    console.error(`Feed proxy: upstream returned a redirect for ${url}`);
+    res.status(502).send("Upstream returned a redirect, which is not allowed");
     return;
   }
 
@@ -61,13 +75,46 @@ export async function handleFeedProxy(req: Request, res: Response) {
     return;
   }
 
+  // Boundary guard: per the fetch types, body can legitimately be null. Surface
+  // a clear error rather than crashing — and never fall back to upstream.text(),
+  // which would re-introduce the unbounded read this read replaces.
+  if (upstream.body === null) {
+    console.error(`Feed proxy: upstream returned a null body for ${url}`);
+    res.status(502).send("Upstream returned an empty response body");
+    return;
+  }
+
   let body: string;
   try {
-    body = await upstream.text();
+    const reader = upstream.body.getReader();
+    const decoder = new TextDecoder("utf-8");
+    let total = 0;
+    let acc = "";
+    let overCap = false;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_FEED_BYTES) {
+        await reader.cancel();
+        overCap = true;
+        break;
+      }
+      acc += decoder.decode(value, { stream: true });
+    }
+    if (overCap) {
+      console.error(
+        `Feed proxy: upstream feed exceeded ${MAX_FEED_BYTES} bytes for ${url}`,
+      );
+      res.status(502).send("Upstream feed exceeded maximum allowed size");
+      return;
+    }
+    acc += decoder.decode();
+    body = acc;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`Feed proxy: body read failed for ${url}: ${message}`);
-    res.status(502).send(`Failed to read upstream response body: ${message}`);
+    res.status(502).send("Failed to read upstream response body");
     return;
   }
 

--- a/functions/src/feed-proxy.ts
+++ b/functions/src/feed-proxy.ts
@@ -10,7 +10,7 @@ const adminApp = getApps().length > 0 ? getApps()[0] : initializeApp();
 
 /** Caps the size of the proxied upstream body (~5 MB). Feeds are small; this
  *  bound prevents a hostile upstream from inflating memory/egress. */
-const MAX_FEED_BYTES = 5 * 1024 * 1024;
+export const MAX_FEED_BYTES = 5 * 1024 * 1024;
 
 /** Verify the AppCheck token in the request. Always returns true in the emulator
  *  because the emulator does not issue or verify AppCheck tokens. */
@@ -52,6 +52,7 @@ export async function handleFeedProxy(req: Request, res: Response) {
     upstream = await fetch(url, {
       headers: { "User-Agent": "commons-systems-feed-proxy/1.0" },
       redirect: "manual",
+      signal: AbortSignal.timeout(10_000),
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -89,7 +90,7 @@ export async function handleFeedProxy(req: Request, res: Response) {
     const reader = upstream.body.getReader();
     const decoder = new TextDecoder("utf-8");
     let total = 0;
-    let acc = "";
+    const parts: string[] = [];
     let overCap = false;
     for (;;) {
       const { done, value } = await reader.read();
@@ -100,7 +101,7 @@ export async function handleFeedProxy(req: Request, res: Response) {
         overCap = true;
         break;
       }
-      acc += decoder.decode(value, { stream: true });
+      parts.push(decoder.decode(value, { stream: true }));
     }
     if (overCap) {
       console.error(
@@ -109,8 +110,8 @@ export async function handleFeedProxy(req: Request, res: Response) {
       res.status(502).send("Upstream feed exceeded maximum allowed size");
       return;
     }
-    acc += decoder.decode();
-    body = acc;
+    parts.push(decoder.decode());
+    body = parts.join("");
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`Feed proxy: body read failed for ${url}: ${message}`);

--- a/functions/test/feed-proxy.test.ts
+++ b/functions/test/feed-proxy.test.ts
@@ -107,12 +107,12 @@ describe("handleFeedProxy", () => {
     const feedXml = "<feed><entry>test</entry></feed>";
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        text: () => Promise.resolve(feedXml),
-        headers: new Headers({ "content-type": "application/atom+xml" }),
-      }),
+      vi.fn().mockResolvedValue(
+        new Response(feedXml, {
+          status: 200,
+          headers: { "content-type": "application/atom+xml" },
+        }),
+      ),
     );
 
     const allowedUrl = [...ALLOWED_FEED_URLS][0];
@@ -121,6 +121,7 @@ describe("handleFeedProxy", () => {
 
     expect(fetch).toHaveBeenCalledWith(allowedUrl, {
       headers: { "User-Agent": "commons-systems-feed-proxy/1.0" },
+      redirect: "manual",
     });
     expect(res.statusCode).toBe(200);
     expect(res.body).toBe(feedXml);
@@ -129,14 +130,19 @@ describe("handleFeedProxy", () => {
   });
 
   it("defaults content-type to application/xml when upstream omits it", async () => {
+    // Use a ReadableStream body so Response does not auto-set a content-type
+    // header — that keeps upstream.headers.get("content-type") null and lets
+    // the production "?? application/xml" fallback fire.
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("<feed/>"));
+        controller.close();
+      },
+    });
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        text: () => Promise.resolve("<feed/>"),
-        headers: new Headers(),
-      }),
+      vi.fn().mockResolvedValue(new Response(stream, { status: 200 })),
     );
 
     const allowedUrl = [...ALLOWED_FEED_URLS][0];
@@ -149,11 +155,7 @@ describe("handleFeedProxy", () => {
   it("forwards upstream error status", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 502,
-        headers: new Headers(),
-      }),
+      vi.fn().mockResolvedValue(new Response(null, { status: 502 })),
     );
 
     const allowedUrl = [...ALLOWED_FEED_URLS][0];
@@ -167,10 +169,35 @@ describe("handleFeedProxy", () => {
   it("returns 502 when reading upstream response body fails", async () => {
     vi.stubGlobal(
       "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.error(new Error("body stream interrupted"));
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/xml" } },
+        ),
+      ),
+    );
+
+    const allowedUrl = [...ALLOWED_FEED_URLS][0];
+    const res = createMockRes();
+    await handleFeedProxy(createMockReq({ url: allowedUrl }), res as never);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toBe("Failed to read upstream response body");
+    expect(res.body).not.toContain("body stream interrupted");
+  });
+
+  it("rejects redirect (SSRF protection) with 502 and does not fall through to status-0 message", async () => {
+    vi.stubGlobal(
+      "fetch",
       vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        text: () => Promise.reject(new Error("body stream interrupted")),
+        type: "opaqueredirect",
+        status: 0,
+        ok: false,
+        body: null,
         headers: new Headers(),
       }),
     );
@@ -180,9 +207,72 @@ describe("handleFeedProxy", () => {
     await handleFeedProxy(createMockReq({ url: allowedUrl }), res as never);
 
     expect(res.statusCode).toBe(502);
-    expect(res.body).toBe(
-      "Failed to read upstream response body: body stream interrupted",
+    expect(res.body).toBe("Upstream returned a redirect, which is not allowed");
+    expect(res.body).not.toBe("Upstream returned 0");
+  });
+
+  it("returns 502 when upstream body exceeds MAX_FEED_BYTES", async () => {
+    // Enqueue 64 KB chunks lazily via pull() so the reader's early cancel()
+    // stops production — no large allocation needed.
+    const CHUNK_SIZE = 64 * 1024;
+    const MAX_FEED_BYTES = 5 * 1024 * 1024;
+    const chunksNeeded = Math.ceil(MAX_FEED_BYTES / CHUNK_SIZE) + 1;
+    let pulled = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (pulled >= chunksNeeded) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(new Uint8Array(CHUNK_SIZE).fill(0x41));
+        pulled++;
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          headers: { "content-type": "application/xml" },
+        }),
+      ),
     );
+
+    const allowedUrl = [...ALLOWED_FEED_URLS][0];
+    const res = createMockRes();
+    await handleFeedProxy(createMockReq({ url: allowedUrl }), res as never);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toBe("Upstream feed exceeded maximum allowed size");
+  });
+
+  it("returns 502 with generic message when fetch throws (no error leak)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("DNS resolution failed")),
+    );
+
+    const allowedUrl = [...ALLOWED_FEED_URLS][0];
+    const res = createMockRes();
+    await handleFeedProxy(createMockReq({ url: allowedUrl }), res as never);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toBe("Failed to fetch upstream feed");
+    expect(res.body).not.toContain("DNS");
+  });
+
+  it("returns 502 with clear message when upstream returns null body on ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
+    );
+
+    const allowedUrl = [...ALLOWED_FEED_URLS][0];
+    const res = createMockRes();
+    await handleFeedProxy(createMockReq({ url: allowedUrl }), res as never);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toBe("Upstream returned an empty response body");
   });
 
   it("ALLOWED_FEED_URLS matches feed registry", () => {

--- a/functions/test/feed-proxy.test.ts
+++ b/functions/test/feed-proxy.test.ts
@@ -10,7 +10,7 @@ vi.mock("firebase-admin/app-check", () => ({
   getAppCheck: () => ({ verifyToken: verifyTokenMock }),
 }));
 
-import { handleFeedProxy, ALLOWED_FEED_URLS } from "../src/feed-proxy";
+import { handleFeedProxy, ALLOWED_FEED_URLS, MAX_FEED_BYTES } from "../src/feed-proxy";
 import { FEED_REGISTRY } from "../../blog/src/blog-roll/feed-registry";
 
 function createMockRes() {
@@ -122,6 +122,7 @@ describe("handleFeedProxy", () => {
     expect(fetch).toHaveBeenCalledWith(allowedUrl, {
       headers: { "User-Agent": "commons-systems-feed-proxy/1.0" },
       redirect: "manual",
+      signal: expect.any(AbortSignal),
     });
     expect(res.statusCode).toBe(200);
     expect(res.body).toBe(feedXml);
@@ -215,7 +216,6 @@ describe("handleFeedProxy", () => {
     // Enqueue 64 KB chunks lazily via pull() so the reader's early cancel()
     // stops production — no large allocation needed.
     const CHUNK_SIZE = 64 * 1024;
-    const MAX_FEED_BYTES = 5 * 1024 * 1024;
     const chunksNeeded = Math.ceil(MAX_FEED_BYTES / CHUNK_SIZE) + 1;
     let pulled = 0;
     const stream = new ReadableStream<Uint8Array>({


### PR DESCRIPTION
Closes #1298

## Summary

Hardens the `feedProxy` Cloud Function (`functions/src/feed-proxy.ts`) against
the three security defects flagged in #1298:

- **SSRF via redirect** — `fetch` now uses `redirect: "manual"`. Undici returns
  an opaque-redirect filtered response (`type === "opaqueredirect"`, `status 0`),
  which an explicit branch rejects with a `502` *before* the `!ok` check (so a
  redirect is never mislabeled `"Upstream returned 0"`). The allowlist is an
  exact-match set of ~3 stable feed URLs, so a redirect target would essentially
  never itself be allowlisted — rejecting all redirects fully closes the SSRF
  with no real-use-case loss.
- **Unbounded body** — `upstream.text()` is replaced with a bounded streaming
  read of `upstream.body` via `getReader()` + a single `TextDecoder`, capping
  cumulative bytes at `MAX_FEED_BYTES` (5 MB). Over-cap cancels the reader and
  returns `502`. A null-body boundary guard (per `.claude/rules/code-style.md` —
  an edge guard, not a defensive fallback) returns a clear `502` rather than
  falling back to the unbounded read.
- **Error reflection** — every client-facing `res.send(...)` is now a static
  generic string; the real `err.message` is still logged server-side via
  `console.error`. The numeric `"Upstream returned ${status}"` line is left
  unchanged (it exposes only the HTTP status, not an error message).

## Tests

`functions/test/feed-proxy.test.ts`: happy-path mocks migrated to real
`Response` objects (so the streaming reader has a real `.body`); the
fetch-options assertion now expects `redirect: "manual"`. New cases cover
redirect rejection, body-over-cap, generic error on fetch throw, generic error
on body-read throw, and the null-body guard. All 34 functions tests pass
(`npx vitest run --project functions`); `npx tsc --noEmit --project functions`
is clean.
