### PR TITLE
dispatch-sweep: isolate per-worktree gh failures + unbounded per-worktree PR query

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
@@ -5,12 +5,19 @@
 #   dispatch-sweep   — cleanup merged worktrees.
 #
 # Behavior, in order:
-#   1. Build a branch -> merged-PR map from a single gh call.
-#      Network/credential failures degrade to an empty map; the sweep continues.
-#   2. Enumerate registered worktrees under <project-root>/worktrees/, excluding
+#   1. Enumerate registered worktrees under <project-root>/worktrees/, excluding
 #      the main worktree and detached HEADs.
-#   3. For each worktree whose branch is in the merged map and which is in sync
-#      (clean tree + zero unpushed commits), remove it and its branch.
+#   2. For each worktree, query its PR state directly with `gh pr list --head
+#      <branch>` — unbounded by construction. A single creation-ordered
+#      `gh pr list --limit N` window never sees the merged backlog tail once the
+#      project accrues more than N PRs (#1313). Precedence over the branch's PRs:
+#      any OPEN PR -> keep (active work); else any MERGED PR -> remove; else
+#      (no PR) -> fall through to the issue path.
+#   3. No-PR + issue-number branch: query the issue state. CLOSED -> remove;
+#      OPEN -> keep; anything else is logged and skipped.
+#   A worktree is removed only when it is reservation-free, has no live session,
+#      and is in sync (clean tree + zero unpushed commits). A per-worktree gh
+#      failure is logged and isolated, never fatal (#1313).
 #
 # Environment overrides for testability:
 #   DISPATCH_SWEEP_LOG_FILE   Override log path. Default: <root>/tmp/dispatch-sweep.log.
@@ -55,24 +62,7 @@ if [[ $# -gt 0 ]]; then
   exit 2
 fi
 
-# ---- Step 1: branch -> PR maps ----------------------------------------------
-# One gh call covers merged PRs. Failure (network, sandbox, missing creds)
-# collapses to an empty map so the merged-cleanup pass still runs (it just
-# finds no merged branches to remove).
-PRS_JSON=$(gh pr list --state all --json number,headRefName,state --limit 200 2>/dev/null) \
-  || PRS_JSON='[]'
-
-declare -A MERGED_BY_BRANCH=()
-declare -A OPEN_BY_BRANCH=()
-while IFS=$'\t' read -r state br n; do
-  [[ -z "$br" ]] && continue
-  case "$state" in
-    MERGED) MERGED_BY_BRANCH["$br"]="$n" ;;
-    OPEN)   OPEN_BY_BRANCH["$br"]="$n" ;;
-  esac
-done < <(printf '%s' "$PRS_JSON" | jq -r '.[] | [.state, .headRefName, .number] | @tsv' 2>/dev/null)
-
-# ---- Step 2: enumerate registered worktrees ---------------------------------
+# ---- Step 1: enumerate registered worktrees ---------------------------------
 # list_worktree_records (lib.sh) walks `git worktree list --porcelain` and emits
 # one tab-separated <issue-number>\t<path>\t<branch> record per worktree.
 # split_worktree_record populates WT_NUM / WT_PATH / WT_BRANCH from each record.
@@ -98,14 +88,16 @@ while IFS= read -r wt_record; do
   WT_NUMS+=("$WT_NUM")
 done < <(list_worktree_records)
 
-# ---- Step 3: merged cleanup pass --------------------------------------------
-# For each worktree whose branch was squash-merged (per gh pr list), if it is
-# in sync remove the worktree + delete the local branch. Not-in-sync merged
-# worktrees are logged with a SKIP line so the user can investigate —
-# the unpushed work may belong to a live session.
-# Liveness gate: even a merged + in-sync worktree is skipped when a live
-# session is registered under its basename (worktree_has_live_session) — the
-# worker owns it and will clean up on its own tick.
+# ---- Step 2: per-worktree reconcile pass ------------------------------------
+# Each worktree is processed reservation-first, then liveness, then by its own
+# per-worktree PR state (gh pr list --head), then (only when there is no PR at
+# all) by issue state. A merged/closed + in-sync worktree is removed along with
+# its local branch; not-in-sync worktrees are logged with a SKIP line so the
+# user can investigate — the unpushed work may belong to a live session.
+# Liveness gate: even a removable worktree is skipped when a live session is
+# registered under its basename (worktree_has_live_session) — the worker owns it
+# and will clean up on its own tick. A per-worktree gh failure is isolated:
+# logged and skipped, never aborting the whole sweep (#1313).
 i=0
 while [[ $i -lt ${#WT_PATHS[@]} ]]; do
   wt_path="${WT_PATHS[$i]}"
@@ -120,21 +112,32 @@ while [[ $i -lt ${#WT_PATHS[@]} ]]; do
     continue
   fi
 
-  pr_num="${MERGED_BY_BRANCH[$wt_branch]:-}"
+  # Per-worktree PR state (defect 3, #1313): query this branch's PRs directly
+  # with `--head` instead of a creation-ordered `--limit N` window that never
+  # sees the merged backlog tail. A failure here is isolated to this worktree
+  # (defect 2, #1313): log and move on, never abort the sweep.
+  if ! pr_json=$(gh_retry gh pr list --head "$wt_branch" --state all --json state,number); then
+    log "ERROR_PR_STATE_FETCH: branch=$wt_branch gh pr list --head failed"
+    continue
+  fi
+
+  # Precedence (a branch may have multiple PRs): any OPEN -> keep (active work).
+  if [[ "$(jq '[.[] | select(.state == "OPEN")] | length' <<<"$pr_json")" -gt 0 ]]; then
+    continue
+  fi
+
+  # Else any MERGED -> merged-remove path; capture the merged PR number to log.
+  pr_num=$(jq -r 'map(select(.state == "MERGED"))[0].number // empty' <<<"$pr_json")
   if [[ -z "$pr_num" ]]; then
-    # Not a merged-PR branch. Check if this is a dispatch-style branch (has an
-    # issue-number prefix captured during enumeration).
+    # No PR at all -> issue path, but only for a dispatch-style branch with an
+    # issue-number prefix. Otherwise there is nothing to reason about.
     if [[ -n "$wt_num" ]]; then
-      # An open PR backs active work; never reap its worktree.
-      if [[ -n "${OPEN_BY_BRANCH[$wt_branch]:-}" ]]; then
+      issue_num="$wt_num"
+      # Per-worktree issue fetch; a failure is isolated (defect 2, #1313).
+      if ! issue_state=$(gh_retry gh issue view "$issue_num" --json state -q .state); then
+        log "ERROR_ISSUE_STATE_FETCH: branch=$wt_branch issue=$issue_num gh issue view failed"
         continue
       fi
-      issue_num="$wt_num"
-      issue_state=$(gh issue view "$issue_num" --json state -q .state 2>/dev/null) || {
-        log "ERROR_ISSUE_STATE_FETCH: branch=$wt_branch issue=$issue_num gh issue view failed"
-        echo "ERROR: gh issue view $issue_num failed for branch=$wt_branch" >&2
-        exit 1
-      }
       case "$issue_state" in
         CLOSED)
           if worktree_has_live_session "$wt_path"; then
@@ -157,8 +160,7 @@ while [[ $i -lt ${#WT_PATHS[@]} ]]; do
           ;;
         *)
           log "ERROR_ISSUE_STATE_FETCH: branch=$wt_branch issue=$issue_num unexpected state='$issue_state'"
-          echo "ERROR: gh issue view $issue_num returned unexpected state '$issue_state' for branch=$wt_branch" >&2
-          exit 1
+          continue
           ;;
       esac
     fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6070,20 +6070,29 @@ sweep_setup() {
   cp "$SCRIPT_DIR/lib-reservation-ledger.sh" "$TMPDIR_TEST/scripts/lib-reservation-ledger.sh"
   chmod +x "$TMPDIR_TEST/scripts/dispatch-sweep"
 
-  # Default empty gh output (each test may overwrite).
-  echo '[]' > "$STUB_DIR/gh-pr-list-all.json"
-
   # Default empty worktree list (each test should overwrite with its records).
   : > "$STUB_DIR/worktree-list.txt"
 
   # gh shim — handles dispatch-sweep's calls.
+  # Shims:
+  #   gh   — per-worktree PR query uses pr-state-<branch>.json (holding
+  #          [{"state":"MERGED"|"OPEN","number":<N>}]); returns '[]' by default
+  #          when no fixture exists. SWEEP_GH_PR_FAIL=<branch> makes the
+  #          --head query fail for that branch. Issue-view uses issue-state-<N>.txt.
   cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
 #!/usr/bin/env bash
 STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
 args="$*"
 case "$args" in
-  "pr list --state all --json number,headRefName,state --limit 200")
-    cat "$STUB_DIR/gh-pr-list-all.json"
+  "pr list --head "*" --state all --json state,number")
+    # dispatch-sweep per-worktree PR query: gh pr list --head <branch> --state all --json state,number
+    br=$(echo "$args" | awk '{print $4}')
+    if [[ "${SWEEP_GH_PR_FAIL:-}" == "$br" ]]; then
+      echo "gh sweep stub: simulated gh pr list --head failure for $br" >&2
+      exit 1
+    fi
+    f="$STUB_DIR/pr-state-${br}.json"
+    if [[ -f "$f" ]]; then cat "$f"; else echo '[]'; fi
     ;;
   issue\ view\ *\ --json\ state\ -q\ .state)
     # dispatch-sweep closed-issue check: gh issue view <N> --json state -q .state
@@ -6197,6 +6206,7 @@ FAKE
   export CLAUDE_AGENTS_CMD="$default_fake"
   export DISPATCH_SWEEP_LOG_FILE="$STUB_DIR/sweep.log"
   export DISPATCH_SWEEP_NOW="2026-01-01T00:00:00Z"
+  export GH_RETRY_BASE_DELAY=0
   # Point the reservation ledger at a scratch dir that is absent by default — no
   # marker files, so reservation_exists is false for every row and the
   # reserved-skip is inert. A reserved-skip test opts in by creating a marker here.
@@ -6208,7 +6218,7 @@ sweep_teardown() {
   TMPDIR_TEST=""
   STUB_DIR=""
   export PATH="$SAVED_PATH"
-  unset CLAUDE_AGENTS_CMD DISPATCH_SWEEP_LOG_FILE DISPATCH_SWEEP_NOW DISPATCH_RESERVATION_DIR
+  unset CLAUDE_AGENTS_CMD DISPATCH_SWEEP_LOG_FILE DISPATCH_SWEEP_NOW DISPATCH_RESERVATION_DIR GH_RETRY_BASE_DELAY SWEEP_GH_PR_FAIL SWEEP_GH_ISSUE_FAIL
 }
 
 # Helper: register a worktree in the porcelain list AND create its directory.
@@ -6263,8 +6273,8 @@ echo "Test: merged worktree (in-sync) is removed + branch deleted"
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/42-feature"
 sweep_register_wt "$WT_PATH" "42-feature"
-echo '[{"number":100,"headRefName":"42-feature","state":"MERGED"}]' \
-  > "$STUB_DIR/gh-pr-list-all.json"
+echo '[{"state":"MERGED","number":100}]' \
+  > "$STUB_DIR/pr-state-42-feature.json"
 # Clean tree + zero unpushed (defaults already match this — explicit for clarity).
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"
@@ -6308,8 +6318,7 @@ echo "Test: closed-issue worktree (in-sync) is removed + branch deleted"
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/57-closed-feature"
 sweep_register_wt "$WT_PATH" "57-closed-feature"
-# No merged PRs — the closed-issue path must fire.
-echo '[]' > "$STUB_DIR/gh-pr-list-all.json"
+# No pr-state fixture — stub returns '[]' by default, sending this to the issue path.
 # Issue 57 is CLOSED.
 echo "CLOSED" > "$STUB_DIR/issue-state-57.txt"
 # Clean tree + zero unpushed (defaults).
@@ -6351,7 +6360,7 @@ echo "Test: closed-issue worktree (not-in-sync) is kept"
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/58-closed-dirty"
 sweep_register_wt "$WT_PATH" "58-closed-dirty"
-echo '[]' > "$STUB_DIR/gh-pr-list-all.json"
+# No pr-state fixture — stub returns '[]' by default, sending this to the issue path.
 echo "CLOSED" > "$STUB_DIR/issue-state-58.txt"
 # Not-in-sync: has an uncommitted change.
 key=$(sweep_path_key "$WT_PATH")
@@ -6384,7 +6393,7 @@ echo "Test: open-issue worktree is kept (regression guard)"
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/59-open-feature"
 sweep_register_wt "$WT_PATH" "59-open-feature"
-echo '[]' > "$STUB_DIR/gh-pr-list-all.json"
+# No pr-state fixture — stub returns '[]' by default, sending this to the issue path.
 echo "OPEN" > "$STUB_DIR/issue-state-59.txt"
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"
@@ -6403,24 +6412,47 @@ else
 fi
 sweep_teardown
 
-# --- Test 1e: gh issue view fails → ERROR_ISSUE_STATE_FETCH, exit 1 ----------
+# --- Test 1e: gh issue view fails → isolated ERROR_ISSUE_STATE_FETCH, exit 0, sibling still removed ---
+#
+# The old contract (exit 1) is gone. A per-worktree gh issue view failure is now
+# isolated: logged as ERROR_ISSUE_STATE_FETCH and skipped, never aborting the sweep.
+# A sibling in-sync MERGED worktree in the same run must still be removed to prove
+# the sweep continues past the failure.
 
-echo "Test: gh issue view fails → ERROR_ISSUE_STATE_FETCH on stderr, exit 1"
+echo "Test: gh issue view fails → isolated log+continue+exit 0, sibling still removed"
 sweep_setup
+# Failing worktree: no pr-state fixture (stub returns '[]') → issue path → gh issue view fails.
 WT_PATH="$TMPDIR_TEST/project/worktrees/60-closed-feature"
 sweep_register_wt "$WT_PATH" "60-closed-feature"
-echo '[]' > "$STUB_DIR/gh-pr-list-all.json"
-# No issue-state-60.txt — let gh fail via the SWEEP_GH_ISSUE_FAIL env var.
+# No issue-state-60.txt — let gh issue view fail via the SWEEP_GH_ISSUE_FAIL env var.
 export SWEEP_GH_ISSUE_FAIL="60"
 
-stderr_out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>&1 1>/dev/null) && rc=0 || rc=$?
-assert_eq "gh issue view fail → exit 1" "1" "$rc"
+# Sibling in-sync MERGED worktree to prove the sweep continues.
+WT_PATH_60B="$TMPDIR_TEST/project/worktrees/60b-sibling-merged"
+sweep_register_wt "$WT_PATH_60B" "60b-sibling-merged"
+echo '[{"state":"MERGED","number":600}]' > "$STUB_DIR/pr-state-60b-sibling-merged.json"
+key_60b=$(sweep_path_key "$WT_PATH_60B")
+: > "$STUB_DIR/status${key_60b}.txt"
+echo "0" > "$STUB_DIR/revlist${key_60b}.txt"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "gh issue view fail → exit 0 (isolated, not fatal)" "0" "$rc"
+
+calls=$(cat "$STUB_DIR/calls" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
-if echo "$stderr_out" | grep -q "60"; then
-  PASS=$((PASS + 1)); echo "  PASS: ERROR_ISSUE_STATE_FETCH stderr mentions issue number"
+if echo "$calls" | grep -qx "worktree-remove:$WT_PATH_60B"; then
+  PASS=$((PASS + 1)); echo "  PASS: sibling was removed (sweep continued past issue-view failure)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: ERROR_ISSUE_STATE_FETCH stderr mentions issue number"
-  echo "    stderr: $stderr_out"
+  FAIL=$((FAIL + 1)); echo "  FAIL: sibling was removed (sweep continued past issue-view failure)"
+  echo "    calls: $calls"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q "ERROR_ISSUE_STATE_FETCH: branch=60-closed-feature issue=60 gh issue view failed" \
+   "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: ERROR_ISSUE_STATE_FETCH log line present"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: ERROR_ISSUE_STATE_FETCH log line present"
+  echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
 fi
 unset SWEEP_GH_ISSUE_FAIL
 sweep_teardown
@@ -6431,9 +6463,9 @@ echo "Test: open-PR worktree with closed issue is kept (OPEN_BY_BRANCH guard)"
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/61-active-pr"
 sweep_register_wt "$WT_PATH" "61-active-pr"
-echo '[{"state":"OPEN","headRefName":"61-active-pr","number":888}]' \
-  > "$STUB_DIR/gh-pr-list-all.json"
-# Issue is CLOSED, but the OPEN_BY_BRANCH guard must short-circuit before gh issue view.
+echo '[{"state":"OPEN","number":888}]' \
+  > "$STUB_DIR/pr-state-61-active-pr.json"
+# Issue is CLOSED, but the OPEN PR precedence guard must short-circuit before gh issue view.
 echo "CLOSED" > "$STUB_DIR/issue-state-61.txt"
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"
@@ -6465,8 +6497,8 @@ sweep_register_wt "$WT_PATH" "70-live-merged"
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"
 echo "0" > "$STUB_DIR/revlist${key}.txt"
-echo '[{"number":300,"headRefName":"70-live-merged","state":"MERGED"}]' \
-  > "$STUB_DIR/gh-pr-list-all.json"
+echo '[{"state":"MERGED","number":300}]' \
+  > "$STUB_DIR/pr-state-70-live-merged.json"
 # Register a live session whose name matches the worktree's basename.
 sweep_fake_claude_sessions_by_name "70-live-merged=sess-live-70"
 
@@ -6503,8 +6535,8 @@ sweep_register_wt "$WT_PATH" "71-no-live-merged"
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"
 echo "0" > "$STUB_DIR/revlist${key}.txt"
-echo '[{"number":301,"headRefName":"71-no-live-merged","state":"MERGED"}]' \
-  > "$STUB_DIR/gh-pr-list-all.json"
+echo '[{"state":"MERGED","number":301}]' \
+  > "$STUB_DIR/pr-state-71-no-live-merged.json"
 # Default fake (no live sessions) — the worktree is free to remove.
 
 out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
@@ -6541,8 +6573,7 @@ WT_PATH="$TMPDIR_TEST/project/worktrees/80-detached"
 mkdir -p "$WT_PATH"
 # Write a branchless porcelain record directly (no branch line).
 printf 'worktree %s\nHEAD deadbeef\n\n' "$WT_PATH" >> "$STUB_DIR/worktree-list.txt"
-# No merged PRs.
-echo '[]' > "$STUB_DIR/gh-pr-list-all.json"
+# No pr-state fixture needed — the branch guard fires before any gh call.
 
 out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
 assert_eq "detached-HEAD sweep exits 0" "0" "$rc"
@@ -6576,8 +6607,8 @@ echo "Test: non-issue branch (hotfix-login) in merged map is reaped"
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/hotfix-login"
 sweep_register_wt "$WT_PATH" "hotfix-login"
-echo '[{"number":400,"headRefName":"hotfix-login","state":"MERGED"}]' \
-  > "$STUB_DIR/gh-pr-list-all.json"
+echo '[{"state":"MERGED","number":400}]' \
+  > "$STUB_DIR/pr-state-hotfix-login.json"
 # Clean tree + zero unpushed.
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"
@@ -6616,8 +6647,8 @@ echo "Test: merged worktree with a reservation marker is skipped (SKIP_RESERVED)
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/90-reserved-merged"
 sweep_register_wt "$WT_PATH" "90-reserved-merged"
-echo '[{"number":500,"headRefName":"90-reserved-merged","state":"MERGED"}]' \
-  > "$STUB_DIR/gh-pr-list-all.json"
+echo '[{"state":"MERGED","number":500}]' \
+  > "$STUB_DIR/pr-state-90-reserved-merged.json"
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"
 echo "0" > "$STUB_DIR/revlist${key}.txt"
@@ -6651,7 +6682,7 @@ echo "Test: closed-issue worktree with a reservation marker is skipped (SKIP_RES
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/91-reserved-closed"
 sweep_register_wt "$WT_PATH" "91-reserved-closed"
-echo '[]' > "$STUB_DIR/gh-pr-list-all.json"
+# No pr-state fixture — stub returns '[]' by default, but the reservation guard fires first.
 echo "CLOSED" > "$STUB_DIR/issue-state-91.txt"
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"
@@ -6686,7 +6717,7 @@ echo "Test: closed-issue worktree with a live session is skipped (SKIP_CLOSED_LI
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/92-closed-live"
 sweep_register_wt "$WT_PATH" "92-closed-live"
-echo '[]' > "$STUB_DIR/gh-pr-list-all.json"
+# No pr-state fixture — stub returns '[]' by default, sending this to the issue path.
 echo "CLOSED" > "$STUB_DIR/issue-state-92.txt"
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"
@@ -6711,6 +6742,91 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: SKIP_CLOSED_LIVE_SESSION log line present"
   echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
 fi
+sweep_teardown
+
+# --- Test I1: unexpected issue state is isolated (ERROR_ISSUE_STATE_FETCH) ---
+#
+# A branch whose issue returns a non-OPEN, non-CLOSED state (e.g. "GARBAGE")
+# must be logged as ERROR_ISSUE_STATE_FETCH and skipped, not fatal. A sibling
+# in-sync MERGED worktree in the same run must still be removed.
+
+echo "Test: unexpected issue state is isolated (exit 0, sibling still removed)"
+sweep_setup
+# Worktree with garbage issue state: no pr-state fixture (stub returns '[]') → issue path.
+WT_PATH="$TMPDIR_TEST/project/worktrees/62-garbage-issue"
+sweep_register_wt "$WT_PATH" "62-garbage-issue"
+echo "GARBAGE" > "$STUB_DIR/issue-state-62.txt"
+
+# Sibling in-sync MERGED worktree to prove the sweep continues.
+WT_PATH_62B="$TMPDIR_TEST/project/worktrees/62b-sibling-merged"
+sweep_register_wt "$WT_PATH_62B" "62b-sibling-merged"
+echo '[{"state":"MERGED","number":620}]' > "$STUB_DIR/pr-state-62b-sibling-merged.json"
+key_62b=$(sweep_path_key "$WT_PATH_62B")
+: > "$STUB_DIR/status${key_62b}.txt"
+echo "0" > "$STUB_DIR/revlist${key_62b}.txt"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "unexpected-state sweep exits 0" "0" "$rc"
+
+calls=$(cat "$STUB_DIR/calls" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if echo "$calls" | grep -qx "worktree-remove:$WT_PATH_62B"; then
+  PASS=$((PASS + 1)); echo "  PASS: sibling was removed (sweep continued past unexpected-state)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: sibling was removed (sweep continued past unexpected-state)"
+  echo "    calls: $calls"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q "ERROR_ISSUE_STATE_FETCH: branch=62-garbage-issue issue=62 unexpected state='GARBAGE'" \
+   "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: ERROR_ISSUE_STATE_FETCH unexpected-state log line present"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: ERROR_ISSUE_STATE_FETCH unexpected-state log line present"
+  echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
+fi
+sweep_teardown
+
+# --- Test I2: pr-list --head failure is isolated (ERROR_PR_STATE_FETCH) -----
+#
+# A branch whose `gh pr list --head` call fails must be logged as
+# ERROR_PR_STATE_FETCH and skipped, not fatal. A sibling in-sync MERGED
+# worktree in the same run must still be removed.
+
+echo "Test: gh pr list --head failure is isolated (exit 0, sibling still removed)"
+sweep_setup
+# Failing worktree: SWEEP_GH_PR_FAIL makes the stub exit 1 for this branch.
+WT_PATH="$TMPDIR_TEST/project/worktrees/63-pr-fail"
+sweep_register_wt "$WT_PATH" "63-pr-fail"
+export SWEEP_GH_PR_FAIL="63-pr-fail"
+
+# Sibling in-sync MERGED worktree to prove the sweep continues.
+WT_PATH_63B="$TMPDIR_TEST/project/worktrees/63b-pr-ok"
+sweep_register_wt "$WT_PATH_63B" "63b-pr-ok"
+echo '[{"state":"MERGED","number":630}]' > "$STUB_DIR/pr-state-63b-pr-ok.json"
+key_63b=$(sweep_path_key "$WT_PATH_63B")
+: > "$STUB_DIR/status${key_63b}.txt"
+echo "0" > "$STUB_DIR/revlist${key_63b}.txt"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "pr-list-fail sweep exits 0" "0" "$rc"
+
+calls=$(cat "$STUB_DIR/calls" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if echo "$calls" | grep -qx "worktree-remove:$WT_PATH_63B"; then
+  PASS=$((PASS + 1)); echo "  PASS: sibling was removed (sweep continued past pr-list failure)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: sibling was removed (sweep continued past pr-list failure)"
+  echo "    calls: $calls"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q "ERROR_PR_STATE_FETCH: branch=63-pr-fail gh pr list --head failed" \
+   "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: ERROR_PR_STATE_FETCH log line present"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: ERROR_PR_STATE_FETCH log line present"
+  echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
+fi
+unset SWEEP_GH_PR_FAIL
 sweep_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6046,9 +6046,10 @@ echo "=== dispatch-sweep ==="
 #   stub/                         per-test JSON + record files (calls, gh out)
 #
 # Shims:
-#   gh   — gh-pr-list-all.json drives `pr list --state all`; each entry carries
-#          {state, headRefName, number}. MERGED entries populate MERGED_BY_BRANCH;
-#          OPEN entries populate OPEN_BY_BRANCH. DRAFT is unused (isDraft not consumed).
+#   gh   — per-worktree PR query is `pr list --head <branch> --state all`, driven
+#          by pr-state-<branch>.json (each entry {state, number}); returns '[]'
+#          when no fixture exists. SWEEP_GH_PR_FAIL=<branch> forces that branch's
+#          --head query to fail. Issue-view is driven by issue-state-<N>.txt.
 #   git  — knows worktree list/remove/prune, branch -D, -C <p> status,
 #          -C <p> rev-list --count, -C <p> log -1 --format=%ct, and
 #          rev-parse --path-format=absolute --git-common-dir.


### PR DESCRIPTION
Closes #1313

## What

Hardens `dispatch-sweep`'s per-worktree reconcile loop against the two
remaining defects from #1313:

- **Defect 2 — per-worktree gh failures no longer abort the whole sweep.** The
  `gh issue view` failure branch and the unexpected-issue-state branch each used
  `exit 1`, violating the script's own "per-worktree errors should not abort"
  contract. Both now log `ERROR_ISSUE_STATE_FETCH` and `continue`, so one bad
  worktree no longer strands every worktree after it. The same isolation now
  covers the PR fetch (`ERROR_PR_STATE_FETCH` + `continue`).
- **Defect 3 — the merged backlog tail is now reachable.** The sweep built its
  merged/open map from one creation-ordered `gh pr list --state all --limit 200`
  call. With hundreds of merged PRs, any fixed window misses the tail: a branch
  whose PR was created early but merged late falls outside the window and its
  worktree is never reaped. The bulk query is replaced by a per-worktree
  `gh pr list --head <branch> --state all` lookup — unbounded by construction (a
  branch has a handful of PRs, so it cannot truncate), wrapped in `gh_retry`, and
  only reached after the reservation and (for the merged path) liveness gates
  prune the candidate set. Precedence per branch: any OPEN PR keeps the worktree;
  else any MERGED PR takes the remove path; else the issue path runs.

## Scope note — overlap with work that landed during this change

This issue's title also covered "dispatch-sweep has no caller" and a missing
closed-path live-session guard. Both were handled by #1475 (for #1451), which
wired the sweep via `dispatch-spawn-sweep` from the worker Stop-hook, added the
closed-path `SKIP_CLOSED_LIVE_SESSION` guard, and introduced the loop-top
reservation gate. #1455 (for #1312) separately set the `--limit`/truncation
discipline for *open*-PR fetches across the pipeline; the unbounded merged
backlog addressed here is a distinct concern that a louder window cannot solve.

So this PR is the residual delta: it layers defects 2 and 3 onto main's
reservation-gated loop and leaves every gate #1475 added untouched —
`SKIP_RESERVED`, `SKIP_CLOSED_LIVE_SESSION`, `SKIP_MERGED_LIVE_SESSION`, and the
`REMOVE_*` / `SKIP_*` removal vocabulary are all preserved. No tick-level caller
is added (the Stop-hook caller from #1475 is the intended one).

## Tests

`test-dispatch-scripts.sh` (the sweep section):

- gh stub migrated from the bulk `gh-pr-list-all.json` fixture to per-branch
  `pr-state-<branch>.json` fixtures matching the `--head` query, plus a
  `SWEEP_GH_PR_FAIL` knob.
- The two `exit 1` assertions (gh-issue-view failure; unexpected issue state)
  inverted to the new contract: the sweep exits 0, logs the `ERROR_*` line, and a
  sibling worktree registered alongside the failing one is still removed —
  proving the failure was isolated.
- New cases: `gh pr list --head` failure isolation, and unexpected-state
  isolation.

Full suite: 2440/2440 passing. `shellcheck` clean on both files (only
pre-existing source-follow/info findings). The suite is not wired into CI
(intentional), so it was run locally.
