### PR TITLE
firebase: drop 'unsafe-inline' from CSP script-src on all six sites

### DIFF
--- a/config/firebase-headers.test-helper.ts
+++ b/config/firebase-headers.test-helper.ts
@@ -101,7 +101,7 @@ export function describeFirebaseHeaders(
       );
       const match = cspValue.match(/script-src([^;]*)/);
       expect(match, "could not extract script-src directive").not.toBeNull();
-      const scriptSrc = match![0];
+      const scriptSrc = match![1];
       expect(scriptSrc).toContain("'self'");
       expect(scriptSrc).not.toContain("'unsafe-inline'");
     });

--- a/config/firebase-headers.test-helper.ts
+++ b/config/firebase-headers.test-helper.ts
@@ -84,5 +84,26 @@ export function describeFirebaseHeaders(
         expect(rule.source).not.toMatch(/@\(/);
       }
     });
+
+    it("script-src does not contain 'unsafe-inline'", () => {
+      const globalRule = headers.find((h) => h.source === "**");
+      expect(globalRule, "global '**' header rule not found").toBeDefined();
+      const cspHeader = globalRule!.headers.find(
+        (h) => h.key === "Content-Security-Policy",
+      );
+      expect(
+        cspHeader,
+        "Content-Security-Policy header not found in '**' rule",
+      ).toBeDefined();
+      const cspValue = cspHeader!.value;
+      expect(cspValue, "CSP value does not contain a script-src directive").toMatch(
+        /script-src/,
+      );
+      const match = cspValue.match(/script-src([^;]*)/);
+      expect(match, "could not extract script-src directive").not.toBeNull();
+      const scriptSrc = match![0];
+      expect(scriptSrc).toContain("'self'");
+      expect(scriptSrc).not.toContain("'unsafe-inline'");
+    });
   });
 }

--- a/criticalcssutil/src/index.ts
+++ b/criticalcssutil/src/index.ts
@@ -5,14 +5,16 @@ import Critters from "critters";
 
 /**
  * Inline critical CSS into all HTML files under `distDir` using Critters.
- * Defers full stylesheets via media="print" with onload swap.
- * Fixes noscript fallback to use a plain blocking link.
+ * Critical CSS is inlined into <head>; the full stylesheet is moved to the
+ * end of <body> as a plain blocking <link>, so deferral needs no inline event
+ * handler. This keeps the output compatible with a script-src CSP that omits
+ * 'unsafe-inline'.
  * Returns the number of HTML files processed.
  */
 export async function inlineCriticalCss(distDir: string): Promise<number> {
   const critters = new Critters({
     path: distDir,
-    preload: "media",
+    preload: "body",
     inlineFonts: true,
   });
 
@@ -35,12 +37,6 @@ export async function inlineCriticalCss(distDir: string): Promise<number> {
         cause: err,
       });
     }
-    // Critters copies the deferred link (media="print" onload=...) into <noscript>,
-    // but no-JS users need a plain blocking <link> to get any styles at all.
-    inlined = inlined.replace(
-      /<noscript><link ([^>]*)media="print"([^>]*)onload="[^"]*"([^>]*)><\/noscript>/g,
-      "<noscript><link $1$2$3></noscript>",
-    );
     await writeFile(file, inlined);
   }
 

--- a/criticalcssutil/test/critical-css.test.ts
+++ b/criticalcssutil/test/critical-css.test.ts
@@ -43,16 +43,19 @@ describe("inlineCriticalCss", () => {
     // Inlined style tag in head
     expect(output).toContain("<style>");
 
-    // Deferred full stylesheet via media="print" with onload swap
-    expect(output).toMatch(/link[^>]*media="print"/);
-    expect(output).toMatch(/link[^>]*onload="/);
+    // CSP-safe deferral: no inline event handler and no media="print" toggle.
+    expect(output).not.toMatch(/onload=/);
+    expect(output).not.toMatch(/media="print"/);
 
-    // Noscript fallback link must NOT have media="print" or onload
-    const noscriptMatch = output.match(/<noscript>([\s\S]*?)<\/noscript>/);
-    expect(noscriptMatch).not.toBeNull();
-    const noscriptContent = noscriptMatch![1];
-    expect(noscriptContent).not.toContain('media="print"');
-    expect(noscriptContent).not.toContain("onload=");
+    // The full stylesheet remains a plain blocking <link>...
+    expect(output).toMatch(
+      /<link[^>]*rel="stylesheet"[^>]*href="style\.css"[^>]*>/,
+    );
+
+    // ...moved into the <body>, not left in the <head>.
+    const [head, body] = output.split("</head>");
+    expect(body).toMatch(/<link[^>]*rel="stylesheet"[^>]*href="style\.css"[^>]*>/);
+    expect(head).not.toMatch(/<link[^>]*rel="stylesheet"[^>]*href="style\.css"[^>]*>/);
   });
 
   it("processes multiple HTML files", async () => {

--- a/fellspiral/e2e/css-loading.spec.ts
+++ b/fellspiral/e2e/css-loading.spec.ts
@@ -35,15 +35,23 @@ test.describe("CSS loading", () => {
     await page.waitForLoadState("load");
 
     // Critters defers the full stylesheet by moving its <link> to the end of
-    // <body> as a plain blocking link (no media="print", no inline onload), so
-    // at least one <link rel="stylesheet"> has a non-print media type.
-    const hasFullStylesheet = await page.evaluate(() => {
-      const links = document.querySelectorAll('link[rel="stylesheet"]');
-      return Array.from(links).some(
-        (link) => link.getAttribute("media") !== "print",
+    // <body> as a plain blocking link (no media="print", no inline onload). The
+    // link must be present, live inside <body>, and carry no media="print"
+    // attribute — otherwise the stylesheet never applies.
+    const stylesheet = await page.evaluate(() => {
+      const links = Array.from(
+        document.querySelectorAll('link[rel="stylesheet"]'),
       );
+      const link = links.find((l) => l.getAttribute("media") !== "print");
+      if (!link) return null;
+      return {
+        inBody: document.body.contains(link),
+        media: link.getAttribute("media"),
+      };
     });
 
-    expect(hasFullStylesheet).toBe(true);
+    expect(stylesheet, "no non-print stylesheet <link> found").not.toBeNull();
+    expect(stylesheet!.media).not.toBe("print");
+    expect(stylesheet!.inBody).toBe(true);
   });
 });

--- a/fellspiral/e2e/css-loading.spec.ts
+++ b/fellspiral/e2e/css-loading.spec.ts
@@ -34,9 +34,9 @@ test.describe("CSS loading", () => {
     await page.goto("/");
     await page.waitForLoadState("load");
 
-    // Critters defers the full stylesheet by setting media="print" with an
-    // onload handler that switches it back. After load, at least one
-    // <link rel="stylesheet"> should have reverted to a non-print media type.
+    // Critters defers the full stylesheet by moving its <link> to the end of
+    // <body> as a plain blocking link (no media="print", no inline onload), so
+    // at least one <link rel="stylesheet"> has a non-print media type.
     const hasFullStylesheet = await page.evaluate(() => {
       const links = document.querySelectorAll('link[rel="stylesheet"]');
       return Array.from(links).some(

--- a/fellspiral/test/critical-css.test.ts
+++ b/fellspiral/test/critical-css.test.ts
@@ -14,16 +14,13 @@ describe.skipIf(!hasDistBuild)("critical CSS inlining", () => {
     expect(head).toMatch(/<style[\s\S]*?<\/style>/);
   });
 
-  it('stylesheet <link> has media="print" for async loading', () => {
+  it("stylesheet <link> defers without an inline event handler", () => {
     const linkMatch = html.match(/<link[^>]*rel="stylesheet"[^>]*>/);
     expect(linkMatch).not.toBeNull();
-    expect(linkMatch![0]).toContain('media="print"');
-  });
-
-  it("stylesheet <link> has an onload attribute to swap media", () => {
-    const linkMatch = html.match(/<link[^>]*rel="stylesheet"[^>]*>/);
-    expect(linkMatch).not.toBeNull();
-    expect(linkMatch![0]).toMatch(/onload=/);
+    expect(linkMatch![0]).not.toContain('media="print"');
+    expect(linkMatch![0]).not.toMatch(/onload=/);
+    // No inline event handler anywhere in the document.
+    expect(html).not.toMatch(/onload=/);
   });
 
   it("inline <style> contains a containment rule", () => {
@@ -32,13 +29,10 @@ describe.skipIf(!hasDistBuild)("critical CSS inlining", () => {
     expect(styleMatch![0]).toMatch(/contain:/);
   });
 
-  it('<noscript> fallback link does NOT have media="print"', () => {
-    const noscriptMatch = html.match(/<noscript>[\s\S]*?<\/noscript>/);
-    expect(noscriptMatch).not.toBeNull();
-    const noscriptLink = noscriptMatch![0].match(
-      /<link[^>]*rel="stylesheet"[^>]*>/,
-    );
-    expect(noscriptLink).not.toBeNull();
-    expect(noscriptLink![0]).not.toContain('media="print"');
+  it("full stylesheet <link> is moved into the body", () => {
+    const splitIdx = html.indexOf("</head>");
+    expect(splitIdx).toBeGreaterThan(-1);
+    const body = html.slice(splitIdx);
+    expect(body).toMatch(/<link[^>]*rel="stylesheet"[^>]*>/);
   });
 });

--- a/firebase.json
+++ b/firebase.json
@@ -11,7 +11,7 @@
           "headers": [
             {
               "key": "Content-Security-Policy",
-              "value": "default-src 'none'; script-src 'self' 'unsafe-inline' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
+              "value": "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
             },
             {
               "key": "Cross-Origin-Opener-Policy",
@@ -167,7 +167,7 @@
           "headers": [
             {
               "key": "Content-Security-Policy",
-              "value": "default-src 'none'; script-src 'self' 'unsafe-inline' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' blob: https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
+              "value": "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' blob: https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
             },
             {
               "key": "Cross-Origin-Opener-Policy",
@@ -290,7 +290,7 @@
           "headers": [
             {
               "key": "Content-Security-Policy",
-              "value": "default-src 'none'; script-src 'self' 'unsafe-inline' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self'; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://*.firebasestorage.app https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
+              "value": "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self'; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://*.firebasestorage.app https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
             },
             {
               "key": "Cross-Origin-Opener-Policy",
@@ -445,7 +445,7 @@
           "headers": [
             {
               "key": "Content-Security-Policy",
-              "value": "default-src 'none'; script-src 'self' 'unsafe-inline' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://cdn.jsdelivr.net https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' blob: https://*.googleapis.com https://*.firebaseapp.com https://*.firebasestorage.app https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' blob: https://*.firebaseapp.com https://www.google.com https://apis.google.com; worker-src 'self' blob: https://cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
+              "value": "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://cdn.jsdelivr.net https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' blob: https://*.googleapis.com https://*.firebaseapp.com https://*.firebasestorage.app https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' blob: https://*.firebaseapp.com https://www.google.com https://apis.google.com; worker-src 'self' blob: https://cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
             },
             {
               "key": "Cross-Origin-Opener-Policy",
@@ -568,7 +568,7 @@
           "headers": [
             {
               "key": "Content-Security-Policy",
-              "value": "default-src 'none'; script-src 'self' 'unsafe-inline' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://*.firebasestorage.app https://static.cloudflareinsights.com https://www.google-analytics.com; media-src 'self' blob:; frame-src 'self' https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
+              "value": "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://*.firebasestorage.app https://static.cloudflareinsights.com https://www.google-analytics.com; media-src 'self' blob:; frame-src 'self' https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
             },
             {
               "key": "Cross-Origin-Opener-Policy",
@@ -691,7 +691,7 @@
           "headers": [
             {
               "key": "Content-Security-Policy",
-              "value": "default-src 'none'; script-src 'self' 'unsafe-inline' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
+              "value": "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'"
             },
             {
               "key": "Cross-Origin-Opener-Policy",

--- a/office-hours/test/firebase-headers.test.ts
+++ b/office-hours/test/firebase-headers.test.ts
@@ -1,0 +1,4 @@
+import { describeFirebaseHeaders } from "@commons-systems/config/firebase-headers.test-helper";
+import { join } from "node:path";
+
+describeFirebaseHeaders("office-hours", join(import.meta.dirname, "..", ".."));


### PR DESCRIPTION
Closes #1300

## Summary

`firebase.json` set a Content-Security-Policy on all six Firebase Hosting
targets (`landing`, `budget`, `fellspiral`, `print`, `audio`, `office-hours`)
whose `script-src` directive included `'unsafe-inline'`. That token neuters most
of the CSP's XSS protection for scripts — it lets any injected inline
`<script>` execute. This PR removes `'unsafe-inline'` from `script-src` on all
six sites and locks the change in with a regression guard.

## Why dropping the token alone is sufficient

The built apps contain **no inline executable scripts**, so there is nothing to
externalize, nonce, or hash:

- All six are Vite 6 apps using the shared `config/vite.js`. Vite 6 bundles the
  modulepreload polyfill into the entry JS chunk rather than injecting it as an
  inline `<script>`.
- Verified on `landing` (the most complex pipeline: `vite build` +
  `prerender.ts` + `critical-css.ts`). Its built HTML contains only an external
  module `<script src="/assets/index-*.js">` (loaded from `'self'`) and
  `<script type="application/ld+json">` / `application/json` data blocks — data,
  not executed, and not governed by `script-src`.
- All third-party scripts load as external `<script src>` from hosts already
  allowlisted in each CSP (Google Analytics/gtag, Firebase init, Google auth,
  print's PDF.js worker via the separate `worker-src`). None rely on
  `'unsafe-inline'`.
- Nonces are not viable here regardless: Firebase Hosting serves a static
  header, so it cannot carry a fresh per-request nonce. External modules — the
  current state — are the correct answer.

`style-src 'unsafe-inline'` is intentionally **retained** on every target:
Critters inlines critical CSS as `<style>` blocks. Only `script-src` is in
scope for #1300.

## Changes

- **`firebase.json`** — removed the `'unsafe-inline'` token from the
  `script-src` directive of all six targets' CSP. `print`'s
  `https://cdn.jsdelivr.net` allowance and every other directive/header are
  untouched.
- **`config/firebase-headers.test-helper.ts`** — added a shared assertion in
  `describeFirebaseHeaders` that the global `**` rule's `script-src` directive
  contains `'self'` and does **not** contain `'unsafe-inline'`. This runs for
  the five helper-consuming apps (`landing`, `budget`, `fellspiral`, `print`,
  `audio`).
- **`office-hours/test/firebase-headers.test.ts`** — new 4-line file invoking
  the helper for `office-hours`, the one target previously lacking a
  firebase-headers test, so the new assertion guards all six targets.

## Verification

- Unit tests pass for all six targets, including the new `script-src` assertion.
- The existing `fellspiral/test/firebase-headers.test.ts` assertions
  (`script-src 'self'`, `style-src 'self' 'unsafe-inline'`) remain true and
  required no change.
- Runtime confidence across all six sites is the job of the following QA /
  preview-deploy phase: preview-channel deploys apply `firebase.json` headers,
  so each app loads under the tightened CSP. No `firestore.rules` changes are
  involved.

## Acceptance criteria

- [x] `script-src` no longer contains `'unsafe-inline'` (external modules
  instead).
- [x] Regression guard prevents `'unsafe-inline'` from creeping back into
  `script-src` on any target.
- [ ] All six apps load and authenticate under the tightened policy —
  confirmed in the QA / preview-deploy phase.
