### PR TITLE
budget: normalize duplicate-date overrides (last-wins) at the mutation boundary

### DIFF
--- a/budget/src/pages/budgets-hydrate.ts
+++ b/budget/src/pages/budgets-hydrate.ts
@@ -451,7 +451,7 @@ export function hydrateBudgetChart(container: HTMLElement): void {
 
 function collectOverridesForBudget(container: HTMLElement, budgetId: string): BudgetOverride[] | null {
   const rows = container.querySelectorAll<HTMLElement>(`.override-row[data-budget-id="${budgetId}"]`);
-  const overrides: BudgetOverride[] = [];
+  const overrides = new Map<number, BudgetOverride>();
   for (const row of rows) {
     const dateInput = row.querySelector<HTMLInputElement>(".edit-override-date");
     const balanceInput = row.querySelector<HTMLInputElement>(".edit-override-balance");
@@ -466,10 +466,9 @@ function collectOverridesForBudget(container: HTMLElement, budgetId: string): Bu
       showInputError(balanceInput, "Balance must be a finite number");
       return null;
     }
-    overrides.push({ date: Timestamp.fromMillis(dateMs), balance });
+    overrides.set(dateMs, { date: Timestamp.fromMillis(dateMs), balance });
   }
-  overrides.sort((a, b) => a.date.toMillis() - b.date.toMillis());
-  return overrides;
+  return [...overrides.values()].sort((a, b) => a.date.toMillis() - b.date.toMillis());
 }
 
 export function hydrateOverridesTable(container: HTMLElement): void {

--- a/budget/test/pages/budgets-hydrate.test.ts
+++ b/budget/test/pages/budgets-hydrate.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockDataSource = {
   updateBudget: vi.fn(),
+  updateBudgetOverrides: vi.fn(),
 };
 vi.mock("../../src/active-data-source.js", () => ({
   getActiveDataSource: () => mockDataSource,
@@ -12,8 +13,9 @@ vi.mock("@commons-systems/errorutil/log", () => ({
   registerErrorSink: vi.fn(),
 }));
 
-import { hydrateBudgetTable } from "../../src/pages/budgets-hydrate";
+import { hydrateBudgetTable, hydrateOverridesTable } from "../../src/pages/budgets-hydrate";
 import { logError } from "@commons-systems/errorutil/log";
+import { parseUploadedJson, UploadValidationError } from "../../src/upload";
 
 function flush(): Promise<void> {
   return new Promise(r => setTimeout(r, 0));
@@ -712,5 +714,109 @@ describe("hydrateBudgetTable — variance", () => {
 
     const funRadio12 = fun.querySelector<HTMLInputElement>('input[value="12"]')!;
     expect(funRadio12.checked).toBe(true);
+  });
+});
+
+// ── hydrateOverridesTable — duplicate-date normalization ──────────────────────
+
+function createOverridesContainer(budgetId: string, rows: Array<{ date: string; balance: string }>): HTMLElement {
+  const container = document.createElement("div");
+  for (const { date, balance } of rows) {
+    const row = document.createElement("div");
+    row.className = "override-row";
+    row.dataset.budgetId = budgetId;
+    const dateInput = document.createElement("input");
+    dateInput.type = "date";
+    dateInput.className = "edit-override-date";
+    dateInput.value = date;
+    dateInput.defaultValue = date;
+    const balanceInput = document.createElement("input");
+    balanceInput.type = "number";
+    balanceInput.className = "edit-override-balance";
+    balanceInput.value = balance;
+    balanceInput.defaultValue = balance;
+    row.appendChild(dateInput);
+    row.appendChild(balanceInput);
+    container.appendChild(row);
+  }
+  document.body.appendChild(container);
+  return container;
+}
+
+describe("hydrateOverridesTable — duplicate-date normalization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockDataSource.updateBudgetOverrides.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("last-wins: two rows with the same date produce one override with the last row's balance", async () => {
+    const container = createOverridesContainer("food", [
+      { date: "2025-06-10", balance: "100" },
+      { date: "2025-06-10", balance: "250" },
+    ]);
+    hydrateOverridesTable(container);
+
+    // Trigger a blur on the second row's balance input (value !== defaultValue to force save)
+    const rows = container.querySelectorAll<HTMLElement>(".override-row");
+    const secondBalanceInput = rows[1].querySelector<HTMLInputElement>(".edit-override-balance")!;
+    secondBalanceInput.value = "250";
+    secondBalanceInput.defaultValue = "999"; // make it differ so the blur handler proceeds
+    secondBalanceInput.dispatchEvent(new Event("blur", { bubbles: true, composed: true }));
+    await flush();
+
+    expect(mockDataSource.updateBudgetOverrides).toHaveBeenCalledTimes(1);
+    const [calledBudgetId, calledOverrides] = mockDataSource.updateBudgetOverrides.mock.calls[0];
+    expect(calledBudgetId).toBe("food");
+    expect(calledOverrides).toHaveLength(1);
+    expect(calledOverrides[0].balance).toBe(250);
+    expect(calledOverrides[0].date.toMillis()).toBe(new Date("2025-06-10T00:00:00Z").getTime());
+  });
+
+  it("round-trip: last-wins normalized overrides pass the load-side validator", async () => {
+    const container = createOverridesContainer("food", [
+      { date: "2025-06-10", balance: "100" },
+      { date: "2025-06-10", balance: "250" },
+    ]);
+    hydrateOverridesTable(container);
+
+    // Trigger the blur to populate updateBudgetOverrides call
+    const rows = container.querySelectorAll<HTMLElement>(".override-row");
+    const secondBalanceInput = rows[1].querySelector<HTMLInputElement>(".edit-override-balance")!;
+    secondBalanceInput.defaultValue = "999";
+    secondBalanceInput.dispatchEvent(new Event("blur", { bubbles: true, composed: true }));
+    await flush();
+
+    expect(mockDataSource.updateBudgetOverrides).toHaveBeenCalledTimes(1);
+    const [, collectedOverrides] = mockDataSource.updateBudgetOverrides.mock.calls[0];
+
+    // Build a minimal snapshot using the collected overrides in their raw ISO form
+    const snapshot = {
+      version: 1,
+      exportedAt: "2025-06-15T10:30:00Z",
+      groupName: "household",
+      transactions: [],
+      budgets: [
+        {
+          id: "food",
+          name: "Food",
+          allowance: 150,
+          allowancePeriod: "weekly",
+          rollover: "none",
+          overrides: collectedOverrides.map((o: { date: { toMillis: () => number }; balance: number }) => ({
+            date: new Date(o.date.toMillis()).toISOString(),
+            balance: o.balance,
+          })),
+        },
+      ],
+    };
+
+    // parseUploadedJson reaches requireRawOverrides (the load-side validator).
+    // If the overrides are not strictly ascending this throws UploadValidationError.
+    expect(() => parseUploadedJson(JSON.stringify(snapshot))).not.toThrow(UploadValidationError);
   });
 });


### PR DESCRIPTION
Closes #1263

## Problem

The budget overrides editor could persist a snapshot the loader later refused
to open. `collectOverridesForBudget` (`budget/src/pages/budgets-hydrate.ts`)
gathered per-budget override rows from the DOM and sorted them by date ascending,
but permitted two rows with the **same** date. Clicking "Add override" twice
creates two rows that both default to today's date; both were saved and exported.

On the next load, `requireRawOverrides` (`budget/src/entities/budget.ts`) enforces
a **strictly** ascending invariant with a `<=` comparison, so two equal dates
threw `UploadValidationError`. `loadFromHandle` treated that as "not valid budget
data," dropped the persisted file handle, and refused the file — the user's
encrypted `.benc` snapshot became unopenable in the app, recoverable only by
hand-editing decrypted JSON outside it.

## Fix

Enforce strict-ascending **last-wins** normalization at the mutation boundary.
`collectOverridesForBudget` now collects rows into a `Map<number, BudgetOverride>`
keyed on `date.toMillis()`, populated in DOM iteration order so a later same-date
row overwrites an earlier one (its balance edits are the most recent), then emits
`[...map.values()]` sorted ascending. The result is always strictly ascending with
no equal dates, so the loader's `<=` check always holds. The invalid-date and
invalid-balance early-return branches are unchanged and still abort the save.

The loader's strict invariant (`requireRawOverrides` / `requireOverrides`) is left
untouched — it is the correct contract; the mutation boundary is what must uphold
it. The IDB/export/file-sync path is out of scope: it faithfully serializes
whatever `collectOverridesForBudget` returns, so fixing the boundary fixes the
whole chain.

## Test

A new suite in `budget/test/pages/budgets-hydrate.test.ts` drives
`hydrateOverridesTable` with two `.override-row` elements for the same budget
carrying the same date but different balances, and asserts:

1. **Normalization** — `updateBudgetOverrides` is called with exactly one
   override carrying the **last** row's balance (last-wins).
2. **Reload survives** — the collected output, serialized to the raw ISO shape
   and fed through `parseUploadedJson`, does **not** throw `UploadValidationError`.

The test fails against the unpatched function (two same-date rows →
`UploadValidationError` on reload) and passes after the normalization.

## Verification

- `npx tsc --noEmit --project budget` — clean
- `npx vitest run --root budget budgets-hydrate upload` — all pass
- lint — clean
