### PR TITLE
dispatch-stamp-session: preserve base_sha across re-stamps

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-stamp-session
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-stamp-session
@@ -32,9 +32,11 @@
 # detached `HEAD`, and any `office-hours-*` branch. A no-op emits at most one
 # short stderr diagnostic and exits 0 — it must NEVER block session start.
 #
-# Mode A is idempotent w.r.t. a backfilled pr: if the sidecar already exists and
-# carries a non-null `.pr`, that value is preserved (everything else is
-# re-derived); otherwise `pr` is written as null.
+# Mode A is idempotent w.r.t. a backfilled pr and the session-start base_sha: if
+# the sidecar already exists, a non-null `.pr` and a non-empty `.base_sha` are
+# preserved (base_sha stays the session-start anchor across resumes); the
+# remaining git-sourced fields and the timestamp are re-derived. When no prior
+# sidecar exists, `pr` is written as null and base_sha is the current HEAD.
 #
 # Mode B — PR backfill (run once a PR number is known). Locates the sidecar by
 # the session id (a UUID) under the projects root via a maxdepth-2 find, then
@@ -238,15 +240,21 @@ fi
 # Locate the sidecar path: transcript with .jsonl → .dispatch-stamp.json.
 sidecar="${TRANSCRIPT_PATH%.jsonl}.dispatch-stamp.json"
 
-# Idempotency: a re-run re-derives every git-sourced field (repo/issue/branch/
-# base_sha) and the timestamp, but must PRESERVE a non-null `.pr` written by a
-# prior --backfill-pr — a re-stamp must never clobber a known PR number back to
-# null. Only `.pr` is carried forward; nothing else is preserved.
+# Idempotency: a re-run re-derives the remaining git-sourced fields (repo/issue/
+# branch) and the timestamp, but must PRESERVE both a non-null `.pr` written by a
+# prior --backfill-pr (a re-stamp must never clobber a known PR number back to
+# null) and the `.base_sha` from the initial startup write (so it remains the
+# session-start anchor across resumes, even after an ff-merge moves HEAD). `.pr`
+# and `.base_sha` are carried forward; nothing else is preserved.
 pr=null
 if [[ -f "$sidecar" ]]; then
   existing_pr=$(jq '.pr' "$sidecar" 2>/dev/null || echo null)
   if [[ -n "$existing_pr" && "$existing_pr" != "null" ]]; then
     pr="$existing_pr"
+  fi
+  existing_base_sha=$(jq -r '.base_sha // empty' "$sidecar" 2>/dev/null || true)
+  if [[ -n "$existing_base_sha" ]]; then
+    base_sha="$existing_base_sha"
   fi
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -38455,7 +38455,8 @@ STAMP="$SCRIPT_DIR/dispatch-stamp-session"
   rm -rf "$root"
 )
 
-# 6. Idempotent re-write preserves a set .pr (does not clobber to null).
+# 6. Idempotent re-write preserves a set .pr (does not clobber to null) and the
+#    seeded .base_sha (the session-start anchor); .branch is still re-derived.
 (
   d=$(mktemp -d)
   git -C "$d" init -q
@@ -38468,7 +38469,32 @@ STAMP="$SCRIPT_DIR/dispatch-stamp-session"
   ( cd "$d" && "$STAMP" --session-id sess6 --transcript-path "$d/sess6.jsonl" )
   assert_eq "stamp: re-write preserves set .pr" "4242" "$(jq -r .pr "$sc")"
   assert_eq "stamp: re-write re-derives .branch" "999-fixture" "$(jq -r .branch "$sc")"
-  assert_eq "stamp: re-write re-derives .base_sha" "$(git -C "$d" rev-parse HEAD)" "$(jq -r .base_sha "$sc")"
+  assert_eq "stamp: re-write preserves seeded .base_sha" "old" "$(jq -r .base_sha "$sc")"
+  rm -rf "$d"
+)
+
+# 7. Resume after HEAD moves (ff-merge) preserves the session-start .base_sha.
+#    This encodes #2270's failure mode: an initial stamp records HEAD=A; a later
+#    git merge --ff-only moves HEAD to B; the resume re-stamp must keep base_sha=A.
+(
+  d=$(mktemp -d)
+  git -C "$d" init -q
+  git -C "$d" remote add origin https://github.com/natb1/commons.systems.git
+  git -C "$d" checkout -q -b 999-fixture
+  git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  A=$(git -C "$d" rev-parse HEAD)
+  # Initial stamp at HEAD=A.
+  ( cd "$d" && "$STAMP" --session-id sess7 --transcript-path "$d/sess7.jsonl" )
+  sc="$d/sess7.dispatch-stamp.json"
+  assert_eq "stamp: initial .base_sha is A" "$A" "$(jq -r .base_sha "$sc")"
+  # HEAD moves to B (simulating an ff-merge of origin/main).
+  git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m advance
+  B=$(git -C "$d" rev-parse HEAD)
+  assert_eq "stamp: HEAD advanced (B != A)" "no" \
+    "$([ "$A" = "$B" ] && echo yes || echo no)"
+  # Resume re-stamp must preserve A, not adopt B.
+  ( cd "$d" && "$STAMP" --session-id sess7 --transcript-path "$d/sess7.jsonl" )
+  assert_eq "stamp: resume preserves session-start .base_sha (A, not B)" "$A" "$(jq -r .base_sha "$sc")"
   rm -rf "$d"
 )
 

--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -192,7 +192,7 @@ These slices are yield metrics, not cost metrics — they do not sort into the r
 
 Each dispatch worker session writes a sidecar file next to its transcript before it starts work. `aggregate-usage.sh` reads the sidecar and surfaces its contents on every entry in `.sessions[]` as the `artifact` field. The join is by transcript stem: `<session-id>.jsonl` and `<session-id>.dispatch-stamp.json` share the same stem, so the script locates the sidecar from the transcript path directly — no separate index or lookup is needed.
 
-**`artifact`** — present on every `.sessions[]` entry. It is the sidecar record `{repo, issue, pr, base_sha, branch}`, or `null` for sessions with no sidecar (subagent transcripts, router ticks, pre-#1861 worker sessions, and any non-worker session that did not write one). The four primary join keys are `{repo, issue, pr, base_sha}`; `branch` is also present for human-readable context.
+**`artifact`** — present on every `.sessions[]` entry. It is the sidecar record `{repo, issue, pr, base_sha, branch}`, or `null` for sessions with no sidecar (subagent transcripts, router ticks, pre-#1861 worker sessions, and any non-worker session that did not write one). The four primary join keys are `{repo, issue, pr, base_sha}`; `branch` is also present for human-readable context. `base_sha` reflects the session-start HEAD and is preserved across re-stamps, so it stays a stable anchor for a resumed session even after an ff-merge of origin/main moves HEAD.
 
 **jq slices against `tmp/usage-audit.json`:**
 


### PR DESCRIPTION
Closes #2270

## Summary

`dispatch-stamp-session` writes a per-session sidecar
(`<transcript>.dispatch-stamp.json`) recording the GitHub artifact a worker acted
on — `{repo, issue, pr, branch, base_sha}` — so the token audit can join a
session to its real-world outcome. It runs at session start **and on resume**.

The idempotency block preserved only `.pr` across re-runs; every git-sourced
field, including `base_sha`, was re-derived from current worktree state on each
call. A worker that resumes after a routine `git merge --ff-only origin/main` has
a moved HEAD, so `git rev-parse HEAD` returns the post-merge SHA. The re-stamp
silently overwrote the original `base_sha`, and the session-start anchor became
unrecoverable — audit joins on `base_sha` then saw wrong data for any resumed
session.

The token-audit `SKILL.md` already documents `base_sha` as one of the primary
join keys, implying it reflects the SHA the session **started from**. This change
makes the implementation match the documented contract (Option A, the issue's
preferred fix), rather than weakening the doc to match a buggy implementation.

## Changes

- **`dispatch-stamp-session`** — in the idempotency block, carry forward the
  existing sidecar's `.base_sha` when present and non-empty, mirroring the
  existing `.pr` preservation. The first-write HEAD derivation is unchanged
  (correct when no prior sidecar exists). Two header comments updated to state
  `base_sha` is now preserved as the session-start anchor.
- **`test-dispatch-scripts.sh`** — corrected test 6's `.base_sha` assertion from
  re-derive to preservation (correcting a test to the fixed spec), and added a
  new test that moves HEAD between the initial stamp and the resume re-stamp,
  encoding the issue's actual ff-merge failure mode and asserting the
  session-start `base_sha` is retained.
- **`dispatch-token-audit/SKILL.md`** — clarified the `base_sha` join-key
  description: it reflects the session-start HEAD and is preserved across
  re-stamps, so it stays a stable anchor for resumed sessions.

## Scope boundary

The separate `base_sha` field in the #1860 outcome envelope
(`dispatch-emit-outcome` / `outcome-envelope.md`) is a different field with
different semantics ("the merge base the phase ran against") and is out of scope.

## Verification

The bash unit suite (run directly by CI's `hook-tests` job) is green; the
corrected and added stamp-session assertions pass.
