### PR TITLE
ds: scaffold @commons-systems/ds with the token layer

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/run-typecheck.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-typecheck.sh
@@ -96,6 +96,17 @@ REGRESSIONS=()
 for ws in "${APP_DIRS[@]}"; do
   echo "=== Typecheck: $ws ==="
 
+  # CSS-only / non-TS workspaces have no tsconfig.json; `tsc --project <ws>`
+  # exits TS5057 with no project to load. Skip them — there is nothing for tsc
+  # to typecheck. This also removes the fragile coincidence whereby a
+  # tsconfig-less workspace that happens to exist on origin/main (e.g. `style`)
+  # was skipped only because its baseline tsc invocation *also* errored and got
+  # misreported as a pre-existing typecheck failure.
+  if [ ! -f "$REPO_ROOT/$ws/tsconfig.json" ]; then
+    echo "$ws: no tsconfig.json — skipping (non-TS workspace)"
+    continue
+  fi
+
   pass_suffix=""
   if git -C "$REPO_ROOT" rev-parse --verify "origin/main:$ws" >/dev/null 2>&1; then
     TOUCHED_WORKSPACES+=("$ws")

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "local-first",
         "mediautil",
         "print",
+        "packages/ds",
         "router",
         "style",
         "rules-test"
@@ -325,6 +326,10 @@
     },
     "node_modules/@commons-systems/criticalcssutil": {
       "resolved": "criticalcssutil",
+      "link": true
+    },
+    "node_modules/@commons-systems/ds": {
+      "resolved": "packages/ds",
       "link": true
     },
     "node_modules/@commons-systems/errorutil": {
@@ -14874,6 +14879,10 @@
         "vite": "^6.4.3",
         "vitest": "^4.1.8"
       }
+    },
+    "packages/ds": {
+      "name": "@commons-systems/ds",
+      "version": "0.0.0"
     },
     "print": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "local-first",
     "mediautil",
     "print",
+    "packages/ds",
     "router",
     "style",
     "rules-test"

--- a/packages/ds/base.css
+++ b/packages/ds/base.css
@@ -1,0 +1,84 @@
+:root {
+  color-scheme: light dark;
+}
+
+/* Production chrome — global element defaults */
+
+body {
+  font-family: var(--font-body);
+  color: var(--text-primary);
+  background: var(--grid-texture), var(--bg);
+}
+
+.page {
+  max-width: var(--max-width-wide);
+  margin: 0 auto;
+  padding-inline: var(--space-4);
+}
+
+h1,
+h2,
+h3 {
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-heading);
+  text-shadow: var(--glow-accent);
+}
+
+a {
+  color: var(--link);
+}
+
+a:hover {
+  text-decoration-thickness: var(--border-width-strong);
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--surface-card);
+  border: var(--border-width) solid var(--border-default);
+  border-bottom-width: var(--border-width-strong);
+  padding-block: var(--space-4);
+  padding-inline: var(--space-6);
+  margin-bottom: var(--space-8);
+}
+
+footer {
+  border-top: var(--border-width-strong) solid var(--border-default);
+  padding-top: var(--space-4);
+  padding-bottom: var(--space-4);
+  margin-top: var(--space-8);
+  color: var(--text-muted);
+}
+
+*,
+*::before,
+*::after {
+  border-radius: var(--radius-none);
+}
+
+main {
+  background: var(--surface-card);
+  padding: var(--space-6);
+  border: var(--border-width) solid var(--border-default);
+}
+
+/* cs-* component interaction states (resting styles are inline in the components) */
+
+.cs-btn:active            { transform: translateY(1px); }
+.cs-btn:focus-visible     { outline: var(--focus-outline); outline-offset: var(--focus-offset); }
+.cs-btn--primary:hover    { background: color-mix(in srgb, var(--accent) 85%, black); }
+.cs-btn--secondary:hover  { border-color: var(--accent);
+                            background: color-mix(in srgb, var(--accent) 10%, transparent); }
+.cs-btn--ghost:hover      { text-decoration: underline; text-decoration-thickness: 2px; }
+
+.cs-card--interactive:hover,
+.cs-card--interactive:focus { border-color: var(--accent);
+                              outline: 2px solid var(--accent); outline-offset: -2px; }
+
+.cs-input:focus,
+.cs-select:focus          { border-color: var(--accent); outline: none; }
+
+.cs-nav__link:hover       { text-decoration: underline; text-decoration-thickness: 2px; }

--- a/packages/ds/fonts.css
+++ b/packages/ds/fonts.css
@@ -1,0 +1,57 @@
+/* All @font-face blocks use font-display: optional — no FOIT, no late swap.
+   Smoke/acceptance tests assert the declared family string, not that the
+   woff2 rendered (uncached first visit may paint in fallback). */
+@font-face {
+  font-family: "IBM Plex Mono";
+  font-style: normal;
+  font-weight: 400;
+  font-display: optional;
+  src: url("/fonts/ibm-plex-mono-latin-400-normal.woff2") format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+    U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+    U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "IBM Plex Mono";
+  font-style: normal;
+  font-weight: 700;
+  font-display: optional;
+  src: url("/fonts/ibm-plex-mono-latin-700-normal.woff2") format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+    U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+    U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "IBM Plex Serif";
+  font-style: normal;
+  font-weight: 400;
+  font-display: optional;
+  src: url("/fonts/ibm-plex-serif-latin-400-normal.woff2") format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+    U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+    U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "IBM Plex Serif";
+  font-style: italic;
+  font-weight: 400;
+  font-display: optional;
+  src: url("/fonts/ibm-plex-serif-latin-400-italic.woff2") format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+    U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+    U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "IBM Plex Serif";
+  font-style: normal;
+  font-weight: 700;
+  font-display: optional;
+  src: url("/fonts/ibm-plex-serif-latin-700-normal.woff2") format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+    U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+    U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}

--- a/packages/ds/package.json
+++ b/packages/ds/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@commons-systems/ds",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "lint": "echo 'CSS-only package, nothing to lint'"
+  },
+  "exports": {
+    "./styles.css": "./styles.css",
+    "./fonts.css": "./fonts.css",
+    "./base.css": "./base.css",
+    "./tokens/colors.css": "./tokens/colors.css",
+    "./tokens/typography.css": "./tokens/typography.css",
+    "./tokens/spacing.css": "./tokens/spacing.css",
+    "./tokens/effects.css": "./tokens/effects.css"
+  }
+}

--- a/packages/ds/styles.css
+++ b/packages/ds/styles.css
@@ -1,0 +1,6 @@
+@import "./fonts.css";
+@import "./tokens/colors.css";
+@import "./tokens/typography.css";
+@import "./tokens/spacing.css";
+@import "./tokens/effects.css";
+@import "./base.css";

--- a/packages/ds/tokens/colors.css
+++ b/packages/ds/tokens/colors.css
@@ -1,0 +1,21 @@
+:root {
+  --fg:      light-dark(#1a1a1a, #e0d8c8);   /* ink / oat */
+  --bg:      light-dark(#f5f0e8, #1a1714);   /* paper / espresso */
+  --surface: light-dark(#ece5d8, #252017);   /* panels, cards, header */
+  --accent:  light-dark(#b8600a, #e8943a);   /* amber — the one hue */
+  --muted:   light-dark(#6b5e4f, #8a7d6e);
+  --border:  light-dark(#c4b8a4, #3d3529);
+
+  --text-primary: var(--fg);  --text-muted: var(--muted);
+  --text-on-accent: var(--bg);
+  --link: var(--accent);
+  --surface-page: var(--bg);  --surface-card: var(--surface);  --surface-raised: var(--surface);
+  --border-default: var(--border);  --focus-ring: var(--accent);
+
+  --success:#4caf50; --favorable:#4caf50; --warning:var(--accent);
+  --error:#e45858;   --unfavorable:#e45858; --positive:#2ca02c;
+
+  /* warm, desaturated categorical palette (budget Sankey order) */
+  --chart-1:#4d6f8f; --chart-2:#c98a3c; --chart-3:#a35d5d;
+  --chart-4:#7a8c5a; --chart-5:#b08a4f; --chart-6:#5f8a8a;
+}

--- a/packages/ds/tokens/effects.css
+++ b/packages/ds/tokens/effects.css
@@ -1,0 +1,15 @@
+:root {
+  --glow-accent:0 0 0.4em var(--accent);
+  --grid-line:rgba(224,216,200,0.04);
+  --grid-texture:
+    repeating-linear-gradient(to right, var(--grid-line) 0 1px, transparent 1px var(--texture-pitch,24px)),
+    repeating-linear-gradient(to bottom, var(--grid-line) 0 1px, transparent 1px var(--texture-pitch,24px));
+  --shadow-overflow-top:inset 0 12px 12px -12px rgba(0,0,0,.2);
+  --shadow-overflow-bottom:inset 0 -12px 12px -12px rgba(0,0,0,.2);
+  --focus-outline:2px solid var(--focus-ring); --focus-offset:2px;
+  --duration-fast:.15s; --duration-base:.2s; --ease:ease;
+  --transition-color: color var(--duration-fast) var(--ease),
+    border-color var(--duration-fast) var(--ease),
+    background var(--duration-fast) var(--ease),
+    outline-color var(--duration-fast) var(--ease);
+}

--- a/packages/ds/tokens/spacing.css
+++ b/packages/ds/tokens/spacing.css
@@ -1,0 +1,10 @@
+:root {
+  --space-0:0; --space-1:.25rem; --space-2:.5rem; --space-3:.75rem; --space-4:1rem;
+  --space-5:1.25rem; --space-6:1.5rem; --space-8:2rem; --space-12:3rem; --space-16:4rem;
+
+  --border-width:1px; --border-width-strong:2px;
+  --radius-none:0; --radius-sm:4px; --radius-md:6px; --radius-lg:8px;  /* radii are the exception, not the rule */
+
+  --max-width-prose:48rem; --max-width-content:64rem; --max-width-wide:68rem;
+  --sidebar-width:16rem; --texture-pitch:24px;
+}

--- a/packages/ds/tokens/typography.css
+++ b/packages/ds/tokens/typography.css
@@ -1,0 +1,14 @@
+:root {
+  --font-mono: "IBM Plex Mono", ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, "DejaVu Sans Mono", monospace;
+  --font-serif: "IBM Plex Serif", Georgia, "Times New Roman", serif;
+  --font-body: var(--font-mono); --font-heading: var(--font-mono); --font-prose: var(--font-serif);
+
+  --text-micro:.65rem; --text-xs:.75rem; --text-sm:.875rem; --text-base:1rem;
+  --text-lg:1.1rem; --text-xl:1.5rem; --text-2xl:2rem;
+  --text-display:clamp(1.75rem,7vw,2.75rem);
+
+  --weight-normal:400; --weight-bold:700;          /* only these two */
+  --leading-tight:1.2; --leading-snug:1.4; --leading-normal:1.5; --leading-prose:1.6;
+  --tracking-tight:0; --tracking-heading:.05em; --tracking-label:.1em;
+  --measure-prose:70ch;
+}


### PR DESCRIPTION
Closes #1865

## Summary

Phase 1 of the design-system epic (#1864): scaffold the `@commons-systems/ds`
workspace package and lift the hand-authored CSS into a token layer of CSS custom
properties. **CSS + package-scaffold only — no component (`.tsx`) and no app
changes.**

The token names/values are a contract the external design environment already
targets, so the token blocks are copied verbatim.

## What's in this PR

- **`packages/ds/package.json`** — a CSS-only workspace package (modeled on
  `@commons-systems/style`): no-op `lint`, `private`, `type: module`, and an
  `exports` map listing every public CSS file. Registered in the root
  `package.json` `workspaces` array; `package-lock.json` updated so `npm ci` stays
  in sync.
- **`packages/ds/tokens/{colors,typography,spacing,effects}.css`** — the token
  layer, copied verbatim from the issue contract.
- **`packages/ds/fonts.css`** — the IBM Plex Mono / Serif `@font-face` blocks
  (weights 400/700 plus the serif italic prose face), ported verbatim from
  `landing/src/style/theme.css`. Keeps the `/fonts/...` absolute URLs and
  `font-display: optional`; consuming apps serve the woff2 from their
  `public/fonts/`.
- **`packages/ds/base.css`** — three parts: `:root { color-scheme: light dark; }`
  (so the `light-dark(...)` tokens resolve in both schemes), the production global
  chrome ported into token terms, and the `cs-*` component interaction-state
  pseudo-class rules for the sibling component work.
- **`packages/ds/styles.css`** — the `@import` manifest a non-React consumer links
  (fonts → tokens → base, in cascade order).

## Two fidelity points

- The contract `colors.css` block omits `color-scheme`, but every color is
  `light-dark(...)`; `base.css` `:root` supplies `color-scheme: light dark;` so
  dark mode resolves.
- `.page` uses `var(--max-width-wide)` (68rem), matching the issue's `base.css`
  prose, not the older 48rem.

## Scope boundaries (handled by siblings)

- #1866 refactors existing global/per-app CSS to consume these tokens.
- #1867 builds the eight React components whose `cs-*` interaction states ship here
  (their resting styles are inline in the components).
- #1878 adds drift-prevention lint + cross-app verification.

## Known downstream gap (filed, not fixed here)

The dispatch CI change-detection (`resolve_dirty_apps` in
`.claude/skills/dispatch-propagate/scripts/lib.sh`) resolves a changed file to its
workspace by first path segment, so a nested path like `packages/ds/*` collapses to
`packages` and matches no workspace key. This does not affect this PR's own CI (the
root `package.json` change marks all apps dirty), but later isolated edits under
`packages/ds` would be silently skipped. Filed as #1887 for the shared-infra fix —
deliberately out of this issue's "no app changes" scope.

## Verification

- `git diff --name-only origin/main...HEAD` shows only `package.json`,
  `package-lock.json`, and new `packages/ds/**` files — no `.tsx`, no existing-app
  edits.
- `npm run -w packages/ds lint` prints the no-op line and exits 0.
- Bare-HTML smoke (linking only `packages/ds/styles.css`) renders the
  cassette-futurism base look and resolves in both light and dark — to be exercised
  in the QA phase.
