### PR TITLE
Sum gscClicks/gscImpressions from topPages, not topQueries

### DIFF
--- a/functions/src/project-signals.ts
+++ b/functions/src/project-signals.ts
@@ -219,8 +219,8 @@ interface ProjectSignalSample {
   forks?: number;
   pageViews?: number; // summed across GA4 apps
   sessions?: number; // summed across GA4 apps
-  gscClicks?: number; // summed
-  gscImpressions?: number; // summed
+  gscClicks?: number; // summed from topPages
+  gscImpressions?: number; // summed from topPages
   psiPerformance?: number; // first-URL mobile performance
 }
 
@@ -629,10 +629,10 @@ export async function collectProjectSignalsCore(deps: CollectProjectSignalsDeps)
   const pageViews = ga4 ? ga4.reduce((sum, a) => sum + a.pageViews, 0) : undefined;
   const sessions = ga4 ? ga4.reduce((sum, a) => sum + a.sessions, 0) : undefined;
   const gscClicks = gsc
-    ? gsc.topQueries.reduce((sum, q) => sum + q.clicks, 0)
+    ? gsc.topPages.reduce((sum, p) => sum + p.clicks, 0)
     : undefined;
   const gscImpressions = gsc
-    ? gsc.topQueries.reduce((sum, q) => sum + q.impressions, 0)
+    ? gsc.topPages.reduce((sum, p) => sum + p.impressions, 0)
     : undefined;
   const psiPerformance =
     psi && psi.length > 0 && psi[0].performance !== null ? psi[0].performance : undefined;

--- a/functions/test/project-signals.test.ts
+++ b/functions/test/project-signals.test.ts
@@ -418,7 +418,10 @@ describe("collectProjectSignalsCore", () => {
       { query: "a", clicks: 10, impressions: 100, ctr: 0.1, position: 2 },
       { query: "b", clicks: 5, impressions: 50, ctr: 0.1, position: 3 },
     ],
-    topPages: [],
+    topPages: [
+      { page: "/", clicks: 8, impressions: 80, ctr: 0.1, position: 2 },
+      { page: "/budget", clicks: 4, impressions: 40, ctr: 0.1, position: 3 },
+    ],
     devices: [],
   };
   const psi: PsiUrlSignals[] = [
@@ -518,9 +521,9 @@ describe("collectProjectSignalsCore", () => {
     // summed across GA4 apps
     expect(sample.pageViews).toBe(1200);
     expect(sample.sessions).toBe(500);
-    // summed GSC query clicks/impressions
-    expect(sample.gscClicks).toBe(15);
-    expect(sample.gscImpressions).toBe(150);
+    // summed from topPages
+    expect(sample.gscClicks).toBe(12);
+    expect(sample.gscImpressions).toBe(120);
     // first-URL mobile performance
     expect(sample.psiPerformance).toBe(88);
 


### PR DESCRIPTION
Closes #2488

## Summary

The `gscClicks` and `gscImpressions` headline scalars in the project signal-samples
time series were summed from `gsc.topQueries` instead of `gsc.topPages`. Both are
top-25 subsets of the GSC response, but a single page is reached via multiple
queries, so summing across queries **double-counts** clicks and impressions.

The office-hours `ProjectSignalsPanel` already renders its "total clicks" /
"total impressions" from `gsc.topPages`, so the charted time-series scalar and the
panel aggregate disagreed for the same snapshot and could not be compared over
time. This PR sums both scalars from `topPages` so they match the panel and avoid
double-counting.

This is the page-based-sum path the issue recommends over the field-rename
alternative (`gscQueryClicks` / `gscQueryImpressions`).

## Changes

- `functions/src/project-signals.ts` — the two reducers now walk `gsc.topPages`
  instead of `gsc.topQueries`; the `ProjectSignalSample` type-field comments name
  the source (`// summed from topPages`).
- `functions/test/project-signals.test.ts` — the shared `gsc` fixture now
  populates `topPages` with rows whose totals (12 clicks / 120 impressions) are
  distinct from the `topQueries` totals (15 / 150), so the test actively pins the
  new source; the headline-scalar assertions are updated accordingly.

## Verification

- `npx vitest run --project functions --root .` — 83 tests pass.
- `npx tsc -p functions --noEmit` — type-clean.
