### PR TITLE
Full-repo Firestore query-bounds decay sensor + bound existing scan sites

### DIFF
--- a/.github/scripts/check-firestore-query-bounds.sh
+++ b/.github/scripts/check-firestore-query-bounds.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Full-repo Firestore getDocs query-bounds decay sensor.
+#
+# Flags every unbounded `getDocs(...)` call in the repository's TS/TSX sources.
+# Unlike the diff-scoped type-safety sensor, this is a FULL-REPO scan: it walks
+# `git ls-files` and reads each file's WHOLE contents, so it catches decay
+# anywhere in the tree, not just on a PR's added lines.
+#
+# A `getDocs` site is UNBOUNDED (and therefore flagged) unless one of these
+# holds:
+#
+#   1. The associated Firestore query carries a `limit(...)` clause. The query
+#      is either inline (`getDocs(query(...))`) or a variable resolved by
+#      scanning backward for its nearest `const q = query(...)` assignment
+#      within the enclosing function. `limit(` is detected over the whole
+#      associated query span (all its physical lines concatenated).
+#
+#   2. A `// query-bounds-ok: <reason>` marker with a NON-EMPTY reason appears
+#      either on the `getDocs` line itself or on any single physical line of the
+#      resolved query span.
+#
+# Suppression: append `// query-bounds-ok: <reason>` to the getDocs line (the
+# required escape hatch for shapes like a ternary-branched query where a static
+# `limit(` scan can't prove boundedness). A NON-EMPTY reason suppresses the
+# site; an empty reason (`// query-bounds-ok:` with nothing after) does NOT.
+#
+# Epic convention (D3): `// query-bounds-ok: <reason>` is a member of the shared
+# `// <sensor>-ok: <reason>` decay-sensor marker family under parent epic #2686.
+# Sibling sensors adopt the same marker shape rather than invent ad-hoc
+# microsyntaxes.
+#
+# Subtle correctness point: `limit(` is detected over the CONCATENATED query
+# span, but the suppression marker is detected PER PHYSICAL LINE. Running the
+# marker check over a concatenated span would let an empty-reason marker on one
+# line see the NEXT line's code as its "reason" and wrongly suppress. The two
+# detections deliberately differ.
+#
+# Limitation: a stray `limit(` inside a comment inside the query span is an
+# accepted false-negative (out of scope, like the type-safety sensor's trailing
+# line-comment limitation). Backward variable resolution stops at a function
+# boundary; an unresolved variable is flagged conservatively.
+#
+# Invocation:
+#   check-firestore-query-bounds.sh
+#       Default (CI) path. Walks `git ls-files` over TS/TSX sources (excluding
+#       test/spec files and packages/rules-test), scans each file's full
+#       contents, and collects every violation across the whole repo.
+#
+#   check-firestore-query-bounds.sh --scan-stdin [<filename>]
+#       Core path. Reads ONE file's full contents on STDIN and scans it; no git
+#       state is touched. The optional <filename> (default `<stdin>`) is used
+#       only to label `::error file=...` annotations. This is the testable entry
+#       point.
+#
+# Exit codes (both paths): 1 if any violation was found, 0 otherwise. All
+# violations across the whole scan are collected; the scan does not stop on the
+# first match.
+#
+# NOTE: the awk core targets mawk (Ubuntu CI default), so it avoids `\s`, `\b`,
+# `\d`, `gensub()`, and `length(array)`, which mawk does not support.
+set -euo pipefail
+
+# --- CORE SCANNER -----------------------------------------------------------
+# Reads ONE file's full contents on stdin, emits `::error file=...,line=N::...`
+# annotations for unbounded getDocs sites, and returns 1 if any were found.
+scan_file() {
+  local fname="${1:-<stdin>}"
+  awk -v fname="$fname" '
+    { arr[NR] = $0 }
+
+    END {
+      n = NR
+      violations = 0
+
+      for (i = 1; i <= n; i++) {
+        line = arr[i]
+
+        # ANCHORED getDocs call. Leading anchor stops mockGetDocs( from
+        # matching; getDoc( without the trailing s never matches.
+        if (line !~ /(^|[^A-Za-z0-9_$])getDocs\(/) continue
+
+        # (a) getDocs-line marker escape hatch: a non-empty reason on the
+        # getDocs line itself passes the site.
+        if (has_marker(line)) continue
+
+        # (b) Extract the getDocs argument.
+        match(line, /(^|[^A-Za-z0-9_$])getDocs\(/)
+        after = substr(line, RSTART + RLENGTH)   # text right after the "("
+        sub(/^[ \t]+/, "", after)
+
+        inline = 0
+        variable = 0
+        id = ""
+
+        if (after ~ /^query[ \t]*\(/) {
+          inline = 1
+        } else if (match(after, /^[A-Za-z_$][A-Za-z0-9_$]*/)) {
+          id = substr(after, RSTART, RLENGTH)
+          rest = substr(after, RSTART + RLENGTH)
+          sub(/^[ \t]+/, "", rest)
+          if (rest ~ /^\)/) variable = 1
+          else inline = 1
+        } else {
+          inline = 1
+        }
+
+        # (b/c) Build the associated query span (array of physical line
+        # indices) and decide.
+        spanCount = 0
+        flagged = 0
+
+        if (inline) {
+          # Gather line i forward to the statement terminator.
+          for (k = i; k <= n; k++) {
+            spanCount++
+            span[spanCount] = k
+            if (arr[k] ~ /;[ \t\r]*$/) break
+          }
+        } else {
+          # VARIABLE: scan backward for the nearest assignment within the
+          # enclosing function.
+          idre = id
+          gsub(/\$/, "\\$", idre)
+          assignRe = "(^|[^A-Za-z0-9_$])" idre "[ \t]*=([^=>]|$)"
+          assignAt = 0
+          for (j = i - 1; j >= 1; j--) {
+            if (arr[j] ~ assignRe) { assignAt = j; break }
+            # Function-boundary markers stop the backward scan.
+            if (arr[j] ~ /(^|[^A-Za-z0-9_$])function([^A-Za-z0-9_$]|$)/ ||
+                arr[j] ~ /=>/ ||
+                arr[j] ~ /(^|[^A-Za-z0-9_$])async([^A-Za-z0-9_$]|$)/ ||
+                arr[j] ~ /^[ \t]*}[ \t]*$/) break
+          }
+          if (assignAt == 0) {
+            # Unresolved variable -> conservative flag.
+            flagged = 1
+          } else {
+            # Gather from the assignment line forward to the terminator.
+            for (k = assignAt; k <= n; k++) {
+              spanCount++
+              span[spanCount] = k
+              if (arr[k] ~ /;[ \t\r]*$/) break
+            }
+          }
+        }
+
+        if (flagged) {
+          emit(fname, i)
+          continue
+        }
+
+        # (c) limit() over the CONCATENATED span.
+        joined = ""
+        for (s = 1; s <= spanCount; s++) joined = joined arr[span[s]] "\n"
+        hasLimit = (joined ~ /limit[ \t]*\(/)
+
+        # (d) marker PER PHYSICAL LINE over {getDocs line i} U {span lines}.
+        hasMarker = 0
+        if (has_marker(arr[i])) hasMarker = 1
+        for (s = 1; s <= spanCount && !hasMarker; s++) {
+          if (has_marker(arr[span[s]])) hasMarker = 1
+        }
+
+        if (!hasLimit && !hasMarker) emit(fname, i)
+      }
+
+      if (violations > 0) exit 1
+    }
+
+    # Non-empty query-bounds-ok marker present on this single physical line?
+    function has_marker(text,    rest) {
+      if (match(text, /\/\/[ \t]*query-bounds-ok:/)) {
+        rest = substr(text, RSTART + RLENGTH)
+        if (rest ~ /[^ \t\r\n]/) return 1
+      }
+      return 0
+    }
+
+    function emit(path, line) {
+      gsub(/,/, "%2C", path)
+      printf "::error file=%s,line=%d::Unbounded Firestore getDocs query (add a limit() or a // query-bounds-ok: <reason> marker).\n", path, line
+      violations++
+    }
+  '
+}
+
+# --- ENTRY POINTS -----------------------------------------------------------
+
+# Core path: scan one file piped on stdin, no git state.
+if [ "${1:-}" = "--scan-stdin" ]; then
+  scan_file "${2:-<stdin>}"
+  exit $?
+fi
+
+if [ -n "${1:-}" ]; then
+  echo "Unknown argument: $1" >&2
+  exit 1
+fi
+
+# Default path: full-repo wrapper. No origin/main, no fetch-depth.
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Enumerate TS/TSX sources, dropping test/spec files and the rules-test package.
+# `grep -v` returns non-zero when it filters everything out; the `|| true`
+# guard keeps an empty match set from aborting the pipeline under `set -e`.
+files="$(git ls-files -- '*.ts' '*.tsx' \
+  | grep -vE '(/(test|tests)/|\.test\.tsx?$|\.spec\.tsx?$|^packages/rules-test/)' || true)"
+
+found=0
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  # OR the per-file exit codes: any violation makes the whole run exit 1. Do
+  # not let a single file's non-zero exit abort the loop.
+  if ! scan_file "$f" < "$f"; then
+    found=1
+  fi
+done <<EOF
+$files
+EOF
+
+exit "$found"

--- a/.github/scripts/test-check-firestore-query-bounds.sh
+++ b/.github/scripts/test-check-firestore-query-bounds.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fixture-based unit tests for check-firestore-query-bounds.sh.
+#
+# Each case feeds a WHOLE TS FILE BODY into the scanner's core entry point
+# (`check-firestore-query-bounds.sh --scan-stdin`) and asserts on the emitted
+# `::error file=<path>,line=<N>::...` annotations and the scanner's exit code.
+#
+# Unlike the diff-scoped type-safety sensor's test, the fixtures here are full
+# file bodies piped on stdin, NOT unified diffs — the scanner reads whole file
+# contents. Run this file with: bash test-check-firestore-query-bounds.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCANNER="$SCRIPT_DIR/check-firestore-query-bounds.sh"
+
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+# File-based counters because each case runs in a subshell (variable changes
+# inside a subshell would be lost to the parent).
+PASS_FILE="${TEST_TMPDIR}/.pass_count"
+FAIL_FILE="${TEST_TMPDIR}/.fail_count"
+echo 0 > "$PASS_FILE"
+echo 0 > "$FAIL_FILE"
+
+pass() {
+  echo "  PASS: $1"
+  echo $(( $(cat "$PASS_FILE") + 1 )) > "$PASS_FILE"
+}
+fail() {
+  echo "  FAIL: $1"
+  echo $(( $(cat "$FAIL_FILE") + 1 )) > "$FAIL_FILE"
+}
+
+# scan_fixture <fixture-file> -> writes scanner stdout to $OUT_FILE, sets $RC.
+# The fixture is a whole TS file body piped on stdin. `set -e` would abort on
+# the scanner's exit 1, so the call is guarded.
+scan_fixture() {
+  local fixture="$1"
+  OUT_FILE="${TEST_TMPDIR}/.out"
+  set +e
+  "$SCANNER" --scan-stdin < "$fixture" > "$OUT_FILE"
+  RC=$?
+  set -e
+}
+
+# Count `::error` annotation lines in the captured output.
+err_count() {
+  grep -c '^::error ' "$OUT_FILE" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# 1. Violation caught: variable-shape query, no limit.
+# ---------------------------------------------------------------------------
+echo "=== Violation: unbounded variable query is flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
+const q = query(collection(db, p), where("x","==",true));
+const s = await getDocs(q);
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ]; then
+    pass "unbounded variable query -> 1 finding, exit 1"
+  else
+    fail "unbounded variable query (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# 2. limit()-bounded passes (multi-line query span).
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Bounded: multi-line limit() query passes ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
+const q = query(
+  collection(db, p),
+  where("x","==",true),
+  limit(50),
+);
+const s = await getDocs(q);
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 0 ] && [ "$n" -eq 0 ]; then
+    pass "multi-line limit(50) query -> 0 findings, exit 0"
+  else
+    fail "multi-line limit query (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# 3. Inline bounded passes.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Bounded: inline getDocs(query(..., limit())) passes ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
+const s = await getDocs(query(collection(db, p), limit(10)));
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 0 ] && [ "$n" -eq 0 ]; then
+    pass "inline limit(10) query -> 0 findings, exit 0"
+  else
+    fail "inline limit query (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# 4. Marked query passes (marker on the query-assignment line).
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Marked: query-bounds-ok on the assignment line passes ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
+const q = query(collection(db, p), where("x","==",true)); // query-bounds-ok: product decision
+const s = await getDocs(q);
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 0 ] && [ "$n" -eq 0 ]; then
+    pass "marker on assignment line -> 0 findings, exit 0"
+  else
+    fail "marker on assignment line (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# 5. Marked passes (marker on the getDocs line — ternary shape).
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Marked: query-bounds-ok on the getDocs line (ternary) passes ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
+const q = admin
+  ? query(collection(db, p), orderBy("d"))
+  : query(collection(db, p), where("pub","==",true));
+const s = await getDocs(q); // query-bounds-ok: blog index needs all
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 0 ] && [ "$n" -eq 0 ]; then
+    pass "marker on getDocs line (ternary) -> 0 findings, exit 0"
+  else
+    fail "marker on getDocs line (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# 6. Empty-reason rejected — MULTI-LINE (CRITICAL DISCRIMINATOR).
+#    An empty-reason marker on a query-span line, real code on the FOLLOWING
+#    line. A concatenation-buggy scanner would treat the next line's code as the
+#    marker's "reason" and wrongly suppress; the per-physical-line scanner
+#    rejects the empty reason and flags. Must NOT collapse to one line.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Empty-reason (multi-line): does NOT suppress, still flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
+const q = query(
+  collection(db, p),
+  where("x","==",true), // query-bounds-ok:
+);
+const s = await getDocs(q);
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ]; then
+    pass "multi-line empty-reason marker -> still flagged (1 finding), exit 1"
+  else
+    fail "multi-line empty-reason (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# 7. getDoc( single-doc read NOT flagged.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Single-doc: getDoc( is NOT flagged ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
+const snap = await getDoc(doc(db, p, id));
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 0 ] && [ "$n" -eq 0 ]; then
+    pass "getDoc( single-doc read -> 0 findings, exit 0"
+  else
+    fail "getDoc single-doc (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# 8. Unresolved variable FLAGGED (conservative default).
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Unresolved: getDocs(<unresolved>) is flagged conservatively ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
+const s = await getDocs(mystery);
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 1 ] && [ "$n" -eq 1 ]; then
+    pass "unresolved variable -> 1 finding (conservative), exit 1"
+  else
+    fail "unresolved variable (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# 9. mockGetDocs( is NOT matched by the anchored getDocs( pattern.
+#    The leading anchor [^A-Za-z0-9_$] before getDocs( excludes mockGetDocs(.
+#    The fixture contains ONLY the mock call (unbounded query above it), so any
+#    finding would prove the anchor leaked.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Anchor: mockGetDocs( is NOT matched ==="
+(
+  F="${TEST_TMPDIR}/f"; cat > "$F" <<'EOF'
+const q = query(collection(db, p));
+const s = await mockGetDocs(q);
+EOF
+  scan_fixture "$F"
+  n=$(err_count)
+  if [ "$RC" -eq 0 ] && [ "$n" -eq 0 ]; then
+    pass "mockGetDocs( -> 0 findings (anchor excludes it), exit 0"
+  else
+    fail "mockGetDocs anchor (rc=$RC count=$n): $(cat "$OUT_FILE")"
+  fi
+)
+
+# ---------------------------------------------------------------------------
+# RESULTS + expected-total guard (catches a crashed/early-exiting subshell).
+# ---------------------------------------------------------------------------
+FINAL_PASS=$(cat "$PASS_FILE")
+FINAL_FAIL=$(cat "$FAIL_FILE")
+
+echo ""
+echo "========================================"
+echo "  Results: $FINAL_PASS passed, $FINAL_FAIL failed"
+echo "========================================"
+
+EXPECTED=9
+ACTUAL=$(( FINAL_PASS + FINAL_FAIL ))
+if [ "$ACTUAL" -ne "$EXPECTED" ]; then
+  echo "ERROR: expected $EXPECTED test results but got $ACTUAL (a test subshell may have crashed)" >&2
+  exit 1
+fi
+
+if [ "$FINAL_FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -87,3 +87,10 @@ jobs:
           fetch-depth: 0
       - name: Flag net-new type-safety escape hatches
         run: .github/scripts/check-type-safety-escapes.sh
+
+  firestore-query-bounds-sensor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Flag unbounded Firestore getDocs queries
+        run: .github/scripts/check-firestore-query-bounds.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -202,6 +202,8 @@ jobs:
         run: .claude/hooks/test-statusline.sh
       - name: Run type-safety escape-hatch sensor tests
         run: .github/scripts/test-check-type-safety-escapes.sh
+      - name: Run Firestore query-bounds sensor tests
+        run: .github/scripts/test-check-firestore-query-bounds.sh
       - name: Run test-integrity script tests
         run: .github/scripts/test-check-test-integrity.sh
 
@@ -256,6 +258,15 @@ jobs:
           fetch-depth: 0
       - name: Flag net-new type-safety escape hatches
         run: .github/scripts/check-type-safety-escapes.sh
+
+  firestore-query-bounds-sensor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Flag unbounded Firestore getDocs queries
+        run: .github/scripts/check-firestore-query-bounds.sh
 
   go-tests:
     runs-on: ubuntu-latest

--- a/office-hours/src/data.ts
+++ b/office-hours/src/data.ts
@@ -64,7 +64,7 @@ export async function getOwnerReminders(
 ): Promise<Reminder[]> {
   if (!user.email) return [];
   const path = nsCollectionPath(namespace, "items");
-  const q = query(collection(db, path), where("memberEmails", "array-contains", user.email));
+  const q = query(collection(db, path), where("memberEmails", "array-contains", user.email)); // query-bounds-ok: per-owner items scoped by membership; pagination is a product decision tracked under #2686
   const snapshot = await getDocs(q);
   const reminders: Reminder[] = [];
   for (const d of snapshot.docs) {

--- a/packages/authutil/src/groups.ts
+++ b/packages/authutil/src/groups.ts
@@ -39,7 +39,7 @@ function requireEmail(caller: string, user: User): string {
 
 export async function getUserGroups(db: Firestore, namespace: Namespace, user: User): Promise<Group[]> {
   const email = requireEmail("getUserGroups", user);
-  const q = query(collection(db, groupsPath(namespace)), where("members", "array-contains", email));
+  const q = query(collection(db, groupsPath(namespace)), where("members", "array-contains", email)); // query-bounds-ok: authz needs the complete group set; a limit would break isInGroup semantics
   const snapshot = await getDocs(q);
   return snapshot.docs
     .map((docSnap) => {

--- a/packages/blog/src/firestore.ts
+++ b/packages/blog/src/firestore.ts
@@ -47,7 +47,7 @@ export async function getPosts(db: Firestore, namespace: Namespace, user: User |
   const q = admin
     ? query(collection(db, path), orderBy("publishedAt", "desc"))
     : query(collection(db, path), where("published", "==", true));
-  const snapshot = await getDocs(q);
+  const snapshot = await getDocs(q); // query-bounds-ok: blog index needs all published posts; pagination is a product decision tracked under #2686
   const posts: PostMeta[] = [];
   let skippedCount = 0;
   for (const d of snapshot.docs) {

--- a/packages/firestoreutil/src/media-queries.ts
+++ b/packages/firestoreutil/src/media-queries.ts
@@ -12,7 +12,7 @@ export function createMediaQueries<T extends { id: string; addedAt: string }>(
   const path = nsCollectionPath(namespace, collectionName);
 
   async function getPublicMedia(): Promise<T[]> {
-    const q = query(collection(db, path), where("publicDomain", "==", true));
+    const q = query(collection(db, path), where("publicDomain", "==", true)); // query-bounds-ok: shared media factory returns the full public library; pagination is a product decision tracked under #2686
     const snapshot = await getDocs(q);
     const items = snapshot.docs.map((docSnap) => toItem(docSnap.id, docSnap.data()));
     items.sort((a, b) => b.addedAt.localeCompare(a.addedAt));
@@ -20,7 +20,7 @@ export function createMediaQueries<T extends { id: string; addedAt: string }>(
   }
 
   async function getUserMedia(email: string): Promise<T[]> {
-    const q = query(collection(db, path), where("memberEmails", "array-contains", email));
+    const q = query(collection(db, path), where("memberEmails", "array-contains", email)); // query-bounds-ok: shared media factory returns the full user set; pagination is a product decision tracked under #2686
     const snapshot = await getDocs(q);
     const items = snapshot.docs.map((docSnap) => toItem(docSnap.id, docSnap.data()));
     items.sort((a, b) => b.addedAt.localeCompare(a.addedAt));

--- a/projects/scaffolding/firebase/templates/app/src/firestore.ts
+++ b/projects/scaffolding/firebase/templates/app/src/firestore.ts
@@ -1,4 +1,4 @@
-import { collection, getDocs, orderBy, query, where } from "firebase/firestore";
+import { collection, getDocs, limit, orderBy, query, where } from "firebase/firestore";
 import { db, NAMESPACE } from "./firebase.js";
 import { nsCollectionPath } from "@commons-systems/firestoreutil/namespace";
 import { requireString } from "@commons-systems/firestoreutil/validate";
@@ -20,7 +20,8 @@ export interface Note {
 
 export async function getMessages(): Promise<Message[]> {
   const path = nsCollectionPath(NAMESPACE, "messages");
-  const q = query(collection(db, path), orderBy("createdAt"));
+  // Bounded read; new apps should tune this limit for their expected data size.
+  const q = query(collection(db, path), orderBy("createdAt"), limit(100));
   const snapshot = await getDocs(q);
   return snapshot.docs.map((doc) => {
     const data = doc.data();
@@ -35,7 +36,7 @@ export async function getMessages(): Promise<Message[]> {
 
 export async function getNotes(email: string): Promise<Note[]> {
   const path = nsCollectionPath(NAMESPACE, "notes");
-  const q = query(collection(db, path), where("memberEmails", "array-contains", email));
+  const q = query(collection(db, path), where("memberEmails", "array-contains", email), limit(100));
   const snapshot = await getDocs(q);
   const notes = snapshot.docs.map((doc) => {
     const data = doc.data();

--- a/projects/scaffolding/firebase/templates/app/test/firestore.test.ts
+++ b/projects/scaffolding/firebase/templates/app/test/firestore.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockGetDocs = vi.fn();
 const mockCollection = vi.fn();
+const mockLimit = vi.fn();
 const mockQuery = vi.fn();
 const mockOrderBy = vi.fn();
 
 vi.mock("firebase/firestore", () => ({
   collection: (...args: unknown[]) => mockCollection(...args),
   getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  limit: (...args: unknown[]) => mockLimit(...args),
   query: (...args: unknown[]) => mockQuery(...args),
   orderBy: (...args: unknown[]) => mockOrderBy(...args),
 }));


### PR DESCRIPTION
Closes #2687

## Summary

Adds a **full-repo** Firestore `getDocs` query-bounds decay sensor and bounds
every existing scan site, so a newly-added unbounded `getDocs(query(...))`
anywhere in the tree is caught on every PR. This is defense-in-depth against the
Firestore read-spike class (parent epic #2686): an unbounded collection scan
reads the whole collection, so cost and latency grow silently with the data set.
Unlike a diff-scoped check, this sensor holds the whole tree green.

## What changed

- **New scanner** `.github/scripts/check-firestore-query-bounds.sh` — a
  testable-core `--scan-stdin` per-file scanner plus a `git ls-files` full-repo
  wrapper, modeled on `check-type-safety-escapes.sh`. It flags any `getDocs(...)`
  whose associated query span has neither a `limit(...)` nor a
  `// query-bounds-ok: <reason>` marker (the D3 decay-sensor marker family). The
  marker is detected per physical line; `limit()` over the concatenated span —
  so an empty-reason marker can't absorb the next line as its reason.
- **New test companion** `.github/scripts/test-check-firestore-query-bounds.sh` —
  9 fixture cases, including a multi-line empty-reason discriminator that catches
  the per-line-vs-concatenated marker bug.
- **Bounded the scaffolding template** (`projects/scaffolding/firebase/templates/app/`)
  — `getMessages`/`getNotes` now carry `limit(100)`, with a matching `limit` mock.
- **Marked five intentional unbounded reads** with `// query-bounds-ok: <reason>`
  (owner reminders, media public+user, authutil groups, blog posts) — a `limit()`
  would be semantically wrong at each; the pagination decision is tracked in the
  follow-up below.
- **CI wiring** — a `firestore-query-bounds-sensor` job on `pr-checks.yml` (the
  red-blocks-ready gate) and `unit-tests.yml`, plus the test step in `hook-tests`.
  No `fetch-depth` — the scan is full-repo, not diff-scoped.

## Follow-up

Consolidated pagination product decision for the five marked sites: #2701 (a
sibling under epic #2686). It is not a blocker — the markers already make the
sensor green.

## Verification

- `test-check-firestore-query-bounds.sh` — 9/9 pass, incl. the multi-line
  empty-reason discriminator.
- `check-firestore-query-bounds.sh` — whole-repo scan exits 0 (every site
  bounded-or-marked; the 3 already-bounded office-hours sites untouched).
- `run-typecheck.sh` and `run-lint.sh` — green across all workspaces.
