### PR TITLE
dispatch-write-phase-log: reject issue-num 0 via ^[1-9][0-9]*$ validation

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-write-phase-log
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-write-phase-log
@@ -30,7 +30,7 @@ if [[ $# -lt 1 || -z "$N" ]]; then
   echo "usage: dispatch-write-phase-log <issue-num> --phase <p> [--attempt <n>]   (entry body on STDIN)" >&2
   exit 2
 fi
-if [[ ! "$N" =~ ^[0-9]+$ ]]; then
+if [[ ! "$N" =~ ^[1-9][0-9]*$ ]]; then
   echo "dispatch-write-phase-log: issue-num must be a positive integer, got: $N" >&2
   exit 2
 fi

--- a/.claude/skills/dispatch-propagate/scripts/test-write-phase-log.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-write-phase-log.sh
@@ -40,6 +40,20 @@ assert_eq "AC2: exit code is 2" "2" "$AC2_RC"
 assert_contains "AC2: stderr mentions --attempt" "--attempt" "$AC2_STDERR"
 
 # ============================================================================
+# issue-num 0 → exit 2, stderr mentions 'positive integer' (#2134)
+# ============================================================================
+
+echo ""
+echo "issue-num 0: exit 2, stderr mentions positive integer"
+
+set +e
+ZERO_STDERR=$(printf 'body\n' | "$SUT" 0 --phase plan 2>&1)
+ZERO_RC=$?
+set -e
+assert_eq "issue-num 0: exit code is 2" "2" "$ZERO_RC"
+assert_contains "issue-num 0: stderr mentions positive integer" "positive integer" "$ZERO_STDERR"
+
+# ============================================================================
 # AC3: valid invocation → exit 0, gh stub records a POST to issues/2132/comments
 # ============================================================================
 


### PR DESCRIPTION
Closes #2134

## What

Tighten the `issue-num` argument validation in
`.claude/skills/dispatch-propagate/scripts/dispatch-write-phase-log` from
`^[0-9]+$` to `^[1-9][0-9]*$`, so `0` (and `00`) are rejected.

## Why

GitHub issue numbers start at 1 — issue #0 does not exist — and the script's own
error message already promises "must be a positive integer", but the old regex
accepted `0`. The sibling script `dispatch-context-pack` already validates the
same kind of argument with `^[1-9][0-9]*$`, so the two were inconsistent. This
makes the guard match its own error message and the project's established
pattern, closing a latent inconsistency surfaced as a backlink from #2108.

All current callers derive the issue number from a branch name (always ≥ 1), so
this never triggered in practice; the change is a guard tightening with no
behavioral effect on valid input.

## Changes

- `dispatch-write-phase-log:33` — regex tightened to `^[1-9][0-9]*$`; the
  error message is unchanged (the edit makes it accurate).
- `test-write-phase-log.sh` — new regression case asserting issue-num `0` exits
  2 with a "positive integer" message. The validation fires before any git/gh
  calls, so the case needs no temp repo or `gh` stub.

## Verification

`run-unit-tests.sh --pr-scripts` passes, including the new 0-rejection
assertions in `test-write-phase-log.sh`.
