### PR TITLE
print: early-exit EPUB search() spine loop when the search epoch advances

### DIFF
--- a/print/src/viewer/epub.ts
+++ b/print/src/viewer/epub.ts
@@ -300,7 +300,7 @@ export function createEpubRenderer(
 
       const results: SearchResult[] = [];
       for (let i = 0; i < spineItems.length; i++) {
-        if (epoch !== _searchEpoch) break; // a newer search/clearSearch superseded us — stop loading sections
+        if (epoch !== _searchEpoch) break;
         const section = spineItems[i]!;
         try {
           try {

--- a/print/src/viewer/epub.ts
+++ b/print/src/viewer/epub.ts
@@ -300,6 +300,7 @@ export function createEpubRenderer(
 
       const results: SearchResult[] = [];
       for (let i = 0; i < spineItems.length; i++) {
+        if (epoch !== _searchEpoch) break; // a newer search/clearSearch superseded us — stop loading sections
         const section = spineItems[i]!;
         try {
           try {

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -806,6 +806,11 @@ describe("createEpubRenderer", () => {
       const renderer = await initRenderer();
 
       const p1 = renderer.search!("first");
+      // Let call-1 pass `await book.loaded.navigation` and park on the gated
+      // load() *inside* its loop, consuming the gate while _searchEpoch is still
+      // 1 — before call-2 bumps it. So call-1 is superseded mid-load and the
+      // post-loop epoch guard (not the new top-of-loop break) discards its burst.
+      await Promise.resolve();
       const p2 = renderer.search!("second");
 
       // call-2 runs to completion (its load resolves immediately).
@@ -942,6 +947,42 @@ describe("createEpubRenderer", () => {
         await p;
 
         // The aborted search must not have painted any highlights.
+        const highlightCfis = mockRendition.annotations.highlight.mock.calls.map((c) => c[0]);
+        expect(highlightCfis).not.toContain("cfi-A");
+      });
+
+      it("stops loading not-yet-visited spine sections once clearSearch advances the epoch mid-loop", async () => {
+        // s0's load parks on a gate so the search is mid-loop (inside iteration 0)
+        // when clearSearch() fires; s1/s2 are plain sections that must never load.
+        const s0: FakeSection = {
+          href: "ch0.xhtml",
+          unload: vi.fn(),
+          find: vi.fn().mockReturnValue([{ cfi: "cfi-A", excerpt: "fox" }]),
+          load: vi.fn() as ReturnType<typeof vi.fn>,
+        };
+        let releaseFirst!: () => void;
+        const gate = new Promise<void>((resolve) => { releaseFirst = resolve; });
+        s0.load.mockImplementationOnce(() => gate);
+        const s1 = makeSection("ch1.xhtml", [{ cfi: "cfi-1", excerpt: "fox" }]);
+        const s2 = makeSection("ch2.xhtml", [{ cfi: "cfi-2", excerpt: "fox" }]);
+        mockSpine.spineItems = [s0, s1, s2];
+        mockBook.navigation.get.mockReturnValue({ label: "X" });
+
+        const renderer = await initRenderer();
+
+        const p = renderer.search!("fox");
+        // Let search pass `await book.loaded.navigation` and park on s0.load()'s
+        // gate *inside* iteration 0 — so the epoch advances mid-loop, not pre-loop.
+        await Promise.resolve();
+        renderer.clearSearch!(); // bumps _searchEpoch; iteration 1's guard will break
+        releaseFirst();
+        await p;
+
+        // The in-flight section completed; the not-yet-visited ones never loaded.
+        expect(s0.load).toHaveBeenCalledTimes(1);
+        expect(s1.load).not.toHaveBeenCalled();
+        expect(s2.load).not.toHaveBeenCalled();
+        // And the superseded search painted no highlight (post-loop guard holds).
         const highlightCfis = mockRendition.annotations.highlight.mock.calls.map((c) => c[0]);
         expect(highlightCfis).not.toContain("cfi-A");
       });

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -958,9 +958,9 @@ describe("createEpubRenderer", () => {
           href: "ch0.xhtml",
           unload: vi.fn(),
           find: vi.fn().mockReturnValue([{ cfi: "cfi-A", excerpt: "fox" }]),
-          load: vi.fn() as ReturnType<typeof vi.fn>,
+          load: vi.fn() as ReturnType<typeof vi.fn>, // type-safety-ok: same pattern as existing load mocks; cast exposes Vitest mock API alongside FakeSection type
         };
-        let releaseFirst!: () => void;
+        let releaseFirst!: () => void; // type-safety-ok: Promise constructor assigns synchronously, so releaseFirst is set before any use
         const gate = new Promise<void>((resolve) => { releaseFirst = resolve; });
         s0.load.mockImplementationOnce(() => gate);
         const s1 = makeSection("ch1.xhtml", [{ cfi: "cfi-1", excerpt: "fox" }]);
@@ -970,11 +970,11 @@ describe("createEpubRenderer", () => {
 
         const renderer = await initRenderer();
 
-        const p = renderer.search!("fox");
+        const p = renderer.search!("fox"); // type-safety-ok: search always set after initRenderer; same pattern as other tests in this suite
         // Let search pass `await book.loaded.navigation` and park on s0.load()'s
         // gate *inside* iteration 0 — so the epoch advances mid-loop, not pre-loop.
         await Promise.resolve();
-        renderer.clearSearch!(); // bumps _searchEpoch; iteration 1's guard will break
+        renderer.clearSearch!(); // type-safety-ok: clearSearch always set after initRenderer — bumps _searchEpoch so iteration 1's guard breaks
         releaseFirst();
         await p;
 


### PR DESCRIPTION
Closes #1819

## What

The EPUB `search()` spine loop kept loading every remaining section after
`clearSearch()` (or a newer `search()`) advanced `_searchEpoch` mid-loop — the
existing epoch guard fired only **once, after the full loop completed**
(`print/src/viewer/epub.ts`). So a cleared or superseded search wasted
potentially many async `section.load()` calls before discovering the abort.

This adds a per-iteration epoch check as the first statement of the spine loop
body, so a cleared or superseded search stops loading not-yet-visited sections
immediately. The already-in-flight section (parked in `await section.load()`
when the clear happened) still completes its own `finally { section.unload() }`,
so no load is leaked. The post-loop guard is retained as a safety net (so
highlights are still never painted for a stale search).

## Changes

- **`print/src/viewer/epub.ts`** — one new line at the top of the spine loop:
  `if (epoch !== _searchEpoch) break;`.
- **`print/test/viewer/epub.test.ts`** — a new regression test
  (`"stops loading not-yet-visited spine sections once clearSearch advances the
  epoch mid-loop"`) proving not-yet-visited sections are never loaded while the
  in-flight section still loads/unloads, and the superseded search paints no
  highlight. Without the guard, `s1.load`/`s2.load` are called and the test
  fails — so it genuinely guards the fix.

## Deviation from the plan

The plan said "do **not** modify any existing test" and claimed the change
"matches the existing overlapping-search semantics." That was not accurate: the
early-break makes a superseded `search()` skip `load()` entirely, which broke the
pre-existing `"only the latest of two overlapping searches performs its
highlight burst"` test (`epub.test.ts:786`). That test gates the *first*
`load()` call and assumed the superseded call-1 consumes it; with the early-break
the gate migrated to call-2 and `await p2` hung (timeout).

The fix is a single line — `await Promise.resolve()` inserted between the two
`search()` calls — so call-1 enters its loop and parks on the gated `load()`
while `_searchEpoch` is still 1 (before call-2 bumps it), restoring the exact
parked-mid-load scenario the test intends. **No assertion in that test was
changed.** This necessary one-line edit is the scope deviation flagged for
office-hours accept/reject.

## Verification

- `npx vitest run --root print test/viewer/epub.test.ts` — **52 passed / 0
  failed** (includes the new test plus the existing overlapping-search / abort /
  "returns matches from every spine section" tests).
- `npx vitest run --root print` — **480 tests passed, 0 test failures.** The run
  reports 4 *suite-load* failures (`(0 test)` each:
  `test/viewer/spread-search-highlight.test.ts`, `test/viewer/pdf.test.ts`,
  `test/enrichment.test.ts`, `test/local-folder-ui.test.ts`). These are a
  local-environment limitation only — vite's fs-deny of
  `node_modules/pdfjs-dist/build/pdf.worker.min.mjs?url` (and happy-dom's
  `blob:` fetch), which prevents those suites from importing at all. They fail
  **identically on the clean baseline** (`git stash`) without this change, and
  none involve `epub.test.ts`. origin/main's CI is green, so these are
  local-only and CI will be green for this PR.
- `npm run build --prefix print` — succeeds (typechecks the source change).
