### PR TITLE
dispatch: phase skills pass --follow-up when auto-filing follow-up issues

### DIFF
--- a/.claude/skills/fix-checks/SKILL.md
+++ b/.claude/skills/fix-checks/SKILL.md
@@ -149,10 +149,12 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
         key; it must identify the same flake across re-runs.
      2. **File the flake issue.** Launch a subagent (`subagent_type:
         general-purpose`, `model: sonnet`) that invokes `/file-issue` via the
-        Skill tool. Build its `$INPUT` as a title hint on line 1 — a short
-        imperative summary that encodes the fingerprint, e.g.
-        `Flaky CI: <check> — <stable identifier>` — followed by a body containing
-        the fingerprint, the reproduce command, and the failure excerpt.
+        Skill tool. Build its `$INPUT` with a leading `--follow-up` token first,
+        then a title hint on the next line — a short imperative summary that encodes
+        the fingerprint, e.g. `Flaky CI: <check> — <stable identifier>` — followed
+        by a body containing the fingerprint, the reproduce command, and the failure
+        excerpt. (The `--follow-up` token is a classification no-op here — a flake
+        is a `bug`, which suppresses `enhancement` — but is passed for consistency.)
         `/file-issue` runs the full pipeline: duplicate detection, 8-category
         evaluation, decomposition gate, type/topic classification, creation (or
         match of an existing open issue), `@me` assignment, `help wanted`, type

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -348,12 +348,15 @@ The Workflow prepares `result.deferred_filings`, each entry carrying `title`,
 `Closes #N`, or `"independent"`). For each entry, fork a subagent (`subagent_type:
 general-purpose`, `model: sonnet`). The subagent:
 
-1. Invokes `/file-issue`, which runs the full pipeline: duplicate detection,
-   8-category evaluation, decomposition gate, type/topic classification, issue
-   creation, `@me` assignment, and the `help wanted` label. `/file-issue` ends with
-   a `===FILE-ISSUE-RESULTS===` … `===FILE-ISSUE-RESULTS-END===` block; read every
-   `<disposition> <N>` record line between the sentinels and iterate steps 2–3 over
-   each. A single finding normally yields one record; a finding that legitimately
+1. Invokes `/file-issue` with a leading `--follow-up` token prepended to the
+   `$INPUT` it builds from the finding's `title` and `body` (the token must come
+   first so file-issue's leading-token strip recognizes it and classifies a non-bug
+   finding as `enhancement`). `/file-issue` runs the full pipeline: duplicate
+   detection, 8-category evaluation, decomposition gate, type/topic classification,
+   issue creation, `@me` assignment, and the `help wanted` label. `/file-issue` ends
+   with a `===FILE-ISSUE-RESULTS===` … `===FILE-ISSUE-RESULTS-END===` block; read
+   every `<disposition> <N>` record line between the sentinels and iterate steps 2–3
+   over each. A single finding normally yields one record; a finding that legitimately
    separates into multiple issues yields several — link them all.
 2. For each record, for a non-independent finding, record a `blocked_by` dependency
    **on the new issue `<N>`, targeting each blocker issue number** from
@@ -418,12 +421,15 @@ subagent:
    Record the follow-up as already-tracked, mapping its `identifier` to the
    existing issue `#<N>` for the Step 7 comment, and return that `<N>`. Otherwise
    proceed to the next step.
-2. Invokes `/file-issue` with the follow-up's `title` on the first line and its
-   `body` after. `/file-issue` owns duplicate detection, creation, `@me`
-   assignment, the `help wanted` label, and type + topic classification; it ends
-   with a `===FILE-ISSUE-RESULTS===` … `===FILE-ISSUE-RESULTS-END===` block. Read
-   the `<disposition> <N>` record(s) between the sentinels — a single machine-keyed
-   follow-up normally yields one record; iterate step 3 over each if more.
+2. Invokes `/file-issue` with a leading `--follow-up` token first, then the
+   follow-up's `title` on the next line and its `body` after (the `--follow-up`
+   token is a classification no-op for a security follow-up, which never carries
+   `enhancement`, but is passed for consistency). `/file-issue` owns duplicate
+   detection, creation, `@me` assignment, the `help wanted` label, and type + topic
+   classification; it ends with a `===FILE-ISSUE-RESULTS===` …
+   `===FILE-ISSUE-RESULTS-END===` block. Read the `<disposition> <N>` record(s)
+   between the sentinels — a single machine-keyed follow-up normally yields one
+   record; iterate step 3 over each if more.
 3. Applies the topic and type labels to each `<N>` (use
    `dangerouslyDisableSandbox: true` — `gh` needs network):
 


### PR DESCRIPTION
Closes #1472

## Summary

The auto-filing phase skills now pass a leading `--follow-up` token to
`/file-issue`, so the deferral-marker semantics shipped by #1471 (PR #1477)
actually take effect.

#1471 taught `/file-issue` to strip a leading `--follow-up` token and apply the
`enhancement` type label only to a non-bug, non-security issue filed *with* that
token. But the skills that auto-file follow-up issues never passed the flag, so
their auto-filed non-bug follow-ups went unmarked. This change wires the flag in
at the three auto-filing call sites.

## Changes

Instruction-text only — three `/file-issue` call sites now prepend a leading
`--follow-up` token to the `$INPUT` they build (the token must come first so
file-issue's leading-token strip recognizes it):

- **`/review-fix` 5a** (deferred code-review/review findings) — a deferred
  non-bug finding filed here is now classified `enhancement`. Passing the flag at
  the top-level invocation also propagates to any decomposed sub-issues via
  file-issue's Step-5 recursion, keeping a split finding uniformly `enhancement`.
- **`/review-fix` 5b** (out-of-scope CodeQL/npm security follow-ups) — a
  classification no-op (a security-topic follow-up never carries `enhancement`),
  but the flag is passed for consistency.
- **`/fix-checks`** (flake-issue filing) — a classification no-op (a flake is a
  `bug`, which suppresses `enhancement`), but the flag is passed for consistency.

`/plan-issue` is unchanged — it only recommends filing to a human and never
invokes `/file-issue`. No code, script, or test changes; there is no automated
test for skill instruction text, so verification is by inspection and by tracing
file-issue's Type classification.
