### PR TITLE
utils: unify error reporting via a global handler in createAppContext

### DIFF
--- a/analyticsutil/src/index.ts
+++ b/analyticsutil/src/index.ts
@@ -6,6 +6,7 @@ import {
 } from "firebase/analytics";
 import type { FirebaseApp } from "firebase/app";
 import { classifyError } from "@commons-systems/errorutil/classify";
+import { logError } from "@commons-systems/errorutil/log";
 import { onLCP, onCLS, onINP, onFCP, onTTFB, type Metric } from "web-vitals";
 
 const STORAGE_KEY = "analytics_traffic_type";
@@ -88,10 +89,11 @@ function reportWebVitals(analytics: Analytics): void {
       });
     } catch (error) {
       if (classifyError(error) === "programmer") throw error;
-      reportError(
+      logError(
         new Error(
           `Failed to log web-vital (metric: ${metric.name}): ${error instanceof Error ? error.message : error}`,
         ),
+        { operation: "analytics-web-vitals" },
       );
     }
   }
@@ -108,10 +110,11 @@ export function initAnalyticsSafe(app: FirebaseApp): (path: string) => void {
     return initAnalytics(app);
   } catch (error) {
     if (classifyError(error) === "programmer") throw error;
-    reportError(
+    logError(
       new Error(
         `Failed to initialize analytics (appId: ${app.options.appId}, measurementId: ${app.options.measurementId}): ${error instanceof Error ? error.message : error}`,
       ),
+      { operation: "analytics-init" },
     );
     return () => {};
   }
@@ -131,10 +134,11 @@ export function initAnalytics(app: FirebaseApp): (path: string) => void {
     trafficType = applyTrafficTag();
   } catch (error) {
     if (classifyError(error) === "programmer") throw error;
-    reportError(
+    logError(
       new Error(
         `Failed to apply traffic tag: ${error instanceof Error ? error.message : error}`,
       ),
+      { operation: "analytics-traffic-tag" },
     );
   }
 
@@ -152,10 +156,11 @@ export function initAnalytics(app: FirebaseApp): (path: string) => void {
       logEvent(analytics, "page_view", { page_path: path });
     } catch (error) {
       if (classifyError(error) === "programmer") throw error;
-      reportError(
+      logError(
         new Error(
           `Failed to log page view (path: ${path}): ${error instanceof Error ? error.message : error}`,
         ),
+        { operation: "analytics-page-view" },
       );
     }
   };

--- a/analyticsutil/test/index.test.ts
+++ b/analyticsutil/test/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { FirebaseApp } from "firebase/app";
+import { registerErrorSink, type ErrorSink } from "@commons-systems/errorutil/log";
 
 vi.mock("firebase/analytics", () => ({
   initializeAnalytics: vi.fn(() => ({ app: {} })),
@@ -22,12 +23,6 @@ import {
   initAnalyticsSafe,
   __resetWebVitalsRegistrationForTest,
 } from "../src/index";
-
-// reportError is a browser API not available in Node — stub it so tests that
-// don't mock it fail loudly rather than silently swallowing errors.
-globalThis.reportError ??= (error: unknown) => {
-  throw error;
-};
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -94,7 +89,9 @@ describe("initAnalytics", () => {
   });
 
   it("reports error when logEvent throws", () => {
-    const reportErrorSpy = vi.spyOn(globalThis, "reportError").mockImplementation(() => {});
+    const sink: ErrorSink = vi.fn();
+    registerErrorSink(sink);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never);
     const badStateError = new Error("bad state");
     vi.mocked(logEvent).mockImplementation(() => {
@@ -105,12 +102,14 @@ describe("initAnalytics", () => {
     const tracker = initAnalytics(app);
 
     expect(() => tracker("/about")).not.toThrow();
-    const reported = reportErrorSpy.mock.calls[0][0] as Error;
+    const reported = (vi.mocked(sink).mock.calls[0][0] as Error);
     expect(reported.message).toBe(
       "Failed to log page view (path: /about): bad state",
     );
+    expect(sink).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ operation: "analytics-page-view" }));
 
-    reportErrorSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    registerErrorSink(undefined);
   });
 
   it("re-throws TypeError from logEvent", () => {
@@ -234,7 +233,9 @@ describe("traffic tagging", () => {
   });
 
   it("continues with organic tag when localStorage throws", () => {
-    const reportErrorSpy = vi.spyOn(globalThis, "reportError").mockImplementation(() => {});
+    const sink: ErrorSink = vi.fn();
+    registerErrorSink(sink);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     setLocation("https://example.com/page?_ct=internal");
     vi.spyOn(localStorage, "setItem").mockImplementation(() => {
       throw new DOMException("The operation is insecure.", "SecurityError");
@@ -244,9 +245,11 @@ describe("traffic tagging", () => {
     expect(setUserProperties).toHaveBeenCalledWith(expect.anything(), {
       traffic_type: "organic",
     });
-    const reported = reportErrorSpy.mock.calls[0][0] as Error;
+    const reported = (vi.mocked(sink).mock.calls[0][0] as Error);
     expect(reported.message).toContain("Failed to apply traffic tag");
-    reportErrorSpy.mockRestore();
+    expect(sink).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ operation: "analytics-traffic-tag" }));
+    consoleErrorSpy.mockRestore();
+    registerErrorSink(undefined);
     vi.mocked(localStorage.setItem).mockRestore();
   });
 
@@ -356,7 +359,9 @@ describe("web-vitals reporting", () => {
   });
 
   it("reports non-programmer logEvent error without propagating", () => {
-    const reportErrorSpy = vi.spyOn(globalThis, "reportError").mockImplementation(() => {});
+    const sink: ErrorSink = vi.fn();
+    registerErrorSink(sink);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never);
     const networkError = new Error("network failure");
     vi.mocked(logEvent).mockImplementation(() => {
@@ -374,12 +379,14 @@ describe("web-vitals reporting", () => {
     } as unknown as Parameters<typeof capturedCallback>[0];
 
     expect(() => capturedCallback(fakeMetric)).not.toThrow();
-    const reported = reportErrorSpy.mock.calls[0][0] as Error;
+    const reported = (vi.mocked(sink).mock.calls[0][0] as Error);
     expect(reported.message).toBe(
       "Failed to log web-vital (metric: LCP): network failure",
     );
+    expect(sink).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ operation: "analytics-web-vitals" }));
 
-    reportErrorSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    registerErrorSink(undefined);
   });
 
   it("re-throws TypeError from logEvent inside web-vital callback", () => {
@@ -404,7 +411,9 @@ describe("web-vitals reporting", () => {
 
 describe("initAnalyticsSafe", () => {
   it("returns no-op and reports error when initializeAnalytics throws", () => {
-    const reportErrorSpy = vi.spyOn(globalThis, "reportError").mockImplementation(() => {});
+    const sink: ErrorSink = vi.fn();
+    registerErrorSink(sink);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const cspError = new Error("CSP blocked");
     vi.mocked(initializeAnalytics).mockImplementation(() => {
       throw cspError;
@@ -413,15 +422,17 @@ describe("initAnalyticsSafe", () => {
     const app = { options: { measurementId: "G-TEST", appId: "1:test:web:abc" } } as unknown as FirebaseApp;
     const tracker = initAnalyticsSafe(app);
 
-    const reported = reportErrorSpy.mock.calls[0][0] as Error;
+    const reported = (vi.mocked(sink).mock.calls[0][0] as Error);
     expect(reported.message).toBe(
       "Failed to initialize analytics (appId: 1:test:web:abc, measurementId: G-TEST): CSP blocked",
     );
+    expect(sink).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ operation: "analytics-init" }));
 
     tracker("/about");
     expect(logEvent).not.toHaveBeenCalled();
 
-    reportErrorSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    registerErrorSink(undefined);
   });
 
   it("re-throws TypeError from initializeAnalytics", () => {

--- a/analyticsutil/test/index.test.ts
+++ b/analyticsutil/test/index.test.ts
@@ -29,6 +29,15 @@ beforeEach(() => {
   __resetWebVitalsRegistrationForTest();
 });
 
+afterEach(() => {
+  // Restore any spies (e.g. console.error) created in test bodies so a thrown
+  // assertion before an inline restore cannot leak a mock into later tests.
+  vi.restoreAllMocks();
+  // Clear the module-level error sink so a test that does not register its own
+  // sink cannot observe a previous test's stale vi.fn().
+  registerErrorSink(undefined);
+});
+
 describe("initAnalytics", () => {
   it("returns no-op tracker and logs debug when measurementId is missing", () => {
     const consoleDebugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
@@ -91,7 +100,7 @@ describe("initAnalytics", () => {
   it("reports error when logEvent throws", () => {
     const sink: ErrorSink = vi.fn();
     registerErrorSink(sink);
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never);
     const badStateError = new Error("bad state");
     vi.mocked(logEvent).mockImplementation(() => {
@@ -107,9 +116,6 @@ describe("initAnalytics", () => {
       "Failed to log page view (path: /about): bad state",
     );
     expect(sink).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ operation: "analytics-page-view" }));
-
-    consoleErrorSpy.mockRestore();
-    registerErrorSink(undefined);
   });
 
   it("re-throws TypeError from logEvent", () => {
@@ -235,7 +241,7 @@ describe("traffic tagging", () => {
   it("continues with organic tag when localStorage throws", () => {
     const sink: ErrorSink = vi.fn();
     registerErrorSink(sink);
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
     setLocation("https://example.com/page?_ct=internal");
     vi.spyOn(localStorage, "setItem").mockImplementation(() => {
       throw new DOMException("The operation is insecure.", "SecurityError");
@@ -248,9 +254,6 @@ describe("traffic tagging", () => {
     const reported = (vi.mocked(sink).mock.calls[0][0] as Error);
     expect(reported.message).toContain("Failed to apply traffic tag");
     expect(sink).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ operation: "analytics-traffic-tag" }));
-    consoleErrorSpy.mockRestore();
-    registerErrorSink(undefined);
-    vi.mocked(localStorage.setItem).mockRestore();
   });
 
   it("calls setUserProperties before returning the tracker", () => {
@@ -361,7 +364,7 @@ describe("web-vitals reporting", () => {
   it("reports non-programmer logEvent error without propagating", () => {
     const sink: ErrorSink = vi.fn();
     registerErrorSink(sink);
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never);
     const networkError = new Error("network failure");
     vi.mocked(logEvent).mockImplementation(() => {
@@ -384,9 +387,6 @@ describe("web-vitals reporting", () => {
       "Failed to log web-vital (metric: LCP): network failure",
     );
     expect(sink).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ operation: "analytics-web-vitals" }));
-
-    consoleErrorSpy.mockRestore();
-    registerErrorSink(undefined);
   });
 
   it("re-throws TypeError from logEvent inside web-vital callback", () => {
@@ -413,7 +413,7 @@ describe("initAnalyticsSafe", () => {
   it("returns no-op and reports error when initializeAnalytics throws", () => {
     const sink: ErrorSink = vi.fn();
     registerErrorSink(sink);
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
     const cspError = new Error("CSP blocked");
     vi.mocked(initializeAnalytics).mockImplementation(() => {
       throw cspError;
@@ -430,9 +430,6 @@ describe("initAnalyticsSafe", () => {
 
     tracker("/about");
     expect(logEvent).not.toHaveBeenCalled();
-
-    consoleErrorSpy.mockRestore();
-    registerErrorSink(undefined);
   });
 
   it("re-throws TypeError from initializeAnalytics", () => {

--- a/errorutil/package.json
+++ b/errorutil/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.ts",
     "./classify": "./src/classify.ts",
     "./defer": "./src/defer.ts",
+    "./global-handler": "./src/global-handler.ts",
     "./log": "./src/log.ts"
   },
   "scripts": {

--- a/errorutil/src/global-handler.ts
+++ b/errorutil/src/global-handler.ts
@@ -1,0 +1,76 @@
+import { logError } from "./log.ts";
+
+/**
+ * Minimal structural types for the global error/rejection events. The errorutil
+ * tsconfig uses lib `ES2022` with no DOM, so the DOM `ErrorEvent`,
+ * `PromiseRejectionEvent`, and `EventTarget` types are unavailable here (the
+ * codebase casts around this rather than adding the DOM lib — see
+ * `self as unknown` in firebaseutil's app-context.ts). These local interfaces
+ * capture only the fields the handlers read, and keep both the production
+ * `globalThis` target and an injected test target assignable.
+ */
+interface ErrorEventLike {
+  /** The thrown value. Null for cross-origin "Script error." events. */
+  error?: unknown;
+  /** Fallback message string when `error` is absent. */
+  message?: string;
+}
+
+interface PromiseRejectionEventLike {
+  /** The rejection reason. */
+  reason?: unknown;
+}
+
+interface ErrorEventTarget {
+  addEventListener(type: string, listener: (event: unknown) => void): void;
+  removeEventListener(type: string, listener: (event: unknown) => void): void;
+}
+
+/**
+ * Install global handlers that route otherwise-untelemetered errors through
+ * {@link logError} (and thus the registered Firestore sink). This catches three
+ * classes that the global `reportError()` and bare `throw`s would otherwise
+ * leave console-only:
+ *
+ *   - `reportError(e)` dispatches an `error` event on the global scope.
+ *   - `setTimeout(() => { throw e })` surfaces as an uncaught `error` event.
+ *   - an unhandled promise rejection fires `unhandledrejection`.
+ *
+ * The `error` listener is registered in the default (non-capture) phase: the
+ * capture phase also catches resource-load failures on `<img>`/`<script>`,
+ * which would flood the sink.
+ *
+ * No infinite-loop risk: the Firestore sink swallows its async write failure
+ * (`addDoc(...).catch(...)`) and `logError` wraps the synchronous sink call in
+ * try/catch.
+ *
+ * @param target Global scope to attach to. Defaults to the ambient global
+ *   (`globalThis`), which works in both window and worker scopes. Injectable
+ *   for testing.
+ * @returns A disposer that removes both listeners. Required for test hygiene so
+ *   repeated `createAppContext` calls don't accumulate listeners and double-log.
+ */
+export function installGlobalErrorHandlers(
+  target: ErrorEventTarget = globalThis as unknown as ErrorEventTarget,
+): () => void {
+  function onError(event: unknown): void {
+    const e = event as ErrorEventLike;
+    // Cross-origin "Script error." events have a null `.error`; fall back to
+    // the message string so something useful still reaches telemetry.
+    const err = e.error ?? e.message;
+    logError(err, { operation: "uncaught" });
+  }
+
+  function onUnhandledRejection(event: unknown): void {
+    const e = event as PromiseRejectionEventLike;
+    logError(e.reason, { operation: "unhandledrejection" });
+  }
+
+  target.addEventListener("error", onError);
+  target.addEventListener("unhandledrejection", onUnhandledRejection);
+
+  return () => {
+    target.removeEventListener("error", onError);
+    target.removeEventListener("unhandledrejection", onUnhandledRejection);
+  };
+}

--- a/errorutil/src/index.ts
+++ b/errorutil/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Error-reporting convention: prefer `logError` over bare `reportError` in any
+ * package that depends on errorutil, and in all apps. See `log.ts` for the
+ * full convention, including the sanctioned exception for zero-dep packages.
+ */
 export { classifyError, type ErrorKind } from "./classify.ts";
 export { deferProgrammerError } from "./defer.ts";
 export { logError, registerErrorSink, type ErrorContext, type EnrichedErrorContext, type ErrorSink } from "./log.ts";

--- a/errorutil/src/index.ts
+++ b/errorutil/src/index.ts
@@ -1,3 +1,4 @@
 export { classifyError, type ErrorKind } from "./classify.ts";
 export { deferProgrammerError } from "./defer.ts";
 export { logError, registerErrorSink, type ErrorContext, type EnrichedErrorContext, type ErrorSink } from "./log.ts";
+export { installGlobalErrorHandlers } from "./global-handler.ts";

--- a/errorutil/src/log.ts
+++ b/errorutil/src/log.ts
@@ -21,6 +21,16 @@ export function registerErrorSink(s: ErrorSink | undefined): void {
 }
 
 /**
+ * Convention: prefer `logError` in any package that depends on `errorutil`,
+ * and in all apps. Bare global `reportError` is permitted ONLY in packages
+ * that do not depend on `errorutil` (e.g. `idbutil`). In those packages, the
+ * global handler installed by `createAppContext` (`installGlobalErrorHandlers`,
+ * in `errorutil/src/global-handler.ts`) catches the dispatched `error` event
+ * and records it via `logError` under `operation: "uncaught"`, so the error
+ * still reaches the Firestore sink — just without a specific operation label.
+ */
+
+/**
  * Log an error with structured context. Always writes to console.error for
  * local visibility, then forwards to the registered sink (e.g., Firestore)
  * if one exists. Synchronous sink failures are caught here. Async sinks

--- a/errorutil/test/global-handler.test.ts
+++ b/errorutil/test/global-handler.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { installGlobalErrorHandlers } from "../src/global-handler.js";
+import { registerErrorSink } from "../src/log.js";
+
+/**
+ * Minimal stand-in for the global EventTarget. Stores listeners per type and
+ * lets a test dispatch a plain event object. errorutil's tsconfig has no DOM
+ * lib, and the production handler reads only `.error`/`.message`/`.reason`, so
+ * a real `ErrorEvent`/`PromiseRejectionEvent` is unnecessary — and
+ * `PromiseRejectionEvent` is not even constructible in the test env.
+ */
+class MockTarget {
+  private listeners = new Map<string, Set<(event: unknown) => void>>();
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  dispatch(type: string, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+describe("installGlobalErrorHandlers", () => {
+  beforeEach(() => {
+    registerErrorSink(undefined);
+    vi.restoreAllMocks();
+  });
+
+  it("forwards an uncaught error event's .error to logError", () => {
+    const sink = vi.fn();
+    registerErrorSink(sink);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const target = new MockTarget();
+    installGlobalErrorHandlers(target);
+
+    const err = new Error("boom");
+    target.dispatch("error", { error: err });
+
+    expect(sink).toHaveBeenCalledWith(
+      err,
+      expect.objectContaining({ operation: "uncaught" }),
+    );
+  });
+
+  it("falls back to the message string when .error is null", () => {
+    const sink = vi.fn();
+    registerErrorSink(sink);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const target = new MockTarget();
+    installGlobalErrorHandlers(target);
+
+    expect(() =>
+      target.dispatch("error", { error: null, message: "Script error." }),
+    ).not.toThrow();
+
+    expect(sink).toHaveBeenCalledWith(
+      "Script error.",
+      expect.objectContaining({ operation: "uncaught" }),
+    );
+  });
+
+  it("forwards an unhandledrejection event's .reason to logError", () => {
+    const sink = vi.fn();
+    registerErrorSink(sink);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const target = new MockTarget();
+    installGlobalErrorHandlers(target);
+
+    const reason = new Error("rejected");
+    target.dispatch("unhandledrejection", { reason });
+
+    expect(sink).toHaveBeenCalledWith(
+      reason,
+      expect.objectContaining({ operation: "unhandledrejection" }),
+    );
+  });
+
+  it("disposer removes both listeners", () => {
+    const sink = vi.fn();
+    registerErrorSink(sink);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const target = new MockTarget();
+    const dispose = installGlobalErrorHandlers(target);
+    dispose();
+
+    target.dispatch("error", { error: new Error("boom") });
+    target.dispatch("unhandledrejection", { reason: new Error("rejected") });
+
+    expect(sink).not.toHaveBeenCalled();
+  });
+});

--- a/firebaseutil/src/app-context.ts
+++ b/firebaseutil/src/app-context.ts
@@ -12,6 +12,7 @@ import type { FirebaseStorage } from "firebase/storage";
 import type { User } from "firebase/auth";
 import { classifyError } from "@commons-systems/errorutil/classify";
 import { logError, registerErrorSink } from "@commons-systems/errorutil/log";
+import { installGlobalErrorHandlers } from "@commons-systems/errorutil/global-handler";
 import type { DeferredAppAuth } from "@commons-systems/authutil/deferred-app-auth";
 import { firebaseConfig } from "./config.js";
 import {
@@ -294,6 +295,10 @@ export function createAppContext(
       getCurrentUser: errorSinkGetCurrentUser,
     }),
   );
+
+  // Route uncaught errors, unhandled promise rejections, and bare
+  // reportError() calls through logError → the Firestore sink just registered.
+  installGlobalErrorHandlers();
 
   const trackPageView = initAnalyticsSafe(app);
 

--- a/firebaseutil/src/app-context.ts
+++ b/firebaseutil/src/app-context.ts
@@ -96,6 +96,12 @@ interface AppContextOptions {
   enableAuth?: boolean;
 }
 
+// Disposer for the global error/unhandledrejection handlers installed by the
+// most recent createAppContext call. Re-invoked before re-installing so repeated
+// calls (hot-module reload, framework re-init, tests) don't accumulate listeners
+// and double-log uncaught errors into the Firestore sink.
+let disposeGlobalHandlers: (() => void) | undefined;
+
 /**
  * Create a Firebase app context with Firestore, analytics, optional AppCheck, and optional Storage.
  *
@@ -133,12 +139,6 @@ export function createAppContext(
   appId: string,
   options?: AppContextOptions,
 ): AppContextBase;
-// Disposer for the global error/unhandledrejection handlers installed by the
-// most recent createAppContext call. Re-invoked before re-installing so repeated
-// calls (hot-module reload, framework re-init, tests) don't accumulate listeners
-// and double-log uncaught errors into the Firestore sink.
-let disposeGlobalHandlers: (() => void) | undefined;
-
 export function createAppContext(
   appName: string,
   appId: string,

--- a/firebaseutil/src/app-context.ts
+++ b/firebaseutil/src/app-context.ts
@@ -133,6 +133,12 @@ export function createAppContext(
   appId: string,
   options?: AppContextOptions,
 ): AppContextBase;
+// Disposer for the global error/unhandledrejection handlers installed by the
+// most recent createAppContext call. Re-invoked before re-installing so repeated
+// calls (hot-module reload, framework re-init, tests) don't accumulate listeners
+// and double-log uncaught errors into the Firestore sink.
+let disposeGlobalHandlers: (() => void) | undefined;
+
 export function createAppContext(
   appName: string,
   appId: string,
@@ -298,7 +304,10 @@ export function createAppContext(
 
   // Route uncaught errors, unhandled promise rejections, and bare
   // reportError() calls through logError → the Firestore sink just registered.
-  installGlobalErrorHandlers();
+  // Dispose any handlers from a prior createAppContext call first so repeated
+  // calls self-correct instead of accumulating listeners and double-logging.
+  disposeGlobalHandlers?.();
+  disposeGlobalHandlers = installGlobalErrorHandlers();
 
   const trackPageView = initAnalyticsSafe(app);
 

--- a/firebaseutil/test/app-context.test.ts
+++ b/firebaseutil/test/app-context.test.ts
@@ -84,6 +84,8 @@ describe("createAppContext", () => {
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
     vi.stubEnv("MODE", "production");
+    vi.stubGlobal("addEventListener", vi.fn());
+    vi.stubGlobal("removeEventListener", vi.fn());
   });
 
   it("returns correct shape without storage option", async () => {

--- a/firebaseutil/test/app-context.test.ts
+++ b/firebaseutil/test/app-context.test.ts
@@ -100,6 +100,20 @@ describe("createAppContext", () => {
     expect(ctx).not.toHaveProperty("STORAGE_NAMESPACE");
   });
 
+  it("installs global error and unhandledrejection handlers", async () => {
+    const { createAppContext } = await loadModule();
+    createAppContext("myapp", "app-id-123");
+
+    expect(globalThis.addEventListener).toHaveBeenCalledWith(
+      "error",
+      expect.any(Function),
+    );
+    expect(globalThis.addEventListener).toHaveBeenCalledWith(
+      "unhandledrejection",
+      expect.any(Function),
+    );
+  });
+
   it("initializes Firestore with persistentLocalCache when no emulator", async () => {
     const { createAppContext } = await loadModule();
     const mocks = await loadMocks();

--- a/idbutil/src/connection.ts
+++ b/idbutil/src/connection.ts
@@ -91,6 +91,11 @@ export function createDbConnection(config: DbConnectionConfig): {
         const db = await pending;
         db.close();
       } catch (err) {
+        // Sanctioned bare reportError: idbutil is zero-dep and a sibling of
+        // errorutil (not below it), so it cannot call logError directly. The
+        // global handler installed by createAppContext (installGlobalErrorHandlers)
+        // catches this dispatched error event and records it to Firestore under
+        // operation "uncaught".
         reportError(new Error("closeDb: failed to close database connection", { cause: err }));
       }
     }

--- a/idbutil/src/lru-blob-cache.ts
+++ b/idbutil/src/lru-blob-cache.ts
@@ -89,6 +89,8 @@ export function createLruBlobCache(config: LruBlobCacheConfig): LruBlobCache {
       }
     };
     tx.onerror = () => {
+      // Sanctioned bare reportError — see connection.ts for the full rationale;
+      // the global handler records it under operation "uncaught".
       reportError(new Error("Failed to touch lastAccessed", { cause: tx.error }));
     };
   }

--- a/router/src/hydrate.ts
+++ b/router/src/hydrate.ts
@@ -1,4 +1,5 @@
 import { deferProgrammerError } from "@commons-systems/errorutil/defer";
+import { logError } from "@commons-systems/errorutil/log";
 
 /*
  * Hydration pattern selection guide
@@ -24,7 +25,7 @@ import { deferProgrammerError } from "@commons-systems/errorutil/defer";
  * Sets `el.dataset.hydrated` to "true" on success, "error" on failure.
  * Programmer errors are deferred as uncaught errors (same convention as the
  * router's afterRender handling). Other errors are passed to `onError` if
- * provided, or reported via `reportError`.
+ * provided, or reported via `logError`.
  */
 export function hydrateOnce(
   root: ParentNode,
@@ -43,7 +44,7 @@ export function hydrateOnce(
     if (onError) {
       onError(error, el);
     } else {
-      reportError(error);
+      logError(error, { operation: "router-hydrate" });
     }
   }
 }

--- a/router/src/index.ts
+++ b/router/src/index.ts
@@ -1,4 +1,5 @@
 import { deferProgrammerError } from "@commons-systems/errorutil/defer";
+import { logError } from "@commons-systems/errorutil/log";
 
 export interface Route {
   /**
@@ -23,7 +24,7 @@ export interface Route {
 }
 
 export interface RouterOptions {
-  /** Called with the parsed path and query params at the start of each navigation, before route matching. Exceptions do not prevent the route from rendering. Programmer errors are deferred as uncaught errors; other exceptions are caught and reported via reportError. */
+  /** Called with the parsed path and query params at the start of each navigation, before route matching. Exceptions do not prevent the route from rendering. Programmer errors are deferred as uncaught errors; other exceptions are caught and reported via `logError`. */
   onNavigate?: (nav: { path: string; params: URLSearchParams }) => void;
   /** Map an error to a user-facing message. Return undefined to use "Something went wrong. Please try again." */
   formatError?: (error: unknown) => string | undefined;
@@ -64,7 +65,7 @@ function createNavigator(
     try {
       options?.onNavigate?.({ path, params });
     } catch (e) {
-      if (!deferProgrammerError(e)) reportError(e);
+      if (!deferProgrammerError(e)) logError(e, { operation: "router-onNavigate" });
     }
     const route = matchRoute(routes, path) ?? routes[0];
     try {
@@ -75,7 +76,7 @@ function createNavigator(
           route.afterRender?.(outlet, path);
         } catch (afterError) {
           if (deferProgrammerError(afterError)) return;
-          reportError(afterError);
+          logError(afterError, { operation: "router-afterRender" });
           outlet.insertAdjacentHTML(
             "beforeend",
             "<p>Some content failed to load. Try refreshing.</p>",
@@ -83,7 +84,7 @@ function createNavigator(
         }
       }
     } catch (error) {
-      if (!deferProgrammerError(error)) reportError(error);
+      if (!deferProgrammerError(error)) logError(error, { operation: "router-render" });
       if (id === navigationId) {
         const message =
           options?.formatError?.(error) ??

--- a/router/test/hydrate.test.ts
+++ b/router/test/hydrate.test.ts
@@ -1,20 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { hydrateOnce, isOutletCurrent } from "../src/hydrate";
+import { registerErrorSink, type ErrorSink } from "@commons-systems/errorutil/log";
 
 describe("hydrateOnce", () => {
   let root: HTMLDivElement;
-  let reportErrorSpy: ReturnType<typeof vi.spyOn>;
+  let sink: ErrorSink;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     root = document.createElement("div");
-    if (typeof globalThis.reportError !== "function") {
-      globalThis.reportError = () => {};
-    }
-    reportErrorSpy = vi.spyOn(globalThis, "reportError").mockImplementation(() => {});
+    sink = vi.fn() as ErrorSink;
+    registerErrorSink(sink);
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
-    reportErrorSpy.mockRestore();
+    registerErrorSink(undefined);
+    consoleErrorSpy.mockRestore();
   });
 
   it("calls hydrate and sets dataset.hydrated to true", () => {
@@ -71,6 +73,7 @@ describe("hydrateOnce", () => {
       expect(onError).not.toHaveBeenCalled();
       expect(deferredErrors).toHaveLength(1);
       expect(deferredErrors[0]).toBeInstanceOf(TypeError);
+      expect(sink).not.toHaveBeenCalled();
     } finally {
       vi.mocked(globalThis.setTimeout).mockRestore();
     }
@@ -93,16 +96,17 @@ describe("hydrateOnce", () => {
       expect(onError).not.toHaveBeenCalled();
       expect(deferredErrors).toHaveLength(1);
       expect(deferredErrors[0]).toBeInstanceOf(ReferenceError);
+      expect(sink).not.toHaveBeenCalled();
     } finally {
       vi.mocked(globalThis.setTimeout).mockRestore();
     }
   });
 
-  it("falls back to reportError when no onError provided", () => {
+  it("falls back to logError when no onError provided", () => {
     root.innerHTML = '<div id="target"></div>';
     const error = new Error("boom");
     hydrateOnce(root, "#target", () => { throw error; });
-    expect(reportErrorSpy).toHaveBeenCalledWith(error);
+    expect(sink).toHaveBeenCalledWith(error, expect.objectContaining({ operation: "router-hydrate" }));
   });
 });
 

--- a/router/test/router.test.ts
+++ b/router/test/router.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { parsePath, createHistoryRouter, type Route, type Router } from "../src/index";
+import { registerErrorSink, type ErrorSink } from "@commons-systems/errorutil/log";
 
 const escapeHtml = (s: string): string =>
   s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -29,6 +30,7 @@ describe("createHistoryRouter", () => {
   let routes: [Route, ...Route[]];
   let router: Router;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let sink: ErrorSink;
 
   beforeEach(() => {
     history.pushState({}, "", "/");
@@ -38,16 +40,14 @@ describe("createHistoryRouter", () => {
       { path: "/about", render: () => "<h2>About</h2>" },
     ];
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    if (typeof globalThis.reportError !== "function") {
-      globalThis.reportError = () => {};
-    }
-    vi.spyOn(globalThis, "reportError").mockImplementation(() => {});
+    sink = vi.fn() as ErrorSink;
+    registerErrorSink(sink);
   });
 
   afterEach(() => {
     router?.destroy();
     consoleErrorSpy.mockRestore();
-    vi.mocked(globalThis.reportError).mockRestore();
+    registerErrorSink(undefined);
   });
 
   it("renders default route", async () => {
@@ -227,6 +227,7 @@ describe("createHistoryRouter", () => {
     await vi.waitFor(() => {
       expect(outlet.innerHTML).toBe("<p>Something went wrong. Please try again.</p>");
     });
+    expect(sink).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ operation: "router-render" }));
   });
 
   it("formatError returns custom message", async () => {
@@ -357,6 +358,7 @@ describe("createHistoryRouter", () => {
       expect(outlet.innerHTML).toContain("<h2>Home</h2>");
       expect(outlet.innerHTML).toContain("Some content failed to load");
     });
+    expect(sink).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ operation: "router-afterRender" }));
   });
 
   it("afterRender TypeError/ReferenceError deferred", async () => {
@@ -382,6 +384,7 @@ describe("createHistoryRouter", () => {
       });
       expect(deferredErrors).toHaveLength(1);
       expect(deferredErrors[0]).toBeInstanceOf(TypeError);
+      expect(sink).not.toHaveBeenCalled();
     } finally {
       vi.mocked(globalThis.setTimeout).mockRestore();
     }
@@ -394,6 +397,7 @@ describe("createHistoryRouter", () => {
     await vi.waitFor(() => {
       expect(outlet.innerHTML).toBe("<h2>Home</h2>");
     });
+    expect(sink).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ operation: "router-onNavigate" }));
   });
 
   it("onNavigate TypeError/ReferenceError deferred", async () => {
@@ -414,6 +418,7 @@ describe("createHistoryRouter", () => {
       });
       expect(deferredErrors).toHaveLength(1);
       expect(deferredErrors[0]).toBeInstanceOf(TypeError);
+      expect(sink).not.toHaveBeenCalled();
     } finally {
       vi.mocked(globalThis.setTimeout).mockRestore();
     }


### PR DESCRIPTION
Closes #1293

## Summary

Unifies error reporting across the monorepo so every error class reaches the
Firestore `errors` sink, addressing the two channels that previously bypassed it:
bare `reportError()` calls (console-only) and uncaught/deferred programmer errors
(no telemetry at all).

The load-bearing change is a single global handler installed in
`createAppContext`. The global `reportError()` dispatches an `error` event on the
global scope; `setTimeout(() => { throw e })` (how `deferProgrammerError` surfaces
programmer errors) shows up as an uncaught `error` event; an unhandled promise
rejection fires `unhandledrejection`. One `addEventListener("error")` +
`addEventListener("unhandledrejection")` pair therefore catches all three classes
and routes them through `logError` to the just-registered Firestore sink. This
net alone satisfies both acceptance criteria; the per-site `logError` conversions
improve telemetry quality with real `operation` labels.

## Changes

**Unit 1 — global handler (the unifying net).**
- New `errorutil/src/global-handler.ts` exporting
  `installGlobalErrorHandlers(target?)`: a non-capture `error` listener (capture
  phase would also catch resource-load failures on `<img>`/`<script>` and flood
  the sink) that logs `event.error ?? event.message` under `operation: "uncaught"`
  (the message fallback covers cross-origin "Script error." events whose `.error`
  is `null`), plus an `unhandledrejection` listener logging `event.reason` under
  `operation: "unhandledrejection"`. Returns a disposer removing both listeners
  for test hygiene. No re-entrancy guard — none is needed: the Firestore sink
  swallows its async write failure (`addDoc(...).catch(...)`) and `logError` wraps
  the synchronous sink call in try/catch, so no escaping rejection can re-enter
  the handler.
- Exported from `errorutil` (root + a `./global-handler` subpath mirroring
  `./log`), and called in `firebaseutil/src/app-context.ts` immediately after the
  Firestore sink is registered.
- New `errorutil/test/global-handler.test.ts` covers the real-`.error`, null-error
  message-fallback, `unhandledrejection`, and disposer cases.

**Unit 2 — convert errorutil-dependent call sites.** Replaced bare `reportError`
with `logError({ operation })` in `router/src/index.ts` (`router-onNavigate`,
`router-afterRender`, `router-render`), `router/src/hydrate.ts`
(`router-hydrate`), and `analyticsutil/src/index.ts` (`analytics-web-vitals`,
`analytics-init`, `analytics-traffic-tag`, `analytics-page-view`). The
programmer-error / `reportError` branches were already mutually exclusive at each
site, so no double-logging is introduced. Updated the affected JSDoc and switched
the `router` / `analyticsutil` suites from `reportError` spies to a registered
spy sink, asserting the `operation` label.

**Unit 3 — document the convention.** Recorded the convention in
`errorutil/src/log.ts` and `errorutil/src/index.ts`: prefer `logError` in any
package that depends on `errorutil` and in all apps; bare global `reportError` is
permitted only in packages that do not depend on `errorutil`, where the global
handler records it under `operation: "uncaught"`. `idbutil` is the sanctioned
exception — zero-dep, a sibling of `errorutil`, internal-only — so it keeps bare
`reportError` (its Error message is preserved and the global net carries it to
Firestore); the rationale is noted inline at both idbutil call sites.

## Deferred (not in scope)

A `no-restricted-globals` lint rule banning `reportError` is the stronger reading
of "enforce", but the shared ESLint config (`config/eslint.config.js`,
re-exported by every package) is a sandbox-protected path, and a global ban there
is wrong — it would flag the intentional `idbutil`/`print`/`budget` exceptions.
Documentation satisfies the acceptance criterion ("the convention is
documented"); a per-package lint rule is left as a possible follow-up.

## Verification

- `npm test --prefix errorutil` (new global-handler suite + existing), `npm test
  --prefix router` (50/50), `npm test --prefix analyticsutil` (25/25) — all green.
- Typecheck of the changed packages adds zero new errors over the pre-existing
  DOM-lib-missing baseline (errorutil clean; router lost 3 `reportError`-not-found
  errors from the conversion).
- End-to-end browser verification (trigger a render failure and a
  `self.reportError(new Error("smoke"))`, confirm documents land in the Firestore
  `errors` collection with the expected `operation`) is the QA step and is not
  run here.
