### PR TITLE
QA auto-fix lane: Opus fix-plan + per-unit implement, re-QA via chain

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-qa-fix-attempt
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-qa-fix-attempt
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# dispatch-qa-fix-attempt — bump the qa-fix attempt counter on a PR and emit
+# a verdict telling the qa-fix skill whether to run a fix pass or escalate.
+#
+# The qa-fix skill runs Opus-based autonomous fixes after a QA failure. Each
+# run is bounded by an attempt counter — `dispatch:qa-fix-attempt-<n>` labels
+# on the PR — so a pathological loop does not run forever. This script reads
+# the current counter, checks it against the cap, and either bumps it (returning
+# `fix`) or signals that the cap is hit (returning `escalate`).
+#
+# Key difference from dispatch-schedule-target-reseed: at the cap this script
+# applies NO label and prints `escalate` — the qa-fix skill handles escalation
+# via the existing dispatch-mark-deviation path. (The reseed script parks the
+# issue itself via dispatch-apply-office-hours; here the caller owns that step.)
+# This script is also qa-scoped, not generalized across fix-checks/ci-wait.
+# Unlike the reseed script there is NO dispatch-find-pr indirection — the
+# caller passes the PR number directly, so this script has no FIND_PR_CMD,
+# no OFFICE_HOURS_CMD, no systemd-run, no timer scheduling, and no NOW/DELAY.
+#
+# CLI contract:
+#   dispatch-qa-fix-attempt <pr_num>
+#
+#   <pr_num> is the PR number directly (NOT an issue number). The caller
+#   resolves the PR before invoking this script.
+#
+# Behavior, in order:
+#   1. Validate <pr_num> is a positive integer. Reject empty / flag-like /
+#      non-numeric input → exit 2.
+#   2. Read the highest extant dispatch:qa-fix-attempt-<n> label on the PR →
+#      CUR (max // 0), via the jq capture idiom.
+#   3. Fail-closed integer guard on CUR → exit 2 on malformed output.
+#   4. Cap check: if CUR >= CAP, print `escalate`, apply/remove NO label,
+#      exit 0. The qa-fix skill escalates via dispatch-mark-deviation.
+#   5. Otherwise (under cap): NEXT=CUR+1. Remove the prior counter label (if
+#      CUR>0) and apply dispatch:qa-fix-attempt-<NEXT> via apply-first /
+#      create-on-"not found". Label failures warn on stderr but do NOT abort.
+#      Print `fix`, exit 0.
+#
+# Stdout protocol (exactly one line on the action paths):
+#   fix        counter was bumped; the qa-fix skill should run a fix pass.
+#   escalate   cap hit; the qa-fix skill should escalate via dispatch-mark-deviation.
+#
+# Exit codes:
+#   0  on a fix or escalate path.
+#   2  on a bad <pr_num>, a non-integer CUR, or a bad CAP env override.
+#
+# Environment overrides for testability:
+#
+#   DISPATCH_QA_FIX_ATTEMPT_GH_CMD
+#     Override the `gh` binary used for label reads/edits. Default: `gh`.
+#
+#   DISPATCH_QA_FIX_ATTEMPT_CAP
+#     Override the attempt cap (positive integer). Default: 2.
+#
+# Sandbox: label reads/edits use `gh` (macOS Security-framework TLS); this
+# script is not sandbox-safe and callers must invoke it with
+# `dangerouslyDisableSandbox: true`.
+
+set -uo pipefail
+
+# ---- Step 0: defaults & config ----------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+GH_CMD="${DISPATCH_QA_FIX_ATTEMPT_GH_CMD:-gh}"
+
+# ---- Step 1: validate <pr_num> ----------------------------------------------
+#
+# PR_NUM is interpolated into `gh pr view/edit "$PR_NUM"` calls below. A
+# non-numeric, flag-like value (e.g. --repo other/repo) would be parsed by gh
+# as an option rather than a PR number. Reject anything that is not a bare
+# positive integer.
+
+PR_NUM="${1:-}"
+if [[ -z "$PR_NUM" || ! "$PR_NUM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: usage: dispatch-qa-fix-attempt <pr_num> (pr_num must be a positive integer)" >&2
+  exit 2
+fi
+
+# ---- Step 2: read the highest qa-fix-attempt counter ------------------------
+#
+# Same label-capture idiom as /fix-checks's fix-checks-attempt counter, adapted
+# to the dispatch:qa-fix-attempt- prefix. `max // 0` yields 0 when no counter
+# label is present yet.
+
+CUR=$("$GH_CMD" pr view "$PR_NUM" --json labels \
+  --jq '[.labels[].name | capture("^dispatch:qa-fix-attempt-(?<n>[0-9]+)$").n | tonumber] | max // 0' \
+  2>/dev/null || true)
+
+# CUR feeds `(( CUR >= CAP ))` and `(( CUR > 0 ))` — bash arithmetic context
+# evaluates array-index command substitution, so any value entering `(( ))`
+# must be a literal integer. A label-read flake or tampered label set could
+# yield a non-integer; fail closed.
+if [[ ! "$CUR" =~ ^[0-9]+$ ]]; then
+  echo "error: dispatch-qa-fix-attempt: qa-fix attempt counter is not an integer, got '$CUR'; aborting" >&2
+  exit 2
+fi
+
+# ---- Step 3: cap check ------------------------------------------------------
+
+CAP="${DISPATCH_QA_FIX_ATTEMPT_CAP:-2}"
+if [[ ! "$CAP" =~ ^[0-9]+$ ]] || (( CAP < 1 )); then
+  echo "error: dispatch-qa-fix-attempt: CAP must be a positive integer, got '$CAP'; aborting" >&2
+  exit 2
+fi
+
+if (( CUR >= CAP )); then
+  # Cap hit — apply NO label. The qa-fix skill escalates via the existing
+  # dispatch-mark-deviation path; this script just emits the verdict.
+  echo "escalate"
+  exit 0
+fi
+
+# ---- Step 4: bump the attempt counter ---------------------------------------
+#
+# Apply-first / create-on-"not found" — the label may not exist yet on a fresh
+# repo. A gh label failure warns on stderr but does NOT abort: the stdout
+# verdict is the load-bearing side effect; the bookkeeping label is best-effort.
+
+NEXT=$(( CUR + 1 ))
+
+if (( CUR > 0 )); then
+  if ! rm_out=$("$GH_CMD" pr edit "$PR_NUM" --remove-label "dispatch:qa-fix-attempt-$CUR" 2>&1); then
+    echo "dispatch-qa-fix-attempt: warning: could not remove dispatch:qa-fix-attempt-$CUR from PR #$PR_NUM: $rm_out" >&2
+  fi
+fi
+
+if ! add_out=$("$GH_CMD" pr edit "$PR_NUM" --add-label "dispatch:qa-fix-attempt-$NEXT" 2>&1); then
+  if [[ "$add_out" != *"not found"* ]]; then
+    echo "dispatch-qa-fix-attempt: warning: could not apply dispatch:qa-fix-attempt-$NEXT to PR #$PR_NUM: $add_out" >&2
+  else
+    if ! create_out=$("$GH_CMD" label create "dispatch:qa-fix-attempt-$NEXT" \
+        --description "dispatch workflow: qa-fix attempt $NEXT of $CAP" 2>&1); then
+      echo "dispatch-qa-fix-attempt: warning: could not create label dispatch:qa-fix-attempt-$NEXT: $create_out" >&2
+    elif ! retry_out=$("$GH_CMD" pr edit "$PR_NUM" --add-label "dispatch:qa-fix-attempt-$NEXT" 2>&1); then
+      echo "dispatch-qa-fix-attempt: warning: could not apply dispatch:qa-fix-attempt-$NEXT to PR #$PR_NUM after create: $retry_out" >&2
+    fi
+  fi
+fi
+
+echo "fix"
+exit 0

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-qa-fix-attempt
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-qa-fix-attempt
@@ -60,8 +60,6 @@ set -uo pipefail
 
 # ---- Step 0: defaults & config ----------------------------------------------
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 GH_CMD="${DISPATCH_QA_FIX_ATTEMPT_GH_CMD:-gh}"
 
 # ---- Step 1: validate <pr_num> ----------------------------------------------
@@ -83,9 +81,17 @@ fi
 # to the dispatch:qa-fix-attempt- prefix. `max // 0` yields 0 when no counter
 # label is present yet.
 
+# Capture gh's exit status separately: a gh failure (PR not found, network
+# error) must surface as a clear "could not read PR labels" error rather than
+# leaving CUR empty and tripping the integer guard with a confusing message.
 CUR=$("$GH_CMD" pr view "$PR_NUM" --json labels \
   --jq '[.labels[].name | capture("^dispatch:qa-fix-attempt-(?<n>[0-9]+)$").n | tonumber] | max // 0' \
-  2>/dev/null || true)
+  2>/dev/null)
+gh_rc=$?
+if (( gh_rc != 0 )); then
+  echo "error: dispatch-qa-fix-attempt: could not read PR labels for PR #$PR_NUM (gh exited $gh_rc); aborting" >&2
+  exit 2
+fi
 
 # CUR feeds `(( CUR >= CAP ))` and `(( CUR > 0 ))` — bash arithmetic context
 # evaluates array-index command substitution, so any value entering `(( ))`
@@ -130,6 +136,7 @@ if ! add_out=$("$GH_CMD" pr edit "$PR_NUM" --add-label "dispatch:qa-fix-attempt-
     echo "dispatch-qa-fix-attempt: warning: could not apply dispatch:qa-fix-attempt-$NEXT to PR #$PR_NUM: $add_out" >&2
   else
     if ! create_out=$("$GH_CMD" label create "dispatch:qa-fix-attempt-$NEXT" \
+        --color F9D0C4 \
         --description "dispatch workflow: qa-fix attempt $NEXT of $CAP" 2>&1); then
       echo "dispatch-qa-fix-attempt: warning: could not create label dispatch:qa-fix-attempt-$NEXT: $create_out" >&2
     elif ! retry_out=$("$GH_CMD" pr edit "$PR_NUM" --add-label "dispatch:qa-fix-attempt-$NEXT" 2>&1); then

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -12055,6 +12055,218 @@ else
 fi
 tr_teardown
 
+# --- dispatch-qa-fix-attempt (#1553) ---
+# ============================================================================
+# dispatch-qa-fix-attempt tests
+# ============================================================================
+#
+# Exercises the qa-fix attempt counter bump: under-cap prints `fix` and bumps
+# the dispatch:qa-fix-attempt-<n> label; at-cap prints `escalate` with no label
+# writes; bad args / non-integer CUR / bad CAP exit 2; the create-on-"not found"
+# path falls back to `label create` + retry and still prints `fix`.
+#
+# Each test gets a fresh tmp tree:
+#   $TMPDIR_TEST/scripts/   copy of dispatch-qa-fix-attempt
+#   $TMPDIR_TEST/bin/       fake-gh stub
+#   $TMPDIR_TEST/gh-edit-log   recorded fake-gh pr-edit / label-create argv
+
+echo ""
+echo "=== dispatch-qa-fix-attempt ==="
+
+qfa_setup() {
+  TMPDIR_TEST=$(mktemp -d)
+  mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/bin"
+
+  cp "$SCRIPT_DIR/dispatch-qa-fix-attempt" \
+    "$TMPDIR_TEST/scripts/dispatch-qa-fix-attempt"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-qa-fix-attempt"
+
+  # fake gh: `pr view` echoes the test-controlled current attempt count
+  # ($FAKE_CUR_ATTEMPT, default 0). `pr edit` / `label create` record their
+  # argv to a log and exit 0.
+  cat > "$TMPDIR_TEST/bin/fake-gh" <<STUB
+#!/usr/bin/env bash
+if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
+  echo "\${FAKE_CUR_ATTEMPT:-0}"
+  exit 0
+fi
+echo "\$*" >> "$TMPDIR_TEST/gh-edit-log"
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/fake-gh"
+  export DISPATCH_QA_FIX_ATTEMPT_GH_CMD="$TMPDIR_TEST/bin/fake-gh"
+  export DISPATCH_QA_FIX_ATTEMPT_CAP=2
+}
+
+qfa_teardown() {
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+  unset DISPATCH_QA_FIX_ATTEMPT_GH_CMD
+  unset DISPATCH_QA_FIX_ATTEMPT_CAP
+  unset FAKE_CUR_ATTEMPT
+}
+
+# --- Test 1: no prior label (CUR=0), default cap 2 → fix, applies attempt-1 ---
+
+echo "Test: no prior label (CUR=0) → fix, applies attempt-1, no remove"
+qfa_setup
+export FAKE_CUR_ATTEMPT=0
+if out=$("$TMPDIR_TEST/scripts/dispatch-qa-fix-attempt" 979 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "qfa CUR=0 exits 0" "0" "$rc"
+assert_eq "qfa CUR=0 stdout is fix" "fix" "$out"
+edits=$(cat "$TMPDIR_TEST/gh-edit-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$edits" == *"--add-label dispatch:qa-fix-attempt-1"* \
+   && "$edits" != *"--remove-label"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: CUR=0 applies attempt-1 with no remove"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: CUR=0 applies attempt-1 with no remove"
+  echo "    edits: $edits"
+fi
+qfa_teardown
+
+# --- Test 2: CUR=1, default cap 2 → fix, removes attempt-1, applies attempt-2 -
+
+echo "Test: CUR=1 → fix, removes attempt-1 and applies attempt-2"
+qfa_setup
+export FAKE_CUR_ATTEMPT=1
+if out=$("$TMPDIR_TEST/scripts/dispatch-qa-fix-attempt" 979 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "qfa CUR=1 exits 0" "0" "$rc"
+assert_eq "qfa CUR=1 stdout is fix" "fix" "$out"
+edits=$(cat "$TMPDIR_TEST/gh-edit-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$edits" == *"--remove-label dispatch:qa-fix-attempt-1"* \
+   && "$edits" == *"--add-label dispatch:qa-fix-attempt-2"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: CUR=1 removes attempt-1 and adds attempt-2"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: CUR=1 removes attempt-1 and adds attempt-2"
+  echo "    edits: $edits"
+fi
+qfa_teardown
+
+# --- Test 3: CUR=2, default cap 2 (at cap) → escalate, no label writes --------
+
+echo "Test: CUR=2, cap=2 (at cap) → escalate, gh-edit-log empty"
+qfa_setup
+export FAKE_CUR_ATTEMPT=2
+if out=$("$TMPDIR_TEST/scripts/dispatch-qa-fix-attempt" 979 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "qfa at-cap exits 0" "0" "$rc"
+assert_eq "qfa at-cap stdout is escalate" "escalate" "$out"
+TOTAL=$((TOTAL + 1))
+if [[ ! -s "$TMPDIR_TEST/gh-edit-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: at-cap writes no labels (gh-edit-log empty)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: at-cap writes no labels (gh-edit-log empty)"
+  echo "    edits: $(cat "$TMPDIR_TEST/gh-edit-log")"
+fi
+qfa_teardown
+
+# --- Test 4: DISPATCH_QA_FIX_ATTEMPT_CAP=1, CUR=1 (at cap via env) → escalate -
+
+echo "Test: CAP=1, CUR=1 (at cap via env override) → escalate, gh-edit-log empty"
+qfa_setup
+export DISPATCH_QA_FIX_ATTEMPT_CAP=1
+export FAKE_CUR_ATTEMPT=1
+if out=$("$TMPDIR_TEST/scripts/dispatch-qa-fix-attempt" 979 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "qfa cap-env at-cap exits 0" "0" "$rc"
+assert_eq "qfa cap-env at-cap stdout is escalate" "escalate" "$out"
+TOTAL=$((TOTAL + 1))
+if [[ ! -s "$TMPDIR_TEST/gh-edit-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: CAP=1 CUR=1 writes no labels (gh-edit-log empty)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: CAP=1 CUR=1 writes no labels (gh-edit-log empty)"
+  echo "    edits: $(cat "$TMPDIR_TEST/gh-edit-log")"
+fi
+qfa_teardown
+
+# --- Test 5a: non-integer CUR → exit 2, no label edits, stderr guard msg ------
+
+echo "Test: non-integer CUR → exit 2, gh-edit-log empty, stderr mentions integer guard"
+qfa_setup
+export FAKE_CUR_ATTEMPT=abc
+if out=$("$TMPDIR_TEST/scripts/dispatch-qa-fix-attempt" 979 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "qfa non-integer CUR exits 2" "2" "$rc"
+err=$(cat "$TMPDIR_TEST/stderr")
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"not an integer"* && ! -s "$TMPDIR_TEST/gh-edit-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-integer CUR; stderr integer-guard message + no label edit"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-integer CUR; stderr integer-guard message + no label edit"
+  echo "    stderr: $err"
+  echo "    gh-edit-log exists: $(test -s "$TMPDIR_TEST/gh-edit-log" && echo yes || echo no)"
+fi
+qfa_teardown
+
+# --- Test 5b: non-integer CAP → exit 2, no label edits, stderr guard msg ------
+
+echo "Test: non-integer CAP → exit 2, gh-edit-log empty, stderr mentions CAP error"
+qfa_setup
+export DISPATCH_QA_FIX_ATTEMPT_CAP=abc
+export FAKE_CUR_ATTEMPT=0
+if out=$("$TMPDIR_TEST/scripts/dispatch-qa-fix-attempt" 979 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "qfa non-integer CAP exits 2" "2" "$rc"
+err=$(cat "$TMPDIR_TEST/stderr")
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"CAP must be a positive integer"* && ! -s "$TMPDIR_TEST/gh-edit-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-integer CAP; stderr CAP-guard message + no label edit"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-integer CAP; stderr CAP-guard message + no label edit"
+  echo "    stderr: $err"
+fi
+qfa_teardown
+
+# --- Test 5c: flag-like arg → exit 2, no label edits -------------------------
+
+echo "Test: flag-like arg --repo → exit 2, no label edits"
+qfa_setup
+if out=$("$TMPDIR_TEST/scripts/dispatch-qa-fix-attempt" --repo 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "qfa flag-like arg exits 2" "2" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -s "$TMPDIR_TEST/gh-edit-log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: flag-like arg; no label edits"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: flag-like arg; no label edits"
+  echo "    edits: $(cat "$TMPDIR_TEST/gh-edit-log")"
+fi
+qfa_teardown
+
+# --- Test 6: create-on-"not found" path (CUR=0) → fix, label create logged ----
+# Replaces the default fake-gh with one whose `pr edit --add-label` simulates
+# a label-not-found failure, forcing the script's `label create` + retry path.
+# The retry `pr edit` hits the same "not found" branch again (warn-not-abort),
+# so rc=0 and stdout=`fix` but gh-edit-log records `label create ...`.
+
+echo "Test: create-on-not-found path (CUR=0) → fix, gh-edit-log contains label create"
+qfa_setup
+export FAKE_CUR_ATTEMPT=0
+# Write a per-test fake-gh that simulates the not-found path.
+cat > "$TMPDIR_TEST/bin/fake-gh" <<STUB
+#!/usr/bin/env bash
+if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
+  echo "\${FAKE_CUR_ATTEMPT:-0}"
+  exit 0
+fi
+if [[ "\$1" == "pr" && "\$2" == "edit" ]]; then
+  echo "Label 'dispatch:qa-fix-attempt-1' not found"
+  exit 1
+fi
+echo "\$*" >> "$TMPDIR_TEST/gh-edit-log"
+exit 0
+STUB
+chmod +x "$TMPDIR_TEST/bin/fake-gh"
+if out=$("$TMPDIR_TEST/scripts/dispatch-qa-fix-attempt" 979 2>"$TMPDIR_TEST/stderr"); then rc=0; else rc=$?; fi
+assert_eq "qfa create-on-not-found exits 0" "0" "$rc"
+assert_eq "qfa create-on-not-found stdout is fix" "fix" "$out"
+edits=$(cat "$TMPDIR_TEST/gh-edit-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$edits" == *"label create dispatch:qa-fix-attempt-1"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: create-on-not-found logs label create dispatch:qa-fix-attempt-1"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: create-on-not-found logs label create dispatch:qa-fix-attempt-1"
+  echo "    edits: $edits"
+fi
+qfa_teardown
+
 # ============================================================================
 # dispatch project-helper tests (item-add / status-read / status-write)
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -12741,8 +12741,12 @@ qfa_teardown
 # --- Test 6: create-on-"not found" path (CUR=0) → fix, label create logged ----
 # Replaces the default fake-gh with one whose `pr edit --add-label` simulates
 # a label-not-found failure, forcing the script's `label create` + retry path.
-# The retry `pr edit` hits the same "not found" branch again (warn-not-abort),
-# so rc=0 and stdout=`fix` but gh-edit-log records `label create ...`.
+# The retry `pr edit` also hits the `pr edit` branch and exits 1 (warn path
+# only); it is NOT recorded in gh-edit-log since the fake-gh `pr edit` branch
+# exits before the `echo >> log` fallthrough. The retry is instead asserted via
+# stderr: only the retry-after-create warning carries the `after create`
+# substring, so checking for it guards the retry step against accidental
+# deletion (a dropped retry would remove that warning).
 
 echo "Test: create-on-not-found path (CUR=0) → fix, gh-edit-log contains label create"
 qfa_setup
@@ -12766,12 +12770,24 @@ if out=$("$TMPDIR_TEST/scripts/dispatch-qa-fix-attempt" 979 2>"$TMPDIR_TEST/stde
 assert_eq "qfa create-on-not-found exits 0" "0" "$rc"
 assert_eq "qfa create-on-not-found stdout is fix" "fix" "$out"
 edits=$(cat "$TMPDIR_TEST/gh-edit-log" 2>/dev/null || true)
+err=$(cat "$TMPDIR_TEST/stderr" 2>/dev/null || true)
 TOTAL=$((TOTAL + 1))
 if [[ "$edits" == *"label create dispatch:qa-fix-attempt-1"* ]]; then
   PASS=$((PASS + 1)); echo "  PASS: create-on-not-found logs label create dispatch:qa-fix-attempt-1"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: create-on-not-found logs label create dispatch:qa-fix-attempt-1"
   echo "    edits: $edits"
+fi
+# Guard the retry pr edit after `label create` against accidental deletion. The
+# retry's stderr warning is the only one carrying `after create` (the initial
+# add-label failure routes to the label-create branch and emits no warning), so
+# its presence proves the retry ran. A dropped retry would remove this warning.
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"after create"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: create-on-not-found retries pr edit after label create (stderr 'after create')"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: create-on-not-found retries pr edit after label create (stderr 'after create')"
+  echo "    stderr: $err"
 fi
 qfa_teardown
 

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qa-fix
-description: QA phase — merge origin/main, run the autonomous portion of user-acceptance QA (plan items, machine-verifiable checks, PR-comment summary), apply the dispatch:qa-done label on a clean pass, and escalate to office-hours on any user-input blocker
+description: QA phase — merge origin/main, run the autonomous portion of user-acceptance QA (plan items, machine-verifiable checks, PR-comment summary), apply the dispatch:qa-done label on a clean pass, run the bounded Opus auto-fix lane on opus-fixable residue (per-unit /implement-unit, re-QA via the chain, attempt-capped), and escalate to office-hours on any user-input blocker
 ---
 
 # QA and Fix
@@ -27,9 +27,11 @@ run, a file check, or one `javascript_tool` assertion — no browser walkthrough
 `needs-browser` (needs the multi-step browser walkthrough loop), or
 `needs-human-judgment` (subjective UX, deferred to office-hours). This split is the
 genuine judgment of QA — it bounds how much of the run pays for a browser loop.
-There are **two** Opus spends in this skill: (1) the Step 2 triage subagent, and
-(2) the Step 3.5 disposition Workflow's classify agent. The disposition skeptics
-(Step 3.5) run on Sonnet. The qa-fix session itself stays on Sonnet: it parses
+There are **three** Opus spends in this skill: (1) the Step 2 triage subagent,
+(2) the Step 3.5 disposition Workflow's classify agent, and (3) the Step 3.5
+Workflow's gated `fix-plan` planner (which runs only when `plan_fix` is true and
+≥1 opus-fixable disposition exists). The disposition skeptics (Step 3.5) run on
+Sonnet. The qa-fix session itself stays on Sonnet: it parses
 the triage output and executes it across three lanes (shell-command,
 single-assertion, walkthrough), reserving the browser walkthrough for
 `needs-browser` items only.
@@ -61,6 +63,24 @@ Read `PR_NUM` and the labels line from the `=== PR ===` section of the output.
 If the output shows `PR: none`, stop with a clear error — qa-fix requires an
 open PR and should not have been dispatched here. If it shows `PR #<num>`, that
 is `PR_NUM`.
+
+From the **same** labels line, read the current qa-fix attempt count
+`ATTEMPT_N` — the highest `dispatch:qa-fix-attempt-<n>` label, defaulting to `0`
+when none is present (the same `max // 0` capture idiom as
+`dispatch-qa-fix-attempt` / the reseed script):
+
+```
+[.labels[].name | capture("^dispatch:qa-fix-attempt-(?<n>[0-9]+)$").n | tonumber] | max // 0
+```
+
+Apply that capture to the already-fetched labels line — do **not** re-call the
+pack. Define `CAP=2`, env-overridable via `DISPATCH_QA_FIX_ATTEMPT_CAP` (matching
+`dispatch-qa-fix-attempt`'s default and override). `ATTEMPT_N` and `CAP` feed the
+Step 3.5 `plan_fix` pre-gate and the Step 3.6 auto-fix lane.
+
+**Note on the name:** the issue number is already bound to `N` in this skill (the
+branch prefix). The attempt count is a **distinct** value — keep it under the
+separate name `ATTEMPT_N` and never overload `N`.
 
 qa-fix adopts `--pr` only and does **not** add `--diff` here: the only diff use
 in this skill is Step 1's local `git diff --name-only origin/main...HEAD` for
@@ -258,12 +278,14 @@ Otherwise run all steps in order.
 
    **Per-item lane FAIL is record-and-continue (all three lanes):** a FAIL in the
    shell-command, single-assertion, or walkthrough lane is **recorded as residue**
-   (see "Residue collection" below) and the lanes **continue** running. Escalation
-   is **deferred to the terminal disposition (Step 6)**, which still fires on any
-   non-empty residue exactly as before — this changes *when* escalation happens,
-   not *whether* it does. Do **not** stop, finalize, or escalate on a single lane
-   FAIL. The retry-once → **SKIP** and 3-consecutive-SKIPs → stop-early rules still
-   apply to the **walkthrough lane only** (Step 3c).
+   (see "Residue collection" below) and the lanes **continue** running. The
+   disposition of recorded residue is **deferred** past this lane: on a
+   **non-fixing pass** it escalates at the terminal disposition (Step 6) on any
+   non-empty residue exactly as before, while on a **fixing pass** an opus-fixable
+   FAIL is classified in Step 3.5 and *fixed* in Step 3.6 rather than escalated
+   (Step 6 is not reached). Either way, do **not** stop, finalize, or escalate on a
+   single lane FAIL here. The retry-once → **SKIP** and 3-consecutive-SKIPs →
+   stop-early rules still apply to the **walkthrough lane only** (Step 3c).
 
    **Cascade-bound:** a FAIL is **not** a SKIP, so it never trips the
    consecutive-SKIP guard. FAIL cascades are bounded by the finite plan-item count
@@ -398,7 +420,7 @@ Otherwise run all steps in order.
               "Per-item lane FAIL is record-and-continue" at the top of Step 3.
       10. Stop GIF recording: `gif_creator` with `action: "stop_recording"`. Export to `tmp/qa-fix-walkthrough-<n>.gif` (where `<n>` is the Step-0-resolved issue number `<N>`).
 
-3.5. **Invoke the disposition Workflow (report-only).**
+3.5. **Invoke the disposition + gated fix-planning Workflow.**
 
    Run this step only when the in-memory residue list from Step 3 is **non-empty**.
    If the residue list is empty — every item PASSed or SKIPped and no
@@ -419,13 +441,36 @@ Otherwise run all steps in order.
                                               // unavailable" was noted in Step 3c,
                                               // or no browser component was detected
      firestore_caveat:   <bool>,              // derived in Step 1
-     residue:            [ ...in-memory residue list... ]
+     residue:            [ ...in-memory residue list... ],
                                               // each entry: {id, title, kind,
                                               //   url_path, expected_outcome,
                                               //   finding, page_text,
                                               //   screenshot_path}
+     plan_fix:           <bool>,              // (ATTEMPT_N < CAP) from the
+                                              //   idempotency preamble — a
+                                              //   read-only pre-gate: false at
+                                              //   the cap so NO Opus is spent
+                                              //   planning a fix that could
+                                              //   never run. The Workflow runs
+                                              //   the gated fix-plan phase only
+                                              //   when plan_fix is true AND ≥1
+                                              //   opus-fixable item exists.
+     acceptance_criteria: <string>,           // the `--issue` section of the
+                                              //   Step-2a context pack
+                                              //   (dispatch-context-pack "$N"
+                                              //   --issue --pr --diff). REUSE
+                                              //   that capture; do NOT re-run
+                                              //   the pack.
+     changed_files:      <string>             // the `--diff` section of that
+                                              //   SAME Step-2a pack. REUSE it;
+                                              //   do NOT re-run the pack.
    }
    ```
+
+   `plan_fix`, `acceptance_criteria`, and `changed_files` are captured already:
+   `ATTEMPT_N`/`CAP` in the idempotency preamble, and the `--issue` / `--diff`
+   sections in the single Step-2a pack call. Reuse them — issue **no** extra
+   `dispatch-context-pack` call here.
 
    **Invoke the Workflow tool on `.claude/workflows/qa-fix.js`**, passing `args`.
    This skill is a sanctioned caller of that Workflow — no `ultracode` keyword
@@ -435,7 +480,8 @@ Otherwise run all steps in order.
    result = {
      dispositions:  [ {id, title, kind, class, aesthetic, verify, rationale} ],
      verify_report: [ {id, verdict, skeptic_votes, rationale} ],
-     deviation:     false
+     fix_plan:      { units, deviation, deviation_reason } | null,
+     deviation:     <bool>
    }
    ```
 
@@ -444,16 +490,124 @@ Otherwise run all steps in order.
    - `verify_report` has one entry per non-aesthetic `needs-human` candidate that
      went through the skeptic fan-out (`verdict`: `upheld` | `refuted` |
      `unverified`).
-   - `result.deviation` is always `false` (this is a report-only Workflow). It is
-     **not** consumed — do not branch on it.
+   - `result.fix_plan` is the ordered Opus fix plan when the gated `fix-plan`
+     phase ran — `{ units, deviation, deviation_reason }`, where each unit is
+     `{ id, scope, model, dependencies, commit_intent, context, resolves_ids }`.
+     It is **`null`** when the phase did not run: `plan_fix` was false (at the
+     cap), no opus-fixable disposition existed, **or** the planning agent died.
+   - `result.deviation` is **LIVE**: `fix_plan.deviation` when the phase ran, else
+     `false`. It signals a scope-deviation the planner refused to author a fix for
+     — Step 3.6 branches on it.
 
    Consume `result.dispositions` and `result.verify_report` for the Step 4
-   PR-comment disposition section.
+   PR-comment disposition section, and `result.fix_plan` / `result.deviation` for
+   the Step 3.6 auto-fix lane.
 
-   **Report-only:** the Workflow classifies and adversarially verifies residue
-   items but this skill does **not** act on the classes. No auto-fix, no change to
-   which items escalate to office-hours. The dispositions are purely informational
-   for the PR comment.
+3.6. **Auto-fix lane.**
+
+   This step runs only when Step 3.5 ran (the residue list was non-empty). It
+   decides whether this pass **fixes** the opus-fixable residue (per-unit
+   `/implement-unit`, then re-QA via the chain) or falls through to the terminal
+   disposition (Step 4 comment, Step 5 cleanup, Step 6 escalate/clean-pass).
+
+   1. Compute `opusFixable = result.dispositions.filter(d => d.class ===
+      'opus-fixable')`. If `opusFixable` is **empty** → **skip the auto-fix lane
+      entirely** and fall through to Step 4 / Step 5 / Step 6 (the existing
+      escalation / clean-pass logic, unchanged).
+
+   2. Otherwise (opus-fixable items present), choose exactly one path:
+
+      - **`result.fix_plan === null`** (planning did not run — `plan_fix` was
+        false because at the cap; a dead planning agent also yields `null`, so the
+        reason is "cap reached or planning did not run") → **escalate** all residue
+        to office-hours with a cap-reached reason. Take the **escalate finalize
+        path** below; apply **no** attempt label.
+
+      - **`result.deviation === true`** → **scope-deviation escape**: the planner
+        refused to author a fix because the change exceeds QA-fix scope. Escalate
+        to office-hours passing `result.fix_plan.deviation_reason`. Take the
+        **escalate finalize path** below; apply **NO** attempt label — a
+        scope-deviation is a permanent escalation, not a retry.
+
+      - **`result.fix_plan.units` is empty** (and not a deviation — i.e. planning
+        produced nothing usable) → escalate with a planning-failed reason. Take the
+        **escalate finalize path** below; apply **no** attempt label.
+
+      - **Otherwise (have units):** run the attempt gate (use
+        `dangerouslyDisableSandbox: true` — it calls `gh`):
+        ```bash
+        .claude/skills/dispatch-propagate/scripts/dispatch-qa-fix-attempt "$PR_NUM"
+        ```
+        Branch on its **STDOUT only**. It applies the attempt label itself as a
+        side effect when it prints `fix` — **this skill must NOT separately apply
+        any attempt label** on any path.
+        - Prints **`escalate`** (defensive cap re-check / race-safety) → escalate
+          with a cap reason. Take the **escalate finalize path** below.
+        - Prints **`fix`** → take the **fix finalize path** below.
+
+   **Fix finalize path** (units present, gate printed `fix`):
+   1. Loop `result.fix_plan.units` **in dependency order** (the `units` array is
+      emitted ordered; respect each unit's `dependencies`). For each unit, invoke
+      `/implement-unit` via the Skill tool, mapping only `unit.model`,
+      `unit.scope`, `unit.context`, `unit.commit_intent` into its parameters
+      (`id` / `dependencies` / `resolves_ids` are for your ordering and the Step 4
+      comment, not passed through). The draft PR already exists — open **NO** new
+      PR.
+   2. Run **Step 4** (post the PR-comment summary; its disposition section uses the
+      **fixing-pass** prose — see Step 4).
+   3. Run **Step 5** (cleanup — it self-guards and no-ops if the QA server never
+      started).
+   4. Write the `qa` phase-completed marker (use `dangerouslyDisableSandbox: true`
+      — it invokes `gh`); apply **NO** `dispatch:qa-done`:
+      ```bash
+      .claude/skills/dispatch-propagate/scripts/dispatch-mark-complete \
+        --phase qa --pr "$PR_NUM"
+      ```
+   5. **STOP.**
+
+   **Escalate finalize path** (cap reached, scope-deviation, planning-failed, or
+   the gate printed `escalate`):
+   1. Run **Step 4** (post the PR-comment summary; non-fixing-pass / escalation
+      prose).
+   2. Run **Step 5** (cleanup — self-guards).
+   3. Escalate per the **Escalation** section (`dispatch-mark-deviation`), tailored
+      to the reason that fired (cap reached / scope-deviation with
+      `deviation_reason` / planning-failed).
+   4. **STOP.**
+
+   **CRITICAL invariants — state and obey these:**
+
+   - **The fix path HARD-STOPS the skill.** After the `/implement-unit` loop +
+     Step 4 + Step 5 + `dispatch-mark-complete --phase qa`, the skill MUST stop and
+     MUST NOT fall through to Step 6. If it fell through, Step 6 would escalate the
+     residue — producing **both** a fix AND an escalation in the same pass. The
+     auto-fix lane writing the `qa` marker is **terminal** for this pass.
+
+   - **Mixed case = fix-first, escalate NOTHING that pass.** The lane fires
+     whenever `opusFixable` is non-empty **regardless** of co-present `needs-main`
+     / `needs-human` items. A fixing pass fixes only the opus-fixable units and
+     **escalates nothing** — it fixes, writes the `qa` marker, and stops. The
+     deferred human/main items re-surface on the re-QA tick; once **no**
+     opus-fixable items remain, *that* later run escalates them via the normal
+     Step 6 path. Do **not** escalate co-present human/main items "while we're
+     here."
+
+   - **Re-QA mechanism.** The fix commits (landed per-unit by `/implement-unit`'s
+     `/commit-merge-push`) restart CI. qa-fix wrote a `qa` phase-completed marker
+     with **no** `dispatch:qa-done`, so the chain re-derives `qa` once CI passes
+     (`dispatch-phase`: qa-done-absent → `qa`) and re-QAs the fixed build. Because
+     qa-fix writes a marker (the Stop hook's "phase advanced" branch), the qa-fix
+     **attempt cap is enforced HERE in this skill**, not in the stop hook — no
+     `dispatch-stop.sh` change is needed.
+
+   - **Known pre-existing race (flag, do NOT "fix").** If a Stop hook fires after a
+     fix push but before GitHub registers the new pending checks, the rollup could
+     read the prior green state → ready → a spurious same-phase office-hours park.
+     This TOCTOU window already governs **every** `fix-*` phase; commit-merge-push
+     pushes synchronously and CI registration is near-immediate, so the worst case
+     is a spurious office-hours park (the spawned tick re-gates), **never lost
+     work** — re-QA rediscovers deferred items regardless. State this so a future
+     reader does not "fix" it by adding a qa-fix-attempt branch to the stop hook.
 
 4. **Post the PR-comment summary.**
 
@@ -468,18 +622,26 @@ Otherwise run all steps in order.
      `/office-hours` walkthrough can pick them up.
    - List of bugs found (if any), each with the item title and the finding.
    - When the walkthrough lane ran: the GIF filename (`tmp/qa-fix-walkthrough-<n>.gif`).
-   - **Disposition triage (report-only)** — include this section only when the
-     residue list was non-empty (i.e. Step 3.5 ran). For each residue item, list
-     its `class` from `result.dispositions`. For non-aesthetic `needs-human`
-     items (where `dispositions[item].aesthetic === false`), include the verify
-     verdict and rationale from the matching entry in `result.verify_report`
-     (matched by `id`). For aesthetic `needs-human` items, use
-     `dispositions[item].verify` (which will be `n/a`) directly — no
-     `verify_report` entry exists for them. Add explicit prose: **"This section
-     is informational only. Every residue item still escalates to office-hours
-     below, exactly as before. The disposition triage changes no terminal
-     behavior."** If the residue list was empty (Step 3.5 was skipped), omit this
-     section entirely.
+   - **Disposition triage** — include this section only when the residue list was
+     non-empty (i.e. Step 3.5 ran). For each residue item, list its `class` from
+     `result.dispositions`. For non-aesthetic `needs-human` items (where
+     `dispositions[item].aesthetic === false`), include the verify verdict and
+     rationale from the matching entry in `result.verify_report` (matched by `id`).
+     For aesthetic `needs-human` items, use `dispositions[item].verify` (which will
+     be `n/a`) directly — no `verify_report` entry exists for them. If the residue
+     list was empty (Step 3.5 was skipped), omit this section entirely.
+
+     The terminal-behavior prose is **conditional** on which Step-3.6 path this
+     pass took:
+     - **Fixing pass** (Step 3.6 took the fix finalize path): say which items were
+       fixed and which were deferred — e.g. **"Fixed this pass: \<opus-fixable
+       items>; deferred to re-QA: \<needs-human / needs-main items>."** The fixed
+       commits restart CI and the chain re-QAs once it passes; the deferred items
+       re-surface on a later pass.
+     - **Non-fixing pass** (no opus-fixable items, so residue escalates; or the
+       Step-3.6 escalate finalize path fired) — keep the existing escalation
+       framing: every residue item escalates to office-hours below, exactly as
+       before.
 
    Post via (use `dangerouslyDisableSandbox: true` — the script invokes `gh`):
    ```bash
@@ -498,10 +660,24 @@ Otherwise run all steps in order.
 
 6. **Terminal disposition.**
 
-   This PR is report-only: the disposition triage records each residue item's
-   class in the Step 4 comment but changes no terminal behavior — every residue
-   item (FAIL, needs-human-judgment, main-gated fail) still escalates to
-   office-hours exactly as before.
+   Three outcomes, in **precedence order**:
+
+   1. **Auto-fix applied** (handled entirely in Step 3.6's fix finalize path) — the
+      lane fixed the opus-fixable units, wrote the `qa` marker with **no**
+      `qa-done`, and deferred any co-present `needs-human` / `needs-main` items to
+      re-QA. This **outranks** escalate-residue: a fixing pass escalates nothing.
+      **Step 6 is not reached on a fixing pass** — Step 3.6 already STOPPED. The
+      re-QA mechanism and the known pre-existing TOCTOU race are documented in Step
+      3.6.
+
+   2. **Escalate residue** (reached only on a non-fixing pass — no opus-fixable
+      items to fix, so Step 3.6 fell through; *or* a cap/scope-deviation/
+      planning-failed escalate already finalized in Step 3.6 and STOPPED before
+      here) — the existing office-hours escalation path, unchanged (see the
+      **User-input blocker** branch below and the **Escalation** section).
+
+   3. **Clean pass** — no residue at all: `dispatch-complete-phase qa` +
+      `dispatch-mark-complete`, unchanged (see **Clean autonomous pass** below).
 
    **Clean autonomous pass** — every `script-verifiable` and `needs-browser` item
    PASSed, zero `needs-human-judgment` items were recorded, and no bug was found:
@@ -561,8 +737,10 @@ residue).
 
 Tailor the reason text to the blocker that actually fired (malformed/empty triage
 plan, `needs-human-judgment` item, `script-verifiable`/`needs-browser` FAIL, failed
-pre-QA check, Chrome extension unavailable, multi-app choice, merge conflict). Then
-**stop**.
+pre-QA check, Chrome extension unavailable, multi-app choice, merge conflict, **the
+qa-fix attempt cap reached on opus-fixable residue**, or **a planner scope-deviation
+on the opus-fixable residue** — pass `result.fix_plan.deviation_reason` for the
+latter). Then **stop**.
 Marking a deviation is **terminal** for the walkthrough — do not restart the QA
 server or re-run the walkthrough after escalating.
 
@@ -571,3 +749,13 @@ server or re-run the walkthrough after escalating.
 The skill is idempotent: a re-invocation with `dispatch:qa-done` already on the
 PR skips Steps 0.5–6 and returns. The label is this skill's terminal action and
 is already applied, so re-entry is a true no-op.
+
+The auto-fix lane (Step 3.6) is bounded on re-invocation by two durable side
+effects. Each `/implement-unit` lands a **durable commit** via
+`/commit-merge-push`, so a re-invocation mid-fix does not redo committed units —
+it re-QAs against the already-landed work. And the `dispatch-qa-fix-attempt` gate
+applies **exactly one** `dispatch:qa-fix-attempt-<n>` label per fixing pass, so
+the number of fixing passes per PR is hard-capped at `CAP` (default 2,
+`DISPATCH_QA_FIX_ATTEMPT_CAP`): at the cap the lane escalates instead of fixing.
+Together the durable commits + the attempt label bound both the work redone and
+the total number of fix attempts.

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -617,11 +617,17 @@ Otherwise run all steps in order.
 
    2. Otherwise (opus-fixable items present), choose exactly one path:
 
-      - **`result.fix_plan === null`** (planning did not run — `plan_fix` was
-        false because at the cap; a dead planning agent also yields `null`, so the
-        reason is "cap reached or planning did not run") → **escalate** all residue
-        to office-hours with a cap-reached reason. Take the **escalate finalize
-        path** below; apply **no** attempt label.
+      - **`result.fix_plan === null`** → **escalate** all residue to office-hours;
+        take the **escalate finalize path** below and apply **no** attempt label.
+        Distinguish the two failure modes that both yield `null` so operators see
+        the correct remediation:
+        - **`plan_fix` was false** (the attempt count `ATTEMPT_N >= CAP`, so
+          planning was deliberately not run) → use a **"cap reached"** reason. The
+          remediation is to wait for the cap to reset.
+        - **`plan_fix` was true but `fix_plan` is `null`** (the planning agent died
+          without returning a plan) → use a distinct **"planning agent did not
+          return a plan"** reason. The remediation is to re-trigger the planner, not
+          to wait for a cap reset.
 
       - **`result.deviation === true`** → **scope-deviation escape**: the planner
         refused to author a fix because the change exceeds QA-fix scope. Escalate

--- a/.claude/workflows/qa-fix.js
+++ b/.claude/workflows/qa-fix.js
@@ -1,42 +1,59 @@
 /*
- * qa-fix.js — the QA disposition-triage Workflow (issue #1551, sub-issue of
- * epic #1550). REPORT-ONLY.
+ * qa-fix.js — the QA disposition-triage + gated fix-planning Workflow (issue
+ * #1553, building on #1551, sub-issues of epic #1550).
  *
  * WHAT THIS IS
  * ------------
  * A self-contained, sandboxed Workflow-tool script structurally modeled on
- * .claude/workflows/review-fix.js, but it FIXES NOTHING. It does NOT apply code
- * changes, does NOT prepare any filings, and does NOT fan out Opus fixes. It
- * ONLY: classifies each QA residue item (opus-fixable / needs-main /
- * needs-human), adversarially verifies the non-aesthetic `needs-human` calls
- * with Sonnet skeptics, and returns the resulting dispositions. It changes no
- * escalation behavior — `deviation` is hard-coded `false`.
+ * .claude/workflows/review-fix.js. It ALWAYS classifies each QA residue item
+ * (opus-fixable / needs-main / needs-human), adversarially verifies the
+ * non-aesthetic `needs-human` calls with Sonnet skeptics, and returns the
+ * resulting dispositions.
+ *
+ * It is REPORT-ONLY when `plan_fix` is false (the #1551 callers): it emits no
+ * fix plan and `deviation` is `false`. WHEN `plan_fix` is true AND at least one
+ * opus-fixable disposition exists, it ALSO runs a read-only `fix-plan` phase that
+ * emits an ordered fix plan (a unit list) plus a LIVE `deviation` flag.
+ *
+ * It still FIXES NOTHING ITSELF: the planning agent is READ-ONLY — it reasons
+ * over the residue + diff + acceptance criteria and runs no tools and mutates
+ * nothing. The actual mutating `/implement-unit` loop that builds each planned
+ * unit runs in the qa-fix SKILL caller thread, NOT in this Workflow.
  *
  * args IN:
  *   { pr_num, issue_num, app_dir, browser_available:bool, firestore_caveat:bool,
  *     residue:[ { id, title, kind:"fail"|"needs-human-judgment"|"main-gated-fail",
- *       url_path, expected_outcome, finding, page_text, screenshot_path } ] }
+ *       url_path, expected_outcome, finding, page_text, screenshot_path } ],
+ *     plan_fix:bool,             // when true (+ opus-fixable items exist), run fix-plan
+ *     acceptance_criteria:string, // issue acceptance criteria the plan must satisfy
+ *     changed_files:string }      // the --diff file list + hunks scoping the plan
  *
- * return OUT (the ONLY thing this script returns):
+ * return OUT:
  *   { dispositions:[ { id, title, kind, class, aesthetic, verify, rationale } ],
  *     verify_report:[ { id, verdict, skeptic_votes, rationale } ],
- *     deviation:false }
+ *     fix_plan: { units, deviation, deviation_reason } | null,
+ *     deviation:boolean }
  *   - dispositions: one entry PER residue item, in input order. `class` is the
  *     FINAL class after any downgrade. `verify` is "Upheld"|"Refuted"|
  *     "Unverified"|"n/a".
  *   - verify_report: one entry per NON-AESTHETIC needs-human candidate that went
  *     through the skeptic fan-out. `verdict` is "refuted"|"upheld"|"unverified".
- *   - deviation: literal false (report-only never asserts auto-ready behavior).
+ *   - fix_plan: the ordered Opus fix plan ({ units, deviation, deviation_reason })
+ *     when the fix-plan phase ran; `null` when it did not (plan_fix false/absent,
+ *     no opus-fixable items, or the planning agent died).
+ *   - deviation: LIVE — `fix_plan.deviation` when the phase ran, else `false`.
  *
  * NORMATIVE SPEC for the inline downgrade kernel below is the pure bash/jq
  * script (the JS helper is kept thin so it cannot drift from its spec):
  *   - applyQaDisposition ← .claude/skills/dispatch-propagate/scripts/dispatch-qa-disposition
+ *   The applyQaDisposition kernel and its normative dispatch-qa-disposition
+ *   mirror are UNCHANGED by #1553.
  */
 
 export const meta = {
   name: 'qa-fix',
-  description: 'QA disposition triage (report-only, #1551): classify each QA residue item opus-fixable / needs-main / needs-human, adversarially verify the needs-human calls, return the classes. Changes no escalation behavior.',
-  phases: [{ title: 'classify' }, { title: 'verify' }],
+  description: 'QA disposition triage + gated fix-planning (#1553): classify each QA residue item opus-fixable / needs-main / needs-human and adversarially verify the needs-human calls; when plan_fix is set and opus-fixable items exist, emit an ordered Opus fix plan and a live deviation flag.',
+  phases: [{ title: 'classify' }, { title: 'verify' }, { title: 'fix-plan' }],
 };
 
 // --- schemas -----------------------------------------------------------------
@@ -70,6 +87,47 @@ const VERDICT_SCHEMA = {
   properties: {
     verdict: { enum: ['refuted', 'upheld'] },
     rationale: { type: 'string' },
+  },
+};
+
+// The PLAN shape (#1553): an ordered unit list mirroring office-hours' unit
+// breakdown + /implement-unit's param contract (model, scope, context,
+// commit_intent). This is NOT review-fix's FIX_SCHEMA — that is an edit-agent
+// OUTPUT shape; this is what the read-only planner emits for the caller's
+// /implement-unit loop to consume. `deviation_reason` is semantically
+// required-when-deviation; `units` is empty when deviation is true.
+const FIX_PLAN_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['deviation', 'deviation_reason', 'units'],
+  properties: {
+    deviation: { type: 'boolean' },
+    deviation_reason: { type: 'string' },
+    units: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: [
+          'id',
+          'scope',
+          'model',
+          'dependencies',
+          'commit_intent',
+          'context',
+          'resolves_ids',
+        ],
+        properties: {
+          id: { type: 'string' },
+          scope: { type: 'string' },
+          model: { enum: ['opus', 'sonnet'] },
+          dependencies: { type: 'array', items: { type: 'string' } },
+          commit_intent: { type: 'string' },
+          context: { type: 'string' },
+          resolves_ids: { type: 'array', items: { type: 'string' } },
+        },
+      },
+    },
   },
 };
 
@@ -324,8 +382,99 @@ const verify_report = candidates.map((c) => {
   };
 });
 
+// --- 4. FIX-PLAN (gated, one read-only Opus planner) -------------------------
+// Runs ONLY when the caller opted in (plan_fix) AND there is at least one
+// opus-fixable disposition to plan against. Otherwise fix_plan stays null and
+// `deviation` below falls back to false — preserving the #1551 report-only
+// contract for absent/false plan_fix callers.
+const opusFixable = dispositions.filter((d) => d.class === 'opus-fixable');
+
+let fix_plan = null;
+if (_a.plan_fix === true && opusFixable.length > 0) {
+  phase('fix-plan');
+  log(`fix-plan: planning ${opusFixable.length} opus-fixable item(s)`);
+
+  // Join each opus-fixable disposition with its residue detail so the planner
+  // sees the full finding/expected_outcome/page_text context.
+  const planItems = opusFixable.map((d) => {
+    const r = residueById.get(d.id);
+    return {
+      id: d.id,
+      title: d.title,
+      finding: r ? r.finding : '',
+      expected_outcome: r ? r.expected_outcome : '',
+      page_text: r ? r.page_text : '',
+    };
+  });
+
+  const fixPlanPrompt = [
+    'You are the QA auto-fix PLANNER. You emit an ordered list of implementation',
+    'units that will fix the opus-fixable QA findings below. You write NO code,',
+    'run NO tools, and mutate NOTHING — you only reason over the data provided',
+    'and produce a plan.',
+    '',
+    UNTRUSTED_GUARD,
+    '',
+    'YOUR JOB:',
+    '- Emit an ordered `units` array. Each unit is ONE logical change.',
+    '- For each unit choose `model` per the /implement-unit heuristic:',
+    '  - "sonnet" for well-specified, mechanical work (clear diff shape, rote',
+    '    wiring, boilerplate, explicit-case unit tests).',
+    '  - "opus" for judgment-heavy work (cross-cutting design, tricky ordering,',
+    '    unfamiliar subsystems, plans that leave decisions for implementation).',
+    '  - If unsure, pick "opus".',
+    '- `dependencies`: ids of other units this one depends on (ordering).',
+    '- `commit_intent`: the "why" for the commit message.',
+    '- `context`: the plan/issue context the implement subagent needs to do the',
+    '  work without re-deriving it.',
+    '- `resolves_ids`: which opus-fixable residue ids (below) this unit fixes.',
+    '',
+    'SCOPE-DEVIATION ESCAPE: if ANY needed fix would exceed the PR\'s scope —',
+    'change behavior the PR does not deliver, touch files outside the concern of',
+    'the changed-files diff below, or require a decision the issue does not',
+    'authorize — set "deviation": true with a one-line "deviation_reason" and',
+    'emit an EMPTY "units" array (emit no units).',
+    '',
+    'Otherwise set "deviation": false, "deviation_reason": "" (empty string), and',
+    'emit the ordered units.',
+    '',
+    'Return { "deviation", "deviation_reason", "units": [ { "id", "scope",',
+    '"model", "dependencies", "commit_intent", "context", "resolves_ids" }, ... ] }.',
+    '',
+    '<untrusted>',
+    'OPUS-FIXABLE FINDINGS:',
+    JSON.stringify(planItems, null, 2),
+    '',
+    'CHANGED FILES (PR diff file list + hunks — the scope boundary):',
+    String(_a.changed_files || ''),
+    '',
+    'ACCEPTANCE CRITERIA:',
+    String(_a.acceptance_criteria || ''),
+    '</untrusted>',
+  ].join('\n');
+
+  const planRes = await agent(fixPlanPrompt, {
+    model: 'opus',
+    agentType: 'general-purpose',
+    schema: FIX_PLAN_SCHEMA,
+    label: 'fix-plan',
+    phase: 'fix-plan',
+  });
+  // Agent death → planRes is null → fix_plan stays null → `deviation` below
+  // falls back to false. No extra branch needed; this assignment cannot throw.
+  fix_plan = planRes;
+  log(
+    fix_plan
+      ? `fix-plan: ${fix_plan.units ? fix_plan.units.length : 0} unit(s), deviation=${fix_plan.deviation}`
+      : 'fix-plan: planning agent returned null — fix_plan=null'
+  );
+} else {
+  log(`fix-plan: skipped (plan_fix=${_a.plan_fix}, opusFixable=${opusFixable.length})`);
+}
+
 return {
   dispositions,
   verify_report,
-  deviation: false,
+  fix_plan,
+  deviation: fix_plan ? fix_plan.deviation : false,
 };

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ result
 /.gitmodules
 /.mcp.json
 /.claude/commands
+/.claude/scheduled_tasks.lock
 /.idea
 /.vscode


### PR DESCRIPTION
Closes #1553

Closes the QA auto-fix loop for the `opus-fixable` residue class. Today `/qa-fix`
(after #1551) classifies QA residue into `opus-fixable` / `needs-main` /
`needs-human` but the result is report-only — every residue item escalates to
office-hours. This PR makes the `opus-fixable` class autonomously fixable: plan
and apply the fix, commit it per unit, write the `qa` phase-completed marker
**without** `dispatch:qa-done`, and let the dispatch chain re-derive the phase and
re-QA the fixed build. This is the same loop office-hours runs manually today, now
made autonomous. It is the backwards-incompatible step of the autonomous-fixing QA
epic #1550 (sibling #1552 will later file follow-ups for `needs-main`).

## What changed

- **New `dispatch-qa-fix-attempt` helper** — reads the highest
  `dispatch:qa-fix-attempt-N` PR label and either prints `escalate` at the cap
  (default 2, env-overridable via `DISPATCH_QA_FIX_ATTEMPT_CAP`; applies no label)
  or bumps the counter label and prints `fix`. Bounds auto-fix retries. Modeled on
  `dispatch-schedule-target-reseed`.

- **New read-only `fix-plan` phase in `.claude/workflows/qa-fix.js`** — when
  `plan_fix` is set and at least one `opus-fixable` disposition exists, a single
  Opus planner agent emits an ordered `/implement-unit` list (id, scope, model,
  dependencies, commit_intent, context, resolves_ids) plus a live `deviation` flag
  with a scope-deviation escape. The planner is read-only; the mutating implement
  loop stays in the skill caller thread. Backward-compatible: absent/false
  `plan_fix` leaves `fix_plan` null and `deviation` false, preserving the #1551
  contract.

- **Auto-fix lane wired into `qa-fix/SKILL.md` (Step 3.6)** — on `opus-fixable`
  residue, under cap, with a non-deviating plan: run the attempt gate, loop
  `/implement-unit` per unit, post the PR comment, clean up, write the `qa` marker
  (no `qa-done`), and stop. The fix path hard-stops before Step 6, so a fixing pass
  fixes-first and escalates nothing — co-present human/main items defer to re-QA and
  re-surface once no opus-fixable remain. Cap-reached and scope-deviation both
  escalate to office-hours via the existing path. Step 6 is rewritten to a
  three-way auto-fix / escalate / clean precedence.

- **Tests** — six cases for `dispatch-qa-fix-attempt` (bump, at-cap escalate,
  env-cap, fail-closed integer guards, create-on-not-found label path) in the
  existing `test-dispatch-scripts.sh` scaffold.

## Re-QA mechanism

The fix commits restart CI. Because qa-fix writes a `qa` marker with no
`dispatch:qa-done`, the chain re-derives `qa` once CI passes and re-QAs the fixed
build. The attempt cap is enforced in the skill (the marker takes the Stop hook's
"phase advanced" branch), so no `dispatch-stop.sh` change is needed. The
`applyQaDisposition` kernel and its `dispatch-qa-disposition` mirror are unchanged.

## Verification

- `test-dispatch-scripts.sh` full suite green with the six new `dispatch-qa-fix-attempt`
  cases (+21 assertions).
- `node --check .claude/workflows/qa-fix.js` passes; absent/false `plan_fix` keeps
  the report-only return shape.
