### PR TITLE
dispatch: single-pass --top selection collapses the fan-out's per-slot selector calls

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -18,14 +18,16 @@
 # supporting detail (a path, a blocker list, the CI line) precedes the token.
 #
 # With `--gap <N>` and `queue` mode, the script FANS OUT: it spawns up to N
-# workers in one held-lock run, selecting a distinct next target each iteration
-# via dispatch-select-target. The first target is the passed-in <issue-N>;
-# targets 2..N come from successive dispatch-select-target calls. The worker no
-# longer registers synchronously (#1048), so the loop threads its SEEN set as
-# `--exclude` to dispatch-select-target AND the just-written reservation marker
-# makes dispatch-select-target's reserved-skip (#1046) skip the reserved
-# worktree — so the next selection yields a distinct target even though the prior
-# worker has not yet registered.
+# workers in one held-lock run. The seed (target 1) is the passed-in <issue-N>;
+# targets 2..GAP come from ONE `dispatch-select-target --top <GAP-after-seed>`
+# scan (#1317) — a single queue pass that returns up to that many distinct
+# ranked targets, instead of one serialized selector call per slot. The seed's
+# just-written reservation marker (dispatch-select-target's reserved-skip, #1046)
+# plus a single static `--exclude <issue-N>` on that one scan close the seed
+# re-selection race; selection dedups the remaining targets internally within
+# that one scan, so no per-slot SEEN threading is needed. The worker no longer
+# registers synchronously (#1048); the reservation marker, not registration,
+# closes the spawn-gap race for each spawned slot.
 # `explicit` mode and `--gap 1` process a single target (backward-compatible).
 # Fan-out (`--gap N` with N>1) is autonomous-only; a manual run arrives as
 # `--gap 1` and takes the single-target path.
@@ -434,33 +436,30 @@ if [[ "$MODE" == "explicit" ]] || (( GAP <= 1 )); then
   exit 0
 fi
 
-# Fan out: fill up to GAP slots in one held-lock run. Target 1 is the passed-in
-# N; targets 2..GAP come from successive dispatch-select-target calls. The loop
-# passes its SEEN set as `--exclude` to dispatch-select-target so selection
-# yields the NEXT distinct target instead of re-returning an already-processed
-# one (#1062). The worker is no longer verified-registered (the spawn is async —
-# #1048), so within-loop de-confliction rests on the SEEN `--exclude` AND the
-# reservation marker (dispatch-select-target's reserved-skip, #1046), not on
-# registration visibility. A re-return would otherwise happen via two mechanisms:
-# (1) a target whose just-written reservation or SEEN membership is not honored;
-# or (2) a fast self-close leaving an orphan worktree, which selection treats as
-# a reuse signal (not a conflict) and does not skip. The
-# exclusion defeats both: an excluded target is filtered during the queue scan
-# (and threaded into the leaf trace), so the loop advances to the next distinct
-# startable leaf. The loop stops only on a genuine `empty`, a deferred selection
-# (main-broken / jit-reminder), or a hard error — plus a defensive backstop if
-# selection ever re-returns a SEEN target despite the exclusion (a selector
-# contract violation), to prevent an infinite loop. Per-target park/skip
-# outcomes are recorded and the loop continues; the lock is released ONCE at the
-# end.
-declare -A SEEN=()
-spawned=0
-stop_reason="gap filled"
-cur_n="$N"
-cur_mode="$MODE"
-while :; do
-  process_one_target "$cur_n" "$cur_mode" || { release_lock; exit 2; }
-  SEEN["$cur_n"]=1
+# Fan out: fill up to GAP slots in one held-lock run. The seed (slot 1) is the
+# passed-in N; slots 2..GAP come from ONE `dispatch-select-target --top
+# <GAP-after-seed>` scan (#1317) — a single queue pass yields up to that many
+# distinct ranked targets, replacing the old once-per-slot serialized selector
+# calls (~131s each) that pinned the lock for O(N) scans and never let
+# concurrency accumulate. Per-run fill may be `< GAP` when targets skip (parked /
+# done / worktree-conflict) or when the single scan returns fewer than the gap's
+# worth of eligible targets — that is normal; the next tick compounds toward the
+# target. The seed's reservation marker (dispatch-select-target's reserved-skip,
+# #1046) plus the single static `--exclude "$N"` on that one scan close the seed
+# re-selection race; selection dedups the remaining targets internally within the
+# scan. A defensive SEEN dedup on consumption is the backstop against a
+# re-returned target (it should never fire) so a stray duplicate is skipped
+# rather than re-dispatched. The loop stops on a genuine `empty`, a deferred
+# selection (main-broken / jit-reminder), the gap being filled, or a hard error.
+# Per-target park/skip outcomes are recorded and consumption continues; the lock
+# is released ONCE at the end (or on a hard `exit 2`).
+
+# record_outcome <cur_n>: apply the per-target OUTCOME → detail-line mapping to
+# the (just-processed) target $1, reading the global OUTCOME and mutating the
+# outer `spawned`. Used for both the seed and each consumed selector line so the
+# two paths print identical detail lines and bump the count identically.
+record_outcome() {
+  local cur_n="$1"
   case "$OUTCOME" in
     spawned)        spawned=$(( spawned + 1 )); echo "propagate: spawned #$cur_n" ;;
     target-blocked) echo "propagate: parked #$cur_n ($OUTCOME)" ;;
@@ -485,34 +484,54 @@ while :; do
       esac
       ;;
   esac
-  (( spawned >= GAP )) && break
-  exclude_args=()
-  (( ${#SEEN[@]} > 0 )) && exclude_args=(--exclude "${!SEEN[@]}")
-  SELECTED=$("$SCRIPT_DIR/dispatch-select-target" "${exclude_args[@]}") || true
-  case "$SELECTED" in
-    pr\ *)
-      # Extract the branch from "pr <pr_num> <branch> <phase>" without clobbering $@.
-      { IFS=' ' read -r _f1 _f2 _pr_branch _f4 <<<"$SELECTED"; }
-      cur_n="${_pr_branch%%-*}"; cur_mode=queue
-      ;;
-    issue\ *) cur_n="${SELECTED#issue }"; cur_mode=queue ;;
-    empty)    stop_reason="queue exhausted"; break ;;
-    main-broken\ *|jit-reminder\ *) stop_reason="selection deferred (${SELECTED%% *})"; break ;;
-    *) release_lock
-       echo "dispatch-materialize-spawn: dispatch-select-target emitted unexpected '$SELECTED' in fan-out" >&2
-       exit 2 ;;
-  esac
-  # Defensive backstop (#1062): the loop passes SEEN as --exclude, so
-  # dispatch-select-target must never return an already-processed target. If it
-  # somehow does, that is a selector contract violation — break rather than spin
-  # forever. This stop is unreachable in normal operation; the loop's real
-  # terminators are `empty`, a deferred selection, and hard errors above.
-  if [[ -n "${SEEN[$cur_n]:-}" ]]; then
-    echo "dispatch-materialize-spawn: dispatch-select-target re-returned already-processed target #$cur_n despite --exclude (contract violation); stopping fan-out to avoid an infinite loop" >&2
-    stop_reason="selection re-returned an excluded target (unexpected)"
-    break
+}
+
+declare -A SEEN=()
+spawned=0
+stop_reason="gap filled"
+
+# --- seed: process the passed-in N first (unchanged semantics) ---
+process_one_target "$N" "$MODE" || { release_lock; exit 2; }
+SEEN["$N"]=1
+record_outcome "$N"
+
+if (( spawned < GAP )); then
+  # --- ONE selector scan fills slots 2..GAP (#1317): O(1) scans, not O(N) ---
+  # The single static --exclude "$N" is belt-and-suspenders atop the seed's
+  # just-written reservation marker; selection dedups the rest internally in
+  # this one scan.
+  SELECTED=$("$SCRIPT_DIR/dispatch-select-target" --top "$(( GAP - spawned ))" --exclude "$N") || true
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    case "$line" in
+      pr\ *)
+        # Extract the branch from "pr <pr_num> <branch> <phase>" without clobbering $@.
+        { IFS=' ' read -r _f1 _f2 _pr_branch _f4 <<<"$line"; }
+        cur_n="${_pr_branch%%-*}"; cur_mode=queue ;;
+      issue\ *) cur_n="${line#issue }"; cur_mode=queue ;;
+      empty) stop_reason="queue exhausted"; break ;;
+      main-broken\ *|jit-reminder\ *) stop_reason="selection deferred (${line%% *})"; break ;;
+      *) release_lock
+         echo "dispatch-materialize-spawn: dispatch-select-target emitted unexpected '$line' in fan-out" >&2
+         exit 2 ;;
+    esac
+    # Defensive dedup backstop: the single scan dedups internally and the seed
+    # is --exclude'd, so a SEEN target should never appear; if it does, skip it
+    # quietly rather than re-dispatching.
+    if [[ -n "${SEEN[$cur_n]:-}" ]]; then continue; fi
+    process_one_target "$cur_n" "$cur_mode" || { release_lock; exit 2; }
+    SEEN["$cur_n"]=1
+    record_outcome "$cur_n"
+    (( spawned >= GAP )) && { stop_reason="gap filled"; break; }
+  done <<< "$SELECTED"
+  # Ran off the end of a short list without filling the gap or hitting a
+  # break: the single --top scan returned fewer than GAP-spawned eligible
+  # targets, so the queue is exhausted for this run (the next tick compounds).
+  if (( spawned < GAP )) && [[ "$stop_reason" == "gap filled" ]]; then
+    stop_reason="queue exhausted"
   fi
-done
+fi
+
 release_lock
 if [[ "$stop_reason" == "gap filled" ]]; then
   echo "propagate: spawned $spawned of gap $GAP"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Select the single highest-priority task from the queue.
-# Usage: dispatch-select-target [--qa | --health-only | --main-broken-sha | --priority-only] [--exclude <n>...]
+# Usage: dispatch-select-target [--qa | --health-only | --main-broken-sha | --priority-only] [--top <N>] [--exclude <n>...]
 #
 # --exclude <n>... names issue numbers the caller has already processed (the
 # fan-out loop's SEEN set, #1062); the selector never returns an excluded target
@@ -28,6 +28,18 @@
 #                                 every PR/issue tier; inert when no local
 #                                 dispatch.config/jit.json is present.
 #   main-broken <sha>           — origin/main's HEAD CI has a failing check; no task selected
+#
+# --top <N> (default 1, default-mode only) emits up to N distinct decision lines
+# in the existing priority order (priority axis → topic category → phase ladder),
+# one per line — the fan-out caller consumes the list in a single scan instead of
+# re-invoking the selector once per slot (#1317). Each scan dedups internally: no
+# target is returned twice, and live/reserved/office-hours/excluded targets are
+# skipped exactly as in single-target mode. A tripped JIT or main-broken gate
+# still emits its single line (the single-target contract is unchanged — the
+# consumer treats it as deferred), and `empty` is still one line when nothing is
+# eligible. --top is rejected when combined with --qa / --health-only /
+# --main-broken-sha / --priority-only. The default --top 1 is byte-identical to
+# the no-flag behavior for every existing caller.
 #
 # Default-mode priority, top to bottom:
 #   1. JIT scan (jit-reminder)
@@ -132,6 +144,8 @@ QA_MODE=false
 HEALTH_ONLY=false
 MAIN_BROKEN_SHA_ONLY=false
 PRIORITY_ONLY=false
+TOP=1
+TOP_EXPLICIT=false
 declare -A EXCLUDED=()
 
 while [[ $# -gt 0 ]]; do
@@ -140,6 +154,16 @@ while [[ $# -gt 0 ]]; do
     --health-only) HEALTH_ONLY=true; shift ;;
     --main-broken-sha) MAIN_BROKEN_SHA_ONLY=true; shift ;;
     --priority-only) PRIORITY_ONLY=true; shift ;;
+    --top)
+      shift
+      if [[ $# -eq 0 || ! "$1" =~ ^[1-9][0-9]*$ ]]; then
+        echo "error: --top requires a positive integer argument" >&2
+        exit 1
+      fi
+      TOP="$1"
+      TOP_EXPLICIT=true
+      shift
+      ;;
     --exclude)
       shift
       while [[ $# -gt 0 && "$1" =~ ^[0-9]+$ ]]; do
@@ -163,6 +187,17 @@ fi
 if [[ "$PRIORITY_ONLY" == "true" \
       && ( "$QA_MODE" == "true" || "$HEALTH_ONLY" == "true" || "$MAIN_BROKEN_SHA_ONLY" == "true" ) ]]; then
   echo "error: --priority-only cannot combine with --qa, --health-only, or --main-broken-sha" >&2
+  exit 1
+fi
+
+# --top is meaningful only in default mode — the --qa / --health-only /
+# --main-broken-sha / --priority-only modes run their own single-line selection
+# or exit early. Reject an explicit --top alongside any of them rather than
+# silently ignoring it. The default TOP=1 (no --top passed) never trips this.
+if [[ "$TOP_EXPLICIT" == "true" \
+      && ( "$QA_MODE" == "true" || "$HEALTH_ONLY" == "true" \
+           || "$MAIN_BROKEN_SHA_ONLY" == "true" || "$PRIORITY_ONLY" == "true" ) ]]; then
+  echo "error: --top cannot combine with --qa, --health-only, --main-broken-sha, or --priority-only" >&2
   exit 1
 fi
 
@@ -597,18 +632,53 @@ has_priority_in_labels() {
   printf '%s' "$1" | jq -r '[.[].name] | if index("priority") then 1 else 0 end'
 }
 
-# First-seen PR per (category, priority-bit, phase): key =
-# "<category>|<priority-bit>|<phase>", value = "<num> <branch>". The "|"
-# separator is collision-free — priority bits are literal `0`/`1`, phase names
-# are fixed identifiers, and no TOPIC_CATEGORIES name contains "|". Both lists
-# are pre-sorted oldest-first, so the first PR captured for a key is the oldest
-# in that bucket.
+# Top-N ranked PRs per (category, priority-bit, phase): key =
+# "<category>|<priority-bit>|<phase>", value = a NEWLINE-DELIMITED list (no
+# leading/trailing newline) of up to TOP entries, each "<num> <branch>", oldest
+# first. The "|" separator is collision-free — priority bits are literal `0`/`1`,
+# phase names are fixed identifiers, and no TOPIC_CATEGORIES name contains "|".
+# PR_SORTED is pre-sorted oldest-first, so entries accumulate oldest-first. For
+# TOP=1 a bucket holds at most one entry — the oldest — and expands to the bare
+# entry with no trailing newline, byte-identical to the former single-entry map.
 declare -A FIRST_PR
-# First-seen help-wanted issue per (category, priority-bit, phase): key =
-# "<category>|<priority-bit>|<phase>" where phase ∈ {implement, plan},
-# value = "<num>". Splitting the bucket by phase lets a planned issue
+# Top-N ranked help-wanted issues per (category, priority-bit, phase): key =
+# "<category>|<priority-bit>|<phase>" where phase ∈ {implement, plan}, value = a
+# NEWLINE-DELIMITED list (no leading/trailing newline) of up to TOP "<num>"
+# entries, oldest first. Splitting the bucket by phase lets a planned issue
 # (implement) be selected ahead of an unplanned one (plan) in the same bucket.
 declare -A FIRST_ISSUE
+
+# Count the newline-delimited entries stored at <map-name>[<key>] (0 if unset or
+# empty). Entries are joined by single newlines with no trailing newline, so a
+# one-entry bucket has zero internal newlines. Counting via an array split on
+# newline yields the exact count for the 0/1/2... cases: an empty value splits to
+# a zero-element array, a single entry to one element, N entries to N elements.
+bucket_count() {
+  local -n _bc_ref="$1"
+  local _bc_key="$2"
+  local _bc_val="${_bc_ref[$_bc_key]:-}"
+  [[ -z "$_bc_val" ]] && { echo 0; return; }
+  local -a _bc_arr=()
+  IFS=$'\n' read -rd '' -a _bc_arr <<<"$_bc_val" || true
+  echo "${#_bc_arr[@]}"
+}
+
+# Append <entry> to <map-name>[<key>]'s newline list, but only while the bucket
+# holds fewer than TOP entries (the per-bucket cap). An empty bucket is set to
+# the bare entry (no leading newline), so a TOP=1 bucket expands to exactly the
+# entry — preserving the former single-entry map's byte layout for the emission
+# path.
+bucket_append() {
+  local -n _ba_ref="$1"
+  local _ba_key="$2" _ba_entry="$3"
+  (( $(bucket_count "$1" "$_ba_key") >= TOP )) && return 0
+  local _ba_cur="${_ba_ref[$_ba_key]:-}"
+  if [[ -z "$_ba_cur" ]]; then
+    _ba_ref[$_ba_key]="$_ba_entry"
+  else
+    _ba_ref[$_ba_key]="$_ba_cur"$'\n'"$_ba_entry"
+  fi
+}
 
 # Within-category phase ladder, highest priority first.
 PHASE_PRIORITY=(fix-conflicts review fix-checks)
@@ -686,13 +756,15 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
        then "true" else "false" end')
   [[ "$pr_blocked" == "true" ]] && continue
 
-  # Record the oldest PR seen in this category+priority+phase. The :- guard
-  # keeps the unset-key read from aborting under set -u.
+  # Record the oldest TOP PRs seen in this category+priority+phase. PR_SORTED is
+  # oldest-first, so the list accumulates oldest-first; bucket_append caps it at
+  # TOP. For TOP=1 this keeps only the oldest — identical to the former
+  # first-seen guard.
   pr_combined=$(pr_combined_labels "$pr_closing")
   pr_cat=$(category_of_labels "$pr_combined")
   pr_pri=$(has_priority_in_labels "$pr_combined")
   pr_key="$pr_cat|$pr_pri|$phase"
-  [[ -z "${FIRST_PR[$pr_key]:-}" ]] && FIRST_PR[$pr_key]="$pr_num $pr_branch"
+  bucket_append FIRST_PR "$pr_key" "$pr_num $pr_branch"
 done <<< "$PR_SORTED"
 
 if [[ "$QA_MODE" == "true" ]]; then
@@ -756,54 +828,78 @@ while IFS=$'\t' read -r issue_num issue_labels; do
   # --priority-only scans only the priority=1 tier — skip non-priority issues
   # before the expensive dispatch-trace-leaf descent.
   [[ "$PRIORITY_ONLY" == "true" && "$issue_pri" != "1" ]] && continue
-  # Coarse pre-trace skip: only when BOTH phase sub-buckets are already filled
-  # is the expensive leaf trace pointless. If either implement or plan slot is
-  # still open, descend — the leaf's phase isn't known until after the trace.
+  # Coarse pre-trace skip: only when BOTH phase sub-buckets already hold TOP
+  # entries is the expensive leaf trace pointless. If either implement or plan
+  # slot is still under TOP, descend — the leaf's phase isn't known until after
+  # the trace.
   impl_bucket="$issue_cat|$issue_pri|implement"
   plan_bucket="$issue_cat|$issue_pri|plan"
-  [[ -n "${FIRST_ISSUE[$impl_bucket]:-}" && -n "${FIRST_ISSUE[$plan_bucket]:-}" ]] && continue
-  # Resolve a startable open leaf within the issue's subtree. dispatch-trace-leaf
-  # in queue mode descends open blockers and sub-issues, skipping any child whose
-  # <N>-* worktree is owned by a live session (#914) — an orphan child worktree
-  # stays descendable. The --exclude set (#1062) is threaded in so a leaf the
-  # fan-out caller already processed — including this help-wanted issue itself as
-  # the trace root, and a multi-leaf subtree's first leaf that self-closed and
-  # left an orphan worktree (not live-skipped) — is descended past to the next
-  # startable leaf, rather than re-returned:
-  #   exit 0 — a startable open leaf was found; record it for this bucket.
-  #   exit 2 — every reachable open leaf is owned by a live session or excluded.
-  #            Skip this issue exactly as a direct live-owned worktree is skipped;
-  #            a later issue in the same bucket may still fill the slot.
-  #   exit 1 — usage error; propagate as a hard failure, never swallow as a skip.
-  if leaf=$("$SCRIPT_DIR/dispatch-trace-leaf" "$issue_num" queue "${EXCLUDE_ARGS[@]}"); then
-    # Readiness gate, symmetric with the PR-loop gate above (#1106). A
-    # help-wanted issue can already carry a draft PR whose CI is in progress —
-    # a draft closing PR does not evict its issue from this queue (#920), so a
-    # stalled/orphaned draft is recyclable. Skip such a leaf: spawning a worker
-    # now would only hit dispatch-route's STOP-waiting re-gate, wasting a tick.
-    # A leaf with no PR (normal implement) or a concluded-CI draft reports
-    # ready and proceeds; a concluded-CI draft is owned by the PR queue
-    # (fix-checks/qa), which precedes the issue within a bucket and recycles the
-    # orphan worktree via `enter` just as the issue path would. dispatch-ci-ready
-    # resolves the all-digit leaf to its PR by headRefName prefix. Reuses the
-    # PR list fetched above.
-    if ! DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-ci-ready" "$leaf" >/dev/null; then
-      continue
-    fi
-    # Phase-key the leaf (NOT the help-wanted root — the traced leaf may differ
-    # from issue_num). dispatch:planned → implement, else plan, mirroring
-    # dispatch-phase. Oldest-wins per phase-bucket: keep the first winner.
-    leaf_phase=plan
-    [[ -n "${ISSUE_PLANNED[$leaf]:-}" ]] && leaf_phase=implement
-    leaf_bucket="$issue_cat|$issue_pri|$leaf_phase"
-    [[ -n "${FIRST_ISSUE[$leaf_bucket]:-}" ]] && continue
-    FIRST_ISSUE[$leaf_bucket]="$leaf"
-  else
-    trace_status=$?
-    [[ "$trace_status" -eq 2 ]] && continue
-    echo "error: dispatch-trace-leaf $issue_num queue failed (exit $trace_status)" >&2
-    exit 1
+  if (( $(bucket_count FIRST_ISSUE "$impl_bucket") >= TOP )) \
+     && (( $(bucket_count FIRST_ISSUE "$plan_bucket") >= TOP )); then
+    continue
   fi
+  # Resolve up to TOP startable open leaves within the issue's subtree, in one
+  # descent. dispatch-trace-leaf in queue mode descends open blockers and
+  # sub-issues, skipping any child whose <N>-* worktree is owned by a live
+  # session (#914) — an orphan child worktree stays descendable. The --exclude
+  # set threaded in starts from the GLOBAL excluded numbers (#1062) and GROWS by
+  # every leaf recorded (or skipped not-ready) within THIS root, so each pass
+  # descends past the leaves already seen to the next startable one — enumerating
+  # the subtree's startable leaves one at a time, the same mechanism the per-slot
+  # --exclude loop relied on across calls (#1317), now within a single scan:
+  #   exit 0 — a startable open leaf was found; gate it and (if ready) record it.
+  #   exit 2 — every reachable open leaf is owned by a live session or excluded;
+  #            stop descending this root. A later issue in the same bucket may
+  #            still fill the slot.
+  #   exit 1 — usage error; propagate as a hard failure, never swallow as a skip.
+  declare -A root_excl=()
+  for _ge in "${!EXCLUDED[@]}"; do root_excl["$_ge"]=1; done
+  root_recorded=0
+  while :; do
+    # Stop once this root has supplied TOP leaves, or both phase buckets are at
+    # TOP globally — no further descent of this root can contribute.
+    (( root_recorded >= TOP )) && break
+    if (( $(bucket_count FIRST_ISSUE "$impl_bucket") >= TOP )) \
+       && (( $(bucket_count FIRST_ISSUE "$plan_bucket") >= TOP )); then
+      break
+    fi
+    root_excl_args=()
+    (( ${#root_excl[@]} > 0 )) && root_excl_args=(--exclude "${!root_excl[@]}")
+    if leaf=$("$SCRIPT_DIR/dispatch-trace-leaf" "$issue_num" queue "${root_excl_args[@]}"); then
+      # Readiness gate, symmetric with the PR-loop gate above (#1106). A
+      # help-wanted issue can already carry a draft PR whose CI is in progress —
+      # a draft closing PR does not evict its issue from this queue (#920), so a
+      # stalled/orphaned draft is recyclable. A not-ready leaf is excluded and the
+      # descent continues to the next startable leaf of the SAME root (rather than
+      # abandoning the whole root), so a sibling can still be picked up. A leaf
+      # with no PR (normal implement) or a concluded-CI draft reports ready and
+      # proceeds; a concluded-CI draft is owned by the PR queue (fix-checks/qa),
+      # which precedes the issue within a bucket and recycles the orphan worktree
+      # via `enter` just as the issue path would. dispatch-ci-ready resolves the
+      # all-digit leaf to its PR by headRefName prefix. Reuses the PR list above.
+      if ! DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-ci-ready" "$leaf" >/dev/null; then
+        root_excl["$leaf"]=1
+        continue
+      fi
+      # Phase-key the leaf (NOT the help-wanted root — the traced leaf may differ
+      # from issue_num). dispatch:planned → implement, else plan, mirroring
+      # dispatch-phase. bucket_append caps each phase bucket at TOP and keeps the
+      # oldest entries; a leaf traced into an already-full bucket is silently
+      # dropped (the cap subsumes the former first-seen guard).
+      leaf_phase=plan
+      [[ -n "${ISSUE_PLANNED[$leaf]:-}" ]] && leaf_phase=implement
+      leaf_bucket="$issue_cat|$issue_pri|$leaf_phase"
+      bucket_append FIRST_ISSUE "$leaf_bucket" "$leaf"
+      root_excl["$leaf"]=1
+      root_recorded=$(( root_recorded + 1 ))
+    else
+      trace_status=$?
+      [[ "$trace_status" -eq 2 ]] && break
+      echo "error: dispatch-trace-leaf $issue_num queue failed (exit $trace_status)" >&2
+      exit 1
+    fi
+  done
+  unset root_excl
 done <<< "$ISSUE_SORTED"
 
 # Default mode: priority is the outermost axis (1 then 0), topic category nests
@@ -818,30 +914,85 @@ done <<< "$ISSUE_SORTED"
 # pass below is then a guaranteed no-op (every lookup misses). It is left in the
 # shared loop rather than special-cased — the empty-map iteration is harmless
 # and keeps the default and --priority-only output paths identical.
-for pri in 1 0; do
-  for category in "${CATEGORIES[@]}"; do
-    for phase in "${PHASE_PRIORITY[@]}"; do
-      pr_key="$category|$pri|$phase"
-      if [[ -n "${FIRST_PR[$pr_key]:-}" ]]; then
-        echo "pr ${FIRST_PR[$pr_key]} $phase"
+if (( TOP == 1 )); then
+  # TOP=1: emit the single highest-priority decision line and exit. Each bucket
+  # holds at most one entry (no trailing newline), so the direct expansion below
+  # is byte-identical to the former single-entry map's output.
+  for pri in 1 0; do
+    for category in "${CATEGORIES[@]}"; do
+      for phase in "${PHASE_PRIORITY[@]}"; do
+        pr_key="$category|$pri|$phase"
+        if [[ -n "${FIRST_PR[$pr_key]:-}" ]]; then
+          echo "pr ${FIRST_PR[$pr_key]} $phase"
+          exit 0
+        fi
+      done
+
+      qa_key="$category|$pri|qa"
+      if [[ -n "${FIRST_PR[$qa_key]:-}" ]]; then
+        echo "pr ${FIRST_PR[$qa_key]} qa"
         exit 0
       fi
-    done
 
-    qa_key="$category|$pri|qa"
-    if [[ -n "${FIRST_PR[$qa_key]:-}" ]]; then
-      echo "pr ${FIRST_PR[$qa_key]} qa"
-      exit 0
-    fi
-
-    for iphase in "${ISSUE_PHASE_PRIORITY[@]}"; do
-      issue_key="$category|$pri|$iphase"
-      if [[ -n "${FIRST_ISSUE[$issue_key]:-}" ]]; then
-        echo "issue ${FIRST_ISSUE[$issue_key]}"
-        exit 0
-      fi
+      for iphase in "${ISSUE_PHASE_PRIORITY[@]}"; do
+        issue_key="$category|$pri|$iphase"
+        if [[ -n "${FIRST_ISSUE[$issue_key]:-}" ]]; then
+          echo "issue ${FIRST_ISSUE[$issue_key]}"
+          exit 0
+        fi
+      done
     done
   done
-done
 
-echo "empty"
+  echo "empty"
+else
+  # TOP>1: a parallel walk over the SAME nesting, draining each bucket's
+  # newline list oldest-first into a results array until it holds TOP entries.
+  # Reads a possibly-empty/unset bucket into an array that yields zero elements
+  # for an empty value (the [[ -z ]] guard skips read entirely), so set -u never
+  # sees a spurious empty element.
+  results=()
+  drain_bucket() {
+    # $1 = map name, $2 = key, $3 = line prefix template ("pr"/"issue"),
+    # $4 = optional phase suffix appended after each entry ("" for none).
+    local -n _db_ref="$1"
+    local _db_key="$2" _db_prefix="$3" _db_suffix="${4:-}"
+    local _db_val="${_db_ref[$_db_key]:-}"
+    [[ -z "$_db_val" ]] && return 0
+    local -a _db_entries=()
+    IFS=$'\n' read -rd '' -a _db_entries <<<"$_db_val" || true
+    local _db_e
+    for _db_e in "${_db_entries[@]}"; do
+      if [[ -n "$_db_suffix" ]]; then
+        results+=("$_db_prefix $_db_e $_db_suffix")
+      else
+        results+=("$_db_prefix $_db_e")
+      fi
+      (( ${#results[@]} >= TOP )) && return 0
+    done
+  }
+
+  for pri in 1 0; do
+    for category in "${CATEGORIES[@]}"; do
+      for phase in "${PHASE_PRIORITY[@]}"; do
+        drain_bucket FIRST_PR "$category|$pri|$phase" pr "$phase"
+        (( ${#results[@]} >= TOP )) && { printf '%s\n' "${results[@]}"; exit 0; }
+      done
+
+      drain_bucket FIRST_PR "$category|$pri|qa" pr qa
+      (( ${#results[@]} >= TOP )) && { printf '%s\n' "${results[@]}"; exit 0; }
+
+      for iphase in "${ISSUE_PHASE_PRIORITY[@]}"; do
+        drain_bucket FIRST_ISSUE "$category|$pri|$iphase" issue ""
+        (( ${#results[@]} >= TOP )) && { printf '%s\n' "${results[@]}"; exit 0; }
+      done
+    done
+  done
+
+  if (( ${#results[@]} > 0 )); then
+    printf '%s\n' "${results[@]}"
+  else
+    echo "empty"
+  fi
+  exit 0
+fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -201,13 +201,6 @@ if [[ "$TOP_EXPLICIT" == "true" \
   exit 1
 fi
 
-# Build the leaf-trace passthrough once: the excluded numbers thread into
-# dispatch-trace-leaf (#1062) so a multi-leaf subtree descends past an excluded
-# leaf. Only constructed when non-empty so the call site passes no --exclude
-# flag at all when no exclusion was requested.
-EXCLUDE_ARGS=()
-(( ${#EXCLUDED[@]} > 0 )) && EXCLUDE_ARGS=(--exclude "${!EXCLUDED[@]}")
-
 # Print origin/main's HEAD SHA if its CI has a failing check; print nothing if
 # main is healthy or only has in-progress checks. main's CI state spans two
 # sources that must both be aggregated:

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -970,6 +970,12 @@ else
       fi
       (( ${#results[@]} >= TOP )) && return 0
     done
+    # The for-loop's last evaluated command is the `(( ... ))` test above; when it
+    # is false (results still under TOP) it returns 1, which — as drain_bucket's
+    # final command — would make the function return 1 and, under `set -e`, abort
+    # the whole scan at the bare `drain_bucket` call site. Return success
+    # explicitly so a not-yet-full results array keeps the scan going (#1317).
+    return 0
   }
 
   for pri in 1 0; do

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3083,6 +3083,178 @@ result=$("$TMPDIR_TEST/dispatch-select-target" --exclude 20)
 assert_eq "excluded PR 20 filtered → empty" "empty" "$result"
 teardown
 
+# --- --top N: single-pass multi-target selection (#1317) ---------------------
+# `--top N` emits up to N DISTINCT ranked decision lines in ONE queue scan,
+# preserving the existing priority order (priority axis 1→0, then topic category,
+# then the phase ladder), oldest-first within a bucket — replacing the old
+# once-per-slot serialized selector calls. `--top 1` is byte-identical to the
+# no-flag call. These run end-to-end through the real trace/ci-ready/phase copies.
+
+# T1. --top N returns N distinct ranked lines across buckets, in the priority-
+#     axis → topic-category → phase order. Three help-wanted issues, all
+#     priority 0, no PRs (so all in `plan` phase) but in DIFFERENT topic
+#     categories: 30 (security) → 20 (bug) → 10 (no topic = other). The category
+#     order is the only discriminator, so the output is deterministically
+#     security, bug, other regardless of issue-number or createdAt order.
+echo "Test: --top 3 returns 3 distinct ranked lines in topic-category order"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":10,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":20,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"bug"}]},{"number":30,"createdAt":"2024-01-03T00:00:00Z","labels":[{"name":"help wanted"},{"name":"security"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --top 3)
+assert_eq "--top 3 ranked across topic categories" "$(printf 'issue 30\nissue 20\nissue 10')" "$result"
+teardown
+
+# T2. --top N honors --exclude: the excluded number never appears. Excluding the
+#     top-ranked security issue 30 leaves bug 20 then other 10.
+echo "Test: --top 3 honors --exclude (excluded number absent)"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":10,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":20,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"bug"}]},{"number":30,"createdAt":"2024-01-03T00:00:00Z","labels":[{"name":"help wanted"},{"name":"security"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --top 3 --exclude 30)
+assert_eq "--top 3 --exclude 30 omits 30" "$(printf 'issue 20\nissue 10')" "$result"
+assert_eq "--top 3 --exclude 30: 30 absent" "0" "$(printf '%s\n' "$result" | grep -c '^issue 30$')"
+teardown
+
+# T3a. --top N with FEWER than N eligible returns all available, no padding.
+#      Only two issues exist; --top 5 returns exactly those two lines.
+echo "Test: --top 5 with 2 eligible returns 2 lines, no padding"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":20,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"bug"}]},{"number":30,"createdAt":"2024-01-03T00:00:00Z","labels":[{"name":"help wanted"},{"name":"security"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --top 5)
+assert_eq "--top 5 with 2 eligible → 2 lines" "$(printf 'issue 30\nissue 20')" "$result"
+assert_eq "--top 5 with 2 eligible → no empty padding" "0" "$(printf '%s\n' "$result" | grep -c '^empty$')"
+teardown
+
+# T3b. --top N with NOTHING eligible prints exactly `empty` (one line).
+echo "Test: --top 5 with nothing eligible → empty"
+setup
+echo '[]' > "$STUB_DIR/pr-list-union.json"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --top 5)
+assert_eq "--top 5 nothing eligible → empty" "empty" "$result"
+teardown
+
+# T4. Multi-leaf descent in ONE scan: a single help-wanted root with several
+#     startable leaves yields MULTIPLE `issue <leaf>` lines from one invocation
+#     (the in-scan growing-local-exclude enumeration, #1317). Root 55 has three
+#     sub-issues 5500/5501/5502, none worktree'd or parked. --top 3 enumerates
+#     all three leaves oldest(lowest-leaf)-first in a single scan.
+echo "Test: --top 3 enumerates multiple startable leaves of one root in one scan"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":5500},{"number":5501},{"number":5502}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' > "$STUB_DIR/issue-5500.json"
+printf '{"title":"Issue 5501","body":"","comments":[],"number":5501,"state":"OPEN"}\n' > "$STUB_DIR/issue-5501.json"
+printf '{"title":"Issue 5502","body":"","comments":[],"number":5502,"state":"OPEN"}\n' > "$STUB_DIR/issue-5502.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --top 3)
+assert_eq "--top 3 multi-leaf descent in one scan" "$(printf 'issue 5500\nissue 5501\nissue 5502')" "$result"
+teardown
+
+# T4b. A leaf whose worktree is LIVE (a live session owns <leaf>-*) is NOT
+#      returned: the descent skips it (#914) and surfaces the next startable
+#      leaf. Leaf 5500's worktree is live, so --top 3 returns 5501, 5502.
+echo "Test: --top 3 multi-leaf descent skips a live-session-owned leaf"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":5500},{"number":5501},{"number":5502}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' > "$STUB_DIR/issue-5500.json"
+printf '{"title":"Issue 5501","body":"","comments":[],"number":5501,"state":"OPEN"}\n' > "$STUB_DIR/issue-5501.json"
+printf '{"title":"Issue 5502","body":"","comments":[],"number":5502,"state":"OPEN"}\n' > "$STUB_DIR/issue-5502.json"
+# Leaf 5500 has an on-disk worktree owned by a live session.
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/5500-leaf\nHEAD def456\nbranch refs/heads/5500-leaf\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+select_target_fake_claude "5500-leaf"
+result=$("$TMPDIR_TEST/dispatch-select-target" --top 3)
+assert_eq "--top 3 descent skips live leaf 5500 → 5501,5502" "$(printf 'issue 5501\nissue 5502')" "$result"
+assert_eq "--top 3 descent: live leaf 5500 absent" "0" "$(printf '%s\n' "$result" | grep -c '^issue 5500$')"
+teardown
+
+# T4c. A leaf whose worktree is RESERVED (reservation marker present, no live
+#      session) is NOT returned either (#1046): the reserved-skip closes the
+#      spawn-gap race. Leaf 5500 is reserved → --top 3 returns 5501, 5502.
+echo "Test: --top 3 multi-leaf descent skips a reserved leaf"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":5500},{"number":5501},{"number":5502}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' > "$STUB_DIR/issue-5500.json"
+printf '{"title":"Issue 5501","body":"","comments":[],"number":5501,"state":"OPEN"}\n' > "$STUB_DIR/issue-5501.json"
+printf '{"title":"Issue 5502","body":"","comments":[],"number":5502,"state":"OPEN"}\n' > "$STUB_DIR/issue-5502.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/5500-leaf\nHEAD def456\nbranch refs/heads/5500-leaf\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+# No live session, but 5500-leaf carries a reservation marker.
+select_target_fake_claude
+mkdir -p "$DISPATCH_RESERVATION_DIR"
+printf 'session=resv-sess\nissue=5500\ntimestamp=2026-01-01T00:00:00Z\n' > "$DISPATCH_RESERVATION_DIR/5500-leaf"
+result=$("$TMPDIR_TEST/dispatch-select-target" --top 3)
+assert_eq "--top 3 descent skips reserved leaf 5500 → 5501,5502" "$(printf 'issue 5501\nissue 5502')" "$result"
+teardown
+
+# T4d. A leaf whose ISSUE carries dispatch:office-hours is NOT returned: the
+#      office-hours-parked leaf is filtered from the descent. Root 55's leaf 5501
+#      is parked, so --top 3 returns 5500, 5502.
+echo "Test: --top 3 multi-leaf descent skips an office-hours-parked leaf"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":5500},{"number":5501},{"number":5502}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' > "$STUB_DIR/issue-5500.json"
+printf '{"title":"Issue 5501","body":"","comments":[],"number":5501,"state":"OPEN"}\n' > "$STUB_DIR/issue-5501.json"
+printf '{"title":"Issue 5502","body":"","comments":[],"number":5502,"state":"OPEN"}\n' > "$STUB_DIR/issue-5502.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+# Leaf 5501 is parked: it appears in the dispatch:office-hours parked set the
+# queue-mode trace reads (#1011). The descent must skip it and surface 5502.
+printf '[{"number":5501}]\n' > "$STUB_DIR/trace-parked.json"
+result=$("$TMPDIR_TEST/dispatch-select-target" --top 3)
+assert_eq "--top 3 descent skips parked leaf 5501 → 5500,5502" "$(printf 'issue 5500\nissue 5502')" "$result"
+assert_eq "--top 3 descent: parked leaf 5501 absent" "0" "$(printf '%s\n' "$result" | grep -c '^issue 5501$')"
+teardown
+
+# T5. --top 1 byte-parity: on a representative fixture, `--top 1` output is
+#     byte-identical to the plain (no-flag) call. Guards that the default path is
+#     unchanged for every existing caller.
+echo "Test: --top 1 is byte-identical to the no-flag call"
+setup
+UNION='['"$(make_pr_union 10 "10-verify-me" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr_union 20 "20-qa-me" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":99,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+plain=$("$TMPDIR_TEST/dispatch-select-target")
+top1=$("$TMPDIR_TEST/dispatch-select-target" --top 1)
+assert_eq "--top 1 byte-parity (same fixture)" "$plain" "$top1"
+assert_eq "--top 1 parity: expected single decision line" "pr 10 10-verify-me fix-checks" "$top1"
+teardown
+
+# T6. --top is rejected when combined with --qa / --priority-only /
+#     --health-only / --main-broken-sha (default-mode-only flag). Each exits
+#     non-zero with a clear stderr error, mirroring the existing mutual-exclusion
+#     checks.
+for other_flag in --qa --priority-only --health-only --main-broken-sha; do
+  echo "Test: --top 3 $other_flag → usage error (exit 1)"
+  setup
+  echo '[]' > "$STUB_DIR/pr-list-union.json"
+  echo '[]' > "$STUB_DIR/issue-list.json"
+  printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+  err_file="$TMPDIR_TEST/err.txt"
+  if "$TMPDIR_TEST/dispatch-select-target" --top 3 "$other_flag" >/dev/null 2>"$err_file"; then rc=0; else rc=$?; fi
+  assert_eq "--top 3 $other_flag → exit 1" "1" "$rc"
+  err_contents=$(cat "$err_file")
+  [[ "$err_contents" == *"--top cannot combine"* ]] && err_msg=ok || err_msg="missing: $err_contents"
+  assert_eq "--top 3 $other_flag → error mentions --top cannot combine" "ok" "$err_msg"
+  teardown
+done
+
 # --- ready-PR gate (#920) ---
 # An open help-wanted issue whose closing PR is non-draft (ready) is excluded
 # from the issue queue. The gate uses closingIssuesReferences from PR_LIST —
@@ -18351,18 +18523,47 @@ FAKE
 #!/usr/bin/env bash
 echo "\${MAT_WT_DECISION:-create \$1-test}"
 FAKE
+  # Single-scan --top selector fake (#1317): the real dispatch-materialize-spawn
+  # now issues ONE `dispatch-select-target --top <k> --exclude <seed>` scan per
+  # fan-out run instead of one call per slot. This fake honors --top <k> (emits up
+  # to k DISTINCT lines in one call) and --exclude <seed>... (never emits an
+  # excluded number, modelling the selector's internal de-dup against the seed it
+  # is told to skip), drawing targets from MAT_QUEUE in order. It logs EXACTLY ONE
+  # line per invocation, so `wc -l logs/select-target.log` is the scan count — the
+  # #1317 single-scan acceptance assertion reads exactly 1. When fewer than k
+  # eligible targets remain it emits all available then a trailing `empty` (the
+  # selector's genuine-exhaustion contract); when none remain it emits just
+  # `empty`.
   cat > "$TMPDIR_TEST/dispatch-select-target" <<FAKE
 #!/usr/bin/env bash
+top=1
+declare -A EX=()
+while [[ \$# -gt 0 ]]; do
+  case "\$1" in
+    --top) shift; top="\$1"; shift ;;
+    --exclude) shift; while [[ \$# -gt 0 && "\$1" =~ ^[0-9]+\$ ]]; do EX["\$1"]=1; shift; done ;;
+    *) shift ;;
+  esac
+done
 read -r -a Q <<< "\${MAT_QUEUE:-}"
-idx_file="$TMPDIR_TEST/logs/select-target.idx"
-i=\$(cat "\$idx_file" 2>/dev/null || echo 0)
-echo "called \$i \${Q[\$i]:-empty}" >> "$TMPDIR_TEST/logs/select-target.log"
-if (( i < \${#Q[@]} )); then
-  echo "issue \${Q[\$i]}"
-  echo \$(( i + 1 )) > "\$idx_file"
-else
-  echo empty
-fi
+# Build the exclude key list explicitly: \${!EX[*]:-} (key-listing + default) yields
+# empty under bash even when keys exist, so iterate instead.
+ex_keys=""
+if (( \${#EX[@]} > 0 )); then ex_keys="\${!EX[*]}"; fi
+echo "called top=\$top exclude=\$ex_keys" >> "$TMPDIR_TEST/logs/select-target.log"
+emitted=0
+declare -A SEEN_OUT=()
+for n in "\${Q[@]}"; do
+  (( emitted >= top )) && break
+  [[ -n "\${EX[\$n]:-}" ]] && continue
+  [[ -n "\${SEEN_OUT[\$n]:-}" ]] && continue
+  SEEN_OUT["\$n"]=1
+  echo "issue \$n"
+  emitted=\$(( emitted + 1 ))
+done
+# Fewer than k eligible → the selector's genuine-exhaustion line so the consumer
+# stops cleanly with "queue exhausted" rather than spinning.
+if (( emitted < top )); then echo empty; fi
 FAKE
   cat > "$TMPDIR_TEST/dispatch-phase" <<'FAKE'
 #!/usr/bin/env bash
@@ -18997,137 +19198,176 @@ assert_eq "spawnfail-fanout: stderr warns on each spawn-failed" "3" \
 assert_eq "spawnfail-fanout: lock released at end" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
-# --- fan-out: dispatch-select-target invoked between spawns ------------------
-echo "Test: materialize-spawn fan-out invokes dispatch-select-target between spawns"
+# --- fan-out: ONE dispatch-select-target scan fills slots 2..GAP (#1317) -----
+# #1317 acceptance: a --gap N fan-out performs O(1) selector scans, not O(N). The
+# seed (839) is processed first, then a SINGLE `--top` scan supplies the rest of
+# the gap (720, 508). The fake selector logs one line per invocation, so the
+# scan count is `wc -l logs/select-target.log` — it MUST be exactly 1.
+echo "Test: materialize-spawn fan-out issues exactly ONE selector scan (#1317)"
 mat_setup
 export MAT_QUEUE="720 508"
 out=$(run_mat 839 queue --gap 3)
-# 3 spawns (839 + 720 + 508); select-target invoked at least twice (for targets 2 and 3).
-assert_eq "distinct: spawn count" "3" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
-assert_eq "distinct: select-target invoked >=2" "1" \
-  "$([ "$(wc -l < "$TMPDIR_TEST/logs/select-target.log")" -ge 2 ] && echo 1 || echo 0)"
-assert_eq "distinct: worktrees all unique" "3" \
+# 3 spawns (839 + 720 + 508), all from the seed + ONE single-pass selector scan.
+assert_eq "single-scan: spawn count" "3" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+# #1317 single-scan acceptance assertion: exactly ONE selector invocation.
+assert_eq "single-scan: select-target invoked exactly once (#1317)" "1" \
+  "$(wc -l < "$TMPDIR_TEST/logs/select-target.log" | tr -d ' ')"
+assert_eq "single-scan: worktrees all unique" "3" \
   "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
+# The single scan was asked for the gap-after-seed slot count and told to exclude
+# the seed (belt-and-suspenders atop the seed's reservation marker).
+assert_eq "single-scan: scan asked for --top 2, --exclude 839" "called top=2 exclude=839" \
+  "$(cat "$TMPDIR_TEST/logs/select-target.log")"
 mat_teardown
 
-# --- fan-out exclusion (#1062): the loop passes its SEEN set as --exclude so ---
-# dispatch-select-target yields the NEXT distinct target instead of re-returning
-# an already-processed one. Each of the following tests overrides the default
-# (arg-ignoring) select-target fake with an EXCLUDE-HONORING fake that returns
-# the first MAT_QUEUE entry NOT in the passed --exclude set. WITHOUT --exclude
-# this fake returns the queue HEAD on every call — re-surfacing an already-
-# spawned target — the exact scenario the loop's exclusion must defeat. The
-# helper below writes that fake into the live TMPDIR_TEST.
-write_exclude_honoring_select_target() {
-  cat > "$TMPDIR_TEST/dispatch-select-target" <<FAKE
+# --- fan-out single-scan consumption (#1317, replacing the #1062 loop tests) --
+# Pre-#1317 the loop re-invoked dispatch-select-target once per slot, threading a
+# growing --exclude SEEN set to defeat a re-surfaced (lagged-live / orphan
+# self-close) target and to drain a multi-leaf subtree past an already-processed
+# leaf. Single-pass selection (#1317) moves ALL of that de-dup INTO the selector:
+# one `--top` scan returns distinct ranked targets, so the loop's job is now just
+# to CONSUME that one multi-line list. The de-dup-mechanism coverage (re-surface
+# exclusion, multi-leaf-subtree descent) moved to the dispatch-select-target
+# `--top` section above; the cases that remain here are what the loop still owns:
+# consuming a multi-line list across distinct worktrees, the defensive SEEN
+# backstop, and stopping cleanly on `empty` / a deferred selection line.
+
+# (consume) multi-line list: the seed (839) plus a single `--top` scan returning
+# 720 and 508 in one call → 3 distinct-worktree spawns from ONE selector scan.
+echo "Test: materialize-spawn fan-out consumes a multi-line --top list across distinct worktrees (#1317)"
+mat_setup
+export MAT_QUEUE="720 508"
+out=$(run_mat 839 queue --gap 3)
+assert_eq "consume-list: spawn count" "3" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+assert_eq "consume-list: distinct worktrees" "3" \
+  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
+assert_eq "consume-list: ONE selector scan (#1317)" "1" \
+  "$(wc -l < "$TMPDIR_TEST/logs/select-target.log" | tr -d ' ')"
+assert_eq "consume-list: summary 3 of gap 3" "1" "$(printf '%s\n' "$out" | grep -c 'spawned 3 of gap 3')"
+assert_eq "consume-list: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+mat_teardown
+
+# (consume PR lines) the single scan can return `pr <num> <branch> <phase>` lines
+# too; the loop keys the spawn on the branch prefix (<N>-), exactly as the
+# single-target path does. Here the scan yields a PR on branch 720-feature plus an
+# issue 508; the seed 839 + both → 3 distinct-worktree spawns from one scan.
+echo "Test: materialize-spawn fan-out consumes pr <branch> lines, keys spawn on branch prefix (#1317)"
+mat_setup
+cat > "$TMPDIR_TEST/dispatch-select-target" <<FAKE
 #!/usr/bin/env bash
-# Exclude-honoring fake (#1062): returns the first MAT_QUEUE entry NOT in the
-# passed --exclude set, modelling a real selector yielding the next distinct
-# target. WITHOUT --exclude it returns the first entry every call — re-surfacing
-# an already-spawned target (registration lag / orphan self-close), the exact
-# scenario the loop's exclusion must defeat.
-declare -A EX=()
-while [[ \$# -gt 0 ]]; do
-  case "\$1" in
-    --exclude) shift; while [[ \$# -gt 0 && "\$1" =~ ^[0-9]+\$ ]]; do EX["\$1"]=1; shift; done ;;
-    *) shift ;;
-  esac
-done
-read -r -a Q <<< "\${MAT_QUEUE:-}"
-echo "called exclude=\${!EX[*]:-}" >> "$TMPDIR_TEST/logs/select-target.log"
-for n in "\${Q[@]}"; do
-  if [[ -z "\${EX[\$n]:-}" ]]; then echo "issue \$n"; exit 0; fi
-done
-echo empty
+echo "scan \$*" >> "$TMPDIR_TEST/logs/select-target.log"
+echo "pr 9001 720-feature fix-checks"
+echo "issue 508"
 FAKE
-  chmod +x "$TMPDIR_TEST/dispatch-select-target"
-}
-
-# (a) lagged-live re-surface: queue HEAD 839 is the already-spawned arg, re-
-# surfacing because its live ownership is not yet visible to the next selection
-# (mechanism 1). Without the loop's --exclude the fake would re-return 839 every
-# call and the run would stall at 1 spawn. With it, selection advances 720, 508.
-echo "Test: materialize-spawn fan-out excludes lagged-live re-surfaced target (#1062)"
-mat_setup
-write_exclude_honoring_select_target
-export MAT_QUEUE="839 720 508"
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
 out=$(run_mat 839 queue --gap 3)
-assert_eq "fanout-lag: spawn count" "3" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
-assert_eq "fanout-lag: distinct worktrees" "3" \
+assert_eq "consume-pr: spawn count" "3" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+assert_eq "consume-pr: ONE selector scan (#1317)" "1" \
+  "$(wc -l < "$TMPDIR_TEST/logs/select-target.log" | tr -d ' ')"
+# The pr line's worktree is keyed on the branch prefix 720, not the PR number 9001.
+assert_eq "consume-pr: pr line keyed on branch prefix 720" "1" \
+  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | grep -cx '720')"
+assert_eq "consume-pr: distinct worktrees (839,720,508)" "3" \
   "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
-assert_eq "fanout-lag: summary 3 of gap 3" "1" "$(printf '%s\n' "$out" | grep -c 'spawned 3 of gap 3')"
-assert_eq "fanout-lag: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "fanout-lag: no 'no further distinct targets' stop" "0" \
-  "$(printf '%s\n' "$out" | grep -c 'no further distinct targets')"
+assert_eq "consume-pr: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
 mat_teardown
 
-# (a') orphan (self-closed) re-surface: 720 re-surfaces because it self-closed
-# fast, leaving an orphan worktree selection does not skip (mechanism 2). The
-# duplicate 720 in the queue is spawned once; the exclusion carries it past.
-echo "Test: materialize-spawn fan-out excludes orphan self-closed re-surfaced target (#1062)"
+# (backstop) defensive SEEN de-dup: the selector should never re-return the seed
+# (the loop passes --exclude <seed>, and single-pass selection de-dups
+# internally), but if a stray duplicate ever appears the loop must SKIP it
+# silently rather than re-dispatch it. Here the scan returns the seed 839 again
+# plus a genuine 720: 839 is skipped (already SEEN), 720 spawns → 2 spawns, NOT 3.
+echo "Test: materialize-spawn fan-out defensive SEEN de-dup skips a re-returned target (#1317)"
 mat_setup
-write_exclude_honoring_select_target
-export MAT_QUEUE="720 720 508"
+cat > "$TMPDIR_TEST/dispatch-select-target" <<FAKE
+#!/usr/bin/env bash
+echo "scan \$*" >> "$TMPDIR_TEST/logs/select-target.log"
+echo "issue 839"
+echo "issue 720"
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
 out=$(run_mat 839 queue --gap 3)
-assert_eq "fanout-orphan: spawn count" "3" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
-assert_eq "fanout-orphan: distinct worktrees (839,720,508)" "3" \
+assert_eq "seen-dedup: spawn count (seed + 720, not the re-returned 839)" "2" \
+  "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+assert_eq "seen-dedup: 839 spawned exactly once" "1" \
+  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | grep -cx '839')"
+assert_eq "seen-dedup: distinct worktrees (839,720)" "2" \
   "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
-assert_eq "fanout-orphan: summary 3 of gap 3" "1" "$(printf '%s\n' "$out" | grep -c 'spawned 3 of gap 3')"
-assert_eq "fanout-orphan: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "fanout-orphan: no 'no further distinct targets' stop" "0" \
-  "$(printf '%s\n' "$out" | grep -c 'no further distinct targets')"
+assert_eq "seen-dedup: ONE selector scan (#1317)" "1" \
+  "$(wc -l < "$TMPDIR_TEST/logs/select-target.log" | tr -d ' ')"
+assert_eq "seen-dedup: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
 mat_teardown
 
-# (b) multi-leaf subtree, first leaf excluded drains to the next: the exclusion
-# threads into the leaf trace, so a subtree whose first startable leaf (5500) was
-# already processed advances to its sibling (5501) rather than abandoning the
-# parent's remaining leaves.
-echo "Test: materialize-spawn fan-out drains multi-leaf subtree past excluded first leaf (#1062)"
+# (stop on empty) genuinely empty frontier: the seed spawns, then the single scan
+# returns `empty` (nothing else eligible) → the loop stops cleanly with the
+# "queue exhausted" stop reason, NOT a re-selection spin.
+echo "Test: materialize-spawn fan-out stops cleanly on an empty selector result (#1317)"
 mat_setup
-write_exclude_honoring_select_target
-export MAT_QUEUE="5500 5501"
-out=$(run_mat 5500 queue --gap 2)
-assert_eq "fanout-subtree: spawn count" "2" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
-assert_eq "fanout-subtree: distinct worktrees (5500,5501)" "2" \
-  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
-assert_eq "fanout-subtree: summary 2 of gap 2" "1" "$(printf '%s\n' "$out" | grep -c 'spawned 2 of gap 2')"
-assert_eq "fanout-subtree: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
-mat_teardown
-
-# (c) genuinely empty frontier: once 839 is excluded the queue has nothing left,
-# so selection returns `empty` and the loop stops cleanly on a real empty — not
-# on a re-selection.
-echo "Test: materialize-spawn fan-out stops cleanly on a genuinely empty frontier (#1062)"
-mat_setup
-write_exclude_honoring_select_target
 export MAT_QUEUE=""
 out=$(run_mat 839 queue --gap 5)
 assert_eq "fanout-empty: spawn count" "1" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+assert_eq "fanout-empty: ONE selector scan (#1317)" "1" \
+  "$(wc -l < "$TMPDIR_TEST/logs/select-target.log" | tr -d ' ')"
 assert_eq "fanout-empty: summary 1 of gap 5 (queue exhausted)" "1" \
   "$(printf '%s\n' "$out" | grep -c 'spawned 1 of gap 5 (queue exhausted)')"
 assert_eq "fanout-empty: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "fanout-empty: no 'no further distinct targets' stop" "0" \
-  "$(printf '%s\n' "$out" | grep -c 'no further distinct targets')"
 mat_teardown
 
-# (backstop) contract violation: dispatch-select-target ALWAYS returns 839 (the
-# already-processed arg) regardless of --exclude. The loop's defensive backstop
-# (#1062) must break rather than spin forever: it records SEEN[839] for target 1,
-# the fake re-returns 839, SEEN[839] is set → backstop fires.
-echo "Test: materialize-spawn fan-out backstop breaks on selector contract violation (#1062)"
+# (stop on deferred) a deferred selection line (main-broken / jit-reminder) breaks
+# the consumption loop: the seed spawns, the scan returns a `main-broken <sha>`
+# line, the loop stops with the "selection deferred (main-broken)" stop reason and
+# spawns nothing further. The next tick re-evaluates once the deferral clears.
+echo "Test: materialize-spawn fan-out stops on a deferred (main-broken) selection line (#1317)"
 mat_setup
-cat > "$TMPDIR_TEST/dispatch-select-target" <<'FAKE'
+cat > "$TMPDIR_TEST/dispatch-select-target" <<FAKE
 #!/usr/bin/env bash
-echo "issue 839"
+echo "scan \$*" >> "$TMPDIR_TEST/logs/select-target.log"
+echo "main-broken deadbeef"
 FAKE
 chmod +x "$TMPDIR_TEST/dispatch-select-target"
-out=$("$TMPDIR_TEST/dispatch-materialize-spawn" 839 queue --gap 5 2>"$TMPDIR_TEST/logs/mat-stderr.log")
-assert_eq "backstop: spawn count (only the arg)" "1" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
-assert_eq "backstop: summary 1 of gap 5 (unexpected re-selection)" "1" \
-  "$(printf '%s\n' "$out" | grep -c 'spawned 1 of gap 5 (selection re-returned an excluded target (unexpected))')"
-assert_eq "backstop: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "backstop: stderr names the contract violation" "1" \
-  "$(grep -c 'contract violation' "$TMPDIR_TEST/logs/mat-stderr.log")"
+out=$(run_mat 839 queue --gap 5)
+assert_eq "deferred: spawn count (seed only)" "1" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+assert_eq "deferred: summary names the deferred stop reason" "1" \
+  "$(printf '%s\n' "$out" | grep -c 'spawned 1 of gap 5 (selection deferred (main-broken))')"
+assert_eq "deferred: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+mat_teardown
+
+# (stop on deferred → drain) the same deferral when the SEED itself did not spawn
+# (a done seed) yields zero net spawns → terminal `drain`.
+echo "Test: materialize-spawn fan-out deferred line with a non-spawning seed → drain (#1317)"
+mat_setup
+export MAT_PHASE=done
+cat > "$TMPDIR_TEST/dispatch-select-target" <<FAKE
+#!/usr/bin/env bash
+echo "scan \$*" >> "$TMPDIR_TEST/logs/select-target.log"
+echo "jit-reminder 4242 digest"
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
+out=$(run_mat 839 queue --gap 5)
+assert_eq "deferred-drain: spawn count" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ' || echo 0)"
+assert_eq "deferred-drain: summary 0 of gap 5 (selection deferred (jit-reminder))" "1" \
+  "$(printf '%s\n' "$out" | grep -c 'spawned 0 of gap 5 (selection deferred (jit-reminder))')"
+assert_eq "deferred-drain: terminal token" "drain" "$(printf '%s\n' "$out" | tail -n 1)"
+mat_teardown
+
+# (unexpected line) an unrecognized selector line is a hard error: release the
+# lock and exit 2 (it must NOT be silently consumed or treated as a target).
+echo "Test: materialize-spawn fan-out unexpected selector line → exit 2 + lock released (#1317)"
+mat_setup
+cat > "$TMPDIR_TEST/dispatch-select-target" <<FAKE
+#!/usr/bin/env bash
+echo "scan \$*" >> "$TMPDIR_TEST/logs/select-target.log"
+echo "garbage not-a-decision-line"
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-select-target"
+err=$("$TMPDIR_TEST/dispatch-materialize-spawn" 839 queue --gap 5 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err" in
+  *"emitted unexpected"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err" ;;
+esac
+assert_eq "unexpected-line: error + exit 2" "ok" "$status"
+assert_eq "unexpected-line: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
 # --- --gap unbounded is removed → usage error exit 2 -------------------------


### PR DESCRIPTION
Closes #1317

## Problem

The autonomous dispatch chain targets up to `max_concurrent_workers` (default 8)
live workers, but live concurrency sat at ~2–3 and troughed to 0–1 even when the
weekly pace gate was wide open and the queue held 100+ startable items. The
limiter was **spawn throughput**, not pacing or depth.

`dispatch-materialize-spawn`'s fan-out loop filled `GAP` slots by calling
`dispatch-select-target` **once per slot, serialized, holding the selection lock
for the whole run**. Each selector call is ~131s (`gh pr list`, `gh issue list
--limit 300`, a batched `blockedBy` GraphQL query, per-issue leaf traces).
Filling `gap=5` took ~9 minutes, during which early-spawned workers drained and
self-closed, so net concurrency never accumulated. The held lock also dropped the
per-worker Stop-hook ticks that should compound concurrency.

## Fix

`dispatch-select-target` already scanned the whole queue and built ranked
per-`(priority, topic, phase)` bucket maps, then discarded everything except the
single top item. This PR has it emit the **top-N distinct targets in one pass**
via a new `--top N` flag, and has the fan-out loop consume that single list
instead of re-invoking the selector once per slot. A `gap=N` fan-out now performs
**O(1)** selector scans, not O(N) — one ~131s scan instead of N — letting
concurrency accumulate toward target.

### Unit 1 — `dispatch-select-target --top N`

The bucket maps (`FIRST_PR` / `FIRST_ISSUE`) became capped, oldest-first newline
lists. The PR scan appends up to `N` per bucket; the issue scan descends each
help-wanted root past not-ready/excluded leaves (a growing local exclude set
within the one scan) to enumerate multiple startable leaves. Emission branches on
`TOP`: `--top 1` (the default) keeps the existing echo-first-and-exit loop
**verbatim** — byte-identical to the prior no-flag behavior for every existing
caller — while `--top N>1` walks the same priority-axis → topic-category → phase
nesting and drains each bucket oldest-first into a results list. `--top` is
default-mode only: rejected (exit 1) alongside `--qa` / `--health-only` /
`--main-broken-sha` / `--priority-only`. Every existing skip filter
(worktree-claim, `dispatch-ci-ready`, `done`, office-hours, `--exclude`,
open-blocker) is preserved unchanged.

### Unit 2 — fan-out consumes one `--top` scan

The fan-out driver processes the seed `N` first, then issues exactly one
`dispatch-select-target --top (GAP - spawned) --exclude <seed>` scan and consumes
its newline-delimited target list. The single static seed `--exclude` plus the
seed's reservation marker close the seed re-selection race; the dropped
intra-loop growing `--exclude` thread is subsumed by the selector's internal
one-scan dedup, with a defensive `SEEN` dedup on consumption as the backstop. The
terminal tokens (`propagate` / `drain`), the `spawned K of gap G [(stop_reason)]`
summary, and the single end-of-run lock release are preserved verbatim.

### Unit 3 — tests

New `--top` selector coverage (N distinct ranked lines in priority order,
`--exclude` honored, fewer-than-N with no padding, multi-leaf descent in one scan
with live/reserved/office-hours leaves excluded, `--top 1` byte-parity, and the
four rejection combinations) and the fan-out tests rewritten to the single-scan
model: the fake selector emits a multi-line `--top` list in one call, and the
invocation assertion flips from `>=2` to **exactly 1 selector scan per fan-out
run** (the acceptance single-scan assertion). The #1062 dedup-mechanism cases
relocated to the selector `--top` tests where the dedup now lives.

A `drain_bucket` bug surfaced by the multi-target tests is also fixed: its
trailing arithmetic test returned 1 when the results array was still under `TOP`,
which under `set -e` aborted the whole scan at the bare call site — making
`--top N>1` non-functional. An explicit `return 0` keeps a not-yet-full scan
going.

## Coordination with #1389

This issue owns **selection only**. It does not touch the spawn primitive
(`claude --bg "/dispatch-worker"` stays — #1391 swaps it for a detached launcher
later) and keeps the reservation markers (they guard the cross-tick race, which
single-pass selection does not address). Lands before #1391.

## Verification

- Full dispatch suite: **2202/2202 pass**.
- `bash -n` clean on both edited scripts.
- `--top 1` output byte-identical to the no-flag call (tested).
- `--top` rejection (exit 1, order-independent) and bad-value validation confirmed.
- Single-scan acceptance assertion: a `--gap N` fan-out issues exactly one
  selector scan (`wc -l logs/select-target.log == 1`).
