### PR TITLE
Cost/scaling lens in the review phase

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-review-finders
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-review-finders
@@ -20,13 +20,14 @@
 #   auth                 (surface==code AND app_or_rules==true)
 #   data-exposure        (surface==code AND app_or_rules==true)
 #   firebase             (surface==code AND app_or_rules==true)
+#   cost                 (surface==code AND app_or_rules==true)
 #   codeql               (surface==code)
 #   erosion              (surface==code)
 #   npm                  (deps==true)
 #
 # surface empty/docs/tests => exactly code-review (zero security finders).
 # surface==code       => 4 always-on security finders + codeql + erosion.
-# app_or_rules==true  => additionally auth, data-exposure, firebase (7 total).
+# app_or_rules==true  => additionally auth, data-exposure, firebase, cost (8 total).
 # deps==true          => additionally npm (independent of surface).
 #
 # No network access, no git, no gh — pure stdin → stdout classification.
@@ -68,6 +69,7 @@ if [[ "$surface" == "code" ]]; then
     echo "auth"
     echo "data-exposure"
     echo "firebase"
+    echo "cost"
   fi
 
   echo "codeql"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -32769,6 +32769,22 @@ assert_eq "finders: docs surface → codeql absent" "0" "$n"
 out=$(printf 'surface=tests\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders")
 assert_eq "finders: tests → code-review only" "code-review" "$out"
 
+# cost finder: present when surface=code + app_or_rules=true
+n=$(printf 'surface=code\ndeps=false\napp_or_rules=true\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -c '^cost$')
+assert_eq "finders: code+app → cost present" "1" "$n"
+
+# cost finder: absent when surface=code + app_or_rules=false
+n=$(printf 'surface=code\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -c '^cost$' || true)
+assert_eq "finders: code !app → cost absent" "0" "$n"
+
+# cost finder: absent on docs surface
+n=$(printf 'surface=docs\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -c '^cost$' || true)
+assert_eq "finders: docs surface → cost absent" "0" "$n"
+
+# cost finder: absent on tests surface
+n=$(printf 'surface=tests\ndeps=false\napp_or_rules=false\n' | "$SCRIPT_DIR/dispatch-review-finders" | grep -c '^cost$' || true)
+assert_eq "finders: tests surface → cost absent" "0" "$n"
+
 # ============================================================================
 # === dispatch-review-dedup ===
 # ============================================================================

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -255,6 +255,49 @@ per-finding schema. Extract the `findings` array for `prescanned_findings`.
 Collect normalized CodeQL, npm, and erosion findings into `prescanned_findings`
 to pass to the Workflow.
 
+#### Finder agents (when `surface=code`)
+
+The Workflow fans out agent finders based on `surface` and `app_or_rules`. The
+`code-review` quality finder always runs. When `surface === 'code'`, the following
+domain finders also run. Four are gated on `surface=code` alone; four additionally
+require `app_or_rules=true` (application/functions/rules source):
+
+**`surface === 'code'`** (any code-surface diff):
+- **input-validation** — Hunt injection in the changed code: SQL/NoSQL injection, XSS,
+  command injection, path traversal. Check that external input is validated and escaped
+  at every boundary it crosses.
+- **secrets** — Hardcoded keys/tokens/credentials in the changed code, `.env` files
+  committed to git, secrets leaking into build output.
+- **red-team** — Construct concrete attack scenarios against the changed code. Pick an
+  attacker goal, trace a path through the diff to reach it, and report each viable
+  scenario as a finding. Build scenarios from the code under review, not a checklist of
+  known vulnerabilities.
+- **security-review** — Invokes the built-in `/security-review` skill for a broad
+  security pass.
+
+**`surface === 'code' && app_or_rules=true`** (app/functions/rules source):
+- **auth** — Auth and access control: Firestore rules coverage for paths the diff touches,
+  missing auth checks, privilege escalation. Confirm each new or changed Firestore path
+  has a matching rule block and that client code does not assume access the rules do not
+  grant.
+- **data-exposure** — API responses returning more fields than the caller needs, PII in
+  logs (console.log and similar), internal details (stack traces, config, paths) leaked
+  in error messages.
+- **firebase** — Firebase-specific: Firestore rules permissiveness (overly broad `allow`
+  conditions, missing field constraints), emulator-only code reachable on production
+  paths, Firebase API key or config exposure.
+- **cost** — Cost/scaling lens: flags three Firestore cost/scaling patterns introduced in
+  the diff: (1) unbounded queries — `getDocs`/collection scans with no `limit()` over a
+  collection that grows without bound; (2) new high-frequency amplifiers layered over
+  collection scans — a new interval, scheduler, polling loop, or refresh (e.g. a 5-minute
+  refresh) placed over a query that scans a growing collection (the query×amplifier
+  interaction); (3) N+1 `getDoc` loops. Reasons about the interaction between a query and
+  its amplifier (call frequency × collection growth), not just the static shape of a
+  single query — a query that is cheap per call becomes a cost/scaling risk once a new
+  refresh or interval runs it repeatedly over a growing collection. Sets Source "cost",
+  OWASP "", STRIDE "" (non-security). Findings are ADVISORY — see the cost disposition
+  note in Step 4.
+
 ### 2. Build `args` and invoke the Workflow
 
 Collect the fields for the Workflow invocation. Parse `Closes #N` from the pack's
@@ -381,6 +424,18 @@ Dismissed is for false positives, trivially wrong findings, or style preferences
 that are not actual improvements; smallness alone never qualifies (out-of-scope
 items go to Deferred, not Dismissed). When a code-review finding is
 ambiguous, default to Informational rather than inventing a code change.
+
+**`Source "cost"` findings are ADVISORY.** A confirmed cost/scaling pattern
+(unbounded collection query, a high-frequency amplifier layered over a scan, or an
+N+1 read loop) always routes to `Deferred` — filed as a non-blocking follow-up
+feeding the deterministic cost sensor (#2687). Even a cost finding that names a
+concrete pattern but is not obviously actionable still classifies `Deferred`
+(so it reaches the sensor) rather than `Informational`. Cost findings are
+**never** `Fixed` (not auto-fixed in this PR), **never** `Required`
+(not merge-blocking), and **never** verify-eligible (the adversarial-verify
+step is skipped for cost). When the classify agent returns no verdict for a cost
+finding, the Workflow falls back to `Deferred` so it is filed as a follow-up
+rather than silently dropped.
 
 ### 5. File meaningful out-of-scope findings as blocked_by follow-ups
 

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -88,6 +88,7 @@ const FINDING_ITEM_SCHEMA = {
         'codeql',
         'npm',
         'erosion',
+        'cost',
       ],
     },
     OWASP: { type: 'string' },
@@ -186,7 +187,7 @@ function agentFinderSet(surface, app_or_rules) {
   if (surface === 'code') {
     set.push('input-validation', 'secrets', 'red-team', 'security-review');
     if (app_or_rules) {
-      set.push('auth', 'data-exposure', 'firebase');
+      set.push('auth', 'data-exposure', 'firebase', 'cost');
     }
   }
   return set;
@@ -337,6 +338,27 @@ function finderPrompt(name, args) {
       'Once /security-review returns, continue: normalize every finding to the schema below with',
       'Source "security-review". Map its severity to Confidence (high/medium/low → high/medium/low),',
       'and infer the OWASP category and STRIDE element from each finding\'s category and description.',
+      SCHEMA_BLURB,
+    ].join('\n');
+  }
+  if (name === 'cost') {
+    return [
+      'You are a findings-only cost/scaling reviewer for Firestore-backed code.',
+      'Your findings are ADVISORY (non-blocking): surface concrete, actionable cost/scaling',
+      'patterns the diff introduces so they can be filed as follow-ups — you fix nothing.',
+      ctx,
+      'Flag these Firestore cost/scaling patterns introduced in the pending diff:',
+      '(1) unbounded or expensive Firestore queries — e.g. `getDocs`/collection scans with no',
+      '    `limit()` over a collection that grows without bound;',
+      '(2) new high-frequency amplifiers layered over collection scans — a new interval, scheduler,',
+      '    polling loop, or refresh (e.g. a 5-minute refresh) placed over a query that scans a growing',
+      '    collection (the query×amplifier interaction);',
+      '(3) N+1 `getDoc` loops — a per-item document read inside a loop over a growing set.',
+      'Reason about the INTERACTION between a query and its amplifier (call frequency × collection',
+      'growth), not just the static shape of a single query: a query that is cheap per call becomes a',
+      'cost/scaling risk once a new refresh or interval runs it repeatedly over a growing collection.',
+      'That query×amplifier interaction is the primary target of this lens.',
+      'Set Source "cost" and OWASP "" and STRIDE "" on every finding (cost is not security-classified).',
       SCHEMA_BLURB,
     ].join('\n');
   }
@@ -549,6 +571,13 @@ if (deduped.length) {
     '  verify→fix machinery as a code-review Fixed finding; it is a QUALITY concern, never a vulnerability).',
     '- Informational (erosion): an advisory complexity/duplication increase with no clear single refactor',
     '  → Informational (an FYI; no change required and nothing is filed).',
+    '- Deferred (cost): a finding with Source "cost" is an ADVISORY cost/scaling quality note,',
+    '  never a security issue. A confirmed, in-scope cost/scaling pattern (an unbounded/growing-',
+    '  collection query, a new high-frequency amplifier layered over a collection scan, or an N+1',
+    '  read loop) → Deferred: filed as a non-blocking follow-up feeding the deterministic cost sensor',
+    '  (#2687). When a cost finding names a concrete pattern but is not obviously actionable, still',
+    '  classify it Deferred (so it reaches the sensor) rather than Informational. Cost findings are',
+    '  NEVER Fixed (never auto-fixed in this PR) and NEVER Required (never merge-blocking).',
     'RULES: A finding is NEVER Dismissed merely because the change is small — if it is a real',
     'improvement within scope, classify it Fixed. When a code-review finding is ambiguous,',
     'default to Informational rather than inventing a code change.',
@@ -591,9 +620,11 @@ if (deduped.length) {
     const c = classById.get(f.id);
     // Fallback when the classify agent gave no verdict for this finding: erosion
     // sources → Informational (advisory, not filed) per the Informational-erosion
-    // design intent; security sources → Out-of-scope; code-review → Deferred
+    // design intent; security sources → Out-of-scope; code-review AND cost → Deferred
     // (NOT Informational) so an unclassified-but-real finding is filed as a follow-up
     // rather than silently dropped from both the fix set and the follow-up filings.
+    // (cost is neither erosion nor a SEC_SOURCE, so it naturally lands in the final
+    // Deferred branch — the same filed-follow-up lane as code-review.)
     const bucket = c
       ? c.bucket
       : f.Source === 'erosion'


### PR DESCRIPTION
Closes #2690

Adds a cost/scaling lens to the review phase — the discovery layer of the epic (#2686) defense against Firestore infrastructure price spikes. The review phase is the only guard that can reason about the query×amplifier *interaction* (e.g. a cheap query placed under a new 5-minute refresh over a growing collection), which no diff-scoped linter can express; the sibling deterministic sensor (#2687) is the complementary guard.

## What changed

- **`cost` agent finder** in the review-fix fan-out (`.claude/workflows/review-fix.js`): a new `Source: "cost"`, launched gated on `surface === 'code' && app_or_rules` alongside the `auth`/`data-exposure`/`firebase` app-domain trio. Its findings-only prompt flags three Firestore cost/scaling patterns introduced in the diff — (1) unbounded/growing-collection queries with no `limit()`, (2) new high-frequency amplifiers (intervals/schedulers/refreshes) layered over collection scans, (3) N+1 `getDoc` loops — and reasons about the query×amplifier interaction, not just static query shape. Findings are non-security (`OWASP ""`, `STRIDE ""`).
- **Advisory routing**: `cost` findings classify to the `Deferred` disposition — filed as a non-blocking follow-up feeding the deterministic cost sensor (#2687). They are never `Fixed` (auto-fixed in-PR), never `Required` (merge-blocking), and never verify-eligible. Cost flows through the existing `Deferred` → follow-up filing lane unchanged; the classify fallback lands an unclassified cost finding in `Deferred` rather than `Informational` (which would be dropped).
- **Normative bash spec** (`dispatch-review-finders`) mirrors the gating — emits `cost` after `firebase` under the `app_or_rules` gate — with new present/absent test assertions in `test-dispatch-scripts.sh`.
- **Documentation** of the lens in the review-fix SKILL (finder description + Deferred disposition) so it is durable.

## Verification

- `node --check .claude/workflows/review-fix.js` — clean.
- `.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` — 4161/4161 passed, 0 failed; the 4 new `cost` assertions pass.
