### PR TITLE
dispatch: add dispatch-context-pack — live flag-sliced per-issue context in one call

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-context-pack
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-context-pack
@@ -143,6 +143,37 @@ build_relations_section() {
   fi
 }
 
+# --pr: resolve the PR via dispatch-find-pr, then emit number, labels, CI
+# verdict, and body as clean markdown prose. Empty dispatch-find-pr output (exit
+# 0) means no PR exists yet → emit "PR: none" and return 0 (legitimate
+# plan-phase case). A non-zero dispatch-find-pr exit is a real failure → return 1.
+# Inside the helper, all command substitutions use the two-line form to avoid
+# masking failures under `local`.
+build_pr_section() {
+  local n="$1"
+  local pr_num
+  pr_num=$("$SCRIPT_DIR/dispatch-find-pr" "$n") || return 1
+
+  if [[ -z "$pr_num" ]]; then
+    printf 'PR: none\n'
+    return 0
+  fi
+
+  local pr_json
+  pr_json=$(gh_retry gh pr view "$pr_num" --json number,labels,statusCheckRollup,body) || return 1
+
+  local pr_number labels_str ci_verdict pr_body
+  pr_number=$(jq -r '.number' <<<"$pr_json") || return 1
+  labels_str=$(jq -r '[ .labels[].name ] | if length == 0 then "(none)" else join(", ") end' <<<"$pr_json") || return 1
+  ci_verdict=$(dispatch_classify_rollup "$(jq -c '.statusCheckRollup' <<<"$pr_json")") || return 1
+  pr_body=$(jq -r '.body // ""' <<<"$pr_json") || return 1
+
+  printf 'PR #%s\n' "$pr_number"
+  printf 'labels: %s\n' "$labels_str"
+  printf 'ci: %s\n' "$ci_verdict"
+  printf '\n%s\n' "$pr_body"
+}
+
 # ---- Step 2: build each requested section into its own variable -------------
 #
 # Buffer-then-flush is mandatory (NOT a stylistic choice): each section is built
@@ -179,9 +210,12 @@ $REL_BODY"
 fi
 
 if [[ "$WANT_PR" == 1 ]]; then
-  # Unit 3 fills this: --pr slice (resolve via dispatch-find-pr, then emit
-  # number, labels, ci rollup, and body; "PR: none" exit 0 when no PR exists).
-  PR_OUT="=== PR ==="
+  # --pr slice (dispatch-find-pr → gh pr view --json number,labels,
+  # statusCheckRollup,body → jq-rendered markdown). "PR: none" exit 0 when no
+  # PR exists yet (plan phase). Header line, blank line, then prose.
+  PR_BODY=$(build_pr_section "$N") || { echo "error: --pr: failed to build PR section for #$N" >&2; exit 1; }
+  PR_OUT="=== PR ===
+$PR_BODY"
 fi
 
 if [[ "$WANT_DIFF" == 1 ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-context-pack
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-context-pack
@@ -68,6 +68,81 @@ if (( WANT_ISSUE + WANT_RELATIONS + WANT_PR + WANT_DIFF == 0 )); then
   exit 2
 fi
 
+# ---- Section builders (Unit 2: --issue, --relations) ------------------------
+#
+# Each builder renders its section to stdout and returns non-zero on any gh
+# failure (NEVER prints a partial section + returns 0). The call sites below
+# assign the builder's output into the section variable and convert a non-zero
+# return into a clear-error `exit 1` — so a failure aborts before the flush with
+# no half-pack on stdout. Inside a builder, command substitutions use the
+# two-line `local x; x=$(cmd) || return 1` form: `local x=$(cmd)` would mask the
+# substitution's failure under set -e.
+
+# --issue: one `gh issue view --json` fetch rendered to clean markdown prose —
+# a `## Issue #N (state): title` heading, the body, then a `### Comments`
+# subsection (each comment as `**@author** (date): body`). Renders from the
+# single JSON object so the body AND the comment thread both appear (plain
+# `gh issue view` prints one or the other; raw JSON re-adds the escaping bloat
+# this script exists to remove). The comment render reuses the field shape from
+# sync-issue-context's render_issue_body (.author.login, .createdAt).
+build_issue_section() {
+  local n="$1"
+  local json
+  json=$(gh_retry gh issue view "$n" --json number,title,state,body,comments) || return 1
+  jq -r '
+    "## Issue #\(.number) (\(.state)): \(.title)\n\n" +
+    (.body // "") +
+    (if (.comments | length) > 0 then
+       "\n\n### Comments\n\n" +
+       ([.comments[] | "**@\(.author.login // "unknown")** (\(.createdAt // "")): \(.body // "")"] | join("\n\n"))
+     else "" end)
+  ' <<<"$json" || return 1
+}
+
+# --relations: blockers / sub-issues / parent / siblings as titles + state + URL
+# only — NEVER any related issue's body or comments. The three array endpoints
+# carry number/state/title/html_url inline, so one gh_api_array call each
+# projects them with no per-issue body fetch. Parent is an OBJECT endpoint (not
+# an array): raw `gh api` with 404 discrimination (no parent → emit nothing for
+# parent or siblings, exit stays 0 — matching issue-parent). Siblings are the
+# parent's sub-issues minus self, only when a parent exists.
+build_relations_section() {
+  local n="$1"
+  local rel_proj='.[] | "#\(.number) [\(.state)] \(.title) — \(.html_url)"'
+  local blockers sub_issues
+  blockers=$(gh_api_array "/repos/{owner}/{repo}/issues/$n/dependencies/blocked_by" "$rel_proj") || return 1
+  sub_issues=$(gh_api_array "/repos/{owner}/{repo}/issues/$n/sub_issues" "$rel_proj") || return 1
+
+  printf 'Blockers:\n'
+  if [[ -n "$blockers" ]]; then printf '%s\n' "$blockers" | sed 's/^/  /'; else printf '  (none)\n'; fi
+  printf 'Sub-issues:\n'
+  if [[ -n "$sub_issues" ]]; then printf '%s\n' "$sub_issues" | sed 's/^/  /'; else printf '  (none)\n'; fi
+
+  # Parent: raw gh api (NOT gh_api_array — the endpoint returns an object, and
+  # NOT gh_retry — gh_retry forwards the 404 to stderr, defeating discrimination).
+  # Capture stderr so a 404 / "No parent issue found" body is visible: that means
+  # "no parent" (not an error) → skip parent and siblings, exit stays 0. Any other
+  # failure exits non-zero (no fallback, per .claude/rules/code-style.md).
+  local parent_json parent_num parent_line
+  if parent_json=$(gh api "/repos/{owner}/{repo}/issues/$n/parent" 2>&1); then
+    parent_num=$(jq -r '.number' <<<"$parent_json") || return 1
+    parent_line=$(jq -r '"#\(.number) [\(.state)] \(.title) — \(.html_url)"' <<<"$parent_json") || return 1
+    printf 'Parent:\n  %s\n' "$parent_line"
+
+    # Siblings: the parent's sub-issues minus self.
+    local sib_filter siblings
+    sib_filter=".[] | select(.number != $n) | \"#\\(.number) [\\(.state)] \\(.title) — \\(.html_url)\""
+    siblings=$(gh_api_array "/repos/{owner}/{repo}/issues/$parent_num/sub_issues" "$sib_filter") || return 1
+    printf 'Siblings:\n'
+    if [[ -n "$siblings" ]]; then printf '%s\n' "$siblings" | sed 's/^/  /'; else printf '  (none)\n'; fi
+  elif [[ "$parent_json" == *"404"* || "$parent_json" == *"No parent issue found"* ]]; then
+    : # no parent → emit nothing for parent or siblings; not an error
+  else
+    echo "error: --relations: failed to fetch parent for #$n: $parent_json" >&2
+    return 1
+  fi
+}
+
 # ---- Step 2: build each requested section into its own variable -------------
 #
 # Buffer-then-flush is mandatory (NOT a stylistic choice): each section is built
@@ -88,15 +163,19 @@ PR_OUT=""
 DIFF_OUT=""
 
 if [[ "$WANT_ISSUE" == 1 ]]; then
-  # Unit 2 fills this: --issue slice (gh issue view --json
-  # number,title,state,body,comments → jq-rendered markdown incl. ### Comments).
-  ISSUE_OUT="=== ISSUE #$N ==="
+  # --issue slice (gh issue view --json number,title,state,body,comments →
+  # jq-rendered markdown incl. ### Comments). Header line, blank line, then prose.
+  ISSUE_BODY=$(build_issue_section "$N") || { echo "error: --issue: failed to build issue section for #$N" >&2; exit 1; }
+  ISSUE_OUT="=== ISSUE #$N ===
+$ISSUE_BODY"
 fi
 
 if [[ "$WANT_RELATIONS" == 1 ]]; then
-  # Unit 2 fills this: --relations slice (blockers / sub-issues / parent /
-  # siblings as titles + state + URL only — never full bodies).
-  REL_OUT="=== RELATIONS #$N ==="
+  # --relations slice (blockers / sub-issues / parent / siblings as titles +
+  # state + URL only — never full bodies). Header line, blank line, then groups.
+  REL_BODY=$(build_relations_section "$N") || { echo "error: --relations: failed to build relations section for #$N" >&2; exit 1; }
+  REL_OUT="=== RELATIONS #$N ===
+$REL_BODY"
 fi
 
 if [[ "$WANT_PR" == 1 ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-context-pack
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-context-pack
@@ -174,6 +174,82 @@ build_pr_section() {
   printf '\n%s\n' "$pr_body"
 }
 
+# --diff: diff the worktree branch against its merge-base with the already-merged
+# origin/main, emitting the FULL section incl. its own
+# "=== DIFF (base <sha>) ===" header — unlike --issue/--relations/--pr (whose
+# call sites prepend a fixed header), only this builder knows the base sha, which
+# is computed here. NO `git fetch`: the worktree already has origin/main merged at
+# provision/phase-entry, so relying on the local ref keeps the slice
+# deterministic, read-only, and test-friendly; a missing origin/main / failed
+# merge-base exits non-zero (no fallback, per .claude/rules/code-style.md).
+#
+# CWD TRAP: all git ops run in the inherited cwd (the worktree) — NEVER cd to
+# resolve_project_root(), which returns the .bare parent (NOT the branch
+# checkout); a merge-base HEAD origin/main there resolves the wrong HEAD.
+#
+# One consistent diff form — `git diff "$base"` (working-tree mode, incl.
+# uncommitted) — across --stat, --name-only, and the hunk loop, so the file count
+# and the truncation line reconcile. Hunks are capped at DISPATCH_CONTEXT_DIFF_CAP
+# bytes (default 60000), whole-file granular, CHECK-BEFORE-EMIT: before emitting a
+# file's hunk, if adding its byte length would exceed the cap, STOP and count that
+# file plus all remaining files as omitted, printing exactly one
+# "truncated: N files omitted" line. Never truncate mid-file (the silent over-cap
+# the spec forbids). A single file whose hunk alone exceeds the cap emits ZERO
+# hunks and is itself counted among the omitted N — the --stat/--name-only output
+# still names every file, so nothing is hidden; only hunk bodies are capped.
+build_diff_section() {
+  local n="$1"
+  local cap="${DISPATCH_CONTEXT_DIFF_CAP:-60000}"
+
+  local base
+  base=$(git merge-base HEAD origin/main) || { echo "error: --diff: git merge-base HEAD origin/main failed (origin/main missing?)" >&2; return 1; }
+
+  local stat name_only
+  stat=$(git diff --stat "$base") || { echo "error: --diff: git diff --stat failed" >&2; return 1; }
+  name_only=$(git diff --name-only "$base") || { echo "error: --diff: git diff --name-only failed" >&2; return 1; }
+
+  printf '=== DIFF (base %s) ===\n' "$base"
+  printf '\n--- stat ---\n%s\n' "$stat"
+  printf '\n--- files ---\n%s\n' "$name_only"
+  printf '\n--- hunks ---\n'
+
+  # Iterate the changed-file list. `name_only` is newline-separated; an empty
+  # diff yields an empty string, which mapfile turns into a zero-length array.
+  local files=()
+  if [[ -n "$name_only" ]]; then
+    mapfile -t files <<<"$name_only"
+  fi
+
+  local total=${#files[@]}
+  local emitted_bytes=0 omitted=0 i
+  for (( i = 0; i < total; i++ )); do
+    local file="${files[$i]}"
+    local hunk hlen
+    # Anchor the pathspec with :(top) so it resolves repo-root-relative (matching
+    # the repo-root-relative paths --name-only emits) regardless of the inherited
+    # cwd — a bare `-- "$file"` would interpret $file relative to cwd and miss the
+    # file when invoked from a subdir. This is a pathspec anchor only; it does NOT
+    # cd, so merge-base still runs against the inherited-cwd HEAD (no cd to .bare).
+    hunk=$(git diff "$base" -- ":(top)$file") || { echo "error: --diff: git diff for '$file' failed" >&2; return 1; }
+    # Byte length (NOT ${#hunk}, which counts characters — multibyte content like
+    # this repo's em-dashes would undercount). wc -c is the byte measure.
+    hlen=$(printf '%s' "$hunk" | wc -c) || return 1
+    hlen=${hlen//[[:space:]]/}
+    # Check BEFORE emitting: if this file would push past the cap, stop and count
+    # this file plus all remaining files as omitted (never truncate mid-file).
+    if (( emitted_bytes + hlen > cap )); then
+      omitted=$(( total - i ))
+      break
+    fi
+    printf '%s\n' "$hunk"
+    emitted_bytes=$(( emitted_bytes + hlen ))
+  done
+
+  if (( omitted > 0 )); then
+    printf 'truncated: %d files omitted\n' "$omitted"
+  fi
+}
+
 # ---- Step 2: build each requested section into its own variable -------------
 #
 # Buffer-then-flush is mandatory (NOT a stylistic choice): each section is built
@@ -219,11 +295,11 @@ $PR_BODY"
 fi
 
 if [[ "$WANT_DIFF" == 1 ]]; then
-  # Unit 4 fills this: --diff slice (merge-base vs origin/main, --stat,
-  # --name-only, capped whole-file hunks). The Unit-4 build computes the base
-  # sha and emits the "=== DIFF (base <sha>) ===" header; this bare-header form
-  # is a Unit-1 placeholder (no base sha computed yet).
-  DIFF_OUT="=== DIFF ==="
+  # --diff slice (merge-base vs origin/main, --stat, --name-only, capped
+  # whole-file hunks). Unlike the slices above, the builder owns its
+  # "=== DIFF (base <sha>) ===" header — the base sha is computed during the
+  # build, so only build_diff_section knows it; no separate header prepend here.
+  DIFF_OUT=$(build_diff_section "$N") || { echo "error: --diff: failed to build diff section for #$N" >&2; exit 1; }
 fi
 
 # ---- Step 3: single flush point — print sections in canonical order ---------

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-context-pack
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-context-pack
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# dispatch-context-pack — emit live per-issue context to stdout in one tool
+# result, with sections selected by flag, so a phase skill collapses its 4-8
+# call live-state preamble into a single scripted call.
+#
+# Usage:
+#   dispatch-context-pack <N> [--issue] [--relations] [--pr] [--diff]
+#
+#   <N>            Issue number (digits only, positive).
+#   --issue        Issue title, state, body, and comments.
+#   --relations    Blockers / sub-issues / parent / siblings as
+#                  titles + state + URL only (never full bodies).
+#   --pr           PR number, labels, CI rollup, and body.
+#   --diff         merge-base, --stat, changed-file list, and capped hunks.
+#
+# At least one section flag is required. Sections are emitted in a fixed
+# canonical order — issue → relations → pr → diff — regardless of the order
+# the flags are given on the command line.
+#
+# Exit codes:
+#   0   success — every requested section built and flushed.
+#   2   usage error (missing/non-positive <N>, unknown flag, or zero flags).
+#   1   a gh/git call failed mid-build — the pack aborts with NO partial
+#       output on stdout (see the buffer-then-flush note at the flush point).
+#
+# Note: callers invoke this with dangerouslyDisableSandbox: true — it calls
+# gh (see .claude/rules/sandbox.md).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+# ---- Step 0: parse the positional issue number ------------------------------
+
+N="${1:-}"
+if [[ -z "$N" || ! "$N" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: usage: dispatch-context-pack <N> [--issue] [--relations] [--pr] [--diff] — <N> must be a positive integer" >&2
+  exit 2
+fi
+shift
+
+# ---- Step 1: parse the section flags ----------------------------------------
+
+WANT_ISSUE=0
+WANT_RELATIONS=0
+WANT_PR=0
+WANT_DIFF=0
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --issue)     WANT_ISSUE=1 ;;
+    --relations) WANT_RELATIONS=1 ;;
+    --pr)        WANT_PR=1 ;;
+    --diff)      WANT_DIFF=1 ;;
+    *)
+      echo "error: unknown flag '$1' — expected --issue, --relations, --pr, or --diff" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# A zero-flag invocation is a usage error, not a silent no-op: an empty pack
+# masks a caller bug (input validation at the edge, per .claude/rules/code-style.md).
+if (( WANT_ISSUE + WANT_RELATIONS + WANT_PR + WANT_DIFF == 0 )); then
+  echo "error: no section selected — pass at least one of --issue, --relations, --pr, --diff" >&2
+  exit 2
+fi
+
+# ---- Step 2: build each requested section into its own variable -------------
+#
+# Buffer-then-flush is mandatory (NOT a stylistic choice): each section is built
+# into its own variable and the whole pack is printed only at the single flush
+# point below, AFTER every requested section has succeeded. A section's failing
+# gh/git call must carry an explicit `|| { echo "error: ..." >&2; exit 1; }` so
+# a mid-build failure aborts non-zero with NO half-pack on stdout — the
+# "one tool result" / no-partial-success contract (.claude/rules/code-style.md;
+# guarded by the test "failed gh issue view → exit non-zero AND empty stdout").
+#
+# CRITICAL: under `set -e`, never write `local VAR=$(failing_cmd)` — the `local`
+# declaration's own (zero) exit status masks the command-substitution failure.
+# Use plain assignment + an explicit `|| { ...; exit 1; }` check instead.
+
+ISSUE_OUT=""
+REL_OUT=""
+PR_OUT=""
+DIFF_OUT=""
+
+if [[ "$WANT_ISSUE" == 1 ]]; then
+  # Unit 2 fills this: --issue slice (gh issue view --json
+  # number,title,state,body,comments → jq-rendered markdown incl. ### Comments).
+  ISSUE_OUT="=== ISSUE #$N ==="
+fi
+
+if [[ "$WANT_RELATIONS" == 1 ]]; then
+  # Unit 2 fills this: --relations slice (blockers / sub-issues / parent /
+  # siblings as titles + state + URL only — never full bodies).
+  REL_OUT="=== RELATIONS #$N ==="
+fi
+
+if [[ "$WANT_PR" == 1 ]]; then
+  # Unit 3 fills this: --pr slice (resolve via dispatch-find-pr, then emit
+  # number, labels, ci rollup, and body; "PR: none" exit 0 when no PR exists).
+  PR_OUT="=== PR ==="
+fi
+
+if [[ "$WANT_DIFF" == 1 ]]; then
+  # Unit 4 fills this: --diff slice (merge-base vs origin/main, --stat,
+  # --name-only, capped whole-file hunks). The Unit-4 build computes the base
+  # sha and emits the "=== DIFF (base <sha>) ===" header; this bare-header form
+  # is a Unit-1 placeholder (no base sha computed yet).
+  DIFF_OUT="=== DIFF ==="
+fi
+
+# ---- Step 3: single flush point — print sections in canonical order ---------
+#
+# Reaching here means every requested section built successfully, so it is now
+# safe to write to stdout. Emit in the fixed canonical order (issue → relations
+# → pr → diff) regardless of flag order, with a blank line between sections so
+# the pack is scannable.
+
+emit() {
+  # Print one section's buffered output followed by a trailing blank line.
+  printf '%s\n\n' "$1"
+}
+
+[[ -n "$ISSUE_OUT" ]] && emit "$ISSUE_OUT"
+[[ -n "$REL_OUT" ]] && emit "$REL_OUT"
+[[ -n "$PR_OUT" ]] && emit "$PR_OUT"
+[[ -n "$DIFF_OUT" ]] && emit "$DIFF_OUT"
+
+exit 0

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -23274,6 +23274,695 @@ assert_eq "launch arg: unsafe-char path → exit 2" "2" "$rc_unsafe"
 lw_teardown
 
 # ============================================================================
+# === dispatch-context-pack ===================================================
+# ============================================================================
+#
+# Self-contained section: own temp dir + PATH-shimmed gh/git stubs.
+# The script sources lib.sh and calls dispatch-find-pr via SCRIPT_DIR, so all
+# three live together in $CTXPACK_DIR. gh/git stubs read per-test fixture files
+# from $CTXPACK_STUB. Failures are injected via marker files, never via
+# non-transient stderr strings.
+
+echo ""
+echo "=== dispatch-context-pack ==="
+
+CTXPACK_DIR=""
+CTXPACK_STUB=""
+CTXPACK_SAVED_PATH="$PATH"
+
+ctxpack_setup() {
+  CTXPACK_DIR=$(mktemp -d)
+  CTXPACK_STUB="$CTXPACK_DIR/stub"
+  mkdir -p "$CTXPACK_DIR/bin" "$CTXPACK_STUB"
+
+  # Co-locate the three files that cross-reference via SCRIPT_DIR.
+  cp "$SCRIPT_DIR/dispatch-context-pack" "$CTXPACK_DIR/dispatch-context-pack"
+  cp "$SCRIPT_DIR/dispatch-find-pr" "$CTXPACK_DIR/dispatch-find-pr"
+  cp "$SCRIPT_DIR/lib.sh" "$CTXPACK_DIR/lib.sh"
+  chmod +x "$CTXPACK_DIR/dispatch-context-pack" "$CTXPACK_DIR/dispatch-find-pr"
+
+  # Avoid sleeps in dispatch-find-pr and gh_retry.
+  export DISPATCH_FIND_PR_RETRY_DELAY=0
+  export GH_RETRY_BASE_DELAY=0
+
+  # --- gh stub -----------------------------------------------------------------
+  # Arms are matched on the full "$*" string.  Per-test fixtures live under
+  # $CTXPACK_STUB/; see the per-test setup for which fixtures are written.
+  #
+  # Failure injection: if $CTXPACK_STUB/fail-issue-view exists, the
+  # "issue view <N> --json number,title,state,body,comments" arm exits 1 with a
+  # non-transient diagnostic (avoids gh_retry retrying).  Similarly
+  # $CTXPACK_STUB/fail-merge-base causes the git merge-base arm to exit 1.
+  cat > "$CTXPACK_DIR/bin/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
+args="$*"
+case "$args" in
+  # --issue slice: dispatch-context-pack calls gh_retry gh issue view <N> --json number,title,state,body,comments
+  issue\ view\ *\ --json\ number,title,state,body,comments)
+    if [[ -f "$STUB_DIR/fail-issue-view" ]]; then
+      echo "error: simulated failure fetching issue" >&2
+      exit 1
+    fi
+    num=$(echo "$args" | awk '{print $3}')
+    if [[ -f "$STUB_DIR/issue-full-${num}.json" ]]; then
+      cat "$STUB_DIR/issue-full-${num}.json"
+    else
+      echo "{\"number\":$num,\"title\":\"Issue $num\",\"state\":\"OPEN\",\"body\":\"body text\",\"comments\":[]}"
+    fi
+    ;;
+  # --pr slice cross-check: dispatch-find-pr calls gh issue view <N> --json closedByPullRequestsReferences
+  issue\ view\ *\ --json\ closedByPullRequestsReferences)
+    num=$(echo "$args" | awk '{print $3}')
+    if [[ -f "$STUB_DIR/issue-closing-prs-${num}.json" ]]; then
+      cat "$STUB_DIR/issue-closing-prs-${num}.json"
+    else
+      echo '{"closedByPullRequestsReferences":[]}'
+    fi
+    ;;
+  # dispatch-find-pr self-fetch
+  "pr list --state open --json number,headRefName")
+    if [[ -f "$STUB_DIR/pr-list.json" ]]; then
+      cat "$STUB_DIR/pr-list.json"
+    else
+      echo "[]"
+    fi
+    ;;
+  # --pr slice: gh pr view <prNum> --json number,labels,statusCheckRollup,body
+  pr\ view\ *\ --json\ number,labels,statusCheckRollup,body)
+    num=$(echo "$args" | awk '{print $3}')
+    if [[ -f "$STUB_DIR/pr-view-${num}.json" ]]; then
+      cat "$STUB_DIR/pr-view-${num}.json"
+    else
+      echo "{\"number\":$num,\"labels\":[],\"statusCheckRollup\":[],\"body\":\"pr body\"}"
+    fi
+    ;;
+  # --relations: blocked_by (array)
+  api\ */issues/*/dependencies/blocked_by)
+    num=$(echo "$args" | grep -oE '[0-9]+' | tail -1)
+    if [[ -f "$STUB_DIR/blockedby-${num}.json" ]]; then
+      cat "$STUB_DIR/blockedby-${num}.json"
+    else
+      echo "[]"
+    fi
+    ;;
+  # --relations: sub_issues (array) — keyed by the number in the path
+  api\ */issues/*/sub_issues)
+    num=$(echo "$args" | grep -oE '[0-9]+' | tail -1)
+    if [[ -f "$STUB_DIR/subissues-${num}.json" ]]; then
+      cat "$STUB_DIR/subissues-${num}.json"
+    else
+      echo "[]"
+    fi
+    ;;
+  # --relations: parent (object, not array)
+  api\ */issues/*/parent)
+    num=$(echo "$args" | grep -oE '[0-9]+' | tail -1)
+    if [[ -f "$STUB_DIR/no-parent-${num}" ]]; then
+      echo "Not Found (HTTP 404)" >&2
+      exit 1
+    fi
+    if [[ -f "$STUB_DIR/parent-${num}.json" ]]; then
+      cat "$STUB_DIR/parent-${num}.json"
+    else
+      # Default: no parent — 404 exit
+      echo "Not Found (HTTP 404)" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "gh stub: unknown invocation: $args" >&2
+    exit 1
+    ;;
+esac
+GHSTUB
+  chmod +x "$CTXPACK_DIR/bin/gh"
+
+  # --- git stub ----------------------------------------------------------------
+  # Failure injection: $CTXPACK_STUB/fail-merge-base → merge-base exits 1.
+  # Hunk stubs: each "diff <base> -- :(top)<file>" call emits a fixed-size hunk
+  # whose byte length is CTXPACK_HUNK_BYTES (default 100, set in individual
+  # tests when needed).  The exact string is 100 x "A" + newline = 101 bytes
+  # after printf; we keep hunks uniform so cap math is trivial.
+  cat > "$CTXPACK_DIR/bin/git" <<'GITSTUB'
+#!/usr/bin/env bash
+STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
+args="$*"
+case "$args" in
+  "merge-base HEAD origin/main")
+    if [[ -f "$STUB_DIR/fail-merge-base" ]]; then
+      echo "error: simulated merge-base failure" >&2
+      exit 1
+    fi
+    echo "BASE0SHA"
+    ;;
+  "diff --stat BASE0SHA")
+    echo " 2 files changed, 10 insertions(+), 2 deletions(-)"
+    ;;
+  "diff --name-only BASE0SHA")
+    # Return the file list from a fixture if present, else two default files.
+    if [[ -f "$STUB_DIR/changed-files.txt" ]]; then
+      cat "$STUB_DIR/changed-files.txt"
+    else
+      printf 'foo/bar.ts\nbaz/qux.ts\n'
+    fi
+    ;;
+  diff\ BASE0SHA\ --\ :\(top\)*)
+    # Per-file hunk: emit CTXPACK_HUNK_BYTES A's + newline so byte size is
+    # deterministic.  Default 100 bytes (101 with trailing newline stripped
+    # by command substitution → 100 bytes).  Each test exports DISPATCH_CONTEXT_DIFF_CAP
+    # as needed; individual file-fixture override via stub/hunk-<file>.txt.
+    file="${args#diff BASE0SHA -- :(top)}"
+    hunk_file="$STUB_DIR/hunk-${file//\//_}.txt"
+    if [[ -f "$hunk_file" ]]; then
+      cat "$hunk_file"
+    else
+      sz="${CTXPACK_HUNK_BYTES:-100}"
+      printf '%*s\n' "$sz" | tr ' ' 'A'
+    fi
+    ;;
+  *)
+    echo "git stub: unknown invocation: $args" >&2
+    exit 1
+    ;;
+esac
+GITSTUB
+  chmod +x "$CTXPACK_DIR/bin/git"
+
+  PATH="$CTXPACK_DIR/bin:$PATH"
+}
+
+ctxpack_teardown() {
+  rm -rf "$CTXPACK_DIR"
+  PATH="$CTXPACK_SAVED_PATH"
+  CTXPACK_DIR=""
+  CTXPACK_STUB=""
+  unset DISPATCH_CONTEXT_DIFF_CAP 2>/dev/null || true
+  unset CTXPACK_HUNK_BYTES 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: --issue in isolation
+# ---------------------------------------------------------------------------
+echo "Test: ctxpack --issue renders title, body, and comment thread"
+ctxpack_setup
+
+# Fixture: issue 5 with one seeded comment. The body and the comment author +
+# body must both appear in output — this proves the --json render path (plain
+# `gh issue view` without --json would suppress comments).
+cat > "$CTXPACK_STUB/issue-full-5.json" <<'EOF'
+{
+  "number": 5,
+  "title": "My test issue",
+  "state": "OPEN",
+  "body": "Issue body content here.",
+  "comments": [
+    {
+      "author": {"login": "alice"},
+      "createdAt": "2026-01-15T10:00:00Z",
+      "body": "SEEDED_COMMENT_BODY"
+    }
+  ]
+}
+EOF
+
+rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --issue 2>/dev/null) || rc=$?
+assert_eq "ctxpack --issue: exit 0" "0" "$rc"
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"## Issue #5 (OPEN): My test issue"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --issue: contains title heading"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --issue: contains title heading"
+  echo "    actual: $out"
+fi
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"Issue body content here."* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --issue: contains body text"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --issue: contains body text"
+  echo "    actual: $out"
+fi
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"### Comments"* && "$out" == *"**@alice**"* && "$out" == *"SEEDED_COMMENT_BODY"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --issue: contains comment thread"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --issue: contains comment thread"
+  echo "    actual: $out"
+fi
+# Section isolation: other section headers must be absent.
+TOTAL=$((TOTAL+1))
+if [[ "$out" != *"=== RELATIONS"* && "$out" != *"=== PR ==="* && "$out" != *"=== DIFF"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --issue: no other section headers"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --issue: no other section headers"
+  echo "    actual: $out"
+fi
+ctxpack_teardown
+
+# ---------------------------------------------------------------------------
+# Test 2: --relations in isolation
+# ---------------------------------------------------------------------------
+echo "Test: ctxpack --relations emits titles+state+URL only, excludes bodies and self"
+ctxpack_setup
+
+# Fixtures: one blocker (with a body field that must NOT leak), one sub-issue,
+# a parent, and siblings (parent's sub_issues includes self N=5 + one sibling).
+# The "DISTINCTIVE_BODY_LEAK_MARKER" is in the body field; it must be absent
+# from the rendered output.
+cat > "$CTXPACK_STUB/blockedby-5.json" <<'EOF'
+[
+  {"number":3,"state":"OPEN","title":"Blocker issue","html_url":"https://github.com/natb1/commons.systems/issues/3","body":"DISTINCTIVE_BODY_LEAK_MARKER"}
+]
+EOF
+cat > "$CTXPACK_STUB/subissues-5.json" <<'EOF'
+[
+  {"number":7,"state":"OPEN","title":"Sub-issue title","html_url":"https://github.com/natb1/commons.systems/issues/7","body":"DISTINCTIVE_BODY_LEAK_MARKER"}
+]
+EOF
+# Parent object (not array).
+cat > "$CTXPACK_STUB/parent-5.json" <<'EOF'
+{"number":2,"state":"OPEN","title":"Parent issue","html_url":"https://github.com/natb1/commons.systems/issues/2","body":"DISTINCTIVE_BODY_LEAK_MARKER"}
+EOF
+# Parent's sub_issues — includes self (5) and one sibling (8). Self must be excluded.
+cat > "$CTXPACK_STUB/subissues-2.json" <<'EOF'
+[
+  {"number":5,"state":"OPEN","title":"SELF_EXCLUDED_TITLE","html_url":"https://github.com/natb1/commons.systems/issues/5","body":"body"},
+  {"number":8,"state":"OPEN","title":"Sibling issue","html_url":"https://github.com/natb1/commons.systems/issues/8","body":"DISTINCTIVE_BODY_LEAK_MARKER"}
+]
+EOF
+
+rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --relations 2>/dev/null) || rc=$?
+assert_eq "ctxpack --relations: exit 0" "0" "$rc"
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"#3 [OPEN] Blocker issue"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --relations: blocker rendered"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --relations: blocker rendered"
+  echo "    actual: $out"
+fi
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"#7 [OPEN] Sub-issue title"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --relations: sub-issue rendered"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --relations: sub-issue rendered"
+  echo "    actual: $out"
+fi
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"#2 [OPEN] Parent issue"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --relations: parent rendered"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --relations: parent rendered"
+  echo "    actual: $out"
+fi
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"#8 [OPEN] Sibling issue"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --relations: sibling rendered"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --relations: sibling rendered"
+  echo "    actual: $out"
+fi
+# Self must be excluded from siblings.
+TOTAL=$((TOTAL+1))
+if [[ "$out" != *"SELF_EXCLUDED_TITLE"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --relations: self excluded from siblings"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --relations: self excluded from siblings"
+  echo "    actual: $out"
+fi
+# Body text must not leak.
+TOTAL=$((TOTAL+1))
+if [[ "$out" != *"DISTINCTIVE_BODY_LEAK_MARKER"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --relations: no body text leaked"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --relations: no body text leaked"
+  echo "    actual: $out"
+fi
+# Section isolation.
+TOTAL=$((TOTAL+1))
+if [[ "$out" != *"=== ISSUE"* && "$out" != *"=== PR ==="* && "$out" != *"=== DIFF"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --relations: no other section headers"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --relations: no other section headers"
+  echo "    actual: $out"
+fi
+ctxpack_teardown
+
+# ---------------------------------------------------------------------------
+# Test 3: --pr in isolation, populated PR
+# ---------------------------------------------------------------------------
+echo "Test: ctxpack --pr renders PR number, labels, ci verdict, and body"
+ctxpack_setup
+
+# dispatch-find-pr: a PR with headRefName "5-my-feature" is open.
+cat > "$CTXPACK_STUB/pr-list.json" <<'EOF'
+[{"number":42,"headRefName":"5-my-feature"}]
+EOF
+# gh pr view fixture: labels + all-SUCCESS rollup → ci: passing.
+# Status-context shape: {"state":"SUCCESS"} classifies passing without needing status/conclusion.
+cat > "$CTXPACK_STUB/pr-view-42.json" <<'EOF'
+{
+  "number": 42,
+  "labels": [{"name":"dispatch:planned"},{"name":"size:medium"}],
+  "statusCheckRollup": [{"state":"SUCCESS"},{"state":"SUCCESS"}],
+  "body": "PR body text here."
+}
+EOF
+
+rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --pr 2>/dev/null) || rc=$?
+assert_eq "ctxpack --pr: exit 0" "0" "$rc"
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"PR #42"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --pr: PR number present"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --pr: PR number present"
+  echo "    actual: $out"
+fi
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"dispatch:planned"* && "$out" == *"size:medium"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --pr: labels present"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --pr: labels present"
+  echo "    actual: $out"
+fi
+assert_eq "ctxpack --pr: ci: passing" "yes" "$([[ "$out" == *'ci: passing'* ]] && echo yes || echo no)"
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"PR body text here."* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --pr: body present"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --pr: body present"
+  echo "    actual: $out"
+fi
+# Section isolation.
+TOTAL=$((TOTAL+1))
+if [[ "$out" != *"=== ISSUE"* && "$out" != *"=== RELATIONS"* && "$out" != *"=== DIFF"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --pr: no other section headers"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --pr: no other section headers"
+  echo "    actual: $out"
+fi
+ctxpack_teardown
+
+# ---------------------------------------------------------------------------
+# Test 4: --pr no-PR case
+# ---------------------------------------------------------------------------
+echo "Test: ctxpack --pr with no open PR emits PR: none and exits 0"
+ctxpack_setup
+
+# dispatch-find-pr: no open PR matching the prefix, and cross-check also empty.
+cat > "$CTXPACK_STUB/pr-list.json" <<'EOF'
+[]
+EOF
+cat > "$CTXPACK_STUB/issue-closing-prs-5.json" <<'EOF'
+{"closedByPullRequestsReferences":[]}
+EOF
+
+rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --pr 2>/dev/null) || rc=$?
+assert_eq "ctxpack --pr no-PR: exit 0" "0" "$rc"
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"=== PR ==="* && "$out" == *"PR: none"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --pr no-PR: emits PR: none"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --pr no-PR: emits PR: none"
+  echo "    actual: $out"
+fi
+ctxpack_teardown
+
+# ---------------------------------------------------------------------------
+# Test 5: --diff with normal cap (both files emitted, no truncation)
+# ---------------------------------------------------------------------------
+echo "Test: ctxpack --diff emits stat, file list, and hunks with no truncation"
+ctxpack_setup
+
+# Two small files; default cap (60000) vastly exceeds their hunk sizes.
+# CTXPACK_HUNK_BYTES default 100 → each hunk ~100 bytes (100 A's + newline).
+rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --diff 2>/dev/null) || rc=$?
+assert_eq "ctxpack --diff normal: exit 0" "0" "$rc"
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"=== DIFF (base BASE0SHA) ==="* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --diff normal: header with base sha"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --diff normal: header with base sha"
+  echo "    actual: $out"
+fi
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"2 files changed"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --diff normal: stat present"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --diff normal: stat present"
+  echo "    actual: $out"
+fi
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"foo/bar.ts"* && "$out" == *"baz/qux.ts"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --diff normal: file list present"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --diff normal: file list present"
+  echo "    actual: $out"
+fi
+# Both hunk bodies must appear (AAAA... strings).
+TOTAL=$((TOTAL+1))
+hunk_count=$(echo "$out" | grep -c 'AAAA' 2>/dev/null || echo 0)
+if [[ "$hunk_count" -ge 2 ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --diff normal: both file hunks present"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --diff normal: both file hunks present (hunk_count=$hunk_count)"
+  echo "    actual: $out"
+fi
+# No truncation line.
+TOTAL=$((TOTAL+1))
+if [[ "$out" != *"truncated:"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --diff normal: no truncation line"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --diff normal: no truncation line"
+  echo "    actual: $out"
+fi
+ctxpack_teardown
+
+# ---------------------------------------------------------------------------
+# Test 6a: --diff all-omitted truncation (cap < first hunk size)
+# ---------------------------------------------------------------------------
+echo "Test: ctxpack --diff all-omitted truncation when cap < first hunk"
+ctxpack_setup
+
+# Hunk bytes = 200 per file; cap = 50 → first file (200 > 50) triggers stop
+# immediately → omitted = 2 (all files), zero hunks emitted.
+export CTXPACK_HUNK_BYTES=200
+export DISPATCH_CONTEXT_DIFF_CAP=50
+
+rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --diff 2>/dev/null) || rc=$?
+assert_eq "ctxpack --diff all-omit: exit 0" "0" "$rc"
+# File list must still name both files.
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"foo/bar.ts"* && "$out" == *"baz/qux.ts"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --diff all-omit: file list names all files"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --diff all-omit: file list names all files"
+  echo "    actual: $out"
+fi
+# Zero hunks emitted (no AAAA content).
+TOTAL=$((TOTAL+1))
+if [[ "$out" != *"AAAA"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --diff all-omit: zero hunks emitted"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --diff all-omit: zero hunks emitted"
+  echo "    actual: $out"
+fi
+# Truncation line with count = 2 (both files omitted).
+assert_eq "ctxpack --diff all-omit: truncation line" "yes" \
+  "$([[ "$out" == *'truncated: 2 files omitted'* ]] && echo yes || echo no)"
+ctxpack_teardown
+
+# ---------------------------------------------------------------------------
+# Test 6b: --diff mid-list truncation (first file fits, second pushes over)
+# ---------------------------------------------------------------------------
+echo "Test: ctxpack --diff mid-list truncation when cap between first and second hunk"
+ctxpack_setup
+
+# Hunk bytes = 100 per file; cap = 150 → first file (100 <= 150) fits,
+# second (100+100=200 > 150) triggers stop → omitted = 1, one hunk emitted.
+export CTXPACK_HUNK_BYTES=100
+export DISPATCH_CONTEXT_DIFF_CAP=150
+
+rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --diff 2>/dev/null) || rc=$?
+assert_eq "ctxpack --diff mid-omit: exit 0" "0" "$rc"
+# Exactly one hunk emitted.
+TOTAL=$((TOTAL+1))
+hunk_count=$(echo "$out" | grep -c 'AAAA' 2>/dev/null || echo 0)
+if [[ "$hunk_count" -ge 1 ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --diff mid-omit: first hunk emitted"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --diff mid-omit: first hunk emitted"
+  echo "    actual: $out"
+fi
+# Truncation line with count = 1 (second file omitted).
+assert_eq "ctxpack --diff mid-omit: truncation line count=1" "yes" \
+  "$([[ "$out" == *'truncated: 1 files omitted'* ]] && echo yes || echo no)"
+ctxpack_teardown
+
+# ---------------------------------------------------------------------------
+# Test 7: combined flags — canonical order regardless of flag order given
+# ---------------------------------------------------------------------------
+echo "Test: ctxpack combined flags emit sections in canonical order issue→relations→pr→diff"
+ctxpack_setup
+
+# Provide minimal fixtures for all four slices.
+cat > "$CTXPACK_STUB/issue-full-5.json" <<'EOF'
+{"number":5,"title":"Combined test","state":"OPEN","body":"combo body","comments":[]}
+EOF
+# No parent for relations (default → no-parent exit).
+touch "$CTXPACK_STUB/no-parent-5"
+cat > "$CTXPACK_STUB/pr-list.json" <<'EOF'
+[{"number":20,"headRefName":"5-combo"}]
+EOF
+cat > "$CTXPACK_STUB/pr-view-20.json" <<'EOF'
+{"number":20,"labels":[],"statusCheckRollup":[],"body":"combo pr body"}
+EOF
+
+# Pass flags in REVERSE canonical order.
+rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --diff --pr --relations --issue 2>/dev/null) || rc=$?
+assert_eq "ctxpack combined: exit 0" "0" "$rc"
+
+# Check canonical order by line numbers of each header.
+line_issue=$(echo "$out" | grep -n '=== ISSUE' | head -1 | cut -d: -f1)
+line_rel=$(echo "$out" | grep -n '=== RELATIONS' | head -1 | cut -d: -f1)
+line_pr=$(echo "$out" | grep -n '=== PR ===' | head -1 | cut -d: -f1)
+line_diff=$(echo "$out" | grep -n '=== DIFF' | head -1 | cut -d: -f1)
+
+TOTAL=$((TOTAL+1))
+if [[ -n "$line_issue" && -n "$line_rel" && -n "$line_pr" && -n "$line_diff" ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack combined: all four section headers present"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack combined: all four section headers present"
+  echo "    issue=$line_issue rel=$line_rel pr=$line_pr diff=$line_diff"
+fi
+TOTAL=$((TOTAL+1))
+if [[ -n "$line_issue" && -n "$line_rel" && -n "$line_pr" && -n "$line_diff" \
+   && "$line_issue" -lt "$line_rel" && "$line_rel" -lt "$line_pr" && "$line_pr" -lt "$line_diff" ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack combined: canonical order issue<relations<pr<diff"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack combined: canonical order issue<relations<pr<diff"
+  echo "    line_issue=$line_issue line_rel=$line_rel line_pr=$line_pr line_diff=$line_diff"
+fi
+ctxpack_teardown
+
+# ---------------------------------------------------------------------------
+# Test 8: --relations parent-404 path — no parent → exits 0, no parent/sibling output
+# ---------------------------------------------------------------------------
+echo "Test: ctxpack --relations with no parent exits 0 and omits parent/siblings"
+ctxpack_setup
+
+# The no-parent-5 marker causes the gh stub's parent arm to exit 1 with "404".
+touch "$CTXPACK_STUB/no-parent-5"
+# Blockers and sub-issues return empty arrays (default).
+
+rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --relations 2>/dev/null) || rc=$?
+assert_eq "ctxpack --relations no-parent: exit 0" "0" "$rc"
+# The output must contain Blockers and Sub-issues sections but no Parent: or Siblings:.
+TOTAL=$((TOTAL+1))
+if [[ "$out" == *"Blockers:"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --relations no-parent: Blockers section present"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --relations no-parent: Blockers section present"
+  echo "    actual: $out"
+fi
+TOTAL=$((TOTAL+1))
+if [[ "$out" != *"Parent:"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --relations no-parent: no Parent line"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --relations no-parent: no Parent line"
+  echo "    actual: $out"
+fi
+TOTAL=$((TOTAL+1))
+if [[ "$out" != *"Siblings:"* ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack --relations no-parent: no Siblings line"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --relations no-parent: no Siblings line"
+  echo "    actual: $out"
+fi
+ctxpack_teardown
+
+# ---------------------------------------------------------------------------
+# Test 9: error paths — bad/missing issue number and zero flags
+# ---------------------------------------------------------------------------
+echo "Test: ctxpack arg-validation errors exit 2"
+ctxpack_setup
+
+# Non-positive N (0 is not matched by ^[1-9][0-9]*$).
+rc=0; "$CTXPACK_DIR/dispatch-context-pack" 0 --issue >/dev/null 2>&1 || rc=$?
+assert_eq "ctxpack arg: N=0 exits 2" "2" "$rc"
+# No N (first arg is a flag).
+rc=0; "$CTXPACK_DIR/dispatch-context-pack" --issue >/dev/null 2>&1 || rc=$?
+assert_eq "ctxpack arg: no N exits 2" "2" "$rc"
+# No args at all.
+rc=0; "$CTXPACK_DIR/dispatch-context-pack" >/dev/null 2>&1 || rc=$?
+assert_eq "ctxpack arg: no args exits 2" "2" "$rc"
+# Unknown flag.
+rc=0; "$CTXPACK_DIR/dispatch-context-pack" 5 --unknown >/dev/null 2>&1 || rc=$?
+assert_eq "ctxpack arg: unknown flag exits 2" "2" "$rc"
+
+ctxpack_teardown
+
+# ---------------------------------------------------------------------------
+# Test 10: error path — zero flags (valid N but no section selected)
+# ---------------------------------------------------------------------------
+echo "Test: ctxpack with valid N but zero flags exits 2"
+ctxpack_setup
+
+rc=0; "$CTXPACK_DIR/dispatch-context-pack" 5 >/dev/null 2>&1 || rc=$?
+assert_eq "ctxpack zero-flags: exits 2" "2" "$rc"
+
+ctxpack_teardown
+
+# ---------------------------------------------------------------------------
+# Test 11: THE CRITICAL CONTRACT TEST — failed gh issue view → exit non-zero
+#          AND stdout is EMPTY (buffer-then-flush, no partial pack)
+# ---------------------------------------------------------------------------
+echo "Test: ctxpack failed gh mid-build exits non-zero with EMPTY stdout"
+ctxpack_setup
+
+# fail-issue-view marker causes gh stub to exit 1 with a non-transient message.
+touch "$CTXPACK_STUB/fail-issue-view"
+
+# Capture stdout and stderr separately; allow non-zero exit.
+rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --issue --diff 2>/dev/null) || rc=$?
+TOTAL=$((TOTAL+1))
+if [[ "$rc" -ne 0 ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack failed-gh: exit non-zero"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack failed-gh: exit non-zero (got rc=$rc)"
+fi
+assert_eq "ctxpack failed-gh: stdout EMPTY (buffer-then-flush contract)" "" "$out"
+
+ctxpack_teardown
+
+# ---------------------------------------------------------------------------
+# Test 12: THE GENUINE BUFFER-THEN-FLUSH DISCRIMINATOR — first section succeeds,
+#          second section fails → stdout EMPTY (not the first section's output).
+#          A print-as-you-go regression would leak the issue section to stdout
+#          even though diff failed.  This is the only ordering that distinguishes
+#          correct buffering from a buggy emit-on-success implementation.
+# ---------------------------------------------------------------------------
+echo "Test: ctxpack first-section-success then diff-failure → stdout EMPTY (buffer-then-flush)"
+ctxpack_setup
+
+# fail-merge-base causes --diff to fail after --issue has already succeeded.
+touch "$CTXPACK_STUB/fail-merge-base"
+# No issue fixture needed: the default gh stub arm returns a valid issue JSON.
+
+rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --issue --diff 2>/dev/null) || rc=$?
+TOTAL=$((TOTAL+1))
+if [[ "$rc" -ne 0 ]]; then
+  PASS=$((PASS+1)); echo "  PASS: ctxpack buffer-flush: exit non-zero after mid-build failure"
+else
+  FAIL=$((FAIL+1)); echo "  FAIL: ctxpack buffer-flush: exit non-zero after mid-build failure (got rc=$rc)"
+fi
+# THE CONTRACT: stdout must be EMPTY even though --issue succeeded.
+# A print-as-you-go script would emit the issue section before hitting the
+# diff failure; the buffer-then-flush contract keeps stdout empty.
+assert_eq "ctxpack buffer-flush: stdout EMPTY (no partial pack leaked)" "" "$out"
+
+ctxpack_teardown
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results


### PR DESCRIPTION
Closes #1426

## Summary

Adds `.claude/skills/dispatch-propagate/scripts/dispatch-context-pack` — the
single scripted entry point for **live** per-issue context. It emits to stdout
in one tool result, with sections selected by flag, so a phase skill's 4-8
`gh`/`git` call preamble collapses to one scripted call returning exactly the
slices that phase needs. This is the foundational sub-issue of #1424; phase-skill
adoption (#1427), the stub `CLAUDE.local.md` (#1428), and the Opus QA-plan triage
(#1430) all build on it. Phase-skill adoption is out of scope here — this PR ships
only the script and its tests.

## Interface

```
dispatch-context-pack <N> [--issue] [--relations] [--pr] [--diff]
```

- `<N>` — positional issue number (digits only, positive).
- Flags select sections in any combination; emitted in a fixed canonical order
  `issue → relations → pr → diff` regardless of flag order.
- Zero flags or an unknown flag → usage error, exit 2.

### Sections

- `--issue` — one `gh issue view --json number,title,state,body,comments` fetch,
  jq-rendered to clean markdown: a `## Issue #N (state): title` heading, the body,
  and a `### Comments` subsection. The single-fetch jq render is the only
  single-call form that carries title, body, **and** the comment thread (plain
  `gh issue view` drops one or the other) without the JSON-escaping bloat this
  script exists to remove.
- `--relations` — blockers, sub-issues, parent, and siblings as titles + state +
  URL only, **never** bodies (full related-issue bodies are the largest bloat
  source in the snapshot this script replaces). Array endpoints go through
  `gh_api_array`; the parent endpoint returns an object, so it uses a raw
  `gh api` with 404 discrimination (no parent → emit nothing for parent or
  siblings, exit 0). Siblings are the parent's sub-issues minus self.
- `--pr` — resolves the PR via the internal `dispatch-find-pr` primitive, then
  emits number, labels, a `ci: failing|passing|pending` verdict (via
  `dispatch_classify_rollup`), and the body. No open PR → `PR: none`, exit 0.
- `--diff` — `git merge-base HEAD origin/main` (no fetch; relies on the already-
  merged local ref), `--stat`, `--name-only`, then whole-file hunks capped at
  `DISPATCH_CONTEXT_DIFF_CAP` bytes (default 60000). Capping is check-before-emit
  and whole-file: a file whose hunk would push past the cap is not emitted, and it
  plus every remaining file is counted in one explicit `truncated: N files
  omitted` line — never a silent mid-file cut. `--stat`/`--name-only` still name
  every file, so only hunk bodies are capped.

## No-partial-success contract

Each requested section is built into its own variable; the whole pack is printed
at a single flush point only after every section has succeeded. A mid-build
`gh`/`git` failure aborts non-zero with **no half-pack on stdout** — honoring both
"one tool result" and the no-fallback rule in `.claude/rules/code-style.md`. The
test suite pins this with a "first section succeeds, then a later section's
`gh`/`git` call fails → exit non-zero **and** empty stdout" case.

## Reuse

Sources `lib.sh` (`gh_retry`, `gh_api_array`, `dispatch_classify_rollup`) and
calls `dispatch-find-pr` internally rather than re-implementing PR lookup.
`dispatch-context-pack` supersedes `dispatch-find-pr` at the model-facing
interface (its `--pr` slice covers every SKILL.md use); the `dispatch-find-pr`
primitive and its `dispatch-route` caller are unchanged.

## Tests

A self-contained section in `test-dispatch-scripts.sh` (own temp dir,
PATH-shimmed `gh`/`git`) covers each slice in isolation (asserting the absence of
unrequested section headers), the `--issue` comment-thread render, `--relations`
body-leak absence and self-exclusion, canonical emission order, the parent-404
path, `--diff` truncation accounting (all-omitted and mid-list), the `--pr`
no-PR case, every arg-validation exit-2 path, and the two buffer-then-flush
empty-stdout error paths. Full suite: 2264/2264 passing.

## Acceptance criteria

- [x] `dispatch-context-pack` exists, is executable, accepts any combination of
      `--issue`/`--relations`/`--pr`/`--diff`, emitting only the requested
      sections.
- [x] `--relations` emits titles + state + URL only, never related-issue bodies.
- [x] `--diff` caps hunk output and prints an explicit truncation line naming the
      omitted-file count.
- [x] `--pr` resolves the PR via `dispatch-find-pr` internally and emits number,
      labels, and CI rollup.
- [x] A bad issue number or failed `gh`/`git` call exits non-zero with a clear
      diagnostic and no partial-success fallback.
- [x] `test-dispatch-scripts.sh` covers each slice and the error path.
