### PR TITLE
audio: test that a local track's media error skips storage-cache eviction

### DIFF
--- a/audio/test/player.test.ts
+++ b/audio/test/player.test.ts
@@ -315,6 +315,27 @@ describe("initPlayer", () => {
       expect(mockRemoveFile).toHaveBeenCalledWith("media/t1.mp3");
     });
 
+    it("skips storage-cache eviction for a local track's media error", async () => {
+      const player = initPlayer(audioEl, playlistEl);
+      player.add(localTrack);
+      player.add(track2);
+
+      await vi.waitFor(() => expect(audioEl.play).toHaveBeenCalledTimes(1));
+
+      audioEl.dispatchEvent(new Event("error"));
+
+      await vi.waitFor(() => expect(audioEl.play).toHaveBeenCalledTimes(2));
+      expect(mockResolveAudioSource).toHaveBeenCalledWith("media/t2.mp3");
+      expect(mockLogError).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          operation: "audio-element-error",
+          id: "local:song.mp3",
+        }),
+      );
+      expect(mockRemoveFile).not.toHaveBeenCalled();
+    });
+
     it("logs the MediaError and its code", async () => {
       const player = initPlayer(audioEl, playlistEl);
       player.add(track1);


### PR DESCRIPTION
Closes #1707

Adds a regression unit test pinning the `if (item.storagePath)` guard in the
audio player's media-element error handler (`audio/src/player.ts` `onError`).

A cloud track has a `storagePath` and lives in the IndexedDB storage cache, so
its media error evicts the cache entry via `removeFile`. A local-folder track
streams from disk, has no `storagePath`, and must skip that eviction. The cloud
path was already covered; the local skip-branch was only covered indirectly —
the existing `removeFile`-not-called test exercises the empty-queue early return
(`currentIndex === -1`), so the handler never reaches the guard.

The new test drives a **live local track** through `onError` so it actually
reaches the `if (item.storagePath)` branch, then asserts:

- `removeFile` is **not** called (the guard holds — no cache eviction for a
  local track),
- the element error is still logged (`operation: "audio-element-error"`, keyed
  on the local track's `id`), and
- the queue still advances to the next (cloud) track.

A regression dropping the guard — calling `removeFile(undefined)` on a local
track — would now fail this test. Verified locally: the audio build passes and
all 147 audio unit tests pass.

Test only; no production code changes.
