### PR TITLE
dispatch: phases emit a machine-readable per-run outcome envelope

### DIFF
--- a/.claude/docs/outcome-envelope.md
+++ b/.claude/docs/outcome-envelope.md
@@ -1,0 +1,199 @@
+# Dispatch Outcome Envelope
+
+The outcome envelope is a machine-readable summary that a dispatch phase emits
+once per run. It records what the phase surfaced, fixed, and decided, so a reader
+can compute per-run hit rates without re-parsing the phase's prose or PR comments.
+
+This doc is the single source of truth for the envelope. The emit script, the
+phase Workflow returns, the SKILL wiring, and the `aggregate-usage.sh` reader are
+all written against the field set, enums, and formulas defined here. Do not change
+them in one place without changing this doc.
+
+## Carrier shape
+
+The envelope is a stable marker line immediately followed by a fenced `json`
+block:
+
+````
+<!-- dispatch:outcome:v1 -->
+```json
+{ "schema": "dispatch.outcome.v1", "phase": "review", ... }
+```
+````
+
+The reader greps for the literal marker line:
+
+```
+<!-- dispatch:outcome:v1 -->
+```
+
+and parses the JSON object in the fenced block that immediately follows it. This
+mirrors the existing `<!-- dispatch:plan -->` HTML-comment carrier convention used
+elsewhere in dispatch (see `dispatch-read-plan` / `dispatch-write-plan`).
+
+## Fields
+
+The envelope object contains exactly these fields. Counts are computed by the
+phase Workflow and passed to the emit script; the reader derives rates from them
+(see [Hit-rate formulas](#hit-rate-formulas)) — the rates are not stored in the
+envelope.
+
+| Field | Type | Nullable | Notes |
+|---|---|---|---|
+| `schema` | string | no | const `"dispatch.outcome.v1"` |
+| `phase` | string | no | enum `{review, qa}`, extensible to future phases |
+| `repo` | string | no | e.g. `natb1/commons.systems` |
+| `issue` | integer | no | the dispatch issue number |
+| `pr` | integer | yes | the PR number, or `null` when no PR exists yet |
+| `base_sha` | string | yes | the merge base the phase ran against, or `null` |
+| `findings_surfaced` | integer ≥ 0 | no | total deduped findings the phase surfaced |
+| `findings_actionable` | integer ≥ 0 | no | the actionable subset (see membership below) |
+| `fixes_applied` | integer ≥ 0 | no | findings the phase actually fixed |
+| `followups_filed` | integer ≥ 0 | no | follow-up issues the phase filed |
+| `subagents_launched` | integer ≥ 0 | no | total subagents spawned (see semantics below) |
+| `disposition` | string | no | enum `{completed, completed_with_fixes, escalated}` |
+| `terminated_reason` | string | yes | escalation reason on `escalated`, else `null` |
+
+## `disposition` enum
+
+A closed set of three values, consistent across phases:
+
+- `completed` — the phase finished its work and applied no fixes.
+- `completed_with_fixes` — the phase finished and applied one or more fixes.
+- `escalated` — the phase stopped for user review (a deviation/escalation).
+
+Path → value mapping:
+
+| Phase | Terminal path | `disposition` |
+|---|---|---|
+| review-fix | normal complete, no fixes (`fixed.length === 0`) | `completed` |
+| review-fix | normal complete, fixes applied (`fixed.length > 0`) | `completed_with_fixes` |
+| review-fix | deviation | `escalated` |
+| qa-fix | clean pass | `completed` |
+| qa-fix | auto-fix applied | `completed_with_fixes` |
+| qa-fix | escalate | `escalated` |
+
+## `terminated_reason`
+
+On an `escalated` path, `terminated_reason` is the escalation/deviation reason
+string — the same text passed to `dispatch-mark-deviation`. On every non-escalated
+path it is `null`.
+
+## `findings_actionable` membership
+
+"Actionable" means the finding warranted action this run (it was fixed, was
+required, or was deferred to a follow-up) — as opposed to findings the phase
+surfaced but dismissed, refuted, or judged out of scope.
+
+### review-fix
+
+`findings_actionable` counts dispositions whose `bucket` is one of:
+
+- `Fixed`
+- `Required`
+- `Deferred`
+
+The following buckets are explicitly **excluded** from `findings_actionable`:
+
+- `Refuted`
+- `Unverified`
+- `Informational`
+- `Dismissed`
+- `False-positive`
+- `Out-of-scope`
+
+`findings_surfaced` counts all deduped findings (every disposition entry,
+regardless of bucket). `fixes_applied` is `fixed.length` — the size of the
+separate `fixed` array, which equals the count of `Fixed`-bucket dispositions.
+
+### qa-fix
+
+`findings_actionable` counts all items in `result.dispositions` — every triaged
+QA residue item, across the classes `opus-fixable`, `needs-main`, and
+`needs-human`. Items in `already_satisfied` are **non-actionable** and are not
+counted in `findings_actionable` (they are also not counted in
+`findings_surfaced`; surfaced counts the triaged residue).
+
+`fixes_applied` is the count of items the auto-fix lane actually fixed
+(`opus-fixable` items resolved this run).
+
+## Hit-rate formulas
+
+The reader computes these from the stored counts. Each rate is `null` when its
+denominator is zero (never emit a divide-by-zero or a fabricated `0`):
+
+- `hit_rate = fixes_applied / findings_surfaced` — `null` when `findings_surfaced == 0`.
+- `actionability = findings_actionable / findings_surfaced` — `null` when `findings_surfaced == 0`. The share of surfaced findings that were actionable.
+- `fix_rate = fixes_applied / findings_actionable` — `null` when `findings_actionable == 0`. The share of actionable findings that were fixed.
+
+`hit_rate` factors as `actionability × fix_rate` when both denominators are
+non-zero.
+
+## `subagents_launched` semantics
+
+`subagents_launched` is the **sum** of two sources:
+
+1. The phase Workflow's own fan-out count. For review-fix this includes the
+   internal finder, skeptic, and fixer fan-out the Workflow spawns. For qa-fix it
+   includes the Workflow's triage and verification fan-out.
+2. SKILL-body subagents spawned outside the Workflow. For review-fix these are the
+   Step 5a deferred-filing and Step 5b security-follow-up `/file-issue`
+   subagents.
+
+Unit 3 (the Workflow returns) computes source 1; the SKILL wiring (Unit 4) adds
+source 2 before calling the emit script. The emitted value is the total.
+
+## Reader contract
+
+- The envelope block lands in a `tool_result` — the stdout of a Bash tool call —
+  in the worker session's transcript `.jsonl`. The reader scans transcripts for
+  the marker line.
+- **Last-wins** precedence: if multiple envelope blocks appear in one transcript,
+  the reader uses the last one.
+- Only top-level worker sessions emit. The reader excludes subagent transcripts,
+  so a subagent that happens to print the marker does not produce a stray
+  envelope.
+
+## Adoption recipe for a new phase
+
+To make a future phase emit the envelope:
+
+1. Extend the phase's Workflow return with the computed fields:
+   `findings_surfaced`, `findings_actionable`, `fixes_applied`,
+   `followups_filed`, and the Workflow's own `subagents_launched` count, plus the
+   `disposition` and `terminated_reason` for each terminal path.
+2. Call `dispatch-emit-outcome` at **every** terminal path of the phase
+   (complete, complete-with-fixes, and escalate), passing the computed fields and
+   adding any SKILL-body subagent count to `subagents_launched`.
+3. Use the `disposition` enum and the actionability/hit-rate definitions in this
+   doc. Add the new `phase` value to the enum here when you do.
+
+## Worked example
+
+A review-fix run that surfaced 8 findings, found 5 actionable, fixed 3, filed 2
+follow-ups, and spawned 11 subagents — a `completed_with_fixes` outcome:
+
+````
+<!-- dispatch:outcome:v1 -->
+```json
+{
+  "schema": "dispatch.outcome.v1",
+  "phase": "review",
+  "repo": "natb1/commons.systems",
+  "issue": 1860,
+  "pr": 1871,
+  "base_sha": "0a454453c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6",
+  "findings_surfaced": 8,
+  "findings_actionable": 5,
+  "fixes_applied": 3,
+  "followups_filed": 2,
+  "subagents_launched": 11,
+  "disposition": "completed_with_fixes",
+  "terminated_reason": null
+}
+```
+````
+
+For these counts the reader computes `hit_rate = 3/8 = 0.375`,
+`actionability = 5/8 = 0.625`, and `fix_rate = 3/5 = 0.6` (and
+`0.625 × 0.6 = 0.375`, matching `hit_rate`).

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# dispatch-emit-outcome — emit a machine-readable per-run outcome envelope.
+#
+# Usage: dispatch-emit-outcome \
+#          --phase <phase> \
+#          --repo <owner/repo> \
+#          --issue <issue-num> \
+#          [--pr <pr-num>] \
+#          [--base-sha <sha>] \
+#          --findings-surfaced <n> \
+#          --findings-actionable <n> \
+#          --fixes-applied <n> \
+#          --followups-filed <n> \
+#          --subagents-launched <n> \
+#          --disposition <disposition> \
+#          [--terminated-reason <reason>]
+#
+# Prints the canonical outcome envelope block — a marker line followed by a
+# fenced JSON block — to stdout. The block lands in the worker session's
+# transcript so the reader (aggregate-usage.sh) can locate and parse it.
+#
+# The envelope contract is defined in .claude/docs/outcome-envelope.md.
+# That doc is the single source of truth for fields, enums, and formulas.
+#
+# --phase: one of the ALLOWED_PHASES set (review, qa). Extensible: update
+#   ALLOWED_PHASES below to add future phases.
+# --disposition: one of the ALLOWED_DISPOSITIONS set
+#   (completed, completed_with_fixes, escalated).
+# --terminated-reason: required-non-null when disposition == escalated;
+#   must be absent (or not provided) for any other disposition.
+# --pr, --base-sha: optional; serialize as JSON null when absent.
+#
+# DIVERGENCE FROM dispatch-mark-complete:
+#   dispatch-mark-complete no-ops when CLAUDE_JOB_DIR is unset/empty, so
+#   that the same call is harmless in an interactive run without writing
+#   marker files. This script does NOT guard on CLAUDE_JOB_DIR. It prints
+#   unconditionally so the envelope always lands in the transcript, including
+#   on escalation/deviation paths where no phase-completed marker is written.
+#   Callers must not gate this call on CLAUDE_JOB_DIR themselves.
+#
+# Validation errors exit 2 with a descriptive message to stderr.
+# An unknown flag exits 2.
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Allowed enum values — edit these to extend the enum sets.
+# ---------------------------------------------------------------------------
+ALLOWED_PHASES="review qa"
+ALLOWED_DISPOSITIONS="completed completed_with_fixes escalated"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+PHASE=""
+REPO=""
+ISSUE=""
+PR=""
+BASE_SHA=""
+FINDINGS_SURFACED=""
+FINDINGS_ACTIONABLE=""
+FIXES_APPLIED=""
+FOLLOWUPS_FILED=""
+SUBAGENTS_LAUNCHED=""
+DISPOSITION=""
+TERMINATED_REASON=""
+
+usage() {
+  cat >&2 <<'EOF'
+usage: dispatch-emit-outcome \
+         --phase <phase> \
+         --repo <owner/repo> \
+         --issue <issue-num> \
+         [--pr <pr-num>] \
+         [--base-sha <sha>] \
+         --findings-surfaced <n> \
+         --findings-actionable <n> \
+         --fixes-applied <n> \
+         --followups-filed <n> \
+         --subagents-launched <n> \
+         --disposition <disposition> \
+         [--terminated-reason <reason>]
+
+  --phase        one of: review qa
+  --disposition  one of: completed completed_with_fixes escalated
+  --terminated-reason  required when disposition=escalated, forbidden otherwise
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --phase)
+      [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --phase requires a value" >&2; exit 2; }
+      PHASE="$2"; shift 2 ;;
+    --repo)
+      [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --repo requires a value" >&2; exit 2; }
+      REPO="$2"; shift 2 ;;
+    --issue)
+      [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --issue requires a value" >&2; exit 2; }
+      ISSUE="$2"; shift 2 ;;
+    --pr)
+      [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --pr requires a value" >&2; exit 2; }
+      PR="$2"; shift 2 ;;
+    --base-sha)
+      [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --base-sha requires a value" >&2; exit 2; }
+      BASE_SHA="$2"; shift 2 ;;
+    --findings-surfaced)
+      [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --findings-surfaced requires a value" >&2; exit 2; }
+      FINDINGS_SURFACED="$2"; shift 2 ;;
+    --findings-actionable)
+      [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --findings-actionable requires a value" >&2; exit 2; }
+      FINDINGS_ACTIONABLE="$2"; shift 2 ;;
+    --fixes-applied)
+      [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --fixes-applied requires a value" >&2; exit 2; }
+      FIXES_APPLIED="$2"; shift 2 ;;
+    --followups-filed)
+      [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --followups-filed requires a value" >&2; exit 2; }
+      FOLLOWUPS_FILED="$2"; shift 2 ;;
+    --subagents-launched)
+      [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --subagents-launched requires a value" >&2; exit 2; }
+      SUBAGENTS_LAUNCHED="$2"; shift 2 ;;
+    --disposition)
+      [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --disposition requires a value" >&2; exit 2; }
+      DISPOSITION="$2"; shift 2 ;;
+    --terminated-reason)
+      [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --terminated-reason requires a value" >&2; exit 2; }
+      TERMINATED_REASON="$2"; shift 2 ;;
+    *)
+      echo "dispatch-emit-outcome: unexpected argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Required-field checks
+# ---------------------------------------------------------------------------
+_require() {
+  local flag="$1" val="$2"
+  if [[ -z "$val" ]]; then
+    echo "dispatch-emit-outcome: --${flag} is required" >&2
+    exit 2
+  fi
+}
+
+_require phase          "$PHASE"
+_require repo           "$REPO"
+_require issue          "$ISSUE"
+_require findings-surfaced   "$FINDINGS_SURFACED"
+_require findings-actionable "$FINDINGS_ACTIONABLE"
+_require fixes-applied       "$FIXES_APPLIED"
+_require followups-filed     "$FOLLOWUPS_FILED"
+_require subagents-launched  "$SUBAGENTS_LAUNCHED"
+_require disposition    "$DISPOSITION"
+
+# ---------------------------------------------------------------------------
+# Enum validation
+# ---------------------------------------------------------------------------
+_in_set() {
+  local val="$1" set="$2"
+  local item
+  for item in $set; do
+    [[ "$item" == "$val" ]] && return 0
+  done
+  return 1
+}
+
+if ! _in_set "$PHASE" "$ALLOWED_PHASES"; then
+  echo "dispatch-emit-outcome: unknown phase: $PHASE (expected one of: $ALLOWED_PHASES)" >&2
+  exit 2
+fi
+
+if ! _in_set "$DISPOSITION" "$ALLOWED_DISPOSITIONS"; then
+  echo "dispatch-emit-outcome: unknown disposition: $DISPOSITION (expected one of: $ALLOWED_DISPOSITIONS)" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Integer validation (non-negative integers only)
+# ---------------------------------------------------------------------------
+_require_nonneg_int() {
+  local flag="$1" val="$2"
+  if [[ ! "$val" =~ ^[0-9]+$ ]]; then
+    echo "dispatch-emit-outcome: --${flag} must be a non-negative integer, got: $val" >&2
+    exit 2
+  fi
+}
+
+_require_nonneg_int issue               "$ISSUE"
+_require_nonneg_int findings-surfaced   "$FINDINGS_SURFACED"
+_require_nonneg_int findings-actionable "$FINDINGS_ACTIONABLE"
+_require_nonneg_int fixes-applied       "$FIXES_APPLIED"
+_require_nonneg_int followups-filed     "$FOLLOWUPS_FILED"
+_require_nonneg_int subagents-launched  "$SUBAGENTS_LAUNCHED"
+
+if [[ -n "$PR" ]]; then
+  _require_nonneg_int pr "$PR"
+fi
+
+# ---------------------------------------------------------------------------
+# terminated_reason cross-validation
+# ---------------------------------------------------------------------------
+if [[ "$DISPOSITION" == "escalated" && -z "$TERMINATED_REASON" ]]; then
+  echo "dispatch-emit-outcome: --terminated-reason is required when --disposition is escalated" >&2
+  exit 2
+fi
+
+if [[ "$DISPOSITION" != "escalated" && -n "$TERMINATED_REASON" ]]; then
+  echo "dispatch-emit-outcome: --terminated-reason must not be provided when --disposition is $DISPOSITION (only valid for escalated)" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Build jq argument arrays for nullable fields.
+# Integers use --argjson; strings use --arg.
+# Absent nullable fields bind to JSON null via --argjson.
+# ---------------------------------------------------------------------------
+
+if [[ -n "$PR" ]]; then
+  pr_arg=(--argjson pr "$PR")
+else
+  pr_arg=(--argjson pr "null")
+fi
+
+if [[ -n "$BASE_SHA" ]]; then
+  base_sha_arg=(--arg base_sha "$BASE_SHA")
+else
+  base_sha_arg=(--argjson base_sha "null")
+fi
+
+if [[ -n "$TERMINATED_REASON" ]]; then
+  terminated_reason_arg=(--arg terminated_reason "$TERMINATED_REASON")
+else
+  terminated_reason_arg=(--argjson terminated_reason "null")
+fi
+
+# ---------------------------------------------------------------------------
+# Emit the envelope block.
+# Field order matches the doc's field table exactly.
+# jq preserves literal insertion order (no -S).
+# ---------------------------------------------------------------------------
+printf '<!-- dispatch:outcome:v1 -->\n'
+printf '```json\n'
+jq -n \
+  --arg     schema              "dispatch.outcome.v1" \
+  --arg     phase               "$PHASE" \
+  --arg     repo                "$REPO" \
+  --argjson issue               "$ISSUE" \
+  "${pr_arg[@]}" \
+  "${base_sha_arg[@]}" \
+  --argjson findings_surfaced   "$FINDINGS_SURFACED" \
+  --argjson findings_actionable "$FINDINGS_ACTIONABLE" \
+  --argjson fixes_applied       "$FIXES_APPLIED" \
+  --argjson followups_filed     "$FOLLOWUPS_FILED" \
+  --argjson subagents_launched  "$SUBAGENTS_LAUNCHED" \
+  --arg     disposition         "$DISPOSITION" \
+  "${terminated_reason_arg[@]}" \
+  '{
+    schema:               $schema,
+    phase:                $phase,
+    repo:                 $repo,
+    issue:                $issue,
+    pr:                   $pr,
+    base_sha:             $base_sha,
+    findings_surfaced:    $findings_surfaced,
+    findings_actionable:  $findings_actionable,
+    fixes_applied:        $fixes_applied,
+    followups_filed:      $followups_filed,
+    subagents_launched:   $subagents_launched,
+    disposition:          $disposition,
+    terminated_reason:    $terminated_reason
+  }'
+printf '```\n'

--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -105,3 +105,40 @@ This skill parses recent Claude session transcripts and emits a ranked report of
    - **All nine lenses represented**: lenses with negligible measured impact appear at the bottom with their measured magnitude and a note that the data shows near-zero impact.
 
 7. **Report-only.** The skill does NOT create GitHub issues and does NOT modify the dispatch workflow. The user reads the report and decides what to file. This prevents the skill from racing or duplicating the optimization issues it surfaces (e.g. #1171, #1172).
+
+## Per-run outcome hit-rates
+
+Each dispatch phase (review-fix, qa-fix) now emits a machine-readable outcome envelope at the end of every run. Previously, measuring phase yield required LLM-classifying prose summaries — expensive, non-reproducible, and a `completed_with_fixes` disposition could lie when no diff materialized. The envelope makes hit-rate a deterministic aggregation: `aggregate-usage.sh` reads each session's last `<!-- dispatch:outcome:v1 -->` block and surfaces per-run data on `.sessions[]` and pooled data under `.by_phase_outcome`. Field definitions, enums, and formulas are in `.claude/docs/outcome-envelope.md` (the single source of truth).
+
+**`by_phase_outcome`** — pooled over non-subagent worker sessions that carry an envelope, keyed by `phase` enum (`"review"`, `"qa"`). Per phase:
+
+- Summed counts: `sessions`, `findings_surfaced`, `findings_actionable`, `fixes_applied`, `followups_filed`, `subagents_launched`
+- `disposition_distribution` — count of `completed` / `completed_with_fixes` / `escalated` outcomes
+- Pooled rates (each `null` when its denominator is 0): `hit_rate`, `actionability`, `fix_rate`
+
+**Per-run** — each `.sessions[]` entry carries `outcome` (the parsed envelope object, or `null`) and `outcome_rates` (`{hit_rate, actionability, fix_rate}`, or `null`).
+
+Formulas (from `.claude/docs/outcome-envelope.md`):
+- `hit_rate = fixes_applied / findings_surfaced`
+- `actionability = findings_actionable / findings_surfaced`
+- `fix_rate = fixes_applied / findings_actionable`
+
+Each rate is `null` when its denominator is 0.
+
+**jq slices against `tmp/usage-audit.json`:**
+
+```bash
+# Full by_phase_outcome table (pooled counts + rates per phase)
+jq '.by_phase_outcome' tmp/usage-audit.json
+
+# Pooled review hit-rate
+jq '.by_phase_outcome.review.hit_rate' tmp/usage-audit.json
+
+# QA disposition distribution
+jq '.by_phase_outcome.qa.disposition_distribution' tmp/usage-audit.json
+
+# Top 10 worker sessions by per-run hit_rate
+jq '[.sessions[] | select(.outcome_rates.hit_rate != null)] | sort_by(-.outcome_rates.hit_rate) | .[0:10] | map({id, hit_rate: .outcome_rates.hit_rate})' tmp/usage-audit.json
+```
+
+These slices are yield metrics, not cost metrics — they do not sort into the ranked token-reduction report. Read them alongside the report to correlate phase spend with phase effectiveness.

--- a/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
@@ -34,6 +34,17 @@
 #     defensive fallbacks).
 #   - Output schema is a documented contract later units depend on; keys are
 #     stable. See the stage-2 jq program below for the full shape.
+#   - Outcome envelope (#1860): each session's last `<!-- dispatch:outcome:v1 -->`
+#     envelope (last-wins; malformed -> null, never aborts the file) is surfaced
+#     on the per-session summary as `outcome` (the parsed object or null) plus
+#     `outcome_rates` ({hit_rate, actionability, fix_rate}, each null when its
+#     denominator is 0). The pooled `by_phase_outcome` aggregate is keyed by the
+#     envelope's `phase` enum (e.g. "review", "qa"), folds only non-subagent rows
+#     that carry an envelope (subagent emitters are excluded), and per phase sums
+#     the counts (findings_surfaced, findings_actionable, fixes_applied,
+#     followups_filed, subagents_launched, sessions), reports a
+#     disposition_distribution map, and the three pooled rates on the summed
+#     counts. See .claude/docs/outcome-envelope.md for field/enum/formula truth.
 #   - Prices are an Opus list-price-equivalent USD PROXY applied to every session
 #     regardless of its actual model — a relative-magnitude figure for ranking,
 #     NOT the actual bill.
@@ -220,6 +231,34 @@ def cmd_prefix(c):
       | err_signature(.content)
     ] ) as $errors
 
+# Outcome envelope (#1860). The phase emits a `<!-- dispatch:outcome:v1 -->`
+# marker followed by a fenced ```json block as a Bash tool_result. Scan every
+# user tool_result (NOT just is_error ones — envelopes are not errors), coerce
+# .content to a string, and capture the JSON between the json-fence and its
+# closing fence.
+#
+# The capture anchors on the full literal marker `<!-- dispatch:outcome:v1 -->`
+# per the reader contract in .claude/docs/outcome-envelope.md. The body is
+# non-greedy (`.*?`) so it stops at the FIRST closing fence — robust to `}`/`{`
+# inside string values and to multiple envelopes in one result. The "m" flag
+# makes "." cross newlines so a pretty-printed multi-line JSON object is
+# captured whole.
+#
+# LAST-WINS (reader contract): collect every envelope match across all
+# tool_results in document order and take the last. fromjson is wrapped in
+# try/catch so a malformed envelope binds null and NEVER aborts the file —
+# mirroring the clear-error/files_failed philosophy.
+| ( [ $msgs[]
+      | select(.type=="user")
+      | .message.content
+      | if type=="array" then .[]? else empty end
+      | select(type=="object" and .type=="tool_result")
+      | content_to_string(.content)
+      | match("<!-- dispatch:outcome:v1 -->\\s*```json\\s*(?<j>.*?)\\s*```"; "gm")
+      | .captures[0].string
+    ] | last // null ) as $outcome_raw
+| ( ($outcome_raw // "") | try fromjson catch null ) as $outcome
+
 # Ordered per-session token list of tool calls, in document order. Bash calls
 # become "Bash:<cmd_prefix>"; other tools become their name.
 | ( [ $msgs[] | select(.type=="assistant")
@@ -265,7 +304,8 @@ def cmd_prefix(c):
     by_skill_model: $by_skill_model,
     errors: $errors,
     tool_calls: $tool_calls,
-    payload: $payload
+    payload: $payload,
+    outcome: $outcome
   }
 STAGE1
 
@@ -309,6 +349,19 @@ def add_to_bucket(bucket; u; turns):
 # for lists shorter than n, yielding nothing — no explicit length guard needed.
 def ngrams($L; $n):
   [ range(0; ($L | length) - $n + 1) as $i | $L[$i:$i+$n] ];
+
+# Outcome-envelope rates (#1860). Each is null when its denominator is 0 — never
+# a divide-by-zero or a fabricated 0. Definitions are the single source of truth
+# in .claude/docs/outcome-envelope.md. The `num`/`den` are the already-summed
+# counts (per-run: one envelope's counts; pooled: sums across a phase's rows).
+def rate($num; $den): if ($den // 0) == 0 then null else ($num // 0) / $den end;
+# Build the three rates {hit_rate, actionability, fix_rate} from a counts object.
+def outcome_rates($o):
+  {
+    hit_rate:      rate($o.fixes_applied;       $o.findings_surfaced),
+    actionability: rate($o.findings_actionable; $o.findings_surfaced),
+    fix_rate:      rate($o.fixes_applied;       $o.findings_actionable)
+  };
 
 . as $rows
 
@@ -425,7 +478,42 @@ def ngrams($L; $n):
           | sort_by(-.bytes) | .[0:10] )
     } ) as $payload_bytes
 
+# ---- by_phase_outcome (pooled hit-rate per envelope phase, #1860) ----
+# Keyed by the envelope's own `.phase` enum value (e.g. "review", "qa") — NOT by
+# skill name like $by_phase. DOUBLE-COUNT GUARD: fold ONLY non-subagent rows that
+# carry an envelope. Per the doc, only top-level worker sessions emit; a subagent
+# transcript that happens to print the marker is excluded so it cannot inflate
+# the pool. Counts are SUMMED across a phase's rows, then the same null-guarded
+# formulas are applied to the pooled sums (pooled rate, not a mean of per-run
+# rates). disposition_distribution counts rows per disposition enum value.
+| ( reduce ( $rows[]
+             | select(.type != "subagent" and .outcome != null) ) as $r ({};
+      ($r.outcome.phase // "<unknown>") as $ph
+      | ($r.outcome) as $o
+      | .[$ph] as $cur
+      | .[$ph] = {
+          sessions:            ((($cur.sessions // 0)) + 1),
+          findings_surfaced:   (($cur.findings_surfaced   // 0) + ($o.findings_surfaced   // 0)),
+          findings_actionable: (($cur.findings_actionable // 0) + ($o.findings_actionable // 0)),
+          fixes_applied:       (($cur.fixes_applied       // 0) + ($o.fixes_applied       // 0)),
+          followups_filed:     (($cur.followups_filed     // 0) + ($o.followups_filed     // 0)),
+          subagents_launched:  (($cur.subagents_launched  // 0) + ($o.subagents_launched  // 0)),
+          disposition_distribution:
+            ( ($cur.disposition_distribution // {}) as $dd
+              | ($o.disposition // "<unknown>") as $d
+              | $dd | .[$d] = ((.[$d] // 0) + 1) )
+        }
+    )
+    # Attach the pooled null-guarded rates computed from the summed counts.
+    | reduce (to_entries[]) as $e (.;
+        .[$e.key] = ($e.value + outcome_rates($e.value))
+      )
+  ) as $by_phase_outcome
+
 # ---- per-session summaries ----
+# Per-run outcome (#1860): surface the parsed envelope and its three null-guarded
+# rates on each session. Sessions with no envelope carry outcome:null and null
+# rates — they never crash the formula (rate() guards a null/zero denominator).
 | ( [ $rows[] | {
         id: .id, file: .file, type: .type,
         model: .primary_model, models: .models,
@@ -433,7 +521,9 @@ def ngrams($L; $n):
         input: .usage.input, cache_creation: .usage.cache_creation,
         cache_read: .usage.cache_read, output: .usage.output,
         price_proxy_usd: price(.usage),
-        phases: ( reduce (.by_skill | to_entries[]) as $e ({}; .[$e.key] = price($e.value.usage)) )
+        phases: ( reduce (.by_skill | to_entries[]) as $e ({}; .[$e.key] = price($e.value.usage)) ),
+        outcome: .outcome,
+        outcome_rates: ( if .outcome == null then null else outcome_rates(.outcome) end )
       } ] ) as $sessions
 
 # ---- lenses ----
@@ -490,6 +580,7 @@ def ngrams($L; $n):
     totals: $totals,
     by_session_type: $by_session_type,
     by_phase: $by_phase,
+    by_phase_outcome: $by_phase_outcome,
     by_model: $by_model,
     by_phase_model: $by_phase_model,
     tool_errors: $tool_errors,

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -40,6 +40,18 @@ report_results() {
 
 # --- harness ----------------------------------------------------------------
 
+# Outcome-envelope fixture blocks (#1860). Authored as literal bytes so the
+# marker `<!-- dispatch:outcome:v1 -->` is byte-exact — the reader anchors on it.
+# envelope_block builds the marker + fenced JSON with real newlines; the line is
+# embedded into .jsonl via jq so .content is correctly escaped.
+WORKER_ENV_JSON='{"schema":"dispatch.outcome.v1","phase":"review","repo":"natb1/commons.systems","issue":999,"pr":1234,"base_sha":"abc123","findings_surfaced":8,"findings_actionable":5,"fixes_applied":3,"followups_filed":2,"subagents_launched":12,"disposition":"completed_with_fixes","terminated_reason":null}'
+ROUTER_ENV_JSON='{"schema":"dispatch.outcome.v1","phase":"qa","repo":"natb1/commons.systems","issue":999,"pr":1234,"base_sha":null,"findings_surfaced":0,"findings_actionable":0,"fixes_applied":0,"followups_filed":0,"subagents_launched":0,"disposition":"completed","terminated_reason":null}'
+SUBAGENT_ENV_JSON='{"schema":"dispatch.outcome.v1","phase":"review","repo":"natb1/commons.systems","issue":999,"pr":1234,"base_sha":"def456","findings_surfaced":1000,"findings_actionable":1000,"fixes_applied":1000,"followups_filed":1000,"subagents_launched":1000,"disposition":"escalated","terminated_reason":"subagent excluded"}'
+envelope_block() { printf '<!-- dispatch:outcome:v1 -->\n```json\n%s\n```' "$1"; }
+WORKER_BLOCK="$(envelope_block "$WORKER_ENV_JSON")"
+ROUTER_BLOCK="$(envelope_block "$ROUTER_ENV_JSON")"
+SUBAGENT_BLOCK="$(envelope_block "$SUBAGENT_ENV_JSON")"
+
 ROOT=""
 
 setup() {
@@ -88,6 +100,13 @@ setup() {
   printf '%s\n' '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_001","content":"PAYLOAD_0123456789"}]}}' \
     >> "$worker_jsonl"
 
+  # line 7: outcome-envelope tool_result (#1860). tool_use_id toolu_001 maps to a
+  # Bash tool_use, so its bytes land in the Bash payload bucket. Built with jq so
+  # the multi-line block is correctly JSON-escaped in .content.
+  jq -nc --arg c "$WORKER_BLOCK" \
+    '{type:"user",message:{content:[{type:"tool_result",tool_use_id:"toolu_001",content:$c}]}}' \
+    >> "$worker_jsonl"
+
   # Verify fixture line is valid JSON
   jq . "$worker_jsonl" >/dev/null
 
@@ -121,6 +140,13 @@ setup() {
   printf '%s\n' '{"type":"assistant","attributionSkill":"review-fix","isSidechain":true,"gitBranch":"999-fixture","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":130000,"output_tokens":0}}}' \
     >> "$subagent_b_jsonl"
 
+  # outcome-envelope on a SUBAGENT transcript (#1860), distinctive 1000 counts.
+  # The reader EXCLUDES subagent envelopes from by_phase_outcome; this proves it
+  # does not inflate the review pool. No tool_use_id -> "unknown" payload bucket.
+  jq -nc --arg c "$SUBAGENT_BLOCK" \
+    '{type:"user",message:{content:[{type:"tool_result",content:$c}]}}' \
+    >> "$subagent_b_jsonl"
+
   jq . "$subagent_b_jsonl" >/dev/null
 
   # 3. Bare router session:
@@ -137,6 +163,13 @@ setup() {
   # line 2: assistant — gitBranch HEAD -> router-tick, opus,
   # usage input=1, cc=2, cr=4, out=1
   printf '%s\n' '{"type":"assistant","gitBranch":"HEAD","message":{"model":"claude-opus-4-8","usage":{"input_tokens":1,"cache_creation_input_tokens":2,"cache_read_input_tokens":4,"output_tokens":1}}}' \
+    >> "$router_jsonl"
+
+  # outcome-envelope on the router-tick (non-subagent) session (#1860): a qa
+  # clean-pass with zero counts, exercising the null-guard (rates -> null) and a
+  # second phase bucket. No tool_use_id -> "unknown" payload bucket.
+  jq -nc --arg c "$ROUTER_BLOCK" \
+    '{type:"user",message:{content:[{type:"tool_result",content:$c}]}}' \
     >> "$router_jsonl"
 
   jq . "$router_jsonl" >/dev/null
@@ -214,18 +247,23 @@ assert_eq 'tool_sequences env-var prefix stripped to "Bash:npm run"' "1" \
 assert_eq 'tool_sequences: no n-gram token keeps an env-var assignment' "0" \
   "$(jq '[.tool_sequences.top[].sequence[] | select(test("="))] | length' <<<"$OUT")"
 
-# payload_bytes: Bash payload "PAYLOAD_0123456789" (18 bytes) + the no-id error
-# result "Exit code 1\nsome detail" parsed to 23 bytes (the \n becomes a real
-# newline) → total 41 bytes.
-PAYLOAD_TOTAL=$(jq -n '("PAYLOAD_0123456789"|utf8bytelength) + ("Exit code 1\nsome detail"|utf8bytelength)')
-PAYLOAD_BASH=$(jq -n '"PAYLOAD_0123456789"|utf8bytelength')
-PAYLOAD_UNKNOWN=$(jq -n '"Exit code 1\nsome detail"|utf8bytelength')
+# payload_bytes (#1860 recompute): base is Bash "PAYLOAD_0123456789" (18 bytes) +
+# the no-id error "Exit code 1\nsome detail" (23 bytes, \n -> real newline). The
+# worker now also carries a Bash-attributed envelope (WORKER_BLOCK), and the
+# router + subagent each carry an unknown-attributed envelope. Expected bytes are
+# computed from the same block strings so they track the fixture exactly.
+PAYLOAD_BASH=$(jq -n --arg e "$WORKER_BLOCK" \
+  '("PAYLOAD_0123456789"|utf8bytelength) + ($e|utf8bytelength)')
+PAYLOAD_UNKNOWN=$(jq -n --arg r "$ROUTER_BLOCK" --arg s "$SUBAGENT_BLOCK" \
+  '("Exit code 1\nsome detail"|utf8bytelength) + ($r|utf8bytelength) + ($s|utf8bytelength)')
+PAYLOAD_TOTAL=$(jq -n --arg e "$WORKER_BLOCK" --arg r "$ROUTER_BLOCK" --arg s "$SUBAGENT_BLOCK" \
+  '("PAYLOAD_0123456789"|utf8bytelength) + ("Exit code 1\nsome detail"|utf8bytelength) + ($e|utf8bytelength) + ($r|utf8bytelength) + ($s|utf8bytelength)')
 
 assert_eq "payload_bytes.total" "$PAYLOAD_TOTAL" \
   "$(jq '.payload_bytes.total' <<<"$OUT")"
 assert_eq "payload_bytes Bash bytes" "$PAYLOAD_BASH" \
   "$(jq '[.payload_bytes.by_tool[] | select(.tool=="Bash")][0].bytes' <<<"$OUT")"
-assert_eq "payload_bytes Bash results" "1" \
+assert_eq "payload_bytes Bash results" "2" \
   "$(jq '[.payload_bytes.by_tool[] | select(.tool=="Bash")][0].results' <<<"$OUT")"
 assert_eq "payload_bytes unknown bytes" "$PAYLOAD_UNKNOWN" \
   "$(jq '[.payload_bytes.by_tool[] | select(.tool=="unknown")][0].bytes' <<<"$OUT")"
@@ -254,6 +292,67 @@ assert_eq "lenses.baseline_context.median_boot_tokens" "16.5" \
   "$(jq '.lenses.baseline_context.median_boot_tokens' <<<"$OUT")"
 assert_eq "lenses.baseline_context.total_proxy_usd" "$EXPECTED_BASELINE_PROXY" \
   "$(jq '.lenses.baseline_context.total_proxy_usd' <<<"$OUT")"
+
+# --- outcome-envelope assertions (#1860) ------------------------------------
+# by_phase_outcome.review pools non-subagent sessions carrying a review envelope
+# = the worker only. The agent-bbb SUBAGENT review envelope (counts 1000) is
+# EXCLUDED, so the pooled counts equal the worker envelope's.
+assert_eq "by_phase_outcome.review.sessions" "1" \
+  "$(jq '.by_phase_outcome.review.sessions' <<<"$OUT")"
+assert_eq "by_phase_outcome.review.findings_surfaced (subagent 1000 excluded)" "8" \
+  "$(jq '.by_phase_outcome.review.findings_surfaced' <<<"$OUT")"
+assert_eq "by_phase_outcome.review.findings_actionable" "5" \
+  "$(jq '.by_phase_outcome.review.findings_actionable' <<<"$OUT")"
+assert_eq "by_phase_outcome.review.fixes_applied" "3" \
+  "$(jq '.by_phase_outcome.review.fixes_applied' <<<"$OUT")"
+assert_eq "by_phase_outcome.review.followups_filed" "2" \
+  "$(jq '.by_phase_outcome.review.followups_filed' <<<"$OUT")"
+assert_eq "by_phase_outcome.review.subagents_launched" "12" \
+  "$(jq '.by_phase_outcome.review.subagents_launched' <<<"$OUT")"
+# pooled rates from summed counts: 3/8=0.375, 5/8=0.625, 3/5=0.6
+assert_eq "by_phase_outcome.review.hit_rate" "0.375" \
+  "$(jq '.by_phase_outcome.review.hit_rate' <<<"$OUT")"
+assert_eq "by_phase_outcome.review.actionability" "0.625" \
+  "$(jq '.by_phase_outcome.review.actionability' <<<"$OUT")"
+assert_eq "by_phase_outcome.review.fix_rate" "0.6" \
+  "$(jq '.by_phase_outcome.review.fix_rate' <<<"$OUT")"
+assert_eq "by_phase_outcome.review.disposition_distribution.completed_with_fixes" "1" \
+  "$(jq '.by_phase_outcome.review.disposition_distribution.completed_with_fixes' <<<"$OUT")"
+
+# by_phase_outcome.qa: the router-tick zero-count clean-pass. Zero denominators
+# -> all three rates null (the null-guard), never a divide-by-zero or a 0.
+assert_eq "by_phase_outcome.qa.sessions" "1" \
+  "$(jq '.by_phase_outcome.qa.sessions' <<<"$OUT")"
+assert_eq "by_phase_outcome.qa.findings_surfaced" "0" \
+  "$(jq '.by_phase_outcome.qa.findings_surfaced' <<<"$OUT")"
+assert_eq "by_phase_outcome.qa.hit_rate is null (zero denom)" "null" \
+  "$(jq '.by_phase_outcome.qa.hit_rate' <<<"$OUT")"
+assert_eq "by_phase_outcome.qa.actionability is null (zero denom)" "null" \
+  "$(jq '.by_phase_outcome.qa.actionability' <<<"$OUT")"
+assert_eq "by_phase_outcome.qa.fix_rate is null (zero denom)" "null" \
+  "$(jq '.by_phase_outcome.qa.fix_rate' <<<"$OUT")"
+assert_eq "by_phase_outcome.qa.disposition_distribution.completed" "1" \
+  "$(jq '.by_phase_outcome.qa.disposition_distribution.completed' <<<"$OUT")"
+
+# Subagent exclusion (defense-in-depth): the review pool must not see the
+# subagent's 1000-count envelope.
+assert_eq "by_phase_outcome.review excludes subagent (not 1008)" "true" \
+  "$(jq '.by_phase_outcome.review.findings_surfaced == 8' <<<"$OUT")"
+
+# Per-run rates on the worker session entry (#1860 AC: per-run hit-rate).
+assert_eq "sessions[sess-worker].outcome.findings_surfaced" "8" \
+  "$(jq '[.sessions[]|select(.id=="sess-worker")][0].outcome.findings_surfaced' <<<"$OUT")"
+assert_eq "sessions[sess-worker].outcome_rates.hit_rate" "0.375" \
+  "$(jq '[.sessions[]|select(.id=="sess-worker")][0].outcome_rates.hit_rate' <<<"$OUT")"
+assert_eq "sessions[sess-worker].outcome_rates.actionability" "0.625" \
+  "$(jq '[.sessions[]|select(.id=="sess-worker")][0].outcome_rates.actionability' <<<"$OUT")"
+assert_eq "sessions[sess-worker].outcome_rates.fix_rate" "0.6" \
+  "$(jq '[.sessions[]|select(.id=="sess-worker")][0].outcome_rates.fix_rate' <<<"$OUT")"
+# A session with no envelope carries outcome:null and null rates (no crash).
+assert_eq "sessions[agent-aaa].outcome is null" "null" \
+  "$(jq '[.sessions[]|select(.id=="agent-aaa")][0].outcome' <<<"$OUT")"
+assert_eq "sessions[agent-aaa].outcome_rates is null" "null" \
+  "$(jq '[.sessions[]|select(.id=="agent-aaa")][0].outcome_rates' <<<"$OUT")"
 
 report_results
 exit $FAIL

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -696,7 +696,38 @@ Otherwise run all steps in order.
       .claude/skills/dispatch-propagate/scripts/dispatch-mark-complete \
         --phase qa --pr "$PR_NUM"
       ```
-   5. **STOP.**
+   5. **Emit the outcome envelope** (contract: `.claude/docs/outcome-envelope.md`).
+      This call runs **sandboxed** — `dispatch-emit-outcome` is pure (no
+      gh/git/network), so do **not** pass `dangerouslyDisableSandbox`. The fix
+      finalize path always runs after Step 3.5, so `result` is in scope. **Override**
+      `--disposition` to `completed_with_fixes` and **recompute** the counts the
+      Workflow could not — do **NOT** forward `result.fixes_applied` /
+      `result.followups_filed` (both literal `0` from the Workflow):
+      - `--fixes-applied` = `result.fix_plan.units.length` — the units the
+        `/implement-unit` loop actually ran this pass (the Workflow plans but never
+        executes; see its header).
+      - `--followups-filed` = the count of `needs-main` follow-ups Step 3.6 actually
+        filed this pass (newly-filed only, not already-tracked); `0` if Step 3.6 did
+        not run.
+      - `--subagents-launched` = `result.subagents_launched` (Workflow fan-out)
+        **plus** the Step-2b Opus triage subagent (always +1) **plus** the Step-3.6
+        filing subagents spawned **plus** the Step-3.7 `/implement-unit` invocations.
+
+      qa-fix keeps **no** merge base (Step 1 runs only a name-only
+      `git diff origin/main...HEAD`), so **omit** `--base-sha` (it serializes as
+      null). Derive `repo` from the local remote (read-only git, sandbox-safe):
+      ```bash
+      REPO=$(git remote get-url origin | sed -E 's#.*github.com[:/]##; s#\.git$##')
+      .claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome \
+        --phase qa --repo "$REPO" --issue "$N" --pr "$PR_NUM" \
+        --findings-surfaced <result.findings_surfaced> \
+        --findings-actionable <result.findings_actionable> \
+        --fixes-applied <result.fix_plan.units.length> \
+        --followups-filed <count of needs-main follow-ups Step 3.6 newly filed> \
+        --subagents-launched <result.subagents_launched + 1 (Step-2b triage) + Step-3.6 filing subagents + Step-3.7 /implement-unit invocations> \
+        --disposition completed_with_fixes
+      ```
+   6. **STOP.**
 
    **Escalate finalize path** (cap reached, scope-deviation, planning-failed, or
    the gate printed `escalate`):
@@ -907,6 +938,38 @@ Otherwise run all steps in order.
      --phase qa --pr "$PR_NUM"
    ```
 
+   **Then emit the outcome envelope** (contract:
+   `.claude/docs/outcome-envelope.md`). This call runs **sandboxed** —
+   `dispatch-emit-outcome` is pure, so do **not** pass
+   `dangerouslyDisableSandbox`. Pass `--disposition completed`, `--fixes-applied 0`,
+   and **omit** `--terminated-reason` (forbidden on a non-escalated disposition).
+   Source the counts by whether Step 3.5 ran this pass:
+
+   - **Step 3.5 ran** (clean pass via only-`needs-main` or only-`already-satisfied`
+     residue): use `result.findings_surfaced` / `result.findings_actionable`;
+     `--followups-filed` = the Step-3.6 newly-filed count (`0` if Step 3.6 did not
+     run); `--subagents-launched` = `result.subagents_launched` + 1 (Step-2b triage)
+     + any Step-3.6 filing subagents.
+   - **Step 3.5 was skipped** (the common clean pass — residue list was empty, so
+     `result` is absent): pass `--findings-surfaced 0 --findings-actionable 0
+     --followups-filed 0` and `--subagents-launched 1` (only the Step-2b Opus triage
+     subagent ran).
+
+   qa-fix keeps **no** merge base, so **omit** `--base-sha`. Derive `repo` from the
+   local remote (read-only git, sandbox-safe):
+
+   ```bash
+   REPO=$(git remote get-url origin | sed -E 's#.*github.com[:/]##; s#\.git$##')
+   .claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome \
+     --phase qa --repo "$REPO" --issue "$N" --pr "$PR_NUM" \
+     --findings-surfaced <result.findings_surfaced, or 0 if Step 3.5 was skipped> \
+     --findings-actionable <result.findings_actionable, or 0 if Step 3.5 was skipped> \
+     --fixes-applied 0 \
+     --followups-filed <Step-3.6 newly-filed count, or 0> \
+     --subagents-launched <result.subagents_launched + 1 + Step-3.6 subagents when Step 3.5 ran; else 1> \
+     --disposition completed
+   ```
+
    Then **stop**. The Stop hook reads the marker and advances the chain.
 
    **User-input blocker** — the escalation set (defined above) is **non-empty**.
@@ -951,7 +1014,50 @@ plan, `needs-human-judgment` item, `script-verifiable`/`needs-browser` FAIL, fai
 pre-QA check, Chrome extension unavailable, multi-app choice, merge conflict, **the
 qa-fix attempt cap reached on opus-fixable residue**, or **a planner scope-deviation
 on the opus-fixable residue** — pass `result.fix_plan.deviation_reason` for the
-latter). Then **stop**.
+latter).
+
+**Then emit the outcome envelope** (contract:
+`.claude/docs/outcome-envelope.md`). This call runs **sandboxed** —
+`dispatch-emit-outcome` is pure, so do **not** pass `dangerouslyDisableSandbox`.
+It must fire **before** the session stops; order relative to
+`dispatch-mark-deviation` does not matter. Pass `--disposition escalated` and
+`--terminated-reason` set to the **same tailored reason string** passed to
+`dispatch-mark-deviation` above.
+
+This Escalation section is the funnel for **two kinds** of escalate route, which
+differ in whether the Step-3.5 Workflow ran — source the counts accordingly:
+
+- **Step-3.5 ran** (the Step-3.7 escalate-finalize path: cap reached,
+  scope-deviation, or planning-failed) — `result` is in scope. Use
+  `result.findings_surfaced` / `result.findings_actionable`; `fixes-applied 0` and
+  `followups-filed` = the Step-3.6 newly-filed count (the escalate path applied no
+  fixes); `subagents-launched` = `result.subagents_launched` + 1 (Step-2b triage)
+  + any Step-3.6 filing subagents.
+- **An early blocker before Step 3.5** (Step 0.5 merge conflict, Step 1 multi-app,
+  Step 3 malformed/empty plan, Step 3b acceptance fail, Step 3c Chrome
+  unavailable) — `result` is **absent**. Pass `--findings-surfaced 0
+  --findings-actionable 0 --fixes-applied 0 --followups-filed 0` and
+  `--subagents-launched <1 if the Step-2b triage subagent had already been spawned
+  before the blocker fired, else 0>` (Step 0.5 / Step 1 blockers fire before Step
+  2, so 0; a Step 3/3b/3c blocker fires after, so 1).
+
+qa-fix keeps **no** merge base, so **omit** `--base-sha`. Derive `repo` from the
+local remote (read-only git, sandbox-safe):
+
+```bash
+REPO=$(git remote get-url origin | sed -E 's#.*github.com[:/]##; s#\.git$##')
+.claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome \
+  --phase qa --repo "$REPO" --issue "$N" --pr "$PR_NUM" \
+  --findings-surfaced <result.findings_surfaced, or 0 if Step 3.5 did not run> \
+  --findings-actionable <result.findings_actionable, or 0 if Step 3.5 did not run> \
+  --fixes-applied 0 \
+  --followups-filed <Step-3.6 newly-filed count, or 0> \
+  --subagents-launched <result.subagents_launched + 1 + Step-3.6 filing subagents when Step 3.5 ran; else 0 or 1 per the early-blocker rule above> \
+  --disposition escalated \
+  --terminated-reason "<the same tailored reason string passed to dispatch-mark-deviation>"
+```
+
+Then **stop**.
 Marking a deviation is **terminal** for the walkthrough — do not restart the QA
 server or re-run the walkthrough after escalating.
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -573,6 +573,29 @@ marker. Call `dispatch-mark-deviation` instead:
   "/review-fix: high-confidence required security finding(s) left unresolved after fixes"
 ```
 
+**Then emit the outcome envelope** (the contract is
+`.claude/docs/outcome-envelope.md`). This call runs **sandboxed** —
+`dispatch-emit-outcome` is pure (no gh/git/network), so do **not** pass
+`dangerouslyDisableSandbox`. It must fire **before** the session stops below;
+order relative to `dispatch-mark-deviation` does not matter. The deviation path
+only runs when the Workflow ran this session, so `result` is in scope. Pass
+`--disposition escalated` and `--terminated-reason` set to the **same string**
+passed to `dispatch-mark-deviation` above. Derive `repo` from the local remote
+(read-only git, sandbox-safe — no network):
+
+```bash
+REPO=$(git remote get-url origin | sed -E 's#.*github.com[:/]##; s#\.git$##')
+.claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome \
+  --phase review --repo "$REPO" --issue <N> --pr "$PR_NUM" --base-sha "$MERGE_BASE" \
+  --findings-surfaced <result.findings_surfaced> \
+  --findings-actionable <result.findings_actionable> \
+  --fixes-applied <result.fixes_applied> \
+  --followups-filed <result.followups_filed + count of Step-5b security follow-ups actually filed> \
+  --subagents-launched <result.subagents_launched + count of Step-5a and Step-5b filing subagents this SKILL spawned> \
+  --disposition escalated \
+  --terminated-reason "/review-fix: high-confidence required security finding(s) left unresolved after fixes"
+```
+
 The Stop hook reads marker-absence as Branch A and applies `dispatch:office-hours`
 to the issue, surfacing the reason in the why-comment, so the parked item explains
 which criterion fired. Do not apply the `dispatch:office-hours` label inline — the
@@ -585,6 +608,29 @@ run; the script no-ops with a clear diagnostic.
 ```bash
 .claude/skills/dispatch-propagate/scripts/dispatch-mark-complete \
   --phase review --pr "$PR_NUM"
+```
+
+**Then, only when the Workflow ran this session** (i.e. **not** the idempotent
+re-entry path, where Steps 1–6 were skipped and `result` is absent), **emit the
+outcome envelope** (contract: `.claude/docs/outcome-envelope.md`). Skip the emit
+entirely on re-entry — re-entry is a separate transcript and emitting zeros would
+inject a phantom run into the aggregate. This call runs **sandboxed** —
+`dispatch-emit-outcome` is pure, so do **not** pass `dangerouslyDisableSandbox`.
+Use `result.disposition` directly (the Workflow already computes `completed` vs
+`completed_with_fixes` from `fixed.length`); **omit** `--terminated-reason` (it
+must be absent on a non-escalated disposition). Derive `repo` from the local
+remote (read-only git, sandbox-safe):
+
+```bash
+REPO=$(git remote get-url origin | sed -E 's#.*github.com[:/]##; s#\.git$##')
+.claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome \
+  --phase review --repo "$REPO" --issue <N> --pr "$PR_NUM" --base-sha "$MERGE_BASE" \
+  --findings-surfaced <result.findings_surfaced> \
+  --findings-actionable <result.findings_actionable> \
+  --fixes-applied <result.fixes_applied> \
+  --followups-filed <result.followups_filed + count of Step-5b security follow-ups actually filed> \
+  --subagents-launched <result.subagents_launched + count of Step-5a and Step-5b filing subagents this SKILL spawned> \
+  --disposition <result.disposition>
 ```
 
 Then **stop**. The Stop hook reads the marker and advances the chain. Applying

--- a/.claude/workflows/qa-fix.js
+++ b/.claude/workflows/qa-fix.js
@@ -214,6 +214,13 @@ log(`args type: ${typeof args}; residue count=${(_a.residue || []).length}; brow
 
 const residue = _a.residue || [];
 
+// subagents_launched (source 1, this Workflow's own fan-out): a single
+// accumulator incremented at each spawn site, inside the guard that actually
+// launches the agents. A launched-but-dead agent still counts — increment at
+// the spawn, not on the result. Unit 4's SKILL body adds any source-2 subagents
+// (e.g. the /implement-unit fix loop) before emitting the envelope.
+let subagentsLaunched = 0;
+
 // --- 1. CLASSIFY (one Opus agent, barrier) -----------------------------------
 phase('classify');
 
@@ -272,6 +279,7 @@ const classifyPrompt = [
   '</untrusted>',
 ].join('\n');
 
+subagentsLaunched += 1;
 const classifyRes = await agent(classifyPrompt, {
   model: 'opus',
   agentType: 'general-purpose',
@@ -319,6 +327,7 @@ if (candidates.length) {
       verifyJobs.push({ id: c.id, k });
     }
   }
+  subagentsLaunched += verifyJobs.length;
   const verifyResults = await parallel(
     verifyJobs.map((job) => () => {
       const r = residueById.get(job.id);
@@ -494,6 +503,7 @@ if (_a.plan_fix === true && opusFixable.length > 0) {
     '</untrusted>',
   ].join('\n');
 
+  subagentsLaunched += 1;
   const planRes = await agent(fixPlanPrompt, {
     model: 'opus',
     agentType: 'general-purpose',
@@ -513,10 +523,46 @@ if (_a.plan_fix === true && opusFixable.length > 0) {
   log(`fix-plan: skipped (plan_fix=${_a.plan_fix}, opusFixable=${opusFixable.length})`);
 }
 
+// --- outcome-envelope counts (Unit 3, issue #1860) ---------------------------
+// Computed per .claude/docs/outcome-envelope.md. Unit 4 passes these into
+// dispatch-emit-outcome (recomputing fixes_applied/followups_filed/disposition
+// after its /implement-unit fix loop runs). Additive only.
+const _deviation = fix_plan ? fix_plan.deviation : false;
+const findings_surfaced = dispositions.length; // triaged residue (excludes already_satisfied)
+// findings_actionable === findings_surfaced here: every disposition (opus-fixable,
+// needs-main, needs-human) is actionable. The non-actionable already_satisfied
+// items are partitioned out into their own array and are NOT in `dispositions`
+// (see the line-403 filter above), so all surfaced findings are actionable.
+const findings_actionable = dispositions.length;
+// fixes_applied: this Workflow PLANS but never executes fix units — the mutating
+// /implement-unit loop runs in the qa-fix SKILL caller thread, not here (see the
+// header comment, lines 20-24). So from the Workflow's own knowledge no fix has
+// run: 0. Unit 4's SKILL body supplies the real count after its fix loop.
+const fixes_applied = 0;
+// followups_filed: this Workflow only CLASSIFIES items as needs-main — it files
+// no follow-up issues itself. So 0 here; Unit 4's SKILL body supplies the count
+// when it files the needs-main follow-ups.
+const followups_filed = 0;
+// disposition: escalated on deviation; else completed_with_fixes when fixes ran;
+// else completed. Matches outcome-envelope.md's path→value table. Since
+// fixes_applied is a literal 0 here, completed_with_fixes is unreachable from the
+// Workflow alone — Unit 4 recomputes this after the fix loop runs.
+const disposition = _deviation
+  ? 'escalated'
+  : fixes_applied > 0
+    ? 'completed_with_fixes'
+    : 'completed';
+
 return {
   dispositions,
   already_satisfied,
   verify_report,
   fix_plan,
-  deviation: fix_plan ? fix_plan.deviation : false,
+  deviation: _deviation,
+  findings_surfaced,
+  findings_actionable,
+  fixes_applied,
+  followups_filed,
+  subagents_launched: subagentsLaunched,
+  disposition,
 };

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -362,10 +362,18 @@ function finderPrompt(name, args) {
 const _a = typeof args === 'string' ? JSON.parse(args) : (args || {});
 log(`args type: ${typeof args}; surface=${_a.surface}; changed_files count=${(_a.changed_files || []).length}`);
 
+// subagents_launched (source 1, this Workflow's own fan-out): a single
+// accumulator incremented at each spawn site, inside the guard that actually
+// launches the agents. A launched-but-dead agent still counts — increment at
+// the spawn, not on the result. The SKILL body (Unit 4) adds its own source-2
+// subagents (Step-5a/5b /file-issue) before emitting the envelope.
+let subagentsLaunched = 0;
+
 // --- 1. FINDERS (parallel, barrier) ------------------------------------------
 phase('finders');
 const finderNames = agentFinderSet(_a.surface, _a.app_or_rules);
 log(`finders: launching ${finderNames.length} agent finder(s) for surface=${_a.surface}`);
+subagentsLaunched += finderNames.length;
 
 const finderResults = await parallel(
   finderNames.map((name) => () =>
@@ -435,6 +443,7 @@ for (const [loc, group] of locationGroups) {
       `exactly one subgroup. The ids are: ${ids.join(', ')}.`,
       `Findings:\n${JSON.stringify(compact, null, 2)}`,
     ].join('\n');
+    subagentsLaunched += 1;
     const res = await agent(prompt, {
       model: 'sonnet',
       agentType: 'general-purpose',
@@ -513,6 +522,7 @@ if (deduped.length) {
     `Findings:\n${JSON.stringify(compact, null, 2)}`,
   ].join('\n');
 
+  subagentsLaunched += 1;
   const classifyRes = await agent(classifyPrompt, {
     model: 'sonnet',
     agentType: 'general-purpose',
@@ -571,6 +581,7 @@ if (requiredFindings.length) {
       verifyJobs.push({ id: f.id, k, finding: f });
     }
   }
+  subagentsLaunched += verifyJobs.length;
   const verifyResults = await parallel(
     verifyJobs.map((job) => () => {
       const f = job.finding;
@@ -668,6 +679,7 @@ const fixed = [];
 if (fileGroups.size) {
   log(`fix: ${fixSet.length} finding(s) across ${fileGroups.size} file-group(s) on Opus`);
   const fixFileList = Array.from(fileGroups.entries()); // [ [file, findings], ... ]
+  subagentsLaunched += fixFileList.length;
   const fixResults = await parallel(
     fixFileList.map(([file, group]) => () => {
       const findingList = group
@@ -833,6 +845,27 @@ const dispositions = deduped.map((f) => {
   return entry;
 });
 
+// --- outcome-envelope counts (Unit 3, issue #1860) ---------------------------
+// Computed per .claude/docs/outcome-envelope.md. Unit 4 passes these straight
+// into dispatch-emit-outcome; Unit 5 aggregates them. Additive only.
+const findings_surfaced = dispositions.length; // every deduped finding, any bucket
+const fixes_applied = fixed.length; // = the count of Fixed-bucket dispositions
+const followups_filed = deferred_filings.length; // this Workflow's OWN deferred filings
+// findings_actionable: dispositions whose FINAL bucket ∈ {Fixed, Required, Deferred}.
+// Compute from `dispositions` (the post-remap array) NOT `deduped`: dispositions
+// remaps refuted/unverified Required findings to Refuted/Unverified, so Required
+// here means upheld-only. Computing from `deduped` would wrongly count those
+// dropped findings (they still carry bucket==='Required' there) as actionable.
+const ACTIONABLE_BUCKETS = new Set(['Fixed', 'Required', 'Deferred']);
+const findings_actionable = dispositions.filter((d) => ACTIONABLE_BUCKETS.has(d.bucket)).length;
+// disposition: escalated on deviation; else completed_with_fixes when any fix
+// landed; else completed. Matches the path→value table in outcome-envelope.md.
+const disposition = deviation
+  ? 'escalated'
+  : fixed.length > 0
+    ? 'completed_with_fixes'
+    : 'completed';
+
 return {
   dispositions,
   fixed,
@@ -841,4 +874,10 @@ return {
   verify_report,
   deviation,
   security_note: _a.security_note,
+  findings_surfaced,
+  findings_actionable,
+  fixes_applied,
+  followups_filed,
+  subagents_launched: subagentsLaunched,
+  disposition,
 };


### PR DESCRIPTION
Closes #1860

## Summary

Dispatch phases now emit a machine-readable per-run **outcome envelope** at every
terminal path, and `dispatch-token-audit` reads it to compute review-fix / qa-fix
hit-rate by deterministic aggregation — no LLM classification step.

Previously, measuring a phase's yield meant LLM-classifying its prose summary with
parallel subagents: expensive, non-reproducible, and unreliable (a "Fixed"
disposition could lie when no diff materialized). With the envelope, hit-rate
becomes a standing metric folded straight out of the transcripts.

Scope is `review-fix` + `qa-fix`; the schema doc explains incremental adoption for
the remaining phases.

## What landed (7 units)

1. **Schema contract** — `.claude/docs/outcome-envelope.md`: the single source of
   truth. Carrier shape (`<!-- dispatch:outcome:v1 -->` marker + fenced JSON,
   mirroring the `dispatch:plan` convention), every field with type + nullability,
   the `disposition` enum (`completed` / `completed_with_fixes` / `escalated`) and
   per-path mapping, `findings_actionable` membership per phase, the hit-rate
   formulas with zero-denominator guards, `subagents_launched` semantics, the
   reader contract (tool_result carrier, last-wins, worker-sessions-only), and the
   adoption recipe.
2. **Emit script** — `dispatch-emit-outcome`: prints the canonical block to stdout,
   patterned on `dispatch-mark-complete` for arg parsing and clear-error
   validation, but **unconditionally** (no `CLAUDE_JOB_DIR` no-op) so the envelope
   always lands in the transcript, including on escalation paths where no
   completion marker is written. Builds JSON via `jq -n`.
3. **Workflow return extensions** — `review-fix.js` / `qa-fix.js`: additive
   computed fields (`findings_surfaced`, `findings_actionable`, `fixes_applied`,
   `followups_filed`, `subagents_launched`, `disposition`) so the SKILL bodies do
   no arithmetic. Adds an explicit subagent-fan-out counter to each workflow.
4. **SKILL wiring** — an emit call at all five terminal paths (review-fix:
   normal-complete, deviation; qa-fix: clean-pass, auto-fix-applied, escalate).
   Because the qa-fix workflow plans but does not execute fixes (the auto-fix loop
   runs in the SKILL thread), the SKILL recomputes `fixes_applied` /
   `followups_filed` / `subagents_launched` and overrides `disposition` on the
   auto-fix path.
5. **Reader** — `aggregate-usage.sh`: a separate tool_result pass greps the literal
   marker, captures the fenced JSON, parses it with `try`/`fromjson` (malformed →
   null, never aborts the file), takes last-wins, and binds a per-session outcome.
   Stage-2 surfaces per-run `hit_rate` / `actionability` / `fix_rate` on
   `sessions[]` and adds a pooled `by_phase_outcome` aggregate (non-subagent
   sessions only, with `disposition_distribution`).
6. **Test** — `test-aggregate-usage.sh`: fixture envelopes (worker review, router
   qa zero-count null-guard, an excluded subagent envelope) and assertions for
   pooled sums, pooled and per-run rates, the null cases, the disposition
   distribution, and subagent exclusion. Suite is green.
7. **Operator docs** — `dispatch-token-audit/SKILL.md`: how to read the metric,
   with `jq` slices against `tmp/usage-audit.json`.

## Verification

- `test-aggregate-usage.sh` passes (covers the envelope reader end to end,
  including the merge with the parallel persist-writer work on `main`).
- `node --check` passes for both workflow files.
- `dispatch-emit-outcome` validates required fields, non-negative integers, the
  phase/disposition enums, and the `terminated_reason`-iff-escalated rule, and
  prints regardless of `CLAUDE_JOB_DIR`.

## Note on the reader anchor

An interim version of the reader anchored its regex on the substring
`dispatch:outcome:v1` after a report that jq could not match a literal `<!--`.
That report was a shell `!`-escaping artifact, not a jq limitation; the reader was
corrected to anchor on the full literal marker `<!-- dispatch:outcome:v1 -->`, per
the contract.
