### PR TITLE
qa-fix efficiency: run-qa-server.sh --detach + walkthrough discipline

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/run-qa-server.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-qa-server.sh
@@ -1,7 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_DIR="${1:?Usage: run-qa-server.sh <app-dir>}"
+# Parse args: required <app-dir>, optional --detach in any position.
+DETACH=false
+APP_DIR=""
+for arg in "$@"; do
+  case "$arg" in
+    --detach)
+      DETACH=true
+      ;;
+    --*)
+      echo "ERROR: unknown flag: $arg" >&2
+      echo "Usage: run-qa-server.sh <app-dir> [--detach]" >&2
+      exit 1
+      ;;
+    *)
+      if [ -n "$APP_DIR" ]; then
+        echo "ERROR: unexpected extra argument: $arg" >&2
+        echo "Usage: run-qa-server.sh <app-dir> [--detach]" >&2
+        exit 1
+      fi
+      APP_DIR="$arg"
+      ;;
+  esac
+done
+if [ -z "$APP_DIR" ]; then
+  echo "Usage: run-qa-server.sh <app-dir> [--detach]" >&2
+  exit 1
+fi
+
+# Set true only at the very end, immediately before the detach exit 0, so the
+# cleanup trap can tell an intentional detached return from any other exit.
+DETACH_SUCCESS=false
 
 # Remember repo root (script must be invoked from repo root)
 REPO_ROOT="$(pwd)"
@@ -120,6 +150,14 @@ WT_PATH="$(git rev-parse --show-toplevel)"
 
 # Cleanup on exit: kill all processes for this worktree, remove stale hub and temp config
 cleanup() {
+  # Detach success: the server is intentionally left running. Skip the kill and
+  # the shutdown echoes — only drop the temp emulator config (firebase-tools
+  # read --config at startup; kill_worktree_processes matches the emulator argv,
+  # not this file, so removing it does not strand the detached server).
+  if [ "$DETACH" = true ] && [ "$DETACH_SUCCESS" = true ]; then
+    rm -f "$TEMP_FIREBASE_JSON"
+    return
+  fi
   echo ""
   echo "Shutting down..."
   kill_worktree_processes "$WT_PATH" || echo "WARNING: kill_worktree_processes failed" >&2
@@ -137,8 +175,14 @@ fi
 
 # Start Firebase emulators in background (if any emulators needed)
 if [ -n "$EMULATOR_LIST" ]; then
-  FIRESTORE_NAMESPACE="$NAMESPACE" \
-  npx firebase-tools emulators:start --only "$EMULATOR_LIST" --config "$TEMP_FIREBASE_JSON" --project "$EMULATOR_PROJECT_ID" &
+  if [ "$DETACH" = true ]; then
+    EMU_LOG="$(get_tmpdir)/qa-emulators-${APP_NAME}.log"
+    FIRESTORE_NAMESPACE="$NAMESPACE" \
+    setsid nohup npx firebase-tools emulators:start --only "$EMULATOR_LIST" --config "$TEMP_FIREBASE_JSON" --project "$EMULATOR_PROJECT_ID" >"$EMU_LOG" 2>&1 &
+  else
+    FIRESTORE_NAMESPACE="$NAMESPACE" \
+    npx firebase-tools emulators:start --only "$EMULATOR_LIST" --config "$TEMP_FIREBASE_JSON" --project "$EMULATOR_PROJECT_ID" &
+  fi
 fi
 
 TIMEOUT=30
@@ -230,7 +274,12 @@ VITE_ARGS+=("VITE_RECAPTCHA_SITE_KEY=emulator-recaptcha-key")
 
 # Start Vite dev server
 cd "$REPO_ROOT/$APP_DIR"
-env "${VITE_ARGS[@]}" npx vite --port "${VITE_PORT}" --strictPort &
+if [ "$DETACH" = true ]; then
+  VITE_LOG="$(get_tmpdir)/qa-vite-${APP_NAME}.log"
+  setsid nohup env "${VITE_ARGS[@]}" npx vite --port "${VITE_PORT}" --strictPort >"$VITE_LOG" 2>&1 &
+else
+  env "${VITE_ARGS[@]}" npx vite --port "${VITE_PORT}" --strictPort &
+fi
 cd "$REPO_ROOT"
 
 # Poll until Vite is serving
@@ -285,6 +334,18 @@ EMU_PORTS=()
 [ -n "$STORAGE_PORT" ] && EMU_PORTS+=("$STORAGE_PORT")
 [ -n "$FUNCTIONS_PORT" ] && EMU_PORTS+=("$FUNCTIONS_PORT")
 print_remote_access_block "$VITE_PORT" "${EMU_PORTS[@]}"
+
+if [ "$DETACH" = true ]; then
+  # Detach: the server is up and ready. Return so the caller's single
+  # foreground Bash call completes; run-qa-cleanup.sh is the stop.
+  #
+  # Trade-off: claim_fixed_vite_port holds an flock on fd 200 for the script's
+  # lifetime; exiting here releases it early. That flock only closed a TOCTOU
+  # window — the function's own OS-level port probe plus Vite --strictPort still
+  # prevent an actual port collision, so early release is safe.
+  DETACH_SUCCESS=true
+  exit 0
+fi
 
 # Block until Ctrl+C
 wait

--- a/.claude/skills/dispatch-propagate/scripts/run-qa-server.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-qa-server.sh
@@ -320,7 +320,11 @@ if [ "$USES_FUNCTIONS" = true ]; then
   echo "  Functions emulator: localhost:${FUNCTIONS_PORT}"
 fi
 echo ""
-echo "  Press Ctrl+C to stop"
+if [ "$DETACH" = true ]; then
+  echo "  Stop: run-qa-cleanup.sh"
+else
+  echo "  Press Ctrl+C to stop"
+fi
 echo "========================================"
 echo ""
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -23274,6 +23274,117 @@ assert_eq "launch arg: unsafe-char path → exit 2" "2" "$rc_unsafe"
 lw_teardown
 
 # ============================================================================
+# run-qa-server.sh --detach
+# ============================================================================
+# Drives the REAL run-qa-server.sh tail to prove --detach takes the `exit 0`
+# branch (returns) instead of `wait` (blocks). An extracted-primitive test would
+# not prove the script took that branch, so this section runs the real script
+# against a feature-free, Vite-only fixture: a throwaway git repo with no
+# firebase imports (detect_features → all USES_*=false → no emulator path), an
+# empty node_modules (ensure_deps no-ops), and no functions/ dir. Only npx and
+# curl are stubbed; real git/node/jq/flock/setsid/ps/nohup come via SAVED_PATH.
+
+qd_setup() {
+  QD_DIR=$(mktemp -d)
+  cp "$SCRIPT_DIR/run-qa-server.sh" "$QD_DIR/run-qa-server.sh"
+  cp "$SCRIPT_DIR/run-qa-cleanup.sh" "$QD_DIR/run-qa-cleanup.sh"
+  cp "$SCRIPT_DIR/lib.sh" "$QD_DIR/lib.sh"
+  chmod +x "$QD_DIR/run-qa-server.sh" "$QD_DIR/run-qa-cleanup.sh"
+
+  # Real throwaway git repo fixture. Canonicalize so the path equals what
+  # `git rev-parse --show-toplevel` and the script's $(pwd) both resolve to
+  # (logical-vs-physical /tmp symlink would otherwise break the argv match).
+  QD_REPO="$QD_DIR/repo"
+  mkdir -p "$QD_REPO"
+  QD_REPO="$(cd "$QD_REPO" && pwd -P)"
+  mkdir -p "$QD_REPO/myapp/src"
+  echo 'export const x = 1;' > "$QD_REPO/myapp/src/main.ts"   # no firebase imports → Vite-only
+  mkdir -p "$QD_REPO/node_modules"                            # empty → ensure_deps no-ops
+  git init -q "$QD_REPO"
+  git -C "$QD_REPO" config user.email qa@example.com
+  git -C "$QD_REPO" config user.name "QA Test"
+  git -C "$QD_REPO" add -A
+  git -C "$QD_REPO" commit -q -m init
+
+  # Stubs: ONLY npx + curl. Real git/node/jq/flock/setsid/ps/nohup via SAVED_PATH.
+  QD_BIN="$QD_DIR/bin"
+  mkdir -p "$QD_BIN"
+  # npx stand-in: a long-running process whose argv carries the repo path so
+  # kill_worktree_processes (argv substring match on "$QD_REPO/") can kill it.
+  # Vite is launched with cwd=$QD_REPO/myapp, so $PWD contains $QD_REPO/.
+  # The path is placed in argv0 via `exec -a`; the inner `bash -c` uses a
+  # compound command (`sleep …; :`) so bash does NOT exec-optimize away its own
+  # argv0 (a single command would `exec sleep`, dropping the marker). coreutils
+  # `sleep` is a multicall binary that dispatches on argv0 basename, so we must
+  # NOT make the marker `sleep`'s own argv0 — hence the bash wrapper.
+  cat > "$QD_BIN/npx" <<'NPX'
+#!/usr/bin/env bash
+exec -a "qa-vite-standin $PWD/strictport" bash -c 'sleep 100000; :'
+NPX
+  # curl stand-in: always reports 200 so the Vite readiness poll passes with no
+  # real listener (python3/nc are unreliable in this env).
+  cat > "$QD_BIN/curl" <<'CURL'
+#!/usr/bin/env bash
+echo 200
+CURL
+  chmod +x "$QD_BIN/npx" "$QD_BIN/curl"
+  export PATH="$QD_BIN:$SAVED_PATH"
+
+  export FIREBASE_PROJECT_ID=demo-qa-detach
+  QD_SAVED_TMPDIR="${TMPDIR:-}"
+  export TMPDIR="$QD_DIR/tmp"
+  mkdir -p "$QD_DIR/tmp"
+}
+
+qd_teardown() {
+  ( cd "$QD_REPO" 2>/dev/null && "$QD_DIR/run-qa-cleanup.sh" >/dev/null 2>&1 ) || true
+  cd "$SCRIPT_DIR"
+  rm -rf "$QD_DIR"
+  export PATH="$SAVED_PATH"
+  unset FIREBASE_PROJECT_ID
+  if [ -n "$QD_SAVED_TMPDIR" ]; then export TMPDIR="$QD_SAVED_TMPDIR"; else unset TMPDIR; fi
+}
+
+echo "Test: run-qa-server.sh --detach returns while the server stays up"
+qd_setup
+
+# 1. --detach returns (does not block). timeout turns a hang into rc 124.
+cd "$QD_REPO"
+set +e
+timeout 30 "$QD_DIR/run-qa-server.sh" myapp --detach >"$QD_DIR/detach.out" 2>&1
+rc=$?
+set -e
+assert_eq "run-qa-server --detach: returns rc 0 (did not block)" "0" "$rc"
+
+# 2. The detached stand-in is still alive after return.
+up=$( . "$QD_DIR/lib.sh" >/dev/null 2>&1; _pids_matching_arg "$QD_REPO/" )
+assert_eq "run-qa-server --detach: server stays up" "yes" \
+  "$([ -n "$up" ] && echo yes || echo no)"
+
+# 3. run-qa-cleanup.sh stops it (bounded poll for kill latency).
+cd "$QD_REPO"
+"$QD_DIR/run-qa-cleanup.sh" >/dev/null 2>&1 || true
+gone=no
+for _ in $(seq 1 15); do
+  rem=$( . "$QD_DIR/lib.sh" >/dev/null 2>&1; _pids_matching_arg "$QD_REPO/" )
+  [ -z "$rem" ] && { gone=yes; break; }
+  sleep 0.3
+done
+assert_eq "run-qa-cleanup: server stopped" "yes" "$gone"
+
+# 4. No-flag form still blocks on wait (rc 124 = timed out = blocking).
+cd "$QD_REPO"
+set +e
+timeout 3 "$QD_DIR/run-qa-server.sh" myapp >/dev/null 2>&1
+rc_block=$?
+set -e
+assert_eq "run-qa-server (no flag): still blocks on wait" "124" "$rc_block"
+cd "$QD_REPO"
+"$QD_DIR/run-qa-cleanup.sh" >/dev/null 2>&1 || true
+
+qd_teardown
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -163,6 +163,10 @@ Otherwise run all steps in order.
       extension.** Needs-human-judgment items are **not** walked — they are
       recorded as deferred-to-office-hours.
 
+      Any `javascript_tool` snippet that uses `await` must be wrapped in an async
+      IIFE — `(async () => { … })()` — because a top-level `await` raises
+      `SyntaxError: await is only valid in async functions`.
+
       1. Load chrome tools via:
          ```
          ToolSearch("select:mcp__claude-in-chrome__tabs_create_mcp,mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__javascript_tool,mcp__claude-in-chrome__get_page_text,mcp__claude-in-chrome__read_console_messages,mcp__claude-in-chrome__read_network_requests,mcp__claude-in-chrome__gif_creator,mcp__claude-in-chrome__computer,mcp__claude-in-chrome__form_input,mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome__list_connected_browsers,mcp__claude-in-chrome__select_browser")
@@ -176,7 +180,7 @@ Otherwise run all steps in order.
       7. Start GIF recording: `gif_creator` with `action: "start_recording"`. Take an initial screenshot.
       8. **For each machine-verifiable plan item:**
          a. **Set up state.** Navigate to the item's URL path (if not "current"). Execute the steps using `computer`, `form_input`, `navigate`. Capture extra GIF frames before and after.
-         b. **Check output.** Take a screenshot. Read `get_page_text` to verify the expected outcome. Check `read_console_messages` (filter for errors). Check `read_network_requests` for 4xx/5xx.
+         b. **Check output.** Take a screenshot only on genuine state transitions — not on every iterative debug step. Read `get_page_text` to verify the expected outcome. Check `read_console_messages` (filter for errors). Check `read_network_requests` for 4xx/5xx using the tool's filter parameter (e.g. filter to error status codes); request a count rather than full metadata when only request counts or specific requests matter — do not pull the full request dump.
          c. **Record the result** — **PASS** or **FAIL**, directly from this
             skill's own checks. **No user prompt.**
             - On interaction failure: retry once, then record **SKIP** and continue.
@@ -184,6 +188,8 @@ Otherwise run all steps in order.
             - Stay on the App URL domain — do not follow external links.
             - **On the first FAIL** → a bug. Stop the walkthrough, finalize the QA
               session (Steps 5 and 6), and escalate per the **Escalation** section.
+              After escalating, the session **stops** — do not restart the QA
+              server or re-run the walkthrough.
       9. Stop GIF recording: `gif_creator` with `action: "stop_recording"`. Export to `tmp/qa-fix-walkthrough-<n>.gif` (where `<n>` is the Step-0-resolved issue number `<N>`).
       10. Write per-item results (PASS/FAIL/SKIP, console errors, network failures, deferred judgment items, summary counts) to `tmp/qa-fix-results-<n>.txt`.
 
@@ -289,6 +295,8 @@ residue).
 
 Tailor the reason text to the blocker that actually fired (judgment item, machine
 FAIL, failed pre-QA check, multi-app choice, merge conflict). Then **stop**.
+Marking a deviation is **terminal** for the walkthrough — do not restart the QA
+server or re-run the walkthrough after escalating.
 
 ## Notes
 

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -142,18 +142,13 @@ Otherwise run all steps in order.
 
 3. **Browser feature path.** Skip to Step 4 if the non-browser path applies.
 
-   a. **Start the QA server in the background.** Use a Bash tool call with `run_in_background: true`:
+   a. **Start the QA server (foreground, returns when ready).** Use a single foreground Bash call with `--detach`; it runs the readiness poll internally and exits 0 with the server still running:
       ```bash
-      .claude/skills/dispatch-propagate/scripts/run-qa-server.sh <app-dir>
+      .claude/skills/dispatch-propagate/scripts/run-qa-server.sh <app-dir> --detach
       ```
-      Capture the App URL printed to stdout. The QA server seeds public data only — do not re-run it or any seed step with `SEED_TEST_ONLY=true` (see [QA data policy](#qa-data-policy)).
+      Capture the App URL from its stdout summary block. The QA server seeds public data only — do not re-run it or any seed step with `SEED_TEST_ONLY=true` (see [QA data policy](#qa-data-policy)).
 
-   b. **Wait for the server:**
-      ```bash
-      .claude/skills/dispatch-propagate/scripts/wait-for-url.sh <url>
-      ```
-
-   c. **Pre-QA acceptance check:**
+   b. **Pre-QA acceptance check:**
       ```bash
       .claude/skills/dispatch-propagate/scripts/run-acceptance-tests.sh <app-dir> <url>
       ```
@@ -164,7 +159,7 @@ Otherwise run all steps in order.
         run cleanup Step 6), and escalate per the **Escalation** section.
       - **If the check passes** → continue to the walkthrough.
 
-   d. **Walk through only the machine-verifiable QA-plan items via the Chrome
+   c. **Walk through only the machine-verifiable QA-plan items via the Chrome
       extension.** Needs-human-judgment items are **not** walked — they are
       recorded as deferred-to-office-hours.
 


### PR DESCRIPTION
Closes #1425

## What

Cut the QA-server startup churn and browser-walkthrough waste that made `/qa-fix`
two of the costliest Sonnet sessions in the 24h token audit (sub-issue of the
#1424 epic).

The autonomous `/qa-fix` worker could not use `run-qa-server.sh` as written: the
script polls until Vite serves 200, prints "QA Server Ready", then blocks forever
on `wait` (Ctrl+C semantics for a human). The worker had to background it, lose
the ready signal, and reinvent readiness detection with `sleep N && cat logfile`,
`ss -tlnp`, and repeated restarts — ~18–22% of qa-fix turns in sampled sessions.

## Changes

1. **`run-qa-server.sh --detach`** (new, position-independent flag): starts the
   emulators + Vite under `setsid nohup`, runs the **existing** readiness poll,
   prints the **existing** summary block, then `exit 0` with the server still
   running. The cleanup trap is now detach-aware — **failure still kills; only
   detach-success skips the kill** (and the "Shutting down…" echoes, so stdout
   never claims a still-running server stopped). The no-flag path is unchanged:
   it still blocks on `wait` for interactive use. `run-qa-cleanup.sh` remains the
   stop — it matches the detached processes by argv substring, and `setsid`
   changes the session but not argv.

2. **`qa-fix` SKILL.md — single detached start:** the browser feature path now
   makes one foreground `run-qa-server.sh <app> --detach` call instead of a
   background start plus a separate `wait-for-url.sh` readiness step. (`wait-for-url.sh`
   is kept for office-hours' interactive blocking path.)

3. **`qa-fix` SKILL.md — walkthrough discipline** (no script dependency, closes
   the other audited waste patterns):
   - `javascript_tool` snippets using `await` must be wrapped in an async IIFE
     (top-level `await` raises `SyntaxError: await is only valid in async
     functions`).
   - `dispatch-mark-deviation` is **terminal** for the walkthrough — do not
     restart the server or re-run the walkthrough after escalating (one sampled
     session ran a second full walkthrough after marking a deviation).
   - `read_network_requests` must use its filter parameter and request a count
     rather than full metadata when only counts/specific requests matter.
   - Screenshots are capped to genuine state transitions, not every iterative
     debug step.

4. **`test-dispatch-scripts.sh` — `--detach` coverage:** a new section drives the
   **real** `run-qa-server.sh` tail against a feature-free, Vite-only fixture
   (throwaway `git init` repo, no firebase imports, empty `node_modules`, stubbed
   `npx`/`curl`). It asserts `--detach` returns rc 0 with the server still up,
   `run-qa-cleanup.sh` stops it, and the no-flag form still blocks (`timeout` →
   rc 124). Running the real script — not an extracted primitive — is what proves
   the `exit 0` branch was taken instead of `wait`.

## Testing

`test-dispatch-scripts.sh`: **2218/2218 passed** (was 2214; +4 new `--detach`
assertions). This is the CI gate (`unit-tests.yml`).

## Out of scope

- `wait-for-url.sh` is **not** deleted — office-hours SKILL.md still uses it for
  the interactive blocking QA path.
- office-hours SKILL.md is unedited — its blocking flow relies on the no-flag
  behavior, which this change preserves.
