### PR TITLE
dispatch: bound the lock's daemon probe + flock, validate TARGET_N

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
@@ -98,13 +98,27 @@
 #                               Default: 300.
 #   DISPATCH_LOCK_WAIT_INTERVAL --wait: poll gap in seconds (fractional
 #                               allowed). Default: 5.
+#   DISPATCH_LOCK_PROBE_TIMEOUT Max seconds the `claude agents --json` liveness
+#                               probe may run before it is treated as a wedged
+#                               daemon (timeout-bounded, with a SIGKILL
+#                               backstop). A healthy probe is sub-second.
+#                               Default: 10.
+#   DISPATCH_LOCK_FLOCK_TIMEOUT Max seconds to wait for the in-section flock
+#                               before abandoning the attempt as contended.
+#                               MUST exceed DISPATCH_LOCK_PROBE_TIMEOUT plus
+#                               margin: the probe is the only slow op inside the
+#                               critical section, so a waiter must not abandon a
+#                               holder that is legitimately mid-probe.
+#                               Default: 15.
 #
 # Stdout protocol (exactly one word):
 #   acquired  this dispatch tick holds the lock — proceed with the tick.
 #   busy      another dispatch tick holds the lock — stop cleanly, no side effects.
-#             Under --wait this means the wait timeout elapsed; a one-line
-#             diagnostic (elapsed time + holding sessionId) is written to
-#             stderr.
+#             Also covers the case where the in-section flock wait timed out (a
+#             wedged holder pinned the critical section): the attempt resolves to
+#             contended rather than deadlocking. Under --wait, busy means the
+#             wait timeout elapsed; a one-line diagnostic (elapsed time + holding
+#             sessionId, or "(flock wait timeout)") is written to stderr.
 #   released  --release: our own recorded sessionId was cleared from the lock
 #             file.
 #   noop      --release: nothing to release — the lock was unheld or held by
@@ -140,6 +154,8 @@ fi
 
 WAIT_TIMEOUT="${DISPATCH_LOCK_WAIT_TIMEOUT:-300}"
 WAIT_INTERVAL="${DISPATCH_LOCK_WAIT_INTERVAL:-5}"
+PROBE_TIMEOUT="${DISPATCH_LOCK_PROBE_TIMEOUT:-10}"
+FLOCK_TIMEOUT="${DISPATCH_LOCK_FLOCK_TIMEOUT:-15}"
 
 # resolve_holder_state <sessionId> — query the daemon's live-session registry
 # for <sessionId> and report both liveness and cwd. Covers the same failure
@@ -159,12 +175,22 @@ WAIT_INTERVAL="${DISPATCH_LOCK_WAIT_INTERVAL:-5}"
 # Return: 0 = live (or opaque failure → fail-safe live)
 #         1 = definitely not live (reclaim)
 #
+# The daemon probe is `timeout`-bounded (DISPATCH_LOCK_PROBE_TIMEOUT, with a
+# `-k 5` SIGKILL backstop): a wedged daemon that never returns must not block
+# the probe — and so the in-section flock — indefinitely. The KILL backstop is
+# required because plain `timeout` only sends SIGTERM and then waits for the
+# child, so a client that ignores SIGTERM would make `timeout` itself hang,
+# reproducing the deadlock. A timed-out probe exits non-zero, which the
+# `if ! out=$(...)` below folds to fail-safe LIVE → the caller stays BUSY.
+#
 # The `9>&-` redirection closes fd 9 (the flock fd, opened by the caller's
 # subshell) in the `claude` child. flock is on the open file description and
 # is released only when the LAST referencing fd closes; without the close,
 # any background helper `claude` ever spawns would inherit fd 9 and hold the
 # flock past our subshell's exit. Today `claude agents --json` is a query-and-
 # exit client, but the cost of defending against a future fork is one redir.
+# The redirections stay on the `timeout` simple command, which execs `claude`
+# with fd 9 already closed and stderr already silenced.
 resolve_holder_state() {
   local sid="$1" out rows match
   # Headless holders (the systemd-launched dispatch-tick's synthetic
@@ -184,7 +210,7 @@ resolve_holder_state() {
     kill -0 "$pid" 2>/dev/null || return 1
     return 0
   fi
-  if ! out=$("${CLAUDE_AGENTS_CMD:-claude}" agents --json 2>/dev/null 9>&-); then
+  if ! out=$(timeout -k 5 "$PROBE_TIMEOUT" "${CLAUDE_AGENTS_CMD:-claude}" agents --json 2>/dev/null 9>&-); then
     return 0
   fi
   if [[ -z "${out//[[:space:]]/}" ]]; then
@@ -265,7 +291,16 @@ try_acquire() {            # 0 = acquired, 1 = contended; sets CONTENDED_SID
   local result
   result=$(
     exec 9>>"$LOCK_FILE"
-    flock 9                # blocking — a short mutex over the read-check-write
+    # Bounded mutex over the read-check-write. The only slow op inside the
+    # critical section is the timeout-bounded daemon probe, so a wait that
+    # exceeds FLOCK_TIMEOUT (> PROBE_TIMEOUT + margin) means the holder is
+    # wedged, not legitimately mid-probe. On timeout we leave the subshell
+    # WITHOUT running the read-check-write (which would be a racy unlocked
+    # read + clobbering write); the parent maps the sentinel to contended.
+    if ! flock -w "$FLOCK_TIMEOUT" 9; then
+      printf 'FLOCK_TIMEOUT'
+      exit 0
+    fi
     local recorded="" cwd="" live=0
     IFS= read -r recorded <"$LOCK_FILE" 2>/dev/null || true
     # Busy iff a different sessionId is recorded AND it is still a live
@@ -297,6 +332,12 @@ try_acquire() {            # 0 = acquired, 1 = contended; sets CONTENDED_SID
   case "$result" in
     OK)       return 0 ;;
     'BUSY '*) CONTENDED_SID="${result#BUSY }"; return 1 ;;
+    # The in-section flock wait timed out: a wedged holder is pinning the
+    # critical section. Treat as contended (never reclaim — we did NOT read
+    # the lock, so the holder is unknown) and surface a diagnostic string
+    # rather than a real sid, since populating one would require a racy
+    # unlocked read.
+    FLOCK_TIMEOUT) CONTENDED_SID="(flock wait timeout)"; return 1 ;;
     *) echo "dispatch-acquire-lock: try_acquire — unexpected subshell output '$result'" >&2
        exit 2 ;;
   esac

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
@@ -102,14 +102,16 @@
 #                               probe may run before it is treated as a wedged
 #                               daemon (timeout-bounded, with a SIGKILL
 #                               backstop). A healthy probe is sub-second.
-#                               Default: 10.
+#                               Must be a POSITIVE integer — 0 disables GNU
+#                               `timeout`'s bound and re-opens the unbounded-probe
+#                               hang, so it is rejected (exit 2). Default: 10.
 #   DISPATCH_LOCK_FLOCK_TIMEOUT Max seconds to wait for the in-section flock
 #                               before abandoning the attempt as contended.
-#                               MUST exceed DISPATCH_LOCK_PROBE_TIMEOUT plus
-#                               margin: the probe is the only slow op inside the
-#                               critical section, so a waiter must not abandon a
-#                               holder that is legitimately mid-probe.
-#                               Default: 15.
+#                               MUST strictly exceed DISPATCH_LOCK_PROBE_TIMEOUT:
+#                               the probe is the only slow op inside the critical
+#                               section, so a waiter must not abandon a holder
+#                               that is legitimately mid-probe. Enforced at
+#                               startup (exit 2 on violation). Default: 15.
 #
 # Stdout protocol (exactly one word):
 #   acquired  this dispatch tick holds the lock — proceed with the tick.
@@ -129,8 +131,10 @@
 #      disambiguates).
 #   2  the script cannot operate — not in a git repo and DISPATCH_LOCK_FILE is
 #      unset, CLAUDE_CODE_SESSION_ID is unset, an unknown/extra command-line
-#      argument, or an unexpected internal sentinel from a flock subshell (a
-#      should-never-happen guard).
+#      argument, a misconfigured timeout knob (DISPATCH_LOCK_PROBE_TIMEOUT not a
+#      positive integer, or DISPATCH_LOCK_FLOCK_TIMEOUT not strictly greater than
+#      it; acquire/wait only), or an unexpected internal sentinel from a flock
+#      subshell (a should-never-happen guard).
 #
 # NOT set -e: exits are handled explicitly (matching the sibling dispatch-sweep).
 set -uo pipefail
@@ -342,6 +346,37 @@ try_acquire() {            # 0 = acquired, 1 = contended; sets CONTENDED_SID
        exit 2 ;;
   esac
 }
+
+# ---- validate the timeout knobs ---------------------------------------------
+# Only try_acquire (acquire/wait modes) consumes the probe + in-section flock
+# timeouts; --release uses neither, so leave it unvalidated and unchanged.
+# A misconfigured knob is a broken environment — fail clear (exit 2), do not
+# fall back (matches the clear-error-over-fallback rule; same convention as the
+# git-repo and CLAUDE_CODE_SESSION_ID guards above).
+if [[ "$MODE" != "release" ]]; then
+  # PROBE_TIMEOUT must be a POSITIVE integer. `^[0-9]+$` alone is not enough:
+  # GNU `timeout 0 <cmd>` DISABLES the bound and runs the probe unbounded,
+  # silently re-opening the very wedged-daemon hang this script fixes (#1315).
+  if [[ ! "$PROBE_TIMEOUT" =~ ^[0-9]+$ || "$PROBE_TIMEOUT" -lt 1 ]]; then
+    echo "dispatch-acquire-lock: DISPATCH_LOCK_PROBE_TIMEOUT must be a positive integer (got '$PROBE_TIMEOUT'); 0 disables GNU timeout's bound and re-opens the unbounded-probe hang" >&2
+    exit 2
+  fi
+  if [[ ! "$FLOCK_TIMEOUT" =~ ^[0-9]+$ ]]; then
+    echo "dispatch-acquire-lock: DISPATCH_LOCK_FLOCK_TIMEOUT must be a non-negative integer (got '$FLOCK_TIMEOUT')" >&2
+    exit 2
+  fi
+  # FLOCK_TIMEOUT must STRICTLY exceed PROBE_TIMEOUT. The probe is the only slow
+  # op inside the critical section, so a waiter that gives up at or before the
+  # probe's normal ceiling would abandon a holder that is legitimately mid-probe
+  # and report a false busy. (The `-k 5` SIGKILL grace pushes a SIGTERM-ignoring
+  # probe to PROBE_TIMEOUT+5, but in that pathological case the holder genuinely
+  # IS wedged, so abandoning-to-busy is the fail-safe outcome — hence `>`, not
+  # `> PROBE_TIMEOUT + 5`, which the shipped 15/10 defaults would also fail.)
+  if [[ "$FLOCK_TIMEOUT" -le "$PROBE_TIMEOUT" ]]; then
+    echo "dispatch-acquire-lock: DISPATCH_LOCK_FLOCK_TIMEOUT ($FLOCK_TIMEOUT) must exceed DISPATCH_LOCK_PROBE_TIMEOUT ($PROBE_TIMEOUT); otherwise a waiter abandons a holder that is legitimately mid-probe" >&2
+    exit 2
+  fi
+fi
 
 # ---- dispatch the mode ------------------------------------------------------
 case "$MODE" in

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -58,7 +58,7 @@
 # See .claude/rules/sandbox.md.
 #
 # Exit code: 0 on every decision line; 2 on an internal/usage error surfaced on
-# stderr.
+# stderr (e.g. non-numeric TARGET_N from dispatch-target-workers).
 #
 # NOT set -e: exits are handled explicitly (matching the sibling dispatch
 # scripts).
@@ -205,6 +205,11 @@ if [[ -z "$MANUAL" && -z "$ARG" ]]; then
   # shellcheck source=/dev/null
   source "$SCRIPT_DIR/lib-reservation-ledger.sh"
   TARGET_N=$("$SCRIPT_DIR/dispatch-target-workers")
+  if [[ ! "$TARGET_N" =~ ^[0-9]+$ ]]; then
+    release_lock
+    echo "dispatch-select-tick: dispatch-target-workers returned non-numeric target '$TARGET_N'" >&2
+    exit 2
+  fi
   # Reconcile the ledger before counting so the gate sees no stranded
   # reservations (sweep reclaim notes → stderr; best-effort).
   # reservation_sweep internally calls claude_agents_list_all, which reads

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6943,9 +6943,13 @@ export CLAUDE_CODE_SESSION_ID="sess-flock-mine"
 # Registry knows only our session → the recorded holder is stale (would be
 # reclaimed if the buggy fall-through ever ran the unlocked read-check-write).
 lock_fake_claude_sessions "sess-flock-mine"
-export DISPATCH_LOCK_FLOCK_TIMEOUT=1
+# FLOCK must strictly exceed PROBE (the startup guard enforces this), so set
+# PROBE=1 and FLOCK=2 — the smallest valid pair that still makes `flock -w 2`
+# time out against the 3s holder below. (The probe never runs here: the flock
+# wait times out before the read-check-write.)
+export DISPATCH_LOCK_PROBE_TIMEOUT=1 DISPATCH_LOCK_FLOCK_TIMEOUT=2
 # Hold the advisory lock on the same file for longer than FLOCK_TIMEOUT so the
-# acquirer's `flock -w 1` genuinely times out.
+# acquirer's `flock -w 2` genuinely times out.
 ( exec 9>>"$DISPATCH_LOCK_FILE"; flock 9; sleep 3 ) &
 flock_holder=$!
 sleep 0.5   # let the holder grab the flock before the acquirer contends
@@ -6955,6 +6959,71 @@ assert_eq "flock-timeout: returns within external budget" "0" "$rc"
 assert_eq "flock-timeout: prints busy" "busy" "$out"
 assert_eq "flock-timeout: lock file NOT clobbered" "sess-flock-stale" \
   "$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)"
+lock_teardown
+
+# --- Test 5d: timeout-knob validation — misconfig → exit 2 (#1315) -----------
+# DISPATCH_LOCK_FLOCK_TIMEOUT must strictly exceed DISPATCH_LOCK_PROBE_TIMEOUT
+# (else a waiter abandons a holder that is legitimately mid-probe), and
+# PROBE_TIMEOUT must be a POSITIVE integer (GNU `timeout 0` DISABLES the bound
+# and silently re-opens the unbounded-probe hang). The acquire/wait path
+# validates both at startup and exits 2 with a clear error rather than letting a
+# misconfigured knob degrade to an always-busy or unbounded probe.
+
+echo "Test: FLOCK_TIMEOUT <= PROBE_TIMEOUT → exit 2 with clear error"
+lock_setup
+export CLAUDE_CODE_SESSION_ID="sess-5d-mine"
+lock_fake_claude_sessions "sess-5d-mine"
+export DISPATCH_LOCK_PROBE_TIMEOUT=10 DISPATCH_LOCK_FLOCK_TIMEOUT=10
+err=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err" in
+  *"DISPATCH_LOCK_FLOCK_TIMEOUT"*"must exceed"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err" ;;
+esac
+assert_eq "FLOCK<=PROBE → error + exit 2" "ok" "$status"
+lock_teardown
+
+echo "Test: PROBE_TIMEOUT=0 → exit 2 (timeout 0 would disable the bound)"
+lock_setup
+export CLAUDE_CODE_SESSION_ID="sess-5d2-mine"
+lock_fake_claude_sessions "sess-5d2-mine"
+export DISPATCH_LOCK_PROBE_TIMEOUT=0
+err=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err" in
+  *"DISPATCH_LOCK_PROBE_TIMEOUT"*"positive integer"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err" ;;
+esac
+assert_eq "PROBE=0 → error + exit 2" "ok" "$status"
+lock_teardown
+
+# --- Test 5e: shipped defaults (probe 10, flock 15) PASS the guard (#1315) ----
+# Regression guard for the threshold decision: the constraint is `FLOCK > PROBE`
+# (strict), NOT `FLOCK > PROBE + 5` — a guard that rejected its own shipped
+# defaults (15 vs 10+5=15) would be broken. Setting the defaults explicitly must
+# acquire cleanly, not exit 2.
+
+echo "Test: shipped default timeouts (10/15) pass the guard and acquire"
+lock_setup
+export CLAUDE_CODE_SESSION_ID="sess-5e-mine"
+lock_fake_claude_sessions "sess-5e-mine"
+export DISPATCH_LOCK_PROBE_TIMEOUT=10 DISPATCH_LOCK_FLOCK_TIMEOUT=15
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+assert_eq "default timeouts: guard not tripped (exit 0)" "0" "$rc"
+assert_eq "default timeouts: prints acquired" "acquired" "$out"
+lock_teardown
+
+# --- Test 5f: --release is NOT subject to the timeout-knob guard (#1315) ------
+# The probe + in-section flock timeouts are consumed only by acquire/wait;
+# --release uses neither, so a misconfigured knob must NOT make --release fail.
+# Releasing our own recorded sessionId succeeds even with FLOCK <= PROBE set.
+
+echo "Test: --release unaffected by a misconfigured timeout knob"
+lock_setup
+export CLAUDE_CODE_SESSION_ID="sess-5f-mine"
+printf '%s\n' "sess-5f-mine" > "$DISPATCH_LOCK_FILE"
+export DISPATCH_LOCK_PROBE_TIMEOUT=10 DISPATCH_LOCK_FLOCK_TIMEOUT=5
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" --release 2>/dev/null); rc=$?
+assert_eq "release with bad knobs: exit 0" "0" "$rc"
+assert_eq "release with bad knobs: prints released" "released" "$out"
 lock_teardown
 
 # --- Test 6a: misconfiguration — non-git dir, no DISPATCH_LOCK_FILE ----------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6746,7 +6746,8 @@ lock_teardown() {
   TMPDIR_TEST=""
   STUB_DIR=""
   unset DISPATCH_LOCK_FILE CLAUDE_CODE_SESSION_ID CLAUDE_AGENTS_CMD \
-    DISPATCH_LOCK_WAIT_INTERVAL DISPATCH_LOCK_WAIT_TIMEOUT
+    DISPATCH_LOCK_WAIT_INTERVAL DISPATCH_LOCK_WAIT_TIMEOUT \
+    DISPATCH_LOCK_PROBE_TIMEOUT DISPATCH_LOCK_FLOCK_TIMEOUT
 }
 
 # Helper: install a fake `claude` whose `agents --json` invocation prints a
@@ -6893,6 +6894,67 @@ lock_fake_claude_sessions "sess-500"
 out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
 assert_eq "re-entry exits 0" "0" "$rc"
 assert_eq "re-entry prints acquired" "acquired" "$out"
+lock_teardown
+
+# --- Test 5b: wedged daemon — probe times out → fail-safe LIVE → busy (#1315) -
+# A foreign holder is recorded; resolving its liveness queries the daemon. A
+# wedged daemon that hangs (and IGNORES SIGTERM) must not deadlock the acquirer:
+# the probe is `timeout -k 5 "$PROBE_TIMEOUT"`, so the SIGKILL backstop guarantees
+# return, the failed probe folds to fail-safe LIVE, and we stay busy. The fake
+# `trap '' TERM; sleep 30` proves the `-k` backstop (plain `timeout` would itself
+# block on a SIGTERM-ignoring child). The EXTERNAL `timeout` turns a regression
+# (no bound, or a missing `-k`) into a visible rc-124 failure instead of a hang.
+
+echo "Test: wedged daemon — probe times out, acquirer stays busy without deadlock"
+lock_setup
+printf '%s\n' "sess-wedged-foreign" > "$DISPATCH_LOCK_FILE"
+export CLAUDE_CODE_SESSION_ID="sess-wedged-mine"
+# Slow fake `claude` that ignores SIGTERM and sleeps far past the probe timeout.
+cat > "$TMPDIR_TEST/fake/claude" <<'FAKE'
+#!/usr/bin/env bash
+trap '' TERM
+sleep 30
+FAKE
+chmod +x "$TMPDIR_TEST/fake/claude"
+export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/fake/claude"
+export DISPATCH_LOCK_PROBE_TIMEOUT=1
+# External bound: the probe's own SIGKILL fires at PROBE_TIMEOUT+5≈6s, so 12s
+# leaves ample margin on a healthy fix while still catching a real hang.
+out=$(timeout 12 "$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+assert_eq "wedged-daemon: returns within external budget (not rc 124)" "0" "$rc"
+assert_eq "wedged-daemon: prints busy" "busy" "$out"
+assert_eq "wedged-daemon: foreign holder untouched" "sess-wedged-foreign" \
+  "$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)"
+lock_teardown
+
+# --- Test 5c: in-section flock wait times out → busy, lock NOT clobbered (#1315)
+# When the in-section `flock -w "$FLOCK_TIMEOUT"` cannot be acquired in time, the
+# acquirer must report contended (busy) WITHOUT running the read-check-write —
+# falling through unlocked would race and could clobber a live holder. Setup is
+# discriminating: a held flock plus a STALE recorded holder (absent from the
+# registry). Correct (guarded) code → busy, lock unchanged. The fall-through bug
+# would instead reclaim the stale holder and WRITE our sid (acquired + clobbered),
+# which these assertions catch.
+
+echo "Test: in-section flock wait timeout → busy, lock file not clobbered"
+lock_setup
+printf '%s\n' "sess-flock-stale" > "$DISPATCH_LOCK_FILE"
+export CLAUDE_CODE_SESSION_ID="sess-flock-mine"
+# Registry knows only our session → the recorded holder is stale (would be
+# reclaimed if the buggy fall-through ever ran the unlocked read-check-write).
+lock_fake_claude_sessions "sess-flock-mine"
+export DISPATCH_LOCK_FLOCK_TIMEOUT=1
+# Hold the advisory lock on the same file for longer than FLOCK_TIMEOUT so the
+# acquirer's `flock -w 1` genuinely times out.
+( exec 9>>"$DISPATCH_LOCK_FILE"; flock 9; sleep 3 ) &
+flock_holder=$!
+sleep 0.5   # let the holder grab the flock before the acquirer contends
+out=$(timeout 12 "$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+wait "$flock_holder" 2>/dev/null || true
+assert_eq "flock-timeout: returns within external budget" "0" "$rc"
+assert_eq "flock-timeout: prints busy" "busy" "$out"
+assert_eq "flock-timeout: lock file NOT clobbered" "sess-flock-stale" \
+  "$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)"
 lock_teardown
 
 # --- Test 6a: misconfiguration — non-git dir, no DISPATCH_LOCK_FILE ----------
@@ -18310,7 +18372,8 @@ sel_tick_teardown() {
     FAKE_GIT_BRANCH FAKE_GIT_FETCH_FAIL FAKE_GIT_MERGE_FAIL \
     SEL_TARGET_N SEL_LIVE_COUNT SEL_LIVE_COUNT_FAIL \
     SEL_EXHAUSTED SEL_PRIORITY_ONLY \
-    DISPATCH_RESERVATION_DIR SEL_AGENTS_TSV SEL_AGENTS_LIST_FAIL
+    DISPATCH_RESERVATION_DIR SEL_AGENTS_TSV SEL_AGENTS_LIST_FAIL \
+    DISPATCH_LOCK_PROBE_TIMEOUT DISPATCH_LOCK_FLOCK_TIMEOUT
 }
 
 # Run the orchestrator, capturing full stdout; the decision is the last line.
@@ -18553,6 +18616,58 @@ case "$err" in
   *) status="bad: $err" ;;
 esac
 assert_eq "extra args → usage error, exit 2" "ok" "$status"
+sel_tick_teardown
+
+# --- TARGET_N validation: non-numeric → release + exit 2 (#1315) -------------
+# dispatch-target-workers always prints a number in count mode (its own fallback
+# to 1), so a non-numeric TARGET_N here means a broken environment. The guard
+# must release the lock and exit 2 with a clear error rather than letting the
+# arithmetic gate throw "operand expected" and silently skip the cap.
+echo "Test: select-tick non-numeric TARGET_N → release + exit 2"
+sel_tick_setup
+export SEL_TARGET_N="not-a-number"
+err=$("$TMPDIR_TEST/dispatch-select-tick" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err" in
+  *"dispatch-target-workers"*"non-numeric"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err" ;;
+esac
+assert_eq "non-numeric TARGET_N → error + exit 2" "ok" "$status"
+assert_eq "non-numeric TARGET_N: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- TARGET_N validation: empty stdout → release + exit 2 (#1315) ------------
+# A crashed dispatch-target-workers prints nothing; empty stdout also fails the
+# `^[0-9]+$` regex, so no separate exit-code check is needed. Override the stub
+# to emit nothing on the no-arg query (keeping --exhausted intact).
+echo "Test: select-tick empty TARGET_N → release + exit 2"
+sel_tick_setup
+cat > "$TMPDIR_TEST/dispatch-target-workers" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "$1" == "--exhausted" ]]; then echo "${SEL_EXHAUSTED:-ok}"; exit 0; fi
+# no-arg: emit nothing (simulate a crashed dispatch-target-workers)
+exit 0
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-target-workers"
+err=$("$TMPDIR_TEST/dispatch-select-tick" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err" in
+  *"dispatch-target-workers"*"non-numeric"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err" ;;
+esac
+assert_eq "empty TARGET_N → error + exit 2" "ok" "$status"
+assert_eq "empty TARGET_N: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- TARGET_N validation: 0 is valid, must NOT trip the guard (#1315) --------
+# The regex is `^[0-9]+$` (not `^[1-9]`) — TARGET_N=0 is a legitimate value (the
+# gate compares LIVE_COUNT >= 0). Regression guard for that decision: a 0 target
+# proceeds normally (at-cap concurrency-cap here), it does NOT exit 2.
+echo "Test: select-tick TARGET_N=0 passes the guard (no exit 2)"
+sel_tick_setup
+export SEL_LIVE_COUNT=0 SEL_TARGET_N=0 SEL_EXHAUSTED=ok SEL_PRIORITY_ONLY=empty
+out=$(run_sel_tick) ; rc=$?
+assert_eq "TARGET_N=0: exit 0 (guard not tripped)" "0" "$rc"
+assert_eq "TARGET_N=0: decision line" "concurrency-cap" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
 sel_tick_teardown
 
 # --- gate at cap, not exhausted, no priority item → concurrency-cap ----------


### PR DESCRIPTION
Closes #1315

## What

Two robustness defects let a wedged (not dead) Claude daemon — or a broken
environment — stall dispatch routing. This bounds both hazards.

### 1. Unbounded daemon query inside the flock (`dispatch-acquire-lock`)

`resolve_holder_state` shelled out to `claude agents --json` with no timeout
while the `try_acquire` subshell held `flock 9`. A wedged daemon blocked the
in-section acquirer indefinitely, and every other router blocked behind
`flock 9` → routing deadlocked until the daemon recovered.

- The daemon probe is now wrapped in `timeout -k 5 "$PROBE_TIMEOUT"`
  (`DISPATCH_LOCK_PROBE_TIMEOUT`, default `10`). The `-k 5` SIGKILL backstop is
  required: a wedged client that ignores SIGTERM would otherwise hang `timeout`
  itself. A timed-out probe exits non-zero, so the existing fail-safe folds it to
  LIVE → the acquirer stays BUSY → clean `busy`. The `9>&-` fd-close stays on the
  `timeout` simple command, preserving the existing semantics.
- The in-section `flock` now waits with `flock -w "$FLOCK_TIMEOUT"`
  (`DISPATCH_LOCK_FLOCK_TIMEOUT`, default `15`, deliberately > probe timeout +
  margin). On wait-timeout the subshell emits a distinct `FLOCK_TIMEOUT` sentinel
  and exits **without** running the read-check-write — `flock -w` alone would fall
  through unlocked and could clobber a live holder. The parent decodes the
  sentinel to contended (busy) with a `(flock wait timeout)` diagnostic.

`--release` and the headless-holder branch are unchanged.

### 2. Unguarded `TARGET_N` (`dispatch-select-tick`)

`TARGET_N=$(dispatch-target-workers)` had no failure guard. An empty/non-numeric
value made the arithmetic gate throw "operand expected" and silently skip the
worker-cap gate (fail-open). `dispatch-target-workers` always prints a number in
count mode (its own fallback to `1`), so a non-numeric value here means a broken
environment. Per the repo's clear-error-over-defensive-fallback rule, the script
now validates `TARGET_N` against `^[0-9]+$` (which allows `0`), releases the lock,
and exits `2` with a clear message — no second fallback.

## Tests

`test-dispatch-scripts.sh` gains coverage for each acceptance criterion:

- Wedged daemon (SIGTERM-ignoring fake under an external `timeout`) → `busy`
  within budget, foreign holder untouched, proving the `-k` backstop.
- In-section flock-wait timeout (held lock + stale recorded holder) → `busy`,
  lock file **not** clobbered — the test that catches the fall-through bug.
- Empty and non-numeric `TARGET_N` → `exit 2`, lock released, clear stderr; plus
  a `TARGET_N=0`-still-passes-the-guard regression.

Full suite: 2403/2403 passing.
