### PR TITLE
intention-stamp-gh-stub: add set -euo pipefail to surface jq pipeline failures

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/intention-stamp-gh-stub.sh
+++ b/.claude/skills/dispatch-propagate/scripts/intention-stamp-gh-stub.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # gh stub for test-intention-stamp.sh
 # The real script passes repos/{owner}/{repo}/... with literal braces — gh would expand
 # them from GH_REPO, but this stub receives the literal string. Match on substrings.

--- a/.claude/skills/dispatch-propagate/scripts/test-intention-stamp.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-intention-stamp.sh
@@ -141,4 +141,17 @@ assert_eq "exits 0" "0" "$exit_code"
 assert_eq "stdout is empty" "" "$output"
 teardown
 
+# ---------------------------------------------------------------------------
+# Test 9: malformed --jq filter in the GET handler exits non-zero (pipefail)
+# Without `set -euo pipefail` in the stub, a non-zero jq exit is masked by the
+# handler's trailing `exit 0`, silently succeeding. With pipefail it surfaces.
+# ---------------------------------------------------------------------------
+echo "Test 9: malformed --jq filter in GET handler exits non-zero"
+setup
+# Seed a stored body so the GET handler reaches the jq pipeline.
+printf '<!-- intention:node-id -->\ngoal-x\n' > "$TMPDIR_TEST/stub/posted-body.txt"
+assert_exit_nonzero "malformed --jq exits non-zero" \
+  "$TMPDIR_TEST/bin/gh" api repos/o/r/issues/comments/777 --jq 'bad jq ('
+teardown
+
 report_results


### PR DESCRIPTION
Closes #2428

## What

Add `set -euo pipefail` to `intention-stamp-gh-stub.sh`, the test-only `gh`
stub used by `test-intention-stamp.sh`, and add a regression test (Test 9) that
proves a malformed `--jq` filter now exits non-zero.

## Why

The stub's single-comment GET handler runs a two-stage `jq` pipeline followed by
an unconditional `exit 0`:

```bash
jq -Rs '{body: .}' < "${STUB_DIR}/posted-body.txt" | jq -r "$JQ_FILTER"
...
exit 0
```

Without `pipefail`, a non-zero exit from either pipeline stage was masked by the
trailing `exit 0`, so a test would assert on empty stdout rather than surfacing
the `jq` error — silently passing. The companion `test-intention-stamp.sh`
already carries `set -euo pipefail` on line 2; the stub did not. This is a latent
correctness trap should the stub ever be extended with variable filters.

## Change

- `intention-stamp-gh-stub.sh` — `set -euo pipefail` inserted as line 2,
  immediately after the shebang, mirroring `test-intention-stamp.sh:2`. No other
  change to the stub.
- `test-intention-stamp.sh` — new Test 9 drives the stub's GET handler directly
  with a malformed `--jq` filter and asserts a non-zero exit (via the existing
  `assert_exit_nonzero` helper).

## Verification

The full shell suite passes: 17/17 assertions across 9 tests. Tests 1–8 confirm
existing behavior is unaffected (including the valid production filter via Test 7);
Test 9 confirms the malformed-filter failure now surfaces.
