### PR TITLE
print: copy the media buffer for the cache write so pdf.js's worker transfer can't detach it

### DIFF
--- a/print/src/pages/view.ts
+++ b/print/src/pages/view.ts
@@ -88,7 +88,7 @@ export async function renderView(id: string, _user: User | null): Promise<string
   }
 }
 
-async function resolveFileSource(url: string, storagePath: string): Promise<string | ArrayBuffer> {
+export async function resolveFileSource(url: string, storagePath: string): Promise<string | ArrayBuffer> {
   try {
     const cached = await getFile(storagePath);
     if (cached) return cached;
@@ -98,8 +98,12 @@ async function resolveFileSource(url: string, storagePath: string): Promise<stri
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Failed to fetch media: ${res.status}`);
   const buf = await res.arrayBuffer();
-  // Cache write is best-effort; failure does not affect the current view
-  putFile(storagePath, buf).catch((err) => {
+  // Cache write is best-effort; failure does not affect the current view.
+  // Hand the cache its own copy: pdf.js transfers (detaches) the returned
+  // buffer to its worker, and that detach can win the race against putFile's
+  // deferred store.put. buf.slice(0) is evaluated synchronously here, while
+  // buf is still intact, so the cached bytes are decoupled from the transfer.
+  putFile(storagePath, buf.slice(0)).catch((err) => {
     reportError(new Error("Failed to cache media file", { cause: err }));
   });
   return buf;

--- a/print/test/pages/view-cache.test.ts
+++ b/print/test/pages/view-cache.test.ts
@@ -1,0 +1,80 @@
+import "fake-indexeddb/auto";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// view.ts transitively imports firestore/storage/auth/viewer modules that require
+// Firebase env vars at module load time. Stub those out so the real media-cache
+// path (which is what this test exercises) is not blocked.
+vi.mock("../../src/firestore.js", () => ({
+  getMediaItem: vi.fn(),
+}));
+vi.mock("../../src/storage.js", () => ({
+  getMediaDownloadUrl: vi.fn(),
+}));
+vi.mock("../../src/auth.js", () => ({
+  auth: { type: "mock-auth" },
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  onAuthStateChanged: vi.fn(),
+}));
+vi.mock("../../src/viewer/shell.js", () => ({
+  renderViewerShell: vi.fn().mockReturnValue('<div class="viewer">mock viewer</div>'),
+  initViewer: vi.fn().mockReturnValue(() => {}),
+}));
+vi.mock("../../src/viewer/pdf.js", () => ({
+  createPdfRenderer: vi.fn().mockReturnValue({}),
+}));
+vi.mock("../../src/viewer/epub.js", () => ({
+  createEpubRenderer: vi.fn().mockReturnValue({}),
+}));
+vi.mock("../../src/viewer/image-archive.js", () => ({
+  createImageArchiveRenderer: vi.fn().mockReturnValue({}),
+}));
+vi.mock("../../src/markdown-actions.js", () => ({
+  wireMarkdownActions: vi.fn(),
+}));
+vi.mock("../../src/library.js", () => ({
+  isLocalId: vi.fn().mockReturnValue(false),
+  getLocalItem: vi.fn(),
+  resolveLocalBlob: vi.fn(),
+}));
+
+import { resolveFileSource } from "../../src/pages/view.js";
+import { getFile, closeDb } from "../../src/media-cache.js";
+
+beforeEach(async () => {
+  await closeDb();
+  const req = indexedDB.deleteDatabase("print-media-cache");
+  await new Promise<void>((resolve) => {
+    req.onsuccess = () => resolve();
+  });
+  if (typeof globalThis.reportError !== "function") {
+    globalThis.reportError = () => {};
+  }
+  vi.spyOn(globalThis, "reportError").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await closeDb();
+});
+
+describe("resolveFileSource caching", () => {
+  it("caches the file after a first view even when the returned buffer is transferred", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(bytes, { status: 200 }));
+
+    const storagePath = "users/u1/doc.pdf";
+    const result = await resolveFileSource("https://example.test/doc.pdf", storagePath);
+
+    // Simulate pdf.js's worker transfer: detach the returned buffer synchronously,
+    // before yielding again. On unfixed code, the still-pending putFile(buf) would
+    // observe the detached buffer at store.put and reject with DataCloneError.
+    structuredClone(result, { transfer: [result as ArrayBuffer] });
+    expect((result as ArrayBuffer).byteLength).toBe(0);
+
+    await vi.waitFor(async () => {
+      expect(await getFile(storagePath)).not.toBeNull();
+    });
+    expect(new Uint8Array((await getFile(storagePath))!)).toEqual(bytes);
+  });
+});


### PR DESCRIPTION
Closes #1282

## Problem

`resolveFileSource(url, storagePath)` in `print/src/pages/view.ts` fetched a
media file, fired a best-effort fire-and-forget cache write
`putFile(storagePath, buf)`, and returned the **same** `buf` to the caller. For
PDFs that buffer flows to pdf.js `getDocument(source)` in
`print/src/viewer/pdf.ts`, and pdfjs-dist 4.10.38 **transfers** the
`ArrayBuffer` to its worker, detaching it.

`putFile` → `cache.putEntry` only reaches `dataStore.put({ key, data })` after
opening the IDB connection and a transaction — several event-loop turns later.
On a warm pdf.js worker the transfer can win that race: by the time `store.put`
runs, `data` is the now-detached buffer, IndexedDB's structured clone throws
`DataCloneError`, `putFile` rejects, and the file is **never cached**. The only
signal was a `reportError`; every subsequent view silently refetched the whole
file.

## Fix

- **Unit 1** (`print/src/pages/view.ts`): hand the cache its own synchronous
  copy via `putFile(storagePath, buf.slice(0))`. The slice is evaluated
  synchronously before `resolveFileSource` returns, while `buf` is still intact,
  so the cached bytes are decoupled from the worker transfer. The original `buf`
  is still returned to the caller (no extra allocation on the render path; the
  off-critical-path best-effort cache pays the copy cost). `resolveFileSource`
  is now exported so the regression test can exercise the real cache path.

- **Unit 2** (`print/test/pages/view-cache.test.ts`): a regression test that
  fetches a file through `resolveFileSource`, detaches the returned buffer
  synchronously (simulating pdf.js's worker transfer), then asserts the file is
  still cached and the cached bytes round-trip. It runs the real
  `fake-indexeddb`-backed cache path (a separate file from `view.test.ts`, which
  mocks `media-cache.js`). The test fails on the pre-fix code (detaching the
  shared buffer triggers the `DataCloneError` and leaves the cache empty) and
  passes after Unit 1.

## Acceptance criteria

- [x] The bytes handed to pdf.js are decoupled from the bytes cached
  (`buf.slice(0)`).
- [x] A test asserts the file is cached after a first view.

## Verification

- `npx tsc --noEmit --project print` — clean.
- `npx vitest run --root print test/pages/view-cache.test.ts test/pages/view.test.ts test/media-cache.test.ts`
  — all pass; the new test is green and the existing two stay green.
