### PR TITLE
Firestore read-count + budget alert definitions

### DIFF
--- a/.claude/docs/monitoring-alerts.md
+++ b/.claude/docs/monitoring-alerts.md
@@ -1,0 +1,166 @@
+# Monitoring Alerts
+
+Detective controls for the Firestore read-spike class of failure on the prod
+`commons-systems` GCP project: a Cloud Monitoring alert on Firestore
+`read_count`, plus a monthly billing budget. See epic #2686 and spike #2683.
+
+## Why
+
+This is a detective control. The #2683 read spike (Jun 28 → Jul 1 2026) ran
+undetected for days because `commons-systems` had no Firestore read-volume
+alert and no budget alert. Nothing watched the two signals that would have
+caught it early: hourly read volume and monthly spend.
+
+Root cause of that spike was two unbounded full-collection dashboard scans that
+re-ran every ~5 minutes per open tab:
+
+- `office-hours/src/usage-data.ts:15-19`
+- `office-hours/src/issue-data.ts:15-21`
+
+Each scan read the entire collection, so reads grew without bound as the
+collections grew, multiplied by every open dashboard tab. Commit `3c961c7c`
+fixed it by capping each scan at `limit(2000)`.
+
+The fix stops the known spike. This alerting adds the missing detection, so a
+similar regression — a new unbounded scan, or a cap that gets dropped — alarms
+early instead of running silently until the bill arrives.
+
+## What's committed
+
+Three files under `ops/`:
+
+- **`ops/monitoring/firestore-read-count-alert.json`** — a native Cloud
+  Monitoring `AlertPolicy`. The apply script passes it straight to
+  `gcloud monitoring policies create --policy-from-file=`, so its shape is
+  exactly what that command expects.
+
+- **`ops/monitoring/budget-alert.json`** — a parameter file, **not** a native
+  gcloud policy file. `gcloud billing budgets create` has no
+  `--policy-from-file` mode; it takes discrete flags (`--budget-amount`,
+  `--threshold-rule`, and so on). So this file is our own small schema —
+  `budgetAmount`, `currencyCode`, `thresholdPercents`, `projectId` — and the
+  apply script reads those fields with `jq` and translates them into the
+  matching flags. It is committed as a param file precisely because there is no
+  file-driven budget-create command to feed a policy file to.
+
+- **`ops/scripts/apply-alerts.sh`** — the apply orchestration. It resolves or
+  creates the notification channel, creates the monitoring policy from the
+  policy file, and creates the budget from the param file. It orchestrates
+  gcloud calls only and must never run in CI — it needs project-owner GCP auth.
+
+## Baseline / threshold rationale
+
+The threshold comes from first principles about post-fix legitimate load.
+
+The office-hours dashboard has 6 getters. After `3c961c7c`, each reads at most
+`limit(2000)` documents per call. The dashboard auto-refreshes roughly 12 times
+per hour per open tab. So the worst-case *legitimate* read volume is about:
+
+```
+6 getters × 2000 docs × 12 refreshes/hr × (a few concurrent tab-hours)
+```
+
+That lands in the low hundreds of thousands of reads per day, and it is spread
+across the hours a tab happens to be open — a modest per-hour rate. A
+regression that re-introduces an unbounded scan over a growing collection
+pushes the *hourly* count far above that, because the per-scan cost is no
+longer capped.
+
+The committed policy fires on:
+
+- metric `firestore.googleapis.com/document/read_count`
+- aggregated over a `3600s` alignment period with `ALIGN_DELTA` /
+  `REDUCE_SUM` (total reads in each 1-hour window)
+- `thresholdValue` **40000** (`COMPARISON_GT`)
+- `duration` **1800s** — the condition must hold for 30 minutes before it fires
+
+So: **more than 40,000 reads/hour, sustained 30 minutes.** That sits
+comfortably above the normal per-hour rate above, and well below a runaway
+full-collection loop. The 30-minute sustain filters out brief, benign bursts
+(a burst of tabs opening at once) while still catching a real regression within
+the hour.
+
+The budget backstops the same failure from the cost side. Firestore reads price
+at about **$0.06 per 100k reads**. The project's normal monthly Firestore bill
+is near zero, so a sustained runaway would materially exceed it and trip the
+`$50/mo` budget's 50% threshold early — long before it reaches the full amount.
+
+Both numbers — the **40,000 reads/hour** threshold and the **$50/mo** budget —
+are tunable starting estimates. They are deliberately round first cuts. The
+owner should adjust them once real post-fix traffic gives a measured baseline;
+raise them if normal load turns out higher, lower them for a tighter tripwire.
+
+## Notification channel
+
+Both alerts notify the owner email **`nathan@natb1.com`**.
+
+`apply-alerts.sh` resolves the channel with list-before-create: it lists
+existing email channels for that address and reuses one if present, otherwise
+creates it. This channel is a prerequisite for **both** alerts. Its resource id
+is injected into the monitoring policy via `--notification-channels` and into
+the budget via `--all-updates-rule-monitoring-notification-channels`.
+
+No environment-specific channel id is committed to the repo — the id is
+resolved at apply time and only exists in the live GCP project.
+
+## Owner apply + verify
+
+This runbook requires project-owner GCP auth. The autonomous dispatch runner
+**cannot** run it — it has no owner GCP credentials — so this is the owner's
+branch of the acceptance work.
+
+1. **Authenticate and select the project:**
+
+   ```
+   gcloud auth login
+   gcloud config set project commons-systems
+   ```
+
+2. **Apply the alerts:**
+
+   ```
+   ./ops/scripts/apply-alerts.sh
+   ```
+
+   The script prints the resolved channel id and a per-resource created
+   summary when it finishes.
+
+3. **Verify the resources exist:**
+
+   ```
+   gcloud monitoring policies list --project=commons-systems
+   gcloud beta monitoring channels list --project=commons-systems
+   ```
+
+   For the budget, first resolve the billing account, then list budgets under
+   it:
+
+   ```
+   gcloud billing projects describe commons-systems \
+     --format='value(billingAccountName)'
+   gcloud billing budgets list --billing-account=<ACCOUNT>
+   ```
+
+   `billingAccountName` comes back as `billingAccounts/<ACCOUNT>`; pass the bare
+   id (without the `billingAccounts/` prefix) to `--billing-account`.
+
+   Confirm the monitoring policy shows the `read_count` condition, the budget
+   shows the `$50` amount with the 50 / 90 / 100% thresholds, and both point at
+   the owner-email channel.
+
+4. **Test-fire the alert.** Temporarily lower the policy `thresholdValue` (or
+   generate enough read load) so the condition trips, confirm the owner
+   receives the alert email, then restore the threshold to `40000`. This
+   end-to-end check is the only way to confirm the channel actually delivers.
+   The autonomous dispatch runner **cannot** perform this step — it requires
+   owner auth and a live inbox.
+
+Re-running `apply-alerts.sh` is **not** fully idempotent. Only the notification
+channel step is idempotent (list-before-create). Steps 2 and 3 create a **new**
+policy and a **new** budget every run, so a second run leaves duplicate
+resources. If you need to re-apply, delete the stale policy and budget first:
+
+```
+gcloud monitoring policies delete <POLICY_ID> --project=commons-systems
+gcloud billing budgets delete <BUDGET_ID> --billing-account=<ACCOUNT>
+```

--- a/ops/monitoring/budget-alert.json
+++ b/ops/monitoring/budget-alert.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Params for `gcloud billing budgets create` — translated to flags by ops/scripts/apply-alerts.sh. Not a native gcloud policy file.",
+  "displayName": "commons-systems monthly spend (#2688)",
+  "budgetAmount": "50",
+  "currencyCode": "USD",
+  "thresholdPercents": [0.5, 0.9, 1.0],
+  "projectId": "commons-systems"
+}

--- a/ops/monitoring/firestore-read-count-alert.json
+++ b/ops/monitoring/firestore-read-count-alert.json
@@ -1,0 +1,29 @@
+{
+  "displayName": "Firestore document read_count above daily baseline (#2688)",
+  "combiner": "OR",
+  "conditions": [
+    {
+      "displayName": "Firestore reads > 40000/hour sustained 30m",
+      "conditionThreshold": {
+        "filter": "metric.type=\"firestore.googleapis.com/document/read_count\" resource.type=\"firestore.googleapis.com/Database\"",
+        "aggregations": [
+          {
+            "alignmentPeriod": "3600s",
+            "perSeriesAligner": "ALIGN_DELTA",
+            "crossSeriesReducer": "REDUCE_SUM"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "thresholdValue": 40000,
+        "duration": "1800s",
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "documentation": {
+    "mimeType": "text/markdown",
+    "content": "See .claude/docs/monitoring-alerts.md for rationale and the owner apply/verify runbook (issue #2688)."
+  }
+}

--- a/ops/scripts/apply-alerts.sh
+++ b/ops/scripts/apply-alerts.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Apply the Firestore read_count monitoring alert and the monthly budget alert
+# to the prod commons-systems GCP project. Requires project-owner GCP auth
+# (`gcloud auth login`). Orchestrates gcloud calls only; never run in CI.
+# See issue #2688 and .claude/docs/monitoring-alerts.md for rationale and the
+# owner apply/verify runbook.
+#
+# Idempotent ONLY for the notification channel (list-before-create). Re-running
+# steps 2 and 3 creates DUPLICATE policy/budget resources, so the owner runs
+# this once. See .claude/docs/monitoring-alerts.md.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PROJECT="commons-systems"
+OWNER_EMAIL="nathan@natb1.com"
+
+usage() {
+  cat >&2 <<EOF
+Usage: apply-alerts.sh
+
+Applies the Firestore read_count monitoring alert and the monthly budget alert
+to the prod ${PROJECT} GCP project. Requires project-owner GCP auth
+(gcloud auth login). Run once — steps 2 and 3 are not idempotent.
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+  esac
+done
+
+for cmd in gcloud jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "error: required command not found: $cmd" >&2
+    exit 1
+  fi
+done
+
+# 1. Resolve-or-create the owner email notification channel (prerequisite for
+#    BOTH alerts). List first so re-runs reuse an existing channel.
+CHANNEL_ID="$(gcloud beta monitoring channels list \
+  --project="$PROJECT" \
+  --filter='type="email" AND labels.email_address="'"$OWNER_EMAIL"'"' \
+  --format='value(name)')"
+
+if [[ -z "$CHANNEL_ID" ]]; then
+  CHANNEL_ID="$(gcloud beta monitoring channels create \
+    --project="$PROJECT" \
+    --type=email \
+    --display-name="Owner email (#2688)" \
+    --channel-labels=email_address="$OWNER_EMAIL" \
+    --format='value(name)')"
+fi
+
+if [[ -z "$CHANNEL_ID" ]]; then
+  echo "error: could not resolve or create the notification channel" >&2
+  exit 1
+fi
+
+# 2. Create the read_count monitoring policy, injecting the channel via flag.
+gcloud monitoring policies create \
+  --project="$PROJECT" \
+  --policy-from-file="$SCRIPT_DIR/../monitoring/firestore-read-count-alert.json" \
+  --notification-channels="$CHANNEL_ID"
+
+# 3. Create the monthly budget from the param file.
+BUDGET_FILE="$SCRIPT_DIR/../monitoring/budget-alert.json"
+DISPLAY_NAME="$(jq -r '.displayName' "$BUDGET_FILE")"
+AMOUNT="$(jq -r '.budgetAmount' "$BUDGET_FILE")"
+CURRENCY="$(jq -r '.currencyCode' "$BUDGET_FILE")"
+PROJECT_ID="$(jq -r '.projectId' "$BUDGET_FILE")"
+
+# Resolve the billing account. describe returns `billingAccounts/XXXX`; the
+# --billing-account flag wants the bare id, so strip the prefix.
+BILLING_ACCOUNT="$(gcloud billing projects describe "$PROJECT" \
+  --format='value(billingAccountName)')"
+BILLING_ACCOUNT="${BILLING_ACCOUNT#billingAccounts/}"
+
+# One --threshold-rule=percent=P flag per element of thresholdPercents.
+THRESHOLD_FLAGS=()
+while IFS= read -r pct; do
+  THRESHOLD_FLAGS+=("--threshold-rule=percent=$pct")
+done < <(jq -r '.thresholdPercents[]' "$BUDGET_FILE")
+
+gcloud billing budgets create \
+  --billing-account="$BILLING_ACCOUNT" \
+  --display-name="$DISPLAY_NAME" \
+  --budget-amount="${AMOUNT}${CURRENCY}" \
+  --filter-projects="projects/$PROJECT_ID" \
+  "${THRESHOLD_FLAGS[@]}" \
+  --all-updates-rule-monitoring-notification-channels="$CHANNEL_ID"
+
+# 4. Done summary.
+echo "Done."
+echo "  Notification channel: $CHANNEL_ID"
+echo "  Read-count monitoring policy: created"
+echo "  Monthly budget: created"
+echo "Verify both per the runbook in .claude/docs/monitoring-alerts.md (#2688)."

--- a/ops/scripts/apply-alerts.sh
+++ b/ops/scripts/apply-alerts.sh
@@ -80,6 +80,10 @@ PROJECT_ID="$(jq -r '.projectId' "$BUDGET_FILE")"
 BILLING_ACCOUNT="$(gcloud billing projects describe "$PROJECT" \
   --format='value(billingAccountName)')"
 BILLING_ACCOUNT="${BILLING_ACCOUNT#billingAccounts/}"
+if [[ -z "$BILLING_ACCOUNT" ]]; then
+  echo "error: could not resolve billing account for $PROJECT" >&2
+  exit 1
+fi
 
 # One --threshold-rule=percent=P flag per element of thresholdPercents.
 THRESHOLD_FLAGS=()


### PR DESCRIPTION
Closes #2688

## What

Adds the missing **detective control** for the Firestore read-spike class of failure (the #2683 spike ran Jun 28 → Jul 1 undetected because the project had no read-volume alert and no budget alert). Ships a committed, reproducible definition of:

1. A Cloud Monitoring `AlertPolicy` on `firestore.googleapis.com/document/read_count`.
2. A GCP budget alert on the `commons-systems` project.

Both route to the owner email, plus a rationale/runbook doc.

## Files

- `ops/monitoring/firestore-read-count-alert.json` — native Cloud Monitoring `AlertPolicy` (`--policy-from-file`). Fires when hourly summed reads exceed **40,000** sustained for **30 min**. No notification-channel id is committed — it is injected at apply time.
- `ops/monitoring/budget-alert.json` — parameter file for `gcloud billing budgets create` ($50/mo, 50/90/100% thresholds). It is a param file, not a native policy file, because `gcloud billing budgets create` takes flags, not `--policy-from-file`; the apply script translates the fields to flags via `jq`.
- `ops/scripts/apply-alerts.sh` — owner-run apply orchestration. Resolves-or-creates the owner email notification channel first (list-before-create), then injects its id into both alerts.
- `.claude/docs/monitoring-alerts.md` — why, the first-principles threshold math, notification-channel handling, and the owner apply + verify runbook.

## Design notes

- The repo has zero IaC, so the greenfield form is a committed gcloud shell script + JSON definition files + a doc, mirroring the existing `<app>/scripts/*.sh` convention. No Terraform is introduced.
- The **notification channel is a prerequisite for both alerts** and is created/resolved first at apply time; its id is injected via CLI flags, so no environment-specific channel id is ever committed.
- The `40000 reads/hour` threshold and `$50/mo` budget are reasoned starting estimates the owner can tune (rationale in the doc).

## Live apply — owner step

The live GCP apply needs project-owner credentials the autonomous runner lacks. It is documented as an owner apply + verify + test-fire step in `.claude/docs/monitoring-alerts.md`. This is the branch of acceptance criterion #4 available to this PR.

## Verification

Static file validation only — no `gcloud` call runs in any verify block (the runner has no owner GCP auth). Both JSON files validate, the policy shape and metric are asserted, the committed policy carries no notification-channel id, the budget param fields are present, and `apply-alerts.sh` parses (`bash -n`).
