### PR TITLE
office-hours: cover getOwnerQueueMetrics falsy-email early return

### DIFF
--- a/office-hours/test/owner-queue-metrics.test.ts
+++ b/office-hours/test/owner-queue-metrics.test.ts
@@ -91,4 +91,13 @@ describe("getOwnerQueueMetrics", () => {
     const result = await getOwnerQueueMetrics(mockDb, mockNamespace, mockUser);
     expect(result).toBeNull();
   });
+
+  it("(e) falsy email — returns null without a Firestore read (AC1)", async () => {
+    const noEmailUser = { email: null } as import("firebase/auth").User;
+
+    const result = await getOwnerQueueMetrics(mockDb, mockNamespace, noEmailUser);
+    expect(result).toBeNull();
+    expect(mockGetDoc).not.toHaveBeenCalled();
+    expect(mockDoc).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #1650

## What

Adds the single missing unit test for `getOwnerQueueMetrics` in
`office-hours/test/owner-queue-metrics.test.ts`.

## Why

Issue #1650 asked for unit coverage of `getOwnerQueueMetrics`. A planning-time
relevance review found that PR #1657 already added this test file and covered
most of the acceptance criteria:

- **AC2** (doc `exists()` returns `false` → `null`) — existing test `(d)`.
- **AC3** (doc exists with valid data → `parseQueueMetrics(data)`) — existing test `(c)`.

The only genuinely uncovered criterion was **AC1**: a `User` with a falsy email
returns `null` *without making a Firestore call* — the early-return guard at
`office-hours/src/data.ts:59`. No existing test constructed a falsy-email user or
asserted that `getDoc`/`doc` are never invoked.

## Change

One new test case `(e)` constructs a `{ email: null }` user, calls
`getOwnerQueueMetrics`, and asserts the result is `null` and that neither
`mockGetDoc` nor `mockDoc` was called — proving the guard short-circuits before
any Firestore read. No production code changes; no existing tests modified.

## Verification

`npx vitest run --root office-hours` — 286 tests pass (36 files), including the
new AC1 case.
