### PR TITLE
ds: add JSX clean-line false-positive battery to lint-ds-drift test suite

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-lint-ds-drift.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lint-ds-drift.sh
@@ -339,4 +339,32 @@ run_sut
 assert_eq "jsx-multiline: exit 0 (known gap)" "0" "$RC"
 assert_contains "jsx-multiline: PASS printed" "PASS" "$OUT"
 
+# ---------------------------------------------------------------------------
+# Test 22: JSX clean-line false-positive battery (camelCase analog of Tests 5-12).
+# A battery of legitimate camelCase style-object values on added lines in an
+# in-scope .tsx file — none of which the four JSX detectors should reach. This
+# exercises the false-positive (precision) side of FONTSIZE_JSX_RE,
+# FONTWEIGHT_JSX_RE, SPACING_JSX_RE, and SPACING_GAP_JSX_RE: a future regex edit
+# that widens any JSX detector to over-match would start flagging legitimate app
+# code, and this test would catch that regression.
+# ---------------------------------------------------------------------------
+echo "Test 22: JSX clean camelCase lines pass (precision battery)"
+make_repo
+mkdir -p "$REPO/myapp/src/components"
+{
+  printf '%s\n' 'const style = {'
+  printf '%s\n' '  fontWeight: 400,'
+  printf '%s\n' '  fontWeight: 700,'
+  printf '%s\n' "  fontSize: 'var(--type-sm)',"
+  printf '%s\n' "  borderRadius: '4px',"
+  printf '%s\n' '  margin: 0,'
+  printf '%s\n' '  gap: 0,'
+  printf '%s\n' '};'
+} > "$REPO/myapp/src/components/Widget.tsx"
+git -C "$REPO" add -A
+git -C "$REPO" commit --quiet -m "add JSX clean camelCase lines"
+run_sut
+assert_eq "jsx-clean-battery: exit 0" "0" "$RC"
+assert_contains "jsx-clean-battery: PASS printed" "PASS" "$OUT"
+
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-lint-ds-drift.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lint-ds-drift.sh
@@ -31,6 +31,19 @@ VIOL_ESCAPED="font-size: 11${_PX}; /* ds-lint-disable-line: SVG label, no exact 
 # /* brand was #abcdef */  (hex in a comment line)
 COMMENT_HEX="/* brand was ${_H}abcdef */"
 
+# JSX camelCase violation fixtures (camelCase analogs of the CSS violations above)
+# fontSize: '14px',  (px font-size in JSX)
+VIOL_JSX_FONTSIZE="fontSize: '14${_PX}',"
+# fontWeight: 300,  (off-scale font-weight in JSX)
+VIOL_JSX_FONTWEIGHT="fontWeight: 300,"
+# marginTop: '5px',  (px spacing in JSX)
+VIOL_JSX_MARGIN="marginTop: '5${_PX}',"
+# gap: '8px',  (px gap in JSX)
+VIOL_JSX_GAP="gap: '8${_PX}',"
+# multiline split: property name and value on separate lines — neither fires alone
+VIOL_JSX_MULTILINE_NAME="fontSize:"
+VIOL_JSX_MULTILINE_VALUE="'14${_PX}',"
+
 # Build a fresh ephemeral repo. Sets globals: REPO, BARE.
 # $1 (optional): "with_violation" — seed the origin/main baseline with a
 #   violating hex line in the in-scope CSS file.

--- a/.claude/skills/dispatch-propagate/scripts/test-lint-ds-drift.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lint-ds-drift.sh
@@ -43,6 +43,8 @@ VIOL_JSX_GAP="gap: '8${_PX}',"
 # multiline split: property name and value on separate lines — neither fires alone
 VIOL_JSX_MULTILINE_NAME="fontSize:"
 VIOL_JSX_MULTILINE_VALUE="'14${_PX}',"
+# fontSize: '14px', // ds-lint-disable-line: ...  (escaped JSX violation, // form)
+VIOL_JSX_ESCAPED="fontSize: '14${_PX}', // ds-lint-disable-line: SVG label, no exact token"
 
 # Build a fresh ephemeral repo. Sets globals: REPO, BARE.
 # $1 (optional): "with_violation" — seed the origin/main baseline with a
@@ -353,10 +355,12 @@ mkdir -p "$REPO/myapp/src/components"
   printf '%s\n' 'const style = {'
   printf '%s\n' '  fontWeight: 400,'
   printf '%s\n' '  fontWeight: 700,'
-  printf '%s\n' "  fontSize: 'var(--type-sm)',"
+  printf '%s\n' "  fontSize: 'var(--text-sm)',"
   printf '%s\n' "  borderRadius: '4px',"
   printf '%s\n' '  margin: 0,'
   printf '%s\n' '  gap: 0,'
+  printf '%s\n' "  marginTop: 'var(--space-1)',"
+  printf '%s\n' "  paddingTop: 'var(--space-2)',"
   printf '%s\n' '};'
 } > "$REPO/myapp/src/components/Widget.tsx"
 git -C "$REPO" add -A
@@ -364,5 +368,26 @@ git -C "$REPO" commit --quiet -m "add JSX clean camelCase lines"
 run_sut
 assert_eq "jsx-clean-battery: exit 0" "0" "$RC"
 assert_contains "jsx-clean-battery: PASS printed" "PASS" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Test 23: real JSX violation carrying the inline // escape hatch is NOT
+# flagged. Mirrors Test 13 (the CSS /* ... */ form) for the TSX-appropriate
+# `// ds-lint-disable-line: <reason>` single-line comment form documented at
+# lint-ds-drift.sh:215. Guards the escape-hatch check (`*ds-lint-disable-line*`)
+# against a regression that broke it specifically for TSX-style // comments.
+# ---------------------------------------------------------------------------
+echo "Test 23: escaped JSX violation (// form) is not flagged"
+make_repo
+mkdir -p "$REPO/myapp/src/components"
+{
+  printf '%s\n' 'const style = {'
+  printf '%s\n' "  $VIOL_JSX_ESCAPED"
+  printf '%s\n' '};'
+} > "$REPO/myapp/src/components/Widget.tsx"
+git -C "$REPO" add -A
+git -C "$REPO" commit --quiet -m "add escaped JSX violation"
+run_sut
+assert_eq "jsx-escaped: exit 0" "0" "$RC"
+assert_contains "jsx-escaped: PASS printed" "PASS" "$OUT"
 
 report_results


### PR DESCRIPTION
Closes #2406

## What

Adds Test 22 to `test-lint-ds-drift.sh`: a JSX clean-line false-positive
(precision) battery — the camelCase `.tsx` analog of the existing clean CSS
battery (Tests 5-12).

## Why

PR #2401 (for #2394) added true-positive coverage for all four JSX camelCase
detectors (Tests 17-20 each assert a detector *fires* on a violating `.tsx`
line). What was missing is the symmetric precision side: a `.tsx` fixture
asserting the JSX regexes do **not** fire on allowed camelCase values. Without
it, a future regex edit that widens a JSX detector to over-match could start
flagging legitimate app code with no test catching the regression.

## How

One test-only addition. The new fixture writes six clean-by-construction
camelCase style-object lines to a `Widget.tsx`, exercising the false-positive
side of all four JSX detectors:

- `fontWeight: 400,` / `fontWeight: 700,` — on-scale weights, excluded from
  `FONTWEIGHT_JSX_RE`'s off-scale set
- `fontSize: 'var(--type-sm)',` — token form, no bare `…px` for `FONTSIZE_JSX_RE`
- `borderRadius: '4px',` — non-spacing px, outside the `SPACING_*_JSX_RE`
  property families
- `margin: 0,` / `gap: 0,` — zero values, no nonzero `…px` for the spacing
  detectors

The test asserts the linter exits 0 and prints PASS. No change to
`lint-ds-drift.sh` (the SUT), existing tests, or CI wiring.

## Verification

`test-lint-ds-drift.sh` now reports `39/39 passed, 0 failed` (was 37/37); the
new `jsx-clean-battery` assertions pass. CI runs this suite directly via
`.github/workflows/unit-tests.yml`.
