### PR TITLE
CI: bound preview-and-smoke/acceptance jobs and wrap playwright install with timeout+retry

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -516,8 +516,10 @@ playwright_install_with_deps() {
       return 0
     fi
     echo "playwright_install_with_deps: attempt $attempt/$attempts failed or timed out after ${timeout_s}s" >&2
-    sleep 5
     attempt=$((attempt + 1))
+    if [ "$attempt" -le "$attempts" ]; then
+      sleep 5
+    fi
   done
   echo "playwright_install_with_deps: failed after $attempts attempts" >&2
   return 1

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -491,6 +491,38 @@ ensure_deps() {
   fi
 }
 
+# ---- playwright_install_with_deps — bounded, timed Playwright browser install -
+# Wraps `npx playwright install --with-deps chromium` (which shells out to apt-get
+# and can stall indefinitely on a flaky archive mirror — #1899) in a per-attempt
+# `timeout` plus a small retry loop, so a transient network stall fails fast and
+# retries instead of hanging until GitHub's 6-hour job cap. Skips entirely when
+# PLAYWRIGHT_BROWSERS_PATH is set (nix provides browsers). Must run from the app
+# directory (npx resolves the project's playwright). Tunables (env):
+# PLAYWRIGHT_INSTALL_TIMEOUT (default 300 seconds, per attempt),
+# PLAYWRIGHT_INSTALL_ATTEMPTS (default 2 = 1 try + 1 retry). Returns non-zero (so
+# the caller's `set -e` aborts) once attempts are exhausted.
+playwright_install_with_deps() {
+  if [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ]; then
+    return 0
+  fi
+  local timeout_s="${PLAYWRIGHT_INSTALL_TIMEOUT:-300}"
+  local attempts="${PLAYWRIGHT_INSTALL_ATTEMPTS:-2}"
+  local attempt=1
+  while [ "$attempt" -le "$attempts" ]; do
+    if [ "$attempt" -gt 1 ]; then
+      echo "playwright_install_with_deps: attempt $attempt/$attempts" >&2
+    fi
+    if timeout --kill-after=30 "$timeout_s" npx playwright install --with-deps chromium; then
+      return 0
+    fi
+    echo "playwright_install_with_deps: attempt $attempt/$attempts failed or timed out after ${timeout_s}s" >&2
+    sleep 5
+    attempt=$((attempt + 1))
+  done
+  echo "playwright_install_with_deps: failed after $attempts attempts" >&2
+  return 1
+}
+
 # Extract the app name from the app directory path.
 # Args: $1 = app directory (e.g. "hello" or "/path/to/hello")
 get_app_name() {

--- a/.claude/skills/dispatch-propagate/scripts/run-acceptance-tests.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-acceptance-tests.sh
@@ -25,9 +25,7 @@ cd "$REPO_ROOT/$APP_DIR"
 # (require the production build / prerendered output, absent from the dev server)
 # — everything else runs.
 if [ -n "$EXTERNAL_BASE_URL" ]; then
-  if [ -z "${PLAYWRIGHT_BROWSERS_PATH:-}" ]; then
-    npx playwright install --with-deps chromium
-  fi
+  playwright_install_with_deps
   BASE_URL="$EXTERNAL_BASE_URL" npx playwright test --config e2e/playwright.config.ts --grep-invert "@hosting|@testonly|@build"
   exit 0
 fi
@@ -93,12 +91,10 @@ env "${BUILD_ARGS[@]}" npm run build
 
 cd "$REPO_ROOT"
 
-# Install Playwright browsers (skip if nix provides them via PLAYWRIGHT_BROWSERS_PATH)
-if [ -z "${PLAYWRIGHT_BROWSERS_PATH:-}" ]; then
-  cd "$REPO_ROOT/$APP_DIR"
-  npx playwright install --with-deps chromium
-  cd "$REPO_ROOT"
-fi
+# Install Playwright browsers (bounded timeout+retry; skips when nix provides them).
+# Subshell keeps the surrounding code running from $REPO_ROOT; under set -e a
+# non-zero subshell aborts the parent.
+(cd "$REPO_ROOT/$APP_DIR" && playwright_install_with_deps)
 
 # Generate temporary firebase.json in repo root with relative path to dist.
 # Firebase emulator resolves public dir relative to the config file location.

--- a/.claude/skills/dispatch-propagate/scripts/run-smoke-tests.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-smoke-tests.sh
@@ -35,10 +35,8 @@ for i in $(seq 1 30); do
   sleep 2
 done
 
-# Install Playwright browsers (skip if nix provides them via PLAYWRIGHT_BROWSERS_PATH)
-if [ -z "${PLAYWRIGHT_BROWSERS_PATH:-}" ]; then
-  npx playwright install --with-deps chromium
-fi
+# Install Playwright browsers (bounded timeout+retry; skips when nix provides them)
+playwright_install_with_deps
 
 # Run smoke tests
 BASE_URL="$BASE_URL" npx playwright test --config e2e/playwright.config.ts --grep @hosting --project=desktop

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   acceptance:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -36,6 +37,7 @@ jobs:
 
   preview-and-smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
Closes #1899

## Problem

CI for a recent PR appeared to "run for an hour" but had actually hung for ~6
hours: 12 of 13 checks passed, but the `preview-and-smoke` job (PR Checks
workflow) never finished and was finally **canceled by GitHub's default 6-hour
job timeout**, not by any failure. The stall was inside `run-smoke-tests.sh`'s
`npx playwright install --with-deps chromium` — `--with-deps` shells out to
`apt-get`, and an apt fetch from `archive.ubuntu.com` hung indefinitely.

Two compounding gaps let a transient network stall burn ~6 hours:

1. **No `timeout-minutes` on any job** in `.github/workflows/pr-checks.yml`, so
   every job inherits GitHub's 6-hour hard cap.
2. **`npx playwright install --with-deps chromium` had no per-command timeout or
   retry** at any of its three call sites — an apt stall hangs forever.

This is a flaky-network reliability fix, not a code regression.

## Changes

### Unit 1 — bounded `playwright_install_with_deps` helper in `lib.sh`

The three `playwright install --with-deps chromium` call sites were
byte-identical and all source `lib.sh`, so the fix is one shared helper that owns
the timeout + retry + skip-guard, with the three sites collapsing to a single
call.

`playwright_install_with_deps` wraps the install in a per-attempt
`timeout --kill-after=30` (so a `SIGTERM`-ignoring D-state apt blocked on network
I/O still gets `SIGKILL`) plus a small retry loop. It owns the
`PLAYWRIGHT_BROWSERS_PATH` skip-guard (nix-provided browsers skip the install)
and exposes env-tunable knobs with defaults that mirror the repo's existing retry
idioms (`npm-ci-with-retry.sh`, `gh_retry`):

- `PLAYWRIGHT_INSTALL_TIMEOUT` (default `300` seconds, per attempt)
- `PLAYWRIGHT_INSTALL_ATTEMPTS` (default `2` = 1 try + 1 retry)

Worst case is `2 × 300s = 600s`, which fits under both job timeouts below. As a
sourced function it `return`s non-zero on exhaustion (not `exit`), so each
caller's `set -euo pipefail` aborts the script and fails the job. All three call
sites are bare calls (the third wrapped in a `( cd … && … )` subshell to preserve
cwd discipline), so the non-zero return fires `set -e`.

### Unit 2 — `timeout-minutes` on both `pr-checks.yml` jobs

- `acceptance` → `timeout-minutes: 30` (builds, starts emulators, seeds, runs the
  full Playwright suite — needs the larger budget; comfortably exceeds the 600s
  worst-case install).
- `preview-and-smoke` → `timeout-minutes: 20` (only deploys a preview and runs the
  `@hosting` smoke grep — lighter, tighter cap).

The job-level cap is the backstop; the helper's per-command timeout is the
fast-fail.

### Scope note (deliberate)

AC1 scopes the `timeout-minutes` change to `.github/workflows/pr-checks.yml`
only. The root-cause analysis observed that *no* workflow carries
`timeout-minutes`, but a repo-wide sweep is intentionally out of scope for this
issue — other workflow files are not touched here.

## Verification

1. **AC1 (timeouts present)** —
   `grep -n 'timeout-minutes' .github/workflows/pr-checks.yml` shows both jobs
   carry the key (`30` for acceptance, `20` for preview-and-smoke).
2. **AC2 (per-command timeout + retry)** — `playwright_install_with_deps` in
   `lib.sh`: `timeout` wrapper + bounded retry loop + env-tunable knobs.
3. **AC3 (a simulated stall surfaces as a fast failure)** — ran the wrapper
   against the **real** command with `PLAYWRIGHT_INSTALL_TIMEOUT=1` and
   `PLAYWRIGHT_BROWSERS_PATH` unset; the helper logged the retry and returned
   non-zero (`exit=1`) within seconds, not hours.

`bash -n` passes on all three edited scripts.
