### PR TITLE
office-hours: relabel backlog-history runway caption and cap its chart projection

### DIFF
--- a/office-hours/src/backlog-runway.ts
+++ b/office-hours/src/backlog-runway.ts
@@ -60,7 +60,7 @@ export function runwayVerdict(fit: BacklogRunwayFit): { text: string; state: str
     case "draining": {
       const days = Math.ceil(fit.daysUntilEmpty);
       const unit = days === 1 ? "day" : "days";
-      return { text: `~${days} ${unit} until the queue empties`, state: "draining" };
+      return { text: `~${days} ${unit} to clear the open backlog at current trend`, state: "draining" };
     }
     case "stable":
       return { text: "queue stable", state: "stable" };

--- a/office-hours/src/issue-history-chart.ts
+++ b/office-hours/src/issue-history-chart.ts
@@ -16,6 +16,8 @@ import {
 
 /** Per-sample chart width allocation along the time axis. */
 const POINT_WIDTH = 60;
+/** Readability ceiling on the chart's forward projection window (days). */
+const MAX_PROJECTION_DAYS = 14;
 const CHART_HEIGHT = 220;
 
 interface Point {
@@ -133,20 +135,33 @@ export function renderIssueHistoryChart(samples: IssueSample[]): HTMLElement {
   const dataDays = (last - first) / 86_400_000;
   const isDraining = fit.state === "draining" && dataDays > 0;
 
+  // Cap the forward projection to a bounded window so empty future space no
+  // longer dominates the x-axis. The cap binds on whichever is smallest:
+  //   - dataDays: the future window never exceeds the past (projection stays
+  //     <= 50% of the chart even for a short history);
+  //   - MAX_PROJECTION_DAYS: a hard ceiling for long histories;
+  //   - daysUntilEmpty: end at the real crossing when the queue empties soon.
+  const projectionDays =
+    fit.state === "draining" && isDraining
+      ? Math.min(fit.daysUntilEmpty, dataDays, MAX_PROJECTION_DAYS)
+      : 0;
+  const projectionEnd = new Date(last + projectionDays * 86_400_000);
+
   // x domain and the projection mark are width-independent — compute once.
   const xDomain: [Date, Date] = isDraining
-    ? [sorted[0].sampledAt, fit.crossingAt]
+    ? [sorted[0].sampledAt, projectionEnd]
     : [sorted[0].sampledAt, sorted[sorted.length - 1].sampledAt];
 
   if (isDraining) {
     // Dashed projection from the fitted value at the last actual point down to
-    // the zero-crossing.
+    // the capped projection horizon (the real zero-crossing when the cap does
+    // not bind; a positive fitted value at the window edge when it does).
     const fittedLast = Math.max(0, fit.slope * dataDays + fit.intercept);
     marks.push(
       Plot.lineY(
         [
           { x: sorted[sorted.length - 1].sampledAt, y: fittedLast },
-          { x: fit.crossingAt, y: 0 },
+          { x: projectionEnd, y: Math.max(0, fit.slope * (dataDays + projectionDays) + fit.intercept) },
         ],
         {
           x: "x",
@@ -187,7 +202,7 @@ export function renderIssueHistoryChart(samples: IssueSample[]): HTMLElement {
     if (isDraining) {
       const pxPerDay = (points.length * POINT_WIDTH) / dataDays;
       chartWidth = Math.max(
-        points.length * POINT_WIDTH + pxPerDay * fit.daysUntilEmpty + MARGIN_RIGHT,
+        points.length * POINT_WIDTH + pxPerDay * projectionDays + MARGIN_RIGHT,
         width - AXIS_WIDTH,
       );
     } else {

--- a/office-hours/src/issue-history-chart.ts
+++ b/office-hours/src/issue-history-chart.ts
@@ -15,9 +15,9 @@ import {
 } from "./chart-util.js";
 
 /** Per-sample chart width allocation along the time axis. */
-const POINT_WIDTH = 60;
+export const POINT_WIDTH = 60;
 /** Readability ceiling on the chart's forward projection window (days). */
-const MAX_PROJECTION_DAYS = 14;
+export const MAX_PROJECTION_DAYS = 14;
 const CHART_HEIGHT = 220;
 
 interface Point {
@@ -141,10 +141,9 @@ export function renderIssueHistoryChart(samples: IssueSample[]): HTMLElement {
   //     <= 50% of the chart even for a short history);
   //   - MAX_PROJECTION_DAYS: a hard ceiling for long histories;
   //   - daysUntilEmpty: end at the real crossing when the queue empties soon.
-  const projectionDays =
-    fit.state === "draining" && isDraining
-      ? Math.min(fit.daysUntilEmpty, dataDays, MAX_PROJECTION_DAYS)
-      : 0;
+  const projectionDays = isDraining
+    ? Math.min(fit.daysUntilEmpty, dataDays, MAX_PROJECTION_DAYS)
+    : 0;
   const projectionEnd = new Date(last + projectionDays * 86_400_000);
 
   // x domain and the projection mark are width-independent — compute once.

--- a/office-hours/test/BacklogPanel.test.tsx
+++ b/office-hours/test/BacklogPanel.test.tsx
@@ -59,7 +59,7 @@ describe("BacklogPanel", () => {
     const { container } = render(<BacklogPanel samples={drainingFixture} />);
     const stateSpan = container.querySelector(".backlog-runway-state");
     expect(stateSpan).not.toBeNull();
-    expect(stateSpan!.textContent).toMatch(/until the queue empties/);
+    expect(stateSpan!.textContent).toMatch(/to clear the open backlog/);
     expect(stateSpan!.classList.contains("draining")).toBe(true);
 
     const projItem = Array.from(container.querySelectorAll(".trend-legend-item")).find(

--- a/office-hours/test/BacklogPanel.test.tsx
+++ b/office-hours/test/BacklogPanel.test.tsx
@@ -59,7 +59,7 @@ describe("BacklogPanel", () => {
     const { container } = render(<BacklogPanel samples={drainingFixture} />);
     const stateSpan = container.querySelector(".backlog-runway-state");
     expect(stateSpan).not.toBeNull();
-    expect(stateSpan!.textContent).toMatch(/to clear the open backlog/);
+    expect(stateSpan!.textContent).toMatch(/to clear the open backlog/); // type-safety-ok: non-null asserted by preceding expect
     expect(stateSpan!.classList.contains("draining")).toBe(true);
 
     const projItem = Array.from(container.querySelectorAll(".trend-legend-item")).find(

--- a/office-hours/test/backlog-runway.test.ts
+++ b/office-hours/test/backlog-runway.test.ts
@@ -51,12 +51,12 @@ describe("fitBacklogRunway", () => {
     expect(isFinite(fit.daysUntilEmpty)).toBe(true);
   });
 
-  it("draining: runwayVerdict text matches 'until the queue empties'", () => {
+  it("draining: runwayVerdict text matches 'to clear the open backlog'", () => {
     const fit = fitBacklogRunway(drainingFixture);
     expect(fit.state).toBe("draining");
     const verdict = runwayVerdict(fit);
     expect(verdict.state).toBe("draining");
-    expect(verdict.text).toMatch(/until the queue empties/);
+    expect(verdict.text).toMatch(/to clear the open backlog/);
   });
 
   it("returns 'stable' for a flat backlog", () => {
@@ -126,7 +126,7 @@ describe("runwayVerdict", () => {
       crossingAt: new Date("2026-01-02T00:00:00Z"),
     };
     const { text } = runwayVerdict(fit);
-    expect(text).toMatch(/~1 day until the queue empties/);
+    expect(text).toMatch(/~1 day to clear the open backlog/);
   });
 
   it("formats plural 'days' when daysUntilEmpty rounds to > 1", () => {
@@ -138,6 +138,6 @@ describe("runwayVerdict", () => {
       crossingAt: new Date("2026-01-05T00:00:00Z"),
     };
     const { text } = runwayVerdict(fit);
-    expect(text).toMatch(/~4 days until the queue empties/);
+    expect(text).toMatch(/~4 days to clear the open backlog/);
   });
 });

--- a/office-hours/test/issue-history-chart.test.ts
+++ b/office-hours/test/issue-history-chart.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { renderIssueHistoryChart } from "../src/issue-history-chart.js";
+import { renderIssueHistoryChart, POINT_WIDTH, MAX_PROJECTION_DAYS } from "../src/issue-history-chart.js";
 import { fitBacklogRunway } from "../src/backlog-runway.js";
+import { MARGIN_RIGHT } from "../src/chart-util.js";
 import type { IssueSample } from "../src/issue-samples.js";
 
 function withFg(): HTMLElement {
@@ -145,11 +146,6 @@ describe("renderIssueHistoryChart", () => {
   });
 
   it("draining with long horizon: forward projection capped at MAX_PROJECTION_DAYS, chart width far below uncapped", () => {
-    // Mirror the source constants for an independent width re-derivation.
-    const POINT_WIDTH = 60;
-    const MARGIN_RIGHT = 20;
-    const MAX_PROJECTION_DAYS = 14;
-
     // 20 daily samples (dataDays = 19) with a shallow decline → daysUntilEmpty
     // far exceeds the 14-day ceiling, so the cap binds on MAX_PROJECTION_DAYS
     // (not on dataDays and not on daysUntilEmpty).
@@ -189,5 +185,51 @@ describe("renderIssueHistoryChart", () => {
     expect(actualWidth).toBeCloseTo(cappedWidth, 1);
     // The cap matters: the uncapped width is far larger.
     expect(uncappedWidth).toBeGreaterThan(cappedWidth * 1.5);
+  });
+
+  it("draining with short history: forward projection capped at dataDays, not MAX_PROJECTION_DAYS", () => {
+    // 10 daily samples (dataDays = 9 < MAX_PROJECTION_DAYS = 14) with a gentle
+    // decline → daysUntilEmpty ≈ 40 days >> dataDays, so dataDays is the binding
+    // cap (not daysUntilEmpty and not MAX_PROJECTION_DAYS).
+    //
+    // N = 10 keeps the computed formula width (1220px) above happy-dom's ~590px
+    // floor so Math.max picks the formula, making the cap observable.
+    const N = 10;
+    // Totals: 40, 39, 38, ... 31 — exact slope = -1/day, intercept = 40,
+    // daysUntilEmpty = 40 >> dataDays = 9.
+    const shortHistoryFixture: IssueSample[] = Array.from({ length: N }, (_, i) => ({
+      sampledAt: new Date(Date.UTC(2026, 4, 1 + i)),
+      openSecurity: 1,
+      openBug: 10 - i, // 10 → 1
+      openEnhancement: 15,
+      openOther: 14,
+      groupId: "g",
+    }));
+
+    const fit = fitBacklogRunway(shortHistoryFixture);
+    expect(fit.state).toBe("draining");
+    if (fit.state !== "draining") throw new Error("expected draining fit");
+
+    const dataDays = N - 1; // 9
+    expect(dataDays).toBeLessThan(MAX_PROJECTION_DAYS); // dataDays is the binding cap
+    expect(fit.daysUntilEmpty).toBeGreaterThan(MAX_PROJECTION_DAYS); // crossing is not binding
+
+    const host = withFg();
+    const el = renderIssueHistoryChart(shortHistoryFixture);
+    host.appendChild(el);
+
+    const svg = el.querySelector(".chart-scroll-wrapper svg") as HTMLElement;
+    const actualWidth = parseFloat(svg.style.width);
+
+    const pxPerDay = (N * POINT_WIDTH) / dataDays;
+    // dataDays binds: projection extends exactly dataDays into the future.
+    const dataDaysCappedWidth = N * POINT_WIDTH + pxPerDay * dataDays + MARGIN_RIGHT;
+    const maxDaysCappedWidth = N * POINT_WIDTH + pxPerDay * MAX_PROJECTION_DAYS + MARGIN_RIGHT;
+
+    // The formula must exceed the happy-dom floor or the cap is not observable.
+    expect(dataDaysCappedWidth).toBeGreaterThan(590);
+    expect(actualWidth).toBeCloseTo(dataDaysCappedWidth, 1);
+    // Confirm dataDays cap is genuinely tighter than MAX_PROJECTION_DAYS.
+    expect(dataDaysCappedWidth).toBeLessThan(maxDaysCappedWidth);
   });
 });

--- a/office-hours/test/issue-history-chart.test.ts
+++ b/office-hours/test/issue-history-chart.test.ts
@@ -218,7 +218,7 @@ describe("renderIssueHistoryChart", () => {
     const el = renderIssueHistoryChart(shortHistoryFixture);
     host.appendChild(el);
 
-    const svg = el.querySelector(".chart-scroll-wrapper svg") as HTMLElement;
+    const svg = el.querySelector(".chart-scroll-wrapper svg") as HTMLElement; // type-safety-ok: SVGElement lacks style.width; cast needed to read inline width
     const actualWidth = parseFloat(svg.style.width);
 
     const pxPerDay = (N * POINT_WIDTH) / dataDays;

--- a/office-hours/test/issue-history-chart.test.ts
+++ b/office-hours/test/issue-history-chart.test.ts
@@ -106,7 +106,7 @@ describe("renderIssueHistoryChart", () => {
 
     const stateSpan = el.querySelector(".backlog-runway-state");
     expect(stateSpan).not.toBeNull();
-    expect(stateSpan!.textContent).toMatch(/to clear the open backlog/);
+    expect(stateSpan!.textContent).toMatch(/to clear the open backlog/); // type-safety-ok: non-null asserted by preceding expect
     expect(stateSpan!.classList.contains("draining")).toBe(true);
 
     const legend = el.querySelector(".trend-legend");
@@ -176,7 +176,7 @@ describe("renderIssueHistoryChart", () => {
     const el = renderIssueHistoryChart(longHorizonFixture);
     host.appendChild(el);
 
-    const svg = el.querySelector(".chart-scroll-wrapper svg") as HTMLElement;
+    const svg = el.querySelector(".chart-scroll-wrapper svg") as HTMLElement; // type-safety-ok: SVGElement lacks style.width; cast needed to read inline width
     const actualWidth = parseFloat(svg.style.width);
 
     const pxPerDay = (N * POINT_WIDTH) / dataDays;

--- a/office-hours/test/issue-history-chart.test.ts
+++ b/office-hours/test/issue-history-chart.test.ts
@@ -105,7 +105,7 @@ describe("renderIssueHistoryChart", () => {
 
     const stateSpan = el.querySelector(".backlog-runway-state");
     expect(stateSpan).not.toBeNull();
-    expect(stateSpan!.textContent).toMatch(/until the queue empties/);
+    expect(stateSpan!.textContent).toMatch(/to clear the open backlog/);
     expect(stateSpan!.classList.contains("draining")).toBe(true);
 
     const legend = el.querySelector(".trend-legend");

--- a/office-hours/test/issue-history-chart.test.ts
+++ b/office-hours/test/issue-history-chart.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { renderIssueHistoryChart } from "../src/issue-history-chart.js";
+import { fitBacklogRunway } from "../src/backlog-runway.js";
 import type { IssueSample } from "../src/issue-samples.js";
 
 function withFg(): HTMLElement {
@@ -141,5 +142,52 @@ describe("renderIssueHistoryChart", () => {
 
     const text = stateSpan!.textContent ?? "";
     expect(text).not.toMatch(/NaN|Infinity/);
+  });
+
+  it("draining with long horizon: forward projection capped at MAX_PROJECTION_DAYS, chart width far below uncapped", () => {
+    // Mirror the source constants for an independent width re-derivation.
+    const POINT_WIDTH = 60;
+    const MARGIN_RIGHT = 20;
+    const MAX_PROJECTION_DAYS = 14;
+
+    // 20 daily samples (dataDays = 19) with a shallow decline → daysUntilEmpty
+    // far exceeds the 14-day ceiling, so the cap binds on MAX_PROJECTION_DAYS
+    // (not on dataDays and not on daysUntilEmpty).
+    const N = 20;
+    const longHorizonFixture: IssueSample[] = Array.from({ length: N }, (_, i) => ({
+      sampledAt: new Date(Date.UTC(2026, 4, 1 + i)),
+      openSecurity: 1,
+      openBug: 10,
+      openEnhancement: 10,
+      openOther: 30 - Math.floor(i / 2),
+      groupId: "g",
+    }));
+
+    const fit = fitBacklogRunway(longHorizonFixture);
+    expect(fit.state).toBe("draining");
+    if (fit.state !== "draining") throw new Error("expected draining fit");
+
+    // Consecutive daily UTC-midnight samples → dataDays is exactly N - 1.
+    const dataDays = N - 1;
+    expect(dataDays).toBeGreaterThan(MAX_PROJECTION_DAYS); // dataDays not binding
+    expect(fit.daysUntilEmpty).toBeGreaterThan(MAX_PROJECTION_DAYS); // crossing not binding
+
+    const host = withFg();
+    const el = renderIssueHistoryChart(longHorizonFixture);
+    host.appendChild(el);
+
+    const svg = el.querySelector(".chart-scroll-wrapper svg") as HTMLElement;
+    const actualWidth = parseFloat(svg.style.width);
+
+    const pxPerDay = (N * POINT_WIDTH) / dataDays;
+    const cappedWidth = N * POINT_WIDTH + pxPerDay * MAX_PROJECTION_DAYS + MARGIN_RIGHT;
+    const uncappedWidth = N * POINT_WIDTH + pxPerDay * fit.daysUntilEmpty + MARGIN_RIGHT;
+
+    // The capped formula must beat the happy-dom 590 floor, else Math.max would
+    // return the floor and the assertion below would not test the cap.
+    expect(cappedWidth).toBeGreaterThan(590);
+    expect(actualWidth).toBeCloseTo(cappedWidth, 1);
+    // The cap matters: the uncapped width is far larger.
+    expect(uncappedWidth).toBeGreaterThan(cappedWidth * 1.5);
   });
 });


### PR DESCRIPTION
Closes #2509

## Problem

The office-hours dashboard showed two runway numbers that read as
contradictory because they shared the wording "the queue empties":

- The **backlog-history chart caption** (e.g. "~33 days until the queue
  empties") is a linear regression over the **entire open backlog** (the
  four-bucket sum: security + bug + enhancement + other), from
  `runwayVerdict()` in `backlog-runway.ts`.
- The **queue status band / metrics panel** runway (e.g. "~8 days until the
  queue empties") is a trailing-window net-drain rate over the **help-wanted
  subset**, from `metrics.runwayDays`.

These are legitimately different measures, but the shared phrasing made them
read as one self-contradicting metric. The chart also set its x-domain end to
the regression's far-future zero-crossing and scaled its width by the full
`daysUntilEmpty`, so the axis ran ~a month past the latest sample and was
dominated by empty future space.

## Fix

Resolve the contradiction by **divergence** — the two surfaces stop sharing
wording — and window the chart's forward projection.

**Unit 1 — relabel the backlog-history caption.** The draining caption now
reads `~N days to clear the open backlog at current trend`. "open backlog"
names the regression's population (distinct from the help-wanted queue) and
"to clear … at current trend" signals a trend extrapolation. The help-wanted
queue band (`queue-band.ts`) keeps "until the queue empties" — that wording is
correct there, and leaving it is *why* the contradiction resolves.

**Unit 2 — cap the chart's forward projection.** A new local
`MAX_PROJECTION_DAYS = 14` caps the projection horizon to
`min(daysUntilEmpty, dataDays, MAX_PROJECTION_DAYS)`. The x-domain, dashed
projection-line endpoint, and chart width now use this capped window. When the
cap does not bind, the geometry is algebraically identical to before; when it
binds, the dashed line terminates on the right frame edge. The whole-backlog
caption still cites the full `daysUntilEmpty` — that divergence is intentional:
the chart is windowed, not forced onto `runwayDays`.

## Verification

- `npx vitest run --project office-hours --root .` — 306 passed (38 files),
  including the 5 updated wording assertions, a new test proving the chart
  width is capped far below the uncapped projection, and the untouched
  `queue-band.test.ts` (help-wanted wording left intact).
- `! grep -rn "until the queue empties" office-hours/src/backlog-runway.ts` —
  the old wording no longer appears in the whole-backlog source.
