### PR TITLE
dispatch: heartbeat timer uses OnCalendar so it self-recovers from elapsed

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -2559,8 +2559,8 @@ EOF
 
 # Install and activate the durable always-on heartbeat: a `systemd --user`
 # `dispatch-heartbeat.timer` firing `dispatch-heartbeat.service` (a no-arg
-# `dispatch-tick`) on a flat drumbeat — `OnBootSec=2min`,
-# `OnUnitActiveSec=15min`, `Persistent=true`. This gives the autonomous chain a
+# `dispatch-tick`) on a wall-clock schedule — `OnBootSec=2min`,
+# `OnCalendar=*:0/15`, `Persistent=true` (#2375). This gives the autonomous chain a
 # liveness floor that is independent of Stop hooks and reseed timers, so the
 # chain self-recovers from abnormal worker death and post-cap stalls where no
 # Stop hook fires and no reseed is armed (#2022). A flat drumbeat is safe and
@@ -2621,6 +2621,27 @@ cleanup_stale_heartbeat_units() {
   # suppress the failure and warn; never abort the caller.
   echo "WARNING: cleanup_stale_heartbeat_units: installed heartbeat unit points at '$installed_workdir' but current main worktree is '$current_main_worktree'; disabling stale timer/service before rewrite" >&2
   "$systemctl_cmd" --user disable --now dispatch-heartbeat.timer dispatch-heartbeat.service || true
+}
+
+# Returns 0 only when the heartbeat timer is armed with a future trigger
+# (SubState=waiting). 'elapsed' (the #2375 stranded state: active but no future
+# fire), 'dead' (inactive), and any other/unrecognized substate all return
+# non-zero so the caller falls through to repair. SubState is the reliable
+# discriminator: NextElapseUSecRealtime is empty for a healthy monotonic timer
+# too, so parsing it would mis-detect.
+# Args: $1 = systemctl command
+heartbeat_timer_is_armed() {
+  local systemctl_cmd="$1"
+  local substate
+  substate=$("$systemctl_cmd" --user show dispatch-heartbeat.timer \
+    --property=SubState --value 2>/dev/null) || return 1
+  # 'waiting' = a future trigger is armed (healthy). 'elapsed' = the #2375
+  # stranded state (active, no future fire). 'dead' = inactive. Fail-safe:
+  # treat anything that is not explicitly 'waiting' as needing repair, so an
+  # unrecognized substate can never be read as healthy. (A transient
+  # 'running' during a heartbeat fire causes at most one harmless re-arm; the
+  # tick oneshot is fast, so the window is tiny.)
+  [ "$substate" = "waiting" ]
 }
 
 # Best-effort: a failure here must not abort the caller (a tick/reseed
@@ -2701,10 +2722,13 @@ WorkingDirectory=$main_worktree
 EOF
 )
 
-  # Desired timer unit: a flat drumbeat. OnBootSec=2min gives a fast post-boot
-  # tick; OnUnitActiveSec=15min sets the steady-state cadence; Persistent=true
-  # makes a missed firing (host asleep/off at the scheduled time) run on the
-  # next wake instead of being skipped.
+  # Desired timer unit: a wall-clock schedule (#2375). OnCalendar=*:0/15 fires at
+  # :00/:15/:30/:45 regardless of when the service last activated, so the timer
+  # always has a future trigger and can never strand in `active (elapsed)` after a
+  # restart (the failure mode a monotonic OnUnitActiveSec drumbeat fell into).
+  # OnBootSec=2min keeps a fast first post-boot tick; Persistent=true is now
+  # meaningful — it catches up a wall-clock fire missed while the host was
+  # asleep/off; RandomizedDelaySec=30 smooths the post-boot launcher storm.
   local desired_timer
   desired_timer=$(cat <<EOF
 [Unit]
@@ -2712,8 +2736,9 @@ Description=Dispatch chain periodic heartbeat timer (#2022)
 
 [Timer]
 OnBootSec=2min
-OnUnitActiveSec=15min
+OnCalendar=*:0/15
 Persistent=true
+RandomizedDelaySec=30
 
 [Install]
 WantedBy=timers.target
@@ -2721,12 +2746,14 @@ EOF
 )
 
   # Steady-state hot path: if both installed units already match byte-for-byte
-  # AND the timer is active, do nothing — skip the writes, daemon-reload, and
-  # enable entirely. (Like the daemon service, the timer must actually be
-  # RUNNING, so the content compare carries an is-active check.)
+  # AND the timer is armed with a future trigger, do nothing — skip the writes,
+  # daemon-reload, and enable entirely. `is-active` is too weak here: it returns
+  # 0 for an `active (elapsed)` timer (the #2375 stranded state), so a dead timer
+  # would be read as healthy. heartbeat_timer_is_armed requires SubState=waiting,
+  # so an elapsed timer falls through to the repair path below.
   if [ -f "$SERVICE_PATH" ] && [ "$(cat "$SERVICE_PATH")" = "$desired_service" ] \
      && [ -f "$TIMER_PATH" ] && [ "$(cat "$TIMER_PATH")" = "$desired_timer" ] \
-     && "$SYSTEMCTL_CMD" --user is-active --quiet dispatch-heartbeat.timer; then
+     && heartbeat_timer_is_armed "$SYSTEMCTL_CMD"; then
     return 0
   fi
 
@@ -2805,11 +2832,18 @@ EOF
     return 1
   fi
 
-  # Install + activate idempotently: enable symlinks the timer under
-  # WantedBy=timers.target (so it auto-starts on every user-session start) and
-  # --now starts it without restarting an already-running instance.
-  if ! "$SYSTEMCTL_CMD" --user enable --now dispatch-heartbeat.timer; then
-    echo "WARNING: ensure_heartbeat_units: systemctl --user enable --now dispatch-heartbeat.timer failed; periodic heartbeat unavailable" >&2
+  # Install + re-arm idempotently. enable symlinks the timer under
+  # WantedBy=timers.target (so it auto-starts on every user-session start).
+  # `enable --now` is NOT enough to repair a stranded timer: its implicit `start`
+  # is a no-op on an already-active `elapsed` timer, so the next fire is never
+  # recomputed. A separate `restart` re-arms in every case — cold install
+  # (inactive → start) and repair (active-elapsed → recompute next elapse) (#2375).
+  if ! "$SYSTEMCTL_CMD" --user enable dispatch-heartbeat.timer; then
+    echo "WARNING: ensure_heartbeat_units: systemctl --user enable dispatch-heartbeat.timer failed; periodic heartbeat unavailable" >&2
+    return 1
+  fi
+  if ! "$SYSTEMCTL_CMD" --user restart dispatch-heartbeat.timer; then
+    echo "WARNING: ensure_heartbeat_units: systemctl --user restart dispatch-heartbeat.timer failed; periodic heartbeat unavailable" >&2
     return 1
   fi
 }

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -34527,8 +34527,10 @@ cat > "$ehu_tmp/bin/systemctl" <<'STUB'
 printf '%s\n' "$*" >> "$STUB_LOG"
 for a in "$@"; do
   case "$a" in
+    show) printf '%s\n' "${STUB_SUBSTATE-dead}"; exit 0 ;;
     is-active) exit "${STUB_IS_ACTIVE_RC:-0}" ;;
     enable)    exit "${STUB_ENABLE_RC:-0}" ;;
+    restart)   exit "${STUB_RESTART_RC:-0}" ;;
     daemon-reload) exit "${STUB_RELOAD_RC:-0}" ;;
   esac
 done
@@ -34546,7 +34548,7 @@ if (
   export DISPATCH_HEARTBEAT_UNIT_DIR="$ehu_unit_dir"
   export DISPATCH_HEARTBEAT_SYSTEMCTL_CMD="$ehu_tmp/bin/systemctl"
   export STUB_LOG="$ehu_log"
-  export STUB_IS_ACTIVE_RC=3 STUB_ENABLE_RC=0 STUB_RELOAD_RC=0
+  export STUB_SUBSTATE=dead STUB_ENABLE_RC=0 STUB_RESTART_RC=0 STUB_RELOAD_RC=0
   source "$SCRIPT_DIR/lib.sh"
   ensure_heartbeat_units "$ehu_tmp/main-worktree"
 ); then
@@ -34567,39 +34569,45 @@ if (
   fi
   if [ -f "$ehu_tmr" ]; then
     TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1)); echo "  PASS: cold path wrote dispatch-heartbeat.timer"
-    grep -q '^OnUnitActiveSec=15min$' "$ehu_tmr" \
-      && { TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1)); echo "  PASS: timer has OnUnitActiveSec=15min"; } \
-      || { TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1)); echo "  FAIL: timer missing OnUnitActiveSec=15min"; }
+    grep -q '^OnCalendar=\*:0/15$' "$ehu_tmr" \
+      && { TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1)); echo "  PASS: timer has OnCalendar=*:0/15"; } \
+      || { TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1)); echo "  FAIL: timer missing OnCalendar=*:0/15"; }
     grep -q '^OnBootSec=2min$' "$ehu_tmr" \
       && { TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1)); echo "  PASS: timer has OnBootSec=2min"; } \
       || { TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1)); echo "  FAIL: timer missing OnBootSec=2min"; }
     grep -q '^Persistent=true$' "$ehu_tmr" \
       && { TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1)); echo "  PASS: timer has Persistent=true"; } \
       || { TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1)); echo "  FAIL: timer missing Persistent=true"; }
+    grep -q '^RandomizedDelaySec=30$' "$ehu_tmr" \
+      && { TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1)); echo "  PASS: timer has RandomizedDelaySec=30"; } \
+      || { TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1)); echo "  FAIL: timer missing RandomizedDelaySec=30"; }
   else
-    TOTAL=$((TOTAL + 4)); FAIL=$((FAIL + 4))
+    TOTAL=$((TOTAL + 5)); FAIL=$((FAIL + 5))
     echo "  FAIL: cold path did not write dispatch-heartbeat.timer"
   fi
   grep -q 'daemon-reload' "$ehu_log" \
     && { TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1)); echo "  PASS: cold path ran daemon-reload"; } \
     || { TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1)); echo "  FAIL: cold path did not run daemon-reload"; }
-  grep -q 'enable --now dispatch-heartbeat.timer' "$ehu_log" \
-    && { TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1)); echo "  PASS: cold path ran enable --now dispatch-heartbeat.timer"; } \
-    || { TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1)); echo "  FAIL: cold path did not run enable --now dispatch-heartbeat.timer"; }
+  grep -q 'enable dispatch-heartbeat.timer' "$ehu_log" \
+    && { TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1)); echo "  PASS: cold path ran enable dispatch-heartbeat.timer"; } \
+    || { TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1)); echo "  FAIL: cold path did not run enable dispatch-heartbeat.timer"; }
+  grep -q 'restart dispatch-heartbeat.timer' "$ehu_log" \
+    && { TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1)); echo "  PASS: cold path ran restart dispatch-heartbeat.timer"; } \
+    || { TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1)); echo "  FAIL: cold path did not run restart dispatch-heartbeat.timer"; }
 else
-  TOTAL=$((TOTAL + 10)); FAIL=$((FAIL + 10))
+  TOTAL=$((TOTAL + 12)); FAIL=$((FAIL + 12))
   echo "  FAIL: ensure_heartbeat_units (cold path) returned non-zero"
 fi
 
-# --- 2. Hot path: both units byte-identical + timer active → no-op ------------
-# The hot-path short-circuit checks is-active (STUB_IS_ACTIVE_RC=0 → active);
-# it returns early and must not run daemon-reload or enable --now.
+# --- 2. Hot path: both units byte-identical + timer armed → no-op -------------
+# The hot-path short-circuit checks SubState (STUB_SUBSTATE=waiting → armed); it
+# returns early and must not run daemon-reload, enable, or restart.
 : > "$ehu_log"
 if (
   export DISPATCH_HEARTBEAT_UNIT_DIR="$ehu_unit_dir"
   export DISPATCH_HEARTBEAT_SYSTEMCTL_CMD="$ehu_tmp/bin/systemctl"
   export STUB_LOG="$ehu_log"
-  export STUB_IS_ACTIVE_RC=0 STUB_ENABLE_RC=0 STUB_RELOAD_RC=0
+  export STUB_SUBSTATE=waiting STUB_ENABLE_RC=0 STUB_RESTART_RC=0 STUB_RELOAD_RC=0
   source "$SCRIPT_DIR/lib.sh"
   ensure_heartbeat_units "$ehu_tmp/main-worktree"
 ); then
@@ -34611,13 +34619,51 @@ if (
   fi
   TOTAL=$((TOTAL + 1))
   if ! grep -q 'enable' "$ehu_log"; then
-    PASS=$((PASS + 1)); echo "  PASS: hot path did not re-run enable --now"
+    PASS=$((PASS + 1)); echo "  PASS: hot path did not re-run enable"
   else
-    FAIL=$((FAIL + 1)); echo "  FAIL: hot path re-ran enable --now"
+    FAIL=$((FAIL + 1)); echo "  FAIL: hot path re-ran enable"
+  fi
+  TOTAL=$((TOTAL + 1))
+  if ! grep -q 'restart' "$ehu_log"; then
+    PASS=$((PASS + 1)); echo "  PASS: hot path did not re-run restart"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: hot path re-ran restart"
+  fi
+else
+  TOTAL=$((TOTAL + 3)); FAIL=$((FAIL + 3))
+  echo "  FAIL: ensure_heartbeat_units (hot path) returned non-zero"
+fi
+
+# --- 2b. Elapsed strand: units match but SubState=elapsed → repair (#2375) -----
+# The #2375 stranded state: units are byte-identical on disk (installed by the
+# cold path above, still present), but the timer is active (elapsed) — no future
+# fire. is-active would read 0 (healthy), but heartbeat_timer_is_armed requires
+# SubState=waiting, so this must fall through to the repair path and re-arm:
+# daemon-reload + restart fire.
+: > "$ehu_log"
+if (
+  export DISPATCH_HEARTBEAT_UNIT_DIR="$ehu_unit_dir"
+  export DISPATCH_HEARTBEAT_SYSTEMCTL_CMD="$ehu_tmp/bin/systemctl"
+  export STUB_LOG="$ehu_log"
+  export STUB_SUBSTATE=elapsed STUB_ENABLE_RC=0 STUB_RESTART_RC=0 STUB_RELOAD_RC=0
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_heartbeat_units "$ehu_tmp/main-worktree"
+); then
+  TOTAL=$((TOTAL + 1))
+  if grep -q 'daemon-reload' "$ehu_log"; then
+    PASS=$((PASS + 1)); echo "  PASS: elapsed timer fell through to repair (daemon-reload)"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: elapsed timer short-circuited (no daemon-reload)"
+  fi
+  TOTAL=$((TOTAL + 1))
+  if grep -q 'restart dispatch-heartbeat.timer' "$ehu_log"; then
+    PASS=$((PASS + 1)); echo "  PASS: elapsed timer is re-armed (#2375) (restart fired)"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: elapsed timer was not re-armed (no restart)"
   fi
 else
   TOTAL=$((TOTAL + 2)); FAIL=$((FAIL + 2))
-  echo "  FAIL: ensure_heartbeat_units (hot path) returned non-zero"
+  echo "  FAIL: ensure_heartbeat_units (elapsed strand) returned non-zero"
 fi
 
 # --- 3. cleanup_stale_heartbeat_units: path-change disable (#2056) ------------


### PR DESCRIPTION
Closes #2375

## Problem

The always-on liveness watchdog `dispatch-heartbeat.timer` (#2022) silently dies
and cannot self-recover because it is scheduled with **monotonic** anchors
(`OnBootSec=2min` + `OnUnitActiveSec=15min`). `OnUnitActiveSec` re-arms only
relative to `dispatch-heartbeat.service`'s last activation, and the only thing
that activates that service is the timer firing — a closed loop. Once the timer
is ever (re)started while both anchors are in the past — exactly the stalled
state the heartbeat exists to recover from — systemd marks it `active (elapsed)`
with `Trigger: n/a` and it never fires again. `Persistent=true` does **not**
rescue it (a documented no-op for monotonic timers).

Worse, the steady-state hot path in `ensure_heartbeat_units` guarded its
self-heal with `systemctl --user is-active --quiet`, which returns 0 for an
`active (elapsed)` timer, so concurrent ticks treated the dead timer as healthy
and never repaired it.

## Fix

`.claude/skills/dispatch-propagate/scripts/lib.sh`, `ensure_heartbeat_units`:

- **Wall-clock schedule.** Replace `OnUnitActiveSec=15min` with
  `OnCalendar=*:0/15` (fires at :00/:15/:30/:45 regardless of service
  activation) and add `RandomizedDelaySec=30` to smooth the post-boot launcher
  storm. `OnBootSec=2min` is kept for a fast first post-boot tick; `Persistent=true`
  is now meaningful (catches up a wall-clock fire missed while the host was
  asleep/off). An `OnCalendar` schedule always has a future trigger, so a restart
  can never strand the timer in `elapsed`.
- **`SubState`-based health check.** New helper `heartbeat_timer_is_armed`
  returns 0 only when `SubState=waiting`. `SubState` is the reliable
  discriminator — `NextElapseUSecRealtime` is empty for a healthy *monotonic*
  timer too, so parsing it would mis-detect. The hot-path short-circuit now calls
  this instead of `is-active`, so an `elapsed` timer falls through to repair.
- **`enable` + `restart` repair.** The slow-path activation was `enable --now`,
  whose implicit `start` is a no-op on an already-active `elapsed` timer and so
  never re-arms it. Split into `enable` (idempotent symlink) + `restart`, which
  recomputes the next elapse in every case — cold install and stranded repair.

`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`: the mock
`systemctl` stub gains `show` (emits `${STUB_SUBSTATE}`) and `restart` cases; the
cold-path and hot-path tests are updated to drive readiness via `STUB_SUBSTATE`
and assert the new timer content + `enable`/`restart` sequencing; a new
regression test asserts an `elapsed` timer is detected and re-armed (#2375).

## Verification

`test-dispatch-scripts.sh` passes (3964/3964). The mock suite proves the wiring
(timer content, hot-path predicate, repair sequencing). Live-systemd
strand-and-recover checks on the real host are noted in the plan for QA.
