### PR TITLE
Extract paginateGhApi shared helper; dedup --paginate --slurp pagination

### DIFF
--- a/intentionsutil/scripts/backfill.ts
+++ b/intentionsutil/scripts/backfill.ts
@@ -22,6 +22,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { writeNode } from "../src/store.js";
 import { ghErrorText } from "../src/errors.js";
+import { paginateGhApi } from "./gh-utils.js";
 
 // --- Paths -----------------------------------------------------------------
 // The script lives at `intentionsutil/scripts/backfill.ts`, so the repo root is
@@ -191,14 +192,10 @@ interface OpenIssue {
  * per page); we flatten it. This is robust regardless of page count.
  */
 export function fetchOpenIssues(): OpenIssue[] {
-  const out = ghWithRetry([
-    "api",
-    "--paginate",
-    "--slurp",
-    "/repos/{owner}/{repo}/issues?state=open&per_page=100",
-  ]);
-  const pages: Array<Array<RawIssueItem>> = JSON.parse(out);
-  const items = pages.flat();
+  const items = paginateGhApi<RawIssueItem>(
+    ["/repos/{owner}/{repo}/issues?state=open&per_page=100"],
+    ghWithRetry,
+  );
   return items
     .filter((it) => it.pull_request === undefined)
     .map((it) => ({

--- a/intentionsutil/scripts/gh-utils.ts
+++ b/intentionsutil/scripts/gh-utils.ts
@@ -31,6 +31,9 @@ export function paginateGhApi<T>(
   args: string[],
   runner: (args: string[]) => string = gh,
 ): T[] {
+  if (args.length === 0) {
+    throw new Error("paginateGhApi: args must not be empty (no endpoint specified)");
+  }
   const out = runner(["api", "--paginate", "--slurp", ...args]);
   const pages: T[][] = JSON.parse(out);
   return pages.flat();

--- a/intentionsutil/scripts/gh-utils.ts
+++ b/intentionsutil/scripts/gh-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared `gh` CLI utilities for intentionsutil scripts.
+ *
+ * Exports a plain `gh` runner and a `paginateGhApi` helper that abstracts the
+ * `--paginate --slurp` + `JSON.parse` + `.flat()` idiom used by multiple call
+ * sites. Callers that need retry logic can inject a custom runner via the
+ * `runner` parameter.
+ */
+
+import { execFileSync } from "node:child_process";
+
+/** Run a `gh` subcommand and return stdout. Throws on non-zero exit. */
+export function gh(args: string[]): string {
+  return execFileSync("gh", args, { encoding: "utf8", maxBuffer: 100 * 1024 * 1024 });
+}
+
+/**
+ * Call a GitHub REST endpoint with `--paginate --slurp` and return all items
+ * as a flat array.
+ *
+ * `--paginate --slurp` returns a single JSON array-of-arrays (one inner array
+ * per page); this helper flattens it. This is robust regardless of page count.
+ *
+ * The `runner` parameter lets a caller inject a retrying runner (e.g.
+ * `ghWithRetry` from backfill.ts); the default is the plain `gh` runner.
+ *
+ * Pass only the endpoint args (e.g. `["/repos/{owner}/{repo}/pulls?…"]`);
+ * the helper prepends `["api", "--paginate", "--slurp"]`.
+ */
+export function paginateGhApi<T>(
+  args: string[],
+  runner: (args: string[]) => string = gh,
+): T[] {
+  const out = runner(["api", "--paginate", "--slurp", ...args]);
+  const pages: T[][] = JSON.parse(out);
+  return pages.flat();
+}

--- a/intentionsutil/scripts/refresh.ts
+++ b/intentionsutil/scripts/refresh.ts
@@ -15,7 +15,6 @@
 //   npx tsx intentionsutil/scripts/refresh.ts <node-id>   # refresh one node
 //   npx tsx intentionsutil/scripts/refresh.ts             # refresh all
 
-import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -27,6 +26,7 @@ import {
 } from "../src/tracker.js";
 import { listNodes } from "../src/store.js";
 import { ghErrorText } from "../src/errors.js";
+import { gh, paginateGhApi } from "./gh-utils.js";
 
 // --- Paths -----------------------------------------------------------------
 // The script lives at `intentionsutil/scripts/refresh.ts`, so the repo root is
@@ -35,13 +35,6 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = dirname(dirname(scriptDir));
 const intentionsDir = join(repoRoot, "intentions");
 const trackersDir = join(repoRoot, "trackers");
-
-// --- Helpers ---------------------------------------------------------------
-
-/** Run a `gh` subcommand and return stdout. Throws on non-zero exit. */
-function gh(args: string[]): string {
-  return execFileSync("gh", args, { encoding: "utf8", maxBuffer: 100 * 1024 * 1024 });
-}
 
 // --- GitHub JSON shapes ----------------------------------------------------
 
@@ -79,14 +72,9 @@ export type LinkedPr = { number: number; state: "open" | "closed" | "merged" };
  * `resolveLinkedPrs` — do NOT call inside a per-node loop.
  */
 export function fetchAllPulls(): RawPull[] {
-  const pullsOut = gh([
-    "api",
-    "--paginate",
-    "--slurp",
+  return paginateGhApi<RawPull>([
     "/repos/{owner}/{repo}/pulls?state=all&per_page=100",
   ]);
-  const pages: RawPull[][] = JSON.parse(pullsOut);
-  return pages.flat();
 }
 
 /**

--- a/intentionsutil/test/gh-utils.test.ts
+++ b/intentionsutil/test/gh-utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
+
+import { execFileSync } from "node:child_process";
+import { paginateGhApi } from "../scripts/gh-utils.js";
+
+const mockExec = vi.mocked(execFileSync);
+
+beforeEach(() => {
+  mockExec.mockReset();
+});
+
+describe("paginateGhApi", () => {
+  it("flattens multi-page slurped payload to a single array", () => {
+    mockExec.mockReturnValueOnce(JSON.stringify([[{ n: 1 }], [{ n: 2 }]]));
+
+    const result = paginateGhApi<{ n: number }>(["/x"]);
+
+    expect(result).toEqual([{ n: 1 }, { n: 2 }]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("default runner builds the right argv", () => {
+    mockExec.mockReturnValueOnce(JSON.stringify([[]]));
+
+    paginateGhApi(["/x"]);
+
+    expect(mockExec).toHaveBeenCalledTimes(1);
+    expect(mockExec).toHaveBeenCalledWith(
+      "gh",
+      ["api", "--paginate", "--slurp", "/x"],
+      expect.anything(),
+    );
+  });
+
+  it("custom runner passthrough bypasses execFileSync and receives prepended args", () => {
+    const runner = vi.fn().mockReturnValue(JSON.stringify([[{ id: 1 }]]));
+
+    const result = paginateGhApi<{ id: number }>(["/y"], runner);
+
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(runner).toHaveBeenCalledWith(["api", "--paginate", "--slurp", "/y"]);
+    expect(mockExec).not.toHaveBeenCalled();
+    expect(result).toEqual([{ id: 1 }]);
+  });
+});


### PR DESCRIPTION
Closes #2435

## What

`refresh.ts` and `backfill.ts` each duplicated the same `gh api --paginate
--slurp` → `JSON.parse` → `.flat()` pagination idiom. This extracts that idiom
into one shared, typed helper that both call sites delegate to.

## Changes

- **New module `intentionsutil/scripts/gh-utils.ts`** exporting:
  - `gh(args)` — the plain `gh` runner (moved verbatim from `refresh.ts`,
    preserving the load-bearing 100 MB `maxBuffer`).
  - `paginateGhApi<T>(args, runner = gh)` — prepends `["api", "--paginate",
    "--slurp"]`, parses the array-of-arrays slurp payload, and flattens it. The
    `runner` parameter lets a caller inject a retrying runner.
- **`refresh.ts`** — `fetchAllPulls()` now delegates to `paginateGhApi<RawPull>`;
  the local `gh` is imported from `gh-utils.ts` and the now-unused
  `execFileSync` import is removed. Default runner is plain `gh`, so refresh's
  non-retrying behavior is unchanged.
- **`backfill.ts`** — `fetchOpenIssues()` now delegates to
  `paginateGhApi<RawIssueItem>`, passing `ghWithRetry` as the runner so
  backfill's retry behavior is preserved unchanged.
- **New test `intentionsutil/test/gh-utils.test.ts`** — direct coverage of
  `paginateGhApi`: page flattening, the default-runner argv, and the
  custom-runner passthrough (the `ghWithRetry`-injection contract).

## Verification

`npx vitest run --project intentionsutil --root .` — 6 files, 53 tests pass. The
existing `refresh.test.ts` / `backfill.test.ts` suites (which mock `execFileSync`,
still reached through both delegating call paths) stay green without changes,
confirming no behavior change.

## Note on naming

The issue was originally written against a `fetchAllPulls()` helper. By the time
this was implemented, `origin/main` had re-extracted exactly that
`fetchAllPulls()` in `refresh.ts`, so this PR refactors it directly — the
duplicated idiom is removed from `fetchAllPulls()` and `fetchOpenIssues()`, and
both now delegate to the shared `paginateGhApi`.
