### PR TITLE
csp-guard: assert script-src excludes 'unsafe-eval', 'unsafe-hashes', 'wasm-unsafe-eval'

### DIFF
--- a/config/firebase-headers.test-helper.ts
+++ b/config/firebase-headers.test-helper.ts
@@ -85,7 +85,7 @@ export function describeFirebaseHeaders(
       }
     });
 
-    it("script-src does not contain 'unsafe-inline'", () => {
+    it("script-src does not contain unsafe keywords", () => {
       const globalRule = headers.find((h) => h.source === "**");
       expect(globalRule, "global '**' header rule not found").toBeDefined();
       const cspHeader = globalRule!.headers.find(
@@ -104,6 +104,9 @@ export function describeFirebaseHeaders(
       const scriptSrc = match![1];
       expect(scriptSrc).toContain("'self'");
       expect(scriptSrc).not.toContain("'unsafe-inline'");
+      expect(scriptSrc).not.toContain("'unsafe-eval'");
+      expect(scriptSrc).not.toContain("'unsafe-hashes'");
+      expect(scriptSrc).not.toContain("'wasm-unsafe-eval'");
     });
   });
 }


### PR DESCRIPTION
Closes #1351

## What

Extends the shared CSP `script-src` regression guard in
`config/firebase-headers.test-helper.ts` so it rejects three additional unsafe
keywords, not just `'unsafe-inline'`:

- `'unsafe-eval'`
- `'unsafe-hashes'`
- `'wasm-unsafe-eval'`

The `it(...)` title is renamed from `"script-src does not contain
'unsafe-inline'"` to `"script-src does not contain unsafe keywords"` to reflect
the broader scope. The existing `script-src([^;]*)` extraction and `scriptSrc`
local are reused unchanged — the three new assertions are the same
`expect(scriptSrc).not.toContain(...)` shape as the existing check.

## Why

PR #1324 dropped `'unsafe-inline'` from `script-src` across all six sites, and
issue #1300 added the regression guard that is the sole automated defense
against `script-src` regression. That guard only checked `'unsafe-inline'`. A
contributor re-introducing `'unsafe-eval'` (e.g. for a library that calls
`eval()`) would pass undetected — yet `'unsafe-eval'` permits `eval()`,
`setTimeout(string)`, and `new Function(string)`, a distinct XSS escalation
path. This change closes that monitoring gap.

## Scope

The change lives entirely in the shared helper, which all six apps (audio,
fellspiral, landing, office-hours, print, budget) import via
`describeFirebaseHeaders` — so one edit covers all six suites with no per-app
changes. No change to `firebase.json` or the per-app callers.

The current `firebase.json` `script-src` directives contain none of the three
keywords (`'self'` plus an https allowlist only), so the extended assertions
pass against current config.

## Verification

`npx vitest run --root audio test/firebase-headers.test.ts` passes (12 tests),
including the extended script-src test.
