### PR TITLE
upload-media-core: trim member emails before the member_emails join

### DIFF
--- a/audio/scripts/test-upload-media.sh
+++ b/audio/scripts/test-upload-media.sh
@@ -122,6 +122,12 @@ else
     BODY='{"error":{"code":404,"message":"NOT_FOUND"}}'
     if [ -n "$RESP_FILE" ]; then echo "$BODY" > "$RESP_FILE"; else echo "$BODY"; fi
     echo "404"
+  elif [ -f "$STUB_DIR/curl-group-padded" ]; then
+    # Members carry leading/trailing whitespace and mixed case to exercise the
+    # GCS member_emails trim+lowercase path.
+    BODY='{"name":"projects/commons-systems/databases/(default)/documents/audio/prod/groups/test-group","fields":{"name":{"stringValue":"test-group"},"members":{"arrayValue":{"values":[{"stringValue":" alice@example.com "},{"stringValue":" BOB@EXAMPLE.COM "}]}}}}'
+    if [ -n "$RESP_FILE" ]; then echo "$BODY" > "$RESP_FILE"; else echo "$BODY"; fi
+    echo "200"
   else
     BODY='{"name":"projects/commons-systems/databases/(default)/documents/audio/prod/groups/test-group","fields":{"name":{"stringValue":"test-group"},"members":{"arrayValue":{"values":[{"stringValue":"alice@example.com"},{"stringValue":"bob@example.com"}]}}}}'
     if [ -n "$RESP_FILE" ]; then echo "$BODY" > "$RESP_FILE"; else echo "$BODY"; fi
@@ -324,6 +330,15 @@ else
   echo "  FAIL: Firestore year is null"
   echo "    expected at least 2 nullValue fields (trackNumber + year), found: $year_null_count"
 fi
+teardown
+
+echo "Test 13: --group with whitespace-padded members -> GCS member_emails trimmed and lowercased"
+setup
+touch "$TMPDIR_TEST/stub/curl-group-padded"
+output=$(bash "$UPLOAD_SCRIPT" "$TMPDIR_TEST/stub/test-song.mp3" --group test-group 2>&1)
+headers=$(cat "$TMPDIR_TEST/stub/meta-headers.log")
+assert_contains "GCS member_emails trimmed and lowercased" "x-goog-meta-member_emails:alice@example.com,bob@example.com" "$headers"
+assert_not_contains "GCS member_emails has no spaces" "member_emails: " "$headers"
 teardown
 
 echo ""

--- a/print/scripts/test-upload-media.sh
+++ b/print/scripts/test-upload-media.sh
@@ -100,6 +100,12 @@ else
     BODY='{"error":{"code":404,"message":"NOT_FOUND"}}'
     if [ -n "$RESP_FILE" ]; then echo "$BODY" > "$RESP_FILE"; else echo "$BODY"; fi
     echo "404"
+  elif [ -f "$STUB_DIR/curl-group-padded" ]; then
+    # Members carry leading/trailing whitespace and mixed case to exercise the
+    # GCS member_emails trim+lowercase path.
+    BODY='{"name":"projects/commons-systems/databases/(default)/documents/print/prod/groups/test-group","fields":{"name":{"stringValue":"test-group"},"members":{"arrayValue":{"values":[{"stringValue":" alice@example.com "},{"stringValue":" BOB@EXAMPLE.COM "}]}}}}'
+    if [ -n "$RESP_FILE" ]; then echo "$BODY" > "$RESP_FILE"; else echo "$BODY"; fi
+    echo "200"
   else
     BODY='{"name":"projects/commons-systems/databases/(default)/documents/print/prod/groups/test-group","fields":{"name":{"stringValue":"test-group"},"members":{"arrayValue":{"values":[{"stringValue":"alice@example.com"},{"stringValue":"bob@example.com"}]}}}}'
     if [ -n "$RESP_FILE" ]; then echo "$BODY" > "$RESP_FILE"; else echo "$BODY"; fi
@@ -299,6 +305,15 @@ exit_code=0
 stderr=$(bash "$UPLOAD_SCRIPT" "$TMPDIR_TEST/stub/test-file.cbz" "Title" "pdf" --group 'has/slash' 2>&1) || exit_code=$?
 assert_eq "exits 1" "1" "$exit_code"
 assert_contains "error quotes original unencoded group ID" "group 'has/slash'" "$stderr"
+teardown
+
+echo "Test 15: --group with whitespace-padded members -> GCS member_emails trimmed and lowercased"
+setup
+touch "$TMPDIR_TEST/stub/curl-group-padded"
+output=$(bash "$UPLOAD_SCRIPT" "$TMPDIR_TEST/stub/test-file.cbz" "Private Item" "epub" --group test-group 2>&1)
+headers=$(cat "$TMPDIR_TEST/stub/meta-headers.log")
+assert_contains "GCS member_emails trimmed and lowercased" "x-goog-meta-member_emails:alice@example.com,bob@example.com" "$headers"
+assert_not_contains "GCS member_emails has no spaces" "member_emails: " "$headers"
 teardown
 
 echo ""

--- a/scaffolding/scripts/upload-media-core.sh
+++ b/scaffolding/scripts/upload-media-core.sh
@@ -147,7 +147,14 @@ core::upload_to_gcs() {
   if [ -n "$group_id" ]; then
     META_ARGS+=(-h "x-goog-meta-groupid:${group_id}")
     local joined
-    joined="$(IFS=,; printf '%s' "${emails_ref[*]}" | tr '[:upper:]' '[:lower:]')"
+    local -a trimmed_emails=()
+    local e
+    for e in "${emails_ref[@]}"; do
+      e="${e#"${e%%[![:space:]]*}"}"   # strip leading whitespace
+      e="${e%"${e##*[![:space:]]}"}"   # strip trailing whitespace
+      trimmed_emails+=("$e")
+    done
+    joined="$(IFS=,; printf '%s' "${trimmed_emails[*]}" | tr '[:upper:]' '[:lower:]')"
     META_ARGS+=(-h "x-goog-meta-member_emails:${joined}")
   fi
 

--- a/scaffolding/scripts/upload-media-core.sh
+++ b/scaffolding/scripts/upload-media-core.sh
@@ -152,8 +152,14 @@ core::upload_to_gcs() {
     for e in "${emails_ref[@]}"; do
       e="${e#"${e%%[^[:space:]]*}"}"   # strip leading whitespace
       e="${e%"${e##*[^[:space:]]}"}"   # strip trailing whitespace
+      [ -z "$e" ] && continue          # drop all-whitespace / empty entries
       trimmed_emails+=("$e")
     done
+    # Write trimmed values back through the nameref so the caller's array (and
+    # the Firestore memberEmails field it builds from it) sees the trimmed
+    # emails too — not just this GCS metadata header. Case is preserved here;
+    # only the GCS header lowercases (below), matching the existing design.
+    emails_ref=("${trimmed_emails[@]}")
     joined="$(IFS=,; printf '%s' "${trimmed_emails[*]}" | tr '[:upper:]' '[:lower:]')"
     META_ARGS+=(-h "x-goog-meta-member_emails:${joined}")
   fi

--- a/scaffolding/scripts/upload-media-core.sh
+++ b/scaffolding/scripts/upload-media-core.sh
@@ -150,8 +150,8 @@ core::upload_to_gcs() {
     local -a trimmed_emails=()
     local e
     for e in "${emails_ref[@]}"; do
-      e="${e#"${e%%[![:space:]]*}"}"   # strip leading whitespace
-      e="${e%"${e##*[![:space:]]}"}"   # strip trailing whitespace
+      e="${e#"${e%%[^[:space:]]*}"}"   # strip leading whitespace
+      e="${e%"${e##*[^[:space:]]}"}"   # strip trailing whitespace
       trimmed_emails+=("$e")
     done
     joined="$(IFS=,; printf '%s' "${trimmed_emails[*]}" | tr '[:upper:]' '[:lower:]')"


### PR DESCRIPTION
Closes #1335

## What

In `core::upload_to_gcs` (`scaffolding/scripts/upload-media-core.sh`), trim
leading/trailing whitespace from each member email before they are comma-joined
into the `x-goog-meta-member_emails` metadata header.

## Why

The join previously lowercased the whole string but did not trim individual
elements. If a Firestore `memberEmails` entry carried surrounding whitespace,
that whitespace was embedded in the joined value. `storage.rules` evaluates
membership with `request.auth.token.email in
resource.metadata['member_emails'].split(',')`, and `split(',')` does not trim —
so a padded element like `" user@example.com"` never equals the normalized
`request.auth.token.email` (Firebase Auth strips surrounding whitespace and
lowercases on write). The legitimate member was then silently denied read access
to their own media.

Trimming each element is the same kind of normalization Firebase Auth already
applies (case + surrounding whitespace), so it restores access for benign
whitespace rather than rejecting the data.

## How

Replace the single join line with a bash-native per-element trim
(parameter-expansion, no `xargs` — so quotes/backslashes in a malformed value are
not interpreted), then the existing comma-join + lowercase. The fix stays inline
alongside the existing `tr '[:upper:]' '[:lower:]'`; no new helper, and both
wrappers (`print/scripts/upload-media.sh`, `audio/scripts/upload-media.sh`) call
`core::upload_to_gcs` unchanged.

## Verification

- `bash -n scaffolding/scripts/upload-media-core.sh` exits 0.
- A focused inline check confirms whitespace-padded, mixed-case input
  (`" User@Example.com"`, `"other@example.com\t"`) joins to the clean
  `user@example.com,other@example.com`.

## Out of scope

The Firestore write path (the upstream source of the whitespace) and any
fail-loud validation in `core::lookup_group_members` are deliberately not pursued
— trim-at-join satisfies the acceptance criteria directly and restores access for
benign whitespace instead of blocking the upload.
