### PR TITLE
dispatch-propagate: test DISPATCH_USAGE_SAMPLES_SECRET_NAME empty/slash guards

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -22756,6 +22756,30 @@ assert_eq "writer W7 → diagnostic message contains DISPATCH_USAGE_SAMPLES_SECR
   "$([[ "$out" == *"DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE"* ]] && echo 1 || echo 0)"
 su_teardown
 
+# W8 — empty DISPATCH_USAGE_SAMPLES_SECRET_NAME → non-zero exit; writer prints
+# "DISPATCH_USAGE_SAMPLES_SECRET_NAME must be non-empty".
+su_setup
+export DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE="a@b.com"
+export DISPATCH_USAGE_SAMPLES_GROUP_ID="grp-1"
+export DISPATCH_USAGE_SAMPLES_NOW="$SU_NOW"
+export DISPATCH_USAGE_SAMPLES_SECRET_NAME=''
+if out=$(WRITER "$W1_PAYLOAD" 2>&1); then rc=0; else rc=$?; fi
+assert_eq "writer W8 empty SECRET_NAME → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "writer W8 → diagnostic mentions must be non-empty" "1" "$([[ "$out" == *"must be non-empty"* ]] && echo 1 || echo 0)"
+su_teardown
+
+# W9 — slash in DISPATCH_USAGE_SAMPLES_SECRET_NAME → non-zero exit; writer prints
+# "DISPATCH_USAGE_SAMPLES_SECRET_NAME must not contain a slash".
+su_setup
+export DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE="a@b.com"
+export DISPATCH_USAGE_SAMPLES_GROUP_ID="grp-1"
+export DISPATCH_USAGE_SAMPLES_NOW="$SU_NOW"
+export DISPATCH_USAGE_SAMPLES_SECRET_NAME='a/b'
+if out=$(WRITER "$W1_PAYLOAD" 2>&1); then rc=0; else rc=$?; fi
+assert_eq "writer W9 slash SECRET_NAME → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "writer W9 → diagnostic mentions must not contain a slash" "1" "$([[ "$out" == *"must not contain a slash"* ]] && echo 1 || echo 0)"
+su_teardown
+
 # --- SAMPLER cases (fakes only; no real daemon / firebase) ------------------
 
 # S1 — opt-in OFF: DISPATCH_USAGE_SAMPLES_ENABLED unset → exit 0 (no-op); writer

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -23046,7 +23046,7 @@ export DISPATCH_USAGE_SAMPLES_NOW="$SU_NOW"
 export DISPATCH_USAGE_SAMPLES_SECRET_NAME=''
 if out=$(WRITER "$W1_PAYLOAD" 2>&1); then rc=0; else rc=$?; fi
 assert_eq "writer W8 empty SECRET_NAME → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
-assert_eq "writer W8 → diagnostic mentions must be non-empty" "1" "$([[ "$out" == *"must be non-empty"* ]] && echo 1 || echo 0)"
+assert_eq "writer W8 → diagnostic mentions must be non-empty" "1" "$([[ "$out" == *"DISPATCH_USAGE_SAMPLES_SECRET_NAME must be non-empty"* ]] && echo 1 || echo 0)"
 su_teardown
 
 # W9 — slash in DISPATCH_USAGE_SAMPLES_SECRET_NAME → non-zero exit; writer prints
@@ -23058,7 +23058,7 @@ export DISPATCH_USAGE_SAMPLES_NOW="$SU_NOW"
 export DISPATCH_USAGE_SAMPLES_SECRET_NAME='a/b'
 if out=$(WRITER "$W1_PAYLOAD" 2>&1); then rc=0; else rc=$?; fi
 assert_eq "writer W9 slash SECRET_NAME → non-zero exit" "1" "$([[ "$rc" -ne 0 ]] && echo 1 || echo 0)"
-assert_eq "writer W9 → diagnostic mentions must not contain a slash" "1" "$([[ "$out" == *"must not contain a slash"* ]] && echo 1 || echo 0)"
+assert_eq "writer W9 → diagnostic mentions must not contain a slash" "1" "$([[ "$out" == *"DISPATCH_USAGE_SAMPLES_SECRET_NAME must not contain a slash"* ]] && echo 1 || echo 0)"
 su_teardown
 
 # --- SAMPLER cases (fakes only; no real daemon / firebase) ------------------


### PR DESCRIPTION
Closes #1386

## What

Adds two writer unit-test cases to
`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` covering the
two `DISPATCH_USAGE_SAMPLES_SECRET_NAME` guards in `usage-sample-writer.mjs`:

- **W8** — empty `DISPATCH_USAGE_SAMPLES_SECRET_NAME` → asserts non-zero exit and
  a diagnostic containing `must be non-empty`.
- **W9** — slash in `DISPATCH_USAGE_SAMPLES_SECRET_NAME` (`a/b`) → asserts non-zero
  exit and a diagnostic containing `must not contain a slash`.

## Why

`DISPATCH_USAGE_SAMPLES_SECRET_NAME` is interpolated directly into a GCP Secret
Manager resource path. The empty-string and slash guards that defend that
interpolation (`usage-sample-writer.mjs:126-131`) were previously exercised by no
test — the variable appeared only in the teardown `unset` list, so a future
refactor could silently break either guard with no test failure. These two cases
pin both error paths, including the guard-specific diagnostic so a test cannot
pass for the wrong reason.

The guards were added by the now-merged #1385, and the missing coverage was
surfaced by its review pass (backlink #1385).

## Notes

- Each case uses a valid `DISPATCH_USAGE_SAMPLES_SECRET_OVERRIDE` and `GROUP_ID`
  so `SECRET_NAME` is the only invalid input. `SECRET_NAME` is validated first in
  `loadConfig` and `?? DEFAULT_SECRET_NAME` falls back only on null/undefined, so
  an exported empty string stays empty and the length-0 guard fires.
- Named W8/W9 rather than the issue's proposed W7/W8 — a W7 case already exists.
- No change to `usage-sample-writer.mjs` (guards already work) and no teardown
  edit (`SECRET_NAME` is already in the shared `su_teardown` `unset` block).

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` →
**2415/2415 passed, 0 failed** (up from 2411; the four new assertions are green
and no existing case regressed).
