### PR TITLE
audio: guard cachedModel writes with a generation counter (mid-read folder-switch TOCTOU)

### DIFF
--- a/audio/src/sidecar.ts
+++ b/audio/src/sidecar.ts
@@ -281,6 +281,9 @@ let writable = false;
 // next access re-reads from the new handle.
 let cachedModel: SidecarData | null = null;
 let loadPromise: Promise<SidecarData> | null = null;
+// Incremented on every setLocalDirectory / clearLocalDirectory so in-memory
+// assignments can be guarded against writes that started before the switch.
+let generation = 0;
 
 // True when the bound folder has a sidecar file on disk that exists but
 // could not be parsed (corrupt). While set, disk writes are suppressed so a
@@ -307,6 +310,7 @@ export function setLocalDirectory(handle: FileSystemDirectoryHandle, isWritable:
   dirHandle = handle;
   writable = isWritable;
   cachedModel = null;
+  generation++;
   loadPromise = null;
   corruptOnDisk = false;
   writeChain = Promise.resolve();
@@ -326,6 +330,7 @@ export function clearLocalDirectory(): void {
   dirHandle = null;
   writable = false;
   cachedModel = null;
+  generation++;
   loadPromise = null;
   corruptOnDisk = false;
   writeChain = Promise.resolve();
@@ -339,12 +344,17 @@ export async function ensureLoaded(): Promise<SidecarData> {
   if (cachedModel !== null) return cachedModel;
   if (loadPromise === null) {
     const handle = dirHandle;
+    const gen = generation;
     loadPromise = (
       handle === null ? Promise.resolve<SidecarData | null>(emptyModel()) : readSidecar(handle)
     ).then((model) => {
-      // The handle may have been rebound (setLocalDirectory) while readSidecar
-      // was in flight. A stale result must not mutate the freshly-reset state —
-      // discard it so the next ensureLoaded re-reads the current handle.
+      // The handle may have been rebound (setLocalDirectory / clearLocalDirectory)
+      // while readSidecar was in flight. A stale result must not mutate the
+      // freshly-reset state — discard it so the next ensureLoaded re-reads the
+      // current handle. The generation guard on `cachedModel = model` below
+      // additionally covers the clear-then-reconnect-with-the-same-handle case,
+      // where this handle check passes (identical handle object) but the folder
+      // was unbound and rebound, so the read is still stale.
       if (dirHandle !== handle) {
         return cachedModel ?? emptyModel();
       }
@@ -355,11 +365,14 @@ export async function ensureLoaded(): Promise<SidecarData> {
           new Error("sidecar corrupt on disk; suppressing writes to preserve recoverable user data"),
           { operation: "ensureLoaded" },
         );
-      } else {
-        corruptOnDisk = false;
-        cachedModel = model;
+        return cachedModel;
       }
-      return cachedModel;
+      corruptOnDisk = false;
+      // Skip the in-memory cache write when a switch landed during the read
+      // (generation moved), but still return the freshly-read model so an
+      // in-flight enqueueWrite task has its folder's data to merge and persist.
+      if (generation === gen) cachedModel = model;
+      return model;
     });
   }
   return loadPromise;
@@ -377,16 +390,21 @@ export async function ensureLoaded(): Promise<SidecarData> {
 function enqueueWrite(patch: SidecarPatch): Promise<void> {
   const snapshotHandle = dirHandle;
   const snapshotWritable = writable;
+  const snapshotGen = generation;
   writeChain = writeChain
     .then(async () => {
       // TOCTOU guard: if the bound directory changed between enqueue and
       // execution (rapid disconnect/reconnect), this patch was issued for the
       // previous folder — skip it entirely so it neither persists to the new
       // folder nor contaminates the new folder's in-memory model.
+      // The generation snapshot additionally guards the `cachedModel = merged`
+      // assignment below: a folder switch that lands during the ensureLoaded
+      // await window increments `generation`, so the stale task's merge result
+      // is never written into the new folder's in-memory cache.
       if (dirHandle !== snapshotHandle) return;
       const model = await ensureLoaded();
       const merged = mergeSidecar(model, patch);
-      cachedModel = merged;
+      if (generation === snapshotGen) cachedModel = merged;
       // The corruption was already logged once at load time (ensureLoaded);
       // return silently here so repeated saves (e.g. periodic playback-position
       // persistence) don't spam the error log.

--- a/audio/test/sidecar.test.ts
+++ b/audio/test/sidecar.test.ts
@@ -132,6 +132,41 @@ function makePreloadedDir(content: string): {
   return { dir, fileHandle };
 }
 
+/**
+ * Build a preloaded dir whose FIRST getDirectoryHandle(".commons-audio") call
+ * parks until release() is called, gating the read at the first FSA round-trip
+ * — the exact window the mid-read folder-switch TOCTOU exploits. Later calls
+ * delegate to the real preloaded behavior.
+ */
+function makeGatedPreloadedDir(content: string): {
+  dir: FileSystemDirectoryHandle;
+  release: () => void;
+} {
+  const { dir } = makePreloadedDir(content);
+  const realGetDirectoryHandle = dir.getDirectoryHandle.bind(dir);
+  let released: (() => void) | null = null;
+  let gated = false;
+  (dir as unknown as { getDirectoryHandle: unknown }).getDirectoryHandle = vi // type-safety-ok: test fake overrides getDirectoryHandle to gate the first FSA round-trip
+    .fn()
+    .mockImplementation((name: string, opts?: { create?: boolean }) => {
+      if (!gated) {
+        gated = true;
+        return new Promise((res) => {
+          released = () => res(realGetDirectoryHandle(name, opts));
+        });
+      }
+      return realGetDirectoryHandle(name, opts);
+    });
+  return {
+    dir,
+    release: () => {
+      if (released === null)
+        throw new Error("release() called before the gated read was reached");
+      released();
+    },
+  };
+}
+
 /** Build a fake directory with `.commons-audio` dir but NO `index.json`. */
 function makeDirWithMissingFile(): FileSystemDirectoryHandle {
   const subdir = makeFakeSubdir({}, true);
@@ -774,6 +809,46 @@ describe("folder switch — stale-handle TOCTOU", () => {
     expect(readB.metadata["b.mp3"]).toEqual({ tags: { title: "B" }, size: 2, lastModified: 2 });
     expect(readB.metadata["c.mp3"]).toEqual({ tags: { title: "C" }, size: 3, lastModified: 3 });
     expect(subdirsOf(dirA)[".commons-audio"]).toBeUndefined();
+  });
+
+  it("drops an in-flight stale write when the switch lands mid-read", async () => {
+    const { dir: dirA, release } = makeGatedPreloadedDir(
+      serializeSidecar({
+        version: 2,
+        metadata: { "diskA.mp3": { tags: { title: "DiskA" }, size: 9, lastModified: 9 } },
+        playlists: {},
+      }),
+    );
+    const dirB = makeEmptyDir();
+
+    setLocalDirectory(dirA, true);
+    // task_A snapshots dirA + generation; capture its promise directly — the
+    // switch below resets writeChain, so a post-switch flushWrites() would drain
+    // only the new chain, not task_A.
+    const pA = cacheMetadata("a.mp3", { tags: { title: "A" }, size: 1, lastModified: 1 });
+    // One microtask tick parks task_A on the gated read (the chain body runs as a
+    // single microtask; ensureLoaded → readSidecar → getDirectoryHandle is
+    // synchronous up to the gated await, so the body suspends on the gate).
+    await Promise.resolve();
+    // Switch to dirB DURING the in-flight dirA read: increments generation, nulls cache.
+    setLocalDirectory(dirB, true);
+    // Resolve dirA's read, letting task_A run past both contamination sites.
+    release();
+    // Safe: the per-link .catch in enqueueWrite swallows; awaiting guarantees both
+    // sites executed (site 1 inside the loadPromise ensureLoaded awaits, site 2 right after).
+    await pA;
+
+    // Site 2: task_A's merged patch must NOT have leaked into dirB's cache.
+    expect(await getMetadata("a.mp3")).toBeUndefined();
+    // Site 1: dirA's raw disk model must NOT have leaked into dirB's cache.
+    expect(await getMetadata("diskA.mp3")).toBeUndefined();
+
+    // dirB's cache is clean + usable: a fresh dirB write lands and the stale keys stay gone.
+    await cacheMetadata("b.mp3", { tags: { title: "B" }, size: 2, lastModified: 2 });
+    await flushWrites();
+    expect(await getMetadata("b.mp3")).toEqual({ tags: { title: "B" }, size: 2, lastModified: 2 });
+    expect(await getMetadata("a.mp3")).toBeUndefined();
+    expect(await getMetadata("diskA.mp3")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #2330

## Problem

`audio/src/sidecar.ts` holds a single in-memory model (`cachedModel`) for the
bound directory and serializes disk writes through `writeChain`. The existing
TOCTOU defense in `enqueueWrite` compares `dirHandle` identity once at the top of
the task body — but that comparison runs **before** `await ensureLoaded()`, which
performs several async FSA round-trips inside `readSidecar` (`getDirectoryHandle`
→ `getFileHandle` → `getFile` → `file.text()`).

If `setLocalDirectory(dirB)` fires during that await window (a user rapidly
picking two folders), two sites contaminate the **new** folder's in-memory cache
with the **old** folder's data:

1. `ensureLoaded`'s `.then()` assigns `cachedModel = model` from the stale dirA
   read, overwriting the `null` that `setLocalDirectory` just placed.
2. `enqueueWrite` then assigns `cachedModel = merged` (dirA patch merged onto
   dirA model), leaving dirB's cache holding dirA data.

Subsequent dirB reads return stale dirA data with no disk re-read, and the next
dirB write merges against that contaminated base and persists wrong data.
Handle-object identity also cannot guard the clear-then-reconnect-with-the-same-handle
edge (identical handle, but the folder was unbound and rebound).

## Fix

A module-scope `generation` counter, incremented on every `setLocalDirectory` /
`clearLocalDirectory`, snapshotted at read-start (`gen`) and at enqueue-time
(`snapshotGen`), guards **both** `cachedModel` assignments:

- `ensureLoaded` guards `cachedModel = model` with `if (generation === gen)`, but
  still **returns the freshly-read model** so an in-flight `enqueueWrite` task
  receives its own folder's data to merge and persist.
- `enqueueWrite` guards `cachedModel = merged` with `if (generation === snapshotGen)`.

The disk persist (`writeSidecar` to the snapshot handle) is deliberately left
**unguarded** — a stale task must still persist its data to the folder it was for
(#2308). Only the two in-memory `cachedModel` writes are guarded. Incrementing on
both `setLocalDirectory` and `clearLocalDirectory` covers the
clear-then-reconnect-with-the-same-handle case that handle identity misses.

## Test

A new test in the `folder switch — stale-handle TOCTOU` block exercises the
**mid-read** switch (the existing tests cover only the synchronous switch). A
gated-read fake parks `task_A` inside `readSidecar`'s first FSA round-trip; the
switch lands in that window. `dirA` is preloaded with distinctive `diskA.mp3`
content so the two contamination sites are discriminated:

- `getMetadata("a.mp3")` → `undefined` catches the `enqueueWrite` merged-patch leak.
- `getMetadata("diskA.mp3")` → `undefined` catches the `ensureLoaded` raw-disk-model leak.

Verified red on pre-fix source (fails at the site-2 assertion) and green after.

## Verification

- `npx vitest run --project audio --root .` — 245 passed, 1 skipped.
- `npx tsc --noEmit -p audio/tsconfig.json` — clean.
