### PR TITLE
test: add E6 covering the dupLinesRose-only (medium confidence) duplication sub-path

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -35809,6 +35809,47 @@ assert_eq "sidecar no-baseline duplication → exactly one finding" "1" "$sideca
 rm -rf "$TMPDIR_TEST"
 TMPDIR_TEST=""
 
+# E6. Sidecar dupLines-only duplication (medium confidence): HEAD and BASE have
+#     EQUAL clone counts (clones=1 both), so clonesRose=false, but HEAD has MORE
+#     duplicated lines (15 > 5), so dupLinesRose=true. The aggregate duplication
+#     finding still fires (clonesRose || dupLinesRose), but takes the
+#     Confidence='medium' sub-path (clonesRose ? 'high' : 'medium'). E4/E5 both
+#     drive clonesRose=true (high), so this medium sub-path is otherwise uncovered.
+#     Empty eslint reports isolate the duplication path (no complexity finding).
+echo "Test: dispatch-review-erosion-diff.mjs — dupLines-only rise yields Confidence=medium duplication finding"
+TMPDIR_TEST=$(mktemp -d)
+mkdir -p "$TMPDIR_TEST/baseline"
+# Empty eslint reports → no complexity finding; isolates the duplication path.
+echo '[]' > "$TMPDIR_TEST/head-eslint.json"
+echo '[]' > "$TMPDIR_TEST/base-eslint.json"
+# HEAD jscpd report: one clone, 15 duplicated lines. The single duplicates entry
+# keeps the fixture realistic (worstCloneLocation has a real span to read).
+cat > "$TMPDIR_TEST/head-jscpd.json" <<'EOF'
+{"statistics":{"total":{"clones":1,"duplicatedLines":15,"percentage":9}},
+ "duplicates":[{"firstFile":{"name":"dup.ts","start":10,"end":22},
+                "secondFile":{"name":"dup.ts","start":40,"end":52}}]}
+EOF
+# BASE jscpd report: SAME clone count (1) so clonesRose=false, but FEWER
+# duplicated lines (5 < 15) so dupLinesRose=true. Statistics-only is fine — the
+# BASE report only feeds jscpdTotals (baseDup).
+cat > "$TMPDIR_TEST/base-jscpd.json" <<'EOF'
+{"statistics":{"total":{"clones":1,"duplicatedLines":5,"percentage":3}}}
+EOF
+sidecar_out=$(cd "$TMPDIR_TEST" && node "$SCRIPT_DIR/dispatch-review-erosion-diff.mjs" \
+  --eslint-head head-eslint.json \
+  --eslint-base base-eslint.json \
+  --jscpd-head head-jscpd.json \
+  --jscpd-base base-jscpd.json \
+  --baseline-dir baseline)
+sidecar_count=$(jq '.findings | length' <<<"$sidecar_out")
+sidecar_source=$(jq -r '.findings[0].Source // "none"' <<<"$sidecar_out")
+sidecar_confidence=$(jq -r '.findings[0].Confidence // "none"' <<<"$sidecar_out")
+assert_eq "sidecar dupLines-only duplication count=1" "1" "$sidecar_count"
+assert_eq "sidecar dupLines-only duplication Source=erosion" "erosion" "$sidecar_source"
+assert_eq "sidecar dupLines-only duplication Confidence=medium (dupLines rose, clones flat)" "medium" "$sidecar_confidence"
+rm -rf "$TMPDIR_TEST"
+TMPDIR_TEST=""
+
 # ============================================================================
 # dispatch-run-verification tests (#2024)
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -35843,9 +35843,11 @@ sidecar_out=$(cd "$TMPDIR_TEST" && node "$SCRIPT_DIR/dispatch-review-erosion-dif
   --baseline-dir baseline)
 sidecar_count=$(jq '.findings | length' <<<"$sidecar_out")
 sidecar_source=$(jq -r '.findings[0].Source // "none"' <<<"$sidecar_out")
+sidecar_location=$(jq -r '.findings[0].Location // "none"' <<<"$sidecar_out")
 sidecar_confidence=$(jq -r '.findings[0].Confidence // "none"' <<<"$sidecar_out")
 assert_eq "sidecar dupLines-only duplication count=1" "1" "$sidecar_count"
 assert_eq "sidecar dupLines-only duplication Source=erosion" "erosion" "$sidecar_source"
+assert_eq "sidecar dupLines-only duplication Location=dup.ts:10" "dup.ts:10" "$sidecar_location"
 assert_eq "sidecar dupLines-only duplication Confidence=medium (dupLines rose, clones flat)" "medium" "$sidecar_confidence"
 rm -rf "$TMPDIR_TEST"
 TMPDIR_TEST=""


### PR DESCRIPTION
Closes #2189

## What

Adds an **E6** test block to
`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`, covering the
`dupLinesRose`-only (medium-confidence) duplication sub-path of
`dispatch-review-erosion-diff.mjs`.

## Why

The duplication finding's `Confidence` has two sub-paths
(`dispatch-review-erosion-diff.mjs:190-218`):

- `clonesRose === true` → `Confidence = 'high'` — a new clone block. Covered by E4
  and E5.
- `clonesRose === false && dupLinesRose === true` → `Confidence = 'medium'` —
  duplicated lines rose without a new clone block. **Previously untested** — E4 and
  E5 both drive `clonesRose=true`, leaving the medium branch dead from the suite's
  perspective.

E6 drives `clonesRose=false` (equal clone counts in HEAD and BASE) and
`dupLinesRose=true` (more duplicated lines in HEAD), locking the
`Confidence='medium'` sub-path so a future refactor of the confidence calculation
cannot silently regress it.

## How

The E6 block mirrors E5's structure exactly: empty eslint reports isolate the
duplication path; the HEAD jscpd report has `clones=1, duplicatedLines=15`; the
BASE jscpd report has `clones=1, duplicatedLines=5`. It asserts the finding count
(1), `Source=erosion`, and `Confidence=medium`.

## Verification

- Full `test-dispatch-scripts.sh` suite passes, including the three new E6
  assertions.
- `run-lint.sh --prose` passes (the new `jq <<<` extractions follow the
  here-string rule).
