### PR TITLE
Add E5 test: sidecar duplication finding with no baseline

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -35536,6 +35536,42 @@ assert_eq "sidecar no net-increase → zero findings" "0" "$sidecar_count"
 rm -rf "$TMPDIR_TEST"
 TMPDIR_TEST=""
 
+# E5. Sidecar no-baseline duplication: all-new-files PR has empty baseline_paths,
+#     so the driver passes NO --jscpd-base. The sidecar then defaults baseDup to
+#     zeros, so any HEAD clone (headDup.clones > 0) fires an aggregate duplication
+#     finding with a path:line Location from the largest HEAD clone. E2/E3 pass a
+#     zero-clone HEAD report, so this duplication path is otherwise uncovered.
+#     Empty eslint reports isolate the duplication path (no complexity finding).
+echo "Test: dispatch-review-erosion-diff.mjs — no-baseline HEAD clone yields Source=erosion duplication finding"
+TMPDIR_TEST=$(mktemp -d)
+mkdir -p "$TMPDIR_TEST/baseline"
+# Empty eslint reports → no complexity finding; isolates the duplication path.
+echo '[]' > "$TMPDIR_TEST/head-eslint.json"
+echo '[]' > "$TMPDIR_TEST/base-eslint.json"
+# HEAD jscpd report: one clone with concrete per-clone detail so the Location is
+# a real path:line (newfile.ts:10), not the changed-files fallback.
+cat > "$TMPDIR_TEST/head-jscpd.json" <<'EOF'
+{"statistics":{"total":{"clones":1,"duplicatedLines":12,"percentage":8}},
+ "duplicates":[{"firstFile":{"name":"newfile.ts","start":10,"end":22},
+                "secondFile":{"name":"newfile.ts","start":40,"end":52}}]}
+EOF
+# Invoke WITHOUT --jscpd-base (the all-new-files / no-baseline case).
+sidecar_out=$(cd "$TMPDIR_TEST" && node "$SCRIPT_DIR/dispatch-review-erosion-diff.mjs" \
+  --eslint-head head-eslint.json \
+  --eslint-base base-eslint.json \
+  --jscpd-head head-jscpd.json \
+  --baseline-dir baseline)
+sidecar_source=$(jq -r '.findings[0].Source // "none"' <<<"$sidecar_out")
+sidecar_location=$(jq -r '.findings[0].Location // "none"' <<<"$sidecar_out")
+sidecar_confidence=$(jq -r '.findings[0].Confidence // "none"' <<<"$sidecar_out")
+sidecar_count=$(jq '.findings | length' <<<"$sidecar_out")
+assert_eq "sidecar no-baseline duplication Source=erosion" "erosion" "$sidecar_source"
+assert_eq "sidecar no-baseline duplication Location=newfile.ts:10" "newfile.ts:10" "$sidecar_location"
+assert_eq "sidecar no-baseline duplication Confidence=high (clones rose 0→1)" "high" "$sidecar_confidence"
+assert_eq "sidecar no-baseline duplication → exactly one finding" "1" "$sidecar_count"
+rm -rf "$TMPDIR_TEST"
+TMPDIR_TEST=""
+
 # ============================================================================
 # dispatch-run-verification tests (#2024)
 # ============================================================================


### PR DESCRIPTION
Closes #2087

## What

Adds a deterministic, network-free **E5** test to
`test-dispatch-scripts.sh`, exercising the erosion JSON-diff sidecar's
no-baseline duplication-finding path.

## Why

`dispatch-review-erosion-diff.mjs` (added in #2082) takes an **optional**
`--jscpd-base` flag. When a PR is all-new-files — empty `baseline_paths` — the
bash driver passes no `--jscpd-base`, so the sidecar defaults `baseDup` to zeros
and any HEAD clone (`headDup.clones > 0`) emits an aggregate duplication finding
with a `path:line` `Location` from the largest HEAD clone.

The existing E2/E3 tests both pass a **zero-clone** HEAD jscpd report, so the
`clonesRose`/`dupLinesRose` branch never fires — the duplication-finding code is
unreachable from the test suite. E5 closes that gap.

## How

E5 mirrors the E2 convention (same `mktemp -d` setup, direct `node` invocation
of the sidecar with synthetic JSON, `jq` + `assert_eq` assertions, teardown). It
supplies **empty** eslint reports (to isolate the duplication path from any
complexity finding) and a HEAD jscpd report carrying one clone with concrete
per-clone detail, then invokes the sidecar **without** `--jscpd-base`. It asserts
exactly one finding with `Source=erosion`, `Location=newfile.ts:10`,
`Confidence=high`.

Test-only addition — no change to `dispatch-review-erosion-diff.mjs`, the
`dispatch-review-erosion` driver, or E1/E2/E3.

## Verification

`test-dispatch-scripts.sh` passes: `3526/3526 passed, 0 failed`, including the
four new E5 assertions.
