### PR TITLE
print: unwrap stale highlights at the top of applyHighlight()

### DIFF
--- a/print/src/viewer/pdf.ts
+++ b/print/src/viewer/pdf.ts
@@ -308,8 +308,15 @@ export function createPdfRenderer(onError?: (err: unknown) => void): ContentRend
    *
    * Children are rebuilt with createTextNode/createElement (never innerHTML) so
    * the text layer's transparent-text CSS keeps applying.
+   *
+   * First restores any divs mutated by a prior call (unwrapHighlights), so the
+   * divs read here are always pristine and the highlightRestores log never
+   * accumulates stale entries for detached divs from a previous render. This
+   * makes applyHighlight safe to call repeatedly for the same page — covering
+   * both the single-page render path and the spread render path uniformly.
    */
   function applyHighlight(tl: TextLayer, h: { offset: number; length: number }): void {
+    unwrapHighlights();
     const itemsStr = tl.textContentItemsStr;
     const divs = tl.textDivs;
     const segments = offsetToDivRanges(itemsStr, h.offset, h.length);

--- a/print/test/viewer/pdf.test.ts
+++ b/print/test/viewer/pdf.test.ts
@@ -387,6 +387,7 @@ describe("clearSearch()", () => {
   let scrollSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     resizeObserverCallbacks = [];
     vi.clearAllMocks();
 
@@ -423,6 +424,7 @@ describe("clearSearch()", () => {
     getContextSpy.mockRestore();
     scrollSpy.mockRestore();
     vi.mocked(globalThis.reportError).mockRestore();
+    vi.useRealTimers();
   });
 
   it("clearSearch() is callable and idempotent before any goToResult (no active highlight)", async () => {
@@ -540,7 +542,7 @@ describe("clearSearch()", () => {
     // ResizeObserver re-render (renderPage(_currentPage)) runs while
     // pendingHighlight is still armed.
     resizeObserverCallbacks.forEach((cb) => cb());
-    await new Promise((r) => setTimeout(r, 220));
+    await vi.advanceTimersByTimeAsync(220);
 
     // The re-render detaches firstDiv; applyHighlight's unwrapHighlights()
     // restores it so it is no longer highlighted.

--- a/print/test/viewer/pdf.test.ts
+++ b/print/test/viewer/pdf.test.ts
@@ -479,4 +479,96 @@ describe("clearSearch()", () => {
 
     expect(container.querySelector(".search-highlight.active")).toBeNull();
   });
+
+  // -------------------------------------------------------------------------
+  // Double-highlight regression (#1726): applyHighlight() restores any divs
+  // mutated by a prior call before reading them, so re-rendering a page that
+  // already carries a highlight never leaves the previous render's detached
+  // div still wrapped in a stale .search-highlight span.
+  // -------------------------------------------------------------------------
+
+  it("double goToResult() on the same page leaves no stale highlighted div", async () => {
+    const renderer = createPdfRenderer();
+    await renderer.init(container, "fake://source.pdf");
+
+    const results = await renderer.search!("the");
+    const page1Result = results.find((r) => r.label === "Page 1");
+    expect(page1Result).toBeDefined();
+
+    // Render #1: capture the first textLayer span before any re-render so it
+    // holds the render-#1 node (which renderPage's up-front replaceChildren
+    // will detach on the next render).
+    await renderer.goToResult!(page1Result!);
+    const firstDiv = container.querySelector(".textLayer span") as HTMLElement;
+    expect(firstDiv).not.toBeNull();
+    expect(firstDiv.querySelector(".search-highlight")).not.toBeNull();
+
+    // Render #2: same page. renderTextLayer detaches firstDiv and builds a
+    // fresh layer; applyHighlight's leading unwrapHighlights() must restore the
+    // now-detached firstDiv, collapsing its stale highlight span. On unfixed
+    // code firstDiv stays wrapped and this assertion fails.
+    await renderer.goToResult!(page1Result!);
+    expect(firstDiv.querySelector(".search-highlight")).toBeNull();
+
+    // The live layer should still show exactly one highlighted "the".
+    const liveHighlights = container.querySelectorAll(".textLayer .search-highlight");
+    expect(liveHighlights.length).toBe(1);
+    expect(liveHighlights[0].textContent).toBe("the");
+
+    renderer.clearSearch!();
+
+    expect(container.querySelector(".search-highlight")).toBeNull();
+    const liveSpans = container.querySelectorAll(".textLayer span");
+    expect(liveSpans.length).toBe(1);
+    expect(liveSpans[0].textContent).toBe("the cat sat");
+  });
+
+  it("ResizeObserver re-render while pendingHighlight is set restores the detached div", async () => {
+    const renderer = createPdfRenderer();
+    await renderer.init(container, "fake://source.pdf");
+
+    const results = await renderer.search!("the");
+    const page1Result = results.find((r) => r.label === "Page 1");
+    expect(page1Result).toBeDefined();
+
+    await renderer.goToResult!(page1Result!);
+    const firstDiv = container.querySelector(".textLayer span") as HTMLElement;
+    expect(firstDiv).not.toBeNull();
+    expect(firstDiv.querySelector(".search-highlight")).not.toBeNull();
+
+    // Fire the stored resize callbacks and let the 150ms debounce elapse so the
+    // ResizeObserver re-render (renderPage(_currentPage)) runs while
+    // pendingHighlight is still armed.
+    resizeObserverCallbacks.forEach((cb) => cb());
+    await new Promise((r) => setTimeout(r, 220));
+
+    // The re-render detaches firstDiv; applyHighlight's unwrapHighlights()
+    // restores it so it is no longer highlighted.
+    expect(firstDiv.querySelector(".search-highlight")).toBeNull();
+
+    renderer.clearSearch!();
+
+    expect(container.querySelector(".search-highlight")).toBeNull();
+    const liveSpans = container.querySelectorAll(".textLayer span");
+    expect(liveSpans.length).toBe(1);
+    expect(liveSpans[0].textContent).toBe("the cat sat");
+  });
+
+  it("every live text-layer span returns to its original text after clearSearch (acceptance #3 guard)", async () => {
+    const renderer = createPdfRenderer();
+    await renderer.init(container, "fake://source.pdf");
+
+    const results = await renderer.search!("the");
+    const page1Result = results.find((r) => r.label === "Page 1");
+    await renderer.goToResult!(page1Result!);
+
+    renderer.clearSearch!();
+
+    const liveSpans = Array.from(container.querySelectorAll(".textLayer span"));
+    expect(liveSpans.length).toBe(1);
+    for (const span of liveSpans) {
+      expect(span.querySelector(".search-highlight")).toBeNull();
+    }
+    expect(liveSpans[0].textContent).toBe("the cat sat");
+  });
 });


### PR DESCRIPTION
Closes #1726

## What

`applyHighlight()` in `print/src/viewer/pdf.ts` now calls `unwrapHighlights()`
as its first statement, restoring and clearing any divs mutated by a prior call
before it reads `div.textContent` and repopulates `highlightRestores`. This
makes `applyHighlight` safe to call repeatedly for the same page and covers both
the single-page render path and the spread render path with one statement.

## The genuine defect (correcting the issue framing)

The issue frames this as permanent data corruption that "loses the true original
text." That symptom does **not** actually manifest, and this PR does not claim
it does. Two mechanics prevent any visible text corruption, both confirmed
empirically against the unfixed code:

1. `applyHighlight` rebuilds each div as
   `replaceChildren(beforeNode, span, afterNode)`, whose three text pieces
   concatenate exactly to the original string, so `div.textContent` flattens
   back to the pristine original.
2. `renderTextLayer` calls `targetDiv.replaceChildren()` and builds a **fresh**
   `TextLayer` (new `textDivs`) on every render, and `applyHighlight` only ever
   runs immediately after that rebuild. So the divs handed to `applyHighlight`
   are always pristine, and every `originalText` it records is correct.

The real defect is **unbounded stale-entry accumulation** in the closure-scoped
`highlightRestores` array. `applyHighlight` has two call sites that re-fire while
`pendingHighlight` stays set — the single-page render path and the spread render
path — triggered by a second `goToResult()` for the already-current page or a
debounced `ResizeObserver` re-render. Each such re-render pushed another entry
whose `div` was the *previous* render's div, detached from the DOM by the next
`replaceChildren()` but still carrying its injected `search-highlight` span and
still retained by the array. The result was one stale, detached, still-wrapped
entry per re-render (a memory leak) plus redundant restore work writing to
detached nodes, until the next navigation-time `unwrapHighlights()` cleared it.

## The fix

Call `unwrapHighlights()` at the top of `applyHighlight()`. It restores and
clears any prior entries before `div.textContent` is read, so `highlightRestores`
holds exactly one set of entries no matter how many times `applyHighlight` runs
for the same page. The change is purely additive — the existing navigation-time
unwrap calls (`goToPage`/`next`/`prev`/`clearSearch`/`destroy`) are unchanged.

## Tests

Added to the existing `describe("clearSearch()", …)` harness in
`print/test/viewer/pdf.test.ts` (reusing its stubs and the `pdfjs-dist` mock,
Page 1 = `"the cat sat"`):

1. **Double `goToResult()` on the same page leaves no stale highlighted div.**
   Captures the first render's div, asserts it is highlighted after render #1,
   re-renders via a second `goToResult()`, and asserts the now-detached first div
   is no longer highlighted — the discriminating proof that the top-of-function
   `unwrapHighlights()` cleaned it up.
2. **`ResizeObserver` re-render while `pendingHighlight` is set** — fires the
   stored resize callbacks, awaits the 150ms debounce, and asserts the detached
   first div is no longer highlighted.
3. **Acceptance-criterion #3 guard** — every live text-layer span returns to its
   original text after `clearSearch()`. Kept as documentation; non-discriminating
   (it holds with or without the fix, per the mechanics above).

## Acceptance-criteria mapping

- AC #1 (unwrapHighlights is the first statement) — satisfied directly.
- AC #2 (exactly one set of entries / no stale accumulation) — satisfied;
  observed via the detached-first-div discriminator (cases 1–2), since
  `highlightRestores` is closure-private and not directly inspectable.
- AC #3 / #4 (divs restore to original) — hold, but were already true pre-fix
  (textContent flattens; divs are rebuilt pristine); covered by the case-3 guard,
  not relied on as the regression proof.

## Verification

- `npx vitest run --root print test/viewer/pdf.test.ts` — 33 passed.
- Discriminator sanity-check: reverting the one-line production change makes
  cases 1 and 2 fail with exactly the stale-highlight symptom; re-applying
  returns them to green.
- `npm run build --prefix print` — green.
- `npx vitest run --root print` — 457 passed across 28 files, no collateral
  breakage.
