### PR TITLE
Pin GSC date window to snapshot computedAt

### DIFF
--- a/functions/src/project-signals.ts
+++ b/functions/src/project-signals.ts
@@ -564,7 +564,7 @@ export interface CollectProjectSignalsDeps {
   // Each fetcher is null when its source is unconfigured (skipped entirely).
   fetchGithub: (() => Promise<GithubSignals>) | null;
   fetchGa4: (() => Promise<Ga4AppSignals[]>) | null;
-  fetchGsc: (() => Promise<GscSignals>) | null;
+  fetchGsc: ((now: Date) => Promise<GscSignals>) | null;
   fetchPsi: (() => Promise<PsiUrlSignals[]>) | null;
 }
 
@@ -594,7 +594,7 @@ export async function collectProjectSignalsCore(deps: CollectProjectSignalsDeps)
   }
   if (deps.fetchGsc) {
     try {
-      gsc = await deps.fetchGsc();
+      gsc = await deps.fetchGsc(deps.now);
     } catch (err) {
       console.error(
         `collectProjectSignals: gsc source failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -785,9 +785,9 @@ export const collectProjectSignals = onSchedule(
           `collectProjectSignals: PROJECT_SIGNALS_GSC_SITE "${gscSite}" is not a valid sc-domain:/https:// site; skipping gsc.`,
         );
       } else {
-        fetchGsc = async (): Promise<GscSignals> => {
+        fetchGsc = async (now: Date): Promise<GscSignals> => {
           const token = await googleToken();
-          return fetchGscLive(fetchFn, token, gscSite, new Date());
+          return fetchGscLive(fetchFn, token, gscSite, now);
         };
       }
     }

--- a/functions/test/project-signals.test.ts
+++ b/functions/test/project-signals.test.ts
@@ -451,6 +451,23 @@ describe("collectProjectSignalsCore", () => {
     },
   ];
 
+  it("passes deps.now to the fetchGsc closure", async () => {
+    const store = createInMemoryFirestore();
+    let capturedNow: Date | undefined;
+    const fetchGsc = async (now: Date): Promise<GscSignals> => {
+      capturedNow = now;
+      return gsc;
+    };
+    await collectProjectSignalsCore({
+      ...baseArgs(store),
+      fetchGithub: null,
+      fetchGa4: null,
+      fetchGsc,
+      fetchPsi: null,
+    });
+    expect(capturedNow).toEqual(new Date("2026-06-23T08:30:00Z"));
+  });
+
   it("writes the shared doc with only the sources that succeeded", async () => {
     const store = createInMemoryFirestore();
     await collectProjectSignalsCore({


### PR DESCRIPTION
Closes #2485

## Problem

The `fetchGsc` closure in `functions/src/project-signals.ts` called `new Date()`
independently when invoking `fetchGscLive`. Because the signal sources run
sequentially inside `collectProjectSignalsCore` (GitHub → GA4 → GSC), that
`new Date()` was evaluated several seconds — longer under slow network — after
the snapshot's `computedAt` (which is `deps.now`). The GSC `startDate`/`endDate`
then drifted from `computedAt`, making the window bounds imprecise for historical
comparison.

## Fix

Thread `now` from the core through to the GSC fetcher so the GSC window is pinned
to the same instant as `computedAt`:

- `CollectProjectSignalsDeps.fetchGsc` now takes a `now: Date` parameter.
- `collectProjectSignalsCore` passes `deps.now` when it invokes the fetcher.
- The handler closure accepts that `now` and forwards it to `fetchGscLive`,
  dropping the independent `new Date()`.

`now: new Date()` at the handler's call into core stays — that is `deps.now`, the
single source of truth that core now forwards to the GSC source.

Only the GSC fetcher computes a date window from `now`; GA4, GitHub, and PSI take
no date parameter and contain no `new Date()` calls, so the `now`-carrying
signature is intentionally GSC-only.

## Test

Adds a core-level regression test in `functions/test/project-signals.test.ts`
that injects a `fetchGsc` stub capturing its `now` argument and asserts it equals
`deps.now`, closing the link between `computedAt` and the GSC window at the
`collectProjectSignalsCore` seam.
