### PR TITLE
rules-test: add unauthenticated-delete denial case to four budget collection suites

### DIFF
--- a/rules-test/test/firestore/budget-journal-entries.test.ts
+++ b/rules-test/test/firestore/budget-journal-entries.test.ts
@@ -163,5 +163,13 @@ describe("budget journal entries", () => {
         deleteDoc(doc(db, `budget/${ENV}/journal-entries/existing1`)),
       );
     });
+
+    it("denies unauthenticated delete", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        deleteDoc(doc(db, `budget/${ENV}/journal-entries/existing1`)),
+      );
+    });
   });
 });

--- a/rules-test/test/firestore/budget-journal-legs.test.ts
+++ b/rules-test/test/firestore/budget-journal-legs.test.ts
@@ -165,5 +165,13 @@ describe("budget journal legs", () => {
         deleteDoc(doc(db, `budget/${ENV}/journal-legs/existing1`)),
       );
     });
+
+    it("denies unauthenticated delete", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        deleteDoc(doc(db, `budget/${ENV}/journal-legs/existing1`)),
+      );
+    });
   });
 });

--- a/rules-test/test/firestore/budget-reconciliation-events.test.ts
+++ b/rules-test/test/firestore/budget-reconciliation-events.test.ts
@@ -172,5 +172,13 @@ describe("budget reconciliation events", () => {
         deleteDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`)),
       );
     });
+
+    it("denies unauthenticated delete", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        deleteDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`)),
+      );
+    });
   });
 });

--- a/rules-test/test/firestore/budget-reconciliation-notes.test.ts
+++ b/rules-test/test/firestore/budget-reconciliation-notes.test.ts
@@ -169,5 +169,13 @@ describe("budget reconciliation notes", () => {
         deleteDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`)),
       );
     });
+
+    it("denies unauthenticated delete", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        deleteDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`)),
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes #1568

## What

Adds a `denies unauthenticated delete` test case to the `delete` describe block
in each of the four budget collection rules-test suites:

- `rules-test/test/firestore/budget-journal-entries.test.ts`
- `rules-test/test/firestore/budget-journal-legs.test.ts`
- `rules-test/test/firestore/budget-reconciliation-events.test.ts`
- `rules-test/test/firestore/budget-reconciliation-notes.test.ts`

Each new case mirrors the file's existing `denies unauthenticated read` case —
`unauthenticatedContext(env)` + `assertFails` — swapping `getDoc` for
`deleteDoc` on the `existing1` doc path.

## Why

The `delete` blocks already covered `allows member to delete` and `denies
non-member delete` but omitted the unauthenticated case, even though the `read`
blocks in the same files test unauthenticated denial. The Firestore rules
already enforce the denial via `request.auth != null && request.auth.token.email
in resource.data.memberEmails`, so the new cases pass against current rules.

The value is regression protection: an accidental rules change dropping the
`request.auth != null` delete guard would now fail the suite instead of slipping
through. Surfaced by the review pass on #1539, out of scope there.

## Verification

The full Firestore rules unit suite was run locally (`run-rules-test.sh`): 21
test files passed, 370 tests passed, including the four new cases. No changes to
`firestore.rules`, helpers, or imports.
