### PR TITLE
Gate dispatch-flake-dedup reopen on run vs closing-fix recency/ancestry

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-flake-dedup
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-flake-dedup
@@ -142,11 +142,18 @@ case "$state" in
     run_head=$(jq -r '.headSha' <<<"$run_info")
 
     stale=0
+    # Track which signal(s) fired so the suppression log states the actual reason.
+    # The message differs by source: recency means the run pre-dates the close,
+    # while ancestry means the run is recent but its branch head lacks the fix —
+    # conflating them makes oscillation-incident diagnosis misleading.
+    stale_recency=0
+    stale_ancestry=0
 
     # Recency floor / fallback: run pre-dates the close. ISO-8601 UTC `Z` strings
     # compare correctly under bash lexicographic `<`.
     if [[ "$run_created" < "$closed_at" ]]; then
       stale=1
+      stale_recency=1
     fi
 
     # Ancestry (primary signal): does the run's head contain the closing fix?
@@ -159,12 +166,21 @@ case "$state" in
         status=$(gh_commit_is_ancestor_rest "$closing" "$run_head" "${local_repo_args[@]}")
         if [[ "$status" == "behind" || "$status" == "diverged" ]]; then
           stale=1
+          stale_ancestry=1
         fi
       fi
     fi
 
     if [[ "$stale" -eq 1 ]]; then
-      echo "dispatch-flake-dedup: suppressing reopen of #$match — run $run_id pre-dates closing fix (stale-head)" >&2
+      # Describe the operative signal accurately. Recency-only and both →
+      # "pre-dates closing fix"; ancestry-only → the run is recent but its branch
+      # head does not contain the fix.
+      if [[ "$stale_recency" -eq 1 ]]; then
+        stale_detail="run $run_id pre-dates closing fix (stale-head)"
+      else
+        stale_detail="branch head does not contain closing fix (stale-head)"
+      fi
+      echo "dispatch-flake-dedup: suppressing reopen of #$match — $stale_detail" >&2
       echo "STALE $match"
       exit 0
     fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-flake-dedup
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-flake-dedup
@@ -2,7 +2,7 @@
 # Deterministic, state-spanning flake-dedup guard. Given a flake fingerprint,
 # find-or-record a same-fingerprint tracking issue and tell the caller whether
 # to file fresh.
-# Usage: dispatch-flake-dedup <fingerprint> --body-file <f> [--repo owner/repo]
+# Usage: dispatch-flake-dedup <fingerprint> --body-file <f> [--run-id <id>] [--repo owner/repo]
 #
 # WHY THIS EXISTS
 #   This is the flake-path analogue of `dispatch-followup-exists` (the security
@@ -33,13 +33,30 @@
 #   than reimplement that jq here and risk divergence, this guard calls the
 #   sibling for the match and adds only the flake-specific recurrence recording
 #   (comment / reopen) on top.
+#
+# STALE-HEAD REOPEN GATE (CLOSED path only) — issue #2442
+#   A flake tracker is closed when its root cause merges to main. But a
+#   long-lived PR branch that pre-dates that fix keeps emitting the pre-fix
+#   failure signature; matching the same fingerprint on every tick would reopen
+#   the already-fixed issue indefinitely (reopen/close oscillation). So the
+#   CLOSED arm gates the reopen on whether the triggering run actually post-dates
+#   the closing fix, using two signals — suppress (report STALE, no comment, no
+#   reopen) if EITHER indicates staleness:
+#     - Recency floor / fallback: run.createdAt < issue.closedAt → STALE.
+#       ISO-8601 UTC `Z` strings compare correctly with bash lexicographic `<`.
+#     - Ancestry (primary): resolve the commit that closed the issue and compare
+#       it to the run's head SHA; `behind`/`diverged` → STALE, `ahead`/`identical`
+#       → fresh. Ancestry is undefined for a NOT_PLANNED close (no fix) or a
+#       manual close (null commit_id); in those cases fall back to recency only.
+#   --run-id is REQUIRED on the CLOSED path (validated at point of use); OPEN/NONE
+#   never consult it. fix-checks is the only caller and always passes it.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
 
 if [[ "$#" -lt 1 || -z "${1:-}" ]]; then
-  echo "error: usage: dispatch-flake-dedup <fingerprint> --body-file <f> [--repo owner/repo]" >&2
+  echo "error: usage: dispatch-flake-dedup <fingerprint> --body-file <f> [--run-id <id>] [--repo owner/repo]" >&2
   exit 2
 fi
 
@@ -48,10 +65,12 @@ shift
 
 body_file=""
 repo=""
+run_id=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --body-file) body_file="$2"; shift 2 ;;
     --repo)      repo="$2";      shift 2 ;;
+    --run-id)    run_id="$2";    shift 2 ;;
     *)
       echo "error: dispatch-flake-dedup: unexpected argument '$1'" >&2
       exit 2
@@ -85,7 +104,12 @@ if [[ -z "$match" ]]; then
 fi
 
 # 3. Match → record the recurrence on the existing issue, keyed by its state.
-state=$(gh_issue_view_rest "$match" "${local_repo_args[@]}" | jq -r '.state')
+#    Capture the whole projection once so the CLOSED arm can also read closedAt
+#    and stateReason from it without a second REST call. Per .claude/rules/
+#    shell-json.md, read fields with a here-string (jq <<<"$info"), never
+#    `echo "$info" | jq` (zsh echo would corrupt embedded \t/\n).
+info=$(gh_issue_view_rest "$match" "${local_repo_args[@]}")
+state=$(jq -r '.state' <<<"$info")
 
 case "$state" in
   OPEN)
@@ -93,6 +117,58 @@ case "$state" in
     echo "EXISTING $match"
     ;;
   CLOSED)
+    # STALE-HEAD REOPEN GATE — see the header block. Suppress the reopen when the
+    # triggering run pre-dates the fix that closed this issue; otherwise reopen.
+    closed_at=$(jq -r '.closedAt' <<<"$info")
+    state_reason=$(jq -r '.stateReason' <<<"$info")
+
+    # --run-id is required here. fix-checks always passes it; an empty value is a
+    # misconfigured caller, not a normal path — fail loud rather than reopen blind
+    # (.claude/rules/code-style.md: clear errors over silent fallbacks).
+    if [[ -z "$run_id" ]]; then
+      echo "error: dispatch-flake-dedup: --run-id is required to reopen closed issue $match (stale-head gate)" >&2
+      exit 1
+    fi
+
+    # Resolve the triggering run's createdAt + headSha. A failure here must abort,
+    # not fall through to a blind reopen. Under `set -euo pipefail` a failing
+    # command substitution in a bare assignment does abort, but capture status
+    # explicitly so the error message is specific.
+    run_info=$(gh_run_view_rest "$run_id" "${local_repo_args[@]}") || {
+      echo "error: dispatch-flake-dedup: could not resolve run $run_id for stale-head gate on issue $match" >&2
+      exit 1
+    }
+    run_created=$(jq -r '.createdAt' <<<"$run_info")
+    run_head=$(jq -r '.headSha' <<<"$run_info")
+
+    stale=0
+
+    # Recency floor / fallback: run pre-dates the close. ISO-8601 UTC `Z` strings
+    # compare correctly under bash lexicographic `<`.
+    if [[ "$run_created" < "$closed_at" ]]; then
+      stale=1
+    fi
+
+    # Ancestry (primary signal): does the run's head contain the closing fix?
+    # Undefined for a NOT_PLANNED close (no fix) or a manual close (null
+    # commit_id) — in those cases we rely on recency alone (do not set stale from
+    # ancestry). OR semantics: a stale verdict from either signal suffices.
+    if [[ "$state_reason" != "NOT_PLANNED" ]]; then
+      closing=$(gh_issue_closing_commit_rest "$match" "${local_repo_args[@]}")
+      if [[ -n "$closing" ]]; then
+        status=$(gh_commit_is_ancestor_rest "$closing" "$run_head" "${local_repo_args[@]}")
+        if [[ "$status" == "behind" || "$status" == "diverged" ]]; then
+          stale=1
+        fi
+      fi
+    fi
+
+    if [[ "$stale" -eq 1 ]]; then
+      echo "dispatch-flake-dedup: suppressing reopen of #$match — run $run_id pre-dates closing fix (stale-head)" >&2
+      echo "STALE $match"
+      exit 0
+    fi
+
     gh_issue_reopen_rest "$match" --comment "$(cat "$body_file")" "${local_repo_args[@]}"
     echo "REOPENED $match"
     ;;

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -776,6 +776,7 @@ gh_issue_view_rest() {
     state: (.state | ascii_upcase),
     stateReason: ((.state_reason // null) | (if . == null then null else ascii_upcase end)),
     createdAt: .created_at,
+    closedAt: .closed_at,
     labels: ((.labels // []) | map({name})),
     assignees: ((.assignees // []) | map({login}))
   }') || return 1
@@ -807,6 +808,125 @@ gh_issue_view_rest() {
   }
 
   jq --argjson comments "$comments" '. + {comments: $comments}' <<<"$projected"
+}
+
+# Resolve a CI run's createdAt and headSha via `gh run view` (porcelain, not
+# gh api). The GitHub Actions API is a separate REST bucket from the core REST
+# bucket used by gh api, so this call does not spend the core rate-limit.
+# Args: $1 = <run-id> (required); --repo owner/repo (optional).
+# Output: {"createdAt":"<iso8601>","headSha":"<sha>"} on stdout.
+gh_run_view_rest() {
+  local id="" repo=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) repo="$2"; shift 2 ;;
+      --*) echo "error: gh_run_view_rest: unknown flag '$1'" >&2; return 1 ;;
+      *)
+        if [[ -z "$id" ]]; then
+          id="$1"; shift 1
+        else
+          echo "error: gh_run_view_rest: unexpected argument '$1'" >&2; return 1
+        fi
+        ;;
+    esac
+  done
+  if [[ -z "$id" ]]; then
+    echo "error: gh_run_view_rest: run id is required" >&2
+    return 1
+  fi
+
+  local cmd=(gh run view "$id" --json createdAt,headSha)
+  [[ -n "$repo" ]] && cmd+=(--repo "$repo")
+
+  local out
+  out=$(gh_retry "${cmd[@]}") || {
+    echo "error: gh_run_view_rest: gh run view failed for run $id" >&2
+    return 1
+  }
+  printf '%s\n' "$out"
+}
+
+# Return the commit SHA that closed an issue, or empty string when the issue
+# was closed manually (no commit). Uses the REST issue timeline endpoint, which
+# is on the core REST rate-limit bucket.
+# Args: $1 = <N> (issue number, required); --repo owner/repo (optional).
+# Output: closing commit SHA on stdout, or empty string when none.
+gh_issue_closing_commit_rest() {
+  local num="" repo=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) repo="$2"; shift 2 ;;
+      --*) echo "error: gh_issue_closing_commit_rest: unknown flag '$1'" >&2; return 1 ;;
+      *)
+        if [[ -z "$num" ]]; then
+          num="$1"; shift 1
+        else
+          echo "error: gh_issue_closing_commit_rest: unexpected argument '$1'" >&2; return 1
+        fi
+        ;;
+    esac
+  done
+  if [[ -z "$num" ]]; then
+    echo "error: gh_issue_closing_commit_rest: issue number is required" >&2
+    return 1
+  fi
+
+  local path
+  if [[ -n "$repo" ]]; then
+    path="repos/$repo/issues/$num/timeline"
+  else
+    path="repos/{owner}/{repo}/issues/$num/timeline"
+  fi
+
+  gh_retry gh api "$path" \
+    | jq -r '[.[] | select(.event=="closed")] | last | .commit_id // empty' || {
+    echo "error: gh_issue_closing_commit_rest: gh api failed for $path" >&2
+    return 1
+  }
+}
+
+# Compare two commits via the GitHub REST compare endpoint and return their
+# relationship. Uses the core REST rate-limit bucket.
+# Args: $1 = <base-commit> (required); $2 = <head-sha> (required);
+#   --repo owner/repo (optional).
+# Output: one of: ahead / identical / behind / diverged on stdout.
+gh_commit_is_ancestor_rest() {
+  local base="" head="" repo=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) repo="$2"; shift 2 ;;
+      --*) echo "error: gh_commit_is_ancestor_rest: unknown flag '$1'" >&2; return 1 ;;
+      *)
+        if [[ -z "$base" ]]; then
+          base="$1"; shift 1
+        elif [[ -z "$head" ]]; then
+          head="$1"; shift 1
+        else
+          echo "error: gh_commit_is_ancestor_rest: unexpected argument '$1'" >&2; return 1
+        fi
+        ;;
+    esac
+  done
+  if [[ -z "$base" ]]; then
+    echo "error: gh_commit_is_ancestor_rest: base commit is required" >&2
+    return 1
+  fi
+  if [[ -z "$head" ]]; then
+    echo "error: gh_commit_is_ancestor_rest: head sha is required" >&2
+    return 1
+  fi
+
+  local path
+  if [[ -n "$repo" ]]; then
+    path="repos/$repo/compare/$base...$head"
+  else
+    path="repos/{owner}/{repo}/compare/$base...$head"
+  fi
+
+  gh_retry gh api "$path" | jq -r '.status' || {
+    echo "error: gh_commit_is_ancestor_rest: gh api failed for $path" >&2
+    return 1
+  }
 }
 
 # REST-backed drop-in for `gh pr view <N> --json

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -879,8 +879,8 @@ gh_issue_closing_commit_rest() {
     path="repos/{owner}/{repo}/issues/$num/timeline"
   fi
 
-  gh_retry gh api "$path" \
-    | jq -r '[.[] | select(.event=="closed")] | last | .commit_id // empty' || {
+  gh_retry gh api --paginate "$path" \
+    | jq -rs '[.[][] | select(.event=="closed")] | last | .commit_id // empty' || {
     echo "error: gh_issue_closing_commit_rest: gh api failed for $path" >&2
     return 1
   }

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1689,7 +1689,7 @@ assert_eq "issue: assignees narrowed to [{login}]" "alice" "$(jq -r '.assignees[
 assert_eq "issue: assignee objects carry ONLY login" "1" "$(jq '.assignees[0] | keys | length' <<<"$iv")"
 assert_eq "issue: raw REST extra field dropped" "" "$(jq -r '.extra_rest_field // empty' <<<"$iv")"
 # Top-level keys are exactly the porcelain set.
-assert_eq "issue: top-level key set" "assignees body createdAt labels number state stateReason title" \
+assert_eq "issue: top-level key set" "assignees body closedAt createdAt labels number state stateReason title" \
   "$(jq -r 'keys | join(" ")' <<<"$iv")"
 teardown
 
@@ -1702,11 +1702,14 @@ printf '%s\n' '{
   "state": "closed",
   "state_reason": "completed",
   "created_at": "2026-02-03T04:05:06Z",
+  "closed_at": "2026-02-04T05:06:07Z",
   "labels": [],
   "assignees": []
 }' > "$STUB_DIR/view-issue-9002.json"
 iv2=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 9002)
 assert_eq "issue: closed → CLOSED" "CLOSED" "$(jq -r '.state' <<<"$iv2")"
+# closedAt passthrough from closed_at (the stale-head gate's recency floor, #2442).
+assert_eq "issue: closedAt passthrough from closed_at" "2026-02-04T05:06:07Z" "$(jq -r '.closedAt' <<<"$iv2")"
 # REST lowercase state_reason `completed` → porcelain UPPERCASE enum COMPLETED.
 assert_eq "issue: stateReason completed upcased to COMPLETED" "COMPLETED" "$(jq -r '.stateReason' <<<"$iv2")"
 # A second non-null case: not_planned → NOT_PLANNED.
@@ -33191,12 +33194,28 @@ case "$args" in
     esac
     echo '{}'
     ;;
+  *"run view "*)
+    # gh_run_view_rest: `gh run view <id> --json createdAt,headSha` (porcelain,
+    # no `api` token → no collision with the api globs). Emit the run.json fixture.
+    if [[ -f "$TREE/run.json" ]]; then cat "$TREE/run.json"; else echo '{}'; fi
+    ;;
+  *"api "*"/compare/"*)
+    # gh_commit_is_ancestor_rest: `gh api .../compare/<base>...<head>`. Wrap the
+    # one-word compare-status fixture as {"status":"<word>"}; jq reads .status.
+    printf '{"status":"%s"}\n' "$(cat "$TREE/compare-status" 2>/dev/null)"
+    ;;
+  *"api "*"/issues/"*"/timeline"*)
+    # gh_issue_closing_commit_rest: `gh api .../issues/<N>/timeline`. MUST precede
+    # the VIEW glob below — `[0-9]*` matches `501/timeline`, swallowing this call.
+    if [[ -f "$TREE/timeline.json" ]]; then cat "$TREE/timeline.json"; else echo '[]'; fi
+    ;;
   *"api "*"/issues/"[0-9]*)
-    # single-issue VIEW (gh_issue_view_rest): emit a raw REST object carrying the
-    # fixture issue's lowercase state; the helper upcases it.
+    # single-issue VIEW (gh_issue_view_rest): emit a raw REST object from the
+    # fixture issue carrying its lowercase state plus snake_case closed_at /
+    # state_reason; the helper upcases state/state_reason and maps closed_at →
+    # closedAt for the stale-head gate to read.
     n="${args##*/}"
-    state=$(jq -r --argjson n "$n" '.[] | select(.number==$n) | .state' "$TREE/issues.json")
-    printf '{"number":%s,"state":"%s"}\n' "$n" "$state"
+    jq -c --argjson n "$n" '.[] | select(.number==$n) | {number, state, closed_at: (.closed_at // null), state_reason: (.state_reason // null)}' "$TREE/issues.json"
     ;;
   *"api "*"/issues"*)
     # issue LIST (gh_issue_list_rest via dispatch-followup-exists): whole fixture,
@@ -33240,16 +33259,22 @@ STUB
   assert_eq "flake-dedup: open match → no reopen" "no" "$r"
   flake_dedup_teardown
 
-  # CASE 2 — CLOSED match → REOPENED <N>, reopen fired, comment fired. (criterion #3)
+  # CASE 2 — CLOSED match, FRESH run → REOPENED <N>, reopen fired, comment fired.
+  # (criterion #3) Under the stale-head gate (#2442) the CLOSED path requires
+  # --run-id. Fresh = run.createdAt AFTER closed_at (recency fresh) AND the run
+  # head contains the closing fix (ancestry `identical`).
   flake_dedup_setup
-  printf '[{"number":501,"title":"Flaky CI: %s","state":"closed"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
+  printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-01-01T00:00:00Z"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
+  printf '{"createdAt":"2026-02-01T00:00:00Z","headSha":"headsha"}\n' > "$TMPDIR_TEST/scripts/run.json"
+  printf 'identical\n' > "$TMPDIR_TEST/scripts/compare-status"
+  printf '[{"event":"closed","commit_id":"closingsha"}]\n' > "$TMPDIR_TEST/scripts/timeline.json"
   printf 'recurred on PR #900 / run http://x\n' > "$TMPDIR_TEST/body.md"
-  out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md")
-  assert_eq "flake-dedup: closed match → REOPENED <N>" "REOPENED 501" "$out"
+  out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md" --run-id 12345)
+  assert_eq "flake-dedup: closed match, fresh run → REOPENED <N>" "REOPENED 501" "$out"
   if grep -qx '501' "$TMPDIR_TEST/scripts/stub/reopen-fired" 2>/dev/null; then r=yes; else r=no; fi
-  assert_eq "flake-dedup: closed match → reopen fired on 501" "yes" "$r"
+  assert_eq "flake-dedup: closed match, fresh run → reopen fired on 501" "yes" "$r"
   if grep -qx '501' "$TMPDIR_TEST/scripts/stub/comments-fired" 2>/dev/null; then c=yes; else c=no; fi
-  assert_eq "flake-dedup: closed match → comment fired on 501" "yes" "$c"
+  assert_eq "flake-dedup: closed match, fresh run → comment fired on 501" "yes" "$c"
   flake_dedup_teardown
 
   # CASE 3 — NO match → NONE, no side effects. (criterion #5)
@@ -33271,6 +33296,98 @@ STUB
   printf 'recurred\n' > "$TMPDIR_TEST/body.md"
   out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md")
   assert_eq "flake-dedup: canonical-title match → EXISTING <N>" "EXISTING 777" "$out"
+  flake_dedup_teardown
+
+  # === STALE-HEAD REOPEN GATE (#2442) ===
+
+  # CASE 5 — STALE by recency: run.createdAt BEFORE closed_at trips STALE even
+  # though ancestry is fresh (compare `identical`, closing commit present) —
+  # proving the recency floor ALONE suppresses the reopen. No comment, no reopen.
+  flake_dedup_setup
+  printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-02-01T00:00:00Z"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
+  printf '{"createdAt":"2026-01-01T00:00:00Z","headSha":"headsha"}\n' > "$TMPDIR_TEST/scripts/run.json"
+  printf 'identical\n' > "$TMPDIR_TEST/scripts/compare-status"
+  printf '[{"event":"closed","commit_id":"closingsha"}]\n' > "$TMPDIR_TEST/scripts/timeline.json"
+  printf 'recurred on PR #900 / run http://x\n' > "$TMPDIR_TEST/body.md"
+  out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md" --run-id 12345 2>"$TMPDIR_TEST/err")
+  assert_eq "flake-dedup: stale by recency → STALE <N>" "STALE 501" "$out"
+  if [[ -s "$TMPDIR_TEST/scripts/stub/comments-fired" ]]; then c=yes; else c=no; fi
+  assert_eq "flake-dedup: stale by recency → no comment" "no" "$c"
+  if [[ -s "$TMPDIR_TEST/scripts/stub/reopen-fired" ]]; then r=yes; else r=no; fi
+  assert_eq "flake-dedup: stale by recency → no reopen" "no" "$r"
+  if grep -q 'suppressing reopen' "$TMPDIR_TEST/err"; then g=yes; else g=no; fi
+  assert_eq "flake-dedup: stale by recency → suppression logged to stderr" "yes" "$g"
+  flake_dedup_teardown
+
+  # CASE 6 — STALE by ancestry (the discriminating case): run.createdAt is AFTER
+  # closed_at (recency says FRESH) yet the run head is `behind` the closing fix
+  # (ancestry says STALE). This is the ONLY case that fails under a recency-only
+  # implementation — the divergent stub values (created-after-close + `behind`)
+  # force the ancestry signal to carry the verdict. No comment, no reopen.
+  flake_dedup_setup
+  printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-01-01T00:00:00Z"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
+  printf '{"createdAt":"2026-02-01T00:00:00Z","headSha":"headsha"}\n' > "$TMPDIR_TEST/scripts/run.json"
+  printf 'behind\n' > "$TMPDIR_TEST/scripts/compare-status"
+  printf '[{"event":"closed","commit_id":"closingsha"}]\n' > "$TMPDIR_TEST/scripts/timeline.json"
+  printf 'recurred on PR #900 / run http://x\n' > "$TMPDIR_TEST/body.md"
+  out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md" --run-id 12345)
+  assert_eq "flake-dedup: stale by ancestry → STALE <N>" "STALE 501" "$out"
+  if [[ -s "$TMPDIR_TEST/scripts/stub/comments-fired" ]]; then c=yes; else c=no; fi
+  assert_eq "flake-dedup: stale by ancestry → no comment" "no" "$c"
+  if [[ -s "$TMPDIR_TEST/scripts/stub/reopen-fired" ]]; then r=yes; else r=no; fi
+  assert_eq "flake-dedup: stale by ancestry → no reopen" "no" "$r"
+  flake_dedup_teardown
+
+  # CASE 7 — null commit_id (manual close) → ancestry skipped → recency fallback →
+  # REOPENED. timeline commit_id is null, so the closing commit is empty and the
+  # ancestry signal is skipped; compare-status `behind` MUST be ignored. recency
+  # is fresh (run after close), so the reopen fires.
+  flake_dedup_setup
+  printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-01-01T00:00:00Z"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
+  printf '{"createdAt":"2026-02-01T00:00:00Z","headSha":"headsha"}\n' > "$TMPDIR_TEST/scripts/run.json"
+  printf 'behind\n' > "$TMPDIR_TEST/scripts/compare-status"
+  printf '[{"event":"closed","commit_id":null}]\n' > "$TMPDIR_TEST/scripts/timeline.json"
+  printf 'recurred on PR #900 / run http://x\n' > "$TMPDIR_TEST/body.md"
+  out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md" --run-id 12345)
+  assert_eq "flake-dedup: null commit_id → recency fallback → REOPENED <N>" "REOPENED 501" "$out"
+  if grep -qx '501' "$TMPDIR_TEST/scripts/stub/reopen-fired" 2>/dev/null; then r=yes; else r=no; fi
+  assert_eq "flake-dedup: null commit_id → reopen fired on 501" "yes" "$r"
+  if grep -qx '501' "$TMPDIR_TEST/scripts/stub/comments-fired" 2>/dev/null; then c=yes; else c=no; fi
+  assert_eq "flake-dedup: null commit_id → comment fired on 501" "yes" "$c"
+  flake_dedup_teardown
+
+  # CASE 8 — NOT_PLANNED close → ancestry skipped → recency fallback → REOPENED.
+  # state_reason=not_planned means there was no fix, so ancestry is skipped;
+  # compare-status `behind` and the present timeline commit_id MUST be ignored.
+  # recency is fresh (run after close), so the reopen fires.
+  flake_dedup_setup
+  printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-01-01T00:00:00Z","state_reason":"not_planned"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
+  printf '{"createdAt":"2026-02-01T00:00:00Z","headSha":"headsha"}\n' > "$TMPDIR_TEST/scripts/run.json"
+  printf 'behind\n' > "$TMPDIR_TEST/scripts/compare-status"
+  printf '[{"event":"closed","commit_id":"closingsha"}]\n' > "$TMPDIR_TEST/scripts/timeline.json"
+  printf 'recurred on PR #900 / run http://x\n' > "$TMPDIR_TEST/body.md"
+  out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md" --run-id 12345)
+  assert_eq "flake-dedup: not_planned → recency fallback → REOPENED <N>" "REOPENED 501" "$out"
+  if grep -qx '501' "$TMPDIR_TEST/scripts/stub/reopen-fired" 2>/dev/null; then r=yes; else r=no; fi
+  assert_eq "flake-dedup: not_planned → reopen fired on 501" "yes" "$r"
+  if grep -qx '501' "$TMPDIR_TEST/scripts/stub/comments-fired" 2>/dev/null; then c=yes; else c=no; fi
+  assert_eq "flake-dedup: not_planned → comment fired on 501" "yes" "$c"
+  flake_dedup_teardown
+
+  # CASE 9 — (guardrail) CLOSED match, missing --run-id → non-zero exit + stderr.
+  # The CLOSED path requires --run-id; an absent one is a misconfigured caller and
+  # must fail loud rather than reopen blind.
+  flake_dedup_setup
+  printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-01-01T00:00:00Z"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
+  printf 'recurred on PR #900 / run http://x\n' > "$TMPDIR_TEST/body.md"
+  if "$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md" 2>"$TMPDIR_TEST/err"; then ec=0; else ec=$?; fi
+  assert_eq "flake-dedup: closed match, missing --run-id → non-zero exit" "1" "$ec"
+  if grep -q 'run-id is required' "$TMPDIR_TEST/err"; then g=yes; else g=no; fi
+  assert_eq "flake-dedup: closed match, missing --run-id → stderr error" "yes" "$g"
+  if [[ -s "$TMPDIR_TEST/scripts/stub/comments-fired" ]]; then c=yes; else c=no; fi
+  assert_eq "flake-dedup: closed match, missing --run-id → no comment" "no" "$c"
+  if [[ -s "$TMPDIR_TEST/scripts/stub/reopen-fired" ]]; then r=yes; else r=no; fi
+  assert_eq "flake-dedup: closed match, missing --run-id → no reopen" "no" "$r"
   flake_dedup_teardown
 
 echo ""

--- a/.claude/skills/fix-checks/SKILL.md
+++ b/.claude/skills/fix-checks/SKILL.md
@@ -143,7 +143,17 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
      as its own tracking issue and block the PR's tracked issue on it. Push
      nothing — there is no fix to this PR. Follow these sub-steps:
 
-     1. **Compute a flake fingerprint (rigid precedence — deterministic across
+     1. **Capture the failing run id.** The Step 3 checks output lists, for each
+        check, a GitHub Actions run URL of the form
+        `https://github.com/<owner>/<repo>/actions/runs/<id>` (optionally with a
+        `/job/<job-id>` suffix). Parse the URL for the **failing** check and read
+        the numeric `<id>` segment immediately after `/actions/runs/` into
+        `RUN_ID` — that trailing all-digits run id, not any `/job/<job-id>` that
+        may follow it. This is the run whose excerpt sub-step 2 fingerprints, and
+        the run id the `dispatch-flake-dedup` guard needs for its CLOSED-path
+        stale-head comparison (sub-step 3); without it the guard's closed-issue
+        path hard-errors.
+     2. **Compute a flake fingerprint (rigid precedence — deterministic across
         runs).** The fingerprint is `<failing-check-name> — <stable-id>`, where
         `<stable-id>` is chosen by this **fixed precedence** (use the first the
         failure excerpt provides):
@@ -158,7 +168,7 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
         dedup key passed to `dispatch-flake-dedup` and (b) the verbatim trailing
         token of the canonical tracking-issue title `Flaky CI: <fingerprint>`. Use
         the **same** fingerprint value for both — do not recompute it.
-     2. **Find-or-file the flake issue (deterministic guard before
+     3. **Find-or-file the flake issue (deterministic guard before
         `/file-issue`).** A same-fingerprint tracking issue may already exist —
         **open or closed**. Run the deterministic, state-spanning guard FIRST and
         only file fresh when it reports no match. This closes the old leak where a
@@ -169,12 +179,11 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
            `tmp/`, like the accumulator): the fingerprint, the reproduce command,
            the failure excerpt, and a `recurred on PR #<pr> / run <url>` line.
         2. Run the guard, passing the fingerprint as the dedup key and the failing
-           run's id (the same run fix-checks already identified when computing the
-           fingerprint in sub-step 1):
+           run's id captured in sub-step 1 (`$RUN_ID`):
            ```bash
            DISP=$(.claude/skills/dispatch-propagate/scripts/dispatch-flake-dedup \
              "<fingerprint>" --body-file tmp/flake-recurrence.md \
-             --run-id <run-id>)
+             --run-id "$RUN_ID")
            ```
            It prints exactly one line: `NONE`, `EXISTING <N>`, `REOPENED <N>`, or
            `STALE <N>`.
@@ -193,14 +202,14 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
              it: the PR branch is stale and is still emitting the pre-fix
              signature. The guard fired no comment and no reopen — suppressing the
              oscillation is the point. Do **not** file. Do **not** reopen. Flake
-             issue = `#<N>`, disposition `STALE`. **Skip sub-step 3 (block the
+             issue = `#<N>`, disposition `STALE`. **Skip sub-step 4 (block the
              PR's tracked issue)** — wiring a `blocked_by` dependency here is
              deferred by design: the STALE disposition stops the reopen oscillation
              only; a stale PR branch that keeps emitting the pre-fix signature is
              the upstream subagent's "main already fixed it" classification job
              (merge main), tracked separately. Record the accumulator note (sub-step
-             4) marking this recurrence as suppressed-stale, then fall through
-             directly to sub-step 5 (post accumulator, push nothing).
+             5) marking this recurrence as suppressed-stale, then fall through
+             directly to sub-step 6 (post accumulator, push nothing).
            - **`NONE`** — no same-fingerprint issue exists; file one via
              `/file-issue` as before. Launch a subagent (`subagent_type:
              general-purpose`, `model: sonnet`) that invokes `/file-issue` via the
@@ -232,7 +241,7 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
                pre-existing (possibly human-filed, differently-titled) issue. Do
                **NOT** reassert its title — re-titling an unrelated issue would
                corrupt it. Flake issue = `#<M>`, disposition `EXISTING`.
-     3. **Block the PR's tracked issue on the flake issue.** In this thread, use
+     4. **Block the PR's tracked issue on the flake issue.** In this thread, use
         the PR body already captured in Step 1's pack output (`=== PR ===` section)
         and parse its `Closes #N` line(s) for the issue(s) this PR implements. For **each** tracked issue, record a
         `blocked_by` dependency **on that tracked issue, targeting each flake issue
@@ -250,10 +259,10 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
         `REOPENED`) — it makes no open-only assumption about the flake issue's
         state. **`STALE` is the one exception: skip this sub-step entirely** —
         deferred by design (see the `STALE` branch above).
-     4. **Record a flake iteration in the accumulator** (the skill's top-level
+     5. **Record a flake iteration in the accumulator** (the skill's top-level
         Step 7) — see [Accumulator](#accumulator); a flake entry is visually
         distinct from a generic no-repro one.
-     5. **Post the accumulator (Step 8) and stop (Step 9). Push nothing** — the
+     6. **Post the accumulator (Step 8) and stop (Step 9). Push nothing** — the
         same terminal behavior as the generic no-repro outcome. On the next
         `/dispatch-propagate` run the PR's tracked issue carries a `blocked_by` against the
         flake issue; `/dispatch-propagate`'s queue scan skips blocked issues, so the PR is

--- a/.claude/skills/fix-checks/SKILL.md
+++ b/.claude/skills/fix-checks/SKILL.md
@@ -168,12 +168,16 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
         1. Write the recurrence body to `tmp/flake-recurrence.md` (git-ignored
            `tmp/`, like the accumulator): the fingerprint, the reproduce command,
            the failure excerpt, and a `recurred on PR #<pr> / run <url>` line.
-        2. Run the guard, passing the fingerprint as the dedup key:
+        2. Run the guard, passing the fingerprint as the dedup key and the failing
+           run's id (the same run fix-checks already identified when computing the
+           fingerprint in sub-step 1):
            ```bash
            DISP=$(.claude/skills/dispatch-propagate/scripts/dispatch-flake-dedup \
-             "<fingerprint>" --body-file tmp/flake-recurrence.md)
+             "<fingerprint>" --body-file tmp/flake-recurrence.md \
+             --run-id <run-id>)
            ```
-           It prints exactly one line: `NONE`, `EXISTING <N>`, or `REOPENED <N>`.
+           It prints exactly one line: `NONE`, `EXISTING <N>`, `REOPENED <N>`, or
+           `STALE <N>`.
            Parse it into a disposition and (when present) the issue number `<N>`.
         3. Branch on the disposition:
            - **`EXISTING <N>`** — a same-fingerprint issue is already open and the
@@ -184,6 +188,19 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
              recurrence (the "closed-as-fixed but still firing" signal a human
              should see on one issue, not N dups). Do **not** file. Flake issue =
              `#<N>`, disposition `REOPENED`.
+           - **`STALE <N>`** — a same-fingerprint issue was closed-as-fixed and
+             the guard determined this triggering run pre-dates the fix that closed
+             it: the PR branch is stale and is still emitting the pre-fix
+             signature. The guard fired no comment and no reopen — suppressing the
+             oscillation is the point. Do **not** file. Do **not** reopen. Flake
+             issue = `#<N>`, disposition `STALE`. **Skip sub-step 3 (block the
+             PR's tracked issue)** — wiring a `blocked_by` dependency here is
+             deferred by design: the STALE disposition stops the reopen oscillation
+             only; a stale PR branch that keeps emitting the pre-fix signature is
+             the upstream subagent's "main already fixed it" classification job
+             (merge main), tracked separately. Record the accumulator note (sub-step
+             4) marking this recurrence as suppressed-stale, then fall through
+             directly to sub-step 5 (post accumulator, push nothing).
            - **`NONE`** — no same-fingerprint issue exists; file one via
              `/file-issue` as before. Launch a subagent (`subagent_type:
              general-purpose`, `model: sonnet`) that invokes `/file-issue` via the
@@ -231,7 +248,8 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
         fingerprint does not re-add the dependency or error. This step consumes
         `<N>` uniformly for every disposition (`CREATED`, `EXISTING`, or
         `REOPENED`) — it makes no open-only assumption about the flake issue's
-        state.
+        state. **`STALE` is the one exception: skip this sub-step entirely** —
+        deferred by design (see the `STALE` branch above).
      4. **Record a flake iteration in the accumulator** (the skill's top-level
         Step 7) — see [Accumulator](#accumulator); a flake entry is visually
         distinct from a generic no-repro one.
@@ -345,8 +363,10 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
   - **Fix** — the fix applied and its commit SHA. Include only when **Outcome**
     is `fixed`; omit otherwise.
   - **Flake issue** — *`flake` outcome only* — the canonical tracking issue, written
-    as `#<N> (CREATED)`, `#<N> (EXISTING)`, or `#<N> (REOPENED)` per the
-    `dispatch-flake-dedup` / `/file-issue` disposition. Omit for every other outcome.
+    as `#<N> (CREATED)`, `#<N> (EXISTING)`, `#<N> (REOPENED)`, or
+    `#<N> (STALE-SUPPRESSED)` per the `dispatch-flake-dedup` / `/file-issue`
+    disposition. `STALE-SUPPRESSED` marks a recurrence suppressed as a stale-head
+    false positive — no reopen was fired. Omit for every other outcome.
   - **Fingerprint** — *`flake` outcome only* — the dedupe key computed in the
     Flake sub-path (the failing check name plus the stable identifier). Omit for
     every other outcome.


### PR DESCRIPTION
Closes #2442

## Problem

`dispatch-flake-dedup` is the idempotent guard the flake-filing path runs before
`/file-issue`. On a CLOSED same-fingerprint match it **reopened** the tracking
issue on *any* same-fingerprint CI failure, with no check that the triggering run
post-dates the fix that closed the issue.

A long-lived PR branch that predates a merged flake fix keeps emitting the
*pre-fix* failure signature. Each `/dispatch-propagate` tick read that as a fresh
recurrence, reopened the already-fixed issue, and re-filed evidence — an endless
reopen/close oscillation on an issue that is genuinely fixed on `main`. Concrete
instance: #2381 was reopened twice citing the same CI run created ~2h *before* its
fix merged, on a stale branch 34 commits behind `main`. This is the flake-dedup
analogue of the known fix-checks stale-head misclassification.

## The fix

Gate the **CLOSED branch only** (OPEN issues have no close to pre-date) on two
signals, suppressing the reopen (new `STALE <N>` disposition) when *either*
indicates the run is stale:

- **Ancestry (primary)** — resolve the commit that closed the issue (last `closed`
  timeline event's `commit_id`), then `GET /compare/{closing}...{run_head}`;
  `behind`/`diverged` = run head lacks the fix = **stale**.
- **Recency (floor / fallback)** — `run.created_at < issue.closed_at` = **stale**.
  Used whenever ancestry is indeterminate (`NOT_PLANNED` close, or a manual close
  with a null `commit_id`).

On `STALE`, the guard fires no comment and no reopen and prints `STALE <N>`.
fix-checks treats `STALE` as a suppressed recurrence: it does not file, reopen, or
block the PR's tracked issue, and records it as `STALE-SUPPRESSED` in its
accumulator.

## Out of scope (deferred by design)

`STALE` fixes the *issue reopen-oscillation* only. It deliberately does **not**
block the PR's tracked issue: a stale-branch PR that keeps hitting the pre-fix
flake is the upstream subagent's "main already fixed it" classification job (merge
`main`), tracked separately.

## Units

- **A** — `lib.sh`: add `closedAt` to the `gh_issue_view_rest` projection; add thin
  REST helpers `gh_run_view_rest`, `gh_issue_closing_commit_rest`,
  `gh_commit_is_ancestor_rest`.
- **B** — `dispatch-flake-dedup`: `--run-id` flag, refactor the state read, rewrite
  the CLOSED arm as the recency+ancestry gate emitting `STALE`/`REOPENED`.
- **C** — `fix-checks/SKILL.md`: pass `--run-id`, handle the `STALE` disposition.
- **D** — `test-dispatch-scripts.sh`: extend the gh stub (timeline/compare/run-view
  branches, snake_case fixtures), convert CASE 2 to fresh→REOPENED, and add
  STALE-by-recency, the discriminating STALE-by-ancestry, null-commit_id and
  NOT_PLANNED recency-fallback, and missing-`--run-id` guardrail cases.

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` —
**4008/4008 passed, 0 failed**, including the discriminating STALE-by-ancestry case
(run created *after* close + compare `behind`), the only case that fails under a
recency-only implementation.
