### PR TITLE
dispatch-input-block: short read timeout so the hook never stalls 1s

### DIFF
--- a/.claude/hooks/dispatch-input-block.sh
+++ b/.claude/hooks/dispatch-input-block.sh
@@ -51,11 +51,12 @@ if ! [[ "$JOB_NAME" =~ ^[0-9]+- ]]; then
   exit 0
 fi
 
-# Consume the payload (defensive — some events pass JSON on stdin). Only
-# worker jobs reach this point; we read so the Notification filter below can
-# act. Read with a timeout so a wired event without stdin doesn't hang.
+# Consume any buffered single-line JSON payload fast. Short timeout so an
+# open, idle stdin (hook events never close stdin at EOF) returns quickly
+# rather than stalling for a full second. -r keeps backslashes in JSON intact
+# so the downstream jq parse cannot be corrupted.
 PAYLOAD=""
-if read -t 1 -d '' PAYLOAD; then :; fi
+if read -rt 0.1 PAYLOAD; then :; fi
 
 # Notification self-filter: only act on permission_prompt notifications.
 # Other notification_type values (e.g. session_complete) reach this hook and

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -14907,6 +14907,17 @@ if [[ "$rc" -ne 124 ]]; then
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: open-stdin: hook was killed at 0.5s — read is still stalling"
 fi
+# Correctness: the payload must have been read and acted on — not merely
+# timed out empty (which would bypass the notification filter and park by
+# accident rather than by correct payload parsing). Mirror Test 1's check.
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$apply_log" == *123* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: open-stdin: dispatch-apply-office-hours invoked with issue 123 (payload was read and acted on)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: open-stdin: dispatch-apply-office-hours invoked with issue 123 (payload was read and acted on)"
+  echo "    apply-log: $apply_log"
+fi
 ib_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -14891,6 +14891,24 @@ else
 fi
 ib_teardown
 
+# --- Test 8: open, non-newline stdin → no 1s stall (regression for #1491) ---
+
+echo "Test: open non-newline stdin → hook returns fast (no read stall)"
+ib_setup
+echo '{"name":"123-foo"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+timeout 0.5 "$TMPDIR_TEST/hooks/dispatch-input-block.sh" \
+  < <(printf '%s' '{"notification_type":"permission_prompt"}'; sleep 1) \
+  >/dev/null 2>&1
+rc=$?
+TOTAL=$((TOTAL + 1))
+if [[ "$rc" -ne 124 ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: open-stdin: hook completed before the 0.5s timeout (no 1s read stall)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: open-stdin: hook was killed at 0.5s — read is still stalling"
+fi
+ib_teardown
+
 # ============================================================================
 # dispatch-office-hours-strip hook tests
 # ============================================================================


### PR DESCRIPTION
Closes #1491

## Problem

`.claude/hooks/dispatch-input-block.sh` consumed the hook payload with:

```bash
if read -t 1 -d '' PAYLOAD; then :; fi
```

`-d ''` sets the read delimiter to NUL (`\x00`). JSON hook payloads never
contain NUL, so on a stdin that stays open the `read` always runs the full
1-second timeout. The hook is wired (`.claude/settings.json`) to three
worker-blocking events — `PreToolUse` (ExitPlanMode / AskUserQuestion),
`Notification` (permission_prompt), and `Elicitation` — so every firing in every
`<N>-`slug worker session paid a guaranteed ~1-second stall. The defect
pre-existed PR #1457; #1457 only made it more visible.

## Fix

Replace the read with:

```bash
if read -rt 0.1 PAYLOAD; then :; fi
```

- **Newline delimiter** (the issue's "or equivalent") returns instantly when a
  newline-terminated payload arrives.
- **0.1 s timeout** caps the wait on an *open, idle* stdin at an imperceptible
  0.1 s. This matters because stdin is left **open** (not EOF-closed) for these
  events — the very existence of the 1-second stall proves it — and whether the
  payload is newline-terminated is undocumented. A plain `read -t 1 PAYLOAD`
  removes the stall only in the newline-terminated case; the short timeout
  sidesteps that undocumented assumption and kills the stall in **every** case.
- **`-r`** keeps backslashes in the JSON intact so the downstream `jq` parse
  cannot be corrupted.

Both knobs — newline delimiter and a shorter timeout — are options the issue
author explicitly listed, so this honors the issue's intent more reliably than
its literal primary suggestion. The `if read …; then :; fi` wrapper and the
downstream `notification_type` filter are unchanged.

## Regression test

Adds one test to the `=== dispatch-input-block ===` section of
`test-dispatch-scripts.sh` asserting the hook does **not** stall on an **open,
non-newline-terminated** stdin — the dimension every existing test missed (all
prior invocations use `< /dev/null` or `printf … | hook`, both reaching EOF
immediately, so none could distinguish the buggy `-d ''` / a `-t 1` regression
from the fix). The old code is killed by a `timeout 0.5` (rc 124 → FAIL); the
fixed code returns in ~0.1 s (rc 0 → PASS).

## Verification

- Behavioral micro-check: `read -rt 0.1 P` on an open non-newline stdin returns
  in ~0.1 s (was ~1.0 s).
- Full `test-dispatch-scripts.sh` suite passes, including the existing
  input-block Tests 1–7 (permission_prompt-acts, session_complete-passes-through)
  and the new open-stdin regression test.

## Out of scope

Two sibling hooks carry the same `read -t 1 -d ''` pattern —
`dispatch-stop.sh` and `dispatch-office-hours-strip.sh`. They fire on different
events whose stdin lifecycles were not verified here, so they are deliberately
left untouched (#1491 names only `dispatch-input-block.sh`). They are a
candidate for a separate follow-up.
