### PR TITLE
De-flake budget transactions blur-filter test (auto-waiting assertion)

### DIFF
--- a/budget/e2e/transactions.spec.ts
+++ b/budget/e2e/transactions.spec.ts
@@ -250,12 +250,17 @@ test.describe("transactions", () => {
     // count() is a one-shot snapshot with no auto-wait; poll until the
     // blur-triggered filter re-render settles before reading the count.
     await expect.poll(async () => visibleRows.count()).toBeLessThan(countBefore);
-    const countAfter = await visibleRows.count();
-    expect(countAfter).toBeGreaterThan(0);
-    for (let i = 0; i < countAfter; i++) {
-      const category = await visibleRows.nth(i).getAttribute("data-category");
-      expect(category).toMatch(/^Food/);
-    }
+    // Auto-waiting assertion: no visible row's data-category falls outside the
+    // "Food" prefix. expect(locator).toHaveCount re-queries on each retry, so a
+    // transient non-Food row from an in-flight second render pass is retried
+    // away rather than read once and asserted (the prior one-shot loop raced
+    // the re-render, especially on mobile).
+    const visibleNonFoodRows = page.locator(
+      '.txn-row:not([style*="display: none"]):not([data-category^="Food"])',
+    );
+    await expect(visibleNonFoodRows).toHaveCount(0);
+    // At least one Food row stays visible after filtering.
+    await expect(visibleRows).not.toHaveCount(0);
   });
 
   test("clearing the filter input and blurring restores all rows", async ({ page }) => {


### PR DESCRIPTION
Closes #1919

## Problem

The `acceptance` CI check intermittently failed on the budget app's e2e test
**"typing a category in the filter and blurring filters table rows"** (mobile
project variant) in `budget/e2e/transactions.spec.ts`. The flake surfaced on a
PR that does not touch the budget app, while the same branch passed the identical
check on an earlier run — a non-deterministic timing failure, not a real
regression.

## Root cause

The test fills the category filter with "Food", blurs, polls until the visible
row count drops, then took a **one-shot** `count()` snapshot and iterated each
visible row reading `data-category`, asserting `/^Food/`. The blur handler toggles
each row's `style.display` per render pass. Between the poll settling and the
per-row attribute reads, a second filter re-render pass can still be in flight, so
a non-Food row may be transiently visible when its `data-category` is read —
especially on the slower mobile project. `count()` and `getAttribute()` are
one-shot reads with no auto-wait.

## Fix

Replace the one-shot snapshot + per-row loop with an auto-waiting negative-locator
assertion:

```ts
const visibleNonFoodRows = page.locator(
  '.txn-row:not([style*="display: none"]):not([data-category^="Food"])',
);
await expect(visibleNonFoodRows).toHaveCount(0);
await expect(visibleRows).not.toHaveCount(0);
```

`expect(locator).toHaveCount` re-queries on every retry, so a transient non-Food
row from an in-flight second render pass is retried away rather than read once and
asserted. The race is removed by construction, not merely made less likely. The
`[data-category^="Food"]` CSS prefix matches the same set as the old `/^Food/`
regex and is a superset of the filter's own match, so a settled DOM always yields
count 0 — the assertion cannot false-fail; it only retries until the render
settles. This is the same auto-waiting `toHaveCount` pattern the sibling
"clearing the filter input and blurring restores all rows" test already uses.

## Verification

- **By construction (primary):** the documented one-shot read between poll-settle
  and the per-row loop is the race; an auto-waiting locator assertion eliminates
  it. A flaky test passing CI once does not prove a fix — the by-construction
  argument does.
- **Local typecheck:** the spec still compiles (`tsc --noEmit`, clean). The change
  uses only already-imported Playwright APIs — no new imports.
- **Scope:** only the one test block changed; no other test references the removed
  `countAfter` local, and no `budget/src/**` source or CI config changed.
