### PR TITLE
test: create main worktree dir in OHST12 to match the spawn-office-hours --cwd contract

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -5448,6 +5448,10 @@ printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"main
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+# dispatch-spawn-office-hours passes this path to claude --bg as --cwd, so it
+# must exist on disk for the full integration; create it like the sibling
+# spawn tests (e.g. OH3) do, even though the selector itself never stats it.
+mkdir -p "$TMPDIR_TEST/worktrees/main"
 select_target_fake_claude   # no live sessions → sessionless, picked fresh
 result=$("$TMPDIR_TEST/office-hours-select-target")
 assert_eq "main-qa override: phase main-qa, main worktree 5th field" \

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -5448,9 +5448,11 @@ printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"main
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
-# dispatch-spawn-office-hours passes this path to claude --bg as --cwd, so it
-# must exist on disk for the full integration; create it like the sibling
-# spawn tests (e.g. OH3) do, even though the selector itself never stats it.
+# The selector itself does not stat this path; this mkdir is a convention match
+# documenting the production contract (dispatch-spawn-office-hours requires the
+# cwd to exist). A full entry-point integration test for the main-qa fresh-spawn
+# path is needed to actually exercise the dispatch-spawn-office-hours directory
+# guard.
 mkdir -p "$TMPDIR_TEST/worktrees/main"
 select_target_fake_claude   # no live sessions → sessionless, picked fresh
 result=$("$TMPDIR_TEST/office-hours-select-target")


### PR DESCRIPTION
Closes #1759

## What

OHST12 in `test-dispatch-scripts.sh` asserts that a fresh, no-PR, no-worktree
item carrying the `main-qa` label makes `office-hours-select-target` emit the
**main** worktree path as the disposition's 5th field. The test set
`DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"` but never
created that directory.

`office-hours-select-target` is a pure selector — it never stats the path — so
the assertion passed even though the directory was absent. The downstream
consumer `dispatch-spawn-office-hours` passes the emitted path to `claude --bg`
as `--cwd`, which would fail at spawn time if the directory did not exist. The
test therefore gave a misleading impression of end-to-end validity.

## Change

Inside the OHST12 block, create the directory with `mkdir -p` immediately after
the `DISPATCH_OFFICE_HOURS_MAIN_WORKTREE` export, matching the idiom that the
sibling spawn tests (e.g. OH3) already use, with a comment documenting why the
directory must exist. No change to `office-hours-select-target`,
`dispatch-spawn-office-hours`, the assertion string, or any other test.

## Verification

`test-dispatch-scripts.sh` passes (2949/2949); OHST12 (`main-qa override: phase
main-qa, main worktree 5th field`) is green.
