### PR TITLE
dispatch: extract shared GH_REPO derivation into gh_repo_from_remote helper

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-read-plan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-read-plan
@@ -20,6 +20,7 @@
 # so gh addresses the right repository from any caller cwd. A missing arg or a
 # non-numeric issue-num is a clear error, not a fallback (exit 2).
 set -euo pipefail
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 
 N="${1:-}"
 if [[ $# -ne 1 || -z "$N" ]]; then
@@ -37,15 +38,8 @@ common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
   echo "dispatch-read-plan: not inside a git repository" >&2; exit 1; }
 url="$(git --git-dir="$common_dir" config --get remote.origin.url 2>/dev/null)" || {
   echo "dispatch-read-plan: no remote.origin.url in git config at $common_dir" >&2; exit 1; }
-# Resolve owner/repo from the remote so gh addresses the repo independent of cwd
-# (dirname(common_dir) is not a working tree in the bare-repo + worktrees layout).
-# Handles https://github.com/<owner>/<repo>(.git) and git@github.com:<owner>/<repo>(.git).
-repo="${url%.git}"; repo="${repo#*github.com[:/]}"
-[[ -n "$repo" ]] || {
-  echo "dispatch-read-plan: could not resolve owner/repo from remote.origin.url ('$url')" >&2; exit 1; }
-[[ "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
-  echo "dispatch-read-plan: unexpected owner/repo format from remote.origin.url ('$url'): $repo" >&2; exit 1; }
-export GH_REPO="$repo"
+GH_REPO="$(gh_repo_from_remote "$url" dispatch-read-plan)" || exit 1
+export GH_REPO
 
 MARKER='<!-- dispatch:plan -->'
 PLAN_AUTHOR_ID="${DISPATCH_PLAN_AUTHOR_ID:-$(gh api user --jq '.id')}"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-write-plan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-write-plan
@@ -19,6 +19,7 @@
 # so gh addresses the right repository from any caller cwd. A missing arg, a
 # non-numeric issue-num, or empty STDIN is a clear error, not a fallback (exit 2).
 set -euo pipefail
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 
 N="${1:-}"
 if [[ $# -ne 1 || -z "$N" ]]; then
@@ -36,15 +37,8 @@ common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
   echo "dispatch-write-plan: not inside a git repository" >&2; exit 1; }
 url="$(git --git-dir="$common_dir" config --get remote.origin.url 2>/dev/null)" || {
   echo "dispatch-write-plan: no remote.origin.url in git config at $common_dir" >&2; exit 1; }
-# Resolve owner/repo from the remote so gh addresses the repo independent of cwd
-# (dirname(common_dir) is not a working tree in the bare-repo + worktrees layout).
-# Handles https://github.com/<owner>/<repo>(.git) and git@github.com:<owner>/<repo>(.git).
-repo="${url%.git}"; repo="${repo#*github.com[:/]}"
-[[ -n "$repo" ]] || {
-  echo "dispatch-write-plan: could not resolve owner/repo from remote.origin.url ('$url')" >&2; exit 1; }
-[[ "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
-  echo "dispatch-write-plan: unexpected owner/repo format from remote.origin.url ('$url'): $repo" >&2; exit 1; }
-export GH_REPO="$repo"
+GH_REPO="$(gh_repo_from_remote "$url" dispatch-write-plan)" || exit 1
+export GH_REPO
 
 MARKER='<!-- dispatch:plan -->'
 PLAN_AUTHOR_ID="${DISPATCH_PLAN_AUTHOR_ID:-$(gh api user --jq '.id')}"

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -36,10 +36,15 @@ resolve_issue_number() {
 # Prints owner/repo to stdout on success; on an empty/non-GitHub/malformed result,
 # prints a caller-prefixed message to stderr and returns 1.
 gh_repo_from_remote() {
-  local url="$1" caller="$2" repo
-  repo="${url%.git}"; repo="${repo#*github.com[:/]}"
-  if [[ -z "$repo" ]]; then
+  local url="$1" caller="$2" stripped repo
+  stripped="${url%.git}"
+  repo="${stripped#*github.com[:/]}"
+  if [[ -z "$stripped" ]]; then
     echo "$caller: could not resolve owner/repo from remote.origin.url ('$url')" >&2
+    return 1
+  fi
+  if [[ "$repo" == "$stripped" ]]; then
+    echo "$caller: remote is not a GitHub repository ('$url')" >&2
     return 1
   fi
   if [[ ! "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -28,6 +28,27 @@ resolve_issue_number() {
   echo "$num"
 }
 
+# Derive and validate owner/repo from a git remote URL.
+# Args: $1 = remote.origin.url value; $2 = caller name (error-message prefix).
+# Resolve owner/repo from the remote so gh addresses the repo independent of cwd
+# (dirname(common_dir) is not a working tree in the bare-repo + worktrees layout).
+# Handles https://github.com/<owner>/<repo>(.git) and git@github.com:<owner>/<repo>(.git).
+# Prints owner/repo to stdout on success; on an empty/non-GitHub/malformed result,
+# prints a caller-prefixed message to stderr and returns 1.
+gh_repo_from_remote() {
+  local url="$1" caller="$2" repo
+  repo="${url%.git}"; repo="${repo#*github.com[:/]}"
+  if [[ -z "$repo" ]]; then
+    echo "$caller: could not resolve owner/repo from remote.origin.url ('$url')" >&2
+    return 1
+  fi
+  if [[ ! "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+    echo "$caller: unexpected owner/repo format from remote.origin.url ('$url'): $repo" >&2
+    return 1
+  fi
+  printf '%s\n' "$repo"
+}
+
 # ---- parse_duration <str> — duration string to whole seconds ----------------
 # Accepts <int><unit> where unit is one of s|m|h|d|w (second/minute/hour/day/
 # week). Prints the duration in seconds on stdout and returns 0. On unparseable

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -28720,10 +28720,10 @@ git --git-dir="$mf_gl_root/.bare" worktree add -q "$mf_gl_root/worktrees/42-foo"
 if err=$( cd "$mf_gl_root/worktrees/42-foo" && env -u GH_REPO "$WP_WRITE" 42 <<<"PLAN" 2>&1 1>/dev/null ); then rc=0; else rc=$?; fi
 assert_eq "write-plan: non-GitHub remote malformed URL exits 1" "1" "$rc"
 TOTAL=$((TOTAL + 1))
-if [[ "$err" == *"unexpected owner/repo format"* ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: write-plan rejects non-GitHub remote URL with format-guard diagnostic"
+if [[ "$err" == *"remote is not a GitHub repository"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: write-plan rejects non-GitHub remote URL with not-GitHub diagnostic"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: write-plan rejects non-GitHub remote URL with format-guard diagnostic"
+  FAIL=$((FAIL + 1)); echo "  FAIL: write-plan rejects non-GitHub remote URL with not-GitHub diagnostic"
   echo "    actual: '$err'"
 fi
 git --git-dir="$mf_gl_root/.bare" worktree prune 2>/dev/null || true
@@ -28814,11 +28814,11 @@ else
   echo "    actual: '$err'"
 fi
 
-# Failure — non-GitHub remote: non-zero return, caller-prefixed format diagnostic.
+# Failure — non-GitHub remote: non-zero return, caller-prefixed not-GitHub diagnostic.
 if err=$( source "$SCRIPT_DIR/lib.sh"; gh_repo_from_remote "https://gitlab.com/a/b" probe 2>&1 1>/dev/null ); then rc=0; else rc=$?; fi
 assert_eq "gh_repo_from_remote: non-GitHub remote exits 1" "1" "$rc"
 TOTAL=$((TOTAL + 1))
-if [[ "$err" == *"probe: unexpected owner/repo format"* ]]; then
+if [[ "$err" == *"probe: remote is not a GitHub repository"* ]]; then
   PASS=$((PASS + 1)); echo "  PASS: gh_repo_from_remote non-GitHub remote emits caller-prefixed diagnostic"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: gh_repo_from_remote non-GitHub remote emits caller-prefixed diagnostic"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -28648,6 +28648,61 @@ rm -rf "$wp_two"
 rm -rf "$wp_root"
 unset DISPATCH_PLAN_AUTHOR_ID
 
+echo ""
+echo "=== gh_repo_from_remote ==="
+
+# gh_repo_from_remote is pure string logic (no git, no gh), so each case sources
+# the real lib.sh in a subshell and calls the helper directly. Success cases
+# assert the derived owner/repo; failure cases assert a non-zero return and that
+# the caller-name prefix appears in the stderr diagnostic (AC: error messages
+# include the caller name).
+
+# Success — HTTPS with .git suffix.
+if out=$( source "$SCRIPT_DIR/lib.sh"; gh_repo_from_remote "https://github.com/natb1/commons.systems.git" probe 2>/dev/null ); then rc=0; else rc=$?; fi
+assert_eq "gh_repo_from_remote: https .git → owner/repo" "natb1/commons.systems" "$out"
+assert_eq "gh_repo_from_remote: https .git → exit 0" "0" "$rc"
+
+# Success — HTTPS without .git suffix.
+out=$( source "$SCRIPT_DIR/lib.sh"; gh_repo_from_remote "https://github.com/natb1/commons.systems" probe 2>/dev/null )
+assert_eq "gh_repo_from_remote: https no-.git → owner/repo" "natb1/commons.systems" "$out"
+
+# Success — SSH scp-style.
+out=$( source "$SCRIPT_DIR/lib.sh"; gh_repo_from_remote "git@github.com:natb1/commons.systems.git" probe 2>/dev/null )
+assert_eq "gh_repo_from_remote: ssh → owner/repo" "natb1/commons.systems" "$out"
+
+# Failure — empty URL: non-zero return, caller-prefixed "could not resolve" diagnostic.
+if err=$( source "$SCRIPT_DIR/lib.sh"; gh_repo_from_remote "" probe 2>&1 1>/dev/null ); then rc=0; else rc=$?; fi
+assert_eq "gh_repo_from_remote: empty URL exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"probe: could not resolve owner/repo"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: gh_repo_from_remote empty URL emits caller-prefixed diagnostic"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: gh_repo_from_remote empty URL emits caller-prefixed diagnostic"
+  echo "    actual: '$err'"
+fi
+
+# Failure — non-GitHub remote: non-zero return, caller-prefixed format diagnostic.
+if err=$( source "$SCRIPT_DIR/lib.sh"; gh_repo_from_remote "https://gitlab.com/a/b" probe 2>&1 1>/dev/null ); then rc=0; else rc=$?; fi
+assert_eq "gh_repo_from_remote: non-GitHub remote exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"probe: unexpected owner/repo format"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: gh_repo_from_remote non-GitHub remote emits caller-prefixed diagnostic"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: gh_repo_from_remote non-GitHub remote emits caller-prefixed diagnostic"
+  echo "    actual: '$err'"
+fi
+
+# Failure — malformed owner/repo (no slash): non-zero return, format diagnostic.
+if err=$( source "$SCRIPT_DIR/lib.sh"; gh_repo_from_remote "https://github.com/onlyowner" probe 2>&1 1>/dev/null ); then rc=0; else rc=$?; fi
+assert_eq "gh_repo_from_remote: malformed owner/repo exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"probe: unexpected owner/repo format"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: gh_repo_from_remote malformed owner/repo emits caller-prefixed diagnostic"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: gh_repo_from_remote malformed owner/repo emits caller-prefixed diagnostic"
+  echo "    actual: '$err'"
+fi
+
 # ============================================================================
 # claim_fixed_vite_port (fixed Vite-port pool) tests
 # ============================================================================


### PR DESCRIPTION
Closes #1771

## What

`dispatch-read-plan` and `dispatch-write-plan` each carried a verbatim copy of
the same `GH_REPO` derivation-and-format-guard block: derive `owner/repo` from
`remote.origin.url`, guard it non-empty, guard it against
`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`, then `export GH_REPO`. The two copies
differed only in the per-script error prefix. This duplication was introduced by
PR #1712 (which added the format guard to both scripts) and flagged there as out
of scope.

This PR extracts the block into a single `gh_repo_from_remote <url> <caller>`
helper in the scripts' shared `lib.sh`, so the derivation logic lives in one
place.

## How

- **`lib.sh`** — add `gh_repo_from_remote(url, caller)`: pure string logic that
  prints `owner/repo` to stdout on success, and on an empty / non-GitHub /
  malformed result prints a `<caller>`-prefixed message to stderr and `return 1`
  (a sourced library function returns; it does not `exit`). The `<caller>`
  argument preserves the per-script error prefix so logs still identify the
  originating script. The URL-handling explanation that was duplicated inline
  now lives single-site in the helper's doc comment.
- **`dispatch-read-plan` / `dispatch-write-plan`** — source `lib.sh` after
  `set -euo pipefail`, then replace the inline block with
  `GH_REPO="$(gh_repo_from_remote "$url" <caller>)" || exit 1; export GH_REPO`.
  The `|| exit 1` turns the helper's `return 1` into the same script-level exit-1
  the inline guards produced.
- **`test-dispatch-scripts.sh`** — add a focused `gh_repo_from_remote` block
  asserting the helper directly: three success cases (HTTPS with/without `.git`,
  SSH scp-style) and three failure cases (empty URL, non-GitHub remote, malformed
  owner/repo), each checking the exit code and the caller-prefixed stderr
  diagnostic.

Behavior for valid HTTPS/SSH remotes and for the three failure cases is
unchanged.

## Verification

- `bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` —
  3069/3069 passed, including the new `gh_repo_from_remote` assertions and the
  existing end-to-end `dispatch-write-plan / dispatch-read-plan` block (the
  existing-behavior-parity check for valid remotes).
- End-to-end smoke: `dispatch-read-plan 1771` still resolves `GH_REPO` through
  the new helper and fetches the plan comment.
- Failure-path spot check: `gh_repo_from_remote "" probe` and
  `gh_repo_from_remote "https://gitlab.com/a/b" probe` both print a
  `probe:`-prefixed diagnostic and return 1.
