### PR TITLE
office-hours: note main-qa exception in dispatch:office-hours label auto-clear comment

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours
@@ -108,8 +108,11 @@ case "$verb" in
     # a b c d = <N> <phase> <pr-or-dash> <worktree-path>. Launch a fresh
     # /office-hours session worker-style — a --bg job named office-hours-<N>,
     # rooted in the <N>-* worktree — then attach the human via attach. Rooting
-    # it in the worktree clears the dispatch:office-hours label (the strip hook
-    # resolves <N> from the cwd branch). The per-worktree concurrency lock is
+    # it in the worktree clears the dispatch:office-hours label for non-main-qa
+    # items (the strip hook resolves <N> from the cwd branch); for main-qa items
+    # the cwd is the main worktree (branch main), which the strip hook's ^[0-9]+
+    # discriminator does not match, so the label is NOT auto-cleared — see the
+    # header EXCEPTION note. The per-worktree concurrency lock is
     # held via the occupancy guard's office-hours-name check (see
     # worktree_has_live_session), which recognizes the office-hours-<N> session
     # as occupying the <N>-slug worktree.

--- a/.claude/skills/dispatch-propagate/scripts/office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours
@@ -29,8 +29,14 @@
 #                                   dispatch-spawn-office-hours; then attach the
 #                                   human to it. Born in the worktree, the session's
 #                                   branch is <N>-..., so the strip hook clears
-#                                   the dispatch:office-hours label and the
-#                                   session holds the per-worktree concurrency
+#                                   the dispatch:office-hours label. EXCEPTION:
+#                                   for main-qa items, cwd is the main worktree
+#                                   (branch `main`), which does not match the
+#                                   strip hook `^[0-9]+` discriminator — the
+#                                   label is NOT auto-cleared; closing the issue
+#                                   is what removes it from the queue (see
+#                                   SKILL.md Step 5). The session also holds the
+#                                   per-worktree concurrency
 #                                   lock via the occupancy guard's
 #                                   office-hours-name check in
 #                                   worktree_has_live_session, which recognizes


### PR DESCRIPTION
Closes #1755

## Summary

The header comment in `.claude/skills/dispatch-propagate/scripts/office-hours`
(the `office-hours <N> <phase> <pr> <worktree-path>` disposition block) stated
unconditionally that, because the spawned session's branch is `<N>-...`, the
strip hook clears the `dispatch:office-hours` label. That holds for the normal
case but is misleading for **main-qa** items: a main-qa session spawns with
cwd = the *main* worktree (branch `main`), so the `dispatch-office-hours-strip.sh`
hook's `grep -oE '^[0-9]+'` discriminator does not match — the label is **not**
auto-cleared, and closing the issue is what removes the item from the queue.

This PR appends a one-paragraph EXCEPTION note to that comment so a reader
understands both the standard case and the main-qa exception.

## Change

Comment-only edit to the office-hours entry script. No executable line changed;
`bash -n` parses cleanly. The exception wording mirrors the already-correct
prose in `office-hours/SKILL.md` Step 5 and the discriminator in
`.claude/hooks/dispatch-office-hours-strip.sh` — no behavior change.
