### PR TITLE
office-hours: label ProjectSignalsPanel GSC cards as top-pages estimates

### DIFF
--- a/office-hours/src/components/ProjectSignalsPanel.tsx
+++ b/office-hours/src/components/ProjectSignalsPanel.tsx
@@ -150,12 +150,12 @@ export function ProjectSignalsPanel(props: ProjectSignalsPanelProps) {
               <>
                 <Metric
                   className="project-signals-card"
-                  label="total clicks"
+                  label="top-pages clicks (est.)"
                   value={String(gsc.topPages.reduce((s, p) => s + p.clicks, 0))}
                 />
                 <Metric
                   className="project-signals-card"
-                  label="total impressions"
+                  label="top-pages impressions (est.)"
                   value={String(gsc.topPages.reduce((s, p) => s + p.impressions, 0))}
                 />
               </>

--- a/office-hours/test/ProjectSignalsPanel.test.tsx
+++ b/office-hours/test/ProjectSignalsPanel.test.tsx
@@ -159,6 +159,15 @@ describe("ProjectSignalsPanel — full snapshot", () => {
     expect(texts).toContain("420");             // top query impressions
   });
 
+  it("labels top-pages aggregate cards as estimates, not totals", () => {
+    const { container } = render(<ProjectSignalsPanel snapshot={fullSnapshot} />);
+    const texts = container.textContent ?? "";
+    expect(texts).toContain("top-pages clicks (est.)");
+    expect(texts).toContain("top-pages impressions (est.)");
+    expect(texts).not.toContain("total clicks");
+    expect(texts).not.toContain("total impressions");
+  });
+
   it("renders PSI scores for each URL", () => {
     const { container } = render(<ProjectSignalsPanel snapshot={fullSnapshot} />);
     const texts = container.textContent ?? "";


### PR DESCRIPTION
Closes #2489

## What

Relabel the two GSC aggregate cards in the office-hours `ProjectSignalsPanel`
so they read `top-pages clicks (est.)` and `top-pages impressions (est.)`
instead of `total clicks` / `total impressions`.

## Why

Issue #2489 was a review nit on PR #2464: the `signal-samples` time-series
`gscClicks`/`gscImpressions` scalars were summed from a different GSC source
(`gsc.topQueries`) than the dashboard panel displayed (`gsc.topPages`).

The data-layer half of that divergence was already resolved by sibling issue
#2488 (commit `dfbe5302`, PR #2558), which switched both reducers in
`functions/src/project-signals.ts` to sum `gsc.topPages` and updated the
corresponding tests. The stored sample and the panel now derive from the same
source.

The residual was the panel wording: the two `<Metric>` cards summed only the
top-25 `topPages` rows but were labeled `total clicks` / `total impressions`,
presenting a partial count as a true site-wide total — misleading regardless of
which source feeds it. This PR fixes that label so the cards communicate the
top-pages-estimate nature of the value.

## Changes

- `office-hours/src/components/ProjectSignalsPanel.tsx`: relabel the two
  `topPages` aggregate `<Metric>` cards.
- `office-hours/test/ProjectSignalsPanel.test.tsx`: add a regression assertion
  pinning the new wording (renders `fullSnapshot`, asserts the new label
  strings appear and the old `total clicks`/`total impressions` strings do not).

## Verification

- `npx vitest run --project office-hours --root .` — 441 tests pass.
- `npx tsc --noEmit --project office-hours` — clean.
