### PR TITLE
dispatch-stamp-session: test path-traversal exit-2 guards

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -38739,6 +38739,60 @@ STAMP="$SCRIPT_DIR/dispatch-stamp-session"
   rm -rf "$d"
 )
 
+# 8. Mode A guard: --session-id with a `..` path-traversal segment exits 2 and
+#    writes no sidecar. The 999-fixture worker branch is load-bearing — the
+#    guard fires BEFORE the branch gate, so were it removed the input would flow
+#    past the gate and a sidecar WOULD be written, failing the assertion below.
+(
+  d=$(mktemp -d)
+  git -C "$d" init -q
+  git -C "$d" remote add origin https://github.com/natb1/commons.systems.git
+  git -C "$d" checkout -q -b 999-fixture
+  git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  rc=0
+  ( cd "$d" && "$STAMP" --session-id ../evil --transcript-path "$d/sess.jsonl" ) 2>/dev/null || rc=$?
+  assert_eq "stamp: --session-id ../evil exits 2" "2" "$rc"
+  assert_eq "stamp: --session-id ../evil writes no sidecar" "no" \
+    "$([ -f "$d/sess.dispatch-stamp.json" ] && echo yes || echo no)"
+  rm -rf "$d"
+)
+
+# 9. Mode A guard: --session-id with a `/` path component exits 2 and writes no
+#    sidecar (the session id is a bare stem; a slash is malformed).
+(
+  d=$(mktemp -d)
+  git -C "$d" init -q
+  git -C "$d" remote add origin https://github.com/natb1/commons.systems.git
+  git -C "$d" checkout -q -b 999-fixture
+  git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  rc=0
+  ( cd "$d" && "$STAMP" --session-id foo/bar --transcript-path "$d/sess.jsonl" ) 2>/dev/null || rc=$?
+  assert_eq "stamp: --session-id foo/bar exits 2" "2" "$rc"
+  assert_eq "stamp: --session-id foo/bar writes no sidecar" "no" \
+    "$([ -f "$d/sess.dispatch-stamp.json" ] && echo yes || echo no)"
+  rm -rf "$d"
+)
+
+# 10. Mode A guard: --transcript-path with a `..` segment exits 2 and writes no
+#     sidecar. The sidecar path is derived ${TRANSCRIPT_PATH%.jsonl}.dispatch-stamp.json,
+#     so with cd "$d" and transcript ../evil.jsonl the would-be sidecar lands at
+#     $d/../evil.dispatch-stamp.json — OUTSIDE $d. The no-sidecar assertion MUST
+#     target that exact escaped path; a `find "$d"` scan would never see it and
+#     would green even with the guard removed.
+(
+  d=$(mktemp -d)
+  git -C "$d" init -q
+  git -C "$d" remote add origin https://github.com/natb1/commons.systems.git
+  git -C "$d" checkout -q -b 999-fixture
+  git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  rc=0
+  ( cd "$d" && "$STAMP" --session-id sessok --transcript-path ../evil.jsonl ) 2>/dev/null || rc=$?
+  assert_eq "stamp: --transcript-path ../evil.jsonl exits 2" "2" "$rc"
+  assert_eq "stamp: --transcript-path ../evil.jsonl writes no sidecar (escaped path)" "no" \
+    "$([ -f "$d/../evil.dispatch-stamp.json" ] && echo yes || echo no)"
+  rm -rf "$d"
+)
+
 # ============================================================================
 # dispatch-open-pr — PR backfill into the per-session sidecar (#1861)
 # ============================================================================


### PR DESCRIPTION
Closes #2267

## What

Add regression test coverage for `dispatch-stamp-session`'s Mode A
path-traversal / control-char input-validation guards, which had no test
coverage. PR #2252 added these exit-2 guards but no test exercised them.

Three new self-contained subshell cases are appended to the
`=== dispatch-stamp-session ===` block in
`test-dispatch-scripts.sh` (tests 8, 9, 10), reusing the established
fresh-`mktemp -d` / `999-fixture` worker-branch pattern from the existing
tests:

- **Test 8** — `--session-id ../evil` → exit 2, no sidecar written.
- **Test 9** — `--session-id foo/bar` → exit 2, no sidecar written.
- **Test 10** — `--transcript-path ../evil.jsonl` → exit 2, no sidecar. The
  no-sidecar assertion targets the *escaped* derived path
  (`$d/../evil.dispatch-stamp.json`), since the sidecar is derived as
  `${TRANSCRIPT_PATH%.jsonl}.dispatch-stamp.json` and would land outside the
  temp dir.

## Why it matters

The Mode A guards fire *before* the worker-branch gate and any sidecar write.
The `999-fixture` worker branch in each test is load-bearing: if a guard were
ever dropped, the malicious input would flow past the branch gate and the
script *would* write a sidecar — failing the no-sidecar assertion. Without the
worker branch the test would green even with the guard deleted, so the branch
setup gives the regression real teeth.

This is purely additive, test-only coverage — `dispatch-stamp-session` itself
is unchanged.

## Verification

Full suite (`test-dispatch-scripts.sh`, the runner CI invokes directly) passes:
3919/3919, 0 failures, including the three new cases.
