### PR TITLE
dispatch: auto-close a verifiably-complete epic instead of parking it on office-hours

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -195,6 +195,26 @@ if [ -f "$CLAUDE_JOB_DIR/parse-job-done" ]; then
   exit 0
 fi
 
+# Branch R — resolved-epic clean completion (#1456): /resolve-epic closes a
+# spent parent epic (every sub-issue closed as completed, the epic's own ACs met
+# by the merged work) and writes a `resolved-closed` sentinel instead of a
+# phase-completed marker. Like a clean parse-job, a resolved epic produces NO PR
+# and needs NO phase advance: the skill already closed the issue. A normal
+# completion marker would not work here — the epic's derived phase is still
+# `plan` (no PR, and /resolve-epic does not apply dispatch:planned), so
+# MARKER_PHASE == CURRENT_PHASE == plan would hit Branch D and park on
+# office-hours. The sentinel path sidesteps phase comparison entirely: spawn the
+# next tick and self-close, exactly as Branch P does. (An escalation writes no
+# sentinel; the epic stays open and falls through to Branch A, which parks it on
+# office-hours — today's behavior, no branch needed here.) Checked BEFORE the
+# PR-centric branches, beside Branch P.
+if [ -f "$CLAUDE_JOB_DIR/resolved-closed" ]; then
+  spawn_tick
+  spawn_sweep
+  self_close
+  exit 0
+fi
+
 # Resolve PR (may be empty for implement-phase before the draft PR opens).
 PR_NUM=$("$SCRIPTS/dispatch-find-pr" "$ISSUE_NUM" 2>/dev/null) || PR_NUM=""
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-close-resolved
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-close-resolved
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# dispatch-close-resolved — terminal close + sentinel for a resolved epic.
+#
+# Usage: dispatch-close-resolved <N> --reason "<text>"
+#
+# Called by /resolve-epic as the terminal step when an epic is verifiably
+# complete. It is state-aware so the already-CLOSED re-entry path still leaves
+# the resolved-closed sentinel (which dispatch-stop.sh Branch R reads to spawn
+# the next tick and self-close) WITHOUT posting a duplicate comment.
+#
+# Behavior:
+#   1. Validate args (exit 2 on any violation, before any gh call).
+#   2. Fetch the issue's current state once. If NOT already closed, close it
+#      with `gh issue close --reason completed --comment "$REASON"`. If already
+#      CLOSED, skip the close + comment and print a diagnostic to stderr so a
+#      re-entry is idempotent and never posts a duplicate comment.
+#   3. Write the resolved-closed sentinel atomically (tempfile + mv) under the
+#      $CLAUDE_JOB_DIR guard. The sentinel content is the reason (diagnostic
+#      only; presence drives dispatch-stop.sh). An interactive run (no
+#      CLAUDE_JOB_DIR) still performs the gh close but no-ops the sentinel
+#      write (exit 0).
+#
+# Sentinel contents (for diagnostics only — presence drives dispatch-stop.sh):
+#
+#   <reason>
+#
+# When CLAUDE_JOB_DIR is unset/empty or not a directory the script is running
+# interactively (not under a dispatch job): it prints a diagnostic and no-ops
+# the sentinel write (exit 0), so the same terminal call is harmless
+# interactively.
+#
+# Exactly one non-empty positional issue-number argument plus a non-empty
+# --reason value are required; any violation is a clear error (exit 2).
+set -euo pipefail
+
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+# ---------------------------------------------------------------------------
+# Arg validation (must happen before any gh call)
+# ---------------------------------------------------------------------------
+
+usage() {
+  echo "usage: dispatch-close-resolved <N> --reason \"<text>\"" >&2
+}
+
+if [[ $# -eq 0 ]]; then
+  echo "dispatch-close-resolved: issue number is required" >&2
+  usage
+  exit 2
+fi
+
+# Parse: expect exactly one positional arg (the issue number) and --reason.
+POSITIONALS=()
+REASON=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reason)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo "dispatch-close-resolved: --reason requires a value" >&2
+        usage
+        exit 2
+      fi
+      REASON="$1"
+      shift
+      ;;
+    --reason=*)
+      REASON="${1#--reason=}"
+      shift
+      ;;
+    -*)
+      echo "dispatch-close-resolved: unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      POSITIONALS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#POSITIONALS[@]} -eq 0 ]]; then
+  echo "dispatch-close-resolved: issue number is required" >&2
+  usage
+  exit 2
+fi
+
+if [[ ${#POSITIONALS[@]} -gt 1 ]]; then
+  echo "dispatch-close-resolved: exactly one issue number argument is accepted (got ${#POSITIONALS[@]})" >&2
+  usage
+  exit 2
+fi
+
+if [[ -z "$REASON" ]]; then
+  echo "dispatch-close-resolved: --reason must be non-empty" >&2
+  usage
+  exit 2
+fi
+
+N=$(resolve_issue_number "${POSITIONALS[0]}")
+
+# ---------------------------------------------------------------------------
+# State-aware gh close/skip
+# ---------------------------------------------------------------------------
+
+STATE=$(gh issue view "$N" --json state --jq .state)
+
+if [ "$(printf '%s' "$STATE" | tr '[:upper:]' '[:lower:]')" = "closed" ]; then
+  echo "dispatch-close-resolved: #$N already CLOSED; skipping re-close, writing sentinel only" >&2
+else
+  gh issue close "$N" --reason completed --comment "$REASON"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUDE_JOB_DIR guard: sentinel write only
+# ---------------------------------------------------------------------------
+
+if [[ -z "${CLAUDE_JOB_DIR:-}" || ! -d "$CLAUDE_JOB_DIR" ]]; then
+  echo "dispatch-close-resolved: CLAUDE_JOB_DIR unset or not a directory; interactive run, skipping sentinel write" >&2
+  exit 0
+fi
+
+# Atomic write: tempfile + mv. Presence is read by dispatch-stop.sh Branch R;
+# the reason is diagnostic only.
+f="$CLAUDE_JOB_DIR/resolved-closed"
+printf '%s\n' "$REASON" > "$f.tmp"
+mv "$f.tmp" "$f"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-epic-resolved-candidate
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-epic-resolved-candidate
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+N=$(resolve_issue_number "${1:-}")
+
+# Fetch sub-issues (now includes stateReason). Propagate a hard error as
+# exit 3 so the caller can distinguish a real gh failure from "not a candidate"
+# (exit 1). Capture raw stream first so a non-zero subscript exit is caught by
+# the || branch before the jq pipeline can mask it.
+kids_stream=$("$SCRIPT_DIR/issue-sub-issues" "$N") || {
+  echo "dispatch-epic-resolved-candidate: issue-sub-issues failed for $N" >&2
+  exit 3
+}
+
+# Slurp the per-child JSON objects (one per line from issue-sub-issues) into an
+# array. Use printf '%s' to avoid zsh echo interpreting \t/\n in captured JSON.
+kids_json=$(printf '%s' "$kids_stream" | jq -s '.')
+
+total=$(jq 'length' <<<"$kids_json")
+
+# Zero sub-issues — not a spent epic.
+if [[ "$total" -eq 0 ]]; then
+  exit 1
+fi
+
+# Count children that are closed-as-completed (case-insensitive). .stateReason
+# may be null; the // "" guard prevents ascii_upcase erroring on null.
+good=$(jq '[.[] | select(
+  ((.state // "") | ascii_upcase) == "CLOSED" and
+  ((.stateReason // "") | ascii_upcase) == "COMPLETED"
+)] | length' <<<"$kids_json")
+
+if [[ "$good" -eq "$total" ]]; then
+  exit 0
+fi
+
+exit 1

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-route
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-route
@@ -195,7 +195,24 @@ case "$PHASE" in
     if [[ "$PARSE_JOB" -eq 1 ]]; then
       echo "INVOKE /budget-parse-job"
     else
-      echo "INVOKE /plan-issue"
+      # Not a parse-job: check if the issue is a spent epic (≥1 sub-issue, all
+      # closed as completed) before defaulting to /plan-issue.  The candidate
+      # predicate exits 0 (resolved candidate), 1 (not a candidate), or 3 (hard
+      # gh/issue-sub-issues failure).  Capture the exit code without tripping
+      # set -e by using the || idiom.  Discard stdout/stderr — branch on code only.
+      CAND_RC=0
+      "$SCRIPT_DIR/dispatch-epic-resolved-candidate" "$N" >/dev/null 2>&1 || CAND_RC=$?
+      if [[ "$CAND_RC" -eq 0 ]]; then
+        echo "INVOKE /resolve-epic"
+      elif [[ "$CAND_RC" -eq 1 ]]; then
+        echo "INVOKE /plan-issue"
+      else
+        # Candidate hard error (e.g. exit 3 from a gh/issue-sub-issues failure, or any
+        # unexpected code): do NOT abort the route — fall back to today's behavior so
+        # the stop hook always gets a directive. Mirrors the gh-failure fallback above.
+        echo "dispatch-route: dispatch-epic-resolved-candidate exited $CAND_RC for $N; defaulting to INVOKE /plan-issue" >&2
+        echo "INVOKE /plan-issue"
+      fi
     fi
     ;;
   implement)

--- a/.claude/skills/dispatch-propagate/scripts/issue-sub-issues
+++ b/.claude/skills/dispatch-propagate/scripts/issue-sub-issues
@@ -4,5 +4,5 @@ source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 ISSUE_NUM=$(resolve_issue_number "${1:-}")
 SUBS=$(gh_api_array "/repos/{owner}/{repo}/issues/$ISSUE_NUM/sub_issues" '.[].number')
 for sub in $SUBS; do
-  gh_retry gh issue view "$sub" --json title,body,comments,number,state
+  gh_retry gh issue view "$sub" --json title,body,comments,number,state,stateReason
 done

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -550,7 +550,7 @@ case "$args" in
     # dispatch-close-resolved state read (#1456): gh issue view <num> --json state --jq .state.
     # The real --jq flag projects .state to a bare string; the fixture file
     # holds {"state":"..."}, so project it here. Absent fixture → OPEN.
-    num=$(echo "$args" | awk '{print $3}')
+    num=$(printf '%s' "$args" | awk '{print $3}')
     if [[ -f "$STUB_DIR/issue-state-${num}.json" ]]; then
       jq -r .state "$STUB_DIR/issue-state-${num}.json"
     else
@@ -1910,7 +1910,10 @@ echo '{"state":"OPEN"}' > "$STUB_DIR/issue-state-702.json"
 if "$TMPDIR_TEST/dispatch-close-resolved" 702 --reason "epic done" >/dev/null 2>&1; then rc=0; else rc=$?; fi
 assert_eq "close-resolved no-JOB_DIR: exit 0" "0" "$rc"
 TOTAL=$((TOTAL + 1))
-if [[ ! -e "$TMPDIR_TEST/job/resolved-closed" ]]; then
+# Assert no resolved-closed sentinel exists ANYWHERE under the tmp tree: the
+# $TMPDIR_TEST/job/ dir is never created in this case, so a path-specific check
+# trivially passes. A scan catches a regression that writes to a fallback path.
+if ! find "$TMPDIR_TEST" -name 'resolved-closed' | grep -q .; then
   PASS=$((PASS + 1)); echo "  PASS: close-resolved no-JOB_DIR: no resolved-closed sentinel"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: close-resolved no-JOB_DIR: no resolved-closed sentinel"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -52,6 +52,12 @@ setup() {
   cp "$SCRIPT_DIR/dispatch-find-pr" "$TMPDIR_TEST/dispatch-find-pr"
   cp "$SCRIPT_DIR/dispatch-route" "$TMPDIR_TEST/dispatch-route"
   cp "$SCRIPT_DIR/dispatch-resolve-arg" "$TMPDIR_TEST/dispatch-resolve-arg"
+  # dispatch-route resolves the resolved-epic candidate predicate via
+  # "$SCRIPT_DIR/dispatch-epic-resolved-candidate" (#1456); SCRIPT_DIR resolves
+  # to TMPDIR_TEST for the copied dispatch-route, so the candidate (and its own
+  # close helper, exercised directly) must sit alongside it.
+  cp "$SCRIPT_DIR/dispatch-epic-resolved-candidate" "$TMPDIR_TEST/dispatch-epic-resolved-candidate"
+  cp "$SCRIPT_DIR/dispatch-close-resolved" "$TMPDIR_TEST/dispatch-close-resolved"
   cp "$SCRIPT_DIR/dispatch-select-target" "$TMPDIR_TEST/dispatch-select-target"
   cp "$SCRIPT_DIR/office-hours-select-target" "$TMPDIR_TEST/office-hours-select-target"
   cp "$SCRIPT_DIR/office-hours" "$TMPDIR_TEST/office-hours"
@@ -95,6 +101,8 @@ setup() {
            "$TMPDIR_TEST/dispatch-ci-ready" \
            "$TMPDIR_TEST/dispatch-find-pr" \
            "$TMPDIR_TEST/dispatch-route" \
+           "$TMPDIR_TEST/dispatch-epic-resolved-candidate" \
+           "$TMPDIR_TEST/dispatch-close-resolved" \
            "$TMPDIR_TEST/dispatch-resolve-arg" \
            "$TMPDIR_TEST/dispatch-select-target" \
            "$TMPDIR_TEST/office-hours-select-target" \
@@ -537,6 +545,21 @@ case "$args" in
     else
       echo '{"items":[],"totalCount":0}'
     fi
+    ;;
+  issue\ view\ *\ --json\ state\ --jq\ .state)
+    # dispatch-close-resolved state read (#1456): gh issue view <num> --json state --jq .state.
+    # The real --jq flag projects .state to a bare string; the fixture file
+    # holds {"state":"..."}, so project it here. Absent fixture → OPEN.
+    num=$(echo "$args" | awk '{print $3}')
+    if [[ -f "$STUB_DIR/issue-state-${num}.json" ]]; then
+      jq -r .state "$STUB_DIR/issue-state-${num}.json"
+    else
+      echo "OPEN"
+    fi
+    ;;
+  issue\ close\ *)
+    # dispatch-close-resolved (#1456): gh issue close <num> --reason completed --comment ...
+    echo "$args" >> "$STUB_DIR/gh-issue-close.log"
     ;;
   *)
     echo "gh stub: unknown invocation: $args" >&2
@@ -1676,6 +1699,231 @@ route_run 42 /wt/42-my-feature
 assert_eq "no PR + no statements config → INVOKE /plan-issue (directive)" \
   "INVOKE /plan-issue" "$ROUTE_OUT"
 assert_eq "no PR + no statements config → INVOKE /plan-issue (exit 0)" "0" "$ROUTE_RC"
+teardown
+
+# 24. No-PR unplanned issue that IS a spent epic → INVOKE /resolve-epic (#1456).
+# Same no-PR-unplanned fixtures as test #1 (no dispatch:planned → plan phase, no
+# statements config → not a parse-job), PLUS a sub-issues fixture whose children
+# are all CLOSED/COMPLETED. The plan arm runs dispatch-epic-resolved-candidate,
+# which exits 0, so the route forks to /resolve-epic instead of /plan-issue.
+echo "Test: no PR + spent epic → INVOKE /resolve-epic"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo "/wt/55-epic" > "$STUB_DIR/worktree-toplevel.txt"
+printf '[{"number":561},{"number":562}]\n' > "$STUB_DIR/subissues-55.json"
+printf '{"title":"c","body":"","comments":[],"number":561,"state":"CLOSED","stateReason":"COMPLETED"}\n' \
+  > "$STUB_DIR/issue-561.json"
+printf '{"title":"c","body":"","comments":[],"number":562,"state":"CLOSED","stateReason":"COMPLETED"}\n' \
+  > "$STUB_DIR/issue-562.json"
+route_run 55 /wt/55-epic
+assert_eq "no PR + spent epic → INVOKE /resolve-epic (directive)" \
+  "INVOKE /resolve-epic" "$ROUTE_OUT"
+assert_eq "no PR + spent epic → INVOKE /resolve-epic (exit 0)" "0" "$ROUTE_RC"
+teardown
+
+# 25. No-PR unplanned issue that is NOT a spent epic → INVOKE /plan-issue (#1456).
+# Replicate test #1 exactly (no subissues fixture). The candidate predicate exits
+# 1 (zero sub-issues → not a candidate), so the route falls through to the
+# unchanged default of INVOKE /plan-issue with the candidate wired in.
+echo "Test: no PR + not a spent epic → INVOKE /plan-issue"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo "/wt/56-foo" > "$STUB_DIR/worktree-toplevel.txt"
+route_run 56 /wt/56-foo
+assert_eq "no PR + not a spent epic → INVOKE /plan-issue (directive)" \
+  "INVOKE /plan-issue" "$ROUTE_OUT"
+assert_eq "no PR + not a spent epic → INVOKE /plan-issue (exit 0)" "0" "$ROUTE_RC"
+teardown
+
+# 26. Parse-job check short-circuits the candidate (#1456). Replicate test #21's
+# statements-config setup so the parse-job arm fires, AND write an all-closed-
+# completed sub-issues fixture. The parse-job check precedes the candidate, so the
+# route routes to /budget-parse-job and never consults the candidate predicate.
+echo "Test: no PR + statements label + spent-epic shape → INVOKE /budget-parse-job (parse-job wins)"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo "/wt/57-stmt" > "$STUB_DIR/worktree-toplevel.txt"
+printf '{"statements":[{"key":"acme","dir":"/s","repo":"o/r","label":"statements:acme","project":"p"}]}\n' \
+  > "$DISPATCH_CONFIG_DIR/statements.json"
+printf '{"labels":[{"name":"statements:acme"}]}\n' > "$STUB_DIR/issue-labels-57.json"
+printf '[{"number":571}]\n' > "$STUB_DIR/subissues-57.json"
+printf '{"title":"c","body":"","comments":[],"number":571,"state":"CLOSED","stateReason":"COMPLETED"}\n' \
+  > "$STUB_DIR/issue-571.json"
+route_run 57 /wt/57-stmt
+assert_eq "parse-job wins over candidate → INVOKE /budget-parse-job (directive)" \
+  "INVOKE /budget-parse-job" "$ROUTE_OUT"
+assert_eq "parse-job wins over candidate → INVOKE /budget-parse-job (exit 0)" "0" "$ROUTE_RC"
+teardown
+
+# ============================================================================
+# dispatch-epic-resolved-candidate tests
+# ============================================================================
+echo ""
+echo "=== dispatch-epic-resolved-candidate ==="
+
+# Mechanical predicate (#1456): exit 0 = epic candidate (≥1 sub-issue, ALL closed
+# as completed), exit 1 = clean "not a candidate", exit 3 = hard error
+# (issue-sub-issues / gh failure). State + stateReason match case-insensitively.
+# The fake issue-sub-issues reads subissues-<N>.json for child numbers, then cat's
+# each issue-<child>.json VERBATIM (a child with no issue-<child>.json fixture
+# defaults to state OPEN, no stateReason). So a child's stateReason lives in its
+# own issue-<child>.json fixture. Capture the exit code with the if/else idiom
+# (the suite runs set -e, so a bare non-zero call would abort).
+
+# 1. Two children, both CLOSED/COMPLETED → candidate (exit 0).
+echo "Test: candidate — 2 children all CLOSED/COMPLETED → exit 0"
+setup
+printf '[{"number":611},{"number":612}]\n' > "$STUB_DIR/subissues-61.json"
+printf '{"title":"c","body":"","comments":[],"number":611,"state":"CLOSED","stateReason":"COMPLETED"}\n' \
+  > "$STUB_DIR/issue-611.json"
+printf '{"title":"c","body":"","comments":[],"number":612,"state":"CLOSED","stateReason":"COMPLETED"}\n' \
+  > "$STUB_DIR/issue-612.json"
+if "$TMPDIR_TEST/dispatch-epic-resolved-candidate" 61 >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "candidate: all CLOSED/COMPLETED → exit 0" "0" "$rc"
+teardown
+
+# 2. Case-insensitive: a lowercase closed/completed child still → candidate.
+echo "Test: candidate — lowercase closed/completed → exit 0"
+setup
+printf '[{"number":621}]\n' > "$STUB_DIR/subissues-62.json"
+printf '{"title":"c","body":"","comments":[],"number":621,"state":"closed","stateReason":"completed"}\n' \
+  > "$STUB_DIR/issue-621.json"
+if "$TMPDIR_TEST/dispatch-epic-resolved-candidate" 62 >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "candidate: lowercase closed/completed → exit 0" "0" "$rc"
+teardown
+
+# 3. No sub-issues → not a candidate (exit 1).
+echo "Test: not a candidate — zero sub-issues → exit 1"
+setup
+printf '[]\n' > "$STUB_DIR/subissues-63.json"
+if "$TMPDIR_TEST/dispatch-epic-resolved-candidate" 63 >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "not a candidate: zero sub-issues → exit 1" "1" "$rc"
+teardown
+
+# 4. An OPEN child alongside a closed-completed one → not a candidate (exit 1).
+echo "Test: not a candidate — an OPEN child → exit 1"
+setup
+printf '[{"number":641},{"number":642}]\n' > "$STUB_DIR/subissues-64.json"
+printf '{"title":"c","body":"","comments":[],"number":641,"state":"CLOSED","stateReason":"COMPLETED"}\n' \
+  > "$STUB_DIR/issue-641.json"
+printf '{"title":"c","body":"","comments":[],"number":642,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-642.json"
+if "$TMPDIR_TEST/dispatch-epic-resolved-candidate" 64 >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "not a candidate: an OPEN child → exit 1" "1" "$rc"
+teardown
+
+# 5. A CLOSED child with stateReason NOT_PLANNED → not a candidate (exit 1).
+echo "Test: not a candidate — CLOSED/NOT_PLANNED child → exit 1"
+setup
+printf '[{"number":651}]\n' > "$STUB_DIR/subissues-65.json"
+printf '{"title":"c","body":"","comments":[],"number":651,"state":"CLOSED","stateReason":"NOT_PLANNED"}\n' \
+  > "$STUB_DIR/issue-651.json"
+if "$TMPDIR_TEST/dispatch-epic-resolved-candidate" 65 >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "not a candidate: CLOSED/NOT_PLANNED child → exit 1" "1" "$rc"
+teardown
+
+# 6. A CLOSED child with NO stateReason key (null) → not a candidate (exit 1).
+echo "Test: not a candidate — CLOSED child with null stateReason → exit 1"
+setup
+printf '[{"number":661}]\n' > "$STUB_DIR/subissues-66.json"
+printf '{"title":"c","body":"","comments":[],"number":661,"state":"CLOSED"}\n' \
+  > "$STUB_DIR/issue-661.json"
+if "$TMPDIR_TEST/dispatch-epic-resolved-candidate" 66 >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "not a candidate: CLOSED child with null stateReason → exit 1" "1" "$rc"
+teardown
+
+# 7. issue-sub-issues hard failure → exit 3 (distinct from "not a candidate").
+echo "Test: hard error — issue-sub-issues fails → exit 3"
+setup
+touch "$STUB_DIR/gh-fail-sub_issues-67"
+if "$TMPDIR_TEST/dispatch-epic-resolved-candidate" 67 >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "hard error: issue-sub-issues fails → exit 3" "3" "$rc"
+teardown
+
+# ============================================================================
+# dispatch-close-resolved tests
+# ============================================================================
+echo ""
+echo "=== dispatch-close-resolved ==="
+
+# dispatch-close-resolved <N> --reason "<text>" (#1456): reads state via
+# `gh issue view <N> --json state --jq .state`; if not closed, runs
+# `gh issue close <N> --reason completed --comment "$REASON"`; if already CLOSED,
+# skips the close (idempotent, no dup comment). ALWAYS writes the resolved-closed
+# sentinel under $CLAUDE_JOB_DIR (atomic), UNLESS CLAUDE_JOB_DIR is unset/not-a-dir
+# (then a no-op exit 0). Arg violations → exit 2 before any gh call.
+# CRITICAL: any case that exports CLAUDE_JOB_DIR must unset it before the next
+# case — the main teardown() does NOT unset it, so a leak would corrupt every
+# downstream suite. Case (c) also unsets defensively at the start.
+
+# (a) OPEN issue + JOB_DIR set → closes the issue and writes the sentinel.
+echo "Test: close-resolved — OPEN issue + JOB_DIR → close + sentinel"
+setup
+echo '{"state":"OPEN"}' > "$STUB_DIR/issue-state-700.json"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/job"
+mkdir -p "$CLAUDE_JOB_DIR"
+"$TMPDIR_TEST/dispatch-close-resolved" 700 --reason "epic done"
+TOTAL=$((TOTAL + 1))
+if [[ -f "$STUB_DIR/gh-issue-close.log" ]] \
+   && grep -q "issue close 700 --reason completed" "$STUB_DIR/gh-issue-close.log"; then
+  PASS=$((PASS + 1)); echo "  PASS: close-resolved OPEN: gh issue close invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: close-resolved OPEN: gh issue close invoked"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ -f "$CLAUDE_JOB_DIR/resolved-closed" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: close-resolved OPEN: resolved-closed sentinel written"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: close-resolved OPEN: resolved-closed sentinel written"
+fi
+unset CLAUDE_JOB_DIR
+teardown
+
+# (b) already-CLOSED issue + JOB_DIR set → skips the close (no dup comment) but
+# still writes the sentinel (re-entry idempotency).
+echo "Test: close-resolved — already-CLOSED issue + JOB_DIR → no re-close, sentinel still written"
+setup
+echo '{"state":"CLOSED"}' > "$STUB_DIR/issue-state-701.json"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/job"
+mkdir -p "$CLAUDE_JOB_DIR"
+"$TMPDIR_TEST/dispatch-close-resolved" 701 --reason "epic done"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/gh-issue-close.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: close-resolved CLOSED: gh issue close NOT invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: close-resolved CLOSED: gh issue close NOT invoked"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ -f "$CLAUDE_JOB_DIR/resolved-closed" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: close-resolved CLOSED: resolved-closed sentinel still written"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: close-resolved CLOSED: resolved-closed sentinel still written"
+fi
+unset CLAUDE_JOB_DIR
+teardown
+
+# (c) JOB_DIR unset + OPEN issue → still closes, no-ops the sentinel write, exit 0.
+echo "Test: close-resolved — JOB_DIR unset + OPEN issue → no sentinel, exit 0"
+setup
+unset CLAUDE_JOB_DIR
+echo '{"state":"OPEN"}' > "$STUB_DIR/issue-state-702.json"
+if "$TMPDIR_TEST/dispatch-close-resolved" 702 --reason "epic done" >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "close-resolved no-JOB_DIR: exit 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$TMPDIR_TEST/job/resolved-closed" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: close-resolved no-JOB_DIR: no resolved-closed sentinel"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: close-resolved no-JOB_DIR: no resolved-closed sentinel"
+fi
+teardown
+
+# (d) Arg validation: no args → exit 2; issue number only (missing --reason) → exit 2.
+echo "Test: close-resolved — arg validation → exit 2"
+setup
+if "$TMPDIR_TEST/dispatch-close-resolved" >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "close-resolved: no args → exit 2" "2" "$rc"
+if "$TMPDIR_TEST/dispatch-close-resolved" 703 >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "close-resolved: missing --reason → exit 2" "2" "$rc"
 teardown
 
 # ============================================================================
@@ -16916,6 +17164,40 @@ if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" \
   PASS=$((PASS + 1)); echo "  PASS: parse-job-done: no label add or remove invoked"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: parse-job-done: no label add or remove invoked"
+fi
+stop_teardown
+
+# --- Test R1: resolved-closed sentinel → spawn + self-close, no label work (#1456)
+# A /resolve-epic session is named <N>-epic like a worker but writes a
+# `resolved-closed` sentinel (no phase-completed marker) once it has auto-closed a
+# verifiably-complete epic. Branch R (checked right after Branch P) spawns the next
+# tick and self-closes; the handler already closed the epic, so there is NO PR and
+# NO office-hours apply or label edit — exactly like Branch P.
+echo "Test: stop hook + resolved-closed sentinel → spawn + self-close, no label work"
+stop_setup
+echo "700-epic" > "$STUB_DIR/current-branch.txt"
+echo '{"name":"700-epic"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+printf 'resolved 700 epic\n' > "$TMPDIR_TEST/jobs/abcd1234/resolved-closed"
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+"$TMPDIR_TEST/hooks/dispatch-stop.sh" < /dev/null >/dev/null 2>&1
+rc=$?
+assert_eq "resolved-closed: hook exits 0" "0" "$rc"
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "resolved-closed: spawn invoked exactly once" "1" "$spawn_calls"
+self_close_calls=$(wc -l < "$STUB_DIR/self-close-calls.log" 2>/dev/null || echo 0)
+assert_eq "resolved-closed: self-close invoked exactly once" "1" "$self_close_calls"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: resolved-closed: no office-hours apply"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: resolved-closed: no office-hours apply"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/gh-pr-edit.log" && ! -e "$STUB_DIR/gh-issue-edit.log" \
+   && ! -e "$STUB_DIR/gh-pr-remove.log" && ! -e "$STUB_DIR/gh-issue-remove.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: resolved-closed: no label add or remove invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: resolved-closed: no label add or remove invoked"
 fi
 stop_teardown
 

--- a/.claude/skills/resolve-epic/SKILL.md
+++ b/.claude/skills/resolve-epic/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: resolve-epic
+description: Resolve-epic handler for the dispatch chain — judges whether a verifiably-complete parent epic's own acceptance criteria are genuinely met by the merged child work, then auto-closes it (dispatch-close-resolved) or escalates to office-hours (dispatch-mark-deviation) when a criterion is not autonomously verifiable.
+---
+
+# Resolve Epic
+
+A dispatch worker runs this skill when the routed target is a **parent epic**
+whose sub-issues are all closed, so the epic became the topological leaf with no
+PR and no `dispatch:planned` label. Routing the epic to `/plan-issue` would find
+nothing to build and stop without a completion marker, so `dispatch-stop.sh`
+Branch A would park the epic on `dispatch:office-hours` for a human to merely
+confirm-and-close. That confirm-and-close is pure ceremony when the epic is
+genuinely done. See issue #1456.
+
+This skill replaces that ceremony. It judges whether the epic's **own**
+acceptance criteria are genuinely met by the merged child work, then either
+**auto-closes** the epic (via `dispatch-close-resolved`, whose `resolved-closed`
+sentinel `dispatch-stop.sh` Branch R reads to advance the chain) or **escalates
+to office-hours** (via `dispatch-mark-deviation`, whose marker-absence
+`dispatch-stop.sh` reads as Branch A, falling back to today's confirm-and-close
+behavior) when a criterion is not autonomously verifiable.
+
+`/resolve-epic` operates **in place** — the current worktree dictates the
+target. The router enters the target worktree; this skill never switches.
+
+## Sandbox
+
+Run every `gh` call and every gh-invoking script with
+`dangerouslyDisableSandbox: true` — `gh`'s TLS validation is blocked by the
+sandbox (`.claude/rules/sandbox.md`). That covers:
+
+- The `gh issue view` state check (Step 2).
+- `dispatch-context-pack` (Step 3) — it calls `gh`.
+- `dispatch-close-resolved` (Steps 2, 4) — it *looks* like a local script but
+  calls `gh issue view`/`gh issue close` internally.
+
+`dispatch-mark-deviation` (Step 4) is a pure local file write — it never calls
+`gh`, so it needs **no** sandbox override.
+
+## Steps
+
+### 1. Derive `N` from the worktree branch
+
+The session must be in the target worktree, whose branch is `<N>-…`:
+
+```bash
+BRANCH=$(basename "$(git rev-parse --show-toplevel)")
+case "$BRANCH" in
+  [0-9]*-*) N="${BRANCH%%-*}" ;;
+  *)
+    echo "/resolve-epic: current branch '$BRANCH' is not a target worktree (expected '<N>-…')" >&2
+    exit 1
+    ;;
+esac
+```
+
+### 2. Idempotency guard — already-closed epic
+
+Read the epic's current state (`dangerouslyDisableSandbox: true` — `gh`):
+
+```bash
+STATE=$(gh issue view "$N" --json state --jq .state)
+```
+
+If the issue is **already CLOSED**, an interrupted prior run closed it but may
+have died before the sentinel write. Re-affirm the closure through
+`dispatch-close-resolved` (`dangerouslyDisableSandbox: true` — it calls `gh`):
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-close-resolved \
+  "$N" --reason "epic already resolved; re-affirming closure"
+```
+
+The script is state-aware: it skips the re-close and the duplicate comment, and
+just writes the `resolved-closed` sentinel. Then **STOP**.
+
+Do **not** do a bare return/stop here. A bare stop skips the sentinel write, so
+`dispatch-stop.sh` falls through to Branch A and parks the (already-closed) epic
+on `dispatch:office-hours` — the exact ceremony this skill exists to kill. The
+sentinel is what routes a closed epic through Branch R instead.
+
+If the issue is **OPEN**, continue to Step 3.
+
+### 3. Gather evidence — METADATA ONLY
+
+Make **one** context-pack call (`dangerouslyDisableSandbox: true` — it calls
+`gh`) for the epic body (its acceptance-criteria checklist) and its children's
+titles, states, and URLs:
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-context-pack "$N" --issue --relations
+```
+
+The `=== ISSUE #N ===` section carries the epic's body and its
+acceptance-criteria checklist. The `=== RELATIONS #N ===` section carries the
+sub-issues as titles + state + URL only.
+
+For the judgment in Step 4 you may optionally inspect the closed-as-completed
+children's merged PRs (their titles, descriptions, and changed-file lists) for
+direct evidence that a criterion was met. That is the deepest you go. **Never
+explore source code** — this is a metadata-only judgment.
+
+### 4. Verdict gate
+
+This gate is the crux of #1456. Walk the epic's **own** acceptance-criteria
+checklist item by item. The router already established that every sub-issue is
+closed — that is **not** the question. The question for each criterion is: can
+you confirm it from the metadata and merged-child-PR evidence in hand, or is it
+a claim only a runtime or a human can confirm?
+
+- **Confirmable from metadata / merged-child evidence** — e.g. "the X parser is
+  added" when a merged child PR adds `parser-x.go`; "the config gains a `Y`
+  field" when a merged PR's diff shows the field; "all N sub-tasks are
+  delivered" when each maps to a closed child whose PR did the work.
+- **Requires runtime / behavioral / human confirmation** — e.g. "a
+  `/dispatch --bg` run leaves no leak" (a runtime claim), "the page renders
+  correctly in Chrome" (a behavioral observation), or an explicit
+  human-sign-off criterion ("the user has accepted the redesign"). These cannot
+  be confirmed from metadata, no matter how many children are closed.
+
+Then take exactly one terminal action:
+
+- **Autonomously verified complete** — *every* acceptance criterion the epic
+  states is satisfied by the merged child work, and you can confirm each one
+  from the metadata/PR evidence. Auto-close (`dangerouslyDisableSandbox: true` —
+  it calls `gh`):
+
+  ```bash
+  .claude/skills/dispatch-propagate/scripts/dispatch-close-resolved \
+    "$N" --reason "<concise why-complete>"
+  ```
+
+  Then **STOP**. The `resolved-closed` sentinel routes the chain through
+  `dispatch-stop.sh` Branch R.
+
+- **Not autonomously verifiable** — the epic carries *any* criterion you cannot
+  confirm on your own (a runtime/behavioral claim or an explicit human-sign-off
+  criterion). Escalate to office-hours, **naming the specific unverifiable
+  criterion** so the office-hours comment tells the human exactly what to check:
+
+  ```bash
+  .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+    "/resolve-epic: <the specific criterion that cannot be autonomously verified>"
+  ```
+
+  Then **STOP**. Marker-absence is read by `dispatch-stop.sh` as Branch A, which
+  parks the epic on `dispatch:office-hours` — falling back to today's
+  confirm-and-close behavior.
+
+**The costs are asymmetric.** Closing a not-actually-done epic is the expensive
+error this gate guards against; parking a done-but-unverifiable epic merely costs
+a human glance. So "verify all work complete" must mean **genuinely**
+verifiable — and **when in doubt, PARK rather than close.**
+
+### 5. Stop
+
+After either terminal call, **stop**. The Stop hook
+(`.claude/hooks/dispatch-stop.sh`) reads the `resolved-closed` sentinel (the new
+Branch R → chain advances) or its absence (Branch A → office-hours park) and
+propagates the chain. Do **not** spawn ticks or apply labels by hand.


### PR DESCRIPTION
Closes #1456

## What

Teaches the dispatch chain to recognize a **spent epic** — a parent epic whose
sub-issues are all closed as completed — and close it autonomously instead of
parking it on `dispatch:office-hours` for a human to merely confirm-and-close.

Today, when `dispatch-trace-leaf` traces a parent epic whose sub-issues are all
closed, the epic itself becomes the topological leaf with no PR and no
`dispatch:planned` label. The router derives `plan` and spawns `/plan-issue`,
which finds nothing to build and stops without a completion marker, so
`dispatch-stop.sh` reads marker-absence as Branch A and parks the spent epic on
office-hours. That step is pure ceremony when the epic is genuinely done.

## How

The epic-resolution path is a `dispatch-route` fork inside the existing `plan)`
arm — not a new phase — mirroring the `/budget-parse-job` precedent. Mechanical
evidence lives in scripts; the acceptance-criteria judgment lives in a skill;
the close lives in a script.

- **Unit 1** — `dispatch-epic-resolved-candidate`: a mechanical predicate that
  exits 0 iff an epic has ≥1 sub-issue and every child is closed-as-completed
  (exit 1 = not a candidate, exit 3 = hard `gh` failure). Adds `stateReason` to
  `issue-sub-issues` (non-breaking; existing consumers read only
  `.number`/`.state`).
- **Unit 2** — `dispatch-close-resolved`: a state-aware terminal close. Closes an
  open epic as completed (with comment), or skips the re-close when already
  CLOSED, and **always** writes the `resolved-closed` sentinel. Idempotency lives
  here, so a re-entry never posts a duplicate comment yet still leaves the
  sentinel.
- **Unit 3** — the `/resolve-epic` skill: a caller's-thread disposition skill
  that judges whether the epic's **own** acceptance criteria are genuinely met by
  the merged child work. Verified-complete → auto-close; any criterion that needs
  a runtime/behavioral check or human sign-off → escalate to office-hours via
  `dispatch-mark-deviation`. The costs are asymmetric — closing a not-actually-done
  epic is the expensive error — so the gate parks when in doubt.
- **Unit 4** — `dispatch-route` fork: inside the no-PR `plan)` arm, after the
  parse-job check and before the `/plan-issue` default, route a candidate epic to
  `/resolve-epic`. A candidate hard error falls back to `/plan-issue`. No `gh`
  call is added to any PR-bearing phase.
- **Unit 5** — `dispatch-stop.sh` Branch R: reads the `resolved-closed` sentinel
  and spawns the next tick + sweep and self-closes, without deriving a phase or
  applying office-hours — sidestepping the `MARKER_PHASE == CURRENT_PHASE == plan`
  comparison that would otherwise park a closed epic on office-hours.
- **Unit 6** — tests in `test-dispatch-scripts.sh` covering the candidate
  predicate (exit 0/1/3, case-insensitive), `dispatch-close-resolved`
  (open-close+sentinel, already-closed skip+sentinel, no-`JOB_DIR` no-op, arg
  validation), the route fork (candidate wins / falls back to `/plan-issue` /
  parse-job still wins), and the stop-hook Branch R.

## Verification

- Full dispatch script suite green: `Results: 2587/2587 passed, 0 failed`
  (`bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`).
- Live predicate spot-check: `dispatch-epic-resolved-candidate 755` → exit 1
  (correct — #755 still has the open child #1456).

This extends the self-closing / two-queue model (#755) and reuses the
terminal-disposition and sentinel idioms of #824 and #1024.
