### PR TITLE
print: goToPosition clears pendingHighlight and drains highlightRestores

### DIFF
--- a/print/src/viewer/pdf.ts
+++ b/print/src/viewer/pdf.ts
@@ -509,6 +509,10 @@ export function createPdfRenderer(onError?: (err: unknown) => void): ContentRend
     },
 
     async goToPosition(position: string): Promise<void> {
+      // Manual navigation discards any active search highlight so a stale
+      // highlight never reappears on the new page.
+      pendingHighlight = null;
+      unwrapHighlights();
       const page = parsePositionPage(position, _pageCount);
       _currentPage = page;
       await renderPage(page);

--- a/print/test/viewer/pdf.test.ts
+++ b/print/test/viewer/pdf.test.ts
@@ -597,4 +597,25 @@ describe("clearSearch()", () => {
     // Exactly one highlight is live in the DOM (the current result).
     expect(container.querySelectorAll(".search-highlight.active").length).toBe(1);
   });
+
+  it("goToPosition() drains the active highlight and disarms pendingHighlight", async () => {
+    const renderer = createPdfRenderer();
+    await renderer.init(container, "fake://source.pdf");
+
+    const results = await renderer.search!("the");
+    const r1 = results.find((r) => r.label === "Page 1")!;
+    await renderer.goToResult!(r1);
+
+    // Capture the text-layer div holding the highlight before navigation.
+    const div1 = container.querySelector(".search-highlight")!.parentElement!;
+    expect(div1.querySelector(".search-highlight")).not.toBeNull();
+
+    // goToPosition must unwrap the highlight and disarm pendingHighlight.
+    await renderer.goToPosition("2");
+
+    // The highlight span is removed from the previously-live text div.
+    expect(div1.querySelector(".search-highlight")).toBeNull();
+    // No highlight exists anywhere in the container.
+    expect(container.querySelectorAll(".search-highlight").length).toBe(0);
+  });
 });


### PR DESCRIPTION
Closes #1744

## What

`goToPosition` is the bookmark / external-caller navigation entry point in
`print/src/viewer/pdf.ts`. Its sibling manual-navigation methods `goToPage`,
`next`, and `prev` each discard any active search highlight before rendering by
running `pendingHighlight = null; unwrapHighlights();` at the top of the method.
`goToPosition` was the lone navigation path that omitted both calls.

This change adds those two lines (plus the matching one-line comment) to the top
of `goToPosition`, mirroring its siblings.

## Why

When a search result was highlighted (via `goToResult`) and the user then jumped
via a bookmark, two defects appeared:

1. **Detached-node leak** — `renderPage` rebuilds the text layer, detaching the
   previously-highlighted divs, but the closure-private `highlightRestores` array
   kept referencing those now-detached nodes, growing without bound across
   navigations.
2. **Stale highlight reappears** — `pendingHighlight` stayed armed, so the next
   resize-triggered re-render re-applied the old search highlight on the
   bookmarked page.

`parsePositionPage` never throws and always returns a valid page, so
top-of-method placement has no early-return hazard — the discard is
unconditional, exactly as in `goToPage`.

This is the analogous fix to #1736, which fixed the same omission in the *arming*
path `goToResult`; the navigation path was explicitly filed as this follow-up.

## Test

Adds one regression test to the `describe("clearSearch()")` block in
`print/test/viewer/pdf.test.ts`, mirroring the #1736 `goToResult` drain test. It
arms a highlight, jumps via `goToPosition`, and asserts the previously-highlighted
div was restored (no leaked references) and no stale highlight survives. The test
fails on the pre-fix `goToPosition` and passes with the fix; the full `print`
suite stays green and the build typechecks.
