### PR TITLE
router tests: HTML-escape interpolated path in render callbacks

### DIFF
--- a/router/test/router.test.ts
+++ b/router/test/router.test.ts
@@ -677,7 +677,7 @@ describe("createHistoryRouter", () => {
       path: /^\/post\//,
       render: (path) => `<h2>Post: ${escapeHtml(path)}</h2>`,
     };
-    const html = route.render("/post/<img src=x>");
-    expect(html).toBe("<h2>Post: /post/&lt;img src=x&gt;</h2>");
+    const html = route.render("/post/<img src=x>&title=y");
+    expect(html).toBe("<h2>Post: /post/&lt;img src=x&gt;&amp;title=y</h2>");
   });
 });

--- a/router/test/router.test.ts
+++ b/router/test/router.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { parsePath, createHistoryRouter, type Route, type Router } from "../src/index";
 
+const escapeHtml = (s: string): string =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
 describe("parsePath", () => {
   it("returns pathname and empty params with no query string", () => {
     const result = parsePath();
@@ -174,7 +177,7 @@ describe("createHistoryRouter", () => {
   it("matches RegExp path", async () => {
     const regexpRoutes: [Route, ...Route[]] = [
       { path: "/", render: () => "<h2>Home</h2>" },
-      { path: /^\/post\//, render: (path) => `<h2>Post: ${path}</h2>` },
+      { path: /^\/post\//, render: (path) => `<h2>Post: ${escapeHtml(path)}</h2>` },
     ];
     history.pushState({}, "", "/post/hello-world");
     router = createHistoryRouter(outlet, regexpRoutes);
@@ -260,7 +263,7 @@ describe("createHistoryRouter", () => {
 
   it("passes path to render function", async () => {
     const pathRoutes: [Route, ...Route[]] = [
-      { path: /^\//, render: (path) => `<h2>Path: ${path}</h2>` },
+      { path: /^\//, render: (path) => `<h2>Path: ${escapeHtml(path)}</h2>` },
     ];
     history.pushState({}, "", "/some/path");
     router = createHistoryRouter(outlet, pathRoutes);
@@ -622,7 +625,7 @@ describe("createHistoryRouter", () => {
   it("matches g-flagged RegExp route correctly under the onClick+navigate double call", async () => {
     const gRoutes: [Route, ...Route[]] = [
       { path: "/", render: () => "<h2>Home</h2>" },
-      { path: /^\/post\//g, render: (path) => `<h2>Post: ${path}</h2>` },
+      { path: /^\/post\//g, render: (path) => `<h2>Post: ${escapeHtml(path)}</h2>` },
     ];
     router = createHistoryRouter(outlet, gRoutes);
     await vi.waitFor(() => {
@@ -647,7 +650,7 @@ describe("createHistoryRouter", () => {
   it("matches y-flagged RegExp route correctly under the onClick+navigate double call", async () => {
     const yRoutes: [Route, ...Route[]] = [
       { path: "/", render: () => "<h2>Home</h2>" },
-      { path: /^\/post\//y, render: (path) => `<h2>Post: ${path}</h2>` },
+      { path: /^\/post\//y, render: (path) => `<h2>Post: ${escapeHtml(path)}</h2>` },
     ];
     router = createHistoryRouter(outlet, yRoutes);
     await vi.waitFor(() => {
@@ -667,5 +670,14 @@ describe("createHistoryRouter", () => {
     } finally {
       document.body.removeChild(anchor);
     }
+  });
+
+  it("escapes HTML metacharacters in the interpolated path", () => {
+    const route: Route = {
+      path: /^\/post\//,
+      render: (path) => `<h2>Post: ${escapeHtml(path)}</h2>`,
+    };
+    const html = route.render("/post/<img src=x>");
+    expect(html).toBe("<h2>Post: /post/&lt;img src=x&gt;</h2>");
   });
 });


### PR DESCRIPTION
Closes #1542

## What

The RegExp-route tests in `router/test/router.test.ts` had render callbacks that
interpolated the raw URL `path` straight into an HTML template literal the router
writes to `outlet.innerHTML`:

```ts
{ path: /^\/post\//, render: (path) => `<h2>Post: ${path}</h2>` }
```

That models an XSS-prone pattern — developers copy this shape into production with
non-`pathname` inputs (decoded segments, query params, fragments) that lack the
browser's percent-encoding guarantee, turning `render` into a direct `innerHTML`
sink. JSDOM (the test runtime) also doesn't match a real browser's encoding, so
the pattern is a live vector in the test environment too.

## Change (test-only)

- Add a test-local `escapeHtml` helper (escapes `&` first, then `<`/`>`; `"`/`'`
  are not escaped because these callbacks interpolate into element text, not an
  attribute value).
- Wrap the interpolated `path` with `escapeHtml(...)` in all **four** RegExp-route
  render callbacks added by #1505 and its g/y-flag follow-up #1419 (the `matches
  RegExp path`, `passes path to render function`, and g- / y-flagged route tests).
  Route patterns and existing assertions are unchanged — every existing test
  asserts a metacharacter-free path, so the escaped output is byte-identical and
  the `expect(...).toBe(...)` assertions still pass as written.
- Add one dedicated test that calls `render` directly with a crafted
  metacharacter string (`/post/<img src=x>`) and asserts escaped output. Calling
  `render` directly avoids relying on `location.pathname` percent-encoding, which
  would mask a no-op or broken helper and let the suite pass green.

Fixing all four callbacks (not just the one the issue names) is the consistent
reading of the issue's "developers copy this" rationale, not a scope expansion.

No changes to `router/src/` — the production router is not the subject; the issue
is strictly about the test modeling a safe pattern.

## Verification

`npx vitest run --root router` — all router tests pass, including the new escape
test.
