### PR TITLE
office-hours: issue-samples schema, rules, parser/serializer, demo seed

### DIFF
--- a/.claude/docs/firestore.md
+++ b/.claude/docs/firestore.md
@@ -42,9 +42,11 @@ documents within that collection:
 {appName}/{envSuffix}/{collection}/{docId}
 ```
 
-Examples: `landing/prod/posts/abc123`, `landing/preview-pr-42/posts/abc123`, `office-hours/prod/items/<jitKey>`, `office-hours/demo/usage-samples/<autoId>`
+Examples: `landing/prod/posts/abc123`, `landing/preview-pr-42/posts/abc123`, `office-hours/prod/items/<jitKey>`, `office-hours/demo/usage-samples/<autoId>`, `office-hours/demo/issue-samples/<autoId>`
 
 For `usage-samples`, the `demo` env is the public-demo tier (world-readable without authentication), while all other envs are owner-gated via the denormalized `memberEmails` field.
+
+`issue-samples` is the backlog-history time series and follows the same access model: the `demo` env is the public-demo tier (world-readable without authentication), while all other envs are owner-gated via the denormalized `memberEmails` field.
 
 Rules use the literal app name as a path segment:
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -521,6 +521,19 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // Issue samples are the backlog-history time series, written by the Admin-SDK
+    // sampler. The `demo` env is world-readable for the public demo tier; every
+    // other env is owner-gated via the denormalized `memberEmails` field. Client
+    // writes are denied.
+    match /office-hours/{env}/issue-samples/{sampleId} {
+      allow get: if env == "demo"
+        || (request.auth != null
+            && request.auth.token.email in resource.data.memberEmails);
+      allow list: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails;
+      allow write: if false;
+    }
+
     // SCAFFOLD MARKER: deny-all catch-all. Do not edit or move this comment.
     // InsertFirestoreRules inserts new rule blocks immediately above this line.
     match /{document=**} {

--- a/office-hours/src/issue-data.ts
+++ b/office-hours/src/issue-data.ts
@@ -1,0 +1,31 @@
+import { collection, getDocs, query, where, type Firestore } from "firebase/firestore";
+import type { User } from "firebase/auth";
+import { nsCollectionPath, type Namespace } from "@commons-systems/firestoreutil/namespace";
+import seedSamples from "virtual:office-hours-issue-seed-data";
+import { toIssueSample, type IssueSample } from "./issue-samples.js";
+
+export function getDemoIssueSamples(): IssueSample[] {
+  return seedSamples.map((s) => ({
+    sampledAt: s.sampledAt,
+    openHelpWanted: s.openHelpWanted,
+    openOther: s.openOther,
+    groupId: s.groupId,
+  }));
+}
+
+export async function getOwnerIssueSamples(
+  db: Firestore,
+  namespace: Namespace,
+  user: User,
+): Promise<IssueSample[]> {
+  if (!user.email) return [];
+  const path = nsCollectionPath(namespace, "issue-samples");
+  const q = query(collection(db, path), where("memberEmails", "array-contains", user.email));
+  const snapshot = await getDocs(q);
+  const samples: IssueSample[] = [];
+  for (const d of snapshot.docs) {
+    const sample = toIssueSample(d.id, d.data());
+    if (sample) samples.push(sample);
+  }
+  return samples;
+}

--- a/office-hours/src/issue-sample-seeds.ts
+++ b/office-hours/src/issue-sample-seeds.ts
@@ -1,0 +1,127 @@
+export interface IssueSampleSeed {
+  /** Minutes relative to build "now": negative = in the past. */
+  sampledAtOffsetMin: number;
+  openHelpWanted: number;
+  openOther: number;
+  groupId: string;
+  memberEmails: string[];
+}
+
+// 14 samples spanning ~7 days, showing a shrinking open-issue backlog. The total
+// (openHelpWanted + openOther) trends downward as sampledAtOffsetMin climbs from
+// -10080 (7 days ago) to 0 ("now"), so the demo renders a real downward runway
+// projection. sampledAtOffsetMin == 0 is the most recent ("now") sample.
+export const issueSampleSeeds: IssueSampleSeed[] = [
+  // Day -7 — backlog at its peak
+  {
+    sampledAtOffsetMin: -10080, // 7 days ago
+    openHelpWanted: 18,
+    openOther: 44,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -6.5
+  {
+    sampledAtOffsetMin: -9360,
+    openHelpWanted: 17,
+    openOther: 42,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -6
+  {
+    sampledAtOffsetMin: -8640,
+    openHelpWanted: 16,
+    openOther: 41,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -5.5 — small uptick (new issues filed) against the overall trend
+  {
+    sampledAtOffsetMin: -7920,
+    openHelpWanted: 17,
+    openOther: 39,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -5
+  {
+    sampledAtOffsetMin: -7200,
+    openHelpWanted: 15,
+    openOther: 37,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -4
+  {
+    sampledAtOffsetMin: -5760,
+    openHelpWanted: 14,
+    openOther: 34,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -3.5
+  {
+    sampledAtOffsetMin: -5040,
+    openHelpWanted: 13,
+    openOther: 32,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -3
+  {
+    sampledAtOffsetMin: -4320,
+    openHelpWanted: 12,
+    openOther: 29,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -2.5 — brief plateau
+  {
+    sampledAtOffsetMin: -3600,
+    openHelpWanted: 12,
+    openOther: 28,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -2
+  {
+    sampledAtOffsetMin: -2880,
+    openHelpWanted: 11,
+    openOther: 25,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -1
+  {
+    sampledAtOffsetMin: -1440,
+    openHelpWanted: 9,
+    openOther: 22,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+  // ~12h ago
+  {
+    sampledAtOffsetMin: -720,
+    openHelpWanted: 8,
+    openOther: 19,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+  // ~2h ago
+  {
+    sampledAtOffsetMin: -120,
+    openHelpWanted: 7,
+    openOther: 16,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+  // Now — most recent sample, backlog at its lowest
+  {
+    sampledAtOffsetMin: 0,
+    openHelpWanted: 6,
+    openOther: 13,
+    groupId: "demo-group",
+    memberEmails: ["demo@example.com"],
+  },
+];

--- a/office-hours/src/issue-samples.ts
+++ b/office-hours/src/issue-samples.ts
@@ -1,0 +1,61 @@
+import { Timestamp } from "firebase/firestore";
+import { logError } from "@commons-systems/errorutil/log";
+
+export interface IssueSample {
+  sampledAt: Date;
+  openHelpWanted: number;
+  openOther: number;
+  groupId: string;
+}
+
+export function toIssueSample(id: string, data: Record<string, unknown>): IssueSample | null {
+  const sampledAtRaw = data.sampledAt;
+  const sampledAt =
+    sampledAtRaw && typeof (sampledAtRaw as { toDate?: unknown }).toDate === "function"
+      ? (sampledAtRaw as { toDate: () => Date }).toDate()
+      : null;
+
+  const openHelpWanted =
+    typeof data.openHelpWanted === "number" ? data.openHelpWanted : null;
+  const openOther = typeof data.openOther === "number" ? data.openOther : null;
+  const groupId = typeof data.groupId === "string" ? data.groupId : null;
+  const memberEmails =
+    Array.isArray(data.memberEmails) &&
+    (data.memberEmails as unknown[]).every((e) => typeof e === "string")
+      ? (data.memberEmails as string[])
+      : null;
+
+  if (
+    sampledAt === null ||
+    openHelpWanted === null ||
+    openOther === null ||
+    groupId === null ||
+    memberEmails === null
+  ) {
+    logError(new Error("issue-samples document missing required fields"), {
+      operation: "issue-sample-validation",
+      itemId: id,
+    });
+    return null;
+  }
+
+  return {
+    sampledAt,
+    openHelpWanted,
+    openOther,
+    groupId,
+  };
+}
+
+export function issueSampleToDoc(
+  s: IssueSample,
+  memberEmails: string[],
+): Record<string, unknown> {
+  return {
+    sampledAt: Timestamp.fromDate(s.sampledAt),
+    openHelpWanted: s.openHelpWanted,
+    openOther: s.openOther,
+    groupId: s.groupId,
+    memberEmails,
+  };
+}

--- a/office-hours/src/office-hours-issue-seed-data.d.ts
+++ b/office-hours/src/office-hours-issue-seed-data.d.ts
@@ -1,0 +1,10 @@
+declare module "virtual:office-hours-issue-seed-data" {
+  export interface IssueSampleResolved {
+    readonly sampledAt: Date;
+    readonly openHelpWanted: number;
+    readonly openOther: number;
+    readonly groupId: string;
+  }
+  const issueSampleSeeds: readonly IssueSampleResolved[];
+  export default issueSampleSeeds;
+}

--- a/office-hours/src/vite-plugin-issue-samples-seed.ts
+++ b/office-hours/src/vite-plugin-issue-samples-seed.ts
@@ -1,0 +1,38 @@
+import type { Plugin } from "vite";
+import { issueSampleSeeds } from "./issue-sample-seeds.js";
+
+const VIRTUAL_MODULE_ID = "virtual:office-hours-issue-seed-data";
+const RESOLVED_VIRTUAL_MODULE_ID = "\0" + VIRTUAL_MODULE_ID;
+
+export function issueSamplesSeedDataPlugin(): Plugin {
+  let moduleCode: string;
+
+  return {
+    name: "office-hours-issue-samples-seed-data",
+    buildStart() {
+      // Strip memberEmails (a denormalized auth field holding real email
+      // addresses) before serializing — it must never be baked into the
+      // public JS bundle. The UI never reads it; Firestore rules gate access
+      // server-side.
+      const publicSeeds = issueSampleSeeds.map(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure-omit memberEmails from the public bundle
+        ({ memberEmails, ...rest }) => rest,
+      );
+      moduleCode =
+        `const seeds = ${JSON.stringify(publicSeeds)};\n` +
+        `const now = Date.now();\n` +
+        `export default seeds.map(({ sampledAtOffsetMin, openHelpWanted, openOther, groupId }) => ({\n` +
+        `  sampledAt: new Date(now + sampledAtOffsetMin * 60000),\n` +
+        `  openHelpWanted,\n` +
+        `  openOther,\n` +
+        `  groupId,\n` +
+        `}));\n`;
+    },
+    resolveId(id) {
+      if (id === VIRTUAL_MODULE_ID) return RESOLVED_VIRTUAL_MODULE_ID;
+    },
+    load(id) {
+      if (id === RESOLVED_VIRTUAL_MODULE_ID) return moduleCode;
+    },
+  };
+}

--- a/office-hours/test/issue-data.test.ts
+++ b/office-hours/test/issue-data.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { getDemoIssueSamples } from "../src/issue-data.js";
+
+describe("getDemoIssueSamples", () => {
+  const samples = getDemoIssueSamples();
+
+  it("returns a non-empty array of ~14 samples", () => {
+    expect(Array.isArray(samples)).toBe(true);
+    expect(samples.length).toBeGreaterThanOrEqual(12);
+    expect(samples.length).toBeLessThanOrEqual(16);
+  });
+
+  it("every sample has the correct fields with correct types and no auth field", () => {
+    for (const s of samples) {
+      expect(s.sampledAt).toBeInstanceOf(Date);
+      expect(typeof s.openHelpWanted).toBe("number");
+      expect(typeof s.openOther).toBe("number");
+      expect(typeof s.groupId).toBe("string");
+      // memberEmails is an auth field that must never reach the public bundle.
+      expect(s).not.toHaveProperty("memberEmails");
+    }
+  });
+
+  it("renders a shrinking backlog (most-recent total < oldest total)", () => {
+    const oldest = samples.reduce((a, b) =>
+      a.sampledAt.getTime() < b.sampledAt.getTime() ? a : b
+    );
+    const mostRecent = samples.reduce((a, b) =>
+      a.sampledAt.getTime() > b.sampledAt.getTime() ? a : b
+    );
+    const oldestTotal = oldest.openHelpWanted + oldest.openOther;
+    const recentTotal = mostRecent.openHelpWanted + mostRecent.openOther;
+    expect(recentTotal).toBeLessThan(oldestTotal);
+  });
+});

--- a/office-hours/test/issue-samples.test.ts
+++ b/office-hours/test/issue-samples.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { toIssueSample, issueSampleToDoc, type IssueSample } from "../src/issue-samples.js";
+
+const baseSample: IssueSample = {
+  sampledAt: new Date("2026-06-07T10:00:00Z"),
+  openHelpWanted: 12,
+  openOther: 30,
+  groupId: "group-abc",
+};
+
+const memberEmails = ["alice@example.com", "bob@example.com"];
+
+describe("issueSampleToDoc / toIssueSample round-trip", () => {
+  it("round-trips an IssueSample through doc and back", () => {
+    const doc = issueSampleToDoc(baseSample, memberEmails);
+    const result = toIssueSample("auto-id", doc);
+
+    expect(result).not.toBeNull();
+    if (result === null) return;
+
+    expect(result.sampledAt.getTime()).toBe(baseSample.sampledAt.getTime());
+    expect(result.openHelpWanted).toBe(baseSample.openHelpWanted);
+    expect(result.openOther).toBe(baseSample.openOther);
+    expect(result.groupId).toBe(baseSample.groupId);
+    // memberEmails is an auth field stripped from the client-facing struct.
+    expect(result).not.toHaveProperty("memberEmails");
+  });
+});
+
+describe("toIssueSample malformed-doc cases", () => {
+  const validDoc = issueSampleToDoc(baseSample, memberEmails);
+
+  it("returns null when sampledAt is missing", () => {
+    const doc = { ...validDoc, sampledAt: undefined };
+    expect(toIssueSample("auto-id", doc)).toBeNull();
+  });
+
+  it("returns null when openHelpWanted is the wrong type", () => {
+    const doc = { ...validDoc, openHelpWanted: "not-a-number" };
+    expect(toIssueSample("auto-id", doc)).toBeNull();
+  });
+
+  it("returns null when memberEmails is not an array", () => {
+    const doc = { ...validDoc, memberEmails: "alice@example.com" };
+    expect(toIssueSample("auto-id", doc)).toBeNull();
+  });
+});

--- a/office-hours/test/vite-plugin-issue-samples-seed.test.ts
+++ b/office-hours/test/vite-plugin-issue-samples-seed.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { issueSamplesSeedDataPlugin } from "../src/vite-plugin-issue-samples-seed";
+import type { Plugin } from "vite";
+
+describe("issueSamplesSeedDataPlugin", () => {
+  let plugin: Plugin;
+  let moduleCode: string | undefined;
+  let resolvedId: string | undefined;
+
+  function resolveId(id: string): string | undefined {
+    return (plugin.resolveId as (id: string) => string | undefined)(id);
+  }
+  function load(id: string): string | undefined {
+    return (plugin.load as (id: string) => string | undefined)(id);
+  }
+
+  beforeAll(() => {
+    plugin = issueSamplesSeedDataPlugin();
+    (plugin.buildStart as () => void)();
+    resolvedId = resolveId("virtual:office-hours-issue-seed-data");
+    moduleCode = resolvedId ? load(resolvedId) : undefined;
+  });
+
+  it("resolves the virtual module ID", () => {
+    expect(resolvedId).toBeDefined();
+    expect(resolvedId).toBe("\0virtual:office-hours-issue-seed-data");
+  });
+
+  it("returns undefined for unrelated module IDs", () => {
+    expect(resolveId("some-other-module")).toBeUndefined();
+  });
+
+  it("returns undefined when loading an unrelated ID", () => {
+    expect(load("some-other-id")).toBeUndefined();
+  });
+
+  it("produces module code containing export default", () => {
+    expect(moduleCode).toBeDefined();
+    expect(moduleCode).toContain("export default");
+  });
+
+  it("does not bake the memberEmails auth field into the bundle", () => {
+    expect(moduleCode).toBeDefined();
+    expect(moduleCode).not.toContain("memberEmails");
+  });
+
+  describe("generated issue samples", () => {
+    let samples: Array<{
+      sampledAt: Date;
+      openHelpWanted: number;
+      openOther: number;
+      groupId: string;
+    }>;
+    let now: number;
+
+    beforeAll(() => {
+      now = Date.now();
+      const body = moduleCode!.replace("export default", "return");
+      samples = new Function(body)() as typeof samples;
+    });
+
+    it("returns an array of samples", () => {
+      expect(Array.isArray(samples)).toBe(true);
+      expect(samples.length).toBeGreaterThan(0);
+    });
+
+    it("every sample has the correct fields with correct types", () => {
+      for (const s of samples) {
+        expect(s.sampledAt).toBeInstanceOf(Date);
+        expect(typeof s.openHelpWanted).toBe("number");
+        expect(typeof s.openOther).toBe("number");
+        expect(typeof s.groupId).toBe("string");
+        // memberEmails is an auth field that must never reach the public bundle.
+        expect(s).not.toHaveProperty("memberEmails");
+      }
+    });
+
+    it("most recent sample is close to build time (sampledAt near now)", () => {
+      const mostRecent = samples.reduce((a, b) =>
+        a.sampledAt.getTime() > b.sampledAt.getTime() ? a : b
+      );
+      // Within 5 minutes of now (the seed has sampledAtOffsetMin: 0)
+      expect(Math.abs(mostRecent.sampledAt.getTime() - now)).toBeLessThan(5 * 60 * 1000);
+    });
+
+    it("series spans multiple days (oldest sample is at least 5 days before newest)", () => {
+      const times = samples.map((s) => s.sampledAt.getTime());
+      const oldest = Math.min(...times);
+      const newest = Math.max(...times);
+      const fiveDaysMs = 5 * 24 * 60 * 60 * 1000;
+      expect(newest - oldest).toBeGreaterThan(fiveDaysMs);
+    });
+
+    it("backlog shrinks over the series (most-recent total < oldest total)", () => {
+      const oldest = samples.reduce((a, b) =>
+        a.sampledAt.getTime() < b.sampledAt.getTime() ? a : b
+      );
+      const mostRecent = samples.reduce((a, b) =>
+        a.sampledAt.getTime() > b.sampledAt.getTime() ? a : b
+      );
+      const oldestTotal = oldest.openHelpWanted + oldest.openOther;
+      const recentTotal = mostRecent.openHelpWanted + mostRecent.openOther;
+      expect(recentTotal).toBeLessThan(oldestTotal);
+    });
+
+    it("contains the expected number of samples (12-16)", () => {
+      expect(samples.length).toBeGreaterThanOrEqual(12);
+      expect(samples.length).toBeLessThanOrEqual(16);
+    });
+  });
+});

--- a/office-hours/vite.config.ts
+++ b/office-hours/vite.config.ts
@@ -1,12 +1,14 @@
 import { createAppConfig } from "@commons-systems/config/vite";
 import { officeHoursSeedDataPlugin } from "./src/vite-plugin-seed-data";
 import { usageSamplesSeedDataPlugin } from "./src/vite-plugin-usage-samples-seed";
+import { issueSamplesSeedDataPlugin } from "./src/vite-plugin-issue-samples-seed";
 import { officeHoursQueueSeedPlugin } from "./src/vite-plugin-queue-seed";
 
 export default createAppConfig({
   plugins: [
     officeHoursSeedDataPlugin(),
     usageSamplesSeedDataPlugin(),
+    issueSamplesSeedDataPlugin(),
     officeHoursQueueSeedPlugin(),
   ],
 });

--- a/rules-test/test/firestore/office-hours.test.ts
+++ b/rules-test/test/firestore/office-hours.test.ts
@@ -414,3 +414,224 @@ describe("office-hours usage-samples", () => {
     );
   });
 });
+
+describe("office-hours issue-samples", () => {
+  let env: RulesTestEnvironment;
+
+  beforeAll(async () => {
+    env = await getTestEnv();
+  });
+
+  setupCleanup();
+
+  const issueSampleDoc = {
+    memberEmails: ["owner@test.com"],
+    sampledAt: new Date("2026-06-07T12:00:00Z"),
+    openHelpWanted: 12,
+    openOther: 30,
+    groupId: "owner-group",
+  };
+
+  const demoIssueSampleDoc = {
+    memberEmails: ["demo@example.com"],
+    sampledAt: new Date("2026-06-07T11:00:00Z"),
+    openHelpWanted: 6,
+    openOther: 13,
+    groupId: "demo-group",
+  };
+
+  beforeEach(async () => {
+    await adminSetDoc(
+      env,
+      `office-hours/${ENV}/issue-samples/sample-owner`,
+      issueSampleDoc,
+    );
+    await adminSetDoc(
+      env,
+      `office-hours/demo/issue-samples/sample-demo`,
+      demoIssueSampleDoc,
+    );
+  });
+
+  it("allows owner to read test-env doc", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertSucceeds(
+      getDoc(doc(db, `office-hours/${ENV}/issue-samples/sample-owner`)),
+    );
+  });
+
+  it("denies non-owner read of test-env doc", async () => {
+    const ctx = authenticatedContext(env, "stranger@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDoc(doc(db, `office-hours/${ENV}/issue-samples/sample-owner`)),
+    );
+  });
+
+  it("denies unauthenticated read of test-env doc", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertFails(
+      getDoc(doc(db, `office-hours/${ENV}/issue-samples/sample-owner`)),
+    );
+  });
+
+  it("allows unauthenticated read of demo-env doc", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertSucceeds(
+      getDoc(doc(db, `office-hours/demo/issue-samples/sample-demo`)),
+    );
+  });
+
+  it("denies owner setDoc on test-env doc", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      setDoc(doc(db, `office-hours/${ENV}/issue-samples/sample-owner`), {
+        memberEmails: ["owner@test.com"],
+      }),
+    );
+  });
+
+  it("denies owner updateDoc on test-env doc", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      updateDoc(doc(db, `office-hours/${ENV}/issue-samples/sample-owner`), {
+        openHelpWanted: 11,
+      }),
+    );
+  });
+
+  it("denies owner deleteDoc on test-env doc", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      deleteDoc(doc(db, `office-hours/${ENV}/issue-samples/sample-owner`)),
+    );
+  });
+
+  it("denies unauthenticated setDoc on demo-env doc", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertFails(
+      setDoc(doc(db, `office-hours/demo/issue-samples/sample-demo`), {
+        memberEmails: ["demo@example.com"],
+      }),
+    );
+  });
+
+  it("allows owner list query on test-env collection", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(db, `office-hours/${ENV}/issue-samples`),
+          where("memberEmails", "array-contains", "owner@test.com"),
+        ),
+      ),
+    );
+  });
+
+  it("denies unfiltered owner list query on test-env issue-samples collection", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(collection(db, `office-hours/${ENV}/issue-samples`)),
+    );
+  });
+
+  it("denies unfiltered stranger list query on test-env issue-samples collection", async () => {
+    const ctx = authenticatedContext(env, "stranger@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(collection(db, `office-hours/${ENV}/issue-samples`)),
+    );
+  });
+
+  // A non-member cannot list another member's samples: filtering for an email
+  // they are not in is denied, because the matching docs carry a memberEmails
+  // the requester is absent from. (A self-targeted array-contains filter is
+  // always rule-compliant and returns an empty set, so it is not a denial
+  // case.)
+  it("denies authenticated non-member list query for another member's samples", async () => {
+    const ctx = authenticatedContext(env, "stranger@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(
+        query(
+          collection(db, `office-hours/${ENV}/issue-samples`),
+          where("memberEmails", "array-contains", "owner@test.com"),
+        ),
+      ),
+    );
+  });
+
+  // "Rules are not filters": a list query is allowed when its where-clause
+  // provably satisfies the rule. A non-member filtering to their own membership
+  // is allowed and simply returns the empty subset they are entitled to.
+  it("allows non-member list query filtered to own (empty) membership", async () => {
+    const ctx = authenticatedContext(env, "stranger@test.com");
+    const db = ctx.firestore();
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(db, `office-hours/${ENV}/issue-samples`),
+          where("memberEmails", "array-contains", "stranger@test.com"),
+        ),
+      ),
+    );
+  });
+
+  it("denies unauthenticated list query on test-env collection", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(
+        query(
+          collection(db, `office-hours/${ENV}/issue-samples`),
+          where("memberEmails", "array-contains", "owner@test.com"),
+        ),
+      ),
+    );
+  });
+
+  it("denies unauthenticated list query on demo-env collection", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(collection(db, `office-hours/demo/issue-samples`)),
+    );
+  });
+
+  it("denies authenticated setDoc on demo-env doc", async () => {
+    const ctx = authenticatedContext(env, "demo@example.com");
+    const db = ctx.firestore();
+    await assertFails(
+      setDoc(doc(db, `office-hours/demo/issue-samples/sample-demo`), {
+        memberEmails: ["demo@example.com"],
+      }),
+    );
+  });
+
+  it("denies authenticated updateDoc on demo-env doc", async () => {
+    const ctx = authenticatedContext(env, "demo@example.com");
+    const db = ctx.firestore();
+    await assertFails(
+      updateDoc(doc(db, `office-hours/demo/issue-samples/sample-demo`), {
+        openHelpWanted: 5,
+      }),
+    );
+  });
+
+  it("denies authenticated deleteDoc on demo-env doc", async () => {
+    const ctx = authenticatedContext(env, "demo@example.com");
+    const db = ctx.firestore();
+    await assertFails(
+      deleteDoc(doc(db, `office-hours/demo/issue-samples/sample-demo`)),
+    );
+  });
+});


### PR DESCRIPTION
Closes #1536

## Summary

Adds the **data layer** for the office-hours backlog-history view (parent epic
#1535): a time-series Firestore collection of open-issue counts —
append-only per-sample documents, the analog of the merged single-document
snapshot schema. This lets the open-backlog count be charted over time.

It is a near-exact **mirror of the existing `usage-samples` data layer** (the
Capacity view's time series). Each `usage-*` artifact is copied to its
`issue-*` counterpart with the schema fields swapped.

**No UI ships here.** The sampler that writes the collection is sibling #1537;
the panel that renders it is sibling #1538. This PR lands only the schema,
rules, parser/serializer, data-access functions, and bundled demo seed.

### `IssueSample` schema

The Firestore document at `office-hours/{env}/issue-samples/{autoId}`:

| field | Firestore | TS |
|---|---|---|
| `sampledAt` | Timestamp | `Date` |
| `openHelpWanted` | number | `number` |
| `openOther` | number | `number` |
| `groupId` | string | `string` |
| `memberEmails` | string[] | (auth field — stripped) |

`openOther` = count of open issues **without** the `help wanted` label;
`openHelpWanted + openOther` = total open backlog. `memberEmails` is
denormalized auth data: it is validated-but-stripped in the parser, passed as a
separate argument to the serializer, and stripped from the public demo bundle —
it is never part of the `IssueSample` interface and never reaches public JS.

## What's included

- **Parser/serializer** (`office-hours/src/issue-samples.ts`) + round-trip and
  malformed-doc tests.
- **Demo seed + Vite virtual-module plugin** (`issue-sample-seeds.ts`,
  `vite-plugin-issue-samples-seed.ts`, the `.d.ts`, vite.config registration) +
  plugin test. ~14 samples spanning ~7 days showing a **shrinking backlog**, so
  the demo renders a real downward runway projection. The plugin strips
  `memberEmails` from the generated module.
- **Data-access layer** (`office-hours/src/issue-data.ts`): `getDemoIssueSamples`
  reads the bundled seed; `getOwnerIssueSamples` runs the owner-gated
  `array-contains` query. Includes a demo-seed render test.
- **Firestore rules** block for `office-hours/{env}/issue-samples/{sampleId}`:
  `demo` env `get` is world-readable; every other env is owner-gated via
  `memberEmails`; `list` always requires auth + member (no demo exception, so an
  unauthenticated demo `list` is denied); client writes are denied. Plus
  rules-test coverage mirroring `usage-samples`, including the cross-member
  list-denial and demo-list-denied cases.
- **Docs**: `.claude/docs/firestore.md` documents the new collection.

## Verification

- `npm test --prefix office-hours` — 170 tests pass (parser round-trip, plugin
  generated code, demo-seed render with shrinking backlog).
- `npm run build --prefix office-hours` — exercises the Vite plugin end-to-end
  (virtual module resolved, demo seed baked in with `memberEmails` stripped).
- `npm test --prefix rules-test` — 426 tests pass, including the new
  `office-hours issue-samples` describe block (owner/demo/non-owner reads,
  write-deny, and all list-query cases). This suite runs in no CI job, so it was
  run manually.
