### PR TITLE
implement + review-fix: skip phase-log write on crash-recovery re-entry

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -63,11 +63,15 @@ a prior attempt or earlier phase left. Treat the sentinel `phase-log: none` as
 empty. When non-empty, feed it into the Step 2 unit-build context so a rebuild or
 re-plan sees why a prior attempt diverged. An absent note leaves Step 2 unchanged.
 
-If a PR already exists, the build + PR already happened: capture its number as
-`PR_NUM`, **skip Steps 1–4**, and go straight to the Step 5 marker write (this
-covers a same-tick crash between PR-open and marker-write). If no PR exists, run
-all steps. (`dispatch-route` normally routes a PR-bearing issue to fix-checks/qa/review,
-not implement, so this is a same-tick crash-recovery edge.)
+If a PR already exists, the build + PR already happened: this is the **re-entry
+branch**. Capture its number as `PR_NUM`, **skip Steps 1–4**, and go straight to
+Step 5 — on re-entry only the **marker** write runs; the Step 5 **phase-log write
+is skipped** (this covers a same-tick crash between PR-open and marker-write).
+Note that the preamble took the re-entry branch (a PR already existed at entry) —
+Step 5 keys its phase-log gate on this. If no PR exists, run all steps (the
+preamble did NOT take the re-entry branch). (`dispatch-route` normally routes a
+PR-bearing issue to fix-checks/qa/review, not implement, so this is a same-tick
+crash-recovery edge.)
 
 ## Steps
 
@@ -222,23 +226,33 @@ the terminal action stays last: `dispatch-mark-complete` (no deviation) or
 `dispatch-mark-deviation` (deviation) remains the single named exit. Write the
 phase-log entry once here, before the deviation branch, so both branches share it.
 
-First write the handoff note. Compose a terse "what-changed" digest of the
-implementation to `tmp/phase-log-entry-$N.md` — a one-line summary of what
+First write the handoff note — **only when Steps 1–4 ran this turn** (i.e. the
+preamble did NOT take the re-entry branch). Compose a terse "what-changed" digest
+of the implementation to `tmp/phase-log-entry-$N.md` — a one-line summary of what
 shipped; on a clean as-planned build the body is a line like `failed: none`.
-Compose it **unconditionally** (no "only on failure" branch). Then upsert it into
-the issue's phase-log comment (use `dangerouslyDisableSandbox: true` — the script
-calls `gh`):
+Compose it **unconditionally** (no "only on failure" branch) — that is the
+failure-vs-success axis (always log, even a clean pass), orthogonal to the
+re-entry gate below. Then upsert it into the issue's phase-log comment (use
+`dangerouslyDisableSandbox: true` — the script calls `gh`):
 
 ```bash
 .claude/skills/dispatch-propagate/scripts/dispatch-write-phase-log \
   "$N" --phase implement < tmp/phase-log-entry-$N.md
 ```
 
+On the crash-recovery re-entry path (a PR already existed at entry → Steps 1–4
+skipped), **skip the phase-log write** entirely, so the prior `(implement, 1)`
+entry is preserved verbatim. **Gate on the re-entry flag, not on PR presence:**
+`PR_NUM` is set on both paths at Step 5 (the normal path created it in Step 4;
+re-entry captured it in the preamble), so a `[ -n "$PR_NUM" ]` gate would skip
+the write ALWAYS and break the normal path. Key the gate on whether Steps 1–4 ran
+this turn (the preamble did NOT take the re-entry branch).
+
 No attempt counter — implement is single-pass, so the default `--attempt 1`
-applies. The upsert is idempotent on the `(implement, 1)` key: on the
-crash-recovery re-entry path (a PR already exists → Steps 1–4 skipped → straight
-to this marker write) the repeated write REPLACES the prior entry in place rather
-than stacking a duplicate, so the repeat is safe.
+applies. On re-entry there is no fresh outcome data: recomposing the digest from
+this turn's limited context would OVERWRITE the prior attempt's accurate entry
+with a thinner restatement. So the write is SKIPPED on re-entry, not repeated —
+the prior entry is authoritative.
 
 Then judge whether the implementation deviated from the
 persisted plan — scope shifted mid-implementation, or the plan could not be

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -90,7 +90,8 @@ resolve `mergeable == MERGEABLE` and promote the PR to ready.
 
 On this re-entry path the Workflow has not run — Step 7 treats the deviation
 criterion as not met (`result.deviation` is absent) and writes the phase-completed
-marker. Otherwise run all steps in order.
+marker. Step 7 also skips the phase-log write on this path, so the prior entry is
+preserved. Otherwise run all steps in order.
 
 ## Steps
 
@@ -611,9 +612,11 @@ if [[ "$AHEAD" -ne 0 ]]; then
 fi
 ```
 
-**Then write the handoff note, before the terminal `dispatch:reviewed` apply.**
-The phase-log write must PRECEDE the `dispatch:reviewed` apply so that label stays
-the terminal durable action. Compose a terse "what the review found / fixed"
+**Then write the handoff note, before the terminal `dispatch:reviewed` apply —
+only when the Workflow ran this session** (i.e. **not** the idempotent re-entry
+path, where Steps 1–6 were skipped and `result` is absent). On the non-re-entry
+path the phase-log write must PRECEDE the `dispatch:reviewed` apply so that label
+stays the terminal durable action. Compose a terse "what the review found / fixed"
 digest of this pass to `tmp/phase-log-entry-$N.md` — a one-line summary of the
 fixes applied; a clean review writes a line like `failed: none`. Compose it
 **unconditionally** (no "only on failure" branch). Then upsert it (use
@@ -624,11 +627,15 @@ fixes applied; a clean review writes a line like `failed: none`. Compose it
   "$N" --phase review < tmp/phase-log-entry-$N.md
 ```
 
+Skip the phase-log write entirely on re-entry. On re-entry `dispatch:reviewed` is
+already present, so the write is skipped — there is no ordering concern relative
+to the label on the re-entry path.
+
 No attempt counter — review is single-pass, so the default `--attempt 1` applies.
-The upsert is idempotent on the `(review, 1)` key: on the re-entry path where
-`dispatch:reviewed` is already present (Steps 1–6 skipped, the Workflow did not
-run), the digest restates the prior pass; the upsert REPLACES the `(review, 1)`
-entry in place rather than stacking a duplicate, so the repeat is safe.
+Re-entry is a separate transcript where the Workflow did not run, so `result` is
+absent and there is no fresh outcome data: recomposing the digest would overwrite
+the prior `(review, 1)` entry with a thinner restatement. So the write is SKIPPED
+on re-entry — the prior entry is authoritative.
 
 Then apply the `dispatch:reviewed` label via `dispatch-complete-phase` (use
 `dangerouslyDisableSandbox: true` — the script calls `gh`):


### PR DESCRIPTION
Closes #2137

## Problem

PR #2108 added a cross-phase phase-log handoff note: each phase worker
(`/implement`, `/review-fix`) composes a terse "what-changed" digest and upserts
it into the issue's phase-log comment, keyed on `(phase, attempt)`. The upsert
replaces the prior entry in place.

On the **crash-recovery re-entry path** the digest was recomputed from the
current turn's *limited* context and upserted unconditionally — overwriting the
prior, richer `(phase, 1)` entry with a thinner restatement. Safe against
duplication, but a semantic regression in exactly the recovery scenario the
feature targets: the re-entry that was supposed to preserve the original
attempt's failure/success context overwrote it.

The fix already existed as a precedent in `review-fix/SKILL.md`: the
outcome-envelope emit already skips entirely on re-entry. The phase-log write a
few paragraphs earlier simply lacked the same gate.

## Change

Gate the phase-log write so it runs **only when the implement/review steps
actually executed this turn**; on the crash-recovery / idempotent re-entry path,
skip the write entirely so the prior entry is preserved verbatim.

- `implement/SKILL.md` — Step 5 phase-log write is now gated on the preamble's
  re-entry branch. Critically, the discriminator keys on *"did Steps 1–4 run this
  turn"*, **not** on PR presence: `PR_NUM` is set on both paths at Step 5, so a
  `[ -n "$PR_NUM" ]` gate would skip the write always and break the normal path.
- `review-fix/SKILL.md` — Step 7 phase-log write reuses the existing
  *"only when the Workflow ran this session"* condition, reading identically to
  the outcome-envelope gate.
- The false-safety *"so the repeat is safe"* rationale is replaced in both files
  with the correct reasoning: on re-entry there is no fresh outcome data, so
  recomposing would overwrite the prior entry with a thinner restatement;
  therefore the write is skipped, not repeated.
- The orthogonal failure-vs-success instruction (*"Compose it unconditionally
  (no 'only on failure' branch)"*) is preserved in both files.

## Verification

The plan's deterministic `verify` block passes — it confirms the false-safety
claim is gone from both files, the failure-vs-success instruction is retained,
and each file carries its re-entry skip gate. Behavioral confirmation (re-enter
each skill with a PR / `dispatch:reviewed` already present and confirm the prior
phase-log entry is unchanged) is manual, per the plan.
