### PR TITLE
rules-test: add Firestore list-query + group-gated CRUD coverage, wire suite into CI

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/run-rules-test.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-rules-test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SCRIPTS="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck source=lib.sh
+source "$SCRIPTS/lib.sh"
+
+# rules-test is a workspace; the emulator-backed suite needs the workspace
+# node_modules at the repo root. ensure_deps installs them when absent.
+ensure_deps
+
+echo "=== rules-test (Firestore rules unit suite) ==="
+# Boots the Firestore + Storage emulators (emulator startup also validates rules
+# syntax), then runs the vitest rules suite against them.
+npm test --prefix "$REPO_ROOT/rules-test"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,6 +34,35 @@ jobs:
       - name: Run unit tests
         run: .claude/skills/dispatch-propagate/scripts/run-unit-tests.sh
 
+  rules-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+      - name: Detect changed file categories
+        id: changes
+        run: .claude/skills/dispatch-propagate/scripts/detect-changes.sh
+      - name: Set up Java (if firestore.rules changed)
+        if: steps.changes.outputs.rules == 'true'
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: "21"
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: .node-version
+          cache: 'npm'
+      - name: Cache Firebase emulators
+        if: steps.changes.outputs.rules == 'true'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.cache/firebase/emulators
+          key: firebase-emulators-${{ runner.os }}
+      - name: Run rules-test suite
+        if: steps.changes.outputs.rules == 'true'
+        run: .claude/skills/dispatch-propagate/scripts/run-rules-test.sh
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/rules-test/test/firestore/budget-journal-entries.test.ts
+++ b/rules-test/test/firestore/budget-journal-entries.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, beforeAll, beforeEach } from "vitest";
+import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
+import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
+import { doc, getDoc, setDoc, updateDoc, deleteDoc } from "firebase/firestore";
+import {
+  getTestEnv,
+  authenticatedContext,
+  unauthenticatedContext,
+  adminSetDoc,
+  setupCleanup,
+} from "../setup.js";
+
+const ENV = "test";
+const MEMBERS = ["member@test.com", "other@test.com"];
+const GROUP_ID = "group1";
+
+const baseDoc = {
+  timestamp: new Date("2024-01-15T00:00:00Z"),
+  description: "Opening balance",
+  note: "memo",
+  legCount: 2,
+  groupId: GROUP_ID,
+  memberEmails: MEMBERS,
+};
+
+describe("budget journal entries", () => {
+  let env: RulesTestEnvironment;
+
+  beforeAll(async () => {
+    env = await getTestEnv();
+  });
+
+  setupCleanup();
+
+  beforeEach(async () => {
+    await adminSetDoc(env, `budget/${ENV}/groups/${GROUP_ID}`, {
+      members: MEMBERS,
+    });
+    await adminSetDoc(env, `budget/${ENV}/journal-entries/existing1`, baseDoc);
+  });
+
+  describe("read", () => {
+    it("allows member to read", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        getDoc(doc(db, `budget/${ENV}/journal-entries/existing1`)),
+      );
+    });
+
+    it("denies non-member read", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        getDoc(doc(db, `budget/${ENV}/journal-entries/existing1`)),
+      );
+    });
+
+    it("denies unauthenticated read", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        getDoc(doc(db, `budget/${ENV}/journal-entries/existing1`)),
+      );
+    });
+  });
+
+  describe("create", () => {
+    it("allows member to create valid doc", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `budget/${ENV}/journal-entries/new1`), baseDoc),
+      );
+    });
+
+    it("denies non-member create", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/journal-entries/new1`), baseDoc),
+      );
+    });
+
+    it("denies create when memberEmails != group.members", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/journal-entries/new1`), {
+          ...baseDoc,
+          memberEmails: ["member@test.com"],
+        }),
+      );
+    });
+
+    it("denies create with invalid field", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/journal-entries/new1`), {
+          ...baseDoc,
+          legCount: "two",
+        }),
+      );
+    });
+  });
+
+  describe("update", () => {
+    it("allows member to update mutable field", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        updateDoc(doc(db, `budget/${ENV}/journal-entries/existing1`), {
+          description: "updated",
+        }),
+      );
+    });
+
+    it("denies changing groupId", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        updateDoc(doc(db, `budget/${ENV}/journal-entries/existing1`), {
+          groupId: "group2",
+        }),
+      );
+    });
+
+    it("denies changing memberEmails", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        updateDoc(doc(db, `budget/${ENV}/journal-entries/existing1`), {
+          memberEmails: ["member@test.com"],
+        }),
+      );
+    });
+
+    it("denies non-member update", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        updateDoc(doc(db, `budget/${ENV}/journal-entries/existing1`), {
+          description: "hack",
+        }),
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("allows member to delete", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        deleteDoc(doc(db, `budget/${ENV}/journal-entries/existing1`)),
+      );
+    });
+
+    it("denies non-member delete", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        deleteDoc(doc(db, `budget/${ENV}/journal-entries/existing1`)),
+      );
+    });
+  });
+});

--- a/rules-test/test/firestore/budget-journal-legs.test.ts
+++ b/rules-test/test/firestore/budget-journal-legs.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, beforeAll, beforeEach } from "vitest";
+import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
+import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
+import { doc, getDoc, setDoc, updateDoc, deleteDoc } from "firebase/firestore";
+import {
+  getTestEnv,
+  authenticatedContext,
+  unauthenticatedContext,
+  adminSetDoc,
+  setupCleanup,
+} from "../setup.js";
+
+const ENV = "test";
+const MEMBERS = ["member@test.com", "other@test.com"];
+const GROUP_ID = "group1";
+
+const baseDoc = {
+  entryId: "entry1",
+  accountId: "acct1",
+  debit: 100,
+  credit: 0,
+  timestamp: new Date("2024-01-15T00:00:00Z"),
+  cleared: false,
+  groupId: GROUP_ID,
+  memberEmails: MEMBERS,
+};
+
+describe("budget journal legs", () => {
+  let env: RulesTestEnvironment;
+
+  beforeAll(async () => {
+    env = await getTestEnv();
+  });
+
+  setupCleanup();
+
+  beforeEach(async () => {
+    await adminSetDoc(env, `budget/${ENV}/groups/${GROUP_ID}`, {
+      members: MEMBERS,
+    });
+    await adminSetDoc(env, `budget/${ENV}/journal-legs/existing1`, baseDoc);
+  });
+
+  describe("read", () => {
+    it("allows member to read", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        getDoc(doc(db, `budget/${ENV}/journal-legs/existing1`)),
+      );
+    });
+
+    it("denies non-member read", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        getDoc(doc(db, `budget/${ENV}/journal-legs/existing1`)),
+      );
+    });
+
+    it("denies unauthenticated read", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        getDoc(doc(db, `budget/${ENV}/journal-legs/existing1`)),
+      );
+    });
+  });
+
+  describe("create", () => {
+    it("allows member to create valid doc", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `budget/${ENV}/journal-legs/new1`), baseDoc),
+      );
+    });
+
+    it("denies non-member create", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/journal-legs/new1`), baseDoc),
+      );
+    });
+
+    it("denies create when memberEmails != group.members", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/journal-legs/new1`), {
+          ...baseDoc,
+          memberEmails: ["member@test.com"],
+        }),
+      );
+    });
+
+    it("denies create with invalid field", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/journal-legs/new1`), {
+          ...baseDoc,
+          debit: -5,
+        }),
+      );
+    });
+  });
+
+  describe("update", () => {
+    it("allows member to update mutable field", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        updateDoc(doc(db, `budget/${ENV}/journal-legs/existing1`), {
+          cleared: true,
+        }),
+      );
+    });
+
+    it("denies changing groupId", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        updateDoc(doc(db, `budget/${ENV}/journal-legs/existing1`), {
+          groupId: "group2",
+        }),
+      );
+    });
+
+    it("denies changing memberEmails", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        updateDoc(doc(db, `budget/${ENV}/journal-legs/existing1`), {
+          memberEmails: ["member@test.com"],
+        }),
+      );
+    });
+
+    it("denies non-member update", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        updateDoc(doc(db, `budget/${ENV}/journal-legs/existing1`), {
+          cleared: true,
+        }),
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("allows member to delete", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        deleteDoc(doc(db, `budget/${ENV}/journal-legs/existing1`)),
+      );
+    });
+
+    it("denies non-member delete", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        deleteDoc(doc(db, `budget/${ENV}/journal-legs/existing1`)),
+      );
+    });
+  });
+});

--- a/rules-test/test/firestore/budget-reconciliation-events.test.ts
+++ b/rules-test/test/firestore/budget-reconciliation-events.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, beforeAll, beforeEach } from "vitest";
+import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
+import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
+import { doc, getDoc, setDoc, updateDoc, deleteDoc } from "firebase/firestore";
+import {
+  getTestEnv,
+  authenticatedContext,
+  unauthenticatedContext,
+  adminSetDoc,
+  setupCleanup,
+} from "../setup.js";
+
+const ENV = "test";
+const MEMBERS = ["member@test.com", "other@test.com"];
+const GROUP_ID = "group1";
+
+const baseDoc = {
+  institution: "Bank",
+  account: "Checking",
+  reconciledThroughDate: new Date("2024-01-31T00:00:00Z"),
+  bankBalance: 1000,
+  clearedBalance: 1000,
+  adjustment: 0,
+  reconciledBy: "member@test.com",
+  reconciledAt: new Date("2024-02-01T00:00:00Z"),
+  legIds: ["leg1", "leg2"],
+  groupId: GROUP_ID,
+  memberEmails: MEMBERS,
+};
+
+describe("budget reconciliation events", () => {
+  let env: RulesTestEnvironment;
+
+  beforeAll(async () => {
+    env = await getTestEnv();
+  });
+
+  setupCleanup();
+
+  beforeEach(async () => {
+    await adminSetDoc(env, `budget/${ENV}/groups/${GROUP_ID}`, {
+      members: MEMBERS,
+    });
+    await adminSetDoc(
+      env,
+      `budget/${ENV}/reconciliation-events/existing1`,
+      baseDoc,
+    );
+  });
+
+  describe("read", () => {
+    it("allows member to read", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        getDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`)),
+      );
+    });
+
+    it("denies non-member read", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        getDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`)),
+      );
+    });
+
+    it("denies unauthenticated read", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        getDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`)),
+      );
+    });
+  });
+
+  describe("create", () => {
+    it("allows member to create valid doc", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `budget/${ENV}/reconciliation-events/new1`), baseDoc),
+      );
+    });
+
+    it("denies non-member create", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/reconciliation-events/new1`), baseDoc),
+      );
+    });
+
+    it("denies create when memberEmails != group.members", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/reconciliation-events/new1`), {
+          ...baseDoc,
+          memberEmails: ["member@test.com"],
+        }),
+      );
+    });
+
+    it("denies create with invalid field", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/reconciliation-events/new1`), {
+          ...baseDoc,
+          bankBalance: "lots",
+        }),
+      );
+    });
+  });
+
+  describe("update", () => {
+    it("allows member to update mutable field", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        updateDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`), {
+          bankBalance: 1234,
+        }),
+      );
+    });
+
+    it("denies changing groupId", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        updateDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`), {
+          groupId: "group2",
+        }),
+      );
+    });
+
+    it("denies changing memberEmails", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        updateDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`), {
+          memberEmails: ["member@test.com"],
+        }),
+      );
+    });
+
+    it("denies non-member update", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        updateDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`), {
+          bankBalance: 1234,
+        }),
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("allows member to delete", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        deleteDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`)),
+      );
+    });
+
+    it("denies non-member delete", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        deleteDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`)),
+      );
+    });
+  });
+});

--- a/rules-test/test/firestore/budget-reconciliation-notes.test.ts
+++ b/rules-test/test/firestore/budget-reconciliation-notes.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, beforeAll, beforeEach } from "vitest";
+import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
+import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
+import { doc, getDoc, setDoc, updateDoc, deleteDoc } from "firebase/firestore";
+import {
+  getTestEnv,
+  authenticatedContext,
+  unauthenticatedContext,
+  adminSetDoc,
+  setupCleanup,
+} from "../setup.js";
+
+const ENV = "test";
+const MEMBERS = ["member@test.com", "other@test.com"];
+const GROUP_ID = "group1";
+
+const baseDoc = {
+  entityType: "transaction",
+  entityId: "txn1",
+  classification: "timing",
+  note: "A note",
+  updatedAt: new Date("2024-01-15T00:00:00Z"),
+  updatedBy: "member@test.com",
+  groupId: GROUP_ID,
+  memberEmails: MEMBERS,
+};
+
+describe("budget reconciliation notes", () => {
+  let env: RulesTestEnvironment;
+
+  beforeAll(async () => {
+    env = await getTestEnv();
+  });
+
+  setupCleanup();
+
+  beforeEach(async () => {
+    await adminSetDoc(env, `budget/${ENV}/groups/${GROUP_ID}`, {
+      members: MEMBERS,
+    });
+    await adminSetDoc(
+      env,
+      `budget/${ENV}/reconciliation-notes/existing1`,
+      baseDoc,
+    );
+  });
+
+  describe("read", () => {
+    it("allows member to read", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        getDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`)),
+      );
+    });
+
+    it("denies non-member read", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        getDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`)),
+      );
+    });
+
+    it("denies unauthenticated read", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        getDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`)),
+      );
+    });
+  });
+
+  describe("create", () => {
+    it("allows member to create valid doc", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `budget/${ENV}/reconciliation-notes/new1`), baseDoc),
+      );
+    });
+
+    it("denies non-member create", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/reconciliation-notes/new1`), baseDoc),
+      );
+    });
+
+    it("denies create when memberEmails != group.members", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/reconciliation-notes/new1`), {
+          ...baseDoc,
+          memberEmails: ["member@test.com"],
+        }),
+      );
+    });
+
+    it("denies create with invalid field", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        setDoc(doc(db, `budget/${ENV}/reconciliation-notes/new1`), {
+          ...baseDoc,
+          classification: "bogus",
+        }),
+      );
+    });
+  });
+
+  describe("update", () => {
+    it("allows member to update mutable field", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        updateDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`), {
+          note: "updated",
+        }),
+      );
+    });
+
+    it("denies changing groupId", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        updateDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`), {
+          groupId: "group2",
+        }),
+      );
+    });
+
+    it("denies changing memberEmails", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        updateDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`), {
+          memberEmails: ["member@test.com"],
+        }),
+      );
+    });
+
+    it("denies non-member update", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        updateDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`), {
+          note: "hack",
+        }),
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("allows member to delete", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        deleteDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`)),
+      );
+    });
+
+    it("denies non-member delete", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        deleteDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`)),
+      );
+    });
+  });
+});

--- a/rules-test/test/firestore/fellspiral.test.ts
+++ b/rules-test/test/firestore/fellspiral.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, beforeAll, beforeEach } from "vitest";
 import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
 import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
-import { doc, getDoc, setDoc } from "firebase/firestore";
+import {
+  doc,
+  getDoc,
+  getDocs,
+  setDoc,
+  collection,
+  query,
+  where,
+  orderBy,
+} from "firebase/firestore";
 import {
   getTestEnv,
   authenticatedContext,
@@ -67,6 +76,58 @@ describe("fellspiral posts", () => {
     const db = ctx.firestore();
     await assertFails(
       getDoc(doc(db, `fellspiral/${ENV}/posts/draft1`)),
+    );
+  });
+
+  it("allows unauthenticated published-filtered list query", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(db, `fellspiral/${ENV}/posts`),
+          where("published", "==", true),
+        ),
+      ),
+    );
+  });
+
+  it("denies unauthenticated bare list query", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(
+        query(
+          collection(db, `fellspiral/${ENV}/posts`),
+          orderBy("publishedAt"),
+        ),
+      ),
+    );
+  });
+
+  it("denies non-admin bare list query", async () => {
+    const ctx = authenticatedContext(env, "nonadmin@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(
+        query(
+          collection(db, `fellspiral/${ENV}/posts`),
+          orderBy("publishedAt"),
+        ),
+      ),
+    );
+  });
+
+  it("allows admin bare list query", async () => {
+    const ctx = authenticatedContext(env, "admin@test.com");
+    const db = ctx.firestore();
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(db, `fellspiral/${ENV}/posts`),
+          orderBy("publishedAt"),
+        ),
+      ),
     );
   });
 

--- a/rules-test/test/firestore/landing.test.ts
+++ b/rules-test/test/firestore/landing.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, beforeAll, beforeEach } from "vitest";
 import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
 import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
-import { doc, getDoc, setDoc } from "firebase/firestore";
+import {
+  doc,
+  getDoc,
+  getDocs,
+  setDoc,
+  collection,
+  query,
+  where,
+  orderBy,
+} from "firebase/firestore";
 import {
   getTestEnv,
   authenticatedContext,
@@ -71,6 +80,58 @@ describe("landing posts", () => {
     const ctx = authenticatedContext(env, "admin@test.com");
     const db = ctx.firestore();
     await assertSucceeds(getDoc(doc(db, `landing/${ENV}/posts/draft1`)));
+  });
+
+  it("allows unauthenticated published-filtered list query", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(db, `landing/${ENV}/posts`),
+          where("published", "==", true),
+        ),
+      ),
+    );
+  });
+
+  it("denies unauthenticated bare list query", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(
+        query(
+          collection(db, `landing/${ENV}/posts`),
+          orderBy("publishedAt"),
+        ),
+      ),
+    );
+  });
+
+  it("denies non-admin bare list query", async () => {
+    const ctx = authenticatedContext(env, "nonadmin@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(
+        query(
+          collection(db, `landing/${ENV}/posts`),
+          orderBy("publishedAt"),
+        ),
+      ),
+    );
+  });
+
+  it("allows admin bare list query", async () => {
+    const ctx = authenticatedContext(env, "admin@test.com");
+    const db = ctx.firestore();
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(db, `landing/${ENV}/posts`),
+          orderBy("publishedAt"),
+        ),
+      ),
+    );
   });
 
   it("denies write", async () => {

--- a/rules-test/test/firestore/office-hours.test.ts
+++ b/rules-test/test/firestore/office-hours.test.ts
@@ -244,10 +244,26 @@ describe("office-hours usage-samples", () => {
     );
   });
 
-  it("denies non-member list query on test-env collection", async () => {
+  it("denies non-member list query for another member's docs", async () => {
     const ctx = authenticatedContext(env, "stranger@test.com");
     const db = ctx.firestore();
     await assertFails(
+      getDocs(
+        query(
+          collection(db, `office-hours/${ENV}/usage-samples`),
+          where("memberEmails", "array-contains", "owner@test.com"),
+        ),
+      ),
+    );
+  });
+
+  // "Rules are not filters": a list query is allowed when its where-clause
+  // provably satisfies the rule. A non-member filtering to their own membership
+  // is allowed and simply returns the empty subset they are entitled to.
+  it("allows non-member list query filtered to own (empty) membership", async () => {
+    const ctx = authenticatedContext(env, "stranger@test.com");
+    const db = ctx.firestore();
+    await assertSucceeds(
       getDocs(
         query(
           collection(db, `office-hours/${ENV}/usage-samples`),


### PR DESCRIPTION
Closes #1290

## What

The `rules-test` Firestore-rules unit suite ran in **no CI job**, so a
collection or rule-condition regression could merge silently and auto-deploy via
`firestore-deploy.yml` (push-to-`main`). This PR closes two coverage gaps and
wires the suite into CI as a PR-time gate.

### Unit 1 — Blog posts list-query coverage

Adds list-query (`getDocs`/`query`) cases to the `landing` and `fellspiral`
`posts` describe blocks, exercising the list branches the rule distinguishes:

- published-filtered list (`where("published","==",true)`) allowed unauthenticated,
- bare `orderBy("publishedAt")` list denied unauthenticated and for non-admins,
- bare list allowed for an admin (via the `isAppAdmin` `get()` during list
  evaluation).

This closes the exact failure mode `.claude/docs/firestore.md` warns about —
previously only `office-hours.test.ts` exercised list queries.

### Unit 2 — Group-gated client-writable collection CRUD coverage

Adds one test file per collection for the four group-gated, client-writable
budget collections — the only consumers of the `isBudgetGroupMember` rule
function, previously entirely untested:

- `budget-reconciliation-notes.test.ts`
- `budget-journal-entries.test.ts`
- `budget-journal-legs.test.ts`
- `budget-reconciliation-events.test.ts`

Each covers read/create/update/delete, including the `get()`-backed
`isBudgetGroupMember` create path (with exact `memberEmails == group.members`
array equality), group/membership denials, immutable `groupId`/`memberEmails` on
update, and per-collection field validation.

### Unit 3 — Wire `rules-test` into CI

- New wrapper `run-rules-test.sh` (`ensure_deps` + emulator-backed `npm test`).
- New `rules-test` job in `unit-tests.yml` (Java 21 + Firebase-emulator cache),
  gated on the existing rules-change detection.

`unit-tests.yml` runs on every PR/feature branch, so this is a PR-time gate: a
rule regression fails the build **before** merge, ahead of the push-to-`main`
rules auto-deploy.

### Incidental fix

Fixes a pre-existing failing `office-hours` usage-samples list-query test whose
non-member case filtered on the stranger's own email — a query Firestore allows,
because the `where` clause provably satisfies the list rule and returns the empty
subset the requester is entitled to, so `assertFails` never held. The non-member
attempt now filters for another member's email (provably unsatisfiable), and a
documenting case for the allowed empty-membership query is added. Without this,
the suite could not pass green in the new CI job.

## Verification

CI is authoritative for this emulator-backed suite. The new `rules-test` job in
`unit-tests.yml` runs the full suite on this PR; the PR is green only if the
suite passes.
