### PR TITLE
dispatch-target-workers: dynamic 5h catch-up ceiling (ceil5_eff) for fuller end-of-week budget use

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
@@ -145,16 +145,20 @@
 # - Gate closed (hw <= 0, used_weekly at/over W) → 0 workers regardless of 5h
 #   usage. The weekly pace curve simply pauses spending.
 # - Gate open (hw > 0) → N is a pure function of used_5h: max_workers at/below
-#   floor5, ramping linearly to 0 at/above ceil5. The clamp floor keeps N >= 1
-#   for any used_5h strictly under ceil5, so there is no `0 >= 0` router
-#   deadlock during healthy under-pace operation.
+#   floor5, ramping linearly to 0 at/above ceil5_eff (the dynamic catch-up
+#   ceiling, which equals the static ceil5 mid-week and rises above it near
+#   end-of-week — see below). The clamp floor keeps N >= 1 for any used_5h
+#   strictly under ceil5_eff, so there is no `0 >= 0` router deadlock during
+#   healthy under-pace operation.
 # - The 5h ramp ceiling is dynamic: ceil5_eff rises above the static ceil5
 #   near end-of-week when the remaining windows r cannot close the weekly
 #   deficit D = terminal - used_weekly at the default per-window burn rate
 #   (required 5h usage u = 100*D/(r*wcap)). It is accelerator-only — the clamp
 #   lower bound is ceil5, so it never reduces N (over-pace slowdown stays the
-#   weekly gate's job). It is inert mid-week (large r makes the term tiny →
-#   clamps to ceil5) and saturates at 100 for a large deficit (required rate >
+#   weekly gate's job). It is inert mid-week when usage is near pace (r large
+#   and D/r small → term < ceil5 → clamps to ceil5); when far behind pace it
+#   activates earlier, proportionally to the deficit. It saturates at 100 for a
+#   large deficit (required rate >
 #   wcap%/window), so it does not always catch up.
 #
 #   # Reopen crossing (--reopen-at mode)

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-target-workers
@@ -124,8 +124,10 @@
 #   if hw <= 0: print 0; exit              # at/over pace → pause
 #
 #   # Stage 3 — workers N from the 5h ramp
-#   span = ceil5 - floor5
-#   h5   = ceil5 - used_5h
+#   r    = remaining / 18000                                     # windows left
+#   ceil5_eff = clamp(100*(terminal-used_weekly)/(r*wcap), ceil5, 100)  # dynamic catch-up ceiling
+#   span = ceil5_eff - floor5
+#   h5   = ceil5_eff - used_5h
 #   N = (h5 <= 0) ? 0 : (span <= 0) ? max_workers
 #                                   : clamp(round(max_workers * h5/span), 1, max_workers)
 #   print N
@@ -146,6 +148,14 @@
 #   floor5, ramping linearly to 0 at/above ceil5. The clamp floor keeps N >= 1
 #   for any used_5h strictly under ceil5, so there is no `0 >= 0` router
 #   deadlock during healthy under-pace operation.
+# - The 5h ramp ceiling is dynamic: ceil5_eff rises above the static ceil5
+#   near end-of-week when the remaining windows r cannot close the weekly
+#   deficit D = terminal - used_weekly at the default per-window burn rate
+#   (required 5h usage u = 100*D/(r*wcap)). It is accelerator-only — the clamp
+#   lower bound is ceil5, so it never reduces N (over-pace slowdown stays the
+#   weekly gate's job). It is inert mid-week (large r makes the term tiny →
+#   clamps to ceil5) and saturates at 100 for a large deficit (required rate >
+#   wcap%/window), so it does not always catch up.
 #
 #   # Reopen crossing (--reopen-at mode)
 #   A pace-curve pause (the binary gate closing, hw<=0, from used_weekly >= W) is
@@ -518,9 +528,19 @@ awk -v mode="$MODE" \
        if (hw <= 0) { print 0; exit }
 
        # ---- Stage 3: workers N from the 5h ramp ----
-       # max_workers at/below floor5, ramping linearly to 0 at/above ceil5.
-       span = (ceil5 + 0) - (floor5 + 0)
-       h5 = (ceil5 + 0) - (used_5h + 0)
+       # Dynamic catch-up ceiling: raise the 5h ramp ceiling above the static
+       # default when the remaining windows cannot close the weekly deficit
+       # D = terminal - used_weekly at the default per-window burn rate. A full 5h
+       # window = wcap% of the weekly limit, so a 5h ceiling u% burns u/wcap weekly-%
+       # per window; closing D over r = remaining/18000 windows needs u = 100*D/(r*wcap)
+       # of 5h usage. clamp lower bound = ceil5 (accelerator only, never a throttle),
+       # upper bound = 100. remaining > 0 here (Stage 1 exits on remaining <= 0), so
+       # r > 0 — no divide-by-zero.
+       # max_workers at/below floor5, ramping linearly to 0 at/above ceil5_eff.
+       r = remaining / 18000
+       ceil5_eff = clamp(100 * ((terminal + 0) - (used_weekly + 0)) / (r * (wcap + 0)), (ceil5 + 0), 100)
+       span = ceil5_eff - (floor5 + 0)
+       h5 = ceil5_eff - (used_5h + 0)
        if (h5 <= 0) {
          N = 0
        } else if (span <= 0) {

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -10768,6 +10768,71 @@ out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
 assert_eq "just under pace (hw=1), used_5h=70 → ramp N=3" "3" "$out"
 tw_teardown
 
+# --- Test 16c: dynamic catch-up ceiling — saturated regime (headline) --------
+
+echo "Test: end-of-week deficit saturates ceil5_eff to 100 → ramp lifts N above 0"
+tw_setup
+# Headline behavior: near end-of-week the static ceil5=80 would gate N=0 at high
+# 5h usage, but the dynamic catch-up ceiling lifts the ramp so work continues.
+# Pin r exactly via the resets override (resets = NOW + remaining), like Test 15.
+#   remaining=18000 → r=1. used_weekly=88, used_5h=85.
+#   Stage 1: W = max(smooth, envelope=100-10*1=90) = 90. hw=90-88=2>0 → gate open.
+#   Stage 3: D = terminal-used_weekly = 100-88 = 12. D/r = 12 (>wcap=10) →
+#     100*D/(r*wcap) = 100*12/(1*10) = 120 → clamp(120,80,100) = ceil5_eff=100.
+#     span=100-50=50, h5=100-85=15 → N=int(8*15/50+0.5)=int(2.9)=2.
+#   (Static ceiling 80 → h5=80-85=-5 → N=0.)
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+export DISPATCH_TARGET_WORKERS_RESETS_AT_WEEKLY=$((TW_NOW + 18000))
+write_rl "rl.json" 88 99999999 85 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "r=1, D/r=12 → ceil5_eff=100; used_5h=85 → N=2 (static 80 → 0)" "2" "$out"
+tw_teardown
+
+# --- Test 16d: dynamic catch-up ceiling — effective regime (8<D/r<=10) -------
+
+echo "Test: end-of-week deficit lifts ceil5_eff into the ramp → N=1 (static → 0)"
+tw_setup
+# Effective (non-saturated) regime: ceil5_eff lands strictly between ceil5 and
+# 100. Pin r exactly via the resets override.
+#   remaining=45000 → r=2.5. used_weekly=77, used_5h=90.
+#   Stage 1: smooth curve dominates (envelope=100-10*2.5=75 < smooth). At
+#     remaining=45000, x=(604800-45000)/604800≈0.9256 → W≈79.45. hw≈2.45>0 → open.
+#   Stage 3: D = 100-77 = 23. D/r = 9.2 → 100*23/(2.5*10) = 92 →
+#     clamp(92,80,100) = ceil5_eff=92. span=92-50=42, h5=92-90=2 →
+#     N=int(8*2/42+0.5)=int(0.88)=0... clamp(0,1,8)? No: int(8*2/42+0.5)=int(0.881)=0,
+#     but the round is 8*2/42=0.381, +0.5=0.881, int=0 → then clamp(0,1,8)=1.
+#   (Static ceiling 80 → h5=80-90=-10 → N=0.)
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+export DISPATCH_TARGET_WORKERS_RESETS_AT_WEEKLY=$((TW_NOW + 45000))
+write_rl "rl.json" 77 99999999 90 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "r=2.5, D/r=9.2 → ceil5_eff=92; used_5h=90 → N=1 (static 80 → 0)" "1" "$out"
+tw_teardown
+
+# --- Test 16e: dynamic ceiling inert mid-week (accelerator-only invariant) ---
+
+echo "Test: mid-week ceil5_eff clamps to ceil5 → behavior identical to today"
+tw_setup
+# Accelerator-only invariant: mid-week the large remaining-window count r makes
+# the catch-up term tiny, so ceil5_eff clamps down to the static ceil5=80 and
+# Stage 3 behaves exactly as it did before this change. Use tw_resets_for_x 0.5
+# (remaining=302400 → r≈16.8), matching the mid-week probes elsewhere.
+#   used_weekly=11 → gate open (W(0.5)=31, hw=20>0).
+#   D = 100-11 = 89. D/r = 89/16.8 ≈ 5.3 → 100*D/(r*wcap) = 10*D/r ≈ 53 (<ceil5=80)
+#     → clamp(53,80,100) = ceil5_eff=80 (static).
+# Sub-assertion A: used_5h=70 → h5=80-70=10 → N=clamp(round(8*10/30),1,8)=3
+#   (byte-identical to Test 16b's mid-week ramp value).
+# Sub-assertion B: used_5h=85 → h5=80-85=-5 → N=0 (no end-of-week lift mid-week).
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+r=$(tw_resets_for_x 0.5)
+write_rl "rl.json" 11 "$r" 70 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "mid-week ceil5_eff=80; used_5h=70 → N=3 (matches Test 16b)" "3" "$out"
+write_rl "rl.json" 11 "$r" 85 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "mid-week ceil5_eff=80; used_5h=85 → N=0 (no mid-week lift)" "0" "$out"
+tw_teardown
+
 # --- Test 17: non-numeric used_weekly sanitized fail-closed → 1 -------------
 
 echo "Test: non-numeric used_weekly is treated as missing → conservative fallback"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -10799,7 +10799,7 @@ tw_setup
 #     remaining=45000, x=(604800-45000)/604800≈0.9256 → W≈79.45. hw≈2.45>0 → open.
 #   Stage 3: D = 100-77 = 23. D/r = 9.2 → 100*23/(2.5*10) = 92 →
 #     clamp(92,80,100) = ceil5_eff=92. span=92-50=42, h5=92-90=2 →
-#     N=int(8*2/42+0.5)=int(0.88)=0... clamp(0,1,8)? No: int(8*2/42+0.5)=int(0.881)=0,
+#     N=int(8*2/42+0.5)=int(0.881)=0... clamp(0,1,8)? No: int(8*2/42+0.5)=int(0.881)=0,
 #     but the round is 8*2/42=0.381, +0.5=0.881, int=0 → then clamp(0,1,8)=1.
 #   (Static ceiling 80 → h5=80-90=-10 → N=0.)
 export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"


### PR DESCRIPTION
Closes #1485

## What

`dispatch-target-workers` computes the concurrent worker count `N` from a weekly
pace **gate** (Stages 1–2) and a 5-hour worker **ramp** (Stage 3). Stage 3's ramp
ceiling was a static 80% (`FIVEH_TARGET_CEILING`): at `used_5h >= 80` the ramp
drove `N` to 0.

Near end-of-week, even when the weekly gate is open (under pace), that static
ceiling throttled `N` to zero before `used_5h` reached the end-of-week budget — so
the last of the weekly allocation went unused. This change raises the 5h ceiling to
a **dynamic** `ceil5_eff` when the remaining windows cannot close the weekly deficit
at the default per-window burn rate, keeping `N > 0` at higher `used_5h` so workers
keep spawning until usage approaches the catch-up ceiling.

## How

A full 5h window burns `wcap`% of the weekly limit, so a 5h ceiling `u%` burns
`u/wcap` weekly-% per window. Closing the weekly deficit `D = terminal − used_weekly`
across `r = remaining/18000` remaining windows requires `u = 100·D/(r·wcap)` of 5h
usage:

```
ceil5_eff = clamp(100·(terminal − used_weekly) / (r · wcap),  ceil5,  100)
```

Three properties keep it honest:

1. **Accelerator only** — the clamp's lower bound is `ceil5` (the static 80), so
   `ceil5_eff` can only rise above 80, never below. It never *reduces* `N`;
   over-pace slowdown stays the weekly gate's job (Stage 2).
2. **Narrow catch-up band** — the default 80 already burns 8%/window; the ceiling
   caps at 100 = 10%/window = `wcap`. The term is inert when the required rate is
   ≤ 8%/window, effective in (8%, 10%], and saturates at 100 above 10%/window (a
   large deficit still under-uses the budget — the term does not always catch up).
3. **Inert mid-week** — large `r` makes the term tiny → clamps to the default → no
   mid-week effect.

`ceil5_eff` is *derived* from existing inputs — no new config field, and
`dispatch-config-load` is unchanged. Reopen mode (`--reopen-at`) is a Stage-1
concern and exits before Stage 3, so it is correctly untouched.

## Tests

Three cases added to the `dispatch-target-workers` count-mode block, each pinning
`r` exactly via the `DISPATCH_TARGET_WORKERS_RESETS_AT_WEEKLY` override:

- **Saturated regime** (r=1, D/r=12 → ceil5_eff clamps to 100): `used_5h=85` → N=2,
  where the static 80 ceiling gave N=0.
- **Effective regime** (r=2.5, D/r=9.2 → ceil5_eff=92): `used_5h=90` → N=1, where
  the static ceiling gave N=0.
- **Inert mid-week** (r≈16.8 → ceil5_eff clamps to the static 80): ramp values are
  byte-identical to today (`used_5h=70` → N=3, `used_5h=85` → N=0), proving the
  accelerator-only invariant at the output.

Full suite: 2664/2664 passed. Every pre-existing count-mode test still passes — the
change is on the shared Stage 3 path, and those tests sit where the required rate is
< 8%/window so `ceil5_eff` clamps to the static 80.
