### PR TITLE
print: gate the view route on local-folder readiness and re-render on bind

### DIFF
--- a/print/src/library.ts
+++ b/print/src/library.ts
@@ -79,6 +79,21 @@ export function fileToLocalItem(file: File, name: string): MediaItem | null {
 
 let localSource: MediaSource<MediaItem> | null = null;
 
+let resolveLocalFolderReady!: () => void;
+const localFolderReadyPromise = new Promise<void>((resolve) => {
+  resolveLocalFolderReady = resolve;
+});
+
+/** Resolves once the initial local-folder init pass has settled (source bound or not). */
+export function whenLocalFolderReady(): Promise<void> {
+  return localFolderReadyPromise;
+}
+
+/** Mark the initial local-folder init pass settled. Idempotent (Promise resolve no-ops after first). */
+export function markLocalFolderReady(): void {
+  resolveLocalFolderReady();
+}
+
 /** Bind a local-folder source over a chosen directory handle. */
 export function createLocalSource(directory: FileSystemDirectoryHandle): void {
   localSource = createLocalFolderMediaSource<MediaItem>({

--- a/print/src/local-folder-ui.ts
+++ b/print/src/local-folder-ui.ts
@@ -69,7 +69,8 @@ export async function initLocalFolder(
     window.addEventListener("focus", onFocus);
     focusCleanup = () => window.removeEventListener("focus", onFocus);
     // Signal that localSource is now bound — lets the caller re-render a
-    // viewer route that was stuck on Not Found before this (post-grant) bind.
+    // viewer route that was stuck on Not Found before this bind (any path:
+    // auto-bind, grant-click, or first-open picker).
     onSourceBound?.();
   }
 

--- a/print/src/local-folder-ui.ts
+++ b/print/src/local-folder-ui.ts
@@ -44,6 +44,7 @@ let focusCleanup: (() => void) | null = null;
 export async function initLocalFolder(
   section: HTMLElement,
   mediaListContainer: HTMLElement,
+  onSourceBound?: () => void,
 ): Promise<(() => void) | null> {
   if (!store.isSupported()) {
     // Non-Chromium: no FSA, stay on the cloud-only path. Render nothing.
@@ -67,6 +68,9 @@ export async function initLocalFolder(
     };
     window.addEventListener("focus", onFocus);
     focusCleanup = () => window.removeEventListener("focus", onFocus);
+    // Signal that localSource is now bound — lets the caller re-render a
+    // viewer route that was stuck on Not Found before this (post-grant) bind.
+    onSourceBound?.();
   }
 
   async function openFolder(): Promise<void> {

--- a/print/src/main.ts
+++ b/print/src/main.ts
@@ -46,6 +46,11 @@ if (navAuthEl) {
   initLocalFolder(localFolderNavEl, app, () => router.navigate())
     .catch((err) => logError(err, { operation: "init-local-folder" }))
     .finally(() => markLocalFolderReady());
+} else {
+  // No .nav-auth means the local-folder UI is never mounted, so initLocalFolder
+  // never runs to settle the readiness gate. Mark it ready here so renderView()
+  // for a local: id never hangs forever waiting on a promise that can't resolve.
+  markLocalFolderReady();
 }
 
 let currentUser: User | null = null;

--- a/print/src/main.ts
+++ b/print/src/main.ts
@@ -42,7 +42,7 @@ if (navAuthEl) {
   const localFolderNavEl = document.createElement("span");
   localFolderNavEl.id = "local-folder";
   navEl.insertBefore(localFolderNavEl, navAuthEl);
-  initLocalFolder(localFolderNavEl, app)
+  initLocalFolder(localFolderNavEl, app, () => router.navigate())
     .catch((err) => logError(err, { operation: "init-local-folder" }))
     .finally(() => markLocalFolderReady());
 }

--- a/print/src/main.ts
+++ b/print/src/main.ts
@@ -11,7 +11,7 @@ import "@commons-systems/components/nav";
 import type { AppNavElement } from "@commons-systems/components/nav";
 import { signIn, signOut, onAuthStateChanged } from "./auth.js";
 import type { User } from "./auth.js";
-import { setViewerEmail } from "./library.js";
+import { setViewerEmail, markLocalFolderReady } from "./library.js";
 import { trackPageView } from "./firebase.js";
 import { renderHero } from "./pages/hero.js";
 import { mountHero } from "@commons-systems/components/hero";
@@ -42,9 +42,9 @@ if (navAuthEl) {
   const localFolderNavEl = document.createElement("span");
   localFolderNavEl.id = "local-folder";
   navEl.insertBefore(localFolderNavEl, navAuthEl);
-  initLocalFolder(localFolderNavEl, app).catch((err) =>
-    logError(err, { operation: "init-local-folder" }),
-  );
+  initLocalFolder(localFolderNavEl, app)
+    .catch((err) => logError(err, { operation: "init-local-folder" }))
+    .finally(() => markLocalFolderReady());
 }
 
 let currentUser: User | null = null;

--- a/print/src/pages/view.ts
+++ b/print/src/pages/view.ts
@@ -9,7 +9,7 @@ import { createPdfRenderer } from "../viewer/pdf.js";
 import { createEpubRenderer } from "../viewer/epub.js";
 import { createImageArchiveRenderer } from "../viewer/image-archive.js";
 import { getFile, putFile } from "../media-cache.js";
-import { isLocalId, getLocalItem, resolveLocalBlob } from "../library.js";
+import { isLocalId, getLocalItem, resolveLocalBlob, whenLocalFolderReady } from "../library.js";
 
 const BACK_LINK = '<a href="/" class="viewer-back">&larr; Back to Library</a>';
 
@@ -59,6 +59,10 @@ export async function renderView(id: string, _user: User | null): Promise<string
   }
 
   if (isLocalId(id)) {
+    // Wait for the initial local-folder init pass to settle before deciding
+    // Not Found — a deep link / refresh navigates before the persisted handle
+    // has bound `localSource`, which would otherwise read as a false miss.
+    await whenLocalFolderReady();
     const item = await getLocalItem(id);
     if (!item) return NOT_FOUND_HTML;
     pendingItem = item;

--- a/print/test/local-folder-ui.test.ts
+++ b/print/test/local-folder-ui.test.ts
@@ -23,7 +23,7 @@ const { mockHandle, mockStore } = vi.hoisted(() => ({
   mockHandle: {} as FileSystemDirectoryHandle,
   mockStore: {
     isSupported: vi.fn(() => true),
-    get: vi.fn(() => Promise.resolve({} as FileSystemDirectoryHandle)),
+    get: vi.fn(() => Promise.resolve(mockHandle)),
     queryPermission: vi.fn(() => Promise.resolve("granted")),
     requestPermission: vi.fn(() => Promise.resolve("granted")),
     put: vi.fn(() => Promise.resolve()),

--- a/print/test/local-folder-ui.test.ts
+++ b/print/test/local-folder-ui.test.ts
@@ -1,12 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Importing local-folder-ui.ts transitively imports library.ts and
 // pages/home.ts, both of which touch print/src/firebase.ts (initializeApp at
 // module load). Mock the firebase-touching modules so the module under test
-// imports cleanly with no real firebase init. createFsaHandleStore is
-// side-effect-free at construction (it only stores config and lazily opens
-// IndexedDB), so it needs no mock.
-import { vi } from "vitest";
+// imports cleanly with no real firebase init.
 vi.mock("../src/firebase.js", () => ({ storage: {}, STORAGE_NAMESPACE: "media" }));
 vi.mock("../src/media-cache.js", () => ({ blobCache: {} }));
 vi.mock("../src/firestore.js", () => ({
@@ -18,7 +15,38 @@ vi.mock("../src/storage.js", () => ({
   getMediaDownloadUrl: () => Promise.resolve(""),
 }));
 
-import { decideFolderUiState } from "../src/local-folder-ui.js";
+// Stub the FSA handle store so initLocalFolder takes the granted ("list")
+// auto-bind path without any real IndexedDB / picker. The fake handle is
+// granted on query, so bindAndRender runs without a user click. Built via
+// vi.hoisted so it exists before the hoisted vi.mock factory references it.
+const { mockHandle, mockStore } = vi.hoisted(() => ({
+  mockHandle: {} as FileSystemDirectoryHandle,
+  mockStore: {
+    isSupported: vi.fn(() => true),
+    get: vi.fn(() => Promise.resolve({} as FileSystemDirectoryHandle)),
+    queryPermission: vi.fn(() => Promise.resolve("granted")),
+    requestPermission: vi.fn(() => Promise.resolve("granted")),
+    put: vi.fn(() => Promise.resolve()),
+  },
+}));
+vi.mock("@commons-systems/local-first/fsa-handle-store", () => ({
+  createFsaHandleStore: () => mockStore,
+}));
+
+// Keep createLocalSource a no-op and listLocal empty so bindAndRender does no
+// real FSA work (markLocalFolderReady stays as the real Promise-deferred).
+vi.mock("../src/library.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/library.js")>(
+    "../src/library.js",
+  );
+  return {
+    ...actual,
+    createLocalSource: vi.fn(),
+    listLocal: vi.fn(() => Promise.resolve([])),
+  };
+});
+
+import { decideFolderUiState, initLocalFolder } from "../src/local-folder-ui.js";
 
 describe("decideFolderUiState", () => {
   it("returns 'open' when no handle is persisted (null)", () => {
@@ -43,5 +71,24 @@ describe("decideFolderUiState", () => {
 
   it("returns 'open' for an unknown permission string", () => {
     expect(decideFolderUiState({}, "something-else")).toBe("open");
+  });
+});
+
+describe("initLocalFolder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStore.isSupported.mockReturnValue(true);
+    mockStore.get.mockResolvedValue(mockHandle);
+    mockStore.queryPermission.mockResolvedValue("granted");
+  });
+
+  it("invokes onSourceBound after binding the source (granted/list path)", async () => {
+    const section = document.createElement("span");
+    const container = document.createElement("div");
+    const onSourceBound = vi.fn();
+
+    await initLocalFolder(section, container, onSourceBound);
+
+    expect(onSourceBound).toHaveBeenCalledTimes(1);
   });
 });

--- a/print/test/pages/view.test.ts
+++ b/print/test/pages/view.test.ts
@@ -42,11 +42,13 @@ vi.mock("../../src/media-cache.js", () => ({
 
 const mockGetLocalItem = vi.fn();
 const mockResolveLocalBlob = vi.fn();
+const mockWhenLocalFolderReady = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("../../src/library.js", () => ({
   isLocalId: (id: string) => id.startsWith("local:"),
   getLocalItem: (...args: unknown[]) => mockGetLocalItem(...args),
   resolveLocalBlob: (...args: unknown[]) => mockResolveLocalBlob(...args),
+  whenLocalFolderReady: (...args: unknown[]) => mockWhenLocalFolderReady(...args),
 }));
 
 import {
@@ -141,6 +143,28 @@ describe("local-folder view path", () => {
       "local:book.pdf",
       null,
     );
+  });
+
+  it("awaits local-folder readiness, then resolves once binding completes", async () => {
+    let bound = false;
+    let resolveReady!: () => void;
+    mockWhenLocalFolderReady.mockReturnValue(
+      new Promise<void>((r) => {
+        resolveReady = r;
+      }),
+    );
+    const item = makeMediaItem({ id: "local:book.pdf", origin: "local" });
+    mockGetLocalItem.mockImplementation(async () => (bound ? item : null));
+
+    // Start the render before readiness settles; it must not resolve to
+    // Not Found while the local source is still unbound.
+    const pending = renderView("local:book.pdf", null);
+    bound = true;
+    resolveReady();
+    const html = await pending;
+
+    expect(html).toContain('class="viewer"');
+    expect(renderViewerShell).toHaveBeenCalledWith(item);
   });
 
   it("resolve closure surfaces the #view-error UI when the file is gone", async () => {

--- a/print/test/pages/view.test.ts
+++ b/print/test/pages/view.test.ts
@@ -99,6 +99,7 @@ describe("readingPositionUid", () => {
 describe("local-folder view path", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockWhenLocalFolderReady.mockResolvedValue(undefined);
     cleanupView();
     if (typeof globalThis.reportError !== "function") {
       globalThis.reportError = () => {};


### PR DESCRIPTION
Closes #1281

## Problem

On a deep link or refresh of a local-folder item route (`/view/local:Foo.pdf`),
the print app showed a false "Not Found". Two independent startup steps in
`print/src/main.ts` race:

- `initLocalFolder(...)` is fire-and-forget async — it loads the persisted
  directory handle from IndexedDB, calls `queryPermission`, and binds the
  module-level `localSource` only in the `granted` state or after the user clicks
  a grant button.
- `createHistoryRouter(...)` navigates immediately at construction. For a local
  id, `renderView` calls `getLocalItem(id)`, which returns `null` while
  `localSource` is still unbound → `NOT_FOUND_HTML`.

A later `onAuthStateChanged` re-navigation sometimes repaired the view, but the
ordering was not guaranteed. Worse, when the persisted handle is in the `prompt`
permission state (normal after a browser restart for a non-PWA tab), binding only
happens after the user clicks "Grant access", and `bindAndRender` only
repopulated the home media list — it never re-rendered the viewer route, so the
deep-linked viewer stayed stuck on "Not Found" with no path back.

## Fix

Two halves, one per acceptance-criteria clause.

**Unit 1 — Readiness gate.** A one-shot "local-folder init settled" deferred
lives in `library.ts` (`whenLocalFolderReady` / `markLocalFolderReady`).
`renderView` awaits it before resolving a local id to Not Found, and `main.ts`
resolves it via `.finally(() => markLocalFolderReady())` on the initial
`initLocalFolder` pass — so the gate always settles regardless of outcome
(granted, prompt, open, or unsupported) and `renderView` never hangs. In the
granted state the source is bound by the time `.finally` fires, eliminating the
false-Not-Found race.

**Unit 2 — Re-render on bind.** `initLocalFolder` gains an optional
`onSourceBound` callback that `bindAndRender` invokes after binding the source,
on every bind path. `main.ts` passes `() => router.navigate()`, so after a
permission grant the open viewer route re-renders, now finds `localSource` bound,
and resolves the item. The router's `navigationId` staleness guard makes the
redundant re-navigation on the granted auto-bind path harmless.

## Tests

- `print/test/pages/view.test.ts` — new test refreshes a local-item route and
  asserts it resolves the viewer shell once binding completes (AC #2). The
  wholesale `library.js` mock gains `whenLocalFolderReady`.
- `print/test/local-folder-ui.test.ts` — new test drives `initLocalFolder`'s
  granted (`list`) path and asserts `onSourceBound` fires once on bind.

Verified: `vitest` (print suite green), `tsc --noEmit --project print` (clean),
`npm run build --prefix print` (clean).
