### PR TITLE
print: EPUB search stops loading sections once superseded

### DIFF
--- a/print/src/viewer/epub.ts
+++ b/print/src/viewer/epub.ts
@@ -376,8 +376,10 @@ export function createEpubRenderer(
     async renderResult(): Promise<void> {},
 
     clearSearch(): void {
-      // Stand down any in-flight search(): bumping the epoch trips its post-loop
-      // guard (search ~line 318) so it applies no highlights for the cleared query.
+      // Stand down any in-flight search(): bumping the epoch trips both of its
+      // guards — the top-of-loop check stops it loading any further spine
+      // sections, and the post-loop check suppresses the highlight burst — so it
+      // applies no highlights for the cleared query.
       _searchEpoch++;
       clearSearchHighlights();
     },

--- a/print/src/viewer/epub.ts
+++ b/print/src/viewer/epub.ts
@@ -301,6 +301,7 @@ export function createEpubRenderer(
       const results: SearchResult[] = [];
       for (let i = 0; i < spineItems.length; i++) {
         const section = spineItems[i]!;
+        if (epoch !== _searchEpoch) break; // superseded: load no further sections
         try {
           try {
             await section.load(loader);

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -793,7 +793,7 @@ describe("createEpubRenderer", () => {
                          : [{ cfi: "cfi-B", excerpt: "second fox" }],
         ),
         // Gate ONLY the first call's load so call-1 parks while call-2 finishes.
-        load: vi.fn() as ReturnType<typeof vi.fn>,
+        load: vi.fn(),
       };
       let releaseFirst!: () => void;
       const gate = new Promise<void>((resolve) => { releaseFirst = resolve; });
@@ -830,7 +830,7 @@ describe("createEpubRenderer", () => {
         href: "ch0.xhtml",
         unload: vi.fn(),
         find: vi.fn().mockReturnValue([{ cfi: "cfi-0", excerpt: "alpha fox" }]),
-        load: vi.fn() as ReturnType<typeof vi.fn>, // type-safety-ok: vi.fn() cast needed to type load as MockInstance for mockImplementationOnce chaining
+        load: vi.fn(),
       };
       // Gate ONLY call-1's load (the first load); call-2's load resolves immediately.
       let release!: () => void; // type-safety-ok: definite assignment assertion — Promise constructor assigns release before it is used

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -830,10 +830,10 @@ describe("createEpubRenderer", () => {
         href: "ch0.xhtml",
         unload: vi.fn(),
         find: vi.fn().mockReturnValue([{ cfi: "cfi-0", excerpt: "alpha fox" }]),
-        load: vi.fn() as ReturnType<typeof vi.fn>,
+        load: vi.fn() as ReturnType<typeof vi.fn>, // type-safety-ok: vi.fn() cast needed to type load as MockInstance for mockImplementationOnce chaining
       };
       // Gate ONLY call-1's load (the first load); call-2's load resolves immediately.
-      let release!: () => void;
+      let release!: () => void; // type-safety-ok: definite assignment assertion — Promise constructor assigns release before it is used
       const gate = new Promise<void>((resolve) => { release = resolve; });
       s0.load
         .mockImplementationOnce(() => gate)
@@ -844,10 +844,10 @@ describe("createEpubRenderer", () => {
 
       const renderer = await initRenderer();
 
-      const p1 = renderer.search!("first");
+      const p1 = renderer.search!("first"); // type-safety-ok: search is optional on ContentRenderer but always present after initRenderer()
       // Flush a macrotask so call-1 parks INSIDE the loop on the gated s0.load().
       await new Promise((r) => setTimeout(r));
-      const p2 = renderer.search!("second");
+      const p2 = renderer.search!("second"); // type-safety-ok: search is optional on ContentRenderer but always present after initRenderer()
       // call-2's s0.load is the second call → resolves immediately; call-2 runs to
       // completion, loading both s0 and s1.
       await p2;

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -806,6 +806,7 @@ describe("createEpubRenderer", () => {
       const renderer = await initRenderer();
 
       const p1 = renderer.search!("first");
+      await new Promise((r) => setTimeout(r)); // flush a macrotask so call-1 parks INSIDE the loop on the gated section.load(); without this the fix breaks call-1 at i=0 before loading and call-2 would consume the gate
       const p2 = renderer.search!("second");
 
       // call-2 runs to completion (its load resolves immediately).
@@ -822,6 +823,42 @@ describe("createEpubRenderer", () => {
       expect(highlightCfis).not.toContain("cfi-A");
       const removeCfis = mockRendition.annotations.remove.mock.calls.map((c) => c[0]);
       expect(removeCfis).not.toContain("cfi-A");
+    });
+
+    it("a superseded search loads no further sections past the supersede point", async () => {
+      const s0: FakeSection = {
+        href: "ch0.xhtml",
+        unload: vi.fn(),
+        find: vi.fn().mockReturnValue([{ cfi: "cfi-0", excerpt: "alpha fox" }]),
+        load: vi.fn() as ReturnType<typeof vi.fn>,
+      };
+      // Gate ONLY call-1's load (the first load); call-2's load resolves immediately.
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => { release = resolve; });
+      s0.load
+        .mockImplementationOnce(() => gate)
+        .mockImplementation(() => Promise.resolve());
+      const s1 = makeSection("ch1.xhtml", [{ cfi: "cfi-1", excerpt: "beta fox" }]);
+      mockSpine.spineItems = [s0, s1];
+      mockBook.navigation.get.mockReturnValue({ label: "X" });
+
+      const renderer = await initRenderer();
+
+      const p1 = renderer.search!("first");
+      // Flush a macrotask so call-1 parks INSIDE the loop on the gated s0.load().
+      await new Promise((r) => setTimeout(r));
+      const p2 = renderer.search!("second");
+      // call-2's s0.load is the second call → resolves immediately; call-2 runs to
+      // completion, loading both s0 and s1.
+      await p2;
+
+      release();
+      await p1;
+
+      // s1.load is a shared mock over the single spine, so 1 call = only call-2
+      // reached it (call-1 broke at the top of i = 1); 2 calls would mean the
+      // superseded call-1 also loaded s1 (the unfixed behavior).
+      expect(s1.load).toHaveBeenCalledTimes(1);
     });
 
     it("skips a section whose load() rejects, surfaces via reportError, and returns matches from remaining sections", async () => {


### PR DESCRIPTION
Closes #1763

## What

The EPUB `search()` spine loop (`print/src/viewer/epub.ts`) only checked
`_searchEpoch` **once, after the whole loop**. So when a newer `search()` (or
`clearSearch()`) superseded an in-flight one, the superseded call kept loading
and searching **every remaining section** to completion before discarding its
work at the post-loop guard. On a large book with slow section loads this
needlessly loaded the rest of the book.

This adds a top-of-loop epoch check so a superseded search stops loading further
sections as soon as it is superseded:

```ts
for (let i = 0; i < spineItems.length; i++) {
  const section = spineItems[i]!;
  if (epoch !== _searchEpoch) break; // superseded: load no further sections
  ...
```

The in-flight `section.load()` already in progress cannot be cancelled (Promises
are not cancellable), but loading the *next* section after being superseded is
avoidable. Breaking at the top of iteration `i` is safe for unload — iteration
`i-1`'s `finally` already called `section.unload()`. The existing post-loop
guard stays; it still suppresses the highlight burst for a search superseded
after entering its last/only iteration.

## Tests

- **New test** — `"a superseded search loads no further sections past the
  supersede point"`: a superseded search reaches `s1.load` zero extra times
  (`expect(s1.load).toHaveBeenCalledTimes(1)` — only the live call-2 loaded it;
  `2` would be the unfixed behavior). Fails without the code change, passes with
  it.
- **Updated existing test** — `"only the latest of two overlapping searches
  performs its highlight burst"`: inserted a macrotask flush between the two
  `search()` calls so the now-superseded call parks **inside** the loop on its
  gated `section.load()`, matching the test's name. Without the flush, under the
  fix the superseded call-1 breaks at `i=0` before loading and call-2 would
  consume the load gate and deadlock the test. **All assertions are unchanged**
  — this is timing maintenance the fix requires, not a weakening.

`npm run test --prefix print` → 555 passed, 1 skipped (pre-existing).
