### PR TITLE
dispatch: sanction CI-equivalent vitest invocation for plan verification

### DIFF
--- a/.claude/rules/sandbox.md
+++ b/.claude/rules/sandbox.md
@@ -129,8 +129,22 @@ doesn't match rules like `Bash(npx vitest:*)`. Use flags that accept a directory
 instead:
 - `npm run build --prefix print` (npm `--prefix` flag)
 - `npm ci --prefix print`
-- `npx vitest run --root print` (vitest `--root` flag)
 - For tests, deploys, QA: use the wrapper scripts which handle directory context
+
+For app vitest suites, do **not** root at the app directory (`--root print`):
+that scopes vite's `server.fs.allow` to `print/`, so root-hoisted `?url` asset
+imports (e.g. `pdfjs-dist`'s worker, hoisted to the worktree-root `node_modules`
+by npm workspaces) are denied and correct changes false-fail. Instead root at the
+worktree/repo root and select the app with `--project`:
+
+- Generic form: `npx vitest run --project <app> --root <repo_root>`
+- From a worktree root: `npx vitest run --project print --root .`
+
+Rooting at the repo root keeps `server.fs.allow` covering the hoisted-to-root
+`node_modules`, so those `?url` asset imports resolve. This is also what CI's
+`run-unit-tests.sh` runs (`npx vitest run --project <app> --root "$REPO_ROOT"`),
+and it is the form plan-verification (```verify```) blocks for app test suites
+should use. The `Bash(npx vitest:*)` wildcard already matches it.
 
 ### `git -C /path` is auto-approved for worktrees
 

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -343,7 +343,11 @@ returns — must contain:
 - A **Verification** section — how to test the change end-to-end. Put
   deterministic, CI-safe, auto-runnable checks (test-suite invocations,
   typechecks, builds) in fenced ` ```verify ` blocks so `/implement`
-  auto-executes them before opening the PR. Keep manual steps, observe-in-
+  auto-executes them before opening the PR. Invoke an app's unit-test suite as
+  `npx vitest run --project <app> --root <repo_root>` (the CI-equivalent form),
+  never `npx vitest run --root <app>` — rooting at the app directory scopes
+  vite's `server.fs.allow` to it and denies root-hoisted `?url` asset imports
+  (e.g. `pdfjs-dist`'s worker). Keep manual steps, observe-in-
   production checks, live-systemd verification, and judgment calls as **prose** —
   `/implement` skips those, leaving them for QA and humans.
 - A clean-context **plan preface** (below), so the `implement` worker executes
@@ -504,7 +508,7 @@ with these substitutions:
 > - Ensure that the plan file is concise enough to scan quickly, but detailed enough to execute effectively
 > - Name the critical files to be modified. For changes that repeat a pattern across many files, describe the pattern once and list a few representative paths — do not enumerate every file or line number
 > - Reference existing functions and utilities you found that should be reused, with their file paths
-> - Include a verification section describing how to test the changes end-to-end. Put deterministic, CI-safe, auto-runnable checks (test-suite invocations, typechecks, builds) in fenced ` ```verify ` blocks so `/implement` auto-executes them before opening the PR. Keep manual steps, observe-in-production checks, live-systemd verification, and judgment calls as **prose** — `/implement` skips those, leaving them for QA and humans.
+> - Include a verification section describing how to test the changes end-to-end. Put deterministic, CI-safe, auto-runnable checks (test-suite invocations, typechecks, builds) in fenced ` ```verify ` blocks so `/implement` auto-executes them before opening the PR. Invoke an app's unit-test suite as `npx vitest run --project <app> --root <repo_root>` (the CI-equivalent form), never `npx vitest run --root <app>` — rooting at the app directory scopes vite's `server.fs.allow` to it and denies root-hoisted `?url` asset imports (e.g. `pdfjs-dist`'s worker). Keep manual steps, observe-in-production checks, live-systemd verification, and judgment calls as **prose** — `/implement` skips those, leaving them for QA and humans.
 
 ### Intentionally NOT adopted
 


### PR DESCRIPTION
Closes #2219

## Problem

The dispatch plan-verification invocation `npx vitest run --root print` is
structurally broken for this repo's hoisted npm-workspace layout. `pdfjs-dist`
is hoisted to the **worktree-root** `node_modules` (npm workspaces;
`print/node_modules` does not exist on a fresh worktree). With `--root print`,
vite scopes `server.fs.allow` to `print/`, so the `?url` import of the
root-hoisted worker `node_modules/pdfjs-dist/build/pdf.worker.min.mjs?url` is
denied. Four print suites that import that path (directly or transitively)
error at import time, so a print issue whose plan verify block uses
`--root print` false-fails a correct, CI-green change and routes it into the
office-hours park lane (discovered on #2006).

CI's `run-unit-tests.sh` does not hit this: it runs
`npx vitest run --project <app> --root "$REPO_ROOT"` (rooted at the repo root),
so `fs.allow` covers the hoisted `node_modules` and the worker resolves. The
divergence was that `.claude/rules/sandbox.md` documented the worktree-scoped
`--root print` as the sanctioned/auto-approved pattern — the structurally wrong
form.

## Change

- **`.claude/rules/sandbox.md`** — replace the `npx vitest run --root print`
  bullet with the CI-equivalent invocation
  `npx vitest run --project <app> --root <repo_root>` (concretely
  `npx vitest run --project print --root .` from a worktree root), with a
  rationale: rooting at the repo root keeps `server.fs.allow` covering the
  hoisted-to-root `node_modules` so root-hoisted `?url` asset imports resolve,
  matching what CI runs. Noted as the form plan Verification blocks for app
  suites should use.
- **`.claude/skills/plan-issue/SKILL.md`** — add the same one-clause instruction
  to both copies of the plan-comment output schema's Verification bullet (the
  main schema and the verbatim "Plan artifact" appendix), so a built-in `Plan`
  subagent — which never reads `.claude/rules/sandbox.md` — authors the correct
  verify block from the inline schema alone.

The `Bash(npx vitest:*)` wildcard in `.claude/settings.json` already matches the
corrected command, so no permission change is needed.

## Out of scope

- `.claude/settings.json` (wildcard already matches; a narrower rule would only
  risk breaking the existing match).
- Correcting #2006's historical plan comment — it has already advanced to a
  draft PR, so its stale verify block is inert (verify blocks run only in the
  implement phase). Criterion 4 is instead validated empirically below.

## Verification

All ` ```verify ` blocks pass from the worktree root:

- The CI-equivalent command passes the four print suites the broken form
  false-failed (`test/enrichment.test.ts`, `test/local-folder-ui.test.ts`,
  `test/viewer/pdf.test.ts`, `test/viewer/spread-search-highlight.test.ts`) —
  78 tests across 4 files passed.
- `sandbox.md` and `plan-issue/SKILL.md` both document the corrected
  `--project … --root` form.
