### PR TITLE
run-typecheck.sh: fully reconstruct HEAD after baseline swap

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/run-typecheck.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-typecheck.sh
@@ -77,7 +77,9 @@ cleanup() {
   local ws
   for ws in "${TOUCHED_WORKSPACES[@]:-}"; do
     [ -z "$ws" ] && continue
+    git -C "$REPO_ROOT" reset -q HEAD -- "$ws" 2>/dev/null || true
     git -C "$REPO_ROOT" checkout HEAD -- "$ws" 2>/dev/null || true
+    git -C "$REPO_ROOT" clean -fdq -- "$ws" 2>/dev/null || true
   done
   exit $rc
 }
@@ -114,7 +116,17 @@ for ws in "${APP_DIRS[@]}"; do
     baseline_ok=true
     (cd "$REPO_ROOT" && npx tsc --noEmit --project "$ws") >/dev/null 2>&1 || baseline_ok=false
     # Restore HEAD version immediately; don't wait for the trap.
+    # Three steps, in order: after `checkout origin/main -- "$ws"` an
+    # origin/main-only file (one HEAD deletes) is staged `A` — in the index and
+    # on disk. `reset HEAD` unstages it (making it untracked); only then can
+    # `clean -fdq` remove it from disk. `checkout HEAD` restores the tracked
+    # files HEAD does have. Order reset->checkout->clean is required: without the
+    # reset, clean is a no-op (file still tracked); without the clean, the file
+    # lingers untracked on disk. `-fd` (no `-x`) preserves gitignored files; the
+    # `$ws` scope + the line-61 dirty guard mean clean only removes swap-introduced files.
+    git -C "$REPO_ROOT" reset -q HEAD -- "$ws"
     git -C "$REPO_ROOT" checkout HEAD -- "$ws"
+    git -C "$REPO_ROOT" clean -fdq -- "$ws"
 
     if [ "$baseline_ok" = false ]; then
       echo "$ws: skipping — origin/main has pre-existing typecheck errors"

--- a/.claude/skills/dispatch-propagate/scripts/test-run-typecheck.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-run-typecheck.sh
@@ -187,4 +187,50 @@ make_shims "$REPO"
 run_sut
 assert_eq "cleanup/fail: working tree clean" "" "$(git -C "$REPO" status --porcelain)"
 
+# --- Test 6: deletion branch — origin/main has a file HEAD deletes (#2607) ---
+# The baseline swap `git checkout origin/main -- <ws>` reintroduces the
+# origin/main-only file (staged A, on disk). A single-step `git checkout HEAD
+# -- <ws>` restore cannot delete it (HEAD has no such path), leaving the file
+# resurrected. The fix restores via reset->checkout->clean. This case needs
+# inline setup because make_repo builds only src/index.ts.
+echo "Test 6: deletion branch -> deleted file not resurrected after baseline swap"
+REPO=$(mktemp -d "$TMP_ROOT/repo.XXXXXX")
+BARE=$(mktemp -d "$TMP_ROOT/bare.XXXXXX")
+git -C "$BARE" init --bare --quiet --initial-branch=main
+git -C "$REPO" init --quiet --initial-branch=main
+git -C "$REPO" config user.email "test@example.com"
+git -C "$REPO" config user.name "Test User"
+git -C "$REPO" remote add origin "$BARE"
+cat > "$REPO/package.json" <<JSON
+{
+  "name": "test-repo",
+  "private": true,
+  "workspaces": ["ws"]
+}
+JSON
+mkdir -p "$REPO/ws/src"
+cat > "$REPO/ws/package.json" <<JSON
+{ "name": "@commons-systems/ws", "version": "0.0.0", "private": true }
+JSON
+cat > "$REPO/ws/tsconfig.json" <<'JSON'
+{ "include": ["src"] }
+JSON
+# origin/main carries both index.ts and extra.ts, both clean.
+write_state clean "$REPO/ws/src/index.ts"
+write_state clean "$REPO/ws/src/extra.ts"
+git -C "$REPO" add -A
+git -C "$REPO" commit --quiet -m "baseline (index + extra)"
+git -C "$REPO" push --quiet origin main
+# feature HEAD deletes extra.ts, so HEAD's tree lacks it.
+git -C "$REPO" checkout --quiet -b feature
+git -C "$REPO" rm --quiet "ws/src/extra.ts"
+git -C "$REPO" commit --quiet -m "head (rm extra.ts)"
+git -C "$REPO" fetch --quiet origin main
+make_shims "$REPO"
+run_sut
+assert_eq "deletion: exit 0" "0" "$RC"
+assert_eq "deletion: working tree clean after run (nothing resurrected/staged)" "" "$(git -C "$REPO" status --porcelain)"
+[ ! -f "$REPO/ws/src/extra.ts" ] && _t6_extra=absent || _t6_extra=present
+assert_eq "deletion: deleted file not left on disk" "absent" "$_t6_extra"
+
 report_results


### PR DESCRIPTION
Closes #2607

## Problem

`run-typecheck.sh --app <ws>` computes a typecheck baseline by swapping a
workspace's files to the `origin/main` version (`git checkout origin/main --
"$ws"`), running `tsc`, then restoring HEAD. The restore was a single-step
`git checkout HEAD -- "$ws"`, which only rewrites files **present in HEAD's
tree**. It cannot delete a file that is in the index/worktree but **absent from
HEAD**.

So on a branch that **deletes** a file still present on `origin/main` (any
deletion-PR before merge), the `origin/main` swap reintroduced that file (staged
`A`, on disk) and the `HEAD` checkout could not remove it — leaving the deleted
file resurrected. Because `dispatch-run-verification` runs a plan's `verify`
blocks in sequence in **one** working tree, a deletion-PR's typecheck block
resurrected the deleted file and a following no-dead-reference grep block then
matched the resurrected file's own symbols and false-failed (first observed on
#2507). CI is unaffected — it runs each typecheck in an isolated per-job
checkout.

## Fix

Replace the single-step restore with a three-step **reset → checkout → clean**
sequence at both restore sites (the inline success-path restore and the cleanup
trap):

- `reset -q HEAD -- "$ws"` unstages the `origin/main`-only addition (making it
  untracked);
- `checkout HEAD -- "$ws"` restores the tracked files HEAD does have;
- `clean -fdq -- "$ws"` removes the now-untracked resurrected file from disk.

The order is required: without the `reset`, `clean` is a no-op (file still
tracked); without the `clean`, the file lingers untracked on disk. `-fd` (no
`-x`) preserves gitignored files; the `$ws` scope plus the pre-flight dirty-tree
guard mean `clean` only removes files the swap itself introduced. The inline
restore stays bare (runs under `set -e`, errors must propagate); the trap keeps
its `2>/dev/null || true` suppression (fires on every exit).

## Test

Adds `Test 6` to `test-run-typecheck.sh`: a deletion-branch scenario where
`origin/main` carries a file (`src/extra.ts`) that HEAD deletes. It asserts a
clean working tree and that the deleted file is absent from disk after the run.
Confirmed during authoring to **fail** against the pre-fix single-step restore
(file left staged `A` and on disk) and pass with the fix — proving it exercises
the bug. The whole suite is 19/19. CI picks it up automatically via
`run-unit-tests.sh`.
