### PR TITLE
budget: validate override ordering on read in idbToBudget

### DIFF
--- a/budget/src/entities/budget.ts
+++ b/budget/src/entities/budget.ts
@@ -112,6 +112,14 @@ function requireAllowancePeriod(value: unknown): AllowancePeriod {
   return requireEnum(value, ALLOWANCE_PERIODS, "allowancePeriod");
 }
 
+function assertOverridesSortedAscending(overrides: readonly BudgetOverride[]): void {
+  for (let i = 1; i < overrides.length; i++) {
+    if (overrides[i].date.toMillis() <= overrides[i - 1].date.toMillis()) {
+      throw new DataIntegrityError(`overrides not sorted by date ascending at index ${i}`);
+    }
+  }
+}
+
 function requireOverrides(value: unknown): BudgetOverride[] {
   if (value == null) return [];
   if (!Array.isArray(value)) {
@@ -127,11 +135,7 @@ function requireOverrides(value: unknown): BudgetOverride[] {
     const balance = requireNumber(entry.balance, `overrides[${i}].balance`);
     result.push({ date, balance });
   }
-  for (let i = 1; i < result.length; i++) {
-    if (result[i].date.toMillis() <= result[i - 1].date.toMillis()) {
-      throw new DataIntegrityError(`overrides not sorted by date ascending at index ${i}`);
-    }
-  }
+  assertOverridesSortedAscending(result);
   return result;
 }
 
@@ -207,16 +211,18 @@ export function budgetToIdbRecord(b: Budget): IdbBudget {
 // ── IdbBudget → Budget ────────────────────────────────────────────────────────
 
 export function idbToBudget(row: IdbBudget): Budget {
+  const overrides = (row.overrides ?? []).map(o => ({
+    date: msToTs(o.dateMs) as Timestamp,
+    balance: o.balance,
+  }));
+  assertOverridesSortedAscending(overrides);
   return {
     id: row.id as BudgetId,
     name: row.name,
     allowance: row.allowance,
     allowancePeriod: requireAllowancePeriod(row.allowancePeriod),
     rollover: requireEnum(row.rollover, ROLLOVERS, "rollover"),
-    overrides: (row.overrides ?? []).map(o => ({
-      date: msToTs(o.dateMs) as Timestamp,
-      balance: o.balance,
-    })),
+    overrides,
     groupId: null as GroupId | null,
   };
 }

--- a/budget/src/entities/budget.ts
+++ b/budget/src/entities/budget.ts
@@ -211,10 +211,15 @@ export function budgetToIdbRecord(b: Budget): IdbBudget {
 // ── IdbBudget → Budget ────────────────────────────────────────────────────────
 
 export function idbToBudget(row: IdbBudget): Budget {
-  const overrides = (row.overrides ?? []).map(o => ({
-    date: msToTs(o.dateMs) as Timestamp,
-    balance: o.balance,
-  }));
+  const overrides = (row.overrides ?? []).map(o => {
+    if (!Number.isFinite(o.dateMs)) {
+      throw new DataIntegrityError("overrides[].dateMs must be a finite number");
+    }
+    return {
+      date: msToTs(o.dateMs) as Timestamp,
+      balance: o.balance,
+    };
+  });
   assertOverridesSortedAscending(overrides);
   return {
     id: row.id as BudgetId,

--- a/budget/test/data-source.test.ts
+++ b/budget/test/data-source.test.ts
@@ -40,6 +40,7 @@ import type { DataSource } from "../src/data-source";
 import type { TransactionId, BudgetId, BudgetPeriodId, RuleId } from "../src/firestore";
 import type { BudgetOverride } from "../src/entities/budget";
 import { makeParsedData } from "./helpers";
+import { DataIntegrityError } from "../src/entities/_helpers";
 
 beforeEach(async () => {
   await closeDb();
@@ -144,6 +145,17 @@ describe("IdbDataSource", () => {
     await storeParsedData(data);
     const ds = new IdbDataSource();
     await expect(ds.getTransactions()).rejects.toThrow(RangeError);
+  });
+
+  it("getBudgets throws for a pre-existing out-of-order overrides record", async () => {
+    const data = makeParsedData();
+    data.budgets[0].overrides = [
+      { dateMs: 2000, balance: 100 },
+      { dateMs: 1000, balance: 200 }, // earlier date — simulates a row written before PR #1686
+    ];
+    await storeParsedData(data);
+    const ds = new IdbDataSource();
+    await expect(ds.getBudgets()).rejects.toThrow(DataIntegrityError);
   });
 
   it("adjustBudgetPeriodTotal does read-modify-write correctly", async () => {


### PR DESCRIPTION
Closes #1703

## Problem

`idbToBudget` (`budget/src/entities/budget.ts`) maps a stored `IdbBudget` row to
a domain `Budget` but did not re-validate that `overrides` are sorted by date
ascending. The domain interface documents this invariant —
`findOverrideInPeriod` assumes the ordering — and PR #1686 added
`validateBudgetOverrideOrdering` at the *write* boundary, but a row written
before that PR could still hold out-of-order overrides. On read, `idbToBudget`
silently produced a malformed `Budget` that corrupts period lookups instead of
surfacing a clear error.

This left the IDB budget read path inconsistent with the transaction read path:
`idbToTransaction` already calls `validateReimbursementRange(row.reimbursement)`
at the top of the function to guard against stale, pre-validator rows.

## Change

Add the missing read-path guard, mirroring the `idbToTransaction` placement:

- Extract the override-ordering check that lived inline in `requireOverrides`
  into a shared private helper `assertOverridesSortedAscending`, so the read-path
  invariant has a single source of truth.
- Call that helper from `idbToBudget` after mapping the overrides, so
  `getBudgets()` throws a clear `DataIntegrityError` on a stale out-of-order row
  instead of returning a malformed `Budget`.

The read guard throws `DataIntegrityError` — the established read-path convention
in `budget.ts` (`requireEnum`, `requireTimestamp`, `requireOverrides` all do).
The write-boundary validator `validateBudgetOverrideOrdering` (which throws
`RangeError`) is deliberately left untouched; the write(`RangeError`) /
read(`DataIntegrityError`) split is intentional and matches the existing
`requireOverrides` read parser.

## Test

Adds `getBudgets throws for a pre-existing out-of-order overrides record` in
`budget/test/data-source.test.ts`, analogous to the existing stale-reimbursement
read test. The full `budget` suite passes.
