### PR TITLE
gh-utils.test.ts: cover paginateGhApi empty-args guard and runner-error propagation

### DIFF
--- a/intentionsutil/test/gh-utils.test.ts
+++ b/intentionsutil/test/gh-utils.test.ts
@@ -44,4 +44,21 @@ describe("paginateGhApi", () => {
     expect(mockExec).not.toHaveBeenCalled();
     expect(result).toEqual([{ id: 1 }]);
   });
+
+  it("throws when args is empty", () => {
+    expect(() => paginateGhApi([])).toThrow(/args must not be empty/);
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it("propagates runner errors to the caller", () => {
+    const boom = new Error("gh exploded");
+    const runner = vi.fn(() => {
+      throw boom;
+    });
+
+    expect(() => paginateGhApi(["/z"], runner)).toThrow(boom);
+
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(mockExec).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #2438

## What

Add two error-path test cases to `intentionsutil/test/gh-utils.test.ts`,
covering the two previously-untested contracts of the `paginateGhApi` helper
(introduced in PR #2437 for #2435):

1. **Empty-args guard** — `paginateGhApi([])` throws
   `paginateGhApi: args must not be empty (no endpoint specified)` and
   short-circuits before invoking the runner.
2. **Runner-error propagation** — an error thrown by the injected `runner`
   reaches the caller unchanged (same `Error` instance, by reference); the
   helper does not catch.

## Why

The existing suite covered only the happy path (page flattening, default-runner
argv, custom-runner passthrough). The error-path contract was unverified: if the
guard were removed or propagation broke in a refactor, nothing would catch it.
These tests pin the existing, correct behavior — no source change to
`gh-utils.ts`.

## Verification

`npx vitest run --project intentionsutil --root .` — all five `paginateGhApi`
tests (three existing plus the two new) green; full suite 55/55 passing.
