### PR TITLE
dispatch-emit-outcome: reject 0 for --issue and --pr

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome
@@ -190,7 +190,15 @@ _require_nonneg_int() {
   fi
 }
 
-_require_nonneg_int issue               "$ISSUE"
+_require_pos_int() {
+  local flag="$1" val="$2"
+  if [[ ! "$val" =~ ^[1-9][0-9]*$ ]]; then
+    echo "dispatch-emit-outcome: --${flag} must be a positive integer (>= 1), got: $val" >&2
+    exit 2
+  fi
+}
+
+_require_pos_int issue               "$ISSUE"
 _require_nonneg_int findings-surfaced   "$FINDINGS_SURFACED"
 _require_nonneg_int findings-actionable "$FINDINGS_ACTIONABLE"
 _require_nonneg_int fixes-applied       "$FIXES_APPLIED"
@@ -198,7 +206,7 @@ _require_nonneg_int followups-filed     "$FOLLOWUPS_FILED"
 _require_nonneg_int subagents-launched  "$SUBAGENTS_LAUNCHED"
 
 if [[ -n "$PR" ]]; then
-  _require_nonneg_int pr "$PR"
+  _require_pos_int pr "$PR"
 fi
 
 # ---------------------------------------------------------------------------

--- a/.claude/skills/dispatch-propagate/scripts/test-emit-outcome.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-emit-outcome.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Self-contained unit test for dispatch-emit-outcome's validator logic (#1902).
+#
+# Verifies that _require_pos_int (regex ^[1-9][0-9]*$) rejects 0, leading-zero
+# forms, and empty values for --issue and --pr, while _require_nonneg_int still
+# accepts 0 for the five count fields (findings-surfaced, findings-actionable,
+# fixes-applied, followups-filed, subagents-launched).
+#
+# Usage: bash test-emit-outcome.sh
+# Exit 0 = all passed; non-zero = one or more failures.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# --- test helpers -----------------------------------------------------------
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected: '$expected'"
+    echo "    actual:   '$actual'"
+  fi
+}
+
+report_results() {
+  echo ""
+  echo "================================"
+  echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+  echo "================================"
+}
+
+# --- helper -----------------------------------------------------------------
+
+# run_emit: runs dispatch-emit-outcome with a baseline valid argument set and
+# any extra flags appended via "$@". Echoes only the exit code; discards
+# stdout/stderr. The "; echo $?" idiom captures the exit code without letting
+# a non-zero exit abort this script (which runs under set -e).
+run_emit() {  # echoes the exit code; discards stdout/stderr
+  "$SCRIPT_DIR/dispatch-emit-outcome" \
+    --phase review --repo natb1/commons.systems \
+    --findings-surfaced 0 --findings-actionable 0 --fixes-applied 0 \
+    --followups-filed 0 --subagents-launched 0 --disposition completed \
+    "$@" >/dev/null 2>&1; echo $?
+}
+
+# --- assertions -------------------------------------------------------------
+
+echo "Testing dispatch-emit-outcome validator (#1902)..."
+echo ""
+echo "--- _require_pos_int on --issue and --pr ---"
+
+assert_eq "issue 0 rejected"              2 "$(run_emit --issue 0)"
+assert_eq "pr 0 rejected"                 2 "$(run_emit --issue 1 --pr 0)"
+assert_eq "issue 1 accepted"              0 "$(run_emit --issue 1)"
+assert_eq "issue 1 pr 1 accepted"         0 "$(run_emit --issue 1 --pr 1)"
+assert_eq "issue 01 (leading zero) rejected" 2 "$(run_emit --issue 01)"
+
+echo ""
+echo "--- _require_nonneg_int count fields still accept 0 ---"
+
+assert_eq "count field 0 accepted"        0 "$(run_emit --issue 1 --findings-surfaced 0)"
+
+report_results
+exit $FAIL

--- a/.claude/skills/dispatch-propagate/scripts/test-emit-outcome.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-emit-outcome.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Self-contained unit test for dispatch-emit-outcome's validator logic (#1902).
 #
-# Verifies that _require_pos_int (regex ^[1-9][0-9]*$) rejects 0, leading-zero
-# forms, and empty values for --issue and --pr, while _require_nonneg_int still
+# Verifies that _require_pos_int (regex ^[1-9][0-9]*$) rejects 0 and
+# leading-zero forms for --issue and --pr, while _require_nonneg_int still
 # accepts 0 for the five count fields (findings-surfaced, findings-actionable,
 # fixes-applied, followups-filed, subagents-launched).
 #
@@ -45,11 +45,16 @@ report_results() {
 # any extra flags appended via "$@". Echoes only the exit code; discards
 # stdout/stderr. The "; echo $?" idiom captures the exit code without letting
 # a non-zero exit abort this script (which runs under set -e).
+#
+# The baseline seeds every count field with a non-zero value (1) so that a test
+# overriding one of them with 0 (via a later "$@" flag, which wins) genuinely
+# exercises _require_nonneg_int's acceptance of 0 — rather than the override
+# being indistinguishable from the baseline.
 run_emit() {  # echoes the exit code; discards stdout/stderr
   "$SCRIPT_DIR/dispatch-emit-outcome" \
     --phase review --repo natb1/commons.systems \
-    --findings-surfaced 0 --findings-actionable 0 --fixes-applied 0 \
-    --followups-filed 0 --subagents-launched 0 --disposition completed \
+    --findings-surfaced 1 --findings-actionable 1 --fixes-applied 1 \
+    --followups-filed 1 --subagents-launched 1 --disposition completed \
     "$@" >/dev/null 2>&1; echo $?
 }
 
@@ -64,10 +69,14 @@ assert_eq "pr 0 rejected"                 2 "$(run_emit --issue 1 --pr 0)"
 assert_eq "issue 1 accepted"              0 "$(run_emit --issue 1)"
 assert_eq "issue 1 pr 1 accepted"         0 "$(run_emit --issue 1 --pr 1)"
 assert_eq "issue 01 (leading zero) rejected" 2 "$(run_emit --issue 01)"
+assert_eq "pr 01 (leading zero) rejected" 2 "$(run_emit --issue 1 --pr 01)"
 
 echo ""
 echo "--- _require_nonneg_int count fields still accept 0 ---"
 
+# The baseline seeds --findings-surfaced 1; appending --findings-surfaced 0
+# overrides it (last flag wins), so a pass here proves _require_nonneg_int
+# accepts 0 independently of the baseline value.
 assert_eq "count field 0 accepted"        0 "$(run_emit --issue 1 --findings-surfaced 0)"
 
 report_results


### PR DESCRIPTION
Closes #1902

## Problem

`dispatch-emit-outcome` validated `--issue` and `--pr` with `_require_nonneg_int`
(regex `^[0-9]+$`), which accepts `0`. GitHub issue and PR numbers start at 1, so
`0` can never reference a real resource. Passing `--issue 0` / `--pr 0` emitted a
syntactically valid envelope whose `issue`/`pr` field silently correlated to
nothing in any downstream join (aggregation, linking) — no error, just a dropped
row.

## Fix

- Add a `_require_pos_int` validator (`^[1-9][0-9]*$` — positive, no leading
  zeros) mirroring `_require_nonneg_int`, and apply it to the `--issue` and
  `--pr` flags. The anchor rejects `0`, empty, leading-zero forms (`01`), and
  non-numeric values.
- The five count fields (`findings-surfaced`, `findings-actionable`,
  `fixes-applied`, `followups-filed`, `subagents-launched`) keep
  `_require_nonneg_int` — `0` is a valid count there.
- Add `test-emit-outcome.sh`, a self-contained bash unit test (following the
  `test-aggregate-usage.sh` convention) covering the rejection of `0` /
  leading-zero for `--issue`/`--pr`, acceptance of valid numbers, and that the
  count fields still accept `0`. Run manually during QA — there is no CI job for
  these dispatch script tests today.

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-emit-outcome.sh` → 6/6
passed, exit 0.
