### PR TITLE
budget: disarm prior file-sync session on every load path

### DIFF
--- a/budget/src/main.ts
+++ b/budget/src/main.ts
@@ -277,15 +277,17 @@ async function loadFromFile(file: File, cachedPassword?: string): Promise<LoadOu
   }
   const parsed = parseUploadedJson(text);
   const data = toParsedData(parsed);
-  // This is the single point of dataset divergence: the line below replaces the
-  // in-memory dataset, so the prior armed (handle, password) no longer matches
-  // what IndexedDB holds. Disarm sync *before* the swap, after every throwing
-  // decrypt/parse step and the password-cancel early return, so a failure leaves
-  // the prior session armed and still correct (IndexedDB is unchanged). This one
-  // placement covers every load path: upload, plaintext-FSA, encrypted-FSA, and
-  // external reload — callers re-arm afterward only when appropriate.
-  resetFileSync();
+  // storeParsedData is the single point of dataset divergence: it replaces the
+  // in-memory dataset, so afterward the prior armed (handle, password) no longer
+  // matches what IndexedDB holds. Disarm sync *after* the swap commits, so any
+  // throwing step that leaves IndexedDB unchanged — a decrypt/parse failure, the
+  // password-cancel early return, or a storeParsedData failure — leaves the prior
+  // session armed and still correct. The generation guard in file-sync protects
+  // any write started before resetFileSync runs. This one placement covers every
+  // load path: upload, plaintext-FSA, encrypted-FSA, and external reload —
+  // callers re-arm afterward only when appropriate.
   await storeParsedData(data);
+  resetFileSync();
   importPassword = pw;
   transition({ source: "local", groupName: parsed.groupName });
   return { committed: true, password: pw };

--- a/budget/src/main.ts
+++ b/budget/src/main.ts
@@ -247,12 +247,20 @@ function promptPassword(message: string): Promise<string | null> {
   });
 }
 
+// Outcome of a load attempt. `committed: true` means this call replaced the
+// in-memory dataset (and disarmed any prior file-sync session); `password` is
+// the password used for the load — `null` for plaintext, the actual string for
+// an encrypted file. `committed: false` means the load did not mutate state
+// (e.g. the user cancelled the password prompt), so any prior sync session is
+// intentionally left armed and still correct.
+type LoadOutcome = { committed: true; password: string | null } | { committed: false };
+
 // Core load pipeline shared by the upload path and the FSA handle path:
 // read bytes, decrypt-or-decode, parse, store, and transition to the local
 // state. Throws on any failure; callers wrap it in error handling.
 // Pass `cachedPassword` to skip the password dialog when the session password
 // is already known (e.g. on an external-change reload).
-async function loadFromFile(file: File, cachedPassword?: string): Promise<void> {
+async function loadFromFile(file: File, cachedPassword?: string): Promise<LoadOutcome> {
   const buffer = await file.arrayBuffer();
   let text: string;
   let pw: string | null = null;
@@ -261,7 +269,7 @@ async function loadFromFile(file: File, cachedPassword?: string): Promise<void> 
       pw = cachedPassword;
     } else {
       pw = await promptPassword("Enter password to decrypt");
-      if (pw === null) return;
+      if (pw === null) return { committed: false };
     }
     text = await decrypt(buffer, pw);
   } else {
@@ -269,9 +277,18 @@ async function loadFromFile(file: File, cachedPassword?: string): Promise<void> 
   }
   const parsed = parseUploadedJson(text);
   const data = toParsedData(parsed);
+  // This is the single point of dataset divergence: the line below replaces the
+  // in-memory dataset, so the prior armed (handle, password) no longer matches
+  // what IndexedDB holds. Disarm sync *before* the swap, after every throwing
+  // decrypt/parse step and the password-cancel early return, so a failure leaves
+  // the prior session armed and still correct (IndexedDB is unchanged). This one
+  // placement covers every load path: upload, plaintext-FSA, encrypted-FSA, and
+  // external reload — callers re-arm afterward only when appropriate.
+  resetFileSync();
   await storeParsedData(data);
   importPassword = pw;
   transition({ source: "local", groupName: parsed.groupName });
+  return { committed: true, password: pw };
 }
 
 async function handleFileUpload(file: File): Promise<void> {
@@ -308,13 +325,15 @@ async function loadFromHandle(handle: FileSystemFileHandle): Promise<void> {
   // a handle pointing at a non-budget file would be auto-loaded, fail validation,
   // and be retried on every subsequent startup — a permanent failing-load loop.
   try {
-    await loadFromFile(file);
-    // Arm encrypted write-back so subsequent UI edits overwrite this on-disk
-    // file in place. loadFromFile sets importPassword only on the success path
-    // (an encrypted file decrypted, or null for a plaintext file); a
-    // password-cancel returns early without transitioning to local, leaving
-    // importPassword null, so this no-ops there.
-    if (importPassword) configureFileSync(handle, importPassword, file.lastModified);
+    const outcome = await loadFromFile(file);
+    // Arm encrypted write-back only when THIS load committed an encrypted file,
+    // using the password the load actually used. A plaintext file (password
+    // null) and a password-cancel (not committed) leave sync disarmed —
+    // loadFromFile has already dropped the prior binding — so we do not re-point
+    // a lingering prior-session password at this new handle.
+    if (outcome.committed && outcome.password !== null) {
+      configureFileSync(handle, outcome.password, file.lastModified);
+    }
   } catch (error) {
     if (error instanceof UploadValidationError) {
       // The persisted handle points to a file that is not valid budget data
@@ -459,12 +478,15 @@ async function reloadIfExternallyChanged(): Promise<void> {
   reloadInFlight = (async () => {
     clearNavError();
     try {
-      await loadFromFile(file, cachedPw);
-      // Stamp the watermark. loadFromFile either set importPassword (success) or
-      // returned early (wrong cached pw). In the early-return case importPassword
-      // still holds its old value, so configureFileSync still advances the watermark
-      // past this file version, preventing a re-prompt loop.
-      if (importPassword) configureFileSync(handle, importPassword, file.lastModified);
+      const outcome = await loadFromFile(file, cachedPw);
+      // Re-arm and stamp the watermark for a genuine committed encrypted reload,
+      // using the password the reload used. A wrong cached password makes
+      // `decrypt` throw (caught below) rather than committing, so we never
+      // re-arm on a bad password — and loadFromFile has already disarmed the
+      // prior session before swapping in the reloaded dataset.
+      if (outcome.committed && outcome.password !== null) {
+        configureFileSync(handle, outcome.password, file.lastModified);
+      }
     } catch (error) {
       // Do NOT clear the file handle here: a content-validation error in an
       // external write should not permanently unlink the FSA handle. The handle

--- a/budget/test/main.test.ts
+++ b/budget/test/main.test.ts
@@ -736,4 +736,181 @@ describe("main module", () => {
     // the FSA handle — the handle is valid, only this file version is bad.
     expect(mockClearFileHandle).not.toHaveBeenCalled();
   });
+
+  // AC1 — any committed load disarms the prior file-sync session.
+  // A committed plaintext load (non-FSA upload) calls resetFileSync and does NOT
+  // call configureFileSync (no handle to re-arm with).
+  it("AC1: committed plaintext upload calls resetFileSync and leaves sync disarmed", async () => {
+    // Start with no persisted handle and no meta so the module initialises to seed state.
+    mockGetFileHandle.mockResolvedValue(undefined);
+    mockGetMeta.mockResolvedValue(undefined);
+
+    resetAndMockAll();
+
+    const { parseUploadedJson, toParsedData } = await import("../src/upload.js");
+    (parseUploadedJson as ReturnType<typeof vi.fn>).mockReturnValue({ groupName: "household" });
+    (toParsedData as ReturnType<typeof vi.fn>).mockReturnValue({ meta: { groupName: "household" } });
+    mockStoreParsedData.mockResolvedValue(undefined);
+
+    await import("../src/main");
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    // Simulate a plaintext non-FSA upload by dispatching a change event on the hidden
+    // file input. The input is wired to handleFileUpload which calls loadFromFile.
+    const uploadInput = document.querySelector(".upload-input") as HTMLInputElement;
+    expect(uploadInput).not.toBeNull();
+
+    const file = new File(['{"groupName":"household"}'], "budget.json");
+    // Inject the file into the input's file list via a DataTransfer.
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(file);
+    Object.defineProperty(uploadInput, "files", { value: dataTransfer.files, configurable: true });
+
+    uploadInput.dispatchEvent(new Event("change"));
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    // loadFromFile calls resetFileSync before storeParsedData — every committed load
+    // disarms whatever prior session was armed.
+    expect(mockResetFileSync).toHaveBeenCalled();
+    // Plaintext upload has no FSA handle, so configureFileSync must never be called.
+    expect(mockConfigureFileSync).not.toHaveBeenCalled();
+  });
+
+  // AC2 — cancelling the password prompt for a new encrypted file does NOT arm
+  // write-back with the prior session's password. The prior session must be left
+  // armed (IndexedDB is unchanged) and must NOT be re-pointed at the new handle.
+  it("AC2: cancelling the password prompt for encrypted file B does not arm B with the prior password", async () => {
+    const handleA = { name: "a.benc" } as unknown as FileSystemFileHandle;
+    // Start with handle A already persisted and permission granted — the startup
+    // path auto-loads it as an encrypted file with password "pw-A".
+    mockGetFileHandle.mockResolvedValue(handleA);
+    mockQueryReadWritePermission.mockResolvedValue("granted");
+    mockReadFileFromHandle.mockResolvedValue(new File(["enc-a"], "a.benc"));
+    mockIsEncrypted.mockReturnValue(true);
+    mockDecrypt.mockResolvedValue("{}");
+    mockIsFsaSupported.mockReturnValue(true);
+
+    resetAndMockAll();
+
+    const { parseUploadedJson, toParsedData } = await import("../src/upload.js");
+    (parseUploadedJson as ReturnType<typeof vi.fn>).mockReturnValue({ groupName: "household" });
+    (toParsedData as ReturnType<typeof vi.fn>).mockReturnValue({ meta: { groupName: "household" } });
+    mockStoreParsedData.mockResolvedValue(undefined);
+
+    await import("../src/main");
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    // Submit password "pw-A" to complete the initial encrypted load and arm handleA.
+    const inputA = document.querySelector(".password-input") as HTMLInputElement;
+    expect(inputA).not.toBeNull();
+    inputA.value = "pw-A";
+    (inputA.closest("form") as HTMLFormElement).requestSubmit();
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    // handleA should now be armed.
+    expect(mockConfigureFileSync).toHaveBeenCalledWith(handleA, "pw-A", expect.any(Number));
+    mockConfigureFileSync.mockClear();
+    mockResetFileSync.mockClear();
+
+    // Now pick handleB (also encrypted). Point mockReadFileFromHandle at the new file.
+    const handleB = { name: "b.benc" } as unknown as FileSystemFileHandle;
+    mockPickBencFile.mockResolvedValue(handleB);
+    mockReadFileFromHandle.mockResolvedValue(new File(["enc-b"], "b.benc"));
+
+    // Click the upload label to trigger the FSA picker → loadFromHandle(handleB).
+    const label = document.querySelector(".upload-label") as HTMLLabelElement;
+    label.click();
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    // The password dialog for file B should now be open. Cancel it.
+    const cancelBtn = document.querySelector(".password-cancel") as HTMLButtonElement;
+    expect(cancelBtn).not.toBeNull();
+    cancelBtn.click();
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    // A cancel must never arm write-back — configureFileSync must not be called at
+    // all after the cancel, and in particular must never be called with handleB.
+    expect(mockConfigureFileSync).not.toHaveBeenCalled();
+    // The cancel also must not re-point sync at handleA: resetFileSync was not
+    // triggered by the cancelled load (IndexedDB is unchanged, so the prior
+    // session remains correctly armed).
+    expect(mockResetFileSync).not.toHaveBeenCalled();
+  });
+
+  // AC3 — switching from encrypted file A to encrypted file B must not leave
+  // write-back armed to handleA after the switch. After the committed load of B:
+  //   • resetFileSync was called (prior session disarmed),
+  //   • the final configureFileSync call targets handleB (not handleA), and
+  //   • no configureFileSync call after the switch targets handleA.
+  it("AC3: switching from encrypted A to encrypted B disarms A and arms B only", async () => {
+    const handleA = { name: "a.benc" } as unknown as FileSystemFileHandle;
+    mockGetFileHandle.mockResolvedValue(handleA);
+    mockQueryReadWritePermission.mockResolvedValue("granted");
+    mockReadFileFromHandle.mockResolvedValue(new File(["enc-a"], "a.benc"));
+    mockIsEncrypted.mockReturnValue(true);
+    mockDecrypt.mockResolvedValue("{}");
+    mockIsFsaSupported.mockReturnValue(true);
+
+    resetAndMockAll();
+
+    const { parseUploadedJson, toParsedData } = await import("../src/upload.js");
+    (parseUploadedJson as ReturnType<typeof vi.fn>).mockReturnValue({ groupName: "household" });
+    (toParsedData as ReturnType<typeof vi.fn>).mockReturnValue({ meta: { groupName: "household" } });
+    mockStoreParsedData.mockResolvedValue(undefined);
+
+    await import("../src/main");
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    // Complete the initial encrypted load with password "pw-A".
+    const inputA = document.querySelector(".password-input") as HTMLInputElement;
+    expect(inputA).not.toBeNull();
+    inputA.value = "pw-A";
+    (inputA.closest("form") as HTMLFormElement).requestSubmit();
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    // Verify handleA is armed.
+    expect(mockConfigureFileSync).toHaveBeenCalledWith(handleA, "pw-A", expect.any(Number));
+    mockConfigureFileSync.mockClear();
+    mockResetFileSync.mockClear();
+
+    // Now switch to encrypted handleB via the FSA picker.
+    const handleB = { name: "b.benc" } as unknown as FileSystemFileHandle;
+    mockPickBencFile.mockResolvedValue(handleB);
+    mockReadFileFromHandle.mockResolvedValue(new File(["enc-b"], "b.benc"));
+    mockPutFileHandle.mockResolvedValue(undefined);
+
+    const label = document.querySelector(".upload-label") as HTMLLabelElement;
+    label.click();
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    // Submit password "pw-B" for the new file.
+    const inputB = document.querySelector(".password-input") as HTMLInputElement;
+    expect(inputB).not.toBeNull();
+    inputB.value = "pw-B";
+    (inputB.closest("form") as HTMLFormElement).requestSubmit();
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    // After the committed switch:
+    // 1. resetFileSync must have been called (prior session disarmed).
+    expect(mockResetFileSync).toHaveBeenCalled();
+    // 2. The final configureFileSync call must target handleB with password "pw-B".
+    expect(mockConfigureFileSync).toHaveBeenCalledWith(handleB, "pw-B", expect.any(Number));
+    // 3. No configureFileSync call after the switch may target handleA.
+    const postSwitchCalls = mockConfigureFileSync.mock.calls;
+    const armedHandleA = postSwitchCalls.some(([h]) => h === handleA);
+    expect(armedHandleA).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #1261

## Problem

`budget` links a budget snapshot to an on-disk `.benc` file via the File System
Access API and debounces encrypted write-backs. `file-sync.ts` holds the active
`(handle, password)` as module globals; a write-back exports the current
IndexedDB dataset, encrypts it with the held password, and overwrites the held
handle in place.

The invariant that must hold: the armed `(handle, password)` must always
correspond to the dataset currently in IndexedDB. But `resetFileSync()` (the
disarm) had exactly one call site — the Clear-data button — and arming was gated
on the stale module global `importPassword`, which cannot distinguish "this load
set the password" from "a prior session's password lingers." So switching the
linked file left sync armed to the *previous* file, and the next UI edit silently
destroyed it:

- **Stale-handle overwrite.** Loading file B (plaintext FSA, or any non-FSA
  upload that never re-armed) swapped IndexedDB to dataset B but left the globals
  at handle A + password A. The next edit wrote dataset B, encrypted with password
  A, to file A — destroying file A.
- **Cancel-arms-wrong-session.** Cancelling the password dialog for encrypted file
  B returned early without touching `importPassword`, so the `if (importPassword)`
  guard armed `configureFileSync(handleB, passwordA, …)`. The next edit overwrote
  file B with the still-displayed dataset A.

This is the load/arm path — distinct from #1179, which hardens the external
*reload* path.

## Fix

Two root-cause changes, both in `budget/src/main.ts`:

1. **Disarm at the single point of dataset divergence.** `loadFromFile` now calls
   `resetFileSync()` on the line immediately before `storeParsedData(data)` — after
   every throwing decrypt/parse step and after the password-cancel early return, so
   a wrong-password / validation failure / cancel leaves the prior session armed and
   still correct (IndexedDB is unchanged in those cases). This one placement covers
   every load path: upload, plaintext-FSA, encrypted-FSA, and external reload.
2. **Arm from an explicit load outcome, never the stale global.** `loadFromFile`
   now returns a discriminated `LoadOutcome` (`{ committed: true; password: string
   | null } | { committed: false }`) instead of signalling cancel via an
   indistinguishable `void` early-return. `loadFromHandle` and
   `reloadIfExternallyChanged` arm `configureFileSync` only when the outcome reports
   a committed encrypted load, using the password the outcome carries — not
   `importPassword`. `importPassword` keeps its existing meaning (the current
   session's encryption password, read by export and reload); it is simply no longer
   abused as the arm-decision proxy.

`file-sync.ts` is unchanged — its generation guard already bails an in-flight
write whose generation moved.

## Tests

Three regression cases added to `budget/test/main.test.ts`, asserting the
arm/disarm contract through the existing mocked `file-sync.js` spies:

- **AC1** — a committed plaintext upload calls `resetFileSync` and leaves sync
  disarmed (no `configureFileSync` re-arm).
- **AC2** — cancelling the password prompt for a new encrypted file does not arm
  write-back with the prior session's password.
- **AC3** — switching encrypted A → encrypted B disarms A, arms B only, and never
  re-arms handle A after the switch.

Full suite: 970 passed, 7 skipped, 0 failed. `npx tsc --noEmit --project budget`
clean.
