### PR TITLE
Refactor: export truncateForLog from office-hours-sync.ts to dedup dispatch-queue-metrics.ts

### DIFF
--- a/functions/src/dispatch-queue-metrics.ts
+++ b/functions/src/dispatch-queue-metrics.ts
@@ -41,7 +41,7 @@ import { defineSecret, defineString } from "firebase-functions/params";
 import { getApps, initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 import type { Firestore } from "firebase-admin/firestore";
-import { mintInstallationToken } from "./office-hours-sync.js";
+import { mintInstallationToken, truncateForLog } from "./office-hours-sync.js";
 
 // Reuse the SAME param names as office-hours-sync.ts so firebase-functions
 // dedupes them across modules (params are keyed by name).
@@ -99,13 +99,6 @@ export function computeQueueMetrics(input: {
   const netDrainPerDay = closedPerDay - createdPerDay;
   const runwayDays = netDrainPerDay > 0 ? input.openHelpWanted / netDrainPerDay : null;
   return { closedPerDay, createdPerDay, netDrainPerDay, runwayDays };
-}
-
-// Truncates a third-party HTTP response body before it enters an Error message
-// (and thus the function logs). Mirrors the helper in office-hours-sync.ts,
-// which is not exported.
-function truncateForLog(text: string, max = 200): string {
-  return text.length > max ? `${text.slice(0, max)}…[truncated]` : text;
 }
 
 interface GraphQLResponse<T> {

--- a/functions/src/office-hours-sync.ts
+++ b/functions/src/office-hours-sync.ts
@@ -87,7 +87,7 @@ export function isValidJitKey(key: string): boolean {
 // Truncates a third-party HTTP response body before it enters an Error message
 // (and thus the function logs). Bounds the blast radius of a verbose or
 // reflected GitHub error response without dropping the leading diagnostic text.
-function truncateForLog(text: string, max = 200): string {
+export function truncateForLog(text: string, max = 200): string {
   return text.length > max ? `${text.slice(0, max)}…[truncated]` : text;
 }
 


### PR DESCRIPTION
Closes #1555

## Summary

`truncateForLog(text, max = 200)` bounds a third-party HTTP response body before
it enters an `Error` message (and thus the function logs). It existed as two
independent, verbatim copies: a private helper in `office-hours-sync.ts` and a
copy added to `dispatch-queue-metrics.ts` by PR #1215 — whose own comment noted
it "Mirrors the helper in office-hours-sync.ts, which is not exported." Two
copies can silently diverge.

This refactor makes `office-hours-sync.ts` the single source of truth:

- Export `truncateForLog` from `office-hours-sync.ts` (was an unexported
  `function`).
- Import it into `dispatch-queue-metrics.ts` by extending the existing
  `./office-hours-sync.js` named import (which already brought in
  `mintInstallationToken`), and delete the local copy + its comment block.

No behavior change, no signature change (`max = 200` default preserved). The
remaining call site in `dispatch-queue-metrics.ts` now resolves to the imported
function.

## Verification

- `npm run build --prefix functions` — TypeScript compiles clean.
- The `office-hours-sync` and `dispatch-queue-metrics` test suites pass (neither
  references `truncateForLog` directly; behavior is unchanged).
- `grep -rn "function truncateForLog" functions/src` now returns only
  `office-hours-sync.ts` — exactly one definition.
