### PR TITLE
refresh.ts: narrow stage-2 catch to only swallow deleted/transferred issue errors

### DIFF
--- a/intentionsutil/scripts/backfill.ts
+++ b/intentionsutil/scripts/backfill.ts
@@ -21,6 +21,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from "node:f
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { writeNode } from "../src/store.js";
+import { ghErrorText } from "../src/errors.js";
 
 // --- Paths -----------------------------------------------------------------
 // The script lives at `intentionsutil/scripts/backfill.ts`, so the repo root is
@@ -96,8 +97,7 @@ export function ghWithRetry(args: string[]): string {
     try {
       return execFileSync("gh", args, { encoding: "utf8" });
     } catch (err) {
-      const e = err as { stderr?: unknown; stdout?: unknown };
-      const text = String(e.stderr ?? "") + "\n" + String(e.stdout ?? "");
+      const text = ghErrorText(err);
       if (attempt < attempts && isTransientGhError(text)) {
         sleepSync(baseDelayMs * 2 ** (attempt - 1));
         continue;

--- a/intentionsutil/scripts/refresh.ts
+++ b/intentionsutil/scripts/refresh.ts
@@ -18,7 +18,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   writeTracker,
   nodeIdToIssue,
@@ -96,7 +96,7 @@ const GQL_STATE: Record<"OPEN" | "CLOSED" | "MERGED", "open" | "closed" | "merge
  * conflict (its `merged_at`-derived state is computed directly from the PR
  * record rather than the issue's reference view).
  */
-function resolveLinkedPrs(issueNumber: number): LinkedPr[] {
+export function resolveLinkedPrs(issueNumber: number): LinkedPr[] {
   const byNumber = new Map<number, LinkedPr>();
 
   // Stage 1: REST pulls list, branch-prefix filtered.
@@ -126,9 +126,21 @@ function resolveLinkedPrs(issueNumber: number): LinkedPr[] {
   try {
     // lint-allow: gh-rest-porcelain GraphQL-only closedByPullRequestsReferences (no REST equivalent)
     viewOut = gh(["issue", "view", String(issueNumber), "--json", "closedByPullRequestsReferences"]);
-  } catch {
-    // Expected: issue deleted/transferred → treat as no closing references.
-    viewOut = null;
+  } catch (err) {
+    // Only the documented expected error — issue deleted/transferred, which gh
+    // reports as a "Could not resolve to an issue or pull request" GraphQL error
+    // — is absorbed (treated as no closing references, mirroring backfill.ts's
+    // /parent 404 discipline). Every other error class (rate-limit 429/403, auth
+    // failure, network failure) must propagate rather than be silently nulled.
+    // refresh.ts's gh() throws the raw execFileSync error, so inspect its stderr
+    // (not an instanceof GhError check — gh() never produces a GhError).
+    const e = err as { stderr?: unknown; stdout?: unknown };
+    const text = String(e.stderr ?? "") + "\n" + String(e.stdout ?? "");
+    if (/could not resolve to (a|an)/i.test(text)) {
+      viewOut = null;
+    } else {
+      throw err;
+    }
   }
   if (viewOut !== null) {
     const view: IssueView = JSON.parse(viewOut);
@@ -221,4 +233,6 @@ function main(): void {
   );
 }
 
-main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/intentionsutil/scripts/refresh.ts
+++ b/intentionsutil/scripts/refresh.ts
@@ -26,6 +26,7 @@ import {
   type ExecutionTracker,
 } from "../src/tracker.js";
 import { listNodes } from "../src/store.js";
+import { ghErrorText } from "../src/errors.js";
 
 // --- Paths -----------------------------------------------------------------
 // The script lives at `intentionsutil/scripts/refresh.ts`, so the repo root is
@@ -134,9 +135,8 @@ export function resolveLinkedPrs(issueNumber: number): LinkedPr[] {
     // failure, network failure) must propagate rather than be silently nulled.
     // refresh.ts's gh() throws the raw execFileSync error, so inspect its stderr
     // (not an instanceof GhError check — gh() never produces a GhError).
-    const e = err as { stderr?: unknown; stdout?: unknown };
-    const text = String(e.stderr ?? "") + "\n" + String(e.stdout ?? "");
-    if (/could not resolve to (a|an)/i.test(text)) {
+    const text = ghErrorText(err);
+    if (/could not resolve to (a|an) (issue|pull request)/i.test(text)) {
       viewOut = null;
     } else {
       throw err;

--- a/intentionsutil/src/errors.ts
+++ b/intentionsutil/src/errors.ts
@@ -4,3 +4,15 @@ export class IntentionSchemaError extends Error {
     this.name = "IntentionSchemaError";
   }
 }
+
+/**
+ * Concatenate a thrown `gh`/`execFileSync` error's stderr and stdout into a
+ * single searchable text blob (newline-joined). The fields are typed `unknown`
+ * and coerced with `String(... ?? "")` because the shape of a child-process
+ * throw is not statically known. Shared by backfill.ts and refresh.ts, whose
+ * gh-error catch blocks both inspect this text to classify the failure.
+ */
+export function ghErrorText(err: unknown): string {
+  const e = err as { stderr?: unknown; stdout?: unknown };
+  return String(e.stderr ?? "") + "\n" + String(e.stdout ?? "");
+}

--- a/intentionsutil/src/index.ts
+++ b/intentionsutil/src/index.ts
@@ -6,7 +6,7 @@ export type {
   SuccessSignal,
   Clarification,
 } from "./schema.js";
-export { IntentionSchemaError } from "./errors.js";
+export { IntentionSchemaError, ghErrorText } from "./errors.js";
 export { writeNode, readNode, listNodes } from "./store.js";
 export { writeTracker, readTracker, listTrackers, nodeIdToIssue, issueToNodeId } from "./tracker.js";
 export type { ExecutionTracker } from "./tracker.js";

--- a/intentionsutil/test/refresh.test.ts
+++ b/intentionsutil/test/refresh.test.ts
@@ -16,14 +16,13 @@ beforeEach(() => {
   mockExec.mockReset();
 });
 
-// Drive the two gh calls resolveLinkedPrs makes: stage 1 (args[0] === "api")
-// returns an empty pages array; stage 2 (args[0] === "issue") throws the
-// supplied error so we can assert swallow-vs-rethrow behavior.
+// Drive the two gh calls resolveLinkedPrs makes: stage 1 (gh api) returns an
+// empty pages array; stage 2 (gh issue view) throws the supplied error so we
+// can assert swallow-vs-rethrow behavior.
 function driveStage2Throw(err: Error): void {
-  mockExec.mockImplementation((_cmd: unknown, args?: readonly string[]) => {
-    if (args?.[0] === "api") return JSON.stringify([[]]) as unknown as Buffer;
-    throw err;
-  });
+  mockExec
+    .mockReturnValueOnce(JSON.stringify([[]])) // stage 1: gh api → empty pages
+    .mockImplementationOnce(() => { throw err; }); // stage 2: gh issue view → throws
 }
 
 describe("resolveLinkedPrs stage-2 catch", () => {

--- a/intentionsutil/test/refresh.test.ts
+++ b/intentionsutil/test/refresh.test.ts
@@ -45,3 +45,50 @@ describe("resolveLinkedPrs stage-2 catch", () => {
     expect(() => resolveLinkedPrs(123)).toThrow();
   });
 });
+
+// Drive the two gh calls with successful (non-throwing) returns: stage 1 (gh
+// api --slurp) returns the supplied pages of PRs; stage 2 (gh issue view)
+// returns the supplied closing-references view.
+function driveBothSucceed(
+  pages: { number: number; state: "open" | "closed"; merged_at: string | null; ref: string }[][],
+  closingRefs: { number: number; state: "OPEN" | "CLOSED" | "MERGED" }[],
+): void {
+  const slurped = pages.map((page) =>
+    page.map((pr) => ({
+      number: pr.number,
+      state: pr.state,
+      merged_at: pr.merged_at,
+      head: { ref: pr.ref },
+    })),
+  );
+  mockExec
+    .mockReturnValueOnce(JSON.stringify(slurped)) // stage 1: gh api → pages
+    .mockReturnValueOnce(
+      JSON.stringify({ closedByPullRequestsReferences: closingRefs }),
+    ); // stage 2: gh issue view → closing references
+}
+
+describe("resolveLinkedPrs merge/dedup", () => {
+  it("stage 1 wins on a number conflict: its state is kept over stage 2's", () => {
+    // Both stages report PR #500, but with different states. Stage 1's
+    // merged_at-derived state ("merged") must win over stage 2's "OPEN".
+    driveBothSucceed(
+      [[{ number: 500, state: "closed", merged_at: "2026-06-01T00:00:00Z", ref: "123-feature" }]],
+      [{ number: 500, state: "OPEN" }],
+    );
+    expect(resolveLinkedPrs(123)).toEqual([{ number: 500, state: "merged" }]);
+  });
+
+  it("adds a stage-2 PR that stage 1 did not see (additive path)", () => {
+    // Stage 1 finds the open in-progress PR #501 (branch-prefix match); stage 2
+    // contributes a separate closing reference #502 not present in stage 1.
+    driveBothSucceed(
+      [[{ number: 501, state: "open", merged_at: null, ref: "123-wip" }]],
+      [{ number: 502, state: "MERGED" }],
+    );
+    expect(resolveLinkedPrs(123)).toEqual([
+      { number: 501, state: "open" },
+      { number: 502, state: "merged" },
+    ]);
+  });
+});

--- a/intentionsutil/test/refresh.test.ts
+++ b/intentionsutil/test/refresh.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
+
+import { execFileSync } from "node:child_process";
+import { resolveLinkedPrs } from "../scripts/refresh.js";
+
+const mockExec = vi.mocked(execFileSync);
+
+// Build an Error shaped like execFileSync's throw (strings because encoding:utf8).
+function ghError(stderr: string): Error {
+  return Object.assign(new Error("Command failed"), { stderr, stdout: "", status: 1 });
+}
+
+beforeEach(() => {
+  mockExec.mockReset();
+});
+
+// Drive the two gh calls resolveLinkedPrs makes: stage 1 (args[0] === "api")
+// returns an empty pages array; stage 2 (args[0] === "issue") throws the
+// supplied error so we can assert swallow-vs-rethrow behavior.
+function driveStage2Throw(err: Error): void {
+  mockExec.mockImplementation((_cmd: unknown, args?: readonly string[]) => {
+    if (args?.[0] === "api") return JSON.stringify([[]]) as unknown as Buffer;
+    throw err;
+  });
+}
+
+describe("resolveLinkedPrs stage-2 catch", () => {
+  it("swallows the deleted/transferred (Could not resolve) error and returns the stage-1 result", () => {
+    driveStage2Throw(
+      ghError(
+        "GraphQL: Could not resolve to an issue or pull request with the number of 123. (repository.issue)",
+      ),
+    );
+    expect(resolveLinkedPrs(123)).toEqual([]);
+  });
+
+  it("re-throws a rate-limit (429) error instead of swallowing it", () => {
+    driveStage2Throw(ghError("gh: API rate limit (HTTP 429)"));
+    expect(() => resolveLinkedPrs(123)).toThrow();
+  });
+
+  it("re-throws an auth failure (403) instead of swallowing it", () => {
+    driveStage2Throw(ghError("gh: HTTP 403 Forbidden"));
+    expect(() => resolveLinkedPrs(123)).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #2418

## Problem

`intentionsutil/scripts/refresh.ts` resolves an issue's linked PRs in two stages.
Stage 2 calls `gh issue view <N> --json closedByPullRequestsReferences` inside a
`try`/`catch`. The `catch` was **unconditional** — it swallowed every error class
(rate-limit 429/403, auth failure, network failure) and silently treated the
stage-2 PR list as empty, even though its comment claimed it only handled the
"issue deleted/transferred" case. When the catch fired for a rate-limit or auth
error, a tracker was written from stage-1 data alone but looked authoritative,
masking the GraphQL-bucket-exhaustion signal. This violated the project code-style
rule "prefer clear errors over defensive fallbacks".

## Change

Narrow the stage-2 catch so it absorbs **only** the genuine deleted/transferred
case — gh's `Could not resolve to an issue or pull request` GraphQL error — and
**re-throws everything else**. This mirrors the discipline already in the sibling
script `backfill.ts` (`fetchParentNumber`, which re-throws anything that is not the
expected 404). `refresh.ts`'s `gh()` helper throws the raw `execFileSync` error
(it does not wrap in `GhError`), so the discriminator inspects the raw error's
`stderr`/`stdout` rather than using an `instanceof` check.

A 429, 403, or network failure from `gh issue view` now propagates as a thrown
error instead of being converted to a silent empty list.

## Testability

To unit-test the narrowed catch, the module is made importable: `main()` is now
guarded by the `import.meta.url === pathToFileURL(process.argv[1]).href` check
(copied verbatim from `backfill.ts`), and `resolveLinkedPrs` is exported.

## Tests

New `intentionsutil/test/refresh.test.ts` (following `backfill.test.ts`'s
`vi.mock("node:child_process")` pattern) covers three cases:

1. **Swallows** the `Could not resolve` (deleted/transferred) error and returns
   the stage-1 result.
2. **Re-throws** a rate-limit (429) error.
3. **Re-throws** an auth (403) error.

Verified with `npx vitest run --project intentionsutil --root .` — 5 files /
38 tests pass (the prior 4 files / 35 tests stay green, plus the 3 new cases).

## Scope

Out of scope (deliberately): any change to the stage-1 REST call, retry behavior,
and the other `gh()` call sites. A larger refactor extracting `backfill.ts`'s
`GhError`/`ghWithRetry` into a shared module is a separate concern — this issue
wants rate-limit errors to *propagate*, not to retry-then-swallow.
