### PR TITLE
dispatch-token-audit: use <PR_NUMBER> placeholder in PR-filter jq example

### DIFF
--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -201,8 +201,8 @@ jq '.sessions | map({id, artifact}) | map(select(.artifact != null))' tmp/usage-
 # Filter sessions by issue number — e.g. all sessions that worked issue 1861
 jq '.sessions | map(select(.artifact.issue == 1861)) | map({id, type, price_proxy_usd, artifact})' tmp/usage-audit.json
 
-# Filter sessions by PR number
-jq '.sessions | map(select(.artifact.pr == 1889)) | map({id, type, price_proxy_usd, artifact})' tmp/usage-audit.json
+# Filter sessions by PR number — substitute your target PR for <PR_NUMBER>
+jq '.sessions | map(select(.artifact.pr == <PR_NUMBER>)) | map({id, type, price_proxy_usd, artifact})' tmp/usage-audit.json
 
 # Token spend grouped by issue — which issues consumed the most proxy spend
 jq '[.sessions[] | select(.artifact != null)] | group_by(.artifact.issue) | map({issue: .[0].artifact.issue, sessions: length, price_proxy_usd: (map(.price_proxy_usd) | add)}) | sort_by(-.price_proxy_usd)' tmp/usage-audit.json

--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -202,7 +202,7 @@ jq '.sessions | map({id, artifact}) | map(select(.artifact != null))' tmp/usage-
 jq '.sessions | map(select(.artifact.issue == 1861)) | map({id, type, price_proxy_usd, artifact})' tmp/usage-audit.json
 
 # Filter sessions by PR number — substitute your target PR for <PR_NUMBER>
-jq '.sessions | map(select(.artifact.pr == <PR_NUMBER>)) | map({id, type, price_proxy_usd, artifact})' tmp/usage-audit.json
+jq '.sessions | map(select(.artifact.pr == "<PR_NUMBER>")) | map({id, type, price_proxy_usd, artifact})' tmp/usage-audit.json
 
 # Token spend grouped by issue — which issues consumed the most proxy spend
 jq '[.sessions[] | select(.artifact != null)] | group_by(.artifact.issue) | map({issue: .[0].artifact.issue, sessions: length, price_proxy_usd: (map(.price_proxy_usd) | add)}) | sort_by(-.price_proxy_usd)' tmp/usage-audit.json


### PR DESCRIPTION
Closes #2271

## Summary

The `dispatch-token-audit` SKILL.md documents jq slices for querying
`tmp/usage-audit.json`. The PR-filter example hardcoded the real PR number
`1889` with no explanatory comment, so a reader could mistake it for a live or
meaningful query and copy it without substituting their own target PR. The
adjacent issue-filter example (`1861`) carries context in its comment, so only
the PR line was ambiguous.

## Change

In `.claude/skills/dispatch-token-audit/SKILL.md`, the PR-filter jq example now
uses an unambiguous `<PR_NUMBER>` angle-bracket placeholder, and its comment
signals the substitution (`# Filter sessions by PR number — substitute your
target PR for <PR_NUMBER>`). The angle-bracket form is the strongest "this is a
template, substitute it" signal — a bare number could still read as a live
value.

Documentation-only change; no other jq slice, the `1861` issue-filter example,
or the `pre-#1861` historical prose anchors were touched.

## Verification

The plan's deterministic check confirms `artifact.pr == 1889` is gone and
`artifact.pr == <PR_NUMBER>` is present.
