### PR TITLE
office-hours: position-on-curve pace panel in the Capacity view

### DIFF
--- a/office-hours/index.html
+++ b/office-hours/index.html
@@ -145,6 +145,21 @@
         color: var(--muted-fg, #9aa0a6);
         margin-bottom: 0.75rem;
       }
+      .capacity-pace {
+        display: block;
+        margin-top: 1.5rem;
+      }
+      .capacity-pace-heading {
+        font-size: 1rem;
+        letter-spacing: 0.05em;
+        color: var(--muted-fg, #9aa0a6);
+        margin-bottom: 0.75rem;
+      }
+      .capacity-pace-delta {
+        font-weight: 700;
+        font-size: 1.1rem;
+        margin: 0 0 0.75rem 0;
+      }
       .demo-banner {
         background: var(--accent-muted, #2a2f3a);
         color: var(--muted-fg, #9aa0a6);

--- a/office-hours/src/app-view.ts
+++ b/office-hours/src/app-view.ts
@@ -1,4 +1,5 @@
 import { renderCapacityBand, selectLatestSample } from "./capacity-band.js";
+import { renderPacePositionPanel } from "./pace-position-panel.js";
 import { renderHistoryBand } from "./history-band.js";
 import { renderReminderList } from "./office-hours.js";
 import { getDemoSamples } from "./usage-data.js";
@@ -23,10 +24,12 @@ export function renderApp(container: Element, state: ViewState, now: Date): void
 
     const samples = getDemoSamples();
     container.appendChild(renderCapacityBand(selectLatestSample(samples), now));
+    container.appendChild(renderPacePositionPanel(samples, now));
     container.appendChild(renderHistoryBand(samples));
     container.appendChild(renderReminderList(getDemoReminders(), now));
   } else if (state.tier === "owner") {
     container.appendChild(renderCapacityBand(selectLatestSample(state.samples), now));
+    container.appendChild(renderPacePositionPanel(state.samples, now));
     container.appendChild(renderHistoryBand(state.samples));
     container.appendChild(renderReminderList(state.reminders, now));
   } else {

--- a/office-hours/src/app-view.ts
+++ b/office-hours/src/app-view.ts
@@ -24,12 +24,12 @@ export function renderApp(container: Element, state: ViewState, now: Date): void
 
     const samples = getDemoSamples();
     container.appendChild(renderCapacityBand(selectLatestSample(samples), now));
-    container.appendChild(renderPacePositionPanel(samples, now));
+    container.appendChild(renderPacePositionPanel(samples));
     container.appendChild(renderHistoryBand(samples));
     container.appendChild(renderReminderList(getDemoReminders(), now));
   } else if (state.tier === "owner") {
     container.appendChild(renderCapacityBand(selectLatestSample(state.samples), now));
-    container.appendChild(renderPacePositionPanel(state.samples, now));
+    container.appendChild(renderPacePositionPanel(state.samples));
     container.appendChild(renderHistoryBand(state.samples));
     container.appendChild(renderReminderList(state.reminders, now));
   } else {

--- a/office-hours/src/pace-position-panel.ts
+++ b/office-hours/src/pace-position-panel.ts
@@ -54,10 +54,7 @@ export function renderPacePositionPanel(samples: UsageSample[]): HTMLElement {
   const backdrop = paceBackdrop();
   const nowX = elapsedWeekFraction(latest.sampledAt, latest.weeklyResetsAt);
 
-  const container = document.createElement("div");
-  container.className = "capacity-pace-chart";
-
-  const fg = getThemeFg(container);
+  const fg = getThemeFg(section);
   const sharedStyle = { background: "transparent", color: fg };
 
   const chartWidth = CONTAINER_WIDTH - AXIS_WIDTH;

--- a/office-hours/src/pace-position-panel.ts
+++ b/office-hours/src/pace-position-panel.ts
@@ -1,0 +1,127 @@
+import * as Plot from "@observablehq/plot";
+import { type UsageSample } from "./usage-samples.js";
+import { segmentByWeek, aheadBehindDelta, paceBackdrop } from "./pace-position.js";
+import { selectLatestSample } from "./capacity-band.js";
+import { elapsedWeekFraction } from "./weekly-pace-curve.js";
+import {
+  getThemeFg,
+  assembleChartLayout,
+  buildLegend,
+  renderAxisSvg,
+  AXIS_WIDTH,
+  MARGIN_RIGHT,
+  MARGIN_BOTTOM,
+} from "./chart-util.js";
+
+const COLOR_WEEKLY = "#26a69a";
+const COLOR_BACKDROP = "#ab47bc";
+
+/** Approximate visible width; the x domain is bounded [0, 1] so no scrolling. */
+const CONTAINER_WIDTH = 640;
+const CHART_HEIGHT = 220;
+
+/**
+ * Renders the position-on-curve pace panel: the fixed weekly pace curve W(x)
+ * drawn once across x ∈ [0, 1] as a muted backdrop, each weekly-usage sample
+ * re-projected onto its own elapsed-week fraction, segmented per weekly window
+ * (so no line crosses a reset boundary), the latest sample marked as "now",
+ * and the ahead/behind-pace delta surfaced as text.
+ *
+ * Weekly-only — the 5-hour series stays in the capacity snapshot band.
+ *
+ * Pure: does not mutate the input array. `now` is not needed because each
+ * sample carries its own reset time; the latest sample defines "now".
+ */
+export function renderPacePositionPanel(samples: UsageSample[], _now: Date): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "capacity-pace";
+
+  const heading = document.createElement("h2");
+  heading.className = "capacity-pace-heading";
+  heading.textContent = "PACE";
+  section.appendChild(heading);
+
+  if (samples.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "empty";
+    empty.textContent = "No usage history to chart pace position.";
+    section.appendChild(empty);
+    return section;
+  }
+
+  const segments = segmentByWeek(samples);
+  const latest = selectLatestSample(samples)!;
+  const backdrop = paceBackdrop();
+  const nowX = elapsedWeekFraction(latest.sampledAt, latest.weeklyResetsAt);
+
+  const container = document.createElement("div");
+  container.className = "capacity-pace-chart";
+
+  const fg = getThemeFg(container);
+  const sharedStyle = { background: "transparent", color: fg };
+
+  const chartWidth = CONTAINER_WIDTH - AXIS_WIDTH;
+  const yDomain: [number, number] = [0, 100];
+
+  const axisSvg = renderAxisSvg({ height: CHART_HEIGHT, style: sharedStyle, yDomain, label: "%" });
+
+  const chartSvg = Plot.plot({
+    width: chartWidth,
+    height: CHART_HEIGHT,
+    marginBottom: MARGIN_BOTTOM,
+    marginLeft: 0,
+    marginRight: MARGIN_RIGHT,
+    style: sharedStyle,
+    x: { domain: [0, 1], label: null },
+    y: { domain: yDomain, label: null, axis: null, grid: true },
+    marks: [
+      // 1. Backdrop — the fixed W(x) ramp drawn once across x∈[0,1], muted.
+      Plot.lineY(backdrop, {
+        x: "x",
+        y: "w",
+        stroke: COLOR_BACKDROP,
+        strokeWidth: 1.5,
+        strokeDasharray: "3,3",
+        curve: "monotone-x",
+      }),
+      // 2. Per-week trails — one mark per segment so no line crosses a reset boundary.
+      ...segments.map((seg) =>
+        Plot.lineY(seg.points, {
+          x: "x",
+          y: "weeklyUsedPct",
+          stroke: COLOR_WEEKLY,
+          strokeWidth: seg.isCurrent ? 2 : 1.5,
+          strokeOpacity: seg.isCurrent ? 1 : 0.35,
+          curve: "monotone-x",
+        }),
+      ),
+      // 3. Now marker — the latest sample's position on the curve.
+      Plot.dot([{ x: nowX, weeklyUsedPct: latest.weeklyUsedPct }], {
+        x: "x",
+        y: "weeklyUsedPct",
+        fill: COLOR_WEEKLY,
+        r: 4,
+      }),
+    ],
+  });
+
+  chartSvg.style.width = `${chartWidth}px`;
+  chartSvg.style.minWidth = `${chartWidth}px`;
+
+  const { layout } = assembleChartLayout(axisSvg, chartSvg);
+
+  const delta = aheadBehindDelta(latest);
+  const n = Math.round(Math.abs(delta));
+  const deltaEl = document.createElement("p");
+  deltaEl.className = "capacity-pace-delta";
+  deltaEl.textContent = delta >= 0 ? `${n} pts ahead of pace` : `${n} pts behind pace`;
+
+  const legend = buildLegend([
+    { label: "weekly %", color: COLOR_WEEKLY },
+    { label: "pace W(x)", color: COLOR_BACKDROP, dashed: true },
+  ]);
+
+  section.append(deltaEl, layout, legend);
+
+  return section;
+}

--- a/office-hours/src/pace-position-panel.ts
+++ b/office-hours/src/pace-position-panel.ts
@@ -29,10 +29,10 @@ const CHART_HEIGHT = 220;
  *
  * Weekly-only — the 5-hour series stays in the capacity snapshot band.
  *
- * Pure: does not mutate the input array. `now` is not needed because each
- * sample carries its own reset time; the latest sample defines "now".
+ * Pure: does not mutate the input array. Each sample carries its own reset
+ * time; the latest sample defines "now".
  */
-export function renderPacePositionPanel(samples: UsageSample[], _now: Date): HTMLElement {
+export function renderPacePositionPanel(samples: UsageSample[]): HTMLElement {
   const section = document.createElement("section");
   section.className = "capacity-pace";
 

--- a/office-hours/src/pace-position.ts
+++ b/office-hours/src/pace-position.ts
@@ -1,0 +1,106 @@
+import { type UsageSample } from "./usage-samples.js";
+import {
+  elapsedWeekFraction,
+  paceCurveAtFraction,
+  weeklyPaceCurve,
+} from "./weekly-pace-curve.js";
+
+/** A usage sample projected onto its elapsed-week fraction x ∈ [0, 1]. */
+export interface PacePoint {
+  /** Elapsed-week fraction in [0, 1]. */
+  x: number;
+  weeklyUsedPct: number;
+  sampledAt: Date;
+}
+
+/**
+ * A group of samples sharing a weekly window (same weeklyResetsAt), projected
+ * onto the elapsed-week fraction axis. Points are sorted ascending by x.
+ */
+export interface WeekSegment {
+  weeklyResetsAt: Date;
+  points: PacePoint[];
+  /** True for the segment with the latest (maximum) weeklyResetsAt. */
+  isCurrent: boolean;
+}
+
+/**
+ * Group samples by their weekly window (keyed by `weeklyResetsAt.getTime()`),
+ * project each sample onto its elapsed-week fraction `x`, sort points within
+ * each segment ascending by `sampledAt`, and order segments by `weeklyResetsAt`
+ * ascending.
+ *
+ * The segment with the latest `weeklyResetsAt` is flagged `isCurrent: true`.
+ * Grouping by `weeklyResetsAt` (not by detecting an x decrease) guarantees no
+ * segment connects x≈1 across a reset to the next week's x≈0.
+ *
+ * Does not mutate the input array.
+ */
+export function segmentByWeek(samples: UsageSample[]): WeekSegment[] {
+  if (samples.length === 0) return [];
+
+  // Group by weeklyResetsAt time value.
+  const map = new Map<number, { weeklyResetsAt: Date; rawSamples: UsageSample[] }>();
+  for (const s of samples) {
+    const key = s.weeklyResetsAt.getTime();
+    let entry = map.get(key);
+    if (entry === undefined) {
+      entry = { weeklyResetsAt: s.weeklyResetsAt, rawSamples: [] };
+      map.set(key, entry);
+    }
+    entry.rawSamples.push(s);
+  }
+
+  // Find the maximum weeklyResetsAt key.
+  let maxKey = -Infinity;
+  for (const key of map.keys()) {
+    if (key > maxKey) maxKey = key;
+  }
+
+  // Build segments sorted by weeklyResetsAt ascending.
+  const sortedKeys = Array.from(map.keys()).sort((a, b) => a - b);
+
+  return sortedKeys.map((key) => {
+    const { weeklyResetsAt, rawSamples } = map.get(key)!;
+
+    // Sort points ascending by sampledAt (== ascending x within a window).
+    const sorted = [...rawSamples].sort(
+      (a, b) => a.sampledAt.getTime() - b.sampledAt.getTime(),
+    );
+
+    const points: PacePoint[] = sorted.map((s) => ({
+      x: elapsedWeekFraction(s.sampledAt, s.weeklyResetsAt),
+      weeklyUsedPct: s.weeklyUsedPct,
+      sampledAt: s.sampledAt,
+    }));
+
+    return {
+      weeklyResetsAt,
+      points,
+      isCurrent: key === maxKey,
+    };
+  });
+}
+
+/**
+ * How far ahead or behind pace the sample is:
+ * `weeklyUsedPct − W(x)` where W(x) is the pace curve value at this sample's
+ * elapsed-week fraction. Positive = ahead of pace; negative = behind.
+ */
+export function aheadBehindDelta(sample: UsageSample): number {
+  return sample.weeklyUsedPct - weeklyPaceCurve(sample.sampledAt, sample.weeklyResetsAt);
+}
+
+/**
+ * The fixed W(x) backdrop — `steps + 1` points sampling the pace curve at
+ * evenly-spaced fractions across x ∈ [0, 1]. Suitable as a reference line
+ * drawn once regardless of which week is being viewed.
+ */
+export function paceBackdrop(steps = 100): { x: number; w: number }[] {
+  const points: { x: number; w: number }[] = [];
+  for (let i = 0; i <= steps; i++) {
+    const x = i / steps;
+    points.push({ x, w: paceCurveAtFraction(x) });
+  }
+  return points;
+}

--- a/office-hours/src/pace-position.ts
+++ b/office-hours/src/pace-position.ts
@@ -51,14 +51,9 @@ export function segmentByWeek(samples: UsageSample[]): WeekSegment[] {
     entry.rawSamples.push(s);
   }
 
-  // Find the maximum weeklyResetsAt key.
-  let maxKey = -Infinity;
-  for (const key of map.keys()) {
-    if (key > maxKey) maxKey = key;
-  }
-
-  // Build segments sorted by weeklyResetsAt ascending.
+  // Build segments sorted by weeklyResetsAt ascending; the last key is the max.
   const sortedKeys = Array.from(map.keys()).sort((a, b) => a - b);
+  const maxKey = sortedKeys[sortedKeys.length - 1];
 
   return sortedKeys.map((key) => {
     const { weeklyResetsAt, rawSamples } = map.get(key)!;

--- a/office-hours/src/weekly-pace-curve.ts
+++ b/office-hours/src/weekly-pace-curve.ts
@@ -47,19 +47,30 @@ function clamp(v: number, lo: number, hi: number): number {
 }
 
 /**
- * The cumulative weekly pace curve value (weekly %) for a sample taken at
- * `sampledAt`, given its weekly window resets at `weeklyResetsAt`.
+ * The elapsed fraction of the weekly window for a sample taken at `sampledAt`,
+ * given its weekly window resets at `weeklyResetsAt`. Clamped to [0, 1]: 0 a
+ * full week (or more) before the reset, 1 at (or past) the reset.
  *
- * Returns 0 when the weekly window has already reset (remaining <= 0), matching
- * the awk reference's early `print 0; exit`.
+ * This is the `x` of the pace curve W(x) — a pure function of where the sample
+ * sits in its weekly window, independent of wall-clock time.
  */
-export function weeklyPaceCurve(sampledAt: Date, weeklyResetsAt: Date): number {
+export function elapsedWeekFraction(sampledAt: Date, weeklyResetsAt: Date): number {
   const remaining = (weeklyResetsAt.getTime() - sampledAt.getTime()) / 1000;
-  if (remaining <= 0) return 0;
+  return clamp((WEEK_SECONDS - remaining) / WEEK_SECONDS, 0, 1);
+}
 
-  // Elapsed fraction of the weekly window, clamped to [0, 1].
-  const x = clamp((WEEK_SECONDS - remaining) / WEEK_SECONDS, 0, 1);
-
+/**
+ * The pace curve W(x) as a pure function of the elapsed-week fraction
+ * `x ∈ [0, 1]`. Both terms reduce to functions of `x` alone, so the curve is
+ * identical every week and can be drawn once as a fixed backdrop.
+ *
+ * The smooth cumulative power curve, maxed with a terminal
+ * "you-can-still-make-it" envelope. The envelope's remaining-seconds term is
+ * reconstructed from `x` as `(1 - x) * WEEK_SECONDS`, then divided by
+ * `WINDOW_SECONDS` — i.e. `(1 - x) * 33.6`, NOT `(1 - x) * T` (T is the rounded
+ * 34) — to match the original `remaining / WINDOW_SECONDS` exactly.
+ */
+export function paceCurveAtFraction(x: number): number {
   // Smooth cumulative power curve.
   let W = T * (FLOOR * x + (END - FLOOR) * x ** (POWER + 1) / (POWER + 1));
 
@@ -67,9 +78,23 @@ export function weeklyPaceCurve(sampledAt: Date, weeklyResetsAt: Date): number {
   // most CAP per remaining window still reaches WEEKLY_TERMINAL. Mid-week the
   // remaining-windows term is large and the envelope is deeply negative, so the
   // smooth curve dominates; the envelope only lifts the final ~1.7 windows.
-  const remWindows = remaining / WINDOW_SECONDS;
-  const envelope = WEEKLY_TERMINAL - CAP * remWindows;
+  const remaining = (1 - x) * WEEK_SECONDS;
+  const envelope = WEEKLY_TERMINAL - CAP * (remaining / WINDOW_SECONDS);
   if (W < envelope) W = envelope;
 
   return W;
+}
+
+/**
+ * The cumulative weekly pace curve value (weekly %) for a sample taken at
+ * `sampledAt`, given its weekly window resets at `weeklyResetsAt`.
+ *
+ * Returns 0 when the weekly window has already reset (remaining <= 0), matching
+ * the awk reference's early `print 0; exit`; otherwise composes
+ * `paceCurveAtFraction(elapsedWeekFraction(...))`.
+ */
+export function weeklyPaceCurve(sampledAt: Date, weeklyResetsAt: Date): number {
+  const remaining = (weeklyResetsAt.getTime() - sampledAt.getTime()) / 1000;
+  if (remaining <= 0) return 0;
+  return paceCurveAtFraction(elapsedWeekFraction(sampledAt, weeklyResetsAt));
 }

--- a/office-hours/test/pace-position-panel.test.ts
+++ b/office-hours/test/pace-position-panel.test.ts
@@ -23,8 +23,6 @@ function oneWeekSamples(): UsageSample[] {
   ];
 }
 
-const NOW = new Date("2026-06-12T00:00:00Z");
-
 function withFg(): HTMLElement {
   // happy-dom has no stylesheet, so missing.css's --fg is absent — set it on
   // the container so getThemeFg reads it live.
@@ -36,7 +34,7 @@ function withFg(): HTMLElement {
 
 describe("renderPacePositionPanel", () => {
   it("shows the empty-state message for an empty array", () => {
-    const el = renderPacePositionPanel([], NOW);
+    const el = renderPacePositionPanel([]);
     const empty = el.querySelector(".empty");
     expect(empty).not.toBeNull();
     expect(empty!.textContent).toBe("No usage history to chart pace position.");
@@ -45,7 +43,7 @@ describe("renderPacePositionPanel", () => {
 
   it("renders the pace panel with chart, delta text, and heading", () => {
     const host = withFg();
-    const el = renderPacePositionPanel(oneWeekSamples(), NOW);
+    const el = renderPacePositionPanel(oneWeekSamples());
     host.appendChild(el);
 
     // The delta text surfaces "pace".

--- a/office-hours/test/pace-position-panel.test.ts
+++ b/office-hours/test/pace-position-panel.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { renderPacePositionPanel } from "../src/pace-position-panel.js";
+import { type UsageSample } from "../src/usage-samples.js";
+
+const baseSample: UsageSample = {
+  sampledAt: new Date("2026-06-09T10:00:00Z"),
+  fiveHourUsedPct: 42.5,
+  weeklyUsedPct: 18.3,
+  fiveHourResetsAt: new Date("2026-06-09T15:00:00Z"),
+  weeklyResetsAt: new Date("2026-06-14T00:00:00Z"),
+  activeWorkers: 3,
+  targetWorkers: 4,
+  groupId: "group-abc",
+};
+
+const make = (o: Partial<UsageSample> = {}): UsageSample => ({ ...baseSample, ...o });
+
+// Two samples within ONE week (same weeklyResetsAt), sampledAt in the 7 days before it.
+function oneWeekSamples(): UsageSample[] {
+  return [
+    make({ sampledAt: new Date("2026-06-09T00:00:00Z"), weeklyUsedPct: 20 }),
+    make({ sampledAt: new Date("2026-06-12T00:00:00Z"), weeklyUsedPct: 55 }),
+  ];
+}
+
+const NOW = new Date("2026-06-12T00:00:00Z");
+
+function withFg(): HTMLElement {
+  // happy-dom has no stylesheet, so missing.css's --fg is absent — set it on
+  // the container so getThemeFg reads it live.
+  const container = document.createElement("div");
+  container.style.setProperty("--fg", "#ddd");
+  document.body.appendChild(container);
+  return container;
+}
+
+describe("renderPacePositionPanel", () => {
+  it("shows the empty-state message for an empty array", () => {
+    const el = renderPacePositionPanel([], NOW);
+    const empty = el.querySelector(".empty");
+    expect(empty).not.toBeNull();
+    expect(empty!.textContent).toBe("No usage history to chart pace position.");
+    expect(el.querySelector("svg")).toBeNull();
+  });
+
+  it("renders the pace panel with chart, delta text, and heading", () => {
+    const host = withFg();
+    const el = renderPacePositionPanel(oneWeekSamples(), NOW);
+    host.appendChild(el);
+
+    // The delta text surfaces "pace".
+    expect(el.textContent).toContain("pace");
+    // A chart body svg exists.
+    expect(el.querySelector(".chart-scroll-wrapper svg")).not.toBeNull();
+    // The PACE heading is present.
+    expect(el.querySelector(".capacity-pace-heading")).not.toBeNull();
+  });
+});

--- a/office-hours/test/pace-position.test.ts
+++ b/office-hours/test/pace-position.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import { segmentByWeek, aheadBehindDelta, paceBackdrop } from "../src/pace-position.js";
+import { type UsageSample } from "../src/usage-samples.js";
+import { weeklyPaceCurve, WEEK_SECONDS } from "../src/weekly-pace-curve.js";
+
+// Two distinct weekly windows:
+//   RESET_A  — the earlier week resets on 2026-06-14T00:00:00Z
+//   RESET_B  — the current week resets on 2026-06-21T00:00:00Z
+const RESET_A = new Date("2026-06-14T00:00:00Z");
+const RESET_B = new Date("2026-06-21T00:00:00Z");
+
+const baseSample: UsageSample = {
+  sampledAt: new Date("2026-06-07T12:00:00Z"),
+  fiveHourUsedPct: 30,
+  weeklyUsedPct: 20,
+  fiveHourResetsAt: new Date("2026-06-07T17:00:00Z"),
+  weeklyResetsAt: RESET_A,
+  activeWorkers: 2,
+  targetWorkers: 3,
+  groupId: "grp-test",
+};
+
+const make = (o: Partial<UsageSample> = {}): UsageSample => ({ ...baseSample, ...o });
+
+// Helper: a sampledAt that is `remainingSeconds` before a given reset, giving
+// a well-defined x = (WEEK_SECONDS - remainingSeconds) / WEEK_SECONDS.
+const atBefore = (reset: Date, remainingSeconds: number): Date =>
+  new Date(reset.getTime() - remainingSeconds * 1000);
+
+describe("segmentByWeek", () => {
+  it("returns [] for an empty input", () => {
+    expect(segmentByWeek([])).toEqual([]);
+  });
+
+  it("produces two segments for a two-week trail", () => {
+    const s1 = make({
+      sampledAt: atBefore(RESET_A, WEEK_SECONDS * 0.5), // mid-week A
+      weeklyResetsAt: RESET_A,
+    });
+    const s2 = make({
+      sampledAt: atBefore(RESET_B, WEEK_SECONDS * 0.5), // mid-week B
+      weeklyResetsAt: RESET_B,
+    });
+
+    const segments = segmentByWeek([s1, s2]);
+    expect(segments).toHaveLength(2);
+  });
+
+  it("orders segments by weeklyResetsAt ascending", () => {
+    const s1 = make({ sampledAt: atBefore(RESET_A, WEEK_SECONDS * 0.3), weeklyResetsAt: RESET_A });
+    const s2 = make({ sampledAt: atBefore(RESET_B, WEEK_SECONDS * 0.3), weeklyResetsAt: RESET_B });
+
+    // Pass in reverse order to confirm sorting, not input order.
+    const segments = segmentByWeek([s2, s1]);
+    expect(segments[0].weeklyResetsAt.getTime()).toBe(RESET_A.getTime());
+    expect(segments[1].weeklyResetsAt.getTime()).toBe(RESET_B.getTime());
+  });
+
+  it("flags only the segment with the latest weeklyResetsAt as isCurrent", () => {
+    const s1 = make({ sampledAt: atBefore(RESET_A, WEEK_SECONDS * 0.5), weeklyResetsAt: RESET_A });
+    const s2 = make({ sampledAt: atBefore(RESET_B, WEEK_SECONDS * 0.5), weeklyResetsAt: RESET_B });
+
+    const segments = segmentByWeek([s1, s2]);
+    expect(segments[0].isCurrent).toBe(false); // RESET_A is earlier
+    expect(segments[1].isCurrent).toBe(true);  // RESET_B is the latest
+  });
+
+  it("sorts points within a segment ascending by sampledAt", () => {
+    // Three samples in RESET_B's window, passed out of time order.
+    const early = make({ sampledAt: atBefore(RESET_B, WEEK_SECONDS * 0.7), weeklyResetsAt: RESET_B });
+    const mid   = make({ sampledAt: atBefore(RESET_B, WEEK_SECONDS * 0.5), weeklyResetsAt: RESET_B });
+    const late  = make({ sampledAt: atBefore(RESET_B, WEEK_SECONDS * 0.2), weeklyResetsAt: RESET_B });
+
+    const segments = segmentByWeek([late, early, mid]);
+    expect(segments).toHaveLength(1);
+    const { points } = segments[0];
+    expect(points[0].sampledAt.getTime()).toBe(early.sampledAt.getTime());
+    expect(points[1].sampledAt.getTime()).toBe(mid.sampledAt.getTime());
+    expect(points[2].sampledAt.getTime()).toBe(late.sampledAt.getTime());
+  });
+
+  it("points within a segment have monotonically increasing x", () => {
+    const s1 = make({ sampledAt: atBefore(RESET_B, WEEK_SECONDS * 0.7), weeklyResetsAt: RESET_B });
+    const s2 = make({ sampledAt: atBefore(RESET_B, WEEK_SECONDS * 0.5), weeklyResetsAt: RESET_B });
+    const s3 = make({ sampledAt: atBefore(RESET_B, WEEK_SECONDS * 0.2), weeklyResetsAt: RESET_B });
+
+    const segments = segmentByWeek([s3, s1, s2]);
+    const xs = segments[0].points.map((p) => p.x);
+    for (let i = 1; i < xs.length; i++) {
+      expect(xs[i]).toBeGreaterThan(xs[i - 1]);
+    }
+  });
+
+  it("does not mutate the input array", () => {
+    const s1 = make({ sampledAt: atBefore(RESET_A, WEEK_SECONDS * 0.6), weeklyResetsAt: RESET_A });
+    const s2 = make({ sampledAt: atBefore(RESET_B, WEEK_SECONDS * 0.4), weeklyResetsAt: RESET_B });
+    const input = [s1, s2];
+    const before = input.slice();
+
+    segmentByWeek(input);
+
+    expect(input[0]).toBe(before[0]);
+    expect(input[1]).toBe(before[1]);
+  });
+
+  it("groups multiple samples sharing a weeklyResetsAt into one segment", () => {
+    const sA1 = make({ sampledAt: atBefore(RESET_A, WEEK_SECONDS * 0.8), weeklyResetsAt: RESET_A });
+    const sA2 = make({ sampledAt: atBefore(RESET_A, WEEK_SECONDS * 0.4), weeklyResetsAt: RESET_A });
+    const sB1 = make({ sampledAt: atBefore(RESET_B, WEEK_SECONDS * 0.6), weeklyResetsAt: RESET_B });
+
+    const segments = segmentByWeek([sB1, sA2, sA1]);
+    expect(segments).toHaveLength(2);
+    // RESET_A segment has 2 points, RESET_B has 1.
+    expect(segments[0].points).toHaveLength(2);
+    expect(segments[1].points).toHaveLength(1);
+  });
+});
+
+describe("aheadBehindDelta", () => {
+  it("returns a positive delta when weeklyUsedPct exceeds W(x)", () => {
+    // At x ≈ 0.5, W ≈ 31. Setting weeklyUsedPct = 50 means delta ≈ +19.
+    const sampledAt = atBefore(RESET_B, WEEK_SECONDS * 0.5);
+    const sample = make({ sampledAt, weeklyResetsAt: RESET_B, weeklyUsedPct: 50 });
+
+    const delta = aheadBehindDelta(sample);
+    expect(delta).toBeGreaterThan(0);
+  });
+
+  it("returns a negative delta when weeklyUsedPct is below W(x)", () => {
+    // At x ≈ 0.5, W ≈ 31. Setting weeklyUsedPct = 10 means delta ≈ −21.
+    const sampledAt = atBefore(RESET_B, WEEK_SECONDS * 0.5);
+    const sample = make({ sampledAt, weeklyResetsAt: RESET_B, weeklyUsedPct: 10 });
+
+    const delta = aheadBehindDelta(sample);
+    expect(delta).toBeLessThan(0);
+  });
+
+  it("equals weeklyUsedPct - weeklyPaceCurve(sampledAt, weeklyResetsAt) exactly", () => {
+    const sampledAt = atBefore(RESET_B, WEEK_SECONDS * 0.5);
+    const sample = make({ sampledAt, weeklyResetsAt: RESET_B, weeklyUsedPct: 50 });
+
+    const expected = sample.weeklyUsedPct - weeklyPaceCurve(sample.sampledAt, sample.weeklyResetsAt);
+    expect(aheadBehindDelta(sample)).toBeCloseTo(expected, 12);
+  });
+
+  it("equals weeklyUsedPct - weeklyPaceCurve for a below-pace sample", () => {
+    const sampledAt = atBefore(RESET_B, WEEK_SECONDS * 0.25);
+    const sample = make({ sampledAt, weeklyResetsAt: RESET_B, weeklyUsedPct: 10 });
+
+    const expected = sample.weeklyUsedPct - weeklyPaceCurve(sample.sampledAt, sample.weeklyResetsAt);
+    expect(aheadBehindDelta(sample)).toBeCloseTo(expected, 12);
+  });
+});
+
+describe("paceBackdrop", () => {
+  it("default steps=100 yields 101 points", () => {
+    expect(paceBackdrop()).toHaveLength(101);
+  });
+
+  it("custom steps=10 yields 11 points", () => {
+    expect(paceBackdrop(10)).toHaveLength(11);
+  });
+
+  it("first point has x === 0", () => {
+    const points = paceBackdrop();
+    expect(points[0].x).toBe(0);
+  });
+
+  it("last point has x === 1", () => {
+    const points = paceBackdrop();
+    expect(points[points.length - 1].x).toBe(1);
+  });
+
+  it("w is monotonically non-decreasing across all points", () => {
+    const points = paceBackdrop();
+    for (let i = 1; i < points.length; i++) {
+      expect(points[i].w).toBeGreaterThanOrEqual(points[i - 1].w);
+    }
+  });
+
+  it("x values are evenly spaced from 0 to 1", () => {
+    const steps = 10;
+    const points = paceBackdrop(steps);
+    for (let i = 0; i <= steps; i++) {
+      expect(points[i].x).toBeCloseTo(i / steps, 12);
+    }
+  });
+});

--- a/office-hours/test/weekly-pace-curve.test.ts
+++ b/office-hours/test/weekly-pace-curve.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   weeklyPaceCurve,
+  elapsedWeekFraction,
+  paceCurveAtFraction,
   WEEK_SECONDS,
   WINDOW_SECONDS,
   T,
@@ -79,5 +81,57 @@ describe("weeklyPaceCurve", () => {
     const late = weeklyPaceCurve(at(WEEK_SECONDS * 0.25), RESET);
     expect(early).toBeLessThan(mid);
     expect(mid).toBeLessThan(late);
+  });
+});
+
+describe("elapsedWeekFraction", () => {
+  it("is 0 a full week before the reset", () => {
+    // remaining = WEEK_SECONDS → (WEEK - WEEK)/WEEK = 0.
+    expect(elapsedWeekFraction(at(WEEK_SECONDS), RESET)).toBe(0);
+  });
+
+  it("is 0.5 half a week before the reset", () => {
+    expect(elapsedWeekFraction(at(WEEK_SECONDS / 2), RESET)).toBeCloseTo(0.5, 12);
+  });
+
+  it("is 1 at the reset", () => {
+    // remaining = 0 → (WEEK - 0)/WEEK = 1.
+    expect(elapsedWeekFraction(at(0), RESET)).toBe(1);
+  });
+
+  it("clamps to 0 when remaining exceeds a full week", () => {
+    // remaining = 2*WEEK → (WEEK - 2*WEEK)/WEEK = -1, clamps to 0.
+    expect(elapsedWeekFraction(at(2 * WEEK_SECONDS), RESET)).toBe(0);
+  });
+
+  it("clamps to 1 when remaining is negative (sampled past the reset)", () => {
+    // remaining < 0 → (WEEK - remaining)/WEEK > 1, clamps to 1.
+    expect(elapsedWeekFraction(at(-WINDOW_SECONDS), RESET)).toBe(1);
+  });
+});
+
+describe("paceCurveAtFraction", () => {
+  it("matches the smooth-curve mid-week value at x=0.5", () => {
+    // Same assertion as weeklyPaceCurve at x=0.5: W = 31.0.
+    expect(paceCurveAtFraction(0.5)).toBeCloseTo(31.0, 6);
+  });
+
+  it("recomposes weeklyPaceCurve via elapsedWeekFraction (remaining > 0)", () => {
+    // For several samples within the week, the decomposition must reproduce
+    // weeklyPaceCurve exactly.
+    const offsets = [
+      WEEK_SECONDS * 0.9,
+      WEEK_SECONDS * 0.75,
+      WEEK_SECONDS * 0.5,
+      WEEK_SECONDS * 0.25,
+      WINDOW_SECONDS,
+      1,
+    ];
+    for (const offset of offsets) {
+      const s = at(offset);
+      expect(paceCurveAtFraction(elapsedWeekFraction(s, RESET))).toBe(
+        weeklyPaceCurve(s, RESET),
+      );
+    }
   });
 });


### PR DESCRIPTION
Closes #1400

## Summary

Adds a **position-on-curve pace panel** to the office-hours Capacity view,
answering "where does our current usage put us on the weekly pace curve?" — the
read the `dispatch-scaling-dashboard.html` position-on-curve diagram delivers but
the office-hours app did not.

The existing `usage-history-chart.ts` plots usage against **wall-clock time** over
the narrow window of collected samples, so it never draws the full `W(x)` ramp,
never anchors how far into the week we are, and never surfaces the ahead/behind
delta as a number. `W(x)` is a pure function of elapsed-week fraction `x`, so it is
identical every week and can be drawn **once** as a fixed backdrop, with each
weekly sample re-projected onto its own elapsed-week fraction.

This panel is complementary to the chronological history chart, which keeps its
"what happened over time" role. The new panel is the "where are we on the curve
now" view. It is weekly-only — the 5-hour series stays in the capacity snapshot
band.

## What changed

- **`weekly-pace-curve.ts`** — extracted two reusable pure cores,
  `elapsedWeekFraction(sampledAt, weeklyResetsAt)` and `paceCurveAtFraction(x)`,
  and recomposed `weeklyPaceCurve` on top of them. Behavior-preserving — the
  existing suite stays green, so there is no second copy of the pace math.
- **`pace-position.ts`** (new) — the pure, DOM-free projection core:
  `segmentByWeek` (groups samples per weekly window and projects each to its own
  elapsed-week fraction `x`, so no trail segment connects `x ≈ 1` across a reset to
  the next week's `x ≈ 0`), `aheadBehindDelta` (= `used_weekly(now) − W(now)`), and
  `paceBackdrop` (the fixed `W(x)` ramp across `x ∈ [0, 1]`).
- **`pace-position-panel.ts`** (new) — renders the panel: the full `W(x)` backdrop
  drawn once, one per-week trail mark (current week emphasized, prior weeks faint
  ghost trails), a "now" dot at the latest sample's `x`, and the
  `N pts ahead/behind of pace` delta text. Empty input renders a message rather
  than erroring.
- **`app-view.ts`** — mounts the panel between the capacity band and the history
  band in both the demo and owner tiers.
- **`index.html`** — `.capacity-pace` / `-heading` / `-delta` CSS; reuses the
  existing chart/legend/empty classes.

## Tests

Unit tests cover the per-sample `x` derivation and pace recomposition
(`weekly-pace-curve.test.ts`), the per-week segmentation and ahead/behind delta
(`pace-position.test.ts`), and the panel's empty-state and render
(`pace-position-panel.test.ts`). Full office-hours suite: 148 tests pass.
Type-check and the production Vite build both succeed.

Builds on the shipped capacity work (#1005 epic — status band #1008, history charts
#1009).
