### PR TITLE
dispatch: route the empty tick disposition through dispatch-tick-recover

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -71,10 +71,13 @@
 #      jit:/calendar: passthrough lines AND the decision line) so journald and a
 #      live relay both see the narrative. The decision is its LAST stdout line.
 #   2. Route on the decision line (mirrors SKILL.md Table 1):
-#        busy / resolver-failed / empty / concurrency-cap /
+#        busy / resolver-failed / concurrency-cap /
 #        sync-repair-pending / sync-broken
 #                          → log a one-line note; exit 0. (select-tick already
 #                            released the lock / scheduled any reseed.)
+#        empty             → log a one-line note; exit 0. On the autonomous
+#                            path additionally invokes dispatch-tick-recover
+#                            (the #1445 continuation backstop, autonomous-only).
 #        NOTE: on the autonomous no-arg path, `concurrency-cap` is emitted by
 #        select-tick only after the priority/main-broken bypass runs (see above):
 #        at-cap + exhausted → concurrency-cap immediately;
@@ -420,7 +423,28 @@ case "${1:-}" in
     echo "dispatch-tick: another tick holds the lock (busy); nothing to do" >&2
     exit 0
     ;;
-  resolver-failed|empty|concurrency-cap|sync-repair-pending|sync-broken)
+  empty)
+    # #1557: an autonomous `empty` tick (work queued, but every reachable open
+    # leaf is claimed/parked/excluded while the fleet is below target) spawns
+    # no worker and arms no continuation on its own, so the chain dead-ends
+    # until an external kick. Route it through the same continuation-guarantor
+    # `drain` uses (#1445): it bounds retries via its consecutive-failure
+    # counter (catching reservation reclaims / clearing parks across a few
+    # ticks), escalates to dispatch:chain-stalled when persistently blocked on
+    # a human, and safely no-ops when a live busy worker already exists.
+    # Autonomous-only (mirror the #1453 convergence-reseed guard above): a
+    # `--manual` empty is a one-shot human probe (an explicit <N> never
+    # resolves to empty), so it must NOT be forced through the backstop, where
+    # with zero live workers it would arm a continuation and increment the
+    # failure counter — the mis-escalation criterion 3 forbids.
+    echo "dispatch-tick: select-tick disposition 'empty'; nothing spawned" >&2
+    if [[ -z "$MANUAL" && -z "$ARG" ]]; then
+      "$SCRIPT_DIR/dispatch-tick-recover" || \
+        echo "dispatch-tick: dispatch-tick-recover failed on 'empty' (continuation not guaranteed)" >&2
+    fi
+    exit 0
+    ;;
+  resolver-failed|concurrency-cap|sync-repair-pending|sync-broken)
     echo "dispatch-tick: select-tick disposition '$1'; nothing spawned" >&2
     exit 0
     ;;

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -21258,11 +21258,13 @@ assert_eq "busy: no spawn-job call" "0" \
   "$([ -f "$TMPDIR_TEST/logs/spawn-job.log" ] && echo 1 || echo 0)"
 tick_teardown
 
-# --- empty / resolver-failed / concurrency-cap / sync-repair-pending / sync-broken ---
-# All pass-through dispositions: exit 0, no materialize, no spawn-job. #1495 adds
+# --- resolver-failed / concurrency-cap / sync-repair-pending / sync-broken ---
+# Pass-through dispositions: exit 0, no materialize, no spawn-job. #1495 adds
 # the two sync pass-throughs (sync-repair-pending, sync-broken); sync-failed moved
-# out of this loop because it now spawns the repair job (covered below).
-for d in empty resolver-failed concurrency-cap sync-repair-pending sync-broken; do
+# out of this loop because it now spawns the repair job (covered below). `empty`
+# moved out because #1557 routes it through dispatch-tick-recover on the
+# autonomous path (covered by its own tests below).
+for d in resolver-failed concurrency-cap sync-repair-pending sync-broken; do
   echo "Test: dispatch-tick $d → exit 0, no materialize/spawn"
   tick_setup
   export TICK_DECISION="$d"
@@ -21447,6 +21449,26 @@ export TICK_DECISION="issue 707 1" TICK_TOKEN="drain"
 out=$(run_tick) && rc=0 || rc=$?
 assert_eq "drain: exit 0" "0" "$rc"
 assert_eq "drain: recover invoked" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/recover.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+echo "Test: dispatch-tick autonomous empty → invokes recover, exit 0 (#1557)"
+tick_setup
+export TICK_DECISION="empty"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "empty: exit 0" "0" "$rc"
+assert_eq "empty: recover invoked" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/recover.log" ] && echo 1 || echo 0)"
+assert_eq "empty: no materialize call" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/materialize.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+echo "Test: dispatch-tick --manual empty → does NOT invoke recover (autonomous-only) (#1557)"
+tick_setup
+export TICK_DECISION="empty"
+out=$(run_tick --manual) && rc=0 || rc=$?
+assert_eq "empty-manual: exit 0" "0" "$rc"
+assert_eq "empty-manual: recover NOT invoked (MANUAL set)" "0" \
   "$([ -f "$TMPDIR_TEST/logs/recover.log" ] && echo 1 || echo 0)"
 tick_teardown
 


### PR DESCRIPTION
Closes #1557

## Problem

The autonomous `dispatch-tick` chain is event-driven with per-disposition
continuation — there is no standing heartbeat (deliberately rejected in #1453),
so every terminal no-spawn disposition must arm its own continuation. The
`empty` disposition armed **nothing**: `dispatch-select-tick` released the lock
and echoed `empty`, and `dispatch-tick` matched it in the combined
`resolver-failed|empty|concurrency-cap|sync-repair-pending|sync-broken` branch
and bare-`exit 0`'d.

`empty` means work exists in the queue but every reachable open leaf is claimed
(live session ∪ reservation marker), parked on `dispatch:office-hours`, or in
the `--exclude` set, **and the fleet is below target**. The block is transient —
it clears when a worker finishes, a stranded reservation is reclaimed, or a park
resolves — but nothing re-ticked to observe that. A reservation held by a *dead*
session fires no Stop-hook, so the chain could stay in an absorbing dead state
indefinitely (observed 2026-06-13: an `empty` tick at 20:14:34, chain dead
~2.5 min until a manual `dispatch` at 20:16:59).

This is the unpatched sibling of #1445, which gave the same continuation backstop
to the `drain` disposition but not to `empty`.

## Fix

Route an autonomous `empty` through the same continuation-guarantor `drain`
uses — `dispatch-tick-recover` — which bounds retries via its consecutive-failure
counter (catching reservation reclaims / clearing parks across a few ticks),
escalates to a `dispatch:chain-stalled` issue when persistently blocked on a
human, and safely no-ops when a live busy worker already exists.

The recover call is guarded **autonomous-only** (`[[ -z "$MANUAL" && -z "$ARG" ]]`,
mirroring the #1453 convergence-reseed guard): a `--manual` empty is a one-shot
human probe (an explicit `<N>` never resolves to `empty`), so it must not be
forced through the backstop, where with zero live workers it would arm a
continuation and increment the failure counter — a mis-escalation. "Exactly as
`drain` does" selects the *mechanism*; the autonomous-only guard is what keeps a
manual probe from mis-escalating.

## Changes

- `dispatch-tick`: split `empty` out of the combined bare-exit branch into a
  dedicated guarded `empty)` arm that logs the existing note and, on the
  autonomous path only, invokes `dispatch-tick-recover` (best-effort, with the
  same `|| echo …` fallback the `drain` arm uses). Header-doc routing summary
  updated to match.
- `test-dispatch-scripts.sh`: pulled `empty` out of the bare-pass-through loop;
  added an autonomous-`empty` → recover test and a `--manual empty` → NO-recover
  test, modeled on the existing bare-`drain` recover test and `--manual`
  convergence-guard test.

`concurrency-cap` keeps its existing `dispatch-schedule-reseed` continuation
(untouched); `sync-failed` / `resolver-failed` routing is unchanged.

## Verification

Full `test-dispatch-scripts.sh` suite passes (2548/2548), including the two new
`empty` tests and the pre-existing `drain` / `concurrency-cap` / `propagate`
continuation tests.
