### PR TITLE
dispatch: move the plan-phase relevance review into /plan-issue

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-drift-scan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-drift-scan
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # dispatch-drift-scan — gather the deterministic evidence for the
-# /dispatch-worker implement-phase relevance-drift review (Step 3) in a single
+# /plan-issue pre-planning relevance review (Step 1) in a single
 # invocation, so the dispatching session only owns the verdict.
 #
-# The implement-phase relevance review asks: has the codebase drifted away from
+# The pre-planning relevance review asks: has the codebase drifted away from
 # what this issue assumes since the issue was filed? The *evidence* for that
 # question is mechanical — issue createdAt (the drift window anchor), commits to
 # the named paths since then, PRs merged in the window, and whether the issue's

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-route
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-route
@@ -14,7 +14,7 @@
 #   INVOKE /budget-parse-job       phase plan         (no PR, unplanned, statements:<key> label) — parse-job issue
 #   INVOKE /implement              phase implement    (no PR + dispatch:planned)
 #   INVOKE /fix-conflicts              provisioning hit an origin/main merge conflict
-#   RELEVANCE-REVIEW                phase plan         (no PR, unplanned) — routes to SKILL.md Step 2
+#   INVOKE /plan-issue              phase plan         (no PR, unplanned) — plan phase
 #   STOP done                       phase done         (non-draft PR)
 #   PUSH-STRANDED                   phase done, but worktree ahead of origin/<branch> — push then park
 #   STOP waiting                    dispatch-ci-ready reports not-ready (draft PR CI pending)
@@ -130,7 +130,7 @@ PHASE=$("$SCRIPT_DIR/dispatch-phase" "$N")
 # Map the phase string to its directive.
 case "$PHASE" in
   plan)
-    # A no-PR unplanned target is normally a plan-phase issue → RELEVANCE-REVIEW.
+    # A no-PR unplanned target is normally a plan-phase issue → INVOKE /plan-issue.
     # But a statement parse-job issue (filed by dispatch-statements-scan, carrying a
     # configured statements:<key> label, with no PR) routes to /budget-parse-job
     # instead — it is a one-phase handler that never opens a code PR. The label
@@ -139,7 +139,7 @@ case "$PHASE" in
     # "no-config", exit 0 — the normal state for repos without statement scanning)
     # from "config present but malformed" (exit 1) — surface the latter as an
     # error, treat the former as no configured labels (empty intersection →
-    # unchanged RELEVANCE-REVIEW).
+    # INVOKE /plan-issue).
     STATEMENTS_CONFIG=$("$SCRIPT_DIR/dispatch-config-load" statements)
     if [[ "$STATEMENTS_CONFIG" == "no-config" ]]; then
       CONFIGURED_LABELS=""
@@ -151,10 +151,10 @@ case "$PHASE" in
       ISSUE_LABELS=""
       ISSUE_LABELS=$(gh issue view "$N" --json labels | jq -r '.labels[].name') || {
         # gh failure (network error, auth issue, etc.) — fall back to the safe
-        # default of RELEVANCE-REVIEW rather than exiting non-zero without a
+        # default of INVOKE /plan-issue rather than exiting non-zero without a
         # directive, which would leave the stop hook with a misleading reason.
-        echo "dispatch-route: gh issue view $N --json labels failed; defaulting to RELEVANCE-REVIEW" >&2
-        echo "RELEVANCE-REVIEW"
+        echo "dispatch-route: gh issue view $N --json labels failed; defaulting to INVOKE /plan-issue" >&2
+        echo "INVOKE /plan-issue"
         exit 0
       }
       # Non-empty intersection of the issue's labels with the configured
@@ -170,7 +170,7 @@ case "$PHASE" in
     if [[ "$PARSE_JOB" -eq 1 ]]; then
       echo "INVOKE /budget-parse-job"
     else
-      echo "RELEVANCE-REVIEW"
+      echo "INVOKE /plan-issue"
     fi
     ;;
   implement)

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1231,16 +1231,16 @@ route_run() {
   ROUTE_OUT=$("$TMPDIR_TEST/dispatch-route" "$@" 2>/dev/null) && ROUTE_RC=0 || ROUTE_RC=$?
 }
 
-# 1. No PR, unplanned → RELEVANCE-REVIEW (plan phase). dispatch-phase fetches the
+# 1. No PR, unplanned → INVOKE /plan-issue (plan phase). dispatch-phase fetches the
 # issue's labels (no issue-labels-42.json → no dispatch:planned → plan), and the
-# plan arm with no statements config falls through to RELEVANCE-REVIEW.
-echo "Test: no PR, unplanned → RELEVANCE-REVIEW"
+# plan arm with no statements config falls through to INVOKE /plan-issue.
+echo "Test: no PR, unplanned → INVOKE /plan-issue"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
 route_run 42 /wt/42-my-feature
-assert_eq "no PR, unplanned → RELEVANCE-REVIEW (directive)" "RELEVANCE-REVIEW" "$ROUTE_OUT"
-assert_eq "no PR, unplanned → RELEVANCE-REVIEW (exit 0)" "0" "$ROUTE_RC"
+assert_eq "no PR, unplanned → INVOKE /plan-issue (directive)" "INVOKE /plan-issue" "$ROUTE_OUT"
+assert_eq "no PR, unplanned → INVOKE /plan-issue (exit 0)" "0" "$ROUTE_RC"
 teardown
 
 # 1b. No PR + dispatch:planned → INVOKE /implement (implement phase). dispatch-phase
@@ -1499,7 +1499,7 @@ teardown
 # (#1024). The plan arm fetches the issue's labels (gh issue view --json labels,
 # served from issue-labels-<num>.json) and the configured statements labels (from
 # dispatch-config-load against DISPATCH_CONFIG_DIR), and on a non-empty intersection
-# routes to the parse-job handler instead of RELEVANCE-REVIEW.
+# routes to the parse-job handler instead of INVOKE /plan-issue.
 echo "Test: no PR + statements label → INVOKE /budget-parse-job"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
@@ -1514,8 +1514,8 @@ assert_eq "no PR + statements label → INVOKE /budget-parse-job (exit 0)" "0" "
 teardown
 
 # 22. No-PR issue with a statements config present, but the issue carries no
-# configured label → RELEVANCE-REVIEW (empty intersection, unchanged behavior).
-echo "Test: no PR + non-statements label → RELEVANCE-REVIEW"
+# configured label → INVOKE /plan-issue (empty intersection, unchanged behavior).
+echo "Test: no PR + non-statements label → INVOKE /plan-issue"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
@@ -1523,22 +1523,22 @@ printf '{"statements":[{"key":"acme","dir":"/s","repo":"o/r","label":"statements
   > "$DISPATCH_CONFIG_DIR/statements.json"
 printf '{"labels":[{"name":"help wanted"}]}\n' > "$STUB_DIR/issue-labels-42.json"
 route_run 42 /wt/42-my-feature
-assert_eq "no PR + non-statements label → RELEVANCE-REVIEW (directive)" \
-  "RELEVANCE-REVIEW" "$ROUTE_OUT"
-assert_eq "no PR + non-statements label → RELEVANCE-REVIEW (exit 0)" "0" "$ROUTE_RC"
+assert_eq "no PR + non-statements label → INVOKE /plan-issue (directive)" \
+  "INVOKE /plan-issue" "$ROUTE_OUT"
+assert_eq "no PR + non-statements label → INVOKE /plan-issue (exit 0)" "0" "$ROUTE_RC"
 teardown
 
-# 23. No statements config present at all → RELEVANCE-REVIEW (the normal state for
+# 23. No statements config present at all → INVOKE /plan-issue (the normal state for
 # repos without statement scanning; dispatch-config-load prints "no-config", the
 # arm treats it as no configured labels and never fetches the issue's labels).
-echo "Test: no PR + no statements config → RELEVANCE-REVIEW"
+echo "Test: no PR + no statements config → INVOKE /plan-issue"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
 route_run 42 /wt/42-my-feature
-assert_eq "no PR + no statements config → RELEVANCE-REVIEW (directive)" \
-  "RELEVANCE-REVIEW" "$ROUTE_OUT"
-assert_eq "no PR + no statements config → RELEVANCE-REVIEW (exit 0)" "0" "$ROUTE_RC"
+assert_eq "no PR + no statements config → INVOKE /plan-issue (directive)" \
+  "INVOKE /plan-issue" "$ROUTE_OUT"
+assert_eq "no PR + no statements config → INVOKE /plan-issue (exit 0)" "0" "$ROUTE_RC"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-worker/SKILL.md
+++ b/.claude/skills/dispatch-worker/SKILL.md
@@ -56,7 +56,7 @@ Act on the one directive:
 | `INVOKE /budget-parse-job` | 0 | a statement parse-job issue (`statements:<key>` label, no PR) | invoke `/budget-parse-job` (see below) |
 | `INVOKE /fix-conflicts` | 0 | provisioning hit an `origin/main` merge conflict | invoke `/fix-conflicts` (the generic INVOKE path below) |
 | `INVOKE /implement` | 0 | no PR + `dispatch:planned` (`implement` phase) | invoke `/implement` (the generic INVOKE path below) |
-| `RELEVANCE-REVIEW` | 0 | no PR, unplanned (`plan` phase) | run the Step 2 relevance review, then dispatch its verdict |
+| `INVOKE /plan-issue` | 0 | no PR, unplanned (`plan` phase) | invoke `/plan-issue` (the generic INVOKE path below) |
 | `STOP done` | 0 | non-draft (ready) PR, or a draft PR carrying `dispatch:reviewed` (review-complete — draft→ready owned by `dispatch-reconcile-ready`) | stop without invoking a phase skill |
 | `PUSH-STRANDED` | 0 | `done` PR, but the worktree has commits `origin/<branch>` hasn't seen | push `origin HEAD`, write an office-hours reason, stop with no marker |
 | `STOP waiting` | 0 | draft PR's CI has no verdict yet | print the verbatim message below and stop |
@@ -94,6 +94,11 @@ and `mergeable == MERGEABLE`). Each phase skill owns and applies its own
   opens a draft PR. Planning already happened in the `plan` phase, so the worker
   runs no relevance review before it. No `dispatch:*` label — the draft PR it opens
   is its own marker.
+- **`/plan-issue`** — the `plan`-phase skill for a no-PR, unplanned issue. It runs
+  the `createdAt`-anchored pre-planning relevance review itself (the worker no
+  longer gates it), then plans the issue into an ordered unit breakdown, persists
+  the plan to the issue, and applies `dispatch:planned` on completion — the worker
+  applies no label.
 
 After the phase skill returns, the worker session ends; the Stop hook reads the
 marker the phase skill wrote and propagates the chain. The worker does not advance
@@ -116,13 +121,6 @@ missing snapshot or password, or (the central case) an uncategorized transaction
 needing the author's judgment — it escalates via `dispatch-mark-deviation` and
 stops with no sentinel, so the Stop hook parks the still-open issue on
 `dispatch:office-hours` for the `/office-hours` residue.
-
-### `RELEVANCE-REVIEW` — run the relevance review, then dispatch its verdict
-
-Run the Step 2 relevance review and dispatch the verdict it returns (`proceed` /
-`adjust` / `stop` — see Step 2). This gates the `plan` phase — a no-PR, unplanned
-issue. `/plan-issue` gets **no** `dispatch:*` label here; it applies
-`dispatch:planned` itself when it finishes and persists the plan.
 
 ### `STOP waiting` — re-gate to the router, no marker
 
@@ -198,70 +196,7 @@ For `wrong-worktree`, the spawn was incoherent — the branch-name sanity check
 rejected the spawn cwd, or the positional `<worktree-path>` disagreed with `git
 rev-parse --show-toplevel`; see `reference.md`.
 
-## 2. Pre-Planning Relevance Review
-
-This step runs **only** for the `plan` phase — a no-PR, unplanned target. Every
-phase with an existing PR (`fix-checks` onward) skips it, as does the `implement`
-phase (a planned no-PR issue routes straight to its build skill): implementation
-is already planned or underway. It is the planning-time counterpart of
-the creation-time relevance check; the two are deliberately separate — the
-creation-time check is `$BASELINE_BRANCH`-anchored, this step is pre-planning and
-`createdAt`-anchored.
-
-Before invoking `/plan-issue` on a `plan`-phase issue, confirm no PR
-exists for the target by running:
-
-```bash
-.claude/skills/dispatch-propagate/scripts/dispatch-find-pr <N>
-```
-
-If it prints a PR number, **skip this relevance review** and re-run Step 1
-(`dispatch-route`) — a PR already exists and implementation is underway.
-
-If `dispatch-find-pr` prints nothing, run a creation-date-anchored drift
-analysis. Gather the deterministic evidence in one call
-(`dangerouslyDisableSandbox: true` — it calls `gh`):
-
-```bash
-.claude/skills/dispatch-propagate/scripts/dispatch-drift-scan <N>
-```
-
-`dispatch-drift-scan` emits, in one invocation, the three mechanical drift
-inputs anchored on the issue's `createdAt`: commits to the paths the issue body
-names since creation, PRs merged in the window, and the validity of the issue's
-named references (paths existence-checked, names grepped — anything renamed,
-moved, or removed is flagged `[ABSENT]`/`[NOT FOUND]`). It mines those
-references from the single-backtick spans in the issue body; read its header for
-what the heuristic does and does not cover. When the merged-PR query hits its
-100-result limit the script prints a `WINDOW-TOO-WIDE` marker recommending
-`/file-issue` instead of a partial scan — treat that as the too-wide-window signal in
-the verdict below.
-
-Two judgments stay with the dispatching session, after reading the script's
-evidence:
-
-1. **Convention drift** — re-read `CLAUDE.md` and any `.claude/rules/*.md` whose
-   domain the issue touches. Flag approaches the issue assumes that no longer
-   match current conventions (e.g. a deprecated pattern, a renamed package, a
-   changed config shape). The script does not mine conventions; this read is
-   yours.
-2. **Merged-PR overlap** — for any merged PR the script lists whose title
-   plausibly relates to the issue's domain, optionally fetch its changed files
-   to judge whether the overlap is incidental or substantive.
-
-### Three-way verdict
-
-- **`proceed`** — drift absent or cosmetic; invoke `/plan-issue`.
-- **`adjust`** — issue still wanted but references, conventions, or scope have
-  shifted; invoke `/new-requirement` with the drift findings as the revised
-  understanding, then `/plan-issue`.
-- **`stop`** — codebase has moved past the need; report what changed and
-  recommend closing the issue or re-running `/file-issue`. Do **not** invoke
-  `/plan-issue`; print the drift report and stop. The Stop hook
-  applies `dispatch:office-hours` to the issue because no marker was
-  written.
-
-## 3. Stop
+## 2. Stop
 
 The Stop hook (`.claude/hooks/dispatch-stop.sh`) owns label management,
 router spawn, and self-close. The worker reaches the end of its tick by

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -24,9 +24,10 @@ fan out the built-in `Explore` and `Plan` subagents directly (no orchestrator
 skill, no nesting). The exploration and design subagents are direct children of
 this session.
 
-Run `gh` commands and the scripts that invoke `gh` (`dispatch-write-plan`,
-`dispatch-apply-planned`, `dispatch-mark-complete`) with
-`dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
+Run `gh` commands and the scripts that invoke `gh` (`dispatch-find-pr`,
+`dispatch-drift-scan`, `dispatch-write-plan`, `dispatch-apply-planned`,
+`dispatch-mark-complete`) with `dangerouslyDisableSandbox: true` — see
+`.claude/rules/sandbox.md`.
 
 ## The running session has no plan mode
 
@@ -69,17 +70,80 @@ the steps in order.
 
 ## Steps
 
-### 1. Trivial-task skip
+### 1. Pre-Planning relevance review — main thread
+
+This is the **opening step** of `/plan-issue`. Before planning a no-PR, unplanned
+target, run a creation-date-anchored drift analysis. It is the planning-time
+counterpart of the creation-time relevance check; the two are deliberately
+separate — the creation-time check is `$BASELINE_BRANCH`-anchored, this step is
+pre-planning and `createdAt`-anchored.
+
+First confirm no PR exists for the target by running
+(`dangerouslyDisableSandbox: true` — it calls `gh`):
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-find-pr "$N"
+```
+
+This is a belt-and-suspenders check — the router already confirmed no PR before
+emitting `INVOKE /plan-issue`. If it nonetheless prints a PR number, this is an
+already-in-flight target that should not be re-planned: **stop without a marker**.
+The Stop hook applies `dispatch:office-hours` and parks it, since the router should
+not have routed a PR-bearing issue to the plan phase.
+
+If `dispatch-find-pr` prints nothing, gather the deterministic drift evidence in
+one call (`dangerouslyDisableSandbox: true` — it calls `gh`):
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-drift-scan "$N"
+```
+
+`dispatch-drift-scan` emits, in one invocation, the three mechanical drift
+inputs anchored on the issue's `createdAt`: commits to the paths the issue body
+names since creation, PRs merged in the window, and the validity of the issue's
+named references (paths existence-checked, names grepped — anything renamed,
+moved, or removed is flagged `[ABSENT]`/`[NOT FOUND]`). It mines those
+references from the single-backtick spans in the issue body; read its header for
+what the heuristic does and does not cover. When the merged-PR query hits its
+100-result limit the script prints a `WINDOW-TOO-WIDE` marker recommending
+`/file-issue` instead of a partial scan — treat that as the too-wide-window signal in
+the verdict below.
+
+Two judgments stay with this session, after reading the script's evidence:
+
+1. **Convention drift** — re-read `CLAUDE.md` and any `.claude/rules/*.md` whose
+   domain the issue touches. Flag approaches the issue assumes that no longer
+   match current conventions (e.g. a deprecated pattern, a renamed package, a
+   changed config shape). The script does not mine conventions; this read is
+   yours.
+2. **Merged-PR overlap** — for any merged PR the script lists whose title
+   plausibly relates to the issue's domain, optionally fetch its changed files
+   to judge whether the overlap is incidental or substantive.
+
+#### Three-way verdict
+
+- **`proceed`** — drift absent or cosmetic; continue to the trivial-task skip and
+  the exploration/design steps below (Step 2 onward).
+- **`adjust`** — issue still wanted but references, conventions, or scope have
+  shifted; invoke `/new-requirement` with the drift findings as the revised
+  understanding, then continue planning (the later steps below).
+- **`stop`** — codebase has moved past the need; report what changed and
+  recommend closing the issue or re-running `/file-issue`, then **stop with no
+  marker**. The Stop hook applies `dispatch:office-hours` to the issue because no
+  completion marker was written. Do **not** apply `dispatch:planned` and do
+  **not** persist a plan.
+
+### 2. Trivial-task skip
 
 If the issue is a typo fix, a single-line change, or a simple rename, **skip the
-exploration and design subagents** (Steps 2–3) and plan it directly: write the
-unit breakdown yourself, then jump to Step 5 (the gate is almost always
-unnecessary for a trivial task) and Step 6 (persist + complete). The plan-comment
+exploration and design subagents** (Steps 3–4) and plan it directly: write the
+unit breakdown yourself, then jump to Step 6 (the gate is almost always
+unnecessary for a trivial task) and Step 7 (persist + complete). The plan-comment
 output schema still applies — a one-unit plan with the preface is fine.
 
-Otherwise continue to Step 2.
+Otherwise continue to Step 3.
 
-### 2. Explore — built-in `Explore` subagent, direct fan-out
+### 3. Explore — built-in `Explore` subagent, direct fan-out
 
 Launch up to **3** built-in `Explore` agents **in parallel** (a single message
 with multiple Agent tool calls, `subagent_type: Explore`), using the **minimum
@@ -96,10 +160,10 @@ components, a third investigates testing patterns). Follow the appendix's
 *Exploration* block.
 
 Collect from the agents: the relevant filenames, the code-path traces, and the
-reuse candidates with their file paths. This is the exploration context Step 3
+reuse candidates with their file paths. This is the exploration context Step 4
 hands to the design agents.
 
-### 3. Design — built-in `Plan` subagent, direct fan-out
+### 4. Design — built-in `Plan` subagent, direct fan-out
 
 Launch **1–3** built-in `Plan` agents (`subagent_type: Plan`). Use **1** for most
 issues; use multiple only for large or architectural work, each with a **distinct
@@ -111,7 +175,7 @@ warranted).
 
 In each `Plan` agent's prompt, provide:
 
-1. The **Step-2 exploration context** — the filenames and code-path traces the
+1. The **Step-3 exploration context** — the filenames and code-path traces the
    `Explore` agents surfaced. The `Plan` agents skip `CLAUDE.md`/git too, so this
    context must be inline.
 2. The **issue scope and acceptance criteria**.
@@ -131,17 +195,17 @@ In each `Plan` agent's prompt, provide:
    the shape this skill persists.
 
 When you launch multiple `Plan` agents, **synthesize** their proposals into a
-single recommended approach in Step 4 — the persisted plan carries the
+single recommended approach in Step 5 — the persisted plan carries the
 recommended approach only, not all alternatives.
 
-### 4. Self-review — main thread
+### 5. Self-review — main thread
 
 Read the **critical files** the `Explore`/`Plan` subagents flagged before
 finalizing, to deepen your own understanding and confirm the plan is executable
 and aligned with the issue's acceptance criteria (the appendix's *Review* block).
 Resolve any disagreement between multiple `Plan` proposals here.
 
-### 5. Clarification / deviation gate — main thread
+### 6. Clarification / deviation gate — main thread
 
 When EITHER:
 
@@ -170,16 +234,16 @@ Note: do **not** call `AskUserQuestion` as the escalation mechanism. The
 `dispatch-*`-named background sessions; worker sessions (named after their
 worktree basename) are excluded and the call would block the session indefinitely.
 
-Otherwise proceed autonomously to Step 6. **Never call `ExitPlanMode`** — that is
+Otherwise proceed autonomously to Step 7. **Never call `ExitPlanMode`** — that is
 the user-approval gate this design removes. This skill's terminus is either
-auto-complete (Step 6) or marker-absent stop → office-hours.
+auto-complete (Step 7) or marker-absent stop → office-hours.
 
 > **Important:** Escalate ONLY on genuine ambiguity or a major scope deviation —
 > not as a routine end-of-planning checkpoint. An unambiguous issue is planned
-> with no user interaction. The relevance / drift re-evaluation is owned by
-> `dispatch-route` and the worker's Step 2; do **not** repeat it here.
+> with no user interaction. The relevance / drift re-evaluation is **already
+> performed in Step 1 of this skill**; do **not** repeat it in this gate.
 
-### 6. Persist + complete
+### 7. Persist + complete
 
 Assemble the final plan markdown (the plan-comment output schema below) and write
 it to `tmp/plan-<N>.md`, then run, in order (all with
@@ -283,13 +347,13 @@ assemble the plan.
 ## Appendix: adopted plan-mode instructions (verbatim)
 
 This session does **not** have plan mode active, so it cannot receive these as
-injected tool instructions. They are reproduced verbatim and govern Steps 2–6,
+injected tool instructions. They are reproduced verbatim and govern Steps 3–7,
 with two substitutions:
 
 - (i) "the user's request" / "the user provided specific file paths" → the
   **issue scope / acceptance criteria** (there is no live user supplying paths).
 - (ii) "Use `AskUserQuestion` to clarify any remaining questions" is the
-  **escalation trigger** (Step 5: ambiguity or major scope deviation →
+  **escalation trigger** (Step 6: ambiguity or major scope deviation →
   office-hours), **not** a routine default.
 
 ### Exploration (built-in `Explore`)


### PR DESCRIPTION
Closes #1390

Moves the plan-phase relevance review out of `/dispatch-worker` and into the
front of `/plan-issue`, so the `plan` phase becomes invokable exactly like every
other phase. This is leaf **A** of epic #1389 (replace the model-session worker
with a detached launcher script) — it removes the worker's lone model-judgment
branch, the precondition for a script launcher that never needs a model to route.

After this change every `dispatch-route` directive is mechanical or a single-skill
`INVOKE`.

## What changed

- **`dispatch-route`** — the `plan)` arm now emits `INVOKE /plan-issue` instead of
  `RELEVANCE-REVIEW` (both the normal `else` branch and the gh-failure fallback),
  with the file-header directive table and surrounding comments refreshed. The
  `statements:<key>` parse-job branch (`INVOKE /budget-parse-job`) is unchanged.
- **`test-dispatch-scripts.sh`** — the three plan-arm cases now assert
  `INVOKE /plan-issue`; the parse-job arm assertion is unchanged. Full suite:
  2174/2174 passing.
- **`/plan-issue`** — gains a new opening **Step 1, "Pre-Planning relevance
  review"**: the `createdAt`-anchored `dispatch-drift-scan` evidence call, the
  convention-drift and merged-PR-overlap judgments, and the three-way
  `proceed`/`adjust`/`stop` verdict — relocated largely verbatim from the worker,
  with the no-PR guard and the verdict continuations adapted to target this
  skill's own later steps. Subsequent steps renumbered 2–7. Semantics unchanged:
  `proceed` continues planning, `adjust` invokes `/new-requirement` then plans,
  `stop` reports the drift and parks with no marker.
- **`/dispatch-worker`** — the `RELEVANCE-REVIEW` directive-table row, its handling
  subsection, and the `## 2. Pre-Planning Relevance Review` section are removed;
  the `plan` directive now flows through the generic `INVOKE` path
  (`INVOKE /plan-issue`). The trailing Stop section is renumbered to Section 2. The
  worker is not deleted here — that is leaf C (#1392).

## Verification

- `test-dispatch-scripts.sh`: 2174/2174 passing.
- `grep -rn 'RELEVANCE-REVIEW' .claude/`: zero matches.
- `/plan-issue` step headings run 1→7; `/dispatch-worker` sections run 1→2; no
  dangling cross-references.
