### PR TITLE
Promote the jq-echo prose rule into a diff-scoped run-lint check

### DIFF
--- a/.claude/rules/shell-json.md
+++ b/.claude/rules/shell-json.md
@@ -38,3 +38,5 @@ PR_NUM=$(printf '%s' "$PR_JSON" | jq -r .number)
 A direct pipe (`gh … --json … | jq`) is also safe — gh's stdout reaches `jq`
 without an `echo` in between. For non-JSON raw text fed to `jq`, use
 `jq --raw-input`.
+
+This rule is mechanically enforced for net-new added lines in committed `.sh` files by `.claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh`, run via `run-lint.sh` in CI; on a match the linter fails with the remediation inline. Enforcement is a project convention for committed scripts (uniformity aids review) — it does not retroactively rewrite pre-existing sites, and it is not a claim that the rule fixes a zsh-only bug in those files. (The original recurrence #1170 was interactive zsh Bash-tool usage, which is not a committed file at all.)

--- a/.claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh
@@ -8,9 +8,10 @@ SCRIPTS="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPTS/lib.sh"
 
 # Detect: echo "$VAR" | jq  (quoted variable form only — see .claude/rules/shell-json.md)
-# Single-quoted to prevent the shell from interpreting \$ as $ (which would make
-# \$ an ERE end-anchor, breaking the match).
-PATTERN='echo[[:space:]]+"\$[A-Za-z_][A-Za-z0-9_]*"[[:space:]]*\|[[:space:]]*jq'
+# Covers optional echo flags (echo -e / echo -n) and the braced ${VAR} form, both
+# of which are the same anti-pattern. Single-quoted to prevent the shell from
+# interpreting \$ as $ (which would make \$ an ERE end-anchor, breaking the match).
+PATTERN='echo([[:space:]]+-[a-zA-Z]+)?[[:space:]]+"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"[[:space:]]*\|[[:space:]]*jq'
 
 # Compute the unified-0 diff of added lines in .sh files against origin/main.
 # Run from REPO_ROOT so that relative paths in diff output are consistent.
@@ -58,8 +59,7 @@ while IFS= read -r line; do
     content="${line:1}"
 
     # Skip comment lines (first non-whitespace character is #)
-    trimmed="${content#"${content%%[! ]*}"}"
-    if [[ "$trimmed" == '#'* ]]; then
+    if [[ "$content" =~ ^[[:space:]]*# ]]; then
       LINE_NUM=$(( LINE_NUM + 1 ))
       continue
     fi

--- a/.claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SCRIPTS="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck source=lib.sh
+source "$SCRIPTS/lib.sh"
+
+# Detect: echo "$VAR" | jq  (quoted variable form only — see .claude/rules/shell-json.md)
+# Single-quoted to prevent the shell from interpreting \$ as $ (which would make
+# \$ an ERE end-anchor, breaking the match).
+PATTERN='echo[[:space:]]+"\$[A-Za-z_][A-Za-z0-9_]*"[[:space:]]*\|[[:space:]]*jq'
+
+# Compute the unified-0 diff of added lines in .sh files against origin/main.
+# Run from REPO_ROOT so that relative paths in diff output are consistent.
+if ! DIFF=$(git -C "$REPO_ROOT" diff origin/main...HEAD --unified=0 -- '*.sh'); then
+  echo "ERROR: could not diff origin/main...HEAD for *.sh files" >&2
+  exit 1
+fi
+
+# Hunk header regex: @@ -a[,b] +c[,d] @@ ...
+# Stored in a variable to avoid bare-word regex splitting issues under set -e.
+HUNK_RE='^@@ -[0-9]+(,[0-9]+)? \+([0-9]+)(,[0-9]+)? @@'
+
+CURRENT_PATH=""
+LINE_NUM=0
+VIOLATIONS=()
+
+while IFS= read -r line; do
+  # +++ header: new-file path (or /dev/null for deleted files)
+  if [[ "$line" == '+++ '* ]]; then
+    rest="${line#+++ }"
+    if [[ "$rest" == '/dev/null' ]]; then
+      CURRENT_PATH=""
+    else
+      # Strip leading b/ prefix from diff paths
+      CURRENT_PATH="${rest#b/}"
+    fi
+    LINE_NUM=0
+    continue
+  fi
+
+  # --- header: ignore (marks old-file side)
+  if [[ "$line" == '--- '* ]]; then
+    continue
+  fi
+
+  # Hunk header: extract the new-side start line number
+  if [[ "$line" =~ $HUNK_RE ]]; then
+    LINE_NUM="${BASH_REMATCH[2]}"
+    continue
+  fi
+
+  # Added content line: starts with + but NOT ++
+  if [[ "$line" == '+'* ]] && [[ "$line" != '++'* ]]; then
+    # Strip the leading +
+    content="${line:1}"
+
+    # Skip comment lines (first non-whitespace character is #)
+    trimmed="${content#"${content%%[! ]*}"}"
+    if [[ "$trimmed" == '#'* ]]; then
+      LINE_NUM=$(( LINE_NUM + 1 ))
+      continue
+    fi
+
+    # Test against the anti-pattern
+    if [[ "$content" =~ $PATTERN ]]; then
+      VIOLATIONS+=("${CURRENT_PATH}:${LINE_NUM}: ${content}")
+    fi
+
+    LINE_NUM=$(( LINE_NUM + 1 ))
+    continue
+  fi
+
+  # Everything else (diff headers, index lines, - lines): ignore.
+  # Do not advance the new-side line counter for these.
+
+done <<<"$DIFF"
+
+if [[ ${#VIOLATIONS[@]} -gt 0 ]]; then
+  echo "FAIL: echo-into-jq violations found in net-new .sh lines:" >&2
+  for v in "${VIOLATIONS[@]}"; do
+    echo "  $v" >&2
+  done
+  cat >&2 <<'REMEDIATION'
+
+Remediation — replace the offending line with one of:
+
+  jq -r .field <<<"$VAR"            # here-string: no escape interpretation
+  gh ... --json field --jq .field   # let gh filter its in-memory JSON
+  printf '%s' "$VAR" | jq -r .field # printf does not interpret escapes
+
+Why this matters (.claude/rules/shell-json.md): zsh's builtin echo interprets
+backslash escapes (\t, \n, \uXXXX) by default. A bash script committed here
+may be sourced into zsh; using echo-into-jq is banned project-wide for
+uniformity and review clarity. The original recurrence (#1170) was interactive
+zsh Bash-tool usage, which is not a committed file — this rule is a project
+convention for committed .sh files, not a claim that the bug occurs in bash.
+
+See: .claude/rules/shell-json.md
+REMEDIATION
+  exit 1
+fi
+
+echo "PASS: no net-new echo-into-jq violations in added .sh lines"

--- a/.claude/skills/dispatch-propagate/scripts/run-lint.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-lint.sh
@@ -11,6 +11,7 @@ source "$SCRIPTS/lib.sh"
 declare -A DIRTY_APPS
 RUN_NIX=false
 RUN_RULES=false
+RUN_PROSE=false
 EXPLICIT=false
 
 while [[ $# -gt 0 ]]; do
@@ -31,8 +32,13 @@ while [[ $# -gt 0 ]]; do
       EXPLICIT=true
       shift
       ;;
+    --prose)
+      RUN_PROSE=true
+      EXPLICIT=true
+      shift
+      ;;
     *)
-      echo "Usage: run-lint.sh [--app <dir>] [--nix] [--rules]" >&2
+      echo "Usage: run-lint.sh [--app <dir>] [--nix] [--rules] [--prose]" >&2
       exit 1
       ;;
   esac
@@ -56,6 +62,7 @@ if [ "$EXPLICIT" = false ]; then
     case "$file" in
       nix/*|flake.nix|flake.lock) RUN_NIX=true ;;
       firestore.rules) RUN_RULES=true ;;
+      *.sh) RUN_PROSE=true ;;
     esac
   done <<< "$CHANGED"
 fi
@@ -101,7 +108,18 @@ if [ "$RUN_RULES" = true ]; then
   fi
 fi
 
-if [ ${#APP_DIRS[@]} -eq 0 ] && [ "$RUN_NIX" = false ] && [ "$RUN_RULES" = false ]; then
+# Run prose-rule lint
+if [ "$RUN_PROSE" = true ]; then
+  echo "=== Prose-rule lint ==="
+  if "$SCRIPTS/lint-prose-rules.sh"; then
+    echo "PASS: prose rules"
+  else
+    echo "FAIL: prose rules" >&2
+    FAILURES+=(prose)
+  fi
+fi
+
+if [ ${#APP_DIRS[@]} -eq 0 ] && [ "$RUN_NIX" = false ] && [ "$RUN_RULES" = false ] && [ "$RUN_PROSE" = false ]; then
   echo "No lint targets matched changed files. Nothing to check."
   exit 0
 fi

--- a/.claude/skills/dispatch-propagate/scripts/test-lint-prose-rules.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lint-prose-rules.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Tests for lint-prose-rules.sh.
+# Builds ephemeral git repos to validate the diff-scoping and detection logic.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+source "$SCRIPT_DIR/test-helpers.sh"
+SUT="$SCRIPT_DIR/lint-prose-rules.sh"
+
+TMP_ROOT=""
+cleanup() { [ -n "${TMP_ROOT:-}" ] && rm -rf "$TMP_ROOT"; }
+trap cleanup EXIT INT TERM
+
+# Assemble the banned pattern from pieces so this source file never contains
+# the contiguous sequence on a non-comment line. These variables are used to
+# write fixture content into ephemeral repos only.
+_PIPE='|'
+# Produces the string: X=$(echo "$J" | jq -r .a)
+VIOL_CONTENT="X=\$(echo \"\$J\" $_PIPE jq -r .a)"
+
+# Build a fresh ephemeral repo. Sets globals: REPO, BARE.
+# $1 (optional): "with_violation" — include VIOL_CONTENT in the origin/main baseline.
+REPO=""
+BARE=""
+make_repo() {
+  local include_viol="${1:-}"
+  REPO=$(mktemp -d "$TMP_ROOT/repo.XXXXXX")
+  BARE=$(mktemp -d "$TMP_ROOT/bare.XXXXXX")
+
+  git -C "$BARE" init --bare --quiet --initial-branch=main
+
+  git -C "$REPO" init --quiet --initial-branch=main
+  git -C "$REPO" config user.email "test@example.com"
+  git -C "$REPO" config user.name "Test User"
+  git -C "$REPO" remote add origin "$BARE"
+
+  # Write the baseline script.sh.
+  printf '%s\n' '#!/usr/bin/env bash' > "$REPO/script.sh"
+  printf '%s\n' 'jq -r .field <<<"$VAR"' >> "$REPO/script.sh"
+  if [ "$include_viol" = "with_violation" ]; then
+    printf '%s\n' "$VIOL_CONTENT" >> "$REPO/script.sh"
+  fi
+
+  git -C "$REPO" add -A
+  git -C "$REPO" commit --quiet -m "baseline"
+  git -C "$REPO" push --quiet origin main
+
+  git -C "$REPO" checkout --quiet -b feature
+
+  # Ensure origin/main is fetchable so origin/main...HEAD resolves.
+  git -C "$REPO" fetch --quiet origin main
+}
+
+# Run the SUT with CWD inside $REPO. Sets globals: RC, OUT.
+RC=0
+OUT=""
+run_sut() {
+  local prev_dir
+  prev_dir=$(pwd)
+  cd "$REPO"
+  set +e
+  OUT=$("$SUT" 2>&1)
+  RC=$?
+  set -e
+  cd "$prev_dir"
+}
+
+TMP_ROOT=$(mktemp -d)
+
+# ---------------------------------------------------------------------------
+# Test 1: net-new violation IS flagged.
+# Baseline has no violation. HEAD adds the banned pattern to a .sh file.
+# ---------------------------------------------------------------------------
+echo "Test 1: net-new violation is flagged"
+make_repo
+printf '%s\n' "$VIOL_CONTENT" >> "$REPO/script.sh"
+git -C "$REPO" add -A
+git -C "$REPO" commit --quiet -m "add violation"
+run_sut
+[ "$RC" -ne 0 ] && _t1_rc=nonzero || _t1_rc=zero
+assert_eq "violation: exit non-zero" "nonzero" "$_t1_rc"
+assert_contains "violation: output names the file" "script.sh" "$OUT"
+assert_contains "violation: remediation pointer present" "shell-json.md" "$OUT"
+assert_contains "violation: good-form hint present" '<<<"$VAR"' "$OUT"
+
+# ---------------------------------------------------------------------------
+# Test 2: pre-existing violation is NOT flagged.
+# The banned pattern is already on origin/main; HEAD makes a no-op change
+# elsewhere so the diff shows no net-new addition of the violating line.
+# ---------------------------------------------------------------------------
+echo "Test 2: pre-existing violation is not flagged"
+make_repo with_violation
+echo "# no-op change" >> "$REPO/script.sh"
+git -C "$REPO" add -A
+git -C "$REPO" commit --quiet -m "no-op change"
+run_sut
+assert_eq "pre-existing: exit 0" "0" "$RC"
+assert_contains "pre-existing: PASS printed" "PASS" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Test 3: added comment mentioning the pattern is NOT flagged.
+# The linter skips comment lines (first non-whitespace char is #).
+# ---------------------------------------------------------------------------
+echo "Test 3: added comment is not flagged"
+make_repo
+# Write a comment referencing the pattern; assembled in parts here to avoid
+# the contiguous banned sequence appearing on this non-comment source line.
+COMMENT_LINE="# do not use: echo \"\$X\" $_PIPE jq"
+printf '%s\n' "$COMMENT_LINE" >> "$REPO/script.sh"
+git -C "$REPO" add -A
+git -C "$REPO" commit --quiet -m "add comment"
+run_sut
+assert_eq "comment: exit 0" "0" "$RC"
+assert_contains "comment: PASS printed" "PASS" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Test 4: clean added line passes.
+# HEAD adds a here-string form (the correct pattern), which must not be flagged.
+# ---------------------------------------------------------------------------
+echo "Test 4: clean added line passes"
+make_repo
+echo 'jq -r .a <<<"$J"' >> "$REPO/script.sh"
+git -C "$REPO" add -A
+git -C "$REPO" commit --quiet -m "add clean line"
+run_sut
+assert_eq "clean-line: exit 0" "0" "$RC"
+assert_contains "clean-line: PASS printed" "PASS" "$OUT"
+
+report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-lint-prose-rules.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lint-prose-rules.sh
@@ -17,6 +17,10 @@ trap cleanup EXIT INT TERM
 _PIPE='|'
 # Produces the string: X=$(echo "$J" | jq -r .a)
 VIOL_CONTENT="X=\$(echo \"\$J\" $_PIPE jq -r .a)"
+# Produces the string: X=$(echo -e "$J" | jq -r .a)  (escape-interpreting flag form)
+VIOL_CONTENT_FLAG="X=\$(echo -e \"\$J\" $_PIPE jq -r .a)"
+# Produces the string: X=$(echo "${MY_VAR}" | jq -r .a)  (braced form)
+VIOL_CONTENT_BRACED="X=\$(echo \"\${MY_VAR}\" $_PIPE jq -r .a)"
 
 # Build a fresh ephemeral repo. Sets globals: REPO, BARE.
 # $1 (optional): "with_violation" — include VIOL_CONTENT in the origin/main baseline.
@@ -99,14 +103,19 @@ assert_contains "pre-existing: PASS printed" "PASS" "$OUT"
 
 # ---------------------------------------------------------------------------
 # Test 3: added comment mentioning the pattern is NOT flagged.
-# The linter skips comment lines (first non-whitespace char is #).
+# The linter skips comment lines (first non-whitespace char is #), including
+# indented comments (leading spaces/tabs before the #).
 # ---------------------------------------------------------------------------
 echo "Test 3: added comment is not flagged"
 make_repo
-# Write a comment referencing the pattern; assembled in parts here to avoid
-# the contiguous banned sequence appearing on this non-comment source line.
+# Write both an un-indented and an indented comment referencing the pattern;
+# assembled in parts here to avoid the contiguous banned sequence appearing on
+# this non-comment source line. The indented case guards the regression where a
+# space-/tab-indented comment was wrongly flagged.
 COMMENT_LINE="# do not use: echo \"\$X\" $_PIPE jq"
+COMMENT_LINE_INDENTED="  # do not use: echo \"\$Y\" $_PIPE jq"
 printf '%s\n' "$COMMENT_LINE" >> "$REPO/script.sh"
+printf '%s\n' "$COMMENT_LINE_INDENTED" >> "$REPO/script.sh"
 git -C "$REPO" add -A
 git -C "$REPO" commit --quiet -m "add comment"
 run_sut
@@ -125,5 +134,34 @@ git -C "$REPO" commit --quiet -m "add clean line"
 run_sut
 assert_eq "clean-line: exit 0" "0" "$RC"
 assert_contains "clean-line: PASS printed" "PASS" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Test 5: net-new flag form (echo -e "$VAR" | jq) IS flagged.
+# The -e flag is the explicit opt-in to escape interpretation — the most
+# dangerous form of the anti-pattern.
+# ---------------------------------------------------------------------------
+echo "Test 5: echo -e flag form is flagged"
+make_repo
+printf '%s\n' "$VIOL_CONTENT_FLAG" >> "$REPO/script.sh"
+git -C "$REPO" add -A
+git -C "$REPO" commit --quiet -m "add flag-form violation"
+run_sut
+[ "$RC" -ne 0 ] && _t5_rc=nonzero || _t5_rc=zero
+assert_eq "flag-form: exit non-zero" "nonzero" "$_t5_rc"
+assert_contains "flag-form: output names the file" "script.sh" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Test 6: net-new braced form (echo "${VAR}" | jq) IS flagged.
+# Semantically identical to the unbraced form; must not be a lint bypass.
+# ---------------------------------------------------------------------------
+echo "Test 6: braced variable form is flagged"
+make_repo
+printf '%s\n' "$VIOL_CONTENT_BRACED" >> "$REPO/script.sh"
+git -C "$REPO" add -A
+git -C "$REPO" commit --quiet -m "add braced-form violation"
+run_sut
+[ "$RC" -ne 0 ] && _t6_rc=nonzero || _t6_rc=zero
+assert_eq "braced-form: exit non-zero" "nonzero" "$_t6_rc"
+assert_contains "braced-form: output names the file" "script.sh" "$OUT"
 
 report_results

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -130,6 +130,8 @@ jobs:
         run: .claude/hooks/test-approve-workflow-commands.sh
       - name: Run dispatch script tests
         run: .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+      - name: Run prose-rule lint tests
+        run: .claude/skills/dispatch-propagate/scripts/test-lint-prose-rules.sh
       - name: Run worktree-remove hook tests
         run: .claude/hooks/test-worktree-remove.sh
       - name: Run statusline hook tests


### PR DESCRIPTION
Closes #2067

## What

Promotes the highest-recurrence prose rule — the **jq-echo control-char trap**
(`.claude/rules/shell-json.md`, first bit #1170) — from a convention an agent
must remember into a mechanical check whose failure message injects the
remediation into agent context. Part of epic #2061 (code-quality decay sensors).

## How

- **`lint-prose-rules.sh`** (new) — a standalone, **diff-scoped** linter. It
  self-computes `git diff origin/main...HEAD --unified=0 -- '*.sh'`, recovers
  `path:line` for each *added* line, skips comment lines, and flags the
  documented `echo "$VAR" | jq` anti-pattern. On a match it prints each offending
  `path:line: <content>` followed by the concrete fixes from `shell-json.md` (the
  `<<<` here-string, `--jq`, and `printf '%s'` forms) and a pointer to the rule,
  then exits non-zero — the **remediation-in-error** that puts the fix in front of
  the agent that tripped it.
- **`test-lint-prose-rules.sh`** (new, registered in the `hook-tests` CI job) —
  four ephemeral-repo cases, including the discriminating one that proves the
  check is diff-scoped (a pre-existing violation unchanged at HEAD is **not**
  flagged) and that an added comment mentioning the pattern is **not** flagged.
- **`run-lint.sh`** — wires in a `RUN_PROSE` flag (auto-detected when any changed
  file matches `*.sh`, plus an explicit `--prose`), mirroring the existing
  `RUN_RULES` delegation. So the check runs in the CI `lint` job and in
  `/fix-checks`.
- **`shell-json.md`** — notes the rule is now mechanically enforced.

## Why diff-scoped, not whole-repo

This is the greenfield ideal for a decay sensor (matching the net-new framing of
sibling sensors #2064 / #2065) and is required for correctness: the repo already
contains `echo "$VAR" | jq` sites in `#!/usr/bin/env bash` scripts (e.g.
`.claude/hooks/statusline.sh`), where `echo` does **not** munge escapes — so they
are not latent bugs, and a whole-repo scan would force churn on working code.

## Honest framing

The original #1170 recurrence was *interactive zsh Bash-tool* usage, which is not
a committed file at all. This linter catches the adjacent committed-`.sh` surface
as a **project convention / defense-in-depth** (a bash script can be sourced into
zsh; uniformity aids review) — not as a claim that it fixes a zsh-only bug in
those bash files. The failure message and the `shell-json.md` note say this
plainly.

## Deferred follow-ups (out of scope here)

1. A one-time whole-repo cleanup of the pre-existing `echo "$VAR" | jq` sites
   (`.claude/hooks/statusline.sh`, `.github/scripts/cloudflare-purge.sh`,
   `audio/scripts/upload-media.sh`, `run-acceptance-tests.sh`,
   `run-preview-deploy.sh`).
2. A closing-keyword adjacency check on the PR-body surface in `dispatch-open-pr`
   — the second prose-rule candidate (`issue-references.md`), which operates on
   PR-body / commit-message prose rather than committed files, so it has no
   file-grep surface in `run-lint.sh`.

Both will be filed as `blocked_by` follow-ups during review.

## Verification

- `test-lint-prose-rules.sh`: 10/10 assertions pass.
- `run-lint.sh --prose` correctly fails with the `path:line` + remediation on a
  net-new violation and passes when there is none; the no-op guard still reports
  "No lint targets matched … Nothing to check."
