### PR TITLE
firebaseutil: extract auth-tier render controller

### DIFF
--- a/firebaseutil/package.json
+++ b/firebaseutil/package.json
@@ -8,7 +8,8 @@
     "./app-context": "./src/app-context.ts",
     "./error-sink": "./src/error-sink.ts",
     "./defer-appcheck": "./src/defer-appcheck.ts",
-    "./seed-storage": "./src/seed-storage.ts"
+    "./seed-storage": "./src/seed-storage.ts",
+    "./auth-tier-controller": "./src/auth-tier-controller.ts"
   },
   "peerDependencies": {
     "@commons-systems/errorutil": "*",

--- a/firebaseutil/src/auth-tier-controller.ts
+++ b/firebaseutil/src/auth-tier-controller.ts
@@ -1,0 +1,49 @@
+/** The tier a consumer's render callback must paint. Generic over loaded data D. */
+export type AuthTier<D> =
+  | { tier: "demo" }
+  | { tier: "owner"; data: D }
+  | { tier: "error" };
+
+export interface AuthTierController<U> {
+  /**
+   * Drive a new auth identity. Synchronously renders demo when user is null;
+   * otherwise loads and renders the owner tier, or the error tier on failure.
+   * A later call supersedes any in-flight load (generation guard), so a stale
+   * result cannot clobber a newer render. Never rejects.
+   */
+  handleAuthChange(user: U | null): void;
+}
+
+/**
+ * Create an auth-tier render controller. Renders the demo tier synchronously on
+ * construction (immediate demo paint), then transitions through owner/error
+ * tiers as auth identities arrive via handleAuthChange.
+ */
+export function createAuthTierController<U, D>({
+  load,
+  render,
+}: {
+  /** Load owner data for a signed-in user. Rejection → error tier. */
+  load: (user: U) => Promise<D>;
+  /** Paint a tier. Called synchronously with {tier:"demo"} on construction. */
+  render: (tier: AuthTier<D>) => void;
+}): AuthTierController<U> {
+  let generation = 0;
+  render({ tier: "demo" });
+  return {
+    handleAuthChange(user: U | null): void {
+      const gen = ++generation;
+      if (user === null) {
+        render({ tier: "demo" });
+        return;
+      }
+      load(user)
+        .then((data) => {
+          if (gen === generation) render({ tier: "owner", data });
+        })
+        .catch(() => {
+          if (gen === generation) render({ tier: "error" });
+        });
+    },
+  };
+}

--- a/firebaseutil/test/auth-tier-controller.test.ts
+++ b/firebaseutil/test/auth-tier-controller.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { createAuthTierController } from "../src/auth-tier-controller.js";
+
+interface TestUser {
+  uid: string;
+}
+
+interface OwnerData {
+  value: string;
+}
+
+describe("createAuthTierController", () => {
+  it("renders the demo tier synchronously on construction", () => {
+    const render = vi.fn();
+    const load = vi.fn<(user: TestUser) => Promise<OwnerData>>();
+
+    createAuthTierController({ load, render });
+
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledWith({ tier: "demo" });
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it("renders the demo tier synchronously when user is null", () => {
+    const render = vi.fn();
+    const load = vi.fn<(user: TestUser) => Promise<OwnerData>>();
+
+    const controller = createAuthTierController({ load, render });
+    render.mockClear();
+
+    controller.handleAuthChange(null);
+
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledWith({ tier: "demo" });
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it("renders the owner tier with loaded data when the load resolves", async () => {
+    const render = vi.fn();
+    const data: OwnerData = { value: "owner-payload" };
+    const load = vi.fn<(user: TestUser) => Promise<OwnerData>>(() =>
+      Promise.resolve(data),
+    );
+
+    const controller = createAuthTierController({ load, render });
+    render.mockClear();
+
+    controller.handleAuthChange({ uid: "u1" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(load).toHaveBeenCalledWith({ uid: "u1" });
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledWith({ tier: "owner", data });
+  });
+
+  it("renders the error tier when the load rejects", async () => {
+    const render = vi.fn();
+    const load = vi.fn<(user: TestUser) => Promise<OwnerData>>(() =>
+      Promise.reject(new Error("permission-denied")),
+    );
+
+    const controller = createAuthTierController({ load, render });
+    render.mockClear();
+
+    controller.handleAuthChange({ uid: "u1" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledWith({ tier: "error" });
+  });
+
+  it("does not render a stale result when the first load resolves after the second (guard direction A)", async () => {
+    const render = vi.fn();
+
+    // Manually-resolved deferred promises so we control resolution order.
+    let resolveFirst!: (data: OwnerData) => void;
+    let resolveSecond!: (data: OwnerData) => void;
+    const firstPromise = new Promise<OwnerData>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondPromise = new Promise<OwnerData>((resolve) => {
+      resolveSecond = resolve;
+    });
+
+    const load = vi
+      .fn<(user: TestUser) => Promise<OwnerData>>()
+      .mockReturnValueOnce(firstPromise)
+      .mockReturnValueOnce(secondPromise);
+
+    const controller = createAuthTierController({ load, render });
+    render.mockClear();
+
+    // Two overlapping auth changes for the SAME user identity — the first load
+    // is still in flight when the second begins. Using one identity is what
+    // discriminates the generation guard from a (rejected) user-identity guard:
+    // an identity guard would compare equal here and wrongly let the stale first
+    // result render, so this case only passes with the generation counter.
+    const user: TestUser = { uid: "u" };
+    controller.handleAuthChange(user);
+    controller.handleAuthChange(user);
+
+    // Resolve the SECOND (newer) load first, then the FIRST (stale) load.
+    resolveSecond({ value: "second" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    resolveFirst({ value: "first" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The stale (first) result must NOT render; only the newer second wins.
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledWith({ tier: "owner", data: { value: "second" } });
+    expect(render).not.toHaveBeenCalledWith({ tier: "owner", data: { value: "first" } });
+  });
+
+  it("renders the newer load's result (guard direction B)", async () => {
+    const render = vi.fn();
+
+    let resolveFirst!: (data: OwnerData) => void;
+    let resolveSecond!: (data: OwnerData) => void;
+    const firstPromise = new Promise<OwnerData>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondPromise = new Promise<OwnerData>((resolve) => {
+      resolveSecond = resolve;
+    });
+
+    const load = vi
+      .fn<(user: TestUser) => Promise<OwnerData>>()
+      .mockReturnValueOnce(firstPromise)
+      .mockReturnValueOnce(secondPromise);
+
+    const controller = createAuthTierController({ load, render });
+    render.mockClear();
+
+    const user: TestUser = { uid: "u" };
+    controller.handleAuthChange(user);
+    controller.handleAuthChange(user);
+
+    resolveSecond({ value: "second" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    resolveFirst({ value: "first" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The newer (second) load's result DOES render.
+    expect(render).toHaveBeenCalledWith({ tier: "owner", data: { value: "second" } });
+  });
+});

--- a/office-hours/src/main.ts
+++ b/office-hours/src/main.ts
@@ -4,6 +4,7 @@ import type { User } from "firebase/auth";
 import { deferProgrammerError } from "@commons-systems/errorutil/defer";
 import { logError } from "@commons-systems/errorutil/log";
 import { deferAppCheckInit } from "@commons-systems/firebaseutil/defer-appcheck";
+import { createAuthTierController } from "@commons-systems/firebaseutil/auth-tier-controller";
 
 import { createAppController } from "./app-controller.js";
 import { getOwnerReminders, getOwnerQueueMetrics } from "./data.js";
@@ -18,6 +19,10 @@ import {
   signOut,
   onAuthStateChanged,
 } from "./firebase.js";
+import type { UsageSample } from "./usage-samples.js";
+import type { Reminder } from "./reminders.js";
+import type { QueueMetricsSnapshot } from "./queue-metrics.js";
+import type { IssueSample } from "./issue-samples.js";
 
 const app = document.querySelector("#app");
 if (!app) throw new Error("#app element not found");
@@ -35,38 +40,40 @@ function updateAuthButton(user: User | null): void {
 // restarts the timer (clearing any prior interval — see createAppController).
 const controller = createAppController(app!);
 
-// Paint the demo tier immediately so the view is meaningful before auth resolves.
-controller.paint({ tier: "demo" }, new Date());
+type OwnerData = {
+  samples: UsageSample[];
+  reminders: Reminder[];
+  queueMetrics: QueueMetricsSnapshot | null;
+  issueSamples: IssueSample[];
+};
 
-async function refresh(): Promise<void> {
-  const refreshUser = currentUser;
-  if (refreshUser === null) {
-    controller.paint({ tier: "demo" }, new Date());
-    return;
-  }
-  try {
-    const [samples, reminders, queueMetrics, issueSamples] = await Promise.all([
-      getOwnerSamples(db, NAMESPACE, refreshUser),
-      getOwnerReminders(db, NAMESPACE, refreshUser),
-      getOwnerQueueMetrics(db, NAMESPACE, refreshUser),
-      getOwnerIssueSamples(db, NAMESPACE, refreshUser),
-    ]);
-    // Auth may have changed while the Firestore calls were in flight — skip the
-    // render so the in-flight result does not clobber the already-updated view.
-    if (currentUser !== refreshUser) return;
-    controller.paint({ tier: "owner", samples, reminders, queueMetrics, issueSamples }, new Date());
-  } catch (error) {
-    // Auth may have changed while the Firestore calls were in flight — skip the
-    // render so the in-flight error does not clobber the already-updated view.
-    if (currentUser !== refreshUser) return;
-    // Load failed — render an explicit error state rather than masking it as
-    // demo data. A non-owner's read is "permission-denied"; logError classifies it.
-    if (!deferProgrammerError(error)) {
-      logError(error, { operation: "load-owner-data" });
+// Paints the demo tier immediately (synchronous in constructor), then
+// transitions to owner/error as auth identities arrive via handleAuthChange.
+const auth = createAuthTierController<User, OwnerData>({
+  load: async (user) => {
+    try {
+      const [samples, reminders, queueMetrics, issueSamples] = await Promise.all([
+        getOwnerSamples(db, NAMESPACE, user),
+        getOwnerReminders(db, NAMESPACE, user),
+        getOwnerQueueMetrics(db, NAMESPACE, user),
+        getOwnerIssueSamples(db, NAMESPACE, user),
+      ]);
+      return { samples, reminders, queueMetrics, issueSamples };
+    } catch (error) {
+      // Load failed — render an explicit error state rather than masking it as
+      // demo data. A non-owner's read is "permission-denied"; logError classifies it.
+      if (!deferProgrammerError(error)) {
+        logError(error, { operation: "load-owner-data" });
+      }
+      throw error; // controller → error tier
     }
-    controller.paint({ tier: "error" }, new Date());
-  }
-}
+  },
+  render: (t) =>
+    controller.paint(
+      t.tier === "owner" ? { tier: "owner", ...t.data } : { tier: t.tier },
+      new Date(),
+    ),
+});
 
 authToggle.addEventListener("click", () => {
   if (currentUser) void signOut();
@@ -77,10 +84,7 @@ onAuthStateChanged((user) => {
   if (user?.uid === currentUser?.uid) return;
   currentUser = user;
   updateAuthButton(user);
-  refresh().catch((err) => {
-    if (deferProgrammerError(err)) return;
-    logError(err, { operation: "auth-change-refresh" });
-  });
+  auth.handleAuthChange(user);
 }).catch((err) => {
   if (deferProgrammerError(err)) return;
   logError(err, { operation: "auth-init" });


### PR DESCRIPTION
Closes #1462

## What

Extracts office-hours' hand-rolled demo→owner→error auth-tier render lifecycle
into a reusable, unit-testable controller in `@commons-systems/firebaseutil`,
then rewires office-hours to consume it.

office-hours previously hand-rolled its auth-driven render lifecycle in
`main.ts`: an immediate demo paint, an async `refresh()` that loaded owner data
and painted the owner or error tier, and a manual `currentUser !== refreshUser`
in-flight guard preventing a slow Firestore load from clobbering the view after
auth had already changed again. This tiering and guard are generic and now live
beside `createAppContext` as the "render half" of the app-composition layer.

## Changes

- **`firebaseutil/src/auth-tier-controller.ts`** (new) — `createAuthTierController({ load, render })`,
  generic over user type `U` and loaded-data type `D`. Owns exactly one
  responsibility: a new auth identity produces a tiered render, with stale
  in-flight loads superseded. The in-flight guard is a monotonic **generation
  counter** (not `User` identity), faithfully preserving the named
  `refreshUser !== currentUser` semantics. The controller never logs and never
  rejects — it only renders. Exposed at the package export
  `@commons-systems/firebaseutil/auth-tier-controller`.
- **`firebaseutil/test/auth-tier-controller.test.ts`** (new) — covers the
  synchronous demo paint on construction, all tier transitions, and both
  directions of the in-flight guard (stale first load dropped; newer load
  rendered) via manually-resolved deferred promises.
- **`office-hours/src/main.ts`** — adopts the controller. `refresh()` and its
  manual guard are gone; the load body moves into the controller's `load`
  callback (keeping `deferProgrammerError` / `logError({operation:"load-owner-data"})`
  / rethrow), and a `render → AppController.paint` adapter translates the tier
  union into a `ViewState`. The firebase subscription, uid dedup, auth button,
  and auth-init error handling stay app-side — that boundary is deliberate, so
  the controller stays testable by direct call with no firebase mock.

## Verification

- `firebaseutil`: vitest (new controller test passes), lint, typecheck clean.
- `office-hours`: build (tsc + vite), full test suite (242 tests), and lint all
  pass — behavior preserved exactly.

The demo/owner/error tiering and the stale-load guard are preserved; the guard
is now the controller's generation counter rather than per-app code.
