### PR TITLE
dispatch: port reference.md Tables A/B as offline target-workers assertions

### DIFF
--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -463,7 +463,9 @@ or a malformed `now`), `dispatch-target-workers` prints `1` and writes a
 one-line note to stderr — the chain degrades to "spawn one per tick". When only
 `five_hour` is absent while `seven_day` is present, Stages 1–3 run with
 `used_5h` treated as 0 — gate-open → max workers. Non-numeric `used_*` values
-are treated as missing (fail-closed). The stdout contract — a single integer —
+are handled asymmetrically: non-numeric `used_weekly` is treated as missing
+(fail-closed → N=1); non-numeric `used_5h` is treated as 0 (fail-open →
+weekly-bounded max workers). The stdout contract — a single integer —
 and the router gate `LIVE_COUNT >= TARGET_N` are unchanged.
 
 ## The #725 cap-keyed re-seed

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -14113,6 +14113,118 @@ else
 fi
 tw_teardown
 
+# --- #2043: reference.md Table A / Table B literal ports ---------------------
+#
+# reference.md's "Concurrency budgeting" section documents the controller's
+# input→output contract as two literal tables. These ports assert the exact
+# target_N each table row claims, so a regression in dispatch-target-workers
+# that diverges from the documented tables fails CI — the tables and the
+# implementation are kept in lockstep (issue #2043 AC). The numbers below are
+# transcribed from reference.md; if the script changes, these assertions catch
+# the divergence. (A reviewer changing the table without the script — a
+# doc-only edit — is caught in review, not here; coupling the test to the
+# markdown file's prose formatting was rejected as brittle.)
+#
+# Both tables use the script's baked-in defaults (max_workers=8, floor5=50,
+# ceil5=80, weekly defaults), which tw_setup's empty synthetic DISPATCH_CONFIG_DIR
+# selects.
+
+# Table A — weekly curve vs. elapsed (used_weekly=0, used_5h=0). With
+# used_weekly=0 the weekly gate is open at every x (hw = W - 0 > 0), and
+# used_5h=0 <= floor5 puts the 5h ramp at max, so target_N=8 across the whole
+# week. This is the whole-week "all gates open, full headroom → max" smoke.
+echo "Test: #2043 reference.md Table A — used_weekly=0,used_5h=0 → target_N=8 at every x"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+# reference.md Table A rows: elapsed x → target_N (all 8). The ~1.0 row uses
+# tw_resets_for_x 1.0 (remaining=1s) so Stage 1 does not take the remaining<=0
+# early-exit.
+for x in 0.00 0.25 0.50 0.75 0.90 1.0; do
+  r=$(tw_resets_for_x "$x")
+  write_rl "tableA.json" 0 "$r" 0 99999999
+  out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+  assert_eq "Table A x=$x (used_weekly=0,used_5h=0) → target_N=8" "8" "$out"
+done
+tw_teardown
+
+# Table B — binary gate + 5h ramp at mid-week (x=0.5, W=65.95). The open-gate
+# rows hold used_weekly=20 (hw=45.95>0) and sweep used_5h; the closed-gate rows
+# hold used_5h=0 and push used_weekly at/over W.
+echo "Test: #2043 reference.md Table B — mid-week gate + 5h ramp rows"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+r=$(tw_resets_for_x 0.5)
+# reference.md Table B open-gate rows: used_5h → target_N (used_weekly=20).
+declare -A tableB=([50]=8 [55]=7 [60]=5 [65]=4 [70]=3 [75]=1 [80]=0)
+for u5 in 50 55 60 65 70 75 80; do
+  write_rl "tableB.json" 20 "$r" "$u5" 99999999
+  out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+  assert_eq "Table B open gate used_weekly=20 used_5h=$u5 → target_N=${tableB[$u5]}" \
+    "${tableB[$u5]}" "$out"
+done
+unset tableB
+# reference.md Table B closed-gate rows: used_weekly at/over W=65.95 → 0.
+write_rl "tableB.json" 66 "$r" 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "Table B closed gate used_weekly=66 (at/over pace) → target_N=0" "0" "$out"
+write_rl "tableB.json" 70 "$r" 0 99999999
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "Table B closed gate used_weekly=70 (over pace) → target_N=0" "0" "$out"
+tw_teardown
+
+# --- #2043: non-numeric used_5h is sanitized → fail-OPEN (not fail-closed) ---
+#
+# Closes the gap left by Test 17 (which covers non-numeric used_weekly →
+# fail-CLOSED to 1). The two used_* fields have OPPOSITE fallback semantics by
+# design: used_weekly is the budget gate (missing → drop the weekly anchor →
+# fallback 1), but used_5h is only the anti-burst ramp WITHIN the weekly budget
+# (missing → treated as 0 → full 5h headroom → the WEEKLY-allowed count). So a
+# non-numeric used_5h must NOT back off to zero; under an open weekly gate it
+# yields max workers. (reference.md's "non-numeric used_* → fail-closed" wording
+# is imprecise — only used_weekly fails closed; this test pins the actual,
+# intended fail-open behavior for used_5h.)
+echo "Test: #2043 non-numeric used_5h sanitized → fail-open (weekly-bounded), not 0"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+r=$(tw_resets_for_x 0.5)
+# used_weekly=20 → gate open at x=0.5 (hw=45.95>0). used_5h="abc" → sanitized to
+# missing → treated as 0 → ramp gives max workers = 8.
+write_rl "rl.json" 20 "$r" 0 99999999
+export DISPATCH_TARGET_WORKERS_USED_5H=abc
+out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>"$TMPDIR_TEST/stderr")
+assert_eq "non-numeric used_5h → fail-open max workers N=8 (not 0)" "8" "$out"
+err=$(cat "$TMPDIR_TEST/stderr")
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"non-numeric value"* && "$err" == *"FIVEH_USED"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: non-numeric used_5h stderr names FIVEH_USED"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: non-numeric used_5h stderr names FIVEH_USED"
+  echo "    stderr: $err"
+fi
+tw_teardown
+
+# --- #2043: --reopen-at none from a transient 5h fill (pace not the blocker) -
+#
+# The AC enumerates the reopen `none` no-op cases as "(target already >= 1,
+# transient 5h fill, missing weekly anchor)". The under-pace and missing-anchor
+# cases are covered above; this covers the transient-5h-fill case: the weekly
+# gate is OPEN (used_weekly under pace) but count mode returns 0 because used_5h
+# is at/over ceil5. Since hw>0 the pace curve is NOT the blocker, so reopen must
+# report `none` (the 0 comes from the 5h fill, which drains on its own and is
+# handled elsewhere — not a pace-curve pause with a curve crossing).
+echo "Test: #2043 --reopen-at transient 5h fill (gate open, count 0) → none"
+tw_setup
+export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
+r=$(tw_resets_for_x 0.5)
+# used_weekly=20 → under pace at x=0.5 (W=65.95, hw=45.95>0 → gate open).
+# used_5h=85 >= ceil5=80 → count mode N=0. reopen: hw>0 → none.
+write_rl "reopen5h.json" 20 "$r" 85 99999999
+cnt=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>/dev/null)
+assert_eq "transient 5h fill: count mode N=0 (gate open, used_5h>=ceil5)" "0" "$cnt"
+rop=$("$TMPDIR_TEST/scripts/dispatch-target-workers" --reopen-at 2>/dev/null)
+assert_eq "transient 5h fill: --reopen-at → none (pace not the blocker)" "none" "$rop"
+tw_teardown
+
 # ============================================================================
 # dispatch-schedule-reseed tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -14189,7 +14189,7 @@ export DISPATCH_TARGET_WORKERS_NOW="$TW_NOW"
 r=$(tw_resets_for_x 0.5)
 # used_weekly=20 → gate open at x=0.5 (hw=45.95>0). used_5h="abc" → sanitized to
 # missing → treated as 0 → ramp gives max workers = 8.
-write_rl "rl.json" 20 "$r" 0 99999999
+write_rl "rl.json" 20 "$r" 0 99999999  # JSON used_5h=0 is overridden below by DISPATCH_TARGET_WORKERS_USED_5H=abc (per-field env override) — the env var is what exercises this path
 export DISPATCH_TARGET_WORKERS_USED_5H=abc
 out=$("$TMPDIR_TEST/scripts/dispatch-target-workers" 2>"$TMPDIR_TEST/stderr")
 assert_eq "non-numeric used_5h → fail-open max workers N=8 (not 0)" "8" "$out"


### PR DESCRIPTION
Closes #2043

## Summary

`dispatch-target-workers` (the fleet's weekly/5h budget controller) already had
extensive offline coverage in `test-dispatch-scripts.sh` — the weekly pace curve
`W`, the binary weekly gate, the linear 5h ramp, the dynamic catch-up ceiling,
the missing-telemetry fallbacks, `--exhausted`, `--reopen-at`, and the #1136
range bounds. This PR closes the residual gaps named by #2043's acceptance
criteria, reusing the existing no-network, PATH-shim harness (`tw_setup` /
`write_rl` / `tw_resets_for_x`).

## What changed

- **reference.md Table A** ported as a literal `x`-sweep (`used_weekly=0`,
  `used_5h=0`) asserting `target_N=8` at every row — the whole-week "all gates
  open, full headroom → max" smoke.
- **reference.md Table B** ported as literal assertions at the table's own
  `used_weekly=20`, including the gate-closed over-pace rows (`66`, `70` → `0`).
  Encoding the literal table values as assertions keeps the documented tables
  and the implementation in lockstep: a script regression that diverges from the
  tables fails CI.
- **Non-numeric `used_5h`** edge case (Test 17 only covered `used_weekly`):
  because `used_5h` is the anti-burst ramp *within* the weekly budget, a bad
  value fails **open** to the weekly-bounded count, not closed.
- **Transient-5h-fill `--reopen-at none`** edge case: the weekly gate is open
  (under pace) but count mode returns `0` because `used_5h >= ceil5`, so the
  pace curve is not the blocker and reopen reports `none`.

## Note on the issue framing

The issue's premise ("no test references its pace curve, `TARGET_N`, or
`--reopen-at` math") was stale — that coverage already existed. Table B's rows
were in substance already covered (the gate is magnitude-independent over
`used_weekly`, and an identical `used_5h` sweep was tested at `used_weekly=11`);
this PR adds the *literal* table ports for lockstep plus the two genuinely-
missing edge cases. A runtime markdown-table parser (one reading of the lockstep
AC) was deliberately rejected as brittle and without harness precedent.

reference.md's "non-numeric `used_*` → fail-closed" wording is imprecise — only
`used_weekly` fails closed; `used_5h` fails open by design. The new test pins the
actual behavior.

## Verification

```verify
.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
```

Full suite locally: **3397/3397 passed, 0 failed** (20 new assertions).
