### PR TITLE
Fix misleading psiPerformance field comment (strategy is configurable)

### DIFF
--- a/functions/src/project-signals.ts
+++ b/functions/src/project-signals.ts
@@ -221,7 +221,7 @@ interface ProjectSignalSample {
   sessions?: number; // summed across GA4 apps
   gscClicks?: number; // summed from topPages
   gscImpressions?: number; // summed from topPages
-  psiPerformance?: number; // first-URL mobile performance
+  psiPerformance?: number; // first-URL performance score at the configured strategy (mobile or desktop)
 }
 
 // ---------------------------------------------------------------------------

--- a/functions/test/project-signals.test.ts
+++ b/functions/test/project-signals.test.ts
@@ -524,7 +524,7 @@ describe("collectProjectSignalsCore", () => {
     // summed from topPages
     expect(sample.gscClicks).toBe(12);
     expect(sample.gscImpressions).toBe(120);
-    // first-URL mobile performance
+    // first-URL performance score at the configured strategy (mobile or desktop)
     expect(sample.psiPerformance).toBe(88);
 
     // Only the headline scalars + identity fields — no full sub-objects.


### PR DESCRIPTION
Closes #2486

## Summary

The `ProjectSignalSample.psiPerformance` field comment in
`functions/src/project-signals.ts` read `// first-URL mobile performance`, but
the PSI strategy is configurable via the `PROJECT_SIGNALS_PSI_STRATEGY` env var
(default `mobile`, also accepts `desktop`). When set to `desktop` the stored
value is a desktop performance score while the comment still claimed "mobile",
misleading any consumer charting or interpreting the time-series.

This corrects the single stale comment to describe the score as the configured
strategy:

```ts
psiPerformance?: number; // first-URL performance score at the configured strategy (mobile or desktop)
```

This is the issue's explicitly Recommended fix. The floated alternative —
adding a persisted `psiStrategy` companion scalar — is deliberately not done: it
changes the character of an interface documented as "Headline scalars only", is
a Firestore-persisted schema change, and has no current consumer (the
office-hours reader pulls the full `psi` array, which already carries its own
per-URL `strategy`).

## Scope

- One-line comment change at `functions/src/project-signals.ts:224`.
- No type/interface field added or removed; no write-path logic changes.
- Other "mobile" mentions in the file (the strategy doc comment, the
  `defineString` default, the `"mobile" | "desktop"` type annotations, and the
  validation error string) are already accurate and were left untouched.

## Verification

Comment-only change — no behavior or types altered, so no test assertions
change. The `functions` unit suite passes as a smoke check that the file still
compiles and parses cleanly (83 tests passed).
