### PR TITLE
dispatch-select-target: test ancestor-chain truncation warning

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -4778,8 +4778,8 @@ printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 for i in 101 100 99 98 97 96 95; do
   printf '%d' $((i - 1)) > "$STUB_DIR/parent-$i.json"
 done
-result=$("$TMPDIR_TEST/dispatch-select-target" 2>"$TMPDIR_TEST/stderr.txt") && rc=0 || rc=$?
-stderr=$(cat "$TMPDIR_TEST/stderr.txt")
+result=$("$TMPDIR_TEST/dispatch-select-target" 2>"$TMPDIR_TEST/stderr") && rc=0 || rc=$?
+stderr=$(cat "$TMPDIR_TEST/stderr")
 assert_eq "deep-chain selection still exits 0" "0" "$rc"
 assert_eq "uncontested PR selected despite truncation" "pr 10 10-deep-chain-leaf fix-checks" "$result"
 assert_eq "truncation warning on stderr" "1" "$(grep -c 'ancestor chain deeper than supported depth (6) for issue 101' <<<"$stderr")"
@@ -4796,8 +4796,8 @@ printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 for i in 101 100 99 98 97 96; do
   printf '%d' $((i - 1)) > "$STUB_DIR/parent-$i.json"
 done
-result=$("$TMPDIR_TEST/dispatch-select-target" 2>"$TMPDIR_TEST/stderr.txt") && rc=0 || rc=$?
-stderr=$(cat "$TMPDIR_TEST/stderr.txt")
+result=$("$TMPDIR_TEST/dispatch-select-target" 2>"$TMPDIR_TEST/stderr") && rc=0 || rc=$?
+stderr=$(cat "$TMPDIR_TEST/stderr")
 assert_eq "depth-6 selection exits 0" "0" "$rc"
 assert_eq "uncontested PR selected at depth 6" "pr 10 10-deep-chain-leaf fix-checks" "$result"
 # Harness has no assert_not_contains; assert absence by counting matches.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -4766,6 +4766,44 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "ancestor priority lifts PR 20 over older PR 10 (default mode)" "pr 20 20-leaf-pr fix-checks" "$result"
 teardown
 
+echo "Test: default mode — ancestor chain deeper than supported depth emits truncation warning"
+setup
+UNION='['"$(make_pr_union 10 "10-deep-chain-leaf" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":101}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":101,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+# Deep parent chain: 7 parent links (101->100->...->94). The closing issue 101
+# MUST itself have parent-101.json or the 7th-hop sentinel never fires. 94 (the
+# 7th-level ancestor) has no parent file. build_parent_json caps at depth>=7.
+for i in 101 100 99 98 97 96 95; do
+  printf '%d' $((i - 1)) > "$STUB_DIR/parent-$i.json"
+done
+result=$("$TMPDIR_TEST/dispatch-select-target" 2>"$TMPDIR_TEST/stderr.txt") && rc=0 || rc=$?
+stderr=$(cat "$TMPDIR_TEST/stderr.txt")
+assert_eq "deep-chain selection still exits 0" "0" "$rc"
+assert_eq "uncontested PR selected despite truncation" "pr 10 10-deep-chain-leaf fix-checks" "$result"
+assert_eq "truncation warning on stderr" "1" "$(grep -c 'ancestor chain deeper than supported depth (6) for issue 101' <<<"$stderr")"
+teardown
+
+echo "Test: default mode — ancestor chain at supported depth (6) emits no truncation warning"
+setup
+UNION='['"$(make_pr_union 10 "10-deep-chain-leaf" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":101}]')"']'
+setup_union_pr_list "$UNION"
+printf '[{"number":101,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+# Chain exactly 6 levels deep (101->100->...->95), parent-95.json ABSENT so the
+# 7th .parent hop resolves to null and the sentinel stays silent.
+for i in 101 100 99 98 97 96; do
+  printf '%d' $((i - 1)) > "$STUB_DIR/parent-$i.json"
+done
+result=$("$TMPDIR_TEST/dispatch-select-target" 2>"$TMPDIR_TEST/stderr.txt") && rc=0 || rc=$?
+stderr=$(cat "$TMPDIR_TEST/stderr.txt")
+assert_eq "depth-6 selection exits 0" "0" "$rc"
+assert_eq "uncontested PR selected at depth 6" "pr 10 10-deep-chain-leaf fix-checks" "$result"
+# Harness has no assert_not_contains; assert absence by counting matches.
+assert_eq "no truncation warning at depth 6" "0" "$(grep -c 'ancestor chain deeper' <<<"$stderr")"
+teardown
+
 # PO-ANC2. Same fixture, --priority-only mode. PR 10 (closes issue 200, no priority)
 #           is filtered by the early-skip guard. PR 20 (closes issue 101, no own
 #           priority but ancestor 100 is priority) passes the guard via inherited


### PR DESCRIPTION
Closes #1941

## What

Adds test coverage for the ancestor-chain truncation-warning path in
`dispatch-select-target`, which previously had none. When a closing issue's
parent chain is deeper than the supported depth (6 levels), the script warns to
stderr and proceeds; the 7th-hop sentinel jq expression that drives this was
correct but untested, so a regression in either direction would silently pass
the suite.

This is **coverage only** — `dispatch-select-target` is not modified.

## Changes

Two new procedural test blocks in
`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`, placed with
the other select-target ancestor tests:

- **Depth-7 case** — a 7-link parent chain (`101→…→94`) trips the sentinel.
  Asserts the truncation warning fires on stderr, exit 0, and the uncontested PR
  is still selected (`pr 10 10-deep-chain-leaf fix-checks`). Catches a sentinel
  that breaks *closed* (never warns).
- **Depth-6 boundary case** — a 6-link chain (`101→…→95`, no 7th ancestor) keeps
  the sentinel silent. Asserts the warning is absent (count of matches is 0),
  plus exit 0 and the same selection. Pins the sentinel's lower edge, catching a
  sentinel that fires *too eagerly* (e.g. a dropped `.parent` hop).

Both reuse the existing harness helpers (`make_pr_union`, `setup_union_pr_list`,
the `build_parent_json` gh stub, `assert_eq`) — no new helpers. Warning
presence/absence is asserted via `grep -c` against stderr, matching the
surrounding select-target style.

## Verification

Full suite passes with both new cases: `Results: 3107/3107 passed, 0 failed`.
`git diff --stat` shows only `test-dispatch-scripts.sh` changed —
`dispatch-select-target` is untouched.
