### PR TITLE
router: getServerSnapshot returns a fresh frozen snapshot per call

### DIFF
--- a/router/src/location-store.ts
+++ b/router/src/location-store.ts
@@ -30,15 +30,6 @@ const listeners = new Set<() => void>();
 let cachedSnapshot: Snapshot | null = null;
 let cachedKey: string | null = null;
 
-/**
- * Stable default snapshot for `getServerSnapshot`. Returned by reference every
- * call so it is referentially stable, matching the client-side caching
- * contract. This is cheap insurance so a future `hydrateRoot`/prerender cannot
- * throw because `getSnapshot` touched the global `location` during SSR. Full
- * SSR location handling is out of scope.
- */
-const SERVER_SNAPSHOT: Snapshot = { path: "/", params: new URLSearchParams() };
-
 function emit(): void {
   for (const listener of listeners) listener();
 }
@@ -69,8 +60,25 @@ export function getSnapshot(): Snapshot {
   return cachedSnapshot;
 }
 
+/**
+ * Returns a fresh frozen snapshot on every call. Two properties protect SSR
+ * callers from each other:
+ *
+ * (a) Fresh allocation (primary protection): each call gets its own object, so
+ *     one caller mutating `params` cannot affect any other call's snapshot.
+ * (b) `Object.freeze` (shallow secondary defense): blocks reassignment of
+ *     `path` and `params` on the returned object, but does NOT prevent
+ *     URLSearchParams methods (`.set`, `.delete`, etc.) from mutating the
+ *     instance — the primary protection above is what prevents cross-call
+ *     contamination.
+ *
+ * Referential stability is not required here: React's SSR/hydration path does
+ * not compare `getServerSnapshot` results across calls. Only the client-side
+ * `getSnapshot` path requires it (handled by the `cachedSnapshot`/`cachedKey`
+ * machinery above).
+ */
 export function getServerSnapshot(): Snapshot {
-  return SERVER_SNAPSHOT;
+  return Object.freeze({ path: "/", params: new URLSearchParams() });
 }
 
 export function navigate(href: string, opts?: { replace?: boolean }): void {

--- a/router/src/location-store.ts
+++ b/router/src/location-store.ts
@@ -77,7 +77,7 @@ export function getSnapshot(): Snapshot {
  * `getSnapshot` path requires it (handled by the `cachedSnapshot`/`cachedKey`
  * machinery above).
  */
-export function getServerSnapshot(): Snapshot {
+export function getServerSnapshot(): Readonly<Snapshot> {
   return Object.freeze({ path: "/", params: new URLSearchParams() });
 }
 

--- a/router/test/location-store.test.ts
+++ b/router/test/location-store.test.ts
@@ -70,11 +70,25 @@ describe("location-store", () => {
     expect(after.path).toBe("/new-path");
   });
 
-  it("getServerSnapshot returns a stable default snapshot", () => {
+  it("getServerSnapshot returns a default snapshot with correct content", () => {
     const server = getServerSnapshot();
     expect(server.path).toBe("/");
     expect([...server.params]).toEqual([]);
-    expect(Object.is(getServerSnapshot(), getServerSnapshot())).toBe(true);
+  });
+
+  it("getServerSnapshot returns a distinct object on each call", () => {
+    expect(Object.is(getServerSnapshot(), getServerSnapshot())).toBe(false);
+  });
+
+  it("getServerSnapshot isolates callers: mutating one call's params does not affect the next", () => {
+    const first = getServerSnapshot();
+    first.params.set("a", "1");
+    const second = getServerSnapshot();
+    expect([...second.params]).toEqual([]);
+  });
+
+  it("getServerSnapshot returns a frozen object", () => {
+    expect(Object.isFrozen(getServerSnapshot())).toBe(true);
   });
 
   it("subscribed callback fires on navigate and stops after unsubscribe", () => {


### PR DESCRIPTION
Closes #2015

## What

`getServerSnapshot()` in `router/src/location-store.ts` previously returned a
module-level singleton `Snapshot` by reference on every call. That singleton's
`params` field is a shared mutable `URLSearchParams`, so any SSR caller that
follows the spec and mutates the returned `params` (`.set()`, `.delete()`,
`.append()`) would corrupt the singleton for every subsequent
`getServerSnapshot()` call in the same Node.js process — the module cache is
shared across requests.

This PR makes cross-call isolation structural: `getServerSnapshot()` now
allocates and returns a **fresh, frozen** snapshot on each call.

## Why

No active bug exists today — usage is client-only and `getServerSnapshot` is
only React's cheap hydration insurance via `useSyncExternalStore`. But the
shared-mutable-singleton design is a latent correctness hazard for any future
SSR adoption. Returning a fresh object per call removes the hazard at the
source.

Referential stability across `getServerSnapshot` calls is **not** required:
React's `useSyncExternalStore` only requires the client `getSnapshot` path to be
referentially stable (to avoid an infinite render loop). `getServerSnapshot` is
invoked by React's SSR/hydration APIs, which do not compare its result across
calls. A fresh object per call is safe and correct.

## Changes

- `router/src/location-store.ts`: delete the `SERVER_SNAPSHOT` singleton (and its
  now-stale doc comment); rewrite `getServerSnapshot()` to return
  `Object.freeze({ path: "/", params: new URLSearchParams() })` with a doc
  comment explaining the isolation guarantee, the shallow nature of
  `Object.freeze`, and why referential stability is unneeded here.
- `router/test/location-store.test.ts`: replace the old referential-stability
  assertion (now inverted by design) with strictly stronger tests — default
  content preserved, distinct objects per call, cross-call mutation isolation,
  and frozen result.

The client path (`getSnapshot`, `subscribe`, `navigate`, and the
`cachedSnapshot`/`cachedKey` caching contract) is unchanged.

## Verification

`npx vitest run --root router` — 74 tests pass, including the new isolation /
distinctness / frozen assertions and the unchanged client-path suite.
