### PR TITLE
dispatch tests: cover gh_issue_list_rest gh-failure and --repo cross-repo paths

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1239,6 +1239,16 @@ err_fail_lim=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state open --l
 assert_eq "gh-failure: single-page branch returns non-zero" "1" "$rc_fail_lim"
 teardown
 
+echo "Test: --repo flag -- cross-repo path uses owner/other-repo segment, not placeholder"
+setup
+: > "$STUB_DIR/gh-issue-list-rest-calls.log"
+actual_repo=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state open --repo owner/other-repo --label dispatch-test-empty)
+if grep -q 'repos/owner/other-repo/issues' "$STUB_DIR/gh-issue-list-rest-calls.log"; then seg=yes; else seg=no; fi
+assert_eq "--repo: API path uses cross-repo segment" "yes" "$seg"
+if grep -q 'repos/{owner}/{repo}/issues' "$STUB_DIR/gh-issue-list-rest-calls.log"; then ph=yes; else ph=no; fi
+assert_eq "--repo: placeholder absent from cross-repo call" "no" "$ph"
+teardown
+
 # ============================================================================
 # dispatch-phase tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -282,6 +282,10 @@ case "$args" in
     # branch (case is first-wins). Log the full $args so tests can assert whether
     # --paginate was passed and what per_page= value was used.
     echo "$args" >> "$STUB_DIR/gh-issue-list-rest-calls.log"
+    if [[ -f "$STUB_DIR/gh-fail-rest" ]]; then
+      echo "stub forced gh api failure" >&2
+      exit 1
+    fi
     rest_path_dt=$(printf '%s' "$args" | grep -oE 'repos/[^ ]+')
     rest_query_dt="${rest_path_dt#*\?}"
     rest_label_dt=""
@@ -1219,6 +1223,20 @@ if grep -q -- '--paginate' "$STUB_DIR/gh-issue-list-rest-calls.log"; then
 else
   assert_eq "limit: log does not contain --paginate" "no" "no"
 fi
+teardown
+
+echo "Test: gh-failure -- both branches return non-zero with diagnostic stderr"
+setup
+: > "$STUB_DIR/gh-issue-list-rest-calls.log"
+: > "$STUB_DIR/gh-fail-rest"
+rc_fail=0
+err_fail=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state open --label dispatch-test-empty 2>&1 >/dev/null) || rc_fail=$?
+assert_eq "gh-failure: --paginate branch returns non-zero" "1" "$rc_fail"
+case "$err_fail" in *"gh_issue_list_rest: gh api failed"*) m=yes ;; *) m=no ;; esac
+assert_eq "gh-failure: stderr names the helper failure" "yes" "$m"
+rc_fail_lim=0
+err_fail_lim=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state open --limit 50 --label dispatch-test-empty 2>&1 >/dev/null) || rc_fail_lim=$?
+assert_eq "gh-failure: single-page branch returns non-zero" "1" "$rc_fail_lim"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1237,6 +1237,8 @@ assert_eq "gh-failure: stderr names the helper failure" "yes" "$m"
 rc_fail_lim=0
 err_fail_lim=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state open --limit 50 --label dispatch-test-empty 2>&1 >/dev/null) || rc_fail_lim=$?
 assert_eq "gh-failure: single-page branch returns non-zero" "1" "$rc_fail_lim"
+case "$err_fail_lim" in *"gh_issue_list_rest: gh api failed"*) m_lim=yes ;; *) m_lim=no ;; esac
+assert_eq "gh-failure: single-page stderr names the helper failure" "yes" "$m_lim"
 teardown
 
 echo "Test: --repo flag -- cross-repo path uses owner/other-repo segment, not placeholder"
@@ -1247,6 +1249,7 @@ if grep -q 'repos/owner/other-repo/issues' "$STUB_DIR/gh-issue-list-rest-calls.l
 assert_eq "--repo: API path uses cross-repo segment" "yes" "$seg"
 if grep -q 'repos/{owner}/{repo}/issues' "$STUB_DIR/gh-issue-list-rest-calls.log"; then ph=yes; else ph=no; fi
 assert_eq "--repo: placeholder absent from cross-repo call" "no" "$ph"
+assert_eq "--repo: returns the stub's empty array" "[]" "$actual_repo"
 teardown
 
 # ============================================================================


### PR DESCRIPTION
Closes #1938

## What

Adds two unit tests to the `gh_issue_list_rest` edge-case block in
`test-dispatch-scripts.sh`, covering the two branches PR #1935 left unexercised.

`gh_issue_list_rest` (`lib.sh:193-241`) is the REST-backed issue-list helper that
keeps per-tick dispatch scans off the shared GraphQL rate-limit bucket. PR #1935
added edge-case tests for the empty, pagination-boundary, and `--limit` paths;
these two branches could still silently regress.

## Tests added

1. **gh-failure path** — a `gh-fail-rest` marker in the `dispatch-test-*`
   sentinel stub forces `gh api` to exit 1 (after still logging the call). The
   forced error message is non-transient, so `gh_retry` does not retry and the
   test stays fast. The test asserts the helper returns non-zero and emits its
   own `gh_issue_list_rest: gh api failed` diagnostic on stderr, covering both
   the single-page (`--limit`) and `--paginate` branches. The failing-call
   captures are guarded with `|| rc=$?` so the forced non-zero exit does not
   abort the `set -euo pipefail` suite.

2. **`--repo` cross-repo path** — asserts that `--repo owner/other-repo` builds
   the `repos/owner/other-repo/issues` API path (logged by the stub), with a
   negative control confirming the `repos/{owner}/{repo}/issues` placeholder is
   absent — pinning that the flag replaces the placeholder rather than appending.

## Notes

No production code changes — `lib.sh` is reference-only. Full suite passes
(3106/3106, zero failures); the run completes promptly, confirming the
non-transient stub error skips `gh_retry`'s backoff.
