### PR TITLE
print: drain stale highlights in goToResult() before re-arming

### DIFF
--- a/print/src/viewer/pdf.ts
+++ b/print/src/viewer/pdf.ts
@@ -597,6 +597,11 @@ export function createPdfRenderer(onError?: (err: unknown) => void): ContentRend
     async goToResult(result: SearchResult): Promise<void> {
       const decoded = decodeLocation(result.location);
       if (!decoded) return;
+      // Drain stale highlightRestores entries — they reference now-detached
+      // nodes from the previous result's text layer — before arming the new
+      // highlight, mirroring goToPage/next/prev. Without this the array grows
+      // unboundedly across result clicks, leaking detached DOM node references.
+      unwrapHighlights();
       _currentPage = decoded.page;
       // Arm the highlight before rendering; renderPage applies it as its final
       // gen-guarded step. Call the internal renderPage directly (like

--- a/print/test/viewer/pdf.test.ts
+++ b/print/test/viewer/pdf.test.ts
@@ -479,4 +479,26 @@ describe("clearSearch()", () => {
 
     expect(container.querySelector(".search-highlight.active")).toBeNull();
   });
+
+  it("goToResult() drains the previous result's highlight before arming the next", async () => {
+    const renderer = createPdfRenderer();
+    await renderer.init(container, "fake://source.pdf");
+
+    const results = await renderer.search!("the");
+    const r1 = results.find((r) => r.label === "Page 1")!;
+    const r2 = results.find((r) => r.label === "Page 2")!;
+
+    await renderer.goToResult!(r1);
+    // Capture the text-layer div that holds the first result's highlight span.
+    const div1 = container.querySelector(".search-highlight")!.parentElement!;
+    expect(div1.querySelector(".search-highlight")).not.toBeNull();
+
+    // Arming the second result must drain the first entry (unwrapHighlights),
+    // restoring div1 instead of leaking it in highlightRestores.
+    await renderer.goToResult!(r2);
+    expect(div1.querySelector(".search-highlight")).toBeNull();
+
+    // Exactly one highlight is live in the DOM (the current result).
+    expect(container.querySelectorAll(".search-highlight.active").length).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #1717

## Problem

`goToResult()` in `print/src/viewer/pdf.ts` armed `pendingHighlight` and called
`renderPage()` **without first calling `unwrapHighlights()`**. Each result click
runs `applyHighlight()`, which pushes a `{ div, originalText }` entry into the
closure-private `highlightRestores` array. `renderPage()` rebuilds the text layer
via `replaceChildren()`, detaching the previously-highlighted divs from the DOM —
but `highlightRestores` kept referencing those detached nodes. Across repeated
result clicks the array grew without bound, leaking detached DOM node references.

The sibling navigation methods `goToPage()`, `next()`, and `prev()` all call
`unwrapHighlights()` before proceeding, draining stale entries. `goToResult()` was
the lone arming path that did not.

## Fix

Drain `highlightRestores` at the start of `goToResult()`, before the new
`pendingHighlight` is armed — mirroring the sibling methods.

The `unwrapHighlights()` call is placed **after** the `if (!decoded) return;`
guard (not before it), so a malformed/undecodable result — which performs no
navigation and no re-render — does not clear the currently-visible highlight. No
`pendingHighlight = null` is added: `goToResult` is *arming* a highlight (unlike
`goToPage`/`next`/`prev`, which *discard* highlights on manual navigation), so
only the drain is wanted. The existing `unwrapHighlights()` helper is reused
verbatim — no new helper.

## Test

Adds one regression test to the section-C `describe("clearSearch()")` block in
`print/test/viewer/pdf.test.ts`. The leak is of *detached* node references, not
directly observable via `container` queries — so the test holds a JS reference to
the first result's tracked text-layer div and asserts it is restored (its
`.search-highlight` span removed) when the second result is armed, and that
exactly one highlight remains live in the DOM. The test fails on the pre-fix
`goToResult` and passes with the drain.

The full `print` suite passes (454 passed, 1 pre-existing skip).
