### PR TITLE
office-hours: attach to stopped/paused and resume removed originating sessions

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-recover-session-id
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-recover-session-id
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# dispatch-recover-session-id — find the newest recoverable session for an issue.
+#
+# Usage: dispatch-recover-session-id --issue <N>
+#
+# Globs the dispatch-stamp sidecar files under
+# ${DISPATCH_STAMP_PROJECTS_ROOT:-${HOME}/.claude/projects}/*/*.dispatch-stamp.json,
+# filters to sidecars whose .issue field equals N, sorts by .stamped_at descending
+# (file mtime as a secondary tiebreak), then returns the FIRST candidate whose
+# sibling <sessionId>.jsonl transcript still exists.
+#
+# On success: prints "<sessionId>\t<branch>" to stdout and exits 0.
+# When no recoverable session exists: exits 1, no stdout.
+# On usage/environment errors: exits 2 with a diagnostic on stderr.
+#
+# Pure filesystem — never touches the Claude daemon (no `claude agents`), so it
+# is sandbox-safe and unit-testable without a running daemon.
+#
+# Test seam: $DISPATCH_STAMP_PROJECTS_ROOT overrides the projects root
+# (default ${HOME}/.claude/projects).
+set -euo pipefail
+
+ISSUE=""
+
+usage() {
+  echo "usage: dispatch-recover-session-id --issue <N>" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue)
+      if [[ $# -lt 2 ]]; then
+        echo "dispatch-recover-session-id: --issue requires a value" >&2
+        usage
+        exit 2
+      fi
+      ISSUE="$2"
+      shift 2
+      ;;
+    *)
+      echo "dispatch-recover-session-id: unexpected argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$ISSUE" ]]; then
+  echo "dispatch-recover-session-id: --issue is required" >&2
+  usage
+  exit 2
+fi
+
+if [[ ! "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "dispatch-recover-session-id: --issue must be a non-negative integer, got: $ISSUE" >&2
+  usage
+  exit 2
+fi
+
+PROJECTS_ROOT="${DISPATCH_STAMP_PROJECTS_ROOT:-${HOME:-}/.claude/projects}"
+if [[ -z "$PROJECTS_ROOT" || ! -d "$PROJECTS_ROOT" ]]; then
+  echo "dispatch-recover-session-id: projects root '$PROJECTS_ROOT' is not a directory" >&2
+  exit 2
+fi
+
+# Collect all matching sidecars: emit "<stamped_at>\t<mtime_epoch>\t<sidecar_path>"
+# for each sidecar whose .issue == N (exact numeric match), then sort descending
+# by stamped_at (primary) and mtime (secondary).
+#
+# We use `jq -r` directly on the file (never echo "$VAR" | jq) to avoid
+# control-character corruption per shell-json.md.  Sidecars that fail to parse
+# or lack a matching .issue are skipped silently — a corrupt/alien sidecar
+# should not abort recovery.
+
+candidates=()
+while IFS= read -r sidecar; do
+  # Read .issue from the file; skip if jq fails or field is missing/wrong type.
+  sidecar_issue=$(jq -r '.issue // empty' "$sidecar" 2>/dev/null) || continue
+  # Exact integer match — do not allow cross-issue attribution.
+  [[ "$sidecar_issue" == "$ISSUE" ]] || continue
+
+  stamped_at=$(jq -r '.stamped_at // empty' "$sidecar" 2>/dev/null) || continue
+  [[ -n "$stamped_at" ]] || continue
+
+  mtime=$(stat -c '%Y' "$sidecar" 2>/dev/null) || continue
+  candidates+=("${stamped_at}	${mtime}	${sidecar}")
+done < <(find "$PROJECTS_ROOT" -maxdepth 2 -name "*.dispatch-stamp.json" 2>/dev/null)
+
+if [[ ${#candidates[@]} -eq 0 ]]; then
+  exit 1
+fi
+
+# Sort descending: primary key = stamped_at (ISO-8601 sorts lexicographically),
+# secondary key = mtime (numeric, descending).  Both fields are unique-enough
+# that a stable tiebreak matters only in adversarial fixtures; for real usage
+# stamped_at is the authoritative ordering.
+#
+# sort -t$'\t' -k1,1r -k2,2rn:
+#   -k1,1r  → column 1 (stamped_at) reverse lexicographic
+#   -k2,2rn → column 2 (mtime) reverse numeric
+sorted=$(printf '%s\n' "${candidates[@]}" | sort -t$'\t' -k1,1r -k2,2rn)
+
+# Iterate sorted candidates; return the first whose transcript (.jsonl) exists.
+while IFS=$'\t' read -r _stamped _mtime sidecar; do
+  sidecar_dir="$(dirname "$sidecar")"
+  session_id=$(jq -r '.session_id // empty' "$sidecar" 2>/dev/null) || continue
+  [[ -n "$session_id" ]] || continue
+
+  transcript="${sidecar_dir}/${session_id}.jsonl"
+  if [[ -f "$transcript" ]]; then
+    branch=$(jq -r '.branch // empty' "$sidecar" 2>/dev/null) || continue
+    [[ -n "$branch" ]] || continue
+    printf '%s\t%s\n' "$session_id" "$branch"
+    exit 0
+  fi
+done <<<"$sorted"
+
+# No candidate had a surviving transcript.
+exit 1

--- a/.claude/skills/dispatch-propagate/scripts/office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours
@@ -57,6 +57,21 @@
 #                                   — the selector already confirmed the remote
 #                                   exists, so a failure here is a genuine error
 #                                   and a silent fresh-spawn would mask it.
+#   resume <N> <sessionId> <cwd>
+#                                 → the originating session was REMOVED from the
+#                                   daemon registry but its on-disk transcript is
+#                                   recoverable and its <N>-* worktree is present
+#                                   (#2240). Resume it in place as a --bg job named
+#                                   office-hours-<N> rooted at <cwd> (--resume, with
+#                                   a --fork-session retry if the kick fails on a
+#                                   stale/colliding id), then attach BY NAME — a
+#                                   forked retry mints a new sessionId, so the
+#                                   verb's <sessionId> is stale for attach.
+#   resume-provision <N> <sessionId> <branch>
+#                                 → as resume, but the worktree was swept while
+#                                   origin/<branch> still exists: provision it from
+#                                   the remote first (dispatch-provision-from-remote),
+#                                   then resume in the freshly-landed worktree.
 #   empty                         → print a queue-empty message and exit WITHOUT
 #                                   launching Claude. The empty queue is handled
 #                                   entirely in bash; no session is booted.
@@ -72,6 +87,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# resolve_project_root (resume-provision worktree path) lives in lib.sh;
+# verify_agent_registered_under (the resume arms' post-kick registration check)
+# lives in lib-claude-agents.sh — the same two libs the selector sources. The
+# thin-dispatcher daemon-query note above still holds for the idle/fresh paths.
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib-claude-agents.sh"
 
 # Launch target only. The selector reads CLAUDE_AGENTS_CMD from the environment
 # for its own liveness queries (default `claude`); this script does not set it.
@@ -108,6 +132,68 @@ attach_session() {
     exit 1
   fi
   exec "$CLAUDE_CMD" attach "$job_id"
+}
+
+# job_id_for_name <name> — echo the daemon job id of the live background job named
+# <name>, or empty. --all so a just-resumed (or just-forked) session is visible
+# regardless of its momentary state.
+job_id_for_name() {
+  "$CLAUDE_CMD" agents --json --all 2>/dev/null \
+    | jq -r --arg n "$1" '
+        if type == "array"
+        then (first(.[] | select(.name == $n) | .id) // empty)
+        else empty end' 2>/dev/null || true
+}
+
+# attach_session_by_name <name> — exec `claude attach` on the background job named
+# <name>. The resume arms attach BY NAME, never by the selector's <sessionId>: a
+# --fork-session retry mints a NEW sessionId, so the original is stale, while the
+# name office-hours-<N> is the stable handle.
+attach_session_by_name() {
+  local name="$1" job_id
+  job_id=$(job_id_for_name "$name")
+  if [[ -z "$job_id" ]]; then
+    echo "office-hours: no live background job named $name — cannot attach (the resume kick may have failed, or the daemon is unreachable). Run 'claude agents' to inspect." >&2
+    exit 1
+  fi
+  exec "$CLAUDE_CMD" attach "$job_id"
+}
+
+# resume_session <sessionId> <N> <cwd> — resume a REMOVED-but-recoverable
+# originating session (#2240) in place. Mirrors dispatch-resume-worker's resume
+# mechanism INLINE — it is NOT invoked, because that script's worker-only
+# `^[0-9]+-` name gate rejects the office-hours-<N> name used here.
+#
+# Kick the session as a --bg job named office-hours-<N>, rooted at <cwd> via a
+# subshell `cd` so SessionStart-derived attributes key on the right directory. A
+# successful resume requires BOTH a clean kick AND verified registration:
+# `claude --bg` returns BEFORE the daemon registers the session, and a
+# dead/colliding <sessionId> is rejected ASYNCHRONOUSLY (the kick returns 0, yet
+# no session ever registers). So gate on kick-rc-0 AND verify_agent_registered_
+# under, mirroring dispatch-resume-worker. On a failed kick OR a failed verify,
+# retry ONCE with --fork-session, which resumes off a fresh id derived from the
+# same transcript. Both attempts failing to register is a hard error (a clear
+# message beats a silent fresh-spawn).
+#
+# THE FORKED-SESSIONID TRAP: --fork-session mints a NEW sessionId, so the
+# selector's <sessionId> is stale for attach. attach_session_by_name keys on the
+# stable name office-hours-<N>, never the original sessionId.
+resume_session() {
+  local session_id="$1" num="$2" cwd="$3" name="office-hours-$2" rc=0
+  ( cd "$cwd" && "$CLAUDE_CMD" --bg --name "$name" --permission-mode auto \
+      --resume "$session_id" "continue" ) >/dev/null 2>&1 || rc=$?
+  if [[ "$rc" -ne 0 ]] || ! verify_agent_registered_under "$name" "$cwd"; then
+    # Primary kick failed, or it returned 0 but no session registered (an
+    # async-rejected stale/colliding id). Retry ONCE off a fresh forked id.
+    rc=0
+    ( cd "$cwd" && "$CLAUDE_CMD" --bg --name "$name" --permission-mode auto \
+        --resume "$session_id" --fork-session "continue" ) >/dev/null 2>&1 || rc=$?
+    if [[ "$rc" -ne 0 ]] || ! verify_agent_registered_under "$name" "$cwd"; then
+      echo "office-hours: failed to resume session $session_id for #$num under name $name in $cwd (both --resume and --fork-session kicks failed to register a live session). Run 'claude agents' to inspect." >&2
+      exit 1
+    fi
+  fi
+  attach_session_by_name "$name"
 }
 
 # One call to the single source of truth; dispatch on the returned verb.
@@ -157,6 +243,24 @@ case "$verb" in
       exit 1
     fi
     attach_session "$a"
+    ;;
+  resume)
+    # a b c = <N> <sessionId> <cwd>. The originating session was removed from the
+    # daemon registry but its transcript is recoverable and its <N>-* worktree is
+    # on disk — resume it in place under name office-hours-<N>, then attach by name.
+    resume_session "$b" "$a" "$c"
+    ;;
+  resume-provision)
+    # a b c = <N> <sessionId> <branch>. As resume, but the worktree was swept while
+    # origin/<branch> still exists: provision it from the remote first, then resume
+    # in the freshly-landed worktree. Redirect provision stdout to stderr so it does
+    # not pollute office-hours' captured stdout.
+    if ! "$SCRIPT_DIR/dispatch-provision-from-remote" "$c" >&2; then
+      echo "office-hours: provisioning worktree for branch '$c' from the remote failed — cannot resume session $b for #$a. Check the output above: origin/$c may be missing or unfetchable (network/fetch error), the worktree-add may have failed, or origin/main may have a merge conflict with the branch." >&2
+      exit 1
+    fi
+    # dispatch-provision-from-remote lands the worktree at <project-root>/worktrees/<branch>.
+    resume_session "$b" "$a" "$(resolve_project_root)/worktrees/$c"
     ;;
   empty)
     echo "office-hours: queue is empty — nothing to resume or start."

--- a/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
@@ -65,6 +65,22 @@
 #     is the invariant the lib-claude-agents.sh tests guard (Test 8b / occupancy
 #     tests added in #2240). Unrecognized/empty/malformed states remain a fail-safe
 #     skip (criterion 3: never attach into an unknown state).
+#   resume <issue> <sessionId> <cwd>
+#     The oldest sessionless labeled item whose originating session has been
+#     REMOVED from the daemon registry but whose on-disk transcript is still
+#     recoverable (#2240). dispatch-recover-session-id resolves the resumable
+#     sessionId + branch from the session's stamp sidecar, conditioned on the
+#     <sessionId>.jsonl transcript still existing; the item's <N>-* worktree is
+#     present on disk, so the consumer resumes the session in place via
+#     `--bg --resume <sessionId>` rather than fresh-launching and discarding the
+#     session's accumulated context. resume ranks BELOW a live idle session (a
+#     live idle session is strictly safer than resurrecting a removed one) and
+#     ABOVE the fresh path, oldest-first within the class.
+#   resume-provision <issue> <sessionId> <branch>
+#     As `resume`, but the item's worktree has been SWEPT while `origin/<branch>`
+#     still exists. The consumer re-provisions the worktree from the remote
+#     branch, then resumes the originating session — symmetric with
+#     `idle-provision` for the removed-but-recoverable case.
 #   office-hours <issue> <phase> <pr-or-dash> <worktree-path>
 #     The oldest labeled item with NO live session — a sessionless item that
 #     /office-hours picks up fresh.
@@ -277,6 +293,7 @@ FRESH_NUM=""
 IDLE_ID=""
 IDLE_CWD=""
 IDLE_NUM=""
+SESSIONLESS_NUMS=()
 while IFS= read -r issue_num; do
   [[ -z "$issue_num" ]] && continue
   if pair=$(issue_live_session_id "$issue_num"); then
@@ -289,7 +306,9 @@ while IFS= read -r issue_num; do
     rc=$?
     case "$rc" in
       2|3) continue ;;                               # UNKNOWN or skip → don't fresh-launch
-      *) [[ -z "$FRESH_NUM" ]] && FRESH_NUM="$issue_num" ;;  # rc 1 → sessionless
+      *)                                                     # rc 1 → sessionless
+        SESSIONLESS_NUMS+=("$issue_num")                     # capture oldest-first for the resume pass
+        [[ -z "$FRESH_NUM" ]] && FRESH_NUM="$issue_num" ;;
     esac
   fi
 done <<< "$SORTED"
@@ -328,7 +347,42 @@ if [[ -n "$IDLE_ID" ]]; then
   [[ -z "$FRESH_NUM" ]] && FRESH_NUM="$IDLE_NUM"
 fi
 
-# Priority 2: pick up the oldest sessionless item fresh. The open-PR list is
+# Priority 2: a REMOVED-but-recoverable originating session (#2240). Reached only
+# when no attachable idle session was emitted above — a live idle session always
+# wins. Walk the sessionless issues oldest-first; the FIRST whose originating
+# session is recoverable (dispatch-recover-session-id resolves its sessionId +
+# branch from the stamp sidecar, conditioned on the <sessionId>.jsonl transcript
+# still existing) settles the class, classified symmetric with the idle classifier:
+#   1. <N>-* worktree present on disk → resume in place: emit `resume <N> <sid> <cwd>`.
+#   2. Worktree swept but `origin/<branch>` still exists → emit
+#      `resume-provision <N> <sid> <branch>`; the consumer provisions then resumes.
+#   3. Worktree swept AND no remote → fall through to the fresh path (below).
+# resume > fresh: a recoverable session is preferred over fresh-launching a
+# sessionless sibling, but never over a live idle session. First recoverable issue
+# settles the class (mirrors the idle classifier's first-attachable-wins).
+for rec_num in "${SESSIONLESS_NUMS[@]:-}"; do
+  [[ -z "$rec_num" ]] && continue
+  rec_pair=$("$SCRIPT_DIR/dispatch-recover-session-id" --issue "$rec_num") || continue
+  IFS=$'\t' read -r rec_sid rec_branch <<< "$rec_pair"
+  [[ -z "$rec_sid" ]] && continue
+  rec_cwd=$(printf '%s' "${WORKTREE_PATHS_BY_NUM[$rec_num]:-}" | head -n 1)
+  if [[ -n "$rec_cwd" && -d "$rec_cwd" ]]; then
+    printf 'resume %s %s %s\n' "$rec_num" "$rec_sid" "$rec_cwd"
+    exit 0
+  fi
+  # Worktree swept — provision from the remote branch if it still exists. Probe
+  # via `git -C <main>` (the selector's cwd is not guaranteed to carry origin),
+  # mirroring the idle-provision swept check.
+  if git -C "$(resolve_main_worktree)" ls-remote --exit-code --heads origin "$rec_branch" >/dev/null 2>&1; then
+    printf 'resume-provision %s %s %s\n' "$rec_num" "$rec_sid" "$rec_branch"
+    exit 0
+  fi
+  # Swept + no remote: the first recoverable issue settles the class and falls
+  # through to the fresh path (FRESH_NUM already holds the oldest sessionless item).
+  break
+done
+
+# Priority 3: pick up the oldest sessionless item fresh. The open-PR list is
 # fetched lazily here — only the fresh path needs it, so the resume path makes
 # no `gh pr list` call. The field set is dispatch-phase's superset;
 # dispatch-find-pr accepts it too (mirrors dispatch-select-target's

--- a/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
@@ -10,10 +10,12 @@
 # <N>-* worktree, and emits exactly one of five dispositions, in this priority:
 #
 #   idle <sessionId>
-#     The oldest labeled item whose originating Claude session is idle/complete
-#     (state waiting/done/idle) AND whose worktree is still present on disk. Idle
-#     wins over fresh: if any labeled item has an attachable idle session, that
-#     session is attached in preference to picking up a sessionless sibling fresh.
+#     The oldest labeled item whose originating Claude session is attachable
+#     (state waiting/done/idle/stopped/paused) AND whose worktree is still present
+#     on disk. Idle wins over fresh: if any labeled item has an attachable session,
+#     that session is attached in preference to picking up a sessionless sibling
+#     fresh. stopped/paused are now attachable (#2240): a human resuming the queue
+#     re-engages the originating session in place rather than wedging.
 #
 #     The chosen attachable item is classified by the state of its session's
 #     worktree (the cwd `issue_live_session_id` now returns alongside the
@@ -28,7 +30,7 @@
 #          exits. Fresh fallback with a diagnostic, never a silent failure.
 #
 #   idle-provision <sessionId> <branch>
-#     The oldest labeled item whose originating session is idle/complete but whose
+#     The oldest labeled item whose originating session is attachable but whose
 #     worktree has been SWEPT, while its remote branch `origin/<branch>` still
 #     exists (#2241). <branch> is the swept worktree's basename. The consumer
 #     re-provisions the worktree from the remote branch, then attaches the
@@ -36,29 +38,33 @@
 #     lose the session's context.
 #
 #     The disposition gates on the granular session `state`, not mere liveness —
-#     it must only surface an IDLE session, never an actively-WORKING one. The
-#     state→action contract:
+#     it must only surface an ATTACHABLE session, never an actively-WORKING one.
+#     The state→action contract:
 #
 #       state                                       action
 #       ------------------------------------------- -----------------------------
-#       working (busy)                              SKIP the issue — being worked
+#       working / busy                              SKIP the issue — being worked
 #                                                   autonomously; don't attach,
 #                                                   don't fresh-launch
-#       waiting / done / idle                       ATTACH (done requires --all
-#                                                   to see)
-#       stopped / paused / any unrecognized state   EXCLUDE from attach — skip
-#                                                   the issue (fail-safe)
+#       waiting / done / idle / stopped / paused    ATTACH (done requires --all
+#                                                   to see; stopped/paused attach
+#                                                   so a human resuming the queue
+#                                                   re-engages the originating
+#                                                   session in place, #2240)
+#       unrecognized / empty / malformed state      SKIP fail-safe — unknown
+#                                                   state, never attach into it
 #       not in registry                             sessionless → fresh-launch
 #
-#     Stopped/paused (and any unrecognized state) are excluded from attach —
-#     treated like working (skip the issue). Known consequence: such a session
-#     still name-matches in `worktree_has_live_session`, so its issue won't
-#     fresh-launch either and can wedge until the session is cleaned up.
-#     Handling that wedge is out of scope here — it would require changing the
-#     shared `worktree_has_live_session` / `claude_agents_list_all` helpers,
-#     which gate the dispatch router's worktree-occupancy decisions on the hot
-#     path; making `done` sessions newly 'occupy' a worktree there would block
-#     phase-worker launches.
+#     Stopped/paused are now ATTACHABLE (#2240): the wedge they previously caused
+#     (name-matching in worktree_has_live_session but excluded from attach →
+#     issue stuck until session cleaned up) is resolved because attach now fires
+#     instead of skip. The shared worktree_has_live_session / claude_agents_list_all
+#     helpers are deliberately NOT changed: a stopped/paused session still reports
+#     the worktree OCCUPIED on the router hot path, which is correct — fresh-launch
+#     is now harmless because attach fires first; the byte-identical router path
+#     is the invariant the lib-claude-agents.sh tests guard (Test 8b / occupancy
+#     tests added in #2240). Unrecognized/empty/malformed states remain a fail-safe
+#     skip (criterion 3: never attach into an unknown state).
 #   office-hours <issue> <phase> <pr-or-dash> <worktree-path>
 #     The oldest labeled item with NO live session — a sessionless item that
 #     /office-hours picks up fresh.
@@ -164,8 +170,9 @@ done < <(list_worktree_records)
 #   rc 2 — UNKNOWN: the daemon could not be queried, and no attachable session
 #          was seen.
 #   rc 3 — present-but-not-attachable: a session was seen but its state is
-#          working/stopped/paused/unrecognized — skip the issue (don't attach,
-#          don't fresh-launch on top of its live work).
+#          working/busy or unrecognized/empty/malformed — skip the issue (don't
+#          attach, don't fresh-launch on top of its live work). stopped/paused
+#          no longer land here — they are now attachable (rc 0, #2240).
 # Gates on the granular session `state` (via claude_sessions_with_name_all /
 # claude_sessions_with_name_prefix_all, which pass --all so `done` sessions are
 # visible), not on mere liveness. An attachable idle session under ANY name wins,
@@ -178,7 +185,7 @@ done < <(list_worktree_records)
 # This is what lets office-hours re-attach to an originating session whose <N>-*
 # worktree has been swept. It also fixes a latent double-claim bug: a `working`
 # session with an unregistered worktree previously returned rc1 (sessionless) and
-# got fresh-launched on top of live work; it is now FOUND, hits the `*) saw_skip`
+# got fresh-launched on top of live work; it is now FOUND, hits the `working|busy)`
 # arm, and returns rc3 so the caller does NOT fresh-launch it (criterion 5).
 #
 # Name set:
@@ -209,18 +216,27 @@ issue_live_session_id() {
         # (code-review #2241).
         while IFS=$'\t' read -r sid state cwd _; do
           case "$state" in
-            waiting|done|idle)
+            waiting|done|idle|stopped|paused)
               # Attachable — emit sessionId<TAB>cwd (#2241) and signal the caller
-              # to return 0 immediately.
+              # to return 0 immediately. stopped/paused now attach so a human
+              # resuming the queue re-engages the originating session in place
+              # (#2240); the wedge they used to cause is gone.
               printf '%s\t%s\n' "$sid" "$cwd"
               return 0
               ;;
+            working|busy)
+              # Genuinely-working (busy) session — being worked autonomously; never
+              # attach or fresh-launch (double-claim). Keep scanning: an attachable
+              # session under another name still wins. A `working` session with no
+              # registered worktree lands here (the #2241 double-claim fix): it is
+              # now found and skips rather than being mistaken for sessionless and
+              # fresh-launched.
+              saw_skip=1
+              ;;
             *)
-              # working/stopped/paused/unrecognized (or empty/malformed) → not
-              # attachable; keep looking — an attachable session under another
-              # name still wins. A `working` session with no registered worktree
-              # lands here (the #2241 double-claim fix): it is now found and skips
-              # rather than being mistaken for sessionless and fresh-launched.
+              # Unrecognized / empty / malformed state → fail-safe skip (#2240
+              # criterion 3: keep the conservative skip rather than attaching into
+              # an unknown state).
               saw_skip=1
               ;;
           esac

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -7498,6 +7498,143 @@ assert_eq "swept + unprovisionable → no LAUNCH (no spawn)" "no" \
 unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 
+# OH11. resume arm end-to-end (#2240): the selector emits `resume <N> <sid> <cwd>`
+# for a removed-but-recoverable session whose worktree is on disk. The entry
+# resumes it as a --bg job named office-hours-<N> rooted at <cwd>, then attaches BY
+# NAME. Stub the selector to emit the directive; a fake claude logs the --bg argv,
+# serves the post-resume registry (office-hours-42 under a FORKED sessionId, so
+# attach must resolve by NAME not by the verb's sess-abc), and echoes attach.
+echo "Test: resume directive → --bg --resume kick named office-hours-N, attach by name"
+setup
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+cat > "$TMPDIR_TEST/office-hours-select-target" <<EOF
+#!/usr/bin/env bash
+echo "resume 42 sess-abc $TMPDIR_TEST/wt/42-x"
+EOF
+chmod +x "$TMPDIR_TEST/office-hours-select-target"
+cat > "$TMPDIR_TEST/bin/claude" <<'FAKE'
+#!/usr/bin/env bash
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+case "$1" in
+  agents)
+    echo '[{"sessionId":"forked-xyz","id":"j-office-hours-42","pid":1,"state":"idle","status":"idle","name":"office-hours-42","cwd":""}]'
+    ;;
+  attach)
+    echo "LAUNCH: attach $2"
+    ;;
+  *)
+    echo "$*" >> "$ROOT/bg-argv-log"
+    ;;
+esac
+exit 0
+FAKE
+chmod +x "$TMPDIR_TEST/bin/claude"
+export OFFICE_HOURS_CLAUDE_CMD="$TMPDIR_TEST/bin/claude"
+export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/bin/claude"   # verify_agent_registered_under queries this
+export LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S=0          # don't sleep between verify polls
+result=$("$TMPDIR_TEST/office-hours")
+bg=$(cat "$TMPDIR_TEST/bg-argv-log" 2>/dev/null || true)
+assert_eq "resume kick argv (single, no fork)" "--bg --name office-hours-42 --permission-mode auto --resume sess-abc continue" "$bg"
+assert_eq "resume attaches by name → j-office-hours-42 (not the verb sessionId)" "LAUNCH: attach j-office-hours-42" "$result"
+unset OFFICE_HOURS_CLAUDE_CMD CLAUDE_AGENTS_CMD LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S
+teardown
+
+# OH12. resume fork-retry (#2240): the primary --bg --resume kick fails (a dead
+# sessionId can collide in the registry), so the entry retries ONCE with
+# --fork-session, then attaches BY NAME (the forked id is reachable via the stable
+# office-hours-<N> name). The fake fails any --bg kick lacking --fork-session.
+echo "Test: resume primary kick fails → fork-session retry, then attach by name"
+setup
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+cat > "$TMPDIR_TEST/office-hours-select-target" <<EOF
+#!/usr/bin/env bash
+echo "resume 42 sess-abc $TMPDIR_TEST/wt/42-x"
+EOF
+chmod +x "$TMPDIR_TEST/office-hours-select-target"
+cat > "$TMPDIR_TEST/bin/claude" <<'FAKE'
+#!/usr/bin/env bash
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+case "$1" in
+  agents)
+    echo '[{"sessionId":"forked-xyz","id":"j-office-hours-42","pid":1,"state":"idle","status":"idle","name":"office-hours-42","cwd":""}]'
+    exit 0
+    ;;
+  attach)
+    echo "LAUNCH: attach $2"
+    exit 0
+    ;;
+  *)
+    echo "$*" >> "$ROOT/bg-argv-log"
+    # Fail the primary kick (no --fork-session); succeed the fork retry.
+    [[ "$*" == *"--fork-session"* ]] || exit 1
+    exit 0
+    ;;
+esac
+FAKE
+chmod +x "$TMPDIR_TEST/bin/claude"
+export OFFICE_HOURS_CLAUDE_CMD="$TMPDIR_TEST/bin/claude"
+export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/bin/claude"   # verify_agent_registered_under queries this
+export LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S=0          # don't sleep between verify polls
+result=$("$TMPDIR_TEST/office-hours")
+mapfile -t oh_resume_argv < "$TMPDIR_TEST/bg-argv-log"
+assert_eq "primary kick carries no --fork-session" "--bg --name office-hours-42 --permission-mode auto --resume sess-abc continue" "${oh_resume_argv[0]:-}"
+assert_eq "fork retry appends --fork-session before continue" "--bg --name office-hours-42 --permission-mode auto --resume sess-abc --fork-session continue" "${oh_resume_argv[1]:-}"
+assert_eq "after fork, attach by name → j-office-hours-42" "LAUNCH: attach j-office-hours-42" "$result"
+unset OFFICE_HOURS_CLAUDE_CMD CLAUDE_AGENTS_CMD LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S
+teardown
+
+# OH13. resume verify-fails-then-fork (#2240): the primary --bg --resume kick
+# returns 0 but NO session registers — the real async-reject mode for a
+# dead/colliding sessionId (claude --bg returns before registration; a rejected
+# id never registers). The verify gate must catch this (rc 0 is not enough) and
+# retry with --fork-session, after which the session registers and attach
+# resolves by name. The fake registers office-hours-42 ONLY after a --fork-session
+# kick.
+echo "Test: resume primary kick returns 0 but never registers → verify fails → fork"
+setup
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+cat > "$TMPDIR_TEST/office-hours-select-target" <<EOF
+#!/usr/bin/env bash
+echo "resume 42 sess-abc $TMPDIR_TEST/wt/42-x"
+EOF
+chmod +x "$TMPDIR_TEST/office-hours-select-target"
+cat > "$TMPDIR_TEST/bin/claude" <<'FAKE'
+#!/usr/bin/env bash
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+case "$1" in
+  agents)
+    # Registered ONLY after a --fork-session kick created the marker.
+    if [[ -f "$ROOT/forked" ]]; then
+      echo '[{"sessionId":"forked-xyz","id":"j-office-hours-42","pid":1,"state":"idle","status":"idle","name":"office-hours-42","cwd":""}]'
+    else
+      echo '[]'
+    fi
+    exit 0
+    ;;
+  attach)
+    echo "LAUNCH: attach $2"
+    exit 0
+    ;;
+  *)
+    echo "$*" >> "$ROOT/bg-argv-log"
+    # Primary kick returns 0 but does NOT register; the fork kick registers.
+    [[ "$*" == *"--fork-session"* ]] && touch "$ROOT/forked"
+    exit 0
+    ;;
+esac
+FAKE
+chmod +x "$TMPDIR_TEST/bin/claude"
+export OFFICE_HOURS_CLAUDE_CMD="$TMPDIR_TEST/bin/claude"
+export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/bin/claude"
+export LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S=0
+result=$("$TMPDIR_TEST/office-hours")
+mapfile -t oh_resume_argv < "$TMPDIR_TEST/bg-argv-log"
+assert_eq "primary kick (rc 0, unregistered) carries no --fork-session" "--bg --name office-hours-42 --permission-mode auto --resume sess-abc continue" "${oh_resume_argv[0]:-}"
+assert_eq "verify-fail triggers fork retry (rc 0 alone is not enough)" "--bg --name office-hours-42 --permission-mode auto --resume sess-abc --fork-session continue" "${oh_resume_argv[1]:-}"
+assert_eq "after fork registers, attach by name → j-office-hours-42" "LAUNCH: attach j-office-hours-42" "$result"
+unset OFFICE_HOURS_CLAUDE_CMD CLAUDE_AGENTS_CMD LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S
+teardown
+
 # ============================================================================
 # dispatch-trace-leaf tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -6026,19 +6026,51 @@ result=$("$TMPDIR_TEST/office-hours-select-target")
 assert_eq "done session is attachable (visible only under --all)" "idle s-42-x" "$result"
 teardown
 
-# OHST3g. Stopped-exclude: the only labeled item (42) has a `stopped` session →
-# EXCLUDED from attach (skip, like working) and not fresh-launched. With no other
-# item and no parked `dispatch-*` router under main → `empty`.
-echo "Test: lone stopped item → excluded from attach, not fresh → empty"
+# OHST3g. Stopped-attach (#2240 behavior change BY DESIGN): the only labeled item
+# (42) has a `stopped` session → ATTACH. stopped is now attachable so a human
+# resuming the queue re-engages the originating session in place rather than
+# wedging. Uses the OHST3f (done-attach) shape: on-disk cwd, no
+# DISPATCH_OFFICE_HOURS_MAIN_WORKTREE export (exits before parked-router fallback).
+echo "Test: lone stopped item → attached (stopped is now attachable, #2240)"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+office_hours_state_fake_claude "42-x:stopped:$TMPDIR_TEST/wt/42-x"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "lone stopped item → attached" "idle s-42-x" "$result"
+teardown
+
+# OHST3g2. Paused-attach (#2240): the only labeled item (42) has a `paused`
+# session → ATTACH. Mirrors OHST3g (stopped-attach) for the paused state.
+echo "Test: lone paused item → attached (paused is now attachable, #2240)"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
+  > "$STUB_DIR/worktree-list.txt"
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+office_hours_state_fake_claude "42-x:paused:$TMPDIR_TEST/wt/42-x"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "lone paused item → attached" "idle s-42-x" "$result"
+teardown
+
+# OHST3g3. Unrecognized-state-exclude (#2240 fail-safe): the only labeled item
+# (42) has a session in state `zombie` (unrecognized/malformed) → EXCLUDED from
+# attach (fail-safe skip, criterion 3: never attach into an unknown state) and
+# not fresh-launched. With no other item and no parked router under main → `empty`.
+echo "Test: lone unrecognized-state (zombie) item → excluded from attach, not fresh → empty"
 setup
 printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/42-x\nHEAD def456\nbranch refs/heads/42-x\n\n' \
   > "$STUB_DIR/worktree-list.txt"
 export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
-office_hours_state_fake_claude "42-x:stopped"
+office_hours_state_fake_claude "42-x:zombie"
 result=$("$TMPDIR_TEST/office-hours-select-target")
-assert_eq "lone stopped item → empty" "empty" "$result"
+assert_eq "lone unrecognized-state item → empty (fail-safe skip)" "empty" "$result"
 unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 
@@ -11249,6 +11281,31 @@ mkdir -p "$wt"
 write_fake_claude '[{"sessionId":"oh-1","pid":99,"status":"busy","name":"office-hours-1311"}]' 0
 if worktree_has_live_session "$wt"; then live=occupied; else live=free; fi
 assert_eq "office-hours occupancy: worktree_has_live_session reports occupied" "occupied" "$live"
+ca_teardown
+
+# --- Test 8c: stopped session still occupies its worktree (#2240 byte-identical router) ---
+#
+# The selector now attaches stopped/paused sessions (#2240), but the shared
+# worktree_has_live_session helper is deliberately NOT changed — it must still
+# report a stopped session as OCCUPIED so the dispatch router hot path is
+# byte-identical. This test proves that invariant.
+
+echo "Test: stopped session still marks worktree occupied (byte-identical router, #2240)"
+ca_setup
+ca_basename=$(basename "$CA_DIR")
+write_fake_claude "[{\"sessionId\":\"s-stop\",\"pid\":5,\"status\":\"stopped\",\"name\":\"$ca_basename\"}]" 0
+if worktree_has_live_session "$CA_DIR"; then live=occupied; else live=free; fi
+assert_eq "stopped occupancy: worktree_has_live_session reports occupied" "occupied" "$live"
+ca_teardown
+
+# --- Test 8d: paused session still occupies its worktree (#2240 byte-identical router) ---
+
+echo "Test: paused session still marks worktree occupied (byte-identical router, #2240)"
+ca_setup
+ca_basename=$(basename "$CA_DIR")
+write_fake_claude "[{\"sessionId\":\"s-pause\",\"pid\":6,\"status\":\"paused\",\"name\":\"$ca_basename\"}]" 0
+if worktree_has_live_session "$CA_DIR"; then live=occupied; else live=free; fi
+assert_eq "paused occupancy: worktree_has_live_session reports occupied" "occupied" "$live"
 ca_teardown
 
 # --- Test 9: claude_sessions_under invokes `claude` with --cwd <path> -------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -38158,6 +38158,108 @@ else
 fi
 
 # ============================================================================
+# dispatch-recover-session-id (#2240)
+# ============================================================================
+#
+# Pure-filesystem reader: globs *.dispatch-stamp.json under
+# DISPATCH_STAMP_PROJECTS_ROOT, filters by .issue, sorts newest-first by
+# .stamped_at, and returns the first candidate whose .jsonl transcript exists.
+#
+# Each case runs in its own subshell over a mktemp -d fake projects root so
+# nothing leaks across tests and teardown() is untouched.
+
+echo ""
+echo "=== dispatch-recover-session-id ==="
+
+RECOVER="$SCRIPT_DIR/dispatch-recover-session-id"
+
+# T1. recoverable: sidecar (.issue==N) + its .jsonl present → emits sid<TAB>branch, rc 0.
+(
+  root=$(mktemp -d)
+  export DISPATCH_STAMP_PROJECTS_ROOT="$root"
+  proj="$root/some-project-slug"
+  mkdir -p "$proj"
+  sid="abc-session-1"
+  printf '%s\n' \
+    '{"schema":1,"session_id":"abc-session-1","repo":"natb1/commons.systems","issue":42,"pr":null,"branch":"42-feature","base_sha":"deadbeef","stamped_at":"2026-06-01T10:00:00Z"}' \
+    > "$proj/${sid}.dispatch-stamp.json"
+  touch "$proj/${sid}.jsonl"
+  rc=0
+  out=$("$RECOVER" --issue 42 2>/dev/null) || rc=$?
+  assert_eq "recover: recoverable → rc 0" "0" "$rc"
+  assert_eq "recover: recoverable → sid<TAB>branch" "abc-session-1	42-feature" "$out"
+  rm -rf "$root"
+) || true
+
+# T2. newest-purged, older-survives: two sidecars for issue N; newest .jsonl absent,
+#     older .jsonl present → emits the OLDER recoverable session (proves
+#     newest-EXISTING, not latest-then-verify).
+(
+  root=$(mktemp -d)
+  export DISPATCH_STAMP_PROJECTS_ROOT="$root"
+  proj="$root/some-project-slug"
+  mkdir -p "$proj"
+  # newer sidecar — stamped_at later, but no .jsonl
+  sid_new="newer-session"
+  printf '%s\n' \
+    '{"schema":1,"session_id":"newer-session","repo":"natb1/commons.systems","issue":99,"pr":null,"branch":"99-newer","base_sha":"aaa","stamped_at":"2026-06-02T12:00:00Z"}' \
+    > "$proj/${sid_new}.dispatch-stamp.json"
+  # Set mtime one second later too so secondary sort agrees with stamped_at.
+  touch -d "2026-06-02 12:00:01" "$proj/${sid_new}.dispatch-stamp.json" 2>/dev/null || true
+  # NO .jsonl for newer session
+
+  # older sidecar — stamped_at earlier, .jsonl present
+  sid_old="older-session"
+  printf '%s\n' \
+    '{"schema":1,"session_id":"older-session","repo":"natb1/commons.systems","issue":99,"pr":null,"branch":"99-older","base_sha":"bbb","stamped_at":"2026-06-01T08:00:00Z"}' \
+    > "$proj/${sid_old}.dispatch-stamp.json"
+  touch -d "2026-06-01 08:00:00" "$proj/${sid_old}.dispatch-stamp.json" 2>/dev/null || true
+  touch "$proj/${sid_old}.jsonl"
+
+  rc=0
+  out=$("$RECOVER" --issue 99 2>/dev/null) || rc=$?
+  assert_eq "recover: newest-purged, older-survives → rc 0" "0" "$rc"
+  assert_eq "recover: newest-purged, older-survives → emits older session" "older-session	99-older" "$out"
+  rm -rf "$root"
+) || true
+
+# T3. no-transcript: sidecar present but .jsonl absent → rc 1, no stdout.
+(
+  root=$(mktemp -d)
+  export DISPATCH_STAMP_PROJECTS_ROOT="$root"
+  proj="$root/some-project-slug"
+  mkdir -p "$proj"
+  sid="no-transcript-session"
+  printf '%s\n' \
+    '{"schema":1,"session_id":"no-transcript-session","repo":"natb1/commons.systems","issue":7,"pr":null,"branch":"7-thing","base_sha":"ccc","stamped_at":"2026-05-01T00:00:00Z"}' \
+    > "$proj/${sid}.dispatch-stamp.json"
+  # Deliberately do NOT touch .jsonl
+  rc=0
+  out=$("$RECOVER" --issue 7 2>/dev/null) || rc=$?
+  assert_eq "recover: no-transcript → rc 1" "1" "$rc"
+  assert_eq "recover: no-transcript → no stdout" "" "$out"
+  rm -rf "$root"
+) || true
+
+# T4. wrong-issue: only a DIFFERENT issue's sidecar present → rc 1 (no misattribution).
+(
+  root=$(mktemp -d)
+  export DISPATCH_STAMP_PROJECTS_ROOT="$root"
+  proj="$root/some-project-slug"
+  mkdir -p "$proj"
+  sid="wrong-issue-session"
+  printf '%s\n' \
+    '{"schema":1,"session_id":"wrong-issue-session","repo":"natb1/commons.systems","issue":100,"pr":null,"branch":"100-other","base_sha":"ddd","stamped_at":"2026-05-15T00:00:00Z"}' \
+    > "$proj/${sid}.dispatch-stamp.json"
+  touch "$proj/${sid}.jsonl"
+  rc=0
+  out=$("$RECOVER" --issue 5 2>/dev/null) || rc=$?
+  assert_eq "recover: wrong-issue → rc 1" "1" "$rc"
+  assert_eq "recover: wrong-issue → no stdout" "" "$out"
+  rm -rf "$root"
+) || true
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -60,6 +60,12 @@ setup() {
   cp "$SCRIPT_DIR/dispatch-close-resolved" "$TMPDIR_TEST/dispatch-close-resolved"
   cp "$SCRIPT_DIR/dispatch-select-target" "$TMPDIR_TEST/dispatch-select-target"
   cp "$SCRIPT_DIR/office-hours-select-target" "$TMPDIR_TEST/office-hours-select-target"
+  # office-hours-select-target's resume pass (#2240) resolves
+  # dispatch-recover-session-id via its SCRIPT_DIR (= TMPDIR_TEST for this copy),
+  # so the reader must sit alongside it. Pure-filesystem; selector resume tests set
+  # DISPATCH_STAMP_PROJECTS_ROOT to a temp projects root carrying stamp sidecars.
+  cp "$SCRIPT_DIR/dispatch-recover-session-id" "$TMPDIR_TEST/dispatch-recover-session-id"
+  chmod +x "$TMPDIR_TEST/dispatch-recover-session-id"
   cp "$SCRIPT_DIR/office-hours" "$TMPDIR_TEST/office-hours"
   # office-hours' idle-provision arm resolves dispatch-provision-from-remote via
   # its SCRIPT_DIR (= TMPDIR_TEST for this copy), so the helper must sit alongside
@@ -7035,6 +7041,98 @@ office_hours_state_fake_claude "42-x:waiting:/worktrees/42-x"
 result=$("$TMPDIR_TEST/office-hours-select-target")
 assert_eq "swept worktree, remote branch missing → fresh fallback with - 5th field" "office-hours 42 plan - -" "$result"
 unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
+teardown
+
+# OHST15a. Removed-but-recoverable, worktree on disk → `resume` (#2240). Issue 42's
+# originating session is ABSENT from the daemon registry (removed), but its <N>-*
+# worktree is still on disk and its stamp sidecar + <sessionId>.jsonl transcript
+# are recoverable. dispatch-recover-session-id resolves the resumable sessionId +
+# branch; the on-disk worktree → resume in place. resume beats the fresh path.
+echo "Test: removed session + on-disk worktree + recoverable transcript → resume"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree %s\nHEAD def456\nbranch refs/heads/42-x\n\n' \
+  "$TMPDIR_TEST/wt/42-x" > "$STUB_DIR/worktree-list.txt"
+# Empty daemon registry → 42's session is removed (sessionless).
+office_hours_state_fake_claude
+# Recoverable: stamp sidecar for issue 42 + its .jsonl transcript present.
+export DISPATCH_STAMP_PROJECTS_ROOT="$TMPDIR_TEST/projects"
+mkdir -p "$DISPATCH_STAMP_PROJECTS_ROOT/proj-42"
+printf '%s\n' '{"schema":1,"session_id":"rec-sess-42","repo":"natb1/commons.systems","issue":42,"pr":null,"branch":"42-x","base_sha":"deadbeef","stamped_at":"2026-06-01T10:00:00Z"}' \
+  > "$DISPATCH_STAMP_PROJECTS_ROOT/proj-42/rec-sess-42.dispatch-stamp.json"
+touch "$DISPATCH_STAMP_PROJECTS_ROOT/proj-42/rec-sess-42.jsonl"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "removed + on-disk worktree + transcript → resume in place" "resume 42 rec-sess-42 $TMPDIR_TEST/wt/42-x" "$result"
+unset DISPATCH_STAMP_PROJECTS_ROOT
+teardown
+
+# OHST15b. Removed-but-NOT-recoverable (transcript purged) → fresh (#2240). Same
+# removed session, but the <sessionId>.jsonl is absent, so dispatch-recover-session-id
+# exits 1 (nothing recoverable) and the selector falls through to the fresh path.
+echo "Test: removed session + transcript purged → fresh-launch fallback"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+# No <N>-* worktree registered (only main) → swept/sessionless.
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' > "$STUB_DIR/worktree-list.txt"
+office_hours_state_fake_claude
+# Sidecar present but transcript PURGED (.jsonl absent) → not recoverable.
+export DISPATCH_STAMP_PROJECTS_ROOT="$TMPDIR_TEST/projects"
+mkdir -p "$DISPATCH_STAMP_PROJECTS_ROOT/proj-42"
+printf '%s\n' '{"schema":1,"session_id":"rec-sess-42","repo":"natb1/commons.systems","issue":42,"pr":null,"branch":"42-x","base_sha":"deadbeef","stamped_at":"2026-06-01T10:00:00Z"}' \
+  > "$DISPATCH_STAMP_PROJECTS_ROOT/proj-42/rec-sess-42.dispatch-stamp.json"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "removed, transcript purged → fresh-launch fallback" "office-hours 42 plan - -" "$result"
+unset DISPATCH_STAMP_PROJECTS_ROOT
+teardown
+
+# OHST15c. Idle beats a removed-but-recoverable sibling (#2240 priority). 42 (older)
+# is removed-but-recoverable; 99 (newer) has a live idle session. A live idle
+# session is strictly safer than resurrecting a removed one, so idle wins and the
+# resume pass never runs.
+echo "Test: live idle item beats a removed-but-recoverable sibling (priority)"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"},{"number":99,"createdAt":"2024-02-01T00:00:00Z"}]\n' \
+  > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+mkdir -p "$TMPDIR_TEST/wt/42-x" "$TMPDIR_TEST/wt/99-y"
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree %s\nHEAD def456\nbranch refs/heads/42-x\n\nworktree %s\nHEAD aaa111\nbranch refs/heads/99-y\n\n' \
+  "$TMPDIR_TEST/wt/42-x" "$TMPDIR_TEST/wt/99-y" > "$STUB_DIR/worktree-list.txt"
+# Only 99 has a live (idle) session; 42 is removed.
+office_hours_state_fake_claude "99-y:idle:$TMPDIR_TEST/wt/99-y"
+# 42 IS recoverable (sidecar + transcript) — but idle 99 must still win.
+export DISPATCH_STAMP_PROJECTS_ROOT="$TMPDIR_TEST/projects"
+mkdir -p "$DISPATCH_STAMP_PROJECTS_ROOT/proj-42"
+printf '%s\n' '{"schema":1,"session_id":"rec-sess-42","repo":"natb1/commons.systems","issue":42,"pr":null,"branch":"42-x","base_sha":"deadbeef","stamped_at":"2026-06-01T10:00:00Z"}' \
+  > "$DISPATCH_STAMP_PROJECTS_ROOT/proj-42/rec-sess-42.dispatch-stamp.json"
+touch "$DISPATCH_STAMP_PROJECTS_ROOT/proj-42/rec-sess-42.jsonl"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "live idle sibling beats removed-recoverable item" "idle s-99-y" "$result"
+unset DISPATCH_STAMP_PROJECTS_ROOT
+teardown
+
+# OHST15d. Removed-but-recoverable, worktree SWEPT, origin/<branch> exists →
+# `resume-provision` (#2240). Symmetric with idle-provision: the consumer
+# re-provisions the worktree from the remote branch, then resumes the session.
+echo "Test: removed session, swept worktree, origin/<branch> exists → resume-provision"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+# 42 NOT registered (only main) → swept.
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' > "$STUB_DIR/worktree-list.txt"
+printf '%s\n' '42-x' > "$STUB_DIR/remote-branches.txt"   # origin/42-x exists
+office_hours_state_fake_claude                            # empty registry → removed
+export DISPATCH_OFFICE_HOURS_MAIN_WORKTREE="$TMPDIR_TEST/worktrees/main"
+export DISPATCH_STAMP_PROJECTS_ROOT="$TMPDIR_TEST/projects"
+mkdir -p "$DISPATCH_STAMP_PROJECTS_ROOT/proj-42"
+printf '%s\n' '{"schema":1,"session_id":"rec-sess-42","repo":"natb1/commons.systems","issue":42,"pr":null,"branch":"42-x","base_sha":"deadbeef","stamped_at":"2026-06-01T10:00:00Z"}' \
+  > "$DISPATCH_STAMP_PROJECTS_ROOT/proj-42/rec-sess-42.dispatch-stamp.json"
+touch "$DISPATCH_STAMP_PROJECTS_ROOT/proj-42/rec-sess-42.jsonl"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "removed swept + remote branch present → resume-provision" "resume-provision 42 rec-sess-42 42-x" "$result"
+unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE DISPATCH_STAMP_PROJECTS_ROOT
 teardown
 
 # OHST16. Not-local fresh-launch under a WORKING daemon (#2241 criterion-4,


### PR DESCRIPTION
Closes #2240

## Summary

Closes two gaps in the office-hours queue's session re-engagement, both surfaced
after the sibling #2241/#2276 work that added originating-session attach +
worktree provisioning for `done`/`idle`/`waiting`:

1. **`stopped`/`paused` sessions no longer wedge the queue.** They were funneled
   to skip — name-matching `worktree_has_live_session` (so never fresh-launched)
   yet excluded from attach — leaving the issue stuck until the session was
   manually reaped. They are now **attachable**: a human resuming the queue
   re-engages the originating session in place.

2. **A removed ("rm'd") originating session resumes instead of fresh-launching.**
   When the session is absent from `claude agents --json --all` but its on-disk
   transcript survives, the selector now emits a `resume`/`resume-provision`
   disposition and the entry script resumes from the transcript via
   `--bg --resume`, preserving accumulated context, rather than discarding it
   with a fresh launch.

A genuinely-`working` session is still never attached, resumed, or
launched-over (no double-claim); unrecognized/empty state keeps its
conservative fail-safe skip.

## What changed

- **Part 1 — `office-hours-select-target` (Unit 1):** widened the `_inspect`
  `case "$state"` attachable arm to `waiting|done|idle|stopped|paused`, split the
  gated `working|busy` and fail-safe `*)` arms so each skip's reason is explicit,
  and rewrote the docstrings (state→action table, the now-resolved wedge note,
  the rc-3 contract). No change to the main loop, the idle classifier, the entry
  script, or any lib helper.

- **Part 2 — `dispatch-recover-session-id` (Unit 2):** a new pure-filesystem
  reader. `--issue <N>` → `sessionId<TAB>branch` (rc 0), resolved from the
  session's stamp sidecar (`<sessionId>.dispatch-stamp.json`), filtered exactly to
  `.issue == N`, sorted newest-first, returning the first candidate whose
  `<sessionId>.jsonl` transcript **actually exists** (newest-existing, not
  latest-then-verify). rc 1 with no stdout is the legitimate "nothing
  recoverable" signal. No daemon calls — sandbox-safe and unit-testable.

- **Part 2 — selector resume disposition (Unit 3):** the selector captures the
  oldest-first sessionless issue set during its main loop and, **only when no
  attachable idle session was found** (live-idle > resume > fresh), walks it
  calling `dispatch-recover-session-id`. The first recoverable issue classifies
  symmetric with the idle classifier: worktree on disk → `resume <N> <sid> <cwd>`;
  worktree swept + `origin/<branch>` exists → `resume-provision <N> <sid>
  <branch>`; swept + no remote → existing fresh path.

- **Part 2 — entry-script resume arms (Unit 4):** `office-hours` gains `resume`
  and `resume-provision` arms. A new inline `resume_session` mirrors
  `dispatch-resume-worker`'s mechanism (it cannot call that script — its
  worker-only `^[0-9]+-` name gate rejects the `office-hours-<N>` name): a
  `--bg --resume` kick named `office-hours-<N>`, **gated on
  `verify_agent_registered_under`** (a clean kick rc alone is insufficient —
  `claude --bg` returns before the daemon registers, and a stale/colliding id is
  rejected asynchronously), with a `--fork-session` retry on failure. Because
  `--fork-session` mints a new sessionId, attach resolves **by name**
  (`office-hours-<N>`), never by the selector's now-stale sessionId.

## Router hot path is byte-identical by construction

The shared occupancy helpers `worktree_has_live_session` /
`claude_agents_list_all` match on the **name** column and never read `.state`.
This PR touches only `issue_live_session_id`'s `case` arm, a new pure-filesystem
reader, and the entry script — and never edits `lib-claude-agents.sh` — so
dispatch-router occupancy for done/stopped/paused/removed cannot change. A
`worktree_has_live_session` regression guard (asserting a `stopped`/`paused`
name-matching session still reports the worktree occupied) pins this.

## Verification

All logic lives in shell scripts exercised by the dispatch test suite, which CI
runs directly with fakes (no real `claude` daemon, no `gh`) — so it runs
sandboxed. The suite passes (**3779/3779**) and covers, per the units above:
stopped/paused → attach, paused → attach, unrecognized → fail-safe skip, working
still skips, router occupancy unchanged; the `dispatch-recover-session-id`
filesystem cases; selector removed-with-transcript → `resume`, removed-without →
fresh, idle-beats-resume priority, swept+remote → `resume-provision`; and the
entry-script resume argv, the verify-fails-then-fork path (the real async-reject
mode), and attach-by-name.

### Live-observation items (the fake suite cannot prove these)

The fake daemon emits a job id for every state and the resume tests only capture
argv shape, so a green suite proves selector logic and argv shape — not live
re-engagement. These remain QA / live items:

- Real `claude attach` re-engaging a genuinely **stopped/paused** session. Named
  contingency if it cannot: route stopped/paused through Part 2's `--bg --resume`
  mechanism (already present after this PR) — no selector re-architecture needed.
- A real **removed** session resuming from a real transcript via `--bg --resume`
  (and the `--fork-session` fallback engaging on a dead-id collision).
- The daemon's real **state vocabulary** emitting literally `stopped`/`paused`.
- `SessionStart:startup` firing for detached `--bg` `office-hours-<N>` sessions so
  the stamp sidecar is reliably written.
- The **`resume-provision` arm's landing-path resolution**
  (`resolve_project_root`/worktrees/`<branch>`) is verified only by live
  observation, not the suite — the green test count does not cover it.
