### PR TITLE
dispatch-phase: a reviewed draft PR is review-complete (done), not a review re-entry

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-phase
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-phase
@@ -123,9 +123,22 @@ if [[ "$VERDICT" == "pending" ]]; then
 fi
 
 # VERDICT == passing — CI is green; map the highest dispatch:* label to the next phase.
-# The single review phase is terminal: dispatch:qa-done maps to "review".
-# dispatch:reviewed is a /review-fix re-entry marker — it maps back to "review";
-# the skill is idempotent and just finishes "gh pr ready".
+# dispatch:reviewed is the review-COMPLETE signal, applied by /review-fix on a
+# clean pass — NOT a re-entry marker. The review phase is terminal once
+# dispatch:reviewed is present, so a reviewed draft PR derives to "done".
+# draft→ready promotion is owned by the router's dispatch-reconcile-ready on a
+# later tick (once CI is passing and mergeable == MERGEABLE), NOT by /review-fix
+# — /review-fix no longer runs "gh pr ready". Returning "done" composes with the
+# worker Stop hook (Branch B self-close) and the spawn boundary
+# (dispatch-materialize-spawn's "target-done" refusal), so a reviewed draft PR
+# self-closes its worker and is not re-selected for a phase skill.
+#
+# A FAILING reviewed PR never reaches this passing-CI mapping: the
+# failing-verdict branch above already returned "fix-checks", and CONFLICTING
+# returned "fix-conflicts" — so a PR demoted back to draft on CI regression
+# routes to the fixer via those earlier branches, not here. dispatch:qa-done
+# still maps to the still-actionable "review" phase (qa complete, review not yet
+# run).
 #
 # In-flight legacy tolerance: an open draft PR may still carry
 # dispatch:code-reviewed or dispatch:security-reviewed from the old three-phase
@@ -133,9 +146,9 @@ fi
 # pass instead of stalling on an orphaned label.
 LABELS=$(printf '%s' "$PR" | jq -r '[.labels[].name | select(startswith("dispatch:"))] | join(" ")')
 
-if echo "$LABELS" | grep -qF "dispatch:security-reviewed"; then
-  echo "review"
-elif echo "$LABELS" | grep -qF "dispatch:reviewed"; then
+if echo "$LABELS" | grep -qF "dispatch:reviewed"; then
+  echo "done"
+elif echo "$LABELS" | grep -qF "dispatch:security-reviewed"; then
   echo "review"
 elif echo "$LABELS" | grep -qF "dispatch:code-reviewed"; then
   echo "review"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -14447,6 +14447,22 @@ self_close_calls=$(wc -l < "$STUB_DIR/self-close-calls.log" 2>/dev/null || echo 
 assert_eq "stop clean-review: self-close invoked exactly once" "1" "$self_close_calls"
 spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
 assert_eq "stop clean-review: spawn invoked exactly once" "1" "$spawn_calls"
+pr_remove_log=$(cat "$STUB_DIR/gh-pr-remove.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$pr_remove_log" == *"pr edit 456 --remove-label dispatch:office-hours"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop clean-review: PR --remove-label invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop clean-review: PR --remove-label invoked"
+  echo "    pr-remove-log: $pr_remove_log"
+fi
+issue_remove_log=$(cat "$STUB_DIR/gh-issue-remove.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$issue_remove_log" == *"issue edit 123 --remove-label dispatch:office-hours"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop clean-review: issue --remove-label invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop clean-review: issue --remove-label invoked"
+  echo "    issue-remove-log: $issue_remove_log"
+fi
 TOTAL=$((TOTAL + 1))
 if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" ]]; then
   PASS=$((PASS + 1)); echo "  PASS: stop clean-review: no add-label calls were made (no dispatch:office-hours applied)"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -826,13 +826,34 @@ result=$("$TMPDIR_TEST/dispatch-phase" "42")
 assert_eq "draft + green + dispatch:qa-done → review" "review" "$result"
 teardown
 
-# 7. Draft + green + dispatch:reviewed → review (idempotent re-entry)
-echo "Test: draft + green + dispatch:reviewed → review (idempotent re-entry)"
+# 7. Draft + green + dispatch:reviewed → done (review-complete; dispatch:reviewed is the
+# terminal review signal; draft→ready promotion is owned by dispatch-reconcile-ready)
+echo "Test: draft + green + dispatch:reviewed → done (review-complete)"
 setup
 printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" '[{"name":"dispatch:reviewed"}]' "$GREEN_ROLLUP")" \
   > "$STUB_DIR/pr-list-full.json"
 result=$("$TMPDIR_TEST/dispatch-phase" "42")
-assert_eq "draft + green + dispatch:reviewed → review (idempotent)" "review" "$result"
+assert_eq "draft + green + dispatch:reviewed → done (review-complete)" "done" "$result"
+teardown
+
+# 7b. Draft + dispatch:reviewed + FAILING CI → fix-checks (failing-verdict branch wins first;
+# a demoted reviewed PR re-routes to the fixer, not back to review)
+echo "Test: draft + dispatch:reviewed + failing CI → fix-checks"
+setup
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" '[{"name":"dispatch:reviewed"}]' "$FAILING_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "draft + dispatch:reviewed + failing CI → fix-checks" "fix-checks" "$result"
+teardown
+
+# 7c. Draft + green + {dispatch:reviewed, dispatch:qa-done} → done (reorder guard:
+# dispatch:reviewed wins over co-present dispatch:qa-done)
+echo "Test: draft + green + dispatch:reviewed + dispatch:qa-done → done (dispatch:reviewed wins)"
+setup
+printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" '[{"name":"dispatch:reviewed"},{"name":"dispatch:qa-done"}]' "$GREEN_ROLLUP")" \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "draft + green + dispatch:reviewed + dispatch:qa-done → done (dispatch:reviewed wins)" "done" "$result"
 teardown
 
 # 8. Draft + green + legacy dispatch:code-reviewed → review (in-flight tolerance)
@@ -1274,16 +1295,16 @@ assert_eq "dispatch:qa-done → INVOKE /review-fix (directive)" "INVOKE /review-
 assert_eq "dispatch:qa-done → INVOKE /review-fix (exit 0)" "0" "$ROUTE_RC"
 teardown
 
-# 5. Draft + green + dispatch:reviewed → INVOKE /review-fix (idempotent re-entry;
-# /review-fix just finishes "gh pr ready").
-echo "Test: draft + green + dispatch:reviewed → INVOKE /review-fix (re-entry)"
+# 5. Draft + green + dispatch:reviewed → STOP done (review-complete; dispatch:reviewed is the
+# terminal review signal so the router returns STOP done, same as a non-draft ready PR).
+echo "Test: draft + green + dispatch:reviewed → STOP done (reviewed draft PR is review-complete)"
 setup
 printf '[%s]\n' "$(make_pr 10 "42-my-feature" "true" '[{"name":"dispatch:reviewed"}]' "$GREEN_ROLLUP")" \
   > "$STUB_DIR/pr-list-full.json"
 echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
 route_run 42 /wt/42-my-feature
-assert_eq "dispatch:reviewed → INVOKE /review-fix (directive)" "INVOKE /review-fix" "$ROUTE_OUT"
-assert_eq "dispatch:reviewed → INVOKE /review-fix (exit 0)" "0" "$ROUTE_RC"
+assert_eq "dispatch:reviewed → STOP done (directive)" "STOP done" "$ROUTE_OUT"
+assert_eq "dispatch:reviewed → STOP done (exit 0)" "0" "$ROUTE_RC"
 teardown
 
 # 6. Draft + green + legacy dispatch:code-reviewed → INVOKE /review-fix
@@ -14403,6 +14424,36 @@ if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" ]]; 
   PASS=$((PASS + 1)); echo "  PASS: stop advance: no add-label calls were made"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: stop advance: no add-label calls were made"
+fi
+stop_teardown
+
+# --- Test 1b: dispatch-stop: clean review pass (marker=review, current=done) self-closes, no office-hours --
+# Simulates Unit-1 behavior: dispatch-phase now returns "done" for a draft+dispatch:reviewed PR
+# with passing CI. The Stop hook sees MARKER_PHASE=review != CURRENT_PHASE=done → Branch B:
+# self-close + spawn + strip office-hours. No dispatch:office-hours add-label must be applied.
+
+echo "Test: dispatch-stop: clean review pass (marker=review, current=done) self-closes, no office-hours"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "456" > "$STUB_DIR/find-pr-output"
+echo "done" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+echo "phase=review" > "$TMPDIR_TEST/jobs/abcd1234/phase-completed"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+"$TMPDIR_TEST/hooks/dispatch-stop.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "stop clean-review: hook exits 0" "0" "$rc"
+self_close_calls=$(wc -l < "$STUB_DIR/self-close-calls.log" 2>/dev/null || echo 0)
+assert_eq "stop clean-review: self-close invoked exactly once" "1" "$self_close_calls"
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "stop clean-review: spawn invoked exactly once" "1" "$spawn_calls"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop clean-review: no add-label calls were made (no dispatch:office-hours applied)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop clean-review: no add-label calls were made (no dispatch:office-hours applied)"
+  echo "    gh-pr-edit.log: $(cat "$STUB_DIR/gh-pr-edit.log" 2>/dev/null || true)"
+  echo "    gh-issue-edit.log: $(cat "$STUB_DIR/gh-issue-edit.log" 2>/dev/null || true)"
 fi
 stop_teardown
 

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -52,7 +52,7 @@ Act on the one directive:
 |---|---|---|---|
 | `INVOKE /fix-checks` | 0 | draft PR, CI completed and failed | invoke `/fix-checks` |
 | `INVOKE /qa-fix` | 0 | draft PR, CI green, no `dispatch:*` label | invoke `/qa-fix` |
-| `INVOKE /review-fix` | 0 | draft PR + `dispatch:qa-done` (or `dispatch:reviewed` re-entry) | invoke `/review-fix` |
+| `INVOKE /review-fix` | 0 | draft PR + `dispatch:qa-done` | invoke `/review-fix` |
 | `INVOKE /budget-parse-job` | 0 | a statement parse-job issue (`statements:<key>` label, no PR) | invoke `/budget-parse-job` (see below) |
 | `INVOKE /fix-conflicts` | 0 | provisioning hit an `origin/main` merge conflict | invoke `/fix-conflicts` (the generic INVOKE path below) |
 | `INVOKE /implement` | 0 | no PR + `dispatch:planned` (`implement` phase) | invoke `/implement` (the generic INVOKE path below) |

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -57,7 +57,7 @@ Act on the one directive:
 | `INVOKE /fix-conflicts` | 0 | provisioning hit an `origin/main` merge conflict | invoke `/fix-conflicts` (the generic INVOKE path below) |
 | `INVOKE /implement` | 0 | no PR + `dispatch:planned` (`implement` phase) | invoke `/implement` (the generic INVOKE path below) |
 | `RELEVANCE-REVIEW` | 0 | no PR, unplanned (`plan` phase) | run the Step 2 relevance review, then dispatch its verdict |
-| `STOP done` | 0 | non-draft (ready) PR — should-never-happen; spawn boundary (#1109) prevents it upstream | stop without invoking a phase skill |
+| `STOP done` | 0 | non-draft (ready) PR, or a draft PR carrying `dispatch:reviewed` (review-complete — draft→ready owned by `dispatch-reconcile-ready`) | stop without invoking a phase skill |
 | `PUSH-STRANDED` | 0 | `done` PR, but the worktree has commits `origin/<branch>` hasn't seen | push `origin HEAD`, write an office-hours reason, stop with no marker |
 | `STOP waiting` | 0 | draft PR's CI has no verdict yet | print the verbatim message below and stop |
 | `STOP provision-failed` | 0 | `direnv`/merge provisioning failed (non-conflict) | stop with no marker (reason already written) |
@@ -66,10 +66,11 @@ Act on the one directive:
 ### `INVOKE` — run exactly one phase skill
 
 Invoke the one named phase skill via the Skill tool. Run exactly one phase per
-`/dispatch-worker` invocation. The PR stays a **draft** through every phase; the
-`review` phase's `/review-fix` flips it to ready as the workflow's terminal
-action. Each phase skill owns and applies its own `dispatch:*` label — the worker
-applies none:
+`/dispatch-worker` invocation. The PR stays a **draft** through every phase;
+after `/review-fix` applies `dispatch:reviewed`, draft→ready promotion is owned
+by the router's `dispatch-reconcile-ready` on a later tick (once CI is passing
+and `mergeable == MERGEABLE`). Each phase skill owns and applies its own
+`dispatch:*` label — the worker applies none:
 
 - **`/fix-checks`** — runs a single pass: fix one set of failed CI checks, record
   the outcome, post it, stop. No label.
@@ -85,7 +86,8 @@ applies none:
   Opus fix, and runs an Opus fix fan-out. The skill then commits the fixes via one
   `/commit-merge-push`, files meaningful out-of-scope findings as `blocked_by`
   follow-ups, posts one PR comment covering every finding, applies
-  `dispatch:reviewed`, and marks the PR ready. It is idempotent on re-entry.
+  `dispatch:reviewed`, and stops — draft→ready promotion is owned by the router's
+  `dispatch-reconcile-ready` on a later tick.
 - **`/implement`** — the `implement`-phase build skill for a no-PR issue carrying
   `dispatch:planned`. It reads the plan persisted to the issue's
   `<!-- dispatch:plan -->` comment, builds each unit via `/implement-unit`, and
@@ -170,14 +172,29 @@ on `dispatch:office-hours`.
 ### `STOP done` / `STOP wrong-worktree` — stop with no marker
 
 Stop without invoking a phase skill and without writing a marker. The Stop hook
-reads marker-absence and applies `dispatch:office-hours` to the issue. For `done`
-(a non-draft PR), no phase skill ran and the slip-past sweep (#843) flags this PR
-for office-hours review. Since #1109 the spawn boundary
-(`dispatch-materialize-spawn`) re-checks done before spawning and refuses to
-dispatch a done target, so `STOP done` is now a defensive guard for the
-sub-millisecond residual window between that re-check and worker boot — the
-normal-case done PR is caught upstream and no worker is spawned. For
-`wrong-worktree`, the spawn was incoherent — the branch-name sanity check
+reads marker-absence and applies `dispatch:office-hours` to the issue.
+
+`dispatch-route` emits `STOP done` for two distinct kinds of `done` PR:
+
+- **A draft PR carrying `dispatch:reviewed`** — `dispatch-phase` derives `done`
+  for it because review is complete (the `dispatch:reviewed` label is the
+  completion signal); draft→ready promotion is owned by the router's
+  `dispatch-reconcile-ready` on a later tick (once CI is passing and
+  `mergeable == MERGEABLE`). This is the **normal** clean-`/review-fix`-pass
+  outcome, not a defensive guard. In the normal flow the review worker already
+  ran `/review-fix` and wrote a `phase=review` marker, so its Stop hook sees the
+  derived `done` advance past `review` and **self-closes** (it does not park on
+  `dispatch:office-hours`). A worker that reaches this directive directly — spawned
+  against an already-reviewed PR with no phase skill to run — stops with no marker
+  and the Stop hook parks it for office-hours review.
+- **A non-draft (ready) PR** — no phase skill ran and the slip-past sweep (#843)
+  flags this PR for office-hours review. Since #1109 the spawn boundary
+  (`dispatch-materialize-spawn`) re-checks done before spawning and refuses to
+  dispatch a done target, so for this case `STOP done` is a defensive guard for
+  the sub-millisecond residual window between that re-check and worker boot — the
+  normal-case ready PR is caught upstream and no worker is spawned.
+
+For `wrong-worktree`, the spawn was incoherent — the branch-name sanity check
 rejected the spawn cwd, or the positional `<worktree-path>` disagreed with `git
 rev-parse --show-toplevel`; see `reference.md`.
 


### PR DESCRIPTION
Closes #1379

## Problem

After a clean `/review-fix` pass the worker applies `dispatch:reviewed` to the
PR, writes a `phase=review` marker, and deliberately leaves the PR a draft —
draft→ready promotion is the router's job (`dispatch-reconcile-ready` flips
draft→ready once CI is passing and `mergeable == MERGEABLE`). `dispatch:reviewed`
is the "review complete" signal.

But `dispatch-phase` still mapped a draft PR carrying `dispatch:reviewed` (with
non-failing CI) back to the phase string `review`. The worker's Stop hook then
computed `MARKER_PHASE (review) == CURRENT_PHASE (review)`; `review` is not a
`fix-*` phase, so the Branch C exemption did not apply and the hook fell into
Branch D ("true non-advancement"): it applied `dispatch:office-hours` to the
issue, spawned the next tick, and exited without self-closing. The review worker
leaked as a `state=done` agent, and every clean review pass wrongly labeled the
issue `dispatch:office-hours`.

The mapping (and its comment) were stale — written when `/review-fix` itself ran
`gh pr ready`. Promotion has since moved to the router's
`dispatch-reconcile-ready`, making the `review` phase terminal once
`dispatch:reviewed` is applied.

## Fix

`dispatch-phase` now derives `done` for a `dispatch:reviewed` draft PR (with
non-failing CI). `done` is the existing terminal phase string, so the fix
composes with every consumer without a new branch:

- **Stop hook** — `CURRENT_PHASE=done` ≠ `MARKER_PHASE=review` → Branch B: strip
  `dispatch:office-hours`, spawn the next tick, self-close.
- **Spawn boundary** — `dispatch-materialize-spawn` already refuses a `done`
  target (`target-done`), so a reviewed draft PR awaiting promotion is not
  re-selected for a phase skill.
- **`dispatch-route`** — the `done` case returns `STOP done`.
- **`dispatch-reconcile-ready`** — does not read `dispatch-phase`; promotion of a
  draft + `dispatch:reviewed` + passing + `MERGEABLE` PR is unchanged.

`dispatch:reviewed` is checked first in the label chain so it wins over any
co-present label. A failing reviewed PR is unaffected: the failing-verdict branch
returns `fix-checks` before the label mapping is reached. The dead legacy labels
(`dispatch:code-reviewed` / `dispatch:security-reviewed`) keep mapping to
`review` for in-flight tolerance.

## Changes

- **`dispatch-phase`** — map `dispatch:reviewed` → `done` (checked first); replace
  the stale "`/review-fix` … just finishes `gh pr ready`" comment with the current
  router-owned-promotion design.
- **`test-dispatch-scripts.sh`** — reviewed+green → `done`; reviewed+failing →
  `fix-checks`; reviewed+qa-done → `done` (reorder guard); dispatch-route
  reviewed-draft → `STOP done`; new dispatch-stop self-close-on-clean-review test
  (marker=review, current=done → one self-close, one spawn, no
  `dispatch:office-hours` add-label).
- **`dispatch-worker/SKILL.md`** — drop the stale `(or dispatch:reviewed
  re-entry)` annotation from the `INVOKE /review-fix` directive row.

## Acceptance criteria

- [x] `dispatch-phase` does not return `review` for a draft `dispatch:reviewed` PR
  with non-failing CI — it returns `done`.
- [x] A draft `dispatch:reviewed` PR with failing CI still classifies as
  `fix-checks` (unchanged failing-verdict branch).
- [x] On a clean `/review-fix` completion, the Stop hook self-closes the session
  (Branch B) — covered by the new dispatch-stop test asserting exactly one
  self-close.
- [x] On a clean `/review-fix` completion, no `dispatch:office-hours` label is
  applied — the new dispatch-stop test asserts no such add-label call.
- [x] `dispatch-reconcile-ready` still promotes a draft `dispatch:reviewed` PR to
  ready once CI is passing and `mergeable == MERGEABLE` — it does not read
  `dispatch-phase`; its existing promotion truth-table tests are untouched.
- [x] The stale `dispatch-phase` comment referencing `/review-fix … gh pr ready`
  is corrected to reflect router-owned promotion.
- [x] `test-dispatch-scripts.sh` covers the `dispatch-phase` mapping for a draft
  `dispatch:reviewed` PR (passing and failing CI) and the dispatch-stop
  self-close-on-clean-review path.

## Verification

`test-dispatch-scripts.sh` passes (2141/2141).
