### PR TITLE
blog: document the panelKey remount invariant on InfoPanelRegion

### DIFF
--- a/blog/src/components/InfoPanelRegion.tsx
+++ b/blog/src/components/InfoPanelRegion.tsx
@@ -136,6 +136,20 @@ function sortBlogrollByDate(panel: HTMLElement): void {
  *
  * PURE and fully prop-driven: no app state and no router hooks. Refs are used
  * solely for hydration mechanics (mount/cancel guards), never for shared state.
+ *
+ * panelKey REMOUNT INVARIANT (load-bearing): the blogroll effect below re-sorts
+ * the React-rendered <li> nodes imperatively (sortBlogrollByDate's appendChild),
+ * mutating DOM this component's React root owns. That is only safe because
+ * callers bump `panelKey` whenever the blogroll data (blogRoll / strategies)
+ * changes, mounting a FRESH React root that side-steps stale-child
+ * reconciliation. A same-key re-render with updated strategies instead skips
+ * root teardown and RECONCILES the existing tree, letting a later reconcile pass
+ * disagree with — and fight — the imperative reorder. `forceInfoPanelRefresh`
+ * (create-blog-app.ts) is the required mechanism: it bumps `panelKey` before
+ * re-rendering. Any call site that changes blogroll data via a bare same-key
+ * re-render, bypassing forceInfoPanelRefresh, is incorrect. The long-term fix
+ * that removes this invariant by driving order through React state is tracked in
+ * #2173.
  */
 export function InfoPanelRegion({
   data,


### PR DESCRIPTION
Closes #2094

## What

Documents the load-bearing `panelKey` remount invariant on `InfoPanelRegion`
(`blog/src/components/InfoPanelRegion.tsx`). This is the short-term mitigation
for the constraint surfaced by review of #2069: the blogroll effect re-sorts
the React-rendered `<li>` nodes imperatively (`sortBlogrollByDate`'s
`appendChild`), mutating DOM that this component's React root owns.

A new paragraph in the existing component JSDoc block now states both points
the invariant rests on:

1. Callers must bump `panelKey` whenever the blogroll data (`blogRoll` /
   `strategies`) changes, mounting a fresh React root that side-steps
   stale-child reconciliation. A bare same-key re-render with updated
   `strategies` instead reconciles the existing tree, letting a later reconcile
   pass disagree with — and fight — the imperative reorder.
2. `forceInfoPanelRefresh` (in `create-blog-app.ts`) is the required mechanism
   — it bumps `panelKey` before re-rendering — and any call site that changes
   blogroll data via a bare same-key re-render, bypassing
   `forceInfoPanelRefresh`, is incorrect.

The paragraph also points to the long-term fix (driving blogroll order through
React state so no imperative `appendChild` touches React-owned nodes), tracked
in follow-up #2173.

## Scope

Documentation only — no change to `sortBlogrollByDate`, the effect, or any
runtime behavior. The wording aligns with the existing partial docs on
`BlogAppHandle.forceInfoPanelRefresh` and the `panelKey` comment in
`create-blog-app.ts`.

## Verification

- `run-typecheck.sh` — passes (the `.tsx` still compiles).
- `run-unit-tests.sh` — 530 tests pass; builds for fellspiral and landing pass.
