### PR TITLE
Add knip dead-code / unused-export sensor as a gated CI check

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/detect-changes.sh
+++ b/.claude/skills/dispatch-propagate/scripts/detect-changes.sh
@@ -32,6 +32,11 @@ fi
 if echo "$CHANGED" | grep -qE '^(firestore\.rules$|storage\.rules$|rules-test/|\.claude/skills/dispatch-propagate/scripts/|firebase\.json$|package\.json$|package-lock\.json$)'; then
   echo "rules=true" >> "$GITHUB_OUTPUT"
 fi
+# dead-code check runs knip at repo root — any TS/JS/knip-config change can
+# orphan code elsewhere, so trigger on any such change across the repo.
+if echo "$CHANGED" | grep -qE '\.(ts|tsx|js|jsx|mjs|cjs)$|^knip\.(json|jsonc|ts)$'; then
+  echo "deadcode=true" >> "$GITHUB_OUTPUT"
+fi
 # go-tests needs the Go toolchain. Set go=true when a changed file is under a
 # discovered Go module. list-go-modules.sh discovers module roots from go.mod
 # locations, so a new Go module needs no edit here.

--- a/.claude/skills/dispatch-propagate/scripts/run-dead-code.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-dead-code.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SCRIPTS="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck source=lib.sh
+source "$SCRIPTS/lib.sh"
+
+# Install root node_modules once (knip runs at repo root, not per-workspace)
+ensure_deps
+
+echo "=== Dead-code check (knip) ==="
+if (cd "$REPO_ROOT" && npx knip --max-issues 0); then
+  echo "PASS: dead-code check"
+else
+  echo "FAIL: dead-code check" >&2
+  exit 1
+fi
+
+echo "All dead-code checks passed."

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -109,6 +109,24 @@ jobs:
       - name: Run lint
         run: .claude/skills/dispatch-propagate/scripts/run-lint.sh
 
+  dead-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+      - name: Detect changed file categories
+        id: changes
+        run: .claude/skills/dispatch-propagate/scripts/detect-changes.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        if: steps.changes.outputs.deadcode == 'true'
+        with:
+          node-version-file: .node-version
+          cache: 'npm'
+      - name: Run dead-code check
+        if: steps.changes.outputs.deadcode == 'true'
+        run: .claude/skills/dispatch-propagate/scripts/run-dead-code.sh
+
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/budget/src/entities/account.ts
+++ b/budget/src/entities/account.ts
@@ -95,6 +95,11 @@ export interface SeedAccount {
 
 // ── Firestore → Account ───────────────────────────────────────────────────────
 
+/**
+ * @public knip baseline (#2066): residual unused export, not deleted per the
+ * no-bulk-delete line — part of the symmetric per-entity parseFirestore* set.
+ * Deletion candidate; see PR notes.
+ */
 export function parseFirestoreAccount(docSnap: QueryDocumentSnapshot<DocumentData, DocumentData>): Account {
   const data = docSnap.data();
   return {

--- a/budget/src/entities/budget-period.ts
+++ b/budget/src/entities/budget-period.ts
@@ -98,6 +98,11 @@ function requireCategoryBreakdown(value: unknown): Record<string, number> {
 
 // ── Firestore → BudgetPeriod ──────────────────────────────────────────────────
 
+/**
+ * @public knip baseline (#2066): residual unused export, not deleted per the
+ * no-bulk-delete line — part of the symmetric per-entity parseFirestore* set.
+ * Deletion candidate; see PR notes.
+ */
 export function parseFirestoreBudgetPeriod(docSnap: QueryDocumentSnapshot<DocumentData, DocumentData>): BudgetPeriod {
   const data = docSnap.data();
   const periodStart = requireTimestamp(data.periodStart, "periodStart");

--- a/budget/src/entities/budget.ts
+++ b/budget/src/entities/budget.ts
@@ -166,6 +166,11 @@ export function validateBudgetOverrideOrdering(
 
 // ── Firestore → Budget ────────────────────────────────────────────────────────
 
+/**
+ * @public knip baseline (#2066): residual unused export, not deleted per the
+ * no-bulk-delete line — part of the symmetric per-entity parseFirestore* set.
+ * Deletion candidate; see PR notes.
+ */
 export function parseFirestoreBudget(docSnap: QueryDocumentSnapshot<DocumentData, DocumentData>): Budget {
   const data = docSnap.data();
   const name = requireString(data.name, "name");

--- a/budget/src/entities/journal-entry.ts
+++ b/budget/src/entities/journal-entry.ts
@@ -68,6 +68,11 @@ export interface SeedJournalEntry {
 
 // ── Firestore → JournalEntry ──────────────────────────────────────────────────
 
+/**
+ * @public knip baseline (#2066): residual unused export, not deleted per the
+ * no-bulk-delete line — part of the symmetric per-entity parseFirestore* set.
+ * Deletion candidate; see PR notes.
+ */
 export function parseFirestoreJournalEntry(docSnap: QueryDocumentSnapshot<DocumentData, DocumentData>): JournalEntry {
   const data = docSnap.data();
   return {

--- a/budget/src/entities/journal-leg.ts
+++ b/budget/src/entities/journal-leg.ts
@@ -94,6 +94,11 @@ export interface SeedJournalLeg {
 
 // ── Firestore → JournalLeg ────────────────────────────────────────────────────
 
+/**
+ * @public knip baseline (#2066): residual unused export, not deleted per the
+ * no-bulk-delete line — part of the symmetric per-entity parseFirestore* set.
+ * Deletion candidate; see PR notes.
+ */
 export function parseFirestoreJournalLeg(docSnap: QueryDocumentSnapshot<DocumentData, DocumentData>): JournalLeg {
   const data = docSnap.data();
   const debit = requireNonNegativeNumber(data.debit, "debit");

--- a/budget/src/entities/reconciliation-event.ts
+++ b/budget/src/entities/reconciliation-event.ts
@@ -95,6 +95,11 @@ export interface SeedReconciliationEvent {
 
 // ── Firestore → ReconciliationEvent ──────────────────────────────────────────
 
+/**
+ * @public knip baseline (#2066): residual unused export, not deleted per the
+ * no-bulk-delete line — part of the symmetric per-entity parseFirestore* set.
+ * Deletion candidate; see PR notes.
+ */
 export function parseFirestoreReconciliationEvent(docSnap: QueryDocumentSnapshot<DocumentData, DocumentData>): ReconciliationEvent {
   const data = docSnap.data();
   return {

--- a/budget/src/entities/reconciliation-note.ts
+++ b/budget/src/entities/reconciliation-note.ts
@@ -82,6 +82,11 @@ export interface SeedReconciliationNote {
 
 // ── Firestore → ReconciliationNote ────────────────────────────────────────────
 
+/**
+ * @public knip baseline (#2066): residual unused export, not deleted per the
+ * no-bulk-delete line — part of the symmetric per-entity parseFirestore* set.
+ * Deletion candidate; see PR notes.
+ */
 export function parseFirestoreReconciliationNote(docSnap: QueryDocumentSnapshot<DocumentData, DocumentData>): ReconciliationNote {
   const data = docSnap.data();
   return {

--- a/budget/src/entities/statement-item.ts
+++ b/budget/src/entities/statement-item.ts
@@ -96,6 +96,11 @@ export interface SeedStatementItem {
 
 // ── Firestore → StatementItem ─────────────────────────────────────────────────
 
+/**
+ * @public knip baseline (#2066): residual unused export, not deleted per the
+ * no-bulk-delete line — part of the symmetric per-entity parseFirestore* set.
+ * Deletion candidate; see PR notes.
+ */
 export function parseFirestoreStatementItem(docSnap: QueryDocumentSnapshot<DocumentData, DocumentData>): StatementItem {
   const data = docSnap.data();
   return {

--- a/budget/src/entities/statement.ts
+++ b/budget/src/entities/statement.ts
@@ -91,6 +91,11 @@ export interface SeedStatement {
 
 // ── Firestore → Statement ─────────────────────────────────────────────────────
 
+/**
+ * @public knip baseline (#2066): residual unused export, not deleted per the
+ * no-bulk-delete line — part of the symmetric per-entity parseFirestore* set.
+ * Deletion candidate; see PR notes.
+ */
 export function parseFirestoreStatement(docSnap: QueryDocumentSnapshot<DocumentData, DocumentData>): Statement {
   const data = docSnap.data();
   return {

--- a/budget/src/entities/transaction.ts
+++ b/budget/src/entities/transaction.ts
@@ -147,6 +147,11 @@ function requireReimbursement(value: unknown): number {
 
 // ── Firestore → Transaction ───────────────────────────────────────────────────
 
+/**
+ * @public knip baseline (#2066): residual unused export, not deleted per the
+ * no-bulk-delete line — part of the symmetric per-entity parseFirestore* set.
+ * Deletion candidate; see PR notes.
+ */
 export function parseFirestoreTransaction(docSnap: QueryDocumentSnapshot<DocumentData, DocumentData>): Transaction {
   const data = docSnap.data();
   return {

--- a/budget/src/entities/weekly-aggregate.ts
+++ b/budget/src/entities/weekly-aggregate.ts
@@ -62,6 +62,11 @@ export interface SeedWeeklyAggregate {
 
 // ── Firestore → WeeklyAggregate ───────────────────────────────────────────────
 
+/**
+ * @public knip baseline (#2066): residual unused export, not deleted per the
+ * no-bulk-delete line — part of the symmetric per-entity parseFirestore* set.
+ * Deletion candidate; see PR notes.
+ */
 export function parseFirestoreWeeklyAggregate(docSnap: QueryDocumentSnapshot<DocumentData, DocumentData>): WeeklyAggregate {
   const data = docSnap.data();
   return {

--- a/budget/src/pages/render-options.ts
+++ b/budget/src/pages/render-options.ts
@@ -16,6 +16,9 @@ export function renderPageNotices(options: { authorized: boolean }, entityLabel:
  * Convert a page-level data loading error to user-facing HTML.
  * Rethrows programmer, range, and data integrity errors so they propagate
  * to the router's top-level handler.
+ *
+ * @public knip baseline (#2066): residual unused export, not deleted per the
+ * no-bulk-delete line. Deletion candidate; see PR notes.
  */
 export function renderLoadError(error: unknown, errorId: string): string {
   const kind = classifyError(error);

--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -25,8 +25,14 @@ const appPackages = workspaces
   })
   .filter((name) => name && !name.startsWith("@commons-systems/"));
 
+// Match the bare package specifier `<app>` and its subpaths `<app>/...`, but
+// never a relative import (`./x/<app>`, `../<app>`). A `group` glob uses
+// gitignore-style matching, where a bare segment matches at any depth — so
+// `budget` would wrongly flag `./entities/budget`. An anchored `regex` matches
+// only specifiers that *start* with the app name, which a relative path never
+// does (it starts with `.`). RegExp-escape the name so a `-` etc. stays literal.
 const appImportPatterns = appPackages.map((app) => ({
-  group: [app, `${app}/**`],
+  regex: `^${app.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(/|$)`,
   message:
     `Layering violation: '${app}' is a top-level app package and must not be ` +
     "imported by libraries, utils, or @commons-systems/ds. Apps are " +

--- a/config/test/eslint-boundaries.test.ts
+++ b/config/test/eslint-boundaries.test.ts
@@ -50,4 +50,22 @@ describe("eslint layering boundary rules", () => {
     const violations = restrictedImportMessages(messages);
     expect(violations).toHaveLength(0);
   });
+
+  // Regression: a relative import whose final path segment coincides with an
+  // app-package name (here `budget`) must NOT be flagged. The rule targets bare
+  // package specifiers, not intra-package relative paths. Canonical case:
+  // budget/src/budget-seed-data.d.ts does `from "./entities/budget"`.
+  it("does not flag a relative import ending in an app-package name", () => {
+    const messages = lint(
+      'import type { SeedBudget } from "./entities/budget";',
+    );
+    const violations = restrictedImportMessages(messages);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("does not flag a parent-relative import ending in an app-package name", () => {
+    const messages = lint('import x from "../print";');
+    const violations = restrictedImportMessages(messages);
+    expect(violations).toHaveLength(0);
+  });
 });

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,0 +1,71 @@
+{
+  "$schema": "./node_modules/knip/schema-jsonc.json",
+
+  // Report an export only when nothing else references it. Exports that are
+  // exported AND used inside their own defining file (e.g. crypto constants
+  // re-used in the same module) are not dead — they have an in-file consumer.
+  // A brand-new export used nowhere still fires, so this stays orphan-safe.
+  "ignoreExportsUsedInFile": true,
+
+  // Each name suppresses exactly ONE package, so a brand-new unused/unlisted
+  // dependency still fires. Two groups, both documented:
+  "ignoreDependencies": [
+    // --- CSS-imported workspace deps: used via `@import "<pkg>/..."` in plain
+    //     .css theme files, which knip 6 does not trace into node_modules. ---
+    "@commons-systems/style", // theme.css @import in fellspiral/landing/office-hours/audio/print/budget
+    "@commons-systems/ds", // style/default.css @imports its design-token CSS
+    // --- Genuinely-unused residuals: grep found ZERO references (no TS, CSS, or
+    //     runtime string import). Baselined, not removed, per no-bulk-delete;
+    //     deletion candidates — see PR notes. ---
+    "@commons-systems/htmlutil", // office-hours: declared, never imported
+    "@commons-systems/components", // audio + print: declared, never imported
+    "@commons-systems/router", // audio: declared, never imported
+    "d3-scale", // budget: declared; code uses d3-hierarchy/interpolate/shape, not d3-scale
+    "d3-scale-chromatic", // budget: declared, never imported
+    "@types/d3-scale", // budget devDep: types for the unused d3-scale
+    "@types/d3-scale-chromatic", // budget devDep: types for the unused d3-scale-chromatic
+    "@google-cloud/secret-manager", // functions: declared, no SecretManager reference anywhere
+    "@eslint/js", // audio devDep: eslint config is re-exported from @commons-systems/config, not consumed here
+    "typescript-eslint", // audio devDep: same — flat config lives in the shared @commons-systems/config preset
+    // --- Unlisted: imported but resolved transitively, not declared. Pre-existing;
+    //     baselined here rather than adding a new direct dependency. ---
+    "playwright", // landing/scripts/capture-screenshots.ts imports `playwright` (root declares @playwright/test)
+    "express" // functions/src/feed-proxy.ts: `import type { Response } from "express"` (transitive via firebase-functions)
+  ],
+
+  // Internal imports inside the COPIED scaffolding templates resolve only after
+  // the template is scaffolded into a new app; `ignoreFiles` excludes the files
+  // as dead-code candidates but not their internal import resolution.
+  "ignoreUnresolved": [
+    "./firebase.js" // scaffolding/firebase/templates/app/src/{firestore,auth}.ts — created at scaffold time
+  ],
+
+  // Trees that are NOT statically imported by any source file and must never be
+  // treated as dead code. Copied/harness-invoked, not part of the module graph.
+  "ignoreFiles": [
+    // Harness-invoked Workflow scripts and skill scripts. The dispatch harness
+    // runs these by path (e.g. .claude/workflows/review-fix.js); no static
+    // importer exists, and deleting one would break the harness.
+    ".claude/**",
+    // Firebase scaffolding templates are COPIED into new app scaffolds, not
+    // imported. Their internal exports/types/imports resolve only post-copy.
+    "scaffolding/firebase/templates/**"
+  ],
+
+  "workspaces": {
+    // Per-workspace entry overrides for tooling files that real code imports or
+    // that a runner/CI invokes directly. `entry` preserves the import trace, so
+    // utils these files consume stay "used" — unlike `ignore`, which would blind
+    // them. Globs cover seeds, e2e specs+helpers, build scripts, and bin CLIs.
+    "fellspiral": { "entry": ["seeds/**", "e2e/**", "scripts/**"] },
+    "audio": { "entry": ["seeds/**", "e2e/**", "scripts/**"] },
+    "landing": { "entry": ["seeds/**", "e2e/**", "scripts/**"] },
+    "office-hours": { "entry": ["seeds/**", "e2e/**"] },
+    "print": { "entry": ["seeds/**", "e2e/**", "scripts/**"] },
+    "budget": { "entry": ["seeds/**", "e2e/**", "scripts/**"] },
+    "authutil": { "entry": ["bin/**"] },
+    "firebaseutil": { "entry": ["bin/**"] },
+    "firestoreutil": { "entry": ["bin/**"] },
+    "functions": { "entry": ["scripts/**"] }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "firebase": "^12.9.0",
         "firebase-tools": "15.20.0",
         "happy-dom": "^20.8.9",
+        "knip": "^6.17.1",
         "sharp": "^0.34.5",
         "tsx": "^4.19.0",
         "typescript": "^5.7.3",
@@ -463,10 +464,33 @@
         "@electric-sql/pglite": "0.3.16"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4100,6 +4124,25 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -4172,6 +4215,663 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.135.0.tgz",
+      "integrity": "sha512-sHeZItACNcA5WRAWqF6ixriR4GkZDyY10gVgnZU7pXku1DjHFATSqnwZM809jl0gXPHxb6fKzYQCK7bNK5cACQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.135.0.tgz",
+      "integrity": "sha512-wPte+SzgzWWFgMSF8YZDNM+tBXtJg0AXBi7+tU3yS2z1f2Af9kRLZLKuJojADmuD/cZexmnMHHC3SDItTW77Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.135.0.tgz",
+      "integrity": "sha512-BmKz3lHIsqVos+9aPcdYCT9MG3APoUyM43KlEFhJMWNVDOGG8FKyiFz81Bc+mGz2o0hpuQ3PfXLfVWJrKXjo2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.135.0.tgz",
+      "integrity": "sha512-dM8BS+8+Br1fNvmh2QZbGiHaYttwLebRa6J4Uz9vuFzMNmvsdRYwf7993ptOaV0JTrR63AaoVLjX7nhWbijxjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.135.0.tgz",
+      "integrity": "sha512-xlZnvvJdR9bGu2pOhvR5hMuKPHCE6Sa9owK5A484mzjHdm75VRV5nCs5w/jkmGODMMTFc+KN7EnZqEieM813kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.135.0.tgz",
+      "integrity": "sha512-PSR8LmBK/H/PQRiN8g7RebQgZX/ntVCrdT/JBfNxE5ezdHG1s2i4rbazsRJYD83TTI1MmgTpC0MGL42PLtskQQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.135.0.tgz",
+      "integrity": "sha512-I85GJXzfUsigkkk7Ngdz95C217M4FdUi1Z2HrX5UyPmURobwQZ7m2bbUvwFkz4VGZd+lymFGKHvDZ3RQC9qOzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.135.0.tgz",
+      "integrity": "sha512-zqEY0npz0g0aGZj/8a5BclunjVDytsBQHYtIC10Gd26HcrLwbVF6YDbqRQjunMGYdSo97u6xOBl05aTDI2diDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.135.0.tgz",
+      "integrity": "sha512-mWAfprP819gQ2qYst1RxgTI8b/z0b29OpoKfRflIXLHde2dZLihQD4g47Onuvtpo5GPIkMYPRlX9QoeZfs/GnQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.135.0.tgz",
+      "integrity": "sha512-gri8c2AOmJKJwOux2KTHFBfUaXoJURuVMKhmKEi/2hTF55cQteTDV2XNfTiE5oCC+Tnem1Y4/MWzcyDadtsSag==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.135.0.tgz",
+      "integrity": "sha512-Y2tkupCG5wo0SxH2rMLG4d4Kmv6DaM3sBp+GuM5lox0S8Za6VxKgQrY2Mut088QQxKkEE89n/4CCCgmw2o0e3Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.135.0.tgz",
+      "integrity": "sha512-xDRJq6i6WTynjeP+ISbDpyH4p9BaJ0wuQcL0lCSDkt9qOXC9dmwpOu1VG/TlwmPI3KpYntmO9nJCuc3TMTsNBA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.135.0.tgz",
+      "integrity": "sha512-V4MoUuiCRNvihxhIufRxvK+ka013V4joTSK0FAGA1KEjLuNprfH6N/Qw2uxQEVIFuNYMhD/hV6xJ/ptbzlKdHg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.135.0.tgz",
+      "integrity": "sha512-JCFZ7zM7KXOKoPAbK/ZB4wY0M1jxRECiem2UQuiXLjzGqS9+hno7mtX+qyK2F7HWK2xPhyJb+frpcOtk5DKOtg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.135.0.tgz",
+      "integrity": "sha512-9jSVS1b3hOV7sdKH4aA2DFfnTz0RgQd0v2BefR+LYbH8yIlmSM22JJZbAAjVeVXmFgUAk3zJQ1tpE/Nd+Vi2YQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.135.0.tgz",
+      "integrity": "sha512-M857ZLBSdn1Uy/SJJz5zh0qGu67B4P9omCgXGBU2LLqTzraX6ZjVNaKq5yW1PDw/LgJXDXR/dbZfgmB310f11Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.135.0.tgz",
+      "integrity": "sha512-2w6DVcntQZX9U5RhXtgiWb3FLWFB5EcwI1U8yr3htOCJUJjagN4BFUHz/Y/d9ZsumndZ6ByxxWEtbUZNE1bfFw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.135.0.tgz",
+      "integrity": "sha512-rX1U8+IH2Z37EJjDXKa1iifvUQAdba+vZ4Ewj1iaG5eA/QaSybzclCOwtWa0/5BuUQnnK/T2JHUEFrwhL6Ck2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.135.0.tgz",
+      "integrity": "sha512-9FAisBbH1QICGAjlJobiuKGd/jOuVmyqniWdQMwTa5SkCl6hhuotBCJf1n46B0flYbSOR5TzfV9HZCWSyb3c/Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.135.0.tgz",
+      "integrity": "sha512-wYF+A2AzJ2n7ul6q+Z2G/ia0S2+8cUp0AgWZzoFvF4WmUcl1P7p+o6se1Gdr5wGnWuF0iAMIkGddrjCarNr2yA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.135.0.tgz",
+      "integrity": "sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.21.3.tgz",
+      "integrity": "sha512-eNU11A2WNizh04v3uyaJCootrHIaS0B9aHYXvAvVnPNk4xYSjMUjHnhQ6dewPN2MRYDskV85d1N0Aw0WNWhcyg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.21.3.tgz",
+      "integrity": "sha512-8Q+ZjTLvn2dIcWsrmhdrEihm7q+ag/k+mkry7Z+t0QbbHaVxXQfvH9AewyVMh/WrpEKhQ3DDgx9fYbqeCpeOEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.21.3.tgz",
+      "integrity": "sha512-wkh0qKZGHXVUDxFw3oA1TXnU2BDYY/r775oJflGeIr8uDPPoN2pk8gijQIzYRT6hoql/lg3+Tx/SaTn9e2/aGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.21.3.tgz",
+      "integrity": "sha512-HbNc23FAQYbuyDV2vBWMez4u4mrsm5RAkniGZAWqr6lYZ3N4beeqIb776jzwRl8qL2zRhHVXpUj97X0QgogVzg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.21.3.tgz",
+      "integrity": "sha512-K6xNsTUPEUdfrn0+kbMq5nOUB5w1C5pavPQngt4TM2FpN91lP0PBe2srSpamb4d69O7h86oAi/qWX/kZNRSjkw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.21.3.tgz",
+      "integrity": "sha512-VcFmOpcpWX1zoEy8M58tR2M9YxM+Z9RuQhqAx5q0CTmrruaP7Gveejg75hzd/5sg5nk9G3aLALEa3hE2FsmmTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.21.3.tgz",
+      "integrity": "sha512-quVoxFLBy43hWaQbbDtQNRwAX5vX76mv7n64icAtQcJ3eNgVeblqmkupF/hAneNthdqSlnd1sTjb3aQSaDPaCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.21.3.tgz",
+      "integrity": "sha512-X0AqNZgcD07Q4V3RDK18/vYOj/HQT/FnmEFGYS2jTWqY7JO13ryE3TEs3eAIgUJhBnNkpEaiXqz3VK8M7qQhWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.21.3.tgz",
+      "integrity": "sha512-YkaQnaKYdbuaXvRt5Qd0GpbihzVnyfR6z1SpYfIUC6RTu4NF7lDKPjVkYb+jRI2gedVO2rVpN35Y6akG6ud4Lw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.21.3.tgz",
+      "integrity": "sha512-gB9HwhrPiFqUzDeEq+y/CgAijz1YdI6BnXz5GaH2Pa9cWdutchlkGFAiAuGb/PjVQpiK6NFKzFuztxrweoit7A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.21.3.tgz",
+      "integrity": "sha512-zjDWBlYk8QGv0H8dsPUWqkfjYIIjG2TvspGkzXL0eImbgxtZorA/klKeHyolevoT3Kvbi+1iMr9Lhrh7jf54Og==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.21.3.tgz",
+      "integrity": "sha512-4UfsQvacV388y1zpXL7C1x1FNYaV52JtuNRiuzrfQA2z1z6ElVrsidkGsrvQ5EgeSq1Pj7kaKqrgGkvFuxJ/tw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.21.3.tgz",
+      "integrity": "sha512-b5uH+HKH0MP5mNBYaK75SKsJbw52URqrx2LavYdq6wb0l3ExAG5niYRP9DWUNHdKilpaBVM2bXk9HNWrH3ew7Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.21.3.tgz",
+      "integrity": "sha512-PjYlmilBpNRh2ntXNYAK3Am5w/nPfEpnU/96iNx7CI8EzAn12J4JRiec63wHJTH31nLoCNxBg/829pN+3CfG3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.21.3.tgz",
+      "integrity": "sha512-QTBAb7JuHlZ7JUEyM8UiQi2f7m/L4swBhP2TNpYIDc9Wp/wRw1G/8sl6i13aIzQAXH7LKIm294LeOHd0lQR8zA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.21.3.tgz",
+      "integrity": "sha512-4j1DFwjwv36ec9kds0jU/ucQ5Ha4ERO/H95BxR5JFf0kqUUAJ1kwII7XhTc1vZrkdJkvLGC9Q2MbpObpum8RBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.21.3.tgz",
+      "integrity": "sha512-i8oluoel5kru/j1WNrjmQSiA3GQ7wvIYVR1IwIoZtKogAhya2iub+ZKIeSIkcJOrnzQ18Tzl/F+kL3fYOxZLvA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.0",
+        "@emnapi/runtime": "1.11.0",
+        "@napi-rs/wasm-runtime": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.21.3.tgz",
+      "integrity": "sha512-M/8dw8dD6aOs+NlPJax401CZB9I7Aut84isQLgALGGwke4Afvw+/7yYhZb94yXf6t2sPLhQLmSmtSV+2FhsOWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.21.3.tgz",
+      "integrity": "sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4746,6 +5446,17 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -8826,6 +9537,16 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^4.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -9375,6 +10096,22 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/formatly": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
+      "integrity": "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fd-package-json": "^2.0.0"
+      },
+      "bin": {
+        "formatly": "bin/index.mjs"
+      },
+      "engines": {
+        "node": ">=18.3.0"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -9581,6 +10318,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/get-uri": {
@@ -10659,6 +11409,16 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
@@ -10883,6 +11643,68 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/knip": {
+      "version": "6.17.1",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.17.1.tgz",
+      "integrity": "sha512-HcQsZSQ4Ymhuay4BVzJtM5pFZNDSomYYqcNCZOSITPQh9g18a09DqziWAxSt2G+BH9wGlG+0ZjWpEnaFlnKseQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/webpro"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/knip"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "formatly": "^0.3.0",
+        "get-tsconfig": "4.14.0",
+        "jiti": "^2.7.0",
+        "oxc-parser": "^0.135.0",
+        "oxc-resolver": "^11.20.0",
+        "picomatch": "^4.0.4",
+        "smol-toml": "^1.6.1",
+        "strip-json-comments": "5.0.3",
+        "tinyglobby": "^0.2.17",
+        "unbash": "^4.0.1",
+        "yaml": "^2.9.0",
+        "zod": "^4.1.11"
+      },
+      "bin": {
+        "knip": "bin/knip.js",
+        "knip-bun": "bin/knip-bun.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/knip/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/knip/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/kuler": {
@@ -11953,6 +12775,75 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.135.0.tgz",
+      "integrity": "sha512-/DaPStu0s2zzNSRRniKyTPM6Z/o+DapOp2JYNKDL8AsgaBGPK2IdZyB87SQjVH+xeQPz+Qr9mrjglfkYgtbVRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.135.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.135.0",
+        "@oxc-parser/binding-android-arm64": "0.135.0",
+        "@oxc-parser/binding-darwin-arm64": "0.135.0",
+        "@oxc-parser/binding-darwin-x64": "0.135.0",
+        "@oxc-parser/binding-freebsd-x64": "0.135.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.135.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.135.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.135.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.135.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.135.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.135.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.135.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.135.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.135.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.135.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.135.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.135.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.135.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.135.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.135.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.21.3.tgz",
+      "integrity": "sha512-2Mx3fKQz7+xgrBONjsxOgCGtMHOn38/HxMzW1I5efwXB5a4lRN0Vp40gYUJFBWJslcrvwoofTrqoTnLbwTd3pA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.21.3",
+        "@oxc-resolver/binding-android-arm64": "11.21.3",
+        "@oxc-resolver/binding-darwin-arm64": "11.21.3",
+        "@oxc-resolver/binding-darwin-x64": "11.21.3",
+        "@oxc-resolver/binding-freebsd-x64": "11.21.3",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.21.3",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.21.3",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.21.3",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.21.3",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-x64-musl": "11.21.3",
+        "@oxc-resolver/binding-openharmony-arm64": "11.21.3",
+        "@oxc-resolver/binding-wasm32-wasi": "11.21.3",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.21.3",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.21.3"
+      }
+    },
     "node_modules/p-defer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
@@ -12971,6 +13862,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -13464,6 +14365,19 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/socks": {
@@ -14051,9 +14965,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14290,6 +15204,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/unbash": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.1.tgz",
+      "integrity": "sha512-1ajSo3813sDoVIHx4inJdUS4l5L2ic5cFiddemPiyjb/PZEoBAhFwHtbaEdRDFxbAKy7FCG7s5ww3/uCFawuIA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/undici": {
@@ -14670,6 +15594,16 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/wcwidth": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "firebase": "^12.9.0",
     "firebase-tools": "15.20.0",
     "happy-dom": "^20.8.9",
+    "knip": "^6.17.1",
     "sharp": "^0.34.5",
     "tsx": "^4.19.0",
     "typescript": "^5.7.3",


### PR DESCRIPTION
Closes #2066

Adds a dead-code / unused-export sensor as a **gated CI check** built on
[knip](https://knip.dev) (the issue's preferred tool — it covers unused files,
exports, types, *and* dependencies in one pass). The check fails a PR when it
introduces *newly* orphaned code, while tolerating the pre-existing backlog via a
documented config allowlist. Part of epic #2061 (code-quality decay sensors).

## How it works

knip has no native baseline feature, so its own config (`entry` / `ignore` /
`ignoreDependencies` / `@public` JSDoc tags) *is* the baseline. A whole-repo run
is clean today; a *newly* orphaned export is not in the allowlist, so knip
reports it and CI fails — **including cross-file orphans** (a PR that removes the
last consumer of an export in an unchanged file is caught, because that export
was not previously dead). The run is whole-repo (not diff-scoped) precisely so
that canonical cross-file case is covered, since knip computes cross-workspace
reachability.

The sensor is **advisory/blocking, never auto-deleting**: the flagged set
includes harness-invoked scripts and seed files, so automatic removal would be
unsafe. Auto-fix / `/review-fix` integration is intentionally out of scope (a
possible future enhancement once the config proves stable).

## Unit 1 — knip + curated config

- Adds `knip` to root `devDependencies`.
- Adds a root **`knip.jsonc`** (JSONC so every allowlist entry carries a one-line
  `//` justification — the AC's "documented allowlist"):
  - **Tree-ignores** `.claude/**` (harness-invoked Workflow/skill scripts —
    deleting e.g. `review-fix.js` would break the harness) and
    `scaffolding/firebase/templates/**` (copied, never imported).
  - **Per-workspace `entry` overrides** for tooling that has no static importer
    but is invoked by a runner/harness: `seeds/**`, `e2e/**`, `scripts/**`,
    `bin/**`. `entry` (not `ignore`) is used so the utilities these files consume
    stay "used" rather than being blinded.
  - **CSS-imported deps** (`@commons-systems/style`, `@commons-systems/ds`) are
    allowlisted per-name — knip 6 doesn't trace bare CSS `@import` into
    `node_modules`.
  - **Genuine residual dead code** is *baselined, not deleted* (some "unused"
    exports are intentional public API). Encoded via narrow per-export `@public`
    JSDoc tags (12, all on `budget/src` sources) plus per-name dep entries — each
    documented. Every allowlist entry is narrow enough that a brand-new orphan of
    the same kind still fires.

Each suppression was checked against the live `npx knip` output of the installed
version, and the genuinely-unused deps (`d3-scale*`, `@google-cloud/secret-manager`,
and a few `@commons-systems/*`) were grep-verified individually before being
baselined as deletion candidates rather than removed in this PR.

## Unit 2 — gated CI job

- **`run-dead-code.sh`** — runs `npx knip --max-issues 0` **once at repo root**
  (cross-workspace reachability requires a single whole-repo run, unlike
  `run-lint.sh`'s per-workspace loop). Installs root deps via `ensure_deps`.
- **`detect-changes.sh`** — adds a broad `deadcode=true` gate on any TS/JS or
  knip-config change (any such change anywhere can orphan code elsewhere, so the
  whole-repo run must trigger).
- **`unit-tests.yml`** — adds a `dead-code` job mirroring the `lint` job
  (checkout `fetch-depth: 0`, detect-changes, gated `setup-node`, gated runner).

## Verification

- **Clean baseline:** `npx knip` exits 0 on the branch.
- **Catches a new orphan:** a deliberately-unused `export const __probe = 1`
  added to a tracked source was flagged by name (exit 1); removed → exit 0.
- **Catches a cross-file orphan:** deleting the sole consumer of an existing
  export made knip flag it in its *unchanged* defining file (exit 1); reverted.
- **Gate:** `detect-changes.sh` emits `deadcode=true` for `.ts`/`.tsx`/knip-config
  changes and omits it for docs-only diffs.
- **CI job:** `run-dead-code.sh` exits 0 locally; the `dead-code` job mirrors the
  `lint` job's structure with the same pinned action SHAs.

## Follow-up (not this PR)

The baselined residual is deletion-candidate work for a future ratchet: the 12
`@public`-tagged `budget` exports (`parseFirestore*`, `renderLoadError`) and the
genuinely-unused deps. Shrinking the allowlist is follow-up, not this PR's scope.
