### PR TITLE
print: make applyHighlight idempotent by unwrapping before re-highlighting

### DIFF
--- a/print/src/viewer/pdf.ts
+++ b/print/src/viewer/pdf.ts
@@ -160,8 +160,12 @@ export function createPdfRenderer(onError?: (err: unknown) => void): ContentRend
   // re-render (renderPage(_currentPage)) re-applies it after a resize. Cleared
   // by the public manual-nav methods so a stale highlight never reappears.
   let pendingHighlight: { page: number; offset: number; length: number } | null = null;
-  // Records the original text content of every div mutated by applyHighlight so
-  // unwrapHighlights can restore the text layer to its pristine state.
+  // Records the original text content of every div mutated by the most recent
+  // applyHighlight call so unwrapHighlights can restore the text layer to its
+  // pristine state. Invariant: after applyHighlight returns, this array holds
+  // exactly one entry per currently-highlighted div (the divs from the most
+  // recent call only — earlier entries are cleared by the unwrapHighlights()
+  // call at the start of applyHighlight).
   const highlightRestores: { div: HTMLElement; originalText: string }[] = [];
   interface SpreadPage { renderTask: RenderTask; textLayer: TextLayer | null; }
   const spreadPages: SpreadPage[] = [];
@@ -308,8 +312,15 @@ export function createPdfRenderer(onError?: (err: unknown) => void): ContentRend
    *
    * Children are rebuilt with createTextNode/createElement (never innerHTML) so
    * the text layer's transparent-text CSS keeps applying.
+   *
+   * Calls unwrapHighlights() first so it is idempotent: any prior highlight
+   * (including detached divs from a superseded render) is restored and
+   * highlightRestores is cleared before the new entries are recorded. After
+   * this function returns, highlightRestores holds exactly one entry per
+   * currently-highlighted div.
    */
   function applyHighlight(tl: TextLayer, h: { offset: number; length: number }): void {
+    unwrapHighlights();
     const itemsStr = tl.textContentItemsStr;
     const divs = tl.textDivs;
     const segments = offsetToDivRanges(itemsStr, h.offset, h.length);

--- a/print/test/viewer/pdf.test.ts
+++ b/print/test/viewer/pdf.test.ts
@@ -464,6 +464,33 @@ describe("clearSearch()", () => {
     expect(restored).toBeDefined();
   });
 
+  it("re-rendering a page with the highlight still armed restores the detached div (idempotent applyHighlight)", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = createPdfRenderer();
+      await renderer.init(container, "fake://source.pdf");
+      const results = await renderer.search!("the");
+      const page1Result = results.find((r) => r.label === "Page 1");
+      await renderer.goToResult!(page1Result!);
+
+      const firstSpan = container.querySelector(".search-highlight");
+      expect(firstSpan).not.toBeNull();
+      const firstDiv = firstSpan!.parentElement!; // the textDiv from render 1
+      expect(firstDiv.querySelector(".search-highlight")).not.toBeNull();
+
+      // Debounced resize re-render with pendingHighlight still armed.
+      resizeObserverCallbacks[resizeObserverCallbacks.length - 1]();
+      await vi.advanceTimersByTimeAsync(200);
+      await Promise.resolve();
+
+      // firstDiv is now detached; without the fix it stays wrapped.
+      expect(firstDiv.querySelector(".search-highlight")).toBeNull();
+      expect(firstDiv.textContent).toBe("the cat sat");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("clearSearch() disarms pendingHighlight so re-render does not reapply", async () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");


### PR DESCRIPTION
Closes #1721

## Problem

`applyHighlight` in `print/src/viewer/pdf.ts` wraps search-match text in
`<span class="search-highlight active">` elements and records each mutated div's
pre-mutation `textContent` into the module-level `highlightRestores` array, so
`unwrapHighlights` can later restore the text layer to pristine plain text. But
`applyHighlight` did **not** unwrap first.

It is called on every re-render of a page whose `pendingHighlight` is still
armed — the single-page resize path (`renderPage`, via the debounced
ResizeObserver) and the spread path (`renderPageInto`). Each re-render pushed a
**new** `highlightRestores` entry without clearing the prior ones. Because every
render builds fresh `textDiv` objects (the previous divs are detached by
`replaceChildren`), the accumulated entries point at **detached** divs:
`highlightRestores` grows unboundedly while a search highlight is active and the
user resizes, and `applyHighlight` is non-idempotent.

## Fix

Call `unwrapHighlights()` as the first statement of `applyHighlight()` — the
issue's recommended one-liner. `unwrapHighlights` restores every recorded div
(including the now-detached prior ones) and resets `highlightRestores.length = 0`
before the new highlight is recorded, making `applyHighlight` idempotent and
self-cleaning regardless of caller. The doc comments on `applyHighlight` and
`highlightRestores` are updated to state the one-entry-per-highlighted-div
invariant.

## Test

Adds one regression test in the `clearSearch()` block of
`print/test/viewer/pdf.test.ts` that drives the debounced resize re-render path
with the highlight still armed and asserts the detached first-render div is
restored (its `.search-highlight` span removed and `textContent` back to plain
text). Validated as a red→green discriminator: the test fails with the
`unwrapHighlights();` line removed and passes with it in place.

## Verification

- `npx vitest run --root print test/viewer/pdf.test.ts` — all pass; red→green
  discriminator confirmed.
- `npx vitest run --root print` — full print suite passes (454 passed, 1
  pre-existing unrelated skip).
- `npm run build --prefix print` — typecheck/build passes.
