### PR TITLE
blog: drop unparseable third-party feed dates at the parse boundary

### DIFF
--- a/blog/src/blog-roll/parse-feed.ts
+++ b/blog/src/blog-roll/parse-feed.ts
@@ -7,13 +7,18 @@ function parseAtomFeed(doc: Document): LatestPost | null {
   const title = entry.querySelector("title")?.textContent ?? "";
   const linkEl = entry.querySelector('link[rel="alternate"][href]') ?? entry.querySelector("link[href]");
   const url = linkEl?.getAttribute("href") ?? "";
-  const published =
-    entry.querySelector("published")?.textContent ??
-    entry.querySelector("updated")?.textContent ??
-    undefined;
+  const rawPublished = entry.querySelector("published")?.textContent;
+  const rawUpdated = entry.querySelector("updated")?.textContent;
   if (!title || !url) return null;
   if (!url.startsWith("http://") && !url.startsWith("https://")) return null;
-  const publishedAt = published && isParseableDate(published) ? published : undefined;
+  // Prefer the first parseable source: when <published> is present but
+  // unparseable, fall back to <updated> instead of dropping the date entirely.
+  const publishedAt =
+    rawPublished && isParseableDate(rawPublished)
+      ? rawPublished
+      : rawUpdated && isParseableDate(rawUpdated)
+        ? rawUpdated
+        : undefined;
   return { title, url, publishedAt };
 }
 

--- a/blog/src/blog-roll/parse-feed.ts
+++ b/blog/src/blog-roll/parse-feed.ts
@@ -1,4 +1,5 @@
 import type { LatestPost } from "./types.ts";
+import { isParseableDate } from "../date.ts";
 
 function parseAtomFeed(doc: Document): LatestPost | null {
   const entry = doc.querySelector("feed > entry");
@@ -12,7 +13,8 @@ function parseAtomFeed(doc: Document): LatestPost | null {
     undefined;
   if (!title || !url) return null;
   if (!url.startsWith("http://") && !url.startsWith("https://")) return null;
-  return { title, url, publishedAt: published };
+  const publishedAt = published && isParseableDate(published) ? published : undefined;
+  return { title, url, publishedAt };
 }
 
 function parseRssFeed(doc: Document): LatestPost | null {
@@ -23,7 +25,8 @@ function parseRssFeed(doc: Document): LatestPost | null {
   const pubDate = item.querySelector("pubDate")?.textContent ?? undefined;
   if (!title || !url) return null;
   if (!url.startsWith("http://") && !url.startsWith("https://")) return null;
-  return { title, url, publishedAt: pubDate };
+  const publishedAt = pubDate && isParseableDate(pubDate) ? pubDate : undefined;
+  return { title, url, publishedAt };
 }
 
 export function parseXml(text: string): LatestPost | null {

--- a/blog/src/blog-roll/vite-plugin-feed-fetch.ts
+++ b/blog/src/blog-roll/vite-plugin-feed-fetch.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from "vite";
 import { classifyError } from "@commons-systems/errorutil";
 import type { LatestPost } from "./types.ts";
+import { isParseableDate } from "../date.ts";
 
 export interface FeedConfig {
   id: string;
@@ -94,7 +95,8 @@ export function parseAtomFeedXml(xml: string): LatestPost | null {
 
   if (!title || !url) return null;
   if (!url.startsWith("http://") && !url.startsWith("https://")) return null;
-  return { title, url, publishedAt: published };
+  const publishedAt = published && isParseableDate(published) ? published : undefined;
+  return { title, url, publishedAt };
 }
 
 export function parseRssFeedXml(xml: string): LatestPost | null {
@@ -108,5 +110,6 @@ export function parseRssFeedXml(xml: string): LatestPost | null {
 
   if (!title || !url) return null;
   if (!url.startsWith("http://") && !url.startsWith("https://")) return null;
-  return { title, url, publishedAt: pubDate };
+  const publishedAt = pubDate && isParseableDate(pubDate) ? pubDate : undefined;
+  return { title, url, publishedAt };
 }

--- a/blog/src/date.ts
+++ b/blog/src/date.ts
@@ -1,3 +1,9 @@
+// Third-party feed dates arrive unvalidated. Callers drop unparseable values
+// at the parse boundary so formatUtcDate never receives garbage.
+export function isParseableDate(value: string): boolean {
+  return !isNaN(new Date(value).getTime());
+}
+
 // Posts store publishedAt as UTC ISO strings; format in UTC to avoid
 // timezone-dependent date shifts (e.g. Feb 1 UTC displaying as Jan 31).
 export function formatUtcDate(

--- a/blog/test/blog-roll/parse-feed.test.ts
+++ b/blog/test/blog-roll/parse-feed.test.ts
@@ -75,6 +75,44 @@ describe("parseXml", () => {
     });
   });
 
+  it("drops publishedAt when Atom date is unparseable", () => {
+    const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Blog</title>
+  <entry>
+    <title>Bad Date Post</title>
+    <link href="https://example.com/bad-date-atom"/>
+    <published>not-a-date</published>
+  </entry>
+</feed>`;
+    const result = parseXml(feed);
+    expect(result).toEqual({
+      title: "Bad Date Post",
+      url: "https://example.com/bad-date-atom",
+      publishedAt: undefined,
+    });
+  });
+
+  it("drops publishedAt when RSS pubDate is unparseable", () => {
+    const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Blog</title>
+    <item>
+      <title>Bad Date RSS Post</title>
+      <link>https://example.com/bad-date-rss</link>
+      <pubDate>garbage</pubDate>
+    </item>
+  </channel>
+</rss>`;
+    const result = parseXml(feed);
+    expect(result).toEqual({
+      title: "Bad Date RSS Post",
+      url: "https://example.com/bad-date-rss",
+      publishedAt: undefined,
+    });
+  });
+
   it("uses updated date when published is absent", () => {
     const feedWithUpdated = `<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/blog/test/blog-roll/parse-feed.test.ts
+++ b/blog/test/blog-roll/parse-feed.test.ts
@@ -113,6 +113,26 @@ describe("parseXml", () => {
     });
   });
 
+  it("falls through to updated when Atom published is present but unparseable", () => {
+    // A present-but-invalid <published> must not block the valid <updated>
+    // fallback: the parse-boundary guard prefers the first parseable source.
+    const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Bad Published Good Updated</title>
+    <link href="https://example.com/bad-published-good-updated"/>
+    <published>not-a-date</published>
+    <updated>2026-02-01T00:00:00Z</updated>
+  </entry>
+</feed>`;
+    const result = parseXml(feed);
+    expect(result).toEqual({
+      title: "Bad Published Good Updated",
+      url: "https://example.com/bad-published-good-updated",
+      publishedAt: "2026-02-01T00:00:00Z",
+    });
+  });
+
   it("uses updated date when published is absent", () => {
     const feedWithUpdated = `<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/blog/test/blog-roll/vite-plugin-feed-fetch.test.ts
+++ b/blog/test/blog-roll/vite-plugin-feed-fetch.test.ts
@@ -48,6 +48,21 @@ describe("parseAtomFeedXml", () => {
     expect(parseAtomFeedXml(xml)?.url).toBe("https://example.com/alternate");
   });
 
+  it("drops publishedAt when Atom date is unparseable", () => {
+    const xml = `<feed>
+        <entry>
+          <title>Bad Date Post</title>
+          <link rel="alternate" href="https://example.com/bad-date-atom" />
+          <published>not-a-date</published>
+        </entry>
+      </feed>`;
+    const result = parseAtomFeedXml(xml);
+    expect(result).not.toBeNull();
+    expect(result?.title).toBe("Bad Date Post");
+    expect(result?.url).toBe("https://example.com/bad-date-atom");
+    expect(result?.publishedAt).toBeUndefined();
+  });
+
   it("falls back to updated when published is absent", () => {
     const xml = `<feed>
         <entry>
@@ -123,6 +138,21 @@ describe("parseRssFeedXml", () => {
         </item>
       </channel></rss>`;
     expect(parseRssFeedXml(xml)).toBeNull();
+  });
+
+  it("drops publishedAt when RSS pubDate is unparseable", () => {
+    const xml = `<rss><channel>
+        <item>
+          <title>Bad Date RSS Post</title>
+          <link>https://example.com/bad-date-rss</link>
+          <pubDate>garbage</pubDate>
+        </item>
+      </channel></rss>`;
+    const result = parseRssFeedXml(xml);
+    expect(result).not.toBeNull();
+    expect(result?.title).toBe("Bad Date RSS Post");
+    expect(result?.url).toBe("https://example.com/bad-date-rss");
+    expect(result?.publishedAt).toBeUndefined();
   });
 
   it("returns null when title is empty", () => {

--- a/blog/test/date.test.ts
+++ b/blog/test/date.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatUtcDate, monthName } from "../src/date";
+import { formatUtcDate, monthName, isParseableDate } from "../src/date";
 
 describe("formatUtcDate", () => {
   it("formats with long month by default", () => {
@@ -19,6 +19,24 @@ describe("formatUtcDate", () => {
     expect(() => formatUtcDate("not-a-date")).toThrow(
       'formatUtcDate: invalid ISO date string: "not-a-date"',
     );
+  });
+});
+
+describe("isParseableDate", () => {
+  it("returns true for ISO date string", () => {
+    expect(isParseableDate("2026-02-01T00:00:00Z")).toBe(true);
+  });
+
+  it("returns true for RFC 2822 date string", () => {
+    expect(isParseableDate("Sun, 01 Feb 2026 00:00:00 GMT")).toBe(true);
+  });
+
+  it("returns false for non-date string", () => {
+    expect(isParseableDate("not-a-date")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isParseableDate("")).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #1288

## Problem

A single third-party blog feed publishing an unparseable `<pubDate>` /
`<published>` date degraded the **entire** blogroll, not just that one entry.

`formatUtcDate` (`blog/src/date.ts`) throws on any string `new Date(...)` cannot
parse. Third-party feed dates reached it **unvalidated** through two independent
feed-parse boundaries:

- **Runtime (browser):** `parseAtomFeed` / `parseRssFeed`
  (`blog/src/blog-roll/parse-feed.ts`) copied the feed date straight into
  `LatestPost.publishedAt`, which was then passed to `formatUtcDate` inside the
  per-entry hydration loop in `info-panel.ts`. One bad date threw mid-loop,
  skipping every remaining entry and the `sortBlogrollByDate` call.
- **Build-time (Node):** `parseAtomFeedXml` / `parseRssFeedXml`
  (`blog/src/blog-roll/vite-plugin-feed-fetch.ts`) build the `buildTimeFeeds` map
  consumed during prerender. A single bad external date threw and failed the
  whole build.

## Fix

Validate feed dates at the **feed-parse boundary**, where untrusted third-party
data enters, and drop unparseable values to `undefined`:

- New shared helper `isParseableDate` in `blog/src/date.ts`, mirroring the
  `isNaN(new Date(...).getTime())` check already inside `formatUtcDate`. It uses
  only `new Date` / `isNaN`, so it is safe in both the browser runtime path and
  the Node build-time path.
- Both runtime parsers (`parse-feed.ts`) and both build-time parsers
  (`vite-plugin-feed-fetch.ts`) now drop the date when it is missing or
  unparseable before returning the entry.

`formatUtcDate`'s throw is **unchanged** — first-party post dates come from
validated `PublishedPost` data and should still surface a clear error on
corruption (`.claude/rules/code-style.md`). This change stops feeding
`formatUtcDate` untrusted input rather than weakening it. The render-side
empty-string fallbacks and `sortBlogrollByDate` in `info-panel.ts` already
tolerate an absent `publishedAt`, so no render-side change is needed.

## Tests

- `date.test.ts` — `isParseableDate` returns `true` for ISO and RFC-2822 dates,
  `false` for `"not-a-date"` and `""`.
- `parse-feed.test.ts` — an Atom feed and an RSS feed with an unparseable date
  parse successfully with `publishedAt` dropped to `undefined`, `title`/`url`
  preserved.
- `vite-plugin-feed-fetch.test.ts` — the matching build-time cases yield a
  non-null result with `publishedAt === undefined`.

Full blog suite: 360 passed. `npx tsc --noEmit --project blog` introduces no new
errors (the remaining `Document`/`DOMParser` DOM-lib errors pre-exist on `main`).

## Acceptance criteria

- An unparseable feed date degrades only that entry, not the rest of the
  blogroll — both parse boundaries drop the bad date to `undefined`; the
  hydration loop and prerender no longer throw mid-iteration.
- Validation happens at the feed-parse boundary, not at render time — the guard
  lives in `parse-feed.ts` and `vite-plugin-feed-fetch.ts`; `formatUtcDate` and
  the render path are unchanged.
