### PR TITLE
dispatch-select-target: count only landed appends so a dropped leaf cannot short-circuit mixed-phase root descent

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -651,17 +651,20 @@ bucket_count() {
 # holds fewer than TOP entries (the per-bucket cap). An empty bucket is set to
 # the bare entry (no leading newline), so a TOP=1 bucket expands to exactly the
 # entry — preserving the former single-entry map's byte layout for the emission
-# path.
+# path. Returns 0 when the entry is inserted, 1 when the bucket is already at TOP
+# and the entry is dropped (the caller observes this to decide whether the entry
+# actually landed).
 bucket_append() {
   local -n _ba_ref="$1"
   local _ba_key="$2" _ba_entry="$3"
-  (( $(bucket_count "$1" "$_ba_key") >= TOP )) && return 0
+  (( $(bucket_count "$1" "$_ba_key") >= TOP )) && return 1
   local _ba_cur="${_ba_ref[$_ba_key]:-}"
   if [[ -z "$_ba_cur" ]]; then
     _ba_ref[$_ba_key]="$_ba_entry"
   else
     _ba_ref[$_ba_key]="$_ba_cur"$'\n'"$_ba_entry"
   fi
+  return 0
 }
 
 # group_emittable_count <category> <priority-bit> — total entries the emission
@@ -814,7 +817,7 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   pr_cat=$(category_of_labels "$pr_combined")
   pr_pri=$(has_priority_in_labels "$pr_combined")
   pr_key="$pr_cat|$pr_pri|$phase"
-  bucket_append FIRST_PR "$pr_key" "$pr_num $pr_branch"
+  bucket_append FIRST_PR "$pr_key" "$pr_num $pr_branch" || true
 done <<< "$PR_SORTED"
 
 if [[ "$QA_MODE" == "true" ]]; then
@@ -1017,9 +1020,16 @@ while IFS=$'\t' read -r issue_num issue_pri issue_catrank issue_cat; do
       leaf_phase=plan
       [[ -n "${ISSUE_PLANNED[$leaf]:-}" ]] && leaf_phase=implement
       leaf_bucket="$issue_cat|$issue_pri|$leaf_phase"
-      bucket_append FIRST_ISSUE "$leaf_bucket" "$leaf"
       root_excl["$leaf"]=1
-      root_recorded=$(( root_recorded + 1 ))
+      if bucket_append FIRST_ISSUE "$leaf_bucket" "$leaf"; then
+        root_recorded=$(( root_recorded + 1 ))
+      else
+        # Bucket already at TOP — this leaf was dropped. Criterion #3 freezes
+        # TOP=1: a root that hits a full bucket on a landed-append attempt stops
+        # descending, byte-identical to the pre-fix loop. TOP>1 keeps descending
+        # past the drop to this root's other-phase leaves (#1403).
+        (( TOP == 1 )) && break
+      fi
     else
       trace_status=$?
       [[ "$trace_status" -eq 2 ]] && break

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -985,8 +985,9 @@ while IFS=$'\t' read -r issue_num issue_pri issue_catrank issue_cat; do
       # Phase-key the leaf (NOT the help-wanted root — the traced leaf may differ
       # from issue_num). dispatch:planned → implement, else plan, mirroring
       # dispatch-phase. bucket_append caps each phase bucket at TOP and keeps the
-      # oldest entries; a leaf traced into an already-full bucket is silently
-      # dropped (the cap subsumes the former first-seen guard).
+      # oldest entries; a leaf traced into an already-full bucket is dropped — the
+      # return code gates root_recorded and, at TOP=1, short-circuits descent
+      # (the cap subsumes the former first-seen guard).
       leaf_phase=plan
       [[ -n "${ISSUE_PLANNED[$leaf]:-}" ]] && leaf_phase=implement
       leaf_bucket="$issue_cat|$issue_pri|$leaf_phase"
@@ -995,7 +996,7 @@ while IFS=$'\t' read -r issue_num issue_pri issue_catrank issue_cat; do
         root_recorded=$(( root_recorded + 1 ))
       else
         # Bucket already at TOP — this leaf was dropped. Criterion #3 freezes
-        # TOP=1: a root that hits a full bucket on a landed-append attempt stops
+        # TOP=1: a root that hits a full bucket on an append attempt stops
         # descending, byte-identical to the pre-fix loop. TOP>1 keeps descending
         # past the drop to this root's other-phase leaves (#1403).
         (( TOP == 1 )) && break

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3320,6 +3320,62 @@ assert_eq "--top 3 descent skips parked leaf 5501 → 5500,5502" "$(printf 'issu
 assert_eq "--top 3 descent: parked leaf 5501 absent" "0" "$(printf '%s\n' "$result" | grep -c '^issue 5501$')"
 teardown
 
+# T4e. Mixed-phase root descent is not short-circuited by full-bucket drops
+#      (#1403). `root_recorded` counts only leaves actually INSERTED, so a root
+#      whose first leaves drop into an already-full bucket still descends to its
+#      other-phase leaf. Prior roots 6010, 6011 (no sub-issues → each its own
+#      plan leaf) fill the `plan` bucket to TOP=2. Root 6020 then descends three
+#      sub-issues in order: 6021, 6022 (both plan → both DROP into the full plan
+#      bucket) then 6023 (dispatch:planned → implement). With the fix the two
+#      plan drops do not advance `root_recorded`, so descent reaches 6023, which
+#      lands in the empty `implement` bucket; emission ranks implement above plan,
+#      so `--top 2` yields `issue 6023` then the oldest plan entry `issue 6010`.
+#      The pre-fix code increments `root_recorded` on every append (drops
+#      included): the two plan drops inflate it to TOP=2, the loop breaks before
+#      reaching 6023, and the output is `issue 6010\nissue 6011` — 6023 never
+#      appears. This test is RED against the pre-fix script and GREEN after it.
+echo "Test: --top 2 mixed-phase descent reaches the implement leaf past full-plan drops"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":6010,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":6011,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":6020,"createdAt":"2024-01-03T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":6023,"createdAt":"2024-01-04T00:00:00Z","labels":[{"name":"dispatch:planned"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":6021},{"number":6022},{"number":6023}]\n' > "$STUB_DIR/subissues-6020.json"
+printf '{"title":"Issue 6021","body":"","comments":[],"number":6021,"state":"OPEN"}\n' > "$STUB_DIR/issue-6021.json"
+printf '{"title":"Issue 6022","body":"","comments":[],"number":6022,"state":"OPEN"}\n' > "$STUB_DIR/issue-6022.json"
+printf '{"title":"Issue 6023","body":"","comments":[],"number":6023,"state":"OPEN"}\n' > "$STUB_DIR/issue-6023.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --top 2)
+assert_eq "--top 2 mixed-phase: implement leaf 6023 reached past full-plan drops" "$(printf 'issue 6023\nissue 6010')" "$result"
+assert_eq "--top 2 mixed-phase: implement leaf 6023 present exactly once" "1" "$(printf '%s\n' "$result" | grep -c '^issue 6023$')"
+teardown
+
+# T4f. TOP=1 byte-parity freeze (#1403, criterion #3). At TOP=1 the fix keeps the
+#      historical short-circuit: a root that hits a full bucket on a landed-append
+#      attempt stops descending, so `--top 1` stays byte-identical to the pre-fix
+#      loop AND to the plain no-flag call. Prior root 6110 (its own plan leaf)
+#      fills the `plan` bucket to TOP=1. Root 6120 descends 6121 (plan → DROPS
+#      into the full plan bucket) then 6122 (dispatch:planned → implement). The
+#      `(( TOP == 1 )) && break` freeze breaks on the first dropped plan leaf, so
+#      6122 is never reached and the output is `issue 6110`. This is the lock on
+#      the freeze: a naive fix that gated the counter on insert WITHOUT the
+#      TOP==1 break would descend to 6122 and emit `issue 6122` (implement
+#      outranks plan), changing the single TOP=1 winner. RED against that naive
+#      variant; GREEN with the freeze (and against the pre-fix code, which it must
+#      match byte-for-byte).
+echo "Test: --top 1 freeze keeps byte-parity, implement leaf not reached past a full-plan drop"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":6110,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":6120,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":6122,"createdAt":"2024-01-03T00:00:00Z","labels":[{"name":"dispatch:planned"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":6121},{"number":6122}]\n' > "$STUB_DIR/subissues-6120.json"
+printf '{"title":"Issue 6121","body":"","comments":[],"number":6121,"state":"OPEN"}\n' > "$STUB_DIR/issue-6121.json"
+printf '{"title":"Issue 6122","body":"","comments":[],"number":6122,"state":"OPEN"}\n' > "$STUB_DIR/issue-6122.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+plain=$("$TMPDIR_TEST/dispatch-select-target")
+top1=$("$TMPDIR_TEST/dispatch-select-target" --top 1)
+assert_eq "--top 1 freeze: plan winner 6110 (implement leaf not reached)" "issue 6110" "$top1"
+assert_eq "--top 1 freeze: byte-parity with no-flag call" "$plain" "$top1"
+assert_eq "--top 1 freeze: implement leaf 6122 absent" "0" "$(printf '%s\n' "$top1" | grep -c '^issue 6122$')"
+teardown
+
 # T5. --top 1 byte-parity: on a representative fixture, `--top 1` output is
 #     byte-identical to the plain (no-flag) call. Guards that the default path is
 #     unchanged for every existing caller.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3406,7 +3406,7 @@ assert_eq "--top 2 mixed-phase: implement leaf 6023 present exactly once" "1" "$
 teardown
 
 # T4f. TOP=1 byte-parity freeze (#1403, criterion #3). At TOP=1 the fix keeps the
-#      historical short-circuit: a root that hits a full bucket on a landed-append
+#      historical short-circuit: a root that hits a full bucket on an append
 #      attempt stops descending, so `--top 1` stays byte-identical to the pre-fix
 #      loop AND to the plain no-flag call. Prior root 6110 (its own plan leaf)
 #      fills the `plan` bucket to TOP=1. Root 6120 descends 6121 (plan → DROPS


### PR DESCRIPTION
Closes #1403

## Problem

`dispatch-select-target`'s single-pass `--top N` fan-out scan descends each
help-wanted root to up to `N` startable leaves, filing each leaf into a
per-`(category, priority, phase)` bucket via `bucket_append` (capped at `TOP`).
The per-root descent is bounded by a `root_recorded` counter and the guard
`(( root_recorded >= TOP )) && break`.

`root_recorded` was incremented **unconditionally** after every `bucket_append`,
including when the append was a silent no-op drop (the bucket was already at
`TOP`). So a root whose leaves traced into an already-full bucket inflated
`root_recorded` on the drops, and once it hit `TOP` the loop broke **before
descending to that root's leaves in the other phase** — e.g. a root's
higher-rank `implement` leaf was skipped after its `plan` leaves dropped into a
full `plan` bucket.

## Fix

`root_recorded` now counts only leaves actually **inserted**:

- `bucket_append` returns `0` on insert and `1` on a full-bucket drop (was
  always `0`). The doc comment now states this contract.
- Both call sites are guarded against `set -euo pipefail`:
  - PR queue site: `bucket_append … || true` (it tracks no counter; a routine
    full-bucket PR drop must not abort the script — PR buckets drop routinely,
    including at `TOP=1`).
  - Issue-leaf site: `if bucket_append …; then root_recorded=$(( … + 1 ))`. The
    leaf is added to `root_excl` unconditionally first (a traced leaf is excluded
    from re-tracing whether it landed or dropped, unchanged from before).
- A deliberate `(( TOP == 1 )) && break` in the drop branch keeps `TOP=1` output
  **byte-identical** to the pre-fix loop: a root that hits a full bucket on a
  landed-append attempt still stops descending at `TOP=1`. `TOP>1` now descends
  past the drop to the root's other-phase leaves.

## Tests

Two new `--top N` tests in `test-dispatch-scripts.sh`, each isolating one half of
the fix (verified red-green in both directions):

- **T4e** (`--top 2`): prior roots fill the `plan` bucket to `TOP=2`; the test
  root's two plan leaves drop, and descent still reaches its `implement` leaf,
  which emission ranks first. RED against the pre-fix script (which broke before
  the implement leaf), GREEN after.
- **T4f** (`--top 1`): the `(( TOP == 1 )) && break` freeze keeps the output
  byte-identical to the plain no-flag call. RED against a no-freeze "naive" fix
  (which would descend to the implement leaf and change the single `TOP=1`
  winner), GREEN with the freeze.

Full suite: 2438/2438 pass.
