### PR TITLE
blog: drive blogroll ordering via React state (remove imperative appendChild)

### DIFF
--- a/blog/src/blog-roll/sort-by-date.ts
+++ b/blog/src/blog-roll/sort-by-date.ts
@@ -1,0 +1,23 @@
+import type { BlogRollEntry, LatestPost } from "./types";
+
+export interface BlogRollItem {
+  entry: BlogRollEntry;
+  post: LatestPost | null;
+}
+
+/**
+ * Sorts blog roll items newest-first by publishedAt, mirroring the
+ * sortBlogrollByDate comparator in InfoPanelRegion. Items with a missing
+ * publishedAt (post is null, or publishedAt is absent/empty) sort last.
+ * Returns a new array; does not mutate the input.
+ */
+export function sortBlogrollByPublishedDesc(items: BlogRollItem[]): BlogRollItem[] {
+  return [...items].sort((a, b) => {
+    const dateA = a.post?.publishedAt || "";
+    const dateB = b.post?.publishedAt || "";
+    if (!dateA && !dateB) return 0;
+    if (!dateA) return 1;
+    if (!dateB) return -1;
+    return new Date(dateB).getTime() - new Date(dateA).getTime();
+  });
+}

--- a/blog/src/components/InfoPanelRegion.tsx
+++ b/blog/src/components/InfoPanelRegion.tsx
@@ -7,7 +7,10 @@ import type {
   BlogRollStrategy,
   LatestPost,
 } from "../blog-roll/types.ts";
-import { sortBlogrollByPublishedDesc } from "../blog-roll/sort-by-date.ts";
+import {
+  sortBlogrollByPublishedDesc,
+  type BlogRollItem,
+} from "../blog-roll/sort-by-date.ts";
 import type { InfoPanelData } from "./info-panel.ts";
 import { InfoPanel } from "./InfoPanel.tsx";
 
@@ -43,11 +46,6 @@ export interface InfoPanelRegionProps {
   aboutContent?: string;
 }
 
-interface FetchResult {
-  entry: BlogRollEntry;
-  post: LatestPost | null;
-}
-
 /**
  * Reproduces info-panel.ts's fetchAllLatestPosts: one fetch per entry, resolving
  * to { entry, post } and degrading to a null post (with a logged error) when the
@@ -56,7 +54,7 @@ interface FetchResult {
 function fetchAllLatestPosts(
   blogRoll: BlogRollEntry[],
   strategies: Map<string, BlogRollStrategy>,
-): Promise<FetchResult>[] {
+): Promise<BlogRollItem>[] {
   return blogRoll.map((entry) => {
     const strategy = strategies.get(entry.id);
     if (!strategy) {
@@ -109,7 +107,7 @@ export function InfoPanelRegion({
 
   // Ordered, enriched blogroll. Lazy initializer is a pure function of `data`, so
   // server and client first renders produce identical (date-sorted) markup.
-  const [items, setItems] = useState<FetchResult[]>(() =>
+  const [items, setItems] = useState<BlogRollItem[]>(() =>
     sortBlogrollByPublishedDesc(
       blogRoll.map((entry) => ({
         entry,
@@ -172,7 +170,10 @@ export function InfoPanelRegion({
   // topPosts). Only blogRoll order and the feed map come from state.
   const feedsFromState: Record<string, LatestPost | null> = {};
   for (const { entry, post } of items) {
-    feedsFromState[entry.id] = post;
+    // Degradation fallback: a null post (unavailable feed / failed fetch) keeps the
+    // build-time content rather than blanking the entry — preserving the "user sees
+    // build-time content" behavior the hydration effect's catch claims.
+    feedsFromState[entry.id] = post ?? data.buildTimeFeeds?.[entry.id] ?? null;
   }
   const derivedData: InfoPanelData = {
     ...data,

--- a/blog/src/components/InfoPanelRegion.tsx
+++ b/blog/src/components/InfoPanelRegion.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { deferProgrammerError } from "@commons-systems/errorutil/defer";
 import { logError } from "@commons-systems/errorutil/log";
 import { initScrollIndicator } from "@commons-systems/components/scroll-indicator";
-import { formatUtcDate } from "../date.ts";
 import type {
   BlogRollEntry,
   BlogRollStrategy,
   LatestPost,
 } from "../blog-roll/types.ts";
+import { sortBlogrollByPublishedDesc } from "../blog-roll/sort-by-date.ts";
 import type { InfoPanelData } from "./info-panel.ts";
 import { InfoPanel } from "./InfoPanel.tsx";
 
@@ -78,64 +78,25 @@ function fetchAllLatestPosts(
   });
 }
 
-/** Reproduces info-panel.ts's updateBlogrollEntry against the InfoPanel DOM. */
-function updateBlogrollEntry(panel: HTMLElement, entry: BlogRollEntry, post: LatestPost): void {
-  const entryLink = panel.querySelector(`#blogroll-entry-${CSS.escape(entry.id)}`);
-  const placeholder = panel.querySelector(`#blogroll-latest-${CSS.escape(entry.id)}`);
-  const dateSpan = panel.querySelector(`#blogroll-date-${CSS.escape(entry.id)}`);
-  if (!entryLink || !placeholder) {
-    logError(new Error(`Blogroll DOM element missing for entry "${entry.id}"`), {
-      operation: "update-blogroll-entry",
-    });
-    return;
-  }
-
-  placeholder.textContent = post.title;
-  entryLink.setAttribute("href", post.url);
-  if (dateSpan && post.publishedAt) {
-    dateSpan.textContent = formatUtcDate(post.publishedAt, "short");
-    dateSpan.setAttribute("data-iso", post.publishedAt);
-  }
-}
-
-/** Reproduces info-panel.ts's sortBlogrollByDate: re-sort entries by date desc. */
-function sortBlogrollByDate(panel: HTMLElement): void {
-  const firstItem = panel.querySelector("li[data-blogroll-id]");
-  const blogrollList = firstItem?.parentElement;
-  if (!blogrollList) return;
-
-  const items = [...blogrollList.querySelectorAll("li[data-blogroll-id]")];
-  items.sort((a, b) => {
-    const dateA = a.querySelector(".blogroll-date")?.getAttribute("data-iso") || "";
-    const dateB = b.querySelector(".blogroll-date")?.getAttribute("data-iso") || "";
-    if (!dateA && !dateB) return 0;
-    if (!dateA) return 1;
-    if (!dateB) return -1;
-    return new Date(dateB).getTime() - new Date(dateA).getTime();
-  });
-
-  for (const item of items) {
-    blogrollList.appendChild(item);
-  }
-}
-
 /**
- * The info-panel sidebar body, owning the same DOM the legacy imperative
- * renderInfoPanel + hydrateInfoPanel pair produced. The JSX delegates verbatim to
- * the frozen presentational <InfoPanel> so the server (react-dom/server) and
- * client (hydrateRoot) initial markup are byte-identical; the effect then
- * reproduces hydrateInfoPanel's per-entry latest-post fetch and re-sort, mutating
- * the DOM imperatively against the same ids/classes/attrs InfoPanel emits.
+ * The info-panel sidebar body. Order and content of the blogroll are driven by
+ * React state (an ordered, enriched `{ entry, post }` list), so React owns the
+ * DOM: the JSX delegates to the frozen presentational <InfoPanel>, and a sort is
+ * a pure function of state rather than an imperative reorder of React-owned nodes.
  *
- * The host <aside id="info-panel" class="sidebar"> is the scroll container (the
- * element Unit 3's hydrateRoot mounts into and the legacy driver passed to
- * hydrateInfoPanel / initScrollIndicator). InfoPanel renders only its children
- * (matching renderInfoPanel's output), so the effects reach the host via
- * `document.getElementById("info-panel")` — the parity-correct root, since the
- * delegated fragment exposes no single ref-able element.
+ * The initial state is computed by a LAZY useState initializer that is a pure
+ * function of `data` — map `data.blogRoll` to `{ entry, post: buildTimeFeeds[id] }`
+ * and sort by published date. That initializer runs during render on BOTH the
+ * server (react-dom/server renderToString) and the client first render, with no
+ * effect involved, so the SSR'd markup is already build-time-date-sorted and is
+ * byte-identical to the client's first render — the hydration-parity contract.
  *
- * PURE and fully prop-driven: no app state and no router hooks. Refs are used
- * solely for hydration mechanics (mount/cancel guards), never for shared state.
+ * The fetch effect then re-fetches each entry's latest post, re-sorts, and calls
+ * setState; InfoPanel keys each <li> by id, so the reorder reconciles via stable
+ * keys and emits the same ids/classes/attrs. Skipped on the About panel.
+ *
+ * PURE and fully prop-driven aside from the blogroll state. Refs are used solely
+ * for hydration mechanics (mount/cancel guards), never for shared state.
  */
 export function InfoPanelRegion({
   data,
@@ -146,8 +107,20 @@ export function InfoPanelRegion({
   const mountedRef = useRef(true);
   const blogRoll = data.blogRoll;
 
-  // Blog-roll hydration: fetch each entry's latest post, write it into the
-  // delegated DOM, then re-sort by date. Skipped on the About panel (no blogroll).
+  // Ordered, enriched blogroll. Lazy initializer is a pure function of `data`, so
+  // server and client first renders produce identical (date-sorted) markup.
+  const [items, setItems] = useState<FetchResult[]>(() =>
+    sortBlogrollByPublishedDesc(
+      blogRoll.map((entry) => ({
+        entry,
+        post: data.buildTimeFeeds?.[entry.id] ?? null,
+      })),
+    ),
+  );
+
+  // Blog-roll hydration: fetch each entry's latest post, sort by date, and drive
+  // the result through state (React reconciles the DOM). Skipped on the About
+  // panel (no blogroll).
   useEffect(() => {
     if (aboutContent !== undefined) return;
 
@@ -158,16 +131,10 @@ export function InfoPanelRegion({
     let cancelled = false;
     const isCurrent = () => mountedRef.current && !cancelled;
 
-    const panel = document.getElementById("info-panel");
-    if (!panel) return; // host not present (e.g. About panel) — no error
-
     Promise.all(fetchAllLatestPosts(blogRoll, strategies))
       .then((results) => {
         if (!isCurrent()) return;
-        for (const { entry, post } of results) {
-          if (post) updateBlogrollEntry(panel, entry, post);
-        }
-        sortBlogrollByDate(panel);
+        setItems(sortBlogrollByPublishedDesc(results));
       })
       // Intentional silent degradation — user sees build-time content, not an error.
       .catch((err) => {
@@ -198,5 +165,20 @@ export function InfoPanelRegion({
     return <div dangerouslySetInnerHTML={{ __html: aboutContent }} />;
   }
 
-  return <InfoPanel data={data} />;
+  // Derive the panel data from state: order from the sorted entries, content from
+  // a buildTimeFeeds map merged with the state's posts. Spread `data` so the live
+  // passthrough fields (linkSections, topPosts, rssFeedUrl, opmlUrl, …) still flow
+  // through on a re-render that keeps the same panelKey (e.g. sign-in bumping
+  // topPosts). Only blogRoll order and the feed map come from state.
+  const feedsFromState: Record<string, LatestPost | null> = {};
+  for (const { entry, post } of items) {
+    feedsFromState[entry.id] = post;
+  }
+  const derivedData: InfoPanelData = {
+    ...data,
+    blogRoll: items.map(({ entry }) => entry),
+    buildTimeFeeds: feedsFromState,
+  };
+
+  return <InfoPanel data={derivedData} />;
 }

--- a/blog/test/blog-roll/sort-by-date.test.ts
+++ b/blog/test/blog-roll/sort-by-date.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { sortBlogrollByPublishedDesc, type BlogRollItem } from "../../src/blog-roll/sort-by-date";
+
+const entry = (id: string) => ({ id, name: id, url: `https://${id}.example.com` });
+
+describe("sortBlogrollByPublishedDesc", () => {
+  it("sorts entries newest-first by publishedAt", () => {
+    const items: BlogRollItem[] = [
+      { entry: entry("a"), post: { title: "A", url: "/a", publishedAt: "2024-01-01" } },
+      { entry: entry("b"), post: { title: "B", url: "/b", publishedAt: "2024-06-15" } },
+      { entry: entry("c"), post: { title: "C", url: "/c", publishedAt: "2023-12-31" } },
+    ];
+    const result = sortBlogrollByPublishedDesc(items);
+    expect(result.map((i) => i.entry.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("sorts entries with missing publishedAt last", () => {
+    const items: BlogRollItem[] = [
+      { entry: entry("no-post"), post: null },
+      { entry: entry("dated"), post: { title: "D", url: "/d", publishedAt: "2024-03-01" } },
+      { entry: entry("empty-date"), post: { title: "E", url: "/e", publishedAt: "" } },
+    ];
+    const result = sortBlogrollByPublishedDesc(items);
+    expect(result[0].entry.id).toBe("dated");
+    expect(result.slice(1).map((i) => i.entry.id)).toEqual(
+      expect.arrayContaining(["no-post", "empty-date"]),
+    );
+  });
+
+  it("treats both-missing as equal (preserves relative order)", () => {
+    const items: BlogRollItem[] = [
+      { entry: entry("x"), post: null },
+      { entry: entry("y"), post: { title: "Y", url: "/y", publishedAt: "" } },
+    ];
+    const result = sortBlogrollByPublishedDesc(items);
+    // both missing → comparator returns 0 → stable sort preserves original order
+    expect(result.map((i) => i.entry.id)).toEqual(["x", "y"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const items: BlogRollItem[] = [
+      { entry: entry("old"), post: { title: "Old", url: "/old", publishedAt: "2022-01-01" } },
+      { entry: entry("new"), post: { title: "New", url: "/new", publishedAt: "2025-01-01" } },
+    ];
+    const originalFirst = items[0];
+    const originalSecond = items[1];
+    sortBlogrollByPublishedDesc(items);
+    expect(items[0]).toBe(originalFirst);
+    expect(items[1]).toBe(originalSecond);
+  });
+});

--- a/blog/test/info-panel-region.test.tsx
+++ b/blog/test/info-panel-region.test.tsx
@@ -8,6 +8,8 @@
 // — InfoPanelRegion is rendered into a container carrying that id, mirroring the
 // real host element.
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
 import { render, cleanup, waitFor } from "@testing-library/react";
 import { InfoPanelRegion } from "../src/components/InfoPanelRegion";
 import { AdminRegion } from "../src/pages/AdminRegion";
@@ -39,6 +41,15 @@ const baseData: InfoPanelData = {
 
 function strategyResolving(post: LatestPost | null): BlogRollStrategy {
   return { fetchLatestPost: () => Promise.resolve(post) };
+}
+
+// The ordered sequence of blogroll entry ids — the parity-relevant signature.
+// (renderToString emits hydration markers a client DOM lacks, so a literal
+// byte-string compare is brittle; the ordered id sequence is the real contract.)
+function orderedBlogrollSignature(root: HTMLElement): string[] {
+  return [...root.querySelectorAll("li[data-blogroll-id]")].map(
+    (li) => li.getAttribute("data-blogroll-id") ?? "",
+  );
 }
 
 // Render into a host carrying id="info-panel" so the hydrate effect's
@@ -132,6 +143,71 @@ describe("InfoPanelRegion", () => {
       expect(items[0].getAttribute("data-blogroll-id")).toBe("new-blog");
       expect(items[1].getAttribute("data-blogroll-id")).toBe("old-blog");
     });
+  });
+
+  it("renders the initial blogroll already sorted by build-time date desc (before any fetch)", () => {
+    // buildTimeFeeds populated in NON-sorted config order: old entry first, new
+    // entry second. The lazy initializer sorts by publishedAt desc on the very
+    // first render — no fetch, no effect — so the new entry comes first.
+    const data: InfoPanelData = {
+      ...baseData,
+      blogRoll: [
+        { id: "old-blog", name: "Old Blog", url: "https://old.com" },
+        { id: "new-blog", name: "New Blog", url: "https://new.com" },
+      ],
+      buildTimeFeeds: {
+        "old-blog": { title: "Old", url: "https://old.com/p", publishedAt: "2025-01-01" },
+        "new-blog": { title: "New", url: "https://new.com/p", publishedAt: "2025-11-19" },
+      },
+    };
+
+    const { container } = renderInPanel(
+      <InfoPanelRegion data={data} strategies={new Map()} />,
+    );
+
+    const items = container.querySelectorAll("li[data-blogroll-id]");
+    expect(items[0].getAttribute("data-blogroll-id")).toBe("new-blog");
+    expect(items[1].getAttribute("data-blogroll-id")).toBe("old-blog");
+  });
+
+  it("server and client initial renders produce byte-identical blogroll order/markup", () => {
+    // Hydration-parity contract: the same `data` (identical buildTimeFeeds on
+    // both sides) must yield the same initial markup on the server
+    // (renderToString) and the client first render. Use a multi-entry blogroll in
+    // non-sorted config order with populated feeds — the only shape where a parity
+    // break is observable.
+    const data: InfoPanelData = {
+      ...baseData,
+      blogRoll: [
+        { id: "old-blog", name: "Old Blog", url: "https://old.com" },
+        { id: "new-blog", name: "New Blog", url: "https://new.com" },
+        { id: "mid-blog", name: "Mid Blog", url: "https://mid.com" },
+      ],
+      buildTimeFeeds: {
+        "old-blog": { title: "Old", url: "https://old.com/p", publishedAt: "2024-05-01" },
+        "new-blog": { title: "New", url: "https://new.com/p", publishedAt: "2026-02-10" },
+        "mid-blog": { title: "Mid", url: "https://mid.com/p", publishedAt: "2025-08-15" },
+      },
+    };
+
+    // Server: renderToString of the SAME component renderPanelHtml uses (empty
+    // strategies map, no fetch). Extract the ordered blogroll signature.
+    const serverHtml = renderToString(
+      createElement(InfoPanelRegion, { data, strategies: new Map() }),
+    );
+    const serverDoc = document.createElement("div");
+    serverDoc.innerHTML = serverHtml;
+    const serverOrder = orderedBlogrollSignature(serverDoc);
+
+    // Client first render (no waitFor — pre-effect, pre-fetch).
+    const { container } = renderInPanel(
+      <InfoPanelRegion data={data} strategies={new Map()} />,
+    );
+    const clientOrder = orderedBlogrollSignature(container);
+
+    // Date-sorted desc: new (2026), mid (2025), old (2024).
+    expect(serverOrder).toEqual(["new-blog", "mid-blog", "old-blog"]);
+    expect(clientOrder).toEqual(serverOrder);
   });
 
   it("leaves the placeholder empty when a strategy resolves null", async () => {

--- a/blog/test/info-panel-region.test.tsx
+++ b/blog/test/info-panel-region.test.tsx
@@ -3,10 +3,12 @@
 // InfoPanelRegion is the React replacement for the imperative renderInfoPanel +
 // hydrateInfoPanel pair (AdminRegion is a thin pass-through over <Admin>). These
 // checks mount via RTL and assert both the initial delegated markup and the
-// post-mount blog-roll hydration. Because the hydrate effect reaches its DOM via
-// document.getElementById("info-panel") — the host <aside> the driver mounts into
-// — InfoPanelRegion is rendered into a container carrying that id, mirroring the
-// real host element.
+// post-mount blog-roll hydration (which now flows through setItems, not imperative
+// DOM mutation). The host <aside> carries id="info-panel" because the scroll
+// indicator effect reaches its DOM via document.getElementById("info-panel") (see
+// InfoPanelRegion's initScrollIndicator effect); the blogroll fetch effect no
+// longer does getElementById. InfoPanelRegion is rendered into a container carrying
+// that id, mirroring the real host element.
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { createElement } from "react";
 import { renderToString } from "react-dom/server";
@@ -52,8 +54,8 @@ function orderedBlogrollSignature(root: HTMLElement): string[] {
   );
 }
 
-// Render into a host carrying id="info-panel" so the hydrate effect's
-// getElementById finds it (the effect mutates that host's subtree).
+// Render into a host carrying id="info-panel" so the scroll indicator effect's
+// getElementById (in InfoPanelRegion) finds it.
 function renderInPanel(ui: React.ReactElement) {
   const host = document.createElement("aside");
   host.id = "info-panel";
@@ -225,6 +227,48 @@ describe("InfoPanelRegion", () => {
 
     await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
     expect(container.querySelector("#blogroll-latest-test-blog")?.textContent).toBe("");
+  });
+
+  it("retains build-time content when a runtime fetch resolves null", async () => {
+    // Build-time data IS present for the entry, so the first render shows it. The
+    // runtime fetch then resolves null. The render-time degradation fallback in
+    // InfoPanelRegion (post ?? data.buildTimeFeeds?.[id]) deliberately keeps the
+    // build-time content rather than blanking the entry — preserving the "user sees
+    // build-time content" behavior. This pins that intended behavior against the
+    // silent-regression case where a null runtime result erases build-time content.
+    const data: InfoPanelData = {
+      ...baseData,
+      blogRoll: [{ id: "test-blog", name: "Test Blog", url: "https://example.com" }],
+      buildTimeFeeds: {
+        "test-blog": {
+          title: "Build-Time Article",
+          url: "https://example.com/build-time",
+          publishedAt: "2025-06-01T00:00:00Z",
+        },
+      },
+    };
+    const strategy = strategyResolving(null);
+    const fetchSpy = vi.spyOn(strategy, "fetchLatestPost");
+    const strategies = new Map<string, BlogRollStrategy>([["test-blog", strategy]]);
+
+    const { container } = renderInPanel(
+      <InfoPanelRegion data={data} strategies={strategies} />,
+    );
+
+    // First render shows the build-time content, before the effect's fetch resolves.
+    expect(container.querySelector("#blogroll-latest-test-blog")?.textContent).toBe(
+      "Build-Time Article",
+    );
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+
+    // The null runtime result does NOT erase the build-time content: it is retained.
+    await Promise.resolve();
+    await waitFor(() =>
+      expect(container.querySelector("#blogroll-latest-test-blog")?.textContent).toBe(
+        "Build-Time Article",
+      ),
+    );
   });
 
   it("degrades silently, leaving the placeholder empty, when a strategy rejects", async () => {


### PR DESCRIPTION
Closes #2173

## What

Migrate the blog's blogroll ordering and per-entry content from imperative DOM
mutation to a sorted-array React state, so order is a pure function of state and
React owns the DOM.

`InfoPanelRegion` previously hydrated the blogroll by mutating React-owned nodes:
after fetching each entry's latest post, its effect called `updateBlogrollEntry`
(writing `textContent`/`href`/`data-iso` onto `querySelector`'d `<li>` children)
and `sortBlogrollByDate` (reading each `<li>`'s `data-iso` and reordering via
`appendChild`). This was only safe because `forceInfoPanelRefresh()` bumped
`panelKey` to **remount** the panel root on every blogroll change, side-stepping
a React reconcile that would otherwise fight the imperative reorder.

## How

- **Unit 1** — extract a pure, unit-tested sort helper
  `sortBlogrollByPublishedDesc` (`blog/src/blog-roll/sort-by-date.ts`): orders
  `{ entry, post }` items by `publishedAt` descending with explicit null-last
  semantics (missing date sorts last, both missing stable), returning a new array
  without mutating its input or touching the DOM.
- **Unit 2** — `InfoPanelRegion` now holds the blogroll in `useState`. A lazy
  initializer derives the **initial** ordered, enriched `{ entry, post }` list
  purely from props (`data.blogRoll` + `data.buildTimeFeeds`), sorted by the Unit 1
  helper; the fetch effect re-fetches, re-sorts, and `setState`. Render derives an
  `InfoPanel` `data` from state (reordered `blogRoll` + merged `buildTimeFeeds`)
  and passes it to the **unchanged** presentational `InfoPanel`, which reconciles
  via stable `key={b.id}`. `updateBlogrollEntry`, the DOM-reading
  `sortBlogrollByDate`, and the `getElementById("info-panel")` lookup are deleted.
- **Unit 3** — doc hygiene: confirmed no `panelKey` reorder-safety invariant JSDoc
  remains and the component JSDoc / re-fetch comments already describe the
  state-driven ordering (no stale "mutates the DOM imperatively" framing).

`forceInfoPanelRefresh`/`panelKey` are **kept** — the remount is still the
mechanism that re-runs the blogroll fetch effect when `[blogRoll, strategies,
aboutContent]` deps are referentially stable (the landing/about → home case).

## Hydration parity

The lazy initializer is a pure function of `data`, and `data.buildTimeFeeds` is
passed identically to server (`renderPanelHtml` → `renderToString`) and client
(`hydrateRoot`). So the initial SSR markup and the client's first render are
byte-identical. This **changes the SSR'd initial order** from config order to
build-time-date-sorted order (the intended behavior) and removes the
post-hydration reflow. A new parity test asserts server and client first renders
produce the same ordered blogroll, plus a test that the initial render is already
build-time-date-descending before any fetch.

This supersedes the never-merged interim approach in #2094.

## Verification

- `run-unit-tests.sh --app blog` — 420 passed (29 files).
- `run-typecheck.sh --app blog` — passes (blog target skipped by the script due to
  a pre-existing red baseline on origin/main; the change introduces no new type
  errors).
