### PR TITLE
dispatch: sanitize launcher environment so the tick survives env-bloated interactive shells (E2BIG)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib-sanitize-launch-env.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-sanitize-launch-env.sh
@@ -74,7 +74,11 @@ sanitize_launch_env() {
         fi
       fi
     done
-    export PATH="$rebuilt"
+    # Guard the export: if dedup produced nothing (e.g. a malformed PATH of all
+    # separators like `:::`), leave the original PATH untouched rather than
+    # clobbering it to empty — an empty PATH would break the `env`/`wc` forks in
+    # step 3 with a confusing "command not found".
+    [[ -n "$rebuilt" ]] && export PATH="$rebuilt"
   fi
 
   # --- Step 3: size guard (acceptance criterion 3) ---------------------------

--- a/.claude/skills/dispatch-propagate/scripts/lib-sanitize-launch-env.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-sanitize-launch-env.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Sanitize the inherited shell environment before a dispatch launcher execs the
+# chain (#1879).
+#
+# Symptom: when `dispatch` is launched from an env-bloated interactive shell
+# (e.g. direnv layering a large PATH and a pile of DIRENV_* vars, plus whatever
+# else accumulated in a long-lived terminal), the chain dies with
+# "Argument list too long" (E2BIG). execve(2) caps the combined size of the
+# argument vector AND the environment block at ARG_MAX; once the inherited
+# environment alone approaches that ceiling, the very next external command the
+# launcher runs fails to exec.
+#
+# This library defines one function, sanitize_launch_env(), that the Nix
+# launcher wrappers `source` to prune the environment back under the ceiling.
+#
+# WHY THE ORDER MATTERS (this is the whole point):
+#   The first two steps — unsetting the DIRENV_* family and deduplicating PATH —
+#   MUST be exec-free (pure bash builtins, no external commands at all). They run
+#   while the environment is still bloated, i.e. while execve would E2BIG. If
+#   step 1 or step 2 shelled out to `tr`/`awk`/`sed`/`printf`-in-a-subshell, that
+#   fork+exec would itself fail before it could shrink anything.
+#   Only AFTER those builtin-only steps have pruned the environment is it safe to
+#   run external commands. So the size guard (step 3) — which uses `env`, `wc`,
+#   and `getconf` — comes last, when execve works again. Measuring the
+#   environment BEFORE the prune would mean even `env | wc -c` could E2BIG.
+#
+# The wrappers also do an inline pre-source `unset` of the DIRENV_* family before
+# they can even source this file; step 1 here repeats that defensively/
+# idempotently. The inline pre-git bootstrap, any allowlist, and any `env -i`
+# rebuild are out of scope for this library — it is exactly one function.
+#
+# Sourced under `set -euo pipefail` by the launcher wrappers, so every construct
+# here is written to be safe under `set -u` (no unbound-variable trip) and not
+# to trip `set -e` (the `|| true` guards on best-effort steps).
+
+sanitize_launch_env() {
+  # --- Step 1: re-unset the direnv family (defensive / idempotent) -----------
+  # `${!DIRENV_@}` is bash prefix-name expansion: it lists the NAMES of all set
+  # variables beginning with `DIRENV_`. When none are set it expands to nothing,
+  # so `unset -v` is called with no operands — a harmless no-op, and crucially it
+  # does NOT trip `set -u` (validated: empty expansion, no unbound-variable
+  # error). `unset` cannot fail in any way we care about here, but the
+  # `2>/dev/null || true` keeps a stray non-zero from tripping `set -e`. This is
+  # a builtin — no fork, no exec — so it is safe while the env is still bloated.
+  unset -v "${!DIRENV_@}" 2>/dev/null || true
+
+  # --- Step 2: deduplicate PATH with an exec-free builtin loop ----------------
+  # Duplicate PATH components are pure bloat: they cost execve budget without
+  # adding any lookup capability. A direnv-layered interactive shell readily
+  # accumulates the same entry many times over. We rebuild PATH keeping only the
+  # first occurrence of each component (first-wins preserves lookup precedence),
+  # using ONLY bash builtins — no `tr`, `awk`, `sed`, or subshell `printf`,
+  # because this runs before the env is small enough for execve to succeed.
+  #
+  # `local IFS=:` makes word-splitting break PATH on `:`. `local -A seen` is an
+  # associative array used as a set of components already emitted. The trailing
+  # `|| true` guards the rare empty-PATH edge: with `set -e`, splitting an empty
+  # value and finding no words is fine, but we keep the guard explicit.
+  if [[ -n "${PATH:-}" ]]; then
+    local IFS=:
+    local -A seen=()
+    local rebuilt=""
+    local component
+    for component in $PATH; do
+      # Skip empty components (e.g. a leading/trailing/`::` colon yields an
+      # empty word) so they don't bloat the result with stray separators.
+      [[ -z "$component" ]] && continue
+      if [[ -z "${seen[$component]:-}" ]]; then
+        seen[$component]=1
+        if [[ -z "$rebuilt" ]]; then
+          rebuilt="$component"
+        else
+          rebuilt="$rebuilt:$component"
+        fi
+      fi
+    done
+    export PATH="$rebuilt"
+  fi
+
+  # --- Step 3: size guard (acceptance criterion 3) ---------------------------
+  # Now that steps 1 and 2 have pruned the environment, external commands can
+  # exec again, so we can finally measure. `env | wc -c` is the size of the
+  # current environment block as a stream of `NAME=VALUE\n` records — a faithful
+  # proxy for what execve must fit. We compare it against the kernel's ARG_MAX
+  # (`getconf ARG_MAX`) minus a conservative 128 KB (131072-byte) safety margin.
+  # The margin leaves headroom for the argument vector itself and for any per-arg
+  # / per-env overhead the kernel charges beyond the raw bytes.
+  #
+  # If the pruned environment STILL exceeds the budget, no further automatic
+  # pruning we are willing to do will help — the inherited shell is simply too
+  # large — so we fail loud with an actionable message and `return 1` rather
+  # than letting the next exec die with a cryptic E2BIG.
+  local env_size arg_max budget
+  env_size=$(env | wc -c)
+  arg_max=$(getconf ARG_MAX)
+  budget=$(( arg_max - 131072 ))
+
+  if (( env_size > budget )); then
+    echo "error: inherited shell environment is too large to launch dispatch (#1879)." >&2
+    echo "  environment size after pruning: ${env_size} bytes" >&2
+    echo "  budget (ARG_MAX ${arg_max} - 131072 safety margin): ${budget} bytes" >&2
+    echo "  An oversized inherited shell environment is the cause: the combined" >&2
+    echo "  environment + argument size exceeds the kernel's execve limit, so the" >&2
+    echo "  next external command would die with 'Argument list too long' (E2BIG)." >&2
+    echo "  Start dispatch from a fresh shell (a new terminal, or a clean login" >&2
+    echo "  shell that has not accumulated a bloated environment), then retry." >&2
+    return 1
+  fi
+
+  # Success: environment fits within budget. Implicit return 0.
+}

--- a/.claude/skills/dispatch-propagate/scripts/test-sanitize-launch-env.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-sanitize-launch-env.sh
@@ -43,15 +43,26 @@ run_case() {
   shift
   echo "--- $case_label ---"
 
-  local output
+  local output rc
   # Use `if` form so set -e does not abort on a subshell non-zero exit;
   # we want to collect output even if the subshell fails.
-  if output=$("$@" 2>&1); then :; fi
+  if output=$("$@" 2>&1); then rc=0; else rc=$?; fi
   echo "$output"
 
   local p f
   p=$(grep -c "^  PASS:" <<<"$output" 2>/dev/null || true)
   f=$(grep -c "^  FAIL:" <<<"$output" 2>/dev/null || true)
+
+  # Infrastructure-failure guard: a subshell that crashes before emitting any
+  # PASS/FAIL line (e.g. a failed `source`, a bash error, or an E2BIG during
+  # case setup) would otherwise contribute 0 assertions, letting report_results
+  # pass vacuously. If neither a PASS nor a FAIL was emitted and the subshell
+  # exited non-zero, record one synthetic FAIL so the crash is reported.
+  if (( p == 0 && f == 0 && rc != 0 )); then
+    echo "  FAIL: $case_label (subshell crashed, rc=$rc, no PASS/FAIL emitted)"
+    f=1
+  fi
+
   PASS=$((PASS + p))
   FAIL=$((FAIL + f))
   TOTAL=$((TOTAL + p + f))
@@ -95,9 +106,10 @@ case1_body() {
   no_second_a="$(case ":$PATH:" in *:/a:*:/a:*) echo dup;; *) echo no-dup;; esac)"
   assert_eq "case1b no duplicate /a" "no-dup" "$no_second_a"
 
-  # (c) A child execve still works after the prune
-  env >/dev/null
-  child_rc=$?
+  # (c) A child execve still works after the prune. Use the `if` form so a
+  # non-zero `env` exit is captured into child_rc and reported as a FAIL,
+  # rather than aborting the subshell under set -e before the assertion runs.
+  if env >/dev/null; then child_rc=0; else child_rc=$?; fi
   assert_eq "case1c child execve succeeds" "0" "$child_rc"
 
   # Dedup on a fully controlled synthetic PATH: prepend dupes in a sub-subshell
@@ -131,12 +143,20 @@ case2_body() {
 }
 
 # --- Case 3 body: over-budget environment triggers the guard ------------------
-# Budget = ARG_MAX (3200000) - 131072 = 3068928 bytes.
-# BIG ≈ 3,100,000 bytes (NON-DIRENV_ var, so step 1 prune won't remove it):
-#   - above budget  (3,068,928)  → guard fires and returns 1
-#   - below ARG_MAX (3,200,000)  → step 3's env/wc/getconf can still exec
-# This window keeps the test in the "guard fires cleanly" zone, not "env itself
-# is E2BIG before the guard can measure it" zone.
+# The guard's budget is ARG_MAX - 131072. We need a single NON-DIRENV_ var (so
+# step 1's prune won't remove it) sized to land in a narrow window:
+#   - above budget  (ARG_MAX - 131072)  → guard fires and returns 1
+#   - below ARG_MAX                      → step 3's env/wc/getconf can still exec
+# This keeps the test in the "guard fires cleanly" zone, not "env itself is
+# E2BIG before the guard can measure it" zone.
+#
+# ARG_MAX is not a portable constant (Linux often 2 MB or 3.2 MB; macOS ~1 MB),
+# so the BIG size MUST be computed from the live `getconf ARG_MAX` rather than
+# hardcoded — otherwise the `export BIG=...` itself E2BIGs on small-ARG_MAX
+# platforms and the subshell crashes with no PASS/FAIL output. We place BIG at
+# budget + 65536: comfortably above the budget, and with ~64 KB of the 131072
+# safety margin still free below ARG_MAX for env/wc/getconf to exec. If ARG_MAX
+# is too small to open this window at all, skip the case rather than crash.
 case3_body() {
   assert_eq() {
     local label="$1" expected="$2" actual="$3"
@@ -149,7 +169,17 @@ case3_body() {
     fi
   }
 
-  export BIG="$(head -c 3100000 /dev/zero | tr '\0' x)"
+  local _arg_max _big_size
+  _arg_max=$(getconf ARG_MAX)
+  # Need room for a value above (ARG_MAX - 131072) yet below ARG_MAX. With a
+  # 262144 floor the window (and the rest of the env) comfortably fits.
+  if (( _arg_max < 262144 )); then
+    echo "  PASS: case3 skip (ARG_MAX too small: ${_arg_max})"
+    return 0
+  fi
+  _big_size=$(( (_arg_max - 131072) + 65536 ))
+
+  export BIG="$(head -c "$_big_size" /dev/zero | tr '\0' x)"
 
   # Capture stderr; use `if` form so set -e does not abort on return 1
   if err=$(sanitize_launch_env 2>&1 1>/dev/null); then rc=0; else rc=$?; fi

--- a/.claude/skills/dispatch-propagate/scripts/test-sanitize-launch-env.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-sanitize-launch-env.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Unit tests for sanitize_launch_env() from lib-sanitize-launch-env.sh (#1879).
+# Runs standalone: ./test-sanitize-launch-env.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib-sanitize-launch-env.sh"
+
+# --- test helpers (copied verbatim from test-dispatch-scripts.sh) ------------
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected: '$expected'"
+    echo "    actual:   '$actual'"
+  fi
+}
+
+report_results() {
+  echo ""
+  echo "================================"
+  echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+  echo "================================"
+  [[ "$FAIL" -eq 0 ]]
+}
+
+# --- helper: run a subshell case and accumulate counters in parent -----------
+# Each case runs in a subshell (to isolate PATH / DIRENV_ mutations). The
+# subshell prints "  PASS: ..." / "  FAIL: ..." lines which we collect and
+# count in the parent so report_results sees real totals.
+run_case() {
+  local case_label="$1"
+  shift
+  echo "--- $case_label ---"
+
+  local output
+  # Use `if` form so set -e does not abort on a subshell non-zero exit;
+  # we want to collect output even if the subshell fails.
+  if output=$("$@" 2>&1); then :; fi
+  echo "$output"
+
+  local p f
+  p=$(grep -c "^  PASS:" <<<"$output" 2>/dev/null || true)
+  f=$(grep -c "^  FAIL:" <<<"$output" 2>/dev/null || true)
+  PASS=$((PASS + p))
+  FAIL=$((FAIL + f))
+  TOTAL=$((TOTAL + p + f))
+}
+
+# --- Case 1 body: runs inside a subshell via run_case -------------------------
+# Isolates the big DIRENV_DIFF export and PATH mutation from later cases.
+case1_body() {
+  # Re-source the lib inside the subshell (it was sourced at top level so the
+  # function definition is inherited, but assert_eq helpers are NOT — they live
+  # in the parent's environment; this subshell defines its own copies).
+  PASS=0; FAIL=0; TOTAL=0
+
+  assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+      echo "  PASS: $label"
+    else
+      echo "  FAIL: $label"
+      echo "    expected: '$expected'"
+      echo "    actual:   '$actual'"
+    fi
+  }
+
+  export DIRENV_DIFF="$(head -c 1500000 /dev/zero | tr '\0' x)"
+  export DIRENV_WATCHES="something"
+  export PATH="/a:/b:/a:/b:/c:/a:$PATH"
+
+  sanitize_launch_env
+
+  # (a) DIRENV_* vars are gone
+  assert_eq "case1a DIRENV_DIFF gone"    "UNSET" "${DIRENV_DIFF:-UNSET}"
+  assert_eq "case1a DIRENV_WATCHES gone" "UNSET" "${DIRENV_WATCHES:-UNSET}"
+  direnv_remaining="${!DIRENV_@}"
+  assert_eq "case1a no DIRENV_ vars remain" "" "$direnv_remaining"
+
+  # (b) PATH is deduped and order-preserved: the synthetic prefix collapses to /a:/b:/c
+  prefix="$(cut -d: -f1-3 <<<"$PATH")"
+  assert_eq "case1b prefix is /a:/b:/c" "/a:/b:/c" "$prefix"
+  # Confirm no second /a survives: :/a: must appear at most once
+  no_second_a="$(case ":$PATH:" in *:/a:*:/a:*) echo dup;; *) echo no-dup;; esac)"
+  assert_eq "case1b no duplicate /a" "no-dup" "$no_second_a"
+
+  # (c) A child execve still works after the prune
+  env >/dev/null
+  child_rc=$?
+  assert_eq "case1c child execve succeeds" "0" "$child_rc"
+
+  # Dedup on a fully controlled synthetic PATH: prepend dupes in a sub-subshell
+  # (real PATH still in scope so step 3 finds env/wc/getconf).
+  synthetic_result="$(
+    export PATH="/a:/b:/a:/b:/c:/a:$PATH"
+    sanitize_launch_env >/dev/null 2>&1
+    cut -d: -f1-3 <<<"$PATH"
+  )"
+  assert_eq "case1b synthetic dedup" "/a:/b:/c" "$synthetic_result"
+}
+
+# --- Case 2 body: no DIRENV_* vars set — no unbound-variable error -----------
+case2_body() {
+  assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+      echo "  PASS: $label"
+    else
+      echo "  FAIL: $label"
+      echo "    expected: '$expected'"
+      echo "    actual:   '$actual'"
+    fi
+  }
+
+  # Clear any DIRENV_* that may be inherited from the outer shell (e.g. direnv)
+  unset -v "${!DIRENV_@}" 2>/dev/null || true
+
+  if sanitize_launch_env; then rc=0; else rc=$?; fi
+  assert_eq "case2 returns 0 with no DIRENV_ vars" "0" "$rc"
+}
+
+# --- Case 3 body: over-budget environment triggers the guard ------------------
+# Budget = ARG_MAX (3200000) - 131072 = 3068928 bytes.
+# BIG ≈ 3,100,000 bytes (NON-DIRENV_ var, so step 1 prune won't remove it):
+#   - above budget  (3,068,928)  → guard fires and returns 1
+#   - below ARG_MAX (3,200,000)  → step 3's env/wc/getconf can still exec
+# This window keeps the test in the "guard fires cleanly" zone, not "env itself
+# is E2BIG before the guard can measure it" zone.
+case3_body() {
+  assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+      echo "  PASS: $label"
+    else
+      echo "  FAIL: $label"
+      echo "    expected: '$expected'"
+      echo "    actual:   '$actual'"
+    fi
+  }
+
+  export BIG="$(head -c 3100000 /dev/zero | tr '\0' x)"
+
+  # Capture stderr; use `if` form so set -e does not abort on return 1
+  if err=$(sanitize_launch_env 2>&1 1>/dev/null); then rc=0; else rc=$?; fi
+
+  assert_eq "case3 guard returns non-zero" "1" "$rc"
+
+  has_ticket="$(case "$err" in *'#1879'*) echo yes;; *) echo no;; esac)"
+  assert_eq "case3 stderr contains #1879" "yes" "$has_ticket"
+
+  has_oversized="$(case "$err" in *'too large'*|*'Argument list'*|*'oversized'*) echo yes;; *) echo no;; esac)"
+  assert_eq "case3 stderr names env-size cause" "yes" "$has_oversized"
+}
+
+# --- Run cases ---------------------------------------------------------------
+
+run_case "Case 1: DIRENV_ prune and PATH dedup" bash -c "
+  source '$SCRIPT_DIR/lib-sanitize-launch-env.sh'
+  $(declare -f case1_body)
+  case1_body
+"
+
+run_case "Case 2: no DIRENV_ vars, returns 0 under set -u" bash -c "
+  source '$SCRIPT_DIR/lib-sanitize-launch-env.sh'
+  $(declare -f case2_body)
+  case2_body
+"
+
+run_case "Case 3: over-budget env triggers guard" bash -c "
+  source '$SCRIPT_DIR/lib-sanitize-launch-env.sh'
+  $(declare -f case3_body)
+  case3_body
+"
+
+report_results

--- a/nix/packages/dispatch.nix
+++ b/nix/packages/dispatch.nix
@@ -9,6 +9,10 @@
 pkgs.writeShellScriptBin "dispatch" ''
   set -euo pipefail
 
+  # Strip the unbounded direnv blob before the first execve (git) so a bloated
+  # interactive-shell environment can't trigger E2BIG (#1879). Exec-free builtin.
+  unset -v "''${!DIRENV_@}" 2>/dev/null || true
+
   TOPLEVEL="$(git rev-parse --show-toplevel)"
   TICK="$TOPLEVEL/.claude/skills/dispatch-propagate/scripts/dispatch-tick"
 
@@ -16,6 +20,14 @@ pkgs.writeShellScriptBin "dispatch" ''
     echo "dispatch: dispatch-tick not found or not executable: $TICK" >&2
     exit 1
   fi
+
+  SANITIZE="$TOPLEVEL/.claude/skills/dispatch-propagate/scripts/lib-sanitize-launch-env.sh"
+  if [ ! -r "$SANITIZE" ]; then
+    echo "dispatch: sanitize lib not found: $SANITIZE" >&2
+    exit 1
+  fi
+  . "$SANITIZE"
+  sanitize_launch_env || exit 1
 
   if [ "$#" -eq 0 ]; then
     exec "$TICK" --manual

--- a/nix/packages/office-hours.nix
+++ b/nix/packages/office-hours.nix
@@ -11,6 +11,10 @@
 pkgs.writeShellScriptBin "office-hours" ''
   set -euo pipefail
 
+  # Strip the unbounded direnv blob before the first execve (git) so a bloated
+  # interactive-shell environment can't trigger E2BIG (#1879). Exec-free builtin.
+  unset -v "''${!DIRENV_@}" 2>/dev/null || true
+
   TOPLEVEL="$(git rev-parse --show-toplevel)"
   SCRIPT="$TOPLEVEL/.claude/skills/dispatch-propagate/scripts/office-hours"
 
@@ -18,6 +22,14 @@ pkgs.writeShellScriptBin "office-hours" ''
     echo "office-hours: script not found or not executable: $SCRIPT" >&2
     exit 1
   fi
+
+  SANITIZE="$TOPLEVEL/.claude/skills/dispatch-propagate/scripts/lib-sanitize-launch-env.sh"
+  if [ ! -r "$SANITIZE" ]; then
+    echo "office-hours: sanitize lib not found: $SANITIZE" >&2
+    exit 1
+  fi
+  . "$SANITIZE"
+  sanitize_launch_env || exit 1
 
   exec "$SCRIPT" "$@"
 ''


### PR DESCRIPTION
Closes #1879

## Problem

The `dispatch` launcher (`nix/packages/dispatch.nix`) is a `writeShellScriptBin`
wrapper that `exec`s `dispatch-tick` carrying the launching interactive shell's
**full inherited environment**. A long-lived shell running the direnv hook on
every prompt accumulates an unbounded base64 `DIRENV_DIFF`/`DIRENV_WATCHES` blob
(compounded by triplicated nix-profile `PATH` entries). Eventually argv +
environment approaches `ARG_MAX` (3.2 MB here), and the next `execve` the tick
reaches dies with `Argument list too long` (E2BIG) — surfacing as a cryptic
`rm: Argument list too long` with no signal about the real cause. The autonomous
chain silently dies.

The wrapper's very first real statement today, `TOPLEVEL="$(git rev-parse
--show-toplevel)"`, is itself a command substitution that `execve`s `git`
carrying the bloated environment — so it E2BIGs *before* any sourced library or
external sanitizer could run.

## Fix

Harden the launcher boundary so the tick runs under a sanitized environment,
immune to the interactive shell's accumulated bloat — and, if a clean run is
still impossible, fail with a clear, actionable error naming the env-size cause
instead of a downstream E2BIG.

- **Unit 1** — new sourced library
  `.claude/skills/dispatch-propagate/scripts/lib-sanitize-launch-env.sh` defining
  `sanitize_launch_env()`: re-unsets the `DIRENV_*` family, dedups `PATH`
  (exec-free, first-occurrence-wins), then a size guard that measures
  `env | wc -c` against `getconf ARG_MAX` minus a 128 KB safety margin and fails
  loud with an actionable message if the pruned environment still exceeds budget.

- **Unit 2** — wires both launchers (`nix/packages/dispatch.nix` and
  `nix/packages/office-hours.nix`). The decisive prune must be **exec-free and
  run first**, so the literal first statement after `set -euo pipefail` is the
  shell builtin `unset -v "${!DIRENV_@}"` (prefix-name expansion, future-proof
  across the whole `DIRENV_*` family). Empirically that alone drops the multi-MB
  blob and brings the environment far below `ARG_MAX`, so `git`, the `source`,
  and the final `exec` all then succeed. After `TOPLEVEL` resolves, the wrapper
  sources the library and runs the full `sanitize_launch_env` (defensive
  re-unset + PATH dedup + size guard) before `exec`.

- **Unit 3** — `test-sanitize-launch-env.sh` covers the bug (DIRENV prune + PATH
  dedup + a child `execve` succeeding), empty-prefix `set -u` safety, and the
  over-budget guard (non-zero exit + actionable stderr). Auto-discovered by
  `run-unit-tests.sh`'s `test-*.sh` glob.

## Design notes

- **Denylist, not allowlist.** Dropping the known unbounded `DIRENV_*` family and
  deduping `PATH` preserves everything else (cert/locale/gh-auth/git config)
  automatically. An allowlist re-exec that omitted `SSL_CERT_FILE` /
  `NIX_SSL_CERT_FILE` / `CURL_CA_BUNDLE` (NixOS sets these for TLS) would break
  `gh`/`git` HTTPS — the exact class of downstream-cryptic failure this issue
  exists to kill. A denylist also fails *loud* (via the size guard) rather than
  silent. It is also the only approach implementable purely in builtins before
  the first exec.

- **`office-hours.nix` included deliberately.** The sibling launcher has the
  identical latent bug (same `exec`-with-inherited-env shape, same env-bloated
  source shell). Sanitizing at every launcher boundary is the greenfield design
  and is one PR, so the fix is applied to both wrappers. The issue names only
  `dispatch`; `office-hours` is a called-out extension, not silent scope creep.

- **Scope boundary.** This handles the reported regime: total env near `ARG_MAX`
  while the wrapper itself still starts. If a *single* variable ever exceeds the
  fixed 128 KB per-string `MAX_ARG_STRLEN` cap, the shell→wrapper `execve` fails
  before the wrapper runs at all — a shell-side limit outside this repo's
  control, which the issue explicitly acknowledges.

## Verification

- `test-sanitize-launch-env.sh`: 11/11 passing locally (prune, dedup, child
  execve, empty-prefix safety, guard fires with actionable message).
- Both `writeShellScriptBin` wrappers evaluate to valid derivations with the new
  inline bootstrap + source lines (Nix `''${` escaping confirmed); `nix flake
  check` runs in CI.
