### PR TITLE
dispatch: strip backslashes from systemd unit PATH; reject backslash worktree/binary paths

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -968,6 +968,13 @@ ensure_recover_unit() {
     echo "WARNING: ensure_recover_unit: main worktree path contains a double-quote; refusing to write unit; OnFailure recovery unavailable" >&2
     return 1
   fi
+  # ExecStart= is double-quoted and systemd C-unescapes it, so a backslash in
+  # the path would be misread as an escape sequence and corrupt the executable
+  # token. The path never legitimately contains a backslash; reject it (#1212).
+  if [[ "$main_worktree" == *'\'* ]]; then
+    echo "WARNING: ensure_recover_unit: main worktree path contains a backslash; refusing to write unit; OnFailure recovery unavailable" >&2
+    return 1
+  fi
 
   local RECOVER_SCRIPT="$main_worktree/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover"
   local UNIT_DIR="${DISPATCH_RECOVER_UNIT_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user}"
@@ -1090,6 +1097,14 @@ ensure_daemon_service() {
   # contains a double-quote; reject it rather than emit a malformed unit.
   if [[ "$CLAUDE_CMD" == *'"'* ]]; then
     echo "WARNING: ensure_daemon_service: claude path contains a double-quote; refusing to write unit; durable daemon service unavailable" >&2
+    return 1
+  fi
+  # ExecStart= is double-quoted and systemd C-unescapes it, so a backslash in
+  # the path would be misread as an escape sequence and corrupt the executable
+  # token. The resolved binary path never legitimately contains a backslash;
+  # reject it (#1212).
+  if [[ "$CLAUDE_CMD" == *'\'* ]]; then
+    echo "WARNING: ensure_daemon_service: claude path contains a backslash; refusing to write unit; durable daemon service unavailable" >&2
     return 1
   fi
 

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -913,6 +913,22 @@ print_remote_access_block() {
   echo ""
 }
 
+# Sanitize a captured PATH for interpolation into a systemd
+# Environment="PATH=..." line. Three distinct hazards, three reasons:
+#   - newline: a unit file is line-structured, so an embedded newline would
+#     land as a stray [Service] directive.
+#   - double-quote: the Environment= value is double-quoted, so an embedded
+#     quote would prematurely terminate it, leaving a bare token as a stray
+#     directive.
+#   - backslash: systemd applies C-style unescaping to Environment= (and
+#     ExecStart=) values, so a backslash is misread as an escape sequence and
+#     silently corrupts the PATH (#1212).
+# None of the three is ever a valid character in a PATH component, so
+# dropping them is safe.
+strip_unit_env_path() {
+  printf '%s' "${1//[$'\n'\"\\]/}"
+}
+
 # Install the static `dispatch-tick-recover.service` unit file so the tick and
 # reseed launchers can attach `OnFailure=dispatch-tick-recover.service`.
 # OnFailure= references a LOADABLE unit file, not a script — and dispatch
@@ -958,13 +974,9 @@ ensure_recover_unit() {
   local UNIT_PATH="$UNIT_DIR/dispatch-tick-recover.service"
   local SYSTEMCTL_CMD="${DISPATCH_RECOVER_SYSTEMCTL_CMD:-systemctl}"
 
-  # Strip any stray newline OR double-quote from the captured PATH for the same
-  # line-structure reason; a newline in PATH is a broken environment, and a
-  # double-quote would prematurely terminate the double-quoted Environment=
-  # value, leaving an attacker-controlled bare token as a stray [Service]
-  # directive. Neither is ever a valid character in a PATH component, so
-  # dropping them is safe (#1207).
-  local safe_path="${PATH//[$'\n'\"]/}"
+  # Sanitize PATH for the Environment= line (see strip_unit_env_path).
+  local safe_path
+  safe_path=$(strip_unit_env_path "$PATH")
 
   # Environment=PATH=... captures the launching caller's PATH at write time,
   # for the same reason dispatch-spawn-tick passes --setenv=PATH: the systemd
@@ -1081,13 +1093,9 @@ ensure_daemon_service() {
     return 1
   fi
 
-  # Strip any stray newline OR double-quote from the captured PATH for the same
-  # line-structure reason; a newline in PATH is a broken environment, and a
-  # double-quote would prematurely terminate the double-quoted Environment=
-  # value, leaving an attacker-controlled bare token as a stray [Service]
-  # directive. Neither is ever a valid character in a PATH component, so
-  # dropping them is safe (#1207).
-  local safe_path="${PATH//[$'\n'\"]/}"
+  # Sanitize PATH for the Environment= line (see strip_unit_env_path).
+  local safe_path
+  safe_path=$(strip_unit_env_path "$PATH")
 
   local UNIT_DIR="${DISPATCH_DAEMON_UNIT_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user}"
   local UNIT_PATH="$UNIT_DIR/dispatch-claude-daemon.service"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -24638,6 +24638,87 @@ fi
 rm -rf "$eru3_tmp"
 
 # ============================================================================
+# ensure_recover_unit: PATH backslash is stripped from Environment= (#1212)
+# ============================================================================
+echo ""
+echo "=== ensure_recover_unit strips backslash from Environment= PATH ==="
+eru4_tmp=$(mktemp -d)
+mkdir -p "$eru4_tmp/bin"
+mkdir -p "$eru4_tmp/main-worktree"
+cat > "$eru4_tmp/bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$eru4_tmp/bin/systemctl"
+if (
+  export DISPATCH_RECOVER_UNIT_DIR="$eru4_tmp/systemd-user"
+  export DISPATCH_RECOVER_SYSTEMCTL_CMD="$eru4_tmp/bin/systemctl"
+  export PATH="/usr/bin:/mnt/c/win\\dows:$PATH"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_recover_unit "$eru4_tmp/main-worktree"
+); then
+  eru4_unit="$eru4_tmp/systemd-user/dispatch-tick-recover.service"
+  if eru4_env_line=$(grep '^Environment=' "$eru4_unit" 2>/dev/null); then
+    TOTAL=$((TOTAL + 1))
+    if [[ "$eru4_env_line" != *'\'* ]]; then
+      PASS=$((PASS + 1)); echo "  PASS: Environment= PATH has no backslash (stripped)"
+    else
+      FAIL=$((FAIL + 1)); echo "  FAIL: Environment= PATH still contains a backslash: $eru4_env_line"
+    fi
+    TOTAL=$((TOTAL + 1))
+    if [[ "$eru4_env_line" == 'Environment="PATH='* ]]; then
+      PASS=$((PASS + 1)); echo "  PASS: Environment= line is well-formed (PATH= prefix intact)"
+    else
+      FAIL=$((FAIL + 1)); echo "  FAIL: Environment= line is malformed: $eru4_env_line"
+    fi
+    TOTAL=$((TOTAL + 1))
+    if [[ "$eru4_env_line" == *'/mnt/c/windows'* ]]; then
+      PASS=$((PASS + 1)); echo "  PASS: backslash removal merged the path segment to /mnt/c/windows"
+    else
+      FAIL=$((FAIL + 1)); echo "  FAIL: /mnt/c/windows not found in Environment= line: $eru4_env_line"
+    fi
+  else
+    TOTAL=$((TOTAL + 3)); FAIL=$((FAIL + 3))
+    echo "  FAIL: unit file missing or lacks Environment= line: $eru4_unit"
+  fi
+else
+  TOTAL=$((TOTAL + 3)); FAIL=$((FAIL + 3))
+  echo "  FAIL: ensure_recover_unit returned non-zero"
+fi
+rm -rf "$eru4_tmp"
+
+# ============================================================================
+# ensure_recover_unit: rejects a path containing a backslash (#1212)
+# ============================================================================
+echo ""
+echo "=== ensure_recover_unit rejects a path with a backslash ==="
+eru5_tmp=$(mktemp -d)
+mkdir -p "$eru5_tmp/bin"
+cat > "$eru5_tmp/bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$eru5_tmp/bin/systemctl"
+TOTAL=$((TOTAL + 1))
+if (
+  export DISPATCH_RECOVER_UNIT_DIR="$eru5_tmp/systemd-user"
+  export DISPATCH_RECOVER_SYSTEMCTL_CMD="$eru5_tmp/bin/systemctl"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_recover_unit "$eru5_tmp/has\\a\\backslash"
+); then
+  FAIL=$((FAIL + 1)); echo "  FAIL: ensure_recover_unit should have returned non-zero for a path with a backslash"
+else
+  PASS=$((PASS + 1)); echo "  PASS: ensure_recover_unit returned non-zero for a path with a backslash"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$eru5_tmp/systemd-user/dispatch-tick-recover.service" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: no unit file was written for a path with a backslash"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: unit file was written despite path containing a backslash"
+fi
+rm -rf "$eru5_tmp"
+
+# ============================================================================
 # ensure_daemon_service: durable daemon service install + attach paths (#1197)
 # ============================================================================
 echo ""
@@ -24898,6 +24979,63 @@ if [[ "$eds_rc2" -ne 0 ]]; then
   PASS=$((PASS + 1)); echo "  PASS: empty claude path → non-zero return"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: empty claude path returned zero"
+fi
+
+# --- 5. PATH backslash is stripped from daemon Environment= (#1212) ----------
+echo ""
+echo "=== ensure_daemon_service strips backslash from Environment= PATH ==="
+eds_path_strip_dir="$eds_tmp/path-strip-systemd-user"
+eds_path_strip_rc=0
+if (
+  export DISPATCH_DAEMON_UNIT_DIR="$eds_path_strip_dir"
+  export DISPATCH_DAEMON_SYSTEMCTL_CMD="$eds_tmp/bin/systemctl"
+  export DISPATCH_DAEMON_CLAUDE_CMD="$eds_claude"
+  export STUB_LOG="$eds_log"
+  export STUB_IS_ACTIVE_RC=0 STUB_ENABLE_RC=0 STUB_RELOAD_RC=0
+  export PATH="/usr/bin:/mnt/c/win\\dows:$PATH"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_daemon_service
+); then
+  eds_path_strip_unit="$eds_path_strip_dir/dispatch-claude-daemon.service"
+  if eds_path_env_line=$(grep '^Environment=' "$eds_path_strip_unit" 2>/dev/null); then
+    TOTAL=$((TOTAL + 1))
+    if [[ "$eds_path_env_line" != *'\'* ]]; then
+      PASS=$((PASS + 1)); echo "  PASS: daemon Environment= PATH has no backslash (stripped)"
+    else
+      FAIL=$((FAIL + 1)); echo "  FAIL: daemon Environment= PATH still contains a backslash: $eds_path_env_line"
+    fi
+  else
+    TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+    echo "  FAIL: daemon unit missing or lacks Environment= line: $eds_path_strip_unit"
+  fi
+else
+  TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+  echo "  FAIL: ensure_daemon_service returned non-zero (path-strip test)"
+fi
+
+# --- 6. ensure_daemon_service rejects a claude path with a backslash (#1212) -
+echo ""
+echo "=== ensure_daemon_service rejects a claude path with a backslash ==="
+eds_reject_rc=0
+(
+  export DISPATCH_DAEMON_UNIT_DIR="$eds_tmp/reject-systemd-user"
+  export DISPATCH_DAEMON_SYSTEMCTL_CMD="$eds_tmp/bin/systemctl"
+  export DISPATCH_DAEMON_CLAUDE_CMD="$eds_tmp/bin/cla\\ude"
+  export STUB_LOG="$eds_log"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_daemon_service
+) 2>/dev/null || eds_reject_rc=$?
+TOTAL=$((TOTAL + 1))
+if [[ "$eds_reject_rc" -ne 0 ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: ensure_daemon_service returned non-zero for a claude path with a backslash"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: ensure_daemon_service returned zero for a claude path with a backslash"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$eds_tmp/reject-systemd-user/dispatch-claude-daemon.service" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: no daemon unit written for a claude path with a backslash"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: daemon unit was written despite claude path containing a backslash"
 fi
 
 rm -rf "$eds_tmp"


### PR DESCRIPTION
Closes #1212

## What

`ensure_recover_unit` and `ensure_daemon_service` (both in
`.claude/skills/dispatch-propagate/scripts/lib.sh`) each build a systemd user
unit with an `Environment="PATH=$safe_path"` line and a double-quoted
`ExecStart=` token. systemd applies **C-style unescaping** to `Environment=` and
`ExecStart=` values, so a backslash in either the captured `PATH` or the
interpolated worktree/binary path is misread as the start of an escape sequence
and silently corrupts the unit — leaving `dispatch-tick-recover` or the durable
daemon unable to resolve its binaries.

Before this change, `safe_path` was derived identically at both sites as
`${PATH//[$'\n'\"]/}` — stripping newlines and double-quotes (#1207) but **not**
backslashes — and the `ExecStart=`-interpolated paths were rejected on
newline/space/double-quote but not backslash. This PR closes the backslash hole
on both fronts.

## Changes

- **Unit 1 — shared PATH sanitizer.** Extract a `strip_unit_env_path` helper
  that strips newline, double-quote, and backslash, and route both call sites
  through it. This is the second synchronized cross-site change to `safe_path`
  (the #1207 quote-strip was the first), so the two byte-identical inline
  derivations collapse onto one helper. The helper comment states each of the
  three mechanisms distinctly — backslash is C-escape corruption, not the
  line-structure hazard that motivates the newline/quote cases.

- **Unit 2 — reject backslashes in the `ExecStart=` paths.** Add a backslash
  reject-guard on `main_worktree` (recover unit) and on `CLAUDE_CMD` (daemon
  service), mirroring the existing double-quote guards. Deliberate asymmetry vs
  `PATH`: a stray char in `PATH` is **stripped** (a droppable component), while a
  backslash in a worktree/binary path is **rejected** — there it signals a broken
  environment, matching the existing guard pattern.

- **Unit 3 — tests.** There was previously **no** test asserting the
  `Environment=PATH=` strip at all. Add four: PATH-strip and backslash-reject
  cases for each of `ensure_recover_unit` and `ensure_daemon_service`, mirroring
  the existing stub-`systemctl` + tmp-unit-dir harnesses.

## Notes

Backslash in `PATH` is not a realistic concern on the current Linux/WSL
platform; the value here is machine-enforcing the invariant completely rather
than leaving a known-identical hole.

## Verification

`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` passes
(2612/2612), including the four new tests.
