### PR TITLE
budget-etl: name concrete removal condition on legacy virtualTransactionRules seed

### DIFF
--- a/budget-etl/main.go
+++ b/budget-etl/main.go
@@ -223,13 +223,21 @@ func virtualStmtPrefix(targetInstitution, targetAccount string) string {
 
 // seedLegacyVirtualTransactionRules seeds the legacy Synchrony->pet rule when
 // vrules is nil (absent in JSON from a pre-refactor snapshot). An explicit empty
-// slice is left alone. MIGRATION: deletable once all snapshots carry
-// virtualTransactionRules.
+// slice is left alone.
+//
+// MIGRATION (#1709): delete this helper and its two call sites (runInputJSON,
+// runMerge) once the real snapshot on the network share carries
+// virtualTransactionRules — observable as the `virtualTransactionRules` key
+// being present in the decrypted .benc snapshot. budget-etl writes vrules back
+// into every output snapshot, so the first successful run over the real
+// snapshot satisfies this; after that this nil branch is dead code. Backstop
+// date: 2026-12-15 (six months after #1277/#1690 merged 2026-06-15), by which
+// the real snapshot is guaranteed updated.
 func seedLegacyVirtualTransactionRules(vrules []export.VirtualTransactionRule) []export.VirtualTransactionRule {
 	if vrules != nil {
 		return vrules
 	}
-	log.Printf("MIGRATION: snapshot has no virtualTransactionRules; seeding legacy Synchrony->pet rule")
+	log.Printf("MIGRATION (#1709): snapshot has no virtualTransactionRules; seeding legacy Synchrony->pet rule")
 	return []export.VirtualTransactionRule{{
 		Institution:         "pnc",
 		Account:             "5111",


### PR DESCRIPTION
Closes #1709

## What

Replace the open-ended `MIGRATION` note on `seedLegacyVirtualTransactionRules`
in `budget-etl/main.go` with a concrete, observable removal condition, and link
it to tracking issue #1709.

The helper (added by PR #1690 for #1277) seeds a legacy Synchrony→pet
virtual-transaction rule when a snapshot's `virtualTransactionRules` field is
`nil` (a pre-refactor snapshot). Its old note —
`MIGRATION: deletable once all snapshots carry virtualTransactionRules.` — named
no concrete trigger, so the migration code had no anchor for its own deletion.

## Change (documentation-only)

- **Comment:** the new `MIGRATION (#1709)` note names what to delete (the helper
  plus its two call sites, `runInputJSON` and `runMerge`), the observable event
  trigger (the real network-share snapshot carrying `virtualTransactionRules` —
  the `virtualTransactionRules` key present in the decrypted `.benc`, which
  `budget-etl` writes back into every output snapshot), and a backstop date of
  `2026-12-15` (six months after #1277/#1690 merged on 2026-06-15).
- **Log line:** the companion `log.Printf` now carries the same `MIGRATION (#1709)`
  reference so log output is traceable to the issue.

No behavioral change: this edits a comment and a log-string literal only. The
actual deletion of the helper and its call sites is the follow-up work gated on
the removal condition (out of scope here).

## Verification

`go -C budget-etl build/vet/test ./...` all pass.
