### PR TITLE
dispatch: post-merge reconciliation closes issues GitHub failed to auto-close

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-reconcile-merged
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-reconcile-merged
@@ -57,6 +57,7 @@ MARKER='<!-- dispatch:auto-close-repair -->'
 # A single GraphQL call (gh pr list with closingIssuesReferences) — never a
 # per-PR gh pr view fan-out. A failed fetch is a HARD error: reconciling on a
 # partial snapshot could miss a stranded issue or act on stale data.
+# lint-allow: gh-rest-porcelain closingIssuesReferences is a GraphQL-only field with no REST equivalent
 PR_LIST=$(gh_retry gh pr list --state merged --json number,title,mergedAt,closingIssuesReferences --limit "$LIMIT") || {
   echo "dispatch-reconcile-merged: error: gh pr list failed" >&2
   exit 1

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-reconcile-merged
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-reconcile-merged
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# dispatch-reconcile-merged — post-merge reconciliation sweep that closes any
+# issue GitHub's merge-time auto-close silently left OPEN (issue #2512).
+#
+# Runs in the tick immediately AFTER dispatch-auto-merge. When a squash-merged
+# PR carries `Closes #N`, GitHub normally closes #N at merge time — but that
+# auto-close is best-effort and occasionally does not fire (parser lag, a body
+# edited after merge, a closing reference added late). The result is a merged
+# PR whose work is on main while its issue is still OPEN, stranded forever
+# because no later tick re-examines a merged PR. This sweep is that re-examiner.
+#
+# Window — GRACE and LOOKBACK bound which merged PRs are reconciled:
+#   - GRACE (default 600s): a just-merged PR is NOT reconciled until it has aged
+#     past the grace window. GitHub's auto-close is asynchronous; closing inside
+#     the grace window would race the platform and double-close issues that were
+#     about to close on their own.
+#   - LOOKBACK (default 172800s = 48h): only PRs merged within the lookback are
+#     considered. Anything older has either already been reconciled or is a
+#     deliberate human decision to leave the issue open; re-litigating ancient
+#     merges is noise.
+#
+# Two-layer idempotency keeps the sweep safe to run every tick:
+#   - Layer 1 (state): an issue already CLOSED is a no-op — no comment, no
+#     PATCH. Only an OPEN closing-issue is a genuine auto-close miss.
+#   - Layer 2 (marker): an OPEN issue that already carries this script's marker
+#     comment was closed by a prior run that GitHub then somehow re-opened (or a
+#     race left the close un-applied); re-close WITHOUT re-commenting so the
+#     issue never accumulates duplicate diagnostics.
+#
+# Stdout protocol: exactly `reconciled #<iss> (PR #<n>)` per issue actually
+# closed by this sweep; NOTHING for any no-op or skip. All diagnostics go to
+# stderr.
+#
+# Sandbox note: the CALLER wraps every invocation of this script with
+# dangerouslyDisableSandbox (per .claude/rules/sandbox.md) because `gh` needs
+# network access and gh's TLS validation is blocked by the sandbox. This script
+# therefore sets NOTHING sandbox-related; that is the caller's responsibility.
+#
+# NOT set -e: a per-item hard error must not abort the sweep. gh exit codes are
+# captured explicitly with `|| rc=$?`; a failing item logs to stderr, sets
+# HARD_ERROR=1, and `continue`s (it self-heals on a later tick). The script
+# exits 1 at the end if any item hard-errored.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"  # gh_retry, gh_issue_view_rest, gh_issue_close_rest, dispatch_marker_comment_id
+
+# ---- Tunables (env-overridable) ---------------------------------------------
+GRACE=${DISPATCH_RECONCILE_GRACE:-600}
+LOOKBACK=${DISPATCH_RECONCILE_LOOKBACK:-172800}
+LIMIT=${DISPATCH_RECONCILE_LIMIT:-100}
+NOW=${DISPATCH_RECONCILE_NOW:-$(date -u +%s)}
+MARKER='<!-- dispatch:auto-close-repair -->'
+
+# ---- Step 1: one fresh fetch of recently-merged PRs -------------------------
+# A single GraphQL call (gh pr list with closingIssuesReferences) — never a
+# per-PR gh pr view fan-out. A failed fetch is a HARD error: reconciling on a
+# partial snapshot could miss a stranded issue or act on stale data.
+PR_LIST=$(gh_retry gh pr list --state merged --json number,title,mergedAt,closingIssuesReferences --limit "$LIMIT") || {
+  echo "dispatch-reconcile-merged: error: gh pr list failed" >&2
+  exit 1
+}
+
+# ---- Step 2: per-PR window filter + per-issue reconciliation -----------------
+HARD_ERROR=0
+
+while IFS= read -r pr; do
+  [[ -n "$pr" ]] || continue
+  PR_NUM=$(jq -r '.number' <<<"$pr")
+  MERGED_AT=$(jq -r '.mergedAt' <<<"$pr")
+
+  # Skip PRs that close no issue — nothing to reconcile.
+  HAS_CLOSING=$(jq -r '(.closingIssuesReferences | length) > 0' <<<"$pr")
+  [[ "$HAS_CLOSING" == "true" ]] || continue
+
+  # Window filter: reconcile only PRs aged past GRACE and within LOOKBACK.
+  MERGED_EPOCH=$(date -u -d "$MERGED_AT" +%s)
+  AGE=$(( NOW - MERGED_EPOCH ))
+  [[ "$AGE" -ge "$GRACE" ]] || continue
+  [[ "$AGE" -le "$LOOKBACK" ]] || continue
+
+  # ---- Per closing issue ----------------------------------------------------
+  while IFS= read -r iss; do
+    [[ -n "$iss" ]] || continue
+
+    # ---- Layer 1 — state check ----------------------------------------------
+    # Only an OPEN closing-issue is a genuine auto-close miss; CLOSED is a no-op.
+    rc=0
+    ISS_JSON=$(gh_issue_view_rest "$iss") || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+      echo "dispatch-reconcile-merged: error: gh_issue_view_rest #$iss failed (rc=$rc)" >&2
+      HARD_ERROR=1
+      continue
+    fi
+    STATE=$(jq -r '.state' <<<"$ISS_JSON")
+    [[ "$STATE" == "CLOSED" ]] && continue
+
+    # ---- Layer 2 — marker check ---------------------------------------------
+    # An OPEN issue already carrying our marker was closed by a prior run; close
+    # again WITHOUT re-commenting so diagnostics never accumulate.
+    rc=0
+    MARKER_ID=$(dispatch_marker_comment_id "$iss" "$MARKER") || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+      echo "dispatch-reconcile-merged: error: dispatch_marker_comment_id #$iss failed (rc=$rc)" >&2
+      HARD_ERROR=1
+      continue
+    fi
+
+    rc=0
+    if [[ -n "$MARKER_ID" ]]; then
+      gh_issue_close_rest "$iss" --reason completed || rc=$?
+    else
+      # The MARKER must be the very first characters of the body: the marker
+      # check is startswith-anchored on the comment's first line.
+      BODY=$(printf '%s\n\n%s\n' "$MARKER" "GitHub's merge-time auto-close did not fire for PR #$PR_NUM; closing this issue as completed (#2512).")
+      gh_issue_close_rest "$iss" --reason completed --comment "$BODY" || rc=$?
+    fi
+    if [[ "$rc" -ne 0 ]]; then
+      echo "dispatch-reconcile-merged: error: gh_issue_close_rest #$iss failed (rc=$rc)" >&2
+      HARD_ERROR=1
+      continue
+    fi
+    echo "reconciled #$iss (PR #$PR_NUM)"
+  done < <(jq -r '.closingIssuesReferences[].number' <<<"$pr")
+done < <(jq -c '.[]' <<<"$PR_LIST")
+
+if [[ "$HARD_ERROR" -ne 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-reconcile-merged
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-reconcile-merged
@@ -59,7 +59,7 @@ MARKER='<!-- dispatch:auto-close-repair -->'
 # partial snapshot could miss a stranded issue or act on stale data.
 # lint-allow: gh-rest-porcelain closingIssuesReferences is a GraphQL-only field with no REST equivalent
 PR_LIST=$(gh_retry gh pr list --state merged --json number,title,mergedAt,closingIssuesReferences --limit "$LIMIT") || {
-  echo "dispatch-reconcile-merged: error: gh pr list failed" >&2
+  echo "dispatch-reconcile-merged: error: merged-PR fetch failed" >&2
   exit 1
 }
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-reconcile-merged
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-reconcile-merged
@@ -63,6 +63,14 @@ PR_LIST=$(gh_retry gh pr list --state merged --json number,title,mergedAt,closin
   exit 1
 }
 
+# The lookback window is implicitly bounded by LIMIT: if the merged-PR list hits
+# the limit, the oldest PRs in the window may be truncated away. Warn so a
+# high-frequency-merge sweep does not silently skip stranded issues; raise
+# DISPATCH_RECONCILE_LIMIT to widen the window.
+if [[ $(jq 'length' <<<"$PR_LIST") -ge "$LIMIT" ]]; then
+  echo "dispatch-reconcile-merged: warning: PR list hit the limit ($LIMIT); oldest merged PRs in the window may be missing from this sweep — raise DISPATCH_RECONCILE_LIMIT" >&2
+fi
+
 # ---- Step 2: per-PR window filter + per-issue reconciliation -----------------
 HARD_ERROR=0
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -390,6 +390,19 @@ if [[ -z "$OPEN_MB" ]]; then
     done <<< "$MERGE_OUT"
   fi
 fi
+
+# --- Step 1d (cont.): post-merge reconciliation (#2512) ----------------------
+# Closes any issue GitHub's merge-time auto-close silently left OPEN (see #2481).
+# Runs unconditionally (NOT gated on $OPEN_MB): it merges nothing, only repairs
+# already-merged work's closing issues, so it is safe during a main-broken
+# episode. Best-effort: a failure here must not abort the tick.
+RECONCILE_MERGED_OUT=$("$SCRIPT_DIR/dispatch-reconcile-merged") || true
+if [[ -n "$RECONCILE_MERGED_OUT" ]]; then
+  while IFS= read -r recon_line; do
+    [[ -n "$recon_line" ]] && echo "reconcile-merged: $recon_line"
+  done <<< "$RECONCILE_MERGED_OUT"
+fi
+
 # Heartbeat: refresh after the auto-merge sub-step completes (#2104).
 refresh_lock
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -403,7 +403,7 @@ if [[ -n "$RECONCILE_MERGED_OUT" ]]; then
   done <<< "$RECONCILE_MERGED_OUT"
 fi
 
-# Heartbeat: refresh after the auto-merge sub-step completes (#2104).
+# Heartbeat: refresh after the auto-merge and reconcile-merged sub-steps complete (#2104, #2512).
 refresh_lock
 
 # --- Step 1b: run-scoped concurrency gate (autonomous no-arg queue path only) -

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -98,6 +98,11 @@ setup() {
   # SCRIPT_DIR (= TMPDIR_TEST for this copy) — both already copied below/above,
   # so both resolve.
   cp "$SCRIPT_DIR/dispatch-auto-merge" "$TMPDIR_TEST/dispatch-auto-merge"
+  # dispatch-reconcile-merged (#2512) sources lib.sh (gh_retry, gh_issue_view_rest,
+  # gh_issue_close_rest, dispatch_marker_comment_id) via its SCRIPT_DIR (= TMPDIR_TEST
+  # for this copy) — lib.sh is copied below, so the source resolves.
+  cp "$SCRIPT_DIR/dispatch-reconcile-merged" "$TMPDIR_TEST/dispatch-reconcile-merged"
+  chmod +x "$TMPDIR_TEST/dispatch-reconcile-merged"
   # dispatch-retriage-orphaned-followups (#1812) sources lib.sh (gh_issue_list_rest,
   # gh_retry) and calls dispatch-apply-office-hours via its SCRIPT_DIR (= TMPDIR_TEST
   # for this copy) — both already copied here, so both resolve.
@@ -838,6 +843,16 @@ case "$args" in
     echo "pr list" >> "$STUB_DIR/gh-auto-merge-pr-list.log"
     if [[ -f "$STUB_DIR/auto-merge-pr-list.json" ]]; then
       cat "$STUB_DIR/auto-merge-pr-list.json"
+    else
+      echo "[]"
+    fi
+    ;;
+  "pr list --state merged --json number,title,mergedAt,closingIssuesReferences --limit "*)
+    # dispatch-reconcile-merged's one fetch (#2512). reconcile-merged-pr-list.json
+    # supplies the per-test merged-PR array; absence means no merged PRs.
+    echo "pr list" >> "$STUB_DIR/gh-reconcile-merged-pr-list.log"
+    if [[ -f "$STUB_DIR/reconcile-merged-pr-list.json" ]]; then
+      cat "$STUB_DIR/reconcile-merged-pr-list.json"
     else
       echo "[]"
     fi
@@ -38344,6 +38359,116 @@ teardown
 echo "Test: dispatch-auto-merge is executable"
 assert_eq "dispatch-auto-merge is executable" "yes" \
   "$([[ -x "$SCRIPT_DIR/dispatch-auto-merge" ]] && echo yes || echo no)"
+
+# ============================================================================
+# dispatch-reconcile-merged (#2512)
+# ============================================================================
+echo "=== dispatch-reconcile-merged (#2512) ==="
+
+# Fixed clock so window membership is deterministic.
+RM_NOW=1700000000
+rm_iso() { date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ; }          # epoch → ISO
+RM_INWIN=$(rm_iso $((RM_NOW - 3600)))      # 1h ago: past GRACE, within LOOKBACK
+RM_TOORECENT=$(rm_iso $((RM_NOW - 60)))    # 60s ago: inside GRACE → skip
+RM_TOOOLD=$(rm_iso $((RM_NOW - 200000)))   # >48h ago: beyond LOOKBACK → skip
+
+# Build one merged-PR fixture object. $1=pr $2=mergedAt-iso $3=closing-json
+make_merged_pr() {
+  printf '{"number":%s,"title":"PR %s","mergedAt":"%s","closingIssuesReferences":%s}' \
+    "$1" "$1" "$2" "$3"
+}
+
+# 1. Repairs a silent auto-close failure: in-window PR closing an OPEN issue.
+echo "Test: reconcile repairs a silent auto-close failure"
+setup
+printf '%s' "[$(make_merged_pr 8001 "$RM_INWIN" '[{"number":9001}]')]" \
+  > "$STUB_DIR/reconcile-merged-pr-list.json"
+printf '%s' '{"number":9001,"state":"open"}' > "$STUB_DIR/view-issue-9001.json"
+out=$(DISPATCH_PLAN_AUTHOR_ID=12345 DISPATCH_RECONCILE_NOW=$RM_NOW "$TMPDIR_TEST/dispatch-reconcile-merged" 2>/dev/null)
+assert_eq "reconcile: stdout repairs #9001" "reconciled #9001 (PR #8001)" "$out"
+assert_eq "reconcile: close call logged" "present" \
+  "$(grep -q 'issues/9001' "$STUB_DIR/gh-issue-close-rest-calls.log" && echo present || echo absent)"
+assert_eq "reconcile: diagnostic comment posted" "present" \
+  "$(grep -q 'issues/9001/comments' "$STUB_DIR/gh-issue-comment-rest-calls.log" && echo present || echo absent)"
+assert_eq "reconcile: exactly one comment posted" "1" \
+  "$(grep -c 'issues/9001/comments' "$STUB_DIR/gh-issue-comment-rest-calls.log")"
+teardown
+
+# 2. No-op when the closing issue is already CLOSED (Layer 1 idempotency).
+echo "Test: reconcile no-op when issue already CLOSED"
+setup
+printf '%s' "[$(make_merged_pr 8001 "$RM_INWIN" '[{"number":9001}]')]" \
+  > "$STUB_DIR/reconcile-merged-pr-list.json"
+printf '%s' '{"number":9001,"state":"closed"}' > "$STUB_DIR/view-issue-9001.json"
+out=$(DISPATCH_PLAN_AUTHOR_ID=12345 DISPATCH_RECONCILE_NOW=$RM_NOW "$TMPDIR_TEST/dispatch-reconcile-merged" 2>/dev/null)
+assert_eq "reconcile: closed-issue empty stdout" "" "$out"
+assert_eq "reconcile: closed-issue no close call" "absent" "$(log_state gh-issue-close-rest-calls.log)"
+assert_eq "reconcile: closed-issue no comment call" "absent" "$(log_state gh-issue-comment-rest-calls.log)"
+teardown
+
+# 3. Grace window: a too-recently-merged PR is skipped (races platform auto-close).
+echo "Test: reconcile skips PR inside the grace window"
+setup
+printf '%s' "[$(make_merged_pr 8001 "$RM_TOORECENT" '[{"number":9001}]')]" \
+  > "$STUB_DIR/reconcile-merged-pr-list.json"
+printf '%s' '{"number":9001,"state":"open"}' > "$STUB_DIR/view-issue-9001.json"
+out=$(DISPATCH_PLAN_AUTHOR_ID=12345 DISPATCH_RECONCILE_NOW=$RM_NOW "$TMPDIR_TEST/dispatch-reconcile-merged" 2>/dev/null)
+assert_eq "reconcile: grace-window empty stdout" "" "$out"
+assert_eq "reconcile: grace-window no close call" "absent" "$(log_state gh-issue-close-rest-calls.log)"
+assert_eq "reconcile: grace-window no comment call" "absent" "$(log_state gh-issue-comment-rest-calls.log)"
+teardown
+
+# 4. Lookback window: an ancient merged PR is skipped.
+echo "Test: reconcile skips PR beyond the lookback window"
+setup
+printf '%s' "[$(make_merged_pr 8001 "$RM_TOOOLD" '[{"number":9001}]')]" \
+  > "$STUB_DIR/reconcile-merged-pr-list.json"
+printf '%s' '{"number":9001,"state":"open"}' > "$STUB_DIR/view-issue-9001.json"
+out=$(DISPATCH_PLAN_AUTHOR_ID=12345 DISPATCH_RECONCILE_NOW=$RM_NOW "$TMPDIR_TEST/dispatch-reconcile-merged" 2>/dev/null)
+assert_eq "reconcile: lookback-window empty stdout" "" "$out"
+assert_eq "reconcile: lookback-window no close call" "absent" "$(log_state gh-issue-close-rest-calls.log)"
+assert_eq "reconcile: lookback-window no comment call" "absent" "$(log_state gh-issue-comment-rest-calls.log)"
+teardown
+
+# 5. Idempotent re-run: an OPEN issue already carrying the marker re-closes WITHOUT
+#    a new diagnostic comment (Layer 2 idempotency).
+echo "Test: reconcile re-run with marker present re-closes without re-commenting"
+setup
+printf '%s' "[$(make_merged_pr 8001 "$RM_INWIN" '[{"number":9001}]')]" \
+  > "$STUB_DIR/reconcile-merged-pr-list.json"
+printf '%s' '{"number":9001,"state":"open"}' > "$STUB_DIR/view-issue-9001.json"
+# The comment carries an `id` so dispatch_marker_comment_id resolves a non-empty
+# marker id (the marker-present path). A page2 fixture (empty array) is required:
+# the comments-sentinel stub's branch ends with `[[ -f ...page2 ]] && cat ...`, so
+# WITHOUT a page2 file that `[[ -f ]]` test returns 1 — gh exits non-zero, the
+# helper hard-errors, and the script exits 1 (aborting the suite under set -e).
+printf '%s' '[{"id":555,"body":"<!-- dispatch:auto-close-repair -->\nprior repair","user":{"id":12345}}]' \
+  > "$STUB_DIR/view-issue-comments-9001-page1.json"
+printf '%s' '[]' > "$STUB_DIR/view-issue-comments-9001-page2.json"
+out=$(DISPATCH_PLAN_AUTHOR_ID=12345 DISPATCH_RECONCILE_NOW=$RM_NOW "$TMPDIR_TEST/dispatch-reconcile-merged" 2>/dev/null)
+assert_eq "reconcile: marker-present stdout repairs #9001" "reconciled #9001 (PR #8001)" "$out"
+assert_eq "reconcile: marker-present close call logged" "present" \
+  "$(grep -q 'issues/9001' "$STUB_DIR/gh-issue-close-rest-calls.log" && echo present || echo absent)"
+assert_eq "reconcile: marker-present no new comment" "absent" "$(log_state gh-issue-comment-rest-calls.log)"
+teardown
+
+# 6. A merged PR that closes NO issue is skipped — but the list was still fetched.
+echo "Test: reconcile skips PR with empty closing set (but fetched the list)"
+setup
+printf '%s' "[$(make_merged_pr 8001 "$RM_INWIN" '[]')]" \
+  > "$STUB_DIR/reconcile-merged-pr-list.json"
+out=$(DISPATCH_PLAN_AUTHOR_ID=12345 DISPATCH_RECONCILE_NOW=$RM_NOW "$TMPDIR_TEST/dispatch-reconcile-merged" 2>/dev/null)
+assert_eq "reconcile: empty-closing-set empty stdout" "" "$out"
+assert_eq "reconcile: empty-closing-set no close call" "absent" "$(log_state gh-issue-close-rest-calls.log)"
+assert_eq "reconcile: empty-closing-set no comment call" "absent" "$(log_state gh-issue-comment-rest-calls.log)"
+assert_eq "reconcile: empty-closing-set still fetched PR list" "present" \
+  "$(log_state gh-reconcile-merged-pr-list.log)"
+teardown
+
+# --- executable-bit guard ----------------------------------------------------
+echo "Test: dispatch-reconcile-merged is executable"
+assert_eq "dispatch-reconcile-merged is executable" "yes" \
+  "$([[ -x "$SCRIPT_DIR/dispatch-reconcile-merged" ]] && echo yes || echo no)"
 
 # ============================================================================
 # dispatch-detect-transient-death tests (#1733)

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -605,6 +605,19 @@ case "$args" in
       echo "stub forced gh api failure" >&2
       exit 1
     fi
+    # Optional per-issue close-failure injection (#2512): if issue-close-fail-on
+    # holds an issue number matching the <N> in this PATCH's path, emit a
+    # non-transient error and exit non-zero so gh_retry returns immediately and
+    # the caller (dispatch-reconcile-merged) takes its gh_issue_close_rest
+    # HARD_ERROR path for that issue. Default-absent, so existing tests sharing
+    # this PATCH branch are unaffected.
+    if [[ -f "$STUB_DIR/issue-close-fail-on" ]]; then
+      close_num=$(printf '%s' "$args" | sed -E 's#.*issues/([0-9]+).*#\1#')
+      if [[ "$close_num" == "$(cat "$STUB_DIR/issue-close-fail-on")" ]]; then
+        echo "issue close PATCH for #$close_num was rejected" >&2
+        exit 1
+      fi
+    fi
     echo '{}'
     ;;
   "api -X POST "*/issues/*/comments*)
@@ -38463,6 +38476,65 @@ assert_eq "reconcile: empty-closing-set no close call" "absent" "$(log_state gh-
 assert_eq "reconcile: empty-closing-set no comment call" "absent" "$(log_state gh-issue-comment-rest-calls.log)"
 assert_eq "reconcile: empty-closing-set still fetched PR list" "present" \
   "$(log_state gh-reconcile-merged-pr-list.log)"
+teardown
+
+# --- HARD_ERROR paths --------------------------------------------------------
+# Each of the three per-item failure branches sets HARD_ERROR=1, `continue`s, and
+# drives the final `exit 1`. Without coverage a regression in the error-return
+# convention of any lib.sh helper (or the branch's own logging) would go unseen.
+
+# 7. gh_issue_view_rest (Layer 1 state read) failure → hard error, exit 1.
+echo "Test: reconcile hard-errors when gh_issue_view_rest fails"
+setup
+printf '%s' "[$(make_merged_pr 8001 "$RM_INWIN" '[{"number":9001}]')]" \
+  > "$STUB_DIR/reconcile-merged-pr-list.json"
+# gh-fail-rest forces every REST `api` call to fail; the merged-PR list fetch is a
+# `pr list` (not an `api` call) so it still succeeds, and gh_issue_view_rest — the
+# first REST call in the per-issue loop — is what fails.
+: > "$STUB_DIR/gh-fail-rest"
+rc=0
+err=$(DISPATCH_PLAN_AUTHOR_ID=12345 DISPATCH_RECONCILE_NOW=$RM_NOW "$TMPDIR_TEST/dispatch-reconcile-merged" 2>&1 >/dev/null) || rc=$?
+assert_eq "reconcile: view-failure exit 1" "1" "$rc"
+case "$err" in *"gh_issue_view_rest #9001 failed"*) m=yes ;; *) m=no ;; esac
+assert_eq "reconcile: view-failure stderr names the hard error" "yes" "$m"
+assert_eq "reconcile: view-failure short-circuits before close" "absent" \
+  "$(log_state gh-issue-close-rest-calls.log)"
+teardown
+
+# 8. dispatch_marker_comment_id (Layer 2 marker read) failure → hard error, exit 1.
+echo "Test: reconcile hard-errors when dispatch_marker_comment_id can't resolve author id"
+setup
+printf '%s' "[$(make_merged_pr 8001 "$RM_INWIN" '[{"number":9001}]')]" \
+  > "$STUB_DIR/reconcile-merged-pr-list.json"
+printf '%s' '{"number":9001,"state":"open"}' > "$STUB_DIR/view-issue-9001.json"
+# A non-numeric DISPATCH_PLAN_AUTHOR_ID trips the helper's author-id guard
+# (return 1) AFTER the OPEN-state read passes Layer 1, isolating the Layer 2 path.
+rc=0
+err=$(DISPATCH_PLAN_AUTHOR_ID=not-a-number DISPATCH_RECONCILE_NOW=$RM_NOW "$TMPDIR_TEST/dispatch-reconcile-merged" 2>&1 >/dev/null) || rc=$?
+assert_eq "reconcile: marker-id-failure exit 1" "1" "$rc"
+case "$err" in *"dispatch_marker_comment_id #9001 failed"*) m=yes ;; *) m=no ;; esac
+assert_eq "reconcile: marker-id-failure stderr names the hard error" "yes" "$m"
+assert_eq "reconcile: marker-id-failure short-circuits before close" "absent" \
+  "$(log_state gh-issue-close-rest-calls.log)"
+teardown
+
+# 9. gh_issue_close_rest (the closing PATCH) failure → hard error, exit 1.
+echo "Test: reconcile hard-errors when gh_issue_close_rest fails"
+setup
+printf '%s' "[$(make_merged_pr 8001 "$RM_INWIN" '[{"number":9001}]')]" \
+  > "$STUB_DIR/reconcile-merged-pr-list.json"
+printf '%s' '{"number":9001,"state":"open"}' > "$STUB_DIR/view-issue-9001.json"
+# No comments fixture → marker check resolves an empty id (markerless path), so
+# the script reaches the close. issue-close-fail-on injects a non-transient PATCH
+# rejection for #9001 so gh_issue_close_rest returns 1.
+printf '9001' > "$STUB_DIR/issue-close-fail-on"
+rc=0
+err=$(DISPATCH_PLAN_AUTHOR_ID=12345 DISPATCH_RECONCILE_NOW=$RM_NOW "$TMPDIR_TEST/dispatch-reconcile-merged" 2>&1 >/dev/null) || rc=$?
+assert_eq "reconcile: close-failure exit 1" "1" "$rc"
+case "$err" in *"gh_issue_close_rest #9001 failed"*) m=yes ;; *) m=no ;; esac
+assert_eq "reconcile: close-failure stderr names the hard error" "yes" "$m"
+assert_eq "reconcile: close-failure attempted the close PATCH" "present" \
+  "$(log_state gh-issue-close-rest-calls.log)"
 teardown
 
 # --- executable-bit guard ----------------------------------------------------


### PR DESCRIPTION
Closes #2512

## Problem

When a dispatch PR merges, nothing verifies that the issues it was registered to
close actually closed. GitHub's merge-time auto-close can **silently fail** even
when the PR carries a correct, registered `closingIssuesReferences` link — the
issue stays OPEN indefinitely. Evidence (#2481): PR #2519 merged with
`closingIssuesReferences == [2481]` registered, yet #2481 stayed OPEN for hours
until closed by hand. The link was present and parsed; the auto-close still did
not fire.

A lingering open issue gets re-dispatched to `/implement` by the router, so one
silent auto-close failure spawns wasted workers / office-hours parks. This is the
**merge-time** half of a two-point defense; the **selection-time** guard (router
refusing to re-dispatch an open issue whose closing PR merged) is tracked
separately in #2511.

## Approach: a dedicated post-merge sweep

A new tick-time sweep, `dispatch-reconcile-merged`, runs right after
`dispatch-auto-merge`. It is a dedicated sweep rather than an inline check in
`dispatch-auto-merge` for two reasons:

1. **Coverage.** `dispatch-auto-merge` is the only *scripted* merge path, but a
   human clicking "Merge" in the GitHub UI goes through no script at all. A sweep
   that scans recently-merged PRs covers every merge path.
2. **GitHub's auto-close is asynchronous.** A check run immediately after the
   merge API returns would see the issue still OPEN on essentially every merge.
   The sweep uses a **grace window** so it only reconciles PRs merged longer than
   `GRACE` ago — which also makes the diagnostic comment truthful.

No kill-switch config gate (unlike `dispatch-auto-merge`): reconciliation only
closes issues already registered as closing-refs of an already-merged PR — far
lower-stakes than performing a merge.

## What changed

- **`dispatch-reconcile-merged`** (new): lists recently-merged PRs in one GraphQL
  call (`gh pr list --state merged --json …closingIssuesReferences`), filters by a
  grace + lookback window (`DISPATCH_RECONCILE_GRACE` 600s, `…_LOOKBACK` 48h,
  `…_LIMIT` 100, all env-overridable), and for each in-window PR's closing issues
  applies two-layer idempotency: skip already-CLOSED issues (layer 1), and for an
  OPEN issue close it with a one-time diagnostic comment anchored by a
  `<!-- dispatch:auto-close-repair -->` marker, re-closing without re-commenting if
  the marker is already present (layer 2). A per-item error never aborts the sweep.
- **`dispatch-select-tick`**: wires the sweep in unconditionally after the
  auto-merge block (independent of main health), best-effort, prefixing output with
  `reconcile-merged:`.
- **`test-dispatch-scripts.sh`**: 6 new cases (silent-failure repair, already-closed
  no-op, grace/lookback window skips, marker-present idempotent re-close, empty
  closing set) plus an executable-bit guard, on a pinned deterministic clock.

## Verification

`bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` passes,
including the new `dispatch-reconcile-merged` cases. The end-to-end behavior (a real
GitHub auto-close failure repaired on a later tick) is observable only in production
over time and is left for QA / observation.
