### PR TITLE
blog: document the dangerouslySetInnerHTML sanitization contract + widening trigger

### DIFF
--- a/blog/src/components/InfoPanelRegion.tsx
+++ b/blog/src/components/InfoPanelRegion.tsx
@@ -28,6 +28,17 @@ export interface InfoPanelRegionProps {
    * wired by a later unit). When present, the About content replaces the standard
    * panel and the blog-roll hydration is skipped entirely. When absent (the common
    * case), the standard info panel renders.
+   *
+   * Sanitization contract: InfoPanelRegion does NOT sanitize this value — it is
+   * injected verbatim via `dangerouslySetInnerHTML` (see render branch below).
+   * The caller guarantees the HTML is already safe; current callers pass
+   * hard-coded template literals such as `renderAboutPanelHtml`.
+   *
+   * Widening trigger: if this prop is ever widened to carry dynamic or
+   * user-influenced content, add a `DOMPurify.sanitize(...)` pass at the
+   * injection site before it reaches `dangerouslySetInnerHTML`. `dompurify` is
+   * already a dependency — see `blog/src/pages/HomeRegion.tsx:83` for the
+   * existing `DOMPurify.sanitize(html, { ADD_ATTR: [...] })` usage to reuse.
    */
   aboutContent?: string;
 }
@@ -183,6 +194,7 @@ export function InfoPanelRegion({
   }, [useScrollIndicator, aboutContent]);
 
   if (aboutContent !== undefined) {
+    // aboutContent is injected verbatim — see the prop contract + widening trigger above.
     return <div dangerouslySetInnerHTML={{ __html: aboutContent }} />;
   }
 

--- a/blog/src/components/InfoPanelRegion.tsx
+++ b/blog/src/components/InfoPanelRegion.tsx
@@ -37,7 +37,7 @@ export interface InfoPanelRegionProps {
    * Widening trigger: if this prop is ever widened to carry dynamic or
    * user-influenced content, add a `DOMPurify.sanitize(...)` pass at the
    * injection site before it reaches `dangerouslySetInnerHTML`. `dompurify` is
-   * already a dependency — see `blog/src/pages/HomeRegion.tsx:83` for the
+   * already a dependency — see `blog/src/pages/HomeRegion.tsx` for the
    * existing `DOMPurify.sanitize(html, { ADD_ATTR: [...] })` usage to reuse.
    */
   aboutContent?: string;

--- a/blog/src/create-blog-app.ts
+++ b/blog/src/create-blog-app.ts
@@ -70,9 +70,38 @@ export interface CreateBlogAppConfig {
     ) => (() => void) | PromiseLike<(() => void) | void>;
   };
   adminGroupId: GroupId;
-  /** Per-route info-panel content override (raw, pre-sanitized HTML). When it returns a string for the current path, InfoPanelRegion renders it as the panel (via aboutContent) instead of the standard blogroll panel; returning undefined yields the standard panel. Landing uses this for /about. */
+  /**
+   * Per-route info-panel content override. When it returns a string for the
+   * current path, InfoPanelRegion renders it as the panel (via `aboutContent`)
+   * instead of the standard blogroll panel; returning `undefined` yields the
+   * standard panel. Landing uses this for /about.
+   *
+   * Sanitization contract: the returned string is passed as `aboutContent` to
+   * InfoPanelRegion and injected verbatim via `dangerouslySetInnerHTML` — the
+   * driver does NOT sanitize. The caller guarantees the HTML is already safe;
+   * current callers return hard-coded template literals.
+   *
+   * Widening trigger: if callers are ever extended to return dynamic or
+   * user-influenced content, add a `DOMPurify.sanitize(...)` pass in
+   * InfoPanelRegion before the value reaches `dangerouslySetInnerHTML`.
+   * `dompurify` is already a dependency — see
+   * `blog/src/pages/HomeRegion.tsx:83` for the existing
+   * `DOMPurify.sanitize(html, { ADD_ATTR: [...] })` usage to reuse.
+   */
   infoPanelContentForPath?: (path: string) => string | undefined;
-  // optional hooks (consumed in units 2/3)
+  /**
+   * Extra SPA routes beyond home / admin. Each route's `render(path)` return
+   * value is injected verbatim into `#app` via `dangerouslySetInnerHTML` — the
+   * driver does NOT sanitize. Callers guarantee the HTML is already safe;
+   * current callers return hard-coded template literals.
+   *
+   * Widening trigger: if `Route.render` is ever extended to return dynamic or
+   * user-influenced content, add a `DOMPurify.sanitize(...)` pass at the
+   * injection sites (entry-hydration and SPA-navigation `dangerouslySetInnerHTML`
+   * sinks below) before the value reaches React. `dompurify` is already a
+   * dependency — see `blog/src/pages/HomeRegion.tsx:83` for the existing
+   * `DOMPurify.sanitize(html, { ADD_ATTR: [...] })` usage to reuse.
+   */
   extraRoutes?: Route[];
   onHomeAfterRender?: (slug: string | undefined) => void;
   onNavigate?: (path: string) => void;
@@ -227,6 +256,7 @@ export function createBlogApp(config: CreateBlogAppConfig): BlogAppHandle {
   const appRoot = hydrateRoot(
     app,
     typeof entryExtraHtml === "string"
+      // entryExtraHtml is unsanitized Route.render output — see extraRoutes contract + widening trigger above.
       ? createElement("div", { dangerouslySetInnerHTML: { __html: entryExtraHtml } })
       : homeElement(initialSlug),
   );
@@ -380,6 +410,7 @@ export function createBlogApp(config: CreateBlogAppConfig): BlogAppHandle {
       try {
         const html = await extra.render(path);
         if (seq === navSeq) {
+          // html is unsanitized Route.render output — see extraRoutes contract + widening trigger above.
           appRoot.render(createElement("div", { dangerouslySetInnerHTML: { __html: html ?? "" } }));
           // Run afterRender after React commits the body.
           queueMicrotask(() => {

--- a/blog/src/create-blog-app.ts
+++ b/blog/src/create-blog-app.ts
@@ -85,7 +85,7 @@ export interface CreateBlogAppConfig {
    * user-influenced content, add a `DOMPurify.sanitize(...)` pass in
    * InfoPanelRegion before the value reaches `dangerouslySetInnerHTML`.
    * `dompurify` is already a dependency — see
-   * `blog/src/pages/HomeRegion.tsx:83` for the existing
+   * `blog/src/pages/HomeRegion.tsx` for the existing
    * `DOMPurify.sanitize(html, { ADD_ATTR: [...] })` usage to reuse.
    */
   infoPanelContentForPath?: (path: string) => string | undefined;
@@ -99,7 +99,7 @@ export interface CreateBlogAppConfig {
    * user-influenced content, add a `DOMPurify.sanitize(...)` pass at the
    * injection sites (entry-hydration and SPA-navigation `dangerouslySetInnerHTML`
    * sinks below) before the value reaches React. `dompurify` is already a
-   * dependency — see `blog/src/pages/HomeRegion.tsx:83` for the existing
+   * dependency — see `blog/src/pages/HomeRegion.tsx` for the existing
    * `DOMPurify.sanitize(html, { ADD_ATTR: [...] })` usage to reuse.
    */
   extraRoutes?: Route[];


### PR DESCRIPTION
Closes #2097

## What

Documents the sanitization contract and its widening trigger at each blog
`dangerouslySetInnerHTML` injection site. Comment/JSDoc only — no behavioral or
runtime change.

Each sink and its upstream contract now states, in-code, that:

1. the component/driver does **not** sanitize the value,
2. the caller guarantees the HTML is already safe (current callers pass
   hard-coded template literals), and
3. **if the contract is ever widened to carry dynamic or user-influenced
   content, add a `DOMPurify.sanitize(...)` pass at the sink before
   `dangerouslySetInnerHTML`** — pointing at the existing
   `blog/src/pages/HomeRegion.tsx:83` usage to reuse (`dompurify@^3.3.1` is
   already a dependency).

Sites documented:

- `blog/src/components/InfoPanelRegion.tsx` — the `aboutContent` prop JSDoc and
  its injection branch.
- `blog/src/create-blog-app.ts` — the `infoPanelContentForPath` and
  `extraRoutes` JSDoc, plus both `dangerouslySetInnerHTML` sinks (entry
  hydration and SPA navigation).

## Why

#2097 splits into two halves. The deferred half — add a DOMPurify pass + a
script-stripping test — is gated on a future widening of
`infoPanelContentForPath` / `extraRoute.render`; no contract has been widened,
so no immediate change is required there. The actionable half is documenting the
sanitization contract at each injection site.

Because this PR `Closes #2097`, the widening trigger is encoded **in-code** at
the sinks rather than left as an issue note — so the deferred guard is not
forgotten when the issue closes. A future author who widens either contract sees
the trigger exactly where the change would happen.

## Out of scope (deliberately deferred)

- No DOMPurify pass and no script-stripping test (both gated on a contract
  actually widening — none has).
- No change to the shared `router` `Route` type, `prerender.ts`, or any caller.
  The ideal greenfield design — a branded `SanitizedHtml` type that makes a
  widening a compile-time error — is backwards-incompatible and spans more than
  one PR; it belongs to a separate migration, noted in the plan.

## Verification

- `run-typecheck.sh --app blog` — green (blog typecheck is skipped by the runner
  because origin/main carries pre-existing typecheck errors).
- `run-unit-tests.sh --app blog` — 414 tests pass across 28 files.
