### PR TITLE
intention-stamp-gh-stub: document LIST body is a CID-only fixture, GET is authoritative

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/intention-stamp-gh-stub.sh
+++ b/.claude/skills/dispatch-propagate/scripts/intention-stamp-gh-stub.sh
@@ -42,6 +42,11 @@ done
 
 # ---- LIST comments (paginate, no method, URL ends with /comments not /comments/<id>) ----
 if [[ $PAGINATE -eq 1 && -z "$METHOD" ]]; then
+  # LIST body is a FIXED FIXTURE — the `old-node` value in the JSON below is
+  # hardcoded and does NOT track ${STUB_DIR}/posted-body.txt. It exists only
+  # for comment-ID (CID) resolution used by Tests 5 and 7. Any future test
+  # that needs to assert the CURRENT comment body must use the GET branch
+  # (single-comment --read path), not LIST.
   if [[ "$URL" == */comments ]]; then
     if [[ "${STUB_EXISTING:-0}" == "1" ]]; then
       # Matching comment: body starts with the marker, author id matches.


### PR DESCRIPTION
Closes #2429

## What

Document the divergent-body contract in the gh stub
`.claude/skills/dispatch-propagate/scripts/intention-stamp-gh-stub.sh`.

The stub's LIST handler returns a hardcoded fixture body (`old-node`) **always**,
regardless of what has been POSTed/PATCHed, while the single-comment GET handler
replays `${STUB_DIR}/posted-body.txt` — the actual stored body — through the real
`--jq` split filter. This split is correct for the current suite (the production
`--read` path uses LIST only to resolve the comment CID, then GETs the body), but
it was undocumented and a latent trap: a future test asserting body content off
the LIST response would silently read the stale `old-node` fixture with no stub
error.

## Change

Comment-only addition on the LIST branch stating that its body field is a fixed
fixture used for CID resolution only (Tests 5 and 7), that it does not track
`posted-body.txt`, and that any future body-content assertion must use the GET
branch. No behavioral change.

## Verification

The full stub suite (`test-intention-stamp.sh`) still passes 16/16 unchanged —
the diff adds only `#` comment lines.

Surfaced during review of #2416 / PR #2421, which made the GET handler stateful.
