### PR TITLE
dispatch tests: cover gh_issue_list_rest --limit cross-repo path

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1254,6 +1254,7 @@ assert_eq "--repo: returns the stub's empty array" "[]" "$actual_repo"
 # emitted under the per_page= (no --paginate) path too, not just --paginate.
 : > "$STUB_DIR/gh-issue-list-rest-calls.log"
 actual_repo_lim=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state open --limit 50 --repo owner/other-repo --label dispatch-test-empty)
+assert_eq "--repo+--limit: returns the stub's empty array" "[]" "$actual_repo_lim"
 if grep -q 'repos/owner/other-repo/issues' "$STUB_DIR/gh-issue-list-rest-calls.log"; then seg_lim=yes; else seg_lim=no; fi
 assert_eq "--repo+--limit: single-page API path uses cross-repo segment" "yes" "$seg_lim"
 # Prove it was the single-page branch (not --paginate) that emitted the segment.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1250,6 +1250,23 @@ assert_eq "--repo: API path uses cross-repo segment" "yes" "$seg"
 if grep -q 'repos/{owner}/{repo}/issues' "$STUB_DIR/gh-issue-list-rest-calls.log"; then ph=yes; else ph=no; fi
 assert_eq "--repo: placeholder absent from cross-repo call" "no" "$ph"
 assert_eq "--repo: returns the stub's empty array" "[]" "$actual_repo"
+# Single-page (--limit) branch with --repo: pin that the cross-repo segment is
+# emitted under the per_page= (no --paginate) path too, not just --paginate.
+: > "$STUB_DIR/gh-issue-list-rest-calls.log"
+actual_repo_lim=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state open --limit 50 --repo owner/other-repo --label dispatch-test-empty)
+if grep -q 'repos/owner/other-repo/issues' "$STUB_DIR/gh-issue-list-rest-calls.log"; then seg_lim=yes; else seg_lim=no; fi
+assert_eq "--repo+--limit: single-page API path uses cross-repo segment" "yes" "$seg_lim"
+# Prove it was the single-page branch (not --paginate) that emitted the segment.
+if grep -q 'per_page=50[^0-9]' "$STUB_DIR/gh-issue-list-rest-calls.log"; then
+  assert_eq "--repo+--limit: log contains per_page=50" "yes" "yes"
+else
+  assert_eq "--repo+--limit: log contains per_page=50" "yes" "no"
+fi
+if grep -q -- '--paginate' "$STUB_DIR/gh-issue-list-rest-calls.log"; then
+  assert_eq "--repo+--limit: log does not contain --paginate" "no" "yes"
+else
+  assert_eq "--repo+--limit: log does not contain --paginate" "no" "no"
+fi
 teardown
 
 # ============================================================================


### PR DESCRIPTION
Closes #1970

## What

Extends the existing `--repo` cross-repo test for the `gh_issue_list_rest`
helper in `test-dispatch-scripts.sh` with a second invocation that exercises the
single-page (`--limit`) branch.

## Why

The original `--repo` test (added in #1966) only invoked the helper with
`--repo owner/other-repo` and no `--limit` flag, so it only exercised the
default `--paginate` branch. The single-page (`per_page=<limit>`) branch never
saw a cross-repo path. The path-building logic in `lib.sh` is shared between
both branches, so the gap was low risk, but the sibling edge-case tests (the
`--limit` test and the gh-failure test) cover *both* branches — this one should
too. A future refactor that moved path construction inside the
`--limit`-branch block would otherwise silently lose cross-repo coverage.

## How

Adds, inside the existing `--repo` test block (sharing its `setup`/`teardown`):

- a `--limit 50 --repo owner/other-repo` invocation through the single-page
  branch, after re-truncating the call log;
- an assertion that the `repos/owner/other-repo/issues` cross-repo segment is
  present in the logged call;
- the load-bearing assertions that the call took the single-page branch —
  `per_page=50` present and `--paginate` absent. The existing `--repo` test
  already proves the segment is emitted under `--paginate`, so the segment grep
  alone would pass on either branch; pinning `--paginate` absent + `per_page=50`
  present is what proves the single-page branch is the one emitting the
  cross-repo segment.

No change to `lib.sh`, the fake-gh sentinel stub, or any other test.

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` —
full suite passes (3121/3121, zero failures), including the three new
`--repo+--limit` assertions.
