### PR TITLE
router: only hijack same-origin clicks that hit a real route; honor download/target and skip protocol-relative hrefs

### DIFF
--- a/router/src/index.ts
+++ b/router/src/index.ts
@@ -119,7 +119,9 @@ export function createHistoryRouter(
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     const href = anchor.getAttribute("href");
     if (!href || !href.startsWith("/") || href.startsWith("//")) return;
-    const path = new URL(href, location.origin).pathname.replace(/\/$/, "") || "/";
+    const url = new URL(href, location.origin);
+    if (url.origin !== location.origin) return;
+    const path = url.pathname.replace(/\/$/, "") || "/";
     if (!matchRoute(routes, path)) return;
     e.preventDefault();
     history.pushState({}, "", href);

--- a/router/src/index.ts
+++ b/router/src/index.ts
@@ -25,10 +25,10 @@ export interface Router {
   showTerminalError(html: string): void;
 }
 
-function matchRoute(routes: [Route, ...Route[]], path: string): Route {
+function matchRoute(routes: [Route, ...Route[]], path: string): Route | undefined {
   return routes.find((r) =>
     typeof r.path === "string" ? r.path === path : r.path.test(path),
-  ) ?? routes[0];
+  );
 }
 
 /**
@@ -54,7 +54,7 @@ function createNavigator(
     } catch (e) {
       if (!deferProgrammerError(e)) reportError(e);
     }
-    const route = matchRoute(routes, path);
+    const route = matchRoute(routes, path) ?? routes[0];
     try {
       const html = await route.render(path);
       if (id === navigationId) {
@@ -114,10 +114,13 @@ export function createHistoryRouter(
     if (e.button !== 0) return;
     const anchor = (e.target as Element).closest("a");
     if (!anchor) return;
-    if (anchor.getAttribute("target") === "_blank") return;
+    if (anchor.hasAttribute("download")) return;
+    if (anchor.getAttribute("target")) return;
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     const href = anchor.getAttribute("href");
-    if (!href || !href.startsWith("/")) return;
+    if (!href || !href.startsWith("/") || href.startsWith("//")) return;
+    const path = new URL(href, location.origin).pathname.replace(/\/$/, "") || "/";
+    if (!matchRoute(routes, path)) return;
     e.preventDefault();
     history.pushState({}, "", href);
     void nav.navigate();

--- a/router/test/router.test.ts
+++ b/router/test/router.test.ts
@@ -549,6 +549,31 @@ describe("createHistoryRouter", () => {
     }
   });
 
+  it("does not intercept backslash-prefixed href that resolves cross-origin", async () => {
+    router = createHistoryRouter(outlet, routes);
+    await vi.waitFor(() => {
+      expect(outlet.innerHTML).toBe("<h2>Home</h2>");
+    });
+
+    const pushStateSpy = vi.spyOn(history, "pushState");
+    const anchor = document.createElement("a");
+    // "/\evil.com/about" — passes startsWith("/") && !startsWith("//")
+    // string guards but the WHATWG URL parser normalizes the backslash to a
+    // slash, resolving cross-origin to //evil.com/about.
+    anchor.setAttribute("href", "/" + "\\" + "evil.com/about");
+    document.body.appendChild(anchor);
+
+    try {
+      expect(() => anchor.click()).not.toThrow();
+      await new Promise((r) => setTimeout(r, 10));
+      expect(pushStateSpy).not.toHaveBeenCalled();
+      expect(outlet.innerHTML).toBe("<h2>Home</h2>");
+    } finally {
+      document.body.removeChild(anchor);
+      pushStateSpy.mockRestore();
+    }
+  });
+
   it("does not intercept unknown same-origin path with no matching route", async () => {
     router = createHistoryRouter(outlet, routes);
     await vi.waitFor(() => {

--- a/router/test/router.test.ts
+++ b/router/test/router.test.ts
@@ -480,4 +480,117 @@ describe("createHistoryRouter", () => {
     await new Promise((r) => setTimeout(r, 10));
     expect(outlet.innerHTML).toBe("<p>Fatal error</p>");
   });
+
+  it("does not intercept anchor with download attribute", async () => {
+    router = createHistoryRouter(outlet, routes);
+    await vi.waitFor(() => {
+      expect(outlet.innerHTML).toBe("<h2>Home</h2>");
+    });
+
+    const pushStateSpy = vi.spyOn(history, "pushState");
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", "/about");
+    anchor.setAttribute("download", "");
+    document.body.appendChild(anchor);
+
+    try {
+      anchor.click();
+      await new Promise((r) => setTimeout(r, 10));
+      expect(pushStateSpy).not.toHaveBeenCalled();
+      expect(outlet.innerHTML).toBe("<h2>Home</h2>");
+    } finally {
+      document.body.removeChild(anchor);
+      pushStateSpy.mockRestore();
+    }
+  });
+
+  it("does not intercept anchor with target=_self", async () => {
+    router = createHistoryRouter(outlet, routes);
+    await vi.waitFor(() => {
+      expect(outlet.innerHTML).toBe("<h2>Home</h2>");
+    });
+
+    const pushStateSpy = vi.spyOn(history, "pushState");
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", "/about");
+    anchor.setAttribute("target", "_self");
+    document.body.appendChild(anchor);
+
+    try {
+      anchor.click();
+      await new Promise((r) => setTimeout(r, 10));
+      expect(pushStateSpy).not.toHaveBeenCalled();
+      expect(outlet.innerHTML).toBe("<h2>Home</h2>");
+    } finally {
+      document.body.removeChild(anchor);
+      pushStateSpy.mockRestore();
+    }
+  });
+
+  it("does not intercept protocol-relative href and does not throw", async () => {
+    router = createHistoryRouter(outlet, routes);
+    await vi.waitFor(() => {
+      expect(outlet.innerHTML).toBe("<h2>Home</h2>");
+    });
+
+    const pushStateSpy = vi.spyOn(history, "pushState");
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", "//external.com/path");
+    document.body.appendChild(anchor);
+
+    try {
+      expect(() => anchor.click()).not.toThrow();
+      await new Promise((r) => setTimeout(r, 10));
+      expect(pushStateSpy).not.toHaveBeenCalled();
+      expect(outlet.innerHTML).toBe("<h2>Home</h2>");
+    } finally {
+      document.body.removeChild(anchor);
+      pushStateSpy.mockRestore();
+    }
+  });
+
+  it("does not intercept unknown same-origin path with no matching route", async () => {
+    router = createHistoryRouter(outlet, routes);
+    await vi.waitFor(() => {
+      expect(outlet.innerHTML).toBe("<h2>Home</h2>");
+    });
+
+    const pushStateSpy = vi.spyOn(history, "pushState");
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", "/feed.xml");
+    document.body.appendChild(anchor);
+
+    try {
+      anchor.click();
+      await new Promise((r) => setTimeout(r, 10));
+      expect(pushStateSpy).not.toHaveBeenCalled();
+      expect(outlet.innerHTML).toBe("<h2>Home</h2>");
+    } finally {
+      document.body.removeChild(anchor);
+      pushStateSpy.mockRestore();
+    }
+  });
+
+  it("intercepts same-origin anchor to a real route (positive control)", async () => {
+    router = createHistoryRouter(outlet, routes);
+    await vi.waitFor(() => {
+      expect(outlet.innerHTML).toBe("<h2>Home</h2>");
+    });
+
+    const pushStateSpy = vi.spyOn(history, "pushState");
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", "/about");
+    document.body.appendChild(anchor);
+
+    try {
+      anchor.click();
+      expect(pushStateSpy).toHaveBeenCalledWith({}, "", "/about");
+      await vi.waitFor(() => {
+        expect(outlet.innerHTML).toBe("<h2>About</h2>");
+      });
+    } finally {
+      document.body.removeChild(anchor);
+      pushStateSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
Closes #1291

## Problem

The router's document-level click handler (`router/src/index.ts`) hijacked
**every** same-origin absolute-path anchor click for client-side navigation.
Two defects fell out of that over-broad claim:

- **Non-SPA links hijacked.** `matchRoute` fell back to `routes[0]` for any
  unmatched path, so the handler couldn't tell a real route from an unknown
  path. A link to a real hosted file was swallowed and the home route rendered
  at that URL. Reachable today: the blog info panel renders the RSS
  `<a href="/feed.xml">` (fellspiral passes `/feed.xml`); clicking it pushed
  `/feed.xml` into history and rendered home instead of opening the feed. There
  was also no opt-out — `download` and any non-`_blank` `target` were ignored.
- **Protocol-relative crash.** `href.startsWith("/")` also matched
  `//host/path`. The handler called `preventDefault()` then
  `history.pushState({}, "", href)`, which throws an uncaught `SecurityError`
  for a cross-origin URL. Content-driven anchors (Firestore post bodies) make
  this reachable.

## Change

The router now intercepts a click **only** when the href is a same-origin
absolute path that hits a real (non-fallback) route and carries no
native-navigation opt-out; everything else falls through to the browser.

- `matchRoute` now returns `Route | undefined` — the `?? routes[0]` fallback is
  dropped from the function and moved to its sole call site inside `navigate`,
  so unknown *visited* paths still render the home route exactly as before.
- `onClick` now: skips anchors with a `download` attribute, skips any non-empty
  `target` (replacing the `=== "_blank"` check; still covers `_blank`), skips
  protocol-relative `//host/...` hrefs (fixing the `SecurityError`), and parses
  the path (mirroring `parsePath`'s trailing-slash normalization) to require a
  non-fallback `matchRoute` hit before calling `pushState`. `/feed.xml` now
  falls through to native navigation.

## Tests

Five cases added in `router/test/router.test.ts`, asserting native
fall-through via a `history.pushState` spy (the outlet alone can't distinguish
"intercepted to home" from "left on home"): `download` attribute, `target="_self"`,
protocol-relative `//external.com/path` (regression guard for the
`SecurityError`), unknown same-origin `/feed.xml` (the RSS-hijack fix), and a
positive control confirming a real `/about` route is still intercepted. All
46 router tests pass; the package type-checks with no new errors.
