### PR TITLE
office-hours: attach to the live bg session instead of --resume

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-office-hours
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # dispatch-spawn-office-hours — spawn a fresh /office-hours background job for a
 # queue item, worker-style, and print the spawned (or deduped) session id so the
-# caller can attach a human via `claude --resume`.
+# caller can attach a human via `claude attach`.
 #
 # This is the office-hours fresh-launch counterpart of dispatch-launch-worker
 # (the router → phase-worker spawn path). Both are thin wrappers over

--- a/.claude/skills/dispatch-propagate/scripts/office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours
@@ -8,10 +8,10 @@
 # enumeration or liveness checking of its own.
 #
 # Dispositions and the action each triggers:
-#   resume <sessionId>            → exec `claude --resume <sessionId>`: the user
-#                                   supplies the pending input to a still-live
-#                                   blocked session. No skill is loaded.
-#   parked-router <sessionId> ... → exec `claude --resume <sessionId>`: re-engage
+#   live <sessionId>              → exec `claude attach <sessionId>`: the user
+#                                   joins a still-live blocked session to supply
+#                                   its pending input. No skill is loaded.
+#   parked-router <sessionId> ... → exec `claude attach <sessionId>`: re-engage
 #                                   a target-less parked dispatch router (#1010),
 #                                   the artifact dispatch-self-close's continuation
 #                                   invariant keeps alive. No skill is loaded.
@@ -21,7 +21,7 @@
 #                                   office-hours-<N>, with cwd = that
 #                                   worktree (5th field), via
 #                                   dispatch-spawn-office-hours; then exec
-#                                   `claude --resume <sessionId>` to attach the
+#                                   `claude attach <sessionId>` to attach the
 #                                   human. Born in the worktree, the session's
 #                                   branch is <N>-..., so the strip hook clears
 #                                   the dispatch:office-hours label and the
@@ -57,14 +57,14 @@ CLAUDE_CMD="${OFFICE_HOURS_CLAUDE_CMD:-claude}"
 directive=$("$SCRIPT_DIR/office-hours-select-target")
 read -r verb a b c d <<< "$directive"
 case "$verb" in
-  resume|parked-router)
+  live|parked-router)
     # a = the live worker / parked-router sessionId.
-    exec "$CLAUDE_CMD" --resume "$a"
+    exec "$CLAUDE_CMD" attach "$a"
     ;;
   office-hours)
     # a b c d = <N> <phase> <pr-or-dash> <worktree-path>. Launch a fresh
     # /office-hours session worker-style — a --bg job named office-hours-<N>,
-    # rooted in the <N>-* worktree — then attach the human via --resume. Rooting
+    # rooted in the <N>-* worktree — then attach the human via attach. Rooting
     # it in the worktree clears the dispatch:office-hours label (the strip hook
     # resolves <N> from the cwd branch). The per-worktree concurrency lock is
     # held via the occupancy guard's office-hours-name check (see
@@ -82,7 +82,7 @@ case "$verb" in
       echo "office-hours: failed to launch a fresh /office-hours session for #$a in $d" >&2
       exit 1
     fi
-    exec "$CLAUDE_CMD" --resume "$sid"
+    exec "$CLAUDE_CMD" attach "$sid"
     ;;
   empty)
     echo "office-hours: queue is empty — nothing to resume or start."

--- a/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
@@ -9,10 +9,10 @@
 # issues oldest-first, makes ONE per-item liveness call against each item's
 # <N>-* worktree, and emits exactly one of four dispositions, in this priority:
 #
-#   resume <sessionId>
+#   live <sessionId>
 #     The oldest labeled item whose <N>-* worktree has a live Claude session.
-#     Resume wins over fresh: if any labeled item is live, its session is
-#     resumed in preference to picking up a sessionless sibling fresh.
+#     Live wins over fresh: if any labeled item is live, its session is
+#     attached in preference to picking up a sessionless sibling fresh.
 #   office-hours <issue> <phase> <pr-or-dash> <worktree-path>
 #     The oldest labeled item with NO live session — a sessionless item that
 #     /office-hours picks up fresh.
@@ -109,8 +109,8 @@ issue_live_session_id() {
   return 1
 }
 
-# Single oldest-first enumeration with one per-item liveness call. RESUME wins
-# over FRESH: a live item is resumed in preference to any sessionless sibling.
+# Single oldest-first enumeration with one per-item liveness call. LIVE wins
+# over FRESH: a live item is attached in preference to any sessionless sibling.
 SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[].number')
 FRESH_NUM=""
 RESUME_ID=""
@@ -126,9 +126,9 @@ while IFS= read -r issue_num; do
   fi
 done <<< "$SORTED"
 
-# Priority 1: resume the oldest live item.
+# Priority 1: emit the oldest live item.
 if [[ -n "$RESUME_ID" ]]; then
-  printf 'resume %s\n' "$RESUME_ID"
+  printf 'live %s\n' "$RESUME_ID"
   exit 0
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
@@ -113,11 +113,11 @@ issue_live_session_id() {
 # over FRESH: a live item is attached in preference to any sessionless sibling.
 SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[].number')
 FRESH_NUM=""
-RESUME_ID=""
+LIVE_ID=""
 while IFS= read -r issue_num; do
   [[ -z "$issue_num" ]] && continue
   if sid=$(issue_live_session_id "$issue_num"); then
-    RESUME_ID="$sid"
+    LIVE_ID="$sid"
     break
   else
     rc=$?
@@ -127,8 +127,8 @@ while IFS= read -r issue_num; do
 done <<< "$SORTED"
 
 # Priority 1: emit the oldest live item.
-if [[ -n "$RESUME_ID" ]]; then
-  printf 'live %s\n' "$RESUME_ID"
+if [[ -n "$LIVE_ID" ]]; then
+  printf 'live %s\n' "$LIVE_ID"
   exit 0
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -4700,7 +4700,7 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktre
   > "$STUB_DIR/worktree-list.txt"
 select_target_fake_claude "42-x"   # 42's worktree has a live session; 99 sessionless
 result=$("$TMPDIR_TEST/office-hours-select-target")
-assert_eq "live item resumed over sessionless sibling 99" "live s-42-x" "$result"
+assert_eq "live item attached over sessionless sibling 99" "live s-42-x" "$result"
 teardown
 
 # OHST3b. Two labeled items both live → attach the oldest one's session
@@ -4714,7 +4714,7 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktre
   > "$STUB_DIR/worktree-list.txt"
 select_target_fake_claude "42-x" "99-y"   # both worktrees live
 result=$("$TMPDIR_TEST/office-hours-select-target")
-assert_eq "oldest of two live items resumed" "live s-42-x" "$result"
+assert_eq "oldest of two live items attached" "live s-42-x" "$result"
 teardown
 
 # OHST3c. Older sessionless item + newer live item → attach the live one
@@ -4729,7 +4729,7 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktre
   > "$STUB_DIR/worktree-list.txt"
 select_target_fake_claude "99-y"   # only 99's worktree is live
 result=$("$TMPDIR_TEST/office-hours-select-target")
-assert_eq "live item resumed regardless of age order" "live s-99-y" "$result"
+assert_eq "live item attached regardless of age order" "live s-99-y" "$result"
 teardown
 
 # OHST4. An empty office-hours queue with no parked router prints `empty`. The
@@ -4901,7 +4901,7 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktre
   > "$STUB_DIR/worktree-list.txt"
 office_hours_fake_claude "42-x"   # 42's worktree has a live session
 result=$("$TMPDIR_TEST/office-hours")
-assert_eq "resumes the live session by its sessionId" "LAUNCH: attach s-42-x" "$result"
+assert_eq "attaches the live session by its sessionId" "LAUNCH: attach s-42-x" "$result"
 teardown
 
 # OH2. Two labeled items both live → attach the oldest one's session.
@@ -4913,7 +4913,7 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktre
   > "$STUB_DIR/worktree-list.txt"
 office_hours_fake_claude "42-x" "99-y"   # both worktrees live
 result=$("$TMPDIR_TEST/office-hours")
-assert_eq "resumes the oldest live item's session" "LAUNCH: attach s-42-x" "$result"
+assert_eq "attaches the oldest live item's session" "LAUNCH: attach s-42-x" "$result"
 teardown
 
 # OH3. Labeled items but none with a live session → launch the fresh /office-hours
@@ -13697,9 +13697,9 @@ else
 fi
 spawn_office_hours_teardown
 
-# --- Test 3: dedup hit — resolve the existing same-name session for resume ----
+# --- Test 3: dedup hit — resolve the existing same-name session for attach ----
 
-echo "Test: a live same-name session deduplicates the spawn; its id is resolved for resume"
+echo "Test: a live same-name session deduplicates the spawn; its id is resolved for attach"
 spawn_office_hours_setup
 # Prime the registry with a different sessionId whose name matches office-hours-<N>
 # (the name the spawn now uses). dispatch-spawn-job dedups (no --bg); the resolve
@@ -13710,7 +13710,7 @@ printf '%s' \
 write_fake_spawn_worker_claude
 if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-office-hours" 839 implement - "$WORKER_TARGET_WORKTREE" 2>/dev/null); then rc=0; else rc=$?; fi
 assert_eq "dedup-oh: dispatch-spawn-office-hours exits 0" "0" "$rc"
-assert_eq "dedup-oh: stdout is the existing session id (resolved for resume)" "sess-other" "$out"
+assert_eq "dedup-oh: stdout is the existing session id (resolved for attach)" "sess-other" "$out"
 # No --bg invocation was recorded — nothing was spawned.
 TOTAL=$((TOTAL + 1))
 if [[ ! -e "$SPAWN_WORKER_BG_ARGV" ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1811,7 +1811,7 @@ FAKE
 # liveness parsing matches production exactly: each named worktree basename gets
 # a live session row (sessionId `s-<name>`). The fake branches on its first arg:
 # `agents` returns the JSON payload (the liveness query); any other invocation —
-# `--resume <id>` or `/office-hours` — prints `LAUNCH: $*` so a test can assert
+# `attach <id>` or `/office-hours` — prints `LAUNCH: $*` so a test can assert
 # which launch fired. Wires both OFFICE_HOURS_CLAUDE_CMD (the entry script's
 # launch target) and CLAUDE_AGENTS_CMD (the selector subprocess's liveness query)
 # at the same fake, so a single binary serves both the query and the launch.
@@ -1831,7 +1831,7 @@ if [[ "${1:-}" == "agents" ]]; then
   cat "$(cd "$(dirname "$0")/.." && pwd)/claude-payload.json"
   exit 0
 fi
-# A launch (`--resume <id>` or `/office-hours`): record which one fired.
+# A launch (`attach <id>` or `/office-hours`): record which one fired.
 echo "LAUNCH: $*"
 exit 0
 FAKE
@@ -1847,7 +1847,7 @@ FAKE
 # style) entry path. Serves `agents` from an oh-registry.json (starts empty); on
 # `--bg` records argv + $PWD and registers {"sessionId":"sess-<name>",...} under
 # --name (so dispatch-spawn-job's verify + dispatch-spawn-office-hours' resolve
-# both find it); prints `LAUNCH: $*` on anything else (the entry's --resume).
+# both find it); prints `LAUNCH: $*` on anything else (the entry's attach).
 office_hours_fresh_fake_claude() {
   printf '[]' > "$TMPDIR_TEST/oh-registry.json"
   cat > "$TMPDIR_TEST/bin/claude" <<'FAKE'
@@ -4361,8 +4361,8 @@ assert_eq "qa item selected with its PR number" "office-hours 50 qa 7 -" "$resul
 teardown
 
 # OHST3. The oldest labeled item whose <N>-* worktree has a live session is
-# RESUMED — resume wins over a sessionless newer sibling.
-echo "Test: oldest live-session item is resumed (resume wins over fresh sibling)"
+# ATTACHED — live wins over a sessionless newer sibling.
+echo "Test: oldest live-session item is attached (live wins over fresh sibling)"
 setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdAt":"2024-02-01T00:00:00Z"}]\n' \
   > "$STUB_DIR/oh-issue-list.json"
@@ -4371,12 +4371,12 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktre
   > "$STUB_DIR/worktree-list.txt"
 select_target_fake_claude "42-x"   # 42's worktree has a live session; 99 sessionless
 result=$("$TMPDIR_TEST/office-hours-select-target")
-assert_eq "live item resumed over sessionless sibling 99" "resume s-42-x" "$result"
+assert_eq "live item resumed over sessionless sibling 99" "live s-42-x" "$result"
 teardown
 
-# OHST3b. Two labeled items both live → resume the oldest one's session
+# OHST3b. Two labeled items both live → attach the oldest one's session
 # (mirrors OH2 on the entry-point side).
-echo "Test: two live items → oldest resumed"
+echo "Test: two live items → oldest attached"
 setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdAt":"2024-02-01T00:00:00Z"}]\n' \
   > "$STUB_DIR/oh-issue-list.json"
@@ -4385,12 +4385,12 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktre
   > "$STUB_DIR/worktree-list.txt"
 select_target_fake_claude "42-x" "99-y"   # both worktrees live
 result=$("$TMPDIR_TEST/office-hours-select-target")
-assert_eq "oldest of two live items resumed" "resume s-42-x" "$result"
+assert_eq "oldest of two live items resumed" "live s-42-x" "$result"
 teardown
 
-# OHST3c. Older sessionless item + newer live item → resume the live one
-# (mirrors OH5: resume wins regardless of age order).
-echo "Test: older sessionless + newer live → resume the live one"
+# OHST3c. Older sessionless item + newer live item → attach the live one
+# (mirrors OH5: live wins regardless of age order).
+echo "Test: older sessionless + newer live → attach the live one"
 setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdAt":"2024-02-01T00:00:00Z"}]\n' \
   > "$STUB_DIR/oh-issue-list.json"
@@ -4400,7 +4400,7 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktre
   > "$STUB_DIR/worktree-list.txt"
 select_target_fake_claude "99-y"   # only 99's worktree is live
 result=$("$TMPDIR_TEST/office-hours-select-target")
-assert_eq "live item resumed regardless of age order" "resume s-99-y" "$result"
+assert_eq "live item resumed regardless of age order" "live s-99-y" "$result"
 teardown
 
 # OHST4. An empty office-hours queue with no parked router prints `empty`. The
@@ -4555,7 +4555,7 @@ echo "=== office-hours (entry point) ==="
 #
 # The single user entry point to the office-hours queue (#759). It is now a thin
 # dispatcher: it calls office-hours-select-target once and switches on the verb —
-# resume / parked-router (exec `claude --resume <sessionId>`), fresh-with-args
+# live / parked-router (exec `claude attach <sessionId>`), fresh-with-args
 # (exec `claude "/office-hours <N> <phase> <pr>"`), or empty (print a queue-empty
 # message and exit WITHOUT launching). These are therefore entry+selector
 # integration tests: setup copies the real selector into TMPDIR_TEST, the
@@ -4564,19 +4564,19 @@ echo "=== office-hours (entry point) ==="
 # case asserts which launch fired (or that none did). The fake's sessionId
 # convention is `s-<worktree-basename>`.
 
-# OH1. One labeled item whose <N>-* worktree has a live session → resume it.
-echo "Test: live-session labeled item → resume its session"
+# OH1. One labeled item whose <N>-* worktree has a live session → attach it.
+echo "Test: live-session labeled item → attach its session"
 setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
   > "$STUB_DIR/worktree-list.txt"
 office_hours_fake_claude "42-x"   # 42's worktree has a live session
 result=$("$TMPDIR_TEST/office-hours")
-assert_eq "resumes the live session by its sessionId" "LAUNCH: --resume s-42-x" "$result"
+assert_eq "resumes the live session by its sessionId" "LAUNCH: attach s-42-x" "$result"
 teardown
 
-# OH2. Two labeled items both live → resume the oldest one's session.
-echo "Test: two live items → resume the oldest"
+# OH2. Two labeled items both live → attach the oldest one's session.
+echo "Test: two live items → attach the oldest"
 setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdAt":"2024-02-01T00:00:00Z"}]\n' \
   > "$STUB_DIR/oh-issue-list.json"
@@ -4584,7 +4584,7 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktre
   > "$STUB_DIR/worktree-list.txt"
 office_hours_fake_claude "42-x" "99-y"   # both worktrees live
 result=$("$TMPDIR_TEST/office-hours")
-assert_eq "resumes the oldest live item's session" "LAUNCH: --resume s-42-x" "$result"
+assert_eq "resumes the oldest live item's session" "LAUNCH: attach s-42-x" "$result"
 teardown
 
 # OH3. Labeled items but none with a live session → launch the fresh /office-hours
@@ -4592,7 +4592,7 @@ teardown
 # via dispatch-spawn-office-hours, then attach the human by resuming the spawned
 # session id. Fixes the originally-reported label leak (#1160): born in the
 # worktree, the session's branch is <N>-..., so the strip hook clears the label.
-echo "Test: labeled item, none live → spawn worker-style --bg then resume"
+echo "Test: labeled item, none live → spawn worker-style --bg then attach"
 setup
 mkdir -p "$TMPDIR_TEST/worktrees/42-x"
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
@@ -4600,8 +4600,8 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree %s\nHEAD
   "$TMPDIR_TEST/worktrees/42-x" > "$STUB_DIR/worktree-list.txt"
 office_hours_fresh_fake_claude
 result=$("$TMPDIR_TEST/office-hours")
-# Attaches the human by resuming the just-spawned session id.
-assert_eq "fresh path resumes the spawned session id" "LAUNCH: --resume sess-office-hours-42" "$result"
+# Attaches the human by attaching the just-spawned session id.
+assert_eq "fresh path attaches the spawned session id" "LAUNCH: attach sess-office-hours-42" "$result"
 # The spawn was a --bg job named office-hours-<N> running /office-hours.
 mapfile -t oh_argv < "$TMPDIR_TEST/oh-bg-argv"
 assert_eq "fresh: --bg" "--bg" "${oh_argv[0]:-}"
@@ -4616,16 +4616,16 @@ assert_eq "fresh: spawn cwd is the worktree" "$(realpath "$TMPDIR_TEST/worktrees
 teardown
 
 # OH3c. A labeled item whose worktree has a live session named office-hours-<N>
-# (the renamed office-hours session, #1311) → resume it directly. Before the
+# (the renamed office-hours session, #1311) → attach it directly. Before the
 # two-name fix the selector keyed only on the basename and missed it.
-echo "Test: live office-hours-<N> session → selector resumes it directly"
+echo "Test: live office-hours-<N> session → selector attaches it directly"
 setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
   > "$STUB_DIR/worktree-list.txt"
 office_hours_fake_claude "office-hours-42"   # the live session is the office-hours-<N> one
 result=$("$TMPDIR_TEST/office-hours")
-assert_eq "resumes the live office-hours-<N> session by its sessionId" "LAUNCH: --resume s-office-hours-42" "$result"
+assert_eq "attaches the live office-hours-<N> session by its sessionId" "LAUNCH: attach s-office-hours-42" "$result"
 teardown
 
 # OH3b. Sessionless item with NO <N>-* worktree on disk (the worktree was swept) →
@@ -4655,9 +4655,9 @@ assert_eq "empty queue → queue-empty message, no launch" "office-hours: queue 
 unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 
-# OH5. Mixed: an older sessionless item + a newer live-session item → resume the
-# live one (resume wins over fresh whenever any labeled item is live).
-echo "Test: older sessionless + newer live → resume the live one"
+# OH5. Mixed: an older sessionless item + a newer live-session item → attach the
+# live one (live wins over fresh whenever any labeled item is live).
+echo "Test: older sessionless + newer live → attach the live one"
 setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdAt":"2024-02-01T00:00:00Z"}]\n' \
   > "$STUB_DIR/oh-issue-list.json"
@@ -4666,7 +4666,7 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktre
   > "$STUB_DIR/worktree-list.txt"
 office_hours_fake_claude "99-y"   # only 99's worktree is live
 result=$("$TMPDIR_TEST/office-hours")
-assert_eq "resume wins over fresh whenever any labeled item is live" "LAUNCH: --resume s-99-y" "$result"
+assert_eq "live wins over fresh whenever any labeled item is live" "LAUNCH: attach s-99-y" "$result"
 teardown
 
 # OH6. UNKNOWN daemon (claude unqueryable). Under the single fail-safe convention
@@ -4700,9 +4700,9 @@ unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 
 # OH7. The selector emits `parked-router <sessionId> <name>` (a target-less
-# parked dispatch router, #1010) → the entry script resumes that session. The
+# parked dispatch router, #1010) → the entry script attaches that session. The
 # entry script gains the parked-router handling the selector already had.
-echo "Test: parked-router directive → entry resumes the router session"
+echo "Test: parked-router directive → entry attaches the router session"
 setup
 echo '[]' > "$STUB_DIR/oh-issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
@@ -4721,7 +4721,7 @@ exit 0
 FAKE
 chmod +x "$TMPDIR_TEST/bin/claude"
 result=$("$TMPDIR_TEST/office-hours")
-assert_eq "parked-router directive resumes the router session" "LAUNCH: --resume s-dispatch-abc123" "$result"
+assert_eq "parked-router directive attaches the router session" "LAUNCH: attach s-dispatch-abc123" "$result"
 unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -13254,7 +13254,7 @@ echo "=== dispatch-spawn-office-hours ==="
 # office-hours-<N> (not the worktree basename) and --cwd = worktree path via
 # dispatch-spawn-job, then — unlike the launcher, which `exec`s the spawn and is
 # done — resolves the spawned (or deduped) session id by office-hours-<N> and
-# prints it, so the caller can attach a human via `claude --resume`.
+# prints it, so the caller can attach a human via `claude attach`.
 #
 # It reuses the spawn-worker fake-`claude` harness (write_fake_spawn_worker_claude)
 # and the SPAWN_WORKER_* fixture globals: that fake's `--bg` handler registers

--- a/.claude/skills/office-hours/SKILL.md
+++ b/.claude/skills/office-hours/SKILL.md
@@ -74,10 +74,10 @@ and office-hours sessions are named `office-hours-<N>` (which does not match its
      phase, and its PR number (or `-`). Carry `<N>`, `<phase>`, and `<pr>`
      through the rest of the skill (same as the args-first path above). Proceed
      to "Enter the item's worktree" below.
-   - `resume <sessionId>` — a labeled item whose `<N>-*` worktree has a live
-     session. This skill cannot resume a session from within an already-running
-     session. Report the session ID and tell the user to run
-     `claude --resume <sessionId>` to re-engage it. **Stop.**
+   - `live <sessionId>` — a labeled item whose `<N>-*` worktree has a live
+     session. This skill cannot attach to a session from within an
+     already-running session. Report the session ID and tell the user to run
+     `claude attach <sessionId>` to re-engage it. **Stop.**
    - `parked-router <sessionId> <name>` — the dispatch chain has a target-less
      parked router (#1010): a router tick left no continuation, so the
      `dispatch-self-close` continuation invariant kept the session alive rather


### PR DESCRIPTION
Closes #1592

## What

The `office-hours` launcher ended every branch with `exec claude --resume <sid>`.
For the fresh-spawn disposition it first spawns a live `--bg` office-hours worker,
then ran `claude --resume <sid>` against it — but the CLI **refuses** `--resume`
for a session that is already live as a background agent (`Session <id> is
currently running as a background agent (bg)…`), dropping the human at a shell
instead of attaching. Even on an idle target where `--resume` succeeded, it
births a *separate foreground* session and orphans the bg worker, dropping the
per-worktree concurrency lock held by the `office-hours-<N>` bg-job name.

This switches every launch branch to `exec claude attach <sid>`, the purpose-built
primitive for joining a live bg session: it joins the *same* session, keeping its
`office-hours-<N>` name and the lock. The selector verb `resume` — which named the
old mechanism — is renamed to `live`, because it names a *finding* (an existing
live session), not an action. A dead session between selection and launch makes
`attach` fail with its own clear diagnostic; `exec` precludes (and the design
deliberately omits) an in-script re-resolve loop.

## Changes

- **`office-hours`** — `exec … --resume` → `exec … attach` on both launch paths;
  case label and header/inline comments renamed `resume`→`live` and rewritten to
  describe `claude attach`. The `--bg` spawn-with-verify is unchanged.
- **`office-hours-select-target`** — emitted verb `resume` → `live`; comments
  updated.
- **`office-hours/SKILL.md`** and **`dispatch-spawn-office-hours`** — doc/comment
  sync to the `live` disposition and `claude attach` command.
- **`test-dispatch-scripts.sh`** — selector-verb assertions `resume`→`live`,
  entry-launch assertions `--resume`→`attach`, and descriptive comments updated.
  Full suite green (2604/2604).
