### PR TITLE
dispatch: persist token-audit window aggregates to a namespaced Firestore collection

### DIFF
--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -21,6 +21,20 @@ This skill parses recent Claude session transcripts and emits a ranked report of
 
    The script prints paths of any corrupt files and the total `files_failed` count to stderr. If `files_failed` is nonzero, surface that count in the report header so the reader knows the window data is incomplete.
 
+   **Optional: persist each window aggregate to Firestore.** When `DISPATCH_AUDIT_AGGREGATES_ENABLED=1` is set in the environment, `aggregate-usage.sh` pipes the assembled JSON document to `audit-aggregate-writer.mjs` after writing the report artifact. The writer stores it idempotently (`.set()` on a deterministic doc id) under `office-hours/{env}/audit-aggregates` via the firebase-admin SDK. The admin SDK bypasses Firestore security rules, so this does not depend on #1863's read rule being deployed. The write is fail-closed: writer failure exits non-zero with a clear stderr message, but only after the report file is already written.
+
+   Required additional env vars for the persist path (consumed by the writer binary):
+   - `DISPATCH_AUDIT_AGGREGATES_GROUP_ID` — owning group id (required, no `/`)
+   - ADC credentials: either `GOOGLE_APPLICATION_CREDENTIALS` pointing at a service-account key, or `gcloud auth application-default login`
+
+   Optional env vars (writer defaults shown):
+   - `DISPATCH_AUDIT_AGGREGATES_NAMESPACE` — Firestore path prefix, default `office-hours/prod`
+   - `DISPATCH_AUDIT_AGGREGATES_PROJECT_ID` — GCP project, default `commons-systems`
+   - `DISPATCH_AUDIT_AGGREGATES_TTL_DAYS` — retention days in [30, 730], default `365`
+   - `DISPATCH_AUDIT_AGGREGATES_WRITER` — override the writer binary path (test seam)
+
+   Member emails are NOT an env var. The writer resolves them from the `OFFICE_HOURS_MEMBER_EMAILS` Secret Manager secret at runtime (the same canonical secret the office-hours-sync Cloud Function uses). When the gate is off, report generation is unaffected and no Firestore writes occur.
+
 3. **Read cheaply via targeted jq slices** of `tmp/usage-audit.json`. Do NOT `cat` the whole file into context — read only the slices needed for each ranking step:
 
    ```bash

--- a/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
@@ -24,6 +24,16 @@
 #     --json-out PATH write the document to PATH instead of stdout.
 #   DISPATCH_AUDIT_PROJECTS_ROOT  override the projects root (used by the test
 #                     fixture). Default: $HOME/.claude/projects.
+#   DISPATCH_AUDIT_AGGREGATES_ENABLED  opt-in persist gate: set to "1" to pipe
+#                     each assembled aggregate JSON document to the writer binary
+#                     after the report artifact is written. Off by default so
+#                     machines without Firestore config stay inert.
+#   DISPATCH_AUDIT_AGGREGATES_WRITER  override the writer binary path (test
+#                     seam; mirrors DISPATCH_USAGE_SAMPLES_WRITER). Default:
+#                     $SCRIPT_DIR/audit-aggregate-writer.mjs.
+#   Additional DISPATCH_AUDIT_AGGREGATES_* env vars are consumed by the writer
+#   binary itself (GROUP_ID, NAMESPACE, TTL_DAYS, PROJECT_ID, etc.) — see
+#   audit-aggregate-writer.mjs for the full list.
 #
 # BEHAVIOR CONTRACT
 #   - The window filter uses an explicit timestamp computed from `date -d`. The
@@ -37,9 +47,17 @@
 #   - Prices are an Opus list-price-equivalent USD PROXY applied to every session
 #     regardless of its actual model — a relative-magnitude figure for ranking,
 #     NOT the actual bill.
+#   - When DISPATCH_AUDIT_AGGREGATES_ENABLED=1, the assembled JSON document is
+#     piped to the writer after the report artifact is written (json-out or
+#     stdout), so the report is always produced first. The writer's own stdout
+#     is redirected to stderr so the script's "stdout must stay a pure JSON
+#     document" contract holds regardless of the gate setting. Writer failure
+#     exits non-zero (clear error, fail-closed) but only after the report is
+#     written.
 #
 # EXIT CODES
 #   0  ok
+#   1  persist step (env-gated) failed; report still written
 #   2  usage error (bad/unknown arg, non-integer --days)
 set -euo pipefail
 
@@ -48,6 +66,8 @@ if ! date -d '1 day ago' +%s >/dev/null 2>&1; then
   echo "error: GNU date required (this script does not support BSD/macOS date)" >&2
   exit 2
 fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 DAYS=7
 JSON_OUT=""
@@ -554,4 +574,12 @@ if [[ -n "$JSON_OUT" ]]; then
   printf '%s\n' "$DOC" >"$JSON_OUT"
 else
   printf '%s\n' "$DOC"
+fi
+
+if [[ "${DISPATCH_AUDIT_AGGREGATES_ENABLED:-}" == "1" ]]; then
+  WRITER="${DISPATCH_AUDIT_AGGREGATES_WRITER:-$SCRIPT_DIR/audit-aggregate-writer.mjs}"
+  if ! printf '%s' "$DOC" | "$WRITER" >&2; then
+    echo "aggregate-usage.sh: audit-aggregate-writer failed; aggregate not persisted (report still written)" >&2
+    exit 1
+  fi
 fi

--- a/.claude/skills/dispatch-token-audit/scripts/audit-aggregate-writer.mjs
+++ b/.claude/skills/dispatch-token-audit/scripts/audit-aggregate-writer.mjs
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+// audit-aggregate-writer.mjs — firebase-admin writer for the office-hours
+// token-audit dashboard (writer side of #1862; epic #1859's audit view).
+//
+// PURPOSE
+//   Reads one token-audit window aggregate JSON document on stdin (the output of
+//   .claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh), validates
+//   env-var config and the payload (fail-closed), projects a CURATED subset into
+//   an `audit-aggregates` Firestore document, and writes it idempotently to
+//   `office-hours/{env}/audit-aggregates/{docId}` via the firebase-admin SDK.
+//   The audit skill computes the window aggregate on the author's machine (it
+//   reads local transcripts the hosted office-hours app cannot see) and pipes it
+//   here; the dashboard then reads the persisted aggregates.
+//
+//   The admin SDK bypasses Firestore security rules, so this writer does NOT
+//   depend on sibling #1863's read rule being deployed. #1863 owns the reader,
+//   seed, and chart panel; this file is the writer only.
+//
+// IDEMPOTENCY (the one deliberate divergence from usage-sample-writer.mjs)
+//   The usage sampler appends one doc per tick via auto-id `.add()`. This writer
+//   instead computes a DETERMINISTIC doc id and `.set()`s it, so re-running the
+//   audit for the same window overwrites in place rather than accumulating
+//   duplicates. The doc id is
+//     `${groupId}-${windowEndDate}-${windowDays}d`
+//   where windowEndDate is the UTC date (YYYY-MM-DD) of the payload's
+//   `window.until` — a pure function of the INPUT payload, never the writer's own
+//   clock, so a near-midnight re-run does not split one window into two docs.
+//
+// CONFIG (environment variables)
+//   Member emails are NOT read from the environment. In real mode they come from
+//     the OFFICE_HOURS_MEMBER_EMAILS Firebase/GCP Secret Manager secret — the same
+//     canonical secret the office-hours-sync Cloud Function reads (reused from
+//     #1257, #1377). The PII therefore lives only in Secret Manager, never in the
+//     repo, a shell var, or a local file. This writer does NOT mint a new secret.
+//   DISPATCH_AUDIT_AGGREGATES_SECRET_NAME    optional, non-PII override for the
+//     secret id; default "OFFICE_HOURS_MEMBER_EMAILS". Non-empty, no "/".
+//   DISPATCH_AUDIT_AGGREGATES_SECRET_OVERRIDE  --dry-run ONLY test seam: the raw
+//     comma-separated payload the secret would return. Consulted only in
+//     --dry-run; real mode always reads Secret Manager and never consults it.
+//   DISPATCH_AUDIT_AGGREGATES_GROUP_ID       owning group id. Required; non-empty
+//     and must contain no "/" (a slash would escape the collection path and the
+//     doc id).
+//   DISPATCH_AUDIT_AGGREGATES_NAMESPACE      default "office-hours/prod". Validated
+//     with the same regex the Function uses, pinning writes to office-hours/<env>.
+//   DISPATCH_AUDIT_AGGREGATES_TTL_DAYS       default "365". Integer in [30, 730];
+//     out of range or non-integer fails closed (clear error over a silent clamp,
+//     per .claude/rules/code-style.md). Feeds `expireAt` (see below).
+//   DISPATCH_AUDIT_AGGREGATES_PROJECT_ID     default "commons-systems".
+//   DISPATCH_AUDIT_AGGREGATES_NOW            epoch SECONDS for `computedAt`;
+//     defaults to Math.floor(Date.now()/1000). Test-determinism seam; a positive
+//     integer. NOTE: this seam feeds computedAt/expireAt ONLY — never the doc id.
+//
+// AUTH — Application Default Credentials (ADC)
+//   Real-mode runs authenticate via ADC: either GOOGLE_APPLICATION_CREDENTIALS
+//   pointing at a service-account key, or `gcloud auth application-default
+//   login`. The SAME ADC authenticates BOTH the Secret Manager read and the
+//   firebase-admin Firestore write. This file does NOT configure credentials.
+//   The service account needs roles/secretmanager.secretAccessor on the
+//   OFFICE_HOURS_MEMBER_EMAILS secret.
+//
+// FAIL-SAFE CONTRACT (per .claude/rules/code-style.md)
+//   Every validation or write failure prints exactly ONE stderr diagnostic line
+//   prefixed "audit-aggregate-writer:" and exits non-zero (1). Credentials and
+//   tokens are never echoed. Exit 0 only on a successful write (real mode) or a
+//   successful validation+assembly (--dry-run).
+//
+// MODES
+//   --dry-run  (first CLI arg): read stdin, run ALL config + payload validation,
+//     take the member-email list from DISPATCH_AUDIT_AGGREGATES_SECRET_OVERRIDE,
+//     assemble the doc with Timestamps rendered as ISO strings, print
+//     `{ "id": <docId>, "doc": <doc> }` as pretty JSON to stdout, exit 0. Neither
+//     firebase-admin nor @google-cloud/secret-manager is imported, so the bash
+//     unit tests stay dependency-free.
+//   real mode (no --dry-run): dynamically import @google-cloud/secret-manager and
+//     fetch the member-email list FIRST (fail-fast, before any firebase-admin
+//     init), then dynamically import firebase-admin, assemble the doc with
+//     firebase-admin Timestamps, `.set()` it under the deterministic doc id, print
+//     the doc id to stdout, exit 0.
+//   The field set and the epoch-second inputs are IDENTICAL between modes; only
+//   the Timestamp representation differs (ISO string vs admin Timestamp).
+//
+// TTL / RETENTION (documented-only here)
+//   `expireAt` = computedAt + TTL days. It is the field a Firestore TTL policy
+//   targets to age out old aggregates. Provisioning that TTL policy is OUT OF
+//   SCOPE for this writer — the field is written so the policy can be attached
+//   separately.
+
+const PREFIX = "audit-aggregate-writer:";
+
+function fail(message) {
+  process.stderr.write(`${PREFIX} ${message}\n`);
+  process.exit(1);
+}
+
+// Read all of stdin to a string.
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    process.stdin.on("data", (c) => chunks.push(c));
+    process.stdin.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    process.stdin.on("error", reject);
+  });
+}
+
+// A finite JS number (not a string, NaN, or Infinity).
+function isFiniteNumber(v) {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+// Default Secret Manager secret id for the member-email PII list. Reuses the
+// canonical secret the office-hours-sync Cloud Function reads (#1257, #1377);
+// do not create a second secret.
+const DEFAULT_SECRET_NAME = "OFFICE_HOURS_MEMBER_EMAILS";
+
+// Parse a comma-separated member-email payload into a trimmed, non-empty list.
+// Identical semantics to office-hours-sync.ts: split on ",", trim, drop empties.
+// An empty resolved list fails closed (the owner would be locked out of the doc).
+function resolveMemberEmails(rawCsv) {
+  const memberEmails = rawCsv
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (memberEmails.length === 0) {
+    fail("member-email list resolved to an empty list");
+  }
+  return memberEmails;
+}
+
+// Parse + validate config from the environment. Returns a config object or
+// calls fail() (which exits).
+function loadConfig(env) {
+  const secretName = env.DISPATCH_AUDIT_AGGREGATES_SECRET_NAME ?? DEFAULT_SECRET_NAME;
+  if (secretName.length === 0) {
+    fail("DISPATCH_AUDIT_AGGREGATES_SECRET_NAME must be non-empty");
+  }
+  if (secretName.includes("/")) {
+    fail("DISPATCH_AUDIT_AGGREGATES_SECRET_NAME must not contain a slash");
+  }
+
+  const groupId = env.DISPATCH_AUDIT_AGGREGATES_GROUP_ID;
+  if (typeof groupId !== "string" || groupId.length === 0) {
+    fail("DISPATCH_AUDIT_AGGREGATES_GROUP_ID is required and must be non-empty");
+  }
+  if (groupId.includes("/")) {
+    fail("DISPATCH_AUDIT_AGGREGATES_GROUP_ID must not contain a slash");
+  }
+
+  const namespace = env.DISPATCH_AUDIT_AGGREGATES_NAMESPACE ?? "office-hours/prod";
+  if (!/^office-hours\/[A-Za-z0-9][A-Za-z0-9-]*$/.test(namespace)) {
+    fail(`DISPATCH_AUDIT_AGGREGATES_NAMESPACE "${namespace}" is not a valid office-hours/<env> path`);
+  }
+
+  const ttlDaysStr = env.DISPATCH_AUDIT_AGGREGATES_TTL_DAYS ?? "365";
+  if (!/^\d+$/.test(ttlDaysStr)) {
+    fail(`DISPATCH_AUDIT_AGGREGATES_TTL_DAYS "${ttlDaysStr}" is not an integer`);
+  }
+  const ttlDays = Number(ttlDaysStr);
+  if (ttlDays < 30 || ttlDays > 730) {
+    fail(`DISPATCH_AUDIT_AGGREGATES_TTL_DAYS ${ttlDays} is outside the allowed range [30, 730]`);
+  }
+
+  const projectId = env.DISPATCH_AUDIT_AGGREGATES_PROJECT_ID ?? "commons-systems";
+  if (typeof projectId !== "string" || projectId.length === 0) {
+    fail("DISPATCH_AUDIT_AGGREGATES_PROJECT_ID must be non-empty");
+  }
+  if (projectId.includes("/")) {
+    fail("DISPATCH_AUDIT_AGGREGATES_PROJECT_ID must not contain a slash");
+  }
+
+  let nowEpochSeconds;
+  const nowStr = env.DISPATCH_AUDIT_AGGREGATES_NOW;
+  if (nowStr === undefined || nowStr === "") {
+    nowEpochSeconds = Math.floor(Date.now() / 1000);
+  } else {
+    if (!/^\d+$/.test(nowStr) || Number(nowStr) <= 0) {
+      fail(`DISPATCH_AUDIT_AGGREGATES_NOW "${nowStr}" is not a positive integer`);
+    }
+    nowEpochSeconds = Number(nowStr);
+  }
+
+  return { secretName, groupId, namespace, ttlDays, projectId, nowEpochSeconds };
+}
+
+// A plain finite-number token bucket {input, cache_creation, cache_read,
+// output}. Validates the four token counts an aggregate bucket always carries.
+function requireNumber(obj, path, field) {
+  const v = obj?.[field];
+  if (!isFiniteNumber(v)) {
+    fail(`payload field ${path}.${field} must be a finite number`);
+  }
+  return v;
+}
+
+// Project a by_phase / by_model bucket into the persisted shape. Both carry the
+// four token counts plus turns + price_proxy_usd.
+function projectBucket(bucket, path) {
+  if (bucket === null || typeof bucket !== "object" || Array.isArray(bucket)) {
+    fail(`payload field ${path} must be a JSON object`);
+  }
+  return {
+    input: requireNumber(bucket, path, "input"),
+    cache_creation: requireNumber(bucket, path, "cache_creation"),
+    cache_read: requireNumber(bucket, path, "cache_read"),
+    output: requireNumber(bucket, path, "output"),
+    turns: requireNumber(bucket, path, "turns"),
+    price_proxy_usd: requireNumber(bucket, path, "price_proxy_usd"),
+  };
+}
+
+// Project a {key: bucket} map (by_phase / by_model) into the persisted shape.
+function projectBucketMap(map, path) {
+  if (map === null || typeof map !== "object" || Array.isArray(map)) {
+    fail(`payload field ${path} must be a JSON object`);
+  }
+  const out = {};
+  for (const [key, bucket] of Object.entries(map)) {
+    out[key] = projectBucket(bucket, `${path}.${key}`);
+  }
+  return out;
+}
+
+// Compute the UTC date (YYYY-MM-DD) of the window-end timestamp. The aggregate
+// emits window.until as a bare `YYYY-MM-DD HH:MM:SS` wall-clock string (see
+// aggregate-usage.sh: `date '+%Y-%m-%d %H:%M:%S'`). We interpret those literal
+// components as a UTC instant so the date portion is a deterministic pure
+// function of the input string — independent of the harness timezone and of the
+// writer's own clock. Fails closed on an unparseable shape.
+function windowEndDateUtc(until) {
+  if (typeof until !== "string") {
+    fail("payload field window.until must be a string");
+  }
+  const m = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})/.exec(until);
+  if (!m) {
+    fail(`payload field window.until "${until}" is not a YYYY-MM-DD HH:MM:SS timestamp`);
+  }
+  const [, y, mo, d, h, mi, s] = m;
+  const ms = Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s));
+  if (!Number.isFinite(ms)) {
+    fail(`payload field window.until "${until}" is not a valid date`);
+  }
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+// Parse + validate the stdin payload, projecting only the curated subset. The
+// unbounded arrays (sessions, tool_sequences, payload_bytes, tool_errors) are
+// deliberately NOT read — persisting them risks the 1MB Firestore doc limit.
+// Returns a payload object or calls fail().
+function loadPayload(raw) {
+  let obj;
+  try {
+    obj = JSON.parse(raw);
+  } catch {
+    fail("stdin is not valid JSON");
+  }
+  if (obj === null || typeof obj !== "object" || Array.isArray(obj)) {
+    fail("stdin payload must be a JSON object");
+  }
+
+  const win = obj.window;
+  if (win === null || typeof win !== "object" || Array.isArray(win)) {
+    fail("payload field window must be a JSON object");
+  }
+  if (!Number.isInteger(win.days) || win.days <= 0) {
+    fail("payload field window.days must be a positive integer");
+  }
+  const windowEndDate = windowEndDateUtc(win.until);
+
+  const tot = obj.totals;
+  if (tot === null || typeof tot !== "object" || Array.isArray(tot)) {
+    fail("payload field totals must be a JSON object");
+  }
+
+  const pm = obj.price_model;
+  if (pm === null || typeof pm !== "object" || Array.isArray(pm)) {
+    fail("payload field price_model must be a JSON object");
+  }
+
+  const window = {
+    days: win.days,
+    since: requireString(win, "window", "since"),
+    until: win.until,
+    files_scanned: requireNumber(win, "window", "files_scanned"),
+    files_failed: requireNumber(win, "window", "files_failed"),
+  };
+
+  const totals = {
+    input: requireNumber(tot, "totals", "input"),
+    cache_creation: requireNumber(tot, "totals", "cache_creation"),
+    cache_read: requireNumber(tot, "totals", "cache_read"),
+    output: requireNumber(tot, "totals", "output"),
+    sessions: requireNumber(tot, "totals", "sessions"),
+    turns: requireNumber(tot, "totals", "turns"),
+    price_proxy_usd: requireNumber(tot, "totals", "price_proxy_usd"),
+  };
+
+  const priceModel = {
+    input_per_mtok: requireNumber(pm, "price_model", "input_per_mtok"),
+    cache_creation_per_mtok: requireNumber(pm, "price_model", "cache_creation_per_mtok"),
+    cache_read_per_mtok: requireNumber(pm, "price_model", "cache_read_per_mtok"),
+    output_per_mtok: requireNumber(pm, "price_model", "output_per_mtok"),
+  };
+
+  return {
+    windowDays: win.days,
+    windowEndDate,
+    window,
+    totals,
+    byPhase: projectBucketMap(obj.by_phase, "by_phase"),
+    byModel: projectBucketMap(obj.by_model, "by_model"),
+    priceModel,
+  };
+}
+
+function requireString(obj, path, field) {
+  const v = obj?.[field];
+  if (typeof v !== "string" || v.length === 0) {
+    fail(`payload field ${path}.${field} must be a non-empty string`);
+  }
+  return v;
+}
+
+// Compute the deterministic, idempotent doc id. A pure function of the payload
+// window (group + window-end UTC date + window length) — NEVER the writer clock.
+export function computeDocId(payload, config) {
+  return `${config.groupId}-${payload.windowEndDate}-${payload.windowDays}d`;
+}
+
+// Pure document assembly. `mkTimestamp(epochSeconds)` is the firebase-admin
+// seam: --dry-run injects an ISO-string factory; real mode injects
+// Timestamp.fromDate. The field set and epoch-second inputs are identical
+// across modes.
+export function assembleDoc(payload, config, mkTimestamp) {
+  return {
+    window: payload.window,
+    totals: payload.totals,
+    byPhase: payload.byPhase,
+    byModel: payload.byModel,
+    priceModel: payload.priceModel,
+    windowDays: payload.windowDays,
+    computedAt: mkTimestamp(config.nowEpochSeconds),
+    groupId: config.groupId,
+    memberEmails: config.memberEmails,
+    expireAt: mkTimestamp(config.nowEpochSeconds + config.ttlDays * 86400),
+  };
+}
+
+async function main() {
+  const dryRun = process.argv[2] === "--dry-run";
+
+  const config = loadConfig(process.env);
+  const raw = await readStdin();
+  const payload = loadPayload(raw);
+
+  if (dryRun) {
+    // Dry-run member-email source — a test seam carrying the raw payload the
+    // secret would return. Consulted ONLY here; never in real mode. Keeps the
+    // bash unit suite (no @google-cloud/secret-manager installed) dependency-free.
+    const rawSecret = process.env.DISPATCH_AUDIT_AGGREGATES_SECRET_OVERRIDE;
+    if (rawSecret === undefined) {
+      fail("--dry-run requires DISPATCH_AUDIT_AGGREGATES_SECRET_OVERRIDE");
+    }
+    config.memberEmails = resolveMemberEmails(rawSecret);
+
+    // ISO-string factory — keeps firebase-admin out of the dependency graph so
+    // the bash unit tests run without it.
+    const mkTimestamp = (epochSeconds) => new Date(epochSeconds * 1000).toISOString();
+    const doc = assembleDoc(payload, config, mkTimestamp);
+    const id = computeDocId(payload, config);
+    console.log(JSON.stringify({ id, doc }, null, 2));
+    process.exit(0);
+  }
+
+  // Real mode — resolve the member-email list from Secret Manager FIRST, before
+  // any firebase-admin init, so a secret/credential failure fails fast through
+  // main().catch -> fail() (one diagnostic, exit 1, no document, no creds echoed).
+  const { SecretManagerServiceClient } = await import("@google-cloud/secret-manager");
+  const secretClient = new SecretManagerServiceClient();
+  const [version] = await secretClient.accessSecretVersion({
+    name: `projects/${config.projectId}/secrets/${config.secretName}/versions/latest`,
+  });
+  if (!version?.payload?.data) {
+    fail(`secret ${config.secretName} returned an empty or missing payload`);
+  }
+  const rawSecret = version.payload.data.toString("utf8");
+  config.memberEmails = resolveMemberEmails(rawSecret);
+
+  // Import firebase-admin only on this path.
+  const { getApps, initializeApp } = await import("firebase-admin/app");
+  const { getFirestore, Timestamp } = await import("firebase-admin/firestore");
+
+  const app =
+    getApps().length > 0 ? getApps()[0] : initializeApp({ projectId: config.projectId });
+
+  const mkTimestamp = (epochSeconds) => Timestamp.fromDate(new Date(epochSeconds * 1000));
+  const doc = assembleDoc(payload, config, mkTimestamp);
+  const id = computeDocId(payload, config);
+
+  await getFirestore(app).collection(`${config.namespace}/audit-aggregates`).doc(id).set(doc);
+  console.log(id);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  // Never echo credentials/tokens — surface only the error message text.
+  const message = err && err.message ? err.message : String(err);
+  fail(message);
+});

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -265,19 +265,20 @@ echo ""
 echo "--- persist-wiring ---"
 
 FAKE_WRITER_DIR=$(mktemp -d)
-trap 'rm -rf "$FAKE_WRITER_DIR"' EXIT
+trap 'rm -rf "$FAKE_WRITER_DIR"; teardown' EXIT
 
 # P1 — gate OFF: writer never invoked.
 SENTINEL_P1="$FAKE_WRITER_DIR/invoked-p1"
 printf '#!/usr/bin/env bash\n: > %s\ncat >/dev/null\n' "'$SENTINEL_P1'" \
   > "$FAKE_WRITER_DIR/fake-writer-p1"
 chmod +x "$FAKE_WRITER_DIR/fake-writer-p1"
-(
+if (
   export DISPATCH_AUDIT_PROJECTS_ROOT="$ROOT"
   export DISPATCH_AUDIT_AGGREGATES_WRITER="$FAKE_WRITER_DIR/fake-writer-p1"
   unset DISPATCH_AUDIT_AGGREGATES_ENABLED 2>/dev/null || true
   bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7 >/dev/null
-)
+); then rc_p1=0; else rc_p1=$?; fi
+assert_eq "P1 gate-off: script succeeded" "0" "$rc_p1"
 assert_eq "P1 gate-off: writer not invoked" "1" \
   "$([[ ! -e "$SENTINEL_P1" ]] && echo 1 || echo 0)"
 

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -255,5 +255,86 @@ assert_eq "lenses.baseline_context.median_boot_tokens" "16.5" \
 assert_eq "lenses.baseline_context.total_proxy_usd" "$EXPECTED_BASELINE_PROXY" \
   "$(jq '.lenses.baseline_context.total_proxy_usd' <<<"$OUT")"
 
+# ---------------------------------------------------------------------------
+# Persist-wiring tests (Unit 2).  These use a fake writer stub controlled via
+# DISPATCH_AUDIT_AGGREGATES_WRITER, mirroring the DISPATCH_USAGE_SAMPLES_WRITER
+# pattern from test-dispatch-scripts.sh.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- persist-wiring ---"
+
+FAKE_WRITER_DIR=$(mktemp -d)
+trap 'rm -rf "$FAKE_WRITER_DIR"' EXIT
+
+# P1 — gate OFF: writer never invoked.
+SENTINEL_P1="$FAKE_WRITER_DIR/invoked-p1"
+printf '#!/usr/bin/env bash\n: > %s\ncat >/dev/null\n' "'$SENTINEL_P1'" \
+  > "$FAKE_WRITER_DIR/fake-writer-p1"
+chmod +x "$FAKE_WRITER_DIR/fake-writer-p1"
+(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$ROOT"
+  export DISPATCH_AUDIT_AGGREGATES_WRITER="$FAKE_WRITER_DIR/fake-writer-p1"
+  unset DISPATCH_AUDIT_AGGREGATES_ENABLED 2>/dev/null || true
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7 >/dev/null
+)
+assert_eq "P1 gate-off: writer not invoked" "1" \
+  "$([[ ! -e "$SENTINEL_P1" ]] && echo 1 || echo 0)"
+
+# P2 — gate ON: the assembled JSON is piped to the writer.
+CAPTURE_P2="$FAKE_WRITER_DIR/captured-p2.json"
+SENTINEL_P2="$FAKE_WRITER_DIR/invoked-p2"
+printf '#!/usr/bin/env bash\n: > %s\ncat > %s\n' "'$SENTINEL_P2'" "'$CAPTURE_P2'" \
+  > "$FAKE_WRITER_DIR/fake-writer-p2"
+chmod +x "$FAKE_WRITER_DIR/fake-writer-p2"
+JSON_OUT_P2="$FAKE_WRITER_DIR/report-p2.json"
+(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$ROOT"
+  export DISPATCH_AUDIT_AGGREGATES_ENABLED="1"
+  export DISPATCH_AUDIT_AGGREGATES_WRITER="$FAKE_WRITER_DIR/fake-writer-p2"
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7 --json-out "$JSON_OUT_P2"
+)
+assert_eq "P2 gate-on: writer invoked" "1" \
+  "$([[ -e "$SENTINEL_P2" ]] && echo 1 || echo 0)"
+# The document received by the writer must match the report file — both are
+# the same assembled JSON.
+GOT_P2=$(jq -S . "$CAPTURE_P2")
+WANT_P2=$(jq -S . "$JSON_OUT_P2")
+assert_eq "P2 gate-on: writer received full aggregate JSON" "$WANT_P2" "$GOT_P2"
+
+# P3 — writer-fail: aggregate-usage.sh exits non-zero AND the json-out file
+# still exists (report written before the failing persist step).
+JSON_OUT_P3="$FAKE_WRITER_DIR/report-p3.json"
+printf '#!/usr/bin/env bash\ncat >/dev/null\nexit 1\n' \
+  > "$FAKE_WRITER_DIR/fake-writer-p3"
+chmod +x "$FAKE_WRITER_DIR/fake-writer-p3"
+if (
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$ROOT"
+  export DISPATCH_AUDIT_AGGREGATES_ENABLED="1"
+  export DISPATCH_AUDIT_AGGREGATES_WRITER="$FAKE_WRITER_DIR/fake-writer-p3"
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7 --json-out "$JSON_OUT_P3" 2>/dev/null
+); then rc_p3=0; else rc_p3=$?; fi
+assert_eq "P3 writer-fail: exit non-zero" "1" "$([[ "$rc_p3" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "P3 writer-fail: json-out still written" "1" \
+  "$([[ -s "$JSON_OUT_P3" ]] && echo 1 || echo 0)"
+
+# P4 — gate ON stdout-mode: writer stdout must NOT leak into the script's
+# stdout (the >&2 redirect works).  The stub prints a recognizable token
+# to its own stdout; the script's stdout must be clean JSON that does NOT
+# contain that token.
+printf '#!/usr/bin/env bash\ncat >/dev/null\necho LEAKED-DOCID\n' \
+  > "$FAKE_WRITER_DIR/fake-writer-p4"
+chmod +x "$FAKE_WRITER_DIR/fake-writer-p4"
+OUT_P4=$(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$ROOT"
+  export DISPATCH_AUDIT_AGGREGATES_ENABLED="1"
+  export DISPATCH_AUDIT_AGGREGATES_WRITER="$FAKE_WRITER_DIR/fake-writer-p4"
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7
+)
+assert_eq "P4 stdout pure JSON (no leak): valid JSON" "object" \
+  "$(jq -r 'type' <<<"$OUT_P4")"
+assert_eq "P4 stdout pure JSON (no leak): token absent" "0" \
+  "$(grep -c 'LEAKED-DOCID' <<<"$OUT_P4" || true)"
+
 report_results
 exit $FAIL

--- a/.claude/skills/dispatch-token-audit/scripts/test-audit-aggregate-writer.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-audit-aggregate-writer.sh
@@ -122,6 +122,67 @@ OUT3=$(printf '%s' "$PAYLOAD" | DISPATCH_AUDIT_AGGREGATES_NOW=1790000000 node "$
 ID3=$(jq -r '.id' <<<"$OUT3")
 assert_eq "doc id unchanged when NOW changes" "$ID" "$ID3"
 
+# --- Case 9: fail-closed validation branches --------------------------------
+# Each branch must exit non-zero and print exactly the matching one-line stderr
+# diagnostic prefixed "audit-aggregate-writer:". assert_fail captures both the
+# exit code and stderr so a wrong-but-still-failing branch can't pass silently.
+#
+# stdin is the otherwise-valid PAYLOAD unless a case overrides it, so the only
+# thing under test in each case is the single injected fault.
+assert_fail() {
+  local name="$1" expected_diag="$2"; shift 2
+  # "$@" is the env-prefixed node invocation; run it with the valid PAYLOAD on
+  # stdin, capturing stderr and the exit code.
+  local err rc
+  err=$(printf '%s' "$PAYLOAD" | "$@" 2>&1 >/dev/null) && rc=0 || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s\n      expected: non-zero exit\n      actual:   exit 0\n' "$name"
+    return
+  fi
+  if [[ "$err" == *"$expected_diag"* ]]; then
+    PASS=$((PASS + 1))
+    printf 'ok   %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s\n      expected diag substring: %s\n      actual stderr:           %s\n' \
+      "$name" "$expected_diag" "$err"
+  fi
+}
+
+# (a) unset GROUP_ID → required-and-non-empty error.
+assert_fail "unset GROUP_ID → fail-closed" \
+  "audit-aggregate-writer: DISPATCH_AUDIT_AGGREGATES_GROUP_ID is required and must be non-empty" \
+  env -u DISPATCH_AUDIT_AGGREGATES_GROUP_ID node "$WRITER_MJS" --dry-run
+
+# (b) TTL_DAYS=20 → out-of-range [30, 730] error.
+assert_fail "TTL_DAYS=20 (below range) → fail-closed" \
+  "audit-aggregate-writer: DISPATCH_AUDIT_AGGREGATES_TTL_DAYS 20 is outside the allowed range [30, 730]" \
+  env DISPATCH_AUDIT_AGGREGATES_TTL_DAYS=20 node "$WRITER_MJS" --dry-run
+
+# (b') TTL_DAYS=abc → non-integer error (the other TTL branch).
+assert_fail "TTL_DAYS=abc (non-integer) → fail-closed" \
+  'audit-aggregate-writer: DISPATCH_AUDIT_AGGREGATES_TTL_DAYS "abc" is not an integer' \
+  env DISPATCH_AUDIT_AGGREGATES_TTL_DAYS=abc node "$WRITER_MJS" --dry-run
+
+# (c) stdin that is not JSON → parse error. Override stdin via a dedicated run.
+NOT_JSON_ERR=$(printf 'not json' | node "$WRITER_MJS" --dry-run 2>&1 >/dev/null) && NOT_JSON_RC=0 || NOT_JSON_RC=$?
+assert_eq "stdin not JSON → exit non-zero" "1" "$([[ "$NOT_JSON_RC" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "stdin not JSON → diagnostic" "1" \
+  "$([[ "$NOT_JSON_ERR" == *'audit-aggregate-writer: stdin is not valid JSON'* ]] && echo 1 || echo 0)"
+
+# (c') stdin missing by_phase → bucket-map object error (malformed payload field).
+NO_BY_PHASE=$(jq -c 'del(.by_phase)' <<<"$PAYLOAD")
+MISSING_ERR=$(printf '%s' "$NO_BY_PHASE" | node "$WRITER_MJS" --dry-run 2>&1 >/dev/null) && MISSING_RC=0 || MISSING_RC=$?
+assert_eq "stdin missing by_phase → exit non-zero" "1" "$([[ "$MISSING_RC" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "stdin missing by_phase → diagnostic" "1" \
+  "$([[ "$MISSING_ERR" == *'audit-aggregate-writer: payload field by_phase must be a JSON object'* ]] && echo 1 || echo 0)"
+
+# (d) --dry-run without SECRET_OVERRIDE → the dry-run-only guard.
+assert_fail "dry-run without SECRET_OVERRIDE → fail-closed" \
+  "audit-aggregate-writer: --dry-run requires DISPATCH_AUDIT_AGGREGATES_SECRET_OVERRIDE" \
+  env -u DISPATCH_AUDIT_AGGREGATES_SECRET_OVERRIDE node "$WRITER_MJS" --dry-run
+
 # --- Summary ----------------------------------------------------------------
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.claude/skills/dispatch-token-audit/scripts/test-audit-aggregate-writer.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-audit-aggregate-writer.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# test-audit-aggregate-writer.sh — dependency-free dry-run unit test for
+# audit-aggregate-writer.mjs (writer side of #1862).
+#
+# Runs the writer ONLY in --dry-run, so firebase-admin and
+# @google-cloud/secret-manager are NEVER imported and no network/credentials are
+# touched. The DISPATCH_AUDIT_AGGREGATES_NOW seam pins computedAt/expireAt and
+# DISPATCH_AUDIT_AGGREGATES_SECRET_OVERRIDE supplies dummy member emails, so the
+# suite is fully deterministic and runs without node_modules.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRITER_MJS="$SCRIPT_DIR/audit-aggregate-writer.mjs"
+
+PASS=0
+FAIL=0
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    printf 'ok   %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s\n      expected: %s\n      actual:   %s\n' "$name" "$expected" "$actual"
+  fi
+}
+
+# Fixed epoch for determinism. NOTE: this NOW is deliberately on a DIFFERENT
+# calendar day than the window.until below, so the doc-id test proves the id
+# uses window.until's date, not the writer clock.
+#   NOW   = 1780600000 = 2026-06-04T... UTC
+#   TTL   = 365 days (default) → expireAt = NOW + 365*86400 = 1812136000
+AA_NOW=1780600000
+AA_EXPIRE=1812136000   # AA_NOW + 365*86400
+
+# Representative aggregate JSON (the aggregate-usage.sh output shape). Includes
+# the unbounded arrays the writer MUST drop (sessions/tool_sequences/
+# payload_bytes/tool_errors) so we can assert their absence in the doc. window
+# .until is 2026-06-10 (a different day than NOW's 2026-06-04).
+PAYLOAD='{
+  "window": {"days": 7, "since": "2026-06-03 12:00:00", "until": "2026-06-10 12:00:00", "files_scanned": 42, "files_failed": 1},
+  "price_model": {"note": "proxy", "input_per_mtok": 15, "cache_creation_per_mtok": 18.75, "cache_read_per_mtok": 1.5, "output_per_mtok": 75},
+  "totals": {"input": 100, "cache_creation": 200, "cache_read": 300, "output": 400, "sessions": 5, "turns": 50, "price_proxy_usd": 1.23},
+  "by_session_type": {"worker": {"input": 1}},
+  "by_phase": {"review-fix": {"input": 10, "cache_creation": 20, "cache_read": 30, "output": 40, "turns": 5, "price_proxy_usd": 0.5}},
+  "by_model": {"opus": {"input": 11, "cache_creation": 21, "cache_read": 31, "output": 41, "turns": 6, "price_proxy_usd": 0.6}},
+  "by_phase_model": {"x": {"input": 1}},
+  "tool_errors": {"sig": {"count": 3}},
+  "tool_sequences": {"top": [1, 2, 3], "distinct": 99},
+  "payload_bytes": {"total": 12345, "by_tool": [{"tool": "Read"}]},
+  "lenses": {"context_over_120k": {"sessions": 2}},
+  "sessions": [{"id": "abc", "turns": 9}]
+}'
+
+run_writer() { printf '%s' "$PAYLOAD" | node "$WRITER_MJS" --dry-run; }
+
+export DISPATCH_AUDIT_AGGREGATES_SECRET_OVERRIDE="a@b.com,c@d.com"
+export DISPATCH_AUDIT_AGGREGATES_GROUP_ID="grp-1"
+export DISPATCH_AUDIT_AGGREGATES_NOW="$AA_NOW"
+
+# --- Case 1: valid payload → exit 0, envelope shape -------------------------
+if OUT=$(run_writer 2>/dev/null); then RC=0; else RC=$?; fi
+assert_eq "valid payload → exit 0" "0" "$RC"
+assert_eq "envelope has id + doc" "1" \
+  "$(jq -e 'has("id") and has("doc")' <<<"$OUT" >/dev/null 2>&1 && echo 1 || echo 0)"
+
+# --- Case 2: curated subset present -----------------------------------------
+assert_eq "doc has curated fields" "1" \
+  "$(jq -e '.doc | has("window") and has("totals") and has("byPhase") and has("byModel") and has("priceModel") and has("windowDays") and has("computedAt") and has("groupId") and has("memberEmails") and has("expireAt")' <<<"$OUT" >/dev/null 2>&1 && echo 1 || echo 0)"
+
+# --- Case 3: unbounded arrays ABSENT ----------------------------------------
+assert_eq "doc omits sessions" "false" "$(jq -c '.doc | has("sessions")' <<<"$OUT")"
+assert_eq "doc omits tool_sequences" "false" "$(jq -c '.doc | has("tool_sequences")' <<<"$OUT")"
+assert_eq "doc omits payload_bytes" "false" "$(jq -c '.doc | has("payload_bytes")' <<<"$OUT")"
+assert_eq "doc omits tool_errors" "false" "$(jq -c '.doc | has("tool_errors")' <<<"$OUT")"
+# Also dropped: by_session_type, by_phase_model, lenses, and price_model.note.
+assert_eq "doc omits by_session_type" "false" "$(jq -c '.doc | has("by_session_type")' <<<"$OUT")"
+assert_eq "doc omits lenses" "false" "$(jq -c '.doc | has("lenses")' <<<"$OUT")"
+assert_eq "priceModel omits note" "false" "$(jq -c '.doc.priceModel | has("note")' <<<"$OUT")"
+
+# --- Case 4: curated values match input -------------------------------------
+assert_eq "window meta projected" \
+  '{"days":7,"since":"2026-06-03 12:00:00","until":"2026-06-10 12:00:00","files_scanned":42,"files_failed":1}' \
+  "$(jq -c '.doc.window' <<<"$OUT")"
+assert_eq "totals projected" \
+  '{"input":100,"cache_creation":200,"cache_read":300,"output":400,"sessions":5,"turns":50,"price_proxy_usd":1.23}' \
+  "$(jq -c '.doc.totals' <<<"$OUT")"
+assert_eq "byPhase projected" \
+  '{"review-fix":{"input":10,"cache_creation":20,"cache_read":30,"output":40,"turns":5,"price_proxy_usd":0.5}}' \
+  "$(jq -c '.doc.byPhase' <<<"$OUT")"
+assert_eq "byModel projected" \
+  '{"opus":{"input":11,"cache_creation":21,"cache_read":31,"output":41,"turns":6,"price_proxy_usd":0.6}}' \
+  "$(jq -c '.doc.byModel' <<<"$OUT")"
+assert_eq "priceModel projected (4 rates only)" \
+  '{"input_per_mtok":15,"cache_creation_per_mtok":18.75,"cache_read_per_mtok":1.5,"output_per_mtok":75}' \
+  "$(jq -c '.doc.priceModel' <<<"$OUT")"
+
+# --- Case 5: usage-samples-convention fields --------------------------------
+assert_eq "windowDays" "7" "$(jq -r '.doc.windowDays' <<<"$OUT")"
+assert_eq "groupId" "grp-1" "$(jq -r '.doc.groupId' <<<"$OUT")"
+assert_eq "memberEmails" '["a@b.com","c@d.com"]' "$(jq -c '.doc.memberEmails' <<<"$OUT")"
+assert_eq "computedAt epoch == NOW" "$AA_NOW" \
+  "$(date -u -d "$(jq -r '.doc.computedAt' <<<"$OUT")" +%s)"
+assert_eq "expireAt epoch == NOW + TTL*86400" "$AA_EXPIRE" \
+  "$(date -u -d "$(jq -r '.doc.expireAt' <<<"$OUT")" +%s)"
+
+# --- Case 6: deterministic doc id uses window.until date, not NOW -----------
+ID=$(jq -r '.id' <<<"$OUT")
+# window.until is 2026-06-10; NOW (1780600000) is 2026-06-04 → id must say 06-10.
+assert_eq "doc id = group-untilDate-Nd" "grp-1-2026-06-10-7d" "$ID"
+assert_eq "doc id uses window.until date not NOW" "1" \
+  "$([[ "$ID" == *"2026-06-10"* && "$ID" != *"2026-06-04"* ]] && echo 1 || echo 0)"
+
+# --- Case 7: idempotency — id STABLE across two runs of the same payload ----
+if OUT2=$(run_writer 2>/dev/null); then :; fi
+ID2=$(jq -r '.id' <<<"$OUT2")
+assert_eq "doc id stable across two runs" "$ID" "$ID2"
+
+# --- Case 8: NOW does not affect the doc id (re-run with a different NOW) ----
+# Re-run with NOW on yet another day; the id must NOT change (pure fn of payload).
+OUT3=$(printf '%s' "$PAYLOAD" | DISPATCH_AUDIT_AGGREGATES_NOW=1790000000 node "$WRITER_MJS" --dry-run 2>/dev/null)
+ID3=$(jq -r '.id' <<<"$OUT3")
+assert_eq "doc id unchanged when NOW changes" "$ID" "$ID3"
+
+# --- Summary ----------------------------------------------------------------
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #1862

## What

Makes the `/dispatch-token-audit` pipeline persist each window's aggregate to a
namespaced Firestore collection `office-hours/{env}/audit-aggregates` — one
document per window, idempotent per window. Previously `aggregate-usage.sh`
produced a rich per-window aggregate JSON and discarded it after the report, so
there was no persisted history to trend against.

This is the **writer half** of the office-hours audit-dashboard epic (#1859).
The reader + seed + chart panel is the sibling sub-issue #1863.

## How

**Unit 1 — `audit-aggregate-writer.mjs` + dry-run test.** A new firebase-admin
writer modeled closely on `usage-sample-writer.mjs` (the writer half of #1007):
same `fail()` fail-closed contract, `loadConfig(env)` validation surface, pure
`assembleDoc(...)`, and `--dry-run`/real-mode split. It reads the full aggregate
JSON on stdin and projects a curated subset (`window`, `totals`, `byPhase`,
`byModel`, `priceModel`) — deliberately dropping the unbounded arrays
(`sessions`, `tool_sequences`, `payload_bytes`, `tool_errors`) that risk
Firestore's 1MB doc limit. It adds the usage-samples-convention fields
(`windowDays`, `computedAt`, `groupId`, `memberEmails`, `expireAt`).

The one deliberate divergence from the `.add()` template: a **deterministic doc
id** `${groupId}-${windowEndDate}-${windowDays}d` written via `.set()`, so
re-running a window overwrites in place rather than appending a duplicate.
`windowEndDate` is the UTC date portion of the payload's `window.until` — a pure
function of the input, never the writer's clock — so a near-midnight re-run
cannot split one window into two docs.

**Unit 2 — env-gated persist wiring + docs.** `aggregate-usage.sh` gains a
default-off `DISPATCH_AUDIT_AGGREGATES_ENABLED=1` gate that pipes the assembled
aggregate to the writer **after** the report artifact is written (so the report
is always produced first), with the writer's stdout redirected to stderr to keep
the script's pure-JSON stdout contract. The writer binary is overridable via
`DISPATCH_AUDIT_AGGREGATES_WRITER` (the test seam). On writer failure the script
fails closed with a clear error. `SKILL.md` documents the persist step.

## Scope notes

- **No `firestore.rules` change.** The writer uses the firebase-admin SDK, which
  bypasses Firestore security rules. The `memberEmails` array-contains read rule
  for `audit-aggregates` is only needed by the reader sibling #1863 and ships
  there — matching the #1007/#1006 writer-before-rules split.
- **No reader, seed, or chart panel** — those are #1863.
- **No TTL policy provisioning** — the writer writes an `expireAt` field so a
  Firestore TTL policy can be attached separately.

## Verification

- `test-audit-aggregate-writer.sh` — 24/24 pass (projected field set, curated
  subset, unbounded arrays absent, convention fields, deterministic doc id stable
  across re-runs and across a changed `NOW` clock).
- `test-aggregate-usage.sh` — 35/35 pass (existing cases + new persist-wiring
  cases: gate-off, gate-on-via-stub, writer-fail-keeps-json-out, pure-stdout).

Real-mode Firestore write and the office-hours read are exercised by the reader
sibling #1863; this PR is verified at the writer/dry-run boundary.
