### PR TITLE
dispatch-token-audit: add per-model-actual cost_usd alongside the Opus-list proxy

### DIFF
--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -5,7 +5,12 @@ description: Audit recent dispatch session transcripts and emit a ranked report 
 
 # Dispatch Token Audit
 
-This skill parses recent Claude session transcripts and emits a ranked report of token-reduction opportunities. It is report-only: it does not create issues or modify the dispatch workflow — the user decides what to act on from the report. All magnitude figures are an **Opus-list-price-equivalent USD proxy** applied uniformly across every session regardless of its actual model. The proxy ranks opportunities by relative magnitude; it is not the actual bill.
+This skill parses recent Claude session transcripts and emits a ranked report of token-reduction opportunities. It is report-only: it does not create issues or modify the dispatch workflow — the user decides what to act on from the report. Two cost figures appear in the output:
+
+- **`price_proxy_usd`** — a uniform Opus-list-price rate applied to every token regardless of the actual model. Holding price constant isolates token count, so this figure ranks opportunities by relative magnitude. It is **not** the actual bill.
+- **`cost_usd`** — the truthful per-model bill. Each model is priced at its real rate (Sonnet, Haiku, or Opus), so this figure measures real dollars and shows the actual savings from model-routing decisions.
+
+Ranking (step 5) stays on `price_proxy_usd`. `cost_usd` is reported alongside it to show the real bill.
 
 1. **Parse the window argument.** The skill accepts an optional argument of the form `Nd` (e.g. `2d`, `14d`). Parse it as follows:
    - If `ARGUMENTS` matches `^[0-9]+d$`, strip the trailing `d` and use that integer as `N`.
@@ -62,6 +67,15 @@ This skill parses recent Claude session transcripts and emits a ranked report of
    # Tool-result payload byte totals — worst offenders by tool and session
    jq '.payload_bytes | {total, by_tool:(.by_tool[0:15]), worst_sessions}' tmp/usage-audit.json
 
+   # Real per-model actual cost vs proxy
+   jq '.by_model | to_entries | map({model:.key, cost_usd:.value.cost_usd, proxy:.value.price_proxy_usd})' tmp/usage-audit.json
+
+   # Per-phase actual cost vs proxy
+   jq '.by_phase | to_entries | map({phase:.key, cost_usd:.value.cost_usd, proxy:.value.price_proxy_usd})' tmp/usage-audit.json
+
+   # Actual rate table
+   jq '.price_model.actual_rates_per_mtok' tmp/usage-audit.json
+
    # Context and small-session lenses
    jq '.lenses' tmp/usage-audit.json
 
@@ -96,7 +110,8 @@ This skill parses recent Claude session transcripts and emits a ranked report of
 
 6. **Emit the ranked markdown report.** Structure it as follows:
 
-   - **Header**: window (e.g. "Last 7 days"), date range (`since`/`until`), total sessions, total turns, total proxy spend in USD. Include the proxy caveat: "Magnitudes are an Opus-list-price-equivalent USD proxy — a relative-magnitude figure for ranking, not the actual bill." Note `files_failed` if nonzero.
+   - **Header**: window (e.g. "Last 7 days"), date range (`since`/`until`), total sessions, total turns, total proxy spend in USD, and total actual cost in USD. Include the proxy caveat: "Magnitudes are an Opus-list-price-equivalent USD proxy — a relative-magnitude figure for ranking, not the actual bill; see `cost_usd` for the real bill."
+   - **Real cost breakdown**: a subsection showing per-model and per-phase `cost_usd` alongside `price_proxy_usd`. Include the AC#3 comparison explicitly: a Sonnet or Haiku phase costs materially less in `cost_usd` than an equivalent-token Opus phase — this gap is the model-routing savings that the uniform proxy erases. Label clearly: proxy = relative-magnitude ranking lens; cost_usd = truthful bill. Note `files_failed` if nonzero.
    - **Ranked opportunities**: a numbered list, highest proxy magnitude first. Each entry includes:
      - The lens name and number.
      - The measured price-proxy magnitude (USD proxy) as the lead figure.

--- a/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
@@ -373,6 +373,32 @@ def price(u):
   + (u.cache_read     // 0) * RATE_CACHE_READ
   + (u.output         // 0) * RATE_OUTPUT ) / 1e6;
 
+# --- Truthful per-model cost (#2027) -------------------------------------
+# Actual list rates per Mtok, keyed by model family. Unlike the proxy above,
+# this prices each session by its REAL model so cost_usd is the actual bill.
+def ACTUAL_RATES:
+  { opus:   {input:5, cache_creation:6.25, cache_read:0.50, output:25},
+    sonnet: {input:3, cache_creation:3.75, cache_read:0.30, output:15},
+    haiku:  {input:1, cache_creation:1.25, cache_read:0.10, output:5} };
+def family($m):
+  if   ($m | startswith("claude-opus"))   then "opus"
+  elif ($m | startswith("claude-sonnet")) then "sonnet"
+  elif ($m | startswith("claude-haiku"))  then "haiku"
+  else null end;
+def cost(u; $model):
+  family($model) as $fam
+  | ((u.input//0)+(u.cache_creation//0)+(u.cache_read//0)+(u.output//0)) as $tok
+  | if $fam == null then
+      (if $tok == 0 then 0
+       else error("dispatch-token-audit: unpriceable model '\($model)' carries \($tok) tokens; add it to the price table") end)
+    else (ACTUAL_RATES[$fam]) as $r
+      | ( (u.input//0)*$r.input + (u.cache_creation//0)*$r.cache_creation
+        + (u.cache_read//0)*$r.cache_read + (u.output//0)*$r.output ) / 1e6
+    end;
+def session_cost($r):
+  reduce ($r.by_skill_model | to_entries[]) as $e (0;
+    . + cost($e.value.usage; ($e.key | split("\t")[1])));
+
 def zero_usage: {input:0, cache_creation:0, cache_read:0, output:0};
 def add_usage(a; b):
   {
@@ -382,13 +408,14 @@ def add_usage(a; b):
     output:         ((a.output         // 0) + (b.output         // 0))
   };
 
-# A flat bucket record {input,cache_creation,cache_read,output,turns,price_proxy_usd}
-def zero_bucket: {input:0, cache_creation:0, cache_read:0, output:0, turns:0, price_proxy_usd:0};
+# A flat bucket record {input,cache_creation,cache_read,output,turns,price_proxy_usd,cost_usd}
+def zero_bucket: {input:0, cache_creation:0, cache_read:0, output:0, turns:0, price_proxy_usd:0, cost_usd:0};
 def add_to_bucket(bucket; u; turns):
   ( add_usage(bucket; u) ) as $nu
   | $nu + {
       turns: ((bucket.turns // 0) + turns),
-      price_proxy_usd: price($nu)
+      price_proxy_usd: price($nu),
+      cost_usd: (bucket.cost_usd // 0)
     };
 
 # Consecutive n-grams of a token list as arrays. range upper bound goes negative
@@ -419,7 +446,8 @@ def outcome_rates($o):
 | ( $tot_usage + {
       sessions: ($rows | length),
       turns: ([ $rows[].turns ] | add // 0),
-      price_proxy_usd: price($tot_usage)
+      price_proxy_usd: price($tot_usage),
+      cost_usd: ([ $rows[] | session_cost(.) ] | add // 0)
     } ) as $totals
 
 # ---- by_session_type (all five buckets always present) ----
@@ -431,6 +459,7 @@ def outcome_rates($o):
     # add sessions count per type
     | reduce $rows[] as $r (.; .[$r.type].sessions = ((.[$r.type].sessions // 0) + 1))
     | reduce (to_entries[] | select(.value.sessions == null)) as $e (.; .[$e.key].sessions = 0)
+    | reduce $rows[] as $r (.; .[$r.type].cost_usd = ((.[$r.type].cost_usd // 0) + session_cost($r)))
   ) as $by_session_type
 
 # ---- by_phase (seven named phases always present) + by_phase_model ----
@@ -445,9 +474,16 @@ def outcome_rates($o):
         .[$e.key] = add_to_bucket((.[$e.key] // zero_bucket); $e.value.usage; $e.value.turns)
       )
     ) ) as $by_phase
+| ( reduce $rows[] as $r ($by_phase;
+      reduce ($r.by_skill_model | to_entries[]) as $e (.;
+        ($e.key | split("\t")) as $k
+        | .[$k[0]] = ((.[$k[0]] // zero_bucket) | .cost_usd += cost($e.value.usage; $k[1]))
+      )
+    ) ) as $by_phase
 | ( reduce $rows[] as $r ({};
       reduce ($r.by_skill_model | to_entries[]) as $e (.;
-        .[$e.key] = add_to_bucket((.[$e.key] // zero_bucket); $e.value.usage; $e.value.turns)
+        .[$e.key] = ( add_to_bucket((.[$e.key] // zero_bucket); $e.value.usage; $e.value.turns)
+                      | .cost_usd += cost($e.value.usage; ($e.key | split("\t")[1])) )
       )
     ) ) as $by_phase_model
 
@@ -455,7 +491,8 @@ def outcome_rates($o):
 | ( reduce $rows[] as $r ({};
       reduce ($r.by_skill_model | to_entries[]) as $e (.;
         ($e.key | split("\t")[1]) as $model
-        | .[$model] = add_to_bucket((.[$model] // zero_bucket); $e.value.usage; $e.value.turns)
+        | .[$model] = ( add_to_bucket((.[$model] // zero_bucket); $e.value.usage; $e.value.turns)
+                        | .cost_usd += cost($e.value.usage; $model) )
       )
     ) ) as $by_model
 
@@ -569,6 +606,7 @@ def outcome_rates($o):
         input: .usage.input, cache_creation: .usage.cache_creation,
         cache_read: .usage.cache_read, output: .usage.output,
         price_proxy_usd: price(.usage),
+        cost_usd: session_cost(.),
         phases: ( reduce (.by_skill | to_entries[]) as $e ({}; .[$e.key] = price($e.value.usage)) ),
         outcome: .outcome,
         outcome_rates: ( if .outcome == null then null else outcome_rates(.outcome) end )
@@ -619,11 +657,12 @@ def outcome_rates($o):
 | {
     window: $win,
     price_model: {
-      note: "Opus list-price-equivalent USD proxy; relative magnitude, not the bill",
+      note: "price_proxy_usd is an Opus-list-price-equivalent USD proxy for RANKING (uniform rate, not the bill); cost_usd is the truthful per-model bill from actual_rates_per_mtok",
       input_per_mtok: RATE_INPUT,
       cache_creation_per_mtok: RATE_CACHE_CREATION,
       cache_read_per_mtok: RATE_CACHE_READ,
-      output_per_mtok: RATE_OUTPUT
+      output_per_mtok: RATE_OUTPUT,
+      actual_rates_per_mtok: ACTUAL_RATES
     },
     totals: $totals,
     by_session_type: $by_session_type,

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -716,5 +716,49 @@ assert_eq "synth: sessions[sess-synth].cost_usd == 0" "0" \
 
 rm -rf "$SYNTH_ROOT"
 
+# ---------------------------------------------------------------------------
+# Haiku per-model cost (#2027). ISOLATED fixture: a worker session whose
+# assistant message carries a real `claude-haiku-*` model with distinct nonzero
+# usage in ALL FOUR components. This is the ONLY coverage of family()'s
+# `startswith("claude-haiku")` branch and the ACTUAL_RATES.haiku row — without
+# it a haiku rate transposition or a startswith match error would pass CI
+# silently. Distinct counts (1000/2000/4000/500) make a rate swap between any
+# two haiku components visible; the expected value uses the full four-term
+# formula at haiku rates (1 / 1.25 / 0.10 / 5 per Mtok). Its own root so the
+# shared setup() totals/price/session-count assertions stay untouched.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- haiku per-model cost (#2027) ---"
+
+HAIKU_ROOT=$(mktemp -d)
+trap 'rm -rf "$HAIKU_ROOT" "$FAKE_WRITER_DIR"; teardown' EXIT INT TERM
+haiku_worktree="$HAIKU_ROOT/-home-x-worktrees-2027-haiku"
+mkdir -p "$haiku_worktree"
+haiku_jsonl="$haiku_worktree/sess-haiku.jsonl"
+
+# line 1: first user line — classifies as worker
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+  >> "$haiku_jsonl"
+# line 2: assistant — claude-haiku-4-5, distinct nonzero usage in all four components
+printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2027-haiku","message":{"model":"claude-haiku-4-5","usage":{"input_tokens":1000,"cache_creation_input_tokens":2000,"cache_read_input_tokens":4000,"output_tokens":500}}}' \
+  >> "$haiku_jsonl"
+jq . "$haiku_jsonl" >/dev/null
+touch "$haiku_jsonl"
+
+OUT_HAIKU=$(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$HAIKU_ROOT"
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7
+)
+
+# Haiku rates: input 1 / cache_creation 1.25 / cache_read 0.10 / output 5 per Mtok.
+EXPECTED_HAIKU_COST=$(jq -n '(1000*1 + 2000*1.25 + 4000*0.10 + 500*5)/1e6')
+assert_eq "sessions[sess-haiku].cost_usd (haiku)" "$EXPECTED_HAIKU_COST" \
+  "$(jq '[.sessions[]|select(.id=="sess-haiku")][0].cost_usd' <<<"$OUT_HAIKU")"
+assert_eq 'by_model["claude-haiku-4-5"].cost_usd (haiku)' "$EXPECTED_HAIKU_COST" \
+  "$(jq '.by_model["claude-haiku-4-5"].cost_usd' <<<"$OUT_HAIKU")"
+
+rm -rf "$HAIKU_ROOT"
+
 report_results
 exit $FAIL

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -263,6 +263,50 @@ assert_eq "totals.cache_read" "134444" "$(jq '.totals.cache_read' <<<"$OUT")"
 assert_eq "totals.output" "556" "$(jq '.totals.output' <<<"$OUT")"
 assert_eq "totals.price_proxy_usd" "$EXPECTED_PRICE" "$(jq '.totals.price_proxy_usd' <<<"$OUT")"
 
+# --- truthful per-model cost_usd (#2027) ------------------------------------
+# cost_usd prices each session by its REAL model family (opus/sonnet/haiku),
+# unlike the uniform Opus-rate price_proxy_usd. Single-component buckets are one
+# /1e6 division (exact); multi-component buckets sum the per-component terms.
+#
+# Worker (sess-worker): plan-implement / opus, summed usage
+# (input=1100, cache_creation=2200, cache_read=4400, output=550) at opus rates
+# (5 / 6.25 / 0.50 / 25 per Mtok).
+EXPECTED_WORKER_COST=$(jq -n '(1100*5 + 2200*6.25 + 4400*0.50 + 550*25)/1e6')
+assert_eq "sessions[sess-worker].cost_usd" "$EXPECTED_WORKER_COST" \
+  "$(jq '[.sessions[]|select(.id=="sess-worker")][0].cost_usd' <<<"$OUT")"
+assert_eq 'by_phase["plan-implement"].cost_usd' "$EXPECTED_WORKER_COST" \
+  "$(jq '.by_phase["plan-implement"].cost_usd' <<<"$OUT")"
+assert_eq 'by_phase_model["plan-implement\tclaude-opus-4-8"].cost_usd' "$EXPECTED_WORKER_COST" \
+  "$(jq '.by_phase_model["plan-implement\tclaude-opus-4-8"].cost_usd' <<<"$OUT")"
+
+# agent-aaa: sonnet (skill <none>), usage (10,20,40,5) at sonnet rates
+# (3 / 3.75 / 0.30 / 15 per Mtok).
+EXPECTED_AAA_COST=$(jq -n '(10*3 + 20*3.75 + 40*0.30 + 5*15)/1e6')
+assert_eq "sessions[agent-aaa].cost_usd (sonnet)" "$EXPECTED_AAA_COST" \
+  "$(jq '[.sessions[]|select(.id=="agent-aaa")][0].cost_usd' <<<"$OUT")"
+
+# by_model["claude-sonnet-4-6"] is CROSS-SESSION (agent-aaa + agent-bbb) → SUM
+# the per-component terms: aaa (10,20,40,5) + bbb cache_read=130000.
+EXPECTED_SONNET_MODEL_COST=$(jq -n '(10*3 + 20*3.75 + 40*0.30 + 5*15)/1e6 + (130000*0.30)/1e6')
+assert_eq 'by_model["claude-sonnet-4-6"].cost_usd' "$EXPECTED_SONNET_MODEL_COST" \
+  "$(jq '.by_model["claude-sonnet-4-6"].cost_usd' <<<"$OUT")"
+
+# AC#3: the same token count costs materially less at Sonnet rates than at Opus
+# rates. agent-bbb's review-fix usage is pure cache_read=130000; at sonnet's
+# 0.30/Mtok it is 0.039, strictly less than opus' 0.50/Mtok (0.065).
+SONNET_BBB=$(jq -n '(130000*0.30)/1e6')   # 0.039
+OPUS_SAME=$(jq -n '(130000*0.50)/1e6')    # 0.065
+assert_eq "AC#3: sonnet review-fix cost < same tokens at opus" "true" \
+  "$(jq --argjson s "$SONNET_BBB" --argjson o "$OPUS_SAME" \
+     '.by_phase_model["review-fix\tclaude-sonnet-4-6"].cost_usd == $s and $s < $o' <<<"$OUT")"
+
+# price_model: the four uniform proxy keys (writer contract) survive unchanged,
+# and the new per-family actual_rates_per_mtok table is present.
+assert_eq "price_model.input_per_mtok (proxy unchanged)" "15" \
+  "$(jq '.price_model.input_per_mtok' <<<"$OUT")"
+assert_eq "price_model.actual_rates_per_mtok.opus.output" "25" \
+  "$(jq '.price_model.actual_rates_per_mtok.opus.output' <<<"$OUT")"
+
 assert_eq "by_session_type.worker.sessions" "1" \
   "$(jq '.by_session_type.worker.sessions' <<<"$OUT")"
 assert_eq "by_session_type.subagent.sessions" "2" \
@@ -592,6 +636,85 @@ assert_eq "partial-envelope by_phase_outcome is empty {} (no fabricated entry)" 
   "$(jq -c '.by_phase_outcome' <<<"$OUT_PARTIAL")"
 
 rm -rf "$PARTIAL_ROOT"
+
+# ---------------------------------------------------------------------------
+# Unpriceable-model cost guard (#2027). ISOLATED fixture: a fresh projects root
+# with ONE worker session whose assistant message carries a model in NO known
+# family (not opus/sonnet/haiku) and NONZERO usage. cost()'s family==null branch
+# raises a stage-2 `error()` (the stage-2 jq call has no 2>/dev/null), which
+# aborts the WHOLE script with a non-zero exit. Stage-1 failures are swallowed
+# (2>/dev/null + tallied in files_failed) and `jq -s` over empty is [], so the
+# stage-2 error() is the SOLE non-zero exit path here — making rc!=0 a reliable
+# signal that the unpriceable-model guard fired.
+#
+# Built in its own mktemp root (a nonzero-unpriceable session anywhere aborts ALL
+# of stage-2, so it cannot share any other root). rc is captured with the P1/P3
+# subshell idiom, NOT a bare `$(...)` — under `set -e` a failing command
+# substitution would abort the whole suite before the assert runs.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- unpriceable-model cost guard (#2027) ---"
+
+GUARD_ROOT=$(mktemp -d)
+trap 'rm -rf "$GUARD_ROOT" "$FAKE_WRITER_DIR"; teardown' EXIT INT TERM
+guard_worktree="$GUARD_ROOT/-home-x-worktrees-2027-guard"
+mkdir -p "$guard_worktree"
+guard_jsonl="$guard_worktree/sess-guard.jsonl"
+
+# line 1: first user line — classifies as worker
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+  >> "$guard_jsonl"
+# line 2: assistant — UNPRICEABLE model "gpt-fake-9" with NONZERO usage
+printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2027-guard","message":{"model":"gpt-fake-9","usage":{"input_tokens":1000,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0}}}' \
+  >> "$guard_jsonl"
+jq . "$guard_jsonl" >/dev/null
+touch "$guard_jsonl"
+
+if (
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$GUARD_ROOT"
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7 >/dev/null 2>&1
+); then rc_guard=0; else rc_guard=$?; fi
+assert_eq "guard: unpriceable model + nonzero usage aborts (rc!=0)" "1" \
+  "$([[ "$rc_guard" -ne 0 ]] && echo 1 || echo 0)"
+
+rm -rf "$GUARD_ROOT"
+
+# ---------------------------------------------------------------------------
+# Zero-usage unclassifiable component does NOT abort (#2027). ISOLATED fixture:
+# a worker session whose assistant message carries an unclassifiable model
+# `<synthetic>` (family==null) but ALL-ZERO usage. cost()'s tok==0 branch returns
+# 0 instead of erroring, so the script succeeds (rc==0) and the session's
+# cost_usd is exactly 0. Its own root (the abort branch above would poison a
+# shared root).
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- zero-usage unclassifiable component does not abort (#2027) ---"
+
+SYNTH_ROOT=$(mktemp -d)
+trap 'rm -rf "$SYNTH_ROOT" "$FAKE_WRITER_DIR"; teardown' EXIT INT TERM
+synth_worktree="$SYNTH_ROOT/-home-x-worktrees-2027-synth"
+mkdir -p "$synth_worktree"
+synth_jsonl="$synth_worktree/sess-synth.jsonl"
+
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+  >> "$synth_jsonl"
+# assistant — unclassifiable "<synthetic>" model, ALL-ZERO usage → cost 0, no abort
+printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2027-synth","message":{"model":"<synthetic>","usage":{"input_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0}}}' \
+  >> "$synth_jsonl"
+jq . "$synth_jsonl" >/dev/null
+touch "$synth_jsonl"
+
+if (
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$SYNTH_ROOT"
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7 >"$SYNTH_ROOT/out.json" 2>/dev/null
+); then rc_synth=0; else rc_synth=$?; fi
+assert_eq "synth: zero-usage unclassifiable model does not abort (rc==0)" "0" "$rc_synth"
+assert_eq "synth: sessions[sess-synth].cost_usd == 0" "0" \
+  "$(jq '[.sessions[]|select(.id=="sess-synth")][0].cost_usd' <"$SYNTH_ROOT/out.json")"
+
+rm -rf "$SYNTH_ROOT"
 
 report_results
 exit $FAIL


### PR DESCRIPTION
Closes #2027

## What

`/dispatch-token-audit`'s `aggregate-usage.sh` priced every session with a
**uniform Opus-list-price USD proxy** (`price_proxy_usd`) regardless of the
session's actual model. That proxy is correct for *ranking* token-reduction
opportunities — it holds price constant to isolate token count — but it cannot
compare real dollar cost across models: a Sonnet phase and an Opus phase price
identically, erasing exactly the savings the chain's model routing
(`dispatch-phase-model`) exists to capture.

This PR **adds** a truthful per-model-actual dollar cost (`cost_usd`)
**alongside** the existing `price_proxy_usd`. The change is additive — the proxy
stays byte-identical (it remains the ranking lens, and the existing tests assert
its exact values); `cost_usd` is the new truthful bill.

## How

- **Pricing core (`aggregate-usage.sh` stage-2).** New `ACTUAL_RATES`,
  `family($m)`, `cost(u;$model)`, and `session_cost($r)` defs price each
  `(skill, model)` component of the per-session `by_skill_model` partition at its
  real per-MTok rate (opus 5/6.25/0.50/25, sonnet 3/3.75/0.30/15, haiku
  1/1.25/0.10/5). Family is resolved by **prefix match** because real model IDs
  carry date suffixes (`claude-haiku-4-5-20251001`). `price()` and
  `price_proxy_usd` are reused unchanged, so the proxy is provably identical.
- **`cost_usd` threaded into** `totals`, `by_session_type`, `by_phase`,
  `by_phase_model`, `by_model`, and per-session `sessions[]`. Cost is accumulated
  as a **separate** pass over `by_skill_model` (a bucket's lumped usage is
  model-blind, so cost cannot be re-derived from it); `add_to_bucket` passes
  `cost_usd` through.
- **`price_model` output** keeps its four writer-required `*_per_mtok` proxy keys
  and gains an `actual_rates_per_mtok` sibling plus a clarified `note`.
- **Fail-closed guard.** An unpriceable model raises a clear `error()` **only when
  it carries nonzero usage**; a zero-usage unclassifiable component (the only one
  in real transcripts is `<synthetic>`) contributes \$0 and does not abort.
- **Tests** (`test-aggregate-usage.sh`): single-component exact-cost assertions,
  the multi-component `by_model` sonnet sum, an AC#3 inequality (a Sonnet phase
  costs materially less than the same tokens at Opus rates), `price_model`
  assertions (proxy keys survive, new rate table present), and an isolated-root
  guard test proving an unpriceable nonzero-usage model aborts while a
  zero-usage `<synthetic>` component contributes \$0. All existing proxy/outcome/
  payload assertions are untouched — that is the proof the proxy is byte-identical.
- **SKILL.md** documents the proxy-vs-bill distinction, adds per-model/per-phase
  `cost_usd`-vs-proxy slices and the actual-rate table, and a report section
  including the AC#3 comparison. Ranking stays sorted on `price_proxy_usd`;
  `cost_usd` is reported, not a re-sort key.

## Verification

- `test-aggregate-usage.sh`: **83/83 passed** (72 prior + 11 new).
- Live run (`--days 2`) exits 0 with valid JSON; spot-check confirms real
  per-model `cost_usd` (`<synthetic>` = \$0, no `unpriceable model` error) and a
  Sonnet:Opus actual-cost ratio well below the uniform-proxy ratio.
- Out-of-scope downstream (`audit-aggregate-writer.mjs`, office-hours app) is
  untouched — extra `cost_usd` fields are ignored by design.
