### PR TITLE
dispatch: execute the plan's Verification section in /implement before the PR

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-run-verification
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-run-verification
@@ -120,6 +120,14 @@ while IFS= read -r line || [[ -n "$line" ]]; do
   fi
 done <<<"$PLAN"
 
+# An unclosed verify fence (opened with ```verify but reaching EOF before its
+# closing ```) leaves capturing=1 with the partial block never appended. Surface
+# it as a malformed plan rather than silently treating it as "no verify blocks".
+if [[ "$capturing" -eq 1 ]]; then
+  echo "dispatch-run-verification: unclosed verify block at end of input" >&2
+  exit 1
+fi
+
 if [[ "${#BLOCKS[@]}" -eq 0 ]]; then
   echo "dispatch-run-verification: no auto-runnable verify blocks" >&2
   exit 3

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-run-verification
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-run-verification
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# dispatch-run-verification — run a plan's Verification section verify blocks.
+#
+# Usage: dispatch-read-plan <issue-num> | dispatch-run-verification
+#
+# Reads the FULL plan markdown on STDIN (no positional args, no gh call, no
+# network — that is what makes it unit-testable). It locates the plan's
+# Verification section, extracts every fenced block whose opening fence is
+# exactly three backticks immediately followed by the info string `verify`, and
+# runs each block body via `bash` in the CURRENT working directory (the worktree
+# root where the implement phase invokes it).
+#
+# Reading STDIN rather than calling dispatch-read-plan internally mirrors
+# dispatch-write-plan's stdin design: the caller pipes the plan in, so this
+# script needs no gh mock to test.
+#
+# Tri-state exit, so the implement phase can branch on the result:
+#   exit 3 — no Verification section, OR a Verification section with no `verify`
+#            blocks. The "proceed unchanged" signal; a one-line diagnostic goes
+#            to stderr. This is NOT a failure — there is simply nothing to run.
+#   exit 0 — every verify block exited 0.
+#   exit 1 — the first verify block to exit non-zero. The failing block index is
+#            reported and no further blocks run.
+#
+# A `## ` heading inside a fenced code block does not terminate the Verification
+# section, and fences outside the section are ignored — fence state is tracked so
+# both hold (a verify block body may itself contain a `## ` line).
+#
+# Any unexpected argument is a clear error, not a silent fallback (exit 2), per
+# .claude/rules/code-style.md.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: dispatch-read-plan <issue-num> | dispatch-run-verification
+
+Reads plan markdown on STDIN, finds the "## Verification" section, and runs each
+```verify fenced block (in order, via bash, in the current directory).
+
+Exit codes:
+  0  all verify blocks passed
+  1  a verify block failed (the failing block index is reported)
+  2  bad usage (unexpected argument)
+  3  no Verification section, or no verify blocks in it (proceed unchanged)
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  '')
+    ;;
+  *)
+    echo "dispatch-run-verification: unexpected argument: $1" >&2
+    echo "usage: dispatch-read-plan <issue-num> | dispatch-run-verification" >&2
+    exit 2
+    ;;
+esac
+
+PLAN="$(cat)"
+
+# --- Extract the verify block bodies from the Verification section ----------
+# Walk the plan line by line. `in_section` is true once we pass the first
+# "## Verification..." heading and false again at the next "## " heading at the
+# section's top level. `in_fence` tracks whether we are inside ANY fenced block,
+# so that (a) a "## " line inside a fence does not end the section, and (b) we
+# can tell a fence open from a fence close. When a `verify` fence opens inside
+# the section, `capturing` is set and subsequent lines are appended to the
+# current block until the closing fence.
+#
+# Blocks are emitted into an array; element i is the full body of block i+1.
+declare -a BLOCKS=()
+in_section=0
+in_fence=0
+capturing=0
+current=""
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  if [[ "$in_fence" -eq 0 ]]; then
+    # Outside a fence: a "## " heading drives section boundaries.
+    if [[ "$line" =~ ^##[[:space:]]+Verification ]]; then
+      in_section=1
+      continue
+    fi
+    if [[ "$in_section" -eq 1 && "$line" =~ ^##[[:space:]] ]]; then
+      # Next top-level section heading ends Verification.
+      in_section=0
+      continue
+    fi
+    # A fence opening. Match exactly three backticks plus an optional info string.
+    if [[ "$line" =~ ^'```'(.*)$ ]]; then
+      info="${BASH_REMATCH[1]}"
+      in_fence=1
+      # Capture only when inside the section and the info string is exactly
+      # `verify` (optional trailing whitespace, nothing else).
+      if [[ "$in_section" -eq 1 && "$info" =~ ^verify[[:space:]]*$ ]]; then
+        capturing=1
+        current=""
+      else
+        capturing=0
+      fi
+      continue
+    fi
+  else
+    # Inside a fence: only a closing triple-backtick fence matters.
+    if [[ "$line" =~ ^'```'[[:space:]]*$ ]]; then
+      in_fence=0
+      if [[ "$capturing" -eq 1 ]]; then
+        BLOCKS+=("$current")
+        capturing=0
+      fi
+      continue
+    fi
+    if [[ "$capturing" -eq 1 ]]; then
+      current+="$line"$'\n'
+    fi
+    continue
+  fi
+done <<<"$PLAN"
+
+if [[ "${#BLOCKS[@]}" -eq 0 ]]; then
+  echo "dispatch-run-verification: no auto-runnable verify blocks" >&2
+  exit 3
+fi
+
+# --- Run each block in order ------------------------------------------------
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+n=0
+for body in "${BLOCKS[@]}"; do
+  n=$((n + 1))
+  echo "=== verify block $n ==="
+  printf '%s' "$body" > "$tmp"
+  if ! bash "$tmp"; then
+    echo "dispatch-run-verification: verify block $n failed" >&2
+    exit 1
+  fi
+done
+
+exit 0

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -34765,6 +34765,95 @@ rm -rf "$TMPDIR_TEST"
 TMPDIR_TEST=""
 
 # ============================================================================
+# dispatch-run-verification tests (#2024)
+# ============================================================================
+# dispatch-run-verification reads the full plan markdown on STDIN, finds the
+# "## Verification" section, runs every ```verify fenced block in order via bash
+# in the current directory, and exits tri-state: 0 (all passed), 1 (a block
+# failed), or 3 (no section / no verify blocks — proceed unchanged). It calls no
+# gh and no network, so these cases pipe fabricated plans straight in and assert
+# the exit code and output — no setup/teardown or PATH shims needed.
+echo ""
+echo "=== dispatch-run-verification (#2024) ==="
+
+RUN_VERIFY="$SCRIPT_DIR/dispatch-run-verification"
+
+# Pass path: a verify block running `true` exits 0.
+echo "Test: dispatch-run-verification -- verify block passes (exit 0)"
+plan=$'## Plan\nbuild it\n\n## Verification (end-to-end)\nrun this:\n```verify\ntrue\n```\n'
+if out=$(printf '%s' "$plan" | "$RUN_VERIFY" 2>&1); then rc=0; else rc=$?; fi
+assert_eq "dispatch-run-verification: passing verify block exits 0" "0" "$rc"
+
+# Escalate path: a verify block running `false` exits 1 and names the block.
+echo "Test: dispatch-run-verification -- verify block fails (exit 1, index reported)"
+plan=$'## Verification\n```verify\nfalse\n```\n'
+if out=$(printf '%s' "$plan" | "$RUN_VERIFY" 2>&1); then rc=0; else rc=$?; fi
+assert_eq "dispatch-run-verification: failing verify block exits 1" "1" "$rc"
+case "$out" in
+  *"verify block 1 failed"*) found=yes ;;
+  *) found=no ;;
+esac
+assert_eq "dispatch-run-verification: failing block index is reported" "yes" "$found"
+
+# No-runnable path (a): a Verification section with only prose + a plain ```bash
+# block (NOT a verify block) exits 3.
+echo "Test: dispatch-run-verification -- section without verify blocks exits 3"
+plan=$'## Verification\nrun things manually\n```bash\ntrue\n```\n'
+if out=$(printf '%s' "$plan" | "$RUN_VERIFY" 2>&1); then rc=0; else rc=$?; fi
+assert_eq "dispatch-run-verification: prose/bash-only section exits 3" "3" "$rc"
+
+# No-runnable path (b): a plan with no Verification heading at all exits 3 — and
+# a ```verify block OUTSIDE the section is ignored (not run).
+echo "Test: dispatch-run-verification -- no Verification section exits 3"
+plan=$'## Plan\nno verification here\n```verify\ntrue\n```\n'
+if out=$(printf '%s' "$plan" | "$RUN_VERIFY" 2>&1); then rc=0; else rc=$?; fi
+assert_eq "dispatch-run-verification: no section exits 3" "3" "$rc"
+
+# Ordering: two verify blocks, first passes, second fails -> exit 1 with the
+# SECOND block identified as the failing one.
+echo "Test: dispatch-run-verification -- first passes, second fails (exit 1, block 2)"
+plan=$'## Verification\n```verify\ntrue\n```\n```verify\nexit 1\n```\n'
+if out=$(printf '%s' "$plan" | "$RUN_VERIFY" 2>&1); then rc=0; else rc=$?; fi
+assert_eq "dispatch-run-verification: first-pass/second-fail exits 1" "1" "$rc"
+case "$out" in
+  *"verify block 2 failed"*) found=yes ;;
+  *) found=no ;;
+esac
+assert_eq "dispatch-run-verification: second block identified as failing" "yes" "$found"
+
+# Converse ordering: first block FAILS, so the second block must NOT run. The
+# second block's only effect is creating a sentinel file; its absence after the
+# run proves the second block never executed.
+echo "Test: dispatch-run-verification -- first fails, second block not run (sentinel absent)"
+RV_TMP=$(mktemp -d)
+sentinel="$RV_TMP/second-ran"
+plan=$'## Verification\n```verify\nfalse\n```\n```verify\ntouch '"$sentinel"$'\n```\n'
+if out=$(printf '%s' "$plan" | "$RUN_VERIFY" 2>&1); then rc=0; else rc=$?; fi
+assert_eq "dispatch-run-verification: first-fail exits 1" "1" "$rc"
+if [[ -e "$sentinel" ]]; then second_ran=yes; else second_ran=no; fi
+assert_eq "dispatch-run-verification: second block did not run after first failed" "no" "$second_ran"
+case "$out" in
+  *"verify block 1 failed"*) found=yes ;;
+  *) found=no ;;
+esac
+assert_eq "dispatch-run-verification: first block identified as failing" "yes" "$found"
+rm -rf "$RV_TMP"
+
+# Boundary robustness: a "## " line INSIDE a verify block body does not end the
+# Verification section, so the block still runs and exits 0.
+echo "Test: dispatch-run-verification -- '## ' inside a verify block is not a section terminator"
+plan=$'## Verification\n```verify\necho "## not a heading"\ntrue\n```\n'
+if out=$(printf '%s' "$plan" | "$RUN_VERIFY" 2>&1); then rc=0; else rc=$?; fi
+assert_eq "dispatch-run-verification: '## ' inside fence does not terminate section" "0" "$rc"
+
+# Usage: --help exits 0; an unexpected argument is a clear error (exit 2).
+echo "Test: dispatch-run-verification -- --help exits 0, bad arg exits 2"
+if "$RUN_VERIFY" --help >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "dispatch-run-verification: --help exits 0" "0" "$rc"
+if "$RUN_VERIFY" bogus </dev/null >/dev/null 2>&1; then rc=0; else rc=$?; fi
+assert_eq "dispatch-run-verification: unexpected argument exits 2" "2" "$rc"
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -34825,7 +34825,7 @@ assert_eq "dispatch-run-verification: second block identified as failing" "yes" 
 # second block's only effect is creating a sentinel file; its absence after the
 # run proves the second block never executed.
 echo "Test: dispatch-run-verification -- first fails, second block not run (sentinel absent)"
-RV_TMP=$(mktemp -d "$TMPDIR_TEST/rv-sentinel.XXXXXX")
+RV_TMP=$(mktemp -d)
 sentinel="$RV_TMP/second-ran"
 plan=$'## Verification\n```verify\nfalse\n```\n```verify\ntouch '"$sentinel"$'\n```\n'
 if out=$(printf '%s' "$plan" | "$RUN_VERIFY" 2>&1); then rc=0; else rc=$?; fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -34825,7 +34825,7 @@ assert_eq "dispatch-run-verification: second block identified as failing" "yes" 
 # second block's only effect is creating a sentinel file; its absence after the
 # run proves the second block never executed.
 echo "Test: dispatch-run-verification -- first fails, second block not run (sentinel absent)"
-RV_TMP=$(mktemp -d)
+RV_TMP=$(mktemp -d "$TMPDIR_TEST/rv-sentinel.XXXXXX")
 sentinel="$RV_TMP/second-ran"
 plan=$'## Verification\n```verify\nfalse\n```\n```verify\ntouch '"$sentinel"$'\n```\n'
 if out=$(printf '%s' "$plan" | "$RUN_VERIFY" 2>&1); then rc=0; else rc=$?; fi

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -58,7 +58,7 @@ output contains `PR: none`, no PR exists yet — run all steps. If it contains
 `PR #<num>`, capture that number as `PR_NUM`.
 
 If a PR already exists, the build + PR already happened: capture its number as
-`PR_NUM`, **skip Steps 1–3**, and go straight to the Step 4 marker write (this
+`PR_NUM`, **skip Steps 1–4**, and go straight to the Step 5 marker write (this
 covers a same-tick crash between PR-open and marker-write). If no PR exists, run
 all steps. (`dispatch-route` normally routes a PR-bearing issue to fix-checks/qa/review,
 not implement, so this is a same-tick crash-recovery edge.)
@@ -69,8 +69,9 @@ not implement, so this is a same-tick crash-recovery edge.)
 final action is a call to `dispatch-mark-complete` (no deviation) or
 `dispatch-mark-deviation` (deviation). This is the single named exit.
 
-- Any OTHER most-recent tool call — a unit finishing in Step 2, the draft PR
-  opening in Step 3 — means the orchestrator is mid-loop, not done.
+- Any OTHER most-recent tool call — a unit finishing in Step 2, a verification
+  run in Step 3, the draft PR opening in Step 4 — means the orchestrator is
+  mid-loop, not done.
 - Mid-loop, the next message contains the next tool call, never a closing
   summary. Do not end the turn until the named exit fires.
 
@@ -97,8 +98,9 @@ Exit codes:
 Before building, create a tracked task list with the harness `TaskCreate` tool:
 
 - one task per planned unit from the Step 1 plan,
-- one task for "open the draft PR" (Step 3),
-- one task for "write the completion marker" (Step 4).
+- one task for "execute the plan's verification" (Step 3),
+- one task for "open the draft PR" (Step 4),
+- one task for "write the completion marker" (Step 5).
 
 Mark each task completed via the harness `TaskUpdate` tool as it lands. This
 keeps the remaining work durable and visible rather than held in the model's
@@ -119,7 +121,45 @@ and recovers from merge / pre-commit / push errors. This is a normal in-session 
 model-selection heuristic in `/implement-unit` — see that skill for the heuristic
 (it is the canonical home; do not restate it here).
 
-### 3. Open the draft PR
+### 3. Execute the plan's Verification section
+
+After every unit is built, run the plan's auto-runnable checks. The runner reads
+the full plan markdown on stdin and routes on a tri-state exit (use
+`dangerouslyDisableSandbox: true` — `dispatch-read-plan` calls `gh`):
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-read-plan <N> \
+  | .claude/skills/dispatch-propagate/scripts/dispatch-run-verification
+```
+
+Route on the exit code:
+
+- **exit 3** — the plan names no ```verify checks. Proceed to Step 4 and open the
+  PR unchanged. This is a clean proceed, not a swallowed error (per
+  `.claude/rules/code-style.md`): the runner reports "no checks to run" by design,
+  and acceptance criterion 4 requires no false block when the plan defines no
+  checks.
+- **exit 0** — every ```verify block passed. Proceed to Step 4 and open the PR.
+- **exit 1** — a ```verify block failed; the runner reports the failing block
+  index on its output. Enter the bounded fix lane: using the failing output, fix
+  the defect with one corrective `/implement-unit` (via the Skill tool), then
+  re-run the runner above. Cap at **2** fix attempts (mirroring `qa-fix`'s
+  `CAP=2`). If the runner still exits 1 after the cap, do **not** open the PR:
+  call `dispatch-mark-deviation` naming the failing check, then **stop** — skip
+  the Step 5 completion marker.
+
+  ```bash
+  .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+    "/implement: plan verification failed after 2 fix attempts (check <index>)"
+  ```
+
+  This `dispatch-mark-deviation` is one of the two existing single-named-exit
+  terminal actions — the only terminal actions remain `dispatch-mark-complete`
+  (no deviation) and `dispatch-mark-deviation` (deviation) — so the single-named-exit
+  invariant still holds. The Stop hook reads marker-absence as Branch A and parks
+  the issue for human review.
+
+### 4. Open the draft PR
 
 After every unit is committed and pushed, write the PR body prose to
 `tmp/pr-body.md`, then open the draft PR with `dispatch-open-pr` (use
@@ -149,7 +189,7 @@ diagnostic naming the offending number. If it exits non-zero, read the
 diagnostic and fix the body or `--closes` set rather than opening the PR by
 hand.
 
-### 4. Check for deviation, then write the marker (or skip it), then stop
+### 5. Check for deviation, then write the marker (or skip it), then stop
 
 Before writing the marker, judge whether the implementation deviated from the
 persisted plan — scope shifted mid-implementation, or the plan could not be
@@ -157,7 +197,7 @@ fully implemented as written. Base this on the `/implement-unit` outcomes
 observed in Step 2.
 
 **Deviation fires** — skip the `phase-completed` marker. Instead call
-`dispatch-mark-deviation` to write the office-hours-reason atomically. If Step 3
+`dispatch-mark-deviation` to write the office-hours-reason atomically. If Step 4
 already opened a draft PR, it stays open. The Stop hook reads marker-absence as Branch A,
 applies `dispatch:office-hours` to the issue (surfacing this reason in the
 why-comment), and parks the issue for human review.

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -340,8 +340,12 @@ returns — must contain:
   - **Dependencies** — prior units that must complete first, so build order is
     explicit.
 - **Reuse** notes — existing functions/utilities to reuse, with their file paths.
-- A **Verification** section — how to test the change end-to-end (run the code,
-  use MCP tools, run tests).
+- A **Verification** section — how to test the change end-to-end. Put
+  deterministic, CI-safe, auto-runnable checks (test-suite invocations,
+  typechecks, builds) in fenced ` ```verify ` blocks so `/implement`
+  auto-executes them before opening the PR. Keep manual steps, observe-in-
+  production checks, live-systemd verification, and judgment calls as **prose** —
+  `/implement` skips those, leaving them for QA and humans.
 - A clean-context **plan preface** (below), so the `implement` worker executes
   from the comment alone.
 
@@ -368,7 +372,12 @@ in the worktree `<worktree-path>` (branch `<N>-…`). Build each unit below in
 order via `/implement-unit` (one commit per unit), then run the terminal
 procedure verbatim:
 
-1. **Open the draft PR** (`dangerouslyDisableSandbox: true` — calls `gh`). Write
+1. **Execute the plan's Verification section** (auto-runnable ` ```verify `
+   blocks): `.claude/skills/dispatch-propagate/scripts/dispatch-read-plan <N> | .claude/skills/dispatch-propagate/scripts/dispatch-run-verification` — exit 3 →
+   proceed unchanged; exit 0 → proceed; exit 1 → fix via `/implement-unit`
+   (cap 2) and re-run, else `dispatch-mark-deviation` and stop.
+
+2. **Open the draft PR** (`dangerouslyDisableSandbox: true` — calls `gh`). Write
    the PR body prose to `tmp/pr-body.md` first, then:
 
    ```bash
@@ -379,7 +388,7 @@ procedure verbatim:
      --body-file tmp/pr-body.md)
    ```
 
-2. **Check for deviation, then write the marker (or skip it), then stop.**
+3. **Check for deviation, then write the marker (or skip it), then stop.**
    - **No deviation** (built as planned):
      ```bash
      .claude/skills/dispatch-propagate/scripts/dispatch-mark-complete \
@@ -456,7 +465,7 @@ with these substitutions:
 > - Ensure that the plan file is concise enough to scan quickly, but detailed enough to execute effectively
 > - Name the critical files to be modified. For changes that repeat a pattern across many files, describe the pattern once and list a few representative paths — do not enumerate every file or line number
 > - Reference existing functions and utilities you found that should be reused, with their file paths
-> - Include a verification section describing how to test the changes end-to-end (run the code, use MCP tools, run tests)
+> - Include a verification section describing how to test the changes end-to-end. Put deterministic, CI-safe, auto-runnable checks (test-suite invocations, typechecks, builds) in fenced ` ```verify ` blocks so `/implement` auto-executes them before opening the PR. Keep manual steps, observe-in-production checks, live-systemd verification, and judgment calls as **prose** — `/implement` skips those, leaving them for QA and humans.
 
 ### Intentionally NOT adopted
 

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -376,7 +376,13 @@ procedure verbatim:
    — `dispatch-read-plan` calls `gh`). Run the auto-runnable ` ```verify `
    blocks: `.claude/skills/dispatch-propagate/scripts/dispatch-read-plan <N> | .claude/skills/dispatch-propagate/scripts/dispatch-run-verification` — exit 3 →
    proceed unchanged; exit 0 → proceed; exit 1 → fix via `/implement-unit`
-   (cap 2) and re-run, else `dispatch-mark-deviation` and stop.
+   (cap 2) and re-run, else run the deviation marker below and stop (skip the
+   Step 3 completion marker):
+
+   ```bash
+   .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+     "/implement: plan verification failed after 2 fix attempts (check <index>)"
+   ```
 
 2. **Open the draft PR** (`dangerouslyDisableSandbox: true` — calls `gh`). Write
    the PR body prose to `tmp/pr-body.md` first, then:

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -372,8 +372,9 @@ in the worktree `<worktree-path>` (branch `<N>-…`). Build each unit below in
 order via `/implement-unit` (one commit per unit), then run the terminal
 procedure verbatim:
 
-1. **Execute the plan's Verification section** (auto-runnable ` ```verify `
-   blocks): `.claude/skills/dispatch-propagate/scripts/dispatch-read-plan <N> | .claude/skills/dispatch-propagate/scripts/dispatch-run-verification` — exit 3 →
+1. **Execute the plan's Verification section** (`dangerouslyDisableSandbox: true`
+   — `dispatch-read-plan` calls `gh`). Run the auto-runnable ` ```verify `
+   blocks: `.claude/skills/dispatch-propagate/scripts/dispatch-read-plan <N> | .claude/skills/dispatch-propagate/scripts/dispatch-run-verification` — exit 3 →
    proceed unchanged; exit 0 → proceed; exit 1 → fix via `/implement-unit`
    (cap 2) and re-run, else `dispatch-mark-deviation` and stop.
 


### PR DESCRIPTION
Closes #2024

## What

`/plan-issue` requires every plan to carry a **Verification** section describing
how to test the change end-to-end, but `/implement` never executed it. The plan's
Verification section was authored and then orphaned — QA later re-derived its own
checks from the issue's acceptance criteria, not from the plan. So the
Plan-Execute-Verify loop was broken at the Verify leg: defects the plan's own test
would catch slipped through to QA one phase later, or to a human.

This change makes `/implement` run the plan's auto-runnable verification checks
after the units are built and before the PR opens, fix fixable failures within a
bounded budget, and escalate unfixable failures via `dispatch-mark-deviation`
instead of opening a green-looking PR.

## How

Auto-runnable checks must be **explicitly marked**, because Verification sections
are prose-dominant and even fenced ```bash blocks are not all safe to auto-run
(some require live systemd, manual observation, or judgment). The design
introduces a dedicated fenced-block info string — ` ```verify ` — that plan
authors use for CI-safe, deterministic checks (test-suite runs, typechecks,
builds). `/implement` runs only those blocks; everything else stays as prose for
QA / humans. A plan with no ` ```verify ` block is a no-op — fully
backward-compatible with the existing backlog of legacy plans (which have zero).

### Units

- **Unit 1** — new `dispatch-run-verification` script with a tri-state run-and-gate
  contract: reads the full plan markdown on stdin (no `gh`, no network — so it's
  unit-testable with no mock), slices the Verification section, extracts every
  ` ```verify ` block, and runs each in the worktree root. Exit **0** = all passed,
  **1** = a block failed (failing index reported, no further blocks run), **3** =
  nothing auto-runnable (the "proceed unchanged" signal). Covered by new cases in
  `test-dispatch-scripts.sh`.
- **Unit 2** — `/implement` runs `dispatch-read-plan <N> | dispatch-run-verification`
  after building units and before opening the PR. Exit 3/0 → proceed; exit 1 →
  a bounded fix lane (one corrective `/implement-unit`, re-run, `CAP=2` mirroring
  `qa-fix`), then `dispatch-mark-deviation` if still failing. Both terminal actions
  remain `dispatch-mark-complete` / `dispatch-mark-deviation`, so the single-named-exit
  invariant holds.
- **Unit 3** — `/plan-issue` now instructs plan authors to mark deterministic,
  CI-safe checks as ` ```verify ` blocks (vs prose for manual / observe-in-production
  / judgment steps), and the embedded plan-preface template carries the verification
  step before the open-PR step.

## Verification

The dispatch test suite (the `hook-tests` CI gate) stays fully green, including the
new `dispatch-run-verification` pass / escalate / no-runnable / ordering cases:

```
Results: 3378/3378 passed, 0 failed
```

Dogfood: piping this issue's own plan through the new runner
(`dispatch-read-plan 2024 | dispatch-run-verification`) correctly extracted the
plan's ` ```verify ` block, ran the suite, and exited 0.

**Note (expected):** this PR's own `/implement` run did **not** auto-fire the new
step — the running session loaded its skill body before Unit 2 landed, and this
plan's preface predates Unit 3. The feature activates for plans authored and
implemented after this PR merges. The verification above was run manually to
confirm the gate; it does not block the PR.
