### PR TITLE
Add blog post: harness engineering in practice

### DIFF
--- a/landing/post/harness-engineering-in-practice.md
+++ b/landing/post/harness-engineering-in-practice.md
@@ -1,0 +1,30 @@
+# A Harness I Own and Can Walk Away From
+
+This repository runs an autonomous coding-agent workflow I call `dispatch`. I own it, I run it on my own GitHub, Firebase, and Anthropic accounts, and it is built to be left. It plans, implements, reviews, and merges its own pull requests while I am asleep, and it is aligned to my intent because I wrote the rules it reads and I sit in the one queue it cannot resolve on its own. This is a field report from inside a running thing, not a theory of how such a thing should be built.
+
+The vocabulary that has grown up around this — [Birgitta Böckeler's "guides" and "sensors"](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html), the [LangChain framing that an agent is just a model plus everything around it](https://www.langchain.com/blog/the-anatomy-of-an-agent-harness), [Mitchell Hashimoto's ratchet where every mistake becomes a rule the agent can't repeat](https://mitchellh.com/writing/my-ai-adoption-journey) — maps cleanly onto `dispatch`, so I'll use it. The guides are the feedforward layer: the `.claude/rules/*.md` files and each skill's `SKILL.md`, read fresh before any phase acts. The sensors are the feedback layer, and they split in two. The computational ones are CI — lint, types, tests — reproduced locally by a `fix-checks` phase so a red check is a fact, not an opinion. The inferential ones are the review fan-out, a set of LLM-as-judge reviewers that read the diff and argue about it.
+
+Around both sits the steering loop: two queues. One is the autonomous dispatch queue, which spends no human tokens and grinds the work forward tick by tick. The other is the office-hours queue, where a human prompt is the only de-escalation event. Everything `dispatch` cannot resolve alone routes there and waits for me. This is the outer harness — the one the practitioner owns and runs — and its job is not to make the agent perfect.
+
+> A harness worth keeping is one you own, one you can walk away from, and one built to contain the ways a long-running agent fails rather than to pretend it won't.
+
+## Where the long-horizon failure modes go
+
+The interesting part is not that agents fail over long horizons — [METR's data has the reliably-completable task length doubling every seven months](https://metr.org/blog/2025-03-19-measuring-ai-ability-to-complete-long-tasks/), which means the horizon keeps stretching into territory where they do fail. The interesting part is where a self-hosted harness puts each failure when it happens.
+
+| Failure mode | Over a long horizon | Containing mechanism in dispatch |
+|---|---|---|
+| Reasoning drift | The agent's model of where things stand diverges from reality | State is re-derived from PR, CI, and labels every tick; there is no store behind the SCM to drift from |
+| Context rot | Accumulated context degrades judgment | Context is cleared at the plan→implement boundary; a persisted `<!-- dispatch:plan -->` comment is the only carrier into a clean build |
+| Premature victory | "Done" declared with nothing finished | Success needs a positive phase-completed marker; any abnormal exit with no marker fails safe to office-hours |
+| Self-evaluation bias | The agent grades its own work generously | An adversarial-verify pass tasks severity-scaled skeptics with refuting a finding before any fix runs |
+| Error compounding | One early mistake cascades | The per-phase context-clear plus re-derived state cap how far a single error can travel |
+| Slop and verbosity creep | Redundant, eroding code accretes | The inferential review sensor plus a standing token-audit discipline |
+
+The skeptic detail under self-evaluation bias is the one I trust most: the verifiers default to "refuted" under uncertainty, so a finding has to survive an attempt to kill it before any Opus fix gets to act on it.
+
+There is a live disagreement worth naming here. [Anthropic's harness-design work](https://www.anthropic.com/engineering/harness-design-long-running-apps) argues you should keep stress-testing your scaffolding and strip out whatever is no longer load-bearing as models improve — though it is careful to say the space of useful harness shapes doesn't shrink, it *moves*. Against that, the reliability literature reads the degradation as intrinsic: [a reliability-science framework finds long-horizon success decaying faster than the per-step error rate would predict](https://arxiv.org/abs/2603.29231), and [SlopCodeBench finds code quality eroding across iterative tasks where human code stays flat](https://arxiv.org/abs/2603.24755). I built `dispatch` as if degradation is intrinsic. It contains failure modes rather than betting a better model makes them disappear; if a future model retires a mechanism, I'll remove it, but the default is to assume the failure stays.
+
+What makes this mine rather than a platform's is the direction it points. The harness is built to be left — success is my eventual independence from it, the inverse of a retention metric — and I stay in planning and design, so my intent is never captured. None of the individual patterns is an invention; the distinctiveness is in the integration, as a Claude Code harness whose state machine is my own GitHub issues and labels. [OpenAI's account of leaning fully into an agent-first codebase](https://openai.com/index/harness-engineering/) and the broader [collected practice](https://github.com/walkinglabs/awesome-harness-engineering) cover most of the parts. Two nearby projects show the seams: Code Conductor runs a fully autonomous loop with no in-loop human-escalation path — its `conductor:blocked` label is defined but never set by any agent — while Claude Plan Orchestrator keeps human approval gates but commits a derived status mirror of an authoritative SQLite store. `dispatch` instead has no authoritative store behind the SCM at all: the PR, CI, and label ground truth *is* the state, re-derived every tick, with office-hours as a peer escalation queue where the human is the one event the loop can't fake.
+
+It's all here, and it's forkable. Take the parts that serve you and leave the rest.

--- a/landing/seeds/firestore.ts
+++ b/landing/seeds/firestore.ts
@@ -33,6 +33,16 @@ const appSeed: Omit<SeedSpec, "namespace"> = {
           } satisfies PostSeedData,
         },
         {
+          id: "harness-engineering-in-practice",
+          data: {
+            title: "A Harness I Own and Can Walk Away From",
+            published: true,
+            publishedAt: "2026-06-19T00:00:00Z",
+            filename: "harness-engineering-in-practice.md",
+            previewDescription: "A field report on harness engineering: how a forkable, self-hosted agent harness contains the long-horizon failure modes that degrade autonomous coding agents.",
+          } satisfies PostSeedData,
+        },
+        {
           id: "draft-ideas",
           data: {
             title: "Draft Ideas",


### PR DESCRIPTION
Closes #2050

## Summary

Adds a new landing blog post, a keyword-targeted bridge piece for the emerging
"harness engineering" discipline that drives traffic to the repo (part of epic
#2048).

The post is a first-person field report from inside `dispatch` — this repo's
own autonomous coding-agent workflow — framed around a harness the practitioner
**owns and can leave**, aligned with the practitioner's intent rather than a
platform's retention metric. The harness vocabulary and a failure-mode mapping
table carry discoverability; the ownership/intent thesis leads (per #2048's
positioning refinement and the #2099 charter principles).

## Changes

- **`landing/post/harness-engineering-in-practice.md`** — the new post (~760
  words + one failure-mode table). H1: *A Harness I Own and Can Walk Away From*.
  First-person essay matching the voice of
  `recovering-autonomy-with-coding-agents.md`; one pull-quote; a GFM table
  mapping named long-horizon failure modes onto the real `dispatch` mechanisms
  that contain them; a debate beat; and an inline-woven citation cluster.
- **`landing/seeds/firestore.ts`** — registers the post (`published: true`,
  keyword-bearing `previewDescription` as the single SEO carrier).

## Citation integrity

Every public-cluster citation was verified against its primary source via
`WebFetch` (live web), attributed exactly — Böckeler (on martinfowler.com, not
Fowler), LangChain, Hashimoto, METR, the Anthropic Mar-2026 harness-design
piece, *Beyond pass@1*, *SlopCodeBench*, and the canonical
`awesome-harness-engineering` list. The OpenAI piece returned HTTP 403 to the
fetcher, so per the plan's pre-authorized unverifiable-citation fallback it is
named and linked without an asserted date or stat. The two comparables (Code
Conductor, Claude Plan Orchestrator) reuse #2049's source-verified,
non-refutable framings verbatim.

## Verification

`npm run build --prefix landing` compiles, renders every published post, and
regenerates `dist/sitemap.xml` + `dist/feed.xml`; the post slug appears in both.
The build's safe-href / no-unknown-image / raw-HTML gates pass (no images, all
links https). Manual QA/review checks (primary-source citation re-confirmation,
refutable-claims check, no-keyword-stuffing-in-body, positioning, brand/voice
read, render check) are listed in the plan's Verification section.
