### PR TITLE
dispatch-token-audit: derive the phase-to-model policy from per-model cost and hit-rate

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
@@ -7,7 +7,7 @@
 # the normalized result to stdout.
 #
 # Usage:
-#   dispatch-config-load <projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus|sweep>
+#   dispatch-config-load <projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus|sweep|phase-model-policy>
 #
 # Config files live in <project-root>/dispatch.config/. The project root is
 # resolved via resolve_project_root (lib.sh).
@@ -266,6 +266,41 @@
 #     "notInSyncGraceSeconds": 86400
 #   }
 #
+# ---- Schema: phase-model-policy.json ----------------------------------------
+#
+# Top-level object holding a generated phase → model routing policy, produced by
+# /dispatch-token-audit at audit time and consulted by `dispatch-phase-model` at
+# tick time as a cheap lookup. This config type follows the GENERIC absent→inert
+# convention (see "Stdout protocol" above): when the file is absent, no-config is
+# emitted and `dispatch-phase-model` uses its hardcoded default case-map. The
+# tick performs NO learning — it only reads `.routes[phase]`.
+#
+# Only `.routes` is load-bearing and validated; the remaining fields
+# (schema_version, generated_at, window, rationale) are optional provenance/audit
+# metadata, carried through normalization but NOT strictly validated here.
+#
+#   routes   object (optional) — phase-name → model-id map. Each VALUE must be a
+#            non-empty string (a claude model id). Consumed as `.routes[phase]`.
+#            `dispatch-phase-model` honors a route only for phases on its own
+#            demotable allowlist {qa, review}; a route for any other phase is
+#            ignored by the consumer (defense-in-depth against demoting a
+#            code-authoring phase). An absent or empty `.routes` → the consumer
+#            falls back to its hardcoded defaults for every phase.
+#
+# Example (the producer in Unit 2 emits this shape):
+#   {
+#     "schema_version": 1,
+#     "generated_at": "<derived from window.until>",
+#     "window": { "days": 7, "since": "...", "until": "..." },
+#     "routes": { "qa": "claude-sonnet-4-6", "review": "claude-opus-4-8" },
+#     "rationale": {
+#       "qa":     { "decision": "keep-cheap", "sessions": 24, "hit_rate": 0.62,
+#                   "cost_usd": 1.23, "price_proxy_usd": 4.56 },
+#       "review": { "decision": "promote",    "sessions": 30, "hit_rate": 0.18,
+#                   "cost_usd": 2.10, "price_proxy_usd": 5.40 }
+#     }
+#   }
+#
 set -euo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
@@ -274,9 +309,9 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 CONFIG_TYPE="${1:-}"
 case "$CONFIG_TYPE" in
-  projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus|sweep) ;;
+  projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus|sweep|phase-model-policy) ;;
   *)
-    echo "error: usage: dispatch-config-load <projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus|sweep>" >&2
+    echo "error: usage: dispatch-config-load <projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus|sweep|phase-model-policy>" >&2
     exit 2
     ;;
 esac
@@ -656,6 +691,27 @@ case "$CONFIG_TYPE" in
         else
           empty
         end)
+      end
+    ' "$CONFIG_FILE")
+    ;;
+  phase-model-policy)
+    # top-level value must be an object. Only `.routes` is load-bearing: when
+    # present it must be an object whose every value is a non-empty string (a
+    # model id the consumer feeds to `claude --model`). The provenance fields
+    # (schema_version, generated_at, window, rationale) are not validated.
+    ERRORS=$(jq -r '
+      if type != "object" then
+        "top-level value must be a JSON object, got \(type)"
+      elif (.routes != null) and ((.routes | type) != "object") then
+        "top-level .routes must be an object, got \(.routes | type)"
+      else
+        (.routes // {}) | to_entries[] |
+        .key as $k | .value as $v |
+        if ($v | type) != "string" then
+          "routes.\($k) must be a string, got \($v | type)"
+        elif ($v | length) == 0 then
+          "routes.\($k) must be a non-empty string"
+        else empty end
       end
     ' "$CONFIG_FILE")
     ;;

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-phase-model
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-phase-model
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # dispatch-phase-model — emit the claude model override for a given dispatch phase.
 #
-# Phase → model map:
+# Default phase → model map (hardcoded fallback):
 #   qa     → claude-sonnet-4-6   (#1171: no product-code authoring; machine-verifiable
 #                                 checks + browser automation + summary writing)
 #   review → claude-sonnet-4-6   (#1172: the review-fix orchestrator authors no fixes —
@@ -10,19 +10,35 @@
 #                                 orchestrator main chain runs on Sonnet)
 #   *      → (empty)             unmapped phases inherit the session default (Opus)
 #
+# Generated policy override (#2028):
+#   /dispatch-token-audit derives a phase → model routing policy from aggregated
+#   cost + hit-rate and writes it to dispatch.config/phase-model-policy.json. This
+#   script consults that artifact (via `dispatch-config-load phase-model-policy`)
+#   as a cheap lookup — it performs NO learning. When the policy supplies a
+#   non-empty route for the requested phase, that route OVERRIDES the default
+#   case-map above; otherwise the default applies. An absent policy file → the
+#   defaults apply unchanged.
+#
+#   Demotable allowlist: a policy route is honored ONLY when PHASE is in {qa,
+#   review}. Any other phase ignores the policy and uses its default — fail-closed
+#   defense-in-depth against a hand-edited policy that tries to demote a
+#   code-authoring phase (implement/fix) off Opus.
+#
+#   A malformed/invalid policy fails LOUDLY: dispatch-config-load exits non-zero
+#   and this script surfaces the error and exits non-zero rather than silently
+#   falling back (per .claude/rules/code-style.md; mirrors the force-opus consumer
+#   at dispatch-spawn-job:228).
+#
 # Contract:
 #   EMPTY stdout means "omit the --model flag, inherit the session default (Opus)".
 #   Callers MUST honor this contract: only pass --model <value> to `claude --bg`
 #   when this script emits a non-empty value.
 #
-#   This `case` map is the single opt-in point for adding other phase → model
-#   overrides later. To route another phase to a specific model, add a case arm
-#   here; every caller already forwards the value opaquely.
-#
 # Usage: dispatch-phase-model <phase>
 #
 # Exit codes:
-#   0  always (an unmapped phase is NOT an error — it means "default").
+#   0  resolved (an unmapped phase is NOT an error — it means "default").
+#   1  the policy file is present but malformed/invalid (dispatch-config-load failed).
 #   2  missing, empty, or extra <phase> argument (usage error).
 #
 # NOT set -e: exits are handled explicitly.
@@ -37,13 +53,45 @@ if [[ $# -gt 1 ]]; then
   exit 2
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 PHASE="$1"
 
+# Hardcoded default for this phase (empty → inherit the session default, Opus).
 case "$PHASE" in
   qa|review)
-    echo "claude-sonnet-4-6"
+    DEFAULT_MODEL="claude-sonnet-4-6"
     ;;
   *)
-    # Unmapped phase: emit nothing. Caller omits --model and inherits Opus.
+    DEFAULT_MODEL=""
     ;;
 esac
+
+# Consult the generated policy. dispatch-config-load prints either normalized
+# JSON, the literal "no-config" (file absent), or exits non-zero on a present-
+# but-invalid policy. Surface that failure rather than silently falling back.
+POLICY=$("$SCRIPT_DIR/dispatch-config-load" phase-model-policy) || {
+  echo "dispatch-phase-model: error: dispatch-config-load phase-model-policy failed (malformed/invalid policy)" >&2
+  exit 1
+}
+
+# Resolution order. A policy route is honored only for an allowlisted phase;
+# everything else uses DEFAULT_MODEL.
+if [[ "$POLICY" == "no-config" ]]; then
+  printf '%s\n' "$DEFAULT_MODEL"
+else
+  case "$PHASE" in
+    qa|review)
+      ROUTE=$(jq -r --arg p "$PHASE" '.routes[$p] // empty' <<<"$POLICY")
+      if [[ -n "$ROUTE" ]]; then
+        printf '%s\n' "$ROUTE"
+      else
+        printf '%s\n' "$DEFAULT_MODEL"
+      fi
+      ;;
+    *)
+      # Phase not on the demotable allowlist: ignore the policy entirely.
+      printf '%s\n' "$DEFAULT_MODEL"
+      ;;
+  esac
+fi

--- a/.claude/skills/dispatch-propagate/scripts/run-unit-tests.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-unit-tests.sh
@@ -13,6 +13,7 @@ RUN_NIX=false
 RUN_RULES=false
 RUN_CI_SCRIPTS=false
 RUN_PR_SCRIPTS=false
+RUN_TOKEN_AUDIT_SCRIPTS=false
 EXPLICIT=false
 
 while [[ $# -gt 0 ]]; do
@@ -43,8 +44,13 @@ while [[ $# -gt 0 ]]; do
       EXPLICIT=true
       shift
       ;;
+    --token-audit-scripts)
+      RUN_TOKEN_AUDIT_SCRIPTS=true
+      EXPLICIT=true
+      shift
+      ;;
     *)
-      echo "Usage: run-unit-tests.sh [--app <dir>] [--nix] [--rules] [--ci-scripts] [--pr-scripts]" >&2
+      echo "Usage: run-unit-tests.sh [--app <dir>] [--nix] [--rules] [--ci-scripts] [--pr-scripts] [--token-audit-scripts]" >&2
       exit 1
       ;;
   esac
@@ -74,6 +80,7 @@ if [ "$EXPLICIT" = false ]; then
       firestore.rules) RUN_RULES=true ;;
       .github/scripts/*) RUN_CI_SCRIPTS=true ;;
       .claude/skills/dispatch-propagate/scripts/*) RUN_PR_SCRIPTS=true ;;
+      .claude/skills/dispatch-token-audit/scripts/*) RUN_TOKEN_AUDIT_SCRIPTS=true ;;
     esac
   done <<< "$CHANGED"
 fi
@@ -186,7 +193,28 @@ if [ "$RUN_PR_SCRIPTS" = true ]; then
   fi
 fi
 
-if [ ${#APP_DIRS[@]} -eq 0 ] && [ "$RUN_NIX" = false ] && [ "$RUN_RULES" = false ] && [ "$RUN_CI_SCRIPTS" = false ] && [ "$RUN_PR_SCRIPTS" = false ]; then
+# Run dispatch-token-audit script tests (no test-helpers.sh in that dir)
+if [ "$RUN_TOKEN_AUDIT_SCRIPTS" = true ]; then
+  echo "=== Dispatch token-audit script tests ==="
+  TOKEN_AUDIT_SCRIPTS="$REPO_ROOT/.claude/skills/dispatch-token-audit/scripts"
+  TOKEN_AUDIT_FAIL=false
+  for test_script in "$TOKEN_AUDIT_SCRIPTS"/test-*.sh; do
+    name=$(basename "$test_script")
+    [[ "$name" == "test-helpers.sh" ]] && continue
+    echo "--- $name ---"
+    if "$test_script"; then
+      echo "PASS: $name"
+    else
+      echo "FAIL: $name" >&2
+      TOKEN_AUDIT_FAIL=true
+    fi
+  done
+  if [ "$TOKEN_AUDIT_FAIL" = true ]; then
+    FAILURES+=(token-audit-scripts)
+  fi
+fi
+
+if [ ${#APP_DIRS[@]} -eq 0 ] && [ "$RUN_NIX" = false ] && [ "$RUN_RULES" = false ] && [ "$RUN_CI_SCRIPTS" = false ] && [ "$RUN_PR_SCRIPTS" = false ] && [ "$RUN_TOKEN_AUDIT_SCRIPTS" = false ]; then
   echo "No test suites matched changed files. Nothing to check."
   exit 0
 fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-phase-model.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-phase-model.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Tests for dispatch-phase-model — the tick-time phase → model lookup (#2028).
+#
+# Covers the generated-policy override path: a phase-model-policy.json route
+# (when present, for an allowlisted phase) overrides the hardcoded default
+# case-map; the demotable allowlist {qa, review} fail-closes against demoting a
+# code-authoring phase; a malformed policy fails loudly (non-zero exit) rather
+# than silently falling back; and the usage-error exit-code contract (exit 2)
+# still fires before any policy load.
+#
+# The SUT is pointed at fixture policies via the DISPATCH_CONFIG_DIR env seam
+# (the same seam dispatch-config-load uses) — each case writes a
+# phase-model-policy.json into a per-case mktemp dir.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+source "$SCRIPT_DIR/test-helpers.sh"
+SUT="$SCRIPT_DIR/dispatch-phase-model"
+
+# run_phase: run the SUT against a given config dir, capturing stdout in OUT and
+# the exit code in RC. Pass "" as the dir to invoke the SUT with no override.
+OUT=""
+RC=0
+run_phase() {  # $1 = config dir (or "" for none), $2 = phase
+  local dir="$1" phase="$2"
+  set +e
+  OUT=$(DISPATCH_CONFIG_DIR="$dir" "$SUT" "$phase" 2>/dev/null)
+  RC=$?
+  set -e
+}
+
+# write_policy: drop a phase-model-policy.json with the given body into a fresh
+# mktemp dir and echo the dir path. The filename is fixed — dispatch-config-load
+# derives it from the config type.
+write_policy() {  # $1 = JSON body; echoes the config dir
+  local dir
+  dir=$(mktemp -d)
+  printf '%s\n' "$1" > "$dir/phase-model-policy.json"
+  printf '%s' "$dir"
+}
+
+# ============================================================================
+# Case 1: no policy file present (empty config dir) → defaults apply.
+# ============================================================================
+echo "Case 1: no policy file -> hardcoded defaults"
+EMPTY_DIR=$(mktemp -d)
+
+run_phase "$EMPTY_DIR" qa
+assert_eq "no policy: qa -> sonnet" "claude-sonnet-4-6" "$OUT"
+assert_eq "no policy: qa exit 0" "0" "$RC"
+
+run_phase "$EMPTY_DIR" review
+assert_eq "no policy: review -> sonnet" "claude-sonnet-4-6" "$OUT"
+
+run_phase "$EMPTY_DIR" plan
+assert_eq "no policy: unmapped plan -> empty" "" "$OUT"
+assert_eq "no policy: plan exit 0" "0" "$RC"
+
+# ============================================================================
+# Case 2: policy routes qa -> opus → override beats the default.
+# ============================================================================
+echo "Case 2: policy route overrides default"
+DIR2=$(write_policy '{"routes":{"qa":"claude-opus-4-8"}}')
+
+run_phase "$DIR2" qa
+assert_eq "policy qa -> opus (override)" "claude-opus-4-8" "$OUT"
+assert_eq "policy qa override exit 0" "0" "$RC"
+
+# ============================================================================
+# Case 3: policy present but missing the requested route → default fallback.
+# ============================================================================
+echo "Case 3: missing route key -> default fallback"
+DIR3=$(write_policy '{"routes":{"qa":"claude-opus-4-8"}}')
+
+run_phase "$DIR3" review
+assert_eq "policy missing review key: review -> default sonnet" "claude-sonnet-4-6" "$OUT"
+
+# ============================================================================
+# Case 4: allowlist guard — a policy demoting a code-authoring phase is ignored.
+# ============================================================================
+echo "Case 4: allowlist guard ignores non-allowlisted route"
+DIR4=$(write_policy '{"routes":{"implement":"claude-sonnet-4-6","qa":"claude-opus-4-8"}}')
+
+run_phase "$DIR4" implement
+assert_eq "policy route for implement IGNORED -> empty" "" "$OUT"
+assert_eq "implement guard exit 0" "0" "$RC"
+
+# The allowlisted route in the same policy is still honored.
+run_phase "$DIR4" qa
+assert_eq "allowlisted qa route still honored -> opus" "claude-opus-4-8" "$OUT"
+
+# ============================================================================
+# Case 5: malformed policy JSON → fail loudly (non-zero exit, no fallback).
+# ============================================================================
+echo "Case 5: malformed policy -> non-zero exit"
+DIR5=$(mktemp -d)
+printf '%s\n' '{ not json' > "$DIR5/phase-model-policy.json"
+
+run_phase "$DIR5" qa
+assert_eq "malformed policy -> nonzero exit" "nonzero" \
+  "$([ "$RC" -ne 0 ] && echo nonzero || echo zero)"
+
+# ============================================================================
+# Case 6: usage errors → exit 2, before any policy load.
+# ============================================================================
+echo "Case 6: usage errors exit 2"
+
+set +e
+"$SUT" >/dev/null 2>&1
+NOARG_RC=$?
+"$SUT" "" >/dev/null 2>&1
+EMPTYARG_RC=$?
+"$SUT" qa review >/dev/null 2>&1
+EXTRAARG_RC=$?
+set -e
+
+assert_eq "no arg -> exit 2" "2" "$NOARG_RC"
+assert_eq "empty arg -> exit 2" "2" "$EMPTYARG_RC"
+assert_eq "extra arg -> exit 2" "2" "$EXTRAARG_RC"
+
+report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -32109,6 +32109,11 @@ lw_setup() {
   # and lib-claude-agents.sh from the same dir.
   cp "$SCRIPT_DIR/dispatch-launch-worker" "$LW_DIR/dispatch-launch-worker"
   cp "$SCRIPT_DIR/dispatch-phase-model" "$LW_DIR/dispatch-phase-model"
+  # dispatch-phase-model consults dispatch-config-load (a sibling, resolved via
+  # $SCRIPT_DIR) for the generated phase-model-policy (#2028), so it must travel
+  # with the copy. With no policy file at the resolved config dir it returns
+  # no-config and the default qa/review → sonnet map applies.
+  cp "$SCRIPT_DIR/dispatch-config-load" "$LW_DIR/dispatch-config-load"
   cp "$SCRIPT_DIR/lib-reservation-ledger.sh" "$LW_DIR/lib-reservation-ledger.sh"
   cp "$SCRIPT_DIR/lib.sh" "$LW_DIR/lib.sh"
   cp "$SCRIPT_DIR/lib-claude-agents.sh" "$LW_DIR/lib-claude-agents.sh"

--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -126,8 +126,18 @@ Ranking (step 5) stays on `price_proxy_usd`. `cost_usd` is reported alongside it
    POLICY_DIR="$(resolve_project_root)/dispatch.config"
    mkdir -p "$POLICY_DIR"
    .claude/skills/dispatch-token-audit/scripts/generate-phase-model-policy.sh tmp/usage-audit.json \
-     > "$POLICY_DIR/phase-model-policy.json"
+     > "$POLICY_DIR/phase-model-policy.json.tmp" \
+     && mv "$POLICY_DIR/phase-model-policy.json.tmp" "$POLICY_DIR/phase-model-policy.json"
    ```
+
+   Write to a temp file in the same directory, then atomically `mv` it into
+   place. The shell redirect truncates its target **before** the producer runs,
+   so redirecting straight onto `phase-model-policy.json` would leave an empty
+   file if the producer exits non-zero (bad `tmp/usage-audit.json`, a failed
+   `MIN_SAMPLE`/`HIT_RATE_FLOOR` override, or any jq error). An empty policy
+   makes `dispatch-config-load` exit 1, cascading to `dispatch-phase-model` and
+   `dispatch-launch-worker` so no phase spawns at all. Staging to `.tmp` and
+   renaming only on success preserves the previous valid policy on failure.
 
    Run this Bash call with `dangerouslyDisableSandbox: true`. `dispatch.config/` lives at the **project root**, which is NOT in `settings.json`'s `allowWrite` list (see `.claude/rules/sandbox.md`), so a sandboxed write fails read-only. Resolve the path exactly as `dispatch-config-load` does — `resolve_project_root` from `lib.sh`, then `/dispatch.config`. Because that directory is OUTSIDE the worktree, the write does not dirty git.
 

--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dispatch-token-audit
-description: Audit recent dispatch session transcripts and emit a ranked report of token-reduction opportunities across nine lenses, ranked by measured price-proxy magnitude. Report-only. Accepts an optional window, e.g. /dispatch-token-audit 2d.
+description: Audit recent dispatch session transcripts and emit a ranked report of token-reduction opportunities across nine lenses, ranked by measured price-proxy magnitude. Primarily report-only; also writes the phase-model routing policy artifact. Accepts an optional window, e.g. /dispatch-token-audit 2d.
 ---
 
 # Dispatch Token Audit
 
-This skill parses recent Claude session transcripts and emits a ranked report of token-reduction opportunities. It is report-only: it does not create issues or modify the dispatch workflow — the user decides what to act on from the report. Two cost figures appear in the output:
+This skill parses recent Claude session transcripts and emits a ranked report of token-reduction opportunities. It creates no GitHub issues and edits no workflow files — the user decides what to act on from the report. It does, however, write one control artifact: `dispatch.config/phase-model-policy.json`, the phase→model routing policy consumed by `dispatch-phase-model` at tick time (step 7 below). That write is the audit closing the routing loop on its own measurements; `force-opus.json` overrides the policy downstream, and deleting the file reverts routing to the hardcoded defaults. Two cost figures appear in the output:
 
 - **`price_proxy_usd`** — a uniform Opus-list-price rate applied to every token regardless of the actual model. Holding price constant isolates token count, so this figure ranks opportunities by relative magnitude. It is **not** the actual bill.
 - **`cost_usd`** — the truthful per-model bill. Each model is priced at its real rate (Sonnet, Haiku, or Opus), so this figure measures real dollars and shows the actual savings from model-routing decisions.
@@ -119,7 +119,21 @@ Ranking (step 5) stays on `price_proxy_usd`. `cost_usd` is reported alongside it
      - A concrete, specific suggestion (not a vague "consider X" — name the phase, the model, the script, the error signature).
    - **All nine lenses represented**: lenses with negligible measured impact appear at the bottom with their measured magnitude and a note that the data shows near-zero impact.
 
-7. **Report-only.** The skill does NOT create GitHub issues and does NOT modify the dispatch workflow. The user reads the report and decides what to file. This prevents the skill from racing or duplicating the optimization issues it surfaces (e.g. #1171, #1172).
+7. **Write the phase-model routing policy.** Run the producer over the same aggregate doc and write its stdout to the resolved project-root `dispatch.config/phase-model-policy.json`. This write happens **unconditionally** — it is the audit closing the routing loop on its own measurements, not an opt-in. The safety net is structural: the producer only ever emits routes for `{qa, review}` (it iterates that allowlist and nothing else), and `dispatch-phase-model` re-applies the same fail-closed allowlist plus the `force-opus` override downstream, so a code-authoring phase can never be demoted.
+
+   ```bash
+   source .claude/skills/dispatch-propagate/scripts/lib.sh
+   POLICY_DIR="$(resolve_project_root)/dispatch.config"
+   mkdir -p "$POLICY_DIR"
+   .claude/skills/dispatch-token-audit/scripts/generate-phase-model-policy.sh tmp/usage-audit.json \
+     > "$POLICY_DIR/phase-model-policy.json"
+   ```
+
+   Run this Bash call with `dangerouslyDisableSandbox: true`. `dispatch.config/` lives at the **project root**, which is NOT in `settings.json`'s `allowWrite` list (see `.claude/rules/sandbox.md`), so a sandboxed write fails read-only. Resolve the path exactly as `dispatch-config-load` does — `resolve_project_root` from `lib.sh`, then `/dispatch.config`. Because that directory is OUTSIDE the worktree, the write does not dirty git.
+
+   What the policy does: `dispatch-phase-model` reads it at tick time and routes `qa`/`review` either to Sonnet (`claude-sonnet-4-6`, keep cheap) when the pooled hit-rate is at/above the floor with enough samples, or promotes to Opus (`claude-opus-4-8`) when the hit-rate falls below the floor. Phases outside `{qa, review}` are never routed. The producer is a pure function of `tmp/usage-audit.json` (no clock call). With healthy data both phases route to Sonnet — identical to the current defaults — so writing by default changes nothing until evidence accumulates and flips a phase to `promote`. `force-opus.json` overrides this policy downstream, and deleting `phase-model-policy.json` reverts every phase to the hardcoded defaults.
+
+8. **Otherwise report-only.** Apart from the one `phase-model-policy.json` control-artifact write in step 7, the skill creates NO GitHub issues and modifies NO dispatch workflow files. The user reads the report and decides what else to file. This keeps the skill from racing or duplicating the optimization issues it surfaces (e.g. #1171, #1172).
 
 ## Per-run outcome hit-rates
 

--- a/.claude/skills/dispatch-token-audit/scripts/generate-phase-model-policy.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/generate-phase-model-policy.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Phase-model routing policy generator for the /dispatch-token-audit skill (#2028).
+#
+# This is the PRODUCER half of the audit-time routing loop. It consumes the one
+# structured aggregate document emitted by aggregate-usage.sh (tmp/usage-audit.json)
+# and emits the phase-model-policy.json artifact that `dispatch-phase-model` reads
+# at tick time. The audit measures per-phase hit-rate + cost; this script turns
+# that measurement into a model-routing decision, closing the loop without a human
+# in between.
+#
+# WHAT IT READS (slices of the aggregate doc — see aggregate-usage.sh for the full
+# schema)
+#   .window               { days, since, until, files_scanned, files_failed }
+#   .by_phase_outcome[ph] keyed by the OUTCOME ENUM ("qa", "review" only). Carries
+#                         .sessions (int) and pooled .hit_rate (number, or null
+#                         when its denominator is 0).
+#   .by_phase[ph + "-fix"] keyed by the ATTRIBUTION SKILL ("qa-fix", "review-fix").
+#                         Carries .cost_usd and .price_proxy_usd.
+#
+# THE COST ↔ OUTCOME JOIN
+#   The two namespaces differ. Hit-rate lives under the outcome enum (`qa`,
+#   `review`); cost lives under the attribution skill (`qa-fix`, `review-fix`).
+#   This script JOINS them: outcome `qa` ↔ cost `qa-fix`, outcome `review` ↔ cost
+#   `review-fix`. The only phases with hit-rate data — and the only phases worth
+#   routing — are `qa` and `review`.
+#
+# DEMOTABLE ALLOWLIST (the structural AC#4 guarantee)
+#   The decision loop iterates ONLY over ["qa","review"]. A route is NEVER emitted
+#   for any phase outside that set, even if the input carries great numbers for some
+#   other phase (e.g. a bogus `by_phase_outcome.implement`). This mirrors the
+#   consumer's fail-closed allowlist in `dispatch-phase-model`: defense-in-depth so
+#   a code-authoring phase can never be demoted to a cheaper model.
+#
+# DECISION LOGIC (per phase $ph in {qa, review})
+#   sessions < MIN_SAMPLE  OR  hit_rate == null  → OMIT from routes (decision
+#                                                   "insufficient-sample"; the
+#                                                   rationale records why so a
+#                                                   human can see it).
+#   hit_rate >= HIT_RATE_FLOOR                    → routes[ph]="claude-sonnet-4-6"
+#                                                   (decision "keep-cheap").
+#   hit_rate <  HIT_RATE_FLOOR                    → routes[ph]="claude-opus-4-8"
+#                                                   (decision "promote").
+#   Every evaluated phase (routed AND omitted) gets a rationale entry carrying
+#   {decision, sessions, hit_rate, cost_usd, price_proxy_usd}.
+#
+# CONSTANTS / ENV SEAMS
+#   MIN_SAMPLE      (default 20) minimum sessions before a phase is routed.
+#   HIT_RATE_FLOOR  (default 0.5) pooled hit-rate at/above which a phase stays on
+#                   the cheap model; below it the phase is promoted to Opus.
+#   Both are ENV-OVERRIDABLE test seams and are passed into jq as NUMBERS via
+#   --argjson, never strings.
+#
+# DAY-ONE DEFAULT BEHAVIOR
+#   With healthy data, both qa and review have hit_rate >= floor, so both route to
+#   Sonnet ("claude-sonnet-4-6") — exactly the current hardcoded default map in
+#   `dispatch-phase-model`. So writing this artifact by default changes NOTHING
+#   until evidence (a low pooled hit-rate with enough samples) accumulates and
+#   flips a phase to "promote". Until then the policy is a no-op echo of defaults.
+#
+# PURE-FUNCTION / NO-CLOCK DISCIPLINE
+#   This script is a PURE, DETERMINISTIC function of its input. It makes NO clock
+#   call: `generated_at` and the emitted `window` are derived from the input's
+#   `.window` (generated_at = window.until). The same input always yields the same
+#   output — which is what makes the test fixtures reproducible.
+#
+# USAGE
+#   generate-phase-model-policy.sh [PATH]   PATH to the aggregate doc, or stdin
+#                                           when no arg is given.
+#   Output: the policy JSON (phase-model-policy schema) to stdout. The output is
+#   guaranteed to pass `dispatch-config-load phase-model-policy`.
+set -euo pipefail
+
+SRC="${1:-/dev/stdin}"
+MIN_SAMPLE="${MIN_SAMPLE:-20}"
+HIT_RATE_FLOOR="${HIT_RATE_FLOOR:-0.5}"
+
+jq -n \
+  --argjson min_sample "$MIN_SAMPLE" \
+  --argjson floor "$HIT_RATE_FLOOR" \
+  --slurpfile doc "$SRC" \
+  '
+  $doc[0] as $d
+  | ($d.window) as $w
+  | reduce ["qa","review"][] as $ph ({routes:{}, rationale:{}};
+      ($d.by_phase_outcome[$ph]) as $oc
+      | ($oc.sessions // 0) as $sessions
+      | ($oc.hit_rate) as $hr
+      | ($d.by_phase[$ph + "-fix"]) as $cost
+      | (if $cost == null then null else $cost.cost_usd end) as $cu
+      | (if $cost == null then null else $cost.price_proxy_usd end) as $pp
+      | if ($sessions < $min_sample) or ($hr == null) then
+          .rationale[$ph] = {decision:"insufficient-sample", sessions:$sessions, hit_rate:$hr, cost_usd:$cu, price_proxy_usd:$pp}
+        elif ($hr >= $floor) then
+          .routes[$ph] = "claude-sonnet-4-6"
+          | .rationale[$ph] = {decision:"keep-cheap", sessions:$sessions, hit_rate:$hr, cost_usd:$cu, price_proxy_usd:$pp}
+        else
+          .routes[$ph] = "claude-opus-4-8"
+          | .rationale[$ph] = {decision:"promote", sessions:$sessions, hit_rate:$hr, cost_usd:$cu, price_proxy_usd:$pp}
+        end
+    )
+  | {schema_version: 1, generated_at: ($w.until), window: {days: $w.days, since: $w.since, until: $w.until}, routes: .routes, rationale: .rationale}
+  '

--- a/.claude/skills/dispatch-token-audit/scripts/test-generate-phase-model-policy.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-generate-phase-model-policy.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Self-contained unit test for generate-phase-model-policy.sh (#2028).
+#
+# Builds small hand-computed usage-audit.json fixtures with `jq -n`, feeds each
+# to the generator (SUT), and asserts on the emitted .routes / .rationale /
+# .window / .generated_at. Also round-trips the output through
+# dispatch-config-load phase-model-policy to prove the emitted JSON validates.
+#
+# Usage: bash test-generate-phase-model-policy.sh
+# Exit 0 = all passed; non-zero = one or more failures.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+SUT="$SCRIPT_DIR/generate-phase-model-policy.sh"
+CONFIG_LOAD="$SCRIPT_DIR/../../dispatch-propagate/scripts/dispatch-config-load"
+
+# --- test helpers -----------------------------------------------------------
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected: '$expected'"
+    echo "    actual:   '$actual'"
+  fi
+}
+
+report_results() {
+  echo ""
+  echo "================================"
+  echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+  echo "================================"
+}
+
+# --- fixtures ---------------------------------------------------------------
+
+# A baseline window block reused across fixtures. files_scanned/files_failed are
+# present so we can assert the SUT DROPS them from the emitted window subset.
+WINDOW='{days:7,since:"2026-06-13",until:"2026-06-20",files_scanned:100,files_failed:0}'
+
+# Healthy fixture: qa high hit-rate (keep-cheap), review low hit-rate (promote),
+# both with enough samples. Also carries a BOGUS by_phase_outcome.implement with
+# great numbers that the SUT must IGNORE (allowlist guard).
+HEALTHY=$(jq -n "{
+  window: $WINDOW,
+  by_phase_outcome: {
+    qa:        {sessions:24, hit_rate:0.62},
+    review:    {sessions:30, hit_rate:0.18},
+    implement: {sessions:999, hit_rate:0.99}
+  },
+  by_phase: {
+    \"qa-fix\":     {cost_usd:1.23, price_proxy_usd:4.56},
+    \"review-fix\": {cost_usd:2.10, price_proxy_usd:5.40}
+  }
+}")
+
+# Under-sample fixture: qa below MIN_SAMPLE (omit), review null hit_rate (omit).
+UNDERSAMPLE=$(jq -n "{
+  window: $WINDOW,
+  by_phase_outcome: {
+    qa:     {sessions:10, hit_rate:0.62},
+    review: {sessions:30, hit_rate:null}
+  },
+  by_phase: {
+    \"qa-fix\":     {cost_usd:1.23, price_proxy_usd:4.56},
+    \"review-fix\": {cost_usd:2.10, price_proxy_usd:5.40}
+  }
+}")
+
+# Flip fixture: qa hit_rate 0.6 with 10 sessions. At defaults it is OMITTED
+# (10 < 20). With MIN_SAMPLE=5 it routes; with HIT_RATE_FLOOR=0.9 it flips from
+# keep-cheap to promote.
+FLIP=$(jq -n "{
+  window: $WINDOW,
+  by_phase_outcome: {
+    qa:     {sessions:10, hit_rate:0.6},
+    review: {sessions:30, hit_rate:0.18}
+  },
+  by_phase: {
+    \"qa-fix\":     {cost_usd:1.23, price_proxy_usd:4.56},
+    \"review-fix\": {cost_usd:2.10, price_proxy_usd:5.40}
+  }
+}")
+
+# --- tests ------------------------------------------------------------------
+
+echo "=== healthy: keep-cheap / promote routing ==="
+HEALTHY_OUT=$(printf '%s' "$HEALTHY" | "$SUT")
+assert_eq "healthy: routes.qa == claude-sonnet-4-6 (keep-cheap)" \
+  "claude-sonnet-4-6" "$(jq -r '.routes.qa' <<<"$HEALTHY_OUT")"
+assert_eq "healthy: rationale.qa.decision == keep-cheap" \
+  "keep-cheap" "$(jq -r '.rationale.qa.decision' <<<"$HEALTHY_OUT")"
+assert_eq "healthy: routes.review == claude-opus-4-8 (promote)" \
+  "claude-opus-4-8" "$(jq -r '.routes.review' <<<"$HEALTHY_OUT")"
+assert_eq "healthy: rationale.review.decision == promote" \
+  "promote" "$(jq -r '.rationale.review.decision' <<<"$HEALTHY_OUT")"
+# cost join surfaced into rationale
+assert_eq "healthy: rationale.qa.cost_usd joined from by_phase[qa-fix]" \
+  "1.23" "$(jq -r '.rationale.qa.cost_usd' <<<"$HEALTHY_OUT")"
+assert_eq "healthy: rationale.review.price_proxy_usd joined from by_phase[review-fix]" \
+  "5.40" "$(jq -r '.rationale.review.price_proxy_usd' <<<"$HEALTHY_OUT")"
+
+echo "=== allowlist guard: never emits a non-{qa,review} route ==="
+assert_eq "healthy: routes keys are subset of [qa,review]" \
+  "true" "$(jq -c '(.routes | keys) - ["qa","review"] | length == 0' <<<"$HEALTHY_OUT")"
+assert_eq "healthy: routes has no 'implement' key despite great input numbers" \
+  "false" "$(jq -c '.routes | has("implement")' <<<"$HEALTHY_OUT")"
+assert_eq "healthy: rationale has no 'implement' key" \
+  "false" "$(jq -c '.rationale | has("implement")' <<<"$HEALTHY_OUT")"
+
+echo "=== under-sample / null hit_rate: omitted from routes ==="
+UNDER_OUT=$(printf '%s' "$UNDERSAMPLE" | "$SUT")
+assert_eq "undersample: routes omits qa (sessions < MIN_SAMPLE)" \
+  "false" "$(jq -c '.routes | has("qa")' <<<"$UNDER_OUT")"
+assert_eq "undersample: rationale.qa.decision == insufficient-sample" \
+  "insufficient-sample" "$(jq -r '.rationale.qa.decision' <<<"$UNDER_OUT")"
+assert_eq "null hit_rate: routes omits review" \
+  "false" "$(jq -c '.routes | has("review")' <<<"$UNDER_OUT")"
+assert_eq "null hit_rate: rationale.review.decision == insufficient-sample" \
+  "insufficient-sample" "$(jq -r '.rationale.review.decision' <<<"$UNDER_OUT")"
+assert_eq "null hit_rate: rationale.review.hit_rate is null" \
+  "null" "$(jq -c '.rationale.review.hit_rate' <<<"$UNDER_OUT")"
+
+echo "=== env overrides: MIN_SAMPLE / HIT_RATE_FLOOR ==="
+# MIN_SAMPLE=5 lets qa (sessions=10) route; at default 20 it was omitted.
+FLIP_MINSAMPLE=$(MIN_SAMPLE=5 "$SUT" <<<"$FLIP")
+assert_eq "MIN_SAMPLE=5: qa now routed (was omitted at default 20)" \
+  "true" "$(jq -c '.routes | has("qa")' <<<"$FLIP_MINSAMPLE")"
+assert_eq "MIN_SAMPLE=5: qa hit_rate 0.6 >= default floor 0.5 -> keep-cheap" \
+  "claude-sonnet-4-6" "$(jq -r '.routes.qa' <<<"$FLIP_MINSAMPLE")"
+# HIT_RATE_FLOOR=0.9 (with MIN_SAMPLE=5 to admit qa) flips qa from keep-cheap to promote.
+FLIP_FLOOR=$(MIN_SAMPLE=5 HIT_RATE_FLOOR=0.9 "$SUT" <<<"$FLIP")
+assert_eq "HIT_RATE_FLOOR=0.9: qa hit_rate 0.6 < 0.9 -> promote" \
+  "claude-opus-4-8" "$(jq -r '.routes.qa' <<<"$FLIP_FLOOR")"
+assert_eq "HIT_RATE_FLOOR=0.9: rationale.qa.decision == promote" \
+  "promote" "$(jq -r '.rationale.qa.decision' <<<"$FLIP_FLOOR")"
+
+echo "=== determinism: generated_at / window subset ==="
+assert_eq "generated_at == window.until" \
+  "2026-06-20" "$(jq -r '.generated_at' <<<"$HEALTHY_OUT")"
+assert_eq "window carries days/since/until only (DROPS files_scanned)" \
+  '["days","since","until"]' "$(jq -c '.window | keys' <<<"$HEALTHY_OUT")"
+assert_eq "window.until == 2026-06-20" \
+  "2026-06-20" "$(jq -r '.window.until' <<<"$HEALTHY_OUT")"
+
+echo "=== round-trip: emitted JSON passes dispatch-config-load ==="
+RT_DIR=$(mktemp -d)
+printf '%s' "$HEALTHY_OUT" > "$RT_DIR/phase-model-policy.json"
+if DISPATCH_CONFIG_DIR="$RT_DIR" "$CONFIG_LOAD" phase-model-policy >/dev/null 2>"$RT_DIR/err.txt"; then
+  rt_rc=0
+else
+  rt_rc=$?
+fi
+assert_eq "round-trip: dispatch-config-load phase-model-policy exits 0 (populated routes)" \
+  "0" "$rt_rc"
+if [[ "$rt_rc" != 0 ]]; then
+  echo "    config-load stderr:"; sed 's/^/      /' "$RT_DIR/err.txt"
+fi
+rm -rf "$RT_DIR"
+
+report_results
+exit "$FAIL"


### PR DESCRIPTION
Closes #2028

## What

Closes the phase-to-model routing loop **at audit time, not on the hot path**.
`/dispatch-token-audit` now derives a phase-to-model **policy** from aggregated
per-model cost and per-phase hit-rate and writes it to a small JSON artifact;
`dispatch-phase-model` consults that artifact at tick time as a cheap lookup and
falls back to its hardcoded defaults when no policy exists. The tick performs no
learning.

## How

### Consumer (Unit 1)

- **`dispatch-config-load`** — new `phase-model-policy` config type with schema
  validation. Only the load-bearing `.routes` object is strictly validated (each
  value a non-empty string); `schema_version` / `generated_at` / `window` /
  `rationale` are free-form provenance.
- **`dispatch-phase-model`** — consults `dispatch.config/phase-model-policy.json`
  via `dispatch-config-load` (cheap lookup, no learning). A policy route overrides
  the hardcoded default **only** for the demotable allowlist `{qa, review}`; any
  other phase ignores the policy and uses its default — fail-closed
  defense-in-depth so a hand-edited policy can never demote a code-authoring phase
  (`implement`/`fix`) off Opus. A malformed/invalid policy fails **loudly**
  (surfaces the error, exits non-zero) rather than silently falling back, per
  `.claude/rules/code-style.md`.
- **`force-opus` already overrides this downstream** at the `dispatch-spawn-job`
  chokepoint, so the manual override and the kill switch are satisfied with no
  change to `dispatch-spawn-job`.

### Producer (Unit 2)

- **`generate-phase-model-policy.sh`** — new pure bash+jq generator. A
  deterministic function of `tmp/usage-audit.json` (no clock call;
  `generated_at`/`window` derived from the input's `.window`). It joins the two
  namespaces (`by_phase_outcome` hit-rate ↔ `by_phase` cost — `review`↔`review-fix`,
  `qa`↔`qa-fix`) and, over the `{qa, review}` allowlist only:
  hit-rate ≥ floor with enough samples → keep cheap (Sonnet); hit-rate < floor →
  promote to Opus; below the sample floor or null hit-rate → omit (default
  applies). `MIN_SAMPLE` (20) and `HIT_RATE_FLOOR` (0.5) are baked constants,
  env-overridable as test seams. It **never** emits a route outside `{qa, review}`
  — the structural guarantee behind the never-auto-demote-code-phases property.
  On healthy day-one data the result is the current map (`qa`/`review` → Sonnet),
  so writing-by-default changes nothing until evidence accumulates.
- **`/dispatch-token-audit`** writes the policy by default after aggregation. The
  audit is no longer purely report-only: it still creates no GitHub issues and
  edits no workflow files, but it now writes the one `phase-model-policy.json`
  control artifact (outside every worktree, so it does not dirty git).
  `force-opus` or deleting the file reverts it.

### Tests / CI

- `test-dispatch-phase-model.sh` (consumer) and `test-generate-phase-model-policy.sh`
  (producer, incl. a round-trip through `dispatch-config-load`).
- `run-unit-tests.sh` now discovers + change-gates `dispatch-token-audit/scripts/`,
  bringing the new generator test — and, as a side benefit, the pre-existing
  `test-aggregate-usage.sh` / `test-audit-aggregate-writer.sh` — under CI.

## Verification

All three plan ```verify blocks pass: `test-dispatch-phase-model.sh` (15/15),
`test-generate-phase-model-policy.sh` (22/22), and the full
`run-unit-tests.sh` ("All unit test suites passed").
