### PR TITLE
file-issue: REST-based duplicate detection (drop gh search issues)

### DIFF
--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -296,9 +296,9 @@ than one issue per file. The issue body carries only the filename and full
 sha256; the statement contents stay in the user's folder on disk.
 
 Idempotency is keyed on GitHub state, not a side file. For each file the scan
-computes its sha256 and runs `gh search issues` (which covers open AND closed
-issues) to check whether an issue with that hash already exists under the
-entry's label. A hit → skip; no hit → file. This is consistent with the #755
+computes its sha256 and runs `gh issue list --state all` (REST core API; covers
+open AND closed issues) to check whether an issue with that hash already exists
+under the entry's label. A hit → skip; no hit → file. This is consistent with the #755
 no-drift-prone-side-file principle. The local `tmp/dispatch-statements-state.json`
 debounce timestamp is a per-machine rate-limiter only — it skips the network
 calls within the configured window so a noisy tick does not hammer GitHub, but

--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -296,8 +296,8 @@ than one issue per file. The issue body carries only the filename and full
 sha256; the statement contents stay in the user's folder on disk.
 
 Idempotency is keyed on GitHub state, not a side file. For each file the scan
-computes its sha256 and runs `gh issue list --state all` (REST core API; covers
-open AND closed issues) to check whether an issue with that hash already exists
+computes its sha256 and runs `gh issue list --state all` (GraphQL-backed `gh
+issue list`; covers open AND closed issues) to check whether an issue with that hash already exists
 under the entry's label. A hit → skip; no hit → file. This is consistent with the #755
 no-drift-prone-side-file principle. The local `tmp/dispatch-statements-state.json`
 debounce timestamp is a per-machine rate-limiter only — it skips the network

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -224,7 +224,7 @@ dispatch_marker_comment_id() {
 # `labels` is already [{name,...}] in REST, so it passes through unchanged; a null
 # closedAt on open issues is harmless. Results are sorted created-descending so a
 # downstream `.[0]` is the most-recently-created issue. When --include-body is
-# passed, each projected object also carries a `body` field.
+# passed, each projected object also carries `title` and `body` fields.
 #
 # On gh failure: errors to stderr and returns 1 (clear-errors convention, no
 # fallback).
@@ -278,7 +278,7 @@ gh_issue_list_rest() {
 
   local projection='add // [] | map(select(.pull_request == null)) | map({number, createdAt: .created_at, closedAt: .closed_at, labels})'
   if [[ -n "$include_body" ]]; then
-    projection='add // [] | map(select(.pull_request == null)) | map({number, createdAt: .created_at, closedAt: .closed_at, labels, body})'
+    projection='add // [] | map(select(.pull_request == null)) | map({number, title, createdAt: .created_at, closedAt: .closed_at, labels, body})'
   fi
   printf '%s' "$raw" | jq -s "$projection"
 }

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -200,10 +200,10 @@ dispatch_marker_comment_id() {
 # per-tick scan was self-exhausting (#1601).
 #
 # Contract:
-#   gh_issue_list_rest --state <open|closed> [--repo <owner/repo>] [--label <name>] [--limit <n>] [--include-body]
+#   gh_issue_list_rest --state <open|closed|all> [--repo <owner/repo>] [--label <name>] [--limit <n>] [--include-body]
 #
 # Flags:
-#   --state  (required) open|closed.
+#   --state  (required) open|closed|all.
 #   --repo   (optional) owner/repo for a cross-repo scan; when absent the path
 #            uses the {owner}/{repo} placeholder gh auto-resolves for the
 #            current repo.
@@ -214,7 +214,7 @@ dispatch_marker_comment_id() {
 #            list's --limit default). When PRESENT we fetch a SINGLE page of that
 #            size (no --paginate).
 #   --include-body (optional) when present, the projected objects additionally
-#            carry a `body` field. Omitted by default so the repo-wide per-tick
+#            carry `title` and `body` fields. Omitted by default so the repo-wide per-tick
 #            callers stay byte-identical and payload-lean.
 #
 # Output: one merged JSON array on stdout. REST /issues returns issues AND PRs;

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -253,6 +253,9 @@ case "$args" in
       dispatch-test-limit)
         cat "$STUB_DIR/rest-limit.json"
         ;;
+      dispatch-test-includebody)
+        cat "$STUB_DIR/rest-includebody.json"
+        ;;
       *)
         echo '[]'
         ;;
@@ -1238,6 +1241,23 @@ if grep -q -- '--paginate' "$STUB_DIR/gh-issue-list-rest-calls.log"; then
 else
   assert_eq "--repo+--limit: log does not contain --paginate" "no" "no"
 fi
+teardown
+
+echo "Test: --include-body -- projection includes title and body; default omits title"
+setup
+printf '%s\n' '[
+  {"number":401,"title":"Fixture title for 401","created_at":"2024-01-09T00:00:00Z","closed_at":null,"labels":[],"body":"Fixture body for 401"}
+]' > "$STUB_DIR/rest-includebody.json"
+: > "$STUB_DIR/gh-issue-list-rest-calls.log"
+# --include-body: projection must carry a non-null title (Unit 1 #2259) and body.
+actual_ib=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state all --include-body --label dispatch-test-includebody)
+assert_eq "--include-body: .[0].title is the fixture title" "Fixture title for 401" "$(jq -r '.[0].title // empty' <<<"$actual_ib")"
+assert_eq "--include-body: .[0].body is the fixture body" "Fixture body for 401" "$(jq -r '.[0].body // empty' <<<"$actual_ib")"
+# Default projection (no --include-body) must still OMIT title (zero blast radius).
+: > "$STUB_DIR/gh-issue-list-rest-calls.log"
+actual_default=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state all --label dispatch-test-includebody)
+assert_eq "default projection: .[0].title is absent" "" "$(jq -r '.[0].title // empty' <<<"$actual_default")"
+assert_eq "default projection: .[0].number is present" "401" "$(jq -r '.[0].number // empty' <<<"$actual_default")"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1253,11 +1253,25 @@ printf '%s\n' '[
 actual_ib=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state all --include-body --label dispatch-test-includebody)
 assert_eq "--include-body: .[0].title is the fixture title" "Fixture title for 401" "$(jq -r '.[0].title // empty' <<<"$actual_ib")"
 assert_eq "--include-body: .[0].body is the fixture body" "Fixture body for 401" "$(jq -r '.[0].body // empty' <<<"$actual_ib")"
+# No --limit was passed, so the helper must take the full-paginate path. Pin the
+# code path: a regression to single-page would still emit the fixture content
+# from the stub but would not pass --paginate.
+if grep -q -- '--paginate' "$STUB_DIR/gh-issue-list-rest-calls.log"; then
+  assert_eq "--include-body: log contains --paginate" "yes" "yes"
+else
+  assert_eq "--include-body: log contains --paginate" "yes" "no"
+fi
 # Default projection (no --include-body) must still OMIT title (zero blast radius).
 : > "$STUB_DIR/gh-issue-list-rest-calls.log"
 actual_default=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state all --label dispatch-test-includebody)
 assert_eq "default projection: .[0].title is absent" "" "$(jq -r '.[0].title // empty' <<<"$actual_default")"
 assert_eq "default projection: .[0].number is present" "401" "$(jq -r '.[0].number // empty' <<<"$actual_default")"
+# Default projection also takes the no-limit full-paginate path.
+if grep -q -- '--paginate' "$STUB_DIR/gh-issue-list-rest-calls.log"; then
+  assert_eq "default projection: log contains --paginate" "yes" "yes"
+else
+  assert_eq "default projection: log contains --paginate" "yes" "no"
+fi
 teardown
 
 # ============================================================================

--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -350,11 +350,12 @@ Then proceed to Step 6 (finalize).
 
 ### Description mode
 
-Check once more for duplicates against the improved title + body using the same
-`gh_issue_list_rest` retrieval and local keyword filter from Step 3a (defense-in-depth
-recheck — `/file-issue` may be called from a non-interactive caller that did not
-pre-screen). If a match is found, skip creation for this spec and record
-`EXISTING <N>` as its Step 7 return line.
+Check once more for duplicates against the improved title + body. Reuse the
+`ALL_ISSUES` result captured in Step 3a and re-run the local keyword filter
+against the improved title + body — do not issue a second `gh_issue_list_rest`
+call (defense-in-depth recheck — `/file-issue` may be called from a
+non-interactive caller that did not pre-screen). If a match is found, skip
+creation for this spec and record `EXISTING <N>` as its Step 7 return line.
 
 If no duplicate, create the issue:
 ```bash

--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -166,11 +166,19 @@ Analyze all eight categories. Compile findings under each heading.
 
 ### a. Duplicates
 
-Extract 3–5 representative keywords from the title and body and run one search:
+Extract 3–5 representative keywords from the title and body. Then fetch all issues once via the REST core bucket (which covers both open and closed issues — an improvement over the old open-only search) and narrow locally on title+body with no additional network calls:
 
 ```bash
-gh search issues --repo {owner}/{repo} --state open --json number,title,body "<keywords>"
+source .claude/skills/dispatch-propagate/scripts/lib.sh
+# One REST fetch of all open+closed issues (REST core bucket, not the Search/GraphQL
+# API), then narrow LOCALLY to a small candidate set on title/body keywords.
+ALL_ISSUES=$(gh_issue_list_rest --state all --include-body)
+printf '%s' "$ALL_ISSUES" | jq -r --arg kw "<keyword>" '
+  .[] | select(((.title // "") + " " + (.body // "")) | ascii_downcase | contains($kw | ascii_downcase))
+      | {number, title, body}'
 ```
+
+Run the local filter for each extracted keyword and union the results to produce the candidate set.
 
 In description mode: if any candidate describes the same actionable change as
 the new title + body, treat it as an EXISTING match — skip creation for this spec
@@ -342,7 +350,8 @@ Then proceed to Step 6 (finalize).
 
 ### Description mode
 
-Check once more for duplicates against the improved title + body (defense-in-depth
+Check once more for duplicates against the improved title + body using the same
+`gh_issue_list_rest` retrieval and local keyword filter from Step 3a (defense-in-depth
 recheck — `/file-issue` may be called from a non-interactive caller that did not
 pre-screen). If a match is found, skip creation for this spec and record
 `EXISTING <N>` as its Step 7 return line.


### PR DESCRIPTION
Closes #2259

## What

Leaf 5 of the GraphQL→REST migration epic #2254: drop the `gh search issues`
call from `/file-issue` duplicate detection and replace it with a single REST
list fetch + local keyword filter.

The GitHub Search API is the tightest rate-limit bucket (30 req/min) and is
GraphQL-backed; a single fleet burst can exhaust it and kill phase workers. The
epic's REST core bucket (5000/hr) sits ~73% idle, so moving this load to REST is
the intended trade.

## Changes

- **`lib.sh`** — `gh_issue_list_rest`'s `--include-body` projection now also
  projects `title` (the default projection is unchanged, so the hot per-tick
  scan callers are unaffected — zero blast radius). The duplicate-detection
  filter needs title+body matching, and the helper previously projected only
  `body`.
- **`file-issue/SKILL.md`** — Step 3a duplicate detection now sources the
  dispatch lib, fetches once via `gh_issue_list_rest --state all --include-body`
  (one REST call covering open **and** closed issues, full-paginate, no
  truncation hazard), then narrows locally on title+body keywords. The semantic
  duplicate-judgment prose (conservative-bias guidance, issue-number-mode note,
  untrusted-data warning) is unchanged — only the retrieval mechanism changed.
  Coverage now includes closed issues, an improvement over the old `--state
  open`-only Search call.
- **`dispatch-propagate/reference.md`** — the stale clause claiming
  `dispatch-statements-scan` "runs `gh search issues`" is corrected to
  `gh issue list --state all` (REST), matching the script's actual
  implementation. This removes the last live `gh search issues` doc reference.
- **`test-dispatch-scripts.sh`** — new `gh_issue_list_rest (edge cases)`
  assertion: `--include-body` projects a non-null `title` and `body`, while the
  default projection still omits `title`.

## Note on title/body off-by-one

This issue's **title** names leaf-4 work ("migrate remaining gh issue list / gh
pr list calls"), but its **body** — the authoritative scope across the epic's
sub-issues — describes leaf-5 work (drop `gh search issues` from file-issue).
Dispatch keys scope off the body, and leaf 4's list-call migration is owned by
#2258's body, so there is no gap. This PR delivers leaf-5 work under a leaf-4
title/branch; the mismatch is cosmetic and expected.

## Verification

- `test-dispatch-scripts.sh`: 3624/3624 passed.
- `gh search issues` no longer appears in `file-issue/SKILL.md` or
  `dispatch-propagate/reference.md`.
- Dedup retrieves via `gh_issue_list_rest --state all`, and the helper's
  `--include-body` projection includes `title`.
