### PR TITLE
dispatch-retriage-orphaned-followups: use REST for per-PR state lookups

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-retriage-orphaned-followups
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-retriage-orphaned-followups
@@ -21,10 +21,11 @@
 # recently-closed PRs.
 #
 # Three-way PR-state gate (load-bearing): a cited PR's follow-ups are flagged
-# ONLY IF the PR is `state == "CLOSED"` AND `mergedAt == null` AND the PR does
+# ONLY IF the PR is `state == "closed"` AND `merged_at == null` AND the PR does
 # not already carry the `dispatch:orphans-retriaged` marker. A merged PR
-# (state MERGED + non-null mergedAt) or a still-open PR (state OPEN) must NEVER
-# be touched.
+# (state "closed" + non-null merged_at) or a still-open PR (state "open") must
+# NEVER be touched. (REST shape: lowercase state, snake_case merged_at — REST has
+# no distinct MERGED state, so the merged-PR skip rides the merged_at arm.)
 #
 # Idempotency: the per-PR `dispatch:orphans-retriaged` label is the correct
 # idempotency key — NOT an issue-level "is office-hours already present?" check.
@@ -54,7 +55,9 @@ RETRIAGED_DESC="dispatch: orphaned review follow-ups re-triaged after source PR 
 # narrowing the fetch to candidate follow-ups; the per-PR source identity is then
 # read from each issue's `<!-- dispatch:source-pr <N> -->` body marker, so the
 # fetch must include bodies (--include-body).
-# REST keeps this scan off the shared GraphQL rate-limit bucket (#1601).
+# REST keeps this scan off the shared GraphQL rate-limit bucket (#1601). The
+# per-PR state lookups in Step 2 are also REST (gh api .../pulls/$N, #2007), so
+# the entire scan is GraphQL-free.
 if ! OPEN_JSON=$(gh_issue_list_rest --state open --label dispatch:review-followup --include-body); then
   # Cannot scan without the open-issue set — best-effort, exit 0.
   echo "dispatch-retriage-orphaned-followups: warning: gh_issue_list_rest --state open --label dispatch:review-followup failed; skipping scan" >&2
@@ -79,22 +82,22 @@ done < <(printf '%s' "$OPEN_JSON" | jq -r '
 # ---- Step 2: for each distinct cited source PR, apply the three-way gate -----
 for N in "${!PR_FOLLOWUPS[@]}"; do
   PR_RC=0
-  PR_JSON=$(gh_retry gh pr view "$N" --json state,mergedAt,labels) || PR_RC=$?
+  PR_JSON=$(gh_retry gh api "repos/{owner}/{repo}/pulls/$N") || PR_RC=$?
   if [[ "$PR_RC" -ne 0 ]]; then
-    echo "dispatch-retriage-orphaned-followups: warning: gh pr view #$N failed; skipping" >&2
+    echo "dispatch-retriage-orphaned-followups: warning: gh api repos/.../pulls/#$N failed; skipping" >&2
     continue
   fi
 
   STATE=$(printf '%s' "$PR_JSON" | jq -r '.state')
-  MERGED_AT=$(printf '%s' "$PR_JSON" | jq -r '.mergedAt')
+  MERGED_AT=$(printf '%s' "$PR_JSON" | jq -r '.merged_at')
   HAS_MARKER=$(printf '%s' "$PR_JSON" \
     | jq -r --arg l "$RETRIAGED_LABEL" 'any(.labels[]?; .name == $l)')
 
-  # The three-way gate. A merged PR has state MERGED + non-null mergedAt; an
-  # open PR has state OPEN; an already-processed PR carries the marker. Skip
-  # silently in every one of those cases — only a CLOSED, never-merged,
-  # unmarked PR's follow-ups get flagged.
-  if [[ "$STATE" != "CLOSED" || "$MERGED_AT" != "null" || "$HAS_MARKER" == "true" ]]; then
+  # The three-way gate. REST has no MERGED state: a merged PR is state "closed"
+  # with a non-null merged_at; an open PR is state "open"; an already-processed
+  # PR carries the marker. Skip silently in every one of those cases — only a
+  # "closed", never-merged (merged_at null), unmarked PR's follow-ups get flagged.
+  if [[ "$STATE" != "closed" || "$MERGED_AT" != "null" || "$HAS_MARKER" == "true" ]]; then
     continue
   fi
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -486,6 +486,17 @@ case "$args" in
       exit 1
     fi
     ;;
+  api\ repos/*/pulls/*)
+    # dispatch-retriage-orphaned-followups (#1812, #2007): gh api
+    # repos/{owner}/{repo}/pulls/<N>. $STUB_DIR/retriage-pr-<N>.json supplies
+    # the per-PR REST state object; absence defaults to an OPEN PR (no action).
+    num="${args##*/}"
+    if [[ -f "$STUB_DIR/retriage-pr-${num}.json" ]]; then
+      cat "$STUB_DIR/retriage-pr-${num}.json"
+    else
+      echo '{"state":"open","merged_at":null,"labels":[]}'
+    fi
+    ;;
   pr\ view\ *\ --json\ closingIssuesReferences)
     # dispatch-resolve-arg PR branch: gh pr view <N> --json closingIssuesReferences.
     num=$(echo "$args" | awk '{print $3}')
@@ -503,17 +514,6 @@ case "$args" in
       cat "$STUB_DIR/pr-headref-${num}.json"
     else
       echo '{"headRefName":""}'
-    fi
-    ;;
-  pr\ view\ *\ --json\ state,mergedAt,labels)
-    # dispatch-retriage-orphaned-followups (#1812): gh pr view <N> --json
-    # state,mergedAt,labels. $STUB_DIR/retriage-pr-<N>.json supplies the per-PR
-    # state object; absence defaults to an OPEN PR (no action taken).
-    num=$(echo "$args" | awk '{print $3}')
-    if [[ -f "$STUB_DIR/retriage-pr-${num}.json" ]]; then
-      cat "$STUB_DIR/retriage-pr-${num}.json"
-    else
-      echo '{"state":"OPEN","mergedAt":null,"labels":[]}'
     fi
     ;;
   label\ create\ *)
@@ -34124,7 +34124,8 @@ echo "=== dispatch-retriage-orphaned-followups (#1812) ==="
 # via the shared `api *repos/*/issues?*` branch; gh_issue_list_rest remaps it.
 # The scan reads the <!-- dispatch:source-pr <N> --> marker from the body field,
 # gated by the static dispatch:review-followup label (server-side filter bypassed in stub).
-# Per-PR state comes from retriage-pr-<N>.json (gh pr view --json state,mergedAt,labels).
+# Per-PR state comes from retriage-pr-<N>.json (gh api repos/{owner}/{repo}/pulls/<N>,
+# REST shape: lowercase state, snake_case merged_at).
 # The office-hours park flows through the REAL copied dispatch-apply-office-hours,
 # which logs to gh-issue-edit.log / gh-issue-comment.log; the per-PR processed
 # marker hits the generic `pr edit *` branch, logged to gh-pr-edit.log.
@@ -34133,7 +34134,7 @@ echo "=== dispatch-retriage-orphaned-followups (#1812) ==="
 echo "Test: closed-unmerged source PR → park follow-up on office-hours + mark PR"
 setup
 printf '[{"number":101,"labels":[{"name":"dispatch:review-followup"}],"body":"orphan finding <!-- dispatch:source-pr 1704 -->"}]\n' > "$STUB_DIR/issue-list.json"
-printf '{"state":"CLOSED","mergedAt":null,"labels":[]}\n' > "$STUB_DIR/retriage-pr-1704.json"
+printf '{"state":"closed","merged_at":null,"labels":[]}\n' > "$STUB_DIR/retriage-pr-1704.json"
 out=$("$TMPDIR_TEST/dispatch-retriage-orphaned-followups" 2>/dev/null)
 assert_eq "a: office-hours applied to the follow-up issue" \
   "issue edit 101 --add-label dispatch:office-hours" "$(cat "$STUB_DIR/gh-issue-edit.log")"
@@ -34159,7 +34160,7 @@ teardown
 echo "Test: merged source PR → no action"
 setup
 printf '[{"number":102,"labels":[{"name":"dispatch:review-followup"}],"body":"orphan finding <!-- dispatch:source-pr 1688 -->"}]\n' > "$STUB_DIR/issue-list.json"
-printf '{"state":"MERGED","mergedAt":"2026-01-01T00:00:00Z","labels":[]}\n' > "$STUB_DIR/retriage-pr-1688.json"
+printf '{"state":"closed","merged_at":"2026-01-01T00:00:00Z","labels":[]}\n' > "$STUB_DIR/retriage-pr-1688.json"
 out=$("$TMPDIR_TEST/dispatch-retriage-orphaned-followups" 2>/dev/null)
 assert_eq "b: no office-hours edit on a merged source PR" "absent" "$(log_state gh-issue-edit.log)"
 assert_eq "b: no PR marker on a merged source PR" "absent" "$(log_state gh-pr-edit.log)"
@@ -34170,7 +34171,7 @@ teardown
 echo "Test: still-open source PR → no action"
 setup
 printf '[{"number":103,"labels":[{"name":"dispatch:review-followup"}],"body":"orphan finding <!-- dispatch:source-pr 1900 -->"}]\n' > "$STUB_DIR/issue-list.json"
-printf '{"state":"OPEN","mergedAt":null,"labels":[]}\n' > "$STUB_DIR/retriage-pr-1900.json"
+printf '{"state":"open","merged_at":null,"labels":[]}\n' > "$STUB_DIR/retriage-pr-1900.json"
 out=$("$TMPDIR_TEST/dispatch-retriage-orphaned-followups" 2>/dev/null)
 assert_eq "c: no office-hours edit on an open source PR" "absent" "$(log_state gh-issue-edit.log)"
 assert_eq "c: no PR marker on an open source PR" "absent" "$(log_state gh-pr-edit.log)"
@@ -34181,7 +34182,7 @@ teardown
 echo "Test: source PR already marked dispatch:orphans-retriaged → no action"
 setup
 printf '[{"number":104,"labels":[{"name":"dispatch:review-followup"}],"body":"orphan finding <!-- dispatch:source-pr 1704 -->"}]\n' > "$STUB_DIR/issue-list.json"
-printf '{"state":"CLOSED","mergedAt":null,"labels":[{"name":"dispatch:orphans-retriaged"}]}\n' > "$STUB_DIR/retriage-pr-1704.json"
+printf '{"state":"closed","merged_at":null,"labels":[{"name":"dispatch:orphans-retriaged"}]}\n' > "$STUB_DIR/retriage-pr-1704.json"
 out=$("$TMPDIR_TEST/dispatch-retriage-orphaned-followups" 2>/dev/null)
 assert_eq "d: no re-park when PR already marked" "absent" "$(log_state gh-issue-edit.log)"
 assert_eq "d: no re-mark when PR already marked" "absent" "$(log_state gh-pr-edit.log)"
@@ -34228,8 +34229,8 @@ setup
 # (wrongly) chosen, the gate would no-op and nothing would park. The genuine
 # trailing marker cites PR #1704 (CLOSED-unmerged), which parks + marks.
 printf '[{"number":106,"labels":[{"name":"dispatch:review-followup"}],"body":"orphan finding mentions <!-- dispatch:source-pr 1500 --> in its text, then the genuine appended marker <!-- dispatch:source-pr 1704 -->"}]\n' > "$STUB_DIR/issue-list.json"
-printf '{"state":"OPEN","mergedAt":null,"labels":[]}\n' > "$STUB_DIR/retriage-pr-1500.json"
-printf '{"state":"CLOSED","mergedAt":null,"labels":[]}\n' > "$STUB_DIR/retriage-pr-1704.json"
+printf '{"state":"open","merged_at":null,"labels":[]}\n' > "$STUB_DIR/retriage-pr-1500.json"
+printf '{"state":"closed","merged_at":null,"labels":[]}\n' > "$STUB_DIR/retriage-pr-1704.json"
 out=$("$TMPDIR_TEST/dispatch-retriage-orphaned-followups" 2>/dev/null)
 assert_eq "g: parks the follow-up against the LAST marker's PR (#1704)" \
   "issue edit 106 --add-label dispatch:office-hours" "$(cat "$STUB_DIR/gh-issue-edit.log")"


### PR DESCRIPTION
Closes #2007

## Problem

`dispatch-retriage-orphaned-followups` is a best-effort tick-time scan. Its Step 1
open-issue fetch deliberately uses REST (`gh_issue_list_rest`) to stay off the
**shared GraphQL rate-limit bucket** — the codebase has repeated GraphQL
rate-limit incidents (#1601, #1636).

But Step 2's per-PR state lookup was `gh pr view "$N" --json state,mergedAt,labels`,
which is **GraphQL-backed**. It runs once per distinct cited source PR on every
tick. Merged and still-open PRs are skipped by the three-way gate but never
marked, so they are re-queried every tick for as long as any of their follow-up
issues stay open — and the set of cited PRs grows monotonically. The result was
unbounded per-tick GraphQL pressure on the exact shared bucket the REST
issue-list choice was meant to protect.

## Fix

Replace the per-PR `gh pr view` GraphQL call with the REST pulls endpoint
(`gh api repos/{owner}/{repo}/pulls/$N`) and adapt the three-way gate to the REST
response shape, so the **entire scan is GraphQL-free**:

- `.mergedAt` → `.merged_at` (REST uses snake_case).
- `state` comparison `"CLOSED"` → `"closed"` (REST state is lowercase). REST has
  no distinct `MERGED` state — a merged PR is `state == "closed"` with a non-null
  `merged_at`, so the merged-PR skip now rides the `merged_at` arm.
- The `.labels[].name` marker read is unchanged — REST pull objects also carry a
  `labels` array.

The `gh_retry` / best-effort `exit 0` / per-PR warn-and-skip scaffolding is reused
unchanged; only the one command and the gate field names change. The REST idiom
matches existing calls at `lib.sh:183` and `lib.sh:471`.

The test harness (`test-dispatch-scripts.sh`) lands in the **same commit**: the
dead `gh pr view --json state,mergedAt,labels` shim case is replaced with a REST
`api repos/*/pulls/*` case, and all six `retriage-pr-<N>.json` fixtures are
converted to REST shape (lowercase `state`, snake_case `merged_at`). The
discriminating merged-PR fixture keeps `merged_at` non-null so the gate still
skips it.

The optional enhancement in the issue (also marking merged/open PRs) is
**deliberately out of scope** — it contradicts acceptance criterion 4 and the
script's load-bearing invariant that a merged or still-open PR must never be
touched.

## Verification

`test-dispatch-scripts.sh` — 3522/3522 pass. A grep confirms no GraphQL
`gh pr view` per-PR call remains in the script.
