### PR TITLE
print: range-based metadata reads for local PDF/EPUB

### DIFF
--- a/print/src/library.ts
+++ b/print/src/library.ts
@@ -8,8 +8,7 @@
  */
 import { createFirebaseMediaSource } from "@commons-systems/mediautil/firebase";
 import { createLocalFolderMediaSource } from "@commons-systems/mediautil/local-folder";
-import type { LocalDirectoryHandleLike } from "@commons-systems/mediautil/local-folder";
-import type { MediaSource } from "@commons-systems/mediautil/source";
+import type { LocalDirectoryHandleLike, LocalFolderMediaSource } from "@commons-systems/mediautil/local-folder";
 
 import { getPublicMedia, getAllAccessibleMedia, getMediaItem } from "./firestore.js";
 import { storage, STORAGE_NAMESPACE } from "./firebase.js";
@@ -81,7 +80,7 @@ export function fileToLocalItem(file: File, name: string, folderId: string): Med
   };
 }
 
-let localSource: MediaSource<MediaItem> | null = null;
+let localSource: LocalFolderMediaSource<MediaItem> | null = null;
 
 let resolveLocalFolderReady!: () => void;
 const localFolderReadyPromise = new Promise<void>((resolve) => {
@@ -120,6 +119,13 @@ export async function resolveLocalBlob(item: MediaItem): Promise<ArrayBuffer | n
     throw new Error('No local source bound');
   }
   return localSource.resolveToBlob(item);
+}
+
+export async function resolveLocalFile(item: MediaItem): Promise<File | null> {
+  if (!localSource) {
+    throw new Error('No local source bound');
+  }
+  return localSource.resolveToFile(item);
 }
 
 export function hasLocalSource(): boolean {

--- a/print/src/library.ts
+++ b/print/src/library.ts
@@ -6,6 +6,8 @@
  * identical; `listCloud()` just dispatches the existing public / accessible
  * queries through `createFirebaseMediaSource`.
  */
+import { logError } from "@commons-systems/errorutil/log";
+
 import { createFirebaseMediaSource } from "@commons-systems/mediautil/firebase";
 import { createLocalFolderMediaSource } from "@commons-systems/mediautil/local-folder";
 import type { LocalDirectoryHandleLike, LocalFolderMediaSource } from "@commons-systems/mediautil/local-folder";
@@ -121,11 +123,25 @@ export async function resolveLocalBlob(item: MediaItem): Promise<ArrayBuffer | n
   return localSource.resolveToBlob(item);
 }
 
+/**
+ * Resolve a local item to a live `File`, or `null` when it can no longer be
+ * read. A vanished file, an index miss, or a permission error here is a
+ * skip-and-retry-later signal, not a misconfiguration to surface: the
+ * enrichment path relies on the `null` return to avoid caching an empty `{}`
+ * (which would permanently suppress a retry). The error is still logged for
+ * observability before returning null. Mirrors the audio app's
+ * `resolveLocalFile`.
+ */
 export async function resolveLocalFile(item: MediaItem): Promise<File | null> {
   if (!localSource) {
     throw new Error('No local source bound');
   }
-  return localSource.resolveToFile(item);
+  try {
+    return await localSource.resolveToFile(item);
+  } catch (err) {
+    logError(err, { operation: "resolve-local-file", id: item.id });
+    return null;
+  }
 }
 
 export function hasLocalSource(): boolean {

--- a/print/src/local-folder-ui.ts
+++ b/print/src/local-folder-ui.ts
@@ -18,7 +18,7 @@ import { createLimiter } from "./concurrency.js";
 import {
   createLocalSource,
   listLocal,
-  resolveLocalBlob,
+  resolveLocalFile,
 } from "./library.js";
 import { extractMetadata } from "./local-metadata.js";
 import { mediaTypeBadge } from "./media-render.js";
@@ -455,13 +455,13 @@ async function enrichLocalItem(
   const { item, node } = target;
   try {
     try {
-      const buf = await resolveLocalBlob(item);
-      if (buf === null) {
+      const file = await resolveLocalFile(item);
+      if (file === null) {
         // Could not read this file — do NOT cache `{}` (that would permanently
         // suppress retry). A later focus retries.
         return;
       }
-      const meta = await extractMetadata(buf, item.mediaType);
+      const meta = await extractMetadata(file, item.mediaType);
       patchLocalRow(node, meta);
       // Persist incrementally: a single entry, written even when `meta` is `{}`.
       await cacheMetadata(item.storagePath, meta);

--- a/print/src/local-metadata.ts
+++ b/print/src/local-metadata.ts
@@ -54,7 +54,7 @@ export function parseOpfTitle(xml: string): string | undefined {
 export class BlobRangeTransport extends pdfjsLib.PDFDataRangeTransport {
   /** Rejects with the first failing range read; never resolves. */
   readonly error: Promise<never>;
-  private rejectError!: (reason: unknown) => void;
+  private rejectError!: (reason: unknown) => void; // type-safety-ok: definite assignment assertion — Promise executor is synchronous so rejectError is set before requestDataRange can be called
 
   constructor(private blob: Blob) {
     super(blob.size, null);

--- a/print/src/local-metadata.ts
+++ b/print/src/local-metadata.ts
@@ -41,11 +41,35 @@ export function parseOpfTitle(xml: string): string | undefined {
   return cleanTitle(plainTitle?.textContent);
 }
 
-async function extractPdf(buf: ArrayBuffer): Promise<{ title?: string; pageCount?: number }> {
-  // getDocument copies/detaches the buffer; pass a fresh Uint8Array view.
+/**
+ * Range transport that serves pdf.js's data requests by slicing the source Blob,
+ * so only the byte ranges pdf.js asks for are read (not the whole file). Read
+ * errors are left to reject so extractMetadata's try/catch yields `{}`.
+ */
+export class BlobRangeTransport extends pdfjsLib.PDFDataRangeTransport {
+  constructor(private blob: Blob) {
+    super(blob.size, null);
+  }
+
+  requestDataRange(begin: number, end: number): void {
+    void this.blob
+      .slice(begin, end)
+      .arrayBuffer()
+      .then((buf) => {
+        this.onDataRange(begin, new Uint8Array(buf));
+      });
+  }
+}
+
+async function extractPdf(blob: Blob): Promise<{ title?: string; pageCount?: number }> {
+  // Range transport reads only the byte ranges pdf.js requests from the Blob.
   let doc: pdfjsLib.PDFDocumentProxy | undefined;
   try {
-    doc = await pdfjsLib.getDocument({ data: new Uint8Array(buf) }).promise;
+    doc = await pdfjsLib.getDocument({
+      range: new BlobRangeTransport(blob),
+      disableStream: true,
+      disableAutoFetch: true,
+    }).promise;
     const pageCount = doc.numPages;
     const { info } = await doc.getMetadata();
     const title = cleanTitle((info as { Title?: string }).Title);
@@ -56,8 +80,8 @@ async function extractPdf(buf: ArrayBuffer): Promise<{ title?: string; pageCount
   }
 }
 
-async function extractEpub(buf: ArrayBuffer): Promise<{ title?: string; pageCount?: number }> {
-  const { entries } = await unzip(buf);
+async function extractEpub(blob: Blob): Promise<{ title?: string; pageCount?: number }> {
+  const { entries } = await unzip(blob);
   const containerEntry = entries["META-INF/container.xml"];
   if (!containerEntry) return {};
   const opfPath = parseContainerXml(await containerEntry.text());
@@ -70,19 +94,19 @@ async function extractEpub(buf: ArrayBuffer): Promise<{ title?: string; pageCoun
 }
 
 /**
- * Extract `{ title?, pageCount? }` from in-memory bytes. Read-only: operates on
- * bytes already in memory, so extraction works even when the source folder is
- * not writable. Tolerant of untrusted/malformed file contents — any failure
- * (corrupt PDF, malformed or missing container.xml/OPF) is logged and reported
- * as `{}` so the caller can fall back to the filename stem.
+ * Extract `{ title?, pageCount? }` from a Blob, range-reading only the bytes
+ * needed. Read-only: never writes back, so extraction works even when the source
+ * folder is not writable. Tolerant of untrusted/malformed file contents — any
+ * failure (corrupt PDF, malformed or missing container.xml/OPF) is logged and
+ * reported as `{}` so the caller can fall back to the filename stem.
  */
 export async function extractMetadata(
-  buf: ArrayBuffer,
+  blob: Blob,
   mediaType: MediaType,
 ): Promise<{ title?: string; pageCount?: number }> {
   try {
-    if (mediaType === "pdf") return await extractPdf(buf);
-    if (mediaType === "epub") return await extractEpub(buf);
+    if (mediaType === "pdf") return await extractPdf(blob);
+    if (mediaType === "epub") return await extractEpub(blob);
     return {};
   } catch (err) {
     logError(err, { operation: "extractMetadata", mediaType });

--- a/print/src/local-metadata.ts
+++ b/print/src/local-metadata.ts
@@ -43,37 +43,61 @@ export function parseOpfTitle(xml: string): string | undefined {
 
 /**
  * Range transport that serves pdf.js's data requests by slicing the source Blob,
- * so only the byte ranges pdf.js asks for are read (not the whole file). Read
- * errors are left to reject so extractMetadata's try/catch yields `{}`.
+ * so only the byte ranges pdf.js asks for are read (not the whole file).
+ *
+ * pdf.js never surfaces a range read that fails to call `onDataRange` — it just
+ * blocks forever waiting for the outstanding range, so `getDocument().promise`
+ * would never settle. To make a failed read observable, a rejected read settles
+ * the `error` promise; callers race it against their pdf.js work so the failure
+ * propagates to `extractMetadata`'s try/catch (which yields `{}`).
  */
 export class BlobRangeTransport extends pdfjsLib.PDFDataRangeTransport {
+  /** Rejects with the first failing range read; never resolves. */
+  readonly error: Promise<never>;
+  private rejectError!: (reason: unknown) => void;
+
   constructor(private blob: Blob) {
     super(blob.size, null);
+    this.error = new Promise<never>((_, reject) => {
+      this.rejectError = reject;
+    });
+    // Attach a no-op handler so a read failure that fires after the caller's
+    // race has already settled does not surface as an unhandled rejection.
+    this.error.catch(() => {});
   }
 
   requestDataRange(begin: number, end: number): void {
-    void this.blob
+    this.blob
       .slice(begin, end)
       .arrayBuffer()
       .then((buf) => {
         this.onDataRange(begin, new Uint8Array(buf));
+      })
+      .catch((err: unknown) => {
+        this.rejectError(err);
       });
   }
 }
 
 async function extractPdf(blob: Blob): Promise<{ title?: string; pageCount?: number }> {
   // Range transport reads only the byte ranges pdf.js requests from the Blob.
+  const transport = new BlobRangeTransport(blob);
   let doc: pdfjsLib.PDFDocumentProxy | undefined;
   try {
-    doc = await pdfjsLib.getDocument({
-      range: new BlobRangeTransport(blob),
-      disableStream: true,
-      disableAutoFetch: true,
-    }).promise;
-    const pageCount = doc.numPages;
-    const { info } = await doc.getMetadata();
-    const title = cleanTitle((info as { Title?: string }).Title);
-    return title !== undefined ? { title, pageCount } : { pageCount };
+    const extract = (async () => {
+      doc = await pdfjsLib.getDocument({
+        range: transport,
+        disableStream: true,
+        disableAutoFetch: true,
+      }).promise;
+      const pageCount = doc.numPages;
+      const { info } = await doc.getMetadata();
+      const title = cleanTitle((info as { Title?: string }).Title);
+      return title !== undefined ? { title, pageCount } : { pageCount };
+    })();
+    // Race the transport's error channel: a failed range read never reaches
+    // pdf.js, so without this the extract promise would hang indefinitely.
+    return await Promise.race([extract, transport.error]);
   } finally {
     // Destroy the document — and its backing worker — even if getMetadata throws.
     await doc?.destroy();

--- a/print/test/enrichment.test.ts
+++ b/print/test/enrichment.test.ts
@@ -86,6 +86,7 @@ import {
 import type { MediaItem, SidecarData } from "../src/sidecar.js";
 import type { MediaItem as LibMediaItem } from "../src/types.js";
 import { deferred } from "./utils";
+import { logError } from "@commons-systems/errorutil/log";
 
 // ---------------------------------------------------------------------------
 // Fake FileSystemDirectoryHandle (same pattern as sidecar.test.ts)
@@ -487,6 +488,49 @@ describe("enrichment — resolveLocalFile returns null (file gone)", () => {
 
     expect(mockResolveLocalFile).toHaveBeenCalledTimes(2);
     expect(mockExtractMetadata).not.toHaveBeenCalled();
+  });
+
+  it("does not cache and clears the spinner when resolveLocalFile THROWS (real file-gone path)", async () => {
+    // Production resolveLocalFile (library.ts:124) does NOT return null when a
+    // file is absent — it throws. That throw propagates out of the awaited
+    // resolveLocalFile, skips the `if (file === null)` guard entirely, and is
+    // caught by enrichLocalItem's inner catch (which logs) before the `finally`
+    // clears the spinner. This test exercises that real catch path — the
+    // null-returning tests above only cover the defensive guard, which is dead
+    // code in production. A regression that removed the null guard would still
+    // pass those, but the throw path here keeps the genuine behavior covered.
+    const item = makeLocalItem({ storagePath: "gone.pdf", title: "gone" });
+    mockListLocal.mockResolvedValue([item]);
+    const gate = deferred<File | null>();
+    mockResolveLocalFile.mockReturnValue(gate.promise);
+
+    const dir = makeEmptyDir();
+    setLocalDirectory(dir, true);
+
+    const container = makeContainer();
+    await renderLocalIntoList(container);
+    const node = rowNode(container, item);
+
+    // Intersection adds the spinner synchronously while the read is in flight.
+    triggerIntersection(node);
+    expect(node.querySelector(".media-loading")).not.toBeNull();
+
+    // Reject the read → the throw lands in the inner catch (logError), then the
+    // `finally` clears the spinner. enrichLocalItem swallows the error, so the
+    // scheduled promise resolves and settleEnrichment drains normally.
+    gate.reject(new Error("File not found"));
+    await settleEnrichment();
+    await flushWrites();
+
+    // The throw path was taken (not the dead null guard): logError ran, which
+    // sits AFTER the guard's early return, so this discriminates the two paths.
+    expect(vi.mocked(logError)).toHaveBeenCalledTimes(1);
+
+    // No extract, no cache (so a later focus retries), and the spinner cleared.
+    expect(mockExtractMetadata).not.toHaveBeenCalled();
+    const cached = await getMetadata("gone.pdf");
+    expect(cached).toBeUndefined();
+    expect(node.querySelector(".media-loading")).toBeNull();
   });
 });
 

--- a/print/test/enrichment.test.ts
+++ b/print/test/enrichment.test.ts
@@ -34,11 +34,11 @@ vi.mock("@commons-systems/local-first/fsa-handle-store", () => ({
 }));
 
 // ---------------------------------------------------------------------------
-// Mock library.js: listLocal and resolveLocalBlob are overridable spies.
+// Mock library.js: listLocal and resolveLocalFile are overridable spies.
 // createLocalSource is a no-op. Other exports are real.
 // ---------------------------------------------------------------------------
 const mockListLocal = vi.fn<[], Promise<import("../src/types.js").MediaItem[]>>();
-const mockResolveLocalBlob = vi.fn<[import("../src/types.js").MediaItem], Promise<ArrayBuffer | null>>();
+const mockResolveLocalFile = vi.fn<[import("../src/types.js").MediaItem], Promise<File | null>>();
 
 vi.mock("../src/library.js", async () => {
   const actual = await vi.importActual<typeof import("../src/library.js")>("../src/library.js");
@@ -46,20 +46,20 @@ vi.mock("../src/library.js", async () => {
     ...actual,
     createLocalSource: vi.fn(),
     listLocal: () => mockListLocal(),
-    resolveLocalBlob: (item: import("../src/types.js").MediaItem) => mockResolveLocalBlob(item),
+    resolveLocalFile: (item: import("../src/types.js").MediaItem) => mockResolveLocalFile(item),
   };
 });
 
 // ---------------------------------------------------------------------------
 // Mock local-metadata.js extractMetadata as a spy
 // ---------------------------------------------------------------------------
-const mockExtractMetadata = vi.fn<[ArrayBuffer, import("../src/types.js").MediaType], Promise<{ title?: string; pageCount?: number }>>();
+const mockExtractMetadata = vi.fn<[Blob, import("../src/types.js").MediaType], Promise<{ title?: string; pageCount?: number }>>();
 
 vi.mock("../src/local-metadata.js", async () => {
   const actual = await vi.importActual<typeof import("../src/local-metadata.js")>("../src/local-metadata.js");
   return {
     ...actual,
-    extractMetadata: (buf: ArrayBuffer, mt: import("../src/types.js").MediaType) => mockExtractMetadata(buf, mt),
+    extractMetadata: (blob: Blob, mt: import("../src/types.js").MediaType) => mockExtractMetadata(blob, mt),
   };
 });
 
@@ -290,7 +290,7 @@ describe("enrichment — cached item (zero IO, no write)", () => {
     document.body.innerHTML = '';
   });
 
-  it("applies cached metadata without calling extractMetadata or resolveLocalBlob", async () => {
+  it("applies cached metadata without calling extractMetadata or resolveLocalFile", async () => {
     const item = makeLocalItem({ storagePath: "book.pdf", title: "book" });
     mockListLocal.mockResolvedValue([item]);
 
@@ -310,7 +310,7 @@ describe("enrichment — cached item (zero IO, no write)", () => {
     // The cached item is not uncached, so NO observer is registered for it and
     // there is nothing to trigger — no IO occurs.
     expect(ioRegistry).toHaveLength(0);
-    expect(mockResolveLocalBlob).not.toHaveBeenCalled();
+    expect(mockResolveLocalFile).not.toHaveBeenCalled();
     expect(mockExtractMetadata).not.toHaveBeenCalled();
 
     // Rendered item should show the enriched title
@@ -326,11 +326,11 @@ describe("enrichment — uncached item (extracts and caches)", () => {
     document.body.innerHTML = '';
   });
 
-  it("calls resolveLocalBlob and extractMetadata for uncached items", async () => {
-    const buf = new ArrayBuffer(8);
+  it("calls resolveLocalFile and extractMetadata for uncached items", async () => {
+    const file = new File([new Uint8Array(8)], "x.pdf");
     const item = makeLocalItem({ storagePath: "book.pdf", title: "book" });
     mockListLocal.mockResolvedValue([item]);
-    mockResolveLocalBlob.mockResolvedValue(buf);
+    mockResolveLocalFile.mockResolvedValue(file);
     mockExtractMetadata.mockResolvedValue({ title: "Extracted Title", pageCount: 20 });
 
     const dir = makeEmptyDir();
@@ -343,8 +343,8 @@ describe("enrichment — uncached item (extracts and caches)", () => {
     await settleEnrichment();
     await flushWrites();
 
-    expect(mockResolveLocalBlob).toHaveBeenCalledWith(item);
-    expect(mockExtractMetadata).toHaveBeenCalledWith(buf, "pdf");
+    expect(mockResolveLocalFile).toHaveBeenCalledWith(item);
+    expect(mockExtractMetadata).toHaveBeenCalledWith(file, "pdf");
 
     // Rendered HTML should reflect extracted title
     expect(container.innerHTML).toContain("Extracted Title");
@@ -355,10 +355,10 @@ describe("enrichment — uncached item (extracts and caches)", () => {
   });
 
   it("persists the cached metadata to disk (writable=true)", async () => {
-    const buf = new ArrayBuffer(4);
+    const file = new File([new Uint8Array(4)], "novel.epub");
     const item = makeLocalItem({ storagePath: "novel.epub", title: "novel" });
     mockListLocal.mockResolvedValue([item]);
-    mockResolveLocalBlob.mockResolvedValue(buf);
+    mockResolveLocalFile.mockResolvedValue(file);
     mockExtractMetadata.mockResolvedValue({ title: "Novel Title" });
 
     const dir = makeEmptyDir();
@@ -411,14 +411,14 @@ describe("enrichment — write suppression on focus-rescan", () => {
     expect(ioRegistry).toHaveLength(0);
     expect(indexHandle.createWritable.mock.calls.length).toBe(createWritableBefore);
     expect(mockExtractMetadata).not.toHaveBeenCalled();
-    expect(mockResolveLocalBlob).not.toHaveBeenCalled();
+    expect(mockResolveLocalFile).not.toHaveBeenCalled();
   });
 
   it("caches a present {} entry so a second render does NOT re-extract", async () => {
-    const buf = new ArrayBuffer(4);
+    const file = new File([new Uint8Array(4)], "unknown.pdf");
     const item = makeLocalItem({ storagePath: "unknown.pdf" });
     mockListLocal.mockResolvedValue([item]);
-    mockResolveLocalBlob.mockResolvedValue(buf);
+    mockResolveLocalFile.mockResolvedValue(file);
     // Extract returns empty (no title, no pageCount) — an {} entry IS cached
     mockExtractMetadata.mockResolvedValue({});
 
@@ -445,7 +445,7 @@ describe("enrichment — write suppression on focus-rescan", () => {
   });
 });
 
-describe("enrichment — resolveLocalBlob returns null (file gone)", () => {
+describe("enrichment — resolveLocalFile returns null (file gone)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -453,39 +453,39 @@ describe("enrichment — resolveLocalBlob returns null (file gone)", () => {
     document.body.innerHTML = '';
   });
 
-  it("does not cache {} when resolveLocalBlob returns null (so next render retries)", async () => {
+  it("does not cache {} when resolveLocalFile returns null (so next render retries)", async () => {
     const item = makeLocalItem({ storagePath: "gone.pdf" });
     mockListLocal.mockResolvedValue([item]);
-    mockResolveLocalBlob.mockResolvedValue(null);
+    mockResolveLocalFile.mockResolvedValue(null);
 
     const dir = makeEmptyDir();
     setLocalDirectory(dir, true);
 
     const container = makeContainer();
-    // First pass: scroll the row in → resolveLocalBlob returns null → no
+    // First pass: scroll the row in → resolveLocalFile returns null → no
     // extract, nothing cached.
     await renderLocalIntoList(container);
     triggerIntersection(rowNode(container, item));
     await settleEnrichment();
     await flushWrites();
 
-    // extractMetadata should NOT be called (no buf)
+    // extractMetadata should NOT be called (no file)
     expect(mockExtractMetadata).not.toHaveBeenCalled();
 
     // No entry should be cached (so next render can retry)
     const cached = await getMetadata("gone.pdf");
     expect(cached).toBeUndefined();
-    expect(mockResolveLocalBlob).toHaveBeenCalledTimes(1);
+    expect(mockResolveLocalFile).toHaveBeenCalledTimes(1);
 
     // Second pass: because nothing was cached, the row is STILL uncached, so a
     // fresh observer registers it. Scrolling it in again re-attempts the read —
-    // proving the null-blob path is a retry, not a permanent suppression.
+    // proving the null-file path is a retry, not a permanent suppression.
     await renderLocalIntoList(container);
     triggerIntersection(rowNode(container, item));
     await settleEnrichment();
     await flushWrites();
 
-    expect(mockResolveLocalBlob).toHaveBeenCalledTimes(2);
+    expect(mockResolveLocalFile).toHaveBeenCalledTimes(2);
     expect(mockExtractMetadata).not.toHaveBeenCalled();
   });
 });
@@ -513,7 +513,7 @@ describe("enrichment — early return when no media list present", () => {
     // Bails before any observer is constructed.
     expect(ioRegistry).toHaveLength(0);
     expect(mockExtractMetadata).not.toHaveBeenCalled();
-    expect(mockResolveLocalBlob).not.toHaveBeenCalled();
+    expect(mockResolveLocalFile).not.toHaveBeenCalled();
   });
 });
 
@@ -526,10 +526,10 @@ describe("enrichment — lazy: deferred until intersection (criterion 1)", () =>
   });
 
   it("does no file IO at first paint, then reads on intersection", async () => {
-    const buf = new ArrayBuffer(8);
+    const file = new File([new Uint8Array(8)], "x.pdf");
     const item = makeLocalItem({ storagePath: "book.pdf", title: "book" });
     mockListLocal.mockResolvedValue([item]);
-    mockResolveLocalBlob.mockResolvedValue(buf);
+    mockResolveLocalFile.mockResolvedValue(file);
     mockExtractMetadata.mockResolvedValue({ title: "Extracted Title" });
 
     const dir = makeEmptyDir();
@@ -539,7 +539,7 @@ describe("enrichment — lazy: deferred until intersection (criterion 1)", () =>
     await renderLocalIntoList(container);
 
     // First paint: the row is rendered but NOT yet enriched — no read fired.
-    expect(mockResolveLocalBlob).not.toHaveBeenCalled();
+    expect(mockResolveLocalFile).not.toHaveBeenCalled();
     expect(mockExtractMetadata).not.toHaveBeenCalled();
 
     // Scrolling the row into view defers-then-fires the read.
@@ -547,8 +547,8 @@ describe("enrichment — lazy: deferred until intersection (criterion 1)", () =>
     await settleEnrichment();
     await flushWrites();
 
-    expect(mockResolveLocalBlob).toHaveBeenCalledWith(item);
-    expect(mockExtractMetadata).toHaveBeenCalledWith(buf, "pdf");
+    expect(mockResolveLocalFile).toHaveBeenCalledWith(item);
+    expect(mockExtractMetadata).toHaveBeenCalledWith(file, "pdf");
   });
 });
 
@@ -576,9 +576,9 @@ describe("enrichment — bounded: reads route through the limiter (criterion 2)"
     // Each read returns a deferred we control. Resolving with `null` makes
     // enrichLocalItem return early (no extract/cache) — shortest deterministic
     // drain. The call itself fires regardless of the resolved value.
-    const gates: Array<ReturnType<typeof deferred<ArrayBuffer | null>>> = [];
-    mockResolveLocalBlob.mockImplementation(() => {
-      const g = deferred<ArrayBuffer | null>();
+    const gates: Array<ReturnType<typeof deferred<File | null>>> = [];
+    mockResolveLocalFile.mockImplementation(() => {
+      const g = deferred<File | null>();
       gates.push(g);
       return g.promise;
     });
@@ -597,14 +597,14 @@ describe("enrichment — bounded: reads route through the limiter (criterion 2)"
     }
 
     // Exactly the bound's worth of reads started; none have resolved.
-    expect(mockResolveLocalBlob).toHaveBeenCalledTimes(ENRICH_READ_CONCURRENCY);
+    expect(mockResolveLocalFile).toHaveBeenCalledTimes(ENRICH_READ_CONCURRENCY);
 
     // Free one slot → the queued (limit+1)th read now runs. Freeing a slot
     // takes enrichLocalItem through its awaits, so wait rather than count
     // microtasks.
     gates[0].resolve(null);
     await vi.waitFor(() =>
-      expect(mockResolveLocalBlob).toHaveBeenCalledTimes(ENRICH_READ_CONCURRENCY + 1),
+      expect(mockResolveLocalFile).toHaveBeenCalledTimes(ENRICH_READ_CONCURRENCY + 1),
     );
 
     // Drain everything so no pending read leaks into the next test's shared,
@@ -626,8 +626,8 @@ describe("enrichment — loading state (criterion 3)", () => {
   it("shows a spinner on intersection and clears it after the read settles", async () => {
     const item = makeLocalItem({ storagePath: "book.pdf", title: "book" });
     mockListLocal.mockResolvedValue([item]);
-    const gate = deferred<ArrayBuffer | null>();
-    mockResolveLocalBlob.mockReturnValue(gate.promise);
+    const gate = deferred<File | null>();
+    mockResolveLocalFile.mockReturnValue(gate.promise);
     mockExtractMetadata.mockResolvedValue({ title: "Extracted Title" });
 
     const dir = makeEmptyDir();
@@ -642,18 +642,18 @@ describe("enrichment — loading state (criterion 3)", () => {
     expect(node.querySelector(".media-loading")).not.toBeNull();
 
     // Resolve the read → patch + cache → spinner cleared.
-    gate.resolve(new ArrayBuffer(8));
+    gate.resolve(new File([], "x.pdf"));
     await settleEnrichment();
     await flushWrites();
 
     expect(node.querySelector(".media-loading")).toBeNull();
   });
 
-  it("clears the spinner even when the file is unreadable (null blob)", async () => {
+  it("clears the spinner even when the file is unreadable (null file)", async () => {
     const item = makeLocalItem({ storagePath: "gone.pdf", title: "gone" });
     mockListLocal.mockResolvedValue([item]);
-    const gate = deferred<ArrayBuffer | null>();
-    mockResolveLocalBlob.mockReturnValue(gate.promise);
+    const gate = deferred<File | null>();
+    mockResolveLocalFile.mockReturnValue(gate.promise);
 
     const dir = makeEmptyDir();
     setLocalDirectory(dir, true);
@@ -665,7 +665,7 @@ describe("enrichment — loading state (criterion 3)", () => {
     triggerIntersection(node);
     expect(node.querySelector(".media-loading")).not.toBeNull();
 
-    // Null blob never reaches patchLocalRow — the `finally` clear must still
+    // Null file never reaches patchLocalRow — the `finally` clear must still
     // remove the spinner.
     gate.resolve(null);
     await settleEnrichment();

--- a/print/test/local-metadata.test.ts
+++ b/print/test/local-metadata.test.ts
@@ -298,6 +298,205 @@ describe("extractMetadata — unsupported type", () => {
 // BlobRangeTransport — range slicing behaviour
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// extractMetadata — epub bounded read (REAL unzipit, hand-rolled STORED zip)
+// ---------------------------------------------------------------------------
+//
+// This proves the EPUB path reads only a small bounded fraction of a multi-MB
+// archive: unzipit reads the EOCD + central directory from the tail and lazily
+// slices only the entries whose `.text()` is requested (container.xml + OPF),
+// never the multi-MB filler. We build a minimal STORED (uncompressed) zip by
+// hand so no compressor dependency is needed — unzipit is read-only.
+
+// Standard CRC-32 (polynomial 0xEDB88320), table-based, over uncompressed bytes.
+const CRC32_TABLE: Uint32Array = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) {
+    crc = (crc >>> 8) ^ CRC32_TABLE[(crc ^ bytes[i]) & 0xff];
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+interface ZipEntry {
+  name: string;
+  data: Uint8Array;
+}
+
+/**
+ * Assemble a minimal STORED-method zip (compression method 0, compressedSize ==
+ * uncompressedSize) from the given entries. All multi-byte integer fields are
+ * little-endian. Layout per entry: Local File Header (30 bytes + filename) +
+ * file data; then one Central Directory File Header (46 bytes + filename) per
+ * entry; then the End-Of-Central-Directory record (22 bytes).
+ */
+function buildStoredZip(entries: ZipEntry[]): Uint8Array {
+  const enc = new TextEncoder();
+  const chunks: Uint8Array[] = [];
+  let offset = 0;
+  const push = (b: Uint8Array) => {
+    chunks.push(b);
+    offset += b.length;
+  };
+
+  const central: Array<{
+    localOffset: number;
+    crc: number;
+    size: number;
+    nameBytes: Uint8Array;
+  }> = [];
+
+  for (const e of entries) {
+    const nameBytes = enc.encode(e.name);
+    const crc = crc32(e.data);
+    const size = e.data.length;
+    const localOffset = offset;
+
+    // Local File Header (signature 0x04034b50)
+    const lfh = new Uint8Array(30 + nameBytes.length);
+    const dv = new DataView(lfh.buffer);
+    dv.setUint32(0, 0x04034b50, true); // signature
+    dv.setUint16(4, 20, true); // version needed to extract
+    dv.setUint16(6, 0, true); // general purpose bit flag
+    dv.setUint16(8, 0, true); // compression method = STORED
+    dv.setUint16(10, 0, true); // last mod file time
+    dv.setUint16(12, 0, true); // last mod file date
+    dv.setUint32(14, crc, true); // crc-32
+    dv.setUint32(18, size, true); // compressed size
+    dv.setUint32(22, size, true); // uncompressed size
+    dv.setUint16(26, nameBytes.length, true); // file name length
+    dv.setUint16(28, 0, true); // extra field length
+    lfh.set(nameBytes, 30);
+    push(lfh);
+    push(e.data);
+
+    central.push({ localOffset, crc, size, nameBytes });
+  }
+
+  const cdStart = offset;
+  for (const c of central) {
+    // Central Directory File Header (signature 0x02014b50)
+    const cdh = new Uint8Array(46 + c.nameBytes.length);
+    const dv = new DataView(cdh.buffer);
+    dv.setUint32(0, 0x02014b50, true); // signature
+    dv.setUint16(4, 20, true); // version made by
+    dv.setUint16(6, 20, true); // version needed to extract
+    dv.setUint16(8, 0, true); // general purpose bit flag
+    dv.setUint16(10, 0, true); // compression method = STORED
+    dv.setUint16(12, 0, true); // last mod file time
+    dv.setUint16(14, 0, true); // last mod file date
+    dv.setUint32(16, c.crc, true); // crc-32
+    dv.setUint32(20, c.size, true); // compressed size
+    dv.setUint32(24, c.size, true); // uncompressed size
+    dv.setUint16(28, c.nameBytes.length, true); // file name length
+    dv.setUint16(30, 0, true); // extra field length
+    dv.setUint16(32, 0, true); // file comment length
+    dv.setUint16(34, 0, true); // disk number start
+    dv.setUint16(36, 0, true); // internal file attributes
+    dv.setUint32(38, 0, true); // external file attributes
+    dv.setUint32(42, c.localOffset, true); // relative offset of local header
+    cdh.set(c.nameBytes, 46);
+    push(cdh);
+  }
+  const cdSize = offset - cdStart;
+
+  // End Of Central Directory record (signature 0x06054b50)
+  const eocd = new Uint8Array(22);
+  const dv = new DataView(eocd.buffer);
+  dv.setUint32(0, 0x06054b50, true); // signature
+  dv.setUint16(4, 0, true); // number of this disk
+  dv.setUint16(6, 0, true); // disk with start of central directory
+  dv.setUint16(8, central.length, true); // entries on this disk
+  dv.setUint16(10, central.length, true); // total entries
+  dv.setUint32(12, cdSize, true); // size of central directory
+  dv.setUint32(16, cdStart, true); // offset of central directory start
+  dv.setUint16(20, 0, true); // .zip file comment length
+  push(eocd);
+
+  const total = new Uint8Array(offset);
+  let p = 0;
+  for (const c of chunks) {
+    total.set(c, p);
+    p += c.length;
+  }
+  return total;
+}
+
+describe("extractMetadata — epub bounded read", () => {
+  const FILLER_SIZE = 4 * 1024 * 1024; // 4 MB
+
+  function buildEpubFile(): File {
+    const enc = new TextEncoder();
+    const containerXml = `<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`;
+    // Title lives in a plain unprefixed <title>: happy-dom's DOMParser does not
+    // implement getElementsByTagNameNS, so parseOpfTitle's NS lookup finds
+    // nothing and falls through to getElementsByTagName("title").
+    const opfXml = `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf">
+  <metadata>
+    <title>Bounded Read Book</title>
+  </metadata>
+</package>`;
+
+    const zipBytes = buildStoredZip([
+      { name: "mimetype", data: enc.encode("application/epub+zip") },
+      { name: "META-INF/container.xml", data: enc.encode(containerXml) },
+      { name: "OEBPS/content.opf", data: enc.encode(opfXml) },
+      // Large filler: if the implementation full-read the file, this would
+      // dominate the byte count. unzipit must never slice it.
+      { name: "big.bin", data: new Uint8Array(FILLER_SIZE) },
+    ]);
+
+    return new File([zipBytes], "book.epub");
+  }
+
+  it("extracts the title reading only a small bounded fraction of a multi-MB archive", async () => {
+    const file = buildEpubFile();
+    expect(file.size).toBeGreaterThan(FILLER_SIZE); // sanity: filler dominates
+
+    const sliceSpy = vi.spyOn(file, "slice");
+    const arrayBufferSpy = vi.spyOn(file, "arrayBuffer");
+
+    const result = await extractMetadata(file, "epub");
+
+    // (a) correct title extracted — EPUB has no pageCount
+    expect(result).toEqual({ title: "Bounded Read Book" });
+
+    // (b) size-independence: total bytes sliced is far below the filler size.
+    // unzipit reads a fixed ~64 KB tail to scan for the EOCD record (bounded by
+    // its MAX_COMMENT_SIZE = 0xffff), then the central directory and the two
+    // tiny requested entries (container.xml + OPF) — never the 4 MB filler. This
+    // tail+directory total is independent of the archive size, so the assertion
+    // proves the read does not scale with the file.
+    let totalSliced = 0;
+    for (const call of sliceSpy.mock.calls) {
+      const begin = (call[0] as number | undefined) ?? 0;
+      const end = call[1] as number | undefined;
+      totalSliced += (end ?? file.size) - begin;
+    }
+    expect(totalSliced).toBeLessThan(128 * 1024); // 32x below the 4 MB filler
+
+    // (c) no full-file materialization
+    expect(arrayBufferSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe("BlobRangeTransport", () => {
   it("slices exactly [begin, end) and delivers the chunk via onDataRange without reading the full file", async () => {
     const bytes = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);

--- a/print/test/local-metadata.test.ts
+++ b/print/test/local-metadata.test.ts
@@ -289,7 +289,7 @@ describe("extractMetadata — pdf", () => {
 
 describe("extractMetadata — unsupported type", () => {
   it("returns {} for image-archive without throwing", async () => {
-    const result = await extractMetadata(new ArrayBuffer(0), "image-archive");
+    const result = await extractMetadata(new Blob([]), "image-archive");
     expect(result).toEqual({});
   });
 });

--- a/print/test/local-metadata.test.ts
+++ b/print/test/local-metadata.test.ts
@@ -9,12 +9,22 @@ const mockDestroy = vi.fn().mockResolvedValue(undefined);
 const mockGetMetadata = vi.fn();
 const mockGetDocument = vi.fn();
 
-vi.mock("pdfjs-dist", () => ({
-  default: {},
-  getDocument: (...args: unknown[]) => mockGetDocument(...args),
-  GlobalWorkerOptions: { workerSrc: "" },
-  version: "0.0.0",
-}));
+vi.mock("pdfjs-dist", () => {
+  class PDFDataRangeTransport {
+    length: number;
+    constructor(length: number, _initialData: unknown) {
+      this.length = length;
+    }
+    onDataRange(_begin: number, _chunk: Uint8Array): void {}
+  }
+  return {
+    default: {},
+    getDocument: (...args: unknown[]) => mockGetDocument(...args),
+    GlobalWorkerOptions: { workerSrc: "" },
+    version: "0.0.0",
+    PDFDataRangeTransport,
+  };
+});
 
 // No-op the side-effect import of ./viewer/pdf.js (which sets workerSrc)
 vi.mock("../src/viewer/pdf.js", () => ({}));
@@ -24,7 +34,7 @@ vi.mock("@commons-systems/errorutil/log", () => ({
   logError: vi.fn(),
 }));
 
-import { parseContainerXml, parseOpfTitle, extractMetadata } from "../src/local-metadata.js";
+import { parseContainerXml, parseOpfTitle, extractMetadata, BlobRangeTransport } from "../src/local-metadata.js";
 
 // ---------------------------------------------------------------------------
 // parseContainerXml
@@ -225,7 +235,7 @@ describe("extractMetadata — pdf", () => {
   it("returns title and pageCount when Title is present", async () => {
     const { destroy } = makeFakeDoc("Great Book", 42);
 
-    const result = await extractMetadata(new ArrayBuffer(8), "pdf");
+    const result = await extractMetadata(new File([new Uint8Array(8)], "x.pdf"), "pdf");
 
     expect(result).toEqual({ title: "Great Book", pageCount: 42 });
     expect(destroy).toHaveBeenCalled();
@@ -234,7 +244,7 @@ describe("extractMetadata — pdf", () => {
   it("returns only pageCount when Title is empty/whitespace", async () => {
     const { destroy } = makeFakeDoc("   ", 10);
 
-    const result = await extractMetadata(new ArrayBuffer(8), "pdf");
+    const result = await extractMetadata(new File([new Uint8Array(8)], "x.pdf"), "pdf");
 
     expect(result).toEqual({ pageCount: 10 });
     expect(result.title).toBeUndefined();
@@ -244,7 +254,7 @@ describe("extractMetadata — pdf", () => {
   it("returns only pageCount when Title is undefined", async () => {
     const { destroy } = makeFakeDoc(undefined, 5);
 
-    const result = await extractMetadata(new ArrayBuffer(8), "pdf");
+    const result = await extractMetadata(new File([new Uint8Array(8)], "x.pdf"), "pdf");
 
     expect(result).toEqual({ pageCount: 5 });
     expect(destroy).toHaveBeenCalled();
@@ -260,7 +270,7 @@ describe("extractMetadata — pdf", () => {
     mockGetDocument.mockReturnValue({ promise: Promise.resolve(doc) });
 
     // extractMetadata swallows errors and returns {}
-    const result = await extractMetadata(new ArrayBuffer(8), "pdf");
+    const result = await extractMetadata(new File([new Uint8Array(8)], "x.pdf"), "pdf");
     expect(result).toEqual({});
     expect(destroy).toHaveBeenCalled();
   });
@@ -268,7 +278,7 @@ describe("extractMetadata — pdf", () => {
   it("returns {} and does not throw when getDocument rejects", async () => {
     mockGetDocument.mockReturnValue({ promise: Promise.reject(new Error("worker crash")) });
 
-    const result = await extractMetadata(new ArrayBuffer(8), "pdf");
+    const result = await extractMetadata(new File([new Uint8Array(8)], "x.pdf"), "pdf");
     expect(result).toEqual({});
   });
 });
@@ -281,5 +291,35 @@ describe("extractMetadata — unsupported type", () => {
   it("returns {} for image-archive without throwing", async () => {
     const result = await extractMetadata(new ArrayBuffer(0), "image-archive");
     expect(result).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BlobRangeTransport — range slicing behaviour
+// ---------------------------------------------------------------------------
+
+describe("BlobRangeTransport", () => {
+  it("slices exactly [begin, end) and delivers the chunk via onDataRange without reading the full file", async () => {
+    const bytes = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const file = new File([bytes], "x.pdf");
+
+    const t = new BlobRangeTransport(file);
+
+    const sliceSpy = vi.spyOn(file, "slice");
+    const arrayBufferSpy = vi.spyOn(file, "arrayBuffer");
+    const onDataRangeSpy = vi.spyOn(t, "onDataRange");
+
+    // requestDataRange returns void; fire it then flush the internal promise chain.
+    t.requestDataRange(2, 6);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(sliceSpy).toHaveBeenCalledWith(2, 6);
+    expect(onDataRangeSpy).toHaveBeenCalledOnce();
+    const [begin, chunk] = onDataRangeSpy.mock.calls[0] as [number, Uint8Array];
+    expect(begin).toBe(2);
+    expect(chunk).toBeInstanceOf(Uint8Array);
+    expect(Array.from(chunk)).toEqual([2, 3, 4, 5]);
+    // The slice's own arrayBuffer() was called, but the file-level full read was not.
+    expect(arrayBufferSpy).not.toHaveBeenCalled();
   });
 });

--- a/print/test/local-metadata.test.ts
+++ b/print/test/local-metadata.test.ts
@@ -486,8 +486,8 @@ describe("extractMetadata — epub bounded read", () => {
     // proves the read does not scale with the file.
     let totalSliced = 0;
     for (const call of sliceSpy.mock.calls) {
-      const begin = (call[0] as number | undefined) ?? 0;
-      const end = call[1] as number | undefined;
+      const begin = call[0] ?? 0;
+      const end = call[1];
       totalSliced += (end ?? file.size) - begin;
     }
     expect(totalSliced).toBeLessThan(128 * 1024); // 32x below the 4 MB filler


### PR DESCRIPTION
Closes #2497

## What

Print's local-folder metadata enrichment previously read each PDF/EPUB file
**fully** into an `ArrayBuffer` just to learn a title and page count. For large
files (a 194 MB PDF, ~123 MB PDFs) that materialized hundreds of MB to extract a
few small fields. This replaces the full-file read on the **enrichment path**
with `File.slice()`-backed **range** reads, so per-file cost drops from
whole-file to KBs, independent of file size.

This composes with the already-merged lazy/bounded enrichment sibling (#2533):
that bounds *how many* files are read at once; this bounds *how much* of each
file is read. The viewer/render path correctly still does a full read and is
unchanged.

## How

- **`local-metadata.ts`**: `extractMetadata` now takes a `Blob` instead of an
  `ArrayBuffer`.
  - **PDF**: a new exported `BlobRangeTransport extends
    pdfjsLib.PDFDataRangeTransport` drives pdf.js, serving each requested range
    via `blob.slice(begin, end).arrayBuffer()` → `onDataRange`. `getDocument`
    runs with `disableStream` / `disableAutoFetch`, so pdf.js pulls only the
    xref/trailer tail + info dict + catalog.
  - **EPUB**: the `Blob` is passed straight to unzipit, whose Blob reader reads
    the End-of-Central-Directory + central directory from the file tail and
    `slice`s only the entries it needs (`META-INF/container.xml`, the OPF).
  - The pure helpers (`cleanTitle`, `parseContainerXml`, `parseOpfTitle`) and the
    `{}`-on-failure tolerance for untrusted/malformed contents are unchanged.
- **`library.ts`**: adds `resolveLocalFile(item)` (returns a lazy FSA `File`, no
  bytes read), mirroring `resolveLocalBlob`. `resolveLocalBlob` / `resolveToBlob`
  stay for the viewer render path.
- **`local-folder-ui.ts`**: the enrichment caller now resolves a `File` and
  passes it to `extractMetadata`.

## Tests

- `local-metadata.test.ts`: the pdfjs mock now provides a constructible
  `PDFDataRangeTransport` base; existing PDF cases pass a `File`; a focused
  `BlobRangeTransport` test proves it slices exactly `[begin, end)`, delivers the
  chunk via `onDataRange`, and never full-reads the file.
- `local-metadata.test.ts` (EPUB): an end-to-end bounded-read test hand-rolls an
  in-memory STORED zip with a 4 MB filler entry and runs it through **real**
  (unmocked) unzipit — extraction returns the expected title while slicing only
  ~66 KB and never calling `file.arrayBuffer()`. This is the genuine
  size-independence proof for EPUB.
- `enrichment.test.ts`: retargeted from `resolveLocalBlob`/`ArrayBuffer` to
  `resolveLocalFile`/`File`; lazy-deferral, bounded-concurrency, write-suppression
  and null-retry behavior and counts unchanged.

## Boundedness verifiability

EPUB boundedness is CI-verified (real unzipit). PDF end-to-end boundedness is a
**manual** check — pdf.js is fully mocked and worker-less under vitest, so no CI
test can prove a 100 MB PDF pulls only KBs. The `BlobRangeTransport` unit test
proves the *mechanism*; the end-to-end PDF check (open a 100 MB+ local PDF and
confirm enrichment reads only a bounded number of bytes) is in the Verification
notes for QA.
