### PR TITLE
print: document intentional clearSearch optional chain at nav call sites

### DIFF
--- a/print/src/viewer/useViewerController.ts
+++ b/print/src/viewer/useViewerController.ts
@@ -315,6 +315,10 @@ export function useViewerController(
     async function goPrev() {
       if (controller.enabled) {
         if (!controller.canGoPrev) return;
+        // Optional chain is intentional: `renderer` is an un-narrowed ContentRenderer,
+        // where clearSearch is optional (types.ts). Only a SearchableRenderer — reached
+        // via isSearchable() — requires it. Do not drop the `?.`: a non-searchable
+        // renderer (e.g. image-archive) has no clearSearch.
         renderer.clearSearch?.();
         await controller.goPrev();
       } else {
@@ -326,6 +330,7 @@ export function useViewerController(
     async function goNext() {
       if (controller.enabled) {
         if (!controller.canGoNext) return;
+        // Intentional optional chain — see goPrev (un-narrowed ContentRenderer).
         renderer.clearSearch?.();
         await controller.goNext();
       } else {
@@ -336,6 +341,7 @@ export function useViewerController(
 
     async function goToPageNum(page: number): Promise<void> {
       if (controller.enabled) {
+        // Intentional optional chain — see goPrev (un-narrowed ContentRenderer).
         renderer.clearSearch?.();
         await controller.goToPage(page);
       } else {


### PR DESCRIPTION
Closes #1836

## What

The `goPrev`, `goNext`, and `goToPageNum` navigation handlers each call
`renderer.clearSearch?.()` using optional chaining. This is intentional but was
undocumented at the call sites. Each call now carries an inline comment
explaining that `renderer` here is an un-narrowed `ContentRenderer` — where
`clearSearch` is declared optional (`types.ts`) — in contrast to a
`SearchableRenderer`, reached via `isSearchable()`, where `clearSearch` is
required. The comment warns against dropping the `?.`: a non-searchable renderer
(e.g. image-archive) has no `clearSearch`.

The full explanation lives at the first site (`goPrev`); `goNext` and
`goToPageNum` carry a brief back-reference. The wording mirrors the existing
`ContentRenderer.clearSearch` comment in `types.ts`.

## Why

The dual convention (optional on `ContentRenderer`, required on the narrowed
`SearchableRenderer`) is correct but easy to misread. Without a note at the call
sites, a future maintainer might remove the optional chaining (a compile error
for non-searchable renderers) or assume the pattern is legacy and strip it
silently.

## File-path note for reviewers

Issue #1836 was filed against `print/src/viewer/shell.ts` (lines 305/316/326).
That file was **deleted by PR #1872** ("mount the viewer behind a React
component"); the three navigation handlers moved verbatim into
`print/src/viewer/useViewerController.ts`. The work is unchanged — only the file
and line numbers shifted. The issue's acceptance criteria reference the stale
`shell.ts` path; the comments land in `useViewerController.ts`.

## Verification

Comments-only change. `npm run build --prefix print` (`tsc && vite build`)
passes with no new errors.
