### PR TITLE
refresh.ts: fetch the pulls list once per refresh, not once per node

### DIFF
--- a/intentionsutil/scripts/refresh.ts
+++ b/intentionsutil/scripts/refresh.ts
@@ -213,6 +213,13 @@ function main(): void {
 
   if (args.length > 0) {
     const nodeId = args[0];
+    // Resolve the node to an issue BEFORE the expensive O(N) pulls fetch: a
+    // principle root or unresolvable node id would make fetchAllPulls() wasted
+    // work, since refreshNode() returns null without consuming the pulls list.
+    if (nodeIdToIssue(nodeId, trackersDir) === null) {
+      console.warn(`refresh: node "${nodeId}" does not resolve to an issue number; skipping`);
+      return;
+    }
     const allPulls = fetchAllPulls();
     const record = refreshNode(nodeId, allPulls);
     if (record !== null) {

--- a/intentionsutil/scripts/refresh.ts
+++ b/intentionsutil/scripts/refresh.ts
@@ -18,7 +18,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   writeTracker,
   nodeIdToIssue,
@@ -82,6 +82,22 @@ const GQL_STATE: Record<"OPEN" | "CLOSED" | "MERGED", "open" | "closed" | "merge
 // --- Linked-PR resolution (two-stage) --------------------------------------
 
 /**
+ * Fetch the full repo pulls list once. Returns a flat `RawPull[]` across all
+ * paginated pages. Callers should fetch this once and pass it to
+ * `resolveLinkedPrs` — do NOT call inside a per-node loop.
+ */
+export function fetchAllPulls(): RawPull[] {
+  const pullsOut = gh([
+    "api",
+    "--paginate",
+    "--slurp",
+    "/repos/{owner}/{repo}/pulls?state=all&per_page=100",
+  ]);
+  const pages: RawPull[][] = JSON.parse(pullsOut);
+  return pages.flat();
+}
+
+/**
  * Resolve the PRs linked to an issue, combining two authorities:
  *
  *   Stage 1 (REST branch-prefix): every PR whose head branch starts with
@@ -96,19 +112,12 @@ const GQL_STATE: Record<"OPEN" | "CLOSED" | "MERGED", "open" | "closed" | "merge
  * conflict (its `merged_at`-derived state is computed directly from the PR
  * record rather than the issue's reference view).
  */
-function resolveLinkedPrs(issueNumber: number): LinkedPr[] {
+export function resolveLinkedPrs(issueNumber: number, allPulls: RawPull[]): LinkedPr[] {
   const byNumber = new Map<number, LinkedPr>();
 
   // Stage 1: REST pulls list, branch-prefix filtered.
-  const pullsOut = gh([
-    "api",
-    "--paginate",
-    "--slurp",
-    "/repos/{owner}/{repo}/pulls?state=all&per_page=100",
-  ]);
-  const pages: RawPull[][] = JSON.parse(pullsOut);
   const prefix = `${issueNumber}-`;
-  for (const pr of pages.flat()) {
+  for (const pr of allPulls) {
     if (pr.head.ref.startsWith(prefix)) {
       byNumber.set(pr.number, {
         number: pr.number,
@@ -151,7 +160,7 @@ function resolveLinkedPrs(issueNumber: number): LinkedPr[] {
  * such as a principle root or a `goal-foo` with no tracker) — that case is
  * logged and skipped.
  */
-function refreshNode(nodeId: string): ExecutionTracker | null {
+function refreshNode(nodeId: string, allPulls: RawPull[]): ExecutionTracker | null {
   const issueNumber = nodeIdToIssue(nodeId, trackersDir);
   if (issueNumber === null) {
     console.warn(`refresh: node "${nodeId}" does not resolve to an issue number; skipping`);
@@ -166,7 +175,7 @@ function refreshNode(nodeId: string): ExecutionTracker | null {
     .filter((n) => n.startsWith("dispatch:"))
     .sort();
 
-  const linkedPrs = resolveLinkedPrs(issueNumber);
+  const linkedPrs = resolveLinkedPrs(issueNumber, allPulls);
 
   const record: ExecutionTracker = {
     node_id: nodeId,
@@ -204,7 +213,8 @@ function main(): void {
 
   if (args.length > 0) {
     const nodeId = args[0];
-    const record = refreshNode(nodeId);
+    const allPulls = fetchAllPulls();
+    const record = refreshNode(nodeId, allPulls);
     if (record !== null) {
       console.log(`Refreshed ${record.node_id} (issue #${record.issue_number}) → ${trackersDir}`);
     }
@@ -212,13 +222,16 @@ function main(): void {
   }
 
   const nodeIds = allNodeIds();
+  const allPulls = fetchAllPulls();
   let refreshed = 0;
   for (const nodeId of nodeIds) {
-    if (refreshNode(nodeId) !== null) refreshed++;
+    if (refreshNode(nodeId, allPulls) !== null) refreshed++;
   }
   console.log(
     `Refresh complete: ${refreshed} of ${nodeIds.length} nodes resolved to issues → ${trackersDir}`,
   );
 }
 
-main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/intentionsutil/test/refresh.test.ts
+++ b/intentionsutil/test/refresh.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
+
+import { execFileSync } from "node:child_process";
+import { fetchAllPulls, resolveLinkedPrs } from "../scripts/refresh.js";
+
+const mockExec = vi.mocked(execFileSync);
+
+// Build an Error shaped like execFileSync's throw (strings because encoding:utf8).
+function ghError(stderr: string, stdout = ""): Error {
+  const e = Object.assign(new Error("Command failed"), {
+    stderr,
+    stdout,
+    status: 1, // gh exits 1 regardless of HTTP status
+  });
+  return e;
+}
+
+beforeEach(() => {
+  mockExec.mockReset();
+});
+
+describe("fetchAllPulls", () => {
+  it("flattens paginated pages and issues exactly one pulls API call", () => {
+    const page1Pull = { number: 1, state: "open" as const, merged_at: null, head: { ref: "1-foo" } };
+    const page2Pull = { number: 2, state: "closed" as const, merged_at: "2026-01-01T00:00:00Z", head: { ref: "2-bar" } };
+    mockExec.mockReturnValueOnce(JSON.stringify([[page1Pull], [page2Pull]]));
+
+    const result = fetchAllPulls();
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(page1Pull);
+    expect(result[1]).toEqual(page2Pull);
+    expect(mockExec).toHaveBeenCalledTimes(1);
+    expect(mockExec).toHaveBeenCalledWith(
+      "gh",
+      ["api", "--paginate", "--slurp", "/repos/{owner}/{repo}/pulls?state=all&per_page=100"],
+      expect.anything(),
+    );
+  });
+});
+
+describe("resolveLinkedPrs", () => {
+  it("issues zero gh api pulls calls — only the stage-2 issue-view call", () => {
+    const prebuiltPulls = [
+      { number: 2414, state: "open" as const, merged_at: null, head: { ref: "2414-feature" } },
+    ];
+    mockExec.mockReturnValueOnce(JSON.stringify({ closedByPullRequestsReferences: [] }));
+
+    resolveLinkedPrs(2414, prebuiltPulls);
+
+    expect(mockExec).toHaveBeenCalledTimes(1);
+    expect(mockExec.mock.calls[0][1][0]).toBe("issue");
+    expect(mockExec.mock.calls[0][1][1]).toBe("view");
+  });
+
+  describe("merge/dedup behavior", () => {
+    it("stage-1 branch-prefix filter: only includes PRs whose head branch starts with the issue number", () => {
+      const pulls = [
+        { number: 10, state: "open" as const, merged_at: null, head: { ref: "2414-feature" } },
+        { number: 11, state: "open" as const, merged_at: null, head: { ref: "9999-other" } },
+      ];
+      mockExec.mockReturnValueOnce(JSON.stringify({ closedByPullRequestsReferences: [] }));
+
+      const result = resolveLinkedPrs(2414, pulls);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].number).toBe(10);
+    });
+
+    it("merged_at !== null → state merged; merged_at null keeps the PR's own state", () => {
+      const pulls = [
+        { number: 12, state: "closed" as const, merged_at: "2026-01-01T00:00:00Z", head: { ref: "2414-x" } },
+        { number: 13, state: "open" as const, merged_at: null, head: { ref: "2414-y" } },
+        { number: 14, state: "closed" as const, merged_at: null, head: { ref: "2414-z" } },
+      ];
+      mockExec.mockReturnValueOnce(JSON.stringify({ closedByPullRequestsReferences: [] }));
+
+      const result = resolveLinkedPrs(2414, pulls);
+
+      expect(result).toHaveLength(3);
+      expect(result.find((p) => p.number === 12)?.state).toBe("merged");
+      expect(result.find((p) => p.number === 13)?.state).toBe("open");
+      expect(result.find((p) => p.number === 14)?.state).toBe("closed");
+    });
+
+    it("stage-1 wins on number conflict; stage-2 only adds numbers stage-1 did not see", () => {
+      const pulls = [
+        { number: 20, state: "open" as const, merged_at: null, head: { ref: "2414-a" } },
+      ];
+      mockExec.mockReturnValueOnce(
+        JSON.stringify({
+          closedByPullRequestsReferences: [
+            { number: 20, state: "MERGED" },
+            { number: 21, state: "CLOSED" },
+          ],
+        }),
+      );
+
+      const result = resolveLinkedPrs(2414, pulls);
+
+      expect(result).toHaveLength(2);
+      // Stage-1 wins for #20: state is "open", not "merged"
+      const pr20 = result.find((p) => p.number === 20);
+      expect(pr20?.state).toBe("open");
+      // Stage-2 adds #21 with "closed"
+      const pr21 = result.find((p) => p.number === 21);
+      expect(pr21?.state).toBe("closed");
+      // Sorted ascending by number
+      expect(result[0].number).toBe(20);
+      expect(result[1].number).toBe(21);
+    });
+
+    it("stage-2 gh issue view throw yields empty stage-2 contribution without aborting", () => {
+      const pulls = [
+        { number: 30, state: "open" as const, merged_at: null, head: { ref: "2414-z" } },
+      ];
+      mockExec.mockImplementationOnce(() => {
+        throw ghError("gh: Not Found (HTTP 404)");
+      });
+
+      const result = resolveLinkedPrs(2414, pulls);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ number: 30, state: "open" });
+    });
+  });
+});

--- a/intentionsutil/test/refresh.test.ts
+++ b/intentionsutil/test/refresh.test.ts
@@ -51,8 +51,11 @@ describe("resolveLinkedPrs", () => {
     resolveLinkedPrs(2414, prebuiltPulls);
 
     expect(mockExec).toHaveBeenCalledTimes(1);
-    expect(mockExec.mock.calls[0][1][0]).toBe("issue");
-    expect(mockExec.mock.calls[0][1][1]).toBe("view");
+    expect(mockExec).toHaveBeenCalledWith(
+      "gh",
+      expect.arrayContaining(["issue", "view"]),
+      expect.anything(),
+    );
   });
 
   describe("merge/dedup behavior", () => {


### PR DESCRIPTION
Closes #2414

## Problem

In no-arg (bulk-refresh) mode, `intentionsutil/scripts/refresh.ts` fetched the
full repository pulls list — potentially multiple paginated pages — **once per
node**, inside `resolveLinkedPrs`. The pulls list (all PRs, all states) is
invariant across every node in a single refresh run: every node queries the same
snapshot. With ~60 intention nodes and a 300+-PR repo, that is ~60 × ~3 pages =
180+ redundant REST calls for stage 1 alone, on the hot path of the only batch
operation.

This is the deferred review-pass finding from #2408 (backlink: #2408).

## Change

Hoist the single pulls fetch out of the per-node function into `main()` and pass
the pre-fetched `RawPull[]` down as a parameter, so exactly one
`gh api /repos/{owner}/{repo}/pulls` call is issued per refresh regardless of
node count.

- New exported `fetchAllPulls(): RawPull[]` performs the single `--paginate
  --slurp` pulls fetch and returns the flattened list (the `.flat()` moves here,
  out of `resolveLinkedPrs`).
- `resolveLinkedPrs(issueNumber, allPulls)` and `refreshNode(nodeId, allPulls)`
  now take the pre-fetched list. Stage 2 (`gh issue view … --json
  closedByPullRequestsReferences`) is inherently per-issue-number and is **not**
  hoisted — it stays exactly as is, including its `// lint-allow:
  gh-rest-porcelain` comment.
- `main()` calls `fetchAllPulls()` once in each branch (single-node and bulk).
- The `main()` call is now guarded by the standard
  `import.meta.url === pathToFileURL(process.argv[1]).href` check (mirroring
  `backfill.ts`) so the module can be imported by the test without executing.

Pure I/O hoist — no change to which PRs are associated with any node.

## Verification

New `intentionsutil/test/refresh.test.ts` asserts the once-per-refresh property
structurally: `resolveLinkedPrs` makes **zero** pulls calls (only its stage-2
issue-view call), `fetchAllPulls` makes **exactly one**, and the
branch-prefix filter, `merged_at`-derived state, stage-1-wins dedup, and
stage-2-throw tolerance are all unchanged.

```
npx vitest run --project intentionsutil --root .
```

→ 5 files, 41 tests passing.
