### PR TITLE
Scope 'testing infrastructure' label to shared test machinery

### DIFF
--- a/.claude/skills/ref-issue-labels/SKILL.md
+++ b/.claude/skills/ref-issue-labels/SKILL.md
@@ -70,14 +70,19 @@ alongside a topic label.
   signals: "dispatch", "phase skill", "issue workflow", "queue selection",
   "worktree resolution".
 
-- **`testing infrastructure`** — concerns CI workflows under
-  `.github/workflows/` (e.g. `pr-checks.yml`, `unit-tests.yml`), the unit or
-  acceptance test harness, Vitest or Playwright configuration, test fixtures or
-  seed data, or a `run-*.sh` test runner under
-  `.claude/skills/dispatch-propagate/scripts/` (e.g. `run-unit-tests.sh`,
-  `run-acceptance-tests.sh`, `run-lint.sh`, `run-typecheck.sh`). Keyword
-  signals: "CI", "unit test", "acceptance test", "Vitest", "Playwright",
-  "fixture", "seed data", "test runner".
+- **`testing infrastructure`** — concerns the *shared* test machinery no single
+  app owns: CI workflows under `.github/workflows/` (e.g. `pr-checks.yml`,
+  `unit-tests.yml`), the unit or acceptance test harness, Vitest or Playwright
+  configuration, cross-app fixtures or seed data, or a `run-*.sh` test runner
+  under `.claude/skills/dispatch-propagate/scripts/` (e.g. `run-unit-tests.sh`,
+  `run-acceptance-tests.sh`, `run-lint.sh`, `run-typecheck.sh`). Keyword signals:
+  "CI workflow", "test harness", "Vitest config", "Playwright config", "test
+  runner", "cross-app fixture".
+  Adding or expanding test *coverage* for a specific app or feature is **not**
+  this label — it takes the topic of the area under test (e.g. unit tests for
+  `dispatch-select-target` → `dispatch`; tests or seed data for the landing blog
+  → `landing`; budget-etl tests → `budget`). `testing infrastructure` applies
+  only when the change's primary subject is the shared machinery itself.
 
 - **`landing`** — concerns the landing app (`landing/`) — marketing site and
   blog. Ranks below `dispatch` and above `fellspiral` in
@@ -113,9 +118,11 @@ alongside a topic label.
 When an issue matches `security` plus another topic, apply `security` — it is
 the most urgent topic, so it wins the tie-break. This keeps the queue ranking
 reflecting the security dimension and lets the consumer (#985) rely on the
-label being applied. Otherwise, when an issue matches both `dispatch` and
-`testing infrastructure`, apply only `dispatch` — the narrower, named workflow
-wins over `testing infrastructure`, the broad category. Most issues match at
+label being applied. Otherwise, when an issue matches both an area topic (`dispatch`, `landing`,
+`fellspiral`, `budget`, `print`, `audio`) and `testing infrastructure` —
+typically a test that exercises one area — apply the area topic.
+`testing infrastructure` wins only when the change's primary subject is shared
+machinery no single app owns. Most issues match at
 most one topic outright; these tie-breaks resolve only the rare issue that
 genuinely spans more than one.
 


### PR DESCRIPTION
Closes #1582

Scopes the `testing infrastructure` topic label (in `ref-issue-labels`) to the
*shared* test machinery no single app owns, so per-app "add tests for X"
follow-ups — the new-test issues the phase skills file through `/file-issue` —
route to the area-under-test topic instead of being mislabeled
`testing infrastructure`.

Two edits to `.claude/skills/ref-issue-labels/SKILL.md`:

- **Bullet rescope.** The `testing infrastructure` bullet now leads with "the
  *shared* test machinery no single app owns", narrows "test fixtures or seed
  data" to "cross-app fixtures or seed data", and drops the over-firing keyword
  signals (`"unit test"`, `"acceptance test"`, unqualified `"fixture"` /
  `"seed data"`) in favor of machinery-specific ones (`"CI workflow"`,
  `"test harness"`, `"Vitest config"`, `"Playwright config"`, `"cross-app
  fixture"`). A new paragraph states that adding or expanding test *coverage*
  for a specific app takes the area-under-test topic, not this label.

- **Tie-break generalization.** The `dispatch`-vs-`testing infrastructure`
  tie-break is generalized to all area topics (`dispatch`, `landing`,
  `fellspiral`, `budget`, `print`, `audio`): a test that exercises one area
  takes the area topic; `testing infrastructure` wins only when the change's
  primary subject is shared machinery. The `security` tie-break above is
  unchanged.

Reference-doc edit only — `/file-issue` inherits topic classification from this
file, so no change is needed there. The three acceptance cases resolve as
intended: "unit tests for `dispatch-select-target`" → `dispatch`; "migrate test
harness Jest→Vitest" → `testing infrastructure`; "seed data for landing blog
tests" → `landing`.
