### PR TITLE
budget: drive export.ts from collectionRegistry

### DIFF
--- a/budget/src/export.ts
+++ b/budget/src/export.ts
@@ -1,52 +1,23 @@
 /** Serializes IndexedDB stores back to the upload JSON format. Inverse of the upload pipeline (parseUploadedJson + toParsedData in upload.ts). */
 import { getAll, getMeta } from "./idb.js";
-import type { CollectionRawData } from "./collection-registry.js";
-import type { IdbTransaction } from "./entities/transaction.js";
-import { transactionToRawJson } from "./entities/transaction.js";
-import type { IdbStatement } from "./entities/statement.js";
-import { statementToRawJson } from "./entities/statement.js";
-import type { IdbStatementItem } from "./entities/statement-item.js";
-import { statementItemToRawJson } from "./entities/statement-item.js";
-import type { IdbReconciliationNote } from "./entities/reconciliation-note.js";
-import { reconciliationNoteToRawJson } from "./entities/reconciliation-note.js";
-import type { IdbAccount } from "./entities/account.js";
-import { accountToRawJson } from "./entities/account.js";
-import type { IdbJournalEntry } from "./entities/journal-entry.js";
-import { journalEntryToRawJson } from "./entities/journal-entry.js";
-import type { IdbJournalLeg } from "./entities/journal-leg.js";
-import { journalLegToRawJson } from "./entities/journal-leg.js";
-import type { IdbReconciliationEvent } from "./entities/reconciliation-event.js";
-import { reconciliationEventToRawJson } from "./entities/reconciliation-event.js";
-import type { IdbBudget } from "./entities/budget.js";
-import { budgetToRawJson } from "./entities/budget.js";
-import type { IdbBudgetPeriod } from "./entities/budget-period.js";
-import { budgetPeriodToRawJson } from "./entities/budget-period.js";
-import type { IdbRule } from "./entities/rule.js";
-import { ruleToRawJson } from "./entities/rule.js";
-import type { IdbNormalizationRule } from "./entities/normalization-rule.js";
-import { normalizationRuleToRawJson } from "./entities/normalization-rule.js";
-import type { IdbWeeklyAggregate } from "./entities/weekly-aggregate.js";
-import { weeklyAggregateToRawJson } from "./entities/weekly-aggregate.js";
+import { collectionRegistry } from "./collection-registry.js";
+import type { CollectionRawData, IdbOf, RawOf, DataStoreName } from "./collection-registry.js";
+
+async function rawCollection<K extends DataStoreName>(name: K): Promise<RawOf<K>[]> {
+  const records = await getAll<IdbOf<K>>(name);
+  const toRawJson = collectionRegistry[name].toRawJson as unknown as (idb: IdbOf<K>) => RawOf<K>;
+  return records.map(toRawJson);
+}
 
 export async function exportToJson(): Promise<string> {
-  const [transactions, budgets, budgetPeriods, rules, normalizationRules, statements, statementItems, reconciliationNotes, accounts, journalEntries, journalLegs, reconciliationEvents, weeklyAggregates, meta] = await Promise.all([
-    getAll<IdbTransaction>("transactions"),
-    getAll<IdbBudget>("budgets"),
-    getAll<IdbBudgetPeriod>("budgetPeriods"),
-    getAll<IdbRule>("rules"),
-    getAll<IdbNormalizationRule>("normalizationRules"),
-    getAll<IdbStatement>("statements"),
-    getAll<IdbStatementItem>("statementItems"),
-    getAll<IdbReconciliationNote>("reconciliationNotes"),
-    getAll<IdbAccount>("accounts"),
-    getAll<IdbJournalEntry>("journalEntries"),
-    getAll<IdbJournalLeg>("journalLegs"),
-    getAll<IdbReconciliationEvent>("reconciliationEvents"),
-    getAll<IdbWeeklyAggregate>("weeklyAggregates"),
-    getMeta(),
-  ]);
-
+  const meta = await getMeta();
   if (!meta) throw new Error("No local data to export. Upload a file first.");
+
+  const names = Object.keys(collectionRegistry) as DataStoreName[];
+  const pairs = await Promise.all(
+    names.map(async (name) => [name, await rawCollection(name)] as const),
+  );
+  const collections = Object.fromEntries(pairs) as CollectionRawData;
 
   const output: CollectionRawData & {
     version: number;
@@ -59,19 +30,7 @@ export async function exportToJson(): Promise<string> {
     // groupId is not stored locally; empty string for format compatibility
     groupId: "",
     groupName: meta.groupName,
-    transactions: transactions.map(transactionToRawJson),
-    budgets: budgets.map(budgetToRawJson),
-    budgetPeriods: budgetPeriods.map(budgetPeriodToRawJson),
-    rules: rules.map(ruleToRawJson),
-    normalizationRules: normalizationRules.map(normalizationRuleToRawJson),
-    statements: statements.map(statementToRawJson),
-    statementItems: statementItems.map(statementItemToRawJson),
-    reconciliationNotes: reconciliationNotes.map(reconciliationNoteToRawJson),
-    accounts: accounts.map(accountToRawJson),
-    journalEntries: journalEntries.map(journalEntryToRawJson),
-    journalLegs: journalLegs.map(journalLegToRawJson),
-    reconciliationEvents: reconciliationEvents.map(reconciliationEventToRawJson),
-    weeklyAggregates: weeklyAggregates.map(weeklyAggregateToRawJson),
+    ...collections,
   };
 
   return JSON.stringify(output, null, 2) + "\n";


### PR DESCRIPTION
Closes #1697

## Summary

`budget/src/export.ts` was the last manual-enumeration holdout among the three
snapshot paths (upload, store, export). It listed all 13 IndexedDB stores twice —
once in the `Promise.all` fan-out and once in the output object literal — and
imported 13 per-entity `Idb*` types plus 13 per-entity `*ToRawJson` functions to
do it. Adding a store to the registry forced two extra edits in this file.

The sibling `budget/src/idb.ts` already drives off `collectionRegistry`
(`Object.keys(collectionRegistry) as DataStoreName[]`). This PR brings
`export.ts` to the same convention, fulfilling the registry's single-edit promise
for the export path.

## What changed

All changes are confined to `budget/src/export.ts`:

- Removed the 13 `import type { Idb* }` lines and the 13 `import { *ToRawJson }`
  lines; replaced them with the `collectionRegistry` value plus the `IdbOf` /
  `RawOf` / `DataStoreName` types (keeping `CollectionRawData`).
- Added a generic per-store helper `rawCollection<K extends DataStoreName>` that
  fetches a store and maps its records through that store's `toRawJson` adaptor.
- Replaced the manual 13-store `Promise.all` + output literal with a
  registry-driven body: iterate `Object.keys(collectionRegistry)`, build the
  collections via `Promise.all` → `Object.fromEntries`, and spread them into the
  output object.

The file shrank from 79 to 38 lines.

## Output is byte-identical

Registry key order matches the prior output-literal order exactly, and
`Object.keys` → `Promise.all` → `Object.fromEntries` preserve insertion order, so
`...collections` emits the same keys in the same order after
`version`/`exportedAt`/`groupId`/`groupName`. The existing `export.test.ts`
round-trip + field-mapping suite (16 tests) passes unchanged.

## Completeness is now by-construction

The issue prose said `CollectionRawData` would "still enforce completeness at
compile time," but that is in tension with the binding acceptance criterion that
adding a registry entry requires no change to `export.ts`: per-key compile-time
completeness would raise a tsc error inside `export.ts` on every registry
addition — exactly the burden this issue removes. So after the refactor,
completeness is by-construction (we iterate every registry key at runtime), not a
per-key tsc check. The `Object.fromEntries(...) as CollectionRawData` cast is
intended, and the registry being the sole source of collection keys is what
guarantees completeness.

### One implementation note for review

The plan's verbatim helper `records.map(collectionRegistry[name].toRawJson)` does
not type-check: TypeScript hits the correlated-union limitation and surfaces the
union of all 13 `toRawJson` signatures rather than the `K`-specific one (the
`idb.ts` `stores[name].put(record)` pattern dodges this only because `put`
accepts `any`). A plain `as (idb: IdbOf<K>) => RawOf<K>` cast was rejected for
insufficient overlap, so the helper binds the adaptor through an
`as unknown as (idb: IdbOf<K>) => RawOf<K>` local. The assertion is erased at
runtime, so output stays byte-identical (confirmed by the passing tests). A
cleaner structural fix would require typing the registry in
`collection-registry.ts`, which is out of scope here.

## Verification

- `npx vitest run --root budget export.test` — 16 passed.
- `npm run build --prefix budget` (`tsc --noEmit -p budget`) — clean.
