### PR TITLE
Architecture boundary lint: forbid importing top-level app packages

### DIFF
--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -1,9 +1,54 @@
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// The config file lives at <root>/config/eslint.config.js, so its dir is
+// <root>/config and the parent is the repo root. Resolve cwd-independently so
+// the layering rule works regardless of which workspace eslint runs from.
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// Derive the top-level app package list dynamically from the workspace
+// manifests. Apps are the dependency-graph roots: unscoped workspace names
+// (e.g. `landing`, `print`). Scoped `@commons-systems/*` names are leaf libs
+// and must NOT be restricted — they are the layers apps are allowed to import.
+const { workspaces } = JSON.parse(
+  readFileSync(join(rootDir, "package.json"), "utf8"),
+);
+const appPackages = workspaces
+  .map((ws) => {
+    const { name } = JSON.parse(
+      readFileSync(join(rootDir, ws, "package.json"), "utf8"),
+    );
+    return name;
+  })
+  .filter((name) => name && !name.startsWith("@commons-systems/"));
+
+const appImportPatterns = appPackages.map((app) => ({
+  group: [app, `${app}/*`, `${app}/**`],
+  message:
+    `Layering violation: '${app}' is a top-level app package and must not be ` +
+    "imported by libraries, utils, or @commons-systems/ds. Apps are " +
+    "dependency-graph roots — move shared code into a @commons-systems/* leaf " +
+    "package instead.",
+}));
 
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      // Turn off the core rule to avoid double-reporting; the
+      // typescript-eslint variant below handles the layering patterns.
+      "no-restricted-imports": "off",
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        { patterns: appImportPatterns },
+      ],
+    },
+  },
   {
     ignores: ["dist/"],
   },

--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -26,7 +26,7 @@ const appPackages = workspaces
   .filter((name) => name && !name.startsWith("@commons-systems/"));
 
 const appImportPatterns = appPackages.map((app) => ({
-  group: [app, `${app}/*`, `${app}/**`],
+  group: [app, `${app}/**`],
   message:
     `Layering violation: '${app}' is a top-level app package and must not be ` +
     "imported by libraries, utils, or @commons-systems/ds. Apps are " +

--- a/config/test/eslint-boundaries.test.ts
+++ b/config/test/eslint-boundaries.test.ts
@@ -37,6 +37,14 @@ describe("eslint layering boundary rules", () => {
     expect(violations[0].message).toContain("landing");
   });
 
+  it("flags a type-only import from an app package", () => {
+    const messages = lint('import type { X } from "landing";');
+    const violations = restrictedImportMessages(messages);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(/top-level app package/);
+    expect(violations[0].message).toContain("landing");
+  });
+
   it("does not flag a scoped leaf-lib import", () => {
     const messages = lint('import { x } from "@commons-systems/errorutil";');
     const violations = restrictedImportMessages(messages);

--- a/config/test/eslint-boundaries.test.ts
+++ b/config/test/eslint-boundaries.test.ts
@@ -1,0 +1,45 @@
+import { Linter } from "eslint";
+import { describe, it, expect } from "vitest";
+import config from "../eslint.config.js";
+
+// Use the flat-config Linter API so the real shipped config is exercised without
+// spawning a child process. Pass a .ts filename so the TS-file `files` glob in
+// the config matches and the @typescript-eslint/no-restricted-imports rule fires.
+
+const linter = new Linter({ configType: "flat" });
+
+function lint(code: string): Linter.LintMessage[] {
+  return linter.verify(code, config as Parameters<typeof linter.verify>[1], {
+    filename: "src/foo.ts",
+  });
+}
+
+function restrictedImportMessages(messages: Linter.LintMessage[]) {
+  return messages.filter(
+    (m) => m.ruleId === "@typescript-eslint/no-restricted-imports",
+  );
+}
+
+describe("eslint layering boundary rules", () => {
+  it("flags a bare app-package import", () => {
+    const messages = lint('import x from "landing";');
+    const violations = restrictedImportMessages(messages);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(/top-level app package/);
+    expect(violations[0].message).toContain("landing");
+  });
+
+  it("flags a subpath import from an app package", () => {
+    const messages = lint('import x from "landing/foo";');
+    const violations = restrictedImportMessages(messages);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(/top-level app package/);
+    expect(violations[0].message).toContain("landing");
+  });
+
+  it("does not flag a scoped leaf-lib import", () => {
+    const messages = lint('import { x } from "@commons-systems/errorutil";');
+    const violations = restrictedImportMessages(messages);
+    expect(violations).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #2063

## What

Installs an architecture-boundary lint sensor in the single shared
`config/eslint.config.js`, which every workspace re-exports verbatim. A source
file that imports a top-level app package — a leaf util or `@commons-systems/ds`
reaching "up" into an app — now fails `run-lint.sh` / the PR lint check with a
remediation message naming the layering rule and how to fix it.

Part of epic #2061 (code-quality decay sensors). Nothing previously stopped an
agent from silently introducing a layering violation that type-check, lint, and
test all pass.

## How

`@typescript-eslint/no-restricted-imports` targeting the **app package
specifiers**, not `eslint-plugin-boundaries`. The apps are dependency-graph roots
with unscoped package names (`audio`, `budget`, `fellspiral`, `landing`,
`office-hours`, `print`), and nothing legitimately imports an app. A single shared
rule that forbids importing any app specifier therefore needs no per-workspace
knowledge, has zero false positives, and enforces both required boundaries at once
(leaf-util→app and ds→app, plus app→app).

`eslint-plugin-boundaries` was rejected as a structural mismatch, not a
migration-cost compromise: each workspace runs `eslint src/` from its own cwd
under the identical shared config, so the importing file's path (`src/foo.ts`)
carries no layer signal — the shared config cannot classify it without
per-workspace configuration, defeating the one-shared-edit goal.

The app list is **derived dynamically** at config load: read the root
`package.json` `workspaces`, read each workspace's `name`, and classify any whose
name does not start with `@commons-systems/` as an app. The repo root is resolved
from the config file's own location (`fileURLToPath(import.meta.url)`) so it is
cwd-independent. One restricted-`patterns` entry is built per app, each carrying a
message naming that specific app. Hard-coding the names would silently drift when
an app is added or removed; deriving them cannot.

The TypeScript-aware `@typescript-eslint/no-restricted-imports` is used (the
tseslint plugin is already registered via `tseslint.configs.recommended`) so
`import type` specifiers are caught too; the core `no-restricted-imports` is turned
off to avoid double-reporting. Each pattern group matches the bare specifier and
subpath forms (`<app>`, `<app>/*`, `<app>/**`).

## Units

1. **Add the layering rule to the shared eslint config** (`config/eslint.config.js`).
   Verified zero false positives — `packages/ds`, `analyticsutil`, and `landing`
   lint still pass — and that the sensor fires: a temporary `import "landing";` in a
   util source fails lint with the layer-naming message (reverted).
2. **Regression test** (`config/test/eslint-boundaries.test.ts`). Lints code
   snippets against the real shipped config via ESLint's flat-config `Linter` API: a
   bare `import "landing"` and a subpath `import "landing/foo"` both report the
   `@typescript-eslint/no-restricted-imports` layer message, while a legitimate
   `@commons-systems/errorutil` import reports none.

## Verification

- `npx vitest run --project config` — 18 tests pass, including the 3 new boundary
  cases (this is the CI-gating invocation).
- Lint passes across `packages/ds`, `analyticsutil`, `landing` (no false positives).
- The sensor fires through the `run-lint.sh` → `npm run -w … lint` path on a
  temporary violation.

No new dependencies — `eslint` and `typescript-eslint` are already root
devDependencies.
