### PR TITLE
dispatch: auto-repair a wedged local main on sync-failed

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-escalate-sync-broken
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-escalate-sync-broken
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# dispatch-escalate-sync-broken — find-or-create the dispatch:sync-broken latch
+# issue when the dispatch tick cannot fast-forward-merge origin/main into local
+# main.
+#
+# WHEN it runs:
+#   Invoked by `dispatch-select-tick` Step 1 (running in the `main` worktree, on
+#   branch `main`) after its `git merge --ff-only origin/main` repair attempt has
+#   failed repeatedly — the per-tick repair attempt-counter has hit its cap and
+#   local main still cannot ff-merge origin/main. That state means local main and
+#   origin/main have diverged with a conflict that `/commit-merge-push` could not
+#   resolve, so the dispatch chain's sync precondition is wedged: every tick that
+#   needs an up-to-date local main is blocked.
+#
+#   This script does NOT attempt the repair itself. It files (or refreshes) a
+#   single human-readable GitHub latch issue labeled `dispatch:sync-broken`. While
+#   that issue is open the tick spawns no further `sync-repair` jobs (the latch
+#   suppresses repeated, futile repair spawns). Closing is automatic: once local
+#   main ff-merges origin/main cleanly again, the tick re-arms/closes the latch.
+#
+# Modeled on the dispatch:main-broken find-or-create pattern in
+# dispatch-diagnose-main/SKILL.md (find-or-create + label create-on-not-found).
+#
+# Input:
+#   The captured stderr of the failing `git merge --ff-only origin/main` is read
+#   from STDIN. The caller invokes:
+#       "$SCRIPT_DIR/dispatch-escalate-sync-broken" <<<"$MERGE_STDERR"
+#
+# Output:
+#   On success, the created-or-edited issue number is echoed to stdout (bare).
+#   All diagnostics go to stderr.
+#
+# No `dispatch:office-hours` label is applied — mirror dispatch:main-broken. A
+# "go fix your local main tree" task fits none of the office-hours worker's
+# input-residues (it is neither a plan-clarification, a QA walkthrough, nor a
+# deviation review), so it is a human-readable latch surfaced via the dispatch
+# queue, NOT routed to the automated office-hours worker.
+#
+# Sandbox: every `gh` call here uses the network and the macOS Security framework
+# for TLS certificate validation, both of which the sandbox blocks (see
+# `.claude/rules/sandbox.md`). The caller MUST invoke this script with
+# `dangerouslyDisableSandbox: true`.
+#
+# Exit codes:
+#   0   issue created or refreshed; issue number on stdout.
+#   1   a gh/git operation failed unexpectedly (surfaced on stderr).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+LABEL="dispatch:sync-broken"
+TITLE="dispatch: local main cannot ff-merge origin/main (sync latch)"
+
+# ---- Read the merge stderr from stdin ---------------------------------------
+#
+# `MERGE_STDERR=$(cat)` consumes the caller's here-string without interpreting
+# escapes or returning a non-zero EOF status that `set -e` would trip on.
+MERGE_STDERR=$(cat)
+
+# ---- Gather conflict diagnostics from the local repo ------------------------
+#
+# This script runs in the main worktree, so the local repo IS local main.
+# `--show-toplevel` derives the worktree path with no hardcoding.
+MAIN_WORKTREE=$(git rev-parse --show-toplevel)
+
+# `git status --porcelain` and `git log origin/main..HEAD` are expected to
+# succeed; a non-zero here signals a broken environment (per
+# .claude/rules/code-style.md, surface it rather than swallow it). They are
+# allowed to produce *empty* output without that being an error.
+GIT_STATUS=$(git status --porcelain)
+GIT_DIVERGENCE=$(git log --oneline origin/main..HEAD)
+
+# ---- Compose the body file --------------------------------------------------
+#
+# The diagnostics may carry shell metacharacters (git/log output, the captured
+# merge stderr). They are written to the body file ONLY and passed with
+# --body-file — never interpolated into the `gh` command line.
+if [[ -n "${CLAUDE_JOB_DIR:-}" ]]; then
+  mkdir -p "$CLAUDE_JOB_DIR/tmp"
+  BODY_FILE=$(mktemp "$CLAUDE_JOB_DIR/tmp/sync-broken-body.XXXXXX")
+else
+  BODY_FILE=$(mktemp)
+fi
+trap 'rm -f "$BODY_FILE"' EXIT
+
+{
+  echo "Local \`main\` cannot fast-forward-merge \`origin/main\`. The dispatch"
+  echo "chain's sync precondition is wedged: local main and origin/main have"
+  echo "diverged with a conflict that automated repair (\`/commit-merge-push\`)"
+  echo "could not resolve, so local main is no longer ff-mergeable."
+  echo
+  echo "**A human must resolve or abort the merge on the \`main\` worktree**"
+  echo "(\`$MAIN_WORKTREE\`) — resolve the divergence and get local main back to a"
+  echo "state where it ff-merges \`origin/main\` cleanly."
+  echo
+  echo "While this issue is open, the dispatch tick spawns no further"
+  echo "\`sync-repair\` jobs (this issue is the latch that suppresses them)."
+  echo "Closing happens automatically: once local main ff-merges \`origin/main\`"
+  echo "clean again, the tick re-arms and closes this latch."
+  echo
+  echo "## git status --porcelain"
+  echo
+  echo '```'
+  echo "$GIT_STATUS"
+  echo '```'
+  echo
+  echo "## git log --oneline origin/main..HEAD (local divergence)"
+  echo
+  echo '```'
+  echo "$GIT_DIVERGENCE"
+  echo '```'
+  echo
+  echo "## git merge --ff-only origin/main (captured stderr)"
+  echo
+  echo '```'
+  echo "$MERGE_STDERR"
+  echo '```'
+} >"$BODY_FILE"
+
+# ---- Find-or-create the latch issue -----------------------------------------
+#
+# One open dispatch:sync-broken issue at a time. A re-run edits the existing
+# issue's body (refreshing the diagnostics) rather than duplicating.
+existing=$(gh issue list --label "$LABEL" --state open --json number -q '.[0].number')
+
+if [[ -n "$existing" ]]; then
+  # The edit touches the body only (no --label flag), so it cannot fail with a
+  # "label not found" error — no create-on-not-found retry needed here.
+  gh issue edit "$existing" --body-file "$BODY_FILE" >/dev/null
+  echo "$existing"
+  exit 0
+fi
+
+# Create path. `bug` + `priority` sort the fix to the top of the dispatch ladder;
+# `dispatch:sync-broken` is the latch label. The label may not exist yet —
+# apply-first / create-on-not-found: if the create fails because the label is
+# "not found", create it once and retry.
+create() {
+  gh issue create \
+    --title "$TITLE" \
+    --body-file "$BODY_FILE" \
+    --label "$LABEL" \
+    --label bug \
+    --label priority
+}
+
+if ! create_out=$(create 2>&1); then
+  if [[ "$create_out" != *"not found"* ]]; then
+    # A real failure (e.g. gh unreachable) — surface it, don't swallow it.
+    echo "$create_out" >&2
+    exit 1
+  fi
+  # The dispatch:sync-broken label does not exist yet. Create it once and retry.
+  # --color is intentionally omitted: the dispatch-label color hex is
+  # single-sourced in dispatch-complete-phase and must not be duplicated here
+  # (mirrors dispatch-diagnose-main/SKILL.md).
+  gh label create "$LABEL" \
+    --description "dispatch workflow: local main cannot ff-merge origin/main (sync latch)"
+  create_out=$(create)
+fi
+
+# `gh issue create` prints the new issue's URL on stdout, not a bare number —
+# the number is the trailing path segment.
+echo "${create_out##*/}"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-escalate-sync-broken
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-escalate-sync-broken
@@ -47,8 +47,6 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 LABEL="dispatch:sync-broken"
 TITLE="dispatch: local main cannot ff-merge origin/main (sync latch)"
 
@@ -157,7 +155,12 @@ if ! create_out=$(create 2>&1); then
   # (mirrors dispatch-diagnose-main/SKILL.md).
   gh label create "$LABEL" \
     --description "dispatch workflow: local main cannot ff-merge origin/main (sync latch)"
-  create_out=$(create)
+  if ! create_out=$(create 2>&1); then
+    # The retry failed too (e.g. gh rate-limited the create right after the
+    # label was made) — surface it, don't swallow it.
+    echo "$create_out" >&2
+    exit 1
+  fi
 fi
 
 # `gh issue create` prints the new issue's URL on stdout, not a bare number —

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -17,7 +17,15 @@
 #
 # Decision lines (the last stdout line is always exactly one of):
 #   busy             lock held by another tick; nothing acquired, nothing released.
-#   sync-failed      git fetch / merge --ff-only failed on `main`; lock released.
+#   sync-failed      git fetch / merge --ff-only failed on `main` and the repair
+#                    attempt-cap is not yet hit; lock released, reseed armed.
+#                    dispatch-tick reads this to spawn the deduped repair job.
+#   sync-repair-pending   a live sync-repair job is mutating the main worktree;
+#                    deferred. lock released; reseed armed.
+#   sync-broken      local main cannot ff-merge origin/main and the repair
+#                    attempt-cap is hit (or the latch is already open); a
+#                    dispatch:sync-broken issue is the latch. lock released;
+#                    reseed armed; nothing spawned.
 #   resolver-failed  explicit arg did not resolve to one issue; lock released.
 #   concurrency-cap  effective-live count (busy workers + outstanding reservations) >= target,
 #                    AND no priority/main-broken item waits to bypass it (or the rate-limit
@@ -49,7 +57,7 @@
 # at/over the worker budget. The only hard floor is genuine token exhaustion.
 #
 # Lock invariant (the three guards): HOLD on pr/issue/explicit; RELEASE on
-# empty/sync-failed/resolver-failed/concurrency-cap/main-broken/jit-reminder;
+# empty/sync-failed/sync-repair-pending/sync-broken/resolver-failed/concurrency-cap/main-broken/jit-reminder;
 # NEVER release on busy (nothing was acquired).
 #
 # Requires `dangerouslyDisableSandbox: true` — sub-scripts write tmp state, call
@@ -103,11 +111,108 @@ if [[ "$LOCK" != acquired ]]; then
 fi
 
 # --- Step 1: sync local main with origin/main (only on the main branch) -------
+# The `--ff-only` merge is the precondition for all selection AND the recovery
+# probe (#1495). On failure the tick auto-repairs: it arms a #725 reseed (so the
+# chain keeps ticking) and emits `sync-failed`, which dispatch-tick reads to
+# spawn a deduped /commit-merge-push bg job against the main worktree. A repair
+# that hits an unresolvable conflict must not loop forever: after a bounded
+# attempt cap it escalates to a find-or-create dispatch:sync-broken latch issue
+# and stops respawning. A successful ff-merge ALWAYS resets the counter and
+# closes any open latch, so a human who resolves the tree by hand auto-recovers.
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 if [[ "$BRANCH" == "main" ]]; then
-  # Redirect git's own chatter to stderr so stdout stays the decision channel.
-  if ! git fetch origin main 1>&2 || ! git merge --ff-only origin/main 1>&2; then
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/lib.sh"            # sync_repair_* + resolve_project_root
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/lib-claude-agents.sh"   # claude_sessions_under
+
+  # Resolve the main worktree the same way dispatch-tick does: an explicit
+  # DISPATCH_TICK_MAIN_WORKTREE override is authoritative and bypasses the git
+  # lookup (tests rely on this); otherwise it is <project-root>/worktrees/main.
+  if [[ -n "${DISPATCH_TICK_MAIN_WORKTREE:-}" ]]; then
+    MAIN_WORKTREE="$DISPATCH_TICK_MAIN_WORKTREE"
+  else
+    PROJECT_ROOT=$(resolve_project_root) \
+      || { echo "dispatch-select-tick: not in a git repo and DISPATCH_TICK_MAIN_WORKTREE is unset" >&2; exit 2; }
+    MAIN_WORKTREE="$PROJECT_ROOT/worktrees/main"
+  fi
+
+  # Decision A — defer while a live sync-repair session is mutating the main
+  # worktree, but fail OPEN on a daemon UNKNOWN (rc 1). claude_sessions_under
+  # returns rc 0 only on a definite list; a row whose name is `sync-repair` and
+  # whose status is not `stopped` means a repair is live: release, arm the
+  # reseed, and defer without bumping the counter or touching the tree. On rc 1
+  # (daemon down) we fall through to the merge — matching the concurrency gate's
+  # fail-open philosophy; the dispatch-spawn-job dedup itself fails closed on
+  # UNKNOWN, so no duplicate repair is spawned and git's index.lock contains the
+  # rare race.
+  if sessions=$(claude_sessions_under "$MAIN_WORKTREE"); then
+    if awk -F'\t' '$4=="sync-repair" && $3!="stopped"{f=1} END{exit !f}' <<<"$sessions"; then
+      release_lock
+      "$SCRIPT_DIR/dispatch-schedule-reseed" 1>&2 || true
+      echo "sync-repair-pending"
+      exit 0
+    fi
+  fi
+
+  # Merge probe. Capture the merge stderr to a temp for escalation diagnostics
+  # while STILL replaying it to the journal (stderr) so nothing is swallowed.
+  # Git's own chatter stays on stderr (1>&2), keeping stdout the decision
+  # channel.
+  if [[ -n "${CLAUDE_JOB_DIR:-}" ]]; then
+    mkdir -p "$CLAUDE_JOB_DIR/tmp"
+    SYNC_TMP=$(mktemp "$CLAUDE_JOB_DIR/tmp/sync-merge.XXXXXX")
+  else
+    SYNC_TMP=$(mktemp)
+  fi
+  if git fetch origin main 1>&2 && git merge --ff-only origin/main 2>"$SYNC_TMP" 1>&2; then
+    merge_ok=1
+  else
+    merge_ok=0
+  fi
+  cat "$SYNC_TMP" >&2          # let the diagnostics reach the journal
+  MERGE_STDERR=$(cat "$SYNC_TMP")
+  rm -f "$SYNC_TMP"
+
+  if [[ "$merge_ok" == 1 ]]; then
+    # SUCCESS — local main ff-merges clean. ALWAYS reset the attempt counter and
+    # close any open dispatch:sync-broken latch (Decision B: a clean probe means
+    # a human resolved the tree, so the chain auto-recovers). Then fall through
+    # to Step 1c — do NOT exit.
+    sync_repair_reset_attempts
+    OPEN_SB=$(gh issue list --label "dispatch:sync-broken" --state open \
+      --json number -q '.[].number')
+    for n in $OPEN_SB; do
+      gh issue close "$n" \
+        --comment "local main ff-merges clean again; closing the sync-broken latch" 1>&2 || true
+    done
+  else
+    # FAILURE — local main is dirty or diverged. The latch is checked only AFTER
+    # a failed merge (Decision B); the probe itself is never suppressed.
+    OPEN_SB=$(gh issue list --label "dispatch:sync-broken" --state open \
+      --json number -q '.[0].number')
+    if [[ -n "$OPEN_SB" ]]; then
+      # a. Already latched — a human owns the tree. Spawn nothing.
+      release_lock
+      "$SCRIPT_DIR/dispatch-schedule-reseed" 1>&2 || true
+      echo "sync-broken"
+      exit 0
+    fi
+    N=$(sync_repair_read_attempts)
+    if [[ "$N" -ge 3 ]]; then
+      # b. Attempt cap hit — escalate to the find-or-create latch issue and stop
+      # respawning. The escalate script reads the captured merge stderr on stdin.
+      # This branch is terminal; it does NOT bump the counter.
+      "$SCRIPT_DIR/dispatch-escalate-sync-broken" <<<"$MERGE_STDERR" 1>&2 || true
+      release_lock
+      "$SCRIPT_DIR/dispatch-schedule-reseed" 1>&2 || true
+      echo "sync-broken"
+      exit 0
+    fi
+    # c. Under the cap — bump the counter and let dispatch-tick spawn the repair.
+    sync_repair_bump_attempts
     release_lock
+    "$SCRIPT_DIR/dispatch-schedule-reseed" 1>&2 || true
     echo "sync-failed"
     exit 0
   fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -71,7 +71,8 @@
 #      jit:/calendar: passthrough lines AND the decision line) so journald and a
 #      live relay both see the narrative. The decision is its LAST stdout line.
 #   2. Route on the decision line (mirrors SKILL.md Table 1):
-#        busy / sync-failed / resolver-failed / empty / concurrency-cap
+#        busy / resolver-failed / empty / concurrency-cap /
+#        sync-repair-pending / sync-broken
 #                          → log a one-line note; exit 0. (select-tick already
 #                            released the lock / scheduled any reseed.)
 #        NOTE: on the autonomous no-arg path, `concurrency-cap` is emitted by
@@ -82,6 +83,9 @@
 #        decision instead, spawned as one gate-exempt worker (GAP=1).
 #        main-broken <sha> → spawn /dispatch-diagnose-main <sha> as a bg job via
 #                            dispatch-spawn-job (--name diagnose-main); exit 0.
+#        sync-failed       → spawn /commit-merge-push as a bg job via
+#                            dispatch-spawn-job (--name sync-repair) on the main
+#                            worktree to auto-repair the wedged local main; exit 0.
 #        jit-reminder ...  → spawn /dispatch-jit-reminder ... as a bg job via
 #                            dispatch-spawn-job (--name jit-reminder-<num>); exit 0.
 #        explicit <num> <gap>            → dispatch-materialize-spawn <num> explicit --gap <gap>
@@ -416,8 +420,14 @@ case "${1:-}" in
     echo "dispatch-tick: another tick holds the lock (busy); nothing to do" >&2
     exit 0
     ;;
-  sync-failed|resolver-failed|empty|concurrency-cap)
+  resolver-failed|empty|concurrency-cap|sync-repair-pending|sync-broken)
     echo "dispatch-tick: select-tick disposition '$1'; nothing spawned" >&2
+    exit 0
+    ;;
+  sync-failed)
+    "$SCRIPT_DIR/dispatch-spawn-job" --name sync-repair --cwd "$MAIN_WORKTREE" \
+      "/commit-merge-push" \
+      || echo "dispatch-tick: WARNING: dispatch-spawn-job (sync-repair) failed; repair job lost" >&2
     exit 0
     ;;
   main-broken)

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -385,7 +385,7 @@ sync_repair_attempts_file() {
 
 # Print the integer stored in the sync-repair attempts file, or 0 if absent/empty/non-numeric.
 sync_repair_read_attempts() {
-  local file n
+  local file n=0
   file=$(sync_repair_attempts_file) || { printf '0\n'; return 0; }
   if [[ -f "$file" ]]; then
     n=$(<"$file")

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -338,6 +338,57 @@ dispatch_lock_file() {
   printf '%s\n' "$project_root/tmp/dispatch.lock"
 }
 
+# Print the sync-repair attempt-counter file path to stdout. An explicit
+# DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE is authoritative and bypasses the git
+# lookup (tests rely on this). Otherwise the file lives at the shared
+# project-root tmp/ (not a per-worktree tmp/) so concurrent ticks in different
+# worktrees contend on the same counter — the same rationale as
+# dispatch_lock_file. Returns non-zero (no output) when the override is unset
+# AND resolve_project_root fails (not in a git repo); the caller supplies its
+# own error handling.
+#
+# A file beside dispatch.lock is the right primitive here: there is no PR to
+# hang a dispatch:<phase>-attempt-<n> label on, and the common path — a
+# transient dirty lockfile that heals in one repair — must stay issue-free.
+sync_repair_attempts_file() {
+  local project_root
+  if [[ -n "${DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE:-}" ]]; then
+    printf '%s\n' "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE"
+    return 0
+  fi
+  project_root=$(resolve_project_root) || return 1
+  printf '%s\n' "$project_root/tmp/sync-repair-attempts"
+}
+
+# Print the integer stored in the sync-repair attempts file, or 0 if absent/empty/non-numeric.
+sync_repair_read_attempts() {
+  local file n
+  file=$(sync_repair_attempts_file) || { printf '0\n'; return 0; }
+  if [[ -f "$file" ]]; then
+    n=$(<"$file")
+  fi
+  if [[ "$n" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$n"
+  else
+    printf '0\n'
+  fi
+}
+
+# Write (current-attempts + 1) to the attempts file, creating it if absent.
+sync_repair_bump_attempts() {
+  local file n
+  file=$(sync_repair_attempts_file) || return 1
+  n=$(sync_repair_read_attempts)
+  printf '%s\n' "$((n + 1))" > "$file"
+}
+
+# Remove the attempts file so the counter resets to 0; a failed path resolution is a no-op.
+sync_repair_reset_attempts() {
+  local file
+  file=$(sync_repair_attempts_file) || return 0
+  rm -f "$file"
+}
+
 # headless_sentinel_path <holder-id> <lock-file> — print the PID-sentinel path
 # for a `headless:<token>` holder id to stdout. The sentinel lives alongside the
 # lock file (same directory) so a concurrent tick in any worktree resolves the

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -18157,6 +18157,9 @@ sel_tick_setup() {
            "$TMPDIR_TEST/dispatch-reconcile-ready"
 
   export DISPATCH_LOCK_FILE="$STUB_DIR/dispatch.lock"
+  # #1495: sync-repair attempt-counter file override (consumed by lib.sh's
+  # sync_repair_* helpers, sourced by dispatch-select-tick's main-branch Step 1).
+  export DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE="$STUB_DIR/sync-repair-attempts"
   export CLAUDE_CODE_SESSION_ID="select-tick-session"
   # Fake `claude agents --json`: our own session is live → first acquisition
   # succeeds and a strict self-release works.
@@ -18169,6 +18172,9 @@ FAKE
   # Single-shot --wait so a busy test never blocks the suite.
   export DISPATCH_LOCK_WAIT_TIMEOUT=0
   export DISPATCH_LOCK_WAIT_INTERVAL=1
+  # #1495: the git stub logs each `merge --ff-only origin/main` here so the
+  # sync-repair defer test can assert the merge was NOT attempted (log absent).
+  export SEL_GIT_MERGE_LOG="$STUB_DIR/git-merge.log"
 
   # Default fake sub-scripts (overridable per test) — land in TMPDIR_TEST so the
   # orchestrator's SCRIPT_DIR resolution finds them.
@@ -18213,6 +18219,15 @@ FAKE
 echo "\$1" >> "$TMPDIR_TEST/logs/schedule-target-reseed.log"
 exit 0
 FAKE
+  # #1495: fake dispatch-escalate-sync-broken — records its invocation and
+  # captures its stdin (the merge stderr) so the at-cap escalation test can
+  # assert it ran. Invoked by dispatch-select-tick via its SCRIPT_DIR (= TMPDIR_TEST).
+  cat > "$TMPDIR_TEST/dispatch-escalate-sync-broken" <<FAKE
+#!/usr/bin/env bash
+cat >> "$TMPDIR_TEST/logs/escalate-stdin.log"
+echo called >> "$TMPDIR_TEST/logs/escalate-sync-broken.log"
+exit 0
+FAKE
   # Sourced helper: provides claude_agents_count_busy_workers (driven by
   # SEL_LIVE_COUNT*) and claude_agents_list_all (driven by SEL_AGENTS_*, used by
   # the reservation-ledger sweep the gate runs before counting). The heredoc is
@@ -18227,6 +18242,16 @@ claude_agents_list_all() {
   [[ -n "${SEL_AGENTS_TSV:-}" ]] && printf '%s\n' "${SEL_AGENTS_TSV}"
   return 0
 }
+claude_sessions_under() {
+  # #1495: default UNKNOWN (rc 1) preserves the pre-#1495 fall-through in
+  # existing main-branch tests. A test sets SEL_SESSIONS_UNDER_RC=0 and
+  # SEL_SESSIONS_UNDER_TSV (tab-separated sid<TAB>pid<TAB>status<TAB>name rows)
+  # to drive a definite session list.
+  local rc="${SEL_SESSIONS_UNDER_RC:-1}"
+  [[ "$rc" != 0 ]] && return "$rc"
+  [[ -n "${SEL_SESSIONS_UNDER_TSV:-}" ]] && printf '%s\n' "${SEL_SESSIONS_UNDER_TSV}"
+  return 0
+}
 FAKE
   # Default empty reservation ledger: the sweep no-ops, reservation_count is 0,
   # and the gap is unchanged from the pre-ledger gate (behavior-preserving).
@@ -18237,7 +18262,8 @@ FAKE
            "$TMPDIR_TEST/dispatch-select-target" \
            "$TMPDIR_TEST/dispatch-target-workers" \
            "$TMPDIR_TEST/dispatch-schedule-reseed" \
-           "$TMPDIR_TEST/dispatch-schedule-target-reseed"
+           "$TMPDIR_TEST/dispatch-schedule-target-reseed" \
+           "$TMPDIR_TEST/dispatch-escalate-sync-broken"
 
   # PATH-shimmed git: branch defaults to main; fetch/merge succeed unless a
   # FAKE_GIT_*_FAIL env var is set.
@@ -18246,7 +18272,7 @@ FAKE
 case "$*" in
   "rev-parse --abbrev-ref HEAD") echo "${FAKE_GIT_BRANCH:-main}" ;;
   "fetch origin main") [[ -n "${FAKE_GIT_FETCH_FAIL:-}" ]] && exit 1 ; exit 0 ;;
-  "merge --ff-only origin/main") [[ -n "${FAKE_GIT_MERGE_FAIL:-}" ]] && exit 1 ; exit 0 ;;
+  "merge --ff-only origin/main") echo merge >> "${SEL_GIT_MERGE_LOG:-/dev/null}" ; [[ -n "${FAKE_GIT_MERGE_FAIL:-}" ]] && exit 1 ; exit 0 ;;
   *) exit 0 ;;
 esac
 STUB
@@ -18264,6 +18290,13 @@ case "$args" in
   issue\ list\ *dispatch:main-broken*)
     if [[ -f "$STUB_DIR/main-broken-open.txt" ]]; then
       cat "$STUB_DIR/main-broken-open.txt"
+    fi
+    ;;
+  issue\ list\ *dispatch:sync-broken*)
+    # #1495: open dispatch:sync-broken latch query. Reads sync-broken-open.txt
+    # (one issue number per line; absent → no open latch).
+    if [[ -f "$STUB_DIR/sync-broken-open.txt" ]]; then
+      cat "$STUB_DIR/sync-broken-open.txt"
     fi
     ;;
   issue\ close\ *)
@@ -18310,7 +18343,9 @@ sel_tick_teardown() {
     FAKE_GIT_BRANCH FAKE_GIT_FETCH_FAIL FAKE_GIT_MERGE_FAIL \
     SEL_TARGET_N SEL_LIVE_COUNT SEL_LIVE_COUNT_FAIL \
     SEL_EXHAUSTED SEL_PRIORITY_ONLY \
-    DISPATCH_RESERVATION_DIR SEL_AGENTS_TSV SEL_AGENTS_LIST_FAIL
+    DISPATCH_RESERVATION_DIR SEL_AGENTS_TSV SEL_AGENTS_LIST_FAIL \
+    DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE SEL_GIT_MERGE_LOG \
+    SEL_SESSIONS_UNDER_RC SEL_SESSIONS_UNDER_TSV
 }
 
 # Run the orchestrator, capturing full stdout; the decision is the last line.
@@ -18423,6 +18458,102 @@ out=$(run_sel_tick)
 assert_eq "re-arm green+no-issue: decision line" "empty" "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "re-arm green+no-issue: no close attempted" "absent" \
   "$([[ -e "$STUB_DIR/gh-issue-close.log" ]] && echo present || echo absent)"
+sel_tick_teardown
+
+# --- #1495: dirty main → sync-failed, reseed armed, counter bumped -----------
+echo "Test: select-tick failing merge under cap → sync-failed, counter bumped"
+sel_tick_setup
+export FAKE_GIT_MERGE_FAIL=1   # local main cannot ff-merge origin/main
+# Default sessions = UNKNOWN (fall through); no sync-broken latch; counter absent (=0).
+out=$(run_sel_tick)
+assert_eq "sync-failed: decision line" "sync-failed" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "sync-failed: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "sync-failed: reseed armed" "present" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-reseed.log" ] && echo present || echo absent)"
+assert_eq "sync-failed: counter bumped to 1" "1" \
+  "$(cat "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE")"
+assert_eq "sync-failed: escalate NOT called" "absent" \
+  "$([ -f "$TMPDIR_TEST/logs/escalate-sync-broken.log" ] && echo present || echo absent)"
+sel_tick_teardown
+
+# --- #1495: live sync-repair session → defer (sync-repair-pending), merge NOT run ---
+echo "Test: select-tick live sync-repair session → sync-repair-pending, merge deferred"
+sel_tick_setup
+export SEL_SESSIONS_UNDER_RC=0
+export SEL_SESSIONS_UNDER_TSV=$'sid1\t100\tbusy\tsync-repair'
+out=$(run_sel_tick)
+assert_eq "defer: decision line" "sync-repair-pending" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "defer: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "defer: reseed armed" "present" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-reseed.log" ] && echo present || echo absent)"
+assert_eq "defer: merge NOT attempted" "absent" \
+  "$([ -f "$STUB_DIR/git-merge.log" ] && echo present || echo absent)"
+assert_eq "defer: counter untouched" "absent" \
+  "$([ -f "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE" ] && echo present || echo absent)"
+sel_tick_teardown
+
+# --- #1495: stopped sync-repair session does NOT defer → falls through to merge ---
+echo "Test: select-tick stopped sync-repair session → no defer, failing merge → sync-failed"
+sel_tick_setup
+export SEL_SESSIONS_UNDER_RC=0
+export SEL_SESSIONS_UNDER_TSV=$'sid1\t100\tstopped\tsync-repair'
+export FAKE_GIT_MERGE_FAIL=1
+out=$(run_sel_tick)
+assert_eq "stopped-defer: decision line" "sync-failed" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "stopped-defer: merge attempted" "present" \
+  "$([ -f "$STUB_DIR/git-merge.log" ] && echo present || echo absent)"
+sel_tick_teardown
+
+# --- #1495: failing merge at attempt cap → escalate + sync-broken, no bump ----
+echo "Test: select-tick failing merge at cap → escalate, sync-broken, counter unchanged"
+sel_tick_setup
+printf '3\n' > "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE"   # already at the cap
+export FAKE_GIT_MERGE_FAIL=1
+# No sync-broken latch open yet → the cap branch escalates (find-or-create).
+out=$(run_sel_tick)
+assert_eq "cap-escalate: decision line" "sync-broken" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "cap-escalate: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "cap-escalate: reseed armed" "present" \
+  "$([ -f "$TMPDIR_TEST/logs/schedule-reseed.log" ] && echo present || echo absent)"
+assert_eq "cap-escalate: escalate called" "present" \
+  "$([ -f "$TMPDIR_TEST/logs/escalate-sync-broken.log" ] && echo present || echo absent)"
+assert_eq "cap-escalate: counter unchanged (no bump on terminal branch)" "3" \
+  "$(cat "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE")"
+sel_tick_teardown
+
+# --- #1495: latch already open + failing merge → sync-broken, NO escalate -----
+echo "Test: select-tick failing merge with open latch → sync-broken, no escalate/bump"
+sel_tick_setup
+printf '88\n' > "$STUB_DIR/sync-broken-open.txt"   # latch already open
+export FAKE_GIT_MERGE_FAIL=1
+out=$(run_sel_tick)
+assert_eq "latched: decision line" "sync-broken" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "latched: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "latched: escalate NOT called" "absent" \
+  "$([ -f "$TMPDIR_TEST/logs/escalate-sync-broken.log" ] && echo present || echo absent)"
+assert_eq "latched: counter NOT bumped (latched branch returns first)" "absent" \
+  "$([ -f "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE" ] && echo present || echo absent)"
+sel_tick_teardown
+
+# --- #1495: clean merge + open latch → counter reset, latch closed -----------
+echo "Test: select-tick clean merge with open latch → reset counter, close latch"
+sel_tick_setup
+printf '77\n' > "$STUB_DIR/sync-broken-open.txt"   # stale latch to close
+printf '2\n' > "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE"   # stale counter to reset
+# Merge succeeds (default, no FAKE_GIT_MERGE_FAIL) → fall through to select-target
+# (default `empty`).
+out=$(run_sel_tick)
+assert_eq "recover: decision line" "empty" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "recover: latch closed" \
+  "issue close 77 --comment local main ff-merges clean again; closing the sync-broken latch" \
+  "$(cat "$STUB_DIR/gh-issue-close.log")"
+assert_eq "recover: counter reset" "absent" \
+  "$([ -f "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE" ] && echo present || echo absent)"
 sel_tick_teardown
 
 # --- jit-reminder → passthrough + lock RELEASED (spawned as a bg job) --------
@@ -20163,15 +20294,20 @@ assert_eq "busy: no spawn-job call" "0" \
   "$([ -f "$TMPDIR_TEST/logs/spawn-job.log" ] && echo 1 || echo 0)"
 tick_teardown
 
-# --- empty / sync-failed / resolver-failed / concurrency-cap → exit 0, no materialize ---
-for d in empty sync-failed resolver-failed concurrency-cap; do
-  echo "Test: dispatch-tick $d → exit 0, no materialize"
+# --- empty / resolver-failed / concurrency-cap / sync-repair-pending / sync-broken ---
+# All pass-through dispositions: exit 0, no materialize, no spawn-job. #1495 adds
+# the two sync pass-throughs (sync-repair-pending, sync-broken); sync-failed moved
+# out of this loop because it now spawns the repair job (covered below).
+for d in empty resolver-failed concurrency-cap sync-repair-pending sync-broken; do
+  echo "Test: dispatch-tick $d → exit 0, no materialize/spawn"
   tick_setup
   export TICK_DECISION="$d"
   out=$(run_tick) && rc=0 || rc=$?
   assert_eq "$d: exit 0" "0" "$rc"
   assert_eq "$d: no materialize call" "0" \
     "$([ -f "$TMPDIR_TEST/logs/materialize.log" ] && echo 1 || echo 0)"
+  assert_eq "$d: no spawn-job call" "0" \
+    "$([ -f "$TMPDIR_TEST/logs/spawn-job.log" ] && echo 1 || echo 0)"
   tick_teardown
 done
 
@@ -20185,6 +20321,19 @@ assert_eq "main-broken: spawn-job argv" \
   "--name diagnose-main --cwd $TMPDIR_TEST /dispatch-diagnose-main abc1234" \
   "$(cat "$TMPDIR_TEST/logs/spawn-job.log")"
 assert_eq "main-broken: no materialize call" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/materialize.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+# --- #1495: sync-failed → spawn-job /commit-merge-push (sync-repair), exit 0 ---
+echo "Test: dispatch-tick sync-failed → spawn-job sync-repair /commit-merge-push"
+tick_setup
+export TICK_DECISION="sync-failed"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "sync-failed: exit 0" "0" "$rc"
+assert_eq "sync-failed: spawn-job argv" \
+  "--name sync-repair --cwd $TMPDIR_TEST /commit-merge-push" \
+  "$(cat "$TMPDIR_TEST/logs/spawn-job.log")"
+assert_eq "sync-failed: no materialize call" "0" \
   "$([ -f "$TMPDIR_TEST/logs/materialize.log" ] && echo 1 || echo 0)"
 tick_teardown
 


### PR DESCRIPTION
Closes #1495

## Problem

`dispatch-select-tick` runs `git fetch origin main && git merge --ff-only
origin/main` as the precondition for **all** worker selection, but only on the
`main` branch. When local main is dirty (uncommitted changes — the reported
`flake.lock` case) or diverged, that `--ff-only` fails: the tick emitted
`sync-failed`, released the lock, and exited. Two defects then halted the whole
chain with no self-heal:

1. The `sync-failed` path armed **no reseed** (unlike `concurrency-cap`), so an
   otherwise-idle chain never ticked again (the #1445 dead-state class).
2. Nothing repaired the tree, so every subsequent tick re-hit the same merge
   failure and spawned nothing.

## Fix

On `sync-failed`, the tick now auto-repairs local main by spawning a deduped
`/commit-merge-push` bg job on the main worktree, arms a reseed so the chain
keeps ticking, and resumes selection automatically once main ff-merges clean.
The failing `--ff-only` *is* the natural gate — selection never advances past
Step 1 while local main is dirty, and the first clean merge after repair lets
fan-out resume. No explicit lock, no latch for the common path.

A repair that hits an unresolvable merge conflict must not loop forever
(`/commit-merge-push` errors on conflict without aborting the merge, leaving main
un-ff-mergeable). After a bounded attempt cap (3), the tick escalates by
find-or-creating a `dispatch:sync-broken` latch issue and stops respawning until
a human resolves the tree — mirroring `dispatch:main-broken`.

### Two load-bearing control-flow decisions

- **Defer while a repair is live, but fail *open* on daemon UNKNOWN.** Before the
  `--ff-only`, the tick checks for a live `sync-repair` session under the main
  worktree (`claude_sessions_under`). If present → defer (`sync-repair-pending`).
  On UNKNOWN (daemon down) → proceed to the merge, matching the concurrency
  gate's fail-open philosophy; the downstream `dispatch-spawn-job` dedup fails
  *closed* on UNKNOWN, so no duplicate repair is spawned, and git's `index.lock`
  contains the rare race.
- **The `--ff-only` attempt *is* the recovery probe.** The `dispatch:sync-broken`
  latch is checked **after** a *failed* merge, never before — so a *successful*
  ff-merge (a human resolved the tree) always takes the success branch, which
  resets the counter and closes the latch. The latch suppresses the repair
  *spawn*, never the probe.

## Units

1. **`lib.sh`** — `sync_repair_{attempts_file,read,bump,reset}_attempts`: a
   persistent attempt-counter beside `dispatch.lock`, mirroring
   `dispatch_lock_file`. A small state file (not a tracking issue) keeps the
   common transient-lockfile path issue-free.
2. **`dispatch-escalate-sync-broken`** (new) — gathers `git status` / divergence
   / merge-stderr diagnostics and find-or-creates the `dispatch:sync-broken`
   latch (`bug` + `priority`, no `dispatch:office-hours`), modeled on
   `dispatch-diagnose-main`.
3. **`dispatch-select-tick` Step 1 rewrite** (the core) — defer / probe / success
   (reset + close latch) / failure (latched → `sync-broken`; at cap → escalate +
   `sync-broken`; else bump + `sync-failed`). Every release path arms a reseed.
4. **`dispatch-tick`** — pull `sync-failed` into its own arm that spawns
   `dispatch-spawn-job --name sync-repair --cwd <main> /commit-merge-push`; add
   `sync-repair-pending` / `sync-broken` as pass-through dispositions.
5. **`test-dispatch-scripts.sh`** — extend the shared select-tick/tick harness
   (a default-UNKNOWN `claude_sessions_under`, a `dispatch:sync-broken` gh case, a
   git-merge log, a `dispatch-escalate-sync-broken` stub, a counter-file override)
   and cover all four states. Suite: **2425/2425**.

## Verification

- `bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` →
  2425/2425 passed (the four new states verified alongside the existing
  dispositions). The harness stubs git/gh/claude-agents/spawn-job, so it runs
  without a live daemon.
