### PR TITLE
budget: validate reimbursement range in idbToTransaction read path

### DIFF
--- a/budget/src/entities/transaction.ts
+++ b/budget/src/entities/transaction.ts
@@ -226,6 +226,7 @@ export function transactionToIdbRecord(t: Transaction): IdbTransaction {
 // ── IdbTransaction → Transaction ─────────────────────────────────────────────
 
 export function idbToTransaction(row: IdbTransaction): Transaction {
+  validateReimbursementRange(row.reimbursement);
   return {
     id: row.id as TransactionId,
     institution: row.institution,

--- a/budget/test/data-source.test.ts
+++ b/budget/test/data-source.test.ts
@@ -123,6 +123,14 @@ describe("IdbDataSource", () => {
     expect(txns[0].reimbursement).toBe(0); // unchanged — never persisted
   });
 
+  it("getTransactions throws for a pre-existing out-of-range reimbursement record", async () => {
+    const data = makeParsedData();
+    data.transactions[0].reimbursement = 150; // simulates a row written before PR #1345
+    await storeParsedData(data);
+    const ds = new IdbDataSource();
+    await expect(ds.getTransactions()).rejects.toThrow(RangeError);
+  });
+
   it("adjustBudgetPeriodTotal does read-modify-write correctly", async () => {
     await storeParsedData(makeParsedData());
     const ds = new IdbDataSource();


### PR DESCRIPTION
Closes #1358

## Summary

PR #1345 (for #1265) added a `validateReimbursementRange` guard on the IDB
**write** path and the upload parse path, so new out-of-range writes are
rejected. But the symmetrical IDB **read** path — `idbToTransaction`
(`budget/src/entities/transaction.ts`) — passed `row.reimbursement` straight
through to the `Transaction` domain object with no validation.

Every other parse path already validates (`parseFirestoreTransaction` via
`requireReimbursement`, `parseRawTransaction` via `validateReimbursementRange`,
`serializeSeedTransaction` via `requireSeedReimbursement`). `idbToTransaction`
was the lone gap: any record written **before** #1345 with `reimbursement > 100`
or `< 0` was read back unvalidated by `getTransactions`, then threw `RangeError`
deep inside `computeNetAmount` on every render that computes net amounts — the
same page-bricking symptom as #1265, surfacing from a corrupt pre-existing DB.

## Changes

- `budget/src/entities/transaction.ts` — `idbToTransaction` now calls the
  already-in-file `validateReimbursementRange(row.reimbursement)` before building
  the `Transaction`, mirroring `parseRawTransaction`. A corrupt IDB record now
  fails fast with a clear `RangeError` at the parse boundary instead of
  detonating later inside render math (consistent with the sibling parse paths
  and `.claude/rules/code-style.md` — prefer clear errors over defensive
  fallbacks).
- `budget/test/data-source.test.ts` — added a test that seeds a pre-existing
  out-of-range record (`reimbursement: 150`, written via `storeParsedData` which
  `put`s as-is with no validation, faithfully reproducing a pre-fix row) and
  asserts `getTransactions` rejects with `RangeError`.

Design choice: **throw**, not clamp — matches all other parse paths and forces
explicit data repair. The optional one-time IDB migration scan remains out of
scope.

## Verification

```
npx vitest run --root budget test/data-source.test.ts
```

All 38 tests pass (37 existing + the new one).
