### PR TITLE
office-hours: comment getOwnerQueueMetrics null propagation

### DIFF
--- a/office-hours/src/data.ts
+++ b/office-hours/src/data.ts
@@ -65,6 +65,7 @@ export async function getOwnerQueueMetrics(
     throw err;
   }
   if (!snap.exists()) return null;
+  // parseQueueMetrics returns null and logs on bad data; null propagates to renderQueueBand which shows the empty placeholder
   return parseQueueMetrics(snap.data());
 }
 

--- a/office-hours/src/data.ts
+++ b/office-hours/src/data.ts
@@ -65,7 +65,7 @@ export async function getOwnerQueueMetrics(
     throw err;
   }
   if (!snap.exists()) return null;
-  // parseQueueMetrics returns null and logs on bad data; null propagates to renderQueueBand which shows the empty placeholder
+  // parseQueueMetrics returns null and logs on bad data; null propagates to QueueMetricsPanel which shows the empty placeholder
   return parseQueueMetrics(snap.data());
 }
 


### PR DESCRIPTION
Closes #1642

## What

Adds a single clarifying inline comment above the
`return parseQueueMetrics(snap.data());` line in `getOwnerQueueMetrics`
(`office-hours/src/data.ts`).

## Why

`getOwnerQueueMetrics` returns `parseQueueMetrics(snap.data())` with no explicit
null handling. `parseQueueMetrics` returns `null` **and** calls `logError`
internally when the Firestore document is malformed or missing required fields.
That `null` then propagates up to `renderQueueBand`, which renders the empty
placeholder — the intended, correct behavior for bad data.

The intent was implicit: a reader had to open `parseQueueMetrics` to learn the
error is already logged before the `null` propagates. The `getOwnerReminders`
sibling handles its error case differently (per-item `[]` rather than a
whole-result `null`), making the asymmetry subtle. The inline comment makes the
intent explicit without changing behavior.

This is a documentation-only follow-up surfaced by the review pass on #1599 and
filed as out-of-scope for that PR.

## Scope

Comment-only. No change to `parseQueueMetrics`, `renderQueueBand`,
`getOwnerReminders`, control flow, return types, or any runtime behavior. No new
tests — there is no behavior to assert.

## Verification

- Workspace typecheck passes (`run-typecheck.sh --app office-hours`).
