### PR TITLE
Bound rate_limits.json telemetry at the budget/reseed boundary

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-reseed
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-schedule-reseed
@@ -221,11 +221,39 @@ for var in WEEKLY_USED FIVEH_USED; do
     echo "dispatch-schedule-reseed: $var has non-numeric value '${!var}'; treating as missing" >&2
     printf -v "$var" ""
   fi
+  # A used_percentage above 100 is physically impossible — reject to missing so
+  # the PRESENT guard drops the window (no CAND_*, no bad timer). 100 is a valid
+  # fully-used reading, so the bound is a strict `>`. awk (not bash `(( ))`)
+  # because *_USED is decimal-capable — `(( 100.5 > 100 ))` is a fatal
+  # arithmetic syntax error under set -e.
+  if [[ -n "${!var}" ]] && awk -v u="${!var}" 'BEGIN{ exit !(u + 0 > 100) }'; then
+    echo "dispatch-schedule-reseed: $var out of range (>100): '${!var}'; treating as missing" >&2
+    printf -v "$var" ""
+  fi
 done
 for var in WEEKLY_RESETS FIVEH_RESETS; do
   if [[ -n "${!var}" && ! "${!var}" =~ ^[0-9]+$ ]]; then
     echo "dispatch-schedule-reseed: $var has non-integer value '${!var}'; treating as missing" >&2
     printf -v "$var" ""
+  fi
+  # A resets_at beyond the window's physically-plausible horizon would arm a
+  # systemd-run reseed timer years out — a durable chain stall. Reject to
+  # missing so the PRESENT guard drops the window (no CAND_*, no bad timer).
+  # The bounds are hardcoded physical properties of the windows (not config
+  # knobs): a 7-day window cannot legitimately reset >8 days out, a 5-hour
+  # window cannot reset >6 hours out (each ~1 unit of margin). bash `(( ))` is
+  # safe here because *_RESETS are integer-validated just above (unlike
+  # target-workers, where the same fields are decimal and the bound needs awk);
+  # NOW is a guaranteed integer (the script exits 2 on a bad NOW above).
+  if [[ -n "${!var}" ]]; then
+    case "$var" in
+      WEEKLY_RESETS) horizon=$(( NOW + 691200 )) ;;  # 8 days
+      FIVEH_RESETS)  horizon=$(( NOW + 21600 ))  ;;  # 6 hours
+    esac
+    if (( ${!var} > horizon )); then
+      echo "dispatch-schedule-reseed: $var '${!var}' beyond plausible future horizon ($horizon); treating as missing" >&2
+      printf -v "$var" ""
+    fi
   fi
 done
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
@@ -293,6 +293,15 @@ for var in WEEKLY_USED FIVEH_USED; do
     echo "dispatch-target-workers: $var has non-numeric value '${!var}'; treating as missing" >&2
     printf -v "$var" ""
   fi
+  # A used_percentage above 100 is physically impossible — reject it to missing
+  # so the PRESENT check routes it to the fail-closed fallback rather than acting
+  # on a poisoned value. 100 is a valid fully-used reading, so the bound is a
+  # strict `>`. awk (not bash `(( ))`) because the value may be a decimal —
+  # `(( 100.5 > 100 ))` is a fatal arithmetic syntax error under set -e.
+  if [[ -n "${!var}" ]] && awk -v u="${!var}" 'BEGIN{ exit !(u + 0 > 100) }'; then
+    echo "dispatch-target-workers: $var out of range (>100): '${!var}'; treating as missing" >&2
+    printf -v "$var" ""
+  fi
 done
 
 # Sanitize the weekly anchor inputs the curve depends on. `now` must be an
@@ -305,6 +314,17 @@ if [[ ! "$NOW" =~ ^[0-9]+$ ]]; then
 fi
 if [[ -n "$WEEKLY_RESETS" && ! "$WEEKLY_RESETS" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
   echo "dispatch-target-workers: WEEKLY_RESETS has non-numeric value '$WEEKLY_RESETS'; treating as missing" >&2
+  WEEKLY_RESETS=""
+fi
+# A weekly reset more than 8 days out is physically impossible for a 7-day
+# window (8 days = ~1 day margin over the nominal 7) — a hardcoded property of
+# the window, not a config knob. Reject to missing → weekly anchor drops →
+# fallback 1. Guard on both being non-empty (NOW may have been reset above;
+# WEEKLY_RESETS may have been emptied by the numeric check). awk (not bash
+# `(( ))`) because WEEKLY_RESETS may be a decimal.
+if [[ -n "$NOW" && -n "$WEEKLY_RESETS" ]] \
+   && awk -v r="$WEEKLY_RESETS" -v now="$NOW" 'BEGIN{ exit !(r + 0 > now + 691200) }'; then
+  echo "dispatch-target-workers: WEEKLY_RESETS '$WEEKLY_RESETS' more than 8 days past now ($NOW); treating as missing" >&2
   WEEKLY_RESETS=""
 fi
 
@@ -335,6 +355,17 @@ if [[ "$MODE" == "exhausted" ]]; then
   if [[ -z "$NOW" ]]; then
     echo ok
     exit 0
+  fi
+  # A 5h reset more than 6 hours out is physically impossible for a 5-hour
+  # window (6h = ~1h margin) — a hardcoded window property, not a config knob.
+  # Reject → that window cannot be "exhausted" (fail open, consistent with this
+  # mode's fail-open-on-invalid posture). This bound lives ONLY in exhausted
+  # mode — count/reopen never read the 5h reset. awk (not bash `(( ))`) because
+  # FIVEH_RESETS may be a decimal; NOW is guaranteed non-empty here.
+  if [[ -n "$FIVEH_RESETS" ]] \
+     && awk -v r="$FIVEH_RESETS" -v now="$NOW" 'BEGIN{ exit !(r + 0 > now + 21600) }'; then
+    echo "dispatch-target-workers: FIVEH_RESETS '$FIVEH_RESETS' more than 6 hours past now ($NOW); treating as missing" >&2
+    FIVEH_RESETS=""
   fi
   awk -v now="$NOW" \
       -v used_weekly="$WEEKLY_USED" -v resets_weekly="$WEEKLY_RESETS" \

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
@@ -311,23 +311,31 @@ fi
 [[ -n "${DISPATCH_TARGET_WORKERS_USED_5H:-}" ]] && FIVEH_USED="$DISPATCH_TARGET_WORKERS_USED_5H"
 [[ -n "${DISPATCH_TARGET_WORKERS_RESETS_AT_5H:-}" ]] && FIVEH_RESETS="$DISPATCH_TARGET_WORKERS_RESETS_AT_5H"
 
-# Sanitize `used_*` telemetry fail-closed before it reaches `awk -v`. awk
-# coerces a non-numeric value to 0, which would read as "no usage yet" and
-# spawn aggressively — a corrupt or tampered rate_limits.json (or a hostile env
-# override) would thus dodge the budget instead of backing off. Treat any
-# malformed value as missing so the PRESENT check below routes it to the
-# conservative missing-telemetry fallback, matching dispatch-schedule-reseed's
-# fail-closed posture on the same telemetry.
+# Sanitize `used_*` telemetry before it reaches `awk -v`. awk coerces a
+# non-numeric value to 0, which would read as "no usage yet"; treat any malformed
+# value as missing so the PRESENT check below routes it to that field's fallback.
+#
+# The two fields then have OPPOSITE fallback semantics, and that is deliberate:
+#   - WEEKLY_USED is the budget gate. Missing → the weekly anchor drops → Step 2
+#     fails closed to N=1 (count) / `none` (reopen). Losing the real budget guard
+#     must back off, matching dispatch-schedule-reseed's fail-closed posture.
+#   - FIVEH_USED is only the anti-burst ramp WITHIN the weekly budget. Missing →
+#     FIVEH_PRESENT=0 → FIVEH_USED_FOR_AWK=0 → full 5h headroom → N falls back to
+#     the WEEKLY-allowed count (fail open). This is safe: the weekly gate still
+#     bounds N, so a corrupt/absent 5h reading can only lose smoothing, never
+#     blow the budget. So 5h does NOT back off to zero on a bad value.
 for var in WEEKLY_USED FIVEH_USED; do
   if [[ -n "${!var}" && ! "${!var}" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
     echo "dispatch-target-workers: $var has non-numeric value '${!var}'; treating as missing" >&2
     printf -v "$var" ""
   fi
   # A used_percentage above 100 is physically impossible — reject it to missing
-  # so the PRESENT check routes it to the fail-closed fallback rather than acting
-  # on a poisoned value. 100 is a valid fully-used reading, so the bound is a
-  # strict `>`. awk (not bash `(( ))`) because the value may be a decimal —
-  # `(( 100.5 > 100 ))` is a fatal arithmetic syntax error under set -e.
+  # so the PRESENT check routes it to this field's fallback (per the per-var
+  # semantics above: WEEKLY_USED fails closed to N=1; FIVEH_USED fails open to the
+  # weekly-bounded count) rather than acting on a poisoned value. 100 is a valid
+  # fully-used reading, so the bound is a strict `>`. awk (not bash `(( ))`)
+  # because the value may be a decimal — `(( 100.5 > 100 ))` is a fatal
+  # arithmetic syntax error under set -e.
   if [[ -n "${!var}" ]] && awk -v u="${!var}" 'BEGIN{ exit !(u + 0 > 100) }'; then
     echo "dispatch-target-workers: $var out of range (>100): '${!var}'; treating as missing" >&2
     printf -v "$var" ""
@@ -354,7 +362,7 @@ fi
 # `(( ))`) because WEEKLY_RESETS may be a decimal.
 if [[ -n "$NOW" && -n "$WEEKLY_RESETS" ]] \
    && awk -v r="$WEEKLY_RESETS" -v now="$NOW" 'BEGIN{ exit !(r + 0 > now + 691200) }'; then
-  echo "dispatch-target-workers: WEEKLY_RESETS '$WEEKLY_RESETS' more than 8 days past now ($NOW); treating as missing" >&2
+  echo "dispatch-target-workers: WEEKLY_RESETS '$WEEKLY_RESETS' more than 8 days out from now ($NOW); treating as missing" >&2
   WEEKLY_RESETS=""
 fi
 
@@ -394,7 +402,7 @@ if [[ "$MODE" == "exhausted" ]]; then
   # FIVEH_RESETS may be a decimal; NOW is guaranteed non-empty here.
   if [[ -n "$FIVEH_RESETS" ]] \
      && awk -v r="$FIVEH_RESETS" -v now="$NOW" 'BEGIN{ exit !(r + 0 > now + 21600) }'; then
-    echo "dispatch-target-workers: FIVEH_RESETS '$FIVEH_RESETS' more than 6 hours past now ($NOW); treating as missing" >&2
+    echo "dispatch-target-workers: FIVEH_RESETS '$FIVEH_RESETS' more than 6 hours out from now ($NOW); treating as missing" >&2
     FIVEH_RESETS=""
   fi
   awk -v now="$NOW" \

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -11371,6 +11371,13 @@ export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 write_rl "exh.json" 30 $((TW_NOW + 302400)) 99 $((TW_NOW + 999999999))
 out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" --exhausted 2>"$TMPDIR_TEST/stderr")
 assert_eq "#1136 --exhausted 5h resets far-future → ok (fail open)" "ok" "$out"
+TOTAL=$((TOTAL + 1))
+if grep -q "FIVEH_RESETS" "$TMPDIR_TEST/stderr"; then
+  PASS=$((PASS + 1)); echo "  PASS: #1136 --exhausted 5h resets far-future stderr names FIVEH_RESETS"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1136 --exhausted 5h resets far-future stderr should name FIVEH_RESETS"
+  echo "    stderr: $(cat "$TMPDIR_TEST/stderr")"
+fi
 tw_teardown
 
 # ============================================================================
@@ -12175,6 +12182,50 @@ if [[ "$log" == *"--on-calendar=@$reset"* ]]; then
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: #1136 in-bound weekly reset should arm timer at $reset"
   echo "    log: $log"
+fi
+sr_teardown
+
+# used_5h=150 (>100) → rejected → 5h window drops. Weekly absent → both windows
+# missing → missing-telemetry no-op: NO systemd-run call. Without the FIVEH_USED
+# >100 bound the rejected value would survive (used_5h=150 >= target_5h=50 →
+# CAND_5H armed at the 5h reset), so empty systemd-log discriminates.
+echo "Test: #1136 used_5h=150 (>100) → window drops → no reseed timer"
+sr_setup
+export DISPATCH_SCHEDULE_RESEED_NOW=1700000000
+sr_write_rl "rl.json" absent absent 150 $((1700000000 + 3600))
+out=$("$TMPDIR_TEST/scripts/dispatch-schedule-reseed" 2>"$TMPDIR_TEST/stderr")
+TOTAL=$((TOTAL + 1))
+if [[ ! -s "$TMPDIR_TEST/systemd-log" ]] && grep -q "FIVEH_USED out of range" "$TMPDIR_TEST/stderr"; then
+  PASS=$((PASS + 1)); echo "  PASS: #1136 used_5h=150 → no timer + FIVEH_USED diagnostic"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1136 used_5h=150 → expected no timer + diagnostic"
+  echo "    systemd-log: $(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null)"
+  echo "    stderr: $(cat "$TMPDIR_TEST/stderr")"
+fi
+sr_teardown
+
+# 5h cap hit but resets_at is 7h out (>6h horizon) → rejected → 5h window drops.
+# Weekly cap hit with an in-bound (5d) reset → timer must arm at the WEEKLY
+# reset. The 5h reset (NOW+25200) is earlier than the weekly reset (NOW+432000),
+# so without the FIVEH_RESETS horizon bound the rejected 5h value would survive
+# (CAND_5H armed) and step 4's earliest-reset pick would arm at the 5h epoch
+# instead — the weekly-not-5h assertion discriminates the regression.
+echo "Test: #1136 5h resets far-future (>6h) → dropped → timer at weekly reset"
+sr_setup
+export DISPATCH_SCHEDULE_RESEED_NOW=1700000000
+weekly_reset=$((1700000000 + 432000))   # 5 days out, in-bound under 8-day horizon
+sr_write_rl "rl.json" 95 "$weekly_reset" 60 $((1700000000 + 25200))  # 5h reset 7h out → rejected
+out=$("$TMPDIR_TEST/scripts/dispatch-schedule-reseed" 2>"$TMPDIR_TEST/stderr")
+assert_eq "#1136 5h resets far-future → timer at weekly reset" \
+  "scheduled dispatch-reseed-$weekly_reset at $weekly_reset" "$out"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$log" == *"--on-calendar=@$weekly_reset"* ]] && grep -q "FIVEH_RESETS" "$TMPDIR_TEST/stderr"; then
+  PASS=$((PASS + 1)); echo "  PASS: #1136 5h resets far-future → armed at weekly $weekly_reset + FIVEH_RESETS diagnostic"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1136 5h resets far-future → expected timer at weekly $weekly_reset + diagnostic"
+  echo "    log: $log"
+  echo "    stderr: $(cat "$TMPDIR_TEST/stderr")"
 fi
 sr_teardown
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -10786,6 +10786,99 @@ result=$("$TMPDIR_TEST/scripts/dispatch-target-workers" --reopen-at 2>/dev/null)
 assert_eq "--reopen-at missing anchor → none" "none" "$result"
 tw_teardown
 
+# --- #1136: rate_limits.json telemetry range bounds -------------------------
+#
+# Out-of-range telemetry (used_percentage > 100, or a reset epoch beyond the
+# window's physically-plausible horizon) is rejected to missing so the existing
+# PRESENT guards route it to the established fail-safe, rather than acting on a
+# poisoned value. See issue #1136.
+
+# used_weekly=150 (>100) → rejected → weekly anchor drops → fallback N=1 (NOT 0).
+# This is the literal bug: an un-bounded used>100 yields negative headroom and
+# pins the target at 0; the bound restores the conservative spawn-1 fallback.
+echo "Test: #1136 used_weekly=150 (>100) → rejected → fallback N=1"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+r=$(tw_resets_for_x 0.5)
+write_rl "rl.json" 150 "$r" 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>"$TMPDIR_TEST/stderr")
+assert_eq "#1136 used_weekly=150 → fallback 1 (not 0)" "1" "$out"
+TOTAL=$((TOTAL + 1))
+if grep -q "WEEKLY_USED out of range" "$TMPDIR_TEST/stderr"; then
+  PASS=$((PASS + 1)); echo "  PASS: #1136 used_weekly=150 stderr names WEEKLY_USED out of range"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1136 used_weekly=150 stderr should name WEEKLY_USED out of range"
+  echo "    stderr: $(cat "$TMPDIR_TEST/stderr")"
+fi
+tw_teardown
+
+# used_weekly=100 is a valid fully-used reading and must be KEPT (strict `>`
+# bound). Consumed → the curve runs: at x=0.5, W=31, used=100 >> pace → gate
+# closed → N=0. A rejected value would instead drop the anchor → fallback N=1,
+# so N=0 discriminates "consumed" from "rejected".
+echo "Test: #1136 used_weekly=100 (boundary) → kept, curve runs → N=0"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+r=$(tw_resets_for_x 0.5)
+write_rl "rl.json" 100 "$r" 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>"$TMPDIR_TEST/stderr")
+assert_eq "#1136 used_weekly=100 kept (curve runs) → N=0" "0" "$out"
+TOTAL=$((TOTAL + 1))
+if grep -q "out of range" "$TMPDIR_TEST/stderr"; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1136 used_weekly=100 must NOT be rejected (strict >)"
+  echo "    stderr: $(cat "$TMPDIR_TEST/stderr")"
+else
+  PASS=$((PASS + 1)); echo "  PASS: #1136 used_weekly=100 not rejected (strict >)"
+fi
+tw_teardown
+
+# used_5h=150 (>100) → rejected → 5h treated as 0 in the ramp → max 5h workers.
+# DOCUMENTED INTENDED fail-open: the issue chooses "do not act on the poisoned
+# value", and the weekly pace gate still bounds N. With the weekly gate open
+# (used_weekly under pace), N>=1.
+echo "Test: #1136 used_5h=150 (>100) → rejected → fail-open under open weekly gate → N>=1"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+r=$(tw_resets_for_x 0.5)
+write_rl "rl.json" 0 "$r" 150 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>"$TMPDIR_TEST/stderr")
+TOTAL=$((TOTAL + 1))
+if (( out >= 1 )); then
+  PASS=$((PASS + 1)); echo "  PASS: #1136 used_5h=150 rejected, weekly open → N=$out (>=1, intended fail-open)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1136 used_5h=150 expected N>=1, got $out"
+fi
+tw_teardown
+
+# weekly resets_at = NOW + 999999999 (far future, >8 days) → rejected → weekly
+# anchor drops → fallback N=1. A far-future weekly reset can no longer feed the
+# curve.
+echo "Test: #1136 weekly resets_at far-future (>8d) → rejected → fallback N=1"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+write_rl "rl.json" 30 $((TW_NOW + 999999999)) 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>"$TMPDIR_TEST/stderr")
+assert_eq "#1136 weekly resets far-future → fallback 1" "1" "$out"
+TOTAL=$((TOTAL + 1))
+if grep -q "WEEKLY_RESETS" "$TMPDIR_TEST/stderr"; then
+  PASS=$((PASS + 1)); echo "  PASS: #1136 weekly resets far-future stderr names WEEKLY_RESETS"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1136 weekly resets far-future stderr should name WEEKLY_RESETS"
+  echo "    stderr: $(cat "$TMPDIR_TEST/stderr")"
+fi
+tw_teardown
+
+# exhausted mode: 5h resets_at = NOW + 999999999 (far future, >6h) with
+# used_5h=99 (>=threshold) → 5h reset rejected → window cannot be exhausted → ok
+# (fail open). Weekly is benign (low usage, in-bound reset).
+echo "Test: #1136 --exhausted 5h resets far-future (>6h) → rejected → ok (fail open)"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+write_rl "exh.json" 30 $((TW_NOW + 302400)) 99 $((TW_NOW + 999999999))
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" --exhausted 2>"$TMPDIR_TEST/stderr")
+assert_eq "#1136 --exhausted 5h resets far-future → ok (fail open)" "ok" "$out"
+tw_teardown
+
 # ============================================================================
 # dispatch-schedule-reseed tests
 # ============================================================================
@@ -11527,6 +11620,67 @@ if grep -q "unexpected result" "$TMPDIR_TEST/stderr"; then
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: reopen=<unexpected>; stderr diagnostic emitted"
   echo "    stderr: $(cat "$TMPDIR_TEST/stderr")"
+fi
+sr_teardown
+
+# --- #1136: rate_limits.json telemetry range bounds -------------------------
+#
+# Far-future resets_at and used>100 are rejected to missing so the script no-ops
+# (the established missing-telemetry fail-safe) instead of arming a reseed timer
+# years out. This is the durable-stall fix. See issue #1136.
+
+# weekly cap hit but resets_at is ~31 years out (>8d) → rejected → weekly window
+# drops → (5h absent) → missing-telemetry no-op: NO systemd-run call.
+echo "Test: #1136 weekly resets far-future (>8d) → no reseed timer armed"
+sr_setup
+export DISPATCH_SCHEDULE_RESEED_NOW=1700000000
+sr_write_rl "rl.json" 95 $((1700000000 + 999999999)) absent absent
+out=$("$TMPDIR_TEST/scripts/dispatch-schedule-reseed" 2>"$TMPDIR_TEST/stderr")
+TOTAL=$((TOTAL + 1))
+if [[ ! -s "$TMPDIR_TEST/systemd-log" ]] && grep -q "WEEKLY_RESETS" "$TMPDIR_TEST/stderr"; then
+  PASS=$((PASS + 1)); echo "  PASS: #1136 weekly resets far-future → empty systemd-log + WEEKLY_RESETS diagnostic"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1136 weekly resets far-future → expected no timer + diagnostic"
+  echo "    systemd-log: $(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null)"
+  echo "    stderr: $(cat "$TMPDIR_TEST/stderr")"
+fi
+sr_teardown
+
+# used_weekly=150 (>100) → rejected → weekly window drops → (5h absent) → no-op,
+# no weekly reseed timer.
+echo "Test: #1136 used_weekly=150 (>100) → window drops → no reseed timer"
+sr_setup
+export DISPATCH_SCHEDULE_RESEED_NOW=1700000000
+sr_write_rl "rl.json" 150 $((1700000000 + 10000)) absent absent
+out=$("$TMPDIR_TEST/scripts/dispatch-schedule-reseed" 2>"$TMPDIR_TEST/stderr")
+TOTAL=$((TOTAL + 1))
+if [[ ! -s "$TMPDIR_TEST/systemd-log" ]] && grep -q "WEEKLY_USED out of range" "$TMPDIR_TEST/stderr"; then
+  PASS=$((PASS + 1)); echo "  PASS: #1136 used_weekly=150 → no timer + WEEKLY_USED diagnostic"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1136 used_weekly=150 → expected no timer + diagnostic"
+  echo "    systemd-log: $(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null)"
+  echo "    stderr: $(cat "$TMPDIR_TEST/stderr")"
+fi
+sr_teardown
+
+# In-bound control (guards against over-rejection): a realistically-large NOW
+# with a weekly reset ~3 days out (well within the 8-day bound) and a weekly cap
+# hit still schedules normally.
+echo "Test: #1136 in-bound weekly reset (~3d out) still schedules (no over-rejection)"
+sr_setup
+export DISPATCH_SCHEDULE_RESEED_NOW=1700000000
+reset=$((1700000000 + 3 * 86400))
+sr_write_rl "rl.json" 95 "$reset" absent absent
+out=$("$TMPDIR_TEST/scripts/dispatch-schedule-reseed" 2>/dev/null)
+assert_eq "#1136 in-bound weekly reset still schedules" \
+  "scheduled dispatch-reseed-$reset at $reset" "$out"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$log" == *"--on-calendar=@$reset"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #1136 in-bound weekly reset armed --on-calendar=@$reset"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1136 in-bound weekly reset should arm timer at $reset"
+  echo "    log: $log"
 fi
 sr_teardown
 


### PR DESCRIPTION
Closes #1136

## Problem

Two dispatch consumers read `rate_limits.json` (`used_percentage` / `resets_at`
for the `seven_day` and `five_hour` windows) and act on the values without
range-checking them. Two concrete stalls result:

- `used_percentage > 100` (malformed) → negative headroom → `dispatch-target-workers`
  pins the worker target at 0 → workers never spawn.
- A far-future `resets_at` → `dispatch-schedule-reseed` arms a
  `systemd-run --on-calendar=@<epoch>` reseed timer years out → durable chain
  stall. The past case was already clamped; the future case was not (same
  self-resume failure class as the frozen-past case fixed in #1127).

## Approach: reject, not clamp

Out-of-range values are set to empty, reusing the exact idiom the existing
non-numeric sanitization loops already use, so the established
`WEEKLY_PRESENT` / `FIVEH_PRESENT` guards route them to the missing-telemetry
fail-safe ("keep prior valid state, log, do not act"). Clamping is rejected
because clamping `weekly_used` to 100 still yields headroom ≈ 0 → target 0 → does
**not** fix the stall; only reject → missing → fallback fixes it.

Bounds are hardcoded constants with explanatory comments, not config tunables —
they are physical properties of the rate-limit windows:

- `used_percentage`: reject if `> 100` (strict `>`; 100 is a valid fully-used
  value and is kept).
- weekly `resets_at` (7-day window): reject if `> now + 8 days`.
- 5h `resets_at` (5-hour window): reject if `> now + 6 hours`.

Lower bounds come for free — the existing numeric regexes already forbid a
leading `-`.

## Changes

- **`dispatch-target-workers`** — extend the existing `used_*` sanitization loop
  with the `> 100` reject; add the weekly-`resets_at` future bound after the
  weekly numeric check; add the 5h-`resets_at` future bound **inside exhausted
  mode only** (count/reopen never read the 5h reset, preserving the suite's
  `99999999` 5h sentinel). All comparisons use `awk` (never bash `(( ))`) because
  the fields are decimal-capable — a bash arithmetic compare on `100.5` would
  abort the script under `set -euo pipefail`. The weekly future bound is guarded
  on a non-empty `NOW`.
- **`dispatch-schedule-reseed`** — extend the existing `*_USED` loop with the
  `> 100` reject (awk, decimal) and the `*_RESETS` loop with per-window future
  bounds. Here `*_RESETS` are integer-validated just above, so bash `(( ))` is
  safe (and `NOW` is a guaranteed integer — the script `exit 2`s on a bad `NOW`).
- **`test-dispatch-scripts.sh`** — 8 new tests across both consumers: the literal
  `used_weekly=150 → N=1` bug, the `used=100` strict-`>` boundary, the documented
  `used_5h=150` fail-open, the weekly far-future-reset fallback, the
  exhausted-mode 5h far-future fail-open, the schedule-reseed no-timer cases, and
  an in-bound control guarding against over-rejection.

The writer (`update-rate-limits.sh`) is intentionally left untouched: write-time
clamping would mask the poison the consumers fail-safe on, defeating the
reject-to-missing design.

## Verification

Full `test-dispatch-scripts.sh` suite green (2616/2616), run after each code unit
to confirm no regression before the tests existed.
