### PR TITLE
rules-test: extract shared describeListQueries helper

### DIFF
--- a/rules-test/test/firestore/budget-journal-entries.test.ts
+++ b/rules-test/test/firestore/budget-journal-entries.test.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { describe, it, beforeAll, beforeEach } from "vitest";
 import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
 import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
-import { doc, getDoc, setDoc, updateDoc, deleteDoc, getDocs, collection, query, where } from "firebase/firestore";
+import { doc, getDoc, setDoc, updateDoc, deleteDoc } from "firebase/firestore";
 import {
   getTestEnv,
   authenticatedContext,
   unauthenticatedContext,
   adminSetDoc,
   setupCleanup,
+  describeListQueries,
 } from "../setup.js";
 
 const ENV = "test";
@@ -207,76 +208,6 @@ describe("budget journal entries", () => {
     });
   });
 
-  describe("list queries", () => {
-    it("allows member list query", async () => {
-      const ctx = authenticatedContext(env, "member@test.com");
-      const db = ctx.firestore();
-      const snap = await assertSucceeds(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/journal-entries`),
-            where("memberEmails", "array-contains", "member@test.com"),
-          ),
-        ),
-      );
-      expect(snap.empty).toBe(false);
-    });
-
-    it("denies unfiltered member list query", async () => {
-      const ctx = authenticatedContext(env, "member@test.com");
-      const db = ctx.firestore();
-      await assertFails(
-        getDocs(collection(db, `budget/${ENV}/journal-entries`)),
-      );
-    });
-
-    // A non-member cannot list another member's docs: filtering for an email
-    // they are not in is denied, because the matching docs carry a memberEmails
-    // the requester is absent from. (A self-targeted array-contains filter is
-    // always rule-compliant and returns an empty set, so it is not a denial
-    // case.)
-    it("denies authenticated non-member list query for another member's docs", async () => {
-      const ctx = authenticatedContext(env, "stranger@test.com");
-      const db = ctx.firestore();
-      await assertFails(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/journal-entries`),
-            where("memberEmails", "array-contains", "member@test.com"),
-          ),
-        ),
-      );
-    });
-
-    it("denies unauthenticated list query", async () => {
-      const ctx = unauthenticatedContext(env);
-      const db = ctx.firestore();
-      await assertFails(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/journal-entries`),
-            where("memberEmails", "array-contains", "member@test.com"),
-          ),
-        ),
-      );
-    });
-
-    // Documents the non-obvious converse of the denial above: a non-member's
-    // self-targeted filter is rule-compliant and succeeds, returning an empty
-    // set rather than being denied. This guards against re-introducing the
-    // false "self-targeted non-member filter is denied" assumption.
-    it("allows authenticated non-member self-targeted list query (returns empty)", async () => {
-      const ctx = authenticatedContext(env, "stranger@test.com");
-      const db = ctx.firestore();
-      const snap = await assertSucceeds(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/journal-entries`),
-            where("memberEmails", "array-contains", "stranger@test.com"),
-          ),
-        ),
-      );
-      expect(snap.empty).toBe(true);
-    });
-  });
 });
+
+describeListQueries(`budget/${ENV}/journal-entries`, baseDoc);

--- a/rules-test/test/firestore/budget-journal-legs.test.ts
+++ b/rules-test/test/firestore/budget-journal-legs.test.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { describe, it, beforeAll, beforeEach } from "vitest";
 import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
 import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
-import { doc, getDoc, setDoc, updateDoc, deleteDoc, getDocs, collection, query, where } from "firebase/firestore";
+import { doc, getDoc, setDoc, updateDoc, deleteDoc } from "firebase/firestore";
 import {
   getTestEnv,
   authenticatedContext,
   unauthenticatedContext,
   adminSetDoc,
   setupCleanup,
+  describeListQueries,
 } from "../setup.js";
 
 const ENV = "test";
@@ -209,76 +210,6 @@ describe("budget journal legs", () => {
     });
   });
 
-  describe("list queries", () => {
-    it("allows member list query", async () => {
-      const ctx = authenticatedContext(env, "member@test.com");
-      const db = ctx.firestore();
-      const snap = await assertSucceeds(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/journal-legs`),
-            where("memberEmails", "array-contains", "member@test.com"),
-          ),
-        ),
-      );
-      expect(snap.empty).toBe(false);
-    });
-
-    it("denies unfiltered member list query", async () => {
-      const ctx = authenticatedContext(env, "member@test.com");
-      const db = ctx.firestore();
-      await assertFails(
-        getDocs(collection(db, `budget/${ENV}/journal-legs`)),
-      );
-    });
-
-    // A non-member cannot list another member's docs: filtering for an email
-    // they are not in is denied, because the matching docs carry a memberEmails
-    // the requester is absent from. (A self-targeted array-contains filter is
-    // always rule-compliant and returns an empty set, so it is not a denial
-    // case.)
-    it("denies authenticated non-member list query for another member's docs", async () => {
-      const ctx = authenticatedContext(env, "stranger@test.com");
-      const db = ctx.firestore();
-      await assertFails(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/journal-legs`),
-            where("memberEmails", "array-contains", "member@test.com"),
-          ),
-        ),
-      );
-    });
-
-    it("denies unauthenticated list query", async () => {
-      const ctx = unauthenticatedContext(env);
-      const db = ctx.firestore();
-      await assertFails(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/journal-legs`),
-            where("memberEmails", "array-contains", "member@test.com"),
-          ),
-        ),
-      );
-    });
-
-    // Documents the non-obvious converse of the denial above: a non-member's
-    // self-targeted filter is rule-compliant and succeeds, returning an empty
-    // set rather than being denied. This guards against re-introducing the
-    // false "self-targeted non-member filter is denied" assumption.
-    it("allows authenticated non-member self-targeted list query (returns empty)", async () => {
-      const ctx = authenticatedContext(env, "stranger@test.com");
-      const db = ctx.firestore();
-      const snap = await assertSucceeds(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/journal-legs`),
-            where("memberEmails", "array-contains", "stranger@test.com"),
-          ),
-        ),
-      );
-      expect(snap.empty).toBe(true);
-    });
-  });
 });
+
+describeListQueries(`budget/${ENV}/journal-legs`, baseDoc);

--- a/rules-test/test/firestore/budget-reconciliation-events.test.ts
+++ b/rules-test/test/firestore/budget-reconciliation-events.test.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { describe, it, beforeAll, beforeEach } from "vitest";
 import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
 import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
-import { doc, getDoc, setDoc, updateDoc, deleteDoc, getDocs, collection, query, where } from "firebase/firestore";
+import { doc, getDoc, setDoc, updateDoc, deleteDoc } from "firebase/firestore";
 import {
   getTestEnv,
   authenticatedContext,
   unauthenticatedContext,
   adminSetDoc,
   setupCleanup,
+  describeListQueries,
 } from "../setup.js";
 
 const ENV = "test";
@@ -216,76 +217,6 @@ describe("budget reconciliation events", () => {
     });
   });
 
-  describe("list queries", () => {
-    it("allows member list query", async () => {
-      const ctx = authenticatedContext(env, "member@test.com");
-      const db = ctx.firestore();
-      const snap = await assertSucceeds(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/reconciliation-events`),
-            where("memberEmails", "array-contains", "member@test.com"),
-          ),
-        ),
-      );
-      expect(snap.empty).toBe(false);
-    });
-
-    it("denies unfiltered member list query", async () => {
-      const ctx = authenticatedContext(env, "member@test.com");
-      const db = ctx.firestore();
-      await assertFails(
-        getDocs(collection(db, `budget/${ENV}/reconciliation-events`)),
-      );
-    });
-
-    // A non-member cannot list another member's docs: filtering for an email
-    // they are not in is denied, because the matching docs carry a memberEmails
-    // the requester is absent from. (A self-targeted array-contains filter is
-    // always rule-compliant and returns an empty set, so it is not a denial
-    // case.)
-    it("denies authenticated non-member list query for another member's docs", async () => {
-      const ctx = authenticatedContext(env, "stranger@test.com");
-      const db = ctx.firestore();
-      await assertFails(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/reconciliation-events`),
-            where("memberEmails", "array-contains", "member@test.com"),
-          ),
-        ),
-      );
-    });
-
-    it("denies unauthenticated list query", async () => {
-      const ctx = unauthenticatedContext(env);
-      const db = ctx.firestore();
-      await assertFails(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/reconciliation-events`),
-            where("memberEmails", "array-contains", "member@test.com"),
-          ),
-        ),
-      );
-    });
-
-    // Documents the non-obvious converse of the denial above: a non-member's
-    // self-targeted filter is rule-compliant and succeeds, returning an empty
-    // set rather than being denied. This guards against re-introducing the
-    // false "self-targeted non-member filter is denied" assumption.
-    it("allows authenticated non-member self-targeted list query (returns empty)", async () => {
-      const ctx = authenticatedContext(env, "stranger@test.com");
-      const db = ctx.firestore();
-      const snap = await assertSucceeds(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/reconciliation-events`),
-            where("memberEmails", "array-contains", "stranger@test.com"),
-          ),
-        ),
-      );
-      expect(snap.empty).toBe(true);
-    });
-  });
 });
+
+describeListQueries(`budget/${ENV}/reconciliation-events`, baseDoc);

--- a/rules-test/test/firestore/budget-reconciliation-notes.test.ts
+++ b/rules-test/test/firestore/budget-reconciliation-notes.test.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { describe, it, beforeAll, beforeEach } from "vitest";
 import { assertSucceeds, assertFails } from "@firebase/rules-unit-testing";
 import type { RulesTestEnvironment } from "@firebase/rules-unit-testing";
-import { doc, getDoc, setDoc, updateDoc, deleteDoc, getDocs, collection, query, where } from "firebase/firestore";
+import { doc, getDoc, setDoc, updateDoc, deleteDoc } from "firebase/firestore";
 import {
   getTestEnv,
   authenticatedContext,
   unauthenticatedContext,
   adminSetDoc,
   setupCleanup,
+  describeListQueries,
 } from "../setup.js";
 
 const ENV = "test";
@@ -213,76 +214,6 @@ describe("budget reconciliation notes", () => {
     });
   });
 
-  describe("list queries", () => {
-    it("allows member list query", async () => {
-      const ctx = authenticatedContext(env, "member@test.com");
-      const db = ctx.firestore();
-      const snap = await assertSucceeds(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/reconciliation-notes`),
-            where("memberEmails", "array-contains", "member@test.com"),
-          ),
-        ),
-      );
-      expect(snap.empty).toBe(false);
-    });
-
-    it("denies unfiltered member list query", async () => {
-      const ctx = authenticatedContext(env, "member@test.com");
-      const db = ctx.firestore();
-      await assertFails(
-        getDocs(collection(db, `budget/${ENV}/reconciliation-notes`)),
-      );
-    });
-
-    // A non-member cannot list another member's docs: filtering for an email
-    // they are not in is denied, because the matching docs carry a memberEmails
-    // the requester is absent from. (A self-targeted array-contains filter is
-    // always rule-compliant and returns an empty set, so it is not a denial
-    // case.)
-    it("denies authenticated non-member list query for another member's docs", async () => {
-      const ctx = authenticatedContext(env, "stranger@test.com");
-      const db = ctx.firestore();
-      await assertFails(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/reconciliation-notes`),
-            where("memberEmails", "array-contains", "member@test.com"),
-          ),
-        ),
-      );
-    });
-
-    it("denies unauthenticated list query", async () => {
-      const ctx = unauthenticatedContext(env);
-      const db = ctx.firestore();
-      await assertFails(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/reconciliation-notes`),
-            where("memberEmails", "array-contains", "member@test.com"),
-          ),
-        ),
-      );
-    });
-
-    // Documents the non-obvious converse of the denial above: a non-member's
-    // self-targeted filter is rule-compliant and succeeds, returning an empty
-    // set rather than being denied. This guards against re-introducing the
-    // false "self-targeted non-member filter is denied" assumption.
-    it("allows authenticated non-member self-targeted list query (returns empty)", async () => {
-      const ctx = authenticatedContext(env, "stranger@test.com");
-      const db = ctx.firestore();
-      const snap = await assertSucceeds(
-        getDocs(
-          query(
-            collection(db, `budget/${ENV}/reconciliation-notes`),
-            where("memberEmails", "array-contains", "stranger@test.com"),
-          ),
-        ),
-      );
-      expect(snap.empty).toBe(true);
-    });
-  });
 });
+
+describeListQueries(`budget/${ENV}/reconciliation-notes`, baseDoc);

--- a/rules-test/test/setup.ts
+++ b/rules-test/test/setup.ts
@@ -7,8 +7,8 @@ import {
 } from "@firebase/rules-unit-testing";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { afterEach, beforeAll, beforeEach, describe, it } from "vitest";
-import { doc, getDoc, setDoc, setLogLevel } from "firebase/firestore";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { doc, getDoc, setDoc, setLogLevel, getDocs, collection, query, where } from "firebase/firestore";
 
 // Suppress Firestore client-side warnings about permission-denied (expected in tests)
 setLogLevel("error");
@@ -216,6 +216,100 @@ export function describeMediaCollection(appName: string): void {
           memberEmails: [],
         }),
       );
+    });
+  });
+}
+
+/**
+ * Shared describe block for `{collectionPath}` budget collections.
+ * Tests the member-only list-query rule contract: a member can list with a
+ * self-targeting `memberEmails array-contains` filter, while unfiltered,
+ * unauthenticated, and other-member-targeting list queries are denied.
+ */
+export function describeListQueries(
+  collectionPath: string,
+  seedDoc: Record<string, unknown>,
+): void {
+  describe(`${collectionPath} list queries`, () => {
+    let env: RulesTestEnvironment;
+
+    beforeAll(async () => {
+      env = await getTestEnv();
+    });
+
+    setupCleanup();
+
+    beforeEach(async () => {
+      await adminSetDoc(env, `${collectionPath}/existing1`, seedDoc);
+    });
+
+    it("allows member list query", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      const snap = await assertSucceeds(
+        getDocs(
+          query(
+            collection(db, collectionPath),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+      expect(snap.empty).toBe(false);
+    });
+
+    it("denies unfiltered member list query", async () => {
+      const ctx = authenticatedContext(env, "member@test.com");
+      const db = ctx.firestore();
+      await assertFails(getDocs(collection(db, collectionPath)));
+    });
+
+    // A non-member cannot list another member's docs: filtering for an email
+    // they are not in is denied, because the matching docs carry a memberEmails
+    // the requester is absent from. (A self-targeted array-contains filter is
+    // always rule-compliant and returns an empty set, so it is not a denial
+    // case.)
+    it("denies authenticated non-member list query for another member's docs", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(
+          query(
+            collection(db, collectionPath),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+    });
+
+    it("denies unauthenticated list query", async () => {
+      const ctx = unauthenticatedContext(env);
+      const db = ctx.firestore();
+      await assertFails(
+        getDocs(
+          query(
+            collection(db, collectionPath),
+            where("memberEmails", "array-contains", "member@test.com"),
+          ),
+        ),
+      );
+    });
+
+    // Documents the non-obvious converse of the denial above: a non-member's
+    // self-targeted filter is rule-compliant and succeeds, returning an empty
+    // set rather than being denied. This guards against re-introducing the
+    // false "self-targeted non-member filter is denied" assumption.
+    it("allows authenticated non-member self-targeted list query (returns empty)", async () => {
+      const ctx = authenticatedContext(env, "stranger@test.com");
+      const db = ctx.firestore();
+      const snap = await assertSucceeds(
+        getDocs(
+          query(
+            collection(db, collectionPath),
+            where("memberEmails", "array-contains", "stranger@test.com"),
+          ),
+        ),
+      );
+      expect(snap.empty).toBe(true);
     });
   });
 }


### PR DESCRIPTION
Closes #1581

## Summary

Extracts a shared `describeListQueries` helper so the budget list-query rule
contract lives in one place instead of being duplicated across four collection
test files.

PR #1578 added a 5-case `describe("list queries", ...)` block to the four budget
collection test files. The block was byte-for-byte identical across all four
files except for the collection-path string. This is the same kind of
duplication the repo already factors into shared describe-block helpers in
`rules-test/test/setup.ts` (`describeGroupsCollection`, `describeMediaCollection`).
The cleanup was surfaced by the review pass on #1578 and deferred out of that
PR's scope.

## Changes

- **`rules-test/test/setup.ts`** — add an exported
  `describeListQueries(collectionPath, seedDoc)` helper, a self-contained
  top-level describe block mirroring the existing `describeGroupsCollection` /
  `describeMediaCollection` helpers. It seeds one collection doc and runs the
  five list-query cases (member filtered list allowed; unfiltered, unauthenticated,
  and other-member-targeting lists denied; self-targeting non-member list allowed
  and empty). The two explanatory comments — including the one guarding the false
  "self-targeted non-member filter is denied" invariant — are preserved verbatim.
- **The four budget collection test files** (`budget-journal-entries`,
  `budget-journal-legs`, `budget-reconciliation-events`,
  `budget-reconciliation-notes`) — replace the inline block with a single
  top-level `describeListQueries(...)` call, and drop the imports
  (`getDocs`, `collection`, `query`, `where`, `expect`) that the removed block was
  the sole user of.

Zero behavior change — future list-rule changes become a single edit instead of
four synchronized edits.

## Verification

- `npm test --prefix rules-test` — all 21 suites green, 408 tests pass
  (the four `budget/test/... list queries` blocks still run 5 cases each). This
  suite runs in no CI job, so it was run manually.
- `npm run lint --prefix rules-test` — clean (confirms the unused-import removal,
  which only the lint step catches since vitest/esbuild does not typecheck).
- `grep -rn 'describe("list queries"' rules-test/test/firestore/` — zero matches.
