### PR TITLE
dispatch: derive selection's claimed-set forward from live sessions + reservations

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -98,21 +98,30 @@
 #   2. Oldest "review"      PR (draft + dispatch:qa-done)
 #   3. Oldest "fix-checks"  PR (draft, CI completed and failed)
 #   4. Oldest "qa"          PR (draft, CI green, no dispatch:* label)
-#   5. Oldest open help-wanted issue whose <N>-* worktree, if any, is not owned
-#      by a live Claude session, and which is not already closed by a non-draft
-#      (ready) PR (#920), resolved to a startable open leaf (an issue whose
-#      entire open-leaf subtree is owned by live sessions is skipped, exactly as
-#      a live-session-owned direct worktree is — an orphan child worktree stays
-#      descendable, #914)
+#   5. Oldest open help-wanted issue whose <N> is not in the forward-derived
+#      claimed set (live ∪ reserved), and which is not already closed by a
+#      non-draft (ready) PR (#920), resolved to a startable open leaf (an issue
+#      whose entire open-leaf subtree is claimed is skipped, exactly as a claimed
+#      direct issue is — an orphan child worktree stays descendable, #914)
 #
-# A PR or help-wanted issue is skipped only when a live Claude session owns its
-# worktree — the row's branch worktree (PR) or any <N>-* worktree (issue). The
-# check sources lib-claude-agents.sh and keys on worktree_has_live_session,
-# which is fail-safe: an unqueryable daemon counts as owned. An orphan worktree
-# (on disk, no live session) does NOT skip the row — it is a reuse signal for
-# dispatch-resolve-worktree, not a priority skip (#905). Worktree existence is a
-# fast-path miss: a row whose branch / <N>-* has no worktree at all never pays
-# the daemon round-trip.
+# A PR or help-wanted issue is skipped iff its issue <N> is in the forward-
+# derived claimed set (#1474): the deduped union of the <N> values claimed by
+# live Claude sessions (#905) and outstanding reservation markers (#1046). The
+# set is derived FORWARD from live-session names + reservation basenames — one
+# daemon query plus one ledger stat — instead of walking every registered git
+# worktree backward; selection is now O(worker cap), not O(worktrees). Both the
+# PR skip and the issue skip unify onto one <N>-keyed predicate (num_is_claimed):
+# a PR's key is its BRANCH PREFIX (<N>-<slug>, the session/worktree name — NOT its
+# closing-issue number), an issue's key is its own number. The derivation FAILS
+# OPEN on a live-UNKNOWN daemon (degrades to the reserved-only set), so a
+# momentary outage narrows skip coverage rather than aborting selection.
+#
+# The set is <N>-keyed, coarser than the former exact-branch worktree map: a live
+# `10-foo` session now also marks a `10-bar` PR's <N>=10 claimed — deliberate, in
+# the safe (more-conservative-skip) direction. An orphan worktree (on disk, no
+# live session, no reservation) is NOT claimed here and does NOT skip the row — it
+# stays a reuse signal for dispatch-resolve-worktree, the per-target net at the
+# spawn boundary (#905, #1046).
 # A PR is also skipped when an issue it closes is blocked_by an open issue.
 # "done" (non-draft) PRs are skipped entirely.
 # Not-ready PRs (draft, CI still running/queued/not started — no verdict yet,
@@ -133,14 +142,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
-# worktree_has_live_session — a worktree-bearing PR/issue row is skipped only
-# when a live Claude session owns the matching worktree (#905). Sourced here so
-# the queue-scan loops below can ask the liveness question.
-source "$SCRIPT_DIR/lib-claude-agents.sh"
-# reservation_exists — a worktree-bearing row is ALSO skipped when its worktree
-# carries a reservation marker (#1046), even before a live session owns it: a
-# reserved-but-not-yet-registered target must not be re-selected, racing the
-# reservation. Load-guarded; re-sources lib.sh / lib-claude-agents.sh harmlessly.
+# claimed_issue_nums (via lib-reservation-ledger.sh, which transitively loads
+# lib-claude-agents.sh) — the forward-derived claimed-issue set the queue scans
+# skip against (#1474). A PR/issue row is skipped iff its issue <N> is claimed by
+# a live Claude session (#905) OR an outstanding reservation marker (#1046).
+# Selection derives that set FORWARD from live-session names + reservation
+# basenames — one daemon query plus one ledger stat — instead of walking every
+# registered git worktree backward. Load-guarded; re-sources lib.sh /
+# lib-claude-agents.sh harmlessly.
 source "$SCRIPT_DIR/lib-reservation-ledger.sh"
 QA_MODE=false
 HEALTH_ONLY=false
@@ -419,78 +428,28 @@ if [[ "$QA_MODE" == "false" ]]; then
 
 fi
 
-# Map each registered worktree's branch — and its <issue>-number prefix — to its
-# on-disk path. A PR/issue row is skipped only when a *live* Claude session owns
-# the matching worktree (#905): an orphan worktree (on disk, no session) is a
-# reuse signal for dispatch-resolve-worktree, not a priority skip here. Built
-# once via the shared lib.sh record parser so the path is on hand for the
-# liveness query; a bare / detached / non-issue record contributes nothing.
-declare -A WORKTREE_PATH_BY_BRANCH=()
-declare -A WORKTREE_PATHS_BY_NUM=()
-while IFS= read -r wt_record; do
-  split_worktree_record "$wt_record"
-  [[ -z "$WT_PATH" ]] && continue
-  [[ -n "$WT_BRANCH" ]] && WORKTREE_PATH_BY_BRANCH["$WT_BRANCH"]="$WT_PATH"
-  if [[ -n "$WT_NUM" ]]; then
-    WORKTREE_PATHS_BY_NUM["$WT_NUM"]="${WORKTREE_PATHS_BY_NUM[$WT_NUM]:-}$WT_PATH"$'\n'
-  fi
-done < <(list_worktree_records)
+# Forward-derived claimed-issue set, built ONCE (#1474). Placed here — after the
+# --main-broken-sha / --health-only / default-mode JIT+main-broken early exits,
+# right where the former worktree-walk map build sat — so those early-exit paths
+# never pay for it (notably --health-only's cheap heartbeat re-seed never reaches
+# the queue scan that reads it). Selection skips a PR or help-wanted issue iff its
+# <N> is claimed; the claimed set is derived FORWARD from claimed_issue_nums (the
+# deduped union of live-session names and outstanding reservation markers, each
+# keyed by issue <N>), not by walking every registered git worktree backward —
+# selection is O(worker cap), not O(worktrees). claimed_issue_nums FAILS OPEN on a
+# live-UNKNOWN daemon (degrades to the reserved-only set internally), so a
+# momentary daemon outage narrows skip coverage rather than aborting selection.
+# This is a coarse <N>-keyed pre-filter, not the final claim: dispatch-resolve-
+# worktree is the per-target net at the spawn boundary — an orphan worktree (on
+# disk, no live session, no reservation) is NOT claimed here and stays a reuse
+# signal there (#905, #1046).
+declare -A CLAIMED_NUMS=()
+while IFS= read -r claimed_n; do
+  [[ -n "$claimed_n" ]] && CLAIMED_NUMS["$claimed_n"]=1
+done < <(claimed_issue_nums)
 
-# True when a live session owns the worktree checked out at <branch>. No
-# worktree for <branch> → fast-path miss (return 1), no daemon round-trip. A
-# worktree exists → defer to worktree_has_live_session, which is fail-safe: an
-# unqueryable daemon counts as owned, so the row is skipped rather than
-# double-claimed.
-pr_branch_has_live_worktree() {
-  local branch="$1"
-  local path="${WORKTREE_PATH_BY_BRANCH[$branch]:-}"
-  [[ -z "$path" ]] && return 1
-  worktree_has_live_session "$path"
-}
-
-# True when a live session owns any <num>-* worktree. No such worktree →
-# fast-path miss. Several matches → owned if any one is live.
-issue_has_live_worktree() {
-  local num="$1" p
-  local paths="${WORKTREE_PATHS_BY_NUM[$num]:-}"
-  [[ -z "$paths" ]] && return 1
-  while IFS= read -r p; do
-    [[ -z "$p" ]] && continue
-    if worktree_has_live_session "$p"; then
-      return 0
-    fi
-  done <<< "$paths"
-  return 1
-}
-
-# True when the <branch> worktree is CLAIMED — a live session owns it (#905) OR
-# it carries a reservation marker (#1046). Both close the spawn-gap re-selection
-# race: a reserved-but-not-yet-registered target must not be re-selected. An
-# orphan worktree (on disk, no live session, no marker) is NOT claimed — it stays
-# a reuse signal for dispatch-resolve-worktree. The reserved check is a fast-path
-# file stat keyed on the worktree basename, no daemon round-trip.
-pr_branch_worktree_claimed() {
-  local branch="$1"
-  pr_branch_has_live_worktree "$branch" && return 0
-  local path="${WORKTREE_PATH_BY_BRANCH[$branch]:-}"
-  [[ -z "$path" ]] && return 1
-  reservation_exists "$(basename "$path")"
-}
-
-# True when any <num>-* worktree is CLAIMED — live-owned (#905) OR reserved
-# (#1046). Several matches → claimed if any one is live or reserved. Orphan
-# worktrees (no session, no marker) stay reuse signals, not skips.
-issue_worktree_claimed() {
-  local num="$1" p
-  issue_has_live_worktree "$num" && return 0
-  local paths="${WORKTREE_PATHS_BY_NUM[$num]:-}"
-  [[ -z "$paths" ]] && return 1
-  while IFS= read -r p; do
-    [[ -z "$p" ]] && continue
-    reservation_exists "$(basename "$p")" && return 0
-  done <<< "$paths"
-  return 1
-}
+# True when issue <N> is in the forward-derived claimed set (live ∪ reserved).
+num_is_claimed() { [[ -n "${CLAIMED_NUMS[$1]:-}" ]]; }
 
 # Fetch all open PRs once, with the union of fields this script and
 # dispatch-phase need. Each per-PR dispatch-phase call below reuses it
@@ -723,6 +682,11 @@ WAITING_NUM=""
 while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   [[ -z "$pr_num" ]] && continue
 
+  # The branch issue-prefix (<N>-<slug>) is this PR's worktree/session key — the
+  # same <N> the office-hours and --exclude checks below key on. Compute it once
+  # here and reuse it (claimed skip, office-hours skip, exclude skip).
+  pr_issue_num="${pr_branch%%-*}"
+
   # --priority-only scans only the priority=1 tier. Skip any PR whose
   # closing-issue label union does not carry `priority` BEFORE the expensive
   # per-PR dispatch-ci-ready / dispatch-phase gh calls — a non-priority PR is
@@ -732,10 +696,15 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
     continue
   fi
 
-  # Skip a PR whose branch worktree is owned by a live session or reserved. An
-  # orphan worktree (no session, no marker) does not skip — it is recycled at
-  # dispatch-resolve-worktree (#905, #1046).
-  if pr_branch_worktree_claimed "$pr_branch"; then
+  # Skip a PR whose branch issue-prefix <N> is in the forward-derived claimed set
+  # — a live session owns a <N>-* worktree (#905) OR a <N>-* reservation marker is
+  # outstanding (#1046). The skip key is the BRANCH PREFIX (the session/worktree
+  # name), NOT the PR's closing-issue number. The set is <N>-keyed, so it is
+  # coarser than the former exact-branch worktree map: a live `10-foo` session now
+  # also marks a `10-bar` PR's <N>=10 claimed — deliberate, in the safe
+  # (more-conservative-skip) direction. An orphan worktree (no session, no marker)
+  # does not skip — it is recycled at dispatch-resolve-worktree (#905, #1046).
+  if num_is_claimed "$pr_issue_num"; then
     continue
   fi
 
@@ -788,9 +757,9 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   esac
 
   # Skip PRs whose ISSUE is parked on a human (dispatch:office-hours). The label
-  # lives on the issue (issue #909), so resolve the issue number from the PR's
-  # branch prefix (<N>-<slug>) and check the issue's labels in ISSUE_LABELS_JSON.
-  pr_issue_num="${pr_branch%%-*}"
+  # lives on the issue (issue #909), so the branch-prefix issue number
+  # (pr_issue_num, computed at the top of the loop) checks the issue's labels in
+  # ISSUE_LABELS_JSON.
   # Skip a PR whose issue is in the --exclude set (#1062): the fan-out caller has
   # already processed this target. Applied during the scan, before FIRST_PR is
   # populated, so the next-oldest PR in an already-tapped bucket surfaces. The
@@ -935,10 +904,11 @@ while IFS=$'\t' read -r issue_num issue_pri issue_catrank issue_cat; do
   fi
   # Skip an open issue already closed by a non-draft (ready) PR (#920).
   [[ -n "${READY_PR_CLOSED_ISSUES[$issue_num]:-}" ]] && continue
-  # Skip an issue whose <N>-* worktree is owned by a live session or reserved.
-  # An orphan <N>-* worktree (no session, no marker) does not skip — it is
-  # recycled at dispatch-resolve-worktree (#905, #1046).
-  if issue_worktree_claimed "$issue_num"; then
+  # Skip an issue whose <N> is in the forward-derived claimed set — a live session
+  # owns its <N>-* worktree (#905) OR a <N>-* reservation marker is outstanding
+  # (#1046). An orphan <N>-* worktree (no session, no marker) does not skip — it
+  # is recycled at dispatch-resolve-worktree (#905, #1046).
+  if num_is_claimed "$issue_num"; then
     continue
   fi
   # Category and priority bit both arrive precomputed from the sorted TSV

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
@@ -23,12 +23,17 @@
 #              dispatch-resolve-worktree's explicit mode, which yields `enter`
 #              for the recycle-after-completion case, or `conflict` if a live
 #              session still owns the worktree — #837).
-#   queue    — descent filters out children whose <N>-* worktree is owned by a
-#              LIVE Claude session (#914) or carries a reservation marker
-#              (#1046). An orphan <N>-* worktree (on disk, no session, no marker)
-#              stays descendable — it is a reuse signal, not a skip, matching the
+#   queue    — descent filters out children whose issue <N> is CLAIMED: claimed
+#              by a LIVE Claude session (#914) or by an outstanding reservation
+#              marker (#1046). The claimed set is derived FORWARD once from
+#              claimed_issue_nums (the deduped union of live-session names and
+#              reservation markers, each keyed by issue <N>), not by walking
+#              every registered git worktree backward per call (#1474) — so trace
+#              latency is independent of worktree count. An orphan <N>-* worktree
+#              (on disk, no session, no marker) is not in the claimed set, so it
+#              stays descendable — a reuse signal, not a skip, matching the
 #              direct-row claimed-skip in dispatch-select-target (#905, #1046). A
-#              child with no worktree at all is never filtered.
+#              child with no live session and no reservation is never filtered.
 #              Queue mode also filters out a child parked on
 #              dispatch:office-hours (#1011): the label parks an item for human
 #              review and must remove it from autonomous selection (#757), so a
@@ -58,15 +63,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
-# worktree_has_live_session — queue-mode descent skips a child only when a live
-# Claude session owns its <N>-* worktree (#914). Sourced here so the descent can
-# ask the liveness question; it sets -uo pipefail (not -e), preserving this
-# script's set -euo pipefail above.
+# lib-claude-agents.sh — provides the live-session half of the claimed set
+# (#914), consumed transitively by claimed_issue_nums below. Sourced here because
+# lib-reservation-ledger.sh depends on it; it sets -uo pipefail (not -e),
+# preserving this script's set -euo pipefail above.
 source "$SCRIPT_DIR/lib-claude-agents.sh"
-# reservation_exists — queue-mode descent ALSO skips a child whose <N>-* worktree
-# carries a reservation marker (#1046), mirroring the selector's reserved-skip
-# applied to subtree children. Load-guarded; re-sources lib.sh /
-# lib-claude-agents.sh harmlessly.
+# claimed_issue_nums — queue mode derives its skip set FORWARD from this (#1474):
+# the deduped union of live-session-claimed (#914) and reservation-claimed (#1046)
+# issue <N> values. Replaces the former backward worktree walk. Load-guarded;
+# re-sources lib.sh / lib-claude-agents.sh harmlessly.
 source "$SCRIPT_DIR/lib-reservation-ledger.sh"
 
 ISSUE_NUM="${1:-}"
@@ -101,31 +106,37 @@ if [[ $# -gt 0 ]]; then
   fi
 fi
 
-# In queue mode, map each issue-number prefix to the on-disk path(s) of its
-# <N>-* worktree(s), so the descent can ask whether a live session owns one
-# (#914) rather than skipping on mere worktree existence. list_worktree_records
-# (lib.sh) does the shared porcelain parse; split_worktree_record splits each
-# line into WT_NUM / WT_PATH / WT_BRANCH — WT_NUM is the branch's issue-number
-# prefix, empty for non-issue / branchless worktrees. Mirrors the selector's
-# WORKTREE_PATHS_BY_NUM (newline-joined paths per number).
-declare -A WORKTREE_PATHS_BY_NUM=()
+# In queue mode, build the forward-derived claimed-issue set ONCE (#1474),
+# mirroring dispatch-select-target's CLAIMED_NUMS. claimed_issue_nums (via
+# lib-reservation-ledger.sh) emits the deduped union of the issue <N> values
+# claimed by live Claude sessions (#914) and by outstanding reservation markers
+# (#1046), one per line. Descent then skips a claimed child with a single map
+# lookup — no per-child liveness/reservation query, and no O(worktrees) walk
+# rebuilt on every queue-mode invocation (the selector calls this once per root,
+# so a backward worktree walk per call is strictly worse than its single walk).
+# claimed_issue_nums FAILS OPEN on a live-UNKNOWN daemon (degrades to the
+# reserved-only set internally), so a momentary daemon outage narrows skip
+# coverage rather than aborting the trace. An orphan <N>-* worktree (on disk, no
+# session, no marker) is NOT in this set, so it stays descendable — a reuse
+# signal, not a skip, matching the selector's direct-row claimed-skip (#905,
+# #1046).
+declare -A CLAIMED_NUMS=()
 if [[ "$MODE" == "queue" ]]; then
-  while IFS= read -r line; do
-    split_worktree_record "$line"
-    [[ -z "$WT_PATH" ]] && continue
-    if [[ -n "$WT_NUM" ]]; then
-      WORKTREE_PATHS_BY_NUM["$WT_NUM"]="${WORKTREE_PATHS_BY_NUM[$WT_NUM]:-}$WT_PATH"$'\n'
-    fi
-  done < <(list_worktree_records)
+  while IFS= read -r claimed_n; do
+    [[ -n "$claimed_n" ]] && CLAIMED_NUMS["$claimed_n"]=1
+  done < <(claimed_issue_nums)
 fi
+
+# True when issue <N> is in the forward-derived claimed set (live ∪ reserved).
+num_is_claimed() { [[ -n "${CLAIMED_NUMS[$1]:-}" ]]; }
 
 # In queue mode, gather the set of open issues parked on dispatch:office-hours
 # (#1011), keyed by issue number. The label parks an item for human review and
 # must remove it from autonomous selection (#757); dispatch-select-target
 # already filters it on top-level queue issues, but a parked leaf reachable from
 # an unparked parent slipped through this descent. Gathered once up front,
-# mirroring WORKTREE_PATHS_BY_NUM above, so child_is_office_hours_parked is a map
-# lookup with no per-child gh round-trip. A gh failure here is a hard error, not
+# mirroring CLAIMED_NUMS above, so child_is_office_hours_parked is a map lookup
+# with no per-child gh round-trip. A gh failure here is a hard error, not
 # an empty set — silently returning a parked leaf is the very bug being fixed.
 # --limit 300 matches dispatch-select-target's open-issue cap: the parked set is
 # a subset of open issues, so the default limit of 30 could silently truncate it
@@ -139,50 +150,12 @@ if [[ "$MODE" == "queue" ]]; then
   done < <(printf '%s' "$parked_json" | jq -r '.[].number')
 fi
 
-# True when a live Claude session owns any <num>-* worktree. No such worktree →
-# fast-path miss (return 1), no daemon round-trip. Several matches → owned if any
-# one is live. A faithful copy of dispatch-select-target's issue_has_live_worktree
-# (#905), applied here to subtree children (#914). worktree_has_live_session is
-# fail-safe: an unqueryable daemon counts as owned, so the child is skipped
-# rather than double-claimed.
-child_has_live_worktree() {
-  local num="$1" p
-  local paths="${WORKTREE_PATHS_BY_NUM[$num]:-}"
-  [[ -z "$paths" ]] && return 1
-  while IFS= read -r p; do
-    [[ -z "$p" ]] && continue
-    if worktree_has_live_session "$p"; then
-      return 0
-    fi
-  done <<< "$paths"
-  return 1
-}
-
-# True when any <num>-* child worktree is CLAIMED — live-owned (#914) OR reserved
-# (#1046). Mirrors dispatch-select-target's issue_worktree_claimed, applied to
-# subtree children: a reserved-but-not-yet-registered child must not be descended
-# into nor returned. An orphan child (no session, no marker) stays descendable.
-# The reserved check is a fast-path file stat keyed on the worktree basename, no
-# daemon round-trip.
-child_worktree_claimed() {
-  local num="$1" p
-  child_has_live_worktree "$num" && return 0
-  local paths="${WORKTREE_PATHS_BY_NUM[$num]:-}"
-  [[ -z "$paths" ]] && return 1
-  while IFS= read -r p; do
-    [[ -z "$p" ]] && continue
-    reservation_exists "$(basename "$p")" && return 0
-  done <<< "$paths"
-  return 1
-}
-
 # True when the given issue number is parked on dispatch:office-hours (#1011).
-# A parked node is filtered from queue-mode descent exactly like a
-# live-session-owned child (child_has_live_worktree, #914): neither descended
-# into nor returned as a startable leaf. The descent then falls through to the
-# next startable sibling, or bubbles up (exit 2) when every reachable open leaf
-# is parked or live-owned. Map lookup against OFFICE_HOURS_PARKED, populated
-# once in queue mode above.
+# A parked node is filtered from queue-mode descent exactly like a claimed child
+# (num_is_claimed, #914/#1046): neither descended into nor returned as a startable
+# leaf. The descent then falls through to the next startable sibling, or bubbles
+# up (exit 2) when every reachable open leaf is parked or claimed. Map lookup
+# against OFFICE_HOURS_PARKED, populated once in queue mode above.
 child_is_office_hours_parked() {
   [[ -n "${OFFICE_HOURS_PARKED[$1]:-}" ]]
 }
@@ -302,15 +275,15 @@ find_leaf() {
   fi
 
   # Descend into children lowest-numbered first; return the first leaf found.
-  # In queue mode, skip any child whose <N>-* worktree is owned by a live
-  # session (#914) or carries a reservation marker (#1046) — an orphan child
-  # worktree (no session, no marker) stays descendable — and any child parked on
-  # dispatch:office-hours (#1011). If every child is skipped the loop finds
-  # nothing and we bubble up.
+  # In queue mode, skip any child whose issue <N> is in the forward-derived
+  # claimed set (live-session-owned, #914, or reserved, #1046) — an orphan child
+  # worktree (no session, no marker) is not claimed and stays descendable — and
+  # any child parked on dispatch:office-hours (#1011). If every child is skipped
+  # the loop finds nothing and we bubble up.
   local kid leaf
   while IFS= read -r kid; do
     [[ -z "$kid" ]] && continue
-    [[ "$MODE" == "queue" ]] && child_worktree_claimed "$kid" && continue
+    [[ "$MODE" == "queue" ]] && num_is_claimed "$kid" && continue
     [[ "$MODE" == "queue" ]] && child_is_office_hours_parked "$kid" && continue
     # Capture the status explicitly (set -e is disabled here) so a hard error
     # (rc 3) is distinguishable from "no leaf in this subtree" (rc 1).
@@ -331,7 +304,7 @@ find_leaf() {
 # to skip it, so guard it here before the trace. Force the no-startable-leaf
 # path (rc 2) so it flows into the exit-2 surface below, matching the
 # all-children-skipped case.
-if [[ "$MODE" == "queue" ]] && { child_is_office_hours_parked "$ISSUE_NUM" || child_worktree_claimed "$ISSUE_NUM"; }; then
+if [[ "$MODE" == "queue" ]] && { child_is_office_hours_parked "$ISSUE_NUM" || num_is_claimed "$ISSUE_NUM"; }; then
   trace_rc=2
 elif LEAF=$(find_leaf "$ISSUE_NUM"); then
   trace_rc=0

--- a/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh
@@ -11,6 +11,7 @@
 #   claude_sessions_under              <worktree-path>
 #   claude_sessions_with_name          <name>
 #   claude_agents_list_all
+#   live_session_claimed_nums
 #   worktree_has_live_session          <worktree-path>
 #   claude_agents_count_busy_workers
 #   verify_agent_registered_under      <agent-name> <cwd>
@@ -301,6 +302,66 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
     # `[]` → empty $lines → emit nothing (zero session lines), still return 0.
     if [[ -n "$lines" ]]; then
       printf '%s\n' "$lines"
+    fi
+    return 0
+  }
+
+  # live_session_claimed_nums — emit the UNIQUE issue numbers claimed by live
+  # sessions, one per line. The forward (in-flight) half of selection's claimed
+  # set: instead of walking every registered worktree backward, derive the
+  # claimed numbers straight from the live-session names in a single daemon
+  # query. A name matches one of two shapes and contributes its captured <N>:
+  #   `^[0-9]+-`            phase workers, spawned with --name=<N>-slug (same
+  #                         `^[0-9]+-` shape used by claude_agents_count_busy_workers,
+  #                         which excludes routers named `dispatch-<short-id>`).
+  #   `^office-hours-[0-9]+$` office-hours sessions, renamed to office-hours-<N>
+  #                         in #1311 (the `$` anchor rejects office-hours-12-extra).
+  # Routers (`dispatch-<short-id>`) and job sessions (diagnose-main, jit names)
+  # match NEITHER shape and are excluded. A null/absent `.name` is guarded in jq.
+  # Same UNKNOWN contract as the other machine-wide functions: a `[]` array is a
+  # definite "no live sessions" (return 0, empty output), NOT unknown — only
+  # whitespace/empty raw output is UNKNOWN.
+  #     return 0 — daemon queried successfully. Stdout carries the unique claimed
+  #               <N> values, one per line (empty for `[]` or no matches).
+  #     return 1 — UNKNOWN. Stdout is empty. Callers should fail open (see
+  #               claimed_issue_nums in lib-reservation-ledger.sh).
+  live_session_claimed_nums() {
+    # No --cwd flag and no name filter: the caller needs the machine-wide claimed
+    # set in one query. The raw array comes from the tick snapshot when set, else
+    # a live per-call query (see _claude_agents_raw). 2>/dev/null inside the
+    # helper drops daemon noise; only exit code and a well-formed JSON array on
+    # stdout are trusted.
+    local out
+    if ! out=$(_claude_agents_raw); then
+      return 1
+    fi
+
+    # A zero exit with empty (or whitespace-only) output is unknown too.
+    if [[ -z "${out//[[:space:]]/}" ]]; then
+      return 1
+    fi
+
+    # One jq pass validates the array shape and projects each live name to its
+    # claimed <N> (or `empty` for non-claim names), then `unique` dedups. Using
+    # test()-guarded sub() rather than capture() — capture() on a non-matching
+    # string errors and would abort the whole pass (a false UNKNOWN). Non-array
+    # input errors out and the result is UNKNOWN.
+    local nums
+    if ! nums=$(jq -r '
+      if type == "array"
+      then [ .[]
+        | select(.name | type == "string")
+        | .name
+        | if test("^[0-9]+-") then sub("-.*$"; "")
+          elif test("^office-hours-[0-9]+$") then sub("^office-hours-"; "")
+          else empty end ] | unique | .[]
+      else error("claude agents --json output is not a JSON array")
+      end' <<<"$out" 2>/dev/null); then
+      return 1
+    fi
+    # `[]` or no claim-name matches → empty $nums → emit nothing, still return 0.
+    if [[ -n "$nums" ]]; then
+      printf '%s\n' "$nums"
     fi
     return 0
   }

--- a/.claude/skills/dispatch-propagate/scripts/lib-reservation-ledger.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-reservation-ledger.sh
@@ -26,6 +26,8 @@
 #   reservation_clear   <worktree-basename>
 #   reservation_exists  <worktree-basename>
 #   reservation_count
+#   reserved_claimed_nums
+#   claimed_issue_nums
 #   reservation_sweep
 #
 # reservation_dir
@@ -288,6 +290,74 @@ if [[ -z "${_LIB_RESERVATION_LEDGER_LOADED:-}" ]]; then
     done
     (( had_nullglob )) || shopt -u nullglob
     printf '%s\n' "$count"
+    return 0
+  }
+
+  # reserved_claimed_nums — emit the UNIQUE issue numbers claimed by outstanding
+  # reservation markers, one per line. The durable (reserved) half of selection's
+  # claimed set. Each marker file is named exactly by the reserved worktree
+  # basename (`<N>-slug`), so the claimed number is the basename's numeric prefix
+  # `${bn%%-*}`. Reuses reservation_count's nullglob regular-file scan (the
+  # default glob already excludes the dot-prefixed `.tmp` in-flight tempfiles, so
+  # a concurrent reservation_write is never seen). NEVER fails — no daemon
+  # dependency, so an unresolvable/absent ledger dir emits nothing and returns 0,
+  # matching reservation_count's contract exactly.
+  #     return 0 — always; stdout carries the unique claimed <N> values, one per
+  #               line (empty for an absent/empty ledger).
+  reserved_claimed_nums() {
+    local dir
+    if ! dir=$(reservation_dir) || [[ ! -d "$dir" ]]; then
+      return 0
+    fi
+    local f bn
+    declare -A seen=()
+    # nullglob so a no-match glob expands to nothing rather than the literal
+    # pattern (mirrors reservation_count). Dotfiles (the `.tmp` tempfiles) are
+    # excluded by the default glob.
+    local had_nullglob=0
+    shopt -q nullglob && had_nullglob=1
+    shopt -s nullglob
+    for f in "$dir"/*; do
+      # Count only regular files directly in the dir (no recursion).
+      [[ -f "$f" ]] || continue
+      bn=$(basename "$f")
+      seen["${bn%%-*}"]=1
+    done
+    (( had_nullglob )) || shopt -u nullglob
+    local n
+    for n in "${!seen[@]}"; do
+      printf '%s\n' "$n"
+    done
+    return 0
+  }
+
+  # claimed_issue_nums — emit the DEDUPED union of the claimed issue numbers from
+  # live sessions (live_session_claimed_nums) and outstanding reservation markers
+  # (reserved_claimed_nums), one per line. This is selection's forward-derived
+  # claimed set, replacing the backward worktree walk.
+  #
+  # FAIL OPEN on live-UNKNOWN: live_session_claimed_nums returns 1 when the daemon
+  # is unqueryable. Rather than abort the whole derivation (which would strand
+  # selection), emit a one-line stderr diagnostic and continue with the reserved
+  # set ONLY. The reservation ledger is the durable, daemon-independent record, so
+  # a momentary daemon outage degrades to "reserved-only" rather than failing.
+  #     return 0 — always; stdout carries the deduped union (empty if both halves
+  #               are empty / the live half is UNKNOWN and the ledger is empty).
+  claimed_issue_nums() {
+    local live
+    if ! live=$(live_session_claimed_nums); then
+      printf 'lib-reservation-ledger: claimed_issue_nums — live sessions unqueryable; using reserved set only (fail open)\n' >&2
+      live=""
+    fi
+    local reserved
+    reserved=$(reserved_claimed_nums)
+    # Guard each side so an empty half does not contribute a phantom blank line
+    # that would survive `sort -u`. The `[[ -n ]]` test failing inside the pipe
+    # under pipefail is absorbed by the explicit `return 0` below.
+    {
+      [[ -n "$live" ]] && printf '%s\n' "$live"
+      [[ -n "$reserved" ]] && printf '%s\n' "$reserved"
+    } | sort -u
     return 0
   }
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3021,9 +3021,15 @@ printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help
 printf '[{"number":5500}]\n' > "$STUB_DIR/subissues-55.json"
 printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPEN"}\n' \
   > "$STUB_DIR/issue-5500.json"
-# Sub-issue 5500's worktree exists (owned by another session) → trace 55 exits 2.
+# Sub-issue 5500's worktree exists AND a live session owns it → 5500 is claimed,
+# so trace 55 finds no startable leaf and exits 2. Under #1474 selection derives
+# the claimed set forward from live sessions (live_session_claimed_nums), not a
+# backward worktree walk — so the block must be a genuine live claim, not a bare
+# on-disk worktree (a deregistered worktree no longer counts; daemon-UNKNOWN
+# fails OPEN). The live `5500-blocked` session supplies that claim.
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/5500-blocked\nHEAD def456\nbranch refs/heads/5500-blocked\n\n' \
   > "$STUB_DIR/worktree-list.txt"
+select_target_fake_claude "5500-blocked"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "subtree-blocked issue 55 skipped → issue 66 chosen" "issue 66" "$result"
 teardown
@@ -3039,6 +3045,10 @@ printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPE
   > "$STUB_DIR/issue-5500.json"
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/5500-blocked\nHEAD def456\nbranch refs/heads/5500-blocked\n\n' \
   > "$STUB_DIR/worktree-list.txt"
+# A live session claims 5500 (#1474: forward-derived claimed set). Without it the
+# bare worktree would no longer block, so 55 would resolve to leaf 5500 and the
+# QA-PR fall-through this test exercises would never be reached.
+select_target_fake_claude "5500-blocked"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "subtree-blocked issue 55 → falls through to QA PR" "pr 20 20-qa qa" "$result"
 teardown
@@ -3053,6 +3063,9 @@ printf '{"title":"Issue 5500","body":"","comments":[],"number":5500,"state":"OPE
   > "$STUB_DIR/issue-5500.json"
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/5500-blocked\nHEAD def456\nbranch refs/heads/5500-blocked\n\n' \
   > "$STUB_DIR/worktree-list.txt"
+# A live session claims 5500 (#1474: forward-derived claimed set) so the subtree
+# is genuinely blocked. A bare worktree alone no longer blocks under #1474.
+select_target_fake_claude "5500-blocked"
 result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "subtree-blocked issue 55, no QA PR → empty" "empty" "$result"
 teardown
@@ -4702,12 +4715,16 @@ result=$("$TMPDIR_TEST/dispatch-trace-leaf" "600" "explicit")
 assert_eq "sub-issues chain 600→601 → leaf 601" "601" "$result"
 teardown
 
-# 8. Queue mode: child whose worktree exists and daemon is UNKNOWN (fail-safe → occupied)
-#    is skipped; sibling with no worktree is returned.
-#    The default CLAUDE_AGENTS_CMD points at a non-existent binary so the daemon
-#    is UNKNOWN, which worktree_has_live_session folds into occupied (fail-safe).
-#    Tests 12a/12b cover the true live-vs-orphan distinction.
-echo "Test: queue mode → skips child with worktree (daemon UNKNOWN → occupied), returns sibling"
+# 8. Queue mode: child whose worktree exists but is unclaimed (daemon UNKNOWN, no
+#    reservation marker) is descendable, NOT skipped. Under #1474 the queue-mode
+#    child skip derives from the forward claimed set (claimed_issue_nums), which
+#    FAILS OPEN on a daemon-UNKNOWN: the reserved-only set here is empty, so 701
+#    is unclaimed and the descent returns the lowest leaf 701, not the sibling.
+#    The old worktree-walk folded daemon-UNKNOWN into occupied and skipped 701;
+#    #1474 removed that fold. dispatch-resolve-worktree is the per-target
+#    fail-closed net that still guards a genuine race at launch. Tests 12a/12b
+#    cover the true live-vs-orphan distinction.
+echo "Test: queue mode → child with unclaimed worktree (daemon UNKNOWN) is descendable"
 setup
 # 700 has two open sub-issues: 701 (worktree on disk, daemon unreachable) and 702 (no worktree).
 printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
@@ -4715,11 +4732,11 @@ printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"
   > "$STUB_DIR/issue-701.json"
 printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
   > "$STUB_DIR/issue-702.json"
-# 701's worktree exists; daemon is UNKNOWN (non-existent binary) → fail-safe → occupied.
+# 701's worktree exists; daemon is UNKNOWN (non-existent binary) → fail OPEN → unclaimed.
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\n' \
   > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
-assert_eq "queue: child 701 (daemon UNKNOWN → occupied) skipped → sibling 702" "702" "$result"
+assert_eq "queue: child 701 (daemon UNKNOWN, unclaimed) descendable → leaf 701" "701" "$result"
 teardown
 
 # 9. Explicit mode: conflicted child returned unchanged (no worktree filtering).
@@ -4737,26 +4754,25 @@ result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "explicit")
 assert_eq "explicit: lowest leaf 701 unchanged" "701" "$result"
 teardown
 
-# 10. Queue mode: every child has a worktree and daemon is UNKNOWN (fail-safe → occupied)
-#     → exit 2 with the worktree-conflicted stderr message.
-#     The default CLAUDE_AGENTS_CMD is a non-existent binary; UNKNOWN folds to occupied.
-#     Tests 12c cover the true all-live-owned scenario.
-echo "Test: queue mode → all children have worktrees (daemon UNKNOWN → occupied), exits non-zero"
+# 10. Queue mode: every child has an on-disk worktree but the daemon is UNKNOWN
+#     and no reservation markers exist → the claimed set FAILS OPEN (empty), so
+#     NO child is skipped and the descent returns the lowest startable leaf 701.
+#     Under #1474 a bare worktree no longer blocks descent; the old worktree-walk
+#     folded daemon-UNKNOWN into occupied and exited 2 here. Test 12c covers the
+#     true all-live-owned exit-2 scenario; dispatch-resolve-worktree remains the
+#     per-target fail-closed net at launch.
+echo "Test: queue mode → all children have unclaimed worktrees (daemon UNKNOWN) → lowest leaf"
 setup
 printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
 printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
   > "$STUB_DIR/issue-701.json"
 printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
   > "$STUB_DIR/issue-702.json"
-# Both children's worktrees exist; daemon is UNKNOWN → both treated as occupied.
+# Both children's worktrees exist; daemon is UNKNOWN, ledger empty → fail OPEN → unclaimed.
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/701-feature\nHEAD def456\nbranch refs/heads/701-feature\n\nworktree /worktrees/702-feature\nHEAD ghi789\nbranch refs/heads/702-feature\n\n' \
   > "$STUB_DIR/worktree-list.txt"
-err_out=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
-case "$err_out" in
-  *"worktree-conflicted"*"EXIT="[1-9]*) status="ok" ;;
-  *) status="bad: $err_out" ;;
-esac
-assert_eq "queue: all children occupied (daemon UNKNOWN) → non-zero with stderr message" "ok" "$status"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
+assert_eq "queue: all children unclaimed (daemon UNKNOWN) → lowest leaf 701" "701" "$result"
 teardown
 
 # 11. Missing mode → arity error on stderr, exit 1.
@@ -7912,6 +7928,79 @@ if out=$(claude_agents_list_all); then rc=0; else rc=$?; fi
 assert_eq "list-all non-array: exits 1 (UNKNOWN)" "1" "$rc"
 ca_teardown
 
+# --- live_session_claimed_nums (#1474) ---------------------------------------
+# Selection's forward in-flight claimed half: maps each live-session NAME to its
+# claimed <N>. A phase-worker name `<N>-slug` and an `office-hours-<N>` name each
+# contribute <N>; routers (`dispatch-<short-id>`) and job sessions (diagnose-main,
+# jit names) match neither shape and are excluded. `[]` → empty + rc 0;
+# whitespace/empty raw output → rc 1 (UNKNOWN). Output is uniqued.
+
+# --- Test 30: live_session_claimed_nums — phase-worker <N>-slug → <N> ---------
+echo "Test: live_session_claimed_nums maps a <N>-slug phase worker to <N>"
+ca_setup
+write_fake_claude '[{"sessionId":"s1","pid":1,"status":"busy","name":"42-add-thing"}]' 0
+if out=$(live_session_claimed_nums); then rc=0; else rc=$?; fi
+assert_eq "live-claimed phase-worker: exits 0" "0" "$rc"
+assert_eq "live-claimed phase-worker: <N>-slug → 42" "42" "$out"
+ca_teardown
+
+# --- Test 31: live_session_claimed_nums — office-hours-<N> → <N> --------------
+echo "Test: live_session_claimed_nums maps an office-hours-<N> session to <N>"
+ca_setup
+write_fake_claude '[{"sessionId":"s1","pid":1,"status":"busy","name":"office-hours-77"}]' 0
+if out=$(live_session_claimed_nums); then rc=0; else rc=$?; fi
+assert_eq "live-claimed office-hours: exits 0" "0" "$rc"
+assert_eq "live-claimed office-hours: office-hours-77 → 77" "77" "$out"
+ca_teardown
+
+# --- Test 32: live_session_claimed_nums — router/job names are excluded -------
+echo "Test: live_session_claimed_nums excludes router and job session names"
+ca_setup
+# A router (dispatch-<short-id>), a diagnose-main job, and a jit-style name —
+# none match `^[0-9]+-` or `^office-hours-[0-9]+$`, so none contribute a claim.
+write_fake_claude '[{"sessionId":"s1","pid":1,"status":"busy","name":"dispatch-ab12cd"},{"sessionId":"s2","pid":2,"status":"busy","name":"diagnose-main"},{"sessionId":"s3","pid":3,"status":"busy","name":"digest"}]' 0
+if out=$(live_session_claimed_nums); then rc=0; else rc=$?; fi
+assert_eq "live-claimed router/job: exits 0" "0" "$rc"
+assert_eq "live-claimed router/job: no claims emitted" "" "$out"
+ca_teardown
+
+# --- Test 33: live_session_claimed_nums — empty [] registry → rc 0, no output -
+echo "Test: live_session_claimed_nums returns 0 with empty output for an empty registry"
+ca_setup
+write_fake_claude '[]' 0
+if out=$(live_session_claimed_nums); then rc=0; else rc=$?; fi
+assert_eq "live-claimed empty: exits 0 (definite zero, not UNKNOWN)" "0" "$rc"
+assert_eq "live-claimed empty: no claims emitted" "" "$out"
+ca_teardown
+
+# --- Test 34: live_session_claimed_nums — UNKNOWN on a missing/empty daemon ---
+echo "Test: live_session_claimed_nums returns rc 1 (UNKNOWN) on empty raw output"
+ca_setup
+# A fake that exits 0 but prints nothing → whitespace/empty raw output is UNKNOWN
+# (indistinguishable from a down daemon), so the helper returns 1.
+write_fake_claude '' 0
+if out=$(live_session_claimed_nums); then rc=0; else rc=$?; fi
+assert_eq "live-claimed empty-raw: exits 1 (UNKNOWN)" "1" "$rc"
+assert_eq "live-claimed empty-raw: prints nothing" "" "$out"
+# And a missing binary is UNKNOWN too.
+CLAUDE_AGENTS_CMD="$CA_DIR/no-such-claude"
+if out=$(live_session_claimed_nums); then rc=0; else rc=$?; fi
+assert_eq "live-claimed missing-claude: exits 1 (UNKNOWN)" "1" "$rc"
+ca_teardown
+
+# --- Test 35: live_session_claimed_nums — uniqueness across same-<N> sessions -
+echo "Test: live_session_claimed_nums emits each claimed <N> once across sibling sessions"
+ca_setup
+# Two live sessions on the same <N> (a phase worker and an office-hours session,
+# plus a second <N>-slug) → <N>=10 must appear exactly once; 20 once.
+write_fake_claude '[{"sessionId":"s1","pid":1,"status":"busy","name":"10-a"},{"sessionId":"s2","pid":2,"status":"busy","name":"10-b"},{"sessionId":"s3","pid":3,"status":"busy","name":"office-hours-10"},{"sessionId":"s4","pid":4,"status":"busy","name":"20-c"}]' 0
+if out=$(live_session_claimed_nums); then rc=0; else rc=$?; fi
+assert_eq "live-claimed unique: exits 0" "0" "$rc"
+# Sort the output so the assertion is independent of jq's unique() ordering.
+assert_eq "live-claimed unique: 10 and 20 each once" \
+  "$(printf '10\n20')" "$(printf '%s\n' "$out" | sort -n)"
+ca_teardown
+
 # ============================================================================
 # lib-reservation-ledger.sh tests
 # ============================================================================
@@ -8227,6 +8316,81 @@ assert_eq "rl-exists: empty arg → return 1" "1" "$rc"
 # Unsafe basename → return 1 (path-safety guard).
 if reservation_exists "../escape"; then rc=0; else rc=$?; fi
 assert_eq "rl-exists: unsafe basename → return 1" "1" "$rc"
+rl_teardown
+
+# --- Test 14: reserved_claimed_nums — marker basename <N>-slug → <N> ----------
+# The durable (reserved) half of selection's forward claimed set (#1474). Each
+# marker file is named by the reserved worktree basename; the claimed <N> is the
+# basename's numeric prefix. NEVER fails (no daemon dependency): an empty dir
+# emits nothing + rc 0; an absent dir emits nothing + rc 0.
+echo "Test: reserved_claimed_nums maps marker basenames to their numeric prefix"
+rl_setup
+reservation_write "44-add-thing" "44" "sess-a"
+reservation_write "44-other" "44" "sess-b"
+reservation_write "88-feature" "88" "sess-c"
+if out=$(reserved_claimed_nums); then rc=0; else rc=$?; fi
+assert_eq "rl-claimed: exits 0" "0" "$rc"
+# Two markers share <N>=44 → it appears once; sort for order-independence.
+assert_eq "rl-claimed: unique <N> from basenames (44, 88)" \
+  "$(printf '44\n88')" "$(printf '%s\n' "$out" | sort -n)"
+rl_teardown
+
+# --- Test 15: reserved_claimed_nums — empty ledger dir → empty, rc 0 ----------
+echo "Test: reserved_claimed_nums returns 0 with empty output for an empty ledger dir"
+rl_setup
+mkdir -p "$DISPATCH_RESERVATION_DIR"   # dir exists but holds no markers
+if out=$(reserved_claimed_nums); then rc=0; else rc=$?; fi
+assert_eq "rl-claimed-empty: exits 0" "0" "$rc"
+assert_eq "rl-claimed-empty: no claims emitted" "" "$out"
+rl_teardown
+
+# --- Test 16: reserved_claimed_nums — absent ledger dir → empty, rc 0 ---------
+echo "Test: reserved_claimed_nums returns 0 with empty output when the ledger dir is absent"
+rl_setup
+# rl_setup points DISPATCH_RESERVATION_DIR at a path that does not yet exist.
+if out=$(reserved_claimed_nums); then rc=0; else rc=$?; fi
+assert_eq "rl-claimed-absent: exits 0 (never fails)" "0" "$rc"
+assert_eq "rl-claimed-absent: no claims emitted" "" "$out"
+rl_teardown
+
+# --- Test 17: claimed_issue_nums — deduped union of live + reserved -----------
+# Selection's forward-derived claimed set: the deduped union of
+# live_session_claimed_nums and reserved_claimed_nums. A number present in BOTH
+# halves appears once.
+echo "Test: claimed_issue_nums emits the deduped union of live and reserved claims"
+rl_setup
+# Live sessions claim 10 and 20; reservation markers claim 20 (overlap) and 30.
+rl_write_fake_claude '[{"sessionId":"s1","pid":1,"status":"busy","name":"10-a"},{"sessionId":"s2","pid":2,"status":"busy","name":"20-b"}]'
+reservation_write "20-b" "20" "sess-x"
+reservation_write "30-c" "30" "sess-y"
+if out=$(claimed_issue_nums); then rc=0; else rc=$?; fi
+assert_eq "rl-union: exits 0" "0" "$rc"
+# claimed_issue_nums already sort -u's its output; 20 appears once.
+assert_eq "rl-union: deduped union {10,20,30}" "$(printf '10\n20\n30')" "$out"
+rl_teardown
+
+# --- Test 18: claimed_issue_nums — FAILS OPEN on live-UNKNOWN -----------------
+# When the daemon is unqueryable, live_session_claimed_nums returns 1 (UNKNOWN).
+# claimed_issue_nums must NOT abort; it degrades to the reserved-only set, warns
+# on stderr, and returns 0. (The per-target fail-closed net at launch is
+# dispatch-resolve-worktree.)
+echo "Test: claimed_issue_nums fails open to the reserved-only set on live-UNKNOWN"
+rl_setup
+# A missing claude binary → live_session_claimed_nums returns 1 (UNKNOWN) → the
+# union must degrade to the reserved-only set. Only the reservation marker
+# contributes.
+CLAUDE_AGENTS_CMD="$RL_DIR/no-such-claude"
+reservation_write "55-resv" "55" "sess-z"
+err=$(claimed_issue_nums 2>&1 1>/dev/null)
+out=$(claimed_issue_nums 2>/dev/null) && rc=0 || rc=$?
+assert_eq "rl-union-failopen: exits 0 (fail open, never aborts)" "0" "$rc"
+assert_eq "rl-union-failopen: reserved-only set {55}" "55" "$out"
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$err" | grep -q 'fail open'; then
+  PASS=$((PASS + 1)); echo "  PASS: rl-union-failopen: stderr diagnostic mentions fail open"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: rl-union-failopen: stderr diagnostic mentions fail open"
+fi
 rl_teardown
 
 # ============================================================================
@@ -25349,6 +25513,140 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "#1452 F(b) — priority leaf 940 selected" "issue 940" "$result"
 lo_c=$(grep -c "^950$" "$STUB_DIR/issue-blocking-calls.log" 2>/dev/null || true)
 assert_eq "#1452 F(b) — lower-rank root 950 never traced (early-exit)" "0" "$lo_c"
+teardown
+
+# ============================================================================
+# #1474: selection derives the claimed set FORWARD from live sessions +
+# reservations (claimed_issue_nums), dropping the backward worktree walk.
+# ============================================================================
+# dispatch-select-target and dispatch-trace-leaf no longer build a worktree map
+# and stat each candidate's <N>-* worktree; they build CLAIMED_NUMS once from
+# claimed_issue_nums and skip a candidate when num_is_claimed is true. The skip
+# now keys on the BRANCH-PREFIX <N> (PR loop) and the issue/leaf number, derived
+# from the per-tick live + reservation sets, not from any worktree's existence.
+echo "=== #1474: forward-derived claimed set ==="
+
+# E1. Behavior-equivalence edge — office-hours ownership (select-target, ISSUE).
+#     A live office-hours-<N> session marks <N> claimed, so the <N>-* issue
+#     candidate is skipped — even though office-hours sessions carry no <N>-slug
+#     name and no reservation marker. live_session_claimed_nums' second shape
+#     (^office-hours-[0-9]+$) supplies the claim. Issue 66 (unclaimed) is chosen.
+echo "Test: #1474 E1 — live office-hours-<N> marks issue <N> claimed (select-target)"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":66,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+# No worktrees at all — the claim is purely the live office-hours session.
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+select_target_fake_claude "office-hours-55"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "#1474 E1 — office-hours-55 claims 55 → 66 chosen" "issue 66" "$result"
+teardown
+
+# E1b. Same edge for a PR candidate. A live office-hours-10 session marks the
+#      branch-prefix <N>=10 of PR 10's branch claimed, so PR 10 is skipped and PR
+#      20 is returned. No worktree for either branch — the claim is the live
+#      office-hours session alone.
+echo "Test: #1474 E1b — live office-hours-<N> marks a PR's branch-prefix <N> claimed"
+setup
+UNION='['"$(make_pr_union 10 "10-active-branch" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"','"$(make_pr_union 20 "20-other" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP")"']'
+setup_union_pr_list "$UNION"
+echo '[]' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' > "$STUB_DIR/worktree-list.txt"
+select_target_fake_claude "office-hours-10"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "#1474 E1b — office-hours-10 claims 10 → PR 20 returned" "pr 20 20-other fix-checks" "$result"
+teardown
+
+# E1c. Same edge for a dispatch-trace-leaf queue child. A live office-hours-701
+#      session marks child 701 claimed, so the descent skips it and returns the
+#      sibling 702 — with NO worktree on disk for either child.
+echo "Test: #1474 E1c — live office-hours-<N> marks a trace-leaf queue child claimed"
+setup
+printf '[{"number":701},{"number":702}]\n' > "$STUB_DIR/subissues-700.json"
+printf '{"title":"Issue 701","body":"","comments":[],"number":701,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-701.json"
+printf '{"title":"Issue 702","body":"","comments":[],"number":702,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-702.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+select_target_fake_claude "office-hours-701"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "700" "queue")
+assert_eq "#1474 E1c — office-hours-701 claims 701 → sibling 702" "702" "$result"
+teardown
+
+# E2. Behavior-equivalence edge #2 + acceptance criterion #4 — a live ^[0-9]+-
+#     session with NO worktree registered marks <N> claimed and the candidate is
+#     skipped. The worktree-list stub is EMPTY (only the main /repo row), so the
+#     old worktree walk would have found nothing to stat and would NOT have
+#     skipped 55. This single test proves two things at once:
+#       (a) the worktree walk is gone — selection's claim is independent of how
+#           many worktrees are registered, so its per-tick latency no longer
+#           scales with the worktree count; and
+#       (b) the deliberate new skip of a deregistered-worktree live session — a
+#           worker whose worktree was removed but whose session is still live now
+#           correctly marks its <N> claimed (the old walk missed it).
+echo "Test: #1474 E2 — live <N>-slug session with no registered worktree marks <N> claimed"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":66,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+# EMPTY worktree list (only the main repo row). No <N>-* worktree exists at all.
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' > "$STUB_DIR/worktree-list.txt"
+# A live phase-worker named 55-feature whose worktree is NOT registered.
+select_target_fake_claude "55-feature"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "#1474 E2 — deregistered-worktree live 55 still claimed → 66 chosen" "issue 66" "$result"
+teardown
+
+# E3. UNKNOWN fail-open — a daemon-UNKNOWN snapshot with NO reservation for the
+#     candidate means the candidate is NOT skipped: it is SELECTED. This pins the
+#     chosen behavior: the forward claimed set fails OPEN (claimed_issue_nums
+#     degrades to the reserved-only set on live-UNKNOWN), trading a rare
+#     double-spawn race for never stranding the queue on a transient daemon
+#     outage. The per-target fail-CLOSED net is dispatch-resolve-worktree, which
+#     re-checks liveness at launch and aborts a genuine collision. Here the
+#     default setup CLAUDE_AGENTS_CMD is a missing binary (UNKNOWN) and the ledger
+#     is empty, so issue 55 (with an on-disk worktree to make the old walk skip
+#     it) is selected anyway.
+echo "Test: #1474 E3 — UNKNOWN daemon + no reservation → candidate NOT skipped (fail open)"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+# 55 has an on-disk worktree — the OLD worktree walk (with UNKNOWN folded to
+# occupied) would have skipped it. The default setup daemon is UNKNOWN and no
+# reservation marker exists, so the new fail-open path leaves 55 unclaimed.
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/55-feature\nHEAD def456\nbranch refs/heads/55-feature\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+# No select_target_fake_claude call: the default UNKNOWN daemon stands.
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "#1474 E3 — UNKNOWN + no reservation → 55 selected (fail open)" "issue 55" "$result"
+teardown
+
+# E4. Snapshot-set zero-daemon-call — a selection run with DISPATCH_AGENTS_SNAPSHOT
+#     set makes ZERO live `claude agents` daemon calls: the claimed set derives
+#     entirely from the inherited per-tick snapshot. The select_target_fake_claude
+#     fake logs every live `agents` invocation to stub/claude-agents-calls.log;
+#     this asserts that log stays empty across the run. (Complements #1452 B,
+#     which proves the same for the worktree-liveness predicate; #1474 routes the
+#     whole claimed-set derivation through the same snapshot.)
+echo "Test: #1474 E4 — snapshot-backed selection makes zero live claude agents calls"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":55,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":66,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+# Install the logging fake, then point the tick snapshot at a payload that claims
+# 55 via a live office-hours session. The fake must NOT be invoked: every
+# claimed-set read comes from the snapshot file.
+select_target_fake_claude   # installs the logging fake (orphan [] payload, unused)
+snap="$TMPDIR_TEST/agents-snapshot.json"
+printf '[{"sessionId":"s1","pid":1,"status":"busy","name":"office-hours-55","cwd":""}]' > "$snap"
+export DISPATCH_AGENTS_SNAPSHOT="$snap"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "#1474 E4 — snapshot claims 55 → 66 selected" "issue 66" "$result"
+calls=$([[ -f "$STUB_DIR/claude-agents-calls.log" ]] && wc -l < "$STUB_DIR/claude-agents-calls.log" | tr -d ' ' || echo 0)
+assert_eq "#1474 E4 — zero live claude agents calls during selection" "0" "$calls"
 teardown
 
 # ============================================================================


### PR DESCRIPTION
Closes #1474

## Summary

Inverts dispatch selection's liveness data flow. Selection no longer enumerates
every registered git worktree to decide which queue items are "already in
flight." Instead it derives the claimed-issue-number set **forward** from two
small in-flight sets — live session names and reservation-ledger markers — and
consults a worktree only post-selection, for the single chosen target, via
`dispatch-resolve-worktree`.

Selection becomes O(worker cap), not O(worktrees). Its latency decouples from
worktree count (286 today, #1451), reframing that GC backlog as a pure-disk
concern. Builds on #1479, which made the per-tick scan reuse one
`claude agents --json` snapshot.

## What changed

- **`lib-claude-agents.sh`** — adds `live_session_claimed_nums`: reads the
  per-tick snapshot and emits the unique `<N>` from session names matching
  `^[0-9]+-` (phase workers `<N>-slug`) or `^office-hours-[0-9]+$` (office-hours
  sessions). Routers and job sessions match neither and are excluded. `[]` → empty
  output, return 0; UNKNOWN daemon → return 1.
- **`lib-reservation-ledger.sh`** — adds `reserved_claimed_nums` (unique `<N>`
  from marker basenames) and the convenience union `claimed_issue_nums`, which
  **fails open** on live-UNKNOWN: continues with the reserved set only and a
  one-line stderr diagnostic.
- **`dispatch-select-target`** — builds the claimed set once from
  `claimed_issue_nums` behind a `num_is_claimed` predicate; deletes the
  worktree-map build and the four worktree-walk helpers. The PR-skip and
  issue-skip now share one `<N>`-keyed predicate.
- **`dispatch-trace-leaf`** — same inversion for the queue-mode child skip; the
  descent-loop and root skip points are preserved (not folded into `--exclude`).
  The `dispatch:office-hours`-parked label check stays distinct.
- **`test-dispatch-scripts.sh`** — helper-unit tests for the new functions, plus
  integration tests for the two deliberate behavior edges and UNKNOWN fail-open
  (see below). Suite green at 2422/2422.

## Deliberate behavior changes (not byte-identical to the old walk)

1. **PR liveness now keys on the branch prefix**, not the exact branch worktree
   path. A live `10-foo` session now also marks a `10-bar` PR's `<N>=10` claimed.
   This is the safe, more-conservative-skip direction.
2. **A live `<N>-*` session whose worktree was deregistered now marks `<N>`
   claimed.** The old walk silently ignored it (empty worktree map → not skipped
   → a second worker). The new design fixes that in the snapshot-present case.
3. **UNKNOWN daemon → fail open** (empty live set; reserved set still applies).
   `dispatch-resolve-worktree` remains the authoritative fail-closed per-target
   net, re-checking the single chosen target and emitting `conflict` on UNKNOWN.
   Fail-closed would starve the fleet (#1450, "fleet sawtooths below target").

The lib helpers `list_worktree_records` / `split_worktree_record` stay — they are
still used by `dispatch-resolve-worktree`, `dispatch-sweep`, and
`office-hours-select-target` for post-selection work. This change removes only the
two selection-path callers.

## Verification

- Full suite: `bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` → 2422/2422.
- `grep 'WORKTREE_PATH_BY_BRANCH\|WORKTREE_PATHS_BY_NUM\|list_worktree_records' dispatch-select-target dispatch-trace-leaf` → no matches.
- Same grep across the tree still shows the helpers in `lib.sh`,
  `dispatch-resolve-worktree`, `dispatch-sweep`, `office-hours-select-target`.
