### PR TITLE
budget: validate reimbursement range on IDB write and load-path parse

### DIFF
--- a/budget/src/data-source.ts
+++ b/budget/src/data-source.ts
@@ -27,7 +27,7 @@ import { assertLegStateTransition } from "./firestore.js";
 import seedData from "virtual:budget-seed-data";
 import { getAll, get, put, deleteRecord } from "./idb.js";
 import type { IdbTransaction, IdbStatement, IdbStatementItem, IdbReconciliationNote, IdbAccount, IdbJournalEntry, IdbJournalLeg, IdbReconciliationEvent, IdbBudget, IdbBudgetPeriod, IdbRule, IdbNormalizationRule, IdbWeeklyAggregate } from "./idb.js";
-import { idbToTransaction } from "./entities/transaction.js";
+import { idbToTransaction, validateReimbursementRange } from "./entities/transaction.js";
 import { idbToStatement } from "./entities/statement.js";
 import { idbToStatementItem } from "./entities/statement-item.js";
 import { idbToReconciliationNote } from "./entities/reconciliation-note.js";
@@ -301,6 +301,9 @@ export class IdbDataSource implements DataSource {
     id: TransactionId,
     fields: Partial<Pick<Transaction, "note" | "category" | "reimbursement" | "budget" | "normalizedId" | "normalizedPrimary" | "normalizedDescription">>,
   ): Promise<void> {
+    if (fields.reimbursement !== undefined) {
+      validateReimbursementRange(fields.reimbursement);
+    }
     await updateRecord<IdbTransaction>("transactions", id, "Transaction", fields);
   }
 

--- a/budget/src/entities/transaction.ts
+++ b/budget/src/entities/transaction.ts
@@ -175,6 +175,8 @@ export function parseFirestoreTransaction(docSnap: QueryDocumentSnapshot<Documen
 // ── Raw upload → Transaction ──────────────────────────────────────────────────
 
 export function parseRawTransaction(t: RawTransaction, i: number): Transaction {
+  const reimbursement = t.reimbursement ?? 0;
+  validateReimbursementRange(reimbursement);
   return {
     id: requireUploadId(t.id, "transaction", i) as TransactionId,
     institution: t.institution ?? "",
@@ -183,7 +185,7 @@ export function parseRawTransaction(t: RawTransaction, i: number): Transaction {
     amount: t.amount ?? 0,
     note: t.note ?? "",
     category: t.category ?? "",
-    reimbursement: t.reimbursement ?? 0,
+    reimbursement,
     budget: (t.budget || null) as BudgetId | null,
     timestamp: t.timestamp ? parseISOTimestamp(t.timestamp, "transaction.timestamp") : null,
     statementId: (t.statementId || null) as StatementId | null,

--- a/budget/test/data-source.test.ts
+++ b/budget/test/data-source.test.ts
@@ -113,6 +113,16 @@ describe("IdbDataSource", () => {
     ).rejects.toThrow("Transaction nonexistent not found");
   });
 
+  it("updateTransaction rejects out-of-range reimbursement and does not persist", async () => {
+    await storeParsedData(makeParsedData());
+    const ds = new IdbDataSource();
+    await expect(
+      ds.updateTransaction("txn-1" as TransactionId, { reimbursement: 150 }),
+    ).rejects.toThrow(RangeError);
+    const txns = await ds.getTransactions();
+    expect(txns[0].reimbursement).toBe(0); // unchanged — never persisted
+  });
+
   it("adjustBudgetPeriodTotal does read-modify-write correctly", async () => {
     await storeParsedData(makeParsedData());
     const ds = new IdbDataSource();

--- a/budget/test/transaction.test.ts
+++ b/budget/test/transaction.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { parseRawTransaction } from "../src/entities/transaction";
+
+describe("parseRawTransaction", () => {
+  it("defaults a missing reimbursement to 0", () => {
+    const t = parseRawTransaction({ id: "txn-1" } as any, 0);
+    expect(t.reimbursement).toBe(0);
+  });
+  it("rejects an out-of-range reimbursement with RangeError", () => {
+    expect(() =>
+      parseRawTransaction({ id: "txn-1", reimbursement: 150 } as any, 0),
+    ).toThrow(RangeError);
+  });
+});


### PR DESCRIPTION
Closes #1265

## Problem

`Transaction.reimbursement` is documented as a percentage in `[0, 100]`,
"validated at read and write boundaries" — but that contract was only
half-enforced. Two boundaries let an out-of-range value through:

- **Write path.** `IdbDataSource.updateTransaction` was a bare read-modify-write
  with no range check, so entering an out-of-range value (e.g. `150`) in the UI
  persisted it to IndexedDB. Thereafter `computeNetAmount` threw `RangeError` on
  every render that computes net amounts (`computeAllBudgetBalances`, charts,
  income statement), bricking the page.
- **Load path.** `parseRawTransaction` did `t.reimbursement ?? 0` with no range
  check, so the bad value round-tripped through export/load.

Only the (currently dead) Firestore path validated.

## Fix

Reuse the existing `validateReimbursementRange` helper at the two unprotected
boundaries:

- **Unit 1** — `IdbDataSource.updateTransaction` guards on
  `fields.reimbursement !== undefined` and validates before any IDB write, so an
  out-of-range value throws before it can persist. Because
  `FileSyncingDataSource.updateTransaction` awaits the inner call before
  scheduling its file write-back, this also covers the wrapped path.
- **Unit 2** — `parseRawTransaction` hoists and validates the defaulted
  reimbursement value before building the returned transaction.
- **Unit 3** — tests assert rejection *and* non-persistence at the write boundary
  (the value reads back as `0`), and rejection at the load/parse boundary.

No UI change is needed: the blur handler's `handleSaveError` already classifies a
thrown `RangeError` as `"range"`, shows "Value out of range", and reverts the
input.

## Verification

`npm run test --prefix budget -- data-source.test.ts transaction.test.ts` — all
pass, including the two pre-existing `updateTransaction` cases and the three new
range tests.
