### PR TITLE
dispatch: clean up stale heartbeat unit files when install path changes

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -1778,6 +1778,42 @@ EOF
 # `OnFailure=dispatch-tick-recover.service` chains a crashing tick to the same
 # systemd-owned recovery handler the tick/reseed launchers use.
 #
+# Disable a stale heartbeat timer/service whose installed unit points at a
+# different main-worktree path than the current one (#2056). Between a dispatch
+# checkout path change and the first ensure_heartbeat_units call from the new
+# path, the timer's Persistent=true can fire dispatch-heartbeat.service at the
+# old/missing path. Detect the mismatch from the installed WorkingDirectory= and
+# disable the stale units before the caller rewrites them.
+#
+# Best-effort: the heartbeat service has no [Install] section, so `disable` exits
+# non-zero by design. Suppress that and never abort the caller (a tick/reseed
+# launcher) — the subsequent unit rewrite is what actually repairs the state.
+# Args: $1 = installed service-unit path, $2 = current main worktree path,
+#       $3 = systemctl command
+cleanup_stale_heartbeat_units() {
+  local service_path="$1"
+  local current_main_worktree="$2"
+  local systemctl_cmd="$3"
+
+  # No prior units → nothing to clean up.
+  [ -f "$service_path" ] || return 0
+
+  local installed_workdir
+  installed_workdir=$(sed -n 's/^WorkingDirectory=//p' "$service_path" | head -1)
+
+  # No WorkingDirectory= to compare → nothing to do.
+  [ -n "$installed_workdir" ] || return 0
+
+  # Path unchanged → the timer points at the right place; leave it running.
+  [ "$installed_workdir" = "$current_main_worktree" ] && return 0
+
+  # Path changed: stop the stale timer/service before the caller rewrites the
+  # unit content. Best-effort — disable exits non-zero (no [Install] section), so
+  # suppress the failure and warn; never abort the caller.
+  echo "WARNING: cleanup_stale_heartbeat_units: installed heartbeat unit points at '$installed_workdir' but current main worktree is '$current_main_worktree'; disabling stale timer/service before rewrite" >&2
+  "$systemctl_cmd" --user disable --now dispatch-heartbeat.timer dispatch-heartbeat.service || true
+}
+
 # Best-effort: a failure here must not abort the caller (a tick/reseed
 # launcher), so we warn to stderr and return non-zero — never `exit`. A missing
 # heartbeat just means the chain falls back to the prior Stop-hook/reseed-only
@@ -1884,6 +1920,13 @@ EOF
      && "$SYSTEMCTL_CMD" --user is-active --quiet dispatch-heartbeat.timer; then
     return 0
   fi
+
+  # Path-change cleanup (#2056): if the installed unit names a different main
+  # worktree, the path changed — disable the stale timer/service before
+  # rewriting the unit content below. Reaching here means the hot path did not
+  # short-circuit, so either the content differs (path change included) or the
+  # timer is inactive. Best-effort; never aborts.
+  cleanup_stale_heartbeat_units "$SERVICE_PATH" "$main_worktree" "$SYSTEMCTL_CMD"
 
   if ! mkdir -p "$UNIT_DIR"; then
     echo "WARNING: ensure_heartbeat_units: mkdir -p $UNIT_DIR failed; periodic heartbeat unavailable" >&2

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -31275,6 +31275,58 @@ else
   echo "  FAIL: ensure_heartbeat_units (hot path) returned non-zero"
 fi
 
+# --- 3. cleanup_stale_heartbeat_units: path-change disable (#2056) ------------
+# Called DIRECTLY (not via ensure_heartbeat_units): the "paths match" case would
+# otherwise hit the hot-path early-return before reaching the cleanup call.
+mkdir -p "$ehu_unit_dir"
+
+# 3a. AC1 — installed WorkingDirectory differs from current → disable fires.
+: > "$ehu_log"
+printf '%s\n' '[Service]' 'WorkingDirectory=/old/path' > "$ehu_svc"
+(
+  export STUB_LOG="$ehu_log"
+  source "$SCRIPT_DIR/lib.sh"
+  cleanup_stale_heartbeat_units "$ehu_svc" "$ehu_tmp/main-worktree" "$ehu_tmp/bin/systemctl"
+)
+TOTAL=$((TOTAL + 1))
+if grep -q 'disable --now dispatch-heartbeat.timer dispatch-heartbeat.service' "$ehu_log"; then
+  PASS=$((PASS + 1)); echo "  PASS: cleanup_stale_heartbeat_units disabled stale units on path change"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: cleanup_stale_heartbeat_units did not disable on path change"
+fi
+
+# 3b. AC2 — installed WorkingDirectory matches current → no disable.
+: > "$ehu_log"
+printf '%s\n' '[Service]' "WorkingDirectory=$ehu_tmp/main-worktree" > "$ehu_svc"
+(
+  export STUB_LOG="$ehu_log"
+  source "$SCRIPT_DIR/lib.sh"
+  cleanup_stale_heartbeat_units "$ehu_svc" "$ehu_tmp/main-worktree" "$ehu_tmp/bin/systemctl"
+)
+TOTAL=$((TOTAL + 1))
+if ! grep -q 'disable' "$ehu_log"; then
+  PASS=$((PASS + 1)); echo "  PASS: cleanup_stale_heartbeat_units did not disable when path matches"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: cleanup_stale_heartbeat_units disabled despite matching path"
+fi
+
+# 3c. AC3 — no prior service unit → no-op (returns 0, no disable).
+: > "$ehu_log"
+ehu_missing_svc="$ehu_unit_dir/does-not-exist.service"
+ehu_cleanup_rc=0
+(
+  export STUB_LOG="$ehu_log"
+  source "$SCRIPT_DIR/lib.sh"
+  cleanup_stale_heartbeat_units "$ehu_missing_svc" "$ehu_tmp/main-worktree" "$ehu_tmp/bin/systemctl"
+) || ehu_cleanup_rc=$?
+assert_eq "cleanup_stale_heartbeat_units: missing unit → returns 0" "0" "$ehu_cleanup_rc"
+TOTAL=$((TOTAL + 1))
+if ! grep -q 'disable' "$ehu_log"; then
+  PASS=$((PASS + 1)); echo "  PASS: cleanup_stale_heartbeat_units no-op when no prior units"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: cleanup_stale_heartbeat_units ran disable with no prior units"
+fi
+
 rm -rf "$ehu_tmp"
 
 # ============================================================================


### PR DESCRIPTION
Closes #2056

## Problem

`ensure_heartbeat_units` (`lib.sh`) embeds the current `$main_worktree` in the
installed `dispatch-heartbeat.service` (`ExecStart=` and
`WorkingDirectory=`). The unit-file *names* are fixed, so a later call from a new
checkout path overwrites the stale content — but only once
`ensure_heartbeat_units` is actually invoked from the new path.

The gap (a known follow-up from PR #2044's review): in the window between a path
change (moving the dispatch checkout, migrating machines) and the first call from
the new path, the timer's `Persistent=true` can fire `dispatch-heartbeat.service`
and run `dispatch-tick` at the **old, possibly-missing** path.

## Change

Add `cleanup_stale_heartbeat_units <service_path> <current_main_worktree>
<systemctl_cmd>`, modeled on the existing best-effort `cleanup_stale_hub`
precedent. It reads the installed `WorkingDirectory=` from the service unit and,
when it differs from the current main worktree, disables the stale
timer/service (`systemctl --user disable --now dispatch-heartbeat.timer
dispatch-heartbeat.service`) **before** the units are rewritten. It is
best-effort: a missing service file or matching path is a no-op, and the
`disable` (the heartbeat service has no `[Install]` section, so it exits non-zero
by design) never aborts the caller.

`ensure_heartbeat_units` calls the helper on the **slow path** — right after the
hot-path early-return and before `mkdir -p "$UNIT_DIR"`. The hot path is only
reached when the embedded path already matches, so a path change always falls
through to the slow path, guaranteeing the stale timer is stopped before the new
unit content lands.

Scope is **heartbeat-only**, covering abnormal migration scenarios. The sibling
helpers (`ensure_recover_unit`, `ensure_daemon_service`, `ensure_sweep_timer`)
share the same latent gap but are out of scope for this issue.

## Tests

Three direct unit cases in `test-dispatch-scripts.sh`, extending the existing
`ensure_heartbeat_units` block and reusing its recording `systemctl` stub:

- path differs → `disable --now` fires;
- path matches → no `disable`;
- no prior service unit → no-op, returns 0.

The full dispatch unit suite passes (3549/3549).
