### PR TITLE
dispatch-select-target: extract shared category/priority jq defs from ISSUE_SORTED + helpers

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -562,14 +562,25 @@ CATEGORIES=("${TOPIC_CATEGORIES[@]}" other)
 # Same priority list as a JSON array, for category_of_labels' jq filter.
 TOPIC_CATEGORIES_JSON=$(printf '%s\n' "${TOPIC_CATEGORIES[@]}" | jq -Rcn '[inputs]')
 
+# Single source of the category/priority label expressions. Each def takes a
+# JSON array of {name:...} label objects as input and derives [.[].name]
+# itself, so callers pass the raw label array. category_of_labels /
+# has_priority_in_labels wrap these, and the ISSUE_SORTED filter below calls
+# the same defs — there is now exactly one copy of each expression.
+JQ_LABEL_DEFS='
+  def has_priority: [.[].name] | if index("priority") then 1 else 0 end;
+  def category_of($cats):
+    [.[].name] as $names
+    | first($cats[] | select(. as $c | $names | index($c))) // "other";
+'
+
 # Highest-priority topic category among a JSON array of {name:...} label
 # objects — the first TOPIC_CATEGORIES entry that appears as an exact label
 # name, else "other". Exact match, so the phase label "dispatch:reviewed" never
 # reads as topic "dispatch".
 category_of_labels() {
-  printf '%s' "$1" | jq -r --argjson cats "$TOPIC_CATEGORIES_JSON" '
-    [.[].name] as $names
-    | first($cats[] | select(. as $c | $names | index($c))) // "other"'
+  printf '%s' "$1" | jq -r --argjson cats "$TOPIC_CATEGORIES_JSON" \
+    "$JQ_LABEL_DEFS"' category_of($cats)'
 }
 
 # Union of a PR's closing issues' labels into a JSON array of {name:...} label
@@ -583,7 +594,7 @@ pr_combined_labels() {
 
 # 1 if the label set contains an exact "priority" label, else 0.
 has_priority_in_labels() {
-  printf '%s' "$1" | jq -r '[.[].name] | if index("priority") then 1 else 0 end'
+  printf '%s' "$1" | jq -r "$JQ_LABEL_DEFS"' has_priority'
 }
 
 # Top-N ranked PRs per (category, priority-bit, phase): key =
@@ -858,19 +869,19 @@ done < <(printf '%s' "$PR_LIST" | jq -r '
 # The roots are now emitted in (priority desc, category-rank asc, createdAt asc)
 # order — the SAME rank order the emission loops drain — so each (priority,
 # category) group's roots are contiguous, enabling the walk's global early-exit
-# (#1452). The category/priority/cat-rank expressions are the exact ones used by
-# category_of_labels / has_priority_in_labels / the CATEGORIES iteration order,
-# so bucket keys are unchanged. (1 - .pri) sorts priority=1 first; jq sort_by is
+# (#1452). pri/catname are computed by the shared JQ_LABEL_DEFS defs — the same
+# defs category_of_labels / has_priority_in_labels call — so the two sites cannot
+# drift; cat-rank is the CATEGORIES iteration order. Bucket keys are unchanged.
+# (1 - .pri) sorts priority=1 first; jq sort_by is
 # stable and createdAt is an ISO string sorting chronologically, so within a
 # (pri, cat-rank) group roots stay oldest-first — byte-identical to the old order
 # for that group. The TSV now carries the precomputed pri/cat-rank/cat columns.
-ISSUE_SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r --argjson cats "$TOPIC_CATEGORIES_JSON" '
+ISSUE_SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r --argjson cats "$TOPIC_CATEGORIES_JSON" "$JQ_LABEL_DEFS"'
   [ .[]
     | select((.labels // []) | any(.name == "help wanted"))
     | select((.labels // []) | any(.name == "dispatch:office-hours") | not)
-    | ([(.labels // [])[].name]) as $names
-    | ($names | if index("priority") then 1 else 0 end) as $pri
-    | (first($cats[] | select(. as $c | $names | index($c))) // "other") as $catname
+    | ((.labels // []) | has_priority) as $pri
+    | ((.labels // []) | category_of($cats)) as $catname
     | (($cats | index($catname)) // ($cats | length)) as $catrank
     | { number: .number, createdAt: .createdAt, pri: $pri, catrank: $catrank, catname: $catname }
   ]

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -165,6 +165,7 @@ QA_MODE=false
 HEALTH_ONLY=false
 MAIN_BROKEN_SHA_ONLY=false
 PRIORITY_ONLY=false
+DEBUG_CLASSIFY=false
 TOP=1
 TOP_EXPLICIT=false
 declare -A EXCLUDED=()
@@ -175,6 +176,7 @@ while [[ $# -gt 0 ]]; do
     --health-only) HEALTH_ONLY=true; shift ;;
     --main-broken-sha) MAIN_BROKEN_SHA_ONLY=true; shift ;;
     --priority-only) PRIORITY_ONLY=true; shift ;;
+    --debug-classify) DEBUG_CLASSIFY=true; shift ;;
     --top)
       shift
       if [[ $# -eq 0 || ! "$1" =~ ^[1-9][0-9]*$ ]]; then
@@ -887,6 +889,23 @@ ISSUE_SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r --argjson cats "$TOPIC_CATEGORI
   ]
   | sort_by([ (1 - .pri), .catrank, .createdAt ])
   | .[] | [.number, .pri, .catrank, .catname] | @tsv')
+
+if [[ "$DEBUG_CLASSIFY" == "true" ]]; then
+  # Emit, for each surviving issue, the REAL inline ISSUE_SORTED jq classification
+  # (sorted_*) alongside the REAL shell-helper classification (helper_*), so the
+  # test can prove the two classification sources agree (#1490).
+  # number <tab> sorted_pri <tab> sorted_cat <tab> helper_pri <tab> helper_cat
+  while IFS=$'\t' read -r dbg_num dbg_pri _dbg_catrank dbg_cat; do
+    [[ -z "$dbg_num" ]] && continue
+    dbg_labels=$(printf '%s' "$ISSUE_LIST" \
+      | jq -c --argjson n "$dbg_num" '(.[] | select(.number == $n) | .labels) // []')
+    h_pri=$(has_priority_in_labels "$dbg_labels")
+    h_cat=$(category_of_labels "$dbg_labels")
+    printf '%s\t%s\t%s\t%s\t%s\n' "$dbg_num" "$dbg_pri" "$dbg_cat" "$h_pri" "$h_cat"
+  done <<< "$ISSUE_SORTED"
+  exit 0
+fi
+
 walk_prev_group=""
 walk_prev_cat=""
 walk_prev_pri=""

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -27900,6 +27900,12 @@ spot_security_scat=""
 spot_security_hcat=""
 spot_priority_spri=""
 spot_priority_hpri=""
+spot_other_scat=""
+spot_other_hcat=""
+spot_other_spri=""
+spot_other_hpri=""
+spot_testing_scat=""
+spot_testing_hcat=""
 row_count=0
 while IFS=$'\t' read -r dc_num dc_spri dc_scat dc_hpri dc_hcat; do
   [[ -z "$dc_num" ]] && continue
@@ -27915,6 +27921,16 @@ while IFS=$'\t' read -r dc_num dc_spri dc_scat dc_hpri dc_hcat; do
     spot_priority_spri="$dc_spri"
     spot_priority_hpri="$dc_hpri"
   fi
+  if [[ "$dc_num" == "110" ]]; then
+    spot_other_scat="$dc_scat"
+    spot_other_hcat="$dc_hcat"
+    spot_other_spri="$dc_spri"
+    spot_other_hpri="$dc_hpri"
+  fi
+  if [[ "$dc_num" == "103" ]]; then
+    spot_testing_scat="$dc_scat"
+    spot_testing_hcat="$dc_hcat"
+  fi
 done <<< "$result"
 # Confirm expected row count (all 11 issues survive: none carry dispatch:office-hours).
 assert_eq "#1490 classify: 11 rows emitted (all issues survive)" "11" "$row_count"
@@ -27923,6 +27939,12 @@ assert_eq "#1490 classify: security issue (101) sorted_cat is 'security'" "secur
 assert_eq "#1490 classify: security issue (101) helper_cat is 'security'" "security" "$spot_security_hcat"
 assert_eq "#1490 classify: priority issue (111) sorted_pri is 1" "1" "$spot_priority_spri"
 assert_eq "#1490 classify: priority issue (111) helper_pri is 1" "1" "$spot_priority_hpri"
+assert_eq "#1490 classify: other issue (110) sorted_cat is 'other'" "other" "$spot_other_scat"
+assert_eq "#1490 classify: other issue (110) helper_cat is 'other'" "other" "$spot_other_hcat"
+assert_eq "#1490 classify: other issue (110) sorted_pri is 0" "0" "$spot_other_spri"
+assert_eq "#1490 classify: other issue (110) helper_pri is 0" "0" "$spot_other_hpri"
+assert_eq "#1490 classify: testing issue (103) sorted_cat is 'testing infrastructure'" "testing infrastructure" "$spot_testing_scat"
+assert_eq "#1490 classify: testing issue (103) helper_cat is 'testing infrastructure'" "testing infrastructure" "$spot_testing_hcat"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -27859,6 +27859,72 @@ calls=$([[ -f "$STUB_DIR/claude-agents-calls.log" ]] && wc -l < "$STUB_DIR/claud
 assert_eq "#1474 E4 — zero live claude agents calls during selection" "0" "$calls"
 teardown
 
+# #1490 — --debug-classify: inline ISSUE_SORTED jq classification agrees with
+# shell helpers (category_of_labels / has_priority_in_labels).
+# One issue per TOPIC_CATEGORIES entry + one "other" + one priority-flagged
+# dispatch issue. --debug-classify exits before PR selection, so no UNION
+# and no fake claude are required.
+echo "Test: #1490 -- --debug-classify: jq sort classification matches shell helpers"
+setup
+setup_union_pr_list '[]'
+# Numbers:
+#   101 security   (help wanted + security)
+#   102 bug        (help wanted + bug)
+#   103 testing    (help wanted + testing infrastructure)
+#   104 dispatch   (help wanted + dispatch)
+#   105 landing    (help wanted + landing)
+#   106 fellspiral (help wanted + fellspiral)
+#   107 budget     (help wanted + budget)
+#   108 print      (help wanted + print)
+#   109 audio      (help wanted + audio)
+#   110 other      (help wanted, no topic label)
+#   111 priority   (help wanted + dispatch + priority) — priority spot-check
+printf '[
+  {"number":101,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"security"}]},
+  {"number":102,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"bug"}]},
+  {"number":103,"createdAt":"2024-01-03T00:00:00Z","labels":[{"name":"help wanted"},{"name":"testing infrastructure"}]},
+  {"number":104,"createdAt":"2024-01-04T00:00:00Z","labels":[{"name":"help wanted"},{"name":"dispatch"}]},
+  {"number":105,"createdAt":"2024-01-05T00:00:00Z","labels":[{"name":"help wanted"},{"name":"landing"}]},
+  {"number":106,"createdAt":"2024-01-06T00:00:00Z","labels":[{"name":"help wanted"},{"name":"fellspiral"}]},
+  {"number":107,"createdAt":"2024-01-07T00:00:00Z","labels":[{"name":"help wanted"},{"name":"budget"}]},
+  {"number":108,"createdAt":"2024-01-08T00:00:00Z","labels":[{"name":"help wanted"},{"name":"print"}]},
+  {"number":109,"createdAt":"2024-01-09T00:00:00Z","labels":[{"name":"help wanted"},{"name":"audio"}]},
+  {"number":110,"createdAt":"2024-01-10T00:00:00Z","labels":[{"name":"help wanted"}]},
+  {"number":111,"createdAt":"2024-01-11T00:00:00Z","labels":[{"name":"help wanted"},{"name":"dispatch"},{"name":"priority"}]}
+]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --debug-classify)
+# Spot-check values captured from the row loop (to avoid set -e aborting on a
+# failed grep; find by number inside the loop instead).
+spot_security_scat=""
+spot_security_hcat=""
+spot_priority_spri=""
+spot_priority_hpri=""
+row_count=0
+while IFS=$'\t' read -r dc_num dc_spri dc_scat dc_hpri dc_hcat; do
+  [[ -z "$dc_num" ]] && continue
+  row_count=$((row_count + 1))
+  assert_eq "#1490 classify: issue $dc_num sorted_pri == helper_pri" "$dc_spri" "$dc_hpri"
+  assert_eq "#1490 classify: issue $dc_num sorted_cat == helper_cat" "$dc_scat" "$dc_hcat"
+  # Stash spot-check values while iterating (avoids grep that would abort on miss).
+  if [[ "$dc_num" == "101" ]]; then
+    spot_security_scat="$dc_scat"
+    spot_security_hcat="$dc_hcat"
+  fi
+  if [[ "$dc_num" == "111" ]]; then
+    spot_priority_spri="$dc_spri"
+    spot_priority_hpri="$dc_hpri"
+  fi
+done <<< "$result"
+# Confirm expected row count (all 11 issues survive: none carry dispatch:office-hours).
+assert_eq "#1490 classify: 11 rows emitted (all issues survive)" "11" "$row_count"
+# Spot-assert absolute values — guards against a both-sides-wrong regression.
+assert_eq "#1490 classify: security issue (101) sorted_cat is 'security'" "security" "$spot_security_scat"
+assert_eq "#1490 classify: security issue (101) helper_cat is 'security'" "security" "$spot_security_hcat"
+assert_eq "#1490 classify: priority issue (111) sorted_pri is 1" "1" "$spot_priority_spri"
+assert_eq "#1490 classify: priority issue (111) helper_pri is 1" "1" "$spot_priority_hpri"
+teardown
+
 # ============================================================================
 # summary
 # ============================================================================


### PR DESCRIPTION
Closes #1490

## Why

`dispatch-select-target` classifies the dispatch queue's open issues by topic
category and priority. Two shell helpers owned that logic —
`category_of_labels()` (first matching `TOPIC_CATEGORIES` entry, else `"other"`)
and `has_priority_in_labels()` (`1` if an exact `priority` label is present).
The `ISSUE_SORTED` jq filter re-implemented **both** expressions inline to
precompute its `pri`/`catname` sort columns, and the two copies were kept in
sync only by a comment — no static check. A helper change not mirrored into the
inline jq would silently mis-sort the queue's roots, breaking the early-exit
soundness argument that relies on the walk and the emission loops sharing one
rank order (#1452/#1548).

## What changed

**Unit 1 — single-source extraction.** The two jq expressions now live in one
`JQ_LABEL_DEFS` shell variable (defs `has_priority` and `category_of($cats)`)
local to the script. `category_of_labels()`, `has_priority_in_labels()`, and the
`ISSUE_SORTED` filter all call those defs — exactly one copy of each expression.
The `pri`/`catname`/`catrank` columns and sort order of `ISSUE_SORTED` are
preserved byte-for-byte; this is a pure dedup. `catrank` (the `CATEGORIES`
iteration-order rank) has no shell-helper analog and stays inline, out of scope
for the dedup.

**Unit 2 — machine-checkable agreement proof.** A hidden `--debug-classify`
subcommand emits, for each surviving issue, the classification from BOTH the
real inline `ISSUE_SORTED` jq and the real `category_of_labels` /
`has_priority_in_labels` shell functions. A new test in
`test-dispatch-scripts.sh` asserts the two agree across every `TOPIC_CATEGORIES`
entry, the `"other"` fallback, and a `priority` case. Because def-level text
equality is true by construction, the real subject under test is the adapter
wiring (`(.labels // []) | the_def` and threading `$cats`).

## Design note

The canonical defs stay in `dispatch-select-target`, not `lib.sh`:
`category_of` depends on `TOPIC_CATEGORIES` and this script's ranking policy with
zero cross-script reuse, so moving it to the generic `lib.sh` would disperse the
policy and re-introduce a list the test would have to mirror. `--debug-classify`
gives the test reachability without that dispersal.

## Verification

The full dispatch script suite passes (2687/2687, exit 0), including the new
criterion-#3 block and every existing select-target subprocess test — confirming
the `ISSUE_SORTED` output is unchanged.
