### PR TITLE
budget: encrypted exports download as .benc; Sankey hydration stops leaking a document listener

### DIFF
--- a/budget/e2e/export.spec.ts
+++ b/budget/e2e/export.spec.ts
@@ -82,7 +82,8 @@ test.describe("export", () => {
 
     const download = await triggerExportDownload(page);
 
-    expect(download.suggestedFilename()).toMatch(/\.benc$/);
+    const today = new Date().toISOString().slice(0, 10);
+    expect(download.suggestedFilename()).toBe(`budget-Test Household-${today}.benc`);
 
     const content = await (await download.createReadStream()).toArray();
     const buf = Buffer.concat(content);

--- a/budget/e2e/export.spec.ts
+++ b/budget/e2e/export.spec.ts
@@ -82,6 +82,8 @@ test.describe("export", () => {
 
     const download = await triggerExportDownload(page);
 
+    expect(download.suggestedFilename()).toMatch(/\.benc$/);
+
     const content = await (await download.createReadStream()).toArray();
     const buf = Buffer.concat(content);
     expect(buf.subarray(0, 4).toString()).toBe("BENC");

--- a/budget/src/main.ts
+++ b/budget/src/main.ts
@@ -407,7 +407,8 @@ exportButton.addEventListener("click", async () => {
     a.href = url;
     const date = new Date().toISOString().slice(0, 10);
     const groupName = state.source === "local" ? state.groupName : "budget";
-    a.download = `budget-${groupName}-${date}.json`;
+    const ext = importPassword ? "benc" : "json";
+    a.download = `budget-${groupName}-${date}.${ext}`;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);

--- a/budget/src/pages/home-chart.ts
+++ b/budget/src/pages/home-chart.ts
@@ -216,6 +216,15 @@ export function hydrateCategorySankey(container: HTMLElement): void {
   }
   const parsed: unknown = JSON.parse(scriptEl.textContent);
   assertChartTransactions(parsed);
+
+  // Remove any prior run's document listener before this run can early-return,
+  // so an empty-data re-hydration cannot leave a stale listener firing with the
+  // previous run's closed-over state (#1267).
+  if (appendedListener) {
+    document.removeEventListener(TRANSACTIONS_APPENDED_EVENT, appendedListener);
+    appendedListener = null;
+  }
+
   const allTxns = parsed;
   if (allTxns.length === 0) {
     container.textContent = "No transaction data to chart.";
@@ -332,9 +341,9 @@ export function hydrateCategorySankey(container: HTMLElement): void {
   // update and the table re-filter run as two independent blocks: a failed chart
   // serialization or render must not skip the table re-filter, which is the only
   // thing that re-applies the active filter to scroll-loaded rows (#578).
-  if (appendedListener) {
-    document.removeEventListener(TRANSACTIONS_APPENDED_EVENT, appendedListener);
-  }
+  //
+  // The prior run's listener was already removed near the top of this function
+  // (before the early-return checks); this run just registers its own (#1267).
   appendedListener = ((e: CustomEvent<SerializedChartTransaction[]>) => {
     const newTxns = e.detail;
 

--- a/budget/src/pages/home-chart.ts
+++ b/budget/src/pages/home-chart.ts
@@ -10,6 +10,13 @@ export type ChartMode = "spending" | "credits";
 /** Custom event name dispatched by home-hydrate.ts after scroll-loading older transactions. The chart listens for this to incorporate the new data and re-apply filters. */
 export const TRANSACTIONS_APPENDED_EVENT = "transactions-appended";
 
+/** The currently-registered TRANSACTIONS_APPENDED_EVENT handler.
+ * hydrateCategorySankey re-runs on every navigation back to /transactions
+ * (MutationObserver re-hydrate), so each run removes the prior run's handler
+ * before registering its own — otherwise listeners accumulate, keep dead
+ * containers alive, and re-run filterTable with stale closure state (#1267). */
+let appendedListener: EventListener | null = null;
+
 export interface SerializedChartTransaction {
   category: string;
   /** Dollars. Positive = spending/debit, negative = credit. Credits mode sign-flips to positive for display. */
@@ -325,7 +332,10 @@ export function hydrateCategorySankey(container: HTMLElement): void {
   // update and the table re-filter run as two independent blocks: a failed chart
   // serialization or render must not skip the table re-filter, which is the only
   // thing that re-applies the active filter to scroll-loaded rows (#578).
-  document.addEventListener(TRANSACTIONS_APPENDED_EVENT, ((e: CustomEvent<SerializedChartTransaction[]>) => {
+  if (appendedListener) {
+    document.removeEventListener(TRANSACTIONS_APPENDED_EVENT, appendedListener);
+  }
+  appendedListener = ((e: CustomEvent<SerializedChartTransaction[]>) => {
     const newTxns = e.detail;
 
     // Chart-update block — skipped when the container is gone. Calls render()
@@ -354,7 +364,8 @@ export function hydrateCategorySankey(container: HTMLElement): void {
     } catch (error) {
       setTimeout(() => { throw error; }, 0);
     }
-  }) as EventListener);
+  }) as EventListener;
+  document.addEventListener(TRANSACTIONS_APPENDED_EVENT, appendedListener);
 
   const debounced = makeDebounced();
 

--- a/budget/test/pages/home-chart.test.ts
+++ b/budget/test/pages/home-chart.test.ts
@@ -844,36 +844,47 @@ describe("hydrateCategorySankey", () => {
     const addSpy = vi.spyOn(document, "addEventListener");
     const removeSpy = vi.spyOn(document, "removeEventListener");
 
-    // First hydration — registers a listener.
-    const container1 = makeContainer([txn({ category: "Food", amount: 50 })]);
-    hydrateCategorySankey(container1);
+    try {
+      // First hydration — registers a listener.
+      const container1 = makeContainer([txn({ category: "Food", amount: 50 })]);
+      hydrateCategorySankey(container1);
 
-    // Capture the handler registered by the first hydration.
-    const firstAddCalls = addSpy.mock.calls.filter(([evt]) => evt === TRANSACTIONS_APPENDED_EVENT);
-    expect(firstAddCalls.length).toBeGreaterThanOrEqual(1);
-    const firstHandler = firstAddCalls[firstAddCalls.length - 1][1]; // last add = the one just registered
+      // Capture the handler registered by the first hydration.
+      const firstAddCalls = addSpy.mock.calls.filter(([evt]) => evt === TRANSACTIONS_APPENDED_EVENT);
+      expect(firstAddCalls.length).toBeGreaterThanOrEqual(1);
+      const firstHandler = firstAddCalls[firstAddCalls.length - 1][1]; // last add = the one just registered
 
-    // Record remove-call count after first hydration (may be >0 if earlier tests left a handler).
-    const removeCountAfterFirst = removeSpy.mock.calls.filter(([evt]) => evt === TRANSACTIONS_APPENDED_EVENT).length;
+      // Record remove-call count after first hydration (may be >0 if earlier tests left a handler).
+      const removeCountAfterFirst = removeSpy.mock.calls.filter(([evt]) => evt === TRANSACTIONS_APPENDED_EVENT).length;
 
-    // Second hydration (simulates navigating away and back) — must remove-before-add.
-    document.body.innerHTML = "";
-    const container2 = makeContainer([txn({ category: "Transport", amount: 30 })]);
-    hydrateCategorySankey(container2);
+      // Second hydration (simulates navigating away and back) — must remove-before-add.
+      document.body.innerHTML = "";
+      const container2 = makeContainer([txn({ category: "Transport", amount: 30 })]);
+      hydrateCategorySankey(container2);
 
-    // The second hydration must have removed the handler registered by the first hydration.
-    const removeCallsAfter = removeSpy.mock.calls.filter(([evt]) => evt === TRANSACTIONS_APPENDED_EVENT);
-    expect(removeCallsAfter.length).toBe(removeCountAfterFirst + 1);
-    expect(removeCallsAfter[removeCallsAfter.length - 1][1]).toBe(firstHandler);
+      // The second hydration must have removed the handler registered by the first hydration.
+      const removeCallsAfter = removeSpy.mock.calls.filter(([evt]) => evt === TRANSACTIONS_APPENDED_EVENT);
+      expect(removeCallsAfter.length).toBe(removeCountAfterFirst + 1);
+      expect(removeCallsAfter[removeCallsAfter.length - 1][1]).toBe(firstHandler);
 
-    // And a new addEventListener call must have followed for the second hydration.
-    const addCallsAfter = addSpy.mock.calls.filter(([evt]) => evt === TRANSACTIONS_APPENDED_EVENT);
-    expect(addCallsAfter.length).toBe(firstAddCalls.length + 1);
-    // The new handler must be a fresh closure, not the same reference.
-    expect(addCallsAfter[addCallsAfter.length - 1][1]).not.toBe(firstHandler);
-
-    addSpy.mockRestore();
-    removeSpy.mockRestore();
+      // And a new addEventListener call must have followed for the second hydration.
+      const addCallsAfter = addSpy.mock.calls.filter(([evt]) => evt === TRANSACTIONS_APPENDED_EVENT);
+      expect(addCallsAfter.length).toBe(firstAddCalls.length + 1);
+      // The new handler must be a fresh closure, not the same reference.
+      expect(addCallsAfter[addCallsAfter.length - 1][1]).not.toBe(firstHandler);
+    } finally {
+      // Remove the live handler the second hydration left attached to `document`
+      // before restoring the spies. hydrateCategorySankey registers a module-level
+      // listener that survives `document.body.innerHTML = ""` cleanup, so without
+      // this it would leak into the `transactions-appended event` block below and
+      // re-fire filterTable with a stale closure against a disconnected container.
+      const lastAdd = addSpy.mock.calls.filter(([evt]) => evt === TRANSACTIONS_APPENDED_EVENT).pop();
+      if (lastAdd) {
+        document.removeEventListener(TRANSACTIONS_APPENDED_EVENT, lastAdd[1] as EventListener);
+      }
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    }
   });
 });
 

--- a/budget/test/pages/home-chart.test.ts
+++ b/budget/test/pages/home-chart.test.ts
@@ -17,6 +17,7 @@ import {
   filterByWeeks,
   distinctWeeks,
   hydrateCategorySankey,
+  TRANSACTIONS_APPENDED_EVENT,
 } from "../../src/pages/home-chart";
 
 /** Monday 2025-01-06 00:00 UTC */
@@ -836,6 +837,43 @@ describe("hydrateCategorySankey", () => {
     expect(txnRows[0].style.display).toBe(""); // Food
     expect(txnRows[1].style.display).toBe(""); // Travel
     expect(txnRows[2].style.display).toBe(""); // Gas
+  });
+
+  it("second hydration removes the first listener so only one listener is ever active", () => {
+    // Spy on addEventListener/removeEventListener before any hydration.
+    const addSpy = vi.spyOn(document, "addEventListener");
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    // First hydration — registers a listener.
+    const container1 = makeContainer([txn({ category: "Food", amount: 50 })]);
+    hydrateCategorySankey(container1);
+
+    // Capture the handler registered by the first hydration.
+    const firstAddCalls = addSpy.mock.calls.filter(([evt]) => evt === TRANSACTIONS_APPENDED_EVENT);
+    expect(firstAddCalls.length).toBeGreaterThanOrEqual(1);
+    const firstHandler = firstAddCalls[firstAddCalls.length - 1][1]; // last add = the one just registered
+
+    // Record remove-call count after first hydration (may be >0 if earlier tests left a handler).
+    const removeCountAfterFirst = removeSpy.mock.calls.filter(([evt]) => evt === TRANSACTIONS_APPENDED_EVENT).length;
+
+    // Second hydration (simulates navigating away and back) — must remove-before-add.
+    document.body.innerHTML = "";
+    const container2 = makeContainer([txn({ category: "Transport", amount: 30 })]);
+    hydrateCategorySankey(container2);
+
+    // The second hydration must have removed the handler registered by the first hydration.
+    const removeCallsAfter = removeSpy.mock.calls.filter(([evt]) => evt === TRANSACTIONS_APPENDED_EVENT);
+    expect(removeCallsAfter.length).toBe(removeCountAfterFirst + 1);
+    expect(removeCallsAfter[removeCallsAfter.length - 1][1]).toBe(firstHandler);
+
+    // And a new addEventListener call must have followed for the second hydration.
+    const addCallsAfter = addSpy.mock.calls.filter(([evt]) => evt === TRANSACTIONS_APPENDED_EVENT);
+    expect(addCallsAfter.length).toBe(firstAddCalls.length + 1);
+    // The new handler must be a fresh closure, not the same reference.
+    expect(addCallsAfter[addCallsAfter.length - 1][1]).not.toBe(firstHandler);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
Closes #1267

Fixes two independent defects in the budget app.

## Encrypted export mislabeled

`budget/src/main.ts`: the export click handler builds a BENC binary blob
(`application/octet-stream`) when `importPassword` is set, but always named the
download `budget-<group>-<date>.json`. The artifact was mislabeled for any
non-budget tool and contradicted the `.benc` accept filter on the upload input.
Re-upload still worked via magic-byte sniffing, but the extension was wrong.

The download extension is now derived from `importPassword` — the same flag that
already selects the binary vs. JSON blob — so encrypted exports download as
`.benc` and unencrypted exports keep `.json`. The encrypted e2e test
(`budget/e2e/export.spec.ts`) now also asserts the suggested filename ends in
`.benc`; the unencrypted test continues to pin `…-<today>.json` unchanged.

## Sankey listener leak

`budget/src/pages/home-chart.ts`: every `hydrateCategorySankey` call registered a
permanent `document.addEventListener(TRANSACTIONS_APPENDED_EVENT, …)` that was
never removed. A MutationObserver re-hydrates after every navigation back to
`/transactions`, so stale listeners accumulated — each kept a dead container
alive and re-ran `filterTable` with stale closure state on every scroll-append.

The handler is now stored in a module-level `appendedListener` handle, and each
hydration removes the prior handler before registering its own (remove-before-add),
so at most one listener is ever active. The handler body is unchanged — the
`container.isConnected`-guarded chart-update block and the unconditional
table re-filter block (#578 behavior) are preserved verbatim. A new
`home-chart.test.ts` test hydrates twice and asserts the second hydration removes
the first listener.

## Verification

- `npm run test --prefix budget` — unit suites green, including the new
  listener-accumulation test.
- `budget/e2e/export.spec.ts` — unencrypted test asserts `…-<today>.json`,
  encrypted test now also asserts the `.benc` suffix.
