### PR TITLE
fellspiral: test that the live-DOM skip persists across Home -> Post -> Home

### DIFF
--- a/fellspiral/test/main-routing.test.ts
+++ b/fellspiral/test/main-routing.test.ts
@@ -208,4 +208,55 @@ describe("fellspiral main routing (#1285)", () => {
     expect(renderHomeHtml).not.toHaveBeenCalled();
     expect(app.querySelector("[data-prerendered]")).not.toBeNull();
   });
+
+  // Issue #1409 — extended scope of the live-DOM skip.
+  //
+  // The live-DOM check (app.querySelector("#posts")) fires whenever #posts is
+  // present, not only on the initial prerender. After a prior loadPosts() run
+  // renders a fresh #posts, repeat navigations to "/" and "/post/..." both
+  // return null from render and leave #posts untouched. This case exercises
+  // the full Home → Post → Home flow to confirm renderHomeHtml is called
+  // exactly once (the initial Home) and #posts remains live throughout.
+  it("keeps skipping while #posts is live from loadPosts across Post and repeat-Home navigations (#1409)", async () => {
+    // 1. Enter via /admin so the first Home nav finds no live #posts and
+    //    therefore runs loadPosts → renderHomeHtml. Mirror the /admin setup.
+    history.pushState({}, "", "/admin");
+    scaffoldDom();
+    await importMainTrackingListeners();
+    const app = document.getElementById("app")!;
+    // Wait for the admin route to clear the prerendered #posts.
+    await vi.waitFor(() => {
+      expect(app.querySelector("#posts")).toBeNull();
+    });
+
+    // 2. Navigate Home via the real router's popstate listener.
+    history.pushState({}, "", "/");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    // Wait until a fresh #posts with data-test="home" is present.
+    await vi.waitFor(() => {
+      expect(app.querySelector("#posts")).not.toBeNull();
+      expect(app.innerHTML).toContain('data-test="home"');
+    });
+    expect(renderHomeHtml).toHaveBeenCalledTimes(1);
+
+    // 3. Navigate to a post. The post route shares the same regex as home
+    //    (/^\/(?:post\/.*)?$/); render returns null because #posts is live
+    //    (the loadPosts-origin live-DOM skip, the new coverage).
+    history.pushState({}, "", "/post/example");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    await new Promise((r) => setTimeout(r, 0));
+    // #posts remains live; renderHomeHtml was not called again.
+    expect(app.querySelector("#posts")).not.toBeNull();
+    expect(renderHomeHtml).toHaveBeenCalledTimes(1);
+
+    // 4. Navigate Home again — also skips because #posts is still live.
+    //    This is the extended scope: the skip fires whenever #posts is
+    //    genuinely live, not only on the initial prerender, and is keyed on
+    //    the live DOM rather than a persistent flag.
+    history.pushState({}, "", "/");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(app.querySelector("#posts")).not.toBeNull();
+    expect(renderHomeHtml).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Closes #1409

## What

Adds one test case to `fellspiral/test/main-routing.test.ts` covering the
extended scope of the live-DOM skip that PR #1396 (for #1285) introduced in
`fellspiral/src/main.ts`.

That change replaced the one-shot `isFirstHomeRender` flag with a live-DOM
check: the home route's `render` returns `null` (preserving the existing DOM,
skipping `loadPosts`) whenever `app.querySelector("#posts")` is present, and
runs `loadPosts` otherwise. The skip therefore fires whenever `#posts` is
genuinely live — not only on the initial prerender, but also after a prior
`loadPosts()` render produced a fresh `#posts`. That extended scope was
intentional but untested.

## The new case

`"keeps skipping while #posts is live from loadPosts across Post and repeat-Home navigations (#1409)"`
walks a faithful Home → Post → Home flow:

1. Enter via `/admin` so the first Home nav finds no live `#posts` and runs
   `loadPosts` → `renderHomeHtml`.
2. Navigate Home — a fresh `#posts` renders; `renderHomeHtml` called once.
3. Navigate to `/post/example` — `/post/...` and `/` share the same route
   regex (`/^\/(?:post\/.*)?$/`); `render` returns `null` because `#posts` is
   live, so `#posts` stays put and `renderHomeHtml` stays at one call.
4. Navigate Home again — also skips for the same reason; `renderHomeHtml`
   remains at exactly one call.

The `toHaveBeenCalledTimes(1)` assertion is the faithful invariant: across the
whole flow the `#posts` from the first `loadPosts()` stays live, so the home
render is reachable exactly once. It fails if `main.ts`'s live-DOM skip were
reverted to a one-shot flag or removed.

## Scope

Test-only — no changes to `fellspiral/src/main.ts` or any other file. Reuses
the file's existing scaffolding (`scaffoldDom`, `importMainTrackingListeners`,
the hoisted spies and `vi.mock` block); no new mocks or helpers.

All three cases in the suite pass.
