### PR TITLE
mount-gdrive: periodic timer heals a stale/missing /mnt/g

### DIFF
--- a/nix/nixos/mounts.nix
+++ b/nix/nixos/mounts.nix
@@ -72,4 +72,85 @@
       '';
     };
   };
+
+  # Timer-driven self-heal for a mid-session stale/missing G: mount.
+  #
+  # Why this exists separately from the boot oneshot above:
+  #
+  #   mount-gdrive is a `Type=oneshot` with `RemainAfterExit=true`: it mounts
+  #   once at boot and then sits as `active (exited)` forever, never
+  #   re-evaluating. But Google Drive for desktop can restart on the Windows
+  #   host mid-session (update, sign-out, crash). When it does, the Linux mount
+  #   entry persists pointing at a now-dead device: the path is still a
+  #   mountpoint, but any access fails with ENODEV ("No such device"). The boot
+  #   oneshot never notices. This timer re-evaluates the mount every minute and
+  #   re-mounts it when it has gone stale or missing.
+  #
+  # Why the probe is `mountpoint -q` + `stat /mnt/g/.`, not `mountpoint -q`
+  # alone:
+  #
+  #   The two failure modes need two different probes, each used for its
+  #   strength:
+  #     - MISSING (not a mountpoint at all) is caught by `mountpoint -q`.
+  #     - STALE (mountpoint present, backing device dead) still PASSES
+  #       `mountpoint -q` — the path is a mountpoint, only the device is gone.
+  #       To catch it we must probe INTO the mount with `stat /mnt/g/.`. The
+  #       trailing `/.` forces path resolution inside the mounted fs, touching
+  #       the dead device; a bare `stat /mnt/g` can return cached mountpoint
+  #       inode metadata and falsely pass. (Conversely, on the
+  #       systemd-created / `x-mount.mkdir` mountpoint, a bare `stat /mnt/g`
+  #       could also pass on an empty unmounted dir.) So each probe does the
+  #       job the other can't.
+  #
+  # Why a bare `oneshot` with no RemainAfterExit and no service `wantedBy`:
+  #
+  #   The service must actually re-run on every timer tick. RemainAfterExit
+  #   would leave it `active (exited)` and systemd would never start it again —
+  #   exactly the boot-oneshot trap we are working around. And only the TIMER
+  #   carries `wantedBy = [ "timers.target" ]`; giving the service a `wantedBy`
+  #   too would have it race the boot mount instead of leaving startup to
+  #   mount-gdrive.
+  #
+  # Why it `exit 0`s every time:
+  #
+  #   The boot oneshot owns the loud "Drive absent at startup" signal (it
+  #   exits non-zero so a Drive that never appears shows up in
+  #   `systemctl --failed`). This healer is a per-minute janitor: it keeps
+  #   `systemctl --failed` clean by always exiting 0, logging any re-mount
+  #   failure to the journal without masking it as a unit failure.
+  systemd.timers."mount-gdrive-heal" = {
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnBootSec = "3min";
+      OnUnitActiveSec = "1min";
+    };
+  };
+
+  systemd.services."mount-gdrive-heal" = {
+    description = "Re-mount Google Drive (G:) if it has gone stale or missing";
+    after = [ "mount-gdrive.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = pkgs.writeShellScript "mount-gdrive-heal" ''
+        # MISSING: not a mountpoint at all (e.g. Drive came up after the boot
+        # poll window, or a prior umount). Mount and finish.
+        ${pkgs.util-linux}/bin/mountpoint -q /mnt/g || {
+          ${pkgs.util-linux}/bin/mount /mnt/g \
+            || echo "G: (Google Drive) not mountable; is Drive for desktop running on Windows?" >&2
+          exit 0
+        }
+        # MOUNTPOINT PRESENT — distinguish healthy from stale by probing INTO the
+        # mount. The trailing /. forces path resolution inside the mounted fs,
+        # which touches the (possibly dead) backing device; bare `stat /mnt/g` can
+        # return cached mountpoint inode metadata and falsely pass on a stale mount.
+        ${pkgs.coreutils}/bin/stat /mnt/g/. >/dev/null 2>&1 && exit 0
+        # STALE: mountpoint passes but device is dead (ENODEV). Lazily detach the
+        # dead entry (tolerate "not mounted"), then re-mount.
+        ${pkgs.util-linux}/bin/umount -l /mnt/g 2>/dev/null || true
+        ${pkgs.util-linux}/bin/mount /mnt/g \
+          || echo "G: (Google Drive) re-mount failed; is Drive for desktop running on Windows?" >&2
+        exit 0
+      '';
+    };
+  };
 }


### PR DESCRIPTION
Closes #2494

## Problem

`/mnt/g` (Google Drive `G:` over WSL2 drvfs) silently dies mid-session. When
Google Drive for desktop restarts on the Windows host (auto-update, sign-out,
crash) it recreates the `G:` virtual volume, invalidating the drvfs handle WSL
holds. The Linux mount entry persists pointing at a dead device, so `ls /mnt/g`
fails with ENODEV ("No such device"). The existing `mount-gdrive.service` is a
boot-only `Type=oneshot` with `RemainAfterExit=true`: it mounts once at boot,
sits `active (exited)` forever, and never re-evaluates — so a stale mid-session
mount never heals without a manual `sudo systemctl restart mount-gdrive`. This
silently breaks every `/mnt/g` consumer (notably `budget-etl`).

## Change

Adds a timer-driven self-heal unit in `nix/nixos/mounts.nix` that re-evaluates
the mount every minute and re-mounts a stale or missing `/mnt/g` within ~1 min.
The existing boot oneshot is left untouched as the first-mount / loud-absent-at-boot
gate.

- `systemd.timers."mount-gdrive-heal"` — `OnBootSec=3min` (past the boot
  oneshot's ~2 min poll window, so it never races the first mount),
  `OnUnitActiveSec=1min` steady-state interval.
- `systemd.services."mount-gdrive-heal"` — a bare `oneshot` (no
  `RemainAfterExit`, no service `wantedBy`) that runs one attempt per tick. The
  timer is the retry loop.

The heal probe combines two checks, each used for its strength: `mountpoint -q`
catches a **missing** mount, and `stat /mnt/g/.` (resolving *into* the fs, which
touches the backing device) catches a **stale** mount that still passes
`mountpoint -q`. On stale, it lazily detaches the dead entry (`umount -l`) and
re-mounts. The script always `exit 0`s — the boot oneshot owns the loud
"Drive absent at startup" signal, so the per-minute janitor keeps
`systemctl --failed` clean while still logging any re-mount failure to the
journal.

## Verification

There is no nix CI. The automated check is a parse check
(`nix-instantiate --parse nix/nixos/mounts.nix`), which passes. Runtime behavior
(stale-mount heal, missing-mount heal, no-spin on genuinely-absent `G:`, survives
`wsl --shutdown`) is validated manually on the live WSL host per the plan's
Verification section — `nixos-rebuild` is neither CI-safe nor deterministic.
