### PR TITLE
dispatch-token-audit: classify --bg workers by real phase-skill first message

### DIFF
--- a/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
@@ -216,7 +216,11 @@ def cmd_prefix(c):
            or ($firstuser_str | test("/recover-api-error")) ) then "recovery"
     elif ( ($path | test("--bare"))
            or ( [ $a[] | select(.gitBranch=="HEAD") ] | length > 0 ) ) then "router-tick"
-    elif ($firstuser_str | test("dispatch-worker")) then "worker"
+    # Real --bg dispatch workers are spawned with a phase-skill slash command.
+    # Their first user message is a <command-name>/<skill></command-name> block
+    # whose skill is one of the dispatch worker phase set. This alternation must
+    # be updated when a new dispatch worker phase skill is added.
+    elif ($firstuser_str | test("<command-name>/(plan-issue|implement|qa-fix|review-fix|fix-checks|fix-conflicts|qa-main|budget-parse-job|resolve-epic|office-hours)</command-name>")) then "worker"
     else "other" end ) as $type
 
 # Peak context across assistant msgs.

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -966,6 +966,43 @@ assert_eq "coverage: window.sidecar_present_rate (2/3)" "$EXPECTED_COV_RATE" \
 rm -rf "$COV_ROOT"
 
 # ---------------------------------------------------------------------------
+# Alternation coverage (#2351): every phase skill in the classifier's worker
+# alternation must classify a first-message <command-name> session as "worker".
+# The #2268 cov block above exercises only 3 of the 10; a typo in any of the
+# other 7 skill names would silently misclassify those sessions as "other".
+# ISOLATED fixture: one minimal worker session per skill, each in its own root
+# so the shared totals stay untouched. Keep this list in lockstep with the
+# alternation regex in aggregate-usage.sh's classifier.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- alternation coverage: all 10 phase skills classify as worker (#2351) ---"
+
+for skill in plan-issue implement qa-fix review-fix fix-checks fix-conflicts \
+             qa-main budget-parse-job resolve-epic office-hours; do
+  ALT_ROOT=$(mktemp -d)
+  trap 'rm -rf "$ALT_ROOT"; teardown' EXIT INT TERM
+  alt_worktree="$ALT_ROOT/-home-x-worktrees-2351-alternation"
+  mkdir -p "$alt_worktree"
+  alt_jsonl="$alt_worktree/sess-alt.jsonl"
+  printf '%s\n' "{\"type\":\"user\",\"message\":{\"content\":\"<command-name>/$skill</command-name>\"}}" \
+    >> "$alt_jsonl"
+  printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2351-alternation","message":{"model":"claude-opus-4-8","usage":{"input_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0}}}' \
+    >> "$alt_jsonl"
+  jq . "$alt_jsonl" >/dev/null
+  touch "$alt_jsonl"
+
+  OUT_ALT=$(
+    export DISPATCH_AUDIT_PROJECTS_ROOT="$ALT_ROOT"
+    bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7
+  )
+  assert_eq "alternation: /$skill session classifies as worker" "worker" \
+    "$(jq -r '[.sessions[]|select(.id=="sess-alt")][0].type' <<<"$OUT_ALT")"
+
+  rm -rf "$ALT_ROOT"
+done
+
+# ---------------------------------------------------------------------------
 # Sidecar-coverage metric, case (c): zero-worker edge (#2268). ISOLATED fixture
 # with only a router-tick session (no worker). The eligible denominator is 0, so
 # sidecar_present_rate must be null (not 0, not a divide-by-zero) and
@@ -1015,7 +1052,7 @@ echo ""
 echo "--- freeform interactive session classifies as other, excluded from sidecar_eligible (#2351) ---"
 
 FREEFORM_ROOT=$(mktemp -d)
-trap 'rm -rf "$FREEFORM_ROOT" "$FAKE_WRITER_DIR"; teardown' EXIT INT TERM
+trap 'rm -rf "$FREEFORM_ROOT"; teardown' EXIT INT TERM
 freeform_worktree="$FREEFORM_ROOT/-home-x-worktrees-2351-freeform"
 mkdir -p "$freeform_worktree"
 freeform_jsonl="$freeform_worktree/sess-freeform.jsonl"

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -87,7 +87,7 @@ setup() {
   local worker_jsonl="$worktree_dir/sess-worker.jsonl"
 
   # line 1: first user line — classifies as worker
-  printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+  printf '%s\n' '{"type":"user","message":{"content":"<command-name>/plan-issue</command-name>"}}' \
     >> "$worker_jsonl"
 
   # line 2: assistant — plan-implement, opus, usage input=1000, cc=2000, cr=4000, out=500
@@ -638,7 +638,7 @@ mkdir -p "$partial_worktree"
 partial_jsonl="$partial_worktree/sess-partial.jsonl"
 
 # line 1: first user line — classifies as worker (mirror line 68)
-printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/plan-issue</command-name>"}}' \
   >> "$partial_jsonl"
 # line 2: assistant — opus, minimal usage (mirror the worker assistant shape)
 printf '%s\n' '{"type":"assistant","attributionSkill":"review-fix","isSidechain":false,"gitBranch":"1909-partial","message":{"model":"claude-opus-4-8","content":[{"type":"tool_use","id":"toolu_p01","name":"Bash","input":{"command":"echo hi"}}],"usage":{"input_tokens":1,"cache_creation_input_tokens":2,"cache_read_input_tokens":4,"output_tokens":1}}}' \
@@ -696,7 +696,7 @@ mkdir -p "$guard_worktree"
 guard_jsonl="$guard_worktree/sess-guard.jsonl"
 
 # line 1: first user line — classifies as worker
-printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/plan-issue</command-name>"}}' \
   >> "$guard_jsonl"
 # line 2: assistant — UNPRICEABLE model "gpt-fake-9" with NONZERO usage
 printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2027-guard","message":{"model":"gpt-fake-9","usage":{"input_tokens":1000,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0}}}' \
@@ -731,7 +731,7 @@ synth_worktree="$SYNTH_ROOT/-home-x-worktrees-2027-synth"
 mkdir -p "$synth_worktree"
 synth_jsonl="$synth_worktree/sess-synth.jsonl"
 
-printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/plan-issue</command-name>"}}' \
   >> "$synth_jsonl"
 # assistant — unclassifiable "<synthetic>" model, ALL-ZERO usage → cost 0, no abort
 printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2027-synth","message":{"model":"<synthetic>","usage":{"input_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0}}}' \
@@ -771,7 +771,7 @@ mkdir -p "$haiku_worktree"
 haiku_jsonl="$haiku_worktree/sess-haiku.jsonl"
 
 # line 1: first user line — classifies as worker
-printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/plan-issue</command-name>"}}' \
   >> "$haiku_jsonl"
 # line 2: assistant — claude-haiku-4-5, distinct nonzero usage in all four components
 printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2027-haiku","message":{"model":"claude-haiku-4-5","usage":{"input_tokens":1000,"cache_creation_input_tokens":2000,"cache_read_input_tokens":4000,"output_tokens":500}}}' \
@@ -815,7 +815,7 @@ mkdir -p "$opus3_worktree"
 opus3_jsonl="$opus3_worktree/sess-opus3.jsonl"
 
 # line 1: first user line — classifies as worker
-printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/plan-issue</command-name>"}}' \
   >> "$opus3_jsonl"
 # line 2: assistant — claude-3-opus-20240229, distinct nonzero usage in all four components
 printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2102-opus3","message":{"model":"claude-3-opus-20240229","usage":{"input_tokens":1000,"cache_creation_input_tokens":2000,"cache_read_input_tokens":4000,"output_tokens":500}}}' \
@@ -848,7 +848,7 @@ mkdir -p "$haiku3_worktree"
 haiku3_jsonl="$haiku3_worktree/sess-haiku3.jsonl"
 
 # line 1: first user line — classifies as worker
-printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/plan-issue</command-name>"}}' \
   >> "$haiku3_jsonl"
 # line 2: assistant — claude-3-haiku-20240307, distinct nonzero usage in all four components
 printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2102-haiku3","message":{"model":"claude-3-haiku-20240307","usage":{"input_tokens":1000,"cache_creation_input_tokens":2000,"cache_read_input_tokens":4000,"output_tokens":500}}}' \
@@ -880,7 +880,7 @@ mkdir -p "$enum_worktree"
 enum_jsonl="$enum_worktree/sess-enum.jsonl"
 
 # line 1: first user line — classifies as worker
-printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/plan-issue</command-name>"}}' \
   >> "$enum_jsonl"
 # line 2: assistant — claude-3-5-haiku-20241022 (omitted in issue's fix snippet)
 printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2102-enum","message":{"model":"claude-3-5-haiku-20241022","usage":{"input_tokens":1000,"cache_creation_input_tokens":2000,"cache_read_input_tokens":4000,"output_tokens":500}}}' \
@@ -928,7 +928,13 @@ mkdir -p "$cov_worktree"
 # worker; one zero-usage assistant line keeps totals/price irrelevant here).
 for s in a b c; do
   cov_jsonl="$cov_worktree/sess-cov-$s.jsonl"
-  printf '%s\n' '{"type":"user","message":{"content":"<command-name>/dispatch-worker</command-name>"}}' \
+  # Use three distinct real phase-skill commands to verify the alternation
+  case "$s" in
+    a) cov_cmd='<command-name>/plan-issue</command-name>' ;;
+    b) cov_cmd='<command-name>/qa-fix</command-name>' ;;
+    c) cov_cmd='<command-name>/review-fix</command-name>' ;;
+  esac
+  printf '%s\n' "{\"type\":\"user\",\"message\":{\"content\":\"$cov_cmd\"}}" \
     >> "$cov_jsonl"
   printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2268-coverage","message":{"model":"claude-opus-4-8","usage":{"input_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0}}}' \
     >> "$cov_jsonl"
@@ -996,6 +1002,44 @@ assert_eq "zero-worker: window.sidecar_present_rate is null (zero denom)" "null"
   "$(jq '.window.sidecar_present_rate' <<<"$OUT_NOWORKER")"
 
 rm -rf "$NOWORKER_ROOT"
+
+# ---------------------------------------------------------------------------
+# Freeform interactive session discriminator (#2351). ISOLATED fixture: a
+# top-level worktree session whose first user message is freeform interactive
+# text (no <command-name> tag) must classify as "other" and must NOT be counted
+# in sidecar_eligible — proving the new alternation does not widen to match
+# arbitrary interactive sessions and inflate sidecar_present_rate.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- freeform interactive session classifies as other, excluded from sidecar_eligible (#2351) ---"
+
+FREEFORM_ROOT=$(mktemp -d)
+trap 'rm -rf "$FREEFORM_ROOT" "$FAKE_WRITER_DIR"; teardown' EXIT INT TERM
+freeform_worktree="$FREEFORM_ROOT/-home-x-worktrees-2351-freeform"
+mkdir -p "$freeform_worktree"
+freeform_jsonl="$freeform_worktree/sess-freeform.jsonl"
+
+# line 1: freeform interactive text — no <command-name> tag, must classify as "other"
+printf '%s\n' '{"type":"user","message":{"content":"Can you help me debug this function?"}}' \
+  >> "$freeform_jsonl"
+# line 2: assistant — minimal usage, normal worktree gitBranch
+printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2351-freeform","message":{"model":"claude-opus-4-8","usage":{"input_tokens":1,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1}}}' \
+  >> "$freeform_jsonl"
+jq . "$freeform_jsonl" >/dev/null
+touch "$freeform_jsonl"
+
+OUT_FREEFORM=$(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$FREEFORM_ROOT"
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7
+)
+
+assert_eq "freeform: session type is other (not worker)" "other" \
+  "$(jq -r '[.sessions[]|select(.id=="sess-freeform")][0].type' <<<"$OUT_FREEFORM")"
+assert_eq "freeform: window.sidecar_eligible == 0 (other session excluded)" "0" \
+  "$(jq '.window.sidecar_eligible' <<<"$OUT_FREEFORM")"
+
+rm -rf "$FREEFORM_ROOT"
 
 report_results
 exit $FAIL


### PR DESCRIPTION
Closes #2351

## Problem

The `dispatch-token-audit` worker-type classifier
(`aggregate-usage.sh`) decided `type == "worker"` with a substring match on the
first user message:

```jq
elif ($firstuser_str | test("dispatch-worker")) then "worker"
```

The string `dispatch-worker` appears **only** in the classifier and its synthetic
test fixtures — no real launcher emits it. Real `claude --bg` dispatch workers are
spawned with a phase-skill slash command (e.g. `dispatch-launch-worker` execs the
phase skill, `dispatch-spawn-office-hours` spawns `/office-hours`), so a real
worker's first user message is a `<command-name>/<skill></command-name>` block,
never that substring.

**Consequence:** `test("dispatch-worker")` was `false` for every real worker, so
the `worker` count was always 0. That `worker` count is the `sidecar_eligible`
denominator for the #2268 sidecar-coverage monitor, so `sidecar_eligible` was
always 0 and `sidecar_present_rate` always `null` — the monitor was silently
useless.

## Fix

- **Classifier** (`aggregate-usage.sh`): replace the substring match with an
  anchored alternation over the dispatch worker phase-skill set, matching the
  exact `<command-name>/<skill></command-name>` form observed in real transcripts.
  The full-tag anchoring is deliberately precise — it matches only the real `--bg`
  worker population and will not widen to interactive slash-command sessions (which
  would inflate `sidecar_present_rate` toward 1.0 and mask the `--bg`-specific
  stamp failure the monitor exists to catch). A comment records the observed format
  and notes the alternation must track new dispatch worker phases.

- **Fixtures** (`test-aggregate-usage.sh`): migrate the synthetic
  `<command-name>/dispatch-worker</command-name>` worker fixtures to real
  phase-skill commands so the fixtures anchor the observed format. The #2268
  sidecar-coverage block now uses three distinct commands (`/plan-issue`,
  `/qa-fix`, `/review-fix`) to guard against a single-command hardcode.

- **Discriminator assertion** (`test-aggregate-usage.sh`): a freeform interactive
  session (no `<command-name>` tag) must classify as `other` and be excluded from
  `sidecar_eligible` — locking the worker / interactive boundary the fix depends
  on.

## Verification

`bash .claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh` — 108/108
passing (up from 106; +2 from the new discriminator assertion).

The end-to-end confirmation (`sidecar_eligible` non-zero, `sidecar_present_rate` a
float in `[0,1]` against real `--bg` transcripts) is an observe-in-production check
left for QA, since it requires a subsequent live dispatch tick.

**Out of scope (follow-up):** the `by_phase` seed list at `aggregate-usage.sh:489`
still references stale synthetic phase names; that is a separate
`attributionSkill` rollup, unrelated to this first-user `type` classifier.
