### PR TITLE
dispatch: delegate plan-issue and implement-unit exploration to compact-findings subagents

### DIFF
--- a/.claude/skills/implement-unit/SKILL.md
+++ b/.claude/skills/implement-unit/SKILL.md
@@ -60,6 +60,23 @@ The caller supplies:
      changes at a time. `.claude/docs/firestore.md` is the authoritative source for
      all three.
 
+   - **If the unit's `scope` is broad or underspecified relative to its `path:line`
+     anchors** — e.g. "refactor across X" or "update all callers of Y" with no
+     enumerated paths, or anchors that name a target but not the surrounding code the
+     change depends on — gather context FIRST via up to 2 built-in `Explore` agents
+     (`subagent_type: Explore`, direct fan-out from this caller thread; the
+     implementation subagent cannot spawn built-in subagents, so exploration happens
+     here, pre-launch). Pass each agent the unit's `scope` and `context` inline. Each
+     RETURNS a compact structured findings block — **not** whole files: a **summary**,
+     **relevant excerpts** as small `path:line`-anchored spans, and **reuse
+     candidates** with their `path:line`. Fold the returned findings into the
+     `context` passed to the implementation subagent, which then reads far fewer whole
+     files — it receives findings + anchors instead of exploring from scratch.
+
+     **Default: do not explore.** When the plan's `path:line` anchors already pin the
+     unit's scope (the common case for most planned units), skip this and lean on the
+     anchors. A mandatory per-unit `Explore` would add cost, not remove it.
+
 2. **Commit, merge `origin/main`, and push — script-first, skill-fork fallback.**
    This step is the **canonical commit-merge-push recipe** — `/qa-fix` and
    `/review-fix` reference this step rather than restating it.

--- a/.claude/skills/implement-unit/SKILL.md
+++ b/.claude/skills/implement-unit/SKILL.md
@@ -66,8 +66,9 @@ The caller supplies:
      change depends on — gather context FIRST via up to 2 built-in `Explore` agents
      (`subagent_type: Explore`, direct fan-out from this caller thread; the
      implementation subagent cannot spawn built-in subagents, so exploration happens
-     here, pre-launch). Pass each agent the unit's `scope` and `context` inline. Each
-     RETURNS a compact structured findings block — **not** whole files: a **summary**,
+     here, pre-launch). Pass each agent the unit's `scope` and `context` inline.
+     Instruct each `Explore` agent to RETURN a compact structured findings block,
+     and to NOT dump whole files into its reply. Each agent returns: a **summary**,
      **relevant excerpts** as small `path:line`-anchored spans, and **reuse
      candidates** with their `path:line`. Fold the returned findings into the
      `context` passed to the implementation subagent, which then reads far fewer whole

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -35,7 +35,7 @@ The built-in plan-mode workflow normally injects its instructions as tool
 guidance when `EnterPlanMode` is active. This session does **not** enter plan
 mode, so it never receives them. The adopted plan-mode instructions are therefore
 reproduced **verbatim in the appendix** below — follow them as the authority for
-how to explore, design, review, and shape the plan artifact, with the two
+how to explore, design, review, and shape the plan artifact, with the
 substitutions the appendix documents.
 
 ## Idempotency preamble and target resolution
@@ -217,9 +217,9 @@ warranted).
 
 In each `Plan` agent's prompt, provide:
 
-1. The **Step-3 exploration context** — the filenames and code-path traces the
-   `Explore` agents surfaced. The `Plan` agents skip `CLAUDE.md`/git too, so this
-   context must be inline.
+1. The **Step-3 exploration context** — the compact findings the `Explore`
+   agents returned (summary, path:line-anchored excerpts, and reuse candidates).
+   The `Plan` agents skip `CLAUDE.md`/git too, so this context must be inline.
 2. The **issue scope and acceptance criteria**.
 3. The **`/implement-unit` model-selection heuristic, inline** (the `Plan` agent
    will not read `implement-unit/SKILL.md`, so reproduce it):

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -242,10 +242,18 @@ recommended approach only, not all alternatives.
 
 ### 5. Self-review — main thread
 
-Read the **critical files** the `Explore`/`Plan` subagents flagged before
-finalizing, to deepen your own understanding and confirm the plan is executable
-and aligned with the issue's acceptance criteria (the appendix's *Review* block).
-Resolve any disagreement between multiple `Plan` proposals here.
+Finalize from the **compact findings** the `Explore`/`Plan` subagents returned
+(Step 3's return contract) — not by re-reading critical files whole. Confirm the
+plan is executable and aligned with the issue's acceptance criteria, and resolve
+any disagreement between multiple `Plan` proposals here.
+
+**Bounded confirmatory read (escape hatch).** If a single specific decision
+turns on a detail the findings did not capture, you may `Read` **one specific
+span** (a named `path:line` range, not a whole file) to confirm it — a narrow,
+targeted check, never a re-hydration of the critical files. If you find yourself
+wanting to re-read files wholesale, the findings were insufficient: re-run a
+focused `Explore` agent (Step 3) with a tighter ask rather than pulling whole
+files into the parent.
 
 ### 6. Clarification / deviation gate — main thread
 
@@ -395,13 +403,17 @@ assemble the plan.
 
 This session does **not** have plan mode active, so it cannot receive these as
 injected tool instructions. They are reproduced verbatim and govern Steps 3–7,
-with two substitutions:
+with these substitutions:
 
 - (i) "the user's request" / "the user provided specific file paths" → the
   **issue scope / acceptance criteria** (there is no live user supplying paths).
 - (ii) "Use `AskUserQuestion` to clarify any remaining questions" is the
   **escalation trigger** (Step 6: ambiguity or major scope deviation →
   office-hours), **not** a routine default.
+- (iii) the *Review* block's "Read the critical files identified by agents" →
+  Step 5's **findings-first** discipline: finalize from the compact findings, and
+  only `Read` one named `path:line` span as a bounded confirmatory check — never
+  re-hydrate the critical files whole.
 
 ### Exploration (built-in `Explore`)
 

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -203,9 +203,7 @@ searches for existing implementations to reuse, another explores related
 components, a third investigates testing patterns). Follow the appendix's
 *Exploration* block.
 
-Collect from the agents: the relevant filenames, the code-path traces, and the
-reuse candidates with their file paths. This is the exploration context Step 4
-hands to the design agents.
+**Return contract (output format only — does not change how the agent explores).** Instruct each `Explore` agent to RETURN a compact structured findings block, and to NOT dump whole files into its reply. Each agent returns: a **summary** of what it found relevant to the issue scope; **relevant excerpts** as small `path:line`-anchored spans (the few lines that matter), not whole-file contents or large verbatim blocks; and **reuse candidates** — existing functions/utilities/patterns to reuse, each with its `path:line`. The parent context then carries these findings, not the files. Mirror the disposition-struct discipline from `review-fix`/`qa-fix`: the orchestrator "never holds raw findings — only this compact summary." This is the exploration context Step 4 hands to the design agents.
 
 ### 4. Design — built-in `Plan` subagent, direct fan-out
 


### PR DESCRIPTION
Closes #1855

## What

Pushes read-heavy codebase exploration in the `plan-issue` and `implement-unit`
phases into `Explore`/`Plan` subagents that return **compact structured
findings**, so the orchestrator and codegen contexts carry findings — not whole
files. Code generation does not move; only the exploratory reads do.

A 7-day dispatch token audit found context-over-120k spend dominated by
`plan-issue` and `implement-unit`, both over-hydrating context with whole-file
`Read`s done inline for exploration. This is an instruction-only change to two
`SKILL.md` files; no application code.

## Units

1. **plan-issue — Explore return contract.** Step 3's bare "collect" line is
   replaced with a stated return contract: each `Explore` agent returns a
   summary, small `path:line`-anchored excerpts (not whole files), and reuse
   candidates with their `path:line`. Governs output format only — it does not
   re-instruct how the agent explores.

2. **plan-issue — Step 5 finalizes from findings.** The Self-review step no
   longer re-reads the critical files whole; it finalizes from the compact
   findings, with a bounded escape hatch permitting a single named `path:line`
   span when one decision turns on a detail the findings missed — never wholesale
   re-hydration. A matching substitution bullet overrides the appendix `Review`
   block's "Read the critical files" line.

3. **implement-unit — conditional caller-thread exploration.** Step 1 gains a
   sibling bullet to the firestore bullet: for units whose scope is broad or
   under-anchored, gather context first via up to 2 caller-thread `Explore`
   agents returning compact findings, folded into the implementation subagent's
   `context`. Defaults to **not** exploring when the plan's `path:line` anchors
   already pin the scope (the common case), so it removes cost rather than adding
   it. The `Explore` fan-out is at the caller-thread level because the
   `general-purpose` implementation subagent cannot spawn built-in subagents.

## Verification

- Skill lint clean; the verbatim `>`-quoted appendix blocks in
  `plan-issue/SKILL.md` are byte-unchanged — the diff touches only the Step 3
  body, Step 5 body, the substitutions preamble, and implement-unit Step 1.
- End-to-end token effect is measured by `dispatch-token-audit` over a
  before/after window — the conditional gate in unit 3 guards against the
  exploration sessions inflating total tokens on already-anchored units.
