### PR TITLE
Make git identity configurable instead of hardcoded fallback

### DIFF
--- a/nix/home/git.nix
+++ b/nix/home/git.nix
@@ -1,9 +1,16 @@
 # Git Configuration Module
 #
-# This module configures Git settings through Home Manager.
-# Home Manager will merge these settings with your existing ~/.gitconfig,
-# so any settings you have defined manually will be preserved unless
-# explicitly overridden here.
+# This module writes settings into Home Manager's XDG git config
+# (~/.config/git/config). Git resolves identity by config precedence:
+# XDG config < ~/.gitconfig < command-line flags. Settings here land in the
+# XDG layer, so ~/.gitconfig values win over anything set by this module.
+#
+# Identity is set only when GIT_AUTHOR_NAME / GIT_AUTHOR_EMAIL are present at
+# eval time (requires `--impure`; builtins.getEnv returns "" under pure eval).
+# If neither env var is set, no [user] section is emitted here and git falls
+# through to whatever ~/.gitconfig provides. If ~/.gitconfig has no identity
+# either, git errors at commit time with "Author identity unknown" and directs
+# you to `git config --global user.name` / `user.email`.
 
 {
   config,
@@ -12,34 +19,29 @@
   ...
 }:
 
+let
+  envName = builtins.getEnv "GIT_AUTHOR_NAME";
+  envEmail = builtins.getEnv "GIT_AUTHOR_EMAIL";
+in
+
 {
   programs.git = {
     enable = true;
 
-    # User identity - automatically detected from environment
-    # These values are read from GIT_AUTHOR_NAME and GIT_AUTHOR_EMAIL environment variables.
-    # If not set, sensible defaults are used.
+    # User identity — read from environment at eval time (requires --impure).
+    # If an env var is unset, that attribute is omitted and git's own config
+    # precedence applies (falls through to ~/.gitconfig, then errors clearly).
     #
     # To customize, either:
-    #   1. Export environment variables: export GIT_AUTHOR_NAME="Your Name"
+    #   1. Export environment variables before running home-manager switch:
+    #        export GIT_AUTHOR_NAME="Your Name"
+    #        export GIT_AUTHOR_EMAIL="you@example.com"
     #   2. Override in Home Manager: programs.git.settings.user.name = lib.mkForce "Your Name";
-    #   3. Keep existing ~/.gitconfig values (Home Manager merges, not replaces)
+    #   3. Set values directly in ~/.gitconfig (takes precedence over this XDG config)
     settings = {
-      user = {
-        name = lib.mkDefault (
-          let
-            envName = builtins.getEnv "GIT_AUTHOR_NAME";
-          in
-          if envName != "" then envName else "Nathan Buesgens"
-        );
-
-        email = lib.mkDefault (
-          let
-            envEmail = builtins.getEnv "GIT_AUTHOR_EMAIL";
-          in
-          if envEmail != "" then envEmail else "nathan@natb1.com"
-        );
-      };
+      user =
+        lib.optionalAttrs (envName != "") { name = lib.mkDefault envName; }
+        // lib.optionalAttrs (envEmail != "") { email = lib.mkDefault envEmail; };
 
       # Core settings
       pull = {

--- a/nix/home/git.nix
+++ b/nix/home/git.nix
@@ -33,9 +33,10 @@ in
     # precedence applies (falls through to ~/.gitconfig, then errors clearly).
     #
     # To customize, either:
-    #   1. Export environment variables before running home-manager switch:
+    #   1. Export environment variables and run home-manager switch with --impure:
     #        export GIT_AUTHOR_NAME="Your Name"
     #        export GIT_AUTHOR_EMAIL="you@example.com"
+    #        home-manager switch --flake .#default --impure
     #   2. Override in Home Manager: programs.git.settings.user.name = lib.mkForce "Your Name";
     #   3. Set values directly in ~/.gitconfig (takes precedence over this XDG config)
     settings = {


### PR DESCRIPTION
Closes #61

## Summary

`nix/home/git.nix` baked a personal identity (`Nathan Buesgens` /
`nathan@natb1.com`) as the fallback whenever `GIT_AUTHOR_NAME` /
`GIT_AUTHOR_EMAIL` were unset. Anyone who cloned this config and ran
`home-manager switch` without those env vars would silently commit as Nathan
Buesgens — a silent-incorrect-behavior failure.

This change removes the hardcoded literals and makes the identity configurable:

- Hoists `envName` / `envEmail` (`builtins.getEnv`) into a module-level `let`.
- Builds `settings.user` conditionally with `lib.optionalAttrs`, so each attr is
  included only when its env var is set. When both are unset, `user = {}` and no
  `[user]` section is emitted into the XDG config.
- Rewrites the misleading header and identity comments to describe the real
  behavior accurately.

## Behavior after this change

- **Env set** (`--impure` eval): identity comes from `GIT_AUTHOR_NAME` /
  `GIT_AUTHOR_EMAIL`.
- **Env unset, `~/.gitconfig` present**: no `[user]` is written to the XDG layer,
  so git's config precedence (XDG < `~/.gitconfig` < CLI) lets the operator's own
  `~/.gitconfig` identity win.
- **Nothing set anywhere**: git surfaces its native clear error at commit time —
  `Author identity unknown` / `*** Please tell me who you are.` — naming the
  exact `git config --global user.name` / `user.email` commands to run. The same
  guidance is duplicated in the module's header comment for in-repo
  discoverability.

This follows `.claude/rules/code-style.md` — clear errors over defensive
fallbacks. There is deliberately no eval-time `throw`: Nix evaluation cannot see
the runtime `~/.gitconfig`, so a throw would wrongly fire in the env-unset /
`~/.gitconfig`-present case.

## Verification

The repo has no nix CI, so the deterministic auto-runnable check asserts the
personal-identity literals are gone:

```
! grep -E "Nathan Buesgens|nathan@natb1.com" nix/home/git.nix
```

Runtime behavior (`--impure` eval, `home-manager switch`, commit-time error) is
verified by inspection per the criteria above.
