### PR TITLE
dispatch: rename dispatch-detect-rate-limit-death to dispatch-detect-transient-death

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -434,7 +434,7 @@ session_scheduled_wakeup() {
 # Grep for literal substrings (not echo-into-jq): the IDs are plain substrings,
 # so grep is robust and sidesteps the control-char trap
 # (.claude/rules/shell-json.md), mirroring dispatch-recover-dispatched-phase /
-# dispatch-detect-rate-limit-death.
+# dispatch-detect-transient-death.
 #
 # Session-scoped scan (#2261): the extractions run against the CURRENT session's
 # records only, not the whole file. A RESUMED session carries the prior run's
@@ -622,7 +622,7 @@ fi
 #   - marker absent AND this is one of Branch A's two continuation gates that
 #     RESUME the same session rather than concluding an attempt: a live
 #     idle-poller (session_scheduled_wakeup) or a transient rate-limit death
-#     (dispatch-detect-rate-limit-death). Counting an idle-poller would bump once
+#     (dispatch-detect-transient-death). Counting an idle-poller would bump once
 #     per poll cycle and blow the ceiling on a single healthy review phase
 #     (#1590). These mirror the gates at ~lines 383 and 397 below — keep the two
 #     in sync. (The rate-limit gate can fall through to an office-hours park when
@@ -637,7 +637,7 @@ fi
 if [ "$ISSUE_OFFICE_HOURS_PRESENT" = no ] \
    && { [ -n "$MARKER_PHASE" ] \
         || { ! session_scheduled_wakeup \
-             && ! "$SCRIPTS/dispatch-detect-rate-limit-death" "$TRANSCRIPT_PATH" 2>/dev/null; }; }; then
+             && ! "$SCRIPTS/dispatch-detect-transient-death" "$TRANSCRIPT_PATH" 2>/dev/null; }; }; then
   attempt_verdict=$("$SCRIPTS/dispatch-attempt-count" "$ISSUE_NUM" 2>/dev/null) || attempt_verdict=proceed
   if [ "$attempt_verdict" = escalate ]; then
     # Re-read the just-bumped total to name it in the office-hours reason (AC4).
@@ -681,7 +681,7 @@ if [ -z "$MARKER_PHASE" ]; then
   # retry. Checked AFTER the scheduled-wakeup gate (a live poller still takes
   # precedence) and BEFORE the office-hours park below. On a positive detection
   # arm a backed-off resume of the dead session in place.
-  if "$SCRIPTS/dispatch-detect-rate-limit-death" "$TRANSCRIPT_PATH"; then
+  if "$SCRIPTS/dispatch-detect-transient-death" "$TRANSCRIPT_PATH"; then
     _sid=$(jq -r '.sessionId // empty' "$STATE_FILE" 2>/dev/null)
     _cwd=$(jq -r '.cwd // empty' "$STATE_FILE" 2>/dev/null)
     _model=$("$SCRIPTS/dispatch-phase-model" "$CURRENT_PHASE" 2>/dev/null || true)

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-detect-transient-death
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-detect-transient-death
@@ -3,7 +3,7 @@
 # (server-overload rate-limit, 529 Overloaded, or stream idle timeout) rather
 # than the user's own usage-limit exhaustion.
 #
-# Usage: dispatch-detect-rate-limit-death <transcript-path>
+# Usage: dispatch-detect-transient-death <transcript-path>
 #
 # Exit codes (fail-safe, positive-evidence-only):
 #   0 — the session's LAST assistant turn matches an allowlisted transient

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -38042,7 +38042,7 @@ assert_eq "dispatch-auto-merge is executable" "yes" \
 # dispatch-detect-transient-death tests (#1733)
 # ============================================================================
 #
-# Exercises the rate-limit-death detector: exit 0 iff the transcript's LAST
+# Exercises the transient-death detector: exit 0 iff the transcript's LAST
 # assistant turn is an isApiErrorMessage:true turn whose joined text contains any
 # of the allowlisted transient-death signatures — the original rate-limit
 # substring `(not your usage limit)`, `529 Overloaded`, or `Stream idle timeout`;
@@ -38061,7 +38061,7 @@ drd_teardown() {
   TMPDIR_TEST=""
 }
 
-# The rate-limit-death turn: isApiErrorMessage:true + the `(not your usage limit)`
+# A transient-death turn (rate-limit signature): isApiErrorMessage:true + the `(not your usage limit)`
 # server-overload substring. A normal assistant final turn has no isApiErrorMessage.
 RL_TURN='{"type":"assistant","isApiErrorMessage":true,"message":{"role":"assistant","content":[{"type":"text","text":"API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited"}]}}'
 NORMAL_TURN='{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"work in progress"}]}}'
@@ -38079,7 +38079,7 @@ echo "Test: last turn is the rate-limit apiError → exit 0 (match)"
 drd_setup
 printf '%s\n' "$NORMAL_TURN" "$RL_TURN" > "$TMPDIR_TEST/match.jsonl"
 if "$DRD" "$TMPDIR_TEST/match.jsonl"; then rc=0; else rc=$?; fi
-assert_eq "rate-limit-death match exits 0" "0" "$rc"
+assert_eq "transient-death (rate-limit) match exits 0" "0" "$rc"
 drd_teardown
 
 # --- Test 2: NO-MATCH — a normal assistant final turn → exit 1 ---------------

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -38032,7 +38032,7 @@ assert_eq "dispatch-auto-merge is executable" "yes" \
   "$([[ -x "$SCRIPT_DIR/dispatch-auto-merge" ]] && echo yes || echo no)"
 
 # ============================================================================
-# dispatch-detect-rate-limit-death tests (#1733)
+# dispatch-detect-transient-death tests (#1733)
 # ============================================================================
 #
 # Exercises the rate-limit-death detector: exit 0 iff the transcript's LAST
@@ -38042,9 +38042,9 @@ assert_eq "dispatch-auto-merge is executable" "yes" \
 # exit 1 otherwise (fail-safe). Fixtures are one compact JSON object per line,
 # written with printf '%s\n' (NOT echo) so the JSONL is byte-exact.
 echo ""
-echo "=== dispatch-detect-rate-limit-death ==="
+echo "=== dispatch-detect-transient-death ==="
 
-DRD="$SCRIPT_DIR/dispatch-detect-rate-limit-death"
+DRD="$SCRIPT_DIR/dispatch-detect-transient-death"
 
 drd_setup() {
   TMPDIR_TEST=$(mktemp -d)


### PR DESCRIPTION
Closes #2355

Pure mechanical rename of the dispatch transient-death detector script.

## What changed

Renamed `.claude/skills/dispatch-propagate/scripts/dispatch-detect-rate-limit-death`
to `dispatch-detect-transient-death` (via `git mv`, preserving history) and
updated every occurrence of the exact script-name string across the repo — 8
occurrences in 3 tracked files:

- the renamed script's own usage-line comment,
- `.claude/hooks/dispatch-stop.sh` (2 comments + 2 live invocations),
- `.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` (a
  section-header comment, an `echo` banner, and the functional `DRD` path
  binding).

## Why

The script was originally written (#1733) to detect a Claude session that died
on a server-side rate-limit API error. Since #2342 / #2340 it detects **any**
allowlisted transient server-side API death — the original `(not your usage
limit)` rate-limit substring **plus** `529 Overloaded` and `Stream idle
timeout`. The name `dispatch-detect-rate-limit-death` understated that scope and
could mislead a future maintainer about which error classes are covered. #2342
deliberately deferred the rename to avoid downstream churn while that PR was in
flight; this is that follow-up.

## Scope

Strictly the exact script-name string. Descriptive "rate-limit" prose
(variable names like `RL_TURN`, the `(not your usage limit)` substring the
detector matches, narrative comments) is intentionally untouched. No behavior
change.

## Verification

- `git grep -n "dispatch-detect-rate-limit-death"` returns nothing.
- The renamed script exists and is executable; the old name is gone.
- The full dispatch test suite passes under the new name: **3957/3957 passed**
  (exercises the renamed script's `DRD` binding and all detector tests).
