### PR TITLE
dispatch: exclude done-ready targets from selection + backstop headless-tick continuation

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -886,20 +886,25 @@ while IFS=$'\t' read -r issue_num issue_labels; do
       # which precedes the issue within a bucket and recycles the orphan worktree
       # via `enter` just as the issue path would. dispatch-ci-ready resolves the
       # all-digit leaf to its PR by headRefName prefix. Reuses the PR list above.
-      if ! DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-ci-ready" "$leaf" >/dev/null; then
+      #
+      # The done-ready exclusion runs FIRST, before dispatch-ci-ready, to skip the
+      # subprocess fork for a done-ready leaf. A non-draft (ready) PR on the leaf's
+      # own <leaf>-* branch makes the leaf phase `done` (dispatch-phase's
+      # non-draft→done rule). dispatch-materialize-spawn would re-derive that done
+      # phase at the spawn boundary and drain it, spawning no worker — killing the
+      # chain. Exclude the done leaf here at selection time, mirroring that
+      # spawn-boundary done re-check, and continue descending the same root to the
+      # next startable leaf — exactly like the not-ready skip below (#1445). The
+      # root-keyed READY_PR_CLOSED_ISSUES skip above only catches a done *root*;
+      # this branch-keyed set is the authoritative check on the traced leaf.
+      # READY_PR_BRANCH_ISSUES membership implies the leaf already has a non-draft
+      # PR, for which dispatch-ci-ready would unconditionally pass — so skipping the
+      # call here changes nothing but the saved fork.
+      if [[ -n "${READY_PR_BRANCH_ISSUES[$leaf]:-}" ]]; then
         root_excl["$leaf"]=1
         continue
       fi
-      # A non-draft (ready) PR on the leaf's own <leaf>-* branch makes the leaf
-      # phase `done` (dispatch-phase's non-draft→done rule). dispatch-materialize-spawn
-      # would re-derive that done phase at the spawn boundary and drain it,
-      # spawning no worker — killing the chain. Exclude the done leaf here at
-      # selection time, mirroring that spawn-boundary done re-check, and continue
-      # descending the same root to the next startable leaf — exactly like the
-      # not-ready skip above (#1445). The root-keyed READY_PR_CLOSED_ISSUES skip
-      # above only catches a done *root*; this branch-keyed set is the
-      # authoritative check on the traced leaf.
-      if [[ -n "${READY_PR_BRANCH_ISSUES[$leaf]:-}" ]]; then
+      if ! DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-ci-ready" "$leaf" >/dev/null; then
         root_excl["$leaf"]=1
         continue
       fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -792,6 +792,22 @@ done < <(printf '%s' "$PR_LIST" | jq -r '
   .[] | select(.isDraft == false)
   | (.closingIssuesReferences // [])[].number')
 
+# Issue numbers whose own <N>-* branch carries a non-draft (ready) PR. Unlike
+# READY_PR_CLOSED_ISSUES (which keys on closingIssuesReferences, i.e. the root
+# help-wanted issue), this set keys on the headRefName branch-prefix issue number
+# — the traced leaf — exactly how dispatch-ci-ready/dispatch-phase resolve a PR
+# (by <N>- prefix). A non-draft PR is phase `done` per dispatch-phase's
+# non-draft→done rule, so this set is provably equivalent to dispatch-phase's
+# `done` over the open-PR domain, built with zero extra gh calls (#1445).
+declare -A READY_PR_BRANCH_ISSUES
+while IFS= read -r branch_num; do
+  [[ -z "$branch_num" ]] && continue
+  READY_PR_BRANCH_ISSUES["$branch_num"]=1
+done < <(printf '%s' "$PR_LIST" | jq -r '
+  .[] | select(.isDraft == false)
+  | select(.headRefName | test("^[0-9]+-"))
+  | (.headRefName | capture("^(?<n>[0-9]+)-").n)')
+
 # First-seen help-wanted issue per category. The queue is the open-issue list
 # filtered client-side to "help wanted"; issues whose <N>-* worktree is owned
 # by a live session are skipped. Each candidate is resolved to a
@@ -871,6 +887,19 @@ while IFS=$'\t' read -r issue_num issue_labels; do
       # via `enter` just as the issue path would. dispatch-ci-ready resolves the
       # all-digit leaf to its PR by headRefName prefix. Reuses the PR list above.
       if ! DISPATCH_PR_LIST="$PR_LIST" "$SCRIPT_DIR/dispatch-ci-ready" "$leaf" >/dev/null; then
+        root_excl["$leaf"]=1
+        continue
+      fi
+      # A non-draft (ready) PR on the leaf's own <leaf>-* branch makes the leaf
+      # phase `done` (dispatch-phase's non-draft→done rule). dispatch-materialize-spawn
+      # would re-derive that done phase at the spawn boundary and drain it,
+      # spawning no worker — killing the chain. Exclude the done leaf here at
+      # selection time, mirroring that spawn-boundary done re-check, and continue
+      # descending the same root to the next startable leaf — exactly like the
+      # not-ready skip above (#1445). The root-keyed READY_PR_CLOSED_ISSUES skip
+      # above only catches a done *root*; this branch-keyed set is the
+      # authoritative check on the traced leaf.
+      if [[ -n "${READY_PR_BRANCH_ISSUES[$leaf]:-}" ]]; then
         root_excl["$leaf"]=1
         continue
       fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -303,7 +303,28 @@ run_materialize() {
   # — materialize-spawn now spawns a resolver bg job and emits `propagate`, so the
   # token no longer reaches here, but the branch keeps it a safe exit-0 disposition.
   case "$token" in
-    propagate|drain|drain\ *|notify\ *|resolve\ merge-conflict)
+    propagate|resolve\ merge-conflict)
+      # A worker/resolver was spawned — its Stop-hook carries the chain. Bare
+      # exit; calling recover here would wrongly increment its failure counter.
+      exit 0
+      ;;
+    notify\ *)
+      # Explicit-dispatch user-facing path: a one-shot named target, not the
+      # autonomous heartbeat — no continuation backstop needed.
+      exit 0
+      ;;
+    drain|drain\ *)
+      # #1445 backstop: a no-spawn drain (target-done / worktree-conflict /
+      # fan-out-all-done) spawns no worker and the headless tick never calls
+      # dispatch-self-close, so nothing else guarantees a continuation. Trigger
+      # the continuation-guarantor directly. Best-effort: recover self-limits
+      # (its continuation-check resets the consecutive-failure count when a
+      # reseed timer or busy worker already exists) and escalates past its cap
+      # via a dispatch:chain-stalled issue — both intended. Its OnFailure=
+      # handler is not wired on this direct call, which is fine: recover almost
+      # never fails and any real failure is logged below.
+      "$SCRIPT_DIR/dispatch-tick-recover" || \
+        echo "dispatch-tick: dispatch-tick-recover failed on '$token' (continuation not guaranteed)" >&2
       exit 0
       ;;
     *)

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -299,9 +299,11 @@ run_materialize() {
   token=$(printf '%s\n' "$mat_out" | tail -n 1)
   # Every recognized terminal token is a log-and-exit-0 disposition for a headless
   # tick: the token is already in the journal via the passthrough above, and there
-  # is no managed job to self-close. `resolve merge-conflict` is a defensive no-op
-  # — materialize-spawn now spawns a resolver bg job and emits `propagate`, so the
-  # token no longer reaches here, but the branch keeps it a safe exit-0 disposition.
+  # is no managed job to self-close. A no-spawn `drain` additionally triggers the
+  # dispatch-tick-recover continuation backstop before exiting 0 (see that arm,
+  # #1445). `resolve merge-conflict` is a defensive no-op — materialize-spawn now
+  # spawns a resolver bg job and emits `propagate`, so the token no longer reaches
+  # here, but the branch keeps it a safe exit-0 disposition.
   case "$token" in
     propagate|resolve\ merge-conflict)
       # A worker/resolver was spawned — its Stop-hook carries the chain. Bare

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3323,6 +3323,52 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "issue closed only by draft PR is still selectable" "issue 55" "$result"
 teardown
 
+# --- done-ready branch-keyed leaf gate (#1445) ---
+# A non-draft (ready) PR on a traced leaf's own <leaf>-* branch makes the leaf
+# phase `done` (dispatch-phase non-draft→done). At the spawn boundary
+# dispatch-materialize-spawn re-derives that done phase and drains it, spawning
+# no worker — killing the chain. dispatch-select-target now excludes such a leaf
+# via the branch-keyed READY_PR_BRANCH_ISSUES set, distinct from the root-keyed
+# READY_PR_CLOSED_ISSUES (#920) which only catches a done *root* via
+# closingIssuesReferences. These cases use EMPTY closing refs so only the
+# branch-keyed set can fire — proving it is the authoritative leaf check.
+
+echo "Test: --priority-only — done-ready priority leaf (non-draft <N>- PR) excluded → empty (#1445)"
+setup
+UNION='['"$(make_pr_union 100 "100-foo" "2024-01-01T00:00:00Z" "false" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "done-ready priority leaf excluded → empty" "empty" "$result"
+teardown
+
+echo "Test: --priority-only — done-ready sub-issue LEAF (non-draft <leaf>- PR) excluded → empty (#1445)"
+setup
+UNION='['"$(make_pr_union 5500 "5500-foo" "2024-01-01T00:00:00Z" "false" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf '[{"number":5500}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-5500.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "done-ready sub-issue leaf excluded → empty" "empty" "$result"
+teardown
+
+echo "Test: default mode — done-ready leaf skipped, next eligible issue selected (#1445)"
+setup
+UNION='['"$(make_pr_union 100 "100-foo" "2024-01-01T00:00:00Z" "false" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"}]},{"number":200,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "done-ready issue skipped → next issue selected" "issue 200" "$result"
+teardown
+
 # --- issue-queue CI-ready gate (#1106) ---
 # A help-wanted issue can carry a draft PR whose CI is in progress (#920 leaves
 # such an issue selectable). The issue loop now applies the same readiness gate
@@ -19215,10 +19261,18 @@ FAKE
 echo refresh >> "$TMPDIR_TEST/logs/order.log"
 exit \${TICK_REFRESH_RC:-0}
 FAKE
+  # Fake dispatch-tick-recover (#1445): records that it ran so a test can assert
+  # the no-spawn-drain backstop fired. Exits 0.
+  cat > "$TMPDIR_TEST/dispatch-tick-recover" <<FAKE
+#!/usr/bin/env bash
+echo "recover" >> "$TMPDIR_TEST/logs/recover.log"
+exit 0
+FAKE
   chmod +x "$TMPDIR_TEST/dispatch-select-tick" \
            "$TMPDIR_TEST/dispatch-materialize-spawn" \
            "$TMPDIR_TEST/dispatch-spawn-job" \
-           "$TMPDIR_TEST/dispatch-refresh-rate-limits"
+           "$TMPDIR_TEST/dispatch-refresh-rate-limits" \
+           "$TMPDIR_TEST/dispatch-tick-recover"
 }
 
 tick_teardown() {
@@ -19318,6 +19372,52 @@ for t in "propagate" "notify target-blocked" "notify spawn-failed" "notify ci-wa
   assert_eq "token '$t': exit 0" "0" "$rc"
   tick_teardown
 done
+
+# --- #1445: a no-spawn drain invokes dispatch-tick-recover; a spawning token does not ---
+echo "Test: dispatch-tick drain target-done → invokes recover, exit 0 (#1445)"
+tick_setup
+export TICK_DECISION="issue 707 1" TICK_TOKEN="drain target-done"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "drain target-done: exit 0" "0" "$rc"
+assert_eq "drain target-done: recover invoked" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/recover.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+echo "Test: dispatch-tick bare drain → invokes recover, exit 0 (#1445)"
+tick_setup
+export TICK_DECISION="issue 707 1" TICK_TOKEN="drain"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "drain: exit 0" "0" "$rc"
+assert_eq "drain: recover invoked" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/recover.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+echo "Test: dispatch-tick propagate → does NOT invoke recover (#1445)"
+tick_setup
+export TICK_DECISION="issue 707 1" TICK_TOKEN="propagate"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "propagate: exit 0" "0" "$rc"
+assert_eq "propagate: recover NOT invoked" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/recover.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+echo "Test: dispatch-tick notify target-blocked → does NOT invoke recover (#1445)"
+tick_setup
+export TICK_DECISION="issue 707 1" TICK_TOKEN="notify target-blocked"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "notify: exit 0" "0" "$rc"
+assert_eq "notify: recover NOT invoked" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/recover.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+echo "Test: dispatch-tick resolve merge-conflict → does NOT invoke recover (#1445)"
+tick_setup
+export TICK_DECISION="issue 707 1" TICK_TOKEN="resolve merge-conflict"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "resolve merge-conflict: exit 0" "0" "$rc"
+assert_eq "resolve merge-conflict: recover NOT invoked" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/recover.log" ] && echo 1 || echo 0)"
+tick_teardown
 
 # --- materialize-spawn exits non-zero → dispatch-tick exits 2 ----------------
 echo "Test: dispatch-tick materialize non-zero exit → exit 2"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3369,6 +3369,31 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "done-ready issue skipped → next issue selected" "issue 200" "$result"
 teardown
 
+# 41-bis. Sibling fallback WITHIN one root: the done-ready skip must continue the
+#         descent to the next leaf, not abandon the whole root. Root 55 has
+#         sub-issues 5500 (non-draft PR on its own 5500-* branch → done-ready,
+#         excluded by READY_PR_BRANCH_ISSUES) and 5501 (open, no PR, startable).
+#         EMPTY closingIssuesReferences keeps the root-keyed #920 set silent, so
+#         only the branch-keyed leaf set fires. The selector must return 5501 —
+#         a regression that terminated the root on the done-ready leaf would
+#         yield empty here.
+echo "Test: default mode — done-ready leaf skipped, sibling leaf in same root selected (#1445)"
+setup
+UNION='['"$(make_pr_union 5500 "5500-foo" "2024-01-01T00:00:00Z" "false" "$NO_LABELS" "$GREEN_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf '[{"number":5500},{"number":5501}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-5500.json"
+printf '{"title":"Issue 5501","body":"","comments":[],"number":5501,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-5501.json"
+# No worktrees — only the done-ready PR on 5500 distinguishes the leaves.
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "done-ready leaf 5500 skipped → sibling leaf 5501 selected" "issue 5501" "$result"
+teardown
+
 # --- issue-queue CI-ready gate (#1106) ---
 # A help-wanted issue can carry a draft PR whose CI is in progress (#920 leaves
 # such an issue selectable). The issue loop now applies the same readiness gate


### PR DESCRIPTION
Closes #1445

## Problem

The autonomous dispatch chain propagates only via a spawned worker's Stop-hook or
an armed `dispatch-reseed-*` timer. A headless tick that spawns no worker **and**
arms no reseed ends the chain silently.

At `target=0`, when the top priority item is an issue whose closing PR is already
**done/ready** (non-draft, merge-pending — not dispatchable), the tick selects it
(`issue <N>`), `dispatch-materialize-spawn` re-derives its phase as `done` and
drains it as `drain target-done`, spawning no worker and arming no reseed. The
chain dies with real dispatchable priority work still waiting. Observed idle
window in the incident: Jun 12 21:12 → Jun 13 09:43.

Two independent root defects, both fixed here:

1. **Selection / materialization disagree.** `dispatch-select-target`'s leaf-trace
   loop gates the leaf on `dispatch-ci-ready` (which *passes* a non-draft/done PR)
   but never checks the done phase, and the existing `READY_PR_CLOSED_ISSUES`
   exclusion keys only on the **root** help-wanted issue, not the traced leaf.
2. **No backstop on the headless path.** The #1010 "park-if-no-continuation"
   invariant lives in `dispatch-self-close`, which the headless `dispatch-tick`
   deliberately never calls. A `drain target-done` (or any no-spawn drain) on the
   autonomous path therefore has no safety net.

## Changes

### 1. Exclude done-ready leaves from selection (primary fix)

`dispatch-select-target` now precomputes `READY_PR_BRANCH_ISSUES` — issue numbers
whose own `<N>-*` branch carries a **non-draft** PR — keyed on the `headRefName`
branch prefix (the traced leaf), the same way `dispatch-ci-ready`/`dispatch-phase`
resolve a PR. A non-draft PR is `done` per `dispatch-phase`'s non-draft→done rule,
so this set is provably equivalent to `done` over the open-PR domain, built with
**zero extra `gh` calls** from the already-fetched `PR_LIST`.

In the leaf-trace loop, after the `dispatch-ci-ready` gate and before the leaf is
recorded, a done leaf is excluded (`root_excl["$leaf"]=1; continue`) — mirroring
`dispatch-materialize-spawn`'s spawn-boundary done re-check at selection time, and
continuing the descent to the next startable leaf. This runs in the shared scan,
covering both default and `--priority-only` selection. The root-keyed
`READY_PR_CLOSED_ISSUES` skip is retained as a cheap pre-trace skip for a done
root; the new branch-keyed set is the authoritative leaf check.

### 2. Backstop the headless tick on a no-spawn drain (defense-in-depth)

`dispatch-tick`'s `run_materialize` token-routing `case` is split: `propagate` /
`resolve merge-conflict` (a worker/resolver was spawned → its Stop-hook carries
the chain) and `notify *` (the one-shot explicit path) keep a bare `exit 0`, while
`drain` / `drain *` (no worker spawned) now invoke `dispatch-tick-recover`
(best-effort) before `exit 0`. `dispatch-tick-recover` (#1150) is the
budget-independent continuation-guarantor: it arms a bounded-backoff reseed timer
when no continuation exists, self-limits, and escalates past its cap via a
`dispatch:chain-stalled` issue. This closes the residual selection→materialize
race (a PR flipping non-draft in the worker-boot gap) and any future
no-continuation drain.

### 3. Tests

`test-dispatch-scripts.sh` gains: three `dispatch-select-target` cases (priority-only
returns `empty` for a done-ready leaf; a leaf-specific variant proving the
branch-keyed set catches a done **sub-issue** leaf the root-keyed set would miss;
a default-mode skip-and-select-next case), and five `dispatch-tick` cases
(extending the existing harness with a fake `dispatch-tick-recover`) asserting
`drain`/`drain target-done` invoke recover while `propagate`/`notify *`/`resolve
merge-conflict` do not.

## Scope boundary

This PR closes #1445 only. Explicitly out of scope: the `target>0, only-done-ready`
benign idle, and the plain-`empty`-path-releases-lock-with-no-reseed finding — that
is the #1444 sibling's separate path.

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` →
**2285/2285 pass**, no existing test regressed (including the `--priority-only`,
#920 ready-PR-closed, and materialize done-re-check cases).
