### PR TITLE
dispatch: add --property=KillMode=process to dispatch-tick-recover reseed

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover
@@ -329,7 +329,10 @@ fi
 #
 # The systemd-run flag style mirrors dispatch-schedule-reseed's Step-6 call
 # exactly, plus --collect (so a failed reseed unit does not linger — Unit 3
-# adds the same flag to dispatch-schedule-reseed). Deliberately NO OnFailure=
+# adds the same flag to dispatch-schedule-reseed) and
+# --property=KillMode=process (so the reseed tick does not reap the bg fleet —
+# daemon + workers — when its transient unit deactivates; same fleet-reaping fix
+# as #1196, now applied here for #1209). Deliberately NO OnFailure=
 # here: arming the recover handler on a recover-armed reseed is Unit 3's concern
 # on the launchers, and the recover unit must not chain to itself.
 
@@ -351,6 +354,7 @@ trap 'rm -f "$RUN_STDERR"' EXIT
 "$SYSTEMD_RUN_CMD" --user \
      --unit="$UNIT_NAME" \
      --collect \
+     --property=KillMode=process \
      --on-calendar="@$RESEED_AT" \
      --working-directory="$MAIN_WORKTREE" \
      --timer-property=Persistent=true \

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -12180,10 +12180,11 @@ TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--on-calendar=@1000300"* \
    && "$log" == *"--unit=dispatch-reseed-1000300"* \
    && "$log" == *"--collect"* \
+   && "$log" == *"--property=KillMode=process"* \
    && "$log" == *"$TMPDIR_TEST/main/.claude/skills/dispatch-propagate/scripts/dispatch-tick"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: first-fail systemd-run argv (calendar + unit + collect + exec)"
+  PASS=$((PASS + 1)); echo "  PASS: first-fail systemd-run argv (calendar + unit + collect + killmode + exec)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: first-fail systemd-run argv (calendar + unit + collect + exec)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: first-fail systemd-run argv (calendar + unit + collect + killmode + exec)"
   echo "    log: $log"
 fi
 assert_eq "first-fail: state count == 1" "1" "$(tr_state_count)"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -12354,10 +12354,11 @@ assert_eq "backoff: dispatch-tick-recover exits 0" "0" "$rc"
 log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--on-calendar=@1000600"* \
-   && "$log" == *"--unit=dispatch-reseed-1000600"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: backoff: reseed armed at NOW + 600 (calendar + unit)"
+   && "$log" == *"--unit=dispatch-reseed-1000600"* \
+   && "$log" == *"--property=KillMode=process"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: backoff: reseed armed at NOW + 600 (calendar + unit + killmode)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: backoff: reseed armed at NOW + 600 (calendar + unit)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: backoff: reseed armed at NOW + 600 (calendar + unit + killmode)"
   echo "    log: $log"
 fi
 assert_eq "backoff: state count == 2" "2" "$(tr_state_count)"
@@ -12376,10 +12377,11 @@ assert_eq "reset-window: dispatch-tick-recover exits 0" "0" "$rc"
 log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--on-calendar=@1000300"* \
-   && "$log" == *"--unit=dispatch-reseed-1000300"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: reset-window: fresh episode armed at NOW + 300"
+   && "$log" == *"--unit=dispatch-reseed-1000300"* \
+   && "$log" == *"--property=KillMode=process"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: reset-window: fresh episode armed at NOW + 300 (killmode)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: reset-window: fresh episode armed at NOW + 300"
+  FAIL=$((FAIL + 1)); echo "  FAIL: reset-window: fresh episode armed at NOW + 300 (killmode)"
   echo "    log: $log"
 fi
 assert_eq "reset-window: state count == 1 (fresh episode)" "1" "$(tr_state_count)"
@@ -12425,10 +12427,11 @@ assert_eq "overflow-clamp: dispatch-tick-recover exits 0" "0" "$rc"
 log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--on-calendar=@1003600"* \
-   && "$log" == *"--unit=dispatch-reseed-1003600"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: overflow-clamp: backoff clamped to MAX, reseed at NOW + 3600"
+   && "$log" == *"--unit=dispatch-reseed-1003600"* \
+   && "$log" == *"--property=KillMode=process"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: overflow-clamp: backoff clamped to MAX, reseed at NOW + 3600 (killmode)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: overflow-clamp: backoff clamped to MAX, reseed at NOW + 3600"
+  FAIL=$((FAIL + 1)); echo "  FAIL: overflow-clamp: backoff clamped to MAX, reseed at NOW + 3600 (killmode)"
   echo "    log: $log"
 fi
 tr_teardown


### PR DESCRIPTION
Closes #1209

## What

Add `--property=KillMode=process` to the `systemd-run --user` reseed call in
`dispatch-tick-recover` (the `OnFailure=` recovery handler that guarantees the
dispatch chain gets a continuation when a tick fails abnormally).

## Why

When the recover-armed `dispatch-reseed-<epoch>` timer fires, the reseed tick's
first `claude` call spawns the per-user bg supervisor daemon and its `--bg`
worker children inside the transient unit's cgroup. With systemd's default
`KillMode=control-group`, the whole cgroup — daemon plus every running worker —
is SIGTERMed when the reseed tick finishes, reaping the fleet.

`--property=KillMode=process` confines the kill to the `dispatch-tick` process
itself, so the detached bg hosts survive as init orphans. This matches the
fleet-reaping fix in #1196 for `dispatch-spawn-tick` and
`dispatch-schedule-reseed`; it was missed on `dispatch-tick-recover`, whose
in-code comment even claimed it "mirrors dispatch-schedule-reseed's Step-6 call
exactly" while omitting the flag.

The flag sits immediately after `--collect`. `--property=OnFailure=...` is
deliberately **not** added — the recover unit must not chain to itself.

Sibling issue #1210 applies the same fix to `dispatch-schedule-target-reseed`;
this PR scopes only `dispatch-tick-recover`.

## Changes

- `dispatch-tick-recover`: add `--property=KillMode=process` after `--collect`
  in the reseed `systemd-run` call; update the preceding comment to note the
  flag and its #1196 fleet-reaping rationale (load-bearing here, not a fallback —
  this path does not call `ensure_daemon_service`).
- `test-dispatch-scripts.sh`: extend the `dispatch-tick-recover` Test 1 argv
  assertion with a `--property=KillMode=process` conjunct and update its
  PASS/FAIL label to `(calendar + unit + collect + killmode + exec)`.

## Verification

`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` →
`Results: 2401/2401 passed, 0 failed`.

