### PR TITLE
dispatch-review-dedup tests: assert absent id zzz never emitted (IN4)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -23260,6 +23260,7 @@ assert_eq "dedup: absent-id partition → present finding emitted" "a" "$(printf
 # ["review", null]. exit/length/id all still pass without the filter, so this
 # sources check is the only one that actually guards the absent-id fix.
 assert_eq "dedup: absent-id partition → sources unpolluted by null member" '["review"]' "$(printf '%s' "$out" | jq -c '.[0].sources')"
+assert_eq "dedup: absent-id partition → absent id zzz never emitted (id or sources)" "0" "$(printf '%s' "$out" | jq -r '[.[] | select(.id == "zzz" or ((.sources // []) | index("zzz")))] | length')"
 
 # empty findings → [], exit 0
 IN5='{"findings":[],"partition":[]}'


### PR DESCRIPTION
Closes #1528

## Summary

Adds one explicit assertion to the `dispatch-review-dedup` `IN4` test case (the
absent-id partition) in `test-dispatch-scripts.sh`.

`IN4` feeds a partition referencing an unknown id (`zzz`) alongside a present id
(`a`); the dedup script must skip the unknown id and emit only the present
finding. The block already asserted exit 0, output length 1, present finding
`id == "a"`, and `sources == ["review"]` (unpolluted by a `null` member). What it
lacked was a direct, intention-revealing assertion that the absent id `zzz` never
appears anywhere in the output. A regression that surfaced `zzz` as a placeholder
finding id, or leaked it into a `sources` array, was only caught incidentally by
the length/sources checks — no assertion's label said "the absent id must not
appear."

## Change

One new `assert_eq` line after the existing `sources unpolluted by null member`
assertion, reusing the `$out` already captured in the block (no new script
invocation):

```bash
assert_eq "dedup: absent-id partition → absent id zzz never emitted (id or sources)" "0" "$(printf '%s' "$out" | jq -r '[.[] | select(.id == "zzz" or ((.sources // []) | index("zzz")))] | length')"
```

The jq filter selects any output element whose `id` is `zzz` or whose `sources`
array contains `zzz`, and asserts the count is `0` — covering both the `id` and
`sources` fields the issue's "What" calls out.

## Verification

Full `test-dispatch-scripts.sh` suite passes under bash: `2661/2661 passed, 0
failed`, with the new line reporting `PASS: dedup: absent-id partition → absent
id zzz never emitted (id or sources)`. Test-only change — the
`dispatch-review-dedup` script itself is untouched.
