### PR TITLE
dispatch-stop: narrow no-PR Branch C backstop to fix-conflicts

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -52,14 +52,17 @@
 #          fix-* failure never reaches Branch C — the fix-* skill skips the marker
 #          for it, so it lands in Branch A (marker absent → park the issue on
 #          office-hours on the first run).
-#      (b) PR_NUM empty (no-PR provisioning backstop, e.g. a fix-conflicts pass
-#          that ran during the implement phase before any PR existed): the attempt
-#          counter lives on a PR label and does not exist yet. Always self-close
-#          and re-seed the chain — the marker being present means the fix-* skill
-#          completed a resolvable conflict. The implement phase that opens the PR
-#          runs on the next tick.
+#      (b) PR_NUM empty AND CURRENT_PHASE is fix-conflicts (the no-PR
+#          provisioning backstop): a fix-conflicts pass that ran during the
+#          implement phase before any PR existed. The attempt counter lives on a
+#          PR label and does not exist yet, so always self-close and re-seed the
+#          chain — the marker being present means fix-conflicts completed a
+#          resolvable conflict. The implement phase that opens the PR runs on the
+#          next tick. This backstop is fix-conflicts-specific: any other fix-*
+#          phase with an empty PR_NUM falls through to Branch D.
 #   D. marker present + same phase + NOT Branch C (i.e. PR-present and attempt
-#      counter >= 3, or a hypothetical same-phase non-fix-* case) — true
+#      counter >= 3, a same-phase fix-* phase other than fix-conflicts with empty
+#      PR_NUM, or a hypothetical same-phase non-fix-* case) — true
 #      non-advancement. Park the ISSUE on a human via dispatch-apply-office-hours
 #      (label + why-comment), spawn router, exit 0.
 #
@@ -281,12 +284,14 @@ case "$CURRENT_PHASE" in
         exit 0
       fi
       # counter at cap: fall through to Branch D (office-hours park)
-    else
-      # Branch C — no-PR provisioning backstop (e.g. a fix-conflicts pass that
-      # ran during the implement phase, before any PR existed). No attempt
-      # counter exists (it lives on a PR label), so always self-close and
-      # re-seed the chain rather than parking — the marker being present means
-      # the fix-* skill completed successfully.
+    elif [ "$CURRENT_PHASE" = 'fix-conflicts' ]; then
+      # Branch C — no-PR provisioning backstop, specific to fix-conflicts: a
+      # fix-conflicts pass that ran during the implement phase, before any PR
+      # existed. No attempt counter exists (it lives on a PR label), so always
+      # self-close and re-seed the chain rather than parking — the marker being
+      # present means fix-conflicts completed successfully. Any OTHER fix-* phase
+      # with an empty PR_NUM matches neither branch and deliberately falls
+      # through to Branch D (office-hours park).
       spawn_tick
       spawn_sweep
       self_close

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -15903,6 +15903,42 @@ else
 fi
 stop_teardown
 
+# --- Test FC1c: fix-checks marker, same phase, no PR (non-fix-conflicts fix-*) → Branch D park
+# A fix-checks pass with no PR (empty PR_NUM) must NOT take the Branch C no-PR
+# self-close (which is fix-conflicts-specific). Instead it falls through to
+# Branch D (office-hours park). This test FAILS before the elif guard (bare else
+# would self-close) and PASSES after.
+echo "Test: stop hook + same phase + fix-checks (non-fix-conflicts fix-*) + no PR → Branch D park (no Branch C self-close)"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+# OMIT find-pr-output → PR_NUM="" (no PR)
+echo "fix-checks" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+echo "phase=fix-checks" > "$TMPDIR_TEST/jobs/abcd1234/phase-completed"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+"$TMPDIR_TEST/hooks/dispatch-stop.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "stop fix-checks-no-pr-fallthrough: hook exits 0" "0" "$rc"
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
+TOTAL=$((TOTAL + 1))
+if [[ "$apply_issue" == "123" && -n "$apply_reason" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop fix-checks-no-pr-fallthrough: dispatch-apply-office-hours invoked with issue 123 + non-empty reason (Branch D park)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop fix-checks-no-pr-fallthrough: dispatch-apply-office-hours invoked with issue 123 + non-empty reason (Branch D park)"
+  echo "    apply-log: $apply_log"
+fi
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "stop fix-checks-no-pr-fallthrough: spawn invoked exactly once" "1" "$spawn_calls"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/self-close-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop fix-checks-no-pr-fallthrough: self-close not invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop fix-checks-no-pr-fallthrough: self-close not invoked"
+fi
+stop_teardown
+
 # --- Test FC2: fix-conflicts marker, same phase, counter >= 3 → Branch D (fuse)
 # A conflict that recurs three times blows the fuse: at attempt 3 the #831
 # invariant falls through to Branch D, parking the issue on dispatch:office-hours


### PR DESCRIPTION
Closes #1330

## What

Narrow the no-PR Branch C backstop in `.claude/hooks/dispatch-stop.sh`'s `fix-*)`
case from a bare `else` (matches **any** `fix-*` phase) to an `elif` guarded on
`fix-conflicts`:

```bash
# before
    else
# after
    elif [ "$CURRENT_PHASE" = 'fix-conflicts' ]; then
```

## Why

PR #1260 (for #1253) added the bare `else` so a `fix-conflicts` pass that runs
during the implement phase — before any PR exists — self-closes and re-seeds the
chain without consulting the per-PR attempt counter (which lives on a PR label
that does not exist yet).

Today this is correct because only `fix-conflicts` can yield a `CURRENT_PHASE`
without a PR. But the bare `else` matches any `fix-*` phase. A future `fix-*`
phase that can complete before a PR exists would bypass the attempt cap and retry
forever instead of parking on `dispatch:office-hours`.

This hardening (identified in review of PR #1260 / #1253) scopes the no-PR
backstop to `fix-conflicts` only. Any other `fix-*` phase with an empty `PR_NUM`
now matches neither the `if [ -n "$PR_NUM" ]` branch nor the new `elif`, so it
falls through to Branch D (office-hours park) as expected. The `fix-conflicts`
no-PR path is unchanged. The `fix-conflicts` SKILL.md already describes this
backstop as fix-conflicts-specific, so the hook now aligns with the doc.

## Changes

- `.claude/hooks/dispatch-stop.sh`: one logic line (`else` → `elif`), plus comment
  updates to Branch C sub-case (b), the inline Branch C comment, and the Branch D
  parenthetical to reflect the narrowed scope.
- `.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`: new
  regression test **FC1c** — a non-`fix-conflicts` `fix-*` phase (`fix-checks`)
  with no PR must fall through to Branch D (office-hours park, no self-close).
  Fails before the change, passes after.

## Verification

- `bash -n .claude/hooks/dispatch-stop.sh` parses clean.
- Full dispatch-scripts suite: 2405/2405 pass, including FC1 (self-close once),
  FC1b (self-close once, unchanged), the new FC1c (Branch D park, no self-close),
  and FC2.
