### PR TITLE
print: bump renderGen in leave() to cancel in-flight render()

### DIFF
--- a/print/src/viewer/spread-controller.ts
+++ b/print/src/viewer/spread-controller.ts
@@ -97,6 +97,8 @@ export class SpreadController {
   }
 
   leave(): number {
+    // Bump the generation counter to cancel any in-flight render() calls.
+    this.renderGen++;
     const spread = this.spreads.length > 0 ? this.spreads[this.spreadIndex]! : null;
     const currentPage = spread !== null
       && this.preSpreadPage >= spread.left

--- a/print/test/viewer/spread-controller.test.ts
+++ b/print/test/viewer/spread-controller.test.ts
@@ -233,7 +233,7 @@ describe("SpreadController", () => {
 
     const { controller } = makeController({ renderPageInto });
 
-    // enter(2) => index 1, two-page spread {left:2,right:3}; exercises both slots.
+    // enter(2) => index 1, two-page spread {left:2,right:3}; only the left slot is reached before leave() cancels the render.
     controller.enter(2);
 
     // Start a render that appends one left child then hangs on left renderPageInto.

--- a/print/test/viewer/spread-controller.test.ts
+++ b/print/test/viewer/spread-controller.test.ts
@@ -214,6 +214,43 @@ describe("SpreadController", () => {
     expect(controller.position).toBe("2");
   });
 
+  it("leave() during render() cancels the in-flight render before the right slot (#1383)", async () => {
+    // leave() bumps renderGen, so an in-flight render() that is awaiting its
+    // left renderPageInto must bail before calling the right renderPageInto.
+    let resolveFirstLeft: (() => void) | null = null;
+    const renderPageInto = vi
+      .fn()
+      .mockImplementationOnce((_page: number, target: HTMLElement) => {
+        // First (stale) left render: append synchronously, then hang.
+        target.appendChild(document.createElement("img"));
+        return new Promise<void>(resolve => {
+          resolveFirstLeft = resolve;
+        });
+      })
+      .mockImplementation(async (_page: number, target: HTMLElement) => {
+        target.appendChild(document.createElement("img"));
+      });
+
+    const { controller } = makeController({ renderPageInto });
+
+    // enter(2) => index 1, two-page spread {left:2,right:3}; exercises both slots.
+    controller.enter(2);
+
+    // Start a render that appends one left child then hangs on left renderPageInto.
+    const first = controller.render();
+
+    // leave() bumps renderGen and removes the spread slot elements.
+    controller.leave();
+
+    // Release the stale render last; its generation guard must bail before
+    // calling the right renderPageInto.
+    resolveFirstLeft!();
+    await first;
+
+    // Only the hung left renderPageInto call ran; the right was never reached.
+    expect(renderPageInto).toHaveBeenCalledTimes(1);
+  });
+
   it("invokes onRenderError when a resize-triggered render rejects (#616 guard)", async () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
Closes #1383

## Problem

`SpreadController.leave()` tears down spread mode — it empties `this.spreads`,
removes the `.spread-page` slot elements from the DOM, and disconnects the resize
observer — but it never bumps `renderGen`. A `render()` call already past its
`spreads.length === 0` early-return guard and awaiting the left
`renderPageInto(spread.left, leftEl)` will, when it resumes, pass the
`gen !== this.renderGen` check (because `leave()` left `renderGen` untouched) and
proceed to `renderPageInto(spread.right, rightEl)` on the now-detached `rightEl`.
The appended `<img>` lands on a detached node and is garbage-collected, but the
blob-decode work runs needlessly.

`render()` mirrors `pdf.ts`'s `renderGen` discipline: each `render()` claims a
generation via `++this.renderGen`, and any later caller that bumps the counter
marks an in-flight render stale so it bails at its next post-await gen check.
`goNext`/`goPrev` get this for free because they call `render()`. `leave()` is
the one teardown path that invalidates the in-flight render's target without
bumping the generation. This gap predates #1376 (which added the generation guard
to `render()`); #1376 neither caused nor fixed it.

## Fix

Increment `renderGen` as the first statement of `leave()`, so any in-flight
`render()` bails at its next post-await gen check — matching `render()`'s existing
`renderGen` discipline.

## Test

Adds one leave-during-render test to `spread-controller.test.ts`, modeled on the
existing #1279 concurrent-render test. It starts a `render()` that hangs after the
left slot, calls `leave()`, releases the stale render last, and asserts the right
slot's `renderPageInto` was never called (`toHaveBeenCalledTimes(1)`). With the
fix removed the test fails (received count 2), confirming it drives the change.

## Verification

- `npx vitest run --root print test/viewer/spread-controller.test.ts` — 12/12 pass.
- Sanity check: reverting the one-line fix makes the new test fail (count 2),
  restoring it passes again.
- `npm run build --prefix print` — type-check and build succeed.
