### PR TITLE
dispatch tests: roadmap jit within-window skip and open-issue guard cases

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -13629,6 +13629,51 @@ else
 fi
 jit_teardown
 
+# --- Test 3-roadmap: roadmap jit (7d/14d) within window — skipped, no issue created ---
+
+echo "Test: dispatch-jit-engine roadmap jit within remindAfterClose is skipped"
+jit_setup
+jit_write_projects
+cat > "$TMPDIR_TEST/config/jit.json" <<'EOF'
+{
+  "jits": [
+    {
+      "key": "roadmap",
+      "repo": "test-owner/test-repo",
+      "label": "jit:roadmap",
+      "title": "Roadmap review",
+      "body": "Recurring roadmap review.",
+      "project": "test-project",
+      "remindAfterClose": "7d",
+      "dueAfterClose": "14d",
+      "skill": "roadmap"
+    }
+  ]
+}
+EOF
+# Newest closed issue closed 5d before "now" — within the 7d window.
+closed_at=$(date -u -d "@$((JIT_NOW_EPOCH - 5*86400))" +%Y-%m-%dT%H:%M:%SZ)
+printf '[{"number":40,"closedAt":"%s"}]\n' "$closed_at" \
+  > "$STUB_DIR/closed-issues.json"
+rc=0
+out=$("$TMPDIR_TEST/scripts/dispatch-jit-engine" 2>/dev/null) || rc=$?
+assert_eq "roadmap within-window exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$out" == *"roadmap: skipped (within remindAfterClose)"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: roadmap within-window reports skipped (within remindAfterClose)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: roadmap within-window reports skipped (within remindAfterClose)"
+  echo "    actual: $out"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -f "$STUB_DIR/gh-issue-create.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: roadmap within-window made no issue create call"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: roadmap within-window made no issue create call"
+  echo "    gh-issue-create.log: $(cat "$STUB_DIR/gh-issue-create.log")"
+fi
+jit_teardown
+
 # --- Test 4: cadence past window creates an issue ----------------------------
 
 echo "Test: dispatch-jit-engine cadence past remindAfterClose creates an issue"
@@ -13760,6 +13805,48 @@ if [[ ! -f "$STUB_DIR/gh-issue-create.log" ]]; then
   PASS=$((PASS + 1)); echo "  PASS: open-guard made no issue create call"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: open-guard made no issue create call"
+  echo "    gh-issue-create.log: $(cat "$STUB_DIR/gh-issue-create.log")"
+fi
+jit_teardown
+
+# --- Test 5-roadmap: roadmap jit (7d/14d) open-issue guard — skipped when an open issue exists ---
+
+echo "Test: dispatch-jit-engine roadmap jit skips when an open issue with the label exists"
+jit_setup
+jit_write_projects
+cat > "$TMPDIR_TEST/config/jit.json" <<'EOF'
+{
+  "jits": [
+    {
+      "key": "roadmap",
+      "repo": "test-owner/test-repo",
+      "label": "jit:roadmap",
+      "title": "Roadmap review",
+      "body": "Recurring roadmap review.",
+      "project": "test-project",
+      "remindAfterClose": "7d",
+      "dueAfterClose": "14d",
+      "skill": "roadmap"
+    }
+  ]
+}
+EOF
+echo '[{"number":50}]' > "$STUB_DIR/open-issues.json"
+rc=0
+out=$("$TMPDIR_TEST/scripts/dispatch-jit-engine" 2>/dev/null) || rc=$?
+assert_eq "roadmap open-guard exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$out" == *"roadmap: skipped (open issue exists)"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: roadmap open-guard reports skipped (open issue exists)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: roadmap open-guard reports skipped (open issue exists)"
+  echo "    actual: $out"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -f "$STUB_DIR/gh-issue-create.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: roadmap open-guard made no issue create call"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: roadmap open-guard made no issue create call"
   echo "    gh-issue-create.log: $(cat "$STUB_DIR/gh-issue-create.log")"
 fi
 jit_teardown


### PR DESCRIPTION
Closes #1221

## What

Adds two `dispatch-jit-engine` test cases that exercise the **roadmap jit's
day-unit cadence** (`remindAfterClose: 7d` / `dueAfterClose: 14d`,
`skill: roadmap`):

- **Test 3-roadmap** — newest closed `jit:roadmap` issue closed 5d ago (within
  the 7d window) → engine reports `roadmap: skipped (within remindAfterClose)`
  and makes no issue-create call.
- **Test 5-roadmap** — an open `jit:roadmap` issue already exists → engine
  reports `roadmap: skipped (open issue exists)` and makes no issue-create call.

## Why

The roadmap jit (added by #771, merged as PR #1193) previously had cadence
coverage only for cold-start (Test 2-roadmap) and steady-state past-window
creation (Test 4-roadmap). The within-`remindAfterClose` skip and the
open-issue guard were covered only for the general 12h **hour-unit** cadence
(Tests 3 and 5). These new day-unit (`7d`/`14d`) cases catch parsing
regressions specific to the day-unit cadence that the hour-unit tests would not
detect. Deferred from PR #1193 review.

## Structure

Each new test mirrors its hour-unit sibling — Test 3-roadmap mirrors Test 3,
Test 5-roadmap mirrors Test 5 — reusing the existing `jit_setup` /
`jit_write_projects` / `jit_teardown` / `assert_eq` helpers and the
`JIT_NOW_EPOCH` constant, and copying the roadmap `jit.json` config block
verbatim from Test 2-roadmap. No new helpers introduced.

## Verification

`test-dispatch-scripts.sh` passes with the four new assertions and no
regressions: `Results: 2407/2407 passed, 0 failed`.
