### PR TITLE
dispatch: migrate gh issue/pr view reads to REST helpers

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours
@@ -26,6 +26,10 @@
 # WITHOUT `set -e` so a guarded gh failure does not abort the script.
 set -uo pipefail
 
+# Source lib.sh for gh_issue_view_rest (the REST-backed issue read, #2257).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
 ISSUE_NUM="${1:-}"
 REASON="${2:-}"
 
@@ -51,14 +55,18 @@ fi
 # Idempotency gate: if the issue already carries the label, do nothing. A gh
 # read failure here is non-fatal — warn and bail out without parking, since we
 # cannot tell whether a comment was already posted.
-if labels_json=$(gh issue view "$ISSUE_NUM" --json labels 2>&1); then
+# Do NOT capture stderr into labels_json: gh_issue_view_rest retries via gh_retry
+# and signals failure through its return code; merging retry stderr into the value
+# would corrupt the JSON the jq below parses. The helper's own diagnostics already
+# reach stderr.
+if labels_json=$(gh_issue_view_rest "$ISSUE_NUM"); then
   if printf '%s' "$labels_json" \
       | jq -e --arg l "$LABEL" '.labels[]? | select(.name == $l)' >/dev/null 2>&1; then
     # Label already present — no-op, no duplicate comment.
     exit 0
   fi
 else
-  echo "dispatch-apply-office-hours: warning: could not read labels for issue #$ISSUE_NUM: $labels_json" >&2
+  echo "dispatch-apply-office-hours: warning: could not read labels for issue #$ISSUE_NUM" >&2
   exit 0
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-close-resolved
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-close-resolved
@@ -104,7 +104,7 @@ N=$(resolve_issue_number "${POSITIONALS[0]}")
 # State-aware gh close/skip
 # ---------------------------------------------------------------------------
 
-STATE=$(gh issue view "$N" --json state --jq .state)
+STATE=$(gh_issue_view_rest "$N" | jq -r '.state')
 
 if [ "$(printf '%s' "$STATE" | tr '[:upper:]' '[:lower:]')" = "closed" ]; then
   echo "dispatch-close-resolved: #$N already CLOSED; skipping re-close, writing sentinel only" >&2

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-context-pack
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-context-pack
@@ -163,13 +163,14 @@ build_pr_section() {
   fi
 
   local pr_json
-  pr_json=$(gh_retry gh pr view "$pr_num" --json number,labels,statusCheckRollup,body) || return 1
+  pr_json=$(gh_pr_view_rest "$pr_num") || return 1
 
-  local pr_number labels_str ci_verdict pr_body
+  local pr_number labels_str ci_verdict pr_body head_oid
   pr_number=$(jq -r '.number' <<<"$pr_json") || return 1
   labels_str=$(jq -r '[ .labels[].name ] | if length == 0 then "(none)" else join(", ") end' <<<"$pr_json") || return 1
-  ci_verdict=$(dispatch_classify_rollup "$(jq -c '.statusCheckRollup' <<<"$pr_json")") || return 1
   pr_body=$(jq -r '.body // ""' <<<"$pr_json") || return 1
+  head_oid=$(jq -r '.headRefOid' <<<"$pr_json") || return 1
+  ci_verdict=$(dispatch_ci_verdict_rest "$head_oid") || return 1
 
   printf 'PR #%s\n' "$pr_number"
   printf 'labels: %s\n' "$labels_str"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-context-pack
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-context-pack
@@ -91,7 +91,7 @@ fi
 build_issue_section() {
   local n="$1"
   local json
-  json=$(gh_retry gh issue view "$n" --json number,title,state,body,comments) || return 1
+  json=$(gh_issue_view_rest "$n" --comments) || return 1
   jq -r '
     "## Issue #\(.number) (\(.state)): \(.title)\n\n" +
     (.body // "") +

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-digest-window
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-digest-window
@@ -49,10 +49,9 @@ fi
 
 # ---- Step 1: fetch the digest issue's label and createdAt -------------------
 
-ISSUE_JSON=$(gh issue view "$NUM" --repo "$REPO" --json createdAt,labels)
+ISSUE_JSON=$(gh_issue_view_rest "$NUM" --repo "$REPO")
 
-JIT_LABEL=$(printf '%s' "$ISSUE_JSON" \
-  | jq -r '.labels[].name | select(startswith("jit:"))' \
+JIT_LABEL=$(jq -r '.labels[].name | select(startswith("jit:"))' <<<"$ISSUE_JSON" \
   | head -n1)
 
 if [[ -z "$JIT_LABEL" ]]; then
@@ -60,7 +59,7 @@ if [[ -z "$JIT_LABEL" ]]; then
   exit 1
 fi
 
-CREATED_AT=$(printf '%s' "$ISSUE_JSON" | jq -r '.createdAt')
+CREATED_AT=$(jq -r '.createdAt' <<<"$ISSUE_JSON")
 
 # ---- Step 2: find the newest prior closed issue with the same jit label -----
 # Exclude <num> itself: a digest issue may be closed mid-run, but it must never

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-drift-scan
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-drift-scan
@@ -64,9 +64,9 @@ fi
 
 # ---- Step A: fetch the issue (one gh call) ----------------------------------
 
-ISSUE_JSON=$(gh issue view "$N" --json createdAt,body)
-CREATED_AT=$(printf '%s' "$ISSUE_JSON" | jq -r '.createdAt')
-BODY=$(printf '%s' "$ISSUE_JSON" | jq -r '.body')
+ISSUE_JSON=$(gh_issue_view_rest "$N")
+CREATED_AT=$(jq -r '.createdAt' <<<"$ISSUE_JSON")
+BODY=$(jq -r '.body' <<<"$ISSUE_JSON")
 
 # ---- Step B: extract references from single-backtick spans ------------------
 # Pull every `...` run, strip the backticks, tokenize on whitespace, partition.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-epic-resolved-candidate
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-epic-resolved-candidate
@@ -28,8 +28,8 @@ fi
 # auth, etc.) makes the pipeline non-zero → exit 3 (hard error, distinct from
 # "not a candidate"). A genuinely-empty-labels success ({"labels":[]}) exits 0
 # with ISSUE_LABELS empty → falls through to the empty-intersection check → exit 1.
-ISSUE_LABELS=$(gh_retry gh issue view "$N" --json labels | jq -r '.labels[].name') || {
-  echo "dispatch-epic-resolved-candidate: gh issue view $N --json labels failed" >&2
+ISSUE_LABELS=$(gh_issue_view_rest "$N" | jq -r '.labels[].name') || {
+  echo "dispatch-epic-resolved-candidate: gh_issue_view_rest $N (labels) failed" >&2
   exit 3
 }
 
@@ -49,7 +49,7 @@ fi
 # failure from "not a candidate" (exit 1). Capture raw stream first so a
 # non-zero subscript exit is caught by the || branch before the jq pipeline
 # can mask it.
-kids_stream=$("$SCRIPT_DIR/issue-sub-issues" "$N" "number,state,stateReason") || {
+kids_stream=$("$SCRIPT_DIR/issue-sub-issues" "$N") || {
   echo "dispatch-epic-resolved-candidate: issue-sub-issues failed for $N" >&2
   exit 3
 }

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-finalize-phase
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-finalize-phase
@@ -28,6 +28,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Source lib.sh for gh_issue_view_rest (the REST-backed issue read, #2257).
+source "$SCRIPT_DIR/lib.sh"
 
 # --- Argument parsing ---
 N="${1:-}"
@@ -70,8 +72,8 @@ done
 # Best-effort: a gh flake must not abort before self-close.
 {
   local_lbl=""
-  gh issue view "$N" --json labels --jq \
-    '.labels[].name | select(test("^dispatch:rate-limit-retry-[0-9]+$"))' 2>/dev/null \
+  gh_issue_view_rest "$N" 2>/dev/null \
+    | jq -r '.labels[].name | select(test("^dispatch:rate-limit-retry-[0-9]+$"))' \
     | while IFS= read -r local_lbl; do
         [ -n "$local_lbl" ] && gh issue edit "$N" --remove-label "$local_lbl" >/dev/null 2>&1 \
           || echo "[dispatch-finalize-phase] WARNING: could not clear $local_lbl (non-fatal)" >&2

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-jit-skill
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-jit-skill
@@ -24,6 +24,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Source lib.sh for gh_issue_view_rest (the REST-backed issue read, #2257).
+source "$SCRIPT_DIR/lib.sh"
 
 # ---- Step 0: parse arguments ------------------------------------------------
 
@@ -54,7 +56,7 @@ fi
 
 # ---- Step 2: fetch the issue's labels and find the jit: label ---------------
 
-LABELS_JSON=$(gh issue view "$NUM" --repo "$REPO" --json labels)
+LABELS_JSON=$(gh_issue_view_rest "$NUM" --repo "$REPO")
 JIT_LABEL=$(printf '%s' "$LABELS_JSON" \
   | jq -r '.labels[].name | select(startswith("jit:"))' \
   | head -n1)

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn
@@ -242,7 +242,7 @@ write_identity_stub() {
   local worktree_path="$1" n="$2"
   local branch title
   branch="$(basename "$worktree_path")"
-  title="$(gh issue view "$n" --json title --jq .title)" || {
+  title="$(gh_issue_view_rest "$n" | jq -r '.title')" || {
     echo "write_identity_stub: gh issue view #$n failed; CLAUDE.local.md stub not written" >&2
     return 1
   }
@@ -349,10 +349,10 @@ process_one_target() {
       fi
     fi
 
-    # Closed-target guard. gh issue view returns OPEN/CLOSED (uppercase). A gh
-    # failure must not fail open (silently dispatching to a possibly-closed
+    # Closed-target guard. gh_issue_view_rest returns OPEN/CLOSED (uppercase). A
+    # gh failure must not fail open (silently dispatching to a possibly-closed
     # issue) — surface it as a hard error.
-    ISSUE_STATE=$(gh issue view "$n" --json state -q .state 2>/dev/null) || {
+    ISSUE_STATE=$( { gh_issue_view_rest "$n" | jq -r '.state'; } 2>/dev/null) || {
       echo "dispatch-materialize-spawn: failed to fetch state for issue #$n" >&2
       return 2
     }

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-phase
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-phase
@@ -78,8 +78,8 @@ if [[ -z "$PR" || "$PR" == "null" ]]; then
       exit 1
     fi
   fi
-  ISSUE_JSON=$(gh_retry gh issue view "$ISSUE_NUM" --json labels) || {
-    echo "dispatch-phase: gh issue view #$ISSUE_NUM (labels) failed; cannot derive phase" >&2
+  ISSUE_JSON=$(gh_issue_view_rest "$ISSUE_NUM") || {
+    echo "dispatch-phase: gh_issue_view_rest #$ISSUE_NUM (labels) failed; cannot derive phase" >&2
     exit 1
   }
   ISSUE_LABELS=$(jq -r '.labels[].name' <<<"$ISSUE_JSON") || {

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
@@ -88,7 +88,7 @@ source "$SCRIPT_DIR/lib-claude-agents.sh"
 # GitHub-sourced name before it reaches git fetch/rev-list/checkout.
 resolve_pr_head() {
   local pr="$1" pr_head
-  pr_head=$(gh pr view "$pr" --json headRefName | jq -r '.headRefName // empty')
+  pr_head=$(gh_pr_view_rest "$pr" | jq -r '.headRefName // empty')
   if [[ -z "$pr_head" || "$pr_head" == -* || "$pr_head" == *..* || ! "$pr_head" =~ ^[A-Za-z0-9._/-]+$ ]]; then
     echo "error: PR #$pr returned an unusable head branch name '$pr_head' for issue $ISSUE" >&2
     exit 1

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-resolve-worktree
@@ -172,7 +172,7 @@ if [[ -n "$pr" ]]; then
   exit 0
 fi
 
-if ! TITLE=$(gh issue view "$ISSUE" --json title | jq -er '.title'); then
+if ! TITLE=$(gh_issue_view_rest "$ISSUE" | jq -er '.title'); then
   echo "error: failed to fetch title for issue $ISSUE" >&2
   exit 1
 fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-route
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-route
@@ -91,8 +91,8 @@ fi
 # routed to a phase skill. Fetch state once, before provisioning. On a gh
 # failure, log and continue (do not strand the issue on a transient error) —
 # matches the gh-failure fallbacks already used below.
-ISSUE_STATE=$(gh_retry gh issue view "$N" --json state -q .state) || {
-  echo "dispatch-route: gh issue view $N --json state failed; continuing to route" >&2
+ISSUE_STATE=$(gh_issue_view_rest "$N" | jq -r '.state') || {
+  echo "dispatch-route: gh_issue_view_rest $N (state) failed; continuing to route" >&2
   ISSUE_STATE=""
 }
 if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
@@ -193,11 +193,11 @@ case "$PHASE" in
     PARSE_JOB=0
     if [[ -n "$CONFIGURED_LABELS" ]]; then
       ISSUE_LABELS=""
-      ISSUE_LABELS=$(gh issue view "$N" --json labels | jq -r '.labels[].name') || {
+      ISSUE_LABELS=$(gh_issue_view_rest "$N" | jq -r '.labels[].name') || {
         # gh failure (network error, auth issue, etc.) — fall back to the safe
         # default of INVOKE /plan-issue rather than exiting non-zero without a
         # directive, which would leave the stop hook with a misleading reason.
-        echo "dispatch-route: gh issue view $N --json labels failed; defaulting to INVOKE /plan-issue" >&2
+        echo "dispatch-route: gh_issue_view_rest $N (labels) failed; defaulting to INVOKE /plan-issue" >&2
         echo "INVOKE /plan-issue"
         exit 0
       }

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
@@ -248,8 +248,8 @@ while [[ $i -lt ${#WT_PATHS[@]} ]]; do
     if [[ -n "$wt_num" ]]; then
       issue_num="$wt_num"
       # Per-worktree issue fetch; a failure is isolated (defect 2, #1313).
-      if ! issue_state=$(gh_retry gh issue view "$issue_num" --json state -q .state); then
-        log "ERROR_ISSUE_STATE_FETCH: branch=$wt_branch issue=$issue_num gh issue view failed"
+      if ! issue_state=$(gh_issue_view_rest "$issue_num" | jq -r '.state'); then
+        log "ERROR_ISSUE_STATE_FETCH: branch=$wt_branch issue=$issue_num gh_issue_view_rest failed"
         continue
       fi
       case "$issue_state" in

--- a/.claude/skills/dispatch-propagate/scripts/issue-blocking
+++ b/.claude/skills/dispatch-propagate/scripts/issue-blocking
@@ -4,5 +4,5 @@ source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 ISSUE_NUM=$(resolve_issue_number "${1:-}")
 BLOCKERS=$(gh_api_array "/repos/{owner}/{repo}/issues/$ISSUE_NUM/dependencies/blocked_by" '.[].number')
 for dep in $BLOCKERS; do
-  gh_retry gh issue view "$dep" --json title,body,comments,number,state
+  gh_issue_view_rest "$dep" --comments
 done

--- a/.claude/skills/dispatch-propagate/scripts/issue-parent
+++ b/.claude/skills/dispatch-propagate/scripts/issue-parent
@@ -13,4 +13,4 @@ if [[ ! "$PARENT" =~ ^[0-9]+$ ]]; then
   echo "error: unexpected parent API response: $PARENT" >&2
   exit 1
 fi
-gh issue view "$PARENT" --json title,body,comments,number,state
+gh_issue_view_rest "$PARENT" --comments

--- a/.claude/skills/dispatch-propagate/scripts/issue-primary
+++ b/.claude/skills/dispatch-propagate/scripts/issue-primary
@@ -2,4 +2,4 @@
 set -euo pipefail
 source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 ISSUE_NUM=$(resolve_issue_number "${1:-}")
-gh issue view "$ISSUE_NUM" --json title,body,comments,number,state
+gh_issue_view_rest "$ISSUE_NUM" --comments

--- a/.claude/skills/dispatch-propagate/scripts/issue-siblings
+++ b/.claude/skills/dispatch-propagate/scripts/issue-siblings
@@ -18,7 +18,7 @@ while IFS=$'\t' read -r sib state; do
   if [[ -z "$sib" ]]; then continue; fi
   if [[ "$sib" = "$ISSUE_NUM" ]]; then continue; fi
   if [[ "$state" = "open" ]]; then
-    gh issue view "$sib" --json title,body,comments,number,state
+    gh_issue_view_rest "$sib" --comments
   else
     gh_issue_view_rest "$sib"
   fi

--- a/.claude/skills/dispatch-propagate/scripts/issue-siblings
+++ b/.claude/skills/dispatch-propagate/scripts/issue-siblings
@@ -20,6 +20,6 @@ while IFS=$'\t' read -r sib state; do
   if [[ "$state" = "open" ]]; then
     gh issue view "$sib" --json title,body,comments,number,state
   else
-    gh issue view "$sib" --json title,number,state
+    gh_issue_view_rest "$sib"
   fi
 done <<< "$SIBLINGS_TSV"

--- a/.claude/skills/dispatch-propagate/scripts/issue-sub-issues
+++ b/.claude/skills/dispatch-propagate/scripts/issue-sub-issues
@@ -2,10 +2,13 @@
 set -euo pipefail
 source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 ISSUE_NUM=$(resolve_issue_number "${1:-}")
-# Lean default covers both hot-path consumers; callers may pass a wider set if ever needed.
-FIELDS="${2:-number,state,stateReason}"
-[[ $# -lt 2 || -n "$2" ]] || { echo "issue-sub-issues: FIELDS arg must not be empty" >&2; exit 2; }
+# Emit one JSON object per sub-issue via the REST-backed helper (#2257). The
+# helper has a FIXED projection (number,title,body,state,stateReason,createdAt,
+# labels,assignees); both live consumers (dispatch-epic-resolved-candidate and
+# dispatch-trace-leaf) read only number/state/stateReason, all in that
+# projection. The former per-call FIELDS arg drove the GraphQL `gh issue view
+# --json <FIELDS>` projection, which no longer exists — so it is gone.
 SUBS=$(gh_api_array "/repos/{owner}/{repo}/issues/$ISSUE_NUM/sub_issues" '.[].number')
 for sub in $SUBS; do
-  gh_retry gh issue view "$sub" --json "$FIELDS"
+  gh_issue_view_rest "$sub"
 done

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -502,28 +502,47 @@ dispatch_ci_verdict_rest() {
 }
 
 # REST-backed drop-in for `gh issue view <N> --json
-# number,title,body,state,labels,assignees` (#2255). The dispatch fleet exhausts
-# GitHub's shared GraphQL rate-limit bucket while the REST bucket sits idle; the
-# `gh issue view` porcelain spends GraphQL, this helper spends REST.
+# number,title,body,state,stateReason,createdAt,labels,assignees` (#2255). The
+# dispatch fleet exhausts GitHub's shared GraphQL rate-limit bucket while the
+# REST bucket sits idle; the `gh issue view` porcelain spends GraphQL, this
+# helper spends REST.
 # Args: $1 = <N> (issue number, required); --repo owner/repo (optional, defaults
-#   to the current repo via the {owner}/{repo} placeholder).
+#   to the current repo via the {owner}/{repo} placeholder); --comments (optional
+#   boolean) opts into a SECOND REST call that fetches the issue's comments.
 # Output: one JSON object on stdout matching the porcelain shape — an EXPLICIT
 #   named projection (not a passthrough of the raw REST object) so the shape is
 #   pinned and tested:
-#     {number, title, body, state, labels:[{name}], assignees:[{login}]}
+#     {number, title, body, state, stateReason, createdAt,
+#      labels:[{name}], assignees:[{login}]}
+#   With --comments, also: comments:[{author:{login}, createdAt, body}].
 # Byte-compat bridges over the raw REST shape:
 #   - state: REST returns lowercase `open`/`closed`; the porcelain emits the
 #     UPPERCASE GraphQL enum `OPEN`/`CLOSED`. `ascii_upcase` bridges it (same as
 #     dispatch_ci_verdict_rest's enum bridge).
+#   - stateReason: REST's snake_case `state_reason` is lowercase
+#     (`completed`/`not_planned`/`reopened`/null); the porcelain emits the
+#     UPPERCASE GraphQL enum (`COMPLETED`/`NOT_PLANNED`/`REOPENED`/null).
+#     `ascii_upcase` bridges it; null is preserved exactly (no upcase of null).
+#   - createdAt: remapped from REST's snake_case `created_at` (ISO 8601 string,
+#     same value the porcelain `createdAt` carries).
 #   - labels / assignees: narrowed to the porcelain-visible keys (`name` /
 #     `login`) rather than passing the full REST objects through.
+# Comments (--comments): a SECOND REST call against the issue's comments endpoint
+#   (built with the SAME --repo logic as the main path). It uses the slurp idiom
+#   (`gh api --paginate ... | jq -s 'map(.[]) | ...'`) rather than gh_api_array:
+#   gh_api_array fetches WITHOUT --paginate (it would truncate at 30 comments),
+#   and --paginate can't be bolted onto it (--paginate emits one JSON doc per
+#   page, breaking gh_api_array's single-array `type=="array"` validator). Each
+#   comment is remapped to {author:{login}, createdAt, body}. Without the flag
+#   there is no second call and no `comments` key.
 # On gh failure: errors to stderr and returns 1 (clear-errors convention, no
 # fallback).
 gh_issue_view_rest() {
-  local num="" repo=""
+  local num="" repo="" want_comments=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --repo) repo="$2"; shift 2 ;;
+      --comments) want_comments=1; shift 1 ;;
       --*) echo "error: gh_issue_view_rest: unknown flag '$1'" >&2; return 1 ;;
       *)
         if [[ -z "$num" ]]; then
@@ -552,14 +571,45 @@ gh_issue_view_rest() {
     return 1
   }
 
-  printf '%s' "$raw" | jq '{
+  local projected
+  projected=$(printf '%s' "$raw" | jq '{
     number,
     title,
     body: (.body // ""),
     state: (.state | ascii_upcase),
+    stateReason: ((.state_reason // null) | (if . == null then null else ascii_upcase end)),
+    createdAt: .created_at,
     labels: ((.labels // []) | map({name})),
     assignees: ((.assignees // []) | map({login}))
-  }'
+  }') || return 1
+
+  if [[ "$want_comments" -eq 0 ]]; then
+    printf '%s\n' "$projected"
+    return 0
+  fi
+
+  # --comments: a second REST call against the issue's comments endpoint, built
+  # with the same --repo logic as the main path. Slurp the per-page arrays
+  # (--paginate emits one array doc per page), flatten, and remap to the
+  # porcelain comment shape. See dispatch_ci_verdict_rest / the header comment for
+  # why gh_api_array can't be used here.
+  local comments_path
+  if [[ -n "$repo" ]]; then
+    comments_path="repos/$repo/issues/$num/comments"
+  else
+    comments_path="repos/{owner}/{repo}/issues/$num/comments"
+  fi
+
+  local comments
+  comments=$(gh_retry gh api --paginate "$comments_path" \
+    | jq -s 'map(.[]) | map({author: {login: .user.login},
+                            createdAt: .created_at,
+                            body: (.body // "")})') || {
+    echo "error: gh_issue_view_rest: gh api failed for $comments_path" >&2
+    return 1
+  }
+
+  jq --argjson comments "$comments" '. + {comments: $comments}' <<<"$projected"
 }
 
 # REST-backed drop-in for `gh pr view <N> --json

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -613,11 +613,13 @@ gh_issue_view_rest() {
 }
 
 # REST-backed drop-in for `gh pr view <N> --json
-# number,title,body,state,mergeable,mergeStateStatus` (#2255). Spends the REST
-# rate-limit bucket instead of GraphQL, like gh_issue_view_rest.
+# number,title,body,state,mergeable,mergeStateStatus,headRefName,headRefOid,labels`
+# (#2255). Spends the REST rate-limit bucket instead of GraphQL, like
+# gh_issue_view_rest.
 # Args: $1 = <N> (PR number, required); --repo owner/repo (optional).
 # Output: one JSON object on stdout matching the porcelain shape — an EXPLICIT
-#   named projection: {number, title, body, state, mergeable, mergeStateStatus}.
+#   named projection: {number, title, body, state, mergeable, mergeStateStatus,
+#   headRefName, headRefOid, labels:[{name}]}.
 # Byte-compat bridges over the raw REST shape:
 #   - state: lowercase `open`/`closed` → UPPERCASE via `ascii_upcase`. (REST has
 #     no distinct MERGED state — a merged PR is state `closed` — so a consumer
@@ -630,6 +632,12 @@ gh_issue_view_rest() {
 #   - mergeStateStatus: remapped from REST's snake_case `mergeable_state` and
 #     `ascii_upcase`d to match the porcelain GraphQL enum casing (REST is
 #     lowercase `clean`/`dirty`/`blocked`).
+#   - headRefName: the PR's head branch name, remapped from REST's `head.ref`
+#     (same value the porcelain `headRefName` carries).
+#   - headRefOid: the PR's head commit oid, remapped from REST's `head.sha`
+#     (same value the porcelain `headRefOid` carries).
+#   - labels: narrowed to the porcelain-visible key (`name`) rather than passing
+#     the full REST label objects through (same as gh_issue_view_rest's labels).
 # On gh failure: errors to stderr and returns 1 (clear-errors convention, no
 # fallback).
 gh_pr_view_rest() {
@@ -675,7 +683,10 @@ gh_pr_view_rest() {
       elif .mergeable == false then "CONFLICTING"
       else "UNKNOWN" end
     ),
-    mergeStateStatus: ((.mergeable_state // "") | ascii_upcase)
+    mergeStateStatus: ((.mergeable_state // "") | ascii_upcase),
+    headRefName: .head.ref,
+    headRefOid: .head.sha,
+    labels: ((.labels // []) | map({name}))
   }'
 }
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -894,12 +894,11 @@ case "$args" in
     ;;
   issue\ view\ *\ --json\ *)
     # Generic catch-all for `gh issue view <num> --json <FIELDS>` calls from
-    # call sites that still use the GraphQL porcelain (NOT migrated to
-    # gh_issue_view_rest in #2257): dispatch-digest-window, dispatch-drift-scan,
-    # dispatch-context-pack, issue-primary/parent/blocking, and the issue-siblings
-    # OPEN branch (which needs comments). Logs the FIELDS token so tests can assert
-    # which fields were requested, then serves issue-<num>.json if present, else a
-    # minimal default carrying only number/state/stateReason.
+    # call sites that still use the GraphQL porcelain (GraphQL exemptions kept in
+    # #2257, e.g. dispatch-find-pr --json closedByPullRequestsReferences).
+    # Logs the FIELDS token so tests can assert which fields were requested,
+    # then serves issue-<num>.json if present, else a minimal default carrying
+    # only number/state/stateReason.
     num=$(printf '%s' "$args" | awk '{print $3}')
     fields="${args##* --json }"
     echo "$fields" >> "$STUB_DIR/gh-issue-view-fields.log"
@@ -31513,11 +31512,14 @@ digest_window_setup() {
 args="$*"
 TREE="$(cd "$(dirname "$0")/.." && pwd)"
 case "$args" in
-  issue\ view\ *\ --repo\ *\ --json\ createdAt,labels)
+  api\ repos/*/issues/[0-9]*)
+    # gh_issue_view_rest single-issue GET: gh api repos/<repo>/issues/<N>.
+    # MUST precede the api repos/*/issues* list arm (first-match-wins).
+    # Serves issue.json in raw REST shape (created_at, not createdAt).
     if [[ -f "$TREE/issue.json" ]]; then
       cat "$TREE/issue.json"
     else
-      echo '{"createdAt":"2026-01-01T00:00:00Z","labels":[{"name":"jit:digest"}]}'
+      echo '{"number":30,"title":"","body":"","state":"open","state_reason":null,"created_at":"2026-01-01T00:00:00Z","labels":[{"name":"jit:digest"}],"assignees":[]}'
     fi
     ;;
   api\ repos/*/issues*)
@@ -31552,7 +31554,7 @@ digest_window_teardown() {
 echo "Test: dispatch-digest-window prints the prior closed digest closedAt (steady state)"
 digest_window_setup
 cat > "$TMPDIR_TEST/issue.json" <<'EOF'
-{"createdAt":"2026-05-01T00:00:00Z","labels":[{"name":"jit:digest"}]}
+{"number":30,"title":"","body":"","state":"open","state_reason":null,"created_at":"2026-05-01T00:00:00Z","labels":[{"name":"jit:digest"}],"assignees":[]}
 EOF
 cat > "$TMPDIR_TEST/closed.json" <<'EOF'
 [{"number":10,"closedAt":"2026-05-20T00:00:00Z"},{"number":11,"closedAt":"2026-05-25T12:00:00Z"}]
@@ -31567,7 +31569,7 @@ digest_window_teardown
 echo "Test: dispatch-digest-window falls back to createdAt on cold start (no prior closed)"
 digest_window_setup
 cat > "$TMPDIR_TEST/issue.json" <<'EOF'
-{"createdAt":"2026-06-01T09:00:00Z","labels":[{"name":"jit:digest"}]}
+{"number":40,"title":"","body":"","state":"open","state_reason":null,"created_at":"2026-06-01T09:00:00Z","labels":[{"name":"jit:digest"}],"assignees":[]}
 EOF
 # No closed.json — the stub's default empty list applies.
 out=$("$TMPDIR_TEST/scripts/dispatch-digest-window" some-owner/some-repo 40); rc=$?
@@ -31580,7 +31582,7 @@ digest_window_teardown
 echo "Test: dispatch-digest-window excludes the issue's own closedAt"
 digest_window_setup
 cat > "$TMPDIR_TEST/issue.json" <<'EOF'
-{"createdAt":"2026-05-01T00:00:00Z","labels":[{"name":"jit:digest"}]}
+{"number":30,"title":"","body":"","state":"open","state_reason":null,"created_at":"2026-05-01T00:00:00Z","labels":[{"name":"jit:digest"}],"assignees":[]}
 EOF
 # Issue 30 is itself closed with a later closedAt than the real prior (20).
 # The script must ignore its own entry and anchor on the prior digest's closedAt.
@@ -31597,7 +31599,7 @@ digest_window_teardown
 echo "Test: dispatch-digest-window exits 1 when the issue carries no jit:* label"
 digest_window_setup
 cat > "$TMPDIR_TEST/issue.json" <<'EOF'
-{"createdAt":"2026-05-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"bug"}]}
+{"number":50,"title":"","body":"","state":"open","state_reason":null,"created_at":"2026-05-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"bug"}],"assignees":[]}
 EOF
 # Capture with the set -e-safe pattern: a bare `cmd; rc=$?` would abort the
 # suite when the command exits nonzero.
@@ -31677,11 +31679,13 @@ drift_scan_setup() {
 args="$*"
 TREE="$(cd "$(dirname "$0")/.." && pwd)"
 case "$args" in
-  issue\ view\ *\ --json\ createdAt,body)
+  api\ repos/*/issues/[0-9]*)
+    # gh_issue_view_rest single-issue GET: gh api repos/.../issues/<N>.
+    # Serves issue.json in raw REST shape (created_at, not createdAt).
     if [[ -f "$TREE/issue.json" ]]; then
       cat "$TREE/issue.json"
     else
-      echo '{"createdAt":"2026-01-01T00:00:00Z","body":"no refs"}'
+      echo '{"number":1080,"title":"","body":"no refs","state":"open","state_reason":null,"created_at":"2026-01-01T00:00:00Z","labels":[],"assignees":[]}'
     fi
     ;;
   api\ *repos/*/pulls\?state=closed*)
@@ -31741,7 +31745,7 @@ drift_scan_setup
 printf 'echo hi\n' > "$TMPDIR_TEST/tree/present.sh"
 printf 'presentName_token here\n' > "$TMPDIR_TEST/tree/lib.txt"
 cat > "$TMPDIR_TEST/issue.json" <<'EOF'
-{"createdAt":"2026-06-03T00:00:00Z","body":"Touches `present.sh` and `does/not/exist.ts`. Uses `presentName_token` and `absentName_token`."}
+{"number":1080,"title":"","body":"Touches `present.sh` and `does/not/exist.ts`. Uses `presentName_token` and `absentName_token`.","state":"open","state_reason":null,"created_at":"2026-06-03T00:00:00Z","labels":[],"assignees":[]}
 EOF
 cat > "$TMPDIR_TEST/prs.json" <<'EOF'
 [{"number":42,"title":"some pr","created_at":"2026-05-20T00:00:00Z","merged_at":"2026-06-04T00:00:00Z","updated_at":"2026-06-04T00:00:00Z"}]
@@ -31769,7 +31773,7 @@ echo "Test: dispatch-drift-scan trips the too-wide-window guard at the 100-PR li
 drift_scan_setup
 printf 'echo hi\n' > "$TMPDIR_TEST/tree/present.sh"
 cat > "$TMPDIR_TEST/issue.json" <<'EOF'
-{"createdAt":"2026-06-03T00:00:00Z","body":"Touches `present.sh`."}
+{"number":1080,"title":"","body":"Touches `present.sh`.","state":"open","state_reason":null,"created_at":"2026-06-03T00:00:00Z","labels":[],"assignees":[]}
 EOF
 # REST snake_case fixtures, all merged IN-WINDOW (merged_at >= the 2026-06-03
 # anchor) so the local merged_at filter keeps all 100 and the >=100 in-window
@@ -31803,7 +31807,7 @@ drift_scan_teardown
 echo "Test: dispatch-drift-scan skips the commit scan when no path refs are named"
 drift_scan_setup
 cat > "$TMPDIR_TEST/issue.json" <<'EOF'
-{"createdAt":"2026-06-03T00:00:00Z","body":"Uses `somename_ref` only."}
+{"number":1080,"title":"","body":"Uses `somename_ref` only.","state":"open","state_reason":null,"created_at":"2026-06-03T00:00:00Z","labels":[],"assignees":[]}
 EOF
 cd "$TMPDIR_TEST/tree"
 out=$("$TMPDIR_TEST/scripts/dispatch-drift-scan" 1080); rc=$?
@@ -31827,7 +31831,7 @@ printf 'echo hi\n' > "$TMPDIR_TEST/tree/present.sh"
 awk 'BEGIN { for (i = 0; i < 20000; i++) print "scalename_tok appears here" }' \
   > "$TMPDIR_TEST/tree/big.txt"
 cat > "$TMPDIR_TEST/issue.json" <<'EOF'
-{"createdAt":"2026-06-03T00:00:00Z","body":"Uses `scalename_tok` across `present.sh`."}
+{"number":1080,"title":"","body":"Uses `scalename_tok` across `present.sh`.","state":"open","state_reason":null,"created_at":"2026-06-03T00:00:00Z","labels":[],"assignees":[]}
 EOF
 cat > "$TMPDIR_TEST/prs.json" <<'EOF'
 []
@@ -31850,7 +31854,7 @@ echo "Test: dispatch-drift-scan does not classify slash-commands as path refs"
 drift_scan_setup
 printf 'echo hi\n' > "$TMPDIR_TEST/tree/present.sh"
 cat > "$TMPDIR_TEST/issue.json" <<'EOF'
-{"createdAt":"2026-06-03T00:00:00Z","body":"Run `/qa-fix` and `/file-issue` then `present.sh`."}
+{"number":1080,"title":"","body":"Run `/qa-fix` and `/file-issue` then `present.sh`.","state":"open","state_reason":null,"created_at":"2026-06-03T00:00:00Z","labels":[],"assignees":[]}
 EOF
 cat > "$TMPDIR_TEST/prs.json" <<'EOF'
 []
@@ -31874,7 +31878,7 @@ echo "Test: dispatch-drift-scan does not glob-expand backtick spans against the 
 drift_scan_setup
 printf 'echo hi\n' > "$TMPDIR_TEST/tree/globbed_unique_xyz.sh"
 cat > "$TMPDIR_TEST/issue.json" <<'EOF'
-{"createdAt":"2026-06-03T00:00:00Z","body":"Touches `*` widely."}
+{"number":1080,"title":"","body":"Touches `*` widely.","state":"open","state_reason":null,"created_at":"2026-06-03T00:00:00Z","labels":[],"assignees":[]}
 EOF
 cat > "$TMPDIR_TEST/prs.json" <<'EOF'
 []
@@ -31896,7 +31900,7 @@ echo "Test: dispatch-drift-scan rejects path-traversal reference tokens"
 drift_scan_setup
 printf 'echo hi\n' > "$TMPDIR_TEST/tree/present.sh"
 cat > "$TMPDIR_TEST/issue.json" <<'EOF'
-{"createdAt":"2026-06-03T00:00:00Z","body":"Touches `present.sh` and `../../../etc/passwd`."}
+{"number":1080,"title":"","body":"Touches `present.sh` and `../../../etc/passwd`.","state":"open","state_reason":null,"created_at":"2026-06-03T00:00:00Z","labels":[],"assignees":[]}
 EOF
 cat > "$TMPDIR_TEST/prs.json" <<'EOF'
 []
@@ -35414,27 +35418,14 @@ ctxpack_setup() {
   # $CTXPACK_STUB/; see the per-test setup for which fixtures are written.
   #
   # Failure injection: if $CTXPACK_STUB/fail-issue-view exists, the
-  # "issue view <N> --json number,title,state,body,comments" arm exits 1 with a
-  # non-transient diagnostic (avoids gh_retry retrying).  Similarly
-  # $CTXPACK_STUB/fail-merge-base causes the git merge-base arm to exit 1.
+  # "api repos/.../issues/<N>" arm exits 1 with a non-transient diagnostic
+  # (avoids gh_retry retrying).  Similarly $CTXPACK_STUB/fail-merge-base causes
+  # the git merge-base arm to exit 1.
   cat > "$CTXPACK_DIR/bin/gh" <<'GHSTUB'
 #!/usr/bin/env bash
 STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
 args="$*"
 case "$args" in
-  # --issue slice: dispatch-context-pack calls gh_retry gh issue view <N> --json number,title,state,body,comments
-  issue\ view\ *\ --json\ number,title,state,body,comments)
-    if [[ -f "$STUB_DIR/fail-issue-view" ]]; then
-      echo "error: simulated failure fetching issue" >&2
-      exit 1
-    fi
-    num=$(echo "$args" | awk '{print $3}')
-    if [[ -f "$STUB_DIR/issue-full-${num}.json" ]]; then
-      cat "$STUB_DIR/issue-full-${num}.json"
-    else
-      echo "{\"number\":$num,\"title\":\"Issue $num\",\"state\":\"OPEN\",\"body\":\"body text\",\"comments\":[]}"
-    fi
-    ;;
   # --pr slice cross-check: dispatch-find-pr calls gh issue view <N> --json closedByPullRequestsReferences
   issue\ view\ *\ --json\ closedByPullRequestsReferences)
     num=$(echo "$args" | awk '{print $3}')
@@ -35492,6 +35483,31 @@ case "$args" in
       # Default: no parent — 404 exit
       echo "Not Found (HTTP 404)" >&2
       exit 1
+    fi
+    ;;
+  # --issue slice comments: gh_issue_view_rest --comments second call.
+  # MUST precede the single-issue GET arm (first-match-wins).
+  api\ --paginate\ */issues/*/comments)
+    num=$(echo "$args" | grep -oE '[0-9]+' | tail -1)
+    if [[ -f "$STUB_DIR/issue-comments-${num}.json" ]]; then
+      cat "$STUB_DIR/issue-comments-${num}.json"
+    else
+      echo "[]"
+    fi
+    ;;
+  # --issue slice: gh_issue_view_rest base GET.
+  # Serves raw REST shape (lowercase state, created_at, etc.).
+  # MUST follow all subpath arms (/dependencies, /sub_issues, /parent, /comments).
+  api\ */issues/[0-9]*)
+    if [[ -f "$STUB_DIR/fail-issue-view" ]]; then
+      echo "error: simulated failure fetching issue" >&2
+      exit 1
+    fi
+    num=$(echo "$args" | grep -oE '[0-9]+' | tail -1)
+    if [[ -f "$STUB_DIR/issue-full-${num}.json" ]]; then
+      cat "$STUB_DIR/issue-full-${num}.json"
+    else
+      echo "{\"number\":$num,\"title\":\"Issue $num\",\"state\":\"open\",\"state_reason\":null,\"body\":\"body text\",\"created_at\":null,\"labels\":[],\"assignees\":[]}"
     fi
     ;;
   *)
@@ -35571,23 +35587,29 @@ ctxpack_teardown() {
 echo "Test: ctxpack --issue renders title, body, and comment thread"
 ctxpack_setup
 
-# Fixture: issue 5 with one seeded comment. The body and the comment author +
-# body must both appear in output — this proves the --json render path (plain
-# `gh issue view` without --json would suppress comments).
+# Fixture: issue 5 with one seeded comment. The raw REST base object is served
+# by the api */issues/[0-9]* arm; the comments are fetched separately via the
+# api --paginate */issues/*/comments arm.
 cat > "$CTXPACK_STUB/issue-full-5.json" <<'EOF'
 {
   "number": 5,
   "title": "My test issue",
-  "state": "OPEN",
+  "state": "open",
+  "state_reason": null,
   "body": "Issue body content here.",
-  "comments": [
-    {
-      "author": {"login": "alice"},
-      "createdAt": "2026-01-15T10:00:00Z",
-      "body": "SEEDED_COMMENT_BODY"
-    }
-  ]
+  "created_at": "2026-01-10T00:00:00Z",
+  "labels": [],
+  "assignees": []
 }
+EOF
+cat > "$CTXPACK_STUB/issue-comments-5.json" <<'EOF'
+[
+  {
+    "user": {"login": "alice"},
+    "created_at": "2026-01-15T10:00:00Z",
+    "body": "SEEDED_COMMENT_BODY"
+  }
+]
 EOF
 
 rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --issue 2>/dev/null) || rc=$?
@@ -35607,7 +35629,10 @@ else
   echo "    actual: $out"
 fi
 TOTAL=$((TOTAL+1))
-if [[ "$out" == *"### Comments"* && "$out" == *"**@alice**"* && "$out" == *"SEEDED_COMMENT_BODY"* ]]; then
+# Assert the full rendered comment line byte-identical: "**@alice** (date): body"
+# This verifies that the REST comments shape (user.login, created_at, body) maps
+# correctly through gh_issue_view_rest --comments into the jq render.
+if [[ "$out" == *"### Comments"* && "$out" == *"**@alice** (2026-01-15T10:00:00Z): SEEDED_COMMENT_BODY"* ]]; then
   PASS=$((PASS+1)); echo "  PASS: ctxpack --issue: contains comment thread"
 else
   FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --issue: contains comment thread"
@@ -35910,7 +35935,7 @@ ctxpack_setup
 
 # Provide minimal fixtures for all four slices.
 cat > "$CTXPACK_STUB/issue-full-5.json" <<'EOF'
-{"number":5,"title":"Combined test","state":"OPEN","body":"combo body","comments":[]}
+{"number":5,"title":"Combined test","state":"open","state_reason":null,"body":"combo body","created_at":null,"labels":[],"assignees":[]}
 EOF
 # No parent for relations (default → no-parent exit).
 touch "$CTXPACK_STUB/no-parent-5"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1573,6 +1573,8 @@ printf '%s\n' '{
   "state": "open",
   "mergeable": true,
   "mergeable_state": "clean",
+  "head": {"ref": "feature-branch", "sha": "abc123def456"},
+  "labels": [{"name": "enhancement", "color": "84b6eb"}, {"name": "dispatch:reviewed", "color": "000000"}],
   "extra_rest_field": "drop me"
 }' > "$STUB_DIR/view-pr-9001.json"
 pv=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_view_rest 9001)
@@ -1582,8 +1584,13 @@ assert_eq "pr: body" "the pr body" "$(jq -r '.body' <<<"$pv")"
 assert_eq "pr: state upcased OPEN" "OPEN" "$(jq -r '.state' <<<"$pv")"
 assert_eq "pr: mergeable boolean true → enum MERGEABLE" "MERGEABLE" "$(jq -r '.mergeable' <<<"$pv")"
 assert_eq "pr: mergeStateStatus key present + upcased" "CLEAN" "$(jq -r '.mergeStateStatus' <<<"$pv")"
+assert_eq "pr: headRefName passthrough from head.ref" "feature-branch" "$(jq -r '.headRefName' <<<"$pv")"
+assert_eq "pr: headRefOid passthrough from head.sha" "abc123def456" "$(jq -r '.headRefOid' <<<"$pv")"
+assert_eq "pr: labels narrowed to [{name}] (2 labels)" "2" "$(jq '.labels | length' <<<"$pv")"
+assert_eq "pr: first label name" "enhancement" "$(jq -r '.labels[0].name' <<<"$pv")"
+assert_eq "pr: label objects carry ONLY name (no color key)" "1" "$(jq '.labels[0] | keys | length' <<<"$pv")"
 assert_eq "pr: raw REST extra field dropped" "" "$(jq -r '.extra_rest_field // empty' <<<"$pv")"
-assert_eq "pr: top-level key set" "body mergeStateStatus mergeable number state title" \
+assert_eq "pr: top-level key set" "body headRefName headRefOid labels mergeStateStatus mergeable number state title" \
   "$(jq -r 'keys | join(" ")' <<<"$pv")"
 teardown
 
@@ -1595,12 +1602,16 @@ printf '%s\n' '{
   "body": "",
   "state": "closed",
   "mergeable": false,
-  "mergeable_state": "dirty"
+  "mergeable_state": "dirty",
+  "head": {"ref": "conflicting-branch", "sha": "deadbeef0001"},
+  "labels": [{"name": "bug", "color": "d73a4a"}]
 }' > "$STUB_DIR/view-pr-9002.json"
 pv2=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_view_rest 9002)
 assert_eq "pr: mergeable boolean false → CONFLICTING" "CONFLICTING" "$(jq -r '.mergeable' <<<"$pv2")"
 assert_eq "pr: mergeStateStatus dirty → DIRTY" "DIRTY" "$(jq -r '.mergeStateStatus' <<<"$pv2")"
 assert_eq "pr: closed → CLOSED" "CLOSED" "$(jq -r '.state' <<<"$pv2")"
+assert_eq "pr: headRefName from head.ref (9002)" "conflicting-branch" "$(jq -r '.headRefName' <<<"$pv2")"
+assert_eq "pr: single label narrowed" "bug" "$(jq -r '.labels[0].name' <<<"$pv2")"
 teardown
 
 echo "Test: gh_pr_view_rest -- mergeable=null → UNKNOWN; absent mergeable_state → empty"
@@ -1610,11 +1621,15 @@ printf '%s\n' '{
   "title": "computing pr",
   "body": "",
   "state": "open",
-  "mergeable": null
+  "mergeable": null,
+  "head": {"ref": "computing-branch", "sha": "cafef00d0003"}
 }' > "$STUB_DIR/view-pr-9003.json"
 pv3=$(source "$TMPDIR_TEST/lib.sh"; gh_pr_view_rest 9003)
 assert_eq "pr: mergeable null → UNKNOWN" "UNKNOWN" "$(jq -r '.mergeable' <<<"$pv3")"
 assert_eq "pr: absent mergeable_state → empty string" "" "$(jq -r '.mergeStateStatus' <<<"$pv3")"
+assert_eq "pr: headRefName from head.ref (9003)" "computing-branch" "$(jq -r '.headRefName' <<<"$pv3")"
+# Absent labels in raw REST → empty array (// [] path), not null.
+assert_eq "pr: absent labels → empty array" "0" "$(jq '.labels | length' <<<"$pv3")"
 teardown
 
 echo "Test: gh_pr_view_rest -- missing number returns non-zero with diagnostic stderr"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -356,15 +356,6 @@ case "$args" in
       echo "{\"title\":\"Issue $num\",\"body\":\"\",\"comments\":[],\"number\":$num,\"state\":\"OPEN\"}"
     fi
     ;;
-  issue\ view\ *\ --json\ title)
-    # dispatch-resolve-worktree create case: gh issue view <num> --json title
-    num=$(echo "$args" | awk '{print $3}')
-    if [[ -f "$STUB_DIR/issue-title-${num}.json" ]]; then
-      cat "$STUB_DIR/issue-title-${num}.json"
-    else
-      echo "{\"title\":\"Issue $num\"}"
-    fi
-    ;;
   issue\ view\ *\ --json\ closedByPullRequestsReferences)
     # dispatch-find-pr cross-check fallback: gh issue view <num> --json closedByPullRequestsReferences
     num=$(echo "$args" | awk '{print $3}')
@@ -602,20 +593,53 @@ case "$args" in
     echo '{}'
     ;;
   api\ repos/*/issues/*)
-    # dispatch-resolve-arg discriminator: gh api repos/{owner}/{repo}/issues/<N>.
-    # The REST issues endpoint returns PRs too; a PR's JSON carries a
-    # "pull_request" key. The fixture file decides issue-vs-PR; an arg-issue-<N>.err
-    # fixture models a non-404 gh failure; absence of either fixture models a 404
-    # (the number is neither an issue nor a PR).
+    # Generic single-issue GET: gh api repos/{owner}/{repo}/issues/<N>. Two
+    # consumers route here (case is first-wins; the 9xxx sentinel arm precedes it):
+    #   - dispatch-resolve-arg discriminator (issue-vs-PR; a PR's JSON carries a
+    #     "pull_request" key — the fixture decides).
+    #   - gh_issue_view_rest (#2257), after the Category-A read swaps off the
+    #     `gh issue view --json` porcelain. The helper consumes the RAW REST object
+    #     and projects/upcases internally, so arg-issue-<N>.json must be in RAW REST
+    #     shape (lowercase "state":"open", state_reason, created_at, labels:[{name}]).
+    # Failure injection (default-absent, so existing tests are unaffected):
+    #   - gh-fail-issue-labels-<N>: HARD (non-transient) failure, exit 1
+    #     UNCONDITIONALLY — gh_retry forwards it (does not retry).
+    #   - issue-view-fail-<N>: TRANSIENT (HTTP 503) failure with a decrementing
+    #     count — gh_retry retries until the count is exhausted, then serves the
+    #     fixture.
+    #   - arg-issue-<N>.err: a non-404 gh failure (used by dispatch-resolve-arg).
+    #   - absence of any fixture models a 404 (number is neither issue nor PR).
     num="${args##*/}"
-    if [[ -f "$STUB_DIR/arg-issue-${num}.json" ]]; then
+    if [[ -f "$STUB_DIR/gh-fail-issue-labels-${num}" ]]; then
+      echo "gh: API error on issues/${num}" >&2
+      exit 1
+    fi
+    if [[ -f "$STUB_DIR/issue-view-fail-${num}" ]]; then
+      remaining=$(cat "$STUB_DIR/issue-view-fail-${num}")
+      if [[ "$remaining" -gt 0 ]]; then
+        echo $((remaining - 1)) > "$STUB_DIR/issue-view-fail-${num}"
+        echo "HTTP 503: Service Unavailable" >&2
+        exit 1
+      fi
+    fi
+    if [[ -f "$STUB_DIR/arg-issue-${num}.notfound" ]]; then
+      # Positive 404 carve-out: dispatch-resolve-arg's existence probe asks "is
+      # this number an issue?" and must see a real 404 (it maps 404→exit 2,
+      # distinct from the arg-issue-<N>.err other-error→exit 1 path). Absent by
+      # default so the empty-labels default below serves the common case.
+      echo "gh: Not Found (HTTP 404)" >&2
+      exit 1
+    elif [[ -f "$STUB_DIR/arg-issue-${num}.json" ]]; then
       cat "$STUB_DIR/arg-issue-${num}.json"
     elif [[ -f "$STUB_DIR/arg-issue-${num}.err" ]]; then
       cat "$STUB_DIR/arg-issue-${num}.err" >&2
       exit 1
     else
-      echo "gh: Not Found (HTTP 404)" >&2
-      exit 1
+      # Default: an existing OPEN issue with no labels — the production-faithful
+      # state for a dispatch target whose specific labels a test does not assert
+      # (mirrors the retired `--json labels` arm's `{"labels":[]}` default).
+      # Raw REST shape; the helper projects/upcases it.
+      printf '{"number":%s,"title":"","body":"","state":"open","state_reason":null,"created_at":null,"labels":[],"assignees":[]}\n' "$num"
     fi
     ;;
   api\ repos/*/pulls/*)
@@ -652,37 +676,6 @@ case "$args" in
     # dispatch-complete-phase / dispatch-apply-office-hours create the label only
     # when the apply reported it missing.
     echo "$args" >> "$STUB_DIR/gh-label-create.log"
-    ;;
-  issue\ view\ *\ --json\ labels)
-    # dispatch-apply-office-hours idempotency read: gh issue view <num> --json labels.
-    # $STUB_DIR/issue-labels-<num>.json supplies the labels object; absence means
-    # the issue carries no labels.
-    num=$(echo "$args" | awk '{print $3}')
-    # #1594: a per-issue HARD-failure marker makes the stub emit a deterministic
-    # (non-transient) error and exit 1 UNCONDITIONALLY, so gh_retry does NOT
-    # retry — it forwards the real failure. Mirrors the gh-fail-sub_issues-<N> /
-    # gh-fail-blocked_by-<num> marker convention. Absent by default → every
-    # existing test is unaffected. Checked BEFORE the transient marker below.
-    if [[ -f "$STUB_DIR/gh-fail-issue-labels-${num}" ]]; then
-      echo "gh: API error on issues/${num} --json labels" >&2
-      exit 1
-    fi
-    # #1314: a per-issue fail-count sentinel makes the stub emit a transient
-    # (HTTP 503) error and decrement the count, so gh_retry retries. Absent by
-    # default → every existing test is unaffected; exhausted → serve labels.
-    if [[ -f "$STUB_DIR/issue-view-fail-${num}" ]]; then
-      remaining=$(cat "$STUB_DIR/issue-view-fail-${num}")
-      if [[ "$remaining" -gt 0 ]]; then
-        echo $((remaining - 1)) > "$STUB_DIR/issue-view-fail-${num}"
-        echo "HTTP 503: Service Unavailable" >&2
-        exit 1
-      fi
-    fi
-    if [[ -f "$STUB_DIR/issue-labels-${num}.json" ]]; then
-      cat "$STUB_DIR/issue-labels-${num}.json"
-    else
-      echo '{"labels":[]}'
-    fi
     ;;
   issue\ edit\ *)
     # Multiple scripts (dispatch-apply-office-hours, dispatch-qa-apply-main-qa-labels, ...)
@@ -856,39 +849,18 @@ case "$args" in
       echo '{"items":[],"totalCount":0}'
     fi
     ;;
-  issue\ view\ *\ --json\ state\ --jq\ .state)
-    # dispatch-close-resolved state read (#1456): gh issue view <num> --json state --jq .state.
-    # The real --jq flag projects .state to a bare string; the fixture file
-    # holds {"state":"..."}, so project it here. Absent fixture → OPEN.
-    num=$(printf '%s' "$args" | awk '{print $3}')
-    if [[ -f "$STUB_DIR/issue-state-${num}.json" ]]; then
-      jq -r .state "$STUB_DIR/issue-state-${num}.json"
-    else
-      echo "OPEN"
-    fi
-    ;;
   issue\ close\ *)
     # dispatch-close-resolved (#1456): gh issue close <num> --reason completed --comment ...
     echo "$args" >> "$STUB_DIR/gh-issue-close.log"
     ;;
-  issue\ view\ *\ --json\ state\ -q\ .state)
-    # Closed-issue router guard (#1845): gh issue view <num> --json state -q .state.
-    # The -q flag projects .state to a bare string; the fixture file holds
-    # {"state":"..."}, so project it here. Absent fixture → OPEN (every existing
-    # route test makes this call and must keep routing normally).
-    num=$(printf '%s' "$args" | awk '{print $3}')
-    if [[ -f "$STUB_DIR/issue-state-${num}.json" ]]; then
-      jq -r .state "$STUB_DIR/issue-state-${num}.json"
-    else
-      echo "OPEN"
-    fi
-    ;;
   issue\ view\ *\ --json\ *)
-    # Generic catch-all for `gh issue view <num> --json <FIELDS>` calls that do
-    # not match the specific arms above (e.g. issue-sub-issues default/explicit
-    # field sets). Logs the FIELDS token so tests can assert which fields were
-    # requested, then serves issue-<num>.json if present, else a minimal default
-    # carrying only number/state/stateReason (the hot-path lean set, #1593).
+    # Generic catch-all for `gh issue view <num> --json <FIELDS>` calls from
+    # call sites that still use the GraphQL porcelain (NOT migrated to
+    # gh_issue_view_rest in #2257): dispatch-digest-window, dispatch-drift-scan,
+    # dispatch-context-pack, issue-primary/parent/blocking, and the issue-siblings
+    # OPEN branch (which needs comments). Logs the FIELDS token so tests can assert
+    # which fields were requested, then serves issue-<num>.json if present, else a
+    # minimal default carrying only number/state/stateReason.
     num=$(printf '%s' "$args" | awk '{print $3}')
     fields="${args##* --json }"
     echo "$fields" >> "$STUB_DIR/gh-issue-view-fields.log"
@@ -2080,11 +2052,12 @@ teardown
 echo "=== dispatch-phase ==="
 
 # 1. No PR, no dispatch:planned label → plan (the issue has not been planned yet).
-# dispatch-phase fetches the issue's labels (gh issue view <num> --json labels);
-# absence of issue-labels-42.json means the issue carries no labels.
+# dispatch-phase fetches the issue via gh_issue_view_rest; an empty-labels issue
+# object (arg-issue-42.json) means the issue carries no labels.
 echo "Test: no PR, unplanned → plan"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
+printf '{"state":"open","labels":[]}\n' > "$STUB_DIR/arg-issue-42.json"
 result=$("$TMPDIR_TEST/dispatch-phase" "42")
 assert_eq "no PR, unplanned → plan" "plan" "$result"
 teardown
@@ -2093,7 +2066,7 @@ teardown
 echo "Test: no PR + dispatch:planned → implement"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
-printf '{"labels":[{"name":"dispatch:planned"}]}\n' > "$STUB_DIR/issue-labels-42.json"
+printf '{"state":"open","labels":[{"name":"dispatch:planned"}]}\n' > "$STUB_DIR/arg-issue-42.json"
 result=$("$TMPDIR_TEST/dispatch-phase" "42")
 assert_eq "no PR + dispatch:planned → implement" "implement" "$result"
 teardown
@@ -2102,7 +2075,7 @@ teardown
 echo "Test: no PR + non-planned label → plan"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
-printf '{"labels":[{"name":"help wanted"}]}\n' > "$STUB_DIR/issue-labels-42.json"
+printf '{"state":"open","labels":[{"name":"help wanted"}]}\n' > "$STUB_DIR/arg-issue-42.json"
 result=$("$TMPDIR_TEST/dispatch-phase" "42")
 assert_eq "no PR + non-planned label → plan" "plan" "$result"
 teardown
@@ -2129,7 +2102,7 @@ echo "Test: no PR + transient-then-succeed gh → retries, derives implement"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo 2 > "$STUB_DIR/issue-view-fail-42"
-printf '{"labels":[{"name":"dispatch:planned"}]}\n' > "$STUB_DIR/issue-labels-42.json"
+printf '{"state":"open","labels":[{"name":"dispatch:planned"}]}\n' > "$STUB_DIR/arg-issue-42.json"
 result=$("$TMPDIR_TEST/dispatch-phase" "42")
 assert_eq "transient-then-succeed → implement" "implement" "$result"
 teardown
@@ -2264,6 +2237,7 @@ echo "Test: issue 6 does not match branch 60-foo"
 setup
 printf '[%s]\n' "$(make_pr 10 "60-foo" "true" "$NO_LABELS" "$GREEN_ROLLUP")" \
   > "$STUB_DIR/pr-list-full.json"
+printf '{"state":"open","labels":[]}\n' > "$STUB_DIR/arg-issue-6.json"
 result=$("$TMPDIR_TEST/dispatch-phase" "6")
 assert_eq "issue 6 does not match branch 60-foo → plan" "plan" "$result"
 teardown
@@ -2687,6 +2661,7 @@ echo "Test: no PR, unplanned → INVOKE /plan-issue"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
+echo '{"state":"open","labels":[]}' > "$STUB_DIR/arg-issue-42.json"
 route_run 42 /wt/42-my-feature
 assert_eq "no PR, unplanned → INVOKE /plan-issue (directive)" "INVOKE /plan-issue" "$ROUTE_OUT"
 assert_eq "no PR, unplanned → INVOKE /plan-issue (exit 0)" "0" "$ROUTE_RC"
@@ -2704,6 +2679,7 @@ echo "Test: provision stdout chatter does not leak into the directive"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
+echo '{"state":"open","labels":[]}' > "$STUB_DIR/arg-issue-42.json"
 cat > "$TMPDIR_TEST/dispatch-provision-worktree" <<'STUB'
 #!/usr/bin/env bash
 printf 'Updating 648157c..ea3a172\nFast-forward\n 2 files changed, 27 insertions(+)\n'
@@ -2723,7 +2699,7 @@ echo "Test: no PR + dispatch:planned → INVOKE /implement"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
-printf '{"labels":[{"name":"dispatch:planned"}]}\n' > "$STUB_DIR/issue-labels-42.json"
+printf '{"state":"open","labels":[{"name":"dispatch:planned"}]}\n' > "$STUB_DIR/arg-issue-42.json"
 route_run 42 /wt/42-my-feature
 assert_eq "no PR + dispatch:planned → INVOKE /implement (directive)" \
   "INVOKE /implement" "$ROUTE_OUT"
@@ -2740,7 +2716,7 @@ echo "Test: closed issue → STOP closed"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/43-closed-feature" > "$STUB_DIR/worktree-toplevel.txt"
-echo '{"state":"CLOSED"}' > "$STUB_DIR/issue-state-43.json"
+echo '{"state":"closed"}' > "$STUB_DIR/arg-issue-43.json"
 route_run 43 /wt/43-closed-feature
 assert_eq "closed issue → STOP closed (directive)" "STOP closed" "$ROUTE_OUT"
 assert_eq "closed issue → STOP closed (exit 0)" "0" "$ROUTE_RC"
@@ -3015,7 +2991,7 @@ echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
 printf '{"statements":[{"key":"acme","dir":"/s","repo":"o/r","label":"statements:acme","project":"p"}]}\n' \
   > "$DISPATCH_CONFIG_DIR/statements.json"
-printf '{"labels":[{"name":"statements:acme"}]}\n' > "$STUB_DIR/issue-labels-42.json"
+printf '{"state":"open","labels":[{"name":"statements:acme"}]}\n' > "$STUB_DIR/arg-issue-42.json"
 route_run 42 /wt/42-my-feature
 assert_eq "no PR + statements label → INVOKE /budget-parse-job (directive)" \
   "INVOKE /budget-parse-job" "$ROUTE_OUT"
@@ -3030,7 +3006,7 @@ echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
 printf '{"statements":[{"key":"acme","dir":"/s","repo":"o/r","label":"statements:acme","project":"p"}]}\n' \
   > "$DISPATCH_CONFIG_DIR/statements.json"
-printf '{"labels":[{"name":"help wanted"}]}\n' > "$STUB_DIR/issue-labels-42.json"
+printf '{"state":"open","labels":[{"name":"help wanted"}]}\n' > "$STUB_DIR/arg-issue-42.json"
 route_run 42 /wt/42-my-feature
 assert_eq "no PR + non-statements label → INVOKE /plan-issue (directive)" \
   "INVOKE /plan-issue" "$ROUTE_OUT"
@@ -3044,6 +3020,7 @@ echo "Test: no PR + no statements config → INVOKE /plan-issue"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
+echo '{"state":"open","labels":[]}' > "$STUB_DIR/arg-issue-42.json"
 route_run 42 /wt/42-my-feature
 assert_eq "no PR + no statements config → INVOKE /plan-issue (directive)" \
   "INVOKE /plan-issue" "$ROUTE_OUT"
@@ -3063,7 +3040,7 @@ setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/55-epic" > "$STUB_DIR/worktree-toplevel.txt"
 printf '{"labels":["epic"]}\n' > "$DISPATCH_CONFIG_DIR/epic.json"
-printf '{"labels":[{"name":"epic"}]}\n' > "$STUB_DIR/issue-labels-55.json"
+printf '{"state":"open","labels":[{"name":"epic"}]}\n' > "$STUB_DIR/arg-issue-55.json"
 printf '[{"number":561},{"number":562}]\n' > "$STUB_DIR/subissues-55.json"
 printf '{"title":"c","body":"","comments":[],"number":561,"state":"CLOSED","stateReason":"COMPLETED"}\n' \
   > "$STUB_DIR/issue-561.json"
@@ -3083,6 +3060,7 @@ echo "Test: no PR + not a spent epic → INVOKE /plan-issue"
 setup
 echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/56-foo" > "$STUB_DIR/worktree-toplevel.txt"
+echo '{"state":"open","labels":[]}' > "$STUB_DIR/arg-issue-56.json"
 route_run 56 /wt/56-foo
 assert_eq "no PR + not a spent epic → INVOKE /plan-issue (directive)" \
   "INVOKE /plan-issue" "$ROUTE_OUT"
@@ -3099,7 +3077,7 @@ echo '[]' > "$STUB_DIR/pr-list-full.json"
 echo "/wt/57-stmt" > "$STUB_DIR/worktree-toplevel.txt"
 printf '{"statements":[{"key":"acme","dir":"/s","repo":"o/r","label":"statements:acme","project":"p"}]}\n' \
   > "$DISPATCH_CONFIG_DIR/statements.json"
-printf '{"labels":[{"name":"statements:acme"}]}\n' > "$STUB_DIR/issue-labels-57.json"
+printf '{"state":"open","labels":[{"name":"statements:acme"}]}\n' > "$STUB_DIR/arg-issue-57.json"
 printf '[{"number":571}]\n' > "$STUB_DIR/subissues-57.json"
 printf '{"title":"c","body":"","comments":[],"number":571,"state":"CLOSED","stateReason":"COMPLETED"}\n' \
   > "$STUB_DIR/issue-571.json"
@@ -3128,7 +3106,7 @@ echo "=== dispatch-epic-resolved-candidate ==="
 echo "Test: candidate — 2 children all CLOSED/COMPLETED → exit 0"
 setup
 printf '{"labels":["epic"]}\n' > "$DISPATCH_CONFIG_DIR/epic.json"
-printf '{"labels":[{"name":"epic"}]}\n' > "$STUB_DIR/issue-labels-61.json"
+printf '{"state":"open","labels":[{"name":"epic"}]}\n' > "$STUB_DIR/arg-issue-61.json"
 printf '[{"number":611},{"number":612}]\n' > "$STUB_DIR/subissues-61.json"
 printf '{"title":"c","body":"","comments":[],"number":611,"state":"CLOSED","stateReason":"COMPLETED"}\n' \
   > "$STUB_DIR/issue-611.json"
@@ -3142,7 +3120,7 @@ teardown
 echo "Test: candidate — lowercase closed/completed → exit 0"
 setup
 printf '{"labels":["epic"]}\n' > "$DISPATCH_CONFIG_DIR/epic.json"
-printf '{"labels":[{"name":"epic"}]}\n' > "$STUB_DIR/issue-labels-62.json"
+printf '{"state":"open","labels":[{"name":"epic"}]}\n' > "$STUB_DIR/arg-issue-62.json"
 printf '[{"number":621}]\n' > "$STUB_DIR/subissues-62.json"
 printf '{"title":"c","body":"","comments":[],"number":621,"state":"closed","stateReason":"completed"}\n' \
   > "$STUB_DIR/issue-621.json"
@@ -3154,7 +3132,7 @@ teardown
 echo "Test: not a candidate — zero sub-issues → exit 1"
 setup
 printf '{"labels":["epic"]}\n' > "$DISPATCH_CONFIG_DIR/epic.json"
-printf '{"labels":[{"name":"epic"}]}\n' > "$STUB_DIR/issue-labels-63.json"
+printf '{"state":"open","labels":[{"name":"epic"}]}\n' > "$STUB_DIR/arg-issue-63.json"
 printf '[]\n' > "$STUB_DIR/subissues-63.json"
 if "$TMPDIR_TEST/dispatch-epic-resolved-candidate" 63 >/dev/null 2>&1; then rc=0; else rc=$?; fi
 assert_eq "not a candidate: zero sub-issues → exit 1" "1" "$rc"
@@ -3164,7 +3142,7 @@ teardown
 echo "Test: not a candidate — an OPEN child → exit 1"
 setup
 printf '{"labels":["epic"]}\n' > "$DISPATCH_CONFIG_DIR/epic.json"
-printf '{"labels":[{"name":"epic"}]}\n' > "$STUB_DIR/issue-labels-64.json"
+printf '{"state":"open","labels":[{"name":"epic"}]}\n' > "$STUB_DIR/arg-issue-64.json"
 printf '[{"number":641},{"number":642}]\n' > "$STUB_DIR/subissues-64.json"
 printf '{"title":"c","body":"","comments":[],"number":641,"state":"CLOSED","stateReason":"COMPLETED"}\n' \
   > "$STUB_DIR/issue-641.json"
@@ -3178,7 +3156,7 @@ teardown
 echo "Test: not a candidate — CLOSED/NOT_PLANNED child → exit 1"
 setup
 printf '{"labels":["epic"]}\n' > "$DISPATCH_CONFIG_DIR/epic.json"
-printf '{"labels":[{"name":"epic"}]}\n' > "$STUB_DIR/issue-labels-65.json"
+printf '{"state":"open","labels":[{"name":"epic"}]}\n' > "$STUB_DIR/arg-issue-65.json"
 printf '[{"number":651}]\n' > "$STUB_DIR/subissues-65.json"
 printf '{"title":"c","body":"","comments":[],"number":651,"state":"CLOSED","stateReason":"NOT_PLANNED"}\n' \
   > "$STUB_DIR/issue-651.json"
@@ -3190,7 +3168,7 @@ teardown
 echo "Test: not a candidate — CLOSED child with null stateReason → exit 1"
 setup
 printf '{"labels":["epic"]}\n' > "$DISPATCH_CONFIG_DIR/epic.json"
-printf '{"labels":[{"name":"epic"}]}\n' > "$STUB_DIR/issue-labels-66.json"
+printf '{"state":"open","labels":[{"name":"epic"}]}\n' > "$STUB_DIR/arg-issue-66.json"
 printf '[{"number":661}]\n' > "$STUB_DIR/subissues-66.json"
 printf '{"title":"c","body":"","comments":[],"number":661,"state":"CLOSED"}\n' \
   > "$STUB_DIR/issue-661.json"
@@ -3202,7 +3180,7 @@ teardown
 echo "Test: hard error — issue-sub-issues fails → exit 3"
 setup
 printf '{"labels":["epic"]}\n' > "$DISPATCH_CONFIG_DIR/epic.json"
-printf '{"labels":[{"name":"epic"}]}\n' > "$STUB_DIR/issue-labels-67.json"
+printf '{"state":"open","labels":[{"name":"epic"}]}\n' > "$STUB_DIR/arg-issue-67.json"
 touch "$STUB_DIR/gh-fail-sub_issues-67"
 if "$TMPDIR_TEST/dispatch-epic-resolved-candidate" 67 >/dev/null 2>&1; then rc=0; else rc=$?; fi
 assert_eq "hard error: issue-sub-issues fails → exit 3" "3" "$rc"
@@ -3219,7 +3197,7 @@ teardown
 echo "Test: gate — epic configured but issue lacks the label → exit 1"
 setup
 printf '{"labels":["epic"]}\n' > "$DISPATCH_CONFIG_DIR/epic.json"
-printf '{"labels":[{"name":"enhancement"}]}\n' > "$STUB_DIR/issue-labels-68.json"
+printf '{"state":"open","labels":[{"name":"enhancement"}]}\n' > "$STUB_DIR/arg-issue-68.json"
 printf '[{"number":681}]\n' > "$STUB_DIR/subissues-68.json"
 printf '{"title":"c","body":"","comments":[],"number":681,"state":"CLOSED","stateReason":"COMPLETED"}\n' \
   > "$STUB_DIR/issue-681.json"
@@ -3231,7 +3209,7 @@ teardown
 # regardless of sub-issue state (all children CLOSED/COMPLETED here).
 echo "Test: gate — no epic config → exit 1 regardless of sub-issue state"
 setup
-printf '{"labels":[{"name":"epic"}]}\n' > "$STUB_DIR/issue-labels-69.json"
+printf '{"state":"open","labels":[{"name":"epic"}]}\n' > "$STUB_DIR/arg-issue-69.json"
 printf '[{"number":691}]\n' > "$STUB_DIR/subissues-69.json"
 printf '{"title":"c","body":"","comments":[],"number":691,"state":"CLOSED","stateReason":"COMPLETED"}\n' \
   > "$STUB_DIR/issue-691.json"
@@ -3250,71 +3228,55 @@ assert_eq "gate: label fetch hard failure → exit 3" "3" "$rc"
 teardown
 
 # ============================================================================
-# issue-sub-issues field-forwarding tests (#1593)
+# issue-sub-issues output-shape tests (#2257)
 # ============================================================================
 echo ""
-echo "=== issue-sub-issues field forwarding ==="
+echo "=== issue-sub-issues output shape ==="
 
-# These tests run the REAL issue-sub-issues script (not the fake that setup()
-# installs for dispatch-trace-leaf). After setup, the fake is overwritten with
-# the real script so any --json field set it requests hits the stub and is
-# logged to gh-issue-view-fields.log. This is the only way to assert which
-# fields the real script actually requests.
+# issue-sub-issues now emits one gh_issue_view_rest object per sub-issue (#2257),
+# replacing the GraphQL `gh issue view --json <FIELDS>` porcelain. The former
+# FIELDS arg (#1593) is gone: the helper has a FIXED projection. So the old
+# field-forwarding tests (which asserted the requested --json field set) are
+# retired in favor of asserting the EMITTED object shape — a stronger check of
+# the actual consumer contract (number/state/stateReason). Children route to the
+# generic `api repos/*/issues/<N>` stub arm by number → arg-issue-<N>.json
+# supplies each child's raw REST object.
+#
+# These tests run the REAL issue-sub-issues script (setup() installs a fake for
+# dispatch-trace-leaf; we overwrite it with the real script here).
 
-# A. Default fields: one child → stub logs exactly "number,state,stateReason".
-echo "Test: issue-sub-issues — default fields → number,state,stateReason"
+# A. One child → exactly one emitted object carrying number/state/stateReason.
+# (Leanness via #1593's narrow --json field set is superseded by the helper's
+# fixed projection; this epic's goal is GraphQL rate-limit relief, not payload
+# size. The helper does project body/labels/etc., which the consumers ignore.)
+echo "Test: issue-sub-issues — one child → one object with number/state/stateReason"
 setup
 cp "$SCRIPT_DIR/issue-sub-issues" "$TMPDIR_TEST/issue-sub-issues"
 chmod +x "$TMPDIR_TEST/issue-sub-issues"
 printf '[{"number":801}]\n' > "$STUB_DIR/subissues-80.json"
-"$TMPDIR_TEST/issue-sub-issues" 80 >/dev/null
-logged=$(cat "$STUB_DIR/gh-issue-view-fields.log" 2>/dev/null || true)
-assert_eq "default fields: logged fields" "number,state,stateReason" "$logged"
+printf '{"number":801,"state":"closed","state_reason":"completed"}\n' > "$STUB_DIR/arg-issue-801.json"
+out=$("$TMPDIR_TEST/issue-sub-issues" 80)
+assert_eq "one child: object count" "1" "$(printf '%s' "$out" | jq -s 'length')"
+assert_eq "one child: number" "801" "$(printf '%s' "$out" | jq -s '.[0].number')"
+assert_eq "one child: state upcased" "CLOSED" "$(printf '%s' "$out" | jq -rs '.[0].state')"
+assert_eq "one child: stateReason upcased" "COMPLETED" "$(printf '%s' "$out" | jq -rs '.[0].stateReason')"
 teardown
 
-# B. Default fields: no body, no comments in the logged field set.
-echo "Test: issue-sub-issues — default fields contain no body or comments"
-setup
-cp "$SCRIPT_DIR/issue-sub-issues" "$TMPDIR_TEST/issue-sub-issues"
-chmod +x "$TMPDIR_TEST/issue-sub-issues"
-printf '[{"number":811}]\n' > "$STUB_DIR/subissues-81.json"
-"$TMPDIR_TEST/issue-sub-issues" 81 >/dev/null
-logged=$(cat "$STUB_DIR/gh-issue-view-fields.log" 2>/dev/null || true)
-assert_eq "default fields: no body in field set" "0" "$(printf '%s' "$logged" | grep -c 'body' || true)"
-assert_eq "default fields: no comments in field set" "0" "$(printf '%s' "$logged" | grep -c 'comments' || true)"
-teardown
-
-# C. Explicit fields arg: forwarded verbatim → stub logs exactly "number,state".
-echo "Test: issue-sub-issues — explicit fields arg forwarded verbatim"
-setup
-cp "$SCRIPT_DIR/issue-sub-issues" "$TMPDIR_TEST/issue-sub-issues"
-chmod +x "$TMPDIR_TEST/issue-sub-issues"
-printf '[{"number":821}]\n' > "$STUB_DIR/subissues-82.json"
-"$TMPDIR_TEST/issue-sub-issues" 82 "number,state" >/dev/null
-logged=$(cat "$STUB_DIR/gh-issue-view-fields.log" 2>/dev/null || true)
-assert_eq "explicit fields: logged fields" "number,state" "$logged"
-teardown
-
-# D. Two children: each child produces one log line → two lines total.
-echo "Test: issue-sub-issues — two children → two field log entries"
+# B. Two children → two emitted objects, each with the projected keys (the
+# per-child-emission invariant the old test D guarded, now asserted on output).
+echo "Test: issue-sub-issues — two children → two objects, both with number/state"
 setup
 cp "$SCRIPT_DIR/issue-sub-issues" "$TMPDIR_TEST/issue-sub-issues"
 chmod +x "$TMPDIR_TEST/issue-sub-issues"
 printf '[{"number":831},{"number":832}]\n' > "$STUB_DIR/subissues-83.json"
-"$TMPDIR_TEST/issue-sub-issues" 83 >/dev/null
-line_count=$(wc -l < "$STUB_DIR/gh-issue-view-fields.log" | tr -d ' ')
-assert_eq "two children: two log lines" "2" "$line_count"
-teardown
-
-# E. Empty FIELDS arg: guard fires → exit 2 with descriptive stderr (before any API call).
-echo "Test: issue-sub-issues — empty FIELDS arg → exit 2 with error"
-setup
-cp "$SCRIPT_DIR/issue-sub-issues" "$TMPDIR_TEST/issue-sub-issues"
-chmod +x "$TMPDIR_TEST/issue-sub-issues"
-err=$("$TMPDIR_TEST/issue-sub-issues" 84 "" 2>&1 1>/dev/null) && rc=0 || rc=$?
-assert_eq "empty FIELDS: exit code 2" "2" "$rc"
-assert_eq "empty FIELDS: descriptive stderr" "1" \
-  "$(printf '%s' "$err" | grep -c 'FIELDS arg must not be empty' || true)"
+printf '{"number":831,"state":"open","state_reason":null}\n' > "$STUB_DIR/arg-issue-831.json"
+printf '{"number":832,"state":"closed","state_reason":"completed"}\n' > "$STUB_DIR/arg-issue-832.json"
+out=$("$TMPDIR_TEST/issue-sub-issues" 83)
+assert_eq "two children: object count" "2" "$(printf '%s' "$out" | jq -s 'length')"
+assert_eq "two children: numbers" "831 832" \
+  "$(printf '%s' "$out" | jq -rs 'map(.number) | join(" ")')"
+assert_eq "two children: all carry state" "2" \
+  "$(printf '%s' "$out" | jq -s '[.[] | select(has("state"))] | length')"
 teardown
 
 # ============================================================================
@@ -3336,7 +3298,7 @@ echo "=== dispatch-close-resolved ==="
 # (a) OPEN issue + JOB_DIR set → closes the issue and writes the sentinel.
 echo "Test: close-resolved — OPEN issue + JOB_DIR → close + sentinel"
 setup
-echo '{"state":"OPEN"}' > "$STUB_DIR/issue-state-700.json"
+echo '{"state":"open"}' > "$STUB_DIR/arg-issue-700.json"
 export CLAUDE_JOB_DIR="$TMPDIR_TEST/job"
 mkdir -p "$CLAUDE_JOB_DIR"
 "$TMPDIR_TEST/dispatch-close-resolved" 700 --reason "epic done"
@@ -3360,7 +3322,7 @@ teardown
 # still writes the sentinel (re-entry idempotency).
 echo "Test: close-resolved — already-CLOSED issue + JOB_DIR → no re-close, sentinel still written"
 setup
-echo '{"state":"CLOSED"}' > "$STUB_DIR/issue-state-701.json"
+echo '{"state":"closed"}' > "$STUB_DIR/arg-issue-701.json"
 export CLAUDE_JOB_DIR="$TMPDIR_TEST/job"
 mkdir -p "$CLAUDE_JOB_DIR"
 "$TMPDIR_TEST/dispatch-close-resolved" 701 --reason "epic done"
@@ -3383,7 +3345,7 @@ teardown
 echo "Test: close-resolved — JOB_DIR unset + OPEN issue → no sentinel, exit 0"
 setup
 unset CLAUDE_JOB_DIR
-echo '{"state":"OPEN"}' > "$STUB_DIR/issue-state-702.json"
+echo '{"state":"open"}' > "$STUB_DIR/arg-issue-702.json"
 if "$TMPDIR_TEST/dispatch-close-resolved" 702 --reason "epic done" >/dev/null 2>&1; then rc=0; else rc=$?; fi
 assert_eq "close-resolved no-JOB_DIR: exit 0" "0" "$rc"
 TOTAL=$((TOTAL + 1))
@@ -3457,10 +3419,12 @@ if ( "$TMPDIR_TEST/dispatch-resolve-arg" "719" ) >/dev/null 2>&1; then rc=0; els
 assert_eq "PR closing multiple issues → exit 4" "4" "$rc"
 teardown
 
-# 6. Number is neither an issue nor a PR (no fixture → stub 404s) → exit 2.
+# 6. Number is neither an issue nor a PR (stub 404s) → exit 2.
 echo "Test: unknown number → exit 2"
 setup
-# No arg-issue-999.json: the stub returns 404.
+# arg-issue-999.notfound forces the issues GET to a real 404 (the number is
+# neither an issue nor a PR), overriding the stub's empty-labels default.
+touch "$STUB_DIR/arg-issue-999.notfound"
 if ( "$TMPDIR_TEST/dispatch-resolve-arg" "999" ) >/dev/null 2>&1; then rc=0; else rc=$?; fi
 assert_eq "neither issue nor PR → exit 2" "2" "$rc"
 teardown
@@ -8433,6 +8397,7 @@ log_state() {
 # to the ISSUE and posts a why-comment containing the reason text.
 echo "Test: label absent → apply to issue + post why-comment"
 setup
+echo '{"state":"open","labels":[]}' > "$STUB_DIR/arg-issue-42.json"
 "$TMPDIR_TEST/dispatch-apply-office-hours" 42 "phase exited before completion"
 assert_eq "applies dispatch:office-hours to the issue" \
   "issue edit 42 --add-label dispatch:office-hours" "$(cat "$STUB_DIR/gh-issue-edit.log")"
@@ -8456,7 +8421,7 @@ teardown
 # comment.
 echo "Test: label already present → no edit, no duplicate comment"
 setup
-echo '{"labels":[{"name":"dispatch:office-hours"}]}' > "$STUB_DIR/issue-labels-42.json"
+echo '{"state":"open","labels":[{"name":"dispatch:office-hours"}]}' > "$STUB_DIR/arg-issue-42.json"
 "$TMPDIR_TEST/dispatch-apply-office-hours" 42 "phase ran but did not advance"
 assert_eq "idempotent: no label edit" "absent" "$(log_state gh-issue-edit.log)"
 assert_eq "idempotent: no duplicate comment" "absent" "$(log_state gh-issue-comment.log)"
@@ -8502,6 +8467,7 @@ teardown
 # retries the edit, then posts the comment.
 echo "Test: label not found → create (FBCA04) then retry + comment"
 setup
+echo '{"state":"open","labels":[]}' > "$STUB_DIR/arg-issue-42.json"
 echo "label-missing" > "$STUB_DIR/issue-edit-mode"
 "$TMPDIR_TEST/dispatch-apply-office-hours" 42 "phase exited before completion"
 TOTAL=$((TOTAL + 1))
@@ -8587,6 +8553,7 @@ echo "=== dispatch-qa-apply-main-qa-labels (#1758) ==="
 # script exits 0. No label create needed.
 echo "Test: happy path → remove help-wanted, add main-qa, route to office-hours; exit 0"
 setup
+echo '{"state":"open","labels":[]}' > "$STUB_DIR/arg-issue-42.json"
 if "$TMPDIR_TEST/dispatch-qa-apply-main-qa-labels" 42; then rc=0; else rc=$?; fi
 assert_eq "happy path: exit 0" "0" "$rc"
 TOTAL=$((TOTAL + 1))
@@ -8615,6 +8582,7 @@ teardown
 # apply main-qa and dispatch:office-hours, exiting 0.
 echo "Test: remove-label-missing → tolerated, main-qa and office-hours still applied; exit 0"
 setup
+echo '{"state":"open","labels":[]}' > "$STUB_DIR/arg-issue-42.json"
 echo "remove-label-missing" > "$STUB_DIR/issue-edit-mode"
 if "$TMPDIR_TEST/dispatch-qa-apply-main-qa-labels" 42; then rc=0; else rc=$?; fi
 assert_eq "not-found removal tolerated, exit 0" "0" "$rc"
@@ -8644,6 +8612,7 @@ teardown
 # unaffected.
 echo "Test: main-qa-missing → create with canonical metadata, retry add, office-hours unaffected; exit 0"
 setup
+echo '{"state":"open","labels":[]}' > "$STUB_DIR/arg-issue-42.json"
 echo "main-qa-missing" > "$STUB_DIR/issue-edit-mode"
 if "$TMPDIR_TEST/dispatch-qa-apply-main-qa-labels" 42; then rc=0; else rc=$?; fi
 assert_eq "lazy create: exit 0" "0" "$rc"
@@ -8866,7 +8835,7 @@ teardown
 # 4. No matching worktree → create <N>-<slug> from the issue title.
 echo "Test: no worktree → create <N>-<slug>"
 setup
-echo '{"title":"Add a feature"}' > "$STUB_DIR/issue-title-42.json"
+echo '{"state":"open","title":"Add a feature"}' > "$STUB_DIR/arg-issue-42.json"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
 assert_eq "no worktree → create <N>-<slug>" "create 42-add-a-feature" "$result"
 teardown
@@ -8875,7 +8844,7 @@ teardown
 #    to a lowercase dash-joined slug.
 echo "Test: title sanitization → create"
 setup
-printf '{"title":"  Fix: The Foo/Bar Widget!  "}' > "$STUB_DIR/issue-title-7.json"
+printf '{"state":"open","title":"  Fix: The Foo/Bar Widget!  "}' > "$STUB_DIR/arg-issue-7.json"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 7 explicit)
 assert_eq "messy title sanitized → create" "create 7-fix-the-foo-bar-widget" "$result"
 teardown
@@ -8884,8 +8853,8 @@ teardown
 #    WorktreeCreate hook form (acceptance criterion 2).
 echo "Test: long title truncated to <= 32-char branch → create"
 setup
-echo '{"title":"Extract the worktree resolution logic into a dedicated script"}' \
-  > "$STUB_DIR/issue-title-656.json"
+echo '{"state":"open","title":"Extract the worktree resolution logic into a dedicated script"}' \
+  > "$STUB_DIR/arg-issue-656.json"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 656 explicit)
 assert_eq "long title truncated → exact create line" \
   "create 656-extract-the-worktree-resolut" "$result"
@@ -8934,7 +8903,7 @@ echo "Test: only a non-matching worktree → create"
 setup
 printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/99-other\nHEAD def456\nbranch refs/heads/99-other\n\n' \
   > "$STUB_DIR/worktree-list.txt"
-echo '{"title":"My Task"}' > "$STUB_DIR/issue-title-42.json"
+echo '{"state":"open","title":"My Task"}' > "$STUB_DIR/arg-issue-42.json"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
 assert_eq "non-matching worktree → create" "create 42-my-task" "$result"
 teardown
@@ -8957,7 +8926,7 @@ teardown
 # 10. A title with no alphanumerics sanitizes to an empty slug → exit 1.
 echo "Test: title with no alphanumerics → empty-slug error"
 setup
-echo '{"title":"!!!"}' > "$STUB_DIR/issue-title-42.json"
+echo '{"state":"open","title":"!!!"}' > "$STUB_DIR/arg-issue-42.json"
 if "$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit 2>/dev/null; then rc=0; else rc=$?; fi
 assert_eq "empty-slug title exits non-zero" "1" "$rc"
 teardown
@@ -8981,7 +8950,7 @@ teardown
 #      create logic is preserved for the genuine implement phase.
 echo "Test: no worktree + no PR → create <N>-<slug> (find-pr fall-through, AC #5)"
 setup
-echo '{"title":"Add a feature"}' > "$STUB_DIR/issue-title-42.json"
+echo '{"state":"open","title":"Add a feature"}' > "$STUB_DIR/arg-issue-42.json"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
 assert_eq "no worktree + no PR → create <N>-<slug>" "create 42-add-a-feature" "$result"
 teardown
@@ -8995,7 +8964,7 @@ teardown
 #      sleep under the lock.
 echo "Test: #1612 create path forces dispatch-find-pr retry delay 0 under the lock"
 setup
-echo '{"title":"Add a feature"}' > "$STUB_DIR/issue-title-42.json"
+echo '{"state":"open","title":"Add a feature"}' > "$STUB_DIR/arg-issue-42.json"
 # Probe find-pr: record the retry delay observed, then return empty (no PR →
 # fall through to fresh-slug create). Overwrites the real copy setup installed.
 cat > "$TMPDIR_TEST/dispatch-find-pr" <<'PROBE'
@@ -9151,14 +9120,13 @@ teardown
 # ----------------------------------------------------------------------------
 
 # 19a. PR number passed as the issue key → reject before the create-path slug.
-#      arg-issue-922.json carries "pull_request"; an issue-title-922.json is also
-#      seeded so the test proves the guard fires *before* the create path (no
-#      decision line despite a usable title fixture).
+#      arg-issue-922.json carries "pull_request" AND a usable title, so the test
+#      proves the guard fires *before* the create path (no decision line despite a
+#      usable title in the issue object).
 echo "Test: PR number as issue key → reject (no stray <pr-num>-* worktree)"
 setup
-echo '{"number":922,"pull_request":{"url":"https://api.github.com/repos/o/r/pulls/922"}}' \
+echo '{"number":922,"state":"open","title":"some pr title","pull_request":{"url":"https://api.github.com/repos/o/r/pulls/922"}}' \
   > "$STUB_DIR/arg-issue-922.json"
-echo '{"title":"some pr title"}' > "$STUB_DIR/issue-title-922.json"
 if result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 922 queue 2>/dev/null); then rc=0; else rc=$?; fi
 assert_eq "PR number as issue key → exit 1" "1" "$rc"
 assert_eq "PR number as issue key → no decision line" "" "$result"
@@ -9432,18 +9400,22 @@ case "$args" in
     f="$STUB_DIR/pr-state-${br}.json"
     if [[ -f "$f" ]]; then cat "$f"; else echo '[]'; fi
     ;;
-  issue\ view\ *\ --json\ state\ -q\ .state)
-    # dispatch-sweep closed-issue check: gh issue view <N> --json state -q .state
-    num=$(echo "$args" | awk '{print $3}')
+  api\ repos/*/issues/[0-9]*)
+    # dispatch-sweep closed-issue check via gh_issue_view_rest (#2257): the helper
+    # issues `gh api repos/{owner}/{repo}/issues/<N>` and projects+upcases .state.
+    num="${args##*/}"
     # Controllable failure: if SWEEP_GH_ISSUE_FAIL matches this issue number, fail.
     if [[ "${SWEEP_GH_ISSUE_FAIL:-}" == "$num" ]]; then
-      echo "gh sweep stub: simulated gh issue view failure for $num" >&2
+      echo "gh sweep stub: simulated gh api issues/$num failure for $num" >&2
       exit 1
     fi
-    # Per-issue state fixture: issue-state-<N>.txt holds the raw state string.
+    # Per-issue state fixture: issue-state-<N>.txt holds the raw state string
+    # (e.g. CLOSED/OPEN/GARBAGE). Emit it inside a raw-REST issue object with the
+    # state lowercased — the porcelain bridge in gh_issue_view_rest upcases it back.
     f="$STUB_DIR/issue-state-${num}.txt"
     if [[ -f "$f" ]]; then
-      cat "$f"
+      state_lc=$(tr '[:upper:]' '[:lower:]' < "$f")
+      printf '{"number":%s,"state":"%s"}\n' "$num" "$state_lc"
     else
       echo "gh sweep stub: no issue-state-${num}.txt for issue view $num" >&2
       exit 1
@@ -9871,7 +9843,7 @@ else
   echo "    calls: $calls"
 fi
 TOTAL=$((TOTAL + 1))
-if grep -q "ERROR_ISSUE_STATE_FETCH: branch=60-closed-feature issue=60 gh issue view failed" \
+if grep -q "ERROR_ISSUE_STATE_FETCH: branch=60-closed-feature issue=60 gh_issue_view_rest failed" \
    "$DISPATCH_SWEEP_LOG_FILE"; then
   PASS=$((PASS + 1)); echo "  PASS: ERROR_ISSUE_STATE_FETCH log line present"
 else
@@ -24072,6 +24044,8 @@ mkdir -p "$FINALIZE_STUB_DIR" "$FINALIZE_BIN" "$FINALIZE_SCRIPTS"
 # Copy the real finalize script into the scripts dir so $SCRIPT_DIR resolves there.
 cp "$SCRIPT_DIR/dispatch-finalize-phase" "$FINALIZE_SCRIPTS/dispatch-finalize-phase"
 chmod +x "$FINALIZE_SCRIPTS/dispatch-finalize-phase"
+# finalize-phase sources lib.sh (gh_issue_view_rest, #2257) via its $SCRIPT_DIR.
+cp "$SCRIPT_DIR/lib.sh" "$FINALIZE_SCRIPTS/lib.sh"
 
 # Stub dispatch-spawn-tick: log to order.log and spawn-calls.log.
 cat > "$FINALIZE_SCRIPTS/dispatch-spawn-tick" <<'STUB'
@@ -24106,9 +24080,11 @@ cat > "$FINALIZE_BIN/gh" <<'STUB'
 FINALIZE_STUB_DIR="$(cd "$(dirname "$0")/.." && pwd)/stub"
 args="$*"
 case "$args" in
-  issue\ view\ *--json\ labels*)
-    # No rate-limit-retry labels to clear.
-    printf '{"labels":[]}\n'
+  api\ repos/*/issues/*)
+    # finalize-phase reads the issue via gh_issue_view_rest (#2257). Emit a raw-REST
+    # object with no rate-limit-retry labels to clear (and a state so the helper's
+    # .state|ascii_upcase does not error).
+    printf '{"number":0,"state":"open","labels":[]}\n'
     ;;
   pr\ edit\ *--remove-label*)
     echo "$args" >> "$FINALIZE_STUB_DIR/gh-pr-remove.log"
@@ -27991,9 +27967,18 @@ esac
 STUB
   cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
 #!/usr/bin/env bash
-# Closed-check (--json state) and identity-stub title fetch (--json title).
+# dispatch-materialize-spawn reads the issue via gh_issue_view_rest (#2257):
+# `gh api repos/{owner}/{repo}/issues/<N>`. Emit a raw-REST issue object built
+# from MAT_ISSUE_TITLE / MAT_ISSUE_STATE; the helper projects+upcases .state, so
+# emit the state lowercased here (CLOSED → closed → helper upcases back).
 case "$*" in
-  *"--json title"*) echo "${MAT_ISSUE_TITLE:-Test issue title}" ;;
+  api\ repos/*/issues/*)
+    state_lc=$(printf '%s' "${MAT_ISSUE_STATE:-OPEN}" | tr '[:upper:]' '[:lower:]')
+    # Build with jq so a title carrying control chars (the #1443 crafted-title
+    # test) is JSON-escaped into a valid raw-REST object the helper can parse.
+    jq -n --arg title "${MAT_ISSUE_TITLE:-Test issue title}" --arg state "$state_lc" \
+      '{number:0, title:$title, body:"", state:$state, state_reason:null, labels:[], assignees:[]}'
+    ;;
   *) echo "${MAT_ISSUE_STATE:-OPEN}" ;;
 esac
 STUB
@@ -30761,19 +30746,21 @@ jit_skill_setup() {
   chmod +x "$TMPDIR_TEST/scripts/dispatch-jit-skill" \
            "$TMPDIR_TEST/scripts/dispatch-config-load"
 
-  # gh stub: handles `issue view <num> --repo <repo> --json labels`.
-  # Reads the labels fixture from $TMPDIR_TEST/labels.json; defaults to empty.
-  # Unknown invocations → stderr + exit 1.
+  # gh stub: handles dispatch-jit-skill's gh_issue_view_rest read (#2257):
+  # `gh api repos/<owner>/<repo>/issues/<N>`. Reads the labels fixture from
+  # $TMPDIR_TEST/labels.json (a raw-REST {"labels":[...]} object) and merges a
+  # state so the helper's .state|ascii_upcase does not error; defaults to empty
+  # labels. Unknown invocations → stderr + exit 1.
   cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
 #!/usr/bin/env bash
 args="$*"
 TREE="$(cd "$(dirname "$0")/.." && pwd)"
 case "$args" in
-  issue\ view\ *\ --repo\ *\ --json\ labels)
+  api\ repos/*/issues/*)
     if [[ -f "$TREE/labels.json" ]]; then
-      cat "$TREE/labels.json"
+      jq '. + {state:"open"}' "$TREE/labels.json"
     else
-      echo '{"labels":[]}'
+      echo '{"state":"open","labels":[]}'
     fi
     ;;
   *)
@@ -35966,6 +35953,9 @@ echo "Test: closed-unmerged source PR → park follow-up on office-hours + mark 
 setup
 printf '[{"number":101,"labels":[{"name":"dispatch:review-followup"}],"body":"orphan finding <!-- dispatch:source-pr 1704 -->"}]\n' > "$STUB_DIR/issue-list.json"
 printf '{"state":"closed","merged_at":null,"labels":[]}\n' > "$STUB_DIR/retriage-pr-1704.json"
+# The park flows through the real dispatch-apply-office-hours, which reads the
+# issue's labels via gh_issue_view_rest (#2257) → arg-issue-101.json.
+echo '{"state":"open","labels":[]}' > "$STUB_DIR/arg-issue-101.json"
 out=$("$TMPDIR_TEST/dispatch-retriage-orphaned-followups" 2>/dev/null)
 assert_eq "a: office-hours applied to the follow-up issue" \
   "issue edit 101 --add-label dispatch:office-hours" "$(cat "$STUB_DIR/gh-issue-edit.log")"
@@ -36062,6 +36052,7 @@ setup
 printf '[{"number":106,"labels":[{"name":"dispatch:review-followup"}],"body":"orphan finding mentions <!-- dispatch:source-pr 1500 --> in its text, then the genuine appended marker <!-- dispatch:source-pr 1704 -->"}]\n' > "$STUB_DIR/issue-list.json"
 printf '{"state":"open","merged_at":null,"labels":[]}\n' > "$STUB_DIR/retriage-pr-1500.json"
 printf '{"state":"closed","merged_at":null,"labels":[]}\n' > "$STUB_DIR/retriage-pr-1704.json"
+echo '{"state":"open","labels":[]}' > "$STUB_DIR/arg-issue-106.json"
 out=$("$TMPDIR_TEST/dispatch-retriage-orphaned-followups" 2>/dev/null)
 assert_eq "g: parks the follow-up against the LAST marker's PR (#1704)" \
   "issue edit 106 --add-label dispatch:office-hours" "$(cat "$STUB_DIR/gh-issue-edit.log")"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -682,11 +682,23 @@ case "$args" in
     fi
     ;;
   api\ repos/*/pulls/*)
-    # dispatch-retriage-orphaned-followups (#1812, #2007): gh api
-    # repos/{owner}/{repo}/pulls/<N>. $STUB_DIR/retriage-pr-<N>.json supplies
-    # the per-PR REST state object; absence defaults to an OPEN PR (no action).
+    # Two consumers route here, both issuing the byte-identical
+    # `gh api repos/{owner}/{repo}/pulls/<N>` GET (no flag to discriminate on):
+    #   - dispatch-resolve-worktree reconciliation (#2257): resolve_pr_head now
+    #     reads the PR head via gh_pr_view_rest (was `gh pr view --json
+    #     headRefName`). $STUB_DIR/pr-headref-<N>.json supplies the raw REST pull
+    #     object (carries head.ref); the gh-pr-view-headref.log write below keeps
+    #     the existing call-made assertions valid. Default-absent → empty head.ref
+    #     so the resolve_pr_head guard still fires its "unusable head" abort.
+    #   - dispatch-retriage-orphaned-followups (#1812, #2007):
+    #     $STUB_DIR/retriage-pr-<N>.json; absence defaults to an OPEN PR.
+    # pr-headref takes priority: resolve-worktree tests use PR numbers (100, 922)
+    # that retriage's tests never use, so the two fixture namespaces don't collide.
     num="${args##*/}"
-    if [[ -f "$STUB_DIR/retriage-pr-${num}.json" ]]; then
+    if [[ -f "$STUB_DIR/pr-headref-${num}.json" ]]; then
+      echo "pr view" >> "$STUB_DIR/gh-pr-view-headref.log"
+      cat "$STUB_DIR/pr-headref-${num}.json"
+    elif [[ -f "$STUB_DIR/retriage-pr-${num}.json" ]]; then
       cat "$STUB_DIR/retriage-pr-${num}.json"
     else
       echo '{"state":"open","merged_at":null,"labels":[]}'
@@ -699,16 +711,6 @@ case "$args" in
       cat "$STUB_DIR/arg-closing-${num}.json"
     else
       echo '{"closingIssuesReferences":[]}'
-    fi
-    ;;
-  pr\ view\ *\ --json\ headRefName)
-    # dispatch-resolve-worktree reconciliation: gh pr view <N> --json headRefName.
-    echo "pr view" >> "$STUB_DIR/gh-pr-view-headref.log"
-    num=$(echo "$args" | awk '{print $3}')
-    if [[ -f "$STUB_DIR/pr-headref-${num}.json" ]]; then
-      cat "$STUB_DIR/pr-headref-${num}.json"
-    else
-      echo '{"headRefName":""}'
     fi
     ;;
   label\ create\ *)
@@ -9414,7 +9416,7 @@ teardown
 echo "Test: no worktree + open PR → create-existing <pr-head>"
 setup
 printf '[{"number":100,"headRefName":"42-existing-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
-echo '{"headRefName":"42-existing-pr-branch"}' > "$STUB_DIR/pr-headref-100.json"
+echo '{"number":100,"state":"open","head":{"ref":"42-existing-pr-branch"}}' > "$STUB_DIR/pr-headref-100.json"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
 assert_eq "no worktree + open PR → create-existing <pr-head>" \
   "create-existing 42-existing-pr-branch" "$result"
@@ -9461,7 +9463,7 @@ teardown
 # ----------------------------------------------------------------------------
 # Branch reconciliation on the `enter` path (#913). PR existence is driven via
 # pr-list-full.json (dispatch-find-pr's prefix match on headRefName); the PR
-# head branch is driven via pr-headref-<num>.json (gh pr view headRefName).
+# head branch is driven via pr-headref-<num>.json (gh_pr_view_rest head.ref).
 # The git stub logs checkouts to git-checkout.log and reads the unique-commit
 # count from rev-list-count.txt (default 0).
 # ----------------------------------------------------------------------------
@@ -9472,7 +9474,7 @@ setup
 printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
 select_target_fake_claude   # sessionless: explicit liveness check (#837) proceeds to reconcile
 printf '[{"number":100,"headRefName":"42-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
-echo '{"headRefName":"42-pr-branch"}' > "$STUB_DIR/pr-headref-100.json"
+echo '{"number":100,"state":"open","head":{"ref":"42-pr-branch"}}' > "$STUB_DIR/pr-headref-100.json"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
 assert_eq "wrong branch + no unique commits → enter" \
   "enter /worktrees/42-my-feature" "$result"
@@ -9486,7 +9488,7 @@ setup
 printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
 select_target_fake_claude   # sessionless: explicit liveness check (#837) proceeds to reconcile
 printf '[{"number":100,"headRefName":"42-my-feature"}]\n' > "$STUB_DIR/pr-list-full.json"
-echo '{"headRefName":"42-my-feature"}' > "$STUB_DIR/pr-headref-100.json"
+echo '{"number":100,"state":"open","head":{"ref":"42-my-feature"}}' > "$STUB_DIR/pr-headref-100.json"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
 assert_eq "already on PR branch → enter" "enter /worktrees/42-my-feature" "$result"
 checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && echo yes || echo no)
@@ -9499,7 +9501,7 @@ setup
 printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
 select_target_fake_claude   # sessionless: conflict here is from unique commits, not liveness (#837)
 printf '[{"number":100,"headRefName":"42-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
-echo '{"headRefName":"42-pr-branch"}' > "$STUB_DIR/pr-headref-100.json"
+echo '{"number":100,"state":"open","head":{"ref":"42-pr-branch"}}' > "$STUB_DIR/pr-headref-100.json"
 echo "2" > "$STUB_DIR/rev-list-count.txt"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit)
 assert_eq "wrong branch + unique commits → conflict" \
@@ -9529,7 +9531,7 @@ setup
 printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
 select_target_fake_claude   # orphan: no live session owns the worktree
 printf '[{"number":100,"headRefName":"42-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
-echo '{"headRefName":"42-pr-branch"}' > "$STUB_DIR/pr-headref-100.json"
+echo '{"number":100,"state":"open","head":{"ref":"42-pr-branch"}}' > "$STUB_DIR/pr-headref-100.json"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
 assert_eq "queue orphan + wrong branch → enter" \
   "enter /worktrees/42-my-feature" "$result"
@@ -9545,7 +9547,7 @@ setup
 printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
 select_target_fake_claude "42-my-feature"   # live session owns the worktree
 printf '[{"number":100,"headRefName":"42-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
-echo '{"headRefName":"42-pr-branch"}' > "$STUB_DIR/pr-headref-100.json"
+echo '{"number":100,"state":"open","head":{"ref":"42-pr-branch"}}' > "$STUB_DIR/pr-headref-100.json"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 queue)
 assert_eq "queue live-session + wrong branch → conflict" \
   "conflict /worktrees/42-my-feature" "$result"
@@ -9564,7 +9566,7 @@ setup
 printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
 select_target_fake_claude   # sessionless: explicit liveness check (#837) proceeds to reconcile
 printf '[{"number":100,"headRefName":"42-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
-echo '{"headRefName":""}' > "$STUB_DIR/pr-headref-100.json"
+echo '{"number":100,"state":"open","head":{"ref":""}}' > "$STUB_DIR/pr-headref-100.json"
 if result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit 2>/dev/null); then rc=0; else rc=$?; fi
 assert_eq "PR + empty headRefName → exit 1" "1" "$rc"
 checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && echo yes || echo no)
@@ -9578,7 +9580,7 @@ setup
 printf '%s' "$WORKTREE_LIST_42" > "$STUB_DIR/worktree-list.txt"
 select_target_fake_claude   # sessionless: explicit liveness check (#837) proceeds to reconcile
 printf '[{"number":100,"headRefName":"42-pr-branch"}]\n' > "$STUB_DIR/pr-list-full.json"
-echo '{"headRefName":"--upload-pack=evil"}' > "$STUB_DIR/pr-headref-100.json"
+echo '{"number":100,"state":"open","head":{"ref":"--upload-pack=evil"}}' > "$STUB_DIR/pr-headref-100.json"
 if result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 42 explicit 2>/dev/null); then rc=0; else rc=$?; fi
 assert_eq "PR + injection-shaped headRefName → exit 1" "1" "$rc"
 checkout_logged=$([[ -f "$STUB_DIR/git-checkout.log" ]] && echo yes || echo no)
@@ -9618,7 +9620,7 @@ printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktre
 select_target_fake_claude   # orphan: no live session owns the worktree
 echo '{"number":918}' > "$STUB_DIR/arg-issue-918.json"
 printf '[{"number":922,"headRefName":"918-dispatch-move"}]\n' > "$STUB_DIR/pr-list-full.json"
-echo '{"headRefName":"918-dispatch-move"}' > "$STUB_DIR/pr-headref-922.json"
+echo '{"number":922,"state":"open","head":{"ref":"918-dispatch-move"}}' > "$STUB_DIR/pr-headref-922.json"
 result=$("$TMPDIR_TEST/dispatch-resolve-worktree" 918 queue)
 assert_eq "PR closing-issue number → enter real worktree" \
   "enter /worktrees/918-dispatch-move" "$result"
@@ -35443,13 +35445,27 @@ case "$args" in
       echo "[]"
     fi
     ;;
-  # --pr slice: gh pr view <prNum> --json number,labels,statusCheckRollup,body
-  pr\ view\ *\ --json\ number,labels,statusCheckRollup,body)
-    num=$(echo "$args" | awk '{print $3}')
+  # --pr slice: build_pr_section reads the PR object via gh_pr_view_rest (#2257),
+  # which GETs repos/{owner}/{repo}/pulls/<N>. The fixture is the RAW REST pull
+  # object (carries number, labels, body, and head.sha so headRefOid projects).
+  api\ */pulls/[0-9]*)
+    num=$(echo "$args" | grep -oE '[0-9]+' | tail -1)
     if [[ -f "$STUB_DIR/pr-view-${num}.json" ]]; then
       cat "$STUB_DIR/pr-view-${num}.json"
     else
-      echo "{\"number\":$num,\"labels\":[],\"statusCheckRollup\":[],\"body\":\"pr body\"}"
+      echo "{\"number\":$num,\"state\":\"open\",\"body\":\"pr body\",\"labels\":[],\"head\":{\"ref\":\"$num-branch\",\"sha\":\"sha-$num\"}}"
+    fi
+    ;;
+  # --pr slice CI verdict: dispatch_ci_verdict_rest fetches the head sha's
+  # check-runs via `gh api --paginate repos/{owner}/{repo}/commits/<sha>/check-runs`.
+  # $STUB_DIR/check-runs-<sha>.json supplies the raw REST (lowercase) check-runs
+  # object; the pr-view fixture's head.sha must match the <sha> here.
+  api\ --paginate\ */commits/*/check-runs)
+    sha=$(echo "$args" | sed -E 's#.*commits/([^/]+)/check-runs.*#\1#')
+    if [[ -f "$STUB_DIR/check-runs-${sha}.json" ]]; then
+      cat "$STUB_DIR/check-runs-${sha}.json"
+    else
+      echo '{"check_runs":[]}'
     fi
     ;;
   # --relations: blocked_by (array)
@@ -35746,15 +35762,20 @@ ctxpack_setup
 cat > "$CTXPACK_STUB/pr-list.json" <<'EOF'
 [{"number":42,"headRefName":"5-my-feature"}]
 EOF
-# gh pr view fixture: labels + all-SUCCESS rollup → ci: passing.
-# Status-context shape: {"state":"SUCCESS"} classifies passing without needing status/conclusion.
+# gh_pr_view_rest fixture (raw REST pull): labels + body + head.sha. The CI
+# verdict is computed by dispatch_ci_verdict_rest over the head.sha's check-runs;
+# two SUCCESS check-runs → ci: passing.
 cat > "$CTXPACK_STUB/pr-view-42.json" <<'EOF'
 {
   "number": 42,
+  "state": "open",
   "labels": [{"name":"dispatch:planned"},{"name":"size:medium"}],
-  "statusCheckRollup": [{"state":"SUCCESS"},{"state":"SUCCESS"}],
-  "body": "PR body text here."
+  "body": "PR body text here.",
+  "head": {"ref": "5-my-feature", "sha": "sha-pass-42"}
 }
+EOF
+cat > "$CTXPACK_STUB/check-runs-sha-pass-42.json" <<'EOF'
+{"check_runs": [{"status":"completed","conclusion":"success"},{"status":"completed","conclusion":"success"}]}
 EOF
 
 rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --pr 2>/dev/null) || rc=$?
@@ -35789,6 +35810,38 @@ else
   FAIL=$((FAIL+1)); echo "  FAIL: ctxpack --pr: no other section headers"
   echo "    actual: $out"
 fi
+ctxpack_teardown
+
+# ---------------------------------------------------------------------------
+# Test 3b: --pr CI verdict equivalence across failing / pending / empty (#2257)
+# ---------------------------------------------------------------------------
+# build_pr_section now derives `ci:` from dispatch_ci_verdict_rest over the PR
+# head sha's REST check-runs (was dispatch_classify_rollup over the porcelain
+# statusCheckRollup). These cases assert the printed verdict matches the
+# pre-migration classifier across ALL terminal states, including the
+# empty-check-runs edge (empty → pending), which both the old and new paths map
+# identically. DISPATCH_CI_VERDICT_CACHE is unset here, so every call fetches.
+ctxpack_ci_case() {
+  local label="$1" check_runs="$2" expected="$3"
+  cat > "$CTXPACK_STUB/pr-list.json" <<'EOF'
+[{"number":42,"headRefName":"5-my-feature"}]
+EOF
+  cat > "$CTXPACK_STUB/pr-view-42.json" <<EOF
+{"number":42,"state":"open","labels":[{"name":"x"}],"body":"b","head":{"ref":"5-my-feature","sha":"sha-ci-case"}}
+EOF
+  printf '%s\n' "$check_runs" > "$CTXPACK_STUB/check-runs-sha-ci-case.json"
+  local rc out
+  rc=0; out=$("$CTXPACK_DIR/dispatch-context-pack" 5 --pr 2>/dev/null) || rc=$?
+  assert_eq "ctxpack --pr ci ($label): exit 0" "0" "$rc"
+  assert_eq "ctxpack --pr ci ($label): ci: $expected" "yes" \
+    "$([[ "$out" == *"ci: $expected"* ]] && echo yes || echo no)"
+}
+
+echo "Test: ctxpack --pr ci verdict equivalence (failing/pending/empty)"
+ctxpack_setup
+ctxpack_ci_case "failing" '{"check_runs":[{"status":"completed","conclusion":"failure"}]}' "failing"
+ctxpack_ci_case "pending" '{"check_runs":[{"status":"in_progress","conclusion":null}]}' "pending"
+ctxpack_ci_case "empty → pending" '{"check_runs":[]}' "pending"
 ctxpack_teardown
 
 # ---------------------------------------------------------------------------
@@ -35943,7 +35996,11 @@ cat > "$CTXPACK_STUB/pr-list.json" <<'EOF'
 [{"number":20,"headRefName":"5-combo"}]
 EOF
 cat > "$CTXPACK_STUB/pr-view-20.json" <<'EOF'
-{"number":20,"labels":[],"statusCheckRollup":[],"body":"combo pr body"}
+{"number":20,"state":"open","labels":[],"body":"combo pr body","head":{"ref":"5-combo","sha":"sha-combo-20"}}
+EOF
+# Empty check-runs for the combo head sha → ci: pending (order test ignores it).
+cat > "$CTXPACK_STUB/check-runs-sha-combo-20.json" <<'EOF'
+{"check_runs":[]}
 EOF
 
 # Pass flags in REVERSE canonical order.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -478,6 +478,24 @@ case "$args" in
       echo "[]"
     fi
     ;;
+  api\ --paginate\ repos/*/issues/9[0-9][0-9][0-9]/comments)
+    # gh_issue_view_rest --comments sentinel branch (#2257): the helper's second
+    # REST call. The pattern REQUIRES the literal `--paginate` token, so a
+    # regression that drops --paginate no longer matches here — it falls through
+    # to the generic `*)` default (the issues/9xxx sentinel ends at the digits, so
+    # /comments does not match it), serving the wrong/empty body and turning the
+    # count assertion RED. The fixtures are MULTI-PAGE (cat'd in sequence, one
+    # array doc per page, like the check-runs --paginate stub), spanning >30
+    # comments total so the count assertion catches a non-paginating fetch.
+    num=$(printf '%s' "$args" | sed -E 's#.*issues/([0-9]+)/comments.*#\1#')
+    if [[ -f "$STUB_DIR/view-issue-comments-${num}-page1.json" ]]; then
+      cat "$STUB_DIR/view-issue-comments-${num}-page1.json"
+      [[ -f "$STUB_DIR/view-issue-comments-${num}-page2.json" ]] && \
+        cat "$STUB_DIR/view-issue-comments-${num}-page2.json"
+    else
+      echo '[]'
+    fi
+    ;;
   api\ repos/*/issues/9[0-9][0-9][0-9])
     # gh_issue_view_rest sentinel branch (#2255): single-issue GET has no label to
     # carry a sentinel, so reserve the 9xxx number range. MUST precede the generic
@@ -1424,6 +1442,8 @@ printf '%s\n' '{
   "title": "a sample issue",
   "body": "the issue body",
   "state": "open",
+  "state_reason": null,
+  "created_at": "2026-01-02T03:04:05Z",
   "labels": [
     {"id": 1, "name": "bug", "color": "ff0000", "description": "a bug"},
     {"id": 2, "name": "dispatch:planned", "color": "00ff00", "description": null}
@@ -1439,6 +1459,9 @@ assert_eq "issue: number" "9001" "$(jq -r '.number' <<<"$iv")"
 assert_eq "issue: title" "a sample issue" "$(jq -r '.title' <<<"$iv")"
 assert_eq "issue: body" "the issue body" "$(jq -r '.body' <<<"$iv")"
 assert_eq "issue: state upcased OPEN" "OPEN" "$(jq -r '.state' <<<"$iv")"
+assert_eq "issue: createdAt passthrough from created_at" "2026-01-02T03:04:05Z" "$(jq -r '.createdAt' <<<"$iv")"
+# state_reason null must be PRESERVED as null (not upcased, not coerced).
+assert_eq "issue: stateReason null preserved" "true" "$(jq '.stateReason == null' <<<"$iv")"
 assert_eq "issue: labels narrowed to [{name}] (2 labels)" "2" "$(jq '.labels | length' <<<"$iv")"
 assert_eq "issue: first label name" "bug" "$(jq -r '.labels[0].name' <<<"$iv")"
 assert_eq "issue: label objects carry ONLY name (no color key)" "1" "$(jq '.labels[0] | keys | length' <<<"$iv")"
@@ -1446,7 +1469,7 @@ assert_eq "issue: assignees narrowed to [{login}]" "alice" "$(jq -r '.assignees[
 assert_eq "issue: assignee objects carry ONLY login" "1" "$(jq '.assignees[0] | keys | length' <<<"$iv")"
 assert_eq "issue: raw REST extra field dropped" "" "$(jq -r '.extra_rest_field // empty' <<<"$iv")"
 # Top-level keys are exactly the porcelain set.
-assert_eq "issue: top-level key set" "assignees body labels number state title" \
+assert_eq "issue: top-level key set" "assignees body createdAt labels number state stateReason title" \
   "$(jq -r 'keys | join(" ")' <<<"$iv")"
 teardown
 
@@ -1457,11 +1480,20 @@ printf '%s\n' '{
   "title": "closed one",
   "body": "",
   "state": "closed",
+  "state_reason": "completed",
+  "created_at": "2026-02-03T04:05:06Z",
   "labels": [],
   "assignees": []
 }' > "$STUB_DIR/view-issue-9002.json"
 iv2=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 9002)
 assert_eq "issue: closed → CLOSED" "CLOSED" "$(jq -r '.state' <<<"$iv2")"
+# REST lowercase state_reason `completed` → porcelain UPPERCASE enum COMPLETED.
+assert_eq "issue: stateReason completed upcased to COMPLETED" "COMPLETED" "$(jq -r '.stateReason' <<<"$iv2")"
+# A second non-null case: not_planned → NOT_PLANNED.
+printf '%s\n' '{"number":9005,"title":"np","body":"","state":"closed","state_reason":"not_planned","created_at":"2026-03-01T00:00:00Z","labels":[],"assignees":[]}' \
+  > "$STUB_DIR/view-issue-9005.json"
+iv_np=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 9005)
+assert_eq "issue: stateReason not_planned upcased to NOT_PLANNED" "NOT_PLANNED" "$(jq -r '.stateReason' <<<"$iv_np")"
 # Byte-compat: a REST null body must surface as porcelain's empty string.
 printf '%s\n' '{"number":9004,"title":"t","state":"open","body":null,"labels":[],"assignees":[]}' \
   > "$STUB_DIR/view-issue-9004.json"
@@ -1500,6 +1532,33 @@ err_ivf=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 9001 2>&1 >/dev/null)
 assert_eq "issue: gh failure → non-zero" "1" "$rc_ivf"
 case "$err_ivf" in *"gh_issue_view_rest: gh api failed"*) mf=yes ;; *) mf=no ;; esac
 assert_eq "issue: gh-failure stderr names the helper" "yes" "$mf"
+teardown
+
+echo "Test: gh_issue_view_rest --comments -- paginated multi-page fetch, remapped shape"
+setup
+# No --comments flag → no second call, no comments key. (Reuse the 9001 fixture.)
+printf '%s\n' '{"number":9001,"title":"t","body":"b","state":"open","state_reason":null,"created_at":"2026-01-01T00:00:00Z","labels":[],"assignees":[]}' \
+  > "$STUB_DIR/view-issue-9001.json"
+iv_nc=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 9001)
+assert_eq "issue: no --comments → comments key absent" "false" "$(jq 'has("comments")' <<<"$iv_nc")"
+# Multi-page comments fixture: page 1 = 30 comments, page 2 = 5 comments (35 > 30,
+# so a non-paginating single-page fetch would miss page 2). Each comment is the
+# RAW REST shape (nested .user.login, snake_case .created_at) so the remap to
+# {author:{login}, createdAt, body} is genuinely exercised.
+jq -n '[range(30) | {user:{login:("u"+(.|tostring)), id:.}, created_at:("2026-01-01T00:00:0"+( . % 10 |tostring)+"Z"), body:("comment "+(.|tostring)), extra:"drop"}]' \
+  > "$STUB_DIR/view-issue-comments-9001-page1.json"
+jq -n '[range(30;35) | {user:{login:("u"+(.|tostring)), id:.}, created_at:"2026-02-01T00:00:00Z", body:("comment "+(.|tostring)), extra:"drop"}]' \
+  > "$STUB_DIR/view-issue-comments-9001-page2.json"
+ivc=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 9001 --comments)
+assert_eq "comments: full count across both pages (>30 proves pagination)" "35" "$(jq '.comments | length' <<<"$ivc")"
+assert_eq "comments: remapped author.login (nested from .user.login)" "u0" "$(jq -r '.comments[0].author.login' <<<"$ivc")"
+assert_eq "comments: remapped createdAt from .created_at" "2026-01-01T00:00:00Z" "$(jq -r '.comments[0].createdAt' <<<"$ivc")"
+assert_eq "comments: remapped body" "comment 0" "$(jq -r '.comments[0].body' <<<"$ivc")"
+assert_eq "comments: page-2 comment present (login)" "u34" "$(jq -r '.comments[34].author.login' <<<"$ivc")"
+assert_eq "comments: remapped object carries ONLY author/createdAt/body" "author body createdAt" \
+  "$(jq -r '.comments[0] | keys | join(" ")' <<<"$ivc")"
+assert_eq "comments: base projection keys still present alongside comments" "true" \
+  "$(jq '(has("number")) and (has("createdAt")) and (has("stateReason"))' <<<"$ivc")"
 teardown
 
 echo "Test: gh_pr_view_rest -- mergeable=true → MERGEABLE, clean→CLEAN, state upcase"


### PR DESCRIPTION
Closes #2257

## What

Migrates the remaining `gh issue view <N> --json …` / `gh pr view <N> --json …`
**reads** in `.claude/skills/dispatch-propagate/scripts/` from GraphQL porcelain
to the REST-backed drop-in helpers `gh_issue_view_rest` / `gh_pr_view_rest`. The
dispatch fleet exhausts GitHub's shared GraphQL rate-limit bucket while the REST
bucket sits idle; `gh issue view` / `gh pr view` spend GraphQL, the helpers spend
REST.

## Why

Part of epic #2254. Each migrated read now spends the idle REST bucket instead of
the contended GraphQL bucket, while preserving the exact projected shape and
end-to-end behavior its call sites consumed before.

## How (units)

1. **Extend `gh_issue_view_rest`** — add `createdAt` + `stateReason`
   (unconditional) to the projection and an opt-in `--comments` flag that makes a
   second *paginated* REST call (slurp idiom, not the non-paginating
   `gh_api_array`) and merges a `comments:[{author:{login},createdAt,body}]`
   array.
2. **Extend `gh_pr_view_rest`** — add `headRefName`, `headRefOid`, and
   `labels:[{name}]` (unconditional).
3. **Category-A issue read swaps** — labels/state/title consumers plus the
   `-q`/`--jq` code-edit sites (`dispatch-route`, `dispatch-close-resolved`,
   `dispatch-finalize-phase`) and `issue-sub-issues` (now a fixed REST
   projection; the per-call `FIELDS` arg is retired).
4. **Category-B `createdAt` + `comments` swaps** — `dispatch-digest-window`,
   `dispatch-drift-scan`, and the comment-rendering wrappers
   (`dispatch-context-pack` `build_issue_section`, `issue-primary`,
   `issue-parent`, `issue-blocking`, `issue-siblings` open branch). Rendered
   comment output stays byte-identical.
5. **PR read swaps** — `dispatch-resolve-worktree` `resolve_pr_head` and
   `dispatch-context-pack` `build_pr_section`, the latter computing the CI verdict
   via `dispatch_ci_verdict_rest <headRefOid>` instead of
   `dispatch_classify_rollup` over `statusCheckRollup`. The printed `ci:` verdict
   stays byte-identical across passing / failing / pending **and** the
   empty-checks edge (both map an empty check set to `pending`).

Each unit extends or flips its own byte-compat key-set assertions and stub
fixtures in `test-dispatch-scripts.sh` (the 9000–9099 sentinel range), which are
intended tripwires when a projection grows.

## Out of scope

`gh issue edit` / `gh pr edit` **mutations** and the close/create/comment/merge
operations are not part of this work — the issue body scopes the view reads (an
epic-sibling title/body off-by-one). The documented GraphQL-only exemptions stay
as porcelain (no REST equivalent): `closingIssuesReferences`
(`dispatch-open-pr`, `dispatch-resolve-arg`) and `closedByPullRequestsReferences`
(`dispatch-find-pr`).

## Verification

- `test-dispatch-scripts.sh` passes (CI-equivalent shell suite).
- Acceptance grep confirms no live `gh issue view` / `gh pr view` porcelain reads
  remain — every remaining match is a code comment or diagnostic string, plus the
  documented GraphQL-only exemptions.
