### PR TITLE
dispatch: add open-blocker re-check at plan-issue/implement worker startup

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -73,6 +73,49 @@ preamble did NOT take the re-entry branch). (`dispatch-route` normally routes a
 PR-bearing issue to fix-checks/qa/review, not implement, so this is a same-tick
 crash-recovery edge.)
 
+**Open-blocker re-check (non-re-entry path only).** When the preamble finds
+`PR: none` — i.e. this is a fresh run, not a crash recovery — verify that the
+target issue has no open blockers before beginning any build work. This catches
+the race window between the queue-gate check (in `/dispatch-propagate`) and now.
+Skip this check on the re-entry branch (`PR #<num>` already exists): the build
+already happened and passed this gate on first run; re-checking would needlessly
+re-park a same-tick crash recovery.
+
+Run with `dangerouslyDisableSandbox: true` — `dispatch-check-blockers` calls
+`gh` (see `.claude/rules/sandbox.md`). Tolerant capture:
+
+```bash
+if out=$(.claude/skills/dispatch-propagate/scripts/dispatch-check-blockers "$N"); then
+  rc=0
+else
+  rc=$?
+fi
+```
+
+Route on `rc`:
+
+- **`rc == 0`** — no open blocker. Proceed unchanged.
+- **`rc == 2`** — `$out` is `blocked:<nums>`. Real open blocker found. Call
+  `dispatch-mark-deviation`, then stop (skip the Step 5 completion marker).
+  Marker absence triggers Stop hook Branch A (`dispatch:office-hours`).
+  `dispatch-mark-deviation` is already one of `/implement`'s two single-named-exit
+  terminal actions, so the single-named-exit invariant in `## Steps` still holds:
+
+  ```bash
+  .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+    "/implement: target #$N has an open blocker ($out) - raced past the queue gate; parking"
+  ```
+
+- **`rc == 1`** (or any other non-zero) — environment error; blockers unverified.
+  Not "no blockers." Call `dispatch-mark-deviation` with a distinct reason
+  including `$rc`, then stop (skip the Step 5 completion marker). Never proceed
+  on `rc == 1`:
+
+  ```bash
+  .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+    "/implement: could not verify open blockers for #$N (dispatch-check-blockers exit $rc)"
+  ```
+
 ## Steps
 
 **Single named exit.** Take exactly one terminal action to end the turn: the

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -111,6 +111,45 @@ counterpart of the creation-time relevance check; the two are deliberately
 separate — the creation-time check is `$BASELINE_BRANCH`-anchored, this step is
 pre-planning and `createdAt`-anchored.
 
+**Open-blocker re-check.** Before spending any planning work, verify that the
+target issue has no open blockers. This catches the race window between the
+queue-gate check (in `/dispatch-propagate`) and now. Run with
+`dangerouslyDisableSandbox: true` — `dispatch-check-blockers` calls `gh`
+(see `.claude/rules/sandbox.md`). Tolerant capture:
+
+```bash
+if out=$(.claude/skills/dispatch-propagate/scripts/dispatch-check-blockers "$N"); then
+  rc=0
+else
+  rc=$?
+fi
+```
+
+Route on `rc`:
+
+- **`rc == 0`** — no open blocker. Proceed unchanged.
+- **`rc == 2`** — `$out` is `blocked:<nums>`. Real open blocker found. Call
+  `dispatch-mark-deviation`, then stop. Marker absence triggers Stop hook Branch A
+  (`dispatch:office-hours`):
+
+  ```bash
+  .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+    "/plan-issue: target #$N has an open blocker ($out) - raced past the queue gate; parking"
+  ```
+
+- **`rc == 1`** (or any other non-zero) — environment error; blockers unverified.
+  Not "no blockers." Call `dispatch-mark-deviation` with a distinct reason
+  including `$rc`, then stop. Never proceed on `rc == 1`:
+
+  ```bash
+  .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
+    "/plan-issue: could not verify open blockers for #$N (dispatch-check-blockers exit $rc)"
+  ```
+
+This runs only on the fresh-run path. The `HAVE_PLAN=1` branch re-finalizes and
+stops before Step 1, so an already-planned issue is not re-parked. Placing it
+before the context-pack and drift work fails fast on a raced blocked target.
+
 Run the opening live-context call (`dangerouslyDisableSandbox: true` — it calls
 `gh`):
 

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -24,10 +24,11 @@ fan out the built-in `Explore` and `Plan` subagents directly (no orchestrator
 skill, no nesting). The exploration and design subagents are direct children of
 this session.
 
-Run `gh` commands and the scripts that invoke `gh` (`dispatch-context-pack`,
-`dispatch-drift-scan`, `dispatch-read-plan`, `dispatch-write-plan`,
-`dispatch-apply-planned`, `dispatch-mark-complete`, `dispatch-plan-finalize`)
-with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
+Run `gh` commands and the scripts that invoke `gh` (`dispatch-check-blockers`,
+`dispatch-context-pack`, `dispatch-drift-scan`, `dispatch-read-plan`,
+`dispatch-write-plan`, `dispatch-apply-planned`, `dispatch-mark-complete`,
+`dispatch-plan-finalize`) with `dangerouslyDisableSandbox: true` — see
+`.claude/rules/sandbox.md`.
 
 ## The running session has no plan mode
 
@@ -130,7 +131,9 @@ Route on `rc`:
 - **`rc == 0`** — no open blocker. Proceed unchanged.
 - **`rc == 2`** — `$out` is `blocked:<nums>`. Real open blocker found. Call
   `dispatch-mark-deviation`, then stop. Marker absence triggers Stop hook Branch A
-  (`dispatch:office-hours`):
+  (`dispatch:office-hours`). `dispatch-mark-deviation` is already the established
+  terminal action for `/plan-issue` (Step 6), so stopping after it preserves the
+  single-named-exit invariant — do not add a completion-marker call:
 
   ```bash
   .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \
@@ -139,7 +142,10 @@ Route on `rc`:
 
 - **`rc == 1`** (or any other non-zero) — environment error; blockers unverified.
   Not "no blockers." Call `dispatch-mark-deviation` with a distinct reason
-  including `$rc`, then stop. Never proceed on `rc == 1`:
+  including `$rc`, then stop. Never proceed on `rc == 1`. As with `rc == 2`,
+  `dispatch-mark-deviation` is the established `/plan-issue` terminal action (Step
+  6), so stopping after it preserves the single-named-exit invariant — do not add a
+  completion-marker call:
 
   ```bash
   .claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation \


### PR DESCRIPTION
Closes #2242

## What

Add an open-blocker re-check at the **phase-worker startup boundary** in both
`/plan-issue` and `/implement`, so a `dispatch` issue with a still-open blocker
that slipped past the queue gate is parked to `dispatch:office-hours` instead of
being planned or built.

## Why

A `dispatch` / `help wanted` issue with an open blocker can still reach a phase
worker when there is a TOCTOU race between the dispatch-ready signal (the labels)
and the `blocked_by` dependency link. The queue gate
(`dispatch-select-target` → `dispatch-trace-leaf` → `count_open_blockers`) is
correct — it simply runs before the `blocked_by` link exists/propagates on the
REST endpoint, or hits read-after-write propagation lag.

Concrete instance: #2135 (blocked by #2039 via PR #2108) had its labels applied
at 05:43:16, the `blocked_by` link added at 05:44:53, and a tick provisioned its
worktree and spawned `/plan-issue` at ~05:46:03 — between the two. It was parked
correctly, but only *incidentally* (the Step 1 drift check happened to notice a
target symbol missing from `main`). There was no blocker re-check at the worker
boundary, so a raced blocked issue whose target code already exists would have
been planned/built against a still-open prerequisite.

## How

Both workers now re-check at startup using the existing `dispatch-check-blockers`
script — which routes through `count_open_blockers`, the same helper the queue
gate uses, so the explicit and queue paths can never diverge on what counts as
"blocked". The capture is tolerant of the expected exit-2 (blocked) case, and
routing is three-way per `.claude/rules/code-style.md` (clear error, never a
swallowed fallback):

- `rc == 0` — no open blocker → proceed unchanged (no behavior change for the
  common case).
- `rc == 2` — `blocked:<nums>` → real open blocker → `dispatch-mark-deviation`
  naming the blocker(s), then stop.
- `rc == 1` (or any other non-zero) — `gh`/API failure → blockers unverified →
  `dispatch-mark-deviation` with a distinct environmental reason including the
  exit code, then stop. Never proceed.

In both stop branches, the absence of a completion marker drives the existing
Stop hook (`dispatch-stop.sh`, Branch A) to apply `dispatch:office-hours`.

Placement:

- **`/plan-issue`** — at the very start of Step 1 (Pre-Planning relevance
  review), before the context-pack call. It runs only on the fresh-run path; the
  `HAVE_PLAN=1` branch re-finalizes and stops before Step 1, so an
  already-planned issue is not re-parked. Running before the expensive
  context-pack / drift work also fails fast on a raced blocked target.
- **`/implement`** — at the end of the idempotency preamble, gated on the
  non-re-entry path (`PR: none`). The re-entry branch already built and passed
  this gate on first run; re-checking there would needlessly re-park a same-tick
  crash recovery. `dispatch-mark-deviation` is already one of `/implement`'s two
  single-named-exit terminal actions, so that invariant still holds.

## Out of scope

`qa-fix`, `review-fix`, `fix-checks` (they run post-PR — the build already
happened); the process-only "apply labels last" backup (does not help REST
propagation lag); any change to `dispatch-check-blockers` or `count_open_blockers`.

## Verification

The plan's `verify` block passed: `bash -n` confirms the reused
`dispatch-check-blockers` still parses, and `grep -q` confirms the re-check
landed in both worker skills (both files had zero references before this change).
