### PR TITLE
rules-test: add publishedAt to draft1 so landing bare-list denial tests are unambiguous

### DIFF
--- a/rules-test/test/firestore/landing.test.ts
+++ b/rules-test/test/firestore/landing.test.ts
@@ -45,6 +45,7 @@ describe("landing posts", () => {
     await adminSetDoc(env, `landing/${ENV}/posts/draft1`, {
       published: false,
       title: "Draft Post",
+      publishedAt: "2024-01-02",
     });
   });
 

--- a/rules-test/test/firestore/landing.test.ts
+++ b/rules-test/test/firestore/landing.test.ts
@@ -45,6 +45,8 @@ describe("landing posts", () => {
     await adminSetDoc(env, `landing/${ENV}/posts/draft1`, {
       published: false,
       title: "Draft Post",
+      // Required: keeps draft1 in the orderBy('publishedAt') result set so the
+      // bare-list denial is unambiguous regardless of emulator evaluation model.
       publishedAt: "2024-01-02",
     });
   });


### PR DESCRIPTION
Closes #1565

## Problem

The `denies unauthenticated bare list query` and `denies non-admin bare list
query` tests in `rules-test/test/firestore/landing.test.ts` assert `assertFails`
on a `collection(...)` query ordered by `orderBy("publishedAt")`. Firestore's
`orderBy` implicitly excludes documents that lack the ordered field, so with the
`draft1` fixture omitting `publishedAt` the emulator's result set contained only
`published1` (`published == true`). The landing posts read rule —
`allow read: if resource.data.published == true || isAppAdmin("landing", env)`
(`firestore.rules:30`) — is satisfied by `published1` for every caller, so
whether the bare list query was *denied* depended on whether the emulator
evaluated the rule against the full collection or only the filtered result set.
That made the two denial tests' pass/fail contingent on emulator-specific
semantics rather than a clearly defined invariant.

## Change

Add `publishedAt: "2024-01-02"` to the `draft1` fixture. The date is distinct
from and later than `published1`'s `"2024-01-01"`, keeping the
`orderBy("publishedAt")` ordering deterministic. With `draft1`
(`published == false`) now in the ordered result set, the read rule must deny
the bare list query for unauthenticated and non-admin callers regardless of
emulator evaluation order, while the admin still passes via `isAppAdmin`. This
makes the denial unambiguous and the tests deterministic.

This is the only change — no rule changes, no new tests, and no changes to the
`published1`/`admin` fixtures or the per-document `getDoc` tests.

## Verification

The Firestore rules unit suite (`run-rules-test.sh`) is wired into CI as of
#1539, so CI on this PR is the authoritative check. Expected results:

- `denies unauthenticated bare list query` passes — `draft1` now in the
  `orderBy("publishedAt")` result set, `published == false`, denied.
- `denies non-admin bare list query` passes — same rationale for an
  authenticated non-admin.
- `allows admin bare list query` still passes — admin reads both via
  `isAppAdmin`.
- All other `landing posts` tests continue to pass.
