### PR TITLE
print: add escapeHtml test coverage for storagePath and markdownPath

### DIFF
--- a/print/test/pages/home.test.tsx
+++ b/print/test/pages/home.test.tsx
@@ -209,6 +209,28 @@ describe("loadMediaHtml", () => {
     expect(html).toContain('data-id="a&amp;b"');
   });
 
+  it("escapes HTML special characters in storagePath", async () => {
+    mockListCloud.mockResolvedValue([
+      makeMediaItem({ storagePath: 'media/"<x>.pdf' }),
+    ]);
+
+    const html = await loadMediaHtml();
+
+    expect(html).toContain('data-path="media/&quot;&lt;x&gt;.pdf"');
+    expect(html).not.toContain('data-path="media/"');
+  });
+
+  it("escapes HTML special characters in markdownPath", async () => {
+    mockListCloud.mockResolvedValue([
+      makeMediaItem({ markdownPath: 'media/"<x>.md' }),
+    ]);
+
+    const html = await loadMediaHtml();
+
+    expect(html).toContain('data-md-path="media/&quot;&lt;x&gt;.md"');
+    expect(html).not.toContain('data-md-path="media/"');
+  });
+
   it("renders items in the order returned by listCloud", async () => {
     mockListCloud.mockResolvedValue([
       makeMediaItem({ id: "first", title: "First" }),


### PR DESCRIPTION
Closes #2301

## What

Adds two regression tests to `print/test/pages/home.test.tsx` covering
`escapeHtml` on `storagePath` and `markdownPath` in `loadMediaHtml`'s rendered
HTML.

`renderMediaList()` already escapes `item.storagePath` (into the `data-path`
attribute) and `item.markdownPath` (into `data-md-path`), but the suite only
asserted escaping for `title` and `id`. If a future refactor dropped the
`escapeHtml` call on either field, nothing would fail. These tests close that
gap.

## Tests

Both new cases pass values containing `"` and `<` via the existing
`makeMediaItem` overrides and assert the rendered attribute is escaped
(`&quot;`/`&lt;`) and does not contain the raw attribute-breaking sequence:

- `escapes HTML special characters in storagePath`
- `escapes HTML special characters in markdownPath` (non-null override, since
  markdown buttons only render when `markdownPath` is non-null)

No production code changes. The full print suite passes (24/24).
