### PR TITLE
office-hours rules-test: assert unfiltered owner list on usage-samples is denied

### DIFF
--- a/rules-test/test/firestore/office-hours.test.ts
+++ b/rules-test/test/firestore/office-hours.test.ts
@@ -244,6 +244,14 @@ describe("office-hours usage-samples", () => {
     );
   });
 
+  it("denies unfiltered owner list query on test-env usage-samples collection", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(collection(db, `office-hours/${ENV}/usage-samples`)),
+    );
+  });
+
   it("denies non-member list query on test-env collection", async () => {
     const ctx = authenticatedContext(env, "stranger@test.com");
     const db = ctx.firestore();


### PR DESCRIPTION
Closes #1556

## What

Adds one Firestore rules-test asserting that an authenticated owner's
**unfiltered** list query against `office-hours/test/usage-samples` is denied.

The `usage-samples` `list` rule (`firestore.rules:505-506`) requires the query to
constrain `memberEmails` to the caller's own email. An unfiltered
`getDocs(collection(...))` — no `where` clause — is denied at query-validation
time, because Firestore cannot prove every matched document satisfies the
per-document predicate.

The suite already documents this for the unauthenticated demo-env case
(`denies unauthenticated list query on demo-env collection`) but had no test for
the authenticated test-env owner path. This adds that symmetric case, inserted
immediately after the allow-with-filter test
(`allows owner list query on test-env collection`) so the allow/deny pair sits
together.

## Scope

- Test-only: one `it(...)` block in
  `rules-test/test/firestore/office-hours.test.ts`.
- No change to `firestore.rules`, the `office-hours items` block, the demo-env
  tests, or any imports/fixtures — the needed imports (`getDocs`, `collection`,
  `assertFails`, `authenticatedContext`), the `ENV` constant, and the seed
  `beforeEach` are already present.

## Verification

The `rules-test` suite runs in no CI job, so this test is not exercised by CI;
run it manually against the Firestore emulator during QA:

```bash
npm test --prefix rules-test
```

`assertFails` passes because the emulator denies the unfiltered list under the
`list` rule.
