### PR TITLE
Decouple local-folder first-paint from cold-folder metadata extraction

### DIFF
--- a/print/src/local-folder-ui.ts
+++ b/print/src/local-folder-ui.ts
@@ -166,10 +166,31 @@ function renderLocalMediaItems(items: MediaItem[]): string {
 }
 
 /**
- * Render the current local items into the shared media list, idempotently:
- * find (or create) the `#media-list` <ul>, strip prior local rows, and prepend
- * freshly-rendered ones before the cloud rows. No-ops when no media list or
- * empty-state placeholder is present (e.g. viewer page).
+ * The detached enrichment task in flight (or `Promise.resolve()` when none).
+ * Reassigned on every `renderLocalIntoList` pass so `settleEnrichment` always
+ * awaits the most recent pass's enrichment. The twin of sidecar's `flushWrites`.
+ */
+let pendingEnrichment: Promise<void> = Promise.resolve();
+
+/**
+ * Settle seam: resolves when the in-flight detached enrichment of the latest
+ * render pass has finished (every row patched and the batched cache write
+ * enqueued). Tests await this before `flushWrites` to observe the cache write;
+ * `bindAndRender` does NOT await it — first paint is already done.
+ */
+export function settleEnrichment(): Promise<void> {
+  return pendingEnrichment;
+}
+
+/**
+ * Render the current local items into the shared media list, resolving at FIRST
+ * PAINT: find (or create) the `#media-list` <ul>, do a single bounded sidecar
+ * read, partition items into cached (overlaid with real metadata, zero file IO)
+ * vs uncached (filename-stem rows), strip prior local rows, and insert all rows
+ * immediately. Cold-folder metadata extraction for the uncached items runs
+ * DETACHED after this resolves — a hung extract never blocks first paint or the
+ * focus listener. No-ops when no media list or empty-state placeholder is
+ * present (e.g. viewer page).
  */
 export async function renderLocalIntoList(container: HTMLElement): Promise<void> {
   const items = await listLocal();
@@ -182,53 +203,70 @@ export async function renderLocalIntoList(container: HTMLElement): Promise<void>
     ul.id = "media-list";
     empty.replaceWith(ul);
   }
-  // Enrich AFTER the early-return guard: a focus event on a list-less route
-  // (e.g. the viewer) must not read bytes or write the sidecar.
-  const enriched = await enrichLocalItems(items);
+  // Single bounded sidecar read AFTER the early-return guard: a focus event on a
+  // list-less route (e.g. the viewer) must not read the sidecar.
+  await ensureLoaded();
+
+  // Partition before insert. getMetadata is an in-memory lookup (zero file IO)
+  // after ensureLoaded: a present entry overlays full title + pageCount now;
+  // undefined keeps the filename-stem item and is queued for detached enrichment.
+  const rows: MediaItem[] = [];
+  const uncached: MediaItem[] = [];
+  for (const item of items) {
+    const cached = await getMetadata(item.storagePath);
+    if (cached !== undefined) {
+      rows.push(overlay(item, cached));
+    } else {
+      rows.push(item);
+      uncached.push(item);
+    }
+  }
+
   for (const li of Array.from(ul.querySelectorAll(".media-item-local"))) {
     li.remove();
   }
-  ul.insertAdjacentHTML("afterbegin", renderLocalMediaItems(enriched));
+  ul.insertAdjacentHTML("afterbegin", renderLocalMediaItems(rows));
+  // First paint is now done.
+
+  // Capture each uncached row's node by id, BY REFERENCE. item.id is
+  // `local:<folderId>/<name>` (contains `:` and `/`) so the data-id selector
+  // needs CSS.escape, not escapeHtml. Patching the captured node (never a
+  // re-query at patch time) keeps a stale patch from a prior pass a harmless
+  // no-op against a now-detached node.
+  const targets: { item: MediaItem; node: Element | null }[] = uncached.map(
+    (item) => ({
+      item,
+      node: ul.querySelector(`[data-id="${CSS.escape(item.id)}"]`),
+    }),
+  );
+
+  // Kick off detached enrichment for the uncached items only — not awaited.
+  // Reassigned each pass so settleEnrichment tracks the latest render.
+  pendingEnrichment = runEnrichment(targets).catch((err) =>
+    logError(err, { operation: "local-folder-enrich" }),
+  );
 }
 
 /**
- * Overlay real metadata (title + pageCount) onto each local `MediaItem`,
- * cache-first. Keys the sidecar on `item.storagePath` (the BARE FILENAME, never
- * the `local:<folderId>/<name>` id). Items with a cached entry are overlaid with
- * zero IO and zero writes; items with NO entry (`getMetadata` returns undefined)
- * are read via `resolveLocalBlob`, extracted, and accumulated for a single
- * batched cache write.
+ * Enrich the uncached items, patching each row in place as its extract resolves.
+ * Reads each file's bytes via `resolveLocalBlob`, extracts metadata (tolerant —
+ * `{}` on error), and patches the captured node. Run with `Promise.all` so a
+ * hung item never blocks another's patch. After all settle, persist every
+ * newly-extracted entry in ONE batched cache write — an empty batch is a no-op,
+ * preserving focus-rescan write suppression.
  *
- * Single batched write: each newly-extracted entry is collected and persisted in
- * ONE `cacheMetadataBatch` call after `Promise.all` resolves, rather than N
- * sequential full-file index.json rewrites (one per new file). At N new files
- * this is 1 disk write instead of N.
- *
- * Write suppression on focus-rescan: an entry is accumulated only for items whose
- * cache entry was `undefined` and whose bytes extracted successfully (even an
- * empty extract contributes a present `{}` entry, which is defined). A focus
- * event with no new files therefore finds every item already cached, so the
- * batch is empty and `cacheMetadataBatch` writes nothing.
+ * Null-blob retry: a file that can't be read yields no patch and no cache entry,
+ * so it re-extracts on the next focus pass rather than being permanently
+ * suppressed by a cached `{}`.
  */
-async function enrichLocalItems(items: MediaItem[]): Promise<MediaItem[]> {
-  await ensureLoaded();
-  const results = await Promise.all(items.map((item) => enrichLocalItem(item)));
+async function runEnrichment(
+  targets: { item: MediaItem; node: Element | null }[],
+): Promise<void> {
+  const results = await Promise.all(targets.map((t) => enrichLocalItem(t)));
   const newEntries = Object.fromEntries(
-    results
-      .filter((r) => r.entry !== null)
-      .map((r) => r.entry as [string, { title?: string; pageCount?: number }]),
+    results.filter((r): r is [string, { title?: string; pageCount?: number }] => r !== null),
   );
   await cacheMetadataBatch(newEntries);
-  return results.map((r) => r.item);
-}
-
-/** Result of enriching one item: the overlaid item plus an optional new cache
- * entry (`[storagePath, meta]`) to be persisted in the render pass's batched
- * write. `entry` is null when nothing new was extracted (cached hit, unreadable
- * file, or extract error) so it contributes nothing to the batch. */
-interface EnrichResult {
-  item: MediaItem;
-  entry: [string, { title?: string; pageCount?: number }] | null;
 }
 
 function overlay(
@@ -244,24 +282,55 @@ function overlay(
   };
 }
 
-async function enrichLocalItem(item: MediaItem): Promise<EnrichResult> {
-  const cached = await getMetadata(item.storagePath);
-  // Present entry (even `{}`) means already extracted — overlay, no new entry.
-  if (cached !== undefined) return { item: overlay(item, cached), entry: null };
+/**
+ * Patch a captured local row in place with extracted metadata, building DOM via
+ * textContent so no manual escaping is needed. A null node (row detached by a
+ * later focus-rescan reinsert) is a harmless no-op.
+ */
+function patchLocalRow(
+  node: Element | null,
+  meta: { title?: string; pageCount?: number },
+): void {
+  if (node === null) return;
+  if (meta.title !== undefined) {
+    const titleLink = node.querySelector(".media-title a");
+    if (titleLink) titleLink.textContent = meta.title;
+  }
+  if (meta.pageCount !== undefined && !node.querySelector(".media-pagecount")) {
+    const info = node.querySelector(".media-info");
+    if (info) {
+      const span = document.createElement("span");
+      span.className = "media-pagecount";
+      span.textContent = `${meta.pageCount} pages`;
+      info.appendChild(span);
+    }
+  }
+}
 
-  // No entry yet: read bytes and extract, tolerating a bad file.
+/**
+ * Extract one uncached item's metadata and patch its captured row. Returns the
+ * `[storagePath, meta]` cache entry to contribute to the batched write, or null
+ * when nothing new was extracted (unreadable file or extract error) so it
+ * contributes nothing — and, for an unreadable file, is not cached, leaving the
+ * null-retry path open.
+ */
+async function enrichLocalItem(
+  target: { item: MediaItem; node: Element | null },
+): Promise<[string, { title?: string; pageCount?: number }] | null> {
+  const { item, node } = target;
   try {
     const buf = await resolveLocalBlob(item);
     if (buf === null) {
       // Could not read this file — do NOT cache `{}` (that would permanently
-      // suppress retry). Fall back to the existing item; a later focus retries.
-      return { item, entry: null };
+      // suppress retry). A later focus retries.
+      return null;
     }
     const meta = await extractMetadata(buf, item.mediaType);
+    patchLocalRow(node, meta);
     // Contribute this entry to the render pass's single batched write.
-    return { item: overlay(item, meta), entry: [item.storagePath, meta] };
+    return [item.storagePath, meta];
   } catch (err) {
     logError(err, { operation: "local-folder-enrich", id: item.id });
-    return { item, entry: null };
+    return null;
   }
 }

--- a/print/src/local-folder-ui.ts
+++ b/print/src/local-folder-ui.ts
@@ -231,8 +231,9 @@ export async function renderLocalIntoList(container: HTMLElement): Promise<void>
   // Capture each uncached row's node by id, BY REFERENCE. item.id is
   // `local:<folderId>/<name>` (contains `:` and `/`) so the data-id selector
   // needs CSS.escape, not escapeHtml. Patching the captured node (never a
-  // re-query at patch time) keeps a stale patch from a prior pass a harmless
-  // no-op against a now-detached node.
+  // re-query at patch time) means that patching a now-detached node (removed by
+  // a later render pass) succeeds silently but has no visible effect — the
+  // mutation reaches a node no longer in the document, not a live row.
   const targets: { item: MediaItem; node: Element | null }[] = uncached.map(
     (item) => ({
       item,
@@ -284,14 +285,14 @@ function overlay(
 
 /**
  * Patch a captured local row in place with extracted metadata, building DOM via
- * textContent so no manual escaping is needed. A null node (row detached by a
- * later focus-rescan reinsert) is a harmless no-op.
+ * textContent so no manual escaping is needed. A null or detached node is a
+ * no-op.
  */
 function patchLocalRow(
   node: Element | null,
   meta: { title?: string; pageCount?: number },
 ): void {
-  if (node === null) return;
+  if (node === null || !node.isConnected) return;
   if (meta.title !== undefined) {
     const titleLink = node.querySelector(".media-title a");
     if (titleLink) titleLink.textContent = meta.title;

--- a/print/test/enrichment.test.ts
+++ b/print/test/enrichment.test.ts
@@ -71,7 +71,7 @@ vi.mock("@commons-systems/errorutil/log", () => ({
 // ---------------------------------------------------------------------------
 // Import real modules AFTER mocks are declared
 // ---------------------------------------------------------------------------
-import { renderLocalIntoList } from "../src/local-folder-ui.js";
+import { renderLocalIntoList, settleEnrichment } from "../src/local-folder-ui.js";
 import {
   setLocalDirectory,
   flushWrites,
@@ -252,6 +252,7 @@ describe("enrichment — uncached item (extracts and caches)", () => {
 
     const container = makeContainer();
     await renderLocalIntoList(container);
+    await settleEnrichment();
     await flushWrites();
 
     expect(mockResolveLocalBlob).toHaveBeenCalledWith(item);
@@ -277,6 +278,7 @@ describe("enrichment — uncached item (extracts and caches)", () => {
 
     const container = makeContainer();
     await renderLocalIntoList(container);
+    await settleEnrichment();
     await flushWrites();
 
     const readBack = await readSidecar(dir);
@@ -332,11 +334,13 @@ describe("enrichment — write suppression on focus-rescan", () => {
     const container = makeContainer();
     // First render: extracts and caches {}
     await renderLocalIntoList(container);
+    await settleEnrichment();
     await flushWrites();
     expect(mockExtractMetadata).toHaveBeenCalledTimes(1);
 
     // Second render (simulates focus rescan): {} is a defined entry → no re-extract
     await renderLocalIntoList(container);
+    await settleEnrichment();
     await flushWrites();
     expect(mockExtractMetadata).toHaveBeenCalledTimes(1); // still only once
   });

--- a/print/test/enrichment.test.ts
+++ b/print/test/enrichment.test.ts
@@ -361,6 +361,7 @@ describe("enrichment — resolveLocalBlob returns null (file gone)", () => {
 
     const container = makeContainer();
     await renderLocalIntoList(container);
+    await settleEnrichment();
     await flushWrites();
 
     // extractMetadata should NOT be called (no buf)

--- a/print/test/enrichment.test.ts
+++ b/print/test/enrichment.test.ts
@@ -6,7 +6,7 @@
  * We use a fake FileSystemDirectoryHandle (same infrastructure as sidecar.test.ts)
  * to avoid any real FSA I/O.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Mock firebase-touching transitive deps (must come before importing source)
@@ -197,6 +197,7 @@ function makeContainer(): HTMLElement {
   const ul = document.createElement("ul");
   ul.id = "media-list";
   container.appendChild(ul);
+  document.body.appendChild(container);
   return container;
 }
 
@@ -207,6 +208,9 @@ function makeContainer(): HTMLElement {
 describe("enrichment — cached item (zero IO, no write)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
   });
 
   it("applies cached metadata without calling extractMetadata or resolveLocalBlob", async () => {
@@ -238,6 +242,9 @@ describe("enrichment — cached item (zero IO, no write)", () => {
 describe("enrichment — uncached item (extracts and caches)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
   });
 
   it("calls resolveLocalBlob and extractMetadata for uncached items", async () => {
@@ -289,6 +296,9 @@ describe("enrichment — uncached item (extracts and caches)", () => {
 describe("enrichment — write suppression on focus-rescan", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
   });
 
   it("does NOT write to sidecar when all items are already cached (rescan case)", async () => {
@@ -350,6 +360,9 @@ describe("enrichment — resolveLocalBlob returns null (file gone)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
   it("does not cache {} when resolveLocalBlob returns null (so next render retries)", async () => {
     const item = makeLocalItem({ storagePath: "gone.pdf" });
@@ -376,6 +389,9 @@ describe("enrichment — resolveLocalBlob returns null (file gone)", () => {
 describe("enrichment — early return when no media list present", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
   });
 
   it("no-ops when container has neither #media-list nor #media-empty", async () => {


### PR DESCRIPTION
Closes #1735

## Problem

`renderLocalIntoList` (`print/src/local-folder-ui.ts`) awaited
`enrichLocalItems(items)` — a `Promise.all` that read every file's bytes and
extracted PDF/EPUB metadata — *before* inserting any `<li>` row. So:

- A cold folder (no sidecar cache) showed nothing until all N files were read
  and extracted.
- A single hung/corrupt file's `extractPdf` promise blocked the whole list **and**
  the `focus` rescan listener, because `bindAndRender` installs that listener only
  after `await renderLocalIntoList(...)` resolves.

## Change

Decouple first paint from IO:

1. After the single bounded `ensureLoaded()` sidecar read, partition items by the
   in-memory, zero-IO `getMetadata(storagePath)` lookup: cached items are
   `overlay`-ed (full title + page count), uncached items keep their filename-stem
   title.
2. Insert **all** rows immediately via the unchanged `renderLocalMediaItems` —
   this is first paint.
3. Capture each uncached row's node (`CSS.escape(item.id)` — ids contain `:`/`/`),
   then kick off **detached** enrichment stored on a module-level
   `pendingEnrichment`; `renderLocalIntoList` returns at first paint.
4. The detached task `Promise.all`s the uncached items, patching each row in place
   (`patchLocalRow`) as its own extract resolves, then does the single batched
   `cacheMetadataBatch`. A hung extract no longer blocks another row's patch, first
   paint, or the focus listener.

A new exported `settleEnrichment(): Promise<void>` (twin of sidecar's
`flushWrites`) drains the detached task for tests. `bindAndRender` does not await
it — it installs the focus listener immediately after first paint.

## Tests

`print/test/enrichment.test.ts`: the three uncached-path tests now `await
settleEnrichment()` before `flushWrites()`; every `expect(...)` is byte-for-byte
identical. The cached-item, all-cached write-suppression, null-blob, and
early-return tests pass unchanged. `decideFolderUiState` (pure) is untouched.
