### PR TITLE
dispatch: consolidate parse_duration into lib.sh

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-jit-calendar-import
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-jit-calendar-import
@@ -113,27 +113,6 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
 
-# ---- parse_duration <str> — duration string to seconds ----------------------
-# Copied inline from dispatch-jit-engine. Accepts <int><unit> where unit is one
-# of s|m|h|d|w. Prints the duration in seconds on stdout and returns 0. On
-# unparseable input prints nothing and returns 1.
-parse_duration() {
-  local spec="$1" num unit
-  if [[ ! "$spec" =~ ^([0-9]+)([smhdw])$ ]]; then
-    return 1
-  fi
-  num="${BASH_REMATCH[1]}"
-  unit="${BASH_REMATCH[2]}"
-  case "$unit" in
-    s) printf '%s\n' "$(( num * 1 ))" ;;
-    m) printf '%s\n' "$(( num * 60 ))" ;;
-    h) printf '%s\n' "$(( num * 3600 ))" ;;
-    d) printf '%s\n' "$(( num * 86400 ))" ;;
-    w) printf '%s\n' "$(( num * 604800 ))" ;;
-  esac
-  return 0
-}
-
 # ---- Step 0: no-config gate -------------------------------------------------
 # Any of the three OAuth env vars unset → silent no-op.
 if [[ -z "${GOOGLE_CALENDAR_CLIENT_ID:-}" \

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-jit-engine
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-jit-engine
@@ -63,27 +63,6 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
 
-# ---- parse_duration <str> — duration string to seconds ----------------------
-# Accepts <int><unit> where unit is one of s|m|h|d|w. Prints the duration in
-# seconds on stdout and returns 0. On unparseable input prints nothing and
-# returns 1 — the caller treats that as a hard error for the jit.
-parse_duration() {
-  local spec="$1" num unit
-  if [[ ! "$spec" =~ ^([0-9]+)([smhdw])$ ]]; then
-    return 1
-  fi
-  num="${BASH_REMATCH[1]}"
-  unit="${BASH_REMATCH[2]}"
-  case "$unit" in
-    s) printf '%s\n' "$(( num * 1 ))" ;;
-    m) printf '%s\n' "$(( num * 60 ))" ;;
-    h) printf '%s\n' "$(( num * 3600 ))" ;;
-    d) printf '%s\n' "$(( num * 86400 ))" ;;
-    w) printf '%s\n' "$(( num * 604800 ))" ;;
-  esac
-  return 0
-}
-
 # ---- Step 0: load and validate the jit config -------------------------------
 # dispatch-config-load handles DISPATCH_CONFIG_DIR resolution and schema
 # validation. "no-config" → silent no-op. A non-zero exit → the loader already

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -251,26 +251,6 @@ main_broken_latch() {
   echo "$sha"
 }
 
-# Convert a duration string ("12h", "7d", "30m") to whole seconds. Units:
-# s second, m minute, h hour, d day, w week. Any other form is a config error.
-parse_duration() {
-  local spec="$1"
-  if [[ ! "$spec" =~ ^([0-9]+)([smhdw])$ ]]; then
-    echo "error: invalid duration '$spec' (expected <integer><s|m|h|d|w>)" >&2
-    exit 1
-  fi
-  # 10# forces base-10: bash arithmetic reads a leading-zero literal as octal,
-  # so an unforced "010h" would compute as 8h and "08h"/"09d" would hard-error.
-  local n=$(( 10#${BASH_REMATCH[1]} )) unit="${BASH_REMATCH[2]}"
-  case "$unit" in
-    s) echo "$n" ;;
-    m) echo "$(( n * 60 ))" ;;
-    h) echo "$(( n * 3600 ))" ;;
-    d) echo "$(( n * 86400 ))" ;;
-    w) echo "$(( n * 604800 ))" ;;
-  esac
-}
-
 # Scan configured JITs and, if any open JIT issue is due, print the most
 # pressing one as: jit-reminder <repo> <num> <project> <item-id>. Prints
 # nothing when no config is present or no JIT is eligible. Emitted before the
@@ -316,7 +296,10 @@ jit_scan() {
       # most-recently-created closed issues contain the most-recently-closed one.
       closed_json=$(gh issue list --repo "$repo" --label "$label" --state closed --limit 100 --json closedAt)
       max_closed=$(printf '%s' "$closed_json" | jq -r 'map(.closedAt) | max // empty')
-      offset=$(parse_duration "$due_after_close")
+      if ! offset=$(parse_duration "$due_after_close"); then
+        echo "error: invalid duration '$due_after_close' (expected <integer><s|m|h|d|w>)" >&2
+        exit 1
+      fi
       if [[ -n "$max_closed" ]]; then
         anchor=$(date -d "$max_closed" +%s)
         due=$(( anchor + offset ))
@@ -326,13 +309,19 @@ jit_scan() {
           exit 1
         fi
         local remind_offset
-        remind_offset=$(parse_duration "$remind_after_close")
+        if ! remind_offset=$(parse_duration "$remind_after_close"); then
+          echo "error: invalid duration '$remind_after_close' (expected <integer><s|m|h|d|w>)" >&2
+          exit 1
+        fi
         anchor=$(date -d "$open_created" +%s)
         due=$(( anchor + offset - remind_offset ))
       fi
     elif [[ -n "$due_after_create" ]]; then
       local offset anchor
-      offset=$(parse_duration "$due_after_create")
+      if ! offset=$(parse_duration "$due_after_create"); then
+        echo "error: invalid duration '$due_after_create' (expected <integer><s|m|h|d|w>)" >&2
+        exit 1
+      fi
       anchor=$(date -d "$open_created" +%s)
       due=$(( anchor + offset ))
     else

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-statements-scan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-statements-scan
@@ -76,27 +76,6 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
 
-# ---- parse_duration <str> — duration string to seconds ----------------------
-# Accepts <int><unit> where unit is one of s|m|h|d|w. Prints the duration in
-# seconds on stdout and returns 0. On unparseable input prints nothing and
-# returns 1 — the caller treats that as a hard error for the entry.
-parse_duration() {
-  local spec="$1" num unit
-  if [[ ! "$spec" =~ ^([0-9]+)([smhdw])$ ]]; then
-    return 1
-  fi
-  num="${BASH_REMATCH[1]}"
-  unit="${BASH_REMATCH[2]}"
-  case "$unit" in
-    s) printf '%s\n' "$num" ;;
-    m) printf '%s\n' "$(( num * 60 ))" ;;
-    h) printf '%s\n' "$(( num * 3600 ))" ;;
-    d) printf '%s\n' "$(( num * 86400 ))" ;;
-    w) printf '%s\n' "$(( num * 604800 ))" ;;
-  esac
-  return 0
-}
-
 # ---- Step 0: load and validate the statements config ------------------------
 # dispatch-config-load handles DISPATCH_CONFIG_DIR resolution and schema
 # validation. "no-config" → silent no-op. A non-zero exit → the loader already

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -28,6 +28,29 @@ resolve_issue_number() {
   echo "$num"
 }
 
+# ---- parse_duration <str> — duration string to whole seconds ----------------
+# Accepts <int><unit> where unit is one of s|m|h|d|w (second/minute/hour/day/
+# week). Prints the duration in seconds on stdout and returns 0. On unparseable
+# input prints nothing and returns 1 — the caller decides how to surface it.
+# 10# forces base-10 so a leading-zero spec like "08h"/"012h" is not read as
+# octal (bash arithmetic treats a leading-zero literal as octal otherwise).
+parse_duration() {
+  local spec="$1" num unit
+  if [[ ! "$spec" =~ ^([0-9]+)([smhdw])$ ]]; then
+    return 1
+  fi
+  num=$(( 10#${BASH_REMATCH[1]} ))
+  unit="${BASH_REMATCH[2]}"
+  case "$unit" in
+    s) printf '%s\n' "$num" ;;
+    m) printf '%s\n' "$(( num * 60 ))" ;;
+    h) printf '%s\n' "$(( num * 3600 ))" ;;
+    d) printf '%s\n' "$(( num * 86400 ))" ;;
+    w) printf '%s\n' "$(( num * 604800 ))" ;;
+  esac
+  return 0
+}
+
 # Classify a captured gh stderr blob as transient (retryable) or deterministic.
 # Args: $1 = the captured stderr text.
 # Returns 0 when the blob matches a known transient class (HTTP 5xx, gateway


### PR DESCRIPTION
Closes #1065

## Summary

Consolidates the duplicated `parse_duration` helper (a `<int><unit>` → seconds
parser, units `s|m|h|d|w`) into the shared `lib.sh`, and removes the four inline
copies. All four scripts already `source lib.sh`, so no new sourcing was needed —
only the inline definitions were removed.

## The copies had already diverged

The issue framed the copies as "duplicated" (implying verbatim). They were not —
they had already drifted into **three variants**, which is exactly the divergence
the consolidation prevents going forward:

1. `dispatch-select-target` (most correct): `10#` base-10 fix so a leading-zero
   spec like `08h`/`012h` parses as decimal, not octal; on bad input printed a
   descriptive `error: invalid duration …` to stderr and `exit 1`.
2. `dispatch-jit-engine` / `dispatch-jit-calendar-import`: identical to each
   other; **no** `10#` fix; silent `return 1` on bad input.
3. `dispatch-statements-scan`: silent `return 1`, no `10#` fix; minor cosmetic
   differences.

## Canonical contract chosen for `lib.sh`

- **Keeps the `10#` base-10 fix** (required by test JS9). Single-source-of-truth
  means the other three scripts now inherit it.
- **Silent `return 1` on bad input** (pure-library contract) — the caller owns
  the error message. This already matched 3 of the 4 call sites, which do
  `if ! X=$(parse_duration …); then <own error>; fi`.

## Forced behavior change in the three silent scripts

Inheriting the `10#` fix is a **forced, strict-improvement behavior change** in
`dispatch-statements-scan`, `dispatch-jit-engine`, and
`dispatch-jit-calendar-import`: a leading-zero duration like `08h`/`012h` now
parses as decimal where it previously hit a bash octal-literal error. There is
no test coverage for these three scripts' parser (they are not copied into the
test harness), so this change is unguarded by a test — acceptable for this
consolidation.

## dispatch-select-target call sites

`dispatch-select-target` was the only caller relying on the function's *internal*
`exit 1` + message. Its three `jit_scan` call sites are now wrapped to check the
return and emit the descriptive error themselves — preserving its clear-error
behavior (per `.claude/rules/code-style.md`) and its non-zero exit (test JS10).
The assignment inside each `if !` stays a plain assignment (not `local …`), so
`local` does not mask the command-substitution exit status.

## Verification

- Full dispatch script suite: **2401/2401 pass**, including JS9 (leading-zero
  parses base-10) and JS10 (invalid duration → non-zero exit).
- `grep 'parse_duration *() *{'` over the scripts dir → exactly one hit:
  `lib.sh`.
