### PR TITLE
dispatch-tick-recover: don't count benign empty/drain ticks as failures (#2445)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -398,13 +398,13 @@ run_materialize() {
       # #1445 backstop: a no-spawn drain (target-done / worktree-conflict /
       # fan-out-all-done) spawns no worker and the headless tick never calls
       # dispatch-self-close, so nothing else guarantees a continuation. Trigger
-      # the continuation-guarantor directly. Best-effort: recover self-limits
-      # (its continuation-check resets the consecutive-failure count when a
-      # reseed timer or busy worker already exists) and escalates past its cap
-      # via a dispatch:chain-stalled issue — both intended. Its OnFailure=
-      # handler is not wired on this direct call, which is fine: recover almost
-      # never fails and any real failure is logged below.
-      "$SCRIPT_DIR/dispatch-tick-recover" || \
+      # the continuation-guarantor directly, flagging it BENIGN (#2445): a
+      # no-spawn drain is a clean no-work decision, not a tick failure, so recover
+      # must guarantee a continuation (heartbeat/reseed) without counting toward
+      # the stall cap. Its OnFailure= handler is not wired on this direct call,
+      # which is fine: recover almost never fails and any real failure is logged
+      # below.
+      DISPATCH_TICK_RECOVER_BENIGN="$token" "$SCRIPT_DIR/dispatch-tick-recover" || \
         echo "dispatch-tick: dispatch-tick-recover failed on '$token' (continuation not guaranteed)" >&2
       exit 0
       ;;
@@ -430,18 +430,19 @@ case "${1:-}" in
     # leaf is claimed/parked/excluded while the fleet is below target) spawns
     # no worker and arms no continuation on its own, so the chain dead-ends
     # until an external kick. Route it through the same continuation-guarantor
-    # `drain` uses (#1445): it bounds retries via its consecutive-failure
-    # counter (catching reservation reclaims / clearing parks across a few
-    # ticks), escalates to dispatch:chain-stalled when persistently blocked on
-    # a human, and safely no-ops when a live busy worker already exists.
+    # `drain` uses (#1445) — flagged BENIGN (#2445): an `empty` tick is a clean
+    # no-work decision, not a tick failure. recover guarantees a continuation
+    # (the #2022 durable heartbeat normally carries it; a backstop reseed only if
+    # the heartbeat is down) WITHOUT counting toward the consecutive-failure
+    # stall cap. Counting benign `empty` ticks as failures was the #2445 false
+    # positive: COUNT climbed unbounded (every benign cycle finds no reseed timer)
+    # and filed a `dispatch:chain-stalled` latch while the chain was alive.
     # Autonomous-only (mirror the #1453 convergence-reseed guard above): a
     # `--manual` empty is a one-shot human probe (an explicit <N> never
-    # resolves to empty), so it must NOT be forced through the backstop, where
-    # with zero live workers it would arm a continuation and increment the
-    # failure counter — the mis-escalation criterion 3 forbids.
+    # resolves to empty), so it must NOT be forced through the backstop.
     echo "dispatch-tick: select-tick disposition 'empty'; nothing spawned" >&2
     if [[ -z "$MANUAL" && -z "$ARG" ]]; then
-      "$SCRIPT_DIR/dispatch-tick-recover" || \
+      DISPATCH_TICK_RECOVER_BENIGN=empty "$SCRIPT_DIR/dispatch-tick-recover" || \
         echo "dispatch-tick: dispatch-tick-recover failed on 'empty' (continuation not guaranteed)" >&2
     fi
     exit 0

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick-recover
@@ -89,6 +89,15 @@
 #     Replaces the `claude` invocation in lib-claude-agents.sh's
 #     claude_agents_count_busy_workers. Default: `claude`.
 #
+#   DISPATCH_TICK_RECOVER_BENIGN
+#     Set by the inline `empty`/`drain` callers in dispatch-tick to the
+#     disposition token. Marks this invocation a benign no-work continuation
+#     request, NOT a tick failure: recover resets the consecutive-failure count
+#     and guarantees a continuation (heartbeat/reseed, or a single backstop
+#     reseed if the heartbeat is down) without ever counting toward the stall cap
+#     or escalating. Unset on the OnFailure= genuine-crash path. See the Step-2.5
+#     block and #2445. Default: unset (genuine-failure behavior).
+#
 # Sandbox: this runs as a systemd `OnFailure=` unit OUTSIDE Claude's Bash
 # sandbox. `systemd-run --user` / `systemctl --user` talk to the user's systemd
 # over D-Bus, `claude agents --json` reaches the local daemon over a Unix
@@ -110,6 +119,14 @@ STATE_PATH="${DISPATCH_TICK_RECOVER_STATE_PATH:-$HOME/.local/share/commons-dispa
 SYSTEMCTL_CMD="${DISPATCH_TICK_RECOVER_SYSTEMCTL_CMD:-systemctl}"
 SYSTEMD_RUN_CMD="${DISPATCH_TICK_RECOVER_SYSTEMD_RUN_CMD:-systemd-run}"
 GH_CMD="${DISPATCH_TICK_RECOVER_GH_CMD:-gh}"
+
+# Benign no-work disposition signal (#2445). The inline empty/drain callers in
+# dispatch-tick set this to the disposition token ('empty' / 'drain'); the
+# OnFailure= genuine-crash path leaves it unset. A benign tick ran select-tick to
+# a clean no-work decision — it is NOT a failure and must not climb the
+# consecutive-failure stall cap. See the Step-2.5 block below for the full
+# rationale (#1557's empty-routing was obsoleted by #2022's durable heartbeat).
+BENIGN="${DISPATCH_TICK_RECOVER_BENIGN:-}"
 
 # Integer tunables. Validate before any value reaches a `(( ))` arithmetic
 # context — bash arithmetic evaluates array-index command substitution (e.g.
@@ -253,8 +270,56 @@ continuation_present() {
 # Read state now so Step 3 has the current COUNT and LAST_FAILURE values.
 read_state
 
+# ---- Step 2.5: benign no-work disposition (empty/drain) — NOT a failure -----
+#
+# #1557 originally routed `empty` (and #1445 `drain`) ticks through this recover
+# counter so a queue persistently blocked on a human would eventually escalate.
+# #2022 then added the durable `dispatch-heartbeat.timer`, which re-runs a no-arg
+# tick every cycle regardless of any reseed — so the chain now self-continues
+# whether or not a benign tick arms anything. That obsoleted routing benign ticks
+# through the FAILURE counter: a benign tick that reached a clean no-work decision
+# is a SUCCESS signal, not a stall. Counting it climbs COUNT unbounded (every
+# benign cycle finds "no pending dispatch-reseed* timer") until it trips the cap
+# and files a false `dispatch:chain-stalled` latch while the chain is
+# demonstrably alive — the #2445 false positive (COUNT reached 116 from benign
+# `empty` ticks alone while workers kept spawning).
+#
+# So in benign mode: reset the count (a clean tick is success) and guarantee a
+# continuation WITHOUT ever counting a failure or escalating:
+#   - heartbeat armed OR a reseed timer pending → continuation guaranteed → no-op.
+#   - heartbeat down AND no reseed pending → the durable carrier is broken, so a
+#     benign tick really would dead-end: fall through to Step 5 to arm a single
+#     backstop reseed. The count was just reset to 0, so Step 3 yields COUNT=1
+#     (<= CAP) and Step 4 cannot escalate — a degraded carrier is repaired, never
+#     reported as a chain stall.
+# This branch never runs on the OnFailure= genuine-crash path (BENIGN unset),
+# which keeps its full count/escalate/fast-reseed behavior — recover's reason for
+# being. continuation_present alone is deliberately NOT taught the heartbeat: that
+# would blind crash recovery (a real crash must get a fast reseed and count toward
+# a crash-loop cap, not wait up to a heartbeat cycle).
+if [[ -n "$BENIGN" ]]; then
+  if (( STATE_COUNT != 0 )); then
+    write_state 0 "$STATE_LAST_FAILURE" || true
+    STATE_COUNT=0
+  fi
+  if continuation_present || heartbeat_timer_is_armed "$SYSTEMCTL_CMD"; then
+    echo "dispatch-tick-recover: benign '$BENIGN' disposition; chain carried by heartbeat/reseed; not counted as a failure" >&2
+    exit 0
+  fi
+  echo "dispatch-tick-recover: benign '$BENIGN' disposition but heartbeat not armed and no reseed pending; arming a backstop reseed (carrier degraded, not counted as a failure)" >&2
+  # Force a fresh single-attempt episode so Step 3 yields COUNT=1 and Step 4
+  # cannot escalate from a benign tick.
+  STATE_LAST_FAILURE=0
+fi
+
 if continuation_present; then
   echo "dispatch-tick-recover: continuation present; no-op" >&2
+  # A pending reseed timer genuinely carries the chain, so this failure is
+  # covered — clear any climbed count so a later crash with no pending timer
+  # starts a fresh episode instead of re-escalating off a stale count (#2445).
+  # Crash loops still escalate: a firing reseed is `--collect`'d before the next
+  # OnFailure, so the no-timer increment path is still reached when truly stuck.
+  (( STATE_COUNT != 0 )) && { write_state 0 "$STATE_LAST_FAILURE" || true; }
   exit 0
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -19694,13 +19694,21 @@ STUB
   chmod +x "$TMPDIR_TEST/bin/systemd-run"
 
   # systemctl fake: `list-units` prints \$TMPDIR_TEST/timer-units (default empty
-  # → no pending dispatch-reseed* timer). Any other subcommand is a no-op exit 0.
+  # → no pending dispatch-reseed* timer); `show` (heartbeat_timer_is_armed's
+  # SubState query) prints \$TMPDIR_TEST/hb-substate (default empty → not
+  # 'waiting' → heartbeat not armed, preserving the genuine-failure path for the
+  # pre-#2445 tests). Any other subcommand is a no-op exit 0.
   : > "$TMPDIR_TEST/timer-units"
+  : > "$TMPDIR_TEST/hb-substate"
   cat > "$TMPDIR_TEST/bin/systemctl" <<STUB
 #!/usr/bin/env bash
 for a in "\$@"; do
   if [[ "\$a" == "list-units" ]]; then
     cat "$TMPDIR_TEST/timer-units"
+    exit 0
+  fi
+  if [[ "\$a" == "show" ]]; then
+    cat "$TMPDIR_TEST/hb-substate"
     exit 0
   fi
 done
@@ -19744,6 +19752,21 @@ STUB
   chmod +x "$TMPDIR_TEST/bin/daemon-systemctl"
   export DISPATCH_DAEMON_UNIT_DIR="$TMPDIR_TEST/daemon-systemd-user"
   export DISPATCH_DAEMON_SYSTEMCTL_CMD="$TMPDIR_TEST/bin/daemon-systemctl"
+  # ensure_heartbeat_units (called at the top of recover) would otherwise write
+  # to the real ~/.config/systemd/user and run the real `systemctl --user`. Wire
+  # it to a temp unit dir and its OWN logging stub so it stays hermetic AND does
+  # not pollute daemon-systemctl-log (which the continuation-no-op / cap tests
+  # assert is empty). Note heartbeat_timer_is_armed() (the #2445 benign-mode
+  # check) uses the RECOVER systemctl ($DISPATCH_TICK_RECOVER_SYSTEMCTL_CMD, the
+  # main fake) instead, so the two heartbeat paths are independent.
+  cat > "$TMPDIR_TEST/bin/heartbeat-systemctl" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$TMPDIR_TEST/heartbeat-systemctl-log"
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/heartbeat-systemctl"
+  export DISPATCH_HEARTBEAT_UNIT_DIR="$TMPDIR_TEST/heartbeat-systemd-user"
+  export DISPATCH_HEARTBEAT_SYSTEMCTL_CMD="$TMPDIR_TEST/bin/heartbeat-systemctl"
   # ensure_daemon_service only needs a non-empty, newline/quote-free path; it
   # does not execute this binary in tests — the claude stub already exists for
   # the CLAUDE_AGENTS_CMD path, so reuse it.
@@ -19779,6 +19802,8 @@ tr_teardown() {
   unset DISPATCH_TICK_RECOVER_RESET_WINDOW
   unset DISPATCH_TICK_RECOVER_HEARTBEAT
   unset DISPATCH_DAEMON_UNIT_DIR DISPATCH_DAEMON_SYSTEMCTL_CMD DISPATCH_DAEMON_CLAUDE_CMD
+  unset DISPATCH_HEARTBEAT_UNIT_DIR DISPATCH_HEARTBEAT_SYSTEMCTL_CMD
+  unset DISPATCH_TICK_RECOVER_BENIGN
 }
 
 # tr_seed_state <count> <last_failure> — write the consecutive-failure state.
@@ -19799,6 +19824,12 @@ tr_state_count() {
   else
     echo none
   fi
+}
+
+# tr_heartbeat_armed — make the recover systemctl fake report the heartbeat timer
+# as armed (SubState=waiting), so heartbeat_timer_is_armed() returns 0.
+tr_heartbeat_armed() {
+  echo waiting > "$TMPDIR_TEST/hb-substate"
 }
 
 # --- Test 1: first failure, no continuation → arms a reseed ------------------
@@ -19893,8 +19924,12 @@ assert_eq "pending-timer: no reseed armed (systemd-run log empty)" "" "$log"
 # Continuation no-op path: ensure_daemon_service must NOT have run (no arming).
 assert_eq "pending-timer: daemon service not touched (continuation no-op)" \
   "" "$(cat "$TMPDIR_TEST/daemon-systemctl-log" 2>/dev/null || true)"
-# The timer continuation branch must NOT reset the count (state left untouched).
-assert_eq "pending-timer: state count preserved (not reset)" "2" "$(tr_state_count)"
+# The timer continuation branch resets a climbed count to 0 (#2445): a pending
+# reseed genuinely carries the chain, so this failure is covered — leaving the
+# count stale would let the next failure with no pending timer re-escalate off
+# it (the #2320→#2445 re-file pattern). Crash loops still escalate because a
+# firing reseed is --collect'd before the next OnFailure.
+assert_eq "pending-timer: climbed count reset to 0 on continuation (#2445)" "0" "$(tr_state_count)"
 tr_teardown
 
 # --- Test 4: cap reached → escalate, not retry -------------------------------
@@ -20091,6 +20126,90 @@ if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
 assert_eq "heartbeat-ge-reset: dispatch-tick-recover exits 2" "2" "$rc"
 log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
 assert_eq "heartbeat-ge-reset: no reseed armed (systemd-run log empty)" "" "$log"
+tr_teardown
+
+# --- Test 13: BENIGN empty + heartbeat armed → no-op, NOT counted (#2445) -----
+# The #2445 false positive: a benign `empty`/`drain` tick was counted as a
+# consecutive failure. With the durable heartbeat armed, a benign tick is a
+# success signal — recover must no-op and never arm a reseed or count a failure.
+echo "Test: BENIGN disposition with heartbeat armed no-ops without counting a failure (#2445)"
+tr_setup
+tr_heartbeat_armed
+export DISPATCH_TICK_RECOVER_BENIGN=empty
+# Fresh state, heartbeat armed → no reseed, no escalation, exit 0.
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "benign-armed: dispatch-tick-recover exits 0" "0" "$rc"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+assert_eq "benign-armed: no reseed armed (systemd-run log empty)" "" "$log"
+ghlog=$(cat "$TMPDIR_TEST/gh-log" 2>/dev/null || true)
+assert_eq "benign-armed: no escalation (gh log empty)" "" "$ghlog"
+tr_teardown
+
+# --- Test 14: BENIGN resets a stale/climbed count → no false escalation -------
+# Reproduces the #2445 mechanism directly: a count parked well past the cap
+# (116, as observed in production) must be RESET by a benign tick while the
+# heartbeat carries the chain — never re-escalated off the stale count.
+echo "Test: BENIGN disposition resets a climbed count and does not escalate (#2445 regression)"
+tr_setup
+tr_heartbeat_armed
+tr_seed_state 116 999000
+export DISPATCH_TICK_RECOVER_BENIGN=empty
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "benign-reset: dispatch-tick-recover exits 0" "0" "$rc"
+assert_eq "benign-reset: count reset to 0" "0" "$(tr_state_count)"
+ghlog=$(cat "$TMPDIR_TEST/gh-log" 2>/dev/null || true)
+assert_eq "benign-reset: no chain-stalled latch created (gh log empty)" "" "$ghlog"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+assert_eq "benign-reset: no reseed armed (systemd-run log empty)" "" "$log"
+tr_teardown
+
+# --- Test 15: BENIGN + heartbeat DOWN → backstop reseed, count=1, no escalate --
+# Degraded-carrier safety net: if the heartbeat is not armed and no reseed is
+# pending, a benign tick really would dead-end, so recover arms a single backstop
+# reseed. But it is still not a failure: the count lands at 1 (a fresh single
+# attempt), well under the cap, so it can never escalate from a benign tick even
+# across repeated heartbeat-down cycles.
+echo "Test: BENIGN disposition with heartbeat down arms one backstop reseed without escalating (#2445)"
+tr_setup
+# hb-substate left empty → heartbeat not armed; no reseed timer; seed a climbed
+# count to prove benign cannot escalate even from past the cap.
+tr_seed_state 116 999000
+export DISPATCH_TICK_RECOVER_BENIGN=drain
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "benign-hb-down: dispatch-tick-recover exits 0" "0" "$rc"
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+# Fresh single attempt → BASE * 2^0 = 300, reseed_at = NOW (1000000) + 300.
+TOTAL=$((TOTAL + 1))
+if [[ "$log" == *"--on-calendar=@1000300"* && "$log" == *"--unit=dispatch-reseed-1000300"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: benign-hb-down: arms a single flat backstop reseed at NOW+BASE"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: benign-hb-down: expected backstop reseed at @1000300, got: $log"
+fi
+assert_eq "benign-hb-down: count is 1 (fresh single attempt, not escalated)" "1" "$(tr_state_count)"
+ghlog=$(cat "$TMPDIR_TEST/gh-log" 2>/dev/null || true)
+assert_eq "benign-hb-down: no chain-stalled latch created (gh log empty)" "" "$ghlog"
+tr_teardown
+
+# --- Test 16: genuine-crash path (BENIGN unset) still escalates past the cap ---
+# Guard that the #2445 fix did NOT blind crash recovery: with BENIGN unset and a
+# count already past the cap, recover must still escalate (create the latch), even
+# though the heartbeat is armed. continuation_present is deliberately not taught
+# the heartbeat.
+echo "Test: genuine-crash path past cap still escalates even with heartbeat armed (#2445 guard)"
+tr_setup
+tr_heartbeat_armed
+tr_seed_state 3 999999   # NOW-last_failure (1000000-999999=1) < RESET_WINDOW → count 3→4 > cap 3
+if "$SCRIPT_DIR/dispatch-tick-recover" 2>/dev/null; then rc=0; else rc=$?; fi
+assert_eq "crash-past-cap: dispatch-tick-recover exits 0" "0" "$rc"
+ghlog=$(cat "$TMPDIR_TEST/gh-log" 2>/dev/null || true)
+TOTAL=$((TOTAL + 1))
+if [[ "$ghlog" == *"issue create"* && "$ghlog" == *"chain-stalled"* ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: crash-past-cap: escalated via chain-stalled latch issue"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: crash-past-cap: expected chain-stalled issue create, got: $ghlog"
+fi
+log=$(cat "$TMPDIR_TEST/systemd-log" 2>/dev/null || true)
+assert_eq "crash-past-cap: no reseed armed on escalation (systemd-run log empty)" "" "$log"
 tr_teardown
 
 # ============================================================================


### PR DESCRIPTION
## What

`dispatch-tick-recover` was counting benign `empty`/`drain` ticks as
consecutive *failures*, climbing the stall-cap counter unbounded and filing a
false `dispatch:chain-stalled` latch (#2445) while the chain was demonstrably
alive — workers kept spawning (#2374/#2456/#2454/#539) and the heartbeat
re-ticked every cycle. The counter reached **116** purely from benign `empty`
ticks (every cycle finds "no pending `dispatch-reseed*` timer"), 25 ticks past
where #2320 had already latched for the same condition.

## Root cause

`empty` (#1557) and `drain` (#1445) dispositions were routed through recover's
failure counter so a queue persistently blocked on a human would eventually
escalate. #2022 later added the durable `dispatch-heartbeat.timer`, which
re-runs a no-arg tick every cycle regardless of any reseed — so the chain
self-continues whether or not a benign tick arms anything. That obsoleted
routing benign ticks through the *failure* counter: a benign tick that reached a
clean no-work decision is a success signal, not a stall. With
`continuation_present()` only recognizing a `dispatch-reseed*` timer (never the
heartbeat), every benign cycle incremented the count, and because the failures
were spaced far under `RESET_WINDOW` (1h), it never reset.

## Fix

- `dispatch-tick`: the inline `empty`/`drain` recover calls now pass
  `DISPATCH_TICK_RECOVER_BENIGN=<token>`.
- `dispatch-tick-recover`: in benign mode, reset the count (success signal) and
  guarantee a continuation **without** counting a failure or escalating — no-op
  when the heartbeat is armed (or a reseed is pending); arm a single capped
  backstop reseed only if the heartbeat is genuinely down (count lands at 1, so
  a benign tick can never escalate). Also reset the count on the
  `continuation_present` healthy exit so a closed latch can't re-escalate off a
  stale count.
- The `OnFailure=` genuine-crash path (BENIGN unset) is untouched:
  `continuation_present` is deliberately **not** taught the heartbeat, so a real
  crash still gets a fast reseed and counts toward a crash-loop cap.

The deployed fix self-heals the frozen production count on the next benign tick;
no manual `recover-state.json` reset is needed. #2445 is deliberately left open
(`Closes #2445` here) — while it stays open the still-deployed old code cannot
file a third latch (recover allows one open `dispatch:chain-stalled` at a time),
and closing it early would re-file off the stale count.

### Behavior note

This intentionally ends chain-stalled auto-escalation for the `empty` case,
including a queue genuinely stuck because every leaf is parked on a human (the
original #1557 trigger). That signal is not lost: the parked
`dispatch:office-hours` items are themselves the human-facing queue. A "chain
stalled / no continuation" latch on a chain the heartbeat is actively carrying
was always false noise.

## Tests

Added four cases to the recover suite: benign+heartbeat-armed no-ops without
counting; benign resets a climbed count (116) with no latch (#2445 regression);
benign+heartbeat-down arms one capped backstop without escalating;
genuine-crash past cap still escalates even with the heartbeat armed (guards
against blinding crash recovery).

## Out of scope

The trigger was the fleet sitting below target for hours with *every* reachable
leaf worktree-conflicted/parked (stale worktrees / piled-up parks). That
underlying saturation is a separate condition, not addressed here. Related:
#2459 (latch issue omits the `dispatch:office-hours` label).

Closes #2445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
