### PR TITLE
idbutil: reject oversized blobs and evict on the replace delta

### DIFF
--- a/idbutil/src/lru-blob-cache.ts
+++ b/idbutil/src/lru-blob-cache.ts
@@ -87,15 +87,24 @@ export function createLruBlobCache(config: LruBlobCacheConfig): LruBlobCache {
     };
   }
 
-  async function getTotalSize(db: IDBDatabase): Promise<number> {
+  async function getTotalAndOldSize(
+    db: IDBDatabase,
+    key: string,
+  ): Promise<{ totalSize: number; oldSize: number }> {
     return new Promise((resolve, reject) => {
       const tx = db.transaction(META_STORE, "readonly");
-      const req = tx.objectStore(META_STORE).get(TOTAL_KEY);
-      req.onsuccess = () => {
-        const entry = req.result as MetaEntry | undefined;
-        resolve(entry ? entry.size : 0);
+      const store = tx.objectStore(META_STORE);
+      const totalReq = store.get(TOTAL_KEY);
+      const oldReq = store.get(key);
+      tx.oncomplete = () => {
+        const totalEntry = totalReq.result as MetaEntry | undefined;
+        const oldEntry = oldReq.result as MetaEntry | undefined;
+        resolve({
+          totalSize: totalEntry ? totalEntry.size : 0,
+          oldSize: oldEntry ? oldEntry.size : 0,
+        });
       };
-      req.onerror = () => reject(req.error);
+      tx.onerror = () => reject(tx.error);
     });
   }
 
@@ -121,10 +130,11 @@ export function createLruBlobCache(config: LruBlobCacheConfig): LruBlobCache {
    * the subsequent put in the caller (putEntry); concurrent writes may briefly
    * exceed the cap, which is acceptable for a best-effort cache.
    */
-  async function evictIfNeeded(db: IDBDatabase, incomingSize: number): Promise<void> {
-    const totalSize = await getTotalSize(db);
+  async function evictIfNeeded(db: IDBDatabase, key: string, incomingSize: number): Promise<void> {
+    const { totalSize, oldSize } = await getTotalAndOldSize(db, key);
+    const delta = incomingSize - oldSize;
 
-    if (totalSize + incomingSize <= maxBytes) return;
+    if (totalSize + delta <= maxBytes) return;
 
     const evictTx = db.transaction([DATA_STORE, META_STORE], "readwrite");
     const metaStore = evictTx.objectStore(META_STORE);
@@ -132,7 +142,7 @@ export function createLruBlobCache(config: LruBlobCacheConfig): LruBlobCache {
     const evictIndex = metaStore.index("lastAccessed");
 
     await new Promise<void>((resolve, reject) => {
-      let remaining = totalSize + incomingSize - maxBytes;
+      let remaining = totalSize + delta - maxBytes;
       let evictedSize = 0;
       const req = evictIndex.openCursor();
       req.onsuccess = () => {
@@ -146,7 +156,7 @@ export function createLruBlobCache(config: LruBlobCacheConfig): LruBlobCache {
           return;
         }
         const entry = cursor.value as MetaEntry;
-        if (entry.key === TOTAL_KEY) { cursor.continue(); return; }
+        if (entry.key === TOTAL_KEY || entry.key === key) { cursor.continue(); return; }
         remaining -= entry.size;
         evictedSize += entry.size;
         dataStore.delete(entry.key);
@@ -178,8 +188,13 @@ export function createLruBlobCache(config: LruBlobCacheConfig): LruBlobCache {
   }
 
   async function putEntry(key: string, data: ArrayBuffer | Uint8Array): Promise<void> {
+    if (data.byteLength > maxBytes) {
+      throw new Error(
+        `Blob (${data.byteLength} bytes) exceeds cache maxBytes (${maxBytes}); not cached`,
+      );
+    }
     const db = await openDb();
-    await evictIfNeeded(db, data.byteLength);
+    await evictIfNeeded(db, key, data.byteLength);
     return new Promise((resolve, reject) => {
       const tx = db.transaction([DATA_STORE, META_STORE], "readwrite");
       const dataStore = tx.objectStore(DATA_STORE);

--- a/idbutil/test/lru-blob-cache.test.ts
+++ b/idbutil/test/lru-blob-cache.test.ts
@@ -163,6 +163,33 @@ describe("LRU eviction", () => {
     vi.restoreAllMocks();
     await cache.closeDb();
   });
+
+  it("rejects an oversized entry without evicting the cache", async () => {
+    const cache = createLruBlobCache({ name: uniqueDbName(), version: 1, maxBytes: 1024 });
+    await cache.putEntry("keep", new ArrayBuffer(500));
+    await expect(cache.putEntry("toobig", new ArrayBuffer(2048))).rejects.toThrow();
+    expect(await cache.getEntry("keep")).not.toBeNull();
+    expect(await cache.getEntry("toobig")).toBeNull();
+    const stats = await cache.getStats();
+    expect(stats.totalBytes).toBe(500);
+    expect(stats.entryCount).toBe(1);
+    await cache.closeDb();
+  });
+
+  it("replace evicts on the size delta, not gross incoming size", async () => {
+    const cache = createLruBlobCache({ name: uniqueDbName(), version: 1, maxBytes: 250 });
+    vi.spyOn(Date, "now").mockReturnValue(1000);
+    await cache.putEntry("b", new ArrayBuffer(100));
+    vi.mocked(Date.now).mockReturnValue(2000);
+    await cache.putEntry("a", new ArrayBuffer(100));
+    vi.mocked(Date.now).mockReturnValue(3000);
+    await cache.putEntry("a", new ArrayBuffer(120));
+    expect(await cache.getEntry("b")).not.toBeNull();
+    expect(await cache.getEntry("a")).not.toBeNull();
+    expect((await cache.getStats()).totalBytes).toBe(220);
+    vi.restoreAllMocks();
+    await cache.closeDb();
+  });
 });
 
 describe("clearCache", () => {


### PR DESCRIPTION
Closes #1294

## Problem

`idbutil/src/lru-blob-cache.ts` — the shared IndexedDB LRU blob cache used by `print` and `audio` — had two accounting defects in its eviction path:

1. **An oversized blob wiped the entire cache.** When `data.byteLength > maxBytes`, the eviction target `totalSize + incomingSize - maxBytes` exceeded `totalSize`, so the eviction cursor deleted *every* existing entry. `putEntry` then wrote the oversized blob anyway, leaving `totalBytes > maxBytes`. One un-storable item destroyed the whole cache.

2. **Replacing a key over-evicted.** `putEntry` passed the gross incoming size to `evictIfNeeded` instead of the net delta (`newSize - oldSize`), so a replace evicted as if the whole incoming blob were new — discarding more entries than the update required.

## Fix

- **Reject oversized blobs.** `putEntry` now throws as its first statement when `data.byteLength > maxBytes` (strict `>`, so a blob exactly at the cap still fits), before opening the DB or evicting — the cache is untouched on rejection. All call sites already `.catch()` the best-effort write, so the rejection surfaces to `reportError`/`logError` cleanly (per `.claude/rules/code-style.md`: prefer clear errors over silent fallbacks).

- **Evict on the net delta.** `evictIfNeeded` now takes the `key`, reads both the `__total__` sentinel and the key's current size in one readonly transaction (`getTotalAndOldSize`), and computes `delta = incomingSize - oldSize`. The early-return guard and eviction target both use `totalSize + delta`. The eviction cursor also skips the replaced `key` — required so the put's later re-read of `oldSize` stays consistent and the total can't overshoot `maxBytes`.

`getTotalSize` was removed: `evictIfNeeded` was its only caller, and `getStats` has its own inline `__total__` read.

## Tests

Two new cases in `idbutil/test/lru-blob-cache.test.ts` (both fail against the old code):

- *rejects an oversized entry without evicting the cache* — verifies the existing entry survives, the oversized blob is not stored, and `totalBytes`/`entryCount` are unchanged.
- *replace evicts on the size delta, not gross incoming size* — cap 250, `b`=100 + `a`=100, then replace `a`→120 (delta 20, fits): `b` survives, total ends at 220.

Full suite: 31 passed. `tsc --noEmit` clean for both `audio` and `print` (idbutil is a source-export package with no own tsconfig; its consumers type-check `lru-blob-cache.ts`).
