### PR TITLE
stamp-dispatch-session.sh: fix comment to list git remote get-url, not git log

### DIFF
--- a/.claude/hooks/stamp-dispatch-session.sh
+++ b/.claude/hooks/stamp-dispatch-session.sh
@@ -14,7 +14,7 @@
 #     the event actually fires in --bg mode.
 # (b) Whether the hook command has working local `git` access in the worktree
 #     context where it runs — dispatch-stamp-session calls `git rev-parse`
-#     and `git log`; if git is unavailable or CWD is wrong the stamp silently
+#     and `git remote get-url`; if git is unavailable or CWD is wrong the stamp silently
 #     no-ops (never blocks).
 #
 # FALLBACK: if this hook proves unreliable for detached --bg sessions, add a


### PR DESCRIPTION
Closes #2265

## Summary

The live-end-to-end-testing comment block in `.claude/hooks/stamp-dispatch-session.sh`
told a tester that `dispatch-stamp-session` "calls `git rev-parse` and `git log`".
The script never calls `git log`. It actually invokes:

- `git rev-parse --abbrev-ref HEAD` (branch)
- `git rev-parse HEAD` (base_sha)
- `git remote get-url origin` (repo)

Naming a command the script does not run sends a live tester looking for `git log`
behavior that does not exist. This corrects the one-line comment so the
enumeration lists `git remote get-url` instead of `git log` — matching the
commands actually run. Comment text only; no executable code changes.

## Verification

- `grep -n 'git remote get-url' .claude/hooks/stamp-dispatch-session.sh` — present.
- `! grep -n 'git log' .claude/hooks/stamp-dispatch-session.sh` — no `git log`
  reference remains anywhere in the file.
