### PR TITLE
dispatch: add REST-backed gh helper functions to lib.sh (foundation)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -617,6 +617,266 @@ gh_pr_view_rest() {
   }'
 }
 
+# REST-backed mutation: add one or more labels to an issue (#2255).
+# Uses POST repos/{owner}/{repo}/issues/<N>/labels which is ADDITIVE (matching
+# `gh issue edit --add-label`). Each label is a separate -f flag so gh_retry
+# can re-invoke safely without draining a stdin pipe.
+# Args: $1 = <N> (issue number, required); then one or more label names;
+#   --repo owner/repo (optional).
+# On gh failure: errors to stderr and returns 1.
+gh_issue_set_labels_rest() {
+  local num="" repo=""
+  local -a labels=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) repo="$2"; shift 2 ;;
+      --*) echo "error: gh_issue_set_labels_rest: unknown flag '$1'" >&2; return 1 ;;
+      *)
+        if [[ -z "$num" ]]; then
+          num="$1"; shift 1
+        else
+          labels+=("$1"); shift 1
+        fi
+        ;;
+    esac
+  done
+  if [[ -z "$num" ]]; then
+    echo "error: gh_issue_set_labels_rest: issue number is required" >&2
+    return 1
+  fi
+  if [[ "${#labels[@]}" -eq 0 ]]; then
+    echo "error: gh_issue_set_labels_rest: at least one label is required" >&2
+    return 1
+  fi
+
+  local path
+  if [[ -n "$repo" ]]; then
+    path="repos/$repo/issues/$num/labels"
+  else
+    path="repos/{owner}/{repo}/issues/$num/labels"
+  fi
+
+  local -a label_flags=()
+  for lbl in "${labels[@]}"; do
+    label_flags+=(-f "labels[]=$lbl")
+  done
+
+  gh_retry gh api -X POST "$path" "${label_flags[@]}" >/dev/null || {
+    echo "error: gh_issue_set_labels_rest: gh api failed for $path" >&2
+    return 1
+  }
+}
+
+# REST-backed mutation: remove a single label from an issue (#2255).
+# Uses DELETE repos/{owner}/{repo}/issues/<N>/labels/<name>.
+# URL-encodes minimally (space→%20) mirroring gh_issue_list_rest.
+# Args: $1 = <N> (issue number, required); $2 = <label> (required);
+#   --repo owner/repo (optional).
+# On gh failure: errors to stderr and returns 1.
+gh_issue_remove_label_rest() {
+  local num="" label="" repo=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) repo="$2"; shift 2 ;;
+      --*) echo "error: gh_issue_remove_label_rest: unknown flag '$1'" >&2; return 1 ;;
+      *)
+        if [[ -z "$num" ]]; then
+          num="$1"; shift 1
+        elif [[ -z "$label" ]]; then
+          label="$1"; shift 1
+        else
+          echo "error: gh_issue_remove_label_rest: unexpected argument '$1'" >&2; return 1
+        fi
+        ;;
+    esac
+  done
+  if [[ -z "$num" ]]; then
+    echo "error: gh_issue_remove_label_rest: issue number is required" >&2
+    return 1
+  fi
+  if [[ -z "$label" ]]; then
+    echo "error: gh_issue_remove_label_rest: label name is required" >&2
+    return 1
+  fi
+
+  # Minimal URL-encode: space → %20 (mirrors gh_issue_list_rest).
+  local enc_label="${label// /%20}"
+
+  local path
+  if [[ -n "$repo" ]]; then
+    path="repos/$repo/issues/$num/labels/$enc_label"
+  else
+    path="repos/{owner}/{repo}/issues/$num/labels/$enc_label"
+  fi
+
+  gh_retry gh api -X DELETE "$path" >/dev/null || {
+    echo "error: gh_issue_remove_label_rest: gh api failed for $path" >&2
+    return 1
+  }
+}
+
+# REST-backed mutation: close an issue (#2255).
+# Uses PATCH repos/{owner}/{repo}/issues/<N> with state=closed.
+# Args: $1 = <N> (issue number, required); --repo owner/repo (optional).
+# On gh failure: errors to stderr and returns 1.
+gh_issue_close_rest() {
+  local num="" repo=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) repo="$2"; shift 2 ;;
+      --*) echo "error: gh_issue_close_rest: unknown flag '$1'" >&2; return 1 ;;
+      *) num="$1"; shift 1 ;;
+    esac
+  done
+  if [[ -z "$num" ]]; then
+    echo "error: gh_issue_close_rest: issue number is required" >&2
+    return 1
+  fi
+
+  local path
+  if [[ -n "$repo" ]]; then
+    path="repos/$repo/issues/$num"
+  else
+    path="repos/{owner}/{repo}/issues/$num"
+  fi
+
+  gh_retry gh api -X PATCH "$path" -f state=closed >/dev/null || {
+    echo "error: gh_issue_close_rest: gh api failed for $path" >&2
+    return 1
+  }
+}
+
+# REST-backed mutation: create a new issue (#2255).
+# Uses POST repos/{owner}/{repo}/issues.
+# Echoes the new issue URL (.html_url) to stdout, matching `gh issue create` output.
+# Args: --title <t> (required); --body <b> (required); --label <l> (repeatable);
+#   --repo owner/repo (optional).
+# On gh failure: errors to stderr and returns 1.
+gh_issue_create_rest() {
+  local title="" body="" repo=""
+  local -a label_flags=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --title) title="$2"; shift 2 ;;
+      --body)  body="$2";  shift 2 ;;
+      --label) label_flags+=(-f "labels[]=$2"); shift 2 ;;
+      --repo)  repo="$2";  shift 2 ;;
+      *) echo "error: gh_issue_create_rest: unknown flag '$1'" >&2; return 1 ;;
+    esac
+  done
+  if [[ -z "$title" ]]; then
+    echo "error: gh_issue_create_rest: --title is required" >&2
+    return 1
+  fi
+  if [[ -z "$body" ]]; then
+    echo "error: gh_issue_create_rest: --body is required" >&2
+    return 1
+  fi
+
+  local path
+  if [[ -n "$repo" ]]; then
+    path="repos/$repo/issues"
+  else
+    path="repos/{owner}/{repo}/issues"
+  fi
+
+  local raw
+  raw=$(gh_retry gh api -X POST "$path" \
+    -f "title=$title" \
+    -f "body=$body" \
+    "${label_flags[@]}") || {
+    echo "error: gh_issue_create_rest: gh api failed for $path" >&2
+    return 1
+  }
+
+  printf '%s' "$raw" | jq -r '.html_url'
+}
+
+# REST-backed mutation: add a comment to an issue (#2255).
+# Uses POST repos/{owner}/{repo}/issues/<N>/comments.
+# Args: $1 = <N> (issue number, required); --body <b> OR --body-file <f>
+#   (exactly one required); --repo owner/repo (optional).
+# On gh failure: errors to stderr and returns 1.
+gh_issue_comment_rest() {
+  local num="" body="" body_file="" repo=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --body)      body="$2";      shift 2 ;;
+      --body-file) body_file="$2"; shift 2 ;;
+      --repo)      repo="$2";      shift 2 ;;
+      --*) echo "error: gh_issue_comment_rest: unknown flag '$1'" >&2; return 1 ;;
+      *) num="$1"; shift 1 ;;
+    esac
+  done
+  if [[ -z "$num" ]]; then
+    echo "error: gh_issue_comment_rest: issue number is required" >&2
+    return 1
+  fi
+  if [[ -z "$body" && -z "$body_file" ]]; then
+    echo "error: gh_issue_comment_rest: --body or --body-file is required" >&2
+    return 1
+  fi
+  if [[ -n "$body" && -n "$body_file" ]]; then
+    echo "error: gh_issue_comment_rest: --body and --body-file are mutually exclusive" >&2
+    return 1
+  fi
+
+  local path
+  if [[ -n "$repo" ]]; then
+    path="repos/$repo/issues/$num/comments"
+  else
+    path="repos/{owner}/{repo}/issues/$num/comments"
+  fi
+
+  local -a body_flag=()
+  if [[ -n "$body_file" ]]; then
+    # -F body=@file re-reads the file on each retry attempt — safe for gh_retry.
+    body_flag=(-F "body=@$body_file")
+  else
+    body_flag=(-f "body=$body")
+  fi
+
+  gh_retry gh api -X POST "$path" "${body_flag[@]}" >/dev/null || {
+    echo "error: gh_issue_comment_rest: gh api failed for $path" >&2
+    return 1
+  }
+}
+
+# REST-backed mutation: merge a pull request (#2255).
+# Uses PUT repos/{owner}/{repo}/pulls/<N>/merge with merge_method.
+# Args: $1 = <N> (PR number, required); [--squash|--merge|--rebase] (default:
+#   merge); --repo owner/repo (optional).
+# On gh failure: errors to stderr and returns 1.
+gh_pr_merge_rest() {
+  local num="" method="merge" repo=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --squash) method="squash"; shift 1 ;;
+      --merge)  method="merge";  shift 1 ;;
+      --rebase) method="rebase"; shift 1 ;;
+      --repo)   repo="$2";       shift 2 ;;
+      --*) echo "error: gh_pr_merge_rest: unknown flag '$1'" >&2; return 1 ;;
+      *) num="$1"; shift 1 ;;
+    esac
+  done
+  if [[ -z "$num" ]]; then
+    echo "error: gh_pr_merge_rest: PR number is required" >&2
+    return 1
+  fi
+
+  local path
+  if [[ -n "$repo" ]]; then
+    path="repos/$repo/pulls/$num/merge"
+  else
+    path="repos/{owner}/{repo}/pulls/$num/merge"
+  fi
+
+  gh_retry gh api -X PUT "$path" -f "merge_method=$method" >/dev/null || {
+    echo "error: gh_pr_merge_rest: gh api failed for $path" >&2
+    return 1
+  }
+}
+
 # Detect what Firebase features the app uses.
 # Sets global variables: USES_FIRESTORE, USES_AUTH, USES_STORAGE, USES_FUNCTIONS
 # Args: $1 = path to app src/ directory, $2 = repo root, $3 = app name

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -501,6 +501,122 @@ dispatch_ci_verdict_rest() {
   printf '%s\n' "$verdict"
 }
 
+# REST-backed drop-in for `gh issue view <N> --json
+# number,title,body,state,labels,assignees` (#2255). The dispatch fleet exhausts
+# GitHub's shared GraphQL rate-limit bucket while the REST bucket sits idle; the
+# `gh issue view` porcelain spends GraphQL, this helper spends REST.
+# Args: $1 = <N> (issue number, required); --repo owner/repo (optional, defaults
+#   to the current repo via the {owner}/{repo} placeholder).
+# Output: one JSON object on stdout matching the porcelain shape — an EXPLICIT
+#   named projection (not a passthrough of the raw REST object) so the shape is
+#   pinned and tested:
+#     {number, title, body, state, labels:[{name}], assignees:[{login}]}
+# Byte-compat bridges over the raw REST shape:
+#   - state: REST returns lowercase `open`/`closed`; the porcelain emits the
+#     UPPERCASE GraphQL enum `OPEN`/`CLOSED`. `ascii_upcase` bridges it (same as
+#     dispatch_ci_verdict_rest's enum bridge).
+#   - labels / assignees: narrowed to the porcelain-visible keys (`name` /
+#     `login`) rather than passing the full REST objects through.
+# On gh failure: errors to stderr and returns 1 (clear-errors convention, no
+# fallback).
+gh_issue_view_rest() {
+  local num="" repo=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) repo="$2"; shift 2 ;;
+      --*) echo "error: gh_issue_view_rest: unknown flag '$1'" >&2; return 1 ;;
+      *) num="$1"; shift 1 ;;
+    esac
+  done
+  if [[ -z "$num" ]]; then
+    echo "error: gh_issue_view_rest: issue number is required" >&2
+    return 1
+  fi
+
+  local path
+  if [[ -n "$repo" ]]; then
+    path="repos/$repo/issues/$num"
+  else
+    path="repos/{owner}/{repo}/issues/$num"
+  fi
+
+  local raw
+  raw=$(gh_retry gh api "$path") || {
+    echo "error: gh_issue_view_rest: gh api failed for $path" >&2
+    return 1
+  }
+
+  printf '%s' "$raw" | jq '{
+    number,
+    title,
+    body: (.body // ""),
+    state: (.state | ascii_upcase),
+    labels: ((.labels // []) | map({name})),
+    assignees: ((.assignees // []) | map({login}))
+  }'
+}
+
+# REST-backed drop-in for `gh pr view <N> --json
+# number,title,body,state,mergeable,mergeStateStatus` (#2255). Spends the REST
+# rate-limit bucket instead of GraphQL, like gh_issue_view_rest.
+# Args: $1 = <N> (PR number, required); --repo owner/repo (optional).
+# Output: one JSON object on stdout matching the porcelain shape — an EXPLICIT
+#   named projection: {number, title, body, state, mergeable, mergeStateStatus}.
+# Byte-compat bridges over the raw REST shape:
+#   - state: lowercase `open`/`closed` → UPPERCASE via `ascii_upcase`. (REST has
+#     no distinct MERGED state — a merged PR is state `closed` — so a consumer
+#     that distinguishes the porcelain `MERGED` state must not migrate to this
+#     helper without handling that.)
+#   - mergeable: REST returns a BOOLEAN (true/false/null); the porcelain emits
+#     the GraphQL enum string `MERGEABLE`/`CONFLICTING`/`UNKNOWN` that dispatch
+#     call sites string-compare. Mapped explicitly: true→MERGEABLE,
+#     false→CONFLICTING, null (or absent)→UNKNOWN.
+#   - mergeStateStatus: remapped from REST's snake_case `mergeable_state` and
+#     `ascii_upcase`d to match the porcelain GraphQL enum casing (REST is
+#     lowercase `clean`/`dirty`/`blocked`).
+# On gh failure: errors to stderr and returns 1 (clear-errors convention, no
+# fallback).
+gh_pr_view_rest() {
+  local num="" repo=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) repo="$2"; shift 2 ;;
+      --*) echo "error: gh_pr_view_rest: unknown flag '$1'" >&2; return 1 ;;
+      *) num="$1"; shift 1 ;;
+    esac
+  done
+  if [[ -z "$num" ]]; then
+    echo "error: gh_pr_view_rest: PR number is required" >&2
+    return 1
+  fi
+
+  local path
+  if [[ -n "$repo" ]]; then
+    path="repos/$repo/pulls/$num"
+  else
+    path="repos/{owner}/{repo}/pulls/$num"
+  fi
+
+  local raw
+  raw=$(gh_retry gh api "$path") || {
+    echo "error: gh_pr_view_rest: gh api failed for $path" >&2
+    return 1
+  }
+
+  printf '%s' "$raw" | jq '{
+    number,
+    title,
+    body: (.body // ""),
+    state: (.state | ascii_upcase),
+    mergeable: (
+      if .mergeable == true then "MERGEABLE"
+      elif .mergeable == false then "CONFLICTING"
+      else "UNKNOWN" end
+    ),
+    mergeStateStatus: ((.mergeable_state // "") | ascii_upcase)
+  }'
+}
+
 # Detect what Firebase features the app uses.
 # Sets global variables: USES_FIRESTORE, USES_AUTH, USES_STORAGE, USES_FUNCTIONS
 # Args: $1 = path to app src/ directory, $2 = repo root, $3 = app name

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -525,7 +525,13 @@ gh_issue_view_rest() {
     case "$1" in
       --repo) repo="$2"; shift 2 ;;
       --*) echo "error: gh_issue_view_rest: unknown flag '$1'" >&2; return 1 ;;
-      *) num="$1"; shift 1 ;;
+      *)
+        if [[ -z "$num" ]]; then
+          num="$1"; shift 1
+        else
+          echo "error: gh_issue_view_rest: unexpected argument '$1'" >&2; return 1
+        fi
+        ;;
     esac
   done
   if [[ -z "$num" ]]; then
@@ -582,7 +588,13 @@ gh_pr_view_rest() {
     case "$1" in
       --repo) repo="$2"; shift 2 ;;
       --*) echo "error: gh_pr_view_rest: unknown flag '$1'" >&2; return 1 ;;
-      *) num="$1"; shift 1 ;;
+      *)
+        if [[ -z "$num" ]]; then
+          num="$1"; shift 1
+        else
+          echo "error: gh_pr_view_rest: unexpected argument '$1'" >&2; return 1
+        fi
+        ;;
     esac
   done
   if [[ -z "$num" ]]; then
@@ -725,7 +737,13 @@ gh_issue_close_rest() {
     case "$1" in
       --repo) repo="$2"; shift 2 ;;
       --*) echo "error: gh_issue_close_rest: unknown flag '$1'" >&2; return 1 ;;
-      *) num="$1"; shift 1 ;;
+      *)
+        if [[ -z "$num" ]]; then
+          num="$1"; shift 1
+        else
+          echo "error: gh_issue_close_rest: unexpected argument '$1'" >&2; return 1
+        fi
+        ;;
     esac
   done
   if [[ -z "$num" ]]; then
@@ -805,7 +823,13 @@ gh_issue_comment_rest() {
       --body-file) body_file="$2"; shift 2 ;;
       --repo)      repo="$2";      shift 2 ;;
       --*) echo "error: gh_issue_comment_rest: unknown flag '$1'" >&2; return 1 ;;
-      *) num="$1"; shift 1 ;;
+      *)
+        if [[ -z "$num" ]]; then
+          num="$1"; shift 1
+        else
+          echo "error: gh_issue_comment_rest: unexpected argument '$1'" >&2; return 1
+        fi
+        ;;
     esac
   done
   if [[ -z "$num" ]]; then
@@ -856,7 +880,13 @@ gh_pr_merge_rest() {
       --rebase) method="rebase"; shift 1 ;;
       --repo)   repo="$2";       shift 2 ;;
       --*) echo "error: gh_pr_merge_rest: unknown flag '$1'" >&2; return 1 ;;
-      *) num="$1"; shift 1 ;;
+      *)
+        if [[ -z "$num" ]]; then
+          num="$1"; shift 1
+        else
+          echo "error: gh_pr_merge_rest: unexpected argument '$1'" >&2; return 1
+        fi
+        ;;
     esac
   done
   if [[ -z "$num" ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1816,6 +1816,117 @@ assert_eq "pr-merge: gh-failure stderr names helper" "yes" "$m"
 teardown
 
 # ============================================================================
+# REST-bucket consumption assertions (#2255)
+# ============================================================================
+# Each new helper must consume the REST bucket (gh api repos/...) and NEVER the
+# GraphQL bucket (gh api graphql). This is the founding invariant of the #2254
+# epic: the fleet was exhausting the 5000/hr GraphQL bucket while the REST
+# bucket sat idle.
+#
+# Technique: drive each helper against the stub gh and assert from the per-helper
+# call-log file that the invocation used "api ... repos/" (REST) rather than
+# "api graphql" (GraphQL). The stub writes STUB_DIR/gh-<helper>-calls.log for
+# each sentinel branch (lines 472-576 of this file), so the log is the oracle.
+#
+# Manual / QA note (not runnable — networked and non-deterministic):
+#   Before: `gh api rate_limit | jq .resources.graphql.used`
+#   Run the helper.
+#   After:  `gh api rate_limit | jq .resources.graphql.used` — must NOT increase.
+#           `gh api rate_limit | jq .resources.core.used`    — must increase by 1.
+#
+# The in-suite form below is deterministic and offline.
+
+echo "=== REST-bucket consumption assertions ==="
+
+# Shared helper: assert a call-log line uses `api … repos/` (REST) and NOT
+# `api graphql` (GraphQL). Calling convention:
+#   assert_rest_only <label> <logfile>
+assert_rest_only() {
+  local label="$1" logfile="$2"
+  # Primary: path contains repos/ (REST endpoint)
+  if grep -q 'repos/' "$logfile"; then rp=yes; else rp=no; fi
+  assert_eq "${label}: REST path (repos/) present" "yes" "$rp"
+  # Secondary: graphql is absent (would spend the GraphQL bucket)
+  if grep -q 'graphql' "$logfile"; then gq=yes; else gq=no; fi
+  assert_eq "${label}: graphql absent from log" "no" "$gq"
+  # Belt-and-suspenders: porcelain subcommands absent (would also spend GraphQL)
+  if grep -qE '^(issue|pr) ' "$logfile"; then pc=yes; else pc=no; fi
+  assert_eq "${label}: porcelain (issue|pr) absent from log" "no" "$pc"
+}
+
+# --- gh_issue_view_rest ---
+# Use a 9xxx number — only the 9xxx sentinel branch (line 472) writes to
+# gh-issue-view-rest-calls.log; the generic issues/* branch does NOT.
+echo "Test: gh_issue_view_rest -- consumes REST bucket, not GraphQL"
+setup
+printf '%s\n' '{"number":9001,"title":"t","body":"b","state":"open","labels":[],"assignees":[]}' \
+  > "$STUB_DIR/view-issue-9001.json"
+: > "$STUB_DIR/gh-issue-view-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 9001 >/dev/null
+assert_rest_only "issue-view" "$STUB_DIR/gh-issue-view-rest-calls.log"
+teardown
+
+# --- gh_pr_view_rest ---
+# Use a 9xxx number — only the 9xxx sentinel branch (line 490) writes to
+# gh-pr-view-rest-calls.log; the generic pulls/* branch does NOT.
+echo "Test: gh_pr_view_rest -- consumes REST bucket, not GraphQL"
+setup
+printf '%s\n' '{"number":9001,"title":"t","body":"b","state":"open","mergeable":true,"mergeable_state":"clean"}' \
+  > "$STUB_DIR/view-pr-9001.json"
+: > "$STUB_DIR/gh-pr-view-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_pr_view_rest 9001 >/dev/null
+assert_rest_only "pr-view" "$STUB_DIR/gh-pr-view-rest-calls.log"
+teardown
+
+# --- gh_issue_set_labels_rest ---
+echo "Test: gh_issue_set_labels_rest -- consumes REST bucket, not GraphQL"
+setup
+: > "$STUB_DIR/gh-issue-set-labels-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_set_labels_rest 42 dispatch:planned
+assert_rest_only "set-labels" "$STUB_DIR/gh-issue-set-labels-rest-calls.log"
+teardown
+
+# --- gh_issue_remove_label_rest ---
+echo "Test: gh_issue_remove_label_rest -- consumes REST bucket, not GraphQL"
+setup
+: > "$STUB_DIR/gh-issue-remove-label-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_remove_label_rest 42 dispatch:planned
+assert_rest_only "remove-label" "$STUB_DIR/gh-issue-remove-label-rest-calls.log"
+teardown
+
+# --- gh_issue_close_rest ---
+echo "Test: gh_issue_close_rest -- consumes REST bucket, not GraphQL"
+setup
+: > "$STUB_DIR/gh-issue-close-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_close_rest 42
+assert_rest_only "close" "$STUB_DIR/gh-issue-close-rest-calls.log"
+teardown
+
+# --- gh_issue_create_rest ---
+echo "Test: gh_issue_create_rest -- consumes REST bucket, not GraphQL"
+setup
+: > "$STUB_DIR/gh-issue-create-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_create_rest --title "t" --body "b" >/dev/null
+assert_rest_only "create" "$STUB_DIR/gh-issue-create-rest-calls.log"
+teardown
+
+# --- gh_issue_comment_rest ---
+echo "Test: gh_issue_comment_rest -- consumes REST bucket, not GraphQL"
+setup
+: > "$STUB_DIR/gh-issue-comment-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_comment_rest 42 --body "a comment"
+assert_rest_only "comment" "$STUB_DIR/gh-issue-comment-rest-calls.log"
+teardown
+
+# --- gh_pr_merge_rest ---
+echo "Test: gh_pr_merge_rest -- consumes REST bucket, not GraphQL"
+setup
+: > "$STUB_DIR/gh-pr-merge-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_pr_merge_rest 42
+assert_rest_only "pr-merge" "$STUB_DIR/gh-pr-merge-rest-calls.log"
+teardown
+
+# ============================================================================
 # dispatch-phase tests
 # ============================================================================
 echo "=== dispatch-phase ==="

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1620,6 +1620,15 @@ case "$err_sl" in *"gh_issue_set_labels_rest: issue number is required"*) m=yes 
 assert_eq "set-labels: missing-number stderr names helper" "yes" "$m"
 teardown
 
+echo "Test: gh_issue_set_labels_rest -- number with zero labels returns non-zero"
+setup
+rc_sl_nl=0
+err_sl_nl=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_set_labels_rest 42 2>&1 >/dev/null) || rc_sl_nl=$?
+assert_eq "set-labels: no labels → non-zero" "1" "$rc_sl_nl"
+case "$err_sl_nl" in *"at least one label is required"*) m=yes ;; *) m=no ;; esac
+assert_eq "set-labels: no-labels stderr names requirement" "yes" "$m"
+teardown
+
 echo "Test: gh_issue_set_labels_rest -- gh failure returns non-zero with diagnostic stderr"
 setup
 : > "$STUB_DIR/gh-fail-rest"
@@ -1779,6 +1788,8 @@ printf '%s' "body from file" > "$STUB_DIR/comment-body.txt"
 source "$TMPDIR_TEST/lib.sh"; gh_issue_comment_rest 42 --body-file "$STUB_DIR/comment-body.txt"
 if grep -q 'issues/42/comments' "$STUB_DIR/gh-issue-comment-rest-calls.log"; then p=yes; else p=no; fi
 assert_eq "comment: --body-file path appears in log" "yes" "$p"
+if grep -q -- '-F body=@' "$STUB_DIR/gh-issue-comment-rest-calls.log"; then f=yes; else f=no; fi
+assert_eq "comment: --body-file uses -F body=@ flag" "yes" "$f"
 teardown
 
 echo "Test: gh_issue_comment_rest -- --repo flag emits cross-repo segment"
@@ -1801,6 +1812,15 @@ err_cmb=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_comment_rest 42 2>&1 >/dev/null
 assert_eq "comment: missing --body/--body-file → non-zero" "1" "$rc_cmb"
 case "$err_cmb" in *"gh_issue_comment_rest: --body or --body-file is required"*) m=yes ;; *) m=no ;; esac
 assert_eq "comment: missing-body stderr names helper" "yes" "$m"
+teardown
+
+echo "Test: gh_issue_comment_rest -- --body and --body-file together return non-zero"
+setup
+rc_cmx=0
+err_cmx=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_comment_rest 42 --body "b" --body-file /dev/null 2>&1 >/dev/null) || rc_cmx=$?
+assert_eq "comment: --body+--body-file → non-zero" "1" "$rc_cmx"
+case "$err_cmx" in *"mutually exclusive"*) m=yes ;; *) m=no ;; esac
+assert_eq "comment: --body+--body-file stderr names conflict" "yes" "$m"
 teardown
 
 echo "Test: gh_issue_comment_rest -- gh failure returns non-zero with diagnostic stderr"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -469,6 +469,41 @@ case "$args" in
       echo "[]"
     fi
     ;;
+  api\ repos/*/issues/9[0-9][0-9][0-9])
+    # gh_issue_view_rest sentinel branch (#2255): single-issue GET has no label to
+    # carry a sentinel, so reserve the 9xxx number range. MUST precede the generic
+    # `api repos/*/issues/*` branch (case is first-wins). A $STUB_DIR/gh-fail-rest
+    # marker forces a non-zero gh failure (drives the clear-errors path); otherwise
+    # $STUB_DIR/view-issue-<N>.json supplies the raw REST issue object.
+    echo "$args" >> "$STUB_DIR/gh-issue-view-rest-calls.log"
+    if [[ -f "$STUB_DIR/gh-fail-rest" ]]; then
+      echo "stub forced gh api failure" >&2
+      exit 1
+    fi
+    num="${args##*/}"
+    if [[ -f "$STUB_DIR/view-issue-${num}.json" ]]; then
+      cat "$STUB_DIR/view-issue-${num}.json"
+    else
+      echo '{}'
+    fi
+    ;;
+  api\ repos/*/pulls/9[0-9][0-9][0-9])
+    # gh_pr_view_rest sentinel branch (#2255): reserve the 9xxx PR number range.
+    # MUST precede the generic `api repos/*/pulls/*` branch (case is first-wins).
+    # A $STUB_DIR/gh-fail-rest marker forces a non-zero gh failure; otherwise
+    # $STUB_DIR/view-pr-<N>.json supplies the raw REST pull object.
+    echo "$args" >> "$STUB_DIR/gh-pr-view-rest-calls.log"
+    if [[ -f "$STUB_DIR/gh-fail-rest" ]]; then
+      echo "stub forced gh api failure" >&2
+      exit 1
+    fi
+    num="${args##*/}"
+    if [[ -f "$STUB_DIR/view-pr-${num}.json" ]]; then
+      cat "$STUB_DIR/view-pr-${num}.json"
+    else
+      echo '{}'
+    fi
+    ;;
   api\ repos/*/issues/*)
     # dispatch-resolve-arg discriminator: gh api repos/{owner}/{repo}/issues/<N>.
     # The REST issues endpoint returns PRs too; a PR's JSON carries a
@@ -1238,6 +1273,184 @@ if grep -q -- '--paginate' "$STUB_DIR/gh-issue-list-rest-calls.log"; then
 else
   assert_eq "--repo+--limit: log does not contain --paginate" "no" "no"
 fi
+teardown
+
+# ============================================================================
+# gh_issue_view_rest / gh_pr_view_rest byte-compatibility tests (#2255)
+# ============================================================================
+# These drive the REAL helpers (sourced from the copied lib.sh) via the 9xxx
+# sentinel stub branches. The oracle for the expected shape is the porcelain the
+# helpers replace: `gh issue view <N> --json number,title,body,state,labels,
+# assignees` (UPPERCASE state, labels:[{name}], assignees:[{login}]) and
+# `gh pr view <N> --json number,title,body,state,mergeable,mergeStateStatus`
+# (UPPERCASE state, mergeable as the GraphQL enum string, mergeStateStatus
+# UPPERCASE). The fixtures are the RAW REST shape (lowercase state, label/
+# assignee objects with extra keys, mergeable as a boolean, snake_case
+# mergeable_state), so the projection + casing/enum bridges are genuinely
+# exercised: delete a bridge and the assertions below flip RED.
+echo "=== gh_issue_view_rest / gh_pr_view_rest (byte-compat) ==="
+
+echo "Test: gh_issue_view_rest -- projection + state upcase + labels/assignees narrowing"
+setup
+# Raw REST issue: lowercase state, label objects carrying extra keys (id/color/
+# description), assignee objects carrying extra keys (id/type). The projection
+# must upcase state and narrow labels→[{name}] / assignees→[{login}].
+printf '%s\n' '{
+  "number": 9001,
+  "title": "a sample issue",
+  "body": "the issue body",
+  "state": "open",
+  "labels": [
+    {"id": 1, "name": "bug", "color": "ff0000", "description": "a bug"},
+    {"id": 2, "name": "dispatch:planned", "color": "00ff00", "description": null}
+  ],
+  "assignees": [
+    {"login": "alice", "id": 10, "type": "User"},
+    {"login": "bob", "id": 11, "type": "User"}
+  ],
+  "extra_rest_field": "must not appear in projection"
+}' > "$STUB_DIR/view-issue-9001.json"
+iv=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 9001)
+assert_eq "issue: number" "9001" "$(jq -r '.number' <<<"$iv")"
+assert_eq "issue: title" "a sample issue" "$(jq -r '.title' <<<"$iv")"
+assert_eq "issue: body" "the issue body" "$(jq -r '.body' <<<"$iv")"
+assert_eq "issue: state upcased OPEN" "OPEN" "$(jq -r '.state' <<<"$iv")"
+assert_eq "issue: labels narrowed to [{name}] (2 labels)" "2" "$(jq '.labels | length' <<<"$iv")"
+assert_eq "issue: first label name" "bug" "$(jq -r '.labels[0].name' <<<"$iv")"
+assert_eq "issue: label objects carry ONLY name (no color key)" "1" "$(jq '.labels[0] | keys | length' <<<"$iv")"
+assert_eq "issue: assignees narrowed to [{login}]" "alice" "$(jq -r '.assignees[0].login' <<<"$iv")"
+assert_eq "issue: assignee objects carry ONLY login" "1" "$(jq '.assignees[0] | keys | length' <<<"$iv")"
+assert_eq "issue: raw REST extra field dropped" "" "$(jq -r '.extra_rest_field // empty' <<<"$iv")"
+# Top-level keys are exactly the porcelain set.
+assert_eq "issue: top-level key set" "assignees body labels number state title" \
+  "$(jq -r 'keys | join(" ")' <<<"$iv")"
+teardown
+
+echo "Test: gh_issue_view_rest -- closed state upcases to CLOSED; empty labels/assignees"
+setup
+printf '%s\n' '{
+  "number": 9002,
+  "title": "closed one",
+  "body": "",
+  "state": "closed",
+  "labels": [],
+  "assignees": []
+}' > "$STUB_DIR/view-issue-9002.json"
+iv2=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 9002)
+assert_eq "issue: closed → CLOSED" "CLOSED" "$(jq -r '.state' <<<"$iv2")"
+# Byte-compat: a REST null body must surface as porcelain's empty string.
+printf '%s\n' '{"number":9004,"title":"t","state":"open","body":null,"labels":[],"assignees":[]}' \
+  > "$STUB_DIR/view-issue-9004.json"
+iv_nb=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 9004)
+assert_eq "issue: null body coerced to empty string" "true" "$(jq '.body == ""' <<<"$iv_nb")"
+assert_eq "issue: empty labels length 0" "0" "$(jq '.labels | length' <<<"$iv2")"
+assert_eq "issue: empty assignees length 0" "0" "$(jq '.assignees | length' <<<"$iv2")"
+teardown
+
+echo "Test: gh_issue_view_rest -- --repo flag emits cross-repo segment"
+setup
+: > "$STUB_DIR/gh-issue-view-rest-calls.log"
+printf '%s\n' '{"number":9003,"title":"t","body":"b","state":"open","labels":[],"assignees":[]}' \
+  > "$STUB_DIR/view-issue-9003.json"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 9003 --repo owner/other-repo >/dev/null
+if grep -q 'repos/owner/other-repo/issues/9003' "$STUB_DIR/gh-issue-view-rest-calls.log"; then seg=yes; else seg=no; fi
+assert_eq "issue: --repo uses cross-repo segment" "yes" "$seg"
+if grep -q 'repos/{owner}/{repo}/issues' "$STUB_DIR/gh-issue-view-rest-calls.log"; then ph=yes; else ph=no; fi
+assert_eq "issue: placeholder absent on cross-repo call" "no" "$ph"
+teardown
+
+echo "Test: gh_issue_view_rest -- missing number returns non-zero with diagnostic stderr"
+setup
+rc_iv=0
+err_iv=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 2>&1 >/dev/null) || rc_iv=$?
+assert_eq "issue: missing number → non-zero" "1" "$rc_iv"
+case "$err_iv" in *"gh_issue_view_rest: issue number is required"*) m=yes ;; *) m=no ;; esac
+assert_eq "issue: missing-number stderr names the helper" "yes" "$m"
+teardown
+
+echo "Test: gh_issue_view_rest -- gh failure returns non-zero with diagnostic stderr"
+setup
+: > "$STUB_DIR/gh-fail-rest"
+rc_ivf=0
+err_ivf=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 9001 2>&1 >/dev/null) || rc_ivf=$?
+assert_eq "issue: gh failure → non-zero" "1" "$rc_ivf"
+case "$err_ivf" in *"gh_issue_view_rest: gh api failed"*) mf=yes ;; *) mf=no ;; esac
+assert_eq "issue: gh-failure stderr names the helper" "yes" "$mf"
+teardown
+
+echo "Test: gh_pr_view_rest -- mergeable=true → MERGEABLE, clean→CLEAN, state upcase"
+setup
+# Raw REST pull: lowercase state, mergeable BOOLEAN true, snake_case
+# mergeable_state lowercase. Projection must map mergeable→enum string and
+# remap+upcase mergeable_state→mergeStateStatus.
+printf '%s\n' '{
+  "number": 9001,
+  "title": "a sample pr",
+  "body": "the pr body",
+  "state": "open",
+  "mergeable": true,
+  "mergeable_state": "clean",
+  "extra_rest_field": "drop me"
+}' > "$STUB_DIR/view-pr-9001.json"
+pv=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_view_rest 9001)
+assert_eq "pr: number" "9001" "$(jq -r '.number' <<<"$pv")"
+assert_eq "pr: title" "a sample pr" "$(jq -r '.title' <<<"$pv")"
+assert_eq "pr: body" "the pr body" "$(jq -r '.body' <<<"$pv")"
+assert_eq "pr: state upcased OPEN" "OPEN" "$(jq -r '.state' <<<"$pv")"
+assert_eq "pr: mergeable boolean true → enum MERGEABLE" "MERGEABLE" "$(jq -r '.mergeable' <<<"$pv")"
+assert_eq "pr: mergeStateStatus key present + upcased" "CLEAN" "$(jq -r '.mergeStateStatus' <<<"$pv")"
+assert_eq "pr: raw REST extra field dropped" "" "$(jq -r '.extra_rest_field // empty' <<<"$pv")"
+assert_eq "pr: top-level key set" "body mergeStateStatus mergeable number state title" \
+  "$(jq -r 'keys | join(" ")' <<<"$pv")"
+teardown
+
+echo "Test: gh_pr_view_rest -- mergeable=false → CONFLICTING, dirty→DIRTY, closed→CLOSED"
+setup
+printf '%s\n' '{
+  "number": 9002,
+  "title": "conflicting pr",
+  "body": "",
+  "state": "closed",
+  "mergeable": false,
+  "mergeable_state": "dirty"
+}' > "$STUB_DIR/view-pr-9002.json"
+pv2=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_view_rest 9002)
+assert_eq "pr: mergeable boolean false → CONFLICTING" "CONFLICTING" "$(jq -r '.mergeable' <<<"$pv2")"
+assert_eq "pr: mergeStateStatus dirty → DIRTY" "DIRTY" "$(jq -r '.mergeStateStatus' <<<"$pv2")"
+assert_eq "pr: closed → CLOSED" "CLOSED" "$(jq -r '.state' <<<"$pv2")"
+teardown
+
+echo "Test: gh_pr_view_rest -- mergeable=null → UNKNOWN; absent mergeable_state → empty"
+setup
+printf '%s\n' '{
+  "number": 9003,
+  "title": "computing pr",
+  "body": "",
+  "state": "open",
+  "mergeable": null
+}' > "$STUB_DIR/view-pr-9003.json"
+pv3=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_view_rest 9003)
+assert_eq "pr: mergeable null → UNKNOWN" "UNKNOWN" "$(jq -r '.mergeable' <<<"$pv3")"
+assert_eq "pr: absent mergeable_state → empty string" "" "$(jq -r '.mergeStateStatus' <<<"$pv3")"
+teardown
+
+echo "Test: gh_pr_view_rest -- missing number returns non-zero with diagnostic stderr"
+setup
+rc_pv=0
+err_pv=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_view_rest 2>&1 >/dev/null) || rc_pv=$?
+assert_eq "pr: missing number → non-zero" "1" "$rc_pv"
+case "$err_pv" in *"gh_pr_view_rest: PR number is required"*) mp=yes ;; *) mp=no ;; esac
+assert_eq "pr: missing-number stderr names the helper" "yes" "$mp"
+teardown
+
+echo "Test: gh_pr_view_rest -- gh failure returns non-zero with diagnostic stderr"
+setup
+: > "$STUB_DIR/gh-fail-rest"
+rc_pvf=0
+err_pvf=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_view_rest 9001 2>&1 >/dev/null) || rc_pvf=$?
+assert_eq "pr: gh failure → non-zero" "1" "$rc_pvf"
+case "$err_pvf" in *"gh_pr_view_rest: gh api failed"*) mpf=yes ;; *) mpf=no ;; esac
+assert_eq "pr: gh-failure stderr names the helper" "yes" "$mpf"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -504,6 +504,76 @@ case "$args" in
       echo '{}'
     fi
     ;;
+  "api -X POST "*/issues/*/labels*)
+    # gh_issue_set_labels_rest sentinel (#2255): POST .../issues/<N>/labels.
+    # MUST precede the generic `api repos/*/issues/*` branch (case is first-wins).
+    # $args form: "api -X POST repos/.../issues/<N>/labels -f labels[]=<label>..."
+    echo "$args" >> "$STUB_DIR/gh-issue-set-labels-rest-calls.log"
+    if [[ -f "$STUB_DIR/gh-fail-rest" ]]; then
+      echo "stub forced gh api failure" >&2
+      exit 1
+    fi
+    echo '[]'
+    ;;
+  "api -X DELETE "*/issues/*/labels/*)
+    # gh_issue_remove_label_rest sentinel (#2255): DELETE .../issues/<N>/labels/<name>.
+    # MUST precede the generic `api repos/*/issues/*` branch.
+    # $args form: "api -X DELETE repos/.../issues/<N>/labels/<url-encoded-name>"
+    echo "$args" >> "$STUB_DIR/gh-issue-remove-label-rest-calls.log"
+    if [[ -f "$STUB_DIR/gh-fail-rest" ]]; then
+      echo "stub forced gh api failure" >&2
+      exit 1
+    fi
+    echo '[]'
+    ;;
+  "api -X PATCH "*/issues/[0-9]*)
+    # gh_issue_close_rest sentinel (#2255): PATCH .../issues/<N> with state=closed.
+    # MUST precede the generic `api repos/*/issues/*` branch.
+    # $args form: "api -X PATCH repos/.../issues/<N> -f state=closed"
+    echo "$args" >> "$STUB_DIR/gh-issue-close-rest-calls.log"
+    if [[ -f "$STUB_DIR/gh-fail-rest" ]]; then
+      echo "stub forced gh api failure" >&2
+      exit 1
+    fi
+    echo '{}'
+    ;;
+  "api -X POST "*/issues/*/comments*)
+    # gh_issue_comment_rest sentinel (#2255): POST .../issues/<N>/comments.
+    # MUST precede the generic `api repos/*/issues/*` branch.
+    # $args form: "api -X POST repos/.../issues/<N>/comments -f body=..."
+    echo "$args" >> "$STUB_DIR/gh-issue-comment-rest-calls.log"
+    if [[ -f "$STUB_DIR/gh-fail-rest" ]]; then
+      echo "stub forced gh api failure" >&2
+      exit 1
+    fi
+    echo '{}'
+    ;;
+  "api -X POST "*/issues\ *)
+    # gh_issue_create_rest sentinel (#2255): POST .../issues (new issue creation).
+    # MUST precede the generic `api repos/*/issues/*` branch. The backslash-space
+    # anchors to the create endpoint (.../issues<SPACE>) rather than subpaths like
+    # .../issues/<N>/labels which the labels/comments branches above already handle.
+    # The labels/comments branches come first in the case so they take priority for
+    # those paths; this branch then catches only the bare create path.
+    # $args form: "api -X POST repos/.../issues -f title=... -f body=..."
+    echo "$args" >> "$STUB_DIR/gh-issue-create-rest-calls.log"
+    if [[ -f "$STUB_DIR/gh-fail-rest" ]]; then
+      echo "stub forced gh api failure" >&2
+      exit 1
+    fi
+    echo '{"number":9999,"html_url":"https://github.com/test/repo/issues/9999"}'
+    ;;
+  "api -X PUT "*/pulls/*/merge*)
+    # gh_pr_merge_rest sentinel (#2255): PUT .../pulls/<N>/merge.
+    # MUST precede the generic `api repos/*/pulls/*` branch.
+    # $args form: "api -X PUT repos/.../pulls/<N>/merge -f merge_method=..."
+    echo "$args" >> "$STUB_DIR/gh-pr-merge-rest-calls.log"
+    if [[ -f "$STUB_DIR/gh-fail-rest" ]]; then
+      echo "stub forced gh api failure" >&2
+      exit 1
+    fi
+    echo '{}'
+    ;;
   api\ repos/*/issues/*)
     # dispatch-resolve-arg discriminator: gh api repos/{owner}/{repo}/issues/<N>.
     # The REST issues endpoint returns PRs too; a PR's JSON carries a
@@ -1451,6 +1521,298 @@ err_pvf=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_view_rest 9001 2>&1 >/dev/null) ||
 assert_eq "pr: gh failure → non-zero" "1" "$rc_pvf"
 case "$err_pvf" in *"gh_pr_view_rest: gh api failed"*) mpf=yes ;; *) mpf=no ;; esac
 assert_eq "pr: gh-failure stderr names the helper" "yes" "$mpf"
+teardown
+
+# ============================================================================
+# Mutation REST helpers (#2255)
+# ============================================================================
+# These drive the REAL mutation helpers (sourced from the copied lib.sh) via the
+# sentinel stub branches added for gh_issue_set_labels_rest, gh_issue_remove_label_rest,
+# gh_issue_close_rest, gh_issue_create_rest, gh_issue_comment_rest, and
+# gh_pr_merge_rest. Each test:
+#   (a) asserts the helper hits the correct REST method and path, and
+#   (b) asserts the helper returns non-zero with descriptive stderr on gh failure.
+echo "=== mutation REST helpers ==="
+
+# --- gh_issue_set_labels_rest ---
+echo "Test: gh_issue_set_labels_rest -- POST to correct path, forwards labels"
+setup
+: > "$STUB_DIR/gh-issue-set-labels-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_set_labels_rest 42 dispatch:planned dispatch:qa-done
+if grep -q 'POST' "$STUB_DIR/gh-issue-set-labels-rest-calls.log"; then m=yes; else m=no; fi
+assert_eq "set-labels: log contains POST" "yes" "$m"
+if grep -q 'issues/42/labels' "$STUB_DIR/gh-issue-set-labels-rest-calls.log"; then p=yes; else p=no; fi
+assert_eq "set-labels: log contains issues/42/labels path" "yes" "$p"
+if grep -q 'dispatch:planned' "$STUB_DIR/gh-issue-set-labels-rest-calls.log"; then l=yes; else l=no; fi
+assert_eq "set-labels: log contains label name" "yes" "$l"
+teardown
+
+echo "Test: gh_issue_set_labels_rest -- --repo flag emits cross-repo segment"
+setup
+: > "$STUB_DIR/gh-issue-set-labels-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_set_labels_rest 42 dispatch:planned --repo owner/other-repo
+if grep -q 'repos/owner/other-repo/issues/42/labels' "$STUB_DIR/gh-issue-set-labels-rest-calls.log"; then seg=yes; else seg=no; fi
+assert_eq "set-labels: --repo uses cross-repo segment" "yes" "$seg"
+if grep -q 'repos/{owner}/{repo}' "$STUB_DIR/gh-issue-set-labels-rest-calls.log"; then ph=yes; else ph=no; fi
+assert_eq "set-labels: --repo placeholder absent" "no" "$ph"
+teardown
+
+echo "Test: gh_issue_set_labels_rest -- missing number returns non-zero"
+setup
+rc_sl=0
+err_sl=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_set_labels_rest 2>&1 >/dev/null) || rc_sl=$?
+assert_eq "set-labels: missing number → non-zero" "1" "$rc_sl"
+case "$err_sl" in *"gh_issue_set_labels_rest: issue number is required"*) m=yes ;; *) m=no ;; esac
+assert_eq "set-labels: missing-number stderr names helper" "yes" "$m"
+teardown
+
+echo "Test: gh_issue_set_labels_rest -- gh failure returns non-zero with diagnostic stderr"
+setup
+: > "$STUB_DIR/gh-fail-rest"
+rc_slf=0
+err_slf=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_set_labels_rest 42 dispatch:planned 2>&1 >/dev/null) || rc_slf=$?
+assert_eq "set-labels: gh failure → non-zero" "1" "$rc_slf"
+case "$err_slf" in *"gh_issue_set_labels_rest: gh api failed"*) m=yes ;; *) m=no ;; esac
+assert_eq "set-labels: gh-failure stderr names helper" "yes" "$m"
+teardown
+
+# --- gh_issue_remove_label_rest ---
+echo "Test: gh_issue_remove_label_rest -- DELETE to correct path, URL-encodes space"
+setup
+: > "$STUB_DIR/gh-issue-remove-label-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_remove_label_rest 42 "help wanted"
+if grep -q 'DELETE' "$STUB_DIR/gh-issue-remove-label-rest-calls.log"; then m=yes; else m=no; fi
+assert_eq "remove-label: log contains DELETE" "yes" "$m"
+if grep -q 'issues/42/labels/help%20wanted' "$STUB_DIR/gh-issue-remove-label-rest-calls.log"; then p=yes; else p=no; fi
+assert_eq "remove-label: path contains URL-encoded label" "yes" "$p"
+teardown
+
+echo "Test: gh_issue_remove_label_rest -- --repo flag emits cross-repo segment"
+setup
+: > "$STUB_DIR/gh-issue-remove-label-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_remove_label_rest 42 "dispatch:planned" --repo owner/other-repo
+if grep -q 'repos/owner/other-repo/issues/42/labels' "$STUB_DIR/gh-issue-remove-label-rest-calls.log"; then seg=yes; else seg=no; fi
+assert_eq "remove-label: --repo uses cross-repo segment" "yes" "$seg"
+teardown
+
+echo "Test: gh_issue_remove_label_rest -- missing args return non-zero"
+setup
+rc_rl=0
+err_rl=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_remove_label_rest 2>&1 >/dev/null) || rc_rl=$?
+assert_eq "remove-label: missing number → non-zero" "1" "$rc_rl"
+case "$err_rl" in *"gh_issue_remove_label_rest: issue number is required"*) m=yes ;; *) m=no ;; esac
+assert_eq "remove-label: missing-number stderr names helper" "yes" "$m"
+rc_rll=0
+err_rll=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_remove_label_rest 42 2>&1 >/dev/null) || rc_rll=$?
+assert_eq "remove-label: missing label → non-zero" "1" "$rc_rll"
+case "$err_rll" in *"gh_issue_remove_label_rest: label name is required"*) m=yes ;; *) m=no ;; esac
+assert_eq "remove-label: missing-label stderr names helper" "yes" "$m"
+teardown
+
+echo "Test: gh_issue_remove_label_rest -- gh failure returns non-zero with diagnostic stderr"
+setup
+: > "$STUB_DIR/gh-fail-rest"
+rc_rlf=0
+err_rlf=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_remove_label_rest 42 dispatch:planned 2>&1 >/dev/null) || rc_rlf=$?
+assert_eq "remove-label: gh failure → non-zero" "1" "$rc_rlf"
+case "$err_rlf" in *"gh_issue_remove_label_rest: gh api failed"*) m=yes ;; *) m=no ;; esac
+assert_eq "remove-label: gh-failure stderr names helper" "yes" "$m"
+teardown
+
+# --- gh_issue_close_rest ---
+echo "Test: gh_issue_close_rest -- PATCH to correct path with state=closed"
+setup
+: > "$STUB_DIR/gh-issue-close-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_close_rest 42
+if grep -q 'PATCH' "$STUB_DIR/gh-issue-close-rest-calls.log"; then m=yes; else m=no; fi
+assert_eq "close: log contains PATCH" "yes" "$m"
+if grep -q 'issues/42' "$STUB_DIR/gh-issue-close-rest-calls.log"; then p=yes; else p=no; fi
+assert_eq "close: log contains issues/42 path" "yes" "$p"
+if grep -q 'state=closed' "$STUB_DIR/gh-issue-close-rest-calls.log"; then s=yes; else s=no; fi
+assert_eq "close: log contains state=closed" "yes" "$s"
+teardown
+
+echo "Test: gh_issue_close_rest -- --repo flag emits cross-repo segment"
+setup
+: > "$STUB_DIR/gh-issue-close-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_close_rest 42 --repo owner/other-repo
+if grep -q 'repos/owner/other-repo/issues/42' "$STUB_DIR/gh-issue-close-rest-calls.log"; then seg=yes; else seg=no; fi
+assert_eq "close: --repo uses cross-repo segment" "yes" "$seg"
+teardown
+
+echo "Test: gh_issue_close_rest -- missing number returns non-zero"
+setup
+rc_cl=0
+err_cl=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_close_rest 2>&1 >/dev/null) || rc_cl=$?
+assert_eq "close: missing number → non-zero" "1" "$rc_cl"
+case "$err_cl" in *"gh_issue_close_rest: issue number is required"*) m=yes ;; *) m=no ;; esac
+assert_eq "close: missing-number stderr names helper" "yes" "$m"
+teardown
+
+echo "Test: gh_issue_close_rest -- gh failure returns non-zero with diagnostic stderr"
+setup
+: > "$STUB_DIR/gh-fail-rest"
+rc_clf=0
+err_clf=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_close_rest 42 2>&1 >/dev/null) || rc_clf=$?
+assert_eq "close: gh failure → non-zero" "1" "$rc_clf"
+case "$err_clf" in *"gh_issue_close_rest: gh api failed"*) m=yes ;; *) m=no ;; esac
+assert_eq "close: gh-failure stderr names helper" "yes" "$m"
+teardown
+
+# --- gh_issue_create_rest ---
+echo "Test: gh_issue_create_rest -- POST to correct path, echoes html_url, forwards title/body/labels"
+setup
+: > "$STUB_DIR/gh-issue-create-rest-calls.log"
+url=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_create_rest --title "Test issue" --body "body text" --label dispatch:planned)
+if grep -q 'POST' "$STUB_DIR/gh-issue-create-rest-calls.log"; then m=yes; else m=no; fi
+assert_eq "create: log contains POST" "yes" "$m"
+if grep -q 'title=Test issue' "$STUB_DIR/gh-issue-create-rest-calls.log"; then t=yes; else t=no; fi
+assert_eq "create: log contains title" "yes" "$t"
+if grep -q 'dispatch:planned' "$STUB_DIR/gh-issue-create-rest-calls.log"; then l=yes; else l=no; fi
+assert_eq "create: log contains label" "yes" "$l"
+assert_eq "create: stdout is the issue URL" "https://github.com/test/repo/issues/9999" "$url"
+teardown
+
+echo "Test: gh_issue_create_rest -- --repo flag emits cross-repo segment"
+setup
+: > "$STUB_DIR/gh-issue-create-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_create_rest --title "t" --body "b" --repo owner/other-repo >/dev/null
+if grep -q 'repos/owner/other-repo/issues' "$STUB_DIR/gh-issue-create-rest-calls.log"; then seg=yes; else seg=no; fi
+assert_eq "create: --repo uses cross-repo segment" "yes" "$seg"
+teardown
+
+echo "Test: gh_issue_create_rest -- missing required args return non-zero"
+setup
+rc_ic=0
+err_ic=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_create_rest --body "b" 2>&1 >/dev/null) || rc_ic=$?
+assert_eq "create: missing --title → non-zero" "1" "$rc_ic"
+case "$err_ic" in *"gh_issue_create_rest: --title is required"*) m=yes ;; *) m=no ;; esac
+assert_eq "create: missing-title stderr names helper" "yes" "$m"
+rc_icb=0
+err_icb=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_create_rest --title "t" 2>&1 >/dev/null) || rc_icb=$?
+assert_eq "create: missing --body → non-zero" "1" "$rc_icb"
+case "$err_icb" in *"gh_issue_create_rest: --body is required"*) m=yes ;; *) m=no ;; esac
+assert_eq "create: missing-body stderr names helper" "yes" "$m"
+teardown
+
+echo "Test: gh_issue_create_rest -- gh failure returns non-zero with diagnostic stderr"
+setup
+: > "$STUB_DIR/gh-fail-rest"
+rc_icf=0
+err_icf=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_create_rest --title "t" --body "b" 2>&1 >/dev/null) || rc_icf=$?
+assert_eq "create: gh failure → non-zero" "1" "$rc_icf"
+case "$err_icf" in *"gh_issue_create_rest: gh api failed"*) m=yes ;; *) m=no ;; esac
+assert_eq "create: gh-failure stderr names helper" "yes" "$m"
+teardown
+
+# --- gh_issue_comment_rest ---
+echo "Test: gh_issue_comment_rest -- POST to correct path, forwards body"
+setup
+: > "$STUB_DIR/gh-issue-comment-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_comment_rest 42 --body "a comment"
+if grep -q 'POST' "$STUB_DIR/gh-issue-comment-rest-calls.log"; then m=yes; else m=no; fi
+assert_eq "comment: log contains POST" "yes" "$m"
+if grep -q 'issues/42/comments' "$STUB_DIR/gh-issue-comment-rest-calls.log"; then p=yes; else p=no; fi
+assert_eq "comment: log contains issues/42/comments path" "yes" "$p"
+if grep -q 'a comment' "$STUB_DIR/gh-issue-comment-rest-calls.log"; then b=yes; else b=no; fi
+assert_eq "comment: log contains body text" "yes" "$b"
+teardown
+
+echo "Test: gh_issue_comment_rest -- --body-file reads body from file"
+setup
+: > "$STUB_DIR/gh-issue-comment-rest-calls.log"
+printf '%s' "body from file" > "$STUB_DIR/comment-body.txt"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_comment_rest 42 --body-file "$STUB_DIR/comment-body.txt"
+if grep -q 'issues/42/comments' "$STUB_DIR/gh-issue-comment-rest-calls.log"; then p=yes; else p=no; fi
+assert_eq "comment: --body-file path appears in log" "yes" "$p"
+teardown
+
+echo "Test: gh_issue_comment_rest -- --repo flag emits cross-repo segment"
+setup
+: > "$STUB_DIR/gh-issue-comment-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_issue_comment_rest 42 --body "b" --repo owner/other-repo
+if grep -q 'repos/owner/other-repo/issues/42/comments' "$STUB_DIR/gh-issue-comment-rest-calls.log"; then seg=yes; else seg=no; fi
+assert_eq "comment: --repo uses cross-repo segment" "yes" "$seg"
+teardown
+
+echo "Test: gh_issue_comment_rest -- missing required args return non-zero"
+setup
+rc_cm=0
+err_cm=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_comment_rest 2>&1 >/dev/null) || rc_cm=$?
+assert_eq "comment: missing number → non-zero" "1" "$rc_cm"
+case "$err_cm" in *"gh_issue_comment_rest: issue number is required"*) m=yes ;; *) m=no ;; esac
+assert_eq "comment: missing-number stderr names helper" "yes" "$m"
+rc_cmb=0
+err_cmb=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_comment_rest 42 2>&1 >/dev/null) || rc_cmb=$?
+assert_eq "comment: missing --body/--body-file → non-zero" "1" "$rc_cmb"
+case "$err_cmb" in *"gh_issue_comment_rest: --body or --body-file is required"*) m=yes ;; *) m=no ;; esac
+assert_eq "comment: missing-body stderr names helper" "yes" "$m"
+teardown
+
+echo "Test: gh_issue_comment_rest -- gh failure returns non-zero with diagnostic stderr"
+setup
+: > "$STUB_DIR/gh-fail-rest"
+rc_cmf=0
+err_cmf=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_comment_rest 42 --body "b" 2>&1 >/dev/null) || rc_cmf=$?
+assert_eq "comment: gh failure → non-zero" "1" "$rc_cmf"
+case "$err_cmf" in *"gh_issue_comment_rest: gh api failed"*) m=yes ;; *) m=no ;; esac
+assert_eq "comment: gh-failure stderr names helper" "yes" "$m"
+teardown
+
+# --- gh_pr_merge_rest ---
+echo "Test: gh_pr_merge_rest -- PUT to correct path, default merge_method=merge"
+setup
+: > "$STUB_DIR/gh-pr-merge-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_pr_merge_rest 42
+if grep -q 'PUT' "$STUB_DIR/gh-pr-merge-rest-calls.log"; then m=yes; else m=no; fi
+assert_eq "pr-merge: log contains PUT" "yes" "$m"
+if grep -q 'pulls/42/merge' "$STUB_DIR/gh-pr-merge-rest-calls.log"; then p=yes; else p=no; fi
+assert_eq "pr-merge: log contains pulls/42/merge path" "yes" "$p"
+if grep -q 'merge_method=merge' "$STUB_DIR/gh-pr-merge-rest-calls.log"; then mm=yes; else mm=no; fi
+assert_eq "pr-merge: default merge_method=merge" "yes" "$mm"
+teardown
+
+echo "Test: gh_pr_merge_rest -- --squash sets merge_method=squash"
+setup
+: > "$STUB_DIR/gh-pr-merge-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_pr_merge_rest 42 --squash
+if grep -q 'merge_method=squash' "$STUB_DIR/gh-pr-merge-rest-calls.log"; then m=yes; else m=no; fi
+assert_eq "pr-merge: --squash → merge_method=squash" "yes" "$m"
+teardown
+
+echo "Test: gh_pr_merge_rest -- --rebase sets merge_method=rebase"
+setup
+: > "$STUB_DIR/gh-pr-merge-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_pr_merge_rest 42 --rebase
+if grep -q 'merge_method=rebase' "$STUB_DIR/gh-pr-merge-rest-calls.log"; then m=yes; else m=no; fi
+assert_eq "pr-merge: --rebase → merge_method=rebase" "yes" "$m"
+teardown
+
+echo "Test: gh_pr_merge_rest -- --repo flag emits cross-repo segment"
+setup
+: > "$STUB_DIR/gh-pr-merge-rest-calls.log"
+source "$TMPDIR_TEST/lib.sh"; gh_pr_merge_rest 42 --repo owner/other-repo
+if grep -q 'repos/owner/other-repo/pulls/42/merge' "$STUB_DIR/gh-pr-merge-rest-calls.log"; then seg=yes; else seg=no; fi
+assert_eq "pr-merge: --repo uses cross-repo segment" "yes" "$seg"
+teardown
+
+echo "Test: gh_pr_merge_rest -- missing number returns non-zero"
+setup
+rc_pm=0
+err_pm=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_merge_rest 2>&1 >/dev/null) || rc_pm=$?
+assert_eq "pr-merge: missing number → non-zero" "1" "$rc_pm"
+case "$err_pm" in *"gh_pr_merge_rest: PR number is required"*) m=yes ;; *) m=no ;; esac
+assert_eq "pr-merge: missing-number stderr names helper" "yes" "$m"
+teardown
+
+echo "Test: gh_pr_merge_rest -- gh failure returns non-zero with diagnostic stderr"
+setup
+: > "$STUB_DIR/gh-fail-rest"
+rc_pmf=0
+err_pmf=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_merge_rest 42 2>&1 >/dev/null) || rc_pmf=$?
+assert_eq "pr-merge: gh failure → non-zero" "1" "$rc_pmf"
+case "$err_pmf" in *"gh_pr_merge_rest: gh api failed"*) m=yes ;; *) m=no ;; esac
+assert_eq "pr-merge: gh-failure stderr names helper" "yes" "$m"
 teardown
 
 # ============================================================================


### PR DESCRIPTION
Closes #2255

## What this does

Foundation slice of the GraphQL→REST rate-limit migration (epic #2254). The
dispatch fleet exhausts GitHub's GraphQL rate-limit bucket (shared 5000 pts/hr
fleet-wide) while the separate REST bucket sits ~73% idle, because nearly all
GitHub access goes through GraphQL-backed `gh issue …` / `gh pr …` porcelain.
When the GraphQL bucket hits zero, phase workers die mid-task.

This PR adds REST-backed `gh` helper functions to
`.claude/skills/dispatch-propagate/scripts/lib.sh`, mirroring the existing
`gh_issue_list_rest` / `dispatch_ci_verdict_rest` pattern (from #1601). **No
call-site changes** — the helpers land first so the later migration slices
(#2256–#2260) are mechanical one-line swaps.

## Helpers added (all `gh_retry`-wrapped, REST-bucket-spending)

Read helpers (byte-compatible with the `gh issue/pr view --json` porcelain they
will replace):

- `gh_issue_view_rest <N> [--repo owner/repo]` — projects to
  `{number,title,body,state,labels:[{name}],assignees:[{login}]}`; `state`
  `ascii_upcase`d to match the UPPERCASE porcelain enum; labels/assignees
  narrowed to the porcelain-visible keys.
- `gh_pr_view_rest <N> [--repo owner/repo]` — projects
  `{number,title,body,state,mergeable,mergeStateStatus}`; `state` upcased;
  `mergeable` mapped from the REST boolean to the GraphQL enum string
  (`true→MERGEABLE`, `false→CONFLICTING`, null/absent→`UNKNOWN`) that call sites
  consume; REST `mergeable_state` remapped to `mergeStateStatus`.

Mutation helpers:

- `gh_issue_set_labels_rest <N> <label…>` — `POST …/issues/<N>/labels` (additive).
- `gh_issue_remove_label_rest <N> <label>` — `DELETE …/issues/<N>/labels/<name>`
  (minimal URL-encode).
- `gh_issue_close_rest <N>` — `PATCH …/issues/<N>` with `state=closed`.
- `gh_issue_create_rest --title <t> --body <b> [--label …]` — `POST …/issues`,
  echoes the new issue URL.
- `gh_issue_comment_rest <N> (--body <b>|--body-file <f>)` — `POST …/issues/<N>/comments`.
- `gh_pr_merge_rest <N> [--squash|--merge|--rebase]` — `PUT …/pulls/<N>/merge`
  with `merge_method`.

Each follows the existing `_rest` conventions: flag-parsing `while`/`case` loop,
required-arg validation with a clear stderr error + `return 1`, and
clear-errors-no-fallback. Bodies are built with `gh api -f/-F` flags (not
`--input -`) so `gh_retry` re-invocations are safe.

## The byte-compatibility contract

Two field-name details from the plan were corrected against the actual `gh`
output (the plan's own stated oracle): the PR helper emits `mergeStateStatus`
(the real `gh pr view --json` field; `mergeableState` is not a valid field and
would error), and `mergeable` is converted from the REST boolean to the GraphQL
enum string that current call sites (`dispatch-route`, `dispatch-phase`,
`dispatch-auto-merge`, `dispatch-reconcile-ready`, …) read.

## Notes for the downstream migration slices

- A merged PR's REST `state` is `closed`, so `gh_pr_view_rest` emits `CLOSED`,
  never the porcelain `MERGED`. The one consumer reading `state == "MERGED"`
  (`dispatch-sweep`) must handle this when it migrates.
- `gh pr ready` has no REST equivalent and stays GraphQL (per #2254/#2257).

## Verification

`test-dispatch-scripts.sh` (3740/3740 passed) and `run-lint.sh --prose` (clean)
— exactly what CI runs. New tests cover field remapping/enum casing, REST
method/path/body for each mutation helper, and a REST-bucket consumption
assertion proving each of the 8 helpers hits a `gh api repos/…` endpoint, never
`gh issue/pr` porcelain or `graphql`. `git diff origin/main` touches only
`lib.sh` and `test-dispatch-scripts.sh` (foundation-only, no call-site changes).
