### PR TITLE
dispatch-route: self-close an open issue whose closing PR has merged

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-launch-worker
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-launch-worker
@@ -191,6 +191,20 @@ case "$DIRECTIVE" in
     # issue's lingering worktree must never park). No park: release the slot and tick.
     release_and_tick
     ;;
+  "STOP merged-pr-closed")
+    # #2511: dispatch-route detected an OPEN issue whose closing PR has already
+    # merged (GitHub failed to auto-close). Close it as resolved — mechanically,
+    # no Claude session (the point: stop burning a worker spawn + office-hours
+    # park every tick). dispatch-close-resolved is REST-backed, state-aware, and
+    # idempotent, so a failed close self-heals on the next tick's re-detection.
+    # Unset CLAUDE_JOB_DIR for this call: the launcher is a headless setsid
+    # script, not a Claude session, so it never runs dispatch-stop.sh — the
+    # resolved-closed sentinel would be orphaned. Unsetting makes the sentinel
+    # write a clean no-op.
+    env -u CLAUDE_JOB_DIR "$SCRIPT_DIR/dispatch-close-resolved" "$N" \
+      --reason "Closing PR has merged but GitHub left #$N open; auto-closing as resolved (#2511 router guard)." || true
+    release_and_tick
+    ;;
   *)
     # Defensive: an unrecognized directive is an unexpected state. Per
     # .claude/rules/code-style.md, surface it (park with a clear reason) rather

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-route
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-route
@@ -116,7 +116,7 @@ if CLOSING_JSON=$(gh_retry gh issue view "$N" --json closedByPullRequestsReferen
   MERGED_CLOSING_PR=$(printf '%s' "$CLOSING_JSON" \
     | jq -r '[.closedByPullRequestsReferences[] | select(.state == "MERGED") | .number] | first // empty')
 else
-  echo "dispatch-route: gh issue view $N (closedByPullRequestsReferences) failed; continuing to route" >&2
+  echo "dispatch-route: closedByPullRequestsReferences query for #$N failed; continuing to route" >&2
 fi
 if [[ -n "$MERGED_CLOSING_PR" ]]; then
   echo "dispatch-route: #$N is OPEN but PR #$MERGED_CLOSING_PR (merged) closes it; routing to self-close" >&2

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-route
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-route
@@ -25,6 +25,7 @@
 #                                   an office-hours-reason is written here before printing it
 #   STOP wrong-worktree             cross-check failed (diagnostic on stderr); exits non-zero
 #   STOP closed                     issue is CLOSED — never dispatch a closed issue to a phase
+#   STOP merged-pr-closed           open issue, but its closing PR has MERGED — self-close (no re-implement loop)
 #
 # Usage error (missing <N> or <worktree-path>) → stderr message, exit 2 (matches
 # the sibling-script convention).
@@ -98,6 +99,28 @@ ISSUE_STATE=$(gh_issue_view_rest "$N" | jq -r '.state') || {
 }
 if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
   echo "STOP closed"
+  exit 0
+fi
+
+# Merged-PR guard (#2511, complements #1845): an OPEN issue whose closing PR
+# has already MERGED — GitHub failed to auto-close it — must not be routed to a
+# build phase (it would loop on INVOKE /implement forever; the #1845
+# state==CLOSED guard can't fire because the issue is open). Detect via the
+# issue's own closedByPullRequestsReferences (GraphQL-only; no REST
+# equivalent), filtering to MERGED. On a gh failure, log and continue (do not
+# strand) — matches the closed-guard fallback above. One gh call per routed
+# worker (bounded by sustained-N), not per-issue.
+MERGED_CLOSING_PR=""
+# lint-allow: gh-rest-porcelain GraphQL-only closedByPullRequestsReferences (no REST equivalent)
+if CLOSING_JSON=$(gh_retry gh issue view "$N" --json closedByPullRequestsReferences 2>/dev/null); then
+  MERGED_CLOSING_PR=$(printf '%s' "$CLOSING_JSON" \
+    | jq -r '[.closedByPullRequestsReferences[] | select(.state == "MERGED") | .number] | first // empty')
+else
+  echo "dispatch-route: gh issue view $N (closedByPullRequestsReferences) failed; continuing to route" >&2
+fi
+if [[ -n "$MERGED_CLOSING_PR" ]]; then
+  echo "dispatch-route: #$N is OPEN but PR #$MERGED_CLOSING_PR (merged) closes it; routing to self-close" >&2
+  echo "STOP merged-pr-closed"
   exit 0
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -3246,6 +3246,52 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: STOP closed is in the launcher's no-park benign-races arm"
 fi
 
+# 1e. Merged-PR guard (#2511, complements #1845): an OPEN issue whose closing PR
+# has already MERGED — GitHub failed to auto-close it — must self-close instead
+# of looping on INVOKE /implement. The guard fires AFTER the closed-issue guard
+# and BEFORE provisioning, detecting the merged closing PR via the issue's own
+# closedByPullRequestsReferences (issue-closing-prs-<num>.json stub). On the
+# PRE-FIX code (open + dispatch:planned, no guard) this routed to INVOKE
+# /implement, so the assertion genuinely guards the new behavior.
+echo "Test: open issue + merged closing PR → STOP merged-pr-closed"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo "/wt/44-merged-feature" > "$STUB_DIR/worktree-toplevel.txt"
+printf '{"state":"open","labels":[{"name":"dispatch:planned"}]}\n' > "$STUB_DIR/arg-issue-44.json"
+printf '{"closedByPullRequestsReferences":[{"number":900,"state":"MERGED"}]}\n' > "$STUB_DIR/issue-closing-prs-44.json"
+route_run 44 /wt/44-merged-feature
+assert_eq "open + merged closing PR → STOP merged-pr-closed (directive)" "STOP merged-pr-closed" "$ROUTE_OUT"
+assert_eq "open + merged closing PR → STOP merged-pr-closed (exit 0)" "0" "$ROUTE_RC"
+teardown
+
+# 1f. The MERGED filter: an open issue whose closing PR is still OPEN (not
+# merged) must NOT trip the guard — it routes normally. Proves the
+# select(.state == "MERGED") filter is load-bearing.
+echo "Test: open issue + OPEN (not merged) closing PR → INVOKE /implement"
+setup
+echo '[]' > "$STUB_DIR/pr-list-full.json"
+echo "/wt/42-my-feature" > "$STUB_DIR/worktree-toplevel.txt"
+printf '{"state":"open","labels":[{"name":"dispatch:planned"}]}\n' > "$STUB_DIR/arg-issue-42.json"
+printf '{"closedByPullRequestsReferences":[{"number":901,"state":"OPEN"}]}\n' > "$STUB_DIR/issue-closing-prs-42.json"
+route_run 42 /wt/42-my-feature
+assert_eq "open + OPEN closing PR → guard not tripped → INVOKE /implement (directive)" "INVOKE /implement" "$ROUTE_OUT"
+assert_eq "open + OPEN closing PR → INVOKE /implement (exit 0)" "0" "$ROUTE_RC"
+teardown
+
+# 1g. The route-level test above cannot prove the launcher closes the issue
+# (driving dispatch-launch-worker end-to-end is out of scope for this harness).
+# Assert at the source that dispatch-launch-worker has a DEDICATED
+# "STOP merged-pr-closed") arm that invokes dispatch-close-resolved — i.e. it is
+# NOT folded into the benign no-park arm (which would leave the issue open).
+echo "Test: dispatch-launch-worker handles STOP merged-pr-closed via dispatch-close-resolved"
+TOTAL=$((TOTAL + 1))
+if grep -Eq '"STOP merged-pr-closed"\)' "$SCRIPT_DIR/dispatch-launch-worker" \
+   && grep -q 'dispatch-close-resolved' "$SCRIPT_DIR/dispatch-launch-worker"; then
+  PASS=$((PASS + 1)); echo "  PASS: launcher closes the issue on STOP merged-pr-closed"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: launcher closes the issue on STOP merged-pr-closed"
+fi
+
 # 2. Draft + failing CI → INVOKE /fix-checks.
 echo "Test: draft + failing CI → INVOKE /fix-checks"
 setup


### PR DESCRIPTION
Closes #2511

## What

Add a selection-time **merged-PR guard** to `dispatch-route` so an OPEN issue
whose closing PR has already merged self-closes instead of looping forever on
`INVOKE /implement`. This complements the closed-issue guard from #1845.

## Why

When GitHub fails to auto-close an issue on its closing PR's merge (parse lag at
PR-open time — see the #2481 case), the issue stays **OPEN** with
`dispatch:planned`. Its merged PR is invisible to `pr_list_open` (which is
`--state open` only), so `dispatch-phase` sees "no PR + dispatch:planned" and
returns `implement`, and the router emits `INVOKE /implement` every tick. The
#1845 closed-issue guard can't fire — the issue is *open* — and `/implement`'s
PR-exists re-entry branch marks complete, re-invoking the router against the same
state: a deterministic loop. Today only a manual office-hours park breaks it,
burning a worker spawn per occurrence.

## How

- **`dispatch-route`** — a new guard immediately after the closed-issue guard
  (pre-provision) detects, for an OPEN target, a **merged** PR that closes it via
  the issue's own `closedByPullRequestsReferences` (GraphQL-only, filtered to
  `MERGED`; the same pattern `dispatch-find-pr` already uses). On a hit it emits a
  new `STOP merged-pr-closed` directive. On a `gh` failure it logs and continues,
  matching the closed-guard fallback. One `gh` call per routed worker.
- **`dispatch-launch-worker`** — a dedicated `STOP merged-pr-closed` case arm
  closes the issue mechanically via `dispatch-close-resolved` (REST-backed,
  state-aware, idempotent) with `CLAUDE_JOB_DIR` unset so the resolved-closed
  sentinel write is a clean no-op, then `release_and_tick`. **No Claude session is
  spawned.** A failed close self-heals: the next tick re-detects the merged PR and
  re-closes.
- **`test-dispatch-scripts.sh`** — three new tests: the positive self-close route,
  the `MERGED`-filter negative (an OPEN closing PR routes normally), and a launcher
  source-grep asserting the dedicated arm invokes `dispatch-close-resolved`.

The loop terminates because once the issue is closed the existing `state ==
CLOSED` guard takes over on the next tick. This is defense-in-depth; a
complementary merge-time reconciliation is tracked separately in #2512.

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` →
4032/4032 passed (4027 baseline + 5 new assertions).
