### PR TITLE
print: enforce renderResult on searchable renderers via SearchableRenderer interface

### DIFF
--- a/print/src/viewer/epub.ts
+++ b/print/src/viewer/epub.ts
@@ -1,5 +1,5 @@
 import ePub, { type Book, type Rendition, type Location, type NavItem } from "epubjs";
-import type { ContentRenderer, OutlineEntry, SearchResult } from "./types.js";
+import type { OutlineEntry, SearchableRenderer, SearchResult } from "./types.js";
 
 // epubjs ships incomplete type declarations. These narrow shapes describe the
 // runtime members we use that are missing from the .d.ts, following the
@@ -26,7 +26,7 @@ const ACTIVE_STYLES = { fill: "#f59e0b", "fill-opacity": "0.5" };
 
 export function createEpubRenderer(
   onError?: (err: unknown) => void,
-): ContentRenderer {
+): SearchableRenderer {
   let book: Book | null = null;
   let rendition: Rendition | null = null;
   let containerDiv: HTMLDivElement | null = null;
@@ -369,6 +369,10 @@ export function createEpubRenderer(
       annotations.highlight(result.location, {}, undefined, "viewer-search-active", ACTIVE_STYLES);
       _activeCfi = result.location;
     },
+
+    // EPUB renders the armed result directly inside goToResult (rendition.display);
+    // there is no separate single-page render step (no spread mode). Documented no-op.
+    async renderResult(): Promise<void> {},
 
     clearSearch(): void {
       // Stand down any in-flight search(): bumping the epoch trips its post-loop

--- a/print/src/viewer/pdf.ts
+++ b/print/src/viewer/pdf.ts
@@ -2,7 +2,7 @@ import * as pdfjsLib from "pdfjs-dist";
 import { TextLayer } from "pdfjs-dist";
 import type { PDFDocumentProxy, PDFPageProxy, RenderTask } from "pdfjs-dist";
 import type { PageViewport } from "pdfjs-dist/types/src/display/display_utils.js";
-import type { ContentRenderer, OutlineEntry, SearchResult } from "./types.js";
+import type { OutlineEntry, SearchableRenderer, SearchResult } from "./types.js";
 import { parsePositionPage } from "./types.js";
 import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 
@@ -137,7 +137,7 @@ export function offsetToDivRanges(
   return segments;
 }
 
-export function createPdfRenderer(onError?: (err: unknown) => void): ContentRenderer {
+export function createPdfRenderer(onError?: (err: unknown) => void): SearchableRenderer {
   let pdfDoc: PDFDocumentProxy | null = null;
   let _currentPage = 0;
   let _pageCount = 0;

--- a/print/src/viewer/search.ts
+++ b/print/src/viewer/search.ts
@@ -1,5 +1,5 @@
 import { escapeHtml } from "@commons-systems/htmlutil";
-import type { ContentRenderer, SearchResult } from "./types.js";
+import type { SearchableRenderer, SearchResult } from "./types.js";
 
 export function renderSearchSection(): string {
   return `
@@ -30,10 +30,9 @@ function renderResultItem(result: SearchResult, index: number): string {
 
 export function initSearch(
   container: HTMLElement,
-  renderer: ContentRenderer,
+  renderer: SearchableRenderer,
   onNavigate: () => void,
-): (() => void) | null {
-  if (!renderer.search || !renderer.goToResult) return null;
+): () => void {
   const search = renderer.search;
   const goToResult = renderer.goToResult;
 
@@ -86,7 +85,7 @@ export function initSearch(
     currentQuery = trimmed;
 
     if (!trimmed) {
-      renderer.clearSearch?.();
+      renderer.clearSearch();
       clearResults();
       return;
     }
@@ -101,7 +100,7 @@ export function initSearch(
     if (searchTimer) clearTimeout(searchTimer);
     if (!input.value.trim()) {
       currentQuery = "";
-      renderer.clearSearch?.();
+      renderer.clearSearch();
       clearResults();
       return;
     }

--- a/print/src/viewer/shell.ts
+++ b/print/src/viewer/shell.ts
@@ -1,7 +1,7 @@
 import { escapeHtml } from "@commons-systems/htmlutil";
 import type { MediaItem } from "../types.js";
 import type { ContentRenderer } from "./types.js";
-import { clampGoToPage } from "./types.js";
+import { clampGoToPage, isSearchable } from "./types.js";
 import { SpreadController } from "./spread-controller.js";
 import type { PositionStore } from "../sidecar.js";
 import type { Bookmark } from "../bookmarks.js";
@@ -453,14 +453,16 @@ export function initViewer(
       }
     }
     initGoto();
-    searchCleanup = initSearch(viewer, renderer, () => {
-      if (controller.enabled) {
-        controller.goToPage(renderer.currentPage).catch(handleRenderError);
-      } else {
-        renderer.renderResult?.().catch(handleRenderError);
-      }
-      updateNav();
-    });
+    if (isSearchable(renderer)) {
+      searchCleanup = initSearch(viewer, renderer, () => {
+        if (controller.enabled) {
+          controller.goToPage(renderer.currentPage).catch(handleRenderError);
+        } else {
+          renderer.renderResult().catch(handleRenderError);
+        }
+        updateNav();
+      });
+    }
     outlineCleanup = initOutline(viewer, renderer, () => updateNav());
     const bookmarksStore = uid && !readFailed
       ? {

--- a/print/src/viewer/types.ts
+++ b/print/src/viewer/types.ts
@@ -45,8 +45,11 @@ export interface ContentRenderer {
   readonly isZoomed?: boolean;
   onZoomChange?: () => void;
   /**
-   * Renderers implementing search must also implement goToResult and
-   * clearSearch, and implement renderResult to render the armed highlight.
+   * Optional search surface. A renderer that supports search should implement
+   * the SearchableRenderer contract (all four methods required); these stay
+   * optional here so non-searchable renderers (image-archive) and generic
+   * `clearSearch?.()` call sites compile unchanged. Use isSearchable() to narrow
+   * a ContentRenderer to SearchableRenderer at call sites that need all four.
    */
   search?(query: string): Promise<SearchResult[]>;
   goToResult?(result: SearchResult): Promise<void>;
@@ -56,6 +59,38 @@ export interface ContentRenderer {
   getOutline?(): Promise<OutlineEntry[]>;
   goToOutlineEntry?(entry: OutlineEntry): Promise<void>;
   destroy(): void;
+}
+
+/**
+ * A ContentRenderer that supports full-text search. Re-declares the four search
+ * methods as REQUIRED (TypeScript lets a sub-interface promote an optional
+ * member to required), so a concrete searchable renderer that omits any of them
+ * is a compile error rather than a silent `renderResult?.()` no-op.
+ */
+export interface SearchableRenderer extends ContentRenderer {
+  search(query: string): Promise<SearchResult[]>;
+  goToResult(result: SearchResult): Promise<void>;
+  /**
+   * Render the armed result in single-page mode. A renderer whose goToResult
+   * already renders the result (no spread mode / no renderPageInto) implements
+   * this as a documented no-op; an arm-only renderer (whose goToResult only
+   * arms a pending highlight) MUST render the armed result here.
+   */
+  renderResult(): Promise<void>;
+  clearSearch(): void;
+}
+
+/**
+ * Runtime type guard narrowing a ContentRenderer to SearchableRenderer by
+ * checking that all four search methods are present.
+ */
+export function isSearchable(r: ContentRenderer): r is SearchableRenderer {
+  return (
+    typeof r.search === "function" &&
+    typeof r.goToResult === "function" &&
+    typeof r.renderResult === "function" &&
+    typeof r.clearSearch === "function"
+  );
 }
 
 /**

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -946,5 +946,25 @@ describe("createEpubRenderer", () => {
         expect(highlightCfis).not.toContain("cfi-A");
       });
     });
+
+    describe("renderResult", () => {
+      it("is exposed as a method on the renderer", async () => {
+        const renderer = await initRenderer();
+        expect(typeof renderer.renderResult).toBe("function");
+      });
+
+      it("is a harmless no-op: resolves without throwing and does not call rendition.display", async () => {
+        const renderer = await initRenderer();
+
+        // Record display call count before renderResult — it may already have
+        // been called during init (initial display). Only new calls would matter.
+        const displayCallsBefore = mockRendition.display.mock.calls.length;
+
+        await expect(renderer.renderResult()).resolves.toBeUndefined();
+
+        // renderResult must not trigger an additional rendition.display call.
+        expect(mockRendition.display.mock.calls.length).toBe(displayCallsBefore);
+      });
+    });
   });
 });

--- a/print/test/viewer/search.test.ts
+++ b/print/test/viewer/search.test.ts
@@ -14,11 +14,12 @@ function makeSearchResult(overrides: Partial<SearchResult> = {}): SearchResult {
   };
 }
 
-/** Renderer with search/goToResult/clearSearch wired up. Pass `search` override to control results. */
+/** Renderer with all four SearchableRenderer methods. Pass overrides to control results. */
 function makeSearchableRenderer(overrides: Partial<ContentRenderer> = {}) {
   return makeMockRenderer({
     search: vi.fn().mockResolvedValue([]),
     goToResult: vi.fn().mockResolvedValue(undefined),
+    renderResult: vi.fn().mockResolvedValue(undefined),
     clearSearch: vi.fn(),
     ...overrides,
   });
@@ -70,40 +71,18 @@ describe("initSearch", () => {
     vi.mocked(globalThis.reportError).mockRestore();
   });
 
-  it("returns null when renderer lacks search method", () => {
-    const renderer = makeMockRenderer();
-    const result = initSearch(container, renderer, vi.fn());
-    expect(result).toBeNull();
-  });
-
-  it("returns null when renderer has search but lacks goToResult", () => {
-    const renderer = makeMockRenderer({
-      search: vi.fn().mockResolvedValue([]),
-    });
-    const result = initSearch(container, renderer, vi.fn());
-    expect(result).toBeNull();
-  });
-
-  it("returns a cleanup function when renderer has search", () => {
+  it("returns a cleanup function", () => {
     const renderer = makeSearchableRenderer();
     const result = initSearch(container, renderer, vi.fn());
     expect(typeof result).toBe("function");
   });
 
-  it("removes search-hidden class when renderer has search", () => {
+  it("removes search-hidden class", () => {
     const renderer = makeSearchableRenderer();
     initSearch(container, renderer, vi.fn());
 
     const section = container.querySelector(".viewer-search") as HTMLElement;
     expect(section.classList.contains("search-hidden")).toBe(false);
-  });
-
-  it("search-hidden class remains when renderer lacks search", () => {
-    const renderer = makeMockRenderer();
-    initSearch(container, renderer, vi.fn());
-
-    const section = container.querySelector(".viewer-search") as HTMLElement;
-    expect(section.classList.contains("search-hidden")).toBe(true);
   });
 
   it("calls renderer.search after 300ms debounce on input", async () => {

--- a/print/test/viewer/searchable-renderer.test-d.ts
+++ b/print/test/viewer/searchable-renderer.test-d.ts
@@ -1,0 +1,25 @@
+/**
+ * Compile-time contract: a renderer missing renderResult is NOT assignable to
+ * SearchableRenderer. This file is included in tsconfig.json (not in vitest's
+ * test glob) so tsc enforces it on every `npm run build`.
+ *
+ * Vacuity: temporarily add `renderResult: async () => {}` to the literal below
+ * and verify tsc reports the @ts-expect-error directive as UNUSED — confirming
+ * the sole cause of the error is the missing method.
+ */
+import type { ContentRenderer, SearchableRenderer } from "../../src/viewer/types";
+
+// Pin the exact SearchableRenderer signatures so no other type mismatch can
+// satisfy the @ts-expect-error vacuously.
+declare const _base: ContentRenderer;
+const _search: SearchableRenderer["search"] = async () => [];
+const _goToResult: SearchableRenderer["goToResult"] = async () => {};
+const _clearSearch: SearchableRenderer["clearSearch"] = () => {};
+
+// @ts-expect-error: a renderer missing renderResult is not assignable to SearchableRenderer
+export const _missingRenderResult: SearchableRenderer = {
+  ..._base,
+  search: _search,
+  goToResult: _goToResult,
+  clearSearch: _clearSearch,
+};

--- a/print/test/viewer/shell.test.ts
+++ b/print/test/viewer/shell.test.ts
@@ -439,6 +439,7 @@ describe("initViewer", () => {
     const renderer = makeMockRenderer({
       search: vi.fn().mockResolvedValue([]),
       goToResult: vi.fn().mockResolvedValue(undefined),
+      renderResult: vi.fn().mockResolvedValue(undefined),
       clearSearch: vi.fn(),
     });
 
@@ -481,6 +482,24 @@ describe("initViewer", () => {
 
     // Should NOT write — the read failed, so the saved state is unknown.
     expect(store.save).not.toHaveBeenCalled();
+  });
+
+  it("non-searchable renderer (missing renderResult) keeps search-hidden — isSearchable gate skips initSearch", async () => {
+    // A renderer with search/goToResult/clearSearch but NO renderResult does not
+    // satisfy isSearchable(), so shell.ts must not wire search. The .viewer-search
+    // panel must remain hidden.
+    const renderer = makeMockRenderer({
+      search: vi.fn().mockResolvedValue([]),
+      goToResult: vi.fn().mockResolvedValue(undefined),
+      clearSearch: vi.fn(),
+      // renderResult intentionally absent — this is the non-searchable case
+    });
+
+    initViewer(outlet, () => renderer, () => Promise.resolve("https://example.com/doc.pdf"), "m1", fakeStore(), null);
+    await flushInit();
+
+    const searchSection = outlet.querySelector(".viewer-search") as HTMLElement;
+    expect(searchSection.classList.contains("search-hidden")).toBe(true);
   });
 });
 
@@ -987,6 +1006,7 @@ describe("initViewer spread mode", () => {
     const renderer = makeMockSpreadRenderer({
       search: vi.fn().mockResolvedValue([result]),
       goToResult: vi.fn().mockImplementation(async () => { await renderer.goToPage(4); }),
+      renderResult: vi.fn().mockResolvedValue(undefined),
       clearSearch: vi.fn(),
     });
     initViewer(outlet, () => renderer, () => Promise.resolve("https://example.com/doc.pdf"), "m1", fakeStore(), null);

--- a/print/tsconfig.json
+++ b/print/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "@commons-systems/config/tsconfig.app.json",
-  "include": ["src"]
+  "include": ["src", "test/viewer/searchable-renderer.test-d.ts"]
 }


### PR DESCRIPTION
Closes #1817

## Problem

`print/src/viewer/shell.ts` called `renderer.renderResult?.()` after a search-result
click. The optional chain silently no-ops when a renderer omits `renderResult`, so a
future searchable renderer that arms a highlight in `goToResult` but forgets
`renderResult` would silently break result-click rendering with no compile-time signal.

## Approach

Turn the obligation into a compile-time contract for the concrete searchable renderers,
without changing PDF or EPUB behavior.

- **`types.ts`** — added `SearchableRenderer extends ContentRenderer` that re-declares
  the four search methods (`search`, `goToResult`, `renderResult`, `clearSearch`) as
  **required**. The four members stay **optional** on the `ContentRenderer` base so
  `image-archive.ts` (no search) and the shell's generic `clearSearch?.()` nav sites
  compile unchanged. Added an `isSearchable(r): r is SearchableRenderer` runtime type
  guard and a doc comment on `SearchableRenderer.renderResult` documenting the
  arm-only-must-render vs. renders-in-`goToResult`-may-no-op contract.
- **`pdf.ts`** — `createPdfRenderer` now returns `SearchableRenderer`. PDF already
  implemented all four methods (arm-only `goToResult` + shell-driven `renderResult`),
  so this is a type-only change.
- **`epub.ts`** — `createEpubRenderer` now returns `SearchableRenderer`, which
  compile-forces an explicit documented no-op `renderResult`. EPUB's `goToResult`
  renders directly via `rendition.display(...)` and EPUB has no spread mode, so the
  no-op is correct (and now declared rather than silently absent).
- **`shell.ts`** — the search wiring is gated on `isSearchable(renderer)`, narrowing
  `renderer` to `SearchableRenderer` inside the closure, so the post-click call drops
  its optional chain: `renderer.renderResult()` instead of `renderer.renderResult?.()`.
  Behavior is unchanged — `initSearch` already returned `null` for non-searchable
  renderers via its own guard, so gating on `isSearchable` is equivalent.
- **`search.ts`** — `initSearch` now takes a `SearchableRenderer` and returns
  `() => void`; its now-redundant `!renderer.search || !renderer.goToResult` presence
  guard is removed (formalized by `isSearchable` at the call site).

## Tests

- A type-level `// @ts-expect-error` fixture (`searchable-renderer.test-d.ts`, compiled
  by the build's `tsc`) proves a renderer with `search`/`goToResult`/`clearSearch` but
  no `renderResult` is **not** assignable to `SearchableRenderer` — locking in
  acceptance criterion #1. The fixture pins method signatures via indexed types so the
  error can only come from the missing `renderResult` (verified: removing the directive
  makes `tsc` fail; adding a no-op `renderResult` makes the directive report unused).
- `epub.test.ts` asserts EPUB exposes `renderResult` and that calling it is a harmless
  no-op (does not throw, does not re-render), with result-click navigate+highlight
  behavior unchanged.
- `shell.test.ts` / `search.test.ts` assert the search callback calls `renderResult()`
  unconditionally on a searchable single-page renderer and that the `isSearchable` gate
  skips wiring for a non-searchable renderer.

## Verification

- `npm run build --prefix print` passes — `tsc` compiles the `@ts-expect-error` fixture
  (and fails if it is removed).
- `shell.ts` calls `renderer.renderResult()` with no optional chain (criterion #2).
- `npx vitest run --root print` — the viewer search suites (epub/shell/search) pass.
  The pdf/spread test files fail to *collect* locally due to a pre-existing
  environmental denial of the `pdfjs-dist/.../pdf.worker.min.mjs?url` import (unrelated
  to this change); CI is authoritative for those.

## Note on the issue premise

The issue stated EPUB and image-archive renderers "do not implement search." That is
outdated — EPUB full-document search (#1688) merged before this issue. EPUB implements
`search`/`goToResult`/`clearSearch` and its `renderResult` no-op is correct;
image-archive has no search and is out of scope. The design here reflects that: both
searchable renderers now *declare* `renderResult`, and the silent-omission trap is a
compile error for the concrete renderers.
