### PR TITLE
dispatch: distinguish fetch failure from merge divergence in sync-broken latch

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-escalate-sync-broken
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-escalate-sync-broken
@@ -5,11 +5,20 @@
 #
 # WHEN it runs:
 #   Invoked by `dispatch-select-tick` Step 1 (running in the `main` worktree, on
-#   branch `main`) after its `git merge --ff-only origin/main` repair attempt has
-#   failed repeatedly — the per-tick repair attempt-counter has hit its cap and
-#   local main still cannot ff-merge origin/main. That state means local main and
-#   origin/main have diverged with a conflict that `/commit-merge-push` could not
-#   resolve, so the dispatch chain's sync precondition is wedged: every tick that
+#   branch `main`) after its origin/main sync attempt has failed repeatedly — the
+#   per-tick repair attempt-counter has hit its cap and local main still cannot be
+#   brought up to date. The caller passes `--reason` to distinguish two wedge
+#   modes:
+#
+#     merge-failed  — `git fetch` succeeded but the subsequent
+#                     `git merge --ff-only origin/main` failed: local main and
+#                     origin/main have diverged with a conflict that
+#                     `/commit-merge-push` could not resolve.
+#     fetch-failed  — `git fetch origin main` itself failed: origin/main could
+#                     not be reached (network / GitHub reachability), so no merge
+#                     was attempted at all.
+#
+#   Either way the dispatch chain's sync precondition is wedged: every tick that
 #   needs an up-to-date local main is blocked.
 #
 #   This script does NOT attempt the repair itself. It files (or refreshes) a
@@ -22,9 +31,11 @@
 # dispatch-diagnose-main/SKILL.md (find-or-create + label create-on-not-found).
 #
 # Input:
-#   The captured stderr of the failing `git merge --ff-only origin/main` is read
-#   from STDIN. The caller invokes:
-#       "$SCRIPT_DIR/dispatch-escalate-sync-broken" <<<"$MERGE_STDERR"
+#   The captured stderr of the failing git command is read from STDIN. Its meaning
+#   depends on `--reason`: for `fetch-failed` it is the `git fetch origin main`
+#   stderr; for `merge-failed` it is the `git merge --ff-only origin/main` stderr.
+#   The caller passes `--reason` and pipes the matching stderr:
+#       "$SCRIPT_DIR/dispatch-escalate-sync-broken" --reason merge-failed <<<"$CAPTURED_STDERR"
 #
 # Output:
 #   On success, the created-or-edited issue number is echoed to stdout (bare).
@@ -48,32 +59,59 @@
 set -euo pipefail
 
 LABEL="dispatch:sync-broken"
-TITLE="dispatch: local main cannot ff-merge origin/main (sync latch)"
 
-# ---- Read the merge stderr from stdin ---------------------------------------
+# ---- Parse --reason ---------------------------------------------------------
 #
-# `MERGE_STDERR=$(cat)` consumes the caller's here-string without interpreting
-# escapes or returning a non-zero EOF status that `set -e` would trip on.
-MERGE_STDERR=$(cat)
+# `--reason fetch-failed|merge-failed` selects the wedge mode. Default to
+# `merge-failed` to preserve existing semantics for any untagged caller. An
+# unrecognized value is a clear error, not a silent fallback (per
+# .claude/rules/code-style.md).
+REASON="merge-failed"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reason)
+      REASON="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "dispatch-escalate-sync-broken: unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
 
-# ---- Gather conflict diagnostics from the local repo ------------------------
+case "$REASON" in
+  fetch-failed|merge-failed) ;;
+  *)
+    echo "dispatch-escalate-sync-broken: --reason must be 'fetch-failed' or 'merge-failed', got: $REASON" >&2
+    exit 1
+    ;;
+esac
+
+# ---- Read the captured stderr from stdin ------------------------------------
+#
+# `CAPTURED_STDERR=$(cat)` consumes the caller's here-string without interpreting
+# escapes or returning a non-zero EOF status that `set -e` would trip on. Its
+# meaning depends on $REASON (fetch stderr vs merge stderr).
+CAPTURED_STDERR=$(cat)
+
+# ---- Gather diagnostics from the local repo ---------------------------------
 #
 # This script runs in the main worktree, so the local repo IS local main.
 # `--show-toplevel` derives the worktree path with no hardcoding.
 MAIN_WORKTREE=$(git rev-parse --show-toplevel)
 
-# `git status --porcelain` and `git log origin/main..HEAD` are expected to
-# succeed; a non-zero here signals a broken environment (per
-# .claude/rules/code-style.md, surface it rather than swallow it). They are
-# allowed to produce *empty* output without that being an error.
+# `git status --porcelain` is expected to succeed; a non-zero here signals a
+# broken environment (per .claude/rules/code-style.md, surface it rather than
+# swallow it). It is allowed to produce *empty* output without that being an
+# error.
 GIT_STATUS=$(git status --porcelain)
-GIT_DIVERGENCE=$(git log --oneline origin/main..HEAD)
 
 # ---- Compose the body file --------------------------------------------------
 #
 # The diagnostics may carry shell metacharacters (git/log output, the captured
-# merge stderr). They are written to the body file ONLY and passed with
-# --body-file — never interpolated into the `gh` command line.
+# stderr). They are written to the body file ONLY and passed with --body-file —
+# never interpolated into the `gh` command line.
 if [[ -n "${CLAUDE_JOB_DIR:-}" ]]; then
   mkdir -p "$CLAUDE_JOB_DIR/tmp"
   BODY_FILE=$(mktemp "$CLAUDE_JOB_DIR/tmp/sync-broken-body.XXXXXX")
@@ -82,39 +120,79 @@ else
 fi
 trap 'rm -f "$BODY_FILE"' EXIT
 
-{
-  echo "Local \`main\` cannot fast-forward-merge \`origin/main\`. The dispatch"
-  echo "chain's sync precondition is wedged: local main and origin/main have"
-  echo "diverged with a conflict that automated repair (\`/commit-merge-push\`)"
-  echo "could not resolve, so local main is no longer ff-mergeable."
-  echo
-  echo "**A human must resolve or abort the merge on the \`main\` worktree**"
-  echo "(\`$MAIN_WORKTREE\`) — resolve the divergence and get local main back to a"
-  echo "state where it ff-merges \`origin/main\` cleanly."
-  echo
-  echo "While this issue is open, the dispatch tick spawns no further"
-  echo "\`sync-repair\` jobs (this issue is the latch that suppresses them)."
-  echo "Closing happens automatically: once local main ff-merges \`origin/main\`"
-  echo "clean again, the tick re-arms and closes this latch."
-  echo
-  echo "## git status --porcelain"
-  echo
-  echo '```'
-  echo "$GIT_STATUS"
-  echo '```'
-  echo
-  echo "## git log --oneline origin/main..HEAD (local divergence)"
-  echo
-  echo '```'
-  echo "$GIT_DIVERGENCE"
-  echo '```'
-  echo
-  echo "## git merge --ff-only origin/main (captured stderr)"
-  echo
-  echo '```'
-  echo "$MERGE_STDERR"
-  echo '```'
-} >"$BODY_FILE"
+if [[ "$REASON" == "merge-failed" ]]; then
+  TITLE="dispatch: local main cannot ff-merge origin/main (sync latch)"
+
+  # `git log origin/main..HEAD` is meaningful only here — on a fetch failure the
+  # origin/main ref is stale, so the divergence listing would be misleading.
+  GIT_DIVERGENCE=$(git log --oneline origin/main..HEAD)
+
+  {
+    echo "Local \`main\` cannot fast-forward-merge \`origin/main\`. The dispatch"
+    echo "chain's sync precondition is wedged: local main and origin/main have"
+    echo "diverged with a conflict that automated repair (\`/commit-merge-push\`)"
+    echo "could not resolve, so local main is no longer ff-mergeable."
+    echo
+    echo "**A human must resolve or abort the merge on the \`main\` worktree**"
+    echo "(\`$MAIN_WORKTREE\`) — resolve the divergence and get local main back to a"
+    echo "state where it ff-merges \`origin/main\` cleanly."
+    echo
+    echo "While this issue is open, the dispatch tick spawns no further"
+    echo "\`sync-repair\` jobs (this issue is the latch that suppresses them)."
+    echo "Closing happens automatically: once local main ff-merges \`origin/main\`"
+    echo "clean again, the tick re-arms and closes this latch."
+    echo
+    echo "## git status --porcelain"
+    echo
+    echo '```'
+    echo "$GIT_STATUS"
+    echo '```'
+    echo
+    echo "## git log --oneline origin/main..HEAD (local divergence)"
+    echo
+    echo '```'
+    echo "$GIT_DIVERGENCE"
+    echo '```'
+    echo
+    echo "## git merge --ff-only origin/main (captured stderr)"
+    echo
+    echo '```'
+    echo "$CAPTURED_STDERR"
+    echo '```'
+  } >"$BODY_FILE"
+else
+  # fetch-failed
+  TITLE="dispatch: cannot reach origin/main to sync local main (sync latch)"
+
+  {
+    echo "The dispatch tick could not reach \`origin/main\` — \`git fetch origin main\`"
+    echo "failed (network / GitHub reachability). No merge was attempted, so local"
+    echo "\`main\` and \`origin/main\` were never compared. The dispatch chain's sync"
+    echo "precondition is wedged: every tick that needs an up-to-date local main is"
+    echo "blocked until origin/main becomes reachable again."
+    echo
+    echo "**A human must restore GitHub reachability from the \`main\` worktree**"
+    echo "(\`$MAIN_WORKTREE\`) — once the tick can \`git fetch origin main\` again it"
+    echo "will ff-merge local main up to date on its own."
+    echo
+    echo "While this issue is open, the dispatch tick spawns no further"
+    echo "\`sync-repair\` jobs (this issue is the latch that suppresses them)."
+    echo "Closing happens automatically: once local main ff-merges \`origin/main\`"
+    echo "clean again, the tick re-arms and closes this latch."
+    echo
+    echo "## git status --porcelain"
+    echo
+    echo '```'
+    echo "$GIT_STATUS"
+    echo '```'
+    echo
+    echo "## git fetch origin main (captured stderr)"
+    echo
+    echo '```'
+    echo "$CAPTURED_STDERR"
+    echo '```'
+  } >"$BODY_FILE"
+fi
 
 # ---- Find-or-create the latch issue -----------------------------------------
 #
@@ -125,7 +203,7 @@ existing=$(gh issue list --label "$LABEL" --state open --json number -q '.[0].nu
 if [[ -n "$existing" ]]; then
   # The edit touches the body only (no --label flag), so it cannot fail with a
   # "label not found" error — no create-on-not-found retry needed here.
-  gh issue edit "$existing" --body-file "$BODY_FILE" >/dev/null
+  gh issue edit "$existing" --title "$TITLE" --body-file "$BODY_FILE" >/dev/null
   echo "$existing"
   exit 0
 fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -155,24 +155,29 @@ if [[ "$BRANCH" == "main" ]]; then
     fi
   fi
 
-  # Merge probe. Capture the merge stderr to a temp for escalation diagnostics
-  # while STILL replaying it to the journal (stderr) so nothing is swallowed.
-  # Git's own chatter stays on stderr (1>&2), keeping stdout the decision
-  # channel.
+  # Fetch and merge probe. Fetch and merge are run separately (#1546) so a fetch
+  # failure is distinguished from a merge divergence — both are captured to temps
+  # and replayed to the journal so nothing is swallowed.
   if [[ -n "${CLAUDE_JOB_DIR:-}" ]]; then
     mkdir -p "$CLAUDE_JOB_DIR/tmp"
+    FETCH_TMP=$(mktemp "$CLAUDE_JOB_DIR/tmp/sync-fetch.XXXXXX")
     SYNC_TMP=$(mktemp "$CLAUDE_JOB_DIR/tmp/sync-merge.XXXXXX")
   else
+    FETCH_TMP=$(mktemp)
     SYNC_TMP=$(mktemp)
   fi
-  if git fetch origin main 1>&2 && git merge --ff-only origin/main 2>"$SYNC_TMP" 1>&2; then
-    merge_ok=1
-  else
-    merge_ok=0
+  fetch_ok=0; merge_ok=0
+  if git fetch origin main 2>"$FETCH_TMP" 1>&2; then
+    fetch_ok=1
+    if git merge --ff-only origin/main 2>"$SYNC_TMP" 1>&2; then
+      merge_ok=1
+    fi
   fi
-  cat "$SYNC_TMP" >&2          # let the diagnostics reach the journal
+  cat "$FETCH_TMP" >&2
+  cat "$SYNC_TMP" >&2
+  FETCH_STDERR=$(cat "$FETCH_TMP")
   MERGE_STDERR=$(cat "$SYNC_TMP")
-  rm -f "$SYNC_TMP"
+  rm -f "$FETCH_TMP" "$SYNC_TMP"
 
   if [[ "$merge_ok" == 1 ]]; then
     # SUCCESS — local main ff-merges clean. ALWAYS reset the attempt counter and
@@ -203,7 +208,11 @@ if [[ "$BRANCH" == "main" ]]; then
       # b. Attempt cap hit — escalate to the find-or-create latch issue and stop
       # respawning. The escalate script reads the captured merge stderr on stdin.
       # This branch is terminal; it does NOT bump the counter.
-      "$SCRIPT_DIR/dispatch-escalate-sync-broken" <<<"$MERGE_STDERR" 1>&2 || true
+      if [[ "$fetch_ok" == 0 ]]; then
+        "$SCRIPT_DIR/dispatch-escalate-sync-broken" --reason fetch-failed <<<"$FETCH_STDERR" 1>&2 || true
+      else
+        "$SCRIPT_DIR/dispatch-escalate-sync-broken" --reason merge-failed <<<"$MERGE_STDERR" 1>&2 || true
+      fi
       release_lock
       "$SCRIPT_DIR/dispatch-schedule-reseed" 1>&2 || true
       echo "sync-broken"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -19135,6 +19135,7 @@ FAKE
   # assert it ran. Invoked by dispatch-select-tick via its SCRIPT_DIR (= TMPDIR_TEST).
   cat > "$TMPDIR_TEST/dispatch-escalate-sync-broken" <<FAKE
 #!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$TMPDIR_TEST/logs/escalate-args.log"
 cat >> "$TMPDIR_TEST/logs/escalate-stdin.log"
 echo called >> "$TMPDIR_TEST/logs/escalate-sync-broken.log"
 exit 0
@@ -19433,7 +19434,26 @@ assert_eq "cap-escalate: reseed armed" "present" \
   "$([ -f "$TMPDIR_TEST/logs/schedule-reseed.log" ] && echo present || echo absent)"
 assert_eq "cap-escalate: escalate called" "present" \
   "$([ -f "$TMPDIR_TEST/logs/escalate-sync-broken.log" ] && echo present || echo absent)"
+assert_eq "cap-escalate: --reason merge-failed passed" "1" \
+  "$(grep -cF -- '--reason merge-failed' "$TMPDIR_TEST/logs/escalate-args.log")"
 assert_eq "cap-escalate: counter unchanged (no bump on terminal branch)" "3" \
+  "$(cat "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE")"
+sel_tick_teardown
+
+# --- #1546: failing fetch at attempt cap → escalate --reason fetch-failed ------
+echo "Test: select-tick failing fetch at cap → escalate, sync-broken, --reason fetch-failed"
+sel_tick_setup
+printf '3\n' > "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE"   # already at the cap
+export FAKE_GIT_FETCH_FAIL=1   # cannot reach origin/main (fetch fails, no merge)
+# No sync-broken latch open yet → the cap branch escalates (find-or-create).
+out=$(run_sel_tick)
+assert_eq "cap-fetch-escalate: decision line" "sync-broken" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "cap-fetch-escalate: escalate called" "present" \
+  "$([ -f "$TMPDIR_TEST/logs/escalate-sync-broken.log" ] && echo present || echo absent)"
+assert_eq "cap-fetch-escalate: --reason fetch-failed passed" "1" \
+  "$(grep -cF -- '--reason fetch-failed' "$TMPDIR_TEST/logs/escalate-args.log")"
+assert_eq "cap-fetch-escalate: counter unchanged (no bump on terminal branch)" "3" \
   "$(cat "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE")"
 sel_tick_teardown
 
@@ -19983,6 +20003,162 @@ case "$err" in
 esac
 assert_eq "--manual + number → usage error, exit 2" "ok" "$status"
 sel_tick_teardown
+
+# ============================================================================
+# === #1546: direct dispatch-escalate-sync-broken body-content tests ===
+# ============================================================================
+# Invokes the REAL dispatch-escalate-sync-broken (by absolute path) with git and
+# gh PATH-shimmed. The git shim feeds fixed diagnostics; the gh shim captures the
+# composed --title and --body-file contents so the test can inspect the body the
+# script wrote. Exercises both the CREATE path (no open latch) and the EDIT path
+# (an existing latch number), and the --reason parametrization (#1546).
+
+ESB_SCRIPT="$SCRIPT_DIR/dispatch-escalate-sync-broken"
+ESB_TMPDIR=""
+ESB_CAPTURE=""
+
+esb_setup() {
+  ESB_TMPDIR=$(mktemp -d)
+  ESB_CAPTURE="$ESB_TMPDIR/capture"
+  mkdir -p "$ESB_TMPDIR/bin" "$ESB_CAPTURE"
+
+  # git shim: fixed diagnostics for the three queries the script runs.
+  cat > "$ESB_TMPDIR/bin/git" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  "rev-parse --show-toplevel")          echo "/fake/main/worktree" ;;
+  "status --porcelain")                 echo " M somefile" ;;
+  "log --oneline origin/main..HEAD")    echo "deadbee some local commit" ;;
+  *)                                    exit 0 ;;
+esac
+STUB
+  chmod +x "$ESB_TMPDIR/bin/git"
+
+  # gh shim: parses --body-file/--title out of "$@" regardless of create/edit,
+  # copies the body to capture/body.txt and the title to capture/title.txt. For
+  # `issue list` it returns capture/existing.txt (empty/absent → no open latch →
+  # CREATE path; nonempty → EDIT path). `issue create` echoes a URL so the
+  # script's ${create_out##*/} yields a bare number; `issue edit` exits 0.
+  cat > "$ESB_TMPDIR/bin/gh" <<STUB
+#!/usr/bin/env bash
+CAP="$ESB_CAPTURE"
+STUB
+  cat >> "$ESB_TMPDIR/bin/gh" <<'STUB'
+sub="$1 $2"
+# Pull --title <val> and --body-file <path> out of the argv.
+prev=""
+for a in "$@"; do
+  case "$prev" in
+    --title)     printf '%s' "$a" > "$CAP/title.txt" ;;
+    --body-file) cat "$a" > "$CAP/body.txt" ;;
+  esac
+  prev="$a"
+done
+case "$sub" in
+  "issue list")
+    # Return the open-latch number if seeded; an absent file means no open
+    # latch (CREATE path). Must exit 0 either way — the script reads this under
+    # `set -e`, so a falsy `[[ -f ]]` test (no file) must not propagate rc 1.
+    [[ -f "$CAP/existing.txt" ]] && cat "$CAP/existing.txt"
+    exit 0
+    ;;
+  "issue create")
+    echo "https://github.com/x/y/issues/123"
+    ;;
+  "issue edit")
+    : # title/body already captured above
+    ;;
+  "label create")
+    : # create-on-not-found path; not exercised here
+    ;;
+  *)
+    echo "gh stub (esb): unknown invocation: $*" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$ESB_TMPDIR/bin/gh"
+
+  export PATH="$ESB_TMPDIR/bin:$SAVED_PATH"
+  # Use plain mktemp inside the script (no CLAUDE_JOB_DIR tmp subtree needed).
+  unset CLAUDE_JOB_DIR
+}
+
+esb_teardown() {
+  export PATH="$SAVED_PATH"
+  rm -rf "$ESB_TMPDIR"
+  ESB_TMPDIR="" ; ESB_CAPTURE=""
+}
+
+# Reset just the capture dir between runs within one setup.
+esb_reset_capture() {
+  rm -rf "$ESB_CAPTURE"
+  mkdir -p "$ESB_CAPTURE"
+}
+
+# --- AC4 + AC3: fetch-failed body (CREATE path) ------------------------------
+echo "Test: dispatch-escalate-sync-broken --reason fetch-failed body content (#1546)"
+esb_setup
+# No existing.txt → list returns empty → CREATE path.
+ISSUE_NUM=$(printf '%s' "fatal: unable to access origin: Could not resolve host" \
+  | "$ESB_SCRIPT" --reason fetch-failed) || ISSUE_NUM="ERR"
+assert_eq "fetch-failed: issue number parsed from create URL" "123" "$ISSUE_NUM"
+BODY=$(cat "$ESB_CAPTURE/body.txt" 2>/dev/null || true)
+TITLE=$(cat "$ESB_CAPTURE/title.txt" 2>/dev/null || true)
+assert_eq "fetch-failed body: states no merge was attempted" "1" \
+  "$(grep -ciF 'no merge was attempted' <<<"$BODY" || true)"
+assert_eq "fetch-failed body: no 'diverge' token" "0" \
+  "$(grep -ic 'diverge' <<<"$BODY" || true)"
+assert_eq "fetch-failed body: no 'conflict' token" "0" \
+  "$(grep -ic 'conflict' <<<"$BODY" || true)"
+assert_eq "fetch-failed body: no merge-stderr section header" "0" \
+  "$(grep -cF 'git merge --ff-only origin/main (captured stderr)' <<<"$BODY" || true)"
+assert_eq "fetch-failed body: no git-log divergence section" "0" \
+  "$(grep -cF 'git log --oneline origin/main..HEAD' <<<"$BODY" || true)"
+assert_eq "fetch-failed body: has fetch-stderr section header" "1" \
+  "$(grep -cF '## git fetch origin main (captured stderr)' <<<"$BODY" || true)"
+assert_eq "fetch-failed title: 'cannot reach origin/main'" "1" \
+  "$(grep -cF 'cannot reach origin/main' <<<"$TITLE" || true)"
+esb_teardown
+
+# --- AC2: merge-failed body retains divergence language (CREATE path) ---------
+echo "Test: dispatch-escalate-sync-broken --reason merge-failed body content (#1546)"
+esb_setup
+ISSUE_NUM=$(printf '%s' "CONFLICT (content): Merge conflict in foo" \
+  | "$ESB_SCRIPT" --reason merge-failed) || ISSUE_NUM="ERR"
+assert_eq "merge-failed: issue number parsed from create URL" "123" "$ISSUE_NUM"
+BODY=$(cat "$ESB_CAPTURE/body.txt" 2>/dev/null || true)
+TITLE=$(cat "$ESB_CAPTURE/title.txt" 2>/dev/null || true)
+assert_eq "merge-failed body: has git-log divergence section" "1" \
+  "$(grep -cF 'git log --oneline origin/main..HEAD (local divergence)' <<<"$BODY" || true)"
+assert_eq "merge-failed body: has merge-stderr section header" "1" \
+  "$(grep -cF 'git merge --ff-only origin/main (captured stderr)' <<<"$BODY" || true)"
+assert_eq "merge-failed body: retains divergence language" "1" \
+  "$([ "$(grep -ic diverge <<<"$BODY")" -ge 1 ] && echo 1 || echo 0)"
+assert_eq "merge-failed title: 'cannot ff-merge origin/main'" "1" \
+  "$(grep -cF 'cannot ff-merge origin/main' <<<"$TITLE" || true)"
+esb_teardown
+
+# --- Edit-path: --title is passed on the edit path too (existing latch) -------
+echo "Test: dispatch-escalate-sync-broken edit path passes --title (#1546)"
+esb_setup
+printf '99\n' > "$ESB_CAPTURE/existing.txt"   # an open latch → EDIT path
+EDIT_NUM=$(printf '%s' "fatal: unable to access origin" \
+  | "$ESB_SCRIPT" --reason fetch-failed) || EDIT_NUM="ERR"
+assert_eq "edit-path: existing issue number echoed" "99" "$EDIT_NUM"
+TITLE=$(cat "$ESB_CAPTURE/title.txt" 2>/dev/null || true)
+assert_eq "edit-path title: fetch-failed 'cannot reach origin/main'" "1" \
+  "$(grep -cF 'cannot reach origin/main' <<<"$TITLE" || true)"
+esb_teardown
+
+# --- Invalid --reason → clear nonzero error ----------------------------------
+echo "Test: dispatch-escalate-sync-broken --reason bogus → nonzero, clear message (#1546)"
+esb_setup
+if "$ESB_SCRIPT" --reason bogus </dev/null 2>"$ESB_CAPTURE/err.txt"; then rc=0; else rc=$?; fi
+assert_eq "invalid --reason: nonzero exit" "1" "$([ "$rc" -ne 0 ] && echo 1 || echo 0)"
+assert_eq "invalid --reason: clear message mentions reason" "1" \
+  "$(grep -ic 'reason' "$ESB_CAPTURE/err.txt" || true)"
+esb_teardown
 
 # ============================================================================
 # dispatch-materialize-spawn tests (#919)


### PR DESCRIPTION
Closes #1546

## Problem

In `dispatch-select-tick`'s main-branch sync step, the fetch and the ff-merge ran
as a single short-circuiting `&&`:

```bash
if git fetch origin main 1>&2 && git merge --ff-only origin/main 2>"$SYNC_TMP" 1>&2; then
```

When `git fetch` failed (a network / GitHub-reachability problem), the merge never
ran, `MERGE_STDERR` stayed empty, yet the cap-hit escalation still called
`dispatch-escalate-sync-broken`, which unconditionally wrote a latch body claiming
"local main and origin/main have diverged with a conflict that automated repair
could not resolve." That is a misleading diagnosis: there was no divergence and no
merge was attempted — and `git log origin/main..HEAD` is itself meaningless because
the `origin/main` ref is stale.

Deferred from PR #1506; surfaced while reviewing #1495.

## Change

Distinguish a fetch failure from a merge failure before composing the latch body.

- **`dispatch-escalate-sync-broken`** gains a `--reason fetch-failed|merge-failed`
  flag (default `merge-failed`, so any untagged caller keeps prior semantics; an
  invalid value is a clear error, not a silent fallback). Both the issue **title**
  and the body branch on the reason:
  - `merge-failed` → unchanged title and the existing body verbatim (porcelain +
    `git log origin/main..HEAD (local divergence)` + merge-stderr sections).
  - `fetch-failed` → a new title and a body that states origin/main could not be
    reached and that **no merge was attempted, so local `main` and `origin/main`
    were never compared**. It keeps the porcelain section, swaps the merge-stderr
    section for a `git fetch origin main (captured stderr)` section, and omits the
    divergence / `git log origin/main..HEAD` section entirely.
- **`dispatch-select-tick`** splits the single `&&` into nested conditionals with a
  separate `FETCH_TMP` capture, and branches the cap-hit escalate call by
  `fetch_ok` — passing `--reason fetch-failed` (with the fetch stderr) or
  `--reason merge-failed` (with the merge stderr).
- **Tests** assert select-tick passes the right `--reason`, and new direct
  `dispatch-escalate-sync-broken` body-content tests prove the fetch-failed body
  carries no divergence/conflict language and no merge-stderr section, while the
  merge-failed body retains them.

## Two deliberate choices beyond the literal ACs (not scope creep)

1. **The latch title is parametrized by reason too.** A fetch-failure latch titled
   "cannot ff-merge origin/main" would itself be part of the misleading diagnosis
   this issue fixes, so the fetch-failed case gets its own title ("cannot reach
   origin/main to sync local main"). The title is corrected on both the create and
   the existing-latch edit path.
2. The fetch-failed body wording is phrased **positively** ("no merge was attempted,
   so local `main` and `origin/main` were never compared") specifically to avoid the
   substrings `diverge`/`conflict` — the natural negative phrasings ("no conflict to
   resolve", "didn't diverge") would reintroduce the very tokens the fix removes.
   A direct test pins this with a case-insensitive substring-absence check.

## Known limitation (intentionally out of scope)

Once a `dispatch:sync-broken` latch is open, `dispatch-select-tick`'s
"already latched" sub-case returns early and never refreshes the body. So a latch
first opened on a fetch failure keeps its fetch-failed body even if a later tick
hits a real merge divergence (and vice versa). This staleness is structural and
pre-existing — not introduced by this change — and is left for a follow-up.

## Verification

`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` — green
(2568/2568 passed), covering AC1–AC4.
