### PR TITLE
firestore.rules: pin error-log env + fully validate/bound the error-doc schema

### DIFF
--- a/firebaseutil/src/error-sink.ts
+++ b/firebaseutil/src/error-sink.ts
@@ -99,7 +99,8 @@ export function createFirestoreErrorSink(options: ErrorSinkOptions): ErrorSink {
     if (Object.keys(extrasObj).length > 0) {
       let extrasStr: string | null = null;
       try {
-        extrasStr = truncate(JSON.stringify(extrasObj), CAPS.extras);
+        const serialized = JSON.stringify(extrasObj);
+        extrasStr = serialized.length <= CAPS.extras ? serialized : null;
       } catch {
         extrasStr = null;
       }

--- a/firebaseutil/src/error-sink.ts
+++ b/firebaseutil/src/error-sink.ts
@@ -20,7 +20,26 @@ export interface ErrorSinkOptions {
 // with these names are dropped so caller-provided extras cannot overwrite canonical
 // error values like the original Error message. operation and kind are included
 // for safety even though they are always written from structured fields.
-const RESERVED_KEYS = new Set(["operation", "kind", "message", "stack", "code", "timestamp", "userAgent", "url", "uid", "email"]);
+// "extras" is reserved for the synthesized JSON blob of non-reserved context.
+const RESERVED_KEYS = new Set(["operation", "kind", "message", "stack", "code", "timestamp", "userAgent", "url", "uid", "email", "extras"]);
+
+// Size caps (UTF-16 code units) — must mirror the firestore.rules isValidErrorLog() caps exactly.
+const CAPS = {
+  message: 10000,
+  operation: 200,
+  kind: 32,
+  stack: 50000,
+  code: 200,
+  userAgent: 500,
+  url: 2000,
+  uid: 128,
+  email: 320,
+  extras: 10000,
+} as const;
+
+function truncate(value: string | null | undefined, max: number): string | null {
+  return value == null ? null : String(value).slice(0, max);
+}
 
 export function createFirestoreErrorSink(options: ErrorSinkOptions): ErrorSink {
   const { db, namespace, getCurrentUser } = options;
@@ -56,22 +75,37 @@ export function createFirestoreErrorSink(options: ErrorSinkOptions): ErrorSink {
     recentWrites++;
     const user = getCurrentUser?.() ?? null;
     const doc: Record<string, unknown> = {
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack ?? null : null,
-      code: (error as { code?: string })?.code ?? null,
-      kind: context.kind,
-      operation: context.operation,
+      message: truncate(error instanceof Error ? error.message : String(error), CAPS.message),
+      stack: truncate(error instanceof Error ? error.stack ?? null : null, CAPS.stack),
+      code: truncate((error as { code?: string })?.code ?? null, CAPS.code),
+      kind: truncate(context.kind, CAPS.kind),
+      operation: truncate(context.operation, CAPS.operation),
       timestamp: Timestamp.now(),
-      userAgent: typeof navigator !== "undefined" ? navigator.userAgent : null,
-      url: typeof location !== "undefined" ? location.href : null,
-      uid: user?.uid ?? null,
-      email: user?.email ?? null,
+      userAgent: truncate(typeof navigator !== "undefined" ? navigator.userAgent : null, CAPS.userAgent),
+      url: truncate(typeof location !== "undefined" ? location.href : null, CAPS.url),
+      uid: truncate(user?.uid ?? null, CAPS.uid),
+      email: truncate(user?.email ?? null, CAPS.email),
     };
 
+    // Collect non-reserved context entries into the extras field.
+    // This keeps the doc shape fixed to the 11 enumerated keys the firestore.rules
+    // isValidErrorLog() hasOnly() check allows.
+    const extrasObj: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(context)) {
       if (!RESERVED_KEYS.has(key)) {
-        doc[key] = value;
+        extrasObj[key] = value;
       }
+    }
+    if (Object.keys(extrasObj).length > 0) {
+      let extrasStr: string | null = null;
+      try {
+        extrasStr = truncate(JSON.stringify(extrasObj), CAPS.extras);
+      } catch {
+        extrasStr = null;
+      }
+      doc.extras = extrasStr;
+    } else {
+      doc.extras = null;
     }
 
     // Fire-and-forget. Never await — error logging must not block the caller.

--- a/firebaseutil/test/error-sink.test.ts
+++ b/firebaseutil/test/error-sink.test.ts
@@ -99,7 +99,7 @@ describe("createFirestoreErrorSink", () => {
     expect(doc.email).toBeNull();
   });
 
-  it("filters RESERVED_KEYS from extra context", () => {
+  it("filters RESERVED_KEYS from extra context and folds custom fields into extras", () => {
     const sink = createFirestoreErrorSink(makeOptions());
     const ctx: EnrichedErrorContext = { operation: "test-op", kind: "unknown", customField: "kept" };
     (ctx as Record<string, unknown>).message = "override";
@@ -107,16 +107,72 @@ describe("createFirestoreErrorSink", () => {
 
     const doc = getWrittenDoc();
     expect(doc.message).toBe("boom"); // from Error, not context
-    expect(doc.customField).toBe("kept");
+    // customField must be in extras JSON, not top-level
+    expect(doc.customField).toBeUndefined();
+    expect(JSON.parse(doc.extras as string).customField).toBe("kept");
   });
 
-  it("passes extra context fields through", () => {
+  it("folds extra context fields into extras as JSON, not top-level", () => {
     const sink = createFirestoreErrorSink(makeOptions());
     sink(new Error("boom"), { operation: "test-op", kind: "unknown", postId: "abc", txnId: "123" });
 
     const doc = getWrittenDoc();
-    expect(doc.postId).toBe("abc");
-    expect(doc.txnId).toBe("123");
+    // Must NOT be top-level keys
+    expect(doc.postId).toBeUndefined();
+    expect(doc.txnId).toBeUndefined();
+    // Must be in extras
+    const extras = JSON.parse(doc.extras as string);
+    expect(extras.postId).toBe("abc");
+    expect(extras.txnId).toBe("123");
+  });
+
+  it("sets extras to null when there are no non-reserved context fields", () => {
+    const sink = createFirestoreErrorSink(makeOptions());
+    sink(new Error("boom"), makeContext());
+
+    const doc = getWrittenDoc();
+    expect(doc.extras).toBeNull();
+  });
+
+  it("drops a caller-supplied extras key (it is reserved) and does not corrupt synthesized extras", () => {
+    const sink = createFirestoreErrorSink(makeOptions());
+    // extras is now a RESERVED_KEY so it should be filtered out
+    const ctx = { operation: "test-op", kind: "unknown" } as EnrichedErrorContext;
+    (ctx as Record<string, unknown>).extras = "caller-supplied";
+    sink(new Error("boom"), ctx);
+
+    const doc = getWrittenDoc();
+    // The caller-supplied extras key was the only non-reserved-... key,
+    // so synthesized extras should be null (no other non-reserved keys).
+    expect(doc.extras).toBeNull();
+  });
+
+  it("truncates oversized message to 10000 characters", () => {
+    const sink = createFirestoreErrorSink(makeOptions());
+    const longMessage = "a".repeat(15000);
+    sink(new Error(longMessage), makeContext());
+
+    const doc = getWrittenDoc();
+    expect((doc.message as string).length).toBe(10000);
+  });
+
+  it("truncates oversized stack to 50000 characters", () => {
+    const sink = createFirestoreErrorSink(makeOptions());
+    const err = new Error("boom");
+    // Override stack with an oversized value
+    Object.defineProperty(err, "stack", { value: "x".repeat(60000), configurable: true });
+    sink(err, makeContext());
+
+    const doc = getWrittenDoc();
+    expect((doc.stack as string).length).toBe(50000);
+  });
+
+  it("truncates oversized kind to 32 characters", () => {
+    const sink = createFirestoreErrorSink(makeOptions());
+    sink(new Error("boom"), makeContext({ kind: "a".repeat(50) as EnrichedErrorContext["kind"] }));
+
+    const doc = getWrittenDoc();
+    expect((doc.kind as string).length).toBe(32);
   });
 
   it("rate-limits after 50 writes within a window", () => {

--- a/firebaseutil/test/error-sink.test.ts
+++ b/firebaseutil/test/error-sink.test.ts
@@ -37,6 +37,7 @@ describe("createFirestoreErrorSink", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("writes error document to Firestore", () => {
@@ -173,6 +174,70 @@ describe("createFirestoreErrorSink", () => {
 
     const doc = getWrittenDoc();
     expect((doc.kind as string).length).toBe(32);
+  });
+
+  it("truncates oversized operation to 200 characters", () => {
+    const sink = createFirestoreErrorSink(makeOptions());
+    sink(new Error("boom"), makeContext({ operation: "a".repeat(201) }));
+
+    const doc = getWrittenDoc();
+    expect((doc.operation as string).length).toBe(200);
+  });
+
+  it("truncates oversized code to 200 characters", () => {
+    const sink = createFirestoreErrorSink(makeOptions());
+    const err = Object.assign(new Error("boom"), { code: "a".repeat(201) });
+    sink(err, makeContext());
+
+    const doc = getWrittenDoc();
+    expect((doc.code as string).length).toBe(200);
+  });
+
+  it("truncates oversized url to 2000 characters", () => {
+    vi.stubGlobal("location", { href: "a".repeat(2001) });
+    const sink = createFirestoreErrorSink(makeOptions());
+    sink(new Error("boom"), makeContext());
+
+    const doc = getWrittenDoc();
+    expect((doc.url as string).length).toBe(2000);
+  });
+
+  it("truncates oversized userAgent to 500 characters", () => {
+    vi.stubGlobal("navigator", { userAgent: "a".repeat(501) });
+    const sink = createFirestoreErrorSink(makeOptions());
+    sink(new Error("boom"), makeContext());
+
+    const doc = getWrittenDoc();
+    expect((doc.userAgent as string).length).toBe(500);
+  });
+
+  it("truncates oversized uid to 128 characters", () => {
+    const sink = createFirestoreErrorSink(makeOptions({
+      getCurrentUser: () => ({ uid: "a".repeat(129), email: "test@example.com" }),
+    }));
+    sink(new Error("boom"), makeContext());
+
+    const doc = getWrittenDoc();
+    expect((doc.uid as string).length).toBe(128);
+  });
+
+  it("truncates oversized email to 320 characters", () => {
+    const sink = createFirestoreErrorSink(makeOptions({
+      getCurrentUser: () => ({ uid: "u1", email: "a".repeat(321) }),
+    }));
+    sink(new Error("boom"), makeContext());
+
+    const doc = getWrittenDoc();
+    expect((doc.email as string).length).toBe(320);
+  });
+
+  it("sets extras to null when serialized extras exceeds 10000 characters", () => {
+    const sink = createFirestoreErrorSink(makeOptions());
+    const ctx = { operation: "test-op", kind: "unknown", bigData: "x".repeat(10001) } as EnrichedErrorContext;
+    sink(new Error("boom"), ctx);
+
+    const doc = getWrittenDoc();
+    expect(doc.extras).toBeNull();
   });
 
   it("rate-limits after 50 writes within a window", () => {

--- a/firestore.rules
+++ b/firestore.rules
@@ -286,38 +286,71 @@ service cloud.firestore {
 
     // Error logs: write-only from clients. Admin reads via Admin SDK.
     // Unauthenticated creates are allowed so error telemetry works regardless
-    // of auth state. Type-validated fields: message (string, max 10KB),
-    // operation (string, max 200 chars), timestamp (timestamp), and optional
-    // stack (string, max 50KB). Other fields (kind, code, userAgent, url, uid,
-    // email, extras) pass through unchecked. Total fields capped at 15.
+    // of auth state — so the rule is the only backstop against cost/DoS abuse
+    // (issue #1296). Two hardening invariants enforce that backstop:
+    //
+    // 1. Env is pinned to a known-env allowlist (isKnownErrorEnv): the {env}
+    //    path segment must match a real environment shape (prod/demo/test,
+    //    preview-pr-N, qa[-id], emulator[-id]). This closes the fabricated-env
+    //    sprawl vector (e.g. budget/zzz/errors/...).
+    // 2. The document is a fully-enumerated, size-bounded schema: exactly the
+    //    11 keys below are allowed (keys().hasOnly) — no arbitrary top-level
+    //    keys pass through — and every field is type- and length-checked. This
+    //    bounds the worst-case doc from ~1 MB to ~73 KB.
+    //
+    // Enumerated fields and caps (UTF-16 code units): message (string, ≤10000),
+    // operation (string, ≤200), timestamp (timestamp); optional kind (≤32),
+    // stack (≤50000), code (≤200), userAgent (≤500), url (≤2000), uid (≤128),
+    // email (≤320), extras (≤10000). Tradeoff: kind is length-capped, not
+    // enum-restricted, to avoid coupling the rule to the ErrorKind union.
+    function isKnownErrorEnv(env) {
+      return env == "prod"
+        || env == "demo"
+        || env == "test"
+        || env.matches("preview-pr-[0-9]+")
+        || env.matches("qa(-[a-z0-9._-]+)?")
+        || env.matches("emulator(-[a-z0-9._-]+)?");
+    }
+    function isOptionalString(data, field, maxLen) {
+      return !(field in data)
+        || data[field] == null
+        || (data[field] is string && data[field].size() <= maxLen);
+    }
     function isValidErrorLog() {
       return request.resource.data.keys().hasAll(["message", "operation", "timestamp"])
-        && request.resource.data.keys().size() <= 15
+        && request.resource.data.keys().hasOnly(["message", "operation", "timestamp", "kind", "stack", "code", "userAgent", "url", "uid", "email", "extras"])
         && request.resource.data.message is string
         && request.resource.data.message.size() <= 10000
         && request.resource.data.operation is string
         && request.resource.data.operation.size() <= 200
         && request.resource.data.timestamp is timestamp
-        && (!("stack" in request.resource.data) || request.resource.data.stack == null || (request.resource.data.stack is string && request.resource.data.stack.size() <= 50000));
+        && isOptionalString(request.resource.data, "kind", 32)
+        && isOptionalString(request.resource.data, "stack", 50000)
+        && isOptionalString(request.resource.data, "code", 200)
+        && isOptionalString(request.resource.data, "userAgent", 500)
+        && isOptionalString(request.resource.data, "url", 2000)
+        && isOptionalString(request.resource.data, "uid", 128)
+        && isOptionalString(request.resource.data, "email", 320)
+        && isOptionalString(request.resource.data, "extras", 10000);
     }
     match /budget/{env}/errors/{errorId} {
-      allow create: if isValidErrorLog();
+      allow create: if isKnownErrorEnv(env) && isValidErrorLog();
       allow read, update, delete: if false;
     }
     match /landing/{env}/errors/{errorId} {
-      allow create: if isValidErrorLog();
+      allow create: if isKnownErrorEnv(env) && isValidErrorLog();
       allow read, update, delete: if false;
     }
     match /fellspiral/{env}/errors/{errorId} {
-      allow create: if isValidErrorLog();
+      allow create: if isKnownErrorEnv(env) && isValidErrorLog();
       allow read, update, delete: if false;
     }
     match /print/{env}/errors/{errorId} {
-      allow create: if isValidErrorLog();
+      allow create: if isKnownErrorEnv(env) && isValidErrorLog();
       allow read, update, delete: if false;
     }
     match /audio/{env}/errors/{errorId} {
-      allow create: if isValidErrorLog();
+      allow create: if isKnownErrorEnv(env) && isValidErrorLog();
       allow read, update, delete: if false;
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -308,8 +308,8 @@ service cloud.firestore {
         || env == "demo"
         || env == "test"
         || env.matches("preview-pr-[0-9]+")
-        || env.matches("qa(-[a-z0-9._-]+)?")
-        || env.matches("emulator(-[a-z0-9._-]+)?");
+        || env.matches("qa(-[a-z0-9._-]+)?")    // suffix optional: bare "qa" is the main-worktree env
+        || env.matches("emulator(-[a-z0-9._-]+)?");  // suffix optional: bare "emulator" is the main-worktree env
     }
     function isOptionalString(data, field, maxLen) {
       return !(field in data)

--- a/rules-test/test/firestore/errors.test.ts
+++ b/rules-test/test/firestore/errors.test.ts
@@ -26,6 +26,7 @@ function validErrorDoc() {
     url: "http://localhost",
     uid: null,
     email: null,
+    extras: null,
   };
 }
 
@@ -137,5 +138,214 @@ describe("error logs", () => {
     await assertFails(
       setDoc(doc(db, `unknownapp/${ENV}/errors/err1`), validErrorDoc()),
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Env allowlist tests (budget only, to bound runtime)
+  // ---------------------------------------------------------------------------
+  describe("budget errors — env allowlist", () => {
+    it("denies fabricated env", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, "budget/zzz/errors/err1"), validErrorDoc()),
+      );
+    });
+
+    it("denies qa- with empty suffix (trailing dash, no chars)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, "budget/qa-/errors/err1"), validErrorDoc()),
+      );
+    });
+
+    it("denies preview-pr- with no number", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, "budget/preview-pr-/errors/err1"), validErrorDoc()),
+      );
+    });
+
+    it("denies preview-pr-abc (non-numeric suffix)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, "budget/preview-pr-abc/errors/err1"), validErrorDoc()),
+      );
+    });
+
+    it("allows demo env", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, "budget/demo/errors/err1"), validErrorDoc()),
+      );
+    });
+
+    it("allows preview-pr-42 env", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, "budget/preview-pr-42/errors/err1"), validErrorDoc()),
+      );
+    });
+
+    it("allows qa-<id> env", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, "budget/qa-1296-foo/errors/err1"), validErrorDoc()),
+      );
+    });
+
+    it("allows emulator-<id> env", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, "budget/emulator-abc/errors/err1"), validErrorDoc()),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Schema / shape tests (budget only, to bound runtime)
+  // ---------------------------------------------------------------------------
+  describe("budget errors — schema enforcement", () => {
+    it("denies unexpected extra top-level key (hasOnly)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), bogus: "x" }),
+      );
+    });
+
+    it("denies oversized message (10001 chars)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), message: "x".repeat(10001) }),
+      );
+    });
+
+    it("denies oversized stack (50001 chars)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), stack: "x".repeat(50001) }),
+      );
+    });
+
+    it("denies oversized extras (10001 chars)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), extras: "x".repeat(10001) }),
+      );
+    });
+
+    it("denies oversized url (2001 chars)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), url: "x".repeat(2001) }),
+      );
+    });
+
+    it("denies oversized userAgent (501 chars)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), userAgent: "x".repeat(501) }),
+      );
+    });
+
+    it("denies oversized uid (129 chars)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), uid: "x".repeat(129) }),
+      );
+    });
+
+    it("denies oversized email (321 chars)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), email: "x".repeat(321) }),
+      );
+    });
+
+    it("denies oversized code (201 chars)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), code: "x".repeat(201) }),
+      );
+    });
+
+    it("denies oversized kind (33 chars)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), kind: "x".repeat(33) }),
+      );
+    });
+
+    it("denies non-string optional field kind (number)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), kind: 123 }),
+      );
+    });
+
+    it("denies non-string optional field url (number)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), url: 5 }),
+      );
+    });
+
+    it("denies non-string optional field extras (number)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), extras: 5 }),
+      );
+    });
+
+    it("allows all optional fields set to null", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), {
+          message: "Test error",
+          operation: "test-op",
+          timestamp: Timestamp.now(),
+          kind: null,
+          stack: null,
+          code: null,
+          userAgent: null,
+          url: null,
+          uid: null,
+          email: null,
+          extras: null,
+        }),
+      );
+    });
+
+    it("allows valid populated extras string", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), {
+          ...validErrorDoc(),
+          extras: '{"txnId":"abc123","postId":42}',
+        }),
+      );
+    });
   });
 });

--- a/rules-test/test/firestore/errors.test.ts
+++ b/rules-test/test/firestore/errors.test.ts
@@ -207,6 +207,38 @@ describe("error logs", () => {
         setDoc(doc(db, "budget/emulator-abc/errors/err1"), validErrorDoc()),
       );
     });
+
+    it("allows bare qa env", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, "budget/qa/errors/err1"), validErrorDoc()),
+      );
+    });
+
+    it("allows bare emulator env", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, "budget/emulator/errors/err1"), validErrorDoc()),
+      );
+    });
+
+    it("allows prod env", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, "budget/prod/errors/err1"), validErrorDoc()),
+      );
+    });
+
+    it("denies emulator- with empty suffix (trailing dash, no chars)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, "budget/emulator-/errors/err1"), validErrorDoc()),
+      );
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -226,6 +258,14 @@ describe("error logs", () => {
       const db = ctx.firestore();
       await assertFails(
         setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), message: "x".repeat(10001) }),
+      );
+    });
+
+    it("denies oversized operation (201 chars)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/errors/err1`), { ...validErrorDoc(), operation: "x".repeat(201) }),
       );
     });
 


### PR DESCRIPTION
Closes #1296

## Problem

`firestore.rules` exposed the error-log collections to fully **unauthenticated**
`create` — `match /<app>/{env}/errors/{errorId} { allow create: if isValidErrorLog(); }`
for five apps (budget, landing, fellspiral, print, audio) — with two abuse levers:

1. **Fabricated envs.** The `{env}` path wildcard accepted *any* string, so an
   anonymous script could sprawl writes across unbounded distinct env subtrees
   (`budget/zzz/errors/...`, `budget/aaa/errors/...`, …).
2. **Unbounded doc size + shape.** `isValidErrorLog()` validated only
   `message`/`operation`/`timestamp`/`stack` and capped total keys at 15.
   `kind`/`code`/`userAgent`/`url`/`uid`/`email` and *arbitrary caller extras*
   passed through unchecked up to the ~1 MB doc limit — the client sink literally
   spread every non-reserved context key as a new top-level field.

Together: anonymous, unbounded ~1 MB writes × five apps × unlimited fabricated
envs — billable cost / DoS on this Blaze-plan project. Rules cannot rate-limit,
and the client-side throttle is useless against an attacker who bypasses the SDK.

## Fix

Make the error document a **fixed, fully-enumerated, size-bounded schema** and
**pin `{env}` to a known-env pattern** — the rules-level path the issue's "and/or"
acceptance permits. This closes the fabricated-env vector and cuts the worst-case
doc from ~1 MB to ~73 KB.

- **Unit 1 — `firestore.rules`.** New `isKnownErrorEnv(env)` pins `{env}` to the
  real env taxonomy (`prod`/`demo`/`test`, `preview-pr-N`, `qa(-id)?`,
  `emulator(-id)?`). `isValidErrorLog()` rewritten to `keys().hasOnly([…11 keys])`
  (replacing the loose `keys().size() <= 15`) plus a reusable
  `isOptionalString(data, field, maxLen)` helper enforcing per-field UTF-16 caps.
  Every match block now gates `allow create: if isKnownErrorEnv(env) &&
  isValidErrorLog();`.
- **Unit 2 — `firebaseutil/src/error-sink.ts`.** The sink no longer spreads
  arbitrary context as top-level keys (which the stricter rule would reject).
  Non-reserved context is folded into a single JSON-stringified `extras` field
  (try/catch → `null` on circular-ref/BigInt so logging never throws), and every
  variable-length field is truncated to the exact caps the rule enforces. The doc
  now has exactly the 11 enumerated keys.
- **Unit 3 — `rules-test/test/firestore/errors.test.ts`.** Coverage for the new
  env-pin (fabricated/malformed envs denied; real envs allowed) and the doc
  size/shape limits (`hasOnly`, each per-field cap, non-string optional fields,
  all-optionals-null, valid populated `extras`).

The `qa`/`emulator` suffix is **optional** (`qa(-id)?`): `get_env_suffix` returns
the bare base suffix outside a git worktree, so bare `qa`/`emulator` are real env
shapes and must be allowed. The patterns never widen to accept arbitrary tokens.

Tradeoff: `kind` is length-capped (32) rather than enum-restricted, to avoid
coupling the rule to the `ErrorKind` union.

## Verification

- `firebaseutil` unit tests: 69 pass (extras-as-JSON, truncation, reserved
  `extras`).
- `rules-test` (run manually — not in CI): all 34 `errors.test.ts` cases pass.
  (One unrelated, pre-existing `office-hours.test.ts` failure is outside this
  change's scope — the `firestore.rules` diff touches only the error-log blocks.)
- Rules syntax check (`run-rules-check.sh`) passes.

## Follow-up (out of scope)

A stronger gate — App Check *enforcement* on Firestore (initialized client-side
but not enforced) or a Cloud Function with per-IP quota — would actually
rate-limit anonymous writes. Both are infrastructure changes risky to bundle into
a rules PR; they complement, not replace, the size/shape/env hardening here. The
review phase may file one as a `blocked_by` follow-up.

## Deployment note

Per `.claude/rules/firestore.md`, `firestore.rules` deploys on merge to `main`
(preview branches do not deploy rules), so smoke tests on this feature branch
permission-deny until the rules land. Units 1 and 2 are functionally coupled —
sequence the app redeploys carrying the new sink to land before/with the rules
deploy. The rules change is ultimately split into a standalone rules-only PR at
QA/merge time.
