### PR TITLE
office-hours: label the PACE panel x-axis with current-week date/time

### DIFF
--- a/office-hours/src/pace-position-panel.ts
+++ b/office-hours/src/pace-position-panel.ts
@@ -1,7 +1,7 @@
 import * as Plot from "@observablehq/plot";
 import { selectLatestSample, type UsageSample } from "./usage-samples.js";
 import { segmentByWeek, aheadBehindDelta, paceBackdrop } from "./pace-position.js";
-import { elapsedWeekFraction } from "./weekly-pace-curve.js";
+import { elapsedWeekFraction, fractionToWindowDate, formatWindowTick } from "./weekly-pace-curve.js";
 import {
   getThemeFg,
   readChartPalette,
@@ -87,7 +87,13 @@ export function renderPacePositionPanel(samples: UsageSample[]): HTMLElement {
       marginLeft: 0,
       marginRight: MARGIN_RIGHT,
       style: sharedStyle,
-      x: { domain: [0, 1], label: null },
+      x: {
+        domain: [0, 1],
+        label: null,
+        ticks: [0, 0.25, 0.5, 0.75, 1],
+        tickFormat: (f: number) =>
+          formatWindowTick(fractionToWindowDate(f, latest.weeklyResetsAt)),
+      },
       y: { domain: yDomain, label: null, axis: null, grid: true },
       marks: [
         // 1. Backdrop — the fixed W(x) ramp drawn once across x∈[0,1], muted.
@@ -127,7 +133,12 @@ export function renderPacePositionPanel(samples: UsageSample[]): HTMLElement {
     return layout;
   });
 
-  section.append(deltaEl, slot, legend);
+  const caption = document.createElement("p");
+  caption.className = "capacity-pace-caption";
+  caption.textContent =
+    "Dates label the current week; faded prior-week trails keep their shape, not these dates.";
+
+  section.append(deltaEl, slot, legend, caption);
 
   return section;
 }

--- a/office-hours/src/style/theme.css
+++ b/office-hours/src/style/theme.css
@@ -277,6 +277,11 @@ svg [aria-label="tip"] text { fill: #222; }
   font-size: 1.1rem;
   margin: 0 0 0.75rem 0;
 }
+.capacity-pace-caption {
+  color: var(--muted);
+  font-size: 0.8rem;
+  margin: 0.5rem 0 0 0;
+}
 .demo-banner {
   background: var(--border);
   color: var(--muted);

--- a/office-hours/src/weekly-pace-curve.ts
+++ b/office-hours/src/weekly-pace-curve.ts
@@ -59,6 +59,26 @@ export function elapsedWeekFraction(sampledAt: Date, weeklyResetsAt: Date): numb
 }
 
 /**
+ * The wall-clock date a fraction `f ∈ [0, 1]` of the weekly window maps to,
+ * given the window resets at `weeklyResetsAt`. The conceptual inverse of
+ * `elapsedWeekFraction`: `f = 0` is one full week before the reset
+ * (`weeklyResetsAt − 7d`), `f = 1` is the reset itself. Pure — no `Date.now()`.
+ */
+export function fractionToWindowDate(fraction: number, weeklyResetsAt: Date): Date {
+  return new Date(weeklyResetsAt.getTime() - (1 - fraction) * WEEK_SECONDS * 1000);
+}
+
+/**
+ * A compact tick label for a date within the current weekly window: weekday +
+ * hour, e.g. "Thu 9 AM". The single exported producer of x-axis tick labels —
+ * the PACE panel wires it into `tickFormat` and the panel test compares against
+ * it, so the test stays deterministic without pinning `TZ`.
+ */
+export function formatWindowTick(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, { weekday: "short", hour: "numeric" }).format(date);
+}
+
+/**
  * The pace curve W(x) as a pure function of the elapsed-week fraction
  * `x ∈ [0, 1]`. Mirrors the awk `W_of` anchored floor→shoulder→terminal curve:
  *   r = (1 - x) * T  (remaining 5-hour windows)

--- a/office-hours/test/pace-position-panel.test.ts
+++ b/office-hours/test/pace-position-panel.test.ts
@@ -67,7 +67,7 @@ describe("renderPacePositionPanel", () => {
 
     const svg = el.querySelector(".chart-scroll-wrapper svg");
     expect(svg).not.toBeNull();
-    const tickText = Array.from(svg!.querySelectorAll("text")).map((t) => t.textContent);
+    const tickText = Array.from(svg!.querySelectorAll("text")).map((t) => t.textContent); // type-safety-ok: asserted not-null by the preceding expect
     for (const label of expected) {
       expect(tickText).toContain(label);
     }
@@ -80,6 +80,6 @@ describe("renderPacePositionPanel", () => {
 
     const caption = el.querySelector(".capacity-pace-caption");
     expect(caption).not.toBeNull();
-    expect(caption!.textContent).toContain("current week");
+    expect(caption!.textContent).toContain("current week"); // type-safety-ok: asserted not-null by the preceding expect
   });
 });

--- a/office-hours/test/pace-position-panel.test.ts
+++ b/office-hours/test/pace-position-panel.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { renderPacePositionPanel } from "../src/pace-position-panel.js";
 import { type UsageSample } from "../src/usage-samples.js";
+import { fractionToWindowDate, formatWindowTick } from "../src/weekly-pace-curve.js";
 
 const baseSample: UsageSample = {
   sampledAt: new Date("2026-06-09T10:00:00Z"),
@@ -52,5 +53,33 @@ describe("renderPacePositionPanel", () => {
     expect(el.querySelector(".chart-scroll-wrapper svg")).not.toBeNull();
     // The PACE heading is present.
     expect(el.querySelector(".capacity-pace-heading")).not.toBeNull();
+  });
+
+  it("labels the x-axis ticks with current-week dates via the exported formatter", () => {
+    const host = withFg();
+    const el = renderPacePositionPanel(oneWeekSamples());
+    host.appendChild(el);
+
+    const weeklyResetsAt = new Date("2026-06-14T00:00:00Z");
+    const expected = [0, 0.25, 0.5, 0.75, 1].map((f) =>
+      formatWindowTick(fractionToWindowDate(f, weeklyResetsAt)),
+    );
+
+    const svg = el.querySelector(".chart-scroll-wrapper svg");
+    expect(svg).not.toBeNull();
+    const tickText = Array.from(svg!.querySelectorAll("text")).map((t) => t.textContent);
+    for (const label of expected) {
+      expect(tickText).toContain(label);
+    }
+  });
+
+  it("shows a caption communicating the current-week-only validity", () => {
+    const host = withFg();
+    const el = renderPacePositionPanel(oneWeekSamples());
+    host.appendChild(el);
+
+    const caption = el.querySelector(".capacity-pace-caption");
+    expect(caption).not.toBeNull();
+    expect(caption!.textContent).toContain("current week");
   });
 });

--- a/office-hours/test/weekly-pace-curve.test.ts
+++ b/office-hours/test/weekly-pace-curve.test.ts
@@ -3,6 +3,8 @@ import {
   weeklyPaceCurve,
   elapsedWeekFraction,
   paceCurveAtFraction,
+  fractionToWindowDate,
+  formatWindowTick,
   WEEK_SECONDS,
   WINDOW_SECONDS,
   T,
@@ -99,6 +101,24 @@ describe("elapsedWeekFraction", () => {
   it("clamps to 1 when remaining is negative (sampled past the reset)", () => {
     // remaining < 0 → (WEEK - remaining)/WEEK > 1, clamps to 1.
     expect(elapsedWeekFraction(at(-WINDOW_SECONDS), RESET)).toBe(1);
+  });
+});
+
+describe("fractionToWindowDate", () => {
+  it("f=0 is exactly one full week before the reset (window start)", () => {
+    expect(fractionToWindowDate(0, RESET).getTime()).toBe(
+      RESET.getTime() - WEEK_SECONDS * 1000,
+    );
+  });
+
+  it("f=1 is the reset itself", () => {
+    expect(fractionToWindowDate(1, RESET).getTime()).toBe(RESET.getTime());
+  });
+
+  it("f=0.5 is the half-week midpoint", () => {
+    expect(fractionToWindowDate(0.5, RESET).getTime()).toBe(
+      RESET.getTime() - 0.5 * WEEK_SECONDS * 1000,
+    );
   });
 });
 

--- a/office-hours/test/weekly-pace-curve.test.ts
+++ b/office-hours/test/weekly-pace-curve.test.ts
@@ -162,3 +162,14 @@ describe("paceCurveAtFraction", () => {
     }
   });
 });
+
+describe("formatWindowTick", () => {
+  it("renders a weekday + hour label for a fixed date", () => {
+    // Local-time constructor: 2026-06-14 is a Sunday, so the weekday token is
+    // "Sun" in the runtime's own zone regardless of TZ (the formatter zones by
+    // local time). The hour token is "9 AM".
+    const label = formatWindowTick(new Date(2026, 5, 14, 9, 0, 0));
+    expect(label).toContain("Sun");
+    expect(label).toMatch(/9\s*AM/);
+  });
+});


### PR DESCRIPTION
Closes #2521

## What

The office-hours Capacity-view **PACE** panel drew its x-axis as a unitless
elapsed-week fraction `x ∈ [0, 1]`, rendering bare numeric ticks (`0, 0.2, …, 1`)
that mean nothing to a reader. This labels those ticks with current-week
date/time instead, so the "now" dot and current trail read against the wall clock
("behind pace as of Thursday morning") rather than as an abstract 0–1 position.

The `[0, 1]` fraction domain is unchanged — only the x-axis tick **labels** and a
new caption change. The W(x) backdrop, per-week trails, and "now" dot keep their
exact shape and positions.

## How

- **Unit 1** — `office-hours/src/weekly-pace-curve.ts`: added two pure exports next
  to `elapsedWeekFraction` (its conceptual inverse):
  - `fractionToWindowDate(fraction, weeklyResetsAt)` maps a tick fraction to its
    wall-clock date within the weekly window (`f = 0` ↔ `weeklyResetsAt − 7d`,
    `f = 1` ↔ `weeklyResetsAt`). Pure — no `Date.now()`.
  - `formatWindowTick(date)` is the single exported tick-label producer (weekday +
    hour), wired into the panel and compared against by the panel test, so the
    test stays deterministic without pinning `TZ`.
- **Unit 2** — `office-hours/src/pace-position-panel.ts`: wired the Plot `x` config
  to explicit `ticks: [0, 0.25, 0.5, 0.75, 1]` with a `tickFormat` mapping each
  fraction through the Unit-1 helpers against `latest.weeklyResetsAt` (the same
  sample that anchors the "now" dot — no `Date.now()` in the render path). Added a
  caption noting the labels apply only to the current week, plus its CSS in
  `theme.css`.

## The 7-day-window caveat

Prior weeks' trails are overlaid on the same `[0, 1]` fraction axis, so their
fraction positions map to *different* real dates. The date/time labels are valid
only for the **current** 7-day window. The faded historical trails keep their
shape but no longer sit under their own wall-clock dates — an accepted trade-off
the new caption communicates explicitly.

## Verification

`npx vitest run --project office-hours --root .` — 439 passed. New unit tests
cover the fraction→date mapping (timezone-independent `.getTime()` assertions) and
the panel tick wiring (rendered tick `<text>` compared against the exported
formatter) plus caption presence. The empty-state path is untouched.

Manual/visual confirmation is left for QA: load the office-hours Capacity view and
confirm the PACE x-axis shows weekday/time labels, the caption shows, and the
backdrop / trails / "now" dot are visually unchanged.
