### PR TITLE
print: findMatches uses needle.length, not query.length

### DIFF
--- a/print/src/viewer/pdf.ts
+++ b/print/src/viewer/pdf.ts
@@ -39,8 +39,8 @@ export function findMatches(
   while (from < haystack.length) {
     const offset = haystack.indexOf(needle, from);
     if (offset === -1) break;
-    results.push({ offset, length: query.length });
-    from = offset + query.length;
+    results.push({ offset, length: needle.length });
+    from = offset + needle.length;
   }
   return results;
 }

--- a/print/test/viewer/pdf.test.ts
+++ b/print/test/viewer/pdf.test.ts
@@ -136,11 +136,12 @@ describe("findMatches", () => {
     expect(findMatches("hello world", "xyz")).toEqual([]);
   });
 
-  it("length equals query length", () => {
+  it("length equals needle (lowercased query) length", () => {
     const query = "needle";
+    const needle = query.toLowerCase();
     const matches = findMatches("needle in a needlestack", query);
     for (const m of matches) {
-      expect(m.length).toBe(query.length);
+      expect(m.length).toBe(needle.length);
     }
   });
 
@@ -158,6 +159,19 @@ describe("findMatches", () => {
     const matches = findMatches(pageText, query);
     // Match spans needle.length (2) at offset 1, not query.length (1).
     expect(matches).toEqual([{ offset: 1, length: 2 }]);
+  });
+
+  it("advances by needle (lowercased) length between adjacent expanding-case matches", () => {
+    // "İ" (U+0130) lowercases to "i" + U+0307 (combining dot above): length 1 → 2.
+    const query = "İ";
+    const needle = query.toLowerCase(); // "i̇", length 2
+    const matches = findMatches(needle + needle, query);
+    // Two adjacent matches: the next search must resume at needle.length (2),
+    // not query.length (1), or it would start inside the consumed needle.
+    expect(matches).toEqual([
+      { offset: 0, length: needle.length },
+      { offset: needle.length, length: needle.length },
+    ]);
   });
 });
 

--- a/print/test/viewer/pdf.test.ts
+++ b/print/test/viewer/pdf.test.ts
@@ -149,6 +149,16 @@ describe("findMatches", () => {
     const matches = findMatches("aaa", "aa");
     expect(matches).toEqual([{ offset: 0, length: 2 }]);
   });
+
+  it("uses needle (lowercased) length, not query length, for expanding-case queries", () => {
+    // "İ" (U+0130) lowercases to "i" + U+0307 (combining dot above): length 1 → 2.
+    const query = "İ";
+    const needle = query.toLowerCase(); // "i̇", length 2
+    const pageText = "a" + needle + "b";
+    const matches = findMatches(pageText, query);
+    // Match spans needle.length (2) at offset 1, not query.length (1).
+    expect(matches).toEqual([{ offset: 1, length: 2 }]);
+  });
 });
 
 describe("buildSnippet", () => {
@@ -253,6 +263,12 @@ describe("offsetToDivRanges", () => {
   it("range entirely within second item", () => {
     const result = offsetToDivRanges(["abc", "defgh"], 3, 3);
     expect(result).toEqual([{ divIndex: 1, localStart: 0, localEnd: 3 }]);
+  });
+
+  it("maps a corrected expanding-case match onto its item", () => {
+    const ci = "İ".toLowerCase(); // "i̇", length 2 — built, not a fragile literal
+    const result = offsetToDivRanges(["a", ci, "b"], 1, 2);
+    expect(result).toEqual([{ divIndex: 1, localStart: 0, localEnd: 2 }]);
   });
 });
 


### PR DESCRIPTION
Closes #1718

## Problem

`findMatches` in `print/src/viewer/pdf.ts` runs a case-insensitive search by
lowercasing both the haystack (`pageText.toLowerCase()`) and the query
(`query.toLowerCase()` → `needle`), then finds `needle` in the haystack. But it
stored `query.length` — not `needle.length` — in both the result's `length`
field and the `from` advance.

For Unicode queries whose lowercased form has a different code-unit count,
`needle.length !== query.length`. For example `"İ"` (U+0130, LATIN CAPITAL
LETTER I WITH DOT ABOVE) has `length` 1, but `"İ".toLowerCase()` is `"i" + U+0307`
(combining dot above) with `length` 2. The match in the lowercased haystack spans
`needle.length` (2) code units at the found `offset`, so storing `query.length`
(1) meant:

- The `length` baked into the `SearchResult.location` token was wrong, so
  `offsetToDivRanges` walked the wrong number of characters and misplaced or
  truncated the highlight span.
- The `from = offset + query.length` advance under-stepped the real match end, so
  a subsequent match could be missed or misfound.

## Fix

Use `needle.length` in both places. The match in `haystack` spans exactly
`needle.length` characters starting at `offset`, and `buildPageText` joins items
with an empty separator, so the raw `pageText` at that offset spans the same
`needle.length` characters used for the highlight.

## Tests

- `findMatches`: an expanding-case query (`"İ"`) now yields `{ offset: 1, length:
  2 }`, not `{ length: 1 }`. The combining string is built via `"İ".toLowerCase()`
  rather than a fragile raw literal.
- `offsetToDivRanges`: the corrected `offset`/`length` maps cleanly onto its item,
  covering the highlight-placement path end to end.

The existing ASCII `"length equals query length"` test (where `needle.length ===
query.length`) is unchanged and still passes. All 32 tests in
`print/test/viewer/pdf.test.ts` pass.
