### PR TITLE
print: clearSearch() aborts an in-flight EPUB search

### DIFF
--- a/print/src/viewer/epub.ts
+++ b/print/src/viewer/epub.ts
@@ -348,6 +348,9 @@ export function createEpubRenderer(
     },
 
     clearSearch(): void {
+      // Stand down any in-flight search(): bumping the epoch trips its post-loop
+      // guard (search ~line 318) so it applies no highlights for the cleared query.
+      _searchEpoch++;
       clearSearchHighlights();
     },
 

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -890,6 +890,37 @@ describe("createEpubRenderer", () => {
         renderer.clearSearch!();
         expect(mockRendition.annotations.remove).not.toHaveBeenCalled();
       });
+
+      it("aborts an in-flight search so its highlights never appear after clearSearch", async () => {
+        // One section whose load parks on a gate; find returns a match.
+        const section: FakeSection = {
+          href: "ch0.xhtml",
+          unload: vi.fn(),
+          find: vi.fn().mockReturnValue([{ cfi: "cfi-A", excerpt: "fox" }]),
+          load: vi.fn() as ReturnType<typeof vi.fn>,
+        };
+        let releaseFirst!: () => void;
+        const gate = new Promise<void>((resolve) => { releaseFirst = resolve; });
+        section.load.mockImplementationOnce(() => gate);
+        mockSpine.spineItems = [section];
+        mockBook.navigation.get.mockReturnValue({ label: "X" });
+
+        const renderer = await initRenderer();
+
+        // Start the search — it parks on the gated section.load().
+        const p = renderer.search!("fox");
+
+        // Clear the search while parked.
+        renderer.clearSearch!();
+
+        // Release the gate so the in-flight search resumes and hits the epoch guard.
+        releaseFirst();
+        await p;
+
+        // The aborted search must not have painted any highlights.
+        const highlightCfis = mockRendition.annotations.highlight.mock.calls.map((c) => c[0]);
+        expect(highlightCfis).not.toContain("cfi-A");
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #1805

## Problem

The EPUB viewer's `clearSearch()` did not abort an in-flight `search()`, so
clearing the search box while a search was still running could let stale
highlights re-paint for the abandoned query.

`search()` (`print/src/viewer/epub.ts`) captures `epoch = ++_searchEpoch` at
entry, runs the spine loop (which can park on a slow `section.load()`), then
guards its highlight burst with `if (epoch !== _searchEpoch) return results;`.
`clearSearch()` only called `clearSearchHighlights()` — it never bumped
`_searchEpoch`. So emptying the search box removed the current highlights, but
the in-flight search then completed, saw an unchanged epoch, and re-painted
highlights for the cleared query. The results list stayed empty (guarded in
`search.ts`), but stale highlights remained visible.

## Fix

`clearSearch()` now bumps `_searchEpoch` before clearing highlights. Any
in-flight `search()` trips its existing post-loop guard and returns early
without a highlight burst. This reuses the monotonic epoch mechanism the
overlapping-search guard already honors — no new state or signal is introduced.
`destroy()`'s `_searchEpoch = 0` reset is unaffected.

## Test

Adds a regression test in `print/test/viewer/epub.test.ts`, inside the existing
`clearSearch` block, modeled on the overlapping-search test: it gates a
section's `load()`, starts a search that parks on the gate, calls
`clearSearch()` while parked, releases the gate, and asserts no highlight is
painted for the abandoned query's cfi. Verified fail-first — the test red-fails
against the unfixed `clearSearch()` and passes with the fix.
