### PR TITLE
flake-dedup: narrow stale-head gate to ancestry-only (drop recency false-positive)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-flake-dedup
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-flake-dedup
@@ -34,22 +34,29 @@
 #   sibling for the match and adds only the flake-specific recurrence recording
 #   (comment / reopen) on top.
 #
-# STALE-HEAD REOPEN GATE (CLOSED path only) — issue #2442
+# STALE-HEAD REOPEN GATE (CLOSED path only) — issues #2442, #2518
 #   A flake tracker is closed when its root cause merges to main. But a
 #   long-lived PR branch that pre-dates that fix keeps emitting the pre-fix
 #   failure signature; matching the same fingerprint on every tick would reopen
 #   the already-fixed issue indefinitely (reopen/close oscillation). So the
-#   CLOSED arm gates the reopen on whether the triggering run actually post-dates
-#   the closing fix, using two signals — suppress (report STALE, no comment, no
-#   reopen) if EITHER indicates staleness:
-#     - Recency floor / fallback: run.createdAt < issue.closedAt → STALE.
-#       ISO-8601 UTC `Z` strings compare correctly with bash lexicographic `<`.
-#     - Ancestry (primary): resolve the commit that closed the issue and compare
-#       it to the run's head SHA; `behind`/`diverged` → STALE, `ahead`/`identical`
-#       → fresh. Ancestry is undefined for a NOT_PLANNED close (no fix) or a
-#       manual close (null commit_id); in those cases fall back to recency only.
-#   --run-id is REQUIRED on the CLOSED path (validated at point of use); OPEN/NONE
-#   never consult it. fix-checks is the only caller and always passes it.
+#   CLOSED arm gates the reopen on POSITIVE evidence that the run head is behind
+#   the closing fix. ANCESTRY is the sole decisive signal — suppress (report
+#   STALE, no comment, no reopen) only when:
+#     - A real closing commit exists (the close was COMPLETED with a commit_id),
+#       AND that commit compared to the run's head SHA is `behind`/`diverged`.
+#       This is the #2442 case: a long-lived branch genuinely behind the fix.
+#   Everything else REOPENs (a live recurrence):
+#     - Real closing commit, head `ahead`/`identical` → the head contains the fix.
+#     - No closing commit — a manual close (null commit_id) or a NOT_PLANNED
+#       close (no fix) — the head cannot be stale relative to a fix that does not
+#       exist, so the contradiction surfaces via a reopen.
+#   The old recency floor (run.createdAt < closedAt → STALE) is REMOVED (#2518):
+#   it was the only live signal on a no-commit close and false-positived a head
+#   that already contains all of main, producing an infinite-STALE loop (the
+#   PR #1849 / tracker #2481 incident).
+#   --run-id is REQUIRED on the CLOSED path (validated at point of use) — ancestry
+#   needs the run's head SHA; OPEN/NONE never consult it. fix-checks is the only
+#   caller and always passes it.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -117,9 +124,8 @@ case "$state" in
     echo "EXISTING $match"
     ;;
   CLOSED)
-    # STALE-HEAD REOPEN GATE — see the header block. Suppress the reopen when the
-    # triggering run pre-dates the fix that closed this issue; otherwise reopen.
-    closed_at=$(jq -r '.closedAt' <<<"$info")
+    # STALE-HEAD REOPEN GATE — see the header block. Suppress the reopen only when
+    # ancestry shows the run head is behind a real closing fix; otherwise reopen.
     state_reason=$(jq -r '.stateReason' <<<"$info")
 
     # --run-id is required here. fix-checks always passes it; an empty value is a
@@ -130,57 +136,43 @@ case "$state" in
       exit 1
     fi
 
-    # Resolve the triggering run's createdAt + headSha. A failure here must abort,
-    # not fall through to a blind reopen. Under `set -euo pipefail` a failing
-    # command substitution in a bare assignment does abort, but capture status
-    # explicitly so the error message is specific.
+    # Resolve the triggering run's head SHA. A failure here must abort, not fall
+    # through to a blind reopen. Under `set -euo pipefail` a failing command
+    # substitution in a bare assignment does abort, but capture status explicitly
+    # so the error message is specific.
     run_info=$(gh_run_view_rest "$run_id" "${local_repo_args[@]}") || {
       echo "error: dispatch-flake-dedup: could not resolve run $run_id for stale-head gate on issue $match" >&2
       exit 1
     }
-    run_created=$(jq -r '.createdAt' <<<"$run_info")
     run_head=$(jq -r '.headSha' <<<"$run_info")
 
+    # STALE requires POSITIVE evidence the run head is behind a real closing fix
+    # (issue #2518). Ancestry is the ONLY signal: resolve the commit that closed
+    # the issue and compare it to the run's head SHA.
+    #   - Real closing commit + head `behind`/`diverged` → STALE (the #2442 case:
+    #     a long-lived branch genuinely behind the fix).
+    #   - Real closing commit + head `ahead`/`identical` → fall through to REOPEN
+    #     (the head contains the fix; a live recurrence).
+    #   - No closing commit — a manual close (null commit_id) or a NOT_PLANNED
+    #     close (no fix) — leaves stale=0 → REOPEN: the head cannot be stale
+    #     relative to a fix that does not exist.
+    # The old recency floor (run.createdAt < closedAt) is REMOVED: it marked every
+    # run created before the administrative close time as stale — a false positive
+    # for a head that already contains all of main, and the only live signal on a
+    # no-commit close, which produced the #2518 infinite-STALE loop.
     stale=0
-    # Track which signal(s) fired so the suppression log states the actual reason.
-    # The message differs by source: recency means the run pre-dates the close,
-    # while ancestry means the run is recent but its branch head lacks the fix —
-    # conflating them makes oscillation-incident diagnosis misleading.
-    stale_recency=0
-    stale_ancestry=0
-
-    # Recency floor / fallback: run pre-dates the close. ISO-8601 UTC `Z` strings
-    # compare correctly under bash lexicographic `<`.
-    if [[ "$run_created" < "$closed_at" ]]; then
-      stale=1
-      stale_recency=1
-    fi
-
-    # Ancestry (primary signal): does the run's head contain the closing fix?
-    # Undefined for a NOT_PLANNED close (no fix) or a manual close (null
-    # commit_id) — in those cases we rely on recency alone (do not set stale from
-    # ancestry). OR semantics: a stale verdict from either signal suffices.
     if [[ "$state_reason" != "NOT_PLANNED" ]]; then
       closing=$(gh_issue_closing_commit_rest "$match" "${local_repo_args[@]}")
       if [[ -n "$closing" ]]; then
         status=$(gh_commit_is_ancestor_rest "$closing" "$run_head" "${local_repo_args[@]}")
         if [[ "$status" == "behind" || "$status" == "diverged" ]]; then
           stale=1
-          stale_ancestry=1
         fi
       fi
     fi
 
     if [[ "$stale" -eq 1 ]]; then
-      # Describe the operative signal accurately. Recency-only and both →
-      # "pre-dates closing fix"; ancestry-only → the run is recent but its branch
-      # head does not contain the fix.
-      if [[ "$stale_recency" -eq 1 ]]; then
-        stale_detail="run $run_id pre-dates closing fix (stale-head)"
-      else
-        stale_detail="branch head does not contain closing fix (stale-head)"
-      fi
-      echo "dispatch-flake-dedup: suppressing reopen of #$match — $stale_detail" >&2
+      echo "dispatch-flake-dedup: suppressing reopen of #$match — branch head does not contain closing fix (stale-head)" >&2
       echo "STALE $match"
       exit 0
     fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -33228,6 +33228,25 @@ STUB
   assert_eq "flake-dedup: stale by ancestry → no reopen" "no" "$r"
   flake_dedup_teardown
 
+  # CASE 6b — STALE by ancestry via `diverged`. Identical to Case 6 except the
+  # run head and the closing fix have DIVERGED (neither is an ancestor of the
+  # other) rather than the head being plainly `behind`. The STALE gate is
+  # `[[ "$status" == "behind" || "$status" == "diverged" ]]`; this pins the
+  # `diverged` arm so a future edit that drops it is caught.
+  flake_dedup_setup
+  printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-01-01T00:00:00Z"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
+  printf '{"createdAt":"2026-02-01T00:00:00Z","headSha":"headsha"}\n' > "$TMPDIR_TEST/scripts/run.json"
+  printf 'diverged\n' > "$TMPDIR_TEST/scripts/compare-status"
+  printf '[{"event":"closed","commit_id":"closingsha"}]\n' > "$TMPDIR_TEST/scripts/timeline.json"
+  printf 'recurred on PR #900 / run http://x\n' > "$TMPDIR_TEST/body.md"
+  out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md" --run-id 12345)
+  assert_eq "flake-dedup: stale by ancestry (diverged) → STALE <N>" "STALE 501" "$out"
+  if [[ -s "$TMPDIR_TEST/scripts/stub/comments-fired" ]]; then c=yes; else c=no; fi
+  assert_eq "flake-dedup: stale by ancestry (diverged) → no comment" "no" "$c"
+  if [[ -s "$TMPDIR_TEST/scripts/stub/reopen-fired" ]]; then r=yes; else r=no; fi
+  assert_eq "flake-dedup: stale by ancestry (diverged) → no reopen" "no" "$r"
+  flake_dedup_teardown
+
   # CASE 7 — null commit_id (manual close), the live incident (PR #1849 / tracker
   # #2481). timeline commit_id is null, so there is no closing commit and ancestry
   # leaves stale=0 → REOPEN; compare-status `behind` MUST be ignored. run.createdAt

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -1714,7 +1714,7 @@ printf '%s\n' '{
 }' > "$STUB_DIR/view-issue-9002.json"
 iv2=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_view_rest 9002)
 assert_eq "issue: closed → CLOSED" "CLOSED" "$(jq -r '.state' <<<"$iv2")"
-# closedAt passthrough from closed_at (the stale-head gate's recency floor, #2442).
+# closedAt passthrough from closed_at: REST snake_case → porcelain camelCase.
 assert_eq "issue: closedAt passthrough from closed_at" "2026-02-04T05:06:07Z" "$(jq -r '.closedAt' <<<"$iv2")"
 # REST lowercase state_reason `completed` → porcelain UPPERCASE enum COMPLETED.
 assert_eq "issue: stateReason completed upcased to COMPLETED" "COMPLETED" "$(jq -r '.stateReason' <<<"$iv2")"
@@ -33147,9 +33147,9 @@ STUB
   flake_dedup_teardown
 
   # CASE 2 — CLOSED match, FRESH run → REOPENED <N>, reopen fired, comment fired.
-  # (criterion #3) Under the stale-head gate (#2442) the CLOSED path requires
-  # --run-id. Fresh = run.createdAt AFTER closed_at (recency fresh) AND the run
-  # head contains the closing fix (ancestry `identical`).
+  # (criterion #3) Under the stale-head gate (#2442, #2518) the CLOSED path requires
+  # --run-id. Fresh = a real closing commit is present and the run head contains it
+  # (ancestry `identical`), so the gate falls through to reopen.
   flake_dedup_setup
   printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-01-01T00:00:00Z"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
   printf '{"createdAt":"2026-02-01T00:00:00Z","headSha":"headsha"}\n' > "$TMPDIR_TEST/scripts/run.json"
@@ -33187,9 +33187,12 @@ STUB
 
   # === STALE-HEAD REOPEN GATE (#2442) ===
 
-  # CASE 5 — STALE by recency: run.createdAt BEFORE closed_at trips STALE even
-  # though ancestry is fresh (compare `identical`, closing commit present) —
-  # proving the recency floor ALONE suppresses the reopen. No comment, no reopen.
+  # CASE 5 — recency removed → REOPEN (#2518): run.createdAt is BEFORE closed_at
+  # (the old recency floor would have tripped STALE here) but the run head
+  # contains the closing fix (ancestry `identical`, real closing commit present).
+  # Ancestry-only is decisive, so this REOPENs. This is exactly the case the
+  # removed recency floor wrongly suppressed: it fails under the old recency code
+  # (which would emit STALE) and passes under ancestry-only.
   flake_dedup_setup
   printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-02-01T00:00:00Z"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
   printf '{"createdAt":"2026-01-01T00:00:00Z","headSha":"headsha"}\n' > "$TMPDIR_TEST/scripts/run.json"
@@ -33197,20 +33200,20 @@ STUB
   printf '[{"event":"closed","commit_id":"closingsha"}]\n' > "$TMPDIR_TEST/scripts/timeline.json"
   printf 'recurred on PR #900 / run http://x\n' > "$TMPDIR_TEST/body.md"
   out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md" --run-id 12345 2>"$TMPDIR_TEST/err")
-  assert_eq "flake-dedup: stale by recency → STALE <N>" "STALE 501" "$out"
-  if [[ -s "$TMPDIR_TEST/scripts/stub/comments-fired" ]]; then c=yes; else c=no; fi
-  assert_eq "flake-dedup: stale by recency → no comment" "no" "$c"
-  if [[ -s "$TMPDIR_TEST/scripts/stub/reopen-fired" ]]; then r=yes; else r=no; fi
-  assert_eq "flake-dedup: stale by recency → no reopen" "no" "$r"
+  assert_eq "flake-dedup: recency removed (run pre-close, head contains fix) → REOPENED <N>" "REOPENED 501" "$out"
+  if grep -qx '501' "$TMPDIR_TEST/scripts/stub/reopen-fired" 2>/dev/null; then r=yes; else r=no; fi
+  assert_eq "flake-dedup: recency removed → reopen fired on 501" "yes" "$r"
+  if grep -qx '501' "$TMPDIR_TEST/scripts/stub/comments-fired" 2>/dev/null; then c=yes; else c=no; fi
+  assert_eq "flake-dedup: recency removed → comment fired on 501" "yes" "$c"
   if grep -q 'suppressing reopen' "$TMPDIR_TEST/err"; then g=yes; else g=no; fi
-  assert_eq "flake-dedup: stale by recency → suppression logged to stderr" "yes" "$g"
+  assert_eq "flake-dedup: recency removed → no suppression logged" "no" "$g"
   flake_dedup_teardown
 
-  # CASE 6 — STALE by ancestry (the discriminating case): run.createdAt is AFTER
-  # closed_at (recency says FRESH) yet the run head is `behind` the closing fix
-  # (ancestry says STALE). This is the ONLY case that fails under a recency-only
-  # implementation — the divergent stub values (created-after-close + `behind`)
-  # force the ancestry signal to carry the verdict. No comment, no reopen.
+  # CASE 6 — STALE by ancestry (the surviving #2442 case): a real closing commit
+  # exists and the run head is `behind` it, so ancestry — the sole decisive
+  # signal — suppresses the reopen. run.createdAt is AFTER closed_at, which the
+  # removed recency floor would have treated as fresh; the verdict is carried
+  # entirely by ancestry. No comment, no reopen.
   flake_dedup_setup
   printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-01-01T00:00:00Z"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
   printf '{"createdAt":"2026-02-01T00:00:00Z","headSha":"headsha"}\n' > "$TMPDIR_TEST/scripts/run.json"
@@ -33225,36 +33228,40 @@ STUB
   assert_eq "flake-dedup: stale by ancestry → no reopen" "no" "$r"
   flake_dedup_teardown
 
-  # CASE 7 — null commit_id (manual close) → ancestry skipped → recency fallback →
-  # REOPENED. timeline commit_id is null, so the closing commit is empty and the
-  # ancestry signal is skipped; compare-status `behind` MUST be ignored. recency
-  # is fresh (run after close), so the reopen fires.
+  # CASE 7 — null commit_id (manual close), the live incident (PR #1849 / tracker
+  # #2481). timeline commit_id is null, so there is no closing commit and ancestry
+  # leaves stale=0 → REOPEN; compare-status `behind` MUST be ignored. run.createdAt
+  # is BEFORE closed_at — the run-before-close that the removed recency floor would
+  # have suppressed as STALE (the infinite-STALE bug); under ancestry-only the
+  # empty closing commit → REOPEN. This is the regression test the incident needs.
   flake_dedup_setup
-  printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-01-01T00:00:00Z"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
-  printf '{"createdAt":"2026-02-01T00:00:00Z","headSha":"headsha"}\n' > "$TMPDIR_TEST/scripts/run.json"
+  printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-02-01T00:00:00Z"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
+  printf '{"createdAt":"2026-01-01T00:00:00Z","headSha":"headsha"}\n' > "$TMPDIR_TEST/scripts/run.json"
   printf 'behind\n' > "$TMPDIR_TEST/scripts/compare-status"
   printf '[{"event":"closed","commit_id":null}]\n' > "$TMPDIR_TEST/scripts/timeline.json"
   printf 'recurred on PR #900 / run http://x\n' > "$TMPDIR_TEST/body.md"
   out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md" --run-id 12345)
-  assert_eq "flake-dedup: null commit_id → recency fallback → REOPENED <N>" "REOPENED 501" "$out"
+  assert_eq "flake-dedup: null commit_id (run pre-close) → REOPENED <N>" "REOPENED 501" "$out"
   if grep -qx '501' "$TMPDIR_TEST/scripts/stub/reopen-fired" 2>/dev/null; then r=yes; else r=no; fi
   assert_eq "flake-dedup: null commit_id → reopen fired on 501" "yes" "$r"
   if grep -qx '501' "$TMPDIR_TEST/scripts/stub/comments-fired" 2>/dev/null; then c=yes; else c=no; fi
   assert_eq "flake-dedup: null commit_id → comment fired on 501" "yes" "$c"
   flake_dedup_teardown
 
-  # CASE 8 — NOT_PLANNED close → ancestry skipped → recency fallback → REOPENED.
+  # CASE 8 — NOT_PLANNED close → ancestry skipped → stale=0 → REOPENED.
   # state_reason=not_planned means there was no fix, so ancestry is skipped;
-  # compare-status `behind` and the present timeline commit_id MUST be ignored.
-  # recency is fresh (run after close), so the reopen fires.
+  # compare-status `behind` and the present timeline commit_id MUST be ignored. The
+  # run.createdAt is BEFORE closed_at — the run-before-close that the removed
+  # recency floor would have suppressed as STALE; under ancestry-only there is no
+  # closing fix to be behind, so it REOPENs. This flip discriminates old vs new code.
   flake_dedup_setup
-  printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-01-01T00:00:00Z","state_reason":"not_planned"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
-  printf '{"createdAt":"2026-02-01T00:00:00Z","headSha":"headsha"}\n' > "$TMPDIR_TEST/scripts/run.json"
+  printf '[{"number":501,"title":"Flaky CI: %s","state":"closed","closed_at":"2026-02-01T00:00:00Z","state_reason":"not_planned"}]\n' "$FP" > "$TMPDIR_TEST/scripts/issues.json"
+  printf '{"createdAt":"2026-01-01T00:00:00Z","headSha":"headsha"}\n' > "$TMPDIR_TEST/scripts/run.json"
   printf 'behind\n' > "$TMPDIR_TEST/scripts/compare-status"
   printf '[{"event":"closed","commit_id":"closingsha"}]\n' > "$TMPDIR_TEST/scripts/timeline.json"
   printf 'recurred on PR #900 / run http://x\n' > "$TMPDIR_TEST/body.md"
   out=$("$TMPDIR_TEST/scripts/dispatch-flake-dedup" "$FP" --body-file "$TMPDIR_TEST/body.md" --run-id 12345)
-  assert_eq "flake-dedup: not_planned → recency fallback → REOPENED <N>" "REOPENED 501" "$out"
+  assert_eq "flake-dedup: not_planned (run pre-close) → REOPENED <N>" "REOPENED 501" "$out"
   if grep -qx '501' "$TMPDIR_TEST/scripts/stub/reopen-fired" 2>/dev/null; then r=yes; else r=no; fi
   assert_eq "flake-dedup: not_planned → reopen fired on 501" "yes" "$r"
   if grep -qx '501' "$TMPDIR_TEST/scripts/stub/comments-fired" 2>/dev/null; then c=yes; else c=no; fi

--- a/.claude/skills/fix-checks/SKILL.md
+++ b/.claude/skills/fix-checks/SKILL.md
@@ -198,8 +198,9 @@ Cross-iteration memory lives entirely in `tmp/fix-checks-summary.md` (see
              should see on one issue, not N dups). Do **not** file. Flake issue =
              `#<N>`, disposition `REOPENED`.
            - **`STALE <N>`** — a same-fingerprint issue was closed-as-fixed and
-             the guard determined this triggering run pre-dates the fix that closed
-             it: the PR branch is stale and is still emitting the pre-fix
+             the guard determined this triggering run's head does **not** contain
+             the closing fix commit (ancestry shows `behind`/`diverged`): the PR
+             branch is stale and is still emitting the pre-fix
              signature. The guard fired no comment and no reopen — suppressing the
              oscillation is the point. Do **not** file. Do **not** reopen. Flake
              issue = `#<N>`, disposition `STALE`. **Skip sub-step 4 (block the


### PR DESCRIPTION
Closes #2518

## What

Narrow `dispatch-flake-dedup`'s CLOSED-arm stale-head reopen gate to
**ancestry-only**, removing the recency trigger that caused infinite-STALE loops
on manual / no-commit closes.

## Why

The stale-head gate (added by #2442) decided whether to suppress reopening a
closed flake tracker using a flat OR of two signals:

1. **Recency:** `run.createdAt < issue.closedAt` → STALE.
2. **Ancestry:** the run's head is `behind`/`diverged` from the commit that
   closed the issue → STALE.

Ancestry is undefined for a manual / no-commit close (`commit_id: null`, or
`NOT_PLANNED`), so recency was the *only* live signal there — and recency is a
false-positive generator: it marks **every** run created before the
administrative close time as stale, including a run whose head already contains
all of `main`.

The live incident (PR #1849 / flake tracker #2481, manually closed `COMPLETED`
with `commit_id: null`) produced an infinite STALE loop: the guard suppressed the
reopen, `/fix-checks` pushed nothing, CI stayed red, `/dispatch-propagate`
re-routed to fix-checks, same STALE — until the attempt counter capped at 3 and
the PR parked on office-hours. A live recurrence was silently swallowed.

## How

STALE now requires **positive evidence the run head is behind a real closing
fix**. Ancestry is the sole, decisive signal; the recency floor is gone:

- Real closing commit + head `behind`/`diverged` → **STALE** (the #2442 case: a
  long-lived branch genuinely behind the fix — preserved).
- Real closing commit + head `ahead`/`identical` → **REOPEN** (head contains the
  fix; a live recurrence).
- No closing commit — manual (`null commit_id`) or `NOT_PLANNED` close →
  **REOPEN**: the head cannot be stale relative to a fix that does not exist.

On a no-commit close the issue now REOPENs, surfacing the "closed `COMPLETED` yet
still firing" contradiction, which drives the `blocked_by` that stops the PR
re-routing. Loop-termination is preserved by the block, not by suppression.

## Tests

In `test-dispatch-scripts.sh`, CASE 5 (previously asserted STALE on a
recency-only condition — it encoded this bug) is repurposed to assert the
corrected REOPEN; CASES 7 and 8 (manual / `NOT_PLANNED` close) flip their run
timestamp before the close so they discriminate the old recency code (which would
STALE) from ancestry-only (which REOPENs). No case is skipped or removed; total
assertion coverage increases. The #2442 surviving case (CASE 6) stays green.

Full dispatch suite: **4027/4027 passed**.

## Coordination note

#2480 (open) also touches the flake-dedup section of `test-dispatch-scripts.sh`
(helper-level unit tests). A merge conflict is possible; it is a fix-conflicts
concern at merge time, not a blocker.
