### PR TITLE
test-dispatch-scripts: extract make_malformed_remote_fixture helper for the 5b-5e malformed-URL cases

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -28968,10 +28968,11 @@ rm -rf "$bw_root"
 
 # Build a bare-repo + worktree fixture whose origin remote is <url>, for the
 # malformed-URL format-guard tests (5b-5e). Creates a temp root with .bare/,
-# seeds one commit on main via a throwaway seed clone, adds a worktree at
+# seeds one commit on main via a throwaway seed repo, adds a worktree at
 # worktrees/42-foo, and echoes the root path for the caller to capture:
 #   root=$(make_malformed_remote_fixture <url>)
 make_malformed_remote_fixture() {
+  set -e
   local url="$1"
   local root seed
   root=$(mktemp -d)

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -28715,23 +28715,35 @@ fi
 git --git-dir="$bw_root/.bare" worktree prune 2>/dev/null || true
 rm -rf "$bw_root"
 
+# Build a bare-repo + worktree fixture whose origin remote is <url>, for the
+# malformed-URL format-guard tests (5b-5e). Creates a temp root with .bare/,
+# seeds one commit on main via a throwaway seed clone, adds a worktree at
+# worktrees/42-foo, and echoes the root path for the caller to capture:
+#   root=$(make_malformed_remote_fixture <url>)
+make_malformed_remote_fixture() {
+  local url="$1"
+  local root seed
+  root=$(mktemp -d)
+  git init --bare "$root/.bare" >/dev/null 2>&1
+  git --git-dir="$root/.bare" config user.email "t@t" 2>/dev/null
+  git --git-dir="$root/.bare" config user.name "t" 2>/dev/null
+  git --git-dir="$root/.bare" remote add origin "$url"
+  seed=$(mktemp -d)
+  git -C "$seed" init -q
+  git -C "$seed" config user.email "t@t"; git -C "$seed" config user.name "t"
+  git -C "$seed" commit -q --allow-empty -m seed
+  git -C "$seed" remote add bare "$root/.bare"
+  git -C "$seed" push -q bare HEAD:refs/heads/main
+  rm -rf "$seed"
+  mkdir -p "$root/worktrees"
+  git --git-dir="$root/.bare" worktree add -q "$root/worktrees/42-foo" main 2>/dev/null
+  printf '%s' "$root"
+}
+
 # 5b. malformed-URL format guard: SSH-with-port → read-plan rejects it.
 # ssh://git@github.com:22/owner/repo.git strips to "22/owner/repo" — two slashes,
 # would pass the old */* check but fails the strict ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ regex.
-mf_ssh_root=$(mktemp -d)
-git init --bare "$mf_ssh_root/.bare" >/dev/null 2>&1
-git --git-dir="$mf_ssh_root/.bare" config user.email "t@t" 2>/dev/null
-git --git-dir="$mf_ssh_root/.bare" config user.name "t" 2>/dev/null
-git --git-dir="$mf_ssh_root/.bare" remote add origin ssh://git@github.com:22/owner/repo.git
-mf_ssh_seed=$(mktemp -d)
-git -C "$mf_ssh_seed" init -q
-git -C "$mf_ssh_seed" config user.email "t@t"; git -C "$mf_ssh_seed" config user.name "t"
-git -C "$mf_ssh_seed" commit -q --allow-empty -m seed
-git -C "$mf_ssh_seed" remote add bare "$mf_ssh_root/.bare"
-git -C "$mf_ssh_seed" push -q bare HEAD:refs/heads/main
-rm -rf "$mf_ssh_seed"
-mkdir -p "$mf_ssh_root/worktrees"
-git --git-dir="$mf_ssh_root/.bare" worktree add -q "$mf_ssh_root/worktrees/42-foo" main 2>/dev/null
+mf_ssh_root=$(make_malformed_remote_fixture ssh://git@github.com:22/owner/repo.git)
 if err=$( cd "$mf_ssh_root/worktrees/42-foo" && env -u GH_REPO "$WP_READ" 42 2>&1 1>/dev/null ); then rc=0; else rc=$?; fi
 assert_eq "read-plan: SSH-with-port malformed URL exits 1" "1" "$rc"
 TOTAL=$((TOTAL + 1))
@@ -28747,20 +28759,7 @@ rm -rf "$mf_ssh_root"
 # 5c. malformed-URL format guard: non-GitHub remote → write-plan rejects it.
 # https://gitlab.com/owner/repo.git has no "github.com" to strip, so repo stays the
 # full URL (contains ":") — has slashes, would pass the old */* check but fails the regex.
-mf_gl_root=$(mktemp -d)
-git init --bare "$mf_gl_root/.bare" >/dev/null 2>&1
-git --git-dir="$mf_gl_root/.bare" config user.email "t@t" 2>/dev/null
-git --git-dir="$mf_gl_root/.bare" config user.name "t" 2>/dev/null
-git --git-dir="$mf_gl_root/.bare" remote add origin https://gitlab.com/owner/repo.git
-mf_gl_seed=$(mktemp -d)
-git -C "$mf_gl_seed" init -q
-git -C "$mf_gl_seed" config user.email "t@t"; git -C "$mf_gl_seed" config user.name "t"
-git -C "$mf_gl_seed" commit -q --allow-empty -m seed
-git -C "$mf_gl_seed" remote add bare "$mf_gl_root/.bare"
-git -C "$mf_gl_seed" push -q bare HEAD:refs/heads/main
-rm -rf "$mf_gl_seed"
-mkdir -p "$mf_gl_root/worktrees"
-git --git-dir="$mf_gl_root/.bare" worktree add -q "$mf_gl_root/worktrees/42-foo" main 2>/dev/null
+mf_gl_root=$(make_malformed_remote_fixture https://gitlab.com/owner/repo.git)
 if err=$( cd "$mf_gl_root/worktrees/42-foo" && env -u GH_REPO "$WP_WRITE" 42 <<<"PLAN" 2>&1 1>/dev/null ); then rc=0; else rc=$?; fi
 assert_eq "write-plan: non-GitHub remote malformed URL exits 1" "1" "$rc"
 TOTAL=$((TOTAL + 1))
@@ -28776,20 +28775,7 @@ rm -rf "$mf_gl_root"
 # 5d. malformed-URL format guard: SSH-with-port → write-plan rejects it.
 # Symmetric counterpart to 5b: same ssh://git@github.com:22/owner/repo.git fixture,
 # exercised against dispatch-write-plan instead of dispatch-read-plan.
-mf_ssh_w_root=$(mktemp -d)
-git init --bare "$mf_ssh_w_root/.bare" >/dev/null 2>&1
-git --git-dir="$mf_ssh_w_root/.bare" config user.email "t@t" 2>/dev/null
-git --git-dir="$mf_ssh_w_root/.bare" config user.name "t" 2>/dev/null
-git --git-dir="$mf_ssh_w_root/.bare" remote add origin ssh://git@github.com:22/owner/repo.git
-mf_ssh_w_seed=$(mktemp -d)
-git -C "$mf_ssh_w_seed" init -q
-git -C "$mf_ssh_w_seed" config user.email "t@t"; git -C "$mf_ssh_w_seed" config user.name "t"
-git -C "$mf_ssh_w_seed" commit -q --allow-empty -m seed
-git -C "$mf_ssh_w_seed" remote add bare "$mf_ssh_w_root/.bare"
-git -C "$mf_ssh_w_seed" push -q bare HEAD:refs/heads/main
-rm -rf "$mf_ssh_w_seed"
-mkdir -p "$mf_ssh_w_root/worktrees"
-git --git-dir="$mf_ssh_w_root/.bare" worktree add -q "$mf_ssh_w_root/worktrees/42-foo" main 2>/dev/null
+mf_ssh_w_root=$(make_malformed_remote_fixture ssh://git@github.com:22/owner/repo.git)
 if err=$( cd "$mf_ssh_w_root/worktrees/42-foo" && env -u GH_REPO "$WP_WRITE" 42 <<<"PLAN" 2>&1 1>/dev/null ); then rc=0; else rc=$?; fi
 assert_eq "write-plan: SSH-with-port malformed URL exits 1" "1" "$rc"
 TOTAL=$((TOTAL + 1))
@@ -28805,20 +28791,7 @@ rm -rf "$mf_ssh_w_root"
 # 5e. malformed-URL format guard: non-GitHub remote → read-plan rejects it.
 # Symmetric counterpart to 5c: same https://gitlab.com/owner/repo.git fixture,
 # exercised against dispatch-read-plan instead of dispatch-write-plan.
-mf_gl_r_root=$(mktemp -d)
-git init --bare "$mf_gl_r_root/.bare" >/dev/null 2>&1
-git --git-dir="$mf_gl_r_root/.bare" config user.email "t@t" 2>/dev/null
-git --git-dir="$mf_gl_r_root/.bare" config user.name "t" 2>/dev/null
-git --git-dir="$mf_gl_r_root/.bare" remote add origin https://gitlab.com/owner/repo.git
-mf_gl_r_seed=$(mktemp -d)
-git -C "$mf_gl_r_seed" init -q
-git -C "$mf_gl_r_seed" config user.email "t@t"; git -C "$mf_gl_r_seed" config user.name "t"
-git -C "$mf_gl_r_seed" commit -q --allow-empty -m seed
-git -C "$mf_gl_r_seed" remote add bare "$mf_gl_r_root/.bare"
-git -C "$mf_gl_r_seed" push -q bare HEAD:refs/heads/main
-rm -rf "$mf_gl_r_seed"
-mkdir -p "$mf_gl_r_root/worktrees"
-git --git-dir="$mf_gl_r_root/.bare" worktree add -q "$mf_gl_r_root/worktrees/42-foo" main 2>/dev/null
+mf_gl_r_root=$(make_malformed_remote_fixture https://gitlab.com/owner/repo.git)
 if err=$( cd "$mf_gl_r_root/worktrees/42-foo" && env -u GH_REPO "$WP_READ" 42 2>&1 1>/dev/null ); then rc=0; else rc=$?; fi
 assert_eq "read-plan: non-GitHub remote malformed URL exits 1" "1" "$rc"
 TOTAL=$((TOTAL + 1))


### PR DESCRIPTION
Closes #1955

## What

The four malformed-URL format-guard test cases in
`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` — 5b
(read-plan / SSH-with-port), 5c (write-plan / non-GitHub), 5d (write-plan /
SSH-with-port), 5e (read-plan / non-GitHub) — each opened with a byte-identical
~14-line bare-repo + worktree fixture setup block. Across the four cases the
setup differed in only two things: the `origin` remote URL and the local root
variable name.

This extracts that block into a single `make_malformed_remote_fixture` helper.
The helper takes the URL, builds the temp bare repo + seeded `main` + worktree,
and echoes the created root path for the caller to capture — matching the
suite's established `make_*` helper convention (`make_pr`, `make_pr_union` emit
their result via `printf` for `$(...)` capture). Each of the four call sites is
now a single capture line; its own (already distinct) assertion and inline
cleanup are unchanged.

## Why

Removes a four-way copy of identical fixture setup. The suite already defines
dozens of `make_*` / `*_setup` helpers, so a section-local fixture helper
matches the existing convention rather than introducing a new one.

## Out of scope

- The per-case assertion blocks and expected diagnostics — each case keeps its
  distinct script and expected error.
- The per-case cleanup (`worktree prune` + `rm -rf`) — left inline; the helper
  covers setup only.
- The unrelated "5." bare+worktree block (`bw_root`) — a real-`github.com` case
  with a fake-gh stub, not a malformed-URL case.

## Verification

- `bash -n` syntax check passes.
- Full suite: 3101/3101 pass, 0 failures (no assertions added or removed).
- All four malformed-URL cases still print PASS.
