### PR TITLE
audio: tag testOnly-dependent public-listing count test @testonly

### DIFF
--- a/audio/e2e/home.spec.ts
+++ b/audio/e2e/home.spec.ts
@@ -10,7 +10,7 @@ test.describe("home page content", () => {
     await expect(page.locator("#media-error")).toHaveCount(0);
   });
 
-  test("public media listing shows 4 items", async ({ page }) => {
+  test("public media listing shows 4 items @testonly", async ({ page }) => {
     await page.goto("/");
     await expect(page.locator(".audio-row")).toHaveCount(4, {
       timeout: 10000,

--- a/audio/e2e/home.spec.ts
+++ b/audio/e2e/home.spec.ts
@@ -10,9 +10,9 @@ test.describe("home page content", () => {
     await expect(page.locator("#media-error")).toHaveCount(0);
   });
 
-  test("public media listing shows 4 items @testonly", async ({ page }) => {
+  test("public media listing shows 3 items", async ({ page }) => {
     await page.goto("/");
-    await expect(page.locator(".audio-row")).toHaveCount(4, {
+    await expect(page.locator(".audio-row")).toHaveCount(3, {
       timeout: 10000,
     });
   });

--- a/audio/e2e/home.spec.ts
+++ b/audio/e2e/home.spec.ts
@@ -10,9 +10,9 @@ test.describe("home page content", () => {
     await expect(page.locator("#media-error")).toHaveCount(0);
   });
 
-  test("public media listing shows 3 items", async ({ page }) => {
+  test("public media listing shows 4 items @testonly", async ({ page }) => {
     await page.goto("/");
-    await expect(page.locator(".audio-row")).toHaveCount(3, {
+    await expect(page.locator(".audio-row")).toHaveCount(4, {
       timeout: 10000,
     });
   });


### PR DESCRIPTION
Closes #1854

## Problem

The audio acceptance test `"public media listing shows 4 items"`
(`audio/e2e/home.spec.ts:13`) asserts exactly 4 `.audio-row` items on the
unauthenticated home page. The 4th row comes from the `testOnly: true` media
seed (`audio/seeds/firestore.ts:80-103`); the non-testOnly public seed has only
3 items.

Because the test was **untagged**, the public-data QA acceptance run
(`run-acceptance-tests.sh`, which excludes `@hosting|@testonly|@build`) did
**not** skip it. It ran against the 3-row public server and failed
(`Expected: 4, Received: 3`). CI seeds testOnly data and runs all tests, so it
saw 4 rows and passed — which is why this went unnoticed.

An untagged exact-count assertion cannot pass in both environments: the
public-data QA server renders 3 rows and the testOnly-seeded CI emulator renders
4. There is no positive "public-only" tag, only the `@testonly` exclusion.

## Fix

Tag the test `@testonly` so it runs **only** where testOnly data is seeded
(CI → 4 rows ✓) and is **excluded** from the public-data QA run. This mirrors
the already-tagged sibling tests at `audio/e2e/home.spec.ts:83` (the 5-row
signed-in test) and `print/e2e/media.spec.ts:10` over the identical
3-public + 2-testOnly seed structure.

Public-rendering coverage on the QA run is already provided, untagged, by
`"titles are visible"` (`audio/e2e/home.spec.ts:20`), which uses
`toContainText` on the three real public titles and passes at both 3 and 4
rows — so no new untagged public-count test is needed.

An audit of all audio and sibling-app e2e specs found no other untagged test
whose assertion depends on testOnly seed data.

## Change

One line: append ` @testonly` to the test title. The `toHaveCount(4)` assertion
is unchanged — 4 is correct under the testOnly-seeded run where this test now
exclusively runs.
