### PR TITLE
functions-deploy: read office-hours config from secrets.* not vars.*

### DIFF
--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -30,18 +30,18 @@ jobs:
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
         run: .github/scripts/firebase-auth.sh
       # syncOfficeHours's and sampleDispatchQueueMetrics's non-secret defineString
-      # params come from repository Variables, written into the dotenv
-      # firebase-tools reads at deploy time. Unset Variables yield empty values,
+      # params come from repository Secrets, written into the dotenv
+      # firebase-tools reads at deploy time. Unset Secrets yield empty values,
       # which deploy the functions dormant. The App private key and member emails
       # are both secrets in Secret Manager; neither flows through this workflow.
       - name: Write office-hours function config
         env:
-          OFFICE_HOURS_GITHUB_APP_ID: ${{ vars.OFFICE_HOURS_GITHUB_APP_ID }}
-          OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID: ${{ vars.OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID }}
-          OFFICE_HOURS_GROUP_REPO: ${{ vars.OFFICE_HOURS_GROUP_REPO }}
-          OFFICE_HOURS_FIRESTORE_NAMESPACE: ${{ vars.OFFICE_HOURS_FIRESTORE_NAMESPACE || 'office-hours/prod' }}
-          OFFICE_HOURS_GROUP_ID: ${{ vars.OFFICE_HOURS_GROUP_ID }}
-          DISPATCH_METRICS_QUEUE_REPO: ${{ vars.DISPATCH_METRICS_QUEUE_REPO }}
+          OFFICE_HOURS_GITHUB_APP_ID: ${{ secrets.OFFICE_HOURS_GITHUB_APP_ID }}
+          OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID: ${{ secrets.OFFICE_HOURS_GITHUB_APP_INSTALLATION_ID }}
+          OFFICE_HOURS_GROUP_REPO: ${{ secrets.OFFICE_HOURS_GROUP_REPO }}
+          OFFICE_HOURS_FIRESTORE_NAMESPACE: ${{ secrets.OFFICE_HOURS_FIRESTORE_NAMESPACE || 'office-hours/prod' }}
+          OFFICE_HOURS_GROUP_ID: ${{ secrets.OFFICE_HOURS_GROUP_ID }}
+          DISPATCH_METRICS_QUEUE_REPO: ${{ secrets.DISPATCH_METRICS_QUEUE_REPO }}
         run: |
           cat > functions/.env.commons-systems <<EOF
           OFFICE_HOURS_GITHUB_APP_ID=${OFFICE_HOURS_GITHUB_APP_ID}


### PR DESCRIPTION
## Problem

`office-hours.commons.systems` shows "Couldn't load your queue. Please try again." for an authenticated owner. Browser console: `[load-owner-data] FirebaseError: Missing or insufficient permissions` — a Firestore rules denial on the single-doc read `office-hours/prod/metrics/dispatch-queue` that #1599 added to `main.ts`'s blocking `Promise.all`.

That metrics doc is written only by the scheduled `sampleDispatchQueueMetrics` function, which deploys dormant unless its config params are set. The params **are** set — but as repository **Secrets**, while the deploy step read them as repository **Variables** (`${{ vars.* }}`). `vars.*` and `secrets.*` are separate namespaces, so `vars.*` resolved to empty: CI wrote an all-empty `functions/.env.commons-systems`, and both `syncOfficeHours` and `sampleDispatchQueueMetrics` deployed dormant. The dormant sampler never wrote the doc, so the read is denied and the queue view errors.

## Fix

Read the five non-secret `defineString` params from `secrets.*` to match where they are provisioned. No values change; the two Secret-Manager secrets (`OFFICE_HOURS_GITHUB_APP_PRIVATE_KEY`, `OFFICE_HOURS_MEMBER_EMAILS`) are untouched.

## After merge

Re-run **Functions — Deploy** so the sampler stops being dormant; it writes `office-hours/prod/metrics/dispatch-queue` on its next hourly tick and the queue loads. Confirm `OFFICE_HOURS_MEMBER_EMAILS` includes the owner's email (the rule denies readers not in the doc's `memberEmails`).

## Follow-up (not in this PR)

Harden the office-hours app so a missing/denied metrics doc degrades only the queue band instead of collapsing the whole owner view (`main.ts` `Promise.all`).