### PR TITLE
type-safety-sensor: percent-encode commas in annotation file paths

### DIFF
--- a/.github/scripts/check-type-safety-escapes.sh
+++ b/.github/scripts/check-type-safety-escapes.sh
@@ -102,6 +102,7 @@ scan_diff() {
     END { if (violations > 0) exit 1 }
 
     function emit(path, line, hatch) {
+      gsub(/,/, "%2C", path)
       printf "::error file=%s,line=%d::Net-new type-safety escape hatch (%s). Suppress with `// type-safety-ok: <reason>` if intentional.\n", path, line, hatch
       violations++
     }

--- a/.github/scripts/test-check-type-safety-escapes.sh
+++ b/.github/scripts/test-check-type-safety-escapes.sh
@@ -412,6 +412,25 @@ EOF
   fi
 )
 
+echo ""
+echo "=== Comma-in-path: file= comma is percent-encoded to %2C ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
+--- a/src/weird,file.ts
++++ b/src/weird,file.ts
+@@ -1,0 +1,1 @@
++const x = y as Foo;
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ] && \
+     grep -q '^::error file=src/weird%2Cfile.ts,line=1::' "$OUT_FILE"; then
+    pass "comma-in-path -> file=src/weird%2Cfile.ts (comma percent-encoded)"
+  else
+    fail "comma-in-path (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
 # ---------------------------------------------------------------------------
 # RESULTS + expected-total guard (catches a crashed/early-exiting subshell).
 # ---------------------------------------------------------------------------
@@ -424,7 +443,7 @@ echo "========================================"
 echo "  Results: $FINAL_PASS passed, $FINAL_FAIL failed"
 echo "========================================"
 
-EXPECTED=18
+EXPECTED=19
 ACTUAL=$(( FINAL_PASS + FINAL_FAIL ))
 if [ "$ACTUAL" -ne "$EXPECTED" ]; then
   echo "ERROR: expected $EXPECTED test results but got $ACTUAL (a test subshell may have crashed)" >&2


### PR DESCRIPTION
Closes #2092

## Problem

The diff-scoped type-safety escape-hatch sensor
(`.github/scripts/check-type-safety-escapes.sh`) emits GitHub Actions
annotations in the form:

```
::error file=<path>,line=N::<message>
```

GitHub's workflow-command format uses the comma as the key–value delimiter
between annotation properties. A TypeScript file path containing a comma — e.g.
`src/weird,file.ts` — is interpolated raw into the `file=` property, so GitHub
splits it at the comma: `file=src/weird` is truncated and `file.ts` becomes an
unrecognized key, causing the annotation to be silently dropped. The violation
then never surfaces in the PR check output.

This was surfaced during review of PR #2077 and deferred because comma-bearing
TypeScript paths are rare.

## Fix

Percent-encode commas in the path before building the annotation, in the awk
`emit` function:

```awk
gsub(/,/, "%2C", path)
```

`path` is a function-local parameter, so the `gsub` mutates only the local copy
— it does not affect the awk-global `path` used elsewhere. A comma path now
produces a well-formed `::error file=src/weird%2Cfile.ts,line=1::…` annotation.

Scope is commas only, exactly as the acceptance criterion specifies — other
GitHub property-encoding characters (`%`, `:`, CR/LF) are out of scope. The
change is backward-compatible: comma-free paths are emitted byte-for-byte as
before.

## Test

Added one positive fixture case to
`.github/scripts/test-check-type-safety-escapes.sh` asserting a comma path emits
`file=src/weird%2Cfile.ts`, and bumped the expected-total guard from 18 to 19.

```
Results: 19 passed, 0 failed
```
