### PR TITLE
firestore.rules: cap qa/emulator error-log env suffixes to 32 chars

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -314,8 +314,8 @@ service cloud.firestore {
         || env == "demo"
         || env == "test"
         || env.matches("preview-pr-[0-9]{1,6}")
-        || env.matches("qa(-[a-z0-9._-]+)?")    // suffix optional: bare "qa" is the main-worktree env
-        || env.matches("emulator(-[a-z0-9._-]+)?");  // suffix optional: bare "emulator" is the main-worktree env
+        || env.matches("qa(-[a-z0-9._-]{1,32})?")    // suffix optional: bare "qa" is the main-worktree env
+        || env.matches("emulator(-[a-z0-9._-]{1,32})?");  // suffix optional: bare "emulator" is the main-worktree env
     }
     function isOptionalString(data, field, maxLen) {
       return !(field in data)

--- a/rules-test/test/firestore/errors.test.ts
+++ b/rules-test/test/firestore/errors.test.ts
@@ -255,6 +255,38 @@ describe("error logs", () => {
         setDoc(doc(db, "budget/emulator-/errors/err1"), validErrorDoc()),
       );
     });
+
+    it("allows qa-<32-char suffix> env (at cap)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `budget/qa-${"a".repeat(32)}/errors/err1`), validErrorDoc()),
+      );
+    });
+
+    it("denies qa-<33-char suffix> env (over cap)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/qa-${"a".repeat(33)}/errors/err1`), validErrorDoc()),
+      );
+    });
+
+    it("allows emulator-<32-char suffix> env (at cap)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `budget/emulator-${"a".repeat(32)}/errors/err1`), validErrorDoc()),
+      );
+    });
+
+    it("denies emulator-<33-char suffix> env (over cap)", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/emulator-${"a".repeat(33)}/errors/err1`), validErrorDoc()),
+      );
+    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1344

## Summary

Caps the `qa-*` and `emulator-*` error-log env suffixes in `isKnownErrorEnv`
(`firestore.rules`) at 32 characters, closing an effectively-unbounded
unauthenticated-write namespace.

`isKnownErrorEnv` pins the error-log `{env}` path segment to a known-env
allowlist (the cost/DoS backstop from #1296, since unauthenticated error creates
are allowed). Two of its allowed shapes used the unbounded `+` quantifier on
their optional suffix:

- `qa(-[a-z0-9._-]+)?`
- `emulator(-[a-z0-9._-]+)?`

An attacker could iterate across arbitrarily many distinct env values (`qa-a`,
`qa-b`, `qa-aaaa…`, etc.) across all 5 apps, each env allowing writes up to the
~73 KB per-doc cap from #1320.

This mirrors the original unbounded `preview-pr-[0-9]+` risk that #1326 fixed
(via merged PR #1336, bounding it to `preview-pr-[0-9]{1,6}`). This follow-up
applies the same length-bounding to the `qa-*` and `emulator-*` sub-namespaces:

- `qa(-[a-z0-9._-]{1,32})?`
- `emulator(-[a-z0-9._-]{1,32})?`

32 chars covers all realistic worktree/branch identifiers (the longest
CI-generated suffix seen is ~20 chars) while blocking contrived large values.
Firestore rules use RE2, which supports `{n,m}` quantifiers.

## Changes

- **`firestore.rules`** — bound the `qa`/`emulator` suffix quantifiers from `+`
  to `{1,32}` in `isKnownErrorEnv`. The `preview-pr-[0-9]{1,6}` line and the
  surrounding comment block are unchanged.
- **`rules-test/test/firestore/errors.test.ts`** — add four boundary cases
  mirroring the existing `preview-pr-123456`/`preview-pr-1234567` pair: a 32-char
  suffix (allowed) and a 33-char suffix (denied) for each of `qa-` and
  `emulator-`.

## Verification

- `run-rules-check.sh` — rules syntax check passes.
- `rules-test` suite (`errors.test.ts`) — 85/85 pass, including the four new
  boundary cases. (The suite is not in CI; run manually.)
