### PR TITLE
fellspiral: skip home teardown on live #posts, not a one-shot flag

### DIFF
--- a/fellspiral/src/main.ts
+++ b/fellspiral/src/main.ts
@@ -126,20 +126,17 @@ async function loadPosts(): Promise<string> {
 
 updateNav(parsePath().path);
 
-// Same pre-render skip pattern as isFirstPanelRender above — return null on
-// the first navigation so the router keeps the existing DOM instead of
-// tearing it down and rebuilding identical markup.
-const hasPrerenderedHome = app.querySelector("#posts") !== null;
-let isFirstHomeRender = hasPrerenderedHome;
-
 const router = createHistoryRouter(
   app,
   [
     {
       path: /^\/(?:post\/.*)?$/,
       render: () => {
-        if (isFirstHomeRender) {
-          isFirstHomeRender = false;
+        // Skip teardown only while the prerendered home DOM is still live —
+        // checked at render time, not via a one-shot flag, so a non-home entry
+        // route (e.g. /admin) that has already replaced #posts does not leave
+        // stale markup on a later Home navigation (#1285).
+        if (app.querySelector("#posts")) {
           // Populate cachedPosts synchronously since the null return skips
           // loadPosts, and afterRender needs them for hydration.
           cachedPosts = buildTimeMetadata;

--- a/fellspiral/test/main-routing.test.ts
+++ b/fellspiral/test/main-routing.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Issue #1285 — fellspiral routing regression.
 //
@@ -96,13 +96,64 @@ function scaffoldDom(): void {
   `;
 }
 
+// main.ts does not export the router it constructs at module load, so the test
+// cannot call router.destroy() directly. Instead, capture the listeners the
+// router registers during import (popstate on window, click on document) by
+// patching addEventListener around the import, then remove them in afterEach.
+// Without this, each imported module's router listeners would linger on
+// window/document into the next test and fire on its popstate dispatch.
+type CapturedListener = {
+  target: EventTarget;
+  type: string;
+  listener: EventListenerOrEventListenerObject;
+  options?: boolean | AddEventListenerOptions;
+};
+let capturedListeners: CapturedListener[] = [];
+
+async function importMainTrackingListeners(): Promise<void> {
+  const targets: EventTarget[] = [window, document];
+  const originals = targets.map((target) => ({
+    target,
+    original: target.addEventListener,
+  }));
+  for (const { target } of originals) {
+    target.addEventListener = function (
+      this: EventTarget,
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions,
+    ) {
+      capturedListeners.push({ target: this, type, listener, options });
+      const original = originals.find((o) => o.target === this)!.original;
+      return original.call(this, type, listener, options);
+    } as typeof target.addEventListener;
+  }
+  try {
+    await import("../src/main");
+  } finally {
+    for (const { target, original } of originals) {
+      target.addEventListener = original;
+    }
+  }
+}
+
 describe("fellspiral main routing (#1285)", () => {
   beforeEach(() => {
     vi.resetModules();
     renderHomeHtml.mockClear();
     renderAdmin.mockClear();
+    capturedListeners = [];
     globalThis.ResizeObserver =
       ResizeObserverStub as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    // Remove the router's popstate/click listeners so a prior test's router
+    // (whose closures point at stale DOM) does not fire during later tests.
+    for (const { target, type, listener, options } of capturedListeners) {
+      target.removeEventListener(type, listener, options);
+    }
+    capturedListeners = [];
   });
 
   it("rebuilds home content after a direct /admin entry, not leaving stale admin DOM", async () => {
@@ -111,7 +162,7 @@ describe("fellspiral main routing (#1285)", () => {
     scaffoldDom();
 
     // 2. Run the entry fresh.
-    await import("../src/main");
+    await importMainTrackingListeners();
 
     const app = document.getElementById("app")!;
 
@@ -142,7 +193,7 @@ describe("fellspiral main routing (#1285)", () => {
     history.pushState({}, "", "/");
     scaffoldDom();
 
-    await import("../src/main");
+    await importMainTrackingListeners();
 
     const app = document.getElementById("app")!;
 

--- a/fellspiral/test/main-routing.test.ts
+++ b/fellspiral/test/main-routing.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Issue #1285 — fellspiral routing regression.
+//
+// A direct load of /admin serves the prerendered home index.html (so the
+// prerendered #posts is in the DOM), but the router renders the admin route,
+// replacing #posts with admin markup. The home route's render must then rebuild
+// home content on a later Home navigation — checked against the *live* DOM
+// (app.querySelector("#posts")), not a one-shot flag. The pre-fix one-shot flag
+// returned null on that Home navigation, leaving stale admin DOM on "/".
+//
+// This is a full-main.ts integration test: it imports ../src/main for its side
+// effects (main.ts constructs the router at module load) under the REAL router
+// and mocked heavy dependencies. The real router's render -> null preservation
+// is the behavior under test, so @commons-systems/router is NOT mocked.
+
+// vi.hoisted so these spies exist before the hoisted vi.mock factories run.
+const { renderHomeHtml, renderAdmin } = vi.hoisted(() => ({
+  renderHomeHtml: vi.fn(() => '<div id="posts" data-test="home">HOME</div>'),
+  renderAdmin: vi.fn(() => '<div data-test="admin">ADMIN</div>'),
+}));
+
+// REAL router — render -> null DOM preservation is the behavior under test.
+// onAuthStateChanged returns a thenable (main.ts calls .catch on it) and must
+// NOT invoke its callback, so currentUser stays null.
+vi.mock("../src/firebase.js", () => ({
+  db: { type: "mock-firestore" },
+  NAMESPACE: "fellspiral/test",
+  trackPageView: vi.fn(),
+  initAppCheck: vi.fn(() => Promise.resolve()),
+  getAppCheckHeaders: vi.fn(async () => ({})),
+  signIn: vi.fn(() => Promise.resolve()),
+  signOut: vi.fn(() => Promise.resolve()),
+  onAuthStateChanged: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("@commons-systems/blog/pages/home", () => ({
+  renderHomeHtml,
+  hydrateHome: vi.fn(),
+}));
+vi.mock("@commons-systems/blog/pages/admin", () => ({ renderAdmin }));
+vi.mock("@commons-systems/authutil/groups", () => ({
+  isInGroup: vi.fn(() => Promise.resolve(false)),
+  ADMIN_GROUP_ID: "admin-group",
+}));
+// Virtual build-time data modules.
+vi.mock("virtual:blog-post-content", () => ({ default: {} }));
+vi.mock("virtual:blog-post-metadata", () => ({ default: [] }));
+vi.mock("virtual:blog-roll-feeds", () => ({ default: {} }));
+// Module-scope side-effectful imports — no-op so import("../src/main")
+// completes under happy-dom.
+vi.mock("@commons-systems/blog/components/info-panel", () => ({
+  renderInfoPanel: vi.fn(() => ""),
+  hydrateInfoPanel: vi.fn(),
+}));
+vi.mock("@commons-systems/blog/og-meta", () => ({ updateOgMeta: vi.fn() }));
+vi.mock("@commons-systems/blog/canonical", () => ({ updateCanonical: vi.fn() }));
+vi.mock("@commons-systems/blog/github", () => ({
+  createFetchPost: vi.fn(() => vi.fn()),
+}));
+vi.mock("@commons-systems/blog/firestore", () => ({
+  getPosts: vi.fn(() => Promise.resolve({ posts: [], skippedCount: 0 })),
+}));
+vi.mock("@commons-systems/components/panel-toggle", () => ({
+  initPanelToggle: vi.fn(),
+}));
+vi.mock("@commons-systems/components/scroll-indicator", () => ({
+  initScrollIndicator: vi.fn(() => () => {}),
+}));
+vi.mock("@commons-systems/components/nav", () => ({}));
+vi.mock("@commons-systems/firebaseutil/defer-appcheck", () => ({
+  deferAppCheckInit: vi.fn(),
+}));
+vi.mock("../src/blog-roll/config.js", () => ({
+  createStrategies: vi.fn(() => new Map()),
+  BLOG_ROLL_ENTRIES: [],
+}));
+
+// happy-dom lacks ResizeObserver; main.ts constructs one at module init.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+function scaffoldDom(): void {
+  document.body.innerHTML = `
+    <div id="nav"></div>
+    <div class="page">
+      <header></header>
+      <div class="content-grid">
+        <div id="app"><div id="posts" data-prerendered="true">PRERENDERED HOME</div></div>
+        <aside id="info-panel"></aside>
+        <button id="panel-toggle"></button>
+      </div>
+    </div>
+  `;
+}
+
+describe("fellspiral main routing (#1285)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    renderHomeHtml.mockClear();
+    renderAdmin.mockClear();
+    globalThis.ResizeObserver =
+      ResizeObserverStub as unknown as typeof ResizeObserver;
+  });
+
+  it("rebuilds home content after a direct /admin entry, not leaving stale admin DOM", async () => {
+    // 1. Resolve /admin as the entry route before main constructs the router.
+    history.pushState({}, "", "/admin");
+    scaffoldDom();
+
+    // 2. Run the entry fresh.
+    await import("../src/main");
+
+    const app = document.getElementById("app")!;
+
+    // 3. The admin route replaced the prerendered home #posts with admin markup.
+    await vi.waitFor(() => {
+      expect(app.innerHTML).toContain('data-test="admin"');
+      expect(app.querySelector("#posts")).toBeNull();
+    });
+
+    // 4. Navigate Home through the real router's popstate listener.
+    history.pushState({}, "", "/");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    // 5. Home content must render — #posts is back and admin markup is gone.
+    //    Pre-fix this failed: the one-shot flag returned null, so the admin DOM
+    //    persisted on "/".
+    await vi.waitFor(() => {
+      expect(app.querySelector("#posts")).not.toBeNull();
+      expect(app.innerHTML).toContain('data-test="home"');
+      expect(app.innerHTML).not.toContain('data-test="admin"');
+    });
+  });
+
+  it("preserves the prerendered home DOM on a direct / entry (skips teardown)", async () => {
+    // Direct home entry: the prerendered #posts is live, so the home render
+    // returns null and renderHomeHtml is never called — the optimization the
+    // live-DOM check preserves.
+    history.pushState({}, "", "/");
+    scaffoldDom();
+
+    await import("../src/main");
+
+    const app = document.getElementById("app")!;
+
+    // Give the router's initial async navigation a chance to run.
+    await vi.waitFor(() => {
+      expect(app.querySelector("#posts")).not.toBeNull();
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The prerendered markup is preserved in place; renderHomeHtml was not
+    // called to rebuild it.
+    expect(renderHomeHtml).not.toHaveBeenCalled();
+    expect(app.querySelector("[data-prerendered]")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1285

## Problem

`fellspiral/src/main.ts` skipped tearing down the prerendered home DOM on the
first navigation using a one-shot `isFirstHomeRender` boolean, seeded at
module-init from whether `#posts` was present. That flag encodes "the first
navigation is the home route" — which only holds when the entry URL is the home
path.

A direct load of `/admin` breaks that assumption: hosting serves the prerendered
home `index.html` (so `#posts` is present and the flag is seeded `true`), but the
router renders the admin route, replacing `#posts` with admin markup while the
flag stays `true`. Clicking Home then returns `null` (flag still `true`), so the
router keeps the existing DOM — the admin markup stays on the `/` URL and
`hydrateHome` logs "#posts container not found" and bails. The home page shows
admin content until a second navigation.

## Fix

Check the *live* DOM at render time — `app.querySelector("#posts")` — instead of
a one-shot flag. The teardown is skipped only while the prerendered `#posts` is
still in the DOM; once a non-home route (e.g. `/admin`) has replaced it, the home
render finds `#posts` absent and runs `loadPosts()`, rebuilding correctly. The
module-level `hasPrerenderedHome` / `isFirstHomeRender` declarations are removed.

The only behavioral change is that repeat *unauthenticated* home navigations now
return `null` (preserving the identical prerendered markup and hydrating in
place) instead of rebuilding it — exactly the teardown the optimization exists to
avoid. The authenticated refresh path is unaffected: authenticated state is
reachable only via `/admin`, which replaces `#posts`, so a subsequent Home
navigation finds `#posts` absent and calls `loadPosts()` (the authenticated
fetch).

## Tests

Adds `fellspiral/test/main-routing.test.ts`, a full-`main.ts` integration test
under the real `@commons-systems/router` and mocked heavy dependencies:

- Loads `/admin` first, confirms the admin route replaces the prerendered
  `#posts`, navigates Home via a `popstate` event, and asserts home content
  renders (`#posts` back, admin markup gone). This fails on the pre-fix one-shot
  flag and passes with the live-DOM check.
- A second case asserts the happy path is preserved: a direct `/` entry with a
  live prerendered `#posts` still skips the teardown (`renderHomeHtml` is not
  called).

Both acceptance criteria from the issue are satisfied: the skip checks
`app.querySelector("#posts")` at render time rather than a one-shot flag, and a
test loads `/admin` first, navigates Home, and asserts home content renders.
