### PR TITLE
print: lazy, async, bounded-concurrency local-folder enrichment with per-row loading indicator

### DIFF
--- a/print/src/concurrency.ts
+++ b/print/src/concurrency.ts
@@ -32,18 +32,24 @@ export function createLimiter(limit: number): Limiter {
     return new Promise<T>((resolve, reject) => {
       function run(): void {
         active++;
-        fn().then(
-          (value) => {
-            active--;
-            next();
-            resolve(value);
-          },
-          (err) => {
-            active--;
-            next();
-            reject(err);
-          },
-        );
+        try {
+          fn().then(
+            (value) => {
+              active--;
+              next();
+              resolve(value);
+            },
+            (err) => {
+              active--;
+              next();
+              reject(err);
+            },
+          );
+        } catch (err) {
+          active--;
+          next();
+          reject(err);
+        }
       }
 
       if (active < limit) {

--- a/print/src/concurrency.ts
+++ b/print/src/concurrency.ts
@@ -23,7 +23,7 @@ export function createLimiter(limit: number): Limiter {
 
   function next(): void {
     if (queue.length > 0 && active < limit) {
-      const run = queue.shift()!;
+      const run = queue.shift()!; // type-safety-ok: queue.length > 0 checked on the preceding line
       run();
     }
   }

--- a/print/src/concurrency.ts
+++ b/print/src/concurrency.ts
@@ -1,0 +1,58 @@
+/**
+ * A pLimit-style incremental scheduler that caps peak concurrency across an
+ * open, unbounded stream of tasks arriving over time (e.g. rows scrolling into
+ * a viewport). This is deliberately different from audio's `mapWithConcurrency`,
+ * which is a sliding-window pool over a fixed array known up front: that helper
+ * takes all items eagerly, spins up `limit` workers that race a shared cursor,
+ * and waits for the full batch. Here tasks arrive one at a time via `schedule`,
+ * the active count is shared instance state, and settling (resolve OR reject)
+ * always frees a slot so the queue never wedges. The two primitives cannot
+ * share an implementation, and the audio helper cannot cross the app boundary
+ * without a shared package. See issue #2496.
+ */
+
+export interface Limiter {
+  schedule<T>(fn: () => Promise<T>): Promise<T>;
+}
+
+export function createLimiter(limit: number): Limiter {
+  if (limit <= 0) throw new Error('createLimiter: limit must be > 0');
+
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  function next(): void {
+    if (queue.length > 0 && active < limit) {
+      const run = queue.shift()!;
+      run();
+    }
+  }
+
+  function schedule<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      function run(): void {
+        active++;
+        fn().then(
+          (value) => {
+            active--;
+            next();
+            resolve(value);
+          },
+          (err) => {
+            active--;
+            next();
+            reject(err);
+          },
+        );
+      }
+
+      if (active < limit) {
+        run();
+      } else {
+        queue.push(run);
+      }
+    });
+  }
+
+  return { schedule };
+}

--- a/print/src/local-folder-ui.ts
+++ b/print/src/local-folder-ui.ts
@@ -14,6 +14,7 @@ import { escapeHtml } from "@commons-systems/htmlutil";
 import { createFsaHandleStore } from "@commons-systems/local-first/fsa-handle-store";
 import { logError } from "@commons-systems/errorutil/log";
 
+import { createLimiter } from "./concurrency.js";
 import {
   createLocalSource,
   listLocal,
@@ -22,12 +23,22 @@ import {
 import { extractMetadata } from "./local-metadata.js";
 import { mediaTypeBadge } from "./media-render.js";
 import {
-  cacheMetadataBatch,
+  cacheMetadata,
   ensureLoaded,
   getMetadata,
   setLocalDirectory,
 } from "./sidecar.js";
 import type { MediaItem } from "./types.js";
+
+/**
+ * Peak in-flight file reads during local-folder enrichment. Mirrors audio's
+ * concurrency value. Unit tests derive `limit + 1` from this to assert the
+ * bound. The limiter is created ONCE at module load (below) — never per render
+ * pass — so a focus-rescan mid-enrichment cannot spawn a second limiter and
+ * double the peak read count, regardless of how many rows are visible.
+ */
+export const ENRICH_READ_CONCURRENCY = 16;
+const limiter = createLimiter(ENRICH_READ_CONCURRENCY);
 
 const store = createFsaHandleStore({ app: "print" });
 const PURPOSE = "library-folder";
@@ -166,17 +177,29 @@ function renderLocalMediaItems(items: MediaItem[]): string {
 }
 
 /**
- * The detached enrichment task in flight (or `Promise.resolve()` when none).
- * Reassigned on every `renderLocalIntoList` pass so `settleEnrichment` always
- * awaits the most recent pass's enrichment. The twin of sidecar's `flushWrites`.
+ * The accumulated detached enrichment of the current render pass (or
+ * `Promise.resolve()` when none). Reset at the START of each
+ * `renderLocalIntoList` pass, then folded forward SYNCHRONOUSLY inside the
+ * IntersectionObserver callback as each visible row is scheduled, so
+ * `settleEnrichment` always awaits the most recent pass's scheduled reads. The
+ * twin of sidecar's `flushWrites`.
  */
 let pendingEnrichment: Promise<void> = Promise.resolve();
 
 /**
- * Settle seam: resolves when the in-flight detached enrichment of the latest
- * render pass has finished (every row patched and the batched cache write
- * enqueued). Tests await this before `flushWrites` to observe the cache write;
- * `bindAndRender` does NOT await it — first paint is already done.
+ * Handle to the previous render pass's IntersectionObserver, so each new pass
+ * can disconnect it before building a fresh one — avoiding leaked observers and
+ * observation of now-detached rows on a focus-rescan.
+ */
+let prevObserver: IntersectionObserver | null = null;
+
+/**
+ * Settle seam: resolves when the scheduled enrichment of the latest render pass
+ * has finished (every intersected row patched and its single cache write
+ * enqueued). Tests do `triggerIntersection(); await settleEnrichment();`, which
+ * works because the observer callback folds each scheduled read into
+ * `pendingEnrichment` synchronously before it returns. `bindAndRender` does NOT
+ * await it — first paint is already done.
  */
 export function settleEnrichment(): Promise<void> {
   return pendingEnrichment;
@@ -187,10 +210,12 @@ export function settleEnrichment(): Promise<void> {
  * PAINT: find (or create) the `#media-list` <ul>, do a single bounded sidecar
  * read, partition items into cached (overlaid with real metadata, zero file IO)
  * vs uncached (filename-stem rows), strip prior local rows, and insert all rows
- * immediately. Cold-folder metadata extraction for the uncached items runs
- * DETACHED after this resolves — a hung extract never blocks first paint or the
- * focus listener. No-ops when no media list or empty-state placeholder is
- * present (e.g. viewer page).
+ * immediately. Cold-folder metadata extraction for the uncached items is LAZY:
+ * an IntersectionObserver schedules each row's bounded-concurrency read only as
+ * it scrolls into view, so a folder of N files no longer kicks off N eager
+ * reads — and a hung extract never blocks first paint or the focus listener.
+ * No-ops when no media list or empty-state placeholder is present (e.g. viewer
+ * page).
  */
 export async function renderLocalIntoList(container: HTMLElement): Promise<void> {
   const items = await listLocal();
@@ -225,49 +250,69 @@ export async function renderLocalIntoList(container: HTMLElement): Promise<void>
   for (const li of Array.from(ul.querySelectorAll(".media-item-local"))) {
     li.remove();
   }
+  // Reset the accumulator at the START of the pass: first paint schedules no
+  // enrichment yet — reads only begin as rows scroll into view (below).
+  pendingEnrichment = Promise.resolve();
+
   ul.insertAdjacentHTML("afterbegin", renderLocalMediaItems(rows));
-  // First paint is now done.
+  // First paint is now done. Rows render filename-only; NO spinner yet.
 
-  // Capture each uncached row's node by id, BY REFERENCE. item.id is
-  // `local:<folderId>/<name>` (contains `:` and `/`) so the data-id selector
-  // needs CSS.escape, not escapeHtml. Patching the captured node (never a
-  // re-query at patch time) means that patching a now-detached node (removed by
-  // a later render pass) succeeds silently but has no visible effect — the
-  // mutation reaches a node no longer in the document, not a live row.
-  const targets: { item: MediaItem; node: Element | null }[] = uncached.map(
-    (item) => ({
-      item,
-      node: ul.querySelector(`[data-id="${CSS.escape(item.id)}"]`),
-    }),
-  );
+  // Map each uncached row's NODE → item, looked up by id BY REFERENCE. item.id
+  // is `local:<folderId>/<name>` (contains `:` and `/`) so the data-id selector
+  // needs CSS.escape, not escapeHtml. Skip rows whose node lookup returns null.
+  // Keying on the node lets the observer callback resolve an `entry.target`
+  // back to its item. Patching the captured node (never a re-query at patch
+  // time) means patching a now-detached node — removed by a later render pass —
+  // succeeds silently but has no visible effect.
+  const nodeItems = new Map<Element, MediaItem>();
+  for (const item of uncached) {
+    const node = ul.querySelector(`[data-id="${CSS.escape(item.id)}"]`);
+    if (node === null) continue;
+    nodeItems.set(node, item);
+  }
 
-  // Kick off detached enrichment for the uncached items only — not awaited.
-  // Reassigned each pass so settleEnrichment tracks the latest render.
-  pendingEnrichment = runEnrichment(targets).catch((err) =>
-    logError(err, { operation: "local-folder-enrich" }),
-  );
-}
+  // Always tear down the previous pass's observer first: it observes rows this
+  // pass has just removed (now detached), and a focus-rescan would otherwise
+  // leak observers. A pass with zero uncached rows tears down and stops here —
+  // no new observer.
+  prevObserver?.disconnect();
+  if (nodeItems.size === 0) {
+    prevObserver = null;
+    return;
+  }
 
-/**
- * Enrich the uncached items, patching each row in place as its extract resolves.
- * Reads each file's bytes via `resolveLocalBlob`, extracts metadata (tolerant —
- * `{}` on error), and patches the captured node. Run with `Promise.all` so a
- * hung item never blocks another's patch. After all settle, persist every
- * newly-extracted entry in ONE batched cache write — an empty batch is a no-op,
- * preserving focus-rescan write suppression.
- *
- * Null-blob retry: a file that can't be read yields no patch and no cache entry,
- * so it re-extracts on the next focus pass rather than being permanently
- * suppressed by a cached `{}`.
- */
-async function runEnrichment(
-  targets: { item: MediaItem; node: Element | null }[],
-): Promise<void> {
-  const results = await Promise.all(targets.map((t) => enrichLocalItem(t)));
-  const newEntries = Object.fromEntries(
-    results.filter((r): r is [string, { title?: string; pageCount?: number }] => r !== null),
-  );
-  await cacheMetadataBatch(newEntries);
+  // Lazy enrichment: read + extract a row's bytes only when it scrolls into
+  // view. The callback is SYNCHRONOUS — all awaiting lives inside the scheduled
+  // fn — so `pendingEnrichment` is folded forward before the callback yields,
+  // making the `settleEnrichment` seam observable right after an intersection.
+  //
+  // Coherence under a mid-flight focus-rescan: the limiter is long-lived
+  // (module-scoped), so a rescan reuses it rather than spawning a second one
+  // that would double peak reads. In-flight tasks from the prior pass patch
+  // now-detached nodes — a no-op via patchLocalRow's isConnected guard — and
+  // their cacheMetadata write is idempotent for the same content, so the
+  // long-lived limiter + per-pass observer combination stays coherent.
+  const observer = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (!entry.isIntersecting) continue;
+      // One-shot: unobserve before scheduling so a re-fire can't double-read
+      // (the per-row analog of budget's `loading` bool).
+      observer.unobserve(entry.target);
+      const item = nodeItems.get(entry.target);
+      if (item === undefined) continue;
+      const node = entry.target;
+      markRowLoading(node);
+      const p = limiter.schedule(() => enrichLocalItem({ item, node }));
+      // Fold into the accumulator SYNCHRONOUSLY (before this callback yields).
+      pendingEnrichment = Promise.allSettled([pendingEnrichment, p]).then(
+        () => {},
+      );
+    }
+  });
+  prevObserver = observer;
+  for (const node of nodeItems.keys()) {
+    observer.observe(node);
+  }
 }
 
 function overlay(
@@ -333,29 +378,38 @@ function patchLocalRow(
 }
 
 /**
- * Extract one uncached item's metadata and patch its captured row. Returns the
- * `[storagePath, meta]` cache entry to contribute to the batched write, or null
- * when nothing new was extracted (unreadable file or extract error) so it
- * contributes nothing — and, for an unreadable file, is not cached, leaving the
- * null-retry path open.
+ * Extract one uncached item's metadata, patch its captured row, and persist the
+ * entry with a single incremental `cacheMetadata` write. Writes even when `meta`
+ * is `{}` — that empty entry is what suppresses re-extraction on the next render
+ * pass. Only an unreadable file (null blob) skips caching, leaving the
+ * null-retry path open so a later focus re-extracts it rather than being
+ * permanently suppressed by a cached `{}`.
+ *
+ * The loading spinner is cleared in a `finally`, REGARDLESS of outcome — so even
+ * a null-blob fallback row (which never reaches `patchLocalRow`) never keeps a
+ * stuck spinner. The inner try/catch swallows extract errors (logged); the
+ * finally runs in addition.
  */
 async function enrichLocalItem(
   target: { item: MediaItem; node: Element | null },
-): Promise<[string, { title?: string; pageCount?: number }] | null> {
+): Promise<void> {
   const { item, node } = target;
   try {
-    const buf = await resolveLocalBlob(item);
-    if (buf === null) {
-      // Could not read this file — do NOT cache `{}` (that would permanently
-      // suppress retry). A later focus retries.
-      return null;
+    try {
+      const buf = await resolveLocalBlob(item);
+      if (buf === null) {
+        // Could not read this file — do NOT cache `{}` (that would permanently
+        // suppress retry). A later focus retries.
+        return;
+      }
+      const meta = await extractMetadata(buf, item.mediaType);
+      patchLocalRow(node, meta);
+      // Persist incrementally: a single entry, written even when `meta` is `{}`.
+      await cacheMetadata(item.storagePath, meta);
+    } catch (err) {
+      logError(err, { operation: "local-folder-enrich", id: item.id });
     }
-    const meta = await extractMetadata(buf, item.mediaType);
-    patchLocalRow(node, meta);
-    // Contribute this entry to the render pass's single batched write.
-    return [item.storagePath, meta];
-  } catch (err) {
-    logError(err, { operation: "local-folder-enrich", id: item.id });
-    return null;
+  } finally {
+    clearRowLoading(node);
   }
 }

--- a/print/src/local-folder-ui.ts
+++ b/print/src/local-folder-ui.ts
@@ -284,15 +284,39 @@ function overlay(
 }
 
 /**
+ * Append a CSS-only loading spinner into the row's `.media-info`. Guards
+ * against double-insert. No-op on a null or detached node.
+ */
+function markRowLoading(node: Element | null): void {
+  if (node === null || !node.isConnected) return;
+  const info = node.querySelector(".media-info");
+  if (!info || info.querySelector(".media-loading")) return;
+  const spinner = document.createElement("span");
+  spinner.className = "media-loading";
+  spinner.setAttribute("aria-hidden", "true");
+  info.appendChild(spinner);
+}
+
+/**
+ * Remove any `.media-loading` spinner from the row. No-op on a null or
+ * detached node.
+ */
+function clearRowLoading(node: Element | null): void {
+  if (node === null || !node.isConnected) return;
+  node.querySelector(".media-loading")?.remove();
+}
+
+/**
  * Patch a captured local row in place with extracted metadata, building DOM via
  * textContent so no manual escaping is needed. A null or detached node is a
- * no-op.
+ * no-op. Clears the loading spinner (if present) before patching.
  */
 function patchLocalRow(
   node: Element | null,
   meta: { title?: string; pageCount?: number },
 ): void {
   if (node === null || !node.isConnected) return;
+  clearRowLoading(node);
   if (meta.title !== undefined) {
     const titleLink = node.querySelector(".media-title a");
     if (titleLink) titleLink.textContent = meta.title;

--- a/print/src/sidecar.ts
+++ b/print/src/sidecar.ts
@@ -156,21 +156,6 @@ export async function cacheMetadata(
   return enqueueWrite({ metadata: { [filename]: meta } });
 }
 
-/**
- * Merge many metadata entries into the model in a SINGLE serialized write. This
- * is the batch form of `cacheMetadata`: the list-enrichment path accumulates
- * every newly-extracted entry for a render pass and persists them in one
- * index.json rewrite, instead of N sequential full-file rewrites (one per new
- * file). An empty `entries` is a no-op — it neither touches the chain nor writes
- * the file, preserving focus-rescan write suppression when nothing is new.
- */
-export async function cacheMetadataBatch(
-  entries: Record<string, { title?: string; pageCount?: number }>,
-): Promise<void> {
-  if (Object.keys(entries).length === 0) return;
-  return enqueueWrite({ metadata: entries });
-}
-
 // ---------------------------------------------------------------------------
 // D. PositionStore interface + sidecar-backed implementation
 // ---------------------------------------------------------------------------

--- a/print/src/style/theme.css
+++ b/print/src/style/theme.css
@@ -48,6 +48,24 @@
   border-radius: var(--radius-sm);
 }
 
+@keyframes media-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.media-loading {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  font-size: var(--text-xs);
+  border: 0.15em solid var(--muted);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: media-spin 0.7s linear infinite;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
 .media-actions {
   display: flex;
   gap: var(--space-1);

--- a/print/test/concurrency.test.ts
+++ b/print/test/concurrency.test.ts
@@ -1,21 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { createLimiter } from "../src/concurrency";
-
-interface Deferred<T> {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (reason: unknown) => void;
-}
-
-function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void; // type-safety-ok: assigned synchronously inside the Promise constructor below
-  let reject!: (reason: unknown) => void; // type-safety-ok: assigned synchronously inside the Promise constructor below
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
+import { deferred, type Deferred } from "./utils";
 
 /** Flush the microtask queue by awaiting a chain of resolved promises. */
 async function flushMicrotasks(): Promise<void> {
@@ -66,7 +51,6 @@ describe("createLimiter", () => {
     it("a later task still runs after an earlier task rejects", async () => {
       const limiter = createLimiter(1);
 
-      const firstDone = deferred<void>();
       const scheduleFirst = limiter.schedule(() =>
         Promise.reject(new Error("first fails")),
       );
@@ -76,7 +60,6 @@ describe("createLimiter", () => {
       await expect(scheduleFirst).rejects.toThrow("first fails");
       const secondResult = await scheduleSecond;
       expect(secondResult).toBe("second ok");
-      void firstDone;
     });
   });
 

--- a/print/test/concurrency.test.ts
+++ b/print/test/concurrency.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { createLimiter } from "../src/concurrency";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Flush the microtask queue by awaiting a chain of resolved promises. */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("createLimiter", () => {
+  describe("Test D (guard)", () => {
+    it("throws when limit is 0", () => {
+      expect(() => createLimiter(0)).toThrow("limit must be > 0");
+    });
+
+    it("throws when limit is negative", () => {
+      expect(() => createLimiter(-1)).toThrow("limit must be > 0");
+    });
+  });
+
+  describe("Test B (results propagate)", () => {
+    it("resolves with the value returned by the scheduled fn", async () => {
+      const limiter = createLimiter(2);
+      const result = await limiter.schedule(() => Promise.resolve(42));
+      expect(result).toBe(42);
+    });
+
+    it("resolves multiple tasks with their respective values", async () => {
+      const limiter = createLimiter(2);
+      const [a, b, c] = await Promise.all([
+        limiter.schedule(() => Promise.resolve("x")),
+        limiter.schedule(() => Promise.resolve("y")),
+        limiter.schedule(() => Promise.resolve("z")),
+      ]);
+      expect(a).toBe("x");
+      expect(b).toBe("y");
+      expect(c).toBe("z");
+    });
+  });
+
+  describe("Test C (rejection does not wedge the queue)", () => {
+    it("rejects the schedule() promise when the fn rejects", async () => {
+      const limiter = createLimiter(2);
+      await expect(
+        limiter.schedule(() => Promise.reject(new Error("boom"))),
+      ).rejects.toThrow("boom");
+    });
+
+    it("a later task still runs after an earlier task rejects", async () => {
+      const limiter = createLimiter(1);
+
+      const firstDone = deferred<void>();
+      const scheduleFirst = limiter.schedule(() =>
+        Promise.reject(new Error("first fails")),
+      );
+      // second is queued behind first (limit=1)
+      const scheduleSecond = limiter.schedule(() => Promise.resolve("second ok"));
+
+      await expect(scheduleFirst).rejects.toThrow("first fails");
+      const secondResult = await scheduleSecond;
+      expect(secondResult).toBe("second ok");
+      void firstDone;
+    });
+  });
+
+  describe("Test A (bound holds — non-vacuous concurrency cap)", () => {
+    it("does not exceed `limit` in-flight tasks at once", async () => {
+      const LIMIT = 2;
+      const TASK_COUNT = 5;
+      const limiter = createLimiter(LIMIT);
+
+      let active = 0;
+      let maxSeen = 0;
+      const deferreds: Array<Deferred<number>> = [];
+
+      const schedulePromises = Array.from({ length: TASK_COUNT }, (_, i) => {
+        const d = deferred<number>();
+        deferreds.push(d);
+        return limiter.schedule(async () => {
+          active++;
+          if (active > maxSeen) maxSeen = active;
+          const result = await d.promise;
+          active--;
+          return result;
+        });
+      });
+
+      // Allow the first `LIMIT` tasks to start (microtask scheduling).
+      await flushMicrotasks();
+
+      // Before releasing any deferred, the cap must hold.
+      expect(maxSeen).toBeLessThanOrEqual(LIMIT);
+      expect(active).toBe(LIMIT);
+
+      // Resolve all deferreds one-by-one and verify all schedule() promises settle.
+      for (let i = 0; i < TASK_COUNT; i++) {
+        deferreds[i].resolve(i);
+        await flushMicrotasks();
+      }
+
+      const results = await Promise.all(schedulePromises);
+      expect(results).toEqual([0, 1, 2, 3, 4]);
+
+      // All tasks ran; cap was never exceeded.
+      expect(maxSeen).toBeLessThanOrEqual(LIMIT);
+      expect(active).toBe(0);
+    });
+  });
+});

--- a/print/test/concurrency.test.ts
+++ b/print/test/concurrency.test.ts
@@ -8,8 +8,8 @@ interface Deferred<T> {
 }
 
 function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  let reject!: (reason: unknown) => void;
+  let resolve!: (value: T) => void; // type-safety-ok: assigned synchronously inside the Promise constructor below
+  let reject!: (reason: unknown) => void; // type-safety-ok: assigned synchronously inside the Promise constructor below
   const promise = new Promise<T>((res, rej) => {
     resolve = res;
     reject = rej;

--- a/print/test/enrichment.test.ts
+++ b/print/test/enrichment.test.ts
@@ -85,6 +85,7 @@ import {
 } from "../src/sidecar.js";
 import type { MediaItem, SidecarData } from "../src/sidecar.js";
 import type { MediaItem as LibMediaItem } from "../src/types.js";
+import { deferred } from "./utils";
 
 // ---------------------------------------------------------------------------
 // Fake FileSystemDirectoryHandle (same pattern as sidecar.test.ts)
@@ -205,21 +206,6 @@ function makeContainer(): HTMLElement {
   return container;
 }
 
-/**
- * A manually-resolvable promise. Used to gate `resolveLocalBlob` so a test can
- * hold reads in-flight and assert the limiter's bound deterministically — never
- * a real timer.
- */
-function deferred<T>() {
-  let resolve!: (v: T) => void; // type-safety-ok: assigned synchronously inside the Promise constructor below
-  let reject!: (e?: unknown) => void; // type-safety-ok: assigned synchronously inside the Promise constructor below
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
-
 // ---------------------------------------------------------------------------
 // Fake IntersectionObserver. happy-dom has no real IntersectionObserver, so we
 // install a stub that only REGISTERS observed nodes (never fires `cb` on its
@@ -280,11 +266,6 @@ function rowNode(container: HTMLElement, item: LibMediaItem): Element {
     throw new Error(`rowNode: no rendered row found for item id "${item.id}"`);
   }
   return node;
-}
-
-/** Flush a few microtask turns (no real timers). */
-async function flushMicrotasks(times = 3): Promise<void> {
-  for (let i = 0; i < times; i++) await Promise.resolve();
 }
 
 // Install the FakeIO global for every test in the file. Stacks with each

--- a/print/test/enrichment.test.ts
+++ b/print/test/enrichment.test.ts
@@ -71,7 +71,11 @@ vi.mock("@commons-systems/errorutil/log", () => ({
 // ---------------------------------------------------------------------------
 // Import real modules AFTER mocks are declared
 // ---------------------------------------------------------------------------
-import { renderLocalIntoList, settleEnrichment } from "../src/local-folder-ui.js";
+import {
+  renderLocalIntoList,
+  settleEnrichment,
+  ENRICH_READ_CONCURRENCY,
+} from "../src/local-folder-ui.js";
 import {
   setLocalDirectory,
   flushWrites,
@@ -201,6 +205,98 @@ function makeContainer(): HTMLElement {
   return container;
 }
 
+/**
+ * A manually-resolvable promise. Used to gate `resolveLocalBlob` so a test can
+ * hold reads in-flight and assert the limiter's bound deterministically — never
+ * a real timer.
+ */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// ---------------------------------------------------------------------------
+// Fake IntersectionObserver. happy-dom has no real IntersectionObserver, so we
+// install a stub that only REGISTERS observed nodes (never fires `cb` on its
+// own). A test fires the intersection for a specific row node via
+// `triggerIntersection`, which drives the production lazy path. Keying the
+// registry by element lets a test target one row; `triggerIntersection` picks
+// the MOST RECENT entry for a node so a multi-pass test resolves a fresh
+// pass-2 node, not a detached pass-1 one.
+// ---------------------------------------------------------------------------
+let ioRegistry: Array<{
+  cb: IntersectionObserverCallback;
+  el: Element;
+  observer: IntersectionObserver;
+}> = [];
+
+class FakeIO {
+  cb: IntersectionObserverCallback;
+  constructor(cb: IntersectionObserverCallback) {
+    this.cb = cb;
+  }
+  observe(el: Element): void {
+    ioRegistry.push({ cb: this.cb, el, observer: this as unknown as IntersectionObserver });
+  }
+  // Production calls unobserve as a one-shot before scheduling; a no-op here is
+  // fine because each node is fired exactly once per pass.
+  unobserve(): void {}
+  // Drop this observer's entries so a torn-down (prior-pass) observer cannot be
+  // re-triggered.
+  disconnect(): void {
+    ioRegistry = ioRegistry.filter((e) => e.observer !== (this as unknown as IntersectionObserver));
+  }
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+/** Fire `isIntersecting: true` for a specific row node (most recent entry). */
+function triggerIntersection(node: Element): void {
+  for (let i = ioRegistry.length - 1; i >= 0; i--) {
+    const entry = ioRegistry[i];
+    if (entry.el === node) {
+      entry.cb(
+        [{ isIntersecting: true, target: node } as IntersectionObserverEntry],
+        entry.observer,
+      );
+      return;
+    }
+  }
+  throw new Error(
+    "triggerIntersection: no IntersectionObserver entry registered for the given node — the lazy enrichment path was not wired for it",
+  );
+}
+
+/** Look up a rendered local row node by its item id. */
+function rowNode(container: HTMLElement, item: LibMediaItem): Element {
+  const node = container.querySelector(`[data-id="${CSS.escape(item.id)}"]`);
+  if (node === null) {
+    throw new Error(`rowNode: no rendered row found for item id "${item.id}"`);
+  }
+  return node;
+}
+
+/** Flush a few microtask turns (no real timers). */
+async function flushMicrotasks(times = 3): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+// Install the FakeIO global for every test in the file. Stacks with each
+// describe's own clearAllMocks/innerHTML hooks.
+beforeEach(() => {
+  ioRegistry = [];
+  vi.stubGlobal("IntersectionObserver", FakeIO as unknown as typeof IntersectionObserver);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -230,7 +326,9 @@ describe("enrichment — cached item (zero IO, no write)", () => {
     await renderLocalIntoList(container);
     await flushWrites();
 
-    // Neither resolveLocalBlob nor extractMetadata should be called
+    // The cached item is not uncached, so NO observer is registered for it and
+    // there is nothing to trigger — no IO occurs.
+    expect(ioRegistry).toHaveLength(0);
     expect(mockResolveLocalBlob).not.toHaveBeenCalled();
     expect(mockExtractMetadata).not.toHaveBeenCalled();
 
@@ -259,6 +357,8 @@ describe("enrichment — uncached item (extracts and caches)", () => {
 
     const container = makeContainer();
     await renderLocalIntoList(container);
+    // Lazy: enrichment fires only when the row scrolls into view.
+    triggerIntersection(rowNode(container, item));
     await settleEnrichment();
     await flushWrites();
 
@@ -285,6 +385,7 @@ describe("enrichment — uncached item (extracts and caches)", () => {
 
     const container = makeContainer();
     await renderLocalIntoList(container);
+    triggerIntersection(rowNode(container, item));
     await settleEnrichment();
     await flushWrites();
 
@@ -324,7 +425,9 @@ describe("enrichment — write suppression on focus-rescan", () => {
     await renderLocalIntoList(container);
     await flushWrites();
 
-    // createWritable should NOT have been called (no new writes)
+    // All items cached → no uncached row → no observer built → nothing to
+    // trigger. createWritable should NOT have been called (no new writes).
+    expect(ioRegistry).toHaveLength(0);
     expect(indexHandle.createWritable.mock.calls.length).toBe(createWritableBefore);
     expect(mockExtractMetadata).not.toHaveBeenCalled();
     expect(mockResolveLocalBlob).not.toHaveBeenCalled();
@@ -342,14 +445,19 @@ describe("enrichment — write suppression on focus-rescan", () => {
     setLocalDirectory(dir, true);
 
     const container = makeContainer();
-    // First render: extracts and caches {}
+    // First render: row is uncached → observer registers it. Scroll it into
+    // view → extract and cache {}.
     await renderLocalIntoList(container);
+    triggerIntersection(rowNode(container, item));
     await settleEnrichment();
     await flushWrites();
     expect(mockExtractMetadata).toHaveBeenCalledTimes(1);
 
-    // Second render (simulates focus rescan): {} is a defined entry → no re-extract
+    // Second render (simulates focus rescan): {} is now a defined cache entry,
+    // so the row partitions into `rows` (not `uncached`) → no observer is built
+    // for it → nothing to trigger → no re-extract.
     await renderLocalIntoList(container);
+    expect(ioRegistry).toHaveLength(0);
     await settleEnrichment();
     await flushWrites();
     expect(mockExtractMetadata).toHaveBeenCalledTimes(1); // still only once
@@ -373,7 +481,10 @@ describe("enrichment — resolveLocalBlob returns null (file gone)", () => {
     setLocalDirectory(dir, true);
 
     const container = makeContainer();
+    // First pass: scroll the row in → resolveLocalBlob returns null → no
+    // extract, nothing cached.
     await renderLocalIntoList(container);
+    triggerIntersection(rowNode(container, item));
     await settleEnrichment();
     await flushWrites();
 
@@ -383,6 +494,18 @@ describe("enrichment — resolveLocalBlob returns null (file gone)", () => {
     // No entry should be cached (so next render can retry)
     const cached = await getMetadata("gone.pdf");
     expect(cached).toBeUndefined();
+    expect(mockResolveLocalBlob).toHaveBeenCalledTimes(1);
+
+    // Second pass: because nothing was cached, the row is STILL uncached, so a
+    // fresh observer registers it. Scrolling it in again re-attempts the read —
+    // proving the null-blob path is a retry, not a permanent suppression.
+    await renderLocalIntoList(container);
+    triggerIntersection(rowNode(container, item));
+    await settleEnrichment();
+    await flushWrites();
+
+    expect(mockResolveLocalBlob).toHaveBeenCalledTimes(2);
+    expect(mockExtractMetadata).not.toHaveBeenCalled();
   });
 });
 
@@ -406,7 +529,168 @@ describe("enrichment — early return when no media list present", () => {
     await renderLocalIntoList(container);
     await flushWrites();
 
+    // Bails before any observer is constructed.
+    expect(ioRegistry).toHaveLength(0);
     expect(mockExtractMetadata).not.toHaveBeenCalled();
     expect(mockResolveLocalBlob).not.toHaveBeenCalled();
+  });
+});
+
+describe("enrichment — lazy: deferred until intersection (criterion 1)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it("does no file IO at first paint, then reads on intersection", async () => {
+    const buf = new ArrayBuffer(8);
+    const item = makeLocalItem({ storagePath: "book.pdf", title: "book" });
+    mockListLocal.mockResolvedValue([item]);
+    mockResolveLocalBlob.mockResolvedValue(buf);
+    mockExtractMetadata.mockResolvedValue({ title: "Extracted Title" });
+
+    const dir = makeEmptyDir();
+    setLocalDirectory(dir, true);
+
+    const container = makeContainer();
+    await renderLocalIntoList(container);
+
+    // First paint: the row is rendered but NOT yet enriched — no read fired.
+    expect(mockResolveLocalBlob).not.toHaveBeenCalled();
+    expect(mockExtractMetadata).not.toHaveBeenCalled();
+
+    // Scrolling the row into view defers-then-fires the read.
+    triggerIntersection(rowNode(container, item));
+    await settleEnrichment();
+    await flushWrites();
+
+    expect(mockResolveLocalBlob).toHaveBeenCalledWith(item);
+    expect(mockExtractMetadata).toHaveBeenCalledWith(buf, "pdf");
+  });
+});
+
+describe("enrichment — bounded: reads route through the limiter (criterion 2)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it("caps in-flight reads at ENRICH_READ_CONCURRENCY; the (limit+1)th waits", async () => {
+    // One more item than the limiter's bound, each with a distinct id AND
+    // storagePath so every row is a distinct node and a distinct cache key.
+    const count = ENRICH_READ_CONCURRENCY + 1;
+    const items = Array.from({ length: count }, (_, i) =>
+      makeLocalItem({
+        id: `local:library/book-${i}.pdf`,
+        storagePath: `book-${i}.pdf`,
+        title: `book-${i}`,
+      }),
+    );
+    mockListLocal.mockResolvedValue(items);
+
+    // Each read returns a deferred we control. Resolving with `null` makes
+    // enrichLocalItem return early (no extract/cache) — shortest deterministic
+    // drain. The call itself fires regardless of the resolved value.
+    const gates: Array<ReturnType<typeof deferred<ArrayBuffer | null>>> = [];
+    mockResolveLocalBlob.mockImplementation(() => {
+      const g = deferred<ArrayBuffer | null>();
+      gates.push(g);
+      return g.promise;
+    });
+
+    const dir = makeEmptyDir();
+    setLocalDirectory(dir, true);
+
+    const container = makeContainer();
+    await renderLocalIntoList(container);
+
+    // Scroll EVERY row into view. Scheduling is synchronous inside the observer
+    // callback: the first ENRICH_READ_CONCURRENCY run immediately, the last is
+    // queued behind the limiter (its `fn` not yet invoked).
+    for (const item of items) {
+      triggerIntersection(rowNode(container, item));
+    }
+
+    // Exactly the bound's worth of reads started; none have resolved.
+    expect(mockResolveLocalBlob).toHaveBeenCalledTimes(ENRICH_READ_CONCURRENCY);
+
+    // Free one slot → the queued (limit+1)th read now runs. Freeing a slot
+    // takes enrichLocalItem through its awaits, so wait rather than count
+    // microtasks.
+    gates[0].resolve(null);
+    await vi.waitFor(() =>
+      expect(mockResolveLocalBlob).toHaveBeenCalledTimes(ENRICH_READ_CONCURRENCY + 1),
+    );
+
+    // Drain everything so no pending read leaks into the next test's shared,
+    // module-scoped limiter.
+    for (const g of gates) g.resolve(null);
+    await settleEnrichment();
+    await flushWrites();
+  });
+});
+
+describe("enrichment — loading state (criterion 3)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it("shows a spinner on intersection and clears it after the read settles", async () => {
+    const item = makeLocalItem({ storagePath: "book.pdf", title: "book" });
+    mockListLocal.mockResolvedValue([item]);
+    const gate = deferred<ArrayBuffer | null>();
+    mockResolveLocalBlob.mockReturnValue(gate.promise);
+    mockExtractMetadata.mockResolvedValue({ title: "Extracted Title" });
+
+    const dir = makeEmptyDir();
+    setLocalDirectory(dir, true);
+
+    const container = makeContainer();
+    await renderLocalIntoList(container);
+    const node = rowNode(container, item);
+
+    // Intersection adds the spinner synchronously, while the read is in flight.
+    triggerIntersection(node);
+    expect(node.querySelector(".media-loading")).not.toBeNull();
+
+    // Resolve the read → patch + cache → spinner cleared.
+    gate.resolve(new ArrayBuffer(8));
+    await settleEnrichment();
+    await flushWrites();
+
+    expect(node.querySelector(".media-loading")).toBeNull();
+  });
+
+  it("clears the spinner even when the file is unreadable (null blob)", async () => {
+    const item = makeLocalItem({ storagePath: "gone.pdf", title: "gone" });
+    mockListLocal.mockResolvedValue([item]);
+    const gate = deferred<ArrayBuffer | null>();
+    mockResolveLocalBlob.mockReturnValue(gate.promise);
+
+    const dir = makeEmptyDir();
+    setLocalDirectory(dir, true);
+
+    const container = makeContainer();
+    await renderLocalIntoList(container);
+    const node = rowNode(container, item);
+
+    triggerIntersection(node);
+    expect(node.querySelector(".media-loading")).not.toBeNull();
+
+    // Null blob never reaches patchLocalRow — the `finally` clear must still
+    // remove the spinner.
+    gate.resolve(null);
+    await settleEnrichment();
+    await flushWrites();
+
+    expect(mockExtractMetadata).not.toHaveBeenCalled();
+    expect(node.querySelector(".media-loading")).toBeNull();
   });
 });

--- a/print/test/enrichment.test.ts
+++ b/print/test/enrichment.test.ts
@@ -211,8 +211,8 @@ function makeContainer(): HTMLElement {
  * a real timer.
  */
 function deferred<T>() {
-  let resolve!: (v: T) => void;
-  let reject!: (e?: unknown) => void;
+  let resolve!: (v: T) => void; // type-safety-ok: assigned synchronously inside the Promise constructor below
+  let reject!: (e?: unknown) => void; // type-safety-ok: assigned synchronously inside the Promise constructor below
   const promise = new Promise<T>((res, rej) => {
     resolve = res;
     reject = rej;
@@ -241,7 +241,7 @@ class FakeIO {
     this.cb = cb;
   }
   observe(el: Element): void {
-    ioRegistry.push({ cb: this.cb, el, observer: this as unknown as IntersectionObserver });
+    ioRegistry.push({ cb: this.cb, el, observer: this as unknown as IntersectionObserver }); // type-safety-ok: test stub, FakeIO only implements the methods the prod code calls
   }
   // Production calls unobserve as a one-shot before scheduling; a no-op here is
   // fine because each node is fired exactly once per pass.
@@ -249,7 +249,7 @@ class FakeIO {
   // Drop this observer's entries so a torn-down (prior-pass) observer cannot be
   // re-triggered.
   disconnect(): void {
-    ioRegistry = ioRegistry.filter((e) => e.observer !== (this as unknown as IntersectionObserver));
+    ioRegistry = ioRegistry.filter((e) => e.observer !== (this as unknown as IntersectionObserver)); // type-safety-ok: test stub self-reference for registry dedup
   }
   takeRecords(): IntersectionObserverEntry[] {
     return [];
@@ -262,7 +262,7 @@ function triggerIntersection(node: Element): void {
     const entry = ioRegistry[i];
     if (entry.el === node) {
       entry.cb(
-        [{ isIntersecting: true, target: node } as IntersectionObserverEntry],
+        [{ isIntersecting: true, target: node } as IntersectionObserverEntry], // type-safety-ok: partial stub entry with only the props the prod code reads
         entry.observer,
       );
       return;
@@ -291,7 +291,7 @@ async function flushMicrotasks(times = 3): Promise<void> {
 // describe's own clearAllMocks/innerHTML hooks.
 beforeEach(() => {
   ioRegistry = [];
-  vi.stubGlobal("IntersectionObserver", FakeIO as unknown as typeof IntersectionObserver);
+  vi.stubGlobal("IntersectionObserver", FakeIO as unknown as typeof IntersectionObserver); // type-safety-ok: test stub class replacing a browser global
 });
 afterEach(() => {
   vi.unstubAllGlobals();

--- a/print/test/local-folder-ui.test.ts
+++ b/print/test/local-folder-ui.test.ts
@@ -31,6 +31,10 @@ vi.mock("@commons-systems/local-first/fsa-handle-store", () => ({
 
 // Keep createLocalSource a no-op and listLocal empty so bindAndRender does no
 // real FSA work (markLocalFolderReady stays as the real Promise-deferred).
+//
+// listLocal returns [] here, so renderLocalIntoList produces no uncached rows
+// and constructs no IntersectionObserver — no IO stub is needed; add one only
+// if a future change makes this render produce uncached rows.
 vi.mock("../src/library.js", async () => {
   const actual = await vi.importActual<typeof import("../src/library.js")>(
     "../src/library.js",

--- a/print/test/utils.ts
+++ b/print/test/utils.ts
@@ -1,0 +1,20 @@
+export interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+/**
+ * A manually-resolvable promise. Used to gate async work so a test can hold
+ * operations in-flight and assert behavior deterministically — never a real
+ * timer.
+ */
+export function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void; // type-safety-ok: assigned synchronously inside the Promise constructor below
+  let reject!: (reason?: unknown) => void; // type-safety-ok: assigned synchronously inside the Promise constructor below
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}


### PR DESCRIPTION
Closes #2496

## Why

Opening a local folder ran `runEnrichment` with `Promise.all` over **every**
uncached item, each reading a full file and parsing it eagerly. On a large or
cloud-synced folder (~140 PDFs/EPUBs, several GB on a Google Drive File Stream
mount) this froze the renderer — the user saw only the cloud library.

This reworks enrichment to be **lazy, async, bounded, and visibly in-progress**,
without changing how much of each file is read (the range-read sibling, #2497) or
the `.commons-print` sidecar content written per row.

## What changed

- **Lazy** — a row's metadata is read only when it scrolls into the viewport
  (per-pass `IntersectionObserver`), not the whole folder on open. First paint
  stays filename-only and non-blocking.
- **Bounded** — a single module-scoped `createLimiter(ENRICH_READ_CONCURRENCY=16)`
  caps concurrent full-file reads across its whole lifetime, so peak in-flight
  reads stay bounded **regardless of how many rows are visible** (a focus-rescan
  reuses the long-lived limiter rather than spawning a second one).
- **Per-row loading indicator** — a CSS-only spinner (`.media-loading`) appears
  when a row enters view and is read, then resolves to the real title + page
  count, or falls back to the filename stem. Cleared in a `finally`, so even an
  unreadable (null-blob) row never keeps a stuck spinner.
- **Incremental writes** — each enriched row persists via a single
  `cacheMetadata` write (written even for an empty `{}` extract, which suppresses
  re-extraction on the next render; only the null-blob path skips caching to keep
  the retry open).

### Units

1. `print/src/concurrency.ts` — `createLimiter`, an incremental `schedule()`
   limiter (deliberately a different primitive than audio's fixed-array
   `mapWithConcurrency`), with a non-vacuous bound test.
2. `print/src/style/theme.css` + loading-state helpers — the spinner CSS and
   `markRowLoading`/`clearRowLoading`.
3. `print/src/local-folder-ui.ts` — the core rework: module-scoped limiter,
   per-pass observer (disconnect-first), synchronous callback that folds
   `pendingEnrichment` forward so the `settleEnrichment` seam stays observable,
   and single incremental writes.
4. `print/test/enrichment.test.ts` — a fake `IntersectionObserver` stub driving
   the lazy path; reworked existing cases plus new lazy / bounded-wiring /
   loading-state tests.

## Verification

- `npx vitest run --project print --root .` — 580 passed, 1 pre-existing skip.
- `npx tsc -p print --noEmit` — clean.

Manual (criterion 4, not auto-runnable): open the print app against a ~140-file,
multi-hundred-MB Google Drive mount; confirm first paint is immediate and
filename-only, the renderer stays responsive while scrolling, rows show a loading
indicator as they enter view and resolve to title + page count (or filename-stem
fallback), enrichment fires only for scrolled-into-view rows, peak concurrent
reads never exceed `ENRICH_READ_CONCURRENCY`, and a reopened folder loads
previously-viewed rows from the sidecar with zero file reads.
