### PR TITLE
dispatch-token-audit: null-ify partial outcome envelopes at the reader

### DIFF
--- a/.claude/docs/outcome-envelope.md
+++ b/.claude/docs/outcome-envelope.md
@@ -153,6 +153,13 @@ source 2 before calling the emit script. The emitted value is the total.
 - Only top-level worker sessions emit. The reader excludes subagent transcripts,
   so a subagent that happens to print the marker does not produce a stray
   envelope.
+- **Strict count validation**: an envelope that parses as JSON but is missing
+  any of the three rate-feeding counts — `findings_surfaced`,
+  `findings_actionable`, `fixes_applied` (each non-nullable here) — is null-ified
+  and treated as **absent**, exactly like a session with no envelope. The reader
+  never coerces a partial envelope into a zero-count object, so a partial
+  envelope can never produce a fabricated `0` rate. (`followups_filed` and
+  `subagents_launched` are not validated this way — they do not feed any rate.)
 
 ## Adoption recipe for a new phase
 

--- a/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
@@ -268,6 +268,19 @@ def cmd_prefix(c):
 # tool_results in document order and take the last. fromjson is wrapped in
 # try/catch so a malformed envelope binds null and NEVER aborts the file —
 # mirroring the clear-error/files_failed philosophy.
+#
+# STRICT VALIDATION (#1909): after a successful fromjson, a PARTIAL envelope
+# (valid JSON missing a required rate-feeding count key) binds null and is
+# treated as ABSENT — never coerced to a zero-count object. The doc marks the
+# three rate-feeding counts (findings_surfaced, findings_actionable,
+# fixes_applied) non-nullable, so we validate each is a `number` (a type check
+# catches both a missing key AND an explicit null). Without this, rate()'s
+# `($num // 0)` would silently fabricate a 0 rate from a partial envelope. Per
+# .claude/rules/code-style.md (clear errors over defensive fallbacks), surface
+# the gap as outcome:null instead. This single stage-1 chokepoint propagates to
+# per-session outcome/outcome_rates and pooled by_phase_outcome downstream.
+# followups_filed/subagents_launched are intentionally NOT validated here —
+# they do not feed rate(), so they keep their `// 0` coercion downstream.
 | ( [ $msgs[]
       | select(.type=="user")
       | .message.content
@@ -277,7 +290,12 @@ def cmd_prefix(c):
       | match("<!-- dispatch:outcome:v1 -->\\s*```json\\s*(?<j>.*?)\\s*```"; "gm")
       | .captures[0].string
     ] | last // null ) as $outcome_raw
-| ( ($outcome_raw // "") | try fromjson catch null ) as $outcome
+| ( ($outcome_raw // "") | try fromjson catch null ) as $parsed
+| ( if ($parsed | type) == "object"
+      and ($parsed.findings_surfaced   | type) == "number"
+      and ($parsed.findings_actionable | type) == "number"
+      and ($parsed.fixes_applied       | type) == "number"
+    then $parsed else null end ) as $outcome
 
 # Ordered per-session token list of tool calls, in document order. Bash calls
 # become "Bash:<cmd_prefix>"; other tools become their name.

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -473,5 +473,65 @@ assert_eq "P4 stdout pure JSON (no leak): valid JSON" "object" \
 assert_eq "P4 stdout pure JSON (no leak): token absent" "0" \
   "$(grep -c 'LEAKED-DOCID' <<<"$OUT_P4" || true)"
 
+# ---------------------------------------------------------------------------
+# Partial-envelope null-ification (#1909). ISOLATED fixture: a fresh projects
+# root with ONE non-subagent worker session whose envelope OMITS the required
+# count key `findings_surfaced` (otherwise well-formed). The reader must treat
+# this partial envelope as ABSENT (outcome:null) — never coerce the missing
+# count to a zero, which rate()'s `($num // 0)` would otherwise turn into a
+# fabricated 0 rate.
+#
+# Built in its own mktemp root (NOT the shared setup() tree) so the existing
+# count assertions are untouched. The session lives under a -worktrees- path,
+# NOT a /subagents/ one, so a clean fix (not the unrelated subagent exclusion)
+# is what keeps it out of by_phase_outcome.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- partial-envelope null-ification (#1909) ---"
+
+# Partial envelope: findings_surfaced OMITTED; everything else mirrors the valid
+# worker envelope (phase "review", the other two counts present as numbers).
+PARTIAL_ENV_JSON='{"schema":"dispatch.outcome.v1","phase":"review","repo":"natb1/commons.systems","issue":1909,"pr":2000,"base_sha":"aaa111","findings_actionable":5,"fixes_applied":3,"followups_filed":2,"subagents_launched":12,"disposition":"completed_with_fixes","terminated_reason":null}'
+PARTIAL_BLOCK="$(envelope_block "$PARTIAL_ENV_JSON")"
+
+PARTIAL_ROOT=$(mktemp -d)
+partial_worktree="$PARTIAL_ROOT/-home-x-worktrees-1909-partial"
+mkdir -p "$partial_worktree"
+partial_jsonl="$partial_worktree/sess-partial.jsonl"
+
+# line 1: first user line — classifies as worker (mirror line 68)
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+  >> "$partial_jsonl"
+# line 2: assistant — opus, minimal usage (mirror the worker assistant shape)
+printf '%s\n' '{"type":"assistant","attributionSkill":"review-fix","isSidechain":false,"gitBranch":"1909-partial","message":{"model":"claude-opus-4-8","content":[{"type":"tool_use","id":"toolu_p01","name":"Bash","input":{"command":"echo hi"}}],"usage":{"input_tokens":1,"cache_creation_input_tokens":2,"cache_read_input_tokens":4,"output_tokens":1}}}' \
+  >> "$partial_jsonl"
+# line 3: partial outcome-envelope tool_result (mirror lines 106–108)
+jq -nc --arg c "$PARTIAL_BLOCK" \
+  '{type:"user",message:{content:[{type:"tool_result",tool_use_id:"toolu_p01",content:$c}]}}' \
+  >> "$partial_jsonl"
+jq . "$partial_jsonl" >/dev/null
+touch "$partial_jsonl"
+
+OUT_PARTIAL=$(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$PARTIAL_ROOT"
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7
+)
+
+# (a) the session's per-run outcome is null (partial envelope treated as absent)
+assert_eq "partial-envelope sessions[sess-partial].outcome is null" "null" \
+  "$(jq '[.sessions[]|select(.id=="sess-partial")][0].outcome' <<<"$OUT_PARTIAL")"
+# (b) its outcome_rates is null too (no fabricated 0 rate)
+assert_eq "partial-envelope sessions[sess-partial].outcome_rates is null" "null" \
+  "$(jq '[.sessions[]|select(.id=="sess-partial")][0].outcome_rates' <<<"$OUT_PARTIAL")"
+# (c) by_phase_outcome carries NO entry for the envelope's "review" phase — the
+# null outcome is filtered at the pool, so the whole object is empty ({}). An
+# absent bucket is `null`, not `0`, so we assert the object is {} (not
+# .review.sessions == 0, which would itself be null).
+assert_eq "partial-envelope by_phase_outcome is empty {} (no fabricated entry)" "{}" \
+  "$(jq -c '.by_phase_outcome' <<<"$OUT_PARTIAL")"
+
+rm -rf "$PARTIAL_ROOT"
+
 report_results
 exit $FAIL

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -535,6 +535,7 @@ PARTIAL_ENV_JSON='{"schema":"dispatch.outcome.v1","phase":"review","repo":"natb1
 PARTIAL_BLOCK="$(envelope_block "$PARTIAL_ENV_JSON")"
 
 PARTIAL_ROOT=$(mktemp -d)
+trap 'rm -rf "$PARTIAL_ROOT" "$FAKE_WRITER_DIR"; teardown' EXIT INT TERM
 partial_worktree="$PARTIAL_ROOT/-home-x-worktrees-1909-partial"
 mkdir -p "$partial_worktree"
 partial_jsonl="$partial_worktree/sess-partial.jsonl"


### PR DESCRIPTION
Closes #1909

## Problem

`dispatch-token-audit`'s stage-2 jq `rate($num; $den)` helper
(`aggregate-usage.sh:377`) guards its denominator (`($den // 0) == 0` → `null`,
no divide-by-zero) but coerces the **numerator** with `($num // 0)`. A *partial*
outcome envelope — valid JSON that survives the stage-1 `try fromjson catch null`
guard but is missing a required count key — therefore yields a silently-wrong
`0` rate instead of signalling the gap. An envelope missing `findings_surfaced`,
for example, produces `hit_rate = (null // 0) / 3 = 0.0`, masking the missing
field.

The writer (`dispatch-emit-outcome`) already `_require`s all three count flags,
so a partial envelope is **not** reachable through the normal emit path today —
only via a future phase-adopter that hand-builds an envelope, or a corrupted /
hand-edited transcript. This is a reader-side trust-boundary fix: per
`.claude/rules/code-style.md` (prefer clear errors over defensive fallbacks), the
reader must surface the gap rather than fabricate a `0`.

## Fix (Option 1 — strict validation)

Null-ify a partial envelope at the **single stage-1 chokepoint** so it is treated
as `outcome: null` everywhere downstream:

```jq
| ( ($outcome_raw // "") | try fromjson catch null ) as $parsed
| ( if ($parsed | type) == "object"
      and ($parsed.findings_surfaced   | type) == "number"
      and ($parsed.findings_actionable | type) == "number"
      and ($parsed.fixes_applied       | type) == "number"
    then $parsed else null end ) as $outcome
```

A **type check** (not `has()`) validates each count is a number, catching both a
missing key *and* an explicit `"findings_surfaced": null`. One edit covers both
consumers automatically: per-session `outcome` / `outcome_rates`, and pooled
`by_phase_outcome` (whose `.outcome != null` filter already drops the null-ified
envelope).

`followups_filed` and `subagents_launched` stay `// 0`-coerced by design — they
do not feed `rate()`, and #1909 is scoped to the three rate numerators.

## Changes

- `aggregate-usage.sh` — the chokepoint edit, plus an expanded outcome-envelope
  comment block documenting the null-ification and the followups/subagents
  exclusion.
- `.claude/docs/outcome-envelope.md` — a Reader-contract bullet documenting that
  a partial envelope is treated as absent (no fabricated `0` rates).
- `test-aggregate-usage.sh` — a new **isolated** regression section (fresh
  `mktemp -d` projects root, one worker session with a `findings_surfaced`-less
  envelope) asserting `outcome == null`, `outcome_rates == null`, and no
  fabricated `by_phase_outcome` bucket. The shared `setup()` fixture is untouched,
  so existing count assertions are unchanged.

## Verification

- `test-aggregate-usage.sh`: 69/69 passed (66 prior + 3 new).
- `test-audit-aggregate-writer.sh`: 32 passed, unchanged.
- Reverted-fix check confirms the three new assertions genuinely flip under the
  fix (they fail against the pre-fix script), proving they exercise the bug.
