### PR TITLE
audio: bound enrichment file-read concurrency to cap peak memory

### DIFF
--- a/audio/src/concurrency.ts
+++ b/audio/src/concurrency.ts
@@ -13,6 +13,7 @@ export async function mapWithConcurrency<T, R>(
   limit: number,
   fn: (item: T, index: number) => Promise<R>,
 ): Promise<R[]> {
+  if (limit <= 0) throw new Error('mapWithConcurrency: limit must be > 0');
   const results = new Array<R>(items.length);
   let next = 0;
   async function worker(): Promise<void> {

--- a/audio/src/concurrency.ts
+++ b/audio/src/concurrency.ts
@@ -1,0 +1,27 @@
+/**
+ * Run `fn` over `items` with at most `limit` invocations in flight at once,
+ * returning results in input order. A sliding-window worker pool: `limit`
+ * workers share a cursor, so a slow item never stalls the others and peak
+ * concurrency is capped at exactly `limit` (the point — it bounds peak
+ * memory when `fn` allocates per item, e.g. reading a file into an
+ * ArrayBuffer). Order is preserved by indexed assignment, independent of
+ * completion order. Rejection semantics match `Promise.all`: the first
+ * rejection propagates and in-flight workers are not cancelled.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await fn(items[i], i);
+    }
+  }
+  const workerCount = Math.max(0, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}

--- a/audio/src/local-source.ts
+++ b/audio/src/local-source.ts
@@ -393,7 +393,7 @@ async function enrichLocalItems(items: LibraryItem[]): Promise<void> {
   const results = await mapWithConcurrency(
     items,
     ENRICH_READ_CONCURRENCY,
-    (item) => enrichLocalItem(item),
+    enrichLocalItem,
   );
   const newEntries = Object.fromEntries(
     results.filter((r) => r.entry !== null).map((r) => r.entry as [string, CachedMetadata]),

--- a/audio/src/local-source.ts
+++ b/audio/src/local-source.ts
@@ -23,10 +23,15 @@ import {
   setLocalDirectory,
 } from "./sidecar.js";
 import { extractAudioMetadata } from "./local-metadata.js";
+import { mapWithConcurrency } from "./concurrency.js";
 import { AUDIO_FORMATS } from "./types.js";
 import type { AudioFormat, AudioTags, LibraryItem } from "./types.js";
 
 const PURPOSE = "library-folder";
+/** Peak simultaneous file reads during enrichment. Each uncached file is
+ * read fully into an ArrayBuffer before tag extraction; bounding this caps
+ * peak memory so large folders don't OOM on low-RAM (≤2GB) devices. */
+const ENRICH_READ_CONCURRENCY = 16;
 const store = createFsaHandleStore({ app: "audio" });
 
 const MIME_TYPES: Record<AudioFormat, string> = {
@@ -353,7 +358,11 @@ async function enrichLocalItem(item: LibraryItem): Promise<EnrichResult> {
 }
 
 async function enrichLocalItems(items: LibraryItem[]): Promise<LibraryItem[]> {
-  const results = await Promise.all(items.map((item) => enrichLocalItem(item)));
+  const results = await mapWithConcurrency(
+    items,
+    ENRICH_READ_CONCURRENCY,
+    (item) => enrichLocalItem(item),
+  );
   const newEntries = Object.fromEntries(
     results.filter((r) => r.entry !== null).map((r) => r.entry as [string, AudioTags]),
   );

--- a/audio/test/concurrency.test.ts
+++ b/audio/test/concurrency.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { mapWithConcurrency } from "../src/concurrency.js";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("mapWithConcurrency", () => {
+  it("caps peak concurrency at exactly limit and preserves input order", async () => {
+    const items = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const limit = 3;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const release: Array<() => void> = [];
+
+    const fn = async (x: number) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise<void>((res) => release.push(res));
+      inFlight--;
+      return x * 2;
+    };
+
+    const call = mapWithConcurrency(items, limit, fn);
+
+    // Let the pool launch its initial window.
+    await tick();
+    expect(inFlight).toBe(3);
+
+    // Drain: as each in-flight item resolves, a worker pulls the next item and
+    // pushes a fresh release resolver — so keep going while any are pending.
+    while (release.length > 0) {
+      release.shift()!();
+      await tick();
+    }
+
+    const result = await call;
+    expect(result).toEqual(items.map((x) => x * 2));
+    expect(maxInFlight).toBe(3);
+  });
+
+  it("returns [] and never calls fn for empty input", async () => {
+    const fn = vi.fn(async (x: number) => x);
+    const result = await mapWithConcurrency([], 4, fn);
+    expect(result).toEqual([]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("handles limit >= length, preserving order", async () => {
+    const items = [1, 2, 3];
+    const result = await mapWithConcurrency(items, 10, async (x) => x * 2);
+    expect(result).toEqual([2, 4, 6]);
+  });
+});

--- a/audio/test/concurrency.test.ts
+++ b/audio/test/concurrency.test.ts
@@ -49,4 +49,13 @@ describe("mapWithConcurrency", () => {
     const result = await mapWithConcurrency(items, 10, async (x) => x * 2);
     expect(result).toEqual([2, 4, 6]);
   });
+
+  it("propagates the first rejection (matches Promise.all semantics)", async () => {
+    await expect(
+      mapWithConcurrency([1, 2, 3], 2, async (x) => {
+        if (x === 1) throw new Error("boom");
+        return x;
+      }),
+    ).rejects.toThrow("boom");
+  });
 });

--- a/audio/test/concurrency.test.ts
+++ b/audio/test/concurrency.test.ts
@@ -28,7 +28,7 @@ describe("mapWithConcurrency", () => {
     // Drain: as each in-flight item resolves, a worker pulls the next item and
     // pushes a fresh release resolver — so keep going while any are pending.
     while (release.length > 0) {
-      release.shift()!();
+      release.shift()?.();
       await tick();
     }
 

--- a/audio/test/local-source.test.ts
+++ b/audio/test/local-source.test.ts
@@ -439,4 +439,44 @@ describe("enrichment", () => {
     // good file is present
     expect(batchArg["tune.flac"]).toEqual({ artist: "Y" });
   });
+
+  it("bounded enrichment over many files: entry-set identical to unbounded (cached excluded, uncached extracted)", async () => {
+    // 40 files > ENRICH_READ_CONCURRENCY (16) so multiple windows run.
+    const entries = Array.from({ length: 40 }, (_, i) => fileEntry(`track${i}.mp3`, 1000 + i));
+    const handle = fakeDir(entries);
+    connectDir(handle);
+
+    // Even-indexed files are already cached; odd-indexed are uncached.
+    const preCached = new Set<string>();
+    const uncached = new Set<string>();
+    for (let i = 0; i < 40; i++) {
+      const name = `track${i}.mp3`;
+      if (i % 2 === 0) preCached.add(name);
+      else uncached.add(name);
+    }
+
+    mockGetMetadata.mockImplementation(async (name: string) =>
+      preCached.has(name) ? { artist: "cached" } : undefined,
+    );
+    mockExtract.mockResolvedValue({ artist: "fresh" });
+    mockCacheMetadataBatch.mockResolvedValue(undefined);
+
+    const mod = await loadModule();
+    await mod.connectLocalFolder();
+    await mod.enrichLocalTracks();
+
+    // Exactly one batched write.
+    expect(mockCacheMetadataBatch).toHaveBeenCalledTimes(1);
+    const batchArg = mockCacheMetadataBatch.mock.calls[0][0] as Record<string, unknown>; // type-safety-ok: mock-call introspection in test
+
+    // Batch key set equals the uncached set exactly (cached excluded).
+    expect(new Set(Object.keys(batchArg))).toEqual(uncached);
+    for (const name of preCached) {
+      expect(name in batchArg).toBe(false);
+    }
+    // Each uncached entry carries its extracted tag.
+    for (const name of uncached) {
+      expect(batchArg[name]).toEqual({ artist: "fresh" });
+    }
+  });
 });

--- a/audio/test/local-source.test.ts
+++ b/audio/test/local-source.test.ts
@@ -653,9 +653,11 @@ describe("enrichment", () => {
       else uncached.add(name);
     }
 
-    mockGetMetadata.mockImplementation(async (name: string) =>
-      preCached.has(name) ? { artist: "cached" } : undefined,
-    );
+    mockGetMetadata.mockImplementation(async (name: string) => {
+      if (!preCached.has(name)) return undefined;
+      const i = parseInt(name.replace(/^track/, "").replace(/\.mp3$/, ""), 10);
+      return { tags: { artist: "cached" }, size: bytes(name).byteLength, lastModified: 1000 + i };
+    });
     mockExtract.mockResolvedValue({ artist: "fresh" });
     mockCacheMetadataBatch.mockResolvedValue(undefined);
 
@@ -672,9 +674,14 @@ describe("enrichment", () => {
     for (const name of preCached) {
       expect(name in batchArg).toBe(false);
     }
-    // Each uncached entry carries its extracted tag.
+    // Each uncached entry carries its extracted tag plus the content fingerprint.
     for (const name of uncached) {
-      expect(batchArg[name]).toEqual({ artist: "fresh" });
+      const i = parseInt(name.replace(/^track/, "").replace(/\.mp3$/, ""), 10);
+      expect(batchArg[name]).toEqual({
+        tags: { artist: "fresh" },
+        size: bytes(name).byteLength,
+        lastModified: 1000 + i,
+      });
     }
   });
 });


### PR DESCRIPTION
Closes #2302

## Problem

The audio app's local-folder enrichment pass `enrichLocalItems` (`audio/src/local-source.ts`) ran a flat `await Promise.all(items.map((item) => enrichLocalItem(item)))`. Each `enrichLocalItem` reads the **entire** audio file into an `ArrayBuffer` before extracting tags, so the flat `Promise.all` allocates **every** uncached file's buffer simultaneously. On a folder with hundreds or thousands of tracks, peak memory scaled with total uncached file size — risking OOM crashes or tab kills during cold-start enrichment on constrained devices (mobile browsers, ≤2 GB-RAM desktops).

Deferred from PR #1839 as an in-scope architectural change that was out of that PR's scope.

## Change

- **New `audio/src/concurrency.ts`** — a generic, dependency-free `mapWithConcurrency<T, R>(items, limit, fn)`: a sliding-window worker pool where `limit` workers share a cursor over an indexed result array. Peak concurrency is capped at exactly `limit`, a slow item never stalls the others, and results are returned in input order (indexed assignment, independent of completion order). Rejection semantics match `Promise.all`. The monorepo has no existing concurrency-limiting utility, so this is written fresh and local to the audio app.

- **`audio/src/local-source.ts`** — route `enrichLocalItems` through the helper with a fixed cap (`ENRICH_READ_CONCURRENCY = 16`). Only the mapping line changed; the `newEntries` build, write-suppression behavior, the single batched `cacheMetadataBatch` write, and the returned-items order are preserved verbatim, so output is byte-for-byte identical to before. `enrichLocalItem` is unchanged.

Peak enrichment memory is now bounded at roughly `ENRICH_READ_CONCURRENCY × typical-file-size` regardless of folder size.

## Tests

- **New `audio/test/concurrency.test.ts`** — deterministic proof of the bound using an in-flight counter and a manual release queue: the cap is both respected and fully reached (`maxInFlight === 3` exactly for 10 items at limit 3), order is preserved, empty input invokes `fn` zero times, and `limit >= length` degrades to unbounded correctly.
- **One equivalence test added to `audio/test/local-source.test.ts`** — 40 files (> the cap of 16, so multiple windows run) with a mix of pre-cached and uncached files; asserts the single batched write is preserved and the entry-set is identical to the unbounded behavior (cached files excluded, every uncached file included with its extracted tag).
- The three existing enrichment tests stay green — the bounded path preserves the batch-build/return logic verbatim.

`npx vitest run --project audio --root .` → 234 passed, 1 skipped (pre-existing).

## Out of scope

An identical pattern exists in `print/src/local-folder-ui.ts` (`Promise.all(targets.map((t) => enrichLocalItem(t)))`). It is deliberately not touched here — per the single-PR-per-leaf convention it belongs in a separate follow-up, and it could not reuse `audio/src/concurrency.ts` across the app boundary without a shared package.

The acceptance criterion that a 500+ track folder completes enrichment without OOM on a ≤2 GB-RAM device is a manual/memory-profiler check left for QA.
