### PR TITLE
lib.sh dispatch_marker_comment_id: propagate gh_retry pipeline failure instead of masking it as no-comment

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -171,7 +171,9 @@ gh_api_array() {
 # plan scripts), fetches comments via gh_retry, and applies the same
 # author-id-filtered first(...) selector. Returns non-zero with a stderr message
 # on an unresolvable author id (clear error, not a fallback). Echoes nothing
-# (empty) when no matching comment exists.
+# (empty) when no matching comment exists. A gh_retry or jq pipeline failure
+# returns non-zero (a clear error), distinct from the empty-output absent case —
+# mirroring gh_api_array's error propagation rather than silently swallowing it.
 dispatch_marker_comment_id() {
   local n="$1" marker="$2"
   local author_id="${DISPATCH_PLAN_AUTHOR_ID:-$(gh api user --jq '.id')}"
@@ -179,10 +181,13 @@ dispatch_marker_comment_id() {
     echo "dispatch_marker_comment_id: could not resolve a numeric comment author id (got: '$author_id')" >&2
     return 1
   fi
+  local raw
+  raw=$(gh_retry gh api --paginate "repos/{owner}/{repo}/issues/$n/comments") \
+    || return 1
   local cid
-  cid=$(gh_retry gh api --paginate "repos/{owner}/{repo}/issues/$n/comments" \
-    | jq -r --arg m "$marker" --argjson author_id "$author_id" \
-        'first(.[] | select((.body | startswith($m)) and (.user.id == $author_id)) | .id)')
+  cid=$(printf '%s\n' "$raw" | jq -r --arg m "$marker" --argjson author_id "$author_id" \
+      'first(.[] | select((.body | startswith($m)) and (.user.id == $author_id)) | .id)') \
+    || return 1
   if [[ -z "$cid" || "$cid" == "null" ]]; then
     return 0
   fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -36092,6 +36092,46 @@ else
   echo "  FAIL: dispatch_marker_comment_id returned 0 on gh_retry failure (output='$dmci_out1') — bug not fixed"
 fi
 
+# Criterion 2a: success/match-found path — gh_retry returns a single-element JSON
+# array whose entry's body starts with the marker and whose user.id equals
+# DISPATCH_PLAN_AUTHOR_ID. dispatch_marker_comment_id must return 0 and print the
+# comment id. This exercises the jq selector + final printf that all callers
+# depend on, which Criteria 1 and 3 never reach.
+dmci_rc2a=0
+dmci_out2a=$(
+  export DISPATCH_PLAN_AUTHOR_ID=12345
+  source "$SCRIPT_DIR/lib.sh"
+  gh_retry() { printf '[{"id":555,"body":"<!-- dispatch:phase-log --> log","user":{"id":12345}}]'; }
+  dispatch_marker_comment_id 7 '<!-- dispatch:phase-log -->'
+) || dmci_rc2a=$?
+TOTAL=$((TOTAL + 1))
+if [[ "$dmci_rc2a" -eq 0 && "$dmci_out2a" == "555" ]]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: dispatch_marker_comment_id returns 0 and prints the matching comment id"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: dispatch_marker_comment_id match case: rc=$dmci_rc2a, output='$dmci_out2a' (expected rc=0, output='555')"
+fi
+
+# Criterion 2b: jq pipeline failure propagates as non-zero. gh_retry returns 0 but
+# emits invalid JSON, so the jq cid= assignment fails and the `|| return 1` guard
+# must propagate non-zero. Guards against a future edit dropping that `|| return 1`.
+dmci_rc2b=0
+dmci_out2b=$(
+  export DISPATCH_PLAN_AUTHOR_ID=12345
+  source "$SCRIPT_DIR/lib.sh"
+  gh_retry() { printf 'not json'; }
+  dispatch_marker_comment_id 7 '<!-- dispatch:phase-log -->' 2>/dev/null
+) || dmci_rc2b=$?
+TOTAL=$((TOTAL + 1))
+if [[ "$dmci_rc2b" -ne 0 ]]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: dispatch_marker_comment_id returns non-zero when jq fails on invalid JSON"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: dispatch_marker_comment_id returned 0 on jq failure (output='$dmci_out2b') — jq || return 1 guard missing"
+fi
+
 # Criterion 3: genuine absent case (valid JSON, no match) returns 0 with empty output.
 dmci_rc3=0
 dmci_out3=$(

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -36008,6 +36008,50 @@ assert_eq "preflight-abort fanout: terminal token (zero spawns → drain)" "drai
 mat_teardown
 
 # ============================================================================
+# dispatch_marker_comment_id: error propagation (#2138)
+# ============================================================================
+echo ""
+echo "=== dispatch_marker_comment_id: error propagation (#2138) ==="
+
+# Criterion 1: gh_retry failure propagates as non-zero (bug regression).
+# The old single-pipeline code returned 0 on gh_retry failure; the fix must not.
+# The gh_retry override and DISPATCH_PLAN_AUTHOR_ID are scoped to a subshell so
+# they do not leak. lib.sh defines gh_retry, so the override must come AFTER the
+# source. The exit status is captured in the parent scope where the counters live.
+dmci_rc1=0
+dmci_out1=$(
+  export DISPATCH_PLAN_AUTHOR_ID=12345
+  source "$SCRIPT_DIR/lib.sh"
+  gh_retry() { return 1; }
+  dispatch_marker_comment_id 7 '<!-- dispatch:phase-log -->' 2>/dev/null
+) || dmci_rc1=$?
+TOTAL=$((TOTAL + 1))
+if [[ "$dmci_rc1" -ne 0 ]]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: dispatch_marker_comment_id returns non-zero when gh_retry fails"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: dispatch_marker_comment_id returned 0 on gh_retry failure (output='$dmci_out1') — bug not fixed"
+fi
+
+# Criterion 3: genuine absent case (valid JSON, no match) returns 0 with empty output.
+dmci_rc3=0
+dmci_out3=$(
+  export DISPATCH_PLAN_AUTHOR_ID=12345
+  source "$SCRIPT_DIR/lib.sh"
+  gh_retry() { printf '[]'; }
+  dispatch_marker_comment_id 7 '<!-- dispatch:phase-log -->'
+) || dmci_rc3=$?
+TOTAL=$((TOTAL + 1))
+if [[ "$dmci_rc3" -eq 0 && -z "$dmci_out3" ]]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: dispatch_marker_comment_id returns 0 with empty output when no comment matches"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: dispatch_marker_comment_id absent case: rc=$dmci_rc3, output='$dmci_out3' (expected rc=0, empty output)"
+fi
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results


### PR DESCRIPTION
Closes #2138

## Problem

Inside `dispatch_marker_comment_id` (`lib.sh`), the comment id was captured from
a single `gh_retry … | jq` pipeline. The pipeline's exit status reflects only
the last command (`jq`), which — on a `gh_retry` failure — reads the now-empty
input, emits nothing, and exits `0`. So a hard `gh` API failure was silently
swallowed: `cid` was left empty and the `[[ -z "$cid" || "$cid" == "null" ]]`
guard returned `0`, handing the caller an empty string **indistinguishable from
"no matching comment exists."**

The first affected caller, `build_phase_log_section` in `dispatch-context-pack`,
would then emit the `phase-log: none` sentinel on a real API failure — a hard
error masked as a clean degrade, contradicting `code-style.md` ("prefer clear
errors over defensive fallbacks") and inconsistent with the body-fetch on the
very next line (which already does `gh_retry … || return 1`).

## Fix

Split the single pipeline into the two-step, error-propagating form the sibling
`gh_api_array` already uses: capture `gh_retry`'s output with `|| return 1`,
then run `jq` on that captured output with `|| return 1`. A `gh_retry`/`jq`
failure now surfaces as a **non-zero return**, while the genuine absent case
still returns `0` with empty output.

No caller change is needed — callers are already wired for this
(`cid=$(dispatch_marker_comment_id …) || return 1`), so this converts a masked
failure into the clear, pack-aborting error the caller is already prepared to
propagate.

## Changes

- `lib.sh`: two-step error-propagating capture in `dispatch_marker_comment_id`;
  header comment records the new contract.
- `test-dispatch-scripts.sh`: hermetic regression test covering both criteria —
  a `gh_retry` failure returns non-zero (the bug), and the genuine absent case
  (valid JSON, no match) still returns `0` with empty output.

## Verification

- Hermetic contract check (the plan's ```verify block) passes.
- Full suite `test-dispatch-scripts.sh`: 3550/3550 passed, 0 failed.
