### PR TITLE
nix: add macOS CI build of darwinConfigurations.default

### DIFF
--- a/.github/scripts/build-darwin-config.sh
+++ b/.github/scripts/build-darwin-config.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT=$(git rev-parse --show-toplevel)
+echo "=== nix build .#darwinConfigurations.default.system ==="
+nix build "$REPO_ROOT#darwinConfigurations.default.system" \
+  --no-link --print-build-logs
+echo "PASS: darwinConfigurations.default build"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -191,3 +191,23 @@ jobs:
             (cd "$dir" && go test ./...) || failed=1
           done <<< "$modules"
           exit "$failed"
+
+  darwin-build:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+      - name: Detect changed file categories
+        id: changes
+        run: .claude/skills/dispatch-propagate/scripts/detect-changes.sh
+      - name: Install nix (if nix files changed)
+        if: steps.changes.outputs.nix == 'true'
+        uses: DeterminateSystems/nix-installer-action@d96bc962e61b3049ce8128d03d57a1144fa96539 # main
+        with:
+          extra-conf: |
+            extra-substituters = https://claude-code.cachix.org
+            extra-trusted-public-keys = claude-code.cachix.org-1:YeXf2aNu7UTX8Vwrze0za1WEDS+4DuI2kVeWEE4fsRk=
+      - name: Build darwinConfigurations.default
+        if: steps.changes.outputs.nix == 'true'
+        run: .github/scripts/build-darwin-config.sh


### PR DESCRIPTION
Closes #1734

## What

Adds a CI job that builds `darwinConfigurations.default` on a real macOS runner,
so a broken nix-darwin config turns a PR check red before merge.

`nix flake check` runs only on Linux runners, and a Linux evaluator cannot
evaluate `darwinConfigurations` (nix-darwin modules require a Darwin evaluator).
So today nothing in CI exercises `darwinConfigurations.default` (added by #1695).
A Darwin-only regression — a module import error, an overlay mismatch, or a
`programs.wezterm.enable` override regression — would be invisible until someone
built on a Mac, where a broken config blocks system activation.

## Changes

- **`.github/scripts/build-darwin-config.sh`** — wrapper running the canonical
  `nix build .#darwinConfigurations.default.system --no-link --print-build-logs`.
  A wrapper (not an inline `run:`) matches the repo convention that CI logic
  lives in scripts, and gives Mac developers a single command to run the same
  check locally.
- **`.github/workflows/unit-tests.yml`** — new `darwin-build` job that:
  - runs on `macos-14` (`aarch64-darwin`, matching the config's
    `nixpkgs.hostPlatform`),
  - is gated on `steps.changes.outputs.nix == 'true'` via the existing
    `detect-changes.sh`, so a non-Nix PR runs the cheap checkout+detect and then
    no-ops (a neutral, not failed, check),
  - configures the `claude-code-nix` Cachix substituter through the
    `nix-installer-action` `extra-conf` input, so the unfree `claude-code`
    closure is pulled from cache rather than built from source on a cold runner.

## Design notes

- **Build target is `.#darwinConfigurations.default.system`** — the buildable
  activation derivation — not the bare flake output.
- **No `--impure`.** #1695 forces `home.username` / `home.homeDirectory` via
  `lib.mkForce` so pure eval passes; `nix build` is pure by default.
- **A full build, not `nix eval` / `--dry-run`** — deliberately the strongest
  check, also catching package build failures, and matching the issue text.
- **Merge gating is automatic.** The repo has no required-status-checks list;
  dispatch auto-merge reads the PR's `statusCheckRollup`, so a failing
  `darwin-build` blocks merge just by existing. No required-checks config to
  update.

## Verification

This cannot be verified on Linux — that is the issue's premise. The macOS CI run
on this PR is the verification: confirm the `darwin-build` job runs on `macos-14`,
installs Nix, and the `nix build` step exits 0. Because "pure eval passes" has
never been exercised by a Darwin evaluator, a first-run red is a possible
expected fix cycle, not a surprise — read the `--print-build-logs` output and fix
forward.
