### PR TITLE
dispatch-write-phase-log: anchor REPLACE-vs-APPEND selector to a full-line match

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-write-phase-log
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-write-phase-log
@@ -94,7 +94,7 @@ fi
 # Comment exists — fetch its body and upsert the (phase, attempt) section.
 BODY=$(gh api "repos/{owner}/{repo}/issues/comments/$CID" --jq '.body')
 
-if printf '%s' "$BODY" | grep -qF "$INNER_MARKER"; then
+if printf '%s' "$BODY" | grep -qxF "$INNER_MARKER"; then
   # REPLACE the existing section in place. The awk state machine drops the lines
   # from the target inner-marker line up to (but not including) the next line
   # beginning '<!-- phase-log:' (the next section's delimiter, which is KEPT) or


### PR DESCRIPTION
Closes #2136

## Problem

`dispatch-write-phase-log` upserts a per-`(phase, attempt)` handoff entry into an
issue's `<!-- dispatch:phase-log -->` comment. On write it picks REPLACE (section
already present → update in place) vs APPEND (new section) by testing whether the
inner marker `<!-- phase-log:<phase>:<attempt> -->` is already in the comment body.

The two predicates that should agree on "is this section present" disagreed:

- **Selector (line 97):** `grep -qF "$INNER_MARKER"` — a **substring** match
  anywhere in the body.
- **awk replace block (line 117):** `if ($0 == target)` — an **exact full-line**
  match.

If the inner-marker text appeared only as a substring embedded in section prose
(e.g. a phase-log entry that quotes the marker — plausible on phase-log-related
issues), `grep -qF` selected the REPLACE branch, but the awk state machine found
no line where `$0 == target` and emitted the body unchanged. The subsequent PATCH
then wrote the unmodified body back, **silently dropping the new phase-log entry**.

## Fix

Add the `-x` flag to the selector: `grep -qF` → `grep -qxF`. The `-x` flag anchors
grep to match only when the marker occupies its own whole line, aligning the
presence-test with the awk exact-line semantics. The REPLACE branch is now taken
only when awk can actually find and replace the section. Single-character change;
the awk block, POST/PATCH calls, and argument parsing are untouched.

## Verification

The plan's `verify` block (syntax check + selector-line text assertion +
behavioral test of the fixed predicate against substring-in-prose vs own-line
fixtures, mirroring awk's exact-line semantics without `gh`/network) passes.
