### PR TITLE
fellspiral/blog: make Archive default-open state data-driven (drop wall-clock read)

### DIFF
--- a/blog/src/components/InfoPanel.tsx
+++ b/blog/src/components/InfoPanel.tsx
@@ -61,27 +61,27 @@ function MonthBlock({
 function YearBlock({
   year,
   months,
-  currentYear,
-  currentMonth,
+  openYear,
+  openMonth,
   postLinkPrefix,
 }: {
   year: number;
   months: Map<number, PublishedPost[]>;
-  currentYear: number;
-  currentMonth: number;
+  openYear: number;
+  openMonth: number;
   postLinkPrefix: string;
 }) {
-  const isCurrentYear = year === currentYear;
+  const isOpenYear = year === openYear;
   const sortedMonths = [...months.keys()].sort((a, b) => b - a);
   return (
-    <details open={isCurrentYear}>
+    <details open={isOpenYear}>
       <summary>{year}</summary>
       {sortedMonths.map((month) => (
         <MonthBlock
           key={month}
           month={month}
           posts={months.get(month)!}
-          isOpen={isCurrentYear && month === currentMonth}
+          isOpen={isOpenYear && month === openMonth}
           postLinkPrefix={postLinkPrefix}
         />
       ))}
@@ -113,8 +113,9 @@ function Archive({
   if (published.length === 0) return null;
 
   const grouped = groupByYearMonth(published);
-  const now = new Date();
   const sortedYears = [...grouped.keys()].sort((a, b) => b - a);
+  const openYear = sortedYears[0];
+  const openMonth = Math.max(...grouped.get(openYear)!.keys());
 
   return (
     <section className="panel-section">
@@ -124,8 +125,8 @@ function Archive({
           key={year}
           year={year}
           months={grouped.get(year)!}
-          currentYear={now.getUTCFullYear()}
-          currentMonth={now.getUTCMonth()}
+          openYear={openYear}
+          openMonth={openMonth}
           postLinkPrefix={postLinkPrefix}
         />
       ))}

--- a/blog/src/components/InfoPanel.tsx
+++ b/blog/src/components/InfoPanel.tsx
@@ -115,7 +115,7 @@ function Archive({
   const grouped = groupByYearMonth(published);
   const sortedYears = [...grouped.keys()].sort((a, b) => b - a);
   const openYear = sortedYears[0];
-  const openMonth = Math.max(...grouped.get(openYear)!.keys());
+  const openMonth = Math.max(...grouped.get(openYear)!.keys()); // type-safety-ok: openYear is derived from grouped.keys() so the entry always exists
 
   return (
     <section className="panel-section">

--- a/blog/test/components/info-panel.test.ts
+++ b/blog/test/components/info-panel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { InfoPanel } from "../../src/components/InfoPanel.tsx";
@@ -337,16 +337,22 @@ describe("renderInfoPanel", () => {
     });
   });
 
-  describe("archive (pinned date)", () => {
-    beforeEach(() => {
+  describe("archive (hydration determinism)", () => {
+    it("renders identical HTML regardless of wall clock (no SSR/hydration drift)", () => {
       vi.useFakeTimers();
-      vi.setSystemTime(new Date("2026-02-15"));
+      try {
+        vi.setSystemTime(new Date("2026-01-31T23:59:00Z"));
+        const before = renderInfoPanel(defaultData());
+        vi.setSystemTime(new Date("2026-02-01T00:01:00Z"));
+        const after = renderInfoPanel(defaultData());
+        expect(after).toBe(before);
+      } finally {
+        vi.useRealTimers();
+      }
     });
+  });
 
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
+  describe("archive", () => {
     it("groups posts by year and month correctly", () => {
       const html = renderInfoPanel(defaultData());
       expect(html).toContain("2026");
@@ -354,7 +360,7 @@ describe("renderInfoPanel", () => {
       expect(html).toContain("January");
     });
 
-    it("current year (2026) is open by default", () => {
+    it("newest year (2026) is open by default", () => {
       const html = renderInfoPanel(defaultData());
       const container = document.createElement("div");
       container.innerHTML = html;
@@ -405,7 +411,7 @@ describe("renderInfoPanel", () => {
       }
     });
 
-    it("current month (February 2026) is open by default", () => {
+    it("newest month (February 2026) is open by default", () => {
       const html = renderInfoPanel(defaultData());
       const container = document.createElement("div");
       container.innerHTML = html;


### PR DESCRIPTION
Closes #2223

## Problem

The shared `blog/` package's info-panel **Archive** section computed its
default-open `<details>` state from the wall clock. `Archive` read
`const now = new Date()` during render and threaded `now.getUTCFullYear()` /
`now.getUTCMonth()` into the `<details open>` attributes.

The SSR prerender runs at **build time**; client hydration runs at **serve
time**. When those two moments straddle a UTC month/year boundary, the baked-in
`open` attributes diverge from what the client renders → a React hydration
mismatch. The `blog` package is consumed by both `fellspiral` and `landing`, so
both apps were affected.

## Fix

Make the Archive default-open state **data-driven**, removing `new Date()` from
the render path entirely:

- **Unit 1 (`blog/src/components/InfoPanel.tsx`)** — derive the default-open year
  from the newest year present (`sortedYears[0]`) and the default-open month from
  that year's newest month (`Math.max(...grouped.get(openYear)!.keys())`), not a
  global newest-month across all years. Rename the now-misleading `currentYear` /
  `currentMonth` props to `openYear` / `openMonth`. The `new Date(post.publishedAt)`
  parse in `groupByYearMonth` is untouched — it reads a fixed published-at string,
  not the clock.
- **Unit 2 (`blog/test/components/info-panel.test.ts`)** — add a determinism
  regression test that renders the panel under two fake clocks straddling a UTC
  month boundary and asserts the HTML is byte-identical, and retire the now-
  unnecessary clock-pin scaffolding (`vi.setSystemTime`) from the existing archive
  block. Net coverage increases; no assertion is removed, skipped, or loosened.

The result is deterministic (byte-identical SSR/client markup) and equal-or-
better UX than "current calendar month" (which can be empty when no posts exist
this month).

## Verification

- `blog` unit tests: 415 passed.
- Typecheck: blog skipped by the runner (origin/main has pre-existing typecheck
  errors unrelated to this change).

Manual QA (deferred, per acceptance criterion 4): in built `fellspiral` and
`landing` previews, confirm the Archive section opens the newest year and its
newest month and the console shows no React hydration warning for the info panel.
