### PR TITLE
dispatch: CI-cadence reseed for CI-pending priority work at target=0

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -735,8 +735,23 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
     # CI is the sole reason this item is unselectable. PR_SORTED is oldest-first,
     # so the first recorded candidate is the oldest.
     if [[ "$PRIORITY_ONLY" == "true" && -z "$WAITING_NUM" ]]; then
-      local_issue="${pr_branch%%-*}"
-      if [[ -n "$local_issue" && -z "${EXCLUDED[$local_issue]:-}" ]] \
+      # The reseed target must be the canonical priority issue, NOT the PR
+      # branch prefix (#1444). A branch may diverge from its closing-issue
+      # number (e.g. `100-fix` closing priority issue `200`), and a branch with
+      # no `<N>-` prefix yields a non-numeric value the reseed sink rejects —
+      # silently stranding the very priority item this path exists to rescue.
+      # Resolve the priority-labeled closing issue from `pr_closing` (already in
+      # scope), reusing ISSUE_LABELS_JSON exactly as pr_combined_labels does. The
+      # line-712 gate guarantees at least one closing issue carries `priority` in
+      # --priority-only mode, and dispatch-find-pr resolves issue→PR via the
+      # issue's closedByPullRequestsReferences fallback, so the priority issue
+      # number is the resolvable, correct target.
+      local_issue=$(printf '%s' "$pr_closing" \
+        | jq -r --argjson map "$ISSUE_LABELS_JSON" \
+          'map(.number | tostring
+               | select((($map[.] // []) | any(.name == "priority"))))
+           | .[0] // empty')
+      if [[ "$local_issue" =~ ^[0-9]+$ && -z "${EXCLUDED[$local_issue]:-}" ]] \
          && ! pr_issue_office_hours_parked "$local_issue" \
          && ! pr_blocked_by_open "$pr_closing"; then
         WAITING_NUM="$local_issue"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -72,6 +72,8 @@
 #   main-broken <sha>           — origin/main's HEAD CI has a failing check
 #   pr <num> <branch> <phase>   — the highest-priority priority=1 PR
 #   issue <num>                 — the highest-priority priority=1 help-wanted issue
+#   waiting <issue#>            — a priority item exists but its draft PR's CI is
+#                                 still pending (skipped solely by dispatch-ci-ready)
 #   empty                       — no priority=1 item eligible
 #
 # Selection is three-tier: the `priority` label is the *outermost* axis, topic
@@ -679,6 +681,27 @@ PHASE_PRIORITY=(fix-conflicts review fix-checks)
 # (implement phase) advances ahead of an unplanned issue (plan phase).
 ISSUE_PHASE_PRIORITY=(implement plan)
 
+# True when the issue (resolved from a PR's branch prefix) is parked on a
+# human via dispatch:office-hours. Reads ISSUE_LABELS_JSON.
+pr_issue_office_hours_parked() {
+  local num="$1"
+  [[ -z "$num" ]] && return 1
+  printf '%s' "$ISSUE_LABELS_JSON" | jq -e --arg n "$num" \
+    '(.[$n] // []) | any(.name == "dispatch:office-hours")' >/dev/null
+}
+
+# True when any issue a PR closes has >0 open blockers (or unknown → fail
+# closed). Reads BLOCKER_COUNTS. Mirrors the inline blocked check.
+pr_blocked_by_open() {
+  local closing="$1" blocked
+  blocked=$(printf '%s' "$closing" \
+    | jq -r --argjson blk "$BLOCKER_COUNTS" \
+      'if any(.[]; $blk[(.number|tostring)] as $c | $c == null or $c > 0)
+       then "true" else "false" end')
+  [[ "$blocked" == "true" ]]
+}
+
+WAITING_NUM=""
 while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   [[ -z "$pr_num" ]] && continue
 
@@ -703,6 +726,22 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   # rollup is still pending; a concluded (passing/failing) rollup, a non-draft
   # PR, or no PR all report ready. Reuses the PR list fetched above.
   if ! DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-ci-ready" "$pr_branch" >/dev/null; then
+    # --priority-only waiting detection (#1444): a CI-pending priority PR that is
+    # otherwise eligible — not office-hours-parked, not blocked, not excluded
+    # (claimed worktrees already `continue`d above; a CI-pending draft can never
+    # be phase `done`) — is recorded as a waiting candidate so dispatch-select-tick
+    # can arm a CI-cadence reseed instead of the pace reseed. The checks mirror the
+    # office-hours/blocked/exclude skips further down, so `waiting` fires ONLY when
+    # CI is the sole reason this item is unselectable. PR_SORTED is oldest-first,
+    # so the first recorded candidate is the oldest.
+    if [[ "$PRIORITY_ONLY" == "true" && -z "$WAITING_NUM" ]]; then
+      local_issue="${pr_branch%%-*}"
+      if [[ -n "$local_issue" && -z "${EXCLUDED[$local_issue]:-}" ]] \
+         && ! pr_issue_office_hours_parked "$local_issue" \
+         && ! pr_blocked_by_open "$pr_closing"; then
+        WAITING_NUM="$local_issue"
+      fi
+    fi
     continue
   fi
 
@@ -726,9 +765,7 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   # (${pr_branch%%-*}). Shared loop ⇒ also covers --qa selection — harmless and
   # consistent.
   [[ -n "$pr_issue_num" && -n "${EXCLUDED[$pr_issue_num]:-}" ]] && continue
-  if [[ -n "$pr_issue_num" ]] && printf '%s' "$ISSUE_LABELS_JSON" \
-      | jq -e --arg n "$pr_issue_num" \
-        '(.[$n] // []) | any(.name == "dispatch:office-hours")' >/dev/null; then
+  if [[ -n "$pr_issue_num" ]] && pr_issue_office_hours_parked "$pr_issue_num"; then
     continue
   fi
 
@@ -743,11 +780,9 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   # between the PR-list fetch and the GraphQL call, so its alias came back null
   # and was dropped. Treat unknown as blocked (fail closed) so a gated PR is
   # never advanced on missing data.
-  pr_blocked=$(printf '%s' "$pr_closing" \
-    | jq -r --argjson blk "$BLOCKER_COUNTS" \
-      'if any(.[]; $blk[(.number|tostring)] as $c | $c == null or $c > 0)
-       then "true" else "false" end')
-  [[ "$pr_blocked" == "true" ]] && continue
+  if pr_blocked_by_open "$pr_closing"; then
+    continue
+  fi
 
   # Record the oldest TOP PRs seen in this category+priority+phase. PR_SORTED is
   # oldest-first, so the list accumulates oldest-first; bucket_append caps it at
@@ -937,7 +972,11 @@ if (( TOP == 1 )); then
     done
   done
 
-  echo "empty"
+  if [[ "$PRIORITY_ONLY" == "true" && -n "$WAITING_NUM" ]]; then
+    echo "waiting $WAITING_NUM"
+  else
+    echo "empty"
+  fi
 else
   # TOP>1: a parallel walk over the SAME nesting, draining each bucket's
   # newline list oldest-first into a results array until it holds TOP entries.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -186,6 +186,16 @@ fi
 #          still counted by claude_agents_count_busy_workers on later ticks, so
 #          it suppresses non-priority fan-out: it bypasses the GATE, not the
 #          COUNT.
+#        - `waiting <N>` → a priority PR exists but its CI is pending (#1444).
+#          At target=0 there is no busy worker re-probing priority on a
+#          baton-pass, so the pace reseed would strand the item until the pace
+#          window reopens. Arm the CI-cadence reseed instead:
+#          `dispatch-schedule-target-reseed <N>` re-runs dispatch-tick <N> on a
+#          short delay (CI concluded → spawns gate-exempt; still pending →
+#          re-arms, bounded by the ci-wait attempt counter → office-hours).
+#          At target>0 a busy worker already re-probes priority on each
+#          baton-pass, so the existing pace reseed (`dispatch-schedule-reseed`)
+#          is correct. Both paths release the lock and emit `concurrency-cap`.
 #   3. `empty` (no priority/main-broken item waiting) → the unchanged hard cap:
 #      release the lock, schedule the #725 re-seed, emit `concurrency-cap`.
 GAP=1
@@ -243,6 +253,25 @@ if [[ -z "$MANUAL" && -z "$ARG" ]]; then
           # No priority/main-broken item waiting → hard cap as before.
           release_lock
           "$SCRIPT_DIR/dispatch-schedule-reseed" 1>&2 || true
+          echo "concurrency-cap"
+          exit 0
+          ;;
+        waiting\ *)
+          # A CI-pending priority item exists (#1444). At target=0 the at-cap
+          # state has no busy worker re-probing priority on a baton-pass, so the
+          # pace reseed would strand it until the pace window reopens. Arm a
+          # CI-cadence reseed instead — dispatch-schedule-target-reseed re-runs
+          # dispatch-tick <N> on a short delay (CI concluded → spawns gate-exempt;
+          # still pending → re-arms, bounded by the ci-wait attempt counter →
+          # office-hours). At target>0 a busy worker already re-probes priority on
+          # each baton-pass, so the existing pace reseed is correct.
+          WAIT_NUM="${PRIO#waiting }"
+          release_lock
+          if (( TARGET_N == 0 )); then
+            "$SCRIPT_DIR/dispatch-schedule-target-reseed" "$WAIT_NUM" 1>&2 || true
+          else
+            "$SCRIPT_DIR/dispatch-schedule-reseed" 1>&2 || true
+          fi
           echo "concurrency-cap"
           exit 0
           ;;

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -17488,6 +17488,11 @@ FAKE
 echo called >> "$TMPDIR_TEST/logs/schedule-reseed.log"
 exit 0
 FAKE
+  cat > "$TMPDIR_TEST/dispatch-schedule-target-reseed" <<FAKE
+#!/usr/bin/env bash
+echo "\$1" >> "$TMPDIR_TEST/logs/schedule-target-reseed.log"
+exit 0
+FAKE
   # Sourced helper: provides claude_agents_count_busy_workers (driven by
   # SEL_LIVE_COUNT*) and claude_agents_list_all (driven by SEL_AGENTS_*, used by
   # the reservation-ledger sweep the gate runs before counting). The heredoc is
@@ -17511,7 +17516,8 @@ FAKE
            "$TMPDIR_TEST/dispatch-resolve-arg" \
            "$TMPDIR_TEST/dispatch-select-target" \
            "$TMPDIR_TEST/dispatch-target-workers" \
-           "$TMPDIR_TEST/dispatch-schedule-reseed"
+           "$TMPDIR_TEST/dispatch-schedule-reseed" \
+           "$TMPDIR_TEST/dispatch-schedule-target-reseed"
 
   # PATH-shimmed git: branch defaults to main; fetch/merge succeed unless a
   # FAKE_GIT_*_FAIL env var is set.
@@ -17845,6 +17851,36 @@ assert_eq "cap: priority-only probe ran (returned empty)" "1" \
   "$([ -f "$TMPDIR_TEST/logs/select-target-priority.log" ] && echo 1 || echo 0)"
 assert_eq "cap: normal no-arg selection did NOT run" "0" \
   "$([ -f "$TMPDIR_TEST/logs/select-target.log" ] && echo 1 || echo 0)"
+sel_tick_teardown
+
+# --- AC4: target=0, waiting <N> → CI-cadence reseed, not pace reseed (#1444) --
+# At target=0 there is no busy worker re-probing priority on a baton-pass, so
+# dispatch-schedule-target-reseed <N> must be armed (not the pace reseed).
+echo "Test: select-tick at cap, target=0, waiting <N> → CI-cadence reseed with issue number (#1444 AC4)"
+sel_tick_setup
+export SEL_LIVE_COUNT=0 SEL_TARGET_N=0 SEL_EXHAUSTED=ok SEL_PRIORITY_ONLY="waiting 1444"
+out=$(run_sel_tick)
+assert_eq "AC4: decision line" "concurrency-cap" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "AC4: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "AC4: CI-cadence reseed got issue number 1444" "1444" \
+  "$(cat "$TMPDIR_TEST/logs/schedule-target-reseed.log" 2>/dev/null)"
+assert_eq "AC4: pace reseed NOT called" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-reseed.log" ] && echo 1 || echo 0)"
+sel_tick_teardown
+
+# --- AC5: target>0 at cap, waiting <N> → pace reseed (not CI-cadence) (#1444) -
+# At target>0 a busy worker already re-probes priority on each baton-pass, so
+# the existing pace reseed (dispatch-schedule-reseed) is correct.
+echo "Test: select-tick at cap, target>0, waiting <N> → pace reseed, not CI-cadence (#1444 AC5)"
+sel_tick_setup
+export SEL_LIVE_COUNT=3 SEL_TARGET_N=1 SEL_EXHAUSTED=ok SEL_PRIORITY_ONLY="waiting 1444"
+out=$(run_sel_tick)
+assert_eq "AC5: decision line" "concurrency-cap" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "AC5: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "AC5: pace reseed called" "called" \
+  "$(cat "$TMPDIR_TEST/logs/schedule-reseed.log" 2>/dev/null)"
+assert_eq "AC5: CI-cadence reseed NOT called" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-target-reseed.log" ] && echo 1 || echo 0)"
 sel_tick_teardown
 
 # --- concurrency-cap tick still runs reconcile (Step 1d before the gate) -----

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3517,6 +3517,109 @@ result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
 assert_eq "--priority-only JIT suppressed → priority issue returned" "issue 400" "$result"
 teardown
 
+# --- --priority-only `waiting` split (#1444) --------------------------------
+# A lone priority PR whose CI is still pending is skipped by the dispatch-ci-ready
+# readiness gate. Before #1444 that produced `empty`, conflating "no priority work"
+# with "priority work exists but is CI-pending". --priority-only now emits
+# `waiting <issue#>` when CI is the SOLE reason a priority item is unselectable, so
+# dispatch-select-tick can arm a CI-cadence reseed instead of the pace reseed.
+
+# AC1 (#1444). A CI-pending priority PR — otherwise eligible — yields `waiting <N>`.
+# Issue 100 carries `priority` but NOT `help wanted`: a help-wanted priority issue
+# would be returned by the issue queue as `issue 100` before the waiting/empty
+# fallback, masking the split under test.
+echo "Test: --priority-only — CI-pending priority PR → waiting <N> (#1444)"
+setup
+UNION='['"$(make_pr_union 100 "100-priority-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP" '[{"number":100}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only CI-pending priority PR → waiting 100" "waiting 100" "$result"
+teardown
+
+# AC2 (#1444). No priority item at all → `empty` stays `empty` (the waiting split
+# must not fire when there is no priority work). PO4 above already covers a
+# non-priority CI-pending PR → empty; this adds an explicit minimal guard with a
+# single non-priority CI-pending PR so the empty-vs-waiting boundary is pinned.
+echo "Test: --priority-only — no priority item, CI-pending non-priority PR → empty (#1444)"
+setup
+UNION='['"$(make_pr_union 100 "100-bug-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP" '[{"number":100}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only no priority item → empty (not waiting)" "empty" "$result"
+teardown
+
+# AC3a (#1444). A CI-pending priority PR whose issue is ALSO office-hours-parked is
+# NOT a waiting candidate — office-hours is an independent reason it is unselectable,
+# so the split must read `empty`, not `waiting`.
+echo "Test: --priority-only — CI-pending priority PR also office-hours-parked → empty (#1444)"
+setup
+UNION='['"$(make_pr_union 100 "100-priority-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP" '[{"number":100}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"priority"},{"name":"dispatch:office-hours"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only CI-pending + office-hours-parked → empty" "empty" "$result"
+teardown
+
+# AC3b (#1444). A CI-pending priority PR whose closing issue is ALSO blocked_by an
+# open issue is NOT a waiting candidate — blocked is an independent reason, so the
+# split reads `empty`. The blocker fixture mirrors the existing blocked-skip tests
+# (`{"number":999,"state":"open"}`): the stub projects `.state` into the GraphQL
+# `blockedBy.nodes[].state` shape, which dispatch-select-target filters on `OPEN`.
+echo "Test: --priority-only — CI-pending priority PR also blocked → empty (#1444)"
+setup
+UNION='['"$(make_pr_union 100 "100-priority-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP" '[{"number":100}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf '[{"number":999,"state":"open"}]\n' > "$STUB_DIR/blockers-100.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only CI-pending + blocked → empty" "empty" "$result"
+teardown
+
+# Guard (#1444). A selectable priority item must NOT be preempted by the waiting
+# probe: one CI-pending priority PR 100 AND one ready priority PR 200 (failing CI →
+# fix-checks). The selection emits `pr 200 ... fix-checks`; `waiting` is only the
+# TOP==1 terminal fallback, reached only when nothing is selectable.
+echo "Test: --priority-only — selectable priority item not preempted by waiting (#1444)"
+setup
+UNION='['
+UNION+="$(make_pr_union 100 "100-priority-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP" '[{"number":100}]')"','
+UNION+="$(make_pr_union 200 "200-priority-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"
+UNION+=']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]},{"number":200,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"priority"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only selectable priority PR beats waiting" "pr 200 200-priority-pr fix-checks" "$result"
+teardown
+
+# Ordering guarantee (#1444). A CI-pending priority PR whose branch worktree is
+# owned by a live session is `continue`d at the claimed-worktree skip, which
+# precedes the CI gate — so it never reaches the waiting capture and the split
+# reads `empty`. Models the live-session fixture on the claimed-skip tests above.
+echo "Test: --priority-only — claimed CI-pending priority PR → empty (#1444)"
+setup
+UNION='['"$(make_pr_union 100 "100-priority-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP" '[{"number":100}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/100-priority-pr\nHEAD def456\nbranch refs/heads/100-priority-pr\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+select_target_fake_claude "100-priority-pr"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only claimed CI-pending priority PR → empty" "empty" "$result"
+teardown
+
 # PO6. --priority-only rejects combination with the other modes. The guard
 # condition covers all three sibling modes, so exercise each arm: --qa,
 # --health-only, and --main-broken-sha must each be rejected with exit 1.


### PR DESCRIPTION
Closes #1444

## Problem

When dispatch is above the weekly usage curve, `dispatch-target-workers` returns
`0` (the pace gate). At `target=0`, a **priority** issue whose phase just finished
fails to drain promptly: it stalls until the pace window reopens (up to ~an hour)
instead of resuming the moment its CI concludes. Priority work is meant to bypass
pacing entirely, but today it only bypasses the *spawn* gate, not the *wakeup
timing*.

Root cause: at the at-cap branch, `dispatch-select-tick` probes
`dispatch-select-target --priority-only`. A lone priority PR whose CI is still
pending is skipped by the readiness gate (`dispatch-ci-ready` → not ready), so
`--priority-only` returns `empty`. `empty` routes to the **pace** reseed
(`dispatch-schedule-reseed`), which arms the wakeup at the pace-curve reopen time,
not at CI cadence. The defect is that `--priority-only` conflated two states behind
one `empty`: "no priority work exists" (deserves the pace reseed) vs. "priority
work exists but is CI-pending" (needs a CI-cadence wakeup).

The fix is scoped to `target=0`. At `target>0` the at-cap state has busy workers
that re-probe priority on every baton-pass, so the pace reseed is fine —
non-priority work proceeds while priority CI runs.

## Change

**Unit 1 — `dispatch-select-target`:** split the `--priority-only` `empty` output
into `empty` vs `waiting <N>`. A CI-pending priority PR that is skipped *solely* by
the readiness gate — not office-hours-parked, not blocked, not excluded, not
claimed by a live worktree — is now reported as `waiting <N>`. The office-hours and
blocked checks were factored into two helpers (`pr_issue_office_hours_parked`,
`pr_blocked_by_open`) so the waiting branch and the existing skip branches share one
definition; default/`--qa` mode behavior is byte-identical.

**Unit 2 — `dispatch-select-tick`:** the at-cap probe gains a `waiting <N>` case
arm. At `target=0` it arms a CI-cadence reseed via the existing
`dispatch-schedule-target-reseed <N>` machinery (re-runs `dispatch-tick <N>` on a
short delay; CI concluded → spawns gate-exempt; still pending → re-arms, bounded by
the ci-wait attempt counter → office-hours escalation). At `target>0` it falls
through to the existing pace reseed. The lock is released in both branches, exactly
as the `empty` arm does today; no new lock-holding sleep is introduced.

## Tests

Added to `test-dispatch-scripts.sh` (suite stays green at 2286/2286):

- `--priority-only` emits `waiting <N>` for a lone CI-pending priority PR; `empty`
  when no priority item exists; `empty` when the CI-pending item is also
  office-hours-parked or blocked; a selectable priority item is never preempted by
  `waiting`; and a claimed CI-pending priority PR stays `empty`.
- `dispatch-select-tick` at `target=0` on `waiting <N>` calls
  `dispatch-schedule-target-reseed <N>` (asserting the correct issue number `<N>`
  propagates) and not the pace reseed; at `target>0` it falls through to the pace
  reseed.

## Out of scope

The plain `empty` path at `target>0` under cap with an empty queue releases the lock
with no reseed, so a CI-pending-priority-only queue with no other work stalls until
the #725 heartbeat. Separate finding; not addressed here.
