### PR TITLE
dispatch flake-filing: dedupe tracking issues by fingerprint across all states

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-flake-dedup
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-flake-dedup
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Deterministic, state-spanning flake-dedup guard. Given a flake fingerprint,
+# find-or-record a same-fingerprint tracking issue and tell the caller whether
+# to file fresh.
+# Usage: dispatch-flake-dedup <fingerprint> --body-file <f> [--repo owner/repo]
+#
+# WHY THIS EXISTS
+#   This is the flake-path analogue of `dispatch-followup-exists` (the security
+#   path). The flake-filing step needs an idempotent guard: before filing a new
+#   flake tracking issue, it must check whether one already tracks the same
+#   fingerprint and, if so, record the recurrence on the existing issue rather
+#   than open a duplicate. This script is that guard. It records the recurrence
+#   (a comment, plus a reopen when the existing issue is closed) and reports the
+#   existing issue; on no match it tells the caller to file fresh via /file-issue.
+#
+# STATE SCOPE
+#   The match spans OPEN and CLOSED issues. A flake that was tracked, fixed, and
+#   the issue closed can recur — an open-only dedup would re-file it. Spanning
+#   closed state lets a recurrence reopen the original tracking issue and append
+#   the new evidence, keeping one durable thread per fingerprint.
+#
+# CRITERION-#4 TITLE INVARIANT
+#   For a FUTURE run's match to work, the fingerprint must sit at a token
+#   boundary in the tracking issue's title. /file-issue files flake trackers as
+#   `Flaky CI: <fingerprint>`, so the fingerprint ends the title — satisfying the
+#   boundary-aware match below (`endswith($id)` / `contains($id + " ")`). The
+#   title reassert that re-establishes this invariant lives in the SKILL wiring
+#   (a later unit), not here.
+#
+# WHY IT REUSES dispatch-followup-exists
+#   The state-spanning, boundary-aware title match is non-trivial (see that
+#   script's MATCHING header for the prefix-collision traps it avoids). Rather
+#   than reimplement that jq here and risk divergence, this guard calls the
+#   sibling for the match and adds only the flake-specific recurrence recording
+#   (comment / reopen) on top.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+if [[ "$#" -lt 1 || -z "${1:-}" ]]; then
+  echo "error: usage: dispatch-flake-dedup <fingerprint> --body-file <f> [--repo owner/repo]" >&2
+  exit 2
+fi
+
+fingerprint="$1"
+shift
+
+body_file=""
+repo=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --body-file) body_file="$2"; shift 2 ;;
+    --repo)      repo="$2";      shift 2 ;;
+    *)
+      echo "error: dispatch-flake-dedup: unexpected argument '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$body_file" ]]; then
+  echo "error: dispatch-flake-dedup: --body-file <f> is required" >&2
+  exit 2
+fi
+if [[ ! -f "$body_file" ]]; then
+  echo "error: dispatch-flake-dedup: --body-file '$body_file' does not exist" >&2
+  exit 2
+fi
+
+# --repo is forwarded ONLY to the lib helpers below. dispatch-followup-exists
+# takes the identifier as $1 and no --repo flag, so it is not forwarded there.
+local_repo_args=()
+[[ -n "$repo" ]] && local_repo_args=(--repo "$repo")
+
+# 1. Match via the sibling — REUSE its state-spanning, boundary-aware match.
+#    Under `set -e`, a non-zero exit from dispatch-followup-exists propagates
+#    (no `|| true` guard masks it).
+match=$("$SCRIPT_DIR/dispatch-followup-exists" "$fingerprint")
+
+# 2. No match → caller files fresh via /file-issue.
+if [[ -z "$match" ]]; then
+  echo "NONE"
+  exit 0
+fi
+
+# 3. Match → record the recurrence on the existing issue, keyed by its state.
+state=$(gh_issue_view_rest "$match" "${local_repo_args[@]}" | jq -r '.state')
+
+case "$state" in
+  OPEN)
+    gh_issue_comment_rest "$match" --body-file "$body_file" "${local_repo_args[@]}"
+    echo "EXISTING $match"
+    ;;
+  CLOSED)
+    gh_issue_reopen_rest "$match" --comment "$(cat "$body_file")" "${local_repo_args[@]}"
+    echo "REOPENED $match"
+    ;;
+  *)
+    echo "error: dispatch-flake-dedup: unexpected state '$state' for issue $match" >&2
+    exit 1
+    ;;
+esac

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -1028,6 +1028,56 @@ gh_issue_close_rest() {
   }
 }
 
+# REST-backed mutation: reopen a closed issue (#2337).
+# Uses PATCH repos/{owner}/{repo}/issues/<N> with state=open (no state_reason).
+# Args: $1 = <N> (issue number, required); --comment <body> (optional; posts the
+#   comment BEFORE the reopen, matching gh_issue_close_rest's comment-then-mutate
+#   ordering); --repo owner/repo (optional).
+# On gh failure: errors to stderr and returns 1.
+gh_issue_reopen_rest() {
+  local num="" comment="" has_comment="" repo=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --comment) comment="$2"; has_comment=1; shift 2 ;;
+      --repo)    repo="$2";    shift 2 ;;
+      --*) echo "error: gh_issue_reopen_rest: unknown flag '$1'" >&2; return 1 ;;
+      *)
+        if [[ -z "$num" ]]; then
+          num="$1"; shift 1
+        else
+          echo "error: gh_issue_reopen_rest: unexpected argument '$1'" >&2; return 1
+        fi
+        ;;
+    esac
+  done
+  if [[ -z "$num" ]]; then
+    echo "error: gh_issue_reopen_rest: issue number is required" >&2
+    return 1
+  fi
+
+  local path
+  if [[ -n "$repo" ]]; then
+    path="repos/$repo/issues/$num"
+  else
+    path="repos/{owner}/{repo}/issues/$num"
+  fi
+
+  # --comment: post the comment BEFORE the reopen (matches the porcelain ordering),
+  # reusing the exact POST issues/<N>/comments shape from gh_issue_comment_rest.
+  if [[ -n "$has_comment" ]]; then
+    local comments_path="$path/comments"
+    gh_retry gh api -X POST "$comments_path" -f "body=$comment" >/dev/null || {
+      echo "error: gh_issue_reopen_rest: gh api failed for $comments_path" >&2
+      return 1
+    }
+  fi
+
+  gh_retry gh api -X PATCH "$path" -f state=open >/dev/null || {
+    echo "error: gh_issue_reopen_rest: gh api failed for $path" >&2
+    return 1
+  }
+}
+
 # REST-backed mutation: edit an issue's title and/or body (#2255).
 # Uses PATCH repos/{owner}/{repo}/issues/<N>. PRs are issues in REST, so this same
 # helper later serves `gh pr edit --body`.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -2046,6 +2046,57 @@ if grep -q 'issues/42' "$STUB_DIR/gh-issue-close-rest-calls.log"; then p=yes; el
 assert_eq "close: --comment still fires PATCH issues/42" "yes" "$p"
 teardown
 
+  # --- gh_issue_reopen_rest (#2337) ---
+  echo "Test: gh_issue_reopen_rest -- PATCH to correct path with state=open"
+  setup
+  : > "$STUB_DIR/gh-issue-close-rest-calls.log"
+  source "$TMPDIR_TEST/lib.sh"; gh_issue_reopen_rest 42
+  if grep -q 'PATCH' "$STUB_DIR/gh-issue-close-rest-calls.log"; then m=yes; else m=no; fi
+  assert_eq "reopen: log contains PATCH" "yes" "$m"
+  if grep -q 'issues/42' "$STUB_DIR/gh-issue-close-rest-calls.log"; then p=yes; else p=no; fi
+  assert_eq "reopen: log contains issues/42 path" "yes" "$p"
+  if grep -q 'state=open' "$STUB_DIR/gh-issue-close-rest-calls.log"; then s=yes; else s=no; fi
+  assert_eq "reopen: log contains state=open" "yes" "$s"
+  teardown
+
+  echo "Test: gh_issue_reopen_rest -- --repo flag emits cross-repo segment"
+  setup
+  : > "$STUB_DIR/gh-issue-close-rest-calls.log"
+  source "$TMPDIR_TEST/lib.sh"; gh_issue_reopen_rest 42 --repo owner/other-repo
+  if grep -q 'repos/owner/other-repo/issues/42' "$STUB_DIR/gh-issue-close-rest-calls.log"; then seg=yes; else seg=no; fi
+  assert_eq "reopen: --repo uses cross-repo segment" "yes" "$seg"
+  teardown
+
+  echo "Test: gh_issue_reopen_rest -- missing number returns non-zero"
+  setup
+  rc_ro=0
+  err_ro=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_reopen_rest 2>&1 >/dev/null) || rc_ro=$?
+  assert_eq "reopen: missing number → non-zero" "1" "$rc_ro"
+  case "$err_ro" in *"gh_issue_reopen_rest: issue number is required"*) m=yes ;; *) m=no ;; esac
+  assert_eq "reopen: missing-number stderr names helper" "yes" "$m"
+  teardown
+
+  echo "Test: gh_issue_reopen_rest -- gh failure returns non-zero with diagnostic stderr"
+  setup
+  : > "$STUB_DIR/gh-fail-rest"
+  rc_rof=0
+  err_rof=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_reopen_rest 42 2>&1 >/dev/null) || rc_rof=$?
+  assert_eq "reopen: gh failure → non-zero" "1" "$rc_rof"
+  case "$err_rof" in *"gh_issue_reopen_rest: gh api failed"*) m=yes ;; *) m=no ;; esac
+  assert_eq "reopen: gh-failure stderr names helper" "yes" "$m"
+  teardown
+
+  echo "Test: gh_issue_reopen_rest -- --comment posts a comment then reopens"
+  setup
+  : > "$STUB_DIR/gh-issue-close-rest-calls.log"
+  : > "$STUB_DIR/gh-issue-comment-rest-calls.log"
+  source "$TMPDIR_TEST/lib.sh"; gh_issue_reopen_rest 42 --comment "reopening note"
+  if grep -q 'issues/42/comments' "$STUB_DIR/gh-issue-comment-rest-calls.log"; then c=yes; else c=no; fi
+  assert_eq "reopen: --comment fires POST issues/42/comments" "yes" "$c"
+  if grep -q 'issues/42' "$STUB_DIR/gh-issue-close-rest-calls.log"; then p=yes; else p=no; fi
+  assert_eq "reopen: --comment still fires PATCH issues/42" "yes" "$p"
+  teardown
+
 # --- gh_issue_edit_rest ---
 echo "Test: gh_issue_edit_rest -- --title only sends title="
 setup
@@ -2412,6 +2463,14 @@ setup
 source "$TMPDIR_TEST/lib.sh"; gh_issue_close_rest 42
 assert_rest_only "close" "$STUB_DIR/gh-issue-close-rest-calls.log"
 teardown
+
+  # --- gh_issue_reopen_rest ---
+  echo "Test: gh_issue_reopen_rest -- consumes REST bucket, not GraphQL"
+  setup
+  : > "$STUB_DIR/gh-issue-close-rest-calls.log"
+  source "$TMPDIR_TEST/lib.sh"; gh_issue_reopen_rest 42
+  assert_rest_only "reopen" "$STUB_DIR/gh-issue-close-rest-calls.log"
+  teardown
 
 # --- gh_issue_edit_rest ---
 echo "Test: gh_issue_edit_rest -- consumes REST bucket, not GraphQL"
@@ -32758,6 +32817,139 @@ EOF
 out=$("$TMPDIR_TEST/scripts/dispatch-followup-exists" "CodeQL js/sql-injection alert #5")
 assert_eq "followup-exists: codeql alert-number prefix collision (#5 vs #50) → empty" "" "$out"
 followup_exists_teardown
+
+  # ============================================================================
+  # === dispatch-flake-dedup (#2337) ===
+  # ============================================================================
+
+  echo "Test: dispatch-flake-dedup"
+
+  # Dedicated setup modeled on followup_exists_setup, but with a MUTATION-RECORDING
+  # gh stub. dispatch-flake-dedup matches (via dispatch-followup-exists) AND records
+  # the recurrence (comment on open; reopen+comment on closed). stdout alone does
+  # not prove the mutation fired, so the stub records side effects to marker files
+  # the cases assert on:
+  #   - comments-fired : one <N> per POST .../issues/<N>/comments
+  #   - reopen-fired   : one <N> per PATCH .../issues/<N> carrying state=open
+  # The issue LIST (followup-exists match) and the single-issue VIEW (state read)
+  # both derive from the same $TREE/issues.json fixture, which carries a per-issue
+  # `state` field (open/closed).
+  flake_dedup_setup() {
+    TMPDIR_TEST=$(mktemp -d)
+    mkdir -p "$TMPDIR_TEST/scripts" "$TMPDIR_TEST/bin" "$TMPDIR_TEST/scripts/stub"
+
+    cp "$SCRIPT_DIR/dispatch-flake-dedup" "$TMPDIR_TEST/scripts/dispatch-flake-dedup"
+    cp "$SCRIPT_DIR/dispatch-followup-exists" "$TMPDIR_TEST/scripts/dispatch-followup-exists"
+    cp "$SCRIPT_DIR/lib.sh" "$TMPDIR_TEST/scripts/lib.sh"
+    chmod +x "$TMPDIR_TEST/scripts/dispatch-flake-dedup" \
+             "$TMPDIR_TEST/scripts/dispatch-followup-exists"
+
+    # gh_retry must not sleep (no retries are expected here, but be safe).
+    export GH_RETRY_BASE_DELAY=0
+
+    cat > "$TMPDIR_TEST/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+TREE="$(cd "$(dirname "$0")/.." && pwd)/scripts"
+MARK="$TREE/stub"
+case "$args" in
+  *"api -X POST "*"/issues/"*"/comments"*)
+    # recurrence comment (open path, and the comment leg of the reopen path)
+    n=$(printf '%s' "$args" | sed -E 's#.*/issues/([0-9]+)/comments.*#\1#')
+    echo "$n" >> "$MARK/comments-fired"
+    echo '{}'
+    ;;
+  *"api -X PATCH "*"/issues/"[0-9]*)
+    # reopen: PATCH .../issues/<N> with state=open
+    case "$args" in
+      *state=open*)
+        n=$(printf '%s' "$args" | sed -E 's#.*/issues/([0-9]+).*#\1#')
+        echo "$n" >> "$MARK/reopen-fired"
+        ;;
+    esac
+    echo '{}'
+    ;;
+  *"api "*"/issues/"[0-9]*)
+    # single-issue VIEW (gh_issue_view_rest): emit a raw REST object carrying the
+    # fixture issue's lowercase state; the helper upcases it.
+    n="${args##*/}"
+    state=$(jq -r --argjson n "$n" '.[] | select(.number==$n) | .state' "$TREE/issues.json")
+    printf '{"number":%s,"state":"%s"}\n' "$n" "$state"
+    ;;
+  *"api "*"/issues"*)
+    # issue LIST (gh_issue_list_rest via dispatch-followup-exists): whole fixture,
+    # remapped to REST shape WITH title (the script passes --include-title).
+    if [[ -f "$TREE/issues.json" ]]; then
+      jq 'map({number, pull_request: null, created_at: null, closed_at: null, labels: []} + (if has("title") then {title} else {} end))' "$TREE/issues.json"
+    else
+      echo '[]'
+    fi
+    ;;
+  *)
+    echo "gh stub: unknown invocation: $args" >&2
+    exit 1
+    ;;
+esac
+STUB
+    chmod +x "$TMPDIR_TEST/bin/gh"
+
+    SAVED_PATH_FD="$PATH"
+    export PATH="$TMPDIR_TEST/bin:$PATH"
+  }
+
+  flake_dedup_teardown() {
+    rm -rf "$TMPDIR_TEST"
+    TMPDIR_TEST=""
+    unset GH_RETRY_BASE_DELAY
+    export PATH="$SAVED_PATH_FD"
+  }
+
+  FP="acceptance — fellspiral/e2e/navigation.spec.ts:4:3 page loads without JS errors @smoke"
+
+  # CASE 1 — OPEN match → EXISTING <N>, comment fired, no reopen. (criterion #2)
+  flake_dedup_setup
+  printf '[{"number":501,"title":"Flaky CI: %s","state":"open"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
+  printf 'recurred on PR #900 / run http://x\n' > "$TMPDIR_TEST/body.md"
+  out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md")
+  assert_eq "flake-dedup: open match → EXISTING <N>" "EXISTING 501" "$out"
+  if grep -qx '501' "$TMPDIR_TEST/scripts/stub/comments-fired" 2>/dev/null; then c=yes; else c=no; fi
+  assert_eq "flake-dedup: open match → comment fired on 501" "yes" "$c"
+  if [[ -s "$TMPDIR_TEST/scripts/stub/reopen-fired" ]]; then r=yes; else r=no; fi
+  assert_eq "flake-dedup: open match → no reopen" "no" "$r"
+  flake_dedup_teardown
+
+  # CASE 2 — CLOSED match → REOPENED <N>, reopen fired, comment fired. (criterion #3)
+  flake_dedup_setup
+  printf '[{"number":501,"title":"Flaky CI: %s","state":"closed"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
+  printf 'recurred on PR #900 / run http://x\n' > "$TMPDIR_TEST/body.md"
+  out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md")
+  assert_eq "flake-dedup: closed match → REOPENED <N>" "REOPENED 501" "$out"
+  if grep -qx '501' "$TMPDIR_TEST/scripts/stub/reopen-fired" 2>/dev/null; then r=yes; else r=no; fi
+  assert_eq "flake-dedup: closed match → reopen fired on 501" "yes" "$r"
+  if grep -qx '501' "$TMPDIR_TEST/scripts/stub/comments-fired" 2>/dev/null; then c=yes; else c=no; fi
+  assert_eq "flake-dedup: closed match → comment fired on 501" "yes" "$c"
+  flake_dedup_teardown
+
+  # CASE 3 — NO match → NONE, no side effects. (criterion #5)
+  flake_dedup_setup
+  printf '[]\n' > "$TMPDIR_TEST/scripts/issues.json"
+  printf 'recurred on PR #900 / run http://x\n' > "$TMPDIR_TEST/body.md"
+  out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md")
+  assert_eq "flake-dedup: no match → NONE" "NONE" "$out"
+  if [[ -s "$TMPDIR_TEST/scripts/stub/comments-fired" ]]; then c=yes; else c=no; fi
+  assert_eq "flake-dedup: no match → no comment" "no" "$c"
+  if [[ -s "$TMPDIR_TEST/scripts/stub/reopen-fired" ]]; then r=yes; else r=no; fi
+  assert_eq "flake-dedup: no match → no reopen" "no" "$r"
+  flake_dedup_teardown
+
+  # CASE 4 — canonical-title match: title is exactly `Flaky CI: <fp>`, probe <fp>
+  # (the deterministic half of criterion #4 — run 2 matches run 1's canonical title).
+  flake_dedup_setup
+  printf '[{"number":777,"title":"Flaky CI: %s","state":"open"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
+  printf 'recurred\n' > "$TMPDIR_TEST/body.md"
+  out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md")
+  assert_eq "flake-dedup: canonical-title match → EXISTING <N>" "EXISTING 777" "$out"
+  flake_dedup_teardown
 
 echo ""
 echo "=== dispatch-mark-complete / dispatch-mark-deviation ==="

--- a/.claude/skills/fix-checks/SKILL.md
+++ b/.claude/skills/fix-checks/SKILL.md
@@ -143,26 +143,78 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
      as its own tracking issue and block the PR's tracked issue on it. Push
      nothing — there is no fix to this PR. Follow these sub-steps:
 
-     1. **Compute a flake fingerprint.** Combine the failing check name with the
-        most stable identifier in the failure excerpt — the test name, file path,
-        or CI workflow name, whichever is most specific. This string is the dedupe
-        key; it must identify the same flake across re-runs.
-     2. **File the flake issue.** Launch a subagent (`subagent_type:
-        general-purpose`, `model: sonnet`) that invokes `/file-issue` via the
-        Skill tool. Build its `$INPUT` with a leading `--follow-up` token first,
-        then a title hint on the next line — a short imperative summary that encodes
-        the fingerprint, e.g. `Flaky CI: <check> — <stable identifier>` — followed
-        by a body containing the fingerprint, the reproduce command, and the failure
-        excerpt. (The `--follow-up` token is a classification no-op here — a flake
-        is a `bug`, which suppresses `enhancement` — but is passed for consistency.)
-        `/file-issue` runs the full pipeline: duplicate detection, 8-category
-        evaluation, decomposition gate, type/topic classification, creation (or
-        match of an existing open issue), `@me` assignment, `help wanted`, type
-        label, and any matched topic label. It ends with a
-        `===FILE-ISSUE-RESULTS===` … `===FILE-ISSUE-RESULTS-END===` block; the
-        subagent reads the `<disposition> <N>` record(s) between the sentinels (a
-        flake is one topic, so normally one record — iterate if more) and returns
-        each `<N>` with its `CREATED`/`EXISTING` disposition to this thread.
+     1. **Compute a flake fingerprint (rigid precedence — deterministic across
+        runs).** The fingerprint is `<failing-check-name> — <stable-id>`, where
+        `<stable-id>` is chosen by this **fixed precedence** (use the first the
+        failure excerpt provides):
+        1. the **test node id** — e.g. `path/to/test.spec.ts:LINE:COL test title`;
+        2. else the **file path:line**;
+        3. else the **CI workflow name**.
+        Read `<stable-id>` from the excerpt strictly by this precedence and
+        **never paraphrase or summarize it** — the same flake must yield a
+        byte-identical fingerprint string on every run, or dedup silently fails in
+        production (no fixture test exercises the live fingerprint computation, so
+        nothing catches a divergent string). This exact string is both (a) the
+        dedup key passed to `dispatch-flake-dedup` and (b) the verbatim trailing
+        token of the canonical tracking-issue title `Flaky CI: <fingerprint>`. Use
+        the **same** fingerprint value for both — do not recompute it.
+     2. **Find-or-file the flake issue (deterministic guard before
+        `/file-issue`).** A same-fingerprint tracking issue may already exist —
+        **open or closed**. Run the deterministic, state-spanning guard FIRST and
+        only file fresh when it reports no match. This closes the old leak where a
+        closed same-fingerprint issue read as "already resolved, so a recurrence is
+        new information" and got re-filed as a duplicate. In this thread
+        (`dangerouslyDisableSandbox: true` — the script calls `gh`):
+        1. Write the recurrence body to `tmp/flake-recurrence.md` (git-ignored
+           `tmp/`, like the accumulator): the fingerprint, the reproduce command,
+           the failure excerpt, and a `recurred on PR #<pr> / run <url>` line.
+        2. Run the guard, passing the fingerprint as the dedup key:
+           ```bash
+           DISP=$(.claude/skills/dispatch-propagate/scripts/dispatch-flake-dedup \
+             "<fingerprint>" --body-file tmp/flake-recurrence.md)
+           ```
+           It prints exactly one line: `NONE`, `EXISTING <N>`, or `REOPENED <N>`.
+           Parse it into a disposition and (when present) the issue number `<N>`.
+        3. Branch on the disposition:
+           - **`EXISTING <N>`** — a same-fingerprint issue is already open and the
+             guard appended this recurrence as a comment. Do **not** file. Flake
+             issue = `#<N>`, disposition `EXISTING`.
+           - **`REOPENED <N>`** — a same-fingerprint issue was closed-as-fixed but
+             the flake fired again; the guard reopened it and appended this
+             recurrence (the "closed-as-fixed but still firing" signal a human
+             should see on one issue, not N dups). Do **not** file. Flake issue =
+             `#<N>`, disposition `REOPENED`.
+           - **`NONE`** — no same-fingerprint issue exists; file one via
+             `/file-issue` as before. Launch a subagent (`subagent_type:
+             general-purpose`, `model: sonnet`) that invokes `/file-issue` via the
+             Skill tool, building its `$INPUT` with a leading `--follow-up` token
+             first, then a title hint `Flaky CI: <fingerprint>` on the next line,
+             then a body containing the fingerprint, the reproduce command, and the
+             failure excerpt. (The `--follow-up` token is a classification no-op
+             here — a flake is a `bug`, which suppresses `enhancement` — but is
+             passed for consistency.) `/file-issue` runs the full pipeline:
+             duplicate detection, 8-category evaluation, decomposition gate,
+             type/topic classification, creation (or match of an existing issue),
+             `@me` assignment, `help wanted`, type label, and any matched topic
+             label. It ends with a `===FILE-ISSUE-RESULTS===` …
+             `===FILE-ISSUE-RESULTS-END===` block; the subagent reads the
+             `<disposition> <N>` record (a flake is one topic, so normally one
+             record) and returns `<N>` with its disposition. Then:
+             - **`CREATED <N>`** — `/file-issue` created a fresh issue, but its
+               title-improver (`/file-issue` Step 4) may have reworded the title
+               and dropped the verbatim fingerprint — which would break a future
+               run's match. **Reassert the canonical title** so the fingerprint is
+               the literal trailing token regardless of the rewording
+               (`dangerouslyDisableSandbox: true`):
+               ```bash
+               source .claude/skills/dispatch-propagate/scripts/lib.sh
+               gh_issue_edit_rest <N> --title "Flaky CI: <fingerprint>"
+               ```
+               Flake issue = `#<N>`, disposition `CREATED`.
+             - **`EXISTING <M>`** — `/file-issue`'s fuzzy dedup matched a
+               pre-existing (possibly human-filed, differently-titled) issue. Do
+               **NOT** reassert its title — re-titling an unrelated issue would
+               corrupt it. Flake issue = `#<M>`, disposition `EXISTING`.
      3. **Block the PR's tracked issue on the flake issue.** In this thread, use
         the PR body already captured in Step 1's pack output (`=== PR ===` section)
         and parse its `Closes #N` line(s) for the issue(s) this PR implements. For **each** tracked issue, record a
@@ -176,7 +228,10 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
         syntax — all `gh` calls use `dangerouslyDisableSandbox: true`). Idempotent:
         first list the tracked issue's current `blocked_by`, and skip the POST if
         the flake issue is already present, so a re-run against the same
-        fingerprint does not re-add the dependency or error.
+        fingerprint does not re-add the dependency or error. This step consumes
+        `<N>` uniformly for every disposition (`CREATED`, `EXISTING`, or
+        `REOPENED`) — it makes no open-only assumption about the flake issue's
+        state.
      4. **Record a flake iteration in the accumulator** (the skill's top-level
         Step 7) — see [Accumulator](#accumulator); a flake entry is visually
         distinct from a generic no-repro one.
@@ -289,9 +344,9 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
   - **Why not caught** — the `why_not_caught` diagnosis.
   - **Fix** — the fix applied and its commit SHA. Include only when **Outcome**
     is `fixed`; omit otherwise.
-  - **Flake issue** — *`flake` outcome only* — the tracking issue filed via
-    `/file-issue`, written as `#<N> (CREATED)` or `#<N> (EXISTING)`. Omit for
-    every other outcome.
+  - **Flake issue** — *`flake` outcome only* — the canonical tracking issue, written
+    as `#<N> (CREATED)`, `#<N> (EXISTING)`, or `#<N> (REOPENED)` per the
+    `dispatch-flake-dedup` / `/file-issue` disposition. Omit for every other outcome.
   - **Fingerprint** — *`flake` outcome only* — the dedupe key computed in the
     Flake sub-path (the failing check name plus the stable identifier). Omit for
     every other outcome.


### PR DESCRIPTION
Closes #2337

## What

Dedupe flake tracking issues by fingerprint across **all** states (open + closed),
so a recurring known flake converges on one canonical tracking issue instead of
re-filing a fresh duplicate on every recurrence.

The proof of the bug is in #2337: the flake
`acceptance — fellspiral/e2e/navigation.spec.ts:4:3 page loads without JS errors @smoke`
was filed four times (#2187, #2245, #2327, #2329) — same fingerprint, all
closed/closing as resolved-by-#2173, with two carrying identical titles yet both
created.

Root cause: the `/fix-checks` Flake sub-path delegated dedup entirely to
`/file-issue`'s fuzzy keyword matching, which is open-state-only (a closed
same-fingerprint issue reads as "already resolved, so a recurrence is new
information" and re-files) and leaks even on exact-title matches.

This generalizes the deterministic, state-spanning guard #1100 added for the
security-followup path to the flake-filing path, and extends it to act on the
matched issue's state: open → record the recurrence as a comment; closed →
reopen the canonical issue and record the recurrence.

## How

- **`gh_issue_reopen_rest`** (`lib.sh`) — new REST helper mirroring
  `gh_issue_close_rest`: PATCHes `state=open` and optionally posts a
  comment-before-reopen.
- **`dispatch-flake-dedup`** (new script) — the deterministic guard. Reuses
  `dispatch-followup-exists` for the boundary-aware `--state all` match, then
  branches on the matched issue's state: prints `NONE` (file fresh),
  `EXISTING <N>` (open → comment), or `REOPENED <N>` (closed → reopen + comment).
- **`fix-checks/SKILL.md`** — the Flake sub-path now runs the guard before
  `/file-issue` and files fresh only on `NONE`. It pins a rigid fingerprint
  precedence (test node id → file path:line → CI workflow name) for cross-run
  determinism, and reasserts the canonical title `Flaky CI: <fingerprint>` after
  a `CREATED` result only (never on a fuzzy-matched `EXISTING`, which would
  corrupt an unrelated issue).
- **Tests** — `gh_issue_reopen_rest` unit + REST-bucket cases, and four
  `dispatch-flake-dedup` cases (open→EXISTING+comment, closed→REOPENED+reopen+comment,
  no-match→NONE+no-side-effects, canonical-title→EXISTING) with a
  mutation-recording gh stub.

The deterministic guard runs *before* `/file-issue`, which is retained on the
no-match path — keeping its fuzzy dedup against differently-titled issues, its
evaluation pipeline, and the labels that make a flake issue dispatch-eligible.

## Verification

`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` — 3944/3944
pass, including all new cases. `bash -n dispatch-flake-dedup` clean.

### Production-only residual risk (named, not harness-coverable)

The fingerprint *string* must be computed identically across runs. It is
LLM-derived from the failure excerpt; the rigid precedence minimizes drift, but a
model that paraphrases the excerpt could still produce divergent strings. No
fixture test exercises the live fingerprint computation, so this is a tracked
manual-verification item for QA.
