### PR TITLE
dispatch: clarify TOTAL increment counts the inline grep check in cleanup_stale_heartbeat_units 3c/3d

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -31437,6 +31437,7 @@ ehu_cleanup_rc=0
   cleanup_stale_heartbeat_units "$ehu_missing_svc" "$ehu_tmp/main-worktree" "$ehu_tmp/bin/systemctl"
 ) || ehu_cleanup_rc=$?
 assert_eq "cleanup_stale_heartbeat_units: missing unit → returns 0" "0" "$ehu_cleanup_rc"
+# Counts the inline grep check below; the assert_eq above counts itself.
 TOTAL=$((TOTAL + 1))
 if ! grep -q 'disable' "$ehu_log"; then
   PASS=$((PASS + 1)); echo "  PASS: cleanup_stale_heartbeat_units no-op when no prior units"
@@ -31456,6 +31457,7 @@ ehu_cleanup_rc=0
   cleanup_stale_heartbeat_units "$ehu_svc" "$ehu_tmp/main-worktree" "$ehu_tmp/bin/systemctl"
 ) || ehu_cleanup_rc=$?
 assert_eq "cleanup_stale_heartbeat_units: no WorkingDirectory= → returns 0" "0" "$ehu_cleanup_rc"
+# Counts the inline grep check below; the assert_eq above counts itself.
 TOTAL=$((TOTAL + 1))
 if ! grep -q 'disable' "$ehu_log"; then
   PASS=$((PASS + 1)); echo "  PASS: cleanup_stale_heartbeat_units no-op when WorkingDirectory= absent"


### PR DESCRIPTION
Closes #2208

## What

Add a one-line clarifying comment above the standalone `TOTAL=$((TOTAL + 1))`
in cases 3c and 3d of the `cleanup_stale_heartbeat_units` test block in
`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`.

## Why

A review pass on PR #2202 misread the standalone `TOTAL=$((TOTAL + 1))` lines
in these two cases as a double-count of the preceding `assert_eq` — which itself
increments `TOTAL` internally per the harness at `test-dispatch-scripts.sh:17`.

It is **not** a double-count. The standalone increment counts the separate
inline `if ! grep -q 'disable' "$ehu_log"` assertion that follows it; that check
increments `PASS`/`FAIL` directly and never calls `assert_eq`. There was no
inflated `TOTAL` and no behavior bug — the confusion was purely visual, caused
by the standalone increment sitting immediately after an `assert_eq`.

The comment makes the intent unambiguous:

```
# Counts the inline grep check below; the assert_eq above counts itself.
```

## Verification

Comment-only change, so `PASS`/`FAIL`/`TOTAL` are unchanged. The suite is its
own oracle: `.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`
reports `Results: 3570/3570 passed, 0 failed` (exit 0), confirming the counts
remain correct. CI runs this script directly via
`.github/workflows/unit-tests.yml`.
