### PR TITLE
dispatch-mark-parse-job-done: fix stale implement/verify phase comment

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-mark-parse-job-done
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-mark-parse-job-done
@@ -7,7 +7,7 @@
 # Writes the dispatch parse-job-done sentinel that dispatch-stop.sh's parse-job
 # clean-completion branch reads to spawn the next tick and self-close — the
 # terminal disposition for a parse-job whose budget-etl statement merge
-# succeeded. Unlike an implement/verify phase, a clean parse-job produces NO PR:
+# succeeded. Unlike an implement/fix-checks phase, a clean parse-job produces NO PR:
 # the handler skill has already closed the parse-job issue, so there is no label
 # work and no PR-centric disposition. The sentinel is written atomically
 # (tempfile + mv) under the $CLAUDE_JOB_DIR guard, exactly as the marker scripts


### PR DESCRIPTION
Closes #1246

## Summary

Fix a stale phase name left behind by the `verify` → `fix-checks` rename
(PR #1245, issue #1242).

The header comment in
`.claude/skills/dispatch-propagate/scripts/dispatch-mark-parse-job-done`
(line 10) still referred to the old `implement/verify` phase. That file was not
in PR #1245's diff, so the rename missed it. The comment now names the current
`implement/fix-checks` phase.

## Change

```
-# succeeded. Unlike an implement/verify phase, a clean parse-job produces NO PR:
+# succeeded. Unlike an implement/fix-checks phase, a clean parse-job produces NO PR:
```

Documentation-only — one word in one comment. No logic or behavior changes.

## Verification

- `grep -rn "implement/verify" .claude/` returns no matches — the stale
  reference is gone.
- `bash -n .claude/skills/dispatch-propagate/scripts/dispatch-mark-parse-job-done`
  parses cleanly; the script is unchanged below the header comment.
