### PR TITLE
office-hours/functions: resolve PR #2464 review nits (computedAt comment + tighten GSC/PSI validators)

### DIFF
--- a/functions/src/project-signals.ts
+++ b/functions/src/project-signals.ts
@@ -853,13 +853,15 @@ export function isValidOwnerName(repo: string): boolean {
 // isValidGscSite — accepts `sc-domain:<host>` (no slashes) or an https URL
 // whose path has no `..` traversal component and no `//` empty segment.
 export function isValidGscSite(site: string): boolean {
-  return /^(sc-domain:[A-Za-z0-9.-]+|https:\/\/(?!.*\/\/)(?!.*\.\.)[A-Za-z0-9._/-]+)$/.test(site);
+  return /^(sc-domain:[A-Za-z0-9.-]+|https:\/\/(?!.*\/\/)(?!.*\.\.)[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]*)*)$/.test(
+    site,
+  );
 }
 
 // isValidPsiUrl — https URL with no `..` traversal component and no `//`
 // empty path segment.
 export function isValidPsiUrl(url: string): boolean {
-  return /^https:\/\/(?!.*\/\/)(?!.*\.\.)[A-Za-z0-9._/-]+$/.test(url);
+  return /^https:\/\/(?!.*\/\/)(?!.*\.\.)[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]*)*$/.test(url);
 }
 
 // Parses "app:propertyId,app:propertyId,..." into validated pairs. An app name

--- a/functions/src/project-signals.ts
+++ b/functions/src/project-signals.ts
@@ -850,12 +850,16 @@ export function isValidOwnerName(repo: string): boolean {
   return slash > 0 && slash !== repo.length - 1 && repo.indexOf("/", slash + 1) === -1;
 }
 
+// isValidGscSite — accepts `sc-domain:<host>` (no slashes) or an https URL
+// whose path has no `..` traversal component and no `//` empty segment.
 export function isValidGscSite(site: string): boolean {
-  return /^(sc-domain:[A-Za-z0-9.-]+|https:\/\/[A-Za-z0-9._/-]+)$/.test(site);
+  return /^(sc-domain:[A-Za-z0-9.-]+|https:\/\/(?!.*\/\/)(?!.*\.\.)[A-Za-z0-9._/\-]+)$/.test(site);
 }
 
+// isValidPsiUrl — https URL with no `..` traversal component and no `//`
+// empty path segment.
 export function isValidPsiUrl(url: string): boolean {
-  return /^https:\/\/[A-Za-z0-9._/-]+$/.test(url);
+  return /^https:\/\/(?!.*\/\/)(?!.*\.\.)[A-Za-z0-9._/\-]+$/.test(url);
 }
 
 // Parses "app:propertyId,app:propertyId,..." into validated pairs. An app name

--- a/functions/src/project-signals.ts
+++ b/functions/src/project-signals.ts
@@ -853,13 +853,13 @@ export function isValidOwnerName(repo: string): boolean {
 // isValidGscSite — accepts `sc-domain:<host>` (no slashes) or an https URL
 // whose path has no `..` traversal component and no `//` empty segment.
 export function isValidGscSite(site: string): boolean {
-  return /^(sc-domain:[A-Za-z0-9.-]+|https:\/\/(?!.*\/\/)(?!.*\.\.)[A-Za-z0-9._/\-]+)$/.test(site);
+  return /^(sc-domain:[A-Za-z0-9.-]+|https:\/\/(?!.*\/\/)(?!.*\.\.)[A-Za-z0-9._/-]+)$/.test(site);
 }
 
 // isValidPsiUrl — https URL with no `..` traversal component and no `//`
 // empty path segment.
 export function isValidPsiUrl(url: string): boolean {
-  return /^https:\/\/(?!.*\/\/)(?!.*\.\.)[A-Za-z0-9._/\-]+$/.test(url);
+  return /^https:\/\/(?!.*\/\/)(?!.*\.\.)[A-Za-z0-9._/-]+$/.test(url);
 }
 
 // Parses "app:propertyId,app:propertyId,..." into validated pairs. An app name

--- a/functions/test/project-signals.test.ts
+++ b/functions/test/project-signals.test.ts
@@ -348,6 +348,8 @@ describe("validation helpers", () => {
     expect(isValidGscSite("https://my-site.commons.systems/")).toBe(true);
     expect(isValidGscSite("ftp://x")).toBe(false);
     expect(isValidGscSite("sc-domain:has space")).toBe(false);
+    expect(isValidGscSite("https://foo.com/../etc")).toBe(false);
+    expect(isValidGscSite("https://foo.com//path")).toBe(false);
   });
 
   it("isValidPsiUrl", () => {
@@ -356,6 +358,8 @@ describe("validation helpers", () => {
     expect(isValidPsiUrl("https://my-site.commons.systems")).toBe(true);
     expect(isValidPsiUrl("http://commons.systems")).toBe(false);
     expect(isValidPsiUrl("https://x?q=1")).toBe(false);
+    expect(isValidPsiUrl("https://foo.com/../etc")).toBe(false);
+    expect(isValidPsiUrl("https://foo.com//path")).toBe(false);
   });
 
   it("parseGa4Pairs keeps valid pairs and drops malformed ones", () => {

--- a/office-hours/src/project-signal-seeds.ts
+++ b/office-hours/src/project-signal-seeds.ts
@@ -1,7 +1,7 @@
 import type { GithubSignals, Ga4AppSignals, GscSignals, PsiUrlSignals } from "./project-signals.js";
 
 export interface ProjectSignalSeed {
-  /** Minutes before "now" the snapshot was computed; the vite plugin converts it to computedAt at build time. */
+  /** Minutes before page-load "now" the snapshot was computed; the vite plugin embeds this as a literal and converts it to `computedAt` via `Date.now()` at module load time. */
   computedAtOffsetMin: number;
   groupId: string;
   memberEmails: string[];

--- a/office-hours/src/vite-plugin-project-signal-seed.ts
+++ b/office-hours/src/vite-plugin-project-signal-seed.ts
@@ -13,8 +13,8 @@ export function projectSignalSeedPlugin(): Plugin {
       // Strip memberEmails (a denormalized auth field holding real email
       // addresses) before serializing — it must never be baked into the
       // public JS bundle. The UI never reads it; Firestore rules gate access
-      // server-side. computedAtOffsetMin is also omitted: it is converted to
-      // computedAt at build time below.
+      // server-side. computedAtOffsetMin is also omitted: it is applied at
+      // module load time (page load) via Date.now() in the generated module below.
       // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure-omit memberEmails from the public bundle // type-safety-ok: deliberate destructure-omit to exclude memberEmails and computedAtOffsetMin from the public bundle
       const { memberEmails, computedAtOffsetMin, ...rest } = projectSignalSeeds;
       moduleCode =


### PR DESCRIPTION
Closes #2490

Resolves two review nits raised on PR #2464, consolidated into #2490 (#2491
was folded in and closed as superseded). Both touch files that only landed on
main with #2464, so they ship as a single deferred cleanup PR. Neither changes
user-visible runtime behavior.

## Nit 1 — `computedAt` comment correction

In `office-hours/src/vite-plugin-project-signal-seed.ts`, the `buildStart()`
comment claimed `computedAtOffsetMin` "is converted to computedAt at build
time". The generated module actually applies the offset via `Date.now()` at
**module load (page load)**, not build time. Comment-only change; the generated
`moduleCode` and strip logic are untouched.

## Nit 2 — tighten `isValidGscSite` / `isValidPsiUrl`

In `functions/src/project-signals.ts`, the `https://` branch of both validators
now rejects `//` empty path segments and `..` traversal components via two
negative lookaheads (`(?!.*\/\/)(?!.*\.\.)`). Defense-in-depth: the downstream
encoding already makes these inputs safe, but the validators should not accept
them. The `sc-domain:` branch and the existing character class are unchanged.
Added rejection cases for `https://foo.com/../etc` and `https://foo.com//path`
to both validator tests; existing positive cases still pass.

## Verification

- `npx vitest run --project functions --root .` — 84 passed
- `npx vitest run --project office-hours --root .` — 440 passed
- `npx tsc -p functions --noEmit` — clean
- `npx tsc -p office-hours --noEmit` — clean
