### PR TITLE
CI: force HTTP/1.1 for nix substituters to de-flake nix env setup

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Install nix (if nix files changed)
         if: steps.changes.outputs.nix == 'true'
         uses: DeterminateSystems/nix-installer-action@d96bc962e61b3049ce8128d03d57a1144fa96539 # main
+        with:
+          extra-conf: |
+            http2 = false
+            fallback = true
       - name: Set up Java (if firestore.rules changed)
         if: steps.changes.outputs.rules == 'true'
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
@@ -96,6 +100,10 @@ jobs:
       - name: Install nix (if nix files changed)
         if: steps.changes.outputs.nix == 'true'
         uses: DeterminateSystems/nix-installer-action@d96bc962e61b3049ce8128d03d57a1144fa96539 # main
+        with:
+          extra-conf: |
+            http2 = false
+            fallback = true
       - name: Set up Java (if firestore.rules changed)
         if: steps.changes.outputs.rules == 'true'
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
@@ -147,6 +155,10 @@ jobs:
       - name: Install nix (only when flake or package-lock changed)
         if: steps.changes.outputs.nix == 'true' || steps.changes.outputs.playwright == 'true'
         uses: DeterminateSystems/nix-installer-action@d96bc962e61b3049ce8128d03d57a1144fa96539 # main
+        with:
+          extra-conf: |
+            http2 = false
+            fallback = true
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         if: steps.changes.outputs.nix == 'true' || steps.changes.outputs.playwright == 'true'
         with:


### PR DESCRIPTION
Closes #1925

## Problem

The `playwright-version-sync` CI job intermittently fails during its `nix develop`
environment build — *before* the version-sync check logic runs. The failure is a
transient corruption of a binary-cache download from `cache.nixos.org`:

```
warning: unable to download 'https://cache.nixos.org/nar/...nar.zst':
  HTTP error 200 (curl error: Stream error in the HTTP/2 framing layer)
error: failed to read compressed data (Zstd decompression failed: Data corruption detected)
error: path '/nix/store/...-openjdk-21.0.12+2' is required, but there is no substituter that can build it
```

The signature is keyed on the **HTTP/2 framing-layer** stream error: nix's own
resume-from-offset retry re-hits the same corrupt HTTP/2 stream and still fails,
so the corrupted download fails the whole `nix develop` env build and the job
dies. The corrupted store path varies per occurrence; the failure class is the
cache + HTTP/2 corruption, not the path.

## Fix

Force curl onto HTTP/1.1 to eliminate the HTTP/2 framing-layer corruption at its
source, with a build-from-source backstop for any residual substituter failure.
Both knobs are added via the `extra-conf` input of the
`DeterminateSystems/nix-installer-action` step, which appends to
`/etc/nix/nix.conf`:

```yaml
with:
  extra-conf: |
    http2 = false
    fallback = true
```

- `http2 = false` forces curl onto HTTP/1.1, eliminating the specific "Stream
  error in the HTTP/2 framing layer" failure class. Preferred over `fallback`
  as the primary mechanism: `fallback` "fixes" corruption by building the failed
  path **from source**, which is unbounded (openjdk-21 is a tens-of-minutes
  build, and the path varies). `fallback = true` is kept only as a cheap
  last-resort backstop, not the primary fix.
- `extra-conf` is a global knob: `/etc/nix/nix.conf` is read by **every** nix
  command in the job, so one block per `nix-installer-action` step covers all
  substituter sites in that job with no script edits.

### Coverage — applied to all three in-CI nix sites

All CI substituter-hitting nix sites live in `unit-tests.yml`, each behind its
own `nix-installer-action` step. The identical `extra-conf` block is added to all
three (the duplication is intentional — each job installs nix independently):

1. `unit-tests` job — `nix flake check` inside `run-unit-tests.sh`.
2. `lint` job — `nix flake check` inside `run-lint.sh`.
3. `playwright-version-sync` job — `nix develop --command check-playwright-version-sync.sh`.

The two `nix flake check` sites buried inside the scripts need **no** edits —
they inherit the global `/etc/nix/nix.conf` the action writes.

**Out of scope, by construction:** `pr-checks.yml` (acceptance / preview-smoke)
installs no nix on CI; `prod-deploy.yml` runs no nix command (references `*.nix`
only as `paths-ignore` filters).

## Verification

This failure is **not locally reproducible** — it is a transient CI-side
HTTP/2 / Zstd corruption event from `cache.nixos.org`, independent of repo code.
So this PR verifies the mitigation is **present, valid, and non-regressing**, not
that it was exercised against a live corruption (the corruption path is
CI-authoritative):

1. **Presence & validity:** all three `nix-installer-action` steps now carry the
   `extra-conf: |` block with `http2 = false` and `fallback = true`
   (`grep -c` returns 3 for each); the YAML structure is unchanged otherwise.
2. **Coverage:** every in-CI substituter site is one of the three jobs whose
   `nix-installer-action` now sets the global config.
3. **Happy path unaffected:** `http2 = false` only changes the HTTP transport and
   `fallback = true` only triggers on a substituter failure, so the normal
   cache-hit path is unchanged. A green `playwright-version-sync` / `lint` /
   `unit-tests` run on this PR is the authoritative check.
