### PR TITLE
Add Firestore composite index for issue-samples memberEmails query

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -35,6 +35,14 @@
         { "fieldPath": "memberEmails", "arrayConfig": "CONTAINS" },
         { "fieldPath": "timestamp", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "issue-samples",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "memberEmails", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "sampledAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
Closes #1623

## What

Adds one Firestore composite index for the `issue-samples` collection covering the
`memberEmails (CONTAINS) + sampledAt (DESCENDING)` query shape:

```json
{
  "collectionGroup": "issue-samples",
  "queryScope": "COLLECTION",
  "fields": [
    { "fieldPath": "memberEmails", "arrayConfig": "CONTAINS" },
    { "fieldPath": "sampledAt", "order": "DESCENDING" }
  ]
}
```

## Why

The `getOwnerIssueSamples` query (`office-hours/src/issue-data.ts`) filters
issue-samples documents with `where("memberEmails", "array-contains", user.email)`
and no `orderBy`. A lone `array-contains` filter is served by Firestore's automatic
single-field index, so the query needs no composite index today and does not throw a
missing-index error.

This index is added **preventatively**. The composite becomes load-bearing only once
a query adds `.orderBy("sampledAt", …)` — anticipated by the first production
sampler / panel work (#1537 / #1538) that drives real time-ordered queries. Landing
the index now means that future query deploys without an index-not-found error and
the per-namespace issue-samples collection is scan-safe at scale.

Unlike the `journal-legs` / `transactions` / `journal-entries` entries, this index
does **not** lead with `groupId (ASCENDING)` — the issue-samples query does not filter
on `groupId`, so the field set matches the query shape exactly.

## Verification

- `firestore.indexes.json` remains valid JSON with exactly one `issue-samples` entry
  whose fields are `memberEmails CONTAINS` then `sampledAt DESCENDING` (deterministic
  `jq` check in the plan's Verification section — passing).
- Acceptance criterion 2 (`firebase deploy --only firestore:indexes` against staging)
  is satisfied automatically by `.github/workflows/firestore-deploy.yml` on merge to
  `main`.
- Acceptance criterion 3 (live query returns without a missing-index error) is a
  QA / observe-in-production check requiring a deployed index.
