### PR TITLE
qa: pin Vite dev port to a fixed 8-slot collision-safe pool

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -751,6 +751,38 @@ find_available_port() {
   find_available_ports 1
 }
 
+# Fixed pool of Vite dev-server ports for QA servers. The claude-in-chrome
+# extension gates navigation per origin (scheme+host+port), so pinning the Vite
+# port to a known 8-slot pool lets the operator approve those 8 origins in Chrome
+# once instead of re-approving a fresh random port every QA session. Emulator
+# ports stay ephemeral (find_available_ports) — the page's own JS reaches them,
+# never the extension, so they never trigger an approval prompt.
+#
+# File-scope globals (not local/readonly) so tests can override them.
+QA_VITE_PORT_POOL=(5170 5171 5172 5173 5174 5175 5176 5177)
+QA_VITE_PORT_LOCK_DIR="${TMPDIR:-/tmp}"
+
+# Sets VITE_PORT and holds an flock on fd 200 for the script's lifetime so
+# concurrent QA workers never select the same pool slot. Errors (does NOT fall
+# back to a random port — that would re-trigger the Chrome approval prompt)
+# when all 8 slots are held.
+claim_fixed_vite_port() {
+  local p lockfile
+  for p in "${QA_VITE_PORT_POOL[@]}"; do
+    lockfile="${QA_VITE_PORT_LOCK_DIR}/qa-vite-port-${p}.lock"
+    exec 200>"$lockfile" || continue
+    if flock -n 200; then
+      if node -e "const net=require('net');const s=net.createServer();s.once('error',()=>process.exit(1));s.listen(${p},'0.0.0.0',()=>s.close(()=>process.exit(0)));" 2>/dev/null; then
+        VITE_PORT="$p"; return 0      # fd 200 stays open in caller, holding the lock
+      fi
+      flock -u 200                    # foreign process owns the port; try next slot
+    fi
+    exec 200>&-
+  done
+  echo "ERROR: all ${#QA_VITE_PORT_POOL[@]} QA Vite ports (${QA_VITE_PORT_POOL[*]}) are in use" >&2
+  return 1
+}
+
 # Print the Remote access block for QA-server startup: the universal localhost
 # URL plus a copy-paste `ssh -L` command forwarding the Vite port and every
 # allocated emulator port to a remote client's localhost, so the served origin

--- a/.claude/skills/dispatch-propagate/scripts/run-qa-server.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-qa-server.sh
@@ -29,8 +29,16 @@ if [ "$USES_AUTH" = true ]; then PORT_COUNT=$((PORT_COUNT + 1)); fi
 if [ "$USES_STORAGE" = true ]; then PORT_COUNT=$((PORT_COUNT + 1)); fi
 if [ "$USES_FUNCTIONS" = true ]; then PORT_COUNT=$((PORT_COUNT + 1)); fi
 
-read -r VITE_PORT EXTRA_PORTS <<< "$(find_available_ports "$PORT_COUNT")"
-echo "Vite dev server will use port $VITE_PORT"
+# Claim the Vite port from a fixed pool (collision-safe via flock, held for the
+# script's lifetime) so the claude-in-chrome extension approves the origin once.
+# Called in the main shell — not a subshell — so the flock'd fd 200 survives.
+claim_fixed_vite_port
+echo "Vite dev server will use port $VITE_PORT (fixed pool — approve once in Chrome)"
+# Emulator ports stay ephemeral — the page's own JS reaches them, never the
+# extension, so they never trigger an approval prompt.
+EMU_PORT_COUNT=$((PORT_COUNT - 1))
+EXTRA_PORTS=""
+[ "$EMU_PORT_COUNT" -gt 0 ] && EXTRA_PORTS="$(find_available_ports "$EMU_PORT_COUNT")"
 
 NAMESPACE=""
 if [ "$USES_FIRESTORE" = true ]; then

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -22101,15 +22101,17 @@ rm -rf "$cvp_lockdir3" "$cvp_results3" "$cvp_stderr3"
 # free slot (post-lock bindability check), not die on the squatted port.
 cvp_lockdir4=$(mktemp -d)
 cvp_squat_port="${CVP_POOL_ARR[0]}"
-node -e "require('net').createServer().listen(${cvp_squat_port},'0.0.0.0');" &
+# The squatter retries on error (so a transient collision can't kill it) and
+# announces readiness by printing READY once bound. We wait for that line rather
+# than bind-probing the port ourselves — a probe would momentarily hold the port
+# and race the squatter's own listen, which is exactly the flake to avoid.
+cvp_squat_out=$(mktemp)
+node -e "const net=require('net');function bind(){const s=net.createServer();s.on('error',()=>setTimeout(bind,50));s.listen(${cvp_squat_port},'0.0.0.0',()=>console.log('READY'));}bind();setInterval(()=>{},1e9);" >"$cvp_squat_out" 2>/dev/null &
 cvp_squat_pid=$!
-# Wait until the squatter has actually bound (the port is no longer bindable).
-for _ in $(seq 1 80); do
-  if node -e "const net=require('net');const s=net.createServer();s.once('error',()=>process.exit(1));s.listen(${cvp_squat_port},'0.0.0.0',()=>s.close(()=>process.exit(0)));" 2>/dev/null; then
-    sleep 0.1
-  else
-    break
-  fi
+# Wait until the squatter reports it has bound the port.
+for _ in $(seq 1 100); do
+  grep -q READY "$cvp_squat_out" 2>/dev/null && break
+  sleep 0.1
 done
 cvp_out4=$(
   source "$SCRIPT_DIR/lib.sh"
@@ -22126,7 +22128,7 @@ else
 fi
 kill "$cvp_squat_pid" 2>/dev/null || true
 wait "$cvp_squat_pid" 2>/dev/null || true
-rm -rf "$cvp_lockdir4"
+rm -rf "$cvp_lockdir4" "$cvp_squat_out"
 
 # ============================================================================
 # dispatch-reconcile-ready tests

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -21922,6 +21922,141 @@ rm -rf "$bw_root"
 rm -rf "$wp_root"
 
 # ============================================================================
+# claim_fixed_vite_port (fixed Vite-port pool) tests
+# ============================================================================
+echo ""
+echo "=== claim_fixed_vite_port (fixed Vite-port pool) ==="
+
+# Isolation: every sub-test sources lib.sh in a subshell, then overrides
+# QA_VITE_PORT_LOCK_DIR (fresh mktemp -d) and QA_VITE_PORT_POOL (a known-free
+# 8-port set discovered via find_available_ports) so the suite never touches a
+# real QA server on 5170–5177 and needs no privileges. The pool/lock-dir are
+# file-scope globals in lib.sh precisely so the overrides take after sourcing.
+cvp_pool=$(source "$SCRIPT_DIR/lib.sh"; find_available_ports 8)
+read -r -a CVP_POOL_ARR <<< "$cvp_pool"
+assert_eq "claim: discovered an 8-member known-free test pool" "8" "${#CVP_POOL_ARR[@]}"
+
+# --- Case 1: single claim returns a pool member -----------------------------
+cvp_lockdir1=$(mktemp -d)
+cvp_out1=$(
+  source "$SCRIPT_DIR/lib.sh"
+  QA_VITE_PORT_LOCK_DIR="$cvp_lockdir1"
+  QA_VITE_PORT_POOL=("${CVP_POOL_ARR[@]}")
+  claim_fixed_vite_port && echo "$VITE_PORT"
+) && cvp_rc1=0 || cvp_rc1=$?
+assert_eq "claim: single claim succeeds (exit 0)" "0" "$cvp_rc1"
+TOTAL=$((TOTAL + 1))
+if [[ " ${CVP_POOL_ARR[*]} " == *" $cvp_out1 "* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: single claim's VITE_PORT ($cvp_out1) is a pool member"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: single claim's VITE_PORT ('$cvp_out1') is not a pool member"
+fi
+rm -rf "$cvp_lockdir1"
+
+# --- Case 2: 8 concurrent claims yield 8 distinct ports ---------------------
+# Each worker claims, records its port, then sleeps to HOLD its flock while the
+# siblings race — without the hold a fast worker could release and a slow one
+# reuse the same slot, masking a collision.
+cvp_lockdir2=$(mktemp -d)
+cvp_results2=$(mktemp -d)
+for i in $(seq 1 8); do
+  (
+    source "$SCRIPT_DIR/lib.sh"
+    QA_VITE_PORT_LOCK_DIR="$cvp_lockdir2"
+    QA_VITE_PORT_POOL=("${CVP_POOL_ARR[@]}")
+    if claim_fixed_vite_port; then
+      echo "$VITE_PORT" > "$cvp_results2/$i"
+      sleep 3
+    fi
+  ) &
+done
+wait
+cvp_total2=$(find "$cvp_results2" -type f | wc -l | tr -d ' ')
+cvp_distinct2=$(find "$cvp_results2" -type f -exec cat {} + 2>/dev/null | sort -un | sed '/^$/d' | wc -l | tr -d ' ')
+assert_eq "claim: 8 concurrent claims all succeed" "8" "$cvp_total2"
+assert_eq "claim: 8 concurrent claims yield 8 distinct ports" "8" "$cvp_distinct2"
+rm -rf "$cvp_lockdir2" "$cvp_results2"
+
+# --- Case 3: 9th claim errors, no random-port fallback ----------------------
+# Hold all 8 slots with background workers, then a 9th claim must exit non-zero,
+# print the "all … in use" diagnostic, and leave VITE_PORT unset (no fallback).
+cvp_lockdir3=$(mktemp -d)
+cvp_results3=$(mktemp -d)
+for i in $(seq 1 8); do
+  (
+    source "$SCRIPT_DIR/lib.sh"
+    QA_VITE_PORT_LOCK_DIR="$cvp_lockdir3"
+    QA_VITE_PORT_POOL=("${CVP_POOL_ARR[@]}")
+    if claim_fixed_vite_port; then
+      echo "$VITE_PORT" > "$cvp_results3/$i"
+      sleep 4
+    fi
+  ) &
+done
+# Wait until all 8 holders have actually claimed before racing the 9th.
+for _ in $(seq 1 80); do
+  [ "$(find "$cvp_results3" -type f | wc -l | tr -d ' ')" -eq 8 ] && break
+  sleep 0.1
+done
+cvp_stderr3=$(mktemp)
+cvp_9th_out=$(
+  source "$SCRIPT_DIR/lib.sh"
+  QA_VITE_PORT_LOCK_DIR="$cvp_lockdir3"
+  QA_VITE_PORT_POOL=("${CVP_POOL_ARR[@]}")
+  unset VITE_PORT
+  if claim_fixed_vite_port 2>"$cvp_stderr3"; then
+    echo "0 ${VITE_PORT:-UNSET}"
+  else
+    echo "1 ${VITE_PORT:-UNSET}"
+  fi
+)
+wait
+cvp_9th_rc="${cvp_9th_out%% *}"
+cvp_9th_port="${cvp_9th_out#* }"
+assert_eq "claim: 9th claim (all slots held) exits non-zero" "1" "$cvp_9th_rc"
+assert_eq "claim: 9th claim leaves VITE_PORT unset (no random-port fallback)" "UNSET" "$cvp_9th_port"
+TOTAL=$((TOTAL + 1))
+if grep -q "all .* QA Vite ports .* are in use" "$cvp_stderr3"; then
+  PASS=$((PASS + 1)); echo "  PASS: 9th claim prints the 'all … in use' diagnostic"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 9th claim did not print the expected diagnostic"
+  echo "    stderr: '$(cat "$cvp_stderr3")'"
+fi
+rm -rf "$cvp_lockdir3" "$cvp_results3" "$cvp_stderr3"
+
+# --- Case 4: a foreign squatter on a pool port is skipped -------------------
+# Bind the first pool port with a foreign listener; a claim must win the NEXT
+# free slot (post-lock bindability check), not die on the squatted port.
+cvp_lockdir4=$(mktemp -d)
+cvp_squat_port="${CVP_POOL_ARR[0]}"
+node -e "require('net').createServer().listen(${cvp_squat_port},'0.0.0.0');" &
+cvp_squat_pid=$!
+# Wait until the squatter has actually bound (the port is no longer bindable).
+for _ in $(seq 1 80); do
+  if node -e "const net=require('net');const s=net.createServer();s.once('error',()=>process.exit(1));s.listen(${cvp_squat_port},'0.0.0.0',()=>s.close(()=>process.exit(0)));" 2>/dev/null; then
+    sleep 0.1
+  else
+    break
+  fi
+done
+cvp_out4=$(
+  source "$SCRIPT_DIR/lib.sh"
+  QA_VITE_PORT_LOCK_DIR="$cvp_lockdir4"
+  QA_VITE_PORT_POOL=("${CVP_POOL_ARR[@]}")
+  claim_fixed_vite_port && echo "$VITE_PORT"
+) && cvp_rc4=0 || cvp_rc4=$?
+assert_eq "claim: squatted pool port → claim succeeds on next slot (exit 0)" "0" "$cvp_rc4"
+TOTAL=$((TOTAL + 1))
+if [[ "$cvp_out4" != "$cvp_squat_port" && " ${CVP_POOL_ARR[*]} " == *" $cvp_out4 "* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: claim skipped the squatted port ($cvp_squat_port), took $cvp_out4"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: claim returned '$cvp_out4' (squatted port was $cvp_squat_port)"
+fi
+kill "$cvp_squat_pid" 2>/dev/null || true
+wait "$cvp_squat_pid" 2>/dev/null || true
+rm -rf "$cvp_lockdir4"
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results


### PR DESCRIPTION
Closes #1349

## Summary

`run-qa-server.sh` allocated **every** port — the Vite dev server and the
Firebase emulators — through `find_available_ports()`, which binds to port `0`
and takes whatever ephemeral port the OS hands back. So the Vite dev server
landed on a fresh random port every run.

The `claude-in-chrome` extension gates `navigate` / `tabs_create_mcp` /
`computer` / `javascript_tool` / `gif_creator` **per origin**
(`scheme+host+port`). A fresh random Vite port every run is a fresh origin every
run, so the operator had to re-approve the extension popup on every QA session.

Only the **Vite port** is an origin the extension navigates to. Emulator ports
are reached by the page's own JS (fetch / Firestore WebChannel), never by the
extension, so they never trigger an approval prompt. This PR pins **only** the
Vite port to a known 8-slot pool (`5170`–`5177`): the operator approves those 8
origins in Chrome once and never again. Emulator ports stay ephemeral so
concurrent QA servers across worktrees never collide.

## How

- **`lib.sh`** — adds the fixed 8-member pool (`QA_VITE_PORT_POOL`), a lock
  directory (`QA_VITE_PORT_LOCK_DIR`), and `claim_fixed_vite_port`. The helper
  walks the pool and, for each candidate, acquires a non-blocking `flock` on a
  per-port lockfile held on fd 200 for the script's lifetime. **The lock, not
  the bind, is the claim** — `flock` arbitrates atomically, so two concurrent
  workers can never select the same slot, closing the TOCTOU race for up to 8
  concurrent workers. A post-lock bindability check skips a pool port squatted
  by a foreign process. When all 8 slots are held it errors loudly and does
  **not** fall back to a random port (which would re-trigger the Chrome prompt).

- **`run-qa-server.sh`** — calls `claim_fixed_vite_port` in the main shell (not a
  subshell, so the `flock`'d fd survives the script's lifetime) for the Vite
  port, and keeps the emulator ports ephemeral via `find_available_ports`. Under
  `set -euo pipefail` an all-slots-held failure aborts loudly. Vite still
  launches with `--strictPort` as the backstop for a slot lost to a foreign
  process between the bindability check and Vite's own bind.

- **`test-dispatch-scripts.sh`** — covers the four acceptance criteria: a single
  claim returns a pool member; 8 concurrent claims yield 8 distinct ports; a 9th
  claim (all slots held) exits non-zero with the "all … in use" diagnostic and
  no random-port fallback; a foreign squatter on a pool port is skipped. Each
  case isolates via a fresh lock-dir and a known-free pool discovered through
  `find_available_ports`, so the suite never touches the real `5170`–`5177` pool.

`run-acceptance-tests.sh` is intentionally **unchanged** — Playwright runs inside
WSL with no extension, so its `find_available_ports` allocation is fine.

## Verification

- `bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` —
  full suite green (2115/2115), confirmed stable across 5 consecutive runs.
- `bash -n` clean on `lib.sh`, `run-qa-server.sh`, and `test-dispatch-scripts.sh`.
