### PR TITLE
refresh.ts: test resolveLinkedPrs catch path when gh issue view throws

### DIFF
--- a/intentionsutil/test/refresh.test.ts
+++ b/intentionsutil/test/refresh.test.ts
@@ -30,6 +30,7 @@ interface RawPull {
 function makeExecMock(opts: {
   pullsPages: RawPull[][];
   closingRefs: { number: number }[];
+  throwOnIssueView?: boolean;
 }): void {
   mockExec.mockImplementation((_cmd, args) => {
     if (!args) throw new Error("args not provided to mock");
@@ -37,6 +38,11 @@ function makeExecMock(opts: {
       return JSON.stringify(opts.pullsPages);
     }
     if (args.includes("issue") && args.includes("view")) {
+      if (opts.throwOnIssueView) {
+        throw new Error(
+          "gh issue view failed: could not resolve to an issue (simulated deleted/transferred issue)",
+        );
+      }
       return JSON.stringify({ closedByPullRequestsReferences: opts.closingRefs });
     }
     throw new Error(`Unexpected gh call: ${args.join(" ")}`);
@@ -134,5 +140,26 @@ describe("resolveLinkedPrs", () => {
     expect(() => resolveLinkedPrs(2417)).toThrow(
       /closing-reference PR #999 for issue #2417 is absent from the repo pulls list/,
     );
+  });
+
+  it("gh issue view throws — catch returns stage-1-only PRs, does not throw", () => {
+    // Simulate the issue being deleted/transferred: `gh issue view` exits
+    // non-zero. The catch at refresh.ts must swallow it, skip stage 2, and
+    // return only the stage-1 prefix-matched PRs. closingRefs names PR 900
+    // (a stage-2-only PR) to prove stage 2 is skipped — 900 must be absent.
+    makeExecMock({
+      pullsPages: PULLS_LIST_FIXTURE,
+      closingRefs: [{ number: 900 }],
+      throwOnIssueView: true,
+    });
+
+    let result: ReturnType<typeof resolveLinkedPrs> | undefined;
+    expect(() => {
+      result = resolveLinkedPrs(2417);
+    }).not.toThrow();
+
+    // Only stage-1 prefix matches (901 open, 902 merged); no stage-2 entry.
+    expect(result?.map((p) => p.number)).toEqual([901, 902]);
+    expect(result?.some((p) => p.number === 900)).toBe(false);
   });
 });

--- a/intentionsutil/test/refresh.test.ts
+++ b/intentionsutil/test/refresh.test.ts
@@ -68,6 +68,31 @@ describe("resolveLinkedPrs stage-2 catch", () => {
     driveStage2Throw(ghError("gh: HTTP 403 Forbidden"));
     expect(() => resolveLinkedPrs(123, [])).toThrow();
   });
+
+  it("gh issue view throws — catch returns stage-1-only PRs, does not throw", () => {
+    // Simulate the issue being deleted/transferred: `gh issue view` exits
+    // non-zero. The catch at refresh.ts must swallow it, skip stage 2, and
+    // return only the stage-1 prefix-matched PRs. PR 900 head branch does not
+    // start with "2417-" (stage-2-only probe) — it must be absent from the result.
+    const allPulls = [
+      { number: 900, state: "closed" as const, merged_at: "2026-01-01T00:00:00Z", head: { ref: "renamed-branch" } },
+      { number: 901, state: "open" as const, merged_at: null, head: { ref: "2417-some-branch" } },
+      { number: 902, state: "closed" as const, merged_at: "2026-02-01T00:00:00Z", head: { ref: "2417-other-branch" } },
+    ];
+    driveStage2Throw(
+      ghError(
+        "GraphQL: Could not resolve to an issue or pull request with the number of 2417. (repository.issue)",
+      ),
+    );
+
+    let result: ReturnType<typeof resolveLinkedPrs> | undefined;
+    expect(() => {
+      result = resolveLinkedPrs(2417, allPulls);
+    }).not.toThrow();
+
+    // Only stage-1 prefix matches (901 open, 902 merged); no stage-2 entry.
+    expect(result?.map((p) => p.number)).toEqual([901, 902]);
+  });
 });
 
 describe("resolveLinkedPrs merge/dedup (additive)", () => {
@@ -231,29 +256,4 @@ describe("resolveLinkedPrs", () => {
     });
   });
 
-  it("gh issue view throws — catch returns stage-1-only PRs, does not throw", () => {
-    // Simulate the issue being deleted/transferred: `gh issue view` exits
-    // non-zero. The catch at refresh.ts must swallow it, skip stage 2, and
-    // return only the stage-1 prefix-matched PRs. PR 900 head branch does not
-    // start with "2417-" (stage-2-only probe) — it must be absent from the result.
-    const allPulls = [
-      { number: 900, state: "closed" as const, merged_at: "2026-01-01T00:00:00Z", head: { ref: "renamed-branch" } },
-      { number: 901, state: "open" as const, merged_at: null, head: { ref: "2417-some-branch" } },
-      { number: 902, state: "closed" as const, merged_at: "2026-02-01T00:00:00Z", head: { ref: "2417-other-branch" } },
-    ];
-    driveStage2Throw(
-      ghError(
-        "GraphQL: Could not resolve to an issue or pull request with the number of 2417. (repository.issue)",
-      ),
-    );
-
-    let result: ReturnType<typeof resolveLinkedPrs> | undefined;
-    expect(() => {
-      result = resolveLinkedPrs(2417, allPulls);
-    }).not.toThrow();
-
-    // Only stage-1 prefix matches (901 open, 902 merged); no stage-2 entry.
-    expect(result?.map((p) => p.number)).toEqual([901, 902]);
-    expect(result?.some((p) => p.number === 900)).toBe(false);
-  });
 });

--- a/intentionsutil/test/refresh.test.ts
+++ b/intentionsutil/test/refresh.test.ts
@@ -44,8 +44,8 @@ function makeExecMock(opts: {
     }
     if (args.includes("issue") && args.includes("view")) {
       if (opts.throwOnIssueView) {
-        throw new Error(
-          "gh issue view failed: could not resolve to an issue (simulated deleted/transferred issue)",
+        throw ghError(
+          "GraphQL: Could not resolve to an issue or pull request with the number of 2417. (repository.issue)",
         );
       }
       return JSON.stringify({ closedByPullRequestsReferences: opts.closingRefs });


### PR DESCRIPTION
Closes #2433

## Summary

`resolveLinkedPrs` in `intentionsutil/scripts/refresh.ts` resolves an issue's
linked PRs in two stages: stage 1 prefix-matches PRs from the paginated pulls
list, and stage 2 adds closing-reference PRs read via
`gh issue view --json closedByPullRequestsReferences`. Stage 2 is wrapped in a
try/catch (`refresh.ts:134–137`) that swallows the error and skips stage 2 when
the issue was deleted or transferred, so the function still returns the stage-1
prefix matches without throwing.

The test suite added by #2424 never configured the exec mock to throw on the
`issue view` call, so that catch contract had zero coverage — if the catch were
removed or narrowed, the regression (throwing instead of returning stage-1-only)
would go undetected.

## What changed (test-only)

`intentionsutil/test/refresh.test.ts`:

- Extended the `makeExecMock` helper with an optional `throwOnIssueView` flag
  that throws from the `issue view` branch, simulating a deleted/transferred
  issue. The flag is falsy by default, so the four existing tests are unchanged.
- Added a test that sets `throwOnIssueView: true` with a stage-2-only closing
  ref (PR 900) and asserts `resolveLinkedPrs(2417)` does not throw, returns only
  the stage-1 prefix matches `[901, 902]`, and excludes PR 900 — proving stage 2
  was skipped.

No production code changes.

## Verification

`npx vitest run --project intentionsutil --root .` — 43 tests pass, including
the five `resolveLinkedPrs` cases.
