### PR TITLE
office-hours: bound dashboard usage/issue-samples reads (Firestore read-spike hotfix)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -45,6 +45,14 @@
       ]
     },
     {
+      "collectionGroup": "usage-samples",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "memberEmails", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "sampledAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "topic-usage",
       "queryScope": "COLLECTION",
       "fields": [

--- a/office-hours/src/issue-data.ts
+++ b/office-hours/src/issue-data.ts
@@ -1,8 +1,24 @@
-import { collection, getDocs, query, where, type Firestore } from "firebase/firestore";
+import {
+  collection,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  where,
+  type Firestore,
+} from "firebase/firestore";
 import type { User } from "firebase/auth";
 import { nsCollectionPath, type Namespace } from "@commons-systems/firestoreutil/namespace";
 import seedSamples from "virtual:office-hours-issue-seed-data";
 import { toIssueSample, type IssueSample } from "./issue-samples.js";
+
+// issue-samples grows ~24 docs/day (one per hourly sampleDispatchQueueMetrics
+// run) and is re-scanned on every dashboard auto-refresh. Cap the read to a
+// bounded, non-growing set so it can never repeat the #2683 read spike. The cap
+// is generous (≈80 days of backlog history) since this collection grows slowly.
+// Uses the existing issue-samples (memberEmails CONTAINS + sampledAt DESC)
+// composite index in firestore.indexes.json.
+const ISSUE_SAMPLE_LIMIT = 2000;
 
 export function getDemoIssueSamples(): IssueSample[] {
   return seedSamples.map((s) => ({
@@ -22,12 +38,19 @@ export async function getOwnerIssueSamples(
 ): Promise<IssueSample[]> {
   if (!user.email) return [];
   const path = nsCollectionPath(namespace, "issue-samples");
-  const q = query(collection(db, path), where("memberEmails", "array-contains", user.email));
+  const q = query(
+    collection(db, path),
+    where("memberEmails", "array-contains", user.email),
+    orderBy("sampledAt", "desc"),
+    limit(ISSUE_SAMPLE_LIMIT),
+  );
   const snapshot = await getDocs(q);
   const samples: IssueSample[] = [];
   for (const d of snapshot.docs) {
     const sample = toIssueSample(d.id, d.data());
     if (sample) samples.push(sample);
   }
+  // Query returns DESC (newest first); reverse to ascending time order for charting.
+  samples.reverse();
   return samples;
 }

--- a/office-hours/src/usage-data.ts
+++ b/office-hours/src/usage-data.ts
@@ -1,8 +1,25 @@
-import { collection, getDocs, query, where, type Firestore } from "firebase/firestore";
+import {
+  collection,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  where,
+  type Firestore,
+} from "firebase/firestore";
 import type { User } from "firebase/auth";
 import { nsCollectionPath, type Namespace } from "@commons-systems/firestoreutil/namespace";
 import seedSamples from "virtual:office-hours-usage-seed-data";
 import { toUsageSample, type UsageSample } from "./usage-samples.js";
+
+// usage-samples is written once per dispatch-tick (~every 5 min, ~288 docs/day)
+// and grows without bound. The owner getter runs on mount AND on every
+// dashboard auto-refresh (Dashboard.tsx REFRESH_INTERVAL_MS), so an unbounded
+// scan makes reads scale with the ever-growing collection — the #2683 read
+// spike. Cap the read (and the charted history) to the most recent ~7 days.
+// Requires the usage-samples (memberEmails CONTAINS + sampledAt DESC) composite
+// index in firestore.indexes.json.
+const USAGE_SAMPLE_LIMIT = 2000;
 
 export function getDemoSamples(): UsageSample[] {
   return seedSamples.map((s) => ({
@@ -24,12 +41,19 @@ export async function getOwnerSamples(
 ): Promise<UsageSample[]> {
   if (!user.email) return [];
   const path = nsCollectionPath(namespace, "usage-samples");
-  const q = query(collection(db, path), where("memberEmails", "array-contains", user.email));
+  const q = query(
+    collection(db, path),
+    where("memberEmails", "array-contains", user.email),
+    orderBy("sampledAt", "desc"),
+    limit(USAGE_SAMPLE_LIMIT),
+  );
   const snapshot = await getDocs(q);
   const samples: UsageSample[] = [];
   for (const d of snapshot.docs) {
     const sample = toUsageSample(d.id, d.data());
     if (sample) samples.push(sample);
   }
+  // Query returns DESC (newest first); reverse to ascending time order for charting.
+  samples.reverse();
   return samples;
 }

--- a/office-hours/test/issue-data.test.ts
+++ b/office-hours/test/issue-data.test.ts
@@ -1,5 +1,78 @@
-import { describe, it, expect } from "vitest";
-import { getDemoIssueSamples } from "../src/issue-data.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockCollection = vi.fn();
+const mockGetDocs = vi.fn();
+const mockQuery = vi.fn();
+const mockWhere = vi.fn();
+const mockOrderBy = vi.fn();
+const mockLimit = vi.fn();
+
+vi.mock("firebase/firestore", () => ({
+  collection: (...args: unknown[]) => mockCollection(...args),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  query: (...args: unknown[]) => mockQuery(...args),
+  where: (...args: unknown[]) => mockWhere(...args),
+  orderBy: (...args: unknown[]) => mockOrderBy(...args),
+  limit: (...args: unknown[]) => mockLimit(...args),
+}));
+
+vi.mock("@commons-systems/firestoreutil/namespace", () => ({
+  nsCollectionPath: vi.fn(() => "test/env/issue-samples"),
+}));
+
+import { getDemoIssueSamples, getOwnerIssueSamples } from "../src/issue-data.js";
+
+const mockDb = {} as import("firebase/firestore").Firestore;
+const mockNamespace = "test" as import("@commons-systems/firestoreutil/namespace").Namespace;
+const mockOwner = { email: "owner@example.com" } as import("firebase/auth").User;
+
+function makeIssueDoc(iso: string) {
+  return {
+    id: iso,
+    data: () => ({
+      sampledAt: { toDate: () => new Date(iso) },
+      openSecurity: 1,
+      openBug: 2,
+      openEnhancement: 3,
+      openOther: 4,
+      groupId: "g1",
+      memberEmails: ["owner@example.com"],
+    }),
+  };
+}
+
+describe("getOwnerIssueSamples", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockReturnValue("mock-query");
+    mockOrderBy.mockReturnValue("mock-orderBy");
+    mockLimit.mockReturnValue("mock-limit");
+  });
+
+  it("no email — returns [] without a Firestore read", async () => {
+    const noEmailUser = { email: null } as import("firebase/auth").User;
+    const result = await getOwnerIssueSamples(mockDb, mockNamespace, noEmailUser);
+    expect(result).toEqual([]);
+    expect(mockGetDocs).not.toHaveBeenCalled();
+  });
+
+  it("bounds the read: orders by sampledAt DESC and caps at limit(2000)", async () => {
+    mockGetDocs.mockResolvedValue({ docs: [] });
+    await getOwnerIssueSamples(mockDb, mockNamespace, mockOwner);
+    expect(mockOrderBy).toHaveBeenCalledWith("sampledAt", "desc");
+    expect(mockLimit).toHaveBeenCalledWith(2000);
+  });
+
+  it("happy path — reverses the DESC result into ascending time order for charting", async () => {
+    mockGetDocs.mockResolvedValue({
+      docs: [makeIssueDoc("2026-06-29T00:00:00Z"), makeIssueDoc("2026-06-27T00:00:00Z")],
+    });
+    const result = await getOwnerIssueSamples(mockDb, mockNamespace, mockOwner);
+    expect(result).toHaveLength(2);
+    expect(result[0].sampledAt.toISOString()).toBe("2026-06-27T00:00:00.000Z");
+    expect(result[1].sampledAt.toISOString()).toBe("2026-06-29T00:00:00.000Z");
+  });
+});
 
 describe("getDemoIssueSamples", () => {
   const samples = getDemoIssueSamples();

--- a/office-hours/test/usage-data.test.ts
+++ b/office-hours/test/usage-data.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockCollection = vi.fn();
+const mockGetDocs = vi.fn();
+const mockQuery = vi.fn();
+const mockWhere = vi.fn();
+const mockOrderBy = vi.fn();
+const mockLimit = vi.fn();
+
+vi.mock("firebase/firestore", () => ({
+  collection: (...args: unknown[]) => mockCollection(...args),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  query: (...args: unknown[]) => mockQuery(...args),
+  where: (...args: unknown[]) => mockWhere(...args),
+  orderBy: (...args: unknown[]) => mockOrderBy(...args),
+  limit: (...args: unknown[]) => mockLimit(...args),
+}));
+
+vi.mock("@commons-systems/firestoreutil/namespace", () => ({
+  nsCollectionPath: vi.fn(() => "test/env/usage-samples"),
+}));
+
+import { getOwnerSamples, getDemoSamples } from "../src/usage-data.js";
+
+const mockDb = {} as import("firebase/firestore").Firestore;
+const mockNamespace = "test" as import("@commons-systems/firestoreutil/namespace").Namespace;
+const mockUser = { email: "owner@example.com" } as import("firebase/auth").User;
+
+function makeDoc(iso: string) {
+  const ts = { toDate: () => new Date(iso) };
+  return {
+    id: iso,
+    data: () => ({
+      sampledAt: ts,
+      fiveHourUsedPct: 10,
+      weeklyUsedPct: 20,
+      fiveHourResetsAt: ts,
+      weeklyResetsAt: ts,
+      activeWorkers: 3,
+      targetWorkers: 5,
+      groupId: "g1",
+      memberEmails: ["owner@example.com"],
+    }),
+  };
+}
+
+describe("getOwnerSamples", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockReturnValue("mock-query");
+    mockOrderBy.mockReturnValue("mock-orderBy");
+    mockLimit.mockReturnValue("mock-limit");
+  });
+
+  it("no email — returns [] without a Firestore read", async () => {
+    const noEmailUser = { email: null } as import("firebase/auth").User;
+    const result = await getOwnerSamples(mockDb, mockNamespace, noEmailUser);
+    expect(result).toEqual([]);
+    expect(mockGetDocs).not.toHaveBeenCalled();
+  });
+
+  it("bounds the read: orders by sampledAt DESC and caps at limit(2000)", async () => {
+    mockGetDocs.mockResolvedValue({ docs: [] });
+    await getOwnerSamples(mockDb, mockNamespace, mockUser);
+    expect(mockOrderBy).toHaveBeenCalledWith("sampledAt", "desc");
+    expect(mockLimit).toHaveBeenCalledWith(2000);
+  });
+
+  it("happy path — reverses the DESC result into ascending time order for charting", async () => {
+    // Firestore returns newest-first (DESC); the getter reverses to ASC.
+    mockGetDocs.mockResolvedValue({
+      docs: [makeDoc("2026-06-29T00:00:00Z"), makeDoc("2026-06-28T00:00:00Z"), makeDoc("2026-06-27T00:00:00Z")],
+    });
+    const result = await getOwnerSamples(mockDb, mockNamespace, mockUser);
+    expect(result).toHaveLength(3);
+    expect(result[0].sampledAt.toISOString()).toBe("2026-06-27T00:00:00.000Z");
+    expect(result[2].sampledAt.toISOString()).toBe("2026-06-29T00:00:00.000Z");
+  });
+
+  it("malformed docs are silently dropped", async () => {
+    mockGetDocs.mockResolvedValue({
+      docs: [makeDoc("2026-06-29T00:00:00Z"), { id: "bad", data: () => ({ groupId: 42 }) }],
+    });
+    const result = await getOwnerSamples(mockDb, mockNamespace, mockUser);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe("getDemoSamples", () => {
+  it("returns the bundled seed samples", () => {
+    const samples = getDemoSamples();
+    expect(Array.isArray(samples)).toBe(true);
+    expect(samples.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Problem

Firestore document reads spiked massively starting Jun 28. Root cause: the dashboard auto-refresh added in `ddbed37c` (#2463) re-runs all six owner getters every 5 min on every open tab. Two of them did **unbounded full-collection scans**:

- `getOwnerSamples` → `usage-samples`, written **once per dispatch-tick** (~288 docs/day, grows without bound)
- `getOwnerIssueSamples` → `issue-samples` (~24 docs/day)

So reads scaled as `collection_size × 12/hr × tab-hours` and climbed every day. Server-side functions were ruled out (no Firestore collection scans in `functions/src`).

## Fix

Bound both getters with `orderBy("sampledAt","desc") + limit(2000)` (mirrors the existing `getOwnerTopicUsage`), then reverse to ascending time order for charting. Each scan is now a fixed, non-growing read set — ~7 days of usage-samples, ~80 days of the slower issue-samples.

- Adds the `usage-samples` (`memberEmails CONTAINS + sampledAt DESC`) composite index. `issue-samples` already has its index.

## Deploy

Deploy is **automatic on merge to main**:

- `firestore-deploy.yml` deploys the new index (triggered by the `firestore.indexes.json` change).
- `prod-deploy.yml` deploys office-hours hosting.

Both fire on the same merge. The index deploy is submitted early in its job, ~2–3 min in; the hosting deploy builds all apps + smoke-tests for ~5–10 min before it flips, so the index build leads hosting by several minutes. The unauthenticated smoke test uses seed/demo data (not the owner getters), so it is unaffected by the index build.

Residual window (owner-only, self-healing): if a **fresh** dashboard load lands before the index reaches `Enabled`, `getOwnerSamples` throws `failed-precondition` and the dashboard shows the error tier. The auto-refresh path retains last-good, so an open tab is unaffected; a reload after the index is `Enabled` clears it.

## Behavior change

The Pace and Backlog history charts now render the bounded recent window instead of the entire accumulated history.

## Verification

- `npx tsc -p office-hours/tsconfig.json --noEmit` — clean
- `npx vitest run --project office-hours --root .` — 44 files, 438 tests pass (8 new: bounded-read + ascending-reversal assertions for both getters)

Closes #2683