### PR TITLE
ds: build the eight React components and index.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4860,6 +4860,13 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
@@ -4871,6 +4878,27 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
     },
     "node_modules/@types/request": {
       "version": "2.48.13",
@@ -7082,6 +7110,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csv-parse": {
       "version": "5.6.0",
@@ -10507,6 +10542,13 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -10986,6 +11028,19 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -12571,6 +12626,33 @@
         "url": "https://github.com/sponsors/uhop"
       }
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -12890,6 +12972,16 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -14882,7 +14974,16 @@
     },
     "packages/ds": {
       "name": "@commons-systems/ds",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "devDependencies": {
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
     },
     "print": {
       "version": "0.0.0",

--- a/packages/ds/eslint.config.js
+++ b/packages/ds/eslint.config.js
@@ -1,0 +1,1 @@
+export { default } from "@commons-systems/config/eslint";

--- a/packages/ds/package.json
+++ b/packages/ds/package.json
@@ -4,9 +4,11 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "lint": "echo 'CSS-only package, nothing to lint'"
+    "lint": "eslint src/",
+    "test": "vitest run"
   },
   "exports": {
+    ".": "./src/index.ts",
     "./styles.css": "./styles.css",
     "./fonts.css": "./fonts.css",
     "./base.css": "./base.css",
@@ -14,5 +16,14 @@
     "./tokens/typography.css": "./tokens/typography.css",
     "./tokens/spacing.css": "./tokens/spacing.css",
     "./tokens/effects.css": "./tokens/effects.css"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  },
+  "devDependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0"
   }
 }

--- a/packages/ds/src/core/Badge.tsx
+++ b/packages/ds/src/core/Badge.tsx
@@ -1,0 +1,59 @@
+import type { CSSProperties, HTMLAttributes } from "react";
+
+interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: "neutral" | "accent" | "success" | "error";
+}
+
+const toneTokens = {
+  accent: "var(--accent)",
+  success: "var(--success)",
+  error: "var(--error)",
+} as const;
+
+const toneMix = {
+  accent: "color-mix(in srgb, var(--accent) 15%, transparent)",
+  success: "color-mix(in srgb, var(--success) 15%, transparent)",
+  error: "color-mix(in srgb, var(--error) 15%, transparent)",
+} as const;
+
+export function Badge(props: BadgeProps) {
+  const { variant = "neutral", className, style, children, ...rest } = props;
+
+  const base: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    fontSize: "var(--text-xs)",
+    fontFamily: "var(--font-mono)",
+    padding: "0.1rem 0.45rem",
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderRadius: "var(--radius-none)",
+  };
+
+  const resting: CSSProperties =
+    variant === "neutral"
+      ? {
+          ...base,
+          borderColor: "var(--border)",
+          color: "var(--fg)",
+          backgroundColor: "transparent",
+        }
+      : {
+          ...base,
+          borderColor: toneTokens[variant],
+          color: toneTokens[variant],
+          backgroundColor: toneMix[variant],
+        };
+
+  return (
+    <span
+      {...rest}
+      className={["cs-badge", `cs-badge--${variant}`, className]
+        .filter(Boolean)
+        .join(" ")}
+      style={{ ...resting, ...style }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/ds/src/core/Badge.tsx
+++ b/packages/ds/src/core/Badge.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties, HTMLAttributes } from "react";
 
-interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   variant?: "neutral" | "accent" | "success" | "error";
 }
 

--- a/packages/ds/src/core/Button.tsx
+++ b/packages/ds/src/core/Button.tsx
@@ -1,6 +1,6 @@
 import type { ButtonHTMLAttributes, CSSProperties, ReactNode } from "react";
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "ghost";
   size?: "sm" | "md" | "lg";
   icon?: ReactNode;

--- a/packages/ds/src/core/Button.tsx
+++ b/packages/ds/src/core/Button.tsx
@@ -1,0 +1,76 @@
+import type { ButtonHTMLAttributes, CSSProperties, ReactNode } from "react";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary" | "ghost";
+  size?: "sm" | "md" | "lg";
+  icon?: ReactNode;
+}
+
+const sizeStyles: Record<NonNullable<ButtonProps["size"]>, CSSProperties> = {
+  sm: { padding: "0.3rem 0.65rem", fontSize: "var(--text-sm)" },
+  md: { padding: "0.5rem 0.95rem", fontSize: "var(--text-base)" },
+  lg: { padding: "0.65rem 1.25rem", fontSize: "var(--text-lg)" },
+};
+
+const variantStyles: Record<
+  NonNullable<ButtonProps["variant"]>,
+  CSSProperties
+> = {
+  primary: {
+    backgroundColor: "var(--accent)",
+    color: "var(--text-on-accent)",
+    borderColor: "var(--accent)",
+  },
+  secondary: {
+    backgroundColor: "transparent",
+    color: "var(--fg)",
+    borderColor: "var(--border)",
+  },
+  ghost: {
+    backgroundColor: "transparent",
+    color: "var(--accent)",
+    borderColor: "transparent",
+  },
+};
+
+export function Button(props: ButtonProps) {
+  const {
+    variant = "secondary",
+    size = "md",
+    icon,
+    type = "button",
+    className,
+    style,
+    children,
+    ...rest
+  } = props;
+
+  const resting: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "var(--space-2)",
+    fontFamily: "var(--font-mono)",
+    fontWeight: "var(--weight-bold)",
+    borderStyle: "solid",
+    borderWidth: "1px",
+    borderRadius: "var(--radius-none)",
+    transition: "var(--transition-color)",
+    cursor: "pointer",
+    ...sizeStyles[size],
+    ...variantStyles[variant],
+  };
+
+  return (
+    <button
+      {...rest}
+      type={type}
+      className={["cs-btn", `cs-btn--${variant}`, className]
+        .filter(Boolean)
+        .join(" ")}
+      style={{ ...resting, ...style }}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}

--- a/packages/ds/src/core/Card.tsx
+++ b/packages/ds/src/core/Card.tsx
@@ -1,0 +1,36 @@
+import type { CSSProperties, ElementType, HTMLAttributes } from "react";
+
+interface CardProps extends HTMLAttributes<HTMLElement> {
+  as?: ElementType;
+  interactive?: boolean;
+}
+
+export function Card(props: CardProps) {
+  const { as: Tag = "div", interactive, className, style, ...rest } = props;
+
+  const isInteractive = interactive || Tag === "a" || !!rest.onClick;
+
+  const resting: CSSProperties = {
+    backgroundColor: "var(--surface)",
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: "var(--border)",
+    borderRadius: "var(--radius-none)",
+    padding: "var(--space-4)",
+    transition: "var(--transition-color)",
+  };
+
+  return (
+    <Tag
+      {...rest}
+      className={[
+        "cs-card",
+        isInteractive ? "cs-card--interactive" : "",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      style={{ ...resting, ...style }}
+    />
+  );
+}

--- a/packages/ds/src/core/Card.tsx
+++ b/packages/ds/src/core/Card.tsx
@@ -10,6 +10,37 @@ export function Card(props: CardProps) {
 
   const isInteractive = interactive || Tag === "a" || !!rest.onClick;
 
+  // Accessibility/safety defaults applied to the rendered element, each only
+  // when the consumer did not already supply it. Kept in a separate object
+  // because `type` is not part of HTMLAttributes<HTMLElement>.
+  const extraProps: { type?: "button"; tabIndex?: number; role?: string } = {};
+
+  // A bare <button> defaults to type="submit", which submits an enclosing
+  // form on click. Default it to "button" unless the consumer set a type.
+  if (Tag === "button" && (rest as { type?: unknown }).type === undefined) {
+    extraProps.type = "button";
+  }
+
+  // When interactivity is auto-detected on a non-interactive element (e.g. the
+  // default <div>), make it keyboard-focusable and expose a button role so the
+  // onClick handler and :focus styles are reachable by keyboard users. Native
+  // interactive elements (a, button, input, select, textarea) already provide
+  // this. Respect any values the consumer supplied.
+  const nativelyInteractive =
+    Tag === "a" ||
+    Tag === "button" ||
+    Tag === "input" ||
+    Tag === "select" ||
+    Tag === "textarea";
+  if (isInteractive && !nativelyInteractive) {
+    if (rest.tabIndex === undefined) {
+      extraProps.tabIndex = 0;
+    }
+    if (rest.role === undefined) {
+      extraProps.role = "button";
+    }
+  }
+
   const resting: CSSProperties = {
     backgroundColor: "var(--surface)",
     borderWidth: "1px",
@@ -23,6 +54,7 @@ export function Card(props: CardProps) {
   return (
     <Tag
       {...rest}
+      {...extraProps}
       className={[
         "cs-card",
         isInteractive ? "cs-card--interactive" : "",

--- a/packages/ds/src/core/Card.tsx
+++ b/packages/ds/src/core/Card.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties, ElementType, HTMLAttributes } from "react";
 
-interface CardProps extends HTMLAttributes<HTMLElement> {
+export interface CardProps extends HTMLAttributes<HTMLElement> {
   as?: ElementType;
   interactive?: boolean;
 }

--- a/packages/ds/src/core/Metric.tsx
+++ b/packages/ds/src/core/Metric.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
 
-interface MetricProps extends HTMLAttributes<HTMLDivElement> {
+export interface MetricProps extends HTMLAttributes<HTMLDivElement> {
   label: ReactNode;
   value: ReactNode;
   delta?: ReactNode;

--- a/packages/ds/src/core/Metric.tsx
+++ b/packages/ds/src/core/Metric.tsx
@@ -1,0 +1,63 @@
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+
+interface MetricProps extends HTMLAttributes<HTMLDivElement> {
+  label: ReactNode;
+  value: ReactNode;
+  delta?: ReactNode;
+  deltaTone?: "favorable" | "unfavorable";
+}
+
+export function Metric(props: MetricProps) {
+  const { label, value, delta, deltaTone, className, style, ...rest } = props;
+
+  const resting: CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--space-2)",
+    backgroundColor: "var(--surface)",
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: "var(--border)",
+    borderRadius: "var(--radius-lg)",
+    padding: "var(--space-4)",
+    minWidth: "10rem",
+    fontFamily: "var(--font-mono)",
+  };
+
+  const labelStyle: CSSProperties = {
+    fontSize: "var(--text-xs)",
+    textTransform: "uppercase",
+    letterSpacing: "var(--tracking-heading)",
+    opacity: 0.7,
+  };
+
+  const valueStyle: CSSProperties = {
+    fontSize: "var(--text-xl)",
+    fontWeight: "var(--weight-bold)",
+    fontVariantNumeric: "tabular-nums",
+  };
+
+  const deltaColor =
+    deltaTone === "favorable"
+      ? "var(--favorable)"
+      : deltaTone === "unfavorable"
+        ? "var(--unfavorable)"
+        : "var(--muted)";
+
+  const deltaStyle: CSSProperties = {
+    fontSize: "var(--text-sm)",
+    color: deltaColor,
+  };
+
+  return (
+    <div
+      {...rest}
+      className={["cs-metric", className].filter(Boolean).join(" ")}
+      style={{ ...resting, ...style }}
+    >
+      <span style={labelStyle}>{label}</span>
+      <span style={valueStyle}>{value}</span>
+      {delta !== undefined && <span style={deltaStyle}>{delta}</span>}
+    </div>
+  );
+}

--- a/packages/ds/src/forms/Checkbox.tsx
+++ b/packages/ds/src/forms/Checkbox.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties, InputHTMLAttributes, ReactNode } from "react";
 
-interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   label: ReactNode;
   type?: "checkbox" | "radio";
 }

--- a/packages/ds/src/forms/Checkbox.tsx
+++ b/packages/ds/src/forms/Checkbox.tsx
@@ -1,0 +1,35 @@
+import type { CSSProperties, InputHTMLAttributes, ReactNode } from "react";
+
+interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: ReactNode;
+  type?: "checkbox" | "radio";
+}
+
+export function Checkbox(props: CheckboxProps) {
+  const { label, type = "checkbox", className, style, ...rest } = props;
+
+  const labelResting: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "var(--space-2)",
+    fontFamily: "var(--font-mono)",
+    fontSize: "var(--text-sm)",
+    cursor: "pointer",
+  };
+
+  const inputResting: CSSProperties = {
+    accentColor: "var(--accent)",
+    width: "1rem",
+    height: "1rem",
+  };
+
+  return (
+    <label
+      className={["cs-checkbox", className].filter(Boolean).join(" ")}
+      style={{ ...labelResting, ...style }}
+    >
+      <input {...rest} type={type} style={inputResting} />
+      {label}
+    </label>
+  );
+}

--- a/packages/ds/src/forms/Input.tsx
+++ b/packages/ds/src/forms/Input.tsx
@@ -22,6 +22,8 @@ export function Input(props: InputProps) {
 
   const generated = useId();
   const id = idProp ?? generated;
+  const descId = `${id}-desc`;
+  const hasDescription = !!(helper || error);
 
   const fieldResting: CSSProperties = {
     width: "100%",
@@ -41,6 +43,7 @@ export function Input(props: InputProps) {
       {...rest}
       id={id}
       aria-invalid={!!error || undefined}
+      aria-describedby={hasDescription ? descId : undefined}
       className={["cs-input", className].filter(Boolean).join(" ")}
       style={{ ...fieldResting, ...style }}
     />
@@ -73,6 +76,7 @@ export function Input(props: InputProps) {
       {input}
       {error || helper ? (
         <span
+          id={descId}
           style={{
             fontSize: "var(--text-xs)",
             color: error ? "var(--error)" : "var(--muted)",

--- a/packages/ds/src/forms/Input.tsx
+++ b/packages/ds/src/forms/Input.tsx
@@ -1,0 +1,86 @@
+import { useId } from "react";
+import type { CSSProperties, InputHTMLAttributes, ReactNode } from "react";
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: ReactNode;
+  helper?: ReactNode;
+  error?: ReactNode;
+  wrapStyle?: CSSProperties;
+}
+
+export function Input(props: InputProps) {
+  const {
+    label,
+    helper,
+    error,
+    wrapStyle,
+    className,
+    style,
+    id: idProp,
+    ...rest
+  } = props;
+
+  const generated = useId();
+  const id = idProp ?? generated;
+
+  const fieldResting: CSSProperties = {
+    width: "100%",
+    fontFamily: "var(--font-mono)",
+    fontSize: "var(--text-sm)",
+    backgroundColor: "var(--surface)",
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: error ? "var(--error)" : "var(--border)",
+    borderRadius: "var(--radius-sm)",
+    padding: "0.4rem 0.6rem",
+    color: "var(--fg)",
+  };
+
+  const input = (
+    <input
+      {...rest}
+      id={id}
+      aria-invalid={!!error || undefined}
+      className={["cs-input", className].filter(Boolean).join(" ")}
+      style={{ ...fieldResting, ...style }}
+    />
+  );
+
+  if (!(label || helper || error)) {
+    return input;
+  }
+
+  const wrapResting: CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--space-2)",
+  };
+
+  const labelResting: CSSProperties = {
+    fontSize: "var(--text-xs)",
+    textTransform: "uppercase",
+    letterSpacing: "var(--tracking-heading)",
+    color: "var(--muted)",
+  };
+
+  return (
+    <div className="cs-field" style={{ ...wrapResting, ...wrapStyle }}>
+      {label ? (
+        <label htmlFor={id} style={labelResting}>
+          {label}
+        </label>
+      ) : null}
+      {input}
+      {error || helper ? (
+        <span
+          style={{
+            fontSize: "var(--text-xs)",
+            color: error ? "var(--error)" : "var(--muted)",
+          }}
+        >
+          {error ?? helper}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ds/src/forms/Input.tsx
+++ b/packages/ds/src/forms/Input.tsx
@@ -1,7 +1,7 @@
 import { useId } from "react";
 import type { CSSProperties, InputHTMLAttributes, ReactNode } from "react";
 
-interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: ReactNode;
   helper?: ReactNode;
   error?: ReactNode;

--- a/packages/ds/src/forms/Select.tsx
+++ b/packages/ds/src/forms/Select.tsx
@@ -1,0 +1,107 @@
+import { useId } from "react";
+import type { CSSProperties, ReactNode, SelectHTMLAttributes } from "react";
+
+type Option = string | { value: string; label: string };
+
+interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  label?: ReactNode;
+  helper?: ReactNode;
+  error?: ReactNode;
+  options: Option[];
+  wrapStyle?: CSSProperties;
+}
+
+function normalize(opt: Option): { value: string; label: string } {
+  return typeof opt === "string" ? { value: opt, label: opt } : opt;
+}
+
+export function Select(props: SelectProps) {
+  const {
+    label,
+    helper,
+    error,
+    options,
+    wrapStyle,
+    className,
+    style,
+    children,
+    id: idProp,
+    ...rest
+  } = props;
+
+  const generated = useId();
+  const id = idProp ?? generated;
+
+  const fieldResting: CSSProperties = {
+    width: "100%",
+    fontFamily: "var(--font-mono)",
+    fontSize: "var(--text-sm)",
+    backgroundColor: "var(--surface)",
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: error ? "var(--error)" : "var(--border)",
+    borderRadius: "var(--radius-sm)",
+    padding: "0.4rem 0.6rem",
+    color: "var(--fg)",
+  };
+
+  const optionEls = options.map((opt) => {
+    const { value, label: optLabel } = normalize(opt);
+    return (
+      <option key={value} value={value}>
+        {optLabel}
+      </option>
+    );
+  });
+
+  const control = (
+    <select
+      {...rest}
+      id={id}
+      aria-invalid={!!error || undefined}
+      className={["cs-select", className].filter(Boolean).join(" ")}
+      style={{ ...fieldResting, ...style }}
+    >
+      {optionEls}
+      {children}
+    </select>
+  );
+
+  if (!(label || helper || error)) {
+    return control;
+  }
+
+  const wrapResting: CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--space-2)",
+  };
+
+  const labelResting: CSSProperties = {
+    fontSize: "var(--text-xs)",
+    textTransform: "uppercase",
+    letterSpacing: "var(--tracking-heading)",
+    color: "var(--muted)",
+  };
+
+  return (
+    <div className="cs-field" style={{ ...wrapResting, ...wrapStyle }}>
+      {label ? (
+        <label htmlFor={id} style={labelResting}>
+          {label}
+        </label>
+      ) : null}
+      {control}
+      {error || helper ? (
+        <span
+          style={{
+            fontSize: "var(--text-xs)",
+            color: error ? "var(--error)" : "var(--muted)",
+          }}
+        >
+          {error ?? helper}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ds/src/forms/Select.tsx
+++ b/packages/ds/src/forms/Select.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties, ReactNode, SelectHTMLAttributes } from "react";
 
 type Option = string | { value: string; label: string };
 
-interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   label?: ReactNode;
   helper?: ReactNode;
   error?: ReactNode;

--- a/packages/ds/src/forms/Select.tsx
+++ b/packages/ds/src/forms/Select.tsx
@@ -54,11 +54,14 @@ export function Select(props: SelectProps) {
     );
   });
 
+  const descId = `${id}-desc`;
+
   const control = (
     <select
       {...rest}
       id={id}
       aria-invalid={!!error || undefined}
+      aria-describedby={error || helper ? descId : undefined}
       className={["cs-select", className].filter(Boolean).join(" ")}
       style={{ ...fieldResting, ...style }}
     >
@@ -94,6 +97,7 @@ export function Select(props: SelectProps) {
       {control}
       {error || helper ? (
         <span
+          id={descId}
           style={{
             fontSize: "var(--text-xs)",
             color: error ? "var(--error)" : "var(--muted)",

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -1,0 +1,21 @@
+// core
+export { Button } from "./core/Button.tsx";
+export type { ButtonProps } from "./core/Button.tsx";
+export { Badge } from "./core/Badge.tsx";
+export type { BadgeProps } from "./core/Badge.tsx";
+export { Card } from "./core/Card.tsx";
+export type { CardProps } from "./core/Card.tsx";
+export { Metric } from "./core/Metric.tsx";
+export type { MetricProps } from "./core/Metric.tsx";
+
+// forms
+export { Input } from "./forms/Input.tsx";
+export type { InputProps } from "./forms/Input.tsx";
+export { Select } from "./forms/Select.tsx";
+export type { SelectProps } from "./forms/Select.tsx";
+export { Checkbox } from "./forms/Checkbox.tsx";
+export type { CheckboxProps } from "./forms/Checkbox.tsx";
+
+// navigation
+export { Nav } from "./navigation/Nav.tsx";
+export type { NavProps } from "./navigation/Nav.tsx";

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -18,4 +18,4 @@ export type { CheckboxProps } from "./forms/Checkbox.tsx";
 
 // navigation
 export { Nav } from "./navigation/Nav.tsx";
-export type { NavProps } from "./navigation/Nav.tsx";
+export type { NavProps, NavLink } from "./navigation/Nav.tsx";

--- a/packages/ds/src/navigation/Nav.tsx
+++ b/packages/ds/src/navigation/Nav.tsx
@@ -1,0 +1,56 @@
+import type { HTMLAttributes, ReactNode, CSSProperties } from "react";
+
+interface NavLink {
+  href: string;
+  label: string;
+  align?: "end";
+}
+
+interface NavProps extends HTMLAttributes<HTMLElement> {
+  links: NavLink[];
+  current?: string;
+  end?: ReactNode;
+}
+
+export function Nav(props: NavProps) {
+  const { links, current, end, className, style, ...rest } = props;
+
+  const resting: CSSProperties = {
+    display: "flex",
+    alignItems: "baseline",
+    gap: "var(--space-4)",
+    fontFamily: "var(--font-mono)",
+  };
+
+  return (
+    <nav
+      {...rest}
+      className={["cs-nav", className].filter(Boolean).join(" ")}
+      style={{ ...resting, ...style }}
+    >
+      {links.map((link) => {
+        const isCurrent =
+          link.href === current || link.label === current;
+        const linkStyle: CSSProperties = {
+          color: "var(--accent)",
+          ...(isCurrent
+            ? { textDecoration: "underline", textDecorationThickness: "2px" }
+            : {}),
+          ...(link.align === "end" ? { marginLeft: "auto" } : {}),
+        };
+        return (
+          <a
+            key={link.href}
+            href={link.href}
+            className="cs-nav__link"
+            style={linkStyle}
+            {...(isCurrent ? { "aria-current": "page" as const } : {})}
+          >
+            {link.label}
+          </a>
+        );
+      })}
+      {end != null && <span style={{ marginLeft: "auto" }}>{end}</span>}
+    </nav>
+  );
+}

--- a/packages/ds/src/navigation/Nav.tsx
+++ b/packages/ds/src/navigation/Nav.tsx
@@ -6,7 +6,7 @@ interface NavLink {
   align?: "end";
 }
 
-interface NavProps extends HTMLAttributes<HTMLElement> {
+export interface NavProps extends HTMLAttributes<HTMLElement> {
   links: NavLink[];
   current?: string;
   end?: ReactNode;

--- a/packages/ds/src/navigation/Nav.tsx
+++ b/packages/ds/src/navigation/Nav.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes, ReactNode, CSSProperties } from "react";
 
-interface NavLink {
+export interface NavLink {
   href: string;
   label: string;
   align?: "end";
@@ -22,35 +22,51 @@ export function Nav(props: NavProps) {
     fontFamily: "var(--font-mono)",
   };
 
+  const startLinks = links.filter((link) => link.align !== "end");
+  const endLinks = links.filter((link) => link.align === "end");
+  const hasEndGroup = endLinks.length > 0 || end != null;
+
+  const renderLink = (link: NavLink) => {
+    const isCurrent = link.href === current;
+    const linkStyle: CSSProperties = {
+      color: "var(--accent)",
+      ...(isCurrent
+        ? { textDecoration: "underline", textDecorationThickness: "2px" }
+        : {}),
+    };
+    return (
+      <a
+        key={link.href}
+        href={link.href}
+        className="cs-nav__link"
+        style={linkStyle}
+        {...(isCurrent ? { "aria-current": "page" as const } : {})}
+      >
+        {link.label}
+      </a>
+    );
+  };
+
   return (
     <nav
       {...rest}
       className={["cs-nav", className].filter(Boolean).join(" ")}
       style={{ ...resting, ...style }}
     >
-      {links.map((link) => {
-        const isCurrent =
-          link.href === current || link.label === current;
-        const linkStyle: CSSProperties = {
-          color: "var(--accent)",
-          ...(isCurrent
-            ? { textDecoration: "underline", textDecorationThickness: "2px" }
-            : {}),
-          ...(link.align === "end" ? { marginLeft: "auto" } : {}),
-        };
-        return (
-          <a
-            key={link.href}
-            href={link.href}
-            className="cs-nav__link"
-            style={linkStyle}
-            {...(isCurrent ? { "aria-current": "page" as const } : {})}
-          >
-            {link.label}
-          </a>
-        );
-      })}
-      {end != null && <span style={{ marginLeft: "auto" }}>{end}</span>}
+      {startLinks.map(renderLink)}
+      {hasEndGroup && (
+        <span
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: "var(--space-4)",
+            marginLeft: "auto",
+          }}
+        >
+          {endLinks.map(renderLink)}
+          {end != null && <span>{end}</span>}
+        </span>
+      )}
     </nav>
   );
 }

--- a/packages/ds/test/components.test.tsx
+++ b/packages/ds/test/components.test.tsx
@@ -47,6 +47,21 @@ describe("cs-* class names", () => {
     expect(html).toContain("cs-card--interactive");
   });
 
+  it("polymorphic Card with as='a' renders an <a> and is interactive", () => {
+    const html = renderToStaticMarkup(
+      <Card as="a" href="/">
+        Content
+      </Card>,
+    );
+    expect(html).toMatch(/<a[^>]*>/);
+    expect(html).toContain("cs-card--interactive");
+  });
+
+  it("Card with onClick is auto-detected as interactive", () => {
+    const html = renderToStaticMarkup(<Card onClick={() => {}}>Content</Card>);
+    expect(html).toContain("cs-card--interactive");
+  });
+
   it("Metric renders cs-metric", () => {
     const html = renderToStaticMarkup(<Metric label="Revenue" value="$1k" />);
     expect(html).toContain("cs-metric");
@@ -66,6 +81,22 @@ describe("cs-* class names", () => {
     expect(html).toContain("cs-field");
   });
 
+  it("Input in error state sets aria-invalid, error token, and message", () => {
+    const html = renderToStaticMarkup(<Input error="Required" />);
+    expect(html).toContain('aria-invalid="true"');
+    expect(html).toContain("var(--error)");
+    expect(html).toContain("Required");
+  });
+
+  it("Select in error state sets aria-invalid, error token, and message", () => {
+    const html = renderToStaticMarkup(
+      <Select error="Required" options={[]} />,
+    );
+    expect(html).toContain('aria-invalid="true"');
+    expect(html).toContain("var(--error)");
+    expect(html).toContain("Required");
+  });
+
   it("Checkbox renders cs-checkbox", () => {
     const html = renderToStaticMarkup(<Checkbox label="Agree" />);
     expect(html).toContain("cs-checkbox");
@@ -77,6 +108,13 @@ describe("cs-* class names", () => {
     );
     expect(html).toContain("cs-nav");
     expect(html).toContain("cs-nav__link");
+  });
+
+  it("Nav marks the current link with aria-current='page'", () => {
+    const html = renderToStaticMarkup(
+      <Nav links={[{ href: "/a", label: "A" }]} current="/a" />,
+    );
+    expect(html).toContain('aria-current="page"');
   });
 });
 

--- a/packages/ds/test/components.test.tsx
+++ b/packages/ds/test/components.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  Button,
+  Badge,
+  Card,
+  Metric,
+  Input,
+  Select,
+  Checkbox,
+  Nav,
+} from "../src/index.ts";
+
+describe("all eight components importable from the barrel", () => {
+  it("each export is a function", () => {
+    expect(typeof Button).toBe("function");
+    expect(typeof Badge).toBe("function");
+    expect(typeof Card).toBe("function");
+    expect(typeof Metric).toBe("function");
+    expect(typeof Input).toBe("function");
+    expect(typeof Select).toBe("function");
+    expect(typeof Checkbox).toBe("function");
+    expect(typeof Nav).toBe("function");
+  });
+});
+
+describe("cs-* class names", () => {
+  it("Button renders cs-btn and cs-btn--primary", () => {
+    const html = renderToStaticMarkup(<Button variant="primary">Go</Button>);
+    expect(html).toContain("cs-btn");
+    expect(html).toContain("cs-btn--primary");
+  });
+
+  it("Badge renders cs-badge and cs-badge--accent", () => {
+    const html = renderToStaticMarkup(<Badge variant="accent">New</Badge>);
+    expect(html).toContain("cs-badge");
+    expect(html).toContain("cs-badge--accent");
+  });
+
+  it("Card renders cs-card", () => {
+    const html = renderToStaticMarkup(<Card>Content</Card>);
+    expect(html).toContain("cs-card");
+  });
+
+  it("interactive Card renders cs-card--interactive", () => {
+    const html = renderToStaticMarkup(<Card interactive>Content</Card>);
+    expect(html).toContain("cs-card--interactive");
+  });
+
+  it("Metric renders cs-metric", () => {
+    const html = renderToStaticMarkup(<Metric label="Revenue" value="$1k" />);
+    expect(html).toContain("cs-metric");
+  });
+
+  it("Input with label renders cs-input and cs-field", () => {
+    const html = renderToStaticMarkup(<Input label="Email" />);
+    expect(html).toContain("cs-input");
+    expect(html).toContain("cs-field");
+  });
+
+  it("Select with label renders cs-select and cs-field", () => {
+    const html = renderToStaticMarkup(
+      <Select label="Color" options={["a", "b"]} />,
+    );
+    expect(html).toContain("cs-select");
+    expect(html).toContain("cs-field");
+  });
+
+  it("Checkbox renders cs-checkbox", () => {
+    const html = renderToStaticMarkup(<Checkbox label="Agree" />);
+    expect(html).toContain("cs-checkbox");
+  });
+
+  it("Nav renders cs-nav and cs-nav__link", () => {
+    const html = renderToStaticMarkup(
+      <Nav links={[{ href: "/", label: "Home" }]} />,
+    );
+    expect(html).toContain("cs-nav");
+    expect(html).toContain("cs-nav__link");
+  });
+});
+
+describe("resting styles from tokens", () => {
+  it("primary Button markup contains var(--accent)", () => {
+    const html = renderToStaticMarkup(<Button variant="primary">Go</Button>);
+    expect(html).toContain("var(--accent)");
+  });
+});
+
+describe("...rest passthrough", () => {
+  it("data-* attribute on Button appears in its markup", () => {
+    const html = renderToStaticMarkup(
+      <Button data-testid="b">Go</Button>,
+    );
+    expect(html).toContain('data-testid="b"');
+  });
+
+  it("Checkbox rest props land on the <input>, not the label", () => {
+    const html = renderToStaticMarkup(
+      <Checkbox label="Agree" data-testid="cb" />,
+    );
+    expect(html).toMatch(/<input[^>]*data-testid="cb"/);
+  });
+});

--- a/packages/ds/tsconfig.json
+++ b/packages/ds/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@commons-systems/config/tsconfig.lib.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src", "test"]
+}

--- a/packages/ds/vite.config.ts
+++ b/packages/ds/vite.config.ts
@@ -1,0 +1,6 @@
+import { createLibConfig } from "@commons-systems/config/vite";
+
+export default createLibConfig({
+  esbuild: { jsx: "automatic", jsxImportSource: "react" },
+  test: { include: ["test/**/*.test.{ts,tsx}"] },
+});


### PR DESCRIPTION
Closes #1867

Builds the eight React components for `@commons-systems/ds` and the `src/index.ts`
barrel — the **first React/`.tsx` code in the monorepo**. The package was
previously CSS-only (tokens, `base.css`, fonts); this adds the component layer on
top of it.

## What's here

Eight stateless components migrated to React under `packages/ds/src/`:

- **core** — `Button`, `Badge`, `Card`, `Metric`
- **forms** — `Input`, `Select`, `Checkbox`
- **navigation** — `Nav`

plus `src/index.ts`, which re-exports all eight (grouped by folder) and their
eight `…Props` types.

Each component emits its `cs-*` class(es) and applies only its **resting** styles
inline via the existing design tokens. Every hover / press / focus state already
lives in `packages/ds/base.css` keyed on those `cs-*` classes — the components add
**no** JS handlers and do not restate those states. `Metric` sets
`borderRadius: var(--radius-lg)` inline specifically to override `base.css`'s
universal `*{border-radius:var(--radius-none)}` reset.

Shared authoring contract (established in core, reused everywhere): `cs-*` classes
are always emitted and the caller's `className` is appended; the caller's `style`
is spread last so each key wins; `{...rest}` is spread first so the explicitly
merged `className`/`style` can't be clobbered. `Input`/`Select` reconcile a
caller-supplied `id` with a `useId()` fallback so the control `id` and the
`<label htmlFor>` always match; `Checkbox` spreads `...rest` onto the `<input>`
(not the wrapping label).

## Tooling

`packages/ds` becomes a real lib package: `tsconfig.json` (`jsx: "react-jsx"` +
the `DOM` lib), `vite.config.ts` (esbuild automatic JSX runtime + a `.tsx` test
glob), an `eslint.config.js` re-export, and a `package.json` that adds the `.`
barrel export, the React devDeps, and a `react >=18` peer. The root
`package-lock.json` is regenerated (React is new to the repo).

## Verification

Run from the worktree root, all green:

- **Typecheck** — `npx tsc -p packages/ds/tsconfig.json`
- **Lint** — `npm run -w packages/ds lint` (`eslint src/`; tseslint parses `.tsx`)
- **Test** — `npm run -w packages/ds test` (13 tests). The smoke test renders
  every component via `renderToStaticMarkup` and asserts the `cs-*` classes, inline
  token presence (`var(--accent)` on a primary `Button`), `...rest` passthrough to
  the correct root (for `Checkbox`, onto the `<input>`), and that all eight resolve
  from the barrel.

**Gate gap (review-only):** none of the three gates prove "all hover/press/focus
live in `base.css`, not JS handlers" — that invariant is verified by review, not
machine-checked.

## Precedent decisions for the downstream consumer migrations (#1868 / #1869 / #1870 / #1873)

This is the first React code in the repo, so it sets two conventions the whole
design-system epic (#1864) inherits. Downstream migrations must adopt both
knowingly:

- **React version pin — React 18.3.1.** This package pins `react`/`react-dom` as
  `^18.3.1` devDeps and declares a `react >=18` peer (only `react` is a peer;
  `react-dom`/`@types/react-dom` are test-only — components import solely from
  `react`, and `react-dom/server` is used only by the smoke test). `ds` sets the
  React version for the whole epic.

- **Automatic-JSX-runtime footgun.** Components ship as raw `.tsx` with **no**
  `import React` (automatic runtime — required to keep `noUnusedLocals` /
  `no-unused-vars` clean). A consumer whose bundler uses esbuild's *classic* JSX
  transform will **fail to compile** these. Consumer apps must configure
  `jsx: "automatic"` (esbuild) / `"jsx": "react-jsx"` (tsconfig).

## Note on scope

Beyond the planned barrel, each component's `…Props` interface is now `export`ed
and re-exported from `index.ts` via `export type` (isolatedModules-safe). The plan
anticipated type re-exports; exporting the prop types makes the package's public
type API complete so the downstream consumer migrations can type their usage. No
other scope change.
