### PR TITLE
test: assert timeout invocation and npx args in playwright_install_with_deps tests

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6957,6 +6957,47 @@ timeout_calls=$( [[ -s "$TIMEOUT_LOG_FILE" ]] && echo nonempty || echo empty )
 assert_eq "first fails then succeeds → timeout invoked" "nonempty" "$timeout_calls"
 teardown
 
+# 5. Timeout expiry (exit 124, stall) → retry exhausted → rc non-zero, 2 npx calls.
+#    Proves the timeout-expiry path works: timeout starts npx (counter increments)
+#    then returns 124 (simulating the child stalling past the deadline).  With
+#    PLAYWRIGHT_INSTALL_ATTEMPTS=2 both attempts time out and the wrapper fails.
+echo "Test: playwright_install_with_deps timeout-stall → rc non-zero, 2 npx calls"
+setup
+cat > "$TMPDIR_TEST/bin/npx" <<'FAKE'
+#!/usr/bin/env bash
+cf="$NPX_COUNT_FILE"
+c=0; [[ -f "$cf" ]] && c=$(cat "$cf"); c=$((c+1)); echo "$c" > "$cf"
+exit "${NPX_EXIT:-0}"
+FAKE
+chmod +x "$TMPDIR_TEST/bin/npx"
+cat > "$TMPDIR_TEST/bin/timeout" <<'FAKE'
+#!/usr/bin/env bash
+[[ -n "${TIMEOUT_LOG_FILE:-}" ]] && echo "$@" >> "$TIMEOUT_LOG_FILE"
+while [[ "$1" == -* ]]; do shift; done
+shift                     # drop the <timeout_s> duration arg
+"$@"                      # run npx (increments NPX_COUNT_FILE); not exec
+exit 124                  # simulate timeout killing the stalled child
+FAKE
+chmod +x "$TMPDIR_TEST/bin/timeout"
+cat > "$TMPDIR_TEST/bin/sleep" <<'FAKE'
+#!/usr/bin/env bash
+exit 0
+FAKE
+chmod +x "$TMPDIR_TEST/bin/sleep"
+NPX_COUNT_FILE="$TMPDIR_TEST/npx-5"
+rc=0
+(
+  source "$TMPDIR_TEST/lib.sh"
+  unset PLAYWRIGHT_BROWSERS_PATH
+  export PLAYWRIGHT_INSTALL_ATTEMPTS=2
+  export NPX_COUNT_FILE="$TMPDIR_TEST/npx-5"
+  playwright_install_with_deps 2>/dev/null
+) || rc=$?
+[[ "$rc" -ne 0 ]] && rc_state="nonzero" || rc_state="zero"
+assert_eq "timeout-stall → 2 npx calls" "2" "$(cat "$NPX_COUNT_FILE")"
+assert_eq "timeout-stall → rc non-zero" "nonzero" "$rc_state"
+teardown
+
 # ============================================================================
 # dispatch-complete-phase tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6985,6 +6985,7 @@ cat > "$TMPDIR_TEST/bin/npx" <<'FAKE'
 #!/usr/bin/env bash
 cf="$NPX_COUNT_FILE"
 c=0; [[ -f "$cf" ]] && c=$(cat "$cf"); c=$((c+1)); echo "$c" > "$cf"
+[[ -n "${NPX_ARGS_FILE:-}" ]] && echo "$@" >> "$NPX_ARGS_FILE"
 exit "${NPX_EXIT:-0}"
 FAKE
 chmod +x "$TMPDIR_TEST/bin/npx"
@@ -7003,16 +7004,20 @@ exit 0
 FAKE
 chmod +x "$TMPDIR_TEST/bin/sleep"
 NPX_COUNT_FILE="$TMPDIR_TEST/npx-5"
+TIMEOUT_LOG_FILE="$TMPDIR_TEST/timeout-calls-5.log"
 rc=0
 (
   source "$TMPDIR_TEST/lib.sh"
   unset PLAYWRIGHT_BROWSERS_PATH
   export PLAYWRIGHT_INSTALL_ATTEMPTS=2
   export NPX_COUNT_FILE="$TMPDIR_TEST/npx-5"
+  export TIMEOUT_LOG_FILE="$TMPDIR_TEST/timeout-calls-5.log"
   playwright_install_with_deps 2>/dev/null
 ) || rc=$?
 [[ "$rc" -ne 0 ]] && rc_state="nonzero" || rc_state="zero"
+timeout_calls=$( [[ -s "$TIMEOUT_LOG_FILE" ]] && echo nonempty || echo empty )
 assert_eq "timeout-stall → 2 npx calls" "2" "$(cat "$NPX_COUNT_FILE")"
+assert_eq "timeout-stall → timeout invoked" "nonempty" "$timeout_calls"
 assert_eq "timeout-stall → rc non-zero" "nonzero" "$rc_state"
 teardown
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6791,11 +6791,13 @@ cat > "$TMPDIR_TEST/bin/npx" <<'FAKE'
 #!/usr/bin/env bash
 cf="$NPX_COUNT_FILE"
 c=0; [[ -f "$cf" ]] && c=$(cat "$cf"); c=$((c+1)); echo "$c" > "$cf"
+[[ -n "${NPX_ARGS_FILE:-}" ]] && echo "$@" >> "$NPX_ARGS_FILE"
 exit "${NPX_EXIT:-0}"
 FAKE
 chmod +x "$TMPDIR_TEST/bin/npx"
 cat > "$TMPDIR_TEST/bin/timeout" <<'FAKE'
 #!/usr/bin/env bash
+[[ -n "${TIMEOUT_LOG_FILE:-}" ]] && echo "$@" >> "$TIMEOUT_LOG_FILE"
 while [[ "$1" == -* ]]; do shift; done
 shift
 exec "$@"
@@ -6807,16 +6809,24 @@ exit 0
 FAKE
 chmod +x "$TMPDIR_TEST/bin/sleep"
 NPX_COUNT_FILE="$TMPDIR_TEST/npx-2"
+TIMEOUT_LOG_FILE="$TMPDIR_TEST/timeout-calls-2.log"
+NPX_ARGS_FILE="$TMPDIR_TEST/npx-args-2"
 rc=0
 (
   source "$TMPDIR_TEST/lib.sh"
   unset PLAYWRIGHT_BROWSERS_PATH
   export NPX_EXIT=0
   export NPX_COUNT_FILE="$TMPDIR_TEST/npx-2"
+  export TIMEOUT_LOG_FILE="$TMPDIR_TEST/timeout-calls-2.log"
+  export NPX_ARGS_FILE="$TMPDIR_TEST/npx-args-2"
   playwright_install_with_deps
 ) || rc=$?
 assert_eq "first-attempt success → rc 0" "0" "$rc"
 assert_eq "first-attempt success → 1 npx call" "1" "$(cat "$NPX_COUNT_FILE")"
+timeout_calls=$( [[ -s "$TIMEOUT_LOG_FILE" ]] && echo nonempty || echo empty )
+assert_eq "first-attempt success → timeout invoked" "nonempty" "$timeout_calls"
+assert_eq "first-attempt success → npx args" \
+  "playwright install --with-deps chromium" "$(cat "$NPX_ARGS_FILE")"
 teardown
 
 # 3. Both attempts fail: npx exits 1 twice → rc non-zero, exactly 2 npx calls.
@@ -6831,6 +6841,7 @@ FAKE
 chmod +x "$TMPDIR_TEST/bin/npx"
 cat > "$TMPDIR_TEST/bin/timeout" <<'FAKE'
 #!/usr/bin/env bash
+[[ -n "${TIMEOUT_LOG_FILE:-}" ]] && echo "$@" >> "$TIMEOUT_LOG_FILE"
 while [[ "$1" == -* ]]; do shift; done
 shift
 exec "$@"
@@ -6842,6 +6853,7 @@ exit 0
 FAKE
 chmod +x "$TMPDIR_TEST/bin/sleep"
 NPX_COUNT_FILE="$TMPDIR_TEST/npx-3"
+TIMEOUT_LOG_FILE="$TMPDIR_TEST/timeout-calls-3.log"
 rc=0
 (
   source "$TMPDIR_TEST/lib.sh"
@@ -6849,11 +6861,14 @@ rc=0
   export NPX_EXIT=1
   export PLAYWRIGHT_INSTALL_ATTEMPTS=2
   export NPX_COUNT_FILE="$TMPDIR_TEST/npx-3"
+  export TIMEOUT_LOG_FILE="$TMPDIR_TEST/timeout-calls-3.log"
   playwright_install_with_deps 2>/dev/null
 ) || rc=$?
 [[ "$rc" -ne 0 ]] && rc_state="nonzero" || rc_state="zero"
 assert_eq "both-attempts fail → rc non-zero" "nonzero" "$rc_state"
 assert_eq "both-attempts fail → 2 npx calls" "2" "$(cat "$NPX_COUNT_FILE")"
+timeout_calls=$( [[ -s "$TIMEOUT_LOG_FILE" ]] && echo nonempty || echo empty )
+assert_eq "both attempts fail → timeout invoked" "nonempty" "$timeout_calls"
 teardown
 
 # 4. First attempt fails, second succeeds: npx exits 1 then 0 → rc 0, 2 npx calls.
@@ -6869,6 +6884,7 @@ FAKE
 chmod +x "$TMPDIR_TEST/bin/npx"
 cat > "$TMPDIR_TEST/bin/timeout" <<'FAKE'
 #!/usr/bin/env bash
+[[ -n "${TIMEOUT_LOG_FILE:-}" ]] && echo "$@" >> "$TIMEOUT_LOG_FILE"
 while [[ "$1" == -* ]]; do shift; done
 shift
 exec "$@"
@@ -6880,16 +6896,20 @@ exit 0
 FAKE
 chmod +x "$TMPDIR_TEST/bin/sleep"
 NPX_COUNT_FILE="$TMPDIR_TEST/npx-4"
+TIMEOUT_LOG_FILE="$TMPDIR_TEST/timeout-calls-4.log"
 rc=0
 (
   source "$TMPDIR_TEST/lib.sh"
   unset PLAYWRIGHT_BROWSERS_PATH
   export PLAYWRIGHT_INSTALL_ATTEMPTS=2
   export NPX_COUNT_FILE="$TMPDIR_TEST/npx-4"
+  export TIMEOUT_LOG_FILE="$TMPDIR_TEST/timeout-calls-4.log"
   playwright_install_with_deps 2>/dev/null
 ) || rc=$?
 assert_eq "first-fails-then-succeeds → rc 0" "0" "$rc"
 assert_eq "first-fails-then-succeeds → 2 npx calls" "2" "$(cat "$NPX_COUNT_FILE")"
+timeout_calls=$( [[ -s "$TIMEOUT_LOG_FILE" ]] && echo nonempty || echo empty )
+assert_eq "first fails then succeeds → timeout invoked" "nonempty" "$timeout_calls"
 teardown
 
 # ============================================================================


### PR DESCRIPTION
Closes #1972

## Why

PR #1964 added four unit tests for `playwright_install_with_deps()` in
`test-dispatch-scripts.sh`, but review (deferred to this issue) found they
under-verify the wrapper's structure:

- The `timeout` stub transparently `exec`ed its payload without recording the
  invocation — so if `lib.sh` dropped the `timeout --kill-after=30 "$timeout_s"`
  wrapper and ran bare `npx`, every test would still pass.
- The `npx` stub ignored `$@`, so a regression to `--with-deps` or the browser
  name (`chromium`) would go undetected.
- The timeout-expiry path (the wrapper's `timeout` returns 124 because the child
  stalled) — the core #1899 motivation — was never exercised.

## What changed

`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`:

- **Tests 2/3/4** (the cases that reach `timeout`): the `timeout` stub now logs
  its full `$@` to `TIMEOUT_LOG_FILE`, and each test asserts the log is non-empty,
  proving the `timeout` wrapper is actually invoked. Test 2 additionally captures
  the `npx` stub's `$@` and asserts the exact argument shape
  `playwright install --with-deps chromium`.
- **New fifth test** — timeout-stall: the `timeout` stub runs `npx` (incrementing
  the counter) and then returns 124, modeling `timeout` killing a stalled child.
  With `PLAYWRIGHT_INSTALL_ATTEMPTS=2` it asserts the retry produces 2 `npx` calls
  and a non-zero return.

Test 1 (skip-guard) is unchanged — it never reaches `timeout`/`npx`.

## Verification

Full suite passes (`bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`,
exit 0, 3131 tests). Adversarially confirmed the new assertions bite: dropping
the `timeout --kill-after=30 "$timeout_s"` prefix from `lib.sh` makes the
timeout-log assertions fail (reverted before committing).
