### PR TITLE
qa-fix.js: extract shared hasRefuted helper

### DIFF
--- a/.claude/workflows/qa-fix.js
+++ b/.claude/workflows/qa-fix.js
@@ -75,6 +75,10 @@ const VERDICT_SCHEMA = {
 
 // --- inline kernel helper (thin mirror of the pure script) -------------------
 
+// True when at least one skeptic refuted. Single source of truth for the
+// refuted-detection rule, shared by applyQaDisposition and verify_report.
+const hasRefuted = (votes) => votes.includes('refuted');
+
 // normative spec: .claude/skills/dispatch-propagate/scripts/dispatch-qa-disposition
 // Apply the QA downgrade rule per classification item, preserving input order.
 // Each input item carries { id, class, aesthetic }; votesById[id] is the array
@@ -105,7 +109,7 @@ function applyQaDisposition(classifications, votesById) {
       // KEEP needs-human (INVERTED relative to applyVerifyDrop — see warning above).
       return { id: c.id, final_class: 'needs-human', verify: 'Unverified' };
     }
-    if (votes.filter((v) => v === 'refuted').length >= 1) {
+    if (hasRefuted(votes)) {
       // At least one skeptic refuted: downgrade to opus-fixable.
       return { id: c.id, final_class: 'opus-fixable', verify: 'Refuted' };
     }
@@ -311,7 +315,7 @@ const verify_report = candidates.map((c) => {
   let verdict;
   if (!votes.length) {
     verdict = 'unverified';
-  } else if (votes.includes('refuted')) {
+  } else if (hasRefuted(votes)) {
     verdict = 'refuted';
   } else {
     verdict = 'upheld';


### PR DESCRIPTION
Closes #1585

`.claude/workflows/qa-fix.js` re-implemented the "has a refuted vote" check in
two independent places:

- `applyQaDisposition` used `votes.filter((v) => v === 'refuted').length >= 1`.
- the `verify_report` derivation block used `votes.includes('refuted')`.

Both were logically equivalent, but they were two separate code paths for the
same rule — a future change to one might not propagate to the other, letting the
reported `verify_report` verdict diverge from the `final_class` the kernel
actually applies.

This extracts a single `hasRefuted(votes)` helper and calls it from both sites,
so the refuted-detection rule lives in one place.

## Behavior-preserving

- `votes.includes('refuted')` and `votes.filter((v) => v === 'refuted').length >= 1`
  are equivalent over an array of enum strings — both use strict `===`, no
  coercion.
- Both call sites already handle the empty-votes case *before* the refuted check,
  so `hasRefuted` only ever sees a non-empty array — and even on `[]` it returns
  `false`, matching both originals. The empty-votes guards are untouched.

The sibling `review-fix.js` carries the identical duplication but is deliberately
out of scope for #1585 and is untouched.

## Verification

- `node --check .claude/workflows/qa-fix.js` — exits 0 (clean parse).
- `grep -n 'hasRefuted\|refuted' .claude/workflows/qa-fix.js` — `hasRefuted` is
  defined exactly once and both former inline checks now call it.
