### PR TITLE
print: surface local-folder scan failures as an error state

### DIFF
--- a/print/src/local-folder-ui.ts
+++ b/print/src/local-folder-ui.ts
@@ -183,17 +183,71 @@ export function settleEnrichment(): Promise<void> {
 }
 
 /**
+ * Remove any stale local-folder scan-error notice from the container. A no-op
+ * when none is present, so it is safe to call on every successful render pass.
+ */
+function clearLocalScanError(container: HTMLElement): void {
+  container.querySelector("#local-folder-error")?.remove();
+}
+
+/**
+ * Render an in-list scan-error notice with a retry button, anchored to the media
+ * list (or the empty-state placeholder) inside `container`. The folder
+ * open/grant buttons live in a separate nav section, so the notice is placed
+ * relative to the list the user is looking at. The anchor deliberately excludes
+ * `#media-error`: when the cloud list itself failed the user already sees an
+ * error, so suppressing the local notice then is intentional. A list-less route
+ * (e.g. the viewer page) has no anchor and is a silent no-op, mirroring
+ * `renderLocalIntoList`'s own early return.
+ */
+function renderLocalScanError(container: HTMLElement, onRetry: () => void): void {
+  clearLocalScanError(container);
+  const anchor =
+    container.querySelector("#media-list") ??
+    container.querySelector("#media-empty");
+  if (!anchor) return;
+  const p = document.createElement("p");
+  p.id = "local-folder-error";
+  p.className = "local-folder-error";
+  p.textContent = "Couldn't read this folder. ";
+  const button = document.createElement("button");
+  button.id = "local-folder-retry";
+  button.type = "button";
+  button.className = "local-folder-button";
+  button.textContent = "Try again";
+  button.addEventListener("click", onRetry);
+  p.appendChild(button);
+  anchor.insertAdjacentElement("beforebegin", p);
+}
+
+/**
  * Render the current local items into the shared media list, resolving at FIRST
  * PAINT: find (or create) the `#media-list` <ul>, do a single bounded sidecar
  * read, partition items into cached (overlaid with real metadata, zero file IO)
  * vs uncached (filename-stem rows), strip prior local rows, and insert all rows
  * immediately. Cold-folder metadata extraction for the uncached items runs
  * DETACHED after this resolves — a hung extract never blocks first paint or the
- * focus listener. No-ops when no media list or empty-state placeholder is
- * present (e.g. viewer page).
+ * focus listener. A whole-scan failure surfaces an in-list error notice with a
+ * retry instead of rejecting. No-ops when no media list or empty-state
+ * placeholder is present (e.g. viewer page).
  */
 export async function renderLocalIntoList(container: HTMLElement): Promise<void> {
-  const items = await listLocal();
+  let items: MediaItem[];
+  try {
+    items = await listLocal();
+  } catch (err) {
+    // A whole-scan enumeration rejection leaves the user on cloud-only with no
+    // signal. Surface it as an in-list notice with a retry rather than swallow
+    // it. The retry re-invokes a fresh scan (scan() clears pendingScan in its
+    // .finally), so it genuinely recovers.
+    logError(err, { operation: "local-folder-scan" });
+    renderLocalScanError(container, () =>
+      renderLocalIntoList(container).catch((e) =>
+        logError(e, { operation: "local-folder-rescan-retry" }),
+      ),
+    );
+    return;
+  }
   let ul = container.querySelector<HTMLUListElement>("#media-list");
   if (!ul) {
     // Empty cloud library renders a `#media-empty` <p> instead of a <ul>.
@@ -206,6 +260,9 @@ export async function renderLocalIntoList(container: HTMLElement): Promise<void>
   // Single bounded sidecar read AFTER the early-return guard: a focus event on a
   // list-less route (e.g. the viewer) must not read the sidecar.
   await ensureLoaded();
+
+  // A scan that previously failed but now succeeds must drop its stale notice.
+  clearLocalScanError(container);
 
   // Partition before insert. getMetadata is an in-memory lookup (zero file IO)
   // after ensureLoaded: a present entry overlays full title + pageCount now;

--- a/print/src/local-folder-ui.ts
+++ b/print/src/local-folder-ui.ts
@@ -248,6 +248,11 @@ export async function renderLocalIntoList(container: HTMLElement): Promise<void>
     );
     return;
   }
+  // A scan that previously failed but now succeeds must drop its stale notice.
+  // Clear it as soon as recovery is confirmed — before the ul lookup and the
+  // unrelated ensureLoaded() await — so the notice does not linger for the full
+  // sidecar load.
+  clearLocalScanError(container);
   let ul = container.querySelector<HTMLUListElement>("#media-list");
   if (!ul) {
     // Empty cloud library renders a `#media-empty` <p> instead of a <ul>.
@@ -260,9 +265,6 @@ export async function renderLocalIntoList(container: HTMLElement): Promise<void>
   // Single bounded sidecar read AFTER the early-return guard: a focus event on a
   // list-less route (e.g. the viewer) must not read the sidecar.
   await ensureLoaded();
-
-  // A scan that previously failed but now succeeds must drop its stale notice.
-  clearLocalScanError(container);
 
   // Partition before insert. getMetadata is an in-memory lookup (zero file IO)
   // after ensureLoaded: a present entry overlays full title + pageCount now;

--- a/print/src/style/theme.css
+++ b/print/src/style/theme.css
@@ -77,6 +77,12 @@
 }
 
 /* Local-folder items + controls */
+.local-folder-error {
+  color: var(--danger);
+  font-size: var(--text-sm);
+  margin: var(--space-1) 0 0;
+}
+
 .media-item-local .media-title a {
   color: inherit;
   text-decoration: none;

--- a/print/test/local-folder-ui.test.ts
+++ b/print/test/local-folder-ui.test.ts
@@ -295,6 +295,7 @@ describe("renderLocalIntoList — scan failure", () => {
     expect(container.querySelector("#local-folder-retry")).not.toBeNull();
     // The notice is anchored before the empty-state placeholder.
     const empty = container.querySelector("#media-empty");
-    expect(notice!.nextElementSibling).toBe(empty);
+    if (!notice) throw new Error("#local-folder-error not found");
+    expect(notice.nextElementSibling).toBe(empty);
   });
 });

--- a/print/test/local-folder-ui.test.ts
+++ b/print/test/local-folder-ui.test.ts
@@ -282,4 +282,19 @@ describe("renderLocalIntoList — scan failure", () => {
     expect(container.querySelector(".media-item-local")).not.toBeNull();
     expect(container.querySelector("#local-folder-error")).toBeNull();
   });
+
+  it("(e) EMPTY-ANCHOR FALLBACK: renders the notice before #media-empty when the cloud library is empty", async () => {
+    vi.mocked(listLocal).mockRejectedValueOnce(new Error("scan failed"));
+    const container = document.createElement("div");
+    container.innerHTML = '<p id="media-empty">No media items available.</p>';
+
+    await renderLocalIntoList(container);
+
+    const notice = container.querySelector("#local-folder-error");
+    expect(notice).not.toBeNull();
+    expect(container.querySelector("#local-folder-retry")).not.toBeNull();
+    // The notice is anchored before the empty-state placeholder.
+    const empty = container.querySelector("#media-empty");
+    expect(notice!.nextElementSibling).toBe(empty);
+  });
 });

--- a/print/test/local-folder-ui.test.ts
+++ b/print/test/local-folder-ui.test.ts
@@ -238,7 +238,8 @@ describe("renderLocalIntoList — scan failure", () => {
 
     const retryButton = container.querySelector<HTMLButtonElement>("#local-folder-retry");
     expect(retryButton).not.toBeNull();
-    retryButton!.click();
+    if (!retryButton) throw new Error('retryButton not found');
+    retryButton.click();
 
     await vi.waitFor(() =>
       expect(container.querySelector("#local-folder-error")).toBeNull(),

--- a/print/test/local-folder-ui.test.ts
+++ b/print/test/local-folder-ui.test.ts
@@ -42,12 +42,21 @@ vi.mock("../src/library.js", async () => {
   };
 });
 
+vi.mock("../src/sidecar.js", () => ({
+  ensureLoaded: vi.fn(() => Promise.resolve()),
+  cacheMetadataBatch: vi.fn(() => Promise.resolve()),
+  getMetadata: vi.fn(() => Promise.resolve(undefined)),
+  setLocalDirectory: vi.fn(() => Promise.resolve()),
+}));
+
 import {
   decideFolderUiState,
   initLocalFolder,
+  renderLocalIntoList,
   FOCUS_RESCAN_DEBOUNCE_MS,
 } from "../src/local-folder-ui.js";
 import { listLocal } from "../src/library.js";
+import type { MediaItem } from "../src/types.js";
 
 describe("decideFolderUiState", () => {
   it("returns 'open' when no handle is persisted (null)", () => {
@@ -197,5 +206,79 @@ describe("initLocalFolder — focus-rescan debounce", () => {
     await vi.advanceTimersByTimeAsync(FOCUS_RESCAN_DEBOUNCE_MS);
 
     expect(listLocal).not.toHaveBeenCalled();
+  });
+});
+
+describe("renderLocalIntoList — scan failure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listLocal).mockReset();
+    vi.mocked(listLocal).mockResolvedValue([]);
+  });
+
+  it("(a) REJECT → NOTICE: renders error notice with retry button on scan rejection", async () => {
+    vi.mocked(listLocal).mockRejectedValueOnce(new Error("scan failed"));
+    const container = document.createElement("div");
+    container.innerHTML = '<ul id="media-list"></ul>';
+
+    await renderLocalIntoList(container);
+
+    expect(container.querySelector("#local-folder-error")).not.toBeNull();
+    expect(container.querySelector("#local-folder-retry")).not.toBeNull();
+  });
+
+  it("(b) RECOVERY BUTTON: clicking retry removes the error notice and rescans", async () => {
+    vi.mocked(listLocal)
+      .mockRejectedValueOnce(new Error("scan failed"))
+      .mockResolvedValue([]);
+    const container = document.createElement("div");
+    container.innerHTML = '<ul id="media-list"></ul>';
+
+    await renderLocalIntoList(container);
+
+    const retryButton = container.querySelector<HTMLButtonElement>("#local-folder-retry");
+    expect(retryButton).not.toBeNull();
+    retryButton!.click();
+
+    await vi.waitFor(() =>
+      expect(container.querySelector("#local-folder-error")).toBeNull(),
+    );
+    expect(vi.mocked(listLocal).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("(c) NO-STACK IDEMPOTENCY: repeated failures do not stack duplicate error notices", async () => {
+    vi.mocked(listLocal).mockRejectedValue(new Error("scan failed"));
+    const container = document.createElement("div");
+    container.innerHTML = '<ul id="media-list"></ul>';
+
+    await renderLocalIntoList(container);
+    await renderLocalIntoList(container);
+
+    expect(container.querySelectorAll("#local-folder-error").length).toBe(1);
+  });
+
+  it("(d) DISCRIMINATOR: a successful scan shows items and no error notice", async () => {
+    const oneItem: MediaItem = {
+      id: "local:f/a.pdf",
+      title: "a",
+      mediaType: "pdf",
+      tags: {},
+      publicDomain: false,
+      sourceNotes: "",
+      storagePath: "local:f/a.pdf",
+      markdownPath: null,
+      groupId: null,
+      memberEmails: [],
+      addedAt: "2024-01-01T00:00:00Z",
+      origin: "local",
+    };
+    vi.mocked(listLocal).mockResolvedValue([oneItem]);
+    const container = document.createElement("div");
+    container.innerHTML = '<ul id="media-list"></ul>';
+
+    await renderLocalIntoList(container);
+
+    expect(container.querySelector(".media-item-local")).not.toBeNull();
+    expect(container.querySelector("#local-folder-error")).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #2498

## What changed

A whole-folder File-System-Access scan rejection used to propagate out of
`renderLocalIntoList` and get silently swallowed at every call site, leaving the
user on cloud-only with no signal — exactly what made "open folder did nothing"
look broken.

`renderLocalIntoList` now catches a whole-scan failure and surfaces it as an
in-list error notice ("Couldn't read this folder.") with a **Try again** button,
inserted directly above the media list. The retry re-runs a fresh scan (`scan()`
clears its memoized `pendingScan` in `.finally()`), so it genuinely recovers; on
a successful render the stale notice is removed.

### Units

1. **`print/src/local-folder-ui.ts`** — wrap `await listLocal()` in try/catch;
   on reject `logError(... operation: "local-folder-scan")`, render the notice
   via the new pure-DOM helpers `renderLocalScanError` / `clearLocalScanError`,
   and return (no re-throw). The notice anchors to `#media-list ?? #media-empty`
   (deliberately excludes `#media-error`: a failed cloud list already shows an
   error) and is a silent no-op on list-less routes (e.g. the viewer). Idempotent
   by id — both the success and error paths first remove any existing
   `#local-folder-error`, so re-renders never stack notices or listeners. Per-file
   enrichment is structurally downstream of the scan `await`, so per-file
   tolerance is untouched by construction.
2. **`print/src/style/theme.css`** — add a `.local-folder-error` rule using the
   `light-dark()`-aware `--danger` status token; the retry button reuses the
   existing `.local-folder-button` class.
3. **`print/test/local-folder-ui.test.ts`** — new `renderLocalIntoList — scan
   failure` block: reject → notice; retry recovers (notice clears, `listLocal`
   re-called); two rejects → exactly one notice (no stacking); discriminator — a
   successful scan renders a `.media-item-local` row and shows no error notice.

## Verification

- `npx vitest run --project print` — 573 passed, 1 skipped (4 new tests).
- `npx tsc --noEmit -p print/tsconfig.json` — clean.

Manual / observe-in-prod (Chromium only, FSA required): grant a folder, force a
scan failure (revoke folder permission or remove the folder out from under a
granted handle, then trigger a window-focus rescan). Confirm a single "Couldn't
read this folder" notice appears above the library list with a working "Try
again" button, the cloud rows remain visible, retry after restoring access clears
the notice and repopulates local rows, repeated failures never stack, and a
folder with one unreadable file among good files still lists everything with no
error notice.
