### PR TITLE
dispatch-acquire-lock: remove dead marker_names_holder() and correct stale test comments

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
@@ -162,20 +162,16 @@ PROBE_TIMEOUT="${DISPATCH_LOCK_PROBE_TIMEOUT:-10}"
 FLOCK_TIMEOUT="${DISPATCH_LOCK_FLOCK_TIMEOUT:-15}"
 
 # resolve_holder_state <sessionId> — query the daemon's live-session registry
-# for <sessionId> and report both liveness and cwd. Covers the same failure
-# modes that lib-claude-agents.sh::claude_sessions_under treats as UNKNOWN
-# (binary missing, non-zero exit, whitespace-only output, non-array JSON, jq
-# failure), but inverts the return convention: this function returns 0 (LIVE
-# — keep the lock) instead of 1 (unknown — caller folds to occupied). The
-# helper's question is "is anything running under this path?"; ours is "is
-# THIS sessionId still alive, and where?", and the global registry has no
-# --cwd filter. A zero-exit, valid `[]` is a definite "no live sessions
-# anywhere" and returns 1 (reclaim); only opaque failures fail safe to LIVE.
+# for <sessionId> and report its liveness via the return code. Covers the same
+# failure modes that lib-claude-agents.sh::claude_sessions_under treats as
+# UNKNOWN (binary missing, non-zero exit, whitespace-only output, non-array
+# JSON, jq failure), but inverts the return convention: this function returns 0
+# (LIVE — keep the lock) instead of 1 (unknown — caller folds to occupied). The
+# helper's question is "is anything running under this path?"; ours is "is THIS
+# sessionId still alive?". A zero-exit, valid `[]` is a definite "no live
+# sessions anywhere" and returns 1 (reclaim); only opaque failures fail safe to
+# LIVE.
 #
-# Stdout: the holder's cwd on a single line if the registry exposed it.
-#         Empty if either the holder is not live OR the daemon query was
-#         opaque (failed/non-array/parse error). Callers treat an empty cwd
-#         on a "live" return as "marker check cannot proceed → stay strict."
 # Return: 0 = live (or opaque failure → fail-safe live)
 #         1 = definitely not live (reclaim)
 #
@@ -196,15 +192,14 @@ FLOCK_TIMEOUT="${DISPATCH_LOCK_FLOCK_TIMEOUT:-15}"
 # The redirections stay on the `timeout` simple command, which execs `claude`
 # with fd 9 already closed and stderr already silenced.
 resolve_holder_state() {
-  local sid="$1" out rows match
+  local sid="$1" out ids id
   # Headless holders (the systemd-launched dispatch-tick's synthetic
   # `headless:<token>` id) never appear in the `claude agents --json` registry —
   # it tracks model sessions, not bash processes. Resolve their liveness through
   # the PID sentinel the tick writes alongside the lock file (#1068): live iff
   # the sentinel exists AND its recorded PID is still alive. A SIGKILL leaves a
   # stale sentinel whose PID is gone, so it resolves DEAD and the lock self-heals.
-  # No cwd is emitted (matches the live-with-empty-cwd convention — marker check
-  # stays strict), and the daemon is never queried for these ids.
+  # The daemon is never queried for these ids.
   if [[ "$sid" == headless:* ]]; then
     local sentinel pid=""
     sentinel=$(headless_sentinel_path "$sid" "$LOCK_FILE")
@@ -220,28 +215,23 @@ resolve_holder_state() {
   if [[ -z "${out//[[:space:]]/}" ]]; then
     return 0
   fi
-  # One TSV row per session: <sessionId>\t<cwd>. `// ""` keeps both fields as
-  # strings even when absent, so the tab-split below always has two slots.
-  if ! rows=$(jq -r '
+  # One sessionId per line. `// ""` keeps the field a string even when absent.
+  if ! ids=$(jq -r '
     if type == "array"
-    then .[] | "\(.sessionId // "")\t\(.cwd // "")"
+    then .[] | .sessionId // ""
     else error("not a JSON array")
     end' <<<"$out" 2>/dev/null); then
     return 0
   fi
-  # Exact-match $1 against sid via awk: a true field equality (not a literal-
-  # substring match), so a sessionId that prefixes or suffixes another row's
-  # sessionId cannot cross-match. Also avoids `grep -F | head -n1`, whose
-  # pipefail+SIGPIPE interaction can collapse a contended-but-live match into
-  # a non-zero exit and trigger a wrong reclaim.
-  match=$(printf '%s\n' "$rows" | awk -F'\t' -v sid="$sid" '$1 == sid {print; exit}')
-  if [[ -z "$match" ]]; then
-    # Definitely not live: registry parsed cleanly and our sid isn't in it.
-    return 1
-  fi
-  # Strip the leading "<sid>\t" prefix to leave the cwd on stdout.
-  printf '%s\n' "${match#*$'\t'}"
-  return 0
+  # Exact line-equality match against sid: a sessionId that prefixes or suffixes
+  # another row's sessionId cannot cross-match. Iterating in the shell (rather
+  # than `grep -F | head -n1`) avoids the pipefail+SIGPIPE interaction that can
+  # collapse a contended-but-live match into a non-zero exit and a wrong reclaim.
+  while IFS= read -r id; do
+    [[ "$id" == "$sid" ]] && return 0
+  done <<<"$ids"
+  # Definitely not live: registry parsed cleanly and our sid isn't in it.
+  return 1
 }
 
 # ---- Step 1: resolve the lock file ------------------------------------------
@@ -298,9 +288,9 @@ try_acquire() {            # 0 = acquired, 1 = contended; sets CONTENDED_SID
     # the holder released the lock. Otherwise — no record, a stale record
     # (sessionId not in the registry), our own session re-entering, or a dead
     # foreign holder — we claim. An opaque-failure from resolve_holder_state
-    # (return 0, no holder cwd emitted) stays BUSY (fail safe).
+    # (return 0) stays BUSY (fail safe).
     if [[ -n "$recorded" && "$recorded" != "$SESSION_ID" ]]; then
-      if resolve_holder_state "$recorded" >/dev/null; then
+      if resolve_holder_state "$recorded"; then
         live=1
       fi
       if (( live )); then

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
@@ -244,22 +244,6 @@ resolve_holder_state() {
   return 0
 }
 
-# marker_names_holder <cwd> <sid> — 0 iff <cwd> is non-empty, carries the
-# tmp/dispatch-worktree marker, and the marker's first line equals <sid>.
-# Empty cwd, missing/empty marker, or a marker naming any other session → 1
-# (no reclaim): a stale empty marker (worktree-create.sh) or a marker naming
-# an older finalized session never reclaims a live mid-selection holder.
-marker_names_holder() {
-  local cwd="$1" sid="$2" marker content=""
-  [[ -n "$cwd" ]] || return 1
-  marker="$cwd/tmp/dispatch-worktree"
-  # Require a regular file: a FIFO or device node at this path would block the
-  # read below indefinitely while the flock is held, deadlocking all routing.
-  [[ -f "$marker" ]] || return 1
-  IFS= read -r content <"$marker" 2>/dev/null || true
-  [[ -n "$content" && "$content" == "$sid" ]]
-}
-
 # ---- Step 1: resolve the lock file ------------------------------------------
 # dispatch_lock_file (lib.sh) honors an explicit DISPATCH_LOCK_FILE (tests rely
 # on this) and otherwise resolves the shared project-root tmp/dispatch.lock (not
@@ -305,7 +289,7 @@ try_acquire() {            # 0 = acquired, 1 = contended; sets CONTENDED_SID
       printf 'FLOCK_TIMEOUT'
       exit 0
     fi
-    local recorded="" cwd="" live=0
+    local recorded="" live=0
     IFS= read -r recorded <"$LOCK_FILE" 2>/dev/null || true
     # Busy iff a different sessionId is recorded AND it is still a live
     # session per `claude agents --json`. A live holder always blocks — even
@@ -314,9 +298,9 @@ try_acquire() {            # 0 = acquired, 1 = contended; sets CONTENDED_SID
     # the holder released the lock. Otherwise — no record, a stale record
     # (sessionId not in the registry), our own session re-entering, or a dead
     # foreign holder — we claim. An opaque-failure from resolve_holder_state
-    # (return 0, empty cwd) stays BUSY (fail safe).
+    # (return 0, no holder cwd emitted) stays BUSY (fail safe).
     if [[ -n "$recorded" && "$recorded" != "$SESSION_ID" ]]; then
-      if cwd=$(resolve_holder_state "$recorded"); then
+      if resolve_holder_state "$recorded" >/dev/null; then
         live=1
       fi
       if (( live )); then

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -7682,9 +7682,10 @@ lock_teardown
 # --- Test 24: live foreign holder with MISMATCHED marker → busy (#928) -------
 #
 # The marker exists but names a DIFFERENT (older, since-finalized) session, not
-# the recorded holder. A live mid-selection holder launched from a previously-
-# marked worktree must NOT have its lock reclaimed: marker_names_holder rejects
-# the content mismatch, so acquire stays busy.
+# the recorded holder. A live foreign holder is unconditionally BUSY as of #945:
+# the BUSY short-circuit fires before any marker is read, so the mismatched
+# marker content is never inspected. The test confirms the live holder is not
+# reclaimed regardless of what the marker contains.
 
 echo "Test: live foreign holder with mismatched marker → busy (#928)"
 lock_setup
@@ -7728,11 +7729,11 @@ lock_teardown
 
 # --- Test 25b: live foreign holder with FIFO marker → busy (no deadlock) -----
 #
-# marker_names_holder reads the marker's content; a non-regular file (here a
-# FIFO) at that path would block the read indefinitely while the flock is held,
-# deadlocking all routing. The regular-file guard must reject it and stay busy
-# rather than reclaim or hang. A `timeout` bounds the call so a regression
-# (reverting to a blocking read) surfaces as a hang, not a silent pass.
+# Because a live foreign holder is unconditionally BUSY as of #945, the marker
+# is never opened — a FIFO at that path cannot deadlock routing. This test is a
+# regression guard: if a future change reintroduced a marker read for live
+# holders, opening the FIFO would block indefinitely, the `timeout 10` below
+# would fire, and the test would fail as a hang rather than pass silently.
 
 echo "Test: live foreign holder with FIFO marker → busy (no deadlock)"
 lock_setup

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -7763,8 +7763,11 @@ lock_teardown
 # --- Test 25: live foreign holder with EMPTY marker → busy (#928) ------------
 #
 # An empty marker is the shape stamped by .claude/hooks/worktree-create.sh's
-# `touch` on every worktree creation. It names no session, so it must never
-# reclaim a live holder co-located in that worktree.
+# `touch` on every worktree creation. As of #945 a live foreign holder is
+# unconditionally BUSY: the BUSY short-circuit fires before any marker is read,
+# so the empty marker's content is never inspected. This is now a regression
+# guard, not a behavioral test of an empty-marker special case — the empty
+# content no longer drives the decision; the live-holder short-circuit does.
 
 echo "Test: live foreign holder with empty (touch) marker → busy (#928)"
 lock_setup


### PR DESCRIPTION
Closes #973

## What

Pure cleanup of dead code and stale comments in
`.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock` and its unit
suite. No behavior change.

After #945/#950 made every *live* lock holder unconditionally BUSY, the lock
script short-circuits to BUSY before any worktree marker is read, so the
marker-inspection helper `marker_names_holder()` is never reached. Its two call
sites were removed at that time, but the function definition, its comment block,
a now-write-only `cwd` local, and three comments that still attribute the BUSY
outcome to marker inspection were left behind.

## Changes

`dispatch-acquire-lock`:
- Delete the dead `marker_names_holder()` function and its comment block.
- Drop the write-only `cwd` local in `try_acquire` — only
  `resolve_holder_state`'s exit status is used now (`if resolve_holder_state … >/dev/null`),
  its stdout cwd was never read after #945.
- Correct the opaque-failure comment: `(return 0, empty cwd)` →
  `(return 0, no holder cwd emitted)`, since cwd is no longer captured.

`test-dispatch-scripts.sh`:
- Rewrite the Test 24 and Test 25b comments that named `marker_names_holder` to
  attribute the BUSY outcome to the #945 short-circuit instead. Test bodies and
  assertions are unchanged; Test 25b remains a regression guard that would
  surface as a `timeout`-bounded hang if a marker read for live holders were
  ever reintroduced.

Test 25 (the EMPTY-marker test) does not name the deleted function and is left
intentionally untouched, keeping the change minimal.

## Verification

- `bash -n` clean on both files.
- `grep -rn marker_names_holder .claude` returns no matches.
- The full dispatch unit suite passes unchanged: `2561/2561 passed, 0 failed`.
