### PR TITLE
ds storybook: fix dev server crash (raise optimizeDeps esbuild target)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/detect-changes.sh
+++ b/.claude/skills/dispatch-propagate/scripts/detect-changes.sh
@@ -32,6 +32,12 @@ fi
 if echo "$CHANGED" | grep -qE '^(firestore\.rules$|storage\.rules$|rules-test/|\.claude/skills/dispatch-propagate/scripts/|firebase\.json$|package\.json$|package-lock\.json$)'; then
   echo "rules=true" >> "$GITHUB_OUTPUT"
 fi
+# storybook-smoke boots the packages/ds Storybook dev server. Trigger on any
+# packages/ds change (a component, story, token, or .storybook config edit can
+# break the dev bundle) and on edits to the smoke script itself.
+if echo "$CHANGED" | grep -qE '^(packages/ds/|\.claude/skills/dispatch-propagate/scripts/run-storybook-smoke\.sh$)'; then
+  echo "ds=true" >> "$GITHUB_OUTPUT"
+fi
 # dead-code check runs knip at repo root — any TS/JS/knip-config change can
 # orphan code elsewhere, so trigger on any such change across the repo.
 if echo "$CHANGED" | grep -qE '\.(ts|tsx|js|jsx|mjs|cjs)$|^knip\.(json|jsonc|ts)$'; then

--- a/.claude/skills/dispatch-propagate/scripts/run-storybook-smoke.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-storybook-smoke.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Storybook dev-server smoke test for packages/ds.
+#
+# The production build (`storybook build`) and the dev server (`storybook dev`)
+# take different esbuild paths: the build is governed by build.target, the dev
+# server by optimizeDeps.esbuildOptions.target (see
+# packages/ds/.storybook/main.ts). A green production build therefore does NOT
+# prove the dev server boots — exactly how #2510 shipped with a dev server that
+# crashed on startup ("Transforming destructuring to the configured target
+# environment is not supported yet"), undetected because no CI ran Storybook.
+#
+# This boots the actual dev server and fails if it does not serve the preview
+# iframe, or if it logs an esbuild bundling error. It is a smoke test, not an
+# acceptance test: it asserts the server comes up and bundles cleanly, NOT that
+# fonts/tokens/variants render correctly (that is human/visual-regression QA).
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SCRIPTS="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck source=lib.sh
+source "$SCRIPTS/lib.sh"
+
+PORT="${STORYBOOK_SMOKE_PORT:-6006}"
+TIMEOUT="${STORYBOOK_SMOKE_TIMEOUT:-120}"
+LOG="$(get_tmpdir)/storybook-smoke.log"
+
+ensure_deps
+
+cd "$REPO_ROOT"
+
+# Start the dev server detached, capturing all output for error inspection.
+# --disable-telemetry keeps the run offline-clean; --no-open skips the browser
+# launch (there is none in CI).
+npm run storybook --prefix packages/ds -- \
+  --port "$PORT" --no-open --disable-telemetry >"$LOG" 2>&1 &
+SB_PID=$!
+
+cleanup() {
+  # Kill the npm wrapper and the storybook/esbuild children it spawned. pkill -P
+  # matches by parent PID (not a command string), so it cannot match this script.
+  pkill -P "$SB_PID" 2>/dev/null || true
+  kill "$SB_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Wait until the preview iframe serves 200, the server dies, or we time out.
+# The preview iframe is the meaningful target: the #2510 crash was in the
+# preview's optimizeDeps pass, which Storybook runs eagerly at startup.
+READY=false
+ELAPSED=0
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+  if ! kill -0 "$SB_PID" 2>/dev/null; then
+    echo "ERROR: storybook dev server exited before serving (port ${PORT})" >&2
+    break
+  fi
+  if curl -fsS -o /dev/null "http://localhost:${PORT}/iframe.html" 2>/dev/null; then
+    READY=true
+    break
+  fi
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+done
+
+# Definitive #2510 signature: an esbuild target-lowering failure. Treat it as a
+# hard failure even in the unlikely case the server answered 200 before dying.
+if grep -qF "is not supported yet" "$LOG"; then
+  echo "ERROR: storybook dev server reported esbuild bundling errors:" >&2
+  # grep -m 10 stops after 10 matches itself, so no downstream `head` closes the
+  # pipe early — avoids a SIGPIPE that `set -o pipefail` would surface as exit
+  # 141 before the intended `exit 1`.
+  grep -m 10 -F "is not supported yet" "$LOG" >&2
+  exit 1
+fi
+
+if [ "$READY" != true ]; then
+  echo "ERROR: storybook dev server did not serve http://localhost:${PORT}/iframe.html within ${TIMEOUT}s" >&2
+  echo "--- last 40 log lines ---" >&2
+  tail -40 "$LOG" >&2
+  exit 1
+fi
+
+echo "PASS: storybook dev server booted and served iframe.html on port ${PORT}"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -143,6 +143,26 @@ jobs:
         if: steps.changes.outputs.deadcode == 'true'
         run: .claude/skills/dispatch-propagate/scripts/run-dead-code.sh
 
+  storybook-smoke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+      - name: Detect changed file categories
+        id: changes
+        run: .claude/skills/dispatch-propagate/scripts/detect-changes.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        if: steps.changes.outputs.ds == 'true'
+        with:
+          node-version-file: .node-version
+          cache: 'npm'
+      - name: Run Storybook dev-server smoke test
+        if: steps.changes.outputs.ds == 'true'
+        run: .claude/skills/dispatch-propagate/scripts/run-storybook-smoke.sh
+
   typecheck:
     runs-on: ubuntu-latest
     permissions:

--- a/packages/ds/.storybook/main.ts
+++ b/packages/ds/.storybook/main.ts
@@ -6,14 +6,24 @@ const config: StorybookConfig = {
   addons: ["@storybook/addon-docs"],
   framework: { name: "@storybook/react-vite", options: {} },
   staticDirs: ["./public"],
-  // Storybook's builder leaves build.target unset, so Vite falls back to its
-  // default browser list. esbuild then refuses to lower the rest-with-defaults
-  // destructuring in our components ("Transforming destructuring to the
-  // configured target environment is not supported yet"). Raising the target to
-  // es2022 (the repo's app build target) makes destructuring native, so esbuild
-  // skips the transform.
+  // Storybook's builder leaves Vite's esbuild target unset, so Vite falls back
+  // to its default browser list. esbuild then refuses to lower the
+  // rest-with-defaults destructuring and `Promise.withResolvers()` in our
+  // components and in Storybook's own prebundled runtime deps ("Transforming
+  // destructuring to the configured target environment is not supported yet").
+  // Two separate targets must be raised to es2022 (the repo's app build target),
+  // because the production build (`storybook build`) and the dev server
+  // (`storybook dev`) take different esbuild paths:
+  //   - build.target governs the production `build-storybook` bundle.
+  //   - optimizeDeps.esbuildOptions.target governs the dev server's dependency
+  //     pre-bundling, where esbuild transforms node_modules deps
+  //     (@storybook/react-dom-shim, @storybook/addon-docs, …). Without it,
+  //     `storybook dev` crashes on startup before serving any story.
   viteFinal: (viteConfig) =>
-    mergeConfig(viteConfig, { build: { target: "es2022" } }),
+    mergeConfig(viteConfig, {
+      build: { target: "es2022" },
+      optimizeDeps: { esbuildOptions: { target: "es2022" } },
+    }),
 };
 
 export default config;


### PR DESCRIPTION
## Problem

`npm run storybook --prefix packages/ds` — the exact command in #2524's
acceptance criteria — crashes on startup before serving any story. Vite's
dependency pre-bundling runs esbuild against the default browser target list
(chrome87, edge88, es2020, firefox78, safari14) and refuses to lower
`Promise.withResolvers()` and rest/destructuring in Storybook's prebundled
runtime deps (`@storybook/react-dom-shim`, `@storybook/addon-docs`), emitting
2372 `Transforming destructuring to the configured target environment is not
supported yet` errors. Port 6006 never serves.

The existing `viteFinal` set only `build.target: es2022`, which governs the
production `storybook build` bundle — a different esbuild path than the dev
server's `optimizeDeps` pass. The production build was already green, which is
why this dev-only crash merged undetected: no CI job ran Storybook.

## Fix

1. Also raise `optimizeDeps.esbuildOptions.target` to `es2022` so the dev
   server's dependency pre-bundling skips the unsupported transform.
2. Add a Storybook dev-server **smoke test** so this class of regression can't
   merge silently again (`run-storybook-smoke.sh`, run by a change-gated
   `storybook-smoke` job in `unit-tests.yml`). It boots `storybook dev`, waits
   for the preview iframe to serve, and fails on any esbuild bundling error.
   It is a smoke test, not an acceptance test — it asserts the server boots and
   bundles cleanly, NOT that fonts/tokens/variants render correctly (that
   remains human / visual-regression QA). Note a `build-storybook` check would
   NOT have caught this dev-only crash.

## Verification (local, on this branch)

- `npm run storybook --prefix packages/ds` now serves 200 on :6006 with **0**
  destructuring errors; all 8 components / 30 stories render.
- `npm run build-storybook --prefix packages/ds` still exits 0.
- `run-storybook-smoke.sh` passes on the fixed config and fails (clean exit 1,
  esbuild errors printed) when the `optimizeDeps` target is removed.
- Visual smoke check (#2524 acceptance criteria) against the running server:
  - IBM Plex fonts load and apply — story Button `font-family` resolves to
    `"IBM Plex Mono"`, weight 700; `document.fonts` reports IBM Plex Mono
    400/700 `loaded`.
  - Design tokens applied — Button bg `#e8943a` (brand amber), `--color-accent`
    custom property present; Badge neutral/accent/success/error render in
    distinct token colors.
  - Variants visually distinguishable — Button primary (filled amber) vs
    secondary (light outline); Badge four color variants.
  - No unstyled or broken stories.

Unblocks the main-qa visual smoke check in #2524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)