### PR TITLE
audio: controlled queue checkbox in Home

### DIFF
--- a/audio/src/pages/Home.tsx
+++ b/audio/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { Button, Checkbox } from "@commons-systems/ds";
 import { DataIntegrityError } from "@commons-systems/firestoreutil/errors";
 import { logError } from "@commons-systems/errorutil/log";
@@ -31,33 +31,40 @@ function formatBytes(bytes: number): string {
 function Row({
   item,
   player,
+  onQueueChange,
 }: {
   item: LibraryItem;
   player: PlayerHandle | null;
+  onQueueChange: () => void;
 }) {
   const onToggle = (e: React.ChangeEvent<HTMLInputElement>) => {
     const checked = e.currentTarget.checked;
-    const { id, title, artist, album, origin, storagePath, localName } = item;
-    const locatorOk = origin === "local" ? !!localName : !!storagePath;
-    if (!id || !title || !artist || !album || !origin || !locatorOk) {
-      logError(new Error("Queue toggle: missing data attributes on audio row"), {
-        operation: "queue-toggle",
-      });
-      e.currentTarget.checked = !checked; // revert
-      return;
-    }
-    if (!player) return;
-    if (checked) {
-      player.add({
-        id,
-        title,
-        artist,
-        album,
-        origin,
-        ...(origin === "local" ? { localName } : { storagePath }),
-      });
-    } else {
-      player.remove(id);
+    try {
+      const { id, title, artist, album, origin, storagePath, localName } = item;
+      const locatorOk = origin === "local" ? !!localName : !!storagePath;
+      if (!id || !title || !artist || !album || !origin || !locatorOk) {
+        logError(new Error("Queue toggle: missing data attributes on audio row"), {
+          operation: "queue-toggle",
+        });
+        return;
+      }
+      if (!player) return;
+      if (checked) {
+        player.add({
+          id,
+          title,
+          artist,
+          album,
+          origin,
+          ...(origin === "local" ? { localName } : { storagePath }),
+        });
+      } else {
+        player.remove(id);
+      }
+    } finally {
+      // Re-render Home so the controlled `checked` reasserts from isQueued on
+      // every exit path (add, remove, validation-fail, or !player).
+      onQueueChange();
     }
   };
 
@@ -79,7 +86,7 @@ function Row({
             label={null}
             data-queue-toggle
             aria-label={`Add ${item.title} to queue`}
-            defaultChecked={player ? player.isQueued(item.id) : false}
+            checked={player ? player.isQueued(item.id) : false}
             onChange={onToggle}
           />
           <span className="title">{item.title}</span>
@@ -120,6 +127,10 @@ export function Home(props: HomeProps) {
   // A DataIntegrityError is stored, then thrown during render so the route-level
   // RouteErrorBoundary catches it (a component cannot catch its own throw).
   const [fatalError, setFatalError] = useState<unknown>(null);
+  // A force-render counter: bumped on every queue toggle so Home (and each
+  // non-memoized Row) re-renders and recomputes the controlled `checked` from
+  // player.isQueued. Its value is never read in render.
+  const [, bumpQueue] = useReducer((n: number) => n + 1, 0);
 
   // Guards async setState after unmount: a late getCacheStats() / listLibrary()
   // resolution must not touch state once Home is gone.
@@ -247,7 +258,12 @@ export function Home(props: HomeProps) {
       ) : (
         <div id="media-list">
           {state.items.map((item) => (
-            <Row key={item.id} item={item} player={player} />
+            <Row
+              key={item.id}
+              item={item}
+              player={player}
+              onQueueChange={bumpQueue}
+            />
           ))}
         </div>
       );

--- a/audio/test/pages/home.test.tsx
+++ b/audio/test/pages/home.test.tsx
@@ -364,12 +364,100 @@ describe("Home", () => {
       const input = container.querySelector<HTMLInputElement>(
         "input[data-queue-toggle]",
       )!;
-      // defaultChecked=true; click toggles unchecked
+      // controlled checked=true; click toggles unchecked
       await act(async () => {
         input.click();
       });
 
       expect(player.remove).toHaveBeenCalledWith("x1");
+
+      await cleanup(container, root);
+    });
+
+    it("keeps the checkbox checked after a successful add (controlled, no revert)", async () => {
+      mockListLibrary.mockResolvedValue([makeLibraryItem({ id: "x1" })]);
+      const player = makeMockPlayer();
+      // Starts unqueued; add flips isQueued to true so the controlled checkbox
+      // re-renders checked instead of reverting.
+      player.isQueued.mockReturnValue(false);
+      player.add.mockImplementation(() => player.isQueued.mockReturnValue(true));
+      const { container, root } = await render(
+        <Home user={null} player={player} refreshKey={0} />,
+      );
+
+      const input = container.querySelector<HTMLInputElement>(
+        "input[data-queue-toggle]",
+      )!;
+      expect(input.checked).toBe(false);
+
+      await act(async () => {
+        input.click();
+      });
+
+      expect(player.add).toHaveBeenCalled();
+      const after = container.querySelector<HTMLInputElement>(
+        "input[data-queue-toggle]",
+      )!;
+      expect(after.checked).toBe(true);
+
+      await cleanup(container, root);
+    });
+
+    it("unchecks the checkbox after a successful remove (controlled)", async () => {
+      mockListLibrary.mockResolvedValue([makeLibraryItem({ id: "x1" })]);
+      const player = makeMockPlayer();
+      player.isQueued.mockReturnValue(true);
+      player.remove.mockImplementation(() =>
+        player.isQueued.mockReturnValue(false),
+      );
+      const { container, root } = await render(
+        <Home user={null} player={player} refreshKey={0} />,
+      );
+
+      const input = container.querySelector<HTMLInputElement>(
+        "input[data-queue-toggle]",
+      )!;
+      expect(input.checked).toBe(true);
+
+      await act(async () => {
+        input.click();
+      });
+
+      expect(player.remove).toHaveBeenCalledWith("x1");
+      const after = container.querySelector<HTMLInputElement>(
+        "input[data-queue-toggle]",
+      )!;
+      expect(after.checked).toBe(false);
+
+      await cleanup(container, root);
+    });
+
+    it("resyncs the checkbox on a focus rescan when the queue changed externally", async () => {
+      mockListLibrary.mockResolvedValue([makeLibraryItem({ id: "x1" })]);
+      const player = makeMockPlayer();
+      player.isQueued.mockReturnValue(true);
+      const { container, root } = await render(
+        <Home user={null} player={player} refreshKey={0} />,
+      );
+
+      const input = container.querySelector<HTMLInputElement>(
+        "input[data-queue-toggle]",
+      )!;
+      expect(input.checked).toBe(true);
+
+      // External mutation: the queue is emptied behind the component's back.
+      player.isQueued.mockReturnValue(false);
+
+      // A focus-driven rescan re-renders Home (same items), reasserting the
+      // controlled `checked` from the now-false isQueued.
+      await act(async () => {
+        window.dispatchEvent(new Event("focus"));
+      });
+
+      const after = container.querySelector<HTMLInputElement>(
+        "input[data-queue-toggle]",
+      )!;
+      expect(after.checked).toBe(false);
 
       await cleanup(container, root);
     });
@@ -392,7 +480,7 @@ describe("Home", () => {
       await cleanup(container, root);
     });
 
-    it("renders checkbox checked when player.isQueued returns true", async () => {
+    it("renders the controlled checked state from player.isQueued", async () => {
       mockListLibrary.mockResolvedValue([makeLibraryItem({ id: "x1" })]);
       const player = makeMockPlayer();
       player.isQueued.mockReturnValue(true);
@@ -405,6 +493,22 @@ describe("Home", () => {
       )!;
       expect(input.checked).toBe(true);
       expect(player.isQueued).toHaveBeenCalledWith("x1");
+
+      await cleanup(container, root);
+    });
+
+    it("renders the controlled unchecked state when player.isQueued is false", async () => {
+      mockListLibrary.mockResolvedValue([makeLibraryItem({ id: "x1" })]);
+      const player = makeMockPlayer();
+      player.isQueued.mockReturnValue(false);
+      const { container, root } = await render(
+        <Home user={null} player={player} refreshKey={0} />,
+      );
+
+      const input = container.querySelector<HTMLInputElement>(
+        "input[data-queue-toggle]",
+      )!;
+      expect(input.checked).toBe(false);
 
       await cleanup(container, root);
     });

--- a/audio/test/pages/home.test.tsx
+++ b/audio/test/pages/home.test.tsx
@@ -387,7 +387,7 @@ describe("Home", () => {
 
       const input = container.querySelector<HTMLInputElement>(
         "input[data-queue-toggle]",
-      )!;
+      )!; // type-safety-ok: querySelector in test, element guaranteed by rendered component
       expect(input.checked).toBe(false);
 
       await act(async () => {
@@ -397,7 +397,7 @@ describe("Home", () => {
       expect(player.add).toHaveBeenCalled();
       const after = container.querySelector<HTMLInputElement>(
         "input[data-queue-toggle]",
-      )!;
+      )!; // type-safety-ok: querySelector in test, element guaranteed by rendered component
       expect(after.checked).toBe(true);
 
       await cleanup(container, root);
@@ -416,7 +416,7 @@ describe("Home", () => {
 
       const input = container.querySelector<HTMLInputElement>(
         "input[data-queue-toggle]",
-      )!;
+      )!; // type-safety-ok: querySelector in test, element guaranteed by rendered component
       expect(input.checked).toBe(true);
 
       await act(async () => {
@@ -426,7 +426,7 @@ describe("Home", () => {
       expect(player.remove).toHaveBeenCalledWith("x1");
       const after = container.querySelector<HTMLInputElement>(
         "input[data-queue-toggle]",
-      )!;
+      )!; // type-safety-ok: querySelector in test, element guaranteed by rendered component
       expect(after.checked).toBe(false);
 
       await cleanup(container, root);
@@ -442,7 +442,7 @@ describe("Home", () => {
 
       const input = container.querySelector<HTMLInputElement>(
         "input[data-queue-toggle]",
-      )!;
+      )!; // type-safety-ok: querySelector in test, element guaranteed by rendered component
       expect(input.checked).toBe(true);
 
       // External mutation: the queue is emptied behind the component's back.
@@ -456,7 +456,7 @@ describe("Home", () => {
 
       const after = container.querySelector<HTMLInputElement>(
         "input[data-queue-toggle]",
-      )!;
+      )!; // type-safety-ok: querySelector in test, element guaranteed by rendered component
       expect(after.checked).toBe(false);
 
       await cleanup(container, root);
@@ -490,7 +490,7 @@ describe("Home", () => {
 
       const input = container.querySelector<HTMLInputElement>(
         "input[data-queue-toggle]",
-      )!;
+      )!; // type-safety-ok: querySelector in test, element guaranteed by rendered component
       expect(input.checked).toBe(true);
       expect(player.isQueued).toHaveBeenCalledWith("x1");
 
@@ -507,7 +507,7 @@ describe("Home", () => {
 
       const input = container.querySelector<HTMLInputElement>(
         "input[data-queue-toggle]",
-      )!;
+      )!; // type-safety-ok: querySelector in test, element guaranteed by rendered component
       expect(input.checked).toBe(false);
 
       await cleanup(container, root);


### PR DESCRIPTION
Closes #2010

## Problem

The audio Home page rendered its per-row queue checkbox with
`defaultChecked={player ? player.isQueued(item.id) : false}` — an **uncontrolled**
React input. React applies `defaultChecked` only on initial mount and never
reasserts it, so the checkbox could drift out of sync with `player.isQueued()`.
The old vanilla-JS code compensated with an `applyCheckboxState()` sweep after
every library re-render; the React migration (PR #1943) dropped that sweep, which
surfaced this issue.

## Fix

Convert the checkbox to a **controlled** input in `audio/src/pages/Home.tsx`
(no change to `audio/src/player.ts`):

- `Row` now uses `checked={player ? player.isQueued(item.id) : false}` instead of
  `defaultChecked`, so the value is recomputed from `player.isQueued()` on every
  Home re-render.
- `Home` gains a force-render counter via
  `const [, bumpQueue] = useReducer((n) => n + 1, 0)`, passed into `Row` as
  `onQueueChange` and called on **every** `onToggle` exit path (via a `finally`).
  A controlled checkbox reverts when its `onChange` doesn't change the rendered
  `checked`; calling `player.add/remove` alone does not re-render React, so the
  bump forces Home (and every non-memoized `Row`) to re-render and reassert
  `checked` from `isQueued`.
- The imperative `e.currentTarget.checked = !checked; // revert` line is removed —
  it fought the controlled input; the `finally` bump now snaps the checkbox back
  to `player.isQueued(item.id)` on the validation-fail and `!player` paths.

Why local React state rather than a player event/subscription (the issue's
floated "Recommended fix"): the queue is mutated **only** by this very checkbox —
`player.add`/`remove` have exactly one caller, Home's own `onToggle`. An added
queue-change event would be a self-loop with no external producer. The controlled
recompute is the general mechanism that surfaces any queue change on the next
render, present or future.

## Acceptance criteria

- **C1 (controlled prop)** — `defaultChecked` replaced with `checked`.
- **C4 (toggle still works)** — the `finally` bump re-renders so the visual flip
  sticks after add/remove.
- **C3 (focus rescan resync)** — the focus rescan already calls
  `setState({status:"loaded", items})`, re-rendering Home; the controlled `checked`
  is recomputed from `player.isQueued()` on that render.
- **C2 (external mutation surfaces)** — satisfied by construction: a controlled
  `checked` recomputes on every Home re-render.

## Tests

Extended the "interactive: checkbox queue toggle" block in
`audio/test/pages/home.test.tsx`: a sticky-add case (checkbox stays checked, no
revert), an uncheck case, and an external/rescan resync case (focus event flips
the checkbox to match a changed `isQueued`). The former `defaultChecked`-asserting
test now asserts the controlled `checked` state.

## Verification

- `npx vitest run --root audio` — 150 passed.
- `npm run build --prefix audio` — `tsc && vite build` succeeds.
