### PR TITLE
dispatch-review-dedup tests: assert partition-split confidence isolation (IN4)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -21296,6 +21296,13 @@ IN3='{"findings":[{"id":"a","Location":"f.ts:1","Source":"review","OWASP":"","ST
 out=$(printf '%s' "$IN3" | "$SCRIPT_DIR/dispatch-review-dedup")
 assert_eq "dedup: same-location distinct-root partition → length 2" "2" "$(printf '%s' "$out" | jq -r 'length')"
 
+# same location, partition splits into separate sub-groups → length 2, each sub-group keeps its own Confidence (no cross-boundary max)
+IN4='{"findings":[{"id":"a","Location":"f.ts:1","Source":"security-review","OWASP":"A03:2021 Injection","STRIDE":"Tampering","Confidence":"high"},{"id":"b","Location":"f.ts:1","Source":"review","OWASP":"","STRIDE":"","Confidence":"low"}],"partition":[["a"],["b"]]}'
+out=$(printf '%s' "$IN4" | "$SCRIPT_DIR/dispatch-review-dedup")
+assert_eq "dedup: partition-split → length 2" "2" "$(printf '%s' "$out" | jq -r 'length')"
+assert_eq "dedup: partition-split → output[0] Confidence preserved (high)" "high" "$(printf '%s' "$out" | jq -r '.[0].Confidence')"
+assert_eq "dedup: partition-split → output[1] Confidence preserved (low)" "low" "$(printf '%s' "$out" | jq -r '.[1].Confidence')"
+
 # ============================================================================
 # === dispatch-review-verify-drop ===
 # ============================================================================


### PR DESCRIPTION
Closes #1338

## What

Adds a fourth test case (`IN4`) to the `dispatch-review-dedup` block in
`test-dispatch-scripts.sh` that pins **per-sub-group confidence isolation**.

## Why

`dispatch-review-dedup` collapses duplicate review findings: mechanical
`path:line` grouping, then a bounded semantic merge within each location group
driven by a caller-supplied `partition`. Within each sub-group the merge takes
the MAX confidence (`high=3 > medium=2 > low=1`).

The existing `IN3` case feeds two same-`Location` findings partitioned into
separate sub-groups and asserts only the output *count* (2) — not that each
split sub-group keeps its own original `Confidence`. A regression that applied
`dedupMerge` *across* partition sub-group boundaries could elevate a
low-confidence finding to `high` via the max-confidence rule while still
emitting 2 outputs, invisible to the count-only assertion.

`IN4` closes that gap. It feeds a `high` and a `low` finding at the same
`Location`, partitioned apart, with the `high` finding first in input order so
it lands at `output[0]` per the earliest-input-index ordering rule, then asserts:

- length 2 (sub-groups stay split),
- `output[0].Confidence == high`,
- `output[1].Confidence == low`.

If the merge ever crossed sub-group boundaries, `output[1]` would be elevated to
`high` and the test would fail.

## Scope

Test-only change. The `dispatch-review-dedup` script, `review-fix.js`, and the
`IN1`/`IN2`/`IN3` cases are byte-for-byte unchanged. The full
`test-dispatch-scripts.sh` suite passes, including the three new `IN4`
assertions.
