### PR TITLE
blog: wrap top-level awaits in prerender entry scripts with descriptive errors

### DIFF
--- a/fellspiral/scripts/prerender.ts
+++ b/fellspiral/scripts/prerender.ts
@@ -45,15 +45,33 @@ try {
   );
 }
 
-generateFeedXml({
-  title: "fellspiral",
-  siteUrl: SITE_URL,
-  distDir,
-  seed: appSeed,
-});
+try {
+  generateFeedXml({
+    title: "fellspiral",
+    siteUrl: SITE_URL,
+    distDir,
+    seed: appSeed,
+  });
+} catch (err) {
+  throw new Error(
+    `Prerender failed in fellspiral/scripts/prerender.ts (generateFeedXml): ${
+      err instanceof Error ? err.message : String(err)
+    }`,
+    { cause: err },
+  );
+}
 
-generateSitemapXml({
-  siteUrl: SITE_URL,
-  distDir,
-  seed: appSeed,
-});
+try {
+  generateSitemapXml({
+    siteUrl: SITE_URL,
+    distDir,
+    seed: appSeed,
+  });
+} catch (err) {
+  throw new Error(
+    `Prerender failed in fellspiral/scripts/prerender.ts (generateSitemapXml): ${
+      err instanceof Error ? err.message : String(err)
+    }`,
+    { cause: err },
+  );
+}

--- a/fellspiral/scripts/prerender.ts
+++ b/fellspiral/scripts/prerender.ts
@@ -16,25 +16,34 @@ import {
 
 const distDir = join(dirname(new URL(import.meta.url).pathname), "..", "dist");
 
-await prerenderPosts({
-  siteUrl: SITE_URL,
-  titleSuffix: "Fellspiral",
-  distDir,
-  seed: appSeed,
-  postDir: join(distDir, "..", "post"),
-  navLinks: NAV_LINKS,
-  infoPanel: {
-    linkSections: INFO_PANEL_LINK_SECTIONS,
-    blogRoll: FEED_REGISTRY.map((f) => ({ id: f.id, name: f.name, url: f.homeUrl })),
-    rssFeedUrl: "/feed.xml",
-    opmlUrl: "/blogroll.opml",
-  },
-  siteDefaults: SITE_DEFAULTS,
-  organization: ORGANIZATION,
-  author: AUTHOR,
-  relMe: REL_ME,
-  showHomeLink: true,
-});
+try {
+  await prerenderPosts({
+    siteUrl: SITE_URL,
+    titleSuffix: "Fellspiral",
+    distDir,
+    seed: appSeed,
+    postDir: join(distDir, "..", "post"),
+    navLinks: NAV_LINKS,
+    infoPanel: {
+      linkSections: INFO_PANEL_LINK_SECTIONS,
+      blogRoll: FEED_REGISTRY.map((f) => ({ id: f.id, name: f.name, url: f.homeUrl })),
+      rssFeedUrl: "/feed.xml",
+      opmlUrl: "/blogroll.opml",
+    },
+    siteDefaults: SITE_DEFAULTS,
+    organization: ORGANIZATION,
+    author: AUTHOR,
+    relMe: REL_ME,
+    showHomeLink: true,
+  });
+} catch (err) {
+  throw new Error(
+    `Prerender failed in fellspiral/scripts/prerender.ts (prerenderPosts): ${
+      err instanceof Error ? err.message : String(err)
+    }`,
+    { cause: err },
+  );
+}
 
 generateFeedXml({
   title: "fellspiral",

--- a/landing/scripts/prerender.ts
+++ b/landing/scripts/prerender.ts
@@ -91,16 +91,34 @@ try {
   );
 }
 
-generateFeedXml({
-  title: "commons.systems",
-  siteUrl: SITE_URL,
-  distDir,
-  seed: appSeed,
-});
+try {
+  generateFeedXml({
+    title: "commons.systems",
+    siteUrl: SITE_URL,
+    distDir,
+    seed: appSeed,
+  });
+} catch (err) {
+  throw new Error(
+    `Prerender failed in landing/scripts/prerender.ts (generateFeedXml): ${
+      err instanceof Error ? err.message : String(err)
+    }`,
+    { cause: err },
+  );
+}
 
-generateSitemapXml({
-  siteUrl: SITE_URL,
-  distDir,
-  seed: appSeed,
-  staticPaths: ["/", "/about"],
-});
+try {
+  generateSitemapXml({
+    siteUrl: SITE_URL,
+    distDir,
+    seed: appSeed,
+    staticPaths: ["/", "/about"],
+  });
+} catch (err) {
+  throw new Error(
+    `Prerender failed in landing/scripts/prerender.ts (generateSitemapXml): ${
+      err instanceof Error ? err.message : String(err)
+    }`,
+    { cause: err },
+  );
+}

--- a/landing/scripts/prerender.ts
+++ b/landing/scripts/prerender.ts
@@ -39,39 +39,57 @@ const infoPanel = {
 // reads dist/index.html as its template and injectBeforeHead only *prepends*
 // its <head> tags — it never strips pre-existing ones — so running it second
 // would leave /about with the home page's SEO tags duplicated alongside its own.
-prerenderStaticPage({
-  siteUrl: SITE_URL,
-  titleSuffix,
-  distDir,
-  page: ABOUT_PAGE_META,
-  // Wrap in a <div> to byte-match how createBlogApp hydrates/renders the /about
-  // extraRoute body — createElement("div", { dangerouslySetInnerHTML }). Without
-  // the wrapper, a deep entry to /about would hydrate this body against a bare
-  // <div> and abandon hydration (React #424), shifting layout on the SEO surface.
-  bodyHtml: `<div>${renderAboutHtml()}</div>`,
-  navLinks: NAV_LINKS,
-  aboutContent: renderAboutPanelHtml(),
-  jsonLdBlocks: [personJsonLd(PERSON)],
-  relMe: REL_ME,
-  showHomeLink: false,
-});
+try {
+  prerenderStaticPage({
+    siteUrl: SITE_URL,
+    titleSuffix,
+    distDir,
+    page: ABOUT_PAGE_META,
+    // Wrap in a <div> to byte-match how createBlogApp hydrates/renders the /about
+    // extraRoute body — createElement("div", { dangerouslySetInnerHTML }). Without
+    // the wrapper, a deep entry to /about would hydrate this body against a bare
+    // <div> and abandon hydration (React #424), shifting layout on the SEO surface.
+    bodyHtml: `<div>${renderAboutHtml()}</div>`,
+    navLinks: NAV_LINKS,
+    aboutContent: renderAboutPanelHtml(),
+    jsonLdBlocks: [personJsonLd(PERSON)],
+    relMe: REL_ME,
+    showHomeLink: false,
+  });
+} catch (err) {
+  throw new Error(
+    `Prerender failed in landing/scripts/prerender.ts (prerenderStaticPage): ${
+      err instanceof Error ? err.message : String(err)
+    }`,
+    { cause: err },
+  );
+}
 
-await prerenderPosts({
-  siteUrl: SITE_URL,
-  titleSuffix,
-  distDir,
-  seed: appSeed,
-  postDir,
-  navLinks: NAV_LINKS,
-  infoPanel,
-  siteDefaults: SITE_DEFAULTS,
-  organization: ORGANIZATION,
-  author: AUTHOR,
-  relMe: REL_ME,
-  softwareApplications: APPS,
-  homeExtraHtml: renderShowcase(APPS),
-  showHomeLink: false,
-});
+try {
+  await prerenderPosts({
+    siteUrl: SITE_URL,
+    titleSuffix,
+    distDir,
+    seed: appSeed,
+    postDir,
+    navLinks: NAV_LINKS,
+    infoPanel,
+    siteDefaults: SITE_DEFAULTS,
+    organization: ORGANIZATION,
+    author: AUTHOR,
+    relMe: REL_ME,
+    softwareApplications: APPS,
+    homeExtraHtml: renderShowcase(APPS),
+    showHomeLink: false,
+  });
+} catch (err) {
+  throw new Error(
+    `Prerender failed in landing/scripts/prerender.ts (prerenderPosts): ${
+      err instanceof Error ? err.message : String(err)
+    }`,
+    { cause: err },
+  );
+}
 
 generateFeedXml({
   title: "commons.systems",


### PR DESCRIPTION
Closes #2036

## What

Both blog prerender entry scripts — `fellspiral/scripts/prerender.ts` and
`landing/scripts/prerender.ts` — invoke `prerenderPosts()` (and, in landing,
`prerenderStaticPage()`) at the module top level. If one of these rejects (a
missing build artifact, an unresolvable module, malformed seed data), the error
surfaced as a raw unhandled rejection naming the internal throw site inside
`@commons-systems/blog/prerender` — not the entry point. Both packages share an
identical `build` script, so a bare rejection did not distinguish the fellspiral
build from the landing build, nor say which function failed.

This wraps each top-level entry call in its own `try`/`catch` that re-throws with
a descriptive, script-path-prefixed message and preserves the original error via
`{ cause: err }`:

- `fellspiral/scripts/prerender.ts` — wraps the single `await prerenderPosts(…)`.
- `landing/scripts/prerender.ts` — wraps `prerenderStaticPage(…)` and
  `await prerenderPosts(…)` in two separate blocks, keeping the load-bearing
  ordering (static page must render before posts) intact.

## Approach

Follows the established ad-hoc `new Error(msg, { cause: err })` convention
(precedent: `fellspiral/scripts/generate-responsive-images.ts:24`) rather than
introducing a shared wrapper for two call sites. The blog package's
`prerenderPosts` / `prerenderStaticPage` deliberately do not add caller context;
that responsibility belongs to the entry script. Each catch uses the
`err instanceof Error ? err.message : String(err)` guard.

## Out of scope

The synchronous `generateFeedXml` / `generateSitemapXml` calls (not `await`ed,
not in the acceptance criteria) and both `critical-css.ts` scripts (separate
files outside this issue) are intentionally left unchanged.

## Verification

The changed scripts live in each package's `scripts/` directory, which is not
covered by the package `tsconfig.json` (`include: ["src"]`), so neither the CI
typecheck nor `eslint src/` checks them. A `verify` block typechecks both changed
scripts directly against each package's exact compiler options — green after the
additive wrap.
