### PR TITLE
office-hours: gate shared layout sidebar column on sidebar presence

### DIFF
--- a/style/layout.css
+++ b/style/layout.css
@@ -41,21 +41,21 @@
 }
 
 @media (min-width: 768px) {
-  .content-grid {
+  .content-grid:has(> .sidebar) {
     grid-template-columns: 1fr var(--sidebar-width, 16rem);
   }
 
-  .page > header {
+  .page:has(.sidebar) > header {
     display: grid;
     grid-template-columns: 1fr var(--sidebar-width, 16rem);
     column-gap: var(--space-6);
   }
 
-  .page > header > * {
+  .page:has(.sidebar) > header > * {
     grid-column: 1;
   }
 
-  .page > header > nav {
+  .page:has(.sidebar) > header > nav {
     grid-column: 1 / -1;
   }
 

--- a/style/layout.css
+++ b/style/layout.css
@@ -45,17 +45,17 @@
     grid-template-columns: 1fr var(--sidebar-width, 16rem);
   }
 
-  .page:has(.sidebar) > header {
+  .page:has(> .content-grid > .sidebar) > header {
     display: grid;
     grid-template-columns: 1fr var(--sidebar-width, 16rem);
     column-gap: var(--space-6);
   }
 
-  .page:has(.sidebar) > header > * {
+  .page:has(> .content-grid > .sidebar) > header > * {
     grid-column: 1;
   }
 
-  .page:has(.sidebar) > header > nav {
+  .page:has(> .content-grid > .sidebar) > header > nav {
     grid-column: 1 / -1;
   }
 


### PR DESCRIPTION
Closes #2508

## Summary

On the office-hours dashboard the navigation header spanned the full page width
while `<main>` was inset ~16rem narrower on the right, so the header and main
right edges did not line up.

**Root cause.** The shared `style/layout.css` defined a two-column grid
(`1fr` + `var(--sidebar-width, 16rem)`) at ≥768px unconditionally — for both
`.page > header` and `.content-grid`. That layout assumes a sidebar fills
column 2. office-hours has no sidebar, so column 2 was reserved but empty: nav
stretched across both columns while main was confined to `1fr`.

**Fix.** Gate the second grid column on a `.sidebar` actually being present,
using `:has()` (already an accepted pattern at `style/default.css:80`). The four
two-column rules inside the `@media (min-width: 768px)` block now carry a
`:has()` guard:

- `.content-grid` → `.content-grid:has(> .sidebar)`
- `.page > header` → `.page:has(.sidebar) > header`
- `.page > header > *` → `.page:has(.sidebar) > header > *`
- `.page > header > nav` → `.page:has(.sidebar) > header > nav`

Sidebar-less apps (office-hours, print, budget) fall back to the unconditional
base `grid-template-columns: 1fr` rule and render one consistent column for both
header and main. Apps with a sidebar (audio, landing, fellspiral) are unchanged.

CSS-only change. The layout effect is visual and verified in the browser during
the QA phase.

## Verification

- `npx vitest run --project office-hours --project audio --root .` — passes
  (regression baseline; the suites do not exercise `style/layout.css` directly).
