### PR TITLE
dispatch: make auto-merge the default (invert the config gate to opt-out)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-auto-merge
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-auto-merge
@@ -18,11 +18,12 @@
 # reviewed conflict-free PR auto-merges regardless of whether it closes a bug,
 # security, or enhancement issue.
 #
-# Config gate (off by default): read from dispatch-config-load auto-merge.
-#   - no config file  → `no-config` → exit 0 with no output (current human-merge
-#                       behavior preserved).
-#   - file present but .enabled != true → exit 0 with no output.
-#   - .enabled == true → arm auto-merging.
+# Config gate (ON by default): read from dispatch-config-load auto-merge. The
+# config file is an opt-OUT kill-switch (incident response), inverting the usual
+# absent→inert convention.
+#   - no config file  → `no-config` → armed (auto-merging is the default).
+#   - file present, .enabled == false → exit 0 with no output (kill-switch).
+#   - file present, .enabled == true → armed (redundant with the default).
 #
 # Merge: gh pr merge <n> --squash with explicit --subject (the PR title) and
 # --body (the PR body), so the non-TTY squash is deterministic and the
@@ -55,9 +56,13 @@ CFG=$("$SCRIPT_DIR/dispatch-config-load" auto-merge) || {
   echo "dispatch-auto-merge: error: dispatch-config-load auto-merge failed" >&2
   exit 1
 }
-[[ "$CFG" == "no-config" ]] && exit 0
-ENABLED=$(jq -r '.enabled' <<<"$CFG")
-[[ "$ENABLED" == "true" ]] || exit 0
+# Default ON: an absent config file arms auto-merging. The file exists only as
+# an opt-OUT kill-switch (incident response). When present, enabled:false turns
+# the reconciler off; enabled:true (the redundant explicit form) keeps it on.
+if [[ "$CFG" != "no-config" ]]; then
+  ENABLED=$(jq -r '.enabled' <<<"$CFG")
+  [[ "$ENABLED" == "false" ]] && exit 0
+fi
 
 # ---- Step 2: one fresh fetch of every open PR -------------------------------
 # Never proceed on a partial fetch — a truncated snapshot could merge a PR whose

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
@@ -216,7 +216,7 @@
 #
 # Top-level object gating the dispatch-auto-merge reconciler. Read by
 # dispatch-auto-merge. UNLIKE every other config type, auto-merge INVERTS the
-# generic absent→inert convention documented above (lines 14-18): an absent file
+# generic absent→inert convention documented above (see "Stdout protocol"): an absent file
 # → no-config → ARMED (auto-merge is ON by default). The file exists only as an
 # opt-OUT kill-switch for incident response.
 #

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
@@ -215,13 +215,16 @@
 # ---- Schema: auto-merge.json -----------------------------------------------
 #
 # Top-level object gating the dispatch-auto-merge reconciler. Read by
-# dispatch-auto-merge; absent file → no-config → the reconciler is inert and the
-# current human-merge behavior is preserved.
+# dispatch-auto-merge. UNLIKE every other config type, auto-merge INVERTS the
+# generic absent→inert convention documented above (lines 14-18): an absent file
+# → no-config → ARMED (auto-merge is ON by default). The file exists only as an
+# opt-OUT kill-switch for incident response.
 #
-#   enabled       boolean (required) — master switch. false (or no file) keeps
-#                 the feature off; only true arms auto-merging.
+#   enabled       boolean (required when the file is present) — kill-switch.
+#                 false turns auto-merging off; true (redundant with the absent-
+#                 file default) keeps it on.
 #
-# Example (see auto-merge.example.json):
+# Example (see auto-merge.example.json) — the kill-switch form:
 #   {
 #     "enabled": false
 #   }

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -290,8 +290,9 @@ fi
 # OPEN_MB is definitively empty — i.e. main health is known-good. It is suppressed
 # both while main is broken (OPEN_MB lists open main-broken issues, from Step 1c)
 # and when main health is UNKNOWN (the Step 1c gh issue list failed): a transient
-# gh failure must not defeat this load-bearing safety gate. Inert unless
-# dispatch.config/auto-merge.json enables it; absent config → no-op.
+# gh failure must not defeat this load-bearing safety gate. Auto-merge is ON by
+# default; dispatch.config/auto-merge.json is an opt-OUT kill-switch
+# (enabled:false suppresses it).
 if [[ -z "$OPEN_MB" ]]; then
   MERGE_OUT=$("$SCRIPT_DIR/dispatch-auto-merge") || true
   if [[ -n "$MERGE_OUT" ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -30694,16 +30694,16 @@ assert_eq "disabled: no merge call" "absent" "$(log_state gh-pr-merge.log)"
 assert_eq "disabled: no PR fetch" "absent" "$(log_state gh-auto-merge-pr-list.log)"
 teardown
 
-# --- 14. absent config → no-op (no fetch) ------------------------------------
-echo "Test: absent config → no-op, no fetch"
+# --- 14. absent config → armed (merges) --------------------------------------
+echo "Test: absent config → armed (merges)"
 setup
 # Deliberately do NOT write config/auto-merge.json.
 printf '[%s]' "$(make_auto_merge_pr 50 false MERGEABLE "$GREEN_ROLLUP" "$AM_REVIEWED" '[{"number":100}]')" \
   > "$STUB_DIR/auto-merge-pr-list.json"
 out=$("$TMPDIR_TEST/dispatch-auto-merge" 2>/dev/null)
-assert_eq "no-config: no stdout" "" "$out"
-assert_eq "no-config: no merge call" "absent" "$(log_state gh-pr-merge.log)"
-assert_eq "no-config: no PR fetch" "absent" "$(log_state gh-auto-merge-pr-list.log)"
+assert_eq "no-config: stdout is 'merged #50'" "merged #50" "$out"
+assert_eq "no-config: gh pr merge log present" "present" "$(log_state gh-pr-merge.log)"
+assert_eq "no-config: PR fetch present" "present" "$(log_state gh-auto-merge-pr-list.log)"
 teardown
 
 # --- 15. multi-PR independence -----------------------------------------------


### PR DESCRIPTION
Closes #1820

## What

Inverts the `dispatch-auto-merge` config gate so that **auto-merge is ON by
default**. An absent `dispatch.config/auto-merge.json` now arms the reconciler
instead of leaving it inert. The config file becomes an **opt-OUT kill-switch**
for incident response rather than an opt-in enabler.

The three config states are now:

- **no file** → armed (the default)
- **file present, `.enabled == false`** → off (the kill-switch) — unchanged
- **file present, `.enabled == true`** → armed (redundant with the default) —
  unchanged

## Why

`dispatch-auto-merge` (tick Step 1d, #1739) squash-merges every PR that reaches
the dispatch ready state (`isDraft==false ∧ dispatch:reviewed ∧ CI passing ∧
mergeable==MERGEABLE`, plus a non-empty `Closes #N` guard). #1739 deliberately
shipped it inert behind an explicit opt-in as a trust ramp. It has since been
armed in production, so the opt-in default is now backwards: a fresh checkout or
new environment silently reverts to hand-merging until someone recreates the
config file. Auto-merging green, reviewed, conflict-free PRs is the intended
steady state, so absent config should mean ON.

The only behavior change is the no-config case (previously a no-op). The
`enabled`-when-present semantics are unchanged, and the kill-switch is retained
so auto-merging to `main` stays reversible during an incident.

## Changes

- **Unit 1** — invert the gate in `dispatch-auto-merge`: an absent config arms
  the reconciler; only an explicit `enabled:false` (file present) exits early.
  Header comment rewritten to describe the inverted default. Test 14 inverted
  (absent config → merges); Test 13 (`enabled:false` → no-op kill-switch)
  unchanged. Full dispatch script suite passes (2994/2994).
- **Unit 2** — docs updated to match: the Step 1d comment in
  `dispatch-select-tick` and the auto-merge schema in `dispatch-config-load` now
  describe the opt-OUT kill-switch, calling out that auto-merge inverts the
  generic absent→inert config convention (which still holds for every other
  config type). `auto-merge.example.json` stays `{"enabled": false}` as the
  canonical kill-switch example.

## Note on the production config

The `dispatch.config/auto-merge.json {"enabled": true}` added in production to
arm the feature is now redundant with the default ON behavior, but harmless to
leave in place. It is safe to delete.
