### PR TITLE
office-hours: source capacity sampler member-emails from Secret Manager (PII-safe)

### DIFF
--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -520,6 +520,84 @@ router via a `parked-router` line, so a human can resume it. This makes a
 genuinely terminal stall visible rather than silently losing it to a missed
 heartbeat window.
 
+## Capacity telemetry sampling (#1007 / #1377)
+
+The office-hours Capacity "HISTORY" chart is driven by
+`office-hours/<env>/usage-samples` documents written locally once per dispatch
+tick by `dispatch-sample-usage` → `usage-sample-writer.mjs`. The hosted app
+cannot read the author's local telemetry (`rate_limits.json` and `claude agents
+--json`), so the time series is sampled locally and pushed to Firestore via the
+firebase-admin SDK.
+
+### Opt-in switch
+
+Sampling is **off by default**. Set `DISPATCH_USAGE_SAMPLES_ENABLED=1` in the
+dispatch machine's shell environment (e.g. `~/.zshrc` or `~/.bashrc`) to enable
+per-tick sampling. Any value other than exactly `"1"` — unset, empty, `"true"`,
+`"0"`, or anything else — causes the sampler to exit 0 as a no-op, leaving the
+tick unaffected.
+
+### Member-email source (PII handling)
+
+Member emails are **not** read from the environment. In real mode the writer
+resolves the member-email list from the **`OFFICE_HOURS_MEMBER_EMAILS`** Firebase
+/ GCP Secret Manager secret — the same canonical secret the `office-hours-sync`
+Cloud Function reads (established in #1257, reused here in #1377). The PII
+therefore lives only in Secret Manager, never in the repo, a shell var, or a
+local file.
+
+Optional non-PII override: set `DISPATCH_USAGE_SAMPLES_SECRET_NAME` to a
+different secret id if you need to point the local sampler at a distinct secret.
+The value must be non-empty and must contain no `/` (it is interpolated into the
+Secret Manager resource path). Default: `"OFFICE_HOURS_MEMBER_EMAILS"`.
+
+### Authentication (ADC)
+
+The writer uses **Application Default Credentials (ADC)** for both the Secret
+Manager read and the firebase-admin Firestore write — the same credentials,
+shared between the two operations. Configure ADC via either:
+
+- `GOOGLE_APPLICATION_CREDENTIALS` pointing at a service-account JSON key file, or
+- `gcloud auth application-default login` (interactive, suitable for local
+  development).
+
+The service account (or the logged-in principal) must have
+`roles/secretmanager.secretAccessor` on the `OFFICE_HOURS_MEMBER_EMAILS` secret.
+No separate credential or token is needed for sampling beyond what the Firestore
+write already requires.
+
+### Non-PII config
+
+All other sampler config is non-PII and may be committed or set in the
+environment. These variables and their defaults:
+
+| Variable | Default | Notes |
+|---|---|---|
+| `DISPATCH_USAGE_SAMPLES_GROUP_ID` | *(required, no default)* | Owning group id; must be non-empty and contain no `/`. |
+| `DISPATCH_USAGE_SAMPLES_NAMESPACE` | `"office-hours/prod"` | Firestore path prefix; must match `office-hours/<env>`. |
+| `DISPATCH_USAGE_SAMPLES_PROJECT_ID` | `"commons-systems"` | GCP project id for Secret Manager and Firestore. |
+| `DISPATCH_USAGE_SAMPLES_TTL_DAYS` | `"60"` | Retention in days; integer in `[30, 90]`. Feeds the `expireAt` TTL field. |
+
+### Fail-safe contract
+
+When `DISPATCH_USAGE_SAMPLES_ENABLED=1` but any required resource is missing or
+invalid — secret not found, credentials absent or expired, empty member-email
+list after resolving the secret, invalid config — the writer prints exactly one
+stderr diagnostic prefixed `usage-sample-writer:` and exits non-zero (1).
+Credentials and secret payloads are never echoed. No document is written; a doc
+with empty or wrong `memberEmails` is never created. The `dispatch-tick` caller
+wraps the sampler so a sample failure never errors the tick — the chain continues
+regardless.
+
+### Dry-run / test seam
+
+`usage-sample-writer.mjs --dry-run` does not import `@google-cloud/secret-manager`
+or `firebase-admin`, keeping the bash unit tests (`test-dispatch-scripts.sh`)
+dependency-free. In dry-run mode the member-email payload is injected via the
+`DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE` env var (the raw comma-separated string
+the secret would return). This seam is for testing only — it is never consulted
+in real mode, which always reads Secret Manager.
+
 ## Target-keyed CI-wait reseed (#979)
 
 CI-wait handling splits on available queue size, not invocation mode. In a

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-sample-usage
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-sample-usage
@@ -15,10 +15,11 @@
 #      which writes one office-hours/{env}/usage-samples document via the
 #      firebase-admin SDK (the admin SDK bypasses Firestore security rules, so
 #      this does NOT depend on the sibling #1006 rules being deployed).
-# The writer reads ALL of its config (member emails, group id, namespace, TTL,
-# project id) from env vars that must be pre-set in the environment (e.g., shell
-# profile); dispatch-tick inherits them but does not export them; this sampler
-# does NOT re-read them, except the opt-in gate (Step 1).
+# The writer reads its non-PII config (group id, namespace, TTL, project id)
+# from env vars that must be pre-set in the environment (e.g., shell profile);
+# dispatch-tick inherits them but does not export them; this sampler does NOT
+# re-read them. Member emails are NOT an env var — the writer resolves them
+# from Secret Manager at runtime (see opt-in gate, Step 1).
 #
 # FAIL-SAFE CONTRACT (per .claude/rules/code-style.md; mirrors
 # dispatch-refresh-rate-limits): every failure path logs exactly ONE stderr
@@ -29,8 +30,13 @@
 # without capacity-sampling config stay inert. A genuine success exits 0 too.
 #
 # TEST SEAMS (mirroring dispatch-target-workers / lib-claude-agents.sh):
-#   DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS      the opt-in switch (Step 1); also
-#                                             consumed by the writer.
+#   DISPATCH_USAGE_SAMPLES_ENABLED            opt-in switch (Step 1): set to "1"
+#                                             to enable per-tick sampling; any
+#                                             other value (unset/empty/other)
+#                                             exits 0 (no-op). Member emails are
+#                                             NOT sourced from an env var — the
+#                                             writer resolves them from Secret
+#                                             Manager at runtime.
 #   DISPATCH_USAGE_SAMPLES_RATE_LIMITS_PATH   override the rate_limits.json path.
 #   CLAUDE_AGENTS_CMD                          consumed by lib-claude-agents.sh
 #                                             for the busy-worker count.
@@ -42,9 +48,11 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # === STEP 1 — OPT-IN GATE =====================================================
-# No member emails configured → this machine is not set up for capacity
-# sampling. Exit 0 (a no-op, NOT a failure) so the tick stays inert here.
-if [[ -z "${DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS:-}" ]]; then
+# DISPATCH_USAGE_SAMPLES_ENABLED not set to "1" → this machine is not configured
+# for capacity sampling. Exit 0 (a no-op, NOT a failure) so the tick stays
+# inert here. Member emails are resolved from Secret Manager by the writer (Unit
+# 1 of #1377) — they are never an env var on this side.
+if [[ "${DISPATCH_USAGE_SAMPLES_ENABLED:-}" != "1" ]]; then
   exit 0
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -21410,11 +21410,12 @@ su_setup() {
 }
 su_teardown() {
   rm -rf "$TMPDIR_TEST"; TMPDIR_TEST=""
-  unset DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS DISPATCH_USAGE_SAMPLES_GROUP_ID \
+  unset DISPATCH_USAGE_SAMPLES_ENABLED DISPATCH_USAGE_SAMPLES_GROUP_ID \
     DISPATCH_USAGE_SAMPLES_NAMESPACE DISPATCH_USAGE_SAMPLES_TTL_DAYS \
     DISPATCH_USAGE_SAMPLES_PROJECT_ID DISPATCH_USAGE_SAMPLES_NOW \
     DISPATCH_USAGE_SAMPLES_RATE_LIMITS_PATH DISPATCH_USAGE_SAMPLES_TARGET_WORKERS_CMD \
-    DISPATCH_USAGE_SAMPLES_WRITER CLAUDE_AGENTS_CMD
+    DISPATCH_USAGE_SAMPLES_WRITER CLAUDE_AGENTS_CMD \
+    DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE DISPATCH_USAGE_SAMPLES_SECRET_NAME
 }
 
 # Fixed epoch for writer determinism: sampledAt=1780600000, TTL 60d →
@@ -21437,7 +21438,7 @@ su_write_fake_claude() {
 # all 9 schema fields + expireAt present; spot-checked values match input/config;
 # sampledAt/expireAt epochs match NOW and NOW+TTL*86400.
 su_setup
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com,c@d.com"
+export DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE="a@b.com,c@d.com"
 export DISPATCH_USAGE_SAMPLES_GROUP_ID="grp-1"
 export DISPATCH_USAGE_SAMPLES_NOW="$SU_NOW"
 W1_PAYLOAD='{"fiveHourUsedPct":4,"weeklyUsedPct":84,"fiveHourResetsAt":1780867800,"weeklyResetsAt":1780880400,"activeWorkers":1,"targetWorkers":3}'
@@ -21459,7 +21460,7 @@ su_teardown
 
 # W2 — null resets pass through as JSON null; exit 0, no crash.
 su_setup
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com"
+export DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE="a@b.com"
 export DISPATCH_USAGE_SAMPLES_GROUP_ID="grp-1"
 export DISPATCH_USAGE_SAMPLES_NOW="$SU_NOW"
 W2_PAYLOAD='{"fiveHourUsedPct":4,"weeklyUsedPct":84,"fiveHourResetsAt":null,"weeklyResetsAt":null,"activeWorkers":0,"targetWorkers":2}'
@@ -21469,18 +21470,18 @@ assert_eq "writer W2 → fiveHourResetsAt null" "null" "$(jq -r '.fiveHourResets
 assert_eq "writer W2 → weeklyResetsAt null" "null" "$(jq -r '.weeklyResetsAt' <<<"$out")"
 su_teardown
 
-# W3 — empty member emails → non-zero exit (fail-closed).
+# W3 — empty secret override → non-zero exit (fail-closed).
 su_setup
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS=""
+export DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE=""
 export DISPATCH_USAGE_SAMPLES_GROUP_ID="grp-1"
 export DISPATCH_USAGE_SAMPLES_NOW="$SU_NOW"
 if out=$(WRITER "$W1_PAYLOAD" 2>/dev/null); then rc=0; else rc=$?; fi
-assert_eq "writer W3 empty member emails → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "writer W3 empty secret override → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
 su_teardown
 
 # W4 — bad namespace (not office-hours/<env>) → non-zero exit.
 su_setup
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com"
+export DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE="a@b.com"
 export DISPATCH_USAGE_SAMPLES_GROUP_ID="grp-1"
 export DISPATCH_USAGE_SAMPLES_NAMESPACE="evil/prod"
 export DISPATCH_USAGE_SAMPLES_NOW="$SU_NOW"
@@ -21490,7 +21491,7 @@ su_teardown
 
 # W5 — TTL out of [30,90] → non-zero exit (above and below range).
 su_setup
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com"
+export DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE="a@b.com"
 export DISPATCH_USAGE_SAMPLES_GROUP_ID="grp-1"
 export DISPATCH_USAGE_SAMPLES_NOW="$SU_NOW"
 export DISPATCH_USAGE_SAMPLES_TTL_DAYS="100"
@@ -21503,7 +21504,7 @@ su_teardown
 
 # W5b — non-integer TTL string → non-zero exit.
 su_setup
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com"
+export DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE="a@b.com"
 export DISPATCH_USAGE_SAMPLES_GROUP_ID="grp-1"
 export DISPATCH_USAGE_SAMPLES_NOW="$SU_NOW"
 export DISPATCH_USAGE_SAMPLES_TTL_DAYS="abc"
@@ -21513,15 +21514,29 @@ su_teardown
 
 # W6 — missing groupId → non-zero exit.
 su_setup
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com"
+export DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE="a@b.com"
 export DISPATCH_USAGE_SAMPLES_NOW="$SU_NOW"
 if out=$(WRITER "$W1_PAYLOAD" 2>/dev/null); then rc=0; else rc=$?; fi
 assert_eq "writer W6 missing groupId → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
 su_teardown
 
+# W7 — DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE unset in --dry-run → non-zero
+# exit; writer prints "usage-sample-writer: --dry-run requires
+# DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE".
+su_setup
+export DISPATCH_USAGE_SAMPLES_GROUP_ID="grp-1"
+export DISPATCH_USAGE_SAMPLES_NOW="$SU_NOW"
+# SECRET_OVERRIDE deliberately unset
+if out=$(WRITER "$W1_PAYLOAD" 2>&1); then rc=0; else rc=$?; fi
+assert_eq "writer W7 unset secret override in dry-run → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "writer W7 → diagnostic message contains DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE" "1" \
+  "$([[ "$out" == *"DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE"* ]] && echo 1 || echo 0)"
+su_teardown
+
 # --- SAMPLER cases (fakes only; no real daemon / firebase) ------------------
 
-# S1 — opt-in OFF: member emails unset → exit 0 (no-op); writer NOT invoked.
+# S1 — opt-in OFF: DISPATCH_USAGE_SAMPLES_ENABLED unset → exit 0 (no-op); writer
+# NOT invoked.
 su_setup
 INVOKED="$TMPDIR_TEST/fix/invoked"
 CAPTURE="$TMPDIR_TEST/fix/payload.json"
@@ -21529,7 +21544,7 @@ printf '#!/usr/bin/env bash\n: > %s\ncat > %s\necho fake-id\n' "'$INVOKED'" "'$C
   > "$TMPDIR_TEST/fix/fake-writer"
 chmod +x "$TMPDIR_TEST/fix/fake-writer"
 export DISPATCH_USAGE_SAMPLES_WRITER="$TMPDIR_TEST/fix/fake-writer"
-# member emails deliberately unset
+# DISPATCH_USAGE_SAMPLES_ENABLED deliberately unset (opt-in switch off)
 if out=$("$TMPDIR_TEST/scripts/dispatch-sample-usage" 2>/dev/null); then rc=0; else rc=$?; fi
 assert_eq "sampler S1 opt-in off → exit 0" "0" "$rc"
 assert_eq "sampler S1 → writer NOT invoked" "1" "$([[ ! -e "$INVOKED" ]] && echo 1 || echo 0)"
@@ -21549,7 +21564,7 @@ su_write_fake_claude "$TMPDIR_TEST/fix/fake-claude" \
   '[{"sessionId":"s1","pid":1,"status":"busy","name":"42-foo"}]'
 printf '#!/usr/bin/env bash\necho 3\n' > "$TMPDIR_TEST/fix/fake-target"
 chmod +x "$TMPDIR_TEST/fix/fake-target"
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com"
+export DISPATCH_USAGE_SAMPLES_ENABLED="1"
 export DISPATCH_USAGE_SAMPLES_RATE_LIMITS_PATH="$TMPDIR_TEST/fix/rate_limits.json"
 export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/fix/fake-claude"
 export DISPATCH_USAGE_SAMPLES_TARGET_WORKERS_CMD="$TMPDIR_TEST/fix/fake-target"
@@ -21574,7 +21589,7 @@ su_write_fake_claude "$TMPDIR_TEST/fix/fake-claude" \
   '[{"sessionId":"s1","pid":1,"status":"busy","name":"42-foo"}]'
 printf '#!/usr/bin/env bash\necho 3\n' > "$TMPDIR_TEST/fix/fake-target"
 chmod +x "$TMPDIR_TEST/fix/fake-target"
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com"
+export DISPATCH_USAGE_SAMPLES_ENABLED="1"
 export DISPATCH_USAGE_SAMPLES_RATE_LIMITS_PATH="$TMPDIR_TEST/fix/does-not-exist.json"
 export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/fix/fake-claude"
 export DISPATCH_USAGE_SAMPLES_TARGET_WORKERS_CMD="$TMPDIR_TEST/fix/fake-target"
@@ -21597,7 +21612,7 @@ printf '%s\n' '{"five_hour":{"used_percentage":4,"resets_at":1780867800},"seven_
 su_write_fake_claude "$TMPDIR_TEST/fix/fake-claude" '{}'
 printf '#!/usr/bin/env bash\necho 3\n' > "$TMPDIR_TEST/fix/fake-target"
 chmod +x "$TMPDIR_TEST/fix/fake-target"
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com"
+export DISPATCH_USAGE_SAMPLES_ENABLED="1"
 export DISPATCH_USAGE_SAMPLES_RATE_LIMITS_PATH="$TMPDIR_TEST/fix/rate_limits.json"
 export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/fix/fake-claude"
 export DISPATCH_USAGE_SAMPLES_TARGET_WORKERS_CMD="$TMPDIR_TEST/fix/fake-target"
@@ -21620,7 +21635,7 @@ su_write_fake_claude "$TMPDIR_TEST/fix/fake-claude" \
   '[{"sessionId":"s1","pid":1,"status":"busy","name":"42-foo"}]'
 printf '#!/usr/bin/env bash\nexit 1\n' > "$TMPDIR_TEST/fix/fake-target"
 chmod +x "$TMPDIR_TEST/fix/fake-target"
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com"
+export DISPATCH_USAGE_SAMPLES_ENABLED="1"
 export DISPATCH_USAGE_SAMPLES_RATE_LIMITS_PATH="$TMPDIR_TEST/fix/rate_limits.json"
 export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/fix/fake-claude"
 export DISPATCH_USAGE_SAMPLES_TARGET_WORKERS_CMD="$TMPDIR_TEST/fix/fake-target"
@@ -21643,7 +21658,7 @@ su_write_fake_claude "$TMPDIR_TEST/fix/fake-claude" \
   '[{"sessionId":"s1","pid":1,"status":"busy","name":"42-foo"}]'
 printf '#!/usr/bin/env bash\necho not-a-number\n' > "$TMPDIR_TEST/fix/fake-target"
 chmod +x "$TMPDIR_TEST/fix/fake-target"
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com"
+export DISPATCH_USAGE_SAMPLES_ENABLED="1"
 export DISPATCH_USAGE_SAMPLES_RATE_LIMITS_PATH="$TMPDIR_TEST/fix/rate_limits.json"
 export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/fix/fake-claude"
 export DISPATCH_USAGE_SAMPLES_TARGET_WORKERS_CMD="$TMPDIR_TEST/fix/fake-target"
@@ -21665,7 +21680,7 @@ su_write_fake_claude "$TMPDIR_TEST/fix/fake-claude" \
   '[{"sessionId":"s1","pid":1,"status":"busy","name":"42-foo"}]'
 printf '#!/usr/bin/env bash\necho 3\n' > "$TMPDIR_TEST/fix/fake-target"
 chmod +x "$TMPDIR_TEST/fix/fake-target"
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com"
+export DISPATCH_USAGE_SAMPLES_ENABLED="1"
 export DISPATCH_USAGE_SAMPLES_RATE_LIMITS_PATH="$TMPDIR_TEST/fix/rate_limits.json"
 export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/fix/fake-claude"
 export DISPATCH_USAGE_SAMPLES_TARGET_WORKERS_CMD="$TMPDIR_TEST/fix/fake-target"
@@ -21687,7 +21702,7 @@ su_write_fake_claude "$TMPDIR_TEST/fix/fake-claude" \
   '[{"sessionId":"s1","pid":1,"status":"busy","name":"42-foo"}]'
 printf '#!/usr/bin/env bash\necho 3\n' > "$TMPDIR_TEST/fix/fake-target"
 chmod +x "$TMPDIR_TEST/fix/fake-target"
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com"
+export DISPATCH_USAGE_SAMPLES_ENABLED="1"
 export DISPATCH_USAGE_SAMPLES_RATE_LIMITS_PATH="$TMPDIR_TEST/fix/rate_limits.json"
 export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/fix/fake-claude"
 export DISPATCH_USAGE_SAMPLES_TARGET_WORKERS_CMD="$TMPDIR_TEST/fix/fake-target"
@@ -21709,13 +21724,28 @@ su_write_fake_claude "$TMPDIR_TEST/fix/fake-claude" \
   '[{"sessionId":"s1","pid":1,"status":"busy","name":"42-foo"}]'
 printf '#!/usr/bin/env bash\necho 3\n' > "$TMPDIR_TEST/fix/fake-target"
 chmod +x "$TMPDIR_TEST/fix/fake-target"
-export DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS="a@b.com"
+export DISPATCH_USAGE_SAMPLES_ENABLED="1"
 export DISPATCH_USAGE_SAMPLES_RATE_LIMITS_PATH="$TMPDIR_TEST/fix/rate_limits.json"
 export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/fix/fake-claude"
 export DISPATCH_USAGE_SAMPLES_TARGET_WORKERS_CMD="$TMPDIR_TEST/fix/fake-target"
 export DISPATCH_USAGE_SAMPLES_WRITER="$TMPDIR_TEST/fix/fake-writer"
 if out=$("$TMPDIR_TEST/scripts/dispatch-sample-usage" 2>/dev/null); then rc=0; else rc=$?; fi
 assert_eq "sampler S9 writer failure → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+su_teardown
+
+# S10 — opt-in switch set to a non-"1" value ("true") → exit 0 (no-op); writer
+# NOT invoked. Locks in the ==1 truthiness contract.
+su_setup
+INVOKED="$TMPDIR_TEST/fix/invoked"
+CAPTURE="$TMPDIR_TEST/fix/payload.json"
+printf '#!/usr/bin/env bash\n: > %s\ncat > %s\necho fake-id\n' "'$INVOKED'" "'$CAPTURE'" \
+  > "$TMPDIR_TEST/fix/fake-writer"
+chmod +x "$TMPDIR_TEST/fix/fake-writer"
+export DISPATCH_USAGE_SAMPLES_ENABLED="true"
+export DISPATCH_USAGE_SAMPLES_WRITER="$TMPDIR_TEST/fix/fake-writer"
+if out=$("$TMPDIR_TEST/scripts/dispatch-sample-usage" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "sampler S10 ENABLED=true (non-1) → exit 0" "0" "$rc"
+assert_eq "sampler S10 → writer NOT invoked" "1" "$([[ ! -e "$INVOKED" ]] && echo 1 || echo 0)"
 su_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/usage-sample-writer.mjs
+++ b/.claude/skills/dispatch-propagate/scripts/usage-sample-writer.mjs
@@ -17,9 +17,19 @@
 //   parser/serializer, rules, and demo seed; this file is the writer only.
 //
 // CONFIG (environment variables)
-//   DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS  comma-separated owner emails. Split on
-//     ",", trim, drop empties (same as office-hours-sync.ts). Required; an empty
-//     resolved list fails closed (the owner would be locked out of the doc).
+//   Member emails are NOT read from the environment. In real mode they come from
+//     the OFFICE_HOURS_MEMBER_EMAILS Firebase/GCP Secret Manager secret — the same
+//     canonical secret the office-hours-sync Cloud Function reads (reused from
+//     #1257, #1377). The PII therefore lives only in Secret Manager, never in the
+//     repo, a shell var, or a local file.
+//   DISPATCH_USAGE_SAMPLES_SECRET_NAME    optional, non-PII override for the secret
+//     id; default "OFFICE_HOURS_MEMBER_EMAILS". Must be non-empty and contain no
+//     "/" (it is interpolated into the secret resource path).
+//   DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE  --dry-run ONLY test seam: the raw
+//     comma-separated payload the secret would return. Consulted only in
+//     --dry-run; real mode always reads Secret Manager and never consults it
+//     (analogous to the DISPATCH_USAGE_SAMPLES_NOW time seam). Carries dummy
+//     emails in tests; it is NOT a production source of PII.
 //   DISPATCH_USAGE_SAMPLES_GROUP_ID       owning group id. Required; non-empty
 //     and must contain no "/" (a slash would escape the collection path).
 //   DISPATCH_USAGE_SAMPLES_NAMESPACE      default "office-hours/prod". Validated
@@ -32,10 +42,13 @@
 //     to Math.floor(Date.now()/1000). Test-determinism seam; a positive integer.
 //
 // AUTH — Application Default Credentials (ADC)
-//   Real-mode writes authenticate via ADC: either GOOGLE_APPLICATION_CREDENTIALS
+//   Real-mode runs authenticate via ADC: either GOOGLE_APPLICATION_CREDENTIALS
 //   pointing at a service-account key, or `gcloud auth application-default
-//   login`. This file does NOT configure credentials — it relies on the ambient
-//   ADC of the author's machine where the sampler runs.
+//   login`. The SAME ADC authenticates BOTH the Secret Manager read (the member-
+//   email list) and the firebase-admin Firestore write. This file does NOT
+//   configure credentials — it relies on the ambient ADC of the author's machine
+//   where the sampler runs. The service account needs
+//   roles/secretmanager.secretAccessor on the OFFICE_HOURS_MEMBER_EMAILS secret.
 //
 // FAIL-SAFE CONTRACT (per .claude/rules/code-style.md; mirrors the "log and
 // skip" posture of office-hours-sync.ts and dispatch-refresh-rate-limits)
@@ -46,12 +59,16 @@
 //
 // MODES
 //   --dry-run  (first CLI arg): read stdin, run ALL config + payload validation,
+//     take the member-email list from DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE,
 //     assemble the doc with Timestamps rendered as ISO strings, print it as
-//     pretty JSON to stdout, exit 0. firebase-admin is NEVER imported, so the
-//     bash unit tests (test-dispatch-scripts.sh) stay dependency-free.
-//   real mode (no --dry-run): dynamically import firebase-admin, assemble the
-//     doc with firebase-admin Timestamps, `.add()` it to the collection, print
-//     the new doc id to stdout, exit 0.
+//     pretty JSON to stdout, exit 0. Neither firebase-admin nor
+//     @google-cloud/secret-manager is imported, so the bash unit tests
+//     (test-dispatch-scripts.sh) stay dependency-free.
+//   real mode (no --dry-run): dynamically import @google-cloud/secret-manager and
+//     fetch the member-email list from the OFFICE_HOURS_MEMBER_EMAILS secret
+//     (fail-fast, before any firebase-admin init), then dynamically import
+//     firebase-admin, assemble the doc with firebase-admin Timestamps, `.add()`
+//     it to the collection, print the new doc id to stdout, exit 0.
 //   The field set and the epoch-second inputs are IDENTICAL between modes; only
 //   the Timestamp representation differs (ISO string vs admin Timestamp).
 //
@@ -83,19 +100,34 @@ function isFiniteNumber(v) {
   return typeof v === "number" && Number.isFinite(v);
 }
 
-// Parse + validate config from the environment. Returns a config object or
-// calls fail() (which exits).
-function loadConfig(env) {
-  const memberEmailsStr = env.DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS;
-  if (typeof memberEmailsStr !== "string") {
-    fail("DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS is required");
-  }
-  const memberEmails = memberEmailsStr
+// Default Secret Manager secret id for the member-email PII list. Reuses the
+// canonical secret the office-hours-sync Cloud Function reads (#1257, #1377);
+// do not create a second secret.
+const DEFAULT_SECRET_NAME = "OFFICE_HOURS_MEMBER_EMAILS";
+
+// Parse a comma-separated member-email payload into a trimmed, non-empty list.
+// Identical semantics to office-hours-sync.ts: split on ",", trim, drop empties.
+// An empty resolved list fails closed (the owner would be locked out of the doc).
+function resolveMemberEmails(rawCsv) {
+  const memberEmails = rawCsv
     .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
   if (memberEmails.length === 0) {
-    fail("DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS resolved to an empty list");
+    fail("member-email list resolved to an empty list");
+  }
+  return memberEmails;
+}
+
+// Parse + validate config from the environment. Returns a config object or
+// calls fail() (which exits).
+function loadConfig(env) {
+  const secretName = env.DISPATCH_USAGE_SAMPLES_SECRET_NAME ?? DEFAULT_SECRET_NAME;
+  if (typeof secretName !== "string" || secretName.length === 0) {
+    fail("DISPATCH_USAGE_SAMPLES_SECRET_NAME must be non-empty");
+  }
+  if (secretName.includes("/")) {
+    fail("DISPATCH_USAGE_SAMPLES_SECRET_NAME must not contain a slash");
   }
 
   const groupId = env.DISPATCH_USAGE_SAMPLES_GROUP_ID;
@@ -136,7 +168,7 @@ function loadConfig(env) {
     nowEpochSeconds = Number(nowStr);
   }
 
-  return { memberEmails, groupId, namespace, ttlDays, projectId, nowEpochSeconds };
+  return { secretName, groupId, namespace, ttlDays, projectId, nowEpochSeconds };
 }
 
 // Parse + validate the stdin payload. Returns a payload object or calls fail().
@@ -209,6 +241,15 @@ async function main() {
   const payload = loadPayload(raw);
 
   if (dryRun) {
+    // Dry-run member-email source — a test seam carrying the raw payload the
+    // secret would return. Consulted ONLY here; never in real mode. Keeps the
+    // bash unit suite (no @google-cloud/secret-manager installed) dependency-free.
+    const rawSecret = process.env.DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE;
+    if (rawSecret === undefined) {
+      fail("--dry-run requires DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE");
+    }
+    config.memberEmails = resolveMemberEmails(rawSecret);
+
     // ISO-string factory — keeps firebase-admin out of the dependency graph so
     // the bash unit tests run without it. JSON.stringify renders Timestamps as
     // ISO strings and null resets as JSON null.
@@ -218,7 +259,18 @@ async function main() {
     process.exit(0);
   }
 
-  // Real mode — import firebase-admin only on this path.
+  // Real mode — resolve the member-email list from Secret Manager FIRST, before
+  // any firebase-admin init, so a secret/credential failure fails fast through
+  // main().catch -> fail() (one diagnostic, exit 1, no document, no creds echoed).
+  const { SecretManagerServiceClient } = await import("@google-cloud/secret-manager");
+  const secretClient = new SecretManagerServiceClient();
+  const [version] = await secretClient.accessSecretVersion({
+    name: `projects/${config.projectId}/secrets/${config.secretName}/versions/latest`,
+  });
+  const rawSecret = version.payload.data.toString("utf8");
+  config.memberEmails = resolveMemberEmails(rawSecret);
+
+  // Import firebase-admin only on this path.
   const { getApps, initializeApp } = await import("firebase-admin/app");
   const { getFirestore, Timestamp } = await import("firebase-admin/firestore");
 

--- a/.claude/skills/dispatch-propagate/scripts/usage-sample-writer.mjs
+++ b/.claude/skills/dispatch-propagate/scripts/usage-sample-writer.mjs
@@ -123,7 +123,7 @@ function resolveMemberEmails(rawCsv) {
 // calls fail() (which exits).
 function loadConfig(env) {
   const secretName = env.DISPATCH_USAGE_SAMPLES_SECRET_NAME ?? DEFAULT_SECRET_NAME;
-  if (typeof secretName !== "string" || secretName.length === 0) {
+  if (secretName.length === 0) {
     fail("DISPATCH_USAGE_SAMPLES_SECRET_NAME must be non-empty");
   }
   if (secretName.includes("/")) {
@@ -155,6 +155,9 @@ function loadConfig(env) {
   const projectId = env.DISPATCH_USAGE_SAMPLES_PROJECT_ID ?? "commons-systems";
   if (typeof projectId !== "string" || projectId.length === 0) {
     fail("DISPATCH_USAGE_SAMPLES_PROJECT_ID must be non-empty");
+  }
+  if (projectId.includes("/")) {
+    fail("DISPATCH_USAGE_SAMPLES_PROJECT_ID must not contain a slash");
   }
 
   let nowEpochSeconds;
@@ -267,6 +270,9 @@ async function main() {
   const [version] = await secretClient.accessSecretVersion({
     name: `projects/${config.projectId}/secrets/${config.secretName}/versions/latest`,
   });
+  if (!version?.payload?.data) {
+    fail(`secret ${config.secretName} returned an empty or missing payload`);
+  }
   const rawSecret = version.payload.data.toString("utf8");
   config.memberEmails = resolveMemberEmails(rawSecret);
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,6 +13,7 @@
     "node": "22"
   },
   "dependencies": {
+    "@google-cloud/secret-manager": "^6.1.3",
     "firebase-admin": "^13.0.0",
     "firebase-functions": "^6.3.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,6 +198,7 @@
     "functions": {
       "name": "@commons-systems/functions",
       "dependencies": {
+        "@google-cloud/secret-manager": "^6.1.3",
         "firebase-admin": "^13.0.0",
         "firebase-functions": "^6.3.0"
       },
@@ -1603,6 +1604,187 @@
         "node": ">=14"
       }
     },
+    "node_modules/@google-cloud/secret-manager": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-6.1.3.tgz",
+      "integrity": "sha512-3e/5GLusy1sWBEUvIlJbJpaaUlaf4MeeGQDUBdIVCqWYnn0lNPtbO6ZbJhTPiOkct2yxi8DXWgzWDbCJdDq9Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/google-gax": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.7.tgz",
+      "integrity": "sha512-EhiqaWWJ+9h7sCcKJTsoo6tMcjokVHhWsbSuWCnZJT4vIBP3y4mAoFLnt9SzgkVZeq24ZsFaArr06nnYYku2yA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "10.5.0",
+        "google-logging-utils": "1.1.3",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "3.0.4",
+        "protobufjs": "^7.5.4",
+        "retry-request": "^8.0.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/retry-request": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.3.tgz",
+      "integrity": "sha512-qqoc4kkGgP9cmQDWELlOpAmfgJOg0Yi7MT82ZjiPWu451ayju4itwomjM4/dBEliify8C1b3tSaeCOldugtwPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/secret-manager/node_modules/teeny-request": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.3.tgz",
+      "integrity": "sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@google-cloud/storage": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
@@ -2271,6 +2453,102 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -2283,7 +2561,6 @@
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
       "license": "MIT",
-      "optional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -2574,6 +2851,16 @@
       "optional": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@playwright/test": {
@@ -3889,7 +4176,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -4254,7 +4540,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4877,13 +5162,18 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1",
         "stream-shift": "^1.0.2"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -4920,7 +5210,6 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -5714,6 +6003,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
@@ -5929,6 +6234,27 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5940,6 +6266,30 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -6488,7 +6838,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isoformat": {
@@ -6496,6 +6845,21 @@
       "resolved": "https://registry.npmjs.org/isoformat/-/isoformat-0.2.1.tgz",
       "integrity": "sha512-tFLRAygk9NqrRPhJSnNGh7g7oaVWDwR0wKh/GM2LgmPa50Eg4UfyaCO4I8k6EqJHl1/uh2RAD6g06n5ygEnrjQ==",
       "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jose": {
       "version": "4.15.9",
@@ -6932,6 +7296,15 @@
         "node": "*"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/missing.css": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/missing.css/-/missing.css-1.3.0.tgz",
@@ -7062,7 +7435,6 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 6"
       }
@@ -7114,7 +7486,6 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -7168,6 +7539,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/pako": {
       "version": "1.0.11",
@@ -7227,11 +7604,32 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
@@ -7486,7 +7884,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7548,6 +7945,21 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/robust-predicates": {
@@ -7772,7 +8184,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7785,7 +8196,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7870,6 +8280,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7908,7 +8330,6 @@
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "stubs": "^3.0.0"
       }
@@ -7917,15 +8338,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -7944,7 +8363,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -7986,8 +8433,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -9059,7 +9505,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -9115,12 +9560,29 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.20.0",


### PR DESCRIPTION
Closes #1377

## What

Brings the local capacity sampler onto the same canonical PII source the
Cloud-Function side already uses, so the office-hours Capacity HISTORY chart can
populate with the owner's real `office-hours/prod/usage-samples` series.

The sampler was a silent opt-in keyed off the **PII** env var
`DISPATCH_USAGE_SAMPLES_MEMBER_EMAILS`. That var is unset on the dispatch
machine, so the deployed sampler wrote nothing every tick. The member-email list
is PII and must not enter the public repo, a shell env var, a local file, or a
local secret store.

This change:

- **Sources member emails from Secret Manager at runtime.** The writer
  (`usage-sample-writer.mjs`) resolves the list from the `OFFICE_HOURS_MEMBER_EMAILS`
  Firebase Secret Manager secret — the same secret #1257 created for the
  office-hours Cloud Function — via the `@google-cloud/secret-manager` SDK,
  authenticating with the same Application Default Credentials the writer already
  needs for its firebase-admin Firestore write. No second secret; one canonical
  source for the function side and the local sampler.
- **Decouples the opt-in gate from the PII.** `dispatch-sample-usage` now gates
  per-tick sampling on a non-PII `DISPATCH_USAGE_SAMPLES_ENABLED=1` switch
  (anything other than exactly `1` → no-op). Enabling sampling no longer requires
  putting emails in the environment.
- **Keeps dry-run dependency-free.** The Secret Manager fetch lives only on the
  real-mode path (mirroring how firebase-admin is dynamically imported only in
  real mode). `--dry-run` reads a test-only `DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE`
  seam and never imports the SDK, so the bash unit suite runs without
  `@google-cloud/secret-manager` or `firebase-admin` installed.
- **Documents the setup** in `dispatch-propagate/reference.md`: the opt-in switch,
  the secret name, ADC authentication, the required
  `roles/secretmanager.secretAccessor` IAM role, the non-PII config defaults, and
  the fail-safe contract — with no PII.

## Fail-safe contract (preserved)

When enabled, a missing/failed secret fetch or missing credentials produces one
stderr diagnostic prefixed `usage-sample-writer:`, a non-zero exit, and no
document written — never a doc with empty/wrong `memberEmails`. The
`dispatch-tick` wrapper logs the sampler failure and proceeds, so the tick is
never gated.

## Tests

- `bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` — all
  writer (W*) and sampler (S*) cases green (2139/2139). Dry-run assembles the doc
  from the secret-override seam; empty/missing override fail-closed; opt-in-off
  no-ops with `DISPATCH_USAGE_SAMPLES_ENABLED` unset; `=1` proceeds; a non-`1`
  value no-ops (locks in the `==1` truthiness contract). This suite is not wired
  into CI, so it was run explicitly during the build.
- No member-email PII introduced by this change (diff scan clean); the only
  `nathan@natb1.com` hits in the repo are the pre-existing public contact email in
  `landing/`, `blog/`, `.claude-plugin/`, and `nix/`.
- `package-lock.json` consistent (`npm install --package-lock-only` leaves no
  further diff).

## Owner follow-up (post-merge, out of scope for this code change)

Acceptance criteria 6–7 require real credentials on the dispatch machine and
cannot run in CI:

1. Grant the sampler's service account `roles/secretmanager.secretAccessor` on
   the `OFFICE_HOURS_MEMBER_EMAILS` secret.
2. Export `DISPATCH_USAGE_SAMPLES_ENABLED=1` on the dispatch machine.
3. Let one dispatch tick run; confirm a new `office-hours/prod/usage-samples`
   document appears whose `memberEmails` (sourced from the secret) includes the
   owner and is readable under `firestore.rules`.

The Capacity HISTORY view then shows the owner's real series once #1304's
empty-vs-demo display fix lands (orthogonal; both needed for real history to
render rather than the demo fallback).

## Related

- #1257 — established the `defineSecret` PII pattern and the
  `OFFICE_HOURS_MEMBER_EMAILS` secret on the Cloud-Function side; reused here.
- #1304 — display bug, orthogonal but both needed for real history to show.
- #1007 / #1005 — the capacity sampler and Capacity view this configures.
