### PR TITLE
commit-merge-push: validate --worktree is under the worktrees root

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/commit-merge-push
+++ b/.claude/skills/dispatch-propagate/scripts/commit-merge-push
@@ -146,17 +146,23 @@ if [[ -n "$WORKTREE" ]]; then
     echo "$PROG: cannot resolve worktrees root '$WORKTREES_ROOT'" >&2
     exit 2
   fi
-  if ! WORKTREE_REAL=$(realpath -- "$WORKTREE" 2>/dev/null); then
+  # realpath -e (GNU) / --canonicalize-existing fails on a nonexistent path on
+  # Linux too; without -e, GNU realpath resolves nonexistent paths syntactically
+  # and returns 0, so the "does not exist" diagnostic would never fire.
+  if ! WORKTREE_REAL=$(realpath -e -- "$WORKTREE" 2>/dev/null); then
     echo "$PROG: --worktree path '$WORKTREE' does not exist" >&2
     exit 2
   fi
-  case "$WORKTREE_REAL/" in
-    "$WORKTREES_ROOT_REAL"/*) : ;;  # strict subdir of the worktrees root — OK
-    *)
-      echo "$PROG: --worktree '$WORKTREE' (resolved '$WORKTREE_REAL') is not under the worktrees root '$WORKTREES_ROOT_REAL'; refusing" >&2
-      exit 2
-      ;;
-  esac
+  # Require a strict subdirectory of the worktrees root: reject the root itself
+  # and anything outside it. The `/?*` pattern requires at least one character
+  # to follow the root's trailing slash, so WORKTREE_REAL == WORKTREES_ROOT_REAL
+  # is rejected (a `*`-only pattern would wrongly accept the root, since `*`
+  # matches the empty string after the appended trailing slash).
+  if [[ "$WORKTREE_REAL" == "$WORKTREES_ROOT_REAL" \
+        || "$WORKTREE_REAL/" != "$WORKTREES_ROOT_REAL"/?* ]]; then
+    echo "$PROG: --worktree '$WORKTREE' (resolved '$WORKTREE_REAL') is not under the worktrees root '$WORKTREES_ROOT_REAL'; refusing" >&2
+    exit 2
+  fi
   WORKTREE="$WORKTREE_REAL"
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/commit-merge-push
+++ b/.claude/skills/dispatch-propagate/scripts/commit-merge-push
@@ -22,8 +22,9 @@
 # Exit-code contract:
 #   0 — success (merge-only clean, or single-unit committed+merged+pushed); pushed.
 #   1 — other failure (fetch failure, unexpected git error); unchanged / safe.
-#   2 — usage error (bad/missing/conflicting args, un-cd-able worktree, or staged
-#       changes in merge-only mode); unchanged.
+#   2 — usage error (bad/missing/conflicting args, a --worktree not under the
+#       worktrees root, an un-cd-able worktree, or staged changes in merge-only
+#       mode); unchanged.
 #   3 — merge conflict; `git merge --abort` run, tree left clean; not pushed.
 #       In single-unit mode the local commit has ALREADY been made before the
 #       merge, so after exit 3 local HEAD is one commit ahead of its pre-script
@@ -117,6 +118,46 @@ else
     echo "$PROG: --intent text must be non-empty" >&2
     exit 2
   fi
+fi
+
+# --- Validate --worktree is under the project worktrees root ----------------
+# A --worktree argument is attacker-influenceable (prompt injection). Before the
+# cd, resolve it canonically and require it to be a strict subdirectory of the
+# project's worktrees root — otherwise the script would run git add/commit/push
+# in a foreign repo. The worktrees root is anchored on this SCRIPT's own
+# location (trusted), never on cwd or the argument. Derivation mirrors lib.sh's
+# resolve_project_root: project root = parent of the git common dir; worktrees
+# root = <project-root>/worktrees. An explicit DISPATCH_WORKTREES_ROOT overrides
+# the git lookup (test seam, same convention as DISPATCH_CONFIG_DIR /
+# DISPATCH_LOCK_FILE).
+if [[ -n "$WORKTREE" ]]; then
+  SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+  if [[ -n "${DISPATCH_WORKTREES_ROOT:-}" ]]; then
+    WORKTREES_ROOT="$DISPATCH_WORKTREES_ROOT"
+  else
+    if ! COMMON_DIR=$(git -C "$SCRIPT_DIR" rev-parse --path-format=absolute \
+        --git-common-dir 2>/dev/null); then
+      echo "$PROG: cannot resolve the script's repository (for worktrees-root check)" >&2
+      exit 2
+    fi
+    WORKTREES_ROOT="$(dirname -- "$COMMON_DIR")/worktrees"
+  fi
+  if ! WORKTREES_ROOT_REAL=$(realpath -- "$WORKTREES_ROOT" 2>/dev/null); then
+    echo "$PROG: cannot resolve worktrees root '$WORKTREES_ROOT'" >&2
+    exit 2
+  fi
+  if ! WORKTREE_REAL=$(realpath -- "$WORKTREE" 2>/dev/null); then
+    echo "$PROG: --worktree path '$WORKTREE' does not exist" >&2
+    exit 2
+  fi
+  case "$WORKTREE_REAL/" in
+    "$WORKTREES_ROOT_REAL"/*) : ;;  # strict subdir of the worktrees root — OK
+    *)
+      echo "$PROG: --worktree '$WORKTREE' (resolved '$WORKTREE_REAL') is not under the worktrees root '$WORKTREES_ROOT_REAL'; refusing" >&2
+      exit 2
+      ;;
+  esac
+  WORKTREE="$WORKTREE_REAL"
 fi
 
 # --- cd to worktree ---------------------------------------------------------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -22762,11 +22762,16 @@ cmp_setup() {
   git clone -q "$CMP_BARE" "$CMP_CLONE" 2>/dev/null
   git -C "$CMP_CLONE" config user.email "test@test"
   git -C "$CMP_CLONE" config user.name "Test"
+
+  # Override the worktrees root to $CMP_TMPDIR so that $CMP_CLONE (=
+  # $CMP_TMPDIR/clone) is treated as a valid worktree by the validation guard.
+  export DISPATCH_WORKTREES_ROOT="$CMP_TMPDIR"
 }
 
 cmp_teardown() {
   rm -rf "$CMP_TMPDIR"
   unset CMP_TMPDIR CMP_BARE CMP_CLONE
+  unset DISPATCH_WORKTREES_ROOT
 }
 
 # --- Case 1: merge-only, clean → exit 0, new commit present in clone ----------
@@ -22997,6 +23002,41 @@ assert_eq "non-ff push rejection → local HEAD advanced (commit was made)" \
 origin_feature_tip=$(git -C "$CMP_BARE" rev-parse feature-x)
 assert_eq "non-ff push rejection → origin feature-x tip is helper's (not force-pushed)" \
   "$helper_tip" "$origin_feature_tip"
+cmp_teardown
+
+# --- Case 8: foreign --worktree outside worktrees root → exit 2, no commit ---
+echo "Test: foreign --worktree outside worktrees root → exit 2, no commit"
+cmp_setup
+unset DISPATCH_WORKTREES_ROOT          # exercise the real derivation
+ATTACKER=$(mktemp -d)                   # independent dir, not under CMP_TMPDIR
+git init -q -b main "$ATTACKER"
+git -C "$ATTACKER" config user.email "atk@atk"
+git -C "$ATTACKER" config user.name "Attacker"
+printf 'seed\n' > "$ATTACKER/seed.txt"
+git -C "$ATTACKER" add seed.txt
+git -C "$ATTACKER" commit -q -m "attacker seed"
+atk_head_before=$(git -C "$ATTACKER" rev-parse HEAD)
+printf 'pwned\n' > "$ATTACKER/seed.txt"
+set +e
+"$CMP" --worktree "$ATTACKER" --intent "exfil" --file seed.txt
+cmp8_rc=$?
+set -e
+assert_eq "foreign --worktree → exit 2" "2" "$cmp8_rc"
+atk_head_after=$(git -C "$ATTACKER" rev-parse HEAD)
+assert_eq "foreign --worktree → attacker HEAD unchanged (no commit)" \
+  "$atk_head_before" "$atk_head_after"
+rm -rf "$ATTACKER"
+export DISPATCH_WORKTREES_ROOT="$CMP_TMPDIR"   # restore for symmetry before teardown
+cmp_teardown
+
+# --- Case 9: nonexistent --worktree → exit 2 ----------------------------------
+echo "Test: nonexistent --worktree → exit 2"
+cmp_setup
+set +e
+"$CMP" --worktree "$CMP_TMPDIR/does-not-exist" --merge-only
+cmp9_rc=$?
+set -e
+assert_eq "nonexistent --worktree → exit 2" "2" "$cmp9_rc"
 cmp_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -23324,14 +23324,35 @@ rm -rf "$ATTACKER"
 export DISPATCH_WORKTREES_ROOT="$CMP_TMPDIR"   # restore for symmetry before teardown
 cmp_teardown
 
-# --- Case 9: nonexistent --worktree → exit 2 ----------------------------------
-echo "Test: nonexistent --worktree → exit 2"
+# --- Case 9: nonexistent --worktree outside the worktrees root → exit 2 -------
+# Exercise the worktrees-root guard, not the later cd failure. On Linux, GNU
+# realpath returns rc=0 for a nonexistent path, so a nonexistent path *under*
+# the override root (e.g. "$CMP_TMPDIR/does-not-exist") would pass the
+# case-statement prefix check and reach the cd — exiting 2 only because cd
+# fails, which tests the wrong guard. By pointing at a nonexistent path OUTSIDE
+# the worktrees root, the case-statement rejection fires before any cd on every
+# platform (on macOS the realpath failure catches it even earlier).
+echo "Test: nonexistent --worktree outside worktrees root → exit 2"
+cmp_setup
+set +e
+"$CMP" --worktree "$CMP_TMPDIR/../outside-does-not-exist" --merge-only
+cmp9_rc=$?
+set -e
+assert_eq "nonexistent --worktree outside root → exit 2" "2" "$cmp9_rc"
+cmp_teardown
+
+# --- Case 10: --worktree under the root but un-cd-able → exit 2 ----------------
+# A nonexistent path UNDER the worktrees root passes the realpath/prefix guard
+# on Linux (GNU realpath succeeds for nonexistent paths) and is rejected only by
+# the subsequent cd failure. This pins that distinct exit-2 path so Case 9's
+# guard coverage and the cd-failure coverage stay separate.
+echo "Test: --worktree under root but un-cd-able → exit 2"
 cmp_setup
 set +e
 "$CMP" --worktree "$CMP_TMPDIR/does-not-exist" --merge-only
-cmp9_rc=$?
+cmp10_rc=$?
 set -e
-assert_eq "nonexistent --worktree → exit 2" "2" "$cmp9_rc"
+assert_eq "un-cd-able --worktree under root → exit 2" "2" "$cmp10_rc"
 cmp_teardown
 
 # ============================================================================


### PR DESCRIPTION
Closes #1384

## Problem

`commit-merge-push` accepts a `--worktree <path>` argument that flowed straight
into `cd "$WORKTREE"` with no validation that the target is a worktree of the
expected repository. `REPO_ROOT` was derived from `git rev-parse --show-toplevel`
*after* the `cd`, so it reflected whatever repo was targeted — offering no
protection.

A model or skill manipulated via prompt injection could invoke the script with
`--worktree /path/to/attacker-controlled-git-repo`, making it run `git add` /
`git commit` / `git push` in a foreign repo — exfiltrating data via a push to an
attacker remote, committing malicious content elsewhere, or silently operating
on a repo with a different push target.

## Fix

Before the `cd`, resolve `--worktree` to a canonical path with `realpath` and
reject (exit 2 — usage error) any path that is not a strict subdirectory of the
project's worktrees root. The worktrees root is anchored on the script's *own*
location (the trusted anchor) via `git -C "$SCRIPT_DIR" rev-parse
--git-common-dir`, never on cwd or the untrusted argument. Both sides are
`realpath`-canonicalized, so the prefix compare holds even when a parent
component is a symlink, and `..` traversal collapses out. The block is guarded
by `[[ -n "$WORKTREE" ]]`, leaving the no-`--worktree` path (caller `cd`s itself)
unchanged.

An explicit `DISPATCH_WORKTREES_ROOT` overrides the git lookup as a test seam,
following the same convention as `DISPATCH_CONFIG_DIR` / `DISPATCH_LOCK_FILE`.

## Tests

`test-dispatch-scripts.sh`:

- The existing commit-merge-push cases (1–7) now export `DISPATCH_WORKTREES_ROOT`
  in `cmp_setup` so their `/tmp` clone resolves as a valid worktree — they pass
  unchanged.
- **Case 8** — a foreign `--worktree` at an independent `mktemp -d` outside the
  real worktrees root is rejected with exit 2, and the attacker repo's HEAD is
  asserted unchanged (no commit). The override is unset for this case so the
  script exercises the real production derivation.
- **Case 9** — a nonexistent `--worktree` is rejected with exit 2.

Full suite passes (2177/2177); the commit-merge-push section reports Cases 1–9
passing. Manual spot-check: `--worktree /tmp --merge-only` is refused with exit 2
and no git write.
