### PR TITLE
dispatch: introduce dispatch-launch-worker and detach it from the router

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-launch-worker
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-launch-worker
@@ -103,6 +103,17 @@ release_and_tick() {
   "$SCRIPT_DIR/dispatch-spawn-tick" >/dev/null 2>&1 || true
 }
 
+# A non-zero route rc with NO directive is a genuine infrastructure failure
+# (e.g. dispatch-ci-ready exiting 2), not a routing disposition. Surface the real
+# exit code rather than falling into the `*)` arm below, which would park the
+# issue with a misleading "unrecognized route directive ''" reason. The `*)` arm
+# still handles genuinely non-empty unrecognized directives.
+if [[ "$ROUTE_RC" -ne 0 && -z "$DIRECTIVE" ]]; then
+  echo "dispatch-launch-worker: dispatch-route exited $ROUTE_RC for #$N with no directive" >&2
+  release_and_tick
+  exit "$ROUTE_RC"
+fi
+
 # ---- Step 4: act on the directive -------------------------------------------
 case "$DIRECTIVE" in
   "INVOKE "*)
@@ -126,9 +137,15 @@ case "$DIRECTIVE" in
     # A done PR whose worktree carries unpushed local commits (#1105). Push them
     # (sandbox-safe HTTPS to github.com) against the target worktree explicitly —
     # the launcher's cwd is the router's, not the worktree — then park for review.
-    git -C "$WORKTREE_PATH" push origin HEAD || true
-    "$SCRIPT_DIR/dispatch-apply-office-hours" "$N" \
-      "dispatch-launch-worker: PUSH-STRANDED — pushed unpushed local commits a done PR left behind; parking for review"
+    push_rc=0
+    git -C "$WORKTREE_PATH" push origin HEAD || push_rc=$?
+    if [[ "$push_rc" -eq 0 ]]; then
+      "$SCRIPT_DIR/dispatch-apply-office-hours" "$N" \
+        "dispatch-launch-worker: PUSH-STRANDED — pushed unpushed local commits a done PR left behind; parking for review" || true
+    else
+      "$SCRIPT_DIR/dispatch-apply-office-hours" "$N" \
+        "dispatch-launch-worker: PUSH-STRANDED — push of unpushed local commits a done PR left behind failed (rc=$push_rc); parking for review" || true
+    fi
     release_and_tick
     ;;
   "STOP provision-failed")
@@ -136,7 +153,7 @@ case "$DIRECTIVE" in
     # office-hours-reason write is a no-op for the launcher, which has no job
     # dir). Park directly via the single label write path.
     "$SCRIPT_DIR/dispatch-apply-office-hours" "$N" \
-      "dispatch-launch-worker: provisioning/merge of origin/main failed for #$N; parking for review"
+      "dispatch-launch-worker: provisioning/merge of origin/main failed for #$N; parking for review" || true
     release_and_tick
     ;;
   "STOP done" | "STOP waiting" | "STOP wrong-worktree")
@@ -149,7 +166,7 @@ case "$DIRECTIVE" in
     # .claude/rules/code-style.md, surface it (park with a clear reason) rather
     # than swallow it.
     "$SCRIPT_DIR/dispatch-apply-office-hours" "$N" \
-      "dispatch-launch-worker: unrecognized route directive '$DIRECTIVE' for #$N; parking for review"
+      "dispatch-launch-worker: unrecognized route directive '$DIRECTIVE' for #$N; parking for review" || true
     release_and_tick
     ;;
 esac

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-launch-worker
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-launch-worker
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# dispatch-launch-worker — the scripted phase-initiation worker (replaces the
+# /dispatch-worker model session for routing + mechanical dispositions).
+#
+# Usage: dispatch-launch-worker <N> <worktree-path>
+#
+# Contract: launched DETACHED by the router (dispatch-materialize-spawn) via
+# `setsid nohup dispatch-launch-worker <N> <wt> </dev/null >tmp/…log 2>&1 &`, so
+# this process owns an independent lifetime — its own session/process-group, no
+# job dir, no `claude agents` registry entry while it runs. It runs the whole
+# deterministic prelude once via dispatch-route (worktree cross-check →
+# provision + origin/main merge → CI gate → dispatch-phase) and acts on the
+# single directive dispatch-route prints:
+#   - a real phase (`INVOKE /<skill>`) → exec the phase-skill spawn, with no
+#     model spent on routing; the phase skill is born in the provisioned, merged
+#     worktree (the #1047 merged-tree guarantee holds because dispatch-route
+#     provisions before this exec).
+#   - every mechanical disposition (STOP done/waiting/wrong-worktree/
+#     provision-failed, PUSH-STRANDED) → handled here with NO `claude` session
+#     spawned (zero tokens).
+#
+# HEARTBEAT RATIONALE (decision 2 of #1391): today every /dispatch-worker — even
+# one that hits a mechanical disposition — fires the Stop hook
+# (.claude/hooks/dispatch-stop.sh), which always calls dispatch-spawn-tick (the
+# chain's heartbeat). A DETACHED launcher that handles a mechanical disposition
+# fires NO Stop hook, so an all-mechanical fan-out would stall the chain.
+# Therefore the launcher MUST call dispatch-spawn-tick on every mechanical path.
+# This is harmless in the common mixed case: dispatch-spawn-tick dedups on a
+# fixed systemd unit name, so a redundant tick that hits the held lock simply
+# prints `busy`/`deduped` and exits. For the real-phase (INVOKE) path the
+# launcher `exec`s the phase skill, whose own Stop hook owns the tick — the
+# launcher does NOT tick there.
+#
+# Sandbox: dispatch-route runs gh + git merge + direnv/npm, and dispatch-spawn-job
+# reaches the local Claude daemon over a Unix socket — the detaching caller
+# (the router) runs OUTSIDE Claude's Bash sandbox, so no per-call sandbox flag
+# applies here. (A direct Bash-tool invocation would need
+# `dangerouslyDisableSandbox: true` — see .claude/rules/sandbox.md.)
+#
+# NOT set -e on the route call (wrong-worktree exits non-zero and is a handled
+# directive); exits are otherwise handled explicitly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---- Step 0: parse and validate arguments -----------------------------------
+# Mirrors dispatch-spawn-worker's validation: exactly two positionals
+# <N> <worktree-path>; N a positive integer; the worktree path an existing dir
+# whose name is restricted to a safe charset (it flows into the `claude --bg`
+# prompt and the session --name via basename). No --model flag — the launcher
+# derives the model from the routed phase. This validation is a deliberate
+# temporary duplication of dispatch-spawn-worker's; #1392 (sub-issue C) removes
+# the original.
+if [[ $# -lt 2 ]]; then
+  echo "dispatch-launch-worker: expected 2 arguments: <N> <worktree-path>" >&2
+  exit 2
+fi
+if [[ $# -gt 2 ]]; then
+  echo "dispatch-launch-worker: unexpected argument '$3'" >&2
+  exit 2
+fi
+
+N="$1"
+WORKTREE_PATH="$2"
+
+if [[ ! "$N" =~ ^[1-9][0-9]*$ ]]; then
+  echo "dispatch-launch-worker: invalid issue number '$N' (expected a positive integer)" >&2
+  exit 2
+fi
+if [[ ! -d "$WORKTREE_PATH" ]]; then
+  echo "dispatch-launch-worker: worktree path '$WORKTREE_PATH' does not exist" >&2
+  exit 2
+fi
+# Defense-in-depth: WORKTREE_PATH flows into the spawned session's --name (via
+# basename) and into the inline prompt string passed to `claude --bg`. Reject
+# characters that could split the prompt argument or affect downstream parsing.
+if [[ ! "$WORKTREE_PATH" =~ ^[A-Za-z0-9/_.-]+$ ]]; then
+  echo "dispatch-launch-worker: worktree path '$WORKTREE_PATH' contains unsafe characters" >&2
+  exit 2
+fi
+
+# ---- Step 1: source the reservation ledger ----------------------------------
+# reservation_clear is called on every mechanical path so the router-written
+# marker is released the instant the launcher resolves the slot (the sweep's
+# boot-grace rule would otherwise only reclaim it after a delay).
+# shellcheck source=lib-reservation-ledger.sh
+source "$SCRIPT_DIR/lib-reservation-ledger.sh"
+wt_basename="$(basename "$WORKTREE_PATH")"
+
+# ---- Step 2: route once -----------------------------------------------------
+# dispatch-route provisions + merges + CI-gates + derives the phase, then prints
+# exactly one directive. STOP wrong-worktree exits non-zero (cross-check
+# failure) and is a HANDLED directive, so capture stdout + rc without letting
+# `set -e` abort.
+DIRECTIVE=$("$SCRIPT_DIR/dispatch-route" "$N" "$WORKTREE_PATH") && ROUTE_RC=0 || ROUTE_RC=$?
+
+# ---- Step 3: mechanical-tail helper -----------------------------------------
+# Release the reservation and fire the chain heartbeat (see HEARTBEAT RATIONALE).
+# Both are best-effort: a failed clear or a busy tick must never abort the
+# launcher's disposition.
+release_and_tick() {
+  reservation_clear "$wt_basename" || true
+  "$SCRIPT_DIR/dispatch-spawn-tick" >/dev/null 2>&1 || true
+}
+
+# ---- Step 4: act on the directive -------------------------------------------
+case "$DIRECTIVE" in
+  "INVOKE "*)
+    # A real phase. Derive the model from the skill (the policy lives in
+    # dispatch-phase-model: qa/review → Sonnet, everything else → inherit Opus),
+    # then EXEC the phase-skill spawn. Do NOT clear the reservation — the
+    # existing sweep reclaims the marker once the phase session registers under
+    # the worktree basename (#1045/#1048). Do NOT tick — the phase skill's own
+    # Stop hook owns the chain heartbeat.
+    SKILL="${DIRECTIVE#INVOKE }"            # e.g. /qa-fix
+    case "$SKILL" in
+      /qa-fix)     MODEL=$("$SCRIPT_DIR/dispatch-phase-model" qa) ;;
+      /review-fix) MODEL=$("$SCRIPT_DIR/dispatch-phase-model" review) ;;
+      *)           MODEL="" ;;
+    esac
+    args=(--no-verify --name "$wt_basename" --cwd "$WORKTREE_PATH")
+    [[ -n "$MODEL" ]] && args+=(--model "$MODEL")
+    exec "$SCRIPT_DIR/dispatch-spawn-job" "${args[@]}" "$SKILL $N $WORKTREE_PATH"
+    ;;
+  "PUSH-STRANDED")
+    # A done PR whose worktree carries unpushed local commits (#1105). Push them
+    # (sandbox-safe HTTPS to github.com) against the target worktree explicitly —
+    # the launcher's cwd is the router's, not the worktree — then park for review.
+    git -C "$WORKTREE_PATH" push origin HEAD || true
+    "$SCRIPT_DIR/dispatch-apply-office-hours" "$N" \
+      "dispatch-launch-worker: PUSH-STRANDED — pushed unpushed local commits a done PR left behind; parking for review"
+    release_and_tick
+    ;;
+  "STOP provision-failed")
+    # dispatch-route already emitted the directive (its CLAUDE_JOB_DIR-guarded
+    # office-hours-reason write is a no-op for the launcher, which has no job
+    # dir). Park directly via the single label write path.
+    "$SCRIPT_DIR/dispatch-apply-office-hours" "$N" \
+      "dispatch-launch-worker: provisioning/merge of origin/main failed for #$N; parking for review"
+    release_and_tick
+    ;;
+  "STOP done" | "STOP waiting" | "STOP wrong-worktree")
+    # Benign races — the router's #1109 done re-check, the CI re-gate, and the
+    # spawn-coherence cross-check. No park: just release the slot and tick.
+    release_and_tick
+    ;;
+  *)
+    # Defensive: an unrecognized directive is an unexpected state. Per
+    # .claude/rules/code-style.md, surface it (park with a clear reason) rather
+    # than swallow it.
+    "$SCRIPT_DIR/dispatch-apply-office-hours" "$N" \
+      "dispatch-launch-worker: unrecognized route directive '$DIRECTIVE' for #$N; parking for review"
+    release_and_tick
+    ;;
+esac

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -9,25 +9,27 @@
 # path guards (leaf trace, closed-target, open-blocker), resolves the target
 # worktree (entering or creating it — `create` path does only the cheap
 # `git worktree add`, leaving direnv/npm provisioning and the origin/main merge
-# for the worker's startup, per #1047 / #1044), writes the recovery marker via
+# for the launcher's startup, per #1047 / #1044), writes the recovery marker via
 # dispatch-finalize-selection (which no longer releases the lock — #945), runs
-# the explicit-target readiness gate (dispatch-ci-ready), spawns the worker, and
-# releases the lock after the worker spawn is kicked (the spawn is async — #1048;
-# the lock no longer spans registration). Prints exactly ONE terminal
+# the explicit-target readiness gate (dispatch-ci-ready), DETACHES the per-target
+# launcher (dispatch-launch-worker, #1391), and releases the lock after the
+# detach is kicked (the detach is instant and fire-and-forget; the lock never
+# spans provisioning or registration). Prints exactly ONE terminal
 # token as its LAST stdout line;
 # supporting detail (a path, a blocker list, the CI line) precedes the token.
 #
-# With `--gap <N>` and `queue` mode, the script FANS OUT: it spawns up to N
-# workers in one held-lock run. The seed (target 1) is the passed-in <issue-N>;
+# With `--gap <N>` and `queue` mode, the script FANS OUT: it detaches up to N
+# launchers in one held-lock run. The seed (target 1) is the passed-in <issue-N>;
 # targets 2..GAP come from ONE `dispatch-select-target --top <GAP-after-seed>`
 # scan (#1317) — a single queue pass that returns up to that many distinct
 # ranked targets, instead of one serialized selector call per slot. The seed's
 # just-written reservation marker (dispatch-select-target's reserved-skip, #1046)
 # plus a single static `--exclude <issue-N>` on that one scan close the seed
 # re-selection race; selection dedups the remaining targets internally within
-# that one scan, so no per-slot SEEN threading is needed. The worker no longer
-# registers synchronously (#1048); the reservation marker, not registration,
-# closes the spawn-gap race for each spawned slot.
+# that one scan, so no per-slot SEEN threading is needed. The launcher provisions
+# off-lock and registers its phase session only after it has provisioned (#1391);
+# the reservation marker, not registration, closes the spawn-gap race for each
+# detached slot.
 # `explicit` mode and `--gap 1` process a single target (backward-compatible).
 # Fan-out (`--gap N` with N>1) is autonomous-only; a manual run arrives as
 # `--gap 1` and takes the single-target path.
@@ -35,16 +37,18 @@
 # <issue-N> is always the ISSUE number (the model derives N=${branch%%-*} for a
 # `pr` row before calling). The two literal `[branch phase]` positionals the
 # queue selection carries are still dropped — no sub-script consumes them. The
-# spawn does consult the phase, but the #1109-recomputed PHASE (Step 5), not the
-# carried positional: it maps PHASE → worker model via dispatch-phase-model so
-# the qa and review phases launch on Sonnet (#1171, #1172); every other phase
-# yields no --model and inherits the session default (Opus).
+# router still recomputes PHASE (Step 5) for the #1109 done re-check, but it no
+# longer maps it to a worker model: the detached launcher (dispatch-launch-worker)
+# routes on the merged tree and derives the phase→model itself (qa/review →
+# Sonnet via dispatch-phase-model, #1171/#1172; every other phase inherits the
+# session default Opus), so the router forwards no --model.
 #
 # Terminal tokens (the last stdout line is always exactly one of):
-#   propagate              the worker spawned (or deduped); the chain advances.
-#                          Lock released after dispatch-spawn-worker kicks the
-#                          (async) worker spawn (#1048); the reservation marker,
-#                          not registration, closes the spawn-gap race.
+#   propagate              the launcher detached; the chain advances. Lock
+#                          released after the launcher is detached (#1391); the
+#                          detach is instant, so provisioning runs off-lock. The
+#                          reservation marker, not registration, closes the
+#                          spawn-gap race.
 #   notify target-blocked  explicit target is closed or has an open blocker; the
 #                          issue is parked via dispatch-apply-office-hours and
 #                          the lock released at the guard.
@@ -58,8 +62,6 @@
 #                          re-check (#1109): same as above but the next tick
 #                          proceeds to the next priority. Lock released after the
 #                          return.
-#   notify spawn-failed    dispatch-spawn-worker exited non-zero; lock released
-#                          after the failed spawn returns.
 #   drain worktree-conflict  the target worktree cannot be safely entered; the
 #                          lock is released at the guard. The conflict path
 #                          precedes this token.
@@ -100,18 +102,20 @@
 #                          distinct target — a normal terminal state, not a
 #                          failure.
 #
-# Lock-release points (#1048): the lock is held THROUGH the reserve + spawn-KICK
-# (not through registration); after release the reservation marker closes the
-# spawn-gap re-selection race so the next tick cannot re-select the target during
-# the worker's boot gap. In a fan-out run the lock is held across the WHOLE loop
-# and released ONCE at the end (or on a hard `exit 2`); per-target park/skip
-# outcomes do NOT release between iterations.
+# Lock-release points (#1048/#1391): the lock is held THROUGH the reserve +
+# launcher-DETACH (not through provisioning or registration); after release the
+# reservation marker closes the spawn-gap re-selection race so the next tick
+# cannot re-select the target during the launcher's provision+boot gap. In a
+# fan-out run the lock is held across the WHOLE loop and released ONCE at the end
+# (or on a hard `exit 2`); per-target park/skip outcomes do NOT release between
+# iterations.
 # dispatch-finalize-selection writes the recovery marker but no longer releases.
 # `notify target-blocked` and `drain worktree-conflict` release explicitly at the
 # guard (the marker does not exist yet on these pre-finalize stop paths).
-# `propagate` and `notify spawn-failed` release AFTER dispatch-spawn-worker
-# returns: on success the spawn was kicked async and the reservation marker is
-# left in place; on failure the marker is cleared.
+# `propagate` releases AFTER the launcher is detached: the detach is instant and
+# fire-and-forget (the router never observes the launcher's exit), so the
+# reservation marker is always left in place — a launcher that dies before
+# spawning leaves a sweepable orphan (#1045/#1048).
 # The single-target ci-waiting stop (now `drain ci-reseeded` / `notify
 # ci-wait-exhausted`, or the fallback `drain ci-waiting` on a scheduler hard-
 # failure) releases the lock at its stop, BEFORE dispatch-schedule-target-reseed
@@ -181,16 +185,17 @@ WAITING_N=""
 # process_one_target <issue-N> <explicit|queue>
 # Runs the per-target sequence (Step 4 guards, the #1109 spawn-boundary done
 # re-check, Step 5 resolve, recovery marker, Step 6a explicit-only readiness
-# gate, Step 6b spawn) for ONE target. Does NOT
+# gate, Step 6b launcher-detach) for ONE target. Does NOT
 # release the lock and does NOT exit — the caller owns lock release and process
-# exit. The Step 6b spawn-kick is async (#1048): on success the reservation
-# marker is left in place as the in-flight contribution; registration is not
-# awaited. Sets the global OUTCOME on every soft path and returns 0; returns 2 on
-# a hard error (the caller maps that to release_lock; exit 2).
+# exit. The Step 6b detach is fire-and-forget (#1391): the reservation marker is
+# always left in place as the in-flight contribution; the launcher provisions and
+# registers its phase session off-lock. Sets the global OUTCOME on every soft
+# path and returns 0; returns 2 on a hard error (the caller maps that to
+# release_lock; exit 2).
 process_one_target() {
   local n="$1" mode="$2"
   local PR LEAF ISSUE_STATE BLOCKERS WT_DECISION WT_ACTION WT_REST
-  local WORKTREE_PATH BRANCH PROJECT_ROOT rc wt_basename PHASE WORKER_MODEL worker_args
+  local WORKTREE_PATH BRANCH PROJECT_ROOT rc wt_basename PHASE PROJECT_ROOT_FOR_LOG
 
   # --- Step 4: explicit-path guards (skipped entirely in queue mode) ---------
   # Queue rows were already vetted by dispatch-select-target (leaf, blockers,
@@ -332,61 +337,50 @@ process_one_target() {
     return 0
   fi
 
-  # --- Step 6b: reserve, then spawn the worker -------------------------------
+  # --- Step 6b: reserve, then detach the launcher ----------------------------
   # The lock is still held here. Write the reservation marker the instant before
-  # the (now async) spawn-kick and LEAVE it in place on success: registration is
-  # no longer awaited (#1048 — dispatch-spawn-worker passes --no-verify), so the
-  # marker, not registration timing, is this slot's in-flight budget/selection
-  # contribution and is what closes the spawn-gap re-selection race #945 closed.
-  # A concurrent acquirer's reserved-skip (#1046) and the budget gate (#1045)
-  # both key on the marker. reservation_sweep reclaims it on registration (rule
-  # (a)) or after the boot grace if the worker never comes up. On a failed kick
-  # no worker is coming, so the marker is cleared (no leaked budget).
+  # the launcher detach and LEAVE it in place: the detach is fire-and-forget
+  # (#1391 — the router never observes the launcher's exit), so the marker, not
+  # registration timing, is this slot's in-flight budget/selection contribution
+  # and is what closes the spawn-gap re-selection race #945 closed. A concurrent
+  # acquirer's reserved-skip (#1046) and the budget gate (#1045) both key on the
+  # marker. reservation_sweep reclaims it once the launcher's phase session
+  # registers (rule (a)) or after the boot grace if the launcher dies before
+  # spawning (its provision+route can take minutes — the marker keeps the slot
+  # counted across that window).
   #
   # The next in-loop selection yields a distinct target because the marker makes
   # dispatch-select-target's reserved-skip (#1046) skip this worktree, and the
   # loop threads its SEEN set as --exclude — neither depends on registration.
   wt_basename="$(basename "$WORKTREE_PATH")"
-  # Best-effort, but surface a failure: a missing marker means the spawn proceeds
+  # Best-effort, but surface a failure: a missing marker means the detach proceeds
   # uncounted, so a silent swallow would hide a budget blind spot. The sweeper
   # still reclaims any stranded state, so a failed write is non-fatal to the loop.
   if ! reservation_write "$wt_basename" "$n" "${CLAUDE_CODE_SESSION_ID:-}" 1>&2; then
     echo "dispatch-materialize-spawn: reservation_write failed for $wt_basename; spawning without a ledger entry (budget may undercount this slot)" >&2
   fi
-  # Resolve the worker model from the #1109-recomputed PHASE (#1171, #1172): the
-  # phase→model map (dispatch-phase-model) returns a non-empty model only for
-  # mapped phases (qa, review → claude-sonnet-4-6); every other phase yields
-  # empty, so no --model is forwarded and the worker inherits the session
-  # default (Opus).
-  # The [[ -n "$PHASE" ]] guard avoids calling dispatch-phase-model with an empty
-  # arg (its usage error) in the defensive case where dispatch-phase exited 3
-  # (pending CI); in normal operation PHASE is non-empty here — queue targets are
-  # CI-pre-gated and explicit targets pass the Step 6a readiness gate.
-  WORKER_MODEL=""
-  if [[ -n "$PHASE" ]]; then
-    if ! WORKER_MODEL=$("$SCRIPT_DIR/dispatch-phase-model" "$PHASE"); then
-      echo "dispatch-materialize-spawn: dispatch-phase-model failed for phase '$PHASE'" >&2
-      return 2
-    fi
-  fi
-  worker_args=()
-  [[ -n "$WORKER_MODEL" ]] && worker_args+=(--model "$WORKER_MODEL")
-  worker_args+=("$n" "$WORKTREE_PATH")
-  if "$SCRIPT_DIR/dispatch-spawn-worker" "${worker_args[@]}" 1>&2; then
-    # Leave the marker in place (#1048): the spawn is async (dispatch-spawn-worker
-    # passes --no-verify), so the worker has not registered yet. The marker is the
-    # in-flight budget/selection contribution that a concurrent acquirer's
-    # reserved-skip (#1046) and the budget gate (#1045) rely on; reservation_sweep
-    # reclaims it once the worker goes live (rule (a)) or after the boot grace if
-    # the worker never comes up.
-    OUTCOME=spawned
-    return 0
-  fi
-  # Failed kick: no worker is coming, so clear the marker (no leaked budget). A
-  # stranded marker would otherwise be reclaimed by the sweep anyway, but clearing
-  # here is immediate and precise.
-  reservation_clear "$wt_basename" 1>&2 || true
-  OUTCOME=spawn-failed
+  # Detach the per-target launcher (#1391, sub-issue B). The router no longer
+  # spawns a /dispatch-worker model session: dispatch-launch-worker is a plain
+  # shell process started DETACHED (setsid nohup … &) so it owns an independent
+  # lifetime. It provisions + routes on the merged tree, handles every mechanical
+  # disposition with no model, and execs the phase skill only for a real phase —
+  # so it also OWNS the phase→model derivation now (the router's old WORKER_MODEL
+  # block is gone). The detach is instant and fire-and-forget: the launcher's
+  # stdout/stderr go to a per-target log under tmp/ (the launcher has no job dir),
+  # and stdin is /dev/null so it never holds the router's stdout pipe (the router
+  # prints terminal tokens a caller reads to EOF).
+  #
+  # No spawn-failed branch: a launcher that dies before spawning leaves the
+  # router-written reservation marker with no live session, which the existing
+  # ledger sweep (#1045/#1048) reclaims after the boot grace — exactly the orphan
+  # signal a dead worker leaves today. So the kick is unconditionally `spawned`:
+  # the marker, not the launcher's exit status (which the router never sees),
+  # is this slot's in-flight budget/selection contribution.
+  PROJECT_ROOT_FOR_LOG="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+  mkdir -p "$PROJECT_ROOT_FOR_LOG/tmp"
+  setsid nohup "$SCRIPT_DIR/dispatch-launch-worker" "$n" "$WORKTREE_PATH" \
+    </dev/null >"$PROJECT_ROOT_FOR_LOG/tmp/dispatch-launch-${wt_basename}.log" 2>&1 &
+  OUTCOME=spawned
   return 0
 }
 
@@ -411,7 +405,6 @@ if [[ "$MODE" == "explicit" ]] || (( GAP <= 1 )); then
         echo "drain target-done"
       fi
       ;;
-    spawn-failed)      echo "notify spawn-failed" ;;
     worktree-conflict) echo "drain worktree-conflict" ;;
     ci-waiting)
       # Single-target path (#979): instead of draining as a no-op, schedule a
@@ -473,13 +466,15 @@ record_outcome() {
       echo "propagate: skipped #$cur_n ($OUTCOME)"
       # ci-waiting never occurs in fan-out: the readiness gate is explicit-only
       # (Step 6a), and queue targets are pre-gated by dispatch-select-target's
-      # dispatch-ci-ready check. spawn-failed / worktree-conflict are real
-      # failures the single-target path surfaces via `notify spawn-failed` /
-      # `drain worktree-conflict`; in fan-out the loop deliberately continues to
-      # fill the gap from other targets, but the failure must not be buried — log
-      # it to stderr so a systemic problem is visible in the router logs.
+      # dispatch-ci-ready check. The launcher detach is fire-and-forget (#1391),
+      # so there is no spawn-failed outcome any more — a launcher that dies leaves
+      # a sweepable reservation orphan. worktree-conflict is the remaining real
+      # failure the single-target path surfaces via `drain worktree-conflict`; in
+      # fan-out the loop deliberately continues to fill the gap from other
+      # targets, but the failure must not be buried — log it to stderr so a
+      # systemic problem is visible in the router logs.
       case "$OUTCOME" in
-        spawn-failed|worktree-conflict)
+        worktree-conflict)
           echo "dispatch-materialize-spawn: #$cur_n $OUTCOME during fan-out (continuing to next target)" >&2 ;;
       esac
       ;;

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -19049,6 +19049,7 @@ mat_setup
 export MAT_CI_READY=waiting
 out=$(run_mat 839 queue)
 assert_eq "queue-no-regate: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+wait_launch_log 1
 assert_eq "queue-no-regate: spawn called once" "839 $TMPDIR_TEST/project/worktrees/839-test" \
   "$(cat "$TMPDIR_TEST/logs/launch-worker.log")"
 mat_teardown
@@ -19060,6 +19061,7 @@ echo "Test: materialize-spawn --gap 1 → propagate (single target, default beha
 mat_setup
 out=$(run_mat 839 queue --gap 1)
 assert_eq "gap1: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+wait_launch_log 1
 assert_eq "gap1: spawn called once" "839 $TMPDIR_TEST/project/worktrees/839-test" \
   "$(cat "$TMPDIR_TEST/logs/launch-worker.log")"
 mat_teardown
@@ -23433,6 +23435,28 @@ assert_eq "launch INVOKE /implement: no spawn-tick (exec path)" "no" \
   "$([[ -f "$LW_DIR/spawn-tick.log" ]] && echo yes || echo no)"
 lw_teardown
 
+# 1b. INVOKE /fix-conflicts → exec dispatch-spawn-job with the unmapped-phase
+# flags (no --model — conflict resolution inherits Opus), reservation RETAINED,
+# no tick. Guards against an inadvertent future model-mapping for this directive.
+echo "Test: INVOKE /fix-conflicts → spawn-job exec, no --model, reservation retained, no tick"
+lw_setup
+lw_write_marker
+lw_run "INVOKE /fix-conflicts"
+assert_eq "launch INVOKE /fix-conflicts: exit 0" "0" "$LW_RC"
+sj=$(cat "$LW_DIR/spawn-job-argv" 2>/dev/null || echo "")
+assert_eq "launch INVOKE /fix-conflicts: spawn-job logged once" "1" \
+  "$([[ -f "$LW_DIR/spawn-job-argv" ]] && wc -l < "$LW_DIR/spawn-job-argv" | tr -d ' ' || echo 0)"
+assert_eq "launch INVOKE /fix-conflicts: spawn-job argv" \
+  "--no-verify --name $LW_WT_BASENAME --cwd $LW_WT /fix-conflicts 839 $LW_WT" "$sj"
+assert_eq "launch INVOKE /fix-conflicts: no --model in argv" "no" \
+  "$([[ "$sj" == *"--model"* ]] && echo yes || echo no)"
+assert_eq "launch INVOKE /fix-conflicts: reservation RETAINED" "yes" "$(lw_marker_exists)"
+assert_eq "launch INVOKE /fix-conflicts: no apply-office-hours" "no" \
+  "$([[ -f "$LW_DIR/apply-oh-argv" ]] && echo yes || echo no)"
+assert_eq "launch INVOKE /fix-conflicts: no spawn-tick (exec path)" "no" \
+  "$([[ -f "$LW_DIR/spawn-tick.log" ]] && echo yes || echo no)"
+lw_teardown
+
 # 2. INVOKE /qa-fix → spawn-job carries --model claude-sonnet-4-6 (real
 # dispatch-phase-model qa policy) and the /qa-fix prompt.
 echo "Test: INVOKE /qa-fix → spawn-job with --model claude-sonnet-4-6"
@@ -23552,6 +23576,27 @@ assert_eq "launch unrecognized: reservation CLEARED" "no" "$(lw_marker_exists)"
 assert_eq "launch unrecognized: spawn-tick called" "yes" \
   "$([[ -f "$LW_DIR/spawn-tick.log" ]] && echo yes || echo no)"
 assert_eq "launch unrecognized: no spawn-job" "no" \
+  "$([[ -f "$LW_DIR/spawn-job-argv" ]] && echo yes || echo no)"
+lw_teardown
+
+# 9b. Route failure: a non-zero route exit with NO directive (empty stdout) is a
+# genuine infrastructure failure (e.g. dispatch-ci-ready exiting 2), NOT an
+# office-hours-worthy "unrecognized directive". The launcher must surface the real
+# exit code and release+tick rather than park the issue with a misleading
+# "unrecognized route directive ''" reason (LW-001). It must NOT call
+# apply-office-hours, MUST clear the reservation, MUST tick, and MUST exit with the
+# route's own non-zero code.
+echo "Test: empty directive + route-exit 2 → release+tick, NO park, exit 2"
+lw_setup
+lw_write_marker
+lw_run "" 2
+assert_eq "launch route-fail: surfaces route exit code" "2" "$LW_RC"
+assert_eq "launch route-fail: no apply-office-hours (no park)" "no" \
+  "$([[ -f "$LW_DIR/apply-oh-argv" ]] && echo yes || echo no)"
+assert_eq "launch route-fail: reservation CLEARED" "no" "$(lw_marker_exists)"
+assert_eq "launch route-fail: spawn-tick called" "yes" \
+  "$([[ -f "$LW_DIR/spawn-tick.log" ]] && echo yes || echo no)"
+assert_eq "launch route-fail: no spawn-job" "no" \
   "$([[ -f "$LW_DIR/spawn-job-argv" ]] && echo yes || echo no)"
 lw_teardown
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -23240,6 +23240,314 @@ assert_eq "non-ff push rejection → origin feature-x tip is helper's (not force
 cmp_teardown
 
 # ============================================================================
+# dispatch-launch-worker tests
+# ============================================================================
+echo "=== dispatch-launch-worker ==="
+#
+# dispatch-launch-worker is the scripted phase-initiation worker: it routes once
+# via dispatch-route and acts on the single directive — exec'ing the phase-skill
+# spawn for a real phase, or handling a mechanical disposition with no `claude`
+# session. These tests isolate the launcher from the full provision/route stack
+# by stubbing its DIRECT dependencies, each of which it calls as
+# "$SCRIPT_DIR/<name>" — so the launcher copy and every stub sit together in one
+# scratch dir, and $SCRIPT_DIR (resolved from the copy) points at the stubs.
+#
+# Stubs (all log their argv to per-stub log files):
+#   dispatch-route          — prints the directive from $LW_DIR/route-directive
+#                             and exits with the code in $LW_DIR/route-exit
+#                             (default 0). The wrong-worktree case sets exit 1
+#                             while still printing STOP wrong-worktree.
+#   dispatch-spawn-job      — logs argv to spawn-job-argv, exits 0. The launcher
+#                             `exec`s it, so the launcher process is replaced;
+#                             the test asserts on the log afterward.
+#   dispatch-spawn-tick     — logs a line to spawn-tick.log, exits 0.
+#   dispatch-apply-office-hours — logs argv to apply-oh-argv, exits 0.
+#   git                     — logs argv to git-argv (PUSH-STRANDED `git -C … push`)
+#                             and exits 0.
+# dispatch-phase-model is the REAL script (copied in), so the model-derivation
+# assertions exercise the actual qa/review → claude-sonnet-4-6 policy.
+#
+# The reservation ledger points at $LW_DIR/reservations via DISPATCH_RESERVATION_DIR
+# (so reservation_clear/_dir never need a git repo). Each mechanical-path test
+# pre-creates a marker named by the worktree basename and asserts it is removed;
+# the INVOKE test asserts the marker is RETAINED (the sweep reclaims it on the
+# phase session's registration, not the launcher).
+#
+# The test shell runs under `set -e`; the launcher can exit non-zero (arg
+# validation), so each invocation is wrapped to capture the rc.
+
+LW_DIR=""
+LW_WT=""
+LW_WT_BASENAME=""
+
+lw_setup() {
+  LW_DIR=$(mktemp -d)
+  # The launcher resolves siblings via $SCRIPT_DIR (its own dir), so the copy
+  # and every stub live together in $LW_DIR. The sourced ledger pulls in lib.sh
+  # and lib-claude-agents.sh from the same dir.
+  cp "$SCRIPT_DIR/dispatch-launch-worker" "$LW_DIR/dispatch-launch-worker"
+  cp "$SCRIPT_DIR/dispatch-phase-model" "$LW_DIR/dispatch-phase-model"
+  cp "$SCRIPT_DIR/lib-reservation-ledger.sh" "$LW_DIR/lib-reservation-ledger.sh"
+  cp "$SCRIPT_DIR/lib.sh" "$LW_DIR/lib.sh"
+  cp "$SCRIPT_DIR/lib-claude-agents.sh" "$LW_DIR/lib-claude-agents.sh"
+  chmod +x "$LW_DIR/dispatch-launch-worker" "$LW_DIR/dispatch-phase-model"
+
+  # The target worktree (arg 2): an existing dir with a safe-charset basename.
+  LW_WT="$LW_DIR/839-test-launch"
+  mkdir -p "$LW_WT"
+  LW_WT_BASENAME="$(basename "$LW_WT")"
+
+  # dispatch-route stub: print the chosen directive, exit with the chosen code.
+  cat > "$LW_DIR/dispatch-route" <<'STUB'
+#!/usr/bin/env bash
+D="$(cd "$(dirname "$0")" && pwd)"
+echo "route $*" >> "$D/route-argv"
+[[ -f "$D/route-directive" ]] && cat "$D/route-directive"
+if [[ -f "$D/route-exit" ]]; then exit "$(cat "$D/route-exit")"; fi
+exit 0
+STUB
+
+  # dispatch-spawn-job stub: log argv, exit 0 (the launcher exec's it).
+  cat > "$LW_DIR/dispatch-spawn-job" <<'STUB'
+#!/usr/bin/env bash
+D="$(cd "$(dirname "$0")" && pwd)"
+printf '%s\n' "$*" >> "$D/spawn-job-argv"
+exit 0
+STUB
+
+  # dispatch-spawn-tick stub: log a heartbeat line, exit 0.
+  cat > "$LW_DIR/dispatch-spawn-tick" <<'STUB'
+#!/usr/bin/env bash
+D="$(cd "$(dirname "$0")" && pwd)"
+echo "tick $*" >> "$D/spawn-tick.log"
+exit 0
+STUB
+
+  # dispatch-apply-office-hours stub: log argv, exit 0.
+  cat > "$LW_DIR/dispatch-apply-office-hours" <<'STUB'
+#!/usr/bin/env bash
+D="$(cd "$(dirname "$0")" && pwd)"
+printf '%s\n' "$*" >> "$D/apply-oh-argv"
+exit 0
+STUB
+
+  # git stub on PATH: log argv (PUSH-STRANDED's `git -C … push origin HEAD`),
+  # exit 0. The launcher's only git call is the explicit `git -C` push.
+  cat > "$LW_DIR/git" <<'STUB'
+#!/usr/bin/env bash
+D="$(cd "$(dirname "$0")" && pwd)"
+printf '%s\n' "$*" >> "$D/git-argv"
+exit 0
+STUB
+  chmod +x "$LW_DIR/dispatch-route" "$LW_DIR/dispatch-spawn-job" \
+    "$LW_DIR/dispatch-spawn-tick" "$LW_DIR/dispatch-apply-office-hours" \
+    "$LW_DIR/git"
+
+  # Point the ledger at a scratch dir (no git repo needed) and put the stub dir
+  # first on PATH so the `git` stub is found.
+  export DISPATCH_RESERVATION_DIR="$LW_DIR/reservations"
+  LW_SAVED_PATH="$PATH"
+  export PATH="$LW_DIR:$PATH"
+}
+
+lw_teardown() {
+  export PATH="$LW_SAVED_PATH"
+  unset DISPATCH_RESERVATION_DIR
+  rm -rf "$LW_DIR"
+  LW_DIR=""
+  LW_WT=""
+  LW_WT_BASENAME=""
+}
+
+# lw_write_marker — pre-create a reservation marker for the worktree basename.
+lw_write_marker() {
+  mkdir -p "$DISPATCH_RESERVATION_DIR"
+  printf 'session=sess-router\nissue=839\ntimestamp=2026-01-01T00:00:00Z\n' \
+    > "$DISPATCH_RESERVATION_DIR/$LW_WT_BASENAME"
+}
+
+# lw_marker_exists — yes/no whether the reservation marker is present.
+lw_marker_exists() {
+  [[ -f "$DISPATCH_RESERVATION_DIR/$LW_WT_BASENAME" ]] && echo yes || echo no
+}
+
+# lw_run — set the routed directive (+ optional route exit code), invoke the
+# launcher, capture rc. Args: <directive> [<route-exit>]
+lw_run() {
+  printf '%s' "$1" > "$LW_DIR/route-directive"
+  [[ $# -ge 2 ]] && printf '%s' "$2" > "$LW_DIR/route-exit"
+  set +e
+  "$LW_DIR/dispatch-launch-worker" 839 "$LW_WT" >/dev/null 2>&1
+  LW_RC=$?
+  set -e
+}
+
+# 1. INVOKE /implement → exec dispatch-spawn-job with the unmapped-phase flags
+# (no --model), reservation RETAINED, no park, no tick (the exec path hands the
+# heartbeat to the phase skill's Stop hook).
+echo "Test: INVOKE /implement → spawn-job exec, reservation retained, no tick"
+lw_setup
+lw_write_marker
+lw_run "INVOKE /implement"
+assert_eq "launch INVOKE /implement: exit 0" "0" "$LW_RC"
+sj=$(cat "$LW_DIR/spawn-job-argv" 2>/dev/null || echo "")
+assert_eq "launch INVOKE /implement: spawn-job logged once" "1" \
+  "$([[ -f "$LW_DIR/spawn-job-argv" ]] && wc -l < "$LW_DIR/spawn-job-argv" | tr -d ' ' || echo 0)"
+assert_eq "launch INVOKE /implement: spawn-job argv" \
+  "--no-verify --name $LW_WT_BASENAME --cwd $LW_WT /implement 839 $LW_WT" "$sj"
+assert_eq "launch INVOKE /implement: no --model in argv" "no" \
+  "$([[ "$sj" == *"--model"* ]] && echo yes || echo no)"
+assert_eq "launch INVOKE /implement: reservation RETAINED" "yes" "$(lw_marker_exists)"
+assert_eq "launch INVOKE /implement: no apply-office-hours" "no" \
+  "$([[ -f "$LW_DIR/apply-oh-argv" ]] && echo yes || echo no)"
+assert_eq "launch INVOKE /implement: no spawn-tick (exec path)" "no" \
+  "$([[ -f "$LW_DIR/spawn-tick.log" ]] && echo yes || echo no)"
+lw_teardown
+
+# 2. INVOKE /qa-fix → spawn-job carries --model claude-sonnet-4-6 (real
+# dispatch-phase-model qa policy) and the /qa-fix prompt.
+echo "Test: INVOKE /qa-fix → spawn-job with --model claude-sonnet-4-6"
+lw_setup
+lw_write_marker
+lw_run "INVOKE /qa-fix"
+assert_eq "launch INVOKE /qa-fix: exit 0" "0" "$LW_RC"
+sj=$(cat "$LW_DIR/spawn-job-argv" 2>/dev/null || echo "")
+assert_eq "launch INVOKE /qa-fix: spawn-job argv (with model)" \
+  "--no-verify --name $LW_WT_BASENAME --cwd $LW_WT --model claude-sonnet-4-6 /qa-fix 839 $LW_WT" \
+  "$sj"
+assert_eq "launch INVOKE /qa-fix: reservation RETAINED" "yes" "$(lw_marker_exists)"
+lw_teardown
+
+# 3. INVOKE /review-fix → spawn-job carries --model claude-sonnet-4-6 (review policy).
+echo "Test: INVOKE /review-fix → spawn-job with --model claude-sonnet-4-6"
+lw_setup
+lw_write_marker
+lw_run "INVOKE /review-fix"
+assert_eq "launch INVOKE /review-fix: exit 0" "0" "$LW_RC"
+sj=$(cat "$LW_DIR/spawn-job-argv" 2>/dev/null || echo "")
+assert_eq "launch INVOKE /review-fix: spawn-job argv (with model)" \
+  "--no-verify --name $LW_WT_BASENAME --cwd $LW_WT --model claude-sonnet-4-6 /review-fix 839 $LW_WT" \
+  "$sj"
+lw_teardown
+
+# 4. STOP done → reservation cleared + spawn-tick called; no spawn-job, no park.
+echo "Test: STOP done → reservation cleared + tick, no spawn/park"
+lw_setup
+lw_write_marker
+lw_run "STOP done"
+assert_eq "launch STOP done: exit 0" "0" "$LW_RC"
+assert_eq "launch STOP done: reservation CLEARED" "no" "$(lw_marker_exists)"
+assert_eq "launch STOP done: spawn-tick called" "yes" \
+  "$([[ -f "$LW_DIR/spawn-tick.log" ]] && echo yes || echo no)"
+assert_eq "launch STOP done: no spawn-job" "no" \
+  "$([[ -f "$LW_DIR/spawn-job-argv" ]] && echo yes || echo no)"
+assert_eq "launch STOP done: no apply-office-hours" "no" \
+  "$([[ -f "$LW_DIR/apply-oh-argv" ]] && echo yes || echo no)"
+lw_teardown
+
+# 5. STOP waiting → reservation cleared + tick; no spawn/park.
+echo "Test: STOP waiting → reservation cleared + tick, no spawn/park"
+lw_setup
+lw_write_marker
+lw_run "STOP waiting"
+assert_eq "launch STOP waiting: exit 0" "0" "$LW_RC"
+assert_eq "launch STOP waiting: reservation CLEARED" "no" "$(lw_marker_exists)"
+assert_eq "launch STOP waiting: spawn-tick called" "yes" \
+  "$([[ -f "$LW_DIR/spawn-tick.log" ]] && echo yes || echo no)"
+assert_eq "launch STOP waiting: no apply-office-hours" "no" \
+  "$([[ -f "$LW_DIR/apply-oh-argv" ]] && echo yes || echo no)"
+lw_teardown
+
+# 6. STOP wrong-worktree → handled even though dispatch-route exits 1; reservation
+# cleared + tick; no spawn/park.
+echo "Test: STOP wrong-worktree (route exit 1) → reservation cleared + tick"
+lw_setup
+lw_write_marker
+lw_run "STOP wrong-worktree" 1
+assert_eq "launch STOP wrong-worktree: exit 0" "0" "$LW_RC"
+assert_eq "launch STOP wrong-worktree: reservation CLEARED" "no" "$(lw_marker_exists)"
+assert_eq "launch STOP wrong-worktree: spawn-tick called" "yes" \
+  "$([[ -f "$LW_DIR/spawn-tick.log" ]] && echo yes || echo no)"
+assert_eq "launch STOP wrong-worktree: no apply-office-hours" "no" \
+  "$([[ -f "$LW_DIR/apply-oh-argv" ]] && echo yes || echo no)"
+lw_teardown
+
+# 7. STOP provision-failed → park (apply-office-hours <N> <reason>) + reservation
+# cleared + tick; no spawn-job.
+echo "Test: STOP provision-failed → park + reservation cleared + tick"
+lw_setup
+lw_write_marker
+lw_run "STOP provision-failed"
+assert_eq "launch STOP provision-failed: exit 0" "0" "$LW_RC"
+oh=$(cat "$LW_DIR/apply-oh-argv" 2>/dev/null || echo "")
+assert_eq "launch STOP provision-failed: apply-office-hours targets #839" "yes" \
+  "$([[ "$oh" == 839\ * ]] && echo yes || echo no)"
+assert_eq "launch STOP provision-failed: reservation CLEARED" "no" "$(lw_marker_exists)"
+assert_eq "launch STOP provision-failed: spawn-tick called" "yes" \
+  "$([[ -f "$LW_DIR/spawn-tick.log" ]] && echo yes || echo no)"
+assert_eq "launch STOP provision-failed: no spawn-job" "no" \
+  "$([[ -f "$LW_DIR/spawn-job-argv" ]] && echo yes || echo no)"
+lw_teardown
+
+# 8. PUSH-STRANDED → git push origin HEAD logged + park + reservation cleared +
+# tick; no spawn-job.
+echo "Test: PUSH-STRANDED → git push + park + reservation cleared + tick"
+lw_setup
+lw_write_marker
+lw_run "PUSH-STRANDED"
+assert_eq "launch PUSH-STRANDED: exit 0" "0" "$LW_RC"
+g=$(cat "$LW_DIR/git-argv" 2>/dev/null || echo "")
+assert_eq "launch PUSH-STRANDED: git push origin HEAD logged" \
+  "-C $LW_WT push origin HEAD" "$g"
+assert_eq "launch PUSH-STRANDED: apply-office-hours targets #839" "yes" \
+  "$([[ -f "$LW_DIR/apply-oh-argv" ]] && echo yes || echo no)"
+assert_eq "launch PUSH-STRANDED: reservation CLEARED" "no" "$(lw_marker_exists)"
+assert_eq "launch PUSH-STRANDED: spawn-tick called" "yes" \
+  "$([[ -f "$LW_DIR/spawn-tick.log" ]] && echo yes || echo no)"
+assert_eq "launch PUSH-STRANDED: no spawn-job" "no" \
+  "$([[ -f "$LW_DIR/spawn-job-argv" ]] && echo yes || echo no)"
+lw_teardown
+
+# 9. Defensive: an unrecognized directive parks with a clear reason + tick.
+echo "Test: unrecognized directive → park + tick"
+lw_setup
+lw_write_marker
+lw_run "SOMETHING UNEXPECTED"
+assert_eq "launch unrecognized: exit 0" "0" "$LW_RC"
+oh=$(cat "$LW_DIR/apply-oh-argv" 2>/dev/null || echo "")
+assert_eq "launch unrecognized: apply-office-hours targets #839" "yes" \
+  "$([[ "$oh" == 839\ * ]] && echo yes || echo no)"
+assert_eq "launch unrecognized: reason names the bad directive" "yes" \
+  "$([[ "$oh" == *"unrecognized route directive"* ]] && echo yes || echo no)"
+assert_eq "launch unrecognized: reservation CLEARED" "no" "$(lw_marker_exists)"
+assert_eq "launch unrecognized: spawn-tick called" "yes" \
+  "$([[ -f "$LW_DIR/spawn-tick.log" ]] && echo yes || echo no)"
+assert_eq "launch unrecognized: no spawn-job" "no" \
+  "$([[ -f "$LW_DIR/spawn-job-argv" ]] && echo yes || echo no)"
+lw_teardown
+
+# 10. Arg validation: each malformed call exits 2.
+echo "Test: arg validation → exit 2"
+lw_setup
+# missing second positional
+set +e; "$LW_DIR/dispatch-launch-worker" 839 >/dev/null 2>&1; rc_missing=$?; set -e
+assert_eq "launch arg: missing worktree → exit 2" "2" "$rc_missing"
+# extra positional
+set +e; "$LW_DIR/dispatch-launch-worker" 839 "$LW_WT" extra >/dev/null 2>&1; rc_extra=$?; set -e
+assert_eq "launch arg: extra positional → exit 2" "2" "$rc_extra"
+# non-numeric N
+set +e; "$LW_DIR/dispatch-launch-worker" abc "$LW_WT" >/dev/null 2>&1; rc_nan=$?; set -e
+assert_eq "launch arg: non-numeric N → exit 2" "2" "$rc_nan"
+# missing worktree dir
+set +e; "$LW_DIR/dispatch-launch-worker" 839 "$LW_DIR/no-such-dir" >/dev/null 2>&1; rc_nodir=$?; set -e
+assert_eq "launch arg: missing worktree dir → exit 2" "2" "$rc_nodir"
+# unsafe-char path (a real dir whose name carries a disallowed char)
+mkdir -p "$LW_DIR/bad worktree"
+set +e; "$LW_DIR/dispatch-launch-worker" 839 "$LW_DIR/bad worktree" >/dev/null 2>&1; rc_unsafe=$?; set -e
+assert_eq "launch arg: unsafe-char path → exit 2" "2" "$rc_unsafe"
+lw_teardown
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -18584,11 +18584,20 @@ fi
 echo waiting
 exit 1
 FAKE
-  cat > "$TMPDIR_TEST/dispatch-spawn-worker" <<FAKE
+  # Detached launcher fake (#1391): dispatch-materialize-spawn now DETACHES
+  # dispatch-launch-worker via `setsid nohup … </dev/null >tmp/…log 2>&1 &`
+  # instead of spawning dispatch-spawn-worker. The launcher is fire-and-forget —
+  # the router never observes its exit — so this fake just records its argv to a
+  # deterministic log of its own (NOT the router's per-target tmp redirect, which
+  # captures the fake's stdout) and exits. Because the launch is backgrounded, a
+  # detach-timing test (below) overrides this with a sleeping variant to prove the
+  # router does not block on it. MAT_LAUNCH_SLEEP lets a test make the default
+  # fake sleep before logging without a full override.
+  cat > "$TMPDIR_TEST/dispatch-launch-worker" <<FAKE
 #!/usr/bin/env bash
-echo "\$*" >> "$TMPDIR_TEST/logs/spawn-worker.log"
-echo spawned
-exit \${MAT_SPAWN_RC:-0}
+[[ -n "\${MAT_LAUNCH_SLEEP:-}" ]] && sleep "\$MAT_LAUNCH_SLEEP"
+echo "\$*" >> "$TMPDIR_TEST/logs/launch-worker.log"
+exit 0
 FAKE
   cat > "$TMPDIR_TEST/dispatch-schedule-target-reseed" <<FAKE
 #!/usr/bin/env bash
@@ -18605,7 +18614,7 @@ FAKE
     "$TMPDIR_TEST"/dispatch-resolve-worktree \
     "$TMPDIR_TEST"/dispatch-phase "$TMPDIR_TEST"/dispatch-ci-ready \
     "$TMPDIR_TEST"/dispatch-select-target \
-    "$TMPDIR_TEST"/dispatch-spawn-worker "$TMPDIR_TEST"/dispatch-schedule-target-reseed \
+    "$TMPDIR_TEST"/dispatch-launch-worker "$TMPDIR_TEST"/dispatch-schedule-target-reseed \
     "$TMPDIR_TEST"/sync-issue-context
 
   mkdir -p "$TMPDIR_TEST/project/.bare" "$TMPDIR_TEST/project/worktrees"
@@ -18614,6 +18623,7 @@ FAKE
 echo "\$*" >> "$TMPDIR_TEST/logs/git.log"
 case "\$*" in
   "rev-parse --path-format=absolute --git-common-dir") echo "$TMPDIR_TEST/project/.bare" ;;
+  "rev-parse --show-toplevel") echo "$TMPDIR_TEST/project" ;;
   "worktree add -b "*) mkdir -p "\$5" ;;
   *) : ;;
 esac
@@ -18634,7 +18644,7 @@ mat_teardown() {
   unset DISPATCH_LOCK_FILE CLAUDE_CODE_SESSION_ID CLAUDE_AGENTS_CMD \
     DISPATCH_RESERVATION_DIR \
     MAT_PR MAT_LEAF MAT_BLOCKED MAT_WT_DECISION MAT_PHASE \
-    MAT_CI_READY MAT_SPAWN_RC MAT_ISSUE_STATE MAT_QUEUE \
+    MAT_CI_READY MAT_LAUNCH_SLEEP MAT_ISSUE_STATE MAT_QUEUE \
     MAT_RESEED_OUT MAT_RESEED_RC
   # Per-issue phase overrides (MAT_PHASE_<N>, #1126) have dynamic names the fixed
   # unset list cannot enumerate; clear any a test set so they don't leak forward.
@@ -18643,77 +18653,109 @@ mat_teardown() {
 
 run_mat() { "$TMPDIR_TEST/dispatch-materialize-spawn" "$@" 2>/dev/null; }
 
+# The launcher is DETACHED (setsid nohup … &), so dispatch-materialize-spawn
+# returns WITHOUT waiting for it (that non-blocking property is itself asserted
+# below). Its argv log is therefore written asynchronously by the detached child.
+# Tests that read logs/launch-worker.log must first wait for the child to have
+# logged its expected number of lines, else they race the detach. Bounded poll
+# (~5s) so a genuine miss still fails rather than hanging. $1 = expected line
+# count; returns 0 once reached, 1 on timeout.
+wait_launch_log() {
+  local want="$1" i=0 have
+  while (( i < 500 )); do
+    if [[ -f "$TMPDIR_TEST/logs/launch-worker.log" ]]; then
+      have=$(wc -l < "$TMPDIR_TEST/logs/launch-worker.log" | tr -d ' ')
+      (( have >= want )) && return 0
+    fi
+    sleep 0.01
+    i=$(( i + 1 ))
+  done
+  return 1
+}
+
 # --- queue happy path → propagate (spawn called, lock released) --------------
 echo "Test: materialize-spawn queue happy path → propagate"
 mat_setup
 out=$(run_mat 839 queue) ; rc=$?
 assert_eq "queue happy: exit 0" "0" "$rc"
 assert_eq "queue happy: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "queue happy: spawn-worker called with issue + worktree" \
+wait_launch_log 1
+assert_eq "queue happy: launch-worker detached with issue + worktree (no --model)" \
   "839 $TMPDIR_TEST/project/worktrees/839-test" \
-  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
-assert_eq "queue happy: lock released after spawn" "" "$(cat "$DISPATCH_LOCK_FILE")"
+  "$(cat "$TMPDIR_TEST/logs/launch-worker.log")"
+assert_eq "queue happy: lock released after detach" "" "$(cat "$DISPATCH_LOCK_FILE")"
 assert_eq "queue happy: marker written into target worktree" "1" \
   "$([ -f "$TMPDIR_TEST/project/worktrees/839-test/tmp/dispatch-worktree" ] && echo 1 || echo 0)"
 mat_teardown
 
-# --- #1048 boot-gap: propagate releases the lock ONLY after spawn ------------
-# The headline assertion: the lock must be HELD while dispatch-spawn-worker runs
-# (i.e. through the worker spawn-kick) and released only after it returns. The
-# spawn is async (#1048), so the lock spans the kick, not registration. Override
-# the spawn-worker fake to snapshot the live lock contents at spawn time, then
-# assert the snapshot equals the held session id AND the final lock file is empty
-# (released after the kick).
-echo "Test: materialize-spawn holds the lock during spawn, releases after (#1048)"
+# --- #1391 detach is non-blocking + reservation is pre-detach ----------------
+# The launcher is DETACHED (setsid nohup … &), so the router must NOT wait on it:
+# it writes the reservation marker UNDER THE LOCK (pre-detach), kicks the detach,
+# and returns immediately. Make the launcher fake sleep 2s before logging; the
+# router run must return well under that sleep (proving it does not block on the
+# launcher), AND the reservation marker must already exist the instant the run
+# returns (written pre-detach, under the lock). Timed with SECONDS.
+echo "Test: materialize-spawn detaches the launcher without blocking; reservation is pre-detach (#1391)"
 mat_setup
-cat > "$TMPDIR_TEST/dispatch-spawn-worker" <<FAKE
-#!/usr/bin/env bash
-echo "\$*" >> "$TMPDIR_TEST/logs/spawn-worker.log"
-# Snapshot the lock contents AT spawn time — this is the boot-gap window.
-cat "\$DISPATCH_LOCK_FILE" > "$TMPDIR_TEST/logs/lock-at-spawn.log"
-echo spawned
-exit 0
-FAKE
-chmod +x "$TMPDIR_TEST/dispatch-spawn-worker"
+export MAT_LAUNCH_SLEEP=2
+start=$SECONDS
 out=$(run_mat 839 queue) ; rc=$?
-assert_eq "boot-gap: exit 0" "0" "$rc"
-assert_eq "boot-gap: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
-# Lock was HELD during spawn (worker registers under <basename> in this window).
-assert_eq "boot-gap: lock held during spawn (== session id)" "mat-session" \
-  "$(cat "$TMPDIR_TEST/logs/lock-at-spawn.log")"
-# Lock released after the spawn returned.
-assert_eq "boot-gap: lock released after spawn" "" "$(cat "$DISPATCH_LOCK_FILE")"
+elapsed=$(( SECONDS - start ))
+assert_eq "detach-nonblock: exit 0" "0" "$rc"
+assert_eq "detach-nonblock: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+# The run returned BEFORE the 2s launcher sleep elapsed — it did not wait.
+TOTAL=$((TOTAL + 1))
+if (( elapsed < 2 )); then
+  PASS=$((PASS + 1)); echo "  PASS: detach-nonblock: router returned without waiting on the launcher (${elapsed}s < 2s)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: detach-nonblock: router blocked on the launcher (${elapsed}s >= 2s)"
+fi
+# Reservation marker was written PRE-detach, under the lock, so it already exists
+# the instant the run returned (the sleeping launcher has not even logged yet).
+assert_eq "detach-nonblock: reservation marker exists pre-detach (under the lock)" "1" \
+  "$([ -f "$DISPATCH_RESERVATION_DIR/839-test" ] && echo 1 || echo 0)"
+# The launcher's argv log is still empty here (it is mid-sleep) — confirms the
+# router truly did not wait. Then wait it out and confirm it logged the bare
+# <N> <wt> argv (no --model: the launcher derives the model itself).
+assert_eq "detach-nonblock: launcher had not logged yet at return (still detached/sleeping)" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && wc -l < "$TMPDIR_TEST/logs/launch-worker.log" | tr -d ' ' || echo 0)"
+wait_launch_log 1
+assert_eq "detach-nonblock: launcher eventually logged bare <N> <wt>" \
+  "839 $TMPDIR_TEST/project/worktrees/839-test" \
+  "$(cat "$TMPDIR_TEST/logs/launch-worker.log")"
+# Lock was released after the (instant) detach kick.
+assert_eq "detach-nonblock: lock released after detach" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
-# --- reservation written before spawn, LEFT in place after success (#1048) ----
-# Step 6b writes the marker the instant before the (now async) spawn-kick and
-# LEAVES it in place on success: the spawn is async (dispatch-spawn-worker passes
-# --no-verify), so the worker has not registered yet. The marker is this slot's
-# in-flight budget/selection contribution; the sweep reclaims it on registration
-# (rule (a)) or after the boot grace. Snapshot the marker presence AT spawn time
-# (must be present), then assert it SURVIVES a successful spawn — AND survives the
+# --- reservation written before detach, LEFT in place (#1048/#1391) ----------
+# Step 6b writes the marker UNDER THE LOCK, the instant before the detach, and
+# LEAVES it in place: the detach is fire-and-forget, so the launcher has not
+# provisioned or registered yet. The marker is this slot's in-flight
+# budget/selection contribution; the sweep reclaims it on registration (rule (a))
+# or after the boot grace. The launcher fake snapshots whether the marker exists
+# when it runs (must be present), then we assert it SURVIVES — AND survives the
 # lock release and a fresh reservation_sweep, the reserve→release→reacquire
 # no-double-select property the AC names (the reserved target stays skipped).
-echo "Test: materialize-spawn leaves the reservation in place after a successful async spawn (#1048)"
+echo "Test: materialize-spawn leaves the reservation in place after the detach (#1048/#1391)"
 mat_setup
-cat > "$TMPDIR_TEST/dispatch-spawn-worker" <<FAKE
+cat > "$TMPDIR_TEST/dispatch-launch-worker" <<FAKE
 #!/usr/bin/env bash
-echo "\$*" >> "$TMPDIR_TEST/logs/spawn-worker.log"
-# Snapshot whether the reservation marker exists AT spawn time.
+# Snapshot whether the reservation marker exists when the detached launcher runs.
 [ -f "\$DISPATCH_RESERVATION_DIR/839-test" ] && echo present > "$TMPDIR_TEST/logs/resv-at-spawn.log" || echo absent > "$TMPDIR_TEST/logs/resv-at-spawn.log"
-echo spawned
+echo "\$*" >> "$TMPDIR_TEST/logs/launch-worker.log"
 exit 0
 FAKE
-chmod +x "$TMPDIR_TEST/dispatch-spawn-worker"
+chmod +x "$TMPDIR_TEST/dispatch-launch-worker"
 out=$(run_mat 839 queue) ; rc=$?
 assert_eq "resv-success: exit 0" "0" "$rc"
 assert_eq "resv-success: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "resv-success: reservation present AT spawn time" "present" \
+wait_launch_log 1
+assert_eq "resv-success: reservation present when the launcher ran" "present" \
   "$(cat "$TMPDIR_TEST/logs/resv-at-spawn.log")"
-assert_eq "resv-success: reservation LEFT in place after a successful spawn" "1" \
+assert_eq "resv-success: reservation LEFT in place after the detach" "1" \
   "$([ -f "$DISPATCH_RESERVATION_DIR/839-test" ] && echo 1 || echo 0)"
-# Lock was released after the kick (the locked phase is fast).
-assert_eq "resv-success: lock released after the spawn-kick" "" "$(cat "$DISPATCH_LOCK_FILE")"
+# Lock was released after the (instant) detach kick.
+assert_eq "resv-success: lock released after the detach" "" "$(cat "$DISPATCH_LOCK_FILE")"
 # reserve→release→reacquire: with the lock released, the marker still exists, so
 # a concurrent acquirer's reserved-skip (#1046) keeps skipping the target.
 TOTAL=$((TOTAL + 1))
@@ -18731,18 +18773,12 @@ assert_eq "resv-success: reservation survives a fresh reservation_sweep" "1" \
   "$([ -f "$DISPATCH_RESERVATION_DIR/839-test" ] && echo 1 || echo 0)"
 mat_teardown
 
-# --- reservation cleared after a FAILED spawn --------------------------------
-# On a non-zero spawn the worker never registered, so the marker must still be
-# cleared (no leaked budget).
-echo "Test: materialize-spawn clears the reservation after a failed spawn"
-mat_setup
-export MAT_SPAWN_RC=1
-out=$(run_mat 839 queue)
-assert_eq "resv-fail: terminal token" "notify spawn-failed" \
-  "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "resv-fail: reservation cleared after a failed spawn" "0" \
-  "$([ -f "$DISPATCH_RESERVATION_DIR/839-test" ] && echo 1 || echo 0)"
-mat_teardown
+# NOTE (#1391): the former "reservation cleared after a FAILED spawn" test is
+# gone — the launcher detach is fire-and-forget, so there is no spawn-failed
+# outcome. A launcher that dies before spawning leaves the router-written
+# reservation marker with no live session, which the existing ledger sweep
+# (#1045/#1048) reclaims after the boot grace. The marker-left-in-place property
+# is covered by the resv-success test above.
 
 # --- pre-spawn (blocked) return path writes NO reservation -------------------
 # A target-blocked outcome returns before Step 6b, so no marker is ever written.
@@ -18789,7 +18825,7 @@ assert_eq "explicit closed: office-hours park reason" "839 named target issue is
   "$(cat "$TMPDIR_TEST/logs/apply-office-hours.log")"
 assert_eq "explicit closed: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 assert_eq "explicit closed: no spawn" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 mat_teardown
 
 # --- explicit open blocker → notify target-blocked ---------------------------
@@ -18813,9 +18849,10 @@ export MAT_LEAF=901
 out=$(run_mat 839 explicit)
 assert_eq "explicit leaf: terminal token" "propagate" \
   "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "explicit leaf: spawn-worker keyed on the leaf 901" \
+wait_launch_log 1
+assert_eq "explicit leaf: launcher keyed on the leaf 901" \
   "901 $TMPDIR_TEST/project/worktrees/901-test" \
-  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
+  "$(cat "$TMPDIR_TEST/logs/launch-worker.log")"
 mat_teardown
 
 # --- explicit PR exists → leaf trace skipped ---------------------------------
@@ -18828,9 +18865,10 @@ assert_eq "explicit PR: terminal token" "propagate" \
   "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "explicit PR: leaf trace not consulted" "0" \
   "$([ -f "$TMPDIR_TEST/logs/trace-leaf.log" ] && echo 1 || echo 0)"
-assert_eq "explicit PR: spawn keyed on original 839" \
+wait_launch_log 1
+assert_eq "explicit PR: launcher keyed on original 839" \
   "839 $TMPDIR_TEST/project/worktrees/839-test" \
-  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
+  "$(cat "$TMPDIR_TEST/logs/launch-worker.log")"
 mat_teardown
 
 # --- explicit trace-leaf hard failure → exit 2, lock released, no spawn -------
@@ -18849,7 +18887,7 @@ out=$(run_mat 839 explicit) && rc=0 || rc=$?
 assert_eq "trace-leaf fail: exit 2" "2" "$rc"
 assert_eq "trace-leaf fail: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 assert_eq "trace-leaf fail: no spawn" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 mat_teardown
 
 # --- resolve-worktree internal failure → exit 2, lock released, no spawn ------
@@ -18867,7 +18905,7 @@ out=$(run_mat 839 queue) && rc=0 || rc=$?
 assert_eq "resolve-wt fail: exit 2" "2" "$rc"
 assert_eq "resolve-wt fail: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 assert_eq "resolve-wt fail: no spawn" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 mat_teardown
 
 # --- enter path → sync-issue-context runs in the worktree --------------------
@@ -18895,7 +18933,7 @@ assert_eq "conflict: terminal token" "drain worktree-conflict" \
   "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "conflict: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 assert_eq "conflict: no spawn" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 mat_teardown
 
 # --- dispatch-merge-main NOT called by materialize-spawn (#1047) -------------
@@ -18926,7 +18964,7 @@ assert_eq "ci-reseeded: terminal token" "drain ci-reseeded" \
 assert_eq "ci-reseeded: scheduler called with target" "1" \
   "$([ -f "$TMPDIR_TEST/logs/schedule-target-reseed.log" ] && grep -qx '839' "$TMPDIR_TEST/logs/schedule-target-reseed.log" && echo 1 || echo 0)"
 assert_eq "ci-reseeded: no spawn" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 assert_eq "ci-reseeded: lock released at stop" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
@@ -18944,8 +18982,9 @@ assert_eq "gap1-no-regate: terminal token" "propagate" \
   "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "gap1-no-regate: scheduler NOT called" "0" \
   "$([ -f "$TMPDIR_TEST/logs/schedule-target-reseed.log" ] && echo 1 || echo 0)"
-assert_eq "gap1-no-regate: spawn called once" "839 $TMPDIR_TEST/project/worktrees/839-test" \
-  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
+wait_launch_log 1
+assert_eq "gap1-no-regate: launcher detached once" "839 $TMPDIR_TEST/project/worktrees/839-test" \
+  "$(cat "$TMPDIR_TEST/logs/launch-worker.log")"
 assert_eq "gap1-no-regate: lock released at stop" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
@@ -18960,7 +18999,7 @@ assert_eq "ci-exhausted: terminal token" "notify ci-wait-exhausted" \
 assert_eq "ci-exhausted: scheduler called with target" "1" \
   "$([ -f "$TMPDIR_TEST/logs/schedule-target-reseed.log" ] && grep -qx '839' "$TMPDIR_TEST/logs/schedule-target-reseed.log" && echo 1 || echo 0)"
 assert_eq "ci-exhausted: no spawn" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 assert_eq "ci-exhausted: lock released at stop" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
@@ -18997,7 +19036,7 @@ assert_eq "ci-wait-fallback: terminal token is drain ci-waiting" "drain ci-waiti
 assert_eq "ci-wait-fallback: scheduler was called" "1" \
   "$([ -f "$TMPDIR_TEST/logs/schedule-target-reseed.log" ] && grep -qx '839' "$TMPDIR_TEST/logs/schedule-target-reseed.log" && echo 1 || echo 0)"
 assert_eq "ci-wait-fallback: no spawn" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 assert_eq "ci-wait-fallback: lock released at stop" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
@@ -19011,7 +19050,7 @@ export MAT_CI_READY=waiting
 out=$(run_mat 839 queue)
 assert_eq "queue-no-regate: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "queue-no-regate: spawn called once" "839 $TMPDIR_TEST/project/worktrees/839-test" \
-  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
+  "$(cat "$TMPDIR_TEST/logs/launch-worker.log")"
 mat_teardown
 
 # --- --gap 1 → propagate (single target, default behavior) -------------------
@@ -19022,7 +19061,7 @@ mat_setup
 out=$(run_mat 839 queue --gap 1)
 assert_eq "gap1: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "gap1: spawn called once" "839 $TMPDIR_TEST/project/worktrees/839-test" \
-  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
+  "$(cat "$TMPDIR_TEST/logs/launch-worker.log")"
 mat_teardown
 
 # --- --gap non-integer → usage error exit 2 ----------------------------------
@@ -19036,18 +19075,12 @@ esac
 assert_eq "gap-bad: usage error exit 2" "ok" "$status"
 mat_teardown
 
-# --- spawn failure → notify spawn-failed -------------------------------------
-echo "Test: materialize-spawn spawn failure → notify spawn-failed"
-mat_setup
-export MAT_SPAWN_RC=1
-out=$(run_mat 839 queue)
-assert_eq "spawn-failed: terminal token" "notify spawn-failed" \
-  "$(printf '%s\n' "$out" | tail -n 1)"
-# #945: spawn-failed releases the lock after the failed spawn returns, so the
-# lock must be empty here.
-assert_eq "spawn-failed: lock released at spawn-failed stop" "" \
-  "$(cat "$DISPATCH_LOCK_FILE")"
-mat_teardown
+# NOTE (#1391): the former "spawn failure → notify spawn-failed" single-target
+# test is gone. The launcher detach is fire-and-forget (setsid nohup … &) — the
+# router never observes the launcher's exit, so there is no spawn-failed terminal
+# token. A launcher that dies before spawning leaves the router-written
+# reservation marker with no live session, reclaimed by the existing ledger sweep
+# (#1045/#1048). The propagate path is the only post-detach single-target token.
 
 # --- unexpected resolve-worktree line → release + exit 2 ---------------------
 echo "Test: materialize-spawn unexpected resolve-worktree line → exit 2, lock released"
@@ -19108,7 +19141,7 @@ out=$(run_mat 839 queue) && rc=0 || rc=$?
 assert_eq "wt-add fail: exit 2" "2" "$rc"
 assert_eq "wt-add fail: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 assert_eq "wt-add fail: no spawn" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 mat_teardown
 
 # --- finalize-selection failure (worktree path missing) → exit 2 + lock released
@@ -19133,7 +19166,7 @@ out=$(run_mat 839 queue) && rc=0 || rc=$?
 assert_eq "finalize fail: exit 2" "2" "$rc"
 assert_eq "finalize fail: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 assert_eq "finalize fail: no spawn" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 mat_teardown
 
 # --- explicit closed-check gh failure → exit 2 + lock released ---------------
@@ -19151,7 +19184,7 @@ out=$(run_mat 839 explicit) && rc=0 || rc=$?
 assert_eq "gh fail: exit 2" "2" "$rc"
 assert_eq "gh fail: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 assert_eq "gh fail: no spawn" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 mat_teardown
 
 # --- fan-out: gap 5, 5 distinct spawns, lock released once, summary ----------
@@ -19159,9 +19192,10 @@ echo "Test: materialize-spawn --gap 5 fans out to 5 distinct spawns"
 mat_setup
 export MAT_QUEUE="720 508 991 644"
 out=$(run_mat 839 queue --gap 5)
-assert_eq "fanout5: spawn count" "5" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+wait_launch_log 5
+assert_eq "fanout5: launcher detach count" "5" "$(wc -l < "$TMPDIR_TEST/logs/launch-worker.log" | tr -d ' ')"
 assert_eq "fanout5: distinct worktrees" "5" \
-  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
+  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/launch-worker.log" | sort -u | wc -l | tr -d ' ')"
 assert_eq "fanout5: summary line" "1" \
   "$(printf '%s\n' "$out" | grep -c 'spawned 5 of gap 5')"
 assert_eq "fanout5: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
@@ -19173,30 +19207,19 @@ echo "Test: materialize-spawn --gap 5 queue exhausted after 2 → propagate"
 mat_setup
 export MAT_QUEUE="720"
 out=$(run_mat 839 queue --gap 5)
-assert_eq "exhaust: spawn count" "2" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+wait_launch_log 2
+assert_eq "exhaust: launcher detach count" "2" "$(wc -l < "$TMPDIR_TEST/logs/launch-worker.log" | tr -d ' ')"
 assert_eq "exhaust: summary" "1" "$(printf '%s\n' "$out" | grep -c 'spawned 2 of gap 5 (queue exhausted)')"
 assert_eq "exhaust: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
 mat_teardown
 
-# --- fan-out: all spawns fail → 0 spawned, drain, stderr surfaces each one ---
-# Single-target mode surfaces a failed spawn via `notify spawn-failed`; the
-# fan-out loop deliberately continues to fill the gap from other targets, but a
-# failed spawn must not be silently buried. Each spawn-failed skip emits a
-# stderr warning so a systemic spawn problem is visible in the router logs.
-echo "Test: materialize-spawn --gap 3 all spawns fail → drain + per-target stderr warning"
-mat_setup
-export MAT_QUEUE="720 508"
-export MAT_SPAWN_RC=1
-out=$("$TMPDIR_TEST/dispatch-materialize-spawn" 839 queue --gap 3 2>"$TMPDIR_TEST/logs/mat-stderr.log")
-assert_eq "spawnfail-fanout: zero net spawns in summary" "1" \
-  "$(printf '%s\n' "$out" | grep -c 'spawned 0 of gap 3')"
-assert_eq "spawnfail-fanout: skipped detail per target" "3" \
-  "$(printf '%s\n' "$out" | grep -c 'skipped #.* (spawn-failed)')"
-assert_eq "spawnfail-fanout: terminal token" "drain" "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "spawnfail-fanout: stderr warns on each spawn-failed" "3" \
-  "$(grep -c 'spawn-failed during fan-out' "$TMPDIR_TEST/logs/mat-stderr.log")"
-assert_eq "spawnfail-fanout: lock released at end" "" "$(cat "$DISPATCH_LOCK_FILE")"
-mat_teardown
+# NOTE (#1391): the former "all spawns fail → drain + per-target stderr warning"
+# fan-out test is gone. With the fire-and-forget launcher detach there is no
+# spawn-failed outcome, so a fan-out always detaches one launcher per selected
+# target and reaches `propagate`; a launcher that later dies leaves a sweepable
+# reservation orphan rather than a router-visible failure. The remaining
+# fan-out failure path is worktree-conflict (a per-target skip with a stderr
+# warning), still exercised by the conflict / record_outcome coverage.
 
 # --- fan-out: ONE dispatch-select-target scan fills slots 2..GAP (#1317) -----
 # #1317 acceptance: a --gap N fan-out performs O(1) selector scans, not O(N). The
@@ -19207,13 +19230,14 @@ echo "Test: materialize-spawn fan-out issues exactly ONE selector scan (#1317)"
 mat_setup
 export MAT_QUEUE="720 508"
 out=$(run_mat 839 queue --gap 3)
-# 3 spawns (839 + 720 + 508), all from the seed + ONE single-pass selector scan.
-assert_eq "single-scan: spawn count" "3" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+wait_launch_log 3
+# 3 detached launchers (839 + 720 + 508), from the seed + ONE single-pass scan.
+assert_eq "single-scan: launcher detach count" "3" "$(wc -l < "$TMPDIR_TEST/logs/launch-worker.log" | tr -d ' ')"
 # #1317 single-scan acceptance assertion: exactly ONE selector invocation.
 assert_eq "single-scan: select-target invoked exactly once (#1317)" "1" \
   "$(wc -l < "$TMPDIR_TEST/logs/select-target.log" | tr -d ' ')"
 assert_eq "single-scan: worktrees all unique" "3" \
-  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
+  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/launch-worker.log" | sort -u | wc -l | tr -d ' ')"
 # The single scan was asked for the gap-after-seed slot count and told to exclude
 # the seed (belt-and-suspenders atop the seed's reservation marker).
 assert_eq "single-scan: scan asked for --top 2, --exclude 839" "called top=2 exclude=839" \
@@ -19238,9 +19262,10 @@ echo "Test: materialize-spawn fan-out consumes a multi-line --top list across di
 mat_setup
 export MAT_QUEUE="720 508"
 out=$(run_mat 839 queue --gap 3)
-assert_eq "consume-list: spawn count" "3" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+wait_launch_log 3
+assert_eq "consume-list: launcher detach count" "3" "$(wc -l < "$TMPDIR_TEST/logs/launch-worker.log" | tr -d ' ')"
 assert_eq "consume-list: distinct worktrees" "3" \
-  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
+  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/launch-worker.log" | sort -u | wc -l | tr -d ' ')"
 assert_eq "consume-list: ONE selector scan (#1317)" "1" \
   "$(wc -l < "$TMPDIR_TEST/logs/select-target.log" | tr -d ' ')"
 assert_eq "consume-list: summary 3 of gap 3" "1" "$(printf '%s\n' "$out" | grep -c 'spawned 3 of gap 3')"
@@ -19261,14 +19286,15 @@ echo "issue 508"
 FAKE
 chmod +x "$TMPDIR_TEST/dispatch-select-target"
 out=$(run_mat 839 queue --gap 3)
-assert_eq "consume-pr: spawn count" "3" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+wait_launch_log 3
+assert_eq "consume-pr: launcher detach count" "3" "$(wc -l < "$TMPDIR_TEST/logs/launch-worker.log" | tr -d ' ')"
 assert_eq "consume-pr: ONE selector scan (#1317)" "1" \
   "$(wc -l < "$TMPDIR_TEST/logs/select-target.log" | tr -d ' ')"
 # The pr line's worktree is keyed on the branch prefix 720, not the PR number 9001.
 assert_eq "consume-pr: pr line keyed on branch prefix 720" "1" \
-  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | grep -cx '720')"
+  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/launch-worker.log" | grep -cx '720')"
 assert_eq "consume-pr: distinct worktrees (839,720,508)" "3" \
-  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
+  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/launch-worker.log" | sort -u | wc -l | tr -d ' ')"
 assert_eq "consume-pr: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
 mat_teardown
 
@@ -19287,12 +19313,13 @@ echo "issue 720"
 FAKE
 chmod +x "$TMPDIR_TEST/dispatch-select-target"
 out=$(run_mat 839 queue --gap 3)
-assert_eq "seen-dedup: spawn count (seed + 720, not the re-returned 839)" "2" \
-  "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+wait_launch_log 2
+assert_eq "seen-dedup: launcher detach count (seed + 720, not the re-returned 839)" "2" \
+  "$(wc -l < "$TMPDIR_TEST/logs/launch-worker.log" | tr -d ' ')"
 assert_eq "seen-dedup: 839 spawned exactly once" "1" \
-  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | grep -cx '839')"
+  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/launch-worker.log" | grep -cx '839')"
 assert_eq "seen-dedup: distinct worktrees (839,720)" "2" \
-  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/spawn-worker.log" | sort -u | wc -l | tr -d ' ')"
+  "$(cut -d' ' -f1 "$TMPDIR_TEST/logs/launch-worker.log" | sort -u | wc -l | tr -d ' ')"
 assert_eq "seen-dedup: ONE selector scan (#1317)" "1" \
   "$(wc -l < "$TMPDIR_TEST/logs/select-target.log" | tr -d ' ')"
 assert_eq "seen-dedup: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
@@ -19305,7 +19332,8 @@ echo "Test: materialize-spawn fan-out stops cleanly on an empty selector result 
 mat_setup
 export MAT_QUEUE=""
 out=$(run_mat 839 queue --gap 5)
-assert_eq "fanout-empty: spawn count" "1" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+wait_launch_log 1
+assert_eq "fanout-empty: launcher detach count" "1" "$(wc -l < "$TMPDIR_TEST/logs/launch-worker.log" | tr -d ' ')"
 assert_eq "fanout-empty: ONE selector scan (#1317)" "1" \
   "$(wc -l < "$TMPDIR_TEST/logs/select-target.log" | tr -d ' ')"
 assert_eq "fanout-empty: summary 1 of gap 5 (queue exhausted)" "1" \
@@ -19326,7 +19354,8 @@ echo "main-broken deadbeef"
 FAKE
 chmod +x "$TMPDIR_TEST/dispatch-select-target"
 out=$(run_mat 839 queue --gap 5)
-assert_eq "deferred: spawn count (seed only)" "1" "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+wait_launch_log 1
+assert_eq "deferred: launcher detach count (seed only)" "1" "$(wc -l < "$TMPDIR_TEST/logs/launch-worker.log" | tr -d ' ')"
 assert_eq "deferred: summary names the deferred stop reason" "1" \
   "$(printf '%s\n' "$out" | grep -c 'spawned 1 of gap 5 (selection deferred (main-broken))')"
 assert_eq "deferred: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
@@ -19345,7 +19374,7 @@ FAKE
 chmod +x "$TMPDIR_TEST/dispatch-select-target"
 out=$(run_mat 839 queue --gap 5)
 assert_eq "deferred-drain: spawn count" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ' || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && wc -l < "$TMPDIR_TEST/logs/launch-worker.log" | tr -d ' ' || echo 0)"
 assert_eq "deferred-drain: summary 0 of gap 5 (selection deferred (jit-reminder))" "1" \
   "$(printf '%s\n' "$out" | grep -c 'spawned 0 of gap 5 (selection deferred (jit-reminder))')"
 assert_eq "deferred-drain: terminal token" "drain" "$(printf '%s\n' "$out" | tail -n 1)"
@@ -19398,7 +19427,7 @@ export MAT_PHASE=done
 out=$(run_mat 839 explicit)
 assert_eq "explicit-done: terminal token" "notify target-done" "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "explicit-done: no spawn" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 assert_eq "explicit-done: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 assert_eq "explicit-done: no office-hours park" "0" \
   "$([ -f "$TMPDIR_TEST/logs/apply-office-hours.log" ] && echo 1 || echo 0)"
@@ -19413,7 +19442,7 @@ export MAT_PHASE=done
 out=$(run_mat 839 queue)
 assert_eq "queue-done: terminal token" "drain target-done" "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "queue-done: no spawn" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 assert_eq "queue-done: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
@@ -19432,7 +19461,7 @@ assert_eq "fanout-done: zero spawns in summary" "1" \
   "$(printf '%s\n' "$out" | grep -c 'spawned 0 of gap 3')"
 assert_eq "fanout-done: terminal token" "drain" "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "fanout-done: no spawn" "0" \
-  "$([ -f "$TMPDIR_TEST/logs/spawn-worker.log" ] && echo 1 || echo 0)"
+  "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 assert_eq "fanout-done: lock released at end" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
@@ -19458,58 +19487,58 @@ assert_eq "mixed-fanout: exactly one spawn line" "1" \
   "$(printf '%s\n' "$out" | grep -c 'propagate: spawned #')"
 assert_eq "mixed-fanout: the spawned target is #840" "1" \
   "$(printf '%s\n' "$out" | grep -c 'propagate: spawned #840')"
-assert_eq "mixed-fanout: spawn-worker invoked exactly once" "1" \
-  "$(wc -l < "$TMPDIR_TEST/logs/spawn-worker.log" | tr -d ' ')"
+wait_launch_log 1
+assert_eq "mixed-fanout: launcher detached exactly once" "1" \
+  "$(wc -l < "$TMPDIR_TEST/logs/launch-worker.log" | tr -d ' ')"
 assert_eq "mixed-fanout: summary spawned 1 of gap 2" "1" \
   "$(printf '%s\n' "$out" | grep -c 'spawned 1 of gap 2')"
 assert_eq "mixed-fanout: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "mixed-fanout: lock released at end" "" "$(cat "$DISPATCH_LOCK_FILE")"
 mat_teardown
 
-# --- phase→model integration: qa phase → --model claude-sonnet-4-6 forwarded --
-# When the recomputed PHASE is qa, dispatch-materialize-spawn calls the real
-# dispatch-phase-model (now staged by mat_setup) which emits claude-sonnet-4-6,
-# and the spawn-worker invocation must include --model claude-sonnet-4-6.
-echo "Test: materialize-spawn qa phase → spawn-worker receives --model claude-sonnet-4-6 (#1171)"
+# --- router no longer derives the worker model (#1391) -----------------------
+# The phase→model derivation moved INTO the launcher (dispatch-launch-worker
+# routes on the merged tree, then maps qa/review → Sonnet via dispatch-phase-model
+# itself). So dispatch-materialize-spawn forwards NO --model to the launcher,
+# whatever the recomputed PHASE: the launcher receives a bare <N> <wt>. The
+# qa/review → Sonnet policy is covered in the dispatch-launch-worker test block;
+# here we assert only that the ROUTER stopped forwarding --model. (The per-phase
+# model coverage that used to live here, #1171/#1172, is exercised in the
+# launcher block.)
+echo "Test: materialize-spawn qa phase → router forwards NO --model to the launcher (#1391)"
 mat_setup
 export MAT_PHASE=qa
 out=$(run_mat 839 queue) ; rc=$?
 assert_eq "qa-model: exit 0" "0" "$rc"
 assert_eq "qa-model: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "qa-model: spawn-worker argv contains --model claude-sonnet-4-6" \
-  "--model claude-sonnet-4-6 839 $TMPDIR_TEST/project/worktrees/839-test" \
-  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
+wait_launch_log 1
+assert_eq "qa-model: launcher argv has NO --model (launcher derives it)" \
+  "839 $TMPDIR_TEST/project/worktrees/839-test" \
+  "$(cat "$TMPDIR_TEST/logs/launch-worker.log")"
 mat_teardown
 
-# --- phase→model integration: non-qa phase → no --model forwarded (Opus default)
-# An unmapped phase (implement) emits nothing from dispatch-phase-model, so no
-# --model flag is passed to dispatch-spawn-worker and the worker inherits the
-# session default (Opus).
-echo "Test: materialize-spawn implement phase → no --model forwarded (Opus default) (#1171)"
+echo "Test: materialize-spawn implement phase → router forwards NO --model (#1391)"
 mat_setup
 export MAT_PHASE=implement
 out=$(run_mat 839 queue) ; rc=$?
 assert_eq "implement-model: exit 0" "0" "$rc"
 assert_eq "implement-model: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "implement-model: spawn-worker argv has no --model flag" \
+wait_launch_log 1
+assert_eq "implement-model: launcher argv has no --model flag" \
   "839 $TMPDIR_TEST/project/worktrees/839-test" \
-  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
+  "$(cat "$TMPDIR_TEST/logs/launch-worker.log")"
 mat_teardown
 
-# --- phase→model integration: review phase → --model claude-sonnet-4-6 forwarded
-# When the recomputed PHASE is review, dispatch-materialize-spawn calls the real
-# dispatch-phase-model which emits claude-sonnet-4-6 (the review-fix orchestrator
-# runs on Sonnet; fix-authoring is delegated to an Opus subagent), so the
-# spawn-worker invocation must include --model claude-sonnet-4-6.
-echo "Test: materialize-spawn review phase → spawn-worker receives --model claude-sonnet-4-6 (#1172)"
+echo "Test: materialize-spawn review phase → router forwards NO --model to the launcher (#1391)"
 mat_setup
 export MAT_PHASE=review
 out=$(run_mat 839 queue) ; rc=$?
 assert_eq "review-model: exit 0" "0" "$rc"
 assert_eq "review-model: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "review-model: spawn-worker argv contains --model claude-sonnet-4-6" \
-  "--model claude-sonnet-4-6 839 $TMPDIR_TEST/project/worktrees/839-test" \
-  "$(cat "$TMPDIR_TEST/logs/spawn-worker.log")"
+wait_launch_log 1
+assert_eq "review-model: launcher argv has NO --model (launcher derives it)" \
+  "839 $TMPDIR_TEST/project/worktrees/839-test" \
+  "$(cat "$TMPDIR_TEST/logs/launch-worker.log")"
 mat_teardown
 
 echo "=== print_remote_access_block ==="


### PR DESCRIPTION
Closes #1391

## What

Sub-issue B of epic #1389. Introduces `dispatch-launch-worker` — a detached
per-target launcher script — and switches the router to detach it instead of
booting a `/dispatch-worker` model session per tick.

With the plan-phase relevance review already moved into `/plan-issue` (#1398)
and single-pass `--top` selection already in place (#1402), every
`dispatch-route` directive is now either mechanical or a single-skill
invocation — so phase initiation no longer needs a model session.

## How

**Unit 1 — `dispatch-launch-worker` (new script).** A plain shell process
launched detached (`setsid nohup … &`), so it owns an independent lifetime. It
routes once via `dispatch-route` (which provisions + merges `origin/main` +
CI-gates + derives the phase) and acts on the single directive:

- Real phase (`INVOKE /<skill>`) → derive the model (`/qa-fix → qa`,
  `/review-fix → review` via `dispatch-phase-model`; every other skill inherits
  Opus) and `exec` `dispatch-spawn-job` — the phase skill is born in the
  provisioned, merged worktree, preserving the merged-tree guarantee (#1047).
  The phase skill's Stop hook owns the chain heartbeat.
- Mechanical dispositions (`STOP done` / `waiting` / `wrong-worktree` /
  `provision-failed`, `PUSH-STRANDED`) → handled with **no model session**:
  park via `dispatch-apply-office-hours` where appropriate, clear the
  reservation, and fire `dispatch-spawn-tick` (a detached launcher fires no Stop
  hook, so it must tick the chain heartbeat itself).

**Unit 2 — router wiring.** `dispatch-materialize-spawn` now detaches
`dispatch-launch-worker` instead of spawning `claude --bg "/dispatch-worker"`
via `dispatch-spawn-worker`. The reservation marker is still written
**pre-detach, under the lock** (unchanged ordering), so a launcher that dies
before registering a session leaves a sweepable orphan (#1045 / #1048). The
detach is instant, so the lock releases after the loop without blocking on
provisioning. The router's `WORKER_MODEL` block is removed (the launcher derives
the model now); the #1109 `PHASE` done re-check stays.

### What goes to zero

A full model-session boot per tick — entirely, for mechanical dispositions; and
the provision-route-invoke prelude, for real phases.

## Coordination boundary

This issue stops *calling* `dispatch-spawn-worker` but leaves it and the
`/dispatch-worker` skill in place — sub-issue C (#1392) deletes them and retires
the absorbed directive prose. Selection (`dispatch-select-target`) is untouched
(#1317's domain, already merged).

## Tests

`test-dispatch-scripts.sh` covers every launcher disposition, the model
derivation, the reservation retain-vs-clear behavior, arg validation, the
detach-is-non-blocking assertion, and the `--gap N` fan-out. Full suite:
**2243/2243 passed, 0 failed**.
