### PR TITLE
dispatch: cap open-PR fetches with an explicit --limit and loud truncation guard

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -106,6 +106,7 @@ ISSUE_NUM="${JOB_NAME%%-*}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 0
 SCRIPTS="$SCRIPT_DIR/../skills/dispatch-propagate/scripts"
+source "$SCRIPTS/lib.sh"
 
 # Resolve the why-comment reason. The #826 enrichment hook may write a
 # context-specific reason to $CLAUDE_JOB_DIR/office-hours-reason; when present
@@ -169,8 +170,7 @@ PR_NUM=$("$SCRIPTS/dispatch-find-pr" "$ISSUE_NUM" 2>/dev/null) || PR_NUM=""
 # phase derivation below via DISPATCH_PR_LIST, avoiding a redundant `gh pr list`
 # per predicate. On fetch failure DISPATCH_PR_LIST stays empty and each script
 # falls back to its own self-fetch.
-DISPATCH_PR_LIST=$(gh pr list --state open \
-  --json number,headRefName,isDraft,statusCheckRollup,labels,mergeable 2>/dev/null) \
+DISPATCH_PR_LIST=$(pr_list_open "number,headRefName,isDraft,statusCheckRollup,labels,mergeable" 2>/dev/null) \
   || DISPATCH_PR_LIST=""
 export DISPATCH_PR_LIST
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-ci-ready
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-ci-ready
@@ -39,7 +39,7 @@ fi
 if [[ -n "${DISPATCH_PR_LIST:-}" ]]; then
   PR_LIST="$DISPATCH_PR_LIST"
 else
-  PR_LIST=$(gh pr list --state open --json number,headRefName,isDraft,statusCheckRollup,labels,mergeable)
+  PR_LIST=$(pr_list_open "number,headRefName,isDraft,statusCheckRollup,labels,mergeable")
 fi
 
 # Find the matching PR.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-find-pr
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-find-pr
@@ -34,6 +34,9 @@
 #     (default: 1). Set to 0 in tests to avoid sleeps.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
 ARG="${1:-}"
 if [[ -z "$ARG" || ! "$ARG" =~ ^[0-9]+$ ]]; then
   echo "error: usage: dispatch-find-pr <issue-num>" >&2
@@ -50,7 +53,7 @@ prefix_match() {
 if [[ -n "${DISPATCH_PR_LIST:-}" ]]; then
   PR_LIST="$DISPATCH_PR_LIST"
 else
-  PR_LIST=$(gh pr list --state open --json number,headRefName)
+  PR_LIST=$(pr_list_open "number,headRefName")
 fi
 
 RESULT=$(prefix_match "$PR_LIST")
@@ -59,7 +62,7 @@ if [[ -n "$RESULT" ]]; then echo "$RESULT"; exit 0; fi
 # Retry-on-empty (self-fetch path only).
 if [[ -z "${DISPATCH_PR_LIST:-}" ]]; then
   sleep "${DISPATCH_FIND_PR_RETRY_DELAY:-1}"
-  PR_LIST=$(gh pr list --state open --json number,headRefName)
+  PR_LIST=$(pr_list_open "number,headRefName")
   RESULT=$(prefix_match "$PR_LIST")
   if [[ -n "$RESULT" ]]; then echo "$RESULT"; exit 0; fi
 fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-find-pr
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-find-pr
@@ -19,7 +19,9 @@
 #   2. Cross-check via closedByPullRequestsReferences: fetches the issue's
 #      own list of closing PRs and returns any OPEN reference. This catches
 #      the branch-renamed-away case and provides a second authority on the
-#      "no PR" question regardless of which path resolved PR_LIST.
+#      "no PR" question regardless of which path successfully resolved
+#      PR_LIST. (On the self-fetch path, a gh failure or truncation guard in
+#      pr_list_open aborts before this cross-check runs — see below.)
 #
 # Environment:
 #   DISPATCH_PR_LIST           — optional. A JSON array of open PRs supplied
@@ -53,7 +55,20 @@ prefix_match() {
 if [[ -n "${DISPATCH_PR_LIST:-}" ]]; then
   PR_LIST="$DISPATCH_PR_LIST"
 else
-  PR_LIST=$(pr_list_open "number,headRefName")
+  # pr_list_open returns non-zero on a gh failure OR when its truncation guard
+  # fires (the snapshot hit --limit and is likely cut off). On either, abort
+  # loudly and propagate the code rather than continuing.
+  #
+  # This is a deliberate behavior change from the pre-#1312 code, where
+  # gh pr list returned exit 0 even on truncation, so the retry below always
+  # ran on the self-fetch path. Now:
+  #   - No retry on truncation: a second fetch hits the same --limit and
+  #     truncates identically, so retrying cannot help.
+  #   - No fall-through to the cross-check: that endpoint only sees PRs linked
+  #     as closing the issue, so a truncated list silently resolving to "no PR"
+  #     is exactly the #1312 bug (caller would create a duplicate PR). A loud
+  #     abort is the safe outcome (see .claude/rules/code-style.md).
+  PR_LIST=$(pr_list_open "number,headRefName") || exit "$?"
 fi
 
 RESULT=$(prefix_match "$PR_LIST")

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-phase
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-phase
@@ -49,7 +49,7 @@ fi
 if [[ -n "${DISPATCH_PR_LIST:-}" ]]; then
   PR_LIST="$DISPATCH_PR_LIST"
 else
-  PR_LIST=$(gh pr list --state open --json number,headRefName,isDraft,statusCheckRollup,labels,mergeable)
+  PR_LIST=$(pr_list_open "number,headRefName,isDraft,statusCheckRollup,labels,mergeable")
 fi
 
 # Find the matching PR.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-reconcile-ready
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-reconcile-ready
@@ -51,8 +51,7 @@ source "$SCRIPT_DIR/lib.sh"  # dispatch_classify_rollup
 
 # ---- Step 1: one fetch of every open PR -------------------------------------
 PR_LIST_RC=0
-PR_LIST=$(gh pr list --state open \
-  --json number,isDraft,labels,statusCheckRollup,mergeable) || PR_LIST_RC=$?
+PR_LIST=$(pr_list_open "number,isDraft,labels,statusCheckRollup,mergeable") || PR_LIST_RC=$?
 if [[ "$PR_LIST_RC" -ne 0 ]]; then
   echo "dispatch-reconcile-ready: error: gh pr list failed (rc=$PR_LIST_RC)" >&2
   exit 1

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-route
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-route
@@ -48,6 +48,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
 
 N="${1:-}"
 WORKTREE_PATH="${2:-}"
@@ -118,7 +119,7 @@ fi
 
 # Fetch the open-PR list once; reuse it for every sibling call via the
 # DISPATCH_PR_LIST env contract (dispatch-ci-ready and dispatch-phase both honor it).
-DISPATCH_PR_LIST=$(gh pr list --state open --json number,headRefName,isDraft,statusCheckRollup,labels,mergeable)
+DISPATCH_PR_LIST=$(pr_list_open "number,headRefName,isDraft,statusCheckRollup,labels,mergeable")
 export DISPATCH_PR_LIST
 
 # Initial CI-ready gate. exit 0 (ready) → continue; exit 1 (waiting) → STOP waiting;

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-route
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-route
@@ -20,6 +20,8 @@
 #   STOP waiting                    dispatch-ci-ready reports not-ready (draft PR CI pending)
 #   STOP provision-failed           direnv/merge provisioning failed (non-conflict);
 #                                   an office-hours-reason is written here before printing it
+#   STOP pr-list-failed             pr_list_open failed (gh error or truncation guard);
+#                                   an office-hours-reason is written here before printing it
 #   STOP wrong-worktree             cross-check failed (diagnostic on stderr); exits non-zero
 #
 # Usage error (missing <N> or <worktree-path>) → stderr message, exit 2 (matches
@@ -119,7 +121,20 @@ fi
 
 # Fetch the open-PR list once; reuse it for every sibling call via the
 # DISPATCH_PR_LIST env contract (dispatch-ci-ready and dispatch-phase both honor it).
-DISPATCH_PR_LIST=$(pr_list_open "number,headRefName,isDraft,statusCheckRollup,labels,mergeable")
+PR_LIST_RC=0
+DISPATCH_PR_LIST=$(pr_list_open "number,headRefName,isDraft,statusCheckRollup,labels,mergeable") || PR_LIST_RC=$?
+if [[ "$PR_LIST_RC" -ne 0 ]]; then
+  # gh failure or truncation guard (>= DISPATCH_PR_LIST_LIMIT open PRs). Don't let
+  # set -e abort silently with no directive — park the issue to office-hours so the
+  # worker's Stop hook escalates rather than leaving the chain in an inconsistent state.
+  if [[ -n "${CLAUDE_JOB_DIR:-}" && -d "$CLAUDE_JOB_DIR" ]]; then
+    printf '%s\n' "dispatch-route: pr_list_open failed for #${N} (exit ${PR_LIST_RC})" \
+      > "$CLAUDE_JOB_DIR/office-hours-reason.tmp"
+    mv "$CLAUDE_JOB_DIR/office-hours-reason.tmp" "$CLAUDE_JOB_DIR/office-hours-reason"
+  fi
+  echo "STOP pr-list-failed"
+  exit 0
+fi
 export DISPATCH_PR_LIST
 
 # Initial CI-ready gate. exit 0 (ready) → continue; exit 1 (waiting) → STOP waiting;

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -495,7 +495,7 @@ issue_worktree_claimed() {
 # (passed as DISPATCH_PR_LIST) instead of re-running gh pr list.
 # closingIssuesReferences drives topic-category resolution: a PR inherits the
 # highest-priority topic among the labels of every issue it closes.
-PR_LIST=$(gh pr list --state open --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels,closingIssuesReferences,mergeable)
+PR_LIST=$(pr_list_open "number,createdAt,headRefName,isDraft,statusCheckRollup,labels,closingIssuesReferences,mergeable")
 # The office-hours skip is ISSUE-anchored (issue #909): dispatch:office-hours
 # lives on the issue, not the PR, so it is not filtered here on PR labels.
 # Instead the main PR loop below resolves each candidate PR's issue from its

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -111,6 +111,31 @@ gh_api_array() {
   fi
 }
 
+# The explicit open-PR fetch cap. gh pr list defaults to 30, which silently
+# truncates the open-PR snapshot once a fan-out crosses 30 open PRs. 300 mirrors
+# dispatch-select-target's open-issue cap. Overridable for tests.
+DISPATCH_PR_LIST_LIMIT="${DISPATCH_PR_LIST_LIMIT:-300}"
+
+# Fetch all open PRs with an explicit --limit and a loud truncation guard.
+# Args: $1 = comma-separated --json field set (e.g. "number,headRefName").
+# Output: the gh pr list JSON array on stdout.
+# Returns non-zero on gh failure (propagated) OR on truncation — when the result
+# length equals the limit, meaning the snapshot is likely cut off. Errors to
+# stderr in the truncation case so the failure is never silent.
+pr_list_open() {
+  local fields="$1"
+  local out rc len
+  out=$(gh pr list --state open --limit "$DISPATCH_PR_LIST_LIMIT" --json "$fields")
+  rc=$?
+  [[ "$rc" -ne 0 ]] && return "$rc"
+  len=$(printf '%s' "$out" | jq 'length')
+  if [[ "$len" -eq "$DISPATCH_PR_LIST_LIMIT" ]]; then
+    echo "error: gh pr list returned exactly $DISPATCH_PR_LIST_LIMIT open PRs (the --limit) — the open-PR snapshot is likely truncated. Raise DISPATCH_PR_LIST_LIMIT." >&2
+    return 1
+  fi
+  printf '%s\n' "$out"
+}
+
 # Count the open blockers of <issue-num> via GitHub's blocked_by dependency
 # edges. Prints an integer; closed blockers do not gate work, so only open
 # blockers are counted.

--- a/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
@@ -129,7 +129,7 @@ fi
 # dispatch-find-pr accepts it too (mirrors dispatch-select-target's
 # DISPATCH_PR_LIST).
 if [[ -n "$FRESH_NUM" ]]; then
-  PR_LIST=$(gh pr list --state open --json number,headRefName,isDraft,statusCheckRollup,labels,mergeable)
+  PR_LIST=$(pr_list_open "number,headRefName,isDraft,statusCheckRollup,labels,mergeable")
   # Readiness gate: dispatch-phase no longer emits `waiting`; check CI readiness
   # first. A not-ready draft PR (exit non-zero) maps to phase=waiting, preserving
   # the byte-identical output contract callers expect.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -158,7 +158,7 @@ STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
 # Reconstruct full args string for matching.
 args="$*"
 case "$args" in
-  "pr list --state open --json number,headRefName,isDraft,statusCheckRollup,labels,mergeable")
+  "pr list --state open --limit 300 --json number,headRefName,isDraft,statusCheckRollup,labels,mergeable")
     echo "pr list" >> "$STUB_DIR/gh-pr-list-calls.log"
     if [[ -f "$STUB_DIR/pr-list-full.json" ]]; then
       cat "$STUB_DIR/pr-list-full.json"
@@ -166,7 +166,7 @@ case "$args" in
       echo "[]"
     fi
     ;;
-  "pr list --state open --json number,headRefName")
+  "pr list --state open --limit 300 --json number,headRefName")
     # dispatch-find-pr self-fetch: only the two correlation fields.
     echo "pr list" >> "$STUB_DIR/gh-pr-list-calls.log"
     echo "pr list" >> "$STUB_DIR/gh-find-pr-calls.log"
@@ -179,7 +179,7 @@ case "$args" in
       echo "[]"
     fi
     ;;
-  "pr list --state open --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels,closingIssuesReferences,mergeable")
+  "pr list --state open --limit 300 --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels,closingIssuesReferences,mergeable")
     # dispatch-select-target's union fetch now carries `mergeable` (#1241). The
     # field is forward-compatible (consumed by #1243); the current selection path
     # does not read it, and make_pr_union fixtures omit it (jq yields null).
@@ -451,7 +451,7 @@ case "$args" in
         ;;
     esac
     ;;
-  "pr list --state open --json number,isDraft,labels,statusCheckRollup,mergeable")
+  "pr list --state open --limit 300 --json number,isDraft,labels,statusCheckRollup,mergeable")
     # dispatch-reconcile-ready's one fetch. $STUB_DIR/reconcile-pr-list.json
     # supplies the per-test PR array; absence means no open PRs.
     echo "pr list" >> "$STUB_DIR/gh-reconcile-pr-list.log"
@@ -1204,7 +1204,7 @@ printf '{"closedByPullRequestsReferences":[{"number":851,"state":"OPEN"}]}\n' \
 result=$(DISPATCH_PR_LIST='[{"number":850,"headRefName":"999-unrelated"}]' \
   "$TMPDIR_TEST/dispatch-find-pr" "822")
 assert_eq "DISPATCH_PR_LIST no prefix match; cross-check finds OPEN PR → PR number" "851" "$result"
-# Verify no self-fetch: gh pr list --state open --json number,headRefName was not called.
+# Verify no self-fetch: pr_list_open (number,headRefName) was not called.
 if [[ -f "$STUB_DIR/gh-find-pr-calls.log" ]]; then
   call_count=$(wc -l < "$STUB_DIR/gh-find-pr-calls.log")
 else
@@ -14124,6 +14124,11 @@ stop_setup() {
     "$TMPDIR_TEST/hooks/dispatch-stop.sh"
   chmod +x "$TMPDIR_TEST/hooks/dispatch-stop.sh"
 
+  # dispatch-stop.sh sources lib.sh via $SCRIPTS; provide it so pr_list_open
+  # is defined when the hook runs.
+  cp "$SCRIPT_DIR/lib.sh" \
+    "$TMPDIR_TEST/skills/dispatch-propagate/scripts/lib.sh"
+
   # Fake dispatch-find-pr: prints contents of $STUB_DIR/find-pr-output if
   # present, else nothing.
   cat > "$TMPDIR_TEST/skills/dispatch-propagate/scripts/dispatch-find-pr" <<'FAKE'
@@ -17440,7 +17445,7 @@ case "$args" in
   issue\ close\ *)
     echo "$args" >> "$STUB_DIR/gh-issue-close.log"
     ;;
-  "pr list --state open --json number,isDraft,labels,statusCheckRollup,mergeable")
+  "pr list --state open --limit 300 --json number,isDraft,labels,statusCheckRollup,mergeable")
     # dispatch-reconcile-ready's one fetch. $STUB_DIR/reconcile-pr-list.json
     # supplies the per-test PR array; absence means no open PRs.
     echo "pr list" >> "$STUB_DIR/gh-reconcile-pr-list.log"
@@ -23458,7 +23463,7 @@ case "$args" in
     fi
     ;;
   # dispatch-find-pr self-fetch
-  "pr list --state open --json number,headRefName")
+  "pr list --state open --limit 300 --json number,headRefName")
     if [[ -f "$STUB_DIR/pr-list.json" ]]; then
       cat "$STUB_DIR/pr-list.json"
     else

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -179,6 +179,11 @@ case "$args" in
       echo "[]"
     fi
     ;;
+  "pr list --state open --limit 5 --json number,headRefName")
+    # #1312 truncation-guard test: exactly 5 PRs at the DISPATCH_PR_LIST_LIMIT=5
+    # boundary so pr_list_open fires the loud guard and returns non-zero.
+    printf '[{"number":1,"headRefName":"1-a"},{"number":2,"headRefName":"2-b"},{"number":3,"headRefName":"3-c"},{"number":4,"headRefName":"4-d"},{"number":5,"headRefName":"5-e"}]\n'
+    ;;
   "pr list --state open --limit 300 --json number,createdAt,headRefName,isDraft,statusCheckRollup,labels,closingIssuesReferences,mergeable")
     # dispatch-select-target's union fetch now carries `mergeable` (#1241). The
     # field is forward-compatible (consumed by #1243); the current selection path
@@ -1211,6 +1216,60 @@ else
   call_count=0
 fi
 assert_eq "no self-fetch gh pr list calls when DISPATCH_PR_LIST set" "0" "$call_count"
+teardown
+
+# 11. #1312: No truncation past 30 PRs (proves the --limit 300 fix).
+# Before the fix, gh pr list defaulted to --limit 30, so PR 33 of 35 open PRs
+# would be silently omitted and dispatch-find-pr would return empty.  With
+# --limit 300, the stub case "pr list --state open --limit 300 --json
+# number,headRefName" serves all 35 entries from pr-list-full.json, so PR 33
+# is found on the first fetch.
+echo "Test: #1312 dispatch-find-pr resolves PR 33 of 35 open PRs (no truncation)"
+setup
+jq -nc '[range(1;36) | {number: ., headRefName: (tostring + "-feature")}]' \
+  > "$STUB_DIR/pr-list-full.json"
+result=$("$TMPDIR_TEST/dispatch-find-pr" "33")
+assert_eq "#1312: dispatch-find-pr resolves PR 33 of 35 open PRs (no truncation)" "33" "$result"
+teardown
+
+# 12. #1312: Loud truncation guard fires when result length equals the limit.
+# With DISPATCH_PR_LIST_LIMIT=5 the stub returns exactly 5 PRs, which equals
+# the limit.  pr_list_open must exit non-zero and write "likely truncated" to
+# stderr so the failure is never silent.
+echo "Test: #1312 pr_list_open exits non-zero and logs loudly when result length equals the limit"
+setup
+if err=$(DISPATCH_PR_LIST_LIMIT=5 bash -c \
+    'source "'"$TMPDIR_TEST"'/lib.sh" && pr_list_open "number,headRefName"' \
+    2>&1 1>/dev/null); then
+  rc=0
+else
+  rc=$?
+fi
+if [[ "$rc" -ne 0 ]]; then
+  PASS=$((PASS + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  PASS: #1312: pr_list_open exits non-zero when result length equals the limit"
+else
+  FAIL=$((FAIL + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  FAIL: #1312: pr_list_open exits non-zero when result length equals the limit"
+  echo "    expected: non-zero exit"
+  echo "    actual:   exit 0"
+fi
+case "$err" in
+  *"likely truncated"*)
+    PASS=$((PASS + 1))
+    TOTAL=$((TOTAL + 1))
+    echo "  PASS: #1312: pr_list_open writes a loud truncation error to stderr"
+    ;;
+  *)
+    FAIL=$((FAIL + 1))
+    TOTAL=$((TOTAL + 1))
+    echo "  FAIL: #1312: pr_list_open writes a loud truncation error to stderr"
+    echo "    expected: stderr containing 'likely truncated'"
+    echo "    actual:   '$err'"
+    ;;
+esac
 teardown
 
 # ============================================================================

--- a/flake.lock
+++ b/flake.lock
@@ -80,8 +80,7 @@
       "inputs": {
         "claude-code-nix": "claude-code-nix",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs",
-        "wezterm-windows-zip": "wezterm-windows-zip"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
@@ -97,19 +96,6 @@
         "owner": "nix-systems",
         "repo": "default",
         "type": "github"
-      }
-    },
-    "wezterm-windows-zip": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1781342324,
-        "narHash": "sha256-eadQd9US1MDNoKhuOkEeTpYRF2xf1VfOWnUmS26aWso=",
-        "type": "tarball",
-        "url": "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip"
       }
     }
   },


### PR DESCRIPTION
Closes #1312

## Problem

`gh pr list` defaults to **30 results** when no `--limit` is given. Across the
dispatch pipeline, every *open-PR* snapshot fetched with no `--limit`, so once
more than 30 PRs are open the list silently truncated at 30. An autonomous
fan-out can quietly cross 30 open PRs, and the truncation corrupts every
predicate built on the snapshot:

- `dispatch-find-pr` falsely reports "no PR" → a worker opens a duplicate PR.
- `dispatch-select-target`'s ready-PR / closed-issue gate misses ready PRs.
- `dispatch-phase` / `dispatch-ci-ready` mis-derive a PR's phase.
- `dispatch-route` and `dispatch-stop.sh` share a truncated `DISPATCH_PR_LIST`
  with their child predicates.
- `dispatch-reconcile-ready` skips truncated-away ready PRs.

The codebase already caps the *issue* fetch at `--limit 300` with a comment that
gh's default of 30 would silently truncate (`dispatch-select-target`). This PR
extends that discipline to every open-PR fetch.

## Change

**Unit 1 — one shared guarded helper, all call sites migrated.** Adds
`pr_list_open` to `lib.sh`: it fetches with an explicit
`--limit "$DISPATCH_PR_LIST_LIMIT"` (default 300, mirroring the open-issue cap)
and makes truncation **loud** — when the result length equals the limit it errors
to stderr (`… likely truncated …`) and returns non-zero, so the failure can never
recur silently. Every open-PR fetch site now routes through it:

- `dispatch-phase`, `dispatch-ci-ready`, `office-hours-select-target`,
  `dispatch-select-target`, `dispatch-reconcile-ready` (already sourced `lib.sh`).
- `dispatch-find-pr` (both self-fetches), `dispatch-route`, and the
  `dispatch-stop.sh` hook now source `lib.sh` and call the helper.
  `dispatch-stop.sh` keeps its deliberate `2>/dev/null || DISPATCH_PR_LIST=""`
  failure-tolerance — on truncation children self-fetch and surface the loud
  error themselves.

Helper + every call-site migration + every test-stub update land in **one
commit**: the harness's `gh` stub matches the exact arg string, so a partial
migration would silently fall through to `[]` (green-but-wrong tests).

**Unit 2 — tests that lock in the fix.**

- *No truncation past 30:* a 35-PR fixture where `dispatch-find-pr 33` must
  resolve to `33` — under the old default-30 behavior PR 33 would be truncated
  away and the lookup would falsely return empty.
- *Loud guard at the limit:* with `DISPATCH_PR_LIST_LIMIT=5` and exactly 5 open
  PRs, `pr_list_open` exits non-zero and writes `likely truncated` to stderr.

## Out of scope (deliberate)

- `dispatch-sweep` (`--state all --limit 200`, no equals-limit guard) — not an
  open-PR snapshot; possible follow-up.
- `dispatch-drift-scan` (`--state merged --limit 100`, already guarded).
- `digest/SKILL.md` (a `--state merged` fetch in a markdown skill body).

## Verification

`test-dispatch-scripts.sh` — 2275/2275 passed; `grep -rn 'gh pr list --state
open'` returns only the helper definition.
