### PR TITLE
dispatch-select-target: deprioritize enhancement issues below all non-enhancement work

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-enhancement-backlog-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-enhancement-backlog-sweep
@@ -82,12 +82,12 @@ failed=0
 
 while IFS= read -r n; do
   [[ -z "$n" ]] && continue
-  if gh issue edit "$n" --remove-label enhancement 2>/dev/null; then
-    log "STRIPPED: #$n"
+  if out=$(gh issue edit "$n" --remove-label enhancement 2>&1); then
+    log "STRIPPED: #$n${out:+ — $out}"
     stripped=$((stripped + 1))
   else
-    log "ERROR: failed to remove enhancement label from #$n"
-    echo "WARNING: could not strip enhancement from #$n" >&2
+    log "ERROR: failed to remove enhancement label from #$n — $out"
+    echo "WARNING: could not strip enhancement from #$n — $out" >&2
     failed=$((failed + 1))
   fi
 done <<<"$issue_nums"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-enhancement-backlog-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-enhancement-backlog-sweep
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# ============================================================
+# ONE-TIME BACKLOG SWEEP — issue #1473 rollout ONLY
+# ============================================================
+# Strips the legacy "enhancement" label from every open issue.
+#
+# WHY THIS EXISTS:
+#   PR #1472 makes "enhancement" a meaningful deferral marker: phase skills
+#   now apply it to genuine follow-up issues filed via /file-issue --follow-up.
+#   Before #1472, ALL open enhancement-labeled issues inherited the label
+#   from GitHub's default label set or from ad-hoc tagging — none are
+#   dispatch-managed deferral markers.
+#
+# #1472 MERGED 2026-06-14 04:00 UTC.  As of that moment the window started
+# closing: every new enhancement issue a phase skill files is a real deferral.
+# This sweep cannot distinguish a legacy label from a legitimate deferral
+# marker — it strips them all.  Run it ONCE, PROMPTLY, before any phase skill
+# files its first --follow-up enhancement issue.
+#
+# DO NOT RUN THIS AFTER THE WINDOW HAS CLOSED.  If any phase skill has already
+# filed a --follow-up issue with the enhancement label, running this sweep will
+# destroy that deferral marker and the router will mis-route those issues.
+#
+# NOT a re-runnable utility.  Run once at rollout and delete or archive it.
+# ============================================================
+#
+# Usage:
+#   dispatch-enhancement-backlog-sweep
+#
+# Exit codes:
+#   0  sweep completed (individual item failures do not change the exit code).
+#   2  invalid invocation.
+#
+# NOT set -e: per-item failures must not abort the sweep — every issue must
+# get an attempt.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=./lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PROJECT_ROOT=$(resolve_project_root) \
+  || { echo "ERROR: not in a git repo" >&2; exit 2; }
+
+LOG_FILE="${DISPATCH_ENHANCEMENT_SWEEP_LOG_FILE:-$PROJECT_ROOT/tmp/dispatch-enhancement-backlog-sweep.log}"
+mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
+
+log() {
+  local ts
+  ts=$(date -u +%FT%TZ)
+  printf '%s [dispatch-enhancement-backlog-sweep] %s\n' "$ts" "$*" >>"$LOG_FILE" 2>/dev/null || true
+}
+
+# Reject any argument — this script has only one mode.
+if [[ $# -gt 0 ]]; then
+  echo "ERROR: unknown argument(s): $*" >&2
+  echo "usage: dispatch-enhancement-backlog-sweep" >&2
+  exit 2
+fi
+
+log "START: querying open enhancement-labeled issues"
+
+# Fetch all open issues with the enhancement label.
+# Use --jq to extract numbers on the gh side, avoiding the echo-into-jq trap.
+# --limit 300 covers the full open backlog (97 verified at time of writing).
+if ! issue_nums=$(gh issue list \
+      --label enhancement \
+      --state open \
+      --limit 300 \
+      --json number \
+      --jq '.[].number'); then
+  log "ERROR: gh issue list failed — aborting"
+  echo "ERROR: gh issue list --label enhancement failed" >&2
+  exit 1
+fi
+
+total=$(printf '%s\n' "$issue_nums" | grep -c '[0-9]' || true)
+log "FOUND: $total open enhancement-labeled issues to sweep"
+
+stripped=0
+failed=0
+
+while IFS= read -r n; do
+  [[ -z "$n" ]] && continue
+  if gh issue edit "$n" --remove-label enhancement 2>/dev/null; then
+    log "STRIPPED: #$n"
+    stripped=$((stripped + 1))
+  else
+    log "ERROR: failed to remove enhancement label from #$n"
+    echo "WARNING: could not strip enhancement from #$n" >&2
+    failed=$((failed + 1))
+  fi
+done <<<"$issue_nums"
+
+log "DONE: stripped=$stripped failed=$failed total=$total"
+echo "dispatch-enhancement-backlog-sweep: done. stripped=$stripped failed=$failed total=$total" >&2
+echo "Log: $LOG_FILE" >&2
+
+exit 0

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -45,8 +45,11 @@
 # Default-mode priority, top to bottom:
 #   1. JIT scan (jit-reminder)
 #   2. origin/main CI health gate (main-broken)
-#   3. the priority × topic-category × phase ladder over open PRs and
-#      help-wanted issues
+#   3. the priority × enhancement × topic-category × phase ladder over open PRs
+#      and help-wanted issues. The enhancement axis applies to the ISSUE path
+#      only: within a priority tier all non-enhancement work (PRs and
+#      non-enhancement issues) drains before any enhancement issue. PRs are never
+#      enhancement-classified, so an in-flight PR completes normally.
 #
 # --health-only mode runs the JIT scan and the origin/main CI health gate, then
 # exits — no queue scan, no PR/issue fetches. /dispatch-propagate SKILL.md uses
@@ -86,14 +89,25 @@
 # CI-pending items are not selectable. (The single-line contract above, including
 # `waiting <issue#>` and `main-broken <sha>`, still holds for the TOP=1 case.)
 #
-# Selection is three-tier: the `priority` label is the *outermost* axis, topic
-# *category* nests inside it, and the phase *ladder* runs innermost. The
-# selector exhausts the entire `priority=1` tier — every topic category, every
+# Selection nests four axes for the ISSUE path: the `priority` label is the
+# *outermost* axis, the `enhancement` bit nests inside it, topic *category* nests
+# inside that, and the phase *ladder* runs innermost. The selector exhausts the
+# entire `priority=1` tier — every enhancement value, every topic category, every
 # phase — before considering any `priority=0` item, so a `priority` item in a
 # low-ranked topic still outranks every non-priority item in a higher-ranked
-# topic. Within one priority level, topic categories run highest priority first:
+# topic (a priority-escalated enhancement still jumps the queue). Within one
+# priority level, all non-enhancement work (enh=0) drains before any enhancement
+# issue (enh=1); within one (priority, enh) level, topic categories run highest
+# priority first:
 #   security → bug → testing infrastructure → dispatch → landing → fellspiral → budget → print → audio → other
-# and within each (priority, topic) bucket the phase ladder runs innermost.
+# and within each (priority, enh, topic) bucket the phase ladder runs innermost.
+#
+# The enhancement axis applies to the ISSUE path ONLY. A PR is never
+# enhancement-classified — its bucket key stays the 3-part
+# `<category>|<priority>|<phase>` and it is drawn only on the enh=0 pass, so an
+# enhancement issue that has already reached a PR completes normally (its PR is
+# NOT re-deprioritized). An issue's enhancement bit is 1 if its own labels carry
+# `enhancement`, else 0.
 #
 # A PR's category is the highest-priority topic among the labels of every issue
 # it closes (closingIssuesReferences); a PR that closes no issue, or whose
@@ -591,15 +605,26 @@ has_priority_in_labels() {
 # leading/trailing newline) of up to TOP entries, each "<num> <branch>", oldest
 # first. The "|" separator is collision-free — priority bits are literal `0`/`1`,
 # phase names are fixed identifiers, and no TOPIC_CATEGORIES name contains "|".
+# PRs are NOT enhancement-classified: this key stays 3-part (unlike the 4-part
+# FIRST_ISSUE key) and the emission loops draw it only on the enh==0 pass, so an
+# in-flight PR completes normally rather than being deprioritized below
+# enhancement issues.
 # PR_SORTED is pre-sorted oldest-first, so entries accumulate oldest-first. For
 # TOP=1 a bucket holds at most one entry — the oldest — and expands to the bare
 # entry with no trailing newline, byte-identical to the former single-entry map.
 declare -A FIRST_PR
-# Top-N ranked help-wanted issues per (category, priority-bit, phase): key =
-# "<category>|<priority-bit>|<phase>" where phase ∈ {implement, plan}, value = a
-# NEWLINE-DELIMITED list (no leading/trailing newline) of up to TOP "<num>"
-# entries, oldest first. Splitting the bucket by phase lets a planned issue
-# (implement) be selected ahead of an unplanned one (plan) in the same bucket.
+# Top-N ranked help-wanted issues per (category, priority-bit, enh-bit, phase):
+# key = "<category>|<priority-bit>|<enh-bit>|<phase>" where phase ∈ {implement,
+# plan}, value = a NEWLINE-DELIMITED list (no leading/trailing newline) of up to
+# TOP "<num>" entries, oldest first. The enh-bit (1 if the issue carries the
+# `enhancement` label, else 0) is an axis between priority and topic-category:
+# within a priority tier all non-enhancement issues (enh=0) drain before any
+# enhancement issue (enh=1). The issue path is the ONLY enhancement-classified
+# path — PRs are never enhancement-classified, so FIRST_PR keeps the 3-part
+# "<category>|<priority-bit>|<phase>" key (a PR that has already reached a phase
+# completes normally; its in-flight work is not re-deprioritized). Splitting the
+# bucket by phase lets a planned issue (implement) be selected ahead of an
+# unplanned one (plan) in the same bucket.
 declare -A FIRST_ISSUE
 
 # Count the newline-delimited entries stored at <map-name>[<key>] (0 if unset or
@@ -637,20 +662,26 @@ bucket_append() {
   return 0
 }
 
-# group_emittable_count <category> <priority-bit> — total entries the emission
-# loops could draw from this (category, priority) group: FIRST_PR across the PR
-# phase ladder (PHASE_PRIORITY) plus qa, and FIRST_ISSUE across the issue ladder
-# (ISSUE_PHASE_PRIORITY). Drives the walk's global early-exit (#1452): once the
-# strictly-higher-rank groups already hold TOP such entries combined, emission
-# fills its TOP results from them before reaching any lower-rank group, so the
-# remaining lower-rank roots cannot change the output and the walk can stop.
+# group_emittable_count <category> <priority-bit> <enh-bit> — total entries the
+# emission loops could draw from this (category, priority, enh) group:
+# FIRST_ISSUE across the issue ladder (ISSUE_PHASE_PRIORITY) keyed
+# cat|pri|enh|phase always, and FIRST_PR across the PR phase ladder
+# (PHASE_PRIORITY) plus qa keyed cat|pri|phase ONLY when enh==0 — matching the
+# emission order, where PRs (never enhancement-classified, so always in the
+# enh==0 pass) are drawn only on the enh==0 iteration. Drives the walk's global
+# early-exit (#1452): once the strictly-higher-rank groups already hold TOP such
+# entries combined, emission fills its TOP results from them before reaching any
+# lower-rank group, so the remaining lower-rank roots cannot change the output
+# and the walk can stop.
 group_emittable_count() {
-  local _gec_cat="$1" _gec_pri="$2" _gec_total=0 _gec_p
-  for _gec_p in "${PHASE_PRIORITY[@]}" qa; do
-    _gec_total=$(( _gec_total + $(bucket_count FIRST_PR "$_gec_cat|$_gec_pri|$_gec_p") ))
-  done
+  local _gec_cat="$1" _gec_pri="$2" _gec_enh="$3" _gec_total=0 _gec_p
+  if (( _gec_enh == 0 )); then
+    for _gec_p in "${PHASE_PRIORITY[@]}" qa; do
+      _gec_total=$(( _gec_total + $(bucket_count FIRST_PR "$_gec_cat|$_gec_pri|$_gec_p") ))
+    done
+  fi
   for _gec_p in "${ISSUE_PHASE_PRIORITY[@]}"; do
-    _gec_total=$(( _gec_total + $(bucket_count FIRST_ISSUE "$_gec_cat|$_gec_pri|$_gec_p") ))
+    _gec_total=$(( _gec_total + $(bucket_count FIRST_ISSUE "$_gec_cat|$_gec_pri|$_gec_enh|$_gec_p") ))
   done
   echo "$_gec_total"
 }
@@ -855,48 +886,57 @@ done < <(printf '%s' "$PR_LIST" | jq -r '
 # help-wanted issue — is what gets recorded; the category is still the
 # top-level issue's own.
 #
-# The roots are now emitted in (priority desc, category-rank asc, createdAt asc)
-# order — the SAME rank order the emission loops drain — so each (priority,
-# category) group's roots are contiguous, enabling the walk's global early-exit
-# (#1452). The category/priority/cat-rank expressions are the exact ones used by
-# category_of_labels / has_priority_in_labels / the CATEGORIES iteration order,
-# so bucket keys are unchanged. (1 - .pri) sorts priority=1 first; jq sort_by is
-# stable and createdAt is an ISO string sorting chronologically, so within a
-# (pri, cat-rank) group roots stay oldest-first — byte-identical to the old order
-# for that group. The TSV now carries the precomputed pri/cat-rank/cat columns.
+# The roots are now emitted in (priority desc, enh asc, category-rank asc,
+# createdAt asc) order — the SAME rank order the emission loops drain — so each
+# (priority, enh, category) group's roots are contiguous, enabling the walk's
+# global early-exit (#1452). The enh bit (1 if the issue carries `enhancement`,
+# else 0) nests BETWEEN priority and topic-category: within a priority tier all
+# non-enhancement issues (enh=0) sort before any enhancement issue (enh=1), and
+# enhancement issues then order by the existing topic ladder. The
+# category/priority/cat-rank/enh expressions are the exact ones used by
+# category_of_labels / has_priority_in_labels / the inline `index(...)` idioms /
+# the CATEGORIES iteration order, so bucket keys are unchanged. (1 - .pri) sorts
+# priority=1 first; .enh sorts non-enhancement (0) first; jq sort_by is stable
+# and createdAt is an ISO string sorting chronologically, so within a
+# (pri, enh, cat-rank) group roots stay oldest-first — byte-identical to the old
+# order for that group. The TSV now carries the precomputed pri/enh/cat-rank/cat
+# columns.
 ISSUE_SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r --argjson cats "$TOPIC_CATEGORIES_JSON" '
   [ .[]
     | select((.labels // []) | any(.name == "help wanted"))
     | select((.labels // []) | any(.name == "dispatch:office-hours") | not)
     | ([(.labels // [])[].name]) as $names
     | ($names | if index("priority") then 1 else 0 end) as $pri
+    | ($names | if index("enhancement") then 1 else 0 end) as $enh
     | (first($cats[] | select(. as $c | $names | index($c))) // "other") as $catname
     | (($cats | index($catname)) // ($cats | length)) as $catrank
-    | { number: .number, createdAt: .createdAt, pri: $pri, catrank: $catrank, catname: $catname }
+    | { number: .number, createdAt: .createdAt, pri: $pri, enh: $enh, catrank: $catrank, catname: $catname }
   ]
-  | sort_by([ (1 - .pri), .catrank, .createdAt ])
-  | .[] | [.number, .pri, .catrank, .catname] | @tsv')
+  | sort_by([ (1 - .pri), .enh, .catrank, .createdAt ])
+  | .[] | [.number, .pri, .enh, .catrank, .catname] | @tsv')
 walk_prev_group=""
 walk_prev_cat=""
 walk_prev_pri=""
+walk_prev_enh=""
 walk_cum_emittable=0
-while IFS=$'\t' read -r issue_num issue_pri issue_catrank issue_cat; do
+while IFS=$'\t' read -r issue_num issue_pri issue_enh issue_catrank issue_cat; do
   [[ -z "$issue_num" ]] && continue
-  # Global early-exit across (priority, category) groups (#1452). The walk now
-  # runs in (pri desc, cat-rank asc, createdAt asc) order — the SAME rank order
-  # the emission loops drain. Roots of one group are contiguous, so when the
-  # group changes the previous group is fully resolved: fold its emittable count
-  # (FIRST_PR + FIRST_ISSUE across all its phases) into the cumulative. If the
-  # strictly-higher-rank groups already hold TOP emittable entries combined,
-  # emission reaches TOP within them before ever draining this or any lower-rank
-  # group, so no remaining root can change the output — stop the whole walk.
-  # Sound because EXCLUDED is frozen before the walk: each group's FIRST_ISSUE
-  # buckets are fed only by that group's own roots, so the reorder leaves bucket
-  # contents byte-identical (the within-group createdAt order is preserved).
-  cur_group="$issue_pri|$issue_catrank"
+  # Global early-exit across (priority, enh, category) groups (#1452). The walk
+  # now runs in (pri desc, enh asc, cat-rank asc, createdAt asc) order — the SAME
+  # rank order the emission loops drain. Roots of one group are contiguous, so
+  # when the group changes the previous group is fully resolved: fold its
+  # emittable count (FIRST_ISSUE across all its phases, plus FIRST_PR only when
+  # enh==0) into the cumulative. If the strictly-higher-rank groups already hold
+  # TOP emittable entries combined, emission reaches TOP within them before ever
+  # draining this or any lower-rank group, so no remaining root can change the
+  # output — stop the whole walk. Sound because EXCLUDED is frozen before the
+  # walk: each group's FIRST_ISSUE buckets are fed only by that group's own roots,
+  # so the reorder leaves bucket contents byte-identical (the within-group
+  # createdAt order is preserved).
+  cur_group="$issue_pri|$issue_enh|$issue_catrank"
   if [[ "$cur_group" != "$walk_prev_group" ]]; then
     if [[ -n "$walk_prev_group" ]]; then
-      walk_cum_emittable=$(( walk_cum_emittable + $(group_emittable_count "$walk_prev_cat" "$walk_prev_pri") ))
+      walk_cum_emittable=$(( walk_cum_emittable + $(group_emittable_count "$walk_prev_cat" "$walk_prev_pri" "$walk_prev_enh") ))
     fi
     if (( walk_cum_emittable >= TOP )); then
       break
@@ -904,6 +944,7 @@ while IFS=$'\t' read -r issue_num issue_pri issue_catrank issue_cat; do
     walk_prev_group="$cur_group"
     walk_prev_cat="$issue_cat"
     walk_prev_pri="$issue_pri"
+    walk_prev_enh="$issue_enh"
   fi
   # Skip an open issue already closed by a non-draft (ready) PR (#920).
   [[ -n "${READY_PR_CLOSED_ISSUES[$issue_num]:-}" ]] && continue
@@ -926,8 +967,8 @@ while IFS=$'\t' read -r issue_num issue_pri issue_catrank issue_cat; do
   # entries is the expensive leaf trace pointless. If either implement or plan
   # slot is still under TOP, descend — the leaf's phase isn't known until after
   # the trace.
-  impl_bucket="$issue_cat|$issue_pri|implement"
-  plan_bucket="$issue_cat|$issue_pri|plan"
+  impl_bucket="$issue_cat|$issue_pri|$issue_enh|implement"
+  plan_bucket="$issue_cat|$issue_pri|$issue_enh|plan"
   if (( $(bucket_count FIRST_ISSUE "$impl_bucket") >= TOP )) \
      && (( $(bucket_count FIRST_ISSUE "$plan_bucket") >= TOP )); then
     continue
@@ -1001,7 +1042,7 @@ while IFS=$'\t' read -r issue_num issue_pri issue_catrank issue_cat; do
       # (the cap subsumes the former first-seen guard).
       leaf_phase=plan
       [[ -n "${ISSUE_PLANNED[$leaf]:-}" ]] && leaf_phase=implement
-      leaf_bucket="$issue_cat|$issue_pri|$leaf_phase"
+      leaf_bucket="$issue_cat|$issue_pri|$issue_enh|$leaf_phase"
       root_excl["$leaf"]=1
       if bucket_append FIRST_ISSUE "$leaf_bucket" "$leaf"; then
         root_recorded=$(( root_recorded + 1 ))
@@ -1022,12 +1063,17 @@ while IFS=$'\t' read -r issue_num issue_pri issue_catrank issue_cat; do
   unset root_excl
 done <<< "$ISSUE_SORTED"
 
-# Default mode: priority is the outermost axis (1 then 0), topic category nests
-# inside it, and the phase ladder runs innermost (see the header for the full
-# three-tier order). The entire priority=1 tier — every topic category, every
-# phase — is exhausted before any priority=0 item is considered; within one
-# priority level topic category is the tie-break, and within each
-# (priority, category) bucket the phase ladder runs innermost.
+# Default mode: priority is the outermost axis (1 then 0); the enhancement bit
+# nests inside it (non-enhancement enh=0 then enhancement enh=1) on the ISSUE
+# path only; topic category nests inside that; and the phase ladder runs
+# innermost (see the header for the full order). The entire priority=1 tier is
+# exhausted before any priority=0 item is considered; within one priority level
+# all non-enhancement work drains before any enhancement issue, then topic
+# category is the tie-break, and within each bucket the phase ladder runs
+# innermost. PRs are never enhancement-classified: FIRST_PR / qa buckets keep the
+# 3-part cat|pri|phase key and are drawn ONLY on the enh==0 pass, so a PR that has
+# already reached a phase completes normally rather than being re-deprioritized.
+# Resulting nesting: pri ⊃ enh ⊃ category ⊃ {PRs+qa if enh==0, then issues}.
 #
 # In --priority-only mode the scan loops above already `continue` on every
 # priority=0 item, so FIRST_PR/FIRST_ISSUE hold only priority=1 keys; the pri=0
@@ -1039,27 +1085,33 @@ if (( TOP == 1 )); then
   # holds at most one entry (no trailing newline), so the direct expansion below
   # is byte-identical to the former single-entry map's output.
   for pri in 1 0; do
-    for category in "${CATEGORIES[@]}"; do
-      for phase in "${PHASE_PRIORITY[@]}"; do
-        pr_key="$category|$pri|$phase"
-        if [[ -n "${FIRST_PR[$pr_key]:-}" ]]; then
-          echo "pr ${FIRST_PR[$pr_key]} $phase"
-          exit 0
-        fi
-      done
+    for enh in 0 1; do
+      for category in "${CATEGORIES[@]}"; do
+        # PRs (never enhancement-classified, 3-part key) are drawn only on the
+        # enh==0 pass, so an in-flight PR completes ahead of any enhancement issue.
+        if (( enh == 0 )); then
+          for phase in "${PHASE_PRIORITY[@]}"; do
+            pr_key="$category|$pri|$phase"
+            if [[ -n "${FIRST_PR[$pr_key]:-}" ]]; then
+              echo "pr ${FIRST_PR[$pr_key]} $phase"
+              exit 0
+            fi
+          done
 
-      qa_key="$category|$pri|qa"
-      if [[ -n "${FIRST_PR[$qa_key]:-}" ]]; then
-        echo "pr ${FIRST_PR[$qa_key]} qa"
-        exit 0
-      fi
-
-      for iphase in "${ISSUE_PHASE_PRIORITY[@]}"; do
-        issue_key="$category|$pri|$iphase"
-        if [[ -n "${FIRST_ISSUE[$issue_key]:-}" ]]; then
-          echo "issue ${FIRST_ISSUE[$issue_key]}"
-          exit 0
+          qa_key="$category|$pri|qa"
+          if [[ -n "${FIRST_PR[$qa_key]:-}" ]]; then
+            echo "pr ${FIRST_PR[$qa_key]} qa"
+            exit 0
+          fi
         fi
+
+        for iphase in "${ISSUE_PHASE_PRIORITY[@]}"; do
+          issue_key="$category|$pri|$enh|$iphase"
+          if [[ -n "${FIRST_ISSUE[$issue_key]:-}" ]]; then
+            echo "issue ${FIRST_ISSUE[$issue_key]}"
+            exit 0
+          fi
+        done
       done
     done
   done
@@ -1103,18 +1155,24 @@ else
   }
 
   for pri in 1 0; do
-    for category in "${CATEGORIES[@]}"; do
-      for phase in "${PHASE_PRIORITY[@]}"; do
-        drain_bucket FIRST_PR "$category|$pri|$phase" pr "$phase"
-        (( ${#results[@]} >= TOP )) && { printf '%s\n' "${results[@]}"; exit 0; }
-      done
+    for enh in 0 1; do
+      for category in "${CATEGORIES[@]}"; do
+        # PRs (never enhancement-classified, 3-part key) are drained only on the
+        # enh==0 pass, so in-flight PRs complete ahead of any enhancement issue.
+        if (( enh == 0 )); then
+          for phase in "${PHASE_PRIORITY[@]}"; do
+            drain_bucket FIRST_PR "$category|$pri|$phase" pr "$phase"
+            (( ${#results[@]} >= TOP )) && { printf '%s\n' "${results[@]}"; exit 0; }
+          done
 
-      drain_bucket FIRST_PR "$category|$pri|qa" pr qa
-      (( ${#results[@]} >= TOP )) && { printf '%s\n' "${results[@]}"; exit 0; }
+          drain_bucket FIRST_PR "$category|$pri|qa" pr qa
+          (( ${#results[@]} >= TOP )) && { printf '%s\n' "${results[@]}"; exit 0; }
+        fi
 
-      for iphase in "${ISSUE_PHASE_PRIORITY[@]}"; do
-        drain_bucket FIRST_ISSUE "$category|$pri|$iphase" issue ""
-        (( ${#results[@]} >= TOP )) && { printf '%s\n' "${results[@]}"; exit 0; }
+        for iphase in "${ISSUE_PHASE_PRIORITY[@]}"; do
+          drain_bucket FIRST_ISSUE "$category|$pri|$enh|$iphase" issue ""
+          (( ${#results[@]} >= TOP )) && { printf '%s\n' "${results[@]}"; exit 0; }
+        done
       done
     done
   done

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3195,6 +3195,134 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "print issue beats untopiced (other) issue" "issue 300" "$result"
 teardown
 
+# --- enhancement-axis deprioritization (#1473) --------------------------------
+# Within a priority tier, ALL non-enhancement issues (enh=0) drain before any
+# enhancement issue (enh=1). Enhancement applies to the ISSUE path only; PRs
+# are never enhancement-classified and always complete normally. The
+# enhancement bit nests BETWEEN priority and topic: pri ⊃ enh ⊃ topic ⊃ phase.
+
+# ENH1. Default-mode within-tier (criteria 1+2): a plain `audio` issue (enh=0,
+#       lower topic) beats a `bug`+`enhancement` issue (enh=1, higher topic).
+#       Proves non-enhancement outranks enhancement even across topic ranks.
+echo "Test: non-enhancement audio issue beats enhancement bug issue (enh axis outranks topic)"
+setup
+setup_union_pr_list '[]'
+# Issue 200 (older) is audio, enh=0. Issue 100 (newer) is bug+enhancement, enh=1.
+# audio is lower than bug in the topic ladder; enh=0 still beats enh=1.
+printf '[{"number":200,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"audio"}]},{"number":100,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"bug"},{"name":"enhancement"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "non-enh audio beats enh bug (enh axis outranks topic)" "issue 200" "$result"
+teardown
+
+# ENH2. Within the enhancement tier, topic ordering applies: a `security`
+#       enhancement issue beats an `audio` enhancement issue regardless of age.
+echo "Test: security+enhancement issue beats audio+enhancement issue (topic still ranks within enh tier)"
+setup
+setup_union_pr_list '[]'
+# Issue 200 (older) is audio+enhancement. Issue 100 (newer) is security+enhancement.
+# Both enh=1; security ranks above audio, so issue 100 wins.
+printf '[{"number":200,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"audio"},{"name":"enhancement"}]},{"number":100,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"security"},{"name":"enhancement"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "security+enh beats audio+enh (topic ladder within enh tier)" "issue 100" "$result"
+teardown
+
+# ENH3. Criterion 3 — cross-axis: priority is the outermost axis. A
+#       `priority`+`enhancement`+`audio` issue (pri=1, enh=1, low topic) beats
+#       a plain `security` issue (pri=0, enh=0, high topic). Priority outermost
+#       means a priority enhancement still jumps the queue over all non-priority
+#       work regardless of enhancement or topic.
+echo "Test: priority+enhancement+audio beats non-priority non-enhancement security (priority is outermost)"
+setup
+setup_union_pr_list '[]'
+# Issue 100 (older): priority+enhancement+audio (pri=1, enh=1, topic=audio).
+# Issue 200 (newer): security (pri=0, enh=0, topic=security).
+# Despite enhancement and low topic, issue 100 wins because priority is outermost.
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"},{"name":"enhancement"},{"name":"audio"}]},{"number":200,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"security"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "priority+enh+audio beats non-priority security (priority outermost)" "issue 100" "$result"
+teardown
+
+# ENH4. Regression guard — bug/security ordering within non-enh tier unchanged:
+#       a `security` issue still beats a `bug` issue (no enhancement labels).
+#       Guards against a regression where the new enhancement axis disrupts the
+#       existing topic ordering for non-enhancement items.
+echo "Test: security issue beats bug issue with no enhancement labels (regression guard)"
+setup
+setup_union_pr_list '[]'
+# Issue 400 (older) is bug, enh=0. Issue 300 (newer) is security, enh=0.
+# Both non-enhancement; security topic wins (mirrors 30i).
+printf '[{"number":400,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"bug"}]},{"number":300,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"security"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "security beats bug within non-enh tier (no regression)" "issue 300" "$result"
+teardown
+
+# ENH5. --top N multi-line ordering: ALL non-enhancement issues drain before
+#       any enhancement issue, even across topics. Four issues:
+#         30 (security, enh=0), 20 (audio, enh=0),
+#         10 (security, enh=1), 40 (audio, enh=1)
+#       Expected order: 30 → 20 → 10 → 40
+#       The money assertion: enh=0 audio (issue 20) emits before enh=1 security
+#       (issue 10) — the across-topic drain proof.
+echo "Test: --top 4 drains all non-enhancement before any enhancement (across topics)"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":30,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"security"}]},{"number":20,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"audio"}]},{"number":10,"createdAt":"2024-01-03T00:00:00Z","labels":[{"name":"help wanted"},{"name":"security"},{"name":"enhancement"}]},{"number":40,"createdAt":"2024-01-04T00:00:00Z","labels":[{"name":"help wanted"},{"name":"audio"},{"name":"enhancement"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --top 4)
+assert_eq "--top 4 non-enh drains before enh across topics" "$(printf 'issue 30\nissue 20\nissue 10\nissue 40')" "$result"
+# Specifically: non-enh audio (20) precedes enh security (10) — the key drain proof.
+enh_before=$(printf '%s\n' "$result" | grep -n '^issue 20$' | cut -d: -f1)
+enh_after=$(printf '%s\n' "$result" | grep -n '^issue 10$' | cut -d: -f1)
+assert_eq "--top 4: non-enh audio (20) appears before enh security (10)" "1" "$(( enh_before < enh_after ? 1 : 0 ))"
+teardown
+
+# ENH6. --priority-only: within the priority=1 tier, a non-enhancement priority
+#       issue is selected before an enhancement priority issue. Issue B is
+#       priority+audio (non-enh); issue A is priority+security+enhancement.
+#       Despite security ranking above audio in the topic ladder, the non-enh
+#       audio issue wins because enh nests inside priority (mirrors PT1's logic).
+echo "Test: --priority-only selects non-enhancement priority issue before enhancement priority issue"
+setup
+setup_union_pr_list '[]'
+# Issue 200 (older): priority+audio, enh=0. Issue 100 (newer): priority+security+enhancement, enh=1.
+# enh=0 wins over enh=1 even though audio < security in topic ranking.
+printf '[{"number":200,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"},{"name":"audio"}]},{"number":100,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"},{"name":"security"},{"name":"enhancement"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only: non-enh priority audio beats enh priority security" "issue 200" "$result"
+teardown
+
+# ENH7. --qa regression: a QA PR whose closing issue carries `enhancement` is
+#       selected normally and is NOT deprioritized behind a non-enhancement QA
+#       PR. PRs are never enhancement-classified, so the enhancement axis does
+#       not apply. The older PR wins on age regardless of enhancement label.
+echo "Test: --qa: QA PR closing an enhancement issue is not deprioritized (PRs unaffected by enh axis)"
+setup
+# PR 10 (older) closes issue 100 (enhancement). PR 20 (newer) closes issue 200 (no enhancement).
+# Both green draft QA PRs in the same topic (other). PR 10 should win on age.
+UNION='['
+UNION+="$(make_pr_union 10 "10-enh-qa" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP" '[{"number":100}]')"','
+UNION+="$(make_pr_union 20 "20-plain-qa" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP" '[{"number":200}]')"
+UNION+=']'
+setup_union_pr_list "$UNION"
+# Issues 100/200 supply label data (no "help wanted" — not queue items themselves).
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"enhancement"}]},{"number":200,"createdAt":"2024-01-01T00:00:00Z","labels":[]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
+assert_eq "--qa: enh-closing PR 10 wins on age (PRs not enh-classified)" "pr 10 10-enh-qa" "$result"
+teardown
+
 # --- blocked-issue PR skip (issue #786) -------------------------------------
 # dispatch-select-target skips a PR from every PR-ladder tier when any issue it
 # closes is blocked_by an open issue; a closing issue blocked only by


### PR DESCRIPTION
Closes #1473

## What

Makes the dispatch router honor the `enhancement` label as a deferral marker.
Within each priority tier, **all non-enhancement work drains before any
enhancement issue**, and enhancement issues then order by the existing topic
ladder. Priority stays the outermost axis (a `priority`-escalated enhancement
still jumps the queue), and an enhancement issue that has already reached a PR
completes normally (its PR is not re-deprioritized).

The new ranking nesting on the issue-selection path is:

```
priority ⊃ enhancement ⊃ topic-category ⊃ phase
```

## Scope decision: issue selection, not in-flight PRs

The issue's Approach §3 offered two scopes; this PR takes the recommended one:
**deprioritize enhancement issue *selection*, not in-flight PRs.** An enhancement
issue waits behind all non-enhancement work in its tier; an enhancement PR
already in flight (review/qa/fix) is not stranded.

Mechanically, the enhancement axis is added to the **issue path only**. The
`FIRST_ISSUE` bucket key grows from `<category>|<pri>|<phase>` to
`<category>|<pri>|<enh>|<phase>`; the `FIRST_PR` key stays the 3-part
`<category>|<pri>|<phase>` (PRs are never enhancement-classified). This deliberate
asymmetry localizes the diff to the issue path and gives the "PRs complete
normally" behavior for free.

## Units

1. **`dispatch-select-target` — enhancement axis on the issue path.** Adds an
   inline `enh` field to the `ISSUE_SORTED` jq (reusing the existing
   `index("enhancement")` idiom), threads it through the #1452 early-exit walk
   (`group_emittable_count` gains a third `enh` parameter; `FIRST_PR` is counted
   only on the `enh==0` pass), the 4-part issue bucket keys, and both emission
   loops (TOP=1 and TOP>1 gain a `for enh in 0 1` pass nested between priority and
   category; the PR phase ladder + qa are drawn only when `enh==0`). `--qa` mode
   is untouched.

2. **`test-dispatch-scripts.sh` — enhancement-axis coverage.** Seven cases
   (ENH1–ENH7): non-enhancement drains before enhancement within a tier; topic
   ordering inside the enhancement tier; priority stays outermost; `bug`/`security`
   non-enhancement ordering unchanged; full `--top N` cross-topic drain order;
   `--priority-only`; and a `--qa` regression proving an enhancement-derived QA PR
   is not deprioritized. Full suite passes (2668/2668).

3. **`dispatch-enhancement-backlog-sweep` — one-time rollout script.** Strips the
   legacy `enhancement` label from all open issues. See the rollout note below.

## Two intentional deviations from the issue's Approach text

Both are documented so the review pass does not read them as omissions; the
acceptance criteria are still met.

1. **No `has_enhancement_in_labels` bash helper (Approach §1).** Under the chosen
   scope the enhancement bit is needed only for issues, and it is computed inline
   in the `ISSUE_SORTED` jq — exactly as `pri` and `catrank` already are. A
   standalone bash helper mirroring `has_priority_in_labels` would have no caller
   (PRs are not enhancement-classified, and jq cannot call a bash function), so it
   would be dead code (`.claude/rules/code-style.md`). The criteria never
   reference the helper.

2. **`--qa` mode unchanged (Approach §3).** `--qa` selects QA PRs only and never
   emits an issue; since PRs are not enhancement-classified under the chosen scope,
   `--qa` ordering does not change. ENH7 discharges this with a regression test.

## Rollout — run the one-time sweep promptly

`dispatch-enhancement-backlog-sweep` (Unit 3) is a **strictly one-time** op and
is **not** run by the autonomous build — it mutates live GitHub labels. Run it
once, manually, at rollout (`dangerouslyDisableSandbox: true`, per
`.claude/rules/sandbox.md`, since it calls `gh`):

```bash
.claude/skills/dispatch-propagate/scripts/dispatch-enhancement-backlog-sweep
```

**Timing — updated from the persisted plan's premise.** The plan was written
assuming #1472 was still open ("the window is clean today"). **#1472 has since
merged (2026-06-14 04:00 UTC)**, so phase skills can now apply `enhancement` to
genuine deferred follow-ups via `/file-issue --follow-up`. The `enhancement`
label stores no provenance: once a phase skill applies it to a real deferral, a
legacy label is indistinguishable from a legitimate marker.

As of this PR all open enhancement-labeled issues (97, verified) are still
legacy — **zero were created after #1472 merged**. But the window is now
**closing**: run the sweep promptly, before any phase skill files its first
`--follow-up` enhancement issue. Do **not** run it afterward — it would strip
real deferral markers. The script carries a loud header to this effect.

> Belt-and-suspenders option, if you run it after enhancement follow-ups may
> already exist: filter the sweep to issues created before the #1472 merge
> (`createdAt < 2026-06-14T04:00:34Z`). The current script intentionally strips
> all open enhancement labels, per the approved plan; the cutoff is offered here
> as an operator choice, not baked in.

## Verification

- `test-dispatch-scripts.sh`: 2668/2668 pass (this suite is not in CI — run
  manually).
- `bash -n` clean on both `dispatch-select-target` and the new sweep script.
- The sweep script was **not** executed against live GitHub from the build.
