### PR TITLE
dispatch-sync-merge-queue: close duplicate merge-pr tracking issues (OPEN_COUNT>1)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-sync-merge-queue
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-sync-merge-queue
@@ -136,6 +136,26 @@ for (( i=0; i<FILTERED_COUNT; i++ )); do
     echo "$LABEL: created #$ISSUE_NUM"
   else
     # ---- Present → update only on title drift -------------------------------
+    if [[ "$OPEN_COUNT" -gt 1 ]]; then
+      # Two concurrent ticks can each create a tracking issue for the same
+      # mergeable PR (OPEN_COUNT>1). Reconcile after the fact: keep .[0] as the
+      # canonical issue and close every duplicate. The bottom close path cannot
+      # reap these — the PR is still mergeable, so its MERGEABLE_NUMS guard skips
+      # it (see #1651).
+      echo "$LABEL: warning ($OPEN_COUNT open tracking issues; closing $((OPEN_COUNT - 1)) duplicate(s))" >&2
+      while read -r DUP_NUM; do
+        [[ -z "$DUP_NUM" ]] && continue
+        DUP_RC=0
+        DUP_OUT=$(gh_retry gh issue close "$DUP_NUM" \
+          --repo "$OFFICE_HOURS_NATE_REPO" 2>&1) || DUP_RC=$?
+        if [[ "$DUP_RC" -ne 0 ]]; then
+          echo "$LABEL: error (gh issue close duplicate #$DUP_NUM failed: $DUP_OUT)" >&2
+          HARD_ERROR=1
+          continue
+        fi
+        echo "$LABEL: closed duplicate #$DUP_NUM"
+      done < <(printf '%s' "$OPEN_JSON" | jq -r '.[1:][].number')
+    fi
     EXISTING_NUM=$(printf '%s' "$OPEN_JSON" | jq -r '.[0].number')
     EXISTING_TITLE=$(printf '%s' "$OPEN_JSON" | jq -r '.[0].title')
     if [[ "$EXISTING_TITLE" == "$PR_TITLE" ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -30097,6 +30097,24 @@ assert_eq "bail: script exits non-zero when the mergeable set cannot be computed
 assert_eq "bail: close pass did not run (no gh issue close)" "absent" "$(log_state gh-merge-issue-close.log)"
 teardown
 
+# (f) OPEN_COUNT>1 (concurrent-tick duplicate) → close every issue beyond .[0]
+echo "Test: OPEN_COUNT>1 → close duplicates, keep .[0]"
+setup
+printf '%s\n' "$MERGE_PR_ONE" > "$STUB_DIR/merge-pr-list.json"
+printf '[{"number":77,"title":"Add widget"},{"number":78,"title":"Add widget"}]\n' > "$STUB_DIR/oh-issue-merge-pr-42.json"
+"$TMPDIR_TEST/dispatch-sync-merge-queue" >/dev/null 2>&1
+assert_eq "dup-close: issue-close log present" "present" "$(log_state gh-merge-issue-close.log)"
+TOTAL=$((TOTAL + 1))
+if grep -q 'issue close 78' "$STUB_DIR/gh-merge-issue-close.log" \
+   && ! grep -q 'issue close 77' "$STUB_DIR/gh-merge-issue-close.log"; then
+  PASS=$((PASS + 1)); echo "  PASS: closed duplicate #78, kept canonical #77"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: closed duplicate #78, kept canonical #77"
+fi
+assert_eq "dup-close: no spurious create" "absent" "$(log_state gh-merge-issue-create.log)"
+assert_eq "dup-close: no edit (.[0] title matches)" "absent" "$(log_state gh-merge-issue-edit.log)"
+teardown
+
 # ============================================================================
 # summary
 # ============================================================================


### PR DESCRIPTION
Closes #1651

## Problem

`dispatch-sync-merge-queue` is the tick-time reconciler that keeps the
`natb1/office-hours-nate` tracking issues in sync with the currently-mergeable
PR set, find-or-creating one tracking issue labeled `merge-pr:<N>` per mergeable
PR.

Two concurrent tick runs can both observe `OPEN_COUNT == 0` for the same PR
(possible under a network partition that delays the first run's
`gh issue create` response) and each create a separate tracking issue with the
same `merge-pr:<N>` label. On subsequent ticks `OPEN_COUNT` is then 2+, but the
find-or-create `else` branch only reads `.[0]`, leaving `.[1:]` open. The bottom
close path does not reap them either: the PR is still mergeable, so its
`MERGEABLE_NUMS[$PR_NUM]` guard skips it. The duplicates persist indefinitely
and the `office-hours-sync` Function sees multiple tracking issues for one PR.

## Fix

Reconciliation-after-the-fact, not race prevention. In the `else` branch, when
`OPEN_COUNT > 1` for a `merge-pr:<N>` label, the script now closes every
tracking issue beyond `.[0]`, logs a warning to stderr so the condition is
observable, then proceeds with the normal title-drift check on `.[0]` (the kept
canonical issue). The single-issue path (`OPEN_COUNT` 0 or 1) is unchanged.

The duplicate-close loop mirrors the existing bottom close path: `gh_retry`,
per-item rc capture, `HARD_ERROR=1` on failure, and a process-substitution feed
(`done < <(jq …)`) rather than a `jq | while` pipe — the latter runs the loop in
a subshell, where a `HARD_ERROR=1` assignment would be silently lost.

This is the complete and only fix: the bottom close path already reaps
duplicates correctly once a PR drops out of the mergeable set. The gap is only
the window while the PR is still mergeable, which the `else`-branch block now
closes.

## Test

Adds case (f) to the `dispatch-sync-merge-queue` suite in
`test-dispatch-scripts.sh`: a 2-element open-guard fixture (`.[0]=#77` with a
matching title, `.[1]=#78` the duplicate) asserts #78 is closed, #77 is kept,
and neither a create nor an edit fires. The full bash unit suite passes
(2890/2890), with the five pre-existing `dispatch-sync-merge-queue` cases
unchanged.
