### PR TITLE
analyticsutil: cover ReferenceError in web-vital callback re-throw test

### DIFF
--- a/analyticsutil/test/index.test.ts
+++ b/analyticsutil/test/index.test.ts
@@ -395,7 +395,7 @@ describe("web-vitals reporting", () => {
   ])(
     "re-throws %s from logEvent inside web-vital callback",
     (_name: string, ErrorCtor: new (msg: string) => Error) => {
-      vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never);
+      vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never); // type-safety-ok: test mock cast, matches established pattern in file
       vi.mocked(logEvent).mockImplementation(() => {
         throw new ErrorCtor("invalid argument");
       });
@@ -408,7 +408,7 @@ describe("web-vitals reporting", () => {
         value: 1800,
         rating: "good",
         id: "v4-abc",
-      } as unknown as Parameters<typeof capturedCallback>[0];
+      } as unknown as Parameters<typeof capturedCallback>[0]; // type-safety-ok: cast for synthetic metric fixture, matches established pattern in file
 
       expect(() => capturedCallback(fakeMetric)).toThrow(ErrorCtor);
     },

--- a/analyticsutil/test/index.test.ts
+++ b/analyticsutil/test/index.test.ts
@@ -389,24 +389,30 @@ describe("web-vitals reporting", () => {
     expect(sink).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ operation: "analytics-web-vitals" }));
   });
 
-  it("re-throws TypeError from logEvent inside web-vital callback", () => {
-    vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never);
-    vi.mocked(logEvent).mockImplementation(() => {
-      throw new TypeError("invalid argument");
-    });
+  it.each([
+    ["TypeError", TypeError],
+    ["ReferenceError", ReferenceError],
+  ])(
+    "re-throws %s from logEvent inside web-vital callback",
+    (_name: string, ErrorCtor: new (msg: string) => Error) => {
+      vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never);
+      vi.mocked(logEvent).mockImplementation(() => {
+        throw new ErrorCtor("invalid argument");
+      });
 
-    initAnalytics(validApp);
+      initAnalytics(validApp);
 
-    const capturedCallback = vi.mocked(onLCP).mock.calls[0][0];
-    const fakeMetric = {
-      name: "LCP",
-      value: 1800,
-      rating: "good",
-      id: "v4-abc",
-    } as unknown as Parameters<typeof capturedCallback>[0];
+      const capturedCallback = vi.mocked(onLCP).mock.calls[0][0];
+      const fakeMetric = {
+        name: "LCP",
+        value: 1800,
+        rating: "good",
+        id: "v4-abc",
+      } as unknown as Parameters<typeof capturedCallback>[0];
 
-    expect(() => capturedCallback(fakeMetric)).toThrow(TypeError);
-  });
+      expect(() => capturedCallback(fakeMetric)).toThrow(ErrorCtor);
+    },
+  );
 });
 
 describe("initAnalyticsSafe", () => {


### PR DESCRIPTION
Closes #1768

## Summary

Adds `ReferenceError` coverage to the `analyticsutil` web-vital callback re-throw
test, closing the gap where only `TypeError` was exercised.

The web-vitals → GA4 instrumentation routes `logEvent` errors through
`classifyError` (`errorutil/src/classify.ts`): "programmer" errors (`TypeError`
**or** `ReferenceError`) are re-thrown, while non-programmer errors are reported to
the error sink without propagating. The existing test
(`re-throws TypeError from logEvent inside web-vital callback`) covered only the
`TypeError` half of that branch, so a `ReferenceError` could have been silently
swallowed had the classification logic ever regressed.

## Change

`analyticsutil/test/index.test.ts` — the single `it(...)` re-throw test is replaced
with an `it.each` parameterized over both programmer-error constructors
`[TypeError, ReferenceError]`, running the same arrange/act/assert body once per
error type. This adds the `ReferenceError` case with no test duplication.

No production code changes — `classifyError` already treats `ReferenceError` as a
programmer error.

## Verification

`npm test --prefix analyticsutil` — 26 passed, including both parameterized titles:

- `re-throws TypeError from logEvent inside web-vital callback`
- `re-throws ReferenceError from logEvent inside web-vital callback`
