### PR TITLE
review-fix: rename result key followups_filed to followups_deferred and clarify --followups-filed emit instructions

### DIFF
--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -352,6 +352,8 @@ prepared filing structures in `result.deferred_filings` and
 `result.security_followup_input`; this skill executes the actual `gh` calls.
 Skip a path when its bucket is empty.
 
+`result.followups_deferred` is the count of Step-5a filing subagents the Workflow queued (not yet filed); it drives the Step-5a fan-out and is NOT the value emitted to `--followups-filed`. Track instead how many Step-5a and Step-5b follow-ups were ACTUALLY filed this run — count only NEW `<disposition>` records (EXISTING records returned by `/file-issue` were not filed this phase). Use the already-captured `<N>` records from the "Capture each `<N>`" lines in 5a and 5b for this count; introduce no new tracking mechanism. Pass that count, not `result.followups_deferred`, as the `--followups-filed` total.
+
 #### 5a. Deferred code-review/review findings → `/file-issue` with a blocked-by link
 
 The Workflow prepares `result.deferred_filings`, each entry carrying `title`,
@@ -597,7 +599,7 @@ REPO=$(git remote get-url origin | sed -E 's#.*github.com[:/]##; s#\.git$##')
   --findings-surfaced <result.findings_surfaced> \
   --findings-actionable <result.findings_actionable> \
   --fixes-applied <result.fixes_applied> \
-  --followups-filed <result.followups_filed + count of Step-5b security follow-ups actually filed> \
+  --followups-filed <count of NEW Step-5a follow-ups filed this run + count of NEW Step-5b security follow-ups filed this run> \
   --subagents-launched <result.subagents_launched + count of Step-5a and Step-5b filing subagents this SKILL spawned> \
   --disposition escalated \
   --terminated-reason "/review-fix: high-confidence required security finding(s) left unresolved after fixes"
@@ -635,7 +637,7 @@ REPO=$(git remote get-url origin | sed -E 's#.*github.com[:/]##; s#\.git$##')
   --findings-surfaced <result.findings_surfaced> \
   --findings-actionable <result.findings_actionable> \
   --fixes-applied <result.fixes_applied> \
-  --followups-filed <result.followups_filed + count of Step-5b security follow-ups actually filed> \
+  --followups-filed <count of NEW Step-5a follow-ups filed this run + count of NEW Step-5b security follow-ups filed this run> \
   --subagents-launched <result.subagents_launched + count of Step-5a and Step-5b filing subagents this SKILL spawned> \
   --disposition <result.disposition>
 ```

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -891,9 +891,11 @@ const dispositions = deduped.map((f) => {
 // --- outcome-envelope counts (Unit 3, issue #1860) ---------------------------
 // Computed per .claude/docs/outcome-envelope.md. Unit 4 passes these straight
 // into dispatch-emit-outcome; Unit 5 aggregates them. Additive only.
+// Exception: followups_deferred is the deferred-filing QUEUE depth, NOT
+// passed straight through — the SKILL body emits its OWN actual filed count.
 const findings_surfaced = dispositions.length; // every deduped finding, any bucket
 const fixes_applied = fixed.length; // = the count of Fixed-bucket dispositions
-const followups_filed = deferred_filings.length; // this Workflow's OWN deferred filings
+const followups_deferred = deferred_filings.length; // deferred-filing QUEUE depth (Step-5a entries the SKILL body must still file); NOT a filed count
 // findings_actionable: dispositions whose FINAL bucket ∈ {Fixed, Required, Deferred}.
 // Compute from `dispositions` (the post-remap array) NOT `deduped`: dispositions
 // remaps refuted/unverified Required findings to Refuted/Unverified, so Required
@@ -925,7 +927,7 @@ return {
   findings_surfaced,
   findings_actionable,
   fixes_applied,
-  followups_filed,
+  followups_deferred,
   subagents_launched: subagentsLaunched,
   disposition,
 };


### PR DESCRIPTION
Closes #1908

## Summary

The review-fix Workflow only *queues* deferred filings in `deferred_filings` —
the actual `gh issue create` calls happen later in the review-fix SKILL body
(Step 5a). So the result-object key `followups_filed` (past tense, implies
completion) misnamed a pending queue, and the two `--followups-filed` emit
blocks double-counted: they added that queue depth to the Step-5b filed count
even though the Step-5a entries were still unfiled at emit time.

This renames the misleading result-object key and corrects the emit
instructions so the count reported to the outcome envelope is the number the
SKILL body **actually filed this run**.

## Changes

- **`.claude/workflows/review-fix.js`** — rename the result-object key
  `followups_filed` → `followups_deferred`, with a comment stating it is the
  deferred-filing **queue depth** (Step-5a entries the SKILL body must still
  file), not a filed count. Note the exception in the outcome-envelope-counts
  comment block: unlike the other counts, this one is **not** passed straight
  through — the SKILL body emits its own actual filed count.
- **`.claude/skills/review-fix/SKILL.md`** — rewrite both `--followups-filed`
  emit blocks (deviation + no-deviation paths) to pass `<count of NEW Step-5a
  follow-ups filed this run + count of NEW Step-5b security follow-ups filed
  this run>`, with no reference to the deferred-queue depth in the arithmetic.
  Add one clarifying note in the Step 5 preamble: `result.followups_deferred`
  drives the Step-5a fan-out and is **not** the value emitted; the SKILL body
  counts only NEW `<disposition>` records (EXISTING/already-tracked records were
  not filed this phase), reusing the already-captured Step-5a/5b `<N>` records.

## Scope boundary

The `dispatch.outcome.v1` envelope field and the `--followups-filed` CLI flag
**keep** the name `followups_filed` — they genuinely mean "follow-ups the phase
filed." The result-key↔envelope-field mismatch is deliberate: the result key
names what the Workflow holds (a queue), and the SKILL body maps the actual
filed count into the envelope's `followups_filed`. `qa-fix.js`
(`followups_filed = 0`), `outcome-envelope.md`, `aggregate-usage.sh`, and the
envelope tests are out of scope and unchanged.

## Verification

By inspection — no runtime harness exercises review-fix.js's result object:

- `grep -n "followups_filed" .claude/workflows/review-fix.js` → no matches.
- `grep -n "followups_deferred" .claude/workflows/review-fix.js` → const + return shorthand.
- `grep -rn "result.followups_filed" .claude/skills/review-fix/SKILL.md` → no matches.
- Both emit lines read the NEW-only wording; the envelope field name is untouched repo-wide.
- `node --check .claude/workflows/review-fix.js` → clean.
