### PR TITLE
dispatch-token-audit: add P2b persist-wiring test for stdout mode

### DIFF
--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -402,6 +402,27 @@ GOT_P2=$(jq -S . "$CAPTURE_P2")
 WANT_P2=$(jq -S . "$JSON_OUT_P2")
 assert_eq "P2 gate-on: writer received full aggregate JSON" "$WANT_P2" "$GOT_P2"
 
+# P2b — gate ON stdout-mode (no --json-out): the assembled JSON piped to the
+# writer matches the script's own stdout (same $DOC, same pipe).
+CAPTURE_P2B="$FAKE_WRITER_DIR/captured-p2b.json"
+SENTINEL_P2B="$FAKE_WRITER_DIR/invoked-p2b"
+printf '#!/usr/bin/env bash\n: > %s\ncat > %s\n' "'$SENTINEL_P2B'" "'$CAPTURE_P2B'" \
+  > "$FAKE_WRITER_DIR/fake-writer-p2b"
+chmod +x "$FAKE_WRITER_DIR/fake-writer-p2b"
+OUT_P2B=$(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$ROOT"
+  export DISPATCH_AUDIT_AGGREGATES_ENABLED="1"
+  export DISPATCH_AUDIT_AGGREGATES_WRITER="$FAKE_WRITER_DIR/fake-writer-p2b"
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7
+)
+assert_eq "P2b stdout-mode: writer invoked" "1" \
+  "$([[ -e "$SENTINEL_P2B" ]] && echo 1 || echo 0)"
+# The document received by the writer must match the script's own stdout — both
+# are the same assembled JSON.
+GOT_P2B=$(jq -S . "$CAPTURE_P2B")
+WANT_P2B=$(jq -S . <<<"$OUT_P2B")
+assert_eq "P2b stdout-mode: writer received full aggregate JSON" "$WANT_P2B" "$GOT_P2B"
+
 # P3 — writer-fail: aggregate-usage.sh exits non-zero AND the json-out file
 # still exists (report written before the failing persist step).
 JSON_OUT_P3="$FAKE_WRITER_DIR/report-p3.json"


### PR DESCRIPTION
Closes #1890

## What

Adds a **P2b** persist-wiring test to
`.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh`, covering
the Firestore writer seam (`DISPATCH_AUDIT_AGGREGATES_WRITER`) in **stdout mode**
— `aggregate-usage.sh --days 7` without `--json-out`.

## Why

`aggregate-usage.sh` has two output paths that both feed the same writer pipe:

- **json-out path** — `printf '%s\n' "$DOC" >"$JSON_OUT"`, report to the file.
- **stdout path** — `printf '%s\n' "$DOC"`, report to stdout.

In both cases the writer receives `printf '%s' "$DOC"` over the same pipe. The
existing **P2** test only exercises the `--json-out` path. No test verified
writer delivery in stdout mode, so a future divergence between the two paths
could silently go unnoticed. P2b closes that gap.

## How

P2b mirrors P2's harness — a fake writer stub that captures its stdin and touches
a sentinel — but runs the script without `--json-out` and captures the script's
own stdout. It asserts:

- the writer was invoked (sentinel file exists), and
- the JSON the writer received equals the script's stdout (`jq -S .` normalized).

Reuses the in-file harness (`FAKE_WRITER_DIR`, the fake-writer `printf`/`chmod`
idiom, the subshell-with-exported-env form, `assert_eq`, `jq -S .`). No change to
`aggregate-usage.sh`, the writer `.mjs`, P1–P4, or any env-var seam.

## Verification

`bash .claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh` — all
61 cases pass (0 failures, exit 0), including the two new `P2b …` assertions and
the unchanged P1–P4.
