### PR TITLE
plan-issue: write the plan-phase marker before the dispatch:planned label

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-plan-finalize
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-plan-finalize
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# dispatch-plan-finalize — compose the three plan-completion sub-steps in the
+# correct order, closing the crash window that issue #1230 describes.
+#
+# Usage: dispatch-plan-finalize <issue-num>   (plan markdown on STDIN)
+#
+# Runs the three sub-steps in this fixed order:
+#   1. dispatch-write-plan <issue-num>     — persist the plan comment (durable)
+#   2. dispatch-mark-complete --phase plan — write the per-session marker (ephemeral)
+#   3. dispatch-apply-planned <issue-num>  — apply the dispatch:planned label (durable)
+#
+# Load-bearing invariant: the marker (step 2) is written BEFORE the label
+# (step 3). The durable label's presence therefore guarantees the ephemeral
+# per-session marker was also written in the same session. If a session crashes
+# between step 2 and step 3, the label is absent — dispatch-phase returns
+# "plan" and the issue is recoverable via office-hours plan-clarification. The
+# previous (reversed) order left the label set but the marker gone, causing
+# dispatch-phase to derive "implement" (no PR) and dead-end in office-hours
+# deviation-review, which never re-runs the plan.
+#
+# Each sub-step is individually idempotent: dispatch-write-plan finds or
+# updates the existing sentinel comment (never stacks a second); dispatch-
+# mark-complete does an atomic tempfile+mv and no-ops when CLAUDE_JOB_DIR is
+# unset; dispatch-apply-planned uses --add-label (naturally idempotent). The
+# whole sequence is therefore safe to re-run.
+#
+# A missing arg or non-numeric issue-num is a clear error, not a fallback
+# (exit 2). Empty STDIN is not re-validated here — dispatch-write-plan already
+# rejects it with exit 2, which propagates through set -euo pipefail.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+N="${1:-}"
+if [[ $# -ne 1 || -z "$N" ]]; then
+  echo "dispatch-plan-finalize: exactly one issue-num argument is required" >&2
+  echo "usage: dispatch-plan-finalize <issue-num>   (plan markdown on STDIN)" >&2
+  exit 2
+fi
+if [[ ! "$N" =~ ^[0-9]+$ ]]; then
+  echo "dispatch-plan-finalize: issue-num must be a positive integer, got: $N" >&2
+  echo "usage: dispatch-plan-finalize <issue-num>   (plan markdown on STDIN)" >&2
+  exit 2
+fi
+
+CONTENT="$(cat)"
+
+# Step 1: persist the plan comment — durable, idempotent (find-or-update).
+printf '%s' "$CONTENT" | "$SCRIPT_DIR/dispatch-write-plan" "$N"
+
+# Step 2: write the per-session phase-completed marker — BEFORE the label.
+"$SCRIPT_DIR/dispatch-mark-complete" --phase plan
+
+# Step 3: apply the dispatch:planned label — LAST action.
+"$SCRIPT_DIR/dispatch-apply-planned" "$N"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -62,6 +62,12 @@ setup() {
   cp "$SCRIPT_DIR/dispatch-complete-phase" "$TMPDIR_TEST/dispatch-complete-phase"
   cp "$SCRIPT_DIR/dispatch-apply-office-hours" "$TMPDIR_TEST/dispatch-apply-office-hours"
   cp "$SCRIPT_DIR/dispatch-apply-planned" "$TMPDIR_TEST/dispatch-apply-planned"
+  # dispatch-plan-finalize resolves its three siblings (dispatch-write-plan,
+  # dispatch-mark-complete, dispatch-apply-planned) via SCRIPT_DIR, which
+  # resolves to TMPDIR_TEST for this copy — so a test stubs those siblings here
+  # in TMPDIR_TEST to observe the call order (#1230).
+  cp "$SCRIPT_DIR/dispatch-plan-finalize" "$TMPDIR_TEST/dispatch-plan-finalize"
+  chmod +x "$TMPDIR_TEST/dispatch-plan-finalize"
   cp "$SCRIPT_DIR/dispatch-resolve-worktree" "$TMPDIR_TEST/dispatch-resolve-worktree"
   # dispatch-reconcile-ready sources lib.sh (for dispatch_classify_rollup) via its
   # SCRIPT_DIR, which resolves to TMPDIR_TEST for this copy — lib.sh is copied
@@ -5499,6 +5505,69 @@ echo "Test: missing issue number → non-zero exit"
 setup
 if "$TMPDIR_TEST/dispatch-apply-planned" 2>/dev/null; then rc=0; else rc=$?; fi
 assert_eq "missing issue number exits non-zero" "1" "$rc"
+teardown
+
+# ============================================================================
+# dispatch-plan-finalize tests (#1230)
+# ============================================================================
+echo ""
+echo "=== dispatch-plan-finalize ==="
+
+# #1230: dispatch-plan-finalize composes the three plan-completion sub-steps in a
+# fixed order whose load-bearing invariant is marker-BEFORE-label:
+#   1. dispatch-write-plan       (persist the plan comment — durable)
+#   2. dispatch-mark-complete    (write the per-session phase-completed marker)
+#   3. dispatch-apply-planned    (apply the dispatch:planned label — LAST)
+# Because the durable label is written last, its presence guarantees the
+# ephemeral marker was already written in the same session. A crash in the
+# window between step 2 and step 3 leaves the label ABSENT, so dispatch-phase
+# returns "plan" (recoverable via office-hours plan-clarification) instead of
+# "implement" (the old dead-end). This test pins that order so it cannot silently
+# drift back to the pre-fix (label-before-marker) sequence.
+echo "Test: dispatch-plan-finalize runs siblings in marker-before-label order (#1230)"
+setup
+export STUB_DIR  # the order-logging sibling stubs read STUB_DIR from the env
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/job"
+mkdir -p "$CLAUDE_JOB_DIR"
+# Overwrite the three siblings in TMPDIR_TEST (where dispatch-plan-finalize's
+# SCRIPT_DIR resolves) with order-logging stubs.
+cat > "$TMPDIR_TEST/dispatch-write-plan" <<'STUB'
+#!/usr/bin/env bash
+cat >/dev/null
+echo write-plan >> "$STUB_DIR/finalize-order.log"
+STUB
+# dispatch-mark-complete logs AND touches the marker — load-bearing: the
+# apply-planned stub asserts the marker already exists when it runs, so a stub
+# that only logged would make the order assertion misleading.
+cat > "$TMPDIR_TEST/dispatch-mark-complete" <<'STUB'
+#!/usr/bin/env bash
+echo mark-complete >> "$STUB_DIR/finalize-order.log"
+touch "$CLAUDE_JOB_DIR/phase-completed"
+STUB
+cat > "$TMPDIR_TEST/dispatch-apply-planned" <<'STUB'
+#!/usr/bin/env bash
+if [[ -f "$CLAUDE_JOB_DIR/phase-completed" ]]; then
+  echo apply-planned >> "$STUB_DIR/finalize-order.log"
+else
+  echo apply-planned-NO-MARKER >> "$STUB_DIR/finalize-order.log"
+fi
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-write-plan" \
+         "$TMPDIR_TEST/dispatch-mark-complete" \
+         "$TMPDIR_TEST/dispatch-apply-planned"
+"$TMPDIR_TEST/dispatch-plan-finalize" 55 <<<'plan body text'
+# The order log records the three steps in sequence. apply-planned (not
+# apply-planned-NO-MARKER) confirms the marker existed when apply-planned ran —
+# i.e. the marker was written before the label.
+assert_eq "dispatch-plan-finalize: marker before label (#1230)" \
+  "$(printf 'write-plan\nmark-complete\napply-planned\n')" \
+  "$(cat "$STUB_DIR/finalize-order.log")"
+# Arg-validation smoke: a non-numeric issue-num exits 2. This path returns at the
+# integer check BEFORE reading STDIN or calling any sibling, so </dev/null is
+# harmless, finalize-order.log is untouched, and no network is reached.
+if "$TMPDIR_TEST/dispatch-plan-finalize" abc </dev/null 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "dispatch-plan-finalize: non-numeric arg exits 2" "2" "$rc"
+unset CLAUDE_JOB_DIR
 teardown
 
 # ============================================================================
@@ -15627,6 +15696,65 @@ if [[ ! -e "$STUB_DIR/self-close-calls.log" ]]; then
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: stop marker-absent: self-close not invoked"
 fi
+stop_teardown
+
+# --- Test 5a1: #1230 crash-before-label routing regression -------------------
+# #1230 hardened the plan phase so the per-session phase-completed marker is
+# written BEFORE the durable dispatch:planned label. This test models the
+# post-fix crash window: a session crashed after writing the marker (phase=plan)
+# but before applying the label, so the label is ABSENT and no PR exists yet.
+#
+# In that window dispatch-phase derives "plan" (no label + no PR → plan), so the
+# Stop hook sees MARKER_PHASE=plan, CURRENT_PHASE=plan (equal → not Branch B),
+# and plan is not a fix-* phase (→ not Branch C) → Branch D: park the ISSUE on a
+# human via dispatch-apply-office-hours, spawn the next tick, exit 0, NO
+# self-close, NO strip. The issue is recoverable via office-hours
+# plan-clarification — NOT the pre-fix dead-end where a present label + absent
+# marker drove dispatch-phase to "implement" and stranded the issue in
+# deviation-review.
+#
+# Scope: this test pins the ROUTING decision GIVEN CURRENT_PHASE=plan — it does
+# NOT itself derive the phase (the dispatch-phase fake just echoes
+# current-phase.txt). The hinge derivation (no-label/no-PR → plan vs.
+# label/no-PR → implement) is pinned SEPARATELY by two existing dispatch-phase
+# tests, which together show the two halves of the crash-window invariant:
+#   - assert "issue 6 does not match branch 60-foo → plan"  (no dispatch:planned + no PR → plan;
+#     in the dispatch-phase section — the bare echo title is shared, but this assert label is unique)
+#   - "Test: no PR + dispatch:planned → INVOKE /implement"   (dispatch:planned + no PR → implement)
+
+echo "Test: stop hook + marker=plan + no label + no PR (#1230 crash window) → Branch D park, no self-close, no strip"
+stop_setup
+echo "55-harden-idempotency" > "$STUB_DIR/current-branch.txt"
+echo '{"name":"55-harden-idempotency"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+echo "phase=plan" > "$TMPDIR_TEST/jobs/abcd1234/phase-completed"
+# No find-pr-output → dispatch-find-pr returns "" → PR_NUM="" (the no-PR window).
+# No ci-ready.txt → dispatch-ci-ready exits 0 (ready), so the early not-ready
+# gate PASSES and execution reaches the branch logic.
+echo "plan" > "$STUB_DIR/current-phase.txt"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+"$TMPDIR_TEST/hooks/dispatch-stop.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "stop #1230 crash-window: hook exits 0" "0" "$rc"
+# Parked recoverably on the RIGHT issue: JOB_NAME 55-harden-idempotency → issue 55.
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
+TOTAL=$((TOTAL + 1))
+if [[ "$apply_issue" == "55" && -n "$apply_reason" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop #1230 crash-window: office-hours parked on issue 55 + non-empty reason (recoverable)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop #1230 crash-window: office-hours parked on issue 55 + non-empty reason (recoverable)"
+  echo "    apply-log: $apply_log"
+fi
+# Did NOT self-close (Branch D is a non-advance, not an advance).
+assert_eq "stop #1230 crash-window: self-close NOT invoked" "absent" "$(log_state self-close-calls.log)"
+# Did NOT strip — Branch B's strip is the only remove path; its absence proves
+# we did NOT take Branch B (no false advance).
+assert_eq "stop #1230 crash-window: no PR remove-label (no strip)" "absent" "$(log_state gh-pr-remove.log)"
+assert_eq "stop #1230 crash-window: no issue remove-label (no strip)" "absent" "$(log_state gh-issue-remove.log)"
+# Branch D still re-seeds the chain.
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "stop #1230 crash-window: spawn invoked exactly once" "1" "$spawn_calls"
 stop_teardown
 
 # --- Test 5b: not-ready (CI back in progress) → early gate: spawn only, no office-hours

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -25,9 +25,9 @@ skill, no nesting). The exploration and design subagents are direct children of
 this session.
 
 Run `gh` commands and the scripts that invoke `gh` (`dispatch-context-pack`,
-`dispatch-drift-scan`, `dispatch-write-plan`, `dispatch-apply-planned`,
-`dispatch-mark-complete`) with `dangerouslyDisableSandbox: true` — see
-`.claude/rules/sandbox.md`.
+`dispatch-drift-scan`, `dispatch-read-plan`, `dispatch-write-plan`,
+`dispatch-apply-planned`, `dispatch-mark-complete`, `dispatch-plan-finalize`)
+with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
 
 ## The running session has no plan mode
 
@@ -56,17 +56,50 @@ case "$BRANCH" in
 esac
 ```
 
-Then check whether the issue already carries `dispatch:planned` (use
-`dangerouslyDisableSandbox: true` — `gh` needs network):
+Then check whether a plan was already persisted, keying the skip on the **plan
+comment** — the durable record of the expensive planning work — not on the
+`dispatch:planned` label. Read the persisted plan, capturing its stdout (use
+`dangerouslyDisableSandbox: true` — `dispatch-read-plan` calls `gh`). The script
+exits non-zero with a clear diagnostic when no `<!-- dispatch:plan -->` comment
+exists; treat that non-zero exit as "no plan comment":
 
 ```bash
-gh issue view "$N" --json labels | jq -r '.labels[].name'
+EXISTING_PLAN=$(.claude/skills/dispatch-propagate/scripts/dispatch-read-plan "$N") \
+  && HAVE_PLAN=1 || HAVE_PLAN=0
 ```
 
-If `dispatch:planned` is already present, this is an interrupted prior run — the
-plan was already persisted and the label applied, which is this skill's terminal
-action. **Skip all steps and return**; re-entry is a true no-op. Otherwise run
-the steps in order.
+**Plan comment exists** (`HAVE_PLAN=1`) — a prior session already did the
+expensive planning (explore / design / persist), and that work is durable.
+**Skip Steps 1–6.** Re-finalize so the *current* session writes its own marker
+and the chain advances — pipe the already-read plan back through finalize so
+there is no second fetch (`dangerouslyDisableSandbox: true` — `dispatch-plan-finalize`
+calls `gh`):
+
+```bash
+printf '%s' "$EXISTING_PLAN" | \
+  .claude/skills/dispatch-propagate/scripts/dispatch-plan-finalize "$N"
+```
+
+Then **stop**. `dispatch-plan-finalize` runs three steps in order:
+`dispatch-write-plan` re-writes the identical comment (a harmless refresh, never
+a second comment), then `dispatch-mark-complete` writes **this** session's
+marker, then `dispatch-apply-planned` re-adds the label idempotently. With the
+marker now present, `dispatch-stop.sh` Branch B advances the chain to
+`implement`.
+
+**No plan comment** (`HAVE_PLAN=0`) — a genuine fresh run, or a crash before the
+plan was ever persisted. Run all the steps below in order.
+
+This mirrors the `/implement` pattern: skip the expensive work when its durable
+artifact already exists, but **always write the marker** for the running session
+(`/implement` skips its build when a PR already exists but still writes the
+marker, to cover a same-tick crash between PR-open and marker-write). The
+`dispatch:planned` label is **no longer** the idempotency signal — the persisted
+plan comment is the durable signal, and the marker is always (re)written for the
+running session. Recovery when a prior session crashed in the window routes
+through office-hours' plan-clarification path: it is office-hours-recoverable,
+**not** a fully autonomous self-heal, because the autonomous tick skips
+office-hours-labelled issues.
 
 ## Steps
 
@@ -260,24 +293,26 @@ auto-complete (Step 7) or marker-absent stop → office-hours.
 ### 7. Persist + complete
 
 Assemble the final plan markdown (the plan-comment output schema below) and write
-it to `tmp/plan-<N>.md`, then run, in order (all with
-`dangerouslyDisableSandbox: true` — each invokes `gh`):
+it to `tmp/plan-<N>.md` first, then run the single ordered finalize call (with
+`dangerouslyDisableSandbox: true` — it invokes `gh`):
 
 ```bash
-# 1. Persist the plan to the issue's find-or-update <!-- dispatch:plan --> comment.
-.claude/skills/dispatch-propagate/scripts/dispatch-write-plan "$N" < tmp/plan-<N>.md
-
-# 2. Apply the dispatch:planned phase-completion label (create-on-first-use).
-.claude/skills/dispatch-propagate/scripts/dispatch-apply-planned "$N"
-
-# 3. Write the phase-completed marker — no --pr (the plan phase has no PR).
-.claude/skills/dispatch-propagate/scripts/dispatch-mark-complete --phase plan
+.claude/skills/dispatch-propagate/scripts/dispatch-plan-finalize "$N" < tmp/plan-<N>.md
 ```
 
-`dispatch-write-plan` is find-or-update — re-running replaces the plan comment,
-it never stacks a second one. `dispatch-mark-complete --phase plan` takes **no
-`--pr`** (the plan phase completes on a no-PR issue). `CLAUDE_JOB_DIR` unset = an
-interactive run; the marker script no-ops with a clear diagnostic.
+`dispatch-plan-finalize` runs three steps in a fixed order: it persists the plan
+via a find-or-update `<!-- dispatch:plan -->` comment (never stacks a second),
+then writes the phase-completed marker (no `--pr` — the plan phase has no PR),
+then applies the `dispatch:planned` label **last**. The whole call is
+find-or-update / idempotent, so it is safe to re-run.
+
+The marker-before-label ordering is load-bearing: the durable label's presence
+guarantees the per-session marker was written in the same session. A crash in the
+window between the marker and the label leaves the label **absent**, so
+`dispatch-phase` returns `plan` (not `implement`) and the issue is
+office-hours-recoverable via the plan-clarification residue — instead of
+dead-ending as `implement`. With `CLAUDE_JOB_DIR` unset (an interactive run) the
+marker write is a clear-diagnostic no-op.
 
 Then **stop**. The Stop hook (`.claude/hooks/dispatch-stop.sh`) reads the marker,
 re-derives the phase (now `implement`, since `dispatch:planned` is present),


### PR DESCRIPTION
Closes #1230

## Problem

`/plan-issue`'s terminal Step 7 ran three actions in this order:

1. `dispatch-write-plan` — persist the `<!-- dispatch:plan -->` comment (durable).
2. `dispatch-apply-planned` — apply the `dispatch:planned` label (durable).
3. `dispatch-mark-complete --phase plan` — write the per-session marker (ephemeral).

If a session died between (2) and (3), the durable `dispatch:planned` label was
set but no marker was written. The damage was not merely a no-op re-entry — the
issue became **unreachable by `/plan-issue` at all**:

- `dispatch-stop.sh` finds the marker absent → Branch A → parks the issue on
  `dispatch:office-hours`.
- With `dispatch:planned` present and no PR, `dispatch-phase` derives the phase as
  **`implement`**, not `plan`.
- `/office-hours` routes an `implement`-phase parked item to deviation-review,
  which by design does not re-run any phase skill.

So the issue dead-ended: `/plan-issue` never ran again, and the only escape was a
human removing `dispatch:planned`. Found during review of PR #1228.

## Fix

Reverse the order so the **marker is written before the label** (issue's "Option
2", made a code invariant). A crash in the window now leaves the label *absent* →
`dispatch-phase` returns `plan` → `/office-hours` routes it to the
plan-clarification residue, which re-runs `/plan-issue`. Because the label is the
last action, its presence guarantees the marker was written in the same session,
so the desync that stranded the issue can no longer occur. Recovery is
office-hours-recoverable (the autonomous tick skips office-hours-labelled issues,
so this is not a fully autonomous self-heal — but it no longer requires manual
label surgery).

The idempotency preamble is also hardened to key on the durable **plan comment**
rather than the label, and to **always (re)write the marker** on re-entry —
mirroring `/implement`, which skips its expensive build when a PR already exists
but still writes the marker to cover a same-tick crash between PR-open and
marker-write. Per the push-logic-into-scripts preference (#975), the ordered
terminal sequence becomes a single tested script rather than three prose calls a
future edit could silently reorder.

## Changes

- **`dispatch-plan-finalize`** (new script) — the single ordered terminal
  sequence: `dispatch-write-plan` → `dispatch-mark-complete --phase plan` (marker)
  → `dispatch-apply-planned` (label, last). Composes the three existing scripts;
  adds no new `gh`/git logic. Each sub-step is individually idempotent, so the
  whole sequence is safe to re-run.
- **`plan-issue/SKILL.md`** — Step 7 now makes the single `dispatch-plan-finalize`
  call. The idempotency preamble keys the skip on the persisted plan comment (via
  `dispatch-read-plan`), not the `dispatch:planned` label, and always (re)writes
  the current session's marker on re-entry.
- **`test-dispatch-scripts.sh`** — two regression tests:
  - **call-order invariant** — stubs the three siblings; the `mark-complete` stub
    creates the marker and the `apply-planned` stub asserts it already exists,
    pinning marker-before-label so the order cannot silently drift back.
  - **crash-before-label routing** — the post-fix crash window (marker
    `phase=plan`, no label, no PR) parks recoverably as the plan phase (Branch D —
    no self-close, no advance), not the old `implement` dead-end.

## Verification

`run-unit-tests.sh` passes (16/16 suites; `test-dispatch-scripts.sh` 2419/2419,
0 failed), with both new tests in the PASS set.
