### PR TITLE
dispatch-route: integration test for the malformed epic.json config-load failure path

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3523,6 +3523,27 @@ assert_eq "parse-job wins over candidate → INVOKE /budget-parse-job (directive
 assert_eq "parse-job wins over candidate → INVOKE /budget-parse-job (exit 0)" "0" "$ROUTE_RC"
 teardown
 
+# 26a. dispatch-route integration: malformed epic.json → candidate exits 3 →
+# route's "candidate hard error" else branch still falls back to INVOKE /plan-issue
+# at exit 0 (#2296). GATE-4 covers the candidate exit-3 in isolation; this asserts
+# the end-to-end route fallback through a dispatch-config-load failure.
+# dispatch-epic-labels (config-load) is the candidate's FIRST step and exits 3 on
+# malformed epic.json BEFORE the epic-label gate or sub-issues fetch, so no
+# sub-issues fixture is needed. The "epic" label on the issue documents that even a
+# would-be epic candidate still falls back safely when its config is malformed.
+echo "Test: no PR + malformed epic.json → candidate exit 3 → INVOKE /plan-issue"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo "/wt/58-epic" > "$STUB_DIR/worktree-toplevel.txt"
+printf 'not json{\n' > "$DISPATCH_CONFIG_DIR/epic.json"
+printf '{"state":"open","labels":[{"name":"epic"}]}\n' > "$STUB_DIR/arg-issue-58.json"
+route_run 58 /wt/58-epic
+assert_eq "malformed epic.json → candidate exit 3 → INVOKE /plan-issue (directive)" \
+  "INVOKE /plan-issue" "$ROUTE_OUT"
+assert_eq "malformed epic.json → candidate exit 3 → INVOKE /plan-issue (exit 0)" \
+  "0" "$ROUTE_RC"
+teardown
+
 # ============================================================================
 # dispatch-epic-resolved-candidate tests
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3527,8 +3527,11 @@ teardown
 # route's "candidate hard error" else branch still falls back to INVOKE /plan-issue
 # at exit 0 (#2296). GATE-4 covers the candidate exit-3 in isolation; this asserts
 # the end-to-end route fallback through a dispatch-config-load failure.
-# dispatch-epic-labels (config-load) is the candidate's FIRST step and exits 3 on
-# malformed epic.json BEFORE the epic-label gate or sub-issues fetch, so no
+# dispatch-epic-labels (config-load) is the candidate's FIRST step and exits 1 on
+# malformed epic.json (set -e propagation from dispatch-config-load);
+# dispatch-epic-resolved-candidate then surfaces that failure as exit 3
+# via its `|| { exit 3 }` branch. This happens BEFORE the epic-label gate or
+# sub-issues fetch, so no
 # sub-issues fixture is needed. The "epic" label on the issue documents that even a
 # would-be epic candidate still falls back safely when its config is malformed.
 echo "Test: no PR + malformed epic.json → candidate exit 3 → INVOKE /plan-issue"


### PR DESCRIPTION
Closes #2296

## What

Add a single `dispatch-route` integration test covering the
`dispatch-config-load` failure path, in
`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`.

## Why

`GATE-4` already tests `dispatch-epic-resolved-candidate` **in isolation** for
the malformed-`epic.json` case: the config-load failure makes the candidate exit
3 (the #2239 guard). What was **not** covered is the end-to-end `dispatch-route`
path: when the candidate exits 3 because of a malformed `epic.json`,
`dispatch-route`'s `else` "candidate hard error" arm must still fall back to
`INVOKE /plan-issue` and exit 0 — never promoting the non-zero candidate code
into a route abort.

A regression in that `else` branch (accidentally aborting on the non-zero code,
or forwarding the exit-3) would currently go undetected, because no test
exercised the route through a config-load failure. This adds exactly that
integration test.

## How

The new test (`26a`) is a faithful, mechanical instance of the established
route-test pattern, modeled on test #24 (the spent-epic → `/resolve-epic` test)
and `GATE-4` — the same `setup` / `teardown` / `route_run` harness, with a
**malformed** `epic.json` and **no** sub-issues fixtures (`dispatch-epic-labels`
runs config-load as the candidate's first step and exits 3 before the
epic-label gate or sub-issues fetch).

## Verification

The standalone, network-free suite (the same command CI runs) passes with the
new assertions:

```
Results: 3921/3921 passed, 0 failed
  PASS: malformed epic.json → candidate exit 3 → INVOKE /plan-issue (directive)
  PASS: malformed epic.json → candidate exit 3 → INVOKE /plan-issue (exit 0)
```
