### PR TITLE
dispatch-stop: anchor in-flight-task notified-set on the <task-notification> envelope

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -475,16 +475,23 @@ session_has_inflight_background_task() {
   fi
   # UPDATE TRIGGER: this literal `launched in background. Task ID: <ID>` is the
   # Workflow/Task tool's `tool_result` output format, emitted by the Claude Code
-  # harness — there is no in-repo definition to track. If the harness changes that
-  # output format, THIS launch pattern AND the matching `taskId":"<ID>"`
-  # notification pattern below must both be updated.
+  # harness — there is no in-repo definition to track. The notification pattern
+  # below is now anchored on the `<task-notification>` envelope; if the harness
+  # renames that wrapper, BOTH this launch pattern AND the envelope anchor must be
+  # updated.
   launched=$(printf '%s\n' "$scan_src" | grep -oE 'launched in background\. Task ID: [A-Za-z0-9_-]+' \
     | grep -oE '[A-Za-z0-9_-]+$' | sort -u)
   [ -n "$launched" ] || return 1
-  # Tolerate the JSONL backslash-escaped quote form (\"taskId\":\"<ID>\") as
-  # well as the bare "taskId":"<ID>" form — the <task-notification> payload is a
-  # string value, so its inner quotes are backslash-escaped in the record.
-  notified=$(printf '%s\n' "$scan_src" | grep -oE 'taskId\\?":\\?"[A-Za-z0-9_-]+' \
+  # Notifications are identified by the `<task-notification>` envelope, NOT a bare
+  # `taskId` substring: the launch record's own sibling `toolUseResult.taskId` also
+  # carries the bare "taskId":"<ID>" form, so a substring-only match would
+  # self-match the launch into `notified`, empty the set difference, and wrongly
+  # report not-in-flight (#2365). The grep -F 'task-notification' stage scopes the
+  # taskId extraction to envelope records only. Within those, tolerate the JSONL
+  # backslash-escaped quote form (\"taskId\":\"<ID>\") as well as the bare form —
+  # the envelope payload is a string value, so its inner quotes are escaped.
+  notified=$(printf '%s\n' "$scan_src" | grep -F 'task-notification' \
+    | grep -oE 'taskId\\?":\\?"[A-Za-z0-9_-]+' \
     | grep -oE '[A-Za-z0-9_-]+$' | sort -u)
   # In-flight iff at least one launched ID has no matching notification, i.e.
   # the set difference (launched ∖ notified) is non-empty. comm -23 lists lines

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -25101,7 +25101,7 @@ export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 # Fixture: one Workflow launch line, no <task-notification>.
 cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
 {"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{}}]}}
-{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: w4stq5fyf"}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: w4stq5fyf"}]},"toolUseResult":{"status":"async_launched","taskId":"w4stq5fyf"}}
 EOF
 FIXTURE="$TMPDIR_TEST/transcript.jsonl"
 printf '%s\n' '{"transcript_path":"'"$FIXTURE"'"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
@@ -25143,8 +25143,8 @@ echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
 export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 # Fixture: launch line + matching task-notification (backslash-escaped quote form).
 cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
-{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: w4stq5fyf"}]}}
-{"type":"user","message":{"content":[{"type":"tool_result","content":"{\"taskId\":\"w4stq5fyf\",\"status\":\"completed\"}"}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: w4stq5fyf"}]},"toolUseResult":{"status":"async_launched","taskId":"w4stq5fyf"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"<task-notification>{\"type\":\"workflow-completed\",\"taskId\":\"w4stq5fyf\",\"status\":\"completed\"}</task-notification>"}]}}
 EOF
 FIXTURE="$TMPDIR_TEST/transcript.jsonl"
 printf '%s\n' '{"transcript_path":"'"$FIXTURE"'"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
@@ -25177,9 +25177,9 @@ echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
 export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 # Fixture: two launch lines, only the first notified.
 cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
-{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: aaa111bbb"}]}}
-{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: ccc222ddd"}]}}
-{"type":"user","message":{"content":[{"type":"tool_result","content":"{\"taskId\":\"aaa111bbb\",\"status\":\"completed\"}"}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: aaa111bbb"}]},"toolUseResult":{"status":"async_launched","taskId":"aaa111bbb"}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: ccc222ddd"}]},"toolUseResult":{"status":"async_launched","taskId":"ccc222ddd"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"<task-notification>{\"type\":\"workflow-completed\",\"taskId\":\"aaa111bbb\",\"status\":\"completed\"}</task-notification>"}]}}
 EOF
 FIXTURE="$TMPDIR_TEST/transcript.jsonl"
 printf '%s\n' '{"transcript_path":"'"$FIXTURE"'"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
@@ -25218,7 +25218,7 @@ export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 # record but no launch. The session-scoped scan must filter out the old-session
 # launch so the in-flight gate does not fire.
 cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
-{"type":"user","sessionId":"old-session-zzz","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: stale111"}]}}
+{"type":"user","sessionId":"old-session-zzz","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: stale111"}]},"toolUseResult":{"status":"async_launched","taskId":"stale111"}}
 {"type":"assistant","sessionId":"cur-session-aaa","message":{"content":[{"type":"text","text":"working"}]}}
 EOF
 FIXTURE="$TMPDIR_TEST/transcript.jsonl"
@@ -25255,9 +25255,9 @@ export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
 # Old session launched stale333 and received its notification → fully completed
 # and must be filtered out by session-scoping.
 cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
-{"type":"user","sessionId":"cur-session-aaa","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: live222"}]}}
-{"type":"user","sessionId":"old-session-zzz","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: stale333"}]}}
-{"type":"user","sessionId":"old-session-zzz","message":{"content":[{"type":"tool_result","content":"{\"taskId\":\"stale333\",\"status\":\"completed\"}"}]}}
+{"type":"user","sessionId":"cur-session-aaa","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: live222"}]},"toolUseResult":{"status":"async_launched","taskId":"live222"}}
+{"type":"user","sessionId":"old-session-zzz","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: stale333"}]},"toolUseResult":{"status":"async_launched","taskId":"stale333"}}
+{"type":"assistant","sessionId":"old-session-zzz","message":{"content":[{"type":"text","text":"<task-notification>{\"type\":\"workflow-completed\",\"taskId\":\"stale333\",\"status\":\"completed\"}</task-notification>"}]}}
 EOF
 FIXTURE="$TMPDIR_TEST/transcript.jsonl"
 printf '%s\n' '{"transcript_path":"'"$FIXTURE"'","session_id":"cur-session-aaa"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
@@ -25283,6 +25283,87 @@ if [[ ! -e "$STUB_DIR/self-close-calls.log" ]]; then
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: #2261 D1.5 current-session in-flight: NOT self-closed"
 fi
+stop_teardown
+
+# --- Test #2365-D1.6: faithful launch record (toolUseResult bare taskId), no notification → hand-back ---
+# Reproduces the REAL transcript shape: the Workflow launch tool_result line also
+# carries a top-level `toolUseResult.taskId` in the BARE "taskId":"<ID>" form. With
+# no <task-notification> record, the task is in-flight. The pre-fix `notified`
+# pattern self-matched the launch record's own bare toolUseResult.taskId, emptying
+# the set difference and wrongly parking; the envelope-anchored fix hands back.
+
+echo "Test: #2365 D1.6 faithful launch (toolUseResult bare taskId), no notification → hand-back"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "implement" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+# No phase-completed marker.
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+# Fixture: real-shape launch line WITH toolUseResult bare taskId metadata, no notification.
+cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: inflight365a"}]},"toolUseResult":{"status":"async_launched","taskId":"inflight365a"}}
+EOF
+FIXTURE="$TMPDIR_TEST/transcript.jsonl"
+printf '%s\n' '{"transcript_path":"'"$FIXTURE"'"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
+rc=$?
+assert_eq "#2365 D1.6 in-flight Workflow: hook exits 0 (hand-back)" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/apply-office-hours.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2365 D1.6 in-flight Workflow: NOT parked on office-hours"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2365 D1.6 in-flight Workflow: NOT parked on office-hours"
+  echo "    apply-log: $(cat "$STUB_DIR/apply-office-hours.log")"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/spawn-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2365 D1.6 in-flight Workflow: NOT spawned (redundant tick suppressed)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2365 D1.6 in-flight Workflow: NOT spawned (redundant tick suppressed)"
+  echo "    spawn-calls: $(cat "$STUB_DIR/spawn-calls.log")"
+fi
+TOTAL=$((TOTAL + 1))
+if [[ ! -e "$STUB_DIR/self-close-calls.log" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2365 D1.6 in-flight Workflow: NOT self-closed"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2365 D1.6 in-flight Workflow: NOT self-closed"
+fi
+stop_teardown
+
+# --- Test #2365-D1.7: faithful launch record + real <task-notification> → normal Branch A park ---
+# The converse of D1.6: the same faithful launch record (toolUseResult bare taskId)
+# PLUS a real <task-notification> envelope for the same ID means the task completed.
+# The in-flight gate must NOT fire; execution falls through to the normal Branch A
+# office-hours park. Proves the envelope-anchored fix still detects completion.
+
+echo "Test: #2365 D1.7 faithful launch + real task-notification → normal Branch A park (office-hours applied, spawn invoked)"
+stop_setup
+echo "123-foo-bar" > "$STUB_DIR/current-branch.txt"
+echo "implement" > "$STUB_DIR/current-phase.txt"
+echo '{"name":"123-foo-bar"}' > "$TMPDIR_TEST/jobs/abcd1234/state.json"
+# No phase-completed marker.
+export CLAUDE_JOB_DIR="$TMPDIR_TEST/jobs/abcd1234"
+# Fixture: faithful launch line + matching real <task-notification> envelope.
+cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
+{"type":"user","message":{"content":[{"type":"tool_result","content":"Workflow launched in background. Task ID: inflight365a"}]},"toolUseResult":{"status":"async_launched","taskId":"inflight365a"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"<task-notification>{\"type\":\"workflow-completed\",\"taskId\":\"inflight365a\",\"status\":\"completed\"}</task-notification>"}]}}
+EOF
+FIXTURE="$TMPDIR_TEST/transcript.jsonl"
+printf '%s\n' '{"transcript_path":"'"$FIXTURE"'"}' | "$TMPDIR_TEST/hooks/dispatch-stop.sh" >/dev/null 2>&1
+rc=$?
+assert_eq "#2365 D1.7 completed Workflow: hook exits 0" "0" "$rc"
+apply_log=$(cat "$STUB_DIR/apply-office-hours.log" 2>/dev/null || true)
+apply_issue=$(printf '%s' "$apply_log" | awk '{print $1}')
+apply_reason=$(printf '%s' "$apply_log" | cut -d' ' -f2-)
+TOTAL=$((TOTAL + 1))
+if [[ "$apply_issue" == "123" && -n "$apply_reason" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: #2365 D1.7 completed Workflow: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: #2365 D1.7 completed Workflow: dispatch-apply-office-hours invoked with issue 123 + non-empty reason"
+  echo "    apply-log: $apply_log"
+fi
+spawn_calls=$(wc -l < "$STUB_DIR/spawn-calls.log" 2>/dev/null || echo 0)
+assert_eq "#2365 D1.7 completed Workflow: spawn invoked exactly once" "1" "$spawn_calls"
 stop_teardown
 
 # ============================================================================


### PR DESCRIPTION
Closes #2365

## Problem

The in-flight-background-task guard `session_has_inflight_background_task` in
`.claude/hooks/dispatch-stop.sh` (added for #2243) never fired. It is meant to
keep Stop-hook Branch A from parking a `qa`/`review` phase session on
`dispatch:office-hours` while that session has launched a background Workflow
fan-out and yielded its turn to await a `<task-notification>`. Instead the guard
self-defeated and the session was wrongly parked — the exact symptom #2243 set
out to prevent.

## Root cause

The guard computes the set difference `launched ∖ notified`. The `notified`
pattern `taskId\?":\?"[A-Za-z0-9_-]+` matched **both** the escaped
`\"taskId\":\"` form (real notifications, where the payload is a string value)
**and** the bare `"taskId":"` form. The Workflow launch `tool_result` record
carries a sibling metadata object
`"toolUseResult":{"status":"async_launched","taskId":"<ID>",…}` whose `taskId`
is in the **bare** form. So at the instant a task launched, its ID appeared in
**both** `launched` and `notified`; the difference was empty; the guard returned
"not in-flight"; Branch A parked. The guard was only ever masked from the bug by
the separate `session_scheduled_wakeup` (#1590) gate when the yielding turn also
scheduled a wakeup.

The existing #2243/#2261 tests passed because their launch fixtures used a
plain-string `content` and **omitted** the `toolUseResult` launch-metadata
object, so the bare `taskId` that triggers the bug was absent — the fixtures
were unfaithful to the real launch-record shape.

## Fix

Anchor the `notified` scan on the `<task-notification>` envelope: a
`grep -F 'task-notification'` filter stage runs before the `taskId` extraction,
so only envelope-bearing records contribute notified IDs. The launch record has
no envelope, so its bare `toolUseResult.taskId` no longer pollutes `notified`.
This is the semantically correct discriminator ("an ID is notified iff a
notification envelope carried it") and is orthogonal to the bare-vs-escaped
quoting, so the existing `\?` quote tolerance is preserved inside the
envelope-filtered records. The `launched` extraction and the #2261 session-scope
logic are untouched.

## Tests

- New case **#2365 D1.6**: a launch fixture reproducing the **real** shape — a
  `tool_result` line carrying the top-level
  `"toolUseResult":{"status":"async_launched","taskId":"<ID>",…}` bare metadata,
  with no `<task-notification>` record — asserts the guard reports in-flight
  (hand-back, no park, no spawn, no self-close). This case is **red against the
  unfixed pattern** and green after the fix.
- New converse case **#2365 D1.7**: the same faithful launch record plus a real
  `<task-notification>` record for the same ID → normal Branch A park.
- The existing #2243/#2261 fixtures are made **faithful** to the real transcript
  format: launch lines gain the real `toolUseResult` bare-`taskId` metadata, and
  the three bare-`tool_result` notification fixtures (D1.2/D1.3/D1.5) are
  rewritten as `assistant`/`<task-notification>` envelope records. The
  assertions are unchanged — this is a faithfulness correction, not a weakening.

Red-first was verified during the build: against the unfixed hook, exactly the
four predicted in-flight cases (D1.1, D1.3, D1.5, D1.6) parked instead of
handing back; after the fix the full suite passes (3966/3966).

The end-to-end behavioural AC (a real `qa`/`review` session that launches a
background Workflow and yields is handed back, not parked) is observed in
production over subsequent dispatch ticks — it is not unit-testable here.
