### PR TITLE
budget-etl: bound the CSV duplicate-ID suffix scan with a defensive cap

### DIFF
--- a/budget-etl/internal/parse/csv.go
+++ b/budget-etl/internal/parse/csv.go
@@ -102,14 +102,25 @@ func parseCSV(path string) (ParseResult, error) {
 		}
 
 		if _, taken := used[txnID]; taken {
-			for n := 2; ; n++ {
+			// Defensive termination guard. The scan is implicitly bounded: every
+			// blocking X-n candidate must be an ID present in the finite file, so a
+			// free suffix always exists at or below n = len(records)-1. This explicit
+			// cap makes termination guaranteed in source against a future change that
+			// breaks that invariant; the error is not reachable on any input (you
+			// cannot pack more distinct X-n blockers into the file than it has rows).
+			found := false
+			for n := 2; n <= len(records); n++ {
 				candidate := fmt.Sprintf("%s-%d", txnID, n)
 				_, inUsed := used[candidate]
 				_, inOriginal := original[candidate]
 				if !inUsed && !inOriginal {
 					txnID = candidate
+					found = true
 					break
 				}
+			}
+			if !found {
+				return ParseResult{}, fmt.Errorf("%s: line %d: cannot find unique suffix for duplicate ID %q within %d candidates", path, i+2, txnID, len(records))
 			}
 		}
 		used[txnID] = struct{}{}

--- a/budget-etl/internal/parse/csv.go
+++ b/budget-etl/internal/parse/csv.go
@@ -109,7 +109,7 @@ func parseCSV(path string) (ParseResult, error) {
 			// breaks that invariant; the error is not reachable on any input (you
 			// cannot pack more distinct X-n blockers into the file than it has rows).
 			found := false
-			for n := 2; n <= len(records); n++ {
+			for n := 2; n <= len(records)-1; n++ {
 				candidate := fmt.Sprintf("%s-%d", txnID, n)
 				_, inUsed := used[candidate]
 				_, inOriginal := original[candidate]
@@ -120,7 +120,7 @@ func parseCSV(path string) (ParseResult, error) {
 				}
 			}
 			if !found {
-				return ParseResult{}, fmt.Errorf("%s: line %d: cannot find unique suffix for duplicate ID %q within %d candidates", path, i+2, txnID, len(records))
+				return ParseResult{}, fmt.Errorf("%s: line %d: cannot find unique suffix for duplicate ID %q within %d candidates", path, i+2, txnID, len(records)-1)
 			}
 		}
 		used[txnID] = struct{}{}

--- a/budget-etl/internal/parse/csv_test.go
+++ b/budget-etl/internal/parse/csv_test.go
@@ -148,3 +148,44 @@ func TestParseCSV_DuplicateIDCollision(t *testing.T) {
 		t.Errorf("txn 2: ID = %q, want %q", txns[2].TransactionID, "X-2")
 	}
 }
+
+// TestParseCSV_DuplicateIDDenseCollision verifies that the suffix scan correctly
+// skips a dense run of blocked candidates. Given IDs X, X-2, X-3, X in file
+// order (original set = {X, X-2, X-3}):
+//   - row 1 (X) → X
+//   - row 2 (X-2) → X-2
+//   - row 3 (X-3) → X-3
+//   - row 4 (duplicate X) → X-2 taken, X-3 taken, so advances to X-4
+func TestParseCSV_DuplicateIDDenseCollision(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "dense.csv")
+	content := "00000000001234567890,2025/06/11,2025/07/10,15000.00,12000.00\n" +
+		"2025/06/16,10.00,\"Row A\",,\"X\",\"DEBIT\"\n" +
+		"2025/06/16,20.00,\"Row B\",,\"X-2\",\"DEBIT\"\n" +
+		"2025/06/16,30.00,\"Row C\",,\"X-3\",\"DEBIT\"\n" +
+		"2025/06/16,40.00,\"Row D\",,\"X\",\"DEBIT\"\n"
+	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result, err := parseCSV(tmp)
+	if err != nil {
+		t.Fatalf("parseCSV: %v", err)
+	}
+	txns := result.Transactions
+	if len(txns) != 4 {
+		t.Fatalf("expected 4 transactions, got %d", len(txns))
+	}
+
+	// All four IDs must be distinct.
+	seen := make(map[string]int)
+	for idx, txn := range txns {
+		seen[txn.TransactionID] = idx
+	}
+	if len(seen) != 4 {
+		t.Errorf("expected 4 distinct IDs, got %d: %v", len(seen), seen)
+	}
+
+	// The duplicate X row (row 4) must skip X-2 and X-3 (both taken) and become X-4.
+	if txns[3].TransactionID != "X-4" {
+		t.Errorf("txn 3: ID = %q, want %q", txns[3].TransactionID, "X-4")
+	}
+}


### PR DESCRIPTION
Closes #1373

## What

`budget-etl/internal/parse/csv.go` dedups duplicate transaction IDs by appending
a numeric suffix (`X` → `X-2`, `X-3`, …), scanning from `n=2` until it finds a
suffix free of both already-assigned IDs and real later IDs. The scan loop was
written unbounded (`for n := 2; ; n++`), which #1373 flagged as a potential DoS
vector.

This PR bounds the scan at `len(records)` and documents the bound as a defensive
termination guard.

## Why this shape

Two facts established during planning drive the chosen fix:

1. **The loop is already implicitly bounded.** Every blocking `X-n` candidate
   must be an ID literally present in the finite file, so a free suffix always
   exists at or below `n = len(records)-1`. The loop can never iterate more than
   ~`len(records)` times even today.

2. **The cap-exceeded error branch is provably unreachable.** To exhaust
   `X-2 … X-{len(records)}` you would need more distinct `X-n` blocker rows than
   the file can hold once the base row and the triggering duplicate are counted —
   you always fall short. There is no input that reaches the error.

`budget-etl` only processes trusted input (the user's own bank exports, run by a
local CLI / the `budget-parse-job` path over the user's own files) — there is no
untrusted submitter, so the "DoS" is theoretical. The right-sized goal is
**defensive hardening**: make the loop's termination *explicit in source* (so a
future refactor that breaks the implicit-finiteness invariant is caught) without
pretending to fix an attack that cannot occur. The explicit cap is therefore a
documented defensive guard, and its error path is unreachable on any input.

## Test

Because the cap-exceeded branch is unreachable, the issue's
originally-requested `TestParseCSV_DuplicateIDCapExceeded` cannot exist. Per the
user-approved resolution it is replaced by `TestParseCSV_DuplicateIDDenseCollision`,
which exercises the scan skipping a dense run of taken suffixes (file order
`X, X-2, X-3, X` → the duplicate `X` lands on `X-4`) and asserts a clean,
no-error result.

The pre-existing `TestParseCSV_DuplicateIDs` and `TestParseCSV_DuplicateIDCollision`
(which encode the collision-safe scan from #1275's review) stay green.

## Verification

```
cd budget-etl && go test ./internal/parse/   # all pass, incl. the new dense-collision test
cd budget-etl && go vet ./internal/parse/    # clean
```
