### PR TITLE
dispatch-write-phase-log: test leading-zero and non-numeric issue-num rejection

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-write-phase-log.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-write-phase-log.sh
@@ -342,6 +342,34 @@ assert_eq "issue-num 0: exit code is 2" "2" "$ZERO_RC"
 assert_contains "issue-num 0: stderr mentions positive integer" "positive integer" "$ZERO_STDERR"
 
 # ============================================================================
+# issue-num 00 (leading zero) -> exit 2, stderr mentions 'positive integer' (#2183)
+# ============================================================================
+
+echo ""
+echo "issue-num 00: exit 2, stderr mentions positive integer"
+
+set +e
+LZ_STDERR=$(printf 'body\n' | "$SUT" 00 --phase plan 2>&1)
+LZ_RC=$?
+set -e
+assert_eq "issue-num 00: exit code is 2" "2" "$LZ_RC"
+assert_contains "issue-num 00: stderr mentions positive integer" "positive integer" "$LZ_STDERR"
+
+# ============================================================================
+# issue-num abc (non-numeric) -> exit 2, stderr mentions 'positive integer' (#2183)
+# ============================================================================
+
+echo ""
+echo "issue-num abc: exit 2, stderr mentions positive integer"
+
+set +e
+NN_STDERR=$(printf 'body\n' | "$SUT" abc --phase plan 2>&1)
+NN_RC=$?
+set -e
+assert_eq "issue-num abc: exit code is 2" "2" "$NN_RC"
+assert_contains "issue-num abc: stderr mentions positive integer" "positive integer" "$NN_STDERR"
+
+# ============================================================================
 # AC3: valid invocation → exit 0, gh stub records a POST to issues/2132/comments
 # ============================================================================
 


### PR DESCRIPTION
Closes #2183

## What

Adds two regression test cases to `test-write-phase-log.sh` pinning that
`dispatch-write-phase-log` rejects malformed `issue-num` inputs:

- **`00`** (leading zero) → exit 2, stderr mentions "positive integer"
- **`abc`** (non-numeric) → exit 2, stderr mentions "positive integer"

## Why

PR #2170 tightened `issue-num` validation to `^[1-9][0-9]*$`, which rejects `0`,
leading-zero, and non-numeric inputs before any git/gh call. A test covered the
`0` case, but the leading-zero and non-numeric cases the same regex rejects were
untested. These tests close that coverage gap so a future loosening of the regex
fails CI.

## How

Each new block mirrors the existing `issue-num 0` block exactly: capture
`stderr`/`rc` from a piped invocation, then assert exit code `2` and a
"positive integer" message. Distinct variable names (`LZ_*`, `NN_*`) avoid
collision with the existing `ZERO_*` vars. Validation precedes any git/gh call,
so no stub or temp-repo setup is needed.

The suite now reports `17/17 passed, 0 failed`.
