### PR TITLE
storage.rules: unbounded member_emails check, removing the 3-member cap

### DIFF
--- a/audio/seeds/storage.ts
+++ b/audio/seeds/storage.ts
@@ -37,7 +37,7 @@ function makeWav(durationSeconds: number): Buffer {
 }
 
 const publicMeta = { publicdomain: "true" };
-const testPrivateMeta = { publicdomain: "false", member_0: TEST_USER.email };
+const testPrivateMeta = { publicdomain: "false", member_emails: TEST_USER.email };
 
 // Public domain items have both a sourceUrl (real audio from Internet Archive)
 // and a content stub (synthetic WAV). The seed script uses the stub in CI

--- a/print/seeds/storage.ts
+++ b/print/seeds/storage.ts
@@ -275,7 +275,7 @@ function makeLittleNemoCbz(): Buffer {
 }
 
 const publicMeta = { publicdomain: "true" };
-const testPrivateMeta = { publicdomain: "false", member_0: "test@example.com" };
+const testPrivateMeta = { publicdomain: "false", member_emails: "test@example.com" };
 
 const storageSeed: StorageSeedItem[] = [
   {

--- a/rules-test/test/storage/audio-media.test.ts
+++ b/rules-test/test/storage/audio-media.test.ts
@@ -26,7 +26,6 @@ describe("storage audio media", () => {
       `audio/${ENV}/media/public-audiobook.mp3`,
       {
         publicdomain: "true",
-        member_0: "member@test.com",
       },
     );
     await adminUploadStorage(
@@ -34,8 +33,7 @@ describe("storage audio media", () => {
       `audio/${ENV}/media/private-audiobook.mp3`,
       {
         publicdomain: "false",
-        member_0: "member@test.com",
-        member_1: "other@test.com",
+        member_emails: "member@test.com,other@test.com",
       },
     );
   });
@@ -57,7 +55,7 @@ describe("storage audio media", () => {
   });
 
   describe("private files - member access", () => {
-    it("allows member_0 to read", async () => {
+    it("allows first listed member to read", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
       const storage = ctx.storage();
       const ref = storage.ref(
@@ -66,7 +64,7 @@ describe("storage audio media", () => {
       await assertSucceeds(ref.getDownloadURL());
     });
 
-    it("allows member_1 to read", async () => {
+    it("allows second listed member to read", async () => {
       const ctx = authenticatedContext(env, "other@test.com");
       const storage = ctx.storage();
       const ref = storage.ref(
@@ -90,6 +88,62 @@ describe("storage audio media", () => {
       const ref = storage.ref(
         `audio/${ENV}/media/private-audiobook.mp3`,
       );
+      await assertFails(ref.getDownloadURL());
+    });
+  });
+
+  describe(">3 members (cap removed)", () => {
+    beforeEach(async () => {
+      await adminUploadStorage(
+        env,
+        `audio/${ENV}/media/four-member.mp3`,
+        {
+          publicdomain: "false",
+          member_emails: "a@test.com,b@test.com,c@test.com,d@test.com",
+        },
+      );
+    });
+
+    it("allows the 4th listed member to read", async () => {
+      const ctx = authenticatedContext(env, "d@test.com");
+      const storage = ctx.storage();
+      const ref = storage.ref(`audio/${ENV}/media/four-member.mp3`);
+      await assertSucceeds(ref.getDownloadURL());
+    });
+
+    it("denies a non-listed email", async () => {
+      const ctx = authenticatedContext(env, "e@test.com");
+      const storage = ctx.storage();
+      const ref = storage.ref(`audio/${ENV}/media/four-member.mp3`);
+      await assertFails(ref.getDownloadURL());
+    });
+  });
+
+  describe("legacy member_0/1/2 fallback", () => {
+    beforeEach(async () => {
+      await adminUploadStorage(
+        env,
+        `audio/${ENV}/media/legacy.mp3`,
+        {
+          publicdomain: "false",
+          member_0: "legacy0@test.com",
+          member_1: "legacy1@test.com",
+          member_2: "legacy2@test.com",
+        },
+      );
+    });
+
+    it("allows a listed legacy member to read", async () => {
+      const ctx = authenticatedContext(env, "legacy0@test.com");
+      const storage = ctx.storage();
+      const ref = storage.ref(`audio/${ENV}/media/legacy.mp3`);
+      await assertSucceeds(ref.getDownloadURL());
+    });
+
+    it("denies a non-listed email on a legacy object", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const storage = ctx.storage();
+      const ref = storage.ref(`audio/${ENV}/media/legacy.mp3`);
       await assertFails(ref.getDownloadURL());
     });
   });

--- a/rules-test/test/storage/audio-media.test.ts
+++ b/rules-test/test/storage/audio-media.test.ts
@@ -140,6 +140,20 @@ describe("storage audio media", () => {
       await assertSucceeds(ref.getDownloadURL());
     });
 
+    it("allows second listed legacy member to read", async () => {
+      const ctx = authenticatedContext(env, "legacy1@test.com");
+      const storage = ctx.storage();
+      const ref = storage.ref(`audio/${ENV}/media/legacy.mp3`);
+      await assertSucceeds(ref.getDownloadURL());
+    });
+
+    it("allows third listed legacy member to read", async () => {
+      const ctx = authenticatedContext(env, "legacy2@test.com");
+      const storage = ctx.storage();
+      const ref = storage.ref(`audio/${ENV}/media/legacy.mp3`);
+      await assertSucceeds(ref.getDownloadURL());
+    });
+
     it("denies a non-listed email on a legacy object", async () => {
       const ctx = authenticatedContext(env, "stranger@test.com");
       const storage = ctx.storage();

--- a/rules-test/test/storage/print-media.test.ts
+++ b/rules-test/test/storage/print-media.test.ts
@@ -124,6 +124,20 @@ describe("storage print media", () => {
       await assertSucceeds(ref.getDownloadURL());
     });
 
+    it("allows second listed legacy member to read", async () => {
+      const ctx = authenticatedContext(env, "legacy1@test.com");
+      const storage = ctx.storage();
+      const ref = storage.ref(`print/${ENV}/media/legacy.epub`);
+      await assertSucceeds(ref.getDownloadURL());
+    });
+
+    it("allows third listed legacy member to read", async () => {
+      const ctx = authenticatedContext(env, "legacy2@test.com");
+      const storage = ctx.storage();
+      const ref = storage.ref(`print/${ENV}/media/legacy.epub`);
+      await assertSucceeds(ref.getDownloadURL());
+    });
+
     it("denies a non-listed email on a legacy object", async () => {
       const ctx = authenticatedContext(env, "stranger@test.com");
       const storage = ctx.storage();

--- a/rules-test/test/storage/print-media.test.ts
+++ b/rules-test/test/storage/print-media.test.ts
@@ -23,12 +23,10 @@ describe("storage print media", () => {
   beforeEach(async () => {
     await adminUploadStorage(env, `print/${ENV}/media/public-book.epub`, {
       publicdomain: "true",
-      member_0: "member@test.com",
     });
     await adminUploadStorage(env, `print/${ENV}/media/private-book.epub`, {
       publicdomain: "false",
-      member_0: "member@test.com",
-      member_1: "other@test.com",
+      member_emails: "member@test.com,other@test.com",
     });
   });
 
@@ -49,14 +47,14 @@ describe("storage print media", () => {
   });
 
   describe("private files - member access", () => {
-    it("allows member_0 to read", async () => {
+    it("allows first listed member to read", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
       const storage = ctx.storage();
       const ref = storage.ref(`print/${ENV}/media/private-book.epub`);
       await assertSucceeds(ref.getDownloadURL());
     });
 
-    it("allows member_1 to read", async () => {
+    it("allows second listed member to read", async () => {
       const ctx = authenticatedContext(env, "other@test.com");
       const storage = ctx.storage();
       const ref = storage.ref(`print/${ENV}/media/private-book.epub`);
@@ -78,25 +76,59 @@ describe("storage print media", () => {
     });
   });
 
-  describe("member_2 access", () => {
+  describe(">3 members (cap removed)", () => {
     beforeEach(async () => {
       await adminUploadStorage(
         env,
-        `print/${ENV}/media/three-member.epub`,
+        `print/${ENV}/media/four-member.epub`,
         {
           publicdomain: "false",
-          member_0: "a@test.com",
-          member_1: "b@test.com",
-          member_2: "c@test.com",
+          member_emails: "a@test.com,b@test.com,c@test.com,d@test.com",
         },
       );
     });
 
-    it("allows member_2 to read", async () => {
-      const ctx = authenticatedContext(env, "c@test.com");
+    it("allows the 4th listed member to read", async () => {
+      const ctx = authenticatedContext(env, "d@test.com");
       const storage = ctx.storage();
-      const ref = storage.ref(`print/${ENV}/media/three-member.epub`);
+      const ref = storage.ref(`print/${ENV}/media/four-member.epub`);
       await assertSucceeds(ref.getDownloadURL());
+    });
+
+    it("denies a non-listed email", async () => {
+      const ctx = authenticatedContext(env, "e@test.com");
+      const storage = ctx.storage();
+      const ref = storage.ref(`print/${ENV}/media/four-member.epub`);
+      await assertFails(ref.getDownloadURL());
+    });
+  });
+
+  describe("legacy member_0/1/2 fallback", () => {
+    beforeEach(async () => {
+      await adminUploadStorage(
+        env,
+        `print/${ENV}/media/legacy.epub`,
+        {
+          publicdomain: "false",
+          member_0: "legacy0@test.com",
+          member_1: "legacy1@test.com",
+          member_2: "legacy2@test.com",
+        },
+      );
+    });
+
+    it("allows a listed legacy member to read", async () => {
+      const ctx = authenticatedContext(env, "legacy0@test.com");
+      const storage = ctx.storage();
+      const ref = storage.ref(`print/${ENV}/media/legacy.epub`);
+      await assertSucceeds(ref.getDownloadURL());
+    });
+
+    it("denies a non-listed email on a legacy object", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const storage = ctx.storage();
+      const ref = storage.ref(`print/${ENV}/media/legacy.epub`);
+      await assertFails(ref.getDownloadURL());
     });
   });
 

--- a/scaffolding/scripts/upload-media-core.sh
+++ b/scaffolding/scripts/upload-media-core.sh
@@ -147,7 +147,7 @@ core::upload_to_gcs() {
   if [ -n "$group_id" ]; then
     META_ARGS+=(-h "x-goog-meta-groupid:${group_id}")
     local joined
-    joined="$(IFS=,; echo "${emails_ref[*]}")"
+    joined="$(IFS=,; printf '%s' "${emails_ref[*]}" | tr '[:upper:]' '[:lower:]')"
     META_ARGS+=(-h "x-goog-meta-member_emails:${joined}")
   fi
 

--- a/scaffolding/scripts/upload-media-core.sh
+++ b/scaffolding/scripts/upload-media-core.sh
@@ -6,7 +6,7 @@
 # has no executable bit and no shebang; it expects to be sourced from a bash
 # script that already enabled `set -euo pipefail`.
 #
-# GCS metadata header casing: lowercase (publicdomain, groupid, member_<i>) —
+# GCS metadata header casing: lowercase (publicdomain, groupid, member_emails) —
 # matches the keys read by storage.rules and emitted by the seed runners.
 #
 # Cleanup: register every temp file via core::register_temp_file. Registrations
@@ -146,10 +146,9 @@ core::upload_to_gcs() {
 
   if [ -n "$group_id" ]; then
     META_ARGS+=(-h "x-goog-meta-groupid:${group_id}")
-    local i
-    for i in "${!emails_ref[@]}"; do
-      META_ARGS+=(-h "x-goog-meta-member_${i}:${emails_ref[$i]}")
-    done
+    local joined
+    joined="$(IFS=,; echo "${emails_ref[*]}")"
+    META_ARGS+=(-h "x-goog-meta-member_emails:${joined}")
   fi
 
   if ! gsutil "${META_ARGS[@]}" cp "$file_path" "$gcs_dest"; then

--- a/storage.rules
+++ b/storage.rules
@@ -2,19 +2,33 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
     match /print/{env}/media/{fileName} {
-      allow read: if resource.metadata["publicdomain"] == "true"
+      allow read: if resource.metadata['publicdomain'] == 'true'
         || (request.auth != null && (
-            resource.metadata["member_0"] == request.auth.token.email
-         || resource.metadata["member_1"] == request.auth.token.email
-         || resource.metadata["member_2"] == request.auth.token.email));
+             // Unbounded membership: metadata mirrors the Firestore media doc's
+             // memberEmails array (comma-joined). No member cap.
+             ('member_emails' in resource.metadata
+               && request.auth.token.email in resource.metadata['member_emails'].split(','))
+             // Transitional fallback for objects uploaded under the legacy
+             // member_0/1/2 scheme (pre-#1301). Removable after a metadata migration.
+             || ('member_0' in resource.metadata && resource.metadata['member_0'] == request.auth.token.email)
+             || ('member_1' in resource.metadata && resource.metadata['member_1'] == request.auth.token.email)
+             || ('member_2' in resource.metadata && resource.metadata['member_2'] == request.auth.token.email)
+           ));
       allow write: if false;
     }
     match /audio/{env}/media/{fileName} {
-      allow read: if resource.metadata["publicdomain"] == "true"
+      allow read: if resource.metadata['publicdomain'] == 'true'
         || (request.auth != null && (
-            resource.metadata["member_0"] == request.auth.token.email
-         || resource.metadata["member_1"] == request.auth.token.email
-         || resource.metadata["member_2"] == request.auth.token.email));
+             // Unbounded membership: metadata mirrors the Firestore media doc's
+             // memberEmails array (comma-joined). No member cap.
+             ('member_emails' in resource.metadata
+               && request.auth.token.email in resource.metadata['member_emails'].split(','))
+             // Transitional fallback for objects uploaded under the legacy
+             // member_0/1/2 scheme (pre-#1301). Removable after a metadata migration.
+             || ('member_0' in resource.metadata && resource.metadata['member_0'] == request.auth.token.email)
+             || ('member_1' in resource.metadata && resource.metadata['member_1'] == request.auth.token.email)
+             || ('member_2' in resource.metadata && resource.metadata['member_2'] == request.auth.token.email)
+           ));
       allow write: if false;
     }
     match /{allPaths=**} {


### PR DESCRIPTION
Closes #1301

## Summary

`storage.rules` gated media-file reads via three hardcoded object-metadata keys
— `member_0`, `member_1`, `member_2` — each compared against
`request.auth.token.email`. The Firestore `media` doc's `memberEmails` array is
unbounded, so a group's **4th** member could read the Firestore doc but got
permission-denied on the file in Storage. It failed closed (not a
vulnerability), but the 3-member cap was invisible until hit — a latent
dual-source-of-truth divergence.

This PR keeps the metadata-mirror architecture (Cloud Storage rules cannot read
Firestore, so membership must be denormalized onto the object's own metadata)
but makes it **unbounded**: the indexed `member_0/1/2` keys are replaced with a
single comma-joined `member_emails` field, checked via
`request.auth.token.email in resource.metadata['member_emails'].split(',')`.
This removes the cap for any group size — no Function, no client changes, no IAM
or signing setup. Satisfies acceptance criterion #1.

## Changes

- **`storage.rules`** — in both the `print/{env}/media` and `audio/{env}/media`
  blocks, replace the hardcoded `member_0/1/2` comparisons with an
  existence-guarded unbounded `member_emails` membership check, plus an
  existence-guarded transitional legacy `member_0/1/2` fallback so objects
  already uploaded under the old scheme keep working. The `'key' in
  resource.metadata` guards matter — a new private object has `member_emails`
  but not `member_0`, and an unguarded access to a missing key errors at
  evaluation.
- **`scaffolding/scripts/upload-media-core.sh`** — the shared upload path for
  both apps now writes a single comma-joined `x-goog-meta-member_emails` header
  instead of per-index `member_<i>` headers. New uploads write only
  `member_emails`.
- **`print/seeds/storage.ts`, `audio/seeds/storage.ts`** — private seed items
  switch from `member_0` to `member_emails`.
- **`rules-test/test/storage/{print,audio}-media.test.ts`** — rewritten for the
  new scheme: private metadata is a comma-joined `member_emails`; the
  three-member block is replaced with a ">3 members (cap removed)" block that
  asserts the **4th** listed member reads successfully (the direct
  acceptance-criterion check) and a non-listed email is denied; a new legacy
  `member_0/1/2` fallback block locks the transitional clause.

## Greenfield design (deferred)

The single-source-of-truth design removes denormalization entirely: a callable
Cloud Function authenticates the caller, loads the Firestore `media` doc, runs
the rules-equivalent check, and mints a short-lived signed URL; `storage.rules`
denies all private reads and the client fetches via the Function. It is deferred
because it is out of single-PR scope and backwards-incompatible — a new
Function, client read-path changes in both apps, upload-script changes, and
owner-privileged IAM setup (the GCF default service account needs the Service
Account Token Creator role to self-sign URLs). A good follow-up candidate; the
review phase may file it.

## Known limitation (pre-existing, out of scope)

The metadata is a snapshot taken at upload time, so a membership change made in
Firestore *after* upload does not propagate to the object's metadata. This
staleness exists in the current scheme too; only the greenfield Function design
eliminates it.

## Deploy / QA caveat

`storage.rules` deploys **only** on merge to `main` via
`.github/workflows/storage-deploy.yml` — preview branch deploys do **not**
deploy Storage rules. So smoke-testing a private read on this feature branch
will hit permission-denied until the rules reach `main`. Per the serialized
rules workflow in `.claude/rules/firestore.md`, this may need user-approved
coordination (merging latest rules and/or a manual `firebase deploy --only
storage:rules`) before/at submission.

## Verification

The primary gate is the `rules-test` Storage suite, which runs in **no** CI job
and requires the Firebase Storage emulator — it must be run manually during QA.
Confirm every case passes, especially the new 4th-member `assertSucceeds` and
the legacy-fallback case. `bash -n` passes on the upload core; both seed
packages type-check clean.
