### PR TITLE
dispatch-token-audit: report sidecar-present rate to verify session-stamp coverage

### DIFF
--- a/.claude/hooks/stamp-dispatch-session.sh
+++ b/.claude/hooks/stamp-dispatch-session.sh
@@ -14,14 +14,22 @@
 #     the event actually fires in --bg mode.
 # (b) Whether the hook command has working local `git` access in the worktree
 #     context where it runs — dispatch-stamp-session calls `git rev-parse`
-#     and `git remote get-url`; if git is unavailable or CWD is wrong the stamp silently
-#     no-ops (never blocks).
+#     and `git remote get-url`; if git is unavailable or CWD is wrong the stamp
+#     silently no-ops (never blocks).
 #
-# FALLBACK: if this hook proves unreliable for detached --bg sessions, add a
-# scripted dispatch-stamp-session call at the start of each phase SKILL.md
-# (plan-issue, implement, qa-fix, review-fix, etc.) as a belt-and-suspenders
-# write. NOT implemented here — implement only if live testing shows the hook
-# is insufficient.
+# MONITOR: dispatch-token-audit now surfaces window.sidecar_eligible (count of
+# top-level worker sessions scanned), window.sidecar_present (those carrying a
+# .dispatch-stamp.json sidecar), and a derived window.sidecar_present_rate
+# (float in [0,1], or null when no workers were scanned). A drop in
+# sidecar_present_rate for worker sessions is observable from existing
+# transcripts WITHOUT a full dispatch run — this is the data-driven signal for
+# the two uncertainties above.
+#
+# ESCALATION: if the monitored rate shows the hook is insufficient for detached
+# --bg sessions, add a scripted dispatch-stamp-session call at the start of
+# each phase SKILL.md (plan-issue, implement, qa-fix, review-fix, etc.) as a
+# belt-and-suspenders write. NOT implemented — the monitor provides a
+# data-driven trigger for filing that follow-up if needed.
 set -uo pipefail
 trap 'echo "[stamp-dispatch-session] WARNING: unexpected error on line $LINENO" >&2; exit 0' ERR
 

--- a/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
@@ -675,7 +675,15 @@ def outcome_rates($o):
     } ) as $baseline_lens
 
 | {
-    window: $win,
+    window: ( $win + {
+      sidecar_eligible:  ( [ $sessions[] | select(.type=="worker") ] | length ),
+      sidecar_present:   ( [ $sessions[] | select(.type=="worker" and .artifact!=null) ] | length ),
+      sidecar_present_rate:
+        ( ( [ $sessions[] | select(.type=="worker") ] | length ) as $elig
+          | if $elig==0 then null
+            else ( [ $sessions[] | select(.type=="worker" and .artifact!=null) ] | length ) / $elig
+            end )
+    } ),
     price_model: {
       note: "price_proxy_usd is an Opus-list-price-equivalent USD proxy for RANKING (uniform rate, not the bill); cost_usd is the truthful per-model bill from actual_rates_per_mtok",
       input_per_mtok: RATE_INPUT,

--- a/.claude/skills/dispatch-token-audit/scripts/audit-aggregate-writer.mjs
+++ b/.claude/skills/dispatch-token-audit/scripts/audit-aggregate-writer.mjs
@@ -281,6 +281,8 @@ function loadPayload(raw) {
     until: win.until,
     files_scanned: requireNumber(win, "window", "files_scanned"),
     files_failed: requireNumber(win, "window", "files_failed"),
+    sidecar_eligible: requireNumber(win, "window", "sidecar_eligible"),
+    sidecar_present: requireNumber(win, "window", "sidecar_present"),
   };
 
   const totals = {

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -339,6 +339,19 @@ assert_eq "sessions sess-worker artifact.issue" "999" \
 assert_eq "sessions sess-router artifact null" "null" \
   "$(jq '.sessions[] | select(.id=="sess-router") | .artifact' <<<"$OUT")"
 
+# sidecar-coverage metric (#2268): worker sessions are the eligible denominator.
+# The shared fixture has exactly ONE worker (sess-worker), which carries a
+# sidecar → sidecar_eligible==1, sidecar_present==1, rate==1. The 2 subagents,
+# the router-tick, and the recovery session are EXCLUDED from the denominator
+# (they legitimately carry artifact:null), proving case (b): a non-worker with no
+# sidecar does not inflate sidecar_eligible.
+assert_eq "window.sidecar_eligible (1 worker; subagent/router/recovery excluded)" "1" \
+  "$(jq '.window.sidecar_eligible' <<<"$OUT")"
+assert_eq "window.sidecar_present (worker has sidecar)" "1" \
+  "$(jq '.window.sidecar_present' <<<"$OUT")"
+assert_eq "window.sidecar_present_rate (1/1)" "1" \
+  "$(jq '.window.sidecar_present_rate' <<<"$OUT")"
+
 assert_eq 'tool_errors: "Exit code N" count' "1" \
   "$(jq '[.tool_errors[] | select(.signature=="Exit code N")] | length' <<<"$OUT")"
 assert_eq 'tool_errors: "Exit code N" .count field' "1" \
@@ -893,6 +906,96 @@ assert_eq 'enum: by_model[claude-3-7-sonnet-20250219].cost_usd (sonnet)' "$EXPEC
   "$(jq '.by_model["claude-3-7-sonnet-20250219"].cost_usd' <"$ENUM_ROOT/out.json")"
 
 rm -rf "$ENUM_ROOT"
+
+# ---------------------------------------------------------------------------
+# Sidecar-coverage metric, case (a): several worker sessions, some with sidecars
+# (#2268). ISOLATED fixture: a fresh projects root with THREE worker sessions,
+# TWO carrying a sibling .dispatch-stamp.json. Expected: sidecar_eligible==3,
+# sidecar_present==2, sidecar_present_rate == 2/3 (derived via jq, not hardcoded).
+# Its own root so the shared setup() one-worker count assertions stay untouched.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- sidecar-coverage: several workers, some sidecars (#2268) ---"
+
+COV_ROOT=$(mktemp -d)
+trap 'rm -rf "$COV_ROOT" "$FAKE_WRITER_DIR"; teardown' EXIT INT TERM
+cov_worktree="$COV_ROOT/-home-x-worktrees-2268-coverage"
+mkdir -p "$cov_worktree"
+
+# Three worker sessions; sess-cov-a and sess-cov-b carry a sidecar, sess-cov-c
+# does not. Each is a minimal worker transcript (first user line classifies as
+# worker; one zero-usage assistant line keeps totals/price irrelevant here).
+for s in a b c; do
+  cov_jsonl="$cov_worktree/sess-cov-$s.jsonl"
+  printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+    >> "$cov_jsonl"
+  printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2268-coverage","message":{"model":"claude-opus-4-8","usage":{"input_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0}}}' \
+    >> "$cov_jsonl"
+  jq . "$cov_jsonl" >/dev/null
+  touch "$cov_jsonl"
+done
+
+# Sibling sidecars for a and b only (c stays sidecar-less).
+for s in a b; do
+  cov_stamp="$cov_worktree/sess-cov-$s.dispatch-stamp.json"
+  printf '%s\n' '{"schema":1,"session_id":"sess-cov-'"$s"'","repo":"natb1/commons.systems","issue":2268,"pr":3000,"branch":"2268-coverage","base_sha":"cafef00d","stamped_at":"2026-01-01T00:00:00Z"}' \
+    >> "$cov_stamp"
+  jq . "$cov_stamp" >/dev/null
+done
+
+OUT_COV=$(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$COV_ROOT"
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7
+)
+
+EXPECTED_COV_RATE=$(jq -n '2/3')
+assert_eq "coverage: window.sidecar_eligible (3 workers)" "3" \
+  "$(jq '.window.sidecar_eligible' <<<"$OUT_COV")"
+assert_eq "coverage: window.sidecar_present (2 with sidecars)" "2" \
+  "$(jq '.window.sidecar_present' <<<"$OUT_COV")"
+assert_eq "coverage: window.sidecar_present_rate (2/3)" "$EXPECTED_COV_RATE" \
+  "$(jq '.window.sidecar_present_rate' <<<"$OUT_COV")"
+
+rm -rf "$COV_ROOT"
+
+# ---------------------------------------------------------------------------
+# Sidecar-coverage metric, case (c): zero-worker edge (#2268). ISOLATED fixture
+# with only a router-tick session (no worker). The eligible denominator is 0, so
+# sidecar_present_rate must be null (not 0, not a divide-by-zero) and
+# sidecar_eligible must be 0. Its own root so the shared totals stay untouched.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- sidecar-coverage: zero-worker edge → rate null (#2268) ---"
+
+NOWORKER_ROOT=$(mktemp -d)
+trap 'rm -rf "$NOWORKER_ROOT" "$FAKE_WRITER_DIR"; teardown' EXIT INT TERM
+noworker_bare="$NOWORKER_ROOT/-home-x--bare"
+mkdir -p "$noworker_bare"
+noworker_jsonl="$noworker_bare/sess-noworker.jsonl"
+
+# first user line (any content); assistant with gitBranch HEAD → router-tick.
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch</command-name>"}}' \
+  >> "$noworker_jsonl"
+printf '%s\n' '{"type":"assistant","gitBranch":"HEAD","message":{"model":"claude-opus-4-8","usage":{"input_tokens":1,"cache_creation_input_tokens":2,"cache_read_input_tokens":4,"output_tokens":1}}}' \
+  >> "$noworker_jsonl"
+jq . "$noworker_jsonl" >/dev/null
+touch "$noworker_jsonl"
+
+OUT_NOWORKER=$(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$NOWORKER_ROOT"
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7
+)
+
+assert_eq "zero-worker: window.sidecar_eligible == 0" "0" \
+  "$(jq '.window.sidecar_eligible' <<<"$OUT_NOWORKER")"
+assert_eq "zero-worker: window.sidecar_present == 0" "0" \
+  "$(jq '.window.sidecar_present' <<<"$OUT_NOWORKER")"
+assert_eq "zero-worker: window.sidecar_present_rate is null (zero denom)" "null" \
+  "$(jq '.window.sidecar_present_rate' <<<"$OUT_NOWORKER")"
+
+rm -rf "$NOWORKER_ROOT"
 
 report_results
 exit $FAIL

--- a/.claude/skills/dispatch-token-audit/scripts/test-audit-aggregate-writer.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-audit-aggregate-writer.sh
@@ -38,7 +38,7 @@ AA_EXPIRE=1812136000   # AA_NOW + 365*86400
 # payload_bytes/tool_errors) so we can assert their absence in the doc. window
 # .until is 2026-06-10 (a different day than NOW's 2026-06-04).
 PAYLOAD='{
-  "window": {"days": 7, "since": "2026-06-03 12:00:00", "until": "2026-06-10 12:00:00", "files_scanned": 42, "files_failed": 1},
+  "window": {"days": 7, "since": "2026-06-03 12:00:00", "until": "2026-06-10 12:00:00", "files_scanned": 42, "files_failed": 1, "sidecar_eligible": 3, "sidecar_present": 2, "sidecar_present_rate": 0.6666666666666666},
   "price_model": {"note": "proxy", "input_per_mtok": 15, "cache_creation_per_mtok": 18.75, "cache_read_per_mtok": 1.5, "output_per_mtok": 75},
   "totals": {"input": 100, "cache_creation": 200, "cache_read": 300, "output": 400, "sessions": 5, "turns": 50, "price_proxy_usd": 1.23},
   "by_session_type": {"worker": {"input": 1}},
@@ -80,7 +80,7 @@ assert_eq "priceModel omits note" "false" "$(jq -c '.doc.priceModel | has("note"
 
 # --- Case 4: curated values match input -------------------------------------
 assert_eq "window meta projected" \
-  '{"days":7,"since":"2026-06-03 12:00:00","until":"2026-06-10 12:00:00","files_scanned":42,"files_failed":1}' \
+  '{"days":7,"since":"2026-06-03 12:00:00","until":"2026-06-10 12:00:00","files_scanned":42,"files_failed":1,"sidecar_eligible":3,"sidecar_present":2}' \
   "$(jq -c '.doc.window' <<<"$OUT")"
 assert_eq "totals projected" \
   '{"input":100,"cache_creation":200,"cache_read":300,"output":400,"sessions":5,"turns":50,"price_proxy_usd":1.23}' \
@@ -177,6 +177,20 @@ MISSING_ERR=$(printf '%s' "$NO_BY_PHASE" | node "$WRITER_MJS" --dry-run 2>&1 >/d
 assert_eq "stdin missing by_phase → exit non-zero" "1" "$([[ "$MISSING_RC" -ne 0 ]] && echo 1 || echo 0)"
 assert_eq "stdin missing by_phase → diagnostic" "1" \
   "$([[ "$MISSING_ERR" == *'audit-aggregate-writer: payload field by_phase must be a JSON object'* ]] && echo 1 || echo 0)"
+
+# (c'') stdin missing window.sidecar_eligible → finite-number error (fail-closed).
+NO_ELIGIBLE=$(jq -c 'del(.window.sidecar_eligible)' <<<"$PAYLOAD")
+NO_ELIGIBLE_ERR=$(printf '%s' "$NO_ELIGIBLE" | node "$WRITER_MJS" --dry-run 2>&1 >/dev/null) && NO_ELIGIBLE_RC=0 || NO_ELIGIBLE_RC=$?
+assert_eq "stdin missing window.sidecar_eligible → exit non-zero" "1" "$([[ "$NO_ELIGIBLE_RC" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "stdin missing window.sidecar_eligible → diagnostic" "1" \
+  "$([[ "$NO_ELIGIBLE_ERR" == *'audit-aggregate-writer: payload field window.sidecar_eligible must be a finite number'* ]] && echo 1 || echo 0)"
+
+# (c''') stdin missing window.sidecar_present → finite-number error (fail-closed).
+NO_PRESENT=$(jq -c 'del(.window.sidecar_present)' <<<"$PAYLOAD")
+NO_PRESENT_ERR=$(printf '%s' "$NO_PRESENT" | node "$WRITER_MJS" --dry-run 2>&1 >/dev/null) && NO_PRESENT_RC=0 || NO_PRESENT_RC=$?
+assert_eq "stdin missing window.sidecar_present → exit non-zero" "1" "$([[ "$NO_PRESENT_RC" -ne 0 ]] && echo 1 || echo 0)"
+assert_eq "stdin missing window.sidecar_present → diagnostic" "1" \
+  "$([[ "$NO_PRESENT_ERR" == *'audit-aggregate-writer: payload field window.sidecar_present must be a finite number'* ]] && echo 1 || echo 0)"
 
 # (d) --dry-run without SECRET_OVERRIDE → the dry-run-only guard.
 assert_fail "dry-run without SECRET_OVERRIDE → fail-closed" \


### PR DESCRIPTION
Closes #2268

## Problem

The per-session dispatch sidecar (`<transcript>.dispatch-stamp.json`, written at
session birth by the `SessionStart:startup` hook) records the GitHub artifact a
worker session acted on, and `dispatch-token-audit` joins each transcript to its
sidecar to attribute token cost to a real-world outcome.

Nobody could confirm `SessionStart:startup` actually fires for detached
`claude --bg` worker sessions — the primary worker launch path. If it does not
fire, **every** sidecar is silently absent and the audit reads `artifact: null`
everywhere, indistinguishable from the legitimate-null case (subagents,
router-ticks, recovery sessions). The hook's own comment block documented this as
untested and deferred a fix to "live failure."

## Change

Detection-first, purely additive:

- **`aggregate-usage.sh`** — the audit's `window` object now reports
  `sidecar_eligible` (count of top-level `worker` sessions scanned),
  `sidecar_present` (those carrying a sidecar), and a derived
  `sidecar_present_rate` (float in `[0,1]`, or `null` when no workers were
  scanned). The denominator is `type == "worker"` — `subagent`, `router-tick`,
  and `recovery` sessions legitimately have `artifact: null` and are excluded, so
  the rate is not misleading.
- **`audit-aggregate-writer.mjs`** — persists the two integer counts through the
  window reconstruction allowlist (validated with the existing `requireNumber`).
  `sidecar_present_rate` is intentionally not persisted — it can be `null` and is
  trivially derivable on read (`present / eligible`).
- **`stamp-dispatch-session.sh`** — the hook comment block now describes the
  implemented monitor as the data-driven signal for the two open uncertainties
  (does the startup hook fire for `--bg` workers; does the hook have working local
  git). The belt-and-suspenders skill-preamble write stays a deferred follow-up,
  to be filed only if the monitored rate shows the hook is insufficient.

So the sidecar-present rate for worker sessions is now verifiable from existing
transcripts without launching a full dispatch run (AC1, AC2, AC4), and the hook
comment reflects what was built (AC3).

## Out of scope

The belt-and-suspenders `dispatch-stamp-session` write in phase skills — this PR
adds the detection that makes filing that follow-up data-driven, per the issue's
"either suffices" framing.

## Verification

- `test-aggregate-usage.sh` — 106/106 (new `#2268` cases: several-workers rate,
  non-worker exclusion, zero-worker `null` edge).
- `test-audit-aggregate-writer.sh` — 36/36 (new round-trip + fail-closed
  missing-field cases for both counts).
