### PR TITLE
dispatch-stop.sh: skip Branch A office-hours park when the stopping worker scheduled a wakeup

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -99,12 +99,38 @@ if ! [[ "$JOB_NAME" =~ ^[0-9]+- ]]; then
   exit 0
 fi
 
-# Drain any buffered single-line JSON payload fast (defensive — Stop may
-# pass JSON on stdin, but this hook never reads a field from it). Short
-# timeout so an open, idle stdin (hook events never close stdin at EOF)
-# returns in ~0.1s rather than stalling a full second on the NUL delimiter.
+# Drain any buffered single-line JSON payload fast. Short timeout so an open,
+# idle stdin (hook events never close stdin at EOF) returns in ~0.1s rather
+# than stalling a full second on the NUL delimiter. The payload is KEPT (not
+# discarded) so Branch A's idle-poll discriminator can resolve the stopping
+# session's transcript path below.
 PAYLOAD=""
 if read -rt 0.1 PAYLOAD; then :; fi
+
+# Resolve the stopping session's transcript path for the Branch A idle-poll
+# discriminator (session_scheduled_wakeup). Two sources, in order:
+#   (a) the Stop payload's `transcript_path` field (standard Claude Code Stop
+#       hook schema) — the primary source; and
+#   (b) a state.json-derived fallback when (a) is empty: sessionId + cwd, with
+#       cwd mapped to the Claude Code project-dir slug by replacing every `/`
+#       and `.` with `-`. The derived path
+#       ~/.claude/projects/<slug>/<sessionId>.jsonl is the live transcript
+#       location (confirmed to exist for a running managed-bg worker), and the
+#       running session's final assistant turn IS flushed to that file before
+#       the Stop hook reads it.
+# A here-string feeds jq (NOT `echo "$PAYLOAD" | jq` — zsh-style echo
+# un-escapes \t/\n in the payload JSON and corrupts it; see
+# .claude/rules/shell-json.md). If both sources fail, TRANSCRIPT_PATH stays
+# empty and the discriminator falls through to today's fail-safe park.
+TRANSCRIPT_PATH=$(jq -r '.transcript_path // empty' <<<"$PAYLOAD" 2>/dev/null) || TRANSCRIPT_PATH=""
+if [ -z "$TRANSCRIPT_PATH" ] && [ -n "${CLAUDE_JOB_DIR:-}" ] && [ -f "$STATE_FILE" ]; then
+  _sid=$(jq -r '.sessionId // empty' "$STATE_FILE" 2>/dev/null)
+  _cwd=$(jq -r '.cwd // empty' "$STATE_FILE" 2>/dev/null)
+  if [ -n "$_sid" ] && [ -n "$_cwd" ]; then
+    _slug=$(printf '%s' "$_cwd" | tr '/.' '--')
+    TRANSCRIPT_PATH="$HOME/.claude/projects/$_slug/$_sid.jsonl"
+  fi
+fi
 
 # Resolve issue number from the validated JOB_NAME (<N>-<slug>). Discriminator 2
 # guarantees JOB_NAME matches ^[0-9]+-, so the numeric prefix is non-empty.
@@ -178,6 +204,26 @@ spawn_sweep() {
 self_close() {
   "$SCRIPTS/dispatch-self-close" >/dev/null 2>&1 \
     || echo "[dispatch-stop] WARNING: dispatch-self-close failed" >&2
+}
+
+# Branch A idle-poll discriminator (#1590). Returns 0 ("will resume on its own")
+# ONLY when the stopping session's transcript shows its FINAL assistant turn
+# contained a `ScheduleWakeup` tool_use; returns 1 in EVERY other case —
+# including all uncertainty: empty TRANSCRIPT_PATH, missing/unreadable file,
+# malformed JSONL, or no trailing wakeup. The fail-safe direction (positive
+# evidence only) is load-bearing: any doubt falls through to today's
+# office-hours park, so a genuine death still parks byte-identically.
+#
+# jq emits one array-of-tool-use-names per assistant turn; a polling worker
+# schedules one ScheduleWakeup PER poll cycle, so only the LAST assistant turn
+# matters — hence `tail -1`. Non-assistant trailing lines (tool_result / user
+# events) are correctly ignored because the jq `select` keeps only assistant
+# turns. Reading the file directly with jq (not via echo) avoids the
+# control-char trap (.claude/rules/shell-json.md).
+session_scheduled_wakeup() {
+  [ -n "$TRANSCRIPT_PATH" ] && [ -r "$TRANSCRIPT_PATH" ] || return 1
+  jq -rc 'select(.type=="assistant") | [.message.content[]? | select(.type=="tool_use") | .name]' "$TRANSCRIPT_PATH" 2>/dev/null \
+    | tail -1 | grep -q '"ScheduleWakeup"'
 }
 
 # Branch P — parse-job clean completion (#1024): a /budget-parse-job session is
@@ -273,6 +319,14 @@ CURRENT_PHASE=$("$SCRIPTS/dispatch-phase" "$ISSUE_NUM" 2>/dev/null) || CURRENT_P
 
 if [ -z "$MARKER_PHASE" ]; then
   # Branch A — marker absent.
+  if session_scheduled_wakeup; then
+    # Live idle-polling worker — its final turn scheduled a ScheduleWakeup,
+    # so it will resume on its own poll cadence. Do NOT park on office-hours
+    # and do NOT spawn a redundant tick (the live worker drives the chain
+    # itself). Without this gate Branch A re-parks the issue once per poll
+    # cycle, oscillating dispatch:office-hours (#1590).
+    exit 0
+  fi
   "$SCRIPTS/dispatch-apply-office-hours" "$ISSUE_NUM" \
     "$(resolve_office_hours_reason "phase exited before completion (mid-phase exit or context compaction)")" \
     || echo "[dispatch-stop] WARNING: dispatch-apply-office-hours failed" >&2

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -16762,6 +16762,129 @@ else
 fi
 stop_teardown
 
+# --- Test A (#1590): live idle-polling worker (trailing ScheduleWakeup) → NOT parked, NOT spawned ---
+# Branch A discriminator: when the stopping session's FINAL assistant turn contains a
+# ScheduleWakeup tool_use, the worker will resume on its own poll cadence — skip the
+# office-hours park AND the redundant tick spawn entirely.
+
+echo "Test: #1590 Branch A idle-waiting worker — trailing ScheduleWakeup → NOT parked, NOT spawned"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "implement" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+# No phase-completed marker.
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+# Fixture: non-wakeup turn earlier, FINAL assistant turn has ScheduleWakeup,
+# with a trailing tool_result line to confirm tail-1/last-turn logic.
+cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"text","text":"poll"}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"ok"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"waiting"},{"type":"tool_use","name":"ScheduleWakeup","input":{}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"scheduled"}]}}
+EOF
+FIXTURE="$TMPDIR_TEST/transcript.jsonl"
+printf '%s\n' '{"transcript_path":"'"$FIXTURE"'"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
+rc=$?
+assert_eq "#1590 idle-waiting worker: hook exits 0 (will resume)" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #1590 idle-waiting worker: NOT parked on office-hours (apply-office-hours NOT invoked)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1590 idle-waiting worker: NOT parked on office-hours (apply-office-hours NOT invoked)"
+  echo "    apply-log: $(cat "$STUB_DIR/apply-office-hours.log")"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/spawn-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #1590 idle-waiting worker: NOT spawned (redundant tick suppressed)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1590 idle-waiting worker: NOT spawned (redundant tick suppressed)"
+  echo "    spawn-calls: $(cat "$STUB_DIR/spawn-calls.log")"
+fi
+stop_teardown
+
+# --- Test B (#1590): genuine mid-phase death (earlier wakeup, no trailing wakeup) → parked ---
+# Branch A discriminator: only the FINAL assistant turn matters (tail -1). An earlier
+# ScheduleWakeup followed by a later non-wakeup turn means the session died mid-phase;
+# the fail-safe park should fire byte-identically to the pre-Unit-1 behavior.
+
+echo "Test: #1590 Branch A mid-phase death — earlier ScheduleWakeup, final turn no wakeup → parked"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "implement" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+# No phase-completed marker.
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+# Fixture: earlier assistant turn with ScheduleWakeup, then a final turn without it.
+# This pins the tail-1 (last-turn-only) discriminator semantics.
+cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"ScheduleWakeup","input":{}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"x"}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{}}]}}
+EOF
+FIXTURE="$TMPDIR_TEST/transcript.jsonl"
+printf '%s\n' '{"transcript_path":"'"$FIXTURE"'"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
+rc=$?
+assert_eq "#1590 mid-phase death: hook exits 0" "0" "$rc"
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
+TOTAL=$((TOTAL + 1))
+if [[ "$apply_issue" == "123" && -n "$apply_reason" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #1590 mid-phase death: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1590 mid-phase death: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+  echo "    apply-log: $apply_log"
+fi
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$apply_reason" | grep -q "phase exited before completion"; then
+  PASS=$((PASS + 1)); echo "  PASS: #1590 mid-phase death: reason contains 'phase exited before completion'"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1590 mid-phase death: reason contains 'phase exited before completion'"
+  echo "    reason: $apply_reason"
+fi
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "#1590 mid-phase death: spawn invoked exactly once" "1" "$spawn_calls"
+stop_teardown
+
+# --- Test C (#1590): uncertainty — transcript path missing → fail-safe park ---
+# Branch A discriminator fail-safe: when transcript_path is provided but the file
+# does not exist, the discriminator returns 1 (uncertainty → park). Positive
+# evidence only; any doubt falls through to the office-hours park.
+
+echo "Test: #1590 Branch A discriminator fail-safe — missing transcript → parked"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "implement" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+# No phase-completed marker.
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+# Feed a payload pointing to a non-existent file — do NOT create it.
+FIXTURE="$TMPDIR_TEST/does-not-exist.jsonl"
+printf '%s\n' '{"transcript_path":"'"$FIXTURE"'"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
+rc=$?
+assert_eq "#1590 missing-transcript fail-safe: hook exits 0" "0" "$rc"
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
+TOTAL=$((TOTAL + 1))
+if [[ "$apply_issue" == "123" && -n "$apply_reason" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #1590 missing-transcript fail-safe: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1590 missing-transcript fail-safe: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+  echo "    apply-log: $apply_log"
+fi
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$apply_reason" | grep -q "phase exited before completion"; then
+  PASS=$((PASS + 1)); echo "  PASS: #1590 missing-transcript fail-safe: reason contains 'phase exited before completion'"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #1590 missing-transcript fail-safe: reason contains 'phase exited before completion'"
+  echo "    reason: $apply_reason"
+fi
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "#1590 missing-transcript fail-safe: spawn invoked exactly once" "1" "$spawn_calls"
+stop_teardown
+
 # --- Test 5a1: #1230 crash-before-label routing regression -------------------
 # #1230 hardened the plan phase so the per-session phase-completed marker is
 # written BEFORE the durable dispatch:planned label. This test models the


### PR DESCRIPTION
Closes #1590

## Problem

`dispatch-stop.sh` Branch A (the marker-absent block) parks an issue on
`dispatch:office-hours` and spawns a tick whenever a worker session ends a turn
with no `phase-completed` marker and CI is ready — unconditionally, with no check
for whether the worker will resume.

A long-running phase worker that polls a slow background task via `ScheduleWakeup`
goes idle between polls. The Stop hook fires on each idle boundary; the marker is
legitimately not written yet (the phase hasn't finished), so Branch A re-parks the
issue once per poll cycle. `dispatch:office-hours` oscillates on the worker's poll
cadence until the phase completes — polluting the queue with false parks and
firing redundant ticks (observed on #1403 / PR #1548).

## Fix

Before Branch A parks, check the stopping session's **own transcript**: did its
**final assistant turn** schedule a `ScheduleWakeup`? A polling worker schedules
its next wakeup as the last action before yielding, so a trailing wakeup means
"will resume." When present, the hook skips both the park and the redundant tick
(the live worker drives the chain itself); otherwise it falls through to today's
park unchanged.

The change is **purely subtractive**: the discriminator returns "will resume"
**only on positive evidence** of a trailing `ScheduleWakeup`. Every uncertainty —
no transcript path, unreadable/empty transcript, no trailing wakeup — falls
through to the existing park. It can only *suppress* a false park when there is
proof the worker will resume; it can never introduce a missed park. The
"genuine death still parks, byte-identical" guarantee holds by construction.

Transcript path is sourced from the Stop payload's `transcript_path` field
(standard Stop hook schema), with a `state.json`-derived fallback
(`sessionId` + `cwd`→project-dir slug) when the payload omits it — verified to
resolve to the live transcript of a running managed-bg worker.

## Deviation from the issue's literal recommended fix — PR review is the gate

The issue's Recommended-fix and AC1 prescribe gating Branch A on a live-session
check via `claude agents --json` (`worktree_has_live_session`). This PR
**deliberately uses a different, more precise mechanism** and does not call
`worktree_has_live_session` in Branch A.

`worktree_has_live_session` matches a live session by name and does **not**
exclude the calling session. The Stop hook runs *inside the stopping worker's own
process*, so that worker is still registered while the hook executes. The registry
therefore cannot answer the operative question — *will this session resume?*:

- An **idle-waiting** worker (between `ScheduleWakeup` polls) is registered.
- A **genuinely-ending** worker, mid-Stop-hook, is *also* registered.

Observed proof: the session this work recovered from, `dd568420`, died on an API
error with no marker and no scheduled wakeup — a textbook must-park death — yet it
remained in the registry hours later as `status: idle, state: failed`. A name-match
liveness gate would see it as "occupied" and skip the park, silently swallowing
the death. `registered` ≠ `will resume`.

The trailing-`ScheduleWakeup` signal lives in the session's own transcript and is
read without ever querying the registry, so the "session sees itself as live"
self-detection trap does not arise. This refines AC1's *mechanism* while fully
satisfying AC1's *intent* (a non-stale liveness signal, not `sessions.json`), AC2,
and AC3. AC4's test design shifts accordingly: the regression tests are
transcript-based, not registry-based.

## Tests

Three regression cases added to `test-dispatch-scripts.sh` in the `dispatch-stop`
section, all driving Branch A (marker absent, CI ready):

1. **Live idle-polling worker** (final assistant turn schedules a wakeup) → **not
   parked, not re-ticked**.
2. **Genuine mid-phase death** (an earlier wakeup but the final turn has none) →
   **parked**, with the existing reason — pins the last-assistant-turn-only
   (`tail -1`) semantics.
3. **Uncertainty** (transcript path points to a missing file) → **parked**
   (fail-safe).

Full suite: 2671/2671 passed.
