### PR TITLE
functions/project-signals: extract shared HTTPS_URL_RE for GSC/PSI validators

### DIFF
--- a/functions/src/project-signals.ts
+++ b/functions/src/project-signals.ts
@@ -850,18 +850,22 @@ export function isValidOwnerName(repo: string): boolean {
   return slash > 0 && slash !== repo.length - 1 && repo.indexOf("/", slash + 1) === -1;
 }
 
+// Shared https URL pattern for GSC sites and PSI URLs: an https URL whose path
+// has no `..` traversal component and no `//` empty segment. Tightening the
+// allowed character set or the lookaheads here applies to both validators.
+const HTTPS_URL_RE =
+  /^https:\/\/(?!.*\/\/)(?!.*\.\.)[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]*)*$/;
+
 // isValidGscSite — accepts `sc-domain:<host>` (no slashes) or an https URL
 // whose path has no `..` traversal component and no `//` empty segment.
 export function isValidGscSite(site: string): boolean {
-  return /^(sc-domain:[A-Za-z0-9.-]+|https:\/\/(?!.*\/\/)(?!.*\.\.)[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]*)*)$/.test(
-    site,
-  );
+  return /^sc-domain:[A-Za-z0-9.-]+$/.test(site) || HTTPS_URL_RE.test(site);
 }
 
 // isValidPsiUrl — https URL with no `..` traversal component and no `//`
 // empty path segment.
 export function isValidPsiUrl(url: string): boolean {
-  return /^https:\/\/(?!.*\/\/)(?!.*\.\.)[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]*)*$/.test(url);
+  return HTTPS_URL_RE.test(url);
 }
 
 // Parses "app:propertyId,app:propertyId,..." into validated pairs. An app name


### PR DESCRIPTION
Closes #2602

## Summary

In `functions/src/project-signals.ts`, `isValidGscSite` and `isValidPsiUrl`
encoded the *same* https URL pattern inline — `https://` with two negative
lookaheads forbidding `//` and `..`, plus the allowed character set. Any future
tightening of the pattern had to be applied in both places by hand, with no
guarantee they stayed in sync.

This extracts a single module-level `HTTPS_URL_RE` regex constant and uses it in
both validators, so the shared pattern is defined once.

## Change

- Added `HTTPS_URL_RE` immediately above `isValidGscSite`, defined before both use
  sites.
- `isValidGscSite` now tests the unchanged `sc-domain` sub-pattern OR `HTTPS_URL_RE`
  (`/^sc-domain:[A-Za-z0-9.-]+$/.test(site) || HTTPS_URL_RE.test(site)`). An
  anchored alternation `/^(A|B)$/` is exactly equivalent to `/^A$/.test(s) ||
  /^B$/.test(s)`, so this is behavior-identical to the original combined regex.
- `isValidPsiUrl` now returns `HTTPS_URL_RE.test(url)`.

The `sc-domain` sub-pattern is not duplicated anywhere, so it stays inline — only
the shared https pattern is extracted. This is a pure behavior-preserving
extraction; the allowed character set, the lookaheads, and the `sc-domain` rule
are unchanged.

## Verification

The existing `validation helpers` tests in
`functions/test/project-signals.test.ts` cover both validators with the relevant
positive/negative cases. They pass unchanged (85/85). Surfaced by the review pass
on PR #2598 and deferred out of that PR's scope.
