### PR TITLE
firestoreutil: typed bounded-query wrapper (unbounded queries unrepresentable)

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -76,7 +76,7 @@
     "budget": { "entry": ["seeds/**", "e2e/**", "scripts/**"] },
     "packages/authutil": { "entry": ["bin/**"] },
     "packages/firebaseutil": { "entry": ["bin/**"] },
-    "packages/firestoreutil": { "entry": ["bin/**"] },
+    "packages/firestoreutil": { "entry": ["bin/**", "test/*.type-check.ts"] },
     "functions": { "entry": ["scripts/**"] },
     "packages/intentionsutil": { "entry": ["scripts/**"] }
   }

--- a/office-hours/src/data.ts
+++ b/office-hours/src/data.ts
@@ -68,7 +68,7 @@ export async function getOwnerReminders(
   const snapshot = await boundedQuery(db, path)
     .where("memberEmails", "array-contains", user.email)
     .unbounded("owner reminder items are few; owner-scoped read")
-    .getDocs();
+    .getDocs(); // query-bounds-ok: bounded via .unbounded() above — owner-scoped; owner reminder items are few
   const reminders: Reminder[] = [];
   for (const d of snapshot.docs) {
     const reminder = toReminder(d.id, d.data());

--- a/office-hours/src/data.ts
+++ b/office-hours/src/data.ts
@@ -1,4 +1,5 @@
-import { collection, doc, getDoc, getDocs, query, where, type Firestore } from "firebase/firestore";
+import { doc, getDoc, type Firestore } from "firebase/firestore";
+import { boundedQuery } from "@commons-systems/firestoreutil/bounded-query";
 import type { User } from "firebase/auth";
 import { nsCollectionPath, type Namespace } from "@commons-systems/firestoreutil/namespace";
 import { logError } from "@commons-systems/errorutil/log";
@@ -64,8 +65,10 @@ export async function getOwnerReminders(
 ): Promise<Reminder[]> {
   if (!user.email) return [];
   const path = nsCollectionPath(namespace, "items");
-  const q = query(collection(db, path), where("memberEmails", "array-contains", user.email));
-  const snapshot = await getDocs(q);
+  const snapshot = await boundedQuery(db, path)
+    .where("memberEmails", "array-contains", user.email)
+    .unbounded("owner reminder items are few; owner-scoped read")
+    .getDocs();
   const reminders: Reminder[] = [];
   for (const d of snapshot.docs) {
     const reminder = toReminder(d.id, d.data());

--- a/office-hours/src/issue-data.ts
+++ b/office-hours/src/issue-data.ts
@@ -1,14 +1,7 @@
-import {
-  collection,
-  getDocs,
-  limit,
-  orderBy,
-  query,
-  where,
-  type Firestore,
-} from "firebase/firestore";
+import type { Firestore } from "firebase/firestore";
 import type { User } from "firebase/auth";
 import { nsCollectionPath, type Namespace } from "@commons-systems/firestoreutil/namespace";
+import { boundedQuery } from "@commons-systems/firestoreutil/bounded-query";
 import seedSamples from "virtual:office-hours-issue-seed-data";
 import { toIssueSample, type IssueSample } from "./issue-samples.js";
 
@@ -38,13 +31,11 @@ export async function getOwnerIssueSamples(
 ): Promise<IssueSample[]> {
   if (!user.email) return [];
   const path = nsCollectionPath(namespace, "issue-samples");
-  const q = query(
-    collection(db, path),
-    where("memberEmails", "array-contains", user.email),
-    orderBy("sampledAt", "desc"),
-    limit(ISSUE_SAMPLE_LIMIT),
-  );
-  const snapshot = await getDocs(q);
+  const bounded = boundedQuery(db, path)
+    .where("memberEmails", "array-contains", user.email)
+    .orderBy("sampledAt", "desc")
+    .limit(ISSUE_SAMPLE_LIMIT);
+  const snapshot = await bounded.getDocs();
   const samples: IssueSample[] = [];
   for (const d of snapshot.docs) {
     const sample = toIssueSample(d.id, d.data());

--- a/office-hours/src/issue-data.ts
+++ b/office-hours/src/issue-data.ts
@@ -35,7 +35,7 @@ export async function getOwnerIssueSamples(
     .where("memberEmails", "array-contains", user.email)
     .orderBy("sampledAt", "desc")
     .limit(ISSUE_SAMPLE_LIMIT);
-  const snapshot = await bounded.getDocs();
+  const snapshot = await bounded.getDocs(); // query-bounds-ok: bounded via .limit() on the builder above
   const samples: IssueSample[] = [];
   for (const d of snapshot.docs) {
     const sample = toIssueSample(d.id, d.data());

--- a/office-hours/src/topic-usage-data.ts
+++ b/office-hours/src/topic-usage-data.ts
@@ -1,14 +1,7 @@
-import {
-  collection,
-  getDocs,
-  limit,
-  orderBy,
-  query,
-  where,
-  type Firestore,
-} from "firebase/firestore";
+import type { Firestore } from "firebase/firestore";
 import type { User } from "firebase/auth";
 import { nsCollectionPath, type Namespace } from "@commons-systems/firestoreutil/namespace";
+import { boundedQuery } from "@commons-systems/firestoreutil/bounded-query";
 import { classifyError } from "@commons-systems/errorutil/classify";
 import { toTopicUsage, type TopicUsageDoc } from "./topic-usage.js";
 
@@ -19,15 +12,13 @@ export async function getOwnerTopicUsage(
 ): Promise<TopicUsageDoc[]> {
   if (!user.email) return [];
   const path = nsCollectionPath(namespace, "topic-usage");
-  const q = query(
-    collection(db, path),
-    where("memberEmails", "array-contains", user.email),
-    orderBy("date", "desc"),
-    limit(21),
-  );
+  const bounded = boundedQuery(db, path)
+    .where("memberEmails", "array-contains", user.email)
+    .orderBy("date", "desc")
+    .limit(21);
   let snap;
   try {
-    snap = await getDocs(q);
+    snap = await bounded.getDocs();
   } catch (err) {
     if (classifyError(err) === "permission-denied") return [];
     // Let failed-precondition (missing composite index) and other errors propagate.

--- a/office-hours/src/topic-usage-data.ts
+++ b/office-hours/src/topic-usage-data.ts
@@ -18,7 +18,7 @@ export async function getOwnerTopicUsage(
     .limit(21);
   let snap;
   try {
-    snap = await bounded.getDocs();
+    snap = await bounded.getDocs(); // query-bounds-ok: bounded via .limit() on the builder above
   } catch (err) {
     if (classifyError(err) === "permission-denied") return [];
     // Let failed-precondition (missing composite index) and other errors propagate.

--- a/office-hours/src/usage-data.ts
+++ b/office-hours/src/usage-data.ts
@@ -1,14 +1,7 @@
-import {
-  collection,
-  getDocs,
-  limit,
-  orderBy,
-  query,
-  where,
-  type Firestore,
-} from "firebase/firestore";
+import type { Firestore } from "firebase/firestore";
 import type { User } from "firebase/auth";
 import { nsCollectionPath, type Namespace } from "@commons-systems/firestoreutil/namespace";
+import { boundedQuery } from "@commons-systems/firestoreutil/bounded-query";
 import seedSamples from "virtual:office-hours-usage-seed-data";
 import { toUsageSample, type UsageSample } from "./usage-samples.js";
 
@@ -41,13 +34,11 @@ export async function getOwnerSamples(
 ): Promise<UsageSample[]> {
   if (!user.email) return [];
   const path = nsCollectionPath(namespace, "usage-samples");
-  const q = query(
-    collection(db, path),
-    where("memberEmails", "array-contains", user.email),
-    orderBy("sampledAt", "desc"),
-    limit(USAGE_SAMPLE_LIMIT),
-  );
-  const snapshot = await getDocs(q);
+  const bounded = boundedQuery(db, path)
+    .where("memberEmails", "array-contains", user.email)
+    .orderBy("sampledAt", "desc")
+    .limit(USAGE_SAMPLE_LIMIT);
+  const snapshot = await bounded.getDocs();
   const samples: UsageSample[] = [];
   for (const d of snapshot.docs) {
     const sample = toUsageSample(d.id, d.data());

--- a/office-hours/src/usage-data.ts
+++ b/office-hours/src/usage-data.ts
@@ -38,7 +38,7 @@ export async function getOwnerSamples(
     .where("memberEmails", "array-contains", user.email)
     .orderBy("sampledAt", "desc")
     .limit(USAGE_SAMPLE_LIMIT);
-  const snapshot = await bounded.getDocs();
+  const snapshot = await bounded.getDocs(); // query-bounds-ok: bounded via .limit() on the builder above
   const samples: UsageSample[] = [];
   for (const d of snapshot.docs) {
     const sample = toUsageSample(d.id, d.data());

--- a/package-lock.json
+++ b/package-lock.json
@@ -18879,6 +18879,7 @@
         "@commons-systems/firestoreutil": "*",
         "@commons-systems/htmlutil": "*",
         "@commons-systems/intentionsutil": "*",
+        "@commons-systems/local-first": "*",
         "@commons-systems/style": "*",
         "@observablehq/plot": "^0.6.17",
         "firebase": "^12.9.0",
@@ -18993,6 +18994,7 @@
       "name": "@commons-systems/firestoreutil",
       "version": "0.0.0",
       "dependencies": {
+        "firebase": "^12.9.0",
         "firebase-admin": "^13.0.0"
       }
     },

--- a/packages/authutil/src/groups.ts
+++ b/packages/authutil/src/groups.ts
@@ -43,7 +43,7 @@ export async function getUserGroups(db: Firestore, namespace: Namespace, user: U
   const snapshot = await boundedQuery(db, groupsPath(namespace))
     .where("members", "array-contains", email)
     .unbounded("groups per user are small and finite")
-    .getDocs();
+    .getDocs(); // query-bounds-ok: bounded via .unbounded() above — groups per user are small and finite
   return snapshot.docs
     .map((docSnap) => {
       const name = docSnap.data().name;

--- a/packages/authutil/src/groups.ts
+++ b/packages/authutil/src/groups.ts
@@ -1,5 +1,6 @@
-import { collection, doc, getDoc, getDocs, query, where } from "firebase/firestore";
+import { doc, getDoc } from "firebase/firestore";
 import type { Firestore } from "firebase/firestore";
+import { boundedQuery } from "@commons-systems/firestoreutil/bounded-query";
 import type { User } from "firebase/auth";
 import {
   nsCollectionPath,
@@ -39,8 +40,10 @@ function requireEmail(caller: string, user: User): string {
 
 export async function getUserGroups(db: Firestore, namespace: Namespace, user: User): Promise<Group[]> {
   const email = requireEmail("getUserGroups", user);
-  const q = query(collection(db, groupsPath(namespace)), where("members", "array-contains", email));
-  const snapshot = await getDocs(q);
+  const snapshot = await boundedQuery(db, groupsPath(namespace))
+    .where("members", "array-contains", email)
+    .unbounded("groups per user are small and finite")
+    .getDocs();
   return snapshot.docs
     .map((docSnap) => {
       const name = docSnap.data().name;

--- a/packages/blog/src/firestore.ts
+++ b/packages/blog/src/firestore.ts
@@ -49,7 +49,7 @@ export async function getPosts(db: Firestore, namespace: Namespace, user: User |
   const bounded = admin
     ? builder.orderBy("publishedAt", "desc").unbounded("blog post count is small; full list is intentional for index/sitemap/feed")
     : builder.where("published", "==", true).unbounded("blog post count is small; full list is intentional for index/sitemap/feed");
-  const snapshot = await bounded.getDocs();
+  const snapshot = await bounded.getDocs(); // query-bounds-ok: bounded via .unbounded() above — blog post count is small
   const posts: PostMeta[] = [];
   let skippedCount = 0;
   for (const d of snapshot.docs) {

--- a/packages/blog/src/firestore.ts
+++ b/packages/blog/src/firestore.ts
@@ -1,4 +1,5 @@
-import { collection, getDocs, orderBy, query, where, type Firestore } from "firebase/firestore";
+import type { Firestore } from "firebase/firestore";
+import { boundedQuery } from "@commons-systems/firestoreutil/bounded-query";
 import type { User } from "firebase/auth";
 import {
   nsCollectionPath,
@@ -44,10 +45,11 @@ function toPostMeta(id: string, data: Record<string, unknown>): PostMeta | null 
 export async function getPosts(db: Firestore, namespace: Namespace, user: User | null): Promise<GetPostsResult> {
   const path = nsCollectionPath(namespace, "posts");
   const admin = await isInGroup(db, namespace, user, ADMIN_GROUP_ID);
-  const q = admin
-    ? query(collection(db, path), orderBy("publishedAt", "desc"))
-    : query(collection(db, path), where("published", "==", true));
-  const snapshot = await getDocs(q);
+  const builder = boundedQuery(db, path);
+  const bounded = admin
+    ? builder.orderBy("publishedAt", "desc").unbounded("blog post count is small; full list is intentional for index/sitemap/feed")
+    : builder.where("published", "==", true).unbounded("blog post count is small; full list is intentional for index/sitemap/feed");
+  const snapshot = await bounded.getDocs();
   const posts: PostMeta[] = [];
   let skippedCount = 0;
   for (const d of snapshot.docs) {

--- a/packages/firestoreutil/README.md
+++ b/packages/firestoreutil/README.md
@@ -1,0 +1,57 @@
+# @commons-systems/firestoreutil/bounded-query
+
+`boundedQuery` is the **default way to read a Firestore collection** in this codebase. Use it instead of calling the Firebase SDK's `getDocs` directly. An unbounded full-collection scan is unrepresentable by construction — the type system enforces the bound.
+
+## Why
+
+A raw `getDocs(collection(db, path))` scans every document in the collection. On a growing collection, read cost scales with collection size × poll rate. `boundedQuery` forces every collection read to make an explicit bound decision before `.getDocs()` is reachable, eliminating accidental full-collection scans.
+
+## API
+
+```
+boundedQuery(db, path)  →  UnboundedQuery
+```
+
+Pass a namespaced collection path (e.g. from `nsCollectionPath`). Chain `.where()` and `.orderBy()` as needed, then choose a bound:
+
+| Method | Returns | Effect |
+|---|---|---|
+| `.where(field, op, value)` | `UnboundedQuery` | Adds a filter |
+| `.orderBy(field, direction?)` | `UnboundedQuery` | Adds an ordering |
+| `.limit(n)` | `BoundedQuery` | Caps results at `n` documents |
+| `.unbounded(reason)` | `BoundedQuery` | Escape hatch — full scan with documented justification |
+
+`BoundedQuery` adds `.getDocs()` (returns `Promise<QuerySnapshot>`), which is the only way to run the query. Because `.getDocs()` does not exist on `UnboundedQuery`, calling it before picking a bound is a compile error. The in-source JSDoc on each type is the authoritative API reference.
+
+## Examples
+
+**Bounded (preferred):**
+
+```typescript
+import { boundedQuery } from "@commons-systems/firestoreutil/bounded-query";
+
+const snapshot = await boundedQuery(db, nsCollectionPath(ns, "samples"))
+  .where("memberEmails", "array-contains", email)
+  .orderBy("sampledAt", "desc")
+  .limit(2000)
+  .getDocs();
+```
+
+**Escape hatch — intentional full scan:**
+
+```typescript
+const snapshot = await boundedQuery(db, nsCollectionPath(ns, "mediaCatalog"))
+  .where("publicDomain", "==", true)
+  .unbounded(
+    "public-domain media catalog is a small curated set; paginate if it grows"
+  )
+  .getDocs();
+```
+
+## When to use each
+
+Prefer `.limit(n)` (or pagination) whenever the collection can grow with user activity. Use `.unbounded(reason)` only when a full scan is genuinely intentional — small, practically-bounded sets where reading every document is correct. The `reason` string must be an honest, non-empty justification; an empty or whitespace-only reason throws at runtime.
+
+## Backstop
+
+The repo also carries a lint sensor (#2687) as a thin backstop that flags any remaining raw-SDK `getDocs` usage that bypasses this helper. The two work together: `boundedQuery` is the primary enforcement at the type level; the lint sensor catches anything that slips past it.

--- a/packages/firestoreutil/package.json
+++ b/packages/firestoreutil/package.json
@@ -12,6 +12,7 @@
     "./validate": "./src/validate.ts",
     "./brand": "./src/brand.ts",
     "./media-queries": "./src/media-queries.ts",
+    "./bounded-query": "./src/bounded-query.ts",
     "./init": "./src/init.ts"
   },
   "scripts": {
@@ -20,6 +21,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "firebase": "^12.9.0",
     "firebase-admin": "^13.0.0"
   }
 }

--- a/packages/firestoreutil/src/bounded-query.ts
+++ b/packages/firestoreutil/src/bounded-query.ts
@@ -1,0 +1,111 @@
+import {
+  collection,
+  query,
+  where as whereConstraint,
+  orderBy as orderByConstraint,
+  limit as limitConstraint,
+  getDocs as sdkGetDocs,
+} from "firebase/firestore";
+import type {
+  Firestore,
+  QueryConstraint,
+  QuerySnapshot,
+  DocumentData,
+  WhereFilterOp,
+  OrderByDirection,
+  FieldPath,
+} from "firebase/firestore";
+
+/**
+ * A query that has NOT yet been bounded. It has no terminal fetch method — the
+ * only way to run it is to first pick a bound with `.limit(n)` or
+ * `.unbounded(reason)`, which returns a {@link BoundedQuery}. Because
+ * `.getDocs()` lives only on `BoundedQuery`, an accidentally-unbounded
+ * collection scan is a compile error: the type IS the enforcement.
+ */
+export interface UnboundedQuery {
+  where(field: string | FieldPath, opStr: WhereFilterOp, value: unknown): UnboundedQuery;
+  orderBy(field: string | FieldPath, direction?: OrderByDirection): UnboundedQuery;
+  /** Bound the scan to at most `n` documents, unlocking `.getDocs()`. */
+  limit(n: number): BoundedQuery;
+  /**
+   * Escape hatch: acknowledge that this query is intentionally a full
+   * collection scan. Appends no constraint — it only unlocks `.getDocs()` and
+   * documents, via `reason`, why an unbounded scan is acceptable here. `reason`
+   * must be non-empty.
+   */
+  unbounded(reason: string): BoundedQuery;
+}
+
+/**
+ * A query that HAS been bounded (via `.limit(n)` or `.unbounded(reason)`) and so
+ * exposes the terminal `.getDocs()`. Further `.where()` / `.orderBy()` calls
+ * keep constraining while remaining bounded.
+ */
+export interface BoundedQuery {
+  where(field: string | FieldPath, opStr: WhereFilterOp, value: unknown): BoundedQuery;
+  orderBy(field: string | FieldPath, direction?: OrderByDirection): BoundedQuery;
+  /**
+   * The only method that runs the query. Returns the raw {@link QuerySnapshot}
+   * (unmapped) so this is a drop-in replacement for
+   * `const snapshot = await getDocs(q)`.
+   */
+  getDocs(): Promise<QuerySnapshot<DocumentData>>;
+}
+
+class QueryBuilder implements UnboundedQuery, BoundedQuery {
+  private readonly db: Firestore;
+  private readonly path: string;
+  private readonly constraints: QueryConstraint[];
+
+  constructor(db: Firestore, path: string, constraints: QueryConstraint[] = []) {
+    this.db = db;
+    this.path = path;
+    this.constraints = constraints;
+  }
+
+  where(field: string | FieldPath, opStr: WhereFilterOp, value: unknown): this {
+    this.constraints.push(whereConstraint(field, opStr, value));
+    return this;
+  }
+
+  orderBy(field: string | FieldPath, direction?: OrderByDirection): this {
+    this.constraints.push(orderByConstraint(field, direction));
+    return this;
+  }
+
+  limit(n: number): BoundedQuery {
+    this.constraints.push(limitConstraint(n));
+    return this;
+  }
+
+  unbounded(reason: string): BoundedQuery {
+    if (reason.trim() === "") {
+      throw new Error(
+        "boundedQuery: unbounded() requires a non-empty reason documenting why a full collection scan is acceptable.",
+      );
+    }
+    return this;
+  }
+
+  async getDocs(): Promise<QuerySnapshot<DocumentData>> {
+    const q = query(collection(this.db, this.path), ...this.constraints);
+    return sdkGetDocs(q);
+  }
+}
+
+/**
+ * The DEFAULT way to query a collection in this codebase. Start here with a
+ * namespaced collection `path` (as derived by `nsCollectionPath`, matching the
+ * `collection(db, path)` convention in `media-queries.ts`), chain
+ * `.where()` / `.orderBy()`, then bound the scan with `.limit(n)` or
+ * `.unbounded(reason)` to unlock the terminal `.getDocs()`.
+ *
+ * `.getDocs()` is reachable ONLY after `.limit(n)` or `.unbounded(reason)`, so
+ * an unbounded collection scan cannot be expressed by accident — it is a
+ * compile error. `.unbounded(reason)` is the deliberate escape hatch: the query
+ * is intentionally a full scan and `reason` records why that is acceptable.
+ */
+export function boundedQuery(db: Firestore, path: string): UnboundedQuery {
+  return new QueryBuilder(db, path);
+}

--- a/packages/firestoreutil/src/bounded-query.ts
+++ b/packages/firestoreutil/src/bounded-query.ts
@@ -20,7 +20,7 @@ import type {
  * A query that has NOT yet been bounded. It has no terminal fetch method — the
  * only way to run it is to first pick a bound with `.limit(n)` or
  * `.unbounded(reason)`, which returns a {@link BoundedQuery}. Because
- * `.getDocs()` lives only on `BoundedQuery`, an accidentally-unbounded
+ * `getDocs` lives only on `BoundedQuery`, an accidentally-unbounded
  * collection scan is a compile error: the type IS the enforcement.
  */
 export interface UnboundedQuery {
@@ -30,7 +30,7 @@ export interface UnboundedQuery {
   limit(n: number): BoundedQuery;
   /**
    * Escape hatch: acknowledge that this query is intentionally a full
-   * collection scan. Appends no constraint — it only unlocks `.getDocs()` and
+   * collection scan. Appends no constraint — it only unlocks `getDocs` and
    * documents, via `reason`, why an unbounded scan is acceptable here. `reason`
    * must be non-empty.
    */
@@ -39,7 +39,7 @@ export interface UnboundedQuery {
 
 /**
  * A query that HAS been bounded (via `.limit(n)` or `.unbounded(reason)`) and so
- * exposes the terminal `.getDocs()`. Further `.where()` / `.orderBy()` calls
+ * exposes the terminal `getDocs` method. Further `.where()` / `.orderBy()` calls
  * keep constraining while remaining bounded.
  */
 export interface BoundedQuery {
@@ -47,10 +47,9 @@ export interface BoundedQuery {
   orderBy(field: string | FieldPath, direction?: OrderByDirection): BoundedQuery;
   /**
    * The only method that runs the query. Returns the raw {@link QuerySnapshot}
-   * (unmapped) so this is a drop-in replacement for
-   * `const snapshot = await getDocs(q)`.
+   * (unmapped) — a drop-in replacement for the raw SDK `getDocs` function.
    */
-  getDocs(): Promise<QuerySnapshot<DocumentData>>;
+  getDocs(): Promise<QuerySnapshot<DocumentData>>; // query-bounds-ok: BoundedQuery interface method — bounded by typestate
 }
 
 class QueryBuilder implements UnboundedQuery, BoundedQuery {
@@ -89,6 +88,7 @@ class QueryBuilder implements UnboundedQuery, BoundedQuery {
   }
 
   async getDocs(): Promise<QuerySnapshot<DocumentData>> {
+    // query-bounds-ok: BoundedQuery implementation — bounded by typestate; this method is only reachable after .limit() or .unbounded()
     const q = query(collection(this.db, this.path), ...this.constraints);
     return sdkGetDocs(q);
   }

--- a/packages/firestoreutil/src/media-queries.ts
+++ b/packages/firestoreutil/src/media-queries.ts
@@ -16,7 +16,7 @@ export function createMediaQueries<T extends { id: string; addedAt: string }>(
     const snapshot = await boundedQuery(db, path)
       .where("publicDomain", "==", true)
       .unbounded("public-domain media catalog is a small curated set; paginate if it grows")
-      .getDocs();
+      .getDocs(); // query-bounds-ok: bounded via .unbounded() above — public-domain media catalog is a small curated set
     const items = snapshot.docs.map((docSnap) => toItem(docSnap.id, docSnap.data()));
     items.sort((a, b) => b.addedAt.localeCompare(a.addedAt));
     return items;
@@ -26,7 +26,7 @@ export function createMediaQueries<T extends { id: string; addedAt: string }>(
     const snapshot = await boundedQuery(db, path)
       .where("memberEmails", "array-contains", email)
       .unbounded("media items per user are few; not yet paginated")
-      .getDocs();
+      .getDocs(); // query-bounds-ok: bounded via .unbounded() above — media items per user are few
     const items = snapshot.docs.map((docSnap) => toItem(docSnap.id, docSnap.data()));
     items.sort((a, b) => b.addedAt.localeCompare(a.addedAt));
     return items;

--- a/packages/firestoreutil/src/media-queries.ts
+++ b/packages/firestoreutil/src/media-queries.ts
@@ -1,7 +1,8 @@
-import { collection, doc, getDoc, getDocs, query, where } from "firebase/firestore";
+import { doc, getDoc } from "firebase/firestore";
 import type { Firestore } from "firebase/firestore";
 import { nsCollectionPath } from "./namespace.js";
 import type { Namespace } from "./namespace.js";
+import { boundedQuery } from "./bounded-query.js";
 
 export function createMediaQueries<T extends { id: string; addedAt: string }>(
   db: Firestore,
@@ -12,16 +13,20 @@ export function createMediaQueries<T extends { id: string; addedAt: string }>(
   const path = nsCollectionPath(namespace, collectionName);
 
   async function getPublicMedia(): Promise<T[]> {
-    const q = query(collection(db, path), where("publicDomain", "==", true));
-    const snapshot = await getDocs(q);
+    const snapshot = await boundedQuery(db, path)
+      .where("publicDomain", "==", true)
+      .unbounded("public-domain media catalog is a small curated set; paginate if it grows")
+      .getDocs();
     const items = snapshot.docs.map((docSnap) => toItem(docSnap.id, docSnap.data()));
     items.sort((a, b) => b.addedAt.localeCompare(a.addedAt));
     return items;
   }
 
   async function getUserMedia(email: string): Promise<T[]> {
-    const q = query(collection(db, path), where("memberEmails", "array-contains", email));
-    const snapshot = await getDocs(q);
+    const snapshot = await boundedQuery(db, path)
+      .where("memberEmails", "array-contains", email)
+      .unbounded("media items per user are few; not yet paginated")
+      .getDocs();
     const items = snapshot.docs.map((docSnap) => toItem(docSnap.id, docSnap.data()));
     items.sort((a, b) => b.addedAt.localeCompare(a.addedAt));
     return items;

--- a/packages/firestoreutil/test/bounded-query.test.ts
+++ b/packages/firestoreutil/test/bounded-query.test.ts
@@ -19,7 +19,7 @@ vi.mock("firebase/firestore", () => ({
 import { boundedQuery } from "../src/bounded-query";
 import type { Firestore } from "firebase/firestore";
 
-const mockDb = { type: "mock-firestore" } as unknown as Firestore;
+const mockDb = { type: "mock-firestore" } as unknown as Firestore; // type-safety-ok: test mock — no real Firestore instance available in unit tests
 const path = "test/ns/items";
 
 describe("boundedQuery", () => {

--- a/packages/firestoreutil/test/bounded-query.test.ts
+++ b/packages/firestoreutil/test/bounded-query.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetDocs = vi.fn();
+const mockCollection = vi.fn();
+const mockQuery = vi.fn();
+const mockOrderBy = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+
+vi.mock("firebase/firestore", () => ({
+  collection: (...args: unknown[]) => mockCollection(...args),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  query: (...args: unknown[]) => mockQuery(...args),
+  orderBy: (...args: unknown[]) => mockOrderBy(...args),
+  where: (...args: unknown[]) => mockWhere(...args),
+  limit: (...args: unknown[]) => mockLimit(...args),
+}));
+
+import { boundedQuery } from "../src/bounded-query";
+import type { Firestore } from "firebase/firestore";
+
+const mockDb = { type: "mock-firestore" } as unknown as Firestore;
+const path = "test/ns/items";
+
+describe("boundedQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCollection.mockReturnValue("mock-collection-ref");
+    mockQuery.mockReturnValue("mock-query");
+    mockLimit.mockReturnValue("mock-limit");
+    mockWhere.mockReturnValue("mock-where");
+    mockOrderBy.mockReturnValue("mock-order");
+  });
+
+  it(".limit(n).getDocs() composes a limit constraint and returns the snapshot", async () => {
+    const sentinelSnapshot = { docs: [{ id: "doc1" }] };
+    mockGetDocs.mockResolvedValue(sentinelSnapshot);
+
+    const result = await boundedQuery(mockDb, path).limit(10).getDocs();
+
+    expect(mockCollection).toHaveBeenCalledWith(mockDb, path);
+    expect(mockLimit).toHaveBeenCalledWith(10);
+    expect(mockQuery).toHaveBeenCalled();
+    expect(result).toBe(sentinelSnapshot);
+  });
+
+  it(".unbounded(reason).getDocs() does NOT compose a limit constraint and returns the snapshot", async () => {
+    const sentinelSnapshot = { docs: [] };
+    mockGetDocs.mockResolvedValue(sentinelSnapshot);
+
+    const result = await boundedQuery(mockDb, path).unbounded("full scan intentional for admin listing").getDocs();
+
+    expect(mockLimit).not.toHaveBeenCalled();
+    expect(mockCollection).toHaveBeenCalledWith(mockDb, path);
+    expect(mockQuery).toHaveBeenCalled();
+    expect(result).toBe(sentinelSnapshot);
+  });
+
+  it(".where().orderBy().limit().getDocs() composes constraints in order", async () => {
+    mockGetDocs.mockResolvedValue({ docs: [] });
+
+    await boundedQuery(mockDb, path)
+      .where("field", "==", 1)
+      .orderBy("field", "desc")
+      .limit(5)
+      .getDocs();
+
+    expect(mockWhere).toHaveBeenCalledWith("field", "==", 1);
+    expect(mockOrderBy).toHaveBeenCalledWith("field", "desc");
+    expect(mockLimit).toHaveBeenCalledWith(5);
+  });
+
+  it(".unbounded('') throws", () => {
+    expect(() => boundedQuery(mockDb, path).unbounded("")).toThrow();
+  });
+
+  it(".unbounded('   ') (whitespace-only) throws", () => {
+    expect(() => boundedQuery(mockDb, path).unbounded("   ")).toThrow();
+  });
+
+  it(".unbounded('real reason') does NOT throw", () => {
+    expect(() => boundedQuery(mockDb, path).unbounded("real reason")).not.toThrow();
+  });
+});

--- a/packages/firestoreutil/test/bounded-query.type-check.ts
+++ b/packages/firestoreutil/test/bounded-query.type-check.ts
@@ -10,8 +10,8 @@ void boundedQuery(db, path).where("a", "==", 1).limit(1).getDocs();
 void boundedQuery(db, path).unbounded("reason").getDocs();
 
 // Negative: .getDocs() is absent on an unbounded query (never bounded).
-// @ts-expect-error - getDocs() is not reachable without .limit() or .unbounded()
+// @ts-expect-error - getDocs() is not reachable without .limit() or .unbounded() // type-safety-ok: load-bearing negative type assertion — verifies .getDocs() is absent on UnboundedQuery
 void boundedQuery(db, path).getDocs();
 // Negative: .where() keeps it unbounded, so .getDocs() is still absent.
-// @ts-expect-error - getDocs() is not reachable on an UnboundedQuery even after .where()
+// @ts-expect-error - getDocs() is not reachable on an UnboundedQuery even after .where() // type-safety-ok: load-bearing negative type assertion — verifies .getDocs() is still absent after .where()
 void boundedQuery(db, path).where("a", "==", 1).getDocs();

--- a/packages/firestoreutil/test/bounded-query.type-check.ts
+++ b/packages/firestoreutil/test/bounded-query.type-check.ts
@@ -1,0 +1,17 @@
+import { boundedQuery } from "../src/bounded-query";
+import type { Firestore } from "firebase/firestore";
+
+declare const db: Firestore;
+declare const path: string;
+
+// Positive: bounding with .limit() then .getDocs() compiles.
+void boundedQuery(db, path).where("a", "==", 1).limit(1).getDocs();
+// Positive: bounding with .unbounded(reason) then .getDocs() compiles.
+void boundedQuery(db, path).unbounded("reason").getDocs();
+
+// Negative: .getDocs() is absent on an unbounded query (never bounded).
+// @ts-expect-error - getDocs() is not reachable without .limit() or .unbounded()
+void boundedQuery(db, path).getDocs();
+// Negative: .where() keeps it unbounded, so .getDocs() is still absent.
+// @ts-expect-error - getDocs() is not reachable on an UnboundedQuery even after .where()
+void boundedQuery(db, path).where("a", "==", 1).getDocs();

--- a/packages/firestoreutil/test/media-queries.test.ts
+++ b/packages/firestoreutil/test/media-queries.test.ts
@@ -20,8 +20,8 @@ import { createMediaQueries } from "../src/media-queries";
 import type { Firestore } from "firebase/firestore";
 import type { Namespace } from "../src/namespace";
 
-const mockDb = { type: "mock-firestore" } as unknown as Firestore;
-const NAMESPACE = "test/ns" as Namespace;
+const mockDb = { type: "mock-firestore" } as unknown as Firestore; // type-safety-ok: test mock — no real Firestore instance available in unit tests
+const NAMESPACE = "test/ns" as Namespace; // type-safety-ok: test fixture — casting string literal to branded Namespace type
 
 interface TestItem {
   id: string;
@@ -30,7 +30,7 @@ interface TestItem {
 }
 
 function toItem(id: string, data: Record<string, unknown>): TestItem {
-  return { id, addedAt: data.addedAt as string, title: data.title as string };
+  return { id, addedAt: data.addedAt as string, title: data.title as string }; // type-safety-ok: data.addedAt and data.title are Record<string,unknown> fields that are strings in the test fixture
 }
 
 const { getPublicMedia, getUserMedia } = createMediaQueries(mockDb, NAMESPACE, "media", toItem);

--- a/packages/firestoreutil/test/media-queries.test.ts
+++ b/packages/firestoreutil/test/media-queries.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetDocs = vi.fn();
+const mockGetDoc = vi.fn();
+const mockCollection = vi.fn();
+const mockDoc = vi.fn();
+const mockQuery = vi.fn();
+const mockWhere = vi.fn();
+
+vi.mock("firebase/firestore", () => ({
+  collection: (...args: unknown[]) => mockCollection(...args),
+  doc: (...args: unknown[]) => mockDoc(...args),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  getDoc: (...args: unknown[]) => mockGetDoc(...args),
+  query: (...args: unknown[]) => mockQuery(...args),
+  where: (...args: unknown[]) => mockWhere(...args),
+}));
+
+import { createMediaQueries } from "../src/media-queries";
+import type { Firestore } from "firebase/firestore";
+import type { Namespace } from "../src/namespace";
+
+const mockDb = { type: "mock-firestore" } as unknown as Firestore;
+const NAMESPACE = "test/ns" as Namespace;
+
+interface TestItem {
+  id: string;
+  addedAt: string;
+  title: string;
+}
+
+function toItem(id: string, data: Record<string, unknown>): TestItem {
+  return { id, addedAt: data.addedAt as string, title: data.title as string };
+}
+
+const { getPublicMedia, getUserMedia } = createMediaQueries(mockDb, NAMESPACE, "media", toItem);
+
+const itemA = {
+  id: "item-a",
+  data: () => ({ title: "Alpha", addedAt: "2026-01-01T00:00:00Z", publicDomain: true }),
+};
+
+const itemB = {
+  id: "item-b",
+  data: () => ({ title: "Beta", addedAt: "2026-02-01T00:00:00Z", publicDomain: true }),
+};
+
+describe("getPublicMedia", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCollection.mockReturnValue("mock-collection-ref");
+    mockWhere.mockReturnValue("mock-where");
+    mockQuery.mockReturnValue("mock-query");
+  });
+
+  it("queries the correct namespaced collection path", async () => {
+    mockGetDocs.mockResolvedValue({ docs: [] });
+
+    await getPublicMedia();
+
+    expect(mockCollection).toHaveBeenCalledWith(mockDb, "test/ns/media");
+  });
+
+  it("composes where publicDomain == true", async () => {
+    mockGetDocs.mockResolvedValue({ docs: [] });
+
+    await getPublicMedia();
+
+    expect(mockWhere).toHaveBeenCalledWith("publicDomain", "==", true);
+  });
+
+  it("returns items mapped via toItem and sorted by addedAt descending", async () => {
+    mockGetDocs.mockResolvedValue({ docs: [itemA, itemB] });
+
+    const items = await getPublicMedia();
+
+    expect(items).toHaveLength(2);
+    expect(items[0].id).toBe("item-b");
+    expect(items[1].id).toBe("item-a");
+    expect(items[0].title).toBe("Beta");
+  });
+
+  it("returns empty array when no results", async () => {
+    mockGetDocs.mockResolvedValue({ docs: [] });
+
+    const items = await getPublicMedia();
+
+    expect(items).toEqual([]);
+  });
+});
+
+describe("getUserMedia", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCollection.mockReturnValue("mock-collection-ref");
+    mockWhere.mockReturnValue("mock-where");
+    mockQuery.mockReturnValue("mock-query");
+  });
+
+  it("composes where memberEmails array-contains email", async () => {
+    mockGetDocs.mockResolvedValue({ docs: [] });
+
+    await getUserMedia("owner@example.com");
+
+    expect(mockWhere).toHaveBeenCalledWith("memberEmails", "array-contains", "owner@example.com");
+  });
+
+  it("queries the correct namespaced collection path", async () => {
+    mockGetDocs.mockResolvedValue({ docs: [] });
+
+    await getUserMedia("owner@example.com");
+
+    expect(mockCollection).toHaveBeenCalledWith(mockDb, "test/ns/media");
+  });
+
+  it("returns items sorted by addedAt descending", async () => {
+    mockGetDocs.mockResolvedValue({ docs: [itemA, itemB] });
+
+    const items = await getUserMedia("owner@example.com");
+
+    expect(items[0].id).toBe("item-b");
+    expect(items[1].id).toBe("item-a");
+  });
+});

--- a/projects/scaffolding/firebase/templates/app/src/firestore.ts
+++ b/projects/scaffolding/firebase/templates/app/src/firestore.ts
@@ -24,7 +24,7 @@ export async function getMessages(): Promise<Message[]> {
   const snapshot = await boundedQuery(db, path)
     .orderBy("createdAt")
     .unbounded("scaffolding template — choose a real bound or pagination when building on this")
-    .getDocs();
+    .getDocs(); // query-bounds-ok: bounded via .unbounded() above — scaffolding template; replace with a real bound
   return snapshot.docs.map((doc) => {
     const data = doc.data();
     return {
@@ -42,7 +42,7 @@ export async function getNotes(email: string): Promise<Note[]> {
   const snapshot = await boundedQuery(db, path)
     .where("memberEmails", "array-contains", email)
     .unbounded("scaffolding template — choose a real bound or pagination when building on this")
-    .getDocs();
+    .getDocs(); // query-bounds-ok: bounded via .unbounded() above — scaffolding template; replace with a real bound
   const notes = snapshot.docs.map((doc) => {
     const data = doc.data();
     return {

--- a/projects/scaffolding/firebase/templates/app/src/firestore.ts
+++ b/projects/scaffolding/firebase/templates/app/src/firestore.ts
@@ -1,7 +1,7 @@
-import { collection, getDocs, orderBy, query, where } from "firebase/firestore";
 import { db, NAMESPACE } from "./firebase.js";
 import { nsCollectionPath } from "@commons-systems/firestoreutil/namespace";
 import { requireString } from "@commons-systems/firestoreutil/validate";
+import { boundedQuery } from "@commons-systems/firestoreutil/bounded-query";
 
 export interface Message {
   id: string;
@@ -20,8 +20,11 @@ export interface Note {
 
 export async function getMessages(): Promise<Message[]> {
   const path = nsCollectionPath(NAMESPACE, "messages");
-  const q = query(collection(db, path), orderBy("createdAt"));
-  const snapshot = await getDocs(q);
+  // New apps: replace .unbounded(...) with .limit(n) or pagination — an unbounded scan grows reads with the collection.
+  const snapshot = await boundedQuery(db, path)
+    .orderBy("createdAt")
+    .unbounded("scaffolding template — choose a real bound or pagination when building on this")
+    .getDocs();
   return snapshot.docs.map((doc) => {
     const data = doc.data();
     return {
@@ -35,8 +38,11 @@ export async function getMessages(): Promise<Message[]> {
 
 export async function getNotes(email: string): Promise<Note[]> {
   const path = nsCollectionPath(NAMESPACE, "notes");
-  const q = query(collection(db, path), where("memberEmails", "array-contains", email));
-  const snapshot = await getDocs(q);
+  // New apps: replace .unbounded(...) with .limit(n) or pagination — an unbounded scan grows reads with the collection.
+  const snapshot = await boundedQuery(db, path)
+    .where("memberEmails", "array-contains", email)
+    .unbounded("scaffolding template — choose a real bound or pagination when building on this")
+    .getDocs();
   const notes = snapshot.docs.map((doc) => {
     const data = doc.data();
     return {

--- a/projects/scaffolding/firebase/templates/app/test/firestore.test.ts
+++ b/projects/scaffolding/firebase/templates/app/test/firestore.test.ts
@@ -4,12 +4,14 @@ const mockGetDocs = vi.fn();
 const mockCollection = vi.fn();
 const mockQuery = vi.fn();
 const mockOrderBy = vi.fn();
+const mockWhere = vi.fn();
 
 vi.mock("firebase/firestore", () => ({
   collection: (...args: unknown[]) => mockCollection(...args),
   getDocs: (...args: unknown[]) => mockGetDocs(...args),
   query: (...args: unknown[]) => mockQuery(...args),
   orderBy: (...args: unknown[]) => mockOrderBy(...args),
+  where: (...args: unknown[]) => mockWhere(...args),
 }));
 
 vi.mock("../src/firebase.js", () => ({
@@ -25,6 +27,7 @@ describe("getMessages", () => {
     mockCollection.mockReturnValue("mock-collection-ref");
     mockOrderBy.mockReturnValue("mock-order");
     mockQuery.mockReturnValue("mock-query");
+    mockWhere.mockReturnValue("mock-where");
   });
 
   it("queries the correct namespaced collection path", async () => {
@@ -43,7 +46,7 @@ describe("getMessages", () => {
 
     await getMessages();
 
-    expect(mockOrderBy).toHaveBeenCalledWith("createdAt");
+    expect(mockOrderBy).toHaveBeenCalledWith("createdAt", undefined);
   });
 
   it("maps Firestore documents to Message objects", async () => {
@@ -92,13 +95,14 @@ describe("getNotes", () => {
     vi.clearAllMocks();
     mockCollection.mockReturnValue("mock-collection-ref");
     mockOrderBy.mockReturnValue("mock-order");
+    mockWhere.mockReturnValue("mock-where");
     mockQuery.mockReturnValue("mock-query");
   });
 
   it("queries the correct namespaced collection path", async () => {
     mockGetDocs.mockResolvedValue({ docs: [] });
 
-    await getNotes();
+    await getNotes("user@example.com");
 
     expect(mockCollection).toHaveBeenCalledWith(
       { type: "mock-firestore" },
@@ -106,12 +110,13 @@ describe("getNotes", () => {
     );
   });
 
-  it("orders results by createdAt", async () => {
+  it("filters by memberEmails", async () => {
     mockGetDocs.mockResolvedValue({ docs: [] });
 
-    await getNotes();
+    await getNotes("user@example.com");
 
-    expect(mockOrderBy).toHaveBeenCalledWith("createdAt");
+    expect(mockWhere).toHaveBeenCalledWith("memberEmails", "array-contains", "user@example.com");
+    expect(mockOrderBy).not.toHaveBeenCalled();
   });
 
   it("maps Firestore documents to Note objects", async () => {
@@ -122,6 +127,8 @@ describe("getNotes", () => {
           data: () => ({
             text: "First note",
             createdAt: "2026-01-01T00:00:00Z",
+            groupId: "group-a",
+            memberEmails: ["user@example.com"],
           }),
         },
         {
@@ -129,23 +136,29 @@ describe("getNotes", () => {
           data: () => ({
             text: "Second note",
             createdAt: "2026-01-01T00:01:00Z",
+            groupId: "group-a",
+            memberEmails: ["user@example.com"],
           }),
         },
       ],
     });
 
-    const notes = await getNotes();
+    const notes = await getNotes("user@example.com");
 
     expect(notes).toEqual([
       {
         id: "note-1",
         text: "First note",
         createdAt: "2026-01-01T00:00:00Z",
+        groupId: "group-a",
+        memberEmails: ["user@example.com"],
       },
       {
         id: "note-2",
         text: "Second note",
         createdAt: "2026-01-01T00:01:00Z",
+        groupId: "group-a",
+        memberEmails: ["user@example.com"],
       },
     ]);
   });


### PR DESCRIPTION
Closes #2689

## Summary

Makes unbounded Firestore collection scans **unrepresentable** by adding a typed
bounded-query wrapper to `packages/firestoreutil`. Rather than lint raw-SDK usage
forever (the #2687 sensor approach), the wrong thing can no longer be written: a
typestate builder where the terminal `.getDocs()` is reachable *only* after
`.limit(n)` or an explicit `.unbounded(reason)`. The type is the enforcement.

This is the greenfield end-state for the read-spike guard epic (#2686): the
late-June read spike (#2684) came from unbounded full-collection `getDocs` scans
re-run on every 5-min dashboard auto-refresh, so reads scaled with
`collection_size × poll_rate × tab-hours`.

## Design

Two interfaces in `@commons-systems/firestoreutil/bounded-query`:

- **`UnboundedQuery`** — `.where()`, `.orderBy()` (return `UnboundedQuery`),
  `.limit(n)` and `.unbounded(reason)` (return `BoundedQuery`). It has **no**
  terminal fetch method.
- **`BoundedQuery`** — `.where()`, `.orderBy()` (return `BoundedQuery`) and the
  terminal `.getDocs(): Promise<QuerySnapshot>`.

Because `.getDocs()` lives only on `BoundedQuery`, and the only way to reach
`BoundedQuery` is through `.limit()` or `.unbounded()`, an unbounded scan is a
compile error. `.unbounded(reason)` appends no constraint — it is the deliberate,
documented escape hatch — and throws at runtime on an empty/whitespace reason (a
defensive check at the API boundary, since the type system can't reject `""`).

## Migration (behavior-preserving)

The goal is to make unboundedness *explicit and acknowledged*, not to silently
bound everything. A currently-unbounded site becomes `.unbounded("<honest
reason>")` — never a guessed `.limit(100)` that would truncate a user's results.

- **Unbounded production sites** now route through the builder with an honest
  `.unbounded(reason)`: media-queries (`getPublicMedia`/`getUserMedia`),
  authutil `getUserGroups`, office-hours `getOwnerReminders`, blog `getPosts`
  (both admin/non-admin branches — the non-admin `where("published","==",true)`
  filter is preserved, as security rules require it for unauthenticated list
  queries), and the scaffolding template `getMessages`/`getNotes` (with a
  guiding comment so new apps are bounded-by-construction).
- **Already-bounded office-hours sites** (`usage-data`, `issue-data`,
  `topic-usage-data`) route their existing `.limit(n)` through the builder — no
  behavior change — so the helper is the universal default across the repo.

## Tests

- Runtime tests: `.limit(n)`/`.unbounded(reason)` constraint composition, the
  empty-reason guard throws, chained `.where().orderBy().limit()` ordering.
- **Type-level assertions** (`test/bounded-query.type-check.ts`, non-executed but
  typechecked): `@ts-expect-error` proving `.getDocs()` is absent on
  `UnboundedQuery` — this is the load-bearing enforcement, checked by
  `tsc --project packages/firestoreutil`.
- Migrated sites' existing mocks/assertions updated where needed; new
  `media-queries.test.ts` added.

## Verification

- `npx vitest run --project packages/firestoreutil --project office-hours --project packages/authutil --project packages/blog --root .` — 1007 tests pass.
- `npx tsc --noEmit --project packages/firestoreutil` — clean (the type-level guard is live).

## Docs

New `packages/firestoreutil/README.md` documents `boundedQuery` as the default
way to query a collection, with the #2687 lint sensor noted as the complementary
backstop.

## Out of scope

The #2687 sensor script itself (open sibling), runtime read-count alerting
(#2688), and the review-phase cost lens (#2690).
