### PR TITLE
refresh.ts: resolve stage-2 closing-ref PR state from the pulls list

### DIFF
--- a/intentionsutil/scripts/refresh.ts
+++ b/intentionsutil/scripts/refresh.ts
@@ -116,7 +116,9 @@ export function resolveLinkedPrs(issueNumber: number): LinkedPr[] {
   const prefix = `${issueNumber}-`;
   for (const pr of pages.flat()) {
     if (pr.head.ref.startsWith(prefix)) {
-      byNumber.set(pr.number, allPulls.get(pr.number)!);
+      const entry = allPulls.get(pr.number);
+      if (!entry) throw new Error(`PR #${pr.number} in paginated list missing from allPulls`);
+      byNumber.set(pr.number, entry);
     }
   }
 

--- a/intentionsutil/scripts/refresh.ts
+++ b/intentionsutil/scripts/refresh.ts
@@ -103,21 +103,19 @@ export function resolveLinkedPrs(issueNumber: number): LinkedPr[] {
   ]);
   const pages: RawPull[][] = JSON.parse(pullsOut);
 
-  // Every fetched pull, by number, with its state derived once. Both stages
-  // source their `LinkedPr` from here.
+  // Single pass over the flattened pulls: record every fetched pull (by number,
+  // state derived once) in `allPulls` so both stages can source their `LinkedPr`
+  // from here, and in the same iteration populate stage 1's branch-prefix
+  // matches in `byNumber`.
   const allPulls = new Map<number, LinkedPr>();
-  for (const pr of pages.flat()) {
-    allPulls.set(pr.number, {
-      number: pr.number,
-      state: pr.merged_at !== null ? "merged" : pr.state,
-    });
-  }
-
   const prefix = `${issueNumber}-`;
   for (const pr of pages.flat()) {
+    const entry: LinkedPr = {
+      number: pr.number,
+      state: pr.merged_at !== null ? "merged" : pr.state,
+    };
+    allPulls.set(pr.number, entry);
     if (pr.head.ref.startsWith(prefix)) {
-      const entry = allPulls.get(pr.number);
-      if (!entry) throw new Error(`PR #${pr.number} in paginated list missing from allPulls`);
       byNumber.set(pr.number, entry);
     }
   }

--- a/intentionsutil/scripts/refresh.ts
+++ b/intentionsutil/scripts/refresh.ts
@@ -18,7 +18,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   writeTracker,
   nodeIdToIssue,
@@ -68,7 +68,7 @@ interface IssueView {
   closedByPullRequestsReferences: ClosingPrRef[];
 }
 
-type LinkedPr = { number: number; state: "open" | "closed" | "merged" };
+export type LinkedPr = { number: number; state: "open" | "closed" | "merged" };
 
 // --- Linked-PR resolution (two-stage) --------------------------------------
 
@@ -91,7 +91,7 @@ type LinkedPr = { number: number; state: "open" | "closed" | "merged" };
  * conflict; either way the `LinkedPr` (with its `merged_at`-derived state) comes
  * from the same already-fetched pulls list.
  */
-function resolveLinkedPrs(issueNumber: number): LinkedPr[] {
+export function resolveLinkedPrs(issueNumber: number): LinkedPr[] {
   const byNumber = new Map<number, LinkedPr>();
 
   // Stage 1: REST pulls list, branch-prefix filtered.
@@ -234,4 +234,6 @@ function main(): void {
   );
 }
 
-main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/intentionsutil/scripts/refresh.ts
+++ b/intentionsutil/scripts/refresh.ts
@@ -62,7 +62,6 @@ interface RawPull {
 
 interface ClosingPrRef {
   number: number;
-  state: "OPEN" | "CLOSED" | "MERGED";
 }
 
 interface IssueView {
@@ -70,14 +69,6 @@ interface IssueView {
 }
 
 type LinkedPr = { number: number; state: "open" | "closed" | "merged" };
-
-// GraphQL PR-state literals → the narrow tracker union. An explicit mapping
-// (not `.toLowerCase()`, which widens to `string`) keeps the result assignable.
-const GQL_STATE: Record<"OPEN" | "CLOSED" | "MERGED", "open" | "closed" | "merged"> = {
-  OPEN: "open",
-  CLOSED: "closed",
-  MERGED: "merged",
-};
 
 // --- Linked-PR resolution (two-stage) --------------------------------------
 
@@ -89,12 +80,16 @@ const GQL_STATE: Record<"OPEN" | "CLOSED" | "MERGED", "open" | "closed" | "merge
  *     in-progress PR that is not yet recorded as a closing reference.
  *
  *   Stage 2 (GraphQL closingReferences): the issue's own
- *     `closedByPullRequestsReferences`. This list alone is a sufficient
- *     snapshot in most cases; stage 1 only adds the not-yet-linked open PR.
+ *     `closedByPullRequestsReferences` supplies WHICH extra PR numbers to
+ *     include (the branch-renamed / closing-ref case stage 1 misses). The
+ *     porcelain returns only each reference's number — not its state — so the
+ *     state for each such PR is read from the stage-1 pulls list, which already
+ *     holds every repo PR (`--paginate&state=all`) with `merged_at` and
+ *     `state`. No second GitHub call.
  *
  * The two lists are merged and deduped by PR number. Stage 1 wins on a number
- * conflict (its `merged_at`-derived state is computed directly from the PR
- * record rather than the issue's reference view).
+ * conflict; either way the `LinkedPr` (with its `merged_at`-derived state) comes
+ * from the same already-fetched pulls list.
  */
 function resolveLinkedPrs(issueNumber: number): LinkedPr[] {
   const byNumber = new Map<number, LinkedPr>();
@@ -107,17 +102,27 @@ function resolveLinkedPrs(issueNumber: number): LinkedPr[] {
     "/repos/{owner}/{repo}/pulls?state=all&per_page=100",
   ]);
   const pages: RawPull[][] = JSON.parse(pullsOut);
+
+  // Every fetched pull, by number, with its state derived once. Both stages
+  // source their `LinkedPr` from here.
+  const allPulls = new Map<number, LinkedPr>();
+  for (const pr of pages.flat()) {
+    allPulls.set(pr.number, {
+      number: pr.number,
+      state: pr.merged_at !== null ? "merged" : pr.state,
+    });
+  }
+
   const prefix = `${issueNumber}-`;
   for (const pr of pages.flat()) {
     if (pr.head.ref.startsWith(prefix)) {
-      byNumber.set(pr.number, {
-        number: pr.number,
-        state: pr.merged_at !== null ? "merged" : pr.state,
-      });
+      byNumber.set(pr.number, allPulls.get(pr.number)!);
     }
   }
 
-  // Stage 2: GraphQL closing references (branch-renamed / closing-ref case).
+  // Stage 2: closing references (branch-renamed / closing-ref case). Each
+  // reference supplies only a PR number; its state is read from the stage-1
+  // pulls list (`allPulls`).
   // `gh issue view` exits non-zero if the issue was deleted or transferred;
   // that is the one documented expected error, caught here so a missing issue
   // yields an empty stage-2 list rather than aborting (mirrors backfill.ts's
@@ -135,7 +140,15 @@ function resolveLinkedPrs(issueNumber: number): LinkedPr[] {
     for (const ref of view.closedByPullRequestsReferences) {
       // Stage 1 wins on conflict: only add a number stage 1 did not already see.
       if (!byNumber.has(ref.number)) {
-        byNumber.set(ref.number, { number: ref.number, state: GQL_STATE[ref.state] });
+        const linked = allPulls.get(ref.number);
+        if (linked === undefined) {
+          throw new Error(
+            `refresh: closing-reference PR #${ref.number} for issue #${issueNumber} ` +
+              `is absent from the repo pulls list; cannot resolve its state ` +
+              `(a same-repo PR should always be present given --paginate)`,
+          );
+        }
+        byNumber.set(ref.number, linked);
       }
     }
   }

--- a/intentionsutil/test/refresh.test.ts
+++ b/intentionsutil/test/refresh.test.ts
@@ -121,4 +121,18 @@ describe("resolveLinkedPrs", () => {
     expect(pr902Entries).toHaveLength(1);
     expect(pr902Entries[0].state).toBe("merged");
   });
+
+  it("absent closing-ref PR throws — closing ref whose number is missing from the pulls list aborts", () => {
+    // PR 999 is in closedByPullRequestsReferences but NOT in the paginated
+    // pulls list, so its state cannot be resolved. Stage 2 must throw rather
+    // than write a record with an undefined/defaulted state.
+    makeExecMock({
+      pullsPages: PULLS_LIST_FIXTURE,
+      closingRefs: [{ number: 999 }],
+    });
+
+    expect(() => resolveLinkedPrs(2417)).toThrow(
+      /closing-reference PR #999 for issue #2417 is absent from the repo pulls list/,
+    );
+  });
 });

--- a/intentionsutil/test/refresh.test.ts
+++ b/intentionsutil/test/refresh.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
+
+import { execFileSync } from "node:child_process";
+import { resolveLinkedPrs } from "../scripts/refresh.js";
+import { validateTracker, type ExecutionTracker } from "../src/tracker.js";
+
+const mockExec = vi.mocked(execFileSync);
+
+// Fixtures
+const PULLS_LIST_FIXTURE: RawPull[][] = [
+  [
+    // PR 900: merged, head branch does NOT start with "2417-"
+    { number: 900, state: "closed", merged_at: "2026-01-01T00:00:00Z", head: { ref: "renamed-branch" } },
+    // PR 901: open, head branch starts with "2417-" (stage-1 match)
+    { number: 901, state: "open", merged_at: null, head: { ref: "2417-some-branch" } },
+    // PR 902: merged, head branch starts with "2417-" AND in closing refs (conflict test)
+    { number: 902, state: "closed", merged_at: "2026-02-01T00:00:00Z", head: { ref: "2417-other-branch" } },
+  ],
+];
+
+interface RawPull {
+  number: number;
+  state: "open" | "closed";
+  merged_at: string | null;
+  head: { ref: string };
+}
+
+function makeExecMock(opts: {
+  pullsPages: RawPull[][];
+  closingRefs: { number: number }[];
+}): void {
+  mockExec.mockImplementation((_cmd, args) => {
+    const argArr = args as string[];
+    if (argArr.includes("api") && argArr.some((a) => a.includes("/pulls"))) {
+      return JSON.stringify(opts.pullsPages);
+    }
+    if (argArr.includes("issue") && argArr.includes("view")) {
+      return JSON.stringify({ closedByPullRequestsReferences: opts.closingRefs });
+    }
+    throw new Error(`Unexpected gh call: ${argArr.join(" ")}`);
+  });
+}
+
+beforeEach(() => {
+  mockExec.mockReset();
+});
+
+describe("resolveLinkedPrs", () => {
+  it("core regression — stage-2-only closing ref has defined state (not undefined)", () => {
+    // PR 900 head ref "renamed-branch" does NOT start with "2417-" so stage 1
+    // skips it. Stage 2 (closedByPullRequestsReferences) adds it. Its state
+    // must be resolved from the pulls list (merged_at set → "merged").
+    makeExecMock({
+      pullsPages: PULLS_LIST_FIXTURE,
+      closingRefs: [{ number: 900 }],
+    });
+
+    const result = resolveLinkedPrs(2417);
+
+    const pr900 = result.find((p) => p.number === 900);
+    expect(pr900).toBeDefined();
+    expect(pr900!.state).not.toBeUndefined();
+    expect(pr900!.state).toBe("merged");
+  });
+
+  it("validateTracker round-trip — record with resolveLinkedPrs result passes validation after JSON round-trip", () => {
+    // This reproduces the old failure mode: JSON.stringify dropped undefined state keys,
+    // causing validateTracker to reject the re-parsed record.
+    makeExecMock({
+      pullsPages: PULLS_LIST_FIXTURE,
+      closingRefs: [{ number: 900 }],
+    });
+
+    const linkedPrs = resolveLinkedPrs(2417);
+
+    const record: ExecutionTracker = {
+      node_id: "test-node",
+      issue_number: 2417,
+      state: "open",
+      linked_prs: linkedPrs,
+      dispatch_labels: ["dispatch:planned"],
+      refreshed_at: new Date().toISOString(),
+    };
+
+    // Direct validation must pass.
+    expect(() => validateTracker(record)).not.toThrow();
+
+    // JSON round-trip must also pass (reproduces the original undefined-key bug).
+    expect(() => validateTracker(JSON.parse(JSON.stringify(record)))).not.toThrow();
+  });
+
+  it("stage-1 prefix match — open PR with matching head branch is returned", () => {
+    // PR 901: head ref "2417-some-branch" starts with "2417-", not in closing refs.
+    makeExecMock({
+      pullsPages: PULLS_LIST_FIXTURE,
+      closingRefs: [],
+    });
+
+    const result = resolveLinkedPrs(2417);
+
+    const pr901 = result.find((p) => p.number === 901);
+    expect(pr901).toBeDefined();
+    expect(pr901!.state).toBe("open");
+  });
+
+  it("stage-1 wins on conflict — PR in both prefix list and closing refs is not duplicated and keeps stage-1 state", () => {
+    // PR 902: head ref "2417-other-branch" matches stage 1 (merged via merged_at).
+    // Also appears in closedByPullRequestsReferences. Should appear once with "merged".
+    makeExecMock({
+      pullsPages: PULLS_LIST_FIXTURE,
+      closingRefs: [{ number: 902 }],
+    });
+
+    const result = resolveLinkedPrs(2417);
+
+    const pr902Entries = result.filter((p) => p.number === 902);
+    expect(pr902Entries).toHaveLength(1);
+    expect(pr902Entries[0].state).toBe("merged");
+  });
+});

--- a/intentionsutil/test/refresh.test.ts
+++ b/intentionsutil/test/refresh.test.ts
@@ -32,14 +32,14 @@ function makeExecMock(opts: {
   closingRefs: { number: number }[];
 }): void {
   mockExec.mockImplementation((_cmd, args) => {
-    const argArr = args as string[];
-    if (argArr.includes("api") && argArr.some((a) => a.includes("/pulls"))) {
+    if (!args) throw new Error("args not provided to mock");
+    if (args.includes("api") && args.some((a) => a.includes("/pulls"))) {
       return JSON.stringify(opts.pullsPages);
     }
-    if (argArr.includes("issue") && argArr.includes("view")) {
+    if (args.includes("issue") && args.includes("view")) {
       return JSON.stringify({ closedByPullRequestsReferences: opts.closingRefs });
     }
-    throw new Error(`Unexpected gh call: ${argArr.join(" ")}`);
+    throw new Error(`Unexpected gh call: ${args.join(" ")}`);
   });
 }
 
@@ -59,10 +59,11 @@ describe("resolveLinkedPrs", () => {
 
     const result = resolveLinkedPrs(2417);
 
-    const pr900 = result.find((p) => p.number === 900);
-    expect(pr900).toBeDefined();
-    expect(pr900!.state).not.toBeUndefined();
-    expect(pr900!.state).toBe("merged");
+    const pr900Entries = result.filter((p) => p.number === 900);
+    expect(pr900Entries).toHaveLength(1);
+    const pr900 = pr900Entries[0];
+    expect(pr900.state).not.toBeUndefined();
+    expect(pr900.state).toBe("merged");
   });
 
   it("validateTracker round-trip — record with resolveLinkedPrs result passes validation after JSON round-trip", () => {
@@ -100,9 +101,10 @@ describe("resolveLinkedPrs", () => {
 
     const result = resolveLinkedPrs(2417);
 
-    const pr901 = result.find((p) => p.number === 901);
-    expect(pr901).toBeDefined();
-    expect(pr901!.state).toBe("open");
+    const pr901Entries = result.filter((p) => p.number === 901);
+    expect(pr901Entries).toHaveLength(1);
+    const pr901 = pr901Entries[0];
+    expect(pr901.state).toBe("open");
   });
 
   it("stage-1 wins on conflict — PR in both prefix list and closing refs is not duplicated and keeps stage-1 state", () => {


### PR DESCRIPTION
Closes #2417

## Problem

`intentionsutil/scripts/refresh.ts` mirrors GitHub execution state into
`trackers/<id>.json`. Its `resolveLinkedPrs` combines two authorities: a
stage-1 REST pulls scan (head branches matching the `<N>-` dispatch convention)
and a stage-2 read of the issue's `closedByPullRequestsReferences` (to catch a
PR renamed off that prefix).

The `gh issue view --json closedByPullRequestsReferences` porcelain returns only
`id`, `number`, `repository`, and `url` per reference — **not** `state`. But the
`ClosingPrRef` interface declared `state` and the code evaluated
`GQL_STATE[ref.state]` with `ref.state` always `undefined` at runtime, producing
a `LinkedPr` with `state: undefined`. `writeTracker` calls `JSON.stringify`
directly, which omits `undefined`-valued keys, so the record was written with
`linked_prs[N].state` **absent**. The next `readTracker` → `validateTracker`
then threw `IntentionSchemaError: Expected string for linked_prs[N].state, got
undefined`, breaking every tracker consumer. The bug fired only for
stage-2-only closing references (PRs the stage-1 branch-prefix scan did not
already see).

## Fix

Make the stage-1 REST pulls list the single state authority for **both** stages.
That list is fetched with `--paginate&state=all`, so it already holds every PR
in the repo with `merged_at` and `state`. Stage-2 closing-ref state is now
resolved by looking the PR number up in that already-fetched list — no second
GitHub call, no GraphQL. The phantom `ClosingPrRef.state` field and the
`GQL_STATE` mapping are deleted as dead code. A closing-ref number genuinely
absent from the pulls list (should not happen for a same-repo PR given
`--paginate`) throws a descriptive error rather than falling back, per
`.claude/rules/code-style.md`.

## Tests

New `intentionsutil/test/refresh.test.ts` covers:

- the stage-2-only closing-ref path resolving a defined `"merged"` state (never
  `undefined`);
- a record built from the result passing `validateTracker` both directly and
  after a `JSON.parse(JSON.stringify(...))` round-trip, reproducing the original
  dropped-key failure mode;
- the stage-1 prefix-match path and the "stage 1 wins on conflict" dedup path.

To make `resolveLinkedPrs` importable, it is now `export`ed and the
unconditional `main()` call is replaced with the run-as-script guard already
used in `backfill.ts`.

## Verification

`npx vitest run --project intentionsutil --root .` — 39 tests pass.
