### PR TITLE
preview-deploy: surface underlying firebase-tools error on auth-class failure

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -150,6 +150,62 @@ gh_retry() {
   return 1
 }
 
+# Neutralize secrets in firebase-tools --debug output. Reads stdin, writes the
+# redacted stream to stdout. This is the BACKSTOP control — firebase_auth_diagnostic's
+# allowlisted error window is the primary one. Ordering matters and is enforced here:
+#   1. the MULTI-LINE PEM private-key block FIRST — collapse everything from
+#      `-----BEGIN ... PRIVATE KEY-----` through `-----END ... PRIVATE KEY-----`
+#      (inclusive) to a single line via an awk range (a per-line sed cannot span
+#      lines), so the key bytes never reach the line-oriented passes below.
+#   2. single-line passes: `Bearer <token>` BEFORE bare `ya29.` tokens (so a
+#      bearer OAuth token collapses to `Bearer [REDACTED]` rather than leaking a
+#      `Bearer ` prefix), then bare OAuth tokens, JWTs, and keyed JSON / key=value
+#      secret values for access_token/refresh_token/id_token/client_secret/private_key.
+redact_firebase_secrets() {
+  awk '
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----/ { print "[REDACTED PRIVATE KEY]"; inkey=1; next }
+    inkey && /-----END [A-Z ]*PRIVATE KEY-----/ { inkey=0; next }
+    inkey { next }
+    { print }
+  ' \
+  | sed -E \
+      -e 's/[Bb]earer[[:space:]]+[A-Za-z0-9._~+/=-]+/Bearer [REDACTED]/g' \
+      -e 's/ya29\.[A-Za-z0-9._-]+/[REDACTED-TOKEN]/g' \
+      -e 's/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/[REDACTED-JWT]/g' \
+      -e 's/("(access_token|refresh_token|id_token|client_secret|private_key)"[[:space:]]*:[[:space:]]*")[^"]*"/\1[REDACTED]"/g' \
+      -e 's/((access_token|refresh_token|id_token|client_secret|private_key)=)[^[:space:]&]+/\1[REDACTED]/g'
+}
+
+# On the auth-class deploy failure ONLY, run a one-shot NON-json firebase-tools
+# --debug probe to surface the underlying transport/credential error that the
+# --json deploy suppressed (e.g. a node/undici "Premature close" on the OAuth
+# token fetch surfacing as the generic "Failed to authenticate"). Writes a
+# redacted, allowlisted window of the probe output to STDERR. Never leaks
+# secrets: the captured output is first passed through redact_firebase_secrets
+# (backstop), then only a bounded window grep'd around the error signature is
+# emitted (allowlist — the primary control). The diagnostic command defaults to
+# `npx firebase-tools projects:list --debug`; override via env var
+# FIREBASE_AUTH_DIAGNOSTIC_CMD (word-split, for test injection). Runs under
+# `timeout` so a hung probe cannot stall the failure path; the probe's expected
+# non-zero exit is captured and does not trip a caller's `set -e`.
+firebase_auth_diagnostic() {
+  local cmd output rc window
+  read -ra cmd <<< "${FIREBASE_AUTH_DIAGNOSTIC_CMD:-npx firebase-tools projects:list --debug}"
+  echo "=== firebase auth diagnostic (non-json --debug) ===" >&2
+  if output=$(timeout 60 "${cmd[@]}" 2>&1); then
+    rc=0
+  else
+    rc=$?
+  fi
+  window=$(printf '%s\n' "$output" | redact_firebase_secrets \
+    | grep -iE -B1 -A2 'error|premature|invalid response|denied|token|fail' || true)
+  if [[ -z "$window" ]]; then
+    echo "auth diagnostic produced no recognizable error lines (exit $rc); auth may have recovered — original failure possibly transient" >&2
+  else
+    printf '%s\n' "$window" >&2
+  fi
+}
+
 # Run a firebase-tools deploy command, retrying ONLY on the transient auth
 # failure with exponential backoff. Args: the command and its arguments (e.g.
 # `firebase_deploy_retry npx firebase-tools hosting:channel:deploy ...`).
@@ -163,6 +219,11 @@ gh_retry() {
 # and its stderr to >&2, then returns the command's real exit code (no
 # swallowing — see .claude/rules/code-style.md). Only "Failed to authenticate"
 # is treated as transient — every other failure fails fast.
+# When the FINAL forwarded failure is auth-class (the --json deploy only ever
+# yields the generic "Failed to authenticate"), additionally run
+# firebase_auth_diagnostic to surface the real underlying firebase-tools error
+# on STDERR (#2522). A non-auth failure already carries its real error in stderr
+# and does NOT trigger the probe.
 # Tunables (env): FIREBASE_DEPLOY_RETRY_ATTEMPTS (default 3 = up to 3 attempts),
 # FIREBASE_DEPLOY_RETRY_BASE_DELAY (default 5 seconds).
 firebase_deploy_retry() {
@@ -183,6 +244,9 @@ firebase_deploy_retry() {
     if [[ "$attempt" -ge "$attempts" ]] || [[ "${combined,,}" != *"failed to authenticate"* ]]; then
       printf '%s\n' "$out"
       printf '%s' "$err" >&2
+      if [[ "${combined,,}" == *"failed to authenticate"* ]]; then
+        firebase_auth_diagnostic >&2
+      fi
       rm -f "$tmpfile"
       return "$rc"
     fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -40916,6 +40916,135 @@ assert_eq "firebase_deploy_retry: non-auth failure not retried (1 attempt)" "1" 
 assert_eq "firebase_deploy_retry: non-auth failure returns nonzero" "nonzero" \
   "$([[ $fdr_rc2 -ne 0 ]] && echo nonzero || echo zero)"
 
+# --- Case 3 (a): auth-class exhaustion runs the diagnostic -----------------
+FDR_STUB_A="$FDR_DIR/stub-always-auth-fail-a"
+cat > "$FDR_STUB_A" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' 'Failed to authenticate'
+exit 1
+STUB
+chmod +x "$FDR_STUB_A"
+
+FDR_DIAG_A="$FDR_DIR/diag-a"
+cat > "$FDR_DIAG_A" <<'DIAGSTUB'
+#!/usr/bin/env bash
+printf '%s\n' '[debug] Connecting to googleapis...'
+printf '%s\n' 'Invalid response body while trying to fetch https://www.googleapis.com/oauth2/v4/token: Premature close'
+exit 1
+DIAGSTUB
+chmod +x "$FDR_DIAG_A"
+export FIREBASE_AUTH_DIAGNOSTIC_CMD="$FDR_DIAG_A"
+
+FDR_STDOUT_A="$FDR_DIR/stdout-a"
+FDR_STDERR_A="$FDR_DIR/stderr-a"
+firebase_deploy_retry "$FDR_STUB_A" >"$FDR_STDOUT_A" 2>"$FDR_STDERR_A" || true
+assert_eq "firebase_deploy_retry: auth exhaustion - 'Failed to authenticate' on stdout" "yes" \
+  "$(grep -q 'Failed to authenticate' "$FDR_STDOUT_A" && echo yes || echo no)"
+assert_eq "firebase_deploy_retry: auth exhaustion - diagnostic shows 'Premature close' on stderr" "yes" \
+  "$(grep -q 'Premature close' "$FDR_STDERR_A" && echo yes || echo no)"
+
+# --- Case 3 (b): secrets are redacted (load-bearing test) -----------------
+# Diagnostic emits realistic --debug output with secrets adjacent to error/token
+# lines so they fall inside the grep -B1 -A2 window — proving redaction when absent.
+# Layout: "error: auth failed, sending token request" (line 1) puts Bearer (line 2)
+# and "access_token" JSON (line 3) inside its A2 window; "access_token" on line 3
+# ("token" match) puts PEM BEGIN (line 4) and PEM body (line 5) inside its A2 window;
+# "error: Premature close while fetching token" (line 7) puts eyJaaa JWT (line 8)
+# inside its A2 window. If redaction were broken, all four secret values would appear
+# verbatim in the emitted window.
+FDR_STUB_B="$FDR_DIR/stub-always-auth-fail-b"
+cat > "$FDR_STUB_B" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' 'Failed to authenticate'
+exit 1
+STUB
+chmod +x "$FDR_STUB_B"
+
+FDR_DIAG_B="$FDR_DIR/diag-b"
+cat > "$FDR_DIAG_B" <<'DIAGSTUB'
+#!/usr/bin/env bash
+printf '%s\n' 'error: auth failed, sending token request'
+printf '%s\n' 'authorization: Bearer ya29.LEAKME123456789'
+printf '%s\n' '"access_token": "ya29.SECRETVAL987654321"'
+printf '%s\n' '-----BEGIN PRIVATE KEY-----'
+printf '%s\n' 'MIIEvQIBADANBgkqhkiG9w0BAQEFAASC'
+printf '%s\n' '-----END PRIVATE KEY-----'
+printf '%s\n' 'error: Premature close while fetching token'
+printf '%s\n' 'eyJaaa.bbb.ccc'
+exit 1
+DIAGSTUB
+chmod +x "$FDR_DIAG_B"
+export FIREBASE_AUTH_DIAGNOSTIC_CMD="$FDR_DIAG_B"
+
+FDR_STDERR_B="$FDR_DIR/stderr-b"
+firebase_deploy_retry "$FDR_STUB_B" >/dev/null 2>"$FDR_STDERR_B" || true
+assert_eq "firebase_deploy_retry: redact - no raw ya29. token in diagnostic output" "no" \
+  "$(grep -q 'ya29\.' "$FDR_STDERR_B" && echo yes || echo no)"
+assert_eq "firebase_deploy_retry: redact - no raw JWT eyJaaa in diagnostic output" "no" \
+  "$(grep -q 'eyJaaa' "$FDR_STDERR_B" && echo yes || echo no)"
+assert_eq "firebase_deploy_retry: redact - no PEM body MIIEvQIBADANBg in diagnostic output" "no" \
+  "$(grep -q 'MIIEvQIBADANBg' "$FDR_STDERR_B" && echo yes || echo no)"
+assert_eq "firebase_deploy_retry: redact - error signature 'Premature' survives redaction" "yes" \
+  "$(grep -q 'Premature' "$FDR_STDERR_B" && echo yes || echo no)"
+
+# --- Case 3 (c): non-auth failure does NOT run the diagnostic --------------
+FDR_STUB_C="$FDR_DIR/stub-non-auth-c"
+cat > "$FDR_STUB_C" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' 'some other deploy error' >&2
+exit 1
+STUB
+chmod +x "$FDR_STUB_C"
+
+FDR_SENTINEL_C="$FDR_DIR/sentinel-c"
+FDR_DIAG_C="$FDR_DIR/diag-c"
+cat > "$FDR_DIAG_C" <<DIAGSTUB
+#!/usr/bin/env bash
+touch "$FDR_SENTINEL_C"
+exit 0
+DIAGSTUB
+chmod +x "$FDR_DIAG_C"
+export FIREBASE_AUTH_DIAGNOSTIC_CMD="$FDR_DIAG_C"
+
+firebase_deploy_retry "$FDR_STUB_C" >/dev/null 2>/dev/null || true
+fdr_sentinel_c_exists=$([[ -e "$FDR_SENTINEL_C" ]] && echo present || echo absent)
+assert_eq "firebase_deploy_retry: non-auth failure does not run diagnostic" "absent" \
+  "$fdr_sentinel_c_exists"
+
+# --- Case 3 (d): success path does NOT run the diagnostic ------------------
+FDR_COUNTER_D="$FDR_DIR/counter-d"
+printf '0' > "$FDR_COUNTER_D"
+FDR_STUB_D="$FDR_DIR/stub-success-d"
+cat > "$FDR_STUB_D" <<STUB
+#!/usr/bin/env bash
+n=\$(cat "$FDR_COUNTER_D")
+n=\$(( n + 1 ))
+printf '%s' "\$n" > "$FDR_COUNTER_D"
+if [[ "\$n" -lt 3 ]]; then
+  printf '%s\n' 'Failed to authenticate'
+  exit 1
+fi
+printf '%s\n' '{"result":{"ok":true}}'
+exit 0
+STUB
+chmod +x "$FDR_STUB_D"
+
+FDR_SENTINEL_D="$FDR_DIR/sentinel-d"
+FDR_DIAG_D="$FDR_DIR/diag-d"
+cat > "$FDR_DIAG_D" <<DIAGSTUB
+#!/usr/bin/env bash
+touch "$FDR_SENTINEL_D"
+exit 0
+DIAGSTUB
+chmod +x "$FDR_DIAG_D"
+export FIREBASE_AUTH_DIAGNOSTIC_CMD="$FDR_DIAG_D"
+
+firebase_deploy_retry "$FDR_STUB_D" >/dev/null 2>/dev/null || true
+fdr_sentinel_d_exists=$([[ -e "$FDR_SENTINEL_D" ]] && echo present || echo absent)
+assert_eq "firebase_deploy_retry: success path does not run diagnostic" "absent" \
+  "$fdr_sentinel_d_exists"
+
+unset FIREBASE_AUTH_DIAGNOSTIC_CMD
 rm -rf "$FDR_DIR"
 unset FIREBASE_DEPLOY_RETRY_BASE_DELAY FIREBASE_DEPLOY_RETRY_ATTEMPTS
 


### PR DESCRIPTION
Closes #2522

## Problem

Every auth-class preview-deploy failure surfaces only the generic
`Error: Failed to authenticate, have you run firebase login?`. `firebase-tools`
runs the deploy with `--json`, which suppresses both its `--debug` stderr and the
`firebase-debug.log` file, and `firebase_deploy_retry` forwards only the final
attempt's generic stderr. The actual cause — in #2481 a node/undici transport
error (`Invalid response body while trying to fetch
https://www.googleapis.com/oauth2/v4/token: Premature close`) — never reaches the
job log, and the generic message misleadingly points at credentials that were
valid the whole time. Root-causing #2481 took hours for this reason.

## Change

On an **auth-class** deploy failure only, `firebase_deploy_retry` now runs a
one-shot **non-json `--debug` diagnostic** (`firebase_auth_diagnostic`) that
surfaces the underlying firebase-tools error to the job log — alongside, not
replacing, the existing generic line. The probe:

- runs `npx firebase-tools projects:list --debug` (a lightweight, read-only,
  project-agnostic probe that exercises the same OAuth token-fetch path that
  failed; overridable via `FIREBASE_AUTH_DIAGNOSTIC_CMD` for test injection),
  under a `timeout` so a hung probe cannot stall the failure path;
- never leaks secrets. Secret handling is two-layered: a `redact_firebase_secrets`
  backstop (multi-line PEM private-key block, `Bearer` tokens, bare `ya29.`
  tokens, JWTs, and keyed `access_token`/`refresh_token`/`id_token`/
  `client_secret`/`private_key` values) runs first, then the **primary** control
  emits only an **allowlisted window** grep'd around the error signature rather
  than dumping raw output;
- is scoped to the auth-class **final-failure** path: it never runs on success,
  on a retry, or on a non-auth failure (which already carries its real error).

`run-preview-deploy.sh` is unchanged — the helper's stderr already flows straight
to the job log.

This follows `.claude/rules/code-style.md` (prefer clear errors over defensive
fallbacks).

## Tests

`test-dispatch-scripts.sh` gains cases that drive `firebase_auth_diagnostic` via
`FIREBASE_AUTH_DIAGNOSTIC_CMD` stubs:

- **auth-class exhaustion runs the diagnostic** — stderr carries both the generic
  line and the underlying `Premature close` error;
- **secrets are redacted** — a realistic mix (Bearer `ya29.` header, JWT,
  `access_token` JSON field, and a multi-line PEM block) emits none of the raw
  secret values while the error signature survives;
- **non-auth failure** and **success path** do **not** run the diagnostic
  (sentinel-file checks).

The full harness passes (4035/4035), which is exactly what CI runs.

## QA notes

The end-to-end behavior (a real auth-class preview-deploy failure surfacing the
underlying gaxios error in a CI job log) can only be observed when a deploy
actually fails auth in CI; it is not reproducible offline. Confirm during QA that
no secret material appears in the diagnostic output of any real failed run.
