### PR TITLE
acceptance: raise Playwright navigation/test timeout to absorb transient CI runner contention

### DIFF
--- a/config/playwright.js
+++ b/config/playwright.js
@@ -1,10 +1,31 @@
 /* global process */
 import { defineConfig, devices } from "@playwright/test";
 
+// Raise the per-navigation and per-test timeout ceilings above Playwright's
+// 30s default to absorb transient GitHub-hosted-runner contention (#2381): a
+// lone mid-run navigation crossing 30s under momentary CPU/IO jitter was
+// flaking the @smoke meta-description test. A larger ceiling never slows a
+// healthy navigation — it resolves the instant `load` fires — it only adds
+// headroom for a self-resolving stall. Env-overridable, mirroring the
+// EMULATOR_READY_TIMEOUT discipline in run-acceptance-tests.sh.
+function navigationTimeoutMs() {
+  const raw = process.env.PLAYWRIGHT_NAVIGATION_TIMEOUT;
+  if (raw === undefined || raw === "") return 60000;
+  if (!/^[0-9]+$/.test(raw) || Number(raw) <= 0) {
+    throw new Error(
+      `PLAYWRIGHT_NAVIGATION_TIMEOUT must be a positive integer (ms); got '${raw}'`,
+    );
+  }
+  return Number(raw);
+}
+const NAVIGATION_TIMEOUT = navigationTimeoutMs();
+
 export default defineConfig({
   testDir: ".", // resolves relative to the consuming config file's directory
+  timeout: NAVIGATION_TIMEOUT + 30000,
   use: {
     baseURL: process.env.BASE_URL || "http://localhost:5173",
+    navigationTimeout: NAVIGATION_TIMEOUT,
   },
   projects: [
     {


### PR DESCRIPTION
Closes #2381

## Problem

The `acceptance` CI check intermittently failed the smoke test
`e2e/meta-description.spec.ts:4:3 › meta description › home page has meta
description @smoke` with `page.goto: Test timeout of 30000ms exceeded` while
navigating to `localhost`, `waiting until "load"`. In the failing run, 451
other tests passed and the emulator readiness poll
(`run-acceptance-tests.sh`) had already confirmed the hosting emulator returns
`200` before Playwright launched.

## Root cause

Not a code defect, and not the cold-start emulator-readiness case #2192 already
fixed (PR #2196 raised the *readiness* ceiling, which runs *before* Playwright).
The remaining failing layer is a single *mid-run* navigation crossing
Playwright's **30s default** under transient GitHub-hosted-runner contention (a
momentary CPU/IO stall, or a sub-resource not finishing under
`waitUntil: "load"`). The page serves fine — the readiness poll proves the
document returns 200, and 451 navigations in the same run succeeded. The flake
is not locally reproducible (Nix-provisioned Chromium version vs. the
project-pinned browser), so the cause is identified by mechanism, not local
reproduction.

## Fix

Harden the acceptance harness's timing robustness rather than add Playwright
`retries` (a suite-wide test-policy change this repo has deliberately never
adopted). Mirroring #2196's precedent — raise a too-tight, env-configurable
timeout ceiling so infra-timing jitter no longer fails a healthy run — this
raises the per-navigation/per-test ceiling in the shared
`config/playwright.js`:

- `use.navigationTimeout` defaults to `60000` ms (up from Playwright's 30s
  default), overridable via `PLAYWRIGHT_NAVIGATION_TIMEOUT` (ms).
- Top-level per-test `timeout` is `navigationTimeout + 30000`, so a slow
  navigation still leaves room for the test body/assertions.
- An explicitly-set `PLAYWRIGHT_NAVIGATION_TIMEOUT` is validated as a positive
  integer; a non-numeric or `<= 0` value throws a clear error (per
  `.claude/rules/code-style.md`). The `60000` default applies only when the var
  is unset/empty — mirroring the `EMULATOR_READY_TIMEOUT` discipline in
  `run-acceptance-tests.sh`.

A larger ceiling never slows a healthy fast navigation (it resolves the instant
`load` fires); it only adds headroom for a self-resolving stall. The single
shared-config change is inherited by every app's `e2e/playwright.config.ts`.

## Verification

`npx playwright test --config print/e2e/playwright.config.ts --list` resolves
and validates the shared config (and the new timeout values) without launching a
browser — unaffected by the local browser-version mismatch that blocks running
the suite locally. Authoritative validation is this PR's own CI `acceptance`
job staying green, and absence of the
`meta-description.spec.ts … @smoke` fingerprint on subsequent runs.
