### PR TITLE
print: add unauthenticated teardown flush test (uid=null localStorage path)

### DIFF
--- a/print/test/viewer/shell.test.ts
+++ b/print/test/viewer/shell.test.ts
@@ -344,6 +344,25 @@ describe("initViewer", () => {
     expect(saveReadingPosition).toHaveBeenCalledWith("uid1", "m1", "2");
   });
 
+  it("cleanup flushes pending save timer (unauthenticated)", async () => {
+    vi.mocked(getReadingPosition).mockResolvedValue(null);
+    const renderer = makeMockRenderer();
+
+    const cleanup = initViewer(outlet, () => renderer, () => Promise.resolve("https://example.com/doc.pdf"), "m1", null);
+    await flushInit();
+
+    const nextBtn = outlet.querySelector(".viewer-next") as HTMLButtonElement;
+    nextBtn.click();
+    await flushInit();
+
+    // Flush synchronously before the 500ms timer fires
+    cleanup();
+
+    // localStorage should have been written with the pending position
+    // without advancing timers — the flush is synchronous
+    expect(localStorage.getItem("reading-position:m1")).toBe("2");
+  });
+
   it("cleanup calls renderer.destroy", async () => {
     const renderer = makeMockRenderer();
 

--- a/print/test/viewer/shell.test.ts
+++ b/print/test/viewer/shell.test.ts
@@ -345,7 +345,6 @@ describe("initViewer", () => {
   });
 
   it("cleanup flushes pending save timer (unauthenticated)", async () => {
-    vi.mocked(getReadingPosition).mockResolvedValue(null);
     const renderer = makeMockRenderer();
 
     const cleanup = initViewer(outlet, () => renderer, () => Promise.resolve("https://example.com/doc.pdf"), "m1", null);


### PR DESCRIPTION
Closes #1410

## What

Adds an unauthenticated (`uid=null`) teardown-flush test to
`print/test/viewer/shell.test.ts`, mirroring the existing authenticated
`cleanup flushes pending save timer` test.

## Why

The authenticated teardown path is covered: the existing test asserts that
`cleanup()` synchronously flushes the pending position via `saveReadingPosition`
before the 500ms save timer fires. The **unauthenticated** path —
`persistPosition()` writing through `saveLocalPosition` to `localStorage` —
had no teardown-flush test. The plan for #1283 (merged via #1397) explicitly
called for both paths ("unauthed: localStorage.getItem reflects it"); a
regression in the `localStorage` branch of `persistPosition()` during teardown
would currently go uncaught.

## What it does

The new test `cleanup flushes pending save timer (unauthenticated)`:

- initializes the viewer with `uid=null`,
- advances the reading position by clicking next,
- calls `cleanup()` **without** advancing any timers,
- asserts `localStorage.getItem("reading-position:m1")` is `"2"`.

Passing without advancing timers proves the teardown flush on the
`localStorage` path is synchronous — the same guarantee the authenticated test
proves for `saveReadingPosition`.

## Test

`npx vitest run --root print test/viewer/shell.test.ts` — 50/50 pass, no
regressions. This PR is test-only; no `src/` production code changes.
