### PR TITLE
dispatch: add a manual force-Opus config toggle

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
@@ -7,7 +7,7 @@
 # the normalized result to stdout.
 #
 # Usage:
-#   dispatch-config-load <projects|jit|statements|target-workers|budget-etl|epic>
+#   dispatch-config-load <projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus>
 #
 # Config files live in <project-root>/dispatch.config/. The project root is
 # resolved via resolve_project_root (lib.sh).
@@ -229,6 +229,24 @@
 #     "enabled": false
 #   }
 #
+# ---- Schema: force-opus.json ------------------------------------------------
+#
+# Top-level object gating a manual Opus override for dispatch-spawned workers.
+# This config type follows the GENERIC absent→inert convention (see "Stdout
+# protocol" above): when the file is absent, no-config is emitted and the
+# feature is OFF (inert) — workers use their normal model. Do NOT confuse this
+# with auto-merge, which INVERTS that convention (absent → ON). force-opus
+# does NOT invert; absent means OFF.
+#
+#   enabled       boolean (required when the file is present) — opt-in toggle.
+#                 true forces all dispatch-spawned workers onto Opus; false
+#                 (or file absent) leaves model selection at the default.
+#
+# Example (see force-opus.example.json) — the opt-in form:
+#   {
+#     "enabled": true
+#   }
+#
 set -euo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
@@ -237,9 +255,9 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 CONFIG_TYPE="${1:-}"
 case "$CONFIG_TYPE" in
-  projects|jit|statements|target-workers|budget-etl|epic|auto-merge) ;;
+  projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus) ;;
   *)
-    echo "error: usage: dispatch-config-load <projects|jit|statements|target-workers|budget-etl|epic|auto-merge>" >&2
+    echo "error: usage: dispatch-config-load <projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus>" >&2
     exit 2
     ;;
 esac
@@ -439,6 +457,21 @@ case "$CONFIG_TYPE" in
     ' "$CONFIG_FILE")
     ;;
   auto-merge)
+    ERRORS=$(jq -r '
+      if type != "object" then
+        "top-level value must be a JSON object, got \(type)"
+      else
+        . as $cfg |
+        # enabled: required boolean
+        (if ($cfg | has("enabled")) | not then
+          "missing required field enabled"
+        elif ($cfg.enabled | type) != "boolean" then
+          "enabled must be a boolean, got \($cfg.enabled | type)"
+        else empty end)
+      end
+    ' "$CONFIG_FILE")
+    ;;
+  force-opus)
     ERRORS=$(jq -r '
       if type != "object" then
         "top-level value must be a JSON object, got \(type)"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-job
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-spawn-job
@@ -39,7 +39,9 @@
 #                   `claude --bg --model <model>`. When absent or empty, the
 #                   --model flag is omitted entirely and the session inherits the
 #                   launcher's default model (Opus). See dispatch-phase-model for
-#                   the phase → model policy (#1171).
+#                   the phase → model policy (#1171). An enabled force-opus.json
+#                   (Step 1b) overrides the requested model with Opus regardless
+#                   of what is passed here.
 #   --park-issue <N> Optional positive integer. Best-effort, and requires
 #                   --no-verify — passing it without --no-verify is rejected with
 #                   exit 2 (parking only applies to the --no-verify kick-failure
@@ -51,6 +53,11 @@
 #                   Absent → no park; behavior is byte-identical to before.
 #
 # Behavior, in order:
+#   0. Force-opus gate — when dispatch.config/force-opus.json is enabled, force
+#                 MODEL=opus (overriding any --model) and export
+#                 CLAUDE_CODE_SUBAGENT_MODEL=opus so the spawned worker and all
+#                 its subagents run on Opus, overriding every per-site Sonnet pin.
+#                 Off (absent file → no-config, or enabled:false) → no change.
 #   1. Dedup    — if another live session with name == <name> is already running
 #                 under <cwd>, spawn nothing. Fail-safe: if the registry cannot
 #                 be queried, also spawn nothing (a dispatch agent may be live).
@@ -200,6 +207,35 @@ SESSION_ID="${DISPATCH_SPAWN_JOB_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/lib-claude-agents.sh"
+
+# ---- Step 1b: force-opus gate (the model-precedence chokepoint) --------------
+# The dispatch queue pins several phases/subagents to Sonnet (skill frontmatter
+# `model: sonnet`, prose "launch a model: sonnet subagent", per-unit "Recommended
+# model: sonnet" in persisted plans, and dispatch-phase-model emitting
+# `claude-sonnet-4-6` for qa/review — carried here as --model). The force-opus
+# config overrides them all FROM ABOVE at the one precedence level that beats
+# every per-site request, set at this single launch chokepoint:
+#   - CLAUDE_CODE_SUBAGENT_MODEL=opus is Claude Code's rank-1 subagent override;
+#     it outranks frontmatter, prose, and persisted-plan model requests for the
+#     spawned worker and ALL its subagents (inherited through the Step 3 cd
+#     subshell, which runs in this script's exported environment).
+#   - MODEL=opus forces the worker's own session model, overriding any --model
+#     the caller passed (e.g. claude-sonnet-4-6 from dispatch-launch-worker for
+#     qa/review); the existing Step 3 bg_args logic then carries --model opus.
+# Per .claude/rules/code-style.md a malformed opt-in config is a misconfigured
+# environment: fail loudly. Silently skipping the force would leave the user
+# wrongly believing they are on Opus.
+FORCE_OPUS_CFG=$("$SCRIPT_DIR/dispatch-config-load" force-opus) || {
+  echo "dispatch-spawn-job: error: dispatch-config-load force-opus failed" >&2
+  exit 1
+}
+if [[ "$FORCE_OPUS_CFG" != "no-config" ]] \
+   && [[ "$(jq -r '.enabled' <<<"$FORCE_OPUS_CFG")" == "true" ]]; then
+  # opus is the correct ALIAS — it passes the --model regex above; do NOT expand
+  # it to a full model id.
+  export CLAUDE_CODE_SUBAGENT_MODEL=opus
+  MODEL=opus
+fi
 
 # ---- Step 2: dedup guard ----------------------------------------------------
 # If another live session already has name == <name>, spawn nothing. The

--- a/.claude/skills/dispatch-propagate/scripts/force-opus.example.json
+++ b/.claude/skills/dispatch-propagate/scripts/force-opus.example.json
@@ -1,0 +1,3 @@
+{
+  "enabled": false
+}

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -10935,6 +10935,76 @@ else
 fi
 config_teardown
 
+# --- Test 7p: force-opus.json enabled → normalized JSON, exit 0 --------------
+
+echo "Test: valid force-opus.json with enabled:true prints normalized JSON"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/force-opus.json" <<'EOF'
+{"enabled":true}
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" force-opus 2>/dev/null); rc=$?
+assert_eq "force-opus enabled: exits 0" "0" "$rc"
+fo_enabled=$(printf '%s' "$out" | jq -r '.enabled')
+assert_eq "force-opus enabled: .enabled is true" "true" "$fo_enabled"
+config_teardown
+
+# --- Test 7q: force-opus.json disabled → normalized JSON, exit 0 -------------
+
+echo "Test: valid force-opus.json with enabled:false prints normalized JSON"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/force-opus.json" <<'EOF'
+{"enabled":false}
+EOF
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" force-opus 2>/dev/null); rc=$?
+assert_eq "force-opus disabled: exits 0" "0" "$rc"
+fo_enabled=$(printf '%s' "$out" | jq -r '.enabled')
+assert_eq "force-opus disabled: .enabled is false" "false" "$fo_enabled"
+config_teardown
+
+# --- Test 7r: absent force-opus.json → no-config, exit 0 --------------------
+
+echo "Test: absent force-opus.json prints no-config and exits 0"
+config_setup
+# no file written — config dir is empty
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" force-opus 2>/dev/null); rc=$?
+assert_eq "force-opus absent: exits 0" "0" "$rc"
+assert_eq "force-opus absent: prints no-config" "no-config" "$out"
+config_teardown
+
+# --- Test 7s: force-opus.json missing enabled field → exit 1 -----------------
+
+echo "Test: force-opus.json missing required enabled field exits 1 and stderr mentions enabled"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/force-opus.json" <<'EOF'
+{}
+EOF
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" force-opus 2>&1 1>/dev/null) || rc=$?
+assert_eq "force-opus missing enabled: exits 1" "1" "$rc"
+if [[ "$err" == *"enabled"* ]]; then
+  assert_eq "force-opus missing enabled: stderr mentions enabled" "yes" "yes"
+else
+  assert_eq "force-opus missing enabled: stderr mentions enabled" "yes" "no: $err"
+fi
+config_teardown
+
+# --- Test 7t: force-opus.json enabled is a string → exit 1 ------------------
+
+echo "Test: force-opus.json with enabled as a string exits 1 and stderr mentions enabled"
+config_setup
+cat > "$DISPATCH_CONFIG_DIR/force-opus.json" <<'EOF'
+{"enabled":"yes"}
+EOF
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" force-opus 2>&1 1>/dev/null) || rc=$?
+assert_eq "force-opus string enabled: exits 1" "1" "$rc"
+if [[ "$err" == *"enabled"* ]]; then
+  assert_eq "force-opus string enabled: stderr mentions enabled" "yes" "yes"
+else
+  assert_eq "force-opus string enabled: stderr mentions enabled" "yes" "no: $err"
+fi
+config_teardown
+
 # ============================================================================
 # ingest-downloads.sh tests
 # ============================================================================
@@ -14883,6 +14953,7 @@ SPAWN_WORKER_REGISTRY=""
 SPAWN_WORKER_BG_ARGV=""
 SPAWN_WORKER_PWD_LOG=""
 SPAWN_WORKER_PENDING=""
+SPAWN_WORKER_SUBAGENT_MODEL=""
 WORKER_TARGET_WORKTREE=""
 
 # write_fake_spawn_worker_claude — install the multi-subcommand fake `claude`.
@@ -14929,6 +15000,7 @@ case "\${1:-}" in
   --bg)
     pwd >> "$SPAWN_WORKER_PWD_LOG"
     printf '%s\n' "\$@" > "$SPAWN_WORKER_BG_ARGV"
+    printf '%s\n' "\${CLAUDE_CODE_SUBAGENT_MODEL:-<unset>}" > "$SPAWN_WORKER_SUBAGENT_MODEL"
     name=""
     while [[ \$# -gt 0 ]]; do
       if [[ "\$1" == "--name" ]]; then name="\${2:-}"; shift 2; continue; fi
@@ -14952,22 +15024,34 @@ spawn_worker_setup() {
   TMPDIR_TEST=$(mktemp -d)
   mkdir -p "$TMPDIR_TEST/scripts" \
     "$TMPDIR_TEST/worktrees/main" \
-    "$TMPDIR_TEST/worktrees/839-test-worker"
+    "$TMPDIR_TEST/worktrees/839-test-worker" \
+    "$TMPDIR_TEST/config"
 
   # dispatch-spawn-job (the generalized spawn primitive) sources
   # lib-claude-agents.sh from its own directory, so both must sit alongside the
   # copy. lib-claude-agents.sh is sourced, not executed — no chmod;
   # dispatch-spawn-job is run, so it is chmod'd.
+  # dispatch-spawn-job's force-opus gate calls dispatch-config-load, which in
+  # turn sources lib.sh — both must sit alongside the copy. dispatch-config-load
+  # is run, so it is chmod'd; lib.sh is sourced, no chmod.
   cp "$SCRIPT_DIR/dispatch-spawn-job" "$TMPDIR_TEST/scripts/dispatch-spawn-job"
   cp "$SCRIPT_DIR/lib-claude-agents.sh" "$TMPDIR_TEST/scripts/lib-claude-agents.sh"
+  cp "$SCRIPT_DIR/dispatch-config-load" "$TMPDIR_TEST/scripts/dispatch-config-load"
+  cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/lib.sh"
   chmod +x "$TMPDIR_TEST/scripts/dispatch-spawn-job"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-config-load"
 
   SPAWN_WORKER_REGISTRY="$TMPDIR_TEST/registry.json"
   SPAWN_WORKER_BG_ARGV="$TMPDIR_TEST/bg-argv"
   SPAWN_WORKER_PWD_LOG="$TMPDIR_TEST/pwd-log"
   SPAWN_WORKER_PENDING="$TMPDIR_TEST/pending"
+  SPAWN_WORKER_SUBAGENT_MODEL="$TMPDIR_TEST/subagent-model"
   WORKER_TARGET_WORKTREE="$TMPDIR_TEST/worktrees/839-test-worker"
   printf '[]' > "$SPAWN_WORKER_REGISTRY"
+
+  # Point dispatch-config-load at the test's config dir so force-opus.json is
+  # under test control (absent config dir → no-config → gate off by default).
+  export DISPATCH_CONFIG_DIR="$TMPDIR_TEST/config"
 }
 
 spawn_worker_teardown() {
@@ -14977,10 +15061,12 @@ spawn_worker_teardown() {
   SPAWN_WORKER_BG_ARGV=""
   SPAWN_WORKER_PWD_LOG=""
   SPAWN_WORKER_PENDING=""
+  SPAWN_WORKER_SUBAGENT_MODEL=""
   WORKER_TARGET_WORKTREE=""
   unset DISPATCH_SPAWN_JOB_CLAUDE_CMD DISPATCH_SPAWN_JOB_SESSION_ID \
     SPAWN_BG_REGISTERS SPAWN_BG_REGISTER_AFTER_N \
-    LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S
+    LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S \
+    DISPATCH_CONFIG_DIR CLAUDE_CODE_SUBAGENT_MODEL
 }
 
 # ============================================================================
@@ -15007,17 +15093,24 @@ spawn_office_hours_setup() {
   TMPDIR_TEST=$(mktemp -d)
   mkdir -p "$TMPDIR_TEST/scripts" \
     "$TMPDIR_TEST/worktrees/main" \
-    "$TMPDIR_TEST/worktrees/839-test-worker"
+    "$TMPDIR_TEST/worktrees/839-test-worker" \
+    "$TMPDIR_TEST/config"
 
   # dispatch-spawn-office-hours sources lib-claude-agents.sh from its own
   # directory and runs dispatch-spawn-job from there, so both must sit alongside
   # the copy. lib-claude-agents.sh is sourced, not executed — no chmod; the two
   # executables are run, so they are chmod'd.
+  # dispatch-spawn-job's force-opus gate calls dispatch-config-load, which
+  # sources lib.sh — both must sit alongside the copy. dispatch-config-load is
+  # run, so it is chmod'd; lib.sh is sourced, no chmod.
   cp "$SCRIPT_DIR/dispatch-spawn-office-hours" "$TMPDIR_TEST/scripts/dispatch-spawn-office-hours"
   cp "$SCRIPT_DIR/dispatch-spawn-job" "$TMPDIR_TEST/scripts/dispatch-spawn-job"
   cp "$SCRIPT_DIR/lib-claude-agents.sh" "$TMPDIR_TEST/scripts/lib-claude-agents.sh"
+  cp "$SCRIPT_DIR/dispatch-config-load" "$TMPDIR_TEST/scripts/dispatch-config-load"
+  cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/lib.sh"
   chmod +x "$TMPDIR_TEST/scripts/dispatch-spawn-office-hours"
   chmod +x "$TMPDIR_TEST/scripts/dispatch-spawn-job"
+  chmod +x "$TMPDIR_TEST/scripts/dispatch-config-load"
 
   # Reuse the SPAWN_WORKER_* fixture globals so write_fake_spawn_worker_claude
   # (which references them) backs this script too.
@@ -15025,11 +15118,16 @@ spawn_office_hours_setup() {
   SPAWN_WORKER_BG_ARGV="$TMPDIR_TEST/bg-argv"
   SPAWN_WORKER_PWD_LOG="$TMPDIR_TEST/pwd-log"
   SPAWN_WORKER_PENDING="$TMPDIR_TEST/pending"
+  SPAWN_WORKER_SUBAGENT_MODEL="$TMPDIR_TEST/subagent-model"
   WORKER_TARGET_WORKTREE="$TMPDIR_TEST/worktrees/839-test-worker"
   printf '[]' > "$SPAWN_WORKER_REGISTRY"
 
   export DISPATCH_SPAWN_OFFICE_HOURS_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
   export DISPATCH_SPAWN_OFFICE_HOURS_SESSION_ID="sess-self"
+
+  # Point dispatch-config-load at the test's config dir so force-opus.json is
+  # under test control (absent config dir → no-config → gate off by default).
+  export DISPATCH_CONFIG_DIR="$TMPDIR_TEST/config"
 }
 
 spawn_office_hours_teardown() {
@@ -15039,11 +15137,13 @@ spawn_office_hours_teardown() {
   SPAWN_WORKER_BG_ARGV=""
   SPAWN_WORKER_PWD_LOG=""
   SPAWN_WORKER_PENDING=""
+  SPAWN_WORKER_SUBAGENT_MODEL=""
   WORKER_TARGET_WORKTREE=""
   unset DISPATCH_SPAWN_OFFICE_HOURS_CLAUDE_CMD DISPATCH_SPAWN_OFFICE_HOURS_SESSION_ID \
     DISPATCH_SPAWN_JOB_CLAUDE_CMD DISPATCH_SPAWN_JOB_SESSION_ID \
     SPAWN_BG_REGISTERS SPAWN_BG_REGISTER_AFTER_N \
-    LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S
+    LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S \
+    DISPATCH_CONFIG_DIR CLAUDE_CODE_SUBAGENT_MODEL
 }
 
 # --- Test 1: happy path — spawn worker-style, resolve + print the id ---------
@@ -15280,6 +15380,83 @@ assert_eq "spawn-job-model: argv[4] is claude-sonnet-4-6" "claude-sonnet-4-6" "$
 assert_eq "spawn-job-model: argv[5] is --permission-mode" "--permission-mode" "${sj_bg_argv[5]:-}"
 assert_eq "spawn-job-model: argv[6] is auto" "auto" "${sj_bg_argv[6]:-}"
 assert_eq "spawn-job-model: argv[7] is the prompt" "/dispatch-diagnose-main abc123" "${sj_bg_argv[7]:-}"
+spawn_worker_teardown
+
+# --- Test 2c: force-opus enabled — overrides caller's --model (#1830) --------
+# With force-opus.json {"enabled":true}, dispatch-spawn-job must replace any
+# caller-supplied --model with --model opus in the bg argv AND set
+# CLAUDE_CODE_SUBAGENT_MODEL=opus so the spawned process inherits it.
+
+echo "Test: force-opus enabled overrides --model claude-sonnet-4-6 with --model opus in bg argv"
+spawn_worker_setup
+write_fake_spawn_worker_claude
+export DISPATCH_SPAWN_JOB_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+export DISPATCH_SPAWN_JOB_SESSION_ID="sess-self"
+# Write an enabled force-opus config into the test's config dir.
+printf '{"enabled":true}\n' > "$DISPATCH_CONFIG_DIR/force-opus.json"
+SPAWN_JOB_CWD="$TMPDIR_TEST/worktrees/839-test-worker"
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-job" \
+    --name diagnose-main --cwd "$SPAWN_JOB_CWD" --model claude-sonnet-4-6 \
+    "/dispatch-diagnose-main abc123" 2>/dev/null ); then rc=0; else rc=$?; fi
+assert_eq "spawn-job-force-opus-on: exits 0" "0" "$rc"
+assert_eq "spawn-job-force-opus-on: stdout is 'spawned'" "spawned" "$out"
+# Check the bg argv — caller passed --model claude-sonnet-4-6 but force-opus
+# must have overridden it to --model opus.
+mapfile -t sj_fo_argv < "$SPAWN_WORKER_BG_ARGV"
+assert_eq "spawn-job-force-opus-on: argv[0] is --bg" "--bg" "${sj_fo_argv[0]:-}"
+assert_eq "spawn-job-force-opus-on: argv[1] is --name" "--name" "${sj_fo_argv[1]:-}"
+assert_eq "spawn-job-force-opus-on: argv[2] is diagnose-main" "diagnose-main" "${sj_fo_argv[2]:-}"
+assert_eq "spawn-job-force-opus-on: argv[3] is --model" "--model" "${sj_fo_argv[3]:-}"
+assert_eq "spawn-job-force-opus-on: argv[4] is opus (not claude-sonnet-4-6)" "opus" "${sj_fo_argv[4]:-}"
+# Check that CLAUDE_CODE_SUBAGENT_MODEL was opus when the fake ran.
+sj_fo_subagent=$(cat "$SPAWN_WORKER_SUBAGENT_MODEL" 2>/dev/null || true)
+assert_eq "spawn-job-force-opus-on: CLAUDE_CODE_SUBAGENT_MODEL recorded as opus" "opus" "$sj_fo_subagent"
+spawn_worker_teardown
+
+# --- Test 2d: force-opus disabled — caller's --model passes verbatim (#1830) -
+# With force-opus.json {"enabled":false}, dispatch-spawn-job must leave the
+# caller's --model untouched and must NOT set CLAUDE_CODE_SUBAGENT_MODEL.
+
+echo "Test: force-opus disabled leaves --model claude-sonnet-4-6 verbatim in bg argv"
+spawn_worker_setup
+write_fake_spawn_worker_claude
+export DISPATCH_SPAWN_JOB_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+export DISPATCH_SPAWN_JOB_SESSION_ID="sess-self"
+printf '{"enabled":false}\n' > "$DISPATCH_CONFIG_DIR/force-opus.json"
+SPAWN_JOB_CWD="$TMPDIR_TEST/worktrees/839-test-worker"
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-job" \
+    --name diagnose-main --cwd "$SPAWN_JOB_CWD" --model claude-sonnet-4-6 \
+    "/dispatch-diagnose-main abc123" 2>/dev/null ); then rc=0; else rc=$?; fi
+assert_eq "spawn-job-force-opus-off: exits 0" "0" "$rc"
+assert_eq "spawn-job-force-opus-off: stdout is 'spawned'" "spawned" "$out"
+mapfile -t sj_foff_argv < "$SPAWN_WORKER_BG_ARGV"
+assert_eq "spawn-job-force-opus-off: argv[3] is --model" "--model" "${sj_foff_argv[3]:-}"
+assert_eq "spawn-job-force-opus-off: argv[4] is claude-sonnet-4-6 (unchanged)" "claude-sonnet-4-6" "${sj_foff_argv[4]:-}"
+sj_foff_subagent=$(cat "$SPAWN_WORKER_SUBAGENT_MODEL" 2>/dev/null || true)
+assert_eq "spawn-job-force-opus-off: CLAUDE_CODE_SUBAGENT_MODEL is <unset>" "<unset>" "$sj_foff_subagent"
+spawn_worker_teardown
+
+# --- Test 2e: force-opus absent — caller's --model passes verbatim (#1830) ---
+# With no force-opus.json at all, the gate must be off: caller's --model is
+# untouched and CLAUDE_CODE_SUBAGENT_MODEL is not set.
+
+echo "Test: force-opus absent (no file) leaves --model claude-sonnet-4-6 verbatim in bg argv"
+spawn_worker_setup
+write_fake_spawn_worker_claude
+export DISPATCH_SPAWN_JOB_CLAUDE_CMD="$TMPDIR_TEST/fake-claude"
+export DISPATCH_SPAWN_JOB_SESSION_ID="sess-self"
+# No force-opus.json written — config dir is empty (dispatch-config-load → no-config).
+SPAWN_JOB_CWD="$TMPDIR_TEST/worktrees/839-test-worker"
+if out=$("$TMPDIR_TEST/scripts/dispatch-spawn-job" \
+    --name diagnose-main --cwd "$SPAWN_JOB_CWD" --model claude-sonnet-4-6 \
+    "/dispatch-diagnose-main abc123" 2>/dev/null ); then rc=0; else rc=$?; fi
+assert_eq "spawn-job-force-opus-absent: exits 0" "0" "$rc"
+assert_eq "spawn-job-force-opus-absent: stdout is 'spawned'" "spawned" "$out"
+mapfile -t sj_fabsent_argv < "$SPAWN_WORKER_BG_ARGV"
+assert_eq "spawn-job-force-opus-absent: argv[3] is --model" "--model" "${sj_fabsent_argv[3]:-}"
+assert_eq "spawn-job-force-opus-absent: argv[4] is claude-sonnet-4-6 (unchanged)" "claude-sonnet-4-6" "${sj_fabsent_argv[4]:-}"
+sj_fabsent_subagent=$(cat "$SPAWN_WORKER_SUBAGENT_MODEL" 2>/dev/null || true)
+assert_eq "spawn-job-force-opus-absent: CLAUDE_CODE_SUBAGENT_MODEL is <unset>" "<unset>" "$sj_fabsent_subagent"
 spawn_worker_teardown
 
 # --- Test 3: exact-name dedup ------------------------------------------------


### PR DESCRIPTION
Closes #1830

## What

Adds a manual, opt-in **force-Opus** toggle for the dispatch queue. When
`dispatch.config/force-opus.json` is `{"enabled": true}`, every worker spawned
through the dispatch launch chokepoint runs on Opus — overriding the hardcoded
Sonnet pins that economize the weekly budget. Absent or `{"enabled": false}` →
behavior is unchanged from today. The switch is dispatch-scoped, orthogonal to
the budget ladder, and reverts instantly.

## Why this design (override from above, not four edits)

Sonnet is pinned in four structurally different places, so no single edit flips
them all — and one of the pins is data already written into past plans. Rather
than touch each site, the toggle overrides them *from above* at the one
precedence level that beats every per-site request, set at the **single
enforcement point** every dispatch worker passes through (`dispatch-spawn-job`):

- `export CLAUDE_CODE_SUBAGENT_MODEL=opus` — Claude Code's rank-1 model override.
  Outranks pin **B** (skill frontmatter `model: sonnet`), pin **C** (prose
  "launch a `model: sonnet` subagent"), and pin **D** (per-unit "Recommended
  model: sonnet" in persisted plans).
- `MODEL=opus` — forces the worker's own session model, overriding pin **A**
  (`dispatch-phase-model` emitting `claude-sonnet-4-6` for `qa`/`review`, carried
  in as `--model`). The existing `bg_args` logic then carries `--model opus`.

The gate lives solely in `dispatch-spawn-job`; `dispatch-launch-worker`,
`dispatch-phase-model`, `dispatch-tick`, and all skill frontmatter are untouched.
Because every dispatch session (phase workers, sync-repair, diagnose-main,
jit-reminder, office-hours) launches through `dispatch-spawn-job`, the gate
scopes to exactly the issue's intended "only workers spawned via
`dispatch-spawn-job`".

## Convention note (not auto-merge's inversion)

`force-opus` follows the **generic** config convention used by
`target-workers`/`epic`/`jit`: absent file → `no-config` → feature **OFF
(inert)**. It deliberately does **not** copy `auto-merge`'s inverted
absent-means-ON semantics (PR #1826 made auto-merge an opt-out kill-switch). The
new schema doc block in `dispatch-config-load` calls out this contrast
explicitly so future readers don't conflate the two. A malformed `force-opus.json`
fails loudly (`exit 1`) rather than silently skipping the force — per
`.claude/rules/code-style.md`, a silent skip would leave the user wrongly
believing they are on Opus.

## Units

1. `dispatch-config-load` — new `force-opus` arm (required boolean `enabled`;
   generic absent→inert convention).
2. `force-opus.example.json` — disabled-by-default committed sibling example.
3. `dispatch-spawn-job` — the gate, placed after config resolution and before the
   spawn so `MODEL=opus` flows into `bg_args` and `CLAUDE_CODE_SUBAGENT_MODEL` is
   exported into the spawn subshell.
4. `test-dispatch-scripts.sh` — tests for both states (config-load validation;
   spawn-job enabled forces `--model opus` + `CLAUDE_CODE_SUBAGENT_MODEL=opus`
   over a caller-passed `--model claude-sonnet-4-6`; disabled/absent are strict
   no-ops).

## Verification

- Full dispatch script suite: **3022/3022 passed** (`bash
  .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`), including
  the new force-opus cases and the unchanged `dispatch-phase-model` /
  `dispatch-spawn-job --model` tests (proving absent/disabled is a strict no-op).
- Ad-hoc config-load smoke: enabled → normalized JSON; absent → `no-config`;
  non-boolean `enabled` → exit 1 + schema error.

## Acceptance criterion 7 — `commit-merge-push` frontmatter (documented deferral)

The `commit-merge-push` frontmatter `model: sonnet` line is **not** edited, by
design. This honors the issue's headline promise ("No edits to …
commit-merge-push"), and `CLAUDE_CODE_SUBAGENT_MODEL` is Claude Code's rank-1
model override — above frontmatter `model:` (rank 3) — so it should outrank that
frontmatter even inside an already-forced subagent. The empirical
`dispatch-token-audit` `by_phase_model` check **cannot run in-PR**: no
forced-worker transcripts exist until the feature ships. Criterion 7 is therefore
satisfied by documented rank-1 precedence; the empirical token-audit
confirmation is a **post-deployment follow-up** (run `/dispatch-token-audit`
after `force-opus.json` has been enabled for a window). Only if a
`commit-merge-push` transcript then leaks onto Sonnet under a forced worker do we
reactively drop/conditionalize that one frontmatter line — the issue's
sanctioned fallback, applied reactively, not preemptively. This is not an
office-hours escalation; the issue anticipates and sanctions this path.
