### PR TITLE
storage.rules: extract isMemberOrPublic() helper to dedupe print/audio

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -1,8 +1,8 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
-    match /print/{env}/media/{fileName} {
-      allow read: if resource.metadata['publicdomain'] == 'true'
+    function isMemberOrPublic() {
+      return resource.metadata['publicdomain'] == 'true'
         || (request.auth != null && (
              // Unbounded membership: metadata mirrors the Firestore media doc's
              // memberEmails array (comma-joined). No member cap.
@@ -14,21 +14,13 @@ service firebase.storage {
              || ('member_1' in resource.metadata && resource.metadata['member_1'] == request.auth.token.email)
              || ('member_2' in resource.metadata && resource.metadata['member_2'] == request.auth.token.email)
            ));
+    }
+    match /print/{env}/media/{fileName} {
+      allow read: if isMemberOrPublic();
       allow write: if false;
     }
     match /audio/{env}/media/{fileName} {
-      allow read: if resource.metadata['publicdomain'] == 'true'
-        || (request.auth != null && (
-             // Unbounded membership: metadata mirrors the Firestore media doc's
-             // memberEmails array (comma-joined). No member cap.
-             ('member_emails' in resource.metadata
-               && request.auth.token.email in resource.metadata['member_emails'].split(','))
-             // Transitional fallback for objects uploaded under the legacy
-             // member_0/1/2 scheme (pre-#1301). Removable after a metadata migration.
-             || ('member_0' in resource.metadata && resource.metadata['member_0'] == request.auth.token.email)
-             || ('member_1' in resource.metadata && resource.metadata['member_1'] == request.auth.token.email)
-             || ('member_2' in resource.metadata && resource.metadata['member_2'] == request.auth.token.email)
-           ));
+      allow read: if isMemberOrPublic();
       allow write: if false;
     }
     match /{allPaths=**} {


### PR DESCRIPTION
Closes #1334

## What

Extract the shared membership check in `storage.rules` into an `isMemberOrPublic()`
rules helper and have both the `print/{env}/media/{fileName}` and
`audio/{env}/media/{fileName}` read blocks delegate to it.

Before this change the two blocks were byte-identical except for the path prefix,
following #1328's expansion of each to an unbounded `member_emails` check plus
three legacy `member_0/1/2` clauses. Every rules change had to be applied in both
places.

## How

- Defined `function isMemberOrPublic()` inside the `match /b/{bucket}/o` scope,
  before the two media match blocks. `resource`/`request` are in scope there, so
  service-level placement is unnecessary.
- Replaced each block's inline `allow read: if …` (12 lines) with
  `allow read: if isMemberOrPublic();`.
- Left both `allow write: if false;` lines and the `match /{allPaths=**}`
  deny-all catch-all untouched.

The function body is lifted verbatim from the existing inline logic — including
the explanatory comments — so behavior is byte-for-byte identical. This is a pure
maintenance refactor with no correctness impact.

## Verification

The `rules-test` Storage suite is not in CI and was run manually via
`.claude/skills/dispatch-propagate/scripts/run-rules-test.sh`, which boots the
Firestore+Storage emulators (emulator startup also validates `storage.rules`
syntax) and runs vitest:

- Emulator booted without a rules-syntax error, validating the new
  `isMemberOrPublic()` definition.
- Full suite passed: 21 test files, 437 tests green — including
  `test/storage/print-media.test.ts` and `test/storage/audio-media.test.ts`
  (publicdomain, `member_emails` with >3 members, legacy `member_0/1/2`,
  non-member denial, unauthenticated denial, write-denied) — with no edits to
  the spec files.

`git diff --stat` shows only `storage.rules` changed (6 insertions, 14
deletions).

This PR is rules-only, satisfying the standalone-rules-PR convention in
`.claude/docs/firestore.md`.
