### PR TITLE
dispatch: migrate remaining gh issue list / gh pr list calls to REST

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -481,6 +481,11 @@ PR_NUM=$("$SCRIPTS/dispatch-find-pr" "$ISSUE_NUM" 2>/dev/null) || PR_NUM=""
 # phase derivation below via DISPATCH_PR_LIST, avoiding a redundant `gh pr list`
 # per predicate. On fetch failure DISPATCH_PR_LIST stays empty and each script
 # falls back to its own self-fetch.
+# This batched per-tick call intentionally stays on GraphQL (gh pr list) because
+# both fields it requires — closingIssuesReferences (which issues a PR closes,
+# no REST-list equivalent) and statusCheckRollup (per-PR CI rollup, no
+# REST-list equivalent) — are GraphQL-only; there is no REST /pulls endpoint
+# that returns either field.
 DISPATCH_PR_LIST=$(pr_list_open "number,headRefName,isDraft,statusCheckRollup,labels,mergeable" 2>/dev/null) \
   || DISPATCH_PR_LIST=""
 export DISPATCH_PR_LIST

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-digest-window
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-digest-window
@@ -70,8 +70,8 @@ CREATED_AT=$(printf '%s' "$ISSUE_JSON" | jq -r '.createdAt')
 # here: GitHub returns closedAt as zero-padded UTC ISO-8601 (e.g.
 # 2026-05-25T12:00:00Z), so string order is time order — no fromdate needed.
 
-CLOSED_JSON=$(gh issue list --repo "$REPO" --label "$JIT_LABEL" \
-  --state closed --limit 100 --json number,closedAt)
+CLOSED_JSON=$(gh_issue_list_rest --repo "$REPO" --label "$JIT_LABEL" \
+  --state closed --limit 100)
 
 PRIOR_CLOSED_AT=$(printf '%s' "$CLOSED_JSON" \
   | jq -r --arg num "$NUM" \

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-digest-window
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-digest-window
@@ -24,6 +24,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
 # ---- Step 0: parse arguments ------------------------------------------------
 
 REPO="${1:-}"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-drift-scan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-drift-scan
@@ -213,15 +213,15 @@ echo "=== Input 2: merged PRs in window ==="
 PRS=$(gh_retry gh api --paginate \
   "repos/{owner}/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100" \
   | jq -s --arg created "$CREATED_AT" \
-      'add
+      'add // []
        | map(select(.merged_at != null and .merged_at >= $created))
        | map({number, title, mergedAt: .merged_at})')
 PR_COUNT=$(printf '%s' "$PRS" | jq 'length')
 
 if [[ "$PR_COUNT" -ge 100 ]]; then
-  echo "WINDOW-TOO-WIDE: the merged-PR query hit the 100-result limit, so this"
-  echo "window is too wide to scan reliably. Re-run /file-issue on this issue to"
-  echo "narrow its window rather than trusting a partial merged-PR scan."
+  echo "WINDOW-TOO-WIDE: the merged-PR scan found 100 or more PRs merged in this"
+  echo "window, so this window is too wide to scan reliably. Re-run /file-issue on"
+  echo "this issue to narrow its window rather than trusting this merged-PR scan."
   echo "(partial PR enumeration suppressed for this input)"
 elif [[ "$PR_COUNT" -eq 0 ]]; then
   echo "(none)"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-drift-scan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-drift-scan
@@ -50,6 +50,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
 # ---- Step 0: parse arguments ------------------------------------------------
 
 N="${1:-}"
@@ -184,8 +187,35 @@ echo ""
 # ---- Step D: Input 2 — merged PRs in window ---------------------------------
 
 echo "=== Input 2: merged PRs in window ==="
-PRS=$(gh pr list --state merged --search "merged:>=$CREATED_AT" --limit 100 \
-  --json number,title,mergedAt)
+# Migrated off GraphQL-backed `gh pr list` to an inline REST `gh api` call
+# (#2258). This windowed merged-PR query stays inline — it is NOT a gh_pr_list_rest
+# drop-in — because the helper has no merged-in-window / early-stop semantics.
+#
+# Soundness of the scan/early-stop key — `updated_at`, NOT `merged_at`/`created_at`:
+#   We enumerate closed PRs sorted newest-UPDATED first
+#   (state=closed&sort=updated&direction=desc). A PR CREATED before the window can
+#   still MERGE inside it. Since updated_at >= merged_at always holds, every
+#   in-window merge has updated_at >= CREATED_AT — so newest-updated-first you
+#   could stop at the first PR with updated_at < CREATED_AT (all later ones are
+#   even older-updated and cannot be in-window merges). Stopping on merged_at or
+#   created_at would be UNSOUND: it would miss in-window merges of PRs created
+#   before the window. A future reader who "optimizes" the early-stop on those
+#   keys would silently drop real in-window merges.
+#
+# Chosen implementation: `gh api --paginate` fetches ALL closed PRs eagerly, then
+# jq filters merged_at != null and merged_at >= CREATED_AT locally. This is sound
+# (no early-stop bug) and acceptable here — the REST bucket is idle and the
+# closed-PR count is bounded. `--paginate` concatenates one JSON array PER PAGE,
+# so we `jq -s` (slurp) and `add` them into a single array before filtering. The
+# projection remaps merged_at -> mergedAt and keeps only number,title (key order
+# number,title,mergedAt) so the downstream consumer is byte-identical to the old
+# `--json number,title,mergedAt` array.
+PRS=$(gh_retry gh api --paginate \
+  "repos/{owner}/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100" \
+  | jq -s --arg created "$CREATED_AT" \
+      'add
+       | map(select(.merged_at != null and .merged_at >= $created))
+       | map({number, title, mergedAt: .merged_at})')
 PR_COUNT=$(printf '%s' "$PRS" | jq 'length')
 
 if [[ "$PR_COUNT" -ge 100 ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-escalate-sync-broken
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-escalate-sync-broken
@@ -58,6 +58,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
 LABEL="dispatch:sync-broken"
 
 # ---- Parse --reason ---------------------------------------------------------

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-escalate-sync-broken
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-escalate-sync-broken
@@ -198,7 +198,7 @@ fi
 #
 # One open dispatch:sync-broken issue at a time. A re-run edits the existing
 # issue's body (refreshing the diagnostics) rather than duplicating.
-existing=$(gh issue list --label "$LABEL" --state open --json number -q '.[0].number')
+existing=$(gh_issue_list_rest --label "$LABEL" --state open | jq -r '.[0].number // empty')
 
 if [[ -n "$existing" ]]; then
   # The edit touches the body only (no --label flag), so it cannot fail with a

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-followup-exists
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-followup-exists
@@ -35,9 +35,10 @@
 #     - CodeQL: `CodeQL <rule_id> alert #<n>`
 #
 # MATCHING
-#   gh's --search is tokenized/fuzzy, so it only narrows the candidate set
-#   server-side (wrapping the identifier in literal double-quotes and adding the
-#   `in:title` qualifier). The authoritative match is the jq post-filter.
+#   The full issue list is fetched via REST (gh_issue_list_rest) and the
+#   authoritative match is the jq post-filter below — there is no server-side
+#   narrowing. (The prior implementation used a fuzzy `gh issue list --search
+#   "...in:title"` to pre-narrow, but the jq filter was always the decision.)
 #
 #   The post-filter is BOUNDARY-AWARE, not a bare substring test. A title matches
 #   only when the identifier sits at a token boundary — it either ends the title
@@ -53,6 +54,9 @@
 #   end-of-string. The first matching issue number is printed; nothing if none.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
 if [[ "$#" -lt 1 || -z "${1:-}" ]]; then
   echo "error: usage: dispatch-followup-exists <identifier>" >&2
   exit 2
@@ -60,6 +64,16 @@ fi
 
 identifier="$1"
 
-gh issue list --search "\"$identifier\" in:title" --state all --json number,title --limit 100 \
+# Fetch the full issue history (open AND closed) via REST and apply the same
+# authoritative boundary-aware jq post-filter below — the prior `--search` only
+# narrowed the candidate set server-side; the jq match was always the decision.
+# Two behavioral notes from dropping `--search "...in:title"` and `--limit 100`:
+#   (a) This now pulls the full issue list rather than a ≤100 server-narrowed
+#       set. Acceptable: it runs on the idle REST bucket and fires only per
+#       security-followup (not per tick).
+#   (b) `[0]` shifts from "first server-search hit" to "most-recently-created
+#       match" (the helper sorts created desc) — irrelevant for an existence
+#       check, which only cares whether ANY match exists.
+gh_issue_list_rest --state all --include-title \
   | jq -r --arg id "$identifier" \
       '[.[] | select((.title | endswith($id)) or (.title | contains($id + " ")))][0].number // empty'

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-jit-calendar-import
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-jit-calendar-import
@@ -183,10 +183,19 @@ fi
 # dedup misses surface instead of silently creating duplicates.
 LIST_LIMIT=1000
 LIST_RC=0
+# Capture stderr to a tmpfile rather than via 2>&1: gh_issue_list_rest runs
+# gh_retry internally, whose transient-retry diagnostics go to stderr. Folding
+# stderr into OPEN_JSON would contaminate the captured JSON on a
+# transient-then-success run (LIST_RC=0 but OPEN_JSON has a retry line prepended),
+# making the subsequent `jq` fail. The error-diagnostic intent is preserved by
+# reading the captured stderr only on failure.
+list_err=$(mktemp)
 OPEN_JSON=$(gh_issue_list_rest --repo "$CALENDAR_REPO" --label "$CALENDAR_LABEL" \
-  --state open --include-body --limit "$LIST_LIMIT" 2>&1) || LIST_RC=$?
+  --state open --include-body --limit "$LIST_LIMIT" 2>"$list_err") || LIST_RC=$?
+err=$(cat "$list_err")
+rm -f "$list_err"
 if [[ "$LIST_RC" -ne 0 ]]; then
-  echo "calendar: error (gh issue list failed: $OPEN_JSON)" >&2
+  echo "calendar: error (gh issue list failed: $err)" >&2
   exit 1
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-jit-calendar-import
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-jit-calendar-import
@@ -183,8 +183,8 @@ fi
 # dedup misses surface instead of silently creating duplicates.
 LIST_LIMIT=1000
 LIST_RC=0
-OPEN_JSON=$(gh issue list --repo "$CALENDAR_REPO" --label "$CALENDAR_LABEL" \
-  --state open --json number,body --limit "$LIST_LIMIT" 2>&1) || LIST_RC=$?
+OPEN_JSON=$(gh_issue_list_rest --repo "$CALENDAR_REPO" --label "$CALENDAR_LABEL" \
+  --state open --include-body --limit "$LIST_LIMIT" 2>&1) || LIST_RC=$?
 if [[ "$LIST_RC" -ne 0 ]]; then
   echo "calendar: error (gh issue list failed: $OPEN_JSON)" >&2
   exit 1

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-jit-engine
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-jit-engine
@@ -236,11 +236,16 @@ for (( i = 0; i < JIT_COUNT; i++ )); do
   # ---- 4d: open-issue guard -------------------------------------------------
   # At most one open issue per jit. If one is already open, skip and stamp the
   # last-check time so debounce holds off the next tick.
+  # gh_issue_list_rest wraps gh_retry INTERNALLY for transient-failure backoff;
+  # its retry lines go to stderr, so capture stderr to a tmpfile (never 2>&1 into
+  # the stdout we parse with jq below).
   OPEN_RC=0
+  open_tmpfile=$(mktemp)
   OPEN_JSON=$(gh_issue_list_rest --repo "$REPO" --label "$LABEL" --state open \
-    2>&1) || OPEN_RC=$?
+    2>"$open_tmpfile") || OPEN_RC=$?
+  OPEN_ERR=$(cat "$open_tmpfile"); rm -f "$open_tmpfile"
   if [[ "$OPEN_RC" -ne 0 ]]; then
-    echo "$KEY: error (gh issue list --state open failed: $OPEN_JSON)" >&2
+    echo "$KEY: error (gh issue list --state open failed: $OPEN_ERR)" >&2
     HARD_ERROR=1
     continue
   fi
@@ -268,11 +273,16 @@ for (( i = 0; i < JIT_COUNT; i++ )); do
       HARD_ERROR=1
       continue
     fi
+    # See the OPEN_JSON note above: gh_issue_list_rest's internal gh_retry emits
+    # retry lines to stderr, so capture stderr to a tmpfile (never 2>&1 into the
+    # stdout parsed by jq below).
     CLOSED_RC=0
+    closed_tmpfile=$(mktemp)
     CLOSED_JSON=$(gh_issue_list_rest --repo "$REPO" --label "$LABEL" --state closed \
-      2>&1) || CLOSED_RC=$?
+      2>"$closed_tmpfile") || CLOSED_RC=$?
+    CLOSED_ERR=$(cat "$closed_tmpfile"); rm -f "$closed_tmpfile"
     if [[ "$CLOSED_RC" -ne 0 ]]; then
-      echo "$KEY: error (gh issue list --state closed failed: $CLOSED_JSON)" >&2
+      echo "$KEY: error (gh issue list --state closed failed: $CLOSED_ERR)" >&2
       HARD_ERROR=1
       continue
     fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-jit-engine
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-jit-engine
@@ -237,8 +237,8 @@ for (( i = 0; i < JIT_COUNT; i++ )); do
   # At most one open issue per jit. If one is already open, skip and stamp the
   # last-check time so debounce holds off the next tick.
   OPEN_RC=0
-  OPEN_JSON=$(gh issue list --repo "$REPO" --label "$LABEL" --state open \
-    --json number 2>&1) || OPEN_RC=$?
+  OPEN_JSON=$(gh_issue_list_rest --repo "$REPO" --label "$LABEL" --state open \
+    2>&1) || OPEN_RC=$?
   if [[ "$OPEN_RC" -ne 0 ]]; then
     echo "$KEY: error (gh issue list --state open failed: $OPEN_JSON)" >&2
     HARD_ERROR=1
@@ -269,8 +269,8 @@ for (( i = 0; i < JIT_COUNT; i++ )); do
       continue
     fi
     CLOSED_RC=0
-    CLOSED_JSON=$(gh issue list --repo "$REPO" --label "$LABEL" --state closed \
-      --json number,closedAt 2>&1) || CLOSED_RC=$?
+    CLOSED_JSON=$(gh_issue_list_rest --repo "$REPO" --label "$LABEL" --state closed \
+      2>&1) || CLOSED_RC=$?
     if [[ "$CLOSED_RC" -ne 0 ]]; then
       echo "$KEY: error (gh issue list --state closed failed: $CLOSED_JSON)" >&2
       HARD_ERROR=1

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -345,8 +345,8 @@ refresh_lock
 # dispatch-select-target --main-broken-sha) to the red/recovering window only;
 # this runs every tick — independent of the local branch — including a capped
 # tick, so recovery is observed even when no worker is spawned.
-OPEN_MB=$(gh issue list --label "dispatch:main-broken" --state open \
-  --json number -q '.[].number') || {
+OPEN_MB=$(gh_issue_list_rest --label "dispatch:main-broken" --state open \
+  | jq -r '.[].number') || {
   echo 'dispatch-select-tick: gh issue list (dispatch:main-broken) failed; treating main health as UNKNOWN' >&2
   OPEN_MB=UNKNOWN
 }

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-statements-scan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-statements-scan
@@ -300,13 +300,15 @@ for (( i = 0; i < STATEMENTS_COUNT; i++ )); do
   # core-API call, then seed SEEN_HASHES from their bodies. This replaces the
   # per-file Search-API query that exhausted the ~30 req/min Search budget on a
   # cold scan of a large folder. Only run when there is at least one file to
-  # dedup. gh_retry wraps the call for transient-failure backoff; its retry
-  # lines go to stderr, so capture stderr to a tmpfile (never 2>&1 into the
-  # stdout we parse).
+  # dedup. gh_issue_list_rest wraps gh_retry INTERNALLY for transient-failure
+  # backoff; its retry lines go to stderr, so capture stderr to a tmpfile (never
+  # 2>&1 into the stdout we parse). The helper paginates per_page=100 then slices
+  # to --limit, so the `len == ISSUE_LIST_LIMIT` truncation guard below now sees
+  # a list actually capped at the limit (rather than gh's old server-side cap).
   if [[ "${#MATCHED[@]}" -gt 0 ]]; then
     tmpfile=$(mktemp)
-    out=$(gh_retry gh issue list --repo "$REPO" --label "$LABEL" --state all \
-      --limit "$ISSUE_LIST_LIMIT" --json number,body 2>"$tmpfile")
+    out=$(gh_issue_list_rest --repo "$REPO" --label "$LABEL" --state all \
+      --limit "$ISSUE_LIST_LIMIT" --include-body 2>"$tmpfile")
     rc=$?
     err=$(cat "$tmpfile"); rm -f "$tmpfile"
     if [[ "$rc" -ne 0 ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
@@ -231,7 +231,7 @@ while [[ $i -lt ${#WT_PATHS[@]} ]]; do
   # sees the merged backlog tail. A failure here is isolated to this worktree
   # (defect 2, #1313): log and move on, never abort the sweep.
   if ! pr_json=$(gh_pr_list_rest --head "$wt_branch" --state all); then
-    log "ERROR_PR_STATE_FETCH: branch=$wt_branch gh pr list --head failed"
+    log "ERROR_PR_STATE_FETCH: branch=$wt_branch gh_pr_list_rest --head failed"
     continue
   fi
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
@@ -230,7 +230,7 @@ while [[ $i -lt ${#WT_PATHS[@]} ]]; do
   # with `--head` instead of a creation-ordered `--limit N` window that never
   # sees the merged backlog tail. A failure here is isolated to this worktree
   # (defect 2, #1313): log and move on, never abort the sweep.
-  if ! pr_json=$(gh_retry gh pr list --head "$wt_branch" --state all --json state,number); then
+  if ! pr_json=$(gh_pr_list_rest --head "$wt_branch" --state all); then
     log "ERROR_PR_STATE_FETCH: branch=$wt_branch gh pr list --head failed"
     continue
   fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
@@ -146,7 +146,7 @@ num_is_claimed() { [[ -n "${CLAIMED_NUMS[$1]:-}" ]]; }
 # and let a parked leaf past position 30 be returned as startable.
 declare -A OFFICE_HOURS_PARKED=()
 if [[ "$MODE" == "queue" ]]; then
-  parked_json=$(gh issue list --state open --label "dispatch:office-hours" --limit 300 --json number) \
+  parked_json=$(gh_issue_list_rest --state open --label "dispatch:office-hours" --limit 300) \
     || { echo "error: dispatch-trace-leaf $ISSUE_NUM: gh issue list for the dispatch:office-hours parked set failed; aborting rather than risk returning a parked leaf" >&2; exit 3; }
   while IFS= read -r parked_num; do
     [[ -n "$parked_num" ]] && OFFICE_HOURS_PARKED["$parked_num"]=1

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -200,19 +200,29 @@ dispatch_marker_comment_id() {
 # per-tick scan was self-exhausting (#1601).
 #
 # Contract:
-#   gh_issue_list_rest --state <open|closed> [--repo <owner/repo>] [--label <name>] [--limit <n>] [--include-body]
+#   gh_issue_list_rest --state <open|closed|all> [--repo <owner/repo>] [--label <name>] [--limit <n>] [--include-title] [--include-body]
 #
 # Flags:
-#   --state  (required) open|closed.
+#   --state  (required) open|closed|all. `all` is accepted — REST's
+#            issues?state=all is native and needs no special-casing.
 #   --repo   (optional) owner/repo for a cross-repo scan; when absent the path
 #            uses the {owner}/{repo} placeholder gh auto-resolves for the
 #            current repo.
 #   --label  (optional) a single label name; URL-encoded minimally (space→%20;
 #            the colon in values like dispatch:main-broken is query-safe).
-#   --limit  (optional) per_page cap. When ABSENT we --paginate the full set
-#            (REST --paginate has no silent-truncation hazard, unlike gh pr/issue
-#            list's --limit default). When PRESENT we fetch a SINGLE page of that
-#            size (no --paginate).
+#   --limit  (optional) cap on the number of issues returned. When ABSENT we
+#            --paginate the full set (REST --paginate has no silent-truncation
+#            hazard, unlike gh pr/issue list's --limit default). When PRESENT and
+#            <= 100 we fetch a SINGLE page of that size (no --paginate). When
+#            PRESENT and > 100 we --paginate at per_page=100 and slice the merged
+#            result to the first <limit> objects in the final jq projection —
+#            REST clamps per_page to 100, so a single-page per_page=<limit> would
+#            silently truncate to <= 100. The slice preserves the
+#            `len == limit ⇒ truncated` guard semantics: paginate-all-then-slice
+#            yields len == limit iff at least <limit> issues exist.
+#   --include-title (optional) when present, the projected objects additionally
+#            carry a `title` field. Omitted by default so the repo-wide per-tick
+#            callers stay byte-identical and payload-lean.
 #   --include-body (optional) when present, the projected objects additionally
 #            carry a `body` field. Omitted by default so the repo-wide per-tick
 #            callers stay byte-identical and payload-lean.
@@ -223,19 +233,21 @@ dispatch_marker_comment_id() {
 # camelCase shape downstream jq expects ({number, createdAt, closedAt, labels}).
 # `labels` is already [{name,...}] in REST, so it passes through unchanged; a null
 # closedAt on open issues is harmless. Results are sorted created-descending so a
-# downstream `.[0]` is the most-recently-created issue. When --include-body is
-# passed, each projected object also carries a `body` field.
+# downstream `.[0]` is the most-recently-created issue. When --include-title is
+# passed, each projected object also carries a `title` field; when --include-body
+# is passed, each also carries a `body` field; both may be passed together.
 #
 # On gh failure: errors to stderr and returns 1 (clear-errors convention, no
 # fallback).
 gh_issue_list_rest() {
-  local state="" repo="" label="" limit="" include_body=""
+  local state="" repo="" label="" limit="" include_title="" include_body=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --state) state="$2"; shift 2 ;;
       --repo)  repo="$2";  shift 2 ;;
       --label) label="$2"; shift 2 ;;
       --limit) limit="$2"; shift 2 ;;
+      --include-title) include_title=1; shift 1 ;;
       --include-body) include_body=1; shift 1 ;;
       *) echo "error: gh_issue_list_rest: unknown flag '$1'" >&2; return 1 ;;
     esac
@@ -252,8 +264,26 @@ gh_issue_list_rest() {
     path="repos/{owner}/{repo}/issues"
   fi
 
-  local per_page="100"
-  [[ -n "$limit" ]] && per_page="$limit"
+  # When --limit > 100, REST clamps a single page's per_page to 100, so we must
+  # --paginate at per_page=100 and slice the merged result down to <limit> in the
+  # projection. A limit <= 100 fits one page (per_page=<limit>, no --paginate).
+  local paginate="" per_page="100" slice=""
+  if [[ -n "$limit" ]]; then
+    if [[ ! "$limit" =~ ^[0-9]+$ ]]; then
+      echo "error: gh_issue_list_rest: --limit must be a non-negative integer (got '$limit')" >&2
+      return 1
+    fi
+    if (( limit > 100 )); then
+      paginate=1
+      per_page="100"
+      slice="$limit"
+    else
+      per_page="$limit"
+    fi
+  else
+    paginate=1
+  fi
+
   local query="state=$state&per_page=$per_page&sort=created&direction=desc"
   if [[ -n "$label" ]]; then
     # Minimal URL-encode: space → %20 (colon is query-safe).
@@ -262,24 +292,28 @@ gh_issue_list_rest() {
   fi
 
   local raw
-  if [[ -n "$limit" ]]; then
+  if [[ -n "$paginate" ]]; then
+    # Full set (--limit absent) or --limit > 100: REST --paginate has no
+    # silent-truncation hazard; a >100 limit is enforced by the projection slice.
+    raw=$(gh_retry gh api --paginate "$path?$query") || {
+      echo "error: gh_issue_list_rest: gh api failed for $path?$query" >&2
+      return 1
+    }
+  else
     # Single page (no --paginate) — caller wants at most one page of per_page.
     raw=$(gh_retry gh api "$path?$query") || {
       echo "error: gh_issue_list_rest: gh api failed for $path?$query" >&2
       return 1
     }
-  else
-    # Full set — REST --paginate has no silent-truncation hazard.
-    raw=$(gh_retry gh api --paginate "$path?$query") || {
-      echo "error: gh_issue_list_rest: gh api failed for $path?$query" >&2
-      return 1
-    }
   fi
 
-  local projection='add // [] | map(select(.pull_request == null)) | map({number, createdAt: .created_at, closedAt: .closed_at, labels})'
-  if [[ -n "$include_body" ]]; then
-    projection='add // [] | map(select(.pull_request == null)) | map({number, createdAt: .created_at, closedAt: .closed_at, labels, body})'
-  fi
+  # Build the projection: filter PRs, remap to camelCase, conditionally add
+  # title/body, then conditionally slice to <limit> (only when --limit > 100).
+  local fields="number, createdAt: .created_at, closedAt: .closed_at, labels"
+  [[ -n "$include_title" ]] && fields="$fields, title"
+  [[ -n "$include_body" ]] && fields="$fields, body"
+  local projection="add // [] | map(select(.pull_request == null)) | map({$fields})"
+  [[ -n "$slice" ]] && projection="$projection | .[:$slice]"
   printf '%s' "$raw" | jq -s "$projection"
 }
 

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -317,6 +317,139 @@ gh_issue_list_rest() {
   printf '%s' "$raw" | jq -s "$projection"
 }
 
+# List pull requests via the GitHub REST API rather than `gh pr list` (which
+# GraphQL-backs). Keeping per-tick dispatch PR scans on REST keeps them off the
+# shared GraphQL rate-limit bucket the per-tick scan was self-exhausting (#1601,
+# #2258). Mirrors gh_issue_list_rest's --limit discipline.
+#
+# Contract:
+#   gh_pr_list_rest --state <open|closed|all> [--repo <owner/repo>] [--head <branch>] [--limit <n>]
+#
+# Flags:
+#   --state  (required) open|closed|all. REST's pulls?state=all is native.
+#   --repo   (optional) owner/repo for a cross-repo scan; when absent the path
+#            uses the {owner}/{repo} placeholder gh auto-resolves for the
+#            current repo.
+#   --head   (optional) filter to PRs from a single head branch. REST wants
+#            head=<owner>:<branch>. The owner is the FIRST path segment of --repo
+#            when given (cut on /); otherwise it is resolved from the current
+#            repo via `gh repo view --json owner -q .owner.login` (wrapped in
+#            gh_retry). Resolution is lazy — only performed when --head is set and
+#            --repo is absent — so the common no-head call path makes no extra
+#            API call.
+#   --limit  (optional) cap on PRs returned. SAME three-way discipline as
+#            gh_issue_list_rest: ABSENT ⇒ --paginate the full set (REST --paginate
+#            has no silent-truncation hazard); PRESENT and <= 100 ⇒ a SINGLE page
+#            of per_page=<limit> (no --paginate); PRESENT and > 100 ⇒ --paginate
+#            at the REST-clamped per_page=100 and slice the merged result to the
+#            first <limit> objects in the final jq projection. The slice preserves
+#            the `len == limit ⇒ truncated` guard semantics.
+#
+# Endpoint: repos/{owner}/{repo}/pulls (or repos/$repo/pulls with --repo). The
+# query string carries state, per_page, and head (when set). No sort/direction
+# param is emitted (this unit migrates no call sites — see #2258).
+#
+# Projection: a FIXED {number, state, title, mergedAt, createdAt} shape, remapped
+# from REST snake_case (merged_at → mergedAt, created_at → createdAt). REST
+# /pulls returns ONLY pull requests, so — unlike /issues — no pull_request filter
+# is needed; every element is a PR.
+#
+# State normalization (CRITICAL): REST PR `state` is only open|closed and does
+# not distinguish merged from closed-unmerged, but consuming scripts compare
+# against the GraphQL state enum (OPEN/CLOSED/MERGED). We normalize IN the jq
+# projection to that vocabulary:
+#   REST open                          → OPEN
+#   REST closed with merged_at != null → MERGED
+#   REST closed with merged_at == null → CLOSED
+#
+# Output: one merged JSON array on stdout.
+#
+# On gh failure: errors to stderr and returns 1 (clear-errors convention, no
+# fallback).
+gh_pr_list_rest() {
+  local state="" repo="" head="" limit=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --state) state="$2"; shift 2 ;;
+      --repo)  repo="$2";  shift 2 ;;
+      --head)  head="$2";  shift 2 ;;
+      --limit) limit="$2"; shift 2 ;;
+      *) echo "error: gh_pr_list_rest: unknown flag '$1'" >&2; return 1 ;;
+    esac
+  done
+  if [[ -z "$state" ]]; then
+    echo "error: gh_pr_list_rest: --state is required" >&2
+    return 1
+  fi
+
+  local path
+  if [[ -n "$repo" ]]; then
+    path="repos/$repo/pulls"
+  else
+    path="repos/{owner}/{repo}/pulls"
+  fi
+
+  # When --limit > 100, REST clamps a single page's per_page to 100, so we must
+  # --paginate at per_page=100 and slice the merged result down to <limit> in the
+  # projection. A limit <= 100 fits one page (per_page=<limit>, no --paginate).
+  local paginate="" per_page="100" slice=""
+  if [[ -n "$limit" ]]; then
+    if [[ ! "$limit" =~ ^[0-9]+$ ]]; then
+      echo "error: gh_pr_list_rest: --limit must be a non-negative integer (got '$limit')" >&2
+      return 1
+    fi
+    if (( limit > 100 )); then
+      paginate=1
+      per_page="100"
+      slice="$limit"
+    else
+      per_page="$limit"
+    fi
+  else
+    paginate=1
+  fi
+
+  local query="state=$state&per_page=$per_page"
+  if [[ -n "$head" ]]; then
+    # Resolve the head owner: first segment of --repo when given, else the
+    # current repo's owner login. Lazy — only when --head is set.
+    local head_owner
+    if [[ -n "$repo" ]]; then
+      head_owner="${repo%%/*}"
+    else
+      head_owner=$(gh_retry gh repo view --json owner -q .owner.login) || {
+        echo "error: gh_pr_list_rest: could not resolve current repo owner for --head" >&2
+        return 1
+      }
+    fi
+    query="$query&head=$head_owner:$head"
+  fi
+
+  local raw
+  if [[ -n "$paginate" ]]; then
+    # Full set (--limit absent) or --limit > 100: REST --paginate has no
+    # silent-truncation hazard; a >100 limit is enforced by the projection slice.
+    raw=$(gh_retry gh api --paginate "$path?$query") || {
+      echo "error: gh_pr_list_rest: gh api failed for $path?$query" >&2
+      return 1
+    }
+  else
+    # Single page (no --paginate) — caller wants at most one page of per_page.
+    raw=$(gh_retry gh api "$path?$query") || {
+      echo "error: gh_pr_list_rest: gh api failed for $path?$query" >&2
+      return 1
+    }
+  fi
+
+  # Build the projection: fixed field set, remap snake_case to camelCase, and
+  # normalize REST open|closed to the GraphQL OPEN|MERGED|CLOSED vocabulary; then
+  # conditionally slice to <limit> (only when --limit > 100).
+  local projection
+  projection='add // [] | map({number, state: (if .state == "open" then "OPEN" elif .merged_at != null then "MERGED" else "CLOSED" end), title, mergedAt: .merged_at, createdAt: .created_at})'
+  [[ -n "$slice" ]] && projection="$projection | .[:$slice]"
+  printf '%s' "$raw" | jq -s "$projection"
+}
+
 # The explicit open-PR fetch cap. gh pr list defaults to 30, which silently
 # truncates the open-PR snapshot once a fan-out crosses 30 open PRs. 300 mirrors
 # dispatch-select-target's open-issue cap. Overridable for tests.

--- a/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
@@ -120,7 +120,7 @@ resolve_main_worktree() {
 # Open issues carrying dispatch:office-hours, with their creation times and
 # labels (labels ride this existing fetch — no extra gh call; the main-qa
 # override below filters ISSUE_LIST in memory (no re-query) to detect the `main-qa` label).
-ISSUE_LIST=$(gh issue list --label dispatch:office-hours --state open --json number,createdAt,labels)
+ISSUE_LIST=$(gh_issue_list_rest --label dispatch:office-hours --state open)
 
 # Map each registered <N>-* worktree to its on-disk path(s), keyed by issue
 # number — the same construction dispatch-select-target uses for its liveness

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -21365,8 +21365,9 @@ jit_teardown
 # own SCRIPT_DIR — which becomes $TMPDIR_TEST/scripts for the copy — so all
 # three scripts are co-located. The gh stub logs EVERY matched invocation to
 # gh-calls.log so a test can assert "zero gh calls" (the debounce case). The
-# `issue list` arm reads a stub/issue-list.json fixture if present (lets a
-# test seed the batched dedup map with pre-existing issues), else "[]".
+# REST issues arm (`api ... repos/.../issues`, the gh_issue_list_rest call after
+# #2258) reads a stub/issue-list.json fixture if present (lets a test seed the
+# batched dedup map with pre-existing issues), else "[]", remapped to snake_case.
 # Transient-failure injection is via stub/issue-list-fail-once. "now" is pinned
 # via DISPATCH_STATEMENTS_NOW so the debounce math is deterministic.
 
@@ -21397,9 +21398,10 @@ statements_setup() {
   export DISPATCH_STATEMENTS_NOW="$STMT_NOW_EPOCH"
 
   # gh PATH stub. Every matched subcommand is appended to gh-calls.log so the
-  # debounce test can assert the log is absent (zero gh calls). `issue list`
-  # reads issue-list.json if present, else "[]"; supports transient-failure
-  # injection via issue-list-fail-once. `issue create` logs its full args
+  # debounce test can assert the log is absent (zero gh calls). The REST issues
+  # arm (`api ... repos/.../issues`, #2258) reads issue-list.json if present,
+  # else "[]", remapped to snake_case; supports transient-failure injection via
+  # issue-list-fail-once. `issue create` logs its full args
   # (including --body) to gh-issue-create.log so the body can be asserted,
   # and echoes a deterministic issue URL. `project item-add` matches the gh
   # subcommand that dispatch-project-item-add invokes internally.
@@ -21412,14 +21414,20 @@ case "$args" in
   "label create "*)
     # Idempotent label create — default success.
     ;;
-  *"issue list "*)
+  *"api "*"repos/"*"/issues"*)
+    # (#2258) dispatch-statements-scan now batches via gh_issue_list_rest, which
+    # issues `gh api [--paginate] repos/<repo>/issues?state=all&...&labels=...`.
+    # The glob spans both the >100 (--paginate) and <=100 forms. Serve the SAME
+    # issue-list.json fixture, jq-remapped from camelCase to REST snake_case and
+    # INCLUDING body (the scan passes --include-body). Transient-failure injection
+    # via issue-list-fail-once still applies — the helper retries internally.
     if [[ -f "$STUB_DIR/issue-list-fail-once" ]]; then
       rm -f "$STUB_DIR/issue-list-fail-once"
       echo "HTTP 503: Service Unavailable" >&2
       exit 1
     fi
     if [[ -f "$STUB_DIR/issue-list.json" ]]; then
-      cat "$STUB_DIR/issue-list.json"
+      jq 'map({number, pull_request: null, created_at: (.createdAt//null), closed_at: (.closedAt//null), labels: (.labels//[])} + (if has("body") then {body} else {} end) + (if has("title") then {title} else {} end))' "$STUB_DIR/issue-list.json"
     else
       echo '[]'
     fi
@@ -21542,13 +21550,13 @@ else
 fi
 calls=$(cat "$STUB_DIR/gh-calls.log")
 TOTAL=$((TOTAL + 1))
-if [[ "$calls" == *"issue list "* && "$calls" == *"issue create"* \
+if [[ "$calls" == *"repos/test-owner/test-repo/issues"* && "$calls" == *"issue create"* \
    && "$calls" == *"project item-add"* ]]; then
   PASS=$((PASS + 1))
-  echo "  PASS: new-file invoked issue list / issue create / project item-add"
+  echo "  PASS: new-file invoked issue list (REST) / issue create / project item-add"
 else
   FAIL=$((FAIL + 1))
-  echo "  FAIL: new-file invoked issue list / issue create / project item-add"
+  echo "  FAIL: new-file invoked issue list (REST) / issue create / project item-add"
   echo "    gh-calls.log: $calls"
 fi
 # Assert both labels are present in the issue create call.
@@ -21756,20 +21764,30 @@ fi
 statements_teardown
 
 # --- Test 9: malformed gh issue list output → hard error, no issue create ----
+# (#2258) The batched lookup now flows through gh_issue_list_rest, which pipes the
+# gh api output through its OWN internal `jq -s` projection. A non-JSON result
+# makes that internal jq fail → the helper returns nonzero with empty stdout, so
+# the malformed case surfaces through the script's rc!=0 hard-error branch ("gh
+# issue list failed") rather than the (now unreachable-via-helper) non-JSON
+# branch. Intent is preserved: malformed output → hard error → files nothing.
+# The non-JSON injection reaches the helper through the stub's REST arm, where
+# the stub's own remap-jq fails on the TLS string and exits nonzero, driving the
+# helper's "gh api failed" path.
 
 echo "Test: dispatch-statements-scan surfaces hard error on malformed gh issue list output, does not file"
 statements_setup
 statements_write_projects
 statements_write_config
 printf 'STATEMENT-CONTENTS\n' > "$TMPDIR_TEST/statements-dir/acct.qfx"
-# Inject a TLS-error-like non-JSON message as the issue list result (gh exits 0).
+# Inject a TLS-error-like non-JSON message as the issue list result. The stub's
+# REST-arm remap jq fails on it → stub exits nonzero → helper rc!=0.
 printf 'tls: failed to verify certificate: x509: certificate signed by unknown authority\n' \
   > "$STUB_DIR/issue-list.json"
 rc=0
 err=$("$TMPDIR_TEST/scripts/dispatch-statements-scan" 2>&1 >/dev/null) || rc=$?
 assert_eq "malformed-list exits 1" "1" "$rc"
 TOTAL=$((TOTAL + 1))
-if [[ "$err" == *"bank: error"* && "$err" == *"non-JSON"* ]]; then
+if [[ "$err" == *"bank: error"* && "$err" == *"failed"* ]]; then
   PASS=$((PASS + 1)); echo "  PASS: malformed-list emits hard error to stderr"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: malformed-list emits hard error to stderr"
@@ -21853,8 +21871,9 @@ statements_teardown
 
 # --- Test 12: one list call regardless of file count -------------------------
 # Proves that the per-file Search-API fan-out is gone: with N=5 distinct new
-# files there is exactly ONE `gh issue list` invocation (per entry, not per
-# file) and exactly 5 `gh issue create` invocations.
+# files there is exactly ONE batched issue-list REST call (per entry, not per
+# file) and exactly 5 `gh issue create` invocations. (#2258) The list call is now
+# `gh api ... repos/.../issues?...`; count it by the REST path.
 
 echo "Test: dispatch-statements-scan makes exactly one gh issue list call for N files"
 statements_setup
@@ -21872,8 +21891,8 @@ out=$("$TMPDIR_TEST/scripts/dispatch-statements-scan" 2>/dev/null) || rc=$?
 assert_eq "one-list-call exits 0" "0" "$rc"
 list_count=0
 [[ -f "$STUB_DIR/gh-calls.log" ]] \
-  && list_count=$(grep -c '^issue list ' "$STUB_DIR/gh-calls.log" || true)
-assert_eq "one-list-call made exactly one issue list call" "1" "$list_count"
+  && list_count=$(grep -c 'repos/.*/issues' "$STUB_DIR/gh-calls.log" || true)
+assert_eq "one-list-call made exactly one issue list (REST) call" "1" "$list_count"
 create_count=0
 [[ -f "$STUB_DIR/gh-calls.log" ]] \
   && create_count=$(grep -c '^issue create ' "$STUB_DIR/gh-calls.log" || true)
@@ -21894,15 +21913,16 @@ printf 'STATEMENT-CONTENTS\n' > "$TMPDIR_TEST/statements-dir/retry.qfx"
 h=$(sha256sum "$TMPDIR_TEST/statements-dir/retry.qfx" | awk '{print $1}')
 jq -n --arg h "$h" '[{number:99, body:("- sha256: `" + $h + "`")}]' \
   > "$STUB_DIR/issue-list.json"
-# First gh issue list attempt fails transiently; retry returns the fixture.
+# (#2258) gh_issue_list_rest wraps gh_retry internally; the first REST issues
+# attempt fails transiently (issue-list-fail-once), the retry returns the fixture.
 touch "$STUB_DIR/issue-list-fail-once"
 rc=0
 out=$("$TMPDIR_TEST/scripts/dispatch-statements-scan" 2>/dev/null) || rc=$?
 assert_eq "retry-list exits 0" "0" "$rc"
 list_count=0
 [[ -f "$STUB_DIR/gh-calls.log" ]] \
-  && list_count=$(grep -c '^issue list ' "$STUB_DIR/gh-calls.log" || true)
-assert_eq "retry-list made exactly 2 issue list calls (fail attempt + retry)" "2" "$list_count"
+  && list_count=$(grep -c 'repos/.*/issues' "$STUB_DIR/gh-calls.log" || true)
+assert_eq "retry-list made exactly 2 issue list (REST) calls (fail attempt + retry)" "2" "$list_count"
 TOTAL=$((TOTAL + 1))
 if [[ "$out" == *"bank: skipped (#99 for retry.qfx)"* ]]; then
   PASS=$((PASS + 1)); echo "  PASS: retry-list skipped (#99 for retry.qfx) — retry parsed correctly"
@@ -31526,20 +31546,25 @@ followup_exists_setup() {
   mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/bin"
 
   cp "$SCRIPT_DIR/dispatch-followup-exists" "$TMPDIR_TEST/scripts/dispatch-followup-exists"
+  # (#2258) dispatch-followup-exists now sources lib.sh (for gh_issue_list_rest),
+  # so lib.sh must sit alongside it. Sourced, not executed — no chmod +x.
+  cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/lib.sh"
   chmod +x "$TMPDIR_TEST/scripts/dispatch-followup-exists"
 
-  # gh stub: matches ONLY the exact invocation the script makes:
-  #   gh issue list --search "\"<id>\" in:title" --state all --json number,title --limit 100
-  # On match, cat the fixture $TREE/issues.json if present, else echo [].
-  # The stub does NOT filter — it returns the whole array; the script's jq filters.
+  # gh stub: (#2258) the script now fetches via gh_issue_list_rest, which issues
+  #   gh api [--paginate] repos/{owner}/{repo}/issues?state=all&...
+  # On match, serve the fixture $TREE/issues.json (else []), jq-remapped from the
+  # fixture's {number,title} to REST snake_case WITH title (the script passes
+  # --include-title). The stub does NOT filter on the identifier — it returns the
+  # whole array; the script's boundary-aware jq post-filter does the matching.
   cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
 #!/usr/bin/env bash
 args="$*"
 TREE="$(cd "$(dirname "$0")/.." && pwd)"
 case "$args" in
-  issue\ list\ *--state\ all\ --json\ number,title\ --limit\ 100)
+  *"api "*"repos/"*"/issues"*)
     if [[ -f "$TREE/issues.json" ]]; then
-      cat "$TREE/issues.json"
+      jq 'map({number, pull_request: null, created_at: null, closed_at: null, labels: []} + (if has("title") then {title} else {} end))' "$TREE/issues.json"
     else
       echo '[]'
     fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -253,6 +253,19 @@ case "$args" in
       dispatch-test-limit)
         cat "$STUB_DIR/rest-limit.json"
         ;;
+      dispatch-test-title)
+        cat "$STUB_DIR/rest-title.json"
+        ;;
+      dispatch-test-limit-paginate)
+        # >100-limit paginate fixture: two pages concatenated (>= limit items).
+        cat "$STUB_DIR/rest-bigpage-1.json"
+        cat "$STUB_DIR/rest-bigpage-2.json"
+        ;;
+      dispatch-test-limit-exact)
+        # Exactly-<limit> fixture: serve a single array of exactly limit items so
+        # a caller's `len == limit ⇒ truncated` guard fires.
+        cat "$STUB_DIR/rest-exact.json"
+        ;;
       *)
         echo '[]'
         ;;
@@ -1238,6 +1251,74 @@ if grep -q -- '--paginate' "$STUB_DIR/gh-issue-list-rest-calls.log"; then
 else
   assert_eq "--repo+--limit: log does not contain --paginate" "no" "no"
 fi
+teardown
+
+echo "Test: --state all -- issued query carries state=all (#2258)"
+setup
+: > "$STUB_DIR/gh-issue-list-rest-calls.log"
+actual_all=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state all --label dispatch-test-empty)
+assert_eq "--state all: returns the stub's empty array" "[]" "$actual_all"
+# The query must carry state=all (anchor with a non-word char so this cannot
+# match state=allowed or similar).
+if grep -qE 'state=all([&?]|$| )' "$STUB_DIR/gh-issue-list-rest-calls.log"; then sa=yes; else sa=no; fi
+assert_eq "--state all: query carries state=all" "yes" "$sa"
+teardown
+
+echo "Test: --include-title -- present projects title, absent omits it (#2258)"
+setup
+printf '%s\n' '[
+  {"number":401,"title":"first issue","body":"b1","created_at":"2024-02-01T00:00:00Z","closed_at":null,"labels":[]},
+  {"number":402,"title":"second issue","body":"b2","created_at":"2024-02-02T00:00:00Z","closed_at":null,"labels":[]}
+]' > "$STUB_DIR/rest-title.json"
+: > "$STUB_DIR/gh-issue-list-rest-calls.log"
+# Absent: projected objects must NOT carry a title key.
+without_title=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state open --label dispatch-test-title)
+assert_eq "--include-title absent: .[0] has no title key" "false" "$(jq '.[0] | has("title")' <<<"$without_title")"
+assert_eq "--include-title absent: .[0] has no body key" "false" "$(jq '.[0] | has("body")' <<<"$without_title")"
+assert_eq "--include-title absent: number still projected" "401" "$(jq '.[0].number' <<<"$without_title")"
+# Present: projected objects carry title but still not body.
+with_title=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state open --include-title --label dispatch-test-title)
+assert_eq "--include-title present: .[0] carries title" "first issue" "$(jq -r '.[0].title' <<<"$with_title")"
+assert_eq "--include-title present: body still omitted" "false" "$(jq '.[0] | has("body")' <<<"$with_title")"
+# Both flags combine: title AND body present.
+with_both=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state open --include-title --include-body --label dispatch-test-title)
+assert_eq "--include-title+--include-body: .[0] carries title" "first issue" "$(jq -r '.[0].title' <<<"$with_both")"
+assert_eq "--include-title+--include-body: .[0] carries body" "b1" "$(jq -r '.[0].body' <<<"$with_both")"
+teardown
+
+echo "Test: --limit > 100 -- paginate path, sliced to limit (#2258)"
+setup
+# 150 items split across two pages (80 + 70). Numbers 1000..1149.
+jq -nc '[range(1000;1080) | {number: ., created_at:"2024-03-01T00:00:00Z", closed_at:null, labels:[]}]' \
+  > "$STUB_DIR/rest-bigpage-1.json"
+jq -nc '[range(1080;1150) | {number: ., created_at:"2024-03-01T00:00:00Z", closed_at:null, labels:[]}]' \
+  > "$STUB_DIR/rest-bigpage-2.json"
+: > "$STUB_DIR/gh-issue-list-rest-calls.log"
+actual_big=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state open --limit 120 --label dispatch-test-limit-paginate)
+assert_eq "--limit 120 over 150 items: result length == 120" "120" "$(jq 'length' <<<"$actual_big")"
+# The >100-limit path must --paginate (not single-page) ...
+if grep -q -- '--paginate' "$STUB_DIR/gh-issue-list-rest-calls.log"; then bp=yes; else bp=no; fi
+assert_eq "--limit 120: log contains --paginate" "yes" "$bp"
+# ... at the clamped per_page=100 (not per_page=120).
+if grep -q 'per_page=100[^0-9]' "$STUB_DIR/gh-issue-list-rest-calls.log"; then pp=yes; else pp=no; fi
+assert_eq "--limit 120: per_page clamped to 100" "yes" "$pp"
+if grep -q 'per_page=120' "$STUB_DIR/gh-issue-list-rest-calls.log"; then pp120=yes; else pp120=no; fi
+assert_eq "--limit 120: per_page is NOT 120" "no" "$pp120"
+teardown
+
+echo "Test: --limit > 100 -- exactly-limit items still trips a caller's len==limit guard (#2258)"
+setup
+# Exactly 120 items. With --limit 120 the result length is 120, so a caller's
+# `len == limit` truncation guard fires (just as it would on a single >100 page).
+jq -nc '[range(2000;2120) | {number: ., created_at:"2024-04-01T00:00:00Z", closed_at:null, labels:[]}]' \
+  > "$STUB_DIR/rest-exact.json"
+: > "$STUB_DIR/gh-issue-list-rest-calls.log"
+actual_exact=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state open --limit 120 --label dispatch-test-limit-exact)
+exact_len=$(jq 'length' <<<"$actual_exact")
+assert_eq "--limit 120 over exactly 120 items: result length == 120" "120" "$exact_len"
+# Simulate a caller's truncation guard: len == limit ⇒ truncated.
+if [[ "$exact_len" -eq 120 ]]; then guard=fired; else guard=clear; fi
+assert_eq "--limit 120: len==limit guard fires on exactly-limit fixture" "fired" "$guard"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -9508,10 +9508,13 @@ echo "=== dispatch-sweep ==="
 #   stub/                         per-test JSON + record files (calls, gh out)
 #
 # Shims:
-#   gh   — per-worktree PR query is `pr list --head <branch> --state all`, driven
-#          by pr-state-<branch>.json (each entry {state, number}); returns '[]'
-#          when no fixture exists. SWEEP_GH_PR_FAIL=<branch> forces that branch's
-#          --head query to fail. Issue-view is driven by issue-state-<N>.txt.
+#   gh   — per-worktree PR query (gh_pr_list_rest --head) issues two calls:
+#          "repo view --json owner -q .owner.login" (returns "natb1") and
+#          "api --paginate repos/.../pulls?state=all&...&head=natb1:<branch>",
+#          driven by pr-state-<branch>.json (REST format: {state:"open"|"closed",
+#          merged_at:<ts>|null, number, created_at, title}); returns '[]' by
+#          default. SWEEP_GH_PR_FAIL=<branch> forces the api call to fail.
+#          Issue-view is driven by issue-state-<N>.txt.
 #   git  — knows worktree list/remove/prune, branch -D, -C <p> status,
 #          -C <p> rev-list --count, -C <p> log -1 --format=%ct, and
 #          rev-parse --path-format=absolute --git-common-dir.
@@ -9548,20 +9551,30 @@ sweep_setup() {
 
   # gh shim — handles dispatch-sweep's calls.
   # Shims:
-  #   gh   — per-worktree PR query uses pr-state-<branch>.json (holding
-  #          [{"state":"MERGED"|"OPEN","number":<N>}]); returns '[]' by default
-  #          when no fixture exists. SWEEP_GH_PR_FAIL=<branch> makes the
-  #          --head query fail for that branch. Issue-view uses issue-state-<N>.txt.
+  #   gh   — per-worktree PR query (gh_pr_list_rest --head) issues two gh calls:
+  #          1. "repo view --json owner -q .owner.login" → returns "natb1"
+  #          2. "api --paginate repos/{owner}/{repo}/pulls?state=all&...&head=natb1:<branch>"
+  #             → serves pr-state-<branch>.json (REST format: each entry has
+  #             {state:"open"|"closed", merged_at:<ts>|null, number, created_at, title}).
+  #             Returns '[]' by default when no fixture exists.
+  #             SWEEP_GH_PR_FAIL=<branch> makes the api call fail for that branch.
+  #          Issue-view uses issue-state-<N>.txt.
   cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
 #!/usr/bin/env bash
 STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
 args="$*"
 case "$args" in
-  "pr list --head "*" --state all --json state,number")
-    # dispatch-sweep per-worktree PR query: gh pr list --head <branch> --state all --json state,number
-    br=$(echo "$args" | awk '{print $4}')
+  "repo view --json owner -q .owner.login")
+    # gh_pr_list_rest --head owner resolution: resolve the current repo owner.
+    echo "natb1"
+    ;;
+  api\ --paginate\ */pulls\?*)
+    # dispatch-sweep per-worktree PR query via gh_pr_list_rest (#2258):
+    # gh api --paginate repos/{owner}/{repo}/pulls?state=all&per_page=100&head=natb1:<branch>
+    # Extract branch from the head=natb1:<branch> query parameter.
+    br=$(printf '%s' "$args" | grep -oE 'head=natb1:[^ ]+' | sed 's/head=natb1://')
     if [[ "${SWEEP_GH_PR_FAIL:-}" == "$br" ]]; then
-      echo "gh sweep stub: simulated gh pr list --head failure for $br" >&2
+      echo "gh sweep stub: simulated gh api pulls failure for $br" >&2
       exit 1
     fi
     f="$STUB_DIR/pr-state-${br}.json"
@@ -9792,7 +9805,7 @@ echo "Test: merged worktree (in-sync) is removed + branch deleted"
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/42-feature"
 sweep_register_wt "$WT_PATH" "42-feature"
-echo '[{"state":"MERGED","number":100}]' \
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":100,"created_at":"2024-01-01T00:00:00Z","title":"PR 100"}]' \
   > "$STUB_DIR/pr-state-42-feature.json"
 # Clean tree + zero unpushed (defaults already match this — explicit for clarity).
 key=$(sweep_path_key "$WT_PATH")
@@ -9843,7 +9856,7 @@ echo "Test: squash-merged worktree retired despite non-zero rev-list (#1845)"
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/80-squash-merged"
 sweep_register_wt "$WT_PATH" "80-squash-merged"
-echo '[{"state":"MERGED","number":800}]' \
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":800,"created_at":"2024-01-01T00:00:00Z","title":"PR 800"}]' \
   > "$STUB_DIR/pr-state-80-squash-merged.json"
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"          # clean working tree
@@ -9989,7 +10002,7 @@ export SWEEP_GH_ISSUE_FAIL="60"
 # Sibling in-sync MERGED worktree to prove the sweep continues.
 WT_PATH_60B="$TMPDIR_TEST/project/worktrees/60b-sibling-merged"
 sweep_register_wt "$WT_PATH_60B" "60b-sibling-merged"
-echo '[{"state":"MERGED","number":600}]' > "$STUB_DIR/pr-state-60b-sibling-merged.json"
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":600,"created_at":"2024-01-01T00:00:00Z","title":"PR 600"}]' > "$STUB_DIR/pr-state-60b-sibling-merged.json"
 key_60b=$(sweep_path_key "$WT_PATH_60B")
 : > "$STUB_DIR/status${key_60b}.txt"
 echo "0" > "$STUB_DIR/revlist${key_60b}.txt"
@@ -10022,7 +10035,7 @@ echo "Test: open-PR worktree with closed issue is kept (OPEN_BY_BRANCH guard)"
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/61-active-pr"
 sweep_register_wt "$WT_PATH" "61-active-pr"
-echo '[{"state":"OPEN","number":888}]' \
+echo '[{"state":"open","merged_at":null,"number":888,"created_at":"2024-01-01T00:00:00Z","title":"PR 888"}]' \
   > "$STUB_DIR/pr-state-61-active-pr.json"
 # Issue is CLOSED, but the OPEN PR precedence guard must short-circuit before gh issue view.
 echo "CLOSED" > "$STUB_DIR/issue-state-61.txt"
@@ -10056,7 +10069,7 @@ sweep_register_wt "$WT_PATH" "70-live-merged"
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"
 echo "0" > "$STUB_DIR/revlist${key}.txt"
-echo '[{"state":"MERGED","number":300}]' \
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":300,"created_at":"2024-01-01T00:00:00Z","title":"PR 300"}]' \
   > "$STUB_DIR/pr-state-70-live-merged.json"
 # Register a live session whose name matches the worktree's basename.
 sweep_fake_claude_sessions_by_name "70-live-merged=sess-live-70"
@@ -10094,7 +10107,7 @@ sweep_register_wt "$WT_PATH" "71-no-live-merged"
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"
 echo "0" > "$STUB_DIR/revlist${key}.txt"
-echo '[{"state":"MERGED","number":301}]' \
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":301,"created_at":"2024-01-01T00:00:00Z","title":"PR 301"}]' \
   > "$STUB_DIR/pr-state-71-no-live-merged.json"
 # Default fake (no live sessions) — the worktree is free to remove.
 
@@ -10166,7 +10179,7 @@ echo "Test: non-issue branch (hotfix-login) in merged map is reaped"
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/hotfix-login"
 sweep_register_wt "$WT_PATH" "hotfix-login"
-echo '[{"state":"MERGED","number":400}]' \
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":400,"created_at":"2024-01-01T00:00:00Z","title":"PR 400"}]' \
   > "$STUB_DIR/pr-state-hotfix-login.json"
 # Clean tree + zero unpushed.
 key=$(sweep_path_key "$WT_PATH")
@@ -10206,7 +10219,7 @@ echo "Test: merged worktree with a reservation marker is skipped (SKIP_RESERVED)
 sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/90-reserved-merged"
 sweep_register_wt "$WT_PATH" "90-reserved-merged"
-echo '[{"state":"MERGED","number":500}]' \
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":500,"created_at":"2024-01-01T00:00:00Z","title":"PR 500"}]' \
   > "$STUB_DIR/pr-state-90-reserved-merged.json"
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"
@@ -10319,7 +10332,7 @@ echo "GARBAGE" > "$STUB_DIR/issue-state-62.txt"
 # Sibling in-sync MERGED worktree to prove the sweep continues.
 WT_PATH_62B="$TMPDIR_TEST/project/worktrees/62b-sibling-merged"
 sweep_register_wt "$WT_PATH_62B" "62b-sibling-merged"
-echo '[{"state":"MERGED","number":620}]' > "$STUB_DIR/pr-state-62b-sibling-merged.json"
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":620,"created_at":"2024-01-01T00:00:00Z","title":"PR 620"}]' > "$STUB_DIR/pr-state-62b-sibling-merged.json"
 key_62b=$(sweep_path_key "$WT_PATH_62B")
 : > "$STUB_DIR/status${key_62b}.txt"
 echo "0" > "$STUB_DIR/revlist${key_62b}.txt"
@@ -10361,7 +10374,7 @@ export SWEEP_GH_PR_FAIL="63-pr-fail"
 # Sibling in-sync MERGED worktree to prove the sweep continues.
 WT_PATH_63B="$TMPDIR_TEST/project/worktrees/63b-pr-ok"
 sweep_register_wt "$WT_PATH_63B" "63b-pr-ok"
-echo '[{"state":"MERGED","number":630}]' > "$STUB_DIR/pr-state-63b-pr-ok.json"
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":630,"created_at":"2024-01-01T00:00:00Z","title":"PR 630"}]' > "$STUB_DIR/pr-state-63b-pr-ok.json"
 key_63b=$(sweep_path_key "$WT_PATH_63B")
 : > "$STUB_DIR/status${key_63b}.txt"
 echo "0" > "$STUB_DIR/revlist${key_63b}.txt"
@@ -10417,7 +10430,7 @@ export DISPATCH_SWEEP_NOT_IN_SYNC_GRACE_S=100
 WT_PATH="$TMPDIR_TEST/project/worktrees/2100-merged-dirty"
 WT_BASE="2100-merged-dirty"
 sweep_register_wt "$WT_PATH" "$WT_BASE"
-echo '[{"state":"MERGED","number":2100}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":2100,"created_at":"2024-01-01T00:00:00Z","title":"PR 2100"}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
 key=$(sweep_path_key "$WT_PATH")
 # Not-in-sync: dirty tree (drives worktree_merged_in_sync to non-zero).
 echo " M residue.txt" > "$STUB_DIR/status${key}.txt"
@@ -10557,7 +10570,7 @@ export DISPATCH_SWEEP_NOT_IN_SYNC_GRACE_S=100
 WT_PATH="$TMPDIR_TEST/project/worktrees/2200-merged-young"
 WT_BASE="2200-merged-young"
 sweep_register_wt "$WT_PATH" "$WT_BASE"
-echo '[{"state":"MERGED","number":2200}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":2200,"created_at":"2024-01-01T00:00:00Z","title":"PR 2200"}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
 key=$(sweep_path_key "$WT_PATH")
 echo " M residue.txt" > "$STUB_DIR/status${key}.txt"
 # Pre-seed the marker (write-once already happened on a prior sweep).
@@ -10623,7 +10636,7 @@ export DISPATCH_SWEEP_NOW_EPOCH=99999
 WT_PATH="$TMPDIR_TEST/project/worktrees/2300-merged-live"
 WT_BASE="2300-merged-live"
 sweep_register_wt "$WT_PATH" "$WT_BASE"
-echo '[{"state":"MERGED","number":2300}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":2300,"created_at":"2024-01-01T00:00:00Z","title":"PR 2300"}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
 key=$(sweep_path_key "$WT_PATH")
 echo " M residue.txt" > "$STUB_DIR/status${key}.txt"
 # Pre-seed an aged-out marker so ONLY the live-session guard prevents the reap.
@@ -10692,7 +10705,7 @@ export DISPATCH_SWEEP_NOW_EPOCH=5000
 WT_PATH="$TMPDIR_TEST/project/worktrees/2400-merged-quarantine"
 WT_BASE="2400-merged-quarantine"
 sweep_register_wt "$WT_PATH" "$WT_BASE"
-echo '[{"state":"MERGED","number":2400}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":2400,"created_at":"2024-01-01T00:00:00Z","title":"PR 2400"}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
 key=$(sweep_path_key "$WT_PATH")
 echo " M residue.txt" > "$STUB_DIR/status${key}.txt"
 # Aged-out marker (age 5000-1000=4000 >= 100).
@@ -10747,7 +10760,7 @@ export DISPATCH_SWEEP_NOW_EPOCH=5000
 WT_PATH="$TMPDIR_TEST/project/worktrees/2401-merged-qfail"
 WT_BASE="2401-merged-qfail"
 sweep_register_wt "$WT_PATH" "$WT_BASE"
-echo '[{"state":"MERGED","number":2401}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":2401,"created_at":"2024-01-01T00:00:00Z","title":"PR 2401"}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
 key=$(sweep_path_key "$WT_PATH")
 echo " M residue.txt" > "$STUB_DIR/status${key}.txt"
 mkdir -p "$TMPDIR_TEST/project/tmp/dispatch-not-in-sync"
@@ -10822,7 +10835,7 @@ sweep_setup
 WT_PATH="$TMPDIR_TEST/project/worktrees/2500-merged-clean"
 WT_BASE="2500-merged-clean"
 sweep_register_wt "$WT_PATH" "$WT_BASE"
-echo '[{"state":"MERGED","number":2500}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":2500,"created_at":"2024-01-01T00:00:00Z","title":"PR 2500"}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
 key=$(sweep_path_key "$WT_PATH")
 : > "$STUB_DIR/status${key}.txt"          # clean
 echo "0" > "$STUB_DIR/revlist${key}.txt"
@@ -10885,7 +10898,7 @@ export DISPATCH_SWEEP_NOW_EPOCH=1050
 WT_PATH="$TMPDIR_TEST/project/worktrees/2600-live-marked"
 WT_BASE="2600-live-marked"
 sweep_register_wt "$WT_PATH" "$WT_BASE"
-echo '[{"state":"MERGED","number":2600}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":2600,"created_at":"2024-01-01T00:00:00Z","title":"PR 2600"}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
 key=$(sweep_path_key "$WT_PATH")
 echo " M residue.txt" > "$STUB_DIR/status${key}.txt"
 mkdir -p "$TMPDIR_TEST/project/tmp/dispatch-not-in-sync"
@@ -10933,7 +10946,7 @@ printf '{"notInSyncGraceSeconds":100}\n' > "$DISPATCH_CONFIG_DIR/sweep.json"
 WT_PATH="$TMPDIR_TEST/project/worktrees/2700-config-grace"
 WT_BASE="2700-config-grace"
 sweep_register_wt "$WT_PATH" "$WT_BASE"
-echo '[{"state":"MERGED","number":2700}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":2700,"created_at":"2024-01-01T00:00:00Z","title":"PR 2700"}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
 key=$(sweep_path_key "$WT_PATH")
 echo " M residue.txt" > "$STUB_DIR/status${key}.txt"
 MARKER="$TMPDIR_TEST/project/tmp/dispatch-not-in-sync/$WT_BASE"
@@ -10980,7 +10993,7 @@ export DISPATCH_SWEEP_NOT_IN_SYNC_GRACE_S=100
 WT_PATH="$TMPDIR_TEST/project/worktrees/2710-empty-config"
 WT_BASE="2710-empty-config"
 sweep_register_wt "$WT_PATH" "$WT_BASE"
-echo '[{"state":"MERGED","number":2710}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":2710,"created_at":"2024-01-01T00:00:00Z","title":"PR 2710"}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
 key=$(sweep_path_key "$WT_PATH")
 echo " M residue.txt" > "$STUB_DIR/status${key}.txt"
 MARKER="$TMPDIR_TEST/project/tmp/dispatch-not-in-sync/$WT_BASE"
@@ -11020,7 +11033,7 @@ export DISPATCH_SWEEP_NOT_IN_SYNC_GRACE_S=100
 WT_PATH="$TMPDIR_TEST/project/worktrees/2720-frac-config"
 WT_BASE="2720-frac-config"
 sweep_register_wt "$WT_PATH" "$WT_BASE"
-echo '[{"state":"MERGED","number":2720}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
+echo '[{"state":"closed","merged_at":"2024-01-01T00:00:00Z","number":2720,"created_at":"2024-01-01T00:00:00Z","title":"PR 2720"}]' > "$STUB_DIR/pr-state-${WT_BASE}.json"
 key=$(sweep_path_key "$WT_PATH")
 echo " M residue.txt" > "$STUB_DIR/status${key}.txt"
 MARKER="$TMPDIR_TEST/project/tmp/dispatch-not-in-sync/$WT_BASE"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -334,6 +334,18 @@ case "$args" in
         # #1085 per-episode latch read. Default [] (gate fires); a fixture models
         # an already-open latch issue (gate falls through).
         if [[ -f "$STUB_DIR/main-broken-issue-list.json" ]]; then cat "$STUB_DIR/main-broken-issue-list.json"; else echo "[]"; fi
+      elif [[ "$rest_label" == "dispatch:office-hours" ]]; then
+        # dispatch-trace-leaf parked set (#1011) and office-hours-select-target queue
+        # (#2258): both migrated from `gh issue list` to gh_issue_list_rest, so the
+        # office-hours scan now lands on the REST issues endpoint. Serve whichever
+        # fixture the active test seeds; absence → [] (nothing parked / empty queue).
+        if [[ -f "$STUB_DIR/trace-parked.json" ]]; then
+          cat "$STUB_DIR/trace-parked.json"
+        elif [[ -f "$STUB_DIR/oh-issue-list.json" ]]; then
+          cat "$STUB_DIR/oh-issue-list.json"
+        else
+          echo "[]"
+        fi
       else
         echo "[]"
       fi
@@ -343,26 +355,6 @@ case "$args" in
       jit_key=$(printf '%s' "$rest_label" | tr '/:' '__')
       jit_fixture="$STUB_DIR/jit-issues-${rest_state}-${jit_key}.json"
       if [[ -f "$jit_fixture" ]]; then cat "$jit_fixture"; else echo "[]"; fi
-    fi
-    ;;
-  "issue list --label dispatch:office-hours --state open --json number,createdAt,labels")
-    # office-hours-select-target: the office-hours queue (labeled open issues).
-    # The fetch now also carries `labels` (#1648) — the main-qa override reads it.
-    if [[ -f "$STUB_DIR/oh-issue-list.json" ]]; then
-      cat "$STUB_DIR/oh-issue-list.json"
-    else
-      echo "[]"
-    fi
-    ;;
-  "issue list --state open --label dispatch:office-hours --limit 300 --json number")
-    # dispatch-trace-leaf queue-mode parked set (#1011): open issues carrying
-    # dispatch:office-hours. $STUB_DIR/trace-parked.json supplies the parked
-    # numbers; absence means nothing is parked (default empty), so every
-    # pre-existing trace-leaf test stays green.
-    if [[ -f "$STUB_DIR/trace-parked.json" ]]; then
-      cat "$STUB_DIR/trace-parked.json"
-    else
-      echo "[]"
     fi
     ;;
   issue\ view\ *\ --json\ state)
@@ -19472,16 +19464,19 @@ case "$args" in
   "label create "*)
     # Idempotent label create — default success.
     ;;
-  *"issue list "*"--state open"*)
-    if [[ -f "$STUB_DIR/open-issues.json" ]]; then
-      cat "$STUB_DIR/open-issues.json"
+  *"api "*"repos/"*"/issues"*)
+    # gh_issue_list_rest (#2258): the engine's open/closed scans now hit REST
+    # (gh api [--paginate] repos/<repo>/issues?state=<s>&...). Serve the SAME
+    # open-issues.json / closed-issues.json fixtures, jq-remapped to REST
+    # snake_case so the helper remaps them back to identical camelCase data.
+    # state=open vs state=closed in the query string selects the fixture.
+    if [[ "$args" == *state=open* ]]; then
+      fixture="$STUB_DIR/open-issues.json"
     else
-      echo '[]'
+      fixture="$STUB_DIR/closed-issues.json"
     fi
-    ;;
-  *"issue list "*"--state closed"*)
-    if [[ -f "$STUB_DIR/closed-issues.json" ]]; then
-      cat "$STUB_DIR/closed-issues.json"
+    if [[ -f "$fixture" ]]; then
+      jq 'map({number, pull_request: null, created_at: (.createdAt // null), closed_at: (.closedAt // null), labels: (.labels // [])} + (if has("body") then {body} else {} end) + (if has("title") then {title} else {} end))' "$fixture"
     else
       echo '[]'
     fi
@@ -19580,8 +19575,8 @@ else
 fi
 calls=$(cat "$STUB_DIR/gh-calls.log")
 TOTAL=$((TOTAL + 1))
-if [[ "$calls" == *"label create"* && "$calls" == *"issue list "*"--state open"* \
-   && "$calls" == *"issue list "*"--state closed"* \
+if [[ "$calls" == *"label create"* && "$calls" == *"issues?"*"state=open"* \
+   && "$calls" == *"issues?"*"state=closed"* \
    && "$calls" == *"issue create"* && "$calls" == *"project item-add"* ]]; then
   PASS=$((PASS + 1))
   echo "  PASS: cold start invoked label create / list / create / item-add"
@@ -24614,9 +24609,14 @@ echo "$args" >> "$STUB_DIR/gh-calls.log"
 case "$args" in
   "label create "*)
     ;;
-  *"issue list "*"--state open"*)
+  *"api "*"repos/"*"/issues"*)
+    # gh_issue_list_rest (#2258): the calendar import's open-issue dedup scan now
+    # hits REST (gh api [--paginate] repos/<repo>/issues?state=open&...) WITH
+    # --include-body, so the helper's projection carries `body`. Serve the SAME
+    # open-issues.json fixture jq-remapped to REST snake_case, preserving `body`
+    # so the helper remaps back to identical camelCase data.
     if [[ -f "$STUB_DIR/open-issues.json" ]]; then
-      cat "$STUB_DIR/open-issues.json"
+      jq 'map({number, pull_request: null, created_at: (.createdAt // null), closed_at: (.closedAt // null), labels: (.labels // [])} + (if has("body") then {body} else {} end) + (if has("title") then {title} else {} end))' "$STUB_DIR/open-issues.json"
     else
       echo '[]'
     fi
@@ -25790,10 +25790,16 @@ STUB
 STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
 args="$*"
 case "$args" in
-  issue\ list\ *dispatch:main-broken*)
-    # Step-1c main-broken latch: still on `gh issue list` (not converted, #1601 A5).
+  api\ *repos/*/issues\?*dispatch:main-broken*)
+    # Step-1c main-broken latch: converted to gh_issue_list_rest (REST) by #2258.
+    # main-broken-open.txt holds one issue number per line; wrap them into a
+    # REST-shape snake_case array so the helper remaps to camelCase and the
+    # script's `jq -r '.[].number'` recovers the same numbers. Absent file → [],
+    # so the open-latch query returns empty and the re-arm short-circuits.
     if [[ -f "$STUB_DIR/main-broken-open.txt" ]]; then
-      cat "$STUB_DIR/main-broken-open.txt"
+      jq -R -s 'split("\n") | map(select(length > 0) | {number: (. | tonumber), pull_request: null, created_at: null, closed_at: null, labels: []})' "$STUB_DIR/main-broken-open.txt"
+    else
+      echo "[]"
     fi
     ;;
   api\ *repos/*/issues\?*dispatch:sync-broken*)
@@ -26871,11 +26877,16 @@ for a in "$@"; do
   prev="$a"
 done
 case "$sub" in
-  "issue list")
-    # Return the open-latch number if seeded; an absent file means no open
-    # latch (CREATE path). Must exit 0 either way — the script reads this under
-    # `set -e`, so a falsy `[[ -f ]]` test (no file) must not propagate rc 1.
-    [[ -f "$CAP/existing.txt" ]] && cat "$CAP/existing.txt"
+  "api --paginate")
+    # gh_issue_list_rest uses REST: gh api --paginate repos/{owner}/{repo}/issues?...
+    # Return the open-latch number if seeded; absent file means no open latch.
+    # gh_issue_list_rest remaps from snake_case REST to camelCase; serve snake_case.
+    if [[ -f "$CAP/existing.txt" ]]; then
+      num=$(cat "$CAP/existing.txt")
+      printf '[{"number":%s,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","closed_at":null,"labels":[]}]' "$num"
+    else
+      echo '[]'
+    fi
     exit 0
     ;;
   "issue create")
@@ -30134,6 +30145,7 @@ digest_window_setup() {
   mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/bin"
 
   cp "$SCRIPT_DIR/dispatch-digest-window" "$TMPDIR_TEST/scripts/dispatch-digest-window"
+  cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/lib.sh"
   chmod +x "$TMPDIR_TEST/scripts/dispatch-digest-window"
 
   cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
@@ -30148,9 +30160,11 @@ case "$args" in
       echo '{"createdAt":"2026-01-01T00:00:00Z","labels":[{"name":"jit:digest"}]}'
     fi
     ;;
-  issue\ list\ --repo\ *\ --label\ *\ --state\ closed\ --limit\ *\ --json\ number,closedAt)
+  api\ repos/*/issues*)
+    # gh_issue_list_rest uses REST: gh api repos/<repo>/issues?state=...
+    # Return each item in REST snake_case format; gh_issue_list_rest remaps to camelCase.
     if [[ -f "$TREE/closed.json" ]]; then
-      cat "$TREE/closed.json"
+      jq 'map({number, pull_request: null, created_at: .createdAt, closed_at: .closedAt, labels})' "$TREE/closed.json"
     else
       echo '[]'
     fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -271,6 +271,29 @@ case "$args" in
         ;;
     esac
     ;;
+  api\ *repos/*/pulls\?*)
+    # gh_pr_list_rest LIST endpoint (#2258): repos/{owner}/{repo}/pulls?state=...
+    # The leading `*` glob absorbs an optional `--paginate` before the path. This
+    # MUST precede the single-PR `api repos/*/pulls/*` arm (case is first-wins) —
+    # though that arm needs a literal `/` after `pulls` and would not match `?`
+    # anyway. Log the full $args so tests can assert --paginate / per_page= / the
+    # head= query param. Routes by fixture-file presence (no shared consumer to
+    # collide with, so no sentinel label needed): serve page-1 then page-2 if it
+    # exists, else `[]`. A gh-fail-pulls marker forces a gh failure.
+    echo "$args" >> "$STUB_DIR/gh-pr-list-rest-calls.log"
+    if [[ -f "$STUB_DIR/gh-fail-pulls" ]]; then
+      echo "stub forced gh api failure (pulls list)" >&2
+      exit 1
+    fi
+    if [[ -f "$STUB_DIR/rest-pulls-page-1.json" ]]; then
+      cat "$STUB_DIR/rest-pulls-page-1.json"
+      if [[ -f "$STUB_DIR/rest-pulls-page-2.json" ]]; then
+        cat "$STUB_DIR/rest-pulls-page-2.json"
+      fi
+    else
+      echo '[]'
+    fi
+    ;;
   api\ *repos/*/issues\?*)
     # gh_issue_list_rest (#1601): the four converted dispatch issue scans now hit
     # the REST issues endpoint instead of `gh issue list`. The fake-gh receives
@@ -439,6 +462,11 @@ case "$args" in
       fi
     fi
     echo "natb1/commons.systems"
+    ;;
+  "repo view --json owner -q .owner.login")
+    # gh_pr_list_rest --head owner resolution (#2258): when --head is set and
+    # --repo is absent, the helper resolves the current repo's owner login.
+    echo "natb1"
     ;;
   api\ */dependencies/blocked_by)
     path=$(echo "$args" | awk '{print $2}')
@@ -1319,6 +1347,114 @@ assert_eq "--limit 120 over exactly 120 items: result length == 120" "120" "$exa
 # Simulate a caller's truncation guard: len == limit ⇒ truncated.
 if [[ "$exact_len" -eq 120 ]]; then guard=fired; else guard=clear; fi
 assert_eq "--limit 120: len==limit guard fires on exactly-limit fixture" "fired" "$guard"
+teardown
+
+# ============================================================================
+# gh_pr_list_rest edge-case tests (#2258)
+# ============================================================================
+# These tests drive the REAL gh_pr_list_rest helper (sourced from the copied
+# lib.sh) via the `api *repos/*/pulls?*` stub arm above, which routes by fixture
+# presence and logs each call to gh-pr-list-rest-calls.log. They mirror the
+# gh_issue_list_rest edge-case block.
+echo "=== gh_pr_list_rest (edge cases) ==="
+
+echo "Test: gh_pr_list_rest empty result -- helper returns [] with length 0"
+setup
+: > "$STUB_DIR/gh-pr-list-rest-calls.log"
+actual_pr_empty=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_list_rest --state open)
+assert_eq "pr empty result: length == 0" "0" "$(jq 'length' <<<"$actual_pr_empty")"
+# No --limit was passed, so the helper must take the full-paginate path.
+if grep -q -- '--paginate' "$STUB_DIR/gh-pr-list-rest-calls.log"; then bp=yes; else bp=no; fi
+assert_eq "pr empty result: log contains --paginate" "yes" "$bp"
+teardown
+
+echo "Test: gh_pr_list_rest --limit > 100 -- paginate path, sliced to limit"
+setup
+# 150 PRs split across two pages (80 + 70). Numbers 1000..1149.
+jq -nc '[range(1000;1080) | {number: ., state:"open", title:"t", merged_at:null, created_at:"2024-03-01T00:00:00Z"}]' \
+  > "$STUB_DIR/rest-pulls-page-1.json"
+jq -nc '[range(1080;1150) | {number: ., state:"open", title:"t", merged_at:null, created_at:"2024-03-01T00:00:00Z"}]' \
+  > "$STUB_DIR/rest-pulls-page-2.json"
+: > "$STUB_DIR/gh-pr-list-rest-calls.log"
+actual_pr_big=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_list_rest --state open --limit 120)
+assert_eq "pr --limit 120 over 150: result length == 120" "120" "$(jq 'length' <<<"$actual_pr_big")"
+# The >100-limit path must --paginate (not single-page) ...
+if grep -q -- '--paginate' "$STUB_DIR/gh-pr-list-rest-calls.log"; then bp=yes; else bp=no; fi
+assert_eq "pr --limit 120: log contains --paginate" "yes" "$bp"
+# ... at the clamped per_page=100 (not per_page=120).
+if grep -qE 'per_page=100([^0-9]|$)' "$STUB_DIR/gh-pr-list-rest-calls.log"; then pp=yes; else pp=no; fi
+assert_eq "pr --limit 120: per_page clamped to 100" "yes" "$pp"
+if grep -q 'per_page=120' "$STUB_DIR/gh-pr-list-rest-calls.log"; then pp120=yes; else pp120=no; fi
+assert_eq "pr --limit 120: per_page is NOT 120" "no" "$pp120"
+teardown
+
+echo "Test: gh_pr_list_rest --limit single page (<=100, per_page=limit, no --paginate)"
+setup
+jq -nc '[range(300;303) | {number: ., state:"open", title:"t", merged_at:null, created_at:"2024-01-06T00:00:00Z"}]' \
+  > "$STUB_DIR/rest-pulls-page-1.json"
+: > "$STUB_DIR/gh-pr-list-rest-calls.log"
+actual_pr_lim=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_list_rest --state open --limit 50)
+assert_eq "pr limit: result length matches fixture (3 items)" "3" "$(jq 'length' <<<"$actual_pr_lim")"
+# The call log must contain per_page=50 (anchor trailing non-digit) ...
+if grep -qE 'per_page=50([^0-9]|$)' "$STUB_DIR/gh-pr-list-rest-calls.log"; then pp=yes; else pp=no; fi
+assert_eq "pr limit: log contains per_page=50" "yes" "$pp"
+# ... and must NOT contain --paginate (single-page branch).
+if grep -q -- '--paginate' "$STUB_DIR/gh-pr-list-rest-calls.log"; then bp=yes; else bp=no; fi
+assert_eq "pr limit: log does not contain --paginate" "no" "$bp"
+teardown
+
+echo "Test: gh_pr_list_rest gh-failure -- returns non-zero with diagnostic stderr"
+setup
+: > "$STUB_DIR/gh-pr-list-rest-calls.log"
+: > "$STUB_DIR/gh-fail-pulls"
+rc_pr_fail=0
+err_pr_fail=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_list_rest --state open 2>&1 >/dev/null) || rc_pr_fail=$?
+assert_eq "pr gh-failure: returns non-zero" "1" "$rc_pr_fail"
+case "$err_pr_fail" in *"gh_pr_list_rest: gh api failed"*) m=yes ;; *) m=no ;; esac
+assert_eq "pr gh-failure: stderr names the helper failure" "yes" "$m"
+teardown
+
+echo "Test: gh_pr_list_rest --head -- query carries head=<owner>:<branch> (repo-view owner)"
+setup
+echo '[]' > "$STUB_DIR/rest-pulls-page-1.json"
+: > "$STUB_DIR/gh-pr-list-rest-calls.log"
+# No --repo: owner resolves via the stubbed `gh repo view ... .owner.login` => natb1.
+actual_pr_head=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_list_rest --state open --head my-branch)
+assert_eq "pr --head: returns the stub's empty array" "[]" "$actual_pr_head"
+if grep -q 'head=natb1:my-branch' "$STUB_DIR/gh-pr-list-rest-calls.log"; then hb=yes; else hb=no; fi
+assert_eq "pr --head: query carries head=natb1:my-branch" "yes" "$hb"
+teardown
+
+echo "Test: gh_pr_list_rest --head + --repo -- owner from repo segment, not repo-view"
+setup
+echo '[]' > "$STUB_DIR/rest-pulls-page-1.json"
+: > "$STUB_DIR/gh-pr-list-rest-calls.log"
+# With --repo owner/other-repo, the head owner is the first segment (owner).
+actual_pr_head_repo=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_list_rest --state open --repo owner/other-repo --head feat-x)
+assert_eq "pr --head+--repo: returns the stub's empty array" "[]" "$actual_pr_head_repo"
+if grep -q 'head=owner:feat-x' "$STUB_DIR/gh-pr-list-rest-calls.log"; then hb=yes; else hb=no; fi
+assert_eq "pr --head+--repo: query carries head=owner:feat-x" "yes" "$hb"
+if grep -q 'repos/owner/other-repo/pulls' "$STUB_DIR/gh-pr-list-rest-calls.log"; then seg=yes; else seg=no; fi
+assert_eq "pr --head+--repo: API path uses cross-repo segment" "yes" "$seg"
+teardown
+
+echo "Test: gh_pr_list_rest state normalization -- OPEN / MERGED / CLOSED"
+setup
+# One open PR, one closed+merged (merged_at set), one closed+unmerged (null).
+printf '%s\n' '[
+  {"number":501,"state":"open","title":"open pr","merged_at":null,"created_at":"2024-05-01T00:00:00Z"},
+  {"number":502,"state":"closed","title":"merged pr","merged_at":"2024-05-02T00:00:00Z","created_at":"2024-05-01T00:00:00Z"},
+  {"number":503,"state":"closed","title":"closed pr","merged_at":null,"created_at":"2024-05-01T00:00:00Z"}
+]' > "$STUB_DIR/rest-pulls-page-1.json"
+: > "$STUB_DIR/gh-pr-list-rest-calls.log"
+actual_pr_norm=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_list_rest --state all)
+assert_eq "pr normalize: 501 (open) -> OPEN" "OPEN" "$(jq -r '.[] | select(.number==501) | .state' <<<"$actual_pr_norm")"
+assert_eq "pr normalize: 502 (closed+merged_at) -> MERGED" "MERGED" "$(jq -r '.[] | select(.number==502) | .state' <<<"$actual_pr_norm")"
+assert_eq "pr normalize: 503 (closed+null merged_at) -> CLOSED" "CLOSED" "$(jq -r '.[] | select(.number==503) | .state' <<<"$actual_pr_norm")"
+# Projection remaps snake_case to camelCase mergedAt/createdAt; title present.
+assert_eq "pr normalize: 502 mergedAt remapped" "2024-05-02T00:00:00Z" "$(jq -r '.[] | select(.number==502) | .mergedAt' <<<"$actual_pr_norm")"
+assert_eq "pr normalize: 501 createdAt remapped" "2024-05-01T00:00:00Z" "$(jq -r '.[] | select(.number==501) | .createdAt' <<<"$actual_pr_norm")"
+assert_eq "pr normalize: 501 title projected" "open pr" "$(jq -r '.[] | select(.number==501) | .title' <<<"$actual_pr_norm")"
 teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -31302,6 +31302,9 @@ drift_scan_setup() {
 
   cp "$SCRIPT_DIR/dispatch-drift-scan" "$TMPDIR_TEST/scripts/dispatch-drift-scan"
   chmod +x "$TMPDIR_TEST/scripts/dispatch-drift-scan"
+  # dispatch-drift-scan now sources lib.sh (for gh_retry); $SCRIPT_DIR inside the
+  # copied script resolves to this temp scripts/ dir, so lib.sh must live there.
+  cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/lib.sh"
 
   cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
 #!/usr/bin/env bash
@@ -31315,7 +31318,13 @@ case "$args" in
       echo '{"createdAt":"2026-01-01T00:00:00Z","body":"no refs"}'
     fi
     ;;
-  "pr list --state merged --search merged:>="*" --limit 100 --json number,title,mergedAt")
+  api\ *repos/*/pulls\?state=closed*)
+    # dispatch-drift-scan's merged-PR window now hits an inline REST call (#2258):
+    # `gh api --paginate repos/{owner}/{repo}/pulls?state=closed&sort=updated&...`.
+    # The leading `*` absorbs the optional `--paginate`. Serve the SAME fixture
+    # data the old `gh pr list --state merged` arm served, but in REST snake_case
+    # (number,title,merged_at,created_at,updated_at) — the script filters and
+    # remaps to mergedAt locally.
     if [[ -f "$TREE/prs.json" ]]; then
       cat "$TREE/prs.json"
     else
@@ -31369,7 +31378,7 @@ cat > "$TMPDIR_TEST/issue.json" <<'EOF'
 {"createdAt":"2026-06-03T00:00:00Z","body":"Touches `present.sh` and `does/not/exist.ts`. Uses `presentName_token` and `absentName_token`."}
 EOF
 cat > "$TMPDIR_TEST/prs.json" <<'EOF'
-[{"number":42,"title":"some pr","mergedAt":"2026-06-02T00:00:00Z"}]
+[{"number":42,"title":"some pr","created_at":"2026-05-20T00:00:00Z","merged_at":"2026-06-04T00:00:00Z","updated_at":"2026-06-04T00:00:00Z"}]
 EOF
 cat > "$TMPDIR_TEST/commits.txt" <<'EOF'
 abc1234 reworked present.sh distinctively_committed
@@ -31396,7 +31405,10 @@ printf 'echo hi\n' > "$TMPDIR_TEST/tree/present.sh"
 cat > "$TMPDIR_TEST/issue.json" <<'EOF'
 {"createdAt":"2026-06-03T00:00:00Z","body":"Touches `present.sh`."}
 EOF
-jq -nc '[range(100) | {number: (.+1), title: ("pr " + (.+1|tostring)), mergedAt: "2026-06-01T00:00:00Z"}]' \
+# REST snake_case fixtures, all merged IN-WINDOW (merged_at >= the 2026-06-03
+# anchor) so the local merged_at filter keeps all 100 and the >=100 in-window
+# guard fires. updated_at >= merged_at as REST guarantees.
+jq -nc '[range(100) | {number: (.+1), title: ("pr " + (.+1|tostring)), created_at: "2026-05-25T00:00:00Z", merged_at: "2026-06-04T00:00:00Z", updated_at: "2026-06-04T00:00:00Z"}]' \
   > "$TMPDIR_TEST/prs.json"
 cd "$TMPDIR_TEST/tree"
 out=$("$TMPDIR_TEST/scripts/dispatch-drift-scan" 1080); rc=$?

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -10627,11 +10627,11 @@ sweep_teardown
 
 # --- Test I2: pr-list --head failure is isolated (ERROR_PR_STATE_FETCH) -----
 #
-# A branch whose `gh pr list --head` call fails must be logged as
+# A branch whose `gh_pr_list_rest --head` call fails must be logged as
 # ERROR_PR_STATE_FETCH and skipped, not fatal. A sibling in-sync MERGED
 # worktree in the same run must still be removed.
 
-echo "Test: gh pr list --head failure is isolated (exit 0, sibling still removed)"
+echo "Test: gh_pr_list_rest --head failure is isolated (exit 0, sibling still removed)"
 sweep_setup
 # Failing worktree: SWEEP_GH_PR_FAIL makes the stub exit 1 for this branch.
 WT_PATH="$TMPDIR_TEST/project/worktrees/63-pr-fail"
@@ -10658,7 +10658,7 @@ else
   echo "    calls: $calls"
 fi
 TOTAL=$((TOTAL + 1))
-if grep -q "ERROR_PR_STATE_FETCH: branch=63-pr-fail gh pr list --head failed" \
+if grep -q "ERROR_PR_STATE_FETCH: branch=63-pr-fail gh_pr_list_rest --head failed" \
    "$DISPATCH_SWEEP_LOG_FILE"; then
   PASS=$((PASS + 1)); echo "  PASS: ERROR_PR_STATE_FETCH log line present"
 else

--- a/.claude/skills/roadmap/scripts/gather-context.sh
+++ b/.claude/skills/roadmap/scripts/gather-context.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
+# shellcheck source=../../dispatch-propagate/scripts/lib.sh
+source "$REPO_ROOT/.claude/skills/dispatch-propagate/scripts/lib.sh"
 
 OUTPUT="$REPO_ROOT/tmp/roadmap-context.txt"
 # Pre-create the file owner-only: it now holds analytics data (Search Console
@@ -29,11 +31,11 @@ cat README.md
 
 echo ""
 echo "=== Open Issues ==="
-gh issue list --state open --json number,title,labels --limit 200
+gh_issue_list_rest --state open --limit 200 --include-title
 
 echo ""
 echo "=== Closed Issues (recent 100) ==="
-gh issue list --state closed --json number,title,closedAt --limit 100
+gh_issue_list_rest --state closed --limit 100 --include-title
 
 echo ""
 echo "=== Repo Stats ==="


### PR DESCRIPTION
Closes #2258

## What this does

Migrates the remaining raw `gh issue list` / `gh pr list` call sites in the
committed dispatch scripts onto the REST rate-limit bucket, part of epic #2254
(the fleet exhausts the shared GraphQL bucket while the REST bucket sits ~73%
idle). Issue-list scans route through `gh_issue_list_rest`; PR-list scans route
through a new `gh_pr_list_rest`; GraphQL is retained only where a field is
genuinely GraphQL-only.

After this PR there is **no executable `gh issue list`** in the dispatch scripts,
and the only executable `gh pr list` is `pr_list_open` (lib.sh) — the one batched
per-tick open-PR snapshot that needs the GraphQL-only list fields
`closingIssuesReferences` and `statusCheckRollup`.

## Units

1. **`gh_issue_list_rest` (lib.sh)** — accept `--state all`; add an
   `--include-title` projection flag; fix `--limit > 100` to paginate-then-slice
   (REST clamps a single page to `per_page=100`, so the old single-page path
   silently truncated). This makes the `len == limit ⇒ truncated` guards in
   `dispatch-trace-leaf`, `dispatch-jit-calendar-import`, and
   `dispatch-statements-scan` actually fire.
2. **`gh_pr_list_rest` (lib.sh)** — new helper mirroring the issue helper, with
   `--head` support and REST→GraphQL state normalization (`open→OPEN`,
   `closed`+`merged_at`→`MERGED`, `closed`+null→`CLOSED`) so consuming scripts'
   `state == "OPEN"/"MERGED"` comparisons stay byte-identical.
3. **Mechanical issue-list drop-ins** — `office-hours-select-target`,
   `dispatch-jit-engine` (×2), `dispatch-escalate-sync-broken`,
   `dispatch-select-tick`, `dispatch-digest-window`.
4. **Limit-sensitive issue-list drop-ins** — `dispatch-trace-leaf` (300),
   `dispatch-jit-calendar-import` (1000, `--include-body`),
   `roadmap/gather-context.sh` (×2, `--include-title`). Also added the missing
   `lib.sh` sourcing to `dispatch-digest-window` and
   `dispatch-escalate-sync-broken` (they called the sourced helper but never
   sourced the lib).
5. **`dispatch-statements-scan`** (`--state all --limit 5000 --include-body`) and
   **`dispatch-followup-exists`** (`--state all --include-title`, dropping the
   GraphQL `--search` in favor of the authoritative boundary-aware jq
   post-filter).
6. **`dispatch-drift-scan`** merged-PR window → inline REST
   `gh api pulls?state=closed&sort=updated`, filtered locally to merged-in-window
   PRs. The sound ordering/early-stop key is `updated_at` (not
   `merged_at`/`created_at`): a PR created before the window can merge inside it,
   and `updated_at >= merged_at` guarantees every in-window merge has
   `updated_at >= window-start`.
7. **`dispatch-sweep`** per-worktree PR-state query → `gh_pr_list_rest --head`.
8. **Documentation** — the `pr_list_open` holdout comment now notes both
   GraphQL-only fields. Follow-up #2284 (blocked by this issue) tracks moving
   `dispatch-stop.sh`'s `statusCheckRollup` over-fetch to REST `check-runs` via
   `dispatch_ci_verdict_rest`, after which `closingIssuesReferences` would be the
   only GraphQL-only field the snapshot needs.

## Behavior-change note (intentional de-truncation)

Several call sites passed **no `--limit`**, so raw `gh issue list` silently
capped at gh's default of 30; `gh_issue_list_rest` with no `--limit` paginates
the full set. Every affected consumer reads field-wise from a created-desc list
(`.[0].number` / `.[].number`), so newest-first ordering and existence semantics
are preserved — this removes a silent truncation rather than changing behavior.
Affected: `office-hours-select-target`, `dispatch-select-tick`,
`dispatch-escalate-sync-broken`, `dispatch-jit-engine`.

## Test footprint

This migration also rewrote the per-test fake-`gh` stubs broadly: every migrated
consumer's stub now routes the REST `gh api .../issues` / `.../pulls` call
(serving the same fixtures jq-remapped to snake_case) instead of the old
`gh issue list` / `gh pr list` porcelain, and a few call-pattern/call-count
assertions were re-targeted to the new call shape. No assertion was weakened —
test intent is preserved throughout. This branch also merged origin/main's
sibling foundation (more REST helpers in lib.sh), reconciling the two epic
siblings' `gh_issue_list_rest` extensions (`--include-title` title-only;
`--include-body` title+body).

## Verification

The dispatch script test suite (the same suite CI's `hook-tests` job runs) is
green at **3800/3800**:

```
.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
```
