### PR TITLE
office-hours: queue status band

### DIFF
--- a/office-hours/index.html
+++ b/office-hours/index.html
@@ -99,6 +99,42 @@
       .capacity-worker-state.paused {
         color: var(--danger, #ff6b6b);
       }
+      .queue-heading {
+        font-size: 1rem;
+        letter-spacing: 0.05em;
+        color: var(--muted-fg, #9aa0a6);
+        margin-bottom: 0.75rem;
+      }
+      .queue-cards {
+        display: flex;
+        gap: 1rem;
+        margin-bottom: 1rem;
+      }
+      .queue-card {
+        border: 1px solid var(--graphical-fg, rgba(255, 255, 255, 0.15));
+        padding: 0.75rem 1rem;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+      .queue-card-label {
+        color: var(--muted-fg, #9aa0a6);
+        font-size: 0.8rem;
+      }
+      .queue-card-value {
+        font-size: 1.75rem;
+        font-weight: 700;
+      }
+      .queue-runway {
+        margin: 0;
+      }
+      .queue-runway-state {
+        color: var(--muted-fg, #9aa0a6);
+      }
+      .queue-runway-state.growing {
+        color: var(--danger, #ff6b6b);
+      }
       /* Plot tip text: force dark so it remains readable on every chart. */
       svg [aria-label="tip"] text { fill: #222; }
       .chart-layout {

--- a/office-hours/src/app-view.ts
+++ b/office-hours/src/app-view.ts
@@ -2,14 +2,16 @@ import { renderCapacityBand, selectLatestSample } from "./capacity-band.js";
 import { renderPacePositionPanel } from "./pace-position-panel.js";
 import { renderHistoryBand } from "./history-band.js";
 import { renderReminderList } from "./office-hours.js";
+import { renderQueueBand } from "./queue-band.js";
 import { getDemoSamples } from "./usage-data.js";
-import { getDemoReminders } from "./data.js";
+import { getDemoReminders, getDemoQueueMetrics } from "./data.js";
 import type { UsageSample } from "./usage-samples.js";
 import type { Reminder } from "./reminders.js";
+import type { QueueMetricsSnapshot } from "./queue-metrics.js";
 
 export type ViewState =
   | { tier: "demo" }                                                  // unauthenticated → labeled demo
-  | { tier: "owner"; samples: UsageSample[]; reminders: Reminder[] }  // authenticated → real (possibly empty)
+  | { tier: "owner"; samples: UsageSample[]; reminders: Reminder[]; queueMetrics: QueueMetricsSnapshot | null }  // authenticated → real (possibly empty)
   | { tier: "error" };                                                // authenticated load failed
 
 export function renderApp(container: Element, state: ViewState, now: Date): void {
@@ -24,11 +26,13 @@ export function renderApp(container: Element, state: ViewState, now: Date): void
 
     const samples = getDemoSamples();
     container.appendChild(renderCapacityBand(selectLatestSample(samples), now));
+    container.appendChild(renderQueueBand(getDemoQueueMetrics()));
     container.appendChild(renderPacePositionPanel(samples));
     container.appendChild(renderHistoryBand(samples));
     container.appendChild(renderReminderList(getDemoReminders(), now));
   } else if (state.tier === "owner") {
     container.appendChild(renderCapacityBand(selectLatestSample(state.samples), now));
+    container.appendChild(renderQueueBand(state.queueMetrics));
     container.appendChild(renderPacePositionPanel(state.samples));
     container.appendChild(renderHistoryBand(state.samples));
     container.appendChild(renderReminderList(state.reminders, now));

--- a/office-hours/src/data.ts
+++ b/office-hours/src/data.ts
@@ -1,11 +1,11 @@
-import { collection, getDocs, query, where, type Firestore } from "firebase/firestore";
+import { collection, doc, getDoc, getDocs, query, where, type Firestore } from "firebase/firestore";
 import type { User } from "firebase/auth";
 import { nsCollectionPath, type Namespace } from "@commons-systems/firestoreutil/namespace";
 import { logError } from "@commons-systems/errorutil/log";
 import seedReminders from "virtual:office-hours-seed-data";
 import seedQueueMetrics from "virtual:office-hours-queue-seed";
 import type { Reminder } from "./reminders.js";
-import type { QueueMetricsSnapshot } from "./queue-metrics.js";
+import { parseQueueMetrics, type QueueMetricsSnapshot } from "./queue-metrics.js";
 
 export function getDemoReminders(): Reminder[] {
   return seedReminders.map((s) => ({
@@ -46,6 +46,17 @@ export async function getOwnerReminders(
     if (reminder) reminders.push(reminder);
   }
   return reminders;
+}
+
+export async function getOwnerQueueMetrics(
+  db: Firestore,
+  namespace: Namespace,
+  user: User,
+): Promise<QueueMetricsSnapshot | null> {
+  if (!user.email) return null;
+  const snap = await getDoc(doc(db, nsCollectionPath(namespace, "metrics"), "dispatch-queue"));
+  if (!snap.exists()) return null;
+  return parseQueueMetrics(snap.data());
 }
 
 export function toReminder(id: string, data: Record<string, unknown>): Reminder | null {

--- a/office-hours/src/main.ts
+++ b/office-hours/src/main.ts
@@ -6,7 +6,7 @@ import { logError } from "@commons-systems/errorutil/log";
 import { deferAppCheckInit } from "@commons-systems/firebaseutil/defer-appcheck";
 
 import { renderApp } from "./app-view.js";
-import { getOwnerReminders } from "./data.js";
+import { getOwnerReminders, getOwnerQueueMetrics } from "./data.js";
 import { getOwnerSamples } from "./usage-data.js";
 import {
   db,
@@ -40,14 +40,15 @@ async function refresh(): Promise<void> {
     return;
   }
   try {
-    const [samples, reminders] = await Promise.all([
+    const [samples, reminders, queueMetrics] = await Promise.all([
       getOwnerSamples(db, NAMESPACE, refreshUser),
       getOwnerReminders(db, NAMESPACE, refreshUser),
+      getOwnerQueueMetrics(db, NAMESPACE, refreshUser),
     ]);
     // Auth may have changed while the Firestore calls were in flight — skip the
     // render so the in-flight result does not clobber the already-updated view.
     if (currentUser !== refreshUser) return;
-    renderApp(app!, { tier: "owner", samples, reminders }, new Date());
+    renderApp(app!, { tier: "owner", samples, reminders, queueMetrics }, new Date());
   } catch (error) {
     // Auth may have changed while the Firestore calls were in flight — skip the
     // render so the in-flight error does not clobber the already-updated view.

--- a/office-hours/src/queue-band.ts
+++ b/office-hours/src/queue-band.ts
@@ -1,0 +1,76 @@
+import type { QueueMetricsSnapshot } from "./queue-metrics.js";
+
+function buildCard(label: string, value: string): HTMLElement {
+  const card = document.createElement("div");
+  card.className = "queue-card";
+
+  const labelSpan = document.createElement("span");
+  labelSpan.className = "queue-card-label";
+  labelSpan.textContent = label;
+
+  const valueSpan = document.createElement("span");
+  valueSpan.className = "queue-card-value";
+  valueSpan.textContent = value;
+
+  card.appendChild(labelSpan);
+  card.appendChild(valueSpan);
+
+  return card;
+}
+
+function runwayReadout(metrics: QueueMetricsSnapshot): { text: string; state: string } {
+  if (metrics.openHelpWanted === 0) {
+    return { text: "queue empty", state: "empty" };
+  }
+  if (metrics.runwayDays !== null) {
+    return {
+      text: `~${Math.ceil(metrics.runwayDays)} days until the queue empties`,
+      state: "draining",
+    };
+  }
+  if (metrics.netDrainPerDay === 0) {
+    return { text: "queue stable", state: "stable" };
+  }
+  return { text: "queue growing", state: "growing" };
+}
+
+/**
+ * Renders the queue status band from the latest dispatch-queue metrics snapshot.
+ */
+export function renderQueueBand(metrics: QueueMetricsSnapshot | null): HTMLElement {
+  const section = document.createElement("section");
+
+  const heading = document.createElement("h2");
+  heading.className = "queue-heading";
+  heading.textContent = "QUEUE";
+  section.appendChild(heading);
+
+  if (metrics === null) {
+    const empty = document.createElement("p");
+    empty.className = "empty";
+    empty.textContent = "No queue data.";
+    section.appendChild(empty);
+    return section;
+  }
+
+  // Cards
+  const cards = document.createElement("div");
+  cards.className = "queue-cards";
+  cards.appendChild(buildCard("backlog", String(metrics.openHelpWanted)));
+  cards.appendChild(buildCard("closed/day", metrics.closedPerDay.toFixed(1)));
+  cards.appendChild(buildCard("created/day", metrics.createdPerDay.toFixed(1)));
+  section.appendChild(cards);
+
+  // Runway verdict
+  const runway = document.createElement("p");
+  runway.className = "queue-runway";
+  const { text, state } = runwayReadout(metrics);
+  const stateSpan = document.createElement("span");
+  stateSpan.className = "queue-runway-state";
+  stateSpan.classList.add(state);
+  stateSpan.textContent = text;
+  runway.appendChild(stateSpan);
+  section.appendChild(runway);
+
+  return section;
+}

--- a/office-hours/test/app-view.test.ts
+++ b/office-hours/test/app-view.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { renderApp } from "../src/app-view.js";
 import type { UsageSample } from "../src/usage-samples.js";
 import type { Reminder } from "../src/reminders.js";
+import type { QueueMetricsSnapshot } from "../src/queue-metrics.js";
 
 const now = new Date("2026-06-11T12:00:00Z");
 
@@ -28,6 +29,12 @@ const baseSample: UsageSample = {
 };
 
 const makeSample = (o: Partial<UsageSample> = {}): UsageSample => ({ ...baseSample, ...o });
+
+const makeQueueMetrics = (o: Partial<QueueMetricsSnapshot> = {}): QueueMetricsSnapshot => ({
+  openHelpWanted: 12, closedPerDay: 1.5, createdPerDay: 1.0, netDrainPerDay: 0.5,
+  runwayDays: 24, windowDays: 14, computedAt: new Date("2026-06-07T10:00:00Z"),
+  groupId: "g", memberEmails: ["x@y"], ...o,
+});
 
 const MINUTE = 60_000;
 const HOUR = 3_600_000;
@@ -78,6 +85,23 @@ describe("renderApp — demo tier", () => {
 
     expect(container.querySelector(".error")).toBeNull();
   });
+
+  it("renders the queue heading", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+
+    const heading = container.querySelector(".queue-heading");
+    expect(heading).not.toBeNull();
+    expect(heading!.textContent).toBe("QUEUE");
+  });
+
+  it("renders 3 queue cards from the demo seed", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+
+    const cards = container.querySelectorAll(".queue-card");
+    expect(cards.length).toBe(3);
+  });
 });
 
 describe("renderApp — owner tier with data", () => {
@@ -92,14 +116,14 @@ describe("renderApp — owner tier with data", () => {
 
   it("does not render a .demo-banner", () => {
     const container = document.createElement("div");
-    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders }, now));
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: makeQueueMetrics() }, now));
 
     expect(container.querySelector(".demo-banner")).toBeNull();
   });
 
   it("renders a reminder list item for each reminder", () => {
     const container = document.createElement("div");
-    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders }, now));
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: makeQueueMetrics() }, now));
 
     const items = container.querySelectorAll("li.reminder");
     expect(items.length).toBe(2);
@@ -107,9 +131,17 @@ describe("renderApp — owner tier with data", () => {
 
   it("does not render an .error element", () => {
     const container = document.createElement("div");
-    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders }, now));
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: makeQueueMetrics() }, now));
 
     expect(container.querySelector(".error")).toBeNull();
+  });
+
+  it("renders 3 queue cards when queueMetrics is provided", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: makeQueueMetrics() }, now));
+
+    const cards = container.querySelectorAll(".queue-card");
+    expect(cards.length).toBe(3);
   });
 });
 
@@ -117,7 +149,7 @@ describe("renderApp — owner tier empty", () => {
   it("does not render a .demo-banner", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null }, now),
     );
 
     expect(container.querySelector(".demo-banner")).toBeNull();
@@ -126,7 +158,7 @@ describe("renderApp — owner tier empty", () => {
   it('renders the reminder-list empty state "No reminders."', () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null }, now),
     );
 
     const list = container.querySelector("#reminder-list");
@@ -142,7 +174,7 @@ describe("renderApp — owner tier empty", () => {
   it('renders the capacity empty state "No capacity data."', () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null }, now),
     );
 
     const empties = Array.from(container.querySelectorAll(".empty"));
@@ -153,7 +185,7 @@ describe("renderApp — owner tier empty", () => {
   it("renders the history-band empty states", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null }, now),
     );
 
     const empties = Array.from(container.querySelectorAll(".empty"));
@@ -168,10 +200,21 @@ describe("renderApp — owner tier empty", () => {
     expect(workerEmpty).not.toBeUndefined();
   });
 
+  it('renders the queue band empty state "No queue data." when queueMetrics is null', () => {
+    const container = document.createElement("div");
+    withThemeFg(() =>
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null }, now),
+    );
+
+    const empties = Array.from(container.querySelectorAll(".empty"));
+    const queueEmpty = empties.find((el) => el.textContent === "No queue data.");
+    expect(queueEmpty).not.toBeUndefined();
+  });
+
   it("does not render an .error element", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null }, now),
     );
 
     expect(container.querySelector(".error")).toBeNull();
@@ -201,6 +244,13 @@ describe("renderApp — error tier", () => {
     renderApp(container, { tier: "error" }, now);
 
     expect(container.querySelector(".capacity-heading")).toBeNull();
+  });
+
+  it("does not render the queue heading", () => {
+    const container = document.createElement("div");
+    renderApp(container, { tier: "error" }, now);
+
+    expect(container.querySelector(".queue-heading")).toBeNull();
   });
 });
 

--- a/office-hours/test/queue-band.test.ts
+++ b/office-hours/test/queue-band.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { renderQueueBand } from "../src/queue-band.js";
+import type { QueueMetricsSnapshot } from "../src/queue-metrics.js";
+
+const baseMetrics: QueueMetricsSnapshot = {
+  openHelpWanted: 12,
+  closedPerDay: 1.5,
+  createdPerDay: 1.0,
+  netDrainPerDay: 0.5,
+  runwayDays: 24,
+  windowDays: 14,
+  computedAt: new Date("2026-06-07T10:00:00Z"),
+  groupId: "g",
+  memberEmails: ["x@y"],
+};
+
+const make = (o: Partial<QueueMetricsSnapshot> = {}): QueueMetricsSnapshot => ({
+  ...baseMetrics,
+  ...o,
+});
+
+describe("renderQueueBand cards", () => {
+  it("renders three cards with the backlog/closed/created values in order", () => {
+    const section = renderQueueBand(make());
+
+    const values = section.querySelectorAll(".queue-card-value");
+    expect(values).toHaveLength(3);
+    expect(values[0].textContent).toBe("12");
+    expect(values[1].textContent).toBe("1.5");
+    expect(values[2].textContent).toBe("1.0");
+  });
+});
+
+describe("renderQueueBand runway readout", () => {
+  it("draining: positive runway renders the days-until-empty phrase", () => {
+    const section = renderQueueBand(make());
+
+    const state = section.querySelector(".queue-runway-state");
+    expect(state).not.toBeNull();
+    expect(state!.textContent).toBe("~24 days until the queue empties");
+    expect(state!.classList.contains("draining")).toBe(true);
+  });
+
+  it("ceil rounding: a fractional runway rounds up to ~1 days", () => {
+    const section = renderQueueBand(make({ runwayDays: 0.6 }));
+
+    const state = section.querySelector(".queue-runway-state");
+    expect(state!.textContent).toContain("~1 days");
+  });
+
+  it("stable: null runway with zero net drain reads 'queue stable'", () => {
+    const section = renderQueueBand(make({ runwayDays: null, netDrainPerDay: 0 }));
+
+    const state = section.querySelector(".queue-runway-state");
+    expect(state!.textContent).toBe("queue stable");
+    expect(state!.classList.contains("stable")).toBe(true);
+  });
+
+  it("growing: null runway with negative net drain reads 'queue growing'", () => {
+    const section = renderQueueBand(make({ runwayDays: null, netDrainPerDay: -0.5 }));
+
+    const state = section.querySelector(".queue-runway-state");
+    expect(state!.textContent).toBe("queue growing");
+    expect(state!.classList.contains("growing")).toBe(true);
+  });
+
+  it("empty queue wins over null runway: 'queue empty'", () => {
+    const section = renderQueueBand(
+      make({ openHelpWanted: 0, runwayDays: null, netDrainPerDay: 0 }),
+    );
+
+    const state = section.querySelector(".queue-runway-state");
+    expect(state!.textContent).toBe("queue empty");
+    expect(state!.classList.contains("empty")).toBe(true);
+  });
+
+  it("never renders Infinity, NaN, or a negative number for the null-runway fixtures", () => {
+    const fixtures = [
+      make({ runwayDays: null, netDrainPerDay: 0 }),
+      make({ runwayDays: null, netDrainPerDay: -0.5 }),
+      make({ openHelpWanted: 0, runwayDays: null, netDrainPerDay: 0 }),
+    ];
+
+    for (const fixture of fixtures) {
+      const section = renderQueueBand(fixture);
+      const text = section.textContent ?? "";
+      expect(/Infinity|NaN|-\d/.test(text)).toBe(false);
+    }
+  });
+});
+
+describe("renderQueueBand(null)", () => {
+  it("renders the empty placeholder and no queue cards", () => {
+    const section = renderQueueBand(null);
+
+    const empty = section.querySelector(".empty");
+    expect(empty).not.toBeNull();
+    expect(empty!.textContent).toBe("No queue data.");
+
+    const cards = section.querySelectorAll(".queue-card");
+    expect(cards).toHaveLength(0);
+  });
+});
+
+describe("renderQueueBand heading", () => {
+  it("renders the QUEUE heading", () => {
+    const section = renderQueueBand(make());
+
+    const heading = section.querySelector(".queue-heading");
+    expect(heading!.textContent).toBe("QUEUE");
+  });
+});


### PR DESCRIPTION
Closes #1183

## What

Adds a read-only **Queue status band** to the office-hours app, mirroring the
existing Capacity band. It renders the latest `dispatch-queue` metrics snapshot:
the live Firestore snapshot when authenticated (owner tier), or the bundled demo
seed when unauthenticated (demo tier). No slider/parameter UI.

The band shows three cards — `backlog` (open help-wanted count), `closed/day`,
and `created/day` — plus a runway verdict. The verdict is computed by a small
state machine designed so `∞`/negative/`NaN` are structurally impossible:

1. `openHelpWanted === 0` → **queue empty**
2. else `runwayDays !== null` → **~N days until the queue empties** (`Math.ceil`,
   so any positive runway rounds to ≥ 1)
3. else `netDrainPerDay === 0` → **queue stable**
4. else → **queue growing** (danger-colored)

Branching on `openHelpWanted` first, then `runwayDays`, then the sign of
`netDrainPerDay` is what disambiguates flat-vs-growing — `runwayDays` alone
cannot (it is null in both cases per the snapshot contract
`runwayDays !== null ⟺ netDrainPerDay > 0`).

## How it's split

- **Unit 1** — `src/queue-band.ts` (`renderQueueBand`), mirrored `.queue-*` CSS in
  `index.html`, and `test/queue-band.test.ts` (card values + every runway branch +
  the no-`∞`/negative/`NaN` guard + null placeholder).
- **Unit 2** — `getOwnerQueueMetrics` in `src/data.ts`: a single-doc `getDoc` fetch
  of `office-hours/{env}/metrics/dispatch-queue`, parsed via the existing
  `parseQueueMetrics`. Mirrors `getOwnerSamples`.
- **Unit 3** — wiring: required `queueMetrics` field on the owner `ViewState`, the
  `main.ts` `Promise.all` fetch, the `app-view.ts` render call (demo + owner),
  and updated `app-view` tests.

## Reuse / no-change notes

- The data plumbing already existed: `QueueMetricsSnapshot` + `parseQueueMetrics`
  (already unit-tested in `test/queue-metrics.test.ts`), `getDemoQueueMetrics()`,
  and the seed via `virtual:office-hours-queue-seed`.
- The Firestore read rule for `office-hours/{env}/metrics/dispatch-queue` already
  exists (`allow read if env=="demo" || request.auth.token.email in
  resource.data.memberEmails`) — **no rules change**, so the rules unit suite
  (which is not in CI) is unaffected.

## Why `getOwnerQueueMetrics` ships without a dedicated test

Established convention: the sibling Firestore wrappers `getOwnerSamples` /
`getOwnerReminders` are not unit-tested, no test mocks `getDoc`/`getDocs`, and the
only logic worth testing — `parseQueueMetrics` — is already covered in
`test/queue-metrics.test.ts`. Adding a `firebase/firestore` mock for one thin
wrapper would break convention for no coverage gain. If a reviewer wants more
coverage here, the right lever is another `parseQueueMetrics` case, not a `getDoc`
mock.

## Verification

- `npx vitest run --root office-hours` — 166 tests pass (new `queue-band.test.ts`
  + updated `app-view.test.ts`; existing suites unaffected).
- `npm run build --prefix office-hours` — typecheck clean; the required
  `queueMetrics` field confirms every owner-tier call site supplies it.
- `npm run lint --prefix office-hours` — clean (the band has no unused `now`
  param).
- Demo (unauthenticated) view renders the QUEUE band from the seed: backlog 12,
  closed/day 1.5, created/day 1.0, `~24 days until the queue empties`. No
  slider/parameter UI.
