### PR TITLE
qa-fix: route planned-deferral items to needs-main, not office-hours

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-qa-disposition
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-qa-disposition
@@ -26,10 +26,11 @@
 # Downgrade rule (applied in order; first matching branch wins):
 #
 #   planned_deferral == true  (issue #1891 — FIRST branch, before everything)
-#     → final_class = "needs-human", verify = "n/a"
+#     → final_class = "needs-main", verify = "n/a"
 #       (planned-deferral residue: criterion non-assertable at merge time, so it
-#       is authoritatively needs-human and never auto-fixable — regardless of
-#       the class the classify agent assigned. Must precede the
+#       is authoritatively needs-main and never auto-fixable — regardless of
+#       the class the classify agent assigned. needs-main items are filed as
+#       blocked_by follow-ups in Step 3.6. Must precede the
 #       class != "needs-human" pass-through or an opus-fixable planned-deferral
 #       item would slip through and re-enter the auto-fix loop)
 #
@@ -89,11 +90,13 @@ jq '
       if ($item.planned_deferral // false) == true then
         # Planned-deferral residue item (issue #1891): its acceptance criterion is
         # documented as non-assertable at merge time, so it is authoritatively
-        # needs-human and never auto-fixable. FIRST branch — fires regardless of
+        # needs-main and never auto-fixable. FIRST branch — fires regardless of
         # the class the classify agent assigned, symmetric with the aesthetic
         # bypass below; placing it after the `class != "needs-human"` pass-through
         # would let an opus-fixable planned-deferral item reintroduce the auto-fix loop.
-        $item + {final_class: "needs-human", verify: "n/a"}
+        # needs-main items are filed as blocked_by follow-ups in Step 3.6 — never
+        # auto-fixed, never skeptic-downgraded.
+        $item + {final_class: "needs-main", verify: "n/a"}
 
       elif $item.class == "already-satisfied" then
         # Already-satisfied: the criterion is already provably met by evidence the

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -28232,19 +28232,19 @@ assert_eq "qa-fix partition: call site present in qa-fix.js" "1" "$(grep -c '= p
 # planned-deferral branch (issue #1891) — three separate input objects to avoid
 # disturbing the f1..f7 order assertion above.
 #
-# (a) opus-fixable + planned_deferral:true → authoritatively needs-human / n/a
+# (a) opus-fixable + planned_deferral:true → authoritatively needs-main / n/a
 #     (the literal original failure mode: an opus-fixable item routed to the
 #     auto-fix loop because the planned-deferral branch was absent)
 IN_PD_A='{"items":[{"id":"pd1","class":"opus-fixable","aesthetic":false,"planned_deferral":true}],"votes":{}}'
 out_pd_a=$(printf '%s' "$IN_PD_A" | "$SCRIPT_DIR/dispatch-qa-disposition")
-assert_eq "qa-disposition: planned_deferral opus-fixable → final_class=needs-human" "needs-human" "$(printf '%s' "$out_pd_a" | jq -r '.dispositions[0].final_class')"
+assert_eq "qa-disposition: planned_deferral opus-fixable → final_class=needs-main" "needs-main" "$(printf '%s' "$out_pd_a" | jq -r '.dispositions[0].final_class')"
 assert_eq "qa-disposition: planned_deferral opus-fixable → verify=n/a" "n/a" "$(printf '%s' "$out_pd_a" | jq -r '.dispositions[0].verify')"
 
-# (b) needs-human + planned_deferral:true WITH a refuting vote → stays needs-human/n/a
+# (b) needs-human + planned_deferral:true WITH a refuting vote → stays needs-main/n/a
 #     (NOT downgraded to opus-fixable — the fan-out is bypassed by the first branch)
 IN_PD_B='{"items":[{"id":"pd2","class":"needs-human","aesthetic":false,"planned_deferral":true}],"votes":{"pd2":["refuted"]}}'
 out_pd_b=$(printf '%s' "$IN_PD_B" | "$SCRIPT_DIR/dispatch-qa-disposition")
-assert_eq "qa-disposition: planned_deferral needs-human with refuted vote → final_class=needs-human (not downgraded)" "needs-human" "$(printf '%s' "$out_pd_b" | jq -r '.dispositions[0].final_class')"
+assert_eq "qa-disposition: planned_deferral needs-human with refuted vote → final_class=needs-main (not downgraded to opus-fixable)" "needs-main" "$(printf '%s' "$out_pd_b" | jq -r '.dispositions[0].final_class')"
 assert_eq "qa-disposition: planned_deferral needs-human with refuted vote → verify=n/a (not Refuted)" "n/a" "$(printf '%s' "$out_pd_b" | jq -r '.dispositions[0].verify')"
 
 # (c) regression guard — non-flagged needs-human with refuting vote still downgrades

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -350,7 +350,8 @@ fork site below (same discipline as the `fixes_applied_count` tally in Step 3.7)
      Set to `true` when the plan item carried `Flag: planned-deferral — <reason>`.
      The flag is orthogonal to `kind` — it normally rides a `needs-human-judgment`
      item but may in principle ride any kind. When set, put the `<reason>` into the
-     item's `finding` so the office-hours human sees why it was deferred.
+     item's `finding` so the reason rides into the `needs-main` follow-up body filed
+     in Step 3.6, recording why it was deferred.
 
    The three residue kinds:
 
@@ -909,18 +910,20 @@ fork site below (same discipline as the `fixes_applied_count` tally in Step 3.7)
    - When the walkthrough lane ran: the GIF filename (`tmp/qa-fix-walkthrough-<n>.gif`).
    - **Disposition triage** — include this section only when the residue list was
      non-empty (i.e. Step 3.5 ran). For each **disposition item**, list its `class`
-     from `result.dispositions`. For `needs-human` items, choose the verify source
-     by joining the disposition back to the in-memory residue list by `id` and
-     reading `residue[item].planned_deferral`:
+     from `result.dispositions`. For `needs-human` items — plus planned-deferral
+     items, now `needs-main` — choose the verify source by joining the disposition
+     back to the in-memory residue list by `id` and reading
+     `residue[item].planned_deferral`:
      - **Aesthetic items** (`dispositions[item].aesthetic === true`): use
        `dispositions[item].verify` (which will be `n/a`) directly — no
        `verify_report` entry exists for them.
-     - **Planned-deferral items** (`residue[item].planned_deferral === true`): use
-       `dispositions[item].verify` (which will be `n/a`) directly — these items are
-       excluded from the skeptic candidate set and have no `verify_report` entry.
-       Note them in the deferred-to-office-hours list as deferred ACs (measured
-       downstream), distinct from aesthetic judgment calls, so the office-hours human
-       understands the deferral reason from `residue[item].finding`.
+     - **Planned-deferral items** (`residue[item].planned_deferral === true`): these
+       classify `needs-main` (not `needs-human`) and are filed as a `blocked_by`
+       follow-up in Step 3.6. Use `dispositions[item].verify` (which will be `n/a`)
+       directly — they are excluded from the skeptic candidate set and have no
+       `verify_report` entry. The deferral reason rides `residue[item].finding`, which
+       flows into the `needs-main` follow-up body (measured downstream), rather than
+       awaiting an office-hours walkthrough.
      - **All other non-aesthetic, non-planned-deferral `needs-human` items**: include
        the verify verdict and rationale from the matching entry in
        `result.verify_report` (matched by `id`).

--- a/.claude/workflows/qa-fix.js
+++ b/.claude/workflows/qa-fix.js
@@ -158,7 +158,7 @@ const hasRefuted = (votes) => votes.includes('refuted');
 // PLANNED-DEFERRAL BYPASS (issue #1891) — the FIRST branch, before everything:
 //   When planned_deferral is true the item's acceptance criterion is documented
 //   as non-assertable at merge time (measured downstream), so it is ALWAYS
-//   needs-human and never auto-fixable — regardless of the class the classify
+//   needs-main and never auto-fixable — regardless of the class the classify
 //   agent assigned. This branch fires FIRST, symmetric with the aesthetic
 //   bypass: it must precede the `!== 'needs-human'` pass-through, or an
 //   opus-fixable planned-deferral item (the literal original failure) would slip
@@ -345,7 +345,7 @@ const classifications = residue.map((r) => {
     throw new Error(`classify: agent returned no classification for residue id "${r.id}"`);
   }
   // planned_deferral is INPUT (sourced from residue r), not classify-agent
-  // output — it authoritatively forces needs-human in applyQaDisposition.
+  // output — it authoritatively forces needs-main in applyQaDisposition.
   return {
     id: r.id,
     class: c.class,
@@ -362,7 +362,7 @@ phase('verify');
 // Candidate set = non-aesthetic, non-planned-deferral needs-human items.
 // Aesthetic needs-human items BYPASS the fan-out and stay needs-human (enforced
 // by applyQaDisposition's aesthetic branch); planned-deferral items are
-// authoritatively needs-human (applyQaDisposition's first branch, issue #1891) —
+// authoritatively needs-main (applyQaDisposition's first branch, issue #1891) —
 // both are excluded here so no skeptic can downgrade them back to opus-fixable.
 const candidates = classifications.filter(
   (c) => c.class === 'needs-human' && c.aesthetic === false && c.planned_deferral !== true

--- a/.claude/workflows/qa-fix.js
+++ b/.claude/workflows/qa-fix.js
@@ -179,11 +179,13 @@ function applyQaDisposition(classifications, votesById) {
     if (c.planned_deferral === true) {
       // Planned-deferral residue item (issue #1891): its acceptance criterion is
       // documented as non-assertable at merge time, so it is authoritatively
-      // needs-human and never auto-fixable. FIRST branch — fires regardless of
+      // needs-main and never auto-fixable. FIRST branch — fires regardless of
       // the class the classify agent assigned, symmetric with the aesthetic
       // bypass below; placing it after the `!== 'needs-human'` pass-through would
       // let an opus-fixable planned-deferral item reintroduce the auto-fix loop.
-      return { id: c.id, final_class: 'needs-human', verify: 'n/a' };
+      // needs-main items are filed as blocked_by follow-ups in Step 3.6 — never
+      // auto-fixed, never skeptic-downgraded.
+      return { id: c.id, final_class: 'needs-main', verify: 'n/a' };
     }
     if (c.class === 'already-satisfied') {
       // No-skeptic-fan-out pass-through, symmetric with the aesthetic bypass:
@@ -298,7 +300,7 @@ const classifyPrompt = [
   'PLANNED-DEFERRAL ITEMS:',
   '- When an item\'s `planned_deferral` is true, its acceptance criterion is',
   '  documented as non-assertable at merge time (measured downstream), so classify',
-  '  it "needs-human", NOT "opus-fixable" — there is no defect Opus can fix now.',
+  '  it "needs-main", NOT "opus-fixable" — there is no defect Opus can fix now.',
   '',
   'VISUAL-EVIDENCE HANDLING:',
   '- page_text is the always-reliable text-primary baseline.',


### PR DESCRIPTION
Closes #2060

## Problem

A QA plan item flagged `planned-deferral` — an acceptance criterion the issue/PR
documents as non-assertable at merge time ("observe in production", "measured
downstream by audit tooling") — currently **parks the PR in office-hours**. A
human who picks up that parked PR can do nothing: there is no walkthrough to
perform now; the criterion is a future post-deploy monitoring task. Parking
blocks the merge for something no human can act on — exactly the manual toil
this disposition system exists to eliminate.

Root cause: the QA disposition kernel (#1891) forces every `planned_deferral`
item to `final_class: "needs-human"` as its FIRST branch, and `needs-human`
items land in `/qa-fix` Step 6's office-hours escalation set.

Observed instance: PR #2055 / issue #2026 (AC5, "the `SKIP_MERGED_NOT_IN_SYNC`
retention class drains after deploy") parked #2026, remediated by hand via
follow-up #2059. This change fixes the systemic behavior.

## Fix

Classify a planned-deferral item `needs-main` instead of `needs-human`. The
`needs-main` route already implements the desired end-to-end behavior — Step 3.6
files a `blocked_by` `main-qa` + `dispatch:office-hours` follow-up via
`/file-issue` (removing `help wanted`), `needs-main` items are dropped from the
Step 6 escalation set, and a run whose only residue is the planned-deferral item
reaches the clean-pass branch → `dispatch:qa-done`. No new code path: the change
only retargets the planned-deferral classification into existing machinery.

Both #1891 invariants survive intact:

- **No auto-fix** — `needs-main` passes straight through Step 3.5; Step 3.7 acts
  only on `opus-fixable`.
- **No skeptic downgrade** — `qa-fix.js`'s skeptic-candidate filter already
  excludes `planned_deferral !== true` regardless of class (preserved here,
  untouched), and the planned-deferral branch fires FIRST, before the
  refuted-vote downgrade branch, so a refuted vote can never downgrade it.

## Changes

**Unit 1 — disposition kernel pair + tests (lockstep, one commit).** Flips the
`needs-human` → `needs-main` routing in both kernel implementations and their two
test assertions so the JS kernel and the jq mirror never disagree:

- `.claude/workflows/qa-fix.js` — `applyQaDisposition` planned-deferral FIRST
  branch return + the classify-prompt instruction.
- `.claude/skills/dispatch-propagate/scripts/dispatch-qa-disposition` — the jq
  mirror's FIRST branch + the header downgrade-rule spec.
- `.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` — both
  planned-deferral assertions. Case (b) keeps input `class:"needs-human"` + a
  refuted vote and now expects `needs-main`/`n/a`, proving the planned-deferral
  branch still wins over the refuted-vote downgrade (never downgraded to
  `opus-fixable`).

**Unit 2 — `qa-fix/SKILL.md` prose.** Restructures the Step 4 disposition-triage
planned-deferral sub-bullet and the Step 3 `planned_deferral` field wording to
describe planned-deferral items as `needs-main`-class items filed as `blocked_by`
follow-ups (Step 3.6), with the deferral reason riding `finding` into the
follow-up body rather than awaiting an office-hours walkthrough. Steps 2 / 3.5 / 6
are unchanged (Step 6 already excludes `needs-main`-class residue).

## Verification

- `test-dispatch-scripts.sh`: **3299/3299 passed, 0 failed** — both flipped
  planned-deferral assertions pass.
- Kernel parity spot-check: a minimal opus-fixable + `planned_deferral:true` item
  piped through `dispatch-qa-disposition` returns `final_class=needs-main`,
  `verify=n/a`.
- End-to-end behavior follows from the unchanged `needs-main` downstream path
  (Step 3.6 follow-up + clean-pass `dispatch:qa-done`).
