### PR TITLE
budget: test two non-primary members of the same normalizedId in an orphan batch

### DIFF
--- a/budget/test/pages/home.test.ts
+++ b/budget/test/pages/home.test.ts
@@ -732,7 +732,11 @@ describe("renderHome", () => {
       expect(primaryHtml).toContain("normalized-group");
     });
 
-    it("suppresses all non-primary members when two share a normalizedId in an orphan batch", () => {
+    it("suppresses every non-primary member via the !primary guard when two share a normalizedId in a primary-less orphan batch", () => {
+      // Neither member is the primary, so the pre-pass group has no primary and the
+      // !primary early-return drops both rows. This exercises the !primary suppression
+      // path for a multi-member orphan batch — not the seenGroups guard, which is
+      // covered separately below.
       const budgetIdToName = new Map<string, string>();
       const batch = [
         txn({ id: "txn-b", description: "Store B", amount: 50, normalizedId: "norm-1", normalizedPrimary: false, timestamp: mockTimestamp("2025-01-04") }),
@@ -742,6 +746,28 @@ describe("renderHome", () => {
       expect(html).not.toContain("Store B");
       expect(html).not.toContain("Store C");
       expect(html).not.toContain("normalized-group");
+      // Positive pin: the whole batch collapses to empty output, so a broken
+      // implementation that emits unexpected non-empty HTML (an error row, a stray
+      // transaction) still fails even though it avoids the strings above.
+      expect(html.trim()).toBe("");
+    });
+
+    it("renders a normalized group exactly once when a second non-primary member shares its normalizedId (seenGroups de-dup)", () => {
+      // A primary member is followed by a second non-primary member of the same
+      // group, both inside one batch. The pre-pass group HAS a primary, so the
+      // !primary guard never fires — the only thing stopping the second member from
+      // calling renderNormalizedGroup a second time is the seenGroups guard. If
+      // seenGroups.add were removed or reordered after the !primary check, the second
+      // iteration would render a duplicate group row, so the count assertion below
+      // fails. This is the genuine regression guard for the seenGroups de-dup path.
+      const budgetIdToName = new Map<string, string>();
+      const batch = [
+        txn({ id: "txn-a", description: "Store A", amount: 50, normalizedId: "norm-1", normalizedPrimary: true, timestamp: mockTimestamp("2025-01-11") }),
+        txn({ id: "txn-b", description: "Store B", amount: 50, normalizedId: "norm-1", normalizedPrimary: false, timestamp: mockTimestamp("2025-01-04") }),
+      ];
+      const html = renderTransactionRows(batch, "household", true, budgetIdToName);
+      const groupRowCount = html.split("normalized-group").length - 1;
+      expect(groupRowCount).toBe(1);
     });
 
     it("renders the table (no data error) when a batch contains only a non-primary member", async () => {

--- a/budget/test/pages/home.test.ts
+++ b/budget/test/pages/home.test.ts
@@ -732,6 +732,18 @@ describe("renderHome", () => {
       expect(primaryHtml).toContain("normalized-group");
     });
 
+    it("suppresses all non-primary members when two share a normalizedId in an orphan batch", () => {
+      const budgetIdToName = new Map<string, string>();
+      const batch = [
+        txn({ id: "txn-b", description: "Store B", amount: 50, normalizedId: "norm-1", normalizedPrimary: false, timestamp: mockTimestamp("2025-01-04") }),
+        txn({ id: "txn-c", description: "Store C", amount: 50, normalizedId: "norm-1", normalizedPrimary: false, timestamp: mockTimestamp("2025-01-03") }),
+      ];
+      const html = renderTransactionRows(batch, "household", true, budgetIdToName);
+      expect(html).not.toContain("Store B");
+      expect(html).not.toContain("Store C");
+      expect(html).not.toContain("normalized-group");
+    });
+
     it("renders the table (no data error) when a batch contains only a non-primary member", async () => {
       const html = await renderHome(localOptions({
         getTransactions: vi.fn().mockResolvedValue([


### PR DESCRIPTION
Closes #1360

## What

Adds a regression test for `renderTransactionRows` (`budget/src/pages/home.ts`)
covering the two-member orphan batch case: two non-primary members sharing the
same `normalizedId` with no in-batch primary. The test asserts both members are
suppressed and no group row renders.

## Why

`renderTransactionRows` de-duplicates normalized groups within a batch via a
`seenGroups` set. When a batch has no in-batch primary for a group, the first
non-primary member takes the suppress-and-skip path *after* `seenGroups.add`
runs; a second non-primary member with the same `normalizedId` is then dropped
earlier at the `seenGroups.has` guard.

The current ordering is correct, but the two-member orphan case was untested. If
`seenGroups.add` were moved after the `!primary` check, both members would still
be suppressed and output would stay correct — so the de-dup ordering invariant
would silently lose its guard with no failing test. The existing test from #1346
only covers a single orphan non-primary.

## Change

Test-only — no production code changes. One new `it(...)` added to the existing
`describe("normalized transaction groups", …)` block in
`budget/test/pages/home.test.ts`, reusing the established `txn()` and
`mockTimestamp()` helpers. All 58 tests in the suite pass.
