### PR TITLE
budget-etl: bound CSV duplicate-ID suffix search with a per-ID counter

### DIFF
--- a/budget-etl/internal/parse/csv.go
+++ b/budget-etl/internal/parse/csv.go
@@ -72,6 +72,7 @@ func parseCSV(path string) (ParseResult, error) {
 
 	var txns []Transaction
 	used := make(map[string]struct{})
+	nextSuffix := make(map[string]int)
 	for i, row := range records[1:] {
 		if len(row) < 6 {
 			return ParseResult{}, fmt.Errorf("%s: line %d: expected 6 fields, got %d", path, i+2, len(row))
@@ -102,15 +103,22 @@ func parseCSV(path string) (ParseResult, error) {
 		}
 
 		if _, taken := used[txnID]; taken {
-			for n := 2; ; n++ {
-				candidate := fmt.Sprintf("%s-%d", txnID, n)
+			origID := txnID
+			n := nextSuffix[origID]
+			if n < 2 {
+				n = 2
+			}
+			for {
+				candidate := fmt.Sprintf("%s-%d", origID, n)
 				_, inUsed := used[candidate]
 				_, inOriginal := original[candidate]
+				n++
 				if !inUsed && !inOriginal {
 					txnID = candidate
 					break
 				}
 			}
+			nextSuffix[origID] = n
 		}
 		used[txnID] = struct{}{}
 

--- a/budget-etl/internal/parse/csv.go
+++ b/budget-etl/internal/parse/csv.go
@@ -105,6 +105,7 @@ func parseCSV(path string) (ParseResult, error) {
 		if _, taken := used[txnID]; taken {
 			origID := txnID
 			n := nextSuffix[origID]
+			// zero value means first duplicate for this ID; suffixes start at 2
 			if n < 2 {
 				n = 2
 			}

--- a/budget-etl/internal/parse/csv_test.go
+++ b/budget-etl/internal/parse/csv_test.go
@@ -3,6 +3,7 @@ package parse
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -146,5 +147,50 @@ func TestParseCSV_DuplicateIDCollision(t *testing.T) {
 	// The real X-2 row (row 3) must keep its original ID.
 	if txns[2].TransactionID != "X-2" {
 		t.Errorf("txn 2: ID = %q, want %q", txns[2].TransactionID, "X-2")
+	}
+}
+
+// TestParseCSV_AllDuplicateIDsPerformance guards against the O(M^2)
+// suffix-search regression fixed in #1375. With 50000 rows sharing the
+// same transaction ID, the unfixed code takes minutes; the fixed O(M)
+// code finishes in milliseconds. A 2-second wall-clock bound separates
+// them with wide margin and no CI flakiness.
+func TestParseCSV_AllDuplicateIDsPerformance(t *testing.T) {
+	const rows = 50000
+	var b strings.Builder
+	// metadata line: accountID, fromDate, toDate, openingBalance, closingBalance
+	b.WriteString("00000000001234567890,2025/06/11,2025/07/10,15000.00,12000.00\n")
+	for i := 0; i < rows; i++ {
+		b.WriteString("2025/06/16,1.00,\"Row\",,\"X\",\"DEBIT\"\n")
+	}
+
+	tmp := filepath.Join(t.TempDir(), "alldupes.csv")
+	if err := os.WriteFile(tmp, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	result, err := parseCSV(tmp)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("parseCSV: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("parseCSV took %v for %d all-duplicate rows; want < 2s (O(M^2) regression?)", elapsed, rows)
+	}
+	if len(result.Transactions) != rows {
+		t.Fatalf("expected %d transactions, got %d", rows, len(result.Transactions))
+	}
+
+	// Suffix correctness at boundaries.
+	if got := result.Transactions[0].TransactionID; got != "X" {
+		t.Errorf("txn[0].TransactionID = %q, want %q", got, "X")
+	}
+	if got := result.Transactions[1].TransactionID; got != "X-2" {
+		t.Errorf("txn[1].TransactionID = %q, want %q", got, "X-2")
+	}
+	if got := result.Transactions[rows-1].TransactionID; got != "X-50000" {
+		t.Errorf("txn[%d].TransactionID = %q, want %q", rows-1, got, "X-50000")
 	}
 }


### PR DESCRIPTION
Closes #1375

## Summary

`parseCSV` in `budget-etl/internal/parse/csv.go` assigns collision-free
synthetic suffixes (`<id>-2`, `<id>-3`, …) to duplicate transaction IDs. The
previous suffix search restarted at `n=2` for every duplicate row and
incremented until it found a free candidate. Under adversarial input where every
data row shares one ID, the k-th duplicate scanned `n=2..k`, giving O(M²) total
work — a ~200k-row CSV is ~2×10¹⁰ iterations, minutes of CPU, with no file-size
guard or iteration cap anywhere in the call chain.

This PR bounds the search with a per-ID counter (`nextSuffix`) keyed by the
**original** ID. Each duplicate's search starts from the stored counter instead
of from `n=2`, and the counter only ever advances, so total work collapses to
O(M) amortized. Because `used` only grows and `original` is fixed for the file, a
candidate skipped once never becomes free again — so starting from the stored
counter produces **identical output** to the previous restart-at-2 code. This is
the performance hardening that PR #1367 (the collision-free correctness fix) did
not deliver.

## Changes

- **`internal/parse/csv.go`** — Replace the unbounded inner suffix loop with a
  `nextSuffix map[string]int` that records the next index to try per original ID.
  The counter is keyed by `origID` captured *before* `txnID` is reassigned, and
  the candidate-free check still tests both `used` and `original` so a synthetic
  suffix never collides with a real later ID.
- **`internal/parse/csv_test.go`** — Add
  `TestParseCSV_AllDuplicateIDsPerformance`: a 50,000-row CSV all sharing one ID
  must parse in well under 2s (the unfixed code took minutes), with
  `len(Transactions) == 50000` and correct boundary suffixes (`X`, `X-2`, …,
  `X-50000`).

## Verification

- `go test ./...` — all packages pass, including the existing
  `TestParseCSV_DuplicateIDs` and `TestParseCSV_DuplicateIDCollision`
  (output unchanged) and the new performance test (~0.05s).
- `go vet ./...` — clean.
