### PR TITLE
budget-etl: mark derived monthly anchors Virtual so they never shadow real statements

### DIFF
--- a/budget-etl/internal/budget/budget.go
+++ b/budget-etl/internal/budget/budget.go
@@ -21,6 +21,10 @@ type StatementData struct {
 	// statement file this data was parsed from; empty for ETL-synthesized
 	// statements (e.g. derived balance anchors).
 	SourceFile string
+	// Virtual marks an ETL-synthesized statement (e.g. a derived monthly balance
+	// anchor) so it can be distinguished from a real parsed statement. Real
+	// statements leave this false.
+	Virtual bool
 }
 
 // StatementDocID generates a deterministic document ID from a statement ID

--- a/budget-etl/main.go
+++ b/budget-etl/main.go
@@ -1193,7 +1193,11 @@ func runMerge(input fileOpts, dir, groupName string, disc parse.DiscoverOpts, ou
 }
 
 // mergeStatements merges dir-parsed statements with input statements.
-// Dir statements override input by statementID; input-only statements are retained.
+// Merge priority by statementID: real dir > real input > derived/virtual anchor.
+// A real dir statement overrides the stale snapshot copy of the same ID. A
+// derived/virtual anchor never shadows a real statement (dir or input); it
+// gap-fills only — emitted solely for a period with no real statement. Virtual
+// input statements (stale prior-snapshot anchors) are skipped and recomputed.
 // Uses maxDates to set LastTransactionDate on all statements (dir and input-only).
 func mergeStatements(dirStmts []budget.StatementData, inputStmts []export.Statement, maxDates map[string]*time.Time) []export.Statement {
 	for i := range dirStmts {
@@ -1202,14 +1206,33 @@ func mergeStatements(dirStmts []budget.StatementData, inputStmts []export.Statem
 	}
 	dirExport := buildExportStatements(dirStmts)
 
-	dirByStmtID := make(map[string]bool, len(dirExport))
+	// realDirByStmtID tracks the IDs of non-virtual (real) dir statements so a
+	// stale input copy of the same ID is dropped in favor of the real dir one.
+	realDirByStmtID := make(map[string]bool, len(dirExport))
 	for _, s := range dirExport {
-		dirByStmtID[s.StatementID] = true
+		if !s.Virtual {
+			realDirByStmtID[s.StatementID] = true
+		}
 	}
 
-	result := dirExport
+	// covered tracks IDs already emitted by a real statement (dir or input), so
+	// a derived anchor only fills periods with no real statement.
+	covered := make(map[string]bool, len(dirExport))
+
+	// Seed result with the real (non-virtual) dir statements.
+	var result []export.Statement
+	for _, s := range dirExport {
+		if s.Virtual {
+			continue
+		}
+		result = append(result, s)
+		covered[s.StatementID] = true
+	}
+
+	// Real input statements: skip virtual ones and those overridden by a real
+	// dir statement; otherwise retain and update LastTransactionDate.
 	for _, s := range inputStmts {
-		if dirByStmtID[s.StatementID] || s.Virtual {
+		if s.Virtual || realDirByStmtID[s.StatementID] {
 			continue
 		}
 		// Update input-only statement's LastTransactionDate from merged transactions
@@ -1219,7 +1242,19 @@ func mergeStatements(dirStmts []budget.StatementData, inputStmts []export.Statem
 			s.LastTransactionDate = &v
 		}
 		result = append(result, s)
+		covered[s.StatementID] = true
 	}
+
+	// Derived/virtual dir anchors gap-fill only: emit one solely when no real
+	// statement (dir or input) already covers its period.
+	for _, s := range dirExport {
+		if !s.Virtual || covered[s.StatementID] {
+			continue
+		}
+		result = append(result, s)
+		covered[s.StatementID] = true
+	}
+
 	return result
 }
 
@@ -1324,6 +1359,7 @@ func deriveMonthlyStatements(parsed []parsedFile) []budget.StatementData {
 				Balance:     derivedBalance,
 				Period:      period,
 				BalanceDate: &bd,
+				Virtual:     true,
 			})
 		}
 		if count := len(derived) - beforeLen; count > 0 {
@@ -1380,6 +1416,7 @@ func buildExportStatements(stmts []budget.StatementData) []export.Statement {
 			BalanceDate:         balanceDate,
 			LastTransactionDate: ltd,
 			SourceFile:          s.SourceFile,
+			Virtual:             s.Virtual,
 		}
 	}
 	return out

--- a/budget-etl/main.go
+++ b/budget-etl/main.go
@@ -431,11 +431,15 @@ func runInputJSON(input fileOpts, output fileOpts) error {
 	weeklyAggregates := computeExportWeeklyAggregatesFromFull(fullTxns)
 
 	// Compute lastTransactionDate on statements from all transactions.
-	// Filter out virtual statements from prior runs.
+	// Filter out Synchrony virtual statements from prior runs — those are
+	// re-generated below from transaction data (vsr.statements). Other virtual
+	// statements (e.g. derived monthly anchors) are NOT re-derivable here, since
+	// runInputJSON has no access to the original parsed statement files, so they
+	// must be retained or balance-history coverage is permanently lost.
 	maxDates := maxTransactionDates(allTxns)
 	var updatedStmts []export.Statement
 	for _, s := range inp.Statements {
-		if s.Virtual {
+		if s.Virtual && strings.HasPrefix(s.StatementID, "synchrony-virtual-") {
 			continue
 		}
 		updated := s

--- a/budget-etl/main_test.go
+++ b/budget-etl/main_test.go
@@ -890,6 +890,141 @@ func TestDeriveMonthlyStatements(t *testing.T) {
 	})
 }
 
+// TestDeriveMonthlyStatementsVirtual asserts that every derived anchor produced
+// by deriveMonthlyStatements carries Virtual == true.
+func TestDeriveMonthlyStatementsVirtual(t *testing.T) {
+	parsed := []parsedFile{{
+		sf: parse.StatementFile{
+			Institution: "testbank",
+			Account:     "9999",
+			Period:      "2026-03",
+		},
+		result: parse.ParseResult{
+			Balance:     500000, // $5000.00
+			BalanceDate: time.Date(2026, 3, 31, 0, 0, 0, 0, time.UTC),
+			Transactions: []parse.Transaction{
+				{Date: time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC), Amount: 10000},
+				{Date: time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), Amount: 20000},
+				{Date: time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC), Amount: 5000},
+			},
+		},
+	}}
+
+	derived := deriveMonthlyStatements(parsed)
+	if len(derived) == 0 {
+		t.Fatal("expected at least one derived anchor, got none")
+	}
+	for i, s := range derived {
+		if !s.Virtual {
+			t.Errorf("derived[%d] (period=%q) has Virtual=false, want true", i, s.Period)
+		}
+	}
+}
+
+// TestMergeStatementsPreservesRealOverDerivedAnchor asserts the three-way merge
+// priority: real dir > real input > derived/virtual anchor.
+//
+//  1. Core criterion: a real input statement is preserved when a derived
+//     (Virtual=true) dir anchor exists for the same StatementID.
+//  2. Gap-fill: a derived anchor IS emitted for a period that has no real
+//     statement in either dir or input.
+func TestMergeStatementsPreservesRealOverDerivedAnchor(t *testing.T) {
+	// Two derived dir anchors:
+	//   anchor-A: "testbank-acct-2026-01" (Virtual=true, balance=$10 estimate)
+	//   anchor-B: "testbank-acct-2026-02" (Virtual=true, balance=$20 estimate — gap month)
+	//
+	// One real input statement:
+	//   real-A: "testbank-acct-2026-01" (Virtual=false, balance=$99 real value)
+	//
+	// After merge, the result for "testbank-acct-2026-01" must be the $99 real
+	// input statement (not the $10 derived estimate), and "testbank-acct-2026-02"
+	// must still appear (gap-fill preserved).
+
+	const (
+		stmtIDJanuary  = "testbank-acct-2026-01"
+		stmtIDFebruary = "testbank-acct-2026-02"
+	)
+
+	bdJan := time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC)
+	bdFeb := time.Date(2026, 2, 28, 0, 0, 0, 0, time.UTC)
+
+	dirStmts := []budget.StatementData{
+		{
+			StatementID: stmtIDJanuary,
+			Institution: "testbank",
+			Account:     "acct",
+			Balance:     1000, // $10.00 — derived estimate
+			Period:      "2026-01",
+			BalanceDate: &bdJan,
+			Virtual:     true,
+		},
+		{
+			StatementID: stmtIDFebruary,
+			Institution: "testbank",
+			Account:     "acct",
+			Balance:     2000, // $20.00 — derived estimate, gap month
+			Period:      "2026-02",
+			BalanceDate: &bdFeb,
+			Virtual:     true,
+		},
+	}
+
+	inputStmts := []export.Statement{
+		{
+			ID:          budget.StatementDocID(stmtIDJanuary),
+			StatementID: stmtIDJanuary,
+			Institution: "testbank",
+			Account:     "acct",
+			Balance:     99.00, // $99.00 — real measured balance
+			Period:      "2026-01",
+			BalanceDate: "2026-01-28",
+			Virtual:     false,
+		},
+	}
+
+	maxDates := map[string]*time.Time{} // no transactions; LastTransactionDate stays nil
+
+	result := mergeStatements(dirStmts, inputStmts, maxDates)
+
+	// Index the result by StatementID for easy lookup.
+	byStmtID := make(map[string]export.Statement, len(result))
+	for _, s := range result {
+		if _, dup := byStmtID[s.StatementID]; dup {
+			t.Errorf("duplicate StatementID %q in merge result", s.StatementID)
+		}
+		byStmtID[s.StatementID] = s
+	}
+
+	// 1. Core criterion: real input wins — $99 balance, Virtual=false.
+	jan, ok := byStmtID[stmtIDJanuary]
+	if !ok {
+		t.Fatalf("StatementID %q missing from merge result", stmtIDJanuary)
+	}
+	if jan.Virtual {
+		t.Errorf("result for %q has Virtual=true, want false (real input should win)", stmtIDJanuary)
+	}
+	if jan.Balance != 99.00 {
+		t.Errorf("result for %q has Balance=%.2f, want 99.00 (real input balance)", stmtIDJanuary, jan.Balance)
+	}
+
+	// 2. Gap-fill preserved: derived anchor for February still appears.
+	feb, ok := byStmtID[stmtIDFebruary]
+	if !ok {
+		t.Fatalf("StatementID %q missing from merge result — gap-fill regressed", stmtIDFebruary)
+	}
+	if !feb.Virtual {
+		t.Errorf("result for %q has Virtual=false, want true (should be the derived anchor)", stmtIDFebruary)
+	}
+	if feb.Balance != 20.00 {
+		t.Errorf("result for %q has Balance=%.2f, want 20.00 (derived anchor balance)", stmtIDFebruary, feb.Balance)
+	}
+
+	// 3. Exactly the two expected statements — no extras.
+	if len(result) != 2 {
+		t.Errorf("expected 2 statements in merge result, got %d", len(result))
+	}
+}
+
 // TestMain lets TestRemovedFlagsRejected re-exec this test binary as the real
 // budget-etl CLI: when BUDGET_ETL_TEST_RUN_MAIN=1 is set, it runs main()
 // instead of the test suite. main() parses flags via flag.CommandLine, and an

--- a/budget-etl/main_test.go
+++ b/budget-etl/main_test.go
@@ -1169,6 +1169,116 @@ func TestMergeStatementsPreservesRealOverDerivedAnchor(t *testing.T) {
 	}
 }
 
+// TestRunInputJSONPreservesDerivedAnchors is an end-to-end round-trip guard for
+// the runInputJSON path: runMerge generates derived virtual anchors from a
+// multi-month statement file, and feeding that output back through runInputJSON
+// must preserve those anchors. This catches the regression where runInputJSON's
+// statement loop drops every virtual statement (the `if s.Virtual { continue }`
+// at main.go:438), silently discarding derived balance-history anchors on a
+// --input-json run.
+func TestRunInputJSONPreservesDerivedAnchors(t *testing.T) {
+	tmp := t.TempDir()
+
+	// A single statement file for one account whose transactions span three
+	// months (Jan, Feb, Mar) with an ending balance — exactly the shape
+	// deriveMonthlyStatements turns into intermediate monthly anchors for the
+	// months before the file's own period (2026-03). The metadata toDate
+	// 2026/03/31 drives the inferred period and the $500.00 ending balance the
+	// anchors are derived from.
+	csvPath := filepath.Join(tmp, "statements", "test_bank", "1234", "2026-03", "stmt.csv")
+	writeCSVFixtureMeta(t, csvPath,
+		"0000000000,2026/01/01,2026/03/31,100.00,500.00",
+		[][6]string{
+			{"2026/01/10", "10.00", "TEST PURCHASE JAN", "", "TXN-JAN", "DEBIT"},
+			{"2026/02/15", "20.00", "TEST PURCHASE FEB", "", "TXN-FEB", "DEBIT"},
+			{"2026/03/05", "5.00", "TEST PURCHASE MAR", "", "TXN-MAR", "DEBIT"},
+		})
+
+	// Minimal input JSON: one transaction (the reader requires a non-empty
+	// transactions field) plus a categorization rule covering every
+	// transaction so the merge does not fail on uncategorized transactions.
+	inputJSON := export.Output{
+		Version:   1,
+		GroupName: "test-group",
+		Transactions: []export.Transaction{
+			{
+				ID:                budget.TransactionDocID("test_bank-1234-2026-03", "TXN-JAN"),
+				Institution:       "test_bank",
+				Account:           "1234",
+				Description:       "TEST PURCHASE JAN",
+				Amount:            10.00,
+				Timestamp:         "2026-01-10T00:00:00Z",
+				StatementID:       "test_bank-1234-2026-03",
+				NormalizedPrimary: true,
+			},
+		},
+		Rules: []export.Rule{
+			{ID: "cat-test", Type: "categorization", Pattern: "TEST PURCHASE", Target: "Test:General", Priority: 10},
+		},
+		NormalizationRules: []export.NormalizationRule{},
+	}
+	inputPath := filepath.Join(tmp, "input.json")
+	if err := export.WriteFile(inputPath, inputJSON, ""); err != nil {
+		t.Fatalf("writing input JSON: %v", err)
+	}
+
+	// Step 1: runMerge produces an output that includes derived virtual anchors.
+	mergedPath := filepath.Join(tmp, "merged.json")
+	statementsDir := filepath.Join(tmp, "statements")
+	if err := runMerge(fileOpts{path: inputPath}, statementsDir, "", parse.DiscoverOpts{}, fileOpts{path: mergedPath}); err != nil {
+		t.Fatalf("runMerge: %v", err)
+	}
+
+	mergedData, err := os.ReadFile(mergedPath)
+	if err != nil {
+		t.Fatalf("reading merged output: %v", err)
+	}
+	var merged export.Output
+	if err := json.Unmarshal(mergedData, &merged); err != nil {
+		t.Fatalf("parsing merged output: %v", err)
+	}
+
+	// Confirm the precondition: runMerge actually emitted derived virtual
+	// anchors. Without them the round-trip below would be vacuous.
+	var mergedVirtualIDs []string
+	for _, s := range merged.Statements {
+		if s.Virtual {
+			mergedVirtualIDs = append(mergedVirtualIDs, s.StatementID)
+		}
+	}
+	if len(mergedVirtualIDs) == 0 {
+		t.Fatalf("precondition failed: runMerge emitted no virtual anchors (statements: %d)", len(merged.Statements))
+	}
+
+	// Step 2: feed the merged output back into runInputJSON as input.
+	roundtripPath := filepath.Join(tmp, "roundtrip.json")
+	if err := runInputJSON(fileOpts{path: mergedPath}, fileOpts{path: roundtripPath}); err != nil {
+		t.Fatalf("runInputJSON: %v", err)
+	}
+
+	roundtripData, err := os.ReadFile(roundtripPath)
+	if err != nil {
+		t.Fatalf("reading roundtrip output: %v", err)
+	}
+	var roundtrip export.Output
+	if err := json.Unmarshal(roundtripData, &roundtrip); err != nil {
+		t.Fatalf("parsing roundtrip output: %v", err)
+	}
+
+	// Step 3: every derived virtual anchor must survive the round-trip.
+	survived := make(map[string]bool, len(roundtrip.Statements))
+	for _, s := range roundtrip.Statements {
+		if s.Virtual {
+			survived[s.StatementID] = true
+		}
+	}
+	for _, id := range mergedVirtualIDs {
+		if !survived[id] {
+			t.Errorf("derived virtual anchor %q dropped by runInputJSON round-trip", id)
+		}
+	}
+}
+
 // TestMain lets TestRemovedFlagsRejected re-exec this test binary as the real
 // budget-etl CLI: when BUDGET_ETL_TEST_RUN_MAIN=1 is set, it runs main()
 // instead of the test suite. main() parses flags via flag.CommandLine, and an


### PR DESCRIPTION
Closes #1274

## Problem

`deriveMonthlyStatements` generates intermediate monthly balance anchors for an
account whose single statement file has a balance snapshot but transactions
spanning multiple months. Each anchor got `StatementID = inst + "-" + acct +
"-" + period` — identical to the ID a *real* statement of the same
account/period produces. In `mergeStatements`, dir statements (which include
these anchors) overrode input statements by `StatementID`, so if the snapshot
already held a real statement for a month a new long-span file also covered
(e.g. a year-to-date export landing after months of normal imports), the
derived **estimate** silently replaced the real balance. Anchors carried no
marker, so in later runs they were indistinguishable from real statements and
persisted.

## Fix

Mark derived anchors `Virtual` and restructure the merge so they gap-fill only
and never shadow a real statement.

- **Add `Virtual bool` to `budget.StatementData`** (defaults to `false`, so
  every existing literal stays valid).
- **Propagate it** through `buildExportStatements` into the JSON export.
- **Set `Virtual: true`** on the derived anchors in `deriveMonthlyStatements`.
- **Restructure `mergeStatements`** to enforce a three-way priority — real dir
  > real input > derived/virtual anchor:
  - Seed the result with the non-virtual dir statements (recording covered IDs).
  - Keep each real input statement, skipping virtual inputs and those overridden
    by a real dir statement of the same ID (preserves current behavior).
  - Append a derived/virtual anchor only when no real statement (dir or input)
    already covers its period.

The existing input-loop guard already skips virtual input statements, so
prior-snapshot anchors are skipped and recomputed on read-back — existing
`.benc` snapshots self-heal without migration.

## Tests

- `TestMergeStatementsPreservesRealOverDerivedAnchor` — a real input statement
  ($99) wins over a `Virtual` derived anchor ($10 estimate) with the same
  `StatementID`; a derived anchor for a period with no real statement is still
  emitted (gap-fill preserved); exactly one statement per ID.
- `TestDeriveMonthlyStatementsVirtual` — every derived anchor carries
  `Virtual == true`.

## Verification

`go build ./...`, `go test ./...`, and `go vet ./...` all pass in `budget-etl`.

## Out of scope

The frontend already handles virtual statements correctly (no balance/net-worth
path filters virtual; the all-virtual-account badge cannot misfire here, since
the one real statement file remains non-virtual). Existing snapshots self-heal,
so no migration is needed.
