### PR TITLE
office-hours: logError when toReminder falls back to doc id for a missing jitKey

### DIFF
--- a/office-hours/src/data.ts
+++ b/office-hours/src/data.ts
@@ -48,11 +48,10 @@ export async function getOwnerReminders(
   return reminders;
 }
 
-function toReminder(id: string, data: Record<string, unknown>): Reminder | null {
+export function toReminder(id: string, data: Record<string, unknown>): Reminder | null {
   const title = typeof data.title === "string" ? data.title : null;
   const repo = typeof data.repo === "string" ? data.repo : null;
   const issueNumber = typeof data.issueNumber === "number" ? data.issueNumber : null;
-  const jitKey = typeof data.jitKey === "string" ? data.jitKey : id;
   const dueAtRaw = data.dueAt;
   const dueAt =
     dueAtRaw && typeof (dueAtRaw as { toDate?: unknown }).toDate === "function"
@@ -64,6 +63,16 @@ function toReminder(id: string, data: Record<string, unknown>): Reminder | null 
       itemId: id,
     });
     return null;
+  }
+  let jitKey: string;
+  if (typeof data.jitKey === "string") {
+    jitKey = data.jitKey;
+  } else {
+    logError(new Error("office-hours item missing jitKey; falling back to document id"), {
+      operation: "reminder-validation",
+      itemId: id,
+    });
+    jitKey = id;
   }
   return { jitKey, title, repo, issueNumber, dueAt };
 }

--- a/office-hours/test/data.test.ts
+++ b/office-hours/test/data.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { registerErrorSink, type EnrichedErrorContext } from "@commons-systems/errorutil/log";
 import { toReminder } from "../src/data.js";
 
@@ -8,6 +8,7 @@ let captured: SinkCall[];
 
 beforeEach(() => {
   captured = [];
+  vi.spyOn(console, "error").mockImplementation(() => {});
   registerErrorSink((error, context) => {
     captured.push({ error, context });
   });
@@ -15,6 +16,7 @@ beforeEach(() => {
 
 afterEach(() => {
   registerErrorSink(undefined);
+  vi.restoreAllMocks();
 });
 
 const validData = {
@@ -37,6 +39,8 @@ describe("toReminder", () => {
     expect(captured).toHaveLength(1);
     expect((captured[0].error as Error).message).toMatch(/jitKey/);
     expect((captured[0].error as Error).message).toMatch(/falling back/);
+    expect(captured[0].context.operation).toBe("reminder-validation");
+    expect(captured[0].context.itemId).toBe(id);
   });
 
   it("(b) missing required field — returns null, logs missing-required-fields, NOT jitKey-fallback", () => {
@@ -46,12 +50,15 @@ describe("toReminder", () => {
       issueNumber: 42,
       dueAt: { toDate: () => new Date("2026-01-01T00:00:00Z") },
     };
-    const result = toReminder("doc-id-xyz", data);
+    const id = "doc-id-xyz";
+    const result = toReminder(id, data);
 
     expect(result).toBeNull();
     expect(captured).toHaveLength(1);
     expect((captured[0].error as Error).message).toMatch(/missing required fields/);
     expect((captured[0].error as Error).message).not.toMatch(/jitKey/);
+    expect(captured[0].context.operation).toBe("reminder-validation");
+    expect(captured[0].context.itemId).toBe(id);
   });
 
   it("(c) present jitKey — returns reminder with correct jitKey, sink NOT fired", () => {

--- a/office-hours/test/data.test.ts
+++ b/office-hours/test/data.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { registerErrorSink, type EnrichedErrorContext } from "@commons-systems/errorutil/log";
+import { toReminder } from "../src/data.js";
+
+type SinkCall = { error: unknown; context: EnrichedErrorContext };
+
+let captured: SinkCall[];
+
+beforeEach(() => {
+  captured = [];
+  registerErrorSink((error, context) => {
+    captured.push({ error, context });
+  });
+});
+
+afterEach(() => {
+  registerErrorSink(undefined);
+});
+
+const validData = {
+  title: "Fix bug",
+  repo: "natb1/commons.systems",
+  issueNumber: 42,
+  dueAt: { toDate: () => new Date("2026-01-01T00:00:00Z") },
+};
+
+describe("toReminder", () => {
+  it("(a) missing jitKey — returns reminder with jitKey === id and logs the fallback", () => {
+    const id = "doc-id-abc";
+    const data = { ...validData };
+    const reminder = toReminder(id, data);
+
+    expect(reminder).not.toBeNull();
+    if (reminder === null) return;
+
+    expect(reminder.jitKey).toBe(id);
+    expect(captured).toHaveLength(1);
+    expect((captured[0].error as Error).message).toMatch(/jitKey/);
+    expect((captured[0].error as Error).message).toMatch(/falling back/);
+  });
+
+  it("(b) missing required field — returns null, logs missing-required-fields, NOT jitKey-fallback", () => {
+    const data = {
+      // title intentionally omitted
+      repo: "natb1/commons.systems",
+      issueNumber: 42,
+      dueAt: { toDate: () => new Date("2026-01-01T00:00:00Z") },
+    };
+    const result = toReminder("doc-id-xyz", data);
+
+    expect(result).toBeNull();
+    expect(captured).toHaveLength(1);
+    expect((captured[0].error as Error).message).toMatch(/missing required fields/);
+    expect((captured[0].error as Error).message).not.toMatch(/jitKey/);
+  });
+
+  it("(c) present jitKey — returns reminder with correct jitKey, sink NOT fired", () => {
+    const id = "doc-id-def";
+    const data = { ...validData, jitKey: "issues/natb1/commons.systems/99" };
+    const reminder = toReminder(id, data);
+
+    expect(reminder).not.toBeNull();
+    if (reminder === null) return;
+
+    expect(reminder.jitKey).toBe("issues/natb1/commons.systems/99");
+    expect(captured).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #1168

## What

In `office-hours/src/data.ts`, `toReminder` resolved a missing `jitKey` field by
silently substituting the Firestore document id, with no log — unlike every other
missing required field (`title`, `repo`, `issueNumber`, `dueAt`), which emits a
`logError`. A missing `jitKey` is a schema anomaly (the sync Function always sets
it), so the silent fallback hid schema drift.

This change makes the fallback observable: `toReminder` now emits a `logError`
when it falls back to the document id for a missing `jitKey`, while still
returning the (fully renderable) reminder.

## Why log, not skip

By design the document id **equals** the `jitKey` field —
`functions/src/office-hours-sync.ts` writes the doc as
`itemsCollection.doc(issue.jitKey)` and stores the same value in the `jitKey`
field; the seeds do the same. So the doc-id fallback yields the *correct* jitKey
value and the reminder renders fine. Skipping it would drop a valid reminder over
a cosmetic field-presence anomaly, so the fallback is kept and merely made
observable.

## Changes

- **`office-hours/src/data.ts`** — move `jitKey` resolution **below** the
  required-fields gate so the fallback log fires only for documents actually
  returned (a doc missing both `jitKey` and a required field is skipped, not
  logged as a fallback). Emit a `logError` on the fallback. Export `toReminder`
  for direct unit testing, matching the `toUsageSample` converter-export
  precedent.
- **`office-hours/test/data.test.ts`** (new) — a focused vitest suite for
  `toReminder`: (a) missing `jitKey` returns a reminder with `jitKey` = doc id
  and the sink fires the fallback message; (b) a doc missing a required field
  still returns `null` and logs "missing required fields" — **not** the
  jitKey-fallback message (guards the ordering fix); (c) present `jitKey` returns
  the reminder unchanged with no log.

## Verification

`npx vitest run --root office-hours` — 17 files, 151 tests pass, including the
three new `data.test.ts` cases.

There is no `logWarning` in `errorutil`; `logError` is the only logging entry
point. The issue title's "warning" is colloquial — the body specifies `logError`.
