### PR TITLE
budget: AccountsReconcile URL sync via @commons-systems/router navigate

### DIFF
--- a/budget/src/pages/AccountsReconcile.tsx
+++ b/budget/src/pages/AccountsReconcile.tsx
@@ -9,7 +9,8 @@
 // The imperative DOM mutations of the legacy hydrate become React state:
 //   - the URL query (institution/account/period) is React state, initialized
 //     from parseReconcileQuery(location.search) — the deep-link read — and written
-//     back with history.replaceState on a Select change. We do NOT dispatch
+//     back via the shared navigate(…, { replace: true }) abstraction on a Select
+//     change. We do NOT dispatch
 //     popstate: useRouter strips the query, so a query-only popstate is inert, and
 //     App re-keys only on a data transition. The component owns its query.
 //   - per-leg checked state is React state (the optimistic toggle); on a persist

--- a/budget/src/pages/AccountsReconcile.tsx
+++ b/budget/src/pages/AccountsReconcile.tsx
@@ -24,6 +24,7 @@
 // behaviorally identical and keeps one code path. The two legacy triggerReload()
 // sites map to: a Select change (query state change) and post-finalize (nonce bump).
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import { navigate } from "@commons-systems/router/react";
 import { Button, Card, Input, Metric, Select } from "@commons-systems/ds";
 import { classifyError } from "@commons-systems/errorutil/classify";
 import { deferProgrammerError } from "@commons-systems/errorutil/defer";
@@ -62,13 +63,13 @@ interface ReconcileQuery {
 }
 
 // Faithful port of accounts-reconcile-hydrate.ts replaceQueryParam: write/clear a
-// single query param via history.replaceState (NOT pushState — matches legacy and
-// avoids back-button query cycling).
+// single query param via the shared `navigate(…, { replace: true })` abstraction
+// (NOT pushState — matches legacy and avoids back-button query cycling).
 function replaceQueryParam(name: string, value: string | null): void {
   const url = new URL(location.href);
   if (value === null || value === "") url.searchParams.delete(name);
   else url.searchParams.set(name, value);
-  history.replaceState(null, "", url);
+  navigate(url.pathname + url.search + url.hash, { replace: true });
 }
 
 /**
@@ -764,8 +765,9 @@ export function AccountsReconcile({ options }: { options: RenderPageOptions }): 
 
   const load = useReconcileData(options, query, reloadNonce);
 
-  // Select change → write the URL (replaceState) AND update query state. No
-  // popstate dispatch (useRouter strips the query, so it is inert).
+  // Select change → write the URL via the shared `navigate(…, { replace: true })`
+  // abstraction AND update query state. No popstate dispatch (useRouter strips the
+  // query, so it is inert).
   const onSelectAccount = (value: string): void => {
     if (!value) {
       replaceQueryParam("institution", null);


### PR DESCRIPTION
Closes #2031

## What

Route the `/accounts/reconcile` page's URL query sync through the shared
`navigate(href, { replace: true })` primitive from `@commons-systems/router/react`
instead of calling `history.replaceState` inline.

`budget/src/pages/AccountsReconcile.tsx`'s file-local `replaceQueryParam` helper
poked `history.replaceState` directly to mirror institution/account/period
selector state into the query string. Every other React page in the budget app
routes navigation through a shared abstraction; this aligns the reconcile page
with that convention. Surfaced during review of PR #2018 (port of #1875).

## Change

- Import `navigate` from `@commons-systems/router/react` (already a budget
  dependency via `@commons-systems/router/hydrate`).
- In `replaceQueryParam`, the only changed line is the write: the helper still
  builds the next URL from `new URL(location.href)` and deletes-on-empty /
  sets-otherwise; the final `history.replaceState(null, "", url)` becomes
  `navigate(url.pathname + url.search + url.hash, { replace: true })`. Unrelated
  query params and the clear-on-empty semantics are preserved.
- Reword the two helper comments that named `replaceState`; keep the
  "NOT pushState / NOT a popstate dispatch" intent notes (still true — `navigate`
  with `replace` uses `replaceState` and fires no `popstate`).

## Why it preserves behavior

`navigate(href, { replace: true })` performs the same `replaceState` write. Its
extra step is a trailing `emit()` that notifies `useLocation()` subscribers — and
no budget-reachable component subscribes (the only `useLocation` consumers are the
router package's own tests), so `emit()` is an observable no-op for the budget
tree. Budget's own `useRouter` listens to `popstate`, which `navigate` does not
fire, so a query-only write stays inert to the page router exactly as before.

The query read path is untouched — initial state is still seeded from
`parseReconcileQuery(location.search)`.

## Verification

- `run-unit-tests.sh --app budget` — build (`tsc && vite build`, typechecks the
  new import) + 957 unit tests pass, including
  `AccountsReconcile.test.tsx` and the accounts-reconcile smoke test, which assert
  the observable `location.search` written on select changes.
- `run-lint.sh --app budget` — clean.
