### PR TITLE
test: make depth-7 truncation test discriminate priority ranking

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -4797,22 +4797,48 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "ancestor priority lifts PR 20 over older PR 10 (default mode)" "pr 20 20-leaf-pr fix-checks" "$result"
 teardown
 
+# PO-ANC-TRUNC. The depth-7 truncation warning must fire WITHOUT disabling
+#           ancestor-priority evaluation across the supported window. This is a
+#           two-PR contest, not an uncontested selection: without ancestor
+#           inheritance PR 10 wins on the higher `bug` topic category (and is
+#           also older); with it, issue 95's depth-6 priority lifts PR 20 on the
+#           outermost priority axis. So a correct result REQUIRES ancestor
+#           priority to be evaluated correctly across the supported window WHILE
+#           the depth-7 chain trips the truncation warning. Placing `priority`
+#           on the depth-6 (deepest in-window) ancestor proves both happen at
+#           once.
+#
+#           Fixture:
+#             issue 101  labels: [help wanted]   (leaf; closed by PR 20; no own priority)
+#             issue 95   labels: [priority]       (depth-6 ancestor of 101; priority-only)
+#             issue 200  labels: [bug]            (closed by PR 10; no priority)
+#             PR 10 (older, 2024-01-01) closes issue 200 (bug, no priority)
+#             PR 20 (newer, 2024-01-02) closes issue 101 (help wanted, no own
+#                     priority — priority only via depth-6 ancestor 95)
+#           Issue 95 is `priority`-only (NOT `help wanted`), so it never enters
+#           the startable issue queue and acts solely as an inherited-priority
+#           ancestor.
+#           Deep parent chain: 7 parent links (101->100->...->94). The closing
+#           issue 101 MUST itself have parent-101.json or the 7th-hop sentinel
+#           never fires. Issue 95 is the depth-6 (deepest in-window) ancestor;
+#           94 (the 7th-level ancestor) has no parent file. build_parent_json
+#           caps at depth>=7.
 echo "Test: default mode — ancestor chain deeper than supported depth emits truncation warning"
 setup
-UNION='['"$(make_pr_union 10 "10-deep-chain-leaf" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":101}]')"']'
+UNION='['
+UNION+="$(make_pr_union 10 "10-bug-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
+UNION+="$(make_pr_union 20 "20-deep-chain-leaf" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":101}]')"
+UNION+=']'
 setup_union_pr_list "$UNION"
-printf '[{"number":101,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' > "$STUB_DIR/issue-list.json"
+printf '[{"number":101,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":95,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
-# Deep parent chain: 7 parent links (101->100->...->94). The closing issue 101
-# MUST itself have parent-101.json or the 7th-hop sentinel never fires. 94 (the
-# 7th-level ancestor) has no parent file. build_parent_json caps at depth>=7.
 for i in 101 100 99 98 97 96 95; do
   printf '%d' $((i - 1)) > "$STUB_DIR/parent-$i.json"
 done
 result=$("$TMPDIR_TEST/dispatch-select-target" 2>"$TMPDIR_TEST/stderr") && rc=0 || rc=$?
 stderr=$(cat "$TMPDIR_TEST/stderr")
 assert_eq "deep-chain selection still exits 0" "0" "$rc"
-assert_eq "uncontested PR selected despite truncation" "pr 10 10-deep-chain-leaf fix-checks" "$result"
+assert_eq "ancestor priority lifts PR 20 over older PR 10 despite truncation" "pr 20 20-deep-chain-leaf fix-checks" "$result"
 assert_eq "truncation warning on stderr" "1" "$(grep -c 'ancestor chain deeper than supported depth (6) for issue 101' <<<"$stderr")"
 teardown
 


### PR DESCRIPTION
Closes #1973

## Summary

The depth-7 ancestor-chain truncation test in `test-dispatch-scripts.sh` (added
by #1968) used a single, uncontested PR in its UNION. With no competing PR, the
selection result was trivially correct regardless of whether ancestor-priority
ranking still worked under truncation — the assertion verified only that
`dispatch-select-target` did not abort, not that it ranked correctly.

This makes the selection assertion discriminating by converting the block into a
two-PR contest, mirroring the PO-ANC1 pattern used for the non-truncated case:

- **PR 10** (older, `2024-01-01`) closes issue **200** (`bug`, no priority).
- **PR 20** (newer, `2024-01-02`) closes issue **101** (`help wanted`, no own
  priority) whose 7-deep parent chain `101→100→…→94` carries `priority` on the
  **depth-6 (deepest in-window) ancestor** issue **95**.

`pr_priority_bit` unions a PR's closing-issue labels with those of its in-window
ancestors, so issue 95's `priority` lifts PR 20 onto the outermost priority axis
— *while* the depth-7 chain (issue 94) still trips the truncation warning. The
selection now asserts `pr 20 20-deep-chain-leaf fix-checks`.

The discriminator is exact: without ancestor inheritance both PRs are `pri=0`,
and the pri=0 tiebreak is topic category — PR 10 wins on the higher `bug`
category (and is also older). Only correct ancestor-priority evaluation across
the supported window flips selection to PR 20, so the assertion genuinely
depends on the mechanism it is meant to verify.

## Changes

- Two-PR UNION (PR 10 / PR 20) replacing the single uncontested PR.
- `issue-list.json` extended to issues 101 (`help wanted`), 95 (`priority`-only,
  so it stays out of the startable queue and acts solely as an inherited-priority
  ancestor), and 200 (`bug`).
- 7-hop parent-chain fixture left unchanged (issue 95 = depth 6, issue 94 = depth
  7 sentinel).
- Selection assertion changed to the discriminating expectation; exit-0 and
  truncation-warning assertions retained.
- Block header comment rewritten with the precise discriminator rationale.

This is a test-only change; `dispatch-select-target` is untouched, as is the
neighbouring depth-6 no-warning test.

## Verification

Full `test-dispatch-scripts.sh` suite passes: `3125/3125 passed, 0 failed`. The
target block's three assertions (exit 0, `pr 20 …` selection, truncation-warning
count 1) all pass.
