### PR TITLE
topic-usage-writer: backfill missed days after offline gaps

### DIFF
--- a/.claude/skills/dispatch-token-audit/scripts/test-topic-usage-writer.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-topic-usage-writer.sh
@@ -270,6 +270,127 @@ assert_eq "backfill cap=1: dropped day is logged (no silent truncate)" "1" \
 rm -rf "$R2" "$S2" "$ERR2" "$ERR2B"
 
 # =========================================================================
+# Case 8: normal daily run — sentinel last-day == yesterday -> [today] only.
+# Guards the unchanged daily-run behavior (acceptance criterion 1).
+# =========================================================================
+R8=$(mktemp -d)
+S8=$(mktemp -d)
+printf '2026-06-19\n' > "$S8/topic-usage-grp-1.last-day"   # yesterday
+DAY8="2026-06-20"
+NOW8=$(date -u -d "$DAY8 12:00:00" +%s)
+WT8="$R8/-home-x-worktrees-daily"
+mkdir -p "$WT8"
+write_transcript "$WT8/sess.jsonl" 12 0 0 0
+touch -d "${DAY8}T12:00:00Z" "$WT8/sess.jsonl"
+OUT8=$(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$R8"
+  export DISPATCH_TOPIC_USAGE_STATE_DIR="$S8"
+  export DISPATCH_TOPIC_USAGE_NOW="$NOW8"
+  node "$WRITER_MJS" --dry-run 2>/dev/null
+)
+assert_eq "daily (last-day == yesterday): today only (1 element)" "1" "$(jq 'length' <<<"$OUT8")"
+assert_eq "daily (last-day == yesterday): the day is today" \
+  '["2026-06-20"]' "$(jq -c '[.[].doc.date]' <<<"$OUT8")"
+rm -rf "$R8" "$S8"
+
+# =========================================================================
+# Case 9: N-day offline recovery — sentinel last-day > one day ago backfills
+# the missed days lastDay+1..today (acceptance criteria 2 + 4). last-day is
+# 3 days behind today, so the producer was offline for the intervening days.
+# =========================================================================
+R9=$(mktemp -d)
+S9=$(mktemp -d)
+printf '2026-06-17\n' > "$S9/topic-usage-grp-1.last-day"   # 3 days behind 06-20
+DAY9="2026-06-20"
+NOW9=$(date -u -d "$DAY9 12:00:00" +%s)
+WT9="$R9/-home-x-worktrees-gap"
+mkdir -p "$WT9"
+# Activity on one of the missed days proves a real doc is produced for it.
+write_transcript "$WT9/sess-18.jsonl" 33 0 0 0
+touch -d "2026-06-18T12:00:00Z" "$WT9/sess-18.jsonl"
+ERR9=$(mktemp)
+OUT9=$(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$R9"
+  export DISPATCH_TOPIC_USAGE_STATE_DIR="$S9"
+  export DISPATCH_TOPIC_USAGE_NOW="$NOW9"
+  node "$WRITER_MJS" --dry-run 2>"$ERR9"
+)
+assert_eq "gap recovery: one element per missed day (lastDay+1..today)" "3" "$(jq 'length' <<<"$OUT9")"
+assert_eq "gap recovery: missed days are lastDay+1..today, ascending" \
+  '["2026-06-18","2026-06-19","2026-06-20"]' "$(jq -c '[.[].doc.date]' <<<"$OUT9")"
+assert_eq "gap recovery: docIds match the missed days" \
+  '["grp-1-2026-06-18","grp-1-2026-06-19","grp-1-2026-06-20"]' "$(jq -c '[.[].id]' <<<"$OUT9")"
+assert_eq "gap recovery: a log line names the gap" "1" \
+  "$(grep -cF 'gap recovery: sentinel last-day 2026-06-17 is 3 day(s) behind today 2026-06-20' "$ERR9" >/dev/null && echo 1 || echo 0)"
+assert_eq "gap recovery: covered-range log line" "1" \
+  "$(grep -cF 'covering 3 day(s) 2026-06-18..2026-06-20' "$ERR9" >/dev/null && echo 1 || echo 0)"
+# The missed day with activity carries that activity (input=33 -> other/none).
+assert_eq "gap recovery: 2026-06-18 doc carries its day's activity (other input=33)" "33" \
+  "$(jq '.[] | select(.doc.date=="2026-06-18") | .doc.byTopic.other.input' <<<"$OUT9")"
+# Dry-run is side-effect-free: sentinel still the pre-seeded last-day.
+assert_eq "gap recovery: dry-run leaves sentinel untouched" "2026-06-17" \
+  "$(cat "$S9/topic-usage-grp-1.last-day")"
+rm -rf "$R9" "$S9" "$ERR9"
+
+# =========================================================================
+# Case 10: gap recovery respects the backfill cap — when the missed range
+# exceeds the cap, only the most-recent N are kept and the drop is logged
+# (acceptance criterion 3; consistent with first-run cap behavior).
+# =========================================================================
+R10=$(mktemp -d)
+S10=$(mktemp -d)
+printf '2026-06-10\n' > "$S10/topic-usage-grp-1.last-day"  # missed 06-11..06-20 = 10 days
+DAY10="2026-06-20"
+NOW10=$(date -u -d "$DAY10 12:00:00" +%s)
+WT10="$R10/-home-x-worktrees-gapcap"
+mkdir -p "$WT10"
+write_transcript "$WT10/sess.jsonl" 5 0 0 0
+touch -d "${DAY10}T12:00:00Z" "$WT10/sess.jsonl"
+ERR10=$(mktemp)
+OUT10=$(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$R10"
+  export DISPATCH_TOPIC_USAGE_STATE_DIR="$S10"
+  export DISPATCH_TOPIC_USAGE_NOW="$NOW10"
+  export DISPATCH_TOPIC_USAGE_BACKFILL_CAP="3"
+  node "$WRITER_MJS" --dry-run 2>"$ERR10"
+)
+assert_eq "gap cap=3: only the 3 most-recent missed days kept" \
+  '["2026-06-18","2026-06-19","2026-06-20"]' "$(jq -c '[.[].doc.date]' <<<"$OUT10")"
+assert_eq "gap cap=3: dropped older days are logged (no silent truncate)" "1" \
+  "$(grep -cF 'cap 3 dropped 7 older day(s): 2026-06-11,2026-06-12,2026-06-13,2026-06-14,2026-06-15,2026-06-16,2026-06-17' "$ERR10" >/dev/null && echo 1 || echo 0)"
+rm -rf "$R10" "$S10" "$ERR10"
+
+# =========================================================================
+# Case 11: corrupt sentinel — an unparseable last-day is treated as a first
+# run (backfill of transcript days), logging a warning, rather than crashing
+# the daily producer or silently producing nothing.
+# =========================================================================
+R11=$(mktemp -d)
+S11=$(mktemp -d)
+printf 'not-a-date\n' > "$S11/topic-usage-grp-1.last-day"
+NOW11=$(date -u -d "2026-06-20 12:00:00" +%s)
+WT11="$R11/-home-x-worktrees-corrupt"
+mkdir -p "$WT11"
+write_transcript "$WT11/sess-d1.jsonl" 5 0 0 0
+write_transcript "$WT11/sess-d2.jsonl" 7 0 0 0
+touch -d "2026-06-15T12:00:00Z" "$WT11/sess-d1.jsonl"
+touch -d "2026-06-18T12:00:00Z" "$WT11/sess-d2.jsonl"
+ERR11=$(mktemp)
+OUT11=$(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$R11"
+  export DISPATCH_TOPIC_USAGE_STATE_DIR="$S11"
+  export DISPATCH_TOPIC_USAGE_NOW="$NOW11"
+  node "$WRITER_MJS" --dry-run 2>"$ERR11"
+)
+RC11=$?
+assert_eq "corrupt sentinel: exit 0 (does not crash the producer)" "0" "$RC11"
+assert_eq "corrupt sentinel: falls through to first-run backfill (transcript days)" \
+  '["2026-06-15","2026-06-18"]' "$(jq -c '[.[].doc.date]' <<<"$OUT11")"
+assert_eq "corrupt sentinel: a warning names the invalid last-day" "1" \
+  "$(grep -cF 'sentinel last-day "not-a-date" is not a valid YYYY-MM-DD' "$ERR11" >/dev/null && echo 1 || echo 0)"
+rm -rf "$R11" "$S11" "$ERR11"
+
+# =========================================================================
 # Case 7: fail-closed branches. Each must exit non-zero with a matching
 # one-line stderr diagnostic prefixed "topic-usage-writer:".
 # =========================================================================

--- a/.claude/skills/dispatch-token-audit/scripts/topic-usage-writer.mjs
+++ b/.claude/skills/dispatch-token-audit/scripts/topic-usage-writer.mjs
@@ -37,11 +37,16 @@
 //   A durable per-host date sentinel under the state dir records the last day
 //   processed (the producer OWNS sentinel writes — written only after a
 //   successful real-mode run).
-//     - Normal run (sentinel present): produce a doc for TODAY (UTC) only.
-//     - First run (sentinel absent): backfill one doc per available transcript
-//       UTC day (distinct days derived from transcript file mtimes), bounded by
-//       a day cap (keep the most recent N). The covered range and any
-//       cap-dropped days are logged to stderr — never silently truncated.
+//     - Normal run (sentinel last-day == yesterday): produce a doc for TODAY
+//       (UTC) only.
+//     - Gap recovery (sentinel last-day > one day ago): the producer was offline
+//       for one or more days; backfill one doc per missed calendar day
+//       (lastDay+1..today) so downtime gaps are recovered, not silently skipped,
+//       bounded by the same day cap.
+//     - First run (sentinel absent) or a corrupt sentinel: backfill one doc per
+//       available transcript UTC day (distinct days derived from transcript file
+//       mtimes), bounded by a day cap (keep the most recent N). The covered range
+//       and any cap-dropped days are logged to stderr — never silently truncated.
 //   The deterministic docId + .set() make a lost/stale sentinel a harmless
 //   idempotent re-write; the sentinel is a cost optimization only (it also
 //   bounds the gh-quota burst of an N-day backfill, since each per-day
@@ -67,8 +72,8 @@
 //     computedAt; defaults to Math.floor(Date.now()/1000). A positive integer.
 //   DISPATCH_TOPIC_USAGE_STATE_DIR       sentinel state dir; default
 //     ${XDG_STATE_HOME:-$HOME/.local/state}/dispatch.
-//   DISPATCH_TOPIC_USAGE_BACKFILL_CAP    first-run day cap; default 30. A
-//     positive integer.
+//   DISPATCH_TOPIC_USAGE_BACKFILL_CAP    backfill day cap (first run and gap
+//     recovery); default 30. A positive integer.
 //   DISPATCH_TOPIC_USAGE_AGGREGATE_SCRIPT  override the aggregate-usage.sh path
 //     (test seam). Default: <scriptdir>/aggregate-usage.sh.
 //   DISPATCH_AUDIT_PROJECTS_ROOT         REUSED (default $HOME/.claude/projects)
@@ -505,37 +510,80 @@ export function assembleDoc(produced, config, mkTimestamp) {
   };
 }
 
-// Determine the ordered list of UTC days to produce.
-//   sentinel present -> [today]
-//   sentinel absent  -> first-run backfill of distinct transcript days, capped
-//                       to the most recent N (covered range + drops logged).
-function targetDays(config) {
-  const today = utcDay(config.nowEpochSeconds);
-  if (fs.existsSync(sentinelPath(config))) {
-    return [today];
+// The UTC days strictly after `afterDay` up to and including `throughDay`,
+// ascending (YYYY-MM-DD). Empty when afterDay >= throughDay. null when afterDay
+// is not a YYYY-MM-DD string, so a corrupt/empty sentinel is handled as a first
+// run rather than crashing the daily producer.
+function missedDaysAfter(afterDay, throughDay) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(afterDay)) return null;
+  const DAY_MS = 86400000;
+  const startMs = Date.parse(`${afterDay}T00:00:00Z`);
+  const endMs = Date.parse(`${throughDay}T00:00:00Z`);
+  const out = [];
+  for (let ms = startMs + DAY_MS; ms <= endMs; ms += DAY_MS) {
+    out.push(new Date(ms).toISOString().slice(0, 10));
   }
-  // First run: backfill.
-  const days = transcriptDays(collectFiles(config.projectsRoot));
-  if (days.length === 0) {
-    log("first-run backfill: no transcript days found; producing today only");
-    return [today];
-  }
-  const cap = config.backfillCap;
+  return out;
+}
+
+// Cap an ascending day list to the most recent `cap`, logging the covered range
+// and any dropped older days (no silent truncation). Shared by the first-run
+// backfill and the gap-recovery path; `label` prefixes the log lines.
+function capDaysToBackfill(days, cap, label) {
   let kept = days;
   let dropped = [];
   if (days.length > cap) {
     dropped = days.slice(0, days.length - cap); // older days fall outside the cap
     kept = days.slice(days.length - cap);
   }
-  log(
-    `first-run backfill: covering ${kept.length} day(s) ${kept[0]}..${kept[kept.length - 1]}`,
-  );
+  log(`${label}: covering ${kept.length} day(s) ${kept[0]}..${kept[kept.length - 1]}`);
   if (dropped.length > 0) {
     log(
-      `first-run backfill: cap ${cap} dropped ${dropped.length} older day(s): ${dropped.join(",")}`,
+      `${label}: cap ${cap} dropped ${dropped.length} older day(s): ${dropped.join(",")}`,
     );
   }
   return kept;
+}
+
+// Determine the ordered list of UTC days to produce.
+//   sentinel present, last-day == yesterday    -> [today] (normal daily run)
+//   sentinel present, last-day > one day ago   -> gap recovery: the missed days
+//                                                 lastDay+1..today, capped.
+//   sentinel present, last-day same/future     -> [today] (idempotent re-run)
+//   sentinel absent or corrupt                 -> first-run backfill of distinct
+//                                                 transcript days, capped.
+// In every backfill case the covered range and any cap drops are logged.
+function targetDays(config) {
+  const today = utcDay(config.nowEpochSeconds);
+  if (fs.existsSync(sentinelPath(config))) {
+    const lastDay = fs.readFileSync(sentinelPath(config), "utf8").trim();
+    const missed = missedDaysAfter(lastDay, today);
+    if (missed === null) {
+      log(
+        `sentinel last-day "${lastDay}" is not a valid YYYY-MM-DD; treating as a first run and backfilling`,
+      );
+      // fall through to the first-run backfill below
+    } else if (missed.length <= 1) {
+      // last-day is yesterday (missed == [today]) or a same-day/future re-run
+      // (missed empty). Either way, today only — unchanged daily behavior.
+      return [today];
+    } else {
+      // The producer was offline for more than a day: backfill the missed days
+      // (lastDay+1..today) so downtime gaps are recovered, not silently skipped.
+      log(
+        `gap recovery: sentinel last-day ${lastDay} is ${missed.length} day(s) behind today ${today}; backfilling missed days`,
+      );
+      return capDaysToBackfill(missed, config.backfillCap, "gap recovery");
+    }
+  }
+  // First run (sentinel absent) or a corrupt sentinel: backfill the distinct
+  // transcript-activity days, capped to the most recent N.
+  const days = transcriptDays(collectFiles(config.projectsRoot));
+  if (days.length === 0) {
+    log("first-run backfill: no transcript days found; producing today only");
+    return [today];
+  }
+  return capDaysToBackfill(days, config.backfillCap, "first-run backfill");
 }
 
 async function main() {


### PR DESCRIPTION
Closes #2629

## Summary

`targetDays()` in `topic-usage-writer.mjs` treated the sentinel file as a boolean
presence flag: once any prior real-mode run wrote it, the function returned
`[today]` unconditionally and never read back the stored last-processed date.
When the producer was offline for N days, those days were permanently
skipped — their transcript data was never backfilled, leaving silent gaps in the
time series (#2629).

The fix reads the sentinel's stored last-day and compares it to today:

- **last-day == yesterday** → `[today]` (unchanged normal daily run)
- **last-day > one day ago** → gap recovery: backfill the missed calendar days
  `lastDay+1..today`, capped to the most recent N (covered range + any drops
  logged to stderr, never silently truncated)
- **last-day same/future** → `[today]` (idempotent same-day re-run)
- **corrupt/empty sentinel** → log a warning and fall through to the first-run
  backfill rather than crashing the daily producer; the existing sentinel
  rewrite then self-heals the corrupt value on the next successful run

The first-run cap+log block is factored into a shared `capDaysToBackfill()` used
by both backfill paths, and a small `missedDaysAfter()` helper enumerates the
`(lastDay, today]` UTC-day range.

## Acceptance criteria

- [x] last-day == yesterday → `targetDays()` returns `[today]` (unchanged daily case)
- [x] last-day > one day ago → returns the full range of missed days up to today
- [x] backfill cap respected when the gap range exceeds it (shared with first-run)
- [x] a test exercises the N-day offline recovery path (sentinel N>1 days ago → docs for the intervening days)

## Testing

`bash .claude/skills/dispatch-token-audit/scripts/test-topic-usage-writer.sh` —
**51 passed, 0 failed**. New cases: normal daily (last-day == yesterday), N-day
gap recovery, gap exceeding the cap, and corrupt sentinel. Existing first-run and
single-day cases unchanged.

Source: review nit from PR #2619.
