### PR TITLE
test: assert dispatch-spawn-sweep is invoked in the stop-hook Branch P/R tests

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -16353,6 +16353,18 @@ exit 0
 FAKE
   chmod +x "$TMPDIR_TEST/skills/dispatch-propagate/scripts/dispatch-spawn-tick"
 
+  # Fake dispatch-spawn-sweep: log to sweep-calls.log so the Branch P and
+  # Branch R tests can assert the sweep reaper was launched. Mirrors the
+  # spawn-tick fake; without it the hook calls the real (absent) script and
+  # the silent `|| WARNING` fallback hides a regression. Intentionally does
+  # NOT write order.log — sweep ordering is not asserted.
+  cat > "$TMPDIR_TEST/skills/dispatch-propagate/scripts/dispatch-spawn-sweep" <<'FAKE'
+#!/usr/bin/env bash
+echo "sweep" >> "$STUB_DIR/sweep-calls.log"
+exit 0
+FAKE
+  chmod +x "$TMPDIR_TEST/skills/dispatch-propagate/scripts/dispatch-spawn-sweep"
+
   # Fake dispatch-self-close: log to order.log + self-close-calls.log.
   cat > "$TMPDIR_TEST/skills/dispatch-propagate/scripts/dispatch-self-close" <<'FAKE'
 #!/usr/bin/env bash
@@ -17364,6 +17376,8 @@ spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
 assert_eq "parse-job-done: spawn invoked exactly once" "1" "$spawn_calls"
 self_close_calls=$(wc -l < "$STUB_DIR/self-close-calls.log" 2>/dev/null || echo 0)
 assert_eq "parse-job-done: self-close invoked exactly once" "1" "$self_close_calls"
+sweep_calls=$(wc -l < "$STUB_DIR/sweep-calls.log" 2>/dev/null || echo 0)
+assert_eq "parse-job-done: sweep invoked exactly once" "1" "$sweep_calls"
 TOTAL=$((TOTAL + 1))
 if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
   PASS=$((PASS + 1)); echo "  PASS: parse-job-done: no office-hours apply"
@@ -17398,6 +17412,8 @@ spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
 assert_eq "resolved-closed: spawn invoked exactly once" "1" "$spawn_calls"
 self_close_calls=$(wc -l < "$STUB_DIR/self-close-calls.log" 2>/dev/null || echo 0)
 assert_eq "resolved-closed: self-close invoked exactly once" "1" "$self_close_calls"
+sweep_calls=$(wc -l < "$STUB_DIR/sweep-calls.log" 2>/dev/null || echo 0)
+assert_eq "resolved-closed: sweep invoked exactly once" "1" "$sweep_calls"
 TOTAL=$((TOTAL + 1))
 if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
   PASS=$((PASS + 1)); echo "  PASS: resolved-closed: no office-hours apply"


### PR DESCRIPTION
Closes #1595

## Problem

`.claude/hooks/dispatch-stop.sh` defines a `spawn_sweep` helper that launches
`dispatch-spawn-sweep` with a silent `|| WARNING` fallback. Both **Branch P**
(`parse-job-done` sentinel) and **Branch R** (`resolved-closed` sentinel) call
it. But the stop-hook test harness's `stop_setup` stages fakes for
`dispatch-spawn-tick` and `dispatch-self-close` and **no fake for
`dispatch-spawn-sweep`**. Under the harness the hook therefore calls the real
(absent-from-the-fake-tree) script, the silent fallback fires, and the sweep
invocation is never observed — so a regression that removed or broke
`spawn_sweep` from these branches would pass Test R1 and Test P1 unnoticed.

This gap was surfaced by the review of PR #1584.

## Change

All edits are in
`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`:

- Stage a `dispatch-spawn-sweep` fake in `stop_setup` that logs to
  `sweep-calls.log`, mirroring the `dispatch-spawn-tick` fake. It intentionally
  does **not** write `order.log` — sweep is not part of any ordering assertion,
  so keeping it out cannot perturb the existing spawn/self-close ordering test.
- Add a `sweep invoked exactly once` assertion to **Test R1** (resolved-closed)
  and **Test P1** (parse-job-done), reusing the existing
  `wc -l … || echo 0` + `assert_eq` idiom.

`exactly once` is correct because every `stop_setup` mints a fresh `STUB_DIR`
via `mktemp -d` (per-test line count), and each branch terminates after its
single spawn.

No change to `.claude/hooks/dispatch-stop.sh` — the `spawn_sweep` helper and
both branch call sites already exist and are correct.

## Verification

- Full `test-dispatch-scripts.sh` suite passes (2662/2662); the two new
  `… : sweep invoked exactly once` assertions pass.
- Regression-catch check: temporarily removing the Branch R `spawn_sweep` call
  (from a hook *copy* only — the real hook untouched) makes the new
  `resolved-closed: sweep invoked exactly once` assertion fail (got 0), while
  spawn and self-close still pass — confirming the assertion catches a Branch R
  regression.
