### PR TITLE
rules-test: expose npm install as an explicit CI step

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/run-rules-test.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-rules-test.sh
@@ -2,16 +2,9 @@
 set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-SCRIPTS="$(cd "$(dirname "$0")" && pwd)"
-
-# shellcheck source=lib.sh
-source "$SCRIPTS/lib.sh"
-
-# rules-test is a workspace; the emulator-backed suite needs the workspace
-# node_modules at the repo root. ensure_deps installs them when absent.
-ensure_deps
 
 echo "=== rules-test (Firestore rules unit suite) ==="
 # Boots the Firestore + Storage emulators (emulator startup also validates rules
-# syntax), then runs the vitest rules suite against them.
+# syntax), then runs the vitest rules suite against them. The CI job installs
+# workspace node_modules via an explicit 'Install workspace dependencies' step.
 npm test --prefix "$REPO_ROOT/rules-test"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -59,6 +59,9 @@ jobs:
         with:
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-${{ runner.os }}
+      - name: Install workspace dependencies
+        if: steps.changes.outputs.rules == 'true'
+        run: .claude/skills/dispatch-propagate/scripts/npm-ci-with-retry.sh
       - name: Run rules-test suite
         if: steps.changes.outputs.rules == 'true'
         run: .claude/skills/dispatch-propagate/scripts/run-rules-test.sh


### PR DESCRIPTION
Closes #1564

## Summary

The `rules-test` CI job in `.github/workflows/unit-tests.yml` had no explicit
`npm ci` step. When `rules == 'true'`, it jumped straight to `run-rules-test.sh`,
which called `ensure_deps` (in `lib.sh`) to install the workspace `node_modules`
only when the directory was absent. The install was hidden inside a shell script
rather than visible as a workflow step, making the job log less transparent and
harder to debug when an install fails.

This change surfaces the install as an explicit workflow step and drops the
hidden `ensure_deps` fallback, matching the `playwright-version-sync` sibling
that already models this pattern.

## Changes

- **`.github/workflows/unit-tests.yml`** — add an explicit
  `Install workspace dependencies` step to the `rules-test` job, gated on
  `steps.changes.outputs.rules == 'true'` and running `npm-ci-with-retry.sh`. It
  sits between `Cache Firebase emulators` and `Run rules-test suite`, mirroring
  the `playwright-version-sync` job.
- **`.claude/skills/dispatch-propagate/scripts/run-rules-test.sh`** — remove the
  now-redundant install plumbing: the `ensure_deps` call and its comment, plus
  the orphaned `SCRIPTS=` line and `source "$SCRIPTS/lib.sh"` (nothing else in
  the script used `lib.sh`). Plain removal — not a clear-error guard — since this
  drops a silent-install fallback rather than adding one that hides errors. The
  script now matches the CI-only `check-playwright-version-sync.sh` shape, which
  carries no install logic.

## Verification

- `run-rules-test.sh` no longer references `ensure_deps`, `SCRIPTS`, or `lib.sh`;
  `bash -n` passes.
- The edited workflow parses; the new step's name and gate match the
  `playwright-version-sync` sibling and sit immediately before
  `Run rules-test suite`.
- Because this PR edits a path under
  `.claude/skills/dispatch-propagate/scripts/`, `detect-changes.sh` sets
  `rules=true`, so the `rules-test` job runs on this PR's CI with the new
  **Install workspace dependencies** step visible in the log, followed by the
  `Run rules-test suite` step. CI is the authoritative signal — the
  emulator-backed rules suite cannot run in the local environment.
