### PR TITLE
fix(dispatch-queue-metrics): declare searchIssueDetailsLive $query as String!

### DIFF
--- a/functions/src/dispatch-queue-metrics.ts
+++ b/functions/src/dispatch-queue-metrics.ts
@@ -225,7 +225,7 @@ export async function searchIssueDetailsLive(
   query: string,
 ): Promise<ParkedIssue[]> {
   const gql = `
-    query($query: String!) {
+    query($query: String!) { # // type-safety-ok: GraphQL non-null type annotation, not a TypeScript assertion
       search(query: $query, type: ISSUE, first: 100) {
         nodes {
           ... on Issue {

--- a/functions/src/dispatch-queue-metrics.ts
+++ b/functions/src/dispatch-queue-metrics.ts
@@ -225,7 +225,7 @@ export async function searchIssueDetailsLive(
   query: string,
 ): Promise<ParkedIssue[]> {
   const gql = `
-    query($query: String) {
+    query($query: String!) {
       search(query: $query, type: ISSUE, first: 100) {
         nodes {
           ... on Issue {

--- a/functions/test/dispatch-queue-metrics.test.ts
+++ b/functions/test/dispatch-queue-metrics.test.ts
@@ -312,6 +312,32 @@ describe("searchIssueDetailsLive", () => {
     );
     await expect(searchIssueDetailsLive("tok", "q")).rejects.toThrow(/503/);
   });
+
+  it("declares $query as a non-null String! (GitHub search requires String!)", async () => {
+    let capturedBody = "";
+    const fetchMock = vi.fn(async (_url: string, init: { body: string }) => {
+      capturedBody = init.body;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: {
+            search: {
+              nodes: [],
+            },
+          },
+        }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchIssueDetailsLive("tok", "q");
+
+    const parsed = JSON.parse(capturedBody) as { query: string };
+    expect(parsed.query).toContain("query($query: String!)");
+    // Must NOT declare $query as nullable String (without !) — GitHub rejects that
+    expect(parsed.query).not.toContain("query($query: String)");
+  });
 });
 
 describe("sampleDispatchQueueCore", () => {

--- a/functions/test/dispatch-queue-metrics.test.ts
+++ b/functions/test/dispatch-queue-metrics.test.ts
@@ -313,7 +313,7 @@ describe("searchIssueDetailsLive", () => {
     await expect(searchIssueDetailsLive("tok", "q")).rejects.toThrow(/503/);
   });
 
-  it("declares $query as a non-null String! (GitHub search requires String!)", async () => {
+  it("declares $query as a non-null String! (GitHub search requires String!)", async () => { // type-safety-ok: String! in description refers to GraphQL non-null type annotation
     let capturedBody = "";
     const fetchMock = vi.fn(async (_url: string, init: { body: string }) => {
       capturedBody = init.body;
@@ -334,7 +334,7 @@ describe("searchIssueDetailsLive", () => {
     await searchIssueDetailsLive("tok", "q");
 
     const parsed = JSON.parse(capturedBody) as { query: string };
-    expect(parsed.query).toContain("query($query: String!)");
+    expect(parsed.query).toContain("query($query: String!)"); // type-safety-ok: GraphQL non-null type annotation in expected string
     // Must NOT declare $query as nullable String (without !) — GitHub rejects that
     expect(parsed.query).not.toContain("query($query: String)");
   });


### PR DESCRIPTION
Closes #2373

## Problem

`searchIssueDetailsLive` in `functions/src/dispatch-queue-metrics.ts` declared
its GraphQL operation as `query($query: String)` — a **nullable** `String`.
GitHub's `search(query:)` argument is non-null (`String!`), so GitHub rejected
**every** call with:

```
GitHub GraphQL errors: Nullability mismatch on variable $query and argument query (String / String!)
```

`sampleDispatchQueueMetrics` caught the error, logged one line, and returned
without writing a snapshot to `office-hours/<env>/metrics/dispatch-queue`. As a
result the office-hours dashboard never received a `parked` array and showed
"Nothing parked" / "No queue metrics yet" even when parked issues existed.

Introduced by #2347 (the parked-issues dashboard panel). The sibling helper
`searchIssueCountLive` in the same file was already correct
(`query($query: String!)`).

## Fix

- One-character source change in `searchIssueDetailsLive`:
  `query($query: String)` → `query($query: String!)`, mirroring
  `searchIssueCountLive`.
- A regression test in `functions/test/dispatch-queue-metrics.test.ts` that
  asserts the GraphQL document sent by `searchIssueDetailsLive` declares
  `$query` as `String!` (and not the nullable form), so a future edit that drops
  the `!` fails CI.

## Verification

`npx vitest run --project functions --root .` — 63 tests pass.

The third acceptance criterion (a deployed `sampleDispatchQueueMetrics` run
completes without the Nullability mismatch error and writes a `parked` array)
requires a deployed run and is left for QA / the main-qa follow-up.
