### PR TITLE
dispatch: single-named-exit invariant + non-terminal handoff to stop /implement stalling mid-loop

### DIFF
--- a/.claude/skills/fix-checks/SKILL.md
+++ b/.claude/skills/fix-checks/SKILL.md
@@ -244,6 +244,11 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
    classification — generic and flake push nothing, main-fixed pushed the merge
    commit — so there is nothing more to do here.
 
+   `/implement-unit` returning here is mid-pass, not the end of the turn. Continue
+   through Steps 7–9; the pass ends only at the Step 9 `dispatch-mark-complete`
+   marker (or the Step 4 needs-human stop). Do not emit a closing summary; the next
+   message is the next tool call.
+
 7. **Append a record to the accumulator.** Append one `## Iteration <n>` section to
    `tmp/fix-checks-summary.md` (see [Accumulator](#accumulator)).
 

--- a/.claude/skills/implement-unit/SKILL.md
+++ b/.claude/skills/implement-unit/SKILL.md
@@ -87,7 +87,7 @@ The caller supplies:
    unit added new untracked files, append them the same way via
    `git ls-files --others --exclude-standard` (also bare, NUL-safe paths) — both
    feed the same quoted `args` array. Exit 0 → unit landed; proceed to Step 4
-   (Return).
+   (hand back to the caller).
 
    **2b. On a non-zero exit, fall back to the fork** — this is the **canonical
    commit-merge-push fork recipe**: issue an Agent tool call with
@@ -127,4 +127,4 @@ The caller supplies:
    - **Push rejection** (non-fast-forward, server hook) → surface to the user. Do
      **not** force-push.
 
-4. **Return** once the unit is committed, merged, and pushed.
+4. **Hand back to the caller** — this unit is committed, merged, and pushed. Do not end the turn; do not emit a closing summary. Issue the caller's next step as a tool call immediately.

--- a/.claude/skills/implement-unit/SKILL.md
+++ b/.claude/skills/implement-unit/SKILL.md
@@ -127,4 +127,4 @@ The caller supplies:
    - **Push rejection** (non-fast-forward, server hook) → surface to the user. Do
      **not** force-push.
 
-4. **Hand back to the caller** — this unit is committed, merged, and pushed. Do not end the turn; do not emit a closing summary. Issue the caller's next step as a tool call immediately.
+4. **Hand back to the caller** — this unit is committed, merged, and pushed. Do not end the turn; do not emit a closing summary. The next message is the next tool call.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -67,7 +67,7 @@ not implement, so this is a same-tick crash-recovery edge.)
 
 **Single named exit.** Take exactly one terminal action to end the turn: the
 final action is a call to `dispatch-mark-complete` (no deviation) or
-`dispatch-mark-deviation` (deviation). These are the single named exit.
+`dispatch-mark-deviation` (deviation). This is the single named exit.
 
 - Any OTHER most-recent tool call — a unit finishing in Step 2, the draft PR
   opening in Step 3 — means the orchestrator is mid-loop, not done.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -65,6 +65,15 @@ not implement, so this is a same-tick crash-recovery edge.)
 
 ## Steps
 
+**Single named exit.** Take exactly one terminal action to end the turn: the
+final action is a call to `dispatch-mark-complete` (no deviation) or
+`dispatch-mark-deviation` (deviation). These are the single named exit.
+
+- Any OTHER most-recent tool call — a unit finishing in Step 2, the draft PR
+  opening in Step 3 — means the orchestrator is mid-loop, not done.
+- Mid-loop, the next message contains the next tool call, never a closing
+  summary. Do not end the turn until the named exit fires.
+
 ### 1. Read the plan
 
 Read the persisted plan from the issue's `<!-- dispatch:plan -->` comment. Invoke
@@ -84,6 +93,17 @@ Exit codes:
 - **exit 2** — non-numeric arg.
 
 ### 2. Build each unit
+
+Before building, create a tracked task list with the harness `TaskCreate` tool:
+
+- one task per planned unit from the Step 1 plan,
+- one task for "open the draft PR" (Step 3),
+- one task for "write the completion marker" (Step 4).
+
+Mark each task completed via the harness `TaskUpdate` tool as it lands. This
+keeps the remaining work durable and visible rather than held in the model's
+head, reinforcing the single-named-exit invariant: the turn ends only when every
+task — including the marker — is completed.
 
 For each unit in the plan read in Step 1, in dependency order, invoke
 `/implement-unit` via the Skill tool, passing:

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -661,7 +661,10 @@ Otherwise run all steps in order.
       `unit.scope`, `unit.context`, `unit.commit_intent` into its parameters
       (`id` / `dependencies` / `resolves_ids` are for your ordering and the Step 4
       comment, not passed through). The draft PR already exists — open **NO** new
-      PR.
+      PR. A unit completing in this `/implement-unit` loop is mid-loop, not the end
+      of the turn — continue to the next unit, then Steps 4 and 5 and the marker;
+      do not emit a closing summary. The terminal rule is the **CRITICAL
+      invariants** block below (the fix path HARD-STOPS the skill).
    2. Run **Step 4** (post the PR-comment summary; its disposition section uses the
       **fixing-pass** prose — see Step 4).
    3. Run **Step 5** (cleanup — it self-guards and no-ops if the QA server never

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -262,6 +262,12 @@ findings — only this compact summary.
 
 ### 3. Commit the Workflow's working-tree edits via one commit-merge-push
 
+The Workflow returning (Step 2), and `/commit-merge-push` (Step 3) and
+`/file-issue` (Step 5) returning, are mid-tail — not the end of the turn. Continue
+through Steps 3–7; the pass ends only after `dispatch:reviewed` is applied and the
+Step 7 marker is written (this skill's terminal action — see the preamble and Step
+7). Do not emit a closing summary; the next message is the next tool call.
+
 Call the script first (use `dangerouslyDisableSandbox: true` — git writes +
 `git push` over HTTPS; see `.claude/rules/sandbox.md`). Compute the changed files:
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -262,8 +262,9 @@ findings — only this compact summary.
 
 ### 3. Commit the Workflow's working-tree edits via one commit-merge-push
 
-The Workflow returning (Step 2), and `/commit-merge-push` (Step 3) and
-`/file-issue` (Step 5) returning, are mid-tail — not the end of the turn. Continue
+The Workflow returning (Step 2), `/commit-merge-push` (Step 3), `/file-issue`
+(Step 5), and `dispatch-complete-phase` applying `dispatch:reviewed` (Step 7)
+returning, are mid-tail — not the end of the turn. Continue
 through Steps 3–7; the pass ends only after `dispatch:reviewed` is applied and the
 Step 7 marker is written (this skill's terminal action — see the preamble and Step
 7). Do not emit a closing summary; the next message is the next tool call.
@@ -352,7 +353,8 @@ Skip a path when its bucket is empty.
 The Workflow prepares `result.deferred_filings`, each entry carrying `title`,
 `body`, and `blocker_issue_nums` (the implementing issue numbers from
 `Closes #N`, or `"independent"`). For each entry, fork a subagent (`subagent_type:
-general-purpose`, `model: sonnet`). The subagent:
+general-purpose`, `model: sonnet`). When these subagents return, this is mid-tail
+— continue to Step 6 without a closing summary. The subagent:
 
 1. Invokes `/file-issue` with a leading `--follow-up` token prepended to the
    `$INPUT` it builds from the finding's `title` and `body` (the token must come
@@ -411,8 +413,9 @@ the same alert or package is never re-filed across repeated runs or multiple PRs
 - `required` and `false-positive` findings are never filed.
 
 For each emitted follow-up, fork a subagent (`subagent_type: general-purpose`,
-`model: sonnet`); run them in parallel (multiple Agent calls in one message). Each
-subagent:
+`model: sonnet`); run them in parallel (multiple Agent calls in one message). When
+these subagents return, this is mid-tail — continue to Step 6 without a closing
+summary. Each subagent:
 
 1. Runs the deterministic existence check (use `dangerouslyDisableSandbox: true`
    — `gh` needs network, see `.claude/rules/sandbox.md`), passing the follow-up's


### PR DESCRIPTION
Closes #1737

## Problem

`/implement` runs a loop in the caller's thread: build each planned unit via
`/implement-unit` (Step 2), open a draft PR (Step 3), then write the
`dispatch-mark-complete` marker (Step 4) that drives the Stop hook to spawn the
next router and self-close the job. The loop's continuation depends entirely on
the model remembering it is mid-loop — there is no single named exit and no
durable record of remaining steps.

The proximate trigger was `/implement-unit` Step 4: a bare `**Return** once the
unit is committed, merged, and pushed.` as the file's last line. That reads as a
turn boundary and invites a closing summary that ends the turn with no further
tool call. Observed on issue #1715: the session built Unit 1, emitted a
"returning control" summary, and ended its turn before Unit 2, the draft PR, or
the marker — so no marker was written and the job stalled mid-workflow.

The same stall surface exists in the sibling inline phase skills: each has a
sub-tool/sub-skill that returns before a tail of further steps reaches a marker.

## Change

Documentation-only reliability fix to the dispatch workflow SKILL.md
instructions — no source-code change. Five SKILL.md files:

- **`/implement-unit`** — replace the terminal `**Return**` last line with an
  explicit non-terminal handoff contract: a completed unit is the middle of the
  caller's loop, not its end; do not end the turn or emit a closing summary; the
  next action is the caller's next step, issued as a tool call. The Step-2
  cross-reference no longer reintroduces "Return" as a terminal verb.
- **`/implement`** — add a single-named-exit invariant (the turn ends only via
  `dispatch-mark-complete` or `dispatch-mark-deviation`; any other most-recent
  tool call means mid-loop, continue with a tool call), plus a tracked
  progress-ledger step (one `TaskCreate` task per planned unit, plus "open draft
  PR" and "write completion marker", marked complete via `TaskUpdate` as each
  lands) so remaining work is durable rather than held in the model's head.
- **`/fix-checks`, `/qa-fix`, `/review-fix`** — the same single-exit framing,
  tailored per skill. `/fix-checks` and `/review-fix` have a linear tail, so they
  get the lighter "a sub-tool returning is mid-pass; continue to the marker"
  note. `/qa-fix` has a per-unit loop and already carries the repo's strongest
  HARD-STOPS invariant, so it gets one mid-loop sentence plus a cross-link to
  that existing block rather than a duplicate.

All wording mirrors existing dispatch vocabulary (`resolve-epic`'s "exactly one
terminal action", the existing "final action" phrasing) and follows
`ref-write-instructions` conventions.

## Verification

Documentation-only — no app to run. Read-back against the acceptance criteria:
the single named exit is stated in `/implement`; `/implement-unit` Step 4 is a
non-terminal handoff with no bare "Return"; the progress ledger covers every
unit plus the PR and marker steps; all three sibling skills carry tailored
single-exit framing with `/qa-fix` cross-linking (not duplicating) its
HARD-STOPS invariant; and `git diff` touches only the five SKILL.md files.
