### PR TITLE
budget-etl: O(1) per-duplicate CSV suffix assignment via per-base counter

### DIFF
--- a/budget-etl/internal/parse/csv.go
+++ b/budget-etl/internal/parse/csv.go
@@ -106,13 +106,13 @@ func parseCSV(path string) (ParseResult, error) {
 			base := txnID
 			n := nextSuffix[base]
 			if n < 2 {
-				n = 2 // map zero-value guard: first collision starts at X-2, never X-0
+				n = 2 // map zero-value guard: first collision starts at X-2; stored values are always >= 3, so n is never 0 or 1
 			}
 			for {
 				candidate := fmt.Sprintf("%s-%d", base, n)
 				_, inUsed := used[candidate]
 				_, inOriginal := original[candidate]
-				n++
+				n++ // advance before acceptance check so nextSuffix stores the slot after the one just taken
 				if !inUsed && !inOriginal {
 					txnID = candidate
 					break

--- a/budget-etl/internal/parse/csv.go
+++ b/budget-etl/internal/parse/csv.go
@@ -72,6 +72,7 @@ func parseCSV(path string) (ParseResult, error) {
 
 	var txns []Transaction
 	used := make(map[string]struct{})
+	nextSuffix := make(map[string]int)
 	for i, row := range records[1:] {
 		if len(row) < 6 {
 			return ParseResult{}, fmt.Errorf("%s: line %d: expected 6 fields, got %d", path, i+2, len(row))
@@ -102,15 +103,22 @@ func parseCSV(path string) (ParseResult, error) {
 		}
 
 		if _, taken := used[txnID]; taken {
-			for n := 2; ; n++ {
-				candidate := fmt.Sprintf("%s-%d", txnID, n)
+			base := txnID
+			n := nextSuffix[base]
+			if n < 2 {
+				n = 2 // map zero-value guard: first collision starts at X-2, never X-0
+			}
+			for {
+				candidate := fmt.Sprintf("%s-%d", base, n)
 				_, inUsed := used[candidate]
 				_, inOriginal := original[candidate]
+				n++
 				if !inUsed && !inOriginal {
 					txnID = candidate
 					break
 				}
 			}
+			nextSuffix[base] = n // record next slot to try; counter never rewinds
 		}
 		used[txnID] = struct{}{}
 

--- a/budget-etl/internal/parse/csv_test.go
+++ b/budget-etl/internal/parse/csv_test.go
@@ -1,8 +1,10 @@
 package parse
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -147,4 +149,65 @@ func TestParseCSV_DuplicateIDCollision(t *testing.T) {
 	if txns[2].TransactionID != "X-2" {
 		t.Errorf("txn 2: ID = %q, want %q", txns[2].TransactionID, "X-2")
 	}
+}
+
+// TestParseCSV_DuplicateIDStress is both an acceptance-criteria document and a
+// real regression guard for the O(K+N) suffix-assignment fix (issue #1374).
+//
+// Why K=N=10000 (not K=1000):
+// At K=1000 the old quadratic code (O(K²+KN)) is still sub-millisecond in
+// practice, so a 1-second bound would pass and the test would document but not
+// guard. At K=N=10000 the old code performs ~2e8 map lookups (several seconds,
+// reliably exceeding the 1 s bound), while the new O(K+N) code does ~4e4
+// operations (microseconds). This asymmetry makes the test a genuine regression
+// guard: accidentally reverting to the quadratic loop causes an immediate
+// failure. Do NOT "simplify" the implementation back to the inner restart loop.
+func TestParseCSV_DuplicateIDStress(t *testing.T) {
+	const K = 10000 // rows with duplicate base ID "X" — drives suffix search
+	const N = 10000 // rows with pre-seeded suffixed IDs "X-2" … "X-(N+1)"
+
+	// Build the CSV: metadata line, then N pre-seeded rows, then K duplicate rows.
+	// The N pre-seeded rows consume X-2 through X-(N+1) as original IDs.
+	// When the K duplicate rows arrive, the suffix counter must skip over all of
+	// them without restarting from 2 each time (the old quadratic behaviour).
+	var sb strings.Builder
+	sb.WriteString("00000000001234567890,2025/06/11,2025/07/10,15000.00,12000.00\n")
+	for i := 2; i <= N+1; i++ {
+		fmt.Fprintf(&sb, "2025/06/16,1.00,\"Seeded row %d\",,\"X-%d\",\"DEBIT\"\n", i, i)
+	}
+	for i := 0; i < K; i++ {
+		fmt.Fprintf(&sb, "2025/06/16,1.00,\"Duplicate row %d\",,\"X\",\"DEBIT\"\n", i)
+	}
+
+	tmp := filepath.Join(t.TempDir(), "stress.csv")
+	if err := os.WriteFile(tmp, []byte(sb.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	result, err := parseCSV(tmp)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("parseCSV: %v", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("parseCSV took %v (> 1s): suffix assignment is not O(K+N)", elapsed)
+	}
+
+	want := K + N
+	if len(result.Transactions) != want {
+		t.Fatalf("expected %d transactions, got %d", want, len(result.Transactions))
+	}
+
+	// All returned IDs must be distinct.
+	seen := make(map[string]struct{}, want)
+	for _, txn := range result.Transactions {
+		seen[txn.TransactionID] = struct{}{}
+	}
+	if len(seen) != want {
+		t.Errorf("expected %d distinct IDs, got %d (collisions present)", want, len(seen))
+	}
+
+	t.Logf("elapsed: %v for K=%d duplicate rows + N=%d pre-seeded rows", elapsed, K, N)
 }


### PR DESCRIPTION
Closes #1374

## Problem

`parseCSV` in `budget-etl/internal/parse/csv.go` deduplicates repeated
transaction IDs by appending a `-N` suffix. The previous inner loop restarted its
search at `n := 2` on every duplicate and had no upper bound. For K duplicate
rows of ID `X` plus N pre-existing suffixed IDs (`X-2` … `X-(N+1)`) in the file,
each duplicate rescanned from `X-2` past every already-taken slot, giving
O(K² + KN) total work. Because `csv.NewReader.ReadAll()` already loads the whole
file into memory, an adversarial statement file in the input directory could
drive quadratic CPU with no I/O relief.

## Fix

Replace the unbounded restart-from-2 inner loop with a per-base
next-free-suffix counter (`nextSuffix map[string]int`, keyed by the base
`txnID`). Each base's counter is monotonic and never rewinds, so every `X-k`
slot is passed at most once across that base's lifetime. Per-duplicate suffix
assignment becomes amortized O(1) — overall O(K + N) linear.

Three correctness invariants are preserved:

1. **Both** the `used[candidate]` and `original[candidate]` checks stay inside
   the loop, so a synthetic suffix can never collide with a real later ID
   (`TestParseCSV_DuplicateIDCollision`).
2. A zero-value guard clamps the counter up to `2` before the loop, since Go's
   `map[string]int` returns 0 for an unseen base.
3. `nextSuffix[base]` is recorded after the loop with the already-incremented
   `n`, so the counter advances monotonically.

The first-pass `original` collection, field parsing, and the `ParseResult` shape
are unchanged.

## Test

Adds `TestParseCSV_DuplicateIDStress` in the adversarial K + N shape: N = 10000
pre-seeded suffixed IDs followed by K = 10000 duplicate rows. It asserts
`parseCSV` succeeds, returns `K + N` distinct IDs, and completes under a 1-second
bound. At K = N = 10000 the old O(K² + KN) code does ~2×10⁸ map lookups (multiple
seconds → fails the bound) while the new O(K + N) code does ~4×10⁴ ops
(microseconds → passes; it ran in ~15 ms locally). So the test is both the
acceptance criteria's documentation **and** a real regression guard — reverting
the fix to the quadratic loop would turn it red. The two existing dedup tests
(`TestParseCSV_DuplicateIDs`, `TestParseCSV_DuplicateIDCollision`) stay green.
