### PR TITLE
dispatch: keep priority-epic work in the priority tier at the PR stage

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -666,6 +666,21 @@ has_priority_in_labels() {
   printf '%s' "$1" | jq -r "$JQ_LABEL_DEFS"' has_priority'
 }
 
+# 1 if any closing issue — or any of its open ancestors — carries the `priority`
+# label; else 0. Inherits priority from the epic subtree by including each
+# closing issue's ancestor numbers (from ANCESTOR_NUMS) in the label union.
+# Closed ancestors are absent from ISSUE_LABELS_JSON (which holds open issues
+# only), so they contribute nothing — "open ancestor" semantics are automatic.
+# A PR with no closing issues, or whose closing issues and ancestors are absent
+# from the map, returns 0.
+pr_priority_bit() {
+  printf '%s' "$1" | jq -r --argjson map "$ISSUE_LABELS_JSON" --argjson anc "$ANCESTOR_NUMS" \
+    "$JQ_LABEL_DEFS"'
+      [ .[].number | tostring as $n
+        | ( ($map[$n] // [])[], ( ($anc[$n] // [])[] | tostring as $a | ($map[$a] // [])[] ) ) ]
+      | has_priority'
+}
+
 # Top-N ranked PRs per (category, priority-bit, phase): key =
 # "<category>|<priority-bit>|<phase>", value = a NEWLINE-DELIMITED list (no
 # leading/trailing newline) of up to TOP entries, each "<num> <branch>", oldest
@@ -792,7 +807,7 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   # per-PR dispatch-ci-ready / dispatch-phase gh calls — a non-priority PR is
   # never selectable in this mode, so it pays nothing.
   if [[ "$PRIORITY_ONLY" == "true" ]] \
-     && [[ "$(has_priority_in_labels "$(pr_combined_labels "$pr_closing")")" != "1" ]]; then
+     && [[ "$(pr_priority_bit "$pr_closing")" != "1" ]]; then
     continue
   fi
 
@@ -901,7 +916,7 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   # first-seen guard.
   pr_combined=$(pr_combined_labels "$pr_closing")
   pr_cat=$(category_of_labels "$pr_combined")
-  pr_pri=$(has_priority_in_labels "$pr_combined")
+  pr_pri=$(pr_priority_bit "$pr_closing")
   pr_key="$pr_cat|$pr_pri|$phase"
   bucket_append FIRST_PR "$pr_key" "$pr_num $pr_branch" || true
 done <<< "$PR_SORTED"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -113,8 +113,9 @@
 # it closes (closingIssuesReferences); a PR that closes no issue, or whose
 # closing issues carry no topic label, is "other". An issue's category is the
 # highest-priority topic among its own labels, else "other". A PR's priority
-# bit is 1 if the union of its closing issues' labels carries `priority`, else
-# 0; an issue's priority bit is 1 if its own labels carry `priority`, else 0.
+# bit is 1 if any closing issue, or any open ancestor of a closing issue (up to
+# 6 levels), carries the `priority` label, else 0; an issue's priority bit is 1
+# if its own labels carry `priority`, else 0.
 #
 # Within each (priority, topic) bucket, default-mode priority (oldest PR wins
 # within a tier):

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -850,17 +850,21 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
       # number (e.g. `100-fix` closing priority issue `200`), and a branch with
       # no `<N>-` prefix yields a non-numeric value the reseed sink rejects —
       # silently stranding the very priority item this path exists to rescue.
-      # Resolve the priority-labeled closing issue from `pr_closing` (already in
-      # scope), reusing ISSUE_LABELS_JSON exactly as pr_combined_labels does. The
-      # line-712 gate guarantees at least one closing issue carries `priority` in
-      # --priority-only mode, and dispatch-find-pr resolves issue→PR via the
-      # issue's closedByPullRequestsReferences fallback, so the priority issue
-      # number is the resolvable, correct target.
+      # Resolve the reseed target from `pr_closing` (already in scope), reusing
+      # ISSUE_LABELS_JSON exactly as pr_combined_labels does. The --priority-only
+      # early skip now admits PRs that are priority via an open ANCESTOR (see
+      # pr_priority_bit), so a PR reaching here may have NO closing issue that
+      # carries `priority` on its own labels. Prefer the priority-direct closing
+      # issue as the target, but fall back to the first closing-issue number when
+      # none is directly priority-labeled. Either way the target is a resolvable
+      # closing-issue number (not the branch prefix #1444) — dispatch-find-pr
+      # resolves issue→PR via the issue's closedByPullRequestsReferences fallback.
       local_issue=$(printf '%s' "$pr_closing" \
         | jq -r --argjson map "$ISSUE_LABELS_JSON" \
-          'map(.number | tostring
-               | select((($map[.] // []) | any(.name == "priority"))))
-           | .[0] // empty')
+          '( map(.number | tostring
+                 | select((($map[.] // []) | any(.name == "priority")))) | .[0] )
+           // ( [.[].number | tostring] | .[0] )
+           // empty')
       if [[ "$local_issue" =~ ^[0-9]+$ && -z "${EXCLUDED[$local_issue]:-}" ]] \
          && ! pr_issue_office_hours_parked "$local_issue" \
          && ! pr_blocked_by_open "$pr_closing"; then

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -522,6 +522,7 @@ CLOSING_NUMS=$(printf '%s' "$PR_LIST" \
   | jq -r '[.[].closingIssuesReferences[]?.number] | unique | .[]')
 if [[ -z "$CLOSING_NUMS" ]]; then
   BLOCKER_COUNTS='{}'
+  ANCESTOR_NUMS='{}'
 else
   # owner/repo for the GraphQL variables (same pattern as post-pr-comment.sh).
   REPO_NWO=$(gh_retry gh repo view --json nameWithOwner -q .nameWithOwner) || {
@@ -542,24 +543,66 @@ else
       echo "error: dispatch-select-target: non-integer closing issue number: $cnum" >&2
       exit 1
     }
-    GQL_FIELDS+="    _${cnum}: issue(number: ${cnum}) { number blockedBy(first: 50) { nodes { state } } }"$'\n'
+    # Each alias also requests a fixed-depth nested parent chain (7 levels): depth
+    # 1..6 are collected as ancestors (ANCESTOR_NUMS), the 7th is a sentinel used
+    # only to detect (and warn about) chains deeper than the supported depth. The
+    # parent walk rides this single batched call rather than adding per-PR REST
+    # round-trips, keeping the GraphQL bucket usage to one query (#1601).
+    GQL_FIELDS+="    _${cnum}: issue(number: ${cnum}) { number blockedBy(first: 50) { nodes { state } } parent { number parent { number parent { number parent { number parent { number parent { number parent { number } } } } } } } }"$'\n'
   done <<< "$CLOSING_NUMS"
   GQL_QUERY="query(\$owner: String!, \$name: String!) {
   repository(owner: \$owner, name: \$name) {
 ${GQL_FIELDS}  }
 }"
-  BLOCKER_COUNTS=$(gh_retry gh api graphql -F owner="$REPO_OWNER" -F name="$REPO_NAME" -f query="$GQL_QUERY" \
-    | jq -c '.data.repository
+  # Capture the batched response ONCE, then project it twice (blocker counts and
+  # ancestor chains). A second gh api graphql call would defeat the single-call
+  # design (#1601) — both maps must derive from this one response.
+  GQL_RESP=$(gh_retry gh api graphql -F owner="$REPO_OWNER" -F name="$REPO_NAME" -f query="$GQL_QUERY") || {
+    echo "error: dispatch-select-target: batched blockedBy GraphQL query failed" >&2
+    exit 1
+  }
+  # number → open-blocker count. Open blockers are counted client-side by
+  # filtering state==OPEN over each issue's blockedBy connection.
+  BLOCKER_COUNTS=$(jq -c '.data.repository
              | to_entries
              | map(select(.value != null)
                    | {key: (.value.number|tostring),
                       value: ([.value.blockedBy.nodes[]
                                | select(.state=="OPEN" or .state=="open")]
                               | length)})
-             | from_entries') || {
-    echo "error: dispatch-select-target: batched blockedBy GraphQL query failed" >&2
+             | from_entries' <<<"$GQL_RESP") || {
+    echo "error: dispatch-select-target: blocker-count projection failed" >&2
     exit 1
   }
+  # number → flat JSON array of ancestor numbers (parent-chain levels 1..6).
+  # recurse(.parent?) starting at .value yields the issue itself first, then its
+  # parent, grandparent, … so .[1:7] drops the issue's own number and keeps only
+  # the six collected ancestor levels (the 7th sentinel level is never included).
+  # Issues with no parent map to []. The downstream open-vs-closed decision is
+  # made later against ISSUE_LABELS_JSON (open-issues only), so closed ancestors
+  # are simply absent there and contribute nothing — this query collects ALL
+  # ancestor numbers regardless of state.
+  ANCESTOR_NUMS=$(jq -c '.data.repository
+             | to_entries
+             | map(select(.value != null)
+                   | {key: (.value.number|tostring),
+                      value: ([.value | recurse(.parent?; . != null) | .number]
+                              | .[1:7])})
+             | from_entries' <<<"$GQL_RESP") || {
+    echo "error: dispatch-select-target: ancestor-chain projection failed" >&2
+    exit 1
+  }
+  # Truncation detection: if the deepest (7th, sentinel) parent level is non-null
+  # for any alias, the real chain is deeper than the supported depth (6). Warn
+  # per offending issue but proceed.
+  while IFS= read -r trunc_num; do
+    [[ -z "$trunc_num" ]] && continue
+    echo "warning: dispatch-select-target: ancestor chain deeper than supported depth (6) for issue $trunc_num; truncating" >&2
+  done < <(jq -r '.data.repository
+             | to_entries[]
+             | select(.value != null)
+             | select(.value.parent.parent.parent.parent.parent.parent.parent != null)
+             | .value.number' <<<"$GQL_RESP")
 fi
 
 # Topic categories in priority order; "other" is the implicit fallback for any

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -372,9 +372,28 @@ case "$args" in
     # Batched blockedBy lookup for dispatch-select-target (#794). The query text
     # arrives in $args as the -f query= value; extract each issue number and
     # project the existing blockers-<num>.json fixture (default []) into the
-    # GraphQL alias shape _<num>: { number, blockedBy { nodes { state } } }. This
-    # reuses the same fixtures the REST blocked_by case serves, so the
+    # GraphQL alias shape _<num>: { number, blockedBy { nodes { state } }, parent }.
+    # This reuses the same fixtures the REST blocked_by case serves, so the
     # select-target blocked-skip tests pass via either delivery mechanism.
+    #
+    # parent fixture: parent-<num>.json holds a single parent number (e.g. "100"),
+    # or is absent. When absent, parent is null. When present, the parent chain is
+    # built recursively (following parent-<k>.json for each ancestor) up to 7
+    # levels deep, producing {number, parent:{number, parent:...null}}.
+    build_parent_json() {
+      local n="$1" depth="${2:-0}"
+      # Cap at 7 levels to prevent infinite loops on cyclic fixtures.
+      if [[ "$depth" -ge 7 ]] || [[ ! -f "$STUB_DIR/parent-${n}.json" ]]; then
+        echo "null"
+        return
+      fi
+      local p
+      p=$(cat "$STUB_DIR/parent-${n}.json")
+      [[ -z "$p" ]] && { echo "null"; return; }
+      local grandparent_json
+      grandparent_json=$(build_parent_json "$p" $(( depth + 1 )))
+      printf '{"number":%s,"parent":%s}' "$p" "$grandparent_json"
+    }
     echo "api graphql" >> "$STUB_DIR/gh-graphql-calls.log"
     nums=$(printf '%s' "$args" | grep -oE 'issue\(number: [0-9]+' | grep -oE '[0-9]+')
     aliases="{}"
@@ -386,8 +405,9 @@ case "$args" in
         fixture="[]"
       fi
       node=$(printf '%s' "$fixture" | jq -c '{nodes: [.[] | {state: .state}]}')
-      aliases=$(printf '%s' "$aliases" | jq -c --arg k "_${n}" --argjson num "$n" --argjson bb "$node" \
-        '.[$k] = {number: $num, blockedBy: $bb}')
+      parent_json=$(build_parent_json "$n" 0)
+      aliases=$(printf '%s' "$aliases" | jq -c --arg k "_${n}" --argjson num "$n" --argjson bb "$node" --argjson par "$parent_json" \
+        '.[$k] = {number: $num, blockedBy: $bb, parent: $par}')
     done <<< "$nums"
     printf '{"data":{"repository":%s}}\n' "$aliases"
     ;;
@@ -4555,6 +4575,71 @@ printf '[{"number":300,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"he
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
 assert_eq "--priority-only returns priority issue" "issue 400" "$result"
+teardown
+
+# PO-ANC1. A PR whose closing issue carries NO own `priority` label, but whose
+#           ancestor epic IS open and carries `priority`, is lifted into the
+#           priority tier via ancestor inheritance (#1914). In DEFAULT mode this
+#           PR (priority-via-ancestor) outranks an older PR whose closing issue
+#           carries `bug` but no priority. The priority axis is the outermost
+#           sort key, so the inherited-priority PR wins regardless of topic
+#           category or creation order.
+#
+#           Fixture:
+#             issue 100  labels: [priority]        (the open ancestor epic)
+#             issue 101  labels: [help wanted]      (leaf; child of 100 via parent-101.json)
+#             issue 200  labels: [bug]              (unrelated, non-priority issue)
+#             PR 10 (older, 2024-01-01) closes issue 200 (bug, no priority)
+#             PR 20 (newer, 2024-01-02) closes issue 101 (help wanted, no own
+#                     priority — priority only via ancestor 100)
+#           parent-101.json → 100; no parent-100.json; no parent-200.json
+#           issue-list.json: 100, 101, 200 — all open; issue 101 is help-wanted
+#             but has no own `priority` so it stays OUT of the issue priority
+#             tier (ISSUE_SORTED uses own labels only). Issues 100 and 200 lack
+#             `help wanted` and are never startable. The issue queue produces
+#             no priority-1 selection — only the PR path selects here.
+#
+#           This is the ONLY assertion that proves ancestor-priority lifts PR 20
+#           above PR 10. Without ancestor inheritance, both PRs have pri=0 and
+#           PR 10 (older) wins. With it, PR 20 gets pri=1 and wins outright.
+echo "Test: default mode — ancestor priority lifts PR over non-priority PR"
+setup
+UNION='['
+UNION+="$(make_pr_union 10 "10-bug-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
+UNION+="$(make_pr_union 20 "20-leaf-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":101}]')"
+UNION+=']'
+setup_union_pr_list "$UNION"
+# issue 100: priority epic (open ancestor of 101); issue 101: leaf (no own priority);
+# issue 200: plain bug. Neither 100 nor 200 has `help wanted`, so neither enters the
+# startable issue queue. Issue 101 has `help wanted` but no own `priority`, so it is
+# not in the priority issue tier and does not preempt the PR selection.
+printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]},{"number":101,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+# parent fixture: issue 101's parent is 100 (the priority epic); no grandparent.
+printf '100' > "$STUB_DIR/parent-101.json"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "ancestor priority lifts PR 20 over older PR 10 (default mode)" "pr 20 20-leaf-pr fix-checks" "$result"
+teardown
+
+# PO-ANC2. Same fixture, --priority-only mode. PR 10 (closes issue 200, no priority)
+#           is filtered by the early-skip guard. PR 20 (closes issue 101, no own
+#           priority but ancestor 100 is priority) passes the guard via inherited
+#           priority. The discriminator: without ancestor inheritance --priority-only
+#           returns empty (both bits 0); with it, returns pr 20.
+echo "Test: --priority-only — ancestor priority qualifies PR (PO-ANC2)"
+setup
+UNION='['
+UNION+="$(make_pr_union 10 "10-bug-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
+UNION+="$(make_pr_union 20 "20-leaf-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":101}]')"
+UNION+=']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]},{"number":101,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '100' > "$STUB_DIR/parent-101.json"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only ancestor priority qualifies PR 20" "pr 20 20-leaf-pr fix-checks" "$result"
 teardown
 
 # PO3. main is red and no latch issue open → main-broken fires first, before the


### PR DESCRIPTION
Closes #1914

## Problem

`dispatch-select-target` computes a per-PR `priority` bit as "1 if the union of
the PR's closing issues' **own** labels carries `priority`." When a `priority`
epic is decomposed into sub-issues that do not inherit the `priority` label, a PR
closing such a sub-issue scores `priority=0` and drops out of the priority tier
the moment it reaches the PR stage (review / fix-checks / qa). The priority a
human applied to the epic is silently lost exactly when the work is closest to
done.

## Fix

A PR's priority bit is now 1 when the closing issue's own labels carry `priority`
**OR any open ancestor** in its parent chain carries `priority`. Priority becomes
a property of the whole epic subtree, through every phase, with no per-sub-issue
label bookkeeping.

The fix extends the **existing** single batched GraphQL call rather than adding
round-trips — the GraphQL bucket is shared with `dispatch-apply-planned`'s
load-bearing label path, so the design adds **zero** new GraphQL calls. The
open-vs-closed ancestor decision falls out for free: ancestor labels are looked
up in the open-issues-only `ISSUE_LABELS_JSON` map, so closed intermediate
ancestors are simply absent and contribute nothing.

## Units

1. **Batched ancestor discovery** — extend the per-closing-issue GraphQL alias to
   also fetch a fixed-depth nested `parent` chain (walk depth 6, fetch 7 with a
   truncation sentinel). Capture the response once, project it twice: into the
   existing `BLOCKER_COUNTS` and a new `ANCESTOR_NUMS` map (closing-issue number →
   ancestor numbers). A non-null sentinel level emits a one-line stderr warning
   and proceeds.
2. **`pr_priority_bit()` helper** — computes the priority bit over the union of
   each closing issue's own labels plus its ancestors' labels, and replaces both
   PR-priority classification call sites (`--priority-only` early skip and main
   bucket classification). Category classification deliberately keeps using the
   closing issues' own labels only — inheriting an ancestor's *topic* would be
   wrong; the bug is priority-only.
3. **WAITING_NUM reseed-target fix** — in the `--priority-only` CI-pending branch,
   the reseed target now prefers a priority-direct closing issue but falls back to
   the first closing-issue number when a PR qualifies for the priority tier only
   via an ancestor, so such a CI-pending PR is not silently stranded from the
   CI-cadence reseed.
4. **Regression tests** — extend the `api graphql` test stub to emit a nested
   `parent` chain from a new `parent-<num>.json` fixture convention (defaulting to
   `null`, so existing tests are unaffected), plus a default-mode ordering test
   (a newer priority-via-ancestor PR outranks an older non-priority PR) and a
   `--priority-only` test (the ancestor-priority PR qualifies vs empty before the
   fix).

`dispatch-select-tick` is unchanged: its at-cap bypass and `N_PRIO` count both
consume `dispatch-select-target --priority-only` output, so the corrected
priority tier propagates to the tick automatically.

## Verification

Full suite passes: `bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`
→ 3045/3045 passed, 0 failed (including the two new ancestor-priority tests and
all existing `--priority-only` / blockedBy tests).
