### PR TITLE
CI: add timeout-minutes: 30 runaway guard to darwin-build job

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -238,6 +238,11 @@ jobs:
 
   darwin-build:
     runs-on: macos-14
+    # No CI runtime baseline yet: the Build step has executed 0 times (it is
+    # gated on nix-file changes and every run so far has skipped it). 30 min is
+    # a conservative runaway guard vs GitHub's 6h default; tighten to ~2x the
+    # observed p95 once 3-5 real warm-cache runs accumulate. (#1932, 2026-06-19)
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
Closes #1932

## What

Add a job-level `timeout-minutes: 30` to the `darwin-build` job in
`.github/workflows/unit-tests.yml` (added by #1927), as a sibling of
`runs-on: macos-14`, with an inline comment documenting its basis.

Without an explicit timeout the job inherits GitHub's 6-hour default. On the
billed `macos-14` runner, a runaway or hung Nix build could burn hours of paid
minutes before GitHub stops it. The new value caps that exposure.

## Why 30 minutes (and why not p95-derived yet)

#1932 asks for a timeout at ~2x the observed p95 from 3–5 successful runs. That
baseline does not exist: the `Build darwinConfigurations.default` step is gated
on `if: steps.changes.outputs.nix == 'true'` and has executed **zero** times —
every `darwin-build` run so far skipped the real build (checkout +
detect-changes only). #1927 itself touched no `.nix` files, so even its own CI
skipped the build. There is no warm/cold-cache runtime to calibrate against.

Per the chosen approach, this PR delivers the safety value now: a conservative
fixed `timeout-minutes: 30` as a pure runaway guard, well under the 6h default.
The inline comment records honestly that this is not yet p95-calibrated, and
that it should be tightened to ~2x observed p95 once 3–5 real warm-cache
`darwin-build` runs accumulate.

## Acceptance-criteria notes

- **Precise-p95 calibration**: relaxed — no p95 data exists yet; the value is a
  documented conservative guard.
- **Documented basis**: satisfied — the inline comment cites the missing
  baseline, the conservative-guard rationale, #1932, and the date.
- **In-PR warm-cache run within the timeout**: relaxed — `detect-changes.sh`
  only sets `nix=true` for changes under `nix/`, `flake.nix`, or `flake.lock`,
  so this workflow-only PR does not trigger the real build on its own CI. It is
  verified naturally on the next nix-touching PR after merge. No nix touch was
  fabricated to force it.

## Scope

Single-line workflow change plus its documenting comment. No change to the build
script, the `if:` guards, the substituter config, the detect-changes script, or
any other job.
