### PR TITLE
dispatch-token-audit: make by_phase_outcome filter an explicit allowlist

### DIFF
--- a/.claude/docs/outcome-envelope.md
+++ b/.claude/docs/outcome-envelope.md
@@ -150,9 +150,10 @@ source 2 before calling the emit script. The emitted value is the total.
   the marker line.
 - **Last-wins** precedence: if multiple envelope blocks appear in one transcript,
   the reader uses the last one.
-- Only top-level worker sessions emit. The reader excludes subagent transcripts,
-  so a subagent that happens to print the marker does not produce a stray
-  envelope.
+- The reader's `by_phase_outcome` reduce admits exactly two session types:
+  `worker` and `router-tick`. Subagent transcripts are excluded (a subagent
+  that happens to print the marker produces no stray envelope), and `recovery`
+  and `other` session types are also excluded — they are not envelope emitters.
 
 ## Adoption recipe for a new phase
 

--- a/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
@@ -500,14 +500,16 @@ def outcome_rates($o):
 
 # ---- by_phase_outcome (pooled hit-rate per envelope phase, #1860) ----
 # Keyed by the envelope's own `.phase` enum value (e.g. "review", "qa") — NOT by
-# skill name like $by_phase. DOUBLE-COUNT GUARD: fold ONLY non-subagent rows that
-# carry an envelope. Per the doc, only top-level worker sessions emit; a subagent
-# transcript that happens to print the marker is excluded so it cannot inflate
-# the pool. Counts are SUMMED across a phase's rows, then the same null-guarded
-# formulas are applied to the pooled sums (pooled rate, not a mean of per-run
-# rates). disposition_distribution counts rows per disposition enum value.
+# skill name like $by_phase. DOUBLE-COUNT GUARD: admit ONLY the allowlisted emitter
+# types — `worker` and `router-tick` — that carry an envelope. The `subagent`,
+# `recovery`, and `other` session types are excluded: subagents are nested
+# transcripts that cannot be top-level emitters, and recovery/other are not
+# proven envelope emitters. Counts are SUMMED across a phase's rows, then the
+# same null-guarded formulas are applied to the pooled sums (pooled rate, not a
+# mean of per-run rates). disposition_distribution counts rows per disposition
+# enum value.
 | ( reduce ( $rows[]
-             | select(.type != "subagent" and .outcome != null) ) as $r ({};
+             | select((.type == "worker" or .type == "router-tick") and .outcome != null) ) as $r ({};
       ($r.outcome.phase // "<unknown>") as $ph
       | ($r.outcome) as $o
       | .[$ph] as $cur

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -48,9 +48,11 @@ WORKER_ENV_JSON='{"schema":"dispatch.outcome.v1","phase":"review","repo":"natb1/
 ROUTER_ENV_JSON='{"schema":"dispatch.outcome.v1","phase":"qa","repo":"natb1/commons.systems","issue":999,"pr":1234,"base_sha":null,"findings_surfaced":0,"findings_actionable":0,"fixes_applied":0,"followups_filed":0,"subagents_launched":0,"disposition":"completed","terminated_reason":null}'
 SUBAGENT_ENV_JSON='{"schema":"dispatch.outcome.v1","phase":"review","repo":"natb1/commons.systems","issue":999,"pr":1234,"base_sha":"def456","findings_surfaced":1000,"findings_actionable":1000,"fixes_applied":1000,"followups_filed":1000,"subagents_launched":1000,"disposition":"escalated","terminated_reason":"subagent excluded"}'
 envelope_block() { printf '<!-- dispatch:outcome:v1 -->\n```json\n%s\n```' "$1"; }
+RECOVERY_ENV_JSON='{"schema":"dispatch.outcome.v1","phase":"review","repo":"natb1/commons.systems","issue":998,"pr":5555,"base_sha":"rec111","findings_surfaced":5555,"findings_actionable":4444,"fixes_applied":3333,"followups_filed":2222,"subagents_launched":1111,"disposition":"completed_with_fixes","terminated_reason":null}'
 WORKER_BLOCK="$(envelope_block "$WORKER_ENV_JSON")"
 ROUTER_BLOCK="$(envelope_block "$ROUTER_ENV_JSON")"
 SUBAGENT_BLOCK="$(envelope_block "$SUBAGENT_ENV_JSON")"
+RECOVERY_BLOCK="$(envelope_block "$RECOVERY_ENV_JSON")"
 
 ROOT=""
 
@@ -174,8 +176,34 @@ setup() {
 
   jq . "$router_jsonl" >/dev/null
 
-  # 4. Touch every .jsonl to now so they fall inside the window
-  touch "$worker_jsonl" "$subagent_jsonl" "$router_jsonl" "$subagent_b_jsonl"
+  # 4. Recovery session (NEGATIVE regression fixture, #1905):
+  #    $ROOT/-home-x-worktrees-998-recovery/sess-recovery.jsonl
+  #    Classifies as `recovery` (firstuser_str contains /recover-api-error).
+  #    Zero usage so token/price/baseline-proxy totals are unchanged.
+  #    Carries a RECOVERY_BLOCK envelope with distinctive 5555 counts;
+  #    by_phase_outcome MUST NOT include it after the allowlist filter change.
+  local recovery_dir="$ROOT/-home-x-worktrees-998-recovery"
+  mkdir -p "$recovery_dir"
+
+  local recovery_jsonl="$recovery_dir/sess-recovery.jsonl"
+
+  # line 1: first user line — classifies as recovery
+  printf '%s\n' '{"type":"user","message":{"content":"<command-name>/recover-api-error</command-name>"}}' \
+    >> "$recovery_jsonl"
+
+  # line 2: assistant — opus, normal gitBranch, ZERO usage so totals stay stable
+  printf '%s\n' '{"type":"assistant","gitBranch":"998-recovery","message":{"model":"claude-opus-4-8","usage":{"input_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0}}}' \
+    >> "$recovery_jsonl"
+
+  # line 3: outcome-envelope tool_result, no tool_use_id -> "unknown" payload bucket
+  jq -nc --arg c "$RECOVERY_BLOCK" \
+    '{type:"user",message:{content:[{type:"tool_result",content:$c}]}}' \
+    >> "$recovery_jsonl"
+
+  jq . "$recovery_jsonl" >/dev/null
+
+  # 5. Touch every .jsonl to now so they fall inside the window
+  touch "$worker_jsonl" "$subagent_jsonl" "$router_jsonl" "$subagent_b_jsonl" "$recovery_jsonl"
 
   export DISPATCH_AUDIT_PROJECTS_ROOT="$ROOT"
 }
@@ -221,6 +249,8 @@ assert_eq "by_session_type.subagent.sessions" "2" \
   "$(jq '.by_session_type.subagent.sessions' <<<"$OUT")"
 assert_eq 'by_session_type["router-tick"].sessions' "1" \
   "$(jq '.by_session_type["router-tick"].sessions' <<<"$OUT")"
+assert_eq "by_session_type.recovery.sessions" "1" \
+  "$(jq '.by_session_type.recovery.sessions' <<<"$OUT")"
 
 assert_eq 'by_phase["plan-implement"].output' "550" \
   "$(jq '.by_phase["plan-implement"].output' <<<"$OUT")"
@@ -254,10 +284,10 @@ assert_eq 'tool_sequences: no n-gram token keeps an env-var assignment' "0" \
 # computed from the same block strings so they track the fixture exactly.
 PAYLOAD_BASH=$(jq -n --arg e "$WORKER_BLOCK" \
   '("PAYLOAD_0123456789"|utf8bytelength) + ($e|utf8bytelength)')
-PAYLOAD_UNKNOWN=$(jq -n --arg r "$ROUTER_BLOCK" --arg s "$SUBAGENT_BLOCK" \
-  '("Exit code 1\nsome detail"|utf8bytelength) + ($r|utf8bytelength) + ($s|utf8bytelength)')
-PAYLOAD_TOTAL=$(jq -n --arg e "$WORKER_BLOCK" --arg r "$ROUTER_BLOCK" --arg s "$SUBAGENT_BLOCK" \
-  '("PAYLOAD_0123456789"|utf8bytelength) + ("Exit code 1\nsome detail"|utf8bytelength) + ($e|utf8bytelength) + ($r|utf8bytelength) + ($s|utf8bytelength)')
+PAYLOAD_UNKNOWN=$(jq -n --arg r "$ROUTER_BLOCK" --arg s "$SUBAGENT_BLOCK" --arg recovery "$RECOVERY_BLOCK" \
+  '("Exit code 1\nsome detail"|utf8bytelength) + ($r|utf8bytelength) + ($s|utf8bytelength) + ($recovery|utf8bytelength)')
+PAYLOAD_TOTAL=$(jq -n --arg e "$WORKER_BLOCK" --arg r "$ROUTER_BLOCK" --arg s "$SUBAGENT_BLOCK" --arg recovery "$RECOVERY_BLOCK" \
+  '("PAYLOAD_0123456789"|utf8bytelength) + ("Exit code 1\nsome detail"|utf8bytelength) + ($e|utf8bytelength) + ($r|utf8bytelength) + ($s|utf8bytelength) + ($recovery|utf8bytelength)')
 
 assert_eq "payload_bytes.total" "$PAYLOAD_TOTAL" \
   "$(jq '.payload_bytes.total' <<<"$OUT")"
@@ -279,16 +309,16 @@ assert_eq 'context_over_120k.by_phase["review-fix"].sessions' "1" \
   "$(jq '.lenses.context_over_120k.by_phase["review-fix"].sessions' <<<"$OUT")"
 
 # --- baseline_context lens ---
-# baseline_context counts ALL sessions (rows). Our PR's agent-bbb is a 4th
-# in-window transcript, so sessions==4. Its first assistant msg has init
+# baseline_context counts ALL sessions (rows). The recovery session (#1905) is a
+# 5th in-window transcript, so sessions==5. Its first assistant msg has init
 # input=0/cc=0 → boot=0, so it does not change peak_boot_tokens (still 3000)
-# nor total_proxy_usd. Boot-token list across the four sessions sorts to
-# [0, 3, 30, 3000]; the even-length median is (3+30)/2 = 16.5.
-assert_eq "lenses.baseline_context.sessions" "4" \
+# nor total_proxy_usd. Boot-token list across the five sessions sorts to
+# [0, 0, 3, 30, 3000]; the odd-length (5) median is the middle value = 3.
+assert_eq "lenses.baseline_context.sessions" "5" \
   "$(jq '.lenses.baseline_context.sessions' <<<"$OUT")"
 assert_eq "lenses.baseline_context.peak_boot_tokens" "3000" \
   "$(jq '.lenses.baseline_context.peak_boot_tokens' <<<"$OUT")"
-assert_eq "lenses.baseline_context.median_boot_tokens" "16.5" \
+assert_eq "lenses.baseline_context.median_boot_tokens" "3" \
   "$(jq '.lenses.baseline_context.median_boot_tokens' <<<"$OUT")"
 assert_eq "lenses.baseline_context.total_proxy_usd" "$EXPECTED_BASELINE_PROXY" \
   "$(jq '.lenses.baseline_context.total_proxy_usd' <<<"$OUT")"
@@ -338,6 +368,15 @@ assert_eq "by_phase_outcome.qa.disposition_distribution.completed" "1" \
 # subagent's 1000-count envelope.
 assert_eq "by_phase_outcome.review excludes subagent (not 1008)" "true" \
   "$(jq '.by_phase_outcome.review.findings_surfaced == 8' <<<"$OUT")"
+
+# Recovery exclusion (#1905 negative regression): the recovery session carries a
+# review envelope with findings_surfaced=5555. The allowlist filter admits only
+# worker and router-tick, so recovery is excluded. Without the fix the old
+# blocklist would admit it and findings_surfaced would be 5563 instead of 8.
+assert_eq "by_session_type.recovery.sessions (recovery is ingested)" "1" \
+  "$(jq '.by_session_type.recovery.sessions' <<<"$OUT")"
+assert_eq "by_phase_outcome.review.findings_surfaced excludes recovery (not 5563)" "8" \
+  "$(jq '.by_phase_outcome.review.findings_surfaced' <<<"$OUT")"
 
 # Per-run rates on the worker session entry (#1860 AC: per-run hit-rate).
 assert_eq "sessions[sess-worker].outcome.findings_surfaced" "8" \


### PR DESCRIPTION
Closes #1905

## Summary

The `by_phase_outcome` aggregate in `aggregate-usage.sh` pools dispatch sessions
by their outcome-envelope `phase` to compute per-phase hit-rates (#1860). Its row
filter was an **exclusive blocklist**:

```jq
select(.type != "subagent" and .outcome != null)
```

That admits *any* non-subagent session carrying an envelope — including the
`other` fallthrough/misclassification bucket and `recovery`. A mis-classified
session that happened to contain an envelope marker would be folded into the pool
silently, inflating the per-phase counts. The DOUBLE-COUNT GUARD comment and
`.claude/docs/outcome-envelope.md` § Reader contract both describe the *intent* as
an allowlist ("only … emit"), so the implementation was weaker than the stated
contract.

This converts the filter to an explicit **allowlist** of the two proven emitter
session types:

```jq
select((.type == "worker" or .type == "router-tick") and .outcome != null)
```

## Why `{worker, router-tick}`

The type classifier produces exactly five `.type` values — `subagent`,
`recovery`, `router-tick`, `worker`, `other`. Evidence per type:

- **`worker`** — proven emitter; the existing fixture's worker session emits a
  `review` envelope counted in `by_phase_outcome.review`.
- **`router-tick`** — proven emitter; the existing fixture's router-tick session
  emits a `qa` envelope counted in `by_phase_outcome.qa`.
- **`subagent`** — excluded by the doc § Reader contract; a subagent that prints
  the marker must not fold in.
- **`recovery`** — excluded; no verifiable evidence it emits an envelope.
- **`other`** — excluded; this is the unclassified fallthrough bucket, exactly the
  silent-inflation source this change targets.

## Changes

- **`aggregate-usage.sh`** — filter switched to the allowlist; DOUBLE-COUNT GUARD
  comment rewritten to describe the allowlist and name the excluded set.
- **`outcome-envelope.md`** § Reader contract — the bullet now names the same
  `{worker, router-tick}` set as the code (the old sentence omitted router-tick,
  which does emit).
- **`test-aggregate-usage.sh`** — a `recovery`-typed session carrying a distinctive
  `5555`-count `review` envelope is added; the new assertions prove it is *ingested*
  (`by_session_type.recovery.sessions == 1`) but *excluded* from the pool
  (`by_phase_outcome.review.findings_surfaced == 8`, unchanged — it would be `5563`
  under the old blocklist). The session carries zero usage, so the only other
  assertions that move are the four bookkeeping items it ripples into
  (`baseline_context.sessions`, `median_boot_tokens`, and the two `payload_bytes`
  byte totals), all recomputed rather than guessed.

## Verification

`bash .claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh` →
**64/64 passed**.
