### PR TITLE
functions: add exact-boundary test for feed-proxy body size cap

### DIFF
--- a/functions/test/feed-proxy.test.ts
+++ b/functions/test/feed-proxy.test.ts
@@ -246,6 +246,34 @@ describe("handleFeedProxy", () => {
     expect(res.body).toBe("Upstream feed exceeded maximum allowed size");
   });
 
+  it("returns 200 when upstream body is exactly MAX_FEED_BYTES (cap is inclusive)", async () => {
+    // Exactly at the cap: total === MAX_FEED_BYTES, which the strict `>`
+    // comparison in feed-proxy.ts admits. Pins the boundary as inclusive — a
+    // regression from `>` to `>=` would reject this and fail the test.
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(MAX_FEED_BYTES).fill(0x41));
+        controller.close();
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          headers: { "content-type": "application/xml" },
+        }),
+      ),
+    );
+
+    const allowedUrl = [...ALLOWED_FEED_URLS][0];
+    const res = createMockRes();
+    await handleFeedProxy(createMockReq({ url: allowedUrl }), res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).not.toBe("Upstream feed exceeded maximum allowed size");
+  });
+
   it("returns 502 with generic message when fetch throws (no error leak)", async () => {
     vi.stubGlobal(
       "fetch",

--- a/functions/test/feed-proxy.test.ts
+++ b/functions/test/feed-proxy.test.ts
@@ -271,7 +271,7 @@ describe("handleFeedProxy", () => {
     await handleFeedProxy(createMockReq({ url: allowedUrl }), res as never);
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).not.toBe("Upstream feed exceeded maximum allowed size");
+    expect(res.body.length).toBe(MAX_FEED_BYTES);
   });
 
   it("returns 502 with generic message when fetch throws (no error leak)", async () => {


### PR DESCRIPTION
Closes #1341

## What

Adds one test to `functions/test/feed-proxy.test.ts`: a body of **exactly**
`MAX_FEED_BYTES` bytes is accepted (`200`), complementing the existing over-cap
case (a body that *strictly exceeds* the cap returns `502`).

## Why

`functions/src/feed-proxy.ts:99` caps the upstream feed body with a
strict-greater comparison — `if (total > MAX_FEED_BYTES)` — so exactly
`MAX_FEED_BYTES` bytes is a valid, non-rejected payload. The existing suite only
exercised strict exceedance, so a regression of that operator from `>` to `>=`
would silently flip the boundary to rejecting at-cap bodies and no test would
catch it. The new case pins the intended inclusive semantics.

Surfaced as a deferred finding during review of PR #1319 (for #1298); the
production hardening already merged in #1319. This is pure test coverage — no
production-code change.

## How

The new `it(...)` sits immediately after the over-cap test so the boundary pair
(at-cap → `200`, over-cap → `502`) reads together. It stubs `fetch` to return a
`Response` whose body streams exactly `MAX_FEED_BYTES` bytes as a single chunk
(production accepts and reads the whole body, so a single exact-size chunk is the
clearest expression of "exactly the cap" and avoids any chunk-size arithmetic),
then asserts `res.statusCode === 200`. It reuses the existing scaffolding
(`createMockReq`/`createMockRes`, the imported `MAX_FEED_BYTES` and
`ALLOWED_FEED_URLS`, and the `ReadableStream` + `vi.stubGlobal("fetch", …)`
pattern) — no new helpers.

## Verification

`npx vitest run --root functions feed-proxy` — the new case passes, the existing
over-cap case still passes, and all other `handleFeedProxy` cases still pass.
