### PR TITLE
office-hours: distinct demo/owner/owner-empty/error states, no demo fallback for authenticated owners

### DIFF
--- a/office-hours/index.html
+++ b/office-hours/index.html
@@ -145,6 +145,18 @@
         color: var(--muted-fg, #9aa0a6);
         margin-bottom: 0.75rem;
       }
+      .demo-banner {
+        background: var(--accent-muted, #2a2f3a);
+        color: var(--muted-fg, #9aa0a6);
+        padding: 0.5rem 0.75rem;
+        border-radius: 6px;
+        font-size: 0.875rem;
+        margin-bottom: 1rem;
+      }
+      .error {
+        color: var(--danger, #ff6b6b);
+        padding: 0.5rem 0.75rem;
+      }
     </style>
   </head>
   <body>

--- a/office-hours/src/app-view.ts
+++ b/office-hours/src/app-view.ts
@@ -1,0 +1,39 @@
+import { renderCapacityBand, selectLatestSample } from "./capacity-band.js";
+import { renderHistoryBand } from "./history-band.js";
+import { renderReminderList } from "./office-hours.js";
+import { getDemoSamples } from "./usage-data.js";
+import { getDemoReminders } from "./data.js";
+import type { UsageSample } from "./usage-samples.js";
+import type { Reminder } from "./reminders.js";
+
+export type ViewState =
+  | { tier: "demo" }                                                  // unauthenticated → labeled demo
+  | { tier: "owner"; samples: UsageSample[]; reminders: Reminder[] }  // authenticated → real (possibly empty)
+  | { tier: "error" };                                                // authenticated load failed
+
+export function renderApp(container: Element, state: ViewState, now: Date): void {
+  container.replaceChildren();
+
+  if (state.tier === "demo") {
+    const banner = document.createElement("p");
+    banner.className = "demo-banner";
+    banner.setAttribute("role", "status");
+    banner.textContent = "Demo data — sign in to see your queue.";
+    container.appendChild(banner);
+
+    const samples = getDemoSamples();
+    container.appendChild(renderCapacityBand(selectLatestSample(samples), now));
+    container.appendChild(renderHistoryBand(samples));
+    container.appendChild(renderReminderList(getDemoReminders(), now));
+  } else if (state.tier === "owner") {
+    container.appendChild(renderCapacityBand(selectLatestSample(state.samples), now));
+    container.appendChild(renderHistoryBand(state.samples));
+    container.appendChild(renderReminderList(state.reminders, now));
+  } else {
+    const error = document.createElement("p");
+    error.className = "error";
+    error.setAttribute("role", "alert");
+    error.textContent = "Couldn't load your queue. Please try again.";
+    container.appendChild(error);
+  }
+}

--- a/office-hours/src/main.ts
+++ b/office-hours/src/main.ts
@@ -5,13 +5,9 @@ import { deferProgrammerError } from "@commons-systems/errorutil/defer";
 import { logError } from "@commons-systems/errorutil/log";
 import { deferAppCheckInit } from "@commons-systems/firebaseutil/defer-appcheck";
 
-import { renderReminderList } from "./office-hours.js";
-import { getDemoReminders, getOwnerReminders } from "./data.js";
-import type { Reminder } from "./reminders.js";
-import { renderCapacityBand, selectLatestSample } from "./capacity-band.js";
-import { renderHistoryBand } from "./history-band.js";
-import { getDemoSamples, getOwnerSamples } from "./usage-data.js";
-import type { UsageSample } from "./usage-samples.js";
+import { renderApp } from "./app-view.js";
+import { getOwnerReminders } from "./data.js";
+import { getOwnerSamples } from "./usage-data.js";
 import {
   db,
   NAMESPACE,
@@ -30,24 +26,17 @@ if (!authToggle) throw new Error("#auth-toggle element not found");
 
 let currentUser: User | null = null;
 
-function render(samples: UsageSample[], reminders: Reminder[]): void {
-  app!.replaceChildren();
-  app!.appendChild(renderCapacityBand(selectLatestSample(samples), new Date()));
-  app!.appendChild(renderHistoryBand(samples));
-  app!.appendChild(renderReminderList(reminders, new Date()));
-}
-
 function updateAuthButton(user: User | null): void {
   authToggle!.textContent = user ? "Sign out" : "Sign in";
 }
 
 // Paint the demo tier immediately so the view is meaningful before auth resolves.
-render(getDemoSamples(), getDemoReminders());
+renderApp(app!, { tier: "demo" }, new Date());
 
 async function refresh(): Promise<void> {
   const refreshUser = currentUser;
   if (refreshUser === null) {
-    render(getDemoSamples(), getDemoReminders());
+    renderApp(app!, { tier: "demo" }, new Date());
     return;
   }
   try {
@@ -58,19 +47,14 @@ async function refresh(): Promise<void> {
     // Auth may have changed while the Firestore calls were in flight — skip the
     // render so the in-flight result does not clobber the already-updated view.
     if (currentUser !== refreshUser) return;
-    // A signed-in non-owner's queries return empty (rules deny the real data) —
-    // fall back to the demo tier per band.
-    render(
-      samples.length > 0 ? samples : getDemoSamples(),
-      reminders.length > 0 ? reminders : getDemoReminders(),
-    );
+    renderApp(app!, { tier: "owner", samples, reminders }, new Date());
   } catch (error) {
-    // Intentional silent degradation — show the demo tier rather than an error.
-    // A non-owner's read is "permission-denied"; logError classifies it.
+    // Load failed — render an explicit error state rather than masking it as
+    // demo data. A non-owner's read is "permission-denied"; logError classifies it.
     if (!deferProgrammerError(error)) {
       logError(error, { operation: "load-owner-data" });
     }
-    render(getDemoSamples(), getDemoReminders());
+    renderApp(app!, { tier: "error" }, new Date());
   }
 }
 

--- a/office-hours/src/main.ts
+++ b/office-hours/src/main.ts
@@ -49,6 +49,9 @@ async function refresh(): Promise<void> {
     if (currentUser !== refreshUser) return;
     renderApp(app!, { tier: "owner", samples, reminders }, new Date());
   } catch (error) {
+    // Auth may have changed while the Firestore calls were in flight — skip the
+    // render so the in-flight error does not clobber the already-updated view.
+    if (currentUser !== refreshUser) return;
     // Load failed — render an explicit error state rather than masking it as
     // demo data. A non-owner's read is "permission-denied"; logError classifies it.
     if (!deferProgrammerError(error)) {

--- a/office-hours/test/app-view.test.ts
+++ b/office-hours/test/app-view.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from "vitest";
+import { renderApp } from "../src/app-view.js";
+import type { UsageSample } from "../src/usage-samples.js";
+import type { Reminder } from "../src/reminders.js";
+
+const now = new Date("2026-06-11T12:00:00Z");
+
+// The history-band chart modules read --fg via getThemeFg; happy-dom has no
+// stylesheet, so set it on the document root (mirrors history-band.test.ts).
+function withThemeFg<T>(fn: () => T): T {
+  document.documentElement.style.setProperty("--fg", "#e8eaed");
+  try {
+    return fn();
+  } finally {
+    document.documentElement.style.removeProperty("--fg");
+  }
+}
+
+const baseSample: UsageSample = {
+  sampledAt: new Date("2026-06-07T10:00:00Z"),
+  fiveHourUsedPct: 42.5,
+  weeklyUsedPct: 18.3,
+  fiveHourResetsAt: new Date("2026-06-07T15:00:00Z"),
+  weeklyResetsAt: new Date("2026-06-14T00:00:00Z"),
+  activeWorkers: 3,
+  targetWorkers: 4,
+  groupId: "group-abc",
+};
+
+const makeSample = (o: Partial<UsageSample> = {}): UsageSample => ({ ...baseSample, ...o });
+
+const MINUTE = 60_000;
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+
+function makeReminder(title: string, offsetMs: number): Reminder {
+  return {
+    jitKey: `jit-${title}`,
+    title,
+    repo: "natb1/office-hours-test",
+    issueNumber: 1,
+    dueAt: new Date(now.getTime() + offsetMs),
+  };
+}
+
+describe("renderApp — demo tier", () => {
+  it("renders a .demo-banner with the correct text", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+
+    const banner = container.querySelector(".demo-banner");
+    expect(banner).not.toBeNull();
+    expect(banner!.textContent).toBe("Demo data — sign in to see your queue.");
+  });
+
+  it("renders the capacity heading", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+
+    const heading = container.querySelector(".capacity-heading");
+    expect(heading).not.toBeNull();
+    expect(heading!.textContent).toBe("CAPACITY");
+  });
+
+  it("renders chart layouts from the demo samples", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+
+    // getDemoSamples() returns non-empty data so both chart layouts render
+    const layouts = container.querySelectorAll(".chart-layout");
+    expect(layouts.length).toBeGreaterThan(0);
+  });
+
+  it("does not render an .error element", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+
+    expect(container.querySelector(".error")).toBeNull();
+  });
+});
+
+describe("renderApp — owner tier with data", () => {
+  const samples = [
+    makeSample({ sampledAt: new Date("2026-06-07T10:00:00Z") }),
+    makeSample({ sampledAt: new Date("2026-06-08T10:00:00Z"), activeWorkers: 2, targetWorkers: 3 }),
+  ];
+  const reminders = [
+    makeReminder("weekly-review", 30 * MINUTE),
+    makeReminder("overdue-task", -4 * HOUR),
+  ];
+
+  it("does not render a .demo-banner", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders }, now));
+
+    expect(container.querySelector(".demo-banner")).toBeNull();
+  });
+
+  it("renders a reminder list item for each reminder", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders }, now));
+
+    const items = container.querySelectorAll("li.reminder");
+    expect(items.length).toBe(2);
+  });
+
+  it("does not render an .error element", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders }, now));
+
+    expect(container.querySelector(".error")).toBeNull();
+  });
+});
+
+describe("renderApp — owner tier empty", () => {
+  it("does not render a .demo-banner", () => {
+    const container = document.createElement("div");
+    withThemeFg(() =>
+      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+    );
+
+    expect(container.querySelector(".demo-banner")).toBeNull();
+  });
+
+  it('renders the reminder-list empty state "No reminders."', () => {
+    const container = document.createElement("div");
+    withThemeFg(() =>
+      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+    );
+
+    const list = container.querySelector("#reminder-list");
+    expect(list).not.toBeNull();
+    expect(list!.querySelectorAll("li").length).toBe(0);
+
+    // The empty placeholder lives alongside the list in the same section
+    const empties = Array.from(container.querySelectorAll(".empty"));
+    const reminderEmpty = empties.find((el) => el.textContent === "No reminders.");
+    expect(reminderEmpty).not.toBeUndefined();
+  });
+
+  it('renders the capacity empty state "No capacity data."', () => {
+    const container = document.createElement("div");
+    withThemeFg(() =>
+      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+    );
+
+    const empties = Array.from(container.querySelectorAll(".empty"));
+    const capacityEmpty = empties.find((el) => el.textContent === "No capacity data.");
+    expect(capacityEmpty).not.toBeUndefined();
+  });
+
+  it("does not render an .error element", () => {
+    const container = document.createElement("div");
+    withThemeFg(() =>
+      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+    );
+
+    expect(container.querySelector(".error")).toBeNull();
+  });
+});
+
+describe("renderApp — error tier", () => {
+  it("renders a .error with the correct text", () => {
+    const container = document.createElement("div");
+    renderApp(container, { tier: "error" }, now);
+
+    const error = container.querySelector(".error");
+    expect(error).not.toBeNull();
+    expect(error!.textContent).toBe("Couldn't load your queue. Please try again.");
+  });
+
+  it("does not render a .demo-banner", () => {
+    const container = document.createElement("div");
+    renderApp(container, { tier: "error" }, now);
+
+    expect(container.querySelector(".demo-banner")).toBeNull();
+  });
+
+  it("does not render the capacity heading", () => {
+    const container = document.createElement("div");
+    renderApp(container, { tier: "error" }, now);
+
+    expect(container.querySelector(".capacity-heading")).toBeNull();
+  });
+});
+
+describe("renderApp — replaceChildren between calls", () => {
+  it("removes the demo banner when re-rendered as error", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+
+    // Demo banner is present after first render
+    expect(container.querySelector(".demo-banner")).not.toBeNull();
+
+    // Second render: error tier
+    renderApp(container, { tier: "error" }, now);
+
+    // Demo banner must be gone
+    expect(container.querySelector(".demo-banner")).toBeNull();
+    // Error element must be present
+    expect(container.querySelector(".error")).not.toBeNull();
+  });
+});

--- a/office-hours/test/app-view.test.ts
+++ b/office-hours/test/app-view.test.ts
@@ -51,6 +51,7 @@ describe("renderApp — demo tier", () => {
     const banner = container.querySelector(".demo-banner");
     expect(banner).not.toBeNull();
     expect(banner!.textContent).toBe("Demo data — sign in to see your queue.");
+    expect(banner!.getAttribute("role")).toBe("status");
   });
 
   it("renders the capacity heading", () => {
@@ -167,6 +168,7 @@ describe("renderApp — error tier", () => {
     const error = container.querySelector(".error");
     expect(error).not.toBeNull();
     expect(error!.textContent).toBe("Couldn't load your queue. Please try again.");
+    expect(error!.getAttribute("role")).toBe("alert");
   });
 
   it("does not render a .demo-banner", () => {


### PR DESCRIPTION
Closes #1304

## Problem

The office-hours page silently fell back to fabricated `natb1/example` demo data
whenever the owner queries returned empty — conflating a signed-in non-owner
(rules-filtered empty) with an owner whose queue is genuinely empty. An owner who
cleared every reminder saw demo reminders ("Weekly review — overdue 4h") with no
demo indicator, and the real empty state was unreachable. The same fallback drove
the CAPACITY and HISTORY bands, so all three page regions were fabricated for an
empty-but-authenticated owner. A silent `catch → render(demo)` also masked load
errors (e.g. a misdeployed rule set) behind a plausible demo screen — the
"prefer clear errors over defensive fallbacks" anti-pattern.

## Change

Introduce a discriminated view-state union and switch render on it, replacing the
`.length > 0 ? real : demo` ternaries and the `catch → demo` fallback:

```typescript
type ViewState =
  | { tier: "demo" }                                        // unauthenticated → labeled demo
  | { tier: "owner"; samples; reminders }                   // authenticated → real (possibly empty)
  | { tier: "error" };                                      // authenticated load failed
```

Mapping: **unauthenticated → demo (labeled); authenticated → owner tier (data /
empty / error)**. A signed-in non-owner sees the owner-empty state, which is
acceptable — the demo tier is the public unauthenticated showcase (the `demo`
Firestore env is world-readable without auth).

The owner-empty case needs no special handling: the per-region empty states
already existed but were unreachable behind the fallback. Passing the real
(possibly empty) arrays to the owner tier lets them show through —
`renderReminderList` → "No reminders.", `renderCapacityBand(null)` → "No capacity
data.", and the chart renderers' empty messages.

### Units

1. **`office-hours/src/app-view.ts`** (new) — firebase-free, unit-testable module
   holding `ViewState` and a pure `renderApp(container, state, now)`. The demo
   branch prepends a labeled `.demo-banner` and renders the bands from the demo
   getters; owner renders from the passed arrays; error renders a single `.error`
   paragraph (and `logError` still fires in the catch branch).
2. **`office-hours/src/main.ts`** — rewired onto `renderApp`; deletes the local
   `render()` helper and the demo fallbacks. The mid-flight auth guard and the
   `deferProgrammerError`/`logError` handling are preserved verbatim.
3. **`office-hours/index.html`** — CSS for `.demo-banner` and `.error` (the
   latter reuses the existing `--danger` variable).
4. **`office-hours/test/app-view.test.ts`** (new) — vitest coverage of all four
   states plus a `replaceChildren` re-render.

## States

- **Demo (unauthenticated):** `.demo-banner` "Demo data — sign in to see your
  queue." above the demo bands.
- **Owner with data:** real data, no banner.
- **Owner empty:** "No reminders." + "No capacity data." + chart empty messages,
  no banner, no demo data.
- **Error:** "Couldn't load your queue. Please try again." (replaces the bands;
  the error is also logged).

## Scope notes

- Two real data sources, not three: `getOwnerSamples` (drives CAPACITY + HISTORY
  via `selectLatestSample`) and `getOwnerReminders`. There is no separate
  `metrics` query in the code — none was added (`getDemoQueueMetrics` is dead
  code; the issue's three-collection observation reflects the live queries, but
  the app only issues two). Out of scope per the plan.
- `main.ts`'s auth/refresh orchestration remains not unit-testable (importing it
  triggers firebase side effects and DOM-entry assertions) — left untested by
  design; the pure render logic moved into `app-view.ts` is what the new suite
  covers.

## Verification

- `npm test --prefix office-hours` — 14 files, 121 tests pass (5 new
  `app-view` cases; all existing suites green).
- `npm run build --prefix office-hours` — clean (only the pre-existing
  chunk-size warning).
- The unauthenticated e2e smoke (`history-charts-smoke.spec.ts`) is preserved:
  unauthenticated → demo tier still renders `renderHistoryBand(getDemoSamples())`,
  so the chart SVGs are produced; the `.demo-banner` is additive.
