### PR TITLE
dispatch-stop: guard in-flight background-Workflow phases; add deterministic self-close terminus

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -391,6 +391,52 @@ session_scheduled_wakeup() {
     | tail -1 | grep -q '"ScheduleWakeup"'
 }
 
+# Branch A background-task discriminator (#2243). Returns 0 ("still running in
+# the background, will resume on its own") ONLY when the transcript shows at
+# least one background task that was LAUNCHED but has not yet been NOTIFIED back
+# — i.e. an in-flight launched∖notified set difference is non-empty; returns 1
+# in EVERY other case — including all uncertainty: empty TRANSCRIPT_PATH,
+# missing/unreadable file, malformed transcript, or no launches at all. The
+# fail-safe direction (positive evidence only) is load-bearing: any doubt falls
+# through to today's office-hours park, so a genuine death still parks.
+#
+# A Workflow-based phase skill (/review-fix, /qa-fix) launches its review/QA
+# fan-out as a BACKGROUND Workflow and yields its turn to await a
+# <task-notification>. That mid-phase turn-end fires this Stop hook while the
+# phase is still running and has not yet written its phase-completed marker.
+# Without this gate Branch A sees marker-absence and prematurely parks the
+# issue on office-hours (#2243) — symmetric to session_scheduled_wakeup (#1590).
+#
+# Transcript shapes (whole-transcript grain, NOT last-turn-only — a background
+# launch is not a per-poll-cycle event):
+#   Launch — a tool_result text `... launched in background. Task ID: <ID>`
+#            (Workflow: `Workflow launched in background. Task ID: <ID>`; the
+#            Task tool uses analogous `... launched in background. Task ID: <ID>`).
+#   Notify — a <task-notification> payload carrying `"taskId":"<ID>"` for ANY
+#            status; any notification means the task resumed the session and is
+#            no longer in-flight.
+#
+# Grep the file directly for literal substrings (not echo-into-jq): the IDs are
+# plain substrings, so grep is robust and sidesteps the control-char trap
+# (.claude/rules/shell-json.md), mirroring dispatch-recover-dispatched-phase /
+# dispatch-detect-rate-limit-death.
+session_has_inflight_background_task() {
+  [ -n "$TRANSCRIPT_PATH" ] && [ -r "$TRANSCRIPT_PATH" ] || return 1
+  local launched notified
+  launched=$(grep -oE 'launched in background\. Task ID: [A-Za-z0-9_-]+' "$TRANSCRIPT_PATH" 2>/dev/null \
+    | grep -oE '[A-Za-z0-9_-]+$' | sort -u)
+  [ -n "$launched" ] || return 1
+  # Tolerate the JSONL backslash-escaped quote form (\"taskId\":\"<ID>\") as
+  # well as the bare "taskId":"<ID>" form — the <task-notification> payload is a
+  # string value, so its inner quotes are backslash-escaped in the record.
+  notified=$(grep -oE 'taskId\\?":\\?"[A-Za-z0-9_-]+' "$TRANSCRIPT_PATH" 2>/dev/null \
+    | grep -oE '[A-Za-z0-9_-]+$' | sort -u)
+  # In-flight iff at least one launched ID has no matching notification, i.e.
+  # the set difference (launched ∖ notified) is non-empty. comm -23 lists lines
+  # unique to the first (sorted) input.
+  [ -n "$(comm -23 <(printf '%s\n' "$launched") <(printf '%s\n' "$notified"))" ]
+}
+
 # Branch P — parse-job clean completion (#1024): a /budget-parse-job session is
 # named <N>-slug like a worker but, on a successful idempotent statement merge,
 # writes a `parse-job-done` sentinel instead of a phase-completed marker. A clean
@@ -556,6 +602,17 @@ if [ -z "$MARKER_PHASE" ]; then
     # itself). Without this gate Branch A re-parks the issue once per poll
     # cycle, oscillating dispatch:office-hours (#1590).
     DLOG_DISPOSITION="hand-back"
+    exit 0
+  fi
+  if session_has_inflight_background_task; then
+    # Live phase running in the background — a Workflow/Task phase skill
+    # (/review-fix, /qa-fix) launched its fan-out as a background task and
+    # yielded its turn to await a <task-notification>. This mid-phase turn-end
+    # fired the Stop hook before the phase-completed marker was written. Hand
+    # back (the running task will resume the session and finish the phase); do
+    # NOT park on office-hours and do NOT spawn a redundant tick. Symmetric to
+    # the scheduled-wakeup gate above (#2243).
+    DLOG_DISPOSITION="hand-back-inflight-task"
     exit 0
   fi
   # Rate-limit self-heal (#1733). A worker that died on a TRANSIENT Anthropic

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-finalize-phase
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-finalize-phase
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# dispatch-finalize-phase — deterministic self-close terminus for /review-fix and
+# /qa-fix success paths.
+#
+# Usage: dispatch-finalize-phase <issue-num> [--pr <pr-num>]
+#
+# Invoke this script as the ABSOLUTE LAST skill action, AFTER dispatch-mark-complete
+# and the outcome-envelope emit. Self-close is the final step so all prior steps
+# complete before the job is deleted. Every step is idempotent: dispatch-spawn-tick
+# uses a fixed systemd unit name (a colliding second spawn is a harmless 'deduped'
+# no-op), gh --remove-label is idempotent, and dispatch-self-close is a no-op when
+# CLAUDE_JOB_DIR is unset (interactive-safe). A stray second Stop hook firing after
+# this script runs is therefore harmless.
+#
+# Requires dangerouslyDisableSandbox at the call site (gh uses macOS TLS framework).
+#
+# Ordered steps — each is best-effort (guarded with || true) so none aborts
+# before self-close:
+#   1. Clear dispatch:rate-limit-retry-<n> labels from the issue (parity with hook).
+#   2. Strip dispatch:office-hours from the PR (if --pr given) and the issue.
+#   3. dispatch-spawn-tick — spawn the next dispatch tick (fixed-unit dedup).
+#   4. dispatch-spawn-sweep — sweep stale worktrees.
+#   5. dispatch-self-close — exec `claude rm`; no-ops when CLAUDE_JOB_DIR unset.
+#
+# Out of scope: does NOT call dispatch-mark-deviation, does NOT apply any label,
+# does NOT replicate clear_attempt_counter (gated on the parked→unparked
+# transition that the hook detects; omitting it here is safe).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Argument parsing ---
+N="${1:-}"
+if [[ $# -lt 1 || -z "$N" ]]; then
+  echo "dispatch-finalize-phase: issue-num argument is required" >&2
+  echo "usage: dispatch-finalize-phase <issue-num> [--pr <pr-num>]" >&2
+  exit 2
+fi
+if [[ ! "$N" =~ ^[0-9]+$ ]]; then
+  echo "dispatch-finalize-phase: issue-num must be a positive integer, got: $N" >&2
+  echo "usage: dispatch-finalize-phase <issue-num> [--pr <pr-num>]" >&2
+  exit 2
+fi
+
+PR_NUM=""
+shift
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "dispatch-finalize-phase: --pr requires a pr-num argument" >&2
+        exit 2
+      fi
+      if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+        echo "dispatch-finalize-phase: --pr value must be a positive integer, got: $2" >&2
+        exit 2
+      fi
+      PR_NUM="$2"
+      shift 2
+      ;;
+    *)
+      echo "dispatch-finalize-phase: unexpected argument: $1" >&2
+      echo "usage: dispatch-finalize-phase <issue-num> [--pr <pr-num>]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# Step 1: clear any dispatch:rate-limit-retry-<n> counter labels from the issue.
+# Best-effort: a gh flake must not abort before self-close.
+{
+  local_lbl=""
+  gh issue view "$N" --json labels --jq \
+    '.labels[].name | select(test("^dispatch:rate-limit-retry-[0-9]+$"))' 2>/dev/null \
+    | while IFS= read -r local_lbl; do
+        [ -n "$local_lbl" ] && gh issue edit "$N" --remove-label "$local_lbl" >/dev/null 2>&1 \
+          || echo "[dispatch-finalize-phase] WARNING: could not clear $local_lbl (non-fatal)" >&2
+      done || true
+} || true
+
+# Step 2: strip dispatch:office-hours from the PR (if given) and the issue.
+if [[ -n "$PR_NUM" ]]; then
+  gh pr edit "$PR_NUM" --remove-label dispatch:office-hours >/dev/null 2>&1 \
+    || echo "[dispatch-finalize-phase] WARNING: gh pr edit --remove-label dispatch:office-hours failed (non-fatal)" >&2
+fi
+gh issue edit "$N" --remove-label dispatch:office-hours >/dev/null 2>&1 \
+  || echo "[dispatch-finalize-phase] WARNING: gh issue edit --remove-label dispatch:office-hours failed (non-fatal)" >&2
+
+# Step 3: spawn the next dispatch tick (idempotent via fixed-unit dedup).
+"$SCRIPT_DIR/dispatch-spawn-tick" || true
+
+# Step 4: spawn the sweep reaper.
+"$SCRIPT_DIR/dispatch-spawn-sweep" || true
+
+# Step 5: self-close — MUST be last; exec's, no return.
+"$SCRIPT_DIR/dispatch-self-close"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -22887,6 +22887,259 @@ else
 fi
 stop_teardown
 
+# --- Test #2243-D1.1: in-flight Workflow → hand back (no park, no spawn) -----
+# Branch A new gate: when the transcript shows a Workflow launched in background
+# that has NOT yet received a <task-notification>, the session yielded to await
+# the running fan-out. Do NOT park on office-hours and do NOT spawn a tick.
+
+echo "Test: #2243 D1.1 in-flight Workflow → hand-back (no park, no spawn)"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "implement" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+# No phase-completed marker.
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+# Fixture: one Workflow launch line, no <task-notification>.
+cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: w4stq5fyf"}]}}
+EOF
+FIXTURE="$TMPDIR_TEST/transcript.jsonl"
+printf '%s\n' '{"transcript_path":"'"$FIXTURE"'"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
+rc=$?
+assert_eq "#2243 D1.1 in-flight Workflow: hook exits 0 (hand-back)" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2243 D1.1 in-flight Workflow: NOT parked on office-hours"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2243 D1.1 in-flight Workflow: NOT parked on office-hours"
+  echo "    apply-log: $(cat "$STUB_DIR/apply-office-hours.log")"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/spawn-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2243 D1.1 in-flight Workflow: NOT spawned (redundant tick suppressed)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2243 D1.1 in-flight Workflow: NOT spawned (redundant tick suppressed)"
+  echo "    spawn-calls: $(cat "$STUB_DIR/spawn-calls.log")"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/self-close-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2243 D1.1 in-flight Workflow: NOT self-closed"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2243 D1.1 in-flight Workflow: NOT self-closed"
+fi
+stop_teardown
+
+# --- Test #2243-D1.2: completed Workflow → normal Branch A park ---------------
+# When the Workflow launch line IS matched by a <task-notification> with the same
+# task ID, the task completed while the session was alive. The in-flight gate must
+# NOT fire; execution falls through to the normal Branch A office-hours park.
+
+echo "Test: #2243 D1.2 completed Workflow → normal Branch A park (office-hours applied, spawn invoked)"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "implement" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+# No phase-completed marker.
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+# Fixture: launch line + matching task-notification (backslash-escaped quote form).
+cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: w4stq5fyf"}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"{\"taskId\":\"w4stq5fyf\",\"status\":\"completed\"}"}]}}
+EOF
+FIXTURE="$TMPDIR_TEST/transcript.jsonl"
+printf '%s\n' '{"transcript_path":"'"$FIXTURE"'"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
+rc=$?
+assert_eq "#2243 D1.2 completed Workflow: hook exits 0" "0" "$rc"
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
+TOTAL=$((TOTAL + 1))
+if [[ "$apply_issue" == "123" && -n "$apply_reason" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2243 D1.2 completed Workflow: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2243 D1.2 completed Workflow: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+  echo "    apply-log: $apply_log"
+fi
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "#2243 D1.2 completed Workflow: spawn invoked exactly once" "1" "$spawn_calls"
+stop_teardown
+
+# --- Test #2243-D1.3: multiple tasks, one outstanding → hand back ------------
+# Two Workflow launches with distinct IDs, only one notified. The un-notified task
+# is still in-flight: the in-flight gate must fire (hand-back, no park, no spawn).
+
+echo "Test: #2243 D1.3 multiple tasks, one outstanding → hand-back"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "implement" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+# No phase-completed marker.
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+# Fixture: two launch lines, only the first notified.
+cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: aaa111bbb"}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: ccc222ddd"}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"{\"taskId\":\"aaa111bbb\",\"status\":\"completed\"}"}]}}
+EOF
+FIXTURE="$TMPDIR_TEST/transcript.jsonl"
+printf '%s\n' '{"transcript_path":"'"$FIXTURE"'"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
+rc=$?
+assert_eq "#2243 D1.3 one outstanding task: hook exits 0 (hand-back)" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2243 D1.3 one outstanding task: NOT parked on office-hours"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2243 D1.3 one outstanding task: NOT parked on office-hours"
+  echo "    apply-log: $(cat "$STUB_DIR/apply-office-hours.log")"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/spawn-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2243 D1.3 one outstanding task: NOT spawned"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2243 D1.3 one outstanding task: NOT spawned"
+  echo "    spawn-calls: $(cat "$STUB_DIR/spawn-calls.log")"
+fi
+stop_teardown
+
+# ============================================================================
+# dispatch-finalize-phase tests (#2243)
+# ============================================================================
+echo ""
+echo "=== dispatch-finalize-phase ==="
+
+# --- Test #2243-D2: finalize-phase spawns once + strips office-hours + self-closes last ---
+# dispatch-finalize-phase calls siblings via its own $SCRIPT_DIR. To stub them,
+# copy the real script into a fresh tmpdir alongside stub siblings in that same
+# dir (the same pattern as dispatch-plan-finalize above). gh is on PATH from a
+# dedicated bin/ subdir inside the tmpdir.
+
+echo "Test: #2243 D2 dispatch-finalize-phase: spawn-once + office-hours removed from issue and PR + self-close last"
+FINALIZE_TMPDIR=$(mktemp -d)
+FINALIZE_STUB_DIR="$FINALIZE_TMPDIR/stub"
+FINALIZE_BIN="$FINALIZE_TMPDIR/bin"
+FINALIZE_SCRIPTS="$FINALIZE_TMPDIR/scripts"
+mkdir -p "$FINALIZE_STUB_DIR" "$FINALIZE_BIN" "$FINALIZE_SCRIPTS"
+
+# Copy the real finalize script into the scripts dir so $SCRIPT_DIR resolves there.
+cp "$SCRIPT_DIR/dispatch-finalize-phase" "$FINALIZE_SCRIPTS/dispatch-finalize-phase"
+chmod +x "$FINALIZE_SCRIPTS/dispatch-finalize-phase"
+
+# Stub dispatch-spawn-tick: log to order.log and spawn-calls.log.
+cat > "$FINALIZE_SCRIPTS/dispatch-spawn-tick" <<'STUB'
+#!/usr/bin/env bash
+echo "spawn" >> "$FINALIZE_STUB_DIR/order.log"
+echo "spawn" >> "$FINALIZE_STUB_DIR/spawn-calls.log"
+exit 0
+STUB
+chmod +x "$FINALIZE_SCRIPTS/dispatch-spawn-tick"
+
+# Stub dispatch-spawn-sweep: log to sweep-calls.log (no order entry — mirrors stop harness).
+cat > "$FINALIZE_SCRIPTS/dispatch-spawn-sweep" <<'STUB'
+#!/usr/bin/env bash
+echo "sweep" >> "$FINALIZE_STUB_DIR/sweep-calls.log"
+exit 0
+STUB
+chmod +x "$FINALIZE_SCRIPTS/dispatch-spawn-sweep"
+
+# Stub dispatch-self-close: log to order.log and self-close-calls.log.
+cat > "$FINALIZE_SCRIPTS/dispatch-self-close" <<'STUB'
+#!/usr/bin/env bash
+echo "self-close" >> "$FINALIZE_STUB_DIR/order.log"
+echo "self-close" >> "$FINALIZE_STUB_DIR/self-close-calls.log"
+exit 0
+STUB
+chmod +x "$FINALIZE_SCRIPTS/dispatch-self-close"
+
+# Stub gh: handle issue view (rate-limit labels — return empty), pr edit --remove-label,
+# issue edit --remove-label. Log remove calls for assertion.
+cat > "$FINALIZE_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+FINALIZE_STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
+args="$*"
+case "$args" in
+  issue\ view\ *--json\ labels*)
+    # No rate-limit-retry labels to clear.
+    printf '{"labels":[]}\n'
+    ;;
+  pr\ edit\ *--remove-label*)
+    echo "$args" >> "$FINALIZE_STUB_DIR/gh-pr-remove.log"
+    ;;
+  issue\ edit\ *--remove-label*)
+    echo "$args" >> "$FINALIZE_STUB_DIR/gh-issue-remove.log"
+    ;;
+  *)
+    echo "gh stub: unknown invocation: $args" >&2
+    exit 1
+    ;;
+esac
+STUB
+chmod +x "$FINALIZE_BIN/gh"
+
+export PATH="$FINALIZE_BIN:$SAVED_PATH"
+export FINALIZE_STUB_DIR
+export CLAUDE_JOB_DIR="$FINALIZE_TMPDIR/job"
+mkdir -p "$CLAUDE_JOB_DIR"
+
+"$FINALIZE_SCRIPTS/dispatch-finalize-phase" 123 --pr 456
+rc=$?
+assert_eq "#2243 D2 dispatch-finalize-phase: exits 0" "0" "$rc"
+
+# Assert office-hours removed from the PR.
+pr_remove_log=$(cat "$FINALIZE_STUB_DIR/gh-pr-remove.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$pr_remove_log" == *"pr edit 456 --remove-label dispatch:office-hours"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2243 D2: --remove-label dispatch:office-hours issued for PR 456"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2243 D2: --remove-label dispatch:office-hours issued for PR 456"
+  echo "    gh-pr-remove.log: $pr_remove_log"
+fi
+
+# Assert office-hours removed from the issue.
+issue_remove_log=$(cat "$FINALIZE_STUB_DIR/gh-issue-remove.log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$issue_remove_log" == *"issue edit 123 --remove-label dispatch:office-hours"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2243 D2: --remove-label dispatch:office-hours issued for issue 123"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2243 D2: --remove-label dispatch:office-hours issued for issue 123"
+  echo "    gh-issue-remove.log: $issue_remove_log"
+fi
+
+# Assert spawn invoked exactly once.
+spawn_calls=$(wc -l < "$FINALIZE_STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "#2243 D2 dispatch-finalize-phase: spawn invoked exactly once" "1" "$spawn_calls"
+
+# Assert sweep invoked.
+TOTAL=$((TOTAL + 1))
+if [[ -e "$FINALIZE_STUB_DIR/sweep-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2243 D2: sweep invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2243 D2: sweep invoked"
+fi
+
+# Assert self-close invoked.
+TOTAL=$((TOTAL + 1))
+if [[ -e "$FINALIZE_STUB_DIR/self-close-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2243 D2: self-close invoked"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2243 D2: self-close invoked"
+fi
+
+# Assert self-close is LAST in order.log (spawn precedes self-close).
+order_log=$(cat "$FINALIZE_STUB_DIR/order.log" 2>/dev/null || true)
+last_entry=$(printf '%s' "$order_log" | tail -1)
+TOTAL=$((TOTAL + 1))
+if [[ "$last_entry" == "self-close" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2243 D2: self-close is last in order.log"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2243 D2: self-close is last in order.log"
+  echo "    order.log: $order_log"
+fi
+
+unset CLAUDE_JOB_DIR FINALIZE_STUB_DIR
+export PATH="$SAVED_PATH"
+rm -rf "$FINALIZE_TMPDIR"
+
 # ============================================================================
 # ensure_deps (lib.sh) retry tests
 # ============================================================================

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -1218,7 +1218,25 @@ fork site below (same discipline as the `fixes_applied_count` tally in Step 3.7)
      --disposition completed
    ```
 
-   Then **stop**. The Stop hook reads the marker and advances the chain.
+   **Then, as the ABSOLUTE LAST action**, run `dispatch-finalize-phase` — AFTER
+   the envelope emit above (it self-closes the session, terminating telemetry, so
+   all prior steps must complete first). It strips any premature
+   `dispatch:office-hours` from the issue + PR, spawns the next tick + sweep, and
+   self-closes (`exec claude rm`; a no-op interactively when `CLAUDE_JOB_DIR` is
+   unset). Use `dangerouslyDisableSandbox: true` — it invokes `gh` (network) and
+   `claude rm` (over a Unix socket):
+
+   ```bash
+   .claude/skills/dispatch-propagate/scripts/dispatch-finalize-phase "$N" --pr "$PR_NUM"
+   ```
+
+   This drives self-close, office-hours stripping, and chain propagation
+   deterministically — the chain no longer depends on a second Stop hook firing
+   (which the harness does not reliably emit after a background-task wait). A
+   stray second Stop firing afterward is harmless: every finalize step is
+   idempotent. This is the clean-pass success terminus only — the user-input
+   blocker escalation below does **not** call `dispatch-finalize-phase`; it
+   legitimately leaves the session for the Stop hook's office-hours disposition.
 
    **User-input blocker** — the escalation set (defined above) is **non-empty**.
    This fires when any member of the set is present: an `opus-fixable` or

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -780,11 +780,31 @@ REPO=$(git remote get-url origin | sed -E 's#.*github.com[:/]##; s#\.git$##')
   --disposition <result.disposition>
 ```
 
-Then **stop**. The Stop hook reads the marker and advances the chain. Applying
-`dispatch:reviewed` is unconditional; only the marker is skipped when the
-deviation criterion fires. Promotion to ready is never this skill's job — the
-router's `dispatch-reconcile-ready` owns it, reconciling the draft↔ready bit on
-every tick once CI is passing and `mergeable == MERGEABLE`.
+**Then, as the ABSOLUTE LAST action**, run `dispatch-finalize-phase` — AFTER the
+envelope emit above (it self-closes the session, terminating telemetry, so all
+prior steps must complete first). It strips any premature `dispatch:office-hours`
+from the issue + PR, spawns the next tick + sweep, and self-closes (`exec claude
+rm`; a no-op interactively when `CLAUDE_JOB_DIR` is unset). Use
+`dangerouslyDisableSandbox: true` — it invokes `gh` (network) and `claude rm`
+(over a Unix socket):
+
+```bash
+.claude/skills/dispatch-propagate/scripts/dispatch-finalize-phase <N> --pr "$PR_NUM"
+```
+
+This is the no-deviation success path only. On the deviation path and the
+idempotent re-entry path, do **not** call `dispatch-finalize-phase` — those
+legitimately leave the session for the Stop hook's office-hours disposition.
+
+`dispatch-finalize-phase` now drives self-close, office-hours stripping, and
+chain propagation deterministically — the chain no longer depends on a second
+Stop hook firing (which the harness does not reliably emit after a
+background-task wait). A stray second Stop firing afterward is harmless: every
+finalize step is idempotent. Applying `dispatch:reviewed` is unconditional; only
+the marker is skipped when the deviation criterion fires. Promotion to ready is
+never this skill's job — the router's `dispatch-reconcile-ready` owns it,
+reconciling the draft↔ready bit on every tick once CI is passing and
+`mergeable == MERGEABLE`.
 
 ## Per-finding schema
 


### PR DESCRIPTION
Closes #2243

## Problem

A Workflow-based phase skill (`/review-fix`, `/qa-fix`) launches its review/QA
fan-out as a **background** Workflow and yields its turn to await a
`<task-notification>`. That mid-phase turn-end fires the Stop hook
(`.claude/hooks/dispatch-stop.sh`) while the phase is still running in the
background and has **not** yet written its `phase-completed` marker. The hook
sees marker-absence, takes Branch A ("phase exited before completion"), parks the
issue on `dispatch:office-hours`, and spawns a tick — but the phase has not
exited. When the Workflow finishes and the session resumes it writes the marker,
but **no second Stop fires**, so the premature `office-hours` label is never
stripped and the session never self-closes. It sits open, parked-as-complete,
indefinitely.

Two coupled defects, fixed together (D1 alone would leave completed sessions
open-but-unparked — a different leak):

## D1 — premature park (Unit 1)

`.claude/hooks/dispatch-stop.sh` gains a new discriminator
`session_has_inflight_background_task`, symmetric to the existing
`session_scheduled_wakeup` guard (#1590). It reads the transcript directly
(positive-evidence-only, return 1 on any uncertainty per
`.claude/rules/shell-json.md`): it collects launched task IDs (`launched in
background. Task ID: <ID>`) and notified task IDs (`<task-notification>`
payloads' `"taskId":"<ID>"`, any status), and returns 0 iff at least one
launched ID has no matching notification. Branch A consults it after the
scheduled-wakeup guard and before the rate-limit-death check: an in-flight
background task hands back (`exit 0`, no park, no spawn) instead of parking.

## D2 — deterministic self-close terminus (Units 2 + 3)

New composite script
`.claude/skills/dispatch-propagate/scripts/dispatch-finalize-phase <issue>
[--pr <pr>]` runs the terminal disposition deterministically rather than
relying on a second Stop the harness does not fire: it clears
rate-limit-retry labels, strips `dispatch:office-hours` from **both** the issue
and the PR, spawns the next tick and the sweep, then self-closes
(`dispatch-self-close`; `exec claude rm`; interactive no-op). Every step is
best-effort and idempotent, so a stray second Stop is harmless. It is wired as
the **absolute last action** of the `/review-fix` and `/qa-fix` success paths,
after `dispatch-mark-complete` and the outcome-envelope emit (self-close
terminates telemetry, so it must run last). The deviation and re-entry paths are
untouched — they keep relying on the existing Stop disposition.

## Tests (Unit 4)

`test-dispatch-scripts.sh` gains: D1 in-flight-Workflow hand-back (no park, no
spawn); completed-Workflow falls through to the normal Branch A park; multiple
tasks with one outstanding hands back; and a D2 finalize test asserting
office-hours removed from issue **and** PR, spawn-once, sweep + self-close
present, and self-close last. Existing scheduled-wakeup hand-back and
genuine-mid-phase-death park tests stay green. Full suite: 3620/3620.
