### PR TITLE
office-hours: resume removed originating session without a continue prompt, named by worktree basename

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours
@@ -62,7 +62,8 @@
 #                                   daemon registry but its on-disk transcript is
 #                                   recoverable and its <N>-* worktree is present
 #                                   (#2240). Resume it in place as a --bg job named
-#                                   office-hours-<N> rooted at <cwd> (--resume, with
+#                                   by the worktree basename (<N>-slug) rooted at
+#                                   <cwd> (--resume, with
 #                                   a --fork-session retry if the kick fails on a
 #                                   stale/colliding id), then attach BY NAME — a
 #                                   forked retry mints a new sessionId, so the

--- a/.claude/skills/dispatch-propagate/scripts/office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours
@@ -148,7 +148,7 @@ job_id_for_name() {
 # attach_session_by_name <name> — exec `claude attach` on the background job named
 # <name>. The resume arms attach BY NAME, never by the selector's <sessionId>: a
 # --fork-session retry mints a NEW sessionId, so the original is stale, while the
-# name office-hours-<N> is the stable handle.
+# worktree basename is the stable handle.
 attach_session_by_name() {
   local name="$1" job_id
   job_id=$(job_id_for_name "$name")
@@ -161,33 +161,38 @@ attach_session_by_name() {
 
 # resume_session <sessionId> <N> <cwd> — resume a REMOVED-but-recoverable
 # originating session (#2240) in place. Mirrors dispatch-resume-worker's resume
-# mechanism INLINE — it is NOT invoked, because that script's worker-only
-# `^[0-9]+-` name gate rejects the office-hours-<N> name used here.
+# mechanism INLINE — it is NOT invoked, because that script submits a "continue"
+# prompt, whereas the office-hours resume must OMIT any prompt: the resumed
+# session is blocked on a human who should attach and drive, so without a
+# -p/--print prompt the --bg launch boots interactive and parks awaiting input
+# (mirroring the idle disposition). The session is named by the worktree
+# basename (`<N>-slug`), so it IS the original phase worker as far as the Stop
+# hook's `^[0-9]+-` discriminator is concerned.
 #
-# Kick the session as a --bg job named office-hours-<N>, rooted at <cwd> via a
-# subshell `cd` so SessionStart-derived attributes key on the right directory. A
-# successful resume requires BOTH a clean kick AND verified registration:
-# `claude --bg` returns BEFORE the daemon registers the session, and a
-# dead/colliding <sessionId> is rejected ASYNCHRONOUSLY (the kick returns 0, yet
-# no session ever registers). So gate on kick-rc-0 AND verify_agent_registered_
-# under, mirroring dispatch-resume-worker. On a failed kick OR a failed verify,
-# retry ONCE with --fork-session, which resumes off a fresh id derived from the
-# same transcript. Both attempts failing to register is a hard error (a clear
-# message beats a silent fresh-spawn).
+# Kick the session as a --bg job named by the worktree basename (`<N>-slug`),
+# rooted at <cwd> via a subshell `cd` so SessionStart-derived attributes key on
+# the right directory. A successful resume requires BOTH a clean kick AND
+# verified registration: `claude --bg` returns BEFORE the daemon registers the
+# session, and a dead/colliding <sessionId> is rejected ASYNCHRONOUSLY (the kick
+# returns 0, yet no session ever registers). So gate on kick-rc-0 AND
+# verify_agent_registered_under, mirroring dispatch-resume-worker. On a failed
+# kick OR a failed verify, retry ONCE with --fork-session, which resumes off a
+# fresh id derived from the same transcript. Both attempts failing to register
+# is a hard error (a clear message beats a silent fresh-spawn).
 #
 # THE FORKED-SESSIONID TRAP: --fork-session mints a NEW sessionId, so the
 # selector's <sessionId> is stale for attach. attach_session_by_name keys on the
-# stable name office-hours-<N>, never the original sessionId.
+# stable worktree basename, never the original sessionId.
 resume_session() {
-  local session_id="$1" num="$2" cwd="$3" name="office-hours-$2" rc=0
+  local session_id="$1" num="$2" cwd="$3" name="$(basename "$3")" rc=0
   ( cd "$cwd" && "$CLAUDE_CMD" --bg --name "$name" --permission-mode auto \
-      --resume "$session_id" "continue" ) >/dev/null 2>&1 || rc=$?
+      --resume "$session_id" ) >/dev/null 2>&1 || rc=$?
   if [[ "$rc" -ne 0 ]] || ! verify_agent_registered_under "$name" "$cwd"; then
     # Primary kick failed, or it returned 0 but no session registered (an
     # async-rejected stale/colliding id). Retry ONCE off a fresh forked id.
     rc=0
     ( cd "$cwd" && "$CLAUDE_CMD" --bg --name "$name" --permission-mode auto \
-        --resume "$session_id" --fork-session "continue" ) >/dev/null 2>&1 || rc=$?
+        --resume "$session_id" --fork-session ) >/dev/null 2>&1 || rc=$?
     if [[ "$rc" -ne 0 ]] || ! verify_agent_registered_under "$name" "$cwd"; then
       echo "office-hours: failed to resume session $session_id for #$num under name $name in $cwd (both --resume and --fork-session kicks failed to register a live session). Run 'claude agents' to inspect." >&2
       exit 1
@@ -247,7 +252,8 @@ case "$verb" in
   resume)
     # a b c = <N> <sessionId> <cwd>. The originating session was removed from the
     # daemon registry but its transcript is recoverable and its <N>-* worktree is
-    # on disk — resume it in place under name office-hours-<N>, then attach by name.
+    # on disk — resume it in place under the worktree basename (`<N>-slug`), then
+    # attach by name.
     resume_session "$b" "$a" "$c"
     ;;
   resume-provision)

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -8182,11 +8182,12 @@ teardown
 
 # OH11. resume arm end-to-end (#2240): the selector emits `resume <N> <sid> <cwd>`
 # for a removed-but-recoverable session whose worktree is on disk. The entry
-# resumes it as a --bg job named office-hours-<N> rooted at <cwd>, then attaches BY
-# NAME. Stub the selector to emit the directive; a fake claude logs the --bg argv,
-# serves the post-resume registry (office-hours-42 under a FORKED sessionId, so
-# attach must resolve by NAME not by the verb's sess-abc), and echoes attach.
-echo "Test: resume directive → --bg --resume kick named office-hours-N, attach by name"
+# resumes it as a --bg job named by the worktree basename (42-x) rooted at <cwd>,
+# carrying NO "continue" prompt (it parks for the human), then attaches BY NAME.
+# Stub the selector to emit the directive; a fake claude logs the --bg argv,
+# serves the post-resume registry (42-x under a FORKED sessionId, so attach must
+# resolve by NAME not by the verb's sess-abc), and echoes attach.
+echo "Test: resume directive → --bg --resume kick named by worktree basename, no continue, attach by name"
 setup
 mkdir -p "$TMPDIR_TEST/wt/42-x"
 cat > "$TMPDIR_TEST/office-hours-select-target" <<EOF
@@ -8199,7 +8200,7 @@ cat > "$TMPDIR_TEST/bin/claude" <<'FAKE'
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 case "$1" in
   agents)
-    echo '[{"sessionId":"forked-xyz","id":"j-office-hours-42","pid":1,"state":"idle","status":"idle","name":"office-hours-42","cwd":""}]'
+    echo '[{"sessionId":"forked-xyz","id":"j-42-x","pid":1,"state":"idle","status":"idle","name":"42-x","cwd":""}]'
     ;;
   attach)
     echo "LAUNCH: attach $2"
@@ -8216,15 +8217,21 @@ export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/bin/claude"   # verify_agent_registered_u
 export LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S=0          # don't sleep between verify polls
 result=$("$TMPDIR_TEST/office-hours")
 bg=$(cat "$TMPDIR_TEST/bg-argv-log" 2>/dev/null || true)
-assert_eq "resume kick argv (single, no fork)" "--bg --name office-hours-42 --permission-mode auto --resume sess-abc continue" "$bg"
-assert_eq "resume attaches by name → j-office-hours-42 (not the verb sessionId)" "LAUNCH: attach j-office-hours-42" "$result"
+assert_eq "resume kick argv (single, no fork, no continue)" "--bg --name 42-x --permission-mode auto --resume sess-abc" "$bg"
+# The resume must NOT auto-run work: no "continue" prompt token, and the --name
+# must equal the worktree basename (42-x), matching the Stop hook's ^[0-9]+- gate.
+oh_has_continue=no; [[ "$bg" == *continue* ]] && oh_has_continue=yes
+assert_eq "resume kick carries no continue prompt token" "no" "$oh_has_continue"
+oh_name=$(printf '%s\n' "$bg" | sed -n 's/.*--name \([^ ]*\).*/\1/p')
+assert_eq "resume --name equals worktree basename" "42-x" "$oh_name"
+assert_eq "resume attaches by name → j-42-x (not the verb sessionId)" "LAUNCH: attach j-42-x" "$result"
 unset OFFICE_HOURS_CLAUDE_CMD CLAUDE_AGENTS_CMD LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S
 teardown
 
 # OH12. resume fork-retry (#2240): the primary --bg --resume kick fails (a dead
 # sessionId can collide in the registry), so the entry retries ONCE with
 # --fork-session, then attaches BY NAME (the forked id is reachable via the stable
-# office-hours-<N> name). The fake fails any --bg kick lacking --fork-session.
+# worktree basename). The fake fails any --bg kick lacking --fork-session.
 echo "Test: resume primary kick fails → fork-session retry, then attach by name"
 setup
 mkdir -p "$TMPDIR_TEST/wt/42-x"
@@ -8238,7 +8245,7 @@ cat > "$TMPDIR_TEST/bin/claude" <<'FAKE'
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 case "$1" in
   agents)
-    echo '[{"sessionId":"forked-xyz","id":"j-office-hours-42","pid":1,"state":"idle","status":"idle","name":"office-hours-42","cwd":""}]'
+    echo '[{"sessionId":"forked-xyz","id":"j-42-x","pid":1,"state":"idle","status":"idle","name":"42-x","cwd":""}]'
     exit 0
     ;;
   attach)
@@ -8259,9 +8266,9 @@ export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/bin/claude"   # verify_agent_registered_u
 export LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S=0          # don't sleep between verify polls
 result=$("$TMPDIR_TEST/office-hours")
 mapfile -t oh_resume_argv < "$TMPDIR_TEST/bg-argv-log"
-assert_eq "primary kick carries no --fork-session" "--bg --name office-hours-42 --permission-mode auto --resume sess-abc continue" "${oh_resume_argv[0]:-}"
-assert_eq "fork retry appends --fork-session before continue" "--bg --name office-hours-42 --permission-mode auto --resume sess-abc --fork-session continue" "${oh_resume_argv[1]:-}"
-assert_eq "after fork, attach by name → j-office-hours-42" "LAUNCH: attach j-office-hours-42" "$result"
+assert_eq "primary kick carries no --fork-session (no continue)" "--bg --name 42-x --permission-mode auto --resume sess-abc" "${oh_resume_argv[0]:-}"
+assert_eq "fork retry appends --fork-session (no continue)" "--bg --name 42-x --permission-mode auto --resume sess-abc --fork-session" "${oh_resume_argv[1]:-}"
+assert_eq "after fork, attach by name → j-42-x" "LAUNCH: attach j-42-x" "$result"
 unset OFFICE_HOURS_CLAUDE_CMD CLAUDE_AGENTS_CMD LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S
 teardown
 
@@ -8270,8 +8277,8 @@ teardown
 # dead/colliding sessionId (claude --bg returns before registration; a rejected
 # id never registers). The verify gate must catch this (rc 0 is not enough) and
 # retry with --fork-session, after which the session registers and attach
-# resolves by name. The fake registers office-hours-42 ONLY after a --fork-session
-# kick.
+# resolves by name. The fake registers the basename session (42-x) ONLY after a
+# --fork-session kick.
 echo "Test: resume primary kick returns 0 but never registers → verify fails → fork"
 setup
 mkdir -p "$TMPDIR_TEST/wt/42-x"
@@ -8287,7 +8294,7 @@ case "$1" in
   agents)
     # Registered ONLY after a --fork-session kick created the marker.
     if [[ -f "$ROOT/forked" ]]; then
-      echo '[{"sessionId":"forked-xyz","id":"j-office-hours-42","pid":1,"state":"idle","status":"idle","name":"office-hours-42","cwd":""}]'
+      echo '[{"sessionId":"forked-xyz","id":"j-42-x","pid":1,"state":"idle","status":"idle","name":"42-x","cwd":""}]'
     else
       echo '[]'
     fi
@@ -8311,9 +8318,9 @@ export CLAUDE_AGENTS_CMD="$TMPDIR_TEST/bin/claude"
 export LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S=0
 result=$("$TMPDIR_TEST/office-hours")
 mapfile -t oh_resume_argv < "$TMPDIR_TEST/bg-argv-log"
-assert_eq "primary kick (rc 0, unregistered) carries no --fork-session" "--bg --name office-hours-42 --permission-mode auto --resume sess-abc continue" "${oh_resume_argv[0]:-}"
-assert_eq "verify-fail triggers fork retry (rc 0 alone is not enough)" "--bg --name office-hours-42 --permission-mode auto --resume sess-abc --fork-session continue" "${oh_resume_argv[1]:-}"
-assert_eq "after fork registers, attach by name → j-office-hours-42" "LAUNCH: attach j-office-hours-42" "$result"
+assert_eq "primary kick (rc 0, unregistered) carries no --fork-session (no continue)" "--bg --name 42-x --permission-mode auto --resume sess-abc" "${oh_resume_argv[0]:-}"
+assert_eq "verify-fail triggers fork retry (rc 0 alone is not enough)" "--bg --name 42-x --permission-mode auto --resume sess-abc --fork-session" "${oh_resume_argv[1]:-}"
+assert_eq "after fork registers, attach by name → j-42-x" "LAUNCH: attach j-42-x" "$result"
 unset OFFICE_HOURS_CLAUDE_CMD CLAUDE_AGENTS_CMD LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S
 teardown
 

--- a/.claude/skills/office-hours/SKILL.md
+++ b/.claude/skills/office-hours/SKILL.md
@@ -37,9 +37,21 @@ So engaging an item here clears the label automatically; this skill does **not**
 clear it itself, and on completion the item is dispatch-eligible again. The
 session simply ends; the next `/dispatch-propagate` router (re-seeded by the
 heartbeat) returns the de-labeled item to the dispatch chain. There is no in-skill
-hand-off and no Stop-hook action — the Stop hook ignores non-`<N>-` session names,
-and office-hours sessions are named `office-hours-<N>` (which does not match its
-`^[0-9]+-` discriminator).
+hand-off.
+
+Stop-hook behavior differs by queue path:
+
+- **Fresh `/office-hours` session** — named `office-hours-<N>`, which does not
+  match the Stop hook's `^[0-9]+-` discriminator. The hook ignores it; no chain
+  action on stop.
+- **Resumed originating session** (`resume` / `resume-provision` dispositions,
+  #2356) — named by the worktree basename (`<N>-slug`), which **does** match
+  `^[0-9]+-`. The Stop hook treats it like any other phase worker: if the
+  phase-completed marker is present (Branch B), the chain advances; if absent
+  (Branch A), the hook re-applies `dispatch:office-hours` — correct, because the
+  item still needs a human. The strip hook is keyed on the git branch (`<N>-*`),
+  not the session name, so it still clears `dispatch:office-hours` on the human's
+  first prompt regardless of which path launched the session.
 
 ## Steps
 
@@ -376,14 +388,17 @@ and office-hours sessions are named `office-hours-<N>` (which does not match its
         only state change this disposition makes; a genuinely-broken behavior is
         the human's call to file a fix separately (out of scope). **Stop.**
 
-   **Stop semantics.** This session is named `office-hours-<N>`, which the Stop
-   hook ignores (its `^[0-9]+-` discriminator does not match), so stopping
-   triggers no chain action — exactly as the other dispositions end. Unlike the
-   `<N>-…` dispositions, the `dispatch-office-hours-strip` hook does **not** fire
-   here (the branch is `main`, not `<N>-…`), so the `dispatch:office-hours` label
-   is not auto-cleared on your first prompt. **Closing the issue is what removes
-   the item from the `--state open` office-hours queue** — that is why the close
-   matters. If you leave it open (not-verified branch), it correctly resurfaces.
+   **Stop semantics.** This describes the fresh `office-hours-<N>`-named session
+   that runs on `main` for the `main-qa` disposition. That session name does not
+   match the Stop hook's `^[0-9]+-` discriminator, so stopping triggers no chain
+   action. For the `resume` / `resume-provision` arms (basename-named sessions),
+   the Stop hook acts on stop like it does for `idle` — see
+   [Label clearing is automatic]. Unlike the `<N>-…` dispositions, the
+   `dispatch-office-hours-strip` hook does **not** fire here (the branch is
+   `main`, not `<N>-…`), so the `dispatch:office-hours` label is not auto-cleared
+   on your first prompt. **Closing the issue is what removes the item from the
+   `--state open` office-hours queue** — that is why the close matters. If you
+   leave it open (not-verified branch), it correctly resurfaces.
 
 [QA data policy]: ../qa-fix/SKILL.md
 [Label clearing is automatic]: #label-clearing-is-automatic


### PR DESCRIPTION
Closes #2356

## Summary

The office-hours queue's `resume` / `resume-provision` dispositions (#2240)
re-engage a *removed-but-recoverable* originating session via
`claude --bg --resume`. Two things were wrong for the human-facing office-hours
context, both in `resume_session()` in
`.claude/skills/dispatch-propagate/scripts/office-hours`:

1. **It auto-ran work instead of waiting for the human.** Both resume kicks
   passed a literal `"continue"` prompt under `--permission-mode auto`, so the
   resumed session resumed autonomous execution rather than parking on input.
   Office-hours items are blocked on a human who is supposed to attach and drive
   — exactly as the `idle` disposition does (it attaches and sends no prompt).
2. **It used a bespoke name `office-hours-<N>`.** The dispatch router names a
   phase session by its **worktree basename** (`<N>-slug`, via
   `basename "$WORKTREE_PATH"` in `dispatch-launch-worker`). The resumed session
   now uses that same convention.

## What changed

- **`resume_session()` (Unit 1).** `name` is now the worktree basename of the
  session cwd (`basename "$cwd"`), and the trailing `"continue"` positional is
  dropped from both the primary `--bg --resume` kick and the `--fork-session`
  retry. Without `-p/--print`, a `--bg` launch boots interactive and parks
  awaiting input — the resume-and-park mechanism. The existing
  `verify_agent_registered_under` gate + `--fork-session` retry remain the safety
  net: a no-prompt kick that fails to register a live session fails loud, never
  silent. The now-false load-bearing comments (the `^[0-9]+-` name-gate rationale,
  the FORKED-SESSIONID-TRAP note, and the `office-hours-<N>` references in the
  disposition arms and `attach_session_by_name()`) are corrected.

- **The Stop-hook reconciliation (Unit 2, docs).** Renaming the resumed session
  to `<N>-slug` makes its name **match** the Stop hook's `^[0-9]+-` discriminator,
  which it did not before. **Decision: let the Stop hook fire — no
  `dispatch-stop.sh` change.** The resumed session *is* the original `<N>-slug`
  phase worker resurrected with its transcript, so the normal Stop-hook
  disposition is correct and consistent with `idle`. The branch-keyed strip hook
  (`dispatch-office-hours-strip.sh`, keyed on the `<N>-*` git branch, not the
  session name) still clears `dispatch:office-hours` on the human's first prompt
  (no missed clear); on stop, Branch B advances the chain if the phase completed,
  Branch A re-parks `dispatch:office-hours` if it did not (the desired "still
  needs a human" outcome). This reconciliation is documented in
  `.claude/skills/office-hours/SKILL.md`.

## Out of scope

- No change to `dispatch-stop.sh`, `dispatch-office-hours-strip.sh`,
  `lib-claude-agents.sh`, `dispatch-spawn-office-hours`, or the **fresh**
  `office-hours` disposition (still named `office-hours-<N>`).
- The attempt-counter bump on human-driven `<N>-slug` stops predates this issue,
  applies equally to `idle`, and exempting human-assisted sessions is a separate
  design problem — left as a possible follow-up.

## Testing

- `.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` — the
  dispatch-scripts unit suite (the exact command CI runs), including the updated
  resume entry-point tests OH11–OH13 with new assertions that the resume kick
  carries **no `continue` token** and that `--name` equals the worktree basename.
  **3959/3959 passed, 0 failed.**
- Live park-and-register confirmation (a no-prompt `--bg --resume` boots, parks
  for the human, and registers under the `<N>-slug` name) requires a live daemon
  and a human-in-the-loop attach — documented as a manual verification step in
  the plan; the existing verify gate surfaces any registration failure loudly.
