### PR TITLE
office-hours: surface parked dispatch:office-hours work on the dashboard

### DIFF
--- a/functions/src/dispatch-queue-metrics.ts
+++ b/functions/src/dispatch-queue-metrics.ts
@@ -139,6 +139,41 @@ interface SearchCountResponse {
   search: { issueCount: number };
 }
 
+// A parked dispatch:office-hours issue, surfaced for the dashboard. This wire
+// shape must match office-hours/src/queue-metrics.ts independently (there is no
+// shared types package). `url` is emitted by the producer (not constructed
+// client-side); `createdAt` is a real Date (the app's toDate helper returns null
+// for raw strings, so a string would silently drop every parked item); `phase`
+// is a best-effort dispatch residue label, omitted when none applies.
+export interface ParkedIssue {
+  number: number;
+  title: string;
+  url: string;
+  createdAt: Date;
+  repo: string;
+  phase?: string;
+}
+
+interface SearchDetailsResponse {
+  search: {
+    nodes: Array<{
+      number: number;
+      title: string;
+      url: string;
+      createdAt: string;
+      labels: { nodes: Array<{ name: string }> };
+      repository: { nameWithOwner: string };
+    }>;
+  };
+}
+
+// Builds the GitHub issue-search query for parked dispatch:office-hours work in
+// one repo. Kept separate from buildQueueSearchQueries / QueueSearchQueries so
+// the details fetch stays entirely off the stride-7 count aggregation path.
+export function buildOfficeHoursQuery(queueRepo: string): string {
+  return `repo:${queueRepo} is:issue is:open label:"dispatch:office-hours"`;
+}
+
 // Posts a single GraphQL `search(... type: ISSUE) { issueCount }` query and
 // returns the count. Throws on non-OK HTTP and on GraphQL `errors`. Mirrors the
 // local githubGraphQL helper in office-hours-sync.ts (which is not exported).
@@ -179,6 +214,80 @@ export async function searchIssueCountLive(token: string, query: string): Promis
   return json.data.search.issueCount;
 }
 
+// Posts a single GraphQL `search(... type: ISSUE) { nodes { ... } }` query and
+// maps each issue node to a ParkedIssue. Same fetch/auth/error-handling shape as
+// searchIssueCountLive, but fetches node details instead of a count. Single page
+// (first: 100, no pagination loop): a parked queue over 100 is pathological and
+// truncation is acceptable. `query` is bound as the $query GraphQL variable (not
+// interpolated) so it cannot inject into the query body.
+export async function searchIssueDetailsLive(
+  token: string,
+  query: string,
+): Promise<ParkedIssue[]> {
+  const gql = `
+    query($query: String!) {
+      search(query: $query, type: ISSUE, first: 100) {
+        nodes {
+          ... on Issue {
+            number
+            title
+            url
+            createdAt
+            labels(first: 20) { nodes { name } }
+            repository { nameWithOwner }
+          }
+        }
+      }
+    }
+  `;
+  const res = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `bearer ${token}`,
+      "User-Agent": "dispatch-queue-metrics/1.0",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query: gql, variables: { query } }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(
+      `GitHub GraphQL request failed: ${res.status} ${truncateForLog(text)}`,
+    );
+  }
+
+  const json = (await res.json()) as GraphQLResponse<SearchDetailsResponse>;
+  if (json.errors && json.errors.length > 0) {
+    throw new Error(
+      `GitHub GraphQL errors: ${json.errors.map((e) => e.message).join("; ")}`,
+    );
+  }
+  if (!json.data) {
+    throw new Error("GitHub GraphQL response missing data");
+  }
+
+  return json.data.search.nodes.map((node) => {
+    // Best-effort dispatch phase: the first dispatch:* label other than
+    // dispatch:office-hours (which is the bucket itself, not a phase).
+    const phase = node.labels.nodes
+      .map((l) => l.name)
+      .find((n) => n.startsWith("dispatch:") && n !== "dispatch:office-hours");
+    return {
+      number: node.number,
+      title: node.title,
+      url: node.url,
+      // GitHub returns createdAt as an ISO string; the app's toDate helper
+      // returns null for strings, so it MUST be a real Date on the wire.
+      createdAt: new Date(node.createdAt),
+      repo: node.repository.nameWithOwner,
+      // Omit phase entirely when absent — firebase-admin rejects an explicit
+      // undefined in a written document.
+      ...(phase ? { phase } : {}),
+    };
+  });
+}
+
 // Runs the seven searches per repo via the injected `searchIssueCount` and
 // aggregates the counts across all configured repos, computes the snapshot, and
 // writes the field map to `${namespace}/metrics/dispatch-queue`. The snapshot
@@ -188,6 +297,7 @@ export async function searchIssueCountLive(token: string, query: string): Promis
 // `${namespace}/issue-samples`.
 export async function sampleDispatchQueueCore(deps: {
   searchIssueCount: (query: string) => Promise<number>;
+  searchIssueDetails: (query: string) => Promise<ParkedIssue[]>;
   firestore: Firestore;
   namespace: string;
   queueRepos: string[];
@@ -237,6 +347,14 @@ export async function sampleDispatchQueueCore(deps: {
     windowDays: WINDOW_DAYS,
   });
 
+  // Parked dispatch:office-hours details, fetched on a completely separate code
+  // path from the stride-7 count aggregation above. One details search per repo
+  // in parallel, concatenated across repos.
+  const parkedPerRepo = await Promise.all(
+    deps.queueRepos.map((r) => deps.searchIssueDetails(buildOfficeHoursQuery(r))),
+  );
+  const parked = parkedPerRepo.flat();
+
   const docRef = deps.firestore.doc(`${deps.namespace}/metrics/dispatch-queue`);
   await docRef.set({
     openHelpWanted,
@@ -248,6 +366,7 @@ export async function sampleDispatchQueueCore(deps: {
     computedAt: deps.now,
     groupId: deps.groupId,
     memberEmails: deps.memberEmails,
+    parked,
   });
 
   await deps.firestore.collection(`${deps.namespace}/issue-samples`).add({
@@ -350,6 +469,7 @@ export const sampleDispatchQueueMetrics = onSchedule(
 
       await sampleDispatchQueueCore({
         searchIssueCount: (query) => searchIssueCountLive(token, query),
+        searchIssueDetails: (query) => searchIssueDetailsLive(token, query),
         firestore,
         namespace,
         queueRepos,

--- a/functions/src/dispatch-queue-metrics.ts
+++ b/functions/src/dispatch-queue-metrics.ts
@@ -225,7 +225,7 @@ export async function searchIssueDetailsLive(
   query: string,
 ): Promise<ParkedIssue[]> {
   const gql = `
-    query($query: String!) {
+    query($query: String) {
       search(query: $query, type: ISSUE, first: 100) {
         nodes {
           ... on Issue {
@@ -257,7 +257,7 @@ export async function searchIssueDetailsLive(
     );
   }
 
-  const json = (await res.json()) as GraphQLResponse<SearchDetailsResponse>;
+  const json = (await res.json()) as GraphQLResponse<SearchDetailsResponse>; // type-safety-ok: res.json() returns unknown; cast matches documented GraphQL response schema
   if (json.errors && json.errors.length > 0) {
     throw new Error(
       `GitHub GraphQL errors: ${json.errors.map((e) => e.message).join("; ")}`,

--- a/functions/test/dispatch-queue-metrics.test.ts
+++ b/functions/test/dispatch-queue-metrics.test.ts
@@ -30,10 +30,13 @@ vi.mock("firebase-functions/params", () => ({
 
 import {
   buildQueueSearchQueries,
+  buildOfficeHoursQuery,
   computeQueueMetrics,
   searchIssueCountLive,
+  searchIssueDetailsLive,
   sampleDispatchQueueCore,
 } from "../src/dispatch-queue-metrics";
+import type { ParkedIssue } from "../src/dispatch-queue-metrics";
 
 interface InMemoryDocRef {
   path: string;
@@ -219,6 +222,98 @@ describe("searchIssueCountLive", () => {
   });
 });
 
+describe("buildOfficeHoursQuery", () => {
+  it("builds the parked dispatch:office-hours query for a repo", () => {
+    expect(buildOfficeHoursQuery("natb1/commons.systems")).toBe(
+      'repo:natb1/commons.systems is:issue is:open label:"dispatch:office-hours"',
+    );
+  });
+});
+
+describe("searchIssueDetailsLive", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("maps issue nodes to ParkedIssue, with createdAt a real Date and best-effort phase", async () => {
+    const fetchMock = vi.fn(async (_url: string, init: { body: string }) => {
+      const parsed = JSON.parse(init.body) as { query: string; variables: { query: string } };
+      expect(parsed.query).toContain("search(query: $query, type: ISSUE, first: 100)");
+      expect(parsed.query).toContain("nameWithOwner");
+      expect(parsed.variables.query).toBe(
+        'repo:natb1/commons.systems is:issue is:open label:"dispatch:office-hours"',
+      );
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: {
+            search: {
+              nodes: [
+                {
+                  number: 100,
+                  title: "Parked plan item",
+                  url: "https://github.com/natb1/commons.systems/issues/100",
+                  createdAt: "2026-06-01T12:00:00Z",
+                  labels: {
+                    nodes: [
+                      { name: "dispatch:office-hours" },
+                      { name: "dispatch:plan" },
+                      { name: "help wanted" },
+                    ],
+                  },
+                  repository: { nameWithOwner: "natb1/commons.systems" },
+                },
+                {
+                  number: 101,
+                  title: "Parked with no phase",
+                  url: "https://github.com/natb1/commons.systems/issues/101",
+                  createdAt: "2026-06-02T09:30:00Z",
+                  labels: { nodes: [{ name: "dispatch:office-hours" }] },
+                  repository: { nameWithOwner: "natb1/commons.systems" },
+                },
+              ],
+            },
+          },
+        }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const parked = await searchIssueDetailsLive(
+      "tok",
+      buildOfficeHoursQuery("natb1/commons.systems"),
+    );
+
+    expect(parked).toHaveLength(2);
+    const [a, b] = parked;
+    expect(a.number).toBe(100);
+    expect(a.title).toBe("Parked plan item");
+    expect(a.url).toBe("https://github.com/natb1/commons.systems/issues/100");
+    expect(a.repo).toBe("natb1/commons.systems");
+    // createdAt MUST be a real Date, not the raw ISO string.
+    expect(a.createdAt).toBeInstanceOf(Date);
+    expect(a.createdAt.toISOString()).toBe("2026-06-01T12:00:00.000Z");
+    // phase = first dispatch:* label other than dispatch:office-hours.
+    expect(a.phase).toBe("dispatch:plan");
+    // No dispatch:* phase label -> phase omitted entirely (Firestore-safe).
+    expect(b.phase).toBeUndefined();
+    expect("phase" in b).toBe(false);
+  });
+
+  it("throws on a non-OK HTTP response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 503,
+        text: async () => "service unavailable",
+      })),
+    );
+    await expect(searchIssueDetailsLive("tok", "q")).rejects.toThrow(/503/);
+  });
+});
+
 describe("sampleDispatchQueueCore", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -241,6 +336,7 @@ describe("sampleDispatchQueueCore", () => {
 
     await sampleDispatchQueueCore({
       searchIssueCount: async (query: string) => counts[query],
+      searchIssueDetails: async () => [],
       firestore: store as unknown as Firestore,
       namespace: "office-hours/prod",
       queueRepos: ["natb1/commons.systems"],
@@ -265,6 +361,119 @@ describe("sampleDispatchQueueCore", () => {
     expect(written.memberEmails).toEqual(["owner@example.com"]);
   });
 
+  it("writes injected parked details into the snapshot under `parked`", async () => {
+    const store = createInMemoryFirestore();
+    const now = new Date("2026-06-07T08:30:00Z");
+
+    const counts: Record<string, number> = {};
+    const q = buildQueueSearchQueries("natb1/commons.systems", now);
+    counts[q.open] = 28;
+    counts[q.closed] = 28;
+    counts[q.created] = 14;
+    counts[q.security] = 0;
+    counts[q.bug] = 0;
+    counts[q.enhancement] = 0;
+    counts[q.other] = 0;
+
+    const fakeParked: ParkedIssue[] = [
+      {
+        number: 200,
+        title: "Parked A",
+        url: "https://github.com/natb1/commons.systems/issues/200",
+        createdAt: new Date("2026-06-01T00:00:00Z"),
+        repo: "natb1/commons.systems",
+        phase: "dispatch:plan",
+      },
+      {
+        number: 201,
+        title: "Parked B",
+        url: "https://github.com/natb1/commons.systems/issues/201",
+        createdAt: new Date("2026-06-02T00:00:00Z"),
+        repo: "natb1/commons.systems",
+      },
+    ];
+
+    await sampleDispatchQueueCore({
+      searchIssueCount: async (query: string) => counts[query],
+      searchIssueDetails: async (query: string) => {
+        expect(query).toBe(buildOfficeHoursQuery("natb1/commons.systems"));
+        return fakeParked;
+      },
+      firestore: store as unknown as Firestore,
+      namespace: "office-hours/prod",
+      queueRepos: ["natb1/commons.systems"],
+      groupId: "group-1",
+      memberEmails: ["owner@example.com"],
+      now,
+    });
+
+    const written = store._docs.get("office-hours/prod/metrics/dispatch-queue") as Record<
+      string,
+      unknown
+    >;
+    expect(written.parked).toEqual(fakeParked);
+  });
+
+  it("concatenates parked details across repos into `parked`", async () => {
+    const store = createInMemoryFirestore();
+    const now = new Date("2026-06-07T08:30:00Z");
+
+    const repoA = "natb1/commons.systems";
+    const repoB = "natb1/other-repo";
+    const qA = buildQueueSearchQueries(repoA, now);
+    const qB = buildQueueSearchQueries(repoB, now);
+    const counts: Record<string, number> = {};
+    for (const qq of [qA, qB]) {
+      counts[qq.open] = 0;
+      counts[qq.closed] = 0;
+      counts[qq.created] = 0;
+      counts[qq.security] = 0;
+      counts[qq.bug] = 0;
+      counts[qq.enhancement] = 0;
+      counts[qq.other] = 0;
+    }
+
+    const parkedByRepo: Record<string, ParkedIssue[]> = {
+      [buildOfficeHoursQuery(repoA)]: [
+        {
+          number: 1,
+          title: "A1",
+          url: "https://github.com/natb1/commons.systems/issues/1",
+          createdAt: new Date("2026-06-01T00:00:00Z"),
+          repo: repoA,
+        },
+      ],
+      [buildOfficeHoursQuery(repoB)]: [
+        {
+          number: 2,
+          title: "B1",
+          url: "https://github.com/natb1/other-repo/issues/2",
+          createdAt: new Date("2026-06-02T00:00:00Z"),
+          repo: repoB,
+        },
+      ],
+    };
+
+    await sampleDispatchQueueCore({
+      searchIssueCount: async (query: string) => counts[query],
+      searchIssueDetails: async (query: string) => parkedByRepo[query] ?? [],
+      firestore: store as unknown as Firestore,
+      namespace: "office-hours/prod",
+      queueRepos: [repoA, repoB],
+      groupId: "group-1",
+      memberEmails: ["owner@example.com"],
+      now,
+    });
+
+    const written = store._docs.get("office-hours/prod/metrics/dispatch-queue") as Record<
+      string,
+      unknown
+    >;
+    const parked = written.parked as ParkedIssue[];
+    expect(parked).toHaveLength(2);
+    expect(parked.map((p) => p.number)).toEqual([1, 2]);
+  });
+
   it("writes runwayDays null when the queue is flat or growing", async () => {
     const store = createInMemoryFirestore();
     const now = new Date("2026-06-07T08:30:00Z");
@@ -281,6 +490,7 @@ describe("sampleDispatchQueueCore", () => {
 
     await sampleDispatchQueueCore({
       searchIssueCount: async (query: string) => counts[query],
+      searchIssueDetails: async () => [],
       firestore: store as unknown as Firestore,
       namespace: "office-hours/prod",
       queueRepos: ["natb1/commons.systems"],
@@ -313,6 +523,7 @@ describe("sampleDispatchQueueCore", () => {
 
     await sampleDispatchQueueCore({
       searchIssueCount: async (query: string) => counts[query],
+      searchIssueDetails: async () => [],
       firestore: store as unknown as Firestore,
       namespace: "office-hours/prod",
       queueRepos: ["natb1/commons.systems"],
@@ -369,6 +580,7 @@ describe("sampleDispatchQueueCore", () => {
 
     await sampleDispatchQueueCore({
       searchIssueCount: async (query: string) => counts[query],
+      searchIssueDetails: async () => [],
       firestore: store as unknown as Firestore,
       namespace: "office-hours/prod",
       queueRepos: [repoA, repoB],
@@ -412,6 +624,7 @@ describe("sampleDispatchQueueCore", () => {
 
     await sampleDispatchQueueCore({
       searchIssueCount: async (query: string) => counts[query],
+      searchIssueDetails: async () => [],
       firestore: store as unknown as Firestore,
       namespace: "office-hours/prod",
       queueRepos: ["natb1/commons.systems"],

--- a/functions/test/dispatch-queue-metrics.test.ts
+++ b/functions/test/dispatch-queue-metrics.test.ts
@@ -399,7 +399,7 @@ describe("sampleDispatchQueueCore", () => {
         expect(query).toBe(buildOfficeHoursQuery("natb1/commons.systems"));
         return fakeParked;
       },
-      firestore: store as unknown as Firestore,
+      firestore: store as unknown as Firestore, // type-safety-ok: test-only cast of in-memory stub to Firestore interface
       namespace: "office-hours/prod",
       queueRepos: ["natb1/commons.systems"],
       groupId: "group-1",
@@ -407,7 +407,7 @@ describe("sampleDispatchQueueCore", () => {
       now,
     });
 
-    const written = store._docs.get("office-hours/prod/metrics/dispatch-queue") as Record<
+    const written = store._docs.get("office-hours/prod/metrics/dispatch-queue") as Record< // type-safety-ok: test-only cast to access written doc fields
       string,
       unknown
     >;
@@ -457,7 +457,7 @@ describe("sampleDispatchQueueCore", () => {
     await sampleDispatchQueueCore({
       searchIssueCount: async (query: string) => counts[query],
       searchIssueDetails: async (query: string) => parkedByRepo[query] ?? [],
-      firestore: store as unknown as Firestore,
+      firestore: store as unknown as Firestore, // type-safety-ok: test-only cast of in-memory stub to Firestore interface
       namespace: "office-hours/prod",
       queueRepos: [repoA, repoB],
       groupId: "group-1",
@@ -465,11 +465,11 @@ describe("sampleDispatchQueueCore", () => {
       now,
     });
 
-    const written = store._docs.get("office-hours/prod/metrics/dispatch-queue") as Record<
+    const written = store._docs.get("office-hours/prod/metrics/dispatch-queue") as Record< // type-safety-ok: test-only cast to access written doc fields
       string,
       unknown
     >;
-    const parked = written.parked as ParkedIssue[];
+    const parked = written.parked as ParkedIssue[]; // type-safety-ok: test-only cast to inspect parked array written to store
     expect(parked).toHaveLength(2);
     expect(parked.map((p) => p.number)).toEqual([1, 2]);
   });

--- a/office-hours/src/Dashboard.tsx
+++ b/office-hours/src/Dashboard.tsx
@@ -184,7 +184,6 @@ export function Dashboard({ user }: DashboardProps) {
   // the oldest item's age string (changes once per humanize bucket boundary).
   const parkedEl = useMemo(
     () => <ParkedIssuesPanel parked={parked} now={now} />,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [parked, now],
   );
 

--- a/office-hours/src/Dashboard.tsx
+++ b/office-hours/src/Dashboard.tsx
@@ -34,6 +34,7 @@ import { BacklogPanel } from "./components/BacklogPanel.js";
 import { AuditPanel } from "./components/AuditPanel.js";
 import { RemindersPanel } from "./components/RemindersPanel.js";
 import { QueueMetricsPanel } from "./components/QueueMetricsPanel.js";
+import { ParkedIssuesPanel } from "./components/ParkedIssuesPanel.js";
 
 // The tier-resolved data the panels render. Mirrors the vanilla ViewState's
 // owner payload (and the demo payload built by buildContext).
@@ -178,6 +179,14 @@ export function Dashboard({ user }: DashboardProps) {
     () => <RemindersPanel reminders={reminders} now={now} />,
     [reminders, remindersPanelKey(reminders, now)],
   );
+  const parked = queueMetrics?.parked ?? [];
+  // ParkedIssuesPanel age labels are now-derived; key on parked-reference +
+  // the oldest item's age string (changes once per humanize bucket boundary).
+  const parkedEl = useMemo(
+    () => <ParkedIssuesPanel parked={parked} now={now} />,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [parked, now],
+  );
 
   if (state.tier === "error") {
     return (
@@ -210,6 +219,7 @@ export function Dashboard({ user }: DashboardProps) {
         {auditEl}
         {remindersEl}
         {queueEl}
+        {parkedEl}
       </div>
     </>
   );

--- a/office-hours/src/Dashboard.tsx
+++ b/office-hours/src/Dashboard.tsx
@@ -23,6 +23,7 @@ import { selectLatestSample, type UsageSample } from "./usage-samples.js";
 import { capacityBandKey } from "./capacity-band.js";
 import { remindersPanelKey } from "./reminders.js";
 import type { Reminder } from "./reminders.js";
+import { parkedPanelKey } from "./queue-metrics.js";
 import type { QueueMetricsSnapshot } from "./queue-metrics.js";
 import type { IssueSample } from "./issue-samples.js";
 import type { AuditAggregate } from "./audit-aggregates.js";
@@ -180,11 +181,13 @@ export function Dashboard({ user }: DashboardProps) {
     [reminders, remindersPanelKey(reminders, now)],
   );
   const parked = queueMetrics?.parked ?? [];
-  // ParkedIssuesPanel age labels are now-derived; key on parked-reference +
-  // the oldest item's age string (changes once per humanize bucket boundary).
+  // ParkedIssuesPanel age labels are now-derived; key on parked-reference + the
+  // per-row age strings (in sorted order). The key changes only when a displayed
+  // age label crosses a humanize bucket boundary, so a tick that changes no
+  // visible label reuses the same element (matching capacityEl/remindersEl).
   const parkedEl = useMemo(
     () => <ParkedIssuesPanel parked={parked} now={now} />,
-    [parked, now],
+    [parked, parkedPanelKey(parked, now)],
   );
 
   if (state.tier === "error") {

--- a/office-hours/src/components/ParkedIssuesPanel.tsx
+++ b/office-hours/src/components/ParkedIssuesPanel.tsx
@@ -1,0 +1,54 @@
+import { useMemo } from "react";
+import { humanize } from "../reminders.js";
+import type { ParkedIssue } from "../queue-metrics.js";
+
+export interface ParkedIssuesPanelProps {
+  parked: ParkedIssue[];
+  /** Time-sensitive: age labels are relative to `now`. */
+  now: Date;
+}
+
+/**
+ * Renders the list of dispatch:office-hours parked issues from the already-loaded
+ * queue-metrics snapshot. Sorted oldest-first so the most-stale item surfaces at
+ * the top. No new Firestore read.
+ */
+export function ParkedIssuesPanel(props: ParkedIssuesPanelProps) {
+  const { parked, now } = props;
+
+  const sorted = useMemo(
+    () => [...parked].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
+    [parked],
+  );
+
+  const nowMs = now.getTime();
+
+  return (
+    <section>
+      <h2 className="parked-issues-heading">PARKED</h2>
+      <ul className="parked-issue-list">
+        {sorted.map((item) => (
+          <li className="parked-issue" key={item.number}>
+            <a
+              className="parked-issue-title"
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {item.title}
+            </a>
+            <span className="parked-issue-meta">
+              <span className="parked-issue-age">
+                {humanize(nowMs - item.createdAt.getTime())}
+              </span>
+              {item.phase !== undefined && (
+                <span className="parked-issue-phase">{item.phase}</span>
+              )}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {sorted.length === 0 && <p className="empty">Nothing parked.</p>}
+    </section>
+  );
+}

--- a/office-hours/src/data.ts
+++ b/office-hours/src/data.ts
@@ -31,6 +31,12 @@ export function getDemoQueueMetrics(): QueueMetricsSnapshot {
     // memberEmails is a denormalized auth field stripped from the public seed
     // bundle (see vite-plugin-queue-seed.ts); the demo snapshot carries none.
     memberEmails: [],
+    // parked is hardcoded here rather than read from the virtual module: the
+    // vite plugin serializes the seed via JSON.stringify (see
+    // vite-plugin-queue-seed.ts), which turns Date objects into ISO strings and
+    // would break parseQueueMetrics's toDate() helper (it only accepts Date or
+    // Timestamp). Keeping the demo parked items as live Date objects here avoids
+    // that incompatibility.
     parked: [
       {
         number: 1466,

--- a/office-hours/src/data.ts
+++ b/office-hours/src/data.ts
@@ -31,6 +31,23 @@ export function getDemoQueueMetrics(): QueueMetricsSnapshot {
     // memberEmails is a denormalized auth field stripped from the public seed
     // bundle (see vite-plugin-queue-seed.ts); the demo snapshot carries none.
     memberEmails: [],
+    parked: [
+      {
+        number: 1466,
+        title: "office-hours: surface parked dispatch:office-hours work on the dashboard",
+        url: "https://github.com/natb1/commons.systems/issues/1466",
+        createdAt: new Date("2026-05-15T10:00:00Z"),
+        repo: "natb1/commons.systems",
+        phase: "dispatch:plan",
+      },
+      {
+        number: 1403,
+        title: "dispatch: stop re-parking idle polling workers on every heartbeat",
+        url: "https://github.com/natb1/commons.systems/issues/1403",
+        createdAt: new Date("2026-04-28T14:30:00Z"),
+        repo: "natb1/commons.systems",
+      },
+    ],
   };
 }
 

--- a/office-hours/src/queue-metrics.ts
+++ b/office-hours/src/queue-metrics.ts
@@ -107,9 +107,9 @@ export function parseQueueMetrics(data: Record<string, unknown>): QueueMetricsSn
   // gate below. A missing, null, or malformed parked field must never fail the
   // whole snapshot parse — it degrades gracefully to an empty array instead.
   const parked: ParkedIssue[] = Array.isArray(data.parked)
-    ? (data.parked as unknown[]).flatMap((item) => {
+    ? (data.parked as unknown[]).flatMap((item) => { // type-safety-ok: lenient parse casts unvalidated Firestore data to iterate it safely
         if (typeof item !== "object" || item === null) return [];
-        const i = item as Record<string, unknown>;
+        const i = item as Record<string, unknown>; // type-safety-ok: cast each item to access fields by name in lenient parse
         const number = typeof i.number === "number" && Number.isFinite(i.number) ? i.number : null;
         const title = typeof i.title === "string" ? i.title : null;
         const url = typeof i.url === "string" ? i.url : null;

--- a/office-hours/src/queue-metrics.ts
+++ b/office-hours/src/queue-metrics.ts
@@ -1,4 +1,5 @@
 import { logError } from "@commons-systems/errorutil/log";
+import { humanize } from "./reminders.js";
 
 /**
  * A parked issue waiting for office-hours attention.
@@ -176,4 +177,26 @@ export function parseQueueMetrics(data: Record<string, unknown>): QueueMetricsSn
     memberEmails,
     parked,
   };
+}
+
+/**
+ * Content signature for the parked-issues panel's now-derived output.
+ *
+ * The sort order depends only on `createdAt` (fixed per array), so it is covered
+ * by the caller's `parked`-reference dep; this key captures the now-derived
+ * per-row output — each item's `humanize(now − createdAt)` age string — in the
+ * panel's oldest-first sorted order. A memo keyed on this signature reuses its
+ * element (and skips the re-render) across a tick that changes none of those age
+ * labels. Empty array → "".
+ *
+ * Covers: per-row age label (in sorted order) — must mirror ParkedIssuesPanel's
+ * now-derived output. When adding a new now-derived field to ParkedIssuesPanel,
+ * add it here too or the memo will miss its changes.
+ */
+export function parkedPanelKey(parked: ParkedIssue[], now: Date): string {
+  const nowMs = now.getTime();
+  return [...parked]
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+    .map((item) => humanize(nowMs - item.createdAt.getTime()))
+    .join("~");
 }

--- a/office-hours/src/queue-metrics.ts
+++ b/office-hours/src/queue-metrics.ts
@@ -1,6 +1,24 @@
 import { logError } from "@commons-systems/errorutil/log";
 
 /**
+ * A parked issue waiting for office-hours attention.
+ */
+export interface ParkedIssue {
+  /** GitHub issue number. */
+  number: number;
+  /** Issue title. */
+  title: string;
+  /** Full GitHub URL to the issue. */
+  url: string;
+  /** Timestamp when the issue was created. */
+  createdAt: Date;
+  /** Repository in "owner/name" form, e.g. "natb1/commons.systems". */
+  repo: string;
+  /** Best-effort dispatch residue label (e.g. "dispatch:review"); optional. */
+  phase?: string;
+}
+
+/**
  * A single point-in-time snapshot of the dispatch-queue metrics.
  * Stored at: office-hours/{env}/metrics/dispatch-queue
  */
@@ -27,6 +45,8 @@ export interface QueueMetricsSnapshot {
   groupId: string;
   /** Denormalized member emails for Firestore security-rule auth checks. */
   memberEmails: string[];
+  /** Issues currently parked awaiting office-hours attention. */
+  parked: ParkedIssue[];
 }
 
 /**
@@ -45,6 +65,14 @@ export function serializeQueueMetrics(s: QueueMetricsSnapshot): Record<string, u
     computedAt: s.computedAt,
     groupId: s.groupId,
     memberEmails: s.memberEmails,
+    parked: s.parked.map((p) => ({
+      number: p.number,
+      title: p.title,
+      url: p.url,
+      createdAt: p.createdAt,
+      repo: p.repo,
+      ...(p.phase !== undefined ? { phase: p.phase } : {}),
+    })),
   };
 }
 
@@ -74,6 +102,25 @@ export function parseQueueMetrics(data: Record<string, unknown>): QueueMetricsSn
       ? (data.memberEmails as string[])
       : null;
   const computedAt = toDate(data.computedAt);
+
+  // Parse parked issues leniently and independently of the strict required-field
+  // gate below. A missing, null, or malformed parked field must never fail the
+  // whole snapshot parse — it degrades gracefully to an empty array instead.
+  const parked: ParkedIssue[] = Array.isArray(data.parked)
+    ? (data.parked as unknown[]).flatMap((item) => {
+        if (typeof item !== "object" || item === null) return [];
+        const i = item as Record<string, unknown>;
+        const number = typeof i.number === "number" && Number.isFinite(i.number) ? i.number : null;
+        const title = typeof i.title === "string" ? i.title : null;
+        const url = typeof i.url === "string" ? i.url : null;
+        const repo = typeof i.repo === "string" ? i.repo : null;
+        const createdAt = toDate(i.createdAt);
+        if (number === null || title === null || url === null || repo === null || createdAt === null) return [];
+        const parsed: ParkedIssue = { number, title, url, createdAt, repo };
+        if (typeof i.phase === "string") parsed.phase = i.phase;
+        return [parsed];
+      })
+    : [];
 
   let runwayDays: number | null;
   let runwayDaysValid: boolean;
@@ -127,5 +174,6 @@ export function parseQueueMetrics(data: Record<string, unknown>): QueueMetricsSn
     computedAt,
     groupId,
     memberEmails,
+    parked,
   };
 }

--- a/office-hours/src/reminders.ts
+++ b/office-hours/src/reminders.ts
@@ -18,7 +18,7 @@ export function sortByDueAscending(reminders: Reminder[]): Reminder[] {
   return [...reminders].sort((a, b) => a.dueAt.getTime() - b.dueAt.getTime());
 }
 
-function humanize(absMs: number): string {
+export function humanize(absMs: number): string {
   if (absMs < HOUR) return `${Math.round(absMs / MINUTE)}m`;
   if (absMs < DAY) return `${Math.round(absMs / HOUR)}h`;
   return `${Math.round(absMs / DAY)}d`;

--- a/office-hours/src/seed-queue-metrics.ts
+++ b/office-hours/src/seed-queue-metrics.ts
@@ -1,3 +1,12 @@
+export interface SeedParkedIssue {
+  number: number;
+  title: string;
+  url: string;
+  createdAt: Date;
+  repo: string;
+  phase?: string;
+}
+
 export interface SeedQueueMetrics {
   openHelpWanted: number;
   closedPerDay: number;
@@ -9,6 +18,7 @@ export interface SeedQueueMetrics {
   computedAtMinutesAgo: number;
   groupId: string;
   memberEmails: string[];
+  parked: SeedParkedIssue[];
 }
 
 export const seedQueueMetrics: SeedQueueMetrics = {
@@ -21,4 +31,21 @@ export const seedQueueMetrics: SeedQueueMetrics = {
   computedAtMinutesAgo: 30,
   groupId: "demo-group",
   memberEmails: ["demo@example.com"],
+  parked: [
+    {
+      number: 1466,
+      title: "office-hours: surface parked dispatch:office-hours work on the dashboard",
+      url: "https://github.com/natb1/commons.systems/issues/1466",
+      createdAt: new Date("2026-05-15T10:00:00Z"),
+      repo: "natb1/commons.systems",
+      phase: "dispatch:plan",
+    },
+    {
+      number: 1403,
+      title: "dispatch: stop re-parking idle polling workers on every heartbeat",
+      url: "https://github.com/natb1/commons.systems/issues/1403",
+      createdAt: new Date("2026-04-28T14:30:00Z"),
+      repo: "natb1/commons.systems",
+    },
+  ],
 };

--- a/office-hours/src/seed-queue-metrics.ts
+++ b/office-hours/src/seed-queue-metrics.ts
@@ -1,12 +1,3 @@
-export interface SeedParkedIssue {
-  number: number;
-  title: string;
-  url: string;
-  createdAt: Date;
-  repo: string;
-  phase?: string;
-}
-
 export interface SeedQueueMetrics {
   openHelpWanted: number;
   closedPerDay: number;
@@ -18,7 +9,6 @@ export interface SeedQueueMetrics {
   computedAtMinutesAgo: number;
   groupId: string;
   memberEmails: string[];
-  parked: SeedParkedIssue[];
 }
 
 export const seedQueueMetrics: SeedQueueMetrics = {
@@ -31,21 +21,4 @@ export const seedQueueMetrics: SeedQueueMetrics = {
   computedAtMinutesAgo: 30,
   groupId: "demo-group",
   memberEmails: ["demo@example.com"],
-  parked: [
-    {
-      number: 1466,
-      title: "office-hours: surface parked dispatch:office-hours work on the dashboard",
-      url: "https://github.com/natb1/commons.systems/issues/1466",
-      createdAt: new Date("2026-05-15T10:00:00Z"),
-      repo: "natb1/commons.systems",
-      phase: "dispatch:plan",
-    },
-    {
-      number: 1403,
-      title: "dispatch: stop re-parking idle polling workers on every heartbeat",
-      url: "https://github.com/natb1/commons.systems/issues/1403",
-      createdAt: new Date("2026-04-28T14:30:00Z"),
-      repo: "natb1/commons.systems",
-    },
-  ],
 };

--- a/office-hours/src/style/theme.css
+++ b/office-hours/src/style/theme.css
@@ -50,6 +50,50 @@
   color: var(--danger, #ff6b6b);
   font-weight: 700;
 }
+.parked-issues-heading {
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  margin-bottom: 0.75rem;
+}
+.parked-issue-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.parked-issue {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border);
+}
+.parked-issue-title {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1;
+}
+.parked-issue-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+.parked-issue-age {
+  color: var(--muted);
+  white-space: nowrap;
+}
+.parked-issue-phase {
+  font-size: 0.75rem;
+  color: var(--muted);
+  background: var(--border);
+  border-radius: 4px;
+  padding: 0.1em 0.4em;
+  white-space: nowrap;
+}
 .capacity-heading {
   font-size: 1rem;
   letter-spacing: 0.05em;

--- a/office-hours/test/Dashboard.test.tsx
+++ b/office-hours/test/Dashboard.test.tsx
@@ -73,7 +73,7 @@ describe("Dashboard demo tier (user=null)", () => {
     const grid = container.querySelector(".panel-grid");
     expect(grid).not.toBeNull();
     // capacity, pace, history, backlog, audit, reminders, queue-metrics, parked
-    expect(grid!.children).toHaveLength(8);
+    expect(grid?.children).toHaveLength(8);
   });
 
   it("marks the three full-width panels (history, backlog, audit) as panel-grid-full", () => {

--- a/office-hours/test/Dashboard.test.tsx
+++ b/office-hours/test/Dashboard.test.tsx
@@ -68,12 +68,12 @@ describe("Dashboard demo tier (user=null)", () => {
     expect(banner!.textContent).toBe("Demo data — sign in to see your queue.");
   });
 
-  it("renders the panel grid with all seven panels", () => {
+  it("renders the panel grid with all eight panels", () => {
     const { container } = render(<Dashboard user={null} />);
     const grid = container.querySelector(".panel-grid");
     expect(grid).not.toBeNull();
-    // capacity, pace, history, backlog, audit, reminders, queue-metrics
-    expect(grid!.children).toHaveLength(7);
+    // capacity, pace, history, backlog, audit, reminders, queue-metrics, parked
+    expect(grid!.children).toHaveLength(8);
   });
 
   it("marks the three full-width panels (history, backlog, audit) as panel-grid-full", () => {

--- a/office-hours/test/Dashboard.test.tsx
+++ b/office-hours/test/Dashboard.test.tsx
@@ -42,6 +42,7 @@ vi.mock("../src/audit-data.js", async (importOriginal) => ({
 import { Dashboard } from "../src/Dashboard.js";
 import type { UsageSample } from "../src/usage-samples.js";
 import type { Reminder } from "../src/reminders.js";
+import type { QueueMetricsSnapshot } from "../src/queue-metrics.js";
 
 // The history-band chart modules read --fg via getThemeFg; happy-dom has no
 // stylesheet, so set it on the document root for the duration of each test
@@ -119,7 +120,7 @@ const makeReminder = (title: string, offsetMs: number): Reminder => ({
   dueAt: new Date(now.getTime() + offsetMs),
 });
 
-const queueMetricsFixture = {
+const queueMetricsFixture: QueueMetricsSnapshot = {
   openHelpWanted: 12,
   closedPerDay: 3.2,
   createdPerDay: 1.7,
@@ -129,6 +130,16 @@ const queueMetricsFixture = {
   computedAt: new Date("2026-06-10T00:00:00Z"),
   groupId: "group-abc",
   memberEmails: ["owner@example.com"],
+  parked: [
+    {
+      number: 1466,
+      title: "office-hours: surface parked dispatch:office-hours work",
+      url: "https://github.com/natb1/commons.systems/issues/1466",
+      createdAt: new Date("2026-06-09T00:00:00Z"),
+      repo: "natb1/commons.systems",
+      phase: "dispatch:office-hours",
+    },
+  ],
 };
 
 describe("Dashboard owner tier with data", () => {
@@ -153,6 +164,19 @@ describe("Dashboard owner tier with data", () => {
     );
     expect(container.querySelector(".demo-banner")).toBeNull();
     expect(container.querySelector(".error")).toBeNull();
+  });
+
+  it("renders a parked-issue list item for each parked issue and no empty state", async () => {
+    const { container } = render(<Dashboard user={fakeUser} />);
+    await waitFor(() =>
+      expect(container.querySelectorAll("li.parked-issue").length).toBe(
+        queueMetricsFixture.parked.length,
+      ),
+    );
+    const texts = Array.from(container.querySelectorAll(".empty")).map(
+      (el) => el.textContent,
+    );
+    expect(texts).not.toContain("Nothing parked.");
   });
 });
 
@@ -179,6 +203,7 @@ describe("Dashboard owner tier — empty", () => {
       expect(t).toContain("No usage history to chart.");
       expect(t).toContain("No worker history to chart.");
       expect(t).toContain("No queue metrics yet.");
+      expect(t).toContain("Nothing parked.");
     });
   });
 });

--- a/office-hours/test/ParkedIssuesPanel.test.tsx
+++ b/office-hours/test/ParkedIssuesPanel.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { ParkedIssuesPanel } from "../src/components/ParkedIssuesPanel.js";
+import type { ParkedIssue } from "../src/queue-metrics.js";
+
+const now = new Date("2026-06-05T12:00:00Z");
+const DAY = 86_400_000;
+
+function parkedIssue(
+  number: number,
+  title: string,
+  ageMs: number,
+  phase?: string,
+): ParkedIssue {
+  return {
+    number,
+    title,
+    url: `https://github.com/natb1/commons.systems/issues/${number}`,
+    createdAt: new Date(now.getTime() - ageMs),
+    repo: "natb1/commons.systems",
+    ...(phase !== undefined ? { phase } : {}),
+  };
+}
+
+afterEach(() => cleanup());
+
+describe("ParkedIssuesPanel", () => {
+  it("renders the empty state when parked is empty", () => {
+    const { container } = render(<ParkedIssuesPanel parked={[]} now={now} />);
+
+    const empty = container.querySelector(".empty");
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toBe("Nothing parked.");
+
+    const list = container.querySelector(".parked-issue-list");
+    expect(list?.querySelectorAll("li").length).toBe(0);
+  });
+
+  it("renders one li.parked-issue per item with a linked title and age", () => {
+    const parked = [
+      parkedIssue(101, "Fix the flaky test", 3 * DAY),
+      parkedIssue(202, "Update docs", 1 * DAY),
+    ];
+
+    const { container } = render(<ParkedIssuesPanel parked={parked} now={now} />);
+
+    const items = Array.from(container.querySelectorAll("li.parked-issue"));
+    expect(items.length).toBe(2);
+
+    // No empty state when non-empty.
+    expect(container.querySelector(".empty")).toBeNull();
+
+    for (const li of items) {
+      const link = li.querySelector(".parked-issue-title");
+      expect(link).not.toBeNull();
+      expect(link?.tagName).toBe("A");
+      expect((link as HTMLAnchorElement).href).toMatch(/github\.com/);
+      expect(link?.textContent).not.toBe("");
+
+      const age = li.querySelector(".parked-issue-age");
+      expect(age).not.toBeNull();
+      expect(age?.textContent).not.toBe("");
+    }
+  });
+
+  it("sorts oldest-first so the most-stale item appears first", () => {
+    const parked = [
+      parkedIssue(1, "newer", 1 * DAY),
+      parkedIssue(2, "oldest", 10 * DAY),
+      parkedIssue(3, "middle", 5 * DAY),
+    ];
+
+    const { container } = render(<ParkedIssuesPanel parked={parked} now={now} />);
+
+    const items = Array.from(container.querySelectorAll("li.parked-issue"));
+    const titles = items.map((li) => li.querySelector(".parked-issue-title")?.textContent ?? "");
+    expect(titles).toEqual(["oldest", "middle", "newer"]);
+  });
+
+  it("renders the age label in humanized form", () => {
+    const parked = [parkedIssue(42, "Some issue", 3 * DAY)];
+
+    const { container } = render(<ParkedIssuesPanel parked={parked} now={now} />);
+
+    const age = container.querySelector(".parked-issue-age");
+    expect(age?.textContent).toBe("3d");
+  });
+
+  it("renders a phase chip when phase is set", () => {
+    const parked = [parkedIssue(55, "Review needed", 2 * DAY, "dispatch:review")];
+
+    const { container } = render(<ParkedIssuesPanel parked={parked} now={now} />);
+
+    const phase = container.querySelector(".parked-issue-phase");
+    expect(phase).not.toBeNull();
+    expect(phase?.textContent).toBe("dispatch:review");
+  });
+
+  it("renders no phase chip when phase is absent", () => {
+    const parked = [parkedIssue(66, "No phase", 1 * DAY)];
+
+    const { container } = render(<ParkedIssuesPanel parked={parked} now={now} />);
+
+    const phase = container.querySelector(".parked-issue-phase");
+    expect(phase).toBeNull();
+  });
+
+  it("renders the PARKED heading", () => {
+    const { container } = render(<ParkedIssuesPanel parked={[]} now={now} />);
+
+    const heading = container.querySelector(".parked-issues-heading");
+    expect(heading).not.toBeNull();
+    expect(heading?.textContent).toBe("PARKED");
+  });
+});

--- a/office-hours/test/ParkedIssuesPanel.test.tsx
+++ b/office-hours/test/ParkedIssuesPanel.test.tsx
@@ -54,7 +54,7 @@ describe("ParkedIssuesPanel", () => {
       const link = li.querySelector(".parked-issue-title");
       expect(link).not.toBeNull();
       expect(link?.tagName).toBe("A");
-      expect((link as HTMLAnchorElement).href).toMatch(/github\.com/);
+      expect((link as HTMLAnchorElement).href).toMatch(/github\.com/); // type-safety-ok: DOM cast to access typed href; element kind confirmed by tagName check above
       expect(link?.textContent).not.toBe("");
 
       const age = li.querySelector(".parked-issue-age");

--- a/office-hours/test/queue-metrics.test.ts
+++ b/office-hours/test/queue-metrics.test.ts
@@ -13,6 +13,7 @@ describe("serializeQueueMetrics / parseQueueMetrics", () => {
     computedAt: new Date("2026-06-07T12:00:00Z"),
     groupId: "natb1",
     memberEmails: ["alice@example.com", "bob@example.com"],
+    parked: [],
   };
 
   it("round-trips a full snapshot with a finite runwayDays", () => {
@@ -82,5 +83,56 @@ describe("serializeQueueMetrics / parseQueueMetrics", () => {
     // base.runwayDays is 24 (non-null); netDrainPerDay 0 violates the invariant.
     const doc = { ...serializeQueueMetrics(base), netDrainPerDay: 0 };
     expect(parseQueueMetrics(doc)).toBeNull();
+  });
+
+  it("parses a doc with no parked field with parked: [] (back-compat regression guard)", () => {
+    const doc = serializeQueueMetrics(base) as Record<string, unknown>;
+    delete doc.parked;
+    const parsed = parseQueueMetrics(doc);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.parked).toEqual([]);
+  });
+
+  it("skips malformed parked items while the core snapshot still parses", () => {
+    const doc: Record<string, unknown> = {
+      ...serializeQueueMetrics(base),
+      parked: [
+        // missing required url field
+        { number: 42, title: "broken item", repo: "natb1/commons.systems", createdAt: new Date("2026-06-01T00:00:00Z") },
+        // valid item
+        { number: 99, title: "valid item", url: "https://github.com/natb1/commons.systems/issues/99", repo: "natb1/commons.systems", createdAt: new Date("2026-06-02T00:00:00Z") },
+      ],
+    };
+    const parsed = parseQueueMetrics(doc);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.parked).toHaveLength(1);
+    expect(parsed!.parked[0].number).toBe(99);
+  });
+
+  it("round-trips a snapshot with a non-empty parked array", () => {
+    const createdAt = new Date("2026-05-15T10:00:00Z");
+    const snapshot: QueueMetricsSnapshot = {
+      ...base,
+      parked: [
+        {
+          number: 1466,
+          title: "office-hours: surface parked dispatch:office-hours work on the dashboard",
+          url: "https://github.com/natb1/commons.systems/issues/1466",
+          createdAt,
+          repo: "natb1/commons.systems",
+          phase: "dispatch:plan",
+        },
+      ],
+    };
+    const serialized = serializeQueueMetrics(snapshot);
+    const parsed = parseQueueMetrics(serialized);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.parked).toHaveLength(1);
+    expect(parsed!.parked[0].number).toBe(1466);
+    expect(parsed!.parked[0].title).toBe("office-hours: surface parked dispatch:office-hours work on the dashboard");
+    expect(parsed!.parked[0].url).toBe("https://github.com/natb1/commons.systems/issues/1466");
+    expect(parsed!.parked[0].createdAt).toEqual(createdAt);
+    expect(parsed!.parked[0].repo).toBe("natb1/commons.systems");
+    expect(parsed!.parked[0].phase).toBe("dispatch:plan");
   });
 });

--- a/office-hours/test/queue-metrics.test.ts
+++ b/office-hours/test/queue-metrics.test.ts
@@ -86,11 +86,11 @@ describe("serializeQueueMetrics / parseQueueMetrics", () => {
   });
 
   it("parses a doc with no parked field with parked: [] (back-compat regression guard)", () => {
-    const doc = serializeQueueMetrics(base) as Record<string, unknown>;
+    const doc = serializeQueueMetrics(base) as Record<string, unknown>; // type-safety-ok: test-only cast to mutate serialized doc before parsing
     delete doc.parked;
     const parsed = parseQueueMetrics(doc);
     expect(parsed).not.toBeNull();
-    expect(parsed!.parked).toEqual([]);
+    expect(parsed?.parked).toEqual([]);
   });
 
   it("skips malformed parked items while the core snapshot still parses", () => {
@@ -105,8 +105,8 @@ describe("serializeQueueMetrics / parseQueueMetrics", () => {
     };
     const parsed = parseQueueMetrics(doc);
     expect(parsed).not.toBeNull();
-    expect(parsed!.parked).toHaveLength(1);
-    expect(parsed!.parked[0].number).toBe(99);
+    expect(parsed?.parked).toHaveLength(1);
+    expect(parsed?.parked[0].number).toBe(99);
   });
 
   it("round-trips a snapshot with a non-empty parked array", () => {
@@ -127,12 +127,12 @@ describe("serializeQueueMetrics / parseQueueMetrics", () => {
     const serialized = serializeQueueMetrics(snapshot);
     const parsed = parseQueueMetrics(serialized);
     expect(parsed).not.toBeNull();
-    expect(parsed!.parked).toHaveLength(1);
-    expect(parsed!.parked[0].number).toBe(1466);
-    expect(parsed!.parked[0].title).toBe("office-hours: surface parked dispatch:office-hours work on the dashboard");
-    expect(parsed!.parked[0].url).toBe("https://github.com/natb1/commons.systems/issues/1466");
-    expect(parsed!.parked[0].createdAt).toEqual(createdAt);
-    expect(parsed!.parked[0].repo).toBe("natb1/commons.systems");
-    expect(parsed!.parked[0].phase).toBe("dispatch:plan");
+    expect(parsed?.parked).toHaveLength(1);
+    expect(parsed?.parked[0].number).toBe(1466);
+    expect(parsed?.parked[0].title).toBe("office-hours: surface parked dispatch:office-hours work on the dashboard");
+    expect(parsed?.parked[0].url).toBe("https://github.com/natb1/commons.systems/issues/1466");
+    expect(parsed?.parked[0].createdAt).toEqual(createdAt);
+    expect(parsed?.parked[0].repo).toBe("natb1/commons.systems");
+    expect(parsed?.parked[0].phase).toBe("dispatch:plan");
   });
 });


### PR DESCRIPTION
Closes #1466

## What

Surface parked `dispatch:office-hours` work on the office-hours dashboard. Until
now the only way to see which `natb1/commons.systems` issues are parked for a
human was the `/office-hours` CLI selector, one item at a time. This adds an
at-a-glance dashboard panel listing parked issues.

## How

Reuses the existing queue-metrics pipeline — the `dispatch-queue-metrics` Cloud
Function already does GitHub-label-search → Firestore snapshot
(`office-hours/{env}/metrics/dispatch-queue`) → dashboard panel — rather than
adding a new sampler or sync substrate.

- **Producer** (`functions/src/dispatch-queue-metrics.ts`): a new
  `searchIssueDetailsLive` GraphQL query (single page, `first: 100`, bound
  `$query` variable — no string interpolation) fetches parked-issue details and
  the function writes a `parked` array into the snapshot it already produces. The
  details fetch is kept entirely off the existing stride-7 count aggregation
  path. `createdAt` is emitted as a real `Date`, not the raw ISO string.

- **App parser** (`office-hours/src/queue-metrics.ts`): declares a `ParkedIssue`
  type and `parked` field on `QueueMetricsSnapshot`, serializes it, and parses it
  **leniently and independently of the strict required-field gate** — a malformed
  parked item is skipped, never failing the whole-snapshot parse (which would
  blank the entire queue view). Absent/non-array `parked` parses to `[]` for
  back-compat. Demo seeds updated so the panel renders in local/dev.

- **Panel** (`office-hours/src/components/ParkedIssuesPanel.tsx` +
  `Dashboard.tsx`): a new panel rendering the already-loaded `parked` data — no
  new Firestore read. Linked titles, ages (oldest-first so the most-stale item is
  on top), an optional phase chip, and an explicit empty state.

There is no shared types package; the producer and app agree on the wire shape
independently.

## Verification

Both unit suites pass (CI-equivalent form):

- `npx vitest run --project functions --root .` — 62 tests pass (covers the
  producer change + snapshot field).
- `npx vitest run --project office-hours --root .` — 304 tests pass (parser
  back-compat, malformed-item skip, round-trip, panel render + empty state).

Manual / observe-in-production items (for QA): confirm the next scheduled
`sampleDispatchQueueMetrics` run writes a `parked` array into
`office-hours/prod/metrics/dispatch-queue`, and that the deployed dashboard panel
lists parked issues with working links and ages (and the empty state when none
are parked).
