### PR TITLE
audio: gate playTrack async resolves behind a generation token

### DIFF
--- a/audio/src/player.ts
+++ b/audio/src/player.ts
@@ -28,6 +28,7 @@ export function initPlayer(
   const queue: PlayRequest[] = [];
   let currentIndex = -1;
   let currentObjectUrl: string | null = null;
+  let playGeneration = 0;
 
   function renderPlaylist(): void {
     if (queue.length === 0) {
@@ -62,11 +63,16 @@ export function initPlayer(
   function playTrack(index: number): void {
     const item = queue[index];
     if (!item) throw new Error(`playTrack: index ${index} out of range (queue length ${queue.length})`);
+    const generation = ++playGeneration;
     currentIndex = index;
     renderPlaylist();
     revokeCurrentObjectUrl();
     resolveAudioSource(item.storagePath)
       .then((url) => {
+        if (generation !== playGeneration) {
+          URL.revokeObjectURL(url);
+          return;
+        }
         currentObjectUrl = url;
         audioEl.src = url;
         audioEl.play().catch((err) => {
@@ -77,11 +83,13 @@ export function initPlayer(
       .catch((err) => {
         if (deferProgrammerError(err)) return;
         logError(err, { operation: "audio-source-resolve", storagePath: item.storagePath });
-        advanceOrStop(index);
+        if (generation !== playGeneration) return;
+        advanceOrStop(currentIndex);
       });
   }
 
   function stop(): void {
+    playGeneration++;
     currentIndex = -1;
     revokeCurrentObjectUrl();
     audioEl.pause();

--- a/audio/test/player.test.ts
+++ b/audio/test/player.test.ts
@@ -313,12 +313,12 @@ describe("initPlayer", () => {
 
       // now resolve the pending promise — should be treated as stale
       deferred[0]!.resolve("blob:http://localhost/t1-blob");
-      await Promise.resolve();
-      await Promise.resolve();
 
+      await vi.waitFor(() => {
+        expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:http://localhost/t1-blob");
+      });
       expect(audioEl.play).not.toHaveBeenCalled();
       expect(audioEl.getAttribute("src")).toBeNull();
-      expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:http://localhost/t1-blob");
     });
 
     it("out-of-order resolve does not desync: gen-1 blob is revoked and src ends on gen-2 blob", async () => {
@@ -338,17 +338,19 @@ describe("initPlayer", () => {
 
       // resolve gen-2 first, then gen-1
       deferred[1]!.resolve("blob:http://localhost/t2-blob");
-      await Promise.resolve();
-      await Promise.resolve();
+      await vi.waitFor(() => {
+        // src should be the gen-2 blob
+        expect(audioEl.src).toContain("t2-blob");
+      });
 
       deferred[0]!.resolve("blob:http://localhost/t1-blob");
-      await Promise.resolve();
-      await Promise.resolve();
+      await vi.waitFor(() => {
+        // gen-1 blob was never stored; it should have been revoked as stale
+        expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:http://localhost/t1-blob");
+      });
 
-      // src should be the gen-2 blob
+      // src should still be the gen-2 blob
       expect(audioEl.src).toContain("t2-blob");
-      // gen-1 blob was never stored; it should have been revoked as stale
-      expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:http://localhost/t1-blob");
       // gen-1 blob was never assigned to src
       expect(audioEl.src).not.toContain("t1-blob");
     });
@@ -370,17 +372,19 @@ describe("initPlayer", () => {
 
       // reject gen-1 promise (stale) — should not advance
       const playCallsBefore = (audioEl.play as ReturnType<typeof vi.fn>).mock.calls.length;
+      // after the remove there are 2 pending resolves (gen-1 for track1, gen-2 for track2)
+      expect(deferred).toHaveLength(2);
       deferred[0]!.reject(new Error("network error"));
-      await Promise.resolve();
-      await Promise.resolve();
 
-      // no additional play calls from the stale failure
-      expect((audioEl.play as ReturnType<typeof vi.fn>).mock.calls.length).toBe(playCallsBefore);
+      // drain the catch chain, then assert the stale reject did NOT advance the
+      // queue — a stale advance would call playTrack(track3), pushing a 3rd deferred.
+      await vi.waitFor(() => {
+        expect((audioEl.play as ReturnType<typeof vi.fn>).mock.calls.length).toBe(playCallsBefore);
+      });
+      expect(deferred).toHaveLength(2);
 
       // now reject gen-2 (live) — should advance from live currentIndex (track2 -> track3)
       deferred[1]!.reject(new Error("network error"));
-      await Promise.resolve();
-      await Promise.resolve();
 
       // gen-3 resolve (track3) is now pending; resolve it to confirm advancement happened
       await vi.waitFor(() => {

--- a/audio/test/player.test.ts
+++ b/audio/test/player.test.ts
@@ -297,4 +297,100 @@ describe("initPlayer", () => {
       expect(playlistEl.querySelector(".playlist-empty")).not.toBeNull();
     });
   });
+
+  describe("generation token", () => {
+    it("play-after-remove: stale resolve does not start playback and revokes the blob", async () => {
+      const deferred: Array<{ resolve: (u: string) => void; reject: (e: unknown) => void }> = [];
+      mockResolveAudioSource.mockImplementation(
+        () => new Promise<string>((resolve, reject) => deferred.push({ resolve, reject })),
+      );
+
+      const player = initPlayer(audioEl, playlistEl);
+      player.add(track1);
+
+      // resolve is pending; remove the track (calls stop(), bumping the generation)
+      player.remove(track1.id);
+
+      // now resolve the pending promise — should be treated as stale
+      deferred[0]!.resolve("blob:http://localhost/t1-blob");
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(audioEl.play).not.toHaveBeenCalled();
+      expect(audioEl.getAttribute("src")).toBeNull();
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:http://localhost/t1-blob");
+    });
+
+    it("out-of-order resolve does not desync: gen-1 blob is revoked and src ends on gen-2 blob", async () => {
+      const deferred: Array<{ resolve: (u: string) => void; reject: (e: unknown) => void }> = [];
+      mockResolveAudioSource.mockImplementation(
+        () => new Promise<string>((resolve, reject) => deferred.push({ resolve, reject })),
+      );
+
+      const player = initPlayer(audioEl, playlistEl);
+      // gen 1: add track1 (resolve pending)
+      player.add(track1);
+      // gen 2: add track2, then fire ended to advance (but track1 never resolved,
+      // so use remove-current to switch tracks synchronously)
+      player.add(track2);
+      // remove track1 while its resolve is pending — player switches to track2 (gen 2)
+      player.remove(track1.id);
+
+      // resolve gen-2 first, then gen-1
+      deferred[1]!.resolve("blob:http://localhost/t2-blob");
+      await Promise.resolve();
+      await Promise.resolve();
+
+      deferred[0]!.resolve("blob:http://localhost/t1-blob");
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // src should be the gen-2 blob
+      expect(audioEl.src).toContain("t2-blob");
+      // gen-1 blob was never stored; it should have been revoked as stale
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:http://localhost/t1-blob");
+      // gen-1 blob was never assigned to src
+      expect(audioEl.src).not.toContain("t1-blob");
+    });
+
+    it("stale failed resolve does not advance; live failure advances from live index", async () => {
+      const deferred: Array<{ resolve: (u: string) => void; reject: (e: unknown) => void }> = [];
+      mockResolveAudioSource.mockImplementation(
+        () => new Promise<string>((resolve, reject) => deferred.push({ resolve, reject })),
+      );
+
+      const player = initPlayer(audioEl, playlistEl);
+      // gen 1: add track1 (resolve pending)
+      player.add(track1);
+      player.add(track2);
+      player.add(track3);
+
+      // supersede gen-1 by removing track1 while resolve is pending (switches to track2, gen 2)
+      player.remove(track1.id);
+
+      // reject gen-1 promise (stale) — should not advance
+      const playCallsBefore = (audioEl.play as ReturnType<typeof vi.fn>).mock.calls.length;
+      deferred[0]!.reject(new Error("network error"));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // no additional play calls from the stale failure
+      expect((audioEl.play as ReturnType<typeof vi.fn>).mock.calls.length).toBe(playCallsBefore);
+
+      // now reject gen-2 (live) — should advance from live currentIndex (track2 -> track3)
+      deferred[1]!.reject(new Error("network error"));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // gen-3 resolve (track3) is now pending; resolve it to confirm advancement happened
+      await vi.waitFor(() => {
+        expect(deferred).toHaveLength(3);
+      });
+      deferred[2]!.resolve("blob:http://localhost/t3-blob");
+      await vi.waitFor(() => {
+        expect(audioEl.src).toContain("t3-blob");
+      });
+      expect(audioEl.play).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Closes #1302

## Problem

`audio/src/player.ts`'s `playTrack` was fire-and-forget async with no
generation/cancellation guard. `resolveAudioSource` on a cache miss does a
`getDownloadURL` plus a full-file fetch (seconds of latency), so a single
`playTrack` call has a long pending window during which queue state can change.
Three defects resulted:

- **Play-after-remove** — queue a track (fetch starts), uncheck it before the
  fetch resolves → `remove` → `stop()` clears `src`, then the pending `.then`
  fired anyway, set `audioEl.src`, and called `play()`. The removed track
  audibly played while the UI showed it unchecked.
- **Out-of-order resolves + blob leak** — two overlapping `playTrack` calls each
  assigned `currentObjectUrl = url`; the first was overwritten without
  `URL.revokeObjectURL`, permanently leaking a blob holding a whole audio file,
  and `audioEl.src` could settle on a different track than the highlighted row.
- **Stale index** — on resolve failure, `advanceOrStop(index)` used the index
  captured at call time against a queue that may have been mutated mid-flight.

## Fix

Mirror the router's `navigationId` pattern (`router/src/index.ts`): a
closure-scoped `playGeneration` counter, captured per `playTrack` call as
`const generation = ++playGeneration`, gates every post-await side effect.

- The `.then` handler bails when `generation !== playGeneration`, revoking the
  just-resolved blob so it never leaks, before touching `currentObjectUrl`,
  `audioEl.src`, or `play()`.
- The `.catch` handler still logs the real failure, but only advances when the
  generation is live — and advances from the **live** `currentIndex`, not the
  stale captured `index` (matching `onEnded`).
- `stop()` bumps the counter, so any resolve still pending when playback stops
  is invalidated. This is what makes the play-after-remove path inert.

Only the most-recent live request can resurrect playback; stopped or superseded
resolves become inert and clean up their own blob. No public API or signature
changes.

## Tests

Three new cases in `audio/test/player.test.ts` drive the defects with a
deferred-promise mock for controllable, interleaved resolution:

- **play-after-remove** — stale resolve does not call `play()`, does not set
  `src`, and revokes the blob.
- **out-of-order resolve does not desync** — `src` ends on the gen-2 blob; the
  gen-1 blob is revoked, never assigned.
- **stale failed resolve does not advance** — a superseded rejection is inert; a
  live rejection advances from the correct live index.

All 24 cases pass (21 existing + 3 new); `tsc --noEmit` and lint are clean.
