### PR TITLE
dispatch-tick-recover: ensure_daemon_service before arming the recovery reseed

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover
@@ -344,6 +344,13 @@ fi
 RESEED_AT=$(( NOW + BACKOFF ))
 UNIT_NAME="dispatch-reseed-${RESEED_AT}"
 
+# Install + activate the durable dispatch-claude-daemon.service (#1197) before
+# arming the recovery reseed, so the reseed's tick attaches to a daemon already
+# running in a stable cgroup rather than spawning one in the transient reseed
+# unit's cgroup. Best-effort: a failure here is non-fatal — the on-demand daemon
+# then falls back to surviving via KillMode=process (#1196).
+ensure_daemon_service || true
+
 RUN_STDERR=$(mktemp)
 trap 'rm -f "$RUN_STDERR"' EXIT
 # Capture the exit code directly — after `if cmd; then ... fi`, `$?` is the exit

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -12207,6 +12207,23 @@ exit 0
 STUB
   chmod +x "$TMPDIR_TEST/bin/gh"
 
+  # ensure_daemon_service (lib.sh) would otherwise write to the real
+  # ~/.config/systemd/user/ and run a real `systemctl --user`. Wire a separate
+  # logging stub (distinct from the recover systemctl) so ensure_daemon_service
+  # calls land in daemon-systemctl-log and are separately assertable.
+  cat > "$TMPDIR_TEST/bin/daemon-systemctl" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/daemon-systemctl-log"
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/daemon-systemctl"
+  export DISPATCH_DAEMON_UNIT_DIR="$TMPDIR_TEST/daemon-systemd-user"
+  export DISPATCH_DAEMON_SYSTEMCTL_CMD="$TMPDIR_TEST/bin/daemon-systemctl"
+  # ensure_daemon_service only needs a non-empty, newline/quote-free path; it
+  # does not execute this binary in tests — the claude stub already exists for
+  # the CLAUDE_AGENTS_CMD path, so reuse it.
+  export DISPATCH_DAEMON_CLAUDE_CMD="$TMPDIR_TEST/bin/claude"
+
   export DISPATCH_TICK_RECOVER_SYSTEMD_RUN_CMD="$TMPDIR_TEST/bin/systemd-run"
   export DISPATCH_TICK_RECOVER_SYSTEMCTL_CMD="$TMPDIR_TEST/bin/systemctl"
   export DISPATCH_TICK_RECOVER_GH_CMD="$TMPDIR_TEST/bin/gh"
@@ -12235,6 +12252,7 @@ tr_teardown() {
   unset DISPATCH_TICK_RECOVER_BASE_BACKOFF
   unset DISPATCH_TICK_RECOVER_MAX_BACKOFF
   unset DISPATCH_TICK_RECOVER_RESET_WINDOW
+  unset DISPATCH_DAEMON_UNIT_DIR DISPATCH_DAEMON_SYSTEMCTL_CMD DISPATCH_DAEMON_CLAUDE_CMD
 }
 
 # tr_seed_state <count> <last_failure> — write the consecutive-failure state.
@@ -12279,6 +12297,27 @@ fi
 assert_eq "first-fail: state count == 1" "1" "$(tr_state_count)"
 tr_teardown
 
+# --- Test 1b: first failure → ensure_daemon_service ran on the arming path ---
+# Same scenario as Test 1 (first failure, no continuation). Assert that
+# ensure_daemon_service ran and called `systemctl --user enable --now
+# dispatch-claude-daemon.service` — proving the durable daemon is set up
+# before the recovery reseed is armed (#1197/#1196).
+
+echo "Test: first failure arming path calls ensure_daemon_service (daemon enabled)"
+tr_setup
+# No state file, empty timer list, 0 busy workers → arming path.
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "first-fail-daemon: dispatch-tick-recover exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if grep -q 'enable --now dispatch-claude-daemon.service' \
+     "$TMPDIR_TEST/daemon-systemctl-log" 2>/dev/null; then
+  PASS=$((PASS + 1)); echo "  PASS: first-fail-daemon: ensure_daemon_service ran enable --now"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: first-fail-daemon: ensure_daemon_service ran enable --now"
+  echo "    daemon-systemctl-log: $(cat "$TMPDIR_TEST/daemon-systemctl-log" 2>/dev/null || echo '(absent)')"
+fi
+tr_teardown
+
 # --- Test 2: continuation present (busy worker) → no reseed, count reset -----
 
 echo "Test: a live busy worker is a continuation → no reseed, count reset to 0"
@@ -12290,6 +12329,9 @@ assert_eq "busy-worker: dispatch-tick-recover exits 0" "0" "$rc"
 log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 assert_eq "busy-worker: no reseed armed (systemd-run log empty)" "" "$log"
 assert_eq "busy-worker: state count reset to 0" "0" "$(tr_state_count)"
+# Continuation no-op path: ensure_daemon_service must NOT have run (no arming).
+assert_eq "busy-worker: daemon service not touched (continuation no-op)" \
+  "" "$(cat "$TMPDIR_TEST/daemon-systemctl-log" 2>/dev/null || true)"
 tr_teardown
 
 # --- Test 3: continuation present (pending dispatch-reseed* timer) → no reseed -
@@ -12303,6 +12345,9 @@ if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
 assert_eq "pending-timer: dispatch-tick-recover exits 0" "0" "$rc"
 log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 assert_eq "pending-timer: no reseed armed (systemd-run log empty)" "" "$log"
+# Continuation no-op path: ensure_daemon_service must NOT have run (no arming).
+assert_eq "pending-timer: daemon service not touched (continuation no-op)" \
+  "" "$(cat "$TMPDIR_TEST/daemon-systemctl-log" 2>/dev/null || true)"
 tr_teardown
 
 # --- Test 4: cap reached → escalate, not retry -------------------------------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -12835,6 +12835,10 @@ assert_eq "cap-latched: no issue create (latch already open)" \
   "0" "$([[ "$ghlog" != *"issue create"* ]] && echo 0 || echo 1)"
 log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 assert_eq "cap-latched: no reseed armed (systemd-run log empty)" "" "$log"
+# Cap-escalation path exits before the arming step: ensure_daemon_service must
+# NOT have run (mirrors the continuation no-op negative assertions above).
+assert_eq "cap: daemon service not touched (cap-escalation path)" \
+  "" "$(cat "$TMPDIR_TEST/daemon-systemctl-log" 2>/dev/null || true)"
 tr_teardown
 
 # --- Test 5: backoff grows with the consecutive-failure count ----------------


### PR DESCRIPTION
Closes #1370

## What

`dispatch-tick-recover` is the `OnFailure=` systemd handler that guarantees a
dispatch-chain continuation after an abnormal tick/reseed exit. When no
continuation exists and the failure count is under the cap, its Step 5 arms a
bounded-backoff recovery reseed by calling `systemd-run --user` directly.

This PR adds `ensure_daemon_service || true` to that arming path — after
`UNIT_NAME` is computed and before the `systemd-run` call — matching the three
sibling launchers (`dispatch-spawn-tick`, `dispatch-schedule-reseed`,
`dispatch-schedule-convergence-reseed`), which all install/activate the durable
`dispatch-claude-daemon.service` (#1197) before arming.

## Why

Without this call, if the daemon service is in systemd's `failed` state (e.g.
`StartLimit` exhausted) and the chain is revived via the recover handler,
`ensure_daemon_service` never runs to reset/revive the service, so the recovery
reseed's tick reverts to the transient-cgroup behavior that #1217 superseded
(the on-demand daemon spawning inside the transient unit's cgroup, #1196).
Surfaced by the #1217 review pass; out of scope for that PR.

## Placement — arming path only

The call sits on the arming path **only**, not early/unconditional like the
siblings. The continuation no-op path (Step 2) and the cap-escalation path
(Step 4) do not spawn a tick, so they need no durable daemon. This matches the
issue's wording "before the `systemd-run` call that arms the recovery reseed".
`ensure_recover_unit` is deliberately **not** added — the recover unit must not
chain to itself.

## Tests

`test-dispatch-scripts.sh`, `dispatch-tick-recover` section:

- `tr_setup` now installs a dedicated `daemon-systemctl` logging stub and exports
  the three `DISPATCH_DAEMON_*` overrides, so the real `ensure_daemon_service`
  never writes to `~/.config/systemd/user/` or runs real `systemctl --user`
  during the suite. `tr_teardown` unsets them.
- New positive test: after a first-failure arm, the daemon log contains
  `enable --now dispatch-claude-daemon.service` — proof the call fires on the
  arming path.
- Negative assertions on the busy-worker and pending-timer continuation no-op
  paths: the daemon log stays empty, locking in arming-path-only placement.

The `/proc/<daemon-pid>/cgroup` runtime property (AC#3) is satisfied by
construction and is not unit-testable under the stub harness — it is covered by
the call now existing on the arming path plus `ensure_daemon_service`'s own
existing install/activate tests.

Full suite: 2415/2415 passing.
