### PR TITLE
audio: fingerprint metadata cache entries so replaced files re-extract

### DIFF
--- a/audio/src/local-source.ts
+++ b/audio/src/local-source.ts
@@ -335,61 +335,62 @@ export async function resolveLocalFile(item: LibraryItem): Promise<File | null> 
 // cache `{}`), so a transient read failure retries on the next pass.
 // ---------------------------------------------------------------------------
 
-/** Result of enriching one item: the overlaid item plus an optional new cache
- * entry (`[localName, CachedMetadata]`) to be persisted in the pass's single
- * batched write. `entry` is null when nothing new was extracted (fresh cache
- * hit, no localName, or an unreadable file) so it contributes nothing to the
- * batch. */
+/** Result of enriching one item: an optional new cache entry (`[localName,
+ * CachedMetadata]`) to be persisted in the pass's single batched write. `entry`
+ * is null when nothing new was extracted (fresh cache hit, no localName, or an
+ * unreadable file) so it contributes nothing to the batch.
+ *
+ * This pass does NOT overlay the listed item: enrichment exists only to populate
+ * the sidecar cache. The user-visible tags (fresh or stale-but-cached) come from
+ * `listLocalTracks`'s own cache overlay on the next render, so there is nothing
+ * to return for display. */
 interface EnrichResult {
-  item: LibraryItem;
   entry: [string, CachedMetadata] | null;
 }
 
 async function enrichLocalItem(item: LibraryItem): Promise<EnrichResult> {
   const localName = item.localName;
   // Cloud-shaped safety; local items always carry a localName.
-  if (!localName) return { item, entry: null };
+  if (!localName) return { entry: null };
   const cached = await getMetadata(localName);
   const file = await resolveLocalFile(item);
-  // Could not read this file. Overlay the cached (stale-but-present) tags if we
-  // have them; never contribute a new entry (do NOT cache `{}` — that would
-  // permanently suppress a retry). A later pass retries.
+  // Could not read this file: contribute no entry (do NOT cache `{}` — that
+  // would permanently suppress a retry). A later pass retries. The cached
+  // (stale-but-present) tags stay user-visible via `listLocalTracks`'s overlay.
   if (file === null) {
-    return { item: cached !== undefined ? overlay(item, cached.tags) : item, entry: null };
+    return { entry: null };
   }
   const fp = { size: file.size, lastModified: file.lastModified };
-  // Fresh cache hit: the file's content is unchanged since extraction. Overlay
-  // the cached tags and skip extraction — no `arrayBuffer()` read.
+  // Fresh cache hit: the file's content is unchanged since extraction. Skip
+  // extraction — no `arrayBuffer()` read — and contribute no new entry.
   if (cached !== undefined && cached.size === fp.size && cached.lastModified === fp.lastModified) {
-    return { item: overlay(item, cached.tags), entry: null };
+    return { entry: null };
   }
   // Miss or mismatch: read the bytes and re-extract. Guard `arrayBuffer()` in a
   // try/catch — TOCTOU: the file can vanish between `getFile()` and the byte
-  // read. On failure, overlay the cached tags if present (else leave as-is) and
-  // contribute no entry, so a later pass retries.
+  // read. On failure, contribute no entry so a later pass retries (the cached
+  // tags, if any, remain visible through `listLocalTracks`).
   let buf: ArrayBuffer;
   try {
     buf = await file.arrayBuffer();
   } catch (err) {
     logError(err, { operation: "enrich-local-item" });
-    return { item: cached !== undefined ? overlay(item, cached.tags) : item, entry: null };
+    return { entry: null };
   }
   const tags = await extractAudioMetadata(buf, item.format);
   // Contribute this entry to the pass's single batched write, fingerprinted with
   // the file's current size/lastModified (an empty `{}` extract is still a
-  // present entry: it caches so we don't re-extract a tagless file every pass,
-  // and `overlay` with `{}` keeps the placeholders).
-  return { item: overlay(item, tags), entry: [localName, { tags, ...fp }] };
+  // present entry: it caches so we don't re-extract a tagless file every pass).
+  return { entry: [localName, { tags, ...fp }] };
 }
 
-async function enrichLocalItems(items: LibraryItem[]): Promise<LibraryItem[]> {
+async function enrichLocalItems(items: LibraryItem[]): Promise<void> {
   const results = await Promise.all(items.map((item) => enrichLocalItem(item)));
   const newEntries = Object.fromEntries(
     results.filter((r) => r.entry !== null).map((r) => r.entry as [string, CachedMetadata]),
   );
   // Empty → no-op (write suppression on a focus-rescan with no changed files).
   await cacheMetadataBatch(newEntries);
-  return results.map((r) => r.item);
 }
 
 /**

--- a/audio/src/local-source.ts
+++ b/audio/src/local-source.ts
@@ -22,6 +22,7 @@ import {
   getMetadata,
   setLocalDirectory,
 } from "./sidecar.js";
+import type { CachedMetadata } from "./sidecar.js";
 import { extractAudioMetadata } from "./local-metadata.js";
 import { AUDIO_FORMATS } from "./types.js";
 import type { AudioFormat, AudioTags, LibraryItem } from "./types.js";
@@ -242,6 +243,12 @@ export function hasLocalFolder(): boolean {
  * `getMetadata` calls `ensureLoaded` internally, which is a no-op once the model
  * is cached. Uncached items keep their synchronous placeholders until the async
  * `enrichLocalTracks` pass (Unit 5) extracts and caches their real tags.
+ *
+ * This path overlays whatever is cached and does NOT validate the fingerprint
+ * (no `getFile()`): it is the cheap first-render overlay. The post-render
+ * `enrichLocalTracks` pass detects a stale entry (fingerprint mismatch),
+ * re-extracts, and re-caches; a later re-render then overlays the fresh cache.
+ * This keeps the cheap-list / IO-enrichment split.
  * Returns [] when none / on error.
  */
 export async function listLocalTracks(): Promise<LibraryItem[]> {
@@ -253,7 +260,7 @@ export async function listLocalTracks(): Promise<LibraryItem[]> {
     return Promise.all(
       items.map(async (item) => {
         const cached = item.localName ? await getMetadata(item.localName) : undefined;
-        return cached !== undefined ? overlay(item, cached) : item;
+        return cached !== undefined ? overlay(item, cached.tags) : item;
       }),
     );
   } catch (err) {
@@ -281,54 +288,61 @@ export async function resolveLocalAudioSource(localName: string): Promise<string
 }
 
 /**
- * Resolve a listed local item's raw bytes for metadata enrichment, or null when
- * unavailable. Distinct from `resolveLocalAudioSource` (which wraps bytes in a
- * blob URL for `<audio>`) — enrichment needs the raw ArrayBuffer, not a URL.
+ * Resolve a listed local item to its `File` for metadata enrichment, or null
+ * when unavailable. Distinct from `resolveLocalAudioSource` (which wraps bytes in
+ * a blob URL for `<audio>`) — enrichment needs the File so it can read both the
+ * content fingerprint (`size`/`lastModified`) and, on a cache miss, the bytes.
  *
  * DESIGN NOTE — returns null on ANY failure ON PURPOSE; do not "correct" this to
  * throw. The repo code-style rule prefers clear errors over fallbacks, but this
  * is a deliberate, documented exception: enrichment is BEST-EFFORT and runs over
  * every listed file. A vanished file ("Local file no longer present"), a read
  * miss, or a permission error here is a skip-and-retry-later signal, not a
- * misconfiguration to surface. Unit 4 relies on the null return to AVOID caching
- * an empty `{}` (which would permanently suppress a retry). The error is still
- * logged for observability before returning null.
+ * misconfiguration to surface. The enrichment path relies on the null return to
+ * AVOID caching an empty `{}` (which would permanently suppress a retry). The
+ * error is still logged for observability before returning null.
  */
-export async function resolveLocalBytes(
-  item: LibraryItem,
-): Promise<ArrayBuffer | null> {
+export async function resolveLocalFile(item: LibraryItem): Promise<File | null> {
   if (!currentHandle) return null;
   currentSource ??= buildSource(currentHandle);
   try {
-    return await currentSource.resolveToBlob(item);
+    return await currentSource.resolveToFile(item);
   } catch (err) {
-    logError(err, { operation: "resolve-local-bytes" });
+    logError(err, { operation: "resolve-local-file" });
     return null;
   }
 }
 
 // ---------------------------------------------------------------------------
-// Async metadata enrichment overlay (cache-first, single batched write).
+// Async metadata enrichment overlay (cache-first w/ fingerprint re-validation,
+// single batched write).
 //
-// `listLocalTracks` overlays only ALREADY-cached tags (cheap, no IO). This pass
-// extracts real tags for the UNCACHED files and populates the cache, so a later
-// re-render's `listLocalTracks` overlays the fresh entries. Unit 5 invokes
-// `enrichLocalTracks` AFTER the initial render.
+// `listLocalTracks` overlays whatever is cached (cheap, no IO, no fingerprint
+// check). This pass reads each file's content fingerprint (`size` +
+// `lastModified`) and:
+//   - FRESH cache hit (fingerprint matches): overlay the cached tags, no
+//     extraction, no `arrayBuffer()` read — cheap.
+//   - MISS or MISMATCH (no cache, fingerprint differs, or a legacy v1 entry
+//     already dropped at parse): re-extract from the bytes and cache the new
+//     tags WITH the new fingerprint, so the next render overlays fresh data.
+// Unit 5 invokes `enrichLocalTracks` AFTER the initial render.
 //
-// Write suppression: an entry is accumulated ONLY when the cache was `undefined`
-// AND the bytes read OK. A focus-rescan with no new files finds every item
-// already cached → `newEntries` is empty → `cacheMetadataBatch` no-ops (no disk
-// write). A `null` (unreadable) buffer must NOT contribute an entry (do not
+// Write suppression: an entry is accumulated ONLY when extraction actually ran
+// (a real miss/mismatch with a readable file). A focus-rescan where every
+// fingerprint matches finds every item fresh → `newEntries` is empty →
+// `cacheMetadataBatch` no-ops (no disk write). An unreadable file (resolve null
+// or a TOCTOU `arrayBuffer()` failure) must NOT contribute an entry (do not
 // cache `{}`), so a transient read failure retries on the next pass.
 // ---------------------------------------------------------------------------
 
 /** Result of enriching one item: the overlaid item plus an optional new cache
- * entry (`[localName, tags]`) to be persisted in the pass's single batched
- * write. `entry` is null when nothing new was extracted (cached hit, no
- * localName, or an unreadable file) so it contributes nothing to the batch. */
+ * entry (`[localName, CachedMetadata]`) to be persisted in the pass's single
+ * batched write. `entry` is null when nothing new was extracted (fresh cache
+ * hit, no localName, or an unreadable file) so it contributes nothing to the
+ * batch. */
 interface EnrichResult {
   item: LibraryItem;
-  entry: [string, AudioTags] | null;
+  entry: [string, CachedMetadata] | null;
 }
 
 async function enrichLocalItem(item: LibraryItem): Promise<EnrichResult> {
@@ -336,28 +350,44 @@ async function enrichLocalItem(item: LibraryItem): Promise<EnrichResult> {
   // Cloud-shaped safety; local items always carry a localName.
   if (!localName) return { item, entry: null };
   const cached = await getMetadata(localName);
-  // Present entry (even `{}`) means already extracted — overlay, no new entry.
-  if (cached !== undefined) return { item: overlay(item, cached), entry: null };
-  // No entry yet: read bytes and extract. `resolveLocalBytes` catches its own
-  // errors (returns null) and `extractAudioMetadata` returns `{}` on any parse
-  // failure, so no try/catch is needed here.
-  const buf = await resolveLocalBytes(item);
-  // Could not read this file — do NOT cache `{}` (that would permanently
-  // suppress retry). A later pass retries.
-  if (buf === null) return { item, entry: null };
+  const file = await resolveLocalFile(item);
+  // Could not read this file. Overlay the cached (stale-but-present) tags if we
+  // have them; never contribute a new entry (do NOT cache `{}` — that would
+  // permanently suppress a retry). A later pass retries.
+  if (file === null) {
+    return { item: cached !== undefined ? overlay(item, cached.tags) : item, entry: null };
+  }
+  const fp = { size: file.size, lastModified: file.lastModified };
+  // Fresh cache hit: the file's content is unchanged since extraction. Overlay
+  // the cached tags and skip extraction — no `arrayBuffer()` read.
+  if (cached !== undefined && cached.size === fp.size && cached.lastModified === fp.lastModified) {
+    return { item: overlay(item, cached.tags), entry: null };
+  }
+  // Miss or mismatch: read the bytes and re-extract. Guard `arrayBuffer()` in a
+  // try/catch — TOCTOU: the file can vanish between `getFile()` and the byte
+  // read. On failure, overlay the cached tags if present (else leave as-is) and
+  // contribute no entry, so a later pass retries.
+  let buf: ArrayBuffer;
+  try {
+    buf = await file.arrayBuffer();
+  } catch (err) {
+    logError(err, { operation: "enrich-local-item" });
+    return { item: cached !== undefined ? overlay(item, cached.tags) : item, entry: null };
+  }
   const tags = await extractAudioMetadata(buf, item.format);
-  // Contribute this entry to the pass's single batched write (an empty `{}`
-  // extract is still a present entry: it caches so we don't re-extract a tagless
-  // file every pass, and `overlay` with `{}` keeps the placeholders).
-  return { item: overlay(item, tags), entry: [localName, tags] };
+  // Contribute this entry to the pass's single batched write, fingerprinted with
+  // the file's current size/lastModified (an empty `{}` extract is still a
+  // present entry: it caches so we don't re-extract a tagless file every pass,
+  // and `overlay` with `{}` keeps the placeholders).
+  return { item: overlay(item, tags), entry: [localName, { tags, ...fp }] };
 }
 
 async function enrichLocalItems(items: LibraryItem[]): Promise<LibraryItem[]> {
   const results = await Promise.all(items.map((item) => enrichLocalItem(item)));
   const newEntries = Object.fromEntries(
-    results.filter((r) => r.entry !== null).map((r) => r.entry as [string, AudioTags]),
+    results.filter((r) => r.entry !== null).map((r) => r.entry as [string, CachedMetadata]),
   );
-  // Empty → no-op (write suppression on a focus-rescan with no new files).
+  // Empty → no-op (write suppression on a focus-rescan with no changed files).
   await cacheMetadataBatch(newEntries);
   return results.map((r) => r.item);
 }
@@ -373,7 +403,7 @@ export async function enrichLocalTracks(): Promise<void> {
   if (!currentHandle) return;
   try {
     currentSource ??= buildSource(currentHandle);
-    // list() also populates the source index so resolveLocalBytes finds handles.
+    // list() also populates the source index so resolveLocalFile finds handles.
     const items = await currentSource.list();
     await enrichLocalItems(items);
   } catch (err) {

--- a/audio/src/sidecar.ts
+++ b/audio/src/sidecar.ts
@@ -42,10 +42,24 @@ export interface PlayerState {
   positionSeconds?: number;
 }
 
+/**
+ * A cached metadata entry: the extracted tags plus a content fingerprint (the
+ * file's `size` + `lastModified` at extraction time). The fingerprint lets the
+ * enrichment path detect when a file's content has changed since its tags were
+ * cached, so a stale entry is re-extracted rather than overlaid forever.
+ */
+export interface CachedMetadata {
+  tags: AudioTags;
+  /** FSA File.size at extraction time (content fingerprint). */
+  size: number;
+  /** FSA File.lastModified (ms since epoch) at extraction time. */
+  lastModified: number;
+}
+
 export interface SidecarData {
-  version: 1;
+  version: 2;
   /** Metadata cache, keyed by localName (bare filename). */
-  metadata: Record<string, AudioTags>;
+  metadata: Record<string, CachedMetadata>;
   /** Player-state for the local queue (absent until first saved). */
   playerState?: PlayerState;
   /** Playlists, keyed by name; each value is a list of localNames. */
@@ -54,44 +68,60 @@ export interface SidecarData {
 
 /** The shape a patch may carry — an arbitrary subset of fields, playerState partial. */
 type SidecarPatch = Partial<{
-  metadata: Record<string, AudioTags>;
+  metadata: Record<string, CachedMetadata>;
   playerState: Partial<PlayerState>;
   playlists: Record<string, string[]>;
 }>;
 
 /** A fresh, empty model. playerState stays undefined; playlists stays `{}`. */
 function emptyModel(): SidecarData {
-  return { version: 1, metadata: {}, playlists: {} };
+  return { version: 2, metadata: {}, playlists: {} };
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Coerce a raw value into typed `AudioTags`, keeping only leaves whose type
+ * matches (`title`/`artist`/`album`/`genre` strings; `trackNumber`/`year`/
+ * `duration` finite numbers). Wrong-typed leaves are dropped so a malformed
+ * on-disk entry can never surface as a non-string title or non-number duration
+ * downstream. */
+function coerceTags(value: Record<string, unknown>): AudioTags {
+  const entry: AudioTags = {};
+  if (typeof value.title === "string") entry.title = value.title;
+  if (typeof value.artist === "string") entry.artist = value.artist;
+  if (typeof value.album === "string") entry.album = value.album;
+  if (typeof value.genre === "string") entry.genre = value.genre;
+  if (typeof value.trackNumber === "number" && Number.isFinite(value.trackNumber))
+    entry.trackNumber = value.trackNumber;
+  if (typeof value.year === "number" && Number.isFinite(value.year)) entry.year = value.year;
+  if (typeof value.duration === "number" && Number.isFinite(value.duration))
+    entry.duration = value.duration;
+  return entry;
+}
+
 /**
- * Coerce a raw `metadata` value into the typed cache, keeping only entries whose
- * value is a plain object and, within each, only the leaves whose type matches
- * `AudioTags` (`title`/`artist`/`album`/`genre` strings; `trackNumber`/`year`/
- * `duration` numbers). Wrong-typed leaves are dropped so a malformed on-disk
- * entry can never surface as a non-string title or non-number duration
- * downstream.
+ * Coerce a raw `metadata` value into the typed cache, keeping only entries that
+ * are a well-formed `CachedMetadata` wrapper: a plain `tags` object plus finite
+ * numeric `size` and `lastModified` (the content fingerprint). The inner `tags`
+ * leaves are coerced per-leaf so a malformed leaf can never surface downstream.
+ *
+ * This IS the v1→v2 migration: a legacy v1 entry is a bare `AudioTags` object
+ * (no `tags`/`size`/`lastModified` wrapper), so it fails the wrapper checks and
+ * is DROPPED at parse — absent from the in-memory model, the enrichment path
+ * then sees `undefined` and re-extracts with a fresh fingerprint. No separate
+ * migration step.
  */
-function coerceMetadata(raw: unknown): Record<string, AudioTags> {
+function coerceMetadata(raw: unknown): Record<string, CachedMetadata> {
   if (!isPlainObject(raw)) return {};
-  const out: Record<string, AudioTags> = {};
+  const out: Record<string, CachedMetadata> = {};
   for (const [key, value] of Object.entries(raw)) {
     if (!isPlainObject(value)) continue;
-    const entry: AudioTags = {};
-    if (typeof value.title === "string") entry.title = value.title;
-    if (typeof value.artist === "string") entry.artist = value.artist;
-    if (typeof value.album === "string") entry.album = value.album;
-    if (typeof value.genre === "string") entry.genre = value.genre;
-    if (typeof value.trackNumber === "number" && Number.isFinite(value.trackNumber))
-      entry.trackNumber = value.trackNumber;
-    if (typeof value.year === "number" && Number.isFinite(value.year)) entry.year = value.year;
-    if (typeof value.duration === "number" && Number.isFinite(value.duration))
-      entry.duration = value.duration;
-    out[key] = entry;
+    if (typeof value.size !== "number" || !Number.isFinite(value.size)) continue;
+    if (typeof value.lastModified !== "number" || !Number.isFinite(value.lastModified)) continue;
+    if (!isPlainObject(value.tags)) continue;
+    out[key] = { tags: coerceTags(value.tags), size: value.size, lastModified: value.lastModified };
   }
   return out;
 }
@@ -137,7 +167,7 @@ function coercePlaylists(raw: unknown): Record<string, string[]> {
  * - `metadata`, `playerState`, and `playlists` are coerced INDEPENDENTLY, so
  *   malformed metadata never discards a good playerState and vice-versa.
  * - Within each field, wrong-typed leaves are dropped.
- * - `version` is forced to 1.
+ * - `version` is forced to 2.
  * Never throws.
  */
 export function parseSidecar(text: string): SidecarData {
@@ -153,7 +183,7 @@ export function parseSidecar(text: string): SidecarData {
     return emptyModel();
   }
   return {
-    version: 1,
+    version: 2,
     metadata: coerceMetadata(parsed.metadata),
     playerState: coercePlayerState(parsed.playerState),
     playlists: coercePlaylists(parsed.playlists),
@@ -183,7 +213,7 @@ export function mergeSidecar(existing: SidecarData, patch: SidecarPatch): Sideca
       })()
     : existing.playerState;
   return {
-    version: 1,
+    version: 2,
     metadata: { ...existing.metadata, ...patch.metadata },
     playerState,
     playlists: { ...existing.playlists, ...patch.playlists },
@@ -339,7 +369,7 @@ export function flushWrites(): Promise<void> {
  * Read a cached metadata entry by localName, ensuring the model is loaded.
  * Returns undefined when no entry is cached.
  */
-export async function getMetadata(localName: string): Promise<AudioTags | undefined> {
+export async function getMetadata(localName: string): Promise<CachedMetadata | undefined> {
   const model = await ensureLoaded();
   return model.metadata[localName];
 }
@@ -350,8 +380,8 @@ export async function getMetadata(localName: string): Promise<AudioTags | undefi
  * shows enriched data; the disk persist no-ops when not writable. Returns the
  * chain promise so callers can await persistence.
  */
-export async function cacheMetadata(localName: string, tags: AudioTags): Promise<void> {
-  return enqueueWrite({ metadata: { [localName]: tags } });
+export async function cacheMetadata(localName: string, entry: CachedMetadata): Promise<void> {
+  return enqueueWrite({ metadata: { [localName]: entry } });
 }
 
 /**
@@ -362,7 +392,7 @@ export async function cacheMetadata(localName: string, tags: AudioTags): Promise
  * no-op — it neither touches the chain nor writes the file, preserving
  * focus-rescan write suppression when nothing is new.
  */
-export async function cacheMetadataBatch(entries: Record<string, AudioTags>): Promise<void> {
+export async function cacheMetadataBatch(entries: Record<string, CachedMetadata>): Promise<void> {
   if (Object.keys(entries).length === 0) return;
   return enqueueWrite({ metadata: entries });
 }

--- a/audio/test/local-source.test.ts
+++ b/audio/test/local-source.test.ts
@@ -287,9 +287,10 @@ describe("resolveLocalFile", () => {
       id: "local:tune.flac",
     } as LibraryItem); // type-safety-ok: partial LibraryItem fixture for test
     expect(file).not.toBeNull();
-    expect(file!.size).toBe(42); // type-safety-ok: file asserted non-null on the preceding line
-    expect(file!.lastModified).toBe(3000);
-    expect(new TextDecoder().decode(await file!.arrayBuffer())).toBe("tune.flac");
+    if (file == null) throw new Error("Expected file to be non-null");
+    expect(file.size).toBe(42);
+    expect(file.lastModified).toBe(3000);
+    expect(new TextDecoder().decode(await file.arrayBuffer())).toBe("tune.flac");
   });
 
   it("returns null (not a throw) when the item is no longer present", async () => {

--- a/audio/test/local-source.test.ts
+++ b/audio/test/local-source.test.ts
@@ -41,6 +41,7 @@ interface FakeEntry {
   kind: "file" | "directory";
   name: string;
   getFile?: () => Promise<{
+    size: number;
     lastModified: number;
     arrayBuffer: () => Promise<ArrayBuffer>;
   }>;
@@ -50,11 +51,14 @@ function bytes(s: string): ArrayBuffer {
   return new TextEncoder().encode(s).buffer;
 }
 
-function fileEntry(name: string, lastModified: number): FakeEntry {
+/** A fake top-level file. `size` defaults to the byte length of `name` (the
+ * content the fake `arrayBuffer()` returns) but can be overridden so a test can
+ * drive the content fingerprint independently of `lastModified`. */
+function fileEntry(name: string, lastModified: number, size = bytes(name).byteLength): FakeEntry {
   return {
     kind: "file",
     name,
-    getFile: async () => ({ lastModified, arrayBuffer: async () => bytes(name) }),
+    getFile: async () => ({ size, lastModified, arrayBuffer: async () => bytes(name) }),
   };
 }
 
@@ -269,9 +273,9 @@ describe("resolveLocalAudioSource", () => {
   });
 });
 
-describe("resolveLocalBytes", () => {
-  it("returns the bytes for a listed local item", async () => {
-    const handle = fakeDir([fileEntry("tune.flac", 3000)]);
+describe("resolveLocalFile", () => {
+  it("returns the File (size/lastModified/arrayBuffer) for a listed local item", async () => {
+    const handle = fakeDir([fileEntry("tune.flac", 3000, 42)]);
     (window as unknown as { showDirectoryPicker: unknown }).showDirectoryPicker = // type-safety-ok: test stubs window.showDirectoryPicker global
       vi.fn().mockResolvedValue(handle);
     fakeStore.put.mockResolvedValue(undefined);
@@ -279,11 +283,13 @@ describe("resolveLocalBytes", () => {
     const mod = await loadModule();
     await mod.connectLocalFolder();
 
-    const buf = await mod.resolveLocalBytes({
+    const file = await mod.resolveLocalFile({
       id: "local:tune.flac",
     } as LibraryItem); // type-safety-ok: partial LibraryItem fixture for test
-    expect(buf).not.toBeNull();
-    expect(new TextDecoder().decode(buf!)).toBe("tune.flac"); // type-safety-ok: buffer asserted non-null on the preceding line
+    expect(file).not.toBeNull();
+    expect(file!.size).toBe(42); // type-safety-ok: file asserted non-null on the preceding line
+    expect(file!.lastModified).toBe(3000);
+    expect(new TextDecoder().decode(await file!.arrayBuffer())).toBe("tune.flac");
   });
 
   it("returns null (not a throw) when the item is no longer present", async () => {
@@ -295,21 +301,21 @@ describe("resolveLocalBytes", () => {
     const mod = await loadModule();
     await mod.connectLocalFolder();
 
-    const buf = await mod.resolveLocalBytes({
+    const file = await mod.resolveLocalFile({
       id: "local:missing.flac",
     } as LibraryItem); // type-safety-ok: partial LibraryItem fixture for test
-    expect(buf).toBeNull();
+    expect(file).toBeNull();
     expect(mockLogError).toHaveBeenCalledWith(expect.anything(), {
-      operation: "resolve-local-bytes",
+      operation: "resolve-local-file",
     });
   });
 
   it("returns null when no folder is connected", async () => {
     const mod = await loadModule();
-    const buf = await mod.resolveLocalBytes({
+    const file = await mod.resolveLocalFile({
       id: "local:tune.flac",
     } as LibraryItem); // type-safety-ok: partial LibraryItem fixture for test
-    expect(buf).toBeNull();
+    expect(file).toBeNull();
   });
 });
 
@@ -340,9 +346,11 @@ describe("enrichment", () => {
     const handle = fakeDir([fileEntry("song.mp3", 1000)]);
     connectDir(handle);
 
-    // Cache returns tags for song.mp3
+    // Cache returns a wrapper entry for song.mp3 (listLocalTracks overlays
+    // .tags and does NOT validate the fingerprint).
     mockGetMetadata.mockImplementation(async (name: string) => {
-      if (name === "song.mp3") return { artist: "Real Artist", duration: 100 };
+      if (name === "song.mp3")
+        return { tags: { artist: "Real Artist", duration: 100 }, size: 8, lastModified: 1000 };
       return undefined;
     });
 
@@ -372,7 +380,7 @@ describe("enrichment", () => {
   });
 
   it("enrichLocalTracks extracts uncached items and writes a single batch", async () => {
-    const handle = fakeDir([fileEntry("song.mp3", 1000), fileEntry("tune.flac", 2000)]);
+    const handle = fakeDir([fileEntry("song.mp3", 1000, 8), fileEntry("tune.flac", 2000, 9)]);
     connectDir(handle);
 
     // Nothing cached
@@ -387,45 +395,57 @@ describe("enrichment", () => {
 
     // One extract call per file
     expect(mockExtract).toHaveBeenCalledTimes(2);
-    // Single batched write
+    // Single batched write; each entry is a fingerprinted wrapper.
     expect(mockCacheMetadataBatch).toHaveBeenCalledTimes(1);
     const batchArg = mockCacheMetadataBatch.mock.calls[0][0] as Record<string, unknown>; // type-safety-ok: mock-call introspection in test
-    expect(batchArg["song.mp3"]).toEqual({ artist: "X" });
-    expect(batchArg["tune.flac"]).toEqual({ artist: "X" });
+    expect(batchArg["song.mp3"]).toEqual({ tags: { artist: "X" }, size: 8, lastModified: 1000 });
+    expect(batchArg["tune.flac"]).toEqual({ tags: { artist: "X" }, size: 9, lastModified: 2000 });
   });
 
-  it("focus-rescan write suppression: all cached → cacheMetadataBatch called with {}", async () => {
-    const handle = fakeDir([fileEntry("song.mp3", 1000)]);
+  it("focus-rescan write suppression: all fresh cache hits → cacheMetadataBatch called with {}", async () => {
+    const handle = fakeDir([fileEntry("song.mp3", 1000, 8)]);
     connectDir(handle);
 
-    // Everything already cached (even an empty entry signals 'present')
-    mockGetMetadata.mockResolvedValue({});
+    // Cached with a fingerprint matching the file → fresh hit, no extraction.
+    mockGetMetadata.mockResolvedValue({ tags: {}, size: 8, lastModified: 1000 });
     mockCacheMetadataBatch.mockResolvedValue(undefined);
 
     const mod = await loadModule();
     await mod.connectLocalFolder();
     await mod.enrichLocalTracks();
 
-    // extract was never called (all cached)
+    // extract was never called (fingerprint matched)
     expect(mockExtract).not.toHaveBeenCalled();
     // cacheMetadataBatch called with empty (real impl no-ops; mock records the call)
     expect(mockCacheMetadataBatch).toHaveBeenCalledWith({});
   });
 
-  it("unreadable file is not included in the batch (null bytes → retry later)", async () => {
-    // Build a dir where song.mp3's getFile rejects
+  it("file whose arrayBuffer() fails (TOCTOU) is not in the batch; cached stale tags overlaid", async () => {
+    // song.mp3 lists + resolves to a File, but reading its bytes throws (the
+    // file vanished between getFile() and the byte read). Its arrayBuffer
+    // failure must be caught: no new entry, and the (stale) cached tags overlay.
     const failingEntry: FakeEntry = {
       kind: "file",
       name: "song.mp3",
-      getFile: async () => {
-        throw new Error("read error");
-      },
+      getFile: async () => ({
+        size: 8,
+        lastModified: 1000,
+        arrayBuffer: async () => {
+          throw new Error("read error");
+        },
+      }),
     };
-    const goodEntry = fileEntry("tune.flac", 2000);
+    const goodEntry = fileEntry("tune.flac", 2000, 9);
     const handle = fakeDir([failingEntry, goodEntry]);
     connectDir(handle);
 
-    mockGetMetadata.mockResolvedValue(undefined);
+    // song.mp3 has a STALE cached entry (fingerprint differs → triggers a
+    // re-extract attempt, whose byte read then fails).
+    mockGetMetadata.mockImplementation(async (name: string) => {
+      if (name === "song.mp3")
+        return { tags: { artist: "Stale" }, size: 999, lastModified: 1 };
+      return undefined;
+    });
     mockExtract.mockResolvedValue({ artist: "Y" });
     mockCacheMetadataBatch.mockResolvedValue(undefined);
 
@@ -433,10 +453,92 @@ describe("enrichment", () => {
     await mod.connectLocalFolder();
     await mod.enrichLocalTracks();
 
-    // batch arg must not include the failing file
+    // batch arg must not include the failing file (no new entry → retry later)
     const batchArg = mockCacheMetadataBatch.mock.calls[0][0] as Record<string, unknown>; // type-safety-ok: mock-call introspection in test
     expect("song.mp3" in batchArg).toBe(false);
-    // good file is present
-    expect(batchArg["tune.flac"]).toEqual({ artist: "Y" });
+    // good file is present, fingerprinted
+    expect(batchArg["tune.flac"]).toEqual({ tags: { artist: "Y" }, size: 9, lastModified: 2000 });
+  });
+
+  // -------------------------------------------------------------------------
+  // Acceptance criteria 5(a)-(c): fingerprint re-validation in enrichment.
+  // -------------------------------------------------------------------------
+
+  it("(a) fresh cache hit (matching size + lastModified) → no extraction, cached tags overlaid", async () => {
+    const handle = fakeDir([fileEntry("song.mp3", 1000, 8)]);
+    connectDir(handle);
+
+    // Cached fingerprint matches the file exactly.
+    mockGetMetadata.mockResolvedValue({
+      tags: { artist: "Cached Artist", duration: 120 },
+      size: 8,
+      lastModified: 1000,
+    });
+    mockCacheMetadataBatch.mockResolvedValue(undefined);
+
+    const mod = await loadModule();
+    await mod.connectLocalFolder();
+    await mod.enrichLocalTracks();
+
+    // extractAudioMetadata NOT called on a fresh hit.
+    expect(mockExtract).not.toHaveBeenCalled();
+    // No new entry written.
+    expect(mockCacheMetadataBatch).toHaveBeenCalledWith({});
+    // Cached tags are overlaid onto the listed item (the user-visible result).
+    const items = await mod.listLocalTracks();
+    const song = items.find((i) => i.localName === "song.mp3");
+    expect(song?.artist).toBe("Cached Artist");
+    expect(song?.duration).toBe(120);
+  });
+
+  it("(b) mismatched fingerprint (file size/lastModified changed) → re-extract + new fingerprinted entry", async () => {
+    // File now has size 50 / lastModified 9999.
+    const handle = fakeDir([fileEntry("song.mp3", 9999, 50)]);
+    connectDir(handle);
+
+    // Stale cache: fingerprint from a prior version of the file.
+    mockGetMetadata.mockResolvedValue({
+      tags: { artist: "Old" },
+      size: 8,
+      lastModified: 1000,
+    });
+    mockExtract.mockResolvedValue({ artist: "Fresh" });
+    mockCacheMetadataBatch.mockResolvedValue(undefined);
+
+    const mod = await loadModule();
+    await mod.connectLocalFolder();
+    await mod.enrichLocalTracks();
+
+    // Mismatch → extraction ran.
+    expect(mockExtract).toHaveBeenCalledTimes(1);
+    // The new entry carries the NEW fingerprint.
+    const batchArg = mockCacheMetadataBatch.mock.calls[0][0] as Record<string, unknown>; // type-safety-ok: mock-call introspection in test
+    expect(batchArg["song.mp3"]).toEqual({
+      tags: { artist: "Fresh" },
+      size: 50,
+      lastModified: 9999,
+    });
+  });
+
+  it("(c) missing fingerprint (getMetadata undefined, e.g. legacy entry dropped at parse) → re-extract + fresh entry", async () => {
+    const handle = fakeDir([fileEntry("song.mp3", 1000, 8)]);
+    connectDir(handle);
+
+    // Post-parse state for a legacy v1 entry: dropped → cache miss.
+    mockGetMetadata.mockResolvedValue(undefined);
+    mockExtract.mockResolvedValue({ artist: "Extracted" });
+    mockCacheMetadataBatch.mockResolvedValue(undefined);
+
+    const mod = await loadModule();
+    await mod.connectLocalFolder();
+    await mod.enrichLocalTracks();
+
+    expect(mockExtract).toHaveBeenCalledTimes(1);
+    const batchArg = mockCacheMetadataBatch.mock.calls[0][0] as Record<string, unknown>; // type-safety-ok: mock-call introspection in test
+    expect(batchArg["song.mp3"]).toEqual({
+      tags: { artist: "Extracted" },
+      size: 8,
+      lastModified: 1000,
+    });
   });
 });

--- a/audio/test/local-source.test.ts
+++ b/audio/test/local-source.test.ts
@@ -461,6 +461,59 @@ describe("enrichment", () => {
     expect(batchArg["tune.flac"]).toEqual({ tags: { artist: "Y" }, size: 9, lastModified: 2000 });
   });
 
+  it("file whose getFile() fails on resolve (resolveLocalFile null) is not in the batch; cached stale tags stay visible", async () => {
+    // song.mp3 lists fine (the scan's getFile succeeds), but the LATER resolve
+    // for enrichment fails: getFile() itself throws (not just arrayBuffer) so
+    // resolveLocalFile returns null. Orthogonal to the TOCTOU case, where
+    // getFile succeeds and only arrayBuffer throws. With a stale cache entry
+    // present, no new entry is contributed (do NOT cache `{}`), and the stale
+    // tags must remain visible to the user via listLocalTracks's cache overlay.
+    // getFile must succeed for the listing scans (so the item is listed and
+    // stays visible) but fail for the enrichment resolve in between, modelling a
+    // transient getFile failure. resolveLocalFile catches that throw → null.
+    let songGetFileCalls = 0;
+    const failingEntry: FakeEntry = {
+      kind: "file",
+      name: "song.mp3",
+      // Call 1 = enrich's listing scan (succeeds → item listed).
+      // Call 2 = enrich's resolveLocalFile (throws → null, the path under test).
+      // Call 3 = the final listLocalTracks re-scan (succeeds → item still listed).
+      getFile: async () => {
+        songGetFileCalls += 1;
+        if (songGetFileCalls === 2) throw new Error("getFile error");
+        return { size: 8, lastModified: 1000, arrayBuffer: async () => bytes("song.mp3") };
+      },
+    };
+    const goodEntry = fileEntry("tune.flac", 2000, 9);
+    const handle = fakeDir([failingEntry, goodEntry]);
+    connectDir(handle);
+
+    // song.mp3 has a STALE cached entry; tune.flac is uncached.
+    mockGetMetadata.mockImplementation(async (name: string) => {
+      if (name === "song.mp3")
+        return { tags: { artist: "Stale" }, size: 999, lastModified: 1 };
+      return undefined;
+    });
+    mockExtract.mockResolvedValue({ artist: "Y" });
+    mockCacheMetadataBatch.mockResolvedValue(undefined);
+
+    const mod = await loadModule();
+    await mod.connectLocalFolder();
+    await mod.enrichLocalTracks();
+
+    // song.mp3 never reached extraction (resolveLocalFile returned null).
+    expect(mockExtract).toHaveBeenCalledTimes(1);
+    // batch arg must not include the failing file (no new entry → retry later).
+    const batchArg = mockCacheMetadataBatch.mock.calls[0][0] as Record<string, unknown>; // type-safety-ok: mock-call introspection in test
+    expect("song.mp3" in batchArg).toBe(false);
+    expect(batchArg["tune.flac"]).toEqual({ tags: { artist: "Y" }, size: 9, lastModified: 2000 });
+
+    // The stale cached tags stay user-visible (listLocalTracks overlays cache).
+    const items = await mod.listLocalTracks();
+    const song = items.find((i) => i.localName === "song.mp3");
+    expect(song?.artist).toBe("Stale");
+  });
+
   // -------------------------------------------------------------------------
   // Acceptance criteria 5(a)-(c): fingerprint re-validation in enrichment.
   // -------------------------------------------------------------------------
@@ -518,6 +571,48 @@ describe("enrichment", () => {
       tags: { artist: "Fresh" },
       size: 50,
       lastModified: 9999,
+    });
+  });
+
+  // (b1)/(b2): the fingerprint gate is `cached.size === fp.size &&
+  // cached.lastModified === fp.lastModified`. Exercise each sub-condition
+  // independently so a regression from `&&` to `||` is caught.
+  it.each([
+    {
+      label: "(b1) same size, different lastModified → re-extract",
+      live: { lastModified: 9999, size: 8 },
+      cached: { size: 8, lastModified: 1000 },
+    },
+    {
+      label: "(b2) different size, same lastModified → re-extract",
+      live: { lastModified: 1000, size: 50 },
+      cached: { size: 8, lastModified: 1000 },
+    },
+  ])("$label", async ({ live, cached }) => {
+    const handle = fakeDir([fileEntry("song.mp3", live.lastModified, live.size)]);
+    connectDir(handle);
+
+    // Stale cache: exactly one fingerprint field differs from the live file.
+    mockGetMetadata.mockResolvedValue({
+      tags: { artist: "Old" },
+      size: cached.size,
+      lastModified: cached.lastModified,
+    });
+    mockExtract.mockResolvedValue({ artist: "Fresh" });
+    mockCacheMetadataBatch.mockResolvedValue(undefined);
+
+    const mod = await loadModule();
+    await mod.connectLocalFolder();
+    await mod.enrichLocalTracks();
+
+    // One field differing must still be treated as a mismatch → extraction ran.
+    expect(mockExtract).toHaveBeenCalledTimes(1);
+    // The new entry carries the NEW (live) fingerprint.
+    const batchArg = mockCacheMetadataBatch.mock.calls[0][0] as Record<string, unknown>; // type-safety-ok: mock-call introspection in test
+    expect(batchArg["song.mp3"]).toEqual({
+      tags: { artist: "Fresh" },
+      size: live.size,
+      lastModified: live.lastModified,
     });
   });
 

--- a/audio/test/sidecar.test.ts
+++ b/audio/test/sidecar.test.ts
@@ -150,8 +150,10 @@ function makeEmptyDir(): FileSystemDirectoryHandle {
 describe("parseSidecar", () => {
   it("parses a valid sidecar JSON into the model", () => {
     const data: SidecarData = {
-      version: 1,
-      metadata: { "song.mp3": { title: "My Song", duration: 200 } },
+      version: 2,
+      metadata: {
+        "song.mp3": { tags: { title: "My Song", duration: 200 }, size: 1024, lastModified: 111 },
+      },
       playlists: { Favs: ["song.mp3"] },
     };
     const result = parseSidecar(JSON.stringify(data));
@@ -159,37 +161,37 @@ describe("parseSidecar", () => {
   });
 
   it("returns empty model for empty string", () => {
-    expect(parseSidecar("")).toEqual({ version: 1, metadata: {}, playlists: {} });
+    expect(parseSidecar("")).toEqual({ version: 2, metadata: {}, playlists: {} });
   });
 
   it("returns empty model for corrupt JSON", () => {
-    expect(parseSidecar("{not json")).toEqual({ version: 1, metadata: {}, playlists: {} });
+    expect(parseSidecar("{not json")).toEqual({ version: 2, metadata: {}, playlists: {} });
   });
 
   it("returns empty model for non-object top-level: number", () => {
-    expect(parseSidecar("42")).toEqual({ version: 1, metadata: {}, playlists: {} });
+    expect(parseSidecar("42")).toEqual({ version: 2, metadata: {}, playlists: {} });
   });
 
   it("returns empty model for non-object top-level: null", () => {
-    expect(parseSidecar("null")).toEqual({ version: 1, metadata: {}, playlists: {} });
+    expect(parseSidecar("null")).toEqual({ version: 2, metadata: {}, playlists: {} });
   });
 
   it("returns empty model for non-object top-level: string", () => {
-    expect(parseSidecar('"a string"')).toEqual({ version: 1, metadata: {}, playlists: {} });
+    expect(parseSidecar('"a string"')).toEqual({ version: 2, metadata: {}, playlists: {} });
   });
 
   it("returns empty model for non-object top-level: array", () => {
-    expect(parseSidecar("[1,2,3]")).toEqual({ version: 1, metadata: {}, playlists: {} });
+    expect(parseSidecar("[1,2,3]")).toEqual({ version: 2, metadata: {}, playlists: {} });
   });
 
-  it("forces version to 1 regardless of input", () => {
+  it("forces version to 2 regardless of input", () => {
     const json = JSON.stringify({ version: 99, metadata: {}, playlists: {} });
-    expect(parseSidecar(json).version).toBe(1);
+    expect(parseSidecar(json).version).toBe(2);
   });
 
   it("coerces missing metadata to {} while preserving valid playerState", () => {
     const json = JSON.stringify({
-      version: 1,
+      version: 2,
       playerState: { queue: ["a.mp3"], currentLocalName: "a.mp3", positionSeconds: 10 },
     });
     const result = parseSidecar(json);
@@ -199,7 +201,7 @@ describe("parseSidecar", () => {
 
   it("coerces wrong-typed metadata (array) to {} but preserves playerState", () => {
     const json = JSON.stringify({
-      version: 1,
+      version: 2,
       metadata: [1, 2],
       playerState: { queue: ["b.mp3"] },
     });
@@ -208,15 +210,57 @@ describe("parseSidecar", () => {
     expect(result.playerState?.queue).toEqual(["b.mp3"]);
   });
 
-  it("drops wrong-typed duration but keeps string title in metadata", () => {
+  it("drops wrong-typed duration but keeps string title in a wrapper entry's tags", () => {
     const json = JSON.stringify({
-      version: 1,
-      metadata: { "song.mp3": { title: "Keep", duration: "bad" } },
+      version: 2,
+      metadata: { "song.mp3": { tags: { title: "Keep", duration: "bad" }, size: 10, lastModified: 5 } },
       playlists: {},
     });
     const result = parseSidecar(json);
-    expect(result.metadata["song.mp3"]?.title).toBe("Keep");
-    expect("duration" in (result.metadata["song.mp3"] ?? {})).toBe(false);
+    expect(result.metadata["song.mp3"]?.tags.title).toBe("Keep");
+    expect("duration" in (result.metadata["song.mp3"]?.tags ?? {})).toBe(false);
+  });
+
+  describe("v1→v2 migration + fingerprint coercion", () => {
+    it("drops legacy v1 bare-AudioTags metadata entries (cache miss) while keeping playerState + playlists", () => {
+      const json = JSON.stringify({
+        version: 1,
+        // Legacy shape: bare AudioTags, no tags/size/lastModified wrapper.
+        metadata: { "old.mp3": { title: "Legacy", duration: 200 } },
+        playerState: { queue: ["old.mp3"], currentLocalName: "old.mp3", positionSeconds: 7 },
+        playlists: { Favs: ["old.mp3"] },
+      });
+      const result = parseSidecar(json);
+      expect(result.version).toBe(2);
+      // The legacy metadata entry is dropped → a cache miss → re-extraction later.
+      expect(result.metadata).toEqual({});
+      // Sibling state survives the migration untouched.
+      expect(result.playerState?.queue).toEqual(["old.mp3"]);
+      expect(result.playlists?.["Favs"]).toEqual(["old.mp3"]);
+    });
+
+    it("drops an entry with a non-numeric or missing size/lastModified, keeps a well-formed wrapper", () => {
+      const json = JSON.stringify({
+        version: 2,
+        metadata: {
+          "bad-size.mp3": { tags: { title: "A" }, size: "nope", lastModified: 5 },
+          "missing-lm.mp3": { tags: { title: "B" }, size: 10 },
+          "no-tags.mp3": { size: 10, lastModified: 5 },
+          "good.mp3": { tags: { title: "Good", duration: "bad" }, size: 20, lastModified: 9 },
+        },
+        playlists: {},
+      });
+      const result = parseSidecar(json);
+      expect("bad-size.mp3" in result.metadata).toBe(false);
+      expect("missing-lm.mp3" in result.metadata).toBe(false);
+      expect("no-tags.mp3" in result.metadata).toBe(false);
+      // Well-formed wrapper kept; inner tags still coerced per-leaf (bad duration dropped).
+      expect(result.metadata["good.mp3"]).toEqual({
+        tags: { title: "Good" },
+        size: 20,
+        lastModified: 9,
+      });
+    });
   });
 
   describe("playlists coercion", () => {
@@ -283,12 +327,12 @@ describe("parseSidecar", () => {
 
     it("malformed playerState does not discard good metadata (independence, vice-versa)", () => {
       const json = JSON.stringify({
-        version: 1,
-        metadata: { "song.mp3": { title: "Keep" } },
+        version: 2,
+        metadata: { "song.mp3": { tags: { title: "Keep" }, size: 10, lastModified: 1 } },
         playerState: 42,
       });
       const result = parseSidecar(json);
-      expect(result.metadata["song.mp3"]?.title).toBe("Keep");
+      expect(result.metadata["song.mp3"]?.tags.title).toBe("Keep");
       expect(result.playerState).toBeUndefined();
     });
   });
@@ -308,30 +352,33 @@ describe("parseSidecar", () => {
 describe("mergeSidecar", () => {
   it("metadata patch wins per-key while untouched siblings + playerState + playlists are preserved", () => {
     const existing: SidecarData = {
-      version: 1,
+      version: 2,
       metadata: {
-        "song.mp3": { title: "Old" },
-        "other.mp3": { title: "Other" },
+        "song.mp3": { tags: { title: "Old" }, size: 10, lastModified: 1 },
+        "other.mp3": { tags: { title: "Other" }, size: 20, lastModified: 2 },
       },
       playerState: { queue: ["song.mp3"], currentLocalName: "song.mp3", positionSeconds: 30 },
       playlists: { Favs: ["song.mp3"] },
     };
-    const result = mergeSidecar(existing, { metadata: { "song.mp3": { title: "New" } } });
+    const result = mergeSidecar(existing, {
+      metadata: { "song.mp3": { tags: { title: "New" }, size: 11, lastModified: 3 } },
+    });
 
-    expect(result.metadata["song.mp3"]?.title).toBe("New");
+    expect(result.metadata["song.mp3"]?.tags.title).toBe("New");
+    expect(result.metadata["song.mp3"]?.size).toBe(11);
     // Sibling preserved
-    expect(result.metadata["other.mp3"]?.title).toBe("Other");
+    expect(result.metadata["other.mp3"]?.tags.title).toBe("Other");
     // playerState preserved
     expect(result.playerState).toEqual(existing.playerState);
     // Playlists preserved
     expect(result.playlists).toEqual(existing.playlists);
-    expect(result.version).toBe(1);
+    expect(result.version).toBe(2);
   });
 
   it("playerState partial patch keeps existing queue + currentLocalName", () => {
     const existing: SidecarData = {
-      version: 1,
-      metadata: { "a.mp3": { title: "A" } },
+      version: 2,
+      metadata: { "a.mp3": { tags: { title: "A" }, size: 10, lastModified: 1 } },
       playerState: { queue: ["a.mp3"], currentLocalName: "a.mp3", positionSeconds: 10 },
       playlists: {},
     };
@@ -341,13 +388,13 @@ describe("mergeSidecar", () => {
     expect(result.playerState?.currentLocalName).toBe("a.mp3");
     expect(result.playerState?.positionSeconds).toBe(99);
     // Metadata preserved
-    expect(result.metadata["a.mp3"]?.title).toBe("A");
+    expect(result.metadata["a.mp3"]?.tags.title).toBe("A");
   });
 
   it("playlist patch preserves metadata + playerState", () => {
     const existing: SidecarData = {
-      version: 1,
-      metadata: { "b.mp3": { title: "B" } },
+      version: 2,
+      metadata: { "b.mp3": { tags: { title: "B" }, size: 10, lastModified: 1 } },
       playerState: { queue: ["b.mp3"] },
       playlists: { Old: ["b.mp3"] },
     };
@@ -361,7 +408,7 @@ describe("mergeSidecar", () => {
 
   it("returns a new object (does not mutate existing)", () => {
     const existing: SidecarData = {
-      version: 1,
+      version: 2,
       metadata: {},
       playlists: { Favs: ["x.mp3"] },
     };
@@ -379,10 +426,14 @@ describe("mergeSidecar", () => {
 describe("serializeSidecar + parseSidecar round-trip", () => {
   it("round-trips a complete model (metadata + playerState + playlists)", () => {
     const data: SidecarData = {
-      version: 1,
+      version: 2,
       metadata: {
-        "song.mp3": { title: "Song", artist: "Artist", duration: 180 },
-        "tune.flac": { title: "Tune", year: 2020 },
+        "song.mp3": {
+          tags: { title: "Song", artist: "Artist", duration: 180 },
+          size: 1000,
+          lastModified: 111,
+        },
+        "tune.flac": { tags: { title: "Tune", year: 2020 }, size: 2000, lastModified: 222 },
       },
       playerState: {
         queue: ["song.mp3", "tune.flac"],
@@ -396,12 +447,16 @@ describe("serializeSidecar + parseSidecar round-trip", () => {
   });
 
   it("round-trips an empty model", () => {
-    const empty: SidecarData = { version: 1, metadata: {}, playlists: {} };
+    const empty: SidecarData = { version: 2, metadata: {}, playlists: {} };
     expect(parseSidecar(serializeSidecar(empty))).toEqual(empty);
   });
 
   it("serializes to valid JSON (parseable by JSON.parse)", () => {
-    const data: SidecarData = { version: 1, metadata: { "a.mp3": { duration: 5 } }, playlists: {} };
+    const data: SidecarData = {
+      version: 2,
+      metadata: { "a.mp3": { tags: { duration: 5 }, size: 10, lastModified: 1 } },
+      playlists: {},
+    };
     expect(() => JSON.parse(serializeSidecar(data))).not.toThrow();
   });
 });
@@ -413,8 +468,8 @@ describe("serializeSidecar + parseSidecar round-trip", () => {
 describe("readSidecar", () => {
   it("reads and parses a present sidecar file", async () => {
     const data: SidecarData = {
-      version: 1,
-      metadata: { "song.mp3": { title: "Found", duration: 100 } },
+      version: 2,
+      metadata: { "song.mp3": { tags: { title: "Found", duration: 100 }, size: 50, lastModified: 7 } },
       playlists: { Favs: ["song.mp3"] },
     };
     const { dir } = makePreloadedDir(serializeSidecar(data));
@@ -426,18 +481,18 @@ describe("readSidecar", () => {
   it("returns empty model when the .commons-audio directory is absent (NotFoundError)", async () => {
     const dir = makeEmptyDir();
     const result = await readSidecar(dir);
-    expect(result).toEqual({ version: 1, metadata: {}, playlists: {} });
+    expect(result).toEqual({ version: 2, metadata: {}, playlists: {} });
   });
 
   it("returns empty model when index.json is absent (NotFoundError)", async () => {
     const dir = makeDirWithMissingFile();
     const result = await readSidecar(dir);
-    expect(result).toEqual({ version: 1, metadata: {}, playlists: {} });
+    expect(result).toEqual({ version: 2, metadata: {}, playlists: {} });
   });
 
   it("returns empty model when content is corrupt JSON", async () => {
     const { dir } = makePreloadedDir("{not json");
-    await expect(readSidecar(dir)).resolves.toEqual({ version: 1, metadata: {}, playlists: {} });
+    await expect(readSidecar(dir)).resolves.toEqual({ version: 2, metadata: {}, playlists: {} });
   });
 });
 
@@ -445,8 +500,8 @@ describe("writeSidecar", () => {
   it("write-then-read round-trip", async () => {
     const dir = makeEmptyDir();
     const data: SidecarData = {
-      version: 1,
-      metadata: { "song.mp3": { title: "Written" } },
+      version: 2,
+      metadata: { "song.mp3": { tags: { title: "Written" }, size: 33, lastModified: 4 } },
       playlists: {},
     };
 
@@ -462,7 +517,7 @@ describe("writeSidecar", () => {
     const dir = makeFakeDir({ ".commons-audio": subdir });
 
     await expect(
-      writeSidecar(dir, { version: 1, metadata: {}, playlists: {} }),
+      writeSidecar(dir, { version: 2, metadata: {}, playlists: {} }),
     ).rejects.toThrow("write failed");
     expect(fileHandle._abortSpy).toHaveBeenCalled();
   });
@@ -474,7 +529,7 @@ describe("writeSidecar", () => {
     const dir = makeFakeDir({ ".commons-audio": subdir });
 
     await expect(
-      writeSidecar(dir, { version: 1, metadata: {}, playlists: {} }),
+      writeSidecar(dir, { version: 2, metadata: {}, playlists: {} }),
     ).rejects.toThrow("close failed");
     expect(fileHandle._abortSpy).toHaveBeenCalled();
   });
@@ -493,24 +548,40 @@ describe("cacheMetadata / getMetadata — writable=true", () => {
     const dir = makeEmptyDir();
     setLocalDirectory(dir, true);
 
-    await cacheMetadata("song.mp3", { title: "Test Song", duration: 180 });
+    await cacheMetadata("song.mp3", {
+      tags: { title: "Test Song", duration: 180 },
+      size: 1024,
+      lastModified: 111,
+    });
     await flushWrites();
 
-    expect(await getMetadata("song.mp3")).toEqual({ title: "Test Song", duration: 180 });
+    expect(await getMetadata("song.mp3")).toEqual({
+      tags: { title: "Test Song", duration: 180 },
+      size: 1024,
+      lastModified: 111,
+    });
 
     const readBack = await readSidecar(dir);
-    expect(readBack.metadata["song.mp3"]).toEqual({ title: "Test Song", duration: 180 });
+    expect(readBack.metadata["song.mp3"]).toEqual({
+      tags: { title: "Test Song", duration: 180 },
+      size: 1024,
+      lastModified: 111,
+    });
   });
 
   it("key is the bare filename, no 'local:' prefix on disk", async () => {
     const dir = makeEmptyDir();
     setLocalDirectory(dir, true);
 
-    await cacheMetadata("song.mp3", { title: "My Song" });
+    await cacheMetadata("song.mp3", { tags: { title: "My Song" }, size: 10, lastModified: 1 });
     await flushWrites();
 
     const readBack = await readSidecar(dir);
-    expect(readBack.metadata["song.mp3"]).toEqual({ title: "My Song" });
+    expect(readBack.metadata["song.mp3"]).toEqual({
+      tags: { title: "My Song" },
+      size: 10,
+      lastModified: 1,
+    });
     expect(Object.keys(readBack.metadata).some((k) => k.startsWith("local:"))).toBe(false);
   });
 
@@ -518,13 +589,21 @@ describe("cacheMetadata / getMetadata — writable=true", () => {
     const dir = makeEmptyDir();
     setLocalDirectory(dir, true);
 
-    void cacheMetadata("a.mp3", { title: "A", duration: 100 });
-    void cacheMetadata("b.mp3", { title: "B", duration: 200 });
+    void cacheMetadata("a.mp3", { tags: { title: "A", duration: 100 }, size: 1, lastModified: 1 });
+    void cacheMetadata("b.mp3", { tags: { title: "B", duration: 200 }, size: 2, lastModified: 2 });
     await flushWrites();
 
     const readBack = await readSidecar(dir);
-    expect(readBack.metadata["a.mp3"]).toEqual({ title: "A", duration: 100 });
-    expect(readBack.metadata["b.mp3"]).toEqual({ title: "B", duration: 200 });
+    expect(readBack.metadata["a.mp3"]).toEqual({
+      tags: { title: "A", duration: 100 },
+      size: 1,
+      lastModified: 1,
+    });
+    expect(readBack.metadata["b.mp3"]).toEqual({
+      tags: { title: "B", duration: 200 },
+      size: 2,
+      lastModified: 2,
+    });
   });
 });
 
@@ -537,11 +616,15 @@ describe("cacheMetadata / getMetadata — writable=false", () => {
     const dir = makeEmptyDir();
     setLocalDirectory(dir, false);
 
-    await cacheMetadata("song.mp3", { title: "In-memory" });
+    await cacheMetadata("song.mp3", { tags: { title: "In-memory" }, size: 10, lastModified: 1 });
     await flushWrites();
 
     // In-memory accessible
-    expect(await getMetadata("song.mp3")).toEqual({ title: "In-memory" });
+    expect(await getMetadata("song.mp3")).toEqual({
+      tags: { title: "In-memory" },
+      size: 10,
+      lastModified: 1,
+    });
 
     // .commons-audio dir was never created
     const anySubdirs = (dir as unknown as { _subdirs: Record<string, unknown> })._subdirs; // type-safety-ok: test fake internals (_subdirs) access
@@ -557,9 +640,13 @@ describe("clearLocalDirectory", () => {
   it("drops the handle and resets the model so the next access is empty", async () => {
     const dir = makeEmptyDir();
     setLocalDirectory(dir, true);
-    await cacheMetadata("song.mp3", { title: "Cached" });
+    await cacheMetadata("song.mp3", { tags: { title: "Cached" }, size: 10, lastModified: 1 });
     await flushWrites();
-    expect(await getMetadata("song.mp3")).toEqual({ title: "Cached" });
+    expect(await getMetadata("song.mp3")).toEqual({
+      tags: { title: "Cached" },
+      size: 10,
+      lastModified: 1,
+    });
 
     clearLocalDirectory();
 
@@ -573,7 +660,7 @@ describe("clearLocalDirectory", () => {
 
     clearLocalDirectory();
 
-    await cacheMetadata("late.mp3", { title: "Late" });
+    await cacheMetadata("late.mp3", { tags: { title: "Late" }, size: 10, lastModified: 1 });
     await flushWrites();
 
     // No disk write hit the now-disconnected folder.
@@ -604,14 +691,22 @@ describe("cacheMetadataBatch", () => {
     setLocalDirectory(dir, true);
 
     await cacheMetadataBatch({
-      "a.mp3": { title: "A", duration: 100 },
-      "b.mp3": { title: "B", duration: 200 },
+      "a.mp3": { tags: { title: "A", duration: 100 }, size: 1, lastModified: 1 },
+      "b.mp3": { tags: { title: "B", duration: 200 }, size: 2, lastModified: 2 },
     });
     await flushWrites();
 
     const readBack = await readSidecar(dir);
-    expect(readBack.metadata["a.mp3"]).toEqual({ title: "A", duration: 100 });
-    expect(readBack.metadata["b.mp3"]).toEqual({ title: "B", duration: 200 });
+    expect(readBack.metadata["a.mp3"]).toEqual({
+      tags: { title: "A", duration: 100 },
+      size: 1,
+      lastModified: 1,
+    });
+    expect(readBack.metadata["b.mp3"]).toEqual({
+      tags: { title: "B", duration: 200 },
+      size: 2,
+      lastModified: 2,
+    });
   });
 });
 
@@ -693,15 +788,21 @@ describe("savePlaylist / getPlaylists", () => {
 describe("sidecar — loads from pre-existing file", () => {
   it("reads existing sidecar from disk on first access", async () => {
     const existingData: SidecarData = {
-      version: 1,
-      metadata: { "existing.mp3": { title: "Existing", duration: 200 } },
+      version: 2,
+      metadata: {
+        "existing.mp3": { tags: { title: "Existing", duration: 200 }, size: 99, lastModified: 8 },
+      },
       playerState: { queue: ["existing.mp3"], currentLocalName: "existing.mp3", positionSeconds: 25 },
       playlists: { Old: ["existing.mp3"] },
     };
     const { dir } = makePreloadedDir(serializeSidecar(existingData));
     setLocalDirectory(dir, true);
 
-    expect(await getMetadata("existing.mp3")).toEqual({ title: "Existing", duration: 200 });
+    expect(await getMetadata("existing.mp3")).toEqual({
+      tags: { title: "Existing", duration: 200 },
+      size: 99,
+      lastModified: 8,
+    });
     expect(await getPlayerState()).toEqual({
       queue: ["existing.mp3"],
       currentLocalName: "existing.mp3",

--- a/mediautil/src/local-folder.ts
+++ b/mediautil/src/local-folder.ts
@@ -30,9 +30,14 @@ export interface LocalFolderMediaSourceConfig<T extends { id: string; addedAt: s
   toItem: (file: File, name: string) => T | null;
 }
 
+export interface LocalFolderMediaSource<T extends { id: string; addedAt: string }>
+  extends MediaSource<T> {
+  resolveToFile(item: T): Promise<File>;
+}
+
 export function createLocalFolderMediaSource<T extends { id: string; addedAt: string }>(
   config: LocalFolderMediaSourceConfig<T>,
-): MediaSource<T> {
+): LocalFolderMediaSource<T> {
   const index = new Map<string, LocalFileHandleLike>();
   const items = new Map<string, T>();
   let pendingScan: Promise<T[]> | null = null;
@@ -93,7 +98,7 @@ export function createLocalFolderMediaSource<T extends { id: string; addedAt: st
       return item ?? null;
     },
 
-    async resolveToBlob(item) {
+    async resolveToFile(item) {
       let handle = index.get(item.id);
       if (!handle) {
         await scan();
@@ -106,7 +111,11 @@ export function createLocalFolderMediaSource<T extends { id: string; addedAt: st
       // revoked, IO failure) — propagate it rather than masking it as
       // "no longer present", which is reserved for a genuinely absent entry.
       const file = await handle.getFile();
-      return file.arrayBuffer();
+      return file;
+    },
+
+    async resolveToBlob(item) {
+      return (await this.resolveToFile(item)).arrayBuffer();
     },
   };
 }

--- a/mediautil/test/local-folder.test.ts
+++ b/mediautil/test/local-folder.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import {
   createLocalFolderMediaSource,
   type LocalDirEntryLike,
-  type LocalFolderMediaSource,
 } from "../src/local-folder";
 
 interface TestItem {

--- a/mediautil/test/local-folder.test.ts
+++ b/mediautil/test/local-folder.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   createLocalFolderMediaSource,
   type LocalDirEntryLike,
+  type LocalFolderMediaSource,
 } from "../src/local-folder";
 
 interface TestItem {
@@ -229,5 +230,70 @@ describe("resolveToBlob", () => {
     };
 
     await expect(source.resolveToBlob(item)).rejects.toThrow("file removed");
+  });
+});
+
+describe("resolveToFile", () => {
+  it("returns the File for a present item with correct name, size, and lastModified", async () => {
+    const content = "hello world";
+    const file = new File([content], "doc.txt", { lastModified: 12345678 });
+    const dir = makeFakeDirectory([{ kind: "file", name: "doc.txt", file }]);
+    const source = createLocalFolderMediaSource<TestItem>({
+      directory: dir,
+      toItem,
+    }) as LocalFolderMediaSource<TestItem>;
+
+    const items = await source.list();
+    const result = await source.resolveToFile(items[0]);
+
+    expect(result.name).toBe("doc.txt");
+    expect(result.size).toBe(new TextEncoder().encode(content).byteLength);
+    expect(result.lastModified).toBe(12345678);
+  });
+
+  it("throws with 'Local file no longer present' when id is absent after re-scan", async () => {
+    const dir = {
+      values(): AsyncIterableIterator<LocalDirEntryLike> {
+        return (async function* () {})();
+      },
+    };
+    const source = createLocalFolderMediaSource<TestItem>({
+      directory: dir,
+      toItem,
+    }) as LocalFolderMediaSource<TestItem>;
+
+    const missingItem: TestItem = {
+      id: "id:gone.txt",
+      addedAt: new Date(1000).toISOString(),
+      name: "gone.txt",
+    };
+
+    await expect(source.resolveToFile(missingItem)).rejects.toThrow(
+      /Local file no longer present/,
+    );
+  });
+
+  it("coalesces onto an in-flight scan", async () => {
+    const content = "hello world";
+    const file = new File([content], "doc.txt", { lastModified: 1000 });
+    const dir = makeFakeDirectory([{ kind: "file", name: "doc.txt", file }]);
+    const source = createLocalFolderMediaSource<TestItem>({
+      directory: dir,
+      toItem,
+    }) as LocalFolderMediaSource<TestItem>;
+
+    const presentItem: TestItem = {
+      id: "id:doc.txt",
+      addedAt: new Date(1000).toISOString(),
+      name: "doc.txt",
+    };
+
+    // Start a scan but do not await it: resolveToFile must coalesce onto this
+    // in-flight scan rather than observe the momentarily-empty index and re-scan.
+    const p1 = source.list();
+    const result = await source.resolveToFile(presentItem);
+
+    expect(result.name).toBe("doc.txt");
+    await p1;
   });
 });

--- a/mediautil/test/local-folder.test.ts
+++ b/mediautil/test/local-folder.test.ts
@@ -241,7 +241,7 @@ describe("resolveToFile", () => {
     const source = createLocalFolderMediaSource<TestItem>({
       directory: dir,
       toItem,
-    }) as LocalFolderMediaSource<TestItem>;
+    });
 
     const items = await source.list();
     const result = await source.resolveToFile(items[0]);
@@ -260,7 +260,7 @@ describe("resolveToFile", () => {
     const source = createLocalFolderMediaSource<TestItem>({
       directory: dir,
       toItem,
-    }) as LocalFolderMediaSource<TestItem>;
+    });
 
     const missingItem: TestItem = {
       id: "id:gone.txt",
@@ -280,7 +280,7 @@ describe("resolveToFile", () => {
     const source = createLocalFolderMediaSource<TestItem>({
       directory: dir,
       toItem,
-    }) as LocalFolderMediaSource<TestItem>;
+    });
 
     const presentItem: TestItem = {
       id: "id:doc.txt",


### PR DESCRIPTION
Closes #2303

## Problem

The audio app's local-folder library cached extracted track metadata in a
`.commons-audio/index.json` sidecar keyed by bare filename, with **no content
fingerprint**. Replacing a file in place with new content under the same name
(e.g. re-encoding a track at a different bitrate) left the cached `title`,
`artist`, `duration`, etc. stale indefinitely: the enrichment cache-hit check
short-circuited on a present entry and never re-extracted.

## Fix

Store a low-cost approximate fingerprint — the FSA `File`'s `.size` and
`.lastModified` — in each cache entry and re-validate it on every enrichment
pass. A mismatch (or a fingerprint-less legacy entry) triggers re-extraction and
rewrites the entry. This is option 1 from the issue (one `getFile()` per entry,
no cryptographic hashing), deferred from PR #1839.

## Changes

- **`mediautil`** — `createLocalFolderMediaSource` now returns a
  `LocalFolderMediaSource` exposing a local-only `resolveToFile(item):
  Promise<File>`, so a single `getFile()` yields size, mtime, and bytes.
  `resolveToBlob` delegates to it; the shared `MediaSource` interface is
  unchanged (the Firebase source has no `File`).
- **`audio` sidecar (schema v2)** — each cached entry is now a `CachedMetadata`
  wrapper (`{ tags, size, lastModified }`). `coerceMetadata` drops any entry
  lacking a finite numeric `size`/`lastModified`, which migrates a v1 sidecar in
  place: legacy bare-`AudioTags` entries are dropped at parse → treated as cache
  misses → re-extracted. `playerState`/`playlists` are unaffected.
- **`audio` enrichment** — `enrichLocalItem` re-validates the fingerprint:
  matching `size`+`lastModified` overlays cached tags and skips the byte read;
  a miss/mismatch re-extracts and rewrites the entry with the current
  fingerprint (`file.arrayBuffer()` guarded against a TOCTOU vanish). The cheap
  first-render `listLocalTracks` overlay is unchanged; staleness is corrected by
  the post-render enrichment pass.

## Verification

- `tsc --noEmit` clean for both `mediautil` and `audio` (the load-bearing gate
  for the schema bump — vitest does not typecheck).
- `vitest --project mediautil` (21 passed) and `vitest --project audio`
  (235 passed) green, including new tests for the three acceptance criteria:
  matching-fingerprint cache hit skips extraction; mismatched fingerprint
  re-extracts and writes the new fingerprint; missing-fingerprint legacy entry
  re-extracts.

Manual QA (deferred): connect a local folder, let metadata enrich, replace a
track file in place with re-encoded content under the same name — the next scan
should update title/artist/duration to the new content.
