### PR TITLE
dispatch: max-hold/heartbeat staleness cap on the selection lock

### DIFF
--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -126,6 +126,56 @@ lock is reclaimed automatically. Same-session re-entry (e.g. after a context cle
 cleanly because the recorded sessionId matches the re-entering session's own
 `CLAUDE_CODE_SESSION_ID`.
 
+## Max-hold / heartbeat staleness cap
+
+Before #2104, the dead-holder reclaim covered the case where a router crashes mid-selection
+and its sessionId disappears from `claude agents --json`. It did not cover a holder that is
+still live but wedged — a session that resumed after a crash without releasing, or one that
+stalled indefinitely inside a retry or wait loop. A wedged live holder blocked the chain
+permanently because no acquisition could proceed against a foreign sessionId that remained
+visible in the agents list.
+
+The staleness cap adds a second reclaim condition: if the recorded foreign holder is live but
+the lock-file mtime is older than `max_hold_seconds`, the acquirer reclaims it regardless,
+logging a `reclaimed stale lock from … (held …s > max_hold …s)` diagnostic. This reclaim
+runs AFTER the existing liveness resolve, so a daemon probe failure that returns UNKNOWN still
+folds to LIVE→BUSY — the acquirer does not steal on uncertainty. `max_hold_seconds` is
+configured in `dispatch.config/selection-lock.json` (`{ "max_hold_seconds": 300 }`), with
+`DISPATCH_LOCK_MAX_HOLD_SECONDS` as an env override; config takes precedence. The default is
+300 seconds.
+
+The **lock-file mtime is the heartbeat**. Only a claim/reclaim write or a `--heartbeat`
+touch bumps it; the low-level append-open and flock do not. `dispatch-acquire-lock
+--heartbeat` is a strict-owner mode: if the caller's sessionId matches the recorded holder it
+bumps the mtime and prints `refreshed`; otherwise it noops. It issues no daemon probe and
+completes in under 100ms. The held region (`dispatch-select-tick`, `dispatch-materialize-spawn`)
+calls `--heartbeat` after each best-effort sub-step completes and before each cross-process
+HOLD handoff.
+
+Three invariants govern correctness of this mechanism:
+
+1. **`max_hold_seconds` bounds the worst-case gap between two consecutive heartbeat *refreshes*,
+   not the worst-case total hold duration.** A dispossessed holder is never signaled it lost the
+   lock: after a stale-reclaim, its next `--heartbeat` sees a foreign sessionId and silently
+   noops. The guarantee against a false reclaim is therefore "heartbeats keep arriving faster
+   than `max_hold_seconds`," not "the hold is short." Legitimate multi-step sequences
+   that take longer than 300 seconds are safe as long as each sub-step finishes and fires a
+   heartbeat within the window.
+
+2. **Heartbeats fire on sub-step *completion*, never inside a retry / poll / wait loop.** The
+   failure mode being fixed is a holder wedged inside a loop — one that is live (visible to
+   `claude agents --json`) but making no selection progress. Placing a refresh inside such a
+   loop would keep the mtime fresh while the holder spins and the wedge would recur. Refreshes
+   are placed only after a sub-step returns, ensuring that a genuinely stalled holder stops
+   refreshing and becomes reclaimable.
+
+3. **The per-worktree spawn dedup — not the heartbeat — is the real #1068 safety net.** When a
+   stale-reclaim races a still-live holder, both may proceed to the selection scan. The existing
+   per-worktree dedup in `dispatch-spawn-job` is what prevents two selectors from spawning the
+   same target. Live-stale reclaim exercises that backstop more often than the existing dead-holder
+   reclaim does. The no-reclaim-when-fresh behavior keeps the race rare; the per-worktree marker
+   keeps it safe when it happens.
+
 ## Per-worktree invariant
 
 The selection lock is **per-repo** and serializes the router's selection
@@ -151,6 +201,8 @@ The two mechanisms have orthogonal scopes:
 
 - **Selection lock** — per-repo, held by the router for the
   duration of Steps 1–5. Prevents two routers from selecting the same target.
+  A live-but-wedged holder is reclaimed once its heartbeat (lock-file mtime) exceeds
+  `max_hold_seconds` (default 300; see *Max-hold / heartbeat staleness cap*).
 - **Per-worktree dedup** (`dispatch-launch-worker`, via `dispatch-spawn-job`) —
   per-worktree-path, enforced at every router-to-worker spawn. Prevents two
   workers from racing on the same issue.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-acquire-lock
@@ -78,6 +78,30 @@
 # the marker exists, so the lenient branch does not engage and strict semantics
 # apply.
 #
+# Staleness-reclaim contract (#2104). Implicit/self-healing release reclaims a
+# DEAD holder; the staleness cap reclaims a LIVE-but-WEDGED holder. The lock-file
+# mtime is the heartbeat: only a claim/reclaim write or a `--heartbeat` touch
+# bumps it; the `exec 9>>` append-open and the `flock` do NOT. A holder that
+# wedges (e.g. spins forever in some step) stops emitting heartbeats, so its mtime
+# goes stale, and the next acquire reclaims the lock once the mtime is older than
+# MAX_HOLD_SECONDS — even though the session is still live in the registry. Three
+# invariants make this safe:
+#   INVARIANT #1 — MAX_HOLD_SECONDS bounds the worst-case gap between two
+#     CONSECUTIVE heartbeat refreshes during legitimate work, NOT the worst-case
+#     total hold. A dispossessed holder is never signaled it lost the lock (its
+#     next `--heartbeat` reads a foreign sid and noops), so the guarantee against
+#     a false reclaim is "heartbeats keep coming faster than MAX_HOLD_SECONDS,"
+#     not "the hold is short." A legitimately-long hold stays safe as long as it
+#     keeps refreshing.
+#   INVARIANT #2 — heartbeats fire on a step's COMPLETION, never inside a
+#     retry/poll/wait loop. A refresh inside a loop would keep the mtime fresh
+#     while the holder spins there, defeating the cap (the original wedge). This
+#     wiring lives at the call sites (a later unit), not in this script.
+#   INVARIANT #3 — when a stale-reclaim races a still-live holder, the
+#     reservation-marker / per-worktree spawn dedup — NOT the heartbeat — is the
+#     real #1068 safety net. No-reclaim-when-fresh keeps the race rare; the marker
+#     keeps it safe.
+#
 # Usage:
 #   dispatch-acquire-lock            — single-shot: print "acquired" or "busy".
 #   dispatch-acquire-lock --wait     — poll until acquired or the wait timeout
@@ -85,6 +109,9 @@
 #   dispatch-acquire-lock --release  — clear our own recorded sessionId from
 #                                      the lock file; print "released" or
 #                                      "noop".
+#   dispatch-acquire-lock --heartbeat — strict-owner: bump the lock-file mtime
+#                                      (the heartbeat) iff we hold the lock;
+#                                      print "refreshed" or "noop".
 #
 # Environment overrides for testability:
 #   DISPATCH_LOCK_FILE          Override the lock-file path. When set, the
@@ -112,6 +139,17 @@
 #                               section, so a waiter must not abandon a holder
 #                               that is legitimately mid-probe. Enforced at
 #                               startup (exit 2 on violation). Default: 15.
+#   DISPATCH_LOCK_MAX_HOLD_SECONDS
+#                               Max-hold / heartbeat staleness cap, in seconds: a
+#                               LIVE holder whose heartbeat (lock-file mtime) is
+#                               older than this is reclaimed by the next acquire,
+#                               even though its session is still live. Must be a
+#                               positive integer (^[0-9]+$). Lowest precedence
+#                               below selection-lock.json's max_hold_seconds;
+#                               default 300. See the staleness-reclaim contract
+#                               below. selection-lock.json max_hold_seconds
+#                               (loaded via dispatch-config-load) takes precedence
+#                               over this env var.
 #
 # Stdout protocol (exactly one word):
 #   acquired  this dispatch tick holds the lock — proceed with the tick.
@@ -123,8 +161,9 @@
 #             sessionId, or "(flock wait timeout)") is written to stderr.
 #   released  --release: our own recorded sessionId was cleared from the lock
 #             file.
-#   noop      --release: nothing to release — the lock was unheld or held by
-#             another session, so the file was left untouched.
+#   refreshed --heartbeat: we hold the lock; its mtime (heartbeat) was bumped.
+#   noop      --release OR --heartbeat: nothing to do — the lock was unheld or
+#             held by another session, so the file was left untouched.
 #
 # Exit codes:
 #   0  acquired/busy/released/noop (all are normal outcomes; stdout
@@ -139,7 +178,8 @@
 # NOT set -e: exits are handled explicitly (matching the sibling dispatch-sweep).
 set -uo pipefail
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
 
 # ---- Step 0: parse the mode -------------------------------------------------
 # Done before any side effect so an unknown argument exits 2 cleanly: no lock
@@ -147,8 +187,9 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 MODE="acquire"
 if [[ $# -gt 0 ]]; then
   case "$1" in
-    --wait)    MODE="wait" ;;
-    --release) MODE="release" ;;
+    --wait)      MODE="wait" ;;
+    --release)   MODE="release" ;;
+    --heartbeat) MODE="heartbeat" ;;
     *) echo "dispatch-acquire-lock: unknown argument '$1'" >&2; exit 2 ;;
   esac
   if [[ $# -gt 1 ]]; then
@@ -160,6 +201,45 @@ WAIT_TIMEOUT="${DISPATCH_LOCK_WAIT_TIMEOUT:-300}"
 WAIT_INTERVAL="${DISPATCH_LOCK_WAIT_INTERVAL:-5}"
 PROBE_TIMEOUT="${DISPATCH_LOCK_PROBE_TIMEOUT:-10}"
 FLOCK_TIMEOUT="${DISPATCH_LOCK_FLOCK_TIMEOUT:-15}"
+
+# ---- resolve the max-hold / heartbeat staleness cap -------------------------
+# MAX_HOLD_SECONDS bounds how stale a live holder's heartbeat (the lock-file
+# mtime) may get before the next acquire reclaims the lock — even though the
+# holder's session is still live. Resolved ONCE here, above the --wait poll loop,
+# never inside try_acquire (which forks a subshell every poll). Only acquire/wait
+# consume it; release/heartbeat skip the config shell-out entirely.
+#
+# INVARIANT #1: this caps the gap between two CONSECUTIVE heartbeat refreshes
+# during legitimate work, NOT the worst-case total hold. A dispossessed holder is
+# never told it lost the lock (its next --heartbeat reads a foreign sid and
+# noops), so the guarantee against a false reclaim is "refreshes keep arriving
+# faster than MAX_HOLD_SECONDS," not "the hold is short."
+#
+# Precedence mirrors dispatch-sweep: selection-lock.json max_hold_seconds (valid
+# integer) > DISPATCH_LOCK_MAX_HOLD_SECONDS env (^[0-9]+$) > baked default 300.
+# The config-load shell-out is TOLERANT (the `if ...; then ... else` wrapping):
+# an absent or erroring dispatch-config-load — the lock test harness copies only
+# dispatch-acquire-lock + lib.sh — falls back to env/default instead of erroring.
+# The default (300) pairs with dense per-sub-step heartbeat placement so the
+# worst-case inter-refresh gap stays well under 300s, and lets a single in-flight
+# --wait call (DISPATCH_LOCK_WAIT_TIMEOUT also defaults to 300) self-reclaim a
+# holder that goes stale mid-wait → one-tick recovery.
+MAX_HOLD_SECONDS=300
+if [[ "$MODE" == "acquire" || "$MODE" == "wait" ]]; then
+  if CONFIG_OUT=$("$SCRIPT_DIR/dispatch-config-load" selection-lock 2>&1); then
+    val=""
+    if [[ "$CONFIG_OUT" != "no-config" ]]; then
+      val=$(jq -r '.max_hold_seconds // empty' <<<"$CONFIG_OUT")
+    fi
+    if [[ "$val" =~ ^[0-9]+$ ]]; then
+      MAX_HOLD_SECONDS="$val"
+    elif [[ "${DISPATCH_LOCK_MAX_HOLD_SECONDS:-}" =~ ^[0-9]+$ ]]; then
+      MAX_HOLD_SECONDS="$DISPATCH_LOCK_MAX_HOLD_SECONDS"
+    fi
+  elif [[ "${DISPATCH_LOCK_MAX_HOLD_SECONDS:-}" =~ ^[0-9]+$ ]]; then
+    MAX_HOLD_SECONDS="$DISPATCH_LOCK_MAX_HOLD_SECONDS"
+  fi
+fi
 
 # resolve_holder_state <sessionId> — query the daemon's live-session registry
 # for <sessionId> and report its liveness via the return code. Covers the same
@@ -294,7 +374,29 @@ try_acquire() {            # 0 = acquired, 1 = contended; sets CONTENDED_SID
         live=1
       fi
       if (( live )); then
-        printf 'BUSY %s' "$recorded"
+        # Staleness cap (#2104): a live holder whose heartbeat — the lock-file
+        # mtime — is older than MAX_HOLD_SECONDS is wedged, so reclaim it even
+        # though its session is still live. This sits AFTER resolve_holder_state
+        # so an opaque daemon failure still folds to LIVE→BUSY (never steal on
+        # UNKNOWN). The mtime IS the heartbeat: the append-open + flock above do
+        # not bump it; only a claim/reclaim write or a --heartbeat touch does, so
+        # a wedged holder's mtime genuinely goes stale. The `holder_mtime != 0`
+        # guard makes a `stat` failure fail safe — without it `echo 0` would make
+        # `age` huge and spuriously reclaim a fresh holder. INVARIANT #3: when
+        # this stale-reclaim races a still-live holder, the reservation-marker /
+        # per-worktree spawn dedup — NOT the heartbeat — is the real #1068 net;
+        # no-reclaim-when-fresh keeps the race rare, the marker keeps it safe.
+        local holder_mtime now age
+        holder_mtime=$(stat -c %Y "$LOCK_FILE" 2>/dev/null || echo 0)
+        now=$(date +%s)
+        age=$(( now - holder_mtime ))
+        if (( holder_mtime != 0 && age > MAX_HOLD_SECONDS )); then
+          printf '%s\n' "$SESSION_ID" >"$LOCK_FILE"
+          echo "dispatch-acquire-lock: reclaimed stale lock from $recorded (held ${age}s > max_hold ${MAX_HOLD_SECONDS}s)" >&2
+          printf 'OK'
+        else
+          printf 'BUSY %s' "$recorded"
+        fi
       else
         # Dead holder (not in registry): reclaim regardless of marker state.
         # A dead holder no longer holds the lock in any region (Steps 0–6 or
@@ -323,11 +425,11 @@ try_acquire() {            # 0 = acquired, 1 = contended; sets CONTENDED_SID
 
 # ---- validate the timeout knobs ---------------------------------------------
 # Only try_acquire (acquire/wait modes) consumes the probe + in-section flock
-# timeouts; --release uses neither, so leave it unvalidated and unchanged.
-# A misconfigured knob is a broken environment — fail clear (exit 2), do not
-# fall back (matches the clear-error-over-fallback rule; same convention as the
-# git-repo and CLAUDE_CODE_SESSION_ID guards above).
-if [[ "$MODE" != "release" ]]; then
+# timeouts; --release and --heartbeat use neither, so leave them unvalidated and
+# unchanged. A misconfigured knob is a broken environment — fail clear (exit 2),
+# do not fall back (matches the clear-error-over-fallback rule; same convention
+# as the git-repo and CLAUDE_CODE_SESSION_ID guards above).
+if [[ "$MODE" != "release" && "$MODE" != "heartbeat" ]]; then
   # PROBE_TIMEOUT must be a POSITIVE integer. `^[0-9]+$` alone is not enough:
   # GNU `timeout 0 <cmd>` DISABLES the bound and runs the probe unbounded,
   # silently re-opening the very wedged-daemon hang this script fixes (#1315).
@@ -413,6 +515,40 @@ case "$MODE" in
       RELEASED) echo released ;;
       NOOP)     echo noop ;;
       *) echo "dispatch-acquire-lock: --release — unexpected subshell output '$result'" >&2
+         exit 2 ;;
+    esac
+    exit 0
+    ;;
+
+  heartbeat)
+    # Strict-owner heartbeat: bump the lock-file mtime — the heartbeat carrier —
+    # iff we are the recorded holder, so a legitimately-long hold stays fresh and
+    # the staleness cap never reclaims it mid-work. `touch` is atomic and
+    # content-preserving (the recorded sessionId is untouched). NEVER refreshes a
+    # foreign holder's lock: a dispossessed holder reading a foreign sid here gets
+    # a silent noop (invariant #1 — it is never signaled it lost the lock). Issues
+    # NO `claude agents --json` probe, so a refresh stays sub-100ms.
+    #
+    # INVARIANT #2 (enforced at the CALL SITES, not here): refresh_lock callers
+    # must fire --heartbeat only on a sub-step's COMPLETION, never inside a
+    # retry/poll/wait loop — a refresh inside a loop would keep mtime fresh while
+    # the holder spins there, defeating the cap (the original wedge).
+    result=$(
+      exec 9>>"$LOCK_FILE"
+      flock 9
+      recorded=""    # plain var: this subshell runs at script top level
+      IFS= read -r recorded <"$LOCK_FILE" 2>/dev/null || true
+      if [[ -n "$recorded" && "$recorded" == "$SESSION_ID" ]]; then
+        touch "$LOCK_FILE"
+        printf 'REFRESHED'
+      else
+        printf 'NOOP'
+      fi
+    )
+    case "$result" in
+      REFRESHED) echo refreshed ;;
+      NOOP)      echo noop ;;
+      *) echo "dispatch-acquire-lock: --heartbeat — unexpected subshell output '$result'" >&2
          exit 2 ;;
     esac
     exit 0

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-config-load
@@ -7,7 +7,7 @@
 # the normalized result to stdout.
 #
 # Usage:
-#   dispatch-config-load <projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus|sweep>
+#   dispatch-config-load <projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus|sweep|selection-lock>
 #
 # Config files live in <project-root>/dispatch.config/. The project root is
 # resolved via resolve_project_root (lib.sh).
@@ -266,6 +266,28 @@
 #     "notInSyncGraceSeconds": 86400
 #   }
 #
+# ---- Schema: selection-lock.json -------------------------------------------
+#
+# Top-level object with optional tunables for the dispatch selection lock
+# (`dispatch-acquire-lock`). Each field must be a number when present; absent
+# fields fall back to the defaults baked into `dispatch-acquire-lock`. This
+# config type follows the GENERIC absent→inert convention (see "Stdout protocol"
+# above): when the file is absent, no-config is emitted and the consumer uses its
+# built-in defaults.
+#
+#   max_hold_seconds        number (optional, must be a positive integer) — the
+#                           max-hold / heartbeat staleness cap, in seconds. A lock
+#                           holder whose heartbeat (lock-file mtime) is older than
+#                           this is reclaimable by the next acquire even though its
+#                           session is still live. The default value (300) is baked
+#                           into dispatch-acquire-lock, not here. Absent →
+#                           dispatch-acquire-lock uses its default.
+#
+# Example (see selection-lock.example.json):
+#   {
+#     "max_hold_seconds": 300
+#   }
+#
 set -euo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
@@ -274,9 +296,9 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 CONFIG_TYPE="${1:-}"
 case "$CONFIG_TYPE" in
-  projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus|sweep) ;;
+  projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus|sweep|selection-lock) ;;
   *)
-    echo "error: usage: dispatch-config-load <projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus|sweep>" >&2
+    echo "error: usage: dispatch-config-load <projects|jit|statements|target-workers|budget-etl|epic|auto-merge|force-opus|sweep|selection-lock>" >&2
     exit 2
     ;;
 esac
@@ -653,6 +675,35 @@ case "$CONFIG_TYPE" in
           # integer comparison, raise an arithmetic error, and fall through to
           # the reap branch — immediately force-reaping every not-in-sync worktree.
           "notInSyncGraceSeconds must be a whole number (integer), got \($cfg.notInSyncGraceSeconds)"
+        else
+          empty
+        end)
+      end
+    ' "$CONFIG_FILE")
+    ;;
+  selection-lock)
+    # top-level value must be an object; the single tunable is optional.
+    # `dispatch-acquire-lock` substitutes a baked-in default (300) when the field
+    # is absent, so absence is silent — only the type of a present field is checked.
+    ERRORS=$(jq -r '
+      if type != "object" then
+        "top-level value must be a JSON object, got \(type)"
+      else
+        . as $cfg |
+        # max_hold_seconds: optional positive integer
+        (if ($cfg | has("max_hold_seconds")) | not then
+          empty
+        elif ($cfg.max_hold_seconds | type) != "number" then
+          "max_hold_seconds must be a number if present, got \($cfg.max_hold_seconds | type)"
+        elif $cfg.max_hold_seconds <= 0 then
+          "max_hold_seconds must be > 0 if present, got \($cfg.max_hold_seconds)"
+        elif ($cfg.max_hold_seconds | tostring | test("^[0-9]+$") | not) then
+          # Mirror the env-override contract (^[0-9]+$): reject any value whose
+          # rendered form is not a plain integer. This catches fractions (0.5)
+          # and scientific notation (1e6 -> jq renders "1E+6"); both would reach
+          # the dispatch-acquire-lock bash `(( age > MAX_HOLD_SECONDS ))` integer
+          # comparison, raise an arithmetic error, and break the staleness check.
+          "max_hold_seconds must be a whole number (integer), got \($cfg.max_hold_seconds)"
         else
           empty
         end)

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -154,6 +154,16 @@ release_lock() {
   "$SCRIPT_DIR/dispatch-acquire-lock" --release >/dev/null 2>&1 || true
 }
 
+# refresh_lock — bump the lock-file mtime (the heartbeat) so a legitimately-long
+# hold never goes stale and is never falsely reclaimed by the staleness cap
+# (#2104). INVARIANT #2: call ONLY on a sub-step's completion, never inside a
+# retry/poll/wait loop — a refresh inside a loop would keep mtime fresh while a
+# holder spins there, defeating the cap. Best-effort: a noop (we no longer hold
+# the lock) or any error is swallowed.
+refresh_lock() {
+  "$SCRIPT_DIR/dispatch-acquire-lock" --heartbeat >/dev/null 2>&1 || true
+}
+
 # Write the static identity stub to <worktree>/CLAUDE.local.md. Static identity
 # only (issue number, title, branch, pointer to dispatch-context-pack) — no
 # issue body/comments/related-issue bodies, so it stays tiny and never goes
@@ -238,6 +248,11 @@ process_one_target() {
   local n="$1" mode="$2"
   local PR LEAF ISSUE_STATE BLOCKERS WT_DECISION WT_ACTION WT_REST
   local WORKTREE_PATH BRANCH PROJECT_ROOT rc wt_basename PHASE PROJECT_ROOT_FOR_LOG
+
+  # Heartbeat: refresh on entry to each per-target spawn (#2104). The spawn
+  # fan-out is the #1068-load-bearing region — keep the lock-file mtime fresh so
+  # the staleness cap never reclaims a holder that is legitimately mid-spawn.
+  refresh_lock
 
   # --- Step 4: explicit-path guards (skipped entirely in queue mode) ---------
   # Queue rows were already vetted by dispatch-select-target (leaf, blockers,
@@ -609,6 +624,9 @@ if (( spawned < GAP )); then
     process_one_target "$cur_n" "$cur_mode" || { release_lock; exit 2; }
     SEEN["$cur_n"]=1
     record_outcome "$cur_n"
+    # Heartbeat: refresh after each fan-out target completes — on completion, not
+    # inside an inner retry (#2104, invariant #2).
+    refresh_lock
     (( spawned >= GAP )) && { stop_reason="gap filled"; break; }
   done <<< "$SELECTED"
   # Ran off the end of a short list without filling the gap or hitting a

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -108,6 +108,16 @@ release_lock() {
   "$SCRIPT_DIR/dispatch-acquire-lock" --release >/dev/null 2>&1 || true
 }
 
+# refresh_lock — bump the lock-file mtime (the heartbeat) so a legitimately-long
+# hold never goes stale and is never falsely reclaimed by the staleness cap
+# (#2104). INVARIANT #2: call ONLY on a sub-step's completion, never inside a
+# retry/poll/wait loop — a refresh inside a loop would keep mtime fresh while a
+# holder spins there, defeating the cap. Best-effort: a noop (we no longer hold
+# the lock) or any error is swallowed.
+refresh_lock() {
+  "$SCRIPT_DIR/dispatch-acquire-lock" --heartbeat >/dev/null 2>&1 || true
+}
+
 # --- Step 0: acquire the dispatch lock ---------------------------------------
 # Let acquire-lock's stderr holder-diagnostic flow through on `busy`.
 LOCK=$("$SCRIPT_DIR/dispatch-acquire-lock" --wait) || true
@@ -249,6 +259,11 @@ if [[ "$BRANCH" == "main" ]]; then
   fi
 fi
 
+# Heartbeat: the origin/main sync (Step 1) is the first held best-effort sub-step.
+# Refresh on its completion — unconditionally, outside the main-only block, so a
+# non-main worktree or manual /dispatch tick refreshes too (#2104, invariant #2).
+refresh_lock
+
 # --- Step 1c: re-arm the main-broken latch when main has recovered -----------
 # A diagnosed red episode leaves an open dispatch:main-broken issue — the gate's
 # per-episode latch (#1085). Once origin/main goes green again, close it so the
@@ -303,6 +318,8 @@ if [[ -z "$OPEN_MB" ]]; then
     done <<< "$MERGE_OUT"
   fi
 fi
+# Heartbeat: refresh after the auto-merge sub-step completes (#2104).
+refresh_lock
 
 # --- Step 1b: run-scoped concurrency gate (autonomous no-arg queue path only) -
 # Runs ONLY on the autonomous no-arg queue path. The explicit-target run (a
@@ -418,6 +435,8 @@ if [[ -z "$MANUAL" && -z "$ARG" ]]; then
           # hold the lock, append GAP=1. Counted by
           # claude_agents_count_busy_workers on later ticks, so it suppresses
           # non-priority fan-out — it bypasses the GATE, not the COUNT.
+          # Heartbeat: fresh mtime for the cross-process handoff to dispatch-materialize-spawn (#2104).
+          refresh_lock
           echo "$PRIO 1"
           exit 0
           ;;
@@ -538,6 +557,8 @@ if [[ -n "$JIT_OUT" ]]; then
     [[ -n "$jit_line" ]] && echo "jit: $jit_line"
   done <<< "$JIT_OUT"
 fi
+# Heartbeat: refresh after the JIT engine sub-step completes (#2104).
+refresh_lock
 
 # --- Step 2b: run the Calendar JIT importer (best-effort) --------------------
 # Files one reminder issue per pressing Google Calendar event and closes
@@ -549,6 +570,8 @@ if [[ -n "$CAL_OUT" ]]; then
     [[ -n "$cal_line" ]] && echo "$cal_line"
   done <<< "$CAL_OUT"
 fi
+# Heartbeat: refresh after the calendar-import sub-step completes (#2104).
+refresh_lock
 
 # --- Step 2c: run the statements scan (best-effort) --------------------------
 # Scans each configured statements folder and files one parse-job issue per new
@@ -561,6 +584,8 @@ if [[ -n "$STMT_OUT" ]]; then
     [[ -n "$stmt_line" ]] && echo "statements: $stmt_line"
   done <<< "$STMT_OUT"
 fi
+# Heartbeat: refresh after the statements-scan sub-step completes (#2104).
+refresh_lock
 
 # --- Step 2e: re-triage orphaned review follow-ups (best-effort) -------------
 # Parks open source-pr:<N>-labeled review follow-up issues on office-hours when
@@ -573,12 +598,16 @@ if [[ -n "$RETRIAGE_OUT" ]]; then
     [[ -n "$retriage_line" ]] && echo "retriage: $retriage_line"
   done <<< "$RETRIAGE_OUT"
 fi
+# Heartbeat: refresh after the retriage sub-step completes (#2104).
+refresh_lock
 
 # --- Step 3: select the target -----------------------------------------------
 if [[ -n "$ARG" ]]; then
   TARGET=$("$SCRIPT_DIR/dispatch-resolve-arg" "$ARG")
   RESOLVE_RC=$?
   if (( RESOLVE_RC == 0 )); then
+    # Heartbeat: fresh mtime for the cross-process handoff to dispatch-materialize-spawn (#2104).
+    refresh_lock
     echo "explicit $TARGET $GAP"
     exit 0
   fi
@@ -613,6 +642,8 @@ SELECTED=$("$SCRIPT_DIR/dispatch-select-target") || true
 case "$SELECTED" in
   pr\ *|issue\ *)
     # Hold the lock; append the run-scoped gap the fan-out loop consumes.
+    # Heartbeat: fresh mtime for the cross-process handoff to dispatch-materialize-spawn (#2104).
+    refresh_lock
     echo "$SELECTED $GAP"
     ;;
   main-broken\ *|jit-reminder\ *)

--- a/.claude/skills/dispatch-propagate/scripts/selection-lock.example.json
+++ b/.claude/skills/dispatch-propagate/scripts/selection-lock.example.json
@@ -1,0 +1,3 @@
+{
+  "max_hold_seconds": 300
+}

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -9877,7 +9877,8 @@ lock_teardown() {
   STUB_DIR=""
   unset DISPATCH_LOCK_FILE CLAUDE_CODE_SESSION_ID CLAUDE_AGENTS_CMD \
     DISPATCH_LOCK_WAIT_INTERVAL DISPATCH_LOCK_WAIT_TIMEOUT \
-    DISPATCH_LOCK_PROBE_TIMEOUT DISPATCH_LOCK_FLOCK_TIMEOUT
+    DISPATCH_LOCK_PROBE_TIMEOUT DISPATCH_LOCK_FLOCK_TIMEOUT \
+    DISPATCH_LOCK_MAX_HOLD_SECONDS DISPATCH_CONFIG_DIR
 }
 
 # Helper: install a fake `claude` whose `agents --json` invocation prints a
@@ -10698,6 +10699,117 @@ assert_eq "mid-spawn-died reclaim prints acquired (not busy)" "acquired" "$out"
 lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
 assert_eq "mid-spawn-died reclaim rewrites lock to caller's sessionId" \
   "sess-2727-self" "$lock_contents"
+lock_teardown
+
+# --- Test 28: live-but-stale holder (heartbeat older than max_hold) → reclaim (#2104)
+#
+# Criterion 2: the max-hold/heartbeat staleness cap. The recorded foreign holder
+# IS live in the registry, but its heartbeat — the lock-file mtime — is far older
+# than DISPATCH_LOCK_MAX_HOLD_SECONDS, so it is wedged and must be reclaimed even
+# though its session is still live. No clock injection is needed: age = real_now
+# - old_mtime dominates.
+echo "Test: a live foreign holder whose heartbeat is stale (mtime > max_hold) is reclaimed (#2104)"
+lock_setup
+export CLAUDE_CODE_SESSION_ID="sess-stale-self"
+printf '%s\n' "sess-stale-live" > "$DISPATCH_LOCK_FILE"
+# The foreign holder IS live in the registry (alongside our own session)...
+lock_fake_claude_sessions "sess-stale-live" "sess-stale-self"
+# ...but its heartbeat (lock-file mtime) is far in the past.
+touch -d "@$(( $(date +%s) - 10000 ))" "$DISPATCH_LOCK_FILE"
+export DISPATCH_LOCK_MAX_HOLD_SECONDS=1
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+assert_eq "28 stale-reclaim exits 0" "0" "$rc"
+assert_eq "28 stale-reclaim prints acquired (live but wedged holder)" "acquired" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "28 stale-reclaim rewrites lock to caller's sessionId" "sess-stale-self" "$lock_contents"
+lock_teardown
+
+# --- Test 29: live holder with a FRESH heartbeat → busy (#1068 regression guard, #2104)
+#
+# Criterion 3: no-reclaim-when-fresh. The same live foreign holder, but its
+# heartbeat is fresh (within the cap), so the staleness path must NOT fire — the
+# acquirer stays busy and the lock is left untouched. This is the #1068
+# duplicate-spawn regression guard: a holder refreshing within budget is never
+# reclaimed.
+echo "Test: a live foreign holder with a fresh heartbeat is NOT reclaimed → busy (#1068 guard, #2104)"
+lock_setup
+export CLAUDE_CODE_SESSION_ID="sess-fresh-self"
+printf '%s\n' "sess-fresh-live" > "$DISPATCH_LOCK_FILE"
+lock_fake_claude_sessions "sess-fresh-live" "sess-fresh-self"
+# Fresh mtime (the printf above already wrote it now; touch makes it explicit).
+touch "$DISPATCH_LOCK_FILE"
+export DISPATCH_LOCK_MAX_HOLD_SECONDS=300
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+assert_eq "29 no-reclaim-when-fresh exits 0" "0" "$rc"
+assert_eq "29 no-reclaim-when-fresh prints busy" "busy" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "29 no-reclaim-when-fresh leaves the foreign holder in place" "sess-fresh-live" "$lock_contents"
+lock_teardown
+
+# --- Test 30: --heartbeat bumps the owner's mtime, noops for a non-owner (#2104)
+#
+# The strict-owner heartbeat. As the recorded holder, --heartbeat bumps the
+# lock-file mtime (the heartbeat carrier) and prints "refreshed", preserving the
+# recorded sessionId. As a non-owner it is a noop: mtime unchanged, content
+# unchanged. --heartbeat issues NO `claude agents --json` probe, so no fake
+# registry is needed.
+echo "Test: --heartbeat bumps the owner's mtime and is a noop for a non-owner (#2104)"
+lock_setup
+export CLAUDE_CODE_SESSION_ID="sess-hb-owner"
+printf '%s\n' "sess-hb-owner" > "$DISPATCH_LOCK_FILE"
+old_epoch=$(( $(date +%s) - 5000 ))
+touch -d "@$old_epoch" "$DISPATCH_LOCK_FILE"
+before=$(stat -c %Y "$DISPATCH_LOCK_FILE")
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" --heartbeat 2>/dev/null); rc=$?
+after=$(stat -c %Y "$DISPATCH_LOCK_FILE")
+assert_eq "30 heartbeat owner exits 0" "0" "$rc"
+assert_eq "30 heartbeat owner prints refreshed" "refreshed" "$out"
+TOTAL=$((TOTAL + 1))
+if (( after > before )); then
+  PASS=$((PASS + 1)); echo "  PASS: 30 heartbeat owner bumped the mtime"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 30 heartbeat owner bumped the mtime (before=$before after=$after)"
+fi
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "30 heartbeat owner preserves the recorded sessionId" "sess-hb-owner" "$lock_contents"
+# Non-owner: re-age the file and run as a different session.
+touch -d "@$old_epoch" "$DISPATCH_LOCK_FILE"
+before=$(stat -c %Y "$DISPATCH_LOCK_FILE")
+export CLAUDE_CODE_SESSION_ID="sess-hb-other"
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" --heartbeat 2>/dev/null); rc=$?
+after=$(stat -c %Y "$DISPATCH_LOCK_FILE")
+assert_eq "30 heartbeat non-owner exits 0" "0" "$rc"
+assert_eq "30 heartbeat non-owner prints noop" "noop" "$out"
+assert_eq "30 heartbeat non-owner leaves the mtime unchanged" "$before" "$after"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "30 heartbeat non-owner preserves the recorded sessionId" "sess-hb-owner" "$lock_contents"
+lock_teardown
+
+# --- Test 31: selection-lock.json max_hold_seconds drives the reclaim, not env (#2104)
+#
+# Criterion 5, end-to-end: the config value (not the env var) drives the stale
+# reclaim, and config takes precedence over the env override. lock_setup copies
+# only dispatch-acquire-lock + lib.sh, so copy dispatch-config-load alongside and
+# point DISPATCH_CONFIG_DIR at a synthetic selection-lock.json. The env var is set
+# HIGH (would NOT reclaim a 10000s-old holder); the config is set LOW (max_hold=1,
+# WOULD reclaim). A reclaim proves the config value wins.
+echo "Test: selection-lock.json max_hold_seconds drives the stale reclaim, overriding env (#2104)"
+lock_setup
+cp "$SCRIPT_DIR/dispatch-config-load" "$TMPDIR_TEST/scripts/dispatch-config-load"
+chmod +x "$TMPDIR_TEST/scripts/dispatch-config-load"
+export DISPATCH_CONFIG_DIR="$TMPDIR_TEST/config"
+mkdir -p "$DISPATCH_CONFIG_DIR"
+printf '{"max_hold_seconds":1}\n' > "$DISPATCH_CONFIG_DIR/selection-lock.json"
+export DISPATCH_LOCK_MAX_HOLD_SECONDS=99999   # env alone would keep it busy
+export CLAUDE_CODE_SESSION_ID="sess-cfg-self"
+printf '%s\n' "sess-cfg-live" > "$DISPATCH_LOCK_FILE"
+lock_fake_claude_sessions "sess-cfg-live" "sess-cfg-self"
+touch -d "@$(( $(date +%s) - 10000 ))" "$DISPATCH_LOCK_FILE"
+out=$("$TMPDIR_TEST/scripts/dispatch-acquire-lock" 2>/dev/null); rc=$?
+assert_eq "31 config-driven reclaim exits 0" "0" "$rc"
+assert_eq "31 config-driven reclaim prints acquired (config max_hold=1 wins over env 99999)" "acquired" "$out"
+lock_contents=$(cat "$DISPATCH_LOCK_FILE" 2>/dev/null || true)
+assert_eq "31 config-driven reclaim rewrites lock to caller's sessionId" "sess-cfg-self" "$lock_contents"
 lock_teardown
 
 # ============================================================================
@@ -12940,6 +13052,106 @@ if [[ "$err" == *"object"* ]]; then
   PASS=$((PASS + 1)); echo "  PASS: 7za non-object sweep.json error mentions 'object'"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: 7za non-object sweep.json error mentions 'object'"
+  echo "    stderr: $err"
+fi
+config_teardown
+
+# --- selection-lock config type validation (#2104) --------------------------
+# The selection-lock config gates the max-hold/heartbeat staleness cap. Its
+# validator is the only path that catches a malformed max_hold_seconds BEFORE it
+# reaches dispatch-acquire-lock's bash arithmetic `(( age > MAX_HOLD_SECONDS ))`,
+# where a non-integer would error and break the staleness check. Mirrors the
+# sweep validator tests: absent → no-config; empty object → valid; valid integer
+# → printed; fractional/<=0/wrong-type/non-object → rejected naming the field.
+
+# --- Test 7sl-a: absent selection-lock.json → no-config, exit 0 --------------
+echo "Test: absent selection-lock.json prints no-config and exits 0"
+config_setup
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" selection-lock 2>/dev/null); rc=$?
+assert_eq "7sl-a absent selection-lock.json exits 0" "0" "$rc"
+assert_eq "7sl-a absent selection-lock.json prints no-config" "no-config" "$out"
+config_teardown
+
+# --- Test 7sl-b: empty-object selection-lock.json → valid, prints {} ---------
+echo "Test: empty-object selection-lock.json is valid and prints the normalized object"
+config_setup
+printf '{}\n' > "$DISPATCH_CONFIG_DIR/selection-lock.json"
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" selection-lock 2>/dev/null); rc=$?
+assert_eq "7sl-b empty-object selection-lock.json exits 0" "0" "$rc"
+norm=$(printf '%s' "$out" | jq -c '.')
+assert_eq "7sl-b empty-object selection-lock.json normalizes to {}" "{}" "$norm"
+config_teardown
+
+# --- Test 7sl-c: max_hold_seconds integer → valid, value round-trips ---------
+echo "Test: selection-lock.json with a valid integer max_hold_seconds round-trips"
+config_setup
+printf '{"max_hold_seconds":300}\n' > "$DISPATCH_CONFIG_DIR/selection-lock.json"
+out=$("$TMPDIR_TEST/scripts/dispatch-config-load" selection-lock 2>/dev/null); rc=$?
+assert_eq "7sl-c integer max_hold exits 0" "0" "$rc"
+mh=$(printf '%s' "$out" | jq -r '.max_hold_seconds')
+assert_eq "7sl-c integer max_hold round-trips" "300" "$mh"
+config_teardown
+
+# --- Test 7sl-d: max_hold_seconds fractional → exit 1 -----------------------
+echo "Test: selection-lock.json with a fractional max_hold_seconds exits 1 and names the field"
+config_setup
+printf '{"max_hold_seconds":0.5}\n' > "$DISPATCH_CONFIG_DIR/selection-lock.json"
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" selection-lock 2>&1 1>/dev/null) || rc=$?
+assert_eq "7sl-d fractional max_hold exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"max_hold_seconds"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: 7sl-d fractional max_hold error names max_hold_seconds"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 7sl-d fractional max_hold error names max_hold_seconds"
+  echo "    stderr: $err"
+fi
+config_teardown
+
+# --- Test 7sl-e: max_hold_seconds <= 0 → exit 1 -----------------------------
+echo "Test: selection-lock.json with max_hold_seconds <= 0 exits 1 and names the field"
+config_setup
+printf '{"max_hold_seconds":0}\n' > "$DISPATCH_CONFIG_DIR/selection-lock.json"
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" selection-lock 2>&1 1>/dev/null) || rc=$?
+assert_eq "7sl-e non-positive max_hold exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"max_hold_seconds"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: 7sl-e non-positive max_hold error names max_hold_seconds"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 7sl-e non-positive max_hold error names max_hold_seconds"
+  echo "    stderr: $err"
+fi
+config_teardown
+
+# --- Test 7sl-f: max_hold_seconds wrong type (string) → exit 1 --------------
+echo "Test: selection-lock.json with a string max_hold_seconds exits 1 and names the field"
+config_setup
+printf '{"max_hold_seconds":"300"}\n' > "$DISPATCH_CONFIG_DIR/selection-lock.json"
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" selection-lock 2>&1 1>/dev/null) || rc=$?
+assert_eq "7sl-f string max_hold exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"max_hold_seconds"* && "$err" == *"number"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: 7sl-f string max_hold error names the field and 'number'"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 7sl-f string max_hold error names the field and 'number'"
+  echo "    stderr: $err"
+fi
+config_teardown
+
+# --- Test 7sl-g: non-object top-level selection-lock.json → exit 1 ----------
+echo "Test: non-object top-level selection-lock.json exits 1 and stderr mentions object"
+config_setup
+printf '[]\n' > "$DISPATCH_CONFIG_DIR/selection-lock.json"
+rc=0
+err=$("$TMPDIR_TEST/scripts/dispatch-config-load" selection-lock 2>&1 1>/dev/null) || rc=$?
+assert_eq "7sl-g non-object selection-lock.json exits 1" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ "$err" == *"object"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: 7sl-g non-object selection-lock.json error mentions 'object'"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 7sl-g non-object selection-lock.json error mentions 'object'"
   echo "    stderr: $err"
 fi
 config_teardown


### PR DESCRIPTION
Closes #2104

## What

Adds a **max-hold / heartbeat staleness cap** to the dispatch selection lock so a
holder that is *live but wedged* — crash-resumed without releasing, stalled, or
otherwise no longer making selection progress — becomes reclaimable. Before this,
`dispatch-acquire-lock` reclaimed a foreign holder only when it was **dead**
(absent from `claude agents --json`); a live-but-wedged holder was never reclaimed
and there was no max-hold cap, which could deadlock the chain.

Incident this fixes (2026-06-19): a post-reboot phase-skill worker acquired the
production lock and held it 20+ minutes; every subsequent tick logged
`gave up after 315s; held by sessionId …` → `busy` → `nothing to do`, and live
sessions fell from 16 to ~4 with full budget headroom. Manually `rm`-ing the lock
immediately refilled the fleet.

## How

The **lock-file mtime is the heartbeat** — no lock-file format change, no new
readers. Only a claim/reclaim write or a `--heartbeat` `touch` bumps it (the
append-open + flock do not), so a wedged holder's mtime genuinely goes stale.

- **`dispatch-acquire-lock --heartbeat`** (new, strict-owner): bumps the lock-file
  mtime iff the caller is the recorded holder (`refreshed`), else `noop`. No daemon
  probe, sub-100ms.
- **Staleness reclaim** on acquire: composes *after* the existing liveness resolve
  (so an opaque daemon failure still folds to LIVE→BUSY — no stealing on UNKNOWN).
  If the recorded foreign holder is live but the lock-file mtime is older than
  `max_hold_seconds`, the acquirer reclaims it and logs
  `reclaimed stale lock from … (held …s > max_hold …s)`.
- **Configurable** via `dispatch.config/selection-lock.json`
  (`{ "max_hold_seconds": 300 }`), overridable by `DISPATCH_LOCK_MAX_HOLD_SECONDS`,
  default 300; config takes precedence over env.
- **Refreshes** are wired into the held region (`dispatch-select-tick`,
  `dispatch-materialize-spawn`) on each best-effort sub-step's *completion* and
  before each cross-process HOLD handoff.

### Three load-bearing invariants (in code comments + reference.md)

1. `max_hold_seconds` bounds the gap between two consecutive heartbeat *refreshes*,
   not the total hold. A dispossessed holder is never signaled it lost the lock, so
   the guarantee is "refreshes arrive faster than the cap," not "the hold is short."
2. Heartbeats fire on sub-step *completion*, never inside a retry/poll/wait loop —
   otherwise a holder wedged in that loop would keep its mtime fresh and survive the
   cap (the original incident).
3. The per-worktree spawn dedup — not the heartbeat — is the real #1068 safety net
   when a stale-reclaim races a still-live holder. No-reclaim-when-fresh keeps the
   race rare; the marker keeps it safe.

## Units

1. `selection-lock` config type in `dispatch-config-load` (mirrors `sweep`).
2. Heartbeat + staleness reclaim in `dispatch-acquire-lock`.
3. Wire `--heartbeat` refreshes into the held region.
4. Tests — lock suite (live-stale reclaim, no-reclaim-when-fresh #1068 guard,
   `--heartbeat` owner/non-owner, config-driven reclaim precedence) + config-load
   schema tests.
5. Documentation in `reference.md`.

## Verification

`test-dispatch-scripts.sh` passes (3476/3476). The new tests directly cover
acceptance criteria 2, 3, and 5 (reclaim-when-stale, no-reclaim-when-fresh,
`--heartbeat` owner/non-owner, config-driven reclaim, and `selection-lock` schema
validation). Criterion 4 (chain self-recovers within one `max_hold_seconds` window
after a real wedge) and the live-stale dedup behavior are integration properties
left for QA / production observation, per the plan.

## Out-of-scope follow-up (not filed — needs authorization)

The plan calls for a `blocked_by`-free follow-up issue covering **lock isolation**
(a `DISPATCH_LOCK_DIR` / per-worktree lock path so a worker running the dispatch
dev-scripts under its own session id can never grab the production lock — the
specific 2026-06-19 trigger). The max-hold cap here is the general fix; isolation
is separate hardening and intentionally **not** in this PR. Filing that issue was
blocked by the auto-mode permission classifier in this session, so it has **not**
been created — it needs to be filed separately. Prior related (closed): #719, #841,
#1054.
