### PR TITLE
rules-test: cover the second group member's read/write access in budget CRUD tests

### DIFF
--- a/rules-test/test/firestore/budget-journal-entries.test.ts
+++ b/rules-test/test/firestore/budget-journal-entries.test.ts
@@ -48,6 +48,14 @@ describe("budget journal entries", () => {
       );
     });
 
+    it("allows second member to read", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        getDoc(doc(db, `budget/${ENV}/journal-entries/existing1`)),
+      );
+    });
+
     it("denies non-member read", async () => {
       const ctx = authenticatedContext(env, "stranger@test.com");
       const db = ctx.firestore();
@@ -68,6 +76,14 @@ describe("budget journal entries", () => {
   describe("create", () => {
     it("allows member to create valid doc", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `budget/${ENV}/journal-entries/new1`), baseDoc),
+      );
+    });
+
+    it("allows second member to create valid doc", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
       const db = ctx.firestore();
       await assertSucceeds(
         setDoc(doc(db, `budget/${ENV}/journal-entries/new1`), baseDoc),
@@ -116,6 +132,16 @@ describe("budget journal entries", () => {
       );
     });
 
+    it("allows second member to update mutable field", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        updateDoc(doc(db, `budget/${ENV}/journal-entries/existing1`), {
+          description: "updated",
+        }),
+      );
+    });
+
     it("denies changing groupId", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
       const db = ctx.firestore();
@@ -150,6 +176,14 @@ describe("budget journal entries", () => {
   describe("delete", () => {
     it("allows member to delete", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        deleteDoc(doc(db, `budget/${ENV}/journal-entries/existing1`)),
+      );
+    });
+
+    it("allows second member to delete", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
       const db = ctx.firestore();
       await assertSucceeds(
         deleteDoc(doc(db, `budget/${ENV}/journal-entries/existing1`)),

--- a/rules-test/test/firestore/budget-journal-legs.test.ts
+++ b/rules-test/test/firestore/budget-journal-legs.test.ts
@@ -50,6 +50,14 @@ describe("budget journal legs", () => {
       );
     });
 
+    it("allows second member to read", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        getDoc(doc(db, `budget/${ENV}/journal-legs/existing1`)),
+      );
+    });
+
     it("denies non-member read", async () => {
       const ctx = authenticatedContext(env, "stranger@test.com");
       const db = ctx.firestore();
@@ -70,6 +78,14 @@ describe("budget journal legs", () => {
   describe("create", () => {
     it("allows member to create valid doc", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `budget/${ENV}/journal-legs/new1`), baseDoc),
+      );
+    });
+
+    it("allows second member to create valid doc", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
       const db = ctx.firestore();
       await assertSucceeds(
         setDoc(doc(db, `budget/${ENV}/journal-legs/new1`), baseDoc),
@@ -118,6 +134,16 @@ describe("budget journal legs", () => {
       );
     });
 
+    it("allows second member to update mutable field", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        updateDoc(doc(db, `budget/${ENV}/journal-legs/existing1`), {
+          cleared: true,
+        }),
+      );
+    });
+
     it("denies changing groupId", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
       const db = ctx.firestore();
@@ -152,6 +178,14 @@ describe("budget journal legs", () => {
   describe("delete", () => {
     it("allows member to delete", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        deleteDoc(doc(db, `budget/${ENV}/journal-legs/existing1`)),
+      );
+    });
+
+    it("allows second member to delete", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
       const db = ctx.firestore();
       await assertSucceeds(
         deleteDoc(doc(db, `budget/${ENV}/journal-legs/existing1`)),

--- a/rules-test/test/firestore/budget-reconciliation-events.test.ts
+++ b/rules-test/test/firestore/budget-reconciliation-events.test.ts
@@ -57,6 +57,14 @@ describe("budget reconciliation events", () => {
       );
     });
 
+    it("allows second member to read", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        getDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`)),
+      );
+    });
+
     it("denies non-member read", async () => {
       const ctx = authenticatedContext(env, "stranger@test.com");
       const db = ctx.firestore();
@@ -77,6 +85,14 @@ describe("budget reconciliation events", () => {
   describe("create", () => {
     it("allows member to create valid doc", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `budget/${ENV}/reconciliation-events/new1`), baseDoc),
+      );
+    });
+
+    it("allows second member to create valid doc", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
       const db = ctx.firestore();
       await assertSucceeds(
         setDoc(doc(db, `budget/${ENV}/reconciliation-events/new1`), baseDoc),
@@ -125,6 +141,16 @@ describe("budget reconciliation events", () => {
       );
     });
 
+    it("allows second member to update mutable field", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        updateDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`), {
+          bankBalance: 1234,
+        }),
+      );
+    });
+
     it("denies changing groupId", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
       const db = ctx.firestore();
@@ -159,6 +185,14 @@ describe("budget reconciliation events", () => {
   describe("delete", () => {
     it("allows member to delete", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        deleteDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`)),
+      );
+    });
+
+    it("allows second member to delete", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
       const db = ctx.firestore();
       await assertSucceeds(
         deleteDoc(doc(db, `budget/${ENV}/reconciliation-events/existing1`)),

--- a/rules-test/test/firestore/budget-reconciliation-notes.test.ts
+++ b/rules-test/test/firestore/budget-reconciliation-notes.test.ts
@@ -54,6 +54,14 @@ describe("budget reconciliation notes", () => {
       );
     });
 
+    it("allows second member to read", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        getDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`)),
+      );
+    });
+
     it("denies non-member read", async () => {
       const ctx = authenticatedContext(env, "stranger@test.com");
       const db = ctx.firestore();
@@ -74,6 +82,14 @@ describe("budget reconciliation notes", () => {
   describe("create", () => {
     it("allows member to create valid doc", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        setDoc(doc(db, `budget/${ENV}/reconciliation-notes/new1`), baseDoc),
+      );
+    });
+
+    it("allows second member to create valid doc", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
       const db = ctx.firestore();
       await assertSucceeds(
         setDoc(doc(db, `budget/${ENV}/reconciliation-notes/new1`), baseDoc),
@@ -122,6 +138,16 @@ describe("budget reconciliation notes", () => {
       );
     });
 
+    it("allows second member to update mutable field", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        updateDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`), {
+          note: "updated",
+        }),
+      );
+    });
+
     it("denies changing groupId", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
       const db = ctx.firestore();
@@ -156,6 +182,14 @@ describe("budget reconciliation notes", () => {
   describe("delete", () => {
     it("allows member to delete", async () => {
       const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertSucceeds(
+        deleteDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`)),
+      );
+    });
+
+    it("allows second member to delete", async () => {
+      const ctx = authenticatedContext(env, "other@test.com");
       const db = ctx.firestore();
       await assertSucceeds(
         deleteDoc(doc(db, `budget/${ENV}/reconciliation-notes/existing1`)),


### PR DESCRIPTION
Closes #1567

## Why

The four budget Firestore-rules test files added by #1539 each seed group
`group1` with **two** members `["member@test.com", "other@test.com"]`, but every
assertion only ever exercised the first member (`member@test.com`) or a
non-member (`stranger@test.com`). The second member, `other@test.com`, was
seeded but never used.

The denormalized `memberEmails` field exists precisely so the Firestore rules
authorize *any* group member, not just the document creator. A regression that
narrowed any CRUD rule from a group-membership check to creator/first-element
identity — e.g. `request.auth.token.email == resource.data.memberEmails[0]` —
would still have passed the suite, because the second-member path was untested.

## What

Adds one positive `other@test.com` assertion to each of the four CRUD
`describe` blocks (read / create / update / delete) in all four files —
16 new tests total. Each new test is an exact twin of the existing
`"allows member to …"` test in the same block, changing only the authenticated
email (`other@test.com`) and the title (`"allows second member to …"`). Each
guards a distinct rule clause, since every CRUD operation is gated by an
independent membership check in `firestore.rules`.

No production code, rules, fixtures, or existing tests change — this is
test-only coverage.

## Verification

`npm test --prefix rules-test` (Firestore emulator + vitest) — the 16 new
`"allows second member to …"` tests pass alongside the existing suite, with no
regressions in the previously-passing budget rules tests. This is the same suite
`unit-tests.yml` runs in CI.
