### PR TITLE
scaffolding: explicit per-app SCAFFOLD markers for firestore.rules; stop re-sorting workspaces

### DIFF
--- a/scaffolding/firebase/internal/scaffold/cleanup.go
+++ b/scaffolding/firebase/internal/scaffold/cleanup.go
@@ -8,10 +8,17 @@ import (
 	"strings"
 )
 
-// RemoveFirestoreRules removes all rule blocks for appName from firestore.rules.
-// Rules are identified by path pattern (match /<appName>/...) rather than markers.
-// Each removed block also strips immediately preceding comment lines and adjacent blank lines.
-// If no rules are found, it logs a note and returns nil (not an error).
+// RemoveFirestoreRules removes the SCAFFOLD-marked rule block for appName from
+// firestore.rules. The block is the contiguous span between the
+// "// SCAFFOLD BEGIN <app>" and "// SCAFFOLD END <app>" marker lines (inclusive),
+// plus the single blank line that immediately follows END.
+//
+// Three boundary cases:
+//  1. BEGIN marker present  → the marker span is deleted.
+//  2. No BEGIN marker, but lines with prefix "match /<app>/" present → returns an
+//     error, because the rules exist without SCAFFOLD markers and so must be
+//     removed manually (this is the case for pre-marker apps).
+//  3. Neither marker nor prefix → logs a note and returns nil (not an error).
 func RemoveFirestoreRules(repoRoot, appName string) error {
 	rulesPath := filepath.Join(repoRoot, "firestore.rules")
 	content, err := os.ReadFile(rulesPath)
@@ -20,55 +27,48 @@ func RemoveFirestoreRules(repoRoot, appName string) error {
 	}
 
 	lines := strings.Split(string(content), "\n")
+	beginMarker := scaffoldBeginMarker(appName)
+	endMarker := scaffoldEndMarker(appName)
 	matchPrefix := "match /" + appName + "/"
 
-	var result []string
-	found := false
-	i := 0
-	for i < len(lines) {
-		if strings.HasPrefix(strings.TrimSpace(lines[i]), matchPrefix) {
-			found = true
-			// Pop preceding comment lines (e.g. "// Messages are publicly readable")
-			for len(result) > 0 && strings.HasPrefix(strings.TrimSpace(result[len(result)-1]), "//") {
-				result = result[:len(result)-1]
-			}
-			// Remove preceding blank line if present
-			if len(result) > 0 && strings.TrimSpace(result[len(result)-1]) == "" {
-				result = result[:len(result)-1]
-			}
-			// Skip block by counting braces
-			depth := 0
-			for i < len(lines) {
-				for _, ch := range lines[i] {
-					if ch == '{' {
-						depth++
-					}
-					if ch == '}' {
-						depth--
-					}
-				}
-				i++
-				if depth == 0 {
-					break
-				}
-			}
-			if depth != 0 {
-				return fmt.Errorf("unbalanced braces in rules block for %q (depth %d)", appName, depth)
-			}
-			// Skip trailing blank line after block
-			if i < len(lines) && strings.TrimSpace(lines[i]) == "" {
-				i++
-			}
-			continue
+	begin := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == beginMarker {
+			begin = i
+			break
 		}
-		result = append(result, lines[i])
-		i++
 	}
 
-	if !found {
+	if begin == -1 {
+		// No marker span. Distinguish a pre-marker app (rules present without
+		// markers) from a genuinely absent app.
+		for _, line := range lines {
+			if strings.HasPrefix(strings.TrimSpace(line), matchPrefix) {
+				return fmt.Errorf("rules for %q exist in firestore.rules but have no SCAFFOLD markers; remove the block manually", appName)
+			}
+		}
 		fmt.Printf("NOTE: no rules for %q found in firestore.rules\n", appName)
 		return nil
 	}
+
+	end := -1
+	for i := begin + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == endMarker {
+			end = i
+			break
+		}
+	}
+	if end == -1 {
+		return fmt.Errorf("found %q but no matching %q in firestore.rules", beginMarker, endMarker)
+	}
+
+	// Drop [begin..end] inclusive, plus one immediately-following blank line.
+	dropEnd := end + 1
+	if dropEnd < len(lines) && strings.TrimSpace(lines[dropEnd]) == "" {
+		dropEnd++
+	}
+
+	result := append(append([]string{}, lines[:begin]...), lines[dropEnd:]...)
 	return os.WriteFile(rulesPath, []byte(strings.Join(result, "\n")), 0o644)
 }
 

--- a/scaffolding/firebase/internal/scaffold/create.go
+++ b/scaffolding/firebase/internal/scaffold/create.go
@@ -180,6 +180,9 @@ func Create(repoRoot, appName string, templateFS fs.FS, dryRun bool) (err error)
 
 const firestoreRulesCatchAll = "// SCAFFOLD MARKER: deny-all catch-all. Do not edit or move this comment."
 
+func scaffoldBeginMarker(app string) string { return "// SCAFFOLD BEGIN " + app }
+func scaffoldEndMarker(app string) string   { return "// SCAFFOLD END " + app }
+
 // InsertFirestoreRules inserts a default rules block for appName into firestore.rules,
 // just before the deny-all catch-all rule. Rules use the literal app name as a
 // top-level path segment (e.g. match /myapp/{env}/messages/{messageId}).
@@ -192,12 +195,12 @@ func InsertFirestoreRules(repoRoot, appName string) error {
 
 	content := string(raw)
 
-	if strings.Contains(content, "match /"+appName+"/") {
+	if strings.Contains(content, "    "+scaffoldBeginMarker(appName)+"\n") {
 		fmt.Printf("NOTE: rules for %q already exist in firestore.rules, skipping insertion\n", appName)
 		return nil
 	}
 
-	block := fmt.Sprintf(
+	matchBlocks := fmt.Sprintf(
 		"    // Groups are readable only by their members (email-based membership).\n"+
 			"    // Uses resource.data directly instead of get() because getUserGroups\n"+
 			"    // performs a list query that Firestore cannot resolve with get() calls.\n"+
@@ -219,8 +222,13 @@ func InsertFirestoreRules(repoRoot, appName string) error {
 			"    match /%s/{env}/errors/{errorId} {\n"+
 			"      allow create: if isKnownErrorEnv(env) && isValidErrorLog();\n"+
 			"      allow read, update, delete: if false;\n"+
-			"    }\n\n",
+			"    }\n",
 		appName, appName, appName, appName)
+
+	block := "    " + scaffoldBeginMarker(appName) + "\n" +
+		matchBlocks +
+		"    " + scaffoldEndMarker(appName) + "\n" +
+		"\n"
 
 	catchAll := "    " + firestoreRulesCatchAll
 	idx := strings.Index(content, catchAll)

--- a/scaffolding/firebase/internal/scaffold/firebase.go
+++ b/scaffolding/firebase/internal/scaffold/firebase.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 )
 
@@ -148,8 +147,8 @@ func (c FirebaseConfig) MarshalJSON() ([]byte, error) {
 type ProjectTargets map[string]HostingSiteMap
 
 type FirebaseRC struct {
-	Projects map[string]string          `json:"projects"`
-	Targets  map[string]ProjectTargets  `json:"targets,omitempty"`
+	Projects map[string]string         `json:"projects"`
+	Targets  map[string]ProjectTargets `json:"targets,omitempty"`
 	// extra preserves unknown JSON keys during round-trip read/write.
 	extra map[string]json.RawMessage
 }
@@ -382,7 +381,7 @@ func WritePackageJSON(repoRoot string, pkg *PackageJSON) error {
 	return nil
 }
 
-// AddWorkspace inserts name into the workspaces array in sorted order.
+// AddWorkspace appends name to the workspaces array preserving existing order.
 // Returns an error if the workspace already exists.
 func AddWorkspace(pkg *PackageJSON, name string) error {
 	for _, w := range pkg.Workspaces {
@@ -391,7 +390,6 @@ func AddWorkspace(pkg *PackageJSON, name string) error {
 		}
 	}
 	pkg.Workspaces = append(pkg.Workspaces, name)
-	sort.Strings(pkg.Workspaces)
 	return nil
 }
 

--- a/scaffolding/firebase/internal/scaffold/firebase_test.go
+++ b/scaffolding/firebase/internal/scaffold/firebase_test.go
@@ -567,9 +567,9 @@ func TestAddAndRemoveWorkspace(t *testing.T) {
 	if len(pkg.Workspaces) != 3 {
 		t.Fatalf("expected 3 workspaces, got %d", len(pkg.Workspaces))
 	}
-	// Should be sorted: blog, demo, landing
-	if pkg.Workspaces[0] != "blog" || pkg.Workspaces[1] != "demo" || pkg.Workspaces[2] != "landing" {
-		t.Errorf("expected [blog demo landing], got %v", pkg.Workspaces)
+	// Should be appended: blog, landing, demo
+	if pkg.Workspaces[0] != "blog" || pkg.Workspaces[1] != "landing" || pkg.Workspaces[2] != "demo" {
+		t.Errorf("expected [blog landing demo], got %v", pkg.Workspaces)
 	}
 
 	removed := RemoveWorkspace(pkg, "demo")
@@ -594,7 +594,7 @@ func TestAddWorkspaceDuplicate(t *testing.T) {
 	}
 }
 
-func TestAddWorkspaceSorting(t *testing.T) {
+func TestAddWorkspaceAppendPreservesOrder(t *testing.T) {
 	pkg := &PackageJSON{
 		Workspaces: []string{"config", "landing", "style"},
 	}
@@ -602,7 +602,8 @@ func TestAddWorkspaceSorting(t *testing.T) {
 	if err := AddWorkspace(pkg, "blog"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected := []string{"blog", "config", "landing", "style"}
+	// config must stay first — this is the regression this test guards against.
+	expected := []string{"config", "landing", "style", "blog"}
 	if len(pkg.Workspaces) != len(expected) {
 		t.Fatalf("expected %d workspaces, got %d", len(expected), len(pkg.Workspaces))
 	}

--- a/scaffolding/firebase/internal/scaffold/rules_test.go
+++ b/scaffolding/firebase/internal/scaffold/rules_test.go
@@ -64,6 +64,21 @@ func TestInsertFirestoreRules(t *testing.T) {
 		if appIdx >= catchAllIdx {
 			t.Error("app rules should appear before catch-all")
 		}
+
+		beginIdx := strings.Index(got, "// SCAFFOLD BEGIN myapp")
+		endIdx := strings.Index(got, "// SCAFFOLD END myapp")
+		if beginIdx == -1 {
+			t.Error("expected SCAFFOLD BEGIN marker")
+		}
+		if endIdx == -1 {
+			t.Error("expected SCAFFOLD END marker")
+		}
+		if beginIdx >= catchAllIdx {
+			t.Error("BEGIN marker should appear before catch-all")
+		}
+		if beginIdx >= endIdx {
+			t.Error("BEGIN marker should appear before END marker")
+		}
 	})
 
 	t.Run("groups rule uses inline resource.data.members check", func(t *testing.T) {
@@ -141,10 +156,12 @@ func TestRemoveFirestoreRules(t *testing.T) {
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    // SCAFFOLD BEGIN myapp
     match /myapp/{env}/messages/{messageId} {
       allow read: if true;
       allow write: if false;
     }
+    // SCAFFOLD END myapp
 
     // SCAFFOLD MARKER: deny-all catch-all. Do not edit or move this comment.
     match /{document=**} {
@@ -177,22 +194,69 @@ service cloud.firestore {
 		}
 	})
 
-	t.Run("errors on unbalanced braces", func(t *testing.T) {
+	t.Run("errors when rules exist without markers", func(t *testing.T) {
 		rules := `rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
     match /myapp/{env}/messages/{messageId} {
       allow read: if true;
+      allow write: if false;
+    }
+
+    // SCAFFOLD MARKER: deny-all catch-all. Do not edit or move this comment.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}
 `
 		dir := writeRulesFile(t, t.TempDir(), rules)
 
 		err := RemoveFirestoreRules(dir, "myapp")
 		if err == nil {
-			t.Fatal("expected error for unbalanced braces")
+			t.Fatal("expected error for rules without SCAFFOLD markers")
 		}
-		if !strings.Contains(err.Error(), "unbalanced braces") {
-			t.Errorf("error should mention unbalanced braces, got: %v", err)
+		if !strings.Contains(err.Error(), "marker") {
+			t.Errorf("error should mention markers, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "manual") {
+			t.Errorf("error should mention manual removal, got: %v", err)
 		}
 	})
+}
+
+// TestInsertNotSkippedByStaleComment guards the insert/remove detection
+// asymmetry defect: a stray comment mentioning "match /myapp/" must NOT make
+// InsertFirestoreRules treat the app as already present and skip insertion.
+func TestInsertNotSkippedByStaleComment(t *testing.T) {
+	rules := `rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // historical note: match /myapp/ was here
+
+    // SCAFFOLD MARKER: deny-all catch-all. Do not edit or move this comment.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}
+`
+	dir := writeRulesFile(t, t.TempDir(), rules)
+
+	if err := InsertFirestoreRules(dir, "myapp"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := readRulesFile(t, dir)
+	if !strings.Contains(got, "// SCAFFOLD BEGIN myapp") {
+		t.Error("insert should not be skipped by a stale comment; expected BEGIN marker")
+	}
+	if !strings.Contains(got, "// SCAFFOLD END myapp") {
+		t.Error("insert should not be skipped by a stale comment; expected END marker")
+	}
+	if !strings.Contains(got, "match /myapp/{env}/messages/{messageId}") {
+		t.Error("expected real messages rule block to be inserted")
+	}
 }


### PR DESCRIPTION
Closes #1309

## What

Replace the heuristic `firestore.rules` text editing in
`scaffolding/firebase/internal/scaffold/` with explicit per-app
`// SCAFFOLD BEGIN <app>` / `// SCAFFOLD END <app>` markers, and stop
`AddWorkspace` from re-sorting the `workspaces` array on every scaffold.

## Why

Three confirmed defects in the scaffold's file-editing helpers:

1. **Brace counting included comments/strings** (`cleanup.go`):
   `RemoveFirestoreRules` skipped an app's block by counting `{`/`}` over every
   character. An unbalanced brace inside a comment or string would swallow
   subsequent blocks (other apps' rules, the catch-all marker) until rebalanced.

2. **Insert/remove detection asymmetry**: insert keyed on a whole-file
   `strings.Contains("match /<app>/")` while remove keyed on a line-prefix
   `match /<app>/`. A stray comment mentioning `match /myapp/` made insert skip
   while remove found nothing, so `Create` could report success having added no
   rules.

3. **`AddWorkspace` re-sorted** (`firebase.go`): `sort.Strings` reordered the
   whole `workspaces` array on every scaffold, discarding the deliberate
   `config`-first ordering in `package.json` and producing a noisy unrelated
   diff.

## How

- Insert wraps the generated block in `// SCAFFOLD BEGIN/END <app>` markers, and
  both insert's idempotency guard and remove's span detection now key on the same
  BEGIN marker — they are exact inverses (a byte-for-byte round-trip test guards
  this).
- Remove drops the `[BEGIN..END]` span inclusive plus the single trailing blank
  line, replacing the brace-counting loop. A three-case boundary keeps behavior
  safe for pre-marker apps: BEGIN present → span-remove; no marker but
  `match /<app>/` prefix lines present → clear error (rules exist without
  markers, manual removal required); neither → unchanged no-op. Existing app
  blocks (landing, budget, fellspiral, print, audio, office-hours) have no
  markers and cannot be retrofitted (their match blocks are non-contiguous), so
  marker-based removal governs only newly-scaffolded apps and the error branch
  surfaces the gap loudly rather than silently mis-editing.
- `AddWorkspace` appends without `sort.Strings`, preserving the existing order.

## Tests

`go test ./...` from `scaffolding/firebase` passes, including the byte-exact
insert→remove round-trip guard, a regression test that a stale `match /myapp/`
comment no longer makes insert skip, the no-marker error-boundary test, and an
`AddWorkspace` test asserting `config` stays first.
