### PR TITLE
test: entry-point integration test for main-qa fresh-spawn with a missing main worktree

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6274,6 +6274,8 @@ rc=0; out=$("$TMPDIR_TEST/office-hours" 2>&1) || rc=$?
 assert_eq "main-qa missing main worktree → exit 1" "1" "$rc"
 assert_eq "main-qa missing main worktree → no spawn recorded" "no" \
   "$([[ -e "$TMPDIR_TEST/oh-bg-argv" ]] && echo yes || echo no)"
+assert_eq "main-qa missing main worktree → spawn-fail diagnostic (not worktree-swept diagnostic)" "yes" \
+  "$([[ "$out" == *'failed to launch'* ]] && echo yes || echo no)"
 unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6254,6 +6254,25 @@ assert_eq "no worktree → no spawn recorded" "no" \
   "$([[ -e "$TMPDIR_TEST/oh-bg-argv" ]] && echo yes || echo no)"
 teardown
 
+# OH3d. main-qa fresh-spawn negative path (OHST12): a main-qa-labelled, no-PR item
+# whose DISPATCH_OFFICE_HOURS_MAIN_WORKTREE directory does NOT exist → the entry
+# script exits 1 and records no spawn (dispatch-spawn-office-hours directory guard).
+echo "Test: main-qa item with missing main worktree dir → exit 1, no spawn"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"main-qa"}]}]\n' \
+  > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+# Do NOT mkdir the main worktree dir — this is the negative path being tested.
+office_hours_fresh_fake_claude
+rc=0; out=$("$TMPDIR_TEST/office-hours" 2>&1) || rc=$?
+assert_eq "main-qa missing main worktree → exit 1" "1" "$rc"
+assert_eq "main-qa missing main worktree → no spawn recorded" "no" \
+  "$([[ -e "$TMPDIR_TEST/oh-bg-argv" ]] && echo yes || echo no)"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
+teardown
+
 # OH4. Empty office-hours queue → selector emits `empty` → the entry script prints
 # the queue-empty message and exits WITHOUT launching Claude.
 echo "Test: empty queue → queue-empty message, no launch"


### PR DESCRIPTION
Closes #1775

## What

Adds one new entry-point integration test (`OH3d`) to the `office-hours (entry
point)` section of `test-dispatch-scripts.sh`, immediately after OH3b.

## Why

The OHST12 selector test only verifies that `office-hours-select-target` emits
the main worktree path as the 5th field for a fresh `main-qa` item — its own
comment notes the selector does not stat that path, and that a full entry-point
integration test for the main-qa fresh-spawn path is needed to actually exercise
the `dispatch-spawn-office-hours` directory guard. That end-to-end test did not
exist.

`OH3d` closes the gap. It drives the real selector → `office-hours` entry script
→ `dispatch-spawn-office-hours` wiring for the main-qa flavor with the main
worktree directory **missing**:

- The entry script passes the selector's 5th field straight to the spawn as
  `--cwd`. For a `main-qa` item that path is the main worktree.
- The `[[ -z "$d" || "$d" == "-" ]]` guard does not trip for a real-but-missing
  path, so the entry script proceeds to spawn.
- The spawn's Step-0 directory guard fires (exit 2), which the entry script maps
  to its own exit 1, launching nothing.

The test asserts the entry script exits 1 and that no spawn was recorded.

## Scope

Test-only. No production code changes. OHST12 and the existing
`dispatch-spawn-office-hours` "non-existent worktree path exits 2" unit test are
unchanged.

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` — the
new `OH3d` test passes and the full suite is green (3485/3485, zero failures).
