### PR TITLE
office-hours: attach to originating session, provisioning a swept worktree from the remote branch

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-provision-from-remote
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-provision-from-remote
@@ -15,8 +15,7 @@
 #   2. git fetch --quiet origin <branch>  — pull the ref from origin.
 #   3. git worktree add --track -b <branch> <path> origin/<branch>  — add the
 #      local worktree tracking the remote branch.
-#   4. Print the created worktree path on stdout (so the caller knows the cwd).
-#   5. exec dispatch-provision-worktree <path>  — direnv allow/exec + merge
+#   4. exec dispatch-provision-worktree <path>  — direnv allow/exec + merge
 #      origin/main; `exec` propagates its exit code directly.
 #
 # Exit-code contract:
@@ -28,7 +27,7 @@
 #   3 — merge conflict; the merge has been aborted, tree is left clean — mirrors
 #       dispatch-provision-worktree's exit 3.
 #
-# `dangerouslyDisableSandbox: true` REQUIREMENT: step 5 runs
+# `dangerouslyDisableSandbox: true` REQUIREMENT: step 4 runs
 # dispatch-provision-worktree, which in turn runs `git merge origin/main`
 # (a tree-updating op over the read-only `.claude/skills/**` sandbox carve-out)
 # and `direnv`/npm (which write the dependency cache). This is the canonical
@@ -86,9 +85,6 @@ if ! git worktree add --track -b "$BRANCH" "$WORKTREE_PATH" "origin/$BRANCH" 1>&
   echo "dispatch-provision-from-remote: git worktree add (remote-only) failed for $BRANCH" >&2
   exit 2
 fi
-
-# Announce the path so the caller can learn the cwd before exec replaces us.
-echo "$WORKTREE_PATH"
 
 # --- Provision (direnv + dispatch-merge-main) ---------------------------------
 # `exec` so this script's exit code IS dispatch-provision-worktree's:

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-provision-from-remote
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-provision-from-remote
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# dispatch-provision-from-remote <branch> — fetch a remote branch and add its
+# worktree locally, then provision it (direnv + dispatch-merge-main).
+#
+# Used by the office-hours skill to re-create a swept worktree before attaching
+# the originating session to it (#2241).
+#
+# Argument:
+#   <branch>  A branch name of the form <N>-<slug> that exists on origin but
+#             has no local worktree yet.
+#
+# Steps, in order:
+#   1. Derive WORKTREE_PATH from PROJECT_ROOT (via resolve_project_root) +
+#      the branch name.
+#   2. git fetch --quiet origin <branch>  — pull the ref from origin.
+#   3. git worktree add --track -b <branch> <path> origin/<branch>  — add the
+#      local worktree tracking the remote branch.
+#   4. Print the created worktree path on stdout (so the caller knows the cwd).
+#   5. exec dispatch-provision-worktree <path>  — direnv allow/exec + merge
+#      origin/main; `exec` propagates its exit code directly.
+#
+# Exit-code contract:
+#   0 — clean provision (dispatch-provision-worktree / dispatch-merge-main says
+#       clean merge or already-up-to-date).
+#   1 — non-conflict failure (direnv failure, fetch failure, or merge failure
+#       other than a conflict) — mirrors dispatch-provision-worktree's exit 1.
+#   2 — usage error, missing remote branch, or git worktree-add failure.
+#   3 — merge conflict; the merge has been aborted, tree is left clean — mirrors
+#       dispatch-provision-worktree's exit 3.
+#
+# `dangerouslyDisableSandbox: true` REQUIREMENT: step 5 runs
+# dispatch-provision-worktree, which in turn runs `git merge origin/main`
+# (a tree-updating op over the read-only `.claude/skills/**` sandbox carve-out)
+# and `direnv`/npm (which write the dependency cache). This is the canonical
+# hazard documented in `.claude/rules/sandbox.md` ("Tree-updating git ops
+# touching read-only paths"). All callers must run this script with
+# `dangerouslyDisableSandbox: true`.
+#
+# Brownfield note: `dispatch-materialize-spawn` lines ~473-482 contain an
+# identical remote-only worktree-creation sequence (git fetch + git worktree add
+# --track). That path runs on the router hot path under a held lock, so a shared
+# refactor risks that critical section. Consolidating it onto this helper is a
+# candidate for a separate PR.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# --- Argument validation ------------------------------------------------------
+
+if [[ $# -lt 1 ]]; then
+  echo "dispatch-provision-from-remote: missing required <branch> argument" >&2
+  exit 2
+fi
+if [[ $# -gt 1 ]]; then
+  echo "dispatch-provision-from-remote: unexpected extra arguments after <branch>" >&2
+  exit 2
+fi
+if [[ "$1" == -* ]]; then
+  echo "dispatch-provision-from-remote: flag-shaped argument '$1' is not a branch name" >&2
+  exit 2
+fi
+
+BRANCH="$1"
+
+# --- Resolve paths ------------------------------------------------------------
+
+PROJECT_ROOT=$(resolve_project_root) || {
+  echo "dispatch-provision-from-remote: resolve_project_root failed — not in a git repo?" >&2
+  exit 2
+}
+
+WORKTREE_PATH="$PROJECT_ROOT/worktrees/$BRANCH"
+
+# --- Fetch the remote branch --------------------------------------------------
+
+if ! git fetch --quiet origin "$BRANCH" 1>&2; then
+  echo "dispatch-provision-from-remote: git fetch origin $BRANCH failed (branch missing on origin or network error)" >&2
+  exit 2
+fi
+
+# --- Add the local worktree ---------------------------------------------------
+
+if ! git worktree add --track -b "$BRANCH" "$WORKTREE_PATH" "origin/$BRANCH" 1>&2; then
+  echo "dispatch-provision-from-remote: git worktree add (remote-only) failed for $BRANCH" >&2
+  exit 2
+fi
+
+# Announce the path so the caller can learn the cwd before exec replaces us.
+echo "$WORKTREE_PATH"
+
+# --- Provision (direnv + dispatch-merge-main) ---------------------------------
+# `exec` so this script's exit code IS dispatch-provision-worktree's:
+#   0 — clean / already-up-to-date
+#   1 — direnv failure or non-conflict merge failure
+#   3 — merge conflict (aborted, tree left clean)
+exec "$SCRIPT_DIR/dispatch-provision-worktree" "$WORKTREE_PATH"

--- a/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh
@@ -293,8 +293,10 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
   }
 
   # claude_sessions_with_name_all <name> — emit live+done sessions matching <name>
-  # as sessionId<TAB>state TSV. See the header comment for the return-code contract
-  # and why it bypasses the snapshot.
+  # as sessionId<TAB>state<TAB>cwd TSV. See the header comment for the return-code
+  # contract and why it bypasses the snapshot. The `.cwd` column was added for #2241
+  # so the consumer (issue_live_session_id) can carry the session's working
+  # directory out and derive its branch when no <N>-* worktree is registered.
   claude_sessions_with_name_all() {
     local name="${1:-}"
     if [[ -z "$name" ]]; then
@@ -318,17 +320,67 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
     fi
 
     # One jq pass validates the JSON is an array and filters by exact name match,
-    # projecting sessionId and the granular state. Non-array input errors out and
-    # the result is UNKNOWN.
+    # projecting sessionId, the granular state, and the cwd (#2241). Non-array
+    # input errors out and the result is UNKNOWN.
     local lines
     if ! lines=$(jq -r --arg name "$name" '
       if type == "array"
-      then .[] | select(.name == $name) | [.sessionId, .state] | @tsv
+      then .[] | select(.name == $name) | [.sessionId, .state, .cwd] | @tsv
       else error("claude agents --json output is not a JSON array")
       end' <<<"$out" 2>/dev/null); then
       return 1
     fi
     # `[]` or no name matches → empty $lines → emit nothing, still return 0.
+    if [[ -n "$lines" ]]; then
+      printf '%s\n' "$lines"
+    fi
+    return 0
+  }
+
+  # claude_sessions_with_name_prefix_all <prefix> — emit live+done sessions whose
+  # name STARTS WITH <prefix> as sessionId<TAB>state<TAB>cwd TSV. Modeled on
+  # claude_sessions_with_name_all, differing only in the jq match: a `^<prefix>`
+  # regex test() instead of an exact `==`. Added for #2241 so issue_live_session_id
+  # can match phase-worker sessions named `<N>-slug` (the `^[0-9]+-` shape) by
+  # passing `<N>-` even when no <N>-* worktree is currently registered. The
+  # return-code contract is IDENTICAL to claude_sessions_with_name_all (rc1 on
+  # query/parse failure, drives the caller's saw_unknown) — only the match differs.
+  claude_sessions_with_name_prefix_all() {
+    local prefix="${1:-}"
+    if [[ -z "$prefix" ]]; then
+      printf 'lib-claude-agents: claude_sessions_with_name_prefix_all requires a <prefix> argument\n' >&2
+      return 1
+    fi
+
+    # --all so completed (`done`) sessions are visible; queried DIRECTLY (not via
+    # _claude_agents_raw) to bypass the snapshot, which is captured without --all
+    # and lacks `done` rows. 2>/dev/null drops daemon noise; only the exit code
+    # and a well-formed JSON array on stdout are trusted. A non-zero exit means
+    # the session state cannot be determined: unknown.
+    local out
+    if ! out=$("${CLAUDE_AGENTS_CMD:-claude}" agents --json --all 2>/dev/null); then
+      return 1
+    fi
+
+    # A zero exit with empty (or whitespace-only) output is unknown too.
+    if [[ -z "${out//[[:space:]]/}" ]]; then
+      return 1
+    fi
+
+    # One jq pass validates the JSON is an array and filters by name prefix
+    # (test("^" + $prefix), reusing the prefix idiom from live_session_claimed_nums
+    # / claude_agents_count_busy_workers), projecting sessionId, state, and cwd.
+    # The name is type-guarded so a null/absent name never aborts the pass.
+    # Non-array input errors out and the result is UNKNOWN.
+    local lines
+    if ! lines=$(jq -r --arg prefix "$prefix" '
+      if type == "array"
+      then .[] | select(.name | type == "string" and test("^" + $prefix)) | [.sessionId, .state, .cwd] | @tsv
+      else error("claude agents --json output is not a JSON array")
+      end' <<<"$out" 2>/dev/null); then
+      return 1
+    fi
+    # `[]` or no prefix matches → empty $lines → emit nothing, still return 0.
     if [[ -n "$lines" ]]; then
       printf '%s\n' "$lines"
     fi

--- a/.claude/skills/dispatch-propagate/scripts/office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours
@@ -150,9 +150,9 @@ case "$verb" in
   idle-provision)
     # a = originating sessionId; b = remote branch whose worktree was swept.
     # Provision the worktree from origin/<branch> first, then attach as idle.
-    # Run without command substitution so the provisioning script's stdout
-    # (git fetch/worktree/merge status) flows straight to the user's terminal.
-    if ! "$SCRIPT_DIR/dispatch-provision-from-remote" "$b"; then
+    # Redirect stdout to stderr so progress/status lines don't pollute office-hours'
+    # stdout (which callers capture to read the LAUNCH directive).
+    if ! "$SCRIPT_DIR/dispatch-provision-from-remote" "$b" >&2; then
       echo "office-hours: provisioning worktree for branch '$b' from the remote failed — cannot attach session $a. Check the output above: origin/$b may be missing or unfetchable (network/fetch error), the worktree-add may have failed, or origin/main may have a merge conflict with the branch." >&2
       exit 1
     fi

--- a/.claude/skills/dispatch-propagate/scripts/office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours
@@ -150,8 +150,10 @@ case "$verb" in
   idle-provision)
     # a = originating sessionId; b = remote branch whose worktree was swept.
     # Provision the worktree from origin/<branch> first, then attach as idle.
-    if ! worktree_path=$("$SCRIPT_DIR/dispatch-provision-from-remote" "$b"); then
-      echo "office-hours: provisioning worktree for branch '$b' from the remote failed — cannot attach session $a. Re-check that origin/$b exists and is fetchable." >&2
+    # Run without command substitution so the provisioning script's stdout
+    # (git fetch/worktree/merge status) flows straight to the user's terminal.
+    if ! "$SCRIPT_DIR/dispatch-provision-from-remote" "$b"; then
+      echo "office-hours: provisioning worktree for branch '$b' from the remote failed — cannot attach session $a. Check the output above: origin/$b may be missing or unfetchable (network/fetch error), the worktree-add may have failed, or origin/main may have a merge conflict with the branch." >&2
       exit 1
     fi
     attach_session "$a"

--- a/.claude/skills/dispatch-propagate/scripts/office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours
@@ -46,6 +46,17 @@
 #                                   <N>-slug worktree. When no <N>-* worktree
 #                                   resolves (5th field `-`), exit non-zero with
 #                                   a diagnostic and launch nothing.
+#   idle-provision <sessionId> <branch>
+#                                 → the originating session's worktree was swept
+#                                   but its remote branch still exists. Provision
+#                                   the worktree from origin/<branch> via
+#                                   dispatch-provision-from-remote, then attach
+#                                   the originating session (exactly as `idle`
+#                                   does). On any provisioning failure, exit
+#                                   non-zero with a diagnostic naming the branch
+#                                   — the selector already confirmed the remote
+#                                   exists, so a failure here is a genuine error
+#                                   and a silent fresh-spawn would mask it.
 #   empty                         → print a queue-empty message and exit WITHOUT
 #                                   launching Claude. The empty queue is handled
 #                                   entirely in bash; no session is booted.
@@ -135,6 +146,15 @@ case "$verb" in
     # sid is the spawned (or deduped) session's sessionId; attach_session
     # translates it to the daemon job id `claude attach` requires.
     attach_session "$sid"
+    ;;
+  idle-provision)
+    # a = originating sessionId; b = remote branch whose worktree was swept.
+    # Provision the worktree from origin/<branch> first, then attach as idle.
+    if ! worktree_path=$("$SCRIPT_DIR/dispatch-provision-from-remote" "$b"); then
+      echo "office-hours: provisioning worktree for branch '$b' from the remote failed — cannot attach session $a. Re-check that origin/$b exists and is fetchable." >&2
+      exit 1
+    fi
+    attach_session "$a"
     ;;
   empty)
     echo "office-hours: queue is empty — nothing to resume or start."

--- a/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
@@ -7,13 +7,33 @@
 # The office-hours queue is "open issues carrying the dispatch:office-hours
 # label" (the label is issue-anchored, #868/#909). The selector enumerates those
 # issues oldest-first, makes ONE per-item liveness call against each item's
-# <N>-* worktree, and emits exactly one of four dispositions, in this priority:
+# <N>-* worktree, and emits exactly one of five dispositions, in this priority:
 #
 #   idle <sessionId>
-#     The oldest labeled item whose <N>-* worktree has an idle/complete Claude
-#     session (state waiting/done/idle). Idle wins over fresh: if any labeled
-#     item has an attachable idle session, that session is attached in preference
-#     to picking up a sessionless sibling fresh.
+#     The oldest labeled item whose originating Claude session is idle/complete
+#     (state waiting/done/idle) AND whose worktree is still present on disk. Idle
+#     wins over fresh: if any labeled item has an attachable idle session, that
+#     session is attached in preference to picking up a sessionless sibling fresh.
+#
+#     The chosen attachable item is classified by the state of its session's
+#     worktree (the cwd `issue_live_session_id` now returns alongside the
+#     sessionId, #2241) into three buckets:
+#       1. Worktree present on disk → attach in place: emit `idle <sessionId>`.
+#       2. Worktree swept, but `origin/<branch>` still exists → emit
+#          `idle-provision <sessionId> <branch>` (below).
+#       3. Worktree swept AND `origin/<branch>` missing (or no cwd known) → fall
+#          back to the fresh path for this same issue, which — finding no
+#          registered worktree — emits `office-hours <N> <phase> <pr> -`; the
+#          consumer's `-` guard prints a clear swept-worktree diagnostic and
+#          exits. Fresh fallback with a diagnostic, never a silent failure.
+#
+#   idle-provision <sessionId> <branch>
+#     The oldest labeled item whose originating session is idle/complete but whose
+#     worktree has been SWEPT, while its remote branch `origin/<branch>` still
+#     exists (#2241). <branch> is the swept worktree's basename. The consumer
+#     re-provisions the worktree from the remote branch, then attaches the
+#     originating session — rather than spawning a fresh /office-hours that would
+#     lose the session's context.
 #
 #     The disposition gates on the granular session `state`, not mere liveness —
 #     it must only surface an IDLE session, never an actively-WORKING one. The
@@ -233,10 +253,15 @@ issue_live_session_id() {
 SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r 'sort_by(.createdAt) | .[].number')
 FRESH_NUM=""
 IDLE_ID=""
+IDLE_CWD=""
+IDLE_NUM=""
 while IFS= read -r issue_num; do
   [[ -z "$issue_num" ]] && continue
-  if sid=$(issue_live_session_id "$issue_num"); then
-    IDLE_ID="$sid"
+  if pair=$(issue_live_session_id "$issue_num"); then
+    # rc 0 → attachable; pair is `sessionId<TAB>cwd` (#2241). Split both fields
+    # and remember the issue so the post-loop classifier can derive its branch.
+    IFS=$'\t' read -r IDLE_ID IDLE_CWD <<< "$pair"
+    IDLE_NUM="$issue_num"
     break
   else
     rc=$?
@@ -247,10 +272,36 @@ while IFS= read -r issue_num; do
   fi
 done <<< "$SORTED"
 
-# Priority 1: emit the oldest idle item.
+# Priority 1: emit the oldest idle item. Classify the chosen attachable issue by
+# the state of its originating session's worktree (#2241):
+#   1. Worktree present on disk → attach in place: emit `idle <sessionId>`.
+#   2. Worktree swept but `origin/<branch>` still exists → emit
+#      `idle-provision <sessionId> <branch>`; the consumer (Unit 4) re-provisions
+#      the worktree from the remote branch before attaching.
+#   3. Worktree swept AND `origin/<branch>` missing, OR no cwd known → fall back
+#      to the fresh path for this issue (clear IDLE_ID, set FRESH_NUM). With no
+#      registered worktree the fresh path's wt_path lookup comes back empty, so it
+#      emits `office-hours <N> <phase> <pr> -`, and the consumer's `-` guard
+#      prints a clear swept-worktree diagnostic and exits — fresh fallback with a
+#      diagnostic, never a silent failure.
 if [[ -n "$IDLE_ID" ]]; then
-  printf 'idle %s\n' "$IDLE_ID"
-  exit 0
+  if [[ -d "$IDLE_CWD" ]]; then
+    printf 'idle %s\n' "$IDLE_ID"
+    exit 0
+  elif [[ -n "$IDLE_CWD" ]]; then
+    # Worktree swept. Its branch is the swept worktree's basename. Check the
+    # remote via `git -C <main>` — the selector's own cwd is not guaranteed to be
+    # a repo carrying `origin`. Suppress output; branch on the exit code.
+    branch=$(basename "$IDLE_CWD")
+    if git -C "$(resolve_main_worktree)" ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+      printf 'idle-provision %s %s\n' "$IDLE_ID" "$branch"
+      exit 0
+    fi
+  fi
+  # Bucket 3: swept with no recoverable remote branch, or no cwd. Route into the
+  # fresh path for the chosen issue.
+  IDLE_ID=""
+  FRESH_NUM="$IDLE_NUM"
 fi
 
 # Priority 2: pick up the oldest sessionless item fresh. The open-PR list is

--- a/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
@@ -134,62 +134,94 @@ while IFS= read -r wt_record; do
   fi
 done < <(list_worktree_records)
 
-# Returns the sessionId of an ATTACHABLE idle/complete session occupying a
-# <num>-* worktree on stdout (rc 0), or one of three non-attachable verdicts:
+# Returns an ATTACHABLE idle/complete session for the issue as a TAB-separated
+# `sessionId<TAB>cwd` on stdout (rc 0), or one of three non-attachable verdicts:
 #   rc 0 — attachable: an idle session (state waiting/done/idle) was found;
-#          its sessionId is on stdout.
-#   rc 1 — sessionless: no worktree, or every worktree queried clean.
-#   rc 2 — UNKNOWN: the daemon could not be queried for some worktree, and no
-#          attachable session was seen.
+#          `sessionId<TAB>cwd` is on stdout. The cwd (added #2241) lets the next
+#          unit stat the session's working directory and derive its branch — e.g.
+#          to provision a swept worktree from the remote branch.
+#   rc 1 — sessionless: no matching session was found anywhere.
+#   rc 2 — UNKNOWN: the daemon could not be queried, and no attachable session
+#          was seen.
 #   rc 3 — present-but-not-attachable: a session was seen but its state is
 #          working/stopped/paused/unrecognized — skip the issue (don't attach,
-#          don't fresh-launch into its occupied worktree).
-# Gates on the granular session `state` (via claude_sessions_with_name_all,
-# which passes --all so `done` sessions are visible), not on mere liveness.
-# Within an issue, an attachable idle session under ANY name/path wins, so the
-# loops keep looking past a skip/unknown row; the resolution priority once both
-# loops finish with no attachable match is attachable > skip (3) > unknown (2)
-# > sessionless (1).
-# Two-name check per worktree (#1311): queries both the worktree basename (phase
-# worker) and office-hours-<N> (the renamed office-hours session). Mirrors
-# worktree_has_live_session's basename-then-office-hours ordering so a
-# basename-named session still resolves first.
+#          don't fresh-launch on top of its live work).
+# Gates on the granular session `state` (via claude_sessions_with_name_all /
+# claude_sessions_with_name_prefix_all, which pass --all so `done` sessions are
+# visible), not on mere liveness. An attachable idle session under ANY name wins,
+# so the probe keeps looking past a skip/unknown row; the resolution priority once
+# every name is checked with no attachable match is attachable > skip (3) >
+# unknown (2) > sessionless (1).
+#
+# #2241: probes the local registry INDEPENDENT of worktree registration — there
+# is no longer a `[[ -z "$paths" ]] && return 1` gate short-circuiting the probe.
+# This is what lets office-hours re-attach to an originating session whose <N>-*
+# worktree has been swept. It also fixes a latent double-claim bug: a `working`
+# session with an unregistered worktree previously returned rc1 (sessionless) and
+# got fresh-launched on top of live work; it is now FOUND, hits the `*) saw_skip`
+# arm, and returns rc3 so the caller does NOT fresh-launch it (criterion 5).
+#
+# Name set:
+#   - When a <N>-* worktree IS registered, query the worktree basename (phase
+#     worker, exact) then office-hours-<N> (the renamed office-hours session,
+#     exact). The basename-first ordering (#1311) lets a basename-named session
+#     resolve first — mirrors worktree_has_live_session.
+#   - When NO worktree is registered there is no basename: match office-hours-<N>
+#     (exact) AND `^<N>-` (prefix, catching phase workers named `<N>-slug`).
 issue_live_session_id() {
-  local num="$1" p base nm sessions sid state saw_unknown=0 saw_skip=0
+  local num="$1" p base sid state cwd saw_unknown=0 saw_skip=0
   local paths="${WORKTREE_PATHS_BY_NUM[$num]:-}"
-  [[ -z "$paths" ]] && return 1
-  while IFS= read -r p; do
-    [[ -z "$p" ]] && continue
-    base=$(basename "$p")
-    # Two-name liveness (#1311): a session named after the worktree basename
-    # (phase worker) OR office-hours-<N> (the renamed office-hours session) occupies
-    # this worktree. Mirrors worktree_has_live_session's basename-then-office-hours
-    # ordering, so a basename-named session still resolves first.
-    for nm in "$base" "office-hours-$num"; do
-      if sessions=$(claude_sessions_with_name_all "$nm"); then
-        # rc 0 with non-empty output → a matching session row; rc 0 with empty
-        # output → no session of that name (continue). Guard before cutting.
-        if [[ -n "$sessions" ]]; then
-          IFS=$'\t' read -r sid state _ <<< "$(printf '%s\n' "$sessions" | head -n 1)"
-          case "$state" in
-            waiting|done|idle)
-              # Attachable — return immediately.
-              printf '%s' "$sid"
-              return 0
-              ;;
-            *)
-              # working/stopped/paused/unrecognized (or empty/malformed) →
-              # not attachable; keep looking — an attachable session under
-              # another name/path still wins.
-              saw_skip=1
-              ;;
-          esac
-        fi
-      else
-        saw_unknown=1
+
+  # Inspect one session-query result (sessionId<TAB>state<TAB>cwd TSV on stdout,
+  # rc reflecting the daemon-query contract). On the first attachable row it emits
+  # `sessionId<TAB>cwd` and returns 0 (the outer function then returns 0); a
+  # non-attachable row sets saw_skip; a query failure sets saw_unknown.
+  _inspect() {
+    local sessions
+    if sessions=$("$@"); then
+      # rc 0 with non-empty output → a matching session row; rc 0 with empty
+      # output → no session of that name (nothing to do). Guard before cutting.
+      if [[ -n "$sessions" ]]; then
+        IFS=$'\t' read -r sid state cwd _ <<< "$(printf '%s\n' "$sessions" | head -n 1)"
+        case "$state" in
+          waiting|done|idle)
+            # Attachable — emit sessionId<TAB>cwd (#2241) and signal the caller
+            # to return 0 immediately.
+            printf '%s\t%s\n' "$sid" "$cwd"
+            return 0
+            ;;
+          *)
+            # working/stopped/paused/unrecognized (or empty/malformed) → not
+            # attachable; keep looking — an attachable session under another
+            # name still wins. A `working` session with no registered worktree
+            # lands here (the #2241 double-claim fix): it is now found and skips
+            # rather than being mistaken for sessionless and fresh-launched.
+            saw_skip=1
+            ;;
+        esac
       fi
-    done
-  done <<< "$paths"
+    else
+      saw_unknown=1
+    fi
+    return 1
+  }
+
+  if [[ -n "$paths" ]]; then
+    # Worktree(s) registered: two-name exact check per worktree (#1311), basename
+    # first so a phase-worker session resolves before the renamed office-hours one.
+    while IFS= read -r p; do
+      [[ -z "$p" ]] && continue
+      base=$(basename "$p")
+      _inspect claude_sessions_with_name_all "$base" && return 0
+      _inspect claude_sessions_with_name_all "office-hours-$num" && return 0
+    done <<< "$paths"
+  else
+    # No worktree registered (#2241): no basename to key on. Match the renamed
+    # office-hours session (exact) AND any phase worker named `<N>-slug` (prefix).
+    _inspect claude_sessions_with_name_all "office-hours-$num" && return 0
+    _inspect claude_sessions_with_name_prefix_all "$num-" && return 0
+  fi
+
   (( saw_skip )) && return 3
   (( saw_unknown )) && return 2
   return 1

--- a/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
@@ -202,23 +202,29 @@ issue_live_session_id() {
       # rc 0 with non-empty output → a matching session row; rc 0 with empty
       # output → no session of that name (nothing to do). Guard before cutting.
       if [[ -n "$sessions" ]]; then
-        IFS=$'\t' read -r sid state cwd _ <<< "$(printf '%s\n' "$sessions" | head -n 1)"
-        case "$state" in
-          waiting|done|idle)
-            # Attachable — emit sessionId<TAB>cwd (#2241) and signal the caller
-            # to return 0 immediately.
-            printf '%s\t%s\n' "$sid" "$cwd"
-            return 0
-            ;;
-          *)
-            # working/stopped/paused/unrecognized (or empty/malformed) → not
-            # attachable; keep looking — an attachable session under another
-            # name still wins. A `working` session with no registered worktree
-            # lands here (the #2241 double-claim fix): it is now found and skips
-            # rather than being mistaken for sessionless and fresh-launched.
-            saw_skip=1
-            ;;
-        esac
+        # Iterate ALL rows: prefix matching (claude_sessions_with_name_prefix_all)
+        # can return multiple matching sessions, and a non-attachable first row
+        # must not mask an attachable later row. First-attachable-wins; keep
+        # scanning past non-attachable rows before settling on saw_skip
+        # (code-review #2241).
+        while IFS=$'\t' read -r sid state cwd _; do
+          case "$state" in
+            waiting|done|idle)
+              # Attachable — emit sessionId<TAB>cwd (#2241) and signal the caller
+              # to return 0 immediately.
+              printf '%s\t%s\n' "$sid" "$cwd"
+              return 0
+              ;;
+            *)
+              # working/stopped/paused/unrecognized (or empty/malformed) → not
+              # attachable; keep looking — an attachable session under another
+              # name still wins. A `working` session with no registered worktree
+              # lands here (the #2241 double-claim fix): it is now found and skips
+              # rather than being mistaken for sessionless and fresh-launched.
+              saw_skip=1
+              ;;
+          esac
+        done <<< "$sessions"
       fi
     else
       saw_unknown=1
@@ -299,9 +305,11 @@ if [[ -n "$IDLE_ID" ]]; then
     fi
   fi
   # Bucket 3: swept with no recoverable remote branch, or no cwd. Route into the
-  # fresh path for the chosen issue.
+  # fresh path for the chosen issue. Guard the overwrite so an older sessionless
+  # item already recorded during the loop is not dropped for a swept-unrecoverable
+  # attachable item (code-review #2241).
   IDLE_ID=""
-  FRESH_NUM="$IDLE_NUM"
+  [[ -z "$FRESH_NUM" ]] && FRESH_NUM="$IDLE_NUM"
 fi
 
 # Priority 2: pick up the oldest sessionless item fresh. The open-PR list is

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -61,6 +61,11 @@ setup() {
   cp "$SCRIPT_DIR/dispatch-select-target" "$TMPDIR_TEST/dispatch-select-target"
   cp "$SCRIPT_DIR/office-hours-select-target" "$TMPDIR_TEST/office-hours-select-target"
   cp "$SCRIPT_DIR/office-hours" "$TMPDIR_TEST/office-hours"
+  # office-hours' idle-provision arm resolves dispatch-provision-from-remote via
+  # its SCRIPT_DIR (= TMPDIR_TEST for this copy), so the helper must sit alongside
+  # it. Selector-only tests never run provisioning (the selector only checks
+  # ls-remote); entry tests that exercise provisioning stub the helper directly.
+  cp "$SCRIPT_DIR/dispatch-provision-from-remote" "$TMPDIR_TEST/dispatch-provision-from-remote"
   cp "$SCRIPT_DIR/dispatch-spawn-office-hours" "$TMPDIR_TEST/dispatch-spawn-office-hours"
   cp "$SCRIPT_DIR/dispatch-spawn-job" "$TMPDIR_TEST/dispatch-spawn-job"
   cp "$SCRIPT_DIR/dispatch-trace-leaf" "$TMPDIR_TEST/dispatch-trace-leaf"
@@ -117,6 +122,7 @@ setup() {
            "$TMPDIR_TEST/dispatch-select-target" \
            "$TMPDIR_TEST/office-hours-select-target" \
            "$TMPDIR_TEST/office-hours" \
+           "$TMPDIR_TEST/dispatch-provision-from-remote" \
            "$TMPDIR_TEST/dispatch-spawn-office-hours" \
            "$TMPDIR_TEST/dispatch-spawn-job" \
            "$TMPDIR_TEST/dispatch-trace-leaf" \
@@ -829,6 +835,20 @@ case "$args" in
     else
       echo "0"
     fi
+    ;;
+  *ls-remote\ --exit-code\ --heads\ origin\ *)
+    # office-hours-select-target's swept-worktree arm probes whether the branch
+    # still exists on origin via `git -C <main> ls-remote --exit-code --heads
+    # origin <branch>`. The -C <main> args precede ls-remote in "$@", so match on
+    # the substring. Consult $STUB_DIR/remote-branches.txt (one branch per line):
+    # exit 0 if listed, else exit 2 — mirroring real ls-remote --exit-code's exit
+    # 2 for no match. A missing fixture means "branch not listed" → exit 2.
+    branch="${args##* }"
+    if [[ -f "$STUB_DIR/remote-branches.txt" ]] && \
+       grep -Fxq "$branch" "$STUB_DIR/remote-branches.txt"; then
+      exit 0
+    fi
+    exit 2
     ;;
   *)
     echo "git stub: unknown invocation: $args" >&2
@@ -2811,12 +2831,20 @@ FAKE
 # entry script's launch + sessionId→job-id resolution) and CLAUDE_AGENTS_CMD
 # (the selector subprocess's state query), mirroring office_hours_fake_claude.
 office_hours_state_fake_claude() {
-  local payload="[" pair name state status_json first=1
+  local payload="[" pair name rest state cwd status_json first=1
   for pair in "$@"; do
-    name="${pair%%:*}"; state="${pair#*:}"
+    # Pair syntax: name:state[:cwd]. The optional third field carries a cwd path
+    # (paths contain no ':'), so split into at most 3 fields. A 2-field input
+    # leaves cwd empty — preserving the legacy name:state call sites.
+    name="${pair%%:*}"; rest="${pair#*:}"
+    if [[ "$rest" == *:* ]]; then
+      state="${rest%%:*}"; cwd="${rest#*:}"
+    else
+      state="$rest"; cwd=""
+    fi
     if [[ "$state" == "working" ]]; then status_json='"busy"'; else status_json='null'; fi
     if (( first )); then first=0; else payload+=","; fi
-    payload+="{\"sessionId\":\"s-$name\",\"id\":\"j-$name\",\"pid\":1,\"state\":\"$state\",\"status\":$status_json,\"name\":\"$name\",\"cwd\":\"\"}"
+    payload+="{\"sessionId\":\"s-$name\",\"id\":\"j-$name\",\"pid\":1,\"state\":\"$state\",\"status\":$status_json,\"name\":\"$name\",\"cwd\":\"$cwd\"}"
   done
   payload+="]"
   printf '%s' "$payload" > "$TMPDIR_TEST/claude-payload.json"
@@ -5871,7 +5899,11 @@ printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdA
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
   > "$STUB_DIR/worktree-list.txt"
-office_hours_state_fake_claude "42-x:waiting"   # 42's session is idle; 99 sessionless
+# The selector emits `idle` only when the session's cwd is a worktree present on
+# disk (#2241). Carry a real, on-disk cwd in the fake-session pair so the
+# present-worktree (bucket 1) branch fires.
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+office_hours_state_fake_claude "42-x:waiting:$TMPDIR_TEST/wt/42-x"   # 42's session is idle; 99 sessionless
 result=$("$TMPDIR_TEST/office-hours-select-target")
 assert_eq "idle item attached over sessionless sibling 99" "idle s-42-x" "$result"
 teardown
@@ -5885,7 +5917,8 @@ printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdA
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\nworktree /worktrees/99-y\nHEAD aaa111\nbranch refs/heads/99-y\n\n' \
   > "$STUB_DIR/worktree-list.txt"
-office_hours_state_fake_claude "42-x:waiting" "99-y:waiting"   # both idle
+mkdir -p "$TMPDIR_TEST/wt/42-x" "$TMPDIR_TEST/wt/99-y"
+office_hours_state_fake_claude "42-x:waiting:$TMPDIR_TEST/wt/42-x" "99-y:waiting:$TMPDIR_TEST/wt/99-y"   # both idle
 result=$("$TMPDIR_TEST/office-hours-select-target")
 assert_eq "oldest of two idle items attached" "idle s-42-x" "$result"
 teardown
@@ -5900,7 +5933,8 @@ echo '[]' > "$STUB_DIR/pr-list-full.json"
 # 42 (older) has no worktree at all → sessionless; 99 (newer) has an idle worktree.
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/99-y\nHEAD aaa111\nbranch refs/heads/99-y\n\n' \
   > "$STUB_DIR/worktree-list.txt"
-office_hours_state_fake_claude "99-y:idle"   # only 99's worktree is idle (attachable)
+mkdir -p "$TMPDIR_TEST/wt/99-y"
+office_hours_state_fake_claude "99-y:idle:$TMPDIR_TEST/wt/99-y"   # only 99's worktree is idle (attachable)
 result=$("$TMPDIR_TEST/office-hours-select-target")
 assert_eq "idle item attached regardless of age order" "idle s-99-y" "$result"
 teardown
@@ -5952,7 +5986,8 @@ printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-is
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
   > "$STUB_DIR/worktree-list.txt"
-office_hours_state_fake_claude "42-x:done"
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+office_hours_state_fake_claude "42-x:done:$TMPDIR_TEST/wt/42-x"
 result=$("$TMPDIR_TEST/office-hours-select-target")
 assert_eq "done session is attachable (visible only under --all)" "idle s-42-x" "$result"
 teardown
@@ -5988,7 +6023,8 @@ echo '[]' > "$STUB_DIR/pr-list-full.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
   > "$STUB_DIR/worktree-list.txt"
 export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
-office_hours_state_fake_claude "42-x:working" "office-hours-42:waiting"
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+office_hours_state_fake_claude "42-x:working" "office-hours-42:waiting:$TMPDIR_TEST/wt/42-x"
 result=$("$TMPDIR_TEST/office-hours-select-target")
 assert_eq "skip basename working, attach office-hours-42 waiting" "idle s-office-hours-42" "$result"
 unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
@@ -6010,19 +6046,27 @@ assert_eq "empty queue, no parked router prints empty" "empty" "$result"
 unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 
-# OHST5. Unknown daemon (UNKNOWN liveness) folds to occupied → the item with a
-# worktree is skipped; an item with no worktree (fast-path miss) still wins.
-echo "Test: UNKNOWN daemon skips worktree-bearing item, picks worktree-free one"
+# OHST5. UNKNOWN daemon → both items (worktree-bearing #42 and worktree-free #99)
+# fold to rc2 (UNKNOWN); neither is fresh-launched. This is the broadened
+# fail-safe from #2241: removing the [[ -z "$paths" ]] worktree gate means every
+# item is now probed against the daemon, so a failed query conservatively blocks
+# launch for ALL items (the item may have a live session the broken daemon could
+# not report). Criterion-4 (worktree-free → fresh) is now covered by OHST16
+# under a WORKING daemon instead. The script falls through to the parked-router
+# fallback → resolve_main_worktree → requires DISPATCH_OFFICE_HOURS_MAIN_WORKTREE.
+echo "Test: UNKNOWN daemon → neither worktree-bearing nor worktree-free item fresh-launched (#2241 fail-safe); empty"
 setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdAt":"2024-02-01T00:00:00Z"}]\n' \
   > "$STUB_DIR/oh-issue-list.json"
 echo '[]' > "$STUB_DIR/pr-list-full.json"
-# 42 has a worktree (liveness UNKNOWN → occupied → skipped); 99 has none.
+# 42 has a worktree; 99 has none. Under an UNKNOWN daemon both fold to rc2.
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
   > "$STUB_DIR/worktree-list.txt"
 # setup's default CLAUDE_AGENTS_CMD points at a non-existent binary (UNKNOWN).
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
 result=$("$TMPDIR_TEST/office-hours-select-target")
-assert_eq "UNKNOWN-liveness worktree item skipped; worktree-free item selected" "office-hours 99 plan - -" "$result"
+assert_eq "UNKNOWN daemon: neither item fresh-launched (no double-claim); empty" "empty" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 
 # Install a fake `claude` whose `agents --json` returns a controllable session
@@ -6186,7 +6230,8 @@ setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
   > "$STUB_DIR/worktree-list.txt"
-office_hours_state_fake_claude "42-x:waiting"   # 42's worktree has an idle session
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+office_hours_state_fake_claude "42-x:waiting:$TMPDIR_TEST/wt/42-x"   # 42's worktree has an idle session
 result=$("$TMPDIR_TEST/office-hours")
 assert_eq "attaches the idle session by its job id" "LAUNCH: attach j-42-x" "$result"
 teardown
@@ -6198,7 +6243,8 @@ printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdA
   > "$STUB_DIR/oh-issue-list.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\nworktree /worktrees/99-y\nHEAD aaa111\nbranch refs/heads/99-y\n\n' \
   > "$STUB_DIR/worktree-list.txt"
-office_hours_state_fake_claude "42-x:waiting" "99-y:waiting"   # both worktrees idle
+mkdir -p "$TMPDIR_TEST/wt/42-x" "$TMPDIR_TEST/wt/99-y"
+office_hours_state_fake_claude "42-x:waiting:$TMPDIR_TEST/wt/42-x" "99-y:waiting:$TMPDIR_TEST/wt/99-y"   # both worktrees idle
 result=$("$TMPDIR_TEST/office-hours")
 assert_eq "attaches the oldest idle item's session by its job id" "LAUNCH: attach j-42-x" "$result"
 teardown
@@ -6239,7 +6285,8 @@ setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
   > "$STUB_DIR/worktree-list.txt"
-office_hours_state_fake_claude "office-hours-42:waiting"   # idle office-hours-<N> session
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+office_hours_state_fake_claude "office-hours-42:waiting:$TMPDIR_TEST/wt/42-x"   # idle office-hours-<N> session
 result=$("$TMPDIR_TEST/office-hours")
 assert_eq "attaches the idle office-hours-<N> session by its job id" "LAUNCH: attach j-office-hours-42" "$result"
 teardown
@@ -6301,7 +6348,8 @@ printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdA
 # 42 (older) has no worktree at all → sessionless; 99 (newer) has an idle worktree.
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/99-y\nHEAD aaa111\nbranch refs/heads/99-y\n\n' \
   > "$STUB_DIR/worktree-list.txt"
-office_hours_state_fake_claude "99-y:idle"   # only 99's worktree is idle
+mkdir -p "$TMPDIR_TEST/wt/99-y"
+office_hours_state_fake_claude "99-y:idle:$TMPDIR_TEST/wt/99-y"   # only 99's worktree is idle
 result=$("$TMPDIR_TEST/office-hours")
 assert_eq "idle wins over fresh whenever any labeled item is attachable" "LAUNCH: attach j-99-y" "$result"
 teardown
@@ -6318,7 +6366,8 @@ setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
   > "$STUB_DIR/worktree-list.txt"
-office_hours_state_fake_claude "42-x:done"
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+office_hours_state_fake_claude "42-x:done:$TMPDIR_TEST/wt/42-x"
 result=$("$TMPDIR_TEST/office-hours")
 assert_eq "done session attached end-to-end by its job id" "LAUNCH: attach j-42-x" "$result"
 teardown

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6206,6 +6206,118 @@ assert_eq "main-qa override: phase main-qa, main worktree 5th field" \
 unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 
+# OHST13. Worktree-present attach (#2241 bucket 1, asserted with a cwd-bearing
+# fake): a registered <N>-* worktree whose originating session's cwd EXISTS on
+# disk → attach in place. This is the unchanged pre-#2241 behavior, now proved
+# through the cwd-bearing state fake: the session reports an on-disk cwd, the
+# selector's `-d "$IDLE_CWD"` gate passes, and it emits plain `idle`.
+echo "Test: registered worktree + on-disk session cwd → idle (attach in place)"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+# Registered worktree basename is 42-x; the session is the renamed office-hours-42
+# carrying an on-disk cwd. issue_live_session_id queries 42-x (miss) then
+# office-hours-42 (hit) → attachable with a present cwd → bucket 1.
+office_hours_state_fake_claude "office-hours-42:idle:$TMPDIR_TEST/wt/42-x"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "registered worktree + on-disk cwd → idle (attach in place)" "idle s-office-hours-42" "$result"
+teardown
+
+# OHST14. Worktree-swept attach-after-provision (#2241 bucket 2): an attachable
+# session whose cwd is NOT on disk (the worktree was swept), the <N>-* worktree is
+# NOT registered, but `origin/<branch>` still exists → emit `idle-provision`. The
+# session is named 42-x (a phase-worker `<N>-slug`), matched via the prefix path
+# since no worktree is registered; its swept cwd's basename is the branch to
+# re-provision.
+echo "Test: swept worktree + remote branch exists → idle-provision"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+# 42-x NOT registered (only main listed) → prefix-match path, swept-cwd bucket.
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '%s\n' '42-x' > "$STUB_DIR/remote-branches.txt"   # origin/42-x exists
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+# cwd /worktrees/42-x is non-empty but does NOT exist on disk → swept.
+office_hours_state_fake_claude "42-x:waiting:/worktrees/42-x"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "swept worktree, remote branch present → idle-provision" "idle-provision s-42-x 42-x" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
+teardown
+
+# OHST15. Remote-branch-missing fallback (#2241 bucket 3): same swept setup as
+# OHST14 but `origin/<branch>` is ABSENT (no remote-branches.txt) → the selector
+# cannot re-provision, so it falls back to the fresh path for this issue. With no
+# registered worktree the wt_path lookup is empty → 5th field `-`; no PR → phase
+# plan. The consumer's `-` guard later prints the swept diagnostic (see OH10).
+echo "Test: swept worktree + remote branch missing → fresh fallback (5th field -)"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' > "$STUB_DIR/worktree-list.txt"
+# Omit remote-branches.txt → ls-remote stub exits 2 → branch not on origin.
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+office_hours_state_fake_claude "42-x:waiting:/worktrees/42-x"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "swept worktree, remote branch missing → fresh fallback with - 5th field" "office-hours 42 plan - -" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
+teardown
+
+# OHST16. Not-local fresh-launch under a WORKING daemon (#2241 criterion-4,
+# relocated from OHST5): a worktree-free item under a daemon that genuinely
+# reports no session for it → fresh-launch. office_hours_state_fake_claude with
+# NO args installs a fake reporting `[]` (rc 0): the daemon is WORKING and the
+# item is genuinely sessionless, so it is picked fresh — distinct from OHST5's
+# UNKNOWN daemon, where the item conservatively folds to skip.
+echo "Test: worktree-free item under WORKING daemon → fresh-launch"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' > "$STUB_DIR/worktree-list.txt"   # no 42-* worktree
+office_hours_state_fake_claude   # WORKING daemon reporting no sessions ([], rc 0)
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "worktree-free item under WORKING daemon → fresh-launch" "office-hours 42 plan - -" "$result"
+teardown
+
+# OHST17. Working-session-no-worktree skip (#2241 criterion-5, latent double-claim
+# guard): a `working` session whose cwd is swept and whose <N>-* worktree is NOT
+# registered → the prefix probe FINDS the working session (rc 3) and SKIPS it,
+# rather than mistaking the item for sessionless and fresh-launching it. The lone
+# item is neither attachable nor fresh → parked-router fallback → no router →
+# empty. (Pre-#2241 the unregistered working session returned rc 1 and would have
+# been double-claimed by a fresh launch.)
+echo "Test: working session, no registered worktree → skip (no double-claim), empty"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' > "$STUB_DIR/worktree-list.txt"   # no 42-* worktree
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+office_hours_state_fake_claude "42-x:working:/worktrees/42-x"   # working session, prefix-matched
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "working session with no registered worktree → skipped, not fresh-launched; empty" "empty" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
+teardown
+
+# OHST18. Null-cwd degrade (#2241): an attachable session reporting an EMPTY cwd
+# (no 3rd field) with no registered <N>-* worktree → the selector finds it
+# attachable but cannot derive a branch (empty cwd fails both the `-d` and the
+# non-empty `[[ -n "$IDLE_CWD" ]]` checks) → bucket 3 → fall through to the fresh
+# path. No PR → plan; no worktree → 5th field `-`.
+echo "Test: attachable session with empty cwd, no worktree → fresh fallback"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' > "$STUB_DIR/worktree-list.txt"   # no 42-* worktree
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+# office-hours-42 (exact-match name) with NO cwd field → empty cwd → null-cwd degrade.
+office_hours_state_fake_claude "office-hours-42:waiting"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "attachable session, empty cwd, no worktree → fresh fallback with - 5th field" "office-hours 42 plan - -" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
+teardown
+
 # ============================================================================
 # office-hours (entry point) tests
 # ============================================================================
@@ -6440,6 +6552,79 @@ FAKE
 chmod +x "$TMPDIR_TEST/bin/claude"
 result=$("$TMPDIR_TEST/office-hours")
 assert_eq "parked-router directive attaches the router session by its job id" "LAUNCH: attach j-dispatch-abc123" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
+teardown
+
+# OH8. idle-provision end-to-end success (#2241): a swept attachable session whose
+# `origin/<branch>` exists → the selector emits `idle-provision s-42-x 42-x`; the
+# entry's idle-provision arm calls dispatch-provision-from-remote (stubbed here to
+# succeed) and then attaches the originating session by its resolved job id. The
+# fake claude must still report 42-x so attach_session resolves s-42-x → j-42-x.
+echo "Test: idle-provision verb → provision then attach (end-to-end success)"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' > "$STUB_DIR/worktree-list.txt"   # 42-x NOT registered → swept path
+printf '%s\n' '42-x' > "$STUB_DIR/remote-branches.txt"   # origin/42-x exists
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+office_hours_state_fake_claude "42-x:waiting:/worktrees/42-x"   # swept cwd; reports 42-x for attach resolution
+# Stub the provisioning helper to succeed (print a worktree path, exit 0).
+cat > "$TMPDIR_TEST/dispatch-provision-from-remote" <<'STUB'
+#!/usr/bin/env bash
+echo "/worktrees/$1"
+exit 0
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-provision-from-remote"
+result=$("$TMPDIR_TEST/office-hours")
+assert_eq "idle-provision → provision succeeds, then attach by job id" "LAUNCH: attach j-42-x" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
+teardown
+
+# OH9. idle-provision provision-failure (#2241): same setup as OH8 but the
+# provisioning helper FAILS (exit 1) → the entry prints a diagnostic to stderr and
+# exits non-zero WITHOUT attaching (no LAUNCH). clear-errors-over-fallbacks: a
+# provisioning failure surfaces, it does not silently fall back to a fresh launch.
+echo "Test: idle-provision provision failure → exit non-zero, no attach"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '%s\n' '42-x' > "$STUB_DIR/remote-branches.txt"
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+office_hours_state_fake_claude "42-x:waiting:/worktrees/42-x"
+# Stub the provisioning helper to FAIL.
+cat > "$TMPDIR_TEST/dispatch-provision-from-remote" <<'STUB'
+#!/usr/bin/env bash
+echo "provision failed" >&2
+exit 1
+STUB
+chmod +x "$TMPDIR_TEST/dispatch-provision-from-remote"
+rc=0; result=$("$TMPDIR_TEST/office-hours") || rc=$?
+assert_eq "provision failure → non-zero exit" "yes" "$([[ "$rc" -ne 0 ]] && echo yes || echo no)"
+assert_eq "provision failure → no LAUNCH (no attach)" "no" \
+  "$([[ "$result" == *LAUNCH:* ]] && echo yes || echo no)"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
+teardown
+
+# OH10. Swept-and-unprovisionable diagnostic (#2241 criterion-3, end-to-end): a
+# swept attachable session whose `origin/<branch>` is ABSENT → the selector falls
+# back to the fresh path with a `-` 5th field (`office-hours 42 plan - -`); the
+# entry's `[[ -z "$d" || "$d" == "-" ]]` guard prints the swept-worktree
+# diagnostic and exits non-zero without launching anything.
+echo "Test: swept + unprovisionable → swept diagnostic, exit non-zero, no launch"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' > "$STUB_DIR/worktree-list.txt"
+# Omit remote-branches.txt → origin/42-x missing → bucket 3 → fresh `-` path.
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+office_hours_state_fake_claude "42-x:waiting:/worktrees/42-x"
+rc=0; out=$("$TMPDIR_TEST/office-hours" 2>&1) || rc=$?
+assert_eq "swept + unprovisionable → non-zero exit" "yes" "$([[ "$rc" -ne 0 ]] && echo yes || echo no)"
+assert_eq "swept + unprovisionable → swept-worktree diagnostic on stderr" "yes" \
+  "$([[ "$out" == *'no <N>-* worktree resolved for #42 — cannot launch a fresh session'* ]] && echo yes || echo no)"
+assert_eq "swept + unprovisionable → no LAUNCH (no spawn)" "no" \
+  "$([[ "$out" == *LAUNCH:* ]] && echo yes || echo no)"
 unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 


### PR DESCRIPTION
Closes #2241

## What & why

When the office-hours queue selects an item, the selector only found the
originating phase-worker / office-hours session if a `<N>-*` worktree was still
registered: the `[[ -z "$paths" ]]` gate in `issue_live_session_id`
short-circuited the registry probe before it queried the daemon. When the
worktree had been swept, the probe reported the item as sessionless, so the
consumer spawned a brand-new `/office-hours` session and abandoned the
originating session's full context. The same gate was a latent **double-claim**
bug: a `working` session whose worktree was unregistered also looked sessionless
and could be fresh-launched on top of live work.

This PR probes the local registry **independent of worktree registration**. When
the originating session is local and attachable (`waiting`/`done`/`idle`) but its
worktree was swept, it provisions the worktree from `origin/<N>-<slug>` first,
then attaches the resumed session to a valid cwd. If the remote branch is missing
(or the session's `.cwd` is null/unresolvable) it falls back to a fresh launch
with a clear diagnostic — never a silent failure. Absent-from-registry still
fresh-launches; `working` stays skipped.

## How

- **Unit 1** — `office-hours-select-target` `issue_live_session_id`: removed the
  worktree gate so the registry is always probed; matches `office-hours-<N>`
  (exact) and `^<N>-` (prefix) when no worktree is registered; widened the return
  contract to `sessionId<TAB>cwd`. New `claude_sessions_with_name_prefix_all`
  helper in `lib-claude-agents.sh`, and both name helpers now project `.cwd`.
- **Unit 2** — the attachable-session loop is now ternary: worktree present →
  `idle`; worktree swept and `origin/<branch>` exists → new `idle-provision`
  verb; swept-and-unrecoverable or null cwd → fall through to fresh with a
  diagnostic.
- **Unit 3** — new helper `dispatch-provision-from-remote <branch>`: fetch +
  `git worktree add --track` + `dispatch-provision-worktree`, mirrored from
  `dispatch-materialize-spawn` (extracted, not duplicated; that hot-path caller
  is left for a separate consolidation PR).
- **Unit 4** — `office-hours` gains an `idle-provision)` arm: provision from the
  remote branch, then `attach_session`; a provisioning failure surfaces a clear
  error and exits non-zero.
- **Units 5–6** — test-harness plumbing (`name:state:cwd` fake-session syntax, a
  stubbable `git ls-remote --exit-code` check, the new helper registered) and
  scenario coverage (OHST13–18, OH8–10).

The attachable set is kept exactly `waiting|done|idle` to minimize the merge
conflict with sibling #2240, which widens it to `stopped`/`paused`.

## Behavior change worth a review eyeball

Removing the gate means every queue item is now probed against the daemon. A
consequence: when the daemon query **fails** (UNKNOWN), a worktree-free item is
no longer fresh-launched — previously the gate bypassed the query and launched it
anyway. This is the conservative side of the same double-claim fix (a worktree-free
item may have a live session a broken daemon could not report), and it matches the
existing "UNKNOWN daemon → empty" behavior elsewhere. The existing `OHST5` test
was updated to assert this; criterion-4 (worktree-free → fresh under a **working**
daemon) is now covered by the new `OHST16`.

## Verification

`test-dispatch-scripts.sh` passes (exit 0, 0 failed), including the new
OHST13–18 and OH8–10. Manual/judgment checks left for QA (documented in the
plan): confirm `git ls-remote` is reachable from the selector's `git -C <main>`
under the sandbox; confirm the real daemon's `agents --json --all` emits `.cwd`
for resumed sessions; eyeball that the `idle-provision` path leaves the resumed
session cwd'd into the freshly-added worktree.

Note: the suite prints one pre-existing, non-gating `FAIL: stamp: re-write
re-derives .base_sha` from a `( … )` subshell subsection. It exists on
`origin/main`, is unrelated to this PR (this branch touches neither the stamp
test nor `dispatch-stamp-session`), and does not affect the suite exit code.
