### PR TITLE
Cover phase-log section bodies with embedded blank lines in test-write-phase-log

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-write-phase-log.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-write-phase-log.sh
@@ -3,6 +3,11 @@
 # Verifies that the awk state machine preserves blank separator lines between
 # phase-log sections on repeated upserts (issue #2139).
 #
+# Also covers section bodies that themselves contain embedded blank lines: a
+# non-last re-upsert must remain byte-for-byte identical even when the body
+# has an embedded blank line that would otherwise be mistaken for a section
+# terminator (issue #2164).
+#
 # Also covers the flag-value guard behavior (#2132):
 #   AC1: --phase with no value exits 2 with '--phase' in stderr
 #   AC2: --attempt with no value exits 2 with '--attempt' in stderr
@@ -285,6 +290,32 @@ BLANK_COUNT=$(awk '
 ' "$STORED_BODY_FILE")
 
 assert_eq "tc4: exactly one blank line between implement:1 and qa:1 after APPEND" "1" "$BLANK_COUNT"
+
+echo ""
+
+# ============================================================================
+# Test case 5: Section body with an embedded blank line — non-last re-upsert
+# is byte-for-byte identical (#2164)
+# ============================================================================
+echo ""
+echo "-- Test 5: non-last section with embedded blank body re-upsert --"
+STORED_BODY_FILE="$WORK/body-tc5.txt"
+
+# Write implement:1 whose BODY contains an embedded blank line.
+run_write 42 implement 1 $'line1\n\nline2'
+# Append qa:1 so implement:1 becomes NON-LAST: the REPLACE skip-state machine
+# must skip past the embedded blank in implement:1's body and terminate only
+# at qa:1's '<!-- phase-log:' header, not at the embedded blank.
+run_write 42 qa 1 "failed: none"
+
+REF5="$WORK/ref-tc5.txt"
+cp "$STORED_BODY_FILE" "$REF5"
+
+# Re-upsert implement:1 (REPLACE path). If a future change treated the embedded
+# blank as a terminator, the skip would stop early and the body would differ.
+run_write 42 implement 1 $'line1\n\nline2'
+
+assert_files_eq "tc5: non-last section with embedded blank re-upsert is byte-for-byte identical" "$REF5" "$STORED_BODY_FILE"
 
 echo ""
 

--- a/.claude/skills/dispatch-propagate/scripts/test-write-phase-log.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-write-phase-log.sh
@@ -320,6 +320,33 @@ assert_files_eq "tc5: non-last section with embedded blank re-upsert is byte-for
 echo ""
 
 # ============================================================================
+# Test case 5b: Section body with an embedded blank line as the SOLE (last)
+# section — re-upsert is byte-for-byte identical (#2164)
+#
+# Mirrors TC3 (last-section REPLACE) but with an embedded-blank body, completing
+# the coverage matrix. If a future change to the awk skip-state machine added a
+# blank-line terminator condition, the last-section REPLACE would stop skipping
+# at the embedded blank and corrupt the re-upsert.
+# ============================================================================
+echo "-- Test 5b: last (sole) section with embedded blank body re-upsert --"
+STORED_BODY_FILE="$WORK/body-tc5b.txt"
+
+# Write implement:1 whose BODY contains an embedded blank line, as the sole
+# (and therefore last) section. No following section, so the REPLACE skip-state
+# machine must skip to end-of-input, not stop at the embedded blank.
+run_write 42 implement 1 $'line1\n\nline2'
+
+REF5B="$WORK/ref-tc5b.txt"
+cp "$STORED_BODY_FILE" "$REF5B"
+
+# Re-upsert implement:1 (REPLACE of the last/sole section).
+run_write 42 implement 1 $'line1\n\nline2'
+
+assert_files_eq "tc5b: last (sole) section with embedded blank re-upsert is byte-for-byte identical" "$REF5B" "$STORED_BODY_FILE"
+
+echo ""
+
+# ============================================================================
 # Flag-value guard tests (#2132)
 # ============================================================================
 


### PR DESCRIPTION
Closes #2164

## What

Add a regression test (Test 5) to `test-write-phase-log.sh` covering a phase-log
section body that itself contains an embedded blank line.

## Why

`dispatch-write-phase-log`'s REPLACE path uses an awk skip-state machine: on
re-upsert of a non-last section it drops every line after the target inner
marker until it hits the next section's `<!-- phase-log:` header (or EOF). The
existing suite (Tests 1–4) only exercises single-line section bodies, so no test
covered a body containing a blank line. The current behavior is already correct —
the embedded blank is dropped as part of the old target content and the new
replacement supplies the matching body — but there was no regression coverage
guarding it. A future change that wrongly treated an embedded blank as a section
terminator would stop the skip early and corrupt the REPLACE output, undetected.

## What the test does

Writes `implement:1` with an embedded-blank body, appends `qa:1` so `implement:1`
is non-last (the only arrangement that exercises the skip *terminator* search
rather than EOF termination), captures the reference, then re-upserts
`implement:1` and asserts the stored comment body is byte-for-byte identical.

Coverage only — no change to `dispatch-write-phase-log`. Full suite passes 12/12.
