### PR TITLE
dispatch: test cleanup_stale_heartbeat_units with no WorkingDirectory= line

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -31444,6 +31444,25 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: cleanup_stale_heartbeat_units ran disable with no prior units"
 fi
 
+# 3d. AC2 (#2191) — [Service] section present but no WorkingDirectory= line →
+# early return at lib.sh:1805 ([ -n "$installed_workdir" ] || return 0): no
+# disable, returns 0.
+: > "$ehu_log"
+printf '%s\n' '[Service]' > "$ehu_svc"
+ehu_cleanup_rc=0
+(
+  export STUB_LOG="$ehu_log"
+  source "$SCRIPT_DIR/lib.sh"
+  cleanup_stale_heartbeat_units "$ehu_svc" "$ehu_tmp/main-worktree" "$ehu_tmp/bin/systemctl"
+) || ehu_cleanup_rc=$?
+assert_eq "cleanup_stale_heartbeat_units: no WorkingDirectory= → returns 0" "0" "$ehu_cleanup_rc"
+TOTAL=$((TOTAL + 1))
+if ! grep -q 'disable' "$ehu_log"; then
+  PASS=$((PASS + 1)); echo "  PASS: cleanup_stale_heartbeat_units no-op when WorkingDirectory= absent"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: cleanup_stale_heartbeat_units ran disable with no WorkingDirectory="
+fi
+
 rm -rf "$ehu_tmp"
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -31444,8 +31444,8 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: cleanup_stale_heartbeat_units ran disable with no prior units"
 fi
 
-# 3d. AC2 (#2191) — [Service] section present but no WorkingDirectory= line →
-# early return at lib.sh:1805 ([ -n "$installed_workdir" ] || return 0): no
+# 3d. AC4 (#2191) — [Service] section present but no WorkingDirectory= line →
+# early return at lib.sh:1810 ([ -n "$installed_workdir" ] || return 0): no
 # disable, returns 0.
 : > "$ehu_log"
 printf '%s\n' '[Service]' > "$ehu_svc"


### PR DESCRIPTION
Closes #2191

## Summary

Adds test case **3d** to `test-dispatch-scripts.sh` covering
`cleanup_stale_heartbeat_units` when the service unit has a `[Service]` section
but **no** `WorkingDirectory=` line — the early-return path at lib.sh:1805
(`[ -n "$installed_workdir" ] || return 0`).

PR #2180 added `cleanup_stale_heartbeat_units` (lib.sh:1793), which disables a
stale dispatch-heartbeat timer/service when the installed `WorkingDirectory=` no
longer matches the current main worktree. Existing cases 3a/3b/3c cover AC1 (path
differs → disable fires), AC2 (path matches → no disable), and AC3 (missing
service file → no-op). The "`[Service]` present but no `WorkingDirectory=` line"
path had no direct test; this closes that gap.

The new case writes a `[Service]` file with the `WorkingDirectory=` line omitted,
calls the helper, asserts it returns 0 and never invokes `disable`. It mirrors
the existing 3b service-file write and the 3c rc-capture + assertion structure.

This is a pure test addition — no production code changes.

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` →
3566/3566 passed, 0 failed (both new 3d assertions PASS).
