### PR TITLE
dispatch: self-heal 529 Overloaded and Stream idle timeout deaths

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-detect-rate-limit-death
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-detect-rate-limit-death
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# Detects whether a Claude session died on a transient Anthropic server-overload
-# rate-limit rather than the user's own usage-limit exhaustion.
+# Detects whether a Claude session died on a transient server-side API death
+# (server-overload rate-limit, 529 Overloaded, or stream idle timeout) rather
+# than the user's own usage-limit exhaustion.
 #
 # Usage: dispatch-detect-rate-limit-death <transcript-path>
 #
 # Exit codes (fail-safe, positive-evidence-only):
-#   0 — the session's LAST assistant turn is a server-overload rate-limit error
+#   0 — the session's LAST assistant turn matches an allowlisted transient
+#       server-side death signature
 #   1 — any doubt: file unreadable, no assistant turns, last turn does not match
 #
 # JSONL shape matched (the death turn):
@@ -19,9 +21,11 @@
 # self-heal sessions that actually terminated on the rate-limit, not ones that
 # already recovered and died later for a different reason.
 #
-# WHY "(not your usage limit)": this substring appears only in the server-overload
-# error, not in the user-quota-exhaustion error. Auto-retry on quota exhaustion
-# would loop forever; we must never trigger it.
+# WHY the allowlist: only substrings known to be safe for a plain --resume retry
+# are listed. The user's quota-exhaustion error must never match — auto-retry on
+# quota exhaustion would loop forever. Similarly, errors that re-fail on a
+# verbatim retry (`prompt is too long`/413, `invalid_request_error`, etc.) must
+# never be added here.
 #
 # Real fixture (line 44 of the JSONL is the rate-limit turn, but NOT the last
 # assistant turn in that file, so the script correctly exits 1 for it):
@@ -41,5 +45,20 @@ last=$(jq -rc 'select(.type=="assistant")
 
 [ -n "$last" ] || exit 1
 
+# Positive allowlist: only signatures known to self-heal on a plain --resume
+# retry belong here. NEVER add re-failing deaths — `prompt is too long`/413,
+# `invalid_request_error`, or the resume-only `thinking blocks cannot be
+# modified` corruption all re-fail forever on a verbatim retry and must keep
+# falling through to office-hours. Match SHORT stable substrings, not full
+# sentences (the 529 message carries a drifting em-dash + URL).
+TRANSIENT_SIGNATURES=(
+  '(not your usage limit)'   # server-overload rate limit (original #1733)
+  '529 Overloaded'           # HTTP 529 server overload
+  'Stream idle timeout'      # streaming transport stall
+)
+
+grep_args=()
+for sig in "${TRANSIENT_SIGNATURES[@]}"; do grep_args+=(-e "$sig"); done
+
 printf '%s' "$last" | grep -q '"e":true' \
-  && printf '%s' "$last" | grep -qF '(not your usage limit)'
+  && printf '%s' "$last" | grep -qF "${grep_args[@]}"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-detect-rate-limit-death
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-detect-rate-limit-death
@@ -61,4 +61,4 @@ grep_args=()
 for sig in "${TRANSIENT_SIGNATURES[@]}"; do grep_args+=(-e "$sig"); done
 
 printf '%s' "$last" | grep -q '"e":true' \
-  && printf '%s' "$last" | grep -qF "${grep_args[@]}"
+  && printf '%s' "$last" | grep -qF "${grep_args[@]}"   # -F applies to ALL -e patterns: every signature is matched as a literal fixed string, so new TRANSIENT_SIGNATURES entries must NOT rely on regex metacharacters (`.`, `*`, etc.)

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -38036,10 +38036,11 @@ assert_eq "dispatch-auto-merge is executable" "yes" \
 # ============================================================================
 #
 # Exercises the rate-limit-death detector: exit 0 iff the transcript's LAST
-# assistant turn is an isApiErrorMessage:true turn whose joined text contains the
-# literal `(not your usage limit)`; exit 1 otherwise (fail-safe). Fixtures are
-# one compact JSON object per line, written with printf '%s\n' (NOT echo) so the
-# JSONL is byte-exact.
+# assistant turn is an isApiErrorMessage:true turn whose joined text contains any
+# of the allowlisted transient-death signatures — the original rate-limit
+# substring `(not your usage limit)`, `529 Overloaded`, or `Stream idle timeout`;
+# exit 1 otherwise (fail-safe). Fixtures are one compact JSON object per line,
+# written with printf '%s\n' (NOT echo) so the JSONL is byte-exact.
 echo ""
 echo "=== dispatch-detect-rate-limit-death ==="
 
@@ -38167,6 +38168,16 @@ SYSTEM_TURN='{"type":"system","content":"529 Overloaded noise"}'
 printf '%s\n' "$SYSTEM_TURN" "$NORMAL_TURN" > "$TMPDIR_TEST/system-only.jsonl"
 if "$DRD" "$TMPDIR_TEST/system-only.jsonl"; then rc=0; else rc=$?; fi
 assert_eq "529 in system line only exits 1" "1" "$rc"
+drd_teardown
+
+# --- Test 13: NOT-LAST — Stream idle timeout present but a later normal turn
+# A session that recovered after a stream-idle-timeout and died later for a
+# different reason has a DIFFERENT last turn; must NOT self-heal.
+echo "Test: Stream idle timeout apiError present but NOT the last turn (recovered) → exit 1"
+drd_setup
+printf '%s\n' "$IDLE_TURN" "$NORMAL_TURN" > "$TMPDIR_TEST/idle-notlast.jsonl"
+if "$DRD" "$TMPDIR_TEST/idle-notlast.jsonl"; then rc=0; else rc=$?; fi
+assert_eq "Stream idle timeout not the last turn exits 1" "1" "$rc"
 drd_teardown
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -37736,6 +37736,11 @@ NORMAL_TURN='{"type":"assistant","message":{"role":"assistant","content":[{"type
 # The user's OWN usage-limit exhaustion error — apiError, but WITHOUT the
 # `(not your usage limit)` substring, so the detector must NOT match it.
 USAGE_TURN='{"type":"assistant","isApiErrorMessage":true,"message":{"role":"assistant","content":[{"type":"text","text":"API Error: You have exceeded your usage limit. Resets at 5pm."}]}}'
+# Transient 529 server-overload death (full real sentence; the matcher keys on
+# the short substring `529 Overloaded`, surviving the drifting em-dash + URL).
+OVERLOADED_TURN='{"type":"assistant","isApiErrorMessage":true,"message":{"role":"assistant","content":[{"type":"text","text":"API Error: 529 Overloaded. This is a server-side issue, usually temporary — try again in a moment. If it persists, check https://status.claude.com."}]}}'
+# Streaming transport stall death.
+IDLE_TURN='{"type":"assistant","isApiErrorMessage":true,"message":{"role":"assistant","content":[{"type":"text","text":"API Error: Stream idle timeout - partial response received"}]}}'
 
 # --- Test 1: MATCH — last assistant turn IS the rate-limit apiError → exit 0 --
 echo "Test: last turn is the rate-limit apiError → exit 0 (match)"
@@ -37802,6 +37807,43 @@ drd_teardown
 echo "Test: no transcript argument → exit 1"
 if "$DRD"; then rc=0; else rc=$?; fi
 assert_eq "no-arg detector exits 1" "1" "$rc"
+
+# --- Test 9: MATCH — last turn is 529 Overloaded apiError → exit 0 -----------
+echo "Test: last turn is 529 Overloaded apiError → exit 0 (match)"
+drd_setup
+printf '%s\n' "$NORMAL_TURN" "$OVERLOADED_TURN" > "$TMPDIR_TEST/overloaded.jsonl"
+if "$DRD" "$TMPDIR_TEST/overloaded.jsonl"; then rc=0; else rc=$?; fi
+assert_eq "529 Overloaded match exits 0" "0" "$rc"
+drd_teardown
+
+# --- Test 10: MATCH — last turn is Stream idle timeout apiError → exit 0 -----
+echo "Test: last turn is Stream idle timeout apiError → exit 0 (match)"
+drd_setup
+printf '%s\n' "$NORMAL_TURN" "$IDLE_TURN" > "$TMPDIR_TEST/idle.jsonl"
+if "$DRD" "$TMPDIR_TEST/idle.jsonl"; then rc=0; else rc=$?; fi
+assert_eq "Stream idle timeout match exits 0" "0" "$rc"
+drd_teardown
+
+# --- Test 11: NOT-LAST — 529 Overloaded present but a later normal turn follows
+# A session that recovered after a 529 and died later for a different reason has
+# a DIFFERENT last turn; must NOT self-heal.
+echo "Test: 529 Overloaded apiError present but NOT the last turn (recovered) → exit 1"
+drd_setup
+printf '%s\n' "$OVERLOADED_TURN" "$NORMAL_TURN" > "$TMPDIR_TEST/overloaded-notlast.jsonl"
+if "$DRD" "$TMPDIR_TEST/overloaded-notlast.jsonl"; then rc=0; else rc=$?; fi
+assert_eq "529 Overloaded not the last turn exits 1" "1" "$rc"
+drd_teardown
+
+# --- Test 12: SYSTEM-LINE ONLY — `529 Overloaded` appears on a non-assistant
+# line; the last ASSISTANT turn is normal → exit 1. Proves the matcher reads
+# only assistant turns, not system/tool lines that happen to contain the text.
+echo "Test: 529 Overloaded only in a system line, last assistant turn normal → exit 1"
+drd_setup
+SYSTEM_TURN='{"type":"system","content":"529 Overloaded noise"}'
+printf '%s\n' "$SYSTEM_TURN" "$NORMAL_TURN" > "$TMPDIR_TEST/system-only.jsonl"
+if "$DRD" "$TMPDIR_TEST/system-only.jsonl"; then rc=0; else rc=$?; fi
+assert_eq "529 in system line only exits 1" "1" "$rc"
+drd_teardown
 
 # ============================================================================
 # dispatch-recover-dispatched-phase tests (#2025)


### PR DESCRIPTION
Closes #2340

## What

Generalize the dispatch transient-API-death detector
(`dispatch-detect-rate-limit-death`) from a single hardcoded server-overload
signature to a positive allowlist of three known-transient signatures, so a
session that dies on a **529 Overloaded** or a **Stream idle timeout** error
self-heals via the existing resume machinery instead of parking to
`dispatch:office-hours`.

## Why

#1733 (PR #1774) added a self-heal that resumes a phase worker which died on a
transient server-overload rate-limit. The detector exits 0 only when the
transcript's last assistant turn is an `isApiErrorMessage:true` turn whose text
contains the single literal `(not your usage limit)`.

Two other transient, server-side API deaths reach the **exact same** terminal
transcript shape (last assistant turn, `isApiErrorMessage:true`, error text in
`content[].text`) but do not contain that literal, so the detector exited 1 and
the worker fell through to an office-hours park — wedging autonomous progress
behind a human for a condition that self-heals on a plain `--resume`:

1. `API Error: 529 Overloaded. This is a server-side issue, usually temporary …`
2. `API Error: Stream idle timeout - partial response received`

## How

The single-literal matcher is replaced by a commented `TRANSIENT_SIGNATURES`
bash array, matched as short fixed substrings (`grep -qF -e … -e …`). The grep
arguments are built from the array so the allowlist and the matcher can never
drift apart. The comment is the safety contract: it documents why each signature
is allowed and warns against adding non-transient deaths (`prompt is too
long`/413, `invalid_request_error`, resume-only `thinking blocks` corruption)
that re-fail forever on a verbatim retry. The user's quota-exhaustion error still
never matches.

Short substrings (`529 Overloaded`, `Stream idle timeout`) are used deliberately
so the match survives the drifting em-dash + status URL in the full 529 message.

The two structural guards are unchanged: the `isApiErrorMessage==true` check and
the `tail -1` last-turn selection (`jq select(.type=="assistant")`). No
downstream change — `dispatch-resume-worker`,
`dispatch-schedule-rate-limit-resume`, and `dispatch-stop.sh` all key off this
script's exit code and are untouched. The script filename and the
`dispatch:rate-limit-retry-<n>` label prefix stay as-is.

## Tests

Four new cases added to the `dispatch-detect-rate-limit-death` block of
`test-dispatch-scripts.sh` (the suite CI runs):

1. 529 match (full real sentence) → exit 0.
2. Stream-idle-timeout match → exit 0.
3. 529 not-last-turn (recovered) → exit 1 (last-turn guard holds for new
   signatures).
4. 529 only in a `type:"system"` line → exit 1 (matcher reads only assistant
   turns).

The existing usage-limit non-match, original-signature not-last-turn non-match,
and original `(not your usage limit)` match remain and still pass under the
allowlist. Full suite: 3925/3925 passed.
