### PR TITLE
dispatch-stop & office-hours-strip: short read timeout so the hooks never stall 1s

### DIFF
--- a/.claude/hooks/dispatch-office-hours-strip.sh
+++ b/.claude/hooks/dispatch-office-hours-strip.sh
@@ -16,9 +16,11 @@
 set -uo pipefail
 trap 'echo "[dispatch-office-hours-strip] WARNING: unexpected error on line $LINENO" >&2; exit 0' ERR
 
-# Consume the payload (UserPromptSubmit delivers JSON on stdin; we do not read
-# any field, but consuming the stdin avoids upstream pipe deadlocks).
-if read -t 1 -d '' _PAYLOAD; then :; fi
+# Drain the payload fast (UserPromptSubmit delivers JSON on stdin; we read no
+# field from it, only drain to avoid an upstream pipe deadlock). Short timeout
+# so an open, idle stdin returns in ~0.1s rather than stalling a full second
+# on the NUL delimiter.
+if read -rt 0.1 _PAYLOAD; then :; fi
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
 ISSUE_NUM=$(printf '%s\n' "$BRANCH" | grep -oE '^[0-9]+') || exit 0

--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -96,9 +96,12 @@ if ! [[ "$JOB_NAME" =~ ^[0-9]+- ]]; then
   exit 0
 fi
 
-# Consume the payload (defensive — Stop may pass JSON on stdin). Unused.
+# Drain any buffered single-line JSON payload fast (defensive — Stop may
+# pass JSON on stdin, but this hook never reads a field from it). Short
+# timeout so an open, idle stdin (hook events never close stdin at EOF)
+# returns in ~0.1s rather than stalling a full second on the NUL delimiter.
 PAYLOAD=""
-if read -t 1 -d '' PAYLOAD; then :; fi
+if read -rt 0.1 PAYLOAD; then :; fi
 
 # Resolve issue number from the validated JOB_NAME (<N>-<slug>). Discriminator 2
 # guarantees JOB_NAME matches ^[0-9]+-, so the numeric prefix is non-empty.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -16267,6 +16267,32 @@ else
 fi
 stop_teardown
 
+# --- Test: open non-newline stdin → hook returns fast (no 1s read stall) (#1519) ---
+echo "Test: stop hook open non-newline stdin → returns fast, normal disposition still fires"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "456" > "$STUB_DIR/find-pr-output"
+echo "fix-checks" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+echo "phase=implement" > "$TMPDIR_TEST/jobs/abcd1234/phase-completed"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+timeout 0.5 "$TMPDIR_TEST/hooks/dispatch-stop.sh" \
+  < <(printf '%s' '{"some":"payload"}'; sleep 1) \
+  >/dev/null 2>&1
+rc=$?
+TOTAL=$((TOTAL + 1))
+if [[ "$rc" -ne 124 ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: stop open-stdin: hook completed before the 0.5s timeout (no 1s read stall)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop open-stdin: hook killed at 0.5s — read is still stalling"
+fi
+# Correctness: the payload is drain-only and unused, so assert the normal
+# disposition still fired (Branch B advance: spawn invoked exactly once) —
+# NOT that the payload was parsed (it never is in this hook).
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "stop open-stdin: spawn invoked exactly once (disposition unaffected)" "1" "$spawn_calls"
+stop_teardown
+
 # ============================================================================
 # ensure_deps (lib.sh) retry tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -15228,6 +15228,32 @@ else
 fi
 ohs_teardown
 
+# --- Test: open non-newline stdin → hook returns fast (no 1s read stall) (#1519) ---
+echo "Test: strip hook open non-newline stdin → returns fast, still strips label"
+ohs_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "456" > "$STUB_DIR/find-pr-output"
+timeout 0.5 "$TMPDIR_TEST/hooks/dispatch-office-hours-strip.sh" \
+  < <(printf '%s' '{"some":"payload"}'; sleep 1) \
+  >/dev/null 2>&1
+rc=$?
+TOTAL=$((TOTAL + 1))
+if [[ "$rc" -ne 124 ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: strip open-stdin: hook completed before the 0.5s timeout (no 1s read stall)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: strip open-stdin: hook killed at 0.5s — read is still stalling"
+fi
+# Correctness: the payload is drain-only, so assert the strip still fired.
+pr_edit_log=$(cat "$STUB_DIR/gh-pr-edit.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$pr_edit_log" == *"pr edit 456 --remove-label dispatch:office-hours"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: strip open-stdin: 'gh pr edit 456 --remove-label' still invoked (drain did not break strip)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: strip open-stdin: 'gh pr edit 456 --remove-label' still invoked"
+  echo "    pr-edit-log: $pr_edit_log"
+fi
+ohs_teardown
+
 # ============================================================================
 # dispatch-stop hook tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -15249,8 +15249,16 @@ TOTAL=$((TOTAL + 1))
 if [[ "$pr_edit_log" == *"pr edit 456 --remove-label dispatch:office-hours"* ]]; then
   PASS=$((PASS + 1)); echo "  PASS: strip open-stdin: 'gh pr edit 456 --remove-label' still invoked (drain did not break strip)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: strip open-stdin: 'gh pr edit 456 --remove-label' still invoked"
+  FAIL=$((FAIL + 1)); echo "  FAIL: strip open-stdin: 'gh pr edit 456 --remove-label' NOT invoked (drain broke strip)"
   echo "    pr-edit-log: $pr_edit_log"
+fi
+issue_edit_log=$(cat "$STUB_DIR/gh-issue-edit.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$issue_edit_log" == *"issue edit 123 --remove-label dispatch:office-hours"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: strip open-stdin: 'gh issue edit 123 --remove-label' still invoked (drain did not break strip)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: strip open-stdin: 'gh issue edit 123 --remove-label' NOT invoked (drain broke strip)"
+  echo "    issue-edit-log: $issue_edit_log"
 fi
 ohs_teardown
 


### PR DESCRIPTION
Closes #1519

## Summary

Two sibling hooks — `dispatch-stop.sh` (Stop) and
`dispatch-office-hours-strip.sh` (UserPromptSubmit) — still carried the
`read -t 1 -d '' PAYLOAD` drain pattern that #1491 (merged as PR #1511) fixed in
`dispatch-input-block.sh`. `-d ''` sets the read delimiter to NUL (`\x00`); JSON
hook payloads never contain NUL, so on an open-but-idle stdin (hook events do not
close stdin at EOF) the `read` always burned its full 1-second timeout. That
stalled the hook by ~1s on **every** Stop event and **every** UserPromptSubmit.

In both hooks the payload is **drain-only** — read into a variable
(`PAYLOAD` / `_PAYLOAD`) that is never referenced again. Neither hook parses the
payload; both read solely to drain buffered stdin and avoid an upstream pipe
deadlock. So the `read -rt 0.1` change from PR #1511 applies cleanly and is
strictly safer here than in input-block (which *does* parse its payload
downstream) — the unused `-r` is kept only as the conventional safe form, not for
any backslash-preservation reason.

Outcome: both hooks drain stdin in ≤0.1s instead of stalling 1s.

## Changes

- `dispatch-stop.sh`: `read -t 1 -d '' PAYLOAD` → `read -rt 0.1 PAYLOAD`, with an
  updated comment explaining the short timeout.
- `dispatch-office-hours-strip.sh`: `read -t 1 -d '' _PAYLOAD` →
  `read -rt 0.1 _PAYLOAD`, same comment update.
- `test-dispatch-scripts.sh`: one regression test per hook, each feeding an open,
  non-newline-held stdin under `timeout 0.5` and asserting the hook returns
  before the timeout (`rc != 124`). Each test also asserts the hook's normal
  behavior is unaffected — the stop test confirms the advance disposition still
  spawns exactly once; the strip test confirms the label strip (`gh pr edit …
  --remove-label`) still fires. Both mirror PR #1511's input-block stall test
  shape.

## Verification

Full dispatch test suite passes (2437/2437), including the four new
`open-stdin` PASS lines.
