### PR TITLE
qa-fix: add 'already-satisfied' disposition class to auto-resolve already-met items

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-qa-disposition
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-qa-disposition
@@ -12,7 +12,7 @@
 #
 # Per-item input fields (at minimum):
 #   id        — string, unique per item
-#   class     — string; one of: opus-fixable | needs-main | needs-human
+#   class     — string; one of: opus-fixable | needs-main | needs-human | already-satisfied
 #   aesthetic — boolean; true when the finding is aesthetic-only
 #   (plus arbitrary passthrough fields preserved unchanged)
 #
@@ -20,6 +20,12 @@
 #   A missing id in votes is treated as [] (no votes — both skeptics failed).
 #
 # Downgrade rule (applied in order; first matching branch wins):
+#
+#   class == "already-satisfied"
+#     → final_class = "already-satisfied", verify = "n/a"
+#       (criterion already provably met; no vote fan-out, no fix, no human —
+#       symmetric with the aesthetic bypass; explicit for kernel-sync with
+#       qa-fix.js applyQaDisposition, not a behavior fix)
 #
 #   class != "needs-human"
 #     → final_class = class, verify = "n/a"
@@ -68,7 +74,16 @@ jq '
       (($votes[$item.id] // [])) as $item_votes |
       ($item_votes | map(select(. == "refuted")) | length) as $refuted_count |
 
-      if $item.class != "needs-human" then
+      if $item.class == "already-satisfied" then
+        # Already-satisfied: the criterion is already provably met by evidence the
+        # agent can read; no code defect to fix, no human needed. No-vote pass-through,
+        # symmetric with the aesthetic bypass below. NOTE: the existing
+        # `class != "needs-human"` branch would already return this exact shape — this
+        # explicit branch is for kernel-sync/legibility with qa-fix.js
+        # applyQaDisposition, not a behavior fix.
+        $item + {final_class: "already-satisfied", verify: "n/a"}
+
+      elif $item.class != "needs-human" then
         # opus-fixable and needs-main: pass through unchanged.
         $item + {final_class: $item.class, verify: "n/a"}
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -25630,7 +25630,8 @@ echo "Test: dispatch-qa-disposition"
 # f4: needs-human, aesthetic:false, votes=[upheld,upheld]  → needs-human,  Upheld
 # f5: needs-human, aesthetic:false, NO entry in votes map  → needs-human,  Unverified (INVERTED EDGE)
 # f6: needs-human, aesthetic:true,  votes=[refuted,refuted]→ needs-human,  n/a (aesthetic bypasses)
-IN='{"items":[{"id":"f1","class":"opus-fixable","aesthetic":false},{"id":"f2","class":"needs-main","aesthetic":false},{"id":"f3","class":"needs-human","aesthetic":false},{"id":"f4","class":"needs-human","aesthetic":false},{"id":"f5","class":"needs-human","aesthetic":false},{"id":"f6","class":"needs-human","aesthetic":true}],"votes":{"f3":["refuted","upheld"],"f4":["upheld","upheld"],"f6":["refuted","refuted"]}}'
+# f7: already-satisfied (no votes entry) → final_class=already-satisfied, verify=n/a (first-branch pass-through)
+IN='{"items":[{"id":"f1","class":"opus-fixable","aesthetic":false},{"id":"f2","class":"needs-main","aesthetic":false},{"id":"f3","class":"needs-human","aesthetic":false},{"id":"f4","class":"needs-human","aesthetic":false},{"id":"f5","class":"needs-human","aesthetic":false},{"id":"f6","class":"needs-human","aesthetic":true},{"id":"f7","class":"already-satisfied","aesthetic":false}],"votes":{"f3":["refuted","upheld"],"f4":["upheld","upheld"],"f6":["refuted","refuted"]}}'
 out=$(printf '%s' "$IN" | "$SCRIPT_DIR/dispatch-qa-disposition")
 
 # Branch: opus-fixable passes through
@@ -25658,6 +25659,10 @@ assert_eq "qa-disposition: needs-human empty-votes → verify=Unverified (invert
 assert_eq "qa-disposition: aesthetic needs-human with refuted votes → final_class=needs-human" "needs-human" "$(printf '%s' "$out" | jq -r '.dispositions[] | select(.id=="f6") | .final_class')"
 assert_eq "qa-disposition: aesthetic needs-human with refuted votes → verify=n/a" "n/a" "$(printf '%s' "$out" | jq -r '.dispositions[] | select(.id=="f6") | .verify')"
 
+# Branch: already-satisfied → first-branch pass-through, no votes needed
+assert_eq "qa-disposition: already-satisfied → final_class=already-satisfied" "already-satisfied" "$(printf '%s' "$out" | jq -r '.dispositions[] | select(.id=="f7") | .final_class')"
+assert_eq "qa-disposition: already-satisfied → verify=n/a" "n/a" "$(printf '%s' "$out" | jq -r '.dispositions[] | select(.id=="f7") | .verify')"
+
 # Passthrough: original class and aesthetic fields survive on output items
 assert_eq "qa-disposition: passthrough class field preserved" "needs-human" "$(printf '%s' "$out" | jq -r '.dispositions[] | select(.id=="f3") | .class')"
 assert_eq "qa-disposition: passthrough aesthetic field preserved" "false" "$(printf '%s' "$out" | jq -r '.dispositions[] | select(.id=="f3") | .aesthetic')"
@@ -25667,13 +25672,14 @@ IN_TITLE='{"items":[{"id":"t1","class":"needs-human","aesthetic":false,"title":"
 out_title=$(printf '%s' "$IN_TITLE" | "$SCRIPT_DIR/dispatch-qa-disposition")
 assert_eq "qa-disposition: passthrough title field preserved" "Check me" "$(printf '%s' "$out_title" | jq -r '.dispositions[0].title')"
 
-# Output order: items must appear in input order (f1..f6)
+# Output order: items must appear in input order (f1..f7)
 assert_eq "qa-disposition: output order preserved" "f1
 f2
 f3
 f4
 f5
-f6" "$(printf '%s' "$out" | jq -r '.dispositions[].id')"
+f6
+f7" "$(printf '%s' "$out" | jq -r '.dispositions[].id')"
 
 # dispatch-jit-skill tests
 # ============================================================================

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -771,11 +771,15 @@ Otherwise run all steps in order.
      rationale from the matching entry in `result.verify_report` (matched by `id`).
      For aesthetic `needs-human` items, use `dispositions[item].verify` (which will
      be `n/a`) directly — no `verify_report` entry exists for them. If the residue
-     list was empty (Step 3.5 was skipped), omit this section entirely.
+     list was empty (Step 3.5 was skipped), omit this section entirely. If
+     `result.dispositions` is empty (every residue item was `already-satisfied`),
+     skip the per-item enumeration and the `needs-main` handling prose below — there
+     are no disposition items and no `needs-main` items to describe; only the
+     **Assessed by Opus (already satisfied)** sub-section applies.
 
-     Always state the `needs-main` handling: **"`needs-main` items are filed as
-     `blocked_by` follow-ups (Step 3.6) and dropped from the escalation set, so they
-     do not park this PR."**
+     When `result.dispositions` contains any item, always state the `needs-main`
+     handling: **"`needs-main` items are filed as `blocked_by` follow-ups (Step 3.6)
+     and dropped from the escalation set, so they do not park this PR."**
 
      The remaining terminal-behavior prose is **conditional** on which Step-3.7 path
      this pass took:
@@ -908,7 +912,8 @@ Otherwise run all steps in order.
    **User-input blocker** — the escalation set (defined above) is **non-empty**.
    This fires when any member of the set is present: an `opus-fixable` or
    `needs-human` residue item (a `script-verifiable`/`needs-browser` FAIL or a
-   `needs-human-judgment` item that did **not** classify `needs-main`), OR any
+   `needs-human-judgment` item that classified `needs-human` — i.e. it did **not**
+   classify `needs-main` or `already-satisfied`), OR any
    non-residue blocker — a malformed or empty triage plan (Step 3 plan
    validation), the pre-QA acceptance check failed (a bug needing a plan-mode fix,
    Step 3b), the Chrome extension unavailable so browser items could not run (Step

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -18,10 +18,14 @@ an unexpected permission prompt, or a bounded auto-fix-exhausted bug (cap
 reached / scope-deviation / planning-failed on an `opus-fixable` item) — it
 escalates to the office-hours queue via the standard path (skip the
 `phase-completed` marker, write `office-hours-reason`; the Stop hook applies
-`dispatch:office-hours` to the issue and parks the session). `opus-fixable`
-bugs are auto-fixed in the bounded Opus fix lane (Step 3.7); `needs-main` bugs
-are filed as `blocked_by` follow-up issues (Step 3.6) and do not escalate. The
-user-input residue runs later via `/office-hours`.
+`dispatch:office-hours` to the issue and parks the session). The Step 3.5
+disposition Workflow classifies residue items on a **four-class axis**:
+`opus-fixable` bugs are auto-fixed in the bounded Opus fix lane (Step 3.7);
+`needs-main` bugs are filed as `blocked_by` follow-up issues (Step 3.6) and do
+not escalate; `already-satisfied` items are **dropped as PASS** — partitioned
+into `result.already_satisfied` by the Workflow, excluded from `result.dispositions`,
+and never reaching fix-plan or the escalation set. The user-input residue
+(`needs-human`) runs later via `/office-hours`.
 
 The QA plan (Step 2) is authored by a **single bounded Opus triage subagent** that
 consumes the live context pack and returns a three-way-classified, ordered item
@@ -484,15 +488,24 @@ Otherwise run all steps in order.
 
    ```
    result = {
-     dispositions:  [ {id, title, kind, class, aesthetic, verify, rationale} ],
-     verify_report: [ {id, verdict, skeptic_votes, rationale} ],
-     fix_plan:      { units, deviation, deviation_reason } | null,
-     deviation:     <bool>
+     dispositions:      [ {id, title, kind, class, aesthetic, verify, rationale} ],
+     already_satisfied: [ {id, title, kind, rationale} ],  // dropped-as-PASS items partitioned out of dispositions
+     verify_report:     [ {id, verdict, skeptic_votes, rationale} ],
+     fix_plan:          { units, deviation, deviation_reason } | null,
+     deviation:         <bool>
    }
    ```
 
-   - `dispositions[].class` is the final class: `opus-fixable` | `needs-main` |
-     `needs-human`. `verify` is `Upheld` | `Refuted` | `Unverified` | `n/a`.
+   - `dispositions[].class` is the final class for items still in the set:
+     `opus-fixable` | `needs-main` | `needs-human`. `verify` is `Upheld` |
+     `Refuted` | `Unverified` | `n/a`. `dispositions` excludes already-satisfied
+     items — those are partitioned into `result.already_satisfied` by the Workflow.
+   - The **four-class disposition axis** is: `opus-fixable` | `needs-main` |
+     `needs-human` | `already-satisfied`. Items the Workflow classifies
+     `already-satisfied` are **dropped as PASS** in the Workflow's aggregation:
+     excluded from `result.dispositions`, never reaching fix-plan, never entering
+     the escalation set, and surfaced separately in `result.already_satisfied`
+     carrying `{id, title, kind, rationale}`.
    - `verify_report` has one entry per non-aesthetic `needs-human` candidate that
      went through the skeptic fan-out (`verdict`: `upheld` | `refuted` |
      `unverified`).
@@ -742,15 +755,18 @@ Otherwise run all steps in order.
    - Items executed (across all three lanes).
    - PASS / FAIL / SKIP counts.
    - **Deferred to office-hours** — each `needs-human-judgment` item **whose
-     disposition class is not `needs-main`**, listed so the `/office-hours`
-     walkthrough can pick them up. A `needs-human-judgment` item the triage
-     classified `needs-main` is filed as a follow-up per Step 3.6 instead (see the
-     filed-follow-ups sub-list below) and is **not** deferred to office-hours.
+     disposition class is `needs-human`** (i.e. neither `needs-main` nor
+     `already-satisfied`), listed so the `/office-hours` walkthrough can pick them
+     up. A `needs-human-judgment` item the triage classified `needs-main` is filed
+     as a follow-up per Step 3.6 instead (see the filed-follow-ups sub-list below)
+     and is **not** deferred to office-hours. A `needs-human-judgment` item the
+     Workflow classified `already-satisfied` is dropped as PASS (in
+     `result.already_satisfied`) and is likewise **not** deferred to office-hours.
    - List of bugs found (if any), each with the item title and the finding.
    - When the walkthrough lane ran: the GIF filename (`tmp/qa-fix-walkthrough-<n>.gif`).
    - **Disposition triage** — include this section only when the residue list was
-     non-empty (i.e. Step 3.5 ran). For each residue item, list its `class` from
-     `result.dispositions`. For non-aesthetic `needs-human` items (where
+     non-empty (i.e. Step 3.5 ran). For each **disposition item**, list its `class`
+     from `result.dispositions`. For non-aesthetic `needs-human` items (where
      `dispositions[item].aesthetic === false`), include the verify verdict and
      rationale from the matching entry in `result.verify_report` (matched by `id`).
      For aesthetic `needs-human` items, use `dispositions[item].verify` (which will
@@ -779,6 +795,11 @@ Otherwise run all steps in order.
      "already tracked by #<N>" (an existing tracking issue was found via
      `dispatch-followup-exists`), using the `identifier`→`<N>` mappings Step 3.6
      captured.
+   - **Assessed by Opus (already satisfied)** — include this sub-list only when
+     `result.already_satisfied` is non-empty. For each item in
+     `result.already_satisfied`, list its `title` and `rationale`. These items had
+     their acceptance criterion provably met at QA time — no code defect exists and
+     no human input is needed — so they are dropped as PASS and do not park the PR.
 
    Post via (use `dangerouslyDisableSandbox: true` — the script invokes `gh`):
    ```bash
@@ -811,23 +832,28 @@ Otherwise run all steps in order.
       items to fix, so Step 3.7 fell through; *or* a cap/scope-deviation/
       planning-failed escalate already finalized in Step 3.7 and STOPPED before
       here) — the existing office-hours escalation path, unchanged. The escalation
-      set **excludes** `needs-main`-class residue: each `needs-main` item was filed
-      as a `blocked_by` follow-up in Step 3.6 and is **dropped** from the set below;
-      `opus-fixable` and `needs-human` residue items still escalate exactly as
-      before (see the **User-input blocker** branch below and the **Escalation**
-      section).
+      set **excludes** `needs-main`-class residue (each `needs-main` item was filed
+      as a `blocked_by` follow-up in Step 3.6 and is **dropped** from the set below)
+      and **excludes** `already-satisfied`-class residue (dropped as PASS by the
+      Workflow, absent from `result.dispositions`); `opus-fixable` and `needs-human`
+      residue items still escalate exactly as before (see the **User-input blocker**
+      branch below and the **Escalation** section).
 
-   3. **Clean pass** — no residue at all (or only `needs-main` residue, all of which
-      was filed and dropped): `dispatch-complete-phase qa` + `dispatch-mark-complete`,
-      unchanged (see **Clean autonomous pass** below).
+   3. **Clean pass** — no residue at all (or only `needs-main` residue, all filed
+      and dropped; or only `already-satisfied` residue, all dropped as PASS):
+      `dispatch-complete-phase qa` + `dispatch-mark-complete`, unchanged (see
+      **Clean autonomous pass** below).
 
-   **Escalation set.** Define it as:
+   **Escalation set.** Build it directly from **`result.dispositions`** — the
+   Workflow's already-filtered output — not by re-deriving class from the raw
+   in-memory residue list. (Re-deriving would find already-satisfied items absent
+   from `result.dispositions`, get `undefined` for their class, and wrongly include
+   them because `undefined !== 'needs-main'`.) Define the set as:
 
-   - every **residue item whose final disposition class is NOT `needs-main`** —
-     i.e. `opus-fixable` and `needs-human` items, which still escalate (the skill
-     does not yet act on those classes); **plus**
+   - every **item in `result.dispositions`** — i.e. `opus-fixable` and `needs-human`
+     items, which still escalate (the skill does not yet act on those classes); **plus**
    - the **non-residue terminal blockers** that already escalate, unchanged. These
-     stay terminal — only `needs-main`-class residue is dropped from the set:
+     stay terminal — only disposition-class residue is dropped from the set:
      - a malformed or empty triage plan (Step 3 plan validation),
      - an `origin/main` merge conflict (Step 0.5),
      - the Chrome extension unavailable so browser items could not run (Step 3c),
@@ -838,13 +864,21 @@ Otherwise run all steps in order.
    filed as follow-ups in Step 3.6, now carrying `main-qa` + `dispatch:office-hours`
    so they route to office-hours human review rather than the autonomous queue.
 
+   `already-satisfied` residue items are likewise in **neither** part of the set —
+   they are **dropped as PASS** by the Workflow (partitioned into
+   `result.already_satisfied`, excluded from `result.dispositions`) and are therefore
+   never members of the escalation set. They do not park this PR.
+
    **Clean autonomous pass** — the escalation set (defined above) is **empty**.
    This now holds even for a run whose only residue items all classified
    `needs-main`: those were filed as `blocked_by` follow-ups in Step 3.6 and
-   dropped, leaving the escalation set empty. (It also holds, as before, when every
-   `script-verifiable` and `needs-browser` item PASSed, zero `needs-human-judgment`
-   items were recorded, no bug was found, and none of the non-residue blockers
-   fired.)
+   dropped, leaving the escalation set empty. It also holds when every residue item
+   classified `already-satisfied`: those were dropped as PASS by the Workflow
+   (partitioned into `result.already_satisfied`), leaving `result.dispositions` and
+   the escalation set both empty — `dispatch:qa-done` applies. (It also holds, as
+   before, when every `script-verifiable` and `needs-browser` item PASSed, zero
+   `needs-human-judgment` items were recorded, no bug was found, and none of the
+   non-residue blockers fired.)
 
    On a clean pass apply the `dispatch:qa-done` label via `dispatch-complete-phase`
    (use
@@ -880,7 +914,10 @@ Otherwise run all steps in order.
    Step 3b), the Chrome extension unavailable so browser items could not run (Step
    3c), a multi-app demo choice (Step 1), or the `origin/main` merge conflicted
    (Step 0.5). A `needs-main`-class residue item is **not** a member — it was filed
-   as a follow-up in Step 3.6 and does not, on its own, trigger this blocker.
+   as a follow-up in Step 3.6 and does not, on its own, trigger this blocker. An
+   `already-satisfied`-class residue item is likewise **not** a member — it was
+   dropped as PASS by the Workflow (absent from `result.dispositions`) and does not
+   trigger this blocker.
 
    Do **not** apply `dispatch:qa-done`. Escalate per the **Escalation** section
    below and **stop**.

--- a/.claude/workflows/qa-fix.js
+++ b/.claude/workflows/qa-fix.js
@@ -6,9 +6,11 @@
  * ------------
  * A self-contained, sandboxed Workflow-tool script structurally modeled on
  * .claude/workflows/review-fix.js. It ALWAYS classifies each QA residue item
- * (opus-fixable / needs-main / needs-human), adversarially verifies the
- * non-aesthetic `needs-human` calls with Sonnet skeptics, and returns the
- * resulting dispositions.
+ * (opus-fixable / needs-main / needs-human / already-satisfied), adversarially
+ * verifies the non-aesthetic `needs-human` calls with Sonnet skeptics, and
+ * returns the resulting dispositions. `already-satisfied` items — whose
+ * criterion is already provably met by readable evidence — are dropped from the
+ * residue as PASS, partitioned out into the `already_satisfied` return array.
  *
  * It is REPORT-ONLY when `plan_fix` is false (the #1551 callers): it emits no
  * fix plan and `deviation` is `false`. WHEN `plan_fix` is true AND at least one
@@ -30,12 +32,17 @@
  *
  * return OUT:
  *   { dispositions:[ { id, title, kind, class, aesthetic, verify, rationale } ],
+ *     already_satisfied:[ { id, title, kind, rationale } ],
  *     verify_report:[ { id, verdict, skeptic_votes, rationale } ],
  *     fix_plan: { units, deviation, deviation_reason } | null,
  *     deviation:boolean }
- *   - dispositions: one entry PER residue item, in input order. `class` is the
- *     FINAL class after any downgrade. `verify` is "Upheld"|"Refuted"|
- *     "Unverified"|"n/a".
+ *   - dispositions: one entry per residue item, in input order, EXCEPT
+ *     already-satisfied items, which are partitioned into `already_satisfied`.
+ *     `class` is the FINAL class after any downgrade. `verify` is "Upheld"|
+ *     "Refuted"|"Unverified"|"n/a".
+ *   - already_satisfied: items whose criterion is already provably met by
+ *     readable evidence (passing tests, page text, code) — dropped from the
+ *     residue as PASS, so no fix-plan and no office-hours escalation.
  *   - verify_report: one entry per NON-AESTHETIC needs-human candidate that went
  *     through the skeptic fan-out. `verdict` is "refuted"|"upheld"|"unverified".
  *   - fix_plan: the ordered Opus fix plan ({ units, deviation, deviation_reason })
@@ -52,7 +59,7 @@
 
 export const meta = {
   name: 'qa-fix',
-  description: 'QA disposition triage + gated fix-planning (#1553): classify each QA residue item opus-fixable / needs-main / needs-human and adversarially verify the needs-human calls; when plan_fix is set and opus-fixable items exist, emit an ordered Opus fix plan and a live deviation flag.',
+  description: 'QA disposition triage + gated fix-planning (#1553): classify each QA residue item opus-fixable / needs-main / needs-human / already-satisfied and adversarially verify the needs-human calls; when plan_fix is set and opus-fixable items exist, emit an ordered Opus fix plan and a live deviation flag.',
   phases: [{ title: 'classify' }, { title: 'verify' }, { title: 'fix-plan' }],
 };
 
@@ -71,7 +78,7 @@ const CLASSIFY_SCHEMA = {
         required: ['id', 'class', 'aesthetic', 'rationale'],
         properties: {
           id: { type: 'string' },
-          class: { enum: ['opus-fixable', 'needs-main', 'needs-human'] },
+          class: { enum: ['opus-fixable', 'needs-main', 'needs-human', 'already-satisfied'] },
           aesthetic: { type: 'boolean' },
           rationale: { type: 'string' },
         },
@@ -153,6 +160,15 @@ const hasRefuted = (votes) => votes.includes('refuted');
 //   the two contexts. Do not align them.
 function applyQaDisposition(classifications, votesById) {
   return classifications.map((c) => {
+    if (c.class === 'already-satisfied') {
+      // No-skeptic-fan-out pass-through, symmetric with the aesthetic bypass:
+      // the criterion is already provably met, so there is nothing to verify
+      // and nothing to fix. The `!== 'needs-human'` branch below would already
+      // return this exact shape; the explicit branch is for legibility and
+      // kernel-sync (so the dispatch-qa-disposition mirror reads the same),
+      // not a behavior fix.
+      return { id: c.id, final_class: 'already-satisfied', verify: 'n/a' };
+    }
     if (c.class !== 'needs-human') {
       // opus-fixable and needs-main pass straight through; never annotated.
       return { id: c.id, final_class: c.class, verify: 'n/a' };
@@ -214,11 +230,12 @@ const classifyItems = residue.map((r) => ({
 
 const classifyPrompt = [
   'You are the QA disposition-triage classifier. For each QA residue item below,',
-  'assign exactly one class: "opus-fixable", "needs-main", or "needs-human".',
+  'assign exactly one class: "opus-fixable", "needs-main", "needs-human", or',
+  '"already-satisfied".',
   '',
   UNTRUSTED_GUARD,
   '',
-  'THE THREE-WAY AXIS:',
+  'THE FOUR-WAY AXIS:',
   '- "opus-fixable" — a code defect, OR a "judgment" item that is really',
   '  resolvable from the DOM / page text with best judgment.',
   '- "needs-main" — only verifiable against merged main / production.',
@@ -226,6 +243,14 @@ const classifyPrompt = [
   '  "main-gated-fail", classify it "needs-main".',
   '- "needs-human" — a pixel-level "does this look right" aesthetic judgment, OR',
   '  a decision that requires the user\'s intent.',
+  '- "already-satisfied" — the item\'s criterion is already provably met by',
+  '  evidence the agent can read (passing tests, page text, code) — emit this',
+  '  when there is no code defect to fix, only a positive confirmation; no code',
+  '  change and no human needed.',
+  '',
+  'The schema still requires `aesthetic` on every item, so emit it for',
+  'already-satisfied items too — its value is immaterial (they never enter the',
+  'candidate filter), so `false` is fine.',
   '',
   'VISUAL-EVIDENCE HANDLING:',
   '- page_text is the always-reliable text-primary baseline.',
@@ -349,9 +374,11 @@ const dispoResults = applyQaDisposition(classifications, votesById);
 const dispoById = new Map(dispoResults.map((d) => [d.id, d]));
 const classMetaById = new Map(classifications.map((c) => [c.id, c]));
 
-// dispositions: one per residue item, in input order, joining residue
-// (id, title, kind) with the final class + aesthetic + verify + rationale.
-const dispositions = residue.map((r) => {
+// Full joined disposition list: one per residue item, in input order, joining
+// residue (id, title, kind) with the final class + aesthetic + verify +
+// rationale. PARTITION it below into the residue dispositions and the
+// already-satisfied PASS items.
+const allDispositions = residue.map((r) => {
   const d = dispoById.get(r.id);
   const c = classMetaById.get(r.id);
   return {
@@ -364,6 +391,16 @@ const dispositions = residue.map((r) => {
     rationale: c.rationale,
   };
 });
+
+// already_satisfied: items whose criterion is already provably met. They are
+// DROPPED from the residue as PASS — partitioned out so every downstream
+// consumer that filters/iterates `dispositions` naturally excludes them.
+const already_satisfied = allDispositions
+  .filter((d) => d.class === 'already-satisfied')
+  .map((d) => ({ id: d.id, title: d.title, kind: d.kind, rationale: d.rationale }));
+
+// dispositions: opus-fixable / needs-main / needs-human only, in input order.
+const dispositions = allDispositions.filter((d) => d.class !== 'already-satisfied');
 
 // verify_report: one entry per non-aesthetic needs-human candidate. verdict is
 // computed from votes exactly like review-fix.js's verify_report (lowercase):
@@ -478,6 +515,7 @@ if (_a.plan_fix === true && opusFixable.length > 0) {
 
 return {
   dispositions,
+  already_satisfied,
   verify_report,
   fix_plan,
   deviation: fix_plan ? fix_plan.deviation : false,


### PR DESCRIPTION
Closes #1841

## Summary

Adds a fourth QA disposition class **`already-satisfied`** so the disposition
workflow can auto-resolve items whose acceptance criterion is already provably
met — without parking the PR in office-hours.

### Root cause (#1040 item 4)

The disposition axis conflated two cases under `opus-fixable`: a genuine **code
defect** Opus can fix, and an **already-satisfied** criterion Opus can confirm
from evidence at hand (passing tests, page text, code) with no code change. The
gated fix-plan phase handled both as "plan a fix"; for the already-satisfied
case it produced no units and signaled `deviation=true`, which the skill treats
as an escalation signal — so the item parked in office-hours even though no
human and no code change were needed.

### Fix

`already-satisfied` items are **partitioned out** of the `dispositions` array
into a new top-level `already_satisfied` return array and **dropped from the
residue as PASS**. Because `dispositions` no longer contains them, every
downstream consumer that filters/iterates it (the `opusFixable` fix-plan filter,
the needs-main join, and the escalation set) naturally excludes them. A run whose
only residue items are all `already-satisfied` yields an empty `dispositions` →
empty escalation set → clean autonomous pass (`dispatch:qa-done`).

## Changes

- **`qa-fix.js`** — `already-satisfied` added to `CLASSIFY_SCHEMA`; classify
  prompt documents the four-way axis and when to emit it; `applyQaDisposition`
  gains an explicit first branch returning `{ final_class: 'already-satisfied',
  verify: 'n/a' }` (no skeptic fan-out, symmetric with the aesthetic bypass); the
  aggregation step partitions the joined list into `dispositions` (opus-fixable /
  needs-main / needs-human only, input order) and `already_satisfied`
  (`{ id, title, kind, rationale }`); header JSDoc updated.
- **`dispatch-qa-disposition`** (normative bash kernel) — mirrors the JS kernel
  with an explicit first `already-satisfied` jq branch and updated header docs;
  the inverted-polarity warning is left intact.
- **`test-dispatch-scripts.sh`** — new `f7` already-satisfied fixture asserts
  the first-branch pass-through (`final_class=already-satisfied`, `verify=n/a`)
  and extends the output-order check to `f1..f7`.
- **`qa-fix/SKILL.md`** — documents the four-class axis and the
  `already_satisfied` return field (Overview + Step 3.5); the Step 4 PR comment
  gains an "Assessed by Opus (already satisfied)" sub-section; **Step 6** now
  builds the escalation set directly from `result.dispositions` (the
  already-filtered output) rather than re-deriving class from the raw residue —
  closing the exact `undefined !== 'needs-main'` hole that would otherwise re-park
  an already-satisfied item.

## Acceptance criteria

- [x] `already-satisfied` is a valid `class` value in `CLASSIFY_SCHEMA`.
- [x] The classify-agent prompt defines when to use `already-satisfied`.
- [x] `already-satisfied` items are filtered out of the residue (dropped as PASS)
  before fix-plan; not passed to the fix-plan agent; absent from the escalation set.
- [x] `applyQaDisposition` returns `{ final_class: 'already-satisfied',
  verify: 'n/a' }` with no skeptic fan-out.
- [x] Step 4 PR-comment section lists already-satisfied items under "Assessed by
  Opus (already satisfied)" with rationale.
- [x] The normative `dispatch-qa-disposition` bash script adds the same fourth
  class and drop-as-PASS handling.
- [x] `SKILL.md` Step 3.5 documents the four-class axis and its drop-as-PASS
  treatment.

## Verification

- `node --check .claude/workflows/qa-fix.js` passes.
- `test-dispatch-scripts.sh` — all `qa-disposition` assertions pass, including the
  new `f7` already-satisfied case and the `f1..f7` order check.
