### PR TITLE
Rename user-facing "apps" product terminology to "projects"

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ run-all-cleanup-preview.sh <pr-number>
 
 ## Where to go next
 
-- **Landing page** — [commons.systems](https://commons.systems): the deployed apps and project overview.
+- **Landing page** — [commons.systems](https://commons.systems): the project showcase and overview.
 - **Design system** — [packages/ds](packages/ds/README.md): tokens, components, and the visual language.
 - **License** — CC-BY-SA; forking is encouraged.
 

--- a/landing/e2e/app-showcase-seo.spec.ts
+++ b/landing/e2e/app-showcase-seo.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@commons-systems/config/playwright-test";
 
-const APPS = [
+const PROJECTS = [
   {
     name: "Office-hours",
     url: "https://office-hours.commons.systems",
@@ -62,9 +62,9 @@ test.describe("SEO: SoftwareApplication JSON-LD", () => {
   }) => {
     await page.goto("/");
     const apps = await getSoftwareApplicationJsonLd(page);
-    expect(apps).toHaveLength(APPS.length);
+    expect(apps).toHaveLength(PROJECTS.length);
 
-    for (const expected of APPS) {
+    for (const expected of PROJECTS) {
       const match = apps.find((a) => a.url === expected.url);
       expect(match, `JSON-LD for ${expected.url}`).toBeTruthy();
       expect(match!.name).toBe(expected.name);

--- a/landing/e2e/hero.spec.ts
+++ b/landing/e2e/hero.spec.ts
@@ -67,6 +67,6 @@ test.describe("hero band", () => {
     await expect(page.locator(".landing-hero-band")).toContainText(
       "Build with commons.systems. Learn to run without.",
     );
-    await expect(page.locator("a.app-card")).toHaveCount(4);
+    await expect(page.locator("a.project-card")).toHaveCount(4);
   });
 });

--- a/landing/e2e/project-showcase.spec.ts
+++ b/landing/e2e/project-showcase.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@commons-systems/config/playwright-test";
 
-const APP_HREFS = [
+const PROJECT_HREFS = [
   "https://office-hours.commons.systems",
   "https://budget.commons.systems",
   "https://print.commons.systems",
@@ -19,7 +19,7 @@ test.describe("project showcase", () => {
     );
   });
 
-  test("three project cards render in PROJECTS order with correct hrefs", async ({
+  test("three project cards render in PROJECT_HREFS order with correct hrefs", async ({
     page,
   }) => {
     await page.goto("/");
@@ -27,8 +27,8 @@ test.describe("project showcase", () => {
     const cards = page.locator(".landing-hero-grid a.project-card");
     await expect(cards).toHaveCount(3);
 
-    for (let i = 0; i < APP_HREFS.length; i++) {
-      await expect(cards.nth(i)).toHaveAttribute("href", APP_HREFS[i]);
+    for (let i = 0; i < PROJECT_HREFS.length; i++) {
+      await expect(cards.nth(i)).toHaveAttribute("href", PROJECT_HREFS[i]);
     }
   });
 

--- a/landing/e2e/project-showcase.spec.ts
+++ b/landing/e2e/project-showcase.spec.ts
@@ -6,7 +6,7 @@ const APP_HREFS = [
   "https://print.commons.systems",
 ];
 
-test.describe("app showcase", () => {
+test.describe("project showcase", () => {
   test("interstitial band shows headline and subline", async ({ page }) => {
     await page.goto("/");
 
@@ -19,12 +19,12 @@ test.describe("app showcase", () => {
     );
   });
 
-  test("three app cards render in APPS order with correct hrefs", async ({
+  test("three project cards render in PROJECTS order with correct hrefs", async ({
     page,
   }) => {
     await page.goto("/");
 
-    const cards = page.locator(".landing-hero-grid a.app-card");
+    const cards = page.locator(".landing-hero-grid a.project-card");
     await expect(cards).toHaveCount(3);
 
     for (let i = 0; i < APP_HREFS.length; i++) {
@@ -37,7 +37,7 @@ test.describe("app showcase", () => {
   }) => {
     await page.goto("/");
 
-    const cards = page.locator(".landing-hero-grid a.app-card");
+    const cards = page.locator(".landing-hero-grid a.project-card");
     // Auto-wait for the client-mounted (React createRoot, deferred) cards
     // before the non-waiting .count() read — same reason as the focus test.
     await expect(cards).toHaveCount(3);
@@ -59,12 +59,12 @@ test.describe("app showcase", () => {
     // synchronous focus check below — mirrors the auto-waiting locators the
     // sibling tests use, and keeps the test honest against the non-prerendered
     // dev server (on a prerendered build the cards are already present at load).
-    await page.waitForSelector(".landing-hero-grid a.app-card");
+    await page.waitForSelector(".landing-hero-grid a.project-card");
 
     for (let i = 0; i < 3; i++) {
       const isActive = await page.evaluate((idx) => {
         const cards = document.querySelectorAll<HTMLAnchorElement>(
-          ".landing-hero-grid a.app-card",
+          ".landing-hero-grid a.project-card",
         );
         const target = cards[idx];
         if (!target) return false;
@@ -83,12 +83,12 @@ test.describe("app showcase", () => {
       // Wait for the client-mounted (React createRoot, deferred) showcase cards
       // before the synchronous geometry read below — same reason as the
       // keyboard-focus test above.
-      await page.waitForSelector(".landing-hero-grid a.app-card");
+      await page.waitForSelector(".landing-hero-grid a.project-card");
 
       const xs = await page.evaluate(() => {
         const cards = Array.from(
           document.querySelectorAll<HTMLAnchorElement>(
-            ".landing-hero-grid a.app-card",
+            ".landing-hero-grid a.project-card",
           ),
         );
         return cards.map((c) => Math.round(c.getBoundingClientRect().x));
@@ -105,7 +105,7 @@ test.describe("app showcase", () => {
   }) => {
     await page.goto("/");
 
-    await expect(page.locator("a.app-card")).toHaveCount(4);
+    await expect(page.locator("a.project-card")).toHaveCount(4);
 
     const scripts = await page.locator('script[type="application/ld+json"]').allTextContents();
     const softwareAppCount = scripts.filter(t => JSON.parse(t)["@type"] === "SoftwareApplication").length;
@@ -117,25 +117,25 @@ test.describe("app showcase", () => {
   }) => {
     await page.goto("/");
 
-    await page.waitForSelector("details.app-showcase-overflow");
+    await page.waitForSelector("details.project-showcase-overflow");
 
-    const details = page.locator("details.app-showcase-overflow");
+    const details = page.locator("details.project-showcase-overflow");
     await expect(details).not.toHaveAttribute("open", /.*/);
 
     const overflowCard = page.locator(
-      '.app-showcase-overflow a.app-card[href="https://audio.commons.systems"]',
+      '.project-showcase-overflow a.project-card[href="https://audio.commons.systems"]',
     );
     await expect(overflowCard).toBeHidden();
 
-    await page.locator(".app-showcase-overflow summary").click();
+    await page.locator(".project-showcase-overflow summary").click();
 
     await expect(overflowCard).toBeVisible();
 
-    await expect(page.locator(".app-showcase-overflow summary")).toHaveText("more…");
+    await expect(page.locator(".project-showcase-overflow summary")).toHaveText("more…");
 
     const overflowAfterGrid = await page.evaluate(() => {
       const grid = document.querySelector(".landing-hero-grid");
-      const overflow = document.querySelector("details.app-showcase-overflow");
+      const overflow = document.querySelector("details.project-showcase-overflow");
       if (!grid || !overflow) return false;
       return (
         grid.compareDocumentPosition(overflow) & Node.DOCUMENT_POSITION_FOLLOWING

--- a/landing/public/screenshots/README.md
+++ b/landing/public/screenshots/README.md
@@ -1,7 +1,7 @@
-# App showcase screenshots
+# Project showcase screenshots
 
-These screenshots are captured ad-hoc from the production apps and committed as
-static assets. The landing page references them via `APPS` in
+These screenshots are captured ad-hoc from the deployed projects and committed as
+static assets. The landing page references them via `PROJECTS` in
 `landing/src/site-config.ts`.
 
 ## Regenerating
@@ -13,7 +13,7 @@ capture all three at a consistent 1200×800 (3:2) viewport:
 npx tsx landing/scripts/capture-screenshots.ts
 ```
 
-The script navigates each production URL, waits for `domcontentloaded` plus a 2.5 s timeout, scrolls 540 px past the app's own hero band to frame the actual UI — adjust `scrollY` in `capture-screenshots.ts` if an app's hero height changes — waits 500 ms for the scroll to settle, and writes each file into
+The script navigates each production URL, waits for `domcontentloaded` plus a 2.5 s timeout, scrolls 540 px past the project's own hero band to frame the actual UI — adjust `scrollY` in `capture-screenshots.ts` if a project's hero height changes — waits 500 ms for the scroll to settle, and writes each file into
 this directory.
 
 ## Sources and framing
@@ -31,7 +31,7 @@ top of each capture is what visitors see.
 
 ## When to regenerate
 
-- The target app's visible UI has changed in a way the current card no longer
+- The target project's visible UI has changed in a way the current card no longer
   represents (new nav, renamed sections, layout overhaul).
 - Seed data shown in the capture has drifted from what production serves.
 

--- a/landing/scripts/prerender.tsx
+++ b/landing/scripts/prerender.tsx
@@ -10,12 +10,12 @@ import appSeed from "../seeds/firestore.js";
 import { BLOG_ROLL_ENTRIES } from "../src/blog-roll/config.js";
 import {
   ABOUT_PAGE_META,
-  APPS,
+  PROJECTS,
   AUTHOR,
   INFO_PANEL_LINK_SECTIONS,
   NAV_LINKS,
   ORGANIZATION,
-  OVERFLOW_APPS,
+  OVERFLOW_PROJECTS,
   PERSON,
   REL_ME,
   SITE_DEFAULTS,
@@ -75,8 +75,8 @@ try {
     organization: ORGANIZATION,
     author: AUTHOR,
     relMe: REL_ME,
-    softwareApplications: [...APPS, ...OVERFLOW_APPS],
-    homeExtraHtml: renderShowcase(APPS, OVERFLOW_APPS),
+    softwareApplications: [...PROJECTS, ...OVERFLOW_PROJECTS],
+    homeExtraHtml: renderShowcase(PROJECTS, OVERFLOW_PROJECTS),
     showHomeLink: false,
   });
 } catch (err) {

--- a/landing/src/components/Showcase.tsx
+++ b/landing/src/components/Showcase.tsx
@@ -1,23 +1,23 @@
 import type { AnchorHTMLAttributes } from "react";
 import { Card } from "@commons-systems/ds";
-import type { AppCard } from "../site-config.ts";
+import type { ProjectCard } from "../site-config.ts";
 
-function ShowcaseCard({ app }: { app: AppCard }) {
+function ShowcaseCard({ project }: { project: ProjectCard }) {
   // href is an anchor attribute; Card's props extend HTMLAttributes<HTMLElement>
   // (no href), so type it explicitly and spread through Card's ...rest.
-  const anchorProps: AnchorHTMLAttributes<HTMLAnchorElement> = { href: app.url };
+  const anchorProps: AnchorHTMLAttributes<HTMLAnchorElement> = { href: project.url };
   return (
-    <Card as="a" interactive className="app-card" {...anchorProps}>
+    <Card as="a" interactive className="project-card" {...anchorProps}>
       <img
-        className="app-card-screenshot"
+        className="project-card-screenshot"
         loading="lazy"
-        src={app.screenshot}
-        alt={app.screenshotAlt}
+        src={project.screenshot}
+        alt={project.screenshotAlt}
         width={1200}
         height={800}
       />
-      <span className="app-name">{app.name}</span>
-      <p className="app-problem">{app.problem}</p>
+      <span className="project-name">{project.name}</span>
+      <p className="project-problem">{project.problem}</p>
     </Card>
   );
 }
@@ -30,11 +30,11 @@ function ShowcaseCard({ app }: { app: AppCard }) {
  * wrapper so the client mount does not nest a second `.landing-hero` section.
  */
 export function ShowcaseContent({
-  apps,
+  projects,
   overflow = [],
 }: {
-  apps: AppCard[];
-  overflow?: AppCard[];
+  projects: ProjectCard[];
+  overflow?: ProjectCard[];
 }) {
   return (
     <>
@@ -52,16 +52,16 @@ export function ShowcaseContent({
         </p>
       </div>
       <div className="landing-hero-grid">
-        {apps.map((app) => (
-          <ShowcaseCard key={app.url} app={app} />
+        {projects.map((project) => (
+          <ShowcaseCard key={project.url} project={project} />
         ))}
       </div>
       {overflow.length > 0 && (
-        <details className="app-showcase-overflow">
+        <details className="project-showcase-overflow">
           <summary>more…</summary>
-          <div className="app-showcase-overflow-cards">
-            {overflow.map((app) => (
-              <ShowcaseCard key={app.url} app={app} />
+          <div className="project-showcase-overflow-cards">
+            {overflow.map((project) => (
+              <ShowcaseCard key={project.url} project={project} />
             ))}
           </div>
         </details>
@@ -77,15 +77,15 @@ export function ShowcaseContent({
  * it mounts ShowcaseContent into the existing placeholder node instead.
  */
 export function Showcase({
-  apps,
+  projects,
   overflow = [],
 }: {
-  apps: AppCard[];
-  overflow?: AppCard[];
+  projects: ProjectCard[];
+  overflow?: ProjectCard[];
 }) {
   return (
-    <section className="landing-hero app-showcase" aria-label="Featured apps">
-      <ShowcaseContent apps={apps} overflow={overflow} />
+    <section className="landing-hero project-showcase" aria-label="Featured projects">
+      <ShowcaseContent projects={projects} overflow={overflow} />
     </section>
   );
 }

--- a/landing/src/components/Showcase.tsx
+++ b/landing/src/components/Showcase.tsx
@@ -23,7 +23,7 @@ function ShowcaseCard({ project }: { project: ProjectCard }) {
 }
 
 /**
- * The hero band + app grid. Rendered as the *children* of the existing
+ * The hero band + project grid. Rendered as the *children* of the existing
  * `.landing-hero` section — both at build time (inside the section wrapper that
  * `Showcase` adds for the prerender seam) and on the client (mounted directly
  * into the `.landing-hero` placeholder node). Kept separate from the section

--- a/landing/src/main.tsx
+++ b/landing/src/main.tsx
@@ -14,7 +14,7 @@ import buildTimeContent from "virtual:blog-post-content";
 import buildTimeMetadata from "virtual:blog-post-metadata";
 
 import { createRoot, type Root } from "react-dom/client";
-import { ABOUT_PAGE_META, APPS, INFO_PANEL_LINK_SECTIONS, NAV_LINKS, OVERFLOW_APPS, SITE_DEFAULTS, SITE_URL } from "./site-config.js";
+import { ABOUT_PAGE_META, PROJECTS, INFO_PANEL_LINK_SECTIONS, NAV_LINKS, OVERFLOW_PROJECTS, SITE_DEFAULTS, SITE_URL } from "./site-config.js";
 import { ShowcaseContent } from "./components/Showcase.js";
 import { About, AboutPanel } from "./pages/About.js";
 import { BLOG_ROLL_ENTRIES, createStrategies } from "./blog-roll/config.js";
@@ -51,9 +51,9 @@ function mountHero(hero: HTMLElement): void {
     heroRoot = createRoot(hero);
     heroNode = hero;
   }
-  hero.classList.add("app-showcase");
-  hero.setAttribute("aria-label", "Featured apps");
-  heroRoot!.render(<ShowcaseContent apps={APPS} overflow={OVERFLOW_APPS} />); // type-safety-ok: heroRoot is always set above — either by the if block or from a prior call
+  hero.classList.add("project-showcase");
+  hero.setAttribute("aria-label", "Featured projects");
+  heroRoot!.render(<ShowcaseContent projects={PROJECTS} overflow={OVERFLOW_PROJECTS} />); // type-safety-ok: heroRoot is always set above — either by the if block or from a prior call
 }
 
 createBlogApp({

--- a/landing/src/showcase-render.tsx
+++ b/landing/src/showcase-render.tsx
@@ -1,12 +1,12 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { Showcase } from "./components/Showcase.tsx";
-import type { AppCard } from "./site-config.ts";
+import type { ProjectCard } from "./site-config.ts";
 
 /**
  * Static markup for the prerender `homeExtraHtml` seam (blog's injectHomeExtra
  * replaces the `<section class="landing-hero">` placeholder with this string).
  * The client mount in main.tsx renders ShowcaseContent directly instead.
  */
-export function renderShowcase(primary: AppCard[], overflow: AppCard[] = []): string {
-  return renderToStaticMarkup(<Showcase apps={primary} overflow={overflow} />);
+export function renderShowcase(primary: ProjectCard[], overflow: ProjectCard[] = []): string {
+  return renderToStaticMarkup(<Showcase projects={primary} overflow={overflow} />);
 }

--- a/landing/src/site-config.ts
+++ b/landing/src/site-config.ts
@@ -55,16 +55,16 @@ export const INFO_PANEL_LINK_SECTIONS: LinkSection[] = [
 ];
 
 /** Extends SoftwareApplication for JSON-LD reuse; overrides `description` to required and adds visual card fields. */
-export interface AppCard extends SoftwareApplication {
+export interface ProjectCard extends SoftwareApplication {
   description: string;
   screenshot: string;
   screenshotAlt: string;
   problem: string;
 }
 
-// App showcase source of truth. Screenshots are captured ad-hoc from production
-// subdomains at a 1200×800 viewport; .app-card-screenshot enforces the ratio at render time with object-fit: cover (see public/screenshots/README.md).
-export const APPS: AppCard[] = [
+// Project showcase source of truth. Screenshots are captured ad-hoc from production
+// subdomains at a 1200×800 viewport; .project-card-screenshot enforces the ratio at render time with object-fit: cover (see public/screenshots/README.md).
+export const PROJECTS: ProjectCard[] = [
   {
     name: "Office-hours",
     url: "https://office-hours.commons.systems",
@@ -97,7 +97,7 @@ export const APPS: AppCard[] = [
   },
 ];
 
-export const OVERFLOW_APPS: AppCard[] = [
+export const OVERFLOW_PROJECTS: ProjectCard[] = [
   {
     name: "Audio",
     url: "https://audio.commons.systems",

--- a/landing/src/style/theme.css
+++ b/landing/src/style/theme.css
@@ -138,7 +138,7 @@ body[data-route="other"] .landing-hero {
   gap: var(--space-4);
 }
 
-.app-card {
+.project-card {
   display: flex;
   flex-direction: column;
   border: var(--border-width) solid var(--border);
@@ -147,13 +147,13 @@ body[data-route="other"] .landing-hero {
   overflow: hidden;
   transition: border-color var(--duration-fast) var(--ease), outline-color var(--duration-fast) var(--ease);
 }
-.app-card:hover,
-.app-card:focus-visible {
+.project-card:hover,
+.project-card:focus-visible {
   border-color: var(--accent);
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
-.app-card-screenshot {
+.project-card-screenshot {
   display: block;
   width: 100%;
   height: auto;
@@ -162,13 +162,13 @@ body[data-route="other"] .landing-hero {
   object-position: top left;
   border-block-end: var(--border-width) solid var(--border);
 }
-.app-name {
+.project-name {
   padding: var(--space-3) var(--space-4) var(--space-1);
   font-weight: var(--weight-bold);
   text-transform: uppercase;
   letter-spacing: var(--tracking-heading);
 }
-.app-problem {
+.project-problem {
   margin: 0;
   padding: 0 var(--space-4) var(--space-4);
   color: var(--muted);
@@ -176,7 +176,7 @@ body[data-route="other"] .landing-hero {
   line-height: 1.4;
 }
 
-.app-showcase-overflow {
+.project-showcase-overflow {
   margin-block: var(--space-4) 0;
   background: none;
   border: 0;
@@ -184,7 +184,7 @@ body[data-route="other"] .landing-hero {
   border-radius: 0;
   overflow: visible;
 }
-.app-showcase-overflow summary {
+.project-showcase-overflow summary {
   cursor: pointer;
   padding: var(--space-2) var(--space-1);
   color: var(--muted);
@@ -194,14 +194,14 @@ body[data-route="other"] .landing-hero {
   margin-inline: 0;
   margin-block: 0;
 }
-.app-showcase-overflow summary:hover {
+.project-showcase-overflow summary:hover {
   color: var(--accent);
 }
-.app-showcase-overflow summary:focus-visible {
+.project-showcase-overflow summary:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
-.app-showcase-overflow-cards {
+.project-showcase-overflow-cards {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: var(--space-4);
@@ -210,7 +210,7 @@ body[data-route="other"] .landing-hero {
 
 @media (max-width: 768px) {
   .landing-hero-grid { grid-template-columns: 1fr; }
-  .app-showcase-overflow-cards { grid-template-columns: 1fr; }
+  .project-showcase-overflow-cards { grid-template-columns: 1fr; }
 }
 
 .profile-card {

--- a/landing/test/projects-config.test.ts
+++ b/landing/test/projects-config.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { APPS, OVERFLOW_APPS } from "../src/site-config";
+import { PROJECTS, OVERFLOW_PROJECTS } from "../src/site-config";
 
-describe("APPS", () => {
+describe("PROJECTS", () => {
   it("has exactly 3 primary entries with names Office-hours, Budget, Print", () => {
-    expect(APPS).toHaveLength(3);
-    expect(APPS.map((a) => a.name)).toEqual(["Office-hours", "Budget", "Print"]);
+    expect(PROJECTS).toHaveLength(3);
+    expect(PROJECTS.map((a) => a.name)).toEqual(["Office-hours", "Budget", "Print"]);
   });
 
   it("all urls are on commons.systems subdomains", () => {
@@ -13,14 +13,14 @@ describe("APPS", () => {
       "https://budget.commons.systems",
       "https://print.commons.systems",
     ];
-    expect(APPS.map((a) => a.url)).toEqual(expected);
-    for (const app of APPS) {
+    expect(PROJECTS.map((a) => a.url)).toEqual(expected);
+    for (const app of PROJECTS) {
       expect(app.url).toMatch(/^https:\/\/[a-z]([a-z0-9-]*[a-z0-9])?\.commons\.systems/);
     }
   });
 
   it("all entries have non-empty problem, screenshotAlt, and screenshot starting with /screenshots/", () => {
-    for (const app of APPS) {
+    for (const app of PROJECTS) {
       expect(app.problem.length).toBeGreaterThan(0);
       expect(app.screenshotAlt.length).toBeGreaterThan(0);
       expect(app.screenshot.startsWith("/screenshots/")).toBe(true);
@@ -28,21 +28,21 @@ describe("APPS", () => {
   });
 
   it("all screenshots end with .png", () => {
-    for (const app of APPS) {
+    for (const app of PROJECTS) {
       expect(app.screenshot.endsWith(".png")).toBe(true);
     }
   });
 });
 
-describe("OVERFLOW_APPS", () => {
+describe("OVERFLOW_PROJECTS", () => {
   it("has exactly 1 entry: Audio", () => {
-    expect(OVERFLOW_APPS).toHaveLength(1);
-    expect(OVERFLOW_APPS[0].name).toBe("Audio");
-    expect(OVERFLOW_APPS[0].url).toBe("https://audio.commons.systems");
+    expect(OVERFLOW_PROJECTS).toHaveLength(1);
+    expect(OVERFLOW_PROJECTS[0].name).toBe("Audio");
+    expect(OVERFLOW_PROJECTS[0].url).toBe("https://audio.commons.systems");
   });
 
-  it("OVERFLOW_APPS entries satisfy the same invariants", () => {
-    for (const app of OVERFLOW_APPS) {
+  it("OVERFLOW_PROJECTS entries satisfy the same invariants", () => {
+    for (const app of OVERFLOW_PROJECTS) {
       expect(app.url).toMatch(/^https:\/\/[a-z]([a-z0-9-]*[a-z0-9])?\.commons\.systems/);
       expect(app.problem.length).toBeGreaterThan(0);
       expect(app.screenshotAlt.length).toBeGreaterThan(0);

--- a/landing/test/showcase-render.test.ts
+++ b/landing/test/showcase-render.test.ts
@@ -31,7 +31,7 @@ describe("renderShowcase", () => {
     expect(html).toContain("Build with commons.systems. Learn to run without.");
   });
 
-  it("contains exactly one project-card anchor per app", () => {
+  it("contains exactly one project-card anchor per project", () => {
     const html = renderShowcase(PROJECTS);
     // The ds Card composes its own classes ahead of the consumer's, so each card
     // anchor is `<a class="cs-card cs-card--interactive project-card" ...>`. Match the
@@ -42,7 +42,7 @@ describe("renderShowcase", () => {
     expect(matches!.length).toBe(PROJECTS.length); // type-safety-ok: guarded by expect(matches).not.toBeNull() above
   });
 
-  it("each anchor href matches the app url", () => {
+  it("each anchor href matches the project url", () => {
     const html = renderShowcase(PROJECTS);
     for (const app of PROJECTS) {
       expect(html).toContain(`href="${app.url}"`);
@@ -62,7 +62,7 @@ describe("renderShowcase", () => {
     }
   });
 
-  it("HTML-escapes special characters in app.problem", () => {
+  it("HTML-escapes special characters in project.problem", () => {
     const apps: ProjectCard[] = [
       {
         ...PROJECTS[0],
@@ -74,7 +74,7 @@ describe("renderShowcase", () => {
     expect(html).toContain("&lt;script&gt;");
   });
 
-  it("HTML-escapes special characters in app.url", () => {
+  it("HTML-escapes special characters in project.url", () => {
     const apps: ProjectCard[] = [
       {
         ...PROJECTS[0],
@@ -117,7 +117,7 @@ describe("renderShowcase", () => {
       expect(html).toContain("<summary");
     });
 
-    it("renders one <a class=\"project-card\" per primary and overflow app", () => {
+    it("renders one <a class=\"project-card\" per primary and overflow project", () => {
       const html = renderShowcase(PROJECTS, OVERFLOW);
       const matches = html.match(/<a [^>]*class="[^"]*\bproject-card"/g);
       expect(matches).not.toBeNull();

--- a/landing/test/showcase-render.test.ts
+++ b/landing/test/showcase-render.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { renderShowcase } from "../src/showcase-render";
-import type { AppCard } from "../src/site-config";
+import type { ProjectCard } from "../src/site-config";
 
-const APPS: AppCard[] = [
+const PROJECTS: ProjectCard[] = [
   {
     name: "Alpha",
     url: "https://alpha.example.com",
@@ -27,31 +27,31 @@ const APPS: AppCard[] = [
 
 describe("renderShowcase", () => {
   it("contains the hero band headline", () => {
-    const html = renderShowcase(APPS);
+    const html = renderShowcase(PROJECTS);
     expect(html).toContain("Build with commons.systems. Learn to run without.");
   });
 
-  it("contains exactly one app-card anchor per app", () => {
-    const html = renderShowcase(APPS);
+  it("contains exactly one project-card anchor per app", () => {
+    const html = renderShowcase(PROJECTS);
     // The ds Card composes its own classes ahead of the consumer's, so each card
-    // anchor is `<a class="cs-card cs-card--interactive app-card" ...>`. Match the
-    // app-card token at the end of an anchor's class list (the closing quote
-    // excludes the `app-card-screenshot` img, which also starts with app-card).
-    const matches = html.match(/<a [^>]*class="[^"]*\bapp-card"/g);
+    // anchor is `<a class="cs-card cs-card--interactive project-card" ...>`. Match the
+    // project-card token at the end of an anchor's class list (the closing quote
+    // excludes the `project-card-screenshot` img, which also starts with project-card).
+    const matches = html.match(/<a [^>]*class="[^"]*\bproject-card"/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(APPS.length);
+    expect(matches!.length).toBe(PROJECTS.length);
   });
 
   it("each anchor href matches the app url", () => {
-    const html = renderShowcase(APPS);
-    for (const app of APPS) {
+    const html = renderShowcase(PROJECTS);
+    for (const app of PROJECTS) {
       expect(html).toContain(`href="${app.url}"`);
     }
   });
 
   it("each image has loading=\"lazy\" and correct src and alt", () => {
-    const html = renderShowcase(APPS);
-    for (const app of APPS) {
+    const html = renderShowcase(PROJECTS);
+    for (const app of PROJECTS) {
       const imgRegex = new RegExp(
         `<img[^>]*loading="lazy"[^>]*src="${app.screenshot}"[^>]*alt="${app.screenshotAlt}"`,
       );
@@ -63,9 +63,9 @@ describe("renderShowcase", () => {
   });
 
   it("HTML-escapes special characters in app.problem", () => {
-    const apps: AppCard[] = [
+    const apps: ProjectCard[] = [
       {
-        ...APPS[0],
+        ...PROJECTS[0],
         problem: "<script>alert('xss')</script>",
       },
     ];
@@ -75,9 +75,9 @@ describe("renderShowcase", () => {
   });
 
   it("HTML-escapes special characters in app.url", () => {
-    const apps: AppCard[] = [
+    const apps: ProjectCard[] = [
       {
-        ...APPS[0],
+        ...PROJECTS[0],
         url: 'https://example.com/"onmouseover="alert(1)',
       },
     ];
@@ -87,7 +87,7 @@ describe("renderShowcase", () => {
   });
 
   describe("overflow tier", () => {
-    const OVERFLOW: AppCard[] = [
+    const OVERFLOW: ProjectCard[] = [
       {
         name: "Gamma",
         url: "https://gamma.example.com",
@@ -101,42 +101,42 @@ describe("renderShowcase", () => {
     ];
 
     it("includes the overflow card href in the SSR string (crawlable)", () => {
-      const html = renderShowcase(APPS, OVERFLOW);
+      const html = renderShowcase(PROJECTS, OVERFLOW);
       expect(html).toContain('href="https://gamma.example.com"');
     });
 
     it("renders a <details> that is collapsed by default", () => {
-      const html = renderShowcase(APPS, OVERFLOW);
+      const html = renderShowcase(PROJECTS, OVERFLOW);
       expect(html).toContain("<details");
       expect(html).not.toContain("<details open");
       expect(html).not.toMatch(/<details[^>]*\sopen/);
     });
 
     it("renders a <summary>", () => {
-      const html = renderShowcase(APPS, OVERFLOW);
+      const html = renderShowcase(PROJECTS, OVERFLOW);
       expect(html).toContain("<summary");
     });
 
-    it("renders one <a class=\"app-card\" per primary and overflow app", () => {
-      const html = renderShowcase(APPS, OVERFLOW);
-      const matches = html.match(/<a [^>]*class="[^"]*\bapp-card"/g);
+    it("renders one <a class=\"project-card\" per primary and overflow app", () => {
+      const html = renderShowcase(PROJECTS, OVERFLOW);
+      const matches = html.match(/<a [^>]*class="[^"]*\bproject-card"/g);
       expect(matches).not.toBeNull();
-      expect(matches).toHaveLength(APPS.length + OVERFLOW.length);
+      expect(matches).toHaveLength(PROJECTS.length + OVERFLOW.length);
     });
 
     it("renders no <details> when overflow is empty", () => {
-      const html = renderShowcase(APPS);
+      const html = renderShowcase(PROJECTS);
       expect(html).not.toContain("<details");
     });
 
-    it("summary text is 'more…' and not 'More apps'", () => {
-      const html = renderShowcase(APPS, OVERFLOW);
+    it("summary text is 'more…' and not 'More projects'", () => {
+      const html = renderShowcase(PROJECTS, OVERFLOW);
       expect(html).toContain("more…");
-      expect(html).not.toContain("More apps");
+      expect(html).not.toContain("More projects");
     });
 
     it("<details> overflow block appears after .landing-hero-grid in SSR output", () => {
-      const html = renderShowcase(APPS, OVERFLOW);
+      const html = renderShowcase(PROJECTS, OVERFLOW);
       const gridIndex = html.indexOf("landing-hero-grid");
       const detailsIndex = html.indexOf("<details");
       expect(detailsIndex).toBeGreaterThan(gridIndex);
@@ -145,19 +145,19 @@ describe("renderShowcase", () => {
 
   describe("band CTAs", () => {
     it("renders Learn More link to /about", () => {
-      const html = renderShowcase(APPS);
+      const html = renderShowcase(PROJECTS);
       expect(html).toContain('href="/about"');
       expect(html).toContain("Learn More");
     });
 
     it("renders Source link to the GitHub repo", () => {
-      const html = renderShowcase(APPS);
+      const html = renderShowcase(PROJECTS);
       expect(html).toContain('href="https://github.com/natb1/commons.systems"');
       expect(html).toContain("Source");
     });
 
     it("CTA row appears after the subline", () => {
-      const html = renderShowcase(APPS);
+      const html = renderShowcase(PROJECTS);
       const sublineIndex = html.indexOf("landing-hero-band-subline");
       const ctaIndex = html.indexOf("landing-hero-band-cta");
       expect(ctaIndex).toBeGreaterThan(sublineIndex);

--- a/landing/test/showcase-render.test.ts
+++ b/landing/test/showcase-render.test.ts
@@ -39,7 +39,7 @@ describe("renderShowcase", () => {
     // excludes the `project-card-screenshot` img, which also starts with project-card).
     const matches = html.match(/<a [^>]*class="[^"]*\bproject-card"/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(PROJECTS.length);
+    expect(matches!.length).toBe(PROJECTS.length); // type-safety-ok: guarded by expect(matches).not.toBeNull() above
   });
 
   it("each anchor href matches the app url", () => {

--- a/packages/rules-test/test/firestore/errors.test.ts
+++ b/packages/rules-test/test/firestore/errors.test.ts
@@ -12,7 +12,7 @@ import {
 
 const ENV = "test";
 
-const KNOWN_APPS = ["budget", "landing", "fellspiral", "print", "audio"];
+const KNOWN_PROJECTS = ["budget", "landing", "fellspiral", "print", "audio"];
 
 function validErrorDoc() {
   return {
@@ -39,7 +39,7 @@ describe("error logs", () => {
 
   setupCleanup();
 
-  for (const appName of KNOWN_APPS) {
+  for (const appName of KNOWN_PROJECTS) {
     describe(`${appName} errors`, () => {
       it("allows unauthenticated create with valid fields", async () => {
         const ctx = unauthenticatedContext(env);


### PR DESCRIPTION
Closes #2453

Renames the user-facing **"apps"** product terminology to **"projects"**
consistently across the landing showcase code/UI, tests, the `rules-test`
constant, and docs prose. Terminology-consistency change only — no behavior
change.

## What changed

- **Landing showcase source + CSS** (`landing/src`, `landing/scripts`): exported
  identifiers `AppCard`→`ProjectCard`, `APPS`→`PROJECTS`,
  `OVERFLOW_APPS`→`OVERFLOW_PROJECTS`; component props `app`→`project` /
  `apps`→`projects`; CSS classes `.app-card`/`.app-showcase*`/`.app-name`/
  `.app-problem`→`.project-*`; user-facing strings "Featured apps"→"Featured
  projects" and "More apps"→"More projects".
- **Landing tests/e2e**: `git mv` of `apps-config.test.ts`→`projects-config.test.ts`
  and `app-showcase.spec.ts`→`project-showcase.spec.ts`; identifiers and
  `.project-card`/`.project-showcase-overflow` selectors updated to match.
- **rules-test**: local constant `KNOWN_APPS`→`KNOWN_PROJECTS` (pure identifier
  rename; array values and Firestore behavior unchanged).
- **Docs prose**: `README.md` landing-page bullet → "the project showcase and
  overview"; `landing/public/screenshots/README.md` retitled and product-noun
  "app" → "project" throughout (including the `APPS`→`PROJECTS` reference).

## Deliberately left unchanged

- The schema.org `SoftwareApplication` structured-data vocabulary and the
  `SoftwareApplication` JSON-LD SEO assertions.
- The CI "app = workspace" tooling section in `README.md`
  (`get-changed-apps.sh`, `<app>` wrapper args) and external URLs.
- Institutional "project"/"the project" uses and Firebase SDK usage.
- The generic SITE_DEFAULTS tagline "Forkable, local-first apps…".

## Plan files that no longer exist

`ROADMAP.md` and `CHARTER.md` were named in the plan but have since been removed
from the repo (migrated into the intention graph). They are skipped — the plan
explicitly treats a removed `ROADMAP.md` as moot, and `CHARTER.md` follows the
same logic. The migrated content does not retain the product-noun "app" phrasing
(the only `intentions/` hit is a historical issue record, out of scope). This
skip is deliberate, not an oversight.

## Verification

All plan auto-verify blocks pass: `npx vitest run --project landing --root .`
(79 tests), `npx tsc --noEmit -p landing`, the leftover-token grep over
`landing/src landing/scripts landing/test landing/e2e`, and the `KNOWN_APPS`
grep. Manual/QA checks (full landing build, e2e, rules-test suite, visual/SEO)
are left for the QA phase per the plan.
