### PR TITLE
print: change/forget-folder control in the granted state

### DIFF
--- a/print/src/library.ts
+++ b/print/src/library.ts
@@ -126,8 +126,11 @@ export function hasLocalSource(): boolean {
   return localSource !== null;
 }
 
-/** Reset the bound local source. Test-only: lets order-independent tests
- *  assert the no-source-bound state regardless of suite execution order. */
+/** Reset the bound local source back to the no-source-bound state.
+ *  Production use: the local-folder "forget" handler calls this to clear the
+ *  in-memory local source when the user revokes a granted folder. Also used by
+ *  order-independent tests to assert the no-source-bound state regardless of
+ *  suite execution order. */
 export function resetLocalSource(): void {
   localSource = null;
 }

--- a/print/src/local-folder-ui.ts
+++ b/print/src/local-folder-ui.ts
@@ -18,6 +18,7 @@ import { createLimiter } from "./concurrency.js";
 import {
   createLocalSource,
   listLocal,
+  resetLocalSource,
   resolveLocalBlob,
 } from "./library.js";
 import { extractMetadata } from "./local-metadata.js";
@@ -110,41 +111,92 @@ export async function initLocalFolder(
       const dir = await window.showDirectoryPicker!({ mode: "readwrite" });
       await store.put(PURPOSE, dir);
       await bindAndRender(dir, true);
+      // Surface the change/forget controls in-session (open→list) without a
+      // reload. From the "change" button the section is already "list", so this
+      // re-render is idempotent (re-binds the change/forget handlers fresh).
+      renderSection("list");
     } catch (e) {
       if ((e as DOMException)?.name === "AbortError") return;
       throw e;
     }
   }
 
-  if (state === "open") {
-    section.innerHTML =
-      '<button id="local-folder-open" class="local-folder-button" type="button">Open folder…</button>';
-    section
-      .querySelector<HTMLButtonElement>("#local-folder-open")!
-      .addEventListener("click", () => {
-        openFolder().catch((err) =>
-          logError(err, { operation: "local-folder-open" }),
-        );
-      });
-  } else if (state === "grant") {
-    section.innerHTML =
-      '<button id="local-folder-grant" class="local-folder-button" type="button">Grant access to your folder</button>';
-    section
-      .querySelector<HTMLButtonElement>("#local-folder-grant")!
-      .addEventListener("click", () => {
-        void (async () => {
-          const res = await store.requestPermission(handle!, "readwrite");
-          if (res === "granted") {
-            section.innerHTML = "";
-            await bindAndRender(handle as FileSystemDirectoryHandle, true);
-          }
-        })().catch((err) =>
-          logError(err, { operation: "local-folder-grant" }),
-        );
-      });
-  } else {
-    // "list" — permission already granted, bind and render.
-    section.innerHTML = "";
+  // Single, re-invokable nav-slot renderer: each branch sets the markup AND
+  // (re-)binds its click handlers, so every transition — open→list (first
+  // pick), grant→list (permission granted), forget's list→open — re-attaches
+  // listeners and never produces a dead button. Operates on `section` (the nav
+  // slot), distinct from `mediaListContainer` (the media list).
+  function renderSection(uiState: FolderUiState): void {
+    if (uiState === "open") {
+      section.innerHTML =
+        '<button id="local-folder-open" class="local-folder-button" type="button">Open folder…</button>';
+      section
+        .querySelector<HTMLButtonElement>("#local-folder-open")!
+        .addEventListener("click", () => {
+          openFolder().catch((err) =>
+            logError(err, { operation: "local-folder-open" }),
+          );
+        });
+    } else if (uiState === "grant") {
+      section.innerHTML =
+        '<button id="local-folder-grant" class="local-folder-button" type="button">Grant access to your folder</button>';
+      section
+        .querySelector<HTMLButtonElement>("#local-folder-grant")!
+        .addEventListener("click", () => {
+          void (async () => {
+            const res = await store.requestPermission(handle!, "readwrite");
+            if (res === "granted") {
+              // Render the change/forget controls, THEN bind the list — so the
+              // controls persist even if the scan fails.
+              renderSection("list");
+              await bindAndRender(handle as FileSystemDirectoryHandle, true);
+            }
+          })().catch((err) =>
+            logError(err, { operation: "local-folder-grant" }),
+          );
+        });
+    } else {
+      // "list" — persistent change/forget controls so the granted folder can be
+      // re-picked or cleared (replaces the old `section.innerHTML = ""`).
+      section.innerHTML =
+        '<div class="local-folder-controls">' +
+        '<button id="local-folder-change" class="local-folder-button" type="button">Change folder</button>' +
+        '<button id="local-folder-forget" class="local-folder-button" type="button">Forget folder</button>' +
+        "</div>";
+      section
+        .querySelector<HTMLButtonElement>("#local-folder-change")!
+        .addEventListener("click", () => {
+          // Reuse the picker flow; section is already "list" so no nav
+          // re-render is needed — bindAndRender re-renders the list rows.
+          openFolder().catch((err) =>
+            logError(err, { operation: "local-folder-change" }),
+          );
+        });
+      section
+        .querySelector<HTMLButtonElement>("#local-folder-forget")!
+        .addEventListener("click", () => {
+          void (async () => {
+            await store.remove(PURPOSE);
+            resetLocalSource();
+            // Drop the focus rescan so it cannot re-scan the forgotten folder.
+            if (focusCleanup) {
+              focusCleanup();
+              focusCleanup = null;
+            }
+            // With the source reset, listLocal() returns [] — this empties the
+            // local rows via the existing strip-`.media-item-local` logic.
+            await renderLocalIntoList(mediaListContainer);
+            // Revert the nav slot to the initial "Open folder…" state.
+            renderSection("open");
+          })().catch((err) =>
+            logError(err, { operation: "local-folder-forget" }),
+          );
+        });
+    }
+  }
+
+  renderSection(state);
+  if (state === "list") {
     await bindAndRender(handle as FileSystemDirectoryHandle, true);
   }
 

--- a/print/src/local-folder-ui.ts
+++ b/print/src/local-folder-ui.ts
@@ -131,7 +131,7 @@ export async function initLocalFolder(
       section.innerHTML =
         '<button id="local-folder-open" class="local-folder-button" type="button">Open folder…</button>';
       section
-        .querySelector<HTMLButtonElement>("#local-folder-open")!
+        .querySelector<HTMLButtonElement>("#local-folder-open")! // type-safety-ok: innerHTML was just set with this id
         .addEventListener("click", () => {
           openFolder().catch((err) =>
             logError(err, { operation: "local-folder-open" }),
@@ -141,15 +141,15 @@ export async function initLocalFolder(
       section.innerHTML =
         '<button id="local-folder-grant" class="local-folder-button" type="button">Grant access to your folder</button>';
       section
-        .querySelector<HTMLButtonElement>("#local-folder-grant")!
+        .querySelector<HTMLButtonElement>("#local-folder-grant")! // type-safety-ok: innerHTML was just set with this id
         .addEventListener("click", () => {
           void (async () => {
-            const res = await store.requestPermission(handle!, "readwrite");
+            const res = await store.requestPermission(handle!, "readwrite"); // type-safety-ok: 'grant' state only reached when handle is non-null
             if (res === "granted") {
               // Render the change/forget controls, THEN bind the list — so the
               // controls persist even if the scan fails.
               renderSection("list");
-              await bindAndRender(handle as FileSystemDirectoryHandle, true);
+              await bindAndRender(handle as FileSystemDirectoryHandle, true); // type-safety-ok: 'grant' state only reached when handle is non-null
             }
           })().catch((err) =>
             logError(err, { operation: "local-folder-grant" }),
@@ -164,7 +164,7 @@ export async function initLocalFolder(
         '<button id="local-folder-forget" class="local-folder-button" type="button">Forget folder</button>' +
         "</div>";
       section
-        .querySelector<HTMLButtonElement>("#local-folder-change")!
+        .querySelector<HTMLButtonElement>("#local-folder-change")! // type-safety-ok: innerHTML was just set with this id
         .addEventListener("click", () => {
           // Reuse the picker flow; section is already "list" so no nav
           // re-render is needed — bindAndRender re-renders the list rows.
@@ -173,7 +173,7 @@ export async function initLocalFolder(
           );
         });
       section
-        .querySelector<HTMLButtonElement>("#local-folder-forget")!
+        .querySelector<HTMLButtonElement>("#local-folder-forget")! // type-safety-ok: innerHTML was just set with this id
         .addEventListener("click", () => {
           void (async () => {
             await store.remove(PURPOSE);

--- a/print/src/style/theme.css
+++ b/print/src/style/theme.css
@@ -127,3 +127,8 @@
 .local-folder-button:hover {
   border-color: var(--fg);
 }
+
+.local-folder-controls {
+  display: flex;
+  gap: var(--space-1);
+}

--- a/print/test/local-folder-ui.test.ts
+++ b/print/test/local-folder-ui.test.ts
@@ -151,14 +151,16 @@ describe("initLocalFolder", () => {
       () => Promise.resolve(newHandle),
     );
 
-    changeBtn!.click(); // type-safety-ok: expect(changeBtn).not.toBeNull() asserts non-null above
+    try {
+      changeBtn!.click(); // type-safety-ok: expect(changeBtn).not.toBeNull() asserts non-null above
 
-    await vi.waitFor(() => {
-      expect(mockStore.put).toHaveBeenCalledWith("library-folder", newHandle);
-    });
-    expect(vi.mocked(createLocalSource)).toHaveBeenCalledWith(newHandle);
-
-    (window as unknown as Record<string, unknown>)["showDirectoryPicker"] = origPicker; // type-safety-ok: test mock restores non-standard window property
+      await vi.waitFor(() => {
+        expect(mockStore.put).toHaveBeenCalledWith("library-folder", newHandle);
+      });
+      expect(vi.mocked(createLocalSource)).toHaveBeenCalledWith(newHandle);
+    } finally {
+      (window as unknown as Record<string, unknown>)["showDirectoryPicker"] = origPicker; // type-safety-ok: test mock restores non-standard window property
+    }
   });
 
   it("forget-folder: removes the persisted handle and reverts nav to the open-folder button", async () => {

--- a/print/test/local-folder-ui.test.ts
+++ b/print/test/local-folder-ui.test.ts
@@ -145,20 +145,20 @@ describe("initLocalFolder", () => {
     const changeBtn = section.querySelector<HTMLButtonElement>("#local-folder-change");
     expect(changeBtn).not.toBeNull();
 
-    const newHandle = {} as FileSystemDirectoryHandle;
-    const origPicker = (window as unknown as Record<string, unknown>)["showDirectoryPicker"];
-    (window as unknown as Record<string, unknown>)["showDirectoryPicker"] = vi.fn(
+    const newHandle = {} as FileSystemDirectoryHandle; // type-safety-ok: test mock only needs the reference, not real FSA methods
+    const origPicker = (window as unknown as Record<string, unknown>)["showDirectoryPicker"]; // type-safety-ok: test mock accesses non-standard window property
+    (window as unknown as Record<string, unknown>)["showDirectoryPicker"] = vi.fn( // type-safety-ok: test mock sets non-standard window property
       () => Promise.resolve(newHandle),
     );
 
-    changeBtn!.click();
+    changeBtn!.click(); // type-safety-ok: expect(changeBtn).not.toBeNull() asserts non-null above
 
     await vi.waitFor(() => {
       expect(mockStore.put).toHaveBeenCalledWith("library-folder", newHandle);
     });
     expect(vi.mocked(createLocalSource)).toHaveBeenCalledWith(newHandle);
 
-    (window as unknown as Record<string, unknown>)["showDirectoryPicker"] = origPicker;
+    (window as unknown as Record<string, unknown>)["showDirectoryPicker"] = origPicker; // type-safety-ok: test mock restores non-standard window property
   });
 
   it("forget-folder: removes the persisted handle and reverts nav to the open-folder button", async () => {
@@ -169,7 +169,7 @@ describe("initLocalFolder", () => {
     const forgetBtn = section.querySelector<HTMLButtonElement>("#local-folder-forget");
     expect(forgetBtn).not.toBeNull();
 
-    forgetBtn!.click();
+    forgetBtn!.click(); // type-safety-ok: expect(forgetBtn).not.toBeNull() asserts non-null above
 
     // Wait for the terminal state: the async handler runs remove → resetLocalSource
     // → renderLocalIntoList → renderSection("open"). Poll for the nav revert.

--- a/print/test/local-folder-ui.test.ts
+++ b/print/test/local-folder-ui.test.ts
@@ -23,6 +23,7 @@ const { mockHandle, mockStore } = vi.hoisted(() => ({
     queryPermission: vi.fn(() => Promise.resolve("granted")),
     requestPermission: vi.fn(() => Promise.resolve("granted")),
     put: vi.fn(() => Promise.resolve()),
+    remove: vi.fn(() => Promise.resolve()),
   },
 }));
 vi.mock("@commons-systems/local-first/fsa-handle-store", () => ({
@@ -59,7 +60,7 @@ import {
   renderLocalIntoList,
   FOCUS_RESCAN_DEBOUNCE_MS,
 } from "../src/local-folder-ui.js";
-import { listLocal } from "../src/library.js";
+import { createLocalSource, listLocal } from "../src/library.js";
 import type { MediaItem } from "../src/types.js";
 
 describe("decideFolderUiState", () => {
@@ -134,6 +135,63 @@ describe("initLocalFolder", () => {
 
     // The click handler is async; wait for it to resolve before asserting.
     await vi.waitFor(() => expect(onSourceBound).toHaveBeenCalledTimes(1));
+  });
+
+  it("change-folder: re-picks via showDirectoryPicker and re-binds the source", async () => {
+    const section = document.createElement("span");
+    const container = document.createElement("div");
+    cleanup = await initLocalFolder(section, container, vi.fn());
+
+    const changeBtn = section.querySelector<HTMLButtonElement>("#local-folder-change");
+    expect(changeBtn).not.toBeNull();
+
+    const newHandle = {} as FileSystemDirectoryHandle;
+    const origPicker = (window as unknown as Record<string, unknown>)["showDirectoryPicker"];
+    (window as unknown as Record<string, unknown>)["showDirectoryPicker"] = vi.fn(
+      () => Promise.resolve(newHandle),
+    );
+
+    changeBtn!.click();
+
+    await vi.waitFor(() => {
+      expect(mockStore.put).toHaveBeenCalledWith("library-folder", newHandle);
+    });
+    expect(vi.mocked(createLocalSource)).toHaveBeenCalledWith(newHandle);
+
+    (window as unknown as Record<string, unknown>)["showDirectoryPicker"] = origPicker;
+  });
+
+  it("forget-folder: removes the persisted handle and reverts nav to the open-folder button", async () => {
+    const section = document.createElement("span");
+    const container = document.createElement("div");
+    cleanup = await initLocalFolder(section, container, vi.fn());
+
+    const forgetBtn = section.querySelector<HTMLButtonElement>("#local-folder-forget");
+    expect(forgetBtn).not.toBeNull();
+
+    forgetBtn!.click();
+
+    // Wait for the terminal state: the async handler runs remove → resetLocalSource
+    // → renderLocalIntoList → renderSection("open"). Poll for the nav revert.
+    await vi.waitFor(() => {
+      expect(section.querySelector("#local-folder-open")).not.toBeNull();
+    });
+    expect(mockStore.remove).toHaveBeenCalledWith("library-folder");
+    expect(section.querySelector("#local-folder-change")).toBeNull();
+    expect(section.querySelector("#local-folder-forget")).toBeNull();
+  });
+
+  it("stranded-recovery: change/forget controls render even when the initial scan fails", async () => {
+    vi.mocked(listLocal).mockRejectedValueOnce(new Error("scan failed"));
+
+    const section = document.createElement("span");
+    const container = document.createElement("div");
+    container.innerHTML = '<ul id="media-list"></ul>';
+
+    cleanup = await initLocalFolder(section, container, vi.fn());
+
+    expect(section.querySelector("#local-folder-change")).not.toBeNull();
+    expect(section.querySelector("#local-folder-forget")).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #2499

## Summary

Once a local folder was picked and granted in the print app, there was no way to
change or clear it: the granted (`"list"`) branch of `initLocalFolder` set the
nav slot to `section.innerHTML = ""`, so the folder button vanished. If the
folder's items also failed to render, the user was stranded with no button and
no items.

This adds a persistent affordance in the granted state — **Change folder** and
**Forget folder** controls — and unifies the nav-slot rendering so every
transition re-derives and re-renders coherently.

## What changed

- **`print/src/local-folder-ui.ts`** — refactored the one-shot state branch into
  a single re-invokable `renderSection(state)` that sets the nav markup **and**
  (re-)binds the click handlers in one place, so every transition re-attaches its
  listeners and never produces a dead button:
  - `"list"` state now renders a `.local-folder-controls` wrapper with
    `#local-folder-change` ("Change folder") and `#local-folder-forget` ("Forget
    folder"). The controls render **before** the folder scan binds, so they
    persist even when the scan fails — directly addressing the stranded case.
  - **Change** reuses the existing `openFolder()` picker flow, rebinding the
    source and re-rendering the list rows for the new folder.
  - **Forget** removes the persisted handle (`store.remove`), resets the local
    source, tears down the focus-rescan listener, clears the local rows, and
    reverts the nav to the initial "Open folder…" state.
  - Fixed a latent bug: `openFolder()` now re-renders the section after a fresh
    pick, so the controls appear in-session without a reload (open→list).

- **`print/src/style/theme.css`** — added a small `.local-folder-controls` flex
  wrapper to space the two list-state buttons.

- **`print/test/local-folder-ui.test.ts`** — added cases for the change-folder
  rebind, the forget-folder revert, and the stranded-recovery case (controls
  render even when the folder scan rejects). Added a `remove` spy to the hoisted
  `mockStore`.

`decideFolderUiState` and the three-state model are unchanged.

## Verification

- `npx vitest run --project print --root .` — 588 passed, 1 skipped.
- `run-typecheck.sh --app print` — passed.

Manual QA (left for the QA phase): pick + grant a folder, confirm the
Change/Forget controls appear; change to a different folder and confirm the list
re-renders; forget and confirm the items disappear and the nav reverts to "Open
folder…"; confirm keyboard access to each control; confirm the controls stay
visible even when a folder's scan fails.
