### PR TITLE
idbutil: close on versionchange, stop onblocked leak, surface onUpgrade errors

### DIFF
--- a/idbutil/src/connection.ts
+++ b/idbutil/src/connection.ts
@@ -24,19 +24,28 @@ export function createDbConnection(config: DbConnectionConfig): {
   function openDb(): Promise<IDBDatabase> {
     if (!dbPromise) {
       dbPromise = new Promise((resolve, reject) => {
+        let upgradeError: unknown;
         const request = indexedDB.open(config.name, config.version);
         request.onupgradeneeded = (event) => {
-          config.onUpgrade(request.result, event.oldVersion);
+          try {
+            config.onUpgrade(request.result, event.oldVersion);
+          } catch (err) {
+            upgradeError = err;
+            request.transaction?.abort();
+          }
         };
         request.onsuccess = () => {
-          request.result.onclose = () => { dbPromise = null; };
-          resolve(request.result);
+          const db = request.result;
+          db.onclose = () => { dbPromise = null; };
+          db.onversionchange = () => { db.close(); dbPromise = null; };
+          resolve(db);
         };
         request.onblocked = () => {
-          dbPromise = null;
-          reject(new Error("Database upgrade blocked. Close other tabs using this app and try again."));
+          console.warn(
+            `IndexedDB upgrade of "${config.name}" is blocked by another connection; waiting for it to close.`,
+          );
         };
-        request.onerror = () => { dbPromise = null; reject(request.error); };
+        request.onerror = () => { dbPromise = null; reject(upgradeError ?? request.error); };
       });
     }
     return dbPromise;

--- a/idbutil/test/connection.test.ts
+++ b/idbutil/test/connection.test.ts
@@ -88,6 +88,91 @@ describe("openDb", () => {
     expect(db2).not.toBe(db1);
     await closeDb();
   });
+
+  it("onversionchange closes the connection, clears the cache, and lets another tab upgrade", async () => {
+    const name = uniqueDbName();
+    // Tab 1: open at v1 and hold the connection.
+    const tab1 = createDbConnection({
+      name,
+      version: 1,
+      onUpgrade(db) { db.createObjectStore("s"); },
+    });
+    const db1 = await tab1.openDb();
+    expect(typeof db1.onversionchange).toBe("function");
+    // Wrap the wired handler so we can observe it fired while keeping its
+    // close-and-clear-cache behavior.
+    const installed = db1.onversionchange!;
+    const versionchangeSpy = vi.fn();
+    db1.onversionchange = (event) => {
+      versionchangeSpy();
+      return installed.call(db1, event);
+    };
+
+    // Tab 2: open the same DB name at v2. This fires db1's onversionchange,
+    // which closes db1 so the v2 upgrade is not permanently blocked.
+    const tab2 = createDbConnection({
+      name,
+      version: 2,
+      onUpgrade(db) {
+        if (!db.objectStoreNames.contains("s2")) db.createObjectStore("s2");
+      },
+    });
+    const db2 = await tab2.openDb();
+    expect(db2.version).toBe(2);
+    // db1's onversionchange fired (the upgrade was not permanently blocked).
+    expect(versionchangeSpy).toHaveBeenCalled();
+
+    // The wired handler cleared tab1's cache. A subsequent openDb() on a
+    // connection for the same name returns a fresh connection rather than the
+    // closed db1. (Use a v2-configured connection because the DB has been
+    // upgraded; an old-version open would be rejected by IndexedDB.)
+    const tab1Reopened = createDbConnection({
+      name,
+      version: 2,
+      onUpgrade() {},
+    });
+    const db1b = await tab1Reopened.openDb();
+    expect(db1b).not.toBe(db1);
+    expect(db1b.version).toBe(2);
+
+    await tab1.closeDb();
+    await tab1Reopened.closeDb();
+    await tab2.closeDb();
+  });
+
+  it("onblocked does not reject an open that later succeeds", async () => {
+    const name = uniqueDbName();
+    // Tab 1 holds a v1 connection open. We deliberately do NOT let its
+    // onversionchange close it immediately — instead we override the handler
+    // to close after a tick, so the v2 open is briefly blocked and then unblocks.
+    const tab1 = createDbConnection({
+      name,
+      version: 1,
+      onUpgrade(db) { db.createObjectStore("s"); },
+    });
+    const db1 = await tab1.openDb();
+    db1.onversionchange = () => {
+      // Defer the close so the upgrading open sees a blocked state first.
+      setTimeout(() => db1.close(), 0);
+    };
+
+    const tab2 = createDbConnection({
+      name,
+      version: 2,
+      onUpgrade(db) {
+        if (!db.objectStoreNames.contains("s2")) db.createObjectStore("s2");
+      },
+    });
+
+    // The upgrading open must resolve to a usable IDBDatabase, not reject,
+    // even though it may pass through a transient blocked state.
+    const db2 = await tab2.openDb();
+    expect(db2).toBeInstanceOf(IDBDatabase);
+    expect(db2.version).toBe(2);
+
+    await tab1.closeDb();
+    await tab2.closeDb();
+  });
 });
 
 describe("closeDb", () => {
@@ -126,7 +211,8 @@ describe("closeDb", () => {
       },
     });
 
-    await expect(openDb()).rejects.toThrow();
+    // openDb rejects with the original onUpgrade error, not a generic AbortError.
+    await expect(openDb()).rejects.toThrow("upgrade failed");
     // closeDb should not throw even though openDb failed
     await closeDb();
     reportSpy.mockRestore();


### PR DESCRIPTION
Closes #1292

## Summary

`createDbConnection` in `idbutil/src/connection.ts` memoizes a versioned
IndexedDB connection. Its open-request handlers had three defects that broke
multi-tab schema upgrades. This PR fixes all three and covers them with tests.

## Defects fixed

1. **No `onversionchange` handler.** An open connection never closed when
   another tab opened the same DB at a bumped `version`, so after a deploy that
   bumps the version (budget is already at v5), an old-code tab permanently
   blocked the new tab's upgrade. Now `request.onsuccess` wires
   `db.onversionchange = () => { db.close(); dbPromise = null; }` — the
   connection releases itself and clears the cached promise. (`close()` does not
   fire `onclose`, so the promise is nulled explicitly.)

2. **`onblocked` leak.** `blocked` does not mean the open failed — the request
   stays pending and later fires `onsuccess`. The old handler rejected and
   nulled `dbPromise`, so the eventual `resolve` was a no-op and the now-open
   `IDBDatabase` leaked, itself a future blocker. `onblocked` now only
   `console.warn`s the transient block and settles nothing; the request settles
   once the other tabs' `onversionchange` handlers close their connections.

3. **`onUpgrade` errors masked.** When `config.onUpgrade` threw, the
   versionchange transaction aborted and `onerror` fired with a generic
   `AbortError`. The thrown cause is now captured in `onupgradeneeded`, the
   transaction is aborted explicitly, and `onerror` rejects with the original
   cause.

## Tests

- `onversionchange` closes the connection, clears the cache, and lets another
  tab upgrade (v1 → v2).
- `onblocked` does not reject an open that later succeeds.
- Strengthened the existing upgrade-throws test to assert the original
  `"upgrade failed"` message rather than a generic abort error.

`npx vitest run --project idbutil` — 31 passed; type-check clean. The public
`{ openDb, closeDb }` shape is unchanged, so no consumer edits are needed.
