### PR TITLE
epub.test.ts: add renderResult armed-state no-op test

### DIFF
--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -973,7 +973,7 @@ describe("createEpubRenderer", () => {
         // waitForRelocated(), which resolves on the rendition.once "relocated"
         // callback — fire it synchronously by inlining the mock.
         mockRendition.once.mockImplementation((_event: string, cb: () => void) => cb());
-        await renderer.goToResult!({
+        await renderer.goToResult({
           location: "cfi-0", label: "L", snippet: "fox", matchStart: 0, matchLength: 3,
         });
 

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -965,6 +965,26 @@ describe("createEpubRenderer", () => {
         // renderResult must not trigger an additional rendition.display call.
         expect(mockRendition.display.mock.calls.length).toBe(displayCallsBefore);
       });
+
+      it("is still a no-op when _activeCfi is armed: does not call rendition.display beyond goToResult", async () => {
+        const renderer = await initRenderer();
+
+        // Arm _activeCfi by driving a goToResult(). goToResult() awaits
+        // waitForRelocated(), which resolves on the rendition.once "relocated"
+        // callback — fire it synchronously by inlining the mock.
+        mockRendition.once.mockImplementation((_event: string, cb: () => void) => cb());
+        await renderer.goToResult!({
+          location: "cfi-0", label: "L", snippet: "fox", matchStart: 0, matchLength: 3,
+        });
+
+        // Baseline includes the display("cfi-0") call made by goToResult().
+        const displayCallsBefore = mockRendition.display.mock.calls.length;
+
+        await expect(renderer.renderResult()).resolves.toBeUndefined();
+
+        // renderResult must not trigger any additional rendition.display call.
+        expect(mockRendition.display.mock.calls.length).toBe(displayCallsBefore);
+      });
     });
   });
 });

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -666,6 +666,12 @@ describe("createEpubRenderer", () => {
       return renderer;
     }
 
+    function driveRelocated() {
+      // goToResult awaits waitForRelocated(), which resolves on the captured
+      // "relocated" once-callback. Mirror the next()/prev() pattern.
+      mockRendition.once.mockImplementation((_event: string, cb: () => void) => cb());
+    }
+
     it("returns matches from every spine section", async () => {
       const s0 = makeSection("ch0.xhtml", [{ cfi: "cfi-0", excerpt: "alpha fox beta" }]);
       const s1 = makeSection("ch1.xhtml", [{ cfi: "cfi-1", excerpt: "gamma fox delta" }]);
@@ -849,12 +855,6 @@ describe("createEpubRenderer", () => {
     });
 
     describe("goToResult", () => {
-      function driveRelocated() {
-        // goToResult awaits waitForRelocated(), which resolves on the captured
-        // "relocated" once-callback. Mirror the next()/prev() pattern.
-        mockRendition.once.mockImplementation((_event: string, cb: () => void) => cb());
-      }
-
       it("displays the result location and adds an active highlight", async () => {
         const renderer = await initRenderer();
         driveRelocated();
@@ -971,8 +971,8 @@ describe("createEpubRenderer", () => {
 
         // Arm _activeCfi by driving a goToResult(). goToResult() awaits
         // waitForRelocated(), which resolves on the rendition.once "relocated"
-        // callback — fire it synchronously by inlining the mock.
-        mockRendition.once.mockImplementation((_event: string, cb: () => void) => cb());
+        // callback — fire it synchronously via driveRelocated().
+        driveRelocated();
         await renderer.goToResult({
           location: "cfi-0", label: "L", snippet: "fox", matchStart: 0, matchLength: 3,
         });


### PR DESCRIPTION
Closes #1835

## Summary

`EpubRenderer.renderResult()` is a documented no-op
(`print/src/viewer/epub.ts:375`): for EPUB, a search result is rendered directly
inside `goToResult()` via `rendition.display(result.location)`, so the separate
single-page render step does nothing.

The existing `renderResult` test only covered the **cold** state — `renderResult()`
called with no prior `goToResult()`, so `_activeCfi` is `null`. The realistic call
path, where a host calls `renderResult()` *after* navigating to a result via
`goToResult()` (which sets `_activeCfi` and applies a highlight annotation), was
untested. A future change that made `renderResult()` re-display in that armed state
would have slipped through CI.

## Change

Adds one `it(...)` to the `renderResult` describe block in
`print/test/viewer/epub.test.ts`. The test arms `_activeCfi` by driving a
`goToResult()`, records the `rendition.display` call count, then asserts
`renderResult()` resolves to `undefined` and adds no further `rendition.display`
call beyond the one `goToResult()` already fired.

Test-only change — `print/src/viewer/epub.ts` is untouched. The full epub viewer
suite passes (52/52).
