### PR TITLE
project-signals: omit empty ga4/psi arrays from the server snapshot

### DIFF
--- a/functions/src/project-signals.ts
+++ b/functions/src/project-signals.ts
@@ -618,9 +618,9 @@ export async function collectProjectSignalsCore(deps: CollectProjectSignalsDeps)
     groupId: deps.groupId,
     memberEmails: deps.memberEmails,
     ...(github ? { github } : {}),
-    ...(ga4 ? { ga4 } : {}),
+    ...(ga4 && ga4.length > 0 ? { ga4 } : {}),
     ...(gsc ? { gsc } : {}),
-    ...(psi ? { psi } : {}),
+    ...(psi && psi.length > 0 ? { psi } : {}),
   };
   await deps.firestore.doc(`${deps.namespace}/metrics/project-signals`).set(snapshot);
 

--- a/functions/test/project-signals.test.ts
+++ b/functions/test/project-signals.test.ts
@@ -575,4 +575,26 @@ describe("collectProjectSignalsCore", () => {
       "https://budget.commons.systems",
     ]);
   });
+
+  it("omits ga4 and psi keys when fetch resolves to an empty array", async () => {
+    const store = createInMemoryFirestore();
+    await collectProjectSignalsCore({
+      ...baseArgs(store),
+      fetchGithub: null,
+      fetchGa4: async () => [],
+      fetchGsc: null,
+      fetchPsi: async () => [],
+    });
+
+    const doc = store._docs.get("office-hours/prod/metrics/project-signals") as Record< // type-safety-ok: in-memory test fixture returns known shape
+      string,
+      unknown
+    >;
+    expect(doc).toBeDefined();
+    // Empty-array results must be omitted (not written) so the client parser
+    // and server snapshot stay consistent — an empty [] on the server would be
+    // promoted to undefined by parseGa4Signals/parsePsiSignals on the client.
+    expect("ga4" in doc).toBe(false);
+    expect("psi" in doc).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #2484

## Summary

Aligns the server-side `project-signals` write semantics with the client parser
so an empty `ga4` or `psi` array is never persisted to Firestore — the key is
omitted instead of writing `ga4: []` / `psi: []`.

## Problem

`parseGa4Signals` (client, `office-hours/src/project-signals.ts`) returns
`undefined` when the parsed results array is empty, omitting the `ga4` key from
the client snapshot. The server side (`functions/src/project-signals.ts`) used a
bare truthy conditional spread `...(ga4 ? { ga4 } : {})`. Because an empty array
`[]` is truthy in JavaScript, if `fetchGa4` ever resolved to `[]` the server
would write `ga4: []` while the client parser promotes that same value to
`undefined` — a latent round-trip mismatch. The same hazard applied to `psi`
(`parsePsiSignals` returns `undefined` for empty).

This is currently unreachable in production (the wrapper nulls `fetchGa4` when
`ga4Pairs` is empty), but the asymmetry is a correctness hazard the moment a
caller or test passes an empty array.

## Change

- `functions/src/project-signals.ts`: the `ga4` and `psi` conditional spreads
  now length-guard — `...(ga4 && ga4.length > 0 ? { ga4 } : {})` and
  `...(psi && psi.length > 0 ? { psi } : {})`. This mirrors the existing
  `psi && psi.length > 0` idiom already used in the headline-scalar derivation.
  The `github` and `gsc` spreads are left unchanged — they are object-valued, so
  a bare truthy check is already correct for them.
- `functions/test/project-signals.test.ts`: a new regression test exercises the
  empty-array path, asserting `"ga4" in doc` and `"psi" in doc` are both `false`
  when the fetchers resolve to `[]`.

The client parser (`office-hours/src/project-signals.ts`) is intentionally left
unchanged — it is already correct.

## Verification

`npx vitest run --project functions --root .` — 84/84 tests pass.
