### PR TITLE
Add explicit permissions block to the dead-code CI job

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -111,6 +111,8 @@ jobs:
 
   dead-code:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
Closes #2090

## What

Add an explicit job-level `permissions: contents: read` block to the
`dead-code` job in `.github/workflows/unit-tests.yml`.

## Why

The `dead-code` job (added in PR #2081 for #2066) defined no explicit
job-level `permissions` block. The workflow carries a top-level
`permissions: contents: read` block, so the job currently inherits read-only
access and is not actively insecure — but that inheritance is implicit. If the
workflow-level block is later changed or removed, the `dead-code` job would
silently fall back to broader default permissions.

An explicit job-level block makes the least-privilege constraint
self-documenting and resilient to future workflow edits, consistent with
GitHub's security-hardening guidance for Actions. The job only checks out the
repo and runs the dead-code sensor, so `contents: read` is the correct
least-privilege scope.

## Change

```yaml
  dead-code:
    runs-on: ubuntu-latest
    permissions:
      contents: read
    steps:
      ...
```

No other job is touched — `dead-code` is the only job in scope, and no other
job currently carries an explicit job-level `permissions` block.

## Verification

The plan's `verify` check confirms the `dead-code` job carries the explicit
`permissions: contents: read` block with intact surrounding structure. Full
validation that GitHub accepts the workflow is confirmed by this PR's own green
CI run of the `Unit Tests & Lint` workflow.
