### PR TITLE
audio: extend AC4 corrupt-sidecar write-suppression test to all four write entry points

### DIFF
--- a/audio/test/sidecar.test.ts
+++ b/audio/test/sidecar.test.ts
@@ -1022,6 +1022,22 @@ describe("corrupt sidecar — fail-closed", () => {
     expect(await getPlayerState()).toMatchObject({ queue: ["a.mp3"], positionSeconds: 12 });
   });
 
+  it("corrupt sidecar: all four write entry points are gated (AC4b)", async () => {
+    const { dir, fileHandle } = makePreloadedDir("{not json");
+    setLocalDirectory(dir, true);
+
+    await savePlayerState({ queue: ["a.mp3"], currentLocalName: "a.mp3", positionSeconds: 12 });
+    await cacheMetadata("song.mp3", { tags: { title: "X" }, size: 10, lastModified: 1 });
+    await cacheMetadataBatch({ "a.mp3": { tags: { title: "A" }, size: 1, lastModified: 1 } });
+    await savePlaylist("Favs", ["a.mp3", "b.mp3"]);
+    await flushWrites();
+
+    // No caller wrote — the shared corrupt-dir gate suppressed every write path.
+    expect(fileHandle.createWritable).not.toHaveBeenCalled();
+    // Corrupt bytes on disk are preserved for recovery.
+    expect(fileHandle._state.content).toBe("{not json");
+  });
+
   it("missing sidecar (NotFoundError): savePlayerState DOES write (AC5)", async () => {
     const dir = makeDirWithMissingFile();
     setLocalDirectory(dir, true);

--- a/audio/test/sidecar.test.ts
+++ b/audio/test/sidecar.test.ts
@@ -1036,6 +1036,11 @@ describe("corrupt sidecar — fail-closed", () => {
     expect(fileHandle.createWritable).not.toHaveBeenCalled();
     // Corrupt bytes on disk are preserved for recovery.
     expect(fileHandle._state.content).toBe("{not json");
+
+    // In-memory session still works for every caller (the merge applied to an empty model).
+    expect(await getPlayerState()).toMatchObject({ queue: ["a.mp3"], positionSeconds: 12 });
+    expect(await getMetadata("song.mp3")).toBeDefined();
+    expect(await getPlaylists()).toEqual({ Favs: ["a.mp3", "b.mp3"] });
   });
 
   it("missing sidecar (NotFoundError): savePlayerState DOES write (AC5)", async () => {


### PR DESCRIPTION
Closes #2331

## Summary

The AC4 corrupt-sidecar test (added in PR #2309 for #2304) asserts that
`savePlayerState` does **not** write to disk when the loaded sidecar is corrupt
— fail-closed, so a later write can't clobber a user's playlists. But all four
public write paths — `savePlayerState`, `cacheMetadata`, `cacheMetadataBatch`,
and `savePlaylist` — funnel through the shared private `enqueueWrite` gate in
`audio/src/sidecar.ts`, and the existing test exercises only one of them.

This adds an `AC4b` sibling test inside the same
`describe("corrupt sidecar — fail-closed", …)` block that sets up the corrupt-dir
fixture once, calls **all four** public write entry points on it, flushes, and
asserts the shared gate suppressed every write (`createWritable` never called,
corrupt bytes on disk preserved). A future refactor that moved the corrupt-dir
gate out of `enqueueWrite` into the individual write functions could otherwise
silently drop fail-closed protection from the three uncovered entry points while
the suite stayed green — this closes that gap.

## Changes

- `audio/test/sidecar.test.ts` — one new `it("…all four write entry points are
  gated (AC4b)")` test. No production code changes; `audio/src/sidecar.ts` is
  correct and untouched.

## Verification

`npx vitest run --project audio --root .` — 251 passed (1 pre-existing skip),
including the new AC4b test.
