### PR TITLE
print: load cloud image archives whole-file (cache-first) to fix flaky offline @cache test

### DIFF
--- a/print/src/media-cache.ts
+++ b/print/src/media-cache.ts
@@ -1,7 +1,7 @@
 /**
- * IndexedDB-backed LRU cache for print media files (PDFs, EPUBs, image archive
- * chunks). Thin wrapper around the shared `@commons-systems/idbutil/lru-blob-cache`
- * primitive. Whole files and range-request chunks share the same stores.
+ * IndexedDB-backed LRU cache for whole print media files (PDFs, EPUBs, image
+ * archives). Thin wrapper around the shared
+ * `@commons-systems/idbutil/lru-blob-cache` primitive.
  */
 import { createLruBlobCache } from "@commons-systems/idbutil/lru-blob-cache";
 
@@ -24,31 +24,10 @@ export const blobCache = cache;
 export const closeDb = cache.closeDb;
 export const clearCache = cache.clearCache;
 
-function chunkKey(storagePath: string, offset: number, length: number): string {
-  return `${storagePath}:${offset}:${length}`;
-}
-
 export function getFile(storagePath: string): Promise<ArrayBuffer | null> {
   return cache.getEntry<ArrayBuffer>(storagePath);
 }
 
 export function putFile(storagePath: string, data: ArrayBuffer): Promise<void> {
   return cache.putEntry(storagePath, data);
-}
-
-export function getChunk(
-  storagePath: string,
-  offset: number,
-  length: number,
-): Promise<Uint8Array | null> {
-  return cache.getEntry<Uint8Array>(chunkKey(storagePath, offset, length));
-}
-
-export function putChunk(
-  storagePath: string,
-  offset: number,
-  length: number,
-  data: Uint8Array,
-): Promise<void> {
-  return cache.putEntry(chunkKey(storagePath, offset, length), data);
 }

--- a/print/src/pages/view.ts
+++ b/print/src/pages/view.ts
@@ -210,7 +210,7 @@ export function resolveViewerProps(
     case "epub":
       return { item, createRenderer: (onError) => createEpubRenderer(onError), resolveSource: () => resolveFileSource(url, spath), store, uid };
     case "image-archive":
-      return { item, createRenderer: (onError) => createImageArchiveRenderer(onError, spath), resolveSource: () => Promise.resolve(url), store, uid };
+      return { item, createRenderer: (onError) => createImageArchiveRenderer(onError, spath), resolveSource: () => resolveFileSource(url, spath), store, uid };
     default: {
       const _exhaustive: never = item.mediaType;
       throw new Error(`Unsupported mediaType in viewer: ${_exhaustive}`);

--- a/print/src/pages/view.ts
+++ b/print/src/pages/view.ts
@@ -210,7 +210,7 @@ export function resolveViewerProps(
     case "epub":
       return { item, createRenderer: (onError) => createEpubRenderer(onError), resolveSource: () => resolveFileSource(url, spath), store, uid };
     case "image-archive":
-      return { item, createRenderer: (onError) => createImageArchiveRenderer(onError, spath), resolveSource: () => resolveFileSource(url, spath), store, uid };
+      return { item, createRenderer: (onError) => createImageArchiveRenderer(onError), resolveSource: () => resolveFileSource(url, spath), store, uid };
     default: {
       const _exhaustive: never = item.mediaType;
       throw new Error(`Unsupported mediaType in viewer: ${_exhaustive}`);

--- a/print/src/viewer/image-archive.ts
+++ b/print/src/viewer/image-archive.ts
@@ -1,8 +1,7 @@
-import { unzip, HTTPRangeReader } from "unzipit";
+import { unzip } from "unzipit";
 import type { ZipEntry } from "unzipit";
 import type { ContentRenderer } from "./types.js";
 import { parsePositionPage } from "./types.js";
-import { getChunk, putChunk, getFile, putFile } from "../media-cache.js";
 
 const IMAGE_EXT = /\.(jpe?g|png|gif|webp)$/i;
 const ZOOM_FACTOR = 1.2;
@@ -26,36 +25,7 @@ type PageSlot = {
   resolvedUrl: string | null;
 };
 
-export class CachedRangeReader {
-  private inner: HTTPRangeReader;
-  private storagePath: string;
-
-  constructor(url: string, storagePath: string) {
-    this.inner = new HTTPRangeReader(url);
-    this.storagePath = storagePath;
-  }
-
-  async getLength(): Promise<number> {
-    return this.inner.getLength();
-  }
-
-  async read(offset: number, length: number): Promise<Uint8Array> {
-    try {
-      const cached = await getChunk(this.storagePath, offset, length);
-      if (cached) return cached;
-    } catch (err) {
-      reportError(new Error("Chunk cache lookup failed, fetching from network", { cause: err }));
-    }
-    const data: Uint8Array = await this.inner.read(offset, length);
-    // Cache write is best-effort; failure does not affect the current read
-    putChunk(this.storagePath, offset, length, data).catch((err) => {
-      reportError(new Error("Failed to cache archive chunk", { cause: err }));
-    });
-    return data;
-  }
-}
-
-export function createImageArchiveRenderer(onError?: (err: unknown) => void, storagePath?: string): ContentRenderer {
+export function createImageArchiveRenderer(onError?: (err: unknown) => void): ContentRenderer {
   // onError used for background prefetch errors that cannot propagate as exceptions.
   // init and goToPage propagate errors via rejection; zoom operations throw synchronously.
   let pages: PageSlot[] = [];
@@ -122,51 +92,9 @@ export function createImageArchiveRenderer(onError?: (err: unknown) => void, sto
     });
   }
 
-  async function fetchArchiveBuffer(url: string): Promise<ArrayBuffer> {
-    if (storagePath) {
-      try {
-        const cached = await getFile(storagePath);
-        if (cached) return cached;
-      } catch (err) {
-        reportError(new Error("Cache lookup failed for archive fallback", { cause: err }));
-      }
-    }
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`Failed to fetch archive: ${res.status}`);
-    const buf = await res.arrayBuffer();
-    if (storagePath) {
-      // Cache write is best-effort; failure does not affect the current view
-      putFile(storagePath, buf).catch((err) => {
-        reportError(new Error("Failed to cache archive download", { cause: err }));
-      });
-    }
-    return buf;
-  }
-
   return {
     async init(container: HTMLElement, source: string | ArrayBuffer, initialPosition?: string): Promise<void> {
-      let entries: Record<string, ZipEntry>;
-      if (typeof source !== "string") {
-        ({ entries } = await unzip(source));
-      } else {
-        try {
-          const reader = storagePath
-            ? new CachedRangeReader(source, storagePath)
-            : new HTTPRangeReader(source);
-          ({ entries } = await unzip(reader));
-        } catch (err) {
-          reportError(new Error("Range-based archive loading failed, falling back to full download", { cause: err }));
-          const buf = await fetchArchiveBuffer(source);
-          try {
-            ({ entries } = await unzip(buf));
-          } catch (unzipErr) {
-            throw new Error(
-              `Failed to decompress archive from ${source} (${buf.byteLength} bytes)`,
-              { cause: unzipErr },
-            );
-          }
-        }
-      }
+      const { entries } = await unzip(source);
 
       const imageEntries = Object.keys(entries)
         .filter((path) => IMAGE_EXT.test(path) && !path.startsWith("__MACOSX/"))

--- a/print/test/media-cache.test.ts
+++ b/print/test/media-cache.test.ts
@@ -4,8 +4,6 @@ import {
   MAX_CACHE_BYTES,
   getFile,
   putFile,
-  getChunk,
-  putChunk,
   clearCache,
   closeDb,
 } from "../src/media-cache";
@@ -51,58 +49,6 @@ describe("putFile / getFile round-trip", () => {
 
     const result = await getFile("images/photo.jpg");
     expect(new Uint8Array(result!)).toEqual(new Uint8Array([50, 60, 70, 80]));
-  });
-});
-
-describe("putChunk / getChunk round-trip", () => {
-  it("stores and retrieves a chunk", async () => {
-    const data = new Uint8Array([10, 20, 30, 40, 50]);
-    await putChunk("archive.zip", 0, 5, data);
-
-    const result = await getChunk("archive.zip", 0, 5);
-    expect(result).not.toBeNull();
-    expect(result!).toEqual(data);
-  });
-
-  it("returns null for a chunk cache miss", async () => {
-    const result = await getChunk("archive.zip", 0, 100);
-    expect(result).toBeNull();
-  });
-
-  it("stores chunks with different offsets independently", async () => {
-    const chunk1 = new Uint8Array([1, 2, 3]);
-    const chunk2 = new Uint8Array([4, 5, 6]);
-
-    await putChunk("archive.zip", 0, 3, chunk1);
-    await putChunk("archive.zip", 3, 3, chunk2);
-
-    const result1 = await getChunk("archive.zip", 0, 3);
-    const result2 = await getChunk("archive.zip", 3, 3);
-
-    expect(result1!).toEqual(chunk1);
-    expect(result2!).toEqual(chunk2);
-  });
-
-  it("stores chunks with different lengths independently", async () => {
-    const chunk1 = new Uint8Array([1, 2]);
-    const chunk2 = new Uint8Array([1, 2, 3, 4]);
-
-    await putChunk("archive.zip", 0, 2, chunk1);
-    await putChunk("archive.zip", 0, 4, chunk2);
-
-    const result1 = await getChunk("archive.zip", 0, 2);
-    const result2 = await getChunk("archive.zip", 0, 4);
-
-    expect(result1!).toEqual(chunk1);
-    expect(result2!).toEqual(chunk2);
-  });
-
-  it("returns null when path matches but offset differs", async () => {
-    const data = new Uint8Array([1, 2, 3]);
-    await putChunk("archive.zip", 0, 3, data);
-
-    const result = await getChunk("archive.zip", 10, 3);
-    expect(result).toBeNull();
   });
 });
 
@@ -168,26 +114,6 @@ describe("LRU eviction", () => {
     vi.restoreAllMocks();
   });
 
-  it("evicts the oldest-accessed chunk entry when cache exceeds MAX_CACHE_BYTES", { timeout: 30_000 }, async () => {
-    const size = 300 * 1024 * 1024;
-    const chunk1 = new Uint8Array(size);
-    const chunk2 = new Uint8Array(size);
-
-    vi.spyOn(Date, "now").mockReturnValue(1000);
-    await putChunk("file.bin", 0, size, chunk1);
-
-    vi.mocked(Date.now).mockReturnValue(2000);
-    await putChunk("file.bin", size, size, chunk2);
-
-    const result1 = await getChunk("file.bin", 0, size);
-    const result2 = await getChunk("file.bin", size, size);
-
-    expect(result1).toBeNull();
-    expect(result2).not.toBeNull();
-
-    vi.restoreAllMocks();
-  });
-
   it("evicts multiple entries if needed to fit incoming data", { timeout: 30_000 }, async () => {
     const size = 200 * 1024 * 1024;
     const bufA = new ArrayBuffer(size);
@@ -229,13 +155,11 @@ describe("clearCache", () => {
   it("removes all file entries", async () => {
     await putFile("a.bin", new ArrayBuffer(32));
     await putFile("b.bin", new ArrayBuffer(32));
-    await putChunk("c.bin", 0, 16, new Uint8Array(16));
 
     await clearCache();
 
     expect(await getFile("a.bin")).toBeNull();
     expect(await getFile("b.bin")).toBeNull();
-    expect(await getChunk("c.bin", 0, 16)).toBeNull();
   });
 });
 

--- a/print/test/pages/view.test.ts
+++ b/print/test/pages/view.test.ts
@@ -200,7 +200,7 @@ describe("resolveViewerProps", () => {
     expect(createEpubRenderer).toHaveBeenCalled();
   });
 
-  it("cloud image-archive: image-archive renderer factory built with the storagePath", async () => {
+  it("cloud image-archive: routes resolveSource through resolveFileSource (cache-first)", async () => {
     const item = makeMediaItem({ mediaType: "image-archive", storagePath: "media/archive.cbz" });
     const cached = new ArrayBuffer(16);
     vi.mocked(getFile).mockResolvedValueOnce(cached);
@@ -208,7 +208,7 @@ describe("resolveViewerProps", () => {
     const props = resolveViewerProps(item, false, "https://example.com/archive", null);
 
     props.createRenderer(() => {});
-    expect(createImageArchiveRenderer).toHaveBeenCalledWith(expect.any(Function), "media/archive.cbz");
+    expect(createImageArchiveRenderer).toHaveBeenCalledWith(expect.any(Function));
     // image-archive routes through resolveFileSource: cache-first whole-file load.
     await expect(props.resolveSource()).resolves.toBe(cached);
     expect(getFile).toHaveBeenCalledWith("media/archive.cbz");
@@ -441,7 +441,7 @@ describe("renderView", () => {
 
       const props = readyProps(getViewFrame());
       props.createRenderer(() => {});
-      expect(createImageArchiveRenderer).toHaveBeenCalledWith(expect.any(Function), "media/archive.cbz");
+      expect(createImageArchiveRenderer).toHaveBeenCalledWith(expect.any(Function));
     });
   });
 });

--- a/print/test/pages/view.test.ts
+++ b/print/test/pages/view.test.ts
@@ -71,6 +71,7 @@ import type { MediaItem } from "../../src/types";
 import { getMediaDownloadUrl } from "../../src/storage";
 import { createImageArchiveRenderer } from "../../src/viewer/image-archive";
 import { createEpubRenderer } from "../../src/viewer/epub";
+import { getFile } from "../../src/media-cache";
 
 function makeMediaItem(overrides: Partial<MediaItem> = {}): MediaItem {
   return {
@@ -199,15 +200,18 @@ describe("resolveViewerProps", () => {
     expect(createEpubRenderer).toHaveBeenCalled();
   });
 
-  it("cloud image-archive: image-archive renderer factory built with the storagePath", () => {
+  it("cloud image-archive: image-archive renderer factory built with the storagePath", async () => {
     const item = makeMediaItem({ mediaType: "image-archive", storagePath: "media/archive.cbz" });
+    const cached = new ArrayBuffer(16);
+    vi.mocked(getFile).mockResolvedValueOnce(cached);
 
     const props = resolveViewerProps(item, false, "https://example.com/archive", null);
 
     props.createRenderer(() => {});
     expect(createImageArchiveRenderer).toHaveBeenCalledWith(expect.any(Function), "media/archive.cbz");
-    // image-archive resolves to the bare URL.
-    return expect(props.resolveSource()).resolves.toBe("https://example.com/archive");
+    // image-archive routes through resolveFileSource: cache-first whole-file load.
+    await expect(props.resolveSource()).resolves.toBe(cached);
+    expect(getFile).toHaveBeenCalledWith("media/archive.cbz");
   });
 
   it("local resolveSource: rejects and reports once when the file is gone", async () => {

--- a/print/test/viewer/image-archive.test.ts
+++ b/print/test/viewer/image-archive.test.ts
@@ -53,14 +53,6 @@ const mockUnzip = vi.fn<(src: unknown) => Promise<ZipInfo>>();
 
 vi.mock("unzipit", () => ({
   unzip: (...args: unknown[]) => mockUnzip(...args),
-  HTTPRangeReader: vi.fn(),
-}));
-
-vi.mock("../../src/media-cache.js", () => ({
-  getChunk: vi.fn().mockResolvedValue(null),
-  putChunk: vi.fn().mockResolvedValue(undefined),
-  getFile: vi.fn().mockResolvedValue(null),
-  putFile: vi.fn().mockResolvedValue(undefined),
 }));
 
 function mockEntries(files: Record<string, Uint8Array>) {
@@ -69,18 +61,15 @@ function mockEntries(files: Record<string, Uint8Array>) {
   return result;
 }
 
-/** Re-apply global stubs after tests that call vi.stubGlobal("fetch", ...). */
-function restoreGlobalStubs() {
-  vi.unstubAllGlobals();
-  stubBrowserGlobals();
-}
+// The renderer now always receives a whole ArrayBuffer; unzip is mocked, so the
+// buffer contents are inert in tests.
+const ARCHIVE_BUF = new ArrayBuffer(0);
 
 function makeContainer(): HTMLElement {
   return document.createElement("div");
 }
 
-import { createImageArchiveRenderer, CachedRangeReader } from "../../src/viewer/image-archive.js";
-import { getChunk, putChunk, getFile, putFile } from "../../src/media-cache";
+import { createImageArchiveRenderer } from "../../src/viewer/image-archive.js";
 
 describe("createImageArchiveRenderer", () => {
   beforeEach(() => {
@@ -99,7 +88,7 @@ describe("createImageArchiveRenderer", () => {
     const parent = document.createElement("div");
     parent.appendChild(container);
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
     const img = container.querySelector("img") as HTMLImageElement;
     Object.defineProperty(img, "clientWidth", { value: 400, configurable: true });
     Object.defineProperty(img, "clientHeight", { value: 300, configurable: true });
@@ -114,7 +103,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     expect(renderer.pageCount).toBe(2);
     expect(renderer.currentPage).toBe(1);
@@ -130,7 +119,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     expect(container.querySelector("img")).not.toBeNull();
   });
@@ -140,7 +129,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     const img = container.querySelector("img") as HTMLImageElement;
     expect(img.alt).toBe("Page 1");
@@ -154,7 +143,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     const img = container.querySelector("img") as HTMLImageElement;
     const firstSrc = img.src;
@@ -174,7 +163,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     const img = container.querySelector("img") as HTMLImageElement;
     const firstSrc = img.src;
@@ -194,7 +183,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     await renderer.goToPage(2);
     await renderer.goToPosition("99");
@@ -209,7 +198,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     await renderer.next();
     expect(renderer.currentPage).toBe(2);
@@ -225,7 +214,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     await renderer.next();
     await renderer.prev();
@@ -242,7 +231,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     expect(renderer.positionLabel).toBe("Page 1 / 2");
     await renderer.next();
@@ -258,7 +247,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     expect(renderer.pageCount).toBe(1);
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
@@ -274,7 +263,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     expect(renderer.pageCount).toBe(4);
   });
@@ -288,7 +277,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     expect(renderer.currentPage).toBe(1);
     await renderer.goToPage(3);
@@ -305,7 +294,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     expect(container.querySelector("img")).not.toBeNull();
 
@@ -324,7 +313,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     await renderer.goToPage(0);
     expect(renderer.currentPage).toBe(1);
@@ -341,7 +330,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     expect(renderer.position).toBe("1");
     await renderer.goToPage(2);
@@ -357,7 +346,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip", "3");
+    await renderer.init(container, ARCHIVE_BUF, "3");
 
     expect(renderer.currentPage).toBe(3);
     expect(renderer.position).toBe("3");
@@ -372,7 +361,7 @@ describe("createImageArchiveRenderer", () => {
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
 
-    await expect(renderer.init(container, "https://example.com/archive.zip")).rejects.toThrow(
+    await expect(renderer.init(container, ARCHIVE_BUF)).rejects.toThrow(
       "No images found in archive",
     );
   });
@@ -386,7 +375,7 @@ describe("createImageArchiveRenderer", () => {
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
 
-    const initPromise = renderer.init(container, "https://example.com/archive.zip");
+    const initPromise = renderer.init(container, ARCHIVE_BUF);
     renderer.destroy();
 
     resolveUnzip(makeMockEntries({ "image-001.png": new Uint8Array([1]) }));
@@ -414,7 +403,7 @@ describe("createImageArchiveRenderer", () => {
     parent.appendChild(container);
     const renderer = createImageArchiveRenderer();
 
-    const initPromise = renderer.init(container, "https://example.com/archive.zip");
+    const initPromise = renderer.init(container, ARCHIVE_BUF);
     renderer.destroy();
 
     resolveBlob(new Blob([new Uint8Array([1])]));
@@ -432,7 +421,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
     renderer.destroy();
 
     await expect(renderer.goToPage(1)).rejects.toThrow("goToPage called after renderer was destroyed");
@@ -451,7 +440,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     const goToPromise = renderer.goToPage(2);
     renderer.destroy();
@@ -477,7 +466,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     const img = container.querySelector("img") as HTMLImageElement;
 
@@ -503,59 +492,9 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip", "99");
+    await renderer.init(container, ARCHIVE_BUF, "99");
 
     expect(renderer.currentPage).toBe(1);
-  });
-
-  it("uses HTTPRangeReader with the provided URL", async () => {
-    mockEntries({ "image-001.png": new Uint8Array([1]) });
-    const { HTTPRangeReader } = await import("unzipit");
-
-    const container = makeContainer();
-    const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
-
-    expect(HTTPRangeReader).toHaveBeenCalledWith("https://example.com/archive.zip");
-  });
-
-  it("falls back to full fetch when HTTPRangeReader fails", async () => {
-    const fallbackEntries = makeMockEntries({ "image-001.png": new Uint8Array([1]) });
-    // First call (HTTPRangeReader path) rejects; second call (ArrayBuffer path) resolves
-    mockUnzip
-      .mockRejectedValueOnce(new Error("Range not supported"))
-      .mockResolvedValueOnce(fallbackEntries as unknown as ZipInfo);
-
-    const mockArrayBuffer = new ArrayBuffer(8);
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true,
-      arrayBuffer: vi.fn().mockResolvedValue(mockArrayBuffer),
-    }));
-
-    const container = makeContainer();
-    const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
-
-    expect(renderer.pageCount).toBe(1);
-    expect(container.querySelector("img")).not.toBeNull();
-    expect(fetch).toHaveBeenCalledWith("https://example.com/archive.zip");
-    expect(mockUnzip).toHaveBeenCalledTimes(2);
-    expect(mockUnzip).toHaveBeenLastCalledWith(mockArrayBuffer);
-
-    restoreGlobalStubs();
-  });
-
-  it("throws on non-ok HTTP response in fallback path", async () => {
-    mockUnzip.mockRejectedValueOnce(new Error("Range not supported"));
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
-
-    const container = makeContainer();
-    const renderer = createImageArchiveRenderer();
-    await expect(renderer.init(container, "https://example.com/archive.zip")).rejects.toThrow(
-      "Failed to fetch archive: 404",
-    );
-
-    restoreGlobalStubs();
   });
 
   it("prefetches next page after init", async () => {
@@ -567,7 +506,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     // Page 1 fetched for display, page 2 prefetched
     expect(result.entries["image-001.png"]!.blob).toHaveBeenCalledTimes(1);
@@ -584,7 +523,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     await renderer.goToPage(2);
 
@@ -600,7 +539,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     // Go to page 2 (already prefetched), then back to page 1 (already cached)
     await renderer.goToPage(2);
@@ -622,7 +561,7 @@ describe("createImageArchiveRenderer", () => {
 
     const container = makeContainer();
     const renderer = createImageArchiveRenderer(onError);
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     await vi.waitFor(() => expect(onError).toHaveBeenCalledWith(prefetchError));
   });
@@ -639,7 +578,7 @@ describe("createImageArchiveRenderer", () => {
     const reportSpy = vi.spyOn(globalThis, "reportError").mockImplementation(() => {});
     const container = makeContainer();
     const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     await vi.waitFor(() => expect(reportSpy).toHaveBeenCalledWith(
       expect.objectContaining({ message: "Image prefetch failed for page 2" }),
@@ -661,7 +600,7 @@ describe("createImageArchiveRenderer", () => {
     const onError = vi.fn();
     const container = makeContainer();
     const renderer = createImageArchiveRenderer(onError);
-    await renderer.init(container, "https://example.com/archive.zip");
+    await renderer.init(container, ARCHIVE_BUF);
 
     // Wait for prefetch error
     await vi.waitFor(() => expect(onError).toHaveBeenCalledWith(prefetchError));
@@ -847,74 +786,6 @@ describe("createImageArchiveRenderer", () => {
     expect(renderer.isZoomed).toBe(false);
   });
 
-  it("uses CachedRangeReader when storagePath is provided", async () => {
-    mockEntries({ "image-001.png": new Uint8Array([1]) });
-    const { HTTPRangeReader } = await import("unzipit");
-
-    const container = makeContainer();
-    const renderer = createImageArchiveRenderer(undefined, "some/storage/path");
-    await renderer.init(container, "https://example.com/archive.zip");
-
-    // CachedRangeReader wraps HTTPRangeReader, so HTTPRangeReader is still constructed
-    expect(HTTPRangeReader).toHaveBeenCalledWith("https://example.com/archive.zip");
-    // unzip receives a CachedRangeReader (not an HTTPRangeReader mock directly)
-    const readerArg = mockUnzip.mock.calls[0]![0];
-    expect(readerArg).toBeInstanceOf(CachedRangeReader);
-  });
-
-  it("uses regular HTTPRangeReader when storagePath is not provided", async () => {
-    mockEntries({ "image-001.png": new Uint8Array([1]) });
-    vi.mocked(getChunk).mockClear();
-
-    const container = makeContainer();
-    const renderer = createImageArchiveRenderer();
-    await renderer.init(container, "https://example.com/archive.zip");
-
-    expect(getChunk).not.toHaveBeenCalled();
-  });
-
-  it("fallback with storagePath checks getFile cache first", async () => {
-    const cachedBuffer = new ArrayBuffer(8);
-    const fallbackEntries = makeMockEntries({ "image-001.png": new Uint8Array([1]) });
-    mockUnzip
-      .mockRejectedValueOnce(new Error("Range not supported"))
-      .mockResolvedValueOnce(fallbackEntries as unknown as ZipInfo);
-    vi.mocked(getFile).mockResolvedValueOnce(cachedBuffer);
-
-    const container = makeContainer();
-    const renderer = createImageArchiveRenderer(undefined, "some/storage/path");
-    await renderer.init(container, "https://example.com/archive.zip");
-
-    expect(getFile).toHaveBeenCalledWith("some/storage/path");
-    expect(renderer.pageCount).toBe(1);
-    expect(mockUnzip).toHaveBeenLastCalledWith(cachedBuffer);
-  });
-
-  it("fallback with storagePath calls putFile after fetch when not in cache", async () => {
-    const fallbackEntries = makeMockEntries({ "image-001.png": new Uint8Array([1]) });
-    mockUnzip
-      .mockRejectedValueOnce(new Error("Range not supported"))
-      .mockResolvedValueOnce(fallbackEntries as unknown as ZipInfo);
-    vi.mocked(getFile).mockResolvedValueOnce(null);
-
-    const mockArrayBuffer = new ArrayBuffer(8);
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true,
-      arrayBuffer: vi.fn().mockResolvedValue(mockArrayBuffer),
-    }));
-
-    const container = makeContainer();
-    const renderer = createImageArchiveRenderer(undefined, "some/storage/path");
-    await renderer.init(container, "https://example.com/archive.zip");
-
-    expect(getFile).toHaveBeenCalledWith("some/storage/path");
-    expect(fetch).toHaveBeenCalledWith("https://example.com/archive.zip");
-    expect(putFile).toHaveBeenCalledWith("some/storage/path", mockArrayBuffer);
-    expect(renderer.pageCount).toBe(1);
-
-    restoreGlobalStubs();
-  });
-
   describe("renderPageInto", () => {
     it("creates an img element in the target container with correct src and alt", async () => {
       mockEntries({
@@ -924,7 +795,7 @@ describe("createImageArchiveRenderer", () => {
 
       const container = makeContainer();
       const renderer = createImageArchiveRenderer();
-      await renderer.init(container, "https://example.com/archive.zip");
+      await renderer.init(container, ARCHIVE_BUF);
 
       const target = makeContainer();
       await renderer.renderPageInto(2, target);
@@ -944,7 +815,7 @@ describe("createImageArchiveRenderer", () => {
 
       const container = makeContainer();
       const renderer = createImageArchiveRenderer();
-      await renderer.init(container, "https://example.com/archive.zip");
+      await renderer.init(container, ARCHIVE_BUF);
 
       // After init: page 1 fetched, page 2 prefetched
       expect(result.entries["image-003.png"]!.blob).not.toHaveBeenCalled();
@@ -964,7 +835,7 @@ describe("createImageArchiveRenderer", () => {
 
       const container = makeContainer();
       const renderer = createImageArchiveRenderer();
-      await renderer.init(container, "https://example.com/archive.zip");
+      await renderer.init(container, ARCHIVE_BUF);
 
       const target = makeContainer();
       await renderer.renderPageInto(0, target);
@@ -993,7 +864,7 @@ describe("createImageArchiveRenderer", () => {
 
       const container = makeContainer();
       const renderer = createImageArchiveRenderer();
-      await renderer.init(container, "https://example.com/archive.zip");
+      await renderer.init(container, ARCHIVE_BUF);
 
       const target = makeContainer();
       const renderPromise = renderer.renderPageInto(2, target);
@@ -1023,7 +894,7 @@ describe("createImageArchiveRenderer", () => {
 
       const container = makeContainer();
       const renderer = createImageArchiveRenderer();
-      await renderer.init(container, "https://example.com/archive.zip");
+      await renderer.init(container, ARCHIVE_BUF);
 
       const target = makeContainer();
       const stale = renderer.renderPageInto(2, target);


### PR DESCRIPTION
Closes #2631

## Why

`print/e2e/viewer.spec.ts:483` (`viewer image archive loads from cache on second view @cache`) flakes in CI. The issue's stated hypothesis — a debounced position-save IndexedDB flush race — is disproven: for an anonymous user the position store is synchronous `localStorage`, and PR #1283's teardown `flushSave` already makes the position half reliable. Position is not the flake.

The real flake is the **image-archive offline load path**. Cloud image-archive was the one media type that did **not** route through whole-file caching. `view.ts` handed the renderer a bare URL string, which drove a range path (`CachedRangeReader` → `unzip(reader)`). `unzip` first calls `getLength()`, an **uncached** network `HEAD`. On the blocked offline second visit that HEAD aborts; the fallback then misses cache (the range path only ever wrote per-chunk entries via `putChunk`, never `putFile`), so the follow-up `fetch` aborts too and the viewer never renders — the test times out. It was intermittent because the blocked request was sometimes served from the browser HTTP cache, and the fire-and-forget chunk writes were not reliably durable before navigate-away.

## What

Route cloud image-archive through `resolveFileSource`, exactly like PDF and EPUB, and remove the now-dead range machinery.

- **Unit 1 — deflake.** `view.ts` image-archive case: `resolveSource: () => Promise.resolve(url)` → `() => resolveFileSource(url, spath)`. The offline second visit is now `getFile` → `unzip(buffer)`: both in-memory, zero network, no `getLength` HEAD and no per-chunk durability race. Flipped the `view.test.ts` canary to assert cache routing.
- **Unit 2 — strip dead machinery.** Removed `CachedRangeReader`, `fetchArchiveBuffer`, the string/range `init` branch, and the `storagePath` param from `createImageArchiveRenderer`. `init` now unconditionally `unzip(source)`. The renderer already had a whole-buffer branch, so this adds no new capability. Converted/deleted the tests for the removed paths.
- **Unit 3 — cleanup.** Removed the now-orphaned `getChunk` / `putChunk` / `chunkKey` from `media-cache.ts` (no remaining callers in `print/`) and their dedicated tests; kept the live whole-file `getFile` / `putFile` path and eviction coverage.

## Tradeoff

Whole-file load means a large `.cbz` fully downloads before first paint, losing the range reader's lazy-loading — matching existing PDF/EPUB behavior. The renderer already eagerly prefetches the next page, so the lazy-load benefit was largely unrealized, and offline reliability is the property the `@cache` test encodes. Per-chunk IndexedDB entries written by old clients become orphaned but harmless (nothing reads them; the LRU cache evicts on its own) — no migration needed.

## Verification

- `npx vitest run --project print --root .` — 578 passed, 1 skipped.
- `run-typecheck.sh --app print` — passed (proves the `createImageArchiveRenderer` signature cascade and no dangling references to the removed symbols).

The Playwright acceptance test cannot run locally (browser-version mismatch; CI is authoritative), and one green CI run cannot prove de-flaking. **Acceptance criterion 3 (no recurrence)** should be tracked as an observation over subsequent CI runs of `print/e2e/viewer.spec.ts:483`, not a one-shot check.

No Playwright retries added, no test weakened or skipped — the deleted tests cover genuinely-removed code paths.
