### PR TITLE
Test-integrity sensor: forbid deleting/skipping tests to pass CI

### DIFF
--- a/.claude/rules/test-integrity.md
+++ b/.claude/rules/test-integrity.md
@@ -1,0 +1,12 @@
+# Test Integrity
+
+## A failing test means fix the code or escalate — never weaken the test
+
+When a test fails, fix the underlying code. Removing, skipping (`.skip`, `xit`,
+`xdescribe`, `test.skip`, `it.skip`), commenting out, or otherwise disabling or
+weakening a test to make CI green is forbidden. A red test is a signal, not an
+obstacle — suppressing it destroys the signal without fixing the problem.
+
+If the underlying code genuinely cannot be fixed within the current session,
+escalate to office-hours. There is no self-serve escape hatch: the test stays
+enabled, and the work is parked until a fix is viable.

--- a/.github/scripts/check-test-integrity.sh
+++ b/.github/scripts/check-test-integrity.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Check for test-integrity violations in the current PR vs origin/main.
+#
+# Three signals — all measured as NET changes across the whole diff so a
+# test moved between files within a single PR nets to zero:
+#
+#   Signal 1 — Disabling-skip additions (net > 0 → violation)
+#     Added lines matching (it|test|describe).skip("title"…) or (xit|xdescribe)(
+#     MINUS removed such lines.
+#     Playwright runtime-conditional skips like test.skip(testInfo.project…) are
+#     NOT flagged because their first arg is an expression, not a string literal —
+#     the discriminator is a quote character immediately after the opening paren.
+#
+#   Signal 2 — Test-declaration removals (net removed > 0 → violation)
+#     Removed lines matching (it|test|describe)[.each(...)]( MINUS added such
+#     lines. A net-negative count means fewer test declarations → flag.
+#     This also catches the common skip-CONVERSION: removing `it("x", …)` while
+#     adding `it.skip("x", …)` — the removed line matches; the added line does
+#     NOT (`.skip` breaks the bare-call pattern).
+#
+#   Signal 3 — Whole test-file deletion
+#     Any test file (*.test.ts, *.test.tsx, *.spec.ts, *.spec.tsx) fully deleted
+#     in this PR.
+#
+# Exit contract: 0 = clean, 1 = violation. Silent on clean pass.
+# On violation: cat >&2 <<EOF remediation block (mirrors check-playwright-version-sync.sh).
+#
+# Requires: git, grep, bash (no node/nix/npm needed — git diff + grep only).
+set -euo pipefail
+
+# Test file globs passed as pathspecs to git diff.
+TEST_GLOBS=(
+  '*.test.ts'
+  '*.test.tsx'
+  '*.spec.ts'
+  '*.spec.tsx'
+)
+
+# ---------------------------------------------------------------------------
+# Capture diff — exit clearly on failure (never silently narrow to HEAD~1).
+# ---------------------------------------------------------------------------
+DIFF=""
+if ! DIFF=$(git diff --unified=0 origin/main...HEAD -- "${TEST_GLOBS[@]}" 2>&1); then
+  cat >&2 <<EOF
+ERROR: check-test-integrity: 'git diff origin/main...HEAD' failed.
+
+This is a required blocking gate. The diff against origin/main must be
+computable. CI checks out with fetch-depth: 0 so origin/main is always
+present. If this is a local run, fetch first:
+
+  git fetch origin main
+
+Raw error from git:
+$DIFF
+EOF
+  exit 1
+fi
+
+# Empty diff — nothing touched test files. Clean pass.
+if [ -z "$DIFF" ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Extract added/removed lines (excluding diff header lines +++ / ---).
+# The || true guards protect set -e when grep finds no matches.
+# ---------------------------------------------------------------------------
+ADDED_LINES=$(printf '%s\n' "$DIFF" | grep '^+' | grep -v '^+++' || true)
+REMOVED_LINES=$(printf '%s\n' "$DIFF" | grep '^-' | grep -v '^---' || true)
+
+# ---------------------------------------------------------------------------
+# Signal 1: Disabling-skip additions
+#   Pattern A: (it|test|describe).skip( followed by a string-literal first arg
+#              (quote char immediately after the open paren).
+#   Pattern B: (xit|xdescribe)(
+#
+# The quote-char discriminator ['"`] after the open paren excludes
+# test.skip(testInfo.project.name !== "desktop", "desktop only") — there,
+# the character after '(' is 't', not a quote.
+# ---------------------------------------------------------------------------
+SKIP_PAT_A='(it|test|describe)\.skip[[:space:]]*\([[:space:]]*["'"'"'`]'
+SKIP_PAT_B='\b(xit|xdescribe)[[:space:]]*\('
+
+SKIP_ADDED=0
+SKIP_REMOVED=0
+
+if [ -n "$ADDED_LINES" ]; then
+  SKIP_ADDED=$(printf '%s\n' "$ADDED_LINES" | grep -cE "$SKIP_PAT_A|$SKIP_PAT_B" || true)
+fi
+if [ -n "$REMOVED_LINES" ]; then
+  SKIP_REMOVED=$(printf '%s\n' "$REMOVED_LINES" | grep -cE "$SKIP_PAT_A|$SKIP_PAT_B" || true)
+fi
+
+SKIP_NET=$((SKIP_ADDED - SKIP_REMOVED))
+
+# ---------------------------------------------------------------------------
+# Signal 2: Test-declaration removals
+#   Matches: it( / test( / describe( / it.each(...)( / test.each(...)(
+#   Does NOT match: it.skip( (no '.skip' in the pattern) — so a
+#   skip-conversion (it → it.skip) is caught here as a net removal.
+# ---------------------------------------------------------------------------
+DECL_PAT='\b(it|test|describe)(\.each\([^)]*\))?[[:space:]]*\('
+
+DECL_ADDED=0
+DECL_REMOVED=0
+
+if [ -n "$ADDED_LINES" ]; then
+  DECL_ADDED=$(printf '%s\n' "$ADDED_LINES" | grep -cE "$DECL_PAT" || true)
+fi
+if [ -n "$REMOVED_LINES" ]; then
+  DECL_REMOVED=$(printf '%s\n' "$REMOVED_LINES" | grep -cE "$DECL_PAT" || true)
+fi
+
+DECL_NET=$((DECL_ADDED - DECL_REMOVED))
+
+# ---------------------------------------------------------------------------
+# Signal 3: Whole test-file deletion
+# ---------------------------------------------------------------------------
+DELETED_FILES=$(git diff --diff-filter=D --name-only origin/main...HEAD -- "${TEST_GLOBS[@]}" 2>/dev/null || true)
+
+# ---------------------------------------------------------------------------
+# Evaluate signals and report
+# ---------------------------------------------------------------------------
+VIOLATION=0
+VIOLATION_MSGS=()
+
+if [ "$SKIP_NET" -gt 0 ]; then
+  VIOLATION=1
+  VIOLATION_MSGS+=("  - Signal 1: $SKIP_NET net disabling-skip(s) added (.skip / xit / xdescribe)")
+fi
+
+if [ "$DECL_NET" -lt 0 ]; then
+  VIOLATION=1
+  NET_REMOVED=$((-DECL_NET))
+  VIOLATION_MSGS+=("  - Signal 2: $NET_REMOVED net test declaration(s) removed")
+fi
+
+if [ -n "$DELETED_FILES" ]; then
+  VIOLATION=1
+  while IFS= read -r f; do
+    VIOLATION_MSGS+=("  - Signal 3: test file deleted: $f")
+  done <<< "$DELETED_FILES"
+fi
+
+if [ "$VIOLATION" -eq 0 ]; then
+  exit 0
+fi
+
+# Build the message lines for the heredoc
+MSG_LINES=""
+for msg in "${VIOLATION_MSGS[@]}"; do
+  MSG_LINES="${MSG_LINES}${msg}
+"
+done
+
+cat >&2 <<EOF
+ERROR: Test-integrity violation
+
+This PR weakens the test suite. CI cannot auto-merge it.
+
+Violations detected:
+${MSG_LINES}
+DO NOT skip or delete tests to make CI pass. The correct responses are:
+
+  1. RESTORE the removed or disabled test, then fix the underlying code so
+     the test passes — this is the preferred path.
+
+  2. ESCALATE to office-hours if the test is genuinely obsolete or the fix
+     requires scope beyond this PR. Document why in the PR body.
+
+Re-deleting or re-disabling the test will re-trigger this check and re-block
+auto-merge. fix-checks will route you here again.
+EOF
+exit 1

--- a/.github/scripts/check-test-integrity.sh
+++ b/.github/scripts/check-test-integrity.sh
@@ -64,9 +64,18 @@ fi
 # ---------------------------------------------------------------------------
 # Extract added/removed lines (excluding diff header lines +++ / ---).
 # The || true guards protect set -e when grep finds no matches.
+#
+# Single-line comment lines (`+ // it(...)` / `- // it(...)`) are excluded so
+# that commenting-out a test is NOT scored as a live declaration. Without this,
+# replacing `it('x', fn)` with `// it('x', fn)` would net DECL_REMOVED=1 /
+# DECL_ADDED=1 → zero → a complete evasion of Signal 2. The `\b` word boundary
+# in DECL_PAT is satisfied by the space after `//`, so the comment line would
+# otherwise match. Dropping commented lines from the ADDED set means a
+# comment-out shows as a net declaration removal (Signal 2 fires); dropping them
+# from the REMOVED set means un-commenting a test is not penalized.
 # ---------------------------------------------------------------------------
-ADDED_LINES=$(printf '%s\n' "$DIFF" | grep '^+' | grep -v '^+++' || true)
-REMOVED_LINES=$(printf '%s\n' "$DIFF" | grep '^-' | grep -v '^---' || true)
+ADDED_LINES=$(printf '%s\n' "$DIFF" | grep '^+' | grep -v '^+++' | grep -vE '^\+[[:space:]]*//' || true)
+REMOVED_LINES=$(printf '%s\n' "$DIFF" | grep '^-' | grep -v '^---' | grep -vE '^-[[:space:]]*//' || true)
 
 # ---------------------------------------------------------------------------
 # Signal 1: Disabling-skip additions
@@ -78,7 +87,7 @@ REMOVED_LINES=$(printf '%s\n' "$DIFF" | grep '^-' | grep -v '^---' || true)
 # test.skip(testInfo.project.name !== "desktop", "desktop only") — there,
 # the character after '(' is 't', not a quote.
 # ---------------------------------------------------------------------------
-SKIP_PAT_A='(it|test|describe)\.skip[[:space:]]*\([[:space:]]*["'"'"'`]'
+SKIP_PAT_A='\b(it|test|describe)\.skip[[:space:]]*\([[:space:]]*["'"'"'`]'
 SKIP_PAT_B='\b(xit|xdescribe)[[:space:]]*\('
 
 SKIP_ADDED=0
@@ -95,11 +104,21 @@ SKIP_NET=$((SKIP_ADDED - SKIP_REMOVED))
 
 # ---------------------------------------------------------------------------
 # Signal 2: Test-declaration removals
-#   Matches: it( / test( / describe( / it.each(...)( / test.each(...)(
+#   Matches: it( / test( / describe( / it.each(...)( / test.each`...`( / etc.
 #   Does NOT match: it.skip( (no '.skip' in the pattern) — so a
 #   skip-conversion (it → it.skip) is caught here as a net removal.
+#
+# Two OR-ed alternatives so every declaration form is counted independently:
+#   - `\b(it|test|describe)[[:space:]]*\(` — plain calls AND the closing `(` of
+#     any `.each(...)` / `.each` ... form (the function call's own open paren).
+#   - `\b(it|test|describe)\.each\b` — `.each` declarations whose argument is a
+#     nested call (`it.each(getCases())('t', fn)`) or a template literal
+#     (`` test.each`${a}`('t', fn) ``), where the earlier alternative's `[^)]*`
+#     /paren-balancing would otherwise miss the line.
+# A single line is counted once by grep -cE regardless of how many alternatives
+# match, so plain calls are not double-counted.
 # ---------------------------------------------------------------------------
-DECL_PAT='\b(it|test|describe)(\.each\([^)]*\))?[[:space:]]*\('
+DECL_PAT='\b(it|test|describe)[[:space:]]*\(|\b(it|test|describe)\.each\b'
 
 DECL_ADDED=0
 DECL_REMOVED=0
@@ -165,8 +184,8 @@ DO NOT skip or delete tests to make CI pass. The correct responses are:
   1. RESTORE the removed or disabled test, then fix the underlying code so
      the test passes — this is the preferred path.
 
-  2. ESCALATE to office-hours if the test is genuinely obsolete or the fix
-     requires scope beyond this PR. Document why in the PR body.
+  2. ESCALATE to office-hours if the fix requires scope beyond this PR.
+     Document why in the PR body.
 
 Re-deleting or re-disabling the test will re-trigger this check and re-block
 auto-merge. fix-checks will route you here again.

--- a/.github/scripts/test-check-test-integrity.sh
+++ b/.github/scripts/test-check-test-integrity.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# Test suite for check-test-integrity.sh
+# Usage: ./test-check-test-integrity.sh
+#
+# Creates hermetic temp git repos to drive the detection script with synthetic
+# diffs. Each case asserts the expected exit code and, where relevant, that
+# stderr contains the remediation text.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-test-integrity.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# ---------------------------------------------------------------------------
+# Cleanup: remove all temp dirs on exit
+# ---------------------------------------------------------------------------
+TMPDIRS=()
+cleanup() {
+  for d in "${TMPDIRS[@]}"; do
+    rm -rf "$d"
+  done
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# make_temp_repo — initialise a hermetic git repo for one test case.
+# Sets up:
+#   - a main branch with one commit (a non-test source file)
+#   - refs/remotes/origin/main pointing at that commit
+#   - a feature branch checked out, ready for the test mutation
+# Prints the repo path.
+make_temp_repo() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  TMPDIRS+=("$tmpdir")
+
+  git -C "$tmpdir" init -q -b main
+  git -C "$tmpdir" config user.email "test@test.local"
+  git -C "$tmpdir" config user.name "Test"
+
+  # Initial commit on main with a non-test file.
+  printf 'export const x = 1;\n' > "$tmpdir/src.ts"
+  git -C "$tmpdir" add src.ts
+  git -C "$tmpdir" commit -q -m "initial"
+
+  # Set refs/remotes/origin/main so 'git diff origin/main...HEAD' resolves.
+  local main_sha
+  main_sha=$(git -C "$tmpdir" rev-parse HEAD)
+  git -C "$tmpdir" update-ref refs/remotes/origin/main "$main_sha"
+
+  # Create and check out a feature branch.
+  git -C "$tmpdir" checkout -q -b feature
+
+  printf '%s\n' "$tmpdir"
+}
+
+# run_check REPO_DIR — run check-test-integrity.sh with CWD=repo dir.
+# Sets RC and STDERR for assertion helpers.
+RC=0
+STDERR=""
+run_check() {
+  local repo="$1"
+  RC=0
+  STDERR=""
+  STDERR=$(cd "$repo" && "$CHECK_SCRIPT" 2>&1 >/dev/null) || RC=$?
+}
+
+# assert_exit EXPECTED_RC DESCRIPTION
+assert_exit() {
+  local expected="$1" desc="$2"
+  TOTAL=$((TOTAL + 1))
+  if [ "$RC" -eq "$expected" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc — expected exit $expected, got $RC"
+  fi
+}
+
+# assert_stderr_contains PATTERN DESCRIPTION
+assert_stderr_contains() {
+  local pattern="$1" desc="$2"
+  TOTAL=$((TOTAL + 1))
+  if printf '%s\n' "$STDERR" | grep -qF -- "$pattern"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc — stderr missing pattern: $pattern"
+    if [ -n "$STDERR" ]; then
+      printf '%s\n' "$STDERR" | sed 's/^/    /'
+    else
+      echo "    <empty stderr>"
+    fi
+  fi
+}
+
+# assert_stderr_empty DESCRIPTION
+assert_stderr_empty() {
+  local desc="$1"
+  TOTAL=$((TOTAL + 1))
+  if [ -z "$STDERR" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc — expected silent output, got:"
+    printf '%s\n' "$STDERR" | sed 's/^/    /'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case (a): Playwright runtime-conditional skip ADDED — must NOT flag.
+#
+# test.skip(testInfo.project.name !== "desktop", "desktop only") has an
+# expression (not a string literal) as the first arg — the char after '(' is
+# 't', not a quote. Signal 1 must NOT match it.
+# ---------------------------------------------------------------------------
+echo "--- case (a): Playwright conditional skip → no flag ---"
+REPO=$(make_temp_repo)
+
+cat > "$REPO/foo.spec.ts" <<'EOF'
+import { test } from '@playwright/test';
+test('desktop only', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop', 'desktop only');
+  await page.goto('/');
+});
+EOF
+git -C "$REPO" add foo.spec.ts
+git -C "$REPO" commit -q -m "add conditional skip"
+
+run_check "$REPO"
+assert_exit 0 "(a) Playwright conditional skip: exit 0"
+assert_stderr_empty "(a) Playwright conditional skip: no output"
+
+# ---------------------------------------------------------------------------
+# Case (b): it.skip conversion (was it("title",…)) in *.test.ts — must flag.
+#
+# The diff shows:
+#   - it("should do thing", () => { … })
+#   + it.skip("should do thing", () => { … })
+# Signal 1: net +1 disabling skip added → flag.
+# Signal 2: net -1 declaration removed → also flag (skip-conversion pattern).
+# ---------------------------------------------------------------------------
+echo "--- case (b): it.skip conversion in *.test.ts → flag ---"
+REPO=$(make_temp_repo)
+
+cat > "$REPO/widget.test.ts" <<'EOF'
+import { it } from 'vitest';
+it('should do thing', () => {
+  expect(1).toBe(1);
+});
+EOF
+git -C "$REPO" add widget.test.ts
+git -C "$REPO" commit -q -m "add test"
+git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+git -C "$REPO" checkout -q -b feature2
+
+cat > "$REPO/widget.test.ts" <<'EOF'
+import { it } from 'vitest';
+it.skip('should do thing', () => {
+  expect(1).toBe(1);
+});
+EOF
+git -C "$REPO" add widget.test.ts
+git -C "$REPO" commit -q -m "disable test"
+
+run_check "$REPO"
+assert_exit 1 "(b) it.skip conversion: exit 1"
+assert_stderr_contains "Test-integrity violation" "(b) it.skip conversion: remediation text present"
+assert_stderr_contains "RESTORE" "(b) it.skip conversion: steers toward restore"
+
+# ---------------------------------------------------------------------------
+# Case (c): Removed it(/test( declaration (test deleted from a file) → flag.
+# ---------------------------------------------------------------------------
+echo "--- case (c): removed test declaration → flag ---"
+REPO=$(make_temp_repo)
+
+cat > "$REPO/math.test.ts" <<'EOF'
+import { it, expect } from 'vitest';
+it('adds numbers', () => {
+  expect(1 + 1).toBe(2);
+});
+it('subtracts numbers', () => {
+  expect(3 - 1).toBe(2);
+});
+EOF
+git -C "$REPO" add math.test.ts
+git -C "$REPO" commit -q -m "add tests"
+git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+git -C "$REPO" checkout -q -b feature2
+
+cat > "$REPO/math.test.ts" <<'EOF'
+import { it, expect } from 'vitest';
+it('adds numbers', () => {
+  expect(1 + 1).toBe(2);
+});
+EOF
+git -C "$REPO" add math.test.ts
+git -C "$REPO" commit -q -m "remove test"
+
+run_check "$REPO"
+assert_exit 1 "(c) removed declaration: exit 1"
+assert_stderr_contains "Test-integrity violation" "(c) removed declaration: remediation text present"
+assert_stderr_contains "Signal 2" "(c) removed declaration: Signal 2 fires"
+
+# ---------------------------------------------------------------------------
+# Case (d): Whole test-file deletion (git rm a *.test.ts) → flag.
+# ---------------------------------------------------------------------------
+echo "--- case (d): whole test-file deleted → flag ---"
+REPO=$(make_temp_repo)
+
+cat > "$REPO/old.test.ts" <<'EOF'
+import { it, expect } from 'vitest';
+it('old test', () => {
+  expect(true).toBe(true);
+});
+EOF
+git -C "$REPO" add old.test.ts
+git -C "$REPO" commit -q -m "add old test"
+git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+git -C "$REPO" checkout -q -b feature2
+
+git -C "$REPO" rm -q old.test.ts
+git -C "$REPO" commit -q -m "delete test file"
+
+run_check "$REPO"
+assert_exit 1 "(d) file deleted: exit 1"
+assert_stderr_contains "Test-integrity violation" "(d) file deleted: remediation text present"
+assert_stderr_contains "Signal 3" "(d) file deleted: Signal 3 fires"
+assert_stderr_contains "old.test.ts" "(d) file deleted: filename mentioned in output"
+
+# ---------------------------------------------------------------------------
+# Case (e): Test moved between two files (net zero) → NO flag.
+#
+# Removes `it('moved', …)` from file A, adds the identical line to file B.
+# Signal 2 net = 0 → clean.
+# ---------------------------------------------------------------------------
+echo "--- case (e): test moved between files → no flag ---"
+REPO=$(make_temp_repo)
+
+cat > "$REPO/a.test.ts" <<'EOF'
+import { it, expect } from 'vitest';
+it('moved', () => { expect(1).toBe(1); });
+it('stays in a', () => { expect(2).toBe(2); });
+EOF
+git -C "$REPO" add a.test.ts
+git -C "$REPO" commit -q -m "initial tests"
+git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+git -C "$REPO" checkout -q -b feature2
+
+cat > "$REPO/a.test.ts" <<'EOF'
+import { it, expect } from 'vitest';
+it('stays in a', () => { expect(2).toBe(2); });
+EOF
+cat > "$REPO/b.test.ts" <<'EOF'
+import { it, expect } from 'vitest';
+it('moved', () => { expect(1).toBe(1); });
+EOF
+git -C "$REPO" add a.test.ts b.test.ts
+git -C "$REPO" commit -q -m "move test to b"
+
+run_check "$REPO"
+assert_exit 0 "(e) test moved between files: exit 0"
+assert_stderr_empty "(e) test moved between files: no output"
+
+# ---------------------------------------------------------------------------
+# Case (f): PR touches only a non-test file → clean exit 0, no output.
+#
+# This is the MOST IMPORTANT case: exercises the set -e / grep-zero-match
+# guards. Every non-test PR hits this path.
+# ---------------------------------------------------------------------------
+echo "--- case (f): non-test file change only → clean exit 0 ---"
+REPO=$(make_temp_repo)
+
+# Add an existing test file on main so the glob can match something if it fails.
+cat > "$REPO/existing.test.ts" <<'EOF'
+import { it, expect } from 'vitest';
+it('existing', () => { expect(true).toBe(true); });
+EOF
+git -C "$REPO" add existing.test.ts
+git -C "$REPO" commit -q -m "add test on main"
+git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+git -C "$REPO" checkout -q -b feature2
+
+# Change only a non-test file.
+printf 'export const y = 2;\n' > "$REPO/util.ts"
+git -C "$REPO" add util.ts
+git -C "$REPO" commit -q -m "add util (no test change)"
+
+run_check "$REPO"
+assert_exit 0 "(f) non-test change: exit 0"
+assert_stderr_empty "(f) non-test change: no output"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $TOTAL total"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+echo "All tests passed."

--- a/.github/scripts/test-check-test-integrity.sh
+++ b/.github/scripts/test-check-test-integrity.sh
@@ -176,6 +176,150 @@ assert_stderr_contains "Test-integrity violation" "(b) it.skip conversion: remed
 assert_stderr_contains "RESTORE" "(b) it.skip conversion: steers toward restore"
 
 # ---------------------------------------------------------------------------
+# Case (b2): describe.skip( ADDED (Signal 1, Pattern A) → flag.
+#
+# A brand-new disabling skip line is added on the feature branch. SKIP_NET = +1
+# (Pattern A: describe.skip( with a string-literal first arg) → Signal 1 fires.
+# The added line is also a fresh DECL add, so Signal 2 stays clean — this case
+# isolates the Pattern A `describe.skip` variant.
+# ---------------------------------------------------------------------------
+echo "--- case (b2): describe.skip( added → flag (Signal 1) ---"
+REPO=$(make_temp_repo)
+
+cat > "$REPO/group.test.ts" <<'EOF'
+import { describe, it, expect } from 'vitest';
+describe('group', () => {
+  it('works', () => { expect(1).toBe(1); });
+});
+EOF
+git -C "$REPO" add group.test.ts
+git -C "$REPO" commit -q -m "add test"
+git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+git -C "$REPO" checkout -q -b feature2
+
+cat > "$REPO/group.test.ts" <<'EOF'
+import { describe, it, expect } from 'vitest';
+describe('group', () => {
+  it('works', () => { expect(1).toBe(1); });
+});
+describe.skip('disabled group', () => {
+  it('does nothing', () => { expect(1).toBe(1); });
+});
+EOF
+git -C "$REPO" add group.test.ts
+git -C "$REPO" commit -q -m "add describe.skip"
+
+run_check "$REPO"
+assert_exit 1 "(b2) describe.skip added: exit 1"
+assert_stderr_contains "Test-integrity violation" "(b2) describe.skip added: remediation text present"
+assert_stderr_contains "Signal 1" "(b2) describe.skip added: Signal 1 fires"
+
+# ---------------------------------------------------------------------------
+# Case (b3): test.skip( with a string literal ADDED (Signal 1, Pattern A) → flag.
+#
+# A brand-new test.skip("title", …) line is added. The char after '(' is a
+# quote, so Pattern A matches (distinct from the Playwright conditional skip in
+# case (a)). SKIP_NET = +1 → Signal 1 fires.
+# ---------------------------------------------------------------------------
+echo "--- case (b3): test.skip( string-literal added → flag (Signal 1) ---"
+REPO=$(make_temp_repo)
+
+cat > "$REPO/feature.spec.ts" <<'EOF'
+import { test, expect } from '@playwright/test';
+test('works', async ({ page }) => { await page.goto('/'); });
+EOF
+git -C "$REPO" add feature.spec.ts
+git -C "$REPO" commit -q -m "add test"
+git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+git -C "$REPO" checkout -q -b feature2
+
+cat > "$REPO/feature.spec.ts" <<'EOF'
+import { test, expect } from '@playwright/test';
+test('works', async ({ page }) => { await page.goto('/'); });
+test.skip('disabled case', async ({ page }) => { await page.goto('/x'); });
+EOF
+git -C "$REPO" add feature.spec.ts
+git -C "$REPO" commit -q -m "add test.skip"
+
+run_check "$REPO"
+assert_exit 1 "(b3) test.skip added: exit 1"
+assert_stderr_contains "Test-integrity violation" "(b3) test.skip added: remediation text present"
+assert_stderr_contains "Signal 1" "(b3) test.skip added: Signal 1 fires"
+
+# ---------------------------------------------------------------------------
+# Case (b4): xit( ADDED (Signal 1, Pattern B) → flag.
+#
+# A brand-new xit(…) line is added. Pattern B matches (xit|xdescribe)( without
+# needing a quote. xit( is NOT matched by the Signal 2 DECL pattern (the word
+# boundary precedes the leading 'x'), so only Signal 1 fires.
+# ---------------------------------------------------------------------------
+echo "--- case (b4): xit( added → flag (Signal 1) ---"
+REPO=$(make_temp_repo)
+
+cat > "$REPO/alpha.test.ts" <<'EOF'
+import { it, expect } from 'vitest';
+it('works', () => { expect(1).toBe(1); });
+EOF
+git -C "$REPO" add alpha.test.ts
+git -C "$REPO" commit -q -m "add test"
+git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+git -C "$REPO" checkout -q -b feature2
+
+cat > "$REPO/alpha.test.ts" <<'EOF'
+import { it, expect } from 'vitest';
+it('works', () => { expect(1).toBe(1); });
+xit('disabled', () => { expect(1).toBe(1); });
+EOF
+git -C "$REPO" add alpha.test.ts
+git -C "$REPO" commit -q -m "add xit"
+
+run_check "$REPO"
+assert_exit 1 "(b4) xit added: exit 1"
+assert_stderr_contains "Test-integrity violation" "(b4) xit added: remediation text present"
+assert_stderr_contains "Signal 1" "(b4) xit added: Signal 1 fires"
+
+# ---------------------------------------------------------------------------
+# Case (b5): xdescribe( ADDED (Signal 1, Pattern B) → flag.
+#
+# A brand-new xdescribe(…) block is added. Pattern B matches without a quote.
+# xdescribe( is NOT matched by the Signal 2 DECL pattern, so only Signal 1 fires.
+# ---------------------------------------------------------------------------
+echo "--- case (b5): xdescribe( added → flag (Signal 1) ---"
+REPO=$(make_temp_repo)
+
+cat > "$REPO/beta.test.ts" <<'EOF'
+import { describe, it, expect } from 'vitest';
+describe('beta', () => {
+  it('works', () => { expect(1).toBe(1); });
+});
+EOF
+git -C "$REPO" add beta.test.ts
+git -C "$REPO" commit -q -m "add test"
+git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+git -C "$REPO" checkout -q -b feature2
+
+cat > "$REPO/beta.test.ts" <<'EOF'
+import { describe, it, expect } from 'vitest';
+describe('beta', () => {
+  it('works', () => { expect(1).toBe(1); });
+});
+xdescribe('disabled beta', () => {
+  it('does nothing', () => { expect(1).toBe(1); });
+});
+EOF
+git -C "$REPO" add beta.test.ts
+git -C "$REPO" commit -q -m "add xdescribe"
+
+run_check "$REPO"
+assert_exit 1 "(b5) xdescribe added: exit 1"
+assert_stderr_contains "Test-integrity violation" "(b5) xdescribe added: remediation text present"
+assert_stderr_contains "Signal 1" "(b5) xdescribe added: Signal 1 fires"
+
+# ---------------------------------------------------------------------------
 # Case (c): Removed it(/test( declaration (test deleted from a file) → flag.
 # ---------------------------------------------------------------------------
 echo "--- case (c): removed test declaration → flag ---"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -134,6 +134,17 @@ jobs:
         run: .claude/hooks/test-worktree-remove.sh
       - name: Run statusline hook tests
         run: .claude/hooks/test-statusline.sh
+      - name: Run test-integrity script tests
+        run: .github/scripts/test-check-test-integrity.sh
+
+  test-integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+      - name: Check for test deletions / disabling skips
+        run: .github/scripts/check-test-integrity.sh
 
   playwright-version-sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #2062

## What

Adds a test-integrity sensor that makes weakening tests to pass CI mechanically
detectable and blocking — part of epic #2061 (code-quality decay sensors). Two
complementary backstops:

1. **Prose prohibition** — `.claude/rules/test-integrity.md`. A concise rule that
   auto-loads as a project instruction into every Claude Code session, including
   the autonomous `qa-fix`/`fix-checks` orchestrator sessions most tempted to
   delete or skip a failing test. It frames a red test as a signal: fix the
   underlying code or escalate to office-hours — never disable the test.

2. **Blocking CI guard** — `.github/scripts/check-test-integrity.sh`, run by a new
   always-on `test-integrity` job in `unit-tests.yml`. It diffs `origin/main...HEAD`
   restricted to TS/JS test globs and flags three signals, each measured **net**
   across the whole diff (a test moved between files nets to zero):

   - new disabling-skips (`it.skip("title")` / `xit` / `xdescribe`),
   - net test-declaration removals (also catches the `it(` → `it.skip(`
     conversion case),
   - whole test-file deletions.

   On a violation the script exits 1 with a loud stderr remediation block steering
   toward *restore-or-escalate*. Because dispatch's auto-merge readiness classifies
   the full status-check rollup, a `FAILURE` here blocks promotion-to-ready /
   auto-merge with no branch-protection change, and routes the PR back through
   `fix-checks` — which reads that remediation text.

## Why prose alone is not enough

The `/implement-unit` fixer subagent does not inherit project instructions, so the
prose rule cannot reach it. The mechanical guard is the enforcement; the prose
steers the orchestrator that *does* inherit it.

## Correctness notes

- The Signal 1 discriminator requires a string-literal first argument (a quote
  char right after `.skip(`), so Playwright runtime-conditional skips like
  `test.skip(testInfo.project.name !== "desktop", "x")` are **not** false-flagged.
- All `grep -c` counts are guarded against `set -e` (zero matches is the common
  case for a non-test PR and would otherwise abort the script and redden every PR).
- The base diff errors clearly rather than silently narrowing to `HEAD~1`
  (per `.claude/rules/code-style.md`); CI checks out with `fetch-depth: 0`.

## Tests

`.github/scripts/test-check-test-integrity.sh` (wired into the `hook-tests` job)
runs 16 hermetic assertions over synthetic git repos covering all six cases: a
Playwright conditional skip (no flag), an `it.skip` conversion (flag), a removed
declaration (flag), a whole-file deletion (flag), a cross-file move (no flag), and
a non-test-touching PR (clean exit 0 — exercises the `set -e`/grep-zero-match
guards). All pass; the guard also exits 0 silently on this branch.

## Out of scope (follow-up notes)

`.only(` focus detection and Go `*_test.go` skip semantics are deliberately out of
AC scope. A legitimate test consolidation that nets to fewer declarations will
false-positive and route to the rule's fix-or-escalate path — intentional; there
is no self-serve escape hatch.
