### PR TITLE
Add explicit permissions: contents: read to remaining unit-tests.yml jobs

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -36,6 +38,8 @@ jobs:
 
   rules-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -86,6 +90,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -131,6 +137,8 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -144,6 +152,8 @@ jobs:
 
   hook-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Run approve-workflow-commands hook tests
@@ -163,6 +173,8 @@ jobs:
 
   test-integrity:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -172,6 +184,8 @@ jobs:
 
   playwright-version-sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -196,6 +210,8 @@ jobs:
 
   type-safety-sensor:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -205,6 +221,8 @@ jobs:
 
   go-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -238,6 +256,8 @@ jobs:
 
   darwin-build:
     runs-on: macos-14
+    permissions:
+      contents: read
     # No CI runtime baseline yet: the Build step has executed 0 times (it is
     # gated on nix-file changes and every run so far has skipped it). 30 min is
     # a conservative runaway guard vs GitHub's 6h default; tighten to ~2x the


### PR DESCRIPTION
Closes #2112

## What

Add an explicit job-level `permissions:` block

```yaml
    permissions:
      contents: read
```

to the 10 jobs in `.github/workflows/unit-tests.yml` that still relied on
implicit inheritance from the single workflow-level `permissions:` block. PR
#2103 already added this block to the `dead-code` job; this change brings the
remaining jobs in line:

`unit-tests`, `rules-test`, `lint`, `typecheck`, `hook-tests`,
`test-integrity`, `playwright-version-sync`, `type-safety-sensor`, `go-tests`,
`darwin-build`.

## Why

Least-privilege hardening. Today every job except `dead-code` inherits its
token scope from the workflow-level `permissions:` block. If that block is ever
changed or removed, all 10 jobs silently acquire the new default (write-all on
private repos) with no per-job guard. An explicit `contents: read` on each job
makes every job self-documenting and resilient to future workflow-level edits.

No behavior change: the granted scope is identical to today's effective
inheritance.

## Verification

The workflow now contains exactly 12 `permissions:` lines (1 workflow-level +
11 job-level) and 12 `contents: read` lines; the workflow-level block at lines
8-9 is unchanged. The real acceptance gate is the push-triggered CI run going
green — GitHub Actions rejects a malformed workflow before any job starts, so a
green run confirms the per-job blocks are syntactically accepted and no job lost
an access it needed.
