### PR TITLE
acceptance gate: resolve nix Playwright browsers when PLAYWRIGHT_BROWSERS_PATH is unset

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -491,6 +491,32 @@ ensure_deps() {
   fi
 }
 
+# Ensure Playwright browsers are resolvable. When PLAYWRIGHT_BROWSERS_PATH is
+# unset and nix is available (NixOS), re-exec the calling script under
+# `nix develop --command` so the devShell shellHook exports the nix-provisioned
+# browsers path. When nix is unavailable (e.g. CI on ubuntu), return so the
+# caller's `npx playwright install --with-deps chromium` fallback runs.
+#
+# Call as: ensure_playwright_browsers "$0" "$@"
+ensure_playwright_browsers() {
+  if [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ]; then
+    return 0
+  fi
+  if command -v nix >/dev/null 2>&1; then
+    if [ -n "${_DISPATCH_NIX_REEXEC:-}" ]; then
+      echo "ERROR: re-exec'd under 'nix develop' but PLAYWRIGHT_BROWSERS_PATH is still unset." >&2
+      echo "       Enter the dev shell ('direnv allow', or 'nix develop') and retry." >&2
+      return 1
+    fi
+    local flake_dir
+    flake_dir="$(git rev-parse --show-toplevel)"
+    export _DISPATCH_NIX_REEXEC=1
+    exec nix develop "$flake_dir" --command "$@"
+  fi
+  # nix unavailable (CI ubuntu): caller's npx fallback handles install
+  return 0
+}
+
 # Extract the app name from the app directory path.
 # Args: $1 = app directory (e.g. "hello" or "/path/to/hello")
 get_app_name() {

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -509,7 +509,14 @@ ensure_playwright_browsers() {
       return 1
     fi
     local flake_dir
-    flake_dir="$(git rev-parse --show-toplevel)"
+    flake_dir="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+      echo "ERROR: could not determine repo root; ensure you are inside a git repository" >&2
+      return 1
+    }
+    [ -n "$flake_dir" ] || {
+      echo "ERROR: git rev-parse --show-toplevel returned empty string" >&2
+      return 1
+    }
     export _DISPATCH_NIX_REEXEC=1
     exec nix develop "$flake_dir" --command "$@"
   fi

--- a/.claude/skills/dispatch-propagate/scripts/run-acceptance-tests.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-acceptance-tests.sh
@@ -11,6 +11,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=lib.sh
 source "$SCRIPT_DIR/lib.sh"
 
+# Resolve nix-provisioned Playwright browsers when PLAYWRIGHT_BROWSERS_PATH is
+# unset (re-execs under `nix develop` on NixOS); no-op when the var is set or
+# nix is absent, leaving the npx fallback below to run.
+ensure_playwright_browsers "$0" "$@"
+
 APP_NAME=$(get_app_name "$APP_DIR")
 EMULATOR_PROJECT_ID=$(get_emulator_project_id)
 

--- a/.claude/skills/dispatch-propagate/scripts/run-smoke-tests.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-smoke-tests.sh
@@ -11,6 +11,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=lib.sh
 source "$SCRIPT_DIR/lib.sh"
 
+# Resolve nix-provisioned Playwright browsers when PLAYWRIGHT_BROWSERS_PATH is
+# unset (re-execs under `nix develop` on NixOS); no-op when the var is set or
+# nix is absent, leaving the npx fallback below to run.
+ensure_playwright_browsers "$0" "$@"
+
 ensure_deps
 
 cd "$REPO_ROOT/$APP_DIR"


### PR DESCRIPTION
Closes #1853

## Problem

The local QA acceptance gate scripts fall back to
`npx playwright install --with-deps chromium` when `PLAYWRIGHT_BROWSERS_PATH`
is unset. On NixOS, `--with-deps` shells out to `apt-get`, which does not exist,
so the install fails with `apt-get: command not found` and the gate reports a
misleading "BLOCKED — Playwright cannot install Chromium".

The browsers are in fact already provisioned system-wide via nix — `flake.nix`
lists `playwright-driver.browsers` in the devShell and the shellHook exports
`PLAYWRIGHT_BROWSERS_PATH`. Only that env var is missing in the non-interactive
dispatch shell, which never enters `nix develop` / direnv.

This was hit during QA of PR #1839 (#1039).

## Fix

A shared `ensure_playwright_browsers` helper in `lib.sh`. When
`PLAYWRIGHT_BROWSERS_PATH` is unset and `nix` is available (NixOS), it re-execs
the calling script under `nix develop --command`, whose shellHook exports the
exact nix-provisioned browsers path. When `nix` is unavailable (e.g. CI on
ubuntu, where `apt-get` exists), it returns so the existing `npx playwright
install --with-deps chromium` fallback runs unchanged.

Re-exec gets zero-drift for free: the re-run inherits the shellHook export,
which resolves against the flake's *locked* nixpkgs, so the resolved chromium
revision is exactly the one the version-sync guard validates — no new flake
output to maintain. An infinite-loop guard (`_DISPATCH_NIX_REEXEC`) turns a
still-unset var on the second pass into a clear, actionable error instead of a
loop. The approach matches the repo's existing `nix develop --command`
invocation pattern (`.github/workflows/unit-tests.yml`).

## Changes

- **`lib.sh`** — add the `ensure_playwright_browsers` helper next to
  `ensure_deps`.
- **`run-acceptance-tests.sh`** — call the helper once at the top, after
  sourcing `lib.sh`. This single guard covers both existing fallback branches
  (external-base-url and emulator).
- **`run-smoke-tests.sh`** — same wiring; it carries the identical
  apt-get-prone fallback and is hit by the same NixOS failure off-CI.

The existing `npx playwright install --with-deps chromium` blocks are left
unchanged — they remain the nix-less (CI) fallback.
