### PR TITLE
lint(porcelain): ban net-new gh issue list and gh pr list in committed scripts

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -493,6 +493,7 @@ DISPATCH_PR_LIST_LIMIT="${DISPATCH_PR_LIST_LIMIT:-300}"
 pr_list_open() {
   local fields="$1"
   local out rc len
+  # lint-allow: gh-rest-porcelain pr_list_open is the canonical open-PR wrapper; predates the list ban, gh_pr_list_rest exists for new code
   out=$(gh pr list --state open --limit "$DISPATCH_PR_LIST_LIMIT" --json "$fields")
   rc=$?
   [[ "$rc" -ne 0 ]] && return "$rc"

--- a/.claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh
@@ -182,10 +182,10 @@ The token-to-helper mapping (subcommand on the left, helper on the right):
     issue create   gh_issue_create_rest
     issue close    gh_issue_close_rest
     issue comment  gh_issue_comment_rest
+    issue list     gh_issue_list_rest
     pr view        gh_pr_view_rest
     pr edit        gh_issue_edit_rest   (PRs are issues in REST — serves the --body edit; see gh_issue_edit_rest in lib.sh)
     pr merge       gh_pr_merge_rest
-    issue list     gh_issue_list_rest
     pr list        gh_pr_list_rest
 
 Exceptions:

--- a/.claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh
@@ -15,10 +15,10 @@ source "$SCRIPTS/lib.sh"
 PATTERN='echo([[:space:]]+-[a-zA-Z]+)?[[:space:]]+"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"[[:space:]]*\|[[:space:]]*jq'
 
 # Detect: net-new raw gh issue/pr porcelain that should use the lib.sh REST helpers.
-# Banned set: gh issue (view|edit|create|close|comment) and gh pr (view|edit|merge).
+# Banned set: gh issue (view|edit|create|close|comment|list) and gh pr (view|edit|merge|list).
 # `gh pr ready` is deliberately excluded. Built from non-contiguous ERE alternatives
 # so this assignment line cannot match itself.
-PORCELAIN_PATTERN='(^|[^[:alnum:]_])gh[[:space:]]+issue[[:space:]]+(view|edit|create|close|comment)([[:space:]]|$)|(^|[^[:alnum:]_])gh[[:space:]]+pr[[:space:]]+(view|edit|merge)([[:space:]]|$)'
+PORCELAIN_PATTERN='(^|[^[:alnum:]_])gh[[:space:]]+issue[[:space:]]+(view|edit|create|close|comment|list)([[:space:]]|$)|(^|[^[:alnum:]_])gh[[:space:]]+pr[[:space:]]+(view|edit|merge|list)([[:space:]]|$)'
 
 # Allow-marker for the porcelain rule: a standalone comment on the line immediately
 # preceding a call suppresses that one call. Reason text after the token is optional.
@@ -185,6 +185,8 @@ The token-to-helper mapping (subcommand on the left, helper on the right):
     pr view        gh_pr_view_rest
     pr edit        gh_issue_edit_rest   (PRs are issues in REST — serves the --body edit; see gh_issue_edit_rest in lib.sh)
     pr merge       gh_pr_merge_rest
+    issue list     gh_issue_list_rest
+    pr list        gh_pr_list_rest
 
 Exceptions:
   - Genuine GraphQL-only fields (closingIssuesReferences,

--- a/.claude/skills/dispatch-propagate/scripts/test-lint-prose-rules.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lint-prose-rules.sh
@@ -177,6 +177,10 @@ _GH='gh'
 PORC_ISSUE_VIEW="RES=\$($_GH issue view \"\$N\" --json title)"
 # Produces: RES=$(gh pr view "$N" --json closingIssuesReferences)
 PORC_PR_VIEW="RES=\$($_GH pr view \"\$N\" --json closingIssuesReferences)"
+# Produces: RES=$(gh issue list --label dispatch:planned --json number)
+PORC_ISSUE_LIST="RES=\$($_GH issue list --label dispatch:planned --json number)"
+# Produces: RES=$(gh pr list --state open --json number)
+PORC_PR_LIST="RES=\$($_GH pr list --state open --json number)"
 
 # Shebang line for extensionless fixtures: construct with printf so zsh
 # history expansion does not escape the '!' in '#!/usr/bin/env bash'.
@@ -319,5 +323,33 @@ git -C "$REPO" commit --quiet -m "edit only the call line"
 run_sut
 assert_eq "preexisting-marker-call-edit: exit 0" "0" "$RC"
 assert_contains "preexisting-marker-call-edit: PASS printed" "PASS" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Test 13: net-new `gh issue list` porcelain in a .sh file is flagged.
+# ---------------------------------------------------------------------------
+echo "Test 13: net-new gh-issue-list porcelain is flagged"
+make_repo
+printf '%s\n' "$PORC_ISSUE_LIST" >> "$REPO/script.sh"
+git -C "$REPO" add -A
+git -C "$REPO" commit --quiet -m "add issue-list porcelain"
+run_sut
+[ "$RC" -ne 0 ] && _t13_rc=nonzero || _t13_rc=zero
+assert_eq "issue-list: exit non-zero" "nonzero" "$_t13_rc"
+assert_contains "issue-list: output names the file" "script.sh" "$OUT"
+assert_contains "issue-list: remediation helper present" "gh_issue_list_rest" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Test 14: net-new `gh pr list` porcelain in a .sh file is flagged.
+# ---------------------------------------------------------------------------
+echo "Test 14: net-new gh-pr-list porcelain is flagged"
+make_repo
+printf '%s\n' "$PORC_PR_LIST" >> "$REPO/script.sh"
+git -C "$REPO" add -A
+git -C "$REPO" commit --quiet -m "add pr-list porcelain"
+run_sut
+[ "$RC" -ne 0 ] && _t14_rc=nonzero || _t14_rc=zero
+assert_eq "pr-list: exit non-zero" "nonzero" "$_t14_rc"
+assert_contains "pr-list: output names the file" "script.sh" "$OUT"
+assert_contains "pr-list: remediation helper present" "gh_pr_list_rest" "$OUT"
 
 report_results


### PR DESCRIPTION
Closes #2385

## What

`PORCELAIN_PATTERN` in `lint-prose-rules.sh` bans net-new raw `gh issue
(view|edit|create|close|comment)` and `gh pr (view|edit|merge)` in committed
shell scripts, steering authors to the lib.sh REST helpers (the #2260 / #1601
GraphQL-rate-limit migration). It omitted `gh issue list` and `gh pr list` — the
two subcommands the dispatch docs name as the *primary* GraphQL spenders that
motivated the migration. A new per-tick script using `gh issue list --label
dispatch:planned` passed the linter undetected.

## Changes

- Add `list` to both alternation groups in `PORCELAIN_PATTERN`, preserving the
  non-contiguous ERE form so the assignment line still cannot match itself.
- Update the "Banned set" doc comment to match.
- Append two remediation rows mapping `issue list` → `gh_issue_list_rest` and
  `pr list` → `gh_pr_list_rest` (both helpers already exist in lib.sh).
- Grandfather the pre-existing `pr_list_open` `gh pr list` call in lib.sh with a
  `# lint-allow: gh-rest-porcelain` marker, so a future call-only edit to that
  line is not tripped by the extended rule.
- Add Tests 13 and 14 covering both new verbs (the AC's explicit deliverable),
  using the established `$_GH` interpolation convention so the test file's own
  fixtures stay lint-clean.

## Verification

- `test-lint-prose-rules.sh` — 34/34 pass (Tests 1–12 unchanged, 13/14 new).
- `lint-prose-rules.sh` against this branch — no violations; this PR's own diff
  is lint-clean.
