### PR TITLE
dispatch: converge to target worker count via end-of-tick convergence reseed

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-convergence-reseed
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-convergence-reseed
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# dispatch-schedule-convergence-reseed — arm a short-delay convergence reseed
+# when an autonomous dispatch tick ends below the worker target.
+#
+# The autonomous fleet refills workers only at tick boundaries: a tick computes
+# a spawn budget GAP = TARGET_N − LIVE_COUNT once, fills up to GAP slots, then
+# waits for the next worker-completion event to tick again. effective_live
+# (busy workers + reservations) is never actively driven back UP to TARGET_N, so
+# two dynamics can leave the fleet below target with nothing armed to recover:
+#
+#   1. Partial fill — the selector returns fewer ready targets than GAP, so the
+#      tick spawns fewer than GAP workers and ends below target.
+#   2. Drain during a tick — workers complete mid-tick, their Stop-hook ticks
+#      collide / dedup, and when the in-flight tick finishes below target there
+#      is no pending tick to refill.
+#
+# This script is the convergence safety net: called at the END of an autonomous
+# tick that spawned workers but ended below target, it re-counts effective-live
+# workers and, if the fleet is still below target and not gated, arms a
+# short-delay transient systemd.user timer that re-runs the headless NO-ARG
+# `dispatch-tick` (re-evaluate the whole queue). The fleet thus converges back
+# to TARGET_N event-driven, without a periodic heartbeat.
+#
+# It is the convergence analog of dispatch-schedule-target-reseed (single-target,
+# CI-keyed) and dispatch-schedule-reseed (pace/cap-reset), but NO-ARG (whole-queue
+# re-evaluation) and on a short FIXED delay.
+#
+# Behavior, in order:
+#   1. Source lib.sh + lib-claude-agents.sh + lib-reservation-ledger.sh.
+#   2. TARGET_N = dispatch-target-workers (default count mode).
+#   3. Recount effective-live workers:
+#        BUSY = claude_agents_count_busy_workers (daemon UNKNOWN → 0, fail toward
+#               arming — mirrors dispatch-tick-recover's no-continuation posture).
+#        RESV = reservation_count.
+#        LIVE = BUSY + RESV.
+#   4. Suppression gates (in order):
+#        LIVE >= TARGET_N → `converged`, exit 0. This also covers the pace-gate-
+#          closed case for free: a pace pause makes dispatch-target-workers return
+#          0, so LIVE >= 0 always holds → no-op. Checking this BEFORE --exhausted
+#          means a TARGET=0 pace pause never even queries exhaustion.
+#        --exhausted == exhausted → `exhausted`, exit 0 (genuine token exhaustion;
+#          a reseed would spawn nothing).
+#   5. Otherwise arm the timer at FIRE = NOW + DELAY. Unit dispatch-converge-<FIRE>,
+#      ExecStart the NO-ARG dispatch-tick in the main worktree. The @<FIRE> epoch
+#      suffix gives idempotency: a same-second re-arm collides on the unit name and
+#      systemd refuses to recreate — treated as a no-op (exit 0).
+#
+# Stdout protocol (exactly one line):
+#   scheduled <unit> at <FIRE>   timer was armed.
+#   converged                    at/above target (incl. pace-gate-closed) no-op.
+#   exhausted                    token-exhaustion no-op.
+#
+# Exit codes:
+#   0  on every action / no-op path (arm, converged, exhausted, idempotent
+#      already-exists collision).
+#   2  on a bad env-integer override.
+#   non-zero — `systemd-run` failed for a reason other than the already-exists
+#              collision; the exit code is passed through.
+#
+# Environment overrides for testability:
+#
+#   DISPATCH_CONVERGE_RESEED_NOW
+#     Override the current epoch seconds. Default: date +%s.
+#
+#   DISPATCH_CONVERGE_RESEED_DELAY
+#     Override the reseed delay in seconds. Default: 120.
+#
+#   DISPATCH_CONVERGE_RESEED_SYSTEMD_RUN_CMD
+#     Override the `systemd-run` binary. Default: `systemd-run`.
+#
+#   DISPATCH_CONVERGE_RESEED_MAIN_WORKTREE
+#     Override the main worktree path. When set, the script does NOT require a
+#     git repo. Default: <project-root>/worktrees/main, where project-root is
+#     the parent of git --git-common-dir. Mirrors dispatch-schedule-reseed.
+#
+#   DISPATCH_CONVERGE_RESEED_TARGET_WORKERS_CMD
+#     Override the dispatch-target-workers binary (consulted for both the default
+#     target and the --exhausted query). Default: $SCRIPT_DIR/dispatch-target-workers.
+#
+#   CLAUDE_AGENTS_CMD
+#     Inherited from lib-claude-agents.sh: replaces the `claude` invocation in
+#     claude_agents_count_busy_workers. Default: `claude`.
+#
+#   DISPATCH_RESERVATION_DIR
+#     Inherited from lib-reservation-ledger.sh: override the ledger directory.
+#
+# Sandbox: `systemd-run --user` talks to the user's systemd over D-Bus, and the
+# recount reads `claude agents --json` over a Unix socket; this script is not
+# sandbox-safe and callers must invoke it with `dangerouslyDisableSandbox: true`.
+# See `.claude/rules/sandbox.md`.
+#
+# NOT set -e: exits are handled explicitly (matching the sibling reseed scripts).
+set -uo pipefail
+
+# ---- Step 0: defaults & config ----------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=lib-claude-agents.sh
+source "$SCRIPT_DIR/lib-claude-agents.sh"
+# shellcheck source=lib-reservation-ledger.sh
+source "$SCRIPT_DIR/lib-reservation-ledger.sh"
+
+TARGET_WORKERS_CMD="${DISPATCH_CONVERGE_RESEED_TARGET_WORKERS_CMD:-$SCRIPT_DIR/dispatch-target-workers}"
+SYSTEMD_RUN_CMD="${DISPATCH_CONVERGE_RESEED_SYSTEMD_RUN_CMD:-systemd-run}"
+
+# ---- Step 1: target -----------------------------------------------------------
+#
+# dispatch-target-workers always emits a non-negative integer in count mode
+# (falling back to 1 on missing telemetry). A pace pause returns 0 — handled by
+# the LIVE >= TARGET_N gate below.
+
+TARGET_N=$("$TARGET_WORKERS_CMD") || TARGET_N=""
+# TARGET_N feeds `(( LIVE >= TARGET_N ))` — bash arithmetic context evaluates
+# array-index command substitution, so it must be a literal integer. The
+# budgeter emits one; a non-integer is a budgeter malfunction — fail closed.
+if [[ ! "$TARGET_N" =~ ^[0-9]+$ ]]; then
+  echo "error: dispatch-schedule-convergence-reseed: dispatch-target-workers returned non-integer target '$TARGET_N'; aborting" >&2
+  exit 2
+fi
+
+# ---- Step 2: recount effective-live workers ---------------------------------
+#
+# BUSY: claude_agents_count_busy_workers returns 0 with a numeric count on
+# success; non-zero on UNKNOWN (daemon unreachable). On UNKNOWN treat as 0 —
+# fail TOWARD arming, mirroring dispatch-tick-recover's no-continuation posture
+# (a redundant reseed is absorbed by dispatch's dedup + the concurrency gate).
+BUSY=$(claude_agents_count_busy_workers) || BUSY=0
+if [[ ! "$BUSY" =~ ^[0-9]+$ ]]; then
+  # A success-with-garbage is not expected (the helper validates its own jq
+  # output), but a non-integer must never reach `(( ))`. Treat as 0 (fail toward
+  # arming, consistent with the UNKNOWN posture above).
+  BUSY=0
+fi
+
+RESV=$(reservation_count)
+if [[ ! "$RESV" =~ ^[0-9]+$ ]]; then
+  echo "error: dispatch-schedule-convergence-reseed: reservation_count returned non-integer '$RESV'; aborting" >&2
+  exit 2
+fi
+
+LIVE=$(( BUSY + RESV ))
+
+# ---- Step 3: suppression gates ----------------------------------------------
+#
+# Order is load-bearing: the at/above-target check runs BEFORE the exhausted
+# query, so a TARGET=0 pace pause (LIVE >= 0 always) reports `converged` without
+# ever consulting --exhausted.
+
+if (( LIVE >= TARGET_N )); then
+  echo "converged"
+  exit 0
+fi
+
+# Genuine token exhaustion — a reseed would spawn nothing. Fail OPEN: a failing
+# --exhausted query must not suppress arming (mirrors dispatch-select-tick:224).
+EXHAUSTED=$("$TARGET_WORKERS_CMD" --exhausted 2>/dev/null) || EXHAUSTED="ok"
+if [[ "$EXHAUSTED" == "exhausted" ]]; then
+  echo "exhausted"
+  exit 0
+fi
+
+# ---- Step 4: compute the fire time ------------------------------------------
+#
+# NOW and DELAY both reach `(( NOW + DELAY ))`; the defaults (date +%s, 120) are
+# always safe — the env-override path is the surface that requires validation.
+
+NOW="${DISPATCH_CONVERGE_RESEED_NOW:-$(date +%s)}"
+if [[ ! "$NOW" =~ ^[0-9]+$ ]]; then
+  echo "error: dispatch-schedule-convergence-reseed: NOW must be an integer epoch, got '$NOW'; aborting" >&2
+  exit 2
+fi
+
+DELAY="${DISPATCH_CONVERGE_RESEED_DELAY:-120}"
+if [[ ! "$DELAY" =~ ^[0-9]+$ ]]; then
+  echo "error: dispatch-schedule-convergence-reseed: DELAY must be an integer, got '$DELAY'; aborting" >&2
+  exit 2
+fi
+
+FIRE=$(( NOW + DELAY ))
+
+# ---- Step 5: resolve the main worktree --------------------------------------
+#
+# Same idiom as dispatch-schedule-reseed. The spawned reseed runs from the main
+# worktree.
+
+if [[ -n "${DISPATCH_CONVERGE_RESEED_MAIN_WORKTREE:-}" ]]; then
+  MAIN_WORKTREE="$DISPATCH_CONVERGE_RESEED_MAIN_WORKTREE"
+else
+  PROJECT_ROOT=$(resolve_project_root) \
+    || { echo "dispatch-schedule-convergence-reseed: not in a git repo and DISPATCH_CONVERGE_RESEED_MAIN_WORKTREE is unset" >&2; exit 2; }
+  MAIN_WORKTREE="$PROJECT_ROOT/worktrees/main"
+fi
+
+# Install the OnFailure recovery unit + durable daemon service before scheduling
+# the transient reseed timer. Both best-effort (warn + return, never exit) —
+# copied verbatim from dispatch-schedule-reseed's Step 5.
+ensure_recover_unit "$MAIN_WORKTREE" || true
+ensure_daemon_service || true
+
+# ---- Step 6: schedule the transient timer -----------------------------------
+#
+# The unit name embeds the epoch fire time — a repeated call with the same FIRE
+# collides, and systemd refuses to recreate the unit. That gives idempotency
+# without coordinating across callers.
+#
+# Carries the SAME unit properties as the sibling reseed launchers: --collect (GC
+# the unit after it finishes OR fails), OnFailure=dispatch-tick-recover.service
+# (guarantee a chain continuation if the reseed tick fails), KillMode=process
+# (confine the kill to dispatch-tick so detached bg hosts survive),
+# Persistent=true (cover a WSL-down window crossing fire time), and
+# --setenv=PATH="$PATH" (propagate the nix-store PATH into the transient unit).
+# ExecStart is the headless dispatch-tick with NO argument — re-evaluate the
+# whole queue, not a single target.
+
+UNIT_NAME="dispatch-converge-${FIRE}"
+
+RUN_STDERR=$(mktemp)
+trap 'rm -f "$RUN_STDERR"' EXIT
+# Capture the exit code directly — after `if cmd; then ... fi`, `$?` is the exit
+# status of the `if` construct, NOT the exit code of `cmd`. Run outside an `if`
+# and capture `$?` immediately so the pass-through-on-failure contract holds.
+"$SYSTEMD_RUN_CMD" --user \
+     --unit="$UNIT_NAME" \
+     --on-calendar="@$FIRE" \
+     --collect \
+     --property=OnFailure=dispatch-tick-recover.service \
+     --property=KillMode=process \
+     --working-directory="$MAIN_WORKTREE" \
+     --timer-property=Persistent=true \
+     --setenv=PATH="$PATH" \
+     "$MAIN_WORKTREE/.claude/skills/dispatch-propagate/scripts/dispatch-tick" \
+     2>"$RUN_STDERR"
+RC=$?
+if (( RC == 0 )); then
+  echo "scheduled $UNIT_NAME at $FIRE"
+  exit 0
+fi
+
+err=$(cat "$RUN_STDERR")
+# systemd's already-exists message varies slightly across versions. Match on the
+# substring rather than the full phrase.
+if [[ "$err" == *"already exists"* ]]; then
+  echo "dispatch-schedule-convergence-reseed: $UNIT_NAME already scheduled; no-op" >&2
+  echo "scheduled $UNIT_NAME at $FIRE"
+  exit 0
+fi
+
+# Some other failure — surface stderr and pass the exit code through.
+echo "$err" >&2
+exit "$RC"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -308,6 +308,25 @@ run_materialize() {
     propagate|resolve\ merge-conflict)
       # A worker/resolver was spawned — its Stop-hook carries the chain. Bare
       # exit; calling recover here would wrongly increment its failure counter.
+      #
+      # Convergence safety net (#1453): on a `propagate` token from an AUTONOMOUS
+      # tick, arm a short-delay convergence reseed. The called script re-counts
+      # effective-live workers (busy + reservations) and arms a no-arg dispatch-tick
+      # ONLY when the fleet is still below target and not gated (it self-suppresses
+      # on converged / pace-gate-closed / exhausted). Placing the call here — on the
+      # token taken when the tick had a normal materialize decision — makes the
+      # trigger a FRESH recount rather than the stale `spawned < GAP` signal,
+      # catching both the partial-fill case and a drain-during-tick.
+      #
+      # Autonomous-only: an explicit `dispatch <N>` (ARG set) and a bare manual
+      # `dispatch` (MANUAL set) are gate-exempt single-target spawns that must NOT
+      # drive fleet convergence. `resolve merge-conflict` is excluded by the
+      # `propagate`-only test below. Best-effort: a failed arm logs ONE note and the
+      # tick still exits 0 — never wedge the tick on a convergence arm.
+      if [[ "$token" == propagate && -z "$MANUAL" && -z "$ARG" ]]; then
+        "$SCRIPT_DIR/dispatch-schedule-convergence-reseed" \
+          || echo "dispatch-tick: convergence reseed arm failed (best-effort)" >&2
+      fi
       exit 0
       ;;
     notify\ *)

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -10554,6 +10554,258 @@ fi
 sr_teardown
 
 # ============================================================================
+# dispatch-schedule-convergence-reseed tests
+# ============================================================================
+#
+# dispatch-schedule-convergence-reseed re-counts effective-live workers
+# (busy workers + reservations) and arms a short-delay transient NO-ARG
+# dispatch-tick timer ONLY when the fleet is below target and not gated. The
+# harness stubs `systemd-run` (records argv), stubs dispatch-target-workers (so
+# the test controls both the count-mode target and the --exhausted token),
+# points CLAUDE_AGENTS_CMD at a controllable fake (busy-worker count) and
+# DISPATCH_RESERVATION_DIR at a scratch dir (reservation_count = marker count).
+#
+# Each test gets a fresh tmp tree:
+#   $TMPDIR_TEST/scripts/      script under test + lib.sh + lib-claude-agents.sh
+#                             + lib-reservation-ledger.sh
+#   $TMPDIR_TEST/bin/          systemd-run + systemctl + dispatch-target-workers stubs
+#   $TMPDIR_TEST/systemd-log   recorded systemd-run argv (one line per call)
+#   $TMPDIR_TEST/resv/         reservation ledger scratch dir
+#   $TMPDIR_TEST/main/         a synthetic main worktree path
+echo ""
+echo "=== dispatch-schedule-convergence-reseed ==="
+
+cr_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/bin" "$TMPDIR_TEST/resv" \
+    "$TMPDIR_TEST/main"
+
+  cp "$SCRIPT_DIR/dispatch-schedule-convergence-reseed" \
+     "$TMPDIR_TEST/scripts/dispatch-schedule-convergence-reseed"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-schedule-convergence-reseed"
+  # The script sources lib.sh + lib-claude-agents.sh + lib-reservation-ledger.sh
+  # via its SCRIPT_DIR, so all three must sit alongside it. Sourced, not
+  # executed — no chmod +x.
+  cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/lib.sh"
+  cp "$SCRIPT_DIR/lib-claude-agents.sh" "$TMPDIR_TEST/scripts/lib-claude-agents.sh"
+  cp "$SCRIPT_DIR/lib-reservation-ledger.sh" "$TMPDIR_TEST/scripts/lib-reservation-ledger.sh"
+
+  # systemd-run stub: records its argv (one line per call), exits 0.
+  cat > "$TMPDIR_TEST/bin/systemd-run" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/systemd-log"
+STUB
+  chmod +x "$TMPDIR_TEST/bin/systemd-run"
+  export DISPATCH_CONVERGE_RESEED_SYSTEMD_RUN_CMD="$TMPDIR_TEST/bin/systemd-run"
+
+  # ensure_recover_unit + ensure_daemon_service (lib.sh) would otherwise write to
+  # the real ~/.config/systemd/user/ and run a real `systemctl --user`. Redirect
+  # the unit dir into the tmp tree and point its systemctl at a no-op stub.
+  cat > "$TMPDIR_TEST/bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/systemctl"
+  export DISPATCH_RECOVER_UNIT_DIR="$TMPDIR_TEST/systemd-user"
+  export DISPATCH_RECOVER_SYSTEMCTL_CMD="$TMPDIR_TEST/bin/systemctl"
+
+  export DISPATCH_CONVERGE_RESEED_MAIN_WORKTREE="$TMPDIR_TEST/main"
+
+  # Recount inputs. Default the busy-worker daemon to UNKNOWN (a non-existent
+  # binary → claude_agents_count_busy_workers returns non-zero → BUSY=0) and the
+  # reservation ledger to the scratch dir (reservation_count = marker count).
+  export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/no-such-claude"
+  export DISPATCH_RESERVATION_DIR="$TMPDIR_TEST/resv"
+}
+
+cr_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  unset DISPATCH_CONVERGE_RESEED_SYSTEMD_RUN_CMD
+  unset DISPATCH_CONVERGE_RESEED_MAIN_WORKTREE
+  unset DISPATCH_CONVERGE_RESEED_TARGET_WORKERS_CMD
+  unset DISPATCH_CONVERGE_RESEED_NOW
+  unset DISPATCH_CONVERGE_RESEED_DELAY
+  unset DISPATCH_RECOVER_UNIT_DIR DISPATCH_RECOVER_SYSTEMCTL_CMD
+  unset CLAUDE_AGENTS_CMD DISPATCH_RESERVATION_DIR
+}
+
+# cr_write_target <count> <exhausted-token>
+#   Install a dispatch-target-workers stub: default (count mode) prints <count>,
+#   and `--exhausted` prints <exhausted-token>. Wires the override.
+cr_write_target() {
+  local count="$1" exhausted="$2"
+  cat > "$TMPDIR_TEST/bin/dispatch-target-workers" <<STUB
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "--exhausted" ]]; then echo "$exhausted"; else echo "$count"; fi
+STUB
+  chmod +x "$TMPDIR_TEST/bin/dispatch-target-workers"
+  export DISPATCH_CONVERGE_RESEED_TARGET_WORKERS_CMD="$TMPDIR_TEST/bin/dispatch-target-workers"
+}
+
+# cr_write_resv <n>
+#   Write <n> reservation marker files into the scratch ledger dir → RESV = <n>.
+cr_write_resv() {
+  local n="$1" i
+  for (( i = 1; i <= n; i++ )); do
+    printf 'session=s\nissue=%s\ntimestamp=2026-01-01T00:00:00Z\n' "$i" \
+      > "$TMPDIR_TEST/resv/${i}-feature"
+  done
+}
+
+# cr_busy_fake_claude <name:status> [<name:status> ...]
+#   Install a fake `claude` whose `agents --json` returns the given rows, so
+#   claude_agents_count_busy_workers yields a real positive count (a row counts
+#   iff name matches ^[0-9]+- AND status == busy). Mirrors parked_router_fake_claude.
+cr_busy_fake_claude() {
+  local payload="[" pair name status first=1
+  for pair in "$@"; do
+    name="${pair%%:*}"; status="${pair#*:}"
+    if (( first )); then first=0; else payload+=","; fi
+    payload+="{\"sessionId\":\"s-$name\",\"pid\":1,\"status\":\"$status\",\"name\":\"$name\",\"cwd\":\"\"}"
+  done
+  payload+="]"
+  printf '%s' "$payload" > "$TMPDIR_TEST/claude-payload.json"
+  cat > "$TMPDIR_TEST/bin/claude" <<'FAKE'
+#!/usr/bin/env bash
+cat "$(cd "$(dirname "$0")/.." && pwd)/claude-payload.json"
+exit 0
+FAKE
+  chmod +x "$TMPDIR_TEST/bin/claude"
+  export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/bin/claude"
+}
+
+# --- Test 1: below target → schedules a no-arg dispatch-tick reseed -----------
+#
+# BUSY=0 (UNKNOWN daemon) + RESV=3 = LIVE=3 < TARGET=8 → arm at NOW+DELAY.
+echo "Test: below target arms a short-delay no-arg dispatch-tick reseed"
+cr_setup
+export DISPATCH_CONVERGE_RESEED_NOW=10000
+export DISPATCH_CONVERGE_RESEED_DELAY=120
+cr_write_target 8 ok
+cr_write_resv 3
+out=$("$TMPDIR_TEST/scripts/dispatch-schedule-convergence-reseed" 2>"$TMPDIR_TEST/stderr")
+assert_eq "below target stdout names the convergence unit" \
+  "scheduled dispatch-converge-10120 at 10120" "$out"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$log" == *"--unit=dispatch-converge-10120"* \
+   && "$log" == *"--on-calendar=@10120"* \
+   && "$log" == *"--collect"* \
+   && "$log" == *"--property=OnFailure=dispatch-tick-recover.service"* \
+   && "$log" == *"--property=KillMode=process"* \
+   && "$log" == *"--working-directory=$TMPDIR_TEST/main"* \
+   && "$log" == *"--setenv=PATH="* \
+   && "$log" == *"$TMPDIR_TEST/main/.claude/skills/dispatch-propagate/scripts/dispatch-tick" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: below target systemd-run argv (unit + calendar + collect + OnFailure + KillMode + cwd + setenv + no-arg exec)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: below target systemd-run argv (unit + calendar + collect + OnFailure + KillMode + cwd + setenv + no-arg exec)"
+  echo "    log: $log"
+fi
+cr_teardown
+
+# --- Test 2: below target with a real busy worker → BUSY+RESV both counted ----
+#
+# BUSY=2 (two busy `^[0-9]+-` workers) + RESV=1 = LIVE=3 < TARGET=8 → arm. A
+# router (dispatch-*) and an idle worker are NOT counted, exercising the helper's
+# filter and the BUSY+RESV addition.
+echo "Test: below target counts busy workers + reservations together"
+cr_setup
+export DISPATCH_CONVERGE_RESEED_NOW=10000
+export DISPATCH_CONVERGE_RESEED_DELAY=120
+cr_write_target 8 ok
+cr_write_resv 1
+cr_busy_fake_claude "101-a:busy" "102-b:busy" "103-c:input" "dispatch-xyz:busy"
+out=$("$TMPDIR_TEST/scripts/dispatch-schedule-convergence-reseed" 2>/dev/null)
+assert_eq "BUSY=2 + RESV=1 = 3 < 8 → arms" \
+  "scheduled dispatch-converge-10120 at 10120" "$out"
+cr_teardown
+
+# --- Test 3: at/above target → converged, no systemd-run call ----------------
+#
+# BUSY=0 + RESV=8 = LIVE=8 >= TARGET=8 → converged no-op.
+echo "Test: at target → converged (no systemd-run call)"
+cr_setup
+export DISPATCH_CONVERGE_RESEED_NOW=10000
+cr_write_target 8 ok
+cr_write_resv 8
+out=$("$TMPDIR_TEST/scripts/dispatch-schedule-convergence-reseed" 2>/dev/null)
+assert_eq "at target stdout is converged" "converged" "$out"
+TOTAL=$((TOTAL + 1))
+if [[ ! -s "$TMPDIR_TEST/systemd-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: at target; no systemd-run invocation"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: at target; no systemd-run invocation"
+  echo "    log: $(cat "$TMPDIR_TEST/systemd-log")"
+fi
+cr_teardown
+
+# --- Test 4: pace gate closed (TARGET=0) → converged, no systemd-run call -----
+#
+# A pace pause makes dispatch-target-workers return 0; LIVE >= 0 always holds, so
+# the script reports converged WITHOUT consulting --exhausted (gate order).
+echo "Test: pace gate closed (TARGET=0) → converged (no systemd-run call)"
+cr_setup
+export DISPATCH_CONVERGE_RESEED_NOW=10000
+# Even with some live workers, TARGET=0 means at-or-above target.
+cr_write_target 0 ok
+cr_write_resv 2
+out=$("$TMPDIR_TEST/scripts/dispatch-schedule-convergence-reseed" 2>/dev/null)
+assert_eq "pace-gate-closed stdout is converged" "converged" "$out"
+TOTAL=$((TOTAL + 1))
+if [[ ! -s "$TMPDIR_TEST/systemd-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: pace gate closed; no systemd-run invocation"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: pace gate closed; no systemd-run invocation"
+  echo "    log: $(cat "$TMPDIR_TEST/systemd-log")"
+fi
+cr_teardown
+
+# --- Test 5: token-exhaustion → exhausted, no systemd-run call ---------------
+#
+# Below target (RESV=1 < TARGET=8) but --exhausted returns `exhausted` → no-op.
+echo "Test: below target but token-exhausted → exhausted (no systemd-run call)"
+cr_setup
+export DISPATCH_CONVERGE_RESEED_NOW=10000
+cr_write_target 8 exhausted
+cr_write_resv 1
+out=$("$TMPDIR_TEST/scripts/dispatch-schedule-convergence-reseed" 2>/dev/null)
+assert_eq "exhausted stdout is exhausted" "exhausted" "$out"
+TOTAL=$((TOTAL + 1))
+if [[ ! -s "$TMPDIR_TEST/systemd-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: exhausted; no systemd-run invocation"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: exhausted; no systemd-run invocation"
+  echo "    log: $(cat "$TMPDIR_TEST/systemd-log")"
+fi
+cr_teardown
+
+# --- Test 6: idempotent re-arm → already-exists collision is a no-op ----------
+#
+# systemd-run emits `already exists` on stderr and exits non-zero (the unit for
+# this exact FIRE epoch is already armed). The script treats it as a no-op:
+# exit 0, stdout still names the unit (so a caller routes it as scheduled).
+echo "Test: idempotent re-arm (systemd already-exists) → exit 0 no-op"
+cr_setup
+export DISPATCH_CONVERGE_RESEED_NOW=10000
+export DISPATCH_CONVERGE_RESEED_DELAY=120
+cr_write_target 8 ok
+cr_write_resv 3
+# Override the systemd-run stub to simulate the collision.
+cat > "$TMPDIR_TEST/bin/systemd-run" <<'STUB'
+#!/usr/bin/env bash
+echo "Failed to start transient timer unit: Unit dispatch-converge-10120.timer already exists." >&2
+exit 1
+STUB
+chmod +x "$TMPDIR_TEST/bin/systemd-run"
+rc=0
+out=$("$TMPDIR_TEST/scripts/dispatch-schedule-convergence-reseed" 2>"$TMPDIR_TEST/stderr") || rc=$?
+assert_eq "idempotent re-arm exit code is 0" "0" "$rc"
+assert_eq "idempotent re-arm stdout names the unit" \
+  "scheduled dispatch-converge-10120 at 10120" "$out"
+cr_teardown
+
+# ============================================================================
 # dispatch-schedule-target-reseed tests
 # ============================================================================
 #

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -19727,11 +19727,21 @@ FAKE
 echo "recover" >> "$TMPDIR_TEST/logs/recover.log"
 exit 0
 FAKE
+  # Fake dispatch-schedule-convergence-reseed (#1453): records each invocation so
+  # a test can assert the convergence safety net was (or was NOT) armed on a
+  # `propagate` token. Exits TICK_CONVERGE_RC (default 0). Same PATH-stub pattern
+  # as the dispatch-spawn-job fake above.
+  cat > "$TMPDIR_TEST/dispatch-schedule-convergence-reseed" <<FAKE
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/converge.log"
+exit \${TICK_CONVERGE_RC:-0}
+FAKE
   chmod +x "$TMPDIR_TEST/dispatch-select-tick" \
            "$TMPDIR_TEST/dispatch-materialize-spawn" \
            "$TMPDIR_TEST/dispatch-spawn-job" \
            "$TMPDIR_TEST/dispatch-refresh-rate-limits" \
-           "$TMPDIR_TEST/dispatch-tick-recover"
+           "$TMPDIR_TEST/dispatch-tick-recover" \
+           "$TMPDIR_TEST/dispatch-schedule-convergence-reseed"
 }
 
 tick_teardown() {
@@ -19739,7 +19749,7 @@ tick_teardown() {
   TMPDIR_TEST=""
   unset TICK_DECISION TICK_TOKEN TICK_SEL_RC TICK_MAT_RC \
     TICK_SEL_PRE TICK_MAT_PRE TICK_SPAWN_RESULT DISPATCH_TICK_MAIN_WORKTREE \
-    DISPATCH_LOCK_FILE TICK_REFRESH_RC
+    DISPATCH_LOCK_FILE TICK_REFRESH_RC TICK_CONVERGE_RC
 }
 
 run_tick() { "$TMPDIR_TEST/dispatch-tick" "$@" 2>/dev/null; }
@@ -19820,6 +19830,85 @@ out=$(run_tick) && rc=0 || rc=$?
 assert_eq "issue: exit 0" "0" "$rc"
 assert_eq "issue: materialize argv" "707 queue --gap 2" \
   "$(cat "$TMPDIR_TEST/logs/materialize.log")"
+tick_teardown
+
+# --- #1453: convergence reseed armed on a propagate token (autonomous only) ---
+# On a `propagate` token from an AUTONOMOUS tick (no --manual, no explicit <N>),
+# dispatch-tick calls dispatch-schedule-convergence-reseed exactly once. The
+# autonomous-only guard keys on the $MANUAL/$ARG globals, NOT the decision string:
+# the explicit and --manual tests below set those globals through the real
+# invocation (an arg trips ARG; --manual trips MANUAL), mirroring the existing
+# arg-forward test.
+echo "Test: dispatch-tick autonomous issue + propagate → convergence reseed armed once (#1453)"
+tick_setup
+export TICK_DECISION="issue 707 2" TICK_TOKEN="propagate"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "converge-issue: exit 0" "0" "$rc"
+assert_eq "converge-issue: convergence script called exactly once" "1" \
+  "$(wc -l < "$TMPDIR_TEST/logs/converge.log" | tr -d ' ')"
+tick_teardown
+
+echo "Test: dispatch-tick autonomous pr + propagate → convergence reseed armed once (#1453)"
+tick_setup
+export TICK_DECISION="pr 660 660-some-branch review 3" TICK_TOKEN="propagate"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "converge-pr: exit 0" "0" "$rc"
+assert_eq "converge-pr: convergence script called exactly once" "1" \
+  "$(wc -l < "$TMPDIR_TEST/logs/converge.log" | tr -d ' ')"
+tick_teardown
+
+echo "Test: dispatch-tick explicit + propagate → convergence reseed NOT armed (autonomous-only) (#1453)"
+tick_setup
+export TICK_DECISION="explicit 55 1" TICK_TOKEN="propagate"
+out=$(run_tick '#55') && rc=0 || rc=$?
+assert_eq "converge-explicit: exit 0" "0" "$rc"
+assert_eq "converge-explicit: convergence script NOT called (ARG set)" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/converge.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+echo "Test: dispatch-tick --manual + propagate → convergence reseed NOT armed (autonomous-only) (#1453)"
+tick_setup
+export TICK_DECISION="issue 707 1" TICK_TOKEN="propagate"
+out=$(run_tick --manual) && rc=0 || rc=$?
+assert_eq "converge-manual: exit 0" "0" "$rc"
+assert_eq "converge-manual: convergence script NOT called (MANUAL set)" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/converge.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+echo "Test: dispatch-tick convergence reseed failure is best-effort → tick still exits 0 (#1453)"
+tick_setup
+export TICK_DECISION="issue 707 2" TICK_TOKEN="propagate" TICK_CONVERGE_RC=1
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "converge-besteffort: exit 0 despite arm failure" "0" "$rc"
+assert_eq "converge-besteffort: convergence script was called" "1" \
+  "$(wc -l < "$TMPDIR_TEST/logs/converge.log" | tr -d ' ')"
+tick_teardown
+
+echo "Test: dispatch-tick concurrency-cap → convergence reseed NOT armed (#1453)"
+tick_setup
+export TICK_DECISION="concurrency-cap"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "converge-cap: exit 0" "0" "$rc"
+assert_eq "converge-cap: convergence script NOT called (no propagate branch)" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/converge.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+echo "Test: dispatch-tick drain → convergence reseed NOT armed (#1453)"
+tick_setup
+export TICK_DECISION="issue 707 1" TICK_TOKEN="drain"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "converge-drain: exit 0" "0" "$rc"
+assert_eq "converge-drain: convergence script NOT called" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/converge.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+echo "Test: dispatch-tick drain target-done → convergence reseed NOT armed (#1453)"
+tick_setup
+export TICK_DECISION="issue 707 1" TICK_TOKEN="drain target-done"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "converge-drain-td: exit 0" "0" "$rc"
+assert_eq "converge-drain-td: convergence script NOT called" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/converge.log" ] && echo 1 || echo 0)"
 tick_teardown
 
 # --- terminal token routing: every recognized token → exit 0 -----------------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -9954,10 +9954,11 @@ STUB
   chmod +x "$TMPDIR_TEST/bin/systemd-run"
   export DISPATCH_SCHEDULE_RESEED_SYSTEMD_RUN_CMD="$TMPDIR_TEST/bin/systemd-run"
 
-  # dispatch-schedule-reseed now calls ensure_recover_unit (lib.sh), which
-  # without isolation would write to the real ~/.config/systemd/user/ and run a
-  # real `systemctl --user daemon-reload`. Redirect the unit dir into the tmp
-  # tree and point its systemctl at a no-op stub so daemon-reload is harmless.
+  # dispatch-schedule-reseed now calls ensure_recover_unit + ensure_daemon_service
+  # (lib.sh), which without isolation would write to the real
+  # ~/.config/systemd/user/ and run a real `systemctl --user`. Redirect both unit
+  # dirs into the tmp tree and point their systemctl at a no-op stub so neither
+  # function writes outside the test sandbox.
   cat > "$TMPDIR_TEST/bin/systemctl" <<'STUB'
 #!/usr/bin/env bash
 exit 0
@@ -9965,6 +9966,14 @@ STUB
   chmod +x "$TMPDIR_TEST/bin/systemctl"
   export DISPATCH_RECOVER_UNIT_DIR="$TMPDIR_TEST/systemd-user"
   export DISPATCH_RECOVER_SYSTEMCTL_CMD="$TMPDIR_TEST/bin/systemctl"
+  # Stub ensure_daemon_service's three overrides. Point the daemon unit dir at a
+  # subdir of the tmp tree (so any written unit file lands there, not in
+  # ~/.config/systemd/user/), reuse the same no-op systemctl stub, and point the
+  # claude binary at the no-op systemctl so path-validation passes without needing
+  # a real claude binary (the unit is never enabled in tests).
+  export DISPATCH_DAEMON_UNIT_DIR="$TMPDIR_TEST/systemd-user"
+  export DISPATCH_DAEMON_SYSTEMCTL_CMD="$TMPDIR_TEST/bin/systemctl"
+  export DISPATCH_DAEMON_CLAUDE_CMD="$TMPDIR_TEST/bin/systemctl"
 }
 
 sr_teardown() {
@@ -9983,6 +9992,7 @@ sr_teardown() {
   unset DISPATCH_SCHEDULE_RESEED_TARGET_WORKERS_CMD
   unset DISPATCH_SCHEDULE_RESEED_SHORT_DELAY
   unset DISPATCH_RECOVER_UNIT_DIR DISPATCH_RECOVER_SYSTEMCTL_CMD
+  unset DISPATCH_DAEMON_UNIT_DIR DISPATCH_DAEMON_SYSTEMCTL_CMD DISPATCH_DAEMON_CLAUDE_CMD
 }
 
 # sr_write_rl <file-name> <used_weekly> <resets_weekly> <used_5h> <resets_5h>
@@ -10671,7 +10681,8 @@ STUB
 
   # ensure_recover_unit + ensure_daemon_service (lib.sh) would otherwise write to
   # the real ~/.config/systemd/user/ and run a real `systemctl --user`. Redirect
-  # the unit dir into the tmp tree and point its systemctl at a no-op stub.
+  # both unit dirs into the tmp tree and point their systemctl at a no-op stub
+  # so neither function writes outside the test sandbox.
   cat > "$TMPDIR_TEST/bin/systemctl" <<'STUB'
 #!/usr/bin/env bash
 exit 0
@@ -10679,6 +10690,14 @@ STUB
   chmod +x "$TMPDIR_TEST/bin/systemctl"
   export DISPATCH_RECOVER_UNIT_DIR="$TMPDIR_TEST/systemd-user"
   export DISPATCH_RECOVER_SYSTEMCTL_CMD="$TMPDIR_TEST/bin/systemctl"
+  # Stub ensure_daemon_service's three overrides. Point the daemon unit dir at a
+  # subdir of the tmp tree (so any written unit file lands there, not in
+  # ~/.config/systemd/user/), reuse the same no-op systemctl stub, and point the
+  # claude binary at the no-op systemctl so path-validation passes without needing
+  # a real claude binary (the unit is never enabled in tests).
+  export DISPATCH_DAEMON_UNIT_DIR="$TMPDIR_TEST/systemd-user"
+  export DISPATCH_DAEMON_SYSTEMCTL_CMD="$TMPDIR_TEST/bin/systemctl"
+  export DISPATCH_DAEMON_CLAUDE_CMD="$TMPDIR_TEST/bin/systemctl"
 
   export DISPATCH_CONVERGE_RESEED_MAIN_WORKTREE="$TMPDIR_TEST/main"
 
@@ -10698,6 +10717,7 @@ cr_teardown() {
   unset DISPATCH_CONVERGE_RESEED_NOW
   unset DISPATCH_CONVERGE_RESEED_DELAY
   unset DISPATCH_RECOVER_UNIT_DIR DISPATCH_RECOVER_SYSTEMCTL_CMD
+  unset DISPATCH_DAEMON_UNIT_DIR DISPATCH_DAEMON_SYSTEMCTL_CMD DISPATCH_DAEMON_CLAUDE_CMD
   unset CLAUDE_AGENTS_CMD DISPATCH_RESERVATION_DIR
 }
 
@@ -19965,6 +19985,15 @@ out=$(run_tick) && rc=0 || rc=$?
 assert_eq "resolve merge-conflict: exit 0" "0" "$rc"
 assert_eq "resolve merge-conflict: recover NOT invoked" "0" \
   "$([ -f "$TMPDIR_TEST/logs/recover.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+echo "Test: dispatch-tick resolve merge-conflict → convergence reseed NOT armed (#1453)"
+tick_setup
+export TICK_DECISION="issue 707 1" TICK_TOKEN="resolve merge-conflict"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "resolve merge-conflict: exit 0" "0" "$rc"
+assert_eq "resolve merge-conflict: convergence script NOT called" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/converge.log" ] && echo 1 || echo 0)"
 tick_teardown
 
 # --- materialize-spawn exits non-zero → dispatch-tick exits 2 ----------------

--- a/flake.lock
+++ b/flake.lock
@@ -80,8 +80,7 @@
       "inputs": {
         "claude-code-nix": "claude-code-nix",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs",
-        "wezterm-windows-zip": "wezterm-windows-zip"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
@@ -97,19 +96,6 @@
         "owner": "nix-systems",
         "repo": "default",
         "type": "github"
-      }
-    },
-    "wezterm-windows-zip": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1781342324,
-        "narHash": "sha256-eadQd9US1MDNoKhuOkEeTpYRF2xf1VfOWnUmS26aWso=",
-        "type": "tarball",
-        "url": "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip"
       }
     }
   },


### PR DESCRIPTION
Closes #1453

## Problem

The autonomous dispatch fleet refills workers only at tick boundaries, and a
tick computes its spawn budget `GAP = TARGET_N − LIVE_COUNT` once, fills up to
`GAP` slots in one batch, then waits for the next worker event. There is no
standing heartbeat, so `effective_live` (busy workers + outstanding
reservations) is never actively driven toward `TARGET_N` and headcount sawtooths
far below target.

Two dynamics push the count below target with nothing armed to recover:

1. **Partial fill.** The selector scan returns fewer ready targets than `GAP`
   (some CI-pending or transiently worktree-conflicted), so the run spawns
   `N < GAP` and exits — no follow-up armed.
2. **Drain during a tick.** A tick takes minutes. While it runs, busy workers
   complete; each completion's Stop-hook calls `dispatch-spawn-tick`, but that
   uses a fixed unit name, so concurrent calls collide and dedup. When the
   in-flight tick finishes — even after reporting "gap filled" — the workers that
   drained leave the fleet below target with no pending tick. A `spawned < GAP`
   trigger does not catch this (the tick's own `GAP` slots were all filled); only
   a fresh `effective_live` re-count at tick end does.

## Change

Drive `effective_live` toward `TARGET_N` by arming a short-delay **convergence
reseed** at the end of any autonomous tick that reached a normal materialize
decision but may have ended below target — modeled on the existing `ci-waiting`
reseed precedent rather than on a periodic heartbeat.

**Unit 1 — new `dispatch-schedule-convergence-reseed`.** Re-counts effective-live
workers (busy + reservations, daemon-UNKNOWN → 0 fail-toward-arming) and arms a
transient no-arg `dispatch-tick` timer only when below target and not gated:

- `LIVE >= TARGET_N` → `converged` no-op (this also covers the pace-gate-closed
  case for free: a pace pause makes `dispatch-target-workers` return `0`, so
  `LIVE >= 0` always holds).
- `--exhausted` reports `exhausted` → `exhausted` no-op (the cap-path pace reseed
  owns resumption).
- otherwise arms `dispatch-converge-<epoch>` at `NOW + DELAY` (default 120s),
  carrying the same `systemd-run` contract as the sibling reseed scripts
  (`--collect`, `OnFailure=dispatch-tick-recover.service`, `KillMode=process`,
  `Persistent=true`, `--setenv=PATH`), with `@<epoch>` idempotency (`already
  exists` collision → no-op). Every value reaching an arithmetic context is
  integer-validated (the siblings' RCE-hardening posture).

**Unit 2 — wire `dispatch-tick`.** On the `propagate` terminal token only, and on
the autonomous queue path only (`[[ -z "$MANUAL" && -z "$ARG" ]]` — explicit and
bare-manual `/dispatch` are gate-exempt single-target spawns), call the new
script best-effort: a failure logs one stderr note and the tick still exits 0.
Placement on `propagate` is what makes the trigger a fresh `effective_live`
recount rather than the stale `spawned < GAP` signal, catching both the
partial-fill and drain-during-tick cases. A paced/exhausted tick returns
`concurrency-cap` and never reaches this branch.

## Tests

Full `test-dispatch-scripts.sh` suite green (2336/2336). New coverage:

- `dispatch-schedule-convergence-reseed`: below-target arm (full `systemd-run`
  argv incl. no-trailing-arg `ExecStart`), busy+reservation sum, at-target
  `converged`, pace-gate-closed `converged`, token-exhausted `exhausted`,
  idempotent already-exists re-arm.
- `dispatch-tick` wiring: autonomous `propagate` (issue + pr) calls the script
  once; explicit and `--manual` `propagate` do not call it; `concurrency-cap`,
  `drain`, and `drain target-done` do not call it; a convergence-arm failure
  still exits 0.

## Alternatives not chosen

A standing periodic heartbeat timer (the issue's second option) would also
converge the fleet, but runs against the architecture's deliberate move away
from a coarse static heartbeat toward event/reset-driven reseeds, and is better
understood as addressing the fully-drained absorbing dead-state (#1445) — a
separate concern. The convergence reseed subsumes it for this issue's criteria
while firing only when actually below target. A global bounded attempt counter
was considered and left out: termination is already natural (a follow-up tick
that cannot fill returns `empty`/`concurrency-cap`, neither of which arms a
convergence reseed), so a counter is at most optional hardening against
degenerate fast-churn (#1454 territory).
