### PR TITLE
dispatch: GC stale worktrees — wire orphaned sweep + reservation gate

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -143,6 +143,11 @@ spawn_tick() {
     || echo "[dispatch-stop] WARNING: dispatch-spawn-tick failed" >&2
 }
 
+spawn_sweep() {
+  "$SCRIPTS/dispatch-spawn-sweep" >/dev/null 2>&1 \
+    || echo "[dispatch-stop] WARNING: dispatch-spawn-sweep failed" >&2
+}
+
 self_close() {
   "$SCRIPTS/dispatch-self-close" >/dev/null 2>&1 \
     || echo "[dispatch-stop] WARNING: dispatch-self-close failed" >&2
@@ -158,6 +163,7 @@ self_close() {
 # here.) Checked BEFORE the PR-centric branches.
 if [ -f "$CLAUDE_JOB_DIR/parse-job-done" ]; then
   spawn_tick
+  spawn_sweep
   self_close
   exit 0
 fi
@@ -207,6 +213,7 @@ if ! "$SCRIPTS/dispatch-ci-ready" "$ISSUE_NUM" >/dev/null 2>&1; then
   if [ -n "$MARKER_PHASE" ]; then
     # Marker present (see the block above): the phase completed and only CI
     # is still running — self-close so the session does not leak idle.
+    spawn_sweep
     self_close
   fi
   # No marker: a genuine mid-phase exit during a CI restart — hand back to
@@ -231,6 +238,7 @@ if [ -n "$CURRENT_PHASE" ] && [ "$MARKER_PHASE" != "$CURRENT_PHASE" ]; then
   # Branch B — phase advanced.
   strip_office_hours_label
   spawn_tick
+  spawn_sweep
   self_close
   exit 0
 fi
@@ -248,6 +256,7 @@ case "$CURRENT_PHASE" in
         # pending. Self-close so the session does not leak idle holding its
         # worktree; the next tick re-runs the fix-* phase or escalates at the cap.
         spawn_tick
+        spawn_sweep
         self_close
         exit 0
       fi
@@ -259,6 +268,7 @@ case "$CURRENT_PHASE" in
       # re-seed the chain rather than parking — the marker being present means
       # the fix-* skill completed successfully.
       spawn_tick
+      spawn_sweep
       self_close
       exit 0
     fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-sweep
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# dispatch-spawn-sweep — launch the dispatch-sweep reaper as a transient
+# systemd-run --user unit so the synchronous Stop-hook caller returns at once.
+#
+# dispatch-sweep walks the worktree registrations and GCs stale ones (worktrees
+# whose worker session has died, leaving the checkout and its .bare/ registration
+# behind — #1451). It is a relatively heavy, gh-touching pass; running it inline
+# in every worker Stop-hook would both block the hook and hammer the GitHub API.
+# This launcher fires it as a transient .service in the background, exactly the
+# way dispatch-spawn-tick fires the headless tick: the transient unit IS the
+# detachment, so the hook returns immediately.
+#
+# TWO SEPARATE concurrency mechanisms (they are distinct — do not conflate them):
+#
+#   (a) Fixed unit name = dedup.
+#       The systemd unit name is FIXED — `dispatch-sweep`. While one sweep unit
+#       is running, a second `systemd-run --unit=dispatch-sweep ...` collides
+#       ("already exists") and we treat that as a no-op (`deduped`). This guards
+#       against two concurrent sweeps racing on the same `git worktree remove`
+#       (a double-remove would error/corrupt). The dedup is concurrency control,
+#       not rate control.
+#
+#   (b) mtime throttle = rate control.
+#       Independently of dedup, a throttle file's mtime gates how OFTEN a sweep
+#       may fire at all. A worker Stop happens often; the sweep is gh-heavy and
+#       must not run on every single Stop (GitHub rate limit). If the throttle
+#       file was stamped less than DISPATCH_SWEEP_THROTTLE_S seconds ago, this
+#       launcher prints `throttled` and exits WITHOUT launching — even when no
+#       sweep is currently running (so dedup would not have caught it). The
+#       throttle limits frequency; the dedup prevents overlap. They solve
+#       different problems.
+#
+# --collect:
+#   Makes systemd garbage-collect a finished OR FAILED transient unit so the
+#   fixed name `dispatch-sweep` frees for the next sweep. Without --collect a
+#   non-zero dispatch-sweep exit would leave a lingering failed unit and the
+#   next `--unit=dispatch-sweep` would collide forever — wedging all future
+#   sweeps. Same reasoning as dispatch-spawn-tick.
+#
+# --setenv=PATH="$PATH":
+#   Propagates the launching caller's PATH into the transient unit. Without it
+#   the unit inherits the systemd user manager's minimal default PATH, which
+#   omits the nix store — so on NixOS/WSL hosts /usr/bin/env can't resolve bash
+#   (exit 127) and dispatch-sweep can't find git/jq/claude. The caller (the
+#   worker Stop-hook) carries the full nix-store PATH, so capturing it at launch
+#   time makes the unit self-sufficient. Same as dispatch-spawn-tick.
+#
+# KillMode=process — cgroup-reaping stop-gap (#1196):
+#   dispatch-sweep calls worktree_has_live_session → `claude agents --json` to
+#   decide whether a worktree is still in use. That first `claude` call spawns
+#   Claude Code's per-user bg supervisor daemon on demand — and it is born
+#   inside THIS transient unit's cgroup. systemd's default
+#   KillMode=control-group SIGTERMs the entire cgroup when the sweep unit
+#   finishes, which would reap that daemon and every background dispatch worker
+#   it hosts. Passing --property=KillMode=process makes a finishing sweep kill
+#   only its own dispatch-sweep process; the detached daemon/workers survive as
+#   init orphans. This is the same minimal stop-gap dispatch-spawn-tick
+#   documents at its KillMode lines; the durable daemon-ownership design is
+#   tracked in #1197. The sweep's `claude agents --json` liveness checks are the
+#   daemon-parenting trigger, so KillMode=process is a HARD requirement here.
+#
+# DELIBERATE OMISSIONS (vs dispatch-spawn-tick):
+#   (a) NO OnFailure recovery unit / no ensure_recover_unit. The sweep is
+#       best-effort, not chain-critical: a failed sweep simply retries on the
+#       next worker Stop (subject to the throttle). dispatch-spawn-tick IS
+#       chain-critical, so it installs dispatch-tick-recover.service to
+#       guarantee a chain continuation; the sweep needs no such guarantee.
+#   (b) NO ensure_daemon_service call. The sweep does not host the fleet — the
+#       durable-daemon ownership (#1197) is dispatch-spawn-tick's concern.
+#       KillMode=process alone suffices to protect the sweep's short-lived
+#       `claude agents --json` calls from reaping the daemon.
+#
+# Stdout protocol (exactly one word on every success path):
+#   spawned    the transient sweep unit was created (exit 0).
+#   deduped    a sweep unit with the fixed name is already running — the
+#              systemd-run collision ("already exists") is treated as a no-op
+#              (exit 0).
+#   throttled  the throttle window has not elapsed since the last sweep — no
+#              unit was launched (exit 0).
+#
+# Exit codes:
+#   0  spawned, deduped, or throttled (stdout disambiguates).
+#   2  a malformed config (positional argument passed, or not in a git repo with
+#      DISPATCH_SPAWN_SWEEP_MAIN_WORKTREE unset).
+#   non-zero — systemd-run failed for a reason other than the already-exists
+#              collision; the exit code is passed through.
+#
+# Environment overrides for testability (mirroring dispatch-spawn-tick):
+#   DISPATCH_SPAWN_SWEEP_SYSTEMD_RUN_CMD  The `systemd-run` binary. Default:
+#                                         `systemd-run`.
+#   DISPATCH_SPAWN_SWEEP_MAIN_WORKTREE    The main worktree path. When set, the
+#                                         script does NOT require a git repo.
+#                                         Default: <project-root>/worktrees/main,
+#                                         via resolve_project_root (lib.sh).
+#   DISPATCH_SPAWN_SWEEP_THROTTLE_FILE    The throttle stamp file. Default:
+#                                         <main-worktree>/tmp/dispatch-sweep-last.
+#   DISPATCH_SWEEP_THROTTLE_S             Throttle window in seconds. Default:
+#                                         300.
+#   DISPATCH_SPAWN_SWEEP_NOW              "now" epoch seconds, for deterministic
+#                                         throttle tests. Default: `date +%s`.
+#
+# Called from the worker Stop-hook, which runs OUTSIDE Claude's Bash sandbox. A
+# Bash-tool caller would need `dangerouslyDisableSandbox: true` because
+# `systemd-run --user` talks to the user's systemd over D-Bus, which the sandbox
+# blocks.
+#
+# NOT set -e: exits are handled explicitly (matching dispatch-spawn-tick).
+set -uo pipefail
+
+# ---- Step 0: reject any positional argument ---------------------------------
+# The sweep takes no target — it walks all worktrees. Reject any positional with
+# exit 2 (mirrors dispatch-sweep's own no-argument stance).
+if [[ $# -gt 0 ]]; then
+  echo "dispatch-spawn-sweep: takes no arguments" >&2
+  exit 2
+fi
+
+# ---- Step 1: resolve config -------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+# The sweep runs from the main worktree (where every autonomous pass is rooted).
+# An explicit DISPATCH_SPAWN_SWEEP_MAIN_WORKTREE is authoritative and bypasses
+# the git lookup — tests rely on this. Otherwise resolve_project_root (lib.sh)
+# returns the project root in both classic (.git) and bare (.bare) layouts.
+if [[ -n "${DISPATCH_SPAWN_SWEEP_MAIN_WORKTREE:-}" ]]; then
+  MAIN_WORKTREE="$DISPATCH_SPAWN_SWEEP_MAIN_WORKTREE"
+else
+  PROJECT_ROOT=$(resolve_project_root) \
+    || { echo "dispatch-spawn-sweep: not in a git repo and DISPATCH_SPAWN_SWEEP_MAIN_WORKTREE is unset" >&2; exit 2; }
+  MAIN_WORKTREE="$PROJECT_ROOT/worktrees/main"
+fi
+
+# ---- Step 2: throttle (rate control — distinct from the dedup below) --------
+# Keeps the gh-heavy sweep off every single worker Stop. If the throttle file
+# was stamped less than the window ago, do not launch at all. This is NOT the
+# dedup: it gates frequency even when no sweep is currently running.
+THROTTLE_FILE="${DISPATCH_SPAWN_SWEEP_THROTTLE_FILE:-$MAIN_WORKTREE/tmp/dispatch-sweep-last}"
+THROTTLE_S="${DISPATCH_SWEEP_THROTTLE_S:-300}"
+NOW="${DISPATCH_SPAWN_SWEEP_NOW:-$(date +%s)}"
+
+if [[ -e "$THROTTLE_FILE" ]]; then
+  # GNU stat (this repo runs on WSL/Linux — no BSD fallback by design). If the
+  # stat fails for an existing file, treat as not-throttled and proceed to
+  # launch — a stat error must not block the sweep.
+  if MTIME=$(stat -c %Y "$THROTTLE_FILE" 2>/dev/null); then
+    if (( NOW - MTIME < THROTTLE_S )); then
+      echo throttled
+      exit 0
+    fi
+  fi
+fi
+
+# Stamp the throttle file (best-effort — a failure to stamp must NOT block the
+# launch). Create the parent dir, then write the now-epoch into the file.
+mkdir -p "$(dirname "$THROTTLE_FILE")" 2>/dev/null || true
+printf '%s\n' "$NOW" >"$THROTTLE_FILE" 2>/dev/null || true
+
+# ---- Step 3: launch the transient sweep unit immediately --------------------
+SYSTEMD_RUN_CMD="${DISPATCH_SPAWN_SWEEP_SYSTEMD_RUN_CMD:-systemd-run}"
+SWEEP_PATH="$MAIN_WORKTREE/.claude/skills/dispatch-propagate/scripts/dispatch-sweep"
+
+# Fixed unit name — the dedup mechanism (see header (a)). A second launch while
+# this unit is running collides and is treated as a `deduped` no-op.
+UNIT_NAME="dispatch-sweep"
+
+RUN_STDERR=$(mktemp)
+trap 'rm -f "$RUN_STDERR"' EXIT
+# Capture the exit code directly — after `if cmd; then ... fi`, `$?` is the exit
+# status of the `if` construct, NOT the exit code of `cmd`. Running `cmd` outside
+# an `if` and capturing `$?` immediately preserves the real exit code so the
+# "pass-through on unexpected failure" contract holds.
+"$SYSTEMD_RUN_CMD" --user \
+     --unit="$UNIT_NAME" \
+     --collect \
+     --property=KillMode=process \
+     --working-directory="$MAIN_WORKTREE" \
+     --setenv=PATH="$PATH" \
+     "$SWEEP_PATH" \
+     2>"$RUN_STDERR"
+RC=$?
+
+if (( RC == 0 )); then
+  echo spawned
+  exit 0
+fi
+
+err=$(cat "$RUN_STDERR")
+# systemd's already-exists message varies slightly across versions
+# ("Unit ... already exists" / "Failed to start transient service unit: Unit
+# ... already exists"). Match on the substring rather than the full phrase. A
+# collision always names the colliding unit, so also require the unit name —
+# this keeps cross-version tolerance while preventing an unrelated failure whose
+# stderr happens to contain "already exists" from being silently treated as a
+# dedup no-op (which would mask a real launch failure).
+if [[ "$err" == *"already exists"* && "$err" == *"$UNIT_NAME"* ]]; then
+  echo deduped
+  exit 0
+fi
+
+# Some other failure — surface stderr and pass the exit code through.
+echo "$err" >&2
+exit "$RC"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-sweep
@@ -30,6 +30,23 @@
 #       throttle limits frequency; the dedup prevents overlap. They solve
 #       different problems.
 #
+#       Stamp-AFTER-launch: the throttle file is stamped only on the spawned and
+#       deduped success paths, never before the systemd-run call. Stamping before
+#       would let a non-dedup launch failure (D-Bus unavailable, systemd user
+#       instance not running, unit-file permission error) consume the full
+#       throttle window — the stamp would carry a fresh mtime even though no
+#       sweep ran, so every worker Stop for the next DISPATCH_SWEEP_THROTTLE_S
+#       seconds would print `throttled` and skip relaunching, opening
+#       multi-minute sweep-coverage gaps on a WSL host whose systemd user session
+#       is transiently unavailable. Stamping only on success lets a failed launch
+#       retry on the very next worker Stop.
+#
+#       Fail-open on an uncreatable stamp path: the stamp is best-effort. If
+#       MAIN_WORKTREE/tmp/ cannot be created (e.g. a missing main worktree), the
+#       stamp never persists and throttling becomes a no-op — every Stop fires a
+#       sweep (bounded by the dedup). This fails OPEN (more sweeps), not closed,
+#       which is the safer direction for stale-worktree GC.
+#
 # --collect:
 #   Makes systemd garbage-collect a finished OR FAILED transient unit so the
 #   fixed name `dispatch-sweep` frees for the next sweep. Without --collect a
@@ -62,7 +79,9 @@
 # DELIBERATE OMISSIONS (vs dispatch-spawn-tick):
 #   (a) NO OnFailure recovery unit / no ensure_recover_unit. The sweep is
 #       best-effort, not chain-critical: a failed sweep simply retries on the
-#       next worker Stop (subject to the throttle). dispatch-spawn-tick IS
+#       next worker Stop. (A failed LAUNCH does not stamp the throttle — see
+#       (b) above — so the retry is immediate, not throttle-delayed.)
+#       dispatch-spawn-tick IS
 #       chain-critical, so it installs dispatch-tick-recover.service to
 #       guarantee a chain continuation; the sweep needs no such guarantee.
 #   (b) NO ensure_daemon_service call. The sweep does not host the fleet — the
@@ -151,10 +170,23 @@ if [[ -e "$THROTTLE_FILE" ]]; then
   fi
 fi
 
-# Stamp the throttle file (best-effort — a failure to stamp must NOT block the
-# launch). Create the parent dir, then write the now-epoch into the file.
-mkdir -p "$(dirname "$THROTTLE_FILE")" 2>/dev/null || true
-printf '%s\n' "$NOW" >"$THROTTLE_FILE" 2>/dev/null || true
+# The throttle is stamped AFTER a successful launch (see stamp_throttle below),
+# NOT before. Stamping before would let a non-dedup launch failure (D-Bus down,
+# systemd user instance not running, unit-file permission error) consume the full
+# throttle window: the stamp would carry a fresh mtime even though no sweep ran,
+# so every worker Stop for the next DISPATCH_SWEEP_THROTTLE_S seconds would print
+# `throttled` and skip relaunching — multi-minute sweep-coverage gaps on a WSL
+# host whose systemd user session is transiently unavailable. Stamping only on
+# the spawned/deduped paths lets a failed launch retry on the very next Stop.
+#
+# Note the stamp is best-effort: if MAIN_WORKTREE/tmp/ cannot be created (e.g. a
+# missing main worktree), the stamp never persists and throttling becomes a
+# no-op — every Stop fires a sweep. This fails OPEN (more sweeps, bounded by the
+# dedup), not closed, which is the safer direction for stale-worktree GC.
+stamp_throttle() {
+  mkdir -p "$(dirname "$THROTTLE_FILE")" 2>/dev/null || true
+  printf '%s\n' "$NOW" >"$THROTTLE_FILE" 2>/dev/null || true
+}
 
 # ---- Step 3: launch the transient sweep unit immediately --------------------
 SYSTEMD_RUN_CMD="${DISPATCH_SPAWN_SWEEP_SYSTEMD_RUN_CMD:-systemd-run}"
@@ -181,6 +213,7 @@ trap 'rm -f "$RUN_STDERR"' EXIT
 RC=$?
 
 if (( RC == 0 )); then
+  stamp_throttle
   echo spawned
   exit 0
 fi
@@ -194,10 +227,15 @@ err=$(cat "$RUN_STDERR")
 # stderr happens to contain "already exists" from being silently treated as a
 # dedup no-op (which would mask a real launch failure).
 if [[ "$err" == *"already exists"* && "$err" == *"$UNIT_NAME"* ]]; then
+  # A sweep is already running — stamp the throttle so the next Stop respects the
+  # rate window (a sweep DID fire recently, just not by this caller).
+  stamp_throttle
   echo deduped
   exit 0
 fi
 
-# Some other failure — surface stderr and pass the exit code through.
+# Some other failure — surface stderr and pass the exit code through. Crucially,
+# do NOT stamp the throttle here: an un-launched sweep must be retryable on the
+# very next worker Stop, not blocked for the full throttle window.
 echo "$err" >&2
 exit "$RC"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
@@ -21,12 +21,10 @@
 #   2  invalid invocation (not in a git repo).
 #
 # NOT set -e: per-worktree errors should not abort the sweep — bookkeeping
-# decisions must keep flowing into the log so the next /dispatch-propagate tick can act.
+# decisions must keep flowing into the log so the next worker Stop (via dispatch-spawn-sweep) can act.
 set -uo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-source "$SCRIPT_DIR/lib.sh"
-
 # shellcheck source=./lib.sh
 source "$SCRIPT_DIR/lib.sh"
 # shellcheck source=./lib-worktree-in-sync.sh

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# dispatch-sweep — reconcile worktrees once per /dispatch-propagate queue-scan tick.
+# dispatch-sweep — reconcile worktrees: reap merged/closed worktrees. Fired by the worker Stop-hook via dispatch-spawn-sweep (the retired /dispatch-propagate router was the old caller).
 #
 # Usage:
 #   dispatch-sweep   — cleanup merged worktrees.
@@ -33,6 +33,8 @@ source "$SCRIPT_DIR/lib.sh"
 source "$SCRIPT_DIR/lib-worktree-in-sync.sh"
 # shellcheck source=./lib-claude-agents.sh
 source "$SCRIPT_DIR/lib-claude-agents.sh"
+# shellcheck source=./lib-reservation-ledger.sh
+source "$SCRIPT_DIR/lib-reservation-ledger.sh"
 
 # Resolve project root + worktrees root via resolve_project_root (lib.sh), which
 # returns the project root in both classic (.git) and bare (.bare) layouts.
@@ -113,6 +115,13 @@ while [[ $i -lt ${#WT_PATHS[@]} ]]; do
   wt_num="${WT_NUMS[$i]}"
   i=$((i + 1))
 
+  # Reservation guard (loop-top, covers BOTH removal paths in one place): a
+  # reserved worktree is claimed by a worker about to start — never reap it.
+  if reservation_exists "$(basename "$wt_path")"; then
+    log "SKIP_RESERVED: '$wt_path' branch=$wt_branch"
+    continue
+  fi
+
   pr_num="${MERGED_BY_BRANCH[$wt_branch]:-}"
   if [[ -z "$pr_num" ]]; then
     # Not a merged-PR branch. Check if this is a dispatch-style branch (has an
@@ -130,7 +139,9 @@ while [[ $i -lt ${#WT_PATHS[@]} ]]; do
       }
       case "$issue_state" in
         CLOSED)
-          if worktree_in_sync "$wt_path" "$LOG_FILE" "dispatch-sweep"; then
+          if worktree_has_live_session "$wt_path"; then
+            log "SKIP_CLOSED_LIVE_SESSION: '$wt_path' branch=$wt_branch issue=#$issue_num"
+          elif worktree_in_sync "$wt_path" "$LOG_FILE" "dispatch-sweep"; then
             if git worktree remove "$wt_path" 2>>"$LOG_FILE"; then
               git worktree prune 2>/dev/null || true
               if ! git branch -D "$wt_branch" >>"$LOG_FILE" 2>&1; then

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2214,8 +2214,9 @@ teardown
 
 # --- --health-only mode (issue #683 AC: gate before sweep) ------------------
 # --health-only runs the JIT scan and the gate, then exits without the queue
-# scan. /dispatch-propagate SKILL.md calls it before dispatch-sweep so the sweep does
-# not run while main is red.
+# scan. The dispatch flow runs the gate before the sweep (now fired by the
+# worker Stop-hook via dispatch-spawn-sweep) so the sweep does not run while
+# main is red.
 
 # 27a. --health-only, main green, not in a worktree → "ok", exit 0.
 echo "Test: --health-only + main green → ok"
@@ -5908,6 +5909,7 @@ sweep_setup() {
   cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/lib.sh"
   cp "$SCRIPT_DIR/lib-worktree-in-sync.sh" "$TMPDIR_TEST/scripts/lib-worktree-in-sync.sh"
   cp "$SCRIPT_DIR/lib-claude-agents.sh" "$TMPDIR_TEST/scripts/lib-claude-agents.sh"
+  cp "$SCRIPT_DIR/lib-reservation-ledger.sh" "$TMPDIR_TEST/scripts/lib-reservation-ledger.sh"
   chmod +x "$TMPDIR_TEST/scripts/dispatch-sweep"
 
   # Default empty gh output (each test may overwrite).
@@ -6037,6 +6039,10 @@ FAKE
   export CLAUDE_AGENTS_CMD="$default_fake"
   export DISPATCH_SWEEP_LOG_FILE="$STUB_DIR/sweep.log"
   export DISPATCH_SWEEP_NOW="2026-01-01T00:00:00Z"
+  # Point the reservation ledger at a scratch dir that is absent by default — no
+  # marker files, so reservation_exists is false for every row and the
+  # reserved-skip is inert. A reserved-skip test opts in by creating a marker here.
+  export DISPATCH_RESERVATION_DIR="$STUB_DIR/reservations"
 }
 
 sweep_teardown() {
@@ -6044,7 +6050,7 @@ sweep_teardown() {
   TMPDIR_TEST=""
   STUB_DIR=""
   export PATH="$SAVED_PATH"
-  unset CLAUDE_AGENTS_CMD DISPATCH_SWEEP_LOG_FILE DISPATCH_SWEEP_NOW
+  unset CLAUDE_AGENTS_CMD DISPATCH_SWEEP_LOG_FILE DISPATCH_SWEEP_NOW DISPATCH_RESERVATION_DIR
 }
 
 # Helper: register a worktree in the porcelain list AND create its directory.
@@ -6443,6 +6449,108 @@ if grep -q "REMOVE_MERGED: '$WT_PATH' branch=hotfix-login pr=#400" \
   PASS=$((PASS + 1)); echo "  PASS: REMOVE_MERGED log line present for non-issue branch"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: REMOVE_MERGED log line present for non-issue branch"
+  echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
+fi
+sweep_teardown
+
+# --- Test R1: merged worktree WITH a reservation marker is skipped (SKIP_RESERVED) ---
+echo "Test: merged worktree with a reservation marker is skipped (SKIP_RESERVED)"
+sweep_setup
+WT_PATH="$TMPDIR_TEST/project/worktrees/90-reserved-merged"
+sweep_register_wt "$WT_PATH" "90-reserved-merged"
+echo '[{"number":500,"headRefName":"90-reserved-merged","state":"MERGED"}]' \
+  > "$STUB_DIR/gh-pr-list-all.json"
+key=$(sweep_path_key "$WT_PATH")
+: > "$STUB_DIR/status${key}.txt"
+echo "0" > "$STUB_DIR/revlist${key}.txt"
+# Opt in: create the reservation marker for this worktree's basename.
+mkdir -p "$DISPATCH_RESERVATION_DIR"
+printf 'session=resv\nissue=90\ntimestamp=2026-01-01T00:00:00Z\n' \
+  > "$DISPATCH_RESERVATION_DIR/90-reserved-merged"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "reserved-merged sweep exits 0" "0" "$rc"
+calls=$(cat "$STUB_DIR/calls" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if ! echo "$calls" | grep -q "worktree-remove"; then
+  PASS=$((PASS + 1)); echo "  PASS: reserved merged worktree not removed"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: reserved merged worktree not removed"
+  echo "    calls: $calls"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q "SKIP_RESERVED: '$WT_PATH' branch=90-reserved-merged" \
+   "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: SKIP_RESERVED log line present (merged)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: SKIP_RESERVED log line present (merged)"
+  echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
+fi
+sweep_teardown
+
+# --- Test R2: closed-issue worktree WITH a reservation marker is skipped (SKIP_RESERVED) ---
+echo "Test: closed-issue worktree with a reservation marker is skipped (SKIP_RESERVED)"
+sweep_setup
+WT_PATH="$TMPDIR_TEST/project/worktrees/91-reserved-closed"
+sweep_register_wt "$WT_PATH" "91-reserved-closed"
+echo '[]' > "$STUB_DIR/gh-pr-list-all.json"
+echo "CLOSED" > "$STUB_DIR/issue-state-91.txt"
+key=$(sweep_path_key "$WT_PATH")
+: > "$STUB_DIR/status${key}.txt"
+echo "0" > "$STUB_DIR/revlist${key}.txt"
+# Opt in: create the reservation marker for this worktree's basename.
+mkdir -p "$DISPATCH_RESERVATION_DIR"
+printf 'session=resv\nissue=91\ntimestamp=2026-01-01T00:00:00Z\n' \
+  > "$DISPATCH_RESERVATION_DIR/91-reserved-closed"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "reserved-closed sweep exits 0" "0" "$rc"
+calls=$(cat "$STUB_DIR/calls" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if ! echo "$calls" | grep -q "worktree-remove"; then
+  PASS=$((PASS + 1)); echo "  PASS: reserved closed worktree not removed"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: reserved closed worktree not removed"
+  echo "    calls: $calls"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q "SKIP_RESERVED: '$WT_PATH' branch=91-reserved-closed" \
+   "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: SKIP_RESERVED log line present (closed)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: SKIP_RESERVED log line present (closed)"
+  echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
+fi
+sweep_teardown
+
+# --- Test R3: closed-issue worktree WITH a live session (NO reservation) is skipped (SKIP_CLOSED_LIVE_SESSION) ---
+echo "Test: closed-issue worktree with a live session is skipped (SKIP_CLOSED_LIVE_SESSION)"
+sweep_setup
+WT_PATH="$TMPDIR_TEST/project/worktrees/92-closed-live"
+sweep_register_wt "$WT_PATH" "92-closed-live"
+echo '[]' > "$STUB_DIR/gh-pr-list-all.json"
+echo "CLOSED" > "$STUB_DIR/issue-state-92.txt"
+key=$(sweep_path_key "$WT_PATH")
+: > "$STUB_DIR/status${key}.txt"
+echo "0" > "$STUB_DIR/revlist${key}.txt"
+sweep_fake_claude_sessions_by_name "92-closed-live=sess-live-92"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "closed-live sweep exits 0" "0" "$rc"
+calls=$(cat "$STUB_DIR/calls" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if ! echo "$calls" | grep -q "worktree-remove"; then
+  PASS=$((PASS + 1)); echo "  PASS: closed live-session worktree not removed"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: closed live-session worktree not removed"
+  echo "    calls: $calls"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q "SKIP_CLOSED_LIVE_SESSION: '$WT_PATH' branch=92-closed-live issue=#92" \
+   "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: SKIP_CLOSED_LIVE_SESSION log line present"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: SKIP_CLOSED_LIVE_SESSION log line present"
   echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
 fi
 sweep_teardown
@@ -11298,6 +11406,154 @@ else
   echo "    log: $(cat "$TMPDIR_TEST/systemd-log")"
 fi
 st_teardown
+
+# ============================================================================
+# dispatch-spawn-sweep tests (#1451)
+# ============================================================================
+echo ""
+echo "=== dispatch-spawn-sweep ==="
+#
+# dispatch-spawn-sweep launches the dispatch-sweep reaper as a transient
+# `systemd-run --user` unit. Exercised against a fake `systemd-run` (stub at the
+# path DISPATCH_SPAWN_SWEEP_SYSTEMD_RUN_CMD points to) that records its argv — no
+# real systemd. DISPATCH_SPAWN_SWEEP_MAIN_WORKTREE points at a synthetic main
+# worktree so no git repo is required. The throttle is driven deterministically
+# via DISPATCH_SPAWN_SWEEP_THROTTLE_FILE + DISPATCH_SPAWN_SWEEP_NOW. Unlike
+# spawn-tick, the sweep installs no recovery/daemon units, so no systemctl stub
+# is needed. The test shell runs under `set -e`; each invocation is wrapped to
+# capture the exit code.
+
+sw_setup() {
+  local stub_body="${1:-}"
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/bin" "$TMPDIR_TEST/main"
+
+  cp "$SCRIPT_DIR/dispatch-spawn-sweep" "$TMPDIR_TEST/scripts/dispatch-spawn-sweep"
+  # dispatch-spawn-sweep sources lib.sh via its SCRIPT_DIR — so lib.sh must sit
+  # alongside it. Sourced, not executed — no chmod +x.
+  cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/lib.sh"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-spawn-sweep"
+
+  if [[ -z "$stub_body" ]]; then
+    stub_body="echo \"\$*\" >> \"$TMPDIR_TEST/systemd-log\""
+  fi
+  cat > "$TMPDIR_TEST/bin/systemd-run" <<STUB
+#!/usr/bin/env bash
+$stub_body
+STUB
+  chmod +x "$TMPDIR_TEST/bin/systemd-run"
+
+  export DISPATCH_SPAWN_SWEEP_SYSTEMD_RUN_CMD="$TMPDIR_TEST/bin/systemd-run"
+  export DISPATCH_SPAWN_SWEEP_MAIN_WORKTREE="$TMPDIR_TEST/main"
+  export DISPATCH_SPAWN_SWEEP_THROTTLE_FILE="$TMPDIR_TEST/throttle"
+}
+
+sw_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  unset DISPATCH_SPAWN_SWEEP_SYSTEMD_RUN_CMD DISPATCH_SPAWN_SWEEP_MAIN_WORKTREE \
+        DISPATCH_SPAWN_SWEEP_THROTTLE_FILE DISPATCH_SWEEP_THROTTLE_S \
+        DISPATCH_SPAWN_SWEEP_NOW
+}
+
+# --- Test SW1: clean launch → spawned + correct argv -------------------------
+echo "Test: a clean dispatch-spawn-sweep launches the dispatch-sweep unit (spawned)"
+sw_setup
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-sweep" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "spawned: dispatch-spawn-sweep exits 0" "0" "$rc"
+assert_eq "spawned: stdout is 'spawned'" "spawned" "$out"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$log" == *"--unit=dispatch-sweep"* \
+   && "$log" == *"--collect"* \
+   && "$log" == *"--property=KillMode=process"* \
+   && "$log" == *"--working-directory=$TMPDIR_TEST/main"* \
+   && "$log" == *"--setenv=PATH="* \
+   && "$log" == *"$TMPDIR_TEST/main/.claude/skills/dispatch-propagate/scripts/dispatch-sweep"* \
+   && "$log" != *"OnFailure"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: spawned systemd-run argv (unit + collect + KillMode + cwd + setenv + exec, no OnFailure)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawned systemd-run argv (unit + collect + KillMode + cwd + setenv + exec, no OnFailure)"
+  echo "    log: $log"
+fi
+sw_teardown
+
+# --- Test SW2: already-exists collision → deduped ----------------------------
+echo "Test: an already-exists systemd-run collision yields 'deduped' (exit 0)"
+sw_setup 'echo "Unit dispatch-sweep.service already exists" >&2; exit 1'
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-sweep" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "deduped: dispatch-spawn-sweep exits 0" "0" "$rc"
+assert_eq "deduped: stdout is 'deduped'" "deduped" "$out"
+sw_teardown
+
+# --- Test SW3: generic failure → stderr surfaced, code passed through --------
+echo "Test: a generic systemd-run failure surfaces stderr and passes the code through"
+sw_setup 'echo "boom" >&2; exit 1'
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-spawn-sweep" 2>&1 1>/dev/null) || rc=$?
+assert_eq "fail: dispatch-spawn-sweep passes the exit code through (1)" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"boom"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: fail: systemd-run stderr is surfaced"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: fail: systemd-run stderr is surfaced"
+  echo "    stderr: $err"
+fi
+sw_teardown
+
+# --- Test SW4: recent throttle file → throttled, no launch ------------------
+echo "Test: a recent throttle file yields 'throttled' and launches nothing"
+sw_setup
+mkdir -p "$(dirname "$DISPATCH_SPAWN_SWEEP_THROTTLE_FILE")"
+: > "$DISPATCH_SPAWN_SWEEP_THROTTLE_FILE"
+mtime=$(stat -c %Y "$DISPATCH_SPAWN_SWEEP_THROTTLE_FILE")
+export DISPATCH_SPAWN_SWEEP_NOW=$((mtime + 10))
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-sweep" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "throttled: dispatch-spawn-sweep exits 0" "0" "$rc"
+assert_eq "throttled: stdout is 'throttled'" "throttled" "$out"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$TMPDIR_TEST/systemd-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: throttled: no systemd-run invocation recorded"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: throttled: no systemd-run invocation recorded"
+  echo "    log: $(cat "$TMPDIR_TEST/systemd-log")"
+fi
+unset DISPATCH_SPAWN_SWEEP_NOW
+sw_teardown
+
+# --- Test SW5: stale throttle file → launches (spawned) ----------------------
+echo "Test: a stale throttle file (older than the window) launches the sweep (spawned)"
+sw_setup
+mkdir -p "$(dirname "$DISPATCH_SPAWN_SWEEP_THROTTLE_FILE")"
+: > "$DISPATCH_SPAWN_SWEEP_THROTTLE_FILE"
+mtime=$(stat -c %Y "$DISPATCH_SPAWN_SWEEP_THROTTLE_FILE")
+export DISPATCH_SPAWN_SWEEP_NOW=$((mtime + 600))
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-sweep" 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "stale-throttle: dispatch-spawn-sweep exits 0" "0" "$rc"
+assert_eq "stale-throttle: stdout is 'spawned'" "spawned" "$out"
+TOTAL=$((TOTAL + 1))
+if [[ -e "$TMPDIR_TEST/systemd-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stale-throttle: systemd-run invocation recorded"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stale-throttle: systemd-run invocation recorded"
+fi
+unset DISPATCH_SPAWN_SWEEP_NOW
+sw_teardown
+
+# --- Test SW6: positional argument rejected (exit 2), launches nothing -------
+echo "Test: a positional argument exits 2 and launches nothing"
+sw_setup
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-spawn-sweep" foo 2>&1 1>/dev/null) || rc=$?
+assert_eq "bad-arg: dispatch-spawn-sweep exits 2" "2" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$TMPDIR_TEST/systemd-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: bad-arg: no systemd-run invocation recorded"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: bad-arg: no systemd-run invocation recorded"
+  echo "    log: $(cat "$TMPDIR_TEST/systemd-log")"
+fi
+sw_teardown
 
 # ============================================================================
 # dispatch-tick-recover tests (#1150)

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -11570,6 +11570,20 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: fail: systemd-run stderr is surfaced"
   echo "    stderr: $err"
 fi
+# Stamp-AFTER-launch: dispatch-spawn-sweep stamps the throttle file only on the
+# spawned/deduped success paths, NOT before systemd-run. A non-dedup launch
+# failure (D-Bus down, systemd user instance not running, unit-file permission
+# error) must NOT consume the throttle window — stamping before would suppress
+# every worker Stop for the next ~300s even though no sweep ran, opening
+# multi-minute sweep-coverage gaps on a WSL host with a transiently-unavailable
+# systemd user session. Lock that in: after a failed launch the file is ABSENT,
+# so the very next worker Stop retries immediately.
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$TMPDIR_TEST/throttle" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: fail: throttle file NOT stamped on a failed launch (next Stop retries)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: fail: throttle file NOT stamped on a failed launch (next Stop retries)"
+fi
 sw_teardown
 
 # --- Test SW4: recent throttle file → throttled, no launch ------------------

--- a/flake.lock
+++ b/flake.lock
@@ -80,8 +80,7 @@
       "inputs": {
         "claude-code-nix": "claude-code-nix",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs",
-        "wezterm-windows-zip": "wezterm-windows-zip"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
@@ -97,19 +96,6 @@
         "owner": "nix-systems",
         "repo": "default",
         "type": "github"
-      }
-    },
-    "wezterm-windows-zip": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1781342324,
-        "narHash": "sha256-eadQd9US1MDNoKhuOkEeTpYRF2xf1VfOWnUmS26aWso=",
-        "type": "tarball",
-        "url": "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip"
       }
     }
   },


### PR DESCRIPTION
Closes #1451

## What

Wires the orphaned `dispatch-sweep` reaper back into the dispatch flow and
hardens its safety gates, so stale worktrees stop accumulating (286 had piled
up — see #1450).

`dispatch-sweep` is a correct, complete reaper, but its only caller was the
**retired** model-router `/dispatch-propagate` skill. The headless `dispatch-tick`
sequencer that replaced it never wired the sweep in, so nothing reaped and
worktrees grew unbounded.

## Changes

- **`dispatch-sweep` safety gates (AC#3).** A loop-top `reservation_exists`
  guard covering **both** removal paths in one place, plus a
  `worktree_has_live_session` gate added to the closed-issue path (the merged
  path was already gated). The reaper never removes a reserved or live-session
  worktree.
- **New `dispatch-spawn-sweep` launcher.** Fires the gh-heavy sweep as a
  transient `systemd-run --user` unit, mirroring `dispatch-spawn-tick`. Two
  separate concurrency mechanisms: a fixed unit name (`dispatch-sweep`) dedups
  concurrent sweeps so two never race on `git worktree remove`; an independent
  mtime throttle (`DISPATCH_SWEEP_THROTTLE_S`, default 300s) keeps the sweep off
  every single worker Stop.
- **Stop-hook wiring (AC#1).** `dispatch-stop.sh` gains a fire-and-forget
  `spawn_sweep()` helper, called on the **clean-completion branches only**
  (parse-job, early-gate marker-present self-close, Branch B advance, both
  Branch C fix-* self-closes). The office-hours park branches (A, D) and the
  early-gate marker-absent TOCTOU hand-back deliberately do **not** sweep — a
  parked worktree is not garbage.
- **Tests (AC#4).** Harness fix so the new `lib-reservation-ledger.sh` source is
  available in the sweep test scratch dir; new gate tests (SKIP_RESERVED on both
  paths, SKIP_CLOSED_LIVE_SESSION); new launcher tests (spawned / deduped /
  throttled / stale-throttle-launch / pass-through failure / arg rejection).

## For reviewer attention

**AC#1 reinterpretation (deliberate).** "A worker that completes cleanly removes
its `<issue>-*` worktree" cannot be taken literally: a worker's cwd *is* its
worktree (git refuses to remove the cwd), worktrees are reused across phases
(implement → qa → review recycle the same one), and at every phase-worker's
Stop-hook time the PR is still open — a worktree only becomes garbage when its
PR merges or its issue closes, an event the worker never witnesses. So AC#1 is
satisfied by an **event-driven sweep**: a cleanly-completing worker fires a
detached `dispatch-spawn-sweep` (the same fire-and-forget pattern the hook
already uses for `dispatch-spawn-tick`), which reaps whatever became garbage
since the last tick — including this worker's now-merged predecessors — without
touching its own live worktree.

**`KillMode=process` is load-bearing.** `dispatch-sweep` calls
`worktree_has_live_session` → `claude agents --json`, which can spawn Claude's
bg supervisor daemon inside the transient unit's cgroup. With systemd's default
`KillMode=control-group`, a finishing sweep unit would SIGTERM its whole cgroup
and reap the daemon and every worker it hosts. `dispatch-spawn-sweep` passes
`--property=KillMode=process` to prevent this (the same stop-gap
`dispatch-spawn-tick` documents for #1196). The shimmed unit tests cannot
surface this, so SW1 asserts the property is present in the launch argv.

**Decision A — where the sweep runs.** The greenfield ideal is a dedicated
`dispatch-sweep.timer` systemd unit decoupled from dispatching; deferred here
because it needs a static unit install plus nix config changes (beyond
single-PR scope, adjacent to the #1452 latency work). The chosen single-PR path
is the sibling transient unit, which adds **zero** latency to the
selection-critical `dispatch-tick` path — the gh-heavy sweep runs detached in
its own cgroup.

**Decision B — clearing the 286 backlog (QA step, not code).** A deliberate
one-time manual `dispatch-sweep` run during QA, observable and
rate-limit-controllable; the sweep already tolerates partial progress across
runs. The 286 → ~live-worker-count drop is the AC#2 evidence. After the backlog
clears, the wired Stop-hook sweep maintains steady state.

## Testing

`test-dispatch-scripts.sh`: 2333/2333 passed.
