### PR TITLE
dispatch: route transient resolve-arg failures during a target-reseed to the recover net

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-target-reseed
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-target-reseed
@@ -224,6 +224,14 @@ else
   MAIN_WORKTREE="$PROJECT_ROOT/worktrees/main"
 fi
 
+# Install the OnFailure recovery unit (dispatch-tick-recover.service) before
+# scheduling the transient reseed timer. Best-effort: OnFailure= resolves
+# lazily at failure time, so a failure here is non-fatal — a missing target
+# only logs an error if the reseed unit ever fails. We still pass OnFailure=
+# unconditionally below so an abnormal reseed exit is guaranteed a chain
+# continuation (#1570).
+ensure_recover_unit "$MAIN_WORKTREE" || true
+
 # ---- Step 8: schedule the transient timer -----------------------------------
 #
 # The unit name embeds N and the epoch fire time — a repeated call with the same
@@ -258,6 +266,7 @@ trap 'rm -f "$RUN_STDERR"' EXIT
 "$SYSTEMD_RUN_CMD" --user \
      --unit="$UNIT_NAME" \
      --on-calendar="@$FIRE" \
+     --property=OnFailure=dispatch-tick-recover.service \
      --working-directory="$MAIN_WORKTREE" \
      --timer-property=Persistent=true \
      --setenv=PATH="$PATH" \

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -26,7 +26,10 @@
 #                    attempt-cap is hit (or the latch is already open); a
 #                    dispatch:sync-broken issue is the latch. lock released;
 #                    reseed armed; nothing spawned.
-#   resolver-failed  explicit arg did not resolve to one issue; lock released.
+#   resolver-failed  explicit arg is a genuine non-resolution (dispatch-resolve-arg
+#                    exit 2/3/4: 404, PR with no/many closing issues); lock released.
+#                    A transient resolve-arg failure (exit 1) does NOT emit this —
+#                    it propagates as exit 2 (see Exit code below).
 #   concurrency-cap  effective-live count (busy workers + outstanding reservations) >= target,
 #                    AND no priority/main-broken item waits to bypass it (or the rate-limit
 #                    window is genuinely exhausted); #725 re-seed scheduled; lock released.
@@ -66,7 +69,8 @@
 # See .claude/rules/sandbox.md.
 #
 # Exit code: 0 on every decision line; 2 on an internal/usage error surfaced on
-# stderr (e.g. non-numeric TARGET_N from dispatch-target-workers).
+# stderr (e.g. non-numeric TARGET_N from dispatch-target-workers, or a
+# dispatch-resolve-arg exit-1 transient/infra failure on the explicit-arg path).
 #
 # NOT set -e: exits are handled explicitly (matching the sibling dispatch
 # scripts).
@@ -438,11 +442,22 @@ fi
 
 # --- Step 3: select the target -----------------------------------------------
 if [[ -n "$ARG" ]]; then
-  if TARGET=$("$SCRIPT_DIR/dispatch-resolve-arg" "$ARG"); then
+  TARGET=$("$SCRIPT_DIR/dispatch-resolve-arg" "$ARG")
+  RESOLVE_RC=$?
+  if (( RESOLVE_RC == 0 )); then
     echo "explicit $TARGET $GAP"
     exit 0
   fi
   release_lock
+  if (( RESOLVE_RC == 1 )); then
+    # Transient / infra resolve-arg failure (auth, network, usage). Propagate
+    # non-zero so dispatch-tick exits non-zero and the reseed unit's OnFailure
+    # handler arms a chain continuation rather than silently dead-ending. (#1570)
+    echo "dispatch-select-tick: dispatch-resolve-arg transient failure (exit 1) on arg '$ARG'; propagating non-zero" >&2
+    exit 2
+  fi
+  # Genuine non-resolution (exit 2/3/4): a bad/ambiguous number on the explicit
+  # human path — bare exit 0 is correct, there is no autonomous chain. (#1570)
   echo "resolver-failed"
   exit 0
 fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -28,8 +28,10 @@
 #                    reseed armed; nothing spawned.
 #   resolver-failed  explicit arg is a genuine non-resolution (dispatch-resolve-arg
 #                    exit 2/3/4: 404, PR with no/many closing issues); lock released.
-#                    A transient resolve-arg failure (exit 1) does NOT emit this —
-#                    it propagates as exit 2 (see Exit code below).
+#                    Only these three genuine-failure codes emit this. A transient
+#                    resolve-arg failure (exit 1) — or ANY other unexpected non-zero
+#                    code (127 not-found, 124 timeout, 137/143 signal/OOM kill) —
+#                    does NOT emit this; it propagates as exit 2 (see Exit code below).
 #   concurrency-cap  effective-live count (busy workers + outstanding reservations) >= target,
 #                    AND no priority/main-broken item waits to bypass it (or the rate-limit
 #                    window is genuinely exhausted); #725 re-seed scheduled; lock released.
@@ -458,17 +460,30 @@ if [[ -n "$ARG" ]]; then
     exit 0
   fi
   release_lock
-  if (( RESOLVE_RC == 1 )); then
-    # Transient / infra resolve-arg failure (auth, network, usage). Propagate
-    # non-zero so dispatch-tick exits non-zero and the reseed unit's OnFailure
-    # handler arms a chain continuation rather than silently dead-ending. (#1570)
-    echo "dispatch-select-tick: dispatch-resolve-arg transient failure (exit 1) on arg '$ARG'; propagating non-zero" >&2
-    exit 2
-  fi
-  # Genuine non-resolution (exit 2/3/4): a bad/ambiguous number on the explicit
-  # human path — bare exit 0 is correct, there is no autonomous chain. (#1570)
-  echo "resolver-failed"
-  exit 0
+  case "$RESOLVE_RC" in
+    2|3|4)
+      # Genuine non-resolution: 404 (2), PR with no closing issue (3), PR with
+      # many closing issues (4) — the target is genuinely gone or ambiguous.
+      # Bare exit 0 is correct even on the autonomous target-reseed timer path:
+      # the target cannot be resolved no matter how often we retry, so arming
+      # the OnFailure recovery net would loop the chain indefinitely. The
+      # OnFailure safety net is intentionally reserved for transient (exit 1)
+      # failures, where the target is known to be valid. (#1570)
+      echo "resolver-failed"
+      exit 0
+      ;;
+    *)
+      # Transient / infra resolve-arg failure. exit 1 is the explicit transient
+      # signal (auth, network, usage); any other unexpected non-zero code
+      # (127 command-not-found, 124 timeout, 137/143 signal/OOM kill, future
+      # codes) is treated the same — a crashed or missing resolver is an
+      # infrastructure failure, not a genuine non-resolution. Propagate non-zero
+      # so dispatch-tick exits non-zero and the reseed unit's OnFailure handler
+      # arms a chain continuation rather than silently dead-ending. (#1570)
+      echo "dispatch-select-tick: dispatch-resolve-arg transient/unexpected failure (exit $RESOLVE_RC) on arg '$ARG'; propagating non-zero" >&2
+      exit 2
+      ;;
+  esac
 fi
 
 SELECTED=$("$SCRIPT_DIR/dispatch-select-target") || true

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -11952,13 +11952,14 @@ log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--unit=dispatch-reseed-target-979-10300"* \
    && "$log" == *"--on-calendar=@10300"* \
+   && "$log" == *"--property=OnFailure=dispatch-tick-recover.service"* \
    && "$log" == *"--working-directory=$TMPDIR_TEST/main"* \
    && "$log" == *"--setenv=PATH="* \
    && "$log" == *"--property=KillMode=process"* \
    && "$log" == *"dispatch-tick 979"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: counter-bump systemd-run argv (unit + calendar + cwd + setenv + KillMode + dispatch-tick 979)"
+  PASS=$((PASS + 1)); echo "  PASS: counter-bump systemd-run argv (unit + calendar + OnFailure + cwd + setenv + KillMode + dispatch-tick 979)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: counter-bump systemd-run argv (unit + calendar + cwd + setenv + KillMode + dispatch-tick 979)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: counter-bump systemd-run argv (unit + calendar + OnFailure + cwd + setenv + KillMode + dispatch-tick 979)"
   echo "    log: $log"
 fi
 tr_teardown

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -11811,6 +11811,17 @@ echo "\$*" >> "$TMPDIR_TEST/oh-log"
 STUB
   chmod +x "$TMPDIR_TEST/bin/fake-oh"
   export DISPATCH_TARGET_RESEED_OFFICE_HOURS_CMD="$TMPDIR_TEST/bin/fake-oh"
+
+  # #1570: dispatch-schedule-target-reseed now calls ensure_recover_unit (lib.sh)
+  # before scheduling. Point its unit dir into the tmp tree and its systemctl at
+  # a no-op stub so the call never writes outside the test sandbox.
+  cat > "$TMPDIR_TEST/bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/systemctl"
+  export DISPATCH_RECOVER_UNIT_DIR="$TMPDIR_TEST/systemd-user"
+  export DISPATCH_RECOVER_SYSTEMCTL_CMD="$TMPDIR_TEST/bin/systemctl"
 }
 
 tr_teardown() {
@@ -11826,6 +11837,7 @@ tr_teardown() {
   unset DISPATCH_TARGET_RESEED_OFFICE_HOURS_CMD
   unset FAKE_CUR_ATTEMPT
   unset FAKE_PR_NUM
+  unset DISPATCH_RECOVER_UNIT_DIR DISPATCH_RECOVER_SYSTEMCTL_CMD
 }
 
 # --- Test 1: under-cap reseed (CUR=0 → 1) ------------------------------------
@@ -11841,12 +11853,13 @@ log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$log" == *"--unit=dispatch-reseed-target-979-10300"* \
    && "$log" == *"--on-calendar=@10300"* \
+   && "$log" == *"--property=OnFailure=dispatch-tick-recover.service"* \
    && "$log" == *"--working-directory=$TMPDIR_TEST/main"* \
    && "$log" == *"--setenv=PATH="* \
    && "$log" == *"dispatch-tick 979"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: under-cap systemd-run argv (unit + calendar + cwd + setenv + dispatch-tick 979)"
+  PASS=$((PASS + 1)); echo "  PASS: under-cap systemd-run argv (unit + calendar + OnFailure + cwd + setenv + dispatch-tick 979)"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: under-cap systemd-run argv (unit + calendar + cwd + setenv + dispatch-tick 979)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: under-cap systemd-run argv (unit + calendar + OnFailure + cwd + setenv + dispatch-tick 979)"
   echo "    log: $log"
 fi
 edits=$(cat "$TMPDIR_TEST/gh-edit-log" 2>/dev/null || true)
@@ -19628,19 +19641,43 @@ assert_eq "explicit '#': decision line" "explicit 88 1" \
   "$(printf '%s\n' "$out" | tail -n 1)"
 sel_tick_teardown
 
-# --- resolver failure (garbage arg) → release + resolver-failed --------------
-echo "Test: select-tick resolver failure → resolver-failed, lock released"
+# --- #1570: transient resolve-arg failure (exit 1) → propagate non-zero ------
+# A transient/infra resolve-arg failure (auth, network) must NOT look like a
+# clean resolver-failed tick: select-tick releases the lock and exits non-zero
+# (2) with no resolver-failed stdout line, so dispatch-tick fails the reseed
+# unit and its OnFailure recover net fires rather than silently dead-ending.
+echo "Test: select-tick transient resolve-arg (exit 1) → exit 2, no resolver-failed, lock released"
 sel_tick_setup
 cat > "$TMPDIR_TEST/dispatch-resolve-arg" <<'FAKE'
 #!/usr/bin/env bash
-echo "error: bad arg" >&2
+echo "error: gh transient failure" >&2
 exit 1
 FAKE
 chmod +x "$TMPDIR_TEST/dispatch-resolve-arg"
-out=$(run_sel_tick abc)
-assert_eq "resolver-failed: decision line" "resolver-failed" \
+if out=$(run_sel_tick abc); then rc=0; else rc=$?; fi
+assert_eq "transient resolve-arg: exit 2" "2" "$rc"
+assert_eq "transient resolve-arg: no resolver-failed stdout" "" \
+  "$(printf '%s' "$out")"
+assert_eq "transient resolve-arg: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+sel_tick_teardown
+
+# --- #1570: genuine non-resolution (exit 2/3/4) → resolver-failed, exit 0 -----
+# A bad/ambiguous number on the explicit human path (404 / PR with no or many
+# closing issues) keeps its correct resolver-failed → exit 0: there is no
+# autonomous chain to continue.
+echo "Test: select-tick genuine non-resolution (exit 2) → resolver-failed, exit 0, lock released"
+sel_tick_setup
+cat > "$TMPDIR_TEST/dispatch-resolve-arg" <<'FAKE'
+#!/usr/bin/env bash
+echo "error: not found (404)" >&2
+exit 2
+FAKE
+chmod +x "$TMPDIR_TEST/dispatch-resolve-arg"
+out=$(run_sel_tick abc) ; rc=$?
+assert_eq "resolver-failed (exit 2): exit 0" "0" "$rc"
+assert_eq "resolver-failed (exit 2): decision line" "resolver-failed" \
   "$(printf '%s\n' "$out" | tail -n 1)"
-assert_eq "resolver-failed: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
+assert_eq "resolver-failed (exit 2): lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 sel_tick_teardown
 
 # --- sync failure on main → release + sync-failed ----------------------------


### PR DESCRIPTION
Closes #1570

## Problem

When `dispatch-schedule-target-reseed <N>`'s systemd timer fires, the autonomous
path is `dispatch-tick <N>` → `dispatch-select-tick <N>` → `dispatch-resolve-arg
<N>`. Two compounding gaps let a **transient** `dispatch-resolve-arg` failure
(auth, network) on this path silently dead-end the chain:

- **Gap 1** — `dispatch-select-tick`'s explicit-arg branch mapped *any* non-zero
  `dispatch-resolve-arg` exit to a single `resolver-failed` disposition that
  bare-`exit 0`s. A transient blip (resolve-arg exit 1) was indistinguishable
  from a genuine bad/ambiguous number (exit 2/3/4) — both looked like a clean
  tick.
- **Gap 2** — `dispatch-schedule-target-reseed`'s `systemd-run` invocation was the
  only reseed launcher that omitted
  `--property=OnFailure=dispatch-tick-recover.service`, so even a propagated
  non-zero exit had no recover net to catch it.

## Fix

- **`dispatch-select-tick`** — the explicit-arg branch now captures the
  `dispatch-resolve-arg` exit code (run outside the `if`, `$?` captured
  immediately) and branches: exit 0 → `explicit <N> <gap>` (unchanged); exit 1
  (transient/infra) → release the lock, write a stderr diagnostic, and `exit 2`
  with no `resolver-failed` stdout line — making `dispatch-tick` exit non-zero so
  the reseed unit's `OnFailure` handler arms a continuation; exit 2/3/4 (genuine
  non-resolution) → `resolver-failed` + `exit 0` (unchanged; the explicit human
  path has no autonomous chain to continue). The header docblock is updated to
  keep the `resolver-failed` disposition and the exit-2 contract coherent.

- **`dispatch-schedule-target-reseed`** — adds
  `--property=OnFailure=dispatch-tick-recover.service` to the `systemd-run` reseed
  unit and calls `ensure_recover_unit "$MAIN_WORKTREE" || true` before scheduling,
  making this launcher self-contained and consistent with every sibling reseed
  launcher.

- **`test-dispatch-scripts.sh`** — the existing select-tick explicit-arg test
  (resolve-arg exit 1 → `resolver-failed`) is updated to assert the new transient
  behavior (exit 2, no `resolver-failed`, lock released), and a new case covers
  genuine non-resolution (exit 2 → `resolver-failed`, exit 0). The target-reseed
  `tr_setup`/`tr_teardown` stub the recover unit (`DISPATCH_RECOVER_UNIT_DIR` /
  `DISPATCH_RECOVER_SYSTEMCTL_CMD` + a no-op `systemctl`), and the under-cap argv
  assertion now requires the `OnFailure` property.

## Why this is correct end-to-end

select-tick exit 2 → `dispatch-tick` sees `SEL_RC != 0` and `exit 2` → the reseed
unit fails → `OnFailure=dispatch-tick-recover.service` fires the continuation —
exactly as any other transient selection-path error already does, while the
genuine non-resolution path on the explicit human `dispatch <N>` keeps its correct
`resolver-failed` → `exit 0`.

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` —
2558/2558 pass, 0 failures. The suite is a bash harness, not in CI; run manually.
