### PR TITLE
audio: snapshot dirHandle in enqueueWrite to fix stale-handle TOCTOU on folder switch

### DIFF
--- a/audio/src/sidecar.ts
+++ b/audio/src/sidecar.ts
@@ -259,7 +259,11 @@ let writeChain: Promise<void> = Promise.resolve();
 /**
  * Store the retained directory handle and writable flag (called by Unit 3 after
  * the folder is picked / permission resolved). Invalidates the cached model so
- * the next access re-reads lazily from the new handle.
+ * the next access re-reads lazily from the new handle. The
+ * `writeChain = Promise.resolve()` reset only detaches FUTURE enqueues from the
+ * old chain; it does NOT stop an already-enqueued stale write — that is the job
+ * of the `enqueueWrite` snapshot guard, which skips any task whose bound handle
+ * no longer matches the live one.
  */
 export function setLocalDirectory(handle: FileSystemDirectoryHandle, isWritable: boolean): void {
   dirHandle = handle;
@@ -271,9 +275,13 @@ export function setLocalDirectory(handle: FileSystemDirectoryHandle, isWritable:
 
 /**
  * Unbind the directory (called when the folder is disconnected). Drops the
- * handle, marks not-writable, and resets the cache + write chain so an in-flight
- * write enqueued before disconnect cannot target the now-stale folder and the
- * next access re-loads an empty model.
+ * handle, marks not-writable, and resets the cache + write chain. The
+ * `writeChain = Promise.resolve()` reset only detaches FUTURE enqueues from the
+ * old chain — it does NOT cancel an already-enqueued write, which still runs.
+ * What prevents a stale write from landing in a later-connected folder is the
+ * `enqueueWrite` snapshot guard: an orphaned task whose snapshot handle no
+ * longer matches the live `dirHandle` is skipped. The cache reset makes the
+ * next access re-load an empty model.
  */
 export function clearLocalDirectory(): void {
   dirHandle = null;
@@ -311,13 +319,22 @@ export async function ensureLoaded(): Promise<SidecarData> {
  * per-link catch keeps one failed write from poisoning the chain.
  */
 function enqueueWrite(patch: SidecarPatch): Promise<void> {
+  const snapshotHandle = dirHandle;
+  const snapshotWritable = writable;
   writeChain = writeChain
     .then(async () => {
+      // TOCTOU guard: if the bound directory changed between enqueue and
+      // execution (rapid disconnect/reconnect), this patch was issued for the
+      // previous folder — skip it entirely so it neither persists to the new
+      // folder nor contaminates the new folder's in-memory model.
+      if (dirHandle !== snapshotHandle) return;
       const model = await ensureLoaded();
       const merged = mergeSidecar(model, patch);
       cachedModel = merged;
-      if (writable && dirHandle !== null) {
-        await writeSidecar(dirHandle, merged);
+      // Persist to the SNAPSHOT handle (not the live global), so a switch that
+      // races in after the guard still writes to the folder this patch was for.
+      if (snapshotWritable && snapshotHandle !== null) {
+        await writeSidecar(snapshotHandle, merged);
       }
     })
     .catch((err) => {

--- a/audio/test/sidecar.test.ts
+++ b/audio/test/sidecar.test.ts
@@ -684,17 +684,21 @@ describe("folder switch — stale-handle TOCTOU", () => {
 
     setLocalDirectory(dirA, true);
     // task_A snapshots A; its body is a pending microtask.
-    void cacheMetadata("a.mp3", { title: "A", duration: 100 });
+    void cacheMetadata("a.mp3", { tags: { title: "A", duration: 100 }, size: 1, lastModified: 1 });
     // Switch to B synchronously, before task_A's body runs.
     setLocalDirectory(dirB, true);
-    void cacheMetadata("b.mp3", { title: "B", duration: 200 });
+    void cacheMetadata("b.mp3", { tags: { title: "B", duration: 200 }, size: 2, lastModified: 2 });
     await flushWrites();
 
-    // B got its write.
-    const readB = await readSidecar(dirB);
-    expect(readB.metadata["b.mp3"]).toEqual({ title: "B", duration: 200 });
     // A's stale write was skipped — its sidecar dir was never created.
     expect(subdirsOf(dirA)[".commons-audio"]).toBeUndefined();
+    // B got its write.
+    const readB = await readSidecar(dirB);
+    expect(readB.metadata["b.mp3"]).toEqual({
+      tags: { title: "B", duration: 200 },
+      size: 2,
+      lastModified: 2,
+    });
   });
 
   it("in-memory model reflects the new folder, not the stale one", async () => {
@@ -702,14 +706,18 @@ describe("folder switch — stale-handle TOCTOU", () => {
     const dirB = makeEmptyDir();
 
     setLocalDirectory(dirA, true);
-    void cacheMetadata("a.mp3", { title: "A" });
+    void cacheMetadata("a.mp3", { tags: { title: "A" }, size: 1, lastModified: 1 });
     setLocalDirectory(dirB, true);
-    void cacheMetadata("b.mp3", { title: "B" });
+    void cacheMetadata("b.mp3", { tags: { title: "B" }, size: 2, lastModified: 2 });
     await flushWrites();
 
     // A's patch never merged into B's model.
     expect(await getMetadata("a.mp3")).toBeUndefined();
-    expect(await getMetadata("b.mp3")).toEqual({ title: "B" });
+    expect(await getMetadata("b.mp3")).toEqual({
+      tags: { title: "B" },
+      size: 2,
+      lastModified: 2,
+    });
   });
 
   it("a mid-session switch writes player-state to the correct folder", async () => {
@@ -737,16 +745,16 @@ describe("folder switch — stale-handle TOCTOU", () => {
     const dirB = makeEmptyDir();
 
     setLocalDirectory(dirA, true);
-    void cacheMetadata("a.mp3", { title: "A" });
+    void cacheMetadata("a.mp3", { tags: { title: "A" }, size: 1, lastModified: 1 });
     setLocalDirectory(dirB, true);
-    void cacheMetadata("b.mp3", { title: "B" });
+    void cacheMetadata("b.mp3", { tags: { title: "B" }, size: 2, lastModified: 2 });
     // A further write on the current folder after the stale-skip.
-    void cacheMetadata("c.mp3", { title: "C" });
+    void cacheMetadata("c.mp3", { tags: { title: "C" }, size: 3, lastModified: 3 });
     await flushWrites();
 
     const readB = await readSidecar(dirB);
-    expect(readB.metadata["b.mp3"]).toEqual({ title: "B" });
-    expect(readB.metadata["c.mp3"]).toEqual({ title: "C" });
+    expect(readB.metadata["b.mp3"]).toEqual({ tags: { title: "B" }, size: 2, lastModified: 2 });
+    expect(readB.metadata["c.mp3"]).toEqual({ tags: { title: "C" }, size: 3, lastModified: 3 });
     expect(subdirsOf(dirA)[".commons-audio"]).toBeUndefined();
   });
 });

--- a/audio/test/sidecar.test.ts
+++ b/audio/test/sidecar.test.ts
@@ -582,6 +582,88 @@ describe("clearLocalDirectory", () => {
   });
 });
 
+describe("folder switch — stale-handle TOCTOU", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Helper: read a dir's sidecar without disturbing the module's bound handle.
+  const subdirsOf = (dir: FileSystemDirectoryHandle) =>
+    (dir as unknown as { _subdirs: Record<string, unknown> })._subdirs; // type-safety-ok: test fake internals (_subdirs) access
+
+  it("drops an in-flight stale write after a synchronous folder switch", async () => {
+    const dirA = makeEmptyDir();
+    const dirB = makeEmptyDir();
+
+    setLocalDirectory(dirA, true);
+    // task_A snapshots A; its body is a pending microtask.
+    void cacheMetadata("a.mp3", { title: "A", duration: 100 });
+    // Switch to B synchronously, before task_A's body runs.
+    setLocalDirectory(dirB, true);
+    void cacheMetadata("b.mp3", { title: "B", duration: 200 });
+    await flushWrites();
+
+    // B got its write.
+    const readB = await readSidecar(dirB);
+    expect(readB.metadata["b.mp3"]).toEqual({ title: "B", duration: 200 });
+    // A's stale write was skipped — its sidecar dir was never created.
+    expect(subdirsOf(dirA)[".commons-audio"]).toBeUndefined();
+  });
+
+  it("in-memory model reflects the new folder, not the stale one", async () => {
+    const dirA = makeEmptyDir();
+    const dirB = makeEmptyDir();
+
+    setLocalDirectory(dirA, true);
+    void cacheMetadata("a.mp3", { title: "A" });
+    setLocalDirectory(dirB, true);
+    void cacheMetadata("b.mp3", { title: "B" });
+    await flushWrites();
+
+    // A's patch never merged into B's model.
+    expect(await getMetadata("a.mp3")).toBeUndefined();
+    expect(await getMetadata("b.mp3")).toEqual({ title: "B" });
+  });
+
+  it("a mid-session switch writes player-state to the correct folder", async () => {
+    const dirA = makeEmptyDir();
+    const dirB = makeEmptyDir();
+
+    setLocalDirectory(dirA, true);
+    void savePlayerState({ queue: ["a.mp3"], currentLocalName: "a.mp3", positionSeconds: 5 });
+    setLocalDirectory(dirB, true);
+    void savePlayerState({ queue: ["b.mp3"], currentLocalName: "b.mp3", positionSeconds: 7 });
+    await flushWrites();
+
+    const readB = await readSidecar(dirB);
+    expect(readB.playerState).toEqual({
+      queue: ["b.mp3"],
+      currentLocalName: "b.mp3",
+      positionSeconds: 7,
+    });
+    // A's stale player-state write was skipped.
+    expect(subdirsOf(dirA)[".commons-audio"]).toBeUndefined();
+  });
+
+  it("a stale-skip does not wedge the chain: subsequent writes still drain", async () => {
+    const dirA = makeEmptyDir();
+    const dirB = makeEmptyDir();
+
+    setLocalDirectory(dirA, true);
+    void cacheMetadata("a.mp3", { title: "A" });
+    setLocalDirectory(dirB, true);
+    void cacheMetadata("b.mp3", { title: "B" });
+    // A further write on the current folder after the stale-skip.
+    void cacheMetadata("c.mp3", { title: "C" });
+    await flushWrites();
+
+    const readB = await readSidecar(dirB);
+    expect(readB.metadata["b.mp3"]).toEqual({ title: "B" });
+    expect(readB.metadata["c.mp3"]).toEqual({ title: "C" });
+    expect(subdirsOf(dirA)[".commons-audio"]).toBeUndefined();
+  });
+});
+
 describe("cacheMetadataBatch", () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
Closes #2305

## Problem

`audio/src/sidecar.ts`'s `enqueueWrite` read the module-level `dirHandle` and
`writable` globals at **task execution time**, inside the chained `.then()`. That
is a TOCTOU bug: if the user rapidly disconnects folder A (`clearLocalDirectory`)
and connects folder B (`setLocalDirectory`) before a write queued for A has
drained, the orphaned task ran against the now-current `dirHandle` (B) and folder
A's data landed in folder B. The `writeChain = Promise.resolve()` reset in those
functions did not prevent this — it only detaches *future* enqueues from the old
chain; the already-chained task still ran and still read the live globals.

## Fix

`enqueueWrite` now captures `dirHandle` and `writable` into closure-local
snapshot constants **before** appending to the chain. Inside the task body:

1. A single TOCTOU guard at task start — `if (dirHandle !== snapshotHandle)
   return;` — skips the whole task if the bound directory changed between enqueue
   and execution, so the patch neither persists to the new folder nor
   contaminates the new folder's in-memory `cachedModel`.
2. The persist targets the **snapshot** handle, not the live global
   (`if (snapshotWritable && snapshotHandle !== null) await writeSidecar(snapshotHandle, merged)`),
   so even a switch racing in after the guard still writes to the folder the
   patch was issued for.

Exactly one guard, at task start. A second post-`ensureLoaded` re-guard is
deliberately not added: it would drop a still-valid write of A's data back to
folder A (A's retained handle stays valid after an in-app disconnect, which does
not revoke OS permission).

The `writeChain = Promise.resolve()` resets in `clearLocalDirectory` /
`setLocalDirectory` are kept (harmless with the guard, lower-risk than removing
them); their doc comments are corrected to state that the reset only detaches
future enqueues and the snapshot guard is what prevents a stale write.

## Tests

Added a `describe("folder switch — stale-handle TOCTOU")` block in
`audio/test/sidecar.test.ts` covering: an in-flight switch dropping the stale
write (dirB written, dirA's `.commons-audio` never created), the in-memory model
reflecting the new folder only, player-state writing to the correct folder after
a switch, and a chain-liveness regression proving the skip path does not wedge
the chain. Full audio suite: 234 passed, 1 skipped.

## Out of scope

A pre-existing read-staleness residual race inside `ensureLoaded` (a switch
landing during the first `readSidecar` await could cache the old folder's model
under the new handle) is unchanged by this fix and will be filed as a separate
low-priority follow-up — it is a read-path bug unrelated to this issue's
write-targeting criteria.
