### PR TITLE
queue-metrics-panel: guard runway card on runwayDays >= 0

### DIFF
--- a/office-hours/src/queue-metrics-panel.ts
+++ b/office-hours/src/queue-metrics-panel.ts
@@ -65,7 +65,9 @@ export function renderQueueMetricsPanel(
   const runwayValue = document.createElement("span");
   runwayValue.className = "capacity-card-value queue-runway-value";
   runwayValue.textContent =
-    metrics.runwayDays !== null ? `${metrics.runwayDays} days` : "growing";
+    metrics.runwayDays !== null && metrics.runwayDays >= 0
+      ? `${metrics.runwayDays} days`
+      : "growing";
   runwayCard.appendChild(runwayLabel);
   runwayCard.appendChild(runwayValue);
 

--- a/office-hours/test/queue-metrics-panel.test.ts
+++ b/office-hours/test/queue-metrics-panel.test.ts
@@ -60,6 +60,16 @@ describe("renderQueueMetricsPanel with runwayDays: null", () => {
   });
 });
 
+describe("renderQueueMetricsPanel with negative runwayDays", () => {
+  it("renders 'growing' when runwayDays is negative", () => {
+    const metrics: QueueMetricsSnapshot = { ...baseMetrics, runwayDays: -5, netDrainPerDay: -0.5 };
+    const section = renderQueueMetricsPanel(metrics);
+    const value = section.querySelector(".queue-runway-value");
+    expect(value).not.toBeNull();
+    expect(value!.textContent).toBe("growing");
+  });
+});
+
 describe("renderQueueMetricsPanel with null metrics", () => {
   it("renders the queue-metrics-heading", () => {
     const section = renderQueueMetricsPanel(null);


### PR DESCRIPTION
Closes #1669

## Summary

Mirror the `>= 0` runway guard into the production queue-metrics renderer.

`office-hours/src/queue-metrics-panel.ts` is the live queue-metrics renderer
(wired into `app-view.ts`). Its runway card only null-checked `runwayDays`, so a
negative value would render e.g. "-5 days" instead of "growing".

PR #1654 added the `>= 0` guard to `queue-band.ts`, but `renderQueueBand` has no
production caller — it is dead code — so that defense-in-depth never reached the
live UI. This PR copies the same guard into the production renderer.

## Changes

- `office-hours/src/queue-metrics-panel.ts` — the runway-value ternary now reads
  `metrics.runwayDays !== null && metrics.runwayDays >= 0`, matching
  `queue-band.ts:25`. A negative `runwayDays` renders "growing".
- `office-hours/test/queue-metrics-panel.test.ts` — added a regression test
  asserting a negative `runwayDays` renders "growing", mirroring the existing
  null-runway test.

## Verification

`npm test --prefix office-hours` — 274 passed, 0 failed (29 files), including the
new negative-runway case.
