### PR TITLE
Fix flaky build: soft-warn on network fetch failures in blog feed-fetch plugin

### DIFF
--- a/blog/src/blog-roll/vite-plugin-feed-fetch.ts
+++ b/blog/src/blog-roll/vite-plugin-feed-fetch.ts
@@ -34,6 +34,20 @@ export function feedFetchPlugin(feeds: FeedConfig[]): Plugin {
             }
             return [id, post];
           } catch (err) {
+            // undici (Node 22+) throws `TypeError: fetch failed` for network-level
+            // failures (DNS, connection refused, temporary unreachability). These are
+            // transient infrastructure errors, not a build misconfiguration — soft-warn
+            // and skip the feed rather than fail the build. This early return MUST
+            // precede the bad-URL re-throw AND the classifyError check below: classifyError
+            // maps every TypeError to "programmer", so without this return a network
+            // TypeError would be re-thrown there and fail the build. Do not collapse this
+            // into a single inverted condition.
+            if (err instanceof TypeError && err.message === "fetch failed") {
+              console.warn(`[feed-fetch] ${id}: fetch error`, err);
+              return [id, null];
+            }
+            // Other TypeErrors (e.g. `Failed to parse URL from <url>`) indicate a
+            // genuinely invalid feed configuration — re-throw as a fatal build error.
             if (err instanceof TypeError) {
               throw new Error(`[feed-fetch] ${id}: invalid fetch configuration`, { cause: err });
             }

--- a/blog/test/blog-roll/vite-plugin-feed-fetch.test.ts
+++ b/blog/test/blog-roll/vite-plugin-feed-fetch.test.ts
@@ -199,11 +199,11 @@ describe("feedFetchPlugin buildStart error handling", () => {
       { id: "test", url: "https://example.com/feed.xml" },
     ]);
 
-    await expect((plugin as any).buildStart()).resolves.toBeUndefined();
+    await expect((plugin as any).buildStart()).resolves.toBeUndefined(); // type-safety-ok: invoking Vite plugin hook directly in unit test
 
     const feedData = parseVirtualModule(
-      (plugin as any).load(RESOLVED_VIRTUAL_MODULE_ID),
-    ) as Record<string, unknown>;
+      (plugin as any).load(RESOLVED_VIRTUAL_MODULE_ID), // type-safety-ok: invoking Vite plugin hook directly in unit test
+    ) as Record<string, unknown>; // type-safety-ok: narrowing parseVirtualModule's unknown JSON
     expect(feedData["test"]).toBeNull();
     expect(warn).toHaveBeenCalled();
   });
@@ -217,7 +217,7 @@ describe("feedFetchPlugin buildStart error handling", () => {
       { id: "test", url: "https://example.com/feed.xml" },
     ]);
 
-    await expect((plugin as any).buildStart()).rejects.toThrow(
+    await expect((plugin as any).buildStart()).rejects.toThrow( // type-safety-ok: invoking Vite plugin hook directly in unit test
       "invalid fetch configuration",
     );
   });

--- a/blog/test/blog-roll/vite-plugin-feed-fetch.test.ts
+++ b/blog/test/blog-roll/vite-plugin-feed-fetch.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
+  feedFetchPlugin,
   parseAtomFeedXml,
   parseRssFeedXml,
 } from "../../src/blog-roll/vite-plugin-feed-fetch";
+
+function parseVirtualModule(moduleCode: string): unknown {
+  return JSON.parse(moduleCode.replace("export default ", "").replace(/;$/, ""));
+}
 
 describe("parseAtomFeedXml", () => {
   it("extracts title, URL, and publishedAt from an Atom entry", () => {
@@ -175,5 +180,45 @@ describe("parseRssFeedXml", () => {
     const result = parseRssFeedXml(xml);
     expect(result?.title).toBe("A & B <3");
     expect(result?.url).toBe("https://example.com/a&b");
+  });
+});
+
+describe("feedFetchPlugin buildStart error handling", () => {
+  const RESOLVED_VIRTUAL_MODULE_ID = "\0virtual:blog-roll-feeds";
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("soft-warns and skips the feed on a network TypeError (build does not fail)", async () => {
+    vi.stubGlobal("fetch", () => Promise.reject(new TypeError("fetch failed")));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const plugin = feedFetchPlugin([
+      { id: "test", url: "https://example.com/feed.xml" },
+    ]);
+
+    await expect((plugin as any).buildStart()).resolves.toBeUndefined();
+
+    const feedData = parseVirtualModule(
+      (plugin as any).load(RESOLVED_VIRTUAL_MODULE_ID),
+    ) as Record<string, unknown>;
+    expect(feedData["test"]).toBeNull();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("re-throws a fatal build error on a bad-URL TypeError", async () => {
+    vi.stubGlobal("fetch", () =>
+      Promise.reject(new TypeError("Failed to parse URL from not-a-url")),
+    );
+
+    const plugin = feedFetchPlugin([
+      { id: "test", url: "https://example.com/feed.xml" },
+    ]);
+
+    await expect((plugin as any).buildStart()).rejects.toThrow(
+      "invalid fetch configuration",
+    );
   });
 });

--- a/blog/test/blog-roll/vite-plugin-feed-fetch.test.ts
+++ b/blog/test/blog-roll/vite-plugin-feed-fetch.test.ts
@@ -205,7 +205,10 @@ describe("feedFetchPlugin buildStart error handling", () => {
       (plugin as any).load(RESOLVED_VIRTUAL_MODULE_ID), // type-safety-ok: invoking Vite plugin hook directly in unit test
     ) as Record<string, unknown>; // type-safety-ok: narrowing parseVirtualModule's unknown JSON
     expect(feedData["test"]).toBeNull();
-    expect(warn).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("[feed-fetch] test"),
+      expect.any(TypeError),
+    );
   });
 
   it("re-throws a fatal build error on a bad-URL TypeError", async () => {


### PR DESCRIPTION
Closes #2535

## Problem

The `build(fellspiral)` CI step intermittently fails because fellspiral's build
imports the blog blog-roll plugin, which fetches each configured feed URL at
build time. When a feed URL is temporarily unreachable (DNS failure, connection
refused, transient network error), undici in Node.js 22+ throws
`TypeError: fetch failed`. The plugin's catch block re-threw **any** `TypeError`
as a fatal build error, so a transient network blip failed the build —
non-deterministic, infrastructure-driven flakiness, not a real defect.

## Fix

In the `buildStart` catch block of `blog/src/blog-roll/vite-plugin-feed-fetch.ts`,
discriminate the network case from the bad-URL case:

- A network `TypeError` (`err.message === "fetch failed"`, undici's stable
  message for network-level failures) now soft-warns and skips the feed, letting
  the build continue.
- A bad-URL `TypeError` (e.g. `Failed to parse URL from <url>`) still re-throws
  as a fatal `invalid fetch configuration` build error — genuine
  misconfiguration should still fail the build.

The network branch is an **early `return` placed before** both the bad-URL
re-throw and the existing `classifyError` check. This ordering is load-bearing:
`@commons-systems/errorutil`'s `classifyError` maps every `TypeError` to
`"programmer"`, so without the early return a network `TypeError` would fall
through and be re-thrown anyway. The fix is deliberately not collapsed into a
single inverted condition.

## Tests

Adds a `describe("feedFetchPlugin buildStart error handling", …)` block to
`blog/test/blog-roll/vite-plugin-feed-fetch.test.ts` covering both directions of
the discrimination, using the established plugin-hook test pattern (stubbed
global `fetch`, `buildStart()`/`load()` invocation, virtual-module parsing):

1. Network `TypeError: fetch failed` → `buildStart()` resolves, the feed maps to
   `null`, `console.warn` fires. This is the deterministic, CI-safe proxy for the
   flaky failure.
2. Bad-URL `TypeError` → `buildStart()` rejects with `invalid fetch configuration`.

## Verification

- `npx vitest run --project blog --root .` — 425/425 pass (29 files), including
  the 2 new cases.
- Blog typecheck via the CI-authoritative `run-typecheck.sh --app blog` — green
  (the change is typecheck-clean; no new type errors in the two changed files).

The end-to-end acceptance criterion (the `build(fellspiral)` step completing on a
transient network blip) is inherently non-deterministic to reproduce locally; the
stubbed unit test guards the discrimination logic, which is the testable part.
