### PR TITLE
utils: fix media ordering, app-check init flag, nav double-define, redirect cancel code

### DIFF
--- a/authutil/src/firebase-auth.ts
+++ b/authutil/src/firebase-auth.ts
@@ -74,7 +74,7 @@ function showAuthError(message: string): void {
  * page load (user returning from GitHub OAuth or emulator picker).
  * Auth errors display a dismissible toast rather than throwing, to
  * prevent unhandled rejections from blocking app initialization.
- * The auth/popup-closed-by-user error is intentionally dismissed without
+ * The auth/user-cancelled error is intentionally dismissed without
  * showing a toast, since it indicates normal user cancellation.
  */
 export function createFirebaseAuth(app: FirebaseApp, options?: FirebaseAuthOptions): AppAuth {
@@ -85,7 +85,7 @@ export function createFirebaseAuth(app: FirebaseApp, options?: FirebaseAuthOptio
   }
 
   getRedirectResult(auth).catch((error) => {
-    if (isAuthError(error) && error.code === "auth/popup-closed-by-user") {
+    if (isAuthError(error) && error.code === "auth/user-cancelled") {
       console.debug("Auth redirect cancelled by user");
       return;
     }

--- a/authutil/test/firebase-auth.test.ts
+++ b/authutil/test/firebase-auth.test.ts
@@ -136,9 +136,9 @@ describe("createFirebaseAuth", () => {
     expect(toast?.textContent).toContain("Network error");
   });
 
-  it("dismisses popup-closed-by-user without showing toast", async () => {
-    const popupError = Object.assign(new Error("popup closed"), {
-      code: "auth/popup-closed-by-user",
+  it("dismisses user-cancelled without showing toast", async () => {
+    const cancelError = Object.assign(new Error("user cancelled"), {
+      code: "auth/user-cancelled",
     });
     let rejectFn!: (error: unknown) => void;
     mockGetRedirectResult.mockReturnValue(
@@ -149,7 +149,7 @@ describe("createFirebaseAuth", () => {
     const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
 
     createFirebaseAuth(mockApp);
-    rejectFn(popupError);
+    rejectFn(cancelError);
     await new Promise((r) => setTimeout(r, 0));
 
     expect(debugSpy).toHaveBeenCalledWith("Auth redirect cancelled by user");

--- a/components/src/nav.ts
+++ b/components/src/nav.ts
@@ -109,6 +109,8 @@ class AppNavElement extends HTMLElement {
   }
 }
 
-customElements.define("app-nav", AppNavElement);
+if (!customElements.get("app-nav")) {
+  customElements.define("app-nav", AppNavElement);
+}
 
 export type { AppNavElement };

--- a/firebaseutil/src/app-context.ts
+++ b/firebaseutil/src/app-context.ts
@@ -193,8 +193,8 @@ export function createAppContext(
     let initialized = false;
     initAppCheck = async () => {
       if (initialized) return;
-      initialized = true;
       resolvedAppCheck = doInitAppCheck();
+      initialized = true;
     };
   } else {
     resolvedAppCheck = doInitAppCheck();

--- a/firestoreutil/src/media-queries.ts
+++ b/firestoreutil/src/media-queries.ts
@@ -22,7 +22,9 @@ export function createMediaQueries<T extends { id: string; addedAt: string }>(
   async function getUserMedia(email: string): Promise<T[]> {
     const q = query(collection(db, path), where("memberEmails", "array-contains", email));
     const snapshot = await getDocs(q);
-    return snapshot.docs.map((docSnap) => toItem(docSnap.id, docSnap.data()));
+    const items = snapshot.docs.map((docSnap) => toItem(docSnap.id, docSnap.data()));
+    items.sort((a, b) => b.addedAt.localeCompare(a.addedAt));
+    return items;
   }
 
   async function getAllAccessibleMedia(email: string): Promise<T[]> {


### PR DESCRIPTION
Closes #1295

Four low-severity correctness fixes in the shared utility packages, each
independent and each a latent trap rather than an active user-facing bug. Each
site is brought into line with its siblings / its own documented intent so the
next consumer does not inherit a surprise.

## Changes

- **`firestoreutil` — `getUserMedia` ordering.** `getUserMedia` returned raw
  Firestore document-ID order while its siblings `getPublicMedia` and
  `getAllAccessibleMedia` sort by `addedAt` descending. It now sorts with the
  same inline comparator, consistent with the siblings it sits beside (and is
  re-exported by audio/print).

- **`firebaseutil` — `initAppCheck` premature flag.** The deferred-init closure
  set `initialized = true` before the fallible `doInitAppCheck()`. A thrown
  programmer error left the guard tripped, so every later call was a silent
  no-op and `getAppCheckHeaders` returned `{}` forever. The flag is now set only
  after a successful init, so a later call retries. `doInitAppCheck()` is
  synchronous, so reentrancy safety is unchanged.

- **`components` — `customElements` double-define.** The bare
  `customElements.define("app-nav", …)` threw a DOMException on a second module
  evaluation (HMR / two entry chunks). It is now guarded with
  `if (!customElements.get("app-nav"))`, making the define idempotent.

- **`authutil` — redirect-cancel error code.** The redirect-only flow suppressed
  `auth/popup-closed-by-user` — a popup-flow code that never fires in a redirect
  flow. The redirect user-cancel code is `auth/user-cancelled`; a backed-out
  consent now is silently dismissed instead of toasting + logging an error. The
  matching JSDoc sentence was updated to agree.

## Verification

Per-package vitest suites, lint, and type-check remain the verification path for
each touched package. Each edit is a single-site change consistent with existing
siblings / documented intent.
