### PR TITLE
budget: pin dev optimizeDeps target to es2022 so the Vite dev server starts

### DIFF
--- a/budget/vite.config.ts
+++ b/budget/vite.config.ts
@@ -1,4 +1,13 @@
 import { createAppConfig } from "@commons-systems/config/vite";
 import { budgetSeedDataPlugin } from "./src/vite-plugin-seed-data";
 
-export default createAppConfig({ plugins: [budgetSeedDataPlugin()] });
+// optimizeDeps target: Vite's default dep-prebundling target ('modules', which
+// includes firefox78) makes esbuild 0.28.x try to downlevel destructuring it
+// can't transform (the `{marks = [], ...options} = {}` form in @observablehq/plot
+// and rest-destructuring in @firebase/analytics), crashing `vite` at startup.
+// Pin dev prebundling to es2022 — matching the production build.target in the
+// shared appBase — so esbuild leaves the modern syntax untouched.
+export default createAppConfig({
+  plugins: [budgetSeedDataPlugin()],
+  optimizeDeps: { esbuildOptions: { target: "es2022" } },
+});


### PR DESCRIPTION
## Problem

The `budget` Vite **dev server** crashes immediately on startup:

```
✘ [ERROR] Transforming destructuring to the configured target environment
("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides) is not
supported yet

    ../node_modules/@observablehq/plot/src/index.js:5:32:
      5 │ Mark.prototype.plot = function ({marks = [], ...options} = {}) {
```

(plus the same error for rest-destructuring in `@firebase/analytics`).

## Root cause

Vite's dev-mode dependency pre-bundling runs esbuild with Vite's default
`'modules'` target — `chrome87, edge88, es2020, firefox78, safari14`. Because
`firefox78` is in that set, esbuild 0.28.x tries to downlevel destructuring to
work around an old-Firefox bug, but it cannot transform the
`{marks = [], ...options} = {}` rest form and aborts the whole optimize pass, so
`vite` never finishes startup.

The shared appBase already sets `build.target: "es2022"`, but that applies only
to the **production** build (Rollup) — not to dev-mode `optimizeDeps`. So
`vite build` succeeds while `vite` (dev) crashes.

## Fix

Pin dev pre-bundling to `es2022` to match the production `build.target`:

```ts
optimizeDeps: { esbuildOptions: { target: "es2022" } }
```

esbuild then leaves the modern syntax untouched and the dev server starts
normally.

## Scope

`budget` is the only app that crashes today (it's the only one depending on
`@observablehq/plot`), so the override is scoped to `budget/vite.config.ts`,
following the existing per-app override pattern (e.g. `print`'s
`resolve.dedupe`).

## Verification

- Before: `npx vite` crashes within ~200ms with the esbuild destructuring error.
- After: dev server reaches HTTP 200 in ~2s, 0 esbuild errors.
- Production build is unchanged (already used `build.target: es2022`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
