### PR TITLE
print: cap EPUB/PDF full-document search results and surface truncation

### DIFF
--- a/print/src/viewer/SearchPanel.tsx
+++ b/print/src/viewer/SearchPanel.tsx
@@ -45,11 +45,15 @@ export function SearchPanel({ controller }: { controller: UseViewerControllerRes
     try {
       const renderer = getRenderer();
       if (!renderer || !isSearchable(renderer)) return;
-      const r = await renderer.search(trimmed);
+      const { results, truncated } = await renderer.search(trimmed);
       if (destroyed.current || trimmed !== currentQuery.current) return;
-      setResults(r);
+      setResults(results);
       setActiveIndex(-1);
-      setCountText(r.length === 1 ? "1 result" : `${r.length} results`);
+      if (truncated) {
+        setCountText(`First ${results.length} results shown — refine your search`);
+      } else {
+        setCountText(results.length === 1 ? "1 result" : `${results.length} results`);
+      }
     } catch (err) {
       setCountText("Search failed");
       setResults([]);

--- a/print/src/viewer/epub.ts
+++ b/print/src/viewer/epub.ts
@@ -1,5 +1,6 @@
 import ePub, { type Book, type Rendition, type Location, type NavItem } from "epubjs";
-import type { OutlineEntry, SearchableRenderer, SearchResult } from "./types.js";
+import type { OutlineEntry, SearchableRenderer, SearchResult, SearchResponse } from "./types.js";
+import { MAX_SEARCH_RESULTS } from "./types.js";
 
 // epubjs ships incomplete type declarations. These narrow shapes describe the
 // runtime members we use that are missing from the .d.ts, following the
@@ -285,11 +286,11 @@ export function createEpubRenderer(
       await relocated;
     },
 
-    async search(query: string): Promise<SearchResult[]> {
+    async search(query: string): Promise<SearchResponse> {
       const trimmed = query.trim();
       if (!book || !trimmed) {
         clearSearchHighlights();
-        return [];
+        return { results: [], truncated: false };
       }
 
       const epoch = ++_searchEpoch;
@@ -299,6 +300,7 @@ export function createEpubRenderer(
       const loader = (book.load as (this: Book, req: unknown) => Promise<unknown>).bind(book);
 
       const results: SearchResult[] = [];
+      let truncated = false;
       for (let i = 0; i < spineItems.length; i++) {
         const section = spineItems[i]!;
         try {
@@ -318,6 +320,7 @@ export function createEpubRenderer(
           try {
             const label = labelForSection(section, i);
             for (const match of section.find(trimmed)) {
+              if (results.length >= MAX_SEARCH_RESULTS) { truncated = true; break; }
               const result = buildResult(match, trimmed, label);
               if (result) results.push(result);
             }
@@ -334,11 +337,13 @@ export function createEpubRenderer(
         } finally {
           section.unload();
         }
+        // Cap tripped mid-section: stop scanning further sections.
+        if (truncated) break;
       }
 
       // A newer search started while we awaited; touch no highlight state and
       // let the UI's stale-result guard discard these.
-      if (epoch !== _searchEpoch) return results;
+      if (epoch !== _searchEpoch) return { results, truncated };
 
       // Single synchronous highlight burst after iteration.
       clearSearchHighlights();
@@ -347,7 +352,7 @@ export function createEpubRenderer(
         annotations.highlight(result.location, {}, undefined, "viewer-search-hl", BASE_STYLES);
         _searchCfis.push(result.location);
       }
-      return results;
+      return { results, truncated };
     },
 
     async goToResult(result: SearchResult): Promise<void> {

--- a/print/src/viewer/pdf.ts
+++ b/print/src/viewer/pdf.ts
@@ -2,8 +2,8 @@ import * as pdfjsLib from "pdfjs-dist";
 import { TextLayer } from "pdfjs-dist";
 import type { PDFDocumentProxy, PDFPageProxy, RenderTask } from "pdfjs-dist";
 import type { PageViewport } from "pdfjs-dist/types/src/display/display_utils.js";
-import type { OutlineEntry, SearchableRenderer, SearchResult } from "./types.js";
-import { parsePositionPage } from "./types.js";
+import type { OutlineEntry, SearchableRenderer, SearchResult, SearchResponse } from "./types.js";
+import { parsePositionPage, MAX_SEARCH_RESULTS } from "./types.js";
 import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
@@ -633,23 +633,20 @@ export function createPdfRenderer(onError?: (err: unknown) => void): SearchableR
 
     // No per-call generation/cancellation guard needed here: search.ts already
     // discards stale results via `trimmed !== currentQuery` after each await.
-    async search(query: string): Promise<SearchResult[]> {
+    async search(query: string): Promise<SearchResponse> {
       const trimmed = query.trim();
-      if (!trimmed) return [];
-      if (!pdfDoc) return [];
+      if (!trimmed) return { results: [], truncated: false };
+      if (!pdfDoc) return { results: [], truncated: false };
 
       const results: SearchResult[] = [];
-
-      // Cap total results at 200 to avoid an unbounded list when the query is
-      // very short and matches thousands of positions across a long document.
-      const MAX_RESULTS = 200;
+      let truncated = false;
 
       // Capture pdfDoc into a local so a concurrent destroy() — which nulls
       // pdfDoc — cannot turn a non-null assertion into a TypeError. Matches the
       // guard pattern in getOutline()/renderPage(). The destroyed flag still
       // short-circuits after each await below.
       const doc = pdfDoc;
-      if (!doc || destroyed) return results;
+      if (!doc || destroyed) return { results, truncated };
 
       for (let i = 1; i <= _pageCount; i++) {
         // Lazily populate the page-layout cache. Re-fetching text for every
@@ -659,7 +656,7 @@ export function createPdfRenderer(onError?: (err: unknown) => void): SearchableR
           let tc;
           try {
             const page = await doc.getPage(i);
-            if (destroyed) return results;
+            if (destroyed) return { results, truncated };
             // DETERMINISM: this getTextContent() call must use the same
             // (default, no-arg) options as the render-side call in
             // renderTextLayer, so the items — and the layout reconstructed from
@@ -671,27 +668,27 @@ export function createPdfRenderer(onError?: (err: unknown) => void): SearchableR
             // UnknownErrorException. Degrade silently — same intent as the
             // `destroyed` short-circuits — instead of surfacing "Search failed".
             if (destroyed || (err as { name?: string })?.name === "UnknownErrorException") {
-              return results;
+              return { results, truncated };
             }
             throw err;
           }
-          if (destroyed) return results;
+          if (destroyed) return { results, truncated };
           layout = reconstructPage(tc.items as TextContentItem[]);
           pageLayoutCache.set(i, layout);
         }
 
         const matches = findMatches(layout.text, trimmed);
         for (const { offset, length } of matches) {
+          if (results.length >= MAX_SEARCH_RESULTS) { truncated = true; break; }
           const location = encodeLocation(i, offset, length);
           const label = "Page " + i;
           const { snippet, matchStart, matchLength } = buildSnippet(layout.text, offset, length);
           results.push({ location, label, snippet, matchStart, matchLength });
-          if (results.length >= MAX_RESULTS) break;
         }
-        if (results.length >= MAX_RESULTS) break;
+        if (truncated) break;
       }
 
-      return results;
+      return { results, truncated };
     },
 
     async getOutline(): Promise<OutlineEntry[]> {

--- a/print/src/viewer/types.ts
+++ b/print/src/viewer/types.ts
@@ -16,6 +16,28 @@ export interface SearchResult {
   readonly matchLength: number;
 }
 
+/**
+ * Maximum number of search results a renderer returns from a single search().
+ *
+ * Common short queries ("the", "a") match thousands of positions across a long
+ * document; collecting and highlighting every one freezes the viewer. Capping
+ * the result count bounds both the returned list and the synchronous highlight
+ * burst. A single shared constant backs both the EPUB and PDF renderers for
+ * uniformity; 200 is the value the PDF renderer already shipped.
+ */
+export const MAX_SEARCH_RESULTS = 200;
+
+/**
+ * Envelope returned by a renderer's search method. Carries the capped result
+ * list plus whether the cap truncated the matches, so the truncation fact
+ * travels with the results rather than living in renderer state (where
+ * overlapping searches would race over it).
+ */
+export interface SearchResponse {
+  readonly results: SearchResult[];
+  readonly truncated: boolean;
+}
+
 /** A node in a document's table of contents tree. */
 export interface OutlineEntry {
   readonly title: string;
@@ -51,7 +73,7 @@ export interface ContentRenderer {
    * `clearSearch?.()` call sites compile unchanged. Use isSearchable() to narrow
    * a ContentRenderer to SearchableRenderer at call sites that need all four.
    */
-  search?(query: string): Promise<SearchResult[]>;
+  search?(query: string): Promise<SearchResponse>;
   goToResult?(result: SearchResult): Promise<void>;
   renderResult?(): Promise<void>;
   clearSearch?(): void;
@@ -68,7 +90,7 @@ export interface ContentRenderer {
  * is a compile error rather than a silent `renderResult?.()` no-op.
  */
 export interface SearchableRenderer extends ContentRenderer {
-  search(query: string): Promise<SearchResult[]>;
+  search(query: string): Promise<SearchResponse>;
   goToResult(result: SearchResult): Promise<void>;
   /**
    * Render the armed result in single-page mode. A renderer whose goToResult

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -922,6 +922,28 @@ describe("createEpubRenderer", () => {
       expect(mockRendition.annotations.highlight).toHaveBeenCalledTimes(MAX_SEARCH_RESULTS);
     });
 
+    it("stops scanning further sections once the cap fires in an earlier section (AC2)", async () => {
+      // Section 0 alone overflows the cap; section 1 must never be loaded once
+      // truncation fires, exercising the outer-loop guard (`if (truncated) break;`).
+      const overMatches = Array.from({ length: MAX_SEARCH_RESULTS + 1 }, (_, i) => ({
+        cfi: `cfi-over-${i}`,
+        excerpt: `fox excerpt ${i}`,
+      }));
+      const s0 = makeSection("ch0.xhtml", overMatches);
+      const s1 = makeSection("ch1.xhtml", [{ cfi: "cfi-1", excerpt: "fox tail" }]);
+      mockSpine.spineItems = [s0, s1];
+      mockBook.navigation.get.mockReturnValue({ label: "Ch. 1" });
+
+      const renderer = await initRenderer();
+      const result = await renderer.search!("fox"); // type-safety-ok: optional renderer API method, present in this test harness
+
+      expect(result.truncated).toBe(true);
+      expect(result.results.length).toBe(MAX_SEARCH_RESULTS);
+      // s0 is loaded, but the cap fires before s1 is ever reached.
+      expect(s0.load).toHaveBeenCalledTimes(1);
+      expect(s1.load).not.toHaveBeenCalled();
+    });
+
     it("does not truncate when total matches are within the cap", async () => {
       const fewMatches = Array.from({ length: MAX_SEARCH_RESULTS }, (_, i) => ({
         cfi: `cfi-few-${i}`,

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -83,6 +83,7 @@ vi.mock("epubjs", () => ({
 }));
 
 import { createEpubRenderer } from "../../src/viewer/epub";
+import { MAX_SEARCH_RESULTS } from "../../src/viewer/types";
 
 describe("createEpubRenderer", () => {
   let container: HTMLElement;
@@ -849,6 +850,44 @@ describe("createEpubRenderer", () => {
       expect(globalThis.reportError).toHaveBeenCalledWith(
         expect.objectContaining({ message: "boom" }),
       );
+    });
+
+    it("caps results at MAX_SEARCH_RESULTS, sets truncated=true, and still calls unload (AC2)", async () => {
+      // Build MAX_SEARCH_RESULTS + 1 matches so the cap fires mid-loop.
+      const overMatches = Array.from({ length: MAX_SEARCH_RESULTS + 1 }, (_, i) => ({
+        cfi: `cfi-over-${i}`,
+        excerpt: `fox excerpt ${i}`,
+      }));
+      const section = makeSection("ch0.xhtml", overMatches);
+      mockSpine.spineItems = [section];
+      mockBook.navigation.get.mockReturnValue({ label: "Ch. 1" });
+
+      const renderer = await initRenderer();
+      const result = await renderer.search!("fox");
+
+      // Result count is capped at the constant.
+      expect(result.results.length).toBe(MAX_SEARCH_RESULTS);
+      // Truncation flag is set.
+      expect(result.truncated).toBe(true);
+      // unload must have been called once regardless of early cap (finally block).
+      expect(section.unload).toHaveBeenCalledTimes(1);
+      // The highlight burst is bounded — exactly MAX_SEARCH_RESULTS annotations painted.
+      expect(mockRendition.annotations.highlight).toHaveBeenCalledTimes(MAX_SEARCH_RESULTS);
+    });
+
+    it("does not truncate when total matches are within the cap", async () => {
+      const fewMatches = Array.from({ length: MAX_SEARCH_RESULTS }, (_, i) => ({
+        cfi: `cfi-few-${i}`,
+        excerpt: `fox few ${i}`,
+      }));
+      mockSpine.spineItems = [makeSection("ch0.xhtml", fewMatches)];
+      mockBook.navigation.get.mockReturnValue({ label: "Ch. 1" });
+
+      const renderer = await initRenderer();
+      const result = await renderer.search!("fox");
+
+      expect(result.results.length).toBe(MAX_SEARCH_RESULTS);
+      expect(result.truncated).toBe(false);
     });
 
     describe("goToResult", () => {

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -674,7 +674,7 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockImplementation((href: string) => ({ label: `Label ${href}` }));
 
       const renderer = await initRenderer();
-      const results = await renderer.search!("fox");
+      const { results } = await renderer.search!("fox");
 
       // load + find called on every section (matches across chapter boundaries).
       for (const s of [s0, s1, s2]) {
@@ -697,7 +697,8 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockReturnValue({ label: "Chapter One" });
 
       const renderer = await initRenderer();
-      const [result] = await renderer.search!("brown");
+      const { results } = await renderer.search!("brown");
+      const [result] = results;
 
       // Whitespace collapsed to single spaces and trimmed.
       expect(result!.snippet).toBe("the quick brown fox jumps");
@@ -716,7 +717,8 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockReturnValue({ label: "Padded" });
 
       const renderer = await initRenderer();
-      const [result] = await renderer.search!("fox");
+      const { results } = await renderer.search!("fox");
+      const [result] = results;
 
       expect(result!.snippet).toBe("...lots of text fox more text...");
       expect(result!.matchStart).toBe(result!.snippet.indexOf("fox"));
@@ -731,7 +733,8 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockReturnValue({ label: "Caps" });
 
       const renderer = await initRenderer();
-      const [result] = await renderer.search!("fox");
+      const { results } = await renderer.search!("fox");
+      const [result] = results;
 
       expect(result!.snippet).toBe("A FOX in the henhouse");
       expect(result!.matchStart).toBe(2); // index of "FOX"
@@ -745,7 +748,7 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockReturnValue(undefined);
 
       const renderer = await initRenderer();
-      const results = await renderer.search!("fox");
+      const { results } = await renderer.search!("fox");
 
       expect(results.map((r) => r.label)).toEqual(["Ch. 1", "Ch. 2"]);
     });
@@ -775,9 +778,9 @@ describe("createEpubRenderer", () => {
       mockSpine.spineItems = [s0];
 
       const renderer = await initRenderer();
-      const results = await renderer.search!("   ");
+      const response = await renderer.search!("   ");
 
-      expect(results).toEqual([]);
+      expect(response).toEqual({ results: [], truncated: false });
       expect(s0.load).not.toHaveBeenCalled();
       expect(s0.find).not.toHaveBeenCalled();
       expect(mockRendition.annotations.highlight).not.toHaveBeenCalled();
@@ -833,7 +836,7 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockImplementation((href: string) => ({ label: `Label ${href}` }));
 
       const renderer = await initRenderer();
-      const results = await renderer.search!("fox");
+      const { results } = await renderer.search!("fox");
 
       // Every section's unload() must still be called (finally block runs
       // for each section regardless of whether a sibling fails).

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -675,7 +675,7 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockImplementation((href: string) => ({ label: `Label ${href}` }));
 
       const renderer = await initRenderer();
-      const { results } = await renderer.search!("fox");
+      const { results } = await renderer.search!("fox"); // type-safety-ok: optional renderer API method, present in this test harness
 
       // load + find called on every section (matches across chapter boundaries).
       for (const s of [s0, s1, s2]) {
@@ -698,7 +698,7 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockReturnValue({ label: "Chapter One" });
 
       const renderer = await initRenderer();
-      const { results } = await renderer.search!("brown");
+      const { results } = await renderer.search!("brown"); // type-safety-ok: optional renderer API method, present in this test harness
       const [result] = results;
 
       // Whitespace collapsed to single spaces and trimmed.
@@ -718,7 +718,7 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockReturnValue({ label: "Padded" });
 
       const renderer = await initRenderer();
-      const { results } = await renderer.search!("fox");
+      const { results } = await renderer.search!("fox"); // type-safety-ok: optional renderer API method, present in this test harness
       const [result] = results;
 
       expect(result!.snippet).toBe("...lots of text fox more text...");
@@ -734,7 +734,7 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockReturnValue({ label: "Caps" });
 
       const renderer = await initRenderer();
-      const { results } = await renderer.search!("fox");
+      const { results } = await renderer.search!("fox"); // type-safety-ok: optional renderer API method, present in this test harness
       const [result] = results;
 
       expect(result!.snippet).toBe("A FOX in the henhouse");
@@ -749,7 +749,7 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockReturnValue(undefined);
 
       const renderer = await initRenderer();
-      const { results } = await renderer.search!("fox");
+      const { results } = await renderer.search!("fox"); // type-safety-ok: optional renderer API method, present in this test harness
 
       expect(results.map((r) => r.label)).toEqual(["Ch. 1", "Ch. 2"]);
     });
@@ -779,7 +779,7 @@ describe("createEpubRenderer", () => {
       mockSpine.spineItems = [s0];
 
       const renderer = await initRenderer();
-      const response = await renderer.search!("   ");
+      const response = await renderer.search!("   "); // type-safety-ok: optional renderer API method, present in this test harness
 
       expect(response).toEqual({ results: [], truncated: false });
       expect(s0.load).not.toHaveBeenCalled();
@@ -837,7 +837,7 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockImplementation((href: string) => ({ label: `Label ${href}` }));
 
       const renderer = await initRenderer();
-      const { results } = await renderer.search!("fox");
+      const { results } = await renderer.search!("fox"); // type-safety-ok: optional renderer API method, present in this test harness
 
       // Every section's unload() must still be called (finally block runs
       // for each section regardless of whether a sibling fails).
@@ -863,7 +863,7 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockReturnValue({ label: "Ch. 1" });
 
       const renderer = await initRenderer();
-      const result = await renderer.search!("fox");
+      const result = await renderer.search!("fox"); // type-safety-ok: optional renderer API method, present in this test harness
 
       // Result count is capped at the constant.
       expect(result.results.length).toBe(MAX_SEARCH_RESULTS);
@@ -884,7 +884,7 @@ describe("createEpubRenderer", () => {
       mockBook.navigation.get.mockReturnValue({ label: "Ch. 1" });
 
       const renderer = await initRenderer();
-      const result = await renderer.search!("fox");
+      const result = await renderer.search!("fox"); // type-safety-ok: optional renderer API method, present in this test harness
 
       expect(result.results.length).toBe(MAX_SEARCH_RESULTS);
       expect(result.truncated).toBe(false);

--- a/print/test/viewer/pdf.test.ts
+++ b/print/test/viewer/pdf.test.ts
@@ -103,6 +103,7 @@ import {
   offsetToItemRanges,
   createPdfRenderer,
 } from "../../src/viewer/pdf";
+import { MAX_SEARCH_RESULTS } from "../../src/viewer/types";
 
 // ---------------------------------------------------------------------------
 // A. Pure helper tests — no mock dependencies needed.
@@ -522,6 +523,48 @@ describe("search()", () => {
     expect(decoded).not.toBeNull();
     expect(decoded!.offset).toBe(0);
     expect(decoded!.length).toBe(5);
+  });
+
+  it("caps results at MAX_SEARCH_RESULTS and sets truncated=true when matches exceed the limit", async () => {
+    // Build a fake doc with MAX_SEARCH_RESULTS + 1 pages, each with one match,
+    // so the total across pages exceeds the cap.
+    const pdfjs = await import("pdfjs-dist");
+    const overPageCount = MAX_SEARCH_RESULTS + 1;
+    const overDoc = {
+      numPages: overPageCount,
+      destroy() {},
+      getPage: (_i: number) =>
+        Promise.resolve({
+          getTextContent: () => Promise.resolve({ items: [{ str: "fox jumps" }] }),
+          getViewport: () => ({ width: 100, height: 100 }),
+          render: () => ({ promise: Promise.resolve(), cancel() {} }),
+        }),
+      getOutline: () => Promise.resolve(null),
+      getDestination: () => Promise.resolve(null),
+      getPageIndex: () => Promise.resolve(0),
+    };
+    const spy = vi
+      .spyOn(pdfjs, "getDocument")
+      .mockReturnValue({ promise: Promise.resolve(overDoc) } as never);
+    try {
+      const renderer = createPdfRenderer();
+      await renderer.init(container, "fake://over.pdf");
+      const result = await renderer.search!("fox");
+      expect(result.results.length).toBe(MAX_SEARCH_RESULTS);
+      expect(result.truncated).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("does not truncate and sets truncated=false when matches are within the limit", async () => {
+    // The default mock doc has 5 pages; search("the") yields 2 matches (pages 1 and 2).
+    // That is well below MAX_SEARCH_RESULTS, so truncated must be false.
+    const renderer = createPdfRenderer();
+    await renderer.init(container, "fake://source.pdf");
+    const result = await renderer.search!("the");
+    expect(result.results.length).toBeLessThanOrEqual(MAX_SEARCH_RESULTS);
+    expect(result.truncated).toBe(false);
   });
 
   it("resolves (does not reject) when destroy() fires during the page loop", async () => {

--- a/print/test/viewer/pdf.test.ts
+++ b/print/test/viewer/pdf.test.ts
@@ -366,7 +366,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the");
+    const { results } = await renderer.search!("the");
 
     const labels = results.map((r) => r.label);
     expect(labels).toContain("Page 1");
@@ -379,7 +379,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the");
+    const { results } = await renderer.search!("the");
     expect(results.length).toBeGreaterThan(0);
 
     for (const result of results) {
@@ -410,21 +410,21 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    expect(await renderer.search!("")).toEqual([]);
+    expect(await renderer.search!("")).toEqual({ results: [], truncated: false });
   });
 
   it("returns [] for whitespace-only query", async () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    expect(await renderer.search!("   ")).toEqual([]);
+    expect(await renderer.search!("   ")).toEqual({ results: [], truncated: false });
   });
 
   it("returns [] when query matches no page", async () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("xyzzy");
+    const { results } = await renderer.search!("xyzzy");
     expect(results).toEqual([]);
   });
 
@@ -432,7 +432,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the");
+    const { results } = await renderer.search!("the");
     const page1 = results.find((r) => r.label === "Page 1");
     expect(page1).toBeDefined();
 
@@ -444,7 +444,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the");
+    const { results } = await renderer.search!("the");
     const page2 = results.find((r) => r.label === "Page 2");
     expect(page2).toBeDefined();
 
@@ -455,7 +455,7 @@ describe("search()", () => {
   it("returns [] without throwing when called before init() resolves", async () => {
     const renderer = createPdfRenderer();
 
-    await expect(renderer.search!("the")).resolves.toEqual([]);
+    await expect(renderer.search!("the")).resolves.toEqual({ results: [], truncated: false });
   });
 
   it("returns [] without throwing when destroy() ran before search()", async () => {
@@ -463,7 +463,7 @@ describe("search()", () => {
     await renderer.init(container, "fake://source.pdf");
     renderer.destroy(); // sets destroyed = true and pdfDoc = null
     // Old code: `await pdfDoc!.getPage(1)` dereferences null → TypeError.
-    await expect(renderer.search!("the")).resolves.toEqual([]);
+    await expect(renderer.search!("the")).resolves.toEqual({ results: [], truncated: false });
   });
 
   // ---------------------------------------------------------------------------
@@ -479,7 +479,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the quick");
+    const { results } = await renderer.search!("the quick");
     const page4Results = results.filter((r) => r.label === "Page 4");
     expect(page4Results.length).toBe(1);
     expect(page4Results[0].label).toBe("Page 4");
@@ -495,7 +495,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the quick");
+    const { results } = await renderer.search!("the quick");
     expect(results.length).toBeGreaterThan(0);
 
     for (const result of results) {
@@ -514,7 +514,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("world");
+    const { results } = await renderer.search!("world");
     const page5Results = results.filter((r) => r.label === "Page 5");
     expect(page5Results.length).toBe(1);
 
@@ -548,8 +548,10 @@ describe("search()", () => {
     try {
       renderer = createPdfRenderer();
       await renderer.init(container, "fake://source.pdf");
-      // Must resolve to a partial/empty result, never reject.
-      await expect(renderer.search!("the")).resolves.toBeInstanceOf(Array);
+      // Must resolve to a partial/empty result envelope, never reject.
+      await expect(renderer.search!("the")).resolves.toEqual(
+        expect.objectContaining({ results: expect.any(Array), truncated: expect.any(Boolean) }),
+      );
     } finally {
       spy.mockRestore();
     }
@@ -708,7 +710,7 @@ describe("clearSearch()", () => {
     await renderer.init(container, "fake://source.pdf");
 
     // Search for "the" and navigate to the first result (Page 1: "the cat sat")
-    const results = await renderer.search!("the");
+    const { results } = await renderer.search!("the");
     const page1Result = results.find((r) => r.label === "Page 1");
     expect(page1Result).toBeDefined();
 
@@ -740,7 +742,7 @@ describe("clearSearch()", () => {
     try {
       const renderer = createPdfRenderer();
       await renderer.init(container, "fake://source.pdf");
-      const results = await renderer.search!("the");
+      const { results } = await renderer.search!("the");
       const page1Result = results.find((r) => r.label === "Page 1");
       // Arm then render so the highlight is live before the resize re-render
       // (goToResult is arm-only).
@@ -769,7 +771,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the");
+    const { results } = await renderer.search!("the");
     const page1Result = results.find((r) => r.label === "Page 1");
     await renderer.goToResult!(page1Result!);
     // Apply the highlight so clearSearch has something real to clear.
@@ -787,7 +789,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the");
+    const { results } = await renderer.search!("the");
     const page1Result = results.find((r) => r.label === "Page 1");
     expect(page1Result).toBeDefined();
 
@@ -815,7 +817,7 @@ describe("clearSearch()", () => {
       const renderer = createPdfRenderer();
       await renderer.init(container, "fake://source.pdf");
 
-      const results = await renderer.search!("the");
+      const { results } = await renderer.search!("the");
       const page1Result = results.find((r) => r.label === "Page 1");
       await renderer.goToResult!(page1Result!);
       // goToResult is arm-only now (#1719); renderResult() applies the highlight.
@@ -850,7 +852,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the");
+    const { results } = await renderer.search!("the");
     const page1Result = results.find((r) => r.label === "Page 1");
     expect(page1Result).toBeDefined();
 
@@ -889,7 +891,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the");
+    const { results } = await renderer.search!("the");
     const page1Result = results.find((r) => r.label === "Page 1");
     expect(page1Result).toBeDefined();
 
@@ -923,7 +925,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the");
+    const { results } = await renderer.search!("the");
     const page1Result = results.find((r) => r.label === "Page 1");
     // Arm then render so clearSearch has a real highlight to clean up
     // (goToResult is arm-only).
@@ -944,7 +946,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the");
+    const { results } = await renderer.search!("the");
     const r1 = results.find((r) => r.label === "Page 1")!;
     const r2 = results.find((r) => r.label === "Page 2")!;
 
@@ -971,7 +973,7 @@ describe("clearSearch()", () => {
     await renderer.init(container, "fake://source.pdf");
 
     // Arm then render pendingHighlight for page 1 so the highlight is live in the DOM.
-    const results = await renderer.search!("the");
+    const { results } = await renderer.search!("the");
     const page1Result = results.find((r) => r.label === "Page 1");
     expect(page1Result).toBeDefined();
     await renderer.goToResult!(page1Result!);
@@ -1028,7 +1030,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     const page1Result = results.find((r) => r.label === "Page 1");
     expect(page1Result).toBeDefined();
 
@@ -1067,7 +1069,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("the");
+    const { results } = await renderer.search!("the");
     const r1 = results.find((r) => r.label === "Page 1")!;
     // Arm then render so the highlight is live before navigating away.
     await renderer.goToResult!(r1);
@@ -1153,7 +1155,7 @@ describe("clearSearch()", () => {
     await renderer.init(container, "fake://source.pdf");
 
     // Search to populate the pageLayoutCache for page 4.
-    const results = await renderer.search!("the quick");
+    const { results } = await renderer.search!("the quick");
     const page4Result = results.find((r) => r.label === "Page 4");
     expect(page4Result).toBeDefined();
 
@@ -1190,7 +1192,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const results = await renderer.search!("world");
+    const { results } = await renderer.search!("world");
     const page5Result = results.find((r) => r.label === "Page 5");
     expect(page5Result).toBeDefined();
 

--- a/print/test/viewer/pdf.test.ts
+++ b/print/test/viewer/pdf.test.ts
@@ -367,7 +367,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("the");
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
 
     const labels = results.map((r) => r.label);
     expect(labels).toContain("Page 1");
@@ -380,7 +380,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("the");
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     expect(results.length).toBeGreaterThan(0);
 
     for (const result of results) {
@@ -411,21 +411,21 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    expect(await renderer.search!("")).toEqual({ results: [], truncated: false });
+    expect(await renderer.search!("")).toEqual({ results: [], truncated: false }); // type-safety-ok: optional renderer API method, present in this test harness
   });
 
   it("returns [] for whitespace-only query", async () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    expect(await renderer.search!("   ")).toEqual({ results: [], truncated: false });
+    expect(await renderer.search!("   ")).toEqual({ results: [], truncated: false }); // type-safety-ok: optional renderer API method, present in this test harness
   });
 
   it("returns [] when query matches no page", async () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("xyzzy");
+    const { results } = await renderer.search!("xyzzy"); // type-safety-ok: optional renderer API method, present in this test harness
     expect(results).toEqual([]);
   });
 
@@ -433,7 +433,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("the");
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     const page1 = results.find((r) => r.label === "Page 1");
     expect(page1).toBeDefined();
 
@@ -445,7 +445,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("the");
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     const page2 = results.find((r) => r.label === "Page 2");
     expect(page2).toBeDefined();
 
@@ -456,7 +456,7 @@ describe("search()", () => {
   it("returns [] without throwing when called before init() resolves", async () => {
     const renderer = createPdfRenderer();
 
-    await expect(renderer.search!("the")).resolves.toEqual({ results: [], truncated: false });
+    await expect(renderer.search!("the")).resolves.toEqual({ results: [], truncated: false }); // type-safety-ok: optional renderer API method, present in this test harness
   });
 
   it("returns [] without throwing when destroy() ran before search()", async () => {
@@ -464,7 +464,7 @@ describe("search()", () => {
     await renderer.init(container, "fake://source.pdf");
     renderer.destroy(); // sets destroyed = true and pdfDoc = null
     // Old code: `await pdfDoc!.getPage(1)` dereferences null → TypeError.
-    await expect(renderer.search!("the")).resolves.toEqual({ results: [], truncated: false });
+    await expect(renderer.search!("the")).resolves.toEqual({ results: [], truncated: false }); // type-safety-ok: optional renderer API method, present in this test harness
   });
 
   // ---------------------------------------------------------------------------
@@ -480,7 +480,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("the quick");
+    const { results } = await renderer.search!("the quick"); // type-safety-ok: optional renderer API method, present in this test harness
     const page4Results = results.filter((r) => r.label === "Page 4");
     expect(page4Results.length).toBe(1);
     expect(page4Results[0].label).toBe("Page 4");
@@ -496,7 +496,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("the quick");
+    const { results } = await renderer.search!("the quick"); // type-safety-ok: optional renderer API method, present in this test harness
     expect(results.length).toBeGreaterThan(0);
 
     for (const result of results) {
@@ -515,7 +515,7 @@ describe("search()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("world");
+    const { results } = await renderer.search!("world"); // type-safety-ok: optional renderer API method, present in this test harness
     const page5Results = results.filter((r) => r.label === "Page 5");
     expect(page5Results.length).toBe(1);
 
@@ -545,11 +545,11 @@ describe("search()", () => {
     };
     const spy = vi
       .spyOn(pdfjs, "getDocument")
-      .mockReturnValue({ promise: Promise.resolve(overDoc) } as never);
+      .mockReturnValue({ promise: Promise.resolve(overDoc) } as never); // type-safety-ok: vitest mock for pdfjs-dist getDocument complex return type
     try {
       const renderer = createPdfRenderer();
       await renderer.init(container, "fake://over.pdf");
-      const result = await renderer.search!("fox");
+      const result = await renderer.search!("fox"); // type-safety-ok: optional renderer API method, present in this test harness
       expect(result.results.length).toBe(MAX_SEARCH_RESULTS);
       expect(result.truncated).toBe(true);
     } finally {
@@ -562,7 +562,7 @@ describe("search()", () => {
     // That is well below MAX_SEARCH_RESULTS, so truncated must be false.
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
-    const result = await renderer.search!("the");
+    const result = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     expect(result.results.length).toBeLessThanOrEqual(MAX_SEARCH_RESULTS);
     expect(result.truncated).toBe(false);
   });
@@ -592,7 +592,7 @@ describe("search()", () => {
       renderer = createPdfRenderer();
       await renderer.init(container, "fake://source.pdf");
       // Must resolve to a partial/empty result envelope, never reject.
-      await expect(renderer.search!("the")).resolves.toEqual(
+      await expect(renderer.search!("the")).resolves.toEqual( // type-safety-ok: optional renderer API method, present in this test harness
         expect.objectContaining({ results: expect.any(Array), truncated: expect.any(Boolean) }),
       );
     } finally {
@@ -753,7 +753,7 @@ describe("clearSearch()", () => {
     await renderer.init(container, "fake://source.pdf");
 
     // Search for "the" and navigate to the first result (Page 1: "the cat sat")
-    const { results } = await renderer.search!("the");
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     const page1Result = results.find((r) => r.label === "Page 1");
     expect(page1Result).toBeDefined();
 
@@ -785,7 +785,7 @@ describe("clearSearch()", () => {
     try {
       const renderer = createPdfRenderer();
       await renderer.init(container, "fake://source.pdf");
-      const { results } = await renderer.search!("the");
+      const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
       const page1Result = results.find((r) => r.label === "Page 1");
       // Arm then render so the highlight is live before the resize re-render
       // (goToResult is arm-only).
@@ -814,7 +814,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("the");
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     const page1Result = results.find((r) => r.label === "Page 1");
     await renderer.goToResult!(page1Result!);
     // Apply the highlight so clearSearch has something real to clear.
@@ -832,7 +832,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("the");
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     const page1Result = results.find((r) => r.label === "Page 1");
     expect(page1Result).toBeDefined();
 
@@ -860,7 +860,7 @@ describe("clearSearch()", () => {
       const renderer = createPdfRenderer();
       await renderer.init(container, "fake://source.pdf");
 
-      const { results } = await renderer.search!("the");
+      const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
       const page1Result = results.find((r) => r.label === "Page 1");
       await renderer.goToResult!(page1Result!);
       // goToResult is arm-only now (#1719); renderResult() applies the highlight.
@@ -895,7 +895,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("the");
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     const page1Result = results.find((r) => r.label === "Page 1");
     expect(page1Result).toBeDefined();
 
@@ -934,7 +934,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("the");
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     const page1Result = results.find((r) => r.label === "Page 1");
     expect(page1Result).toBeDefined();
 
@@ -968,7 +968,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("the");
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     const page1Result = results.find((r) => r.label === "Page 1");
     // Arm then render so clearSearch has a real highlight to clean up
     // (goToResult is arm-only).
@@ -989,7 +989,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("the");
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     const r1 = results.find((r) => r.label === "Page 1")!;
     const r2 = results.find((r) => r.label === "Page 2")!;
 
@@ -1016,7 +1016,7 @@ describe("clearSearch()", () => {
     await renderer.init(container, "fake://source.pdf");
 
     // Arm then render pendingHighlight for page 1 so the highlight is live in the DOM.
-    const { results } = await renderer.search!("the");
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     const page1Result = results.find((r) => r.label === "Page 1");
     expect(page1Result).toBeDefined();
     await renderer.goToResult!(page1Result!);
@@ -1112,7 +1112,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("the");
+    const { results } = await renderer.search!("the"); // type-safety-ok: optional renderer API method, present in this test harness
     const r1 = results.find((r) => r.label === "Page 1")!;
     // Arm then render so the highlight is live before navigating away.
     await renderer.goToResult!(r1);
@@ -1198,7 +1198,7 @@ describe("clearSearch()", () => {
     await renderer.init(container, "fake://source.pdf");
 
     // Search to populate the pageLayoutCache for page 4.
-    const { results } = await renderer.search!("the quick");
+    const { results } = await renderer.search!("the quick"); // type-safety-ok: optional renderer API method, present in this test harness
     const page4Result = results.find((r) => r.label === "Page 4");
     expect(page4Result).toBeDefined();
 
@@ -1235,7 +1235,7 @@ describe("clearSearch()", () => {
     const renderer = createPdfRenderer();
     await renderer.init(container, "fake://source.pdf");
 
-    const { results } = await renderer.search!("world");
+    const { results } = await renderer.search!("world"); // type-safety-ok: optional renderer API method, present in this test harness
     const page5Result = results.find((r) => r.label === "Page 5");
     expect(page5Result).toBeDefined();
 

--- a/print/test/viewer/search.test.ts
+++ b/print/test/viewer/search.test.ts
@@ -320,8 +320,8 @@ describe("SearchPanel", () => {
     const controller = makeMockController({ getRenderer: () => renderer });
     render(controller);
 
-    const input = container.querySelector(".viewer-search-input") as HTMLInputElement;
-    const countEl = container.querySelector(".viewer-search-count") as HTMLElement;
+    const input = container.querySelector(".viewer-search-input") as HTMLInputElement; // type-safety-ok: querySelector result narrowed by test setup guarantee
+    const countEl = container.querySelector(".viewer-search-count") as HTMLElement; // type-safety-ok: querySelector result narrowed by test setup guarantee
 
     setInputValue(input, "fox");
     await act(async () => {
@@ -343,8 +343,8 @@ describe("SearchPanel", () => {
     const controller = makeMockController({ getRenderer: () => renderer });
     render(controller);
 
-    const input = container.querySelector(".viewer-search-input") as HTMLInputElement;
-    const countEl = container.querySelector(".viewer-search-count") as HTMLElement;
+    const input = container.querySelector(".viewer-search-input") as HTMLInputElement; // type-safety-ok: querySelector result narrowed by test setup guarantee
+    const countEl = container.querySelector(".viewer-search-count") as HTMLElement; // type-safety-ok: querySelector result narrowed by test setup guarantee
 
     setInputValue(input, "fox");
     await act(async () => {
@@ -446,7 +446,7 @@ describe("SearchPanel", () => {
   // -------------------------------------------------------------------------
 
   it("discards stale search results when query changes during await", async () => {
-    let resolveFirst!: (value: SearchResponse) => void;
+    let resolveFirst!: (value: SearchResponse) => void; // type-safety-ok: definite assignment — assigned in Promise constructor callback before first read
     const staleResults = { results: [makeSearchResult({ label: "Stale" })], truncated: false };
     const freshResults = { results: [makeSearchResult({ label: "Fresh" })], truncated: false };
     const searchFn = vi.fn()

--- a/print/test/viewer/search.test.ts
+++ b/print/test/viewer/search.test.ts
@@ -5,7 +5,7 @@ import { act } from "react";
 import { createElement } from "react";
 import { SearchPanel } from "../../src/viewer/SearchPanel";
 import type { UseViewerControllerResult } from "../../src/viewer/useViewerController";
-import type { SearchResult } from "../../src/viewer/types";
+import type { SearchResult, SearchResponse } from "../../src/viewer/types";
 import { makeMockRenderer } from "./mock-renderer";
 
 // ---------------------------------------------------------------------------
@@ -26,7 +26,7 @@ function makeSearchResult(overrides: Partial<SearchResult> = {}): SearchResult {
 /** Build a mock controller stub with all search-related methods wired up. */
 function makeMockController(overrides: Partial<UseViewerControllerResult> = {}): UseViewerControllerResult {
   const renderer = makeMockRenderer({
-    search: vi.fn().mockResolvedValue([]),
+    search: vi.fn().mockResolvedValue({ results: [], truncated: false }),
     goToResult: vi.fn().mockResolvedValue(undefined),
     renderResult: vi.fn().mockResolvedValue(undefined),
     clearSearch: vi.fn(),
@@ -136,7 +136,7 @@ describe("SearchPanel", () => {
   // -------------------------------------------------------------------------
 
   it("calls renderer.search after 300ms debounce on input", async () => {
-    const searchFn = vi.fn().mockResolvedValue([]);
+    const searchFn = vi.fn().mockResolvedValue({ results: [], truncated: false });
     const renderer = makeMockRenderer({ search: searchFn, goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
     const controller = makeMockController({ getRenderer: () => renderer });
     render(controller);
@@ -160,7 +160,7 @@ describe("SearchPanel", () => {
   // -------------------------------------------------------------------------
 
   it("search event (Enter key) triggers search immediately without debounce", async () => {
-    const searchFn = vi.fn().mockResolvedValue([]);
+    const searchFn = vi.fn().mockResolvedValue({ results: [], truncated: false });
     const renderer = makeMockRenderer({ search: searchFn, goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
     const controller = makeMockController({ getRenderer: () => renderer });
     render(controller);
@@ -179,7 +179,7 @@ describe("SearchPanel", () => {
   });
 
   it("search event cancels pending debounce and deduplicates", async () => {
-    const searchFn = vi.fn().mockResolvedValue([]);
+    const searchFn = vi.fn().mockResolvedValue({ results: [], truncated: false });
     const renderer = makeMockRenderer({ search: searchFn, goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
     const controller = makeMockController({ getRenderer: () => renderer });
     render(controller);
@@ -212,7 +212,7 @@ describe("SearchPanel", () => {
 
   it("empty input calls renderer.clearSearch and clears results", async () => {
     const clearSearch = vi.fn();
-    const searchFn = vi.fn().mockResolvedValue([makeSearchResult()]);
+    const searchFn = vi.fn().mockResolvedValue({ results: [makeSearchResult()], truncated: false });
     const renderer = makeMockRenderer({ search: searchFn, goToResult: vi.fn(), renderResult: vi.fn(), clearSearch });
     const controller = makeMockController({ getRenderer: () => renderer });
     render(controller);
@@ -243,7 +243,7 @@ describe("SearchPanel", () => {
     const result1 = makeSearchResult({ location: "3", label: "Page 3" });
     const result2 = makeSearchResult({ location: "7", label: "Page 7" });
     const goToResult = vi.fn().mockResolvedValue(undefined);
-    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue([result1, result2]), goToResult, renderResult: vi.fn(), clearSearch: vi.fn() });
+    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue({ results: [result1, result2], truncated: false }), goToResult, renderResult: vi.fn(), clearSearch: vi.fn() });
     const controller = makeMockController({ getRenderer: () => renderer });
     render(controller);
 
@@ -264,7 +264,7 @@ describe("SearchPanel", () => {
 
   it("clicking a result calls the onSearchNavigate callback", async () => {
     const onSearchNavigate = vi.fn();
-    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue([makeSearchResult()]), goToResult: vi.fn().mockResolvedValue(undefined), renderResult: vi.fn(), clearSearch: vi.fn() });
+    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue({ results: [makeSearchResult()], truncated: false }), goToResult: vi.fn().mockResolvedValue(undefined), renderResult: vi.fn(), clearSearch: vi.fn() });
     const controller = makeMockController({ getRenderer: () => renderer, onSearchNavigate });
     render(controller);
 
@@ -290,8 +290,8 @@ describe("SearchPanel", () => {
 
   it("count text shows correct singular and plural forms", async () => {
     const searchFn = vi.fn()
-      .mockResolvedValueOnce([makeSearchResult()])
-      .mockResolvedValueOnce([makeSearchResult(), makeSearchResult(), makeSearchResult()]);
+      .mockResolvedValueOnce({ results: [makeSearchResult()], truncated: false })
+      .mockResolvedValueOnce({ results: [makeSearchResult(), makeSearchResult(), makeSearchResult()], truncated: false });
     const renderer = makeMockRenderer({ search: searchFn, goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
     const controller = makeMockController({ getRenderer: () => renderer });
     render(controller);
@@ -315,7 +315,7 @@ describe("SearchPanel", () => {
   });
 
   it("zero results shows '0 results' count", async () => {
-    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue([]), goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
+    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue({ results: [], truncated: false }), goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
     const controller = makeMockController({ getRenderer: () => renderer });
     render(controller);
 
@@ -340,7 +340,7 @@ describe("SearchPanel", () => {
       matchStart: 0,
       matchLength: 8,
     });
-    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue([xssResult]), goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
+    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue({ results: [xssResult], truncated: false }), goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
     const controller = makeMockController({ getRenderer: () => renderer });
     render(controller);
 
@@ -359,7 +359,7 @@ describe("SearchPanel", () => {
     const xssResult = makeSearchResult({
       label: '<img onerror="alert(1)">',
     });
-    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue([xssResult]), goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
+    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue({ results: [xssResult], truncated: false }), goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
     const controller = makeMockController({ getRenderer: () => renderer });
     render(controller);
 
@@ -378,7 +378,7 @@ describe("SearchPanel", () => {
   // -------------------------------------------------------------------------
 
   it("cleanup cancels timer (unmount before 300ms → search not called)", async () => {
-    const searchFn = vi.fn().mockResolvedValue([]);
+    const searchFn = vi.fn().mockResolvedValue({ results: [], truncated: false });
     const renderer = makeMockRenderer({ search: searchFn, goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
     const controller = makeMockController({ getRenderer: () => renderer });
     render(controller);
@@ -406,11 +406,11 @@ describe("SearchPanel", () => {
   // -------------------------------------------------------------------------
 
   it("discards stale search results when query changes during await", async () => {
-    let resolveFirst!: (value: SearchResult[]) => void;
-    const staleResults = [makeSearchResult({ label: "Stale" })];
-    const freshResults = [makeSearchResult({ label: "Fresh" })];
+    let resolveFirst!: (value: SearchResponse) => void;
+    const staleResults = { results: [makeSearchResult({ label: "Stale" })], truncated: false };
+    const freshResults = { results: [makeSearchResult({ label: "Fresh" })], truncated: false };
     const searchFn = vi.fn()
-      .mockImplementationOnce(() => new Promise<SearchResult[]>((r) => { resolveFirst = r; }))
+      .mockImplementationOnce(() => new Promise<SearchResponse>((r) => { resolveFirst = r; }))
       .mockImplementationOnce(() => Promise.resolve(freshResults));
     const renderer = makeMockRenderer({ search: searchFn, goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
     const controller = makeMockController({ getRenderer: () => renderer });
@@ -454,7 +454,7 @@ describe("SearchPanel", () => {
       makeSearchResult({ location: "1", label: "Page 1" }),
       makeSearchResult({ location: "2", label: "Page 2" }),
     ];
-    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue(results), goToResult: vi.fn().mockResolvedValue(undefined), renderResult: vi.fn(), clearSearch: vi.fn() });
+    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue({ results, truncated: false }), goToResult: vi.fn().mockResolvedValue(undefined), renderResult: vi.fn(), clearSearch: vi.fn() });
     const controller = makeMockController({ getRenderer: () => renderer });
     render(controller);
 

--- a/print/test/viewer/search.test.ts
+++ b/print/test/viewer/search.test.ts
@@ -314,6 +314,46 @@ describe("SearchPanel", () => {
     expect(countEl.textContent).toBe("3 results");
   });
 
+  it("truncated=true shows 'First N results shown — refine your search' in count (AC3)", async () => {
+    const results = [makeSearchResult(), makeSearchResult(), makeSearchResult()];
+    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue({ results, truncated: true }), goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
+    const controller = makeMockController({ getRenderer: () => renderer });
+    render(controller);
+
+    const input = container.querySelector(".viewer-search-input") as HTMLInputElement;
+    const countEl = container.querySelector(".viewer-search-count") as HTMLElement;
+
+    setInputValue(input, "fox");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    // Must differ from the plain "N results" text — includes a truncation hint.
+    const countText = countEl.textContent ?? "";
+    expect(countText).not.toBe("3 results");
+    expect(countText.length).toBeGreaterThan(0);
+    // The count and a truncation hint are both present.
+    expect(countText).toContain("3");
+    expect(countText.toLowerCase()).toMatch(/refine|first/);
+  });
+
+  it("truncated=false shows plain 'N results' count", async () => {
+    const results = [makeSearchResult(), makeSearchResult(), makeSearchResult()];
+    const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue({ results, truncated: false }), goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
+    const controller = makeMockController({ getRenderer: () => renderer });
+    render(controller);
+
+    const input = container.querySelector(".viewer-search-input") as HTMLInputElement;
+    const countEl = container.querySelector(".viewer-search-count") as HTMLElement;
+
+    setInputValue(input, "fox");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(countEl.textContent).toBe("3 results");
+  });
+
   it("zero results shows '0 results' count", async () => {
     const renderer = makeMockRenderer({ search: vi.fn().mockResolvedValue({ results: [], truncated: false }), goToResult: vi.fn(), renderResult: vi.fn(), clearSearch: vi.fn() });
     const controller = makeMockController({ getRenderer: () => renderer });

--- a/print/test/viewer/searchable-renderer.test-d.ts
+++ b/print/test/viewer/searchable-renderer.test-d.ts
@@ -12,7 +12,7 @@ import type { ContentRenderer, SearchableRenderer } from "../../src/viewer/types
 // Pin the exact SearchableRenderer signatures so no other type mismatch can
 // satisfy the @ts-expect-error vacuously.
 declare const _base: ContentRenderer;
-const _search: SearchableRenderer["search"] = async () => [];
+const _search: SearchableRenderer["search"] = async () => ({ results: [], truncated: false });
 const _goToResult: SearchableRenderer["goToResult"] = async () => {};
 const _clearSearch: SearchableRenderer["clearSearch"] = () => {};
 

--- a/print/test/viewer/spread-search-highlight.test.ts
+++ b/print/test/viewer/spread-search-highlight.test.ts
@@ -153,7 +153,7 @@ describe("spread search highlight (real SpreadController + pdf renderer)", () =>
     await controller.render();
 
     // Search "dog" → single result on page 2.
-    const results = await renderer.search!("dog");
+    const { results } = await renderer.search!("dog");
     const page2Result = results.find((r) => r.label === "Page 2");
     expect(page2Result).toBeDefined();
 
@@ -180,7 +180,7 @@ describe("spread search highlight (real SpreadController + pdf renderer)", () =>
     controller.enter(renderer.currentPage);
     await controller.render();
 
-    const results = await renderer.search!("dog");
+    const { results } = await renderer.search!("dog");
     const page2Result = results.find((r) => r.label === "Page 2");
     await renderer.goToResult!(page2Result!);
     await controller.goToPage(renderer.currentPage);

--- a/print/test/viewer/spread-search-highlight.test.ts
+++ b/print/test/viewer/spread-search-highlight.test.ts
@@ -153,7 +153,7 @@ describe("spread search highlight (real SpreadController + pdf renderer)", () =>
     await controller.render();
 
     // Search "dog" → single result on page 2.
-    const { results } = await renderer.search!("dog");
+    const { results } = await renderer.search!("dog"); // type-safety-ok: optional renderer API method, present in this test harness
     const page2Result = results.find((r) => r.label === "Page 2");
     expect(page2Result).toBeDefined();
 
@@ -180,9 +180,9 @@ describe("spread search highlight (real SpreadController + pdf renderer)", () =>
     controller.enter(renderer.currentPage);
     await controller.render();
 
-    const { results } = await renderer.search!("dog");
+    const { results } = await renderer.search!("dog"); // type-safety-ok: optional renderer API method, present in this test harness
     const page2Result = results.find((r) => r.label === "Page 2");
-    await renderer.goToResult!(page2Result!);
+    await renderer.goToResult!(page2Result!); // type-safety-ok: optional renderer API method, present in this test harness
     await controller.goToPage(renderer.currentPage);
 
     // Highlight is present on the spread.


### PR DESCRIPTION
Closes #1810

## Problem

The print viewer's EPUB full-document search (shipped in #1688) accumulated
every match across the whole spine with no upper bound: `search()` pushed every
`buildResult()` into `results` and then highlighted all of them in a single
synchronous burst. Searching a common token (e.g. `"the"`) in a large EPUB built
an unbounded `SearchResult[]` and painted thousands of epub.js SVG annotations at
once, which could jank or freeze the viewer.

The PDF renderer already capped at 200, but **silently** — the shared
`SearchPanel` had no truncation affordance, so a capped PDF search read as
"exactly 200 results" with no hint that more matched.

## Change

- Introduce a shared `MAX_SEARCH_RESULTS = 200` constant and a `SearchResponse`
  envelope (`{ results, truncated }`) in `types.ts`. The truncation fact now
  travels *with* the results it describes rather than living in renderer state,
  so the panel never has to read a stateful getter after the await and overlapping
  searches don't race.
- Cap EPUB search with the same check-before-push pattern PDF uses, and stop
  scanning further sections once the cap trips. The existing
  `finally { section.unload() }` still unloads the section where the cap trips
  mid-match-loop; the highlight burst is bounded automatically because it iterates
  only the (now-capped) `results`.
- Rework PDF's push-then-break into the precise check-before-push shape so
  `truncated` is only `true` when a genuine (MAX+1)th match is encountered — a
  document with *exactly* MAX matches reports `truncated: false`.
- `SearchPanel` surfaces truncation in the existing `.viewer-search-count` span:
  `First N results shown — refine your search` when truncated, otherwise the
  plain `"N results"` text. Because the panel is shared, this also fixes PDF's
  previously-silent cap — a deliberate, in-scope consequence.

All in-repo `search()` callers and existing tests are updated to the new envelope
shape in the same change so the tree stays compiling and green.

## Tests

New behavior tests cover the issue's acceptance criteria:

- **EPUB cap (AC2):** a section returning `MAX_SEARCH_RESULTS + 1` matches yields
  `results.length === MAX_SEARCH_RESULTS`, `truncated === true`, the section is
  still unloaded once, and the highlight burst paints exactly
  `MAX_SEARCH_RESULTS` annotations.
- **PDF cap:** matches exceeding the limit yield the capped count and
  `truncated === true`.
- **Panel affordance (AC3):** `truncated: true` renders the truncation message;
  `truncated: false` renders the plain count.
- Not-truncated companion cases for both renderers.

## Verification

- `run-lint.sh --app print` — PASS
- `run-unit-tests.sh --app print` (tsc build + vitest) — 561/561 PASS

Manual / QA (not auto-run): load a large EPUB, search a common token, confirm the
viewer does not jank, the highlight count is bounded, and the panel shows the
truncation affordance; repeat for a large PDF to confirm the panel now surfaces
the 200-cap.
