### PR TITLE
audio: fail closed when the sidecar is corrupt so a later write can't clobber playlists

### DIFF
--- a/audio/src/sidecar.ts
+++ b/audio/src/sidecar.ts
@@ -133,24 +133,25 @@ function coercePlaylists(raw: unknown): Record<string, string[]> {
 /**
  * Parse sidecar text into a model. Tolerant of untrusted/partial on-disk
  * contents (input validation at the system edge, not a banned fallback):
- * - JSON parse failure or a non-object top level → log + fresh empty model.
+ * - JSON parse failure or a non-object top level → log + `null` (signals
+ *   corruption; the caller must not overwrite the file).
  * - `metadata`, `playerState`, and `playlists` are coerced INDEPENDENTLY, so
  *   malformed metadata never discards a good playerState and vice-versa.
  * - Within each field, wrong-typed leaves are dropped.
  * - `version` is forced to 1.
  * Never throws.
  */
-export function parseSidecar(text: string): SidecarData {
+export function parseSidecar(text: string): SidecarData | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
   } catch (err) {
     logError(err, { operation: "parseSidecar" });
-    return emptyModel();
+    return null;
   }
   if (!isPlainObject(parsed)) {
     logError(new Error("sidecar root is not an object"), { operation: "parseSidecar" });
-    return emptyModel();
+    return null;
   }
   return {
     version: 1,
@@ -196,11 +197,12 @@ export function mergeSidecar(existing: SidecarData, patch: SidecarPatch): Sideca
 
 /**
  * Read and parse the sidecar from `dir`. A missing `.commons-audio` directory or
- * `index.json` file (NotFoundError) yields an empty model. Any other unexpected
- * error is logged and also yields an empty model, so a flaky read never crashes
- * the library render. Never throws.
+ * `index.json` file (NotFoundError) yields an empty model (a missing file is
+ * safe to start fresh from). Any other unexpected error is logged and yields
+ * `null` (corrupt/unknown → the caller must not overwrite the file). Never
+ * throws.
  */
-export async function readSidecar(dir: FileSystemDirectoryHandle): Promise<SidecarData> {
+export async function readSidecar(dir: FileSystemDirectoryHandle): Promise<SidecarData | null> {
   try {
     const sidecarDir = await dir.getDirectoryHandle(SIDECAR_DIR);
     const fileHandle = await sidecarDir.getFileHandle(SIDECAR_FILE);
@@ -211,7 +213,7 @@ export async function readSidecar(dir: FileSystemDirectoryHandle): Promise<Sidec
       return emptyModel();
     }
     logError(err, { operation: "readSidecar" });
-    return emptyModel();
+    return null;
   }
 }
 
@@ -250,6 +252,12 @@ let writable = false;
 let cachedModel: SidecarData | null = null;
 let loadPromise: Promise<SidecarData> | null = null;
 
+// True when the bound folder has a sidecar file on disk that exists but
+// could not be parsed (corrupt). While set, disk writes are suppressed so a
+// routine save cannot overwrite the user's still-recoverable bytes; the
+// in-memory model proceeds from an empty model so the session stays usable.
+let corruptOnDisk = false;
+
 // Single-flight write chain: every mutation appends to this promise so the
 // player-state save and the metadata batch cannot race or interleave on the
 // file. Each link merges its patch against the result of the prior link, then
@@ -266,6 +274,7 @@ export function setLocalDirectory(handle: FileSystemDirectoryHandle, isWritable:
   writable = isWritable;
   cachedModel = null;
   loadPromise = null;
+  corruptOnDisk = false;
   writeChain = Promise.resolve();
 }
 
@@ -280,6 +289,7 @@ export function clearLocalDirectory(): void {
   writable = false;
   cachedModel = null;
   loadPromise = null;
+  corruptOnDisk = false;
   writeChain = Promise.resolve();
 }
 
@@ -291,12 +301,18 @@ export async function ensureLoaded(): Promise<SidecarData> {
   if (cachedModel !== null) return cachedModel;
   if (loadPromise === null) {
     const handle = dirHandle;
-    loadPromise = (handle === null ? Promise.resolve(emptyModel()) : readSidecar(handle)).then(
-      (model) => {
+    loadPromise = (
+      handle === null ? Promise.resolve<SidecarData | null>(emptyModel()) : readSidecar(handle)
+    ).then((model) => {
+      if (model === null) {
+        corruptOnDisk = true;
+        cachedModel = emptyModel();
+      } else {
+        corruptOnDisk = false;
         cachedModel = model;
-        return model;
-      },
-    );
+      }
+      return cachedModel;
+    });
   }
   return loadPromise;
 }
@@ -316,6 +332,13 @@ function enqueueWrite(patch: SidecarPatch): Promise<void> {
       const model = await ensureLoaded();
       const merged = mergeSidecar(model, patch);
       cachedModel = merged;
+      if (corruptOnDisk) {
+        logError(
+          new Error("sidecar corrupt on disk; skipping write to preserve recoverable user data"),
+          { operation: "sidecarWrite" },
+        );
+        return;
+      }
       if (writable && dirHandle !== null) {
         await writeSidecar(dirHandle, merged);
       }

--- a/audio/src/sidecar.ts
+++ b/audio/src/sidecar.ts
@@ -334,9 +334,19 @@ export async function ensureLoaded(): Promise<SidecarData> {
     loadPromise = (
       handle === null ? Promise.resolve<SidecarData | null>(emptyModel()) : readSidecar(handle)
     ).then((model) => {
+      // The handle may have been rebound (setLocalDirectory) while readSidecar
+      // was in flight. A stale result must not mutate the freshly-reset state —
+      // discard it so the next ensureLoaded re-reads the current handle.
+      if (dirHandle !== handle) {
+        return cachedModel ?? emptyModel();
+      }
       if (model === null) {
         corruptOnDisk = true;
         cachedModel = emptyModel();
+        logError(
+          new Error("sidecar corrupt on disk; suppressing writes to preserve recoverable user data"),
+          { operation: "ensureLoaded" },
+        );
       } else {
         corruptOnDisk = false;
         cachedModel = model;
@@ -362,11 +372,10 @@ function enqueueWrite(patch: SidecarPatch): Promise<void> {
       const model = await ensureLoaded();
       const merged = mergeSidecar(model, patch);
       cachedModel = merged;
+      // The corruption was already logged once at load time (ensureLoaded);
+      // return silently here so repeated saves (e.g. periodic playback-position
+      // persistence) don't spam the error log.
       if (corruptOnDisk) {
-        logError(
-          new Error("sidecar corrupt on disk; skipping write to preserve recoverable user data"),
-          { operation: "sidecarWrite" },
-        );
         return;
       }
       if (writable && dirHandle !== null) {

--- a/audio/test/sidecar.test.ts
+++ b/audio/test/sidecar.test.ts
@@ -158,33 +158,33 @@ describe("parseSidecar", () => {
     expect(result).toEqual(data);
   });
 
-  it("returns empty model for empty string", () => {
-    expect(parseSidecar("")).toEqual({ version: 1, metadata: {}, playlists: {} });
+  it("returns null for empty string", () => {
+    expect(parseSidecar("")).toBeNull();
   });
 
-  it("returns empty model for corrupt JSON", () => {
-    expect(parseSidecar("{not json")).toEqual({ version: 1, metadata: {}, playlists: {} });
+  it("returns null for corrupt JSON", () => {
+    expect(parseSidecar("{not json")).toBeNull();
   });
 
-  it("returns empty model for non-object top-level: number", () => {
-    expect(parseSidecar("42")).toEqual({ version: 1, metadata: {}, playlists: {} });
+  it("returns null for non-object top-level: number", () => {
+    expect(parseSidecar("42")).toBeNull();
   });
 
-  it("returns empty model for non-object top-level: null", () => {
-    expect(parseSidecar("null")).toEqual({ version: 1, metadata: {}, playlists: {} });
+  it("returns null for non-object top-level: null", () => {
+    expect(parseSidecar("null")).toBeNull();
   });
 
-  it("returns empty model for non-object top-level: string", () => {
-    expect(parseSidecar('"a string"')).toEqual({ version: 1, metadata: {}, playlists: {} });
+  it("returns null for non-object top-level: string", () => {
+    expect(parseSidecar('"a string"')).toBeNull();
   });
 
-  it("returns empty model for non-object top-level: array", () => {
-    expect(parseSidecar("[1,2,3]")).toEqual({ version: 1, metadata: {}, playlists: {} });
+  it("returns null for non-object top-level: array", () => {
+    expect(parseSidecar("[1,2,3]")).toBeNull();
   });
 
   it("forces version to 1 regardless of input", () => {
     const json = JSON.stringify({ version: 99, metadata: {}, playlists: {} });
-    expect(parseSidecar(json).version).toBe(1);
+    expect(parseSidecar(json)!.version).toBe(1);
   });
 
   it("coerces missing metadata to {} while preserving valid playerState", () => {
@@ -192,7 +192,7 @@ describe("parseSidecar", () => {
       version: 1,
       playerState: { queue: ["a.mp3"], currentLocalName: "a.mp3", positionSeconds: 10 },
     });
-    const result = parseSidecar(json);
+    const result = parseSidecar(json)!;
     expect(result.metadata).toEqual({});
     expect(result.playerState?.queue).toEqual(["a.mp3"]);
   });
@@ -203,7 +203,7 @@ describe("parseSidecar", () => {
       metadata: [1, 2],
       playerState: { queue: ["b.mp3"] },
     });
-    const result = parseSidecar(json);
+    const result = parseSidecar(json)!;
     expect(result.metadata).toEqual({});
     expect(result.playerState?.queue).toEqual(["b.mp3"]);
   });
@@ -214,7 +214,7 @@ describe("parseSidecar", () => {
       metadata: { "song.mp3": { title: "Keep", duration: "bad" } },
       playlists: {},
     });
-    const result = parseSidecar(json);
+    const result = parseSidecar(json)!;
     expect(result.metadata["song.mp3"]?.title).toBe("Keep");
     expect("duration" in (result.metadata["song.mp3"] ?? {})).toBe(false);
   });
@@ -226,7 +226,7 @@ describe("parseSidecar", () => {
         metadata: {},
         playlists: { Good: ["a.mp3", "b.mp3"], Bad: "not-an-array" },
       });
-      const result = parseSidecar(json);
+      const result = parseSidecar(json)!;
       expect(result.playlists?.["Good"]).toEqual(["a.mp3", "b.mp3"]);
       expect("Bad" in (result.playlists ?? {})).toBe(false);
     });
@@ -237,7 +237,7 @@ describe("parseSidecar", () => {
         metadata: {},
         playlists: { Mix: ["a.mp3", 42, null, "b.mp3"] },
       });
-      const result = parseSidecar(json);
+      const result = parseSidecar(json)!;
       expect(result.playlists?.["Mix"]).toEqual(["a.mp3", "b.mp3"]);
     });
   });
@@ -245,7 +245,7 @@ describe("parseSidecar", () => {
   describe("playerState coercion", () => {
     it("non-array queue defaults to []", () => {
       const json = JSON.stringify({ version: 1, metadata: {}, playerState: { queue: "bad" } });
-      const result = parseSidecar(json);
+      const result = parseSidecar(json)!;
       expect(result.playerState?.queue).toEqual([]);
     });
 
@@ -255,7 +255,7 @@ describe("parseSidecar", () => {
         metadata: {},
         playerState: { queue: [], currentLocalName: 42 },
       });
-      const result = parseSidecar(json);
+      const result = parseSidecar(json)!;
       expect("currentLocalName" in (result.playerState ?? {})).toBe(false);
     });
 
@@ -265,19 +265,19 @@ describe("parseSidecar", () => {
         metadata: {},
         playerState: { queue: [], positionSeconds: "bad" },
       });
-      const result = parseSidecar(json);
+      const result = parseSidecar(json)!;
       expect("positionSeconds" in (result.playerState ?? {})).toBe(false);
     });
 
     it("a plain-object playerState always yields at least { queue: [] }", () => {
       const json = JSON.stringify({ version: 1, metadata: {}, playerState: {} });
-      const result = parseSidecar(json);
+      const result = parseSidecar(json)!;
       expect(result.playerState).toEqual({ queue: [] });
     });
 
     it("a non-object playerState yields undefined", () => {
       const json = JSON.stringify({ version: 1, metadata: {}, playerState: "invalid" });
-      const result = parseSidecar(json);
+      const result = parseSidecar(json)!;
       expect(result.playerState).toBeUndefined();
     });
 
@@ -287,7 +287,7 @@ describe("parseSidecar", () => {
         metadata: { "song.mp3": { title: "Keep" } },
         playerState: 42,
       });
-      const result = parseSidecar(json);
+      const result = parseSidecar(json)!;
       expect(result.metadata["song.mp3"]?.title).toBe("Keep");
       expect(result.playerState).toBeUndefined();
     });
@@ -435,9 +435,9 @@ describe("readSidecar", () => {
     expect(result).toEqual({ version: 1, metadata: {}, playlists: {} });
   });
 
-  it("returns empty model when content is corrupt JSON", async () => {
+  it("returns null when content is corrupt JSON", async () => {
     const { dir } = makePreloadedDir("{not json");
-    await expect(readSidecar(dir)).resolves.toEqual({ version: 1, metadata: {}, playlists: {} });
+    await expect(readSidecar(dir)).resolves.toBeNull();
   });
 });
 
@@ -708,5 +708,42 @@ describe("sidecar — loads from pre-existing file", () => {
       positionSeconds: 25,
     });
     expect(await getPlaylists()).toEqual({ Old: ["existing.mp3"] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F. Corrupt sidecar — fail-closed acceptance criteria
+// ---------------------------------------------------------------------------
+
+describe("corrupt sidecar — fail-closed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("corrupt sidecar: savePlayerState does NOT overwrite the file (AC4)", async () => {
+    const { dir, fileHandle } = makePreloadedDir("{not json");
+    setLocalDirectory(dir, true);
+
+    await savePlayerState({ queue: ["a.mp3"], currentLocalName: "a.mp3", positionSeconds: 12 });
+    await flushWrites();
+
+    // File on disk is untouched — corrupt bytes preserved for recovery.
+    expect(fileHandle._state.content).toBe("{not json");
+    expect(fileHandle.createWritable).not.toHaveBeenCalled();
+
+    // In-memory session still works (the merge applied to an empty model).
+    expect(await getPlayerState()).toMatchObject({ queue: ["a.mp3"], positionSeconds: 12 });
+  });
+
+  it("missing sidecar (NotFoundError): savePlayerState DOES write (AC5)", async () => {
+    const dir = makeDirWithMissingFile();
+    setLocalDirectory(dir, true);
+
+    await savePlayerState({ queue: ["a.mp3"], positionSeconds: 5 });
+    await flushWrites();
+
+    const readBack = await readSidecar(dir);
+    expect(readBack).not.toBeNull();
+    expect(readBack?.playerState).toMatchObject({ queue: ["a.mp3"], positionSeconds: 5 });
   });
 });

--- a/audio/test/sidecar.test.ts
+++ b/audio/test/sidecar.test.ts
@@ -184,7 +184,9 @@ describe("parseSidecar", () => {
 
   it("forces version to 1 regardless of input", () => {
     const json = JSON.stringify({ version: 99, metadata: {}, playlists: {} });
-    expect(parseSidecar(json)!.version).toBe(1);
+    const result = parseSidecar(json);
+    if (!result) throw new Error("expected non-null for valid input");
+    expect(result.version).toBe(1);
   });
 
   it("coerces missing metadata to {} while preserving valid playerState", () => {
@@ -192,7 +194,8 @@ describe("parseSidecar", () => {
       version: 1,
       playerState: { queue: ["a.mp3"], currentLocalName: "a.mp3", positionSeconds: 10 },
     });
-    const result = parseSidecar(json)!;
+    const result = parseSidecar(json);
+    if (!result) throw new Error("expected non-null for valid input");
     expect(result.metadata).toEqual({});
     expect(result.playerState?.queue).toEqual(["a.mp3"]);
   });
@@ -203,7 +206,8 @@ describe("parseSidecar", () => {
       metadata: [1, 2],
       playerState: { queue: ["b.mp3"] },
     });
-    const result = parseSidecar(json)!;
+    const result = parseSidecar(json);
+    if (!result) throw new Error("expected non-null for valid input");
     expect(result.metadata).toEqual({});
     expect(result.playerState?.queue).toEqual(["b.mp3"]);
   });
@@ -214,7 +218,8 @@ describe("parseSidecar", () => {
       metadata: { "song.mp3": { title: "Keep", duration: "bad" } },
       playlists: {},
     });
-    const result = parseSidecar(json)!;
+    const result = parseSidecar(json);
+    if (!result) throw new Error("expected non-null for valid input");
     expect(result.metadata["song.mp3"]?.title).toBe("Keep");
     expect("duration" in (result.metadata["song.mp3"] ?? {})).toBe(false);
   });
@@ -226,7 +231,8 @@ describe("parseSidecar", () => {
         metadata: {},
         playlists: { Good: ["a.mp3", "b.mp3"], Bad: "not-an-array" },
       });
-      const result = parseSidecar(json)!;
+      const result = parseSidecar(json);
+      if (!result) throw new Error("expected non-null for valid input");
       expect(result.playlists?.["Good"]).toEqual(["a.mp3", "b.mp3"]);
       expect("Bad" in (result.playlists ?? {})).toBe(false);
     });
@@ -237,7 +243,8 @@ describe("parseSidecar", () => {
         metadata: {},
         playlists: { Mix: ["a.mp3", 42, null, "b.mp3"] },
       });
-      const result = parseSidecar(json)!;
+      const result = parseSidecar(json);
+      if (!result) throw new Error("expected non-null for valid input");
       expect(result.playlists?.["Mix"]).toEqual(["a.mp3", "b.mp3"]);
     });
   });
@@ -245,7 +252,8 @@ describe("parseSidecar", () => {
   describe("playerState coercion", () => {
     it("non-array queue defaults to []", () => {
       const json = JSON.stringify({ version: 1, metadata: {}, playerState: { queue: "bad" } });
-      const result = parseSidecar(json)!;
+      const result = parseSidecar(json);
+      if (!result) throw new Error("expected non-null for valid input");
       expect(result.playerState?.queue).toEqual([]);
     });
 
@@ -255,7 +263,8 @@ describe("parseSidecar", () => {
         metadata: {},
         playerState: { queue: [], currentLocalName: 42 },
       });
-      const result = parseSidecar(json)!;
+      const result = parseSidecar(json);
+      if (!result) throw new Error("expected non-null for valid input");
       expect("currentLocalName" in (result.playerState ?? {})).toBe(false);
     });
 
@@ -265,19 +274,22 @@ describe("parseSidecar", () => {
         metadata: {},
         playerState: { queue: [], positionSeconds: "bad" },
       });
-      const result = parseSidecar(json)!;
+      const result = parseSidecar(json);
+      if (!result) throw new Error("expected non-null for valid input");
       expect("positionSeconds" in (result.playerState ?? {})).toBe(false);
     });
 
     it("a plain-object playerState always yields at least { queue: [] }", () => {
       const json = JSON.stringify({ version: 1, metadata: {}, playerState: {} });
-      const result = parseSidecar(json)!;
+      const result = parseSidecar(json);
+      if (!result) throw new Error("expected non-null for valid input");
       expect(result.playerState).toEqual({ queue: [] });
     });
 
     it("a non-object playerState yields undefined", () => {
       const json = JSON.stringify({ version: 1, metadata: {}, playerState: "invalid" });
-      const result = parseSidecar(json)!;
+      const result = parseSidecar(json);
+      if (!result) throw new Error("expected non-null for valid input");
       expect(result.playerState).toBeUndefined();
     });
 
@@ -287,7 +299,8 @@ describe("parseSidecar", () => {
         metadata: { "song.mp3": { title: "Keep" } },
         playerState: 42,
       });
-      const result = parseSidecar(json)!;
+      const result = parseSidecar(json);
+      if (!result) throw new Error("expected non-null for valid input");
       expect(result.metadata["song.mp3"]?.title).toBe("Keep");
       expect(result.playerState).toBeUndefined();
     });

--- a/audio/test/sidecar.test.ts
+++ b/audio/test/sidecar.test.ts
@@ -577,6 +577,7 @@ describe("cacheMetadata / getMetadata — writable=true", () => {
     });
 
     const readBack = await readSidecar(dir);
+    if (!readBack) throw new Error("expected non-null sidecar");
     expect(readBack.metadata["song.mp3"]).toEqual({
       tags: { title: "Test Song", duration: 180 },
       size: 1024,
@@ -592,6 +593,7 @@ describe("cacheMetadata / getMetadata — writable=true", () => {
     await flushWrites();
 
     const readBack = await readSidecar(dir);
+    if (!readBack) throw new Error("expected non-null sidecar");
     expect(readBack.metadata["song.mp3"]).toEqual({
       tags: { title: "My Song" },
       size: 10,
@@ -609,6 +611,7 @@ describe("cacheMetadata / getMetadata — writable=true", () => {
     await flushWrites();
 
     const readBack = await readSidecar(dir);
+    if (!readBack) throw new Error("expected non-null sidecar");
     expect(readBack.metadata["a.mp3"]).toEqual({
       tags: { title: "A", duration: 100 },
       size: 1,
@@ -712,6 +715,7 @@ describe("cacheMetadataBatch", () => {
     await flushWrites();
 
     const readBack = await readSidecar(dir);
+    if (!readBack) throw new Error("expected non-null sidecar");
     expect(readBack.metadata["a.mp3"]).toEqual({
       tags: { title: "A", duration: 100 },
       size: 1,
@@ -744,6 +748,7 @@ describe("savePlayerState / getPlayerState", () => {
     });
 
     const readBack = await readSidecar(dir);
+    if (!readBack) throw new Error("expected non-null sidecar");
     expect(readBack.playerState).toEqual({
       queue: ["a.mp3"],
       currentLocalName: "a.mp3",
@@ -796,6 +801,7 @@ describe("savePlaylist / getPlaylists", () => {
     expect(await getPlaylists()).toEqual({ Favs: ["a.mp3", "b.mp3"] });
 
     const readBack = await readSidecar(dir);
+    if (!readBack) throw new Error("expected non-null sidecar");
     expect(readBack.playlists?.["Favs"]).toEqual(["a.mp3", "b.mp3"]);
   });
 });


### PR DESCRIPTION
Closes #2304

## Problem

`parseSidecar()` in `audio/src/sidecar.ts` was too tolerant of a genuinely
corrupt `.commons-audio/index.json`: on a JSON parse error or a non-object root
it logged and returned `emptyModel()` — an empty but valid-looking model. That
empty model was then cached by `ensureLoaded()`, so the next routine
`enqueueWrite()` (e.g. `savePlayerState()` persisting the playback position)
merged its patch against the empty cache and wrote the result back,
**permanently destroying every named playlist** that was in the corrupt file.

## Fix — fail closed

When the on-disk file exists but cannot be parsed, treat it as corrupt: keep the
in-memory session fully functional (start from an empty model so playback still
works), but **never overwrite the corrupt file on disk**, preserving the user's
bytes for recovery. A missing file (`NotFoundError`) is *not* corruption — the
new-folder path keeps working and still writes.

- `parseSidecar` / `readSidecar` now return `SidecarData | null`, using `null`
  as the corrupt sentinel.
- A module-level `corruptOnDisk` flag is set in `ensureLoaded()` when the load
  resolves `null`; the session proceeds from `emptyModel()`. The flag is reset in
  `setLocalDirectory` / `clearLocalDirectory` so re-binding a good folder
  re-enables writes (and tests stay isolated).
- `enqueueWrite` still merges in-memory (the session stays consistent) but skips
  the disk write while `corruptOnDisk` is set, logging a clear skip diagnostic.
- `ensureLoaded` keeps its non-null `SidecarData` return, so every accessor and
  external caller (`player.ts`, `local-source.ts`) is untouched.

### One intentional behavior change

`readSidecar()`'s catch-all branch (an unexpected, non-`NotFoundError` read
error) now returns the corrupt sentinel (`null`) instead of `emptyModel()`. An
unexpected error on a file that may exist with data means we cannot prove it is
safe to overwrite, so disk writes are suppressed for the session (in-memory stays
functional). This is the deliberate fail-closed choice per
`.claude/rules/code-style.md`, not scope creep.

## Tests

`audio/test/sidecar.test.ts`: updated the existing `parseSidecar`/`readSidecar`
corrupt-input assertions to expect `null` (behavior-change update, not
weakening), fixed the `SidecarData | null` type ripple in the valid-input tests,
and added two acceptance-criteria tests — a corrupt sidecar then
`savePlayerState()` leaves the file on disk untouched (and the session still
works), and a missing sidecar then `savePlayerState()` still writes.

Full audio suite green (233 passed); `npm run build --prefix audio` typechecks
the signature changes.
