### PR TITLE
office-hours: assert history-band empty states in owner-empty test

### DIFF
--- a/office-hours/test/app-view.test.ts
+++ b/office-hours/test/app-view.test.ts
@@ -150,6 +150,24 @@ describe("renderApp — owner tier empty", () => {
     expect(capacityEmpty).not.toBeUndefined();
   });
 
+  it("renders the history-band empty states", () => {
+    const container = document.createElement("div");
+    withThemeFg(() =>
+      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+    );
+
+    const empties = Array.from(container.querySelectorAll(".empty"));
+    const usageEmpty = empties.find(
+      (el) => el.textContent === "No usage history to chart.",
+    );
+    expect(usageEmpty).not.toBeUndefined();
+
+    const workerEmpty = empties.find(
+      (el) => el.textContent === "No worker history to chart.",
+    );
+    expect(workerEmpty).not.toBeUndefined();
+  });
+
   it("does not render an .error element", () => {
     const container = document.createElement("div");
     withThemeFg(() =>


### PR DESCRIPTION
Closes #1388

## Summary

PR #1381 (for #1304) gave office-hours distinct demo / owner / owner-empty /
error states. During that review a gap surfaced: the `renderApp — owner tier
empty` describe block in `office-hours/test/app-view.test.ts` asserts the
capacity and reminder empty states (`"No capacity data."` and `"No
reminders."`) but never the **history-band** empty states.

For an owner with an empty queue, `renderApp` calls `renderHistoryBand([])`
(`office-hours/src/app-view.ts:33`), which delegates to
`renderUsageHistoryChart` and `renderWorkerHistoryChart`; each renders a
`.empty` paragraph on empty input:

- `office-hours/src/usage-history-chart.ts:65` → `"No usage history to chart."`
- `office-hours/src/worker-history-chart.ts:45` → `"No worker history to chart."`

So the acceptance criterion "owner with an empty queue sees the empty state"
was under-verified for the history region.

## Change

Test-only. Adds one `it("renders the history-band empty states", …)` to the
`renderApp — owner tier empty` block, placed between the existing
`"No capacity data."` and `"does not render an .error element"` tests. It
renders the same owner-empty state and asserts both history-band `.empty`
paragraphs are present, mirroring the existing `.empty`-text-match pattern and
reusing the block's `withThemeFg` wrapper and module-level `now` constant. No
production code changes.

## Verification

`npm test --prefix office-hours` — 16 test files, 149 tests, all green
(up from 148; the new test passes with no regressions).
