### PR TITLE
office-hours rules-test: deny unfiltered stranger list on test-env usage-samples

### DIFF
--- a/rules-test/test/firestore/office-hours.test.ts
+++ b/rules-test/test/firestore/office-hours.test.ts
@@ -323,6 +323,14 @@ describe("office-hours usage-samples", () => {
     );
   });
 
+  it("denies unfiltered stranger list query on test-env usage-samples collection", async () => {
+    const ctx = authenticatedContext(env, "stranger@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(collection(db, `office-hours/${ENV}/usage-samples`)),
+    );
+  });
+
   // A non-member cannot list another member's samples: filtering for an email
   // they are not in is denied, because the matching docs carry a memberEmails
   // the requester is absent from. (A self-targeted array-contains filter is


### PR DESCRIPTION
Closes #1573

## What

Add a test asserting that an authenticated **non-member** (`stranger@test.com`)
is denied an unfiltered `getDocs` on the `office-hours/test/usage-samples`
collection.

## Why

The existing unfiltered-list denial test (added in #1562) authenticates as
`owner@test.com` — an email present in the sample fixtures' `memberEmails`. It
proves an authorized **member** is denied an unfiltered list, but it does not
exercise the non-member path: a rule misconfiguration that granted `list` to
*any* authenticated user, regardless of membership, would slip past the suite
because a member being denied does not prove a stranger is denied.

This companion test closes that gap, mirroring the equivalent owner/stranger
pair that already exists for the `items` collection.

## Test

The new test copies the adjacent owner unfiltered-denial test verbatim, swapping
the identity to the established non-member `stranger@test.com`. It passes the
bare `collection(...)` to `getDocs` with no `query`/`where` wrapper — the
unfiltered case — and asserts the read fails.

## Verification

`npm test --prefix rules-test` — 368 tests pass (the new test appears in the
`office-hours usage-samples` suite and the unfiltered stranger `getDocs` is
correctly denied; rest of the suite green).
