### PR TITLE
dispatch-stop: session-scope in-flight background-task detection

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -132,6 +132,21 @@ if [ -z "$TRANSCRIPT_PATH" ] && [ -n "${CLAUDE_JOB_DIR:-}" ] && [ -f "$STATE_FIL
   fi
 fi
 
+# Resolve the current session ID for session_has_inflight_background_task's
+# session-scoped scan (#2261). PAYLOAD is the PRIMARY source: it reflects the
+# actually-running session, whereas state.json can be stale across a re-stamp.
+# Here-string feeds jq (NOT `echo "$PAYLOAD" | jq` — zsh echo un-escapes \t/\n
+# and corrupts the JSON; see .claude/rules/shell-json.md). Fallback when the
+# payload yields nothing: reuse the `_sid` already parsed from $STATE_FILE in the
+# block above (do not re-read). `${_sid:-}` is mandatory — `_sid` is only set
+# inside that `if` block, and under `set -u` + the ERR trap a bare unset
+# reference would abort the whole hook. When CURRENT_SESSION_ID stays empty the
+# scan degrades to the whole file (today's behavior).
+CURRENT_SESSION_ID=$(jq -r '.session_id // empty' <<<"$PAYLOAD" 2>/dev/null) || CURRENT_SESSION_ID=""
+if [ -z "$CURRENT_SESSION_ID" ] && [ -n "${_sid:-}" ]; then
+  CURRENT_SESSION_ID="$_sid"
+fi
+
 # Resolve issue number from the validated JOB_NAME (<N>-<slug>). Discriminator 2
 # guarantees JOB_NAME matches ^[0-9]+-, so the numeric prefix is non-empty.
 ISSUE_NUM="${JOB_NAME%%-*}"
@@ -416,20 +431,60 @@ session_scheduled_wakeup() {
 #            status; any notification means the task resumed the session and is
 #            no longer in-flight.
 #
-# Grep the file directly for literal substrings (not echo-into-jq): the IDs are
-# plain substrings, so grep is robust and sidesteps the control-char trap
+# Grep for literal substrings (not echo-into-jq): the IDs are plain substrings,
+# so grep is robust and sidesteps the control-char trap
 # (.claude/rules/shell-json.md), mirroring dispatch-recover-dispatched-phase /
 # dispatch-detect-rate-limit-death.
+#
+# Session-scoped scan (#2261): the extractions run against the CURRENT session's
+# records only, not the whole file. A RESUMED session carries the prior run's
+# transcript records forward into its own <sessionId>.jsonl, and each carried
+# record retains its ORIGINAL `sessionId`. A whole-file scan therefore re-detects
+# a background task launched-but-never-notified by a now-dead prior run as a
+# false in-flight positive — yielding hand-back and silently stalling the chain.
+# Filtering to CURRENT_SESSION_ID drops those carried records. This stays safe
+# for the live #2243 case: a still-running session's OWN launch record carries
+# that same session's sessionId (verified), so it survives the filter and still
+# hands back correctly.
+#
+# The whole-file fallback (CURRENT_SESSION_ID empty) is DELIBERATE and
+# LOAD-BEARING, and the asymmetry is exact — do NOT "simplify" it away per
+# code-style.md:
+#   - It fires ONLY when CURRENT_SESSION_ID is unresolvable (empty payload AND no
+#     state.json sessionId). That preserves today's exact behavior in that case.
+#   - It MUST NOT fire on "the scoped scan found no launch." When
+#     CURRENT_SESSION_ID IS resolved but the scoped scan finds no current-session
+#     launch, the correct result is a normal `return 1` (not in-flight). Softening
+#     that into a whole-file retry would re-detect the stale prior-session launch
+#     and reintroduce #2261.
 session_has_inflight_background_task() {
   [ -n "$TRANSCRIPT_PATH" ] && [ -r "$TRANSCRIPT_PATH" ] || return 1
-  local launched notified
-  launched=$(grep -oE 'launched in background\. Task ID: [A-Za-z0-9_-]+' "$TRANSCRIPT_PATH" 2>/dev/null \
+  local launched notified scan_src
+  # Scope the scan to the CURRENT session's raw records when CURRENT_SESSION_ID
+  # is resolved; otherwise fall back to the whole file (today's behavior). The
+  # gate is computed ONCE on CURRENT_SESSION_ID being empty. The whole-file leg
+  # is DELIBERATE and LOAD-BEARING — see the docblock above for why it must never
+  # become a `return 1` (#2261 vs #2243 asymmetry).
+  if [ -z "$CURRENT_SESSION_ID" ]; then
+    scan_src=$(cat "$TRANSCRIPT_PATH")
+  else
+    # Real transcripts carry the top-level un-escaped `"sessionId":"<id>"` form
+    # (no space after colon, raw quotes), so grep -F matches — keeping this
+    # function's literal-substring / control-char-trap-avoiding philosophy.
+    scan_src=$(grep -F "\"sessionId\":\"$CURRENT_SESSION_ID\"" "$TRANSCRIPT_PATH" 2>/dev/null)
+  fi
+  # UPDATE TRIGGER: this literal `launched in background. Task ID: <ID>` is the
+  # Workflow/Task tool's `tool_result` output format, emitted by the Claude Code
+  # harness — there is no in-repo definition to track. If the harness changes that
+  # output format, THIS launch pattern AND the matching `taskId":"<ID>"`
+  # notification pattern below must both be updated.
+  launched=$(printf '%s\n' "$scan_src" | grep -oE 'launched in background\. Task ID: [A-Za-z0-9_-]+' \
     | grep -oE '[A-Za-z0-9_-]+$' | sort -u)
   [ -n "$launched" ] || return 1
   # Tolerate the JSONL backslash-escaped quote form (\"taskId\":\"<ID>\") as
   # well as the bare "taskId":"<ID>" form — the <task-notification> payload is a
   # string value, so its inner quotes are backslash-escaped in the record.
-  notified=$(grep -oE 'taskId\\?":\\?"[A-Za-z0-9_-]+' "$TRANSCRIPT_PATH" 2>/dev/null \
+  notified=$(printf '%s\n' "$scan_src" | grep -oE 'taskId\\?":\\?"[A-Za-z0-9_-]+' \
     | grep -oE '[A-Za-z0-9_-]+$' | sort -u)
   # In-flight iff at least one launched ID has no matching notification, i.e.
   # the set difference (launched ∖ notified) is non-empty. comm -23 lists lines

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -25087,6 +25087,90 @@ else
 fi
 stop_teardown
 
+# --- Test #2261-D1.4: stale prior-session launch is ignored → normal Branch A park ---
+# A launch line from a DIFFERENT/old sessionId is a stale record carried forward
+# by a resume; the session-scoped scan (#2261) must ignore it, so with no
+# current-session launch the hook falls through to the normal Branch A
+# office-hours park.
+
+echo "Test: #2261 D1.4 stale prior-session launch ignored → normal Branch A park"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "implement" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+# No phase-completed marker.
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+# Fixture: old-session has a launch but NO notification; current session has a
+# record but no launch. The session-scoped scan must filter out the old-session
+# launch so the in-flight gate does not fire.
+cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
+{"type":"user","sessionId":"old-session-zzz","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: stale111"}]}}
+{"type":"assistant","sessionId":"cur-session-aaa","message":{"content":[{"type":"text","text":"working"}]}}
+EOF
+FIXTURE="$TMPDIR_TEST/transcript.jsonl"
+printf '%s\n' '{"transcript_path":"'"$FIXTURE"'","session_id":"cur-session-aaa"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
+rc=$?
+assert_eq "#2261 D1.4 stale prior-session launch: hook exits 0" "0" "$rc"
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
+TOTAL=$((TOTAL + 1))
+if [[ "$apply_issue" == "123" && -n "$apply_reason" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2261 D1.4 stale prior-session launch: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2261 D1.4 stale prior-session launch: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+  echo "    apply-log: $apply_log"
+fi
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "#2261 D1.4 stale prior-session launch: spawn invoked exactly once" "1" "$spawn_calls"
+stop_teardown
+
+# --- Test #2261-D1.5: current-session launch detected despite stale other-session noise → hand-back ---
+# The live #2243 guard: a current-session launch with no notification IS
+# in-flight and must hand back, even when a stale completed launch from another
+# session is also present; proves session-scoping did not regress #2243.
+
+echo "Test: #2261 D1.5 current-session launch in-flight despite stale noise → hand-back"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "implement" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+# No phase-completed marker.
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+# Fixture: current session launched live222 with NO notification → in-flight.
+# Old session launched stale333 and received its notification → fully completed
+# and must be filtered out by session-scoping.
+cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
+{"type":"user","sessionId":"cur-session-aaa","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: live222"}]}}
+{"type":"user","sessionId":"old-session-zzz","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: stale333"}]}}
+{"type":"user","sessionId":"old-session-zzz","message":{"content":[{"type":"tool_result","content":"{\"taskId\":\"stale333\",\"status\":\"completed\"}"}]}}
+EOF
+FIXTURE="$TMPDIR_TEST/transcript.jsonl"
+printf '%s\n' '{"transcript_path":"'"$FIXTURE"'","session_id":"cur-session-aaa"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
+rc=$?
+assert_eq "#2261 D1.5 current-session in-flight: hook exits 0 (hand-back)" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2261 D1.5 current-session in-flight: NOT parked on office-hours"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2261 D1.5 current-session in-flight: NOT parked on office-hours"
+  echo "    apply-log: $(cat "$STUB_DIR/apply-office-hours.log")"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/spawn-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2261 D1.5 current-session in-flight: NOT spawned (redundant tick suppressed)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2261 D1.5 current-session in-flight: NOT spawned (redundant tick suppressed)"
+  echo "    spawn-calls: $(cat "$STUB_DIR/spawn-calls.log")"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/self-close-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2261 D1.5 current-session in-flight: NOT self-closed"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2261 D1.5 current-session in-flight: NOT self-closed"
+fi
+stop_teardown
+
 # ============================================================================
 # dispatch-finalize-phase tests (#2243)
 # ============================================================================


### PR DESCRIPTION
Closes #2261

## Problem

`session_has_inflight_background_task` in `.claude/hooks/dispatch-stop.sh`
(added in PR #2251 for #2243) decides whether a Stop-hook turn yielded to await a
live background Workflow/Task. It detected in-flight tasks by grepping the
**entire** transcript file for launch lines (`launched in background. Task ID:
<ID>`) and notification entries (`taskId":"<ID>"`).

A resumed session carries the prior run's transcript records forward into its own
`<sessionId>.jsonl`, and those carried records retain their **original**
`sessionId`. So a background task launched-but-never-notified by a now-dead prior
run leaves a launched-without-notification record in the current session's file —
a **false positive**. The hook then hands the session back (exit 0, no park, no
tick spawned) waiting on a notification that never arrives, and the chain silently
stalls. A scan of 4843 live transcript files found 65 multi-session files,
confirming the collision premise is real, not theoretical.

## Fix

**AC2 — session-scoped scan.** Resolve `CURRENT_SESSION_ID` from the Stop
payload's `.session_id` (primary, here-string-fed to `jq` per
`.claude/rules/shell-json.md`) with the `state.json` `.sessionId` as fallback,
then scope the scan to the current session's records via a literal-substring
`grep -F "\"sessionId\":\"$CURRENT_SESSION_ID\""` before the launch/notify
extractions. Carried-forward prior-session records are dropped, so the false
positive disappears.

The whole-file fallback (today's behavior) fires **only** when
`CURRENT_SESSION_ID` is unresolvable — gated strictly on `[ -z
"$CURRENT_SESSION_ID" ]`, never on "the scoped scan found no launch." This
asymmetry is load-bearing and documented in the function docblock: the live
#2243 case stays safe because a still-running session's own launch record carries
that same session's `sessionId` and survives the filter, so genuine in-flight
phases still hand back and are never wrong-parked.

**AC1 — source-of-truth comment.** A maintenance note next to the launch-pattern
grep names the harness `tool_result` output format as the origin of the Task-ID
launch/notify patterns (there is no in-repo definition), so a future harness
format change has an explicit update trigger.

## Tests

Two new cases in `test-dispatch-scripts.sh`, mirroring the existing D1.1–D1.3
harness shape, both with top-level `sessionId` fixtures and a `session_id`
payload:

- **D1.4** — a stale prior-session launch is ignored; with no current-session
  launch the hook parks normally (the #2261 fix).
- **D1.5** — a current-session launch with no notification is still detected as
  in-flight and hands back, despite a stale completed other-session launch (the
  #2243 live-case guard).

D1.1–D1.3 are unchanged and still exercise the whole-file fallback (no
`sessionId`/`session_id`). Full suite: `3926/3926 passed, 0 failed`.
