### PR TITLE
dispatch-phase: gh_retry the no-PR label fetch, fail clear instead of mapping to plan

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-phase
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-phase
@@ -26,6 +26,7 @@
 # For a no-PR target, the phase is `plan` unless the issue carries the
 # `dispatch:planned` label (then `implement`). This is determined by fetching
 # the issue's labels via `gh issue view`.
+# A gh/network failure in this fetch exits non-zero (it is no longer silently mapped to plan); transient blips self-heal via gh_retry.
 #
 # Environment:
 #   DISPATCH_PR_LIST — optional. A JSON array of open PRs supplied by the
@@ -78,9 +79,13 @@ if [[ -z "$PR" || "$PR" == "null" ]]; then
       exit 1
     fi
   fi
-  ISSUE_LABELS=$(gh issue view "$ISSUE_NUM" --json labels | jq -r '.labels[].name' 2>/dev/null) || {
-    echo "plan"
-    exit 0
+  ISSUE_JSON=$(gh_retry gh issue view "$ISSUE_NUM" --json labels) || {
+    echo "dispatch-phase: gh issue view #$ISSUE_NUM (labels) failed; cannot derive phase" >&2
+    exit 1
+  }
+  ISSUE_LABELS=$(jq -r '.labels[].name' <<<"$ISSUE_JSON") || {
+    echo "dispatch-phase: failed to parse labels JSON for #$ISSUE_NUM" >&2
+    exit 1
   }
   if grep -qxF "dispatch:planned" <<<"$ISSUE_LABELS"; then
     echo "implement"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -397,6 +397,17 @@ case "$args" in
     # $STUB_DIR/issue-labels-<num>.json supplies the labels object; absence means
     # the issue carries no labels.
     num=$(echo "$args" | awk '{print $3}')
+    # #1314: a per-issue fail-count sentinel makes the stub emit a transient
+    # (HTTP 503) error and decrement the count, so gh_retry retries. Absent by
+    # default → every existing test is unaffected; exhausted → serve labels.
+    if [[ -f "$STUB_DIR/issue-view-fail-${num}" ]]; then
+      remaining=$(cat "$STUB_DIR/issue-view-fail-${num}")
+      if [[ "$remaining" -gt 0 ]]; then
+        echo $((remaining - 1)) > "$STUB_DIR/issue-view-fail-${num}"
+        echo "HTTP 503: Service Unavailable" >&2
+        exit 1
+      fi
+    fi
     if [[ -f "$STUB_DIR/issue-labels-${num}.json" ]]; then
       cat "$STUB_DIR/issue-labels-${num}.json"
     else
@@ -781,6 +792,30 @@ echo '[]' > "$STUB_DIR/pr-list-full.json"
 printf '{"labels":[{"name":"help wanted"}]}\n' > "$STUB_DIR/issue-labels-42.json"
 result=$("$TMPDIR_TEST/dispatch-phase" "42")
 assert_eq "no PR + non-planned label → plan" "plan" "$result"
+teardown
+
+# 1d. No PR + persistently-transient gh failure → exit non-zero, NOT a silent
+# "plan" (the bug in #1314). GH_RETRY_ATTEMPTS defaults to 4, so a fail count of
+# 5 exhausts every attempt. The fix exits 1.
+echo "Test: no PR + persistently-transient gh failure → exit 1, not plan"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo 5 > "$STUB_DIR/issue-view-fail-42"
+result=$("$TMPDIR_TEST/dispatch-phase" "42" 2>/dev/null) && rc=0 || rc=$?
+assert_eq "transient-exhausted → exit 1" "1" "$rc"
+assert_eq "transient-exhausted → empty stdout (not plan)" "" "$result"
+teardown
+
+# 1e. No PR + transient-then-succeed gh → gh_retry retries within the 4-attempt
+# budget and the phase is derived correctly (implement), proving the retry fires
+# and self-heals instead of the old silent "plan" fallback.
+echo "Test: no PR + transient-then-succeed gh → retries, derives implement"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo 2 > "$STUB_DIR/issue-view-fail-42"
+printf '{"labels":[{"name":"dispatch:planned"}]}\n' > "$STUB_DIR/issue-labels-42.json"
+result=$("$TMPDIR_TEST/dispatch-phase" "42")
+assert_eq "transient-then-succeed → implement" "implement" "$result"
 teardown
 
 # 2. Draft + failing CI → fix-checks

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -795,15 +795,18 @@ assert_eq "no PR + non-planned label → plan" "plan" "$result"
 teardown
 
 # 1d. No PR + persistently-transient gh failure → exit non-zero, NOT a silent
-# "plan" (the bug in #1314). GH_RETRY_ATTEMPTS defaults to 4, so a fail count of
-# 5 exhausts every attempt. The fix exits 1.
+# "plan" (the bug in #1314). Pin GH_RETRY_ATTEMPTS=4 explicitly (matching the
+# gh_retry unit tests) so a fail count of 5 exhausts every attempt regardless of
+# the lib.sh default. The fix exits 1.
 echo "Test: no PR + persistently-transient gh failure → exit 1, not plan"
 setup
+export GH_RETRY_ATTEMPTS=4
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo 5 > "$STUB_DIR/issue-view-fail-42"
 result=$("$TMPDIR_TEST/dispatch-phase" "42" 2>/dev/null) && rc=0 || rc=$?
 assert_eq "transient-exhausted → exit 1" "1" "$rc"
 assert_eq "transient-exhausted → empty stdout (not plan)" "" "$result"
+unset GH_RETRY_ATTEMPTS
 teardown
 
 # 1e. No PR + transient-then-succeed gh → gh_retry retries within the 4-attempt


### PR DESCRIPTION
Closes #1314

## Problem

`dispatch-phase` answers "which workflow phase skill runs for an issue/branch."
For a no-PR target it derives the phase from whether the issue carries the
`dispatch:planned` label — present → `implement`, absent → `plan` — learned via
`gh issue view <num> --json labels`.

The label fetch swallowed any failure and emitted `plan`:

```bash
ISSUE_LABELS=$(gh issue view "$ISSUE_NUM" --json labels | jq -r '.labels[].name' 2>/dev/null) || {
    echo "plan"
    exit 0
}
```

So a transient `gh`/network blip was indistinguishable from "no
`dispatch:planned` label" and yielded `plan`. A genuinely-planned issue then
routed to relevance-review / re-planning instead of `/implement` — wasting a
tick or duplicating the plan. This is the "defensive fallback that buries
errors" anti-pattern called out in `.claude/rules/code-style.md`; the rest of
`dispatch-phase` already fails clear under `set -euo pipefail`.

## Fix

Wrap the fetch in `gh_retry` (`lib.sh:54`, already sourced) so a *transient*
failure self-heals via retry, and fail clear (exit non-zero) on a real failure
instead of swallowing it. Because `gh_retry` wraps a single command (not a
pipeline), the former `gh … | jq …` one-liner is split into a `gh_retry` fetch
and a separate `jq` parse, each failing clear:

```bash
ISSUE_JSON=$(gh_retry gh issue view "$ISSUE_NUM" --json labels) || {
  echo "dispatch-phase: gh issue view #$ISSUE_NUM (labels) failed; cannot derive phase" >&2
  exit 1
}
ISSUE_LABELS=$(jq -r '.labels[].name' <<<"$ISSUE_JSON") || {
  echo "dispatch-phase: failed to parse labels JSON for #$ISSUE_NUM" >&2
  exit 1
}
```

`dispatch-route` runs `PHASE=$(... dispatch-phase "$N")` under `set -euo
pipefail`, so a non-zero exit propagates as a route failure — the desired
fail-clear behavior. No caller change is needed.

**Empty-labels behavior is preserved:** a successful fetch of an unlabeled issue
yields `{"labels":[]}` → `jq` prints nothing → the `dispatch:planned` check
misses → `plan`. Legitimately-unplanned issues still route to `plan`; only
*failures* now exit non-zero. The trailing `2>/dev/null` (which had masked `jq`
parse errors) is dropped.

**Out of scope:** the bare `gh pr list` at `dispatch-phase:52` is not part of
this fix — it has no silent fallback and already fails clear under `set -e`.

## Tests

`test-dispatch-scripts.sh` gains a per-issue fail-count stub sentinel
(`issue-view-fail-<num>`) that emits a transient `HTTP 503` error and decrements
on each call — absent by default, so every existing test is unaffected. Two new
`dispatch-phase` tests:

- **transient-exhausted → exit 1, not `plan`** — fail count above the retry
  budget; asserts non-zero exit and empty stdout (the #1314 bug).
- **transient-then-succeed → `implement`** — fail twice within budget, then
  serve a `dispatch:planned` label; proves the retry fires and derives the
  correct phase.

Full suite: `2394/2394 passed, 0 failed`.
