### PR TITLE
budget-etl: validate category-filter fields on transaction-specific categorization rules

### DIFF
--- a/budget-etl/cmd/patch/integration_test.go
+++ b/budget-etl/cmd/patch/integration_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
 	"os"
 	"testing"
@@ -102,9 +103,19 @@ func ruleIDPresent(rs []export.Rule, id string) bool {
 // convertExportRules. It is duplicated here because that helper is
 // package-private to the parent budget-etl/main.go and cmd/patch can't
 // import it.
+//
+// DIVERGENCE RISK: this is a hand-maintained copy. When main.go's
+// convertExportRules changes (e.g. the validateCategoryFilterFields check
+// added below), this helper must be updated in lockstep or the integration
+// test will silently accept inputs the real binary rejects.
 func convertExportRulesForTest(exportRules []export.Rule) ([]rules.Rule, error) {
 	out := make([]rules.Rule, len(exportRules))
 	for i, r := range exportRules {
+		// Mirror convertExportRules' validateCategoryFilterFields call:
+		// category-filter fields are only valid on budget_assignment rules.
+		if r.Type == "categorization" && (r.MatchCategory != "" || r.ExcludeCategory != "" || r.Category != "") {
+			return nil, fmt.Errorf("rule %s: category-filter fields (matchCategory/excludeCategory/category) are only valid on budget_assignment rules, not categorization rules", r.ID)
+		}
 		out[i] = rules.Rule{
 			ID:              r.ID,
 			Type:            r.Type,

--- a/budget-etl/main.go
+++ b/budget-etl/main.go
@@ -517,12 +517,20 @@ func buildRule(r rules.Rule, minAmountDollars, maxAmountDollars *float64) (rules
 	return r, nil
 }
 
+// validateCategoryFilterFields rejects category-filter fields on categorization rules.
+func validateCategoryFilterFields(r export.Rule) error {
+	if r.Type == "categorization" && (r.MatchCategory != "" || r.ExcludeCategory != "" || r.Category != "") {
+		return fmt.Errorf("rule %s: category-filter fields (matchCategory/excludeCategory/category) are only valid on budget_assignment rules, not categorization rules", r.ID)
+	}
+	return nil
+}
+
 // convertExportRules converts export.Rule to rules.Rule for the rules engine.
 func convertExportRules(exportRules []export.Rule) ([]rules.Rule, error) {
 	ruleSet := make([]rules.Rule, len(exportRules))
 	for i, r := range exportRules {
-		if r.Type == "categorization" && (r.MatchCategory != "" || r.ExcludeCategory != "" || r.Category != "") {
-			return nil, fmt.Errorf("rule %s: category-filter fields (matchCategory/excludeCategory/category) are only valid on budget_assignment rules, not categorization rules", r.ID)
+		if err := validateCategoryFilterFields(r); err != nil {
+			return nil, err
 		}
 		built, err := buildRule(rules.Rule{
 			ID:              r.ID,
@@ -557,6 +565,9 @@ func applyTransactionRules(txns []budget.TransactionData, txnDocIDs []string, tx
 		idIndex[id] = i
 	}
 	for _, r := range txnRules {
+		if err := validateCategoryFilterFields(r); err != nil {
+			return err
+		}
 		idx, ok := idIndex[r.TransactionID]
 		if !ok {
 			continue

--- a/budget-etl/main_test.go
+++ b/budget-etl/main_test.go
@@ -238,6 +238,77 @@ func TestConvertExportRulesRejectsCategoryFilterOnCategorization(t *testing.T) {
 	}
 }
 
+func TestApplyTransactionRulesRejectsCategoryFilterOnCategorization(t *testing.T) {
+	ts := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		rule    export.Rule
+		wantErr bool
+	}{
+		{
+			name: "categorization with MatchCategory errors",
+			rule: export.Rule{
+				ID:            "r1",
+				Type:          "categorization",
+				Target:        "Food:Coffee",
+				MatchCategory: "Food",
+				TransactionID: "doc-1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "categorization with ExcludeCategory errors",
+			rule: export.Rule{
+				ID:              "r2",
+				Type:            "categorization",
+				Target:          "Food:Coffee",
+				ExcludeCategory: "Dining",
+				TransactionID:   "doc-1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "categorization with Category errors",
+			rule: export.Rule{
+				ID:            "r3",
+				Type:          "categorization",
+				Target:        "Food:Coffee",
+				Category:      "Food",
+				TransactionID: "doc-1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "budget_assignment with category fields succeeds",
+			rule: export.Rule{
+				ID:              "r4",
+				Type:            "budget_assignment",
+				Target:          "budget-food",
+				MatchCategory:   "Food",
+				ExcludeCategory: "Dining",
+				Category:        "Food",
+				TransactionID:   "doc-1",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			txns := []budget.TransactionData{
+				{Description: "Test Item", Amount: 500, Timestamp: ts, TransactionID: "t1"},
+			}
+			docIDs := []string{"doc-1"}
+			err := applyTransactionRules(txns, docIDs, []export.Rule{tc.rule})
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestApplyTransactionRules(t *testing.T) {
 	ts := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
 

--- a/budget-etl/main_test.go
+++ b/budget-etl/main_test.go
@@ -291,6 +291,17 @@ func TestApplyTransactionRulesRejectsCategoryFilterOnCategorization(t *testing.T
 			},
 			wantErr: false,
 		},
+		{
+			name: "categorization with MatchCategory errors even when target transaction is absent",
+			rule: export.Rule{
+				ID:            "r5",
+				Type:          "categorization",
+				Target:        "Food:Coffee",
+				MatchCategory: "Food",
+				TransactionID: "doc-absent",
+			},
+			wantErr: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #1371

## What

`budget-etl` rejects category-filter fields (`MatchCategory`, `ExcludeCategory`,
`Category`) on general categorization rules — #1366 added that check in
`convertExportRules`. But transaction-specific rules (those with a
`TransactionID`) are split off by `splitRules` *before* `convertExportRules`
runs, and are applied by `applyTransactionRules`, which writes `r.Target`
directly without ever consulting the category-filter fields. As a result, a
`MatchCategory`/`ExcludeCategory`/`Category` set on a transaction-specific
categorization rule was silently inert — the same class of author confusion
#1276 / #1366 fixed for general rules.

## How

- Extract a single shared helper `validateCategoryFilterFields(export.Rule) error`
  in `budget-etl/main.go`, reproducing the existing condition and error message
  byte-for-byte.
- Wire it into `convertExportRules` (replacing the previous inline check — no
  behavior change, the error string is identical).
- Wire it into `applyTransactionRules` at the top of the rule loop, *before* the
  transaction-index lookup, so validation is unconditional and a bad txn rule
  errors even when its target transaction is not in the current batch — matching
  `convertExportRules`, which validates every rule.

The validation logic and error message now live in one place and stay identical
across both paths.

## Test

- New table-driven test `TestApplyTransactionRulesRejectsCategoryFilterOnCategorization`
  mirroring the existing `convertExportRules` test: the three reject cases
  (categorization rule with `MatchCategory`, `ExcludeCategory`, `Category` set)
  plus the pass case (`budget_assignment` rule with the same fields set).
- `go test ./...` passes from `budget-etl/`.
