### PR TITLE
audio: test that rebinding a clean folder after a corrupt one re-enables sidecar writes

### DIFF
--- a/audio/test/sidecar.test.ts
+++ b/audio/test/sidecar.test.ts
@@ -1072,6 +1072,6 @@ describe("corrupt sidecar — fail-closed", () => {
 
     const readBack = await readSidecar(cleanDir);
     if (!readBack) throw new Error("expected non-null sidecar");
-    expect(readBack.playerState).toMatchObject({ queue: ["a.mp3"], positionSeconds: 12 });
+    expect(readBack.playerState).toEqual({ queue: ["a.mp3"], currentLocalName: "a.mp3", positionSeconds: 12 });
   });
 });

--- a/audio/test/sidecar.test.ts
+++ b/audio/test/sidecar.test.ts
@@ -1033,4 +1033,24 @@ describe("corrupt sidecar — fail-closed", () => {
     expect(readBack).not.toBeNull();
     expect(readBack?.playerState).toMatchObject({ queue: ["a.mp3"], positionSeconds: 5 });
   });
+
+  it("rebinding a clean dir after a corrupt one re-enables disk writes", async () => {
+    // Corrupt folder: writes are suppressed, corrupt bytes preserved.
+    const { dir: corruptDir, fileHandle: corruptFile } = makePreloadedDir("{not json");
+    setLocalDirectory(corruptDir, true);
+    await savePlayerState({ queue: ["x.mp3"], positionSeconds: 1 });
+    await flushWrites();
+    expect(corruptFile._state.content).toBe("{not json");
+    expect(corruptFile.createWritable).not.toHaveBeenCalled();
+
+    // Rebind a clean folder → corrupt flag cleared → writes resume.
+    const cleanDir = makeEmptyDir();
+    setLocalDirectory(cleanDir, true);
+    await savePlayerState({ queue: ["a.mp3"], currentLocalName: "a.mp3", positionSeconds: 12 });
+    await flushWrites();
+
+    const readBack = await readSidecar(cleanDir);
+    if (!readBack) throw new Error("expected non-null sidecar");
+    expect(readBack.playerState).toMatchObject({ queue: ["a.mp3"], positionSeconds: 12 });
+  });
 });


### PR DESCRIPTION
Closes #2332

## What

Adds one behavioural test to the `corrupt sidecar — fail-closed` block in
`audio/test/sidecar.test.ts` covering the rebind path introduced by PR #2309:
binding a corrupt directory suppresses disk writes, and rebinding a clean folder
clears `corruptOnDisk` so disk writes resume.

The test binds a corrupt directory, asserts `savePlayerState` + `flushWrites`
does not touch the file, then rebinds a clean empty directory, calls
`savePlayerState` + `flushWrites` again, and reads back the sidecar to confirm
the new state was persisted.

## Why

`setLocalDirectory` resets the corrupt-on-disk flag when a new directory is
bound, but no test exercised the full path (bind corrupt → writes suppressed →
bind clean → writes resume). A regression there could silently suppress all disk
writes on the new folder — the same data-loss risk the fail-closed behaviour was
built to prevent.

## Acceptance criteria notes

Per the user's office-hours resolution, the original AC2 ("test fails if the
`factory.ts:179` reset line is removed") is not satisfiable: `corruptOnDisk` is
reset in two independent, defense-in-depth places (`factory.ts:179` and the
`ensureLoaded` success branch at `:227`), and rebinding a clean dir clears the
flag via `:227` regardless of `:179`. The test is therefore sensitive to the
genuine regression — both resets removed makes it fail — and is intentionally not
sensitive to removing a single reset line. The mutation triplet was validated
locally during planning; it is not re-run in CI.

Test-only change. No source modifications.
