### PR TITLE
print: guard search() against null pdfDoc before the page-fetch loop

### DIFF
--- a/print/src/viewer/pdf.ts
+++ b/print/src/viewer/pdf.ts
@@ -546,6 +546,7 @@ export function createPdfRenderer(onError?: (err: unknown) => void): ContentRend
     async search(query: string): Promise<SearchResult[]> {
       const trimmed = query.trim();
       if (!trimmed) return [];
+      if (!pdfDoc) return [];
 
       const results: SearchResult[] = [];
 

--- a/print/test/viewer/pdf.test.ts
+++ b/print/test/viewer/pdf.test.ts
@@ -367,6 +367,20 @@ describe("search()", () => {
     const decoded = decodeLocation(page2!.location);
     expect(decoded).toEqual({ page: 2, offset: 0, length: 3 });
   });
+
+  it("returns [] without throwing when called before init() resolves", async () => {
+    const renderer = createPdfRenderer();
+
+    await expect(renderer.search!("the")).resolves.toEqual([]);
+  });
+
+  it("returns [] without throwing after destroy()", async () => {
+    const renderer = createPdfRenderer();
+    await renderer.init(container, "fake://source.pdf");
+    renderer.destroy();
+
+    await expect(renderer.search!("the")).resolves.toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1725

## Summary

`search()` in `print/src/viewer/pdf.ts` dereferenced `pdfDoc!` inside its
page-fetch loop with no prior null check. `pdfDoc` is `null` both before
`init()` resolves and after `destroy()` runs (which sets `pdfDoc = null`). The
in-loop `destroyed` guards only fire *after* each `await`, so they catch
destruction that races an in-progress `getPage` call but not a fresh `search()`
invoked on an already-null `pdfDoc` — in that case `pdfDoc!.getPage` threw
`TypeError: Cannot read properties of null`.

This adds an early `if (!pdfDoc) return [];` guard before the page-fetch loop,
mirroring the existing guard in `getOutline()` verbatim. `search()` now returns
`[]` without throwing when called before `init()` resolves or after `destroy()`.

Follow-up hardening to #1691 (PDF full-document search), which introduced
`search()`.

## Changes

- `print/src/viewer/pdf.ts`: add `if (!pdfDoc) return [];` in `search()` after
  the trimmed-query guard, before the page-fetch loop. No other behavior change
  — the existing `pdfDoc!.getPage(i)` assertion and in-loop `destroyed` checks
  are unchanged, so the non-null search path is unaffected.
- `print/test/viewer/pdf.test.ts`: two regression tests in the `search()` block
  — `search()` before `init()` and after `destroy()` each resolve to `[]`
  rather than throwing.

## Verification

```
npx vitest run --root print test/viewer/pdf.test.ts   # 32 passed
npx vitest run --root print test/viewer                # 286 passed
```
