### PR TITLE
print, budget: declare sharp as a devDependency

### DIFF
--- a/budget/package.json
+++ b/budget/package.json
@@ -39,6 +39,7 @@
     "@types/d3-scale-chromatic": "^3.1.0",
     "@types/d3-shape": "^3.1.8",
     "fake-indexeddb": "^6.0.0",
+    "sharp": "^0.34.5",
     "vite": "^6.4.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -144,6 +144,7 @@
         "@types/d3-scale-chromatic": "^3.1.0",
         "@types/d3-shape": "^3.1.8",
         "fake-indexeddb": "^6.0.0",
+        "sharp": "^0.34.5",
         "vite": "^6.4.3"
       }
     },
@@ -15008,6 +15009,7 @@
       },
       "devDependencies": {
         "fake-indexeddb": "^6.2.5",
+        "sharp": "^0.34.5",
         "vite": "^6.4.3"
       }
     },

--- a/print/package.json
+++ b/print/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "fake-indexeddb": "^6.2.5",
+    "sharp": "^0.34.5",
     "vite": "^6.4.3"
   }
 }


### PR DESCRIPTION
Closes #1708

## Summary

The `icons` script in both `print` and `budget` (`node scripts/generate-icons.mjs`)
imports `sharp`, but `sharp` was declared only in the root workspace
`package.json` (`^0.34.5`) — not in either package's own `devDependencies`. It
resolved at build time via npm workspace hoisting, which hid the undeclared
dependency: a developer installing a single package in isolation
(`npm install --prefix print`) could not run `npm run icons --prefix print` —
they hit a module-not-found error with no hint that a root install was needed.

This PR adds `"sharp": "^0.34.5"` to the `devDependencies` of
`print/package.json` and `budget/package.json` so each package is
self-describing, and refreshes `package-lock.json` to record the new dependency
edges. The version specifier matches root exactly, so the workspace still
resolves to the single hoisted `sharp@0.34.5` — no resolved-version churn.

This mirrors the established workspace convention: commit `e8c02e4f` already
applied the same per-package pattern for `vite`, which both packages already
carry.

## Changes

- `print/package.json` — add `"sharp": "^0.34.5"` to `devDependencies`
  (between `fake-indexeddb` and `vite`).
- `budget/package.json` — same addition.
- `package-lock.json` — record the two new workspace dependency edges; no
  resolved-version change.

## Verification

- `sharp` appears under `devDependencies` in both `print/package.json` and
  `budget/package.json`.
- `git diff package-lock.json` shows only the two `sharp` edges added for the
  `print`/`budget` workspace entries — no resolved-version churn.
- Root `npm install` reports `up to date`; no stray PNG churn under
  `print/public/icons` or `budget/public/icons`.

Out of scope: the `generate-icons.mjs` scripts (already import `sharp`
correctly), `fellspiral`/`landing` (no `icons` script), and root `package.json`
(keeps its own declaration).
