### PR TITLE
blog: unsubscribe onAuthStateChanged auth listener in destroy()

### DIFF
--- a/blog/src/create-blog-app.ts
+++ b/blog/src/create-blog-app.ts
@@ -57,7 +57,9 @@ export interface CreateBlogAppConfig {
     initAppCheck: (() => Promise<void>) | undefined;
     signIn: () => Promise<unknown> | void;
     signOut: () => Promise<unknown> | void;
-    onAuthStateChanged: (cb: (user: User | null) => void) => PromiseLike<unknown>;
+    onAuthStateChanged: (
+      cb: (user: User | null) => void,
+    ) => (() => void) | PromiseLike<(() => void) | void>;
   };
   adminGroupId: GroupId;
   // optional hooks (consumed in units 2/3)
@@ -267,7 +269,28 @@ export function createBlogApp(config: CreateBlogAppConfig): BlogAppHandle {
     updateInfoPanel();
   }
 
-  config.firebase.onAuthStateChanged((user) => {
+  // Capture the auth-state unsubscribe so destroy() can tear it down; without
+  // this an auth event can still fire refreshAfterAuthChange on a destroyed
+  // instance. Production passes firebaseutil's async wrapper resolving to the
+  // unsubscribe (Promise<() => void>), so we handle both a sync function return
+  // and a promise resolving to one, with a guard for the destroy-before-resolve
+  // race. The teardown is registered before the call so a synchronous capture
+  // and the race guard share the same closure state.
+  let authUnsub: (() => void) | undefined;
+  let authDestroyed = false;
+  teardowns.push(() => {
+    authDestroyed = true;
+    authUnsub?.();
+  });
+
+  const captureUnsub = (unsub: (() => void) | void): void => {
+    if (typeof unsub !== "function") return;
+    // destroy() may have run before an async unsubscribe resolved.
+    if (authDestroyed) unsub();
+    else authUnsub = unsub;
+  };
+
+  const authResult = config.firebase.onAuthStateChanged((user) => {
     if (user?.uid === currentUser?.uid) return;
     currentUser = user;
     // Intentional silent degradation — user sees stale content rather than an error.
@@ -275,10 +298,16 @@ export function createBlogApp(config: CreateBlogAppConfig): BlogAppHandle {
       if (deferProgrammerError(err)) return;
       logError(err, { operation: "auth-change-refresh" });
     });
-  }).then(undefined, (err) => {
-    if (deferProgrammerError(err)) return;
-    logError(err, { operation: "auth-init" });
   });
+
+  if (typeof authResult === "function") {
+    captureUnsub(authResult);
+  } else {
+    authResult.then(captureUnsub, (err) => {
+      if (deferProgrammerError(err)) return;
+      logError(err, { operation: "auth-init" });
+    });
+  }
 
   deferAppCheckInit(
     config.firebase.initAppCheck,

--- a/blog/test/create-blog-app.test.ts
+++ b/blog/test/create-blog-app.test.ts
@@ -420,6 +420,98 @@ describe("createBlogApp routing and panel behavior", () => {
     });
   });
 
+  // Case 8 — #1715: onAuthStateChanged unsubscribe is called on destroy().
+  // Production-representative: createAppContext returns Promise<() => void>.
+  it("calls the onAuthStateChanged unsubscribe returned as Promise<() => void> on destroy() (#1715)", async () => {
+    history.pushState({}, "", "/");
+    scaffoldDom();
+
+    const unsubscribeSpy = vi.fn();
+    const config = makeConfig({
+      firebase: {
+        db: { type: "mock-firestore" } as never,
+        namespace: "test/env" as never,
+        trackPageView: vi.fn(),
+        initAppCheck: vi.fn(() => Promise.resolve()),
+        signIn: vi.fn(() => Promise.resolve()),
+        signOut: vi.fn(() => Promise.resolve()),
+        // Production-representative: createAppContext wraps Firebase's
+        // onAuthStateChanged and returns Promise<() => void>.
+        onAuthStateChanged: vi.fn(() => Promise.resolve(unsubscribeSpy)),
+      },
+    });
+
+    handle = createBlogApp(config);
+
+    // Flush the microtask queue so .then(captureUnsub) stores authUnsub.
+    await new Promise((r) => setTimeout(r, 0));
+
+    handle.destroy();
+
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // Case 9 — #1715: destroy-before-resolve race: destroy() runs before the
+  // Promise resolves; captureUnsub must call unsub() immediately on late resolution.
+  it("calls the onAuthStateChanged unsubscribe even when destroy() runs before the Promise resolves (#1715)", async () => {
+    history.pushState({}, "", "/");
+    scaffoldDom();
+
+    const unsubscribeSpy = vi.fn();
+    let resolveUnsub!: (unsub: () => void) => void;
+    const controlledPromise = new Promise<() => void>((resolve) => {
+      resolveUnsub = resolve;
+    });
+
+    const config = makeConfig({
+      firebase: {
+        db: { type: "mock-firestore" } as never,
+        namespace: "test/env" as never,
+        trackPageView: vi.fn(),
+        initAppCheck: vi.fn(() => Promise.resolve()),
+        signIn: vi.fn(() => Promise.resolve()),
+        signOut: vi.fn(() => Promise.resolve()),
+        onAuthStateChanged: vi.fn(() => controlledPromise),
+      },
+    });
+
+    handle = createBlogApp(config);
+
+    // destroy() before the promise resolves — sets authDestroyed, authUnsub is still undefined.
+    handle.destroy();
+
+    // Now resolve with the spy — captureUnsub sees authDestroyed and calls unsub() immediately.
+    resolveUnsub(unsubscribeSpy);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // Case 10 — #1715: synchronous-function case: onAuthStateChanged returns
+  // the unsubscribe directly (not a promise).
+  it("calls the onAuthStateChanged unsubscribe returned synchronously on destroy() (#1715)", () => {
+    history.pushState({}, "", "/");
+    scaffoldDom();
+
+    const unsubscribeSpy = vi.fn();
+    const config = makeConfig({
+      firebase: {
+        db: { type: "mock-firestore" } as never,
+        namespace: "test/env" as never,
+        trackPageView: vi.fn(),
+        initAppCheck: vi.fn(() => Promise.resolve()),
+        signIn: vi.fn(() => Promise.resolve()),
+        signOut: vi.fn(() => Promise.resolve()),
+        onAuthStateChanged: vi.fn(() => unsubscribeSpy),
+      },
+    });
+
+    handle = createBlogApp(config);
+    handle.destroy();
+
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
+  });
+
   // Case 7 — #1409: the live-DOM skip fires whenever #posts is live, not only
   // on the initial prerender. After a loadPosts() run renders a fresh #posts,
   // repeat navigations to "/" and "/post/..." both return null from render and

--- a/blog/test/create-blog-app.test.ts
+++ b/blog/test/create-blog-app.test.ts
@@ -443,7 +443,8 @@ describe("createBlogApp routing and panel behavior", () => {
 
     handle = createBlogApp(config);
 
-    // Flush the microtask queue so .then(captureUnsub) stores authUnsub.
+    // setTimeout(r, 0) is a macrotask; all pending Promise .then() callbacks
+    // (including .then(captureUnsub)) run before it, so authUnsub is stored.
     await new Promise((r) => setTimeout(r, 0));
 
     handle.destroy();


### PR DESCRIPTION
Closes #1715

## Summary

`createBlogApp` wired the auth-state listener via
`config.firebase.onAuthStateChanged(cb)` but consumed the return value only as a
`PromiseLike` for error handling (`.then(undefined, errHandler)`), never
capturing the unsubscribe. `destroy()` therefore never unsubscribed — after
teardown an auth-state event could still fire `refreshAfterAuthChange` on the
destroyed instance, writing to detached DOM and calling the already-destroyed
router.

## The production return shape

The value passed in production is firebaseutil's **async** wrapper from
`createAppContext` (`landing/src/main.ts`, `fellspiral/src/main.ts`), which
returns `Promise<() => void>` — the unsubscribe resolves *inside* the promise. A
literal `typeof === "function"` check would be false in production and drop the
unsubscribe, so the fix captures it in **both** shapes.

## Changes (entirely within `blog/src/create-blog-app.ts`)

- **Config type** — widened `onAuthStateChanged`'s return to
  `(() => void) | PromiseLike<(() => void) | void>`. This admits the production
  `Promise<() => void>`, a synchronous `() => void`, and the existing
  `Promise<void>` test mocks without any caller edits.
- **Capture + race guard** — register a teardown (before the listener call) that
  flips an `authDestroyed` flag and calls the captured unsubscribe; capture from
  the synchronous-function arm and the promise arm. If `destroy()` ran before an
  async unsubscribe resolved, the resolved unsubscribe is invoked immediately.
  The existing auth callback body and the `auth-init` error handler
  (`deferProgrammerError` / `logError`) are preserved unchanged; only the
  previously-`undefined` success arm now captures the resolved unsubscribe.

## Tests (`blog/test/create-blog-app.test.ts`)

Three new cases on the existing harness:

1. Production-representative `Promise<() => void>` — unsubscribe called once on
   `destroy()`.
2. Destroy-before-resolve race — `destroy()` runs first, then the promise
   resolves; unsubscribe still called once.
3. Synchronous-function return — unsubscribe called once on `destroy()`.

All pre-existing cases still pass (the default mock returning `Promise.resolve()`
is unaffected).

## Verification

- `npx vitest run --root blog test/create-blog-app.test.ts` — 11 passed.
- `npm run build --prefix landing` and `npm run build --prefix fellspiral` — both
  type-check clean; the widened union accepts the production `Promise<() => void>`
  with no caller changes.

`blog` is a library workspace with no standalone DOM-resolving typecheck, so the
consuming-app builds and vitest are the authoritative checks.
