### PR TITLE
office-hours: panel registry + responsive grid layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ result
 /.gitmodules
 /.mcp.json
 /.claude/commands
+/.claude/scheduled_tasks.lock
 /.idea
 /.vscode

--- a/office-hours/index.html
+++ b/office-hours/index.html
@@ -167,6 +167,12 @@
         color: var(--muted-fg, #9aa0a6);
         margin-bottom: 0.75rem;
       }
+      .queue-metrics-heading {
+        font-size: 1rem;
+        letter-spacing: 0.05em;
+        color: var(--muted-fg, #9aa0a6);
+        margin-bottom: 0.75rem;
+      }
       .capacity-pace-delta {
         font-weight: 700;
         font-size: 1.1rem;

--- a/office-hours/index.html
+++ b/office-hours/index.html
@@ -141,7 +141,9 @@
         gap: 1.5rem;
       }
       /* gap replaces the per-panel margin-top spacing that double-spaces under a grid */
-      .panel-grid > * {
+      .panel-grid > *,
+      .panel-grid > .capacity-history,
+      .panel-grid > .capacity-pace {
         margin-top: 0;
       }
       .panel-grid-full {

--- a/office-hours/index.html
+++ b/office-hours/index.html
@@ -135,6 +135,18 @@
         border-radius: 1px;
         flex-shrink: 0;
       }
+      .panel-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
+        gap: 1.5rem;
+      }
+      /* gap replaces the per-panel margin-top spacing that double-spaces under a grid */
+      .panel-grid > * {
+        margin-top: 0;
+      }
+      .panel-grid-full {
+        grid-column: 1 / -1;
+      }
       .capacity-history {
         display: block;
         margin-top: 1.5rem;

--- a/office-hours/src/app-view.ts
+++ b/office-hours/src/app-view.ts
@@ -3,17 +3,112 @@ import { renderPacePositionPanel } from "./pace-position-panel.js";
 import { renderHistoryBand } from "./history-band.js";
 import { renderReminderList } from "./office-hours.js";
 import { getDemoSamples } from "./usage-data.js";
-import { getDemoReminders } from "./data.js";
+import { getDemoReminders, getDemoQueueMetrics } from "./data.js";
 import type { UsageSample } from "./usage-samples.js";
 import type { Reminder } from "./reminders.js";
+import type { QueueMetricsSnapshot } from "./queue-metrics.js";
 
 export type ViewState =
   | { tier: "demo" }                                                  // unauthenticated → labeled demo
   | { tier: "owner"; samples: UsageSample[]; reminders: Reminder[] }  // authenticated → real (possibly empty)
   | { tier: "error" };                                                // authenticated load failed
 
+type PanelTier = "demo" | "owner";
+
+interface PanelContext {
+  samples: UsageSample[];
+  reminders: Reminder[];
+  queueMetrics: QueueMetricsSnapshot | null;
+  now: Date;
+}
+
+interface Panel {
+  id: string;
+  title: string;                    // reserved metadata; renderApp does NOT render it
+  availableIn: readonly PanelTier[];
+  fullWidth?: boolean;
+  renderInto(ctx: PanelContext): HTMLElement;
+}
+
+function definePanel<T>(spec: {
+  id: string;
+  title: string;
+  availableIn: readonly PanelTier[];
+  fullWidth?: boolean;
+  load(ctx: PanelContext): T;
+  render(data: T, now: Date): HTMLElement;
+}): Panel {
+  return {
+    id: spec.id,
+    title: spec.title,
+    availableIn: spec.availableIn,
+    fullWidth: spec.fullWidth,
+    renderInto: (ctx) => spec.render(spec.load(ctx), ctx.now),
+  };
+}
+
+const PANELS: readonly Panel[] = [
+  definePanel({
+    id: "capacity",
+    title: "Capacity",
+    availableIn: ["demo", "owner"],
+    load: (c) => selectLatestSample(c.samples),
+    render: (s, now) => renderCapacityBand(s, now),
+  }),
+  definePanel({
+    id: "pace",
+    title: "Pace",
+    availableIn: ["demo", "owner"],
+    load: (c) => c.samples,
+    render: (s) => renderPacePositionPanel(s),
+  }),
+  definePanel({
+    id: "history",
+    title: "History",
+    availableIn: ["demo", "owner"],
+    fullWidth: true,
+    load: (c) => c.samples,
+    render: (s) => renderHistoryBand(s),
+  }),
+  definePanel({
+    id: "reminders",
+    title: "Reminders",
+    availableIn: ["demo", "owner"],
+    load: (c) => c.reminders,
+    render: (r, now) => renderReminderList(r, now),
+  }),
+];
+
+function buildContext(
+  state: Extract<ViewState, { tier: "demo" } | { tier: "owner" }>,
+  now: Date,
+): PanelContext {
+  if (state.tier === "demo")
+    return {
+      samples: getDemoSamples(),
+      reminders: getDemoReminders(),
+      queueMetrics: getDemoQueueMetrics(),
+      now,
+    };
+  return {
+    samples: state.samples,
+    reminders: state.reminders,
+    queueMetrics: null, // → state.queueMetrics in a later unit
+    now,
+  };
+}
+
 export function renderApp(container: Element, state: ViewState, now: Date): void {
   container.replaceChildren();
+
+  if (state.tier === "error") {
+    const error = document.createElement("p");
+    error.className = "error";
+    error.setAttribute("role", "alert");
+    error.textContent = "Couldn't load your queue. Please try again.";
+    container.appendChild(error);
+    return;
+  }
 
   if (state.tier === "demo") {
     const banner = document.createElement("p");
@@ -21,22 +116,16 @@ export function renderApp(container: Element, state: ViewState, now: Date): void
     banner.setAttribute("role", "status");
     banner.textContent = "Demo data — sign in to see your queue.";
     container.appendChild(banner);
-
-    const samples = getDemoSamples();
-    container.appendChild(renderCapacityBand(selectLatestSample(samples), now));
-    container.appendChild(renderPacePositionPanel(samples));
-    container.appendChild(renderHistoryBand(samples));
-    container.appendChild(renderReminderList(getDemoReminders(), now));
-  } else if (state.tier === "owner") {
-    container.appendChild(renderCapacityBand(selectLatestSample(state.samples), now));
-    container.appendChild(renderPacePositionPanel(state.samples));
-    container.appendChild(renderHistoryBand(state.samples));
-    container.appendChild(renderReminderList(state.reminders, now));
-  } else {
-    const error = document.createElement("p");
-    error.className = "error";
-    error.setAttribute("role", "alert");
-    error.textContent = "Couldn't load your queue. Please try again.";
-    container.appendChild(error);
   }
+
+  const ctx = buildContext(state, now);
+  const grid = document.createElement("div");
+  grid.className = "panel-grid";
+  for (const panel of PANELS) {
+    if (!panel.availableIn.includes(state.tier)) continue;
+    const el = panel.renderInto(ctx);
+    if (panel.fullWidth) el.classList.add("panel-grid-full");
+    grid.appendChild(el);
+  }
+  container.appendChild(grid);
 }

--- a/office-hours/src/app-view.ts
+++ b/office-hours/src/app-view.ts
@@ -83,7 +83,7 @@ const PANELS: readonly Panel[] = [
     title: "Queue",
     availableIn: ["demo", "owner"],
     load: (c) => c.queueMetrics,
-    render: (m, now) => renderQueueMetricsPanel(m, now),
+    render: (m) => renderQueueMetricsPanel(m),
   }),
 ];
 

--- a/office-hours/src/app-view.ts
+++ b/office-hours/src/app-view.ts
@@ -2,6 +2,7 @@ import { renderCapacityBand, selectLatestSample } from "./capacity-band.js";
 import { renderPacePositionPanel } from "./pace-position-panel.js";
 import { renderHistoryBand } from "./history-band.js";
 import { renderReminderList } from "./office-hours.js";
+import { renderQueueMetricsPanel } from "./queue-metrics-panel.js";
 import { getDemoSamples } from "./usage-data.js";
 import { getDemoReminders, getDemoQueueMetrics } from "./data.js";
 import type { UsageSample } from "./usage-samples.js";
@@ -10,7 +11,7 @@ import type { QueueMetricsSnapshot } from "./queue-metrics.js";
 
 export type ViewState =
   | { tier: "demo" }                                                  // unauthenticated → labeled demo
-  | { tier: "owner"; samples: UsageSample[]; reminders: Reminder[] }  // authenticated → real (possibly empty)
+  | { tier: "owner"; samples: UsageSample[]; reminders: Reminder[]; queueMetrics: QueueMetricsSnapshot | null }  // authenticated → real (possibly empty)
   | { tier: "error" };                                                // authenticated load failed
 
 type PanelTier = "demo" | "owner";
@@ -77,6 +78,13 @@ const PANELS: readonly Panel[] = [
     load: (c) => c.reminders,
     render: (r, now) => renderReminderList(r, now),
   }),
+  definePanel({
+    id: "queue-metrics",
+    title: "Queue",
+    availableIn: ["demo", "owner"],
+    load: (c) => c.queueMetrics,
+    render: (m, now) => renderQueueMetricsPanel(m, now),
+  }),
 ];
 
 function buildContext(
@@ -93,7 +101,7 @@ function buildContext(
   return {
     samples: state.samples,
     reminders: state.reminders,
-    queueMetrics: null, // → state.queueMetrics in a later unit
+    queueMetrics: state.queueMetrics,
     now,
   };
 }

--- a/office-hours/src/data.ts
+++ b/office-hours/src/data.ts
@@ -1,4 +1,4 @@
-import { collection, getDocs, query, where, type Firestore } from "firebase/firestore";
+import { collection, doc, getDoc, getDocs, query, where, type Firestore } from "firebase/firestore";
 import type { User } from "firebase/auth";
 import { nsCollectionPath, type Namespace } from "@commons-systems/firestoreutil/namespace";
 import { logError } from "@commons-systems/errorutil/log";
@@ -6,6 +6,7 @@ import seedReminders from "virtual:office-hours-seed-data";
 import seedQueueMetrics from "virtual:office-hours-queue-seed";
 import type { Reminder } from "./reminders.js";
 import type { QueueMetricsSnapshot } from "./queue-metrics.js";
+import { parseQueueMetrics } from "./queue-metrics.js";
 
 export function getDemoReminders(): Reminder[] {
   return seedReminders.map((s) => ({
@@ -46,6 +47,18 @@ export async function getOwnerReminders(
     if (reminder) reminders.push(reminder);
   }
   return reminders;
+}
+
+export async function getOwnerQueueMetrics(
+  db: Firestore,
+  namespace: Namespace,
+  user: User,
+): Promise<QueueMetricsSnapshot | null> {
+  if (!user.email) return null;
+  const path = nsCollectionPath(namespace, "metrics");
+  const snap = await getDoc(doc(db, path, "dispatch-queue"));
+  if (!snap.exists()) return null;
+  return parseQueueMetrics(snap.data());
 }
 
 export function toReminder(id: string, data: Record<string, unknown>): Reminder | null {

--- a/office-hours/src/data.ts
+++ b/office-hours/src/data.ts
@@ -28,7 +28,9 @@ export function getDemoQueueMetrics(): QueueMetricsSnapshot {
     windowDays: seedQueueMetrics.windowDays,
     computedAt: seedQueueMetrics.computedAt,
     groupId: seedQueueMetrics.groupId,
-    memberEmails: [...seedQueueMetrics.memberEmails],
+    // memberEmails is a denormalized auth field stripped from the public seed
+    // bundle (see vite-plugin-queue-seed.ts); the demo snapshot carries none.
+    memberEmails: [],
   };
 }
 

--- a/office-hours/src/main.ts
+++ b/office-hours/src/main.ts
@@ -6,7 +6,7 @@ import { logError } from "@commons-systems/errorutil/log";
 import { deferAppCheckInit } from "@commons-systems/firebaseutil/defer-appcheck";
 
 import { renderApp } from "./app-view.js";
-import { getOwnerReminders } from "./data.js";
+import { getOwnerReminders, getOwnerQueueMetrics } from "./data.js";
 import { getOwnerSamples } from "./usage-data.js";
 import {
   db,
@@ -40,14 +40,15 @@ async function refresh(): Promise<void> {
     return;
   }
   try {
-    const [samples, reminders] = await Promise.all([
+    const [samples, reminders, queueMetrics] = await Promise.all([
       getOwnerSamples(db, NAMESPACE, refreshUser),
       getOwnerReminders(db, NAMESPACE, refreshUser),
+      getOwnerQueueMetrics(db, NAMESPACE, refreshUser),
     ]);
     // Auth may have changed while the Firestore calls were in flight — skip the
     // render so the in-flight result does not clobber the already-updated view.
     if (currentUser !== refreshUser) return;
-    renderApp(app!, { tier: "owner", samples, reminders }, new Date());
+    renderApp(app!, { tier: "owner", samples, reminders, queueMetrics }, new Date());
   } catch (error) {
     // Auth may have changed while the Firestore calls were in flight — skip the
     // render so the in-flight error does not clobber the already-updated view.

--- a/office-hours/src/office-hours-queue-seed.d.ts
+++ b/office-hours/src/office-hours-queue-seed.d.ts
@@ -8,7 +8,6 @@ declare module "virtual:office-hours-queue-seed" {
     readonly windowDays: number;
     readonly computedAt: Date;
     readonly groupId: string;
-    readonly memberEmails: readonly string[];
   };
   export default seedQueueMetrics;
 }

--- a/office-hours/src/queue-metrics-panel.ts
+++ b/office-hours/src/queue-metrics-panel.ts
@@ -3,12 +3,12 @@ import { type QueueMetricsSnapshot } from "./queue-metrics.js";
 /**
  * Renders the queue metrics panel: queue depth, net drain rate, and runway.
  *
- * The `now` parameter matches the panel-registry render signature (metrics, now)
- * and may be used for relative timestamps.
+ * Takes no `now`: the snapshot is rendered as-is, mirroring the `pace` and
+ * `history` panels whose render fns also omit `now`. The panel-registry render
+ * signature supplies `now` but a render fn is free to ignore it.
  */
 export function renderQueueMetricsPanel(
   metrics: QueueMetricsSnapshot | null,
-  _now: Date,
 ): HTMLElement {
   const section = document.createElement("section");
 

--- a/office-hours/src/queue-metrics-panel.ts
+++ b/office-hours/src/queue-metrics-panel.ts
@@ -1,0 +1,74 @@
+import { type QueueMetricsSnapshot } from "./queue-metrics.js";
+
+/**
+ * Renders the queue metrics panel: queue depth, net drain rate, and runway.
+ *
+ * The `now` parameter matches the panel-registry render signature (metrics, now)
+ * and may be used for relative timestamps.
+ */
+export function renderQueueMetricsPanel(
+  metrics: QueueMetricsSnapshot | null,
+  _now: Date,
+): HTMLElement {
+  const section = document.createElement("section");
+
+  const heading = document.createElement("h2");
+  heading.className = "queue-metrics-heading";
+  heading.textContent = "QUEUE";
+  section.appendChild(heading);
+
+  if (metrics === null) {
+    const empty = document.createElement("p");
+    empty.className = "empty";
+    empty.textContent = "No queue metrics yet.";
+    section.appendChild(empty);
+    return section;
+  }
+
+  const cards = document.createElement("div");
+  cards.className = "capacity-cards";
+
+  // Queue depth card
+  const depthCard = document.createElement("div");
+  depthCard.className = "capacity-card";
+  const depthLabel = document.createElement("span");
+  depthLabel.className = "capacity-card-label";
+  depthLabel.textContent = "queue depth";
+  const depthValue = document.createElement("span");
+  depthValue.className = "capacity-card-value queue-depth-value";
+  depthValue.textContent = String(metrics.openHelpWanted);
+  depthCard.appendChild(depthLabel);
+  depthCard.appendChild(depthValue);
+
+  // Net drain/day card
+  const drainCard = document.createElement("div");
+  drainCard.className = "capacity-card";
+  const drainLabel = document.createElement("span");
+  drainLabel.className = "capacity-card-label";
+  drainLabel.textContent = "net drain";
+  const drainValue = document.createElement("span");
+  drainValue.className = "capacity-card-value queue-drain-value";
+  drainValue.textContent = `${metrics.netDrainPerDay.toFixed(1)}/day`;
+  drainCard.appendChild(drainLabel);
+  drainCard.appendChild(drainValue);
+
+  // Runway card
+  const runwayCard = document.createElement("div");
+  runwayCard.className = "capacity-card";
+  const runwayLabel = document.createElement("span");
+  runwayLabel.className = "capacity-card-label";
+  runwayLabel.textContent = "runway";
+  const runwayValue = document.createElement("span");
+  runwayValue.className = "capacity-card-value queue-runway-value";
+  runwayValue.textContent =
+    metrics.runwayDays !== null ? `${metrics.runwayDays} days` : "growing";
+  runwayCard.appendChild(runwayLabel);
+  runwayCard.appendChild(runwayValue);
+
+  cards.appendChild(depthCard);
+  cards.appendChild(drainCard);
+  cards.appendChild(runwayCard);
+  section.appendChild(cards);
+
+  return section;
+}

--- a/office-hours/src/queue-metrics-panel.ts
+++ b/office-hours/src/queue-metrics-panel.ts
@@ -45,10 +45,14 @@ export function renderQueueMetricsPanel(
   drainCard.className = "capacity-card";
   const drainLabel = document.createElement("span");
   drainLabel.className = "capacity-card-label";
-  drainLabel.textContent = "net drain";
+  // A negative net-drain means the queue is growing, not draining. Relabel the
+  // card to "net growth" and show the magnitude so the displayed sign stays
+  // consistent with the label's meaning (mirrors the runway card's "growing").
+  const isGrowing = metrics.netDrainPerDay < 0;
+  drainLabel.textContent = isGrowing ? "net growth" : "net drain";
   const drainValue = document.createElement("span");
   drainValue.className = "capacity-card-value queue-drain-value";
-  drainValue.textContent = `${metrics.netDrainPerDay.toFixed(1)}/day`;
+  drainValue.textContent = `${Math.abs(metrics.netDrainPerDay).toFixed(1)}/day`;
   drainCard.appendChild(drainLabel);
   drainCard.appendChild(drainValue);
 

--- a/office-hours/src/vite-plugin-queue-seed.ts
+++ b/office-hours/src/vite-plugin-queue-seed.ts
@@ -10,11 +10,17 @@ export function officeHoursQueueSeedPlugin(): Plugin {
   return {
     name: "office-hours-queue-seed",
     buildStart() {
+      // Strip memberEmails (a denormalized auth field holding real email
+      // addresses) before serializing — it must never be baked into the
+      // public JS bundle. The UI never reads it; Firestore rules gate access
+      // server-side. computedAtMinutesAgo is also omitted: it is converted to
+      // computedAt at build time below.
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure-omit memberEmails from the public bundle
+      const { memberEmails, computedAtMinutesAgo, ...rest } = seedQueueMetrics;
       moduleCode =
-        `const seed = ${JSON.stringify(seedQueueMetrics)};\n` +
+        `const seed = ${JSON.stringify(rest)};\n` +
         `const now = Date.now();\n` +
-        `const { computedAtMinutesAgo, ...rest } = seed;\n` +
-        `export default { ...rest, computedAt: new Date(now - computedAtMinutesAgo * 60000) };\n`;
+        `export default { ...seed, computedAt: new Date(now - ${computedAtMinutesAgo} * 60000) };\n`;
     },
     resolveId(id) {
       if (id === VIRTUAL_MODULE_ID) return RESOLVED_VIRTUAL_MODULE_ID;

--- a/office-hours/test/app-view.test.ts
+++ b/office-hours/test/app-view.test.ts
@@ -233,3 +233,164 @@ describe("renderApp — replaceChildren between calls", () => {
     expect(container.querySelector(".error")).not.toBeNull();
   });
 });
+
+// ── Panel-registry integration tests ──────────────────────────────────────────
+//
+// These tests verify the registry composition: that the right panels appear in
+// the right tiers, that the grid container is present (or absent for error),
+// and that no panel heading is duplicated (the title-doubling guard below).
+
+describe("renderApp — panel-registry: grid container", () => {
+  const samples = [
+    makeSample({ sampledAt: new Date("2026-06-07T10:00:00Z") }),
+    makeSample({ sampledAt: new Date("2026-06-08T10:00:00Z"), activeWorkers: 2, targetWorkers: 3 }),
+  ];
+  const reminders = [
+    makeReminder("weekly-review", 30 * MINUTE),
+    makeReminder("overdue-task", -4 * HOUR),
+  ];
+
+  it("demo render: .panel-grid is present", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+    expect(container.querySelector(".panel-grid")).not.toBeNull();
+  });
+
+  it("owner-with-data render: .panel-grid is present", () => {
+    const container = document.createElement("div");
+    withThemeFg(() =>
+      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture }, now),
+    );
+    expect(container.querySelector(".panel-grid")).not.toBeNull();
+  });
+
+  it("error render: .panel-grid is absent", () => {
+    const container = document.createElement("div");
+    renderApp(container, { tier: "error" }, now);
+    expect(container.querySelector(".panel-grid")).toBeNull();
+  });
+});
+
+describe("renderApp — panel-registry: all panels present per tier", () => {
+  const samples = [
+    makeSample({ sampledAt: new Date("2026-06-07T10:00:00Z") }),
+    makeSample({ sampledAt: new Date("2026-06-08T10:00:00Z"), activeWorkers: 2, targetWorkers: 3 }),
+  ];
+  const reminders = [
+    makeReminder("weekly-review", 30 * MINUTE),
+    makeReminder("overdue-task", -4 * HOUR),
+  ];
+
+  it("demo: all five panels are present", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+    expect(container.querySelector(".capacity-heading")).not.toBeNull();
+    expect(container.querySelector(".capacity-pace")).not.toBeNull();
+    expect(container.querySelector(".capacity-history")).not.toBeNull();
+    expect(container.querySelector("#reminder-list")).not.toBeNull();
+    expect(container.querySelector(".queue-metrics-heading")).not.toBeNull();
+  });
+
+  it("owner-with-data: all five panels are present", () => {
+    const container = document.createElement("div");
+    withThemeFg(() =>
+      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture }, now),
+    );
+    expect(container.querySelector(".capacity-heading")).not.toBeNull();
+    expect(container.querySelector(".capacity-pace")).not.toBeNull();
+    expect(container.querySelector(".capacity-history")).not.toBeNull();
+    expect(container.querySelector("#reminder-list")).not.toBeNull();
+    expect(container.querySelector(".queue-metrics-heading")).not.toBeNull();
+  });
+});
+
+describe("renderApp — panel-registry: title-doubling guard", () => {
+  // querySelector finds only the FIRST match — a registry bug that duplicates a
+  // panel heading (e.g. renders <h2>CAPACITY</h2> twice) would pass querySelector
+  // but fail querySelectorAll(...).length === 1. Count is the correct check.
+  const samples = [
+    makeSample({ sampledAt: new Date("2026-06-07T10:00:00Z") }),
+    makeSample({ sampledAt: new Date("2026-06-08T10:00:00Z"), activeWorkers: 2, targetWorkers: 3 }),
+  ];
+  const reminders = [
+    makeReminder("weekly-review", 30 * MINUTE),
+    makeReminder("overdue-task", -4 * HOUR),
+  ];
+
+  it("demo: each panel heading appears exactly once", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+    expect(container.querySelectorAll(".capacity-heading").length).toBe(1);
+    expect(container.querySelectorAll(".capacity-pace-heading").length).toBe(1);
+    expect(container.querySelectorAll(".capacity-history-heading").length).toBe(1);
+    expect(container.querySelectorAll(".queue-metrics-heading").length).toBe(1);
+  });
+
+  it("owner-with-data: each panel heading appears exactly once", () => {
+    const container = document.createElement("div");
+    withThemeFg(() =>
+      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture }, now),
+    );
+    expect(container.querySelectorAll(".capacity-heading").length).toBe(1);
+    expect(container.querySelectorAll(".capacity-pace-heading").length).toBe(1);
+    expect(container.querySelectorAll(".capacity-history-heading").length).toBe(1);
+    expect(container.querySelectorAll(".queue-metrics-heading").length).toBe(1);
+  });
+});
+
+describe("renderApp — panel-registry: history panel is full-width", () => {
+  it("demo: .capacity-history has the panel-grid-full class", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+    const history = container.querySelector(".capacity-history");
+    expect(history).not.toBeNull();
+    expect(history!.classList.contains("panel-grid-full")).toBe(true);
+    // The history section IS the full-width element
+    expect(container.querySelector(".panel-grid-full")).toBe(history);
+  });
+});
+
+describe("renderApp — panel-registry: queue-metrics in both tiers", () => {
+  const samples = [
+    makeSample({ sampledAt: new Date("2026-06-07T10:00:00Z") }),
+    makeSample({ sampledAt: new Date("2026-06-08T10:00:00Z"), activeWorkers: 2, targetWorkers: 3 }),
+  ];
+  const reminders = [
+    makeReminder("weekly-review", 30 * MINUTE),
+    makeReminder("overdue-task", -4 * HOUR),
+  ];
+
+  it("demo: queue-metrics heading present, populated value element present (not empty placeholder)", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+    const heading = container.querySelector(".queue-metrics-heading");
+    expect(heading).not.toBeNull();
+    expect(heading!.textContent).toBe("QUEUE");
+    // getDemoQueueMetrics() returns non-null data, so the depth value renders
+    expect(container.querySelector(".queue-depth-value")).not.toBeNull();
+  });
+
+  it("owner with queueMetrics: queue-metrics heading and populated value element present", () => {
+    const container = document.createElement("div");
+    withThemeFg(() =>
+      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture }, now),
+    );
+    const heading = container.querySelector(".queue-metrics-heading");
+    expect(heading).not.toBeNull();
+    expect(heading!.textContent).toBe("QUEUE");
+    expect(container.querySelector(".queue-depth-value")).not.toBeNull();
+  });
+
+  it("owner with queueMetrics: null — heading present, empty placeholder with exact text", () => {
+    const container = document.createElement("div");
+    withThemeFg(() =>
+      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: null }, now),
+    );
+    const heading = container.querySelector(".queue-metrics-heading");
+    expect(heading).not.toBeNull();
+    // Find the queue-metrics empty placeholder specifically (other panels also emit .empty)
+    const empties = Array.from(container.querySelectorAll(".empty"));
+    const queueEmpty = empties.find((el) => el.textContent === "No queue metrics yet.");
+    expect(queueEmpty).not.toBeUndefined();
+  });
+});

--- a/office-hours/test/app-view.test.ts
+++ b/office-hours/test/app-view.test.ts
@@ -43,6 +43,18 @@ function makeReminder(title: string, offsetMs: number): Reminder {
   };
 }
 
+const queueMetricsFixture = {
+  openHelpWanted: 12,
+  closedPerDay: 3.2,
+  createdPerDay: 1.7,
+  netDrainPerDay: 1.5,
+  runwayDays: 8,
+  windowDays: 14,
+  computedAt: new Date("2026-06-10T00:00:00Z"),
+  groupId: "group-abc",
+  memberEmails: ["owner@example.com"],
+};
+
 describe("renderApp — demo tier", () => {
   it("renders a .demo-banner with the correct text", () => {
     const container = document.createElement("div");
@@ -92,14 +104,14 @@ describe("renderApp — owner tier with data", () => {
 
   it("does not render a .demo-banner", () => {
     const container = document.createElement("div");
-    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders }, now));
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture }, now));
 
     expect(container.querySelector(".demo-banner")).toBeNull();
   });
 
   it("renders a reminder list item for each reminder", () => {
     const container = document.createElement("div");
-    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders }, now));
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture }, now));
 
     const items = container.querySelectorAll("li.reminder");
     expect(items.length).toBe(2);
@@ -107,7 +119,7 @@ describe("renderApp — owner tier with data", () => {
 
   it("does not render an .error element", () => {
     const container = document.createElement("div");
-    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders }, now));
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture }, now));
 
     expect(container.querySelector(".error")).toBeNull();
   });
@@ -117,7 +129,7 @@ describe("renderApp — owner tier empty", () => {
   it("does not render a .demo-banner", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null }, now),
     );
 
     expect(container.querySelector(".demo-banner")).toBeNull();
@@ -126,7 +138,7 @@ describe("renderApp — owner tier empty", () => {
   it('renders the reminder-list empty state "No reminders."', () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null }, now),
     );
 
     const list = container.querySelector("#reminder-list");
@@ -142,7 +154,7 @@ describe("renderApp — owner tier empty", () => {
   it('renders the capacity empty state "No capacity data."', () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null }, now),
     );
 
     const empties = Array.from(container.querySelectorAll(".empty"));
@@ -153,7 +165,7 @@ describe("renderApp — owner tier empty", () => {
   it("renders the history-band empty states", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null }, now),
     );
 
     const empties = Array.from(container.querySelectorAll(".empty"));
@@ -171,7 +183,7 @@ describe("renderApp — owner tier empty", () => {
   it("does not render an .error element", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null }, now),
     );
 
     expect(container.querySelector(".error")).toBeNull();

--- a/office-hours/test/queue-metrics-panel.test.ts
+++ b/office-hours/test/queue-metrics-panel.test.ts
@@ -14,39 +14,37 @@ const baseMetrics: QueueMetricsSnapshot = {
   memberEmails: ["alice@example.com"],
 };
 
-const now = new Date("2026-06-14T06:00:00Z");
-
 describe("renderQueueMetricsPanel with populated metrics", () => {
   it("renders a heading with text QUEUE", () => {
-    const section = renderQueueMetricsPanel(baseMetrics, now);
+    const section = renderQueueMetricsPanel(baseMetrics);
     const heading = section.querySelector(".queue-metrics-heading");
     expect(heading).not.toBeNull();
     expect(heading!.textContent).toBe("QUEUE");
   });
 
   it("renders the queue depth value", () => {
-    const section = renderQueueMetricsPanel(baseMetrics, now);
+    const section = renderQueueMetricsPanel(baseMetrics);
     const value = section.querySelector(".queue-depth-value");
     expect(value).not.toBeNull();
     expect(value!.textContent).toBe("12");
   });
 
   it("renders the net drain value formatted to one decimal with /day", () => {
-    const section = renderQueueMetricsPanel(baseMetrics, now);
+    const section = renderQueueMetricsPanel(baseMetrics);
     const value = section.querySelector(".queue-drain-value");
     expect(value).not.toBeNull();
     expect(value!.textContent).toBe("1.5/day");
   });
 
   it("renders the runway value as 'N days' when runwayDays is a number", () => {
-    const section = renderQueueMetricsPanel(baseMetrics, now);
+    const section = renderQueueMetricsPanel(baseMetrics);
     const value = section.querySelector(".queue-runway-value");
     expect(value).not.toBeNull();
     expect(value!.textContent).toContain("8 days");
   });
 
   it("renders three capacity cards", () => {
-    const section = renderQueueMetricsPanel(baseMetrics, now);
+    const section = renderQueueMetricsPanel(baseMetrics);
     const cards = section.querySelectorAll(".capacity-card");
     expect(cards).toHaveLength(3);
   });
@@ -55,7 +53,7 @@ describe("renderQueueMetricsPanel with populated metrics", () => {
 describe("renderQueueMetricsPanel with runwayDays: null", () => {
   it("renders 'growing' in the runway value when runwayDays is null", () => {
     const metrics: QueueMetricsSnapshot = { ...baseMetrics, runwayDays: null, netDrainPerDay: -0.5 };
-    const section = renderQueueMetricsPanel(metrics, now);
+    const section = renderQueueMetricsPanel(metrics);
     const value = section.querySelector(".queue-runway-value");
     expect(value).not.toBeNull();
     expect(value!.textContent).toBe("growing");
@@ -64,21 +62,21 @@ describe("renderQueueMetricsPanel with runwayDays: null", () => {
 
 describe("renderQueueMetricsPanel with null metrics", () => {
   it("renders the queue-metrics-heading", () => {
-    const section = renderQueueMetricsPanel(null, now);
+    const section = renderQueueMetricsPanel(null);
     const heading = section.querySelector(".queue-metrics-heading");
     expect(heading).not.toBeNull();
     expect(heading!.textContent).toBe("QUEUE");
   });
 
   it("renders the empty placeholder with correct text", () => {
-    const section = renderQueueMetricsPanel(null, now);
+    const section = renderQueueMetricsPanel(null);
     const empty = section.querySelector(".empty");
     expect(empty).not.toBeNull();
     expect(empty!.textContent).toBe("No queue metrics yet.");
   });
 
   it("renders no capacity cards", () => {
-    const section = renderQueueMetricsPanel(null, now);
+    const section = renderQueueMetricsPanel(null);
     const cards = section.querySelectorAll(".capacity-card");
     expect(cards).toHaveLength(0);
   });

--- a/office-hours/test/queue-metrics-panel.test.ts
+++ b/office-hours/test/queue-metrics-panel.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { renderQueueMetricsPanel } from "../src/queue-metrics-panel.js";
+import { type QueueMetricsSnapshot } from "../src/queue-metrics.js";
+
+const baseMetrics: QueueMetricsSnapshot = {
+  openHelpWanted: 12,
+  closedPerDay: 3.5,
+  createdPerDay: 2.0,
+  netDrainPerDay: 1.5,
+  runwayDays: 8,
+  windowDays: 14,
+  computedAt: new Date("2026-06-14T00:00:00Z"),
+  groupId: "group-abc",
+  memberEmails: ["alice@example.com"],
+};
+
+const now = new Date("2026-06-14T06:00:00Z");
+
+describe("renderQueueMetricsPanel with populated metrics", () => {
+  it("renders a heading with text QUEUE", () => {
+    const section = renderQueueMetricsPanel(baseMetrics, now);
+    const heading = section.querySelector(".queue-metrics-heading");
+    expect(heading).not.toBeNull();
+    expect(heading!.textContent).toBe("QUEUE");
+  });
+
+  it("renders the queue depth value", () => {
+    const section = renderQueueMetricsPanel(baseMetrics, now);
+    const value = section.querySelector(".queue-depth-value");
+    expect(value).not.toBeNull();
+    expect(value!.textContent).toBe("12");
+  });
+
+  it("renders the net drain value formatted to one decimal with /day", () => {
+    const section = renderQueueMetricsPanel(baseMetrics, now);
+    const value = section.querySelector(".queue-drain-value");
+    expect(value).not.toBeNull();
+    expect(value!.textContent).toBe("1.5/day");
+  });
+
+  it("renders the runway value as 'N days' when runwayDays is a number", () => {
+    const section = renderQueueMetricsPanel(baseMetrics, now);
+    const value = section.querySelector(".queue-runway-value");
+    expect(value).not.toBeNull();
+    expect(value!.textContent).toContain("8 days");
+  });
+
+  it("renders three capacity cards", () => {
+    const section = renderQueueMetricsPanel(baseMetrics, now);
+    const cards = section.querySelectorAll(".capacity-card");
+    expect(cards).toHaveLength(3);
+  });
+});
+
+describe("renderQueueMetricsPanel with runwayDays: null", () => {
+  it("renders 'growing' in the runway value when runwayDays is null", () => {
+    const metrics: QueueMetricsSnapshot = { ...baseMetrics, runwayDays: null, netDrainPerDay: -0.5 };
+    const section = renderQueueMetricsPanel(metrics, now);
+    const value = section.querySelector(".queue-runway-value");
+    expect(value).not.toBeNull();
+    expect(value!.textContent).toBe("growing");
+  });
+});
+
+describe("renderQueueMetricsPanel with null metrics", () => {
+  it("renders the queue-metrics-heading", () => {
+    const section = renderQueueMetricsPanel(null, now);
+    const heading = section.querySelector(".queue-metrics-heading");
+    expect(heading).not.toBeNull();
+    expect(heading!.textContent).toBe("QUEUE");
+  });
+
+  it("renders the empty placeholder with correct text", () => {
+    const section = renderQueueMetricsPanel(null, now);
+    const empty = section.querySelector(".empty");
+    expect(empty).not.toBeNull();
+    expect(empty!.textContent).toBe("No queue metrics yet.");
+  });
+
+  it("renders no capacity cards", () => {
+    const section = renderQueueMetricsPanel(null, now);
+    const cards = section.querySelectorAll(".capacity-card");
+    expect(cards).toHaveLength(0);
+  });
+});

--- a/office-hours/test/vite-plugin-queue-seed.test.ts
+++ b/office-hours/test/vite-plugin-queue-seed.test.ts
@@ -39,6 +39,11 @@ describe("officeHoursQueueSeedPlugin", () => {
     expect(moduleCode).toContain("export default");
   });
 
+  it("does not bake the memberEmails auth field into the bundle", () => {
+    expect(moduleCode).toBeDefined();
+    expect(moduleCode).not.toContain("memberEmails");
+  });
+
   describe("generated snapshot", () => {
     let snapshot: {
       openHelpWanted: number;
@@ -49,7 +54,6 @@ describe("officeHoursQueueSeedPlugin", () => {
       windowDays: number;
       computedAt: Date;
       groupId: string;
-      memberEmails: string[];
     };
     let now: number;
 
@@ -88,8 +92,8 @@ describe("officeHoursQueueSeedPlugin", () => {
       expect(typeof snapshot.groupId).toBe("string");
     });
 
-    it("memberEmails is an array", () => {
-      expect(Array.isArray(snapshot.memberEmails)).toBe(true);
+    it("does not expose memberEmails (a denormalized auth field stripped from the public bundle)", () => {
+      expect((snapshot as Record<string, unknown>).memberEmails).toBeUndefined();
     });
 
     it("computedAt is a Date in the recent past", () => {


### PR DESCRIPTION
Closes #1465

## What

Refactors the office-hours dashboard from two hard-coded per-tier panel branches
into a **panel registry** composed into a **responsive CSS grid**, and wires the
already-scaffolded `queue-metrics` panel so it renders in both tiers.

`renderApp` previously composed its dashboard by hard-coding four panel renders
behind sequential `appendChild` calls — one branch for the demo tier, a
near-duplicate branch for the owner tier. That fixed composition is now a
registry of `Panel` entries rendered into a `.panel-grid`. This is the
foundational, no-new-data step for the multi-panel dashboard epic (#1464).

## How

Built in four commits:

1. **Panel registry + `renderApp` refactor + `.panel-grid` CSS.** A
   `definePanel<T>` factory binds each panel's `load`→`render` input type at the
   definition site and type-erases to a uniform `Panel`. `buildContext` resolves
   the per-tier data centrally; `renderApp` filters `PANELS` by `availableIn`,
   renders each into a `.panel-grid` (`grid-template-columns: repeat(auto-fit,
   minmax(min(100%, 22rem), 1fr))` — multi-column when wide, single column under
   ~22rem, no JS, no `@media`), and tags full-width panels with `panel-grid-full`.
   The four existing panels render unchanged; the history band spans full width.

2. **`renderQueueMetricsPanel` render fn + CSS + unit test.** A standalone render
   fn for the dispatch-queue snapshot (queue depth, net drain/day, runway), with
   an `.empty` placeholder for the null case, mirroring the existing per-panel
   render pattern.

3. **Wire queue-metrics live.** Adds `getOwnerQueueMetrics` (a single-doc `getDoc`
   read of `office-hours/{env}/metrics/dispatch-queue` — the first client read of
   this doc), extends the owner `ViewState` with `queueMetrics`, registers the
   panel, and loads it via `main.ts`'s `Promise.all`. The panel now renders in
   both demo and owner tiers — the acceptance criterion. The security rule already
   exists (`match /office-hours/{env}/metrics/{metricId}`), so no rules change is
   needed.

4. **Registry-composition + integration tests.** Asserts the `.panel-grid`
   container exists in demo/owner tiers and not in error, all registered panels
   render per tier, history spans full width, and the queue-metrics panel renders
   in both tiers (plus its empty placeholder for null owner metrics).

## Design notes

- **`renderApp` never renders a panel's `title`.** Each render fn already emits
  its own heading; a registry-rendered `<h2>{title}</h2>` wrapper would double
  every heading — and the existing first-match `querySelector` tests would pass
  silently. `title` is reserved metadata. The integration tests guard this with
  count-of-one heading assertions (`querySelectorAll(...).length === 1`), which a
  plain non-null check would not catch.
- **`PanelContext` pre-resolves all data centrally** (mirroring `main.ts`'s
  `Promise.all`), so each panel's `load(ctx)` is a *selector* over already-loaded
  data, not a self-sourcing loader. When the epic's later panels source from
  different backends, `load` becomes async and `renderApp` awaits — a change
  contained at the registry boundary, left for that work.

## Verification

- `npm test --prefix office-hours` — 172 tests pass across 18 files.
- `npm run build --prefix office-hours` — `tsc` typecheck (proves the
  `definePanel<T>` load→render bindings and the extended owner `ViewState` are
  sound) + `vite build` succeed.
