### PR TITLE
budget-etl: gate transfer-pair merging on a Transfer:* leg

### DIFF
--- a/budget-etl/internal/journal/journal.go
+++ b/budget-etl/internal/journal/journal.go
@@ -6,9 +6,10 @@
 // imported bank account and a balancing counter leg on a placeholder account
 // (Uncategorized Expense / Uncategorized Income, or Unresolved Transfers for
 // Transfer:* lines). After per-line emission, the batch is scanned for transfer
-// pairs — opposite-sign amounts on different accounts within a time window —
-// and each matched pair is merged into a single entry that debits the
-// destination account and credits the source account, dropping the placeholders.
+// pairs — opposite-sign amounts on different accounts within a time window,
+// where at least one leg is categorized Transfer:* — and each matched pair is
+// merged into a single entry that debits the destination account and credits
+// the source account, dropping the placeholders.
 package journal
 
 import (
@@ -232,10 +233,11 @@ type pair struct {
 
 // detectPairs finds transfer pairs via greedy nearest-time matching. A
 // candidate pair has different (institution, account), opposite-sign amounts
-// equal within a one-cent tolerance, and |Δtimestamp| <= window. Candidates are
-// consumed in ascending timestamp-delta order, skipping lines already taken, so
-// two pairs in one window match to their nearest partner. Marks matched
-// tentatives as paired and returns the chosen pairs.
+// equal within a one-cent tolerance, at least one leg categorized Transfer:*,
+// and |Δtimestamp| <= window. Candidates are consumed in ascending
+// timestamp-delta order, skipping lines already taken, so two pairs in one
+// window match to their nearest partner. Marks matched tentatives as paired and
+// returns the chosen pairs.
 func detectPairs(tents []*tentative, window time.Duration) []pair {
 	type candidate struct {
 		i, j  int
@@ -255,6 +257,11 @@ func detectPairs(tents []*tentative, window time.Duration) []pair {
 			}
 			// Equal magnitude within tolerance.
 			if absInt64(a.txn.Amount+b.txn.Amount) > centTolerance {
+				continue
+			}
+			// At least one leg must be categorized Transfer:* to merge — otherwise two
+			// unrelated equal-and-opposite amounts would be falsely merged.
+			if !a.isTransfer && !b.isTransfer {
 				continue
 			}
 			delta := a.txn.Timestamp.Sub(b.txn.Timestamp)

--- a/budget-etl/internal/journal/journal_test.go
+++ b/budget-etl/internal/journal/journal_test.go
@@ -503,6 +503,56 @@ func TestUnrelatedSameAmountNotMerged(t *testing.T) {
 	}
 }
 
+func TestOneLegTransferOneLegNot(t *testing.T) {
+	// A real-world transfer where only one leg carries the Transfer:* category:
+	// the outflow is categorized Transfer:Savings, but the matching inflow
+	// arrives as a plain "Deposit". A single Transfer:* leg is sufficient to
+	// merge — the gate requires at least one transfer leg, not both.
+	txns := []budget.TransactionData{
+		{ // outflow categorized as a transfer
+			Institution:   "Example Bank",
+			Account:       "Checking",
+			Description:   "Transfer to Savings",
+			Amount:        30000,
+			Timestamp:     ts("2025-02-18"),
+			StatementID:   "s",
+			TransactionID: "out",
+			Category:      "Transfer:Savings",
+		},
+		{ // inflow NOT categorized as a transfer
+			Institution:   "Example Credit Union",
+			Account:       "Savings",
+			Description:   "Deposit",
+			Amount:        -30000,
+			Timestamp:     ts("2025-02-19"),
+			StatementID:   "s",
+			TransactionID: "in",
+			Category:      "Deposit",
+		},
+	}
+	r := Build(txns, nil, nil, DefaultPairWindow)
+
+	if len(r.Entries) != 1 {
+		t.Fatalf("expected 1 merged entry (one Transfer:* leg is sufficient), got %d", len(r.Entries))
+	}
+	if len(r.Legs) != 2 {
+		t.Fatalf("expected 2 legs, got %d", len(r.Legs))
+	}
+	assertBalanced(t, r.Legs)
+
+	// No Unresolved Transfers placeholder — the pair matched.
+	if _, ok := accountIDs(r.Accounts)[acctUnresolvedTransfers]; ok {
+		t.Errorf("Unresolved Transfers should not be emitted for a matched pair")
+	}
+
+	// Both docIDs map to the single merged entry.
+	docOut := budget.TransactionDocID("s", "out")
+	docIn := budget.TransactionDocID("s", "in")
+	if r.EntryIDByDocID[docOut] != r.Entries[0].ID || r.EntryIDByDocID[docIn] != r.Entries[0].ID {
+		t.Errorf("both docIDs should map to the merged entry")
+	}
+}
+
 func TestNonPrimaryNormalizedDuplicateSkipped(t *testing.T) {
 	// One real purchase appears in two overlapping statements with different
 	// statement IDs. rules.ApplyNormalization marks one member primary and the

--- a/budget-etl/internal/journal/journal_test.go
+++ b/budget-etl/internal/journal/journal_test.go
@@ -440,6 +440,69 @@ func TestIdempotency(t *testing.T) {
 	}
 }
 
+func TestUnrelatedSameAmountNotMerged(t *testing.T) {
+	// A positive spending line on one account and a negative income line on a
+	// different account — same magnitude, timestamps one day apart (well within
+	// DefaultPairWindow) — must NOT merge because neither is Transfer:*.
+	txns := []budget.TransactionData{
+		{
+			Institution:   "Example Bank",
+			Account:       "Credit Card",
+			Description:   "Grocery Store",
+			Amount:        2500, // spending
+			Timestamp:     ts("2025-03-01"),
+			StatementID:   "s",
+			TransactionID: "grocery",
+			Category:      "Groceries",
+		},
+		{
+			Institution:   "Example Bank",
+			Account:       "Checking",
+			Description:   "Refund",
+			Amount:        -2500, // income / credit
+			Timestamp:     ts("2025-03-02"),
+			StatementID:   "s",
+			TransactionID: "refund",
+			Category:      "Income",
+		},
+	}
+	r := Build(txns, nil, DefaultPairWindow)
+
+	if len(r.Entries) != 2 {
+		t.Fatalf("expected 2 distinct entries (not merged), got %d", len(r.Entries))
+	}
+	assertBalanced(t, r.Legs)
+
+	byEntry := legsByEntry(r.Legs)
+	for _, e := range r.Entries {
+		assertBalanced(t, byEntry[e.ID])
+	}
+
+	ids := accountIDs(r.Accounts)
+
+	// Neither line is Transfer:* — Unresolved Transfers must not appear.
+	if _, ok := ids[acctUnresolvedTransfers]; ok {
+		t.Errorf("Unresolved Transfers should not be emitted for unrelated non-transfer lines")
+	}
+
+	// The spending line lands on Uncategorized Expense; the income line on
+	// Uncategorized Income.
+	if ids[acctUncategorizedExpense] != "expense" {
+		t.Errorf("Uncategorized Expense should be emitted for the spending line, got %q", ids[acctUncategorizedExpense])
+	}
+	if ids[acctUncategorizedIncome] != "income" {
+		t.Errorf("Uncategorized Income should be emitted for the income line, got %q", ids[acctUncategorizedIncome])
+	}
+
+	// Each entry must have exactly 2 legs (single-line tentative form).
+	for _, e := range r.Entries {
+		legs := byEntry[e.ID]
+		if len(legs) != 2 {
+			t.Errorf("entry %s should have 2 legs, got %d", e.ID, len(legs))
+		}
+	}
+}
+
 func TestEmptyInputNonNilSlices(t *testing.T) {
 	r := Build(nil, nil, DefaultPairWindow)
 	if r.Entries == nil || r.Legs == nil || r.Accounts == nil {


### PR DESCRIPTION
Closes #1273

## Problem

`detectPairs` (`budget-etl/internal/journal/journal.go`) merged two tentative
lines into a single transfer entry whenever they had different accounts,
opposite-sign amounts equal within one cent, and timestamps within the pair
window — without ever consulting whether either line was actually categorized as
a transfer.

The consequence: an unrelated $25.00 grocery purchase on a card and a $25.00
refund on checking in the same week (opposite signs, equal magnitude, different
accounts, neither a transfer) silently merged into one transfer entry, erasing
both the expense and the income from the books.

The `tentative.isTransfer` field was already computed from the line's category
but used only for placeholder selection — never in pair detection. That
dead-end field reflected the intent drift the issue notes.

## Change

Gate pair detection on at least one leg being categorized `Transfer:*`. A new
guard in the candidate loop, placed among the existing `continue` checks, skips
any pair where **neither** leg is a transfer:

```go
// At least one leg must be categorized Transfer:* to merge — otherwise two
// unrelated equal-and-opposite amounts would be falsely merged.
if !a.isTransfer && !b.isTransfer {
    continue
}
```

This reuses the already-computed `isTransfer` field — no recomputation from the
category — giving it a second real use and resolving the intent drift.

The `detectPairs` doc comment and the package doc comment's pairing description
are updated to state the new requirement.

## Test

`TestUnrelatedSameAmountNotMerged` asserts that two unrelated same-amount,
opposite-sign, non-transfer lines on different accounts (one day apart, well
within `DefaultPairWindow`) produce **2** distinct entries — landing on the
`Uncategorized Expense` / `Uncategorized Income` placeholders rather than a
single merged transfer — instead of 1.

All existing transfer-pair tests (`TestMatchingPairMerge`,
`TestTwoCandidatePairsNearestTime`, `TestPairWindowExcludesFarApart`) use
`Transfer:*` categories, so they still satisfy the new gate and merge unchanged.

## Verification

`go test ./...` from `budget-etl/` passes — all 10 journal tests and all 9
module packages green.
