### PR TITLE
dispatch-token-audit: condense duplicate sidecar prose in Per-session artifact join

### DIFF
--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -190,9 +190,7 @@ These slices are yield metrics, not cost metrics — they do not sort into the r
 
 ## Per-session artifact join
 
-Each dispatch worker session writes a sidecar file next to its transcript before it starts work. `aggregate-usage.sh` reads the sidecar and surfaces its contents on every entry in `.sessions[]` as the `artifact` field. The join is by transcript stem: `<session-id>.jsonl` and `<session-id>.dispatch-stamp.json` share the same stem, so the script locates the sidecar from the transcript path directly — no separate index or lookup is needed.
-
-**`artifact`** — present on every `.sessions[]` entry. It is the sidecar record `{repo, issue, pr, base_sha, branch}`, or `null` for sessions with no sidecar (subagent transcripts, router ticks, pre-#1861 worker sessions, and any non-worker session that did not write one). The four primary join keys are `{repo, issue, pr, base_sha}`; `branch` is also present for human-readable context. `base_sha` is the worktree HEAD at session start — preserved across resume — so it anchors each session to the repository state it began from.
+The `artifact` field on each `.sessions[]` entry carries the per-session GitHub join record. Its `{repo, issue, pr, base_sha, branch}` shape, the session-id join key, and the sidecar's role as the authoritative-source for the overlapping join keys are described in Step 3 above. The field is `null` for sessions with no sidecar — subagent transcripts, router ticks, pre-#1861 worker sessions, and any non-worker session that did not write one.
 
 **jq slices against `tmp/usage-audit.json`:**
 
@@ -209,5 +207,3 @@ jq '.sessions | map(select(.artifact.pr == 1889)) | map({id, type, price_proxy_u
 # Token spend grouped by issue — which issues consumed the most proxy spend
 jq '[.sessions[] | select(.artifact != null)] | group_by(.artifact.issue) | map({issue: .[0].artifact.issue, sessions: length, price_proxy_usd: (map(.price_proxy_usd) | add)}) | sort_by(-.price_proxy_usd)' tmp/usage-audit.json
 ```
-
-**Sidecar ownership.** The sidecar is the single authoritative source for the overlapping join keys (`repo/issue/pr/base_sha`). The #1860 outcome envelope carries only its own non-overlapping outcome fields (findings, disposition, fix counts) — it does not repeat the join keys. This keeps the two records non-redundant: join on session id to combine cost figures with artifact context and outcome yield in one query.

--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -190,7 +190,7 @@ These slices are yield metrics, not cost metrics — they do not sort into the r
 
 ## Per-session artifact join
 
-The `artifact` field on each `.sessions[]` entry carries the per-session GitHub join record. Its `{repo, issue, pr, base_sha, branch}` shape, the session-id join key, and the sidecar's role as the authoritative-source for the overlapping join keys are described in Step 3 above. The field is `null` for sessions with no sidecar — subagent transcripts, router ticks, pre-#1861 worker sessions, and any non-worker session that did not write one.
+The `artifact` field on each `.sessions[]` entry carries the per-session GitHub join record. Its `{repo, issue, pr, base_sha, branch}` shape, the session-id join key, and the sidecar's role as the authoritative source for the overlapping join keys are described in Step 3 above. `base_sha` is the worktree HEAD at session start — preserved across resume — so it anchors each session to the repository state it began from. The field is `null` for sessions with no sidecar — subagent transcripts, router ticks, pre-#1861 worker sessions, and any non-worker session that did not write one.
 
 **jq slices against `tmp/usage-audit.json`:**
 


### PR DESCRIPTION
Closes #2266

## What

The `dispatch-token-audit` SKILL.md described the per-session sidecar join
record in two places: the Step 3 jq-slices block (`SKILL.md:88-93`) and the
`## Per-session artifact join` section. The section's intro paragraph, its
`**artifact**` field note, and its `**Sidecar ownership.**` paragraph all
restated the sidecar `{repo, issue, pr, base_sha, branch}` shape, the session-id
join key, and the authoritative-source rationale already given at line 93 — so
the schema lived in two places and both had to be edited whenever it changed.

## Change

Condensed the duplicated conceptual prose in `## Per-session artifact join` into
a single one-sentence forward reference to the Step 3 description. Retained the
section's unique contributions: the `null`-case enumeration (subagent
transcripts, router ticks, pre-#1861 worker sessions, non-worker sessions) and
the four jq slices. The Step 3 block is unchanged — it is now the single
canonical home of the sidecar schema.

## Verification

Documentation-only edit to a `SKILL.md`; no app test suite exercises it. The
plan's deterministic `verify` block passed: the duplicate `Sidecar ownership`
lead-in and intro sentence are gone, exactly one `authoritative source`
occurrence remains (the canonical Step 3 one), the `Step 3` forward reference is
present, and the `null`-case note plus all four jq slices are retained.

Surfaced by review of PR #2252; out of scope for that PR.
