### PR TITLE
dispatch-finalize-phase: document tick-before-sweep ordering

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-finalize-phase
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-finalize-phase
@@ -90,6 +90,8 @@ fi
 gh_issue_remove_label_rest "$N" dispatch:office-hours >/dev/null 2>&1 \
   || echo "[dispatch-finalize-phase] WARNING: remove-label dispatch:office-hours on issue #$N failed (non-fatal)" >&2
 
+# Ordering matters: spawn the tick BEFORE the Step 4 sweep so the dispatch chain
+# is re-established before the reaper runs — never reorder these two.
 # Step 3: spawn the next dispatch tick (idempotent via fixed-unit dedup).
 "$SCRIPT_DIR/dispatch-spawn-tick" || true
 


### PR DESCRIPTION
Closes #2262

## What

Adds a brief ordering comment in
`.claude/skills/dispatch-propagate/scripts/dispatch-finalize-phase` above the
Step 3 `dispatch-spawn-tick` call, documenting that the tick is spawned **before**
the Step 4 `dispatch-spawn-sweep` reaper deliberately.

## Why

Spawning the tick before the sweep re-establishes the dispatch chain before the
reaper runs, closing the window where the sweep could remove stale worktrees
while no tick has re-armed the chain. That intent was implicit in the step
numbering only, so a future edit could reorder the two calls and silently
reintroduce the window. The comment makes the ordering self-documenting.

## Scope

Comment-only. No behavior change — the tick-then-sweep call order is unchanged.
