### PR TITLE
office-hours: list-query test coverage + array-contains comment for the items rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -488,6 +488,9 @@ service cloud.firestore {
     // Office Hours reminders are the synced JIT queue, scoped to the owner via a
     // denormalized `memberEmails` field. Client writes are denied; only the
     // Admin-SDK sync Function (functions/src/office-hours-sync.ts) writes here.
+    // Because the read rule references resource.data.memberEmails, a list query
+    // (getDocs) must include where("memberEmails", "array-contains", <email>);
+    // Firestore rejects unfiltered list queries even when every document would pass.
     match /office-hours/{env}/items/{itemId} {
       allow read: if request.auth != null
         && request.auth.token.email in resource.data.memberEmails;

--- a/rules-test/test/firestore/office-hours.test.ts
+++ b/rules-test/test/firestore/office-hours.test.ts
@@ -135,14 +135,19 @@ describe("office-hours items", () => {
     );
   });
 
-  it("denies non-member list query on items collection", async () => {
+  // A non-member cannot list another member's items: filtering for an email
+  // they are not in is denied, because the matching docs carry a memberEmails
+  // the requester is absent from. (A self-targeted array-contains filter is
+  // always rule-compliant and returns an empty set, so it is not a denial
+  // case.)
+  it("denies authenticated non-member list query for another member's items", async () => {
     const ctx = authenticatedContext(env, "stranger@test.com");
     const db = ctx.firestore();
     await assertFails(
       getDocs(
         query(
           collection(db, `office-hours/${ENV}/items`),
-          where("memberEmails", "array-contains", "stranger@test.com"),
+          where("memberEmails", "array-contains", "owner@test.com"),
         ),
       ),
     );
@@ -291,14 +296,19 @@ describe("office-hours usage-samples", () => {
     );
   });
 
-  it("denies non-member list query on test-env collection", async () => {
+  // A non-member cannot list another member's samples: filtering for an email
+  // they are not in is denied, because the matching docs carry a memberEmails
+  // the requester is absent from. (A self-targeted array-contains filter is
+  // always rule-compliant and returns an empty set, so it is not a denial
+  // case.)
+  it("denies authenticated non-member list query for another member's samples", async () => {
     const ctx = authenticatedContext(env, "stranger@test.com");
     const db = ctx.firestore();
     await assertFails(
       getDocs(
         query(
           collection(db, `office-hours/${ENV}/usage-samples`),
-          where("memberEmails", "array-contains", "stranger@test.com"),
+          where("memberEmails", "array-contains", "owner@test.com"),
         ),
       ),
     );

--- a/rules-test/test/firestore/office-hours.test.ts
+++ b/rules-test/test/firestore/office-hours.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeAll, beforeEach } from "vitest";
+import { describe, it, beforeAll, beforeEach, expect } from "vitest";
 import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
 import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
 import {
@@ -164,6 +164,24 @@ describe("office-hours items", () => {
         ),
       ),
     );
+  });
+
+  // Documents the non-obvious converse of the denial above: a non-member's
+  // self-targeted filter is rule-compliant and succeeds, returning an empty
+  // set rather than being denied. This guards against re-introducing the
+  // false "self-targeted non-member filter is denied" assumption.
+  it("allows authenticated non-member self-targeted list query (returns empty)", async () => {
+    const ctx = authenticatedContext(env, "stranger@test.com");
+    const db = ctx.firestore();
+    const snap = await assertSucceeds(
+      getDocs(
+        query(
+          collection(db, `office-hours/${ENV}/items`),
+          where("memberEmails", "array-contains", "stranger@test.com"),
+        ),
+      ),
+    );
+    expect(snap.empty).toBe(true);
   });
 });
 

--- a/rules-test/test/firestore/office-hours.test.ts
+++ b/rules-test/test/firestore/office-hours.test.ts
@@ -117,7 +117,7 @@ describe("office-hours items", () => {
   it("allows owner list query on items collection", async () => {
     const ctx = authenticatedContext(env, "owner@test.com");
     const db = ctx.firestore();
-    await assertSucceeds(
+    const snap = await assertSucceeds(
       getDocs(
         query(
           collection(db, `office-hours/${ENV}/items`),
@@ -125,6 +125,7 @@ describe("office-hours items", () => {
         ),
       ),
     );
+    expect(snap.empty).toBe(false);
   });
 
   it("denies unfiltered owner list query on items collection", async () => {

--- a/rules-test/test/firestore/office-hours.test.ts
+++ b/rules-test/test/firestore/office-hours.test.ts
@@ -113,6 +113,53 @@ describe("office-hours items", () => {
       }),
     );
   });
+
+  it("allows owner list query on items collection", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(db, `office-hours/${ENV}/items`),
+          where("memberEmails", "array-contains", "owner@test.com"),
+        ),
+      ),
+    );
+  });
+
+  it("denies unfiltered owner list query on items collection", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(collection(db, `office-hours/${ENV}/items`)),
+    );
+  });
+
+  it("denies non-member list query on items collection", async () => {
+    const ctx = authenticatedContext(env, "stranger@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(
+        query(
+          collection(db, `office-hours/${ENV}/items`),
+          where("memberEmails", "array-contains", "stranger@test.com"),
+        ),
+      ),
+    );
+  });
+
+  it("denies unauthenticated list query on items collection", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(
+        query(
+          collection(db, `office-hours/${ENV}/items`),
+          where("memberEmails", "array-contains", "owner@test.com"),
+        ),
+      ),
+    );
+  });
 });
 
 describe("office-hours usage-samples", () => {


### PR DESCRIPTION
Closes #1117

## What

Completes the test coverage and documentation that PR #1107 (#778) deliberately
left out of scope for the `office-hours/{env}/items` collection:

1. **`firestore.rules`** — documents on the `match /office-hours/{env}/items/{itemId}`
   comment block that, because the read rule references `resource.data.memberEmails`,
   a list query (`getDocs`) must carry a matching
   `where("memberEmails", "array-contains", <viewer-email>)` filter. An unfiltered
   list query is rejected by the rules engine even when every document would satisfy
   the per-document condition. The wording mirrors the existing landing/groups
   list-query comment.

2. **`rules-test/test/firestore/office-hours.test.ts`** — adds four list-query tests
   to the `office-hours items` describe block, mirroring the existing
   `office-hours usage-samples` list-query pattern and reusing the block's `jit-demo`
   seed doc:
   - owner array-contains-filtered list query **succeeds**;
   - **unfiltered** owner list query is **denied** (the rules-engine constraint the
     usage-samples block does not cover);
   - authenticated non-member list query **for another member's items is denied**;
   - unauthenticated list query is **denied**;
   - authenticated non-member **self-targeted** filter **succeeds and returns an
     empty set** — a positive test documenting the non-obvious converse, so the
     false "self-targeted non-member filter is denied" assumption (below) can't be
     silently re-introduced.

## Deviation from the persisted plan (ratified)

The plan's third case asserted that a non-member's **self-targeted** filter
(`array-contains "stranger@test.com"` authed as `stranger@test.com`) is denied.
The emulator showed it **succeeds** — and so does the rule: a self-targeted
`array-contains` filter is tautologically rule-compliant (every doc it could
return has the requester in `memberEmails`), so the engine permits it and it
returns an empty set. The meaningful denial is a non-member filtering for
**another** member's email, which is what the corrected case 3 now asserts.

The plan inherited this false expectation by mirroring the pre-existing
`usage-samples` test added in #1184, which asserts the same false invariant.
Because `rules-test` runs in **no CI job**, that test had never run red. This PR
therefore also corrects the `usage-samples` `denies non-member list query`
assertion (one line + a clarifying comment) so the whole suite is green. This is
a scope expansion beyond the issue's stated items-only scope — flagging #1184
here so a human can ratify the change and note that a merged test asserted a
false security invariant.

The author has ratified both calls: permit-empty is the intended model (the
test was wrong, the rule stays), and the #1184 usage-samples correction stays in
this PR.

## Why

The owner's due-sorted reminder list view (#780) issues the filtered list query this
rule must permit. These tests lock in that the rule permits the filtered owner list
query and rejects every other shape, and the comment prevents future readers from
writing an unfiltered `getDocs` the rules engine would reject.

## Verification

`firestore.rules` is comment-only (no condition changes). The `rules-test` suite is
not run by any CI job, so it was run manually against the Firestore emulator:
`npm test --prefix rules-test` (firestore+storage emulator) — **all 305 tests pass**
(17 files), including the five new `office-hours items` list-query tests and the
corrected `usage-samples` non-member case.
