### PR TITLE
ci: anchor prod-deploy DIFF_BASE to last successfully deployed commit

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/run-all-prod-deploy-smoke.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-all-prod-deploy-smoke.sh
@@ -7,14 +7,16 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 # shellcheck source=lib.sh
 source "$SCRIPT_DIR/lib.sh"
 
-# The workflow checks out github.sha and passes DIFF_BASE=github.event.before, so
-# change detection diffs the merge's own before...sha range, deterministic
-# regardless of run order.
-# DEPLOY_ALL=1 deploys every app with a hosting target (for workflow_dispatch).
+# The workflow resolves DIFF_BASE from the last-prod-deploy marker (the last
+# successfully deployed commit), so change detection diffs from there. A dropped
+# intermediate run is recovered by the next successful run, which re-covers the
+# missed window.
+# DEPLOY_ALL=1 deploys every app with a hosting target; the workflow sets it for
+# workflow_dispatch and for the first-run bootstrap when no marker exists yet.
 if [ "${DEPLOY_ALL:-}" = "1" ]; then
   CHANGED_APPS=$("$SCRIPT_DIR/get-changed-apps.sh" --all)
 else
-  : "${DIFF_BASE:?DIFF_BASE required (set to github.event.before) for change detection}"
+  : "${DIFF_BASE:?DIFF_BASE required (set from the last-prod-deploy marker) for change detection}"
   CHANGED_APPS=$("$SCRIPT_DIR/get-changed-apps.sh" --base "$DIFF_BASE")
 fi
 

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -27,6 +27,8 @@ jobs:
     concurrency:
       group: prod-deploy
       cancel-in-progress: false
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -40,6 +42,21 @@ jobs:
         env:
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
         run: .github/scripts/firebase-auth.sh
+      - name: Resolve deploy base
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "workflow_dispatch: deploying all apps"
+            echo "DEPLOY_ALL=1" >> "$GITHUB_ENV"
+          else
+            SHA=$(git ls-remote origin refs/tags/last-prod-deploy | cut -f1)
+            if [ -n "$SHA" ]; then
+              echo "Diffing from last-prod-deploy ($SHA)"
+              echo "DIFF_BASE=$SHA" >> "$GITHUB_ENV"
+            else
+              echo "No last-prod-deploy tag on origin; bootstrapping with full deploy"
+              echo "DEPLOY_ALL=1" >> "$GITHUB_ENV"
+            fi
+          fi
       - name: Deploy to production and run smoke tests
         env:
           GA_MEASUREMENT_ID_AUDIO: ${{ secrets.GA_MEASUREMENT_ID_AUDIO }}
@@ -51,9 +68,12 @@ jobs:
           VITE_RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          DEPLOY_ALL: ${{ github.event_name == 'workflow_dispatch' && '1' || '' }}
-          DIFF_BASE: ${{ github.event.before }}
         run: .claude/skills/dispatch-propagate/scripts/run-all-prod-deploy-smoke.sh
+      - name: Record last-prod-deploy marker
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git tag -f last-prod-deploy "$GITHUB_SHA"
+          git push -f origin refs/tags/last-prod-deploy
       - name: Cleanup credentials
         if: always()
         run: .github/scripts/firebase-auth-cleanup.sh

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -70,7 +70,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: .claude/skills/dispatch-propagate/scripts/run-all-prod-deploy-smoke.sh
       - name: Record last-prod-deploy marker
-        if: github.ref == 'refs/heads/main'
+        if: success() && github.ref == 'refs/heads/main'
         run: |
           git tag -f last-prod-deploy "$GITHUB_SHA"
           git push -f origin refs/tags/last-prod-deploy


### PR DESCRIPTION
Closes #1446

## Problem

`.github/workflows/prod-deploy.yml` serializes production deploys with a
`prod-deploy` concurrency group and `cancel-in-progress: false`. That protects an
in-progress deploy, but GitHub still evicts any *pending* run when a newer one
queues. In a merge burst (A deploying; B then C landing while A runs), B is
queued then cancelled by C. Because each run's diff base was its own
`github.event.before`, the surviving run C deployed only `B.sha...C.sha` — the
range `A.sha...B.sha` (B's changes) was deployed by nobody. Apps changed only in
that dropped window silently skipped production until a later push happened to
touch them again.

The root cause is the per-push `before...sha` diff base: each run was responsible
only for its own push window, so a dropped run permanently skipped its window.

## Fix

Anchor the diff base to the **last successfully deployed commit**, recorded as a
force-updated `last-prod-deploy` git tag written by the workflow after a
successful run. Each run diffs `last-prod-deploy...HEAD`, so a dropped
intermediate run is automatically recovered by the next run that completes
successfully. `cancel-in-progress: false` is preserved — cancelling a mid-flight
deploy risks a half-deployed state.

### Changes to the `deploy-and-smoke` job (`prod-deploy.yml`)

- **Resolve deploy base** step (new, before the deploy step): for a
  `workflow_dispatch` run, deploy all apps; otherwise look up the marker on the
  remote with `git ls-remote origin refs/tags/last-prod-deploy` and set
  `DIFF_BASE` to that SHA. When the tag is absent on origin (the first run after
  this ships, and only then), bootstrap with a full deploy — a legitimate
  first-run state, not an error, and the safest bootstrap since it skips no app.
  The remote lookup is deliberate: `actions/checkout@v4` with `fetch-depth: 0`
  does not necessarily fetch the tag *ref* (`fetch-tags` defaults false), so a
  local `rev-parse` could silently miss it and degrade the workflow to
  deploy-all forever while staying green. The marker's *commit* is already in
  local history, so the diff works without the ref.
- **Removed** the inline `DEPLOY_ALL`/`DIFF_BASE` step-`env:` entries — a
  step-level `env:` key shadows anything a prior step writes to `$GITHUB_ENV`, so
  these had to go for the resolve step's output to take effect. Every secret env
  entry is untouched.
- **Record last-prod-deploy marker** step (new, after the deploy step): force-tags
  `last-prod-deploy` at `$GITHUB_SHA` and pushes it. No `if: always()`, so it runs
  only when the deploy step succeeded — a per-app deploy/smoke failure leaves the
  marker put and the next run idempotently re-diffs from the old marker.
  `if: github.ref == 'refs/heads/main'` prevents a non-main `workflow_dispatch`
  from poisoning the marker.
- **`permissions: contents: write`** at the job level so the tag push works with
  the persisted `GITHUB_TOKEN` (precedent: `budget-etl-release.yml`). The
  workflow-level `contents: read` stays, keeping `cleanup-preview` read-only.

### `run-all-prod-deploy-smoke.sh`

Comment-only: synced the explanatory comment and the `DIFF_BASE` guard's error
message to the new marker-based contract. The `DEPLOY_ALL`/`DIFF_BASE` control
flow is unchanged — only how those vars are populated (in the workflow) changed.

## Verification

No actionlint config or local workflow/script test harness exercises this path,
so end-to-end coverage cannot run locally; CI on this PR plus the first
post-merge run are authoritative. Verified locally: YAML well-formedness and
step-indentation of `prod-deploy.yml`, and the marker query
(`git ls-remote origin refs/tags/last-prod-deploy` returns empty today — the
bootstrap case).

**Note for whoever watches the first production deploy after merge:** it takes
the bootstrap deploy-all path because no `last-prod-deploy` tag exists yet — this
is expected, not a regression. That run creates the tag; every subsequent run
diffs from it.

Out of scope for #1422 (which fixed the double-trigger and nondeterministic diff
base); this is the follow-up #1422 deferred.
