### PR TITLE
lint-prose-rules.sh: drop unused SCRIPTS declaration and lib.sh source

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh
@@ -2,10 +2,6 @@
 set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-SCRIPTS="$(cd "$(dirname "$0")" && pwd)"
-
-# shellcheck source=lib.sh
-source "$SCRIPTS/lib.sh"
 
 # Detect: echo "$VAR" | jq  (quoted variable form only — see .claude/rules/shell-json.md)
 # Covers optional echo flags (echo -e / echo -n) and the braced ${VAR} form, both


### PR DESCRIPTION
Closes #2086

## Summary

`lint-prose-rules.sh` declared a `SCRIPTS` variable and sourced `lib.sh`, but
called no function from `lib.sh`. The linter is self-contained — it uses only
`git`, bash builtins, `echo`, and `cat` — and `REPO_ROOT` is already set
independently via `git rev-parse --show-toplevel`. The only use of `SCRIPTS`
was the `source` line itself.

This drops the unused `SCRIPTS` declaration, the `# shellcheck source=lib.sh`
comment, and the `source "$SCRIPTS/lib.sh"` line. Removing the coupling keeps
the linter fast and hermetic, and avoids silently inheriting any future
source-time side effects `lib.sh` might gain (it already exports
`FIREBASE_PROJECT_ID` and `QA_REMOTE_SSH_HOST` at source time).

## Changes

- `lint-prose-rules.sh`: remove the `SCRIPTS` assignment and the `lib.sh`
  source; `REPO_ROOT` (line 4) is unchanged and remains the only setup the
  linter needs.

No change to `lib.sh`, `run-lint.sh`, the detection logic, or the test harness.

## Verification

The behavioral suite `test-lint-prose-rules.sh` passes (14/14) — it builds
ephemeral git repos with and without echo-into-jq violations and asserts the
exit code / output for both, the same check CI runs.
