### PR TITLE
dispatch: machine-enforce no-spaces invariant in ensure_recover_unit

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -862,6 +862,12 @@ ensure_recover_unit() {
     echo "WARNING: ensure_recover_unit: main worktree path contains a newline; refusing to write unit; OnFailure recovery unavailable" >&2
     return 1
   fi
+  # WorkingDirectory= does not unescape quotes, so a space in the bare path would
+  # split the value at the first space; reject it (same contract: warn + return 1).
+  if [[ "$main_worktree" == *' '* ]]; then
+    echo "WARNING: ensure_recover_unit: main worktree path contains a space; refusing to write unit; OnFailure recovery unavailable" >&2
+    return 1
+  fi
 
   local RECOVER_SCRIPT="$main_worktree/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover"
   local UNIT_DIR="${DISPATCH_RECOVER_UNIT_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user}"
@@ -888,7 +894,8 @@ ensure_recover_unit() {
   # single token rather than split into an executable + spurious arguments.
   # WorkingDirectory= is the exception — it does NOT unescape quotes; a leading
   # `"` makes the path non-absolute and systemd rejects the unit (bad-setting),
-  # so it takes the bare path (safe here: the worktree path has no spaces).
+  # so it takes the bare path (the no-spaces invariant is enforced by the guard
+  # above, so the bare value is a single token).
   #
   # Deliberately NO OnFailure= on this unit — the recover handler must not chain
   # to itself, or a failing recovery would recurse.

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -891,6 +891,16 @@ ensure_recover_unit() {
     echo "WARNING: ensure_recover_unit: main worktree path contains a space; refusing to write unit; OnFailure recovery unavailable" >&2
     return 1
   fi
+  # ExecStart= is double-quoted ("$RECOVER_SCRIPT"); RECOVER_SCRIPT is derived
+  # from main_worktree below. An embedded double-quote in the path would
+  # prematurely close that quoted token, making systemd parse the executable and
+  # arguments wrong (bad-setting) and permanently break the unit. The path never
+  # legitimately contains a double-quote; reject it rather than emit a malformed
+  # unit (same contract: warn + return 1).
+  if [[ "$main_worktree" == *'"'* ]]; then
+    echo "WARNING: ensure_recover_unit: main worktree path contains a double-quote; refusing to write unit; OnFailure recovery unavailable" >&2
+    return 1
+  fi
 
   local RECOVER_SCRIPT="$main_worktree/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover"
   local UNIT_DIR="${DISPATCH_RECOVER_UNIT_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user}"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -23327,6 +23327,37 @@ fi
 rm -rf "$eru2_tmp"
 
 # ============================================================================
+# ensure_recover_unit: rejects a path containing a double-quote (#1211)
+# ============================================================================
+echo ""
+echo "=== ensure_recover_unit rejects a path with a double-quote ==="
+eru3_tmp=$(mktemp -d)
+mkdir -p "$eru3_tmp/bin"
+cat > "$eru3_tmp/bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$eru3_tmp/bin/systemctl"
+TOTAL=$((TOTAL + 1))
+if (
+  export DISPATCH_RECOVER_UNIT_DIR="$eru3_tmp/systemd-user"
+  export DISPATCH_RECOVER_SYSTEMCTL_CMD="$eru3_tmp/bin/systemctl"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_recover_unit "$eru3_tmp/has\"a\"quote"
+); then
+  FAIL=$((FAIL + 1)); echo "  FAIL: ensure_recover_unit should have returned non-zero for a path with a double-quote"
+else
+  PASS=$((PASS + 1)); echo "  PASS: ensure_recover_unit returned non-zero for a path with a double-quote"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$eru3_tmp/systemd-user/dispatch-tick-recover.service" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: no unit file was written for a path with a double-quote"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: unit file was written despite path containing a double-quote"
+fi
+rm -rf "$eru3_tmp"
+
+# ============================================================================
 # ensure_daemon_service: durable daemon service install + attach paths (#1197)
 # ============================================================================
 echo ""

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -22925,6 +22925,37 @@ fi
 rm -rf "$eru_tmp"
 
 # ============================================================================
+# ensure_recover_unit: rejects a path containing a space (#1211)
+# ============================================================================
+echo ""
+echo "=== ensure_recover_unit rejects a path with a space ==="
+eru2_tmp=$(mktemp -d)
+mkdir -p "$eru2_tmp/bin"
+cat > "$eru2_tmp/bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$eru2_tmp/bin/systemctl"
+TOTAL=$((TOTAL + 1))
+if (
+  export DISPATCH_RECOVER_UNIT_DIR="$eru2_tmp/systemd-user"
+  export DISPATCH_RECOVER_SYSTEMCTL_CMD="$eru2_tmp/bin/systemctl"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_recover_unit "$eru2_tmp/has a space"
+); then
+  FAIL=$((FAIL + 1)); echo "  FAIL: ensure_recover_unit should have returned non-zero for a path with a space"
+else
+  PASS=$((PASS + 1)); echo "  PASS: ensure_recover_unit returned non-zero for a path with a space"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$eru2_tmp/systemd-user/dispatch-tick-recover.service" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: no unit file was written for a path with a space"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: unit file was written despite path containing a space"
+fi
+rm -rf "$eru2_tmp"
+
+# ============================================================================
 # ensure_daemon_service: durable daemon service install + attach paths (#1197)
 # ============================================================================
 echo ""


### PR DESCRIPTION
Closes #1211

## Summary

`ensure_recover_unit` (`lib.sh`) writes `WorkingDirectory=$main_worktree`
**unquoted** in the generated `dispatch-tick-recover.service` systemd unit —
deliberately, because systemd's `WorkingDirectory=` does not unescape quotes
(#1203). The function relied on a documented "no spaces" invariant stated only
in a comment, while already machine-enforcing the related newline invariant. A
space in the path would let systemd truncate `WorkingDirectory=` at the first
space and run the recovery handler in an unintended directory.

This machine-enforces the documented no-spaces invariant by adding a space
guard alongside the existing newline guard, plus a regression test. It
surfaced during `/review-fix` of PR #1207 (for #1203), out of scope there.

## Changes

- `lib.sh` — in `ensure_recover_unit`, a space guard immediately after the
  newline guard, following the same best-effort `warn + return 1` contract
  (never `exit`): a `main_worktree` containing a space is refused with a
  warning and `OnFailure recovery unavailable`. The now-enforced invariant is
  reflected in the `WorkingDirectory=` comment, which previously only assumed
  it.
- `test-dispatch-scripts.sh` — a regression test mirroring the existing
  `ensure_recover_unit` WorkingDirectory block: asserts that a path with a
  space returns non-zero and that no unit file is written.

## Verification

Full dispatch script suite: `2403/2403 passed, 0 failed`. The existing
WorkingDirectory assertions still pass and the new space-rejection assertions
pass.

## Out of scope

- The `WorkingDirectory=` quoting itself (#1203, already fixed).
- The `safe_path` PATH sanitization (#1207).
- Any change to the newline guard.
