### PR TITLE
test-dispatch-scripts.sh: add null-base_sha idempotent re-write test

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -38618,6 +38618,23 @@ STAMP="$SCRIPT_DIR/dispatch-stamp-session"
   rm -rf "$d"
 )
 
+# 6b. Idempotent re-write with an explicitly-null .base_sha falls through to
+#     the HEAD-derived fallback (exercises the jq `// empty` operator that
+#     distinguishes JSON null from a real SHA in dispatch-stamp-session).
+(
+  d=$(mktemp -d)
+  git -C "$d" init -q
+  git -C "$d" remote add origin https://github.com/natb1/commons.systems.git
+  git -C "$d" checkout -q -b 999-fixture
+  git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  sc="$d/sess6b.dispatch-stamp.json"
+  # Seed a sidecar whose base_sha is JSON null (not the string "null", not absent).
+  printf '%s\n' '{"schema":1,"session_id":"sess6b","repo":"old/repo","issue":1,"pr":null,"branch":"old","base_sha":null,"stamped_at":"2026-01-01T00:00:00Z"}' > "$sc"
+  ( cd "$d" && "$STAMP" --session-id sess6b --transcript-path "$d/sess6b.jsonl" )
+  assert_eq "stamp: re-write with null .base_sha falls through to HEAD" "$(git -C "$d" rev-parse HEAD)" "$(jq -r .base_sha "$sc")"
+  rm -rf "$d"
+)
+
 # 7. Resume after HEAD moves (ff-merge) preserves the session-start .base_sha.
 #    This encodes #2270's failure mode: an initial stamp records HEAD=A; a later
 #    git merge --ff-only moves HEAD to B; the resume re-stamp must keep base_sha=A.


### PR DESCRIPTION
Closes #2298

## What

Adds a missing test case (`test 6b`) to
`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` covering the
idempotent re-write path where a `dispatch-stamp-session` sidecar already exists
but carries an **explicitly-null** `base_sha`.

## Why

PR #2294 added session-start `base_sha` preservation to `dispatch-stamp-session`.
The logic distinguishes an explicitly-null `base_sha` from a real SHA via
`jq -r '.base_sha // empty'`: a null value yields empty, falls through the
`[[ -n "$existing_base_sha" ]]` guard, and is replaced by the HEAD-derived value.

The existing Test 6 covers the real-SHA preservation path and Test 7 covers the
ff-merge resume path, but neither exercises the explicitly-null path — the one
place where the `// empty` operator actually does the work. Without a test for it,
a future change that drops `// empty` would make null stringify to the literal
`"null"`, pass `[[ -n "null" ]]`, and write the string `"null"` as `base_sha` — a
regression no test would catch.

## How

The new test 6b mirrors the surrounding test-6/test-7 subshell idiom: a `mktemp -d`
fake repo on a `999-fixture` branch, a seeded sidecar whose `base_sha` is JSON
`null`, a re-stamp, and an assertion that the resulting `base_sha` equals the
current HEAD (the HEAD-derived fallback), not the string `"null"`.

Test-only addition — no change to `dispatch-stamp-session` itself, other test
blocks, or CI config.

## Verification

The suite is invoked directly in CI (`.github/workflows/unit-tests.yml`) and is
self-contained (bash + git + jq + find + date, PATH-shimmed, no network). Running
it locally executes test 6b along with the full suite: **3908/3908 passed, 0
failed.**
