### PR TITLE
office-hours: add audit-aggregate dashboard panel (reader + seed + chart)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -546,6 +546,19 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // Audit aggregates are the cost/cache-reuse time series, written by the
+    // Admin-SDK aggregator. The `demo` env is world-readable for the public demo
+    // tier; every other env is owner-gated via the denormalized `memberEmails`
+    // field. Client writes are denied.
+    match /office-hours/{env}/audit-aggregates/{aggId} {
+      allow get: if env == "demo"
+        || (request.auth != null
+            && request.auth.token.email in resource.data.memberEmails);
+      allow list: if request.auth != null
+        && request.auth.token.email in resource.data.memberEmails;
+      allow write: if false;
+    }
+
     // SCAFFOLD MARKER: deny-all catch-all. Do not edit or move this comment.
     // InsertFirestoreRules inserts new rule blocks immediately above this line.
     match /{document=**} {

--- a/office-hours/src/app-view.ts
+++ b/office-hours/src/app-view.ts
@@ -7,14 +7,17 @@ import { renderIssueHistoryChart } from "./issue-history-chart.js";
 import { getDemoSamples } from "./usage-data.js";
 import { getDemoReminders, getDemoQueueMetrics } from "./data.js";
 import { getDemoIssueSamples } from "./issue-data.js";
+import { renderAuditAggregateChart } from "./audit-aggregate-chart.js";
+import { getDemoAuditAggregates } from "./audit-data.js";
 import { selectLatestSample, type UsageSample } from "./usage-samples.js";
 import type { Reminder } from "./reminders.js";
 import type { QueueMetricsSnapshot } from "./queue-metrics.js";
 import type { IssueSample } from "./issue-samples.js";
+import type { AuditAggregate } from "./audit-aggregates.js";
 
 export type ViewState =
   | { tier: "demo" }                                                  // unauthenticated → labeled demo
-  | { tier: "owner"; samples: UsageSample[]; reminders: Reminder[]; queueMetrics: QueueMetricsSnapshot | null; issueSamples: IssueSample[] }  // authenticated → real (possibly empty)
+  | { tier: "owner"; samples: UsageSample[]; reminders: Reminder[]; queueMetrics: QueueMetricsSnapshot | null; issueSamples: IssueSample[]; auditAggregates: AuditAggregate[] }  // authenticated → real (possibly empty)
   | { tier: "error" };                                                // authenticated load failed
 
 type PanelTier = "demo" | "owner";
@@ -24,6 +27,7 @@ interface PanelContext {
   reminders: Reminder[];
   queueMetrics: QueueMetricsSnapshot | null;
   issueSamples: IssueSample[];
+  auditAggregates: AuditAggregate[];
   now: Date;
 }
 
@@ -88,6 +92,14 @@ const PANELS: readonly Panel[] = [
     render: (s) => renderIssueHistoryChart(s),
   }),
   definePanel({
+    id: "audit",
+    title: "Audit",
+    availableIn: ["demo", "owner"],
+    fullWidth: true,
+    load: (c) => c.auditAggregates,
+    render: (a) => renderAuditAggregateChart(a),
+  }),
+  definePanel({
     id: "reminders",
     title: "Reminders",
     availableIn: ["demo", "owner"],
@@ -114,6 +126,7 @@ function buildContext(
       reminders: getDemoReminders(),
       queueMetrics: getDemoQueueMetrics(),
       issueSamples: getDemoIssueSamples(),
+      auditAggregates: getDemoAuditAggregates(),
       now,
     };
   return {
@@ -121,6 +134,7 @@ function buildContext(
     reminders: state.reminders,
     queueMetrics: state.queueMetrics,
     issueSamples: state.issueSamples,
+    auditAggregates: state.auditAggregates,
     now,
   };
 }

--- a/office-hours/src/audit-aggregate-chart.ts
+++ b/office-hours/src/audit-aggregate-chart.ts
@@ -1,0 +1,209 @@
+import * as Plot from "@observablehq/plot";
+import { type AuditAggregate } from "./audit-aggregates.js";
+import {
+  getThemeFg,
+  assembleChartLayout,
+  buildLegend,
+  computeChartWidth,
+  renderAxisSvg,
+  type LegendEntry,
+  MARGIN_RIGHT,
+  MARGIN_BOTTOM,
+  POINT_WIDTH,
+  CONTAINER_WIDTH,
+  CHART_HEIGHT,
+} from "./chart-util.js";
+
+const SERIES_HIT_RATE = "cache hit %";
+const COLOR_HIT_RATE = "#26a69a";
+
+// Fixed palette cycled by phase index, so each phase line's color is known and
+// can be reused verbatim in the legend (vs. Plot's auto categorical scale,
+// whose assignment we'd have to reverse-engineer).
+const PHASE_PALETTE = [
+  "#42a5f5",
+  "#ab47bc",
+  "#ffa726",
+  "#66bb6a",
+  "#ec407a",
+  "#29b6f6",
+  "#d4e157",
+  "#8d6e63",
+];
+
+interface SpendPoint {
+  x: Date;
+  spend: number | undefined;
+}
+
+interface HitRatePoint {
+  x: Date;
+  hitPct: number;
+}
+
+/**
+ * Renders the audit-aggregate dashboard panel: two stacked sub-charts sharing a
+ * time axis. The top sub-chart plots per-phase spend ($-proxy dollars), one
+ * line per phase across the union of phase keys. The bottom sub-chart plots the
+ * derived cache hit-rate trend (cacheRead / (cacheRead + cacheCreation)) as a
+ * percentage. The two y-scales are incompatible, so they get separate plots and
+ * separate fixed y-axes rather than a single dual-axis Plot.
+ *
+ * Pure: does not mutate the input array. Returns the composed panel element, or
+ * an empty-state element when there are no aggregates.
+ */
+export function renderAuditAggregateChart(aggregates: AuditAggregate[]): HTMLElement {
+  const container = document.createElement("div");
+  container.className = "audit-aggregate-chart";
+
+  if (aggregates.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "empty";
+    empty.textContent = "No audit history to chart.";
+    container.appendChild(empty);
+    return container;
+  }
+
+  // Sort a copy ascending by computedAt — input order is not guaranteed.
+  const sorted = [...aggregates].sort((a, b) => a.computedAt.getTime() - b.computedAt.getTime());
+
+  // Union of phase keys across all windows, sorted for stable line/legend order.
+  const phaseSet = new Set<string>();
+  for (const a of sorted) {
+    for (const key of Object.keys(a.phaseSpend)) phaseSet.add(key);
+  }
+  const phases = [...phaseSet].sort();
+
+  const phaseEntries: LegendEntry[] = phases.map((phase, i) => ({
+    label: phase,
+    color: PHASE_PALETTE[i % PHASE_PALETTE.length],
+  }));
+
+  // Per-phase point series. A phase missing from a given window yields an
+  // undefined y, which Plot gaps (does not draw a segment through).
+  const phaseSeries: Record<string, SpendPoint[]> = {};
+  for (const phase of phases) {
+    phaseSeries[phase] = sorted.map((a) => ({
+      x: a.computedAt,
+      spend: phase in a.phaseSpend ? a.phaseSpend[phase] : undefined,
+    }));
+  }
+
+  // Derived hit-rate trend, as a percentage. Guard the zero denominator by
+  // omitting the point (no read + no creation = no meaningful rate).
+  const hitRatePoints: HitRatePoint[] = [];
+  for (const a of sorted) {
+    const denom = a.cacheRead + a.cacheCreation;
+    if (denom > 0) {
+      hitRatePoints.push({ x: a.computedAt, hitPct: (a.cacheRead / denom) * 100 });
+    }
+  }
+
+  // Shared x domain so the two stacked charts line up vertically regardless of
+  // which windows a series happens to be defined in.
+  const xDomain: [Date, Date] = [
+    sorted[0].computedAt,
+    sorted[sorted.length - 1].computedAt,
+  ];
+
+  const chartWidth = computeChartWidth(sorted.length, POINT_WIDTH, CONTAINER_WIDTH);
+
+  const fg = getThemeFg(container);
+  const sharedStyle = { background: "transparent", color: fg };
+
+  // --- Top sub-chart: per-phase spend ($). ---
+  // Compute the spend domain across all phases×windows; the axis SVG and the
+  // chart body are separate Plot instances, so both must share this exact array
+  // (and CHART_HEIGHT / MARGIN_BOTTOM) for ticks to line up with the lines.
+  let maxSpend = 0;
+  for (const phase of phases) {
+    for (const p of phaseSeries[phase]) {
+      if (p.spend !== undefined && p.spend > maxSpend) maxSpend = p.spend;
+    }
+  }
+  const spendDomain: [number, number] = [0, maxSpend > 0 ? maxSpend : 1];
+
+  const spendAxisSvg = renderAxisSvg({
+    height: CHART_HEIGHT,
+    style: sharedStyle,
+    yDomain: spendDomain,
+    label: "$",
+  });
+
+  const spendChartSvg = Plot.plot({
+    width: chartWidth,
+    height: CHART_HEIGHT,
+    marginBottom: MARGIN_BOTTOM,
+    marginLeft: 0,
+    marginRight: MARGIN_RIGHT,
+    style: sharedStyle,
+    x: { type: "time", label: null, domain: xDomain },
+    y: { label: null, axis: null, grid: true, domain: spendDomain },
+    marks: phases.map((phase, i) =>
+      Plot.lineY(phaseSeries[phase], {
+        x: "x",
+        y: "spend",
+        stroke: PHASE_PALETTE[i % PHASE_PALETTE.length],
+        strokeWidth: 2,
+        curve: "monotone-x",
+      }),
+    ),
+  });
+
+  spendChartSvg.style.width = `${chartWidth}px`;
+  spendChartSvg.style.minWidth = `${chartWidth}px`;
+
+  const { layout: spendLayout, wrapper: spendWrapper } = assembleChartLayout(
+    spendAxisSvg,
+    spendChartSvg,
+  );
+
+  // --- Bottom sub-chart: derived hit-rate trend (%). ---
+  const hitDomain: [number, number] = [0, 100];
+
+  const hitAxisSvg = renderAxisSvg({
+    height: CHART_HEIGHT,
+    style: sharedStyle,
+    yDomain: hitDomain,
+    label: "%",
+  });
+
+  const hitChartSvg = Plot.plot({
+    width: chartWidth,
+    height: CHART_HEIGHT,
+    marginBottom: MARGIN_BOTTOM,
+    marginLeft: 0,
+    marginRight: MARGIN_RIGHT,
+    style: sharedStyle,
+    x: { type: "time", label: null, domain: xDomain },
+    y: { label: null, axis: null, grid: true, domain: hitDomain },
+    marks: [
+      Plot.lineY(hitRatePoints, {
+        x: "x",
+        y: "hitPct",
+        stroke: COLOR_HIT_RATE,
+        strokeWidth: 2,
+        curve: "monotone-x",
+      }),
+    ],
+  });
+
+  hitChartSvg.style.width = `${chartWidth}px`;
+  hitChartSvg.style.minWidth = `${chartWidth}px`;
+
+  const { layout: hitLayout, wrapper: hitWrapper } = assembleChartLayout(hitAxisSvg, hitChartSvg);
+
+  const legend = buildLegend([...phaseEntries, { label: SERIES_HIT_RATE, color: COLOR_HIT_RATE }]);
+
+  container.replaceChildren(spendLayout, hitLayout, legend);
+
+  // Scroll both bodies to the newest data (rightmost) on first paint. The
+  // container is still detached here (the view appends it after this returns),
+  // so scrollWidth is 0 until a layout pass — defer to the next frame.
+  requestAnimationFrame(() => {
+    spendWrapper.scrollLeft = spendWrapper.scrollWidth;
+    hitWrapper.scrollLeft = hitWrapper.scrollWidth;
+  });
+
+  return container;
+}

--- a/office-hours/src/audit-aggregate-chart.ts
+++ b/office-hours/src/audit-aggregate-chart.ts
@@ -67,6 +67,16 @@ export function renderAuditAggregateChart(aggregates: AuditAggregate[]): HTMLEle
   // Sort a copy ascending by computedAt — input order is not guaranteed.
   const sorted = [...aggregates].sort((a, b) => a.computedAt.getTime() - b.computedAt.getTime());
 
+  // A single aggregate, or multiple aggregates sharing one timestamp, yields a
+  // zero-width time domain that Plot renders as a degenerate single-x chart.
+  if (sorted.length < 2 || sorted[0].computedAt.getTime() === sorted[sorted.length - 1].computedAt.getTime()) {
+    const empty = document.createElement("p");
+    empty.className = "empty";
+    empty.textContent = "Not enough audit history to chart — waiting for a second window.";
+    container.appendChild(empty);
+    return container;
+  }
+
   // Union of phase keys across all windows, sorted for stable line/legend order.
   const phaseSet = new Set<string>();
   for (const a of sorted) {

--- a/office-hours/src/audit-aggregate-seeds.ts
+++ b/office-hours/src/audit-aggregate-seeds.ts
@@ -1,0 +1,144 @@
+export interface AuditAggregateSeed {
+  /** Minutes relative to build "now": negative = in the past. */
+  computedAtOffsetMin: number;
+  windowDays: number;
+  groupId: string;
+  /** Per-phase spend in USD over the window. */
+  phaseSpend: Record<string, number>;
+  cacheRead: number;
+  cacheCreation: number;
+  memberEmails: string[];
+}
+
+// 7 daily aggregate windows spanning the last week, computedAtOffsetMin == 0 is
+// the most recent ("now") window. Per-phase spend shifts across phases over the
+// series, and the cache hit-rate — cacheRead / (cacheRead + cacheCreation) —
+// climbs from ~0.50 to ~0.90 to give the chart a visibly improving trend.
+export const auditAggregateSeeds: AuditAggregateSeed[] = [
+  // Day -6 — early window, low cache reuse (hit rate ~0.50)
+  {
+    computedAtOffsetMin: -8640, // 6 days ago
+    windowDays: 1,
+    groupId: "demo-group",
+    phaseSpend: {
+      "plan-implement": 4.2,
+      "review-fix": 2.1,
+      "security-review-fix": 0.8,
+      "qa-fix": 1.3,
+      "code-review-fix": 1.0,
+      "fix-checks": 0.6,
+      "dispatch-worker": 3.5,
+    },
+    cacheRead: 1_200_000,
+    cacheCreation: 1_180_000,
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -5 — heavier planning load, cache warming (hit rate ~0.62)
+  {
+    computedAtOffsetMin: -7200, // 5 days ago
+    windowDays: 1,
+    groupId: "demo-group",
+    phaseSpend: {
+      "plan-implement": 6.8,
+      "review-fix": 2.6,
+      "security-review-fix": 1.1,
+      "qa-fix": 1.0,
+      "code-review-fix": 1.4,
+      "fix-checks": 0.9,
+      "dispatch-worker": 4.1,
+    },
+    cacheRead: 2_000_000,
+    cacheCreation: 1_230_000,
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -4 — review-heavy day (hit rate ~0.70)
+  {
+    computedAtOffsetMin: -5760, // 4 days ago
+    windowDays: 1,
+    groupId: "demo-group",
+    phaseSpend: {
+      "plan-implement": 3.9,
+      "review-fix": 5.4,
+      "security-review-fix": 2.2,
+      "qa-fix": 1.7,
+      "code-review-fix": 2.8,
+      "fix-checks": 1.1,
+      "dispatch-worker": 3.8,
+    },
+    cacheRead: 2_800_000,
+    cacheCreation: 1_200_000,
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -3 — QA-heavy day (hit rate ~0.77)
+  {
+    computedAtOffsetMin: -4320, // 3 days ago
+    windowDays: 1,
+    groupId: "demo-group",
+    phaseSpend: {
+      "plan-implement": 4.5,
+      "review-fix": 3.1,
+      "security-review-fix": 1.4,
+      "qa-fix": 4.9,
+      "code-review-fix": 2.0,
+      "fix-checks": 1.8,
+      "dispatch-worker": 4.6,
+    },
+    cacheRead: 3_400_000,
+    cacheCreation: 1_020_000,
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -2 — steady, cache hot (hit rate ~0.82)
+  {
+    computedAtOffsetMin: -2880, // 2 days ago
+    windowDays: 1,
+    groupId: "demo-group",
+    phaseSpend: {
+      "plan-implement": 5.1,
+      "review-fix": 3.8,
+      "security-review-fix": 1.0,
+      "qa-fix": 2.2,
+      "code-review-fix": 2.5,
+      "fix-checks": 1.2,
+      "dispatch-worker": 5.0,
+    },
+    cacheRead: 4_100_000,
+    cacheCreation: 900_000,
+    memberEmails: ["demo@example.com"],
+  },
+  // Day -1 — high throughput, cache very hot (hit rate ~0.87)
+  {
+    computedAtOffsetMin: -1440, // 1 day ago
+    windowDays: 1,
+    groupId: "demo-group",
+    phaseSpend: {
+      "plan-implement": 6.2,
+      "review-fix": 4.4,
+      "security-review-fix": 1.6,
+      "qa-fix": 3.0,
+      "code-review-fix": 3.1,
+      "fix-checks": 1.5,
+      "dispatch-worker": 6.3,
+    },
+    cacheRead: 5_200_000,
+    cacheCreation: 780_000,
+    memberEmails: ["demo@example.com"],
+  },
+  // Now — most recent window, peak cache reuse (hit rate ~0.90)
+  {
+    computedAtOffsetMin: 0,
+    windowDays: 1,
+    groupId: "demo-group",
+    phaseSpend: {
+      "plan-implement": 5.6,
+      "review-fix": 4.0,
+      "security-review-fix": 1.3,
+      "qa-fix": 2.6,
+      "code-review-fix": 2.9,
+      "fix-checks": 1.3,
+      "dispatch-worker": 5.8,
+    },
+    cacheRead: 6_300_000,
+    cacheCreation: 700_000,
+    memberEmails: ["demo@example.com"],
+  },
+];

--- a/office-hours/src/audit-aggregates.ts
+++ b/office-hours/src/audit-aggregates.ts
@@ -1,0 +1,81 @@
+import { Timestamp } from "firebase/firestore";
+import { logError } from "@commons-systems/errorutil/log";
+
+export interface AuditAggregate {
+  computedAt: Date;
+  windowDays: number;
+  groupId: string;
+  phaseSpend: Record<string, number>;
+  cacheRead: number;
+  cacheCreation: number;
+}
+
+export function toAuditAggregate(
+  id: string,
+  data: Record<string, unknown>,
+): AuditAggregate | null {
+  const computedAtRaw = data.computedAt;
+  const computedAt =
+    computedAtRaw && typeof (computedAtRaw as { toDate?: unknown }).toDate === "function"
+      ? (computedAtRaw as { toDate: () => Date }).toDate()
+      : null;
+
+  const windowDays = typeof data.windowDays === "number" ? data.windowDays : null;
+  const cacheRead = typeof data.cacheRead === "number" ? data.cacheRead : null;
+  const cacheCreation = typeof data.cacheCreation === "number" ? data.cacheCreation : null;
+  const groupId = typeof data.groupId === "string" ? data.groupId : null;
+  const memberEmails =
+    Array.isArray(data.memberEmails) &&
+    (data.memberEmails as unknown[]).every((e) => typeof e === "string")
+      ? (data.memberEmails as string[])
+      : null;
+
+  const phaseSpendRaw = data.phaseSpend;
+  const phaseSpend =
+    phaseSpendRaw &&
+    typeof phaseSpendRaw === "object" &&
+    !Array.isArray(phaseSpendRaw) &&
+    Object.values(phaseSpendRaw as Record<string, unknown>).every((v) => typeof v === "number")
+      ? (phaseSpendRaw as Record<string, number>)
+      : null;
+
+  if (
+    computedAt === null ||
+    windowDays === null ||
+    cacheRead === null ||
+    cacheCreation === null ||
+    groupId === null ||
+    memberEmails === null ||
+    phaseSpend === null
+  ) {
+    logError(new Error("audit-aggregates document missing required fields"), {
+      operation: "audit-aggregate-validation",
+      itemId: id,
+    });
+    return null;
+  }
+
+  return {
+    computedAt,
+    windowDays,
+    groupId,
+    phaseSpend,
+    cacheRead,
+    cacheCreation,
+  };
+}
+
+export function auditAggregateToDoc(
+  a: AuditAggregate,
+  memberEmails: string[],
+): Record<string, unknown> {
+  return {
+    computedAt: Timestamp.fromDate(a.computedAt),
+    windowDays: a.windowDays,
+    groupId: a.groupId,
+    phaseSpend: a.phaseSpend,
+    cacheRead: a.cacheRead,
+    cacheCreation: a.cacheCreation,
+    memberEmails,
+  };
+}

--- a/office-hours/src/audit-data.ts
+++ b/office-hours/src/audit-data.ts
@@ -1,0 +1,33 @@
+import { collection, getDocs, query, where, type Firestore } from "firebase/firestore";
+import type { User } from "firebase/auth";
+import { nsCollectionPath, type Namespace } from "@commons-systems/firestoreutil/namespace";
+import seedAggregates from "virtual:office-hours-audit-aggregate-seed-data";
+import { toAuditAggregate, type AuditAggregate } from "./audit-aggregates.js";
+
+export function getDemoAuditAggregates(): AuditAggregate[] {
+  return seedAggregates.map((a) => ({
+    computedAt: a.computedAt,
+    windowDays: a.windowDays,
+    groupId: a.groupId,
+    phaseSpend: a.phaseSpend,
+    cacheRead: a.cacheRead,
+    cacheCreation: a.cacheCreation,
+  }));
+}
+
+export async function getOwnerAuditAggregates(
+  db: Firestore,
+  namespace: Namespace,
+  user: User,
+): Promise<AuditAggregate[]> {
+  if (!user.email) return [];
+  const path = nsCollectionPath(namespace, "audit-aggregates");
+  const q = query(collection(db, path), where("memberEmails", "array-contains", user.email));
+  const snapshot = await getDocs(q);
+  const aggregates: AuditAggregate[] = [];
+  for (const d of snapshot.docs) {
+    const aggregate = toAuditAggregate(d.id, d.data());
+    if (aggregate) aggregates.push(aggregate);
+  }
+  return aggregates;
+}

--- a/office-hours/src/main.ts
+++ b/office-hours/src/main.ts
@@ -10,6 +10,7 @@ import { createAppController } from "./app-controller.js";
 import { getOwnerReminders, getOwnerQueueMetrics } from "./data.js";
 import { getOwnerSamples } from "./usage-data.js";
 import { getOwnerIssueSamples } from "./issue-data.js";
+import { getOwnerAuditAggregates } from "./audit-data.js";
 import {
   db,
   NAMESPACE,
@@ -46,16 +47,17 @@ async function refresh(): Promise<void> {
     return;
   }
   try {
-    const [samples, reminders, queueMetrics, issueSamples] = await Promise.all([
+    const [samples, reminders, queueMetrics, issueSamples, auditAggregates] = await Promise.all([
       getOwnerSamples(db, NAMESPACE, refreshUser),
       getOwnerReminders(db, NAMESPACE, refreshUser),
       getOwnerQueueMetrics(db, NAMESPACE, refreshUser),
       getOwnerIssueSamples(db, NAMESPACE, refreshUser),
+      getOwnerAuditAggregates(db, NAMESPACE, refreshUser),
     ]);
     // Auth may have changed while the Firestore calls were in flight — skip the
     // render so the in-flight result does not clobber the already-updated view.
     if (currentUser !== refreshUser) return;
-    controller.paint({ tier: "owner", samples, reminders, queueMetrics, issueSamples }, new Date());
+    controller.paint({ tier: "owner", samples, reminders, queueMetrics, issueSamples, auditAggregates }, new Date());
   } catch (error) {
     // Auth may have changed while the Firestore calls were in flight — skip the
     // render so the in-flight error does not clobber the already-updated view.

--- a/office-hours/src/office-hours-audit-aggregate-seed-data.d.ts
+++ b/office-hours/src/office-hours-audit-aggregate-seed-data.d.ts
@@ -1,0 +1,12 @@
+declare module "virtual:office-hours-audit-aggregate-seed-data" {
+  export interface AuditAggregateResolved {
+    readonly computedAt: Date;
+    readonly windowDays: number;
+    readonly groupId: string;
+    readonly phaseSpend: Record<string, number>;
+    readonly cacheRead: number;
+    readonly cacheCreation: number;
+  }
+  const auditAggregateSeeds: readonly AuditAggregateResolved[];
+  export default auditAggregateSeeds;
+}

--- a/office-hours/src/vite-plugin-audit-aggregate-seed.ts
+++ b/office-hours/src/vite-plugin-audit-aggregate-seed.ts
@@ -1,0 +1,40 @@
+import type { Plugin } from "vite";
+import { auditAggregateSeeds } from "./audit-aggregate-seeds.js";
+
+const VIRTUAL_MODULE_ID = "virtual:office-hours-audit-aggregate-seed-data";
+const RESOLVED_VIRTUAL_MODULE_ID = "\0" + VIRTUAL_MODULE_ID;
+
+export function auditAggregateSeedPlugin(): Plugin {
+  let moduleCode: string;
+
+  return {
+    name: "office-hours-audit-aggregate-seed-data",
+    buildStart() {
+      // Strip memberEmails (a denormalized auth field holding real email
+      // addresses) before serializing — it must never be baked into the
+      // public JS bundle. The UI never reads it; Firestore rules gate access
+      // server-side.
+      const publicSeeds = auditAggregateSeeds.map(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure-omit memberEmails from the public bundle
+        ({ memberEmails, ...rest }) => rest,
+      );
+      moduleCode =
+        `const seeds = ${JSON.stringify(publicSeeds)};\n` +
+        `const now = Date.now();\n` +
+        `export default seeds.map(({ computedAtOffsetMin, windowDays, groupId, phaseSpend, cacheRead, cacheCreation }) => ({\n` +
+        `  computedAt: new Date(now + computedAtOffsetMin * 60000),\n` +
+        `  windowDays,\n` +
+        `  groupId,\n` +
+        `  phaseSpend,\n` +
+        `  cacheRead,\n` +
+        `  cacheCreation,\n` +
+        `}));\n`;
+    },
+    resolveId(id) {
+      if (id === VIRTUAL_MODULE_ID) return RESOLVED_VIRTUAL_MODULE_ID;
+    },
+    load(id) {
+      if (id === RESOLVED_VIRTUAL_MODULE_ID) return moduleCode;
+    },
+  };
+}

--- a/office-hours/test/app-controller.test.ts
+++ b/office-hours/test/app-controller.test.ts
@@ -57,6 +57,7 @@ const ownerState: ViewState = {
   reminders,
   queueMetrics: queueMetricsFixture,
   issueSamples: [],
+  auditAggregates: [],
 };
 
 afterEach(() => {

--- a/office-hours/test/app-view.test.ts
+++ b/office-hours/test/app-view.test.ts
@@ -3,6 +3,7 @@ import { renderApp, type AppView, type ViewState } from "../src/app-view.js";
 import type { UsageSample } from "../src/usage-samples.js";
 import type { Reminder } from "../src/reminders.js";
 import type { IssueSample } from "../src/issue-samples.js";
+import type { AuditAggregate } from "../src/audit-aggregates.js";
 
 const now = new Date("2026-06-11T12:00:00Z");
 
@@ -126,14 +127,14 @@ describe("renderApp — owner tier with data", () => {
 
   it("does not render a .demo-banner", () => {
     const container = document.createElement("div");
-    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [] }, now));
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [], auditAggregates: [] }, now));
 
     expect(container.querySelector(".demo-banner")).toBeNull();
   });
 
   it("renders a reminder list item for each reminder", () => {
     const container = document.createElement("div");
-    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [] }, now));
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [], auditAggregates: [] }, now));
 
     const items = container.querySelectorAll("li.reminder");
     expect(items.length).toBe(2);
@@ -141,14 +142,14 @@ describe("renderApp — owner tier with data", () => {
 
   it("does not render an .error element", () => {
     const container = document.createElement("div");
-    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [] }, now));
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [], auditAggregates: [] }, now));
 
     expect(container.querySelector(".error")).toBeNull();
   });
 
   it("renders 3 queue cards when queueMetrics is provided", () => {
     const container = document.createElement("div");
-    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [] }, now));
+    withThemeFg(() => renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [], auditAggregates: [] }, now));
 
     // The capacity panel also emits .capacity-card, so scope the count to the
     // queue panel's unique value cells (depth, drain, runway).
@@ -163,7 +164,7 @@ describe("renderApp — owner tier empty", () => {
   it("does not render a .demo-banner", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null, issueSamples: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null, issueSamples: [], auditAggregates: [] }, now),
     );
 
     expect(container.querySelector(".demo-banner")).toBeNull();
@@ -172,7 +173,7 @@ describe("renderApp — owner tier empty", () => {
   it('renders the reminder-list empty state "No reminders."', () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null, issueSamples: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null, issueSamples: [], auditAggregates: [] }, now),
     );
 
     const list = container.querySelector("#reminder-list");
@@ -188,7 +189,7 @@ describe("renderApp — owner tier empty", () => {
   it('renders the capacity empty state "No capacity data."', () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null, issueSamples: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null, issueSamples: [], auditAggregates: [] }, now),
     );
 
     const empties = Array.from(container.querySelectorAll(".empty"));
@@ -199,7 +200,7 @@ describe("renderApp — owner tier empty", () => {
   it("renders the history-band empty states", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null, issueSamples: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null, issueSamples: [], auditAggregates: [] }, now),
     );
 
     const empties = Array.from(container.querySelectorAll(".empty"));
@@ -217,7 +218,7 @@ describe("renderApp — owner tier empty", () => {
   it('renders the queue band empty state "No queue metrics yet." when queueMetrics is null', () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null, issueSamples: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null, issueSamples: [], auditAggregates: [] }, now),
     );
 
     const empties = Array.from(container.querySelectorAll(".empty"));
@@ -228,7 +229,7 @@ describe("renderApp — owner tier empty", () => {
   it("does not render an .error element", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null, issueSamples: [] }, now),
+      renderApp(container, { tier: "owner", samples: [], reminders: [], queueMetrics: null, issueSamples: [], auditAggregates: [] }, now),
     );
 
     expect(container.querySelector(".error")).toBeNull();
@@ -311,7 +312,7 @@ describe("renderApp — panel-registry: grid container", () => {
   it("owner-with-data render: .panel-grid is present", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [] }, now),
+      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [], auditAggregates: [] }, now),
     );
     expect(container.querySelector(".panel-grid")).not.toBeNull();
   });
@@ -338,7 +339,7 @@ describe("renderApp — panel-registry: all panels present per tier", () => {
     { sampledAt: new Date("2026-06-09T00:00:00Z"), openHelpWanted: 6, openOther: 3, groupId: "g" },
   ];
 
-  it("demo: all six panels are present", () => {
+  it("demo: all seven panels are present", () => {
     const container = document.createElement("div");
     withThemeFg(() => renderApp(container, { tier: "demo" }, now));
     expect(container.querySelector(".capacity-heading")).not.toBeNull();
@@ -347,12 +348,13 @@ describe("renderApp — panel-registry: all panels present per tier", () => {
     expect(container.querySelector("#reminder-list")).not.toBeNull();
     expect(container.querySelector(".queue-metrics-heading")).not.toBeNull();
     expect(container.querySelector(".backlog-history")).not.toBeNull();
+    expect(container.querySelector(".audit-aggregate-chart")).not.toBeNull();
   });
 
-  it("owner-with-data: all six panels are present", () => {
+  it("owner-with-data: all seven panels are present", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples }, now),
+      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples, auditAggregates: [] }, now),
     );
     expect(container.querySelector(".capacity-heading")).not.toBeNull();
     expect(container.querySelector(".capacity-pace")).not.toBeNull();
@@ -360,6 +362,7 @@ describe("renderApp — panel-registry: all panels present per tier", () => {
     expect(container.querySelector("#reminder-list")).not.toBeNull();
     expect(container.querySelector(".queue-metrics-heading")).not.toBeNull();
     expect(container.querySelector(".backlog-history")).not.toBeNull();
+    expect(container.querySelector(".audit-aggregate-chart")).not.toBeNull();
   });
 });
 
@@ -388,7 +391,7 @@ describe("renderApp — panel-registry: title-doubling guard", () => {
   it("owner-with-data: each panel heading appears exactly once", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [] }, now),
+      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [], auditAggregates: [] }, now),
     );
     expect(container.querySelectorAll(".capacity-heading").length).toBe(1);
     expect(container.querySelectorAll(".capacity-pace-heading").length).toBe(1);
@@ -419,6 +422,59 @@ describe("renderApp — panel-registry: backlog-history panel is full-width", ()
   });
 });
 
+describe("renderApp — panel-registry: audit panel", () => {
+  const samples = [
+    makeSample({ sampledAt: new Date("2026-06-07T10:00:00Z") }),
+    makeSample({ sampledAt: new Date("2026-06-08T10:00:00Z"), activeWorkers: 2, targetWorkers: 3 }),
+  ];
+  const reminders = [
+    makeReminder("weekly-review", 30 * MINUTE),
+    makeReminder("overdue-task", -4 * HOUR),
+  ];
+  const auditAggregates: AuditAggregate[] = [
+    {
+      computedAt: new Date("2026-06-07T00:00:00Z"),
+      windowDays: 14,
+      groupId: "g",
+      phaseSpend: { plan: 0.5, implement: 1.2 },
+      cacheRead: 800,
+      cacheCreation: 200,
+    },
+  ];
+
+  it("demo: .audit-aggregate-chart is present and carries panel-grid-full", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+    const audit = container.querySelector(".audit-aggregate-chart");
+    expect(audit).not.toBeNull();
+    expect(audit!.classList.contains("panel-grid-full")).toBe(true);
+  });
+
+  it("demo: .audit-aggregate-chart appears exactly once", () => {
+    const container = document.createElement("div");
+    withThemeFg(() => renderApp(container, { tier: "demo" }, now));
+    expect(container.querySelectorAll(".audit-aggregate-chart").length).toBe(1);
+  });
+
+  it("owner: .audit-aggregate-chart is present and carries panel-grid-full", () => {
+    const container = document.createElement("div");
+    withThemeFg(() =>
+      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [], auditAggregates }, now),
+    );
+    const audit = container.querySelector(".audit-aggregate-chart");
+    expect(audit).not.toBeNull();
+    expect(audit!.classList.contains("panel-grid-full")).toBe(true);
+  });
+
+  it("owner: .audit-aggregate-chart appears exactly once", () => {
+    const container = document.createElement("div");
+    withThemeFg(() =>
+      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [], auditAggregates }, now),
+    );
+    expect(container.querySelectorAll(".audit-aggregate-chart").length).toBe(1);
+  });
+});
+
 describe("renderApp — panel-registry: queue-metrics in both tiers", () => {
   const samples = [
     makeSample({ sampledAt: new Date("2026-06-07T10:00:00Z") }),
@@ -442,7 +498,7 @@ describe("renderApp — panel-registry: queue-metrics in both tiers", () => {
   it("owner with queueMetrics: queue-metrics heading and populated value element present", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [] }, now),
+      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: queueMetricsFixture, issueSamples: [], auditAggregates: [] }, now),
     );
     const heading = container.querySelector(".queue-metrics-heading");
     expect(heading).not.toBeNull();
@@ -453,7 +509,7 @@ describe("renderApp — panel-registry: queue-metrics in both tiers", () => {
   it("owner with queueMetrics: null — heading present, empty placeholder with exact text", () => {
     const container = document.createElement("div");
     withThemeFg(() =>
-      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: null, issueSamples: [] }, now),
+      renderApp(container, { tier: "owner", samples, reminders, queueMetrics: null, issueSamples: [], auditAggregates: [] }, now),
     );
     const heading = container.querySelector(".queue-metrics-heading");
     expect(heading).not.toBeNull();
@@ -486,6 +542,7 @@ describe("renderApp — AppView.tick refreshes time-sensitive panels", () => {
     reminders,
     queueMetrics: queueMetricsFixture,
     issueSamples: [],
+    auditAggregates: [],
   };
 
   it("owner: weekly countdown text changes after tick(laterNow)", () => {
@@ -542,14 +599,17 @@ describe("renderApp — AppView.tick refreshes time-sensitive panels", () => {
 
     const historyBefore = container.querySelector(".capacity-history");
     const backlogBefore = container.querySelector(".backlog-history");
+    const auditBefore = container.querySelector(".audit-aggregate-chart");
     expect(historyBefore).not.toBeNull();
     expect(backlogBefore).not.toBeNull();
+    expect(auditBefore).not.toBeNull();
 
     withThemeFg(() => view.tick(new Date("2026-06-15T12:00:00Z")));
 
     // Charts are NOT re-rendered: the same DOM nodes remain in place.
     expect(container.querySelector(".capacity-history")).toBe(historyBefore);
     expect(container.querySelector(".backlog-history")).toBe(backlogBefore);
+    expect(container.querySelector(".audit-aggregate-chart")).toBe(auditBefore);
   });
 
   it("error-tier AppView.tick is a harmless no-op", () => {

--- a/office-hours/test/audit-aggregate-chart.test.ts
+++ b/office-hours/test/audit-aggregate-chart.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { renderAuditAggregateChart } from "../src/audit-aggregate-chart.js";
+import { type AuditAggregate } from "../src/audit-aggregates.js";
+
+const baseAggregate: AuditAggregate = {
+  computedAt: new Date("2026-06-07T00:00:00Z"),
+  windowDays: 7,
+  groupId: "group-abc",
+  phaseSpend: { plan: 1.5, implement: 3.2, review: 0.8 },
+  cacheRead: 800,
+  cacheCreation: 200,
+};
+
+const make = (o: Partial<AuditAggregate> = {}): AuditAggregate => ({ ...baseAggregate, ...o });
+
+/**
+ * A multi-window fixture. Phase keys vary across windows (the union defines the
+ * line set), and cache counts vary so the hit-rate trend moves.
+ */
+function multiAggregate(): AuditAggregate[] {
+  return [
+    make({
+      computedAt: new Date("2026-06-07T00:00:00Z"),
+      phaseSpend: { plan: 1.5, implement: 3.2 },
+      cacheRead: 800,
+      cacheCreation: 200,
+    }),
+    make({
+      computedAt: new Date("2026-06-14T00:00:00Z"),
+      phaseSpend: { plan: 2.1, implement: 4.0, review: 1.1 },
+      cacheRead: 600,
+      cacheCreation: 400,
+    }),
+    make({
+      computedAt: new Date("2026-06-21T00:00:00Z"),
+      phaseSpend: { implement: 5.5, review: 2.0 },
+      cacheRead: 900,
+      cacheCreation: 100,
+    }),
+  ];
+}
+
+function withFg(): HTMLElement {
+  // happy-dom has no stylesheet, so missing.css's --fg is absent — set it on
+  // the container so getThemeFg reads it live (mirrors the sibling test host).
+  const container = document.createElement("div");
+  container.style.setProperty("--fg", "#ddd");
+  document.body.appendChild(container);
+  return container;
+}
+
+describe("renderAuditAggregateChart", () => {
+  it("renders both stacked sub-charts, each with a fixed axis and a scroll wrapper", () => {
+    const host = withFg();
+    const el = renderAuditAggregateChart(multiAggregate());
+    host.appendChild(el);
+
+    // Two sub-charts → two layout blocks, each with its own axis + body SVG.
+    expect(el.querySelectorAll(".chart-layout").length).toBe(2);
+    expect(el.querySelectorAll(".chart-y-axis svg").length).toBe(2);
+    expect(el.querySelectorAll(".chart-scroll-wrapper svg").length).toBe(2);
+  });
+
+  it("shows the empty-state message for an empty array", () => {
+    const el = renderAuditAggregateChart([]);
+    const empty = el.querySelector(".empty");
+    expect(empty).not.toBeNull();
+    expect(empty!.textContent).toBe("No audit history to chart.");
+    expect(el.querySelector("svg")).toBeNull();
+  });
+
+  it("includes the hit-rate entry and every phase in the legend", () => {
+    withFg();
+    const el = renderAuditAggregateChart(multiAggregate());
+
+    const legend = el.querySelector(".trend-legend");
+    expect(legend).not.toBeNull();
+    const labels = Array.from(legend!.querySelectorAll(".trend-legend-item")).map(
+      (i) => i.textContent ?? "",
+    );
+    expect(labels).toContain("cache hit %");
+    // Union of phase keys across all windows.
+    expect(labels).toContain("plan");
+    expect(labels).toContain("implement");
+    expect(labels).toContain("review");
+  });
+
+  it("does not mutate the input array order", () => {
+    withFg();
+    // Deliberately unsorted input.
+    const a = make({ computedAt: new Date("2026-06-21T00:00:00Z") });
+    const b = make({ computedAt: new Date("2026-06-07T00:00:00Z") });
+    const c = make({ computedAt: new Date("2026-06-14T00:00:00Z") });
+    const aggregates = [a, b, c];
+    const originalRefs = aggregates.map((x) => x);
+
+    renderAuditAggregateChart(aggregates);
+
+    expect(aggregates[0]).toBe(originalRefs[0]);
+    expect(aggregates[1]).toBe(originalRefs[1]);
+    expect(aggregates[2]).toBe(originalRefs[2]);
+  });
+});

--- a/office-hours/test/audit-aggregate-chart.test.ts
+++ b/office-hours/test/audit-aggregate-chart.test.ts
@@ -85,6 +85,26 @@ describe("renderAuditAggregateChart", () => {
     expect(labels).toContain("review");
   });
 
+  it("shows the not-enough-history message for a single aggregate", () => {
+    const el = renderAuditAggregateChart([make()]);
+    const empty = el.querySelector(".empty");
+    expect(empty).not.toBeNull();
+    expect(empty!.textContent).toBe(
+      "Not enough audit history to chart — waiting for a second window.",
+    );
+    expect(el.querySelector("svg")).toBeNull();
+  });
+
+  it("shows the not-enough-history message for duplicate timestamps", () => {
+    const ts = new Date("2026-06-07T00:00:00Z");
+    const el = renderAuditAggregateChart([make({ computedAt: ts }), make({ computedAt: ts })]);
+    const empty = el.querySelector(".empty");
+    expect(empty).not.toBeNull();
+    expect(empty!.textContent).toBe(
+      "Not enough audit history to chart — waiting for a second window.",
+    );
+  });
+
   it("does not mutate the input array order", () => {
     withFg();
     // Deliberately unsorted input.

--- a/office-hours/test/audit-aggregates.test.ts
+++ b/office-hours/test/audit-aggregates.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  toAuditAggregate,
+  auditAggregateToDoc,
+  type AuditAggregate,
+} from "../src/audit-aggregates.js";
+
+const baseAggregate: AuditAggregate = {
+  computedAt: new Date("2026-06-07T10:00:00Z"),
+  windowDays: 1,
+  groupId: "group-abc",
+  phaseSpend: {
+    "plan-implement": 5.5,
+    "review-fix": 3.2,
+    "dispatch-worker": 4.1,
+  },
+  cacheRead: 3_000_000,
+  cacheCreation: 1_000_000,
+};
+
+const memberEmails = ["alice@example.com", "bob@example.com"];
+
+const make = (o: Partial<AuditAggregate> = {}): AuditAggregate => ({ ...baseAggregate, ...o });
+
+describe("auditAggregateToDoc / toAuditAggregate round-trip", () => {
+  it("round-trips an AuditAggregate through doc and back", () => {
+    const doc = auditAggregateToDoc(baseAggregate, memberEmails);
+    const result = toAuditAggregate("auto-id", doc);
+
+    expect(result).not.toBeNull();
+    if (result === null) return;
+
+    expect(result.computedAt.getTime()).toBe(baseAggregate.computedAt.getTime());
+    expect(result.windowDays).toBe(baseAggregate.windowDays);
+    expect(result.groupId).toBe(baseAggregate.groupId);
+    expect(result.phaseSpend).toEqual(baseAggregate.phaseSpend);
+    expect(result.cacheRead).toBe(baseAggregate.cacheRead);
+    expect(result.cacheCreation).toBe(baseAggregate.cacheCreation);
+    // memberEmails is an auth field stripped from the client-facing struct.
+    expect(result).not.toHaveProperty("memberEmails");
+  });
+
+  it("accepts an empty phaseSpend object", () => {
+    const doc = auditAggregateToDoc(make({ phaseSpend: {} }), memberEmails);
+    const result = toAuditAggregate("auto-id", doc);
+    expect(result).not.toBeNull();
+    expect(result?.phaseSpend).toEqual({});
+  });
+});
+
+describe("toAuditAggregate malformed-doc cases", () => {
+  const validDoc = auditAggregateToDoc(baseAggregate, memberEmails);
+
+  it("returns null when computedAt is missing", () => {
+    const doc = { ...validDoc, computedAt: undefined };
+    expect(toAuditAggregate("auto-id", doc)).toBeNull();
+  });
+
+  it("returns null when windowDays is the wrong type", () => {
+    const doc = { ...validDoc, windowDays: "not-a-number" };
+    expect(toAuditAggregate("auto-id", doc)).toBeNull();
+  });
+
+  it("returns null when groupId is the wrong type", () => {
+    const doc = { ...validDoc, groupId: 42 };
+    expect(toAuditAggregate("auto-id", doc)).toBeNull();
+  });
+
+  it("returns null when cacheRead is the wrong type", () => {
+    const doc = { ...validDoc, cacheRead: "lots" };
+    expect(toAuditAggregate("auto-id", doc)).toBeNull();
+  });
+
+  it("returns null when cacheCreation is missing", () => {
+    const doc = { ...validDoc, cacheCreation: undefined };
+    expect(toAuditAggregate("auto-id", doc)).toBeNull();
+  });
+
+  it("returns null when memberEmails is not an array", () => {
+    const doc = { ...validDoc, memberEmails: "alice@example.com" };
+    expect(toAuditAggregate("auto-id", doc)).toBeNull();
+  });
+
+  it("returns null when phaseSpend is missing", () => {
+    const doc = { ...validDoc, phaseSpend: undefined };
+    expect(toAuditAggregate("auto-id", doc)).toBeNull();
+  });
+
+  it("returns null when phaseSpend has a non-number value", () => {
+    const doc = { ...validDoc, phaseSpend: { "plan-implement": "free" } };
+    expect(toAuditAggregate("auto-id", doc)).toBeNull();
+  });
+
+  it("returns null when phaseSpend is an array", () => {
+    const doc = { ...validDoc, phaseSpend: [1, 2, 3] };
+    expect(toAuditAggregate("auto-id", doc)).toBeNull();
+  });
+});

--- a/office-hours/test/vite-plugin-audit-aggregate-seed.test.ts
+++ b/office-hours/test/vite-plugin-audit-aggregate-seed.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { auditAggregateSeedPlugin } from "../src/vite-plugin-audit-aggregate-seed";
+import type { Plugin } from "vite";
+
+describe("auditAggregateSeedPlugin", () => {
+  let plugin: Plugin;
+  let moduleCode: string | undefined;
+  let resolvedId: string | undefined;
+
+  function resolveId(id: string): string | undefined {
+    return (plugin.resolveId as (id: string) => string | undefined)(id);
+  }
+  function load(id: string): string | undefined {
+    return (plugin.load as (id: string) => string | undefined)(id);
+  }
+
+  beforeAll(() => {
+    plugin = auditAggregateSeedPlugin();
+    (plugin.buildStart as () => void)();
+    resolvedId = resolveId("virtual:office-hours-audit-aggregate-seed-data");
+    moduleCode = resolvedId ? load(resolvedId) : undefined;
+  });
+
+  it("resolves the virtual module ID", () => {
+    expect(resolvedId).toBeDefined();
+    expect(resolvedId).toBe("\0virtual:office-hours-audit-aggregate-seed-data");
+  });
+
+  it("returns undefined for unrelated module IDs", () => {
+    expect(resolveId("some-other-module")).toBeUndefined();
+  });
+
+  it("returns undefined when loading an unrelated ID", () => {
+    expect(load("some-other-id")).toBeUndefined();
+  });
+
+  it("produces module code containing export default", () => {
+    expect(moduleCode).toBeDefined();
+    expect(moduleCode).toContain("export default");
+  });
+
+  it("does not bake the memberEmails auth field into the bundle", () => {
+    expect(moduleCode).toBeDefined();
+    expect(moduleCode).not.toContain("memberEmails");
+  });
+
+  describe("generated audit aggregates", () => {
+    let aggregates: Array<{
+      computedAt: Date;
+      windowDays: number;
+      groupId: string;
+      phaseSpend: Record<string, number>;
+      cacheRead: number;
+      cacheCreation: number;
+    }>;
+    let now: number;
+
+    beforeAll(() => {
+      now = Date.now();
+      const body = moduleCode!.replace("export default", "return");
+      aggregates = new Function(body)() as typeof aggregates;
+    });
+
+    it("returns an array of aggregates", () => {
+      expect(Array.isArray(aggregates)).toBe(true);
+      expect(aggregates.length).toBeGreaterThan(0);
+    });
+
+    it("every aggregate has the correct fields with correct types", () => {
+      for (const a of aggregates) {
+        expect(a.computedAt).toBeInstanceOf(Date);
+        expect(typeof a.windowDays).toBe("number");
+        expect(typeof a.groupId).toBe("string");
+        expect(typeof a.phaseSpend).toBe("object");
+        for (const v of Object.values(a.phaseSpend)) {
+          expect(typeof v).toBe("number");
+        }
+        expect(typeof a.cacheRead).toBe("number");
+        expect(typeof a.cacheCreation).toBe("number");
+        // memberEmails is an auth field that must never reach the public bundle.
+        expect(a).not.toHaveProperty("memberEmails");
+      }
+    });
+
+    it("computedAtOffsetMin resolves to a Date relative to build time", () => {
+      const mostRecent = aggregates.reduce((a, b) =>
+        a.computedAt.getTime() > b.computedAt.getTime() ? a : b,
+      );
+      // Within 5 minutes of now (the seed has computedAtOffsetMin: 0).
+      expect(Math.abs(mostRecent.computedAt.getTime() - now)).toBeLessThan(5 * 60 * 1000);
+    });
+
+    it("series spans multiple days", () => {
+      const times = aggregates.map((a) => a.computedAt.getTime());
+      const oldest = Math.min(...times);
+      const newest = Math.max(...times);
+      const fiveDaysMs = 5 * 24 * 60 * 60 * 1000;
+      expect(newest - oldest).toBeGreaterThan(fiveDaysMs);
+    });
+
+    it("cache hit rate varies across the series", () => {
+      const hitRates = aggregates.map((a) => a.cacheRead / (a.cacheRead + a.cacheCreation));
+      const min = Math.min(...hitRates);
+      const max = Math.max(...hitRates);
+      expect(max - min).toBeGreaterThan(0.1);
+    });
+  });
+});

--- a/office-hours/vite.config.ts
+++ b/office-hours/vite.config.ts
@@ -3,6 +3,7 @@ import { officeHoursSeedDataPlugin } from "./src/vite-plugin-seed-data";
 import { usageSamplesSeedDataPlugin } from "./src/vite-plugin-usage-samples-seed";
 import { issueSamplesSeedDataPlugin } from "./src/vite-plugin-issue-samples-seed";
 import { officeHoursQueueSeedPlugin } from "./src/vite-plugin-queue-seed";
+import { auditAggregateSeedPlugin } from "./src/vite-plugin-audit-aggregate-seed";
 
 export default createAppConfig({
   plugins: [
@@ -10,5 +11,6 @@ export default createAppConfig({
     usageSamplesSeedDataPlugin(),
     issueSamplesSeedDataPlugin(),
     officeHoursQueueSeedPlugin(),
+    auditAggregateSeedPlugin(),
   ],
 });

--- a/rules-test/test/firestore/office-hours.test.ts
+++ b/rules-test/test/firestore/office-hours.test.ts
@@ -635,3 +635,228 @@ describe("office-hours issue-samples", () => {
     );
   });
 });
+
+describe("office-hours audit-aggregates", () => {
+  let env: RulesTestEnvironment;
+
+  beforeAll(async () => {
+    env = await getTestEnv();
+  });
+
+  setupCleanup();
+
+  const aggregateDoc = {
+    memberEmails: ["owner@test.com"],
+    computedAt: new Date("2026-06-07T12:00:00Z"),
+    windowDays: 1,
+    groupId: "owner-group",
+    phaseSpend: { "plan-implement": 5.5, "review-fix": 3.2 },
+    cacheRead: 3_000_000,
+    cacheCreation: 1_000_000,
+  };
+
+  const demoAggregateDoc = {
+    memberEmails: ["demo@example.com"],
+    computedAt: new Date("2026-06-07T11:00:00Z"),
+    windowDays: 1,
+    groupId: "demo-group",
+    phaseSpend: { "plan-implement": 2.0, "qa-fix": 1.5 },
+    cacheRead: 1_200_000,
+    cacheCreation: 1_180_000,
+  };
+
+  beforeEach(async () => {
+    await adminSetDoc(
+      env,
+      `office-hours/${ENV}/audit-aggregates/agg-owner`,
+      aggregateDoc,
+    );
+    await adminSetDoc(
+      env,
+      `office-hours/demo/audit-aggregates/agg-demo`,
+      demoAggregateDoc,
+    );
+  });
+
+  it("allows owner to read test-env doc", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertSucceeds(
+      getDoc(doc(db, `office-hours/${ENV}/audit-aggregates/agg-owner`)),
+    );
+  });
+
+  it("denies non-owner read of test-env doc", async () => {
+    const ctx = authenticatedContext(env, "stranger@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDoc(doc(db, `office-hours/${ENV}/audit-aggregates/agg-owner`)),
+    );
+  });
+
+  it("denies unauthenticated read of test-env doc", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertFails(
+      getDoc(doc(db, `office-hours/${ENV}/audit-aggregates/agg-owner`)),
+    );
+  });
+
+  it("allows unauthenticated read of demo-env doc", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertSucceeds(
+      getDoc(doc(db, `office-hours/demo/audit-aggregates/agg-demo`)),
+    );
+  });
+
+  it("denies owner setDoc on test-env doc", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      setDoc(doc(db, `office-hours/${ENV}/audit-aggregates/agg-owner`), {
+        memberEmails: ["owner@test.com"],
+      }),
+    );
+  });
+
+  it("denies owner updateDoc on test-env doc", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      updateDoc(doc(db, `office-hours/${ENV}/audit-aggregates/agg-owner`), {
+        cacheRead: 9_000_000,
+      }),
+    );
+  });
+
+  it("denies owner deleteDoc on test-env doc", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      deleteDoc(doc(db, `office-hours/${ENV}/audit-aggregates/agg-owner`)),
+    );
+  });
+
+  it("denies unauthenticated setDoc on demo-env doc", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertFails(
+      setDoc(doc(db, `office-hours/demo/audit-aggregates/agg-demo`), {
+        memberEmails: ["demo@example.com"],
+      }),
+    );
+  });
+
+  it("allows owner list query on test-env collection", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(db, `office-hours/${ENV}/audit-aggregates`),
+          where("memberEmails", "array-contains", "owner@test.com"),
+        ),
+      ),
+    );
+  });
+
+  it("denies unfiltered owner list query on test-env audit-aggregates collection", async () => {
+    const ctx = authenticatedContext(env, "owner@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(collection(db, `office-hours/${ENV}/audit-aggregates`)),
+    );
+  });
+
+  it("denies unfiltered stranger list query on test-env audit-aggregates collection", async () => {
+    const ctx = authenticatedContext(env, "stranger@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(collection(db, `office-hours/${ENV}/audit-aggregates`)),
+    );
+  });
+
+  // A non-member cannot list another member's aggregates: filtering for an email
+  // they are not in is denied, because the matching docs carry a memberEmails
+  // the requester is absent from. (A self-targeted array-contains filter is
+  // always rule-compliant and returns an empty set, so it is not a denial
+  // case.)
+  it("denies authenticated non-member list query for another member's aggregates", async () => {
+    const ctx = authenticatedContext(env, "stranger@test.com");
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(
+        query(
+          collection(db, `office-hours/${ENV}/audit-aggregates`),
+          where("memberEmails", "array-contains", "owner@test.com"),
+        ),
+      ),
+    );
+  });
+
+  // "Rules are not filters": a list query is allowed when its where-clause
+  // provably satisfies the rule. A non-member filtering to their own membership
+  // is allowed and simply returns the empty subset they are entitled to.
+  it("allows non-member list query filtered to own (empty) membership", async () => {
+    const ctx = authenticatedContext(env, "stranger@test.com");
+    const db = ctx.firestore();
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(db, `office-hours/${ENV}/audit-aggregates`),
+          where("memberEmails", "array-contains", "stranger@test.com"),
+        ),
+      ),
+    );
+  });
+
+  it("denies unauthenticated list query on test-env collection", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(
+        query(
+          collection(db, `office-hours/${ENV}/audit-aggregates`),
+          where("memberEmails", "array-contains", "owner@test.com"),
+        ),
+      ),
+    );
+  });
+
+  it("denies unauthenticated list query on demo-env collection", async () => {
+    const ctx = unauthenticatedContext(env);
+    const db = ctx.firestore();
+    await assertFails(
+      getDocs(collection(db, `office-hours/demo/audit-aggregates`)),
+    );
+  });
+
+  it("denies authenticated setDoc on demo-env doc", async () => {
+    const ctx = authenticatedContext(env, "demo@example.com");
+    const db = ctx.firestore();
+    await assertFails(
+      setDoc(doc(db, `office-hours/demo/audit-aggregates/agg-demo`), {
+        memberEmails: ["demo@example.com"],
+      }),
+    );
+  });
+
+  it("denies authenticated updateDoc on demo-env doc", async () => {
+    const ctx = authenticatedContext(env, "demo@example.com");
+    const db = ctx.firestore();
+    await assertFails(
+      updateDoc(doc(db, `office-hours/demo/audit-aggregates/agg-demo`), {
+        cacheRead: 5,
+      }),
+    );
+  });
+
+  it("denies authenticated deleteDoc on demo-env doc", async () => {
+    const ctx = authenticatedContext(env, "demo@example.com");
+    const db = ctx.firestore();
+    await assertFails(
+      deleteDoc(doc(db, `office-hours/demo/audit-aggregates/agg-demo`)),
+    );
+  });
+});


### PR DESCRIPTION
Closes #1863

## What

Adds the **reader + UI half** of the office-hours audit-aggregate dashboard
panel: a `getOwner*`/`getDemo*` reader for a new `audit-aggregates` Firestore
collection, a demo seed bundle, and a full-width chart panel rendering per-window
phase spend and the cache hit-rate trend, wired into the dashboard.

The sibling **writer** (#1862) persists the documents this reader consumes. It is
a *sibling, not a blocker*, and is not yet merged. **This PR can land first**: the
panel renders demo data when unauthenticated and degrades to an empty state when
an authenticated owner has no audit documents yet, so the no-writer case is safe.

## The #1862 ↔ #1863 contract (authoritative)

The reader and writer must agree on a collection name and document shape. This PR
locks the contract; #1862 must write documents matching it.

**Collection:** `office-hours/{env}/audit-aggregates/{aggId}`

**Document fields** (one document per audited window):

| Field | Type | Notes |
| --- | --- | --- |
| `computedAt` | Timestamp | window's point on the time axis |
| `windowDays` | number | audit window length |
| `groupId` | string | owning group |
| `memberEmails` | string[] | denormalized auth gate; stripped from the client bundle, never returned by the reader |
| `phaseSpend` | map<string, number> | phase name → Opus-proxy USD spend for the window |
| `cacheRead` | number | window-total cache-read tokens (hit-rate input) |
| `cacheCreation` | number | window-total cache-creation tokens (hit-rate input) |

**Derived hit-rate** (computed in the reader/chart, never stored):
`hitRate = cacheRead / (cacheRead + cacheCreation)`, guarding the
zero-denominator case.

`toAuditAggregate` returns `null` + `logError` on **any** field mismatch (modeled
on `toUsageSample`), so a schema disagreement surfaces as an **empty panel** —
indistinguishable from "no data yet." That is why the contract must be exact, and
why a field-name/type mismatch should be the first suspect if #1862's documents
exist but the panel is empty (check the `audit-aggregate-validation` `logError`
output).

## Units

1. **Data layer** — `audit-aggregates.ts` (contract type + validating parser +
   `auditAggregateToDoc`), `audit-data.ts` (owner/demo readers), the demo seed
   bundle (seeds + vite plugin + ambient `.d.ts` + `vite.config.ts`
   registration), the `audit-aggregates` `firestore.rules` block, and rules-test
   cases. The rules block ships in this PR — without it an authenticated owner
   read is permission-denied and would reject the shared `Promise.all` in
   `main.ts`, dropping the whole view to the error tier.
2. **Chart panel** — `audit-aggregate-chart.ts`: `renderAuditAggregateChart`
   renders two stacked sub-charts in one panel (per-phase spend on a `$` axis;
   the derived hit-rate trend on a `%` axis), reusing `chart-util` for
   axes/scroll/legend, with an empty state for graceful degradation.
3. **Wiring** — registers the full-width **Audit** panel in `app-view`'s `PANELS`
   (demo + owner tiers), threads `auditAggregates` through
   `ViewState`/`PanelContext`/`buildContext`, and adds the
   `getOwnerAuditAggregates` reader to `main.ts`'s shared `Promise.all` and the
   owner paint.

## Verification

- `npm run build --prefix office-hours` — passes (proves the virtual-module
  `.d.ts` typing and `vite.config.ts` registration).
- `npx vitest run --root office-hours` — passes, including the new parser, seed
  plugin, chart, and extended app-view tests.
- `npm run test --prefix rules-test` (not in CI — run manually) — passes,
  including the new `audit-aggregates` cases (demo-readable get; member-gated
  get/list; filtered list allowed; unfiltered list denied; write denied).
