### PR TITLE
test: add PO-ANC3 for the CI-pending ancestor-priority WAITING_NUM fallback

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -4786,6 +4786,51 @@ result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
 assert_eq "--priority-only ancestor priority qualifies PR 20" "pr 20 20-leaf-pr fix-checks" "$result"
 teardown
 
+# PO-ANC3. Same fixture as PO-ANC2 but PR 20's rollup is PENDING, not FAILING.
+#           This exercises the CI-pending ancestor-priority WAITING_NUM FALLBACK
+#           path — the orthogonal case to PO-ANC1/PO-ANC2's *selection* assertions.
+#
+#           PR 20 qualifies for the priority tier (ci_rc path at line 849 checks
+#           --priority-only + inherited ancestor priority to enter WAITING_NUM arm).
+#           Its CI is pending (ci_rc==1), so it is NOT selectable. The selector
+#           emits `waiting <first-closing-issue-num>` from the fallback arm of the
+#           jq at dispatch-select-target:864-869:
+#
+#             ( map(.number|tostring|select(own-priority-label?)) | .[0] )
+#             // ( [.[].number|tostring] | .[0] )
+#             // empty
+#
+#           CRITICAL INVARIANT — do NOT change this: issue 101 carries ONLY
+#           [help wanted] and has NO own `priority` label. Priority comes solely
+#           from ancestor 100 (via parent-101.json). This is exactly what forces
+#           the jq FALLBACK arm: the first arm (select own priority-labeled issues)
+#           returns null because 101 is not directly priority-labeled, so the
+#           fallback `[.[].number|tostring]|.[0]` resolves to "101". If anyone
+#           adds `priority` to issue 101, the FIRST arm would fire and also return
+#           101 — the assertion would still pass while silently testing the WRONG
+#           branch. So 101 MUST stay non-priority. A broken fallback arm yields
+#           `empty` (no `waiting` line; the PR falls through), not `waiting 101`.
+#
+#           PR 10 (older, closes issue 200, $FAILING_ROLLUP) is dropped by the
+#           --priority-only early-skip guard (issue 200 has `bug` only, no priority,
+#           no ancestor with priority), proving the ancestor-priority PR is the only
+#           candidate and does not interfere with the waiting result.
+echo "Test: --priority-only — CI-pending ancestor priority → waiting fallback (PO-ANC3)"
+setup
+UNION='['
+UNION+="$(make_pr_union 10 "10-bug-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
+UNION+="$(make_pr_union 20 "20-leaf-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$PENDING_ROLLUP" '[{"number":101}]')"
+UNION+=']'
+setup_union_pr_list "$UNION"
+printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]},{"number":101,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '100' > "$STUB_DIR/parent-101.json"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "--priority-only CI-pending ancestor priority → waiting (fallback target)" \
+  "waiting 101" "$result"
+teardown
+
 # PO3. main is red and no latch issue open → main-broken fires first, before the
 #      priority scan (the gate runs ahead of the ladder, same as default mode).
 echo "Test: --priority-only — main red, no latch → main-broken (gate first)"


### PR DESCRIPTION
Closes #1940

## What

Adds **PO-ANC3** to `test-dispatch-scripts.sh`, pinning the previously-untested
CI-pending ancestor-priority `WAITING_NUM` fallback path in
`dispatch-select-target`.

## Why

The `WAITING_NUM` reseed-target fallback (jq at `dispatch-select-target:864-869`)
is entered in `--priority-only` mode when a PR qualifies for the priority tier
*only* via an open ancestor — no closing issue carries `priority` directly — and
the PR is CI-pending (`ci_rc == 1`). When the first arm (own-priority-labeled
closing issue) returns null, the fallback arm picks the first closing-issue
number. A regression there — emitting `empty` or a wrong value — would silently
strand a CI-pending ancestor-priority PR from the CI-cadence reseed, and no test
would catch it.

PO-ANC1 and PO-ANC2 already cover ancestor-priority *qualification* (the PR is
*selected* when CI is failing/ready). PO-ANC3 covers the orthogonal **CI-pending**
case, where the PR is not yet selectable and the selector instead emits
`waiting 101` from the fallback arm. This path was opened by #1933, which lifted
ancestor-priority PRs into the `--priority-only` early-skip admission.

## How

Reuses the PO-ANC2 fixture verbatim, changing only PR 20's CI rollup from
`$FAILING_ROLLUP` to `$PENDING_ROLLUP` (CI-pending) and the assertion to
`waiting 101`. The fixture keeps issue 101 non-priority (`[help wanted]` only;
priority inherited solely from ancestor 100) — the load-bearing invariant that
forces the jq *fallback* arm rather than the first arm. The leading comment
states this invariant explicitly so it is not "fixed" away.

Test-only: no change to `dispatch-select-target` or to PO-ANC1/PO-ANC2.

## Verification

`test-dispatch-scripts.sh` passes 3102/3102: PO-ANC3 prints and asserts
`waiting 101` (not `empty`, not `pr 20 …`); PO-ANC1 and PO-ANC2 pass unchanged.
