### PR TITLE
Type-safety escape-hatch CI sensor: flag net-new any/ts-ignore/eslint-disable/as/!

### DIFF
--- a/.github/scripts/check-type-safety-escapes.sh
+++ b/.github/scripts/check-type-safety-escapes.sh
@@ -54,15 +54,22 @@ scan_diff() {
   awk '
     BEGIN { violations = 0 }
 
-    # File header for the new side: "+++ b/<path>" (note the trailing space,
-    # which distinguishes it from an added source line beginning "+++").
-    /^\+\+\+ / {
+    # Old-side header "--- a/<path>" arms the new-side header rule. A line
+    # beginning "+++ " is only a file header when it immediately follows a
+    # "--- " line; otherwise it is an added source line (e.g. "++ x; const y =
+    # z as any;") that must be scanned, not consumed as a header.
+    /^--- / { in_diff_header = 1; next }
+
+    # File header for the new side: "+++ b/<path>", only when armed by a
+    # preceding "--- " line.
+    in_diff_header && /^\+\+\+ / {
       path = substr($0, 5)            # strip "+++ "
       sub(/^b\//, "", path)           # strip the "b/" prefix
       if (path == "/dev/null") path = ""
+      in_diff_header = 0
       next
     }
-    /^--- / { next }                  # old-side header; ignore
+    { in_diff_header = 0 }            # any other line disarms the header rule
 
     # Hunk header: "@@ -a,b +c,d @@" or "@@ -a +c @@". The new-file start line
     # is the number after the "+".
@@ -84,8 +91,12 @@ scan_diff() {
     # Removed line: does NOT advance the new-file counter.
     /^-/ { next }
 
-    # Anything else (context line " ", "\ No newline...", etc.) advances the
-    # counter. With -U0 there are no context lines, but handle them anyway.
+    # "\ No newline at end of file" marker: not a real source line, so it must
+    # NOT advance the new-file counter.
+    /^\\/  { next }
+
+    # Anything else (context line " ", etc.) advances the counter. With -U0
+    # there are no context lines, but handle them anyway.
     { line++ }
 
     END { if (violations > 0) exit 1 }
@@ -95,12 +106,12 @@ scan_diff() {
       violations++
     }
 
-    function process(content, path, line,    s, code) {
+    function process(content, path, line,    rest, code) {
       # 1. SUPPRESSION (first). A non-empty reason after the marker suppresses
       #    the whole line. An empty reason does not.
       if (match(content, /\/\/[ \t]*type-safety-ok:/)) {
         rest = substr(content, RSTART + RLENGTH)
-        if (rest ~ /[^ \t]/) return    # non-empty reason -> suppressed
+        if (rest ~ /[^ \t\r\n]/) return    # non-empty reason -> suppressed
         # empty reason -> fall through and keep checking
       }
 
@@ -125,10 +136,9 @@ scan_diff() {
       # `as <Type>` cast. Excludes import/export alias lines and `as const`.
       # `as any` is owned by the any rule above, so exclude lowercase `any`
       # from this alternation.
-      if (!(code ~ /^[ \t]*(import|export)([^A-Za-z0-9_$]|$)/) &&
-          !(code ~ /[ \t]from[ \t]*['"'"'"]/) &&
-          !(code ~ /^[ \t]*[A-Za-z0-9_$]+[ \t]+as[ \t]+[A-Za-z0-9_$]+,?[ \t]*$/)) {
-        if (code ~ /(^|[^A-Za-z0-9_$])as[ \t]+(unknown|string|number|boolean|object|symbol|bigint|[A-Z_$])/) {
+      if (!(code ~ /^[ \t]*(import|export)[^{]*\{/) &&
+          !(code ~ /[ \t]from[ \t]*['"'"'"]/)) {
+        if (code ~ /(^|[^A-Za-z0-9_$])as[ \t]+(unknown|string|number|boolean|object|symbol|bigint|never|null|undefined|void|[A-Z_$])/) {
           emit(path, line, "as <Type> cast")
         }
       }
@@ -147,6 +157,11 @@ scan_diff() {
 if [ "${1:-}" = "--scan-stdin" ]; then
   scan_diff
   exit $?
+fi
+
+if [ -n "${1:-}" ]; then
+  echo "Unknown argument: $1" >&2
+  exit 1
 fi
 
 # Default path: thin git wrapper.

--- a/.github/scripts/check-type-safety-escapes.sh
+++ b/.github/scripts/check-type-safety-escapes.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Diff-scoped net-new type-safety escape-hatch sensor.
+#
+# Flags type-safety escape hatches that a PR *introduces* on added lines,
+# relative to origin/main. It does NOT flag escape hatches that already exist
+# on origin/main — only net-new ones in the branch's diff. The six hatches:
+#
+#   1. @ts-ignore                (comment directive)
+#   2. @ts-expect-error          (comment directive)
+#   3. eslint-disable[-line|-next-line]  (comment directive)
+#   4. `any` in type position    (: any | as any | <any | any[] | any>)
+#   5. `as <Type>` cast          (as unknown / as string / as Foo / ...; not `as const`)
+#   6. non-null assertion `!`    (foo!.bar, arr[0]! ; not !=, !==, !!x, leading !foo)
+#
+# Suppression: append `// type-safety-ok: <reason>` to an added line. A
+# NON-EMPTY reason suppresses the whole line (no rule runs on it). An empty
+# reason (`// type-safety-ok:` with nothing after) does NOT suppress.
+#
+# Epic convention (D3): `// type-safety-ok: <reason>` is the shared suppression
+# marker family for all six code-quality decay sensors (#2062-#2067). Sibling
+# sensors should adopt the same `// <sensor>-ok: <reason>` shape rather than
+# invent ad-hoc microsyntaxes.
+#
+# Accepted tradeoff (D1): editing a line that already carried a hatch shows in
+# the diff as an addition, so it is flagged. Acceptable — the suppression
+# marker is the escape.
+#
+# Limitation (D2): full string-literal / block-comment stripping in bash/awk is
+# out of scope. Only a trailing `//` line-comment is stripped before the code
+# rules run. Residual false positives are covered by the suppression marker.
+#
+# Invocation:
+#   check-type-safety-escapes.sh
+#       Default (CI) path. Diffs origin/main...HEAD over TS/JS files and scans
+#       the unified diff. Hard-errors if origin/main is unresolvable.
+#
+#   check-type-safety-escapes.sh --scan-stdin
+#       Core path. Reads a unified diff on STDIN and scans it; no git state is
+#       touched. This is the testable entry point — Unit 2's test pipes
+#       synthetic diffs through it.
+#
+# Exit codes (both paths): 1 if any violation was found, 0 otherwise. All
+# violations across the whole diff are collected; the scan does not stop on the
+# first match.
+#
+# NOTE: the awk core targets mawk (Ubuntu CI default), so it avoids `\s` and
+# `\b`, which mawk does not support.
+set -euo pipefail
+
+# --- CORE SCANNER -----------------------------------------------------------
+# Reads a unified diff on stdin, emits `::error file=...,line=N::...`
+# annotations for net-new escape hatches, and returns 1 if any were found.
+scan_diff() {
+  awk '
+    BEGIN { violations = 0 }
+
+    # File header for the new side: "+++ b/<path>" (note the trailing space,
+    # which distinguishes it from an added source line beginning "+++").
+    /^\+\+\+ / {
+      path = substr($0, 5)            # strip "+++ "
+      sub(/^b\//, "", path)           # strip the "b/" prefix
+      if (path == "/dev/null") path = ""
+      next
+    }
+    /^--- / { next }                  # old-side header; ignore
+
+    # Hunk header: "@@ -a,b +c,d @@" or "@@ -a +c @@". The new-file start line
+    # is the number after the "+".
+    /^@@ / {
+      line = 0
+      if (match($0, /\+[0-9]+/)) {
+        line = substr($0, RSTART + 1, RLENGTH - 1) + 0
+      }
+      next
+    }
+
+    # Added line: starts with "+" but is not a "+++ " header.
+    /^\+/ {
+      process(substr($0, 2), path, line)
+      line++
+      next
+    }
+
+    # Removed line: does NOT advance the new-file counter.
+    /^-/ { next }
+
+    # Anything else (context line " ", "\ No newline...", etc.) advances the
+    # counter. With -U0 there are no context lines, but handle them anyway.
+    { line++ }
+
+    END { if (violations > 0) exit 1 }
+
+    function emit(path, line, hatch) {
+      printf "::error file=%s,line=%d::Net-new type-safety escape hatch (%s). Suppress with `// type-safety-ok: <reason>` if intentional.\n", path, line, hatch
+      violations++
+    }
+
+    function process(content, path, line,    s, code) {
+      # 1. SUPPRESSION (first). A non-empty reason after the marker suppresses
+      #    the whole line. An empty reason does not.
+      if (match(content, /\/\/[ \t]*type-safety-ok:/)) {
+        rest = substr(content, RSTART + RLENGTH)
+        if (rest ~ /[^ \t]/) return    # non-empty reason -> suppressed
+        # empty reason -> fall through and keep checking
+      }
+
+      # 2. COMMENT-BASED rules: match against the FULL line.
+      if (content ~ /@ts-ignore/)        emit(path, line, "@ts-ignore")
+      if (content ~ /@ts-expect-error/)  emit(path, line, "@ts-expect-error")
+      if (content ~ /eslint-disable/)    emit(path, line, "eslint-disable")
+
+      # 3. CODE rules: strip a trailing // line-comment first.
+      code = content
+      if (match(code, /\/\//)) code = substr(code, 1, RSTART - 1)
+
+      # `any` in type position. Anchored so anything/many/Company do not match.
+      if (code ~ /:[ \t]*any([^A-Za-z0-9_$]|$)/ ||
+          code ~ /(^|[^A-Za-z0-9_$])as[ \t]+any([^A-Za-z0-9_$]|$)/ ||
+          code ~ /<any([^A-Za-z0-9_$]|$)/ ||
+          code ~ /any\[\]/ ||
+          code ~ /any>/) {
+        emit(path, line, "any in type position")
+      }
+
+      # `as <Type>` cast. Excludes import/export alias lines and `as const`.
+      # `as any` is owned by the any rule above, so exclude lowercase `any`
+      # from this alternation.
+      if (!(code ~ /^[ \t]*(import|export)([^A-Za-z0-9_$]|$)/) &&
+          !(code ~ /[ \t]from[ \t]*['"'"'"]/) &&
+          !(code ~ /^[ \t]*[A-Za-z0-9_$]+[ \t]+as[ \t]+[A-Za-z0-9_$]+,?[ \t]*$/)) {
+        if (code ~ /(^|[^A-Za-z0-9_$])as[ \t]+(unknown|string|number|boolean|object|symbol|bigint|[A-Z_$])/) {
+          emit(path, line, "as <Type> cast")
+        }
+      }
+
+      # non-null assertion `!`: a word/closing char, then `!`, not followed by `=`.
+      if (code ~ /[]A-Za-z0-9_)]![^=]/ || code ~ /[]A-Za-z0-9_)]!$/) {
+        emit(path, line, "non-null assertion !")
+      }
+    }
+  '
+}
+
+# --- ENTRY POINTS -----------------------------------------------------------
+
+# Core path: scan a diff piped on stdin, no git state.
+if [ "${1:-}" = "--scan-stdin" ]; then
+  scan_diff
+  exit $?
+fi
+
+# Default path: thin git wrapper.
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# origin/main must be resolvable. No HEAD~1 fallback — CI uses fetch-depth: 0,
+# and an unresolvable baseline is a misconfigured environment, not a no-op.
+if ! git rev-parse --verify origin/main >/dev/null 2>&1; then
+  echo "::error::check-type-safety-escapes: origin/main is not resolvable; cannot compute the net-new diff. Ensure the workflow checks out with fetch-depth: 0 and that origin/main is fetched." >&2
+  cat >&2 <<'EOF'
+ERROR: cannot resolve origin/main
+
+This sensor diffs the branch against origin/main to find net-new type-safety
+escape hatches. `git rev-parse --verify origin/main` failed, so there is no
+baseline to diff against.
+
+In CI this usually means the checkout was shallow. Use `fetch-depth: 0` (or
+explicitly fetch origin/main) before running this script.
+EOF
+  exit 1
+fi
+
+# Diff the new side of TS/JS changes only. --diff-filter=d drops deletions so
+# we never scan removed files. -U0 keeps the diff to added/removed lines.
+diff_output="$(git diff --no-color -U0 --diff-filter=d origin/main...HEAD \
+  -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs')"
+
+# Self-noop: nothing in scope changed.
+if [ -z "$diff_output" ]; then
+  exit 0
+fi
+
+printf '%s\n' "$diff_output" | scan_diff
+exit $?

--- a/.github/scripts/test-check-type-safety-escapes.sh
+++ b/.github/scripts/test-check-type-safety-escapes.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fixture-based unit tests for check-type-safety-escapes.sh.
+#
+# Each case feeds a synthetic unified diff into the scanner's core entry point
+# (`check-type-safety-escapes.sh --scan-stdin`) and asserts on the emitted
+# `::error file=<path>,line=<N>::...` annotations and the scanner's exit code.
+#
+# The diffs are written as heredocs INSIDE this bash script on purpose. A literal
+# `!` (needed for the non-null-assertion fixtures) is unreliable when typed into
+# an interactive zsh shell — it can pick up a stray backslash even inside
+# single-quoted heredocs. When *bash* executes these heredocs at test runtime,
+# history expansion is off and `!` is literal, so the non-null fixtures match as
+# intended. Run this file with: bash test-check-type-safety-escapes.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCANNER="$SCRIPT_DIR/check-type-safety-escapes.sh"
+
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+# File-based counters because each case runs in a subshell (variable changes
+# inside a subshell would be lost to the parent).
+PASS_FILE="${TEST_TMPDIR}/.pass_count"
+FAIL_FILE="${TEST_TMPDIR}/.fail_count"
+echo 0 > "$PASS_FILE"
+echo 0 > "$FAIL_FILE"
+
+pass() {
+  echo "  PASS: $1"
+  echo $(( $(cat "$PASS_FILE") + 1 )) > "$PASS_FILE"
+}
+fail() {
+  echo "  FAIL: $1"
+  echo $(( $(cat "$FAIL_FILE") + 1 )) > "$FAIL_FILE"
+}
+
+# run_scan <fixture-file> -> writes scanner stdout to $OUT_FILE, sets $RC.
+# Uses a global OUT_FILE/RC pair so subshell cases can inspect both. `set -e`
+# would abort on the scanner's exit 1, so the call is guarded.
+scan_fixture() {
+  local fixture="$1"
+  OUT_FILE="${TEST_TMPDIR}/.out"
+  set +e
+  "$SCANNER" --scan-stdin < "$fixture" > "$OUT_FILE"
+  RC=$?
+  set -e
+}
+
+# Count `::error` annotation lines in the captured output.
+err_count() {
+  grep -c '^::error ' "$OUT_FILE" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# POSITIVE CASES: each pattern must produce a finding.
+# ---------------------------------------------------------------------------
+
+echo "=== Positive: @ts-ignore is flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,1 @@
++// @ts-ignore
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && grep -q 'hatch (@ts-ignore)' "$OUT_FILE"; then
+    pass "@ts-ignore -> 1 finding, exit 1"
+  else
+    fail "@ts-ignore (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+echo ""
+echo "=== Positive: eslint-disable-next-line is flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,1 @@
++// eslint-disable-next-line no-explicit
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && grep -q 'hatch (eslint-disable)' "$OUT_FILE"; then
+    pass "eslint-disable-next-line -> 1 finding (eslint-disable)"
+  else
+    fail "eslint-disable (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+echo ""
+echo "=== Positive: @ts-expect-error is flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,1 @@
++// @ts-expect-error
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && grep -q 'hatch (@ts-expect-error)' "$OUT_FILE"; then
+    pass "@ts-expect-error -> 1 finding, exit 1"
+  else
+    fail "@ts-expect-error (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+echo ""
+echo "=== Positive: ': any' is flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,1 @@
++function f(x: any) {}
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && grep -q 'hatch (any in type position)' "$OUT_FILE"; then
+    pass ": any -> 1 finding (any in type position)"
+  else
+    fail ": any (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+echo ""
+echo "=== Positive: 'as any' is flagged EXACTLY once (any rule owns it) ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,1 @@
++const x = y as any;
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && grep -q 'hatch (any in type position)' "$OUT_FILE"; then
+    pass "as any -> EXACTLY 1 finding (not double-counted by as <Type>)"
+  else
+    fail "as any (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+echo ""
+echo "=== Positive: 'any[]' is flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,1 @@
++const xs: any[] = [];
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -ge 1 ] && grep -q 'hatch (any in type position)' "$OUT_FILE"; then
+    pass "any[] -> flagged (any in type position)"
+  else
+    fail "any[] (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+echo ""
+echo "=== Positive: 'as Foo' cast is flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,1 @@
++const x = y as Foo;
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && grep -q 'hatch (as <Type> cast)' "$OUT_FILE"; then
+    pass "as Foo -> 1 finding (as <Type> cast)"
+  else
+    fail "as Foo (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+echo ""
+echo "=== Positive: 'foo!.bar' non-null assertion is flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,1 @@
++const v = foo!.bar;
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && grep -q 'hatch (non-null assertion' "$OUT_FILE"; then
+    pass "foo!.bar -> 1 finding (non-null assertion) [! fixture fired]"
+  else
+    fail "foo!.bar (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+echo ""
+echo "=== Positive: 'arr[0]!' non-null assertion is flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,1 @@
++const v = arr[0]!;
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && grep -q 'hatch (non-null assertion' "$OUT_FILE"; then
+    pass "arr[0]! -> 1 finding (non-null assertion) [! fixture fired]"
+  else
+    fail "arr[0]! (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# NEGATIVE / EXCLUSION CASES: each must produce NO finding.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Negative: clean exclusions produce no findings ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,13 @@
++const x = [1, 2] as const;
++import { X as Y } from './x';
++  Foo as RenamedFoo,
++export { foo as Bar } from './re-export';
++const eq = a !== b;
++const notnot = !!x;
++const ok = !foo;
++const a = many;
++const b = Company;
++const c = anything;
++const d = 1; // cast as Foo here
++const e = 2; // foo!.bar in a comment
++function g(h: number) { return h; }
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 0 ] && [ "$n" -eq 0 ]; then
+    pass "as const / import aliases / re-export / !== / !!x / leading !foo / many / Company / anything / comment-only hatches -> 0 findings"
+  else
+    fail "exclusions (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# SUPPRESSION: a non-empty reason suppresses; an empty reason does not.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Suppression: '// type-safety-ok: reason' suppresses the line ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,1 @@
++const x = y as Foo; // type-safety-ok: legacy interop, verified by hand
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 0 ] && [ "$n" -eq 0 ]; then
+    pass "as Foo + non-empty type-safety-ok reason -> suppressed (0 findings)"
+  else
+    fail "suppression non-empty (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+echo ""
+echo "=== Suppression: EMPTY reason '// type-safety-ok:' does NOT suppress ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,1 @@
++const x = y as Foo; // type-safety-ok:
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && grep -q 'hatch (as <Type> cast)' "$OUT_FILE"; then
+    pass "as Foo + EMPTY type-safety-ok reason -> still flagged (1 finding)"
+  else
+    fail "suppression empty (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# DIFF-SCOPED: only added (+) lines are scanned; unchanged context is invisible.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Diff-scoped: pre-existing hatch on an unchanged line is NOT seen ==="
+(
+  # Context lines (leading space) carry a pre-existing `as Foo`; they are not
+  # additions, so the scanner must not flag them. The single added line is clean.
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,3 +1,4 @@
+ const pre = old as Foo;
+ const mid = 1;
++const fresh = 2;
+ const post = arr[0]!;
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 0 ] && [ "$n" -eq 0 ]; then
+    pass "hatches on unchanged context lines -> 0 findings (diff-scoped)"
+  else
+    fail "diff-scoped clean-add (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+echo ""
+echo "=== Diff-scoped: a net-new hatch added in the same hunk IS flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,3 +1,4 @@
+ const pre = old as Foo;
+ const mid = 1;
++const fresh = bad as Foo;
+ const post = clean;
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && grep -q 'hatch (as <Type> cast)' "$OUT_FILE"; then
+    pass "net-new hatch on an added line -> 1 finding (diff-scoped)"
+  else
+    fail "diff-scoped net-new (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# LINE-NUMBER CORRECTNESS: hatch on the 3rd added line of a hunk starting at
+# +10 must report line=12 (10 -> first added line, 11, 12).
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Line-number: hatch on 3rd added line of '@@ +10' reports line=12 ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/src/deep/a.ts
+@@ -1,0 +10,3 @@
++const a = 1;
++const b = 2;
++const c = obj as Foo;
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && \
+     grep -q '^::error file=src/deep/a.ts,line=12::' "$OUT_FILE"; then
+    pass "line bookkeeping: file=src/deep/a.ts line=12"
+  else
+    fail "line-number (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# RESULTS + expected-total guard (catches a crashed/early-exiting subshell).
+# ---------------------------------------------------------------------------
+
+FINAL_PASS=$(cat "$PASS_FILE")
+FINAL_FAIL=$(cat "$FAIL_FILE")
+
+echo ""
+echo "========================================"
+echo "  Results: $FINAL_PASS passed, $FINAL_FAIL failed"
+echo "========================================"
+
+EXPECTED=15
+ACTUAL=$(( FINAL_PASS + FINAL_FAIL ))
+if [ "$ACTUAL" -ne "$EXPECTED" ]; then
+  echo "ERROR: expected $EXPECTED test results but got $ACTUAL (a test subshell may have crashed)" >&2
+  exit 1
+fi
+
+if [ "$FINAL_FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/.github/scripts/test-check-type-safety-escapes.sh
+++ b/.github/scripts/test-check-type-safety-escapes.sh
@@ -176,6 +176,40 @@ EOF
 )
 
 echo ""
+echo "=== Positive: 'export const x = y as Foo' cast is flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,1 @@
++export const x = y as Foo;
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && grep -q 'hatch (as <Type> cast)' "$OUT_FILE"; then
+    pass "export const x = y as Foo -> 1 finding (as <Type> cast)"
+  else
+    fail "export const as Foo (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+echo ""
+echo "=== Negative: 'export { X as Y };' rename is NOT flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
++++ b/a.ts
+@@ -1,0 +1,1 @@
++export { X as Y };
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 0 ] && [ "$n" -eq 0 ]; then
+    pass "export { X as Y } -> 0 findings (brace rename excluded)"
+  else
+    fail "export brace rename (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+echo ""
 echo "=== Positive: 'foo!.bar' non-null assertion is flagged ==="
 (
   F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
@@ -221,7 +255,7 @@ echo "=== Negative: clean exclusions produce no findings ==="
 @@ -1,0 +1,13 @@
 +const x = [1, 2] as const;
 +import { X as Y } from './x';
-+  Foo as RenamedFoo,
++  Foo as RenamedFoo, // type-safety-ok: bare re-export alias body line
 +export { foo as Bar } from './re-export';
 +const eq = a !== b;
 +const notnot = !!x;
@@ -335,6 +369,7 @@ echo ""
 echo "=== Line-number: hatch on 3rd added line of '@@ +10' reports line=12 ==="
 (
   F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
+--- a/src/deep/a.ts
 +++ b/src/deep/a.ts
 @@ -1,0 +10,3 @@
 +const a = 1;
@@ -351,6 +386,32 @@ EOF
   fi
 )
 
+echo ""
+echo "=== Line-number: '\ No newline' marker does NOT skew the counter ==="
+(
+  # The old file lacked a trailing newline, so git emits a "\ No newline at end
+  # of file" marker after the removed line. That marker is not a real source
+  # line and must not advance the new-file counter. The added hatch is the 2nd
+  # added line of a hunk starting at +1, so it must report line=2.
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
+--- a/a.ts
++++ b/a.ts
+@@ -1 +1,2 @@
+-const old = 1;
+\ No newline at end of file
++const a = 1;
++const c = obj as Foo;
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && \
+     grep -q '^::error file=a.ts,line=2::' "$OUT_FILE"; then
+    pass "no-newline marker ignored: as Foo reports line=2"
+  else
+    fail "no-newline marker (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
 # ---------------------------------------------------------------------------
 # RESULTS + expected-total guard (catches a crashed/early-exiting subshell).
 # ---------------------------------------------------------------------------
@@ -363,7 +424,7 @@ echo "========================================"
 echo "  Results: $FINAL_PASS passed, $FINAL_FAIL failed"
 echo "========================================"
 
-EXPECTED=15
+EXPECTED=18
 ACTUAL=$(( FINAL_PASS + FINAL_FAIL ))
 if [ "$ACTUAL" -ne "$EXPECTED" ]; then
   echo "ERROR: expected $EXPECTED test results but got $ACTUAL (a test subshell may have crashed)" >&2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,3 +78,12 @@ jobs:
       - name: Cleanup credentials
         if: always()
         run: .github/scripts/firebase-auth-cleanup.sh
+
+  type-safety-sensor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+      - name: Flag net-new type-safety escape hatches
+        run: .github/scripts/check-type-safety-escapes.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -134,6 +134,8 @@ jobs:
         run: .claude/hooks/test-worktree-remove.sh
       - name: Run statusline hook tests
         run: .claude/hooks/test-statusline.sh
+      - name: Run type-safety escape-hatch sensor tests
+        run: .github/scripts/test-check-type-safety-escapes.sh
 
   playwright-version-sync:
     runs-on: ubuntu-latest
@@ -158,6 +160,15 @@ jobs:
       - name: Verify nix playwright-driver chromium matches npm @playwright/test
         if: steps.changes.outputs.nix == 'true' || steps.changes.outputs.playwright == 'true'
         run: nix develop --command .github/scripts/check-playwright-version-sync.sh
+
+  type-safety-sensor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+      - name: Flag net-new type-safety escape hatches
+        run: .github/scripts/check-type-safety-escapes.sh
 
   go-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #2065

## What

Adds the first code-quality decay sensor from epic #2061: a deterministic,
diff-scoped CI check that flags **net-new** type-safety escape hatches a PR
introduces versus `origin/main`. The existing sensors verify correctness
(type/lint/test/CI); nothing measured the type-level analog of deleting a test —
an agent reaching for `any`, `@ts-ignore`, `@ts-expect-error`, an
`eslint-disable`, a broad `as <Type>` cast, or a non-null `!` to satisfy the
checker. The autonomous CI-fixing lanes (`qa-fix`, `fix-checks`) are tempted to
do exactly that.

A casual escape hatch now fails a fast, zero-token CI check, reported at
`file:line` on the PR diff. A genuinely-needed one is kept via a one-line,
diff-visible `// type-safety-ok: <reason>` suppression marker — converting a
casual choice into a deliberate, reviewed one.

## How

Three units:

1. **Core scanner + git wrapper** — `.github/scripts/check-type-safety-escapes.sh`.
   An awk core reads a unified diff on stdin (`--scan-stdin`, the testable entry
   point), walks `+++ b/<path>` and `@@ +c,d @@` headers to track the new-file
   line number, and inspects only added (`+`) lines. Per line it checks the
   suppression marker first, then comment-directive rules against the full line
   (`@ts-ignore`/`@ts-expect-error`/`eslint-disable`), then code rules against a
   `//`-stripped line (`any` in type position, `as <Type>` cast, non-null `!`).
   The default invocation is a thin git wrapper:
   `git diff --no-color -U0 --diff-filter=d origin/main...HEAD -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs'`
   piped into the core. It hard-errors if `origin/main` is unresolvable (no
   `HEAD~1` fallback — CI uses `fetch-depth: 0`) and self-noops (exit 0) when the
   scoped diff is empty. Mirrors `check-playwright-version-sync.sh` idioms.

2. **Fixture-based unit test** —
   `.github/scripts/test-check-type-safety-escapes.sh`, mirroring
   `test-firebase-auth.sh` (pass/fail counters, subshell isolation, mktemp+trap,
   expected-total guard). 15 cases pipe synthetic unified diffs into the
   `--scan-stdin` core: one positive per pattern (incl. `as any` asserted as a
   single finding, not double-counted), exclusions (`as const`, import aliases,
   `a !== b`, `!!x`, leading `!foo`, `many`/`Company`/`anything`, comment-only
   hatches), suppression (non-empty reason suppresses, empty reason still flags),
   the diff-scoped property (a pre-existing hatch on an unchanged line is not
   flagged), and awk line-number bookkeeping.

3. **CI wiring** — `.github/workflows/unit-tests.yml`: a new `type-safety-sensor`
   job (checkout with `fetch-depth: 0`, no setup-node, runs **unconditionally** so
   it can't be skipped — the script self-noops on an empty scoped diff), plus a
   `hook-tests` step running the fixture test. This is the **first**
   `.github/scripts/test-*.sh` wired into CI (the existing
   `test-cloudflare-purge.sh` / `test-firebase-auth.sh` are unwired) —
   establishing the wiring.

## Design notes

- **Diff-scoped, stateless, zero-token:** computed purely from git at HEAD — no
  persisted store — and only flags additions; pre-existing hatches on untouched
  lines never block. It's a plain CI check, never inside the headless
  dispatch-tick.
- **`--diff-filter=d`** (all changes except pure deletions), not `=AM`: covers
  renames/copies, so `git mv foo.ts bar.ts` while adding an `any` in the same
  commit can't slip through — the threat model is "agents route around the
  check."
- **False-positive control:** the `any`/`as`/`!` rules strip trailing `//`
  comments first; import/export alias lines are excluded from the `as` rule;
  `as const` and `!=`/`!==`/`!!`/leading-`!` are deliberately not matched.
  Residual FPs (string literals, block comments) are covered by the suppression
  marker.
- **Epic-wide convention:** `// type-safety-ok: <reason>` is the shared
  suppression-marker family for all six decay sensors (#2062–#2067); siblings
  should adopt the same `// <sensor>-ok: <reason>` shape. Recorded in the script
  header.

## Testing

- `.github/scripts/test-check-type-safety-escapes.sh` — 15/15 pass locally.
- Sanity-checked the core against hand-written diffs (one-of-each → one
  annotation per hatch, correct line numbers, exit 1; clean additions → exit 0;
  exclusions don't fire; suppression works) and the wrapper (empty scope → exit
  0; unresolvable origin/main → hard error).
