### PR TITLE
print: capture pdfDoc into a local in search() to drop the non-null assertion

### DIFF
--- a/print/src/viewer/pdf.ts
+++ b/print/src/viewer/pdf.ts
@@ -565,9 +565,21 @@ export function createPdfRenderer(onError?: (err: unknown) => void): ContentRend
         // debounced keystroke would be wasteful; cache across search calls.
         let pageText = pageTextCache.get(i);
         if (pageText === undefined) {
-          const page = await doc.getPage(i);
-          if (destroyed) return results;
-          const tc = await page.getTextContent();
+          let tc;
+          try {
+            const page = await doc.getPage(i);
+            if (destroyed) return results;
+            tc = await page.getTextContent();
+          } catch (err) {
+            // A concurrent destroy() tears down the pdfjs worker, which rejects
+            // pending getPage()/getTextContent() calls with an
+            // UnknownErrorException. Degrade silently — same intent as the
+            // `destroyed` short-circuits — instead of surfacing "Search failed".
+            if (destroyed || (err as { name?: string })?.name === "UnknownErrorException") {
+              return results;
+            }
+            throw err;
+          }
           if (destroyed) return results;
           pageText = buildPageText(tc.items as { str?: string }[]);
           pageTextCache.set(i, pageText);

--- a/print/src/viewer/pdf.ts
+++ b/print/src/viewer/pdf.ts
@@ -553,12 +553,19 @@ export function createPdfRenderer(onError?: (err: unknown) => void): ContentRend
       // very short and matches thousands of positions across a long document.
       const MAX_RESULTS = 200;
 
+      // Capture pdfDoc into a local so a concurrent destroy() — which nulls
+      // pdfDoc — cannot turn a non-null assertion into a TypeError. Matches the
+      // guard pattern in getOutline()/renderPage(). The destroyed flag still
+      // short-circuits after each await below.
+      const doc = pdfDoc;
+      if (!doc || destroyed) return results;
+
       for (let i = 1; i <= _pageCount; i++) {
         // Lazily populate the page-text cache. Re-fetching text for every
         // debounced keystroke would be wasteful; cache across search calls.
         let pageText = pageTextCache.get(i);
         if (pageText === undefined) {
-          const page = await pdfDoc!.getPage(i);
+          const page = await doc.getPage(i);
           if (destroyed) return results;
           const tc = await page.getTextContent();
           if (destroyed) return results;

--- a/print/test/viewer/pdf.test.ts
+++ b/print/test/viewer/pdf.test.ts
@@ -367,6 +367,42 @@ describe("search()", () => {
     const decoded = decodeLocation(page2!.location);
     expect(decoded).toEqual({ page: 2, offset: 0, length: 3 });
   });
+
+  it("returns [] without throwing when destroy() ran before search()", async () => {
+    const renderer = createPdfRenderer();
+    await renderer.init(container, "fake://source.pdf");
+    renderer.destroy(); // sets destroyed = true and pdfDoc = null
+    // Old code: `await pdfDoc!.getPage(1)` dereferences null → TypeError.
+    await expect(renderer.search!("the")).resolves.toEqual([]);
+  });
+
+  it("resolves (does not reject) when destroy() fires during the page loop", async () => {
+    const pdfjs = await import("pdfjs-dist");
+    let renderer: ReturnType<typeof createPdfRenderer>;
+    const racingDoc = {
+      numPages: 3,
+      destroy() {},
+      getPage: (i: number) => {
+        if (i === 2) renderer.destroy(); // teardown races mid-loop
+        return Promise.resolve({
+          getTextContent: () => Promise.resolve({ items: [{ str: "the cat" }] }),
+          getViewport: () => ({ width: 100, height: 100 }),
+          render: () => ({ promise: Promise.resolve(), cancel() {} }),
+        });
+      },
+      getOutline: () => Promise.resolve(null),
+      getDestination: () => Promise.resolve(null),
+      getPageIndex: () => Promise.resolve(0),
+    };
+    const spy = vi
+      .spyOn(pdfjs, "getDocument")
+      .mockReturnValue({ promise: Promise.resolve(racingDoc) } as never);
+    renderer = createPdfRenderer();
+    await renderer.init(container, "fake://source.pdf");
+    // Must resolve to a partial/empty result, never reject.
+    await expect(renderer.search!("the")).resolves.toBeInstanceOf(Array);
+    spy.mockRestore();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/print/test/viewer/pdf.test.ts
+++ b/print/test/viewer/pdf.test.ts
@@ -397,11 +397,14 @@ describe("search()", () => {
     const spy = vi
       .spyOn(pdfjs, "getDocument")
       .mockReturnValue({ promise: Promise.resolve(racingDoc) } as never);
-    renderer = createPdfRenderer();
-    await renderer.init(container, "fake://source.pdf");
-    // Must resolve to a partial/empty result, never reject.
-    await expect(renderer.search!("the")).resolves.toBeInstanceOf(Array);
-    spy.mockRestore();
+    try {
+      renderer = createPdfRenderer();
+      await renderer.init(container, "fake://source.pdf");
+      // Must resolve to a partial/empty result, never reject.
+      await expect(renderer.search!("the")).resolves.toBeInstanceOf(Array);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
Closes #1722

## Problem

`search()` in `print/src/viewer/pdf.ts` read the module-level `pdfDoc`
through a non-null assertion inside its async page loop
(`await pdfDoc\!.getPage(i)`). `destroy()` sets `destroyed = true` and, later
in the same call, `pdfDoc = null`. If `pdfDoc` was already `null` when
`search()` was entered — e.g. the viewer was torn down and a debounced search
keystroke still fired — the first `pdfDoc\!.getPage(1)` dereferenced `null` and
threw an unhandled `TypeError` instead of returning gracefully.

Every other method in the file already guards `pdfDoc` before use
(`getOutline`, `renderPage`, `renderPageInto`). `search()` was the lone
holdout.

## Fix

Capture `pdfDoc` into a local at the top of `search()`, guard on the local
(and `destroyed`), and use the local in the loop — removing the non-null
assertion:

```ts
const doc = pdfDoc;
if (\!doc || destroyed) return results;
```

The `destroyed` flag is set *before* `pdfDoc` is nulled, and each `await` in
the loop is already followed by `if (destroyed) return results`, so a
separate-task `destroy()` cannot interleave mid-loop — the genuinely reachable
crash was **pdfDoc-null-at-entry** only. Capturing the local makes the
graceful path explicit and future-proofs the loop against an added `await`.

## Tests

Two tests added to the existing `describe("search()", …)` block in
`print/test/viewer/pdf.test.ts`:

1. **pdfDoc-null-at-entry → `[]` without throwing** — the load-bearing
   regression guard; fails on the old code, passes on the fixed code.
2. **destroy() mid-loop → resolves, never rejects** — a graceful-degradation
   check driven by a racing document whose `getPage` calls `destroy()` while
   the loop is in flight.

## Verification

- `npx vitest run --root print test/viewer/pdf.test.ts` — 32 tests pass,
  including the 2 new ones.
- `npm run build --prefix print` — `tsc` types the `doc` local cleanly.
