### PR TITLE
intention-stamp-node --read: test + document no-comment empty-stdout contract

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/intention-stamp-node
+++ b/.claude/skills/dispatch-propagate/scripts/intention-stamp-node
@@ -9,7 +9,7 @@ MARKER='<!-- intention:node-id -->'
 usage() {
   echo "Usage:" >&2
   echo "  intention-stamp-node <issue-num> <node-id>    # write/upsert" >&2
-  echo "  intention-stamp-node --read <issue-num>       # read back node-id" >&2
+  echo "  intention-stamp-node --read <issue-num>       # read back node-id (empty stdout + exit 0 if no stamp comment exists)" >&2
   exit 2
 }
 
@@ -71,6 +71,9 @@ elif [[ $# -eq 2 && "$1" == "--read" ]]; then
   CID="$(dispatch_marker_comment_id "$N" "$MARKER")"
 
   if [[ -z "$CID" ]]; then
+    # Contract: no stamp comment → empty stdout + exit 0 (not an error).
+    # Callers use "empty stdout = no stamp" to detect absence; do not change
+    # this to exit non-zero or print an error without updating callers.
     exit 0
   fi
 

--- a/.claude/skills/dispatch-propagate/scripts/test-intention-stamp.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-intention-stamp.sh
@@ -125,4 +125,17 @@ assert_eq "exits 0" "0" "$exit_code"
 assert_eq "stdout is the node-id" "goal-foo" "$output"
 teardown
 
+# ---------------------------------------------------------------------------
+# Test 8: --read mode with no existing comment → exit 0, empty stdout
+# STUB_EXISTING is NOT set, so the LIST stub returns [] → CID empty →
+# the script's `if [[ -z "$CID" ]]; then exit 0; fi` path (no output).
+# ---------------------------------------------------------------------------
+echo "Test 8: --read mode with no comment returns empty stdout"
+setup
+exit_code=0
+output="$("$STAMP_SCRIPT" --read 5 2>/dev/null)" || exit_code=$?
+assert_eq "exits 0" "0" "$exit_code"
+assert_eq "stdout is empty" "" "$output"
+teardown
+
 report_results


### PR DESCRIPTION
Closes #2415

## What

`intention-stamp-node --read <issue-num>` returns empty stdout and exits 0 when
the issue carries no `<!-- intention:node-id -->` marker comment. This
"empty stdout = no stamp comment" behavior is the contract `intention-emit`
relies on to detect whether a stamp already exists — but it was previously
**untested** and **undocumented**, so a future refactor could silently change
the no-comment path to exit non-zero (breaking the caller) with no test to catch
it.

This PR closes that gap:

- **Test:** adds **Test 8** to `test-intention-stamp.sh`, exercising the
  no-existing-comment `--read` path. With no `STUB_EXISTING` set, the gh stub's
  LIST branch returns `[]`, so `CID` is empty and the script takes its
  `if [[ -z "$CID" ]]; then exit 0; fi` branch. The test asserts exit code 0 and
  empty stdout. Test 7 (the existing comment-present `--read` test) is unchanged.
- **Docs:** documents the empty-stdout contract inline next to the code that
  enforces it — the `usage()` `--read` line and a comment on the `[[ -z "$CID" ]]`
  branch warning callers not to change the exit behavior without updating
  dependents. Documentation only; no behavior change.

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-intention-stamp.sh` →
`Results: 15/15 passed, 0 failed` (up from 13/13; Test 8 adds two assertions).
The suite uses a gh stub, so it needs no network or real GitHub access, and CI
discovers it via `run-unit-tests.sh`.
