### PR TITLE
dispatch-review-dedup tests: absent-id partition, empty findings, missing Confidence

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -21206,6 +21206,31 @@ IN3='{"findings":[{"id":"a","Location":"f.ts:1","Source":"review","OWASP":"","ST
 out=$(printf '%s' "$IN3" | "$SCRIPT_DIR/dispatch-review-dedup")
 assert_eq "dedup: same-location distinct-root partition → length 2" "2" "$(printf '%s' "$out" | jq -r 'length')"
 
+# absent-id partition: unknown id is skipped, present finding survives, exit 0
+IN4='{"findings":[{"id":"a","Location":"f.ts:1","Source":"review","OWASP":"","STRIDE":"","Confidence":"low"}],"partition":[["a","zzz"]]}'
+if out=$(printf '%s' "$IN4" | "$SCRIPT_DIR/dispatch-review-dedup"); then rc=0; else rc=$?; fi
+assert_eq "dedup: absent-id partition → exit 0" "0" "$rc"
+assert_eq "dedup: absent-id partition → length 1 (unknown id skipped)" "1" "$(printf '%s' "$out" | jq -r 'length')"
+assert_eq "dedup: absent-id partition → present finding emitted" "a" "$(printf '%s' "$out" | jq -r '.[0].id')"
+# Discriminating assertion: WITHOUT the map(select(.finding != null)) filter
+# (dispatch-review-dedup:79-80), the null member pollutes the union →
+# ["review", null]. exit/length/id all still pass without the filter, so this
+# sources check is the only one that actually guards the absent-id fix.
+assert_eq "dedup: absent-id partition → sources unpolluted by null member" '["review"]' "$(printf '%s' "$out" | jq -c '.[0].sources')"
+
+# empty findings → [], exit 0
+IN5='{"findings":[],"partition":[]}'
+if out=$(printf '%s' "$IN5" | "$SCRIPT_DIR/dispatch-review-dedup"); then rc=0; else rc=$?; fi
+assert_eq "dedup: empty findings → exit 0" "0" "$rc"
+assert_eq "dedup: empty findings → []" "[]" "$(printf '%s' "$out" | jq -c '.')"
+
+# missing Confidence field → graceful fallback (Confidence: null), exit 0
+IN6='{"findings":[{"id":"a","Location":"f.ts:1","Source":"review","OWASP":"","STRIDE":""}],"partition":[]}'
+if out=$(printf '%s' "$IN6" | "$SCRIPT_DIR/dispatch-review-dedup"); then rc=0; else rc=$?; fi
+assert_eq "dedup: missing Confidence → exit 0" "0" "$rc"
+assert_eq "dedup: missing Confidence → length 1" "1" "$(printf '%s' "$out" | jq -r 'length')"
+assert_eq "dedup: missing Confidence → Confidence null fallback" "null" "$(printf '%s' "$out" | jq -c '.[0].Confidence')"
+
 # ============================================================================
 # === dispatch-review-verify-drop ===
 # ============================================================================


### PR DESCRIPTION
Closes #1337

## What

Adds three regression test cases to the `dispatch-review-dedup` block in
`test-dispatch-scripts.sh`, pinning input paths the script exercises but the
harness never asserted:

1. **Absent-id partition** — a partition group references an id (`zzz`) not
   present in `findings`. Asserts the unknown id is skipped, the present finding
   survives, and exit 0. The load-bearing assertion is `sources unpolluted by
   null member`: without `map(select(.finding != null))`
   (`dispatch-review-dedup:79-80`), the dropped id's `null` would pollute the
   merged `sources` union (`["review", null]`). exit/length/id all pass without
   that filter, so this is the only assertion that actually guards the fix.
2. **Empty findings** — `findings: []`, `partition: []` → `[]`, exit 0.
3. **Missing `Confidence` field** — a finding with no `Confidence` key passes
   through with `Confidence: null` (the `confrank` fallback at
   `dispatch-review-dedup:52` ranks missing/null confidence as 0), exit 0.

## Why

The absent-id null-merge crash that motivated this issue (a partition id absent
from `findings` feeding a `null` into the merge, surfaced by #1331) is **already
fixed** at HEAD. This change is **test-only** — no production code is modified.
The new assertions lock in the now-correct behavior so a future refactor cannot
silently re-introduce the crash or change the missing-Confidence fallback.

The three cases capture exit status via an `if` guard rather than a bare
`$(...)` so a non-zero exit asserts gracefully under the harness's
`set -euo pipefail`, instead of aborting the whole run.

## Verification

Full suite passes: `Results: 2410/2410 passed, 0 failed`, with the new
`dedup: absent-id partition …`, `dedup: empty findings …`, and
`dedup: missing Confidence …` lines all PASS.
