### PR TITLE
Goals as the actionable frontier: graph-side goal model + frontier view

### DIFF
--- a/intentionsutil/SCHEMA.md
+++ b/intentionsutil/SCHEMA.md
@@ -22,7 +22,8 @@ clarifications:
   - question: Does a leaf differ in type from a root?
     answer: No — every node is the same type at any altitude.
 tooling_goals:
-  - intentionsutil
+  - kind: actuator
+    statement: intentionsutil
 success_signal:
   observable: nodes validated by validateNode
   sensor: vitest
@@ -53,7 +54,7 @@ authoritative data.
 | `reading`        | `string \| null`      | no       | Source the node was read from during backfill. Defaults to `null`. |
 | `gap`            | `string \| null`      | no       | A known shortfall between intention and current state. Defaults to `null`. |
 | `clarifications` | `Clarification[]`     | no       | Q&A pairs resolved during the dialectic. Defaults to `[]`. |
-| `tooling_goals`  | `string[]`            | no       | Tooling the node aims to produce or change. Defaults to `[]`. |
+| `tooling_goals`  | `ToolingGoal[]`       | no       | Tooling the node aims to produce or change. Defaults to `[]`. |
 | `success_signal` | `SuccessSignal \| null` | no     | A measurable signal the intention is met. Defaults to `null`. |
 
 ### `SuccessSignal`
@@ -71,6 +72,13 @@ authoritative data.
 | ---------- | -------- | ------- |
 | `question` | `string` | A question raised during the dialectic. |
 | `answer`   | `string` | Its resolved answer. |
+
+### `ToolingGoal`
+
+| Name        | Type           | Meaning |
+| ----------- | -------------- | ------- |
+| `kind`      | `ToolingKind` enum | What the goal codifies. |
+| `statement` | `string`       | The tooling goal, in one sentence. |
 
 ## Enums
 
@@ -90,6 +98,13 @@ authoritative data.
 | `refining`  | Being clarified through the dialectic. |
 | `delegated` | Handed to an owner to act on. |
 | `codified`  | Realized in tooling, code, or a procedure. |
+
+### `ToolingKind`
+
+| Value       | Meaning |
+| ----------- | ------- |
+| `actuator`  | Codifies *doing* — an automated procedure or action. |
+| `sensor`    | Codifies *knowing* — an observation or measurement. |
 
 ## Required vs. optional
 

--- a/intentionsutil/package.json
+++ b/intentionsutil/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "frontier-view": "tsx scripts/frontier-view.ts"
   },
   "dependencies": {
     "yaml": "^2.9.0"

--- a/intentionsutil/scripts/frontier-view.ts
+++ b/intentionsutil/scripts/frontier-view.ts
@@ -1,0 +1,37 @@
+// Active-frontier projection of the intention graph to stdout.
+//
+// Renders the active-frontier view by reading the local `intentions/` store,
+// computing the goal projection, and writing the rendered frontier to stdout.
+// It reads only the local store (no gh, no network) and writes only stdout —
+// no committed file, no ROADMAP.md.
+//
+// Run from anywhere (the store dir is resolved relative to this file, not cwd):
+//   npx tsx intentionsutil/scripts/frontier-view.ts
+//
+// Determinism: `listNodes` returns nodes in id-sorted order, the projection
+// sort has a unique `id` final tiebreak, and the output carries no
+// wall-clock/environment data — two runs on the same store emit byte-identical
+// stdout.
+
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { listNodes } from "../src/store.js";
+import { projectGoals, renderFrontier } from "../src/goals.js";
+
+// --- Paths -----------------------------------------------------------------
+// The script lives at `intentionsutil/scripts/frontier-view.ts`, so the repo
+// root is two directories up. Resolve from this file's own location, never
+// from cwd.
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(dirname(scriptDir));
+const intentionsDir = join(repoRoot, "intentions");
+
+// --- Main ------------------------------------------------------------------
+
+function main(): void {
+  process.stdout.write(renderFrontier(projectGoals(listNodes(intentionsDir))));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/intentionsutil/src/goals.ts
+++ b/intentionsutil/src/goals.ts
@@ -1,0 +1,91 @@
+import type { IntentionNode, Owner } from "./schema.js";
+
+/**
+ * How a goal is realized once it becomes actionable. A procedure node is
+ * codified as a script with tests; a human/ai node is realized as an issue or
+ * pull request.
+ */
+export type Realization = "issue-or-pr" | "script-and-tests";
+
+/** An active-frontier node paired with how it should be realized. */
+export interface Goal {
+  node: IntentionNode;
+  realization: Realization;
+}
+
+/**
+ * Map a node's owner to its realization. A `procedure` is owned by the machine
+ * and codified as a script + tests; `human` and `ai` work surfaces as an
+ * issue/PR.
+ */
+export function realizationForOwner(owner: Owner): Realization {
+  return owner === "procedure" ? "script-and-tests" : "issue-or-pr";
+}
+
+/**
+ * A node is a leaf when no other node names it as a parent. Childless nodes —
+ * including childless principle roots — are leaves.
+ */
+export function isLeaf(node: IntentionNode, all: IntentionNode[]): boolean {
+  return !all.some((n) => n.parent === node.id);
+}
+
+/**
+ * The active frontier: the leaf nodes that still have open work.
+ *
+ * The predicate is `status !== "codified" && isLeaf(node, nodes)`. Rationale:
+ * every issue leaf is currently `status: "raw"`, so gating on a
+ * `delegated`/`codified` status would yield an empty frontier. Leaf-ness alone
+ * would wrongly include the childless `codified` principle roots; the
+ * `!== "codified"` clause drops those. Input order is preserved (filter only).
+ */
+export function activeFrontier(nodes: IntentionNode[]): IntentionNode[] {
+  return nodes.filter((node) => node.status !== "codified" && isLeaf(node, nodes));
+}
+
+/**
+ * Project the active frontier into an ordered list of goals.
+ *
+ * Sort is a TOTAL order, independent of input order:
+ *   1. gap-present (non-null) before gap-absent;
+ *   2. then success_signal-present (non-null) before absent;
+ *   3. then `id` ascending (the unique tiebreak guaranteeing totality).
+ *
+ * The input array is not mutated (a copy is sorted).
+ */
+export function projectGoals(nodes: IntentionNode[]): Goal[] {
+  const frontier = activeFrontier(nodes);
+  const sorted = [...frontier].sort((a, b) => {
+    const aGap = a.gap !== null ? 0 : 1;
+    const bGap = b.gap !== null ? 0 : 1;
+    if (aGap !== bGap) return aGap - bGap;
+
+    const aSig = a.success_signal !== null ? 0 : 1;
+    const bSig = b.success_signal !== null ? 0 : 1;
+    if (aSig !== bSig) return aSig - bSig;
+
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+  return sorted.map((node) => ({ node, realization: realizationForOwner(node.owner) }));
+}
+
+function renderRealization(realization: Realization): string {
+  return realization === "script-and-tests" ? "script + tests" : "issue/PR";
+}
+
+/**
+ * Render the projected goals as deterministic markdown, one line per goal in
+ * `projectGoals` order. The output is byte-stable across repeated calls with
+ * the same input: no dates, no wall-clock, no environment data. Ends with a
+ * trailing newline.
+ */
+export function renderFrontier(goals: Goal[]): string {
+  if (goals.length === 0) {
+    return "_No active frontier goals._\n";
+  }
+  const lines = goals.map(({ node, realization }) => {
+    const base = `- **${node.id}** — ${node.statement} _(owner: ${node.owner} → ${renderRealization(realization)})_`;
+    return node.gap !== null ? `${base} — gap: ${node.gap}` : base;
+  });
+  return `${lines.join("\n")}\n`;
+}

--- a/intentionsutil/src/goals.ts
+++ b/intentionsutil/src/goals.ts
@@ -23,24 +23,25 @@ export function realizationForOwner(owner: Owner): Realization {
 }
 
 /**
- * A node is a leaf when no other node names it as a parent. Childless nodes —
- * including childless principle roots — are leaves.
- */
-export function isLeaf(node: IntentionNode, all: IntentionNode[]): boolean {
-  return !all.some((n) => n.parent === node.id);
-}
-
-/**
  * The active frontier: the leaf nodes that still have open work.
  *
- * The predicate is `status !== "codified" && isLeaf(node, nodes)`. Rationale:
- * every issue leaf is currently `status: "raw"`, so gating on a
- * `delegated`/`codified` status would yield an empty frontier. Leaf-ness alone
- * would wrongly include the childless `codified` principle roots; the
- * `!== "codified"` clause drops those. Input order is preserved (filter only).
+ * A node is a leaf when no other node names it as a parent; childless nodes —
+ * including childless principle roots — are leaves. The predicate is
+ * `status !== "codified" && <node is a leaf>`. Rationale: every issue leaf is
+ * currently `status: "raw"`, so gating on a `delegated`/`codified` status would
+ * yield an empty frontier. Leaf-ness alone would wrongly include the childless
+ * `codified` principle roots; the `!== "codified"` clause drops those. Input
+ * order is preserved (filter only).
+ *
+ * Leaf-ness is resolved against a Set of all non-null parent ids built once up
+ * front, so the whole pass is O(n) rather than O(n²) (a per-node scan over all
+ * nodes).
  */
 export function activeFrontier(nodes: IntentionNode[]): IntentionNode[] {
-  return nodes.filter((node) => node.status !== "codified" && isLeaf(node, nodes));
+  const parentIds = new Set(
+    nodes.map((n) => n.parent).filter((p): p is string => p !== null),
+  );
+  return nodes.filter((node) => node.status !== "codified" && !parentIds.has(node.id));
 }
 
 /**

--- a/intentionsutil/src/index.ts
+++ b/intentionsutil/src/index.ts
@@ -1,10 +1,12 @@
-export { validateNode, OWNERS, STATUSES } from "./schema.js";
+export { validateNode, OWNERS, STATUSES, TOOLING_KINDS } from "./schema.js";
 export type {
   IntentionNode,
   Owner,
   Status,
   SuccessSignal,
   Clarification,
+  ToolingGoal,
+  ToolingKind,
 } from "./schema.js";
 export { IntentionSchemaError, ghErrorText } from "./errors.js";
 export { writeNode, readNode, listNodes } from "./store.js";

--- a/intentionsutil/src/index.ts
+++ b/intentionsutil/src/index.ts
@@ -12,3 +12,5 @@ export { IntentionSchemaError, ghErrorText } from "./errors.js";
 export { writeNode, readNode, listNodes } from "./store.js";
 export { writeTracker, readTracker, listTrackers, nodeIdToIssue, issueToNodeId } from "./tracker.js";
 export type { ExecutionTracker } from "./tracker.js";
+export { projectGoals, activeFrontier, realizationForOwner, renderFrontier } from "./goals.js";
+export type { Goal, Realization } from "./goals.js";

--- a/intentionsutil/src/schema.ts
+++ b/intentionsutil/src/schema.ts
@@ -12,6 +12,11 @@ export type Status = "raw" | "refining" | "delegated" | "codified";
 
 export const STATUSES: readonly Status[] = ["raw", "refining", "delegated", "codified"];
 
+/** What kind of tooling a goal codifies. */
+export type ToolingKind = "actuator" | "sensor";
+
+export const TOOLING_KINDS: readonly ToolingKind[] = ["actuator", "sensor"];
+
 // --- Structured optional fields --------------------------------------------
 
 /** A measurable signal that a node's intention is being met. */
@@ -26,6 +31,12 @@ export interface SuccessSignal {
 export interface Clarification {
   question: string;
   answer: string;
+}
+
+/** A tooling goal a node aims to produce or change. */
+export interface ToolingGoal {
+  kind: ToolingKind;
+  statement: string;
 }
 
 // --- Node ------------------------------------------------------------------
@@ -50,7 +61,7 @@ export interface IntentionNode {
   reading: string | null;
   gap: string | null;
   clarifications: Clarification[];
-  tooling_goals: string[];
+  tooling_goals: ToolingGoal[];
   success_signal: SuccessSignal | null;
 }
 
@@ -70,7 +81,7 @@ export interface IntentionNodeInput {
   reading?: string | null;
   gap?: string | null;
   clarifications?: Clarification[];
-  tooling_goals?: string[];
+  tooling_goals?: ToolingGoal[];
   success_signal?: SuccessSignal | null;
 }
 
@@ -99,18 +110,6 @@ function requireOneOf<T extends string>(value: unknown, allowed: readonly T[], f
     throw new IntentionSchemaError(`Invalid ${field}: "${s}"`);
   }
   return found;
-}
-
-function requireStringArray(value: unknown, field: string): string[] {
-  if (!Array.isArray(value)) {
-    throw new IntentionSchemaError(`Expected array for ${field}, got ${typeof value}`);
-  }
-  return value.map((item, i) => {
-    if (typeof item !== "string") {
-      throw new IntentionSchemaError(`Expected string at ${field}[${i}], got ${typeof item}`);
-    }
-    return item;
-  });
 }
 
 function optionalString(value: unknown, field: string): string | null {
@@ -148,6 +147,21 @@ function validateClarifications(value: unknown, field: string): Clarification[] 
     return {
       question: requireString(item.question, `${field}[${i}].question`),
       answer: requireString(item.answer, `${field}[${i}].answer`),
+    };
+  });
+}
+
+function validateToolingGoals(value: unknown, field: string): ToolingGoal[] {
+  if (!Array.isArray(value)) {
+    throw new IntentionSchemaError(`Expected array for ${field}, got ${typeof value}`);
+  }
+  return value.map((item, i) => {
+    if (!isPlainObject(item)) {
+      throw new IntentionSchemaError(`Expected object at ${field}[${i}], got ${typeof item}`);
+    }
+    return {
+      kind: requireOneOf(item.kind, TOOLING_KINDS, `${field}[${i}].kind`),
+      statement: requireString(item.statement, `${field}[${i}].statement`),
     };
   });
 }
@@ -195,7 +209,7 @@ export function validateNode(value: unknown): IntentionNode {
     tooling_goals:
       value.tooling_goals == null
         ? []
-        : requireStringArray(value.tooling_goals, "tooling_goals"),
+        : validateToolingGoals(value.tooling_goals, "tooling_goals"),
     success_signal:
       value.success_signal == null
         ? null

--- a/intentionsutil/test/goals.test.ts
+++ b/intentionsutil/test/goals.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import type { IntentionNode, Owner } from "../src/schema.js";
+import {
+  activeFrontier,
+  projectGoals,
+  realizationForOwner,
+  renderFrontier,
+} from "../src/goals.js";
+
+/** Build an IntentionNode fixture, filling required/default fields. */
+function node(partial: Partial<IntentionNode> & { id: string }): IntentionNode {
+  return {
+    id: partial.id,
+    statement: partial.statement ?? `Statement for ${partial.id}`,
+    owner: partial.owner ?? "human",
+    status: partial.status ?? "raw",
+    parent: partial.parent ?? null,
+    rationale: partial.rationale ?? null,
+    reading: partial.reading ?? null,
+    gap: partial.gap ?? null,
+    clarifications: partial.clarifications ?? [],
+    tooling_goals: partial.tooling_goals ?? [],
+    success_signal: partial.success_signal ?? null,
+  };
+}
+
+describe("activeFrontier", () => {
+  it("excludes a codified childless root, excludes a non-leaf epic, includes a raw leaf", () => {
+    const root = node({ id: "principle", status: "codified", parent: null });
+    const epic = node({ id: "epic", status: "raw", parent: "principle" });
+    const leaf = node({ id: "leaf", status: "raw", parent: "epic" });
+
+    const frontier = activeFrontier([root, epic, leaf]);
+    expect(frontier.map((n) => n.id)).toEqual(["leaf"]);
+  });
+
+  it("preserves input order among surviving nodes", () => {
+    const a = node({ id: "a", status: "raw" });
+    const b = node({ id: "b", status: "raw" });
+    const frontier = activeFrontier([b, a]);
+    expect(frontier.map((n) => n.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("realizationForOwner", () => {
+  it("maps all three owners correctly", () => {
+    const cases: [Owner, string][] = [
+      ["human", "issue-or-pr"],
+      ["ai", "issue-or-pr"],
+      ["procedure", "script-and-tests"],
+    ];
+    for (const [owner, expected] of cases) {
+      expect(realizationForOwner(owner)).toBe(expected);
+    }
+  });
+});
+
+describe("projectGoals", () => {
+  it("produces a total, fully id-sorted order on the all-null-gap shape", () => {
+    const nodes = [
+      node({ id: "c", status: "raw" }),
+      node({ id: "a", status: "raw" }),
+      node({ id: "b", status: "raw" }),
+    ];
+    const goals = projectGoals(nodes);
+    expect(goals.map((g) => g.node.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("floats a non-null-gap node ahead of null-gap nodes regardless of input order", () => {
+    const withGap = node({ id: "z", status: "raw", gap: "missing tooling" });
+    const noGapA = node({ id: "a", status: "raw" });
+    const noGapB = node({ id: "b", status: "raw" });
+
+    // Scrambled input order; gap node has the highest id so a naive id sort
+    // would place it last.
+    const goals = projectGoals([noGapB, withGap, noGapA]);
+    expect(goals.map((g) => g.node.id)).toEqual(["z", "a", "b"]);
+  });
+
+  it("orders success_signal-present ahead of absent within the same gap class", () => {
+    const sig = node({
+      id: "y",
+      status: "raw",
+      success_signal: { observable: "o", sensor: "s", threshold: "t", is_proxy: false },
+    });
+    const noSig = node({ id: "a", status: "raw" });
+    const goals = projectGoals([noSig, sig]);
+    expect(goals.map((g) => g.node.id)).toEqual(["y", "a"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const nodes = [
+      node({ id: "c", status: "raw" }),
+      node({ id: "a", status: "raw" }),
+    ];
+    const snapshot = nodes.map((n) => n.id);
+    projectGoals(nodes);
+    expect(nodes.map((n) => n.id)).toEqual(snapshot);
+  });
+
+  it("attaches the correct realization", () => {
+    const goals = projectGoals([
+      node({ id: "p", owner: "procedure", status: "raw" }),
+      node({ id: "h", owner: "human", status: "raw" }),
+    ]);
+    const byId = Object.fromEntries(goals.map((g) => [g.node.id, g.realization]));
+    expect(byId.p).toBe("script-and-tests");
+    expect(byId.h).toBe("issue-or-pr");
+  });
+});
+
+describe("renderFrontier", () => {
+  it("is byte-identical across two calls with the same input", () => {
+    const goals = projectGoals([
+      node({ id: "z", status: "raw", gap: "missing tooling" }),
+      node({ id: "a", status: "raw" }),
+      node({ id: "p", owner: "procedure", status: "raw" }),
+    ]);
+    expect(renderFrontier(goals)).toBe(renderFrontier(goals));
+  });
+
+  it("contains no date-shaped substring (determinism guard)", () => {
+    const goals = projectGoals([
+      node({ id: "z", status: "raw", gap: "missing tooling" }),
+      node({ id: "a", status: "raw" }),
+    ]);
+    const out = renderFrontier(goals);
+    expect(out).not.toMatch(/\d{4}-\d{2}-\d{2}/);
+  });
+
+  it("ends with a trailing newline and renders a gap when present", () => {
+    const goals = projectGoals([node({ id: "z", status: "raw", gap: "missing tooling" })]);
+    const out = renderFrontier(goals);
+    expect(out.endsWith("\n")).toBe(true);
+    expect(out).toContain("gap: missing tooling");
+  });
+
+  it("renders the stable placeholder for an empty frontier", () => {
+    expect(renderFrontier([])).toBe("_No active frontier goals._\n");
+  });
+});

--- a/intentionsutil/test/goals.test.ts
+++ b/intentionsutil/test/goals.test.ts
@@ -34,6 +34,14 @@ describe("activeFrontier", () => {
     expect(frontier.map((n) => n.id)).toEqual(["leaf"]);
   });
 
+  it("includes delegated and refining leaves (all non-codified leaves survive)", () => {
+    const delegated = node({ id: "delegated", status: "delegated" });
+    const refining = node({ id: "refining", status: "refining" });
+
+    const frontier = activeFrontier([delegated, refining]);
+    expect(frontier.map((n) => n.id)).toEqual(["delegated", "refining"]);
+  });
+
   it("preserves input order among surviving nodes", () => {
     const a = node({ id: "a", status: "raw" });
     const b = node({ id: "b", status: "raw" });

--- a/intentionsutil/test/schema.test.ts
+++ b/intentionsutil/test/schema.test.ts
@@ -13,7 +13,7 @@ describe("validateNode", () => {
       reading: "rd",
       gap: "g",
       clarifications: [{ question: "q", answer: "a" }],
-      tooling_goals: ["t"],
+      tooling_goals: [{ kind: "actuator", statement: "t" }],
       success_signal: {
         observable: "o",
         sensor: "s",
@@ -59,6 +59,18 @@ describe("validateNode", () => {
         statement: "Bad owner.",
         owner: "robot",
         status: "raw",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects a tooling_goal with a bad kind", () => {
+    expect(() =>
+      validateNode({
+        id: "n5",
+        statement: "Bad tooling kind.",
+        owner: "human",
+        status: "raw",
+        tooling_goals: [{ kind: "lever", statement: "x" }],
       }),
     ).toThrow();
   });

--- a/intentionsutil/test/schema.test.ts
+++ b/intentionsutil/test/schema.test.ts
@@ -74,4 +74,28 @@ describe("validateNode", () => {
       }),
     ).toThrow();
   });
+
+  it("rejects a tooling_goal that is a bare string", () => {
+    expect(() =>
+      validateNode({
+        id: "n6",
+        statement: "Old format.",
+        owner: "human",
+        status: "raw",
+        tooling_goals: ["bare-string"],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects a tooling_goal with missing statement", () => {
+    expect(() =>
+      validateNode({
+        id: "n7",
+        statement: "Missing statement.",
+        owner: "human",
+        status: "raw",
+        tooling_goals: [{ kind: "actuator" }],
+      }),
+    ).toThrow();
+  });
 });

--- a/intentionsutil/test/store.test.ts
+++ b/intentionsutil/test/store.test.ts
@@ -25,7 +25,7 @@ describe("store round-trip", () => {
         { question: "Who arbitrates conflicts?", answer: "The charter owner." },
         { question: "How often is it reviewed?", answer: "Each digest cycle." },
       ],
-      tooling_goals: ["align-cli", "intention-tree"],
+      tooling_goals: [{ kind: "actuator", statement: "align-cli" }, { kind: "sensor", statement: "intention-tree" }],
       success_signal: {
         observable: "intention-tree builds without orphans",
         sensor: "align --check",
@@ -63,7 +63,7 @@ describe("store round-trip", () => {
           answer: "Yes — the rationale field above contains one.",
         },
       ],
-      tooling_goals: ["yaml-round-trip", "intention-store"],
+      tooling_goals: [{ kind: "actuator", statement: "yaml-round-trip" }, { kind: "sensor", statement: "intention-store" }],
       success_signal: {
         observable: "readNode returns the exact node written, including trailing newlines",
         sensor: "vitest store.test.ts",


### PR DESCRIPTION
Closes #2368

Delivers the graph-side goal model and a deterministic active-frontier view
rendered from the intention graph (epic #2100). All work is confined to the
`intentionsutil` package; nothing touches, generates, or depends on the legacy
hand-maintained `ROADMAP.md` (its removal is a separate leaf, #2441).

Three units, one per acceptance criterion:

- **Unit 1 — First-class tooling-goals.** `tooling_goals` becomes a structured
  `ToolingGoal[]` with an `actuator` / `sensor` discriminator (codifies *doing*
  vs *knowing*), replacing the untyped `string[]`. Adds `ToolingKind`,
  `TOOLING_KINDS`, `ToolingGoal`, and a `validateToolingGoals` guard modeled on
  `validateClarifications`; removes the now-unused `requireStringArray`. Every
  committed node has `tooling_goals: []` (the default), so no node-file rewrite is
  needed and `backfill.ts` is untouched. `SCHEMA.md` and the test fixtures are
  updated in lockstep.

- **Unit 2 — `Goal` type + `projectGoals` projection.** New pure-logic
  `src/goals.ts`: `activeFrontier` (the predicate `status !== "codified" &&
  isLeaf`), `realizationForOwner` (`procedure` → script + tests; `human`/`ai` →
  issue/PR), `projectGoals` (frontier filtered, total-ordered by gap-present →
  success_signal-present → `id` ascending), and `renderFrontier` (deterministic
  markdown, no wall-clock data). The `id` tiebreak guarantees a total order; the
  no-date assertion in the tests is the network-free determinism guard for AC#2.

- **Unit 3 — Deterministic frontier-view generator.** New
  `scripts/frontier-view.ts` renders the active frontier from the local
  `intentions/` store to stdout — no `gh`, no network, no committed artifact.
  Two runs emit byte-identical output. Added a `frontier-view` package script.

## Verification

`npx vitest run --project intentionsutil --root .` — 69 tests pass across 7
files. The suite covers the lossless schema round-trip with the structured
`tooling_goals` (Unit 1); the frontier predicate, owner→realization mapping, and
total-order ordering (Unit 2); and the byte-stability + no-date determinism guard
in `goals.test.ts` (the primary auto-runnable proof of AC#2). The end-to-end
generator idempotency (`frontier-view.ts` run twice → identical stdout) was
confirmed manually.
