### PR TITLE
rules-test: add list-query coverage to the four budget collection test files

### DIFF
--- a/rules-test/test/firestore/budget-journal-entries.test.ts
+++ b/rules-test/test/firestore/budget-journal-entries.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
 import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
-import { doc, getDoc, setDoc, updateDoc, deleteDoc } from "firebase/firestore";
+import { doc, getDoc, setDoc, updateDoc, deleteDoc, getDocs, collection, query, where } from "firebase/firestore";
 import {
   getTestEnv,
   authenticatedContext,
@@ -162,6 +162,79 @@ describe("budget journal entries", () => {
       await assertFails(
         deleteDoc(doc(db, `budget/${ENV}/journal-entries/existing1`)),
       );
+    });
+  });
+
+  describe("list queries", () => {
+    it("allows member list query", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      const snap = await assertSucceeds(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/journal-entries`),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+      expect(snap.empty).toBe(false);
+    });
+
+    it("denies unfiltered member list query", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(collection(db, `budget/${ENV}/journal-entries`)),
+      );
+    });
+
+    // A non-member cannot list another member's docs: filtering for an email
+    // they are not in is denied, because the matching docs carry a memberEmails
+    // the requester is absent from. (A self-targeted array-contains filter is
+    // always rule-compliant and returns an empty set, so it is not a denial
+    // case.)
+    it("denies authenticated non-member list query for another member's docs", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/journal-entries`),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+    });
+
+    it("denies unauthenticated list query", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/journal-entries`),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+    });
+
+    // Documents the non-obvious converse of the denial above: a non-member's
+    // self-targeted filter is rule-compliant and succeeds, returning an empty
+    // set rather than being denied. This guards against re-introducing the
+    // false "self-targeted non-member filter is denied" assumption.
+    it("allows authenticated non-member self-targeted list query (returns empty)", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      const snap = await assertSucceeds(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/journal-entries`),
+            where("memberEmails", "array-contains", "stranger@test.com"),
+          ),
+        ),
+      );
+      expect(snap.empty).toBe(true);
     });
   });
 });

--- a/rules-test/test/firestore/budget-journal-legs.test.ts
+++ b/rules-test/test/firestore/budget-journal-legs.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
 import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
-import { doc, getDoc, setDoc, updateDoc, deleteDoc } from "firebase/firestore";
+import { doc, getDoc, setDoc, updateDoc, deleteDoc, getDocs, collection, query, where } from "firebase/firestore";
 import {
   getTestEnv,
   authenticatedContext,
@@ -164,6 +164,79 @@ describe("budget journal legs", () => {
       await assertFails(
         deleteDoc(doc(db, `budget/${ENV}/journal-legs/existing1`)),
       );
+    });
+  });
+
+  describe("list queries", () => {
+    it("allows member list query", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      const snap = await assertSucceeds(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/journal-legs`),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+      expect(snap.empty).toBe(false);
+    });
+
+    it("denies unfiltered member list query", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(collection(db, `budget/${ENV}/journal-legs`)),
+      );
+    });
+
+    // A non-member cannot list another member's docs: filtering for an email
+    // they are not in is denied, because the matching docs carry a memberEmails
+    // the requester is absent from. (A self-targeted array-contains filter is
+    // always rule-compliant and returns an empty set, so it is not a denial
+    // case.)
+    it("denies authenticated non-member list query for another member's docs", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/journal-legs`),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+    });
+
+    it("denies unauthenticated list query", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/journal-legs`),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+    });
+
+    // Documents the non-obvious converse of the denial above: a non-member's
+    // self-targeted filter is rule-compliant and succeeds, returning an empty
+    // set rather than being denied. This guards against re-introducing the
+    // false "self-targeted non-member filter is denied" assumption.
+    it("allows authenticated non-member self-targeted list query (returns empty)", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      const snap = await assertSucceeds(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/journal-legs`),
+            where("memberEmails", "array-contains", "stranger@test.com"),
+          ),
+        ),
+      );
+      expect(snap.empty).toBe(true);
     });
   });
 });

--- a/rules-test/test/firestore/budget-reconciliation-events.test.ts
+++ b/rules-test/test/firestore/budget-reconciliation-events.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
 import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
-import { doc, getDoc, setDoc, updateDoc, deleteDoc } from "firebase/firestore";
+import { doc, getDoc, setDoc, updateDoc, deleteDoc, getDocs, collection, query, where } from "firebase/firestore";
 import {
   getTestEnv,
   authenticatedContext,
@@ -171,6 +171,79 @@ describe("budget reconciliation events", () => {
       await assertFails(
         deleteDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`)),
       );
+    });
+  });
+
+  describe("list queries", () => {
+    it("allows member list query", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      const snap = await assertSucceeds(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/reconciliation-events`),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+      expect(snap.empty).toBe(false);
+    });
+
+    it("denies unfiltered member list query", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(collection(db, `budget/${ENV}/reconciliation-events`)),
+      );
+    });
+
+    // A non-member cannot list another member's docs: filtering for an email
+    // they are not in is denied, because the matching docs carry a memberEmails
+    // the requester is absent from. (A self-targeted array-contains filter is
+    // always rule-compliant and returns an empty set, so it is not a denial
+    // case.)
+    it("denies authenticated non-member list query for another member's docs", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/reconciliation-events`),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+    });
+
+    it("denies unauthenticated list query", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/reconciliation-events`),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+    });
+
+    // Documents the non-obvious converse of the denial above: a non-member's
+    // self-targeted filter is rule-compliant and succeeds, returning an empty
+    // set rather than being denied. This guards against re-introducing the
+    // false "self-targeted non-member filter is denied" assumption.
+    it("allows authenticated non-member self-targeted list query (returns empty)", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      const snap = await assertSucceeds(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/reconciliation-events`),
+            where("memberEmails", "array-contains", "stranger@test.com"),
+          ),
+        ),
+      );
+      expect(snap.empty).toBe(true);
     });
   });
 });

--- a/rules-test/test/firestore/budget-reconciliation-notes.test.ts
+++ b/rules-test/test/firestore/budget-reconciliation-notes.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
 import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
-import { doc, getDoc, setDoc, updateDoc, deleteDoc } from "firebase/firestore";
+import { doc, getDoc, setDoc, updateDoc, deleteDoc, getDocs, collection, query, where } from "firebase/firestore";
 import {
   getTestEnv,
   authenticatedContext,
@@ -168,6 +168,79 @@ describe("budget reconciliation notes", () => {
       await assertFails(
         deleteDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`)),
       );
+    });
+  });
+
+  describe("list queries", () => {
+    it("allows member list query", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      const snap = await assertSucceeds(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/reconciliation-notes`),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+      expect(snap.empty).toBe(false);
+    });
+
+    it("denies unfiltered member list query", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(collection(db, `budget/${ENV}/reconciliation-notes`)),
+      );
+    });
+
+    // A non-member cannot list another member's docs: filtering for an email
+    // they are not in is denied, because the matching docs carry a memberEmails
+    // the requester is absent from. (A self-targeted array-contains filter is
+    // always rule-compliant and returns an empty set, so it is not a denial
+    // case.)
+    it("denies authenticated non-member list query for another member's docs", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/reconciliation-notes`),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+    });
+
+    it("denies unauthenticated list query", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/reconciliation-notes`),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+    });
+
+    // Documents the non-obvious converse of the denial above: a non-member's
+    // self-targeted filter is rule-compliant and succeeds, returning an empty
+    // set rather than being denied. This guards against re-introducing the
+    // false "self-targeted non-member filter is denied" assumption.
+    it("allows authenticated non-member self-targeted list query (returns empty)", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      const snap = await assertSucceeds(
+        getDocs(
+          query(
+            collection(db, `budget/${ENV}/reconciliation-notes`),
+            where("memberEmails", "array-contains", "stranger@test.com"),
+          ),
+        ),
+      );
+      expect(snap.empty).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Closes #1561

## What

Adds a `list queries` describe block to each of the four budget collection
rules-test files that previously had zero list-query coverage:

- `rules-test/test/firestore/budget-journal-entries.test.ts`
- `rules-test/test/firestore/budget-journal-legs.test.ts`
- `rules-test/test/firestore/budget-reconciliation-events.test.ts`
- `rules-test/test/firestore/budget-reconciliation-notes.test.ts`

Each new block mirrors the proven office-hours `items` list-query guard
(`office-hours.test.ts:117-186`), pointing at the file's own collection path,
with five `it(...)` cases:

- member `array-contains` query → `assertSucceeds`, returns the seeded doc
- unfiltered member list query → `assertFails` (rules require a matching
  `where` filter)
- non-member filtering for another member's email → `assertFails`
- unauthenticated list query → `assertFails`
- non-member self-targeted `array-contains` filter → `assertSucceeds`, returns
  empty (guards against re-introducing the false "self-targeted non-member
  filter is denied" invariant behind #1184/#1117)

## Why

The four files were added in #1290 with single-doc read/create/update/delete
coverage but no `getDocs`/`query` tests. The budget read rules
(`request.auth.token.email in resource.data.memberEmails`) provably support a
`where('memberEmails', 'array-contains', email)` list query — the same pattern
the office-hours suite already exercises. Without these tests, a rules change
that broke member-filtered listing, or that wrongly allowed a non-member to
enumerate another member's docs, would pass CI silently. Surfaced by the review
pass on #1539 and deferred out of that PR's scope.

No `firestore.rules` change — the existing read rules already support the query;
this is test-only coverage.

## Verification

`npm test --prefix rules-test` (boots the Firestore emulator): 386 tests pass
across 21 files, including the 20 new list-query cases (5 per collection).
