### PR TITLE
dispatch-emit-outcome: reject explicit empty --terminated-reason on non-escalated dispositions

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome
@@ -27,7 +27,10 @@
 # --disposition: one of the ALLOWED_DISPOSITIONS set
 #   (completed, completed_with_fixes, escalated).
 # --terminated-reason: required-non-null when disposition == escalated;
-#   must be absent (or not provided) for any other disposition.
+#   forbidden for any other disposition. An explicit empty
+#   --terminated-reason '' on a non-escalated disposition is rejected
+#   (exit 2), not silently treated as absent — presence is tracked by a
+#   set-flag, not by emptiness.
 # --pr, --base-sha: optional; serialize as JSON null when absent.
 #
 # DIVERGENCE FROM dispatch-mark-complete:
@@ -63,6 +66,7 @@ FOLLOWUPS_FILED=""
 SUBAGENTS_LAUNCHED=""
 DISPOSITION=""
 TERMINATED_REASON=""
+TERMINATED_REASON_SET=false
 
 usage() {
   cat >&2 <<'EOF'
@@ -127,7 +131,7 @@ while [[ $# -gt 0 ]]; do
       DISPOSITION="$2"; shift 2 ;;
     --terminated-reason)
       [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --terminated-reason requires a value" >&2; exit 2; }
-      TERMINATED_REASON="$2"; shift 2 ;;
+      TERMINATED_REASON="$2"; TERMINATED_REASON_SET=true; shift 2 ;;
     *)
       echo "dispatch-emit-outcome: unexpected argument: $1" >&2
       usage
@@ -203,13 +207,16 @@ fi
 
 # ---------------------------------------------------------------------------
 # terminated_reason cross-validation
+# "Provided" is tracked by TERMINATED_REASON_SET (set in the parser), NOT by
+# emptiness, so an explicit --terminated-reason '' on a non-escalated
+# disposition is rejected rather than silently treated as absent.
 # ---------------------------------------------------------------------------
 if [[ "$DISPOSITION" == "escalated" && -z "$TERMINATED_REASON" ]]; then
   echo "dispatch-emit-outcome: --terminated-reason is required when --disposition is escalated" >&2
   exit 2
 fi
 
-if [[ "$DISPOSITION" != "escalated" && -n "$TERMINATED_REASON" ]]; then
+if [[ "$DISPOSITION" != "escalated" && "$TERMINATED_REASON_SET" == true ]]; then
   echo "dispatch-emit-outcome: --terminated-reason must not be provided when --disposition is $DISPOSITION (only valid for escalated)" >&2
   exit 2
 fi

--- a/.claude/skills/dispatch-propagate/scripts/test-emit-outcome.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-emit-outcome.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Tests for dispatch-emit-outcome — the terminated_reason cross-validation contract (#1907).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+source "$SCRIPT_DIR/test-helpers.sh"
+SUT="$SCRIPT_DIR/dispatch-emit-outcome"
+
+COMMON=(--phase review --repo natb1/commons.systems --issue 1907
+  --findings-surfaced 0 --findings-actionable 0 --fixes-applied 0
+  --followups-filed 0 --subagents-launched 0)
+
+# Run the SUT, capturing stdout+stderr in OUT and exit code in RC.
+RC=0
+OUT=""
+run_sut() {
+  set +e
+  OUT=$("$SUT" "${COMMON[@]}" "$@" 2>&1)
+  RC=$?
+  set -e
+}
+
+# --- Case 1: the fix — completed + empty reason → exit 2 ---
+echo "Case 1: completed + empty reason -> exit 2"
+run_sut --disposition completed --terminated-reason ''
+assert_eq "AC1: exit code is 2" "2" "$RC"
+assert_contains "AC1: message mentions must not be provided" "must not be provided" "$OUT"
+
+# --- Case 2: preserved — escalated + empty reason → exit 2 ---
+echo "Case 2: escalated + empty reason -> exit 2"
+run_sut --disposition escalated --terminated-reason ''
+assert_eq "AC2: exit code is 2" "2" "$RC"
+assert_contains "AC2: message mentions is required when" "is required when" "$OUT"
+
+# --- Case 3: no regression — escalated + non-empty reason → exit 0, reason serialized ---
+echo "Case 3: escalated + non-empty reason -> exit 0, reason in JSON"
+run_sut --disposition escalated --terminated-reason 'some reason'
+assert_eq "AC3: exit code is 0" "0" "$RC"
+REASON=$(printf '%s\n' "$OUT" | sed -n '/^```json$/,/^```$/p' | sed '1d;$d' | jq -r '.terminated_reason')
+assert_eq "AC3: terminated_reason serialized" "some reason" "$REASON"
+
+# --- Case 4: regression — completed, no --terminated-reason → exit 0, null in JSON ---
+echo "Case 4: completed + reason omitted -> exit 0, terminated_reason null"
+run_sut --disposition completed
+assert_eq "REGRESSION: exit code is 0" "0" "$RC"
+NULLVAL=$(printf '%s\n' "$OUT" | sed -n '/^```json$/,/^```$/p' | sed '1d;$d' | jq -r '.terminated_reason')
+assert_eq "REGRESSION: terminated_reason null" "null" "$NULLVAL"
+
+report_results


### PR DESCRIPTION
Closes #1907

## Summary

`dispatch-emit-outcome` cross-validates `--terminated-reason` against
`--disposition`: a reason is **required** when `disposition == escalated` and
**forbidden** otherwise. The forbidden-path guard tested emptiness
(`[[ -n "$TERMINATED_REASON" ]]`), which can't tell "flag not passed" from "flag
passed as the empty string". So `--disposition completed --terminated-reason ''`
exited 0 and silently serialized `terminated_reason: null` — swallowing the
forbidden argument instead of rejecting it. That is exactly the
"defensive fallback that buries an error" `.claude/rules/code-style.md` warns
against; the greenfield-correct behavior is to reject the contract violation
with exit 2.

## Changes

- **Fix the guard** (`dispatch-emit-outcome`): track flag presence with a
  `TERMINATED_REASON_SET` boolean set in the parser, and gate the forbidden-path
  check on that flag rather than on emptiness. An explicit
  `--terminated-reason ''` on a non-escalated disposition is now rejected
  (exit 2) with the existing descriptive message. The escalated-required check
  keeps its `-z` test (an empty reason on `escalated` still exits 2), and the
  post-validation jq-builder branch is unchanged (after validation, only a
  valid escalated reason is ever non-empty). The header contract comment and an
  inline comment now document the set-flag treatment.

- **Add coverage** (`test-emit-outcome.sh`): a new standalone unit test
  following the `test-run-typecheck.sh` convention, encoding the four acceptance
  criteria. The script was previously untested. `run-unit-tests.sh`
  auto-discovers `test-*.sh` and auto-triggers the PR-scripts suite on changes
  under the scripts dir, so no runner wiring is needed.

## Verification

`test-emit-outcome.sh` passes 8/8:

- `--disposition completed --terminated-reason ''` → exit 2 (the fix)
- `--disposition escalated --terminated-reason ''` → exit 2 (preserved)
- `--disposition escalated --terminated-reason 'some reason'` → exit 0 with
  `terminated_reason == "some reason"` (no regression)
- `--disposition completed` (flag omitted) → exit 0 with
  `terminated_reason == null` (no regression)

## Caller compatibility

The only live callers are the `review-fix` and `qa-fix` skills/workflows. Every
non-escalated path omits `--terminated-reason` entirely; only escalated paths
pass a non-empty string. No caller passes `--terminated-reason ''` on a
non-escalated disposition, so the stricter behavior breaks nothing in the
autonomous chain.
