### PR TITLE
error-sink: strip sensitive-named extras keys + document PII residual risk

### DIFF
--- a/firebaseutil/src/error-sink.ts
+++ b/firebaseutil/src/error-sink.ts
@@ -21,7 +21,22 @@ export interface ErrorSinkOptions {
 // error values like the original Error message. operation and kind are included
 // for safety even though they are always written from structured fields.
 // "extras" is reserved for the synthesized JSON blob of non-reserved context.
+//
+// WARNING — residual PII risk: the extras field carries unvalidated caller context.
+// Structurally-reserved keys (this set) are dropped before serialization, and
+// sensitive-named keys (see SENSITIVE_KEY_RE below) are stripped by name pattern.
+// However, a sensitive value passed under a non-matching key name (e.g. a session
+// token stored as "sessionData") is still serialized durably to Firestore.
+// Callers must not rely on this filter as a PII/secret sanitizer — it is a
+// best-effort defence, not a guarantee.
 const RESERVED_KEYS = new Set(["operation", "kind", "message", "stack", "code", "timestamp", "userAgent", "url", "uid", "email", "extras"]);
+
+// Strips obviously-sensitive keys from extras by name before serialization.
+// Matches substrings case-insensitively: token, secret, password, auth, key,
+// credential. Note the g flag is intentionally absent — .test() is stateless.
+// Cross-reference: see the RESERVED_KEYS comment above for the residual risk
+// of values stored under non-matching key names.
+const SENSITIVE_KEY_RE = /token|secret|password|auth|key|credential/i;
 
 // Size caps (UTF-16 code units) — must mirror the firestore.rules isValidErrorLog() caps exactly.
 const CAPS = {
@@ -91,10 +106,19 @@ export function createFirestoreErrorSink(options: ErrorSinkOptions): ErrorSink {
     // This keeps the doc shape fixed to the 11 enumerated keys the firestore.rules
     // isValidErrorLog() hasOnly() check allows.
     const extrasObj: Record<string, unknown> = {};
+    const droppedSensitiveKeys: string[] = [];
     for (const [key, value] of Object.entries(context)) {
-      if (!RESERVED_KEYS.has(key)) {
-        extrasObj[key] = value;
+      if (RESERVED_KEYS.has(key)) continue;
+      if (SENSITIVE_KEY_RE.test(key)) {
+        droppedSensitiveKeys.push(key);
+        continue;
       }
+      extrasObj[key] = value;
+    }
+    if (droppedSensitiveKeys.length > 0) {
+      console.warn(
+        `Firestore error sink: dropped sensitive-named extras keys: ${droppedSensitiveKeys.join(", ")}`,
+      );
     }
     if (Object.keys(extrasObj).length > 0) {
       let extrasStr: string | null = null;

--- a/firebaseutil/test/error-sink.test.ts
+++ b/firebaseutil/test/error-sink.test.ts
@@ -310,4 +310,59 @@ describe("createFirestoreErrorSink", () => {
     const doc = getWrittenDoc();
     expect(doc.code).toBe("permission-denied");
   });
+
+  describe("sensitive-key stripping", () => {
+    it("strips a sensitive-named key (sessionToken) from doc.extras", () => {
+      const sink = createFirestoreErrorSink(makeOptions());
+      const ctx = makeContext({ txnId: "123" } as Partial<EnrichedErrorContext>);
+      (ctx as Record<string, unknown>).sessionToken = "tok";
+      sink(new Error("boom"), ctx);
+
+      const doc = getWrittenDoc();
+      expect(doc.sessionToken).toBeUndefined();
+      const extras = JSON.parse(doc.extras as string);
+      expect(extras.sessionToken).toBeUndefined();
+    });
+
+    it("emits a console.warn naming the dropped sensitive key", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const sink = createFirestoreErrorSink(makeOptions());
+      const ctx = makeContext({ txnId: "123" } as Partial<EnrichedErrorContext>);
+      (ctx as Record<string, unknown>).sessionToken = "tok";
+      sink(new Error("boom"), ctx);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("sessionToken"),
+      );
+    });
+
+    it("retains a non-sensitive key (txnId) in doc.extras", () => {
+      // Spy only to suppress the drop warning; restored in beforeEach.
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const sink = createFirestoreErrorSink(makeOptions());
+      const ctx = makeContext({ txnId: "123" } as Partial<EnrichedErrorContext>);
+      (ctx as Record<string, unknown>).sessionToken = "tok";
+      sink(new Error("boom"), ctx);
+
+      const doc = getWrittenDoc();
+      const extras = JSON.parse(doc.extras as string);
+      expect(extras.txnId).toBe("123");
+    });
+
+    it("strips a key that contains a sensitive substring (apiKey matches 'key')", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const sink = createFirestoreErrorSink(makeOptions());
+      const ctx = makeContext({ txnId: "123" } as Partial<EnrichedErrorContext>);
+      (ctx as Record<string, unknown>).apiKey = "secret-api-key";
+      sink(new Error("boom"), ctx);
+
+      const doc = getWrittenDoc();
+      expect(doc.apiKey).toBeUndefined();
+      const extras = JSON.parse(doc.extras as string);
+      expect(extras.apiKey).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("apiKey"),
+      );
+    });
+  });
 });

--- a/firebaseutil/test/error-sink.test.ts
+++ b/firebaseutil/test/error-sink.test.ts
@@ -313,6 +313,7 @@ describe("createFirestoreErrorSink", () => {
 
   describe("sensitive-key stripping", () => {
     it("strips a sensitive-named key (sessionToken) from doc.extras", () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
       const sink = createFirestoreErrorSink(makeOptions());
       const ctx = makeContext({ txnId: "123" } as Partial<EnrichedErrorContext>);
       (ctx as Record<string, unknown>).sessionToken = "tok";


### PR DESCRIPTION
Closes #1327

## Summary

`firebaseutil/src/error-sink.ts` synthesizes a Firestore error document. PR #1320
(for #1296) folded all non-reserved caller-supplied context into a single
JSON-stringified `extras` field and added per-field size caps, but it still
serializes **every** non-reserved key's value as-is. A caller doing
`logError(e, { operation: "checkout", sessionToken: tok })` therefore silently
writes `sessionToken` into a durable Firestore document, with no content-level
filtering and no documentation of the risk.

This PR adds a defensive, key-**name**-based strip of obviously-sensitive keys
before serialization, warns so callers notice the drop during development, and
documents the residual risk.

## Changes

`firebaseutil/src/error-sink.ts`:

- Add a module-level `SENSITIVE_KEY_RE = /token|secret|password|auth|key|credential/i`
  (no `g` flag — stateless `.test()`) next to `RESERVED_KEYS`.
- In the extras-collection loop, after the existing `RESERVED_KEYS` skip, drop
  any key whose **name** matches `SENSITIVE_KEY_RE`, accumulating the dropped
  names. After the loop, emit a single `console.warn` listing them when any were
  dropped. The existing size-cap / `JSON.stringify` try-catch block is unchanged
  and now operates on the filtered `extrasObj`.
- Extend the `RESERVED_KEYS` comment to document that `extras` carries
  **unvalidated caller context**: structurally-reserved keys are dropped and
  sensitive-*named* keys are stripped, but a sensitive value passed under a
  non-matching key name is still serialized durably to Firestore — the residual
  risk callers must not rely on this filter to cover.

`firebaseutil/test/error-sink.test.ts`:

- Add a `sensitive-key stripping` describe block with four tests: `sessionToken`
  is absent from `doc.extras`; the `console.warn` fires naming the dropped key;
  a non-sensitive key (`txnId`) is retained; and a key containing a sensitive
  substring (`apiKey` → matches `key`) is dropped, confirming substring matching.

## Scope

Key-**name** matching only. No value-content scanning/redaction, no changes to
`CAPS`, the rate-limiter, or `firestore.rules`.

## Verification

- `npx vitest run --project firebaseutil --root <repo> error-sink` — 29/29 pass
  (25 existing + 4 new).
- `npx tsc --noEmit --project firebaseutil` — the change introduces no new type
  errors (the 36 reported are pre-existing DOM/Vite-global errors in untouched
  files under standalone `tsc`).
