### PR TITLE
test-dispatch-scripts: add PO-ANC3 depth-2 ancestor priority test

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -4829,6 +4829,34 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "depth-2 ancestor priority lifts PR 20 over older PR 10 (PO-ANC3)" "pr 20 20-leaf-pr fix-checks" "$result"
 teardown
 
+# PO-ANC4. Depth-2 ancestor priority, --priority-only mode. Same fixture as
+#           PO-ANC3, but exercises the `--priority-only` early-skip guard, which
+#           also calls pr_priority_bit (dispatch-select-target line 811-812) and
+#           its depth-2 ANCESTOR_NUMS traversal. PR 10 (closes issue 200, no
+#           priority) is filtered by the guard; PR 20 (closes issue 101, priority
+#           only via grandparent 100 through intermediate 102) passes the guard via
+#           inherited priority. The discriminator: a 1-level recursion bug would see
+#           only the neutral intermediate 102, leave PR 20 with pri=0, and
+#           --priority-only would return empty (both bits 0); with depth-2 recursion
+#           it returns pr 20. Mirrors the PO-ANC1/PO-ANC2 (depth-1) pattern at depth 2.
+echo "Test: --priority-only — depth-2 ancestor priority qualifies PR (PO-ANC4)"
+setup
+UNION='['
+UNION+="$(make_pr_union 10 "10-bug-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
+UNION+="$(make_pr_union 20 "20-leaf-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":101}]')"
+UNION+=']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]},{"number":102,"created_at":"2024-01-01T00:00:00Z","labels":[]},{"number":101,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+# 2-hop parent chain: 101 → 102 → 100. Priority sits on the grandparent (100).
+printf '102' > "$STUB_DIR/parent-101.json"   # 101 → 102
+printf '100' > "$STUB_DIR/parent-102.json"   # 102 → 100
+# no parent-100.json — chain terminates at the grandparent
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only depth-2 ancestor priority qualifies PR 20 (PO-ANC4)" "pr 20 20-leaf-pr fix-checks" "$result"
+teardown
+
 # PO3. main is red and no latch issue open → main-broken fires first, before the
 #      priority scan (the gate runs ahead of the ladder, same as default mode).
 echo "Test: --priority-only — main red, no latch → main-broken (gate first)"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -4786,6 +4786,49 @@ result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
 assert_eq "--priority-only ancestor priority qualifies PR 20" "pr 20 20-leaf-pr fix-checks" "$result"
 teardown
 
+# PO-ANC3. Depth-2 ancestor priority. Same shape as PO-ANC1, but the `priority`
+#           label sits on the GRANDPARENT (issue 100), reached through a
+#           NON-priority intermediate parent (issue 102). The assertion passes
+#           only if ancestor detection recurses to depth 2: a 1-level recursion
+#           bug would see only the intermediate 102 (no priority), fail to lift
+#           PR 20, and let the older PR 10 win. So this assertion proves the
+#           depth-2 `recurse`/`.[1:7]` ancestor path detects inherited priority
+#           through a multi-hop chain.
+#
+#           Fixture:
+#             issue 100  labels: [priority]        (open grandparent epic)
+#             issue 102  labels: []                (intermediate parent; NO priority)
+#             issue 101  labels: [help wanted]     (leaf; child of 102 via parent-101.json)
+#             issue 200  labels: [bug]             (unrelated, non-priority issue)
+#             PR 10 (older, 2024-01-01) closes issue 200 (bug, no priority)
+#             PR 20 (newer, 2024-01-02) closes issue 101 (help wanted, no own
+#                     priority — priority only via grandparent 100)
+#           parent-101.json → 102; parent-102.json → 100; no parent-100.json.
+#           Issue 102's neutral labels keep it out of the startable issue queue so
+#           it does not perturb selection. Without depth-2 recursion both PRs have
+#           pri=0 and PR 10 (older) wins; with it PR 20 gets pri=1 and wins.
+echo "Test: default mode — depth-2 ancestor priority lifts PR over non-priority PR"
+setup
+UNION='['
+UNION+="$(make_pr_union 10 "10-bug-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
+UNION+="$(make_pr_union 20 "20-leaf-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":101}]')"
+UNION+=']'
+setup_union_pr_list "$UNION"
+# issue 100: priority grandparent epic; issue 102: neutral intermediate parent (no
+# priority); issue 101: leaf (help wanted, no own priority); issue 200: plain bug.
+# Only the grandparent carries priority, reached via the 102 → 100 hop.
+printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]},{"number":102,"created_at":"2024-01-01T00:00:00Z","labels":[]},{"number":101,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+# 2-hop parent chain: 101 → 102 → 100. Priority sits on the grandparent (100),
+# so the assertion proves ancestor detection recurses to depth 2.
+printf '102' > "$STUB_DIR/parent-101.json"   # 101 → 102
+printf '100' > "$STUB_DIR/parent-102.json"   # 102 → 100
+# no parent-100.json — chain terminates at the grandparent
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "depth-2 ancestor priority lifts PR 20 over older PR 10 (PO-ANC3)" "pr 20 20-leaf-pr fix-checks" "$result"
+teardown
+
 # PO3. main is red and no latch issue open → main-broken fires first, before the
 #      priority scan (the gate runs ahead of the ladder, same as default mode).
 echo "Test: --priority-only — main red, no latch → main-broken (gate first)"


### PR DESCRIPTION
Closes #1939

## What

Adds a single new test case `PO-ANC3` to
`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`, exercising
**depth-2** ancestor-priority detection. Purely added test coverage — no
production code change.

## Why

`PO-ANC1` and `PO-ANC2` both exercise only a **1-level** parent chain
(`parent-101.json` → 100). The ancestor-priority implementation in
`dispatch-select-target` collects up to 6 ancestor levels via
`[.value | recurse(.parent?; . != null) | .number] | .[1:7]`. No existing test
verified that a `priority` label is detected at **depth ≥ 2** (a grandparent). A
defect in the `recurse`/`.[1:7]` path at depth > 1 would silently let a
priority-bearing grandparent go undetected, ranking the PR lower than it should —
with no test to catch it. Surfaced by the review pass on #1933, out of scope
there.

## How

`PO-ANC3` mirrors `PO-ANC1` exactly, changing only the fixture to add one
parent-chain hop so the `priority` label sits on the **grandparent** (issue 100),
reached through a **non-priority intermediate** (issue 102):

- 2-hop chain: `parent-101.json → 102`, `parent-102.json → 100` (no
  `parent-100.json`).
- Issue 100 carries `priority`; intermediate 102 is neutral (the load-bearing
  property — it must NOT carry `priority`, or the test would collapse to depth-1).
- Default mode asserts PR 20 (closing leaf issue 101) wins over the older PR 10.

A 1-level recursion bug would see only intermediate 102 (no priority), fail to
lift PR 20, and let the older PR 10 win — so the assertion proves the depth-2
path. The recursion already supports this; no change to `dispatch-select-target`
is needed.

## Verification

`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` —
`3102/3102 passed, 0 failed`, including the new
`depth-2 ancestor priority lifts PR 20 over older PR 10 (PO-ANC3)` assertion.
