### PR TITLE
budget: round-trip the snapshot schema through a single collection registry

### DIFF
--- a/budget/src/collection-registry.ts
+++ b/budget/src/collection-registry.ts
@@ -1,0 +1,77 @@
+/**
+ * Single source of truth for the budget snapshot collections.
+ *
+ * Each entry pairs the three adaptors for one IndexedDB store — parse a raw
+ * JSON record into the domain shape, convert the domain shape into the IDB
+ * record, and serialize the IDB record back to raw JSON. `defineCollection`
+ * forces those three to chain, so a mispaired adaptor is a compile error at
+ * the offending entry rather than a silent data loss on round-trip.
+ *
+ * The export/upload/idb paths derive their collection lists from this registry,
+ * so adding a store here is the single edit that wires it through every path.
+ *
+ * This module must NOT import from idb.ts — idb.ts imports the registry, and a
+ * back-import would create a cycle. The Idb/Domain/Raw types are derived from
+ * the adaptor signatures via ReturnType, not imported by name.
+ */
+import { parseRawTransaction, transactionToIdbRecord, transactionToRawJson } from "./entities/transaction.js";
+import { parseRawBudget, budgetToIdbRecord, budgetToRawJson } from "./entities/budget.js";
+import { parseRawBudgetPeriod, budgetPeriodToIdbRecord, budgetPeriodToRawJson } from "./entities/budget-period.js";
+import { parseRawRule, ruleToIdbRecord, ruleToRawJson } from "./entities/rule.js";
+import { parseRawNormalizationRule, normalizationRuleToIdbRecord, normalizationRuleToRawJson } from "./entities/normalization-rule.js";
+import { parseRawStatement, statementToIdbRecord, statementToRawJson } from "./entities/statement.js";
+import { parseRawStatementItem, statementItemToIdbRecord, statementItemToRawJson } from "./entities/statement-item.js";
+import { parseRawReconciliationNote, reconciliationNoteToIdbRecord, reconciliationNoteToRawJson } from "./entities/reconciliation-note.js";
+import { parseRawAccount, accountToIdbRecord, accountToRawJson } from "./entities/account.js";
+import { parseRawJournalEntry, journalEntryToIdbRecord, journalEntryToRawJson } from "./entities/journal-entry.js";
+import { parseRawJournalLeg, journalLegToIdbRecord, journalLegToRawJson } from "./entities/journal-leg.js";
+import { parseRawReconciliationEvent, reconciliationEventToIdbRecord, reconciliationEventToRawJson } from "./entities/reconciliation-event.js";
+import { parseRawWeeklyAggregate, weeklyAggregateToIdbRecord, weeklyAggregateToRawJson } from "./entities/weekly-aggregate.js";
+
+/**
+ * Identity helper that infers the domain (D), IDB (I), raw-in (RIn), and
+ * raw-out (ROut) types from the three adaptor functions and forces them to
+ * chain. The two links the registry guarantees:
+ *   - parseRaw output type === toIdbRecord input type (both D)
+ *   - toRawJson input type === toIdbRecord output type (both I)
+ *
+ * RIn and ROut are kept as separate type parameters on purpose. Several
+ * `*ToRawJson` adaptors still return the wide `object` type mid-migration,
+ * which cannot satisfy a single shared R that is both a supertype of `object`
+ * (toRawJson's return) and a subtype of the specific `Raw*` parse input. Two
+ * params let each side infer independently without widening any entry to `any`.
+ */
+function defineCollection<D, I, RIn, ROut>(a: {
+  parseRaw: (raw: RIn, i: number) => D;
+  toIdbRecord: (d: D) => I;
+  toRawJson: (idb: I) => ROut;
+}): typeof a {
+  return a;
+}
+
+const collectionRegistry = {
+  transactions: defineCollection({ parseRaw: parseRawTransaction, toIdbRecord: transactionToIdbRecord, toRawJson: transactionToRawJson }),
+  budgets: defineCollection({ parseRaw: parseRawBudget, toIdbRecord: budgetToIdbRecord, toRawJson: budgetToRawJson }),
+  budgetPeriods: defineCollection({ parseRaw: parseRawBudgetPeriod, toIdbRecord: budgetPeriodToIdbRecord, toRawJson: budgetPeriodToRawJson }),
+  rules: defineCollection({ parseRaw: parseRawRule, toIdbRecord: ruleToIdbRecord, toRawJson: ruleToRawJson }),
+  normalizationRules: defineCollection({ parseRaw: parseRawNormalizationRule, toIdbRecord: normalizationRuleToIdbRecord, toRawJson: normalizationRuleToRawJson }),
+  statements: defineCollection({ parseRaw: parseRawStatement, toIdbRecord: statementToIdbRecord, toRawJson: statementToRawJson }),
+  statementItems: defineCollection({ parseRaw: parseRawStatementItem, toIdbRecord: statementItemToIdbRecord, toRawJson: statementItemToRawJson }),
+  reconciliationNotes: defineCollection({ parseRaw: parseRawReconciliationNote, toIdbRecord: reconciliationNoteToIdbRecord, toRawJson: reconciliationNoteToRawJson }),
+  accounts: defineCollection({ parseRaw: parseRawAccount, toIdbRecord: accountToIdbRecord, toRawJson: accountToRawJson }),
+  journalEntries: defineCollection({ parseRaw: parseRawJournalEntry, toIdbRecord: journalEntryToIdbRecord, toRawJson: journalEntryToRawJson }),
+  journalLegs: defineCollection({ parseRaw: parseRawJournalLeg, toIdbRecord: journalLegToIdbRecord, toRawJson: journalLegToRawJson }),
+  reconciliationEvents: defineCollection({ parseRaw: parseRawReconciliationEvent, toIdbRecord: reconciliationEventToIdbRecord, toRawJson: reconciliationEventToRawJson }),
+  weeklyAggregates: defineCollection({ parseRaw: parseRawWeeklyAggregate, toIdbRecord: weeklyAggregateToIdbRecord, toRawJson: weeklyAggregateToRawJson }),
+};
+
+export type CollectionRegistry = typeof collectionRegistry;
+export type DataStoreName = keyof CollectionRegistry;
+export type IdbOf<K extends DataStoreName> = ReturnType<CollectionRegistry[K]["toIdbRecord"]>;
+export type DomainOf<K extends DataStoreName> = ReturnType<CollectionRegistry[K]["parseRaw"]>;
+export type RawOf<K extends DataStoreName> = ReturnType<CollectionRegistry[K]["toRawJson"]>;
+export type CollectionIdbData = { [K in DataStoreName]: IdbOf<K>[] };
+export type CollectionDomainData = { [K in DataStoreName]: DomainOf<K>[] };
+export type CollectionRawData = { [K in DataStoreName]: RawOf<K>[] };
+
+export { collectionRegistry };

--- a/budget/src/entities/_helpers.ts
+++ b/budget/src/entities/_helpers.ts
@@ -129,9 +129,12 @@ export function requireStringArray(value: unknown, field: string): string[] {
 
 // ── Upload-side validators (throw UploadValidationError) ──────────────────────
 
-export function requireUploadId(value: unknown, entity: string, index: number): string {
+export function requireUploadId(
+  value: unknown, entity: string, index: number, field?: string,
+): string {
   if (typeof value !== "string" || value === "") {
-    throw new UploadValidationError(`${entity}[${index}] is missing a valid id`);
+    const suffix = field ? `.${field}` : "";
+    throw new UploadValidationError(`${entity}[${index}]${suffix} is missing a valid id`);
   }
   return value;
 }

--- a/budget/src/entities/reconciliation-note.ts
+++ b/budget/src/entities/reconciliation-note.ts
@@ -8,12 +8,16 @@ import type { QueryDocumentSnapshot, DocumentData } from "firebase/firestore";
 import type { GroupId } from "@commons-systems/authutil/groups";
 import {
   optionalString,
+  parseISOTimestamp,
   requireEnum,
   requireMs,
   requireSeedEnum,
   requireSeedString,
   requireString,
   requireTimestamp,
+  requireUploadEnum,
+  requireUploadId,
+  requireUploadString,
 } from "./_helpers.js";
 import type { ReconciliationNoteSeedData } from "../../seeds/firestore.js";
 import {
@@ -22,8 +26,6 @@ import {
   type ReconciliationClassification,
   type ReconciliationEntityType,
 } from "../schema/enums.js";
-
-// No upload/Raw shape — upload pipeline doesn't ingest these yet.
 
 // ── Domain interface ──────────────────────────────────────────────────────────
 
@@ -48,6 +50,18 @@ export interface IdbReconciliationNote {
   classification: ReconciliationClassification;
   note: string;
   updatedAtMs: number;
+  updatedBy: string;
+}
+
+// ── Raw upload interface ──────────────────────────────────────────────────────
+
+export interface RawReconciliationNote {
+  id: string;
+  entityType: ReconciliationEntityType;
+  entityId: string;
+  classification: ReconciliationClassification;
+  note: string;
+  updatedAt: string;
   updatedBy: string;
 }
 
@@ -98,9 +112,38 @@ export function idbToReconciliationNote(row: IdbReconciliationNote): Reconciliat
   };
 }
 
+// ── Raw upload → ReconciliationNote ──────────────────────────────────────────
+
+export function parseRawReconciliationNote(raw: RawReconciliationNote, i: number): ReconciliationNote {
+  return {
+    id: requireUploadId(raw.id, "reconciliationNote", i),
+    entityType: requireUploadEnum(raw.entityType, RECONCILIATION_ENTITY_TYPES, `reconciliationNote[${i}].entityType`),
+    entityId: requireUploadId(raw.entityId, "reconciliationNote.entityId", i),
+    classification: requireUploadEnum(raw.classification, RECONCILIATION_CLASSIFICATIONS, `reconciliationNote[${i}].classification`),
+    note: requireUploadString(raw.note, "reconciliationNote", i, "note"),
+    updatedAt: parseISOTimestamp(raw.updatedAt, `reconciliationNote[${i}].updatedAt`),
+    updatedBy: requireUploadString(raw.updatedBy, "reconciliationNote", i, "updatedBy"),
+    groupId: null as GroupId | null,
+  };
+}
+
+// ── ReconciliationNote → IdbReconciliationNote ────────────────────────────────
+
+export function reconciliationNoteToIdbRecord(n: ReconciliationNote): IdbReconciliationNote {
+  return {
+    id: n.id,
+    entityType: n.entityType,
+    entityId: n.entityId,
+    classification: n.classification,
+    note: n.note,
+    updatedAtMs: n.updatedAt.toMillis(),
+    updatedBy: n.updatedBy,
+  };
+}
+
 // ── IdbReconciliationNote → export JSON ───────────────────────────────────────
 
-export function reconciliationNoteToRawJson(n: IdbReconciliationNote): object {
+export function reconciliationNoteToRawJson(n: IdbReconciliationNote): RawReconciliationNote {
   return {
     id: n.id,
     entityType: n.entityType,

--- a/budget/src/entities/reconciliation-note.ts
+++ b/budget/src/entities/reconciliation-note.ts
@@ -118,9 +118,11 @@ export function parseRawReconciliationNote(raw: RawReconciliationNote, i: number
   return {
     id: requireUploadId(raw.id, "reconciliationNote", i),
     entityType: requireUploadEnum(raw.entityType, RECONCILIATION_ENTITY_TYPES, `reconciliationNote[${i}].entityType`),
-    entityId: requireUploadId(raw.entityId, "reconciliationNote.entityId", i),
+    entityId: requireUploadString(raw.entityId, "reconciliationNote", i, "entityId"),
     classification: requireUploadEnum(raw.classification, RECONCILIATION_CLASSIFICATIONS, `reconciliationNote[${i}].classification`),
-    note: requireUploadString(raw.note, "reconciliationNote", i, "note"),
+    // Mirror the Firestore/IDB tolerance for an empty note (parseFirestoreReconciliationNote
+    // stores non-string note as ""), so an exported "" note round-trips back through import.
+    note: typeof raw.note === "string" ? raw.note : "",
     updatedAt: parseISOTimestamp(raw.updatedAt, `reconciliationNote[${i}].updatedAt`),
     updatedBy: requireUploadString(raw.updatedBy, "reconciliationNote", i, "updatedBy"),
     groupId: null as GroupId | null,

--- a/budget/src/entities/statement-item.ts
+++ b/budget/src/entities/statement-item.ts
@@ -9,17 +9,19 @@ import type { GroupId } from "@commons-systems/authutil/groups";
 import type { Brand } from "@commons-systems/firestoreutil/brand";
 import {
   optionalString,
+  parseISOTimestamp,
   requireMs,
   requireNumber,
   requireSeedNumber,
   requireSeedString,
   requireString,
   requireTimestamp,
+  requireUploadFiniteNumber,
+  requireUploadId,
+  requireUploadString,
 } from "./_helpers.js";
 import type { StatementItemSeedData } from "../../seeds/firestore.js";
 import type { StatementId } from "./statement.js";
-
-// No upload/Raw shape — upload pipeline doesn't ingest these yet.
 
 export type StatementItemId = Brand<"StatementItemId">;
 
@@ -55,6 +57,21 @@ export interface IdbStatementItem {
   period: string;
   amount: number;
   timestampMs: number;
+  description: string;
+  fitid: string;
+}
+
+// ── Raw upload interface ──────────────────────────────────────────────────────
+
+export interface RawStatementItem {
+  id: string;
+  statementItemId: string;
+  statementId: string;
+  institution: string;
+  account: string;
+  period: string;
+  amount: number;
+  timestamp: string;
   description: string;
   fitid: string;
 }
@@ -114,9 +131,44 @@ export function idbToStatementItem(row: IdbStatementItem): StatementItem {
   };
 }
 
+// ── Raw upload → StatementItem ────────────────────────────────────────────────
+
+export function parseRawStatementItem(raw: RawStatementItem, i: number): StatementItem {
+  return {
+    id: requireUploadId(raw.id, "statementItem", i),
+    statementItemId: requireUploadId(raw.statementItemId, "statementItem.statementItemId", i) as StatementItemId,
+    statementId: requireUploadId(raw.statementId, "statementItem.statementId", i) as StatementId,
+    institution: requireUploadString(raw.institution, "statementItem", i, "institution"),
+    account: requireUploadString(raw.account, "statementItem", i, "account"),
+    period: requireUploadString(raw.period, "statementItem", i, "period"),
+    amount: requireUploadFiniteNumber(raw.amount, "statementItem", i, "amount"),
+    timestamp: parseISOTimestamp(raw.timestamp, `statementItem[${i}].timestamp`),
+    description: requireUploadString(raw.description, "statementItem", i, "description"),
+    fitid: requireUploadString(raw.fitid, "statementItem", i, "fitid"),
+    groupId: null as GroupId | null,
+  };
+}
+
+// ── StatementItem → IdbStatementItem ─────────────────────────────────────────
+
+export function statementItemToIdbRecord(s: StatementItem): IdbStatementItem {
+  return {
+    id: s.id,
+    statementItemId: s.statementItemId,
+    statementId: s.statementId,
+    institution: s.institution,
+    account: s.account,
+    period: s.period,
+    amount: s.amount,
+    timestampMs: s.timestamp.toMillis(),
+    description: s.description,
+    fitid: s.fitid,
+  };
+}
+
 // ── IdbStatementItem → export JSON ────────────────────────────────────────────
 
-export function statementItemToRawJson(i: IdbStatementItem): object {
+export function statementItemToRawJson(i: IdbStatementItem): RawStatementItem {
   return {
     id: i.id,
     statementItemId: i.statementItemId,

--- a/budget/src/entities/statement-item.ts
+++ b/budget/src/entities/statement-item.ts
@@ -136,8 +136,8 @@ export function idbToStatementItem(row: IdbStatementItem): StatementItem {
 export function parseRawStatementItem(raw: RawStatementItem, i: number): StatementItem {
   return {
     id: requireUploadId(raw.id, "statementItem", i),
-    statementItemId: requireUploadId(raw.statementItemId, "statementItem.statementItemId", i) as StatementItemId,
-    statementId: requireUploadId(raw.statementId, "statementItem.statementId", i) as StatementId,
+    statementItemId: requireUploadId(raw.statementItemId, "statementItem", i, "statementItemId") as StatementItemId,
+    statementId: requireUploadId(raw.statementId, "statementItem", i, "statementId") as StatementId,
     institution: requireUploadString(raw.institution, "statementItem", i, "institution"),
     account: requireUploadString(raw.account, "statementItem", i, "account"),
     period: requireUploadString(raw.period, "statementItem", i, "period"),

--- a/budget/src/export.ts
+++ b/budget/src/export.ts
@@ -1,5 +1,6 @@
 /** Serializes IndexedDB stores back to the upload JSON format. Inverse of the upload pipeline (parseUploadedJson + toParsedData in upload.ts). */
 import { getAll, getMeta } from "./idb.js";
+import type { CollectionRawData } from "./collection-registry.js";
 import type { IdbTransaction } from "./entities/transaction.js";
 import { transactionToRawJson } from "./entities/transaction.js";
 import type { IdbStatement } from "./entities/statement.js";
@@ -47,7 +48,12 @@ export async function exportToJson(): Promise<string> {
 
   if (!meta) throw new Error("No local data to export. Upload a file first.");
 
-  const output = {
+  const output: CollectionRawData & {
+    version: number;
+    exportedAt: string;
+    groupId: string;
+    groupName: string;
+  } = {
     version: meta.version,
     exportedAt: new Date().toISOString(),
     // groupId is not stored locally; empty string for format compatibility

--- a/budget/src/idb.ts
+++ b/budget/src/idb.ts
@@ -25,25 +25,12 @@ import type { IdbNormalizationRule } from "./entities/normalization-rule.js";
 export type { IdbNormalizationRule };
 import type { IdbWeeklyAggregate } from "./entities/weekly-aggregate.js";
 export type { IdbWeeklyAggregate };
+import { collectionRegistry } from "./collection-registry.js";
+import type { CollectionIdbData, DataStoreName } from "./collection-registry.js";
 
-const STORE_NAMES = [
-  "transactions",
-  "budgets",
-  "budgetPeriods",
-  "rules",
-  "normalizationRules",
-  "statements",
-  "statementItems",
-  "reconciliationNotes",
-  "accounts",
-  "journalEntries",
-  "journalLegs",
-  "reconciliationEvents",
-  "weeklyAggregates",
-  "meta",
-] as const;
+const STORE_NAMES = [...(Object.keys(collectionRegistry) as DataStoreName[]), "meta"] as const;
 
-export type StoreName = (typeof STORE_NAMES)[number];
+export type StoreName = DataStoreName | "meta";
 
 const { openDb, closeDb: closeDbConn } = createDbConnection({
   name: "budget",
@@ -85,22 +72,7 @@ export async function clearFileHandle(): Promise<void> {
   await deleteRecord("meta", "fileHandle");
 }
 
-export interface ParsedData {
-  transactions: IdbTransaction[];
-  budgets: IdbBudget[];
-  budgetPeriods: IdbBudgetPeriod[];
-  rules: IdbRule[];
-  normalizationRules: IdbNormalizationRule[];
-  statements: IdbStatement[];
-  statementItems: IdbStatementItem[];
-  reconciliationNotes: IdbReconciliationNote[];
-  accounts: IdbAccount[];
-  journalEntries: IdbJournalEntry[];
-  journalLegs: IdbJournalLeg[];
-  reconciliationEvents: IdbReconciliationEvent[];
-  weeklyAggregates: IdbWeeklyAggregate[];
-  meta: UploadMeta;
-}
+export type ParsedData = CollectionIdbData & { meta: UploadMeta };
 
 export async function storeParsedData(data: ParsedData): Promise<void> {
   const db = await openDb();
@@ -137,19 +109,10 @@ export async function storeParsedData(data: ParsedData): Promise<void> {
   await Promise.all(clearPromises);
 
   // Write all records
-  for (const record of data.transactions) stores.transactions.put(record);
-  for (const record of data.budgets) stores.budgets.put(record);
-  for (const record of data.budgetPeriods) stores.budgetPeriods.put(record);
-  for (const record of data.rules) stores.rules.put(record);
-  for (const record of data.normalizationRules) stores.normalizationRules.put(record);
-  for (const record of data.statements) stores.statements.put(record);
-  for (const record of data.statementItems) stores.statementItems.put(record);
-  for (const record of data.reconciliationNotes) stores.reconciliationNotes.put(record);
-  for (const record of data.accounts) stores.accounts.put(record);
-  for (const record of data.journalEntries) stores.journalEntries.put(record);
-  for (const record of data.journalLegs) stores.journalLegs.put(record);
-  for (const record of data.reconciliationEvents) stores.reconciliationEvents.put(record);
-  for (const record of data.weeklyAggregates) stores.weeklyAggregates.put(record);
+  const dataStoreNames = Object.keys(collectionRegistry) as DataStoreName[];
+  for (const name of dataStoreNames) {
+    for (const record of data[name]) stores[name].put(record);
+  }
   stores.meta.put(data.meta);
 
   await new Promise<void>((resolve, reject) => {

--- a/budget/src/upload.ts
+++ b/budget/src/upload.ts
@@ -33,6 +33,11 @@ import type { RawJournalLeg } from "./entities/journal-leg.js";
 import { parseRawJournalLeg, journalLegToIdbRecord } from "./entities/journal-leg.js";
 import type { RawReconciliationEvent } from "./entities/reconciliation-event.js";
 import { parseRawReconciliationEvent, reconciliationEventToIdbRecord } from "./entities/reconciliation-event.js";
+import type { RawStatementItem } from "./entities/statement-item.js";
+import { parseRawStatementItem, statementItemToIdbRecord } from "./entities/statement-item.js";
+import type { RawReconciliationNote } from "./entities/reconciliation-note.js";
+import { parseRawReconciliationNote, reconciliationNoteToIdbRecord } from "./entities/reconciliation-note.js";
+import type { CollectionDomainData } from "./collection-registry.js";
 // Re-export so existing import sites keep working.
 export { UploadValidationError };
 
@@ -47,6 +52,8 @@ interface RawOutput {
   rules: RawRule[];
   normalizationRules: RawNormalizationRule[];
   statements: RawStatement[];
+  statementItems?: RawStatementItem[];
+  reconciliationNotes?: RawReconciliationNote[];
   accounts?: RawAccount[];
   journalEntries?: RawJournalEntry[];
   journalLegs?: RawJournalLeg[];
@@ -54,22 +61,11 @@ interface RawOutput {
   weeklyAggregates?: RawWeeklyAggregate[];
 }
 
-export interface ParsedUpload {
-  transactions: Transaction[];
-  statements: Statement[];
-  budgets: Budget[];
-  budgetPeriods: BudgetPeriod[];
-  rules: Rule[];
-  normalizationRules: NormalizationRule[];
-  accounts: Account[];
-  journalEntries: JournalEntry[];
-  journalLegs: JournalLeg[];
-  reconciliationEvents: ReconciliationEvent[];
-  weeklyAggregates: WeeklyAggregate[];
+export type ParsedUpload = CollectionDomainData & {
   groupName: string;
   version: number;
   exportedAt: string;
-}
+};
 
 export function parseUploadedJson(text: string): ParsedUpload {
   let raw: RawOutput;
@@ -108,6 +104,8 @@ export function parseUploadedJson(text: string): ParsedUpload {
   const rules: Rule[] = (raw.rules ?? []).map((r: RawRule, i: number) => parseRawRule(r, i));
   const normalizationRules: NormalizationRule[] = (raw.normalizationRules ?? []).map((r: RawNormalizationRule, i: number) => parseRawNormalizationRule(r, i));
   const statements: Statement[] = (raw.statements ?? []).map((s: RawStatement, i: number) => parseRawStatement(s, i));
+  const statementItems = (raw.statementItems ?? []).map((s: RawStatementItem, i: number) => parseRawStatementItem(s, i));
+  const reconciliationNotes = (raw.reconciliationNotes ?? []).map((n: RawReconciliationNote, i: number) => parseRawReconciliationNote(n, i));
   const accounts: Account[] = (raw.accounts ?? []).map((a: RawAccount, i: number) => parseRawAccount(a, i));
   const journalEntries: JournalEntry[] = (raw.journalEntries ?? []).map((e: RawJournalEntry, i: number) => parseRawJournalEntry(e, i));
   const journalLegs: JournalLeg[] = (raw.journalLegs ?? []).map((l: RawJournalLeg, i: number) => parseRawJournalLeg(l, i));
@@ -121,6 +119,8 @@ export function parseUploadedJson(text: string): ParsedUpload {
     budgetPeriods,
     rules,
     normalizationRules,
+    statementItems,
+    reconciliationNotes,
     accounts,
     journalEntries,
     journalLegs,
@@ -141,8 +141,8 @@ export function toParsedData(parsed: ParsedUpload): ParsedData {
     rules: parsed.rules.map(ruleToIdbRecord),
     normalizationRules: parsed.normalizationRules.map(normalizationRuleToIdbRecord),
     statements: parsed.statements.map(statementToIdbRecord),
-    statementItems: [],
-    reconciliationNotes: [],
+    statementItems: parsed.statementItems.map(statementItemToIdbRecord),
+    reconciliationNotes: parsed.reconciliationNotes.map(reconciliationNoteToIdbRecord),
     accounts: parsed.accounts.map(accountToIdbRecord),
     journalEntries: parsed.journalEntries.map(journalEntryToIdbRecord),
     journalLegs: parsed.journalLegs.map(journalLegToIdbRecord),

--- a/budget/test/export.test.ts
+++ b/budget/test/export.test.ts
@@ -24,6 +24,15 @@ vi.mock("../src/idb", () => ({
 import { exportToJson } from "../src/export";
 import { getAll, getMeta } from "../src/idb";
 import { parseUploadedJson, toParsedData } from "../src/upload";
+import { collectionRegistry } from "../src/collection-registry.js";
+import type { DataStoreName } from "../src/collection-registry.js";
+import type { ParsedData } from "../src/idb";
+
+// Compile-time guard: ParsedData's keys must be exactly the registry stores plus
+// "meta". Registry drift surfaces as a tsc error here, not a runtime surprise.
+type AssertEqual<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+const _parsedDataKeysExhaustive: AssertEqual<keyof ParsedData, DataStoreName | "meta"> = true;
+void _parsedDataKeysExhaustive;
 
 const mockGetAll = vi.mocked(getAll);
 const mockGetMeta = vi.mocked(getMeta);
@@ -445,8 +454,22 @@ describe("exportToJson", () => {
     expect(data.weeklyAggregates[0]).toEqual(idbWeeklyAggregates[0]);
   });
 
-  it("ETL-snapshot round-trip empties no store", async () => {
-    // Minimal well-formed IDB fixtures for ETL-emitted stores not already in setupMocks
+  it("round-trip empties no registry store", async () => {
+    // A non-empty, minimally-valid IDB fixture for EVERY registry collection.
+    // Reuses the module-level fixtures where they exist and adds minimal valid
+    // ones for the rest. Typing the map as Record<DataStoreName, unknown[]>
+    // makes a MISSING registry key a tsc error; the sort-equality guard below
+    // makes a future-ADDED registry key a runtime failure.
+    const idbAccountsFixture = [
+      {
+        id: "bankone_1234",
+        institution: "bankone",
+        account: "1234",
+        accountType: "asset" as const,
+        openingBalance: null,
+        openingBalanceDateMs: null,
+      },
+    ];
     const idbJournalEntriesFixture = [
       {
         id: "je-001",
@@ -470,58 +493,83 @@ describe("exportToJson", () => {
         statementItemId: null,
       },
     ];
-    const idbAccountsFixture = [
+    const idbStatementItemsFixture = [
       {
-        id: "bankone_1234",
+        id: "si-001",
+        statementItemId: "si-001",
+        statementId: "stmt-1",
         institution: "bankone",
         account: "1234",
-        accountType: "asset" as const,
-        openingBalance: null,
-        openingBalanceDateMs: null,
+        period: "2025-06",
+        amount: -52.3,
+        timestampMs: Date.parse("2025-06-10T00:00:00.000Z"),
+        description: "KROGER",
+        fitid: "fit-001",
+      },
+    ];
+    const idbReconciliationNotesFixture = [
+      {
+        id: "transaction_txn-001",
+        entityType: "transaction" as const,
+        entityId: "txn-001",
+        classification: "timing" as const,
+        note: "pending clear",
+        updatedAtMs: Date.parse("2025-06-11T00:00:00.000Z"),
+        updatedBy: "nathan@natb1.com",
+      },
+    ];
+    const idbReconciliationEventsFixture = [
+      {
+        id: "bankone_1234_2025-06-10",
+        institution: "bankone",
+        account: "1234",
+        reconciledThroughDateMs: Date.parse("2025-06-10T00:00:00.000Z"),
+        bankBalance: 1234.56,
+        clearedBalance: 1234.56,
+        adjustment: 0,
+        reconciledBy: "nathan@natb1.com",
+        reconciledAtMs: Date.parse("2025-06-11T00:00:00.000Z"),
+        legIds: ["jl-001"],
+        adjustmentEntryId: null,
       },
     ];
 
-    // Override the mocks for this test to supply non-empty ETL stores
+    const idbFixtures: Record<DataStoreName, unknown[]> = {
+      transactions: idbTransactions,
+      budgets: idbBudgets,
+      budgetPeriods: idbBudgetPeriods,
+      rules: idbRules,
+      normalizationRules: idbNormalizationRules,
+      statements: idbStatements,
+      statementItems: idbStatementItemsFixture,
+      reconciliationNotes: idbReconciliationNotesFixture,
+      accounts: idbAccountsFixture,
+      journalEntries: idbJournalEntriesFixture,
+      journalLegs: idbJournalLegsFixture,
+      reconciliationEvents: idbReconciliationEventsFixture,
+      weeklyAggregates: idbWeeklyAggregates,
+    };
+
+    // Exhaustiveness guard: a future registry entry added without a fixture FAILS here.
+    expect(Object.keys(idbFixtures).sort()).toEqual(Object.keys(collectionRegistry).sort());
+
     const original = mockGetAll.getMockImplementation()!;
-    mockGetAll.mockImplementation((storeName: string) => {
-      switch (storeName) {
-        case "journalEntries":
-          return Promise.resolve(idbJournalEntriesFixture);
-        case "journalLegs":
-          return Promise.resolve(idbJournalLegsFixture);
-        case "accounts":
-          return Promise.resolve(idbAccountsFixture);
-        default:
-          return original(storeName);
-      }
-    });
+    mockGetAll.mockImplementation((storeName: string) =>
+      storeName in idbFixtures
+        ? Promise.resolve(idbFixtures[storeName as DataStoreName])
+        : original(storeName),
+    );
 
     try {
       const json = await exportToJson();
       const parsed = parseUploadedJson(json);
       const data = toParsedData(parsed);
 
-      // Static list of the ETL-emitted stores (from budget-etl/internal/export/export.go)
-      // that this test verifies round-trip without being emptied. This is a hardcoded
-      // list, not auto-detected: a new ETL store added to export.ts must also be added
-      // here to be covered. statementItems, reconciliationNotes, and reconciliationEvents
-      // are excluded because they are app-only (not ETL-emitted) and are never populated
-      // in setupMocks.
-      const etlStores: Array<{ name: string; result: unknown[] }> = [
-        { name: "transactions", result: data.transactions },
-        { name: "statements", result: data.statements },
-        { name: "budgets", result: data.budgets },
-        { name: "budgetPeriods", result: data.budgetPeriods },
-        { name: "rules", result: data.rules },
-        { name: "normalizationRules", result: data.normalizationRules },
-        { name: "weeklyAggregates", result: data.weeklyAggregates },
-        { name: "journalEntries", result: data.journalEntries },
-        { name: "journalLegs", result: data.journalLegs },
-        { name: "accounts", result: data.accounts },
-      ];
-
-      for (const { name, result } of etlStores) {
-        expect(result, `store "${name}" was emptied by the export/import round-trip`).not.toHaveLength(0);
+      // Every registry store must survive the round-trip non-empty — derived from
+      // the registry, not a hardcoded list. This proves statementItems,
+      // reconciliationNotes, and reconciliationEvents (the #1268 fix) round-trip.
+      for (const name of Object.keys(collectionRegistry) as DataStoreName[]) {
+        expect(data[name], `store "${name}" emptied by round-trip`).not.toHaveLength(0);
       }
     } finally {
       mockGetAll.mockImplementation(original);


### PR DESCRIPTION
Closes #1268

## What

The budget web app serializes its IndexedDB stores to a snapshot JSON on export
and reconstructs them on upload. Three code paths (export, load, IDB setup) each
hand-maintained their own parallel list of collections, so when one path omitted
a collection the others kept, data was silently lost on a round-trip. The live
instance of that trap: `statementItems` and `reconciliationNotes` were
**exported** but **dropped on upload** (`toParsedData` hardcoded them to `[]`,
and neither entity had a parse path), so a user who exported then re-uploaded
lost both collections with no error.

This PR introduces a single **collection registry** (`budget/src/collection-registry.ts`)
that pairs the three round-trip adaptors (`parseRaw` / `toIdbRecord` /
`toRawJson`) per data collection, and rewires export, load, and IDB setup to
derive their collection lists and types from it. Omitting a collection on one
side is now a **compile error** (or a test failure) rather than silent data
loss, and every exported collection — including the two previously
export-only ones — round-trips losslessly.

## How

- **`collection-registry.ts`** (added earlier in the branch) — a non-widening
  `defineCollection` identity helper forces each entry's three adaptors to chain
  (a mispaired adaptor is a compile error at that entry), and registry-derived
  mapped types (`CollectionIdbData`, `CollectionDomainData`, `CollectionRawData`,
  `DataStoreName`) become the single source of truth for the set of collections.
- **`statement-item.ts` / `reconciliation-note.ts`** (added earlier) — the two
  missing upload/parse paths (`RawStatementItem` / `RawReconciliationNote`,
  `parseRaw*`, `*ToIdbRecord`), with their `*ToRawJson` return types tightened
  from `object` to the specific `Raw*` type.
- **`idb.ts`** — `STORE_NAMES`, `StoreName`, `ParsedData`, and the
  `storeParsedData` write loop now derive from the registry; `meta` stays
  special-cased and last.
- **`upload.ts`** — `ParsedUpload` becomes `CollectionDomainData & { … }` (every
  collection a required key), and `parseUploadedJson` / `toParsedData` now wire
  `statementItems` and `reconciliationNotes` through instead of dropping them.
- **`export.ts`** — the `output` object is constrained by `CollectionRawData & { … }`,
  so omitting a collection from export is a compile error.
- **`export.test.ts`** — the hardcoded `etlStores` round-trip list is replaced by
  a registry-driven exhaustiveness test that asserts its fixture-map keys
  deep-equal `Object.keys(collectionRegistry)`, drives a non-empty fixture for
  every collection, and asserts no store is emptied by a round-trip — now
  covering `statementItems`, `reconciliationNotes`, and `reconciliationEvents`.
  A compile-time `AssertEqual<keyof ParsedData, DataStoreName | "meta">` guard
  surfaces registry drift as a tsc error.

## Implementation note

`RawOutput` (the upload *input* type) is deliberately kept hand-written with the
specific `Raw*` field types rather than derived from `RawOf<K>`. Eight
`*ToRawJson` adaptors still return the wide `object` type mid-migration, so a
derived input type would narrow `object` → a specific `Raw*` in the existing
`.map` callbacks and fail `tsc`. This matches the plan's intentionally-loose
input-type decision — real uploaded files legitimately omit collections, and the
round-trip guarantee comes entirely from the **required** `ParsedUpload` /
`ParsedData` return types, not the input type.

## Verification

- `npm run build --prefix budget` — green (`tsc` + vite). A collection omitted
  from `toParsedData`, `parseUploadedJson`, or the export `output`, or a
  mispaired registry adaptor, now fails here.
- `npx vitest run --root budget` — full suite green (50 files, 992 tests),
  including the new registry-driven round-trip test proving the two
  previously-dropped collections survive a full export → parse → store cycle.
