### PR TITLE
intentionsutil/listTrackers: remove dead README.md guard from .json filter

### DIFF
--- a/intentionsutil/src/tracker.ts
+++ b/intentionsutil/src/tracker.ts
@@ -125,7 +125,7 @@ export function readTracker(dir: string, node_id: string): ExecutionTracker {
 
 export function listTrackers(dir: string): ExecutionTracker[] {
   return readdirSync(dir)
-    .filter((n) => n.endsWith(".json") && n !== "README.md")
+    .filter((n) => n.endsWith(".json"))
     .sort()
     .map((n) => readTracker(dir, n.slice(0, -".json".length)));
 }


### PR DESCRIPTION
Closes #2413

## Summary

Removes the permanently-dead `n !== "README.md"` guard from `listTrackers`'s
`.json` filter in `intentionsutil/src/tracker.ts`.

The filter at `tracker.ts:128` previously read:

```ts
.filter((n) => n.endsWith(".json") && n !== "README.md")
```

The second clause is dead: `README.md` does not end in `.json`, so
`n.endsWith(".json")` already excludes it unconditionally. The guard misled
readers into thinking non-tracker `.json`-named files would be skipped by name —
they would not. The filter now reads exactly what it does:

```ts
.filter((n) => n.endsWith(".json"))
```

## Scope

A single one-line deletion in `tracker.ts`. The visually-similar `.md`+README
guards in `store.ts` (`listNodes`) and `backfill.ts` are **load-bearing** —
`README.md` *does* end in `.md`, so removing them there would break `readNode`
on the missing frontmatter fence. Those are explicitly untouched.

## Verification

The `intentionsutil` unit suite passes (35 tests, 4 files):

```
npx vitest run --project intentionsutil --root .
```

The existing `tracker.test.ts` "ignores non-.json files in the directory" test —
which writes a `README.md` and asserts it is excluded — still passes, confirming
the removed guard was dead (`README.md` is excluded by the `.endsWith(".json")`
clause regardless).

This was surfaced by the review pass on #2408 and deferred out of scope there.
