### PR TITLE
dispatch-statements-scan: batch the parse-job existence lookup and add gh_retry backoff

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-statements-scan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-statements-scan
@@ -4,12 +4,21 @@
 #
 # Reads the local statements.json config (via dispatch-config-load) and, for
 # each statements entry, scans the configured directory for bank-statement
-# files. For each file it computes the file's sha256 and asks GitHub whether a
-# parse-job issue already carries that hash (open OR closed). If one exists the
-# file is skipped; otherwise a single parse-job issue is filed whose body names
-# only the filename and the sha256 — never the statement contents. The data
-# stays in the user's folder. No statements entry is hardcoded: the scan is
-# fully driven by config.
+# files. For each entry it issues ONE batched `gh issue list` against the core
+# API to fetch every parse-job issue under the label (open AND closed), then
+# seeds a local hash→issue map from their bodies and dedups every file in the
+# directory locally — no per-file Search-API call. For each file it computes the
+# file's sha256 and consults that map: if a parse-job issue already carries the
+# hash the file is skipped; otherwise a single parse-job issue is filed whose
+# body names only the filename and the sha256 — never the statement contents.
+# The bounded per-new-file `gh issue create` fan-out is wrapped in gh_retry
+# backoff. The data stays in the user's folder. No statements entry is
+# hardcoded: the scan is fully driven by config.
+#
+# Why batched: the prior design fired one rate-limited `gh search issues` query
+# per file against GitHub's Search API (~30 req/min). A cold scan over a large
+# statements folder exhausted that budget and aborted on a 429. The batched
+# `gh issue list` hits the core API (~5000 req/hr) once per entry instead.
 #
 # Idempotency is keyed on GitHub state (the content-hash dedup), NOT a side
 # file. The project-root state file is a per-machine debounce rate-limiter only.
@@ -23,13 +32,15 @@
 #      inert.
 #   3. Ensures the entry's label exists in its repo (idempotent).
 #   4. Enumerates the regular files directly in the directory (NON-RECURSIVE),
-#      filtered by extension (case-insensitive). For each file:
+#      filtered by extension (case-insensitive). Before the per-file loop it
+#      runs ONE `gh issue list` for all label issues (open and closed) and seeds
+#      a local hash→issue map from their bodies. For each file:
 #        a. Computes its sha256.
-#        b. Asks GitHub for an issue carrying that hash under the label (open or
-#           closed). If found, skips.
+#        b. Consults the seeded map (plus hashes filed earlier this run). If the
+#           hash is already covered by an existing or freshly filed issue, skips.
 #        c. Otherwise files one parse-job issue (filename + sha256 only), adds
 #           it to the entry's project, and records the hash so a byte-identical
-#           file later in the same run is deduped without a second search.
+#           file later in the same run is deduped locally.
 #   5. Records the last check time (debounce stamp).
 #
 # Usage:
@@ -63,6 +74,17 @@
 #                                  Default: <project-root>/tmp.
 #   DISPATCH_STATEMENTS_NOW        Override "now" as epoch seconds. Default:
 #                                  date +%s.
+#   DISPATCH_STATEMENTS_ISSUE_LIST_LIMIT  Override the per-entry gh issue list
+#                                  --limit (the batched existence-lookup cap).
+#                                  Default: 5000. A returned count equal to the
+#                                  limit is treated as a likely-truncated list
+#                                  and hard-errors the entry (dedup would be
+#                                  unsound). Tests set this low to reach the guard.
+#
+# Pagination over the list is a deliberate follow-up, not done here: the
+# truncation guard turns a silent dedup miss into a hard error but does not
+# paginate past the --limit. The hour-scale debounce keeps the per-entry issue
+# count well under the 5000 default, so the ceiling is unlikely to bite soon.
 #
 # Dependency: invokes the `gh` CLI directly. Per .claude/rules/sandbox.md the
 # caller (the /dispatch-propagate SKILL step) must wrap this script with
@@ -108,6 +130,13 @@ STATE_FILE="$STATE_DIR/dispatch-statements-state.json"
 
 # ---- Step 2: resolve "now" --------------------------------------------------
 NOW="${DISPATCH_STATEMENTS_NOW:-$(date +%s)}"
+
+# The per-entry `gh issue list --limit` for the batched existence lookup. A high
+# default since the dedup map must see EVERY existing label issue; overridable
+# (tests set it low to reach the truncation guard). NOTE: a returned count equal
+# to this limit hard-errors the entry rather than silently truncating the dedup
+# snapshot. Pagination past the limit is a deliberate follow-up (see header).
+ISSUE_LIST_LIMIT="${DISPATCH_STATEMENTS_ISSUE_LIST_LIMIT:-5000}"
 
 # ---- state-file helpers -----------------------------------------------------
 # The state file is a JSON object mapping <key> → last-check epoch (number).
@@ -256,12 +285,63 @@ for (( i = 0; i < STATEMENTS_COUNT; i++ )); do
     mapfile -d '' -t MATCHED < <(printf '%s\0' "${MATCHED[@]}" | sort -z)
   fi
 
-  # ---- 4f: per-file dedup-and-file ------------------------------------------
-  # SEEN_HASHES maps a content hash seen this run → the issue number that covers
-  # it (either freshly filed or an existing GitHub hit). A byte-identical file
-  # later in the same run is then deduped without a second gh search.
+  # SEEN_HASHES maps a content hash known to be covered → the issue number that
+  # covers it (a pre-seeded existing GitHub issue, or one freshly filed this
+  # run). Declared fresh per entry so prior-entry state never leaks. A
+  # byte-identical file is then deduped locally, with no per-file gh call.
+  # ENTRY_HARD_ERROR is set before the pre-fetch so the pre-fetch can mark the
+  # entry as hard-errored; the 4g stamp guard skips stamping when it is set.
   declare -A SEEN_HASHES=()
   ENTRY_HARD_ERROR=0
+
+  # ---- 4e′: batched existence lookup (ONE gh issue list per entry) ----------
+  # Fetch every parse-job issue under the label (open AND closed) in a single
+  # core-API call, then seed SEEN_HASHES from their bodies. This replaces the
+  # per-file Search-API query that exhausted the ~30 req/min Search budget on a
+  # cold scan of a large folder. Only run when there is at least one file to
+  # dedup. gh_retry wraps the call for transient-failure backoff; its retry
+  # lines go to stderr, so capture stderr to a tmpfile (never 2>&1 into the
+  # stdout we parse).
+  if [[ "${#MATCHED[@]}" -gt 0 ]]; then
+    tmpfile=$(mktemp)
+    out=$(gh_retry gh issue list --repo "$REPO" --label "$LABEL" --state all \
+      --limit "$ISSUE_LIST_LIMIT" --json number,body 2>"$tmpfile")
+    rc=$?
+    err=$(cat "$tmpfile"); rm -f "$tmpfile"
+    if [[ "$rc" -ne 0 ]]; then
+      echo "$KEY: error (gh issue list failed: $err)" >&2
+      HARD_ERROR=1
+      ENTRY_HARD_ERROR=1
+      continue
+    fi
+    if ! printf '%s' "$out" | jq -e . >/dev/null 2>&1; then
+      echo "$KEY: error (gh issue list returned non-JSON: $out)" >&2
+      HARD_ERROR=1
+      ENTRY_HARD_ERROR=1
+      continue
+    fi
+    len=$(printf '%s' "$out" | jq 'length')
+    if [[ "$len" -eq "$ISSUE_LIST_LIMIT" ]]; then
+      echo "$KEY: error (gh issue list returned exactly $ISSUE_LIST_LIMIT issues (the --limit) — the existing-issue snapshot is likely truncated and dedup is unsound. Raise DISPATCH_STATEMENTS_ISSUE_LIST_LIMIT.)" >&2
+      HARD_ERROR=1
+      ENTRY_HARD_ERROR=1
+      continue
+    fi
+    # Seed SEEN_HASHES from each issue body. The body carries the hash on a
+    # `- sha256: \`<64-hex>\`` line; `scan` extracts the first 64-hex run. Use
+    # `(.body // "")` so an empty-bodied (null) issue yields "" — which `scan`
+    # tolerates — rather than throwing and aborting the seed mid-stream. An
+    # unparseable body is an advisory to stderr, NOT a hard error.
+    while IFS=$'\t' read -r num hash; do
+      if [[ -n "$hash" ]]; then
+        SEEN_HASHES[$hash]="$num"
+      else
+        echo "$KEY: warning (issue #$num under label '$LABEL' has no parseable sha256 in body; skipping seed)" >&2
+      fi
+    done < <(printf '%s' "$out" | jq -r '.[] | [(.number|tostring), ([(.body // "") | scan("[0-9a-f]{64}")] | .[0] // "")] | @tsv')
+  fi
+
+  # ---- 4f: per-file dedup-and-file ------------------------------------------
   for file in "${MATCHED[@]}"; do
     [[ -n "$file" ]] || continue
     base="$(basename "$file")"
@@ -285,34 +365,12 @@ for (( i = 0; i < STATEMENTS_COUNT; i++ )); do
       continue
     fi
 
-    # In-run duplicate: a prior file this run had the same content.
+    # Dedup against the seeded map. SEEN_HASHES holds both pre-seeded existing
+    # GitHub issues (open or closed, from the 4e′ batched list) and hashes filed
+    # earlier this run — so this single check covers the existing-issue skip and
+    # the in-run byte-identical-file skip.
     if [[ -n "${SEEN_HASHES[$HASH]:-}" ]]; then
       echo "$KEY: skipped (#${SEEN_HASHES[$HASH]} for $base)"
-      continue
-    fi
-
-    # Query GitHub for an issue carrying this hash under the label. `gh search
-    # issues` searches open AND closed by default — satisfying the open-or-closed
-    # dedup requirement.
-    SEARCH_RC=0
-    SEARCH_JSON=$(gh search issues "$HASH" --repo "$REPO" --label "$LABEL" \
-      --limit 1 --json number,state 2>&1) || SEARCH_RC=$?
-    if [[ "$SEARCH_RC" -ne 0 ]]; then
-      echo "$KEY: error (gh search issues failed: $SEARCH_JSON)" >&2
-      HARD_ERROR=1
-      ENTRY_HARD_ERROR=1
-      break
-    fi
-    if ! printf '%s' "$SEARCH_JSON" | jq -e . >/dev/null 2>&1; then
-      echo "$KEY: error (gh search issues returned non-JSON: $SEARCH_JSON)" >&2
-      HARD_ERROR=1
-      ENTRY_HARD_ERROR=1
-      break
-    fi
-    HIT_NUM=$(printf '%s' "$SEARCH_JSON" | jq -r 'if length > 0 then .[0].number else empty end')
-    if [[ -n "$HIT_NUM" ]]; then
-      echo "$KEY: skipped (#$HIT_NUM for $base)"
-      SEEN_HASHES[$HASH]="$HIT_NUM"
       continue
     fi
 
@@ -324,11 +382,13 @@ for (( i = 0; i < STATEMENTS_COUNT; i++ )); do
 - File: \`$base\`
 - sha256: \`$HASH\`"
 
-    CREATE_RC=0
-    CREATE_OUT=$(gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY" \
-      --label "$LABEL" --label "help wanted" 2>&1) || CREATE_RC=$?
+    tmpfile=$(mktemp)
+    CREATE_OUT=$(gh_retry gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY" \
+      --label "$LABEL" --label "help wanted" 2>"$tmpfile")
+    CREATE_RC=$?
+    CREATE_ERR=$(cat "$tmpfile"); rm -f "$tmpfile"
     if [[ "$CREATE_RC" -ne 0 ]]; then
-      echo "$KEY: error (gh issue create failed for $base: $CREATE_OUT)" >&2
+      echo "$KEY: error (gh issue create failed for $base: $CREATE_ERR)" >&2
       HARD_ERROR=1
       ENTRY_HARD_ERROR=1
       break

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-statements-scan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-statements-scan
@@ -291,6 +291,7 @@ for (( i = 0; i < STATEMENTS_COUNT; i++ )); do
   # byte-identical file is then deduped locally, with no per-file gh call.
   # ENTRY_HARD_ERROR is set before the pre-fetch so the pre-fetch can mark the
   # entry as hard-errored; the 4g stamp guard skips stamping when it is set.
+  unset SEEN_HASHES
   declare -A SEEN_HASHES=()
   ENTRY_HARD_ERROR=0
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -15849,6 +15849,10 @@ touch "$STUB_DIR/issue-list-fail-once"
 rc=0
 out=$("$TMPDIR_TEST/scripts/dispatch-statements-scan" 2>/dev/null) || rc=$?
 assert_eq "retry-list exits 0" "0" "$rc"
+list_count=0
+[[ -f "$STUB_DIR/gh-calls.log" ]] \
+  && list_count=$(grep -c '^issue list ' "$STUB_DIR/gh-calls.log" || true)
+assert_eq "retry-list made exactly 2 issue list calls (fail attempt + retry)" "2" "$list_count"
 TOTAL=$((TOTAL + 1))
 if [[ "$out" == *"bank: skipped (#99 for retry.qfx)"* ]]; then
   PASS=$((PASS + 1)); echo "  PASS: retry-list skipped (#99 for retry.qfx) — retry parsed correctly"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -14968,9 +14968,10 @@ jit_teardown
 # own SCRIPT_DIR — which becomes $TMPDIR_TEST/scripts for the copy — so all
 # three scripts are co-located. The gh stub logs EVERY matched invocation to
 # gh-calls.log so a test can assert "zero gh calls" (the debounce case). The
-# `search issues` arm reads a stub/search-result.json fixture if present (lets a
-# test inject an open or closed hit), else "[]". "now" is pinned via
-# DISPATCH_STATEMENTS_NOW so the debounce math is deterministic.
+# `issue list` arm reads a stub/issue-list.json fixture if present (lets a
+# test seed the batched dedup map with pre-existing issues), else "[]".
+# Transient-failure injection is via stub/issue-list-fail-once. "now" is pinned
+# via DISPATCH_STATEMENTS_NOW so the debounce math is deterministic.
 
 # A fixed reference epoch — 2026-01-01T00:00:00Z.
 STMT_NOW_EPOCH=1767225600
@@ -14999,9 +15000,10 @@ statements_setup() {
   export DISPATCH_STATEMENTS_NOW="$STMT_NOW_EPOCH"
 
   # gh PATH stub. Every matched subcommand is appended to gh-calls.log so the
-  # debounce test can assert the log is absent (zero gh calls). `search issues`
-  # reads search-result.json if present, else "[]". `issue create` logs its full
-  # args (including --body) to gh-issue-create.log so the body can be asserted,
+  # debounce test can assert the log is absent (zero gh calls). `issue list`
+  # reads issue-list.json if present, else "[]"; supports transient-failure
+  # injection via issue-list-fail-once. `issue create` logs its full args
+  # (including --body) to gh-issue-create.log so the body can be asserted,
   # and echoes a deterministic issue URL. `project item-add` matches the gh
   # subcommand that dispatch-project-item-add invokes internally.
   cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
@@ -15013,9 +15015,14 @@ case "$args" in
   "label create "*)
     # Idempotent label create — default success.
     ;;
-  *"search issues "*)
-    if [[ -f "$STUB_DIR/search-result.json" ]]; then
-      cat "$STUB_DIR/search-result.json"
+  *"issue list "*)
+    if [[ -f "$STUB_DIR/issue-list-fail-once" ]]; then
+      rm -f "$STUB_DIR/issue-list-fail-once"
+      echo "HTTP 503: Service Unavailable" >&2
+      exit 1
+    fi
+    if [[ -f "$STUB_DIR/issue-list.json" ]]; then
+      cat "$STUB_DIR/issue-list.json"
     else
       echo '[]'
     fi
@@ -15035,6 +15042,7 @@ case "$args" in
 esac
 STUB
   chmod +x "$TMPDIR_TEST/bin/gh"
+  export GH_RETRY_BASE_DELAY=0
   PATH="$TMPDIR_TEST/bin:$PATH"
 }
 
@@ -15046,6 +15054,8 @@ statements_teardown() {
   unset DISPATCH_CONFIG_DIR
   unset DISPATCH_STATEMENTS_STATE_DIR
   unset DISPATCH_STATEMENTS_NOW
+  unset GH_RETRY_BASE_DELAY
+  unset DISPATCH_STATEMENTS_ISSUE_LIST_LIMIT
 }
 
 # statements_write_projects — projects.json fixture with one project whose key
@@ -15135,13 +15145,13 @@ else
 fi
 calls=$(cat "$STUB_DIR/gh-calls.log")
 TOTAL=$((TOTAL + 1))
-if [[ "$calls" == *"search issues "* && "$calls" == *"issue create"* \
+if [[ "$calls" == *"issue list "* && "$calls" == *"issue create"* \
    && "$calls" == *"project item-add"* ]]; then
   PASS=$((PASS + 1))
-  echo "  PASS: new-file invoked search / issue create / project item-add"
+  echo "  PASS: new-file invoked issue list / issue create / project item-add"
 else
   FAIL=$((FAIL + 1))
-  echo "  FAIL: new-file invoked search / issue create / project item-add"
+  echo "  FAIL: new-file invoked issue list / issue create / project item-add"
   echo "    gh-calls.log: $calls"
 fi
 # Assert both labels are present in the issue create call.
@@ -15159,13 +15169,18 @@ fi
 statements_teardown
 
 # --- Test 3: open hit → skipped ----------------------------------------------
+# Dedup now comes from the batched gh issue list body parse: the fixture issue's
+# body carries the file's sha256 on a `- sha256: \`<hash>\`` line, which seeds
+# SEEN_HASHES[hash]=42, so the file is deduped locally without a per-file call.
 
 echo "Test: dispatch-statements-scan skips when an open issue carries the hash"
 statements_setup
 statements_write_projects
 statements_write_config
 printf 'STATEMENT-CONTENTS\n' > "$TMPDIR_TEST/statements-dir/acct.qfx"
-echo '[{"number":42,"state":"open"}]' > "$STUB_DIR/search-result.json"
+h=$(sha256sum "$TMPDIR_TEST/statements-dir/acct.qfx" | awk '{print $1}')
+jq -n --arg h "$h" '[{number:42, body:("- File: `acct.qfx`\n- sha256: `" + $h + "`")}]' \
+  > "$STUB_DIR/issue-list.json"
 rc=0
 out=$("$TMPDIR_TEST/scripts/dispatch-statements-scan" 2>/dev/null) || rc=$?
 assert_eq "open-hit exits 0" "0" "$rc"
@@ -15186,13 +15201,19 @@ fi
 statements_teardown
 
 # --- Test 4: closed hit → skipped (proves open-OR-closed dedup) --------------
+# Dedup comes from the batched gh issue list body parse (the script no longer
+# reads `state`). The fixture includes state:"closed" for documentation; only
+# `number` and `body` are functionally needed. The hash in the body seeds
+# SEEN_HASHES[hash]=43, so the file is deduped locally regardless of state.
 
 echo "Test: dispatch-statements-scan skips when a CLOSED issue carries the hash"
 statements_setup
 statements_write_projects
 statements_write_config
 printf 'STATEMENT-CONTENTS\n' > "$TMPDIR_TEST/statements-dir/acct.qfx"
-echo '[{"number":43,"state":"closed"}]' > "$STUB_DIR/search-result.json"
+h=$(sha256sum "$TMPDIR_TEST/statements-dir/acct.qfx" | awk '{print $1}')
+jq -n --arg h "$h" '[{number:43, state:"closed", body:("- sha256: `" + $h + "`")}]' \
+  > "$STUB_DIR/issue-list.json"
 rc=0
 out=$("$TMPDIR_TEST/scripts/dispatch-statements-scan" 2>/dev/null) || rc=$?
 assert_eq "closed-hit exits 0" "0" "$rc"
@@ -15337,31 +15358,31 @@ else
 fi
 statements_teardown
 
-# --- Test 9: malformed gh search issues output → hard error, no issue create --
+# --- Test 9: malformed gh issue list output → hard error, no issue create ----
 
-echo "Test: dispatch-statements-scan surfaces hard error on malformed search output, does not file"
+echo "Test: dispatch-statements-scan surfaces hard error on malformed gh issue list output, does not file"
 statements_setup
 statements_write_projects
 statements_write_config
 printf 'STATEMENT-CONTENTS\n' > "$TMPDIR_TEST/statements-dir/acct.qfx"
-# Inject a TLS-error-like non-JSON message as the search result (gh exits 0).
+# Inject a TLS-error-like non-JSON message as the issue list result (gh exits 0).
 printf 'tls: failed to verify certificate: x509: certificate signed by unknown authority\n' \
-  > "$STUB_DIR/search-result.json"
+  > "$STUB_DIR/issue-list.json"
 rc=0
 err=$("$TMPDIR_TEST/scripts/dispatch-statements-scan" 2>&1 >/dev/null) || rc=$?
-assert_eq "malformed-search exits 1" "1" "$rc"
+assert_eq "malformed-list exits 1" "1" "$rc"
 TOTAL=$((TOTAL + 1))
 if [[ "$err" == *"bank: error"* && "$err" == *"non-JSON"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: malformed-search emits hard error to stderr"
+  PASS=$((PASS + 1)); echo "  PASS: malformed-list emits hard error to stderr"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: malformed-search emits hard error to stderr"
+  FAIL=$((FAIL + 1)); echo "  FAIL: malformed-list emits hard error to stderr"
   echo "    actual stderr: $err"
 fi
 TOTAL=$((TOTAL + 1))
 if [[ ! -f "$STUB_DIR/gh-issue-create.log" ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: malformed-search made no issue create call"
+  PASS=$((PASS + 1)); echo "  PASS: malformed-list made no issue create call"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: malformed-search made no issue create call"
+  FAIL=$((FAIL + 1)); echo "  FAIL: malformed-list made no issue create call"
   echo "    gh-issue-create.log: $(cat "$STUB_DIR/gh-issue-create.log")"
 fi
 statements_teardown
@@ -15429,6 +15450,104 @@ if [[ ! -f "$STUB_DIR/gh-issue-create.log" ]]; then
   PASS=$((PASS + 1)); echo "  PASS: ctrl-char-name filed nothing"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: ctrl-char-name filed nothing"
+  echo "    gh-issue-create.log: $(cat "$STUB_DIR/gh-issue-create.log")"
+fi
+statements_teardown
+
+# --- Test 12: one list call regardless of file count -------------------------
+# Proves that the per-file Search-API fan-out is gone: with N=5 distinct new
+# files there is exactly ONE `gh issue list` invocation (per entry, not per
+# file) and exactly 5 `gh issue create` invocations.
+
+echo "Test: dispatch-statements-scan makes exactly one gh issue list call for N files"
+statements_setup
+statements_write_projects
+statements_write_config
+# Write 5 distinct files (different contents → different hashes).
+printf 'STATEMENT-CONTENTS-1\n' > "$TMPDIR_TEST/statements-dir/acct1.qfx"
+printf 'STATEMENT-CONTENTS-2\n' > "$TMPDIR_TEST/statements-dir/acct2.qfx"
+printf 'STATEMENT-CONTENTS-3\n' > "$TMPDIR_TEST/statements-dir/acct3.qfx"
+printf 'STATEMENT-CONTENTS-4\n' > "$TMPDIR_TEST/statements-dir/acct4.qfx"
+printf 'STATEMENT-CONTENTS-5\n' > "$TMPDIR_TEST/statements-dir/acct5.qfx"
+# No issue-list.json → stub returns [] → all 5 files are new and get filed.
+rc=0
+out=$("$TMPDIR_TEST/scripts/dispatch-statements-scan" 2>/dev/null) || rc=$?
+assert_eq "one-list-call exits 0" "0" "$rc"
+list_count=0
+[[ -f "$STUB_DIR/gh-calls.log" ]] \
+  && list_count=$(grep -c '^issue list ' "$STUB_DIR/gh-calls.log" || true)
+assert_eq "one-list-call made exactly one issue list call" "1" "$list_count"
+create_count=0
+[[ -f "$STUB_DIR/gh-calls.log" ]] \
+  && create_count=$(grep -c '^issue create ' "$STUB_DIR/gh-calls.log" || true)
+assert_eq "one-list-call made exactly five issue create calls" "5" "$create_count"
+statements_teardown
+
+# --- Test 13: transient-then-succeed on the list call -------------------------
+# Proves gh_retry retries the list and that the retried stdout parses correctly.
+# If the JSON from the retry were corrupted or not parsed, the file would be
+# FILED (hash not in SEEN_HASHES) rather than SKIPPED — so a SKIPPED assertion
+# proves both the retry and the parse.
+
+echo "Test: dispatch-statements-scan retries gh issue list on transient failure and parses the result"
+statements_setup
+statements_write_projects
+statements_write_config
+printf 'STATEMENT-CONTENTS\n' > "$TMPDIR_TEST/statements-dir/retry.qfx"
+h=$(sha256sum "$TMPDIR_TEST/statements-dir/retry.qfx" | awk '{print $1}')
+jq -n --arg h "$h" '[{number:99, body:("- sha256: `" + $h + "`")}]' \
+  > "$STUB_DIR/issue-list.json"
+# First gh issue list attempt fails transiently; retry returns the fixture.
+touch "$STUB_DIR/issue-list-fail-once"
+rc=0
+out=$("$TMPDIR_TEST/scripts/dispatch-statements-scan" 2>/dev/null) || rc=$?
+assert_eq "retry-list exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$out" == *"bank: skipped (#99 for retry.qfx)"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: retry-list skipped (#99 for retry.qfx) — retry parsed correctly"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: retry-list skipped (#99 for retry.qfx) — retry parsed correctly"
+  echo "    actual: $out"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -f "$STUB_DIR/gh-issue-create.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: retry-list made no issue create call"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: retry-list made no issue create call"
+  echo "    gh-issue-create.log: $(cat "$STUB_DIR/gh-issue-create.log")"
+fi
+statements_teardown
+
+# --- Test 14: truncation guard -----------------------------------------------
+# When gh issue list returns exactly DISPATCH_STATEMENTS_ISSUE_LIST_LIMIT
+# results the dedup snapshot is likely truncated; the script hard-errors rather
+# than silently misfiling. Set the limit to 2 and supply a fixture of exactly 2
+# issues to trigger the guard.
+
+echo "Test: dispatch-statements-scan hard-errors when gh issue list returns exactly the limit"
+statements_setup
+statements_write_projects
+statements_write_config
+export DISPATCH_STATEMENTS_ISSUE_LIST_LIMIT=2
+printf 'STATEMENT-CONTENTS\n' > "$TMPDIR_TEST/statements-dir/acct.qfx"
+# Fixture of exactly 2 issues — matches the limit of 2, triggering the guard.
+jq -n '[{number:1, body:"- sha256: `aabbcc`"}, {number:2, body:"- sha256: `ddeeff`"}]' \
+  > "$STUB_DIR/issue-list.json"
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-statements-scan" 2>&1 >/dev/null) || rc=$?
+assert_eq "truncation-guard exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"bank: error"* && "$err" == *"truncat"* && "$err" == *"limit"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: truncation-guard emits hard error mentioning truncat and limit"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: truncation-guard emits hard error mentioning truncat and limit"
+  echo "    actual stderr: $err"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -f "$STUB_DIR/gh-issue-create.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: truncation-guard made no issue create call"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: truncation-guard made no issue create call"
   echo "    gh-issue-create.log: $(cat "$STUB_DIR/gh-issue-create.log")"
 fi
 statements_teardown


### PR DESCRIPTION
Closes #1066

## Problem

`dispatch-statements-scan` fired one `gh search issues <hash>` query **per file**
in each configured statements folder, serially, with no rate-limit handling.
GitHub's Search API is limited to ~30 requests/minute. A cold scan over a large
folder (e.g. 200 files) issued 200 serial search queries in one tick; once the
per-minute budget was spent the next query returned a 429 that surfaced as a hard
`gh search issues failed` error and aborted the entry.

## Fix

Replace the per-file Search-API fan-out with **one `gh issue list` per statements
entry** against the core API (~5000 requests/hour — roughly 100× the Search API's
headroom), then dedup every file locally against the fetched set.

- **Batched existence lookup.** Before the per-file loop, one
  `gh issue list --label <label> --state all --json number,body` fetches every
  parse-job issue under the label (open and closed). Each issue body carries the
  file's sha256 on its fixed `- sha256: \`<hash>\`` line; the scan parses those
  hashes (via jq `scan`) and seeds the existing `SEEN_HASHES` map, so the
  per-file dedup is now purely local — no per-file gh call. The lookup is skipped
  entirely when an entry has no matching files.
- **`gh_retry` backoff** wraps the batched `gh issue list` and the per-new-file
  `gh issue create` (the one genuinely per-new-file call that cannot be batched —
  a burst of creates on initial population is exactly the secondary-rate-limit /
  abuse-detection condition `gh_retry`'s detector already matches). Pure backoff
  alone was insufficient: a primary rate limit resets on an hour window, so a
  4-attempt retry can only slow a sustained 200-file fan-out, not survive it —
  removing the fan-out is the real fix.
- **Truncation guard.** `--state all` means closed parse-job issues accumulate
  forever, so the list carries a high `--limit` default (5000, overridable via the
  new `DISPATCH_STATEMENTS_ISSUE_LIST_LIMIT` for tests). If the returned count
  equals the limit the list is likely truncated and local dedup is no longer
  sound, so the entry hard-errors rather than silently risking a duplicate file
  — mirroring `lib.sh:pr_list_open`'s loud-truncation pattern. There is **no**
  fallback to per-file search; that would reinstate the fan-out
  (`.claude/rules/code-style.md`: clear error over fallback).
- An issue body with no parseable sha256 is logged as a stderr advisory and not
  seeded (a silent skip would risk re-filing a duplicate), but does not error the
  entry.

The shared `_gh_error_is_transient` detector and `gh_retry` in `lib.sh` are
unchanged — a primary rate limit is deliberately *not* retryable.

## Idempotency

Unchanged in spirit: dedup is still keyed on live GitHub state. It now reads that
state via `gh issue list` (live, exact) rather than the eventually-consistent
`gh search issues` index — in fact slightly more accurate.

## Tests

The `dispatch-statements-scan` suite in `test-dispatch-scripts.sh` is updated to
the batched model: the gh stub gains an `issue list` arm (with transient-failure
injection), the dedup tests inject an `issue-list.json` whose body carries the
matching sha256, and three new tests cover the key guarantees:

- **one `gh issue list` call regardless of file count** (5 files → exactly 1 list
  call, 5 creates) — the acceptance check that the fan-out is gone;
- **transient-then-succeed on the list call** — a first-attempt HTTP 503 is
  retried and the file is correctly deduped from the retried response (proves the
  retried stdout parsed cleanly, not just that the scan exited 0);
- **truncation guard** — a returned count equal to the limit hard-errors the
  entry and files nothing.

Full suite: 2613/2613 passing.

## Follow-up (out of scope)

The truncation guard turns the `--limit` ceiling into a hard error rather than a
silent dedup miss, but does not paginate. A header note records pagination over
`gh issue list` as a deliberate follow-up so the scan can tolerate an unboundedly
growing pool of closed parse-job issues without raising the limit; the hour-scale
debounce makes the ceiling unlikely to bite soon.
