### PR TITLE
dispatch-run-verification: exit 5 for an unclosed verify fence

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-run-verification
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-run-verification
@@ -14,7 +14,7 @@
 # dispatch-write-plan's stdin design: the caller pipes the plan in, so this
 # script needs no gh mock to test.
 #
-# Exit codes, so the implement phase can branch on the result (four states):
+# Exit codes, so the implement phase can branch on the result (five states):
 #   exit 3 — no Verification section, OR a Verification section with no `verify`
 #            blocks. The "proceed unchanged" signal; a one-line diagnostic goes
 #            to stderr. This is NOT a failure — there is simply nothing to run.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-run-verification
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-run-verification
@@ -24,6 +24,9 @@
 #   exit 4 — empty/absent input on stdin. The upstream plan producer
 #            (dispatch-read-plan) likely failed; refusing to emit the exit-3
 #            "proceed unchanged" signal. NOT a proceed-unchanged.
+#   exit 5 — an unclosed verify fence (opened with ```verify inside the
+#            Verification section but reaching EOF before its closing ```).
+#            A malformed/authoring error, NOT a failed verify block.
 #
 # A `## ` heading inside a fenced code block does not terminate the Verification
 # section, and fences outside the section are ignored — fence state is tracked so
@@ -46,6 +49,7 @@ Exit codes:
   2  bad usage (unexpected argument)
   3  no Verification section, or no verify blocks in it (proceed unchanged)
   4  empty stdin (upstream producer failed; NOT a proceed-unchanged)
+  5  unclosed verify fence (malformed plan; NOT a failed block)
 EOF
 }
 
@@ -133,8 +137,8 @@ done <<<"$PLAN"
 # closing ```) leaves capturing=1 with the partial block never appended. Surface
 # it as a malformed plan rather than silently treating it as "no verify blocks".
 if [[ "$capturing" -eq 1 ]]; then
-  echo "dispatch-run-verification: unclosed verify block at end of input" >&2
-  exit 1
+  echo "dispatch-run-verification: unclosed verify block at end of input (malformed plan)" >&2
+  exit 5
 fi
 
 if [[ "${#BLOCKS[@]}" -eq 0 ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -34944,6 +34944,29 @@ ws=$'  \n\t\n'
 if out=$(printf '%s' "$ws" | "$RUN_VERIFY" 2>&1); then rc=0; else rc=$?; fi
 assert_eq "dispatch-run-verification: whitespace-only stdin exits 4" "4" "$rc"
 
+# Unclosed verify fence in-section (exit 5): a ```verify fence opened inside the
+# Verification section but never closed before EOF is a malformed/authoring
+# error, distinct from a failed verify block (exit 1) — so the routing logic can
+# tell an unfixable plan from a fixable block (#2118).
+echo "Test: dispatch-run-verification -- unclosed verify fence in section exits 5"
+plan=$'## Verification\n```verify\ntrue\n'
+if out=$(printf '%s' "$plan" | "$RUN_VERIFY" 2>&1); then rc=0; else rc=$?; fi
+assert_eq "dispatch-run-verification: unclosed verify fence exits 5" "5" "$rc"
+case "$out" in
+  *"unclosed verify block"*) found=yes ;;
+  *) found=no ;;
+esac
+assert_eq "dispatch-run-verification: unclosed-fence diagnostic reported" "yes" "$found"
+
+# Converse boundary (exit 3, NOT 5): an unclosed ```verify fence OUTSIDE any
+# Verification section leaves capturing=0, so it is ignored like any out-of-
+# section fence and stays the "proceed unchanged" exit 3 — pinning that exit 5
+# fires only for an in-section unclosed fence.
+echo "Test: dispatch-run-verification -- unclosed verify fence outside any section stays exit 3"
+plan=$'## Plan\n```verify\ntrue\n'
+if out=$(printf '%s' "$plan" | "$RUN_VERIFY" 2>&1); then rc=0; else rc=$?; fi
+assert_eq "dispatch-run-verification: unclosed fence outside section exits 3" "3" "$rc"
+
 # Preservation guard (criterion 2): the exit-3 cases above confirm a
 # no-verify-block plan (prose/bash-only Verification section, or no section)
 # still exits 3. No duplication needed here.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -35411,6 +35411,21 @@ case "$out" in
 esac
 assert_eq "dispatch-run-verification: unclosed-fence diagnostic reported" "yes" "$found"
 
+# Unclosed fence AFTER a completed block (exit 5): the loop accumulates one or
+# more closed ```verify blocks, then sets capturing=1 on the trailing unclosed
+# fence. exit 5 must still fire at EOF even though blocks were successfully
+# accumulated before — pinning the capturing-reset boundary on fence close so a
+# future refactor cannot silently downgrade this to exit 0/1 (#2118).
+echo "Test: dispatch-run-verification -- unclosed verify fence after a completed block exits 5"
+plan=$'## Verification\n```verify\ntrue\n```\n```verify\nfalse\n'
+if out=$(printf '%s' "$plan" | "$RUN_VERIFY" 2>&1); then rc=0; else rc=$?; fi
+assert_eq "dispatch-run-verification: unclosed fence after completed block exits 5" "5" "$rc"
+case "$out" in
+  *"unclosed verify block"*) found=yes ;;
+  *) found=no ;;
+esac
+assert_eq "dispatch-run-verification: post-block unclosed-fence diagnostic reported" "yes" "$found"
+
 # Converse boundary (exit 3, NOT 5): an unclosed ```verify fence OUTSIDE any
 # Verification section leaves capturing=0, so it is ignored like any out-of-
 # section fence and stays the "proceed unchanged" exit 3 — pinning that exit 5

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -164,6 +164,18 @@ Route on the exit code:
   (no deviation) and `dispatch-mark-deviation` (deviation) — so the single-named-exit
   invariant still holds. The Stop hook reads marker-absence as Branch A and parks
   the issue for human review.
+- **exit 5** — the plan has an unclosed/malformed ```verify fence (opened inside
+  the Verification section but never closed before EOF). This is a
+  **plan-authoring error**, not a failing verify block — the worker cannot repair
+  the plan comment, so do **not** enter the `/implement-unit` fix lane. Route
+  straight to `dispatch-mark-deviation` with an accurate reason and **stop** (skip
+  the Step 5 completion marker):
+
+  ```bash
+  .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+    "/implement: plan verification could not run — malformed plan (unclosed verify fence)"
+  ```
+
 - **any other non-zero exit** — exit **4** (empty/absent plan input: the upstream
   `dispatch-read-plan` failed and the runner refused to emit the exit-3
   "proceed unchanged" signal), or any upstream failure surfaced via `set -o

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -394,6 +394,17 @@ procedure verbatim:
        "/implement: plan verification failed after 2 fix attempts (check <index>)"
      ```
 
+   - **exit 5** → the plan has an unclosed/malformed ```verify fence (opened in
+     the Verification section but never closed before EOF). This is a
+     plan-authoring error the worker cannot repair, **not** a fixable verify
+     failure — do **not** enter the fix lane; run this deviation marker and stop
+     (skip the Step 3 completion marker):
+
+     ```bash
+     .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+       "/implement: plan verification could not run — malformed plan (unclosed verify fence)"
+     ```
+
    - **any other non-zero exit** (exit 4 = empty/absent plan input, or an
      upstream `dispatch-read-plan` failure surfaced via `pipefail`) is an
      environment/upstream error, **not** a fixable verify failure — do **not**


### PR DESCRIPTION
Closes #2118

## Problem

In `dispatch-run-verification`, an **unclosed verify fence** — a ` ```verify `
fence opened inside the `## Verification` section but reaching EOF before its
closing ` ``` ` — fell through to `exit 1`, the **same exit code** the runner
uses when a verify block actually runs and fails.

The two states are indistinguishable to the routing logic that branches on the
exit code. A plan with a malformed (unclosed) fence was read as "a verify block
failed", so the implement worker wrongly entered the bounded fix lane and burned
fix attempts on what is really a plan-authoring error — when it cannot fix it,
because it cannot edit the plan comment. It should mark a deviation and park for
office-hours instead.

## Fix

Give the unclosed-fence branch a **distinct exit code 5** and route it, in both
routing tables, the way exit 4 (empty/upstream-failed input) is routed: straight
to `dispatch-mark-deviation`, never the fix lane. This mirrors the precedent
#2106 set when it added exit 4 as a distinct non-fix-lane code.

### Unit 1 — runner exit 5 + unit tests

- `dispatch-run-verification`: the unclosed-fence branch now `exit 5` (was
  `exit 1`); the stderr diagnostic still contains `unclosed verify block`. Exit 5
  is documented in the header Exit-codes block and the `usage()` heredoc.
- `test-dispatch-scripts.sh`: two new cases — an in-section unclosed fence exits
  **5** (asserting both code and diagnostic), and the converse boundary, an
  unclosed fence **outside** any Verification section, stays **3** (pinning that
  exit 5 fires only for an in-section unclosed fence).

### Unit 2 — route exit 5 in both routing tables

- `implement/SKILL.md` Step 3 and `plan-issue/SKILL.md` plan-preface routing each
  get a distinct **exit 5** branch between the exit-1 branch and the "any other
  non-zero exit" branch: an unclosed/malformed verify fence is a plan-authoring
  error → `dispatch-mark-deviation`, never the `/implement-unit` fix lane.

The retired `dispatch-propagate/SKILL.md` stub carries no routing table and is
untouched.

## Verification

The hermetic dispatch unit-test suite passes (3448/3448), including the 3 new
cases. This validates both that the existing exit-1 (failed-block) tests are
unaffected and that the new exit-5 path works.
