### PR TITLE
budget: tolerate a normalized group whose primary is outside the scroll batch

### DIFF
--- a/budget/src/pages/home.ts
+++ b/budget/src/pages/home.ts
@@ -241,7 +241,12 @@ export function renderTransactionRows(
       const members = normalizedGroups.get(txn.normalizedId)!;
       const primary = members.find(t => t.normalizedPrimary);
       if (!primary) {
-        throw new DataIntegrityError(`Normalized group ${txn.normalizedId} has no primary transaction`);
+        // The group's single primary is in another scroll batch; that batch renders
+        // the canonical group row. Non-primary duplicates are hidden everywhere else
+        // (chart, balance, income), so suppress these orphan members here rather than
+        // throwing a fatal DataIntegrityError that kills the table / disconnects
+        // infinite scroll (#1266).
+        return [];
       }
       return renderNormalizedGroup({ primary, members, groupName, editable, budgetIdToName, balance: getBalance(primary.id) });
     })

--- a/budget/test/pages/home.test.ts
+++ b/budget/test/pages/home.test.ts
@@ -23,7 +23,7 @@ vi.mock("../../src/balance.js", async (importOriginal) => {
   };
 });
 
-import { renderHome } from "../../src/pages/home";
+import { renderHome, renderTransactionRows } from "../../src/pages/home";
 import type { Transaction, BudgetPeriod } from "../../src/firestore";
 import { computeAllBudgetBalances } from "../../src/balance";
 
@@ -709,6 +709,39 @@ describe("renderHome", () => {
       }));
       expect(html).toContain('class="expand-row txn-row"');
       expect(html).not.toContain("normalized-group");
+    });
+
+    it("tolerates a normalized group whose primary is outside the current batch", () => {
+      const budgetIdToName = new Map<string, string>();
+      // Older scroll batch: only the non-primary member of the group is present;
+      // its primary fell into an adjacent 12-week batch.
+      const orphanBatch = [
+        txn({ id: "txn-b", description: "Store B", amount: 50, normalizedId: "norm-1", normalizedPrimary: false, timestamp: mockTimestamp("2025-01-04") }),
+      ];
+      expect(() => renderTransactionRows(orphanBatch, "household", true, budgetIdToName)).not.toThrow();
+      const orphanHtml = renderTransactionRows(orphanBatch, "household", true, budgetIdToName);
+      // The orphan duplicate is suppressed — no group row, and it is not shown as a
+      // standalone transaction either.
+      expect(orphanHtml).not.toContain("normalized-group");
+      expect(orphanHtml).not.toContain("Store B");
+
+      // The adjacent batch that holds the primary still renders the group normally.
+      const primaryBatch = [
+        txn({ id: "txn-a", description: "Store A", amount: 50, normalizedId: "norm-1", normalizedPrimary: true, timestamp: mockTimestamp("2025-01-11") }),
+      ];
+      const primaryHtml = renderTransactionRows(primaryBatch, "household", true, budgetIdToName);
+      expect(primaryHtml).toContain("normalized-group");
+    });
+
+    it("renders the table (no data error) when a batch contains only a non-primary member", async () => {
+      mockComputeAllBalances.mockReturnValue(new Map());
+      const html = await renderHome(localOptions({
+        getTransactions: vi.fn().mockResolvedValue([
+          txn({ id: "txn-b", description: "Store B", amount: 50, normalizedId: "norm-1", normalizedPrimary: false, timestamp: mockTimestamp("2025-01-04") }),
+        ]),
+      }));
+      expect(html).toContain('id="transactions-table"');
+      expect(html).not.toContain("transactions-error");
     });
   });
 

--- a/budget/test/pages/home.test.ts
+++ b/budget/test/pages/home.test.ts
@@ -718,7 +718,6 @@ describe("renderHome", () => {
       const orphanBatch = [
         txn({ id: "txn-b", description: "Store B", amount: 50, normalizedId: "norm-1", normalizedPrimary: false, timestamp: mockTimestamp("2025-01-04") }),
       ];
-      expect(() => renderTransactionRows(orphanBatch, "household", true, budgetIdToName)).not.toThrow();
       const orphanHtml = renderTransactionRows(orphanBatch, "household", true, budgetIdToName);
       // The orphan duplicate is suppressed — no group row, and it is not shown as a
       // standalone transaction either.
@@ -734,7 +733,6 @@ describe("renderHome", () => {
     });
 
     it("renders the table (no data error) when a batch contains only a non-primary member", async () => {
-      mockComputeAllBalances.mockReturnValue(new Map());
       const html = await renderHome(localOptions({
         getTransactions: vi.fn().mockResolvedValue([
           txn({ id: "txn-b", description: "Store B", amount: 50, normalizedId: "norm-1", normalizedPrimary: false, timestamp: mockTimestamp("2025-01-04") }),


### PR DESCRIPTION
Closes #1266

## Problem

`renderTransactionRows` (`budget/src/pages/home.ts`) builds its normalized-group
map from only the transactions in the current 12-week scroll batch, then for each
group requires an in-batch primary member, throwing `DataIntegrityError` if none
is found. But a normalized group has exactly one primary **globally** (set in the
ETL), and time-windowed batching can place that primary in a different batch — so
a batch can legitimately contain only a non-primary member.

When that happened the render threw over data that is globally valid:

- **Initial load** — the throw replaced the entire transactions table with an error.
- **Scroll batch** — the hydration path caught the error, showed "Data error —
  please re-upload your file", and **permanently disconnected infinite scroll**
  (`home-hydrate.ts`), even though the underlying data was fine.

## Fix

Suppress the orphan non-primary members instead of throwing. When a batch holds a
normalized group with no in-batch primary, the primary lives in another scroll
batch and **that** batch renders the canonical group row, so this batch should
render nothing for the orphan duplicates rather than throw. Non-primary normalized
duplicates are already hidden everywhere else in the app (the chart, balance, and
income-statement paths all drop them), so this makes the transactions table
consistent with the rest. Both the initial render and the scroll-append path call
the same `renderTransactionRows`, so the one change fixes both.

The `seenGroups` add still runs before the primary check, so a second non-primary
member of the same group in the same batch remains a no-op. `renderNormalizedGroup`,
the data model, the ETL, and the scroll/hydration error handling are unchanged —
the existing `home-hydrate.ts` handling remains the correct response to a genuine
data-integrity error from another source.

## Tests

In `budget/test/pages/home.test.ts`, inside the existing `normalized transaction
groups` block:

- A direct-call test drives a boundary-straddling pair through
  `renderTransactionRows`: an orphan-only batch (non-primary member) renders
  without throwing and shows neither a group row nor the orphan as a standalone
  transaction; the adjacent batch holding the primary still renders the group
  normally.
- A `renderHome`-level test asserts the table renders (`id="transactions-table"`,
  no `transactions-error` fallback) when a window contains only the orphan
  non-primary member.

`npx vitest run --root budget test/pages/home.test.ts` — 57 passed (55 existing +
2 new). `npx tsc --noEmit --project budget` — clean.
