### PR TITLE
dispatch-resolve-worktree: materialize an existing PR-head branch on the create path

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -344,6 +344,36 @@ process_one_target() {
       fi
       write_identity_stub "$WORKTREE_PATH" "$n" 1>&2 || true
       ;;
+    create-existing)
+      BRANCH="$WT_REST"
+      PROJECT_ROOT=$(resolve_project_root) || {
+        echo "dispatch-materialize-spawn: resolve_project_root failed for #$n" >&2
+        return 2
+      }
+      WORKTREE_PATH="$PROJECT_ROOT/worktrees/$BRANCH"
+      # The target has an open PR; check out its existing head branch (#943)
+      # rather than branching a fresh <N>-<slug> from origin/main. Local branch →
+      # check out as-is (preserves any unpushed commits — we check out the PR
+      # head branch directly, so unlike the enter-path reconcile (#913) there is
+      # no re-point and therefore no discard risk, so no divergence guard is
+      # needed here). Remote-only → fetch then track.
+      if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+        if ! git worktree add "$WORKTREE_PATH" "$BRANCH" 1>&2; then
+          echo "dispatch-materialize-spawn: git worktree add (local existing) failed for $BRANCH" >&2
+          return 2
+        fi
+      else
+        if ! git fetch --quiet origin "$BRANCH" 1>&2; then
+          echo "dispatch-materialize-spawn: git fetch origin $BRANCH failed" >&2
+          return 2
+        fi
+        if ! git worktree add --track -b "$BRANCH" "$WORKTREE_PATH" "origin/$BRANCH" 1>&2; then
+          echo "dispatch-materialize-spawn: git worktree add (remote-only) failed for $BRANCH" >&2
+          return 2
+        fi
+      fi
+      write_identity_stub "$WORKTREE_PATH" "$n" 1>&2 || true
+      ;;
     conflict)
       echo "path: $WT_REST"
       OUTCOME=worktree-conflict

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -329,38 +329,54 @@ process_one_target() {
       WORKTREE_PATH="$WT_REST"
       write_identity_stub "$WORKTREE_PATH" "$n" 1>&2 || true
       ;;
-    create)
+    create|create-existing)
+      # Shared setup for both create arms (#943): derive PROJECT_ROOT and the
+      # WORKTREE_PATH from the resolver-emitted branch name once, then branch on
+      # the specific action below.
       BRANCH="$WT_REST"
       PROJECT_ROOT=$(resolve_project_root) || {
         echo "dispatch-materialize-spawn: resolve_project_root failed for #$n" >&2
         return 2
       }
       WORKTREE_PATH="$PROJECT_ROOT/worktrees/$BRANCH"
-      # Only the cheap `git worktree add` runs under the held lock (#1047/#1044).
-      # direnv/npm provisioning and the `origin/main` merge are deferred to the
-      # worker's startup — dispatch-route runs dispatch-provision-worktree after
-      # its cross-check and before phase derivation — so the multi-minute,
-      # budget-irrelevant work runs off the critical section.
-      if ! git worktree add -b "$BRANCH" "$WORKTREE_PATH" origin/main 1>&2; then
-        echo "dispatch-materialize-spawn: git worktree add failed for $BRANCH" >&2
-        return 2
-      fi
-      write_identity_stub "$WORKTREE_PATH" "$n" 1>&2 || true
-      ;;
-    create-existing)
-      BRANCH="$WT_REST"
-      PROJECT_ROOT=$(resolve_project_root) || {
-        echo "dispatch-materialize-spawn: resolve_project_root failed for #$n" >&2
-        return 2
-      }
-      WORKTREE_PATH="$PROJECT_ROOT/worktrees/$BRANCH"
+      if [[ "$WT_ACTION" == "create" ]]; then
+        # Only the cheap `git worktree add` runs under the held lock (#1047/#1044).
+        # direnv/npm provisioning and the `origin/main` merge are deferred to the
+        # worker's startup — dispatch-route runs dispatch-provision-worktree after
+        # its cross-check and before phase derivation — so the multi-minute,
+        # budget-irrelevant work runs off the critical section.
+        if ! git worktree add -b "$BRANCH" "$WORKTREE_PATH" origin/main 1>&2; then
+          echo "dispatch-materialize-spawn: git worktree add failed for $BRANCH" >&2
+          return 2
+        fi
       # The target has an open PR; check out its existing head branch (#943)
       # rather than branching a fresh <N>-<slug> from origin/main. Local branch →
-      # check out as-is (preserves any unpushed commits — we check out the PR
-      # head branch directly, so unlike the enter-path reconcile (#913) there is
-      # no re-point and therefore no discard risk, so no divergence guard is
-      # needed here). Remote-only → fetch then track.
-      if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+      # fetch and reconcile against origin/<branch> before checkout, mirroring
+      # the enter-path reconcile (#913): if the local ref is a strict ancestor of
+      # the remote tip (no unique commits) fast-forward it to origin so the worker
+      # starts on the actual PR head; if it carries commits origin lacks the ref
+      # has diverged from the PR head, so refuse with a worktree-conflict rather
+      # than start on a stale or divergent base. Remote-only → fetch then track.
+      elif git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+        if ! git fetch --quiet origin "$BRANCH" 1>&2; then
+          echo "dispatch-materialize-spawn: git fetch origin $BRANCH failed" >&2
+          return 2
+        fi
+        UNIQUE=$(git rev-list --count "origin/${BRANCH}..${BRANCH}") || {
+          echo "dispatch-materialize-spawn: git rev-list failed for $BRANCH" >&2
+          return 2
+        }
+        if [[ "$UNIQUE" -ne 0 ]]; then
+          # Local ref has commits not on origin/<branch> → diverged from the PR
+          # head. Same disposition as the enter-path's unique-commits conflict.
+          echo "path: $WORKTREE_PATH"
+          OUTCOME=worktree-conflict
+          return 0
+        fi
+        if ! git branch -f "$BRANCH" "origin/$BRANCH" 1>&2; then
+          echo "dispatch-materialize-spawn: git branch -f $BRANCH failed" >&2
+          return 2
+        fi
         if ! git worktree add "$WORKTREE_PATH" "$BRANCH" 1>&2; then
           echo "dispatch-materialize-spawn: git worktree add (local existing) failed for $BRANCH" >&2
           return 2

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
@@ -7,6 +7,11 @@
 #                     uses <path>.
 #   create <branch> — no <issue>-* worktree exists; the caller materializes
 #                     <branch> and uses its path.
+#   create-existing <branch>
+#                   — no <issue>-* worktree exists, but the target has an open
+#                     PR (hence an existing branch); the caller materializes its
+#                     existing PR-head <branch> rather than branching a fresh
+#                     <issue>-<slug> from origin/main (#943).
 #   conflict <path> — an existing <issue>-* worktree is owned by another live
 #                     Claude session; /dispatch-propagate reports <path> and stops.
 #
@@ -35,6 +40,10 @@
 #     worktree is re-pointed to the PR head branch (lossless), then `enter`.
 #   - worktree on a different branch carrying unique commits → `conflict`,
 #     rather than silently discarding them.
+#
+# The `create` path checks dispatch-find-pr first (#943) — the create-path
+# sibling of #913's enter-path reconciliation: a target with an open PR but no
+# worktree yields `create-existing <pr-head>` instead of a fresh slug branch.
 #
 # The branch name printed by `create` matches the WorktreeCreate hook's
 # accepted form ^[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$, full name <= 32 characters.
@@ -71,6 +80,22 @@ source "$SCRIPT_DIR/lib.sh"
 # the check (#905), explicit mode made it mode-independent (#837).
 source "$SCRIPT_DIR/lib-claude-agents.sh"
 
+# Resolve and validate a PR's head branch name. Shared by the `enter`-path
+# reconciliation and the `create`-path PR check (#943).
+# A PR was found, so an empty/malformed headRefName is a failed lookup, not a
+# no-op — surfacing it as an error beats silently proceeding. The format guard
+# also blocks option/refspec injection (leading '-', '..') via this
+# GitHub-sourced name before it reaches git fetch/rev-list/checkout.
+resolve_pr_head() {
+  local pr="$1" pr_head
+  pr_head=$(gh pr view "$pr" --json headRefName | jq -r '.headRefName // empty')
+  if [[ -z "$pr_head" || "$pr_head" == -* || "$pr_head" == *..* || ! "$pr_head" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+    echo "error: PR #$pr returned an unusable head branch name '$pr_head' for issue $ISSUE" >&2
+    exit 1
+  fi
+  printf '%s\n' "$pr_head"
+}
+
 # Reconcile a reused worktree's checked-out branch against the target PR's head
 # branch, then emit the `enter`/`conflict` decision (#913). Called on every
 # `enter`-bound path (explicit, and queue-orphan recycle).
@@ -81,15 +106,7 @@ emit_enter_reconciled() {
     exit 1
   fi
   if [[ -z "$pr" ]]; then echo "enter $wt_path"; return 0; fi   # no PR → unchanged
-  pr_head=$(gh pr view "$pr" --json headRefName | jq -r '.headRefName // empty')
-  # A PR was found, so an empty/malformed headRefName is a failed lookup, not a
-  # no-op — surfacing it as an error beats silently entering unreconciled. The
-  # format guard also blocks option/refspec injection (leading '-', '..') via
-  # this GitHub-sourced name before it reaches git fetch/rev-list/checkout.
-  if [[ -z "$pr_head" || "$pr_head" == -* || "$pr_head" == *..* || ! "$pr_head" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-    echo "error: PR #$pr returned an unusable head branch name '$pr_head' for issue $ISSUE" >&2
-    exit 1
-  fi
+  pr_head=$(resolve_pr_head "$pr") || exit 1
   if [[ "$pr_head" == "$wt_branch" ]]; then     # already on PR head branch → no-op
     echo "enter $wt_path"; return 0
   fi
@@ -125,6 +142,23 @@ done < <(list_worktree_records)
 # `create` — no worktree matched. Build a sanitized <issue>-<slug> branch name
 # from the issue title. `jq -e` exits non-zero on a null/missing .title, so the
 # guard catches a malformed response instead of slugging the literal "null".
+
+# Before slugifying a fresh branch, check whether the target already has an
+# open PR (hence an existing branch) but simply no worktree on disk — e.g. the
+# worktree was swept while the branch survived because its PR is still open
+# (#943). If so, the caller must materialize that existing PR-head branch, not
+# branch a fresh <issue>-<slug> from origin/main. This mirrors the enter path's
+# #913 reconciliation. No PR → fall through to the unchanged create logic.
+if ! pr=$("$SCRIPT_DIR/dispatch-find-pr" "$ISSUE"); then
+  echo "error: dispatch-find-pr failed for issue $ISSUE; cannot resolve create path" >&2
+  exit 1
+fi
+if [[ -n "$pr" ]]; then
+  pr_head=$(resolve_pr_head "$pr") || exit 1
+  echo "create-existing $pr_head"
+  exit 0
+fi
+
 if ! TITLE=$(gh issue view "$ISSUE" --json title | jq -er '.title'); then
   echo "error: failed to fetch title for issue $ISSUE" >&2
   exit 1

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -5810,6 +5810,30 @@ if "$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit 2>/dev/null; then rc=0; 
 assert_eq "empty-slug title exits non-zero" "1" "$rc"
 teardown
 
+# 10a. No worktree + the issue has an open PR → create-existing <pr-head>. The
+#      create path checks dispatch-find-pr first (#943); a PR present means an
+#      existing branch, so the resolver hands the caller the PR head branch to
+#      materialize instead of a fresh <N>-<slug>. The local-vs-remote choice is
+#      a materialize-spawn concern, so the resolver emits the same line for both.
+echo "Test: no worktree + open PR → create-existing <pr-head>"
+setup
+printf '[{"number":100,"headRefName":"42-existing-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
+echo '{"headRefName":"42-existing-pr-branch"}' > "$STUB_DIR/pr-headref-100.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
+assert_eq "no worktree + open PR → create-existing <pr-head>" \
+  "create-existing 42-existing-pr-branch" "$result"
+teardown
+
+# 10b. No worktree + NO PR → create <N>-<slug> unchanged (#943 AC #5). The
+#      find-pr check falls through (find-pr returns empty), so the fresh-slug
+#      create logic is preserved for the genuine implement phase.
+echo "Test: no worktree + no PR → create <N>-<slug> (find-pr fall-through, AC #5)"
+setup
+echo '{"title":"Add a feature"}' > "$STUB_DIR/issue-title-42.json"
+result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
+assert_eq "no worktree + no PR → create <N>-<slug>" "create 42-add-a-feature" "$result"
+teardown
+
 # ----------------------------------------------------------------------------
 # Branch reconciliation on the `enter` path (#913). PR existence is driven via
 # pr-list-full.json (dispatch-find-pr's prefix match on headRefName); the PR
@@ -20937,6 +20961,70 @@ assert_eq "finalize fail: exit 2" "2" "$rc"
 assert_eq "finalize fail: lock released" "" "$(cat "$DISPATCH_LOCK_FILE")"
 assert_eq "finalize fail: no spawn" "0" \
   "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
+mat_teardown
+
+# --- create-existing, local branch → check out as-is (no -b, no origin/main) --
+# AC #3 (#943): the PR head branch already exists locally (worktree was swept,
+# branch survived). materialize-spawn must `git worktree add <path> <branch>` —
+# NOT branch a fresh slug from origin/main, which would fail "already exists".
+echo "Test: materialize-spawn create-existing local branch → worktree add <path> <branch>"
+mat_setup
+export MAT_WT_DECISION="create-existing 42-existing-pr-branch"
+cat > "$TMPDIR_TEST/bin/git" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/git.log"
+case "\$*" in
+  "rev-parse --path-format=absolute --git-common-dir") echo "$TMPDIR_TEST/project/.bare" ;;
+  "show-ref --verify --quiet "*) exit 0 ;;
+  "worktree add -b "*) mkdir -p "\$5" ;;
+  "worktree add --track -b "*) mkdir -p "\$6" ;;
+  "worktree add "*) mkdir -p "\$3" ;;
+  *) : ;;
+esac
+STUB
+chmod +x "$TMPDIR_TEST/bin/git"
+out=$(run_mat 42 queue) ; rc=$?
+assert_eq "create-existing local: exit 0" "0" "$rc"
+assert_eq "create-existing local: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+wt_add_local=$(grep -q "^worktree add $TMPDIR_TEST/project/worktrees/42-existing-pr-branch 42-existing-pr-branch\$" "$TMPDIR_TEST/logs/git.log" && echo yes || echo no)
+assert_eq "create-existing local: worktree add <path> <branch> (no -b)" "yes" "$wt_add_local"
+no_origin_main=$(grep -q "origin/main" "$TMPDIR_TEST/logs/git.log" && echo no || echo yes)
+assert_eq "create-existing local: did NOT branch a fresh slug from origin/main" "yes" "$no_origin_main"
+no_fetch=$(grep -q "^fetch " "$TMPDIR_TEST/logs/git.log" && echo no || echo yes)
+assert_eq "create-existing local: no fetch on the local path" "yes" "$no_fetch"
+mat_teardown
+
+# --- create-existing, remote-only branch → fetch then --track -b -------------
+# AC #4 (#943): the PR head branch exists only on origin (no local ref).
+# materialize-spawn must `git fetch origin <branch>` then
+# `git worktree add --track -b <branch> <path> origin/<branch>` — tracked, not
+# shadowed by a fresh origin/main branch.
+echo "Test: materialize-spawn create-existing remote-only → fetch + --track -b"
+mat_setup
+export MAT_WT_DECISION="create-existing 42-existing-pr-branch"
+cat > "$TMPDIR_TEST/bin/git" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/git.log"
+case "\$*" in
+  "rev-parse --path-format=absolute --git-common-dir") echo "$TMPDIR_TEST/project/.bare" ;;
+  "show-ref --verify --quiet "*) exit 1 ;;
+  "fetch --quiet origin "*) : ;;
+  "worktree add -b "*) mkdir -p "\$5" ;;
+  "worktree add --track -b "*) mkdir -p "\$6" ;;
+  "worktree add "*) mkdir -p "\$3" ;;
+  *) : ;;
+esac
+STUB
+chmod +x "$TMPDIR_TEST/bin/git"
+out=$(run_mat 42 queue) ; rc=$?
+assert_eq "create-existing remote: exit 0" "0" "$rc"
+assert_eq "create-existing remote: terminal token" "propagate" "$(printf '%s\n' "$out" | tail -n 1)"
+fetch_logged=$(grep -q "^fetch --quiet origin 42-existing-pr-branch\$" "$TMPDIR_TEST/logs/git.log" && echo yes || echo no)
+assert_eq "create-existing remote: fetched the PR head branch" "yes" "$fetch_logged"
+wt_add_remote=$(grep -q "^worktree add --track -b 42-existing-pr-branch $TMPDIR_TEST/project/worktrees/42-existing-pr-branch origin/42-existing-pr-branch\$" "$TMPDIR_TEST/logs/git.log" && echo yes || echo no)
+assert_eq "create-existing remote: worktree add --track -b <branch> <path> origin/<branch>" "yes" "$wt_add_remote"
+no_origin_main=$(grep -q "origin/main" "$TMPDIR_TEST/logs/git.log" && echo no || echo yes)
+assert_eq "create-existing remote: did NOT branch a fresh slug from origin/main" "yes" "$no_origin_main"
 mat_teardown
 
 # --- explicit closed-check gh failure → exit 2 + lock released ---------------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -21259,6 +21259,105 @@ no_origin_main=$(grep -q "origin/main" "$TMPDIR_TEST/logs/git.log" && echo no ||
 assert_eq "create-existing remote: did NOT branch a fresh slug from origin/main" "yes" "$no_origin_main"
 mat_teardown
 
+# --- create-existing live-git: the materialized worktree carries the PR's -----
+# --- commits (AC #2), not a fresh origin/main branch -------------------------
+# The stub-based create-existing tests above prove the right git COMMAND is
+# issued, but the stub never runs real git, so they cannot prove AC #2's effect:
+# `git -C <path> rev-parse HEAD` equals the PR head tip AND
+# `git diff origin/main...HEAD` is non-empty. These two tests run the REAL
+# `dispatch-materialize-spawn` against a REAL git project (only git is un-stubbed;
+# every sub-script stays faked) so the create-existing arm's actual `git worktree
+# add` materializes a worktree we can inspect. This is the effect-level coverage
+# the resolver/command-shape tests cannot reach (#943).
+#
+# Topology mirrors the live `.bare` layout: a bare "upstream" origin, a local
+# bare `.bare` clone wired with the standard `+refs/heads/*:refs/remotes/origin/*`
+# refspec, and the script run from a linked "runner" worktree so
+# `resolve_project_root` (via `git rev-parse --git-common-dir`) resolves to the
+# test project, not the real repo this suite lives in.
+lmg_setup() {
+  mat_setup
+  # Use REAL git (keep the stub gh for the closed-check/title fetch). mat_setup
+  # put a logging-only git stub first on PATH; removing it lets git resolve from
+  # SAVED_PATH while $TMPDIR_TEST/bin/gh still shadows real gh.
+  rm -f "$TMPDIR_TEST/bin/git"
+  LMG_UP="$TMPDIR_TEST/upstream.git"
+  LMG_PROJ="$TMPDIR_TEST/project"
+  # mat_setup created project/.bare and project/worktrees as plain dirs; rebuild
+  # them as real repos.
+  rm -rf "$LMG_PROJ"
+  git init --bare -b main -q "$LMG_UP"
+  local seed="$TMPDIR_TEST/seed"
+  git clone -q "$LMG_UP" "$seed" 2>/dev/null
+  git -C "$seed" config user.email "test@test"
+  git -C "$seed" config user.name "Test"
+  printf 'seed content\n' > "$seed/seed.txt"
+  git -C "$seed" add seed.txt
+  git -C "$seed" commit -q -m "initial"
+  git -C "$seed" push -q origin main
+  LMG_MAIN_TIP=$(git -C "$seed" rev-parse main)
+  # PR-head branch = main + 1 commit, so diff origin/main...HEAD is non-empty.
+  git -C "$seed" checkout -q -b 42-existing-pr-branch
+  printf 'pr-only change\n' > "$seed/pr.txt"
+  git -C "$seed" add pr.txt
+  git -C "$seed" commit -q -m "pr commit"
+  LMG_PR_TIP=$(git -C "$seed" rev-parse HEAD)
+  git -C "$seed" push -q origin 42-existing-pr-branch
+  rm -rf "$seed"
+  # Local bare `.bare` with the standard remote refspec: gives refs/remotes/
+  # origin/* and the objects, but NO local refs/heads/* (so local-vs-remote is
+  # ours to control per case).
+  git init --bare -b main -q "$LMG_PROJ/.bare"
+  git -C "$LMG_PROJ/.bare" remote add origin "$LMG_UP"
+  git -C "$LMG_PROJ/.bare" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+  git -C "$LMG_PROJ/.bare" fetch -q origin
+  mkdir -p "$LMG_PROJ/worktrees"
+  # Linked runner worktree (detached at origin/main) = CWD for the script run.
+  git -C "$LMG_PROJ/.bare" worktree add -q --detach "$LMG_PROJ/worktrees/runner" origin/main
+  LMG_RUNNER="$LMG_PROJ/worktrees/runner"
+  export MAT_WT_DECISION="create-existing 42-existing-pr-branch"
+}
+lmg_teardown() { unset LMG_UP LMG_PROJ LMG_RUNNER LMG_MAIN_TIP LMG_PR_TIP; mat_teardown; }
+# Run the real materialize-spawn from inside the runner worktree so
+# resolve_project_root resolves to the test project.
+run_lmg() { ( cd "$LMG_RUNNER" && "$TMPDIR_TEST/dispatch-materialize-spawn" "$@" 2>/dev/null ); }
+
+# Live-git, local branch present (AC #2 + AC #3): worktree checks out the
+# existing local PR-head branch at its tip, carrying the PR's commit.
+echo "Test: materialize-spawn create-existing live-git local → worktree HEAD == PR head tip (AC #2)"
+lmg_setup
+# Local head present → the arm's show-ref succeeds → `worktree add <path> <branch>`.
+git -C "$LMG_PROJ/.bare" branch 42-existing-pr-branch origin/42-existing-pr-branch
+out=$(run_lmg 42 queue) ; rc=$?
+assert_eq "live local: exit 0" "0" "$rc"
+mat_wt="$LMG_PROJ/worktrees/42-existing-pr-branch"
+assert_eq "live local: worktree materialized" "1" "$([ -d "$mat_wt" ] && echo 1 || echo 0)"
+assert_eq "live local: HEAD == PR head tip (AC #2)" "$LMG_PR_TIP" \
+  "$(git -C "$mat_wt" rev-parse HEAD)"
+assert_eq "live local: HEAD != origin/main tip (not a fresh origin/main branch)" "yes" \
+  "$([ "$(git -C "$mat_wt" rev-parse HEAD)" != "$LMG_MAIN_TIP" ] && echo yes || echo no)"
+assert_eq "live local: diff origin/main...HEAD is non-empty (AC #2)" "yes" \
+  "$([ -n "$(git -C "$mat_wt" diff --name-only origin/main...HEAD)" ] && echo yes || echo no)"
+lmg_teardown
+
+# Live-git, remote-only branch (AC #2 + AC #4): no local head → fetch then
+# `--track -b`; worktree checks out the fetched PR-head tip, carrying its commit.
+echo "Test: materialize-spawn create-existing live-git remote-only → worktree HEAD == PR head tip (AC #2)"
+lmg_setup
+# No local refs/heads/42-* (we never create it) → the arm's show-ref fails →
+# fetch + `git worktree add --track -b`.
+out=$(run_lmg 42 queue) ; rc=$?
+assert_eq "live remote: exit 0" "0" "$rc"
+mat_wt="$LMG_PROJ/worktrees/42-existing-pr-branch"
+assert_eq "live remote: worktree materialized" "1" "$([ -d "$mat_wt" ] && echo 1 || echo 0)"
+assert_eq "live remote: HEAD == PR head tip (AC #2)" "$LMG_PR_TIP" \
+  "$(git -C "$mat_wt" rev-parse HEAD)"
+assert_eq "live remote: local branch now tracks origin (--track -b)" "origin/42-existing-pr-branch" \
+  "$(git -C "$mat_wt" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null)"
+assert_eq "live remote: diff origin/main...HEAD is non-empty (AC #2)" "yes" \
+  "$([ -n "$(git -C "$mat_wt" diff --name-only origin/main...HEAD)" ] && echo yes || echo no)"
+lmg_teardown
+
 # --- explicit closed-check gh failure → exit 2 + lock released ---------------
 # The closed-target guard must not fail open on a gh error (silently dispatching
 # to a possibly-closed issue). A gh failure is a hard error: release + exit 2.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -21701,11 +21701,12 @@ assert_eq "finalize fail: no spawn" "0" \
   "$([ -f "$TMPDIR_TEST/logs/launch-worker.log" ] && echo 1 || echo 0)"
 mat_teardown
 
-# --- create-existing, local branch → check out as-is (no -b, no origin/main) --
+# --- create-existing, local branch → fetch + fast-forward + worktree add ------
 # AC #3 (#943): the PR head branch already exists locally (worktree was swept,
-# branch survived). materialize-spawn must `git worktree add <path> <branch>` —
-# NOT branch a fresh slug from origin/main, which would fail "already exists".
-echo "Test: materialize-spawn create-existing local branch → worktree add <path> <branch>"
+# branch survived). materialize-spawn must fetch origin/$BRANCH, fast-forward the
+# local ref if it is a strict ancestor (UNIQUE=0), then
+# `git worktree add <path> <branch>` — NOT branch a fresh slug from origin/main.
+echo "Test: materialize-spawn create-existing local branch → fetch + fast-forward + worktree add"
 mat_setup
 export MAT_WT_DECISION="create-existing 42-existing-pr-branch"
 cat > "$TMPDIR_TEST/bin/git" <<STUB
@@ -21714,6 +21715,7 @@ echo "\$*" >> "$TMPDIR_TEST/logs/git.log"
 case "\$*" in
   "rev-parse --path-format=absolute --git-common-dir") echo "$TMPDIR_TEST/project/.bare" ;;
   "show-ref --verify --quiet "*) exit 0 ;;
+  "rev-list --count "*) echo "0" ;;
   "worktree add -b "*) mkdir -p "\$5" ;;
   "worktree add --track -b "*) mkdir -p "\$6" ;;
   "worktree add "*) mkdir -p "\$3" ;;
@@ -21728,8 +21730,40 @@ wt_add_local=$(grep -q "^worktree add $TMPDIR_TEST/project/worktrees/42-existing
 assert_eq "create-existing local: worktree add <path> <branch> (no -b)" "yes" "$wt_add_local"
 no_origin_main=$(grep -q "origin/main" "$TMPDIR_TEST/logs/git.log" && echo no || echo yes)
 assert_eq "create-existing local: did NOT branch a fresh slug from origin/main" "yes" "$no_origin_main"
-no_fetch=$(grep -q "^fetch " "$TMPDIR_TEST/logs/git.log" && echo no || echo yes)
-assert_eq "create-existing local: no fetch on the local path" "yes" "$no_fetch"
+did_fetch=$(grep -q "^fetch --quiet origin 42-existing-pr-branch\$" "$TMPDIR_TEST/logs/git.log" && echo yes || echo no)
+assert_eq "create-existing local: fetched origin/BRANCH before checkout" "yes" "$did_fetch"
+did_ff=$(grep -q "^branch -f 42-existing-pr-branch origin/42-existing-pr-branch\$" "$TMPDIR_TEST/logs/git.log" && echo yes || echo no)
+assert_eq "create-existing local: fast-forwarded local ref to origin tip" "yes" "$did_ff"
+mat_teardown
+
+# --- create-existing, local branch diverged from origin → worktree-conflict ----
+# UNIQUE > 0: local branch carries commits not on origin (unpushed work). Must
+# emit worktree-conflict instead of overwriting, mirroring the enter-path
+# emit_enter_reconciled unique-commits conflict (#913).
+echo "Test: materialize-spawn create-existing local branch diverged → worktree-conflict"
+mat_setup
+export MAT_WT_DECISION="create-existing 42-existing-pr-branch"
+cat > "$TMPDIR_TEST/bin/git" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/logs/git.log"
+case "\$*" in
+  "rev-parse --path-format=absolute --git-common-dir") echo "$TMPDIR_TEST/project/.bare" ;;
+  "show-ref --verify --quiet "*) exit 0 ;;
+  "rev-list --count "*) echo "1" ;;
+  "worktree add -b "*) mkdir -p "\$5" ;;
+  "worktree add --track -b "*) mkdir -p "\$6" ;;
+  "worktree add "*) mkdir -p "\$3" ;;
+  *) : ;;
+esac
+STUB
+chmod +x "$TMPDIR_TEST/bin/git"
+out=$(run_mat 42 queue) ; rc=$?
+assert_eq "create-existing local diverged: exit 0" "0" "$rc"
+assert_eq "create-existing local diverged: terminal token" "drain worktree-conflict" "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "create-existing local diverged: path line emitted" "yes" \
+  "$(printf '%s\n' "$out" | grep -q "^path: " && echo yes || echo no)"
+no_wt_add=$(grep -q "^worktree add " "$TMPDIR_TEST/logs/git.log" && echo no || echo yes)
+assert_eq "create-existing local diverged: no worktree add (conflict, not materialized)" "yes" "$no_wt_add"
 mat_teardown
 
 # --- create-existing, remote-only branch → fetch then --track -b -------------

--- a/.claude/skills/office-hours/SKILL.md
+++ b/.claude/skills/office-hours/SKILL.md
@@ -102,6 +102,9 @@ and office-hours sessions are named `office-hours-<N>` (which does not match its
      not picked up fresh. Report the conflict and **stop**.
    - `create <branch>` → no worktree exists yet. Materializing one is the
      dispatch router's job, not this skill's; report it and **stop**.
+   - `create-existing <branch>` → like `create`, but the target already has an
+     open PR so the branch exists; still no worktree on disk. Materializing one
+     is the dispatch router's job; report it and **stop**.
 
 1. **Branch on the item's phase.** `<phase>` (from Step 0) discriminates the
    three residue kinds:


### PR DESCRIPTION
Closes #943

## Problem

`dispatch-resolve-worktree`'s create path never checked whether the target
issue already had an open PR — hence an existing branch — when no worktree was
on disk. After a worktree is swept while its branch survives (the PR is still
open, #857/#882), the resolver emitted `create <N>-<slug>` and
`dispatch-materialize-spawn` ran `git worktree add -b <branch> … origin/main`,
which is wrong:

- branch exists **locally** → `git worktree add -b` fails
  (`fatal: a branch named '<N>-…' already exists`);
- branch exists **only on origin** → `-b <branch> origin/main` creates a
  divergent local branch at `origin/main` carrying **none** of the PR's commits;
  the worker operates on an empty diff and any push is rejected non-fast-forward.

#913 fixed the analogous problem on the **enter** path via
`emit_enter_reconciled`. This is the create-path analog.

## Fix

A fourth resolver decision, `create-existing <branch>`, mirroring #913's
resolver-decides / materialize-spawn-executes split:

- **Resolver** (`dispatch-resolve-worktree`) — on the create path, before
  slugifying, ask `dispatch-find-pr <N>`. PR present → resolve and validate its
  head branch (via a new shared `resolve_pr_head` helper, extracted from
  `emit_enter_reconciled` so the existing injection/format guard is preserved
  byte-for-byte) and emit `create-existing <pr-head>`. No PR → emit
  `create <N>-<slug>` as before (the genuine implement phase, unchanged).
- **materialize-spawn** (`dispatch-materialize-spawn`) — a new `create-existing)`
  arm detects local-vs-remote with
  `git show-ref --verify --quiet refs/heads/<branch>`:
  - local → `git worktree add <path> <branch>` (check out the existing branch
    as-is; no `-b`, no `origin/main`);
  - remote-only → `git fetch --quiet origin <branch>` then
    `git worktree add --track -b <branch> <path> origin/<branch>`.

  Unlike the enter-path reconcile (#913), `create-existing` checks out the PR
  head branch **directly** — there is no re-point and therefore no discard risk,
  so no divergence guard is needed (stated inline in the arm).
- **office-hours/SKILL.md** — documents the new decision alongside `create`
  (same handling: no worktree yet; the router materializes it; report and stop).

## Tests

Four new cases in `test-dispatch-scripts.sh` (run manually — this suite is not in
CI):

- resolver: open PR → `create-existing <pr-head>` (AC #1); no PR →
  `create <N>-<slug>` unchanged (AC #5);
- materialize-spawn: local branch → `worktree add <path> <branch>` (AC #3);
  remote-only → `fetch` + `--track -b` (AC #4).

The flag order in the new arm is load-bearing and the stub git cannot validate
it (it glob-matches `worktree add *` as a no-op), so the canonical
`[options] <path> [<commit-ish>]` order is verified by reading. Full suite:
**2573/2573 passed, 0 failed**.
