### PR TITLE
preview-and-smoke: retry Firebase deploy on transient auth failure

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -150,6 +150,51 @@ gh_retry() {
   return 1
 }
 
+# Run a firebase-tools deploy command, retrying ONLY on the transient auth
+# failure with exponential backoff. Args: the command and its arguments (e.g.
+# `firebase_deploy_retry npx firebase-tools hosting:channel:deploy ...`).
+# Unlike gh_retry, the retryable signature ("Failed to authenticate") arrives on
+# the command's STDOUT (inside the firebase-tools --json payload), not stderr —
+# so classification reads the combined stdout+stderr, and the failure-forward
+# path forwards STDOUT too, keeping the JSON error visible to the caller's
+# downstream preview-URL extraction.
+# On success: prints the command's stdout and returns 0. On a non-auth failure
+# or once attempts are exhausted: forwards the last attempt's stdout to stdout
+# and its stderr to >&2, then returns the command's real exit code (no
+# swallowing — see .claude/rules/code-style.md). Only "Failed to authenticate"
+# is treated as transient — every other failure fails fast.
+# Tunables (env): FIREBASE_DEPLOY_RETRY_ATTEMPTS (default 3 = up to 3 attempts),
+# FIREBASE_DEPLOY_RETRY_BASE_DELAY (default 5 seconds).
+firebase_deploy_retry() {
+  local attempts="${FIREBASE_DEPLOY_RETRY_ATTEMPTS:-3}"
+  local delay="${FIREBASE_DEPLOY_RETRY_BASE_DELAY:-5}"
+  local attempt out rc err combined tmpfile
+  tmpfile=$(mktemp) || { echo "error: could not create temp file" >&2; return 1; }
+  for (( attempt=1; attempt<=attempts; attempt++ )); do
+    out=$("$@" 2>"$tmpfile")
+    rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+      printf '%s\n' "$out"
+      rm -f "$tmpfile"
+      return 0
+    fi
+    err=$(cat "$tmpfile")
+    combined="$out"$'\n'"$err"
+    if [[ "$attempt" -ge "$attempts" ]] || [[ "${combined,,}" != *"failed to authenticate"* ]]; then
+      printf '%s\n' "$out"
+      printf '%s' "$err" >&2
+      rm -f "$tmpfile"
+      return "$rc"
+    fi
+    echo "firebase_deploy_retry: transient auth failure (attempt $attempt/$attempts), retrying in ${delay}s" >&2
+    sleep "$delay"
+    delay=$(( delay * 2 ))
+  done
+  # Unreachable — the loop returns on every path — but keep the temp file clean.
+  rm -f "$tmpfile"
+  return 1
+}
+
 # Call gh api and validate the response is a JSON array before applying a jq filter.
 # Args: $1 = API path (e.g. "/repos/{owner}/{repo}/issues/42/sub_issues")
 #        $2 = jq filter to apply to the array (e.g. '.[].number')

--- a/.claude/skills/dispatch-propagate/scripts/run-preview-deploy.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-preview-deploy.sh
@@ -31,7 +31,7 @@ cd "$REPO_ROOT"
 
 # Deploy hosting channel — reuses existing channel if present (uses deploy target from .firebaserc)
 echo "Deploying to preview channel '$CHANNEL_ID' on site '$HOSTING_SITE'..."
-DEPLOY_OUTPUT=$(npx firebase-tools hosting:channel:deploy "$CHANNEL_ID" \
+DEPLOY_OUTPUT=$(firebase_deploy_retry npx firebase-tools hosting:channel:deploy "$CHANNEL_ID" \
   --only "$APP_NAME" \
   --project "$FIREBASE_PROJECT_ID" \
   --expires 7d \

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -40976,6 +40976,68 @@ assert_eq "T8: daemon UNKNOWN → 0 schedule calls" "0" "$lines"
 scan_teardown
 
 # ============================================================================
+# firebase_deploy_retry (#2481)
+# ============================================================================
+echo "=== firebase_deploy_retry (#2481) ==="
+export FIREBASE_DEPLOY_RETRY_BASE_DELAY=0
+export FIREBASE_DEPLOY_RETRY_ATTEMPTS=3
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib.sh"
+
+FDR_DIR=$(mktemp -d)
+
+# --- Case 1: retry-then-succeed, signature on STDOUT (empty stderr) ---------
+FDR_COUNTER="$FDR_DIR/counter1"
+printf '0' > "$FDR_COUNTER"
+FDR_STUB1="$FDR_DIR/stub-success"
+cat > "$FDR_STUB1" <<STUB
+#!/usr/bin/env bash
+n=\$(cat "$FDR_COUNTER")
+n=\$(( n + 1 ))
+printf '%s' "\$n" > "$FDR_COUNTER"
+if [[ "\$n" -lt 3 ]]; then
+  # Transient auth failure: signature on STDOUT, nothing on stderr.
+  printf '%s\n' 'Failed to authenticate'
+  exit 1
+fi
+printf '%s\n' '{"result":{"site":{"url":"https://example.web.app"}}}'
+exit 0
+STUB
+chmod +x "$FDR_STUB1"
+
+fdr_actual=$(firebase_deploy_retry "$FDR_STUB1" 2>/dev/null)
+fdr_rc=$?
+assert_eq "firebase_deploy_retry: returns final success JSON on stdout" \
+  '{"result":{"site":{"url":"https://example.web.app"}}}' "$fdr_actual"
+assert_eq "firebase_deploy_retry: exit code 0 on eventual success" "0" "$fdr_rc"
+fdr_count1=$(cat "$FDR_COUNTER")
+assert_eq "firebase_deploy_retry: retried until success (3 attempts)" "3" "$fdr_count1"
+
+# --- Case 2: non-auth failure is NOT retried -------------------------------
+FDR_COUNTER2="$FDR_DIR/counter2"
+printf '0' > "$FDR_COUNTER2"
+FDR_STUB2="$FDR_DIR/stub-fail"
+cat > "$FDR_STUB2" <<STUB
+#!/usr/bin/env bash
+n=\$(cat "$FDR_COUNTER2")
+n=\$(( n + 1 ))
+printf '%s' "\$n" > "$FDR_COUNTER2"
+printf '%s\n' 'some other deploy error' >&2
+exit 1
+STUB
+chmod +x "$FDR_STUB2"
+
+fdr_rc2=0
+firebase_deploy_retry "$FDR_STUB2" >/dev/null 2>&1 || fdr_rc2=$?
+fdr_count2=$(cat "$FDR_COUNTER2")
+assert_eq "firebase_deploy_retry: non-auth failure not retried (1 attempt)" "1" "$fdr_count2"
+assert_eq "firebase_deploy_retry: non-auth failure returns nonzero" "nonzero" \
+  "$([[ $fdr_rc2 -ne 0 ]] && echo nonzero || echo zero)"
+
+rm -rf "$FDR_DIR"
+unset FIREBASE_DEPLOY_RETRY_BASE_DELAY FIREBASE_DEPLOY_RETRY_ATTEMPTS
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results


### PR DESCRIPTION
Closes #2481

## Problem

The `preview-and-smoke` CI check intermittently failed all six preview deploys
(audio, budget, fellspiral, landing, office-hours, print) with:

```
Deploy failed: {"status": "error", "error": "Failed to authenticate, have you run firebase login?"}
```

The `firebase-auth.sh` step succeeds (the service-account credentials file is
written), but the subsequent `firebase-tools` deploy transiently fails to resolve
those credentials — a GCP/Firebase credential-service hiccup, not a code defect
(a sibling PR passed the identical check minutes later under the same config, the
failing PRs did not touch auth/deploy/workflow files, and all six deploys failed
with the same error simultaneously). Recurred on PR #2467 and PR #1849.

## Fix

Add a bounded retry-with-backoff around the per-app preview deploy command, keyed
on the `Failed to authenticate` signature. Because the credentials file is valid
and `firebase-tools` re-authenticates on each invocation, re-running the deploy
command alone (no re-auth, no rebuild) is expected to clear a transient failure.

- **Unit 1** — new `firebase_deploy_retry` helper in `lib.sh`, modeled on the
  existing `gh_retry` (up to 3 attempts, exponential backoff, env-tunable). The
  one load-bearing difference from `gh_retry`: the auth-error string arrives on
  the deploy command's **stdout** (inside the `--json` payload), so the helper
  classifies on **combined stdout+stderr** and forwards **stdout** on failure so
  the caller's downstream preview-URL extraction (and its error diagnostic) still
  sees the JSON.
- **Unit 2** — wire the helper into the `hosting:channel:deploy` call in
  `run-preview-deploy.sh`. Only the deploy command is wrapped; the build runs once
  and is not repeated on retry.
- **Unit 3** — unit tests for the helper: a positive retry-then-succeed case with
  the auth signature on **stdout** (the stream that matters), and a negative case
  proving a non-auth failure fails fast (one attempt, no retry).

The 3-attempt cap means a genuine credential misconfiguration still fails the
check — just after the retries are exhausted — rather than being masked
indefinitely (per `.claude/rules/code-style.md`: clear errors over silent
fallbacks; only the focused `Failed to authenticate` signature retries).

`run-prod-deploy.sh` is intentionally out of scope: it is a different workflow,
is not the flaking check, and streams its deploy output live rather than
capturing it. The helper is reusable so a future follow-up can adopt it for prod.

## Verification

- `bash -n` on both modified shell scripts.
- The dispatch-scripts unit suite (what CI runs in `unit-tests.yml`), including
  the new `firebase_deploy_retry` tests: 4037/4037 passed.

End-to-end confirmation is CI-only and not locally reproducible (a live Firebase
deploy cannot run locally) — a subsequent green `preview-and-smoke` run on a PR
that does not touch auth/deploy config is the observe-in-CI check for QA.
