### PR TITLE
dispatch: pre-approve dispatch-plan-finalize in permissions.allow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,6 +42,7 @@
       "Bash(.claude/skills/dispatch-propagate/scripts/dispatch-mark-complete:*)",
       "Bash(.claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation:*)",
       "Bash(.claude/skills/dispatch-propagate/scripts/dispatch-mark-parse-job-done:*)",
+      "Bash(.claude/skills/dispatch-propagate/scripts/dispatch-plan-finalize:*)",
       "Bash(gh search:*)",
       "Bash(go build:*)",
       "Bash(go test:*)",


### PR DESCRIPTION
Closes #1822

## What

Adds one `permissions.allow` entry pre-approving the plan phase's terminal
script:

```json
"Bash(.claude/skills/dispatch-propagate/scripts/dispatch-plan-finalize:*)",
```

It sits in the contiguous block of dispatch phase-terminal script entries in
`.claude/settings.json`, immediately after `dispatch-mark-parse-job-done`.

## Why

In `auto` permission mode, dispatch phase terminal scripts are stopped by the
auto-mode classifier unless a narrow, script-path-pinned `permissions.allow`
rule pre-approves them at decision step 1. PR #1808 added such entries for the
implement / fix-conflicts / fix-checks / qa / review phase terminal scripts but
left out the **plan** phase's terminal script `dispatch-plan-finalize`
(explicitly noted as an out-of-scope follow-up in #1808's body).

`plan-issue/SKILL.md` calls `dispatch-plan-finalize` as its final model action
on both the re-finalize (skip) path and the full-run path. Without an allow
entry, the classifier stops at that terminal step in `auto` mode, breaking the
fully-unattended chain at the plan phase. This change adds the one missing entry
so the plan phase completes through its terminal step like the others.

## Verification

- **Mechanical:** the file remains valid JSON and contains the new entry —
  `jq -e '.permissions.allow | index("Bash(.claude/skills/dispatch-propagate/scripts/dispatch-plan-finalize:*)")' .claude/settings.json`
  succeeds (entry at index 41).
- **End-to-end (next unattended run, not CI):** in an `auto`-mode run that takes
  an issue through the plan phase, no auto-mode classifier confirmation fires at
  the `dispatch-plan-finalize` terminal step. Observable only on a real
  `auto`-mode run.

## Out of scope

No other settings keys, and no other sibling scripts (`dispatch-open-pr`,
`dispatch-write-plan`, `dispatch-apply-planned`, `dispatch-close-resolved`) —
those remain a separate follow-up, as in #1808.
