### PR TITLE
dispatch: add --property=KillMode=process to dispatch-schedule-target-reseed systemd-run (#1210)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-target-reseed
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-target-reseed
@@ -246,6 +246,19 @@ fi
 # /usr/bin/env can't resolve bash (exit 127) and the tick can't find
 # claude/git/jq. The caller (a /dispatch tick) always carries the full
 # nix-store PATH, so capturing it at schedule time makes the unit self-sufficient.
+#
+# --property=KillMode=process (#1196): Claude Code's per-user bg supervisor
+# daemon and its --bg-spare / --bg-pty-host worker children can be born inside
+# this transient unit's cgroup — the first `claude` call during the tick the
+# timer fires spawns them. systemd's default KillMode=control-group SIGTERMs the
+# entire cgroup when the tick finishes, reaping the daemon and every worker. The
+# bg hosts are spawned detached (setsid) to outlive their launcher, but setsid
+# only changes the session/process-group, not the cgroup, so cgroup-kill ignores
+# it. KillMode=process confines the kill to the dispatch-tick process itself, so
+# the detached bg hosts survive as init orphans across reseed cycles. (Unlike the
+# dispatch-schedule-reseed sibling, this script does not install a durable daemon
+# service, so the daemon can live in this transient cgroup and KillMode=process
+# is load-bearing here, not a degraded-path fallback.)
 
 UNIT_NAME="dispatch-reseed-target-${N}-${FIRE}"
 
@@ -260,6 +273,7 @@ trap 'rm -f "$RUN_STDERR"' EXIT
      --on-calendar="@$FIRE" \
      --working-directory="$MAIN_WORKTREE" \
      --timer-property=Persistent=true \
+     --property=KillMode=process \
      --setenv=PATH="$PATH" \
      "$MAIN_WORKTREE/.claude/skills/dispatch-propagate/scripts/dispatch-tick" "$N" \
      2>"$RUN_STDERR"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -11324,10 +11324,11 @@ if [[ "$log" == *"--unit=dispatch-reseed-target-979-10300"* \
    && "$log" == *"--on-calendar=@10300"* \
    && "$log" == *"--working-directory=$TMPDIR_TEST/main"* \
    && "$log" == *"--setenv=PATH="* \
+   && "$log" == *"--property=KillMode=process"* \
    && "$log" == *"dispatch-tick 979"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: under-cap systemd-run argv (unit + calendar + cwd + setenv + dispatch-tick 979)"
+  PASS=$((PASS + 1)); echo "  PASS: under-cap systemd-run argv (unit + calendar + cwd + setenv + KillMode + dispatch-tick 979)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: under-cap systemd-run argv (unit + calendar + cwd + setenv + dispatch-tick 979)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: under-cap systemd-run argv (unit + calendar + cwd + setenv + KillMode + dispatch-tick 979)"
   echo "    log: $log"
 fi
 edits=$(cat "$TMPDIR_TEST/gh-edit-log" 2>/dev/null || true)

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -11810,11 +11810,18 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: counter-bump removes attempt-1 and adds attempt-2"
   echo "    edits: $edits"
 fi
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
-if [[ -s "$TMPDIR_TEST/systemd-log" ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: counter-bump schedules a timer"
+if [[ "$log" == *"--unit=dispatch-reseed-target-979-10300"* \
+   && "$log" == *"--on-calendar=@10300"* \
+   && "$log" == *"--working-directory=$TMPDIR_TEST/main"* \
+   && "$log" == *"--setenv=PATH="* \
+   && "$log" == *"--property=KillMode=process"* \
+   && "$log" == *"dispatch-tick 979"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: counter-bump systemd-run argv (unit + calendar + cwd + setenv + KillMode + dispatch-tick 979)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: counter-bump schedules a timer"
+  FAIL=$((FAIL + 1)); echo "  FAIL: counter-bump systemd-run argv (unit + calendar + cwd + setenv + KillMode + dispatch-tick 979)"
+  echo "    log: $log"
 fi
 tr_teardown
 


### PR DESCRIPTION
Closes #1210

## Summary

`dispatch-schedule-target-reseed` schedules each per-target reseed timer with
`systemd-run --user` but, unlike its siblings, was missed in the #1196 sweep that
added `--property=KillMode=process`. When such a timer fires, its transient unit
runs `dispatch-tick`, whose first `claude` call can spawn the per-user bg
supervisor daemon and its `--bg-spare` / `--bg-pty-host` workers **inside the
transient unit's cgroup**. When the tick finishes and the unit deactivates,
systemd's default `KillMode=control-group` SIGTERMs the whole cgroup — reaping
the daemon and every bg worker. `setsid`/`detached` only changes the
process-group, not the cgroup, so it does not save them.

This PR adds `--property=KillMode=process` to the `systemd-run --user`
invocation, confining the kill to the `dispatch-tick` process itself so the
detached bg hosts survive as init orphans across reseed cycles. This closes the
last instance of the #1196 class.

Unlike the `dispatch-schedule-reseed` sibling, this script does **not** install a
durable daemon service (`ensure_daemon_service`), so the daemon can genuinely
live in this transient cgroup — `KillMode=process` is load-bearing here, not a
degraded-path fallback. The added rationale comment deliberately omits the
sibling's #1197 "fallback" framing.

## Changes

- `dispatch-schedule-target-reseed`: add `--property=KillMode=process` to the
  `systemd-run --user` argv (after `--timer-property=Persistent=true`), with a
  #1196 rationale comment.
- `test-dispatch-scripts.sh`: extend the Test 1 ("under-cap reseed") argv
  assertion to require `--property=KillMode=process` in the captured systemd-run
  log, and name `KillMode` in the PASS/FAIL message.

## Scope

Scoped to `KillMode=process` only — `--collect` and
`--property=OnFailure=dispatch-tick-recover.service` (the sibling has them) are
deliberately out of scope.

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` —
2433/2433 pass; the `dispatch-schedule-target-reseed` Test 1 line now reads
`PASS: under-cap systemd-run argv (unit + calendar + cwd + setenv + KillMode + dispatch-tick 979)`.
