### PR TITLE
intention-stamp-gh-stub: make GET handler stateful so the jq split is tested

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/intention-stamp-gh-stub.sh
+++ b/.claude/skills/dispatch-propagate/scripts/intention-stamp-gh-stub.sh
@@ -11,7 +11,8 @@
 #   (neither)        → return empty array []
 #
 # STUB_DIR must be set to a writable directory where POST/PATCH calls record
-# posted-method.txt and posted-body.txt.
+# posted-method.txt and posted-body.txt. GET replays posted-body.txt so the
+# real --jq filter is exercised against the stored body.
 
 METHOD=""
 URL=""
@@ -93,12 +94,16 @@ fi
 # gh api repos/{owner}/{repo}/issues/comments/<CID> [--jq <filter>]
 if [[ -z "$METHOD" && $PAGINATE -eq 0 ]]; then
   if [[ "$URL" == */issues/comments/* ]]; then
+    if [[ ! -f "${STUB_DIR}/posted-body.txt" ]]; then
+      echo "stub: GET called but no posted-body.txt in STUB_DIR='${STUB_DIR}' — run a POST/PATCH first" >&2
+      exit 1
+    fi
     if [[ -n "$JQ_FILTER" ]]; then
-      # Script uses: --jq '.body | split("\n")[1]'
-      # Return the node-id directly since the stub can't run jq
-      printf 'goal-foo\n'
+      # Reconstruct {"body": <stored body>} and apply the real --jq filter so the
+      # production split expression (.body | split("\n")[1]) is exercised by tests.
+      jq -Rs '{body: .}' < "${STUB_DIR}/posted-body.txt" | jq -r "$JQ_FILTER"
     else
-      printf '{"body":"<!-- intention:node-id -->\ngoal-foo\n"}\n'
+      jq -Rs '{body: .}' < "${STUB_DIR}/posted-body.txt"
     fi
     exit 0
   fi

--- a/.claude/skills/dispatch-propagate/scripts/test-intention-stamp.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-intention-stamp.sh
@@ -114,15 +114,18 @@ assert_eq "took POST branch (startswith anchoring)" "POST" "$(cat "$TMPDIR_TEST/
 teardown
 
 # ---------------------------------------------------------------------------
-# Test 7: --read mode returns the stamped node-id
+# Test 7: --read mode returns the stamped node-id through the real jq split filter
 # ---------------------------------------------------------------------------
-echo "Test 7: --read mode returns node-id"
+echo "Test 7: --read mode returns the stamped node-id through the real jq split filter"
 setup
-export STUB_EXISTING=1
+export STUB_EXISTING=1        # keep set for the WHOLE test so the read path resolves CID 777
 exit_code=0
-output="$("$STAMP_SCRIPT" --read 5 2>/dev/null)" || exit_code=$?
-assert_eq "exits 0" "0" "$exit_code"
-assert_eq "stdout is the node-id" "goal-foo" "$output"
+"$STAMP_SCRIPT" 5 goal-roundtrip 2>/dev/null || exit_code=$?   # LIST returns existing comment 777 → PATCH branch → writes posted-body.txt
+assert_eq "stamp exits 0" "0" "$exit_code"
+exit_code=0
+output="$("$STAMP_SCRIPT" --read 5 2>/dev/null)" || exit_code=$?   # LIST resolves CID 777 → GET on comments/777 → stateful handler runs real --jq '.body | split("\n")[1]'
+assert_eq "read exits 0" "0" "$exit_code"
+assert_eq "read returns the stamped node-id" "goal-roundtrip" "$output"
 teardown
 
 report_results


### PR DESCRIPTION
Closes #2416

## Problem

`intention-stamp-gh-stub.sh` is the fake `gh` installed on `PATH` by
`test-intention-stamp.sh` to exercise `intention-stamp-node` without hitting the
real GitHub API. The production `--read` mode reads a stamped node-id back out of
an issue comment with `gh api … --jq '.body | split("\n")[1]'`.

The stub's single-comment GET handler hardcoded its return: when a `--jq` filter
was present it unconditionally `printf 'goal-foo\n'`, regardless of what was
POSTed/PATCHed. The real `.body | split("\n")[1]` expression was therefore never
executed by the suite, so a split-index regression (`[1]`→`[0]`) or a body
line-order change would pass CI silently.

## Change

- **`intention-stamp-gh-stub.sh`** — the GET handler is now stateful. It reads the
  body recorded by the POST/PATCH handlers in `${STUB_DIR}/posted-body.txt`,
  reconstructs `{"body": <stored body>}` via `jq -Rs '{body: .}'`, and applies the
  real `--jq` filter with real `jq` — so the production split expression runs. A
  GET with no preceding POST/PATCH now fails with a clear error (`exit 1`) rather
  than returning a stale hardcoded value, per `.claude/rules/code-style.md`.

- **`test-intention-stamp.sh`** — Test 7 is now a full POST/PATCH→GET roundtrip
  using a distinct node-id (`goal-roundtrip`). The distinct value is load-bearing:
  it fails against both the old hardcode and a `[1]`→`[0]` split-index flip, so the
  one test durably guards the split index.

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-intention-stamp.sh` — all 7
tests pass (14/14 asserts). Manually confirmed the regression guard: flipping
`split("\n")[1]`→`[0]` in `intention-stamp-node` makes Test 7 fail (read returns
the marker line instead of `goal-roundtrip`); reverted.

Out of scope: no change to `intention-stamp-node` (it already passes the correct
filter), no change to the LIST/POST/PATCH handlers, no new test file.
