### PR TITLE
office-hours: syncOfficeHours mirrors merge-pr tracking issues as a new item kind

### DIFF
--- a/functions/src/office-hours-sync.ts
+++ b/functions/src/office-hours-sync.ts
@@ -118,7 +118,7 @@ export function parseMergePrMarker(body: string): MergePrMarker | null {
     typeof prRepo !== "string" ||
     prRepo === "" ||
     typeof prUrl !== "string" ||
-    prUrl === "" ||
+    !prUrl.startsWith("https://github.com/") ||
     typeof prTitle !== "string" ||
     prTitle === "" ||
     !Number.isInteger(prNumber) ||

--- a/functions/src/office-hours-sync.ts
+++ b/functions/src/office-hours-sync.ts
@@ -46,7 +46,8 @@ const NAMESPACE = defineString("OFFICE_HOURS_FIRESTORE_NAMESPACE", { default: "o
 
 const adminApp = getApps().length > 0 ? getApps()[0] : initializeApp();
 
-export interface JitIssue {
+export interface ReminderItem {
+  kind: "reminder";
   number: number;
   title: string;
   body: string;
@@ -55,10 +56,21 @@ export interface JitIssue {
   dueAt: Date | null;
 }
 
+export interface MergePrItem {
+  kind: "merge-pr";
+  number: number; // tracking-issue number
+  title: string; // tracking-issue title
+  repo: string; // scanned repo (office-hours-nate)
+  marker: MergePrMarker | null; // parsed PR fields; null ⇒ malformed (skip)
+}
+
+export type OfficeHoursItem = ReminderItem | MergePrItem;
+
 export interface SyncResult {
   written: number;
   deleted: number;
   skippedNoDate: number;
+  skippedMalformed: number;
 }
 
 // Matches the marker written by dispatch-jit-engine:
@@ -134,7 +146,7 @@ export function isValidJitKey(key: string): boolean {
 }
 
 export async function syncOfficeHoursCore(deps: {
-  fetchOpenJitIssues: () => Promise<JitIssue[]>;
+  fetchOpenJitIssues: () => Promise<OfficeHoursItem[]>;
   firestore: Firestore;
   namespace: string;
   memberEmails: string[];
@@ -149,38 +161,78 @@ export async function syncOfficeHoursCore(deps: {
   const writtenKeys = new Set<string>();
   let written = 0;
   let skippedNoDate = 0;
+  let skippedMalformed = 0;
 
   for (const issue of issues) {
-    if (!isValidJitKey(issue.jitKey)) {
-      console.warn(
-        `syncOfficeHours: issue #${issue.number} has invalid jitKey "${issue.jitKey}"; skipping`,
-      );
-      continue;
-    }
+    switch (issue.kind) {
+      case "reminder": {
+        if (!isValidJitKey(issue.jitKey)) {
+          console.warn(
+            `syncOfficeHours: issue #${issue.number} has invalid jitKey "${issue.jitKey}"; skipping`,
+          );
+          continue;
+        }
 
-    if (!issue.dueAt) {
-      skippedNoDate += 1;
-      console.warn(
-        `syncOfficeHours: issue #${issue.number} has no jit-due marker; skipping`,
-      );
-      continue;
-    }
+        if (!issue.dueAt) {
+          skippedNoDate += 1;
+          console.warn(
+            `syncOfficeHours: issue #${issue.number} has no jit-due marker; skipping`,
+          );
+          continue;
+        }
 
-    const dueAt = Timestamp.fromDate(issue.dueAt);
-    const docRef = itemsCollection.doc(issue.jitKey);
-    writes.push(
-      writer.set(docRef, {
-        title: issue.title,
-        dueAt,
-        repo: issue.repo,
-        issueNumber: issue.number,
-        jitKey: issue.jitKey,
-        memberEmails: deps.memberEmails,
-        updatedAt: FieldValue.serverTimestamp(),
-      }),
-    );
-    writtenKeys.add(issue.jitKey);
-    written += 1;
+        const dueAt = Timestamp.fromDate(issue.dueAt);
+        const docRef = itemsCollection.doc(issue.jitKey);
+        writes.push(
+          writer.set(docRef, {
+            kind: "reminder",
+            title: issue.title,
+            dueAt,
+            repo: issue.repo,
+            issueNumber: issue.number,
+            jitKey: issue.jitKey,
+            memberEmails: deps.memberEmails,
+            updatedAt: FieldValue.serverTimestamp(),
+          }),
+        );
+        writtenKeys.add(issue.jitKey);
+        written += 1;
+        break;
+      }
+      case "merge-pr": {
+        if (issue.marker === null) {
+          skippedMalformed += 1;
+          console.warn(
+            `syncOfficeHours: issue #${issue.number} has no/invalid oh-merge-pr marker; skipping`,
+          );
+          continue;
+        }
+
+        const docId = `merge-pr-${issue.marker.prNumber}`;
+        const docRef = itemsCollection.doc(docId);
+        writes.push(
+          writer.set(docRef, {
+            kind: "merge-pr",
+            title: issue.title,
+            prUrl: issue.marker.prUrl,
+            prTitle: issue.marker.prTitle,
+            prNumber: issue.marker.prNumber,
+            prRepo: issue.marker.prRepo,
+            repo: issue.repo,
+            issueNumber: issue.number,
+            memberEmails: deps.memberEmails,
+            updatedAt: FieldValue.serverTimestamp(),
+          }),
+        );
+        writtenKeys.add(docId);
+        written += 1;
+        break;
+      }
+      default: {
+        const _exhaustive: never = issue;
+        throw new Error("syncOfficeHours: unhandled item kind: " + String(_exhaustive));
+      }
+    }
   }
 
   const existing = await itemsCollection.get();
@@ -195,7 +247,7 @@ export async function syncOfficeHoursCore(deps: {
   await writer.close(); // flushes all enqueued writes in ≤500-op chunks
   await Promise.all(writes); // BulkWriter routes per-op failures to the individual op promises, not to close(); this is what re-raises them
 
-  return { written, deleted, skippedNoDate };
+  return { written, deleted, skippedNoDate, skippedMalformed };
 }
 
 // Builds a GitHub App JWT (RS256) signed with the App's private key. GitHub
@@ -313,7 +365,7 @@ async function githubGraphQL<T>(
 export async function fetchOpenJitIssuesLive(
   repo: string,
   token: string,
-): Promise<JitIssue[]> {
+): Promise<OfficeHoursItem[]> {
   const slash = repo.indexOf("/");
   if (slash <= 0 || slash === repo.length - 1) {
     throw new Error(`Invalid repo "${repo}"; expected "owner/name"`);
@@ -337,7 +389,7 @@ export async function fetchOpenJitIssuesLive(
     }
   `;
 
-  const results: JitIssue[] = [];
+  const results: OfficeHoursItem[] = [];
   let cursor: string | null = null;
 
   while (true) {
@@ -348,16 +400,35 @@ export async function fetchOpenJitIssuesLive(
     );
 
     for (const node of data.repository.issues.nodes) {
+      // A `merge-pr:` label wins over a `jit:` label if both somehow appear on
+      // one issue, so the discrimination is deterministic.
+      const mergePrLabel = node.labels.nodes.find((l) =>
+        l.name.startsWith("merge-pr:"),
+      );
+      if (mergePrLabel) {
+        results.push({
+          kind: "merge-pr",
+          number: node.number,
+          title: node.title,
+          repo,
+          marker: parseMergePrMarker(node.body),
+        });
+        continue;
+      }
+
       const jitLabel = node.labels.nodes.find((l) => l.name.startsWith("jit:"));
-      if (!jitLabel) continue;
-      results.push({
-        number: node.number,
-        title: node.title,
-        body: node.body,
-        jitKey: jitLabel.name.slice("jit:".length),
-        repo,
-        dueAt: parseJitDueMarker(node.body),
-      });
+      if (jitLabel) {
+        results.push({
+          kind: "reminder",
+          number: node.number,
+          title: node.title,
+          body: node.body,
+          jitKey: jitLabel.name.slice("jit:".length),
+          repo,
+          dueAt: parseJitDueMarker(node.body),
+        });
+        continue;
+      }
     }
 
     const { hasNextPage, endCursor } = data.repository.issues.pageInfo;
@@ -434,7 +505,7 @@ export const syncOfficeHours = onSchedule(
     });
 
     console.log(
-      `syncOfficeHours: wrote ${result.written}, deleted ${result.deleted}, skipped ${result.skippedNoDate} (no due date)`,
+      `syncOfficeHours: wrote ${result.written}, deleted ${result.deleted}, skipped ${result.skippedNoDate} (no due date), ${result.skippedMalformed} (malformed merge-pr)`,
     );
   },
 );

--- a/functions/src/office-hours-sync.ts
+++ b/functions/src/office-hours-sync.ts
@@ -74,6 +74,54 @@ export function parseJitDueMarker(body: string): Date | null {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
+export interface MergePrMarker {
+  prRepo: string;
+  prNumber: number;
+  prUrl: string;
+  prTitle: string;
+}
+
+// Matches the marker written by dispatch-sync-merge-queue:
+//   <!-- oh-merge-pr: {"repo":"natb1/commons.systems","number":42,"url":"https://...","title":"..."} -->
+// Mirrors the null-on-malformed contract of parseJitDueMarker: returns null for
+// any missing/wrong-typed field so callers need no additional guards.
+const OH_MERGE_PR_RE = /<!--\s*oh-merge-pr:\s*(\{.*?\})\s*-->/;
+
+export function parseMergePrMarker(body: string): MergePrMarker | null {
+  const match = body.match(OH_MERGE_PR_RE);
+  if (!match) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(match[1]);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+  const prRepo = obj["repo"];
+  const prNumber = obj["number"];
+  const prUrl = obj["url"];
+  const prTitle = obj["title"];
+  if (
+    typeof prRepo !== "string" ||
+    prRepo === "" ||
+    typeof prUrl !== "string" ||
+    prUrl === "" ||
+    typeof prTitle !== "string" ||
+    prTitle === "" ||
+    !Number.isInteger(prNumber) ||
+    (prNumber as number) <= 0
+  ) {
+    return null;
+  }
+  return {
+    prRepo,
+    prNumber: prNumber as number,
+    prUrl,
+    prTitle,
+  };
+}
+
 // A jitKey is the `jit:<key>` label suffix and becomes a Firestore document ID.
 // The label name is external input from the scanned repo, so guard it: a key
 // containing a slash would make `collection.doc(key)` resolve to a nested path

--- a/functions/test/office-hours-sync.test.ts
+++ b/functions/test/office-hours-sync.test.ts
@@ -404,7 +404,7 @@ describe("syncOfficeHoursCore", () => {
 
     // Only the valid key is written; the path-escaping / invalid keys are
     // skipped before any Firestore write, so no nested doc is created.
-    expect(result.written).toBe(1);
+    expect(result).toEqual({ written: 1, deleted: 0, skippedNoDate: 0, skippedMalformed: 0 });
     expect(store._docs.has("office-hours/prod/items/daily-chore")).toBe(true);
     expect(store._docs.has("office-hours/prod/items/a/b/c")).toBe(false);
     expect([...store._docs.keys()]).toEqual(["office-hours/prod/items/daily-chore"]);

--- a/functions/test/office-hours-sync.test.ts
+++ b/functions/test/office-hours-sync.test.ts
@@ -36,7 +36,8 @@ import {
   parseMergePrMarker,
   buildAppJwt,
   mintInstallationToken,
-  type JitIssue,
+  type ReminderItem,
+  type MergePrItem,
   type MergePrMarker,
 } from "../src/office-hours-sync";
 import { truncateForLog } from "../src/log-utils";
@@ -146,14 +147,35 @@ function createInMemoryFirestore(
   return { doc, collection, batch, bulkWriter, _docs: docs };
 }
 
-function makeIssue(overrides: Partial<JitIssue> = {}): JitIssue {
+function makeIssue(overrides: Partial<ReminderItem> = {}): ReminderItem {
   return {
+    kind: "reminder",
     number: 1,
     title: "Daily chore",
     body: "Recurring daily chore. Close when done.",
     jitKey: "daily-chore",
     repo: "natb1/office-hours-nate",
     dueAt: new Date("2026-01-15T12:00:00Z"),
+    ...overrides,
+  };
+}
+
+function makeMergePrIssue(
+  overrides: Partial<MergePrItem> = {},
+  markerOverrides: Partial<MergePrMarker> = {},
+): MergePrItem {
+  return {
+    kind: "merge-pr",
+    number: 100,
+    title: "Merge PR #42",
+    repo: "natb1/office-hours-nate",
+    marker: {
+      prRepo: "natb1/commons.systems",
+      prNumber: 42,
+      prUrl: "https://github.com/natb1/commons.systems/pull/42",
+      prTitle: "Some PR",
+      ...markerOverrides,
+    },
     ...overrides,
   };
 }
@@ -178,12 +200,18 @@ describe("syncOfficeHoursCore", () => {
       memberEmails: ["owner@example.com"],
     });
 
-    expect(result).toEqual({ written: 1, deleted: 0, skippedNoDate: 0 });
+    expect(result).toEqual({
+      written: 1,
+      deleted: 0,
+      skippedNoDate: 0,
+      skippedMalformed: 0,
+    });
 
     const written = store._docs.get("office-hours/prod/items/daily-chore") as Record<
       string,
       unknown
     > & { dueAt: { toDate: () => Date } };
+    expect(written.kind).toBe("reminder");
     expect(written.title).toBe("Daily chore");
     expect(written.repo).toBe("natb1/office-hours-nate");
     expect(written.issueNumber).toBe(42);
@@ -205,7 +233,12 @@ describe("syncOfficeHoursCore", () => {
       memberEmails: ["owner@example.com"],
     });
 
-    expect(result).toEqual({ written: 1, deleted: 0, skippedNoDate: 1 });
+    expect(result).toEqual({
+      written: 1,
+      deleted: 0,
+      skippedNoDate: 1,
+      skippedMalformed: 0,
+    });
     expect(store._docs.has("office-hours/prod/items/daily-chore")).toBe(true);
     expect(store._docs.has("office-hours/prod/items/budget-review")).toBe(false);
   });
@@ -224,7 +257,12 @@ describe("syncOfficeHoursCore", () => {
       memberEmails: ["owner@example.com"],
     });
 
-    expect(result).toEqual({ written: 0, deleted: 1, skippedNoDate: 0 });
+    expect(result).toEqual({
+      written: 0,
+      deleted: 1,
+      skippedNoDate: 0,
+      skippedMalformed: 0,
+    });
     expect(store._docs.has("office-hours/prod/items/stale-key")).toBe(false);
   });
 
@@ -242,10 +280,112 @@ describe("syncOfficeHoursCore", () => {
     const first = await syncOfficeHoursCore(deps);
     const second = await syncOfficeHoursCore(deps);
 
-    expect(first).toEqual({ written: 1, deleted: 0, skippedNoDate: 0 });
-    expect(second).toEqual({ written: 1, deleted: 0, skippedNoDate: 0 });
+    expect(first).toEqual({
+      written: 1,
+      deleted: 0,
+      skippedNoDate: 0,
+      skippedMalformed: 0,
+    });
+    expect(second).toEqual({
+      written: 1,
+      deleted: 0,
+      skippedNoDate: 0,
+      skippedMalformed: 0,
+    });
     expect(store._docs.size).toBe(1);
     expect(store._docs.has("office-hours/prod/items/daily-chore")).toBe(true);
+  });
+
+  it("writes a merge-pr item with a valid marker", async () => {
+    const store = createInMemoryFirestore();
+    const issue = makeMergePrIssue({ number: 200 });
+
+    const result = await syncOfficeHoursCore({
+      fetchOpenJitIssues: async () => [issue],
+      firestore: store as unknown as Firestore,
+      namespace: "office-hours/prod",
+      memberEmails: ["owner@example.com"],
+    });
+
+    expect(result).toEqual({
+      written: 1,
+      deleted: 0,
+      skippedNoDate: 0,
+      skippedMalformed: 0,
+    });
+
+    const written = store._docs.get("office-hours/prod/items/merge-pr-42") as
+      | Record<string, unknown>
+      | undefined;
+    expect(written).toBeDefined();
+    expect(written!.kind).toBe("merge-pr");
+    expect(written!.title).toBe("Merge PR #42");
+    expect(written!.prUrl).toBe("https://github.com/natb1/commons.systems/pull/42");
+    expect(written!.prTitle).toBe("Some PR");
+    expect(written!.prNumber).toBe(42);
+    expect(written!.prRepo).toBe("natb1/commons.systems");
+    expect(written!.repo).toBe("natb1/office-hours-nate");
+    expect(written!.issueNumber).toBe(200);
+    expect(written!.memberEmails).toEqual(["owner@example.com"]);
+    expect(written!.updatedAt).toBe("__server_timestamp__");
+    // merge-pr docs carry no dueAt field.
+    expect("dueAt" in written!).toBe(false);
+  });
+
+  it("skips a merge-pr issue with a null (malformed) marker", async () => {
+    const store = createInMemoryFirestore();
+    const issue = makeMergePrIssue({ number: 201, marker: null });
+
+    const result = await syncOfficeHoursCore({
+      fetchOpenJitIssues: async () => [issue],
+      firestore: store as unknown as Firestore,
+      namespace: "office-hours/prod",
+      memberEmails: ["owner@example.com"],
+    });
+
+    expect(result).toEqual({
+      written: 0,
+      deleted: 0,
+      skippedNoDate: 0,
+      skippedMalformed: 1,
+    });
+    expect(store._docs.size).toBe(0);
+  });
+
+  it("delete-reconciles stale docs of both kinds while writing the fresh set", async () => {
+    const store = createInMemoryFirestore();
+    // Seed one stale reminder and one stale merge-pr doc.
+    store._docs.set("office-hours/prod/items/stale-chore", {
+      kind: "reminder",
+      title: "Stale chore",
+      jitKey: "stale-chore",
+    });
+    store._docs.set("office-hours/prod/items/merge-pr-99", {
+      kind: "merge-pr",
+      title: "Stale merge",
+      prNumber: 99,
+    });
+
+    const freshReminder = makeIssue({ number: 1, jitKey: "fresh-chore" });
+    const freshMergePr = makeMergePrIssue({ number: 2 }, { prNumber: 7 });
+
+    const result = await syncOfficeHoursCore({
+      fetchOpenJitIssues: async () => [freshReminder, freshMergePr],
+      firestore: store as unknown as Firestore,
+      namespace: "office-hours/prod",
+      memberEmails: ["owner@example.com"],
+    });
+
+    expect(result).toEqual({
+      written: 2,
+      deleted: 2,
+      skippedNoDate: 0,
+      skippedMalformed: 0,
+    });
+    expect(store._docs.has("office-hours/prod/items/stale-chore")).toBe(false);
+    expect(store._docs.has("office-hours/prod/items/merge-pr-99")).toBe(false);
+    expect(store._docs.has("office-hours/prod/items/fresh-chore")).toBe(true);
+    expect(store._docs.has("office-hours/prod/items/merge-pr-7")).toBe(true);
   });
 
   it("skips an issue whose jitKey would escape the items collection", async () => {
@@ -525,6 +665,13 @@ describe("fetchOpenJitIssuesLive", () => {
                     body: "Body",
                     labels: { nodes: [{ name: "bug" }] },
                   },
+                  {
+                    number: 60,
+                    title: "Merge PR #42",
+                    body:
+                      'Body\n\n<!-- oh-merge-pr: {"repo":"natb1/commons.systems","number":42,"url":"https://github.com/natb1/commons.systems/pull/42","title":"Some PR"} -->',
+                    labels: { nodes: [{ name: "merge-pr:42" }] },
+                  },
                 ],
               },
             },
@@ -554,19 +701,39 @@ describe("fetchOpenJitIssuesLive", () => {
       cursor: null,
     });
 
-    expect(issues).toHaveLength(2);
-    expect(issues[0]).toMatchObject({
+    expect(issues).toHaveLength(3);
+
+    const reminder0 = issues[0] as ReminderItem;
+    expect(reminder0).toMatchObject({
+      kind: "reminder",
       number: 42,
       title: "Daily chore",
       jitKey: "daily-chore",
       repo: "natb1/office-hours-nate",
     });
-    expect(issues[0].dueAt?.toISOString()).toBe("2026-01-15T12:00:00.000Z");
-    expect(issues[1]).toMatchObject({
+    expect(reminder0.dueAt?.toISOString()).toBe("2026-01-15T12:00:00.000Z");
+
+    const reminder1 = issues[1] as ReminderItem;
+    expect(reminder1).toMatchObject({
+      kind: "reminder",
       number: 50,
       jitKey: "legacy",
       dueAt: null,
     });
+
+    // The merge-pr node yields a MergePrItem with a parsed marker.
+    const mergePr = issues[2] as MergePrItem;
+    expect(mergePr.kind).toBe("merge-pr");
+    expect(mergePr.number).toBe(60);
+    expect(mergePr.title).toBe("Merge PR #42");
+    expect(mergePr.repo).toBe("natb1/office-hours-nate");
+    expect(mergePr.marker).not.toBeNull();
+    expect(mergePr.marker!.prNumber).toBe(42);
+    expect(mergePr.marker!.prRepo).toBe("natb1/commons.systems");
+    expect(mergePr.marker!.prUrl).toBe(
+      "https://github.com/natb1/commons.systems/pull/42",
+    );
+    expect(mergePr.marker!.prTitle).toBe("Some PR");
   });
 
   it("throws when the fetch returns non-OK", async () => {
@@ -667,8 +834,8 @@ describe("fetchOpenJitIssuesLive", () => {
     expect(secondBody.variables.cursor).toBe("cursor-abc");
 
     expect(issues).toHaveLength(2);
-    expect(issues[0].jitKey).toBe("page1-key");
-    expect(issues[1].jitKey).toBe("page2-key");
+    expect((issues[0] as ReminderItem).jitKey).toBe("page1-key");
+    expect((issues[1] as ReminderItem).jitKey).toBe("page2-key");
   });
 
   it("stops pagination when hasNextPage is true but endCursor is null", async () => {
@@ -704,7 +871,7 @@ describe("fetchOpenJitIssuesLive", () => {
     // Must not loop — one fetch only.
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(issues).toHaveLength(1);
-    expect(issues[0].jitKey).toBe("solo-key");
+    expect((issues[0] as ReminderItem).jitKey).toBe("solo-key");
   });
 });
 

--- a/functions/test/office-hours-sync.test.ts
+++ b/functions/test/office-hours-sync.test.ts
@@ -33,9 +33,11 @@ import {
   syncOfficeHoursCore,
   fetchOpenJitIssuesLive,
   parseJitDueMarker,
+  parseMergePrMarker,
   buildAppJwt,
   mintInstallationToken,
   type JitIssue,
+  type MergePrMarker,
 } from "../src/office-hours-sync";
 import { truncateForLog } from "../src/log-utils";
 
@@ -408,6 +410,80 @@ describe("parseJitDueMarker", () => {
 
   it("returns null when the marker is malformed", () => {
     expect(parseJitDueMarker("<!-- jit-due: not-a-date -->")).toBeNull();
+  });
+});
+
+describe("parseMergePrMarker", () => {
+  const WELL_FORMED_BODY =
+    'Body text\n\n<!-- oh-merge-pr: {"repo":"natb1/commons.systems","number":42,"url":"https://github.com/natb1/commons.systems/pull/42","title":"Some PR"} -->';
+
+  it("parses a well-formed marker", () => {
+    const result = parseMergePrMarker(WELL_FORMED_BODY);
+    expect(result).not.toBeNull();
+    expect(result!.prRepo).toBe("natb1/commons.systems");
+    expect(result!.prNumber).toBe(42);
+    expect(result!.prUrl).toBe(
+      "https://github.com/natb1/commons.systems/pull/42"
+    );
+    expect(result!.prTitle).toBe("Some PR");
+  });
+
+  it("tolerates extra whitespace inside the marker", () => {
+    const body =
+      '<!--   oh-merge-pr:   {"repo":"natb1/commons.systems","number":42,"url":"https://github.com/natb1/commons.systems/pull/42","title":"Some PR"}   -->';
+    const result = parseMergePrMarker(body);
+    expect(result).not.toBeNull();
+    expect(result!.prNumber).toBe(42);
+  });
+
+  it("returns null when no marker is present", () => {
+    expect(parseMergePrMarker("Plain body, no marker.")).toBeNull();
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(
+      parseMergePrMarker("<!-- oh-merge-pr: {not json} -->")
+    ).toBeNull();
+  });
+
+  it("returns null when a field is missing (title omitted)", () => {
+    expect(
+      parseMergePrMarker(
+        '<!-- oh-merge-pr: {"repo":"natb1/commons.systems","number":42,"url":"https://github.com/natb1/commons.systems/pull/42"} -->'
+      )
+    ).toBeNull();
+  });
+
+  it("returns null when number is zero", () => {
+    expect(
+      parseMergePrMarker(
+        '<!-- oh-merge-pr: {"repo":"natb1/commons.systems","number":0,"url":"https://github.com/natb1/commons.systems/pull/42","title":"Some PR"} -->'
+      )
+    ).toBeNull();
+  });
+
+  it("returns null when number is negative", () => {
+    expect(
+      parseMergePrMarker(
+        '<!-- oh-merge-pr: {"repo":"natb1/commons.systems","number":-1,"url":"https://github.com/natb1/commons.systems/pull/42","title":"Some PR"} -->'
+      )
+    ).toBeNull();
+  });
+
+  it("returns null when number is non-integer (1.5)", () => {
+    expect(
+      parseMergePrMarker(
+        '<!-- oh-merge-pr: {"repo":"natb1/commons.systems","number":1.5,"url":"https://github.com/natb1/commons.systems/pull/42","title":"Some PR"} -->'
+      )
+    ).toBeNull();
+  });
+
+  it("returns null when number is a string", () => {
+    expect(
+      parseMergePrMarker(
+        '<!-- oh-merge-pr: {"repo":"natb1/commons.systems","number":"42","url":"https://github.com/natb1/commons.systems/pull/42","title":"Some PR"} -->'
+      )
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #1481

## What

Extend `syncOfficeHours` (`functions/src/office-hours-sync.ts`) to mirror
`merge-pr:*` tracking issues from `natb1/office-hours-nate` into the same
`office-hours/{env}/items` Firestore collection as the existing `jit:*`
reminders, as a new item kind. This is the **consumer** side of epic #1467;
the producer (sibling #1480, merged) find-or-creates a `merge-pr:<n>` issue per
mergeable PR carrying a one-line `<!-- oh-merge-pr: {…} -->` marker.

## How

- **Unit 1** — add `parseMergePrMarker` + the `MergePrMarker` interface, a pure
  parser mirroring `parseJitDueMarker`'s null-on-malformed contract. It returns
  `null` unless all four PR fields are present and well-typed (`prNumber` a
  positive integer), which guarantees the constructed `merge-pr-<prNumber>` doc
  id is always a single safe path segment.
- **Unit 2** — replace the in-memory `JitIssue` type with an `OfficeHoursItem`
  discriminated union (`ReminderItem` `kind:"reminder"` | `MergePrItem`
  `kind:"merge-pr"`). `fetchOpenJitIssuesLive` now discriminates by label
  (`merge-pr:` wins over `jit:` deterministically); `syncOfficeHoursCore`
  switches on `kind` with a `never` exhaustiveness guard. Reminder docs are
  unchanged behaviorally, now stamped `kind:"reminder"`. Merge-pr docs carry the
  four `pr*` fields, `repo`, `issueNumber`, `memberEmails` (load-bearing — the
  owner panel reads via `where("memberEmails","array-contains",…)`), and no
  `dueAt`. A malformed/missing marker skips-with-warning, counted by a new
  `skippedMalformed` `SyncResult` counter (parallel to `skippedNoDate`). The
  existing delete-reconcile is unchanged, so closing a tracking issue drops its
  `items` doc for free.

## Scope notes

- Rendering the new merge-pr items on the queue panel is the **separate** sibling
  #1482 — out of scope here. Until #1482 ships, the current reader `toReminder`
  returns `null` for a `dueAt`-less item and the read loop skips nulls, so
  merge-pr items are tolerated (one logged non-fatal validation error per
  merge-pr item per load until #1482 lands) — never crash the panel.

## Verification

- `npx vitest run --project functions` — 69/69 pass (3 files): new
  `parseMergePrMarker` block, merge-pr write, malformed-skip, dual-kind
  delete-reconcile, reminder-`kind` assertions, plus existing reminder /
  pagination / JWT / token tests all green.
- `npm run build --prefix functions` — `tsc` clean (discriminated union + `never`
  guard hold).

(The function is scheduled and GitHub-App-authenticated; unit coverage of
`syncOfficeHoursCore` with the in-memory Firestore is the established
verification seam — no emulator/deploy path.)
