### PR TITLE
audio: parallelize generate-icons.mjs render calls with Promise.all

### DIFF
--- a/audio/scripts/generate-icons.mjs
+++ b/audio/scripts/generate-icons.mjs
@@ -14,7 +14,9 @@ async function render(svgName, size, outName) {
   console.log(`wrote icons/${outName} (${size}x${size})`);
 }
 
-await render("icon.svg", 192, "icon-192.png");
-await render("icon.svg", 512, "icon-512.png");
-await render("icon.svg", 180, "apple-touch-icon-180.png");
-await render("icon-maskable.svg", 512, "icon-maskable-512.png");
+await Promise.all([
+  render("icon.svg", 192, "icon-192.png"),
+  render("icon.svg", 512, "icon-512.png"),
+  render("icon.svg", 180, "apple-touch-icon-180.png"),
+  render("icon-maskable.svg", 512, "icon-maskable-512.png"),
+]);


### PR DESCRIPTION
Closes #1846

## Summary

`audio/scripts/generate-icons.mjs` regenerates the PWA icon PNGs from the source
SVGs. Its four `render()` calls ran sequentially via `await`. Each call is
independent — distinct input SVG names, distinct output filenames, and no
read-after-write dependency between them — so they can run concurrently.

This replaces the four sequential `await render(...)` statements with a single
`await Promise.all([...])`, so the four renders run in parallel. Arguments,
order, and output filenames/sizes are unchanged; the same four PNGs are produced.
`render`'s body, the `sharp` parameters, the per-render `console.log`, and
`audio/package.json` are untouched.

## Verification

- `node --check audio/scripts/generate-icons.mjs` — module still parses (ESM
  top-level await).
- Exactly one `Promise.all`, no remaining sequential `await render(` calls, all
  four render calls present with their original input/output names.

Runtime regeneration (`npm run icons --prefix audio`, which needs the native
`sharp` dependency not installed in the build worktree) is left for QA: it should
exit 0 and rewrite the four PNGs identical to the committed outputs, since the
source SVGs and render parameters are unchanged.

Surfaced by a review pass on PR #1838 (for #1040) and deferred as out of scope
there.
