### PR TITLE
review-fix: drop the redundant generic /review quality finder

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-review-finders
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-review-finders
@@ -5,7 +5,7 @@
 #
 # Reads three key=value lines on stdin (as emitted by dispatch-security-surface),
 # in any order, blank lines ignored:
-#   surface=<empty|docs|code>
+#   surface=<empty|docs|tests|code>
 #   deps=<true|false>
 #   app_or_rules=<true|false>
 # Missing keys default to: surface=empty, deps=false, app_or_rules=false.
@@ -24,7 +24,7 @@
 #   erosion              (surface==code)
 #   npm                  (deps==true)
 #
-# surface empty/docs => exactly code-review (zero security finders).
+# surface empty/docs/tests => exactly code-review (zero security finders).
 # surface==code       => 4 always-on security finders + codeql + erosion.
 # app_or_rules==true  => additionally auth, data-exposure, firebase (7 total).
 # deps==true          => additionally npm (independent of surface).
@@ -53,7 +53,7 @@ done
 
 # --- emit finder set ------------------------------------------------------------
 
-# Always-present finder (review quality, all surfaces including empty/docs).
+# Always-present finder (review quality, all surfaces including empty/docs/tests).
 echo "code-review"
 
 # Security finders: only when surface==code.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-review-finders
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-review-finders
@@ -13,7 +13,6 @@
 # Prints finder source names to stdout, one per line, in this fixed order,
 # omitting any not warranted by the surface flags:
 #   code-review          (always)
-#   review               (always)
 #   input-validation     (surface==code)
 #   secrets              (surface==code)
 #   red-team             (surface==code)
@@ -25,7 +24,7 @@
 #   erosion              (surface==code)
 #   npm                  (deps==true)
 #
-# surface empty/docs => exactly code-review and review (zero security finders).
+# surface empty/docs => exactly code-review (zero security finders).
 # surface==code       => 4 always-on security finders + codeql + erosion.
 # app_or_rules==true  => additionally auth, data-exposure, firebase (7 total).
 # deps==true          => additionally npm (independent of surface).
@@ -54,9 +53,8 @@ done
 
 # --- emit finder set ------------------------------------------------------------
 
-# Always-present finders (review quality, all surfaces including empty/docs).
+# Always-present finder (review quality, all surfaces including empty/docs).
 echo "code-review"
-echo "review"
 
 # Security finders: only when surface==code.
 if [[ "$surface" == "code" ]]; then

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -32089,15 +32089,13 @@ assert_eq "qa-needs-main-followup: 2-item input → length 2" "2" "$(printf '%s'
 
 echo "Test: dispatch-review-finders"
 
-# empty surface → exactly code-review and review
+# empty surface → exactly code-review
 out=$(printf 'surface=empty\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders")
-assert_eq "finders: empty → code-review,review only" "code-review
-review" "$out"
+assert_eq "finders: empty → code-review only" "code-review" "$out"
 
-# docs surface → exactly code-review and review
+# docs surface → exactly code-review
 out=$(printf 'surface=docs\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders")
-assert_eq "finders: docs → code-review,review only" "code-review
-review" "$out"
+assert_eq "finders: docs → code-review only" "code-review" "$out"
 
 # code + app_or_rules=false + deps=false → 4 always-on security finders present
 n=$(printf 'surface=code\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -cE '^(input-validation|secrets|red-team|security-review)$')
@@ -32135,10 +32133,9 @@ assert_eq "finders: code surface → codeql present" "1" "$n"
 n=$(printf 'surface=docs\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -c '^codeql$' || true)
 assert_eq "finders: docs surface → codeql absent" "0" "$n"
 
-# tests surface → exactly code-review and review (no security finders)
+# tests surface → exactly code-review (no security finders)
 out=$(printf 'surface=tests\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders")
-assert_eq "finders: tests → code-review,review only" "code-review
-review" "$out"
+assert_eq "finders: tests → code-review only" "code-review" "$out"
 
 # ============================================================================
 # === dispatch-review-dedup ===

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-fix
-description: Review phase — the workflow's single terminal review pass. Runs the combined /review-fix fan-out through the Workflow tool: surface-conditional finders (code-review, review, security domain reviewers) in parallel → code dedup → classify → adversarial-verify (Required findings refuted by severity-scaled skeptics — 2 for high-confidence, 1 below — before any Opus fix runs) → Opus fix fan-out → deferred/follow-up filing prep. Returns a compact disposition summary; applies fixes via one /commit-merge-push, files blocked_by follow-ups, posts one PR comment, and applies the dispatch:reviewed label
+description: Review phase — the workflow's single terminal review pass. Runs the combined /review-fix fan-out through the Workflow tool: surface-conditional finders (code-review, security domain reviewers) in parallel → code dedup → classify → adversarial-verify (Required findings refuted by severity-scaled skeptics — 2 for high-confidence, 1 below — before any Opus fix runs) → Opus fix fan-out → deferred/follow-up filing prep. Returns a compact disposition summary; applies fixes via one /commit-merge-push, files blocked_by follow-ups, posts one PR comment, and applies the dispatch:reviewed label
 ---
 
 # Review and Fix
@@ -360,26 +360,26 @@ Step 6 comment or note that no code changes were applied.
 
 Every finding from every source appears exactly once in one of these buckets. The
 Workflow's classifier preserves **both** vocabularies: the security pass's
-`required` / `out-of-scope` / `false-positive` axis and the code-review/review
+`required` / `out-of-scope` / `false-positive` axis and the code-review
 `Fixed` / `Informational` / `Dismissed` / `Deferred` axis.
 
 | Bucket | Source vocabulary | Meaning |
 |---|---|---|
-| Fixed | code-review/review | A concrete, in-scope code change applicable to this PR — applied by the Workflow's Opus fix agents. |
+| Fixed | code-review | A concrete, in-scope code change applicable to this PR — applied by the Workflow's Opus fix agents. |
 | Required | security | A real vulnerability or weakness in the changed code. Adversarially verified; upheld Required findings applied by the Workflow's Opus fix agents. |
 | Refuted | security | A Required finding refuted by the adversarial-verify step — dropped before any Opus fix, recorded in verify_report. |
-| Informational | code-review/review | FYIs, notes, observations surfaced for human reference; no change required. |
-| Dismissed | code-review/review | Nits, incorrect findings, or not applicable; no change, each with a one-line rationale. |
+| Informational | code-review | FYIs, notes, observations surfaced for human reference; no change required. |
+| Dismissed | code-review | Nits, incorrect findings, or not applicable; no change, each with a one-line rationale. |
 | False-positive | security | Not an actual vulnerability — a misread of the code or a non-issue; each with a one-line rationale. |
-| Deferred | code-review/review | Valid but out of scope for this PR; filed as a `blocked_by` follow-up in Step 6. |
+| Deferred | code-review | Valid but out of scope for this PR; filed as a `blocked_by` follow-up in Step 6. |
 | Out-of-scope | security | A genuine concern, but in pre-existing code the diff did not touch; meaningful CodeQL/npm out-of-scope findings are filed as `security` follow-ups in Step 6. |
 
 A finding is **never Dismissed/Disregarded purely because the change is small.**
-If a code-review/review finding is a real improvement within the PR's scope,
+If a code-review finding is a real improvement within the PR's scope,
 classify it Fixed and implement it — regardless of how trivial the diff is.
 Dismissed is for false positives, trivially wrong findings, or style preferences
 that are not actual improvements; smallness alone never qualifies (out-of-scope
-items go to Deferred, not Dismissed). When a code-review/review finding is
+items go to Deferred, not Dismissed). When a code-review finding is
 ambiguous, default to Informational rather than inventing a code change.
 
 ### 5. File meaningful out-of-scope findings as blocked_by follow-ups
@@ -423,7 +423,7 @@ create_out=$(gh label create "dispatch:review-followup" \
   || echo "review-fix: warning: could not ensure dispatch:review-followup label: $create_out" >&2
 ```
 
-#### 5a. Deferred code-review/review findings → `/file-issue` with a blocked-by link
+#### 5a. Deferred code-review findings → `/file-issue` with a blocked-by link
 
 The Workflow prepares `result.deferred_filings`, each entry carrying `title`,
 `body`, and `blocker_issue_nums` (the implementing issue numbers from
@@ -570,7 +570,7 @@ directory. Organize the body by disposition bucket, omitting any bucket with no
 entries (on a docs-only / empty diff the security note from `result.security_note`
 stands in for the security buckets):
 
-- **Fixed** — code-review/review findings implemented; one line per finding plus
+- **Fixed** — code-review findings implemented; one line per finding plus
   the fix commit SHA from Step 3.
 - **Required (security)** — security findings fixed; one line per finding plus the
   fix commit SHA, or the reason if left unresolved.
@@ -579,10 +579,10 @@ stands in for the security buckets):
   verdict and rationale. These were **not** fixed; include the skeptic rationale
   so the audit trail explains the drop.
 - **Informational** — surfaced for human reference; no action.
-- **Dismissed** — code-review/review false positives or nits; each with a
+- **Dismissed** — code-review false positives or nits; each with a
   one-line rationale.
 - **False-positive (security)** — each with a one-line rationale.
-- **Deferred** — out-of-scope code-review/review findings; each references its
+- **Deferred** — out-of-scope code-review findings; each references its
   follow-up issue `#<N>` from Step 5a.
 - **Out-of-scope (security)** — pre-existing CodeQL/npm findings; each meaningful
   one references its follow-up issue `#<N>` from Step 5b. CodeQL-sourced findings
@@ -819,7 +819,7 @@ through to the unified set — has these fields:
   several sources on one finding.
 - **OWASP** — the OWASP Top 10 (2021) category (e.g. `A01:2021 Broken Access
   Control`, `A03:2021 Injection`). Security findings only; empty for
-  code-review/review findings.
+  code-review findings.
 - **STRIDE** — one of Spoofing, Tampering, Repudiation, Information Disclosure,
   Denial of Service, Elevation of Privilege. Security findings only.
 - **Confidence** — `high`, `medium`, or `low`.
@@ -831,7 +831,7 @@ through to the unified set — has these fields:
 
 - **Empty, docs-only, or test-only diff** — `surface` is `empty`, `docs`, or
   `tests`; the Workflow launches no security finders and no security agents. The
-  code-review and review agents still run. The skill still applies
+  code-review agent still runs. The skill still applies
   `dispatch:reviewed` and writes the marker.
 - **A finder finds nothing** — record that source as clean; it contributes no
   findings to the Workflow.
@@ -868,7 +868,7 @@ something re-entry asserts.
 **Model split (#1172).** The dispatch chain runs this `review` phase orchestrator
 on **Sonnet** (via `dispatch-phase-model`, which maps `review →
 claude-sonnet-4-6`). The model tiering is now owned by the Workflow's per-`agent()`
-`model:` settings: finder agents (code-review, review, security domains) run on
+`model:` settings: finder agents (code-review, security domains) run on
 **Sonnet**, dedup/classify/verify agents run on **Sonnet**, and **fix-authoring
 Opus fix agents** (`model: opus`) write all working-tree changes. Fix-authoring is
 pinned to Opus **exactly once** in the Workflow's fix phase — there is no
@@ -876,15 +876,19 @@ double-tiering. The orchestrator (this skill) authors no product code.
 
 **Probe-wave throttle short-circuit (#1857).** On a `code` surface the Workflow
 splits the finder fan-out into two waves instead of one barrier. Wave 1 launches
-only the two always-on quality finders (`code-review`, `review`) — real review
-work that runs on every surface — and doubles them as a throttle probe. If **both**
-return `null` (a strong outage signal — far more robust than a single flake), the
-Workflow skips the security finder wave entirely rather than waste those launches
-on a throttled model, and sets `result.coverage_incomplete = true` with a human
-`result.coverage_note` (surfaced in the Step 6 partial-coverage line). Otherwise
-wave 2 launches the surface-gated security finders. On `empty`/`docs`/`tests`
-surfaces there are no security finders, so this degenerates to a single wave (no
-change). **Marker/label behavior is intentionally unchanged:** a throttled run
+only the single always-on `code-review` quality finder — real review work that
+runs on every surface — and doubles it as a throttle probe. If it returns `null`,
+the Workflow skips the security finder wave entirely rather than waste those
+launches on a throttled model, and sets `result.coverage_incomplete = true` with a
+human `result.coverage_note` (surfaced in the Step 6 partial-coverage line). The
+`agent()` primitive already retries internally, so a `null` result is a repeated
+failure after retries — a genuine outage signal, not a one-off flake. This
+deliberately accepts the reduced throttle-probe robustness of a single finder
+(versus the prior two): the internal retry means `null` already means "failed
+after retries". Otherwise wave 2 launches the surface-gated security finders. On
+`empty`/`docs`/`tests` surfaces there are no security finders, so this degenerates
+to a single wave (no change). **Marker/label behavior is intentionally unchanged:**
+a throttled run
 still applies `dispatch:reviewed` and writes the marker — this matches today's
 behavior when all finders return `null`, producing a degraded quality-only review.
 This is a launch-efficiency change only; genuine worker *death* on a transient

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -6,7 +6,7 @@ description: Review phase — the workflow's single terminal review pass. Runs t
 # Review and Fix
 
 The `review` phase of the issue workflow, dispatched by the dispatch chain. This
-skill consolidates what were three separate review phases — code-review, review,
+skill consolidates what were three separate review phases — code-review, generic review,
 and security — into one pass over a single diff. It invokes the **Workflow tool**
 on `.claude/workflows/review-fix.js`, which fans out surface-conditional finders,
 deduplicates and classifies findings in code, adversarially verifies `Required`

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -989,7 +989,7 @@ return {
   deviation,
   security_note: _a.security_note,
   // coverage_incomplete is independent of `deviation`: it flags a launch-efficiency
-  // back-off (security wave skipped because both quality finders died — model
+  // back-off (security wave skipped because the code-review quality finder failed — model
   // likely throttled), surfaced in the Step 6 partial-coverage comment line.
   coverage_incomplete,
   coverage_note,

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -78,7 +78,6 @@ const FINDING_ITEM_SCHEMA = {
     Source: {
       enum: [
         'code-review',
-        'review',
         'input-validation',
         'secrets',
         'red-team',
@@ -180,10 +179,10 @@ const FIX_SCHEMA = {
 // Returns the AGENT finder-source set (the codeql/npm finders are NOT agents —
 // they arrive via args.prescanned_findings — so they are excluded here).
 function agentFinderSet(surface, app_or_rules) {
-  // Any non-`code` surface (`empty`/`docs`/`tests`) yields only the two quality
-  // finders — the `surface === 'code'` gate below covers `tests` with no code
+  // Any non-`code` surface (`empty`/`docs`/`tests`) yields only the single quality
+  // finder — the `surface === 'code'` gate below covers `tests` with no code
   // change, since a test-only diff has no production attack surface.
-  const set = ['code-review', 'review'];
+  const set = ['code-review'];
   if (surface === 'code') {
     set.push('input-validation', 'secrets', 'red-team', 'security-review');
     if (app_or_rules) {
@@ -330,16 +329,6 @@ function finderPrompt(name, args) {
       SCHEMA_BLURB,
     ].join('\n');
   }
-  if (name === 'review') {
-    return [
-      'You are a findings-only PR-review subagent.',
-      'Invoke the built-in `/review` skill via the Skill tool — the generic PR review.',
-      ctx,
-      'Once /review returns, continue: normalize every finding it produced to the schema below',
-      'with Source "review" and OWASP "" and STRIDE "".',
-      SCHEMA_BLURB,
-    ].join('\n');
-  }
   if (name === 'security-review') {
     return [
       'You are a findings-only security-review subagent.',
@@ -381,16 +370,18 @@ let subagentsLaunched = 0;
 // --- 1. FINDERS (two waves, probe-gated) -------------------------------------
 phase('finders');
 const finderNames = agentFinderSet(_a.surface, _a.app_or_rules);
-// Probe-wave throttle short-circuit: the two always-on quality finders are real
-// review work that runs on every surface, so launch them FIRST as wave 1 and
-// double them as a throttle probe. If BOTH return null (a strong outage signal —
-// far more robust than one flake), skip the security finder wave entirely rather
-// than waste those launches on a throttled model. On empty/docs/tests surfaces
-// there are no security finders, so this degenerates to a single wave (no change).
-const qualityFinders = finderNames.filter((n) => n === 'code-review' || n === 'review');
-const securityFinders = finderNames.filter((n) => n !== 'code-review' && n !== 'review');
+// Probe-wave throttle short-circuit: the single always-on `code-review` quality
+// finder is real review work that runs on every surface, so launch it FIRST as
+// wave 1 and double it as a throttle probe. The `agent()` primitive already
+// retries internally, so a `null` result means the finder failed AFTER retries —
+// a genuine outage signal, not a one-off flake. On that signal, skip the security
+// finder wave entirely rather than waste those launches on a throttled model. On
+// empty/docs/tests surfaces there are no security finders, so this degenerates to
+// a single wave (no change).
+const qualityFinders = finderNames.filter((n) => n === 'code-review');
+const securityFinders = finderNames.filter((n) => n !== 'code-review');
 log(
-  `finders: wave 1 = ${qualityFinders.length} quality finder(s); ` +
+  `finders: wave 1 = ${qualityFinders.length} quality finder; ` +
     `${securityFinders.length} security finder(s) pending for surface=${_a.surface}`
 );
 
@@ -403,20 +394,20 @@ const launchFinder = (name) => () =>
     phase: 'finders',
   });
 
-// Wave 1 — the quality finders (also the throttle probe).
+// Wave 1 — the quality finder (also the throttle probe).
 subagentsLaunched += qualityFinders.length;
 const qualityResults = await parallel(qualityFinders.map(launchFinder));
 
-// Gate: both quality finders dead → model likely throttled; skip the security
+// Gate: the quality finder is dead → model likely throttled; skip the security
 // wave. coverage_incomplete records the degraded review for the Step 6 comment.
 let securityResults = [];
 let coverage_incomplete = false;
 let coverage_note = '';
-const bothQualityDead = qualityResults.filter(Boolean).length === 0;
-if (securityFinders.length && bothQualityDead) {
+const qualityDead = qualityResults.filter(Boolean).length === 0;
+if (securityFinders.length && qualityDead) {
   coverage_incomplete = true;
   coverage_note =
-    'Security finders skipped: both quality finders failed (model likely throttled).';
+    'Security finders skipped: the code-review quality finder failed (model likely throttled).';
   log(`finders: ${coverage_note} Backing off the security wave.`);
 } else if (securityFinders.length) {
   // Wave 2 — the surface-gated security finders.
@@ -546,12 +537,12 @@ if (deduped.length) {
   const classifyPrompt = [
     'Classify each finding into exactly one disposition bucket, preserving BOTH vocabularies.',
     'Disposition table (from /review-fix SKILL.md Step 3):',
-    '- Fixed (code-review/review): a concrete, in-scope code change applicable to this PR — implement it.',
+    '- Fixed (code-review): a concrete, in-scope code change applicable to this PR — implement it.',
     '- Required (security): a real vulnerability/weakness in the changed code that should be fixed.',
-    '- Informational (code-review/review): FYIs/notes/observations; no change required.',
-    '- Dismissed (code-review/review): nits, incorrect findings, or N/A; one-line rationale.',
+    '- Informational (code-review): FYIs/notes/observations; no change required.',
+    '- Dismissed (code-review): nits, incorrect findings, or N/A; one-line rationale.',
     '- False-positive (security): not an actual vulnerability — a misread / non-issue.',
-    '- Deferred (code-review/review): valid but out of scope for this PR (filed as a follow-up).',
+    '- Deferred (code-review): valid but out of scope for this PR (filed as a follow-up).',
     '- Out-of-scope (security): a genuine concern in pre-existing code the diff did not touch.',
     '- Fixed (erosion): an actionable net-erosion finding (Source "erosion") with a concrete refactor',
     '  that reverses the structural decay this diff introduced → Fixed (it runs the same adversarial',
@@ -559,10 +550,10 @@ if (deduped.length) {
     '- Informational (erosion): an advisory complexity/duplication increase with no clear single refactor',
     '  → Informational (an FYI; no change required and nothing is filed).',
     'RULES: A finding is NEVER Dismissed merely because the change is small — if it is a real',
-    'improvement within scope, classify it Fixed. When a code-review/review finding is ambiguous,',
+    'improvement within scope, classify it Fixed. When a code-review finding is ambiguous,',
     'default to Informational rather than inventing a code change.',
     'Also set security_class: "required" | "out-of-scope" | "false-positive" for security-sourced',
-    'findings, else "none" for code-review/review findings.',
+    'findings, else "none" for code-review findings.',
     'Return { "classifications": [ { "id", "bucket", "security_class" }, ... ] } — one per finding id.',
     `Findings:\n${JSON.stringify(compact, null, 2)}`,
   ].join('\n');
@@ -582,7 +573,7 @@ if (deduped.length) {
   }
   if (!classById.size) {
     log(
-      `classify: agent returned no usable classifications for ${deduped.length} finding(s) — falling back per-source (code-review/review → Deferred so they are filed, security → Out-of-scope)`
+      `classify: agent returned no usable classifications for ${deduped.length} finding(s) — falling back per-source (code-review → Deferred so they are filed, security → Out-of-scope)`
     );
   }
   const SEC_SOURCES = new Set([
@@ -600,7 +591,7 @@ if (deduped.length) {
     const c = classById.get(f.id);
     // Fallback when the classify agent gave no verdict for this finding: erosion
     // sources → Informational (advisory, not filed) per the Informational-erosion
-    // design intent; security sources → Out-of-scope; code-review/review → Deferred
+    // design intent; security sources → Out-of-scope; code-review → Deferred
     // (NOT Informational) so an unclassified-but-real finding is filed as a follow-up
     // rather than silently dropped from both the fix set and the follow-up filings.
     const bucket = c
@@ -837,7 +828,7 @@ const upheldErosionIds = new Set(
 // --- 6. FILE-PREP (pure JS, no gh) -------------------------------------------
 phase('file');
 
-// 6a. Deferred code-review/review findings → deferred_filings.
+// 6a. Deferred code-review findings → deferred_filings.
 function shortTitle(desc) {
   const text = (desc || '').trim();
   const firstSentence = text.split(/(?<=[.!?])\s/)[0] || text;
@@ -850,7 +841,7 @@ const blockerNums =
     : 'independent';
 
 const deferred_filings = deduped
-  // Deferred code-review/review findings, Unverified Required findings (every
+  // Deferred code-review findings, Unverified Required findings (every
   // skeptic failed), plus (issue #2064) upheld erosion findings Opus did NOT fix:
   // none are resolved in this terminal phase, so file a follow-up rather than
   // silently dropping them. A REFUTED erosion finding falls through all three


### PR DESCRIPTION
Closes #2461

## What

Drop the redundant always-on generic `review` quality finder from the
`/review-fix` fan-out, leaving `code-review` (the built-in `/code-review` skill at
`max` effort) as the single always-on quality finder.

`/code-review max` is now the broad-coverage correctness + cleanup review; the
generic `/review` no longer adds coverage on top of it. Running both was
duplicated review work — extra subagent spend and duplicate findings the dedup
stage had to collapse — with no added signal. This is the follow-on
simplification to the original three-phase consolidation (#1069 / #1091), which
created the two quality finders.

## Changes

- **`.claude/workflows/review-fix.js`** — removed `'review'` from the `Source`
  enum, the `agentFinderSet` list, and `finderPrompt`; the quality/security
  partition now keys on `code-review` only. The throttle-probe gate is reworked
  **mechanically only** (no new control flow): `bothQualityDead` → `qualityDead`,
  recomputed over the one-element quality-finder array, with reworded
  comments/`coverage_note`/log wording describing the single `code-review` probe.
- **`.claude/skills/dispatch-propagate/scripts/dispatch-review-finders`** (the
  normative spec the workflow mirrors) — dropped the `echo "review"` emission and
  updated the header/surface-summary doc comments so every surface's always-on
  quality set reads `code-review` only.
- **`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`** —
  updated the `dispatch-review-finders` empty/docs/tests assertions to expect
  `code-review` only. The `dispatch-review-dedup` fixtures (`Source:"review"` as
  opaque merge-mechanics labels, not a live finder source) are intentionally left
  unchanged.
- **`.claude/skills/review-fix/SKILL.md`** — dropped `review` from the
  description, disposition tables, `Source` vocabulary, finder-model line, and the
  present-tense live-finder prose; rewrote the probe-wave throttle paragraph for
  the single `code-review` probe.

## Throttle-probe decision

`review-fix.js` launches the quality finders as "wave 1", doubling as a throttle
probe: if the quality finders return `null`, the security wave is skipped and
`coverage_incomplete` is recorded. Removing `review` degrades this to a
single-`code-review` probe. **Decision (the issue's first-listed option): accept
the reduced robustness — mechanical rename only, no retry control flow.** The
Workflow `agent()` primitive already retries internally, so a `null` `code-review`
result means *failed after its own retries* (model likely throttled), not *flaked
once* — the single-flake concern is already mitigated at the primitive layer.
Adding an explicit probe-retry would inject new, untested control flow into a
workflow with no JS test harness, contradicting this PR's simplification purpose.

## Verification

- `test-dispatch-scripts.sh`: 4032/4032 green.
- Greps confirm no remaining `review` reference treats it as a *live* finder
  source in the workflow, the normative spec, or the skill doc (the retained
  historical-narrative and `dispatch-review-dedup` fixture references are
  deliberately excluded).
