### PR TITLE
dispatch-stamp-session: preserve session-start base_sha across resume

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-stamp-session
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-stamp-session
@@ -32,9 +32,10 @@
 # detached `HEAD`, and any `office-hours-*` branch. A no-op emits at most one
 # short stderr diagnostic and exits 0 — it must NEVER block session start.
 #
-# Mode A is idempotent w.r.t. a backfilled pr: if the sidecar already exists and
-# carries a non-null `.pr`, that value is preserved (everything else is
-# re-derived); otherwise `pr` is written as null.
+# Mode A is idempotent w.r.t. session-start state: if the sidecar already exists,
+# `base_sha` (session-start audit anchor) and a non-null `.pr` (from a prior
+# --backfill-pr) are preserved; `stamped_at` and other git-sourced fields
+# re-derive on every stamp.
 #
 # Mode B — PR backfill (run once a PR number is known). Locates the sidecar by
 # the session id (a UUID) under the projects root via a maxdepth-2 find, then
@@ -238,15 +239,25 @@ fi
 # Locate the sidecar path: transcript with .jsonl → .dispatch-stamp.json.
 sidecar="${TRANSCRIPT_PATH%.jsonl}.dispatch-stamp.json"
 
-# Idempotency: a re-run re-derives every git-sourced field (repo/issue/branch/
-# base_sha) and the timestamp, but must PRESERVE a non-null `.pr` written by a
-# prior --backfill-pr — a re-stamp must never clobber a known PR number back to
-# null. Only `.pr` is carried forward; nothing else is preserved.
+# Idempotency: Mode A runs on both `startup` and `resume`. `base_sha` is one of
+# the audit join keys {repo, issue, pr, base_sha} and must anchor the session's
+# STARTING ground truth — a resume after committed work must NOT advance it to
+# the post-resume HEAD. When the sidecar already exists, preserve its `base_sha`
+# (and a non-null `.pr` from a prior `--backfill-pr`); only the first (startup)
+# write derives `base_sha` from HEAD. `repo`/`issue`/`branch` are stable within
+# a session and are harmlessly re-derived. `stamped_at` deliberately DOES
+# re-derive on every stamp: unlike `base_sha` it is not a join key (not carried
+# into the audit `artifact` record), so it records the most-recent stamp time,
+# not session start.
 pr=null
 if [[ -f "$sidecar" ]]; then
   existing_pr=$(jq '.pr' "$sidecar" 2>/dev/null || echo null)
   if [[ -n "$existing_pr" && "$existing_pr" != "null" ]]; then
     pr="$existing_pr"
+  fi
+  existing_base_sha=$(jq -r '.base_sha // empty' "$sidecar" 2>/dev/null || echo "")
+  if [[ -n "$existing_base_sha" ]]; then
+    base_sha="$existing_base_sha"
   fi
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -38455,7 +38455,9 @@ STAMP="$SCRIPT_DIR/dispatch-stamp-session"
   rm -rf "$root"
 )
 
-# 6. Idempotent re-write preserves a set .pr (does not clobber to null).
+# 6. Idempotent re-write preserves a set .pr (does not clobber to null),
+#    preserves session-start .base_sha (not advanced to post-resume HEAD),
+#    and advances .stamped_at (re-derived, not preserved).
 (
   d=$(mktemp -d)
   git -C "$d" init -q
@@ -38463,12 +38465,14 @@ STAMP="$SCRIPT_DIR/dispatch-stamp-session"
   git -C "$d" checkout -q -b 999-fixture
   git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
   sc="$d/sess6.dispatch-stamp.json"
-  # Seed a sidecar that already carries a backfilled pr.
+  # Seed a sidecar that already carries a backfilled pr and a session-start base_sha.
   printf '%s\n' '{"schema":1,"session_id":"sess6","repo":"old/repo","issue":1,"pr":4242,"branch":"old","base_sha":"old","stamped_at":"2026-01-01T00:00:00Z"}' > "$sc"
   ( cd "$d" && "$STAMP" --session-id sess6 --transcript-path "$d/sess6.jsonl" )
   assert_eq "stamp: re-write preserves set .pr" "4242" "$(jq -r .pr "$sc")"
   assert_eq "stamp: re-write re-derives .branch" "999-fixture" "$(jq -r .branch "$sc")"
-  assert_eq "stamp: re-write re-derives .base_sha" "$(git -C "$d" rev-parse HEAD)" "$(jq -r .base_sha "$sc")"
+  assert_eq "stamp: re-write PRESERVES session-start .base_sha" "old" "$(jq -r .base_sha "$sc")"
+  assert_eq "stamp: re-write advances .stamped_at (re-derived, not preserved)" "differs" \
+    "$([ "$(jq -r .stamped_at "$sc")" != "2026-01-01T00:00:00Z" ] && echo differs || echo same)"
   rm -rf "$d"
 )
 

--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -192,7 +192,7 @@ These slices are yield metrics, not cost metrics — they do not sort into the r
 
 Each dispatch worker session writes a sidecar file next to its transcript before it starts work. `aggregate-usage.sh` reads the sidecar and surfaces its contents on every entry in `.sessions[]` as the `artifact` field. The join is by transcript stem: `<session-id>.jsonl` and `<session-id>.dispatch-stamp.json` share the same stem, so the script locates the sidecar from the transcript path directly — no separate index or lookup is needed.
 
-**`artifact`** — present on every `.sessions[]` entry. It is the sidecar record `{repo, issue, pr, base_sha, branch}`, or `null` for sessions with no sidecar (subagent transcripts, router ticks, pre-#1861 worker sessions, and any non-worker session that did not write one). The four primary join keys are `{repo, issue, pr, base_sha}`; `branch` is also present for human-readable context.
+**`artifact`** — present on every `.sessions[]` entry. It is the sidecar record `{repo, issue, pr, base_sha, branch}`, or `null` for sessions with no sidecar (subagent transcripts, router ticks, pre-#1861 worker sessions, and any non-worker session that did not write one). The four primary join keys are `{repo, issue, pr, base_sha}`; `branch` is also present for human-readable context. `base_sha` is the worktree HEAD at session start — preserved across resume — so it anchors each session to the repository state it began from.
 
 **jq slices against `tmp/usage-audit.json`:**
 


### PR DESCRIPTION
Closes #2264

## Problem

`dispatch-stamp-session` writes a per-session sidecar recording the GitHub
artifact each dispatch worker acted on. `dispatch-token-audit` joins each
session to its real-world outcome on the four primary keys `{repo, issue, pr,
base_sha}`, where `base_sha` is meant to anchor the session to the repository
state it *started* from.

Mode A (the session-start write) runs on both `startup` and `resume`. PR #2252,
while adding path-traversal validation, rewrote the idempotency block and dropped
the preservation of `base_sha` from the session-start write — its replacement
comment stated "Only `.pr` is carried forward; nothing else is preserved." As a
result, a session that resumes after committing work re-derives `base_sha` from
the post-resume HEAD, so the join key reflects the most-recent-stamp HEAD rather
than session-start ground truth — non-deterministic and useless as a stable join
key (unlike `repo`/`issue`/`pr`, which do not move mid-session).

## Fix

Restore the session-start preservation of `base_sha` across resume (acceptance
Option 1). When the sidecar already exists, the re-stamp now preserves its
`base_sha`; only the first (startup) write derives `base_sha` from HEAD.

`stamped_at` deliberately keeps the re-derive behavior #2252 introduced: it is
**not** a join key and is **not** carried into the audit `artifact` record, so it
correctly records the most-recent stamp time, not session start. The script and
the audit SKILL.md now document this intentional `base_sha`-vs-`stamped_at`
temporal split.

This is **not** a revert of #2252 — its path-traversal validation stays; only the
`base_sha` preservation is restored.

## Changes

- `dispatch-stamp-session`: re-add the `base_sha` preserve in the idempotency
  block; rewrite the block comment and header note to document the restored
  invariant and the `base_sha`-vs-`stamped_at` split.
- `test-dispatch-scripts.sh` (test #6): correct the idempotency assertion in
  lockstep — `base_sha` must be PRESERVED (was asserting the regressed re-derive
  behavior), plus a new assertion that `stamped_at` advances.
- `dispatch-token-audit/SKILL.md`: document that `base_sha` is the session-start
  HEAD, preserved across resume.

## Verification

The dispatch script test suite (what CI runs) passes: 3894/3894, including the
corrected preserve assertion and the new `stamped_at`-advances assertion.
