### PR TITLE
file-issue: apply the configured epic label to parent epics

### DIFF
--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -377,6 +377,41 @@ it is split — finalize each sub-issue instead.
 gh issue edit <N> --add-assignee @me --add-label "help wanted"
 ```
 
+### Epic label
+
+Apply the configured epic label only when `<N>` IS a parent epic. Leaf-vs-epic is
+determined solely by whether the Step 1 sub-issue fetch returned a non-empty list
+— never by body self-description. Concretely, `<N>` is a parent epic when:
+
+- **issue number mode** — its own Step 1 sub-issue fetch (`:74-77`) returned a
+  non-empty list.
+- **description mode** — Step 3f decomposition fired and created sub-issues for
+  `<N>`, so `<N>` is the parent epic (see Step 7, `CREATED <N>` = parent epic).
+
+Step 6 runs for the parent AND each sub-issue, so this sub-step fires for the
+PARENT ONLY. A leaf issue receives no epic label, and the sub-issues themselves —
+whose own sub-issue fetch is empty when the loop finalizes them — receive no epic
+label either.
+
+The label is sourced from config (single source of truth). Read the `epic` config
+type: `no-config` → apply NO epic label (the feature stays inert); otherwise apply
+each label in the `.labels[]` array to the parent `<N>`:
+
+```bash
+EPIC_CONFIG=$(.claude/skills/dispatch-propagate/scripts/dispatch-config-load epic)
+if [[ "$EPIC_CONFIG" != "no-config" ]]; then
+  while IFS= read -r epic_label; do
+    [[ -n "$epic_label" ]] && gh issue edit <N> --add-label "$epic_label"
+  done < <(jq -r '.labels[]' <<<"$EPIC_CONFIG")
+fi
+```
+
+End-to-end auto-resolution ADDITIONALLY requires the user's machine-local
+`dispatch.config/epic.json` (e.g. `{"labels": ["epic"]}` — see
+`.claude/skills/dispatch-propagate/scripts/epic.example.json`). The `/file-issue`
+change alone is INERT without it: `dispatch-config-load epic` returns `no-config`,
+so no label is applied.
+
 ### Type classification
 
 Classify from title and body. Type and topic are orthogonal axes.

--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -364,9 +364,10 @@ the new issue's `<N>`.
 
 ## Step 6. Finalize — assign, label, classify
 
-Finalize `<N>` (and each sub-issue) by assigning `@me`, applying `help wanted`, and
-applying at most one type label and at most one topic label. The Type classification
-subsection below defines when the type label is zero.
+Finalize `<N>` (and each sub-issue) by assigning `@me`, applying `help wanted`,
+applying the epic label when `<N>` is a parent epic, and applying at most one type
+label and at most one topic label. The Type classification subsection below defines
+when the type label is zero.
 
 A leaf issue that hit the decomposition gate (3f) must not be finalized before
 it is split — finalize each sub-issue instead.
@@ -410,7 +411,9 @@ End-to-end auto-resolution ADDITIONALLY requires the user's machine-local
 `dispatch.config/epic.json` (e.g. `{"labels": ["epic"]}` — see
 `.claude/skills/dispatch-propagate/scripts/epic.example.json`). The `/file-issue`
 change alone is INERT without it: `dispatch-config-load epic` returns `no-config`,
-so no label is applied.
+so no label is applied. Each label listed in `.labels[]` must be pre-created in
+the repo before `/file-issue` runs (e.g. `gh label create <name>`) — `gh issue
+edit --add-label` fails non-zero for labels that do not exist.
 
 ### Type classification
 


### PR DESCRIPTION
Closes #2057

## What

`/file-issue` decomposes an over-large issue into a parent epic + sub-issues (Step 3f), and treats an existing issue that already has sub-issues as a parent epic — but it never applied an **epic label** to that parent. Step 6 finalize stamped only `help wanted`, at most one type label, and at most one topic label.

This broke the dispatch epic-resolution path: `dispatch-epic-resolved-candidate` gates on the issue carrying a configured epic label *before* it inspects the sub-issues. With nothing in the filing pipeline applying that label, a verifiably-complete parent epic was not routed to `/resolve-epic`; it fell through to `/plan-issue` (nothing to plan) and had to be office-hours-parked for a manual close. Observed on epic #1873.

## Changes

- **`.claude/skills/file-issue/SKILL.md` Step 6** — new `### Epic label` subsection. It applies the configured epic label to the **parent epic only**, gated on the canonical leaf-vs-epic signal (non-empty Step 1 sub-issue fetch / Step 3f decomposition), and explicitly excludes leaf issues and sub-issues. The label name is read from `dispatch-config-load epic`, mirroring the resolution-side reader in `dispatch-epic-resolved-candidate` so the filing side and the resolver share **one source of truth**. `no-config` → no label applied (the feature stays inert).
- **Repo-side `epic` label created** (live `gh label create`, repo metadata — no diff) so a future `--add-label "epic"` succeeds.

## Scope boundary

End-to-end auto-resolution **additionally** requires the user's machine-local, uncommitted `dispatch.config/epic.json` with a `labels` array — that config is user-controlled and out of scope. In this repo `dispatch-config-load epic` returns `no-config`, so the Step 6 change is **inert here** (applies no label) until the config exists. The new subsection documents this requirement. No change to `dispatch-epic-resolved-candidate`, `dispatch-route`, or `/resolve-epic`.

## Verification

SKILL.md prose plus repo metadata — no CI-testable code surface, so the plan defines no `verify` block (confirmed: `dispatch-run-verification` exits 3, build proceeds unchanged). Repo `epic` label confirmed present via `gh label list --search epic`.
