### PR TITLE
acceptance: raise Firebase emulator readiness timeout to env-configurable 300s

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/run-acceptance-tests.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-acceptance-tests.sh
@@ -195,9 +195,12 @@ fi
 
 npx firebase-tools emulators:start --only "$EMULATORS" --config "$TEMP_FIREBASE_JSON" --project "$EMULATOR_PROJECT_ID" &
 
-# Poll until hosting emulator serves content.
-# Timeout allows headroom for slow CI (npx download + emulator startup can take 30-60s).
-TIMEOUT=120
+# Poll until hosting emulator serves content. The loop exits the instant
+# curl gets a 200, so a larger ceiling never slows a healthy start — it only
+# adds headroom for slow CI (JVM cold start + scheduling jitter under
+# contention can push the hosting listener past a tight deadline; see #2192).
+# Override with EMULATOR_READY_TIMEOUT (seconds).
+TIMEOUT="${EMULATOR_READY_TIMEOUT:-300}"
 ELAPSED=0
 until curl -s -o /dev/null -w '%{http_code}' "http://localhost:${HOSTING_PORT}/" 2>/dev/null | grep -q '^200$'; do
   if [ $ELAPSED -ge $TIMEOUT ]; then

--- a/.claude/skills/dispatch-propagate/scripts/run-acceptance-tests.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-acceptance-tests.sh
@@ -201,6 +201,21 @@ npx firebase-tools emulators:start --only "$EMULATORS" --config "$TEMP_FIREBASE_
 # contention can push the hosting listener past a tight deadline; see #2192).
 # Override with EMULATOR_READY_TIMEOUT (seconds).
 TIMEOUT="${EMULATOR_READY_TIMEOUT:-300}"
+# Validate: non-numeric input would make `[ $ELAPSED -ge $TIMEOUT ]` print
+# 'integer expected' and evaluate false forever (infinite loop until the CI
+# job timeout), and a value <= 0 would time out on the first iteration before
+# the just-forked emulator has any chance to respond. Fail fast with a clear
+# message instead.
+case "$TIMEOUT" in
+  '' | *[!0-9]*)
+    echo "ERROR: EMULATOR_READY_TIMEOUT must be a positive integer (got '${EMULATOR_READY_TIMEOUT}')" >&2
+    exit 1
+    ;;
+esac
+if [ "$TIMEOUT" -le 0 ]; then
+  echo "ERROR: EMULATOR_READY_TIMEOUT must be a positive integer (got '${EMULATOR_READY_TIMEOUT}')" >&2
+  exit 1
+fi
 ELAPSED=0
 until curl -s -o /dev/null -w '%{http_code}' "http://localhost:${HOSTING_PORT}/" 2>/dev/null | grep -q '^200$'; do
   if [ $ELAPSED -ge $TIMEOUT ]; then
@@ -213,7 +228,9 @@ done
 
 echo "Firebase hosting emulator ready on port ${HOSTING_PORT}"
 
-# Poll until Firestore emulator is ready (if used)
+# Poll until Firestore emulator is ready (if used). Reuses the TIMEOUT set
+# above, so EMULATOR_READY_TIMEOUT governs the Firestore readiness ceiling too —
+# the hosting and Firestore waits are coupled to the same env override.
 if [ "$USES_FIRESTORE" = true ]; then
   ELAPSED=0
   until curl -s -o /dev/null -w '%{http_code}' "http://localhost:${FIRESTORE_PORT}/" 2>/dev/null | grep -q '^200$'; do

--- a/.claude/skills/dispatch-propagate/scripts/run-acceptance-tests.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-acceptance-tests.sh
@@ -207,7 +207,7 @@ TIMEOUT="${EMULATOR_READY_TIMEOUT:-300}"
 # the just-forked emulator has any chance to respond. Fail fast with a clear
 # message instead.
 case "$TIMEOUT" in
-  '' | *[!0-9]*)
+  '' | *[^0-9]*)
     echo "ERROR: EMULATOR_READY_TIMEOUT must be a positive integer (got '${EMULATOR_READY_TIMEOUT}')" >&2
     exit 1
     ;;
@@ -229,8 +229,8 @@ done
 echo "Firebase hosting emulator ready on port ${HOSTING_PORT}"
 
 # Poll until Firestore emulator is ready (if used). Reuses the TIMEOUT set
-# above, so EMULATOR_READY_TIMEOUT governs the Firestore readiness ceiling too —
-# the hosting and Firestore waits are coupled to the same env override.
+# above, so EMULATOR_READY_TIMEOUT governs every emulator's readiness ceiling —
+# hosting, Firestore, Auth, and Storage waits all share the same TIMEOUT.
 if [ "$USES_FIRESTORE" = true ]; then
   ELAPSED=0
   until curl -s -o /dev/null -w '%{http_code}' "http://localhost:${FIRESTORE_PORT}/" 2>/dev/null | grep -q '^200$'; do


### PR DESCRIPTION
Closes #2192

## Problem

CI's acceptance job (`run-acceptance-tests.sh budget`) intermittently fails with:

```
ERROR: Firebase hosting emulator did not start within 120s
```

The harness starts the Firebase emulators in the background, then polls
`curl http://localhost:${HOSTING_PORT}/` once per second for an HTTP 200, with a
hard `TIMEOUT=120` deadline. The polling itself is correct — it waits for a real
HTTP 200 from the listener, not for the "All emulators ready!" log line. The
flake is a pure **headroom** problem: under CI resource contention (JVM cold
start for the co-started Java emulators, scheduling jitter), the gap between
launching the emulator and the hosting HTTP listener serving 200 can exceed the
120-second window even though the emulator eventually becomes ready.

`firebase-tools` is a pinned devDependency installed by `npm ci` before the timer
starts, so there is no npx network download inside the timed window — raising the
ceiling is the headroom fix the issue's acceptance criteria explicitly sanction.

## Change

In `.claude/skills/dispatch-propagate/scripts/run-acceptance-tests.sh`, raise the
single shared readiness-poll timeout from a hardcoded `120` to an env-tunable
default of `300`:

```bash
TIMEOUT="${EMULATOR_READY_TIMEOUT:-300}"
```

This one variable is set once and reused by all four readiness-poll blocks
(hosting, Firestore, Auth, Storage), so the single assignment raises the deadline
for every emulator consistently. The accompanying comment now documents the
override and why the larger ceiling is safe: the loop exits the instant curl gets
a 200, so a larger ceiling never slows a healthy start — it only adds headroom
for slow CI.

This mirrors the established env-tunable-timeout convention already used for
`PLAYWRIGHT_INSTALL_TIMEOUT` (default 300) in `lib.sh`.

## Trade-off

The only cost is that a *genuinely* dead emulator now takes up to 300s (worst
case, serial across the four blocks) to surface its "did not start" error instead
of 120s. That trade is acceptable: a false timeout forces a retry of the entire
expensive acceptance run, which dwarfs the extra seconds spent in the rare
true-failure case.

A background-process liveness check (`kill -0 $!`) to fail fast on a crashed
emulator was deliberately left out of scope — the reliability of `$!` as a proxy
for the emulator's liveness after `npx firebase-tools emulators:start &` is
unverified and the acceptance suite cannot be run locally here to confirm it.
Coupling that unverified behavior to a flaky-CI fix would risk a new flake
source.

## Verification

- `bash -n` syntax check of the edited script passes.
- The new `TIMEOUT="${EMULATOR_READY_TIMEOUT:-300}"` line is present.

Because the flake is intermittent, real validation comes from observing
subsequent CI acceptance runs: they should no longer fail with "Firebase hosting
emulator did not start within 120s". A single green run does not prove the fix;
confidence comes from the absence of the timeout error across several runs.
