### PR TITLE
qa-fix: gate office-hours on autonomous-vs-human determination for needs-main follow-ups

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-qa-apply-main-qa-labels
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-qa-apply-main-qa-labels
@@ -32,7 +32,11 @@ ISSUE_NUM=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --route)
-      ROUTE="${2:-}"
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "error: dispatch-qa-apply-main-qa-labels: --route requires a value (human|autonomous)" >&2
+        exit 1
+      fi
+      ROUTE="$2"
       shift 2
       ;;
     --route=*)

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-qa-apply-main-qa-labels
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-qa-apply-main-qa-labels
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 # Apply main-qa routing labels to a needs-main QA follow-up issue.
-# Usage: dispatch-qa-apply-main-qa-labels <issue-num>
+# Usage: dispatch-qa-apply-main-qa-labels <issue-num> [--route human|autonomous]
 #
-# Idempotent: safe to re-run. Performs three label ops:
-#   1. Removes "help wanted" (tolerates absent — not an error).
+# --route selects how the follow-up is routed downstream (default: human):
+#   human      → Step 3 applies "dispatch:office-hours" (human review queue).
+#   autonomous → Step 3 is SKIPPED; "dispatch:office-hours" is withheld so the
+#                router routes the follow-up to the autonomous /qa-main handler.
+# Both --route VAL and --route=VAL forms are accepted. Any other value is a
+# clear error (exit 1), not a silent fallback.
+#
+# Idempotent: safe to re-run. Performs up to three label ops:
+#   1. Removes "help wanted" (tolerates absent — not an error). UNCONDITIONAL.
 #   2. Applies "main-qa" (ensure-label-exists-first, then add via REST).
+#      UNCONDITIONAL — every follow-up carries main-qa regardless of route.
 #   3. Applies "dispatch:office-hours" via the shared helper (which also posts
-#      a why-comment on first apply).
+#      a why-comment on first apply). ROUTE-CONDITIONAL — runs only for the
+#      human route; skipped for autonomous.
 #
 # @me / assignees are never touched.
 set -euo pipefail
@@ -14,11 +23,38 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
 
-ISSUE_NUM="${1:-}"
+# Parse a leading --route flag; collect the lone non-flag positional into
+# ISSUE_NUM so the positional contract (`dispatch-qa-apply-main-qa-labels 42`)
+# is unchanged. A flag-like positional such as "--repo other/repo" is NOT a
+# --route flag, so it falls through to ISSUE_NUM and fails the numeric guard.
+ROUTE="human"
+ISSUE_NUM=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --route)
+      ROUTE="${2:-}"
+      shift 2
+      ;;
+    --route=*)
+      ROUTE="${1#--route=}"
+      shift
+      ;;
+    *)
+      ISSUE_NUM="$1"
+      shift
+      ;;
+  esac
+done
+
+# Validate ROUTE: clear error on any unexpected value (no silent fallback).
+if [[ "$ROUTE" != "human" && "$ROUTE" != "autonomous" ]]; then
+  echo "error: dispatch-qa-apply-main-qa-labels: --route must be 'human' or 'autonomous', got '${ROUTE}'" >&2
+  exit 1
+fi
 
 # Missing arg is a clear misuse, not a recoverable condition — hard error.
 if [[ -z "$ISSUE_NUM" ]]; then
-  echo "error: usage: dispatch-qa-apply-main-qa-labels <issue-num>" >&2
+  echo "error: usage: dispatch-qa-apply-main-qa-labels <issue-num> [--route human|autonomous]" >&2
   exit 1
 fi
 
@@ -65,12 +101,18 @@ if ! gh_issue_set_labels_rest "$ISSUE_NUM" "$MAIN_QA_LABEL"; then
   exit 1
 fi
 
-# ---- Step 3: Apply "dispatch:office-hours" ----------------------------------
+# ---- Step 3: Apply "dispatch:office-hours" (route-conditional) ---------------
 #
-# Reuse the shared helper — it owns idempotency, label creation, and the
-# why-comment. Pass a clear reason so a human reading the parked issue
-# understands why it landed in office-hours.
-"$SCRIPT_DIR/dispatch-apply-office-hours" "$ISSUE_NUM" \
-  "needs-main QA: this follow-up can only be verified against deployed main/production — routed to office-hours for human review"
+# Only the human route lands the follow-up in office-hours. The autonomous route
+# withholds dispatch:office-hours so the router hands the follow-up to /qa-main.
+if [[ "$ROUTE" == "human" ]]; then
+  # Reuse the shared helper — it owns idempotency, label creation, and the
+  # why-comment. Pass a clear reason so a human reading the parked issue
+  # understands why it landed in office-hours.
+  "$SCRIPT_DIR/dispatch-apply-office-hours" "$ISSUE_NUM" \
+    "needs-main QA: this follow-up can only be verified against deployed main/production — routed to office-hours for human review"
+else
+  echo "dispatch-qa-apply-main-qa-labels: autonomous route — withholding dispatch:office-hours; routed to /qa-main" >&2
+fi
 
 exit 0

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -9459,6 +9459,85 @@ assert_eq "missing issue number exits non-zero" "1" "$rc"
 assert_eq "missing arg: no label edit" "absent" "$(log_state gh-issue-edit.log)"
 teardown
 
+# --route autonomous: Step 1 (remove help-wanted) and Step 2 (add main-qa) run
+# unconditionally; Step 3 is skipped, so dispatch:office-hours is ABSENT from the
+# set-labels log. Exit 0.
+echo "Test: --route autonomous → help-wanted removed, main-qa added, office-hours withheld; exit 0"
+setup
+echo '{"state":"open","labels":[]}' > "$STUB_DIR/arg-issue-42.json"
+if "$TMPDIR_TEST/dispatch-qa-apply-main-qa-labels" 42 --route autonomous 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "--route autonomous: exit 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if grep -q 'DELETE' "$STUB_DIR/gh-issue-remove-label-rest-calls.log" \
+   && grep -q 'issues/42/labels/help%20wanted' "$STUB_DIR/gh-issue-remove-label-rest-calls.log"; then
+  PASS=$((PASS + 1)); echo "  PASS: autonomous route: REST-removed help wanted"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: autonomous route: REST-removed help wanted"
+  echo "    actual: '$(cat "$STUB_DIR/gh-issue-remove-label-rest-calls.log" 2>/dev/null)'"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q 'labels\[\]=main-qa' "$STUB_DIR/gh-issue-set-labels-rest-calls.log"; then
+  PASS=$((PASS + 1)); echo "  PASS: autonomous route: REST-added main-qa"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: autonomous route: REST-added main-qa"
+fi
+TOTAL=$((TOTAL + 1))
+if ! grep -q 'labels\[\]=dispatch:office-hours' "$STUB_DIR/gh-issue-set-labels-rest-calls.log" 2>/dev/null; then
+  PASS=$((PASS + 1)); echo "  PASS: autonomous route: dispatch:office-hours withheld"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: autonomous route: dispatch:office-hours withheld (should be absent)"
+fi
+teardown
+
+# --route human (explicit): identical to the default no-flag path. Steps 1-3 all
+# run, including the dispatch-apply-office-hours call that REST-adds office-hours.
+echo "Test: --route human (explicit) → help-wanted removed, main-qa added, office-hours applied; exit 0"
+setup
+echo '{"state":"open","labels":[]}' > "$STUB_DIR/arg-issue-42.json"
+if "$TMPDIR_TEST/dispatch-qa-apply-main-qa-labels" 42 --route human; then rc=0; else rc=$?; fi
+assert_eq "--route human explicit: exit 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if grep -q 'DELETE' "$STUB_DIR/gh-issue-remove-label-rest-calls.log" \
+   && grep -q 'issues/42/labels/help%20wanted' "$STUB_DIR/gh-issue-remove-label-rest-calls.log"; then
+  PASS=$((PASS + 1)); echo "  PASS: explicit human route: REST-removed help wanted"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: explicit human route: REST-removed help wanted"
+  echo "    actual: '$(cat "$STUB_DIR/gh-issue-remove-label-rest-calls.log" 2>/dev/null)'"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q 'labels\[\]=main-qa' "$STUB_DIR/gh-issue-set-labels-rest-calls.log"; then
+  PASS=$((PASS + 1)); echo "  PASS: explicit human route: REST-added main-qa"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: explicit human route: REST-added main-qa"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q 'labels\[\]=dispatch:office-hours' "$STUB_DIR/gh-issue-set-labels-rest-calls.log"; then
+  PASS=$((PASS + 1)); echo "  PASS: explicit human route: dispatch:office-hours applied"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: explicit human route: dispatch:office-hours applied"
+fi
+teardown
+
+# Invalid --route value: the script must exit 1 with an error to stderr and must
+# NOT write any label ops (no REST removes, no REST adds).
+echo "Test: --route bogus → non-zero exit, no label writes"
+setup
+if "$TMPDIR_TEST/dispatch-qa-apply-main-qa-labels" 42 --route bogus 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "--route bogus: non-zero exit" "1" "$rc"
+TOTAL=$((TOTAL + 1))
+if ! grep -q '.' "$STUB_DIR/gh-issue-remove-label-rest-calls.log" 2>/dev/null; then
+  PASS=$((PASS + 1)); echo "  PASS: invalid route: no REST remove-label writes"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: invalid route: no REST remove-label writes (should be absent)"
+fi
+TOTAL=$((TOTAL + 1))
+if ! grep -q '.' "$STUB_DIR/gh-issue-set-labels-rest-calls.log" 2>/dev/null; then
+  PASS=$((PASS + 1)); echo "  PASS: invalid route: no REST set-labels writes"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: invalid route: no REST set-labels writes (should be absent)"
+fi
+teardown
+
 # ============================================================================
 # dispatch-plan-finalize tests (#1230)
 # ============================================================================

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -665,6 +665,33 @@ fork site below (same discipline as the `fixes_applied_count` tally in Step 3.7)
       finding}` (the disposition contributes `id`/`title`/`kind`; the residue
       contributes `url_path`/`expected_outcome`/`finding`).
 
+      **Determine the route.** The **parent thread** (this caller — it holds the
+      joined residue fields above and these documented criteria) computes a
+      per-item `route` for each joined needs-main item. The `identifier` does not
+      exist yet (the Step 3.6.2 emitter produces it). So compute `route` here
+      against the `id`-keyed join, then carry it across to each item's
+      `identifier` once Step 3.6.2 emits one `{identifier, …}` object per input
+      item, in input order — the parent owns this `id`↔`identifier`
+      correspondence and ends with an `identifier`→`route` map threaded into the
+      Step 3.6.3 forks.
+
+      - `autonomous` (apply `main-qa` only; **withhold** `dispatch:office-hours`
+        so the router routes the follow-up to `/qa-main`) — when verification is
+        an **objective check observable on public deployed prod** that
+        `/qa-main`'s read-only Claude-in-Chrome flow can perform: hitting a
+        deployed public URL and checking deployed behavior, element-or-text
+        presence, console errors, network responses, or public analytics. **No**
+        auth wall, **no** private credentials/accounts, **no** subjective
+        product/UX judgment.
+      - `human` (apply `main-qa` + `dispatch:office-hours`, unchanged) — when
+        verification needs private credentials/accounts Claude lacks (an
+        auth-walled view), subjective product/UX judgment, or the user's product
+        intent.
+      - **Uncertain → `human`** (conservative default). The asymmetry is
+        explicit: a wrongly-`autonomous` item is recoverable via `/qa-main`'s
+        cannot-verify valve, but a verification that needs the user must never be
+        silently skipped.
+
    2. **Compose the follow-ups** by piping the joined needs-main items through the
       Unit-1 emitter (pure — no network/git/gh, runs sandboxed-fine, no
       `dangerouslyDisableSandbox` needed for this call):
@@ -679,9 +706,12 @@ fork site below (same discipline as the `fixes_applied_count` tally in Step 3.7)
       `title` so `dispatch-followup-exists` can dedup it.
 
    3. **File each follow-up.** For each emitted `{identifier, title, body}`, fork a
-      subagent (`subagent_type: general-purpose`, `model: sonnet`). These subagents
-      touch only GitHub and never the working tree, so fan them out in parallel
-      (multiple Agent calls in one message). Each subagent, with
+      subagent (`subagent_type: general-purpose`, `model: sonnet`). Pass this
+      item's `route` (from the parent's `identifier`→`route` map, Step 3.6.1) into
+      the subagent prompt **as data**. The subagent does **not** make the
+      determination — it only relays the value to the script in sub-step c. These
+      subagents touch only GitHub and never the working tree, so fan them out in
+      parallel (multiple Agent calls in one message). Each subagent, with
       `dangerouslyDisableSandbox: true` for the `gh` calls (`gh` needs network — see
       `.claude/rules/sandbox.md`):
 
@@ -716,12 +746,15 @@ fork site below (same discipline as the `fixes_applied_count` tally in Step 3.7)
          (`dangerouslyDisableSandbox: true` — it calls `gh`):
 
          ```bash
-         .claude/skills/dispatch-propagate/scripts/dispatch-qa-apply-main-qa-labels "<followup-N>"
+         .claude/skills/dispatch-propagate/scripts/dispatch-qa-apply-main-qa-labels "<followup-N>" --route <autonomous|human>
          ```
 
-         This removes `help wanted` and adds `main-qa` + `dispatch:office-hours`,
-         leaving `@me` — so the follow-up lands on the office-hours queue (human
-         review), not the autonomous dispatch queue.
+         Pass the `route` relayed into this subagent. The script always removes
+         `help wanted` and adds `main-qa`, leaving `@me`. For `--route human` it
+         **also** adds `dispatch:office-hours`, so the follow-up lands on the
+         office-hours queue (human review). For `--route autonomous` it
+         **withholds** `dispatch:office-hours`, so the router routes the follow-up
+         to the autonomous `/qa-main` handler instead.
 
       d. Returns `<followup-N>` mapped to its `identifier`.
 
@@ -1045,7 +1078,10 @@ fork site below (same discipline as the `fixes_applied_count` tally in Step 3.7)
      `needs-main` item, list its follow-up: `#<followup-N>` (newly filed), or
      "already tracked by #<N>" (an existing tracking issue was found via
      `dispatch-followup-exists`), using the `identifier`→`<N>` mappings Step 3.6
-     captured.
+     captured. Record each follow-up's **route** from the `identifier`→`route`
+     map: an `autonomous` follow-up routed to the `/qa-main` handler (`main-qa`
+     only), versus a `human` follow-up routed to office-hours human review
+     (`main-qa` + `dispatch:office-hours`).
    - **Assessed by Opus (already satisfied)** — include this sub-list only when
      `result.already_satisfied` is non-empty. For each item in
      `result.already_satisfied`, list its `title` and `rationale`. These items had
@@ -1142,8 +1178,11 @@ fork site below (same discipline as the `fixes_applied_count` tally in Step 3.7)
      - a failed pre-QA acceptance check (Step 3b, a bug needing a plan-mode fix).
 
    `needs-main`-class residue items are in **neither** part of the set — they were
-   filed as follow-ups in Step 3.6, now carrying `main-qa` + `dispatch:office-hours`
-   so they route to office-hours human review rather than the autonomous queue.
+   filed as follow-ups in Step 3.6, always carrying `main-qa`. Each carries
+   `dispatch:office-hours` **only** when its Step-3.6.1 determination is `human`,
+   routing it to office-hours human review; `autonomous` follow-ups withhold
+   `dispatch:office-hours` and route to the `/qa-main` handler. Either way they
+   are filed, not escalated.
 
    `already-satisfied` residue items are likewise in **neither** part of the set —
    they are **dropped as PASS** by the Workflow (partitioned into


### PR DESCRIPTION
Closes #2275

## Summary

qa-fix today files **every** `needs-main` QA follow-up through
`dispatch-qa-apply-main-qa-labels`, which unconditionally applies both `main-qa`
and `dispatch:office-hours` — sending all of them to human office-hours review.
With the `/qa-main` autonomous handler now in place (added by #2274), a
machine-verifiable follow-up no longer needs a human: `/qa-main` verifies a
`main-qa`-labelled, no-PR follow-up against deployed main/prod via read-only
Claude-in-Chrome. The dispatch router sends a `main-qa` follow-up carrying **no**
`dispatch:office-hours` to `/qa-main`; one that **does** carry it goes to human
office-hours.

This PR gates the office-hours apply on a per-follow-up **autonomous-vs-human
capability determination**: machine-verifiable follow-ups flow to the autonomous
`/qa-main` route (`main-qa` only); user-dependent ones keep the unchanged
office-hours behavior (`main-qa` + `dispatch:office-hours`); uncertain defaults to
human (a wrongly-autonomous item is recoverable via `/qa-main`'s cannot-verify
valve, but a verification silently skipped is not).

## Changes

- **`dispatch-qa-apply-main-qa-labels`** — adds a `--route human|autonomous`
  option (default `human`). The `help wanted` removal and `main-qa` apply stay
  unconditional; only the `dispatch:office-hours` apply (Step 3) is now
  route-conditional. `autonomous` withholds it (and echoes a one-line diagnostic);
  an invalid `--route` value is a clear error, not a silent fallback. Default
  preserves backward compatibility for the script's only caller and its tests.
- **`qa-fix/SKILL.md`** — documents the determination criteria inside Step 3.6,
  has the **parent thread** compute a per-item `route` keyed by `identifier` and
  thread it as **data** into the parallel filing forks (the subagent relays the
  value, it does not judge), makes the `dispatch-qa-apply-main-qa-labels` call
  route-aware, and reconciles every other needs-main→office-hours prose site (the
  3.6.3.c prose, the Step 4 "Filed follow-ups" sub-list, and the escalation-set
  prose) so no surviving instruction contradicts the conditional routing.
- **`test-dispatch-scripts.sh`** — covers the new flag: `--route autonomous`
  withholds `dispatch:office-hours`, explicit `--route human` applies it, an
  invalid route errors with no label writes, and the default (no flag) still
  applies office-hours.

The disposition struct and the qa-fix triage Workflow are untouched: this is
capability-routing about `/qa-main`'s envelope applied at the filing/routing site,
not a residue-classification change.

## Verification

`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` — 3919/3919
passed. The SKILL.md prose changes are prose-verified by review (instructions, not
executable code).
