### PR TITLE
budget-etl: dedup statements by StatementID, error on balance disagreement

### DIFF
--- a/budget-etl/main.go
+++ b/budget-etl/main.go
@@ -151,6 +151,10 @@ func runDirJSON(dir, groupName string, disc parse.DiscoverOpts, output fileOpts)
 	maxDates := maxTransactionDates(allTxns)
 	allStmts := buildStatementData(parsed, maxDates)
 	allStmts = append(allStmts, deriveMonthlyStatements(parsed)...)
+	allStmts, err = dedupStatementData(allStmts)
+	if err != nil {
+		return fmt.Errorf("statements: %w", err)
+	}
 
 	return runOutputJSON(allTxns, allStmts, groupName, output)
 }
@@ -1059,6 +1063,10 @@ func runMerge(input fileOpts, dir, groupName string, disc parse.DiscoverOpts, ou
 	// Build statements from dir-parsed files (maxDates computed later after merge)
 	dirStmts := buildStatementData(parsed, nil)
 	dirStmts = append(dirStmts, deriveMonthlyStatements(parsed)...)
+	dirStmts, err = dedupStatementData(dirStmts)
+	if err != nil {
+		return fmt.Errorf("statements: %w", err)
+	}
 
 	// Build input lookup by doc ID
 	inputByID := make(map[string]export.Transaction, len(inp.Transactions))

--- a/budget-etl/main_test.go
+++ b/budget-etl/main_test.go
@@ -338,21 +338,29 @@ func TestApplyTransactionRulesSkippedByGeneral(t *testing.T) {
 	}
 }
 
-// writeCSVFixture writes a minimal bank statement CSV file to path.
+// writeCSVFixtureBalance writes a minimal bank statement CSV file to path with
+// a caller-specified ending balance in the metadata header line.
 // Each entry is [date, amount, description, "", txnID, type].
-func writeCSVFixture(t *testing.T, path string, rows [][6]string) {
+func writeCSVFixtureBalance(t *testing.T, path, balance string, rows [][6]string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatalf("creating fixture dir: %v", err)
 	}
 	var lines []string
-	lines = append(lines, "0000000000,2025/01/01,2025/01/31,100.00,50.00")
+	lines = append(lines, "0000000000,2025/01/01,2025/01/31,100.00,"+balance)
 	for _, r := range rows {
 		lines = append(lines, strings.Join(r[:], ","))
 	}
 	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
 		t.Fatalf("writing fixture: %v", err)
 	}
+}
+
+// writeCSVFixture writes a minimal bank statement CSV file to path.
+// Each entry is [date, amount, description, "", txnID, type].
+func writeCSVFixture(t *testing.T, path string, rows [][6]string) {
+	t.Helper()
+	writeCSVFixtureBalance(t, path, "50.00", rows)
 }
 
 func TestRunMerge(t *testing.T) {
@@ -633,6 +641,62 @@ func TestRunMergeDedupOverlappingFiles(t *testing.T) {
 	}
 	if ids[docUnique] != 1 {
 		t.Errorf("TXN-UNIQUE: expected 1 occurrence, got %d", ids[docUnique])
+	}
+
+	// Both overlapping CSV files share the same statementId; they must collapse
+	// to exactly one deduped statement record.
+	if len(out.Statements) != 1 {
+		t.Fatalf("expected 1 statement (deduped), got %d", len(out.Statements))
+	}
+	wantStmtID := "test_bank-1234-2025-01"
+	if out.Statements[0].StatementID != wantStmtID {
+		t.Errorf("statement.statementId = %q, want %q", out.Statements[0].StatementID, wantStmtID)
+	}
+	wantDocID := budget.StatementDocID(wantStmtID)
+	if out.Statements[0].ID != wantDocID {
+		t.Errorf("statement.id = %q, want %q", out.Statements[0].ID, wantDocID)
+	}
+}
+
+func TestRunMergeErrorsOnBalanceDisagreement(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Two overlapping CSV files for the same institution/account/period — same
+	// statementId — but with different ending balances. dedupStatementData must
+	// detect the balance disagreement and return an error.
+	stmtID := "test_bank-1234-2025-01"
+	csv1 := filepath.Join(tmp, "statements", "test_bank", "1234", "2025-01", "download1.csv")
+	writeCSVFixtureBalance(t, csv1, "50.00", [][6]string{
+		{"2025/01/10", "5.00", "SHARED PURCHASE", "", "TXN-OVERLAP", "DEBIT"},
+	})
+	csv2 := filepath.Join(tmp, "statements", "test_bank", "1234", "2025-01", "download2.csv")
+	writeCSVFixtureBalance(t, csv2, "75.00", [][6]string{
+		{"2025/01/10", "5.00", "SHARED PURCHASE", "", "TXN-OVERLAP", "DEBIT"},
+	})
+
+	inputJSON := export.Output{
+		Version:      1,
+		GroupName:    "test-group",
+		Transactions: []export.Transaction{},
+		Rules: []export.Rule{
+			{ID: "cat-all", Type: "categorization", Pattern: "PURCHASE", Target: "Test:General", Priority: 10},
+		},
+	}
+	inputPath := filepath.Join(tmp, "input.json")
+	if err := export.WriteFile(inputPath, inputJSON, ""); err != nil {
+		t.Fatalf("writing input JSON: %v", err)
+	}
+
+	outputPath := filepath.Join(tmp, "output.json")
+	err := runMerge(fileOpts{path: inputPath}, filepath.Join(tmp, "statements"), "", parse.DiscoverOpts{}, fileOpts{path: outputPath})
+	if err == nil {
+		t.Fatal("runMerge: expected error for balance disagreement, got nil")
+	}
+	if !strings.Contains(err.Error(), stmtID) {
+		t.Errorf("error %q does not mention statementId %q", err.Error(), stmtID)
+	}
+	if !strings.Contains(err.Error(), "balance disagreement") {
+		t.Errorf("error %q does not contain 'balance disagreement'", err.Error())
 	}
 }
 

--- a/budget-etl/pipeline.go
+++ b/budget-etl/pipeline.go
@@ -57,6 +57,42 @@ func parseStatementDir(dir string, disc parse.DiscoverOpts) (parsed []parsedFile
 	return parsed, totalTxns, skipped, nil
 }
 
+// dedupStatementData deduplicates a slice of StatementData by StatementID,
+// preserving first-seen order. When two entries share a StatementID but have
+// different Balance values, it returns an error naming both source files and
+// balances so the caller can surface a clear failure rather than emitting
+// conflicting records. Equal-balance duplicates are silently dropped.
+func dedupStatementData(stmts []budget.StatementData) ([]budget.StatementData, error) {
+	seen := make(map[string]budget.StatementData, len(stmts))
+	out := make([]budget.StatementData, 0, len(stmts))
+	for _, s := range stmts {
+		prior, dup := seen[s.StatementID]
+		if !dup {
+			seen[s.StatementID] = s
+			out = append(out, s)
+			continue
+		}
+		if s.Balance == prior.Balance {
+			continue
+		}
+		srcA := prior.SourceFile
+		if srcA == "" {
+			srcA = "<derived>"
+		}
+		srcB := s.SourceFile
+		if srcB == "" {
+			srcB = "<derived>"
+		}
+		return nil, fmt.Errorf(
+			"statement %q: balance disagreement between %s ($%.2f) and %s ($%.2f)",
+			s.StatementID,
+			srcA, budget.DollarAmount(prior.Balance),
+			srcB, budget.DollarAmount(s.Balance),
+		)
+	}
+	return out, nil
+}
+
 // buildTransactions iterates parsed files and deduplicates transactions by
 // transaction doc ID: overlapping statement files (same statementId) can
 // produce duplicate transactions with the same OFX FITID. The visit callback


### PR DESCRIPTION
Closes #1272

## Problem

`budget-etl` dedups *transactions* by doc ID, but emits one `budget.StatementData`
per parsed file and never dedups the statement side. When two overlapping
downloads cover the same period (same `institution-account-period`, hence the
same `StatementID`), each produces a `StatementData` with that identical
`StatementID`. The result is two `export.Statement` entries with the same `ID`
(`StatementDocID(StatementID)`) and possibly different `Balance` — downstream
stores keyed by `id` pick one arbitrarily.

Neither statement-building path deduped:

- `runDirJSON` built `buildStatementData(...)` + `deriveMonthlyStatements(...)`
  and wrote them as-is.
- `runMerge` → `mergeStatements` built `dirByStmtID` only to filter *input*
  statements, passing the dir side through undeduped.

The existing `TestRunMergeDedupOverlappingFiles` asserted transaction count but
never statement count.

## Change

- **`dedupStatementData` helper** (`budget-etl/pipeline.go`), mirroring
  `buildTransactions`'s `seen`-map dedup shape. It dedups statements by
  `StatementID`, preserving first-seen order. On a duplicate `StatementID` it
  compares `Balance` (the `int64` cents field — exact integer comparison): equal
  balances collapse to one statement; disagreeing balances return an error naming
  the `StatementID`, both balances (rendered via `budget.DollarAmount`), and both
  source files (falling back to `<derived>` for derived anchors with no
  `SourceFile`). This follows the clear-errors-over-fallbacks rule rather than
  emitting both records arbitrarily.
- **Wired into both call sites** (`runDirJSON` and `runMerge` in
  `budget-etl/main.go`), deduping the *combined* per-file + derived-monthly slice
  after the `append`, propagating the error. `mergeStatements`'s signature is
  unchanged — it now receives a pre-deduped `dirStmts`.

Deduping the combined slice covers both the per-file collision and the
multi-month derived-anchor collision (two files each derive earlier-month anchors
with the same StatementIDs) uniformly.

## Tests

- `TestRunMergeDedupOverlappingFiles` now asserts `len(out.Statements) == 1`
  after an overlapping-files merge, plus the deduped statement's `StatementID` /
  `ID`.
- New `TestRunMergeErrorsOnBalanceDisagreement` writes two overlapping files for
  one period with differing balances and asserts `runMerge` returns an error
  naming the conflicting `StatementID`.

## Acceptance criteria

- [x] Statements are deduped by `StatementID` alongside transactions.
- [x] When two files for one statement disagree on balance, the run errors rather
  than emitting both.
- [x] A test asserts statement count after an overlapping-files merge.
