### PR TITLE
error-sink: extend SENSITIVE_KEY_RE to cover email/phone/ssn/dob/address PII substrings

### DIFF
--- a/firebaseutil/src/error-sink.ts
+++ b/firebaseutil/src/error-sink.ts
@@ -33,10 +33,10 @@ const RESERVED_KEYS = new Set(["operation", "kind", "message", "stack", "code", 
 
 // Strips obviously-sensitive keys from extras by name before serialization.
 // Matches substrings case-insensitively: token, secret, password, auth, key,
-// credential. Note the g flag is intentionally absent — .test() is stateless.
-// Cross-reference: see the RESERVED_KEYS comment above for the residual risk
-// of values stored under non-matching key names.
-const SENSITIVE_KEY_RE = /token|secret|password|auth|key|credential/i;
+// credential, email, phone, ssn, dob, address. Note the g flag is intentionally
+// absent — .test() is stateless. Cross-reference: see the RESERVED_KEYS comment
+// above for the residual risk of values stored under non-matching key names.
+const SENSITIVE_KEY_RE = /token|secret|password|auth|key|credential|email|phone|ssn|dob|address/i;
 
 // Size caps (UTF-16 code units) — must mirror the firestore.rules isValidErrorLog() caps exactly.
 const CAPS = {

--- a/firebaseutil/test/error-sink.test.ts
+++ b/firebaseutil/test/error-sink.test.ts
@@ -365,5 +365,75 @@ describe("createFirestoreErrorSink", () => {
         expect.stringContaining("apiKey"),
       );
     });
+
+    it("strips a key with a PII substring (recipientEmail matches 'email')", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const sink = createFirestoreErrorSink(makeOptions());
+      const ctx = makeContext({ txnId: "123" } as Partial<EnrichedErrorContext>);
+      (ctx as Record<string, unknown>).recipientEmail = "victim@example.com";
+      sink(new Error("boom"), ctx);
+
+      const doc = getWrittenDoc();
+      expect(doc.recipientEmail).toBeUndefined();
+      const extras = JSON.parse(doc.extras as string);
+      expect(extras.recipientEmail).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("recipientEmail"));
+    });
+
+    it("strips a key with a PII substring (phoneNumber matches 'phone')", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const sink = createFirestoreErrorSink(makeOptions());
+      const ctx = makeContext({ txnId: "123" } as Partial<EnrichedErrorContext>);
+      (ctx as Record<string, unknown>).phoneNumber = "555-1234";
+      sink(new Error("boom"), ctx);
+
+      const doc = getWrittenDoc();
+      expect(doc.phoneNumber).toBeUndefined();
+      const extras = JSON.parse(doc.extras as string);
+      expect(extras.phoneNumber).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("phoneNumber"));
+    });
+
+    it("strips a key with a PII substring (userSsn matches 'ssn')", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const sink = createFirestoreErrorSink(makeOptions());
+      const ctx = makeContext({ txnId: "123" } as Partial<EnrichedErrorContext>);
+      (ctx as Record<string, unknown>).userSsn = "000-00-0000";
+      sink(new Error("boom"), ctx);
+
+      const doc = getWrittenDoc();
+      expect(doc.userSsn).toBeUndefined();
+      const extras = JSON.parse(doc.extras as string);
+      expect(extras.userSsn).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("userSsn"));
+    });
+
+    it("strips a key with a PII substring (userDob matches 'dob')", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const sink = createFirestoreErrorSink(makeOptions());
+      const ctx = makeContext({ txnId: "123" } as Partial<EnrichedErrorContext>);
+      (ctx as Record<string, unknown>).userDob = "1990-01-01";
+      sink(new Error("boom"), ctx);
+
+      const doc = getWrittenDoc();
+      expect(doc.userDob).toBeUndefined();
+      const extras = JSON.parse(doc.extras as string);
+      expect(extras.userDob).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("userDob"));
+    });
+
+    it("strips a key with a PII substring (mailingAddress matches 'address')", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const sink = createFirestoreErrorSink(makeOptions());
+      const ctx = makeContext({ txnId: "123" } as Partial<EnrichedErrorContext>);
+      (ctx as Record<string, unknown>).mailingAddress = "1 Main St";
+      sink(new Error("boom"), ctx);
+
+      const doc = getWrittenDoc();
+      expect(doc.mailingAddress).toBeUndefined();
+      const extras = JSON.parse(doc.extras as string);
+      expect(extras.mailingAddress).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("mailingAddress"));
+    });
   });
 });


### PR DESCRIPTION
Closes #1342

## Summary

Extends `SENSITIVE_KEY_RE` in `firebaseutil/src/error-sink.ts` to strip
high-frequency PII field-name substrings — `email`, `phone`, `ssn`, `dob`,
`address` — from `doc.extras` before the error-sink serializes caller context
into Firestore.

`SENSITIVE_KEY_RE` (introduced in #1327 / PR #1339) previously covered only
`token|secret|password|auth|key|credential`. The literal key `email` is already
blocked by `RESERVED_KEYS`, but compound names like `recipientEmail`,
`phoneNumber`, or `emailAddress` slipped through silently. A caller passing
`{ recipientEmail: 'victim@example.com', phoneNumber: '555-1234' }` could
durably write PII into a Firestore error document. These substrings are common
enough that adding them to the regex is a low-cost improvement over the
residual-risk documentation alone.

## Changes

- **`firebaseutil/src/error-sink.ts`** — extend the `SENSITIVE_KEY_RE` literal
  with `email|phone|ssn|dob|address` and update its adjacent comment's
  enumeration. The drop loop and `console.warn` emission are already general
  over the regex, so no code-path change is needed — a matching compound key is
  dropped before serialization and named in a `console.warn`.
- **`firebaseutil/test/error-sink.test.ts`** — add five unit tests (one per new
  substring: `recipientEmail`, `phoneNumber`, `userSsn`, `userDob`,
  `mailingAddress`), each asserting the compound key is absent from `doc.extras`
  and that `console.warn` names it. Mirrors the existing `apiKey`-matches-`key`
  case.

## Verification

- `vitest run --project firebaseutil error-sink` — all 34 cases pass, including
  the 5 new PII-substring cases.

Scope is the two files above only — no Firestore-rules or caller changes.
