### PR TITLE
budget: poll-until-settled in the unbudgeted-toggle e2e row-count test

### DIFF
--- a/budget/e2e/transactions.spec.ts
+++ b/budget/e2e/transactions.spec.ts
@@ -114,8 +114,8 @@ test.describe("transactions", () => {
     const countBefore = await visibleRows.count();
     expect(countBefore).toBeGreaterThan(0);
     await page.locator("#sankey-unbudgeted").check();
+    await expect.poll(async () => visibleRows.count()).toBeLessThan(countBefore);
     const countAfter = await visibleRows.count();
-    expect(countAfter).toBeLessThan(countBefore);
     expect(countAfter).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
Closes #1258

## Summary

The `unbudgeted toggle filters table rows` e2e test in
`budget/e2e/transactions.spec.ts` read `visibleRows.count()` immediately after
`#sankey-unbudgeted.check()` with no auto-retrying poll. The checkbox toggling
does not guarantee the `.txn-row` visibility has re-rendered, so `countAfter`
could still reflect the pre-filter set — a flaky row-count race.

This is the same race class fixed for blur-triggered filters in #1028 and for the
Sankey-node-click filter in #1250 (#1067). The settled `expect.poll` pattern is
already established throughout this file (lines 252, 270, 292, 317, 335, 350).

## Change

Insert an auto-retrying poll after `.check()` and drop the now-redundant
immediate `toBeLessThan` assertion (the poll establishes the reduction):

```ts
    await page.locator("#sankey-unbudgeted").check();
    await expect.poll(async () => visibleRows.count()).toBeLessThan(countBefore);
    const countAfter = await visibleRows.count();
    expect(countAfter).toBeGreaterThan(0);
```

This mirrors the settled block at `budget/e2e/transactions.spec.ts:252-254`
exactly. Test-file only — no production code changes, no new helper.

## Verification

- `npx tsc --noEmit --project budget` passes.
- The budget acceptance suite runs the test on the CI acceptance job.
