### PR TITLE
budget: honor mid-period overrides in bulk balance functions

### DIFF
--- a/budget/src/balance.ts
+++ b/budget/src/balance.ts
@@ -146,15 +146,6 @@ function periodsForBudget(periods: BudgetPeriod[], budgetId: BudgetId): BudgetPe
     .sort((a, b) => a.periodStart.toMillis() - b.periodStart.toMillis());
 }
 
-/** Return the override with the greatest date <= beforeMs, or null. Requires overrides sorted by date ascending. */
-export function findLatestOverride(overrides: BudgetOverride[], beforeMs: number): BudgetOverride | null {
-  let result: BudgetOverride | null = null;
-  for (const o of overrides) {
-    if (o.date.toMillis() <= beforeMs) result = o;
-    else break;
-  }
-  return result;
-}
 
 /**
  * Latest override whose date falls within the half-open period

--- a/budget/src/balance.ts
+++ b/budget/src/balance.ts
@@ -217,43 +217,30 @@ export function computeBudgetBalance(
 
   const targetPeriod = periods[targetPeriodIndex];
 
-  // Check for override that applies at or before the target period start
-  const targetStartMs = targetPeriod.periodStart.toMillis();
-  const override = findLatestOverride(budget.overrides, targetStartMs);
-
-  // Determine which period to start accumulating from
-  let startIdx = 0;
+  // Accumulate through prior periods, resetting to any override that falls
+  // inside the period (else applying normal rollover), then subtracting the
+  // period total. A later in-period override overwrites all prior accumulation.
   let running = 0;
-
-  // Find the period containing the override date (if any)
-  const overridePeriodIdx = override ? periods.findIndex(
-    (p) => {
-      const overrideMs = override.date.toMillis();
-      return p.periodStart.toMillis() <= overrideMs && overrideMs < p.periodEnd.toMillis();
-    },
-  ) : -1;
-
-  if (override && overridePeriodIdx !== -1 && overridePeriodIdx <= targetPeriodIndex) {
-    // Start from the override: set balance to override value, subtract the override period's total, then continue
-    startIdx = overridePeriodIdx + 1;
-    running = override.balance - periods[overridePeriodIdx].total;
-  }
-
-  // Accumulate through prior periods (from startIdx, which is 0 when no override)
-  for (let i = startIdx; i < targetPeriodIndex; i++) {
+  for (let i = 0; i < targetPeriodIndex; i++) {
+    const periodStart = periods[i].periodStart.toMillis();
+    const periodEnd = periods[i].periodEnd.toMillis();
+    const override = findOverrideInPeriod(budget.overrides, periodStart, periodEnd);
     const prevMs = i > 0 ? periods[i - 1].periodStart.toMillis() : null;
-    const allow = periodAllowance(budget.allowance, budget.allowancePeriod, prevMs, periods[i].periodStart.toMillis());
-    running = applyRollover(running, allow, budget.rollover);
+    const allow = periodAllowance(budget.allowance, budget.allowancePeriod, prevMs, periodStart);
+    running = override ? override.balance : applyRollover(running, allow, budget.rollover);
     running -= periods[i].total;
   }
 
-  // Apply rollover entering the target period (unless override is in this period)
-  if (override && overridePeriodIdx === targetPeriodIndex) {
-    // Override is in the target period: running starts at override balance
-    running = override.balance;
+  // Enter the target period: an in-period override replaces the rollover and no
+  // total is subtracted (the same-period txn walk below subtracts within-period spend).
+  const targetStartMs = targetPeriod.periodStart.toMillis();
+  const targetEndMs = targetPeriod.periodEnd.toMillis();
+  const targetOverride = findOverrideInPeriod(budget.overrides, targetStartMs, targetEndMs);
+  if (targetOverride) {
+    running = targetOverride.balance;
   } else {
     const prevMs = targetPeriodIndex > 0 ? periods[targetPeriodIndex - 1].periodStart.toMillis() : null;
-    const allow = periodAllowance(budget.allowance, budget.allowancePeriod, prevMs, targetPeriod.periodStart.toMillis());
+    const allow = periodAllowance(budget.allowance, budget.allowancePeriod, prevMs, targetStartMs);
     running = applyRollover(running, allow, budget.rollover);
   }
 

--- a/budget/src/balance.ts
+++ b/budget/src/balance.ts
@@ -156,6 +156,25 @@ export function findLatestOverride(overrides: BudgetOverride[], beforeMs: number
   return result;
 }
 
+/**
+ * Latest override whose date falls within the half-open period
+ * [periodStartMs, periodEndMs), or null. Requires overrides sorted by
+ * date ascending.
+ */
+export function findOverrideInPeriod(
+  overrides: BudgetOverride[],
+  periodStartMs: number,
+  periodEndMs: number,
+): BudgetOverride | null {
+  let result: BudgetOverride | null = null;
+  for (const o of overrides) {
+    const ms = o.date.toMillis();
+    if (ms >= periodStartMs && ms < periodEndMs) result = o;
+    else if (ms >= periodEndMs) break;
+  }
+  return result;
+}
+
 // Exclude non-primary normalized transactions to avoid double-counting duplicates
 function transactionsForBudget(txns: Transaction[], budgetId: BudgetId): TimestampedTransaction[] {
   return txns
@@ -281,12 +300,12 @@ export function computePeriodBalances(
       const period = sorted[idx];
       const periodStartMs = period.periodStart.toMillis();
       const periodEndMs = period.periodEnd.toMillis();
-      const override = findLatestOverride(budget.overrides, periodStartMs);
+      const override = findOverrideInPeriod(budget.overrides, periodStartMs, periodEndMs);
       const prevMs = idx > 0 ? sorted[idx - 1].periodStart.toMillis() : null;
       const allow = periodAllowance(budget.allowance, budget.allowancePeriod, prevMs, periodStartMs);
 
       let running: number;
-      if (override && override.date.toMillis() >= periodStartMs && override.date.toMillis() < periodEndMs) {
+      if (override) {
         // Override is in this period: replaces rollover
         running = override.balance;
       } else {
@@ -323,11 +342,11 @@ export function computeAllBudgetBalances(
       const periodStartMs = period.periodStart.toMillis();
       const periodEndMs = period.periodEnd.toMillis();
 
-      const override = findLatestOverride(budget.overrides, periodStartMs);
+      const override = findOverrideInPeriod(budget.overrides, periodStartMs, periodEndMs);
       const prevMs = pIdx > 0 ? periods[pIdx - 1].periodStart.toMillis() : null;
       const allow = periodAllowance(budget.allowance, budget.allowancePeriod, prevMs, periodStartMs);
       let running: number;
-      if (override && override.date.toMillis() >= periodStartMs && override.date.toMillis() < periodEndMs) {
+      if (override) {
         accumulated = override.balance;
         running = accumulated;
       } else {

--- a/budget/src/entities/budget.ts
+++ b/budget/src/entities/budget.ts
@@ -51,7 +51,7 @@ export interface Budget {
   readonly allowance: number;
   readonly allowancePeriod: AllowancePeriod;
   readonly rollover: Rollover;
-  /** Sorted by date ascending. findLatestOverride assumes this ordering. */
+  /** Sorted by date ascending. findOverrideInPeriod assumes this ordering. */
   readonly overrides: BudgetOverride[];
   readonly groupId: GroupId | null;
 }

--- a/budget/test/balance.test.ts
+++ b/budget/test/balance.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { Timestamp } from "firebase/firestore";
-import { weekStart, computeNetAmount, findPeriodForTimestamp, computeBudgetBalance, computeAllBudgetBalances, computePeriodBalances, computeAverageWeeklyCredits, computeRollingAverage, computeAggregateTrend, computePerBudgetTrend, computeAverageWeeklySpending, computeNetWorth, computeCashFlow, computeDerivedBalances, periodAllowance, weeklyEquivalent, periodEquivalent, computeBudgetStatsAndVariances, MATERIALITY_THRESHOLD } from "../src/balance";
+import { weekStart, computeNetAmount, findPeriodForTimestamp, computeBudgetBalance, computeAllBudgetBalances, computePeriodBalances, findOverrideInPeriod, computeAverageWeeklyCredits, computeRollingAverage, computeAggregateTrend, computePerBudgetTrend, computeAverageWeeklySpending, computeNetWorth, computeCashFlow, computeDerivedBalances, periodAllowance, weeklyEquivalent, periodEquivalent, computeBudgetStatsAndVariances, MATERIALITY_THRESHOLD } from "../src/balance";
 import type { BudgetDiff, PerBudgetStats } from "../src/balance";
 import type { Budget, BudgetOverride, BudgetPeriod, Statement, Transaction, WeeklyAggregate } from "../src/firestore";
 
@@ -1390,6 +1390,49 @@ function makeOverride(dateStr: string, balance: number): BudgetOverride {
   return { date: ts(dateStr), balance };
 }
 
+describe("findOverrideInPeriod", () => {
+  // Period w2 = [Jan 13, Jan 20).
+  const periodStartMs = ts("2025-01-13").toMillis();
+  const periodEndMs = ts("2025-01-20").toMillis();
+
+  it("empty overrides → null", () => {
+    expect(findOverrideInPeriod([], periodStartMs, periodEndMs)).toBeNull();
+  });
+
+  it("all overrides before periodStart → null", () => {
+    const overrides = [makeOverride("2025-01-06", 10), makeOverride("2025-01-12", 20)];
+    expect(findOverrideInPeriod(overrides, periodStartMs, periodEndMs)).toBeNull();
+  });
+
+  it("override exactly at periodStart → returned (half-open lower bound is inclusive)", () => {
+    const o = makeOverride("2025-01-13", 50);
+    expect(findOverrideInPeriod([o], periodStartMs, periodEndMs)).toBe(o);
+  });
+
+  it("override at periodEnd − 1ms → returned", () => {
+    const justBefore: BudgetOverride = {
+      date: { toMillis: () => periodEndMs - 1, toDate: () => new Date(periodEndMs - 1) } as Timestamp,
+      balance: 50,
+    };
+    expect(findOverrideInPeriod([justBefore], periodStartMs, periodEndMs)).toBe(justBefore);
+  });
+
+  it("override at periodEnd → null (half-open upper bound is exclusive)", () => {
+    const o = makeOverride("2025-01-20", 50);
+    expect(findOverrideInPeriod([o], periodStartMs, periodEndMs)).toBeNull();
+  });
+
+  it("multiple overrides in period → latest returned", () => {
+    const earlier = makeOverride("2025-01-14", 10);
+    const later = makeOverride("2025-01-16", 99);
+    expect(findOverrideInPeriod([earlier, later], periodStartMs, periodEndMs)).toBe(later);
+  });
+
+  it("override after period → null", () => {
+    const o = makeOverride("2025-01-25", 50);
+    expect(findOverrideInPeriod([o], periodStartMs, periodEndMs)).toBeNull();
+  });
+});
 
 describe("computeBudgetBalance with overrides", () => {
   const w1 = makePeriod({ id: "w1", budgetId: "food", periodStart: ts("2025-01-06"), periodEnd: ts("2025-01-13"), total: 40 });
@@ -1422,17 +1465,16 @@ describe("computeBudgetBalance with overrides", () => {
     expect(computeBudgetBalance(txn, [txn], budget, periods)).toBe(20);
   });
 
-  it("multiple overrides: latest one before the target period start is used", () => {
+  it("multiple overrides in separate prior periods: each applied in its own period", () => {
     // Two overrides: Jan 6 (w1) and Jan 13 (w2). Target txn in w3.
-    // Latest override at or before start of w3 (Jan 20) is Jan 13.
     const budget = makeBudget({
       allowance: 100,
       rollover: "balance",
       overrides: [makeOverride("2025-01-06", 20), makeOverride("2025-01-13", 50)],
     });
     const txn = makeTxn({ id: "txn-1", amount: 25, timestamp: ts("2025-01-22") });
-    // Override at Jan 13 (w2) is used: running = 50 - w2.total(30) = 20
-    // w3: 20+100=120, -txn25 = 95
+    // w1 override (bal=20): running=20-40=-20; w2 override (bal=50): running=50-30=20;
+    // w3: 20+100=120, -25=95
     expect(computeBudgetBalance(txn, [txn], budget, periods)).toBe(95);
   });
 
@@ -1440,7 +1482,7 @@ describe("computeBudgetBalance with overrides", () => {
     // Override at Jan 27 (after w3) — target txn is in w2
     const budget = makeBudget({ allowance: 100, rollover: "balance", overrides: [makeOverride("2025-01-27", 999)] });
     const txn = makeTxn({ id: "txn-1", amount: 30, timestamp: ts("2025-01-15") });
-    // No applicable override for w2 target period start (Jan 13): normal behavior
+    // Override at Jan 27 >= w2.end (Jan 20): findOverrideInPeriod returns null for w2 → normal rollover.
     // w1: 0+100=100, -40=60; w2: 60+100=160, -txn30=130
     expect(computeBudgetBalance(txn, [txn], budget, periods)).toBe(130);
   });
@@ -1468,7 +1510,7 @@ describe("computeBudgetBalance with overrides", () => {
     const gapPeriods = [w1, w3];
     const budget = makeBudget({ allowance: 100, rollover: "balance", overrides: [makeOverride("2025-01-15", 999)] });
     const txn = makeTxn({ id: "txn-1", amount: 10, timestamp: ts("2025-01-22") });
-    // Override at Jan 15 falls in no period (gap), so overridePeriodIdx = -1 → ignored.
+    // Override at Jan 15 falls in no period boundary ([Jan6,Jan13) or [Jan20,Jan27)); findOverrideInPeriod returns null for each — ignored.
     // Normal behavior: w1: 0+100-40=60; w3: 60+100=160, -txn10 = 150
     expect(computeBudgetBalance(txn, [txn], budget, gapPeriods)).toBe(150);
   });

--- a/budget/test/balance.test.ts
+++ b/budget/test/balance.test.ts
@@ -1548,6 +1548,45 @@ describe("computeAllBudgetBalances with overrides", () => {
   });
 });
 
+describe("mid-period override agreement (#1264)", () => {
+  // Regression guard: a strictly mid-period override (Jan 16, inside w2 = [Jan13, Jan20))
+  // must be honored identically by all three balance functions.
+  // Against the old bulk code, w2 would yield 130 (override ignored); only the corrected
+  // findOverrideInPeriod resolver yields the expected values (20, 95).
+  const w1 = makePeriod({ id: "w1", budgetId: "food", periodStart: ts("2025-01-06"), periodEnd: ts("2025-01-13"), total: 40 });
+  const w2 = makePeriod({ id: "w2", budgetId: "food", periodStart: ts("2025-01-13"), periodEnd: ts("2025-01-20"), total: 30 });
+  const w3 = makePeriod({ id: "w3", budgetId: "food", periodStart: ts("2025-01-20"), periodEnd: ts("2025-01-27"), total: 25 });
+  const periods = [w1, w2, w3];
+
+  // Override date Jan 16 is strictly inside w2 [Jan13, Jan20) — not on a period boundary.
+  // Allowance 100, rollover "balance", per-period totals w1=40/w2=30/w3=25.
+  // Expected values:
+  //   w1: no override → applyRollover(0, 100, "balance") = 100; 100-40 = 60 accumulated
+  //   w2: override in period → running = 50 (replaces rollover); txn-w2 amount 30 → 50-30 = 20
+  //   w3: no override → applyRollover(20, 100, "balance") = 120; txn-w3 amount 25 → 120-25 = 95
+  const budget = makeBudget({ allowance: 100, rollover: "balance", overrides: [makeOverride("2025-01-16", 50)] });
+  const txn1 = makeTxn({ id: "txn-w2", amount: 30, timestamp: ts("2025-01-15") });
+  const txn2 = makeTxn({ id: "txn-w3", amount: 25, timestamp: ts("2025-01-22") });
+  const allTxns = [txn1, txn2];
+
+  it("all three functions agree and reflect a mid-period override", () => {
+    const batch = computeAllBudgetBalances(allTxns, [budget], periods);
+
+    // computeAllBudgetBalances matches computeBudgetBalance for each transaction
+    expect(batch.get("txn-w2")).toBe(computeBudgetBalance(txn1, allTxns, budget, periods));
+    expect(batch.get("txn-w3")).toBe(computeBudgetBalance(txn2, allTxns, budget, periods));
+
+    // Concrete values: override is honored in w2 (old buggy bulk code → 130, not 20)
+    expect(batch.get("txn-w2")).toBe(20);
+    expect(batch.get("txn-w3")).toBe(95);
+
+    // computePeriodBalances also reflects the override in w2 and correct w3 rollover
+    const pb = computePeriodBalances([budget], periods).get("food" as any)!;
+    expect(pb[1].runningBalance).toBe(20);  // w2: override applied (old buggy code → 130)
+    expect(pb[2].runningBalance).toBe(95);  // w3: rollover from corrected w2 balance
+  });
+});
+
 describe("periodAllowance", () => {
   it("weekly: always returns full allowance", () => {
     expect(periodAllowance(100, "weekly", null, Date.parse("2025-01-06"))).toBe(100);

--- a/budget/test/balance.test.ts
+++ b/budget/test/balance.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { Timestamp } from "firebase/firestore";
-import { weekStart, computeNetAmount, findPeriodForTimestamp, computeBudgetBalance, computeAllBudgetBalances, computePeriodBalances, computeAverageWeeklyCredits, computeRollingAverage, computeAggregateTrend, computePerBudgetTrend, computeAverageWeeklySpending, computeNetWorth, computeCashFlow, computeDerivedBalances, findLatestOverride, periodAllowance, weeklyEquivalent, periodEquivalent, computeBudgetStatsAndVariances, MATERIALITY_THRESHOLD } from "../src/balance";
+import { weekStart, computeNetAmount, findPeriodForTimestamp, computeBudgetBalance, computeAllBudgetBalances, computePeriodBalances, computeAverageWeeklyCredits, computeRollingAverage, computeAggregateTrend, computePerBudgetTrend, computeAverageWeeklySpending, computeNetWorth, computeCashFlow, computeDerivedBalances, periodAllowance, weeklyEquivalent, periodEquivalent, computeBudgetStatsAndVariances, MATERIALITY_THRESHOLD } from "../src/balance";
 import type { BudgetDiff, PerBudgetStats } from "../src/balance";
 import type { Budget, BudgetOverride, BudgetPeriod, Statement, Transaction, WeeklyAggregate } from "../src/firestore";
 
@@ -1390,43 +1390,6 @@ function makeOverride(dateStr: string, balance: number): BudgetOverride {
   return { date: ts(dateStr), balance };
 }
 
-describe("findLatestOverride", () => {
-  it("returns null for empty overrides", () => {
-    expect(findLatestOverride([], ts("2025-01-15").toMillis())).toBeNull();
-  });
-
-  it("returns null when all overrides are after beforeMs", () => {
-    const overrides = [makeOverride("2025-01-20", 50), makeOverride("2025-01-27", 75)];
-    expect(findLatestOverride(overrides, ts("2025-01-15").toMillis())).toBeNull();
-  });
-
-  it("returns the only override when it is before beforeMs", () => {
-    const overrides = [makeOverride("2025-01-13", 50)];
-    const result = findLatestOverride(overrides, ts("2025-01-15").toMillis());
-    expect(result).not.toBeNull();
-    expect(result!.balance).toBe(50);
-  });
-
-  it("returns the latest override before beforeMs when there are multiple", () => {
-    const overrides = [
-      makeOverride("2025-01-06", 30),
-      makeOverride("2025-01-13", 50),
-      makeOverride("2025-01-20", 80),
-    ];
-    // beforeMs is Jan 15 — Jan 6 and Jan 13 qualify, Jan 20 does not
-    const result = findLatestOverride(overrides, ts("2025-01-15").toMillis());
-    expect(result).not.toBeNull();
-    expect(result!.balance).toBe(50);
-    expect(result!.date.toMillis()).toBe(ts("2025-01-13").toMillis());
-  });
-
-  it("returns override exactly at the beforeMs boundary (inclusive)", () => {
-    const overrides = [makeOverride("2025-01-13", 50)];
-    const result = findLatestOverride(overrides, ts("2025-01-13").toMillis());
-    expect(result).not.toBeNull();
-    expect(result!.balance).toBe(50);
-  });
-});
 
 describe("computeBudgetBalance with overrides", () => {
   const w1 = makePeriod({ id: "w1", budgetId: "food", periodStart: ts("2025-01-06"), periodEnd: ts("2025-01-13"), total: 40 });


### PR DESCRIPTION
Closes #1264

## Problem

`budget/src/balance.ts` computes budget balances three ways: per-transaction
(`computeBudgetBalance`) and two bulk functions (`computePeriodBalances`,
`computeAllBudgetBalances`). A *mid-period budget override* — a manual balance
reset whose date falls strictly inside a period — was honored by the
per-transaction function but **silently ignored by both bulk functions**, so the
transaction-detail balance and the period-balance chart disagreed for the same
budget.

Root cause: both bulk functions resolved the override with
`findLatestOverride(budget.overrides, periodStartMs)`, which returns only
overrides with `date <= periodStartMs`, then gated on
`override.date >= periodStartMs && override.date < periodEndMs`. Those two
conditions can both hold only when `date === periodStartMs` *exactly*. The UI's
"Add override" defaults to today at midnight UTC — almost never a period
boundary — so a typical override did nothing in the bulk paths.
`computeBudgetBalance` avoided the bug by locating the override's *own* period,
honoring any in-period date.

Every pre-existing override test used `date === periodStart` (Jan 13 = w2 start),
which is why the bug went uncaught.

## Fix

Introduce one shared, period-scoped resolver and route all three functions
through it:

```ts
findOverrideInPeriod(overrides, periodStartMs, periodEndMs)
```

It returns the latest override whose date falls within the half-open period
`[periodStartMs, periodEndMs)`, or null. The reset rule becomes identical and
period-local in all three functions: if an override falls inside this period,
`running = override.balance`; else apply normal rollover.

`computeBudgetBalance` was rewritten from its `findLatestOverride` + `findIndex`
+ `startIdx` seeding to a per-period reset loop using the shared resolver. The
rewrite is behavior-preserving — a later in-period override unconditionally
overwrites `running`, the same effect the old seeding produced — and the full
existing override suite stays green, unchanged, as the equivalence proof. With
no remaining callers, `findLatestOverride` is removed.

## Changes

- Add exported `findOverrideInPeriod`; route `computePeriodBalances` and
  `computeAllBudgetBalances` through it.
- Rewrite `computeBudgetBalance` to use the shared resolver (per-period reset
  loop).
- Remove the now-dead `findLatestOverride`, its test, and a stale doc-comment
  reference in `entities/budget.ts` (now naming `findOverrideInPeriod`).
- Add a regression test (`mid-period override agreement (#1264)`) with a
  strictly mid-period override (Jan 16, inside w2 `[Jan13, Jan20)`) asserting all
  three functions agree (`txn-w2` = 20, `txn-w3` = 95). Against the pre-fix bulk
  code w2 would be 130 (override ignored); only the corrected resolver passes.

## Acceptance criteria

- [x] Bulk and per-transaction balance functions apply a mid-period override
  identically.
- [x] A shared period-start resolver (`findOverrideInPeriod`) is used by all
  three functions, with a test asserting agreement.

## Verification

- `npx vitest run --root budget test/balance.test.ts` — 162 tests pass,
  including the unchanged `computeBudgetBalance` override suite (equivalence) and
  the new mid-period agreement test.
- `npx tsc --noEmit --project budget` — clean.
- `grep -rn findLatestOverride budget` — returns nothing.
