### PR TITLE
rules-test: report whether the suite ran or was skipped

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -62,6 +62,14 @@ jobs:
       - name: Run rules-test suite
         if: steps.changes.outputs.rules == 'true'
         run: .claude/skills/dispatch-propagate/scripts/run-rules-test.sh
+      - name: Report rules-test outcome
+        if: always()
+        run: |
+          if [[ "${{ steps.changes.outputs.rules }}" == "true" ]]; then
+            echo "rules-test suite ran (rules-adjacent files changed)"
+          else
+            echo "rules-test suite skipped (no rules-adjacent files changed)"
+          fi
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,16 +60,26 @@ jobs:
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-${{ runner.os }}
       - name: Run rules-test suite
+        id: run-rules-test
         if: steps.changes.outputs.rules == 'true'
         run: .claude/skills/dispatch-propagate/scripts/run-rules-test.sh
       - name: Report rules-test outcome
         if: always()
         run: |
-          if [[ "${{ steps.changes.outputs.rules }}" == "true" ]]; then
-            echo "rules-test suite ran (rules-adjacent files changed)"
-          else
-            echo "rules-test suite skipped (no rules-adjacent files changed)"
-          fi
+          case "${{ steps.run-rules-test.outcome }}" in
+            success)
+              echo "rules-test suite ran and passed (rules-adjacent files changed)"
+              ;;
+            failure)
+              echo "rules-test suite ran and failed (rules-adjacent files changed)"
+              ;;
+            skipped)
+              echo "rules-test suite skipped (no rules-adjacent files changed, or a prior step failed before the suite could run)"
+              ;;
+            *)
+              echo "rules-test suite outcome unknown: '${{ steps.run-rules-test.outcome }}'"
+              ;;
+          esac
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #1566

## Problem

The `rules-test` job in `.github/workflows/unit-tests.yml` gates every
substantive step — "Set up Java", "Cache Firebase emulators", and "Run
rules-test suite" — on `steps.changes.outputs.rules == 'true'`. When a PR
touches no rules-adjacent files, all of those steps skip and the job finishes
green with no substantive output. A reviewer reading the check status alone
cannot tell a genuine passing run from a trivially-skipped no-op.

## Change

Add one final `Report rules-test outcome` step to the `rules-test` job, guarded
by `if: always()` so it runs even when the gated steps skip. It reuses the
existing `steps.changes.outputs.rules` gate output (produced by the in-job
"Detect changed file categories" step) to print one line:

- `rules-test suite ran (rules-adjacent files changed)` when the suite ran, or
- `rules-test suite skipped (no rules-adjacent files changed)` when it skipped.

Because the step always runs, the line appears in the job log on every run, so a
skipped run is no longer indistinguishable from a clean green check. The body is
a pure `echo` with no failing command, so it cannot turn an intentionally-skipped
job red.

## Verification

This PR touches only `.github/workflows/unit-tests.yml`, which matches none of
the rules-adjacent patterns in `detect-changes.sh`, so `rules` stays `false` and
this PR's own `rules-test` run exercises the **skipped** branch. Its green status
is itself the proof that the always-run step does not fail an
intentionally-skipped job — confirm the job log prints
`rules-test suite skipped (no rules-adjacent files changed)`.
