### PR TITLE
useViewerController onSearchNavigate: narrow to SearchableRenderer, drop renderResult?.()

### DIFF
--- a/print/src/viewer/useViewerController.ts
+++ b/print/src/viewer/useViewerController.ts
@@ -472,8 +472,8 @@ export function useViewerController(
     function onSearchNavigate() {
       if (controller.enabled) {
         controller.goToPage(renderer.currentPage).catch(handleRenderError);
-      } else {
-        renderer.renderResult?.().catch(handleRenderError);
+      } else if (isSearchable(renderer)) {
+        renderer.renderResult().catch(handleRenderError);
       }
       syncNav();
     }


### PR DESCRIPTION
Closes #2222

## Summary

Completes #1817's compile-time `renderResult` guarantee at the only call site.

#1817 made omitting `renderResult` on a searchable renderer a compile error at
the renderer-*definition* site (`SearchableRenderer` declares the four search
methods as required). That guarantee did not reach the *call* site:
`onSearchNavigate` in `print/src/viewer/useViewerController.ts` still used
optional chaining (`renderer.renderResult?.()`), where `renderer` is a
`ContentRenderer` whose `renderResult` is optional. The `?.` was type-permitted
and would silently no-op if `renderResult` were ever absent — exactly the
failure mode #1817 set out to eliminate, relocated to the call site.

## Change

Narrow `renderer` to `SearchableRenderer` via the existing `isSearchable` guard
and drop the optional chain:

```ts
function onSearchNavigate() {
  if (controller.enabled) {
    controller.goToPage(renderer.currentPage).catch(handleRenderError);
  } else if (isSearchable(renderer)) {
    renderer.renderResult().catch(handleRenderError);
  }
  syncNav();
}
```

This reuses the `isSearchable()` narrowing idiom already present elsewhere in the
file — no new guard. After narrowing, `renderResult()` is required, so the
non-optional call typechecks and a future regression that drops `renderResult`
is caught by the type checker.

## Behavior

Runtime-behavior-preserving type hygiene. A non-searchable renderer previously
hit the `?.` no-op and is now skipped — identical observable effect.
`onSearchNavigate` only fires for searchable content in practice, so the guard
is true at every real call.

## Verification

- `npm run build --prefix print` — typecheck + build pass (the narrowing is what
  makes the non-optional call compile).
- `npx vitest run --root print test/viewer/useViewerController.test.tsx` — 32
  tests pass; the existing `onSearchNavigate` test mocks all four search methods,
  so `isSearchable()` returns true and the single-mode assertion still holds.
