### PR TITLE
idbutil: validate maxBytes is a positive integer at construction time

### DIFF
--- a/idbutil/src/lru-blob-cache.ts
+++ b/idbutil/src/lru-blob-cache.ts
@@ -55,6 +55,11 @@ export interface LruBlobCache {
 
 export function createLruBlobCache(config: LruBlobCacheConfig): LruBlobCache {
   const maxBytes = config.maxBytes ?? DEFAULT_MAX_BYTES;
+  if (!Number.isInteger(maxBytes) || maxBytes <= 0) {
+    throw new Error(
+      `LruBlobCache: maxBytes must be a positive integer, got ${maxBytes}`,
+    );
+  }
 
   const { openDb, closeDb } = createDbConnection({
     name: config.name,

--- a/idbutil/test/lru-blob-cache.test.ts
+++ b/idbutil/test/lru-blob-cache.test.ts
@@ -375,7 +375,7 @@ describe("maxBytes validation", () => {
   it("throws at construction when maxBytes is -1", () => {
     expect(() =>
       createLruBlobCache({ name: uniqueDbName(), version: 1, maxBytes: -1 }),
-    ).toThrow(/got -1/);
+    ).toThrow("got -1");
   });
 
   it("throws at construction when maxBytes is a non-integer", () => {

--- a/idbutil/test/lru-blob-cache.test.ts
+++ b/idbutil/test/lru-blob-cache.test.ts
@@ -365,6 +365,32 @@ describe("onUpgrade hook", () => {
   });
 });
 
+describe("maxBytes validation", () => {
+  it("throws at construction when maxBytes is 0", () => {
+    expect(() =>
+      createLruBlobCache({ name: uniqueDbName(), version: 1, maxBytes: 0 }),
+    ).toThrow("got 0");
+  });
+
+  it("throws at construction when maxBytes is -1", () => {
+    expect(() =>
+      createLruBlobCache({ name: uniqueDbName(), version: 1, maxBytes: -1 }),
+    ).toThrow(/got -1/);
+  });
+
+  it("throws at construction when maxBytes is a non-integer", () => {
+    expect(() =>
+      createLruBlobCache({ name: uniqueDbName(), version: 1, maxBytes: 1.5 }),
+    ).toThrow("got 1.5");
+  });
+
+  it("constructs successfully with a valid positive integer maxBytes", async () => {
+    const cache = createLruBlobCache({ name: uniqueDbName(), version: 1, maxBytes: 1024 });
+    expect(cache.maxBytes).toBe(1024);
+    await cache.closeDb();
+  });
+});
+
 describe("error paths", () => {
   // Opening an existing database at a version lower than the stored one is a
   // spec-defined failure: the open request errors instead of upgrading. This


### PR DESCRIPTION
Closes #1418

## Summary

`createLruBlobCache` resolved `maxBytes` from config and used it directly as
both the eviction cap and the oversized-blob rejection threshold, without
validating it. Two misconfigurations silently corrupted the cache:

- `maxBytes: 0` — the `putEntry` guard `data.byteLength > maxBytes` rejects every
  non-empty blob, disabling the cache entirely.
- `maxBytes: -1` (any negative) — `data.byteLength > -1` is always false, so the
  oversized guard is bypassed; every blob then reaches `evictIfNeeded`, where the
  negative cap makes `totalSize + delta <= maxBytes` always false, triggering a
  full eviction loop on every put.

The `putEntry` oversized-blob guard is the core correctness fix delivered by
#1294 / PR #1414, so a misconfigured `maxBytes` that disables or inverts it is a
real regression risk.

## Change

Add a construction-time validation guard immediately after the `maxBytes`
resolution in `idbutil/src/lru-blob-cache.ts`:

```ts
if (!Number.isInteger(maxBytes) || maxBytes <= 0) {
  throw new Error(
    `LruBlobCache: maxBytes must be a positive integer, got ${maxBytes}`,
  );
}
```

Placing the guard after the `??` resolution means the default
(`DEFAULT_MAX_BYTES`, a positive integer) always passes, while an explicit `0` —
not nullish, so not replaced by the default — is correctly caught. This turns
silent misbehavior into a clear, value-bearing error at a public API boundary,
consistent with `.claude/rules/code-style.md`.

The guard is the only source change — no change to `putEntry` / `evictIfNeeded`
logic, the default value, the config type, or `connection.ts`.

## Tests

A new `describe("maxBytes validation", ...)` block in
`idbutil/test/lru-blob-cache.test.ts` covers the acceptance criteria: `maxBytes`
of `0`, `-1`, and `1.5` each throw with the offending value in the message, and a
valid `1024` constructs successfully with `cache.maxBytes === 1024` (existing
behavior preserved). The four existing `maxBytes`-related tests still pass,
confirming valid positive integers are unaffected.

Verification: `npx vitest run --root idbutil` (41 tests, all pass) and
`npm run lint --prefix idbutil` (clean).
