### PR TITLE
budget-etl: reject category-filter fields on categorization rules

### DIFF
--- a/budget-etl/main.go
+++ b/budget-etl/main.go
@@ -513,6 +513,9 @@ func buildRule(r rules.Rule, minAmountDollars, maxAmountDollars *float64) (rules
 func convertExportRules(exportRules []export.Rule) ([]rules.Rule, error) {
 	ruleSet := make([]rules.Rule, len(exportRules))
 	for i, r := range exportRules {
+		if r.Type == "categorization" && (r.MatchCategory != "" || r.ExcludeCategory != "" || r.Category != "") {
+			return nil, fmt.Errorf("rule %s: category-filter fields (matchCategory/excludeCategory/category) are only valid on budget_assignment rules, not categorization rules", r.ID)
+		}
 		built, err := buildRule(rules.Rule{
 			ID:              r.ID,
 			Type:            r.Type,

--- a/budget-etl/main_test.go
+++ b/budget-etl/main_test.go
@@ -152,6 +152,92 @@ func TestConvertExportRulesEmpty(t *testing.T) {
 	}
 }
 
+func TestConvertExportRulesRejectsCategoryFilterOnCategorization(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    export.Rule
+		wantErr bool
+	}{
+		{
+			name: "categorization with MatchCategory errors",
+			rule: export.Rule{
+				ID:            "r1",
+				Type:          "categorization",
+				Pattern:       "coffee",
+				Target:        "Food:Coffee",
+				MatchCategory: "Food",
+			},
+			wantErr: true,
+		},
+		{
+			name: "categorization with ExcludeCategory errors",
+			rule: export.Rule{
+				ID:              "r2",
+				Type:            "categorization",
+				Pattern:         "coffee",
+				Target:          "Food:Coffee",
+				ExcludeCategory: "Dining",
+			},
+			wantErr: true,
+		},
+		{
+			name: "categorization with Category errors",
+			rule: export.Rule{
+				ID:       "r3",
+				Type:     "categorization",
+				Pattern:  "coffee",
+				Target:   "Food:Coffee",
+				Category: "Food",
+			},
+			wantErr: true,
+		},
+		{
+			name: "budget_assignment with MatchCategory succeeds",
+			rule: export.Rule{
+				ID:            "r4",
+				Type:          "budget_assignment",
+				Pattern:       "coffee",
+				Target:        "budget-food",
+				MatchCategory: "Food",
+			},
+			wantErr: false,
+		},
+		{
+			name: "budget_assignment with ExcludeCategory succeeds",
+			rule: export.Rule{
+				ID:              "r5",
+				Type:            "budget_assignment",
+				Pattern:         "coffee",
+				Target:          "budget-food",
+				ExcludeCategory: "Dining",
+			},
+			wantErr: false,
+		},
+		{
+			name: "budget_assignment with Category succeeds",
+			rule: export.Rule{
+				ID:       "r6",
+				Type:     "budget_assignment",
+				Pattern:  "coffee",
+				Target:   "budget-food",
+				Category: "Food",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := convertExportRules([]export.Rule{tc.rule})
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestApplyTransactionRules(t *testing.T) {
 	ts := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
 

--- a/budget-etl/main_test.go
+++ b/budget-etl/main_test.go
@@ -229,7 +229,7 @@ func TestConvertExportRulesRejectsCategoryFilterOnCategorization(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := convertExportRules([]export.Rule{tc.rule})
 			if tc.wantErr && err == nil {
-				t.Errorf("expected error, got nil")
+				t.Fatalf("expected error, got nil")
 			}
 			if !tc.wantErr && err != nil {
 				t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
Closes #1276

## Problem

A *categorization* rule that sets `matchCategory`, `category`, or
`excludeCategory` can never behave as its author intends, yet nothing rejected
those fields.

`ApplyCategorization` only visits transactions whose `Category == ""` and passes
that empty string to `Rule.Match`. Against an empty category:

- `MatchCategory != ""` → the rule can **never fire**.
- `Category != ""` → the rule can **never fire**.
- `ExcludeCategory != ""` → the exclusion is a **silent no-op**.

These three fields are meaningful only for `budget_assignment` rules, which run
against transactions that already carry a category. A rule author who set them on
a categorization rule got a silently never-matching (or silently inert) rule with
no feedback.

## Change

`convertExportRules` now rejects a `categorization` rule that carries any
category-filter field with a clear, rule-ID-prefixed error:

```
rule <id>: category-filter fields (matchCategory/excludeCategory/category) are only valid on budget_assignment rules, not categorization rules
```

`convertExportRules` is the right gate: it runs only on the general rule set
(after `splitRules` removes transaction-specific rules), so every rule it sees is
either `categorization` or `budget_assignment`. The check is scoped specifically
to `Type == "categorization"`, not a blanket non-`budget_assignment` check, so it
does not over-reject any future rule type.

Runtime semantics (`Rule.Match` / `ApplyCategorization`) are unchanged — the
defect was the missing author-facing validation, not the matching behavior.

## Test

`TestConvertExportRulesRejectsCategoryFilterOnCategorization` is table-driven over
the three fields set individually on a `categorization` rule (each must error) and
on a `budget_assignment` rule (each must convert without error, guarding against
an over-broad check).
