### PR TITLE
Add unit tests for truncateForLog in office-hours-sync

### DIFF
--- a/functions/src/office-hours-sync.ts
+++ b/functions/src/office-hours-sync.ts
@@ -87,7 +87,7 @@ export function isValidJitKey(key: string): boolean {
 // Truncates a third-party HTTP response body before it enters an Error message
 // (and thus the function logs). Bounds the blast radius of a verbose or
 // reflected GitHub error response without dropping the leading diagnostic text.
-function truncateForLog(text: string, max = 200): string {
+export function truncateForLog(text: string, max = 200): string {
   return text.length > max ? `${text.slice(0, max)}…[truncated]` : text;
 }
 

--- a/functions/test/office-hours-sync.test.ts
+++ b/functions/test/office-hours-sync.test.ts
@@ -35,6 +35,7 @@ import {
   parseJitDueMarker,
   buildAppJwt,
   mintInstallationToken,
+  truncateForLog,
   type JitIssue,
 } from "../src/office-hours-sync";
 
@@ -732,5 +733,32 @@ describe("mintInstallationToken", () => {
         privateKey: testKeyPair.privateKey,
       }),
     ).rejects.toThrow(/missing token/);
+  });
+});
+
+describe("truncateForLog", () => {
+  it("passes an empty string through unchanged", () => {
+    expect(truncateForLog("")).toBe("");
+  });
+
+  it("passes a string of exactly max length through unchanged", () => {
+    const result = truncateForLog("a".repeat(200));
+    expect(result).toBe("a".repeat(200));
+    expect(result).not.toContain("…[truncated]");
+  });
+
+  it("truncates a string one character over max to max chars plus the suffix", () => {
+    expect(truncateForLog("a".repeat(201))).toBe("a".repeat(200) + "…[truncated]");
+  });
+
+  it("truncates a string significantly longer than max correctly", () => {
+    const result = truncateForLog("b".repeat(1000));
+    expect(result).toBe("b".repeat(200) + "…[truncated]");
+    expect(result.length).toBe(200 + 12);
+    expect(result.slice(0, 200)).toBe("b".repeat(200));
+  });
+
+  it("respects an explicit max override", () => {
+    expect(truncateForLog("x".repeat(50), 10)).toBe("x".repeat(10) + "…[truncated]");
   });
 });


### PR DESCRIPTION
Closes #1621

## What

Export `truncateForLog` from `functions/src/office-hours-sync.ts` and add a
`describe("truncateForLog", …)` block in `functions/test/office-hours-sync.test.ts`
covering its previously-unverified contract.

`truncateForLog` bounds a third-party HTTP response body before it enters an
`Error` message (and the function logs). Its contract — passthrough at or below
`max`, truncate to `max` chars plus the suffix `…[truncated]` above `max`,
default `max = 200` — had no test. A future refactor could silently break the
off-by-one boundary (`text.length > max`) or change the suffix string with no
test catching it.

## Changes

- `functions/src/office-hours-sync.ts`: add `export` to `function truncateForLog`
  (function body unchanged; the two existing call sites are unaffected).
- `functions/test/office-hours-sync.test.ts`: add `truncateForLog` to the
  named-import block and append five `it` cases — empty-string passthrough,
  exact-`max` passthrough (asserting no suffix), `max + 1` truncation (exact
  full-suffix equality), significantly-longer truncation (length + body
  assertions), and explicit-`max` override (a 50-char input that passes through
  under the default 200 but truncates at 10).

## Notes

The issue's "Why" stated `truncateForLog` was already exported — it was not. The
function was module-private; exporting it is the enabling step for direct unit
testing and is part of this change.

## Verification

`vitest run` for the functions project passes — the new 5-test block plus the
existing suite (27 tests total) are green. CI's functions test job covers the
"All new tests pass in CI" acceptance criterion.
