### PR TITLE
functions: use Firestore BulkWriter in office-hours-sync to clear the 500-op batch limit

### DIFF
--- a/functions/src/office-hours-sync.ts
+++ b/functions/src/office-hours-sync.ts
@@ -150,7 +150,7 @@ export async function syncOfficeHoursCore(deps: {
   }
 
   await writer.close(); // flushes all enqueued writes in ≤500-op chunks
-  await Promise.all(writes); // surface any write failure as a thrown error
+  await Promise.all(writes); // BulkWriter routes per-op failures to the individual op promises, not to close(); this is what re-raises them
 
   return { written, deleted, skippedNoDate };
 }

--- a/functions/src/office-hours-sync.ts
+++ b/functions/src/office-hours-sync.ts
@@ -100,7 +100,8 @@ export async function syncOfficeHoursCore(deps: {
 
   const itemsPath = `${deps.namespace}/items`;
   const itemsCollection = deps.firestore.collection(itemsPath);
-  const batch = deps.firestore.batch();
+  const writer = deps.firestore.bulkWriter();
+  const writes: Promise<unknown>[] = [];
 
   const writtenKeys = new Set<string>();
   let written = 0;
@@ -124,15 +125,17 @@ export async function syncOfficeHoursCore(deps: {
 
     const dueAt = Timestamp.fromDate(issue.dueAt);
     const docRef = itemsCollection.doc(issue.jitKey);
-    batch.set(docRef, {
-      title: issue.title,
-      dueAt,
-      repo: issue.repo,
-      issueNumber: issue.number,
-      jitKey: issue.jitKey,
-      memberEmails: deps.memberEmails,
-      updatedAt: FieldValue.serverTimestamp(),
-    });
+    writes.push(
+      writer.set(docRef, {
+        title: issue.title,
+        dueAt,
+        repo: issue.repo,
+        issueNumber: issue.number,
+        jitKey: issue.jitKey,
+        memberEmails: deps.memberEmails,
+        updatedAt: FieldValue.serverTimestamp(),
+      }),
+    );
     writtenKeys.add(issue.jitKey);
     written += 1;
   }
@@ -141,12 +144,13 @@ export async function syncOfficeHoursCore(deps: {
   let deleted = 0;
   for (const doc of existing.docs) {
     if (!writtenKeys.has(doc.id)) {
-      batch.delete(doc.ref);
+      writes.push(writer.delete(doc.ref));
       deleted += 1;
     }
   }
 
-  await batch.commit();
+  await writer.close(); // flushes all enqueued writes in ≤500-op chunks
+  await Promise.all(writes); // surface any write failure as a thrown error
 
   return { written, deleted, skippedNoDate };
 }

--- a/functions/test/office-hours-sync.test.ts
+++ b/functions/test/office-hours-sync.test.ts
@@ -268,6 +268,56 @@ describe("syncOfficeHoursCore", () => {
       | undefined;
     expect(written?.memberEmails).toEqual(["a@example.com", "b@example.com"]);
   });
+
+  it("handles more than 500 operations in a single sync", async () => {
+    // Part 1: >500 set-only path — 600 writes in one sync run.
+    // The regression guard: batch() throws on the 501st op, so a revert to
+    // firestore.batch() fails here. BulkWriter chunks internally and passes.
+    const store1 = createInMemoryFirestore();
+    const issues = Array.from({ length: 600 }, (_, i) =>
+      makeIssue({ number: i, jitKey: `k-${i}` }),
+    );
+
+    const result1 = await syncOfficeHoursCore({
+      fetchOpenJitIssues: async () => issues,
+      firestore: store1 as unknown as Firestore,
+      namespace: "office-hours/prod",
+      memberEmails: ["owner@example.com"],
+    });
+
+    expect(result1.written).toBe(600);
+    for (let i = 0; i < 600; i++) {
+      expect(store1._docs.has(`office-hours/prod/items/k-${i}`)).toBe(true);
+    }
+
+    // Part 2: combined set+delete >500 path — 600 stale deletions + 5 fresh writes = 605 ops.
+    const store2 = createInMemoryFirestore();
+    for (let i = 0; i < 600; i++) {
+      store2._docs.set(`office-hours/prod/items/stale-${i}`, {
+        title: `Stale ${i}`,
+        jitKey: `stale-${i}`,
+      });
+    }
+    const freshIssues = Array.from({ length: 5 }, (_, i) =>
+      makeIssue({ number: 700 + i, jitKey: `fresh-${i}` }),
+    );
+
+    const result2 = await syncOfficeHoursCore({
+      fetchOpenJitIssues: async () => freshIssues,
+      firestore: store2 as unknown as Firestore,
+      namespace: "office-hours/prod",
+      memberEmails: ["owner@example.com"],
+    });
+
+    expect(result2.written).toBe(5);
+    expect(result2.deleted).toBe(600);
+    for (let i = 0; i < 600; i++) {
+      expect(store2._docs.has(`office-hours/prod/items/stale-${i}`)).toBe(false);
+    }
+    for (let i = 0; i < 5; i++) {
+      expect(store2._docs.has(`office-hours/prod/items/fresh-${i}`)).toBe(true);
+    }
+  });
 });
 
 describe("parseJitDueMarker", () => {

--- a/functions/test/office-hours-sync.test.ts
+++ b/functions/test/office-hours-sync.test.ts
@@ -82,13 +82,24 @@ function createInMemoryFirestore() {
     doc: (id: string) => doc(`${path}/${id}`),
   });
 
+  // Deliberate regression guard: enforces Firestore's real 500-op WriteBatch cap
+  // so reverting production to a single batch fails the >500-op sync test.
   const batch = () => {
     const ops: Array<() => void> = [];
+    let opCount = 0;
+    const guard = () => {
+      opCount += 1;
+      if (opCount > 500) {
+        throw new Error("INVALID_ARGUMENT: maximum 500 writes allowed per request");
+      }
+    };
     return {
       set: (ref: InMemoryDocRef, data: Record<string, unknown>) => {
+        guard();
         ops.push(() => docs.set(ref.path, data));
       },
       delete: (ref: InMemoryDocRef) => {
+        guard();
         ops.push(() => docs.delete(ref.path));
       },
       commit: async () => {
@@ -97,7 +108,24 @@ function createInMemoryFirestore() {
     };
   };
 
-  return { doc, collection, batch, _docs: docs };
+  const bulkWriter = () => {
+    const ops: Array<() => void> = [];
+    return {
+      set: (ref: InMemoryDocRef, data: Record<string, unknown>) => {
+        ops.push(() => docs.set(ref.path, data));
+        return Promise.resolve();
+      },
+      delete: (ref: InMemoryDocRef) => {
+        ops.push(() => docs.delete(ref.path));
+        return Promise.resolve();
+      },
+      close: async () => {
+        for (const op of ops) op();
+      },
+    };
+  };
+
+  return { doc, collection, batch, bulkWriter, _docs: docs };
 }
 
 function makeIssue(overrides: Partial<JitIssue> = {}): JitIssue {


### PR DESCRIPTION
Closes #1299

## Problem

`syncOfficeHoursCore` in `functions/src/office-hours-sync.ts` mirrors open
`jit:`-labelled GitHub issues into the `office-hours/{env}/items` Firestore
collection on a 30-minute schedule. It accumulated one `set` per open jit issue
plus one `delete` per stale doc into a **single** `firestore.batch()`.

Firestore caps a `WriteBatch` at **500 operations**. Once
`written + deleted > 500`, `batch.commit()` threw on every run and the sync
collection went permanently stale — the function could never recover on its own
because each run re-attempted the same over-cap batch.

## Fix

Replace the single batch with a Firestore **`BulkWriter`**
(`firestore.bulkWriter()`), which is purpose-built for bulk writes that exceed
the batch limit: it internally chunks at 500 ops, parallelizes, and retries.
This removes all manual op-counting. Atomicity is not a correctness requirement
here — the sync is idempotent and reconciles on the next run — and a single
batch already forfeited all-or-nothing semantics by failing entirely past 500.

Each enqueued write's promise is collected into a `writes` array; after
`writer.close()` flushes the chunks, `await Promise.all(writes)` surfaces any
permanent write failure as a thrown error rather than swallowing it (per
`.claude/rules/code-style.md`). No `onWriteError` handler is added.

The `written` / `deleted` / `skippedNoDate` counters, the `isValidJitKey` /
`dueAt` skip logic, and the `SyncResult` contract are unchanged — only the write
mechanism changes.

## Tests

- The in-memory firestore mock gains a `bulkWriter()` factory; existing
  `syncOfficeHoursCore` tests now drive that path.
- The mock's `batch()` is kept and hardened to throw on the 501st op
  (`INVALID_ARGUMENT: maximum 500 writes allowed per request`) as a deliberate
  regression guard — reverting production to a single batch fails the new test.
- New test `handles more than 500 operations in a single sync` exercises both
  the 600-issue set-only path and the combined set+delete >500 path
  (600 stale deletes + 5 fresh writes = 605 ops in one run).

`npx vitest run --project functions … office-hours-sync` — 20 tests green;
`npx tsc --noEmit --project functions` — clean.
