### PR TITLE
office-hours-select-target: attach registered-worktree idle session on null daemon cwd

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours-select-target
@@ -293,6 +293,7 @@ FRESH_NUM=""
 IDLE_ID=""
 IDLE_CWD=""
 IDLE_NUM=""
+IDLE_WT_PATH=""
 SESSIONLESS_NUMS=()
 while IFS= read -r issue_num; do
   [[ -z "$issue_num" ]] && continue
@@ -301,6 +302,7 @@ while IFS= read -r issue_num; do
     # and remember the issue so the post-loop classifier can derive its branch.
     IFS=$'\t' read -r IDLE_ID IDLE_CWD <<< "$pair"
     IDLE_NUM="$issue_num"
+    IDLE_WT_PATH=$(printf '%s' "${WORKTREE_PATHS_BY_NUM[$IDLE_NUM]:-}" | head -n 1)
     break
   else
     rc=$?
@@ -326,7 +328,7 @@ done <<< "$SORTED"
 #      prints a clear swept-worktree diagnostic and exits — fresh fallback with a
 #      diagnostic, never a silent failure.
 if [[ -n "$IDLE_ID" ]]; then
-  if [[ -d "$IDLE_CWD" ]]; then
+  if [[ -d "$IDLE_WT_PATH" || -d "$IDLE_CWD" ]]; then
     printf 'idle %s\n' "$IDLE_ID"
     exit 0
   elif [[ -n "$IDLE_CWD" ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -7846,6 +7846,30 @@ assert_eq "attachable session, empty cwd, no worktree → fresh fallback with - 
 unset DISPATCH_OFFICE_HOURS_MAIN_WORKTREE
 teardown
 
+# OHST19. Registered-worktree null-cwd degrade (#2281): an attachable session
+# reporting an EMPTY cwd whose <N>-* worktree IS registered and on disk → attach
+# in place via the known worktree path (IDLE_WT_PATH), not a fresh launch.
+# Pre-#2281 the empty cwd failed both -d and -n checks and fell to bucket 3.
+echo "Test: registered worktree + null-cwd session → idle (attach via worktree path)"
+setup
+printf '[{"number":42,"createdAt":"2024-01-01T00:00:00Z"}]\n' > "$STUB_DIR/oh-issue-list.json"
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+mkdir -p "$TMPDIR_TEST/wt/42-x"
+# CRITICAL: the path REGISTERED in worktree-list.txt must be the SAME on-disk
+# path that is mkdir'd above, so IDLE_WT_PATH (derived from
+# WORKTREE_PATHS_BY_NUM) resolves to a real directory. Do NOT copy OHST13's
+# split fake-path/real-path setup: there the registered path is a non-existent
+# /worktrees/42-x and the test passes via IDLE_CWD, which would NOT exercise the
+# IDLE_WT_PATH check this case is for.
+printf 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree %s\nHEAD def456\nbranch refs/heads/42-x\n\n' \
+  "$TMPDIR_TEST/wt/42-x" > "$STUB_DIR/worktree-list.txt"
+# Registered basename 42-x has no session; office-hours-42 is attachable with a
+# 2-field (name:state) fake → EMPTY cwd → null-cwd degrade.
+office_hours_state_fake_claude "office-hours-42:waiting"
+result=$("$TMPDIR_TEST/office-hours-select-target")
+assert_eq "registered worktree + null cwd → idle via worktree path" "idle s-office-hours-42" "$result"
+teardown
+
 # ============================================================================
 # office-hours (entry point) tests
 # ============================================================================


### PR DESCRIPTION
Closes #2281

## Problem

`office-hours-select-target` classifies an attachable (`idle`) originating
session into attach-in-place, attach-after-provision, or fresh-fallback. For the
registered-worktree branch, bucket 1 ("attach in place") was gated **only** on
the daemon-reported cwd (`[[ -d "$IDLE_CWD" ]]`).

The daemon populating a non-empty `.cwd` for a resumed idle session is not
guaranteed. When it returns an empty `.cwd`, both `[[ -d "$IDLE_CWD" ]]` and
`[[ -n "$IDLE_CWD" ]]` fail and the code falls through to bucket 3, launching a
**fresh** session on top of an occupied worktree instead of attaching to the
live session.

## Fix

For the registered-worktree case the on-disk path is already known from
`WORKTREE_PATHS_BY_NUM[$IDLE_NUM]` and does not need the daemon.

- Record it as `IDLE_WT_PATH` in the enumeration loop (same `printf … | head -n 1`
  idiom the resume and fresh passes already use).
- Check it first in the bucket-1 gate:
  `if [[ -d "$IDLE_WT_PATH" || -d "$IDLE_CWD" ]]; then`.

When `IDLE_WT_PATH` is empty (no registered worktree), `[[ -d "" ]]` is false, so
the gate reduces to the existing `[[ -d "$IDLE_CWD" ]]` — no behavior change for
the non-registered-worktree branch, and the swept and bucket-3 paths are
untouched.

## Tests

Adds `OHST19` to `test-dispatch-scripts.sh`: an attachable session with an empty
daemon cwd whose `<N>-*` worktree is registered and on disk now attaches in place
via `IDLE_WT_PATH` instead of falling to a fresh launch. Full suite passes
3952/3952.

Surfaced by the code-review pass for PR #2276 (which implements #2241); was out
of scope for that PR.
