### PR TITLE
implement/SKILL.md: skip phase-log write on crash-recovery re-entry

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -222,12 +222,11 @@ the terminal action stays last: `dispatch-mark-complete` (no deviation) or
 `dispatch-mark-deviation` (deviation) remains the single named exit. Write the
 phase-log entry once here, before the deviation branch, so both branches share it.
 
-First write the handoff note. Compose a terse "what-changed" digest of the
-implementation to `tmp/phase-log-entry-$N.md` — a one-line summary of what
-shipped; on a clean as-planned build the body is a line like `failed: none`.
-Compose it **unconditionally** (no "only on failure" branch). Then upsert it into
-the issue's phase-log comment (use `dangerouslyDisableSandbox: true` — the script
-calls `gh`):
+**On the normal path (Steps 1–4 ran this pass):** compose a terse
+"what-changed" digest of the implementation to `tmp/phase-log-entry-$N.md` — a
+one-line summary of what shipped; on a clean as-planned build the body is a line
+like `failed: none`. Then upsert it into the issue's phase-log comment (use
+`dangerouslyDisableSandbox: true` — the script calls `gh`):
 
 ```bash
 .claude/skills/dispatch-propagate/scripts/dispatch-write-phase-log \
@@ -235,12 +234,18 @@ calls `gh`):
 ```
 
 No attempt counter — implement is single-pass, so the default `--attempt 1`
-applies. The upsert is idempotent on the `(implement, 1)` key: on the
-crash-recovery re-entry path (a PR already exists → Steps 1–4 skipped → straight
-to this marker write) the repeated write REPLACES the prior entry in place rather
-than stacking a duplicate, so the repeat is safe.
+applies.
 
-Then judge whether the implementation deviated from the
+**On the re-entry path (a PR already existed at the preamble → Steps 1–4 were
+skipped this pass):** skip the phase-log compose and the
+`dispatch-write-phase-log` call entirely. The agent ran no `/implement-unit`
+units this pass and holds no fresh implementation data; composing a digest now
+would overwrite the accurate `(implement, 1)` entry the original pass wrote with
+uninformed or fabricated content — or fabricate an entry where none should exist.
+The prior entry is already correct and durable. Go straight to the
+deviation/marker logic below.
+
+Judge whether the implementation deviated from the
 persisted plan — scope shifted mid-implementation, or the plan could not be
 fully implemented as written. Base this on the `/implement-unit` outcomes
 observed in Step 2.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -219,8 +219,9 @@ hand.
 
 **Ordering invariant.** The phase-log write must PRECEDE the terminal action so
 the terminal action stays last: `dispatch-mark-complete` (no deviation) or
-`dispatch-mark-deviation` (deviation) remains the single named exit. Write the
-phase-log entry once here, before the deviation branch, so both branches share it.
+`dispatch-mark-deviation` (deviation) remains the single named exit. On the normal
+path, write the phase-log entry once here, before the deviation branch, so both
+terminal branches (deviation and no-deviation) share it.
 
 **On the normal path (Steps 1–4 ran this pass):** compose a terse
 "what-changed" digest of the implementation to `tmp/phase-log-entry-$N.md` — a
@@ -242,13 +243,16 @@ skipped this pass):** skip the phase-log compose and the
 units this pass and holds no fresh implementation data; composing a digest now
 would overwrite the accurate `(implement, 1)` entry the original pass wrote with
 uninformed or fabricated content — or fabricate an entry where none should exist.
-The prior entry is already correct and durable. Go straight to the
-deviation/marker logic below.
+The prior entry, if any, is already correct and durable; if the original pass
+crashed before writing one, skipping still yields an honest absence — never
+fabricate content now. Go straight to the deviation/marker logic below.
 
 Judge whether the implementation deviated from the
 persisted plan — scope shifted mid-implementation, or the plan could not be
 fully implemented as written. Base this on the `/implement-unit` outcomes
-observed in Step 2.
+observed in Step 2. On the re-entry path (Steps 1–4 were skipped this pass),
+no `/implement-unit` outcomes were observed — treat deviation as false and
+proceed to `dispatch-mark-complete`.
 
 **Deviation fires** — skip the `phase-completed` marker. Instead call
 `dispatch-mark-deviation` to write the office-hours-reason atomically. If Step 4


### PR DESCRIPTION
## Problem

`implement/SKILL.md` Step 5 instructed the worker to compose a "what-changed"
phase-log digest **unconditionally** and upsert it via `dispatch-write-phase-log`,
keyed on `(implement, 1)`. On the crash-recovery re-entry path — a draft PR already
exists at the preamble, so Steps 1–4 are skipped this pass — the worker has run no
`/implement-unit` work and holds no fresh implementation data. The unconditional
write then composes an uninformed (or fabricated) digest and REPLACES the accurate
`(implement, 1)` handoff note the original pass wrote, silently destroying the
cross-phase handoff that downstream phases and the dispatch chain rely on. The
SKILL's own commentary compounded the bug by calling that repeated REPLACE "safe."

## Fix

Step 5's phase-log paragraph now branches on the same re-entry signal the preamble
already establishes:

- **Normal path** (Steps 1–4 ran this pass): compose and upsert the digest exactly
  as before — the `dispatch-write-phase-log … --phase implement` block is unchanged.
- **Re-entry path** (PR already existed → Steps 1–4 skipped): skip the phase-log
  compose and the `dispatch-write-phase-log` call entirely. The prior `(implement, 1)`
  entry, if any, is already correct and durable; composing one now would overwrite it
  with uninformed content or fabricate one where none should exist.

The misleading "the repeat is safe" commentary is removed: the corrected framing
states the upsert is idempotent on the `(implement, 1)` key and the re-entry path now
skips the write precisely so the repeat can never overwrite the accurate prior entry.

This is plan option 1, which strictly dominates option 2 (re-emit verbatim from
`PRIOR_PHASE_LOG`): a crash *before* the original write leaves nothing to re-emit
(`dispatch-write-phase-log` rejects empty stdin), whereas skip yields an honest
absence that downstream treats as empty.

## Scope

Documentation-only edits to `.claude/skills/implement/SKILL.md` Step 5:

- Phase-log write paragraph: gated on the normal path; re-entry path skips with
  clarified prose ("if any … honest absence — never fabricate").
- Ordering invariant sentence: scoped to the normal path to match the conditional below.
- Deviation judgment paragraph: added a re-entry-path clarification (treat deviation
  as false when Steps 1–4 were skipped and no `/implement-unit` outcomes were observed).

There is no auto-runnable test for SKILL prose; verification is by reading Step 5 for
internal self-consistency.

Closes #2133