### PR TITLE
print: test grant-click onSourceBound path in initLocalFolder

### DIFF
--- a/print/test/local-folder-ui.test.ts
+++ b/print/test/local-folder-ui.test.ts
@@ -91,4 +91,25 @@ describe("initLocalFolder", () => {
 
     expect(onSourceBound).toHaveBeenCalledTimes(1);
   });
+
+  it("invokes onSourceBound after the grant-click binds the source (prompt/grant path)", async () => {
+    mockStore.queryPermission.mockResolvedValue("prompt");
+    mockStore.requestPermission.mockResolvedValue("granted");
+
+    const section = document.createElement("span");
+    const container = document.createElement("div");
+    const onSourceBound = vi.fn();
+
+    await initLocalFolder(section, container, onSourceBound);
+
+    // The grant path defers the callback until after the user clicks the button.
+    expect(onSourceBound).not.toHaveBeenCalled();
+
+    const button = section.querySelector<HTMLButtonElement>("#local-folder-grant");
+    expect(button).not.toBeNull();
+    button!.click();
+
+    // The click handler is async; wait for it to resolve before asserting.
+    await vi.waitFor(() => expect(onSourceBound).toHaveBeenCalledTimes(1));
+  });
 });


### PR DESCRIPTION
Closes #1408

## Summary

Adds the missing unit-test coverage for the **grant-click `onSourceBound`** path
in `initLocalFolder` (`print/src/local-folder-ui.ts`).

`onSourceBound` re-renders a viewer route stuck on "Not Found" after a browser
restart. It fires on three paths inside `bindAndRender`: auto-bind (`list`),
grant-click (`grant`), and first-open picker (`open`). The existing suite only
exercised the granted/list auto-bind path. The prompt-state + grant-click path
(`local-folder-ui.ts:98-113`) — the primary stuck-viewer scenario, normal after
a browser restart in a non-PWA tab — had no test, so a regression in its
`onSourceBound` invocation would have gone undetected.

## Changes

- `print/test/local-folder-ui.test.ts`: one new `it(...)` case in the existing
  `initLocalFolder` describe block. It overrides `queryPermission` → `"prompt"`
  (driving `decideFolderUiState` to the `"grant"` branch) and
  `requestPermission` → `"granted"`, asserts `onSourceBound` has **not** fired
  immediately after `initLocalFolder` (the grant path defers it), then clicks the
  rendered `#local-folder-grant` button and uses `vi.waitFor` to assert
  `onSourceBound` fires exactly once after the async handler resolves.

Pure test addition — no production code changes.

## Verification

`run-unit-tests.sh`: 362 passed, 1 pre-existing skip, 0 failed.
