### PR TITLE
dispatch: extract shared num_has_live_worktree helper into lib.sh

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -448,21 +448,6 @@ pr_branch_has_live_worktree() {
   worktree_has_live_session "$path"
 }
 
-# True when a live session owns any <num>-* worktree. No such worktree →
-# fast-path miss. Several matches → owned if any one is live.
-issue_has_live_worktree() {
-  local num="$1" p
-  local paths="${WORKTREE_PATHS_BY_NUM[$num]:-}"
-  [[ -z "$paths" ]] && return 1
-  while IFS= read -r p; do
-    [[ -z "$p" ]] && continue
-    if worktree_has_live_session "$p"; then
-      return 0
-    fi
-  done <<< "$paths"
-  return 1
-}
-
 # True when the <branch> worktree is CLAIMED — a live session owns it (#905) OR
 # it carries a reservation marker (#1046). Both close the spawn-gap re-selection
 # race: a reserved-but-not-yet-registered target must not be re-selected. An
@@ -482,7 +467,7 @@ pr_branch_worktree_claimed() {
 # worktrees (no session, no marker) stay reuse signals, not skips.
 issue_worktree_claimed() {
   local num="$1" p
-  issue_has_live_worktree "$num" && return 0
+  num_has_live_worktree WORKTREE_PATHS_BY_NUM "$num" && return 0
   local paths="${WORKTREE_PATHS_BY_NUM[$num]:-}"
   [[ -z "$paths" ]] && return 1
   while IFS= read -r p; do

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
@@ -139,25 +139,6 @@ if [[ "$MODE" == "queue" ]]; then
   done < <(printf '%s' "$parked_json" | jq -r '.[].number')
 fi
 
-# True when a live Claude session owns any <num>-* worktree. No such worktree →
-# fast-path miss (return 1), no daemon round-trip. Several matches → owned if any
-# one is live. A faithful copy of dispatch-select-target's issue_has_live_worktree
-# (#905), applied here to subtree children (#914). worktree_has_live_session is
-# fail-safe: an unqueryable daemon counts as owned, so the child is skipped
-# rather than double-claimed.
-child_has_live_worktree() {
-  local num="$1" p
-  local paths="${WORKTREE_PATHS_BY_NUM[$num]:-}"
-  [[ -z "$paths" ]] && return 1
-  while IFS= read -r p; do
-    [[ -z "$p" ]] && continue
-    if worktree_has_live_session "$p"; then
-      return 0
-    fi
-  done <<< "$paths"
-  return 1
-}
-
 # True when any <num>-* child worktree is CLAIMED — live-owned (#914) OR reserved
 # (#1046). Mirrors dispatch-select-target's issue_worktree_claimed, applied to
 # subtree children: a reserved-but-not-yet-registered child must not be descended
@@ -166,7 +147,7 @@ child_has_live_worktree() {
 # daemon round-trip.
 child_worktree_claimed() {
   local num="$1" p
-  child_has_live_worktree "$num" && return 0
+  num_has_live_worktree WORKTREE_PATHS_BY_NUM "$num" && return 0
   local paths="${WORKTREE_PATHS_BY_NUM[$num]:-}"
   [[ -z "$paths" ]] && return 1
   while IFS= read -r p; do
@@ -178,7 +159,7 @@ child_worktree_claimed() {
 
 # True when the given issue number is parked on dispatch:office-hours (#1011).
 # A parked node is filtered from queue-mode descent exactly like a
-# live-session-owned child (child_has_live_worktree, #914): neither descended
+# live-session-owned child (num_has_live_worktree, #914): neither descended
 # into nor returned as a startable leaf. The descent then falls through to the
 # next startable sibling, or bubbles up (exit 2) when every reachable open leaf
 # is parked or live-owned. Map lookup against OFFICE_HOURS_PARKED, populated

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -688,6 +688,34 @@ split_worktree_record() {
   WT_BRANCH="${rest#*$'\t'}"
 }
 
+# True when a live Claude session owns any worktree registered for issue
+# <num>. <paths_ref> names the caller's associative array mapping issue-number
+# → newline-joined worktree path(s) (built from list_worktree_records /
+# split_worktree_record). No worktree for <num> → fast-path miss (return 1),
+# no daemon round-trip. Several matches → owned if any one is live.
+#
+# Consolidates dispatch-select-target's issue_has_live_worktree (#905) and
+# dispatch-trace-leaf's child_has_live_worktree (#914), which were byte-
+# identical (#971).
+#
+# DEPENDENCY: calls worktree_has_live_session, defined in lib-claude-agents.sh
+# (not lib.sh). A consumer must source lib-claude-agents.sh before any call.
+# worktree_has_live_session is fail-safe: an unqueryable daemon counts as
+# owned, so the caller skips the row rather than double-claim.
+num_has_live_worktree() {
+  local -n _wt_paths_by_num="$1"
+  local num="$2" p
+  local paths="${_wt_paths_by_num[$num]:-}"
+  [[ -z "$paths" ]] && return 1
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    if worktree_has_live_session "$p"; then
+      return 0
+    fi
+  done <<< "$paths"
+  return 1
+}
+
 # Kill processes belonging to worktrees that no longer exist.
 # Scopes the search to this repo's worktree directory (derived from git
 # common dir) to avoid killing processes from unrelated repositories.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -5980,6 +5980,56 @@ assert_eq "active_paths holds every full worktree path" \
 teardown
 
 # ============================================================================
+# num_has_live_worktree (lib.sh) tests
+# ============================================================================
+echo ""
+echo "=== num_has_live_worktree ==="
+
+# num_has_live_worktree is the shared helper that consolidates
+# dispatch-select-target's issue_has_live_worktree and dispatch-trace-leaf's
+# child_has_live_worktree (#971). It is pure (no git, no daemon), so each test
+# sources lib.sh in a subshell, defines a stub worktree_has_live_session, then
+# exercises three behaviors together in one subshell to share the fixture and
+# avoid running under set -e with bare non-zero returns.
+#
+# All three assertions are collected inside a single subshell that prints a
+# composite "rc_a|rc_b|rc_c" result — each rc is captured with
+# `if …; then rc=0; else rc=$?; fi` so set -euo pipefail does not abort on
+# the expected non-zero returns.
+
+echo "Test: no-worktree fast-path miss / any-live early return / all-dead miss"
+result=$(
+  source "$SCRIPT_DIR/lib.sh"
+
+  # Stub: path containing 'live' is live; all others are dead.
+  worktree_has_live_session() {
+    case "$1" in
+      */live*) return 0 ;;
+      *)       return 1 ;;
+    esac
+  }
+
+  declare -A WORKTREE_PATHS_BY_NUM
+  # Issue 5: no entry → fast-path miss (no stub call)
+  # Issue 7: one dead path, one live path → any-live early return
+  WORKTREE_PATHS_BY_NUM[7]=$'/wt/dead\n/wt/live'
+  # Issue 9: both paths are dead → all-dead miss
+  WORKTREE_PATHS_BY_NUM[9]=$'/wt/dead1\n/wt/dead2'
+
+  # (a) no worktree for num 5 → return 1
+  if num_has_live_worktree WORKTREE_PATHS_BY_NUM 5; then rc_a=0; else rc_a=$?; fi
+
+  # (b) num 7 has a live path → return 0
+  if num_has_live_worktree WORKTREE_PATHS_BY_NUM 7; then rc_b=0; else rc_b=$?; fi
+
+  # (c) num 9, all paths dead → return 1
+  if num_has_live_worktree WORKTREE_PATHS_BY_NUM 9; then rc_c=0; else rc_c=$?; fi
+
+  printf '%s|%s|%s' "$rc_a" "$rc_b" "$rc_c"
+)
+assert_eq "no-worktree miss / any-live hit / all-dead miss" "1|0|1" "$result"
+
+# ============================================================================
 # resolve_project_root (lib.sh) tests
 # ============================================================================
 echo ""


### PR DESCRIPTION
Closes #971

## What

Consolidate the byte-identical `child_has_live_worktree` (`dispatch-trace-leaf`,
added in PR #967) and `issue_has_live_worktree` (`dispatch-select-target`) into a
single `num_has_live_worktree` helper in `lib.sh`, where the other shared
worktree-record helpers (`list_worktree_records`, `split_worktree_record`)
already live.

## Why

The two functions were a byte-for-byte structural duplicate — same
`WORKTREE_PATHS_BY_NUM` lookup, same per-path `worktree_has_live_session` loop
with first-live early return, same no-worktree fast-path miss. Only the name and
surrounding comments differed. A code-review finding flagged this as a second
maintenance point that could silently drift; folding both into one shared helper
keeps the two scripts in lockstep with one source of truth.

## Changes

- **`lib.sh`** — add `num_has_live_worktree`, placed after `split_worktree_record`
  to cluster with the worktree-record helpers. Takes the issue-number→paths
  associative array by **nameref** (`local -n`, the established pattern in
  `dispatch-select-target`), with an underscore-prefixed nameref name to avoid a
  circular reference when callers pass `WORKTREE_PATHS_BY_NUM`.
- **`dispatch-trace-leaf`** — delete `child_has_live_worktree`; rewire
  `child_worktree_claimed` to call the shared helper; update the stale comment
  reference.
- **`dispatch-select-target`** — delete `issue_has_live_worktree`; rewire
  `issue_worktree_claimed` to call the shared helper.
- **`test-dispatch-scripts.sh`** — add a focused, daemon-free unit test (stubbed
  `worktree_has_live_session`) covering the no-worktree fast-path miss, the
  any-live early return, and the all-dead case; also exercises the nameref binding.

Behavior is unchanged — this is a pure refactor.

## Verification

- `test-dispatch-scripts.sh`: **2402/2402 passing**, including the three new
  `num_has_live_worktree` assertions.
- `bash -n` clean on `lib.sh`, `dispatch-trace-leaf`, `dispatch-select-target`.
- `grep` confirms neither old function name survives as a definition or live call
  (historical comments only).

## Out of scope

- `pr_branch_has_live_worktree` (`dispatch-select-target`) — branch-keyed, single
  path, not a duplicate of the num-array helper.
- The `reservation_exists` duplication shared by `child_worktree_claimed` /
  `issue_worktree_claimed` — a separate extraction this PR deliberately does not
  address.
