### PR TITLE
Resolve nested workspace paths in dispatch CI change-detection

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -685,6 +685,25 @@ kill_tree() {
   done <<< "$pids"
 }
 
+# Resolve the workspace key that owns a changed file via longest-prefix match.
+# Echoes the LONGEST key `ws` from the `all_apps` associative array such that
+# `file == ws` OR `file` begins with "$ws/" (the trailing "/" is load-bearing:
+# without it "print" would match "printer/x" and "packages/ds" would match
+# "packages/ds-utils/x"). Reads `all_apps` via bash dynamic scoping from the
+# caller. Echoes nothing if no workspace matches.
+# Args: $1 = changed file path
+_resolve_workspace_for_file() {
+  local file="$1" ws best=""
+  for ws in "${!all_apps[@]}"; do
+    if [ "$file" = "$ws" ] || [ "${file#"$ws"/}" != "$file" ]; then
+      if (( ${#ws} > ${#best} )); then
+        best="$ws"
+      fi
+    fi
+  done
+  echo "$best"
+}
+
 # Resolve which apps are affected by a set of changed files.
 # Reads changed file paths from stdin, one per line.
 # Outputs dirty app names to stdout, one per line (unsorted).
@@ -726,11 +745,10 @@ resolve_dirty_apps() {
   done
 
   declare -A dirty_apps
-  local file top_dir
+  local file
 
   while IFS= read -r file; do
     [ -z "$file" ] && continue
-    top_dir="${file%%/*}"
     case "$file" in
       firebase.json|firestore.rules|storage.rules|package.json|package-lock.json)
         # Root-level config changes affect all workspaces
@@ -739,15 +757,27 @@ resolve_dirty_apps() {
         done
         ;;
       *)
-        # Check if this is a shared package change
-        if [ -n "${shared_pkgs[$top_dir]+x}" ]; then
-          for app in ${shared_pkgs[$top_dir]}; do
+        # Longest-prefix match the file to its owning workspace key.
+        local ws short
+        ws=$(_resolve_workspace_for_file "$file")
+        [ -z "$ws" ] && continue
+        # Shared-package lookup keys on the workspace's leaf dir, which is
+        # bridged to the @commons-systems/<name> dependency short name in the
+        # shared_pkgs build above. This assumes the leaf dir equals the short
+        # name; if a future nested workspace's leaf dir ever differs (e.g.
+        # packages/foo providing @commons-systems/bar), its shared-package
+        # retrigger silently breaks — revisit if that convention is relaxed.
+        # A literal glob workspace entry (e.g. packages/*) is out of scope: it
+        # already hard-errors today at the jq on $repo_root/$app/package.json.
+        short="${ws##*/}"
+        if [ -n "${shared_pkgs[$short]+x}" ]; then
+          for app in ${shared_pkgs[$short]}; do
             dirty_apps["$app"]=1
           done
         fi
-        # Check if this is a direct app change
-        if [ -n "${all_apps[$top_dir]+x}" ]; then
-          dirty_apps["$top_dir"]=1
+        # Check if this is a direct app change (full matched path).
+        if [ -n "${all_apps[$ws]+x}" ]; then
+          dirty_apps["$ws"]=1
         fi
         ;;
     esac

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -713,7 +713,7 @@ resolve_dirty_apps() {
 
   # Discover all workspaces from root package.json
   declare -A all_apps
-  local workspace_list
+  local workspace_list ws
   if ! workspace_list=$(jq -r '.workspaces[]' "$repo_root/package.json"); then
     echo "ERROR: failed to read workspaces from $repo_root/package.json" >&2
     return 1
@@ -758,7 +758,7 @@ resolve_dirty_apps() {
         ;;
       *)
         # Longest-prefix match the file to its owning workspace key.
-        local ws short
+        local short
         ws=$(_resolve_workspace_for_file "$file")
         [ -z "$ws" ] && continue
         # Shared-package lookup keys on the workspace's leaf dir, which is

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -31511,6 +31511,48 @@ rm -rf "$TMPDIR_TEST"
 TMPDIR_TEST=""
 
 # ============================================================================
+# resolve_dirty_apps (#1887)
+# ============================================================================
+#
+# Covers the longest-prefix workspace resolution and shared-package retrigger
+# path introduced in #1887. A synthetic fixture declares three workspaces:
+# landing (flat), blog (flat, consumes @commons-systems/ds), and packages/ds
+# (nested). Each case is sorted before asserting because resolve_dirty_apps
+# emits names in hash-iteration order.
+
+echo ""
+echo "=== resolve_dirty_apps: nested workspace resolution ==="
+
+echo "Test: resolve_dirty_apps -- nested direct + shared retrigger"
+root=$(mktemp -d)
+mkdir -p "$root/landing" "$root/blog" "$root/packages/ds"
+printf '%s' '{"workspaces":["landing","blog","packages/ds"]}' > "$root/package.json"
+printf '%s' '{}' > "$root/landing/package.json"
+printf '%s' '{"dependencies":{"@commons-systems/ds":"*"}}' > "$root/blog/package.json"
+printf '%s' '{}' > "$root/packages/ds/package.json"
+
+out=$(printf '%s\n' "packages/ds/base.css" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$root") | sort)
+assert_eq "resolve_dirty_apps: nested direct + shared retrigger" \
+  $'blog\npackages/ds' "$out"
+
+echo "Test: resolve_dirty_apps -- flat workspace regression"
+out=$(printf '%s\n' "landing/index.html" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$root") | sort)
+assert_eq "resolve_dirty_apps: flat workspace regression" \
+  "landing" "$out"
+
+echo "Test: resolve_dirty_apps -- prefix boundary marks nothing"
+out=$(printf '%s\n' "packages/dsx/foo" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$root") | sort)
+assert_eq "resolve_dirty_apps: prefix boundary marks nothing" \
+  "" "$out"
+
+echo "Test: resolve_dirty_apps -- root-config fan-out marks all workspaces"
+out=$(printf '%s\n' "package.json" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$root") | sort)
+assert_eq "resolve_dirty_apps: root-config fan-out marks all workspaces" \
+  $'blog\nlanding\npackages/ds' "$out"
+
+rm -rf "$root"
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -31578,33 +31578,34 @@ echo ""
 echo "=== resolve_dirty_apps: nested workspace resolution ==="
 
 echo "Test: resolve_dirty_apps -- nested direct + shared retrigger"
-root=$(mktemp -d)
-mkdir -p "$root/landing" "$root/blog" "$root/packages/ds"
-printf '%s' '{"workspaces":["landing","blog","packages/ds"]}' > "$root/package.json"
-printf '%s' '{}' > "$root/landing/package.json"
-printf '%s' '{"dependencies":{"@commons-systems/ds":"*"}}' > "$root/blog/package.json"
-printf '%s' '{}' > "$root/packages/ds/package.json"
+TMPDIR_TEST=$(mktemp -d)
+mkdir -p "$TMPDIR_TEST/landing" "$TMPDIR_TEST/blog" "$TMPDIR_TEST/packages/ds"
+printf '%s' '{"workspaces":["landing","blog","packages/ds"]}' > "$TMPDIR_TEST/package.json"
+printf '%s' '{}' > "$TMPDIR_TEST/landing/package.json"
+printf '%s' '{"dependencies":{"@commons-systems/ds":"*"}}' > "$TMPDIR_TEST/blog/package.json"
+printf '%s' '{}' > "$TMPDIR_TEST/packages/ds/package.json"
 
-out=$(printf '%s\n' "packages/ds/base.css" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$root") | sort)
+out=$(printf '%s\n' "packages/ds/base.css" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$TMPDIR_TEST") | sort)
 assert_eq "resolve_dirty_apps: nested direct + shared retrigger" \
   $'blog\npackages/ds' "$out"
 
 echo "Test: resolve_dirty_apps -- flat workspace regression"
-out=$(printf '%s\n' "landing/index.html" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$root") | sort)
+out=$(printf '%s\n' "landing/index.html" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$TMPDIR_TEST") | sort)
 assert_eq "resolve_dirty_apps: flat workspace regression" \
   "landing" "$out"
 
 echo "Test: resolve_dirty_apps -- prefix boundary marks nothing"
-out=$(printf '%s\n' "packages/dsx/foo" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$root") | sort)
+out=$(printf '%s\n' "packages/dsx/foo" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$TMPDIR_TEST") | sort)
 assert_eq "resolve_dirty_apps: prefix boundary marks nothing" \
   "" "$out"
 
 echo "Test: resolve_dirty_apps -- root-config fan-out marks all workspaces"
-out=$(printf '%s\n' "package.json" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$root") | sort)
+out=$(printf '%s\n' "package.json" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$TMPDIR_TEST") | sort)
 assert_eq "resolve_dirty_apps: root-config fan-out marks all workspaces" \
   $'blog\nlanding\npackages/ds' "$out"
 
-rm -rf "$root"
+rm -rf "$TMPDIR_TEST"
+TMPDIR_TEST=""
 
 # ============================================================================
 # summary


### PR DESCRIPTION
Closes #1887

## Problem

`resolve_dirty_apps` in `.claude/skills/dispatch-propagate/scripts/lib.sh` mapped
a changed file to its workspace by the file's **first** path segment
(`top_dir="${file%%/*}"`). For a nested workspace path like `packages/ds`, an
edit to `packages/ds/base.css` collapsed to `top_dir=packages`, which matched
neither `all_apps` (keyed by the full workspace string `packages/ds`) nor
`shared_pkgs` (keyed by the short name `ds`). The file was silently dropped — the
`ds` workspace was never marked dirty and no consuming app retriggered.

## Fix

Resolve a changed file to its workspace by **longest-prefix match** against the
actual `workspaces[]` entries, then:

- mark the matched workspace dirty using its **full path** (`packages/ds` for a
  nested direct change; the flat name for flat workspaces — unchanged), and
- look up shared-package consumers by the workspace **basename** (`packages/ds` →
  `ds`), preserving today's flat behavior exactly (`${ws##*/}` == `ws` for flat
  workspaces).

A new top-level helper `_resolve_workspace_for_file` picks the longest workspace
key `ws` such that `file == ws` or `file` begins with `"$ws/"`. The trailing `/`
is load-bearing: it keeps `print` from matching `printer/x` and `packages/ds`
from matching `packages/ds-utils/x`. The root-config `case` arm
(`firebase.json`, `firestore.rules`, …) is untouched and still fans out to all
workspaces.

`get-changed-apps.sh` delegates to `resolve_dirty_apps` with no duplicated
resolution logic, so its change-detection picks up the fix for free.

## The one explicit trade

The basename bridge relies on the leaf directory name equalling the package's
`@commons-systems/<name>` short name — the same convention flat workspaces
already depend on. If a future nested workspace's leaf dir ever differs from its
short name, its shared-package retrigger would silently break. This is stated in
a code comment as a follow-up condition. Glob workspace entries (`packages/*`)
remain out of scope (a literal `packages/*` entry already hard-errors today at
the per-workspace `jq`) and are noted in the same comment.

## Tests

Added a `resolve_dirty_apps` block to `test-dispatch-scripts.sh` (runs in the
`hook-tests` CI job) using a synthetic fixture, since the real repo has no nested
workspace yet:

1. Nested direct change + shared retrigger — `packages/ds/base.css` → `blog`,
   `packages/ds`.
2. Flat regression — `landing/index.html` → `landing`.
3. Prefix-boundary — `packages/dsx/foo` → marks nothing.
4. Root-config fan-out — `package.json` → all workspaces.

Full suite passes locally: `Results: 3034/3034 passed, 0 failed`.
