### PR TITLE
dispatch: port the combined /review-fix fan-out to a Workflow-tool pipeline

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-review-dedup
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-review-dedup
@@ -49,7 +49,7 @@ set -euo pipefail
 jq '
   # --- helpers ----------------------------------------------------------------
 
-  def confrank: {"high":3,"medium":2,"low":1}[.] // 0;
+  def confrank: (. // "_") | {"high":3,"medium":2,"low":1}[.] // 0;
 
   # Build id → input-index map (0-based) for ordering.
   (.findings | to_entries | map({key: .value.id, value: .key}) | from_entries) as $idx |
@@ -73,8 +73,11 @@ jq '
     $all_groups[] |
     . as $group |
 
-    # Enrich each id with its finding and input index.
-    (map({ id: ., finding: $byid[.], idx: $idx[.] })) as $members |
+    # Enrich each id with its finding and input index. Drop ids absent from the
+    # findings map (mirrors the JS `.filter(Boolean)` after `byId.get(id)`) so a
+    # partition referencing an unknown id never feeds a null into the merge.
+    (map({ id: ., finding: $byid[.], idx: $idx[.] })
+      | map(select(.finding != null))) as $members |
 
     # Earliest-input-index member (for output ordering).
     ($members | min_by(.idx) | .idx) as $min_idx |

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-review-dedup
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-review-dedup
@@ -62,11 +62,11 @@ jq '
   ([.partition // [] | .[]] | flatten | unique) as $partitioned_ids |
 
   # Append singleton groups for findings not covered by any partition group.
-  (.partition // []) + [
+  ((.partition // []) + [
     .findings[].id
     | select(. as $id | $partitioned_ids | index($id) == null)
     | [.]
-  ] as $all_groups |
+  ]) as $all_groups |
 
   # --- merge each group -------------------------------------------------------
   [

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-review-dedup
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-review-dedup
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Deterministically collapse duplicate findings using mechanical location-grouping
+# plus a caller-supplied partition — NO model decisions made here.
+# Usage: printf '%s' '<json>' | dispatch-review-dedup
+#
+# Reads a single JSON object on stdin:
+#   {
+#     "findings": [ <finding>, ... ],
+#     "partition": [ [<id>, <id>, ...], ... ]
+#   }
+#
+# Per-finding input fields (at minimum):
+#   id         — string, unique per finding
+#   Location   — string (path:line)
+#   Source     — string (code-review | review | input-validation | secrets |
+#                        red-team | security-review | auth | data-exposure |
+#                        firebase | codeql | npm)
+#   OWASP      — string ("" for code-review/review findings)
+#   STRIDE     — string ("" for code-review/review findings)
+#   Confidence — "high" | "medium" | "low"
+#   sources    — optional array of strings (pre-existing multi-source list)
+#   (plus arbitrary passthrough fields preserved from the representative)
+#
+# partition: list of id-groups; findings in each group collapse into ONE output
+# finding. Any finding id NOT in any partition group is treated as a singleton
+# (still emitted, normalized to carry a `sources` array).
+# PRECONDITION (trusted): all ids in a partition group share one Location.
+#
+# Merge arithmetic per group (and singletons — no-op except normalizing sources):
+#   confidence rank: high=3, medium=2, low=1.
+#   representative = finding with highest Confidence; tie-break = earliest in
+#                    input findings order. All passthrough fields come from it.
+#   output.Confidence = MAX Confidence across the group.
+#   output.OWASP      = first non-empty OWASP, ordered by (Confidence desc,
+#                       input order); else "".
+#   output.STRIDE     = same rule as OWASP.
+#   output.sources    = sorted-unique union of every group finding's Source
+#                       plus any pre-existing sources entries.
+#
+# Output (stdout): JSON array of deduped findings, ordered by the group's
+# earliest-appearing member's input index.
+#
+# No network access, no git, no gh, no model calls — pure stdin → stdout via jq.
+#
+# Consumer: .claude/workflows/review-fix.js mirrors this merge arithmetic in JS;
+# this script is the normative spec for that inline JS logic.
+set -euo pipefail
+
+jq '
+  # --- helpers ----------------------------------------------------------------
+
+  def confrank: {"high":3,"medium":2,"low":1}[.] // 0;
+
+  # Build id → input-index map (0-based) for ordering.
+  (.findings | to_entries | map({key: .value.id, value: .key}) | from_entries) as $idx |
+
+  # Build id → finding map for fast lookup.
+  (.findings | map({key: .id, value: .}) | from_entries) as $byid |
+
+  # --- canonicalize partition -------------------------------------------------
+  # Collect all ids that appear in at least one partition group.
+  ([.partition // [] | .[]] | flatten | unique) as $partitioned_ids |
+
+  # Append singleton groups for findings not covered by any partition group.
+  (.partition // []) + [
+    .findings[].id
+    | select(. as $id | $partitioned_ids | index($id) == null)
+    | [.]
+  ] as $all_groups |
+
+  # --- merge each group -------------------------------------------------------
+  [
+    $all_groups[] |
+    . as $group |
+
+    # Enrich each id with its finding and input index.
+    (map({ id: ., finding: $byid[.], idx: $idx[.] })) as $members |
+
+    # Earliest-input-index member (for output ordering).
+    ($members | min_by(.idx) | .idx) as $min_idx |
+
+    # Representative: highest Confidence; tie-break by earliest input index.
+    ($members | sort_by([(.finding.Confidence | confrank | -.), .idx]) | .[0].finding) as $rep |
+
+    # Max confidence across all group members.
+    ($members | map(.finding.Confidence | confrank) | max) as $max_conf_rank |
+    ({"3":"high","2":"medium","1":"low"}[$max_conf_rank | tostring]) as $max_conf |
+
+    # OWASP: first non-empty, ordered by (Confidence desc, input index).
+    ($members
+      | sort_by([(.finding.Confidence | confrank | -.), .idx])
+      | map(.finding.OWASP)
+      | map(select(. != null and . != ""))
+      | .[0] // "") as $owasp |
+
+    # STRIDE: same rule.
+    ($members
+      | sort_by([(.finding.Confidence | confrank | -.), .idx])
+      | map(.finding.STRIDE)
+      | map(select(. != null and . != ""))
+      | .[0] // "") as $stride |
+
+    # sources: sorted-unique union of Source + any pre-existing sources entries
+    # across all group members.
+    ([
+      $members[].finding |
+      [.Source] + (.sources // []) |
+      .[]
+    ] | unique | sort) as $sources |
+
+    # Compose the merged finding: representative fields overridden by computed ones.
+    {
+      _sort_key: $min_idx,
+      merged: ($rep + {
+        Confidence: $max_conf,
+        OWASP:      $owasp,
+        STRIDE:     $stride,
+        sources:    $sources
+      })
+    }
+  ] |
+
+  # --- sort by earliest-group-member input index and strip sort key -----------
+  sort_by(._sort_key) |
+  map(.merged)
+' </dev/stdin

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-review-finders
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-review-finders
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Map changed-surface flags → the surface-conditional finder-source set for the
+# /review-fix Workflow fan-out (issue #890).
+# Usage: printf 'surface=code\ndeps=true\napp_or_rules=true\n' | dispatch-review-finders
+#
+# Reads three key=value lines on stdin (as emitted by dispatch-security-surface),
+# in any order, blank lines ignored:
+#   surface=<empty|docs|code>
+#   deps=<true|false>
+#   app_or_rules=<true|false>
+# Missing keys default to: surface=empty, deps=false, app_or_rules=false.
+#
+# Prints finder source names to stdout, one per line, in this fixed order,
+# omitting any not warranted by the surface flags:
+#   code-review          (always)
+#   review               (always)
+#   input-validation     (surface==code)
+#   secrets              (surface==code)
+#   red-team             (surface==code)
+#   security-review      (surface==code)
+#   auth                 (surface==code AND app_or_rules==true)
+#   data-exposure        (surface==code AND app_or_rules==true)
+#   firebase             (surface==code AND app_or_rules==true)
+#   codeql               (surface==code)
+#   npm                  (deps==true)
+#
+# surface empty/docs => exactly code-review and review (zero security finders).
+# surface==code       => 4 always-on security finders + codeql.
+# app_or_rules==true  => additionally auth, data-exposure, firebase (7 total).
+# deps==true          => additionally npm (independent of surface).
+#
+# No network access, no git, no gh — pure stdin → stdout classification.
+#
+# Consumer: .claude/workflows/review-fix.js mirrors this mapping in JS;
+# this script is the normative spec for that inline JS logic.
+set -euo pipefail
+
+# --- parse stdin ----------------------------------------------------------------
+
+surface="empty"
+deps="false"
+app_or_rules="false"
+
+while IFS= read -r line; do
+  # Skip blank / whitespace-only lines.
+  [[ -z "${line//[[:space:]]/}" ]] && continue
+  case "$line" in
+    surface=*)   surface="${line#surface=}" ;;
+    deps=*)      deps="${line#deps=}" ;;
+    app_or_rules=*) app_or_rules="${line#app_or_rules=}" ;;
+  esac
+done
+
+# --- emit finder set ------------------------------------------------------------
+
+# Always-present finders (review quality, all surfaces including empty/docs).
+echo "code-review"
+echo "review"
+
+# Security finders: only when surface==code.
+if [[ "$surface" == "code" ]]; then
+  echo "input-validation"
+  echo "secrets"
+  echo "red-team"
+  echo "security-review"
+
+  # App/rules-specific security finders.
+  if [[ "$app_or_rules" == "true" ]]; then
+    echo "auth"
+    echo "data-exposure"
+    echo "firebase"
+  fi
+
+  echo "codeql"
+fi
+
+# Dependency audit finder: gated on deps flag, independent of surface.
+if [[ "$deps" == "true" ]]; then
+  echo "npm"
+fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-review-verify-drop
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-review-verify-drop
@@ -16,19 +16,22 @@
 #   (plus arbitrary passthrough fields preserved unchanged)
 #
 # votes: map of finding-id → array of skeptic verdicts ("refuted" or "upheld").
-#   A missing id in votes is treated as [] (no votes → upheld).
+#   A missing id in votes is treated as [] (no votes — both skeptics failed).
 #
 # Drop rule (Required findings only):
-#   REFUTED if votes[id] contains AT LEAST ONE "refuted" => dropped, verify="Refuted"
-#   UPHELD  if votes[id] contains NO "refuted"          => kept,   verify="Upheld"
-#   (threshold is ≥1-refuted-of-N; empty votes array => Upheld)
+#   UNVERIFIED if votes[id] is EMPTY (both skeptics failed) => dropped, verify="Unverified"
+#   REFUTED    if votes[id] contains AT LEAST ONE "refuted"  => dropped, verify="Refuted"
+#   UPHELD     if votes[id] has ≥1 vote and NONE "refuted"  => kept,    verify="Upheld"
+#   (threshold is ≥1-refuted-of-N. Empty votes are NOT upheld: in this terminal
+#   auto-ready phase a finding whose verification could not run is dropped — not
+#   auto-fixed — matching the skeptic prompt's "refute under uncertainty" bias.)
 #
 # Non-Required findings: always kept, never annotated with verify.
 #
 # Output (stdout): a single JSON object:
 #   {
 #     "kept":    [ <finding>, ... ],   // non-Required (unchanged) + Upheld Required
-#     "dropped": [ <finding>, ... ]    // Refuted Required findings
+#     "dropped": [ <finding>, ... ]    // Refuted + Unverified Required findings
 #   }
 # Original relative order of findings is preserved within each output array.
 #
@@ -47,9 +50,13 @@ jq '
 
     if $f.bucket == "Required" then
       # Fetch votes for this finding; default to empty array.
-      (($votes[$f.id] // []) | map(select(. == "refuted")) | length) as $refuted_count |
+      (($votes[$f.id] // [])) as $finding_votes |
+      ($finding_votes | map(select(. == "refuted")) | length) as $refuted_count |
 
-      if $refuted_count >= 1 then
+      if ($finding_votes | length) == 0 then
+        # Both skeptics failed to vote: verification could not run.
+        { disposition: "dropped", finding: ($f + {verify: "Unverified"}) }
+      elif $refuted_count >= 1 then
         { disposition: "dropped", finding: ($f + {verify: "Refuted"}) }
       else
         { disposition: "kept",    finding: ($f + {verify: "Upheld"}) }

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-review-verify-drop
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-review-verify-drop
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Apply the adversarial-verify drop threshold: drop Required findings where at
+# least one skeptic voted "refuted". Non-Required findings are never affected.
+# Usage: printf '%s' '<json>' | dispatch-review-verify-drop
+#
+# Reads a single JSON object on stdin:
+#   {
+#     "findings": [ <finding>, ... ],
+#     "votes":    { "<id>": ["refuted"|"upheld", ...], ... }
+#   }
+#
+# Per-finding input fields (at minimum):
+#   id     — string, unique per finding
+#   bucket — string; one of: Fixed | Required | Informational | Dismissed |
+#             False-positive | Deferred | Out-of-scope
+#   (plus arbitrary passthrough fields preserved unchanged)
+#
+# votes: map of finding-id → array of skeptic verdicts ("refuted" or "upheld").
+#   A missing id in votes is treated as [] (no votes → upheld).
+#
+# Drop rule (Required findings only):
+#   REFUTED if votes[id] contains AT LEAST ONE "refuted" => dropped, verify="Refuted"
+#   UPHELD  if votes[id] contains NO "refuted"          => kept,   verify="Upheld"
+#   (threshold is ≥1-refuted-of-N; empty votes array => Upheld)
+#
+# Non-Required findings: always kept, never annotated with verify.
+#
+# Output (stdout): a single JSON object:
+#   {
+#     "kept":    [ <finding>, ... ],   // non-Required (unchanged) + Upheld Required
+#     "dropped": [ <finding>, ... ]    // Refuted Required findings
+#   }
+# Original relative order of findings is preserved within each output array.
+#
+# No network access, no git, no gh, no model calls — pure stdin → stdout via jq.
+#
+# Consumer: .claude/workflows/review-fix.js mirrors this threshold logic in JS;
+# this script is the normative spec for that inline JS logic.
+set -euo pipefail
+
+jq '
+  .votes as $votes |
+
+  [
+    .findings[] |
+    . as $f |
+
+    if $f.bucket == "Required" then
+      # Fetch votes for this finding; default to empty array.
+      (($votes[$f.id] // []) | map(select(. == "refuted")) | length) as $refuted_count |
+
+      if $refuted_count >= 1 then
+        { disposition: "dropped", finding: ($f + {verify: "Refuted"}) }
+      else
+        { disposition: "kept",    finding: ($f + {verify: "Upheld"}) }
+      end
+    else
+      # Non-Required: always kept, no annotation.
+      { disposition: "kept", finding: $f }
+    end
+  ] as $annotated |
+
+  {
+    kept:    [ $annotated[] | select(.disposition == "kept")    | .finding ],
+    dropped: [ $annotated[] | select(.disposition == "dropped") | .finding ]
+  }
+' </dev/stdin

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -19889,6 +19889,110 @@ assert_eq "followup: empty input → 0" "0" "$(printf '%s' "$out" | jq -r 'lengt
 out=$(printf '%s' '[{"source":"sonarqube","classification":"out-of-scope","security_severity_level":"high"},{"classification":"out-of-scope","severity":"critical"}]' | "$SCRIPT_DIR/dispatch-security-followup" 123)
 assert_eq "followup: unknown/missing source → 0" "0" "$(printf '%s' "$out" | jq -r 'length')"
 
+# ============================================================================
+# === dispatch-review-finders ===
+# ============================================================================
+
+echo "Test: dispatch-review-finders"
+
+# empty surface → exactly code-review and review
+out=$(printf 'surface=empty\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders")
+assert_eq "finders: empty → code-review,review only" "code-review
+review" "$out"
+
+# docs surface → exactly code-review and review
+out=$(printf 'surface=docs\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders")
+assert_eq "finders: docs → code-review,review only" "code-review
+review" "$out"
+
+# code + app_or_rules=false + deps=false → 4 always-on security finders present
+n=$(printf 'surface=code\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -cE '^(input-validation|secrets|red-team|security-review)$')
+assert_eq "finders: code !app → 4 always-on security finders" "4" "$n"
+
+# code + app_or_rules=false → codeql present
+n=$(printf 'surface=code\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -c '^codeql$')
+assert_eq "finders: code !app → codeql present" "1" "$n"
+
+# code + app_or_rules=false → npm absent
+n=$(printf 'surface=code\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -c '^npm$' || true)
+assert_eq "finders: code !app !deps → npm absent" "0" "$n"
+
+# code + app_or_rules=false → app-domain trio absent
+n=$(printf 'surface=code\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -cE '^(auth|data-exposure|firebase)$' || true)
+assert_eq "finders: code !app → app-domain trio absent" "0" "$n"
+
+# code + app_or_rules=true + deps=false → 7 security reviewers present
+n=$(printf 'surface=code\ndeps=false\napp_or_rules=true\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -cE '^(input-validation|secrets|red-team|security-review|auth|data-exposure|firebase)$')
+assert_eq "finders: code+app → 7 security reviewers" "7" "$n"
+
+# code + app_or_rules=true + deps=false → npm absent
+n=$(printf 'surface=code\ndeps=false\napp_or_rules=true\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -c '^npm$' || true)
+assert_eq "finders: code+app !deps → npm absent" "0" "$n"
+
+# deps=true on a code surface → npm present
+n=$(printf 'surface=code\ndeps=true\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -c '^npm$')
+assert_eq "finders: deps=true → npm present" "1" "$n"
+
+# codeql gating: present on code surface
+n=$(printf 'surface=code\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -c '^codeql$')
+assert_eq "finders: code surface → codeql present" "1" "$n"
+
+# codeql gating: absent on docs surface
+n=$(printf 'surface=docs\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -c '^codeql$' || true)
+assert_eq "finders: docs surface → codeql absent" "0" "$n"
+
+# ============================================================================
+# === dispatch-review-dedup ===
+# ============================================================================
+
+echo "Test: dispatch-review-dedup"
+
+# same location, partition collapses → length 1, sources merged, Confidence max, OWASP from high
+IN1='{"findings":[{"id":"a","Location":"f.ts:1","Source":"review","OWASP":"","STRIDE":"","Confidence":"low"},{"id":"b","Location":"f.ts:1","Source":"security-review","OWASP":"A03:2021 Injection","STRIDE":"Tampering","Confidence":"high"}],"partition":[["a","b"]]}'
+out=$(printf '%s' "$IN1" | "$SCRIPT_DIR/dispatch-review-dedup")
+assert_eq "dedup: same-location merge → length 1" "1" "$(printf '%s' "$out" | jq -r 'length')"
+assert_eq "dedup: same-location merge → sources union" '["review","security-review"]' "$(printf '%s' "$out" | jq -c '.[0].sources')"
+assert_eq "dedup: same-location merge → Confidence max (high)" "high" "$(printf '%s' "$out" | jq -r '.[0].Confidence')"
+assert_eq "dedup: same-location merge → OWASP from high-confidence member" "A03:2021 Injection" "$(printf '%s' "$out" | jq -r '.[0].OWASP')"
+
+# distinct locations → length 2
+IN2='{"findings":[{"id":"a","Location":"f.ts:1","Source":"review","OWASP":"","STRIDE":"","Confidence":"low"},{"id":"b","Location":"f.ts:9","Source":"review","OWASP":"","STRIDE":"","Confidence":"low"}],"partition":[["a"],["b"]]}'
+out=$(printf '%s' "$IN2" | "$SCRIPT_DIR/dispatch-review-dedup")
+assert_eq "dedup: distinct locations → length 2" "2" "$(printf '%s' "$out" | jq -r 'length')"
+
+# same location, distinct root issues, partition keeps them apart → length 2
+IN3='{"findings":[{"id":"a","Location":"f.ts:1","Source":"review","OWASP":"","STRIDE":"","Confidence":"low"},{"id":"b","Location":"f.ts:1","Source":"secrets","OWASP":"A02:2021 Cryptographic Failures","STRIDE":"Information Disclosure","Confidence":"medium"}],"partition":[["a"],["b"]]}'
+out=$(printf '%s' "$IN3" | "$SCRIPT_DIR/dispatch-review-dedup")
+assert_eq "dedup: same-location distinct-root partition → length 2" "2" "$(printf '%s' "$out" | jq -r 'length')"
+
+# ============================================================================
+# === dispatch-review-verify-drop ===
+# ============================================================================
+
+echo "Test: dispatch-review-verify-drop"
+
+IN='{"findings":[{"id":"r1","bucket":"Required"},{"id":"r2","bucket":"Required"},{"id":"r3","bucket":"Required"},{"id":"r4","bucket":"Required"},{"id":"i1","bucket":"Informational"}],"votes":{"r1":["refuted","upheld"],"r2":["refuted","refuted"],"r3":["upheld","upheld"]}}'
+out=$(printf '%s' "$IN" | "$SCRIPT_DIR/dispatch-review-verify-drop")
+
+# dropped ids (sorted) == r1 and r2
+assert_eq "verify-drop: dropped ids" "r1
+r2" "$(printf '%s' "$out" | jq -r '.dropped[].id' | sort)"
+
+# every dropped finding has verify=="Refuted"
+assert_eq "verify-drop: all dropped have verify=Refuted" "2" "$(printf '%s' "$out" | jq -r '.dropped[] | select(.verify=="Refuted") | .id' | wc -l | tr -d ' ')"
+
+# r1 NOT in kept
+assert_eq "verify-drop: r1 not in kept" "0" "$(printf '%s' "$out" | jq -r '.kept[].id' | grep -c '^r1$' || true)"
+
+# r3 in kept with verify=="Upheld"
+assert_eq "verify-drop: r3 kept with verify=Upheld" "Upheld" "$(printf '%s' "$out" | jq -r '.kept[] | select(.id=="r3") | .verify')"
+
+# r4 (empty votes) in kept with verify=="Upheld"
+assert_eq "verify-drop: r4 empty-votes kept with verify=Upheld" "Upheld" "$(printf '%s' "$out" | jq -r '.kept[] | select(.id=="r4") | .verify')"
+
+# i1 (non-Required) in kept with no verify key
+assert_eq "verify-drop: i1 non-Required kept without verify key" "false" "$(printf '%s' "$out" | jq -r '.kept[] | select(.id=="i1") | has("verify")')"
+
 # dispatch-jit-skill tests
 # ============================================================================
 #

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -19974,12 +19974,13 @@ echo "Test: dispatch-review-verify-drop"
 IN='{"findings":[{"id":"r1","bucket":"Required"},{"id":"r2","bucket":"Required"},{"id":"r3","bucket":"Required"},{"id":"r4","bucket":"Required"},{"id":"i1","bucket":"Informational"}],"votes":{"r1":["refuted","upheld"],"r2":["refuted","refuted"],"r3":["upheld","upheld"]}}'
 out=$(printf '%s' "$IN" | "$SCRIPT_DIR/dispatch-review-verify-drop")
 
-# dropped ids (sorted) == r1 and r2
+# dropped ids (sorted) == r1, r2, r4 (r4 = empty votes → Unverified, also dropped)
 assert_eq "verify-drop: dropped ids" "r1
-r2" "$(printf '%s' "$out" | jq -r '.dropped[].id' | sort)"
+r2
+r4" "$(printf '%s' "$out" | jq -r '.dropped[].id' | sort)"
 
-# every dropped finding has verify=="Refuted"
-assert_eq "verify-drop: all dropped have verify=Refuted" "2" "$(printf '%s' "$out" | jq -r '.dropped[] | select(.verify=="Refuted") | .id' | wc -l | tr -d ' ')"
+# r1, r2 dropped with verify=="Refuted"
+assert_eq "verify-drop: refuted dropped count" "2" "$(printf '%s' "$out" | jq -r '.dropped[] | select(.verify=="Refuted") | .id' | wc -l | tr -d ' ')"
 
 # r1 NOT in kept
 assert_eq "verify-drop: r1 not in kept" "0" "$(printf '%s' "$out" | jq -r '.kept[].id' | grep -c '^r1$' || true)"
@@ -19987,8 +19988,9 @@ assert_eq "verify-drop: r1 not in kept" "0" "$(printf '%s' "$out" | jq -r '.kept
 # r3 in kept with verify=="Upheld"
 assert_eq "verify-drop: r3 kept with verify=Upheld" "Upheld" "$(printf '%s' "$out" | jq -r '.kept[] | select(.id=="r3") | .verify')"
 
-# r4 (empty votes) in kept with verify=="Upheld"
-assert_eq "verify-drop: r4 empty-votes kept with verify=Upheld" "Upheld" "$(printf '%s' "$out" | jq -r '.kept[] | select(.id=="r4") | .verify')"
+# r4 (empty votes — both skeptics failed) dropped with verify=="Unverified", NOT kept
+assert_eq "verify-drop: r4 empty-votes dropped with verify=Unverified" "Unverified" "$(printf '%s' "$out" | jq -r '.dropped[] | select(.id=="r4") | .verify')"
+assert_eq "verify-drop: r4 not in kept" "0" "$(printf '%s' "$out" | jq -r '.kept[].id' | grep -c '^r4$' || true)"
 
 # i1 (non-Required) in kept with no verify key
 assert_eq "verify-drop: i1 non-Required kept without verify key" "false" "$(printf '%s' "$out" | jq -r '.kept[] | select(.id=="i1") | has("verify")')"

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -77,13 +77,15 @@ applies none:
   itself on a clean pass. On a user-input blocker (a needs-human-judgment item, a
   bug, a failed pre-QA check) it escalates to the office-hours queue instead,
   where `/office-hours` runs the interactive residue.
-- **`/review-fix`** — the single terminal review pass. It runs `/code-review max
-  --fix`, `/review`, and the full surface-gated security fan-out as direct
-  subagents over the same diff, unifies and de-duplicates the findings, applies
-  the in-scope fixes via one `/commit-merge-push`, files meaningful out-of-scope
-  findings as `blocked_by` follow-ups, posts one PR comment covering every
-  finding, applies `dispatch:reviewed`, and marks the PR ready. It is idempotent
-  on re-entry.
+- **`/review-fix`** — the single terminal review pass. It invokes the Workflow
+  tool on `.claude/workflows/review-fix.js`, which fans out surface-conditional
+  finders (`/code-review max` findings-only, `/review`, and the surface-gated
+  security reviewers) over the same diff, de-duplicates and classifies the
+  findings in code, adversarially verifies `Required` findings before spending an
+  Opus fix, and runs an Opus fix fan-out. The skill then commits the fixes via one
+  `/commit-merge-push`, files meaningful out-of-scope findings as `blocked_by`
+  follow-ups, posts one PR comment covering every finding, applies
+  `dispatch:reviewed`, and marks the PR ready. It is idempotent on re-entry.
 - **`/implement`** — the `implement`-phase build skill for a no-PR issue carrying
   `dispatch:planned`. It reads the plan persisted to the issue's
   `<!-- dispatch:plan -->` comment, builds each unit via `/implement-unit`, and

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -1,27 +1,27 @@
 ---
 name: review-fix
-description: Review phase — the workflow's single terminal review pass. Run /code-review max, /review, and the full surface-gated security fan-out as direct subagents over the same diff, unify and de-duplicate the findings, apply the in-scope fixes via one /commit-merge-push, file meaningful out-of-scope findings as blocked_by follow-ups, post one PR comment covering every finding, apply the dispatch:reviewed label, and mark the PR ready
+description: Review phase — the workflow's single terminal review pass. Runs the combined /review-fix fan-out through the Workflow tool: surface-conditional finders (code-review, review, security domain reviewers) in parallel → code dedup → classify → adversarial-verify (Required findings refuted by 2 skeptics before any Opus fix runs) → Opus fix fan-out → deferred/follow-up filing prep. Returns a compact disposition summary; applies fixes via one /commit-merge-push, files blocked_by follow-ups, posts one PR comment, applies the dispatch:reviewed label, and marks the PR ready
 ---
 
 # Review and Fix
 
 The `review` phase of the issue workflow, dispatched by the dispatch chain. This
 skill consolidates what were three separate review phases — code-review, review,
-and security — into one pass over a single diff. It runs all three generic
-reviews as direct subagents, unifies and de-duplicates their findings into one
-disposition table, applies the in-scope fixes via one `/commit-merge-push`, files
-meaningful out-of-scope findings as `blocked_by` follow-ups, posts **one** PR
-comment, applies the `dispatch:reviewed` label, and marks the PR ready.
+and security — into one pass over a single diff. It invokes the **Workflow tool**
+on `.claude/workflows/review-fix.js`, which fans out surface-conditional finders,
+deduplicates and classifies findings in code, adversarially verifies `Required`
+findings before spending an Opus fix, and prepares filing structures. The skill
+retains all bash/gh/git work the Workflow cannot do: the idempotency preamble,
+diff capture, inline scans, the single `/commit-merge-push`, follow-up filing,
+the PR comment, the `dispatch:reviewed` label, and the marker.
 
 This is the workflow's **terminal actionable phase** — it marks the PR ready
 itself, so there is no separate phase after it. Resulting chain: `qa -> review
 -> done`.
 
-This skill runs in the **caller's thread** — it has no `context:` key — so it can
-launch the three review subagents directly via the Agent tool, run the CodeQL and
-dependency-audit scans inline, fork `/commit-merge-push`, and launch
-implementation and follow-up-issue subagents. Every review is a **direct child**
-of this skill: there is no intermediate orchestrator and no nesting.
+**Sanctioned Workflow caller.** This skill invokes the Workflow tool directly
+(see Step 2). The Workflow runs in the background and returns a compact
+disposition summary; this skill never sees raw findings.
 
 Run `gh` commands (directly or via `post-pr-comment.sh` / `dispatch-complete-phase`)
 and `npx`-backed scans (CodeQL, the dependency audit) with
@@ -44,7 +44,7 @@ un-escapes `\t`/`\n` in the JSON and injects raw control chars `jq` rejects — 
 `.claude/rules/shell-json.md`.
 
 `PR_NUM` is carried through to every later step — do not re-resolve. The PR body
-stays in `PR_JSON` (`jq -r .body <<<"$PR_JSON"`); Step 6 parses its
+stays in `PR_JSON` (`jq -r .body <<<"$PR_JSON"`); Step 3 parses its
 `Closes #N` line(s) to resolve the issue(s) this PR implements.
 
 If the printed labels already include `dispatch:reviewed` — an interrupted prior
@@ -55,18 +55,15 @@ Step 8's terminal flush and readying the PR. Routing re-entry through Step 8
 (rather than readying the PR inline) means its flush guard also carries any
 commits an interrupted prior run left stranded.
 
-On this re-entry path the unified finding set is not in context — Step 8 treats
-the deviation criterion as not met and writes the phase-completed marker.
-Otherwise run all steps in order.
+On this re-entry path the Workflow has not run — Step 8 treats the deviation
+criterion as not met (`result.deviation` is absent) and writes the phase-completed
+marker. Otherwise run all steps in order.
 
 ## Steps
 
-### 1. Run the three generic reviews as direct subagents over the same diff
+### 1. Capture the diff context and run the inline bash scans
 
-All three reviews look at the same diff — the branch's pending changes against
-the merge-base with `origin/main`. Capture that diff context once; every review
-needs it. Git runs sandboxed — `origin` is HTTPS to an allowlisted host, so no
-`dangerouslyDisableSandbox` is needed:
+All reviews look at the same diff. Capture it once:
 
 ```bash
 git fetch origin main
@@ -74,62 +71,8 @@ MERGE_BASE=$(git merge-base HEAD origin/main)
 git diff --name-only "$MERGE_BASE"...HEAD
 ```
 
-Launch the three reviews as direct child subagents of this skill (no intermediate
-orchestrator, no nesting). The code-review and review subagents launch
-unconditionally; the security pass is surface-gated (1c below). Each review
-returns a **schema-bounded finding set** (the **Per-finding schema** below) that
-the parent **immediately serializes to a file under `tmp/`** — one file per
-review source (e.g. `tmp/findings-code-review.json`, `tmp/findings-review.json`,
-`tmp/findings-security.json`). See **Context-budget discipline** below for why
-this serialization is not optional.
-
-#### 1a. `/code-review max` — a findings-only subagent
-
-Fork a subagent via the Agent tool (`subagent_type: general-purpose`,
-`model: sonnet`) that invokes the built-in `/code-review` skill via the Skill
-tool with the `max` effort argument (the highest thoroughness available) inside
-the subagent — **without** the `--fix` flag. It produces findings; it applies no
-fixes. Detection stays on Sonnet; all fix-authoring is concentrated in Step 5's
-Opus-pinned implementation subagents (#1172), so `/code-review` here is
-findings-only, exactly like `/review` (1b).
-
-The subagent boundary is the control-flow guarantee: the parent never sees the
-inner Skill's prompt template, so it remains on this step when the Agent call
-returns. `/code-review` is built-in and uneditable: the subagent passes the inner
-skill no output contract and returns its natural output as-is. Keep the "once it
-returns, continue" wording inside the **subagent's** prompt as defense-in-depth
-for the inner Skill invocation; any "final reply" / "nothing else" wording in
-`/code-review`'s prompt scopes only to its findings deliverable. The subagent
-stays non-isolated for consistency with the other findings-only subagents; it
-writes nothing to the working tree, so isolation would change nothing either way.
-
-Normalize the subagent's output to the **Per-finding schema** — code-review emits
-no fixes, so every finding is `skipped` (the wrapper classifies each into the
-disposition table in Step 2) — and serialize the finding set to
-`tmp/findings-code-review.json`.
-
-#### 1b. `/review` — a findings-only subagent
-
-Fork a subagent via the Agent tool (`subagent_type: general-purpose`,
-`model: sonnet`) that invokes the built-in `/review` skill via the Skill tool
-inside the subagent and returns its output verbatim — the generic PR review. It
-produces findings; it applies no fixes. The subagent boundary is the control-flow
-guarantee: the parent never sees the inner Skill's prompt template, so it remains
-on this step when the Agent call returns. `/review` is built-in and uneditable:
-the subagent passes the inner skill no output contract and returns its natural
-output as-is. Keep the "once it returns, continue" wording inside the
-**subagent's** prompt as defense-in-depth for the inner Skill invocation; any
-"final reply" / "nothing else" wording in `/review`'s prompt scopes only to its
-findings deliverable.
-
-Normalize the subagent's output to the **Per-finding schema** and serialize the
-finding set to `tmp/findings-review.json`.
-
-#### 1c. The full security pass — surface-gated, exactly as the security phase ran it
-
-Classify the changed surface, then fan out only the reviewers the surface
-warrants. Classify the changed-file list with `dispatch-security-surface` — a
-pure stdin→stdout classifier (no `gh`/git/network, so it runs sandboxed-fine):
+Classify the changed surface (no `dangerouslyDisableSandbox` needed — pure
+stdin→stdout):
 
 ```bash
 SURFACE_OUT=$(git diff --name-only "$MERGE_BASE"...HEAD \
@@ -147,85 +90,12 @@ app_or_rules=$(printf '%s\n' "$SURFACE_OUT" | sed -n 's/^app_or_rules=//p')
   (`.ts`/`.tsx`/`.js`/`.jsx`/`.mjs`/`.cjs`/`.go` outside `.claude/`) or a
   Firestore / Storage rules file.
 
-**`surface=empty` or `surface=docs`** → launch no security reviewers and run no
-inline scans. Serialize an empty security finding set to
-`tmp/findings-security.json`. Record a one-line "no attack surface" note for the
-Step 7 PR comment: for `docs`, `Security review: no attack surface — docs-only
-diff (no executable, config, dependency, or Firestore-rules changes).`; for
-`empty`, `Security review: no attack surface — diff is empty (no changed files
-detected).` The rest of the skill still runs end-to-end (the empty security
-finding set contributes nothing to the disposition).
+Set `security_note` for the Workflow `args`:
+- `surface=docs`: `Security review: no attack surface — docs-only diff (no executable, config, dependency, or Firestore-rules changes).`
+- `surface=empty`: `Security review: no attack surface — diff is empty (no changed files detected).`
+- `surface=code`: omit `security_note` (leave it unset).
 
-**`surface=code`** → fan out the security reviewers below in **a single message,
-one Agent tool call per reviewer**. Every reviewer is a direct child of this
-skill; there is no intermediate orchestrator. Every reviewer uses
-`subagent_type: general-purpose` and `model: sonnet`, and emits findings in the
-**Per-finding schema** below, so the aggregation step treats every output
-uniformly. CodeQL and the dependency audit are **not** subagents — they run
-inline in this parent thread (see their subsections below), consistent with the
-dispatch convention of direct subagents and no nesting.
-
-##### Shared preamble (in every security subagent prompt)
-
-- The **Per-finding schema** restated in full, so the subagent emits exactly
-  those fields.
-- The findings-only constraint: the subagent reports findings only. It edits no
-  files, commits nothing, and posts nothing.
-- `MERGE_BASE` and the changed-file list, plus the instruction: review only the
-  pending changes (the diff vs `MERGE_BASE`), but Read full files for the context
-  needed to judge each change.
-
-##### Reviewers that run on every code diff
-
-These four launch whenever `surface=code`, regardless of `app_or_rules` —
-command injection in a bash script and hardcoded secrets in config are real
-attack surface even when no application code changed:
-
-- **Input validation** — injection in the changed code: SQL/NoSQL injection,
-  XSS, command injection, path traversal. Check that external input is validated
-  and escaped at every boundary it crosses.
-- **Secrets scan** — hardcoded keys/tokens/credentials in the changed code,
-  `.env` files committed to git, secrets leaking into build output.
-- **Red team** — construct concrete attack scenarios against the changed code:
-  pick an attacker goal, trace a path through the diff to reach it, and report
-  each viable scenario as a finding. Build scenarios from the code under review
-  rather than pattern-matching a checklist of known vulnerabilities.
-- **Built-in `/security-review` scan** — fork a subagent that invokes the
-  built-in `/security-review` skill via the Skill tool inside the subagent and
-  returns its output normalized to the **Per-finding schema**. The subagent
-  boundary is the control-flow guarantee: the parent never sees the inner Skill's
-  prompt template, so this skill remains on Step 1 when the Agent call returns.
-  The subagent passes the inner skill no output contract. Keep the "once it
-  returns, continue" wording inside the **subagent's** prompt as defense-in-depth
-  for the inner Skill invocation; any "final reply" / "nothing else" wording in
-  `/security-review`'s prompt scopes only to its findings deliverable.
-
-  Normalize each built-in finding:
-
-  - **Confidence** — from the built-in's severity: `high`/`medium`/`low`
-    severity maps to `high`/`medium`/`low` confidence.
-  - **OWASP** and **STRIDE** — inferred from the finding's category and
-    description.
-  - **Location**, **Description**, **Recommended fix** — carried through
-    directly.
-
-##### App-domain reviewers (only when `app_or_rules=true`)
-
-These three are structurally N/A when the diff touches no application code or
-Firestore rules, so launch them only when `app_or_rules=true`:
-
-- **Auth & access control** — Firestore rules coverage for paths the diff
-  touches, missing auth checks, privilege escalation. Confirm each new or changed
-  Firestore path has a matching rule block and that client code does not assume
-  access the rules do not grant.
-- **Data exposure** — API responses returning more fields than the caller needs,
-  PII in logs (`console.log` and similar), internal details (stack traces,
-  config, paths) leaked in error messages.
-- **Firebase-specific** — Firestore rules permissiveness (overly broad `allow`
-  conditions, missing field constraints), emulator-only code reachable on
-  production paths, Firebase API key or config exposure.
-
-##### Dependency audit (inline, when `deps=true`)
+#### Dependency audit (inline, when `deps=true`)
 
 Run inline in this parent thread — not a subagent — when `deps=true`. The `deps`
 gate already confirms the diff touches `package.json` / `package-lock.json`, so
@@ -234,7 +104,7 @@ produce the differential audit directly (use a private temp dir):
 ```bash
 AUDIT_DIR=$(mktemp -d)
 trap 'rm -rf "$AUDIT_DIR"' EXIT
-# MERGE_BASE is already set in the Step 1 git commands above — reuse it here.
+# MERGE_BASE is already set above — reuse it here.
 
 # Audit HEAD (current working tree)
 npm audit --json > "$AUDIT_DIR/audit-head.json"
@@ -261,7 +131,7 @@ the **Per-finding schema** with `introduced_by_diff=false` and classify
 required-fix set. Pre-existing advisories rated `moderate` or `low` are below the
 meaningfulness threshold — do not surface them.
 
-##### CodeQL alerts (inline, when `surface=code`)
+#### CodeQL alerts (inline, when `surface=code`)
 
 Run inline in this parent thread — not a subagent — whenever `surface=code`.
 Fetch the PR's open code-scanning alerts from GitHub Advanced Security (use
@@ -293,56 +163,76 @@ preamble), skip the fetch and record the CodeQL scan as "could not run (no PR
 ref)" with no findings. An empty alert array is normal — no open CodeQL alerts —
 and is not an error.
 
-Serialize the security finding set — the returned security-reviewer findings
-together with the inline CodeQL and dependency-audit findings, each in the
-**Per-finding schema** — to `tmp/findings-security.json`.
+Collect normalized CodeQL and npm findings into `prescanned_findings` to pass to
+the Workflow.
 
-### 2. Aggregate, de-duplicate, and classify in a dedicated subagent
+### 2. Build `args` and invoke the Workflow
 
-**Run the unification in its OWN subagent** — `subagent_type: general-purpose`,
-`model: sonnet`. The subagent reads the three `tmp/` finding files written in
-Step 1 and returns one **compact disposition summary** (see the **Disposition
-table** below). The parent passes the subagent only the three file paths and the
-disposition schema; it does **not** paste the raw findings into the prompt. The
-parent holds only the file paths plus the returned summary — never the three
-reviews' raw finding sets simultaneously (see **Context-budget discipline**).
+Collect the fields for the Workflow invocation. Parse `Closes #N` from the PR
+body (`jq -r .body <<<"$PR_JSON"`) to resolve `implementing_issues`:
 
-The unification subagent:
+```
+args = {
+  pr_num:              <PR_NUM>,
+  merge_base:          <MERGE_BASE>,
+  changed_files:       [ ...from git diff --name-only... ],
+  surface:             "empty" | "docs" | "code",
+  deps:                <true|false>,
+  app_or_rules:        <true|false>,
+  prescanned_findings: [ ...normalized CodeQL + npm findings in Per-finding schema... ],
+  implementing_issues: [ <N>, ... ],    // parsed from Closes #N lines; [] if none
+  security_note:       <string or omit> // set for empty/docs; omit for code
+}
+```
 
-1. Merges the findings from all three files into one set.
-2. De-duplicates. The built-in `/security-review` scan, the inline CodeQL alerts,
-   and the domain reviewers overlap each other and the code-review/review passes,
-   so the same issue often arrives from several sources. When two or more findings
-   name the **same root issue at the same location**, collapse them into one: pick
-   the most specific OWASP category and STRIDE element across the duplicates (a
-   single value each per the Per-finding schema), take the highest confidence
-   among them, and record which sources flagged it. Distinct issues — even in the
-   same file — stay separate.
-3. Classifies every de-duplicated finding into the **Disposition table** below,
-   preserving both vocabularies (the security `required`/`out-of-scope`/
-   `false-positive` axis and the code-review/review `Fixed`/`Informational`/
-   `Dismissed`/`Deferred` axis).
+**Invoke the Workflow tool on `.claude/workflows/review-fix.js`**, passing `args`.
+The Workflow is a sanctioned call from this skill — no `ultracode` keyword needed.
+The Workflow runs in the background and returns one compact disposition summary:
 
-It returns a compact summary: for each finding, a short description, its
-location, its disposition bucket, its source(s), and — for findings that need
-later handling — the per-finding handling fields Steps 5–7 require (the composed
-follow-up title/body for Deferred findings, the serialized
-`codeql`/`npm` follow-up array for out-of-scope security findings, the
-recommended fix for required/Fixed findings, and the `required`-with-`high`-
-confidence flag for the Step 8 deviation check). It must **not** echo every
-finding's full prose back — the summary is bounded.
+```
+result = {
+  dispositions:         [ {id, short_desc, location, bucket, sources:[...],
+                            recommended_fix?, codeql_ref?:{rule_id,alert_number,html_url}} ],
+  fixed:                [ {id, location, fix_summary, touched_files:[...]} ],
+  deferred_filings:     [ {title, body, blocker_issue_nums:[N,...]|"independent"} ],
+  security_followup_input: [ ...codeql/npm out-of-scope subset... ],
+  verify_report:        [ {id, location, verdict, skeptic_votes, rationale} ],
+  deviation:            <bool>,
+  security_note?:       <string>
+}
+```
 
-### 3. One disposition table
+The Workflow's fix-authoring agents (non-isolated, Opus) have already edited the
+working tree by the time `result` is returned. The skill's context never holds raw
+findings — only this compact summary.
 
-Every finding from every source appears exactly once, de-duplicated, in one of
-these buckets. The table preserves **both** classification vocabularies: the
-security pass's `required` / `out-of-scope` / `false-positive` axis and the
-code-review/review `Fixed` / `Informational` / `Dismissed` / `Deferred` axis.
+### 3. Commit the Workflow's working-tree edits via one commit-merge-push
+
+Fork **one** `/commit-merge-push` to commit every pending working-tree change —
+the Workflow's Opus fix edits — and push. Issue an Agent tool call with
+`subagent_type: general-purpose` and `model: sonnet` whose prompt invokes
+`/commit-merge-push` via the Skill tool, the canonical fork recipe
+`/implement-unit` Step 2 documents (`subagent_type` is `general-purpose`, never the
+skill name). The `/commit-merge-push` fork stays on `model: sonnet`: it is
+orchestration (commit/merge/push), not fix-authoring. If there were no code
+changes at all, `/commit-merge-push` tolerates the no-op and creates no commit.
+Even on that no-op it pushes `origin HEAD`, so it carries any pending local merge
+(left by `dispatch-merge-main` / `/fix-conflicts`) to origin; Step 8's flush guard
+is the authoritative backstop when this fork is skipped entirely. Capture the
+resulting fix commit SHA(s) for the Step 7 comment.
+
+### 4. Disposition table
+
+Every finding from every source appears exactly once in one of these buckets. The
+Workflow's classifier preserves **both** vocabularies: the security pass's
+`required` / `out-of-scope` / `false-positive` axis and the code-review/review
+`Fixed` / `Informational` / `Dismissed` / `Deferred` axis.
 
 | Bucket | Source vocabulary | Meaning |
 |---|---|---|
-| Fixed | code-review/review | A concrete, in-scope code change applicable to this PR — the in-scope code-review/review findings the wrapper decides to implement. All are applied in Step 5 (no finding is pre-applied). |
-| Required | security | A real vulnerability or weakness in the changed code that should be fixed (applied in Step 5). |
+| Fixed | code-review/review | A concrete, in-scope code change applicable to this PR — applied by the Workflow's Opus fix agents. |
+| Required | security | A real vulnerability or weakness in the changed code. Adversarially verified; upheld Required findings applied by the Workflow's Opus fix agents. |
+| Refuted | security | A Required finding refuted by the adversarial-verify step — dropped before any Opus fix, recorded in verify_report. |
 | Informational | code-review/review | FYIs, notes, observations surfaced for human reference; no change required. |
 | Dismissed | code-review/review | Nits, incorrect findings, or not applicable; no change, each with a one-line rationale. |
 | False-positive | security | Not an actual vulnerability — a misread of the code or a non-issue; each with a one-line rationale. |
@@ -357,90 +247,20 @@ that are not actual improvements; smallness alone never qualifies (out-of-scope
 items go to Deferred, not Dismissed). When a code-review/review finding is
 ambiguous, default to Informational rather than inventing a code change.
 
-### 4. Context-budget discipline (correctness-critical)
-
-The merged parent session never resets between the three reviews. Naively holding
-all three reviews' raw findings in the parent would stack their context and
-routinely trip auto-compaction mid-review — a token cost and, worse, a
-correctness risk for the one phase that marks the PR ready with no human
-checkpoint (compaction can drop a finding before it is fixed or commented).
-
-So the parent must **never** hold all three reviews' raw findings in context
-simultaneously:
-
-- Each review subagent (Step 1) returns a schema-bounded finding set that the
-  parent **immediately serializes to a `tmp/` file** and then drops from working
-  context.
-- The unified de-dup + classification (Step 2) runs in its **own subagent** that
-  reads those `tmp/` files and returns a **compact disposition summary**.
-- After Step 2 the parent holds only the `tmp/` file paths plus the compact
-  summary.
-
-This keeps the parent's peak context close to a single phase's (~70–90k) rather
-than the stacked ~138k that would trip auto-compaction.
-
-### 5. Apply the required/Fixed fixes, then one commit-merge-push
-
-This step authors **all** in-scope fixes — no finding is pre-applied, because
-Step 1a's `/code-review` runs detection-only. It applies every Fixed-bucket
-finding (from `/code-review` and `/review`) and every `required`-bucket finding
-from the security pass.
-
-For each such finding, launch an implementation subagent via the Agent tool,
-constrained to **working-tree edits only — no commits, no pushes** (when there
-are multiple findings to apply, these implementation subagents may be fanned out
-in parallel — multiple Agent calls in one message — but only when they touch
-disjoint files; group findings that edit the same file into one subagent to
-avoid write conflicts). **Pin these
-implementation subagents to `model: opus`** (#1172): writing a correct fix is
-code generation, where Opus has the edge, so all fix-authoring is concentrated on
-Opus while the orchestrator chain and detection run on Sonnet. Informational,
-Dismissed, false-positive, Deferred, and out-of-scope findings are **not**
-implemented here. If there are no Fixed/required findings to apply, skip the
-implementation subagents.
-
-Then fork **one** `/commit-merge-push` to commit every pending working-tree
-change — the implementation subagents' edits — and push. Issue an Agent tool call
-with `subagent_type: general-purpose` and `model: sonnet` whose prompt invokes
-`/commit-merge-push` via the Skill tool, the canonical fork recipe
-`/implement-unit` Step 2 documents (`subagent_type` is `general-purpose`, never the
-skill name). The `/commit-merge-push` fork stays on `model: sonnet`: it is
-orchestration (commit/merge/push), not fix-authoring. If there were no code changes at all, `/commit-merge-push`
-tolerates the no-op and creates no commit. Even on that no-op it pushes `origin
-HEAD`, so it carries any pending local merge (left by `dispatch-merge-main` /
-`/fix-conflicts`) to origin; Step 8's flush guard is the
-authoritative backstop when this fork is skipped entirely. Capture the resulting
-fix commit SHA(s) for the Step 7 comment.
-
-### 6. File meaningful out-of-scope findings as blocked_by follow-ups
+### 5. File meaningful out-of-scope findings as blocked_by follow-ups
 
 Two follow-up paths, both filing `blocked_by` tracking issues so meaningful
-out-of-scope findings do not evaporate when the PR merges. Skip a path when its
-bucket is empty.
+out-of-scope findings do not evaporate when the PR merges. The Workflow has
+prepared filing structures in `result.deferred_filings` and
+`result.security_followup_input`; this skill executes the actual `gh` calls.
+Skip a path when its bucket is empty.
 
-#### 6a. Deferred code-review/review findings → `/file-issue` with a blocked-by link
+#### 5a. Deferred code-review/review findings → `/file-issue` with a blocked-by link
 
-First resolve the PR's **implementing issue(s)**: parse the `Closes #N` line(s)
-from the PR body captured in `PR_JSON` (`jq -r .body <<<"$PR_JSON"`). These
-are the issue(s) this PR's work delivers.
-
-Then, for **each** Deferred finding, assess — as a required sub-step, never
-skipped — what the new tracking issue is blocked by:
-
-- Deferred because it depends on or builds on this PR's changes → **blocked by
-  the PR's implementing issue(s)**.
-- Blocked by some other identifiable open issue → **blocked by that issue**.
-- Unrelated pre-existing code with no sequencing constraint → **independent**.
-- When unsure, prefer recording the dependency over leaving the issue unlinked.
-
-For each finding, fork a subagent via the Agent tool (`subagent_type:
-general-purpose`, `model: sonnet`). Build the subagent's `$INPUT` from the
-finding: a short imperative title on the first line, then the body — the finding
-text, the files the finding names, the PR backlink `#<PR_NUM>` (reuse `PR_NUM`
-from the idempotency preamble), and a short rationale for why the finding is out
-of scope for this PR. Pass the assessed blocker issue number(s) — or an explicit
-`independent` marker — into the subagent's prompt alongside `$INPUT`. The
-subagent:
+The Workflow prepares `result.deferred_filings`, each entry carrying `title`,
+`body`, and `blocker_issue_nums` (the implementing issue numbers from
+`Closes #N`, or `"independent"`). For each entry, fork a subagent (`subagent_type:
+general-purpose`, `model: sonnet`). The subagent:
 
 1. Invokes `/file-issue`, which runs the full pipeline: duplicate detection,
    8-category evaluation, decomposition gate, type/topic classification, issue
@@ -450,24 +270,38 @@ subagent:
    each. A single finding normally yields one record; a finding that legitimately
    separates into multiple issues yields several — link them all.
 2. For each record, for a non-independent finding, record a `blocked_by` dependency
-   **on the new issue `<N>`, targeting each blocker issue number** passed in. The
-   target is the GitHub **issue** — never the PR number, and the dependency is the
-   API relationship, never body text. Use the `ref-github-issues` dependencies API
-   (database-ID resolution with `gh api`, `--input` JSON; see `ref-github-issues`,
-   do not restate the syntax). On an `EXISTING <N>` record, first list `<N>`'s
-   current `blocked_by` (same dependencies API — see `ref-github-issues`) and skip
-   the POST for any blocker already present, so a duplicate does not error. An
-   `independent` finding records no dependency.
+   **on the new issue `<N>`, targeting each blocker issue number** from
+   `blocker_issue_nums`. The target is the GitHub **issue** — never the PR number,
+   and the dependency is the API relationship, never body text. Use the
+   `ref-github-issues` dependencies API (database-ID resolution with `gh api`,
+   `--input` JSON; see `ref-github-issues`, do not restate the syntax). On an
+   `EXISTING <N>` record, first list `<N>`'s current `blocked_by` (same
+   dependencies API — see `ref-github-issues`) and skip the POST for any blocker
+   already present, so a duplicate does not error. An `independent` finding records
+   no dependency.
 3. Returns every `<N>` to this thread.
 
 Capture each `<N>` against its source finding for the Step 7 comment.
 
-#### 6b. Meaningful out-of-scope CodeQL alerts / npm advisories → `dispatch-security-followup` → `/file-issue`
+#### 5b. Meaningful out-of-scope CodeQL alerts / npm advisories → `dispatch-security-followup` → `/file-issue`
 
-Meaningful out-of-scope CodeQL alerts and pre-existing npm advisories are filed
-as `security`-labeled follow-up issues — otherwise they evaporate when the PR
-merges. The PR's own required-fix set stays scoped to the diff (unchanged); this
-only files trackers for genuine findings the diff did not introduce.
+The Workflow prepares `result.security_followup_input` (the codeql/npm out-of-scope
+subset). Pipe it through `dispatch-security-followup` with `PR_NUM` (pure — no
+network/git/gh, runs sandboxed-fine):
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-security-followup "$PR_NUM" \
+  < <(printf '%s' '<result.security_followup_input as JSON array>')
+```
+
+It applies the threshold and emits a JSON array of `{identifier, title, body}`
+follow-ups (empty when none qualify). CodeQL emits one follow-up per alert; npm
+emits one follow-up per vulnerable package. Each `identifier` — CodeQL
+`rule.id` + alert number, or `npm advisories in <package>` — is embedded
+verbatim in the `title`. Before filing, the per-follow-up subagent runs
+`dispatch-followup-exists "<identifier>"`, a deterministic exact-identifier
+existence check spanning all issue states (`--state all`, open and closed), so
+the same alert or package is never re-filed across repeated runs or multiple PRs.
 
 **Meaningfulness threshold** (documented to keep follow-up noise low):
 
@@ -476,46 +310,10 @@ only files trackers for genuine findings the diff did not introduce.
 - npm: a package qualifies if any of its `out-of-scope`,
   not-introduced-by-diff (`introduced_by_diff=false`) advisories is rated
   `high` or `critical`. The follow-up is grouped per package (one issue per
-  vulnerable package, listing every such advisory it resolves) — because
-  `npm audit` reports each GHSA in a coordinated disclosure as a separate
-  advisory on the same package node, all fixed by a single version bump.
+  vulnerable package) because `npm audit` reports each GHSA in a coordinated
+  disclosure as a separate advisory on the same package node, all fixed by a
+  single version bump.
 - `required` and `false-positive` findings are never filed.
-
-Serialize the classified `codeql` and `npm` findings to a JSON array at
-`tmp/security-followup-input.json` — a codeql/npm subset distinct from the full
-`tmp/findings-security.json` set written in Step 1c — one object per finding
-carrying `classification`, `source`, and the source's fields (CodeQL: `rule_id`,
-`alert_number`, `security_severity_level`, `description`, `location`,
-`html_url`; npm: `advisory_id`, `severity`, `introduced_by_diff`, `package`,
-`title`, `url`), all already captured during normalization. Findings from other
-sources carry no stable ID and are omitted. Pipe the array through
-`dispatch-security-followup` with `PR_NUM` (pure — no network/git/gh, so it runs
-sandboxed-fine):
-
-```bash
-.claude/skills/dispatch-propagate/scripts/dispatch-security-followup "$PR_NUM" \
-  < tmp/security-followup-input.json
-```
-
-It applies the threshold and emits a JSON array of `{identifier, title, body}`
-follow-ups (empty when none qualify). CodeQL emits one follow-up per alert; npm
-emits one follow-up per vulnerable package. Each `identifier` — CodeQL
-`rule.id` + alert number, or `npm advisories in <package>` — is embedded
-verbatim in the `title`. Before filing, the
-per-follow-up subagent runs `dispatch-followup-exists "<identifier>"`, a
-deterministic exact-identifier existence check spanning all issue states
-(`--state all`, open and closed), so the same alert or package is never re-filed
-across repeated runs or multiple PRs. This deterministic guard is specific to
-this machine-keyed security-followup path; `/file-issue`'s fuzzy
-keyword+judgment dedup stays in place as defense-in-depth for free-text callers.
-
-Tradeoff: because the npm dedup key is package-scoped, a newly disclosed
-advisory on an already-filed package won't auto-file a fresh issue — the
-existing "upgrade this package" issue already covers the remediation (one
-version bump resolves every advisory on that package node). And because
-`dispatch-followup-exists` spans `--state all`, a closed tracking issue —
-already-resolved or already-rejected — suppresses re-filing of its identifier;
-re-filing is noise either way.
 
 For each emitted follow-up, fork a subagent (`subagent_type: general-purpose`,
 `model: sonnet`); run them in parallel (multiple Agent calls in one message). Each
@@ -553,38 +351,39 @@ subagent:
 
 Capture each `<N>` against its source finding for the Step 7 comment.
 
-The 6a and 6b follow-up subagents touch only GitHub and the working tree never,
-so they may be fanned out in the same message as one another and alongside Step
-5's implementation subagents (Step 5 touches only the working tree, Step 6 only
-GitHub — they do not conflict). The single `/commit-merge-push` in Step 5 runs
-after the implementation subagents return.
+The 5a and 5b follow-up subagents touch only GitHub and the working tree never,
+so they may be fanned out in the same message as one another (Step 3's
+`/commit-merge-push` has already returned by this point).
 
-### 7. Post exactly one PR comment
+### 6. Post exactly one PR comment
 
 Reuse the `PR_NUM` captured in the preamble — do not re-resolve. Post **one**
-comment covering **every** finding from the unified disposition and its
-disposition — not three.
+comment covering **every** finding from `result.dispositions` and its bucket.
 
 Write the comment body to a file under the repo's `tmp/` directory. The body file
 **must** live under `tmp/` because `post-pr-comment.sh` restricts paths to that
 directory. Organize the body by disposition bucket, omitting any bucket with no
-entries (on a docs-only / empty diff the security note from Step 1c stands in for
-the security buckets):
+entries (on a docs-only / empty diff the security note from `result.security_note`
+stands in for the security buckets):
 
 - **Fixed** — code-review/review findings implemented; one line per finding plus
-  the fix commit SHA from Step 5.
+  the fix commit SHA from Step 3.
 - **Required (security)** — security findings fixed; one line per finding plus the
   fix commit SHA, or the reason if left unresolved.
+- **Refuted (adversarial-verify dropped)** — Required findings refuted by the
+  adversarial-verify step; one line per entry from `result.verify_report` with
+  verdict and rationale. These were **not** fixed; include the skeptic rationale
+  so the audit trail explains the drop.
 - **Informational** — surfaced for human reference; no action.
 - **Dismissed** — code-review/review false positives or nits; each with a
   one-line rationale.
 - **False-positive (security)** — each with a one-line rationale.
 - **Deferred** — out-of-scope code-review/review findings; each references its
-  follow-up issue `#<N>` from Step 6a.
+  follow-up issue `#<N>` from Step 5a.
 - **Out-of-scope (security)** — pre-existing CodeQL/npm findings; each meaningful
-  one references its follow-up issue `#<N>` from Step 6b. CodeQL-sourced findings
-  are identified by their `rule.id` and alert number, linked via their
-  `html_url`.
+  one references its follow-up issue `#<N>` from Step 5b. CodeQL-sourced findings
+  are identified by their `rule.id` and alert number (from `codeql_ref`), linked
+  via their `html_url`.
 
 If a security reviewer or inline scan could not run (re-launch / retry exhausted),
 note partial coverage here — name the reviewer or scan whose domain could not be
@@ -597,7 +396,7 @@ Then post it (use `dangerouslyDisableSandbox: true` — the script invokes `gh`)
 .claude/skills/dispatch-propagate/scripts/post-pr-comment.sh "$PR_NUM" tmp/<file>
 ```
 
-### 8. Apply the terminal label, ready the PR, then write the marker (or park on deviation)
+### 7. Apply the terminal label, ready the PR, then write the marker (or park on deviation)
 
 **First, flush any unpushed local commits — the terminal flush of the "never
 push a bare merge commit" contract.** `dispatch-merge-main` (pre-spawn) and
@@ -608,7 +407,7 @@ ready, every later tick routes `STOP done` and no push point ever fires again.
 So any local merge left behind must be carried to origin here, before the PR is
 readied — otherwise the remote branch stays behind local HEAD and GitHub reports
 the PR `CONFLICTING` permanently. This guard runs **unconditionally**,
-independent of whether any findings were fixed: on a zero-findings run Step 5's
+independent of whether any findings were fixed: on a zero-findings run Step 3's
 `/commit-merge-push` may be skipped entirely, so the readiness gate is the only
 place the flush is guaranteed and it cannot be reasoned away.
 
@@ -616,7 +415,7 @@ place the flush is guaranteed and it cannot be reasoned away.
 normal path and the re-entry path. Git runs sandboxed here — `origin` is HTTPS
 to an allowlisted host, so **no `dangerouslyDisableSandbox`** (unlike the
 surrounding `gh` / `dispatch-complete-phase` calls in this step). The push is a
-no-op when Step 5 already pushed (HEAD `==` origin/$BRANCH) and fails safe: when
+no-op when Step 3 already pushed (HEAD `==` origin/$BRANCH) and fails safe: when
 the remote branch is up to date the count is `0` and nothing is pushed; it does
 real work only when no push point fired this run.
 
@@ -655,14 +454,15 @@ gh pr ready "$PR_NUM"
 Then write the phase-completed marker — or, on deviation, the office-hours reason.
 The Stop hook (`.claude/hooks/dispatch-stop.sh`) reads this to decide propagate vs
 park. `CLAUDE_JOB_DIR` unset = interactive run; skip both branches. On idempotent
-re-entry (Steps 1–7 were skipped), the unified finding set is not in context —
-treat the deviation criterion as not met and write the marker.
+re-entry (Steps 1–6 were skipped), the Workflow has not run — treat the deviation
+criterion as not met and write the marker.
 
-**Deviation criterion:** any security finding classified `required` with
-Confidence `high` remains unresolved after the Step 5 fix pass.
+**Deviation criterion:** `result.deviation` is `true` — any `Required` + `Upheld`
+finding with `Confidence` `high` remained unresolved after the Workflow's fix
+pipeline.
 
-**Deviation fires** (a high-confidence `required` finding is still unresolved) —
-skip the phase-completed marker. Call `dispatch-mark-deviation` instead:
+**Deviation fires** (`result.deviation === true`) — skip the phase-completed
+marker. Call `dispatch-mark-deviation` instead:
 
 ```bash
 .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
@@ -674,8 +474,8 @@ to the issue, surfacing the reason in the why-comment, so the parked item explai
 which criterion fired. Do not apply the `dispatch:office-hours` label inline — the
 Stop hook owns label application.
 
-**No deviation** (all high-confidence `required` findings resolved, or none
-existed) — call `dispatch-mark-complete`. `CLAUDE_JOB_DIR` unset = interactive
+**No deviation** (`result.deviation === false`, or Workflow did not run on
+re-entry) — call `dispatch-mark-complete`. `CLAUDE_JOB_DIR` unset = interactive
 run; the script no-ops with a clear diagnostic.
 
 ```bash
@@ -689,14 +489,14 @@ deviation — only the marker is skipped when the deviation criterion fires.
 
 ## Per-finding schema
 
-Every finding — emitted by the Step 1 subagents and inline scans, and carried
-through to the unified set in Step 2 — has these fields:
+Every finding — emitted by the Workflow's finders and inline scans, and carried
+through to the unified set — has these fields:
 
 - **Location** — `path:line`.
 - **Description** — what the issue is and why it is a risk.
 - **Source** — which review produced it (`code-review`, `review`,
   `input-validation`, `secrets`, `red-team`, `security-review`, `auth`,
-  `data-exposure`, `firebase`, `codeql`, `npm`). De-dup in Step 2 may record
+  `data-exposure`, `firebase`, `codeql`, `npm`). Dedup in the Workflow may record
   several sources on one finding.
 - **OWASP** — the OWASP Top 10 (2021) category (e.g. `A01:2021 Broken Access
   Control`, `A03:2021 Injection`). Security findings only; empty for
@@ -706,23 +506,19 @@ through to the unified set in Step 2 — has these fields:
 - **Confidence** — `high`, `medium`, or `low`.
 - **Recommended fix** — the concrete change that resolves the finding.
 - **Disposition** — the unified bucket from the **Disposition table**, set by the
-  Step 2 unification subagent. Security sources additionally carry the underlying
-  `required` / `out-of-scope` / `false-positive` classification; code-review
-  findings (detection-only, per Step 1a) and review findings both carry
-  `skipped`, which the unification subagent extends into Fixed / Informational /
-  Dismissed / Deferred.
+  Workflow's classify step.
 
 ## Edge cases
 
-- **Empty or docs-only diff** — `surface` is `empty` or `docs`; launch no security
-  reviewers, run no inline scans, and serialize an empty security finding set. The
-  code-review and review subagents still run, and the skill still applies
-  `dispatch:reviewed`, readies the PR, and writes the marker.
-- **A subagent finds nothing** — record that source as clean; it contributes no
-  findings.
-- **A subagent fails** — re-launch it once. If it fails again, note partial
-  coverage in the Step 7 PR comment (name the reviewer whose domain could not be
-  reviewed).
+- **Empty or docs-only diff** — `surface` is `empty` or `docs`; the Workflow
+  launches no security finders and no security agents. The code-review and review
+  agents still run. The skill still applies `dispatch:reviewed`, readies the PR,
+  and writes the marker.
+- **A finder finds nothing** — record that source as clean; it contributes no
+  findings to the Workflow.
+- **A finder agent fails** — the Workflow retries once. If it fails again, partial
+  coverage is noted in `result.dispositions` and surfaced in the Step 6 PR
+  comment.
 - **`npm audit` sandbox or network failure** — the dependency audit runs inline;
   retry its `npm audit` with `dangerouslyDisableSandbox: true`. If it still fails,
   report the dependency audit as "could not run" rather than silently dropping
@@ -734,24 +530,22 @@ through to the unified set in Step 2 — has these fields:
 
 ## Notes
 
-This is the workflow's terminal actionable phase: `gh pr ready` (Step 8) is the
+This is the workflow's terminal actionable phase: `gh pr ready` (Step 7) is the
 terminal PR-state action and writing the phase-completed marker is the dispatch
 chain's hand-off cue. After this change the dispatch workflow has no human
 checkpoint before a PR goes ready — the single PR-comment summary is the audit
 trail. This is an intentional trade-off for an autonomous background-job run.
 
 The skill is idempotent: a re-invocation with `dispatch:reviewed` already on the
-PR skips Steps 1–7 and runs Step 8, which flushes any unpushed commits, ensures
-the PR is ready, and writes the phase-completed marker (the unified finding set
-is not in context on re-entry, so the deviation criterion is treated as not met).
+PR skips Steps 1–6 and runs Step 7, which flushes any unpushed commits, ensures
+the PR is ready, and writes the phase-completed marker (the Workflow is not
+re-run on re-entry, so the deviation criterion is treated as not met).
 
 **Model split (#1172).** The dispatch chain runs this `review` phase orchestrator
 on **Sonnet** (via `dispatch-phase-model`, which maps `review →
-claude-sonnet-4-6`). Findings detection is unchanged — it stays on the **Sonnet**
-review subagents (Step 1's `/code-review`, `/review`, and the security fan-out).
-**Fix-authoring is pinned to an Opus subagent** (Step 5's implementation
-subagents, `model: opus`), so the Sonnet orchestrator authors no product code.
-When #890 ports this fan-out to a Workflow pipeline, that port carries the same
-tiering as per-`agent()` `model:` settings (finders + orchestrator Sonnet,
-fix-authoring Opus) so fix-authoring stays pinned to Opus **exactly once** — there
-is no double model-tiering.
+claude-sonnet-4-6`). The model tiering is now owned by the Workflow's per-`agent()`
+`model:` settings: finder agents (code-review, review, security domains) run on
+**Sonnet**, dedup/classify/verify agents run on **Sonnet**, and **fix-authoring
+Opus fix agents** (`model: opus`) write all working-tree changes. Fix-authoring is
+pinned to Opus **exactly once** in the Workflow's fix phase — there is no
+double-tiering. The orchestrator (this skill) authors no product code.

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -1,0 +1,775 @@
+/*
+ * review-fix.js — the issue #890 Workflow-tool port of the /review-fix review
+ * fan-out (the dispatch chain's single terminal review pass).
+ *
+ * WHAT THIS IS
+ * ------------
+ * A self-contained, sandboxed Workflow-tool script. The /review-fix SKILL.md
+ * runs the bash/gh/git/tmp work (idempotency preamble, diff + MERGE_BASE
+ * capture, dispatch-security-surface, the inline CodeQL + npm-audit scans, the
+ * Closes #N parse) and then invokes this Workflow, passing everything in via
+ * `args`. This script performs ONLY the pure fan-out + JS aggregation: it spawns
+ * the finders, dedups + classifies + adversarially-verifies the findings, runs
+ * the Opus fix fan-out (non-isolated, edits land in the caller's worktree so the
+ * skill's single /commit-merge-push picks them up), and prepares the deferred /
+ * security follow-up filing structure. It returns ONE compact disposition
+ * summary; the skill never sees raw findings. No filesystem, no gh, no git, no
+ * node:* — the skill does all of that around the call.
+ *
+ * args IN:
+ *   { pr_num, merge_base, changed_files:[...], surface:"empty"|"docs"|"code",
+ *     deps:bool, app_or_rules:bool,
+ *     prescanned_findings:[...Per-finding items, Source "codeql"|"npm",
+ *       carrying their source-specific fields...],
+ *     implementing_issues:[N,...], security_note?:string }
+ *
+ * return OUT (the ONLY thing this script returns):
+ *   { dispositions:[{id, short_desc, location, bucket, sources:[...],
+ *       recommended_fix?, codeql_ref?:{rule_id,alert_number,html_url}}],
+ *     fixed:[{id, location, fix_summary, touched_files:[...]}],
+ *     deferred_filings:[{title, body, blocker_issue_nums:[N,...]|"independent"}],
+ *     security_followup_input:[...codeql/npm out-of-scope subset...],
+ *     verify_report:[{id, location, verdict, skeptic_votes, rationale}],
+ *     deviation:bool, security_note? }
+ *
+ * NORMATIVE SPECS for the three inline kernel helpers below are the pure bash/jq
+ * scripts (unit-tested by test-dispatch-scripts.sh). The JS helpers are kept
+ * thin so they cannot drift from their specs:
+ *   - agentFinderSet  ←  .claude/skills/dispatch-propagate/scripts/dispatch-review-finders
+ *   - dedupMerge      ←  .claude/skills/dispatch-propagate/scripts/dispatch-review-dedup
+ *   - applyVerifyDrop ←  .claude/skills/dispatch-propagate/scripts/dispatch-review-verify-drop
+ */
+
+export const meta = {
+  name: 'review-fix',
+  description:
+    'Combined /review-fix review fan-out: surface-conditional finders → code dedup → classify → adversarial-verify → Opus fix fan-out → follow-up filing prep. Returns a compact disposition summary (issue #890).',
+  phases: [
+    { title: 'finders' },
+    { title: 'dedup' },
+    { title: 'classify' },
+    { title: 'verify' },
+    { title: 'fix' },
+    { title: 'file' },
+  ],
+};
+
+// --- schemas -----------------------------------------------------------------
+
+// Per-finding schema (FINDING_SCHEMA) — mirrors the "Per-finding schema" section
+// of .claude/skills/review-fix/SKILL.md. Note the literal key "Recommended fix"
+// (with a space) is the canonical field name.
+const FINDING_ITEM_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'Location',
+    'Description',
+    'Source',
+    'OWASP',
+    'STRIDE',
+    'Confidence',
+    'Recommended fix',
+    'Disposition',
+  ],
+  properties: {
+    Location: { type: 'string' },
+    Description: { type: 'string' },
+    Source: {
+      enum: [
+        'code-review',
+        'review',
+        'input-validation',
+        'secrets',
+        'red-team',
+        'security-review',
+        'auth',
+        'data-exposure',
+        'firebase',
+        'codeql',
+        'npm',
+      ],
+    },
+    OWASP: { type: 'string' },
+    STRIDE: { type: 'string' },
+    Confidence: { enum: ['high', 'medium', 'low'] },
+    'Recommended fix': { type: 'string' },
+    Disposition: { type: 'string' },
+  },
+};
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['findings'],
+  properties: {
+    findings: { type: 'array', items: FINDING_ITEM_SCHEMA },
+  },
+};
+
+const PARTITION_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['groups'],
+  properties: {
+    groups: {
+      type: 'array',
+      items: { type: 'array', items: { type: 'string' } },
+    },
+  },
+};
+
+const CLASSIFY_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['classifications'],
+  properties: {
+    classifications: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'bucket', 'security_class'],
+        properties: {
+          id: { type: 'string' },
+          bucket: {
+            enum: [
+              'Fixed',
+              'Required',
+              'Informational',
+              'Dismissed',
+              'False-positive',
+              'Deferred',
+              'Out-of-scope',
+            ],
+          },
+          security_class: {
+            enum: ['required', 'out-of-scope', 'false-positive', 'none'],
+          },
+        },
+      },
+    },
+  },
+};
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['verdict', 'rationale'],
+  properties: {
+    verdict: { enum: ['refuted', 'upheld'] },
+    rationale: { type: 'string' },
+  },
+};
+
+const FIX_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['touched_files', 'fix_summary', 'resolved_ids'],
+  properties: {
+    touched_files: { type: 'array', items: { type: 'string' } },
+    fix_summary: { type: 'string' },
+    resolved_ids: { type: 'array', items: { type: 'string' } },
+  },
+};
+
+// --- inline kernel helpers (thin mirrors of the pure scripts) ----------------
+
+// normative spec: .claude/skills/dispatch-propagate/scripts/dispatch-review-finders
+// Returns the AGENT finder-source set (the codeql/npm finders are NOT agents —
+// they arrive via args.prescanned_findings — so they are excluded here).
+function agentFinderSet(surface, app_or_rules) {
+  const set = ['code-review', 'review'];
+  if (surface === 'code') {
+    set.push('input-validation', 'secrets', 'red-team', 'security-review');
+    if (app_or_rules) {
+      set.push('auth', 'data-exposure', 'firebase');
+    }
+  }
+  return set;
+}
+
+// normative spec: .claude/skills/dispatch-propagate/scripts/dispatch-review-dedup
+// Collapse one partition subgroup of same-root findings into one representative.
+// Each finding must carry an `_idx` (its global input index) for tie-breaking.
+const CONF_RANK = { high: 3, medium: 2, low: 1 };
+function rankConf(c) {
+  return CONF_RANK[c] || 0;
+}
+function dedupMerge(groupFindings) {
+  // Order by (Confidence desc, _idx asc) — used for representative + first
+  // non-empty OWASP/STRIDE selection.
+  const ordered = groupFindings
+    .slice()
+    .sort((a, b) => rankConf(b.Confidence) - rankConf(a.Confidence) || a._idx - b._idx);
+  const rep = ordered[0];
+
+  // Max confidence across the group.
+  let maxRank = 0;
+  for (const f of groupFindings) maxRank = Math.max(maxRank, rankConf(f.Confidence));
+  const maxConf = maxRank === 3 ? 'high' : maxRank === 2 ? 'medium' : maxRank === 1 ? 'low' : '';
+
+  // First non-empty OWASP / STRIDE in (Confidence desc, _idx asc) order.
+  const firstNonEmpty = (key) => {
+    for (const f of ordered) {
+      if (f[key] !== null && f[key] !== undefined && f[key] !== '') return f[key];
+    }
+    return '';
+  };
+
+  // sources: sorted-unique union of each member's Source + any pre-existing sources.
+  const srcSet = new Set();
+  for (const f of groupFindings) {
+    srcSet.add(f.Source);
+    for (const s of f.sources || []) srcSet.add(s);
+  }
+  const sources = Array.from(srcSet).sort();
+
+  // Representative fields overridden by the four computed ones; id stays = rep.id.
+  return Object.assign({}, rep, {
+    Confidence: maxConf,
+    OWASP: firstNonEmpty('OWASP'),
+    STRIDE: firstNonEmpty('STRIDE'),
+    sources,
+  });
+}
+
+// normative spec: .claude/skills/dispatch-propagate/scripts/dispatch-review-verify-drop
+// For each Required finding, drop (Refuted) if ≥1 skeptic voted "refuted";
+// otherwise keep (Upheld). Non-Required findings are never affected. Annotates
+// each Required finding with `verify`. Returns {kept, dropped}.
+function applyVerifyDrop(findings, votesById) {
+  const kept = [];
+  const dropped = [];
+  for (const f of findings) {
+    if (f.bucket === 'Required') {
+      const votes = votesById[f.id] || [];
+      const refutedCount = votes.filter((v) => v === 'refuted').length;
+      if (refutedCount >= 1) {
+        dropped.push(Object.assign({}, f, { verify: 'Refuted' }));
+      } else {
+        kept.push(Object.assign({}, f, { verify: 'Upheld' }));
+      }
+    } else {
+      kept.push(f);
+    }
+  }
+  return { kept, dropped };
+}
+
+// --- finder prompts ----------------------------------------------------------
+
+const SCHEMA_BLURB = [
+  'Emit EVERY finding as an object with exactly these fields (the Per-finding schema):',
+  '- "Location": "path:line"',
+  '- "Description": what the issue is and why it is a risk',
+  '- "Source": the source name (set as instructed below)',
+  '- "OWASP": OWASP Top 10 (2021) category (e.g. "A03:2021 Injection"); "" for non-security',
+  '- "STRIDE": one STRIDE element (Spoofing|Tampering|Repudiation|Information Disclosure|Denial of Service|Elevation of Privilege); "" for non-security',
+  '- "Confidence": "high" | "medium" | "low"',
+  '- "Recommended fix": the concrete change that resolves the finding',
+  '- "Disposition": "skipped" (the orchestrator classifies it later)',
+  'Return { "findings": [ ...those objects... ] }. If you find nothing, return { "findings": [] }.',
+].join('\n');
+
+function diffContext(args) {
+  return [
+    `Review ONLY the pending diff against the merge base \`${args.merge_base}\` (the branch's`,
+    `changes vs origin/main). Changed files: ${args.changed_files.join(', ')}.`,
+    'Read full files for the context needed to judge each change, but report findings only',
+    'on the pending changes. You report findings ONLY — edit no files, commit nothing, push nothing.',
+  ].join(' ');
+}
+
+// Direct security-domain reviewer descriptions — mirror SKILL.md §1c.
+const DOMAIN_PROMPTS = {
+  'input-validation':
+    'Input validation: hunt injection in the changed code — SQL/NoSQL injection, XSS, command injection, path traversal. Check that external input is validated and escaped at every boundary it crosses.',
+  secrets:
+    'Secrets scan: hardcoded keys/tokens/credentials in the changed code, `.env` files committed to git, secrets leaking into build output.',
+  'red-team':
+    'Red team: construct concrete attack scenarios against the changed code. Pick an attacker goal, trace a path through the diff to reach it, and report each viable scenario as a finding. Build scenarios from the code under review, not a checklist of known vulnerabilities.',
+  auth:
+    'Auth & access control: Firestore rules coverage for paths the diff touches, missing auth checks, privilege escalation. Confirm each new or changed Firestore path has a matching rule block and that client code does not assume access the rules do not grant.',
+  'data-exposure':
+    'Data exposure: API responses returning more fields than the caller needs, PII in logs (console.log and similar), internal details (stack traces, config, paths) leaked in error messages.',
+  firebase:
+    'Firebase-specific: Firestore rules permissiveness (overly broad `allow` conditions, missing field constraints), emulator-only code reachable on production paths, Firebase API key or config exposure.',
+};
+
+function finderPrompt(name, args) {
+  const ctx = diffContext(args);
+  if (name === 'code-review') {
+    return [
+      'You are a findings-only code-review subagent.',
+      'Invoke the built-in `/code-review` skill via the Skill tool with the `max` effort argument,',
+      'FINDINGS-ONLY — do NOT pass the `--fix` flag; apply no fixes.',
+      ctx,
+      'Once /code-review returns, continue: normalize every finding it produced to the schema below',
+      'with Source "code-review" and OWASP "" and STRIDE "" (code-review findings are not security-classified).',
+      SCHEMA_BLURB,
+    ].join('\n');
+  }
+  if (name === 'review') {
+    return [
+      'You are a findings-only PR-review subagent.',
+      'Invoke the built-in `/review` skill via the Skill tool — the generic PR review.',
+      ctx,
+      'Once /review returns, continue: normalize every finding it produced to the schema below',
+      'with Source "review" and OWASP "" and STRIDE "".',
+      SCHEMA_BLURB,
+    ].join('\n');
+  }
+  if (name === 'security-review') {
+    return [
+      'You are a findings-only security-review subagent.',
+      'Invoke the built-in `/security-review` skill via the Skill tool.',
+      ctx,
+      'Once /security-review returns, continue: normalize every finding to the schema below with',
+      'Source "security-review". Map its severity to Confidence (high/medium/low → high/medium/low),',
+      'and infer the OWASP category and STRIDE element from each finding\'s category and description.',
+      SCHEMA_BLURB,
+    ].join('\n');
+  }
+  // input-validation | secrets | red-team | auth | data-exposure | firebase
+  return [
+    `You are a findings-only security reviewer. Domain: ${DOMAIN_PROMPTS[name]}`,
+    ctx,
+    `Set Source "${name}" on every finding. Fill OWASP and STRIDE for each finding.`,
+    SCHEMA_BLURB,
+  ].join('\n');
+}
+
+// =============================================================================
+// Pipeline
+// =============================================================================
+
+// --- 1. FINDERS (parallel, barrier) ------------------------------------------
+phase('finders');
+const finderNames = agentFinderSet(args.surface, args.app_or_rules);
+log(`finders: launching ${finderNames.length} agent finder(s) for surface=${args.surface}`);
+
+const finderResults = await parallel(
+  finderNames.map((name) => () =>
+    agent(finderPrompt(name, args), {
+      model: 'sonnet',
+      agentType: 'general-purpose',
+      schema: FINDINGS_SCHEMA,
+      label: `find:${name}`,
+      phase: 'finders',
+    })
+  )
+);
+
+// Gather: surviving finder findings + the prescanned codeql/npm findings.
+let allFindings = [];
+for (const res of finderResults.filter(Boolean)) {
+  for (const f of res.findings || []) allFindings.push(f);
+}
+for (const f of args.prescanned_findings || []) allFindings.push(f);
+
+// Assign a unique id and a global input index (_idx) to every finding.
+{
+  const counters = {};
+  allFindings = allFindings.map((f, i) => {
+    const src = f.Source || 'unknown';
+    const n = counters[src] || 0;
+    counters[src] = n + 1;
+    return Object.assign({}, f, { id: `${src}-${n}`, _idx: i });
+  });
+}
+log(`finders: gathered ${allFindings.length} raw finding(s)`);
+
+// --- 2. DEDUP (barrier) ------------------------------------------------------
+phase('dedup');
+
+// Mechanical: group by trimmed Location. Distinct locations never merge.
+const locationGroups = new Map();
+for (const f of allFindings) {
+  const loc = (f.Location || '').trim();
+  if (!locationGroups.has(loc)) locationGroups.set(loc, []);
+  locationGroups.get(loc).push(f);
+}
+
+const dedupedById = new Map(); // representative id → merged finding
+for (const [loc, group] of locationGroups) {
+  let partition;
+  if (group.length <= 1) {
+    // Single-finding location group → trivial partition, no model call.
+    partition = group.map((f) => [f.id]);
+  } else {
+    // Bounded semantic: one Sonnet partition over THIS group's ids by same-root.
+    const ids = group.map((f) => f.id);
+    const compact = group.map((f) => ({
+      id: f.id,
+      Source: f.Source,
+      Description: f.Description,
+      Confidence: f.Confidence,
+      OWASP: f.OWASP,
+      STRIDE: f.STRIDE,
+    }));
+    const prompt = [
+      `Several findings name the same location (${loc}). Partition them by SAME ROOT ISSUE:`,
+      'findings describing the same underlying problem at this location go in one subgroup;',
+      'genuinely distinct problems at the same location go in separate subgroups.',
+      'Return { "groups": [ [id, ...], ... ] } — a partition of exactly these ids, each id in',
+      `exactly one subgroup. The ids are: ${ids.join(', ')}.`,
+      `Findings:\n${JSON.stringify(compact, null, 2)}`,
+    ].join('\n');
+    const res = await agent(prompt, {
+      model: 'sonnet',
+      agentType: 'general-purpose',
+      schema: PARTITION_SCHEMA,
+      label: `dedup:${loc}`,
+      phase: 'dedup',
+    });
+    // Fall back to all-separate if the agent died or returned nothing usable.
+    partition = res && res.groups && res.groups.length ? res.groups : ids.map((id) => [id]);
+  }
+
+  // Apply the partition: collapse each subgroup via dedupMerge.
+  const byId = new Map(group.map((f) => [f.id, f]));
+  const covered = new Set();
+  for (const sub of partition) {
+    const members = sub.map((id) => byId.get(id)).filter(Boolean);
+    if (!members.length) continue;
+    for (const id of sub) covered.add(id);
+    const merged = dedupMerge(members);
+    dedupedById.set(merged.id, merged);
+  }
+  // Any id the partition omitted → emit as its own singleton (spec: uncovered = singleton).
+  for (const f of group) {
+    if (!covered.has(f.id)) {
+      const merged = dedupMerge([f]);
+      dedupedById.set(merged.id, merged);
+    }
+  }
+}
+
+// Preserve first-appearance order by min _idx.
+let deduped = Array.from(dedupedById.values()).sort((a, b) => a._idx - b._idx);
+log(`dedup: ${allFindings.length} → ${deduped.length} finding(s)`);
+
+// --- 3. CLASSIFY (barrier) ---------------------------------------------------
+phase('classify');
+if (deduped.length) {
+  const compact = deduped.map((f) => ({
+    id: f.id,
+    Location: f.Location,
+    Source: f.Source,
+    Description: f.Description,
+    Confidence: f.Confidence,
+    OWASP: f.OWASP,
+    STRIDE: f.STRIDE,
+  }));
+  const classifyPrompt = [
+    'Classify each finding into exactly one disposition bucket, preserving BOTH vocabularies.',
+    'Disposition table (from /review-fix SKILL.md Step 3):',
+    '- Fixed (code-review/review): a concrete, in-scope code change applicable to this PR — implement it.',
+    '- Required (security): a real vulnerability/weakness in the changed code that should be fixed.',
+    '- Informational (code-review/review): FYIs/notes/observations; no change required.',
+    '- Dismissed (code-review/review): nits, incorrect findings, or N/A; one-line rationale.',
+    '- False-positive (security): not an actual vulnerability — a misread / non-issue.',
+    '- Deferred (code-review/review): valid but out of scope for this PR (filed as a follow-up).',
+    '- Out-of-scope (security): a genuine concern in pre-existing code the diff did not touch.',
+    'RULES: A finding is NEVER Dismissed merely because the change is small — if it is a real',
+    'improvement within scope, classify it Fixed. When a code-review/review finding is ambiguous,',
+    'default to Informational rather than inventing a code change.',
+    'Also set security_class: "required" | "out-of-scope" | "false-positive" for security-sourced',
+    'findings, else "none" for code-review/review findings.',
+    'Return { "classifications": [ { "id", "bucket", "security_class" }, ... ] } — one per finding id.',
+    `Findings:\n${JSON.stringify(compact, null, 2)}`,
+  ].join('\n');
+
+  const classifyRes = await agent(classifyPrompt, {
+    model: 'sonnet',
+    agentType: 'general-purpose',
+    schema: CLASSIFY_SCHEMA,
+    label: 'classify',
+    phase: 'classify',
+  });
+
+  const classById = new Map();
+  if (classifyRes && classifyRes.classifications) {
+    for (const c of classifyRes.classifications) classById.set(c.id, c);
+  }
+  const SEC_SOURCES = new Set([
+    'input-validation',
+    'secrets',
+    'red-team',
+    'security-review',
+    'auth',
+    'data-exposure',
+    'firebase',
+    'codeql',
+    'npm',
+  ]);
+  deduped = deduped.map((f) => {
+    const c = classById.get(f.id);
+    const bucket = c ? c.bucket : SEC_SOURCES.has(f.Source) ? 'Out-of-scope' : 'Informational';
+    // For prescanned codeql/npm findings, prefer their own carried classification if present.
+    let security_class = c ? c.security_class : 'none';
+    if ((f.Source === 'codeql' || f.Source === 'npm') && f.classification) {
+      security_class = f.classification;
+    }
+    return Object.assign({}, f, { bucket, security_class });
+  });
+}
+
+// --- 4. VERIFY (parallel) ----------------------------------------------------
+phase('verify');
+const requiredFindings = deduped.filter((f) => f.bucket === 'Required');
+const votesById = {};
+const rationalesById = {};
+if (requiredFindings.length) {
+  log(`verify: ${requiredFindings.length} Required finding(s), 2 skeptics each`);
+  // Flat thunk list across (finding × skeptic) so the barrier covers all votes.
+  const verifyJobs = [];
+  for (const f of requiredFindings) {
+    for (let k = 0; k < 2; k++) {
+      verifyJobs.push({ id: f.id, k, finding: f });
+    }
+  }
+  const verifyResults = await parallel(
+    verifyJobs.map((job) => () => {
+      const f = job.finding;
+      const prompt = [
+        'You are an adversarial skeptic. Build the STRONGEST possible case that the finding below',
+        'is a FALSE POSITIVE / not-exploitable. Default to verdict="refuted" under uncertainty —',
+        'this gate guards spending an expensive Opus fix and a false "required" deviation that marks',
+        'the PR ready without review.',
+        `Finding location: ${f.Location}`,
+        `Description: ${f.Description}`,
+        `OWASP: ${f.OWASP}  STRIDE: ${f.STRIDE}  Confidence: ${f.Confidence}`,
+        `Recommended fix: ${f['Recommended fix']}`,
+        'Return { "verdict": "refuted" | "upheld", "rationale": "..." }.',
+      ].join('\n');
+      return agent(prompt, {
+        model: 'sonnet',
+        agentType: 'general-purpose',
+        schema: VERDICT_SCHEMA,
+        label: `verify:${job.id}#${job.k}`,
+        phase: 'verify',
+      });
+    })
+  );
+  // Collect votes per id. A dead skeptic (null) → no vote contributed (so a
+  // finding whose both skeptics died gets [] → Upheld, the conservative-to-keep
+  // default for a Required finding when verification could not run).
+  verifyResults.forEach((res, i) => {
+    const job = verifyJobs[i];
+    if (!votesById[job.id]) votesById[job.id] = [];
+    if (!rationalesById[job.id]) rationalesById[job.id] = [];
+    if (res && res.verdict) {
+      votesById[job.id].push(res.verdict);
+      if (res.rationale) rationalesById[job.id].push(res.rationale);
+    }
+  });
+}
+
+const { kept: keptFindings, dropped: refutedFindings } = applyVerifyDrop(deduped, votesById);
+
+// verify_report — one entry per Required finding (upheld or refuted).
+const verify_report = requiredFindings.map((f) => {
+  const votes = votesById[f.id] || [];
+  const refuted = votes.includes('refuted');
+  return {
+    id: f.id,
+    location: f.Location,
+    verdict: refuted ? 'refuted' : 'upheld',
+    skeptic_votes: votes,
+    rationale: (rationalesById[f.id] || []).join(' | '),
+  };
+});
+
+// Map refuted Required findings to a "Refuted" disposition bucket for the audit trail.
+const refutedIds = new Set(refutedFindings.map((f) => f.id));
+
+// --- 5. FIX (parallel over file-groups) --------------------------------------
+phase('fix');
+// fixSet = Fixed-bucket findings + Upheld Required findings (refuted ones excluded).
+const fixSet = keptFindings.filter(
+  (f) => f.bucket === 'Fixed' || (f.bucket === 'Required' && f.verify === 'Upheld')
+);
+
+// Group by file path (Location before the last ':').
+function filePath(location) {
+  const loc = location || '';
+  const idx = loc.lastIndexOf(':');
+  return idx >= 0 ? loc.slice(0, idx) : loc;
+}
+const fileGroups = new Map();
+for (const f of fixSet) {
+  const file = filePath(f.Location);
+  if (!fileGroups.has(file)) fileGroups.set(file, []);
+  fileGroups.get(file).push(f);
+}
+
+const fixed = [];
+if (fileGroups.size) {
+  log(`fix: ${fixSet.length} finding(s) across ${fileGroups.size} file-group(s) on Opus`);
+  const fixFileList = Array.from(fileGroups.entries()); // [ [file, findings], ... ]
+  const fixResults = await parallel(
+    fixFileList.map(([file, group]) => () => {
+      const findingList = group
+        .map(
+          (f) =>
+            `- [${f.id}] ${f.Location} (${f.bucket}): ${f.Description}\n  Recommended fix: ${f['Recommended fix']}`
+        )
+        .join('\n');
+      const prompt = [
+        `Apply the recommended fix for each of these findings in file ${file}.`,
+        'Edit the working tree ONLY — make NO commits and NO pushes (a later step commits).',
+        'Findings to resolve:',
+        findingList,
+        'Return { "touched_files": [...], "fix_summary": "one-line summary of what you changed",',
+        '"resolved_ids": [ ...the ids you actually applied a fix for... ] }.',
+        'Only list an id in resolved_ids if you applied its fix; omit ids you could not or chose not to fix.',
+      ].join('\n');
+      // DEFAULT (non-isolated) isolation — edits land in the caller's worktree so
+      // the skill's single /commit-merge-push picks them up. Opus per #1172.
+      return agent(prompt, {
+        model: 'opus',
+        agentType: 'general-purpose',
+        schema: FIX_SCHEMA,
+        label: `fix:${file}`,
+        phase: 'fix',
+      });
+    })
+  );
+
+  // Record one `fixed` entry per resolved finding.
+  const findingById = new Map(fixSet.map((f) => [f.id, f]));
+  fixResults.forEach((res, gi) => {
+    if (!res) return;
+    for (const id of res.resolved_ids || []) {
+      const f = findingById.get(id);
+      if (!f) continue;
+      fixed.push({
+        id,
+        location: f.Location,
+        fix_summary: res.fix_summary || '',
+        touched_files: res.touched_files || [],
+      });
+    }
+  });
+}
+const fixedIds = new Set(fixed.map((e) => e.id));
+
+// --- 6. FILE-PREP (pure JS, no gh) -------------------------------------------
+phase('file');
+
+// 6a. Deferred code-review/review findings → deferred_filings.
+function shortTitle(desc) {
+  const text = (desc || '').trim();
+  const firstSentence = text.split(/(?<=[.!?])\s/)[0] || text;
+  const candidate = firstSentence.length <= 80 ? firstSentence : text.slice(0, 80);
+  return candidate.trim().replace(/\s+/g, ' ');
+}
+const blockerNums =
+  args.implementing_issues && args.implementing_issues.length
+    ? args.implementing_issues
+    : 'independent';
+
+const deferred_filings = deduped
+  .filter((f) => f.bucket === 'Deferred')
+  .map((f) => {
+    const files = filePath(f.Location);
+    const body = [
+      f.Description,
+      '',
+      `Recommended fix: ${f['Recommended fix']}`,
+      '',
+      `Files: ${files}`,
+      '',
+      `Backlink: #${args.pr_num}`,
+      '',
+      'Out of scope for this PR: surfaced by the review pass but not a change this PR delivers.',
+    ].join('\n');
+    return {
+      title: shortTitle(f.Description),
+      body,
+      blocker_issue_nums: blockerNums,
+    };
+  });
+
+// 6b. Out-of-scope codeql/npm findings → security_followup_input (pass fields through).
+const security_followup_input = deduped
+  .filter(
+    (f) => (f.Source === 'codeql' || f.Source === 'npm') && f.security_class === 'out-of-scope'
+  )
+  .map((f) => {
+    if (f.Source === 'codeql') {
+      return {
+        classification: f.security_class,
+        source: 'codeql',
+        rule_id: f.rule_id,
+        alert_number: f.alert_number,
+        security_severity_level: f.security_severity_level,
+        description: f.description !== undefined ? f.description : f.Description,
+        location: f.location !== undefined ? f.location : f.Location,
+        html_url: f.html_url,
+      };
+    }
+    // npm
+    return {
+      classification: f.security_class,
+      source: 'npm',
+      advisory_id: f.advisory_id,
+      severity: f.severity,
+      introduced_by_diff: f.introduced_by_diff,
+      package: f.package,
+      title: f.title,
+      url: f.url,
+    };
+  });
+
+// --- 7. deviation + dispositions + return ------------------------------------
+
+// deviation: any Required + Upheld + high-confidence finding still unresolved after fixes.
+const deviation = keptFindings.some(
+  (f) =>
+    f.bucket === 'Required' &&
+    f.verify === 'Upheld' &&
+    f.Confidence === 'high' &&
+    !fixedIds.has(f.id)
+);
+
+function truncate(text, n) {
+  const t = (text || '').trim().replace(/\s+/g, ' ');
+  return t.length <= n ? t : t.slice(0, n);
+}
+
+// dispositions: one entry for EVERY deduped finding (incl. Refuted).
+const dispositions = deduped.map((f) => {
+  const isRefuted = refutedIds.has(f.id);
+  const bucket = isRefuted ? 'Refuted' : f.bucket;
+  const entry = {
+    id: f.id,
+    short_desc: truncate(f.Description, 140),
+    location: f.Location,
+    bucket,
+    sources: f.sources && f.sources.length ? f.sources : [f.Source],
+  };
+  if (f.bucket === 'Fixed' || f.bucket === 'Required') {
+    entry.recommended_fix = f['Recommended fix'];
+  }
+  if (f.Source === 'codeql') {
+    entry.codeql_ref = {
+      rule_id: f.rule_id,
+      alert_number: f.alert_number,
+      html_url: f.html_url,
+    };
+  }
+  return entry;
+});
+
+return {
+  dispositions,
+  fixed,
+  deferred_filings,
+  security_followup_input,
+  verify_report,
+  deviation,
+  security_note: args.security_note,
+};

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -235,9 +235,16 @@ function dedupMerge(groupFindings) {
 }
 
 // normative spec: .claude/skills/dispatch-propagate/scripts/dispatch-review-verify-drop
-// For each Required finding, drop (Refuted) if ≥1 skeptic voted "refuted";
-// otherwise keep (Upheld). Non-Required findings are never affected. Annotates
-// each Required finding with `verify`. Returns {kept, dropped}.
+// For each Required finding:
+//   - no skeptic vote at all (both verify agents failed) → drop (Unverified):
+//     verification could not run, so for a terminal auto-ready phase we do NOT
+//     auto-spend an Opus fix on it — it is dropped from the fix set and filed as
+//     a follow-up, consistent with the skeptic prompt's "default to refuted under
+//     uncertainty" bias (a crashed skeptic is the most uncertain case of all).
+//   - ≥1 skeptic voted "refuted" → drop (Refuted).
+//   - otherwise → keep (Upheld).
+// Non-Required findings are never affected. Annotates each Required finding with
+// `verify`. Returns {kept, dropped}.
 function applyVerifyDrop(findings, votesById) {
   const kept = [];
   const dropped = [];
@@ -245,7 +252,9 @@ function applyVerifyDrop(findings, votesById) {
     if (f.bucket === 'Required') {
       const votes = votesById[f.id] || [];
       const refutedCount = votes.filter((v) => v === 'refuted').length;
-      if (refutedCount >= 1) {
+      if (!votes.length) {
+        dropped.push(Object.assign({}, f, { verify: 'Unverified' }));
+      } else if (refutedCount >= 1) {
         dropped.push(Object.assign({}, f, { verify: 'Refuted' }));
       } else {
         kept.push(Object.assign({}, f, { verify: 'Upheld' }));
@@ -273,9 +282,11 @@ const SCHEMA_BLURB = [
 ].join('\n');
 
 function diffContext(args) {
+  const base = args.merge_base || 'origin/main';
+  const filesStr = (args.changed_files || []).join(', ') || '(see git diff HEAD)';
   return [
-    `Review ONLY the pending diff against the merge base \`${args.merge_base}\` (the branch's`,
-    `changes vs origin/main). Changed files: ${args.changed_files.join(', ')}.`,
+    `Review ONLY the pending diff against the merge base \`${base}\` (the branch's`,
+    `changes vs origin/main). Changed files: ${filesStr}.`,
     'Read full files for the context needed to judge each change, but report findings only',
     'on the pending changes. You report findings ONLY — edit no files, commit nothing, push nothing.',
   ].join(' ');
@@ -344,14 +355,21 @@ function finderPrompt(name, args) {
 // Pipeline
 // =============================================================================
 
+// Normalize args — the Workflow runtime may deliver it as a JSON string rather
+// than a parsed object (property accesses on a string silently return undefined,
+// causing downstream .join/.map calls to throw). Parse once at the top so all
+// downstream code sees a plain JS object.
+const _a = typeof args === 'string' ? JSON.parse(args) : (args || {});
+log(`args type: ${typeof args}; surface=${_a.surface}; changed_files count=${(_a.changed_files || []).length}`);
+
 // --- 1. FINDERS (parallel, barrier) ------------------------------------------
 phase('finders');
-const finderNames = agentFinderSet(args.surface, args.app_or_rules);
-log(`finders: launching ${finderNames.length} agent finder(s) for surface=${args.surface}`);
+const finderNames = agentFinderSet(_a.surface, _a.app_or_rules);
+log(`finders: launching ${finderNames.length} agent finder(s) for surface=${_a.surface}`);
 
 const finderResults = await parallel(
   finderNames.map((name) => () =>
-    agent(finderPrompt(name, args), {
+    agent(finderPrompt(name, _a), {
       model: 'sonnet',
       agentType: 'general-purpose',
       schema: FINDINGS_SCHEMA,
@@ -366,7 +384,7 @@ let allFindings = [];
 for (const res of finderResults.filter(Boolean)) {
   for (const f of res.findings || []) allFindings.push(f);
 }
-for (const f of args.prescanned_findings || []) allFindings.push(f);
+for (const f of _a.prescanned_findings || []) allFindings.push(f);
 
 // Assign a unique id and a global input index (_idx) to every finding.
 {
@@ -391,7 +409,8 @@ for (const f of allFindings) {
   locationGroups.get(loc).push(f);
 }
 
-const dedupedById = new Map(); // representative id → merged finding
+const dedupedById = new Map(); // unique merge key → merged finding
+let dedupCounter = 0; // monotonic key so distinct merges never collide on a shared representative id
 for (const [loc, group] of locationGroups) {
   let partition;
   if (group.length <= 1) {
@@ -428,20 +447,33 @@ for (const [loc, group] of locationGroups) {
   }
 
   // Apply the partition: collapse each subgroup via dedupMerge.
+  // The schema cannot enforce "each id in exactly one subgroup"; a valid-but-
+  // malformed partition that re-uses an id across subgroups would otherwise
+  // silently drop findings (a re-used representative id overwrites its prior
+  // merge under the same map key, and the displaced finding is marked covered
+  // so it never falls through to the singleton fallback). Guard it: skip any
+  // subgroup containing an already-covered id so the FIRST merge wins, and key
+  // the collapsed result by a unique counter rather than merged.id so two
+  // distinct merges that happen to share a representative id both survive.
   const byId = new Map(group.map((f) => [f.id, f]));
   const covered = new Set();
   for (const sub of partition) {
+    const reused = sub.find((id) => covered.has(id));
+    if (reused !== undefined) {
+      log(`dedup: partition for ${loc} re-used id ${reused} across subgroups — skipping the later subgroup (first merge wins)`);
+      continue;
+    }
     const members = sub.map((id) => byId.get(id)).filter(Boolean);
     if (!members.length) continue;
     for (const id of sub) covered.add(id);
     const merged = dedupMerge(members);
-    dedupedById.set(merged.id, merged);
+    dedupedById.set(`merge:${dedupCounter++}`, merged);
   }
   // Any id the partition omitted → emit as its own singleton (spec: uncovered = singleton).
   for (const f of group) {
     if (!covered.has(f.id)) {
       const merged = dedupMerge([f]);
-      dedupedById.set(merged.id, merged);
+      dedupedById.set(`merge:${dedupCounter++}`, merged);
     }
   }
 }
@@ -493,6 +525,11 @@ if (deduped.length) {
   if (classifyRes && classifyRes.classifications) {
     for (const c of classifyRes.classifications) classById.set(c.id, c);
   }
+  if (!classById.size) {
+    log(
+      `classify: agent returned no usable classifications for ${deduped.length} finding(s) — falling back per-source (code-review/review → Deferred so they are filed, security → Out-of-scope)`
+    );
+  }
   const SEC_SOURCES = new Set([
     'input-validation',
     'secrets',
@@ -506,7 +543,11 @@ if (deduped.length) {
   ]);
   deduped = deduped.map((f) => {
     const c = classById.get(f.id);
-    const bucket = c ? c.bucket : SEC_SOURCES.has(f.Source) ? 'Out-of-scope' : 'Informational';
+    // Fallback when the classify agent gave no verdict for this finding: security
+    // sources → Out-of-scope; code-review/review → Deferred (NOT Informational) so
+    // an unclassified-but-real finding is filed as a follow-up rather than silently
+    // dropped from both the fix set and the follow-up filings.
+    const bucket = c ? c.bucket : SEC_SOURCES.has(f.Source) ? 'Out-of-scope' : 'Deferred';
     // For prescanned codeql/npm findings, prefer their own carried classification if present.
     let security_class = c ? c.security_class : 'none';
     if ((f.Source === 'codeql' || f.Source === 'npm') && f.classification) {
@@ -553,9 +594,11 @@ if (requiredFindings.length) {
       });
     })
   );
-  // Collect votes per id. A dead skeptic (null) → no vote contributed (so a
-  // finding whose both skeptics died gets [] → Upheld, the conservative-to-keep
-  // default for a Required finding when verification could not run).
+  // Collect votes per id. A dead skeptic (null) contributes no vote, so a
+  // finding whose both skeptics died gets [] → handled by applyVerifyDrop as
+  // "Unverified": dropped (not auto-fixed) and surfaced as verdict "unverified"
+  // in verify_report, matching the skeptic prompt's "refute under uncertainty"
+  // bias. (A finding is only Upheld when at least one skeptic ran and voted.)
   verifyResults.forEach((res, i) => {
     const job = verifyJobs[i];
     if (!votesById[job.id]) votesById[job.id] = [];
@@ -569,21 +612,37 @@ if (requiredFindings.length) {
 
 const { kept: keptFindings, dropped: refutedFindings } = applyVerifyDrop(deduped, votesById);
 
-// verify_report — one entry per Required finding (upheld or refuted).
+// verify_report — one entry per Required finding (upheld / refuted / unverified).
+// "unverified" = both skeptics failed to vote: distinct from a clean upheld pass
+// so the PR comment shows the verification could not run rather than masking it
+// as verdict "upheld" with empty evidence.
 const verify_report = requiredFindings.map((f) => {
   const votes = votesById[f.id] || [];
-  const refuted = votes.includes('refuted');
+  let verdict;
+  if (!votes.length) {
+    verdict = 'unverified';
+  } else if (votes.includes('refuted')) {
+    verdict = 'refuted';
+  } else {
+    verdict = 'upheld';
+  }
   return {
     id: f.id,
     location: f.Location,
-    verdict: refuted ? 'refuted' : 'upheld',
+    verdict,
     skeptic_votes: votes,
     rationale: (rationalesById[f.id] || []).join(' | '),
   };
 });
 
-// Map refuted Required findings to a "Refuted" disposition bucket for the audit trail.
-const refutedIds = new Set(refutedFindings.map((f) => f.id));
+// Map dropped (refuted OR unverified) Required findings to a non-fixed disposition
+// bucket for the audit trail: refuted → "Refuted", unverified → "Unverified".
+const refutedIds = new Set(
+  refutedFindings.filter((f) => f.verify === 'Refuted').map((f) => f.id)
+);
+const unverifiedIds = new Set(
+  refutedFindings.filter((f) => f.verify === 'Unverified').map((f) => f.id)
+);
 
 // --- 5. FIX (parallel over file-groups) --------------------------------------
 phase('fix');
@@ -667,14 +726,21 @@ function shortTitle(desc) {
   return candidate.trim().replace(/\s+/g, ' ');
 }
 const blockerNums =
-  args.implementing_issues && args.implementing_issues.length
-    ? args.implementing_issues
+  _a.implementing_issues && _a.implementing_issues.length
+    ? _a.implementing_issues
     : 'independent';
 
 const deferred_filings = deduped
-  .filter((f) => f.bucket === 'Deferred')
+  // Deferred code-review/review findings, plus Unverified Required findings
+  // (both skeptics failed): not auto-fixed in this terminal phase, so file a
+  // follow-up rather than silently dropping them.
+  .filter((f) => f.bucket === 'Deferred' || unverifiedIds.has(f.id))
   .map((f) => {
     const files = filePath(f.Location);
+    const isUnverified = unverifiedIds.has(f.id);
+    const tail = isUnverified
+      ? 'Required finding whose adversarial-verify skeptics both failed to vote: deferred to a follow-up rather than auto-applied in the terminal review phase.'
+      : 'Out of scope for this PR: surfaced by the review pass but not a change this PR delivers.';
     const body = [
       f.Description,
       '',
@@ -682,9 +748,9 @@ const deferred_filings = deduped
       '',
       `Files: ${files}`,
       '',
-      `Backlink: #${args.pr_num}`,
+      `Backlink: #${_a.pr_num}`,
       '',
-      'Out of scope for this PR: surfaced by the review pass but not a change this PR delivers.',
+      tail,
     ].join('\n');
     return {
       title: shortTitle(f.Description),
@@ -740,10 +806,13 @@ function truncate(text, n) {
   return t.length <= n ? t : t.slice(0, n);
 }
 
-// dispositions: one entry for EVERY deduped finding (incl. Refuted).
+// dispositions: one entry for EVERY deduped finding (incl. Refuted/Unverified).
 const dispositions = deduped.map((f) => {
-  const isRefuted = refutedIds.has(f.id);
-  const bucket = isRefuted ? 'Refuted' : f.bucket;
+  const bucket = refutedIds.has(f.id)
+    ? 'Refuted'
+    : unverifiedIds.has(f.id)
+      ? 'Unverified'
+      : f.bucket;
   const entry = {
     id: f.id,
     short_desc: truncate(f.Description, 140),
@@ -771,5 +840,5 @@ return {
   security_followup_input,
   verify_report,
   deviation,
-  security_note: args.security_note,
+  security_note: _a.security_note,
 };


### PR DESCRIPTION
Closes #890

## What

Ports the dispatch chain's terminal `/review-fix` review fan-out from prose
subagent orchestration to a deterministic **Workflow-tool pipeline**. The skill
now invokes `.claude/workflows/review-fix.js`, which fans out the
surface-conditional finders, de-duplicates and classifies findings **in code**,
**adversarially verifies** every `Required` finding before any Opus fix runs, and
runs an Opus fix fan-out — returning one compact disposition summary. The skill
retains everything the sandboxed Workflow cannot do (bash/`gh`/`git`/`tmp`): the
idempotency preamble, diff + `MERGE_BASE` capture, `dispatch-security-surface`,
the inline CodeQL + `npm audit` scans, the single `/commit-merge-push`, follow-up
filing, the one PR comment, the `dispatch:reviewed` label, the ready-flip, and the
phase marker.

This is greenfield-only — no migration path: the skill's external contract
(labels, markers, PR-comment bucket structure) is unchanged; there is no caller of
a prior workflow artifact.

## How it maps to the acceptance criteria (#890)

- **Workflow-tool fan-out, surface-conditional (not fixed-count):** the finder set
  is built from the `surface`/`deps`/`app_or_rules` flags
  (`agentFinderSet` mirrors `dispatch-review-finders`). A docs/empty diff launches
  zero security finders.
- **`/code-review` reconciled with #1172:** run **findings-only** (no `--fix`), like
  `/review`. All fix-authoring is concentrated in the Workflow's **Opus**,
  **non-isolated** fix agents, whose working-tree edits survive for the skill's
  single `/commit-merge-push`. Fix-authoring is pinned to Opus **exactly once** (in
  the Workflow's `model:` settings) — no double-tiering.
- **Schema-bounded findings; dedup is code:** each finder returns
  `{findings:[...]}` against the Per-finding schema. Dedup is mechanical
  `path:line` grouping + a bounded per-group Sonnet partition, collapsed by
  deterministic merge arithmetic (`dedupMerge` mirrors `dispatch-review-dedup`).
- **Adversarial-verify before fixes:** N=2 Sonnet skeptics per `Required` finding,
  drop on ≥1 refuted (`applyVerifyDrop` mirrors `dispatch-review-verify-drop`).
  Refuted findings are **not** fixed and are recorded under a **Refuted** section
  in the PR comment with the skeptic rationale.
- **Deferred / out-of-scope filings:** the Workflow prepares `deferred_filings` and
  `security_followup_input`; the skill executes the `/file-issue` +
  `dispatch-security-followup` + `dispatch-followup-exists` filings, preserving the
  `blocked_by` wiring and the `EXISTING <N>` dedup.
- **Empty / clean diff:** handled — finders that find nothing produce no fixes, the
  PR is still readied and `dispatch:reviewed` applied; `security_note` stands in for
  the security buckets on docs/empty.
- **Idempotency preamble unchanged:** re-entry with `dispatch:reviewed` skips to the
  terminal flush + ready + marker; the Workflow does not re-run, so the deviation
  criterion is treated as not met (R3).
- **PR-comment audit trail:** lists every finding and disposition, including
  CodeQL-sourced findings identified by `rule.id` and alert number (via
  `codeql_ref`).
- **Tests (criterion 9):** `test-dispatch-scripts.sh` gains direct-invocation
  coverage of the three kernels — fan-out count, dedup, and verify-drop — 23 new
  assertions; suite at **2055/2055**.

## Design

The deterministic kernels live as three pure stdin/stdout scripts
(`dispatch-review-finders`, `dispatch-review-dedup`, `dispatch-review-verify-drop`)
so they can be unit-tested in the pure-bash harness; the Workflow JS mirrors their
arithmetic inline (the sandbox cannot shell out), with each helper comment-linked
to its script as the normative spec. The Workflow holds raw findings in JS memory
and returns only a compact summary, which subsumes the #1069 "serialize to `tmp/`,
aggregate in a subagent" context-budget discipline.

## Verification

- Confirmed at runtime in a worker session that the **Workflow tool is invocable**
  and that a Workflow `agent()` can reach the **Skill tool** (a live probe returned
  `skill_tool_available: true`) — closing the worker-runtime loop the original
  blocker raised, so the primary design (finders invoke `/code-review` / `/review` /
  `/security-review` inside Workflow agents) holds with no fallback.
- `node --check` (harness-equivalent ES-module parse) on `review-fix.js`: clean. No
  `Date.now`/`Math.random`/`node:*`/`fs`/`gh`/`git`; `meta` is a pure literal; fix
  agents omit `isolation` (default = caller's worktree).
- `test-dispatch-scripts.sh`: 2055/2055.

## Note on commit sequencing

The `SKILL.md` rewrite landed in commit `bd654a83` (authored during the
workflow-script build step) rather than as separate per-unit commits; the
`dispatch-worker` cross-reference refresh followed in `85d2d775`. The final state
matches the approved plan's intended outcome — the rewrite was reviewed against the
plan's retain/remove spec line-by-line (Workflow invocation, retained bash scans,
`result`-driven filing/comment/ready steps, the new Refuted bucket, R3 re-entry,
the #1172 model-split note pinned once, and removal of the prose fan-out and
`/code-review max --fix`).