### PR TITLE
searchable-renderer.test-d.ts: spread an explicit required-only literal so the @ts-expect-error is non-vacuous

### DIFF
--- a/print/test/viewer/searchable-renderer.test-d.ts
+++ b/print/test/viewer/searchable-renderer.test-d.ts
@@ -3,15 +3,37 @@
  * SearchableRenderer. This file is included in tsconfig.json (not in vitest's
  * test glob) so tsc enforces it on every `npm run build`.
  *
- * Vacuity: temporarily add `renderResult: async () => {}` to the literal below
- * and verify tsc reports the @ts-expect-error directive as UNUSED — confirming
- * the sole cause of the error is the missing method.
+ * The spread source `_base` below is an explicit object literal listing only the
+ * REQUIRED ContentRenderer members (annotated `satisfies ContentRenderer`, which
+ * keeps its narrow inferred type rather than re-widening to ContentRenderer's
+ * optional surface). Because `_base` carries no `renderResult` key, the spread
+ * provably cannot supply renderResult — so the @ts-expect-error below can only be
+ * satisfied by the intended missing-member mismatch, never vacuously.
+ *
+ * Vacuity (one-time / manual check, not CI-enforced): temporarily add
+ * `renderResult: async () => {}` to the literal below and run
+ * `tsc --noEmit -p print/tsconfig.json`; tsc should then report the
+ * @ts-expect-error directive as UNUSED (TS2578) — confirming the sole cause of
+ * the error is the missing method.
  */
 import type { ContentRenderer, SearchableRenderer } from "../../src/viewer/types";
 
 // Pin the exact SearchableRenderer signatures so no other type mismatch can
 // satisfy the @ts-expect-error vacuously.
-declare const _base: ContentRenderer;
+const _base = {
+  init: async (_c: HTMLElement, _s: string | ArrayBuffer, _p?: string) => {},
+  goToPage: async (_p: number) => {},
+  goToPosition: async (_p: string) => {},
+  next: async () => {},
+  prev: async () => {},
+  pageCount: 0,
+  currentPage: 0,
+  canGoNext: false,
+  canGoPrev: false,
+  position: "",
+  positionLabel: "",
+  destroy: () => {},
+} satisfies ContentRenderer;
 const _search: SearchableRenderer["search"] = async () => [];
 const _goToResult: SearchableRenderer["goToResult"] = async () => {};
 const _clearSearch: SearchableRenderer["clearSearch"] = () => {};

--- a/print/test/viewer/searchable-renderer.test-d.ts
+++ b/print/test/viewer/searchable-renderer.test-d.ts
@@ -12,8 +12,8 @@
  *
  * Vacuity (one-time / manual check, not CI-enforced): temporarily add
  * `renderResult: async () => {}` to the literal below and run
- * `tsc --noEmit -p print/tsconfig.json`; tsc should then report the
- * that directive as unused (TS2578) — confirming the sole cause of
+ * `tsc --noEmit -p print/tsconfig.json`; tsc should then report that
+ * directive as unused (TS2578) — confirming the sole cause of
  * the error is the missing method.
  */
 import type { ContentRenderer, SearchableRenderer } from "../../src/viewer/types";

--- a/print/test/viewer/searchable-renderer.test-d.ts
+++ b/print/test/viewer/searchable-renderer.test-d.ts
@@ -7,13 +7,13 @@
  * REQUIRED ContentRenderer members (annotated `satisfies ContentRenderer`, which
  * keeps its narrow inferred type rather than re-widening to ContentRenderer's
  * optional surface). Because `_base` carries no `renderResult` key, the spread
- * provably cannot supply renderResult — so the @ts-expect-error below can only be
+ * provably cannot supply renderResult — so the suppress-error directive below can only be
  * satisfied by the intended missing-member mismatch, never vacuously.
  *
  * Vacuity (one-time / manual check, not CI-enforced): temporarily add
  * `renderResult: async () => {}` to the literal below and run
  * `tsc --noEmit -p print/tsconfig.json`; tsc should then report the
- * @ts-expect-error directive as UNUSED (TS2578) — confirming the sole cause of
+ * that directive as unused (TS2578) — confirming the sole cause of
  * the error is the missing method.
  */
 import type { ContentRenderer, SearchableRenderer } from "../../src/viewer/types";


### PR DESCRIPTION
Closes #1834

## Problem

`print/test/viewer/searchable-renderer.test-d.ts` is a compile-time contract
test: a `@ts-expect-error` directive asserts that a renderer missing
`renderResult` is **not** assignable to `SearchableRenderer`. The file is in
`print/tsconfig.json`'s `include`, so `tsc` enforces it on every build.

The literal was built by spreading `declare const _base: ContentRenderer`.
`ContentRenderer` declares `renderResult?()` as **optional**, so the spread
source's inferred type carried that optional member. The directive's correctness
then hinged on a subtle, version-sensitive detail of how TypeScript handles an
optional-in-spread against a required target member — risking that the
`@ts-expect-error` was satisfied by a *different* mismatch, or became vacuous.

## Change

Replace the `ContentRenderer`-typed spread source with an explicit object literal
that lists **only the required `ContentRenderer` members** and is annotated
`satisfies ContentRenderer` (not `: ContentRenderer`). `satisfies` keeps the
literal's narrow inferred type — which has no `renderResult` key — while still
type-checking conformance. Because `_base` provably cannot contribute
`renderResult`, the directive can only be satisfied by the intended
missing-member mismatch, never vacuously. The header comment is updated to
describe this mechanism and to keep the vacuity check framed as a one-time manual
`tsc --noEmit` confirmation.

## Verification

- `npx tsc --noEmit -p print/tsconfig.json` passes — the `@ts-expect-error` is
  still **used** (a real missing-`renderResult` error is suppressed) and the file
  remains in the build.
- Vacuity check: temporarily injecting `renderResult: async () => {}` into the
  literal makes `tsc` report the directive as **unused** (`TS2578`), confirming
  the missing method is the sole cause of the error.
