### PR TITLE
dispatch: gate review-fix finders by diff surface, scale skeptics by severity, fail fast on a throttled model

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-security-surface
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-security-surface
@@ -70,10 +70,14 @@ if [[ "$all_docs" == true ]]; then
 fi
 
 # --- check all-tests ---------------------------------------------------------
+# A path that is also a dependency manifest (e.g. test/package.json) matches
+# TEST_RE via the directory-prefix patterns but still carries dependency attack
+# surface. Treat any such path as non-test so the diff falls through to the
+# surface=code branch, where DEPS_RE runs and the npm/CodeQL fan-out fires.
 
 all_tests=true
 for path in "${paths[@]}"; do
-  if ! [[ "$path" =~ $TEST_RE ]]; then
+  if ! [[ "$path" =~ $TEST_RE ]] || [[ "$path" =~ $DEPS_RE ]]; then
     all_tests=false
     break
   fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-security-surface
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-security-surface
@@ -4,7 +4,7 @@
 #
 # Reads newline-separated changed file paths on stdin. Prints exactly three
 # lines to stdout:
-#   surface=<empty|docs|code>
+#   surface=<empty|docs|tests|code>
 #   deps=<true|false>
 #   app_or_rules=<true|false>
 #
@@ -19,6 +19,11 @@ set -euo pipefail
 # extension here would misclassify code files such as NOTICE.ts or LICENSE.sh as
 # docs and skip the security fan-out.
 DOCS_RE='(\.(md|mdx|markdown|txt|rst|adoc)$)|((^|/)(LICENSE|NOTICE|AUTHORS|CONTRIBUTORS)$)'
+
+# TEST: test/spec files that carry no production attack surface — standard
+# language test suffixes, Go _test.go files, __tests__ dirs, test/ and spec/
+# directory prefixes, and shell test scripts.
+TEST_RE='(\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$)|((^|/)[^/]+_test\.go$)|((^|/)__tests__/)|((^|/)(test|tests|spec|e2e)/)|((^|/)test-[^/]*\.(sh|bash)$)'
 
 # DEPS: npm dependency manifests.
 DEPS_RE='(^|/)package(-lock)?\.json$'
@@ -64,7 +69,27 @@ if [[ "$all_docs" == true ]]; then
   exit 0
 fi
 
+# --- check all-tests ---------------------------------------------------------
+
+all_tests=true
+for path in "${paths[@]}"; do
+  if ! [[ "$path" =~ $TEST_RE ]]; then
+    all_tests=false
+    break
+  fi
+done
+
+if [[ "$all_tests" == true ]]; then
+  echo "surface=tests"
+  echo "deps=false"
+  echo "app_or_rules=false"
+  exit 0
+fi
+
 # --- surface=code: compute deps and app_or_rules ----------------------------
+# Order is load-bearing: empty → all-docs → all-tests → code. A mixed
+# docs+tests diff (neither all-docs nor all-tests) correctly falls through
+# to code, which is the conservative boundary for mixed diffs.
 
 deps=false
 app_or_rules=false

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -25206,6 +25206,55 @@ assert_eq "surface: non-.claude sh → code no app_or_rules" "surface=code
 deps=false
 app_or_rules=false" "$out"
 
+# src/foo.test.ts → tests
+out=$(printf '%s\n' "src/foo.test.ts" | "$SCRIPT_DIR/dispatch-security-surface")
+assert_eq "surface: tests .test.ts" "surface=tests
+deps=false
+app_or_rules=false" "$out"
+
+# landing/src/app.spec.tsx → tests
+out=$(printf '%s\n' "landing/src/app.spec.tsx" | "$SCRIPT_DIR/dispatch-security-surface")
+assert_eq "surface: tests .spec.tsx" "surface=tests
+deps=false
+app_or_rules=false" "$out"
+
+# budget-etl/main_test.go → tests
+out=$(printf '%s\n' "budget-etl/main_test.go" | "$SCRIPT_DIR/dispatch-security-surface")
+assert_eq "surface: tests _test.go" "surface=tests
+deps=false
+app_or_rules=false" "$out"
+
+# src/__tests__/foo.ts → tests
+out=$(printf '%s\n' "src/__tests__/foo.ts" | "$SCRIPT_DIR/dispatch-security-surface")
+assert_eq "surface: tests __tests__ dir" "surface=tests
+deps=false
+app_or_rules=false" "$out"
+
+# test/fixtures/x.json → tests
+out=$(printf '%s\n' "test/fixtures/x.json" | "$SCRIPT_DIR/dispatch-security-surface")
+assert_eq "surface: tests test/ dir prefix" "surface=tests
+deps=false
+app_or_rules=false" "$out"
+
+# .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh → tests
+out=$(printf '%s\n' ".claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh" | "$SCRIPT_DIR/dispatch-security-surface")
+assert_eq "surface: tests test-*.sh script" "surface=tests
+deps=false
+app_or_rules=false" "$out"
+
+# mixed README.md + src/foo.test.ts → code (not all-docs, not all-tests);
+# .test.ts still carries the .ts extension so app_or_rules=true
+out=$(printf '%s\n' "README.md" "src/foo.test.ts" | "$SCRIPT_DIR/dispatch-security-surface")
+assert_eq "surface: mixed doc+test → code" "surface=code
+deps=false
+app_or_rules=true" "$out"
+
+# mixed src/foo.test.ts + src/bar.ts → code (a real source file present)
+out=$(printf '%s\n' "src/foo.test.ts" "src/bar.ts" | "$SCRIPT_DIR/dispatch-security-surface")
+assert_eq "surface: mixed test+source → code" "surface=code
+deps=false
+app_or_rules=true" "$out"
+
 # ============================================================================
 # === dispatch-changed-files ===
 # ============================================================================
@@ -25613,6 +25662,11 @@ assert_eq "finders: code surface → codeql present" "1" "$n"
 # codeql gating: absent on docs surface
 n=$(printf 'surface=docs\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -c '^codeql$' || true)
 assert_eq "finders: docs surface → codeql absent" "0" "$n"
+
+# tests surface → exactly code-review and review (no security finders)
+out=$(printf 'surface=tests\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders")
+assert_eq "finders: tests → code-review,review only" "code-review
+review" "$out"
 
 # ============================================================================
 # === dispatch-review-dedup ===

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -138,7 +138,8 @@ of diff size.
 
 - `surface` is `empty` (no changed files), `docs` (every changed path is
   documentation — markdown/text/license, no executable, config, dependency, or
-  rules surface), or `code` (anything else).
+  rules surface), `tests` (every changed path is a test file — no production
+  source, config, dependency, or rules surface), or `code` (anything else).
 - `deps` is `true` when the diff touches `package.json` / `package-lock.json`.
 - `app_or_rules` is `true` when the diff touches application source
   (`.ts`/`.tsx`/`.js`/`.jsx`/`.mjs`/`.cjs`/`.go` outside `.claude/`) or a
@@ -146,6 +147,7 @@ of diff size.
 
 Set `security_note` for the Workflow `args`:
 - `surface=docs`: `Security review: no attack surface — docs-only diff (no executable, config, dependency, or Firestore-rules changes).`
+- `surface=tests`: `Security review: no attack surface — test-only diff (every changed path is a test file).`
 - `surface=empty`: `Security review: no attack surface — diff is empty (no changed files detected).`
 - `surface=code`: omit `security_note` (leave it unset).
 
@@ -230,12 +232,12 @@ args = {
   pr_num:              <PR_NUM>,
   merge_base:          <MERGE_BASE>,
   changed_files:       [ ...the changed-file list from the pack's === DIFF section (same list dispatch-changed-files extracts)... ],
-  surface:             "empty" | "docs" | "code",
+  surface:             "empty" | "docs" | "tests" | "code",
   deps:                <true|false>,
   app_or_rules:        <true|false>,
   prescanned_findings: [ ...normalized CodeQL + npm findings in Per-finding schema... ],
   implementing_issues: [ <N>, ... ],    // parsed from Closes #N lines; [] if none
-  security_note:       <string or omit> // set for empty/docs; omit for code
+  security_note:       <string or omit> // set for empty/docs/tests; omit for code
 }
 ```
 
@@ -616,10 +618,10 @@ through to the unified set — has these fields:
 
 ## Edge cases
 
-- **Empty or docs-only diff** — `surface` is `empty` or `docs`; the Workflow
-  launches no security finders and no security agents. The code-review and review
-  agents still run. The skill still applies `dispatch:reviewed` and writes the
-  marker.
+- **Empty, docs-only, or test-only diff** — `surface` is `empty`, `docs`, or
+  `tests`; the Workflow launches no security finders and no security agents. The
+  code-review and review agents still run. The skill still applies
+  `dispatch:reviewed` and writes the marker.
 - **A finder finds nothing** — record that source as clean; it contributes no
   findings to the Workflow.
 - **A finder agent fails** — the Workflow retries once. If it fails again, partial

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -254,6 +254,8 @@ result = {
   security_followup_input: [ ...codeql/npm out-of-scope subset... ],
   verify_report:        [ {id, location, verdict, skeptic_votes, rationale} ],
   deviation:            <bool>,
+  coverage_incomplete:  <bool>,
+  coverage_note?:       <string>,
   security_note?:       <string>
 }
 ```

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-fix
-description: Review phase — the workflow's single terminal review pass. Runs the combined /review-fix fan-out through the Workflow tool: surface-conditional finders (code-review, review, security domain reviewers) in parallel → code dedup → classify → adversarial-verify (Required findings refuted by 2 skeptics before any Opus fix runs) → Opus fix fan-out → deferred/follow-up filing prep. Returns a compact disposition summary; applies fixes via one /commit-merge-push, files blocked_by follow-ups, posts one PR comment, and applies the dispatch:reviewed label
+description: Review phase — the workflow's single terminal review pass. Runs the combined /review-fix fan-out through the Workflow tool: surface-conditional finders (code-review, review, security domain reviewers) in parallel → code dedup → classify → adversarial-verify (Required findings refuted by severity-scaled skeptics — 2 for high-confidence, 1 below — before any Opus fix runs) → Opus fix fan-out → deferred/follow-up filing prep. Returns a compact disposition summary; applies fixes via one /commit-merge-push, files blocked_by follow-ups, posts one PR comment, and applies the dispatch:reviewed label
 ---
 
 # Review and Fix

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -490,8 +490,11 @@ stands in for the security buckets):
 
 If a security reviewer or inline scan could not run (re-launch / retry exhausted),
 note partial coverage here — name the reviewer or scan whose domain could not be
-reviewed. If every bucket is empty and there was no security note, the comment is
-still well-formed (render empty buckets as `_None._`).
+reviewed. When `result.coverage_incomplete` is true, include `result.coverage_note`
+in this partial-coverage line (the probe-wave skipped the security finders because
+both quality finders died — the model was likely throttled). If every bucket is
+empty and there was no security note, the comment is still well-formed (render
+empty buckets as `_None._`).
 
 Then post it (use `dangerouslyDisableSandbox: true` — the script invokes `gh`):
 
@@ -661,3 +664,21 @@ claude-sonnet-4-6`). The model tiering is now owned by the Workflow's per-`agent
 Opus fix agents** (`model: opus`) write all working-tree changes. Fix-authoring is
 pinned to Opus **exactly once** in the Workflow's fix phase — there is no
 double-tiering. The orchestrator (this skill) authors no product code.
+
+**Probe-wave throttle short-circuit (#1857).** On a `code` surface the Workflow
+splits the finder fan-out into two waves instead of one barrier. Wave 1 launches
+only the two always-on quality finders (`code-review`, `review`) — real review
+work that runs on every surface — and doubles them as a throttle probe. If **both**
+return `null` (a strong outage signal — far more robust than a single flake), the
+Workflow skips the security finder wave entirely rather than waste those launches
+on a throttled model, and sets `result.coverage_incomplete = true` with a human
+`result.coverage_note` (surfaced in the Step 6 partial-coverage line). Otherwise
+wave 2 launches the surface-gated security finders. On `empty`/`docs`/`tests`
+surfaces there are no security finders, so this degenerates to a single wave (no
+change). **Marker/label behavior is intentionally unchanged:** a throttled run
+still applies `dispatch:reviewed` and writes the marker — this matches today's
+behavior when all finders return `null`, producing a degraded quality-only review.
+This is a launch-efficiency change only; genuine worker *death* on a transient
+rate-limit (and its backed-off resume) remains #1733's responsibility via the Stop
+hook, not this gate. `coverage_incomplete` is independent of the `deviation`
+criterion.

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -179,6 +179,9 @@ const FIX_SCHEMA = {
 // Returns the AGENT finder-source set (the codeql/npm finders are NOT agents —
 // they arrive via args.prescanned_findings — so they are excluded here).
 function agentFinderSet(surface, app_or_rules) {
+  // Any non-`code` surface (`empty`/`docs`/`tests`) yields only the two quality
+  // finders — the `surface === 'code'` gate below covers `tests` with no code
+  // change, since a test-only diff has no production attack surface.
   const set = ['code-review', 'review'];
   if (surface === 'code') {
     set.push('input-validation', 'secrets', 'red-team', 'security-review');

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -365,22 +365,52 @@ function finderPrompt(name, args) {
 const _a = typeof args === 'string' ? JSON.parse(args) : (args || {});
 log(`args type: ${typeof args}; surface=${_a.surface}; changed_files count=${(_a.changed_files || []).length}`);
 
-// --- 1. FINDERS (parallel, barrier) ------------------------------------------
+// --- 1. FINDERS (two waves, probe-gated) -------------------------------------
 phase('finders');
 const finderNames = agentFinderSet(_a.surface, _a.app_or_rules);
-log(`finders: launching ${finderNames.length} agent finder(s) for surface=${_a.surface}`);
-
-const finderResults = await parallel(
-  finderNames.map((name) => () =>
-    agent(finderPrompt(name, _a), {
-      model: 'sonnet',
-      agentType: 'general-purpose',
-      schema: FINDINGS_SCHEMA,
-      label: `find:${name}`,
-      phase: 'finders',
-    })
-  )
+// Probe-wave throttle short-circuit: the two always-on quality finders are real
+// review work that runs on every surface, so launch them FIRST as wave 1 and
+// double them as a throttle probe. If BOTH return null (a strong outage signal —
+// far more robust than one flake), skip the security finder wave entirely rather
+// than waste those launches on a throttled model. On empty/docs/tests surfaces
+// there are no security finders, so this degenerates to a single wave (no change).
+const qualityFinders = finderNames.filter((n) => n === 'code-review' || n === 'review');
+const securityFinders = finderNames.filter((n) => n !== 'code-review' && n !== 'review');
+log(
+  `finders: wave 1 = ${qualityFinders.length} quality finder(s); ` +
+    `${securityFinders.length} security finder(s) pending for surface=${_a.surface}`
 );
+
+const launchFinder = (name) => () =>
+  agent(finderPrompt(name, _a), {
+    model: 'sonnet',
+    agentType: 'general-purpose',
+    schema: FINDINGS_SCHEMA,
+    label: `find:${name}`,
+    phase: 'finders',
+  });
+
+// Wave 1 — the quality finders (also the throttle probe).
+const qualityResults = await parallel(qualityFinders.map(launchFinder));
+
+// Gate: both quality finders dead → model likely throttled; skip the security
+// wave. coverage_incomplete records the degraded review for the Step 6 comment.
+let securityResults = [];
+let coverage_incomplete = false;
+let coverage_note = '';
+const bothQualityDead = qualityResults.filter(Boolean).length === 0;
+if (securityFinders.length && bothQualityDead) {
+  coverage_incomplete = true;
+  coverage_note =
+    'Security finders skipped: both quality finders failed (model likely throttled).';
+  log(`finders: ${coverage_note} Backing off the security wave.`);
+} else if (securityFinders.length) {
+  // Wave 2 — the surface-gated security finders.
+  log(`finders: wave 2 = launching ${securityFinders.length} security finder(s)`);
+  securityResults = await parallel(securityFinders.map(launchFinder));
+}
+
+const finderResults = qualityResults.concat(securityResults);
 
 // Gather: surviving finder findings + the prescanned codeql/npm findings.
 let allFindings = [];
@@ -853,4 +883,9 @@ return {
   verify_report,
   deviation,
   security_note: _a.security_note,
+  // coverage_incomplete is independent of `deviation`: it flags a launch-efficiency
+  // back-off (security wave skipped because both quality finders died — model
+  // likely throttled), surfaced in the Step 6 partial-coverage comment line.
+  coverage_incomplete,
+  coverage_note,
 };

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -566,11 +566,20 @@ const requiredFindings = deduped.filter((f) => f.bucket === 'Required');
 const votesById = {};
 const rationalesById = {};
 if (requiredFindings.length) {
-  log(`verify: ${requiredFindings.length} Required finding(s), 2 skeptics each`);
+  log(
+    `verify: ${requiredFindings.length} Required finding(s), severity-scaled ` +
+      `skeptics (2 for high-confidence, 1 for medium/low)`
+  );
   // Flat thunk list across (finding × skeptic) so the barrier covers all votes.
+  // Skeptic count scales with finding confidence: a high-confidence Required
+  // finding (the only tier that can trigger the deviation gate) gets 2 skeptics;
+  // medium/low get 1. The floor is 1, NEVER 0 — a Required finding given 0 votes
+  // is treated as "Unverified" by applyVerifyDrop (dropped + filed, not fixed),
+  // so 1 vote is the minimum that preserves the existing verify-drop semantics.
   const verifyJobs = [];
   for (const f of requiredFindings) {
-    for (let k = 0; k < 2; k++) {
+    const skepticCount = f.Confidence === 'high' ? 2 : 1;
+    for (let k = 0; k < skepticCount; k++) {
       verifyJobs.push({ id: f.id, k, finding: f });
     }
   }
@@ -598,7 +607,7 @@ if (requiredFindings.length) {
     })
   );
   // Collect votes per id. A dead skeptic (null) contributes no vote, so a
-  // finding whose both skeptics died gets [] → handled by applyVerifyDrop as
+  // finding whose every skeptic died gets [] → handled by applyVerifyDrop as
   // "Unverified": dropped (not auto-fixed) and surfaced as verdict "unverified"
   // in verify_report, matching the skeptic prompt's "refute under uncertainty"
   // bias. (A finding is only Upheld when at least one skeptic ran and voted.)

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -17,7 +17,7 @@
  * node:* — the skill does all of that around the call.
  *
  * args IN:
- *   { pr_num, merge_base, changed_files:[...], surface:"empty"|"docs"|"code",
+ *   { pr_num, merge_base, changed_files:[...], surface:"empty"|"docs"|"tests"|"code",
  *     deps:bool, app_or_rules:bool,
  *     prescanned_findings:[...Per-finding items, Source "codeql"|"npm",
  *       carrying their source-specific fields...],
@@ -30,7 +30,7 @@
  *     deferred_filings:[{title, body, blocker_issue_nums:[N,...]|"independent"}],
  *     security_followup_input:[...codeql/npm out-of-scope subset...],
  *     verify_report:[{id, location, verdict, skeptic_votes, rationale}],
- *     deviation:bool, security_note? }
+ *     deviation:bool, security_note?, coverage_incomplete:bool, coverage_note?:string }
  *
  * NORMATIVE SPECS for the three inline kernel helpers below are the pure bash/jq
  * scripts (unit-tested by test-dispatch-scripts.sh). The JS helpers are kept
@@ -655,7 +655,7 @@ if (requiredFindings.length) {
 const { kept: keptFindings, dropped: refutedFindings } = applyVerifyDrop(deduped, votesById);
 
 // verify_report — one entry per Required finding (upheld / refuted / unverified).
-// "unverified" = both skeptics failed to vote: distinct from a clean upheld pass
+// "unverified" = every skeptic failed to vote: distinct from a clean upheld pass
 // so the PR comment shows the verification could not run rather than masking it
 // as verdict "upheld" with empty evidence.
 const verify_report = requiredFindings.map((f) => {
@@ -774,7 +774,7 @@ const blockerNums =
 
 const deferred_filings = deduped
   // Deferred code-review/review findings, plus Unverified Required findings
-  // (both skeptics failed): not auto-fixed in this terminal phase, so file a
+  // (every skeptic failed): not auto-fixed in this terminal phase, so file a
   // follow-up rather than silently dropping them.
   .filter((f) => f.bucket === 'Deferred' || unverifiedIds.has(f.id))
   .map((f) => {


### PR DESCRIPTION
Closes #1857

## Summary

`/review-fix` is the dispatch chain's single terminal review pass. A token-audit
hit-rate analysis found that ~41% of `review-fix` runs surface nothing actionable
yet still fire ~8.2 finder/skeptic subagents each. This PR cuts the
disproportionate-launch subset in three specific shapes, without regressing the
caught-finding rate (NONE/TRIVIAL on a diff that genuinely warranted review is the
classify + adversarial-verify filter working — not the target).

## What changed

**AC1 — gate finders by diff surface (test-only diffs skip the security fan-out).**
Added a `tests` surface to the `dispatch-security-surface` classifier, parallel to
the existing `docs` surface. A diff where every changed path is a test file now
classifies as `surface=tests` and (like `docs`) emits only the two quality finders
(`code-review` + `review`), skipping the security fan-out — a test-only diff has no
production attack surface. Ordering is load-bearing (empty → all-docs → all-tests →
code), so a mixed docs+tests or test+source diff correctly falls through to the
conservative `code` boundary. The finder-set scripts already gate security finders
on `surface == "code"`, so they needed no logic change — only a locking test. The
new surface is documented across `review-fix/SKILL.md` (surface bullets,
`security_note` mapping, args enum, edge cases) and the `review-fix.js` mirror.

**AC2 — scale skeptic fan-out by finding confidence.** The adversarial-verify phase
gave every `Required` finding a flat 2 skeptics regardless of confidence. It now
scales by `Confidence`: high-confidence findings (the only tier that can trigger
the high-confidence-only deviation gate) keep 2 skeptics; medium/low get 1. The
floor stays at 1 — never 0 — because a 0-vote `Required` finding is treated as
"Unverified" by `applyVerifyDrop` and would be silently dropped + filed rather than
fixed. Keeping the floor at 1 preserves the existing verify-drop semantics
unchanged.

**AC3 — probe-wave throttle short-circuit before the security fan-out.** On a `code`
surface the finder fan-out is split into two waves. Wave 1 launches only the two
always-on quality finders — real review work that runs on every surface — and
doubles them as a throttle probe. If both return `null` (a strong outage signal,
more robust than a single flake), the Workflow skips the security finder wave
entirely rather than waste those launches on a throttled model, setting
`coverage_incomplete` (surfaced in the Step 6 partial-coverage PR comment).
Otherwise wave 2 launches the surface-gated security finders. On `empty`/`docs`/
`tests` surfaces there are no security finders, so this degenerates to a single
wave (no change). Marker/label behavior is intentionally unchanged: a throttled run
still applies `dispatch:reviewed` and writes the marker (matching today's behavior
when all finders return `null`). This is a launch-efficiency change only — genuine
worker *death* on a transient rate-limit and its backed-off resume remain #1733's
responsibility.

## Verification

- `bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` —
  **3039/3039 passed** (11 new cases: the `dispatch-security-surface` docs/tests/
  code samples and the `dispatch-review-finders` `surface=tests` locking case).
- `node --check .claude/workflows/review-fix.js` — OK.
- AC2 and AC3 are Workflow-runtime orchestration in `review-fix.js` (no JS unit
  harness exists in this repo); verified by code inspection against the
  verify-drop spec and the plan's documented landmines.
- AC4 ("no regression in caught-finding rate") is measured downstream by the
  `dispatch-token-audit` aggregation, not asserted at merge time.
