### PR TITLE
review-fix: skip the Step 7 phase-log write on the re-entry path

### DIFF
--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -617,10 +617,9 @@ fi
 but only when the Workflow ran this session.** The phase-log write must PRECEDE
 the `dispatch:reviewed` apply so that label stays the terminal durable action.
 This compose-and-write happens **only when the Workflow ran this session** (the
-normal path) — the same "only when the Workflow ran this session" guard the
-outcome-envelope emit uses below (it skips on re-entry for the same reason). On
-the re-entry path (Steps 1–6 skipped, `result` absent) **SKIP the phase-log
-write entirely**; do not compose or upsert anything.
+normal path) — the same guard the outcome-envelope emit uses below (it skips on
+re-entry for the same reason). On the re-entry path (Steps 1–6 skipped, `result`
+absent) **SKIP the phase-log write entirely**; do not compose or upsert anything.
 
 On the normal path, compose a terse "what the review found / fixed" digest of
 this pass to `tmp/phase-log-entry-$N.md` — a one-line summary of the fixes
@@ -637,8 +636,8 @@ upsert it (use `dangerouslyDisableSandbox: true` — the script calls `gh`):
 No attempt counter — review is single-pass, so the default `--attempt 1` applies.
 The upsert is idempotent on the `(review, 1)` key. Why re-entry must skip rather
 than re-write: the phase-log write PRECEDES the `dispatch:reviewed` apply (above),
-and re-entry is GATED on `dispatch:reviewed` already being present (preamble,
-line ~83). So whenever re-entry fires, the accurate `(review, 1)` entry the
+and re-entry is GATED on `dispatch:reviewed` already being present (see preamble:
+"If the labels line already includes `dispatch:reviewed`"). So whenever re-entry fires, the accurate `(review, 1)` entry the
 original run wrote is guaranteed already durable on the comment. Skipping the
 write preserves it. A re-write on re-entry has no prior-pass data to restate
 (`result` is absent), so it would only overwrite the good entry with a
@@ -804,10 +803,11 @@ goes ready — the single PR-comment summary is the audit trail. This is an
 intentional trade-off for an autonomous background-job run.
 
 The skill is idempotent: a re-invocation with `dispatch:reviewed` already on the
-PR skips Steps 1–6 and runs Step 7, which flushes any unpushed commits and writes
-the phase-completed marker (the Workflow is not re-run on re-entry, so the
-deviation criterion is treated as not met). Readiness is the router's projection,
-reconciled on later ticks — not something re-entry asserts.
+PR skips Steps 1–6 and runs Step 7, which flushes any unpushed commits, skips the
+phase-log write and outcome-envelope emit, and writes the phase-completed marker
+(the Workflow is not re-run on re-entry, so the deviation criterion is treated as
+not met). Readiness is the router's projection, reconciled on later ticks — not
+something re-entry asserts.
 
 **Model split (#1172).** The dispatch chain runs this `review` phase orchestrator
 on **Sonnet** (via `dispatch-phase-model`, which maps `review →

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -88,9 +88,11 @@ flush. Routing re-entry through Step 7 means its flush guard also carries any
 commits an interrupted prior run left stranded — the flush that lets the router
 resolve `mergeable == MERGEABLE` and promote the PR to ready.
 
-On this re-entry path the Workflow has not run — Step 7 treats the deviation
-criterion as not met (`result.deviation` is absent) and writes the phase-completed
-marker. Otherwise run all steps in order.
+On this re-entry path the Workflow has not run — so Step 7 **skips the phase-log
+write entirely** (the accurate `(review, 1)` entry the original run wrote is
+already durable; a dataless re-write would overwrite it), treats the deviation
+criterion as not met (`result.deviation` is absent), skips the outcome-envelope
+emit, and writes the phase-completed marker. Otherwise run all steps in order.
 
 ## Steps
 
@@ -611,13 +613,21 @@ if [[ "$AHEAD" -ne 0 ]]; then
 fi
 ```
 
-**Then write the handoff note, before the terminal `dispatch:reviewed` apply.**
-The phase-log write must PRECEDE the `dispatch:reviewed` apply so that label stays
-the terminal durable action. Compose a terse "what the review found / fixed"
-digest of this pass to `tmp/phase-log-entry-$N.md` — a one-line summary of the
-fixes applied; a clean review writes a line like `failed: none`. Compose it
-**unconditionally** (no "only on failure" branch). Then upsert it (use
-`dangerouslyDisableSandbox: true` — the script calls `gh`):
+**Then write the handoff note, before the terminal `dispatch:reviewed` apply —
+but only when the Workflow ran this session.** The phase-log write must PRECEDE
+the `dispatch:reviewed` apply so that label stays the terminal durable action.
+This compose-and-write happens **only when the Workflow ran this session** (the
+normal path) — the same "only when the Workflow ran this session" guard the
+outcome-envelope emit uses below (it skips on re-entry for the same reason). On
+the re-entry path (Steps 1–6 skipped, `result` absent) **SKIP the phase-log
+write entirely**; do not compose or upsert anything.
+
+On the normal path, compose a terse "what the review found / fixed" digest of
+this pass to `tmp/phase-log-entry-$N.md` — a one-line summary of the fixes
+applied. This write is **unconditional across pass and fail**: a clean review
+still writes a line like `failed: none` — never gate it on "only on failure."
+The only narrowing is normal-vs-re-entry; pass-vs-fail stays unconditional. Then
+upsert it (use `dangerouslyDisableSandbox: true` — the script calls `gh`):
 
 ```bash
 .claude/skills/dispatch-propagate/scripts/dispatch-write-phase-log \
@@ -625,10 +635,14 @@ fixes applied; a clean review writes a line like `failed: none`. Compose it
 ```
 
 No attempt counter — review is single-pass, so the default `--attempt 1` applies.
-The upsert is idempotent on the `(review, 1)` key: on the re-entry path where
-`dispatch:reviewed` is already present (Steps 1–6 skipped, the Workflow did not
-run), the digest restates the prior pass; the upsert REPLACES the `(review, 1)`
-entry in place rather than stacking a duplicate, so the repeat is safe.
+The upsert is idempotent on the `(review, 1)` key. Why re-entry must skip rather
+than re-write: the phase-log write PRECEDES the `dispatch:reviewed` apply (above),
+and re-entry is GATED on `dispatch:reviewed` already being present (preamble,
+line ~83). So whenever re-entry fires, the accurate `(review, 1)` entry the
+original run wrote is guaranteed already durable on the comment. Skipping the
+write preserves it. A re-write on re-entry has no prior-pass data to restate
+(`result` is absent), so it would only overwrite the good entry with a
+content-free/degraded one — it can never fill a gap, only destroy one.
 
 Then apply the `dispatch:reviewed` label via `dispatch-complete-phase` (use
 `dangerouslyDisableSandbox: true` — the script calls `gh`):


### PR DESCRIPTION
Closes #2141

## Problem

PR #2108 added the cross-phase `<!-- dispatch:phase-log -->` handoff note: each
dispatch phase upserts a terse "what-failed / what-changed" entry, keyed on an
inner marker `<!-- phase-log:<phase>:<attempt> -->` (replace-in-place on a key
match).

In `review-fix/SKILL.md` Step 7 the phase-log digest is composed from the
Workflow `result`. On the **re-entry path** — `dispatch:reviewed` already
present, so Steps 1–6 (and therefore the Workflow) are skipped — `result` is
absent. The instruction told the worker to compose and write the digest
**unconditionally**, with a rationale claiming "the digest restates the prior
pass … the upsert REPLACES the `(review, 1)` entry in place … so the repeat is
safe." That claim was false: on re-entry there is no prior-pass data to restate,
so the upsert overwrote the accurate `(review, 1)` entry the original run wrote
with a content-free / degraded one — destroying the handoff note.

## Fix

Gate the entire compose-and-write on **"only when the Workflow ran this
session"** and skip the phase-log write entirely on the re-entry path. This is a
consistency repair, not a new mechanism: Step 7 already skips the
outcome-envelope emit on re-entry with exactly this reasoning. The phase-log
write now reuses the same guard.

Why skipping is provably safe: the phase-log write precedes the
`dispatch:reviewed` apply, and re-entry is gated on `dispatch:reviewed` already
being present. So whenever re-entry fires, the accurate `(review, 1)` entry is
guaranteed already durable on the comment — skipping preserves it, while a
dataless re-write could only overwrite good data with degraded data, never fill
a gap.

## Changes (prose-only, `review-fix/SKILL.md`)

1. **Step 7 core fix.** Narrowed the "compose unconditionally" instruction to
   the normal path only and added an explicit re-entry skip; preserved the
   genuine unconditional axis (a clean review still writes `failed: none` —
   normal-vs-re-entry is the only narrowing, pass-vs-fail stays unconditional);
   replaced the false "restates / safe" rationale with the ordering-guarantee
   rationale.
2. **Preamble re-entry description.** Updated the re-entry enumeration to state
   Step 7 skips the phase-log write, alongside the already-documented
   outcome-emit skip and deviation handling.
3. **Whole-file sweep.** Confirmed no surviving passage claims re-entry writes
   the phase-log or that the re-entry replace is "safe."

No code/script change — `dispatch-write-phase-log`'s upsert is already correct;
only the SKILL's instructions were wrong.

## Scope

`review-fix` only. `qa-fix`'s re-entry is a true no-op that never reaches its
phase-log write, so it is unaffected. `implement` does reach its phase-log write
on re-entry and carries an analogous risk, but its re-entry gate ("a PR exists")
precedes the write, so the accurate entry is not guaranteed to exist on re-entry
— "skip on re-entry" is not provably safe there. That is a separate, harder
problem and is deliberately left to a follow-up rather than widened into this PR.

## Verification

Prose-only `SKILL.md` change with no mechanical test or lint coverage
(`lint-prose-rules.sh` diffs only `*.sh` files). Verification is a manual
prose-consistency review per the plan's Verification section.
