### PR TITLE
firestore.rules: bound preview-pr error-log env to 6-digit PR numbers

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -313,7 +313,7 @@ service cloud.firestore {
       return env == "prod"
         || env == "demo"
         || env == "test"
-        || env.matches("preview-pr-[0-9]+")
+        || env.matches("preview-pr-[0-9]{1,6}")
         || env.matches("qa(-[a-z0-9._-]+)?")    // suffix optional: bare "qa" is the main-worktree env
         || env.matches("emulator(-[a-z0-9._-]+)?");  // suffix optional: bare "emulator" is the main-worktree env
     }

--- a/rules-test/test/firestore/errors.test.ts
+++ b/rules-test/test/firestore/errors.test.ts
@@ -192,6 +192,22 @@ describe("error logs", () => {
       );
     });
 
+    it("allows preview-pr-123456 env (6 digits, at cap)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, "budget/preview-pr-123456/errors/err1"), validErrorDoc()),
+      );
+    });
+
+    it("denies preview-pr-1234567 env (7 digits, over cap)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, "budget/preview-pr-1234567/errors/err1"), validErrorDoc()),
+      );
+    });
+
     it("allows qa-<id> env", async () => {
       const ctx = unauthenticatedContext(env);
       const db = ctx.firestore();


### PR DESCRIPTION
Closes #1326

## Summary

The `preview-pr-[0-9]+` env pattern in `isKnownErrorEnv` (`firestore.rules`)
accepts arbitrarily large PR numbers. Because error-log creates are fully
unauthenticated (`allow create: if isKnownErrorEnv(env) && isValidErrorLog()`),
an attacker can iterate writes across `{app}/preview-pr-1/errors/...`,
`{app}/preview-pr-2/errors/...` up to arbitrarily high numbers across all five
apps, each up to the ~73 KB per-doc cap from #1296 — all billable on this
Blaze-plan project. The per-doc size cap from #1296 reduces severity, but the
`preview-pr-N` sub-namespace remains effectively unbounded.

This bounds the suffix to a realistic length — 6 digits — which covers all
realistic GitHub PR numbers (repo PR numbers rarely exceed 100,000) while
blocking contrived large values. Firestore rules use RE2, which supports
`{n,m}` quantifiers.

Residual tightening filed as a follow-up from PR #1320 (which pinned the env
allowlist and bounded the error-doc schema for #1296).

## Change

`firestore.rules` — inside `isKnownErrorEnv`:

```
- || env.matches("preview-pr-[0-9]+")
+ || env.matches("preview-pr-[0-9]{1,6}")
```

## Tests

`rules-test/test/firestore/errors.test.ts` — two new boundary cases in the
`budget errors — env allowlist` block:

- `allows preview-pr-123456 env (6 digits, at cap)` — `assertSucceeds`.
- `denies preview-pr-1234567 env (7 digits, over cap)` — `assertFails`.

The empty-suffix `preview-pr-` denial is already covered (`denies preview-pr-
with no number`); `{1,6}` still requires ≥1 digit, so that case passes
unchanged.

## Verification

- Rules syntax check (`run-rules-check.sh`) — passes; confirms RE2 accepts the
  `{1,6}` quantifier.
- `rules-test` suite (emulator-driven, in no CI job) — `errors.test.ts` fully
  green, including both new boundary cases.

## Deployment note

Standalone rules-only PR targeting `main`, per `.claude/rules/firestore.md`.
`firestore.rules` deploys automatically via `firestore-deploy.yml` on merge to
`main`.
