### PR TITLE
dispatch-select-target: global recorded-leaf dedup so --top N never emits a shared leaf twice

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -183,6 +183,7 @@ DEBUG_CLASSIFY=false
 TOP=1
 TOP_EXPLICIT=false
 declare -A EXCLUDED=()
+declare -A RECORDED_LEAVES=()  # leaves successfully recorded into any bucket this scan; used at TOP>1 to dedup the same leaf reached from sibling roots (#1915)
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -1039,6 +1040,9 @@ while IFS=$'\t' read -r issue_num issue_pri issue_enh issue_catrank issue_cat; d
   #   exit 1 — usage error; propagate as a hard failure, never swallow as a skip.
   declare -A root_excl=()
   for _ge in "${!EXCLUDED[@]}"; do root_excl["$_ge"]=1; done
+  if (( TOP > 1 )); then
+    for _rl in "${!RECORDED_LEAVES[@]}"; do root_excl["$_rl"]=1; done
+  fi
   root_recorded=0
   while :; do
     # Stop once this root has supplied TOP leaves, or both phase buckets are at
@@ -1105,6 +1109,7 @@ while IFS=$'\t' read -r issue_num issue_pri issue_enh issue_catrank issue_cat; d
       root_excl["$leaf"]=1
       if bucket_append FIRST_ISSUE "$leaf_bucket" "$leaf"; then
         root_recorded=$(( root_recorded + 1 ))
+        RECORDED_LEAVES["$leaf"]=1
       else
         # Bucket already at TOP — this leaf was dropped. Criterion #3 freezes
         # TOP=1: a root that hits a full bucket on an append attempt stops

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -4824,6 +4824,34 @@ printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 assert_eq "--priority-only --top 3 → exit 0 (no rejection)" "0" "$rc"
 teardown
 
+# PT6. Shared startable leaf across sibling roots is emitted EXACTLY ONCE (#1915).
+#      Two distinct help-wanted+priority roots 1858 and 1861 carry the SAME topic
+#      category (dispatch), so they fall in ONE (category, priority, enh, phase)
+#      bucket. Both roots descend (via their sub-issues) to the SAME startable
+#      leaf 1863. Before the fix, each root re-seeded `root_excl` only from the
+#      frozen global EXCLUDED and `bucket_append` did no value-level dedup, so the
+#      leaf recorded while descending root 1858 was not excluded when sibling root
+#      1861 descended to it — emitting `issue 1863` twice and inflating N_PRIO.
+#      The fix records every successfully-appended leaf in a global
+#      RECORDED_LEAVES set and, at TOP>1, seeds each root's `root_excl` from it,
+#      so a leaf reached from a sibling root is skipped. Run at --top 3 (NOT
+#      --top 1): the TOP=1 byte-identity guard means the cross-root dedup is a
+#      TOP>1 concern. Assert the shared leaf appears exactly once.
+echo "Test: --priority-only --top 3 shared leaf across sibling roots emitted once (#1915)"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":1858,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"},{"name":"dispatch"}]},{"number":1861,"created_at":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"},{"name":"dispatch"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+# Both sibling roots descend to the SAME shared leaf 1863 via their sub-issues.
+printf '[{"number":1863}]\n' > "$STUB_DIR/subissues-1858.json"
+printf '[{"number":1863}]\n' > "$STUB_DIR/subissues-1861.json"
+printf '{"title":"Issue 1863","body":"","comments":[],"number":1863,"state":"OPEN"}\n' > "$STUB_DIR/issue-1863.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only --top 3)
+assert_eq "--priority-only --top 3 shared leaf 1863 emitted exactly once" "1" "$(printf '%s\n' "$result" | grep -c '^issue 1863$')"
+assert_eq "--priority-only --top 3 shared leaf → single issue line" "issue 1863" "$result"
+teardown
+
 # ============================================================================
 # --- JIT scan ---
 # dispatch-select-target's JIT scan runs before the main-broken health gate.


### PR DESCRIPTION
Closes #1915

## Problem

`dispatch-select-target … --top N` could emit the **same startable leaf twice**
when two distinct help-wanted roots in the same `(category, priority, enh, phase)`
bucket traced to a **shared** startable leaf. The leaf-recording loop re-declared
`root_excl` empty for each root (seeded only from the frozen global `EXCLUDED`),
and `bucket_append` appends without value-level dedup — so a leaf recorded while
descending root A was not excluded when sibling root B descended to it, and it was
appended a second time.

This matters because `--priority-only --top N` is the manual fan-out's `N_PRIO`
counting primitive (`dispatch-select-tick` counts the emitted `pr`/`issue` lines
to size its spawn budget). A duplicate line inflated `N_PRIO`. Observed
2026-06-18: `--priority-only --top 5` emitted `issue 1863` twice (roots #1858 and
#1861, both `dispatch`+`priority`, both tracing to the same leaf).

## Fix

Add a global `RECORDED_LEAVES` set, populated on each successful `bucket_append`,
and seed each root's descent `root_excl` from `EXCLUDED ∪ RECORDED_LEAVES`. So a
leaf recorded under one root is excluded when a sibling root descends to it, and
the sibling finds its own next-eligible leaf instead.

The seed read is guarded by `(( TOP > 1 ))`. The TOP=1 emission loop emits exactly
one line and exits, so a cross-root duplicate is structurally impossible at TOP=1
— the dedup is definitionally a TOP>1 concern. Guarding the read leaves the TOP=1
path **byte-for-byte unchanged**, preserving the deliberate TOP=1 byte-identity
contract (a shared plan-phase leaf must not be skipped in favor of a sibling's
implement-phase leaf, which would flip the single emitted line). Every existing
TOP=1 test passing unchanged is the proof.

## Test

Adds regression test PT6 in the `--priority-only --top N` block: two sibling
help-wanted+priority `dispatch`-topic roots in one bucket both descend to a single
shared startable leaf, run at `--priority-only --top 3`, asserting the shared leaf
is emitted exactly once. Reverting the seed-guard block makes PT6 fail, confirming
the test exercises the bug. Full suite: 3045/3045 passing, no regression.
