### PR TITLE
dispatch: stamp session artifact into a per-session sidecar for audit joins

### DIFF
--- a/.claude/hooks/stamp-dispatch-session.sh
+++ b/.claude/hooks/stamp-dispatch-session.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# stamp-dispatch-session.sh — write a per-session dispatch sidecar at session
+# birth using local git only (no network). Records repo/issue/branch/base_sha;
+# `pr` starts null and is backfilled later by dispatch-stamp-session --backfill-pr.
+#
+# Bound to SessionStart:startup (fresh claude --bg worker sessions) and
+# SessionStart:resume (resumed sessions). Always exits 0 — never blocks session
+# start.
+set -uo pipefail
+trap 'echo "[stamp-dispatch-session] WARNING: unexpected error on line $LINENO" >&2; exit 0' ERR
+
+STDIN_JSON=$(cat 2>/dev/null) || STDIN_JSON=""
+SESSION_ID=$(printf '%s' "$STDIN_JSON" | jq -r '.session_id // empty' 2>/dev/null) || SESSION_ID=""
+TRANSCRIPT_PATH=$(printf '%s' "$STDIN_JSON" | jq -r '.transcript_path // empty' 2>/dev/null) || TRANSCRIPT_PATH=""
+
+if [[ -z "$SESSION_ID" || -z "$TRANSCRIPT_PATH" ]]; then
+  echo "[stamp-dispatch-session] session_id or transcript_path missing in hook payload; skipping stamp" >&2
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 0
+STAMP_SCRIPT="$SCRIPT_DIR/../skills/dispatch-propagate/scripts/dispatch-stamp-session"
+
+if [[ ! -x "$STAMP_SCRIPT" ]]; then
+  echo "[stamp-dispatch-session] dispatch-stamp-session not found or not executable at '$STAMP_SCRIPT'; skipping stamp" >&2
+  exit 0
+fi
+
+"$STAMP_SCRIPT" --session-id "$SESSION_ID" --transcript-path "$TRANSCRIPT_PATH" || true
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -133,6 +133,15 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/restore-dispatch-skill.sh"
           }
         ]
+      },
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stamp-dispatch-session.sh"
+          }
+        ]
       }
     ],
     "WorktreeCreate": [

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-open-pr
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-open-pr
@@ -61,6 +61,10 @@ usage() {
 # Used both for stripping a stray keyword before an extra number.
 KEYWORD_RE='close[sd]?|fix(?:e[sd])?|resolve[sd]?'
 
+# Resolve this script's own directory so the sibling dispatch-stamp-session
+# (PR backfill) is found regardless of the caller's cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # --- argument parsing ---------------------------------------------------------
 
 PRIMARY=""
@@ -215,6 +219,12 @@ while :; do
     -q '.closingIssuesReferences[].number' | sort -n -u)"
 
   if [[ "$PARSED" == "$INTENDED_SORTED" ]]; then
+    # Stamp the now-known PR number into this session's dispatch sidecar so the
+    # token audit can join the session to its PR (#1861). The backfill is
+    # non-fatal (it exits 0 on any miss) and all its output goes to stderr; the
+    # `|| true` defends the set -e shell against any non-zero. The stdout
+    # contract is preserved: the bare PR number remains the ONLY stdout line.
+    "$SCRIPT_DIR/dispatch-stamp-session" --backfill-pr "$PR_NUM" 1>&2 || true
     echo "$PR_NUM"
     exit 0
   fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-stamp-session
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-stamp-session
@@ -115,7 +115,7 @@ if [[ -n "$BACKFILL_PR" ]]; then
 
   # --- Mode B: PR backfill --------------------------------------------------
   # A non-numeric --backfill-pr value is the one genuine caller bug → exit 2.
-  if [[ ! "$BACKFILL_PR" =~ ^[0-9]+$ ]]; then
+  if [[ ! "$BACKFILL_PR" =~ ^[1-9][0-9]*$ ]]; then
     echo "dispatch-stamp-session: --backfill-pr must be a positive integer, got: $BACKFILL_PR" >&2
     usage
     exit 2
@@ -221,16 +221,30 @@ fi
 # Locate the sidecar path: transcript with .jsonl → .dispatch-stamp.json.
 sidecar="${TRANSCRIPT_PATH%.jsonl}.dispatch-stamp.json"
 
-# Idempotency: preserve a non-null .pr already on disk (e.g. a prior backfill).
+# Idempotency: Mode A runs on both `startup` and `resume`. The audit joins a
+# session to its *starting* ground truth, so an existing sidecar's anchor fields
+# are authoritative — a resume after committed work must not advance them to a
+# post-resume HEAD/clock. Preserve a non-null .pr (e.g. a prior backfill) and the
+# original base_sha/stamped_at when the sidecar already exists; only re-derive
+# them on the first (startup) write.
 pr=null
 if [[ -f "$sidecar" ]]; then
   existing_pr=$(jq '.pr' "$sidecar" 2>/dev/null || echo null)
   if [[ -n "$existing_pr" && "$existing_pr" != "null" ]]; then
     pr="$existing_pr"
   fi
+  existing_base_sha=$(jq -r '.base_sha // empty' "$sidecar" 2>/dev/null || echo "")
+  if [[ -n "$existing_base_sha" ]]; then
+    base_sha="$existing_base_sha"
+  fi
+  existing_stamped_at=$(jq -r '.stamped_at // empty' "$sidecar" 2>/dev/null || echo "")
 fi
 
-stamped_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+if [[ -n "${existing_stamped_at:-}" ]]; then
+  stamped_at="$existing_stamped_at"
+else
+  stamped_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+fi
 
 # Build atomically with jq -n so the JSON is always valid. Numerics
 # (schema/issue/pr) use --argjson; strings use --arg.
@@ -249,4 +263,4 @@ if ! jq -n \
   rm -f "$sidecar.tmp"
   exit 0
 fi
-mv "$sidecar.tmp" "$sidecar"
+mv "$sidecar.tmp" "$sidecar" || { echo "dispatch-stamp-session: failed to move sidecar into place; skipping stamp" >&2; rm -f "$sidecar.tmp"; exit 0; }

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-stamp-session
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-stamp-session
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# dispatch-stamp-session — write/backfill a per-session GitHub-artifact sidecar.
+#
+# Usage:
+#   dispatch-stamp-session --session-id <id> --transcript-path <path>   (Mode A)
+#   dispatch-stamp-session --backfill-pr <N>                            (Mode B)
+#
+# A dispatch worker session does not otherwise record the GitHub artifact it
+# acted on (repo/issue/pr/branch/base_sha), so the token audit cannot join a
+# session to its real-world outcome. This script writes a JSON sidecar next to
+# the session transcript — `<transcript>.dispatch-stamp.json`, i.e. the
+# transcript path with its `.jsonl` suffix replaced by `.dispatch-stamp.json` —
+# holding that artifact. The audit later globs the sidecar by session id.
+#
+# Sidecar JSON shape (always emitted via `jq -n`, so always valid JSON):
+#
+#   {"schema":1,"session_id":"<id>","repo":"<owner/name>","issue":<N>,
+#    "pr":null,"branch":"<branch>","base_sha":"<sha>","stamped_at":"<iso8601>"}
+#
+# Mode A — initial write (run at session start). Derives everything from git
+# only (NEVER gh, no network):
+#   repo      owner/name parsed from `git remote get-url origin` (SSH or HTTPS,
+#             trailing `.git` stripped).
+#   branch    `git rev-parse --abbrev-ref HEAD`.
+#   base_sha  `git rev-parse HEAD`.
+#   issue     the numeric prefix of the branch (leading digits before `-`), as
+#             a JSON number.
+#   stamped_at  current UTC time, ISO-8601.
+#
+# Mode A no-ops (exit 0, writes nothing) unless the branch matches `^[0-9]+-`.
+# That single positive gate already excludes the non-worker branches `main`,
+# detached `HEAD`, and any `office-hours-*` branch. A no-op emits at most one
+# short stderr diagnostic and exits 0 — it must NEVER block session start.
+#
+# Mode A is idempotent w.r.t. a backfilled pr: if the sidecar already exists and
+# carries a non-null `.pr`, that value is preserved (everything else is
+# re-derived); otherwise `pr` is written as null.
+#
+# Mode B — PR backfill (run once a PR number is known). Locates the sidecar by
+# the session id (a UUID) under the projects root via a maxdepth-2 find, then
+# applies an idempotent `.pr = N` update. A backfill failure must NEVER fail its
+# caller: an unset/empty $CLAUDE_CODE_SESSION_ID or a sidecar that isn't found
+# emits a short stderr diagnostic and exits 0. Only a malformed --backfill-pr
+# argument (non-numeric) is a clear caller bug → exit 2.
+#
+# All writes are atomic (build into a `.tmp` file, then `mv` into place).
+#
+# NOTE on no-op-via-exit-0: the `|| { echo ...; exit 0; }` guards below are not
+# the "defensive fallback" that code-style.md forbids — they implement the
+# documented never-block-session-start discipline, mirroring the worker-branch
+# guard in .claude/hooks/restore-dispatch-skill.sh.
+#
+# Test seams: $DISPATCH_STAMP_PROJECTS_ROOT overrides the projects root
+# (default $HOME/.claude/projects); $HOME is honored as the fallback base.
+#
+# A missing argument, missing flag value, unknown arg, or mixing modes
+# incoherently is a clear error, not a fallback (exit 2).
+set -euo pipefail
+
+SESSION_ID=""
+TRANSCRIPT_PATH=""
+BACKFILL_PR=""
+
+usage() {
+  echo "usage: dispatch-stamp-session --session-id <id> --transcript-path <path>" >&2
+  echo "       dispatch-stamp-session --backfill-pr <N>" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --session-id)
+      if [[ $# -lt 2 ]]; then
+        echo "dispatch-stamp-session: --session-id requires a value" >&2
+        usage
+        exit 2
+      fi
+      SESSION_ID="$2"
+      shift 2
+      ;;
+    --transcript-path)
+      if [[ $# -lt 2 ]]; then
+        echo "dispatch-stamp-session: --transcript-path requires a value" >&2
+        usage
+        exit 2
+      fi
+      TRANSCRIPT_PATH="$2"
+      shift 2
+      ;;
+    --backfill-pr)
+      if [[ $# -lt 2 ]]; then
+        echo "dispatch-stamp-session: --backfill-pr requires a value" >&2
+        usage
+        exit 2
+      fi
+      BACKFILL_PR="$2"
+      shift 2
+      ;;
+    *)
+      echo "dispatch-stamp-session: unexpected argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+# --- mode selection ---------------------------------------------------------
+# Exactly one mode per invocation. --backfill-pr selects Mode B; --session-id /
+# --transcript-path select Mode A. Mixing them is incoherent → exit 2.
+if [[ -n "$BACKFILL_PR" ]]; then
+  if [[ -n "$SESSION_ID" || -n "$TRANSCRIPT_PATH" ]]; then
+    echo "dispatch-stamp-session: --backfill-pr cannot be combined with --session-id/--transcript-path" >&2
+    usage
+    exit 2
+  fi
+
+  # --- Mode B: PR backfill --------------------------------------------------
+  # A non-numeric --backfill-pr value is the one genuine caller bug → exit 2.
+  if [[ ! "$BACKFILL_PR" =~ ^[0-9]+$ ]]; then
+    echo "dispatch-stamp-session: --backfill-pr must be a positive integer, got: $BACKFILL_PR" >&2
+    usage
+    exit 2
+  fi
+
+  # From here on, a failure must NEVER fail the caller — diagnose and exit 0.
+  if [[ -z "${CLAUDE_CODE_SESSION_ID:-}" ]]; then
+    echo "dispatch-stamp-session: CLAUDE_CODE_SESSION_ID unset/empty; cannot locate sidecar to backfill, skipping" >&2
+    exit 0
+  fi
+
+  # The session id is interpolated into a find -name glob; reject path-traversal
+  # and control chars before composing it.
+  case "$CLAUDE_CODE_SESSION_ID" in
+    *..*|*/*|*[[:cntrl:]]*)
+      echo "dispatch-stamp-session: CLAUDE_CODE_SESSION_ID contains illegal characters; skipping backfill" >&2
+      exit 0
+      ;;
+  esac
+
+  PROJECTS_ROOT="${DISPATCH_STAMP_PROJECTS_ROOT:-${HOME:-}/.claude/projects}"
+  if [[ -z "$PROJECTS_ROOT" || ! -d "$PROJECTS_ROOT" ]]; then
+    echo "dispatch-stamp-session: projects root '$PROJECTS_ROOT' is not a directory; skipping backfill" >&2
+    exit 0
+  fi
+
+  sidecar=$(find "$PROJECTS_ROOT" -maxdepth 2 -name "${CLAUDE_CODE_SESSION_ID}.dispatch-stamp.json" 2>/dev/null | head -n1)
+  if [[ -z "$sidecar" ]]; then
+    echo "dispatch-stamp-session: no sidecar found for session $CLAUDE_CODE_SESSION_ID under $PROJECTS_ROOT; skipping backfill" >&2
+    exit 0
+  fi
+
+  if ! jq --argjson pr "$BACKFILL_PR" '.pr = $pr' "$sidecar" > "$sidecar.tmp" 2>/dev/null; then
+    echo "dispatch-stamp-session: failed to update pr in '$sidecar'; skipping backfill" >&2
+    rm -f "$sidecar.tmp"
+    exit 0
+  fi
+  mv "$sidecar.tmp" "$sidecar"
+  exit 0
+fi
+
+# --- Mode A: initial write --------------------------------------------------
+if [[ -z "$SESSION_ID" ]]; then
+  echo "dispatch-stamp-session: --session-id is required for the initial write" >&2
+  usage
+  exit 2
+fi
+if [[ -z "$TRANSCRIPT_PATH" ]]; then
+  echo "dispatch-stamp-session: --transcript-path is required for the initial write" >&2
+  usage
+  exit 2
+fi
+
+# Derive the branch. A failure here is not fatal to session start — no-op.
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || {
+  echo "dispatch-stamp-session: could not resolve current branch (not a git checkout?); skipping stamp" >&2
+  exit 0
+}
+
+# Worker-branch gate: only phase-worker target branches (^[0-9]+-) are stamped.
+# This single positive gate already excludes main, detached HEAD, and
+# office-hours-* — mirroring restore-dispatch-skill.sh's guard shape.
+if ! printf '%s\n' "$branch" | grep -qE '^[0-9]+-'; then
+  echo "dispatch-stamp-session: branch '$branch' is not a worker branch (^[0-9]+-); skipping stamp" >&2
+  exit 0
+fi
+
+# Reject path-traversal / control chars in the branch before it is used to build
+# the issue number (and as a sidecar field). Git refnames already disallow these,
+# so a match indicates a malformed or hostile source.
+case "$branch" in
+  *..*|*/*|*[[:cntrl:]]*)
+    echo "dispatch-stamp-session: branch '$branch' contains illegal characters; skipping stamp" >&2
+    exit 0
+    ;;
+esac
+
+# issue = leading digits of the branch, as a JSON number.
+issue=$(printf '%s\n' "$branch" | grep -oE '^[0-9]+')
+
+# base_sha = current HEAD.
+base_sha=$(git rev-parse HEAD 2>/dev/null) || {
+  echo "dispatch-stamp-session: could not resolve HEAD sha; skipping stamp" >&2
+  exit 0
+}
+
+# repo = owner/name from origin. Handle SSH and HTTPS forms; strip trailing .git.
+# If origin can't be resolved we still write the sidecar with an empty repo
+# rather than block session start.
+repo=""
+if origin_url=$(git remote get-url origin 2>/dev/null); then
+  # Normalize both forms to owner/name:
+  #   git@github.com:owner/name.git    → owner/name
+  #   https://github.com/owner/name.git → owner/name
+  stripped="${origin_url%.git}"   # drop a trailing .git
+  path="${stripped#*://}"         # drop scheme:// if present (HTTPS)
+  path="${path#*@}"               # drop user@ if present (SSH)
+  path="${path#github.com:}"      # drop the SSH host + ':' separator
+  path="${path#github.com/}"      # drop the HTTPS host + '/' separator
+  repo="$path"
+fi
+
+# Locate the sidecar path: transcript with .jsonl → .dispatch-stamp.json.
+sidecar="${TRANSCRIPT_PATH%.jsonl}.dispatch-stamp.json"
+
+# Idempotency: preserve a non-null .pr already on disk (e.g. a prior backfill).
+pr=null
+if [[ -f "$sidecar" ]]; then
+  existing_pr=$(jq '.pr' "$sidecar" 2>/dev/null || echo null)
+  if [[ -n "$existing_pr" && "$existing_pr" != "null" ]]; then
+    pr="$existing_pr"
+  fi
+fi
+
+stamped_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Build atomically with jq -n so the JSON is always valid. Numerics
+# (schema/issue/pr) use --argjson; strings use --arg.
+if ! jq -n \
+  --argjson schema 1 \
+  --arg session_id "$SESSION_ID" \
+  --arg repo "$repo" \
+  --argjson issue "$issue" \
+  --argjson pr "$pr" \
+  --arg branch "$branch" \
+  --arg base_sha "$base_sha" \
+  --arg stamped_at "$stamped_at" \
+  '{schema:$schema, session_id:$session_id, repo:$repo, issue:$issue, pr:$pr, branch:$branch, base_sha:$base_sha, stamped_at:$stamped_at}' \
+  > "$sidecar.tmp" 2>/dev/null; then
+  echo "dispatch-stamp-session: failed to build sidecar JSON for '$sidecar'; skipping stamp" >&2
+  rm -f "$sidecar.tmp"
+  exit 0
+fi
+mv "$sidecar.tmp" "$sidecar"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -31511,6 +31511,110 @@ rm -rf "$TMPDIR_TEST"
 TMPDIR_TEST=""
 
 # ============================================================================
+# dispatch-stamp-session — per-session GitHub-artifact sidecar writer/backfill
+# ============================================================================
+# These cases call "$SCRIPT_DIR/dispatch-stamp-session" directly: it has no
+# sibling-script dependencies (git/jq/find/date only), so no setup() copy is
+# needed. Each case is a self-contained subshell over its own fake git repo /
+# fake projects root under a mktemp -d, cleaned at block end — env seams
+# (DISPATCH_STAMP_PROJECTS_ROOT, CLAUDE_CODE_SESSION_ID) are scoped per-subshell
+# so nothing leaks across tests and teardown() is untouched.
+echo ""
+echo "=== dispatch-stamp-session ==="
+
+STAMP="$SCRIPT_DIR/dispatch-stamp-session"
+
+# 1. Initial write on a worker branch derives repo/issue/branch/base_sha.
+(
+  d=$(mktemp -d)
+  git -C "$d" init -q
+  git -C "$d" remote add origin https://github.com/natb1/commons.systems.git
+  git -C "$d" checkout -q -b 999-fixture
+  git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  ( cd "$d" && "$STAMP" --session-id sess1 --transcript-path "$d/sess1.jsonl" )
+  sc="$d/sess1.dispatch-stamp.json"
+  assert_eq "stamp: sidecar written on worker branch" "yes" \
+    "$([ -f "$sc" ] && echo yes || echo no)"
+  assert_eq "stamp: .repo parsed from HTTPS origin" "natb1/commons.systems" "$(jq -r .repo "$sc")"
+  assert_eq "stamp: .issue is numeric branch prefix" "999" "$(jq -r .issue "$sc")"
+  assert_eq "stamp: .branch" "999-fixture" "$(jq -r .branch "$sc")"
+  assert_eq "stamp: .pr null on initial write" "null" "$(jq -r .pr "$sc")"
+  assert_eq "stamp: .base_sha equals HEAD" "$(git -C "$d" rev-parse HEAD)" "$(jq -r .base_sha "$sc")"
+  assert_eq "stamp: .session_id" "sess1" "$(jq -r .session_id "$sc")"
+  assert_eq "stamp: .schema is 1" "1" "$(jq -r .schema "$sc")"
+  rm -rf "$d"
+)
+
+# 2. No-op on main — no sidecar, exit 0.
+(
+  d=$(mktemp -d)
+  git -C "$d" init -q
+  git -C "$d" remote add origin https://github.com/natb1/commons.systems.git
+  git -C "$d" checkout -q -b main
+  git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  rc=0
+  ( cd "$d" && "$STAMP" --session-id s --transcript-path "$d/m.jsonl" ) 2>/dev/null || rc=$?
+  assert_eq "stamp: main exits 0" "0" "$rc"
+  assert_eq "stamp: main writes no sidecar" "no" \
+    "$([ -f "$d/m.dispatch-stamp.json" ] && echo yes || echo no)"
+  rm -rf "$d"
+)
+
+# 3. No-op on office-hours-5 — no sidecar, exit 0.
+(
+  d=$(mktemp -d)
+  git -C "$d" init -q
+  git -C "$d" remote add origin https://github.com/natb1/commons.systems.git
+  git -C "$d" checkout -q -b office-hours-5
+  git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  rc=0
+  ( cd "$d" && "$STAMP" --session-id s --transcript-path "$d/o.jsonl" ) 2>/dev/null || rc=$?
+  assert_eq "stamp: office-hours-5 exits 0" "0" "$rc"
+  assert_eq "stamp: office-hours-5 writes no sidecar" "no" \
+    "$([ -f "$d/o.dispatch-stamp.json" ] && echo yes || echo no)"
+  rm -rf "$d"
+)
+
+# 4. Backfill sets .pr and exits 0.
+(
+  root=$(mktemp -d)
+  mkdir -p "$root/somedir"
+  sc="$root/somedir/sess2.dispatch-stamp.json"
+  printf '%s\n' '{"schema":1,"session_id":"sess2","repo":"natb1/commons.systems","issue":5,"pr":null,"branch":"5-x","base_sha":"abc123","stamped_at":"2026-01-01T00:00:00Z"}' > "$sc"
+  rc=0
+  CLAUDE_CODE_SESSION_ID=sess2 DISPATCH_STAMP_PROJECTS_ROOT="$root" "$STAMP" --backfill-pr 4242 2>/dev/null || rc=$?
+  assert_eq "stamp: backfill exits 0" "0" "$rc"
+  assert_eq "stamp: backfill sets .pr" "4242" "$(jq -r .pr "$sc")"
+  rm -rf "$root"
+)
+
+# 5. Backfill no-ops + exits 0 when the sidecar is missing.
+(
+  root=$(mktemp -d)
+  rc=0
+  CLAUDE_CODE_SESSION_ID=nope DISPATCH_STAMP_PROJECTS_ROOT="$root" "$STAMP" --backfill-pr 7 2>/dev/null || rc=$?
+  assert_eq "stamp: backfill missing sidecar exits 0" "0" "$rc"
+  rm -rf "$root"
+)
+
+# 6. Idempotent re-write preserves a set .pr (does not clobber to null).
+(
+  d=$(mktemp -d)
+  git -C "$d" init -q
+  git -C "$d" remote add origin https://github.com/natb1/commons.systems.git
+  git -C "$d" checkout -q -b 999-fixture
+  git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  sc="$d/sess6.dispatch-stamp.json"
+  # Seed a sidecar that already carries a backfilled pr.
+  printf '%s\n' '{"schema":1,"session_id":"sess6","repo":"old/repo","issue":1,"pr":4242,"branch":"old","base_sha":"old","stamped_at":"2026-01-01T00:00:00Z"}' > "$sc"
+  ( cd "$d" && "$STAMP" --session-id sess6 --transcript-path "$d/sess6.jsonl" )
+  assert_eq "stamp: re-write preserves set .pr" "4242" "$(jq -r .pr "$sc")"
+  assert_eq "stamp: re-write re-derives .branch" "999-fixture" "$(jq -r .branch "$sc")"
+  assert_eq "stamp: re-write re-derives .base_sha" "$(git -C "$d" rev-parse HEAD)" "$(jq -r .base_sha "$sc")"
+  rm -rf "$d"
+)
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -31545,6 +31545,19 @@ STAMP="$SCRIPT_DIR/dispatch-stamp-session"
   rm -rf "$d"
 )
 
+# 1b. SSH origin URL normalizes to owner/name (git@github.com:owner/name.git).
+(
+  d=$(mktemp -d)
+  git -C "$d" init -q
+  git -C "$d" remote add origin git@github.com:natb1/commons.systems.git
+  git -C "$d" checkout -q -b 999-fixture
+  git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  ( cd "$d" && "$STAMP" --session-id sessSSH --transcript-path "$d/sessSSH.jsonl" )
+  sc="$d/sessSSH.dispatch-stamp.json"
+  assert_eq "stamp: .repo parsed from SSH origin" "natb1/commons.systems" "$(jq -r .repo "$sc")"
+  rm -rf "$d"
+)
+
 # 2. No-op on main — no sidecar, exit 0.
 (
   d=$(mktemp -d)

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -31615,6 +31615,88 @@ STAMP="$SCRIPT_DIR/dispatch-stamp-session"
 )
 
 # ============================================================================
+# dispatch-open-pr — PR backfill into the per-session sidecar (#1861)
+# ============================================================================
+# dispatch-open-pr resolves its sibling dispatch-stamp-session via its own
+# SCRIPT_DIR. Running the REAL "$SCRIPT_DIR/dispatch-open-pr" (not a copy) means
+# that sibling resolves to the real script, so the backfill actually runs. Each
+# case is a self-contained subshell that (a) puts a gh stub first on PATH and
+# (b) sets CLAUDE_CODE_SESSION_ID + DISPATCH_STAMP_PROJECTS_ROOT so the backfill
+# targets a seeded fake sidecar. The backfill needs only find/jq (no git), so no
+# fake git repo is required. Env exports are scoped per-subshell — teardown()
+# untouched. The gh stub keeps the two numbers DISTINCT: `pr create` returns a
+# URL whose basename is 4242 (the PR number), while `pr view` prints 1861 (the
+# primary issue), so the exact-match branch fires on pass 1 (no `pr edit`) and a
+# sidecar `.pr == 4242` proves the backfill wrote the PR number, not the issue.
+echo ""
+echo "=== dispatch-open-pr backfill (#1861) ==="
+
+OPENPR="$SCRIPT_DIR/dispatch-open-pr"
+
+open_pr_backfill_gh_stub() {
+  # $1 = bin dir to write the stub into.
+  cat > "$1/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "pr create")
+    # Basename of the URL is the PR number.
+    echo "https://github.com/natb1/commons.systems/pull/4242"
+    ;;
+  "pr view")
+    # The intended close set is the primary issue 1861 only — print it so the
+    # exact-match branch in dispatch-open-pr fires immediately.
+    echo "1861"
+    ;;
+  *)
+    echo "gh stub: unknown invocation: $*" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$1/gh"
+}
+
+# 1. Backfill on PR open: the seeded sidecar's .pr is set to the PR number, and
+#    stdout is the BARE PR number only.
+(
+  bin=$(mktemp -d)
+  root=$(mktemp -d)
+  open_pr_backfill_gh_stub "$bin"
+  mkdir -p "$root/projdir"
+  sc="$root/projdir/sessP.dispatch-stamp.json"
+  printf '%s\n' '{"schema":1,"session_id":"sessP","repo":"natb1/commons.systems","issue":1861,"pr":null,"branch":"1861-x","base_sha":"abc123","stamped_at":"2026-01-01T00:00:00Z"}' > "$sc"
+  body=$(mktemp)
+  echo "Body prose." > "$body"
+  export PATH="$bin:$PATH"
+  export CLAUDE_CODE_SESSION_ID=sessP
+  export DISPATCH_STAMP_PROJECTS_ROOT="$root"
+  rc=0
+  out=$("$OPENPR" 1861 --title "t" --body-file "$body" 2>/dev/null) || rc=$?
+  assert_eq "open-pr backfill: rc 0" "0" "$rc"
+  assert_eq "open-pr backfill: stdout is bare PR number only" "4242" "$out"
+  assert_eq "open-pr backfill: sidecar .pr set to PR number" "4242" "$(jq -r .pr "$sc")"
+  rm -rf "$bin" "$root" "$body"
+)
+
+# 2. Missing-sidecar run is non-fatal: PR creation is unaffected by the backfill
+#    miss — still rc 0 and the bare PR number on stdout.
+(
+  bin=$(mktemp -d)
+  root=$(mktemp -d)
+  open_pr_backfill_gh_stub "$bin"
+  body=$(mktemp)
+  echo "Body prose." > "$body"
+  export PATH="$bin:$PATH"
+  export CLAUDE_CODE_SESSION_ID=no-such-session
+  export DISPATCH_STAMP_PROJECTS_ROOT="$root"
+  rc=0
+  out=$("$OPENPR" 1861 --title "t" --body-file "$body" 2>/dev/null) || rc=$?
+  assert_eq "open-pr backfill: missing sidecar → rc 0" "0" "$rc"
+  assert_eq "open-pr backfill: missing sidecar → bare PR number on stdout" "4242" "$out"
+  rm -rf "$bin" "$root" "$body"
+)
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -56,7 +56,13 @@ This skill parses recent Claude session transcripts and emits a ranked report of
 
    # Top 10 costliest individual sessions
    jq '.sessions | sort_by(-.price_proxy_usd) | .[0:10] | map({id,type,model,peak_context,price_proxy_usd})' tmp/usage-audit.json
+
+   # Per-session GitHub artifact join record — repo/issue/pr/base_sha/branch the session
+   # acted on. null for sessions without a sidecar (subagents, router ticks, pre-#1861 sessions).
+   jq '.sessions | map({id, artifact}) | map(select(.artifact != null))' tmp/usage-audit.json
    ```
+
+   The join key is the session id: the sidecar `<id>.dispatch-stamp.json` sits next to `<id>.jsonl` in the transcripts directory, so `.sessions[].id` is the join key between audit findings and GitHub artifacts. Each `artifact` record carries `{repo, issue, pr, base_sha, branch}`. The sidecar is the authoritative source of the overlapping join keys (`repo/issue/pr/base_sha`); the sibling outcome envelope (the #1860 internal-yield record) carries only its own non-overlapping outcome fields (findings, disposition) — so there is exactly one join-key source.
 
 4. **Interpret and rank against all nine lenses.** Evaluate every lens. Map each to the script output it draws from:
 

--- a/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
@@ -253,6 +253,7 @@ def cmd_prefix(c):
 | {
     type: $type,
     id: $id,
+    artifact: ( ($stamp[0] // null) | if . == null then null else {repo, issue, pr, base_sha, branch} end ),
     file: $path,
     primary_model: $primary_model,
     models: $models,
@@ -428,6 +429,7 @@ def ngrams($L; $n):
 # ---- per-session summaries ----
 | ( [ $rows[] | {
         id: .id, file: .file, type: .type,
+        artifact: .artifact,
         model: .primary_model, models: .models,
         turns: .turns, peak_context: .peak_context,
         input: .usage.input, cache_creation: .usage.cache_creation,
@@ -516,7 +518,12 @@ if [[ -d "$PROJECTS_ROOT" ]]; then
   # Gather candidate project dirs (worktrees + bare), then find *.jsonl in window.
   while IFS= read -r -d '' file; do
     FILES_SCANNED=$((FILES_SCANNED + 1))
-    if jq -cs -f "$TMP/stage1.jq" "$file" >>"$STAGE1_OUT" 2>/dev/null; then
+    # Per-session sidecar (#1861): <stem>.dispatch-stamp.json next to the
+    # transcript. Most transcripts have none; --slurpfile needs a readable file,
+    # so absent sidecars point at /dev/null, which slurps to [].
+    stamp="${file%.jsonl}.dispatch-stamp.json"
+    [[ -f "$stamp" ]] || stamp=/dev/null
+    if jq -cs --slurpfile stamp "$stamp" -f "$TMP/stage1.jq" "$file" >>"$STAGE1_OUT" 2>/dev/null; then
       :
     else
       FILES_FAILED=$((FILES_FAILED + 1))

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -91,6 +91,14 @@ setup() {
   # Verify fixture line is valid JSON
   jq . "$worker_jsonl" >/dev/null
 
+  # 1b. Per-session sidecar (#1861) next to the worker transcript. Found by
+  #     deriving its path from the in-window .jsonl stem, so its own mtime is
+  #     irrelevant. The aggregator projects {repo,issue,pr,base_sha,branch}.
+  local worker_stamp="$worktree_dir/sess-worker.dispatch-stamp.json"
+  printf '%s\n' '{"schema":1,"session_id":"sess-worker","repo":"natb1/commons.systems","issue":999,"pr":1234,"branch":"999-fixture","base_sha":"deadbeef","stamped_at":"2026-01-01T00:00:00Z"}' \
+    >> "$worker_stamp"
+  jq . "$worker_stamp" >/dev/null
+
   # 2. Subagent transcript:
   #    $ROOT/-home-x-worktrees-999-fixture/sess-worker/subagents/agent-aaa.jsonl
   local subagent_dir="$worktree_dir/sess-worker/subagents"
@@ -191,6 +199,18 @@ assert_eq 'by_session_type["router-tick"].sessions' "1" \
 
 assert_eq 'by_phase["plan-implement"].output' "550" \
   "$(jq '.by_phase["plan-implement"].output' <<<"$OUT")"
+
+# artifact join (#1861): the worker session's sidecar surfaces as
+# .sessions[].artifact = {repo,issue,pr,base_sha,branch}; sessions with no
+# sidecar (the router) carry artifact == null.
+assert_eq "sessions sess-worker artifact.pr" "1234" \
+  "$(jq '.sessions[] | select(.id=="sess-worker") | .artifact.pr' <<<"$OUT")"
+assert_eq "sessions sess-worker artifact.repo" "natb1/commons.systems" \
+  "$(jq -r '.sessions[] | select(.id=="sess-worker") | .artifact.repo' <<<"$OUT")"
+assert_eq "sessions sess-worker artifact.issue" "999" \
+  "$(jq '.sessions[] | select(.id=="sess-worker") | .artifact.issue' <<<"$OUT")"
+assert_eq "sessions sess-router artifact null" "null" \
+  "$(jq '.sessions[] | select(.id=="sess-router") | .artifact' <<<"$OUT")"
 
 assert_eq 'tool_errors: "Exit code N" count' "1" \
   "$(jq '[.tool_errors[] | select(.signature=="Exit code N")] | length' <<<"$OUT")"

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -71,6 +71,15 @@ If the output shows `PR: none`, stop with a clear error — qa-fix requires an
 open PR and should not have been dispatched here. If it shows `PR #<num>`, that
 is `PR_NUM`.
 
+Once `PR_NUM` is confirmed, stamp it into this session's dispatch sidecar so the
+token audit can join the session to its PR (#1861). Its failure is non-fatal —
+the script exits 0 on any miss. Use `dangerouslyDisableSandbox: true` (the
+sidecar lives under `~/.claude/projects`, outside the sandbox write-allowlist):
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-stamp-session --backfill-pr "$PR_NUM"
+```
+
 From the **same** labels line, read the current qa-fix attempt count
 `ATTEMPT_N` — the highest `dispatch:qa-fix-attempt-<n>` label, defaulting to `0`
 when none is present (the same `max // 0` capture idiom as

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -75,6 +75,16 @@ output — do not re-resolve any of them later:
 - The **changed-file list** — extracted by `dispatch-changed-files` from the
   `=== DIFF ===` section (same list Step 1 reads via the script).
 
+Once `PR_NUM` is confirmed present, stamp it into this session's dispatch
+sidecar so the token audit can join the session to its PR (#1861). Its failure
+is non-fatal — the script exits 0 on any miss. Use `dangerouslyDisableSandbox:
+true` (the sidecar lives under `~/.claude/projects`, outside the sandbox
+write-allowlist):
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-stamp-session --backfill-pr "$PR_NUM"
+```
+
 If the labels line already includes `dispatch:reviewed` — an interrupted prior
 run — **skip Steps 1–6** and go straight to Step 7, which flushes any unpushed
 commits and writes the marker. `dispatch:reviewed` is this skill's terminal


### PR DESCRIPTION
## What

Stamp the GitHub artifact each dispatch worker session acts on
(`repo/issue/pr/branch/base_sha`) into a per-session JSON sidecar, and surface it
in the token audit as a per-session `artifact` join record. This lets
`dispatch-token-audit` join a session to its real-world GitHub outcome — the
precondition for measuring efficacy against ground truth (the highest-ceiling
item of the runtime-efficacy-instrumentation epic #1858).

## Mechanism

A per-session sidecar written by trusted scripts, next to the transcript:
`<projectdir>/<session-id>.dispatch-stamp.json` holding
`{schema, session_id, repo, issue, pr, branch, base_sha, stamped_at}`.

- A `SessionStart` hook writes it at session birth from **local git only** (no
  network); `pr` starts `null`.
- `pr` is backfilled with the PR number when the PR opens (implement, via
  `dispatch-open-pr`) or read at session start (review-fix / qa-fix, which run on
  an already-open PR). plan-issue has no PR, so its sidecar `pr` stays `null`.
- The audit reads the sidecar by transcript-stem join: the sidecar
  `<id>.dispatch-stamp.json` sits next to `<id>.jsonl`, so `.sessions[].id` is the
  join key.

This was chosen over emitting the record into the transcript as a fenced JSON
block. A join key to GitHub ground truth must not come from spoofable transcript
content (the audit treats all transcript content as opaque, attacker-influenceable
data); a sidecar written only by the hook and `dispatch-open-pr` is authoritative.
Both the initial write (a hook) and the backfill (a scripted `jq` update) are
model-independent — the same scripted-durable-write precedent as
`dispatch-mark-complete` / #824.

## Units

1. `dispatch-stamp-session` writer/backfill script (git-only initial write,
   worker-branch-gated, idempotent, PR backfill that never fails its caller) +
   unit tests.
2. `SessionStart` hook (`stamp-dispatch-session.sh`) + `settings.json` wiring
   (`startup|resume` matcher). The hook reads `transcript_path` directly from
   SessionStart stdin (a documented common-input field), so no cwd-mangle fallback
   is needed. **To confirm on the next live worker run** (CI does not exercise the
   harness's SessionStart behavior): that `SessionStart:startup` actually fires for
   a detached `--bg` worker — the docs imply but do not explicitly state it. If it
   doesn't fire, the hook never runs, every sidecar is absent, and the audit reads
   `artifact: null` everywhere. QA check: the sidecar should exist at session start
   with `pr: null`, then carry the real PR number after `dispatch-open-pr`. The
   plan's documented fallback if startup proves unreliable is a scripted
   `dispatch-stamp-session` call at each phase skill's boundary.
3. PR backfill wiring: folded into `dispatch-open-pr` before it echoes the bare PR
   number (stdout contract preserved), plus one-line backfill calls in the
   review-fix / qa-fix preambles. The standalone preamble calls carry a
   `dangerouslyDisableSandbox` note since the sidecar under `~/.claude/projects` is
   outside the sandbox write-allowlist.
4. Audit reader: `aggregate-usage.sh` slurps each transcript's sidecar (absent →
   `[]`), `stage1.jq` emits `artifact: {repo,issue,pr,base_sha,branch}`,
   `stage2.jq` carries it into the per-session summaries. Sidecar-less sessions
   (subagents, router ticks) yield `artifact: null`.
5. `dispatch-token-audit/SKILL.md` documents the join (slice example + prose).

## Coordination with sibling #1860 (this PR ships first and sets the precedent)

The sidecar is the authoritative source for the overlapping join keys
(`repo/issue/pr/base_sha`). #1860's end-of-run outcome envelope — the model's
outcome self-report (findings/fixes/disposition) — should carry only its
non-overlapping outcome fields, not a second copy of the join keys. The audit
grows exactly one sidecar join-key reader here; #1860 adds its own reader for
genuinely different data. This precedent is documented in the audit SKILL.md.

## Tests

- `test-dispatch-scripts.sh` — covers Unit 1 (initial-write fields, branch no-op,
  backfill set/no-op, idempotent `pr` preserve) and Unit 3 (`dispatch-open-pr`
  backfills the sidecar while keeping stdout the bare PR number; missing-sidecar
  run is non-fatal).
- `test-aggregate-usage.sh` — the fixture's sidecar surfaces as `artifact` with the
  backfilled `pr/repo/issue`; a sidecar-less session yields `artifact: null`.
