### PR TITLE
office-hours: size charts from measured container, not hardcoded CONTAINER_WIDTH

### DIFF
--- a/office-hours/src/audit-aggregate-chart.ts
+++ b/office-hours/src/audit-aggregate-chart.ts
@@ -7,11 +7,11 @@ import {
   buildLegend,
   computeChartWidth,
   renderAxisSvg,
+  mountResponsiveChart,
   type LegendEntry,
   MARGIN_RIGHT,
   MARGIN_BOTTOM,
   POINT_WIDTH,
-  CONTAINER_WIDTH,
   CHART_HEIGHT,
 } from "./chart-util.js";
 
@@ -109,8 +109,6 @@ export function renderAuditAggregateChart(aggregates: AuditAggregate[]): HTMLEle
     sorted[sorted.length - 1].computedAt,
   ];
 
-  const chartWidth = computeChartWidth(sorted.length, POINT_WIDTH, CONTAINER_WIDTH);
-
   const fg = getThemeFg(container);
   const sharedStyle = { background: "transparent", color: fg };
 
@@ -126,87 +124,100 @@ export function renderAuditAggregateChart(aggregates: AuditAggregate[]): HTMLEle
   }
   const spendDomain: [number, number] = [0, maxSpend > 0 ? maxSpend : 1];
 
-  const spendAxisSvg = renderAxisSvg({
-    height: CHART_HEIGHT,
-    style: sharedStyle,
-    yDomain: spendDomain,
-    label: "$",
-  });
-
-  const spendChartSvg = Plot.plot({
-    width: chartWidth,
-    height: CHART_HEIGHT,
-    marginBottom: MARGIN_BOTTOM,
-    marginLeft: 0,
-    marginRight: MARGIN_RIGHT,
-    style: sharedStyle,
-    x: { type: "time", label: null, domain: xDomain },
-    y: { label: null, axis: null, grid: true, domain: spendDomain },
-    marks: phases.map((phase, i) =>
-      Plot.lineY(phaseSeries[phase], {
-        x: "x",
-        y: "spend",
-        stroke: phaseColor(i),
-        strokeWidth: 2,
-        curve: "monotone-x",
-      }),
-    ),
-  });
-
-  spendChartSvg.style.width = `${chartWidth}px`;
-  spendChartSvg.style.minWidth = `${chartWidth}px`;
-
-  const { layout: spendLayout, wrapper: spendWrapper } = assembleChartLayout(
-    spendAxisSvg,
-    spendChartSvg,
-  );
-
   // --- Bottom sub-chart: derived hit-rate trend (%). ---
   const hitDomain: [number, number] = [0, 100];
 
-  const hitAxisSvg = renderAxisSvg({
-    height: CHART_HEIGHT,
-    style: sharedStyle,
-    yDomain: hitDomain,
-    label: "%",
-  });
-
-  const hitChartSvg = Plot.plot({
-    width: chartWidth,
-    height: CHART_HEIGHT,
-    marginBottom: MARGIN_BOTTOM,
-    marginLeft: 0,
-    marginRight: MARGIN_RIGHT,
-    style: sharedStyle,
-    x: { type: "time", label: null, domain: xDomain },
-    y: { label: null, axis: null, grid: true, domain: hitDomain },
-    marks: [
-      Plot.lineY(hitRatePoints, {
-        x: "x",
-        y: "hitPct",
-        stroke: COLOR_HIT_RATE,
-        strokeWidth: 2,
-        curve: "monotone-x",
-      }),
-    ],
-  });
-
-  hitChartSvg.style.width = `${chartWidth}px`;
-  hitChartSvg.style.minWidth = `${chartWidth}px`;
-
-  const { layout: hitLayout, wrapper: hitWrapper } = assembleChartLayout(hitAxisSvg, hitChartSvg);
-
   const legend = buildLegend([...phaseEntries, { label: SERIES_HIT_RATE, color: COLOR_HIT_RATE }]);
 
-  container.replaceChildren(spendLayout, hitLayout, legend);
+  // Block-level slot the ResizeObserver measures; the .chart-scroll-wrapper
+  // inside each sub-layout clips horizontally so the slot stays at the panel
+  // content-box width.
+  const slot = document.createElement("div");
 
-  // Scroll both bodies to the newest data (rightmost) on first paint. The
-  // container is still detached here (the view appends it after this returns),
-  // so scrollWidth is 0 until a layout pass — defer to the next frame.
-  requestAnimationFrame(() => {
-    spendWrapper.scrollLeft = spendWrapper.scrollWidth;
-    hitWrapper.scrollLeft = hitWrapper.scrollWidth;
+  mountResponsiveChart(slot, (width) => {
+    const chartWidth = computeChartWidth(sorted.length, POINT_WIDTH, width);
+
+    const spendAxisSvg = renderAxisSvg({
+      height: CHART_HEIGHT,
+      style: sharedStyle,
+      yDomain: spendDomain,
+      label: "$",
+    });
+
+    const spendChartSvg = Plot.plot({
+      width: chartWidth,
+      height: CHART_HEIGHT,
+      marginBottom: MARGIN_BOTTOM,
+      marginLeft: 0,
+      marginRight: MARGIN_RIGHT,
+      style: sharedStyle,
+      x: { type: "time", label: null, domain: xDomain },
+      y: { label: null, axis: null, grid: true, domain: spendDomain },
+      marks: phases.map((phase, i) =>
+        Plot.lineY(phaseSeries[phase], {
+          x: "x",
+          y: "spend",
+          stroke: phaseColor(i),
+          strokeWidth: 2,
+          curve: "monotone-x",
+        }),
+      ),
+    });
+
+    spendChartSvg.style.width = `${chartWidth}px`;
+    spendChartSvg.style.minWidth = `${chartWidth}px`;
+
+    const { layout: spendLayout, wrapper: spendWrapper } = assembleChartLayout(
+      spendAxisSvg,
+      spendChartSvg,
+    );
+
+    const hitAxisSvg = renderAxisSvg({
+      height: CHART_HEIGHT,
+      style: sharedStyle,
+      yDomain: hitDomain,
+      label: "%",
+    });
+
+    const hitChartSvg = Plot.plot({
+      width: chartWidth,
+      height: CHART_HEIGHT,
+      marginBottom: MARGIN_BOTTOM,
+      marginLeft: 0,
+      marginRight: MARGIN_RIGHT,
+      style: sharedStyle,
+      x: { type: "time", label: null, domain: xDomain },
+      y: { label: null, axis: null, grid: true, domain: hitDomain },
+      marks: [
+        Plot.lineY(hitRatePoints, {
+          x: "x",
+          y: "hitPct",
+          stroke: COLOR_HIT_RATE,
+          strokeWidth: 2,
+          curve: "monotone-x",
+        }),
+      ],
+    });
+
+    hitChartSvg.style.width = `${chartWidth}px`;
+    hitChartSvg.style.minWidth = `${chartWidth}px`;
+
+    const { layout: hitLayout, wrapper: hitWrapper } = assembleChartLayout(hitAxisSvg, hitChartSvg);
+
+    // Scroll both bodies to the newest data (rightmost). The slot is detached on
+    // the first paint, so scrollWidth is 0 until a layout pass — defer to the
+    // next frame.
+    requestAnimationFrame(() => {
+      spendWrapper.scrollLeft = spendWrapper.scrollWidth;
+      hitWrapper.scrollLeft = hitWrapper.scrollWidth;
+    });
+
+    const fragment = document.createDocumentFragment();
+    fragment.append(spendLayout, hitLayout);
+    return fragment;
   });
+
+  container.replaceChildren(slot, legend);
 
   return container;
 }

--- a/office-hours/src/chart-util.ts
+++ b/office-hours/src/chart-util.ts
@@ -97,7 +97,7 @@ export function mountResponsiveChart(slot: HTMLElement, render: (width: number) 
       return;
     }
     const entry = entries[entries.length - 1];
-    const next = Math.round(entry.contentRect.width) || FALLBACK_CONTAINER_WIDTH;
+    const next = entry.contentRect.width > 0 ? Math.round(entry.contentRect.width) : FALLBACK_CONTAINER_WIDTH;
     // Debounce sub-pixel jitter and guard against any re-paint feedback loop.
     if (Math.abs(next - last) >= 1) {
       last = next;

--- a/office-hours/src/chart-util.ts
+++ b/office-hours/src/chart-util.ts
@@ -50,13 +50,61 @@ export const MARGIN_RIGHT = 20;
 export const MARGIN_BOTTOM = 50;
 /** Per-sample chart width allocation along the time axis. */
 export const POINT_WIDTH = 60;
-/** Approximate visible width before horizontal scrolling kicks in. */
-export const CONTAINER_WIDTH = 640;
+/**
+ * Fallback width used only for the initial synchronous paint, when the chart
+ * core builds a DETACHED element whose `clientWidth` is 0. Once mounted and
+ * sized, `mountResponsiveChart`'s ResizeObserver re-paints at the slot's real
+ * content-box width. Private — layout width now comes from the live container,
+ * not a fixed constant.
+ */
+const FALLBACK_CONTAINER_WIDTH = 640;
 export const CHART_HEIGHT = 220;
 
 /** Compute scrollable chart body width from point count and point width, filling at least the visible area. */
 export function computeChartWidth(pointCount: number, pointWidth: number, containerWidth: number): number {
   return Math.max(pointCount * pointWidth + MARGIN_RIGHT, containerWidth - AXIS_WIDTH);
+}
+
+/**
+ * Mount a responsive chart into `slot`: paint once synchronously at the slot's
+ * measured width (or the fallback when detached/unsized), then re-paint via a
+ * ResizeObserver as the slot's real width changes.
+ *
+ * `render(width)` must build and return the chart DOM for the given container
+ * width. It is called on every (debounced) size change, so all width-dependent
+ * DOM — Plot bodies, layout, scroll-to-newest — belongs inside it.
+ *
+ * Observer cleanup is by `isConnected` self-disconnect rather than an explicit
+ * teardown handle: the React/vanilla mount paths tear down only via
+ * `host.replaceChildren()`, which detaches the slot. A spec-compliant
+ * ResizeObserver then fires a final size→0 callback, and the `!slot.isConnected`
+ * guard disconnects the observer. Documented fallback (NOT implemented now): if
+ * that final callback proves unreliable in a target browser, return a disconnect
+ * fn here for the islands' teardowns to call. Self-disconnect is the chosen path.
+ */
+export function mountResponsiveChart(slot: HTMLElement, render: (width: number) => Node): void {
+  const w = slot.clientWidth || FALLBACK_CONTAINER_WIDTH;
+  slot.replaceChildren(render(w));
+  let last = w;
+
+  // happy-dom test env has no ResizeObserver — the synchronous fallback-width
+  // paint above already produced the asserted DOM, so we are done.
+  if (typeof ResizeObserver === "undefined") return;
+
+  const obs = new ResizeObserver((entries) => {
+    if (!slot.isConnected) {
+      obs.disconnect();
+      return;
+    }
+    const entry = entries[entries.length - 1];
+    const next = Math.round(entry.contentRect.width) || FALLBACK_CONTAINER_WIDTH;
+    // Debounce sub-pixel jitter and guard against any re-paint feedback loop.
+    if (Math.abs(next - last) >= 1) {
+      last = next;
+      slot.replaceChildren(render(next));
+    }
+  });
+  obs.observe(slot);
 }
 
 /** Read a CSS custom property from the container's computed style; returns fallback if empty or missing. */

--- a/office-hours/src/issue-history-chart.ts
+++ b/office-hours/src/issue-history-chart.ts
@@ -8,6 +8,7 @@ import {
   buildLegend,
   computeChartWidth,
   renderAxisSvg,
+  mountResponsiveChart,
   MARGIN_RIGHT,
   MARGIN_BOTTOM,
   AXIS_WIDTH,
@@ -15,8 +16,6 @@ import {
 
 /** Per-sample chart width allocation along the time axis. */
 const POINT_WIDTH = 60;
-/** Approximate visible width before horizontal scrolling kicks in. */
-const CONTAINER_WIDTH = 640;
 const CHART_HEIGHT = 220;
 
 interface Point {
@@ -129,22 +128,17 @@ export function renderIssueHistoryChart(samples: IssueSample[]): HTMLElement {
 
   const fit = fitBacklogRunway(samples);
 
-  let width: number;
-  let xDomain: [Date, Date];
-
   const first = sorted[0].sampledAt.getTime();
   const last = sorted[sorted.length - 1].sampledAt.getTime();
   const dataDays = (last - first) / 86_400_000;
+  const isDraining = fit.state === "draining" && dataDays > 0;
 
-  if (fit.state === "draining" && dataDays > 0) {
-    xDomain = [sorted[0].sampledAt, fit.crossingAt];
+  // x domain and the projection mark are width-independent — compute once.
+  const xDomain: [Date, Date] = isDraining
+    ? [sorted[0].sampledAt, fit.crossingAt]
+    : [sorted[0].sampledAt, sorted[sorted.length - 1].sampledAt];
 
-    const pxPerDay = (points.length * POINT_WIDTH) / dataDays;
-    width = Math.max(
-      points.length * POINT_WIDTH + pxPerDay * fit.daysUntilEmpty + MARGIN_RIGHT,
-      CONTAINER_WIDTH - AXIS_WIDTH,
-    );
-
+  if (isDraining) {
     // Dashed projection from the fitted value at the last actual point down to
     // the zero-crossing.
     const fittedLast = Math.max(0, fit.slope * dataDays + fit.intercept);
@@ -164,27 +158,7 @@ export function renderIssueHistoryChart(samples: IssueSample[]): HTMLElement {
         },
       ),
     );
-  } else {
-    xDomain = [sorted[0].sampledAt, sorted[sorted.length - 1].sampledAt];
-    width = computeChartWidth(points.length, POINT_WIDTH, CONTAINER_WIDTH);
   }
-
-  const chartSvg = Plot.plot({
-    width,
-    height: CHART_HEIGHT,
-    marginBottom: MARGIN_BOTTOM,
-    marginLeft: 0,
-    marginRight: MARGIN_RIGHT,
-    style: sharedStyle,
-    x: { type: "time", label: null, domain: xDomain },
-    y: { label: null, axis: null, grid: true, domain: yDomain },
-    marks,
-  });
-
-  chartSvg.style.width = `${width}px`;
-  chartSvg.style.minWidth = `${width}px`;
-
-  const { layout, wrapper } = assembleChartLayout(axisSvg, chartSvg);
 
   // Runway caption — textContent-assertable, mirroring queue-band's runway DOM.
   const caption = document.createElement("p");
@@ -204,14 +178,50 @@ export function renderIssueHistoryChart(samples: IssueSample[]): HTMLElement {
     { label: "projection", color: COLOR_PROJECTION, dashed: true },
   ]);
 
-  container.replaceChildren(layout, caption, legend);
+  // Block-level slot the ResizeObserver measures; .chart-scroll-wrapper inside
+  // clips horizontally so the slot stays at the panel content-box width.
+  const slot = document.createElement("div");
 
-  // Scroll to the newest data (rightmost) on first paint. scrollWidth is 0 for a
-  // detached element, and this container is still detached here, so defer the
-  // assignment to the next frame — by then a layout pass has run.
-  requestAnimationFrame(() => {
-    wrapper.scrollLeft = wrapper.scrollWidth;
+  mountResponsiveChart(slot, (width) => {
+    let chartWidth: number;
+    if (isDraining) {
+      const pxPerDay = (points.length * POINT_WIDTH) / dataDays;
+      chartWidth = Math.max(
+        points.length * POINT_WIDTH + pxPerDay * fit.daysUntilEmpty + MARGIN_RIGHT,
+        width - AXIS_WIDTH,
+      );
+    } else {
+      chartWidth = computeChartWidth(points.length, POINT_WIDTH, width);
+    }
+
+    const chartSvg = Plot.plot({
+      width: chartWidth,
+      height: CHART_HEIGHT,
+      marginBottom: MARGIN_BOTTOM,
+      marginLeft: 0,
+      marginRight: MARGIN_RIGHT,
+      style: sharedStyle,
+      x: { type: "time", label: null, domain: xDomain },
+      y: { label: null, axis: null, grid: true, domain: yDomain },
+      marks,
+    });
+
+    chartSvg.style.width = `${chartWidth}px`;
+    chartSvg.style.minWidth = `${chartWidth}px`;
+
+    const { layout, wrapper } = assembleChartLayout(axisSvg, chartSvg);
+
+    // Scroll to the newest data (rightmost). scrollWidth is 0 for a detached
+    // element, and the slot is detached on the first paint, so defer to the next
+    // frame — by then a layout pass has run.
+    requestAnimationFrame(() => {
+      wrapper.scrollLeft = wrapper.scrollWidth;
+    });
+
+    return layout;
   });
+
+  container.replaceChildren(slot, caption, legend);
 
   return container;
 }

--- a/office-hours/src/pace-position-panel.ts
+++ b/office-hours/src/pace-position-panel.ts
@@ -8,13 +8,12 @@ import {
   assembleChartLayout,
   buildLegend,
   renderAxisSvg,
+  mountResponsiveChart,
   AXIS_WIDTH,
   MARGIN_RIGHT,
   MARGIN_BOTTOM,
 } from "./chart-util.js";
 
-/** Approximate visible width; the x domain is bounded [0, 1] so no scrolling. */
-const CONTAINER_WIDTH = 640;
 const CHART_HEIGHT = 220;
 
 /**
@@ -58,55 +57,7 @@ export function renderPacePositionPanel(samples: UsageSample[]): HTMLElement {
   const COLOR_BACKDROP = palette[4]; // --chart-5 tan (dashed W(x) backdrop)
   const sharedStyle = { background: "transparent", color: fg };
 
-  const chartWidth = CONTAINER_WIDTH - AXIS_WIDTH;
   const yDomain: [number, number] = [0, 100];
-
-  const axisSvg = renderAxisSvg({ height: CHART_HEIGHT, style: sharedStyle, yDomain, label: "%" });
-
-  const chartSvg = Plot.plot({
-    width: chartWidth,
-    height: CHART_HEIGHT,
-    marginBottom: MARGIN_BOTTOM,
-    marginLeft: 0,
-    marginRight: MARGIN_RIGHT,
-    style: sharedStyle,
-    x: { domain: [0, 1], label: null },
-    y: { domain: yDomain, label: null, axis: null, grid: true },
-    marks: [
-      // 1. Backdrop — the fixed W(x) ramp drawn once across x∈[0,1], muted.
-      Plot.lineY(backdrop, {
-        x: "x",
-        y: "w",
-        stroke: COLOR_BACKDROP,
-        strokeWidth: 1.5,
-        strokeDasharray: "3,3",
-        curve: "monotone-x",
-      }),
-      // 2. Per-week trails — one mark per segment so no line crosses a reset boundary.
-      ...segments.map((seg) =>
-        Plot.lineY(seg.points, {
-          x: "x",
-          y: "weeklyUsedPct",
-          stroke: COLOR_WEEKLY,
-          strokeWidth: seg.isCurrent ? 2 : 1.5,
-          strokeOpacity: seg.isCurrent ? 1 : 0.35,
-          curve: "monotone-x",
-        }),
-      ),
-      // 3. Now marker — the latest sample's position on the curve.
-      Plot.dot([{ x: nowX, weeklyUsedPct: latest.weeklyUsedPct }], {
-        x: "x",
-        y: "weeklyUsedPct",
-        fill: COLOR_WEEKLY,
-        r: 4,
-      }),
-    ],
-  });
-
-  chartSvg.style.width = `${chartWidth}px`;
-  chartSvg.style.minWidth = `${chartWidth}px`;
-
-  const { layout } = assembleChartLayout(axisSvg, chartSvg);
 
   const delta = aheadBehindDelta(latest);
   const n = Math.round(Math.abs(delta));
@@ -119,7 +70,64 @@ export function renderPacePositionPanel(samples: UsageSample[]): HTMLElement {
     { label: "pace W(x)", color: COLOR_BACKDROP, dashed: true },
   ]);
 
-  section.append(deltaEl, layout, legend);
+  // Block-level slot occupying the panel content-box width; the ResizeObserver
+  // reads its clientWidth. Keep it block (no inline-block/flex) so it spans the
+  // panel and the .chart-scroll-wrapper inside clips rather than widening it.
+  const slot = document.createElement("div");
+
+  mountResponsiveChart(slot, (width) => {
+    const chartWidth = width - AXIS_WIDTH;
+
+    const axisSvg = renderAxisSvg({ height: CHART_HEIGHT, style: sharedStyle, yDomain, label: "%" });
+
+    const chartSvg = Plot.plot({
+      width: chartWidth,
+      height: CHART_HEIGHT,
+      marginBottom: MARGIN_BOTTOM,
+      marginLeft: 0,
+      marginRight: MARGIN_RIGHT,
+      style: sharedStyle,
+      x: { domain: [0, 1], label: null },
+      y: { domain: yDomain, label: null, axis: null, grid: true },
+      marks: [
+        // 1. Backdrop — the fixed W(x) ramp drawn once across x∈[0,1], muted.
+        Plot.lineY(backdrop, {
+          x: "x",
+          y: "w",
+          stroke: COLOR_BACKDROP,
+          strokeWidth: 1.5,
+          strokeDasharray: "3,3",
+          curve: "monotone-x",
+        }),
+        // 2. Per-week trails — one mark per segment so no line crosses a reset boundary.
+        ...segments.map((seg) =>
+          Plot.lineY(seg.points, {
+            x: "x",
+            y: "weeklyUsedPct",
+            stroke: COLOR_WEEKLY,
+            strokeWidth: seg.isCurrent ? 2 : 1.5,
+            strokeOpacity: seg.isCurrent ? 1 : 0.35,
+            curve: "monotone-x",
+          }),
+        ),
+        // 3. Now marker — the latest sample's position on the curve.
+        Plot.dot([{ x: nowX, weeklyUsedPct: latest.weeklyUsedPct }], {
+          x: "x",
+          y: "weeklyUsedPct",
+          fill: COLOR_WEEKLY,
+          r: 4,
+        }),
+      ],
+    });
+
+    chartSvg.style.width = `${chartWidth}px`;
+    chartSvg.style.minWidth = `${chartWidth}px`;
+
+    const { layout } = assembleChartLayout(axisSvg, chartSvg);
+    return layout;
+  });
+
+  section.append(deltaEl, slot, legend);
 
   return section;
 }

--- a/office-hours/src/style/theme.css
+++ b/office-hours/src/style/theme.css
@@ -197,6 +197,7 @@ svg [aria-label="tip"] text { fill: #222; }
 .panel-grid > .capacity-history,
 .panel-grid > .capacity-pace {
   margin-top: 0;
+  min-width: 0;
 }
 .panel-grid-full {
   grid-column: 1 / -1;

--- a/office-hours/src/usage-history-chart.ts
+++ b/office-hours/src/usage-history-chart.ts
@@ -9,10 +9,10 @@ import {
   buildLegend,
   computeChartWidth,
   renderAxisSvg,
+  mountResponsiveChart,
   MARGIN_RIGHT,
   MARGIN_BOTTOM,
   POINT_WIDTH,
-  CONTAINER_WIDTH,
   CHART_HEIGHT,
 } from "./chart-util.js";
 
@@ -74,7 +74,6 @@ export function renderUsageHistoryChart(samples: UsageSample[]): HTMLElement {
   const weeklyResetTimes = distinctTimes(sorted, (s) => s.weeklyResetsAt);
   const fiveHourResetTimes = distinctTimes(sorted, (s) => s.fiveHourResetsAt);
 
-  const chartWidth = computeChartWidth(points.length, POINT_WIDTH, CONTAINER_WIDTH);
   const yDomain: [number, number] = [0, 100];
 
   const fg = getThemeFg(container);
@@ -88,70 +87,79 @@ export function renderUsageHistoryChart(samples: UsageSample[]): HTMLElement {
   const COLOR_RESET = readThemeVar(container, "--danger") || "#ff6b6b";
   const sharedStyle = { background: "transparent", color: fg };
 
-  const axisSvg = renderAxisSvg({ height: CHART_HEIGHT, style: sharedStyle, yDomain, label: "%" });
-
-  const chartSvg = Plot.plot({
-    width: chartWidth,
-    height: CHART_HEIGHT,
-    marginBottom: MARGIN_BOTTOM,
-    marginLeft: 0,
-    marginRight: MARGIN_RIGHT,
-    style: sharedStyle,
-    x: { type: "time", label: null },
-    y: { label: null, axis: null, grid: true, domain: yDomain },
-    marks: [
-      // Over-pace shading: actual weekly% above the pace curve. Clamp y2 at the
-      // pace level so each area renders only where its sign holds (mirrors the
-      // cash-flow chart's positive/negative split via min/max).
-      Plot.areaY(points, {
-        x: "x",
-        y1: "paceW",
-        y2: (d: UsagePoint) => Math.max(d.paceW, d.weeklyUsedPct),
-        fill: COLOR_RESET,
-        fillOpacity: 0.15,
-        curve: "monotone-x",
-      }),
-      // Under-pace shading: actual weekly% below the pace curve.
-      Plot.areaY(points, {
-        x: "x",
-        y1: "paceW",
-        y2: (d: UsagePoint) => Math.min(d.paceW, d.weeklyUsedPct),
-        fill: COLOR_WEEKLY,
-        fillOpacity: 0.15,
-        curve: "monotone-x",
-      }),
-      // Reset boundaries — weekly resets (the dominant sawtooth) and 5-hour
-      // resets (the finer sawtooth). Distinct dash patterns keep them legible.
-      Plot.ruleX(weeklyResetTimes, { stroke: COLOR_RESET, strokeDasharray: "4,3", strokeOpacity: 0.7 }),
-      Plot.ruleX(fiveHourResetTimes, { stroke: fg, strokeDasharray: "2,4", strokeOpacity: 0.4 }),
-      // Series lines.
-      Plot.lineY(points, { x: "x", y: "fiveHourUsedPct", stroke: COLOR_FIVE_HOUR, strokeWidth: 2, curve: "monotone-x" }),
-      Plot.lineY(points, { x: "x", y: "weeklyUsedPct", stroke: COLOR_WEEKLY, strokeWidth: 2, curve: "monotone-x" }),
-      // Pace overlay — dashed so it reads as the target.
-      Plot.lineY(points, { x: "x", y: "paceW", stroke: COLOR_PACE, strokeWidth: 2, strokeDasharray: "8,4", curve: "monotone-x" }),
-    ],
-  });
-
-  chartSvg.style.width = `${chartWidth}px`;
-  chartSvg.style.minWidth = `${chartWidth}px`;
-
-  const { layout, wrapper } = assembleChartLayout(axisSvg, chartSvg);
-
   const legend = buildLegend([
     { label: SERIES_FIVE_HOUR, color: COLOR_FIVE_HOUR },
     { label: SERIES_WEEKLY, color: COLOR_WEEKLY },
     { label: SERIES_PACE, color: COLOR_PACE, dashed: true },
   ]);
 
-  container.replaceChildren(layout, legend);
+  // Block-level slot the ResizeObserver measures; .chart-scroll-wrapper inside
+  // clips horizontally so the slot stays at the panel content-box width.
+  const slot = document.createElement("div");
 
-  // Scroll to the newest data (rightmost) on first paint. scrollWidth is 0 for a
-  // detached element, and this container is still detached here (main.ts attaches
-  // the section after this returns), so defer the assignment to the next frame —
-  // by then a layout pass has run and scrollWidth is meaningful.
-  requestAnimationFrame(() => {
-    wrapper.scrollLeft = wrapper.scrollWidth;
+  mountResponsiveChart(slot, (width) => {
+    const chartWidth = computeChartWidth(points.length, POINT_WIDTH, width);
+
+    const axisSvg = renderAxisSvg({ height: CHART_HEIGHT, style: sharedStyle, yDomain, label: "%" });
+
+    const chartSvg = Plot.plot({
+      width: chartWidth,
+      height: CHART_HEIGHT,
+      marginBottom: MARGIN_BOTTOM,
+      marginLeft: 0,
+      marginRight: MARGIN_RIGHT,
+      style: sharedStyle,
+      x: { type: "time", label: null },
+      y: { label: null, axis: null, grid: true, domain: yDomain },
+      marks: [
+        // Over-pace shading: actual weekly% above the pace curve. Clamp y2 at the
+        // pace level so each area renders only where its sign holds (mirrors the
+        // cash-flow chart's positive/negative split via min/max).
+        Plot.areaY(points, {
+          x: "x",
+          y1: "paceW",
+          y2: (d: UsagePoint) => Math.max(d.paceW, d.weeklyUsedPct),
+          fill: COLOR_RESET,
+          fillOpacity: 0.15,
+          curve: "monotone-x",
+        }),
+        // Under-pace shading: actual weekly% below the pace curve.
+        Plot.areaY(points, {
+          x: "x",
+          y1: "paceW",
+          y2: (d: UsagePoint) => Math.min(d.paceW, d.weeklyUsedPct),
+          fill: COLOR_WEEKLY,
+          fillOpacity: 0.15,
+          curve: "monotone-x",
+        }),
+        // Reset boundaries — weekly resets (the dominant sawtooth) and 5-hour
+        // resets (the finer sawtooth). Distinct dash patterns keep them legible.
+        Plot.ruleX(weeklyResetTimes, { stroke: COLOR_RESET, strokeDasharray: "4,3", strokeOpacity: 0.7 }),
+        Plot.ruleX(fiveHourResetTimes, { stroke: fg, strokeDasharray: "2,4", strokeOpacity: 0.4 }),
+        // Series lines.
+        Plot.lineY(points, { x: "x", y: "fiveHourUsedPct", stroke: COLOR_FIVE_HOUR, strokeWidth: 2, curve: "monotone-x" }),
+        Plot.lineY(points, { x: "x", y: "weeklyUsedPct", stroke: COLOR_WEEKLY, strokeWidth: 2, curve: "monotone-x" }),
+        // Pace overlay — dashed so it reads as the target.
+        Plot.lineY(points, { x: "x", y: "paceW", stroke: COLOR_PACE, strokeWidth: 2, strokeDasharray: "8,4", curve: "monotone-x" }),
+      ],
+    });
+
+    chartSvg.style.width = `${chartWidth}px`;
+    chartSvg.style.minWidth = `${chartWidth}px`;
+
+    const { layout, wrapper } = assembleChartLayout(axisSvg, chartSvg);
+
+    // Scroll to the newest data (rightmost). scrollWidth is 0 for a detached
+    // element, and the slot is detached on the first paint, so defer to the next
+    // frame — by then a layout pass has run and scrollWidth is meaningful.
+    requestAnimationFrame(() => {
+      wrapper.scrollLeft = wrapper.scrollWidth;
+    });
+
+    return layout;
   });
+
+  container.replaceChildren(slot, legend);
 
   return container;
 }

--- a/office-hours/src/worker-history-chart.ts
+++ b/office-hours/src/worker-history-chart.ts
@@ -7,10 +7,10 @@ import {
   buildLegend,
   computeChartWidth,
   renderAxisSvg,
+  mountResponsiveChart,
   MARGIN_RIGHT,
   MARGIN_BOTTOM,
   POINT_WIDTH,
-  CONTAINER_WIDTH,
   CHART_HEIGHT,
 } from "./chart-util.js";
 
@@ -56,8 +56,6 @@ export function renderWorkerHistoryChart(samples: UsageSample[]): HTMLElement {
   const yMax = Math.max(maxActive, maxTarget) + 1;
   const yDomain: [number, number] = [0, yMax];
 
-  const chartWidth = computeChartWidth(points.length, POINT_WIDTH, CONTAINER_WIDTH);
-
   const fg = getThemeFg(container);
   // DS categorical palette, read from the container at runtime.
   const palette = readChartPalette(container);
@@ -65,37 +63,53 @@ export function renderWorkerHistoryChart(samples: UsageSample[]): HTMLElement {
   const COLOR_TARGET = palette[4]; // --chart-5 tan (dashed target overlay)
   const sharedStyle = { background: "transparent", color: fg };
 
-  const axisSvg = renderAxisSvg({ height: CHART_HEIGHT, style: sharedStyle, yDomain, label: "workers" });
-
-  const chartSvg = Plot.plot({
-    width: chartWidth,
-    height: CHART_HEIGHT,
-    marginBottom: MARGIN_BOTTOM,
-    marginLeft: 0,
-    marginRight: MARGIN_RIGHT,
-    style: sharedStyle,
-    x: { type: "time", label: null },
-    y: { label: null, axis: null, grid: true, domain: yDomain },
-    marks: [
-      // Active workers — solid line.
-      Plot.lineY(points, { x: "x", y: "activeWorkers", stroke: COLOR_ACTIVE, strokeWidth: 2, curve: "monotone-x" }),
-      // Target workers — dashed step line.
-      Plot.lineY(points, { x: "x", y: "targetWorkers", stroke: COLOR_TARGET, strokeWidth: 2, strokeDasharray: "8,4", curve: "step-after" }),
-    ],
-  });
-
-  chartSvg.style.width = `${chartWidth}px`;
-  chartSvg.style.minWidth = `${chartWidth}px`;
-
-  const { layout, wrapper } = assembleChartLayout(axisSvg, chartSvg);
-
   const legend = buildLegend([
     { label: SERIES_ACTIVE, color: COLOR_ACTIVE },
     { label: SERIES_TARGET, color: COLOR_TARGET, dashed: true },
   ]);
 
-  container.replaceChildren(layout, legend);
-  wrapper.scrollLeft = wrapper.scrollWidth;
+  // Block-level slot the ResizeObserver measures; .chart-scroll-wrapper inside
+  // clips horizontally so the slot stays at the panel content-box width.
+  const slot = document.createElement("div");
+
+  mountResponsiveChart(slot, (width) => {
+    const chartWidth = computeChartWidth(points.length, POINT_WIDTH, width);
+
+    const axisSvg = renderAxisSvg({ height: CHART_HEIGHT, style: sharedStyle, yDomain, label: "workers" });
+
+    const chartSvg = Plot.plot({
+      width: chartWidth,
+      height: CHART_HEIGHT,
+      marginBottom: MARGIN_BOTTOM,
+      marginLeft: 0,
+      marginRight: MARGIN_RIGHT,
+      style: sharedStyle,
+      x: { type: "time", label: null },
+      y: { label: null, axis: null, grid: true, domain: yDomain },
+      marks: [
+        // Active workers — solid line.
+        Plot.lineY(points, { x: "x", y: "activeWorkers", stroke: COLOR_ACTIVE, strokeWidth: 2, curve: "monotone-x" }),
+        // Target workers — dashed step line.
+        Plot.lineY(points, { x: "x", y: "targetWorkers", stroke: COLOR_TARGET, strokeWidth: 2, strokeDasharray: "8,4", curve: "step-after" }),
+      ],
+    });
+
+    chartSvg.style.width = `${chartWidth}px`;
+    chartSvg.style.minWidth = `${chartWidth}px`;
+
+    const { layout, wrapper } = assembleChartLayout(axisSvg, chartSvg);
+
+    // Scroll to the newest data (rightmost). The slot is detached on the first
+    // paint, so a synchronous scroll there is a no-op (scrollWidth is 0); defer
+    // to the next frame, by which a layout pass has run.
+    requestAnimationFrame(() => {
+      wrapper.scrollLeft = wrapper.scrollWidth;
+    });
+
+    return layout;
+  });
+
+  container.replaceChildren(slot, legend);
 
   return container;
 }

--- a/office-hours/test/chart-util.test.ts
+++ b/office-hours/test/chart-util.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mountResponsiveChart } from "../src/chart-util.js";
+
+describe("mountResponsiveChart", () => {
+  let savedResizeObserver: typeof ResizeObserver | undefined;
+
+  afterEach(() => {
+    // Restore ResizeObserver if it was replaced by a test.
+    if (savedResizeObserver !== undefined) {
+      (global as Record<string, unknown>).ResizeObserver = savedResizeObserver;
+      savedResizeObserver = undefined;
+    } else {
+      // It was undefined before; delete so other files aren't affected.
+      delete (global as Record<string, unknown>).ResizeObserver;
+    }
+    vi.restoreAllMocks();
+    // Clean up any body children appended during tests.
+    document.body.replaceChildren();
+  });
+
+  it("(a) initial synchronous paint at fallback width", () => {
+    // Detached slot: clientWidth is 0 under happy-dom, so the fallback 640 is used.
+    const slot = document.createElement("div");
+    const widthsSeen: number[] = [];
+
+    const render = (w: number): Node => {
+      widthsSeen.push(w);
+      const marker = document.createElement("span");
+      marker.dataset.testid = "marker";
+      return marker;
+    };
+
+    mountResponsiveChart(slot, render);
+
+    expect(widthsSeen).toEqual([640]);
+    const child = slot.firstElementChild as HTMLElement | null;
+    expect(child).not.toBeNull();
+    expect(child!.dataset.testid).toBe("marker");
+  });
+
+  it("(b) ResizeObserver re-paints at a new width", () => {
+    // Capture the current value (likely undefined in happy-dom) so afterEach can restore it.
+    savedResizeObserver = (global as Record<string, unknown>).ResizeObserver as
+      | typeof ResizeObserver
+      | undefined;
+
+    let capturedCallback: ((entries: ResizeObserverEntry[]) => void) | null = null;
+    const disconnectSpy = vi.fn();
+
+    class MockResizeObserver {
+      constructor(cb: (entries: ResizeObserverEntry[]) => void) {
+        capturedCallback = cb;
+      }
+      observe() {}
+      disconnect = disconnectSpy;
+    }
+
+    (global as Record<string, unknown>).ResizeObserver = MockResizeObserver;
+
+    const slot = document.createElement("div");
+    document.body.appendChild(slot); // slot.isConnected === true
+
+    const renderSpy = vi.fn((w: number): Node => {
+      const marker = document.createElement("span");
+      marker.dataset.testid = `marker-${w}`;
+      return marker;
+    });
+
+    mountResponsiveChart(slot, renderSpy);
+    // Initial paint happened at fallback 640.
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    expect(renderSpy).toHaveBeenCalledWith(640);
+
+    // Simulate a ResizeObserver callback at width 900.
+    expect(capturedCallback).not.toBeNull();
+    capturedCallback!([{ contentRect: { width: 900 } } as ResizeObserverEntry]);
+
+    expect(renderSpy).toHaveBeenCalledTimes(2);
+    expect(renderSpy).toHaveBeenLastCalledWith(900);
+    const child = slot.firstElementChild as HTMLElement | null;
+    expect(child).not.toBeNull();
+    expect(child!.dataset.testid).toBe("marker-900");
+  });
+
+  it("(c) self-disconnects when slot is detached", () => {
+    savedResizeObserver = (global as Record<string, unknown>).ResizeObserver as
+      | typeof ResizeObserver
+      | undefined;
+
+    let capturedCallback: ((entries: ResizeObserverEntry[]) => void) | null = null;
+    const disconnectSpy = vi.fn();
+
+    class MockResizeObserver {
+      constructor(cb: (entries: ResizeObserverEntry[]) => void) {
+        capturedCallback = cb;
+      }
+      observe() {}
+      disconnect = disconnectSpy;
+    }
+
+    (global as Record<string, unknown>).ResizeObserver = MockResizeObserver;
+
+    // Slot NOT appended to document: slot.isConnected === false.
+    const slot = document.createElement("div");
+
+    const renderSpy = vi.fn((w: number): Node => {
+      const marker = document.createElement("span");
+      marker.dataset.testid = `marker-${w}`;
+      return marker;
+    });
+
+    mountResponsiveChart(slot, renderSpy);
+    expect(renderSpy).toHaveBeenCalledTimes(1); // initial paint
+
+    renderSpy.mockClear();
+
+    // Invoke the callback — slot is detached, so the observer should self-disconnect.
+    expect(capturedCallback).not.toBeNull();
+    capturedCallback!([{ contentRect: { width: 900 } } as ResizeObserverEntry]);
+
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+    expect(renderSpy).not.toHaveBeenCalled();
+  });
+});

--- a/style/layout.css
+++ b/style/layout.css
@@ -37,6 +37,7 @@
 .content-grid > main {
   max-inline-size: none;
   margin-inline: 0;
+  min-width: 0;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
Closes #2070

## What

The office-hours dashboard sized its charts from a hardcoded `CONTAINER_WIDTH = 640`
constant instead of measuring the actual panel, producing two visible defects on
https://office-hours.commons.systems/ :

1. **PACE chart** did not fill its panel and showed a horizontal scrollbar — its
   x-domain is normalized `[0, 1]` so it can fill any width, yet it rendered at a
   fixed `640 - AXIS_WIDTH = 590px`.
2. **History charts** overflowed `main` far to the right. A dense (~1370-sample)
   history chart emits an SVG of `pointCount * 60px` (~82,000px). The
   `.chart-scroll-wrapper`'s `overflow-x: auto` should clip that, but the clip
   never engaged: `main#app` is a grid item with the default `min-width: auto`, so
   its min-content (the 82k chart) floored the `1fr` track. `main` resolved to
   ~82,270px and overflowed its column rightward, decoupling from the header/nav.

Both stem from the same root cause and ship in one PR. The two fixes are
independent and complementary.

## How

- **CSS containment** (Unit 1): add `min-width: 0` to `.content-grid > main`
  (`style/layout.css`) and `.panel-grid > *` (`office-hours/src/style/theme.css`).
  This lets the `1fr` track stop being floored by `main`'s min-content, so
  `.chart-scroll-wrapper`'s existing `overflow-x: auto` clips the dense SVG and
  `main` stays inside its column. For dense history data the SVG stays ~82k px by
  design and scrolls *within* the bounded wrapper.

- **Measured width** (Units 2–3): add `mountResponsiveChart(slot, render)` in
  `chart-util.ts`. It paints synchronously at a fallback width (640) for the
  detached first build, then observes the panel slot with a `ResizeObserver` and
  re-paints at the real width once mounted, self-disconnecting when the slot
  detaches. All five chart cores (pace, issue-history, usage-history,
  worker-history, audit-aggregate) now render at the measured width: PACE fills its
  panel with no scrollbar; history charts get the correct width floor at narrow
  datasets.

The chart cores stay framework-agnostic — they still return a plain
`HTMLElement` / `DocumentFragment`, so both the React-island path and the vanilla
`history-band.ts` path are unchanged. The exported `CONTAINER_WIDTH` is now a
private `FALLBACK_CONTAINER_WIDTH`.

## Tests

`npm test --prefix office-hours` — 285 tests green, including a new
`chart-util.test.ts` covering the helper's three behaviors: the synchronous
fallback-width paint, the `ResizeObserver`-driven re-paint at a new width, and the
self-disconnect on detach. The existing chart tests run under happy-dom (no layout
engine, `clientWidth` 0) and assert DOM presence, so the fallback-640 render keeps
them green.
