### PR TITLE
dispatch-write-phase-log: guard --phase/--attempt shift on missing value

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-write-phase-log
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-write-phase-log
@@ -40,8 +40,12 @@ PHASE=""
 ATTEMPT="1"
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --phase)   PHASE="${2:-}"; shift 2 ;;
-    --attempt) ATTEMPT="${2:-}"; shift 2 ;;
+    --phase)
+      [[ $# -ge 2 ]] || { echo 'dispatch-write-phase-log: --phase requires a value' >&2; exit 2; }
+      PHASE="$2"; shift 2 ;;
+    --attempt)
+      [[ $# -ge 2 ]] || { echo 'dispatch-write-phase-log: --attempt requires a value' >&2; exit 2; }
+      ATTEMPT="$2"; shift 2 ;;
     *)
       echo "dispatch-write-phase-log: unknown argument '$1'" >&2
       echo "usage: dispatch-write-phase-log <issue-num> --phase <p> [--attempt <n>]" >&2

--- a/.claude/skills/dispatch-propagate/scripts/test-write-phase-log.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-write-phase-log.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Tests for dispatch-write-phase-log flag-value guard (#2132).
+#
+# AC1: --phase with no value exits 2 with '--phase' in stderr
+# AC2: --attempt with no value exits 2 with '--attempt' in stderr
+# AC3: valid invocation (--phase qa --attempt 2) exits 0 and POSTs to issues/2132/comments
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+source "$SCRIPT_DIR/test-helpers.sh"
+SUT="$SCRIPT_DIR/dispatch-write-phase-log"
+
+# ============================================================================
+# AC1: --phase with no following value → exit 2, stderr contains '--phase'
+# ============================================================================
+
+echo "AC1: --phase with no value -> exit 2, stderr mentions --phase"
+
+set +e
+AC1_STDERR=$(printf 'body\n' | "$SUT" 2132 --phase 2>&1)
+AC1_RC=$?
+set -e
+
+assert_eq "AC1: exit code is 2" "2" "$AC1_RC"
+assert_contains "AC1: stderr mentions --phase" "--phase" "$AC1_STDERR"
+
+# ============================================================================
+# AC2: --attempt with no following value → exit 2, stderr contains '--attempt'
+# ============================================================================
+
+echo ""
+echo "AC2: --attempt with no value -> exit 2, stderr mentions --attempt"
+
+set +e
+AC2_STDERR=$(printf 'body\n' | "$SUT" 2132 --phase qa --attempt 2>&1)
+AC2_RC=$?
+set -e
+
+assert_eq "AC2: exit code is 2" "2" "$AC2_RC"
+assert_contains "AC2: stderr mentions --attempt" "--attempt" "$AC2_STDERR"
+
+# ============================================================================
+# AC3: valid invocation → exit 0, gh stub records a POST to issues/2132/comments
+# ============================================================================
+
+echo ""
+echo "AC3: valid invocation -> exit 0, POST to issues/2132/comments"
+
+# Create a temp directory to act as the git repo and stub home.
+TMPDIR_TEST="$(mktemp -d)"
+GH_LOG="$TMPDIR_TEST/gh-calls.log"
+
+cleanup() {
+  rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# Init a git repo in the temp dir and add a remote so git rev-parse and
+# git config --get remote.origin.url work when the script calls them.
+git init -q "$TMPDIR_TEST"
+git -C "$TMPDIR_TEST" remote add origin https://github.com/natb1/commons.systems.git
+
+# Create a stub gh that:
+#   - appends its full args to the call log
+#   - if args contain --method POST → exit 0 (the create-comment call)
+#   - else (the list/get call from dispatch_marker_comment_id) → print []
+mkdir -p "$TMPDIR_TEST/bin"
+cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$GH_LOG"
+for arg in "$@"; do
+  if [[ "$arg" == "POST" ]]; then
+    exit 0
+  fi
+done
+# Default: return empty comment list so script takes the POST-fresh-comment branch.
+echo "[]"
+STUB
+chmod +x "$TMPDIR_TEST/bin/gh"
+
+# Export GH_LOG so the stub can append to it.
+export GH_LOG
+
+# Export DISPATCH_PLAN_AUTHOR_ID to skip the gh api user call inside
+# dispatch_marker_comment_id.
+export DISPATCH_PLAN_AUTHOR_ID=123
+
+# Prepend stub bin/ to PATH and run the SUT from inside the temp git repo.
+ORIG_PATH="$PATH"
+export PATH="$TMPDIR_TEST/bin:$PATH"
+
+set +e
+AC3_STDERR=$(cd "$TMPDIR_TEST" && printf 'phase handoff note\n' | "$SUT" 2132 --phase qa --attempt 2 2>&1)
+AC3_RC=$?
+set -e
+
+export PATH="$ORIG_PATH"
+
+assert_eq "AC3: exit code is 0" "0" "$AC3_RC"
+
+# Verify that the stub gh call log contains a POST to issues/2132/comments.
+AC3_LOG=""
+if [[ -f "$GH_LOG" ]]; then
+  AC3_LOG="$(cat "$GH_LOG")"
+fi
+assert_contains "AC3: gh called with POST to issues/2132/comments" "issues/2132/comments" "$AC3_LOG"
+assert_contains "AC3: gh called with --method POST" "POST" "$AC3_LOG"
+
+report_results


### PR DESCRIPTION
Closes #2132

## What

`dispatch-write-phase-log`'s `--phase` and `--attempt` flag handlers called
`shift 2` unconditionally. When either flag was the **last argument** (no value
following), only one positional remained, so `shift 2` returned non-zero. Under
the script's `set -euo pipefail` that aborted the whole script with an opaque
**exit 1 and no message**, instead of the **exit 2 with a usage message** that
every other argument error in the script uses.

## Fix

Guard each `shift 2` with a `$# -ge 2` check that emits a clear stderr message
and `exit 2`, matching the script's existing usage-error convention. With the
guard in place the prior `${2:-}` defaulting is unnecessary, so the assignments
become plain `$2`. The rest of the parse loop, the downstream `PHASE`/`ATTEMPT`
regex validation, and the upsert logic are unchanged.

## Test

New hermetic, network-free regression suite
`test-write-phase-log.sh` (auto-discovered by `run-unit-tests.sh`'s
`RUN_PR_SCRIPTS` glob, so it runs in CI's `unit-tests` job) covers all three
acceptance criteria:

- **AC1** — `… 2132 --phase` (trailing flag) exits 2 with `--phase` in stderr;
  aborts at the guard before any git/gh access.
- **AC2** — `… 2132 --phase qa --attempt` (trailing flag) exits 2 with
  `--attempt` in stderr; also pre-git/gh.
- **AC3 (no regression)** — a valid `--phase qa --attempt 2` invocation parses
  past the loop and performs the comment write, run inside a temp git repo with
  a PATH-shim `gh` stub and `DISPATCH_PLAN_AUTHOR_ID` set; asserts exit 0 and a
  recorded `POST` to `issues/2132/comments`.

7/7 assertions pass.
