### PR TITLE
nix: integrate home-manager into the WSL NixOS config via flake-based nixosConfigurations

### DIFF
--- a/.github/scripts/build-nixos-config.sh
+++ b/.github/scripts/build-nixos-config.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT=$(git rev-parse --show-toplevel)
+echo "=== nix build .#nixosConfigurations.nixos.config.system.build.toplevel ==="
+nix build "$REPO_ROOT#nixosConfigurations.nixos.config.system.build.toplevel" \
+  --no-link --print-build-logs
+echo "PASS: nixosConfigurations.nixos build"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -316,3 +316,30 @@ jobs:
       - name: Build darwinConfigurations.default
         if: steps.changes.outputs.nix == 'true'
         run: .github/scripts/build-darwin-config.sh
+
+  nixos-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # No CI runtime baseline yet: the Build step has executed 0 times (it is
+    # gated on nix-file changes and every run so far has skipped it). 30 min is
+    # a conservative runaway guard vs GitHub's 6h default; tighten to ~2x the
+    # observed p95 once 3-5 real warm-cache runs accumulate. (#2636)
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+      - name: Detect changed file categories
+        id: changes
+        run: .claude/skills/dispatch-propagate/scripts/detect-changes.sh
+      - name: Install nix (if nix files changed)
+        if: steps.changes.outputs.nix == 'true'
+        uses: DeterminateSystems/nix-installer-action@d96bc962e61b3049ce8128d03d57a1144fa96539 # main
+        with:
+          extra-conf: |
+            extra-substituters = https://claude-code.cachix.org
+            extra-trusted-public-keys = claude-code.cachix.org-1:YeXf2aNu7UTX8Vwrze0za1WEDS+4DuI2kVeWEE4fsRk=
+      - name: Build nixosConfigurations.nixos
+        if: steps.changes.outputs.nix == 'true'
+        run: .github/scripts/build-nixos-config.sh

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ run-all-cleanup-preview.sh <pr-number>
 - **Project Management** (github): Created a [project](https://github.com/users/natb1/projects/2).
 - **Version Control** (git): Created a repo.
 - **Agentic Coding Tools** (Claude Code): `nix flake update && home-manager switch --flake .#default --impure`
+  (Generic forker path — plain Linux/macOS without NixOS-WSL or nix-darwin. The author's WSL NixOS box activates home-manager atomically via `sudo nixos-rebuild switch` through `nixosConfigurations.nixos`; macOS via `darwin-rebuild switch` through `darwinConfigurations.default`.)
 - **Infrastructure** (Firebase): Hosting and storage.
 
 ## Where to go next

--- a/flake.lock
+++ b/flake.lock
@@ -42,6 +42,22 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -81,6 +97,27 @@
         "type": "github"
       }
     },
+    "nixos-wsl": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781182279,
+        "narHash": "sha256-V5EQQbDnmdiXGQXrEF1PEL7QYsFqfH8N1E89Z5ONwFk=",
+        "owner": "nix-community",
+        "repo": "NixOS-WSL",
+        "rev": "5675822ba756e6e56f8f6a5a76e90e0da2ece94d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NixOS-WSL",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1782467914,
@@ -102,6 +139,7 @@
         "claude-code-nix": "claude-code-nix",
         "darwin": "darwin",
         "home-manager": "home-manager",
+        "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,13 @@
       url = "github:nix-darwin/nix-darwin/master";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nixos-wsl = {
+      url = "github:nix-community/NixOS-WSL";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = inputs@{ nixpkgs, home-manager, claude-code-nix, darwin, ... }:
+  outputs = inputs@{ nixpkgs, home-manager, claude-code-nix, darwin, nixos-wsl, ... }:
     let
       # direnv 2.37.1 checkPhase hangs when built from source; skip tests.
       direnvSkipTestsOverlay = final: prev: {
@@ -94,11 +98,12 @@
       # `error: attribute 'claude-code' missing in set` at eval time. Apply
       # claude-code-nix.overlays.default to nixpkgs before using this module.
       #
-      # nixosModules is intentionally NOT exported: nix/nixos/configuration.nix
-      # is machine-specific (imports <nixos-wsl/modules> via the nixos-wsl
-      # channel, which is unresolvable under pure flake eval, and hardcodes
-      # wsl.* / the n8 user), so it is not a reusable module. The real machine
-      # consumes it through the /etc/nixos stub + channel, not this flake.
+      # The WSL box is now built in-flake as nixosConfigurations.nixos (below),
+      # consuming nixos-wsl as a flake input rather than the channel — so the old
+      # channel-unresolvability caveat is gone. But a *reusable*
+      # nixosModules.default export is still NOT provided:
+      # nix/nixos/configuration.nix hardcodes wsl.* / the n8 user, and exporting a
+      # reusable, identity-parameterized module is deferred to epic #2446 / #2449.
       homeManagerModules = { default = ./nix/home/default.nix; };
       darwinModules      = { default = ./nix/darwin/default.nix; };
 
@@ -174,6 +179,50 @@
           }
         ];
       };
+
+      nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {
+        specialArgs = { inherit inputs; };
+        modules = [
+          nixos-wsl.nixosModules.default
+          ./nix/nixos/configuration.nix
+          home-manager.nixosModules.home-manager
+          {
+            nixpkgs.hostPlatform = "x86_64-linux";
+
+            # System nixpkgs config — shared with home-manager via useGlobalPkgs.
+            # Mirrors mkHomeConfig so the reused nix/home/default.nix (which pulls
+            # the unfree pkgs.claude-code from the claude-code-nix overlay) builds.
+            nixpkgs.overlays = [ claude-code-nix.overlays.default direnvSkipTestsOverlay ];
+            nixpkgs.config.allowUnfreePredicate =
+              pkg: builtins.elem (nixpkgs.lib.getName pkg) [ "claude-code" ];
+
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.extraSpecialArgs = { inherit inputs; };
+
+            # backupFileExtension makes the clobber-abort impossible: when a switch
+            # meets an unmanaged file it wants to own, it backs it up (.backup)
+            # instead of aborting mid-activation. This option exists only in the
+            # NixOS/nix-darwin module, not standalone home-manager.
+            home-manager.backupFileExtension = "backup";
+
+            home-manager.users.n8 = { lib, ... }: {
+              imports = [ homeManagerModules.default ];
+
+              # nix/home/default.nix derives username/homeDirectory impurely via
+              # builtins.getEnv (fine for the standalone --impure homeConfigurations,
+              # but it would throw under the PURE acceptance eval). Force them so the
+              # getEnv/throw thunks are never evaluated and pure eval passes.
+              home.username = lib.mkForce "n8";
+              home.homeDirectory = lib.mkForce "/home/n8";
+
+              # Contrast with darwin: do NOT disable programs.wezterm here. Linux/WSL
+              # wants wezterm and its mux-server user service; the darwin config
+              # force-disables it only because macOS is out of scope there.
+            };
+          }
+        ];
+      };
     in
-    systemOutputs // { inherit homeConfigurations darwinConfigurations homeManagerModules darwinModules; };
+    systemOutputs // { inherit homeConfigurations darwinConfigurations nixosConfigurations homeManagerModules darwinModules; };
 }

--- a/nix/apps/home-manager-setup.nix
+++ b/nix/apps/home-manager-setup.nix
@@ -3,9 +3,17 @@
 pkgs.writeShellScriptBin "home-manager-setup" ''
   set -euo pipefail
 
+  # Generic forker bootstrap: for plain Linux/macOS without NixOS-WSL or nix-darwin.
+  # The author's WSL NixOS box uses `sudo nixos-rebuild switch` (nixosConfigurations.nixos)
+  # and macOS uses `darwin-rebuild switch` (darwinConfigurations.default) instead.
+
   # Detect the current system
   SYSTEM="${pkgs.stdenv.hostPlatform.system}"
 
+  echo "home-manager-setup: generic forker bootstrap (plain Linux/macOS)"
+  echo "  NixOS-WSL users: use 'sudo nixos-rebuild switch' instead."
+  echo "  nix-darwin users: use 'darwin-rebuild switch' instead."
+  echo ""
   echo "Detected system: $SYSTEM"
   echo ""
 

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -2,7 +2,19 @@
 #
 # Manages user-specific configuration files declaratively.
 #
-# To activate this configuration:
+# The author's own machines activate this module through their integrated host
+# configs rather than via standalone home-manager switch:
+#   - WSL NixOS box: `sudo nixos-rebuild switch` builds `nixosConfigurations.nixos`,
+#     which integrates home-manager as a NixOS module.
+#   - macOS box: `darwin-rebuild switch` builds `darwinConfigurations.default`,
+#     which integrates home-manager via nix-darwin.
+# On those integrated paths, the NixOS/nix-darwin module sets
+# `home-manager.backupFileExtension` automatically.
+#
+# The standalone instructions below are for the generic forker path — plain
+# Linux/macOS without NixOS-WSL or nix-darwin.
+#
+# To activate this configuration (generic forker path):
 #   First time (requires experimental features flags):
 #     nix --extra-experimental-features 'nix-command flakes' run home-manager/master -- switch --extra-experimental-features 'nix-command flakes' --flake .#default --impure
 #
@@ -12,9 +24,10 @@
 #   Or explicitly specify system:
 #     home-manager switch -b backup --flake .#x86_64-linux --impure
 #
-# Always pass `-b backup`: standalone home-manager has no equivalent of the
-# NixOS/nix-darwin module's `home-manager.backupFileExtension`, and without it a
-# switch aborts mid-activation when it meets an unmanaged file it wants to own
+# Always pass `-b backup` on the standalone forker path: standalone home-manager
+# has no equivalent of the NixOS/nix-darwin module's
+# `home-manager.backupFileExtension`, and without it a switch aborts
+# mid-activation when it meets an unmanaged file it wants to own
 # (e.g. a stray ~/.zprofile), leaving the profile half-updated.
 #
 # Note: --impure is required because home.username and home.homeDirectory are

--- a/nix/home/wezterm-windows.nix
+++ b/nix/home/wezterm-windows.nix
@@ -90,7 +90,8 @@
             -o "$WW_TMPDIR/wezterm.zip" \
             || { echo "ERROR: Failed to download WezTerm Windows nightly" >&2; exit $WW_ERR_DOWNLOAD_FAILED; }
 
-          ${pkgs.unzip}/bin/unzip -q "$WW_TMPDIR/wezterm.zip" -d "$WW_TMPDIR/extracted"
+          ${pkgs.unzip}/bin/unzip -q "$WW_TMPDIR/wezterm.zip" -d "$WW_TMPDIR/extracted" \
+            || { echo "ERROR: Failed to extract WezTerm zip" >&2; exit $WW_ERR_INSTALL_FAILED; }
 
           GUI_EXE=$(find "$WW_TMPDIR/extracted" -maxdepth 3 -name 'wezterm-gui.exe' -type f | head -n1)
           if [ -z "$GUI_EXE" ]; then

--- a/nix/home/wezterm-windows.nix
+++ b/nix/home/wezterm-windows.nix
@@ -1,24 +1,18 @@
 # Windows WezTerm Installer (WSL only)
 #
-# Builds the WezTerm Windows binary set from the upstream WezTerm Windows nightly zip
-# and installs it declaratively into the Windows user's %LOCALAPPDATA%\WezTerm\
-# on each home-manager activation.
+# Downloads and installs the WezTerm Windows nightly binary to the Windows
+# user's %LOCALAPPDATA%\WezTerm\ at each home-manager activation.
 #
 # Why: the Windows GUI auto-connects to the NixOS mux server over SSH; when the
 # Windows binary and the NixOS wezterm package drift in version, the mux PDU
 # protocol fails and the GUI window closes immediately. Both sides track upstream
-# nightly: the NixOS package via nixpkgs, the Windows binary via an impure
-# builtins.fetchurl, so each switch picks up the same rolling nightly.
+# nightly: the NixOS package via nixpkgs, the Windows binary via a runtime curl
+# fetch in this activation script, so each switch picks up the same rolling nightly.
 #
 # Update workflow:
-#   The Windows zip auto-tracks upstream's rolling "nightly" tag via an in-module
-#   impure builtins.fetchurl (no flake input / lock pin), so each switch picks up
-#   current nightly content. Fetches are tarball-ttl-gated (default 1h); to force
-#   a fresh pull immediately, add --refresh:
-#     home-manager switch --flake .#default --impure --refresh
-#
-# When bumping nixpkgs (and thus wezterm), the impure fetch already tracks the
-# latest nightly, keeping the two sides in lockstep.
+#   The Windows zip auto-tracks upstream's rolling "nightly" tag via a runtime
+#   curl fetch on each activation — no flake input / lock pin so upstream
+#   republishes are automatically picked up. Each switch re-downloads the zip.
 
 {
   config,
@@ -27,48 +21,8 @@
   ...
 }:
 
-let
-  wezterm-windows-pkg = pkgs.stdenv.mkDerivation {
-    pname = "wezterm-windows";
-    version = "nightly";
-
-    # Impure raw-file fetch of the rolling upstream "nightly" Windows asset.
-    # Hashless (no flake input / lock pin) so a cold-cache re-fetch tolerates an
-    # upstream republish instead of failing a stale narHash check. Requires
-    # --impure eval (already the only mode used here). Raw .zip, no unpacking —
-    # the unzip nativeBuildInput + default unpackPhase extract it below.
-    src = builtins.fetchurl "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip";
-
-    nativeBuildInputs = [ pkgs.unzip ];
-
-    dontConfigure = true;
-    dontBuild = true;
-
-    # The default unpackPhase handles either an opaque .zip (when Nix downloads
-    # without auto-extraction) or an already-extracted directory. After unpack,
-    # locate the directory containing wezterm-gui.exe — release zips wrap the
-    # binaries in a single versioned subdirectory like
-    # WezTerm-windows-20260117-074626-90b5d1cb/.
-    installPhase = ''
-      runHook preInstall
-
-      GUI_EXE=$(find . -maxdepth 3 -name 'wezterm-gui.exe' -type f | head -n1)
-      if [ -z "$GUI_EXE" ]; then
-        echo "ERROR: wezterm-gui.exe not found in source" >&2
-        find . -maxdepth 3 -type f >&2
-        exit 1
-      fi
-
-      SOURCE_ROOT=$(dirname "$GUI_EXE")
-      mkdir -p $out
-      cp -r "$SOURCE_ROOT"/. $out/
-
-      runHook postInstall
-    '';
-  };
-in
 {
-  # WSL: install Windows WezTerm into the user's %LOCALAPPDATA%
+  # WSL: download and install Windows WezTerm into the user's %LOCALAPPDATA%.
   # DAG ordering: runs after "linkGeneration" so symlinks are stable before we
   # reach across the WSL boundary.
   home.activation.installWeztermWindows = lib.mkIf pkgs.stdenv.isLinux (
@@ -77,6 +31,7 @@ in
       readonly WW_ERR_USERNAME_DETECTION=22
       readonly WW_ERR_INSTALL_FAILED=23
       readonly WW_ERR_FILE_LOCKED=24
+      readonly WW_ERR_DOWNLOAD_FAILED=25
 
       if [ ! -d "/mnt/c/Users" ]; then
         echo "Not running on WSL, skipping Windows WezTerm install"
@@ -123,20 +78,41 @@ in
 
         TARGET_DIR="/mnt/c/Users/$WINDOWS_USER/AppData/Local/WezTerm"
 
-        $DRY_RUN_CMD ${pkgs.coreutils}/bin/mkdir -p "$TARGET_DIR"
-
-        # rsync without -p/-o/-g: /mnt/c is a Windows filesystem where unix
-        # permissions/ownership are not meaningful and attempting to set them
-        # produces spurious errors. -rlt preserves recursion, symlinks, and
-        # mtimes — enough to keep --delete idempotent across runs.
         if [ -z "$DRY_RUN_CMD" ]; then
+          # Download the nightly Windows zip and rsync its contents to TARGET_DIR.
+          # Re-downloads on each switch so the Windows binary stays in lockstep
+          # with the nixpkgs-managed mux server without a hash pin.
+          WW_TMPDIR=$(mktemp -d)
+          trap 'rm -rf "$WW_TMPDIR"' EXIT
+
+          ${pkgs.curl}/bin/curl -fsSL \
+            "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip" \
+            -o "$WW_TMPDIR/wezterm.zip" \
+            || { echo "ERROR: Failed to download WezTerm Windows nightly" >&2; exit $WW_ERR_DOWNLOAD_FAILED; }
+
+          ${pkgs.unzip}/bin/unzip -q "$WW_TMPDIR/wezterm.zip" -d "$WW_TMPDIR/extracted"
+
+          GUI_EXE=$(find "$WW_TMPDIR/extracted" -maxdepth 3 -name 'wezterm-gui.exe' -type f | head -n1)
+          if [ -z "$GUI_EXE" ]; then
+            echo "ERROR: wezterm-gui.exe not found in source" >&2
+            find "$WW_TMPDIR/extracted" -maxdepth 3 -type f >&2
+            exit $WW_ERR_INSTALL_FAILED
+          fi
+
+          SOURCE_ROOT=$(dirname "$GUI_EXE")
+          ${pkgs.coreutils}/bin/mkdir -p "$TARGET_DIR"
+
+          # rsync without -p/-o/-g: /mnt/c is a Windows filesystem where unix
+          # permissions/ownership are not meaningful and attempting to set them
+          # produces spurious errors. -rlt preserves recursion, symlinks, and
+          # mtimes — enough to keep --delete idempotent across runs.
           rsync_error=$(${pkgs.rsync}/bin/rsync -rlt --delete \
-            "${wezterm-windows-pkg}/" "$TARGET_DIR/" 2>&1)
+            "$SOURCE_ROOT/" "$TARGET_DIR/" 2>&1)
           rsync_exit=$?
           if [ $rsync_exit -ne 0 ]; then
             if echo "$rsync_error" | grep -qi "permission denied"; then
               echo "ERROR: Failed to install Windows WezTerm — files appear locked" >&2
-              echo "  Close WezTerm on Windows and re-run 'home-manager switch'" >&2
+              echo "  Close WezTerm on Windows and re-run 'nixos-rebuild switch'" >&2
               echo "  Details:" >&2
               echo "$rsync_error" | sed 's/^/    /' >&2
               exit $WW_ERR_FILE_LOCKED
@@ -147,8 +123,7 @@ in
             exit $WW_ERR_INSTALL_FAILED
           fi
         else
-          $DRY_RUN_CMD ${pkgs.rsync}/bin/rsync -rlt --delete \
-            "${wezterm-windows-pkg}/" "$TARGET_DIR/"
+          echo "Would download WezTerm nightly and install to $TARGET_DIR"
         fi
 
         echo "Installed Windows WezTerm to $TARGET_DIR"

--- a/nix/nixos/configuration.nix
+++ b/nix/nixos/configuration.nix
@@ -11,8 +11,6 @@
 
 {
   imports = [
-    # include NixOS-WSL modules (resolved via the nixos-wsl channel)
-    <nixos-wsl/modules>
     # Tailscale VPN for secure networking
     ./tailscale.nix
     # Windows drive mounts (Google Drive G: -> /mnt/g)
@@ -59,6 +57,9 @@
     home = "/home/n8";
     extraGroups = [ "wheel" "docker" ];
     shell = pkgs.zsh;
+    # Keep the wezterm-mux-server user service alive across logins declaratively,
+    # replacing the imperative `loginctl enable-linger`.
+    linger = true;
   };
 
   # environment.systemPackages = with pkgs; [ ]; # add system packages here

--- a/nix/nixos/configuration.nix
+++ b/nix/nixos/configuration.nix
@@ -2,7 +2,16 @@
 #
 # This is the substance of the system config; /etc/nixos/configuration.nix is a
 # thin stub that imports this file, so the machine's configuration is managed in
-# this repo. Rebuild with `sudo nixos-rebuild switch` after editing.
+# this repo. Rebuild with `sudo nixos-rebuild switch --flake .#nixos` after
+# editing.
+#
+# The `--flake` form is required: the `wsl.*` options below (e.g. `wsl.enable`,
+# `wsl.defaultUser`) are provided by `nixos-wsl.nixosModules.default`, which the
+# flake injects into this configuration. This file no longer imports the
+# channel's `<nixos-wsl/modules>` itself, so a standalone
+# `sudo nixos-rebuild switch` (without `--flake`) — or a stub that imports this
+# file without separately importing `<nixos-wsl/modules>` — fails with an
+# undefined-option error for `wsl.enable`.
 #
 # NixOS-WSL specific options are documented on the NixOS-WSL repository:
 # https://github.com/nix-community/NixOS-WSL


### PR DESCRIPTION
Closes #2636

## What this does

Integrates home-manager into the WSL2 NixOS box (`nixos` Tailscale host) as a
**NixOS module**, so it activates atomically with `sudo nixos-rebuild switch`
instead of a separate, standalone `home-manager switch`. This mirrors the pattern
macOS already uses (`darwinConfigurations.default` with
`home-manager.darwinModules.home-manager`).

The original bug: a standalone switch silently aborted mid-activation when it met
an unmanaged `~/.zprofile` it wanted to own, leaving the profile half-updated. The
wezterm binary never upgraded, so `wezterm connect nixos` broke with a mux
protocol version mismatch. The integrated module sets
`home-manager.backupFileExtension`, which backs up the conflicting file instead of
aborting — making that failure mode impossible.

## Design decision — flakify the WSL system

The WSL box was channel-based (`nixos` 24.11 + `nixos-wsl` channels), consumed via
a thin `/etc/nixos/configuration.nix` stub. A channel-based system config cannot
reach `pkgs.claude-code`, which comes from the `claude-code-nix` **flake** overlay
that `nix/home/default.nix` depends on. So this PR converts the WSL system to a
**flake**-built `nixosConfigurations.nixos` consuming `nixos-wsl` + `home-manager`
as flake inputs — the issue's greenfield recommendation, which both fixes the
overlay problem and unifies version pinning across the fleet.

**Consequential side effect:** the flake's `nixpkgs` is `nixos-unstable`, so
flakifying moves the box from channel `nixos-24.11` to **unstable** — a full system
nixpkgs bump, not just an HM integration. This is in scope ("unify pinning across
the fleet") but is called out explicitly here because the acceptance criteria do
not spell it out.

## Epic coordination

This is the **activation-architecture** half (atomic rebuild, backup, linger);
epic #2446 / #2449 is the **identity/forkability** half. Creating
`nixosConfigurations.nixos` with the `n8` identity inline is symmetric with the
existing `darwinConfigurations.default` (also hardcoded `n8` in this same flake),
and #2449's own criteria expect this `nixosConfigurations` to already exist and
plan to move it out to the instance flake later. So this is the prerequisite the
epic builds on, not a competing architecture.

**Out of scope (left to the epic):** removing the `n8`/identity hardcoding,
exporting a reusable `nixosModules.default`, and fully eliminating
`builtins.getEnv` from `nix/home/default.nix`. This PR only forces identity for
the WSL host (mirroring darwin) so pure eval passes.

## Changes

- **`flake.nix`** — add a `nixos-wsl` flake input; add
  `nixosConfigurations.nixos` (mirroring `darwinConfigurations.default`) with the
  integrated home-manager module, `backupFileExtension = "backup"`, forced
  `n8`/`/home/n8` identity for pure eval, and wezterm left enabled (unlike darwin,
  which disables it as out-of-scope); export `nixosConfigurations`.
- **`nix/nixos/configuration.nix`** — drop the channel `<nixos-wsl/modules>`
  import (now supplied by `nixos-wsl.nixosModules.default` from the flake); add
  `users.users.n8.linger = true` so the `wezterm-mux-server` user service survives
  logout declaratively (replacing the imperative `loginctl enable-linger`).
- **`.github/scripts/build-nixos-config.sh` + `nixos-build` CI job** — a full
  `nix build` of `nixosConfigurations.nixos.config.system.build.toplevel` on
  `ubuntu-latest`, mirroring the `darwin-build` precedent (gated on nix-file
  changes, cachix substituter, 30-min runaway guard).
- **Docs** (`README.md`, `nix/home/default.nix` header,
  `nix/apps/home-manager-setup.nix`) — retire the WSL box's *use* of standalone
  switch, clarifying that standalone `home-manager switch` is now the **generic
  forker path** (plain Linux/macOS). `homeConfigurations` and the
  `home-manager-setup` app are **kept** for forkers without NixOS-WSL or
  nix-darwin.

## Verification

CI-authoritative (nix cannot run in the worker sandbox — no network for the new
`nixos-wsl` input):

- `nix flake check --impure` must evaluate `nixosConfigurations.nixos` cleanly —
  proves pure eval passes (forced identity working, no `getEnv`/`--impure` needed
  for this host).
- The new `nixos-build` job must build
  `nixosConfigurations.nixos.config.system.build.toplevel` — proves the integrated
  config builds.

### On-box manual QA (not CI-verifiable — performed on the actual WSL box)

1. Point the box at the flake config: change `/etc/nixos/configuration.nix` (the
   thin stub) to a `/etc/nixos/flake.nix` referencing this repo's
   `nixosConfigurations.nixos`, then `sudo nixos-rebuild switch` (NixOS
   auto-detects `/etc/nixos/flake.nix`). Confirm activation is **atomic** and does
   not invoke a separate standalone `home-manager switch`.
2. Confirm `home-manager.backupFileExtension` works: plant an unmanaged file
   home-manager wants to own (e.g. a stray `~/.zprofile`) and verify the switch
   **backs it up** (`.backup`) instead of aborting mid-activation.
3. Confirm `users.users.n8.linger = true` keeps the `wezterm-mux-server` user
   service running across a full logout/login — no imperative `loginctl
   enable-linger` needed.
4. Confirm `wezterm connect nixos` works after the switch upgrades the wezterm
   binary (the mux-server restarts onto the new generation; the original bug is
   gone).
5. Retire the standalone profile so dotfiles are not double-managed: remove the
   old standalone home-manager generation/profile on the box after the integrated
   switch succeeds. Confirm only the integrated module manages the dotfiles
   afterward.
