### PR TITLE
office-hours: dispatch event-hook triggers for low-latency snapshot refresh

### DIFF
--- a/.claude/hooks/dispatch-office-hours-strip.sh
+++ b/.claude/hooks/dispatch-office-hours-strip.sh
@@ -47,4 +47,10 @@ fi
 gh_issue_remove_label_rest "$ISSUE_NUM" dispatch:office-hours >/dev/null 2>&1 \
   || echo "[dispatch-office-hours-strip] WARNING: gh_issue_remove_label_rest failed for issue #$ISSUE_NUM" >&2
 
+# Office-hours snapshot: un-park `parked-only` refresh (#2661). Fired
+# unconditionally — this hook already runs only inside an <N>-* worktree on user
+# engagement; env-gated OFF by default + flock-serialized + best-effort, so a
+# redundant refresh is harmless. Preserves the never-block-submission contract.
+"$SCRIPTS/office-hours-snapshot-launch" parked-only || true
+
 exit 0

--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -295,6 +295,11 @@ strip_office_hours_label() {
   # cross-phase accumulation that is the whole point of the ceiling.
   if [ "${ISSUE_OFFICE_HOURS_PRESENT:-no}" = yes ]; then
     clear_attempt_counter
+    # Office-hours snapshot: park→unpark `parked-only` refresh (#2661). Same
+    # transition gate as the counter reset — only on a genuine unpark, not on
+    # every advance/self-close. Best-effort; the `|| true` keeps the function
+    # total (the file runs `set -uo pipefail` with a `trap … exit 0 ERR`).
+    "$SCRIPTS/office-hours-snapshot-launch" parked-only || true
   fi
 }
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-apply-office-hours
@@ -90,6 +90,14 @@ if ! add_output=$(gh_issue_set_labels_rest "$ISSUE_NUM" "$LABEL" 2>&1); then
   exit 0
 fi
 
+# --- Office-hours snapshot: park-event `parked-only` refresh (#2661) ---------
+# The label just landed on a FRESH apply (the idempotency no-op at the top
+# already exited for a repeat), so trigger a low-latency parked-only snapshot
+# refresh — this changes exactly what the Parked Issues panel shows. Env-gated
+# OFF by default; best-effort; the `|| true` preserves the never-block-a-hook
+# contract.
+"$SCRIPT_DIR/office-hours-snapshot-launch" parked-only || true
+
 # The label is now on the issue. Post the why-comment. A comment failure is
 # non-fatal (the label still landed) — warn and exit 0.
 if ! comment_output=$(gh_issue_comment_rest "$ISSUE_NUM" --body "Parked on \`$LABEL\`. Reason: $REASON" 2>&1); then

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -214,6 +214,16 @@ if [[ "${DISPATCH_TOPIC_USAGE_ENABLED:-}" == "1" ]]; then
   fi
 fi
 
+# --- Office-hours snapshot: tick-start `full` refresh (#2661) ----------------
+# Env-gated OFF by default (OFFICE_HOURS_SNAPSHOT_ENABLED); a no-op on every
+# current tick.  `full` (not `parked-only`) because the tick-start criterion
+# requires refreshing queue-metrics + parked-issues, and only `full` runs the
+# cores that carry queue-metrics (parked-only does no core runs — see
+# office-hours-snapshot/README.md).  A `full` run also runs project-signals when
+# configured; the cadence/cost of that at per-tick frequency is a #2660 concern,
+# not this PR.
+"$SCRIPT_DIR/office-hours-snapshot-launch" full || true
+
 # --- Step 0: parse the single optional positional <N> ------------------------
 ARG=""
 MANUAL=""

--- a/.claude/skills/dispatch-propagate/scripts/office-hours-snapshot-launch
+++ b/.claude/skills/dispatch-propagate/scripts/office-hours-snapshot-launch
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# office-hours-snapshot-launch — reusable detached snapshot-refresh launcher (#2661)
+#
+# The shared primitive behind #2661's low-latency office-hours snapshot refresh
+# triggers: tick-start (scope=full) and park/un-park (scope=parked-only). All
+# four call sites invoke this one launcher.
+#
+# Properties:
+#   - Env-gated OFF by default. Until OFFICE_HOURS_SNAPSHOT_ENABLED=1, this is a
+#     pure no-op (exit 0) so every normal tick/hook stays byte-for-byte
+#     unchanged.
+#   - Detached + best-effort. The producer runs in a fully detached child
+#     (setsid, </dev/null, redirected to a log). This launcher never blocks and
+#     never aborts the tick/hook that invokes it: only argument misuse is a hard
+#     error; every other path exits 0.
+#   - Per-scope serialization via a bounded-wait flock INSIDE the child, so a
+#     `full` and a `parked-only` refresh may run concurrently, while two of the
+#     same scope serialize — the second waits briefly, and if the wait times out
+#     it exits quietly (the in-flight run already covers the burst).
+
+usage() {
+  echo "usage: office-hours-snapshot-launch <full|parked-only>" >&2
+}
+
+# (a) Validate args first — misuse is a hard error, always caught even when the
+#     feature is disabled (this is misuse detection, not a fallback).
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+SCOPE="$1"
+if [[ "$SCOPE" != "full" && "$SCOPE" != "parked-only" ]]; then
+  echo "office-hours-snapshot-launch: invalid scope '$SCOPE' (want: full|parked-only)" >&2
+  usage
+  exit 2
+fi
+
+# (b) Env-gate — OFF by default. Any value other than exactly "1" is a no-op.
+if [[ "${OFFICE_HOURS_SNAPSHOT_ENABLED:-}" != "1" ]]; then
+  exit 0
+fi
+
+# (c) Resolve the launch command. #2660 later overrides this with a compiled
+#     binary path via OFFICE_HOURS_SNAPSHOT_CMD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/../../../.."  # scripts -> dispatch-propagate -> skills -> .claude -> repo root
+if [[ -n "${OFFICE_HOURS_SNAPSHOT_CMD:-}" ]]; then
+  SNAPSHOT_CMD="$OFFICE_HOURS_SNAPSHOT_CMD"
+  CMD_IS_DEFAULT=0
+else
+  SNAPSHOT_CMD="npx tsx $REPO_ROOT/office-hours-snapshot/src/main.ts"
+  CMD_IS_DEFAULT=1
+fi
+
+# Synchronous precondition check — only for the default tsx command, which needs
+# npx (and hence node) on PATH. Backgrounding always exits 0 after the fork, so
+# this is the only place a doomed launch can be caught. When the override is set
+# (e.g. a compiled binary that needs neither), skip this guard.
+if [[ "$CMD_IS_DEFAULT" == "1" ]] && ! command -v npx >/dev/null 2>&1; then
+  echo "office-hours-snapshot-launch: WARNING: npx not found; snapshot ($SCOPE) skipped" >&2
+  exit 0
+fi
+
+STATE_DIR="${OFFICE_HOURS_SNAPSHOT_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/dispatch}"
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+LOCKFILE="$STATE_DIR/office-hours-snapshot-$SCOPE.lock"  # per-scope: full and parked-only never block each other
+LOG="$STATE_DIR/office-hours-snapshot.log"
+
+# Detached, best-effort launch. The bounded-wait flock runs INSIDE the detached
+# child so the caller never waits: a same-scope run in flight makes this child
+# wait up to 30s (running the latest event's refresh rather than dropping it as
+# `-n` would); if the wait times out the child exits quietly. flock accepts the
+# bare fd number.
+#
+# shellcheck disable=SC2086  # $SNAPSHOT_CMD must word-split: the default value
+# is the multi-word `npx tsx <path>` command and must tokenize into argv.
+(
+  setsid bash -c '
+    exec 9>"$1"
+    flock -w 30 9 || exit 0   # a same-scope run holds it; that run covers this burst
+    shift
+    exec "$@"
+  ' _ "$LOCKFILE" $SNAPSHOT_CMD --scope "$SCOPE" >>"$LOG" 2>&1 </dev/null &
+)
+
+exit 0

--- a/.claude/skills/dispatch-propagate/scripts/test-office-hours-snapshot-launch.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-office-hours-snapshot-launch.sh
@@ -148,4 +148,23 @@ wait_for_file "$STATE_DIR/office-hours-snapshot-parked-only.lock"
   && assert_eq "per-scope lock: parked-only.lock exists" "yes" "yes" \
   || assert_eq "per-scope lock: parked-only.lock exists" "yes" "no"
 
+# --- Case 5: caller returns fast even under same-scope contention ------------
+# This verifies the load-bearing design decision: the bounded-wait flock lives
+# INSIDE the detached child, so the CALLER never blocks even when a same-scope
+# run already holds the lock. If flock were moved into the caller, holding the
+# lock externally here would stall the launcher for the full -w 30 window.
+echo "== Case 5: caller fast under contention =="
+exec 8>"$STATE_DIR/office-hours-snapshot-full.lock"
+flock 8   # hold the full-scope lock so any in-caller flock would block
+SECONDS=0
+rc=0
+"$LAUNCH" full || rc=$?
+elapsed=$SECONDS
+flock -u 8
+exec 8>&-
+assert_eq "contention: exit 0" "0" "$rc"
+[[ "$elapsed" -lt 10 ]] \
+  && assert_eq "contention: caller returns fast (flock in child)" "fast" "fast" \
+  || assert_eq "contention: caller returns fast (flock in child)" "fast" "slow(${elapsed}s)"
+
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-office-hours-snapshot-launch.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-office-hours-snapshot-launch.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Unit-test suite for office-hours-snapshot-launch (#2661). Drives the launcher
+# via a FAKE producer stub (OFFICE_HOURS_SNAPSHOT_CMD) and an isolated state dir,
+# so no node/network is required (the CMD override skips the node guard).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LAUNCH="$SCRIPT_DIR/office-hours-snapshot-launch"
+
+# --- test helpers -----------------------------------------------------------
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected: '$expected'"
+    echo "    actual:   '$actual'"
+  fi
+}
+
+report_results() {
+  echo ""
+  echo "================================"
+  echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+  echo "================================"
+  [[ "$FAIL" -eq 0 ]]
+}
+
+# Poll up to ~5s for a file to exist.
+wait_for_file() {
+  local f="$1" n=0
+  while [[ ! -e "$f" && $n -lt 50 ]]; do sleep 0.1; n=$((n + 1)); done
+}
+
+# Poll up to ~5s for a file to contain a substring.
+wait_for_content() {
+  local f="$1" needle="$2" n=0
+  while [[ $n -lt 50 ]]; do
+    [[ -e "$f" ]] && grep -q -- "$needle" "$f" && return 0
+    sleep 0.1; n=$((n + 1))
+  done
+  return 1
+}
+
+# --- harness ----------------------------------------------------------------
+
+TMPDIR_TEST=""
+cleanup() { [[ -n "$TMPDIR_TEST" && -d "$TMPDIR_TEST" ]] && rm -rf "$TMPDIR_TEST"; }
+trap cleanup EXIT
+
+TMPDIR_TEST=$(mktemp -d)
+STATE_DIR="$TMPDIR_TEST/state"
+MARKER="$TMPDIR_TEST/marker"
+FAKE="$TMPDIR_TEST/fake-producer"
+
+# Fake producer: parse --scope <value> and append the value to $FAKE_MARKER.
+cat >"$FAKE" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+scope=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --scope) scope="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+echo "$scope" >> "$FAKE_MARKER"
+EOF
+chmod +x "$FAKE"
+
+export OFFICE_HOURS_SNAPSHOT_STATE_DIR="$STATE_DIR"
+export OFFICE_HOURS_SNAPSHOT_CMD="bash $FAKE"
+export FAKE_MARKER="$MARKER"
+
+# --- Case 1: gate OFF -> no-op, no launch -----------------------------------
+echo "== Case 1: gate OFF =="
+unset OFFICE_HOURS_SNAPSHOT_ENABLED || true
+rc=0
+"$LAUNCH" full || rc=$?
+assert_eq "gate off: exit 0" "0" "$rc"
+sleep 0.5
+if [[ -e "$MARKER" ]]; then
+  assert_eq "gate off: marker absent" "absent" "present"
+else
+  assert_eq "gate off: marker absent" "absent" "absent"
+fi
+
+# --- Case 2: invalid scope / wrong arg count -> hard error, no launch -------
+echo "== Case 2: misuse =="
+export OFFICE_HOURS_SNAPSHOT_ENABLED=1
+rc=0
+"$LAUNCH" bogus || rc=$?
+[[ "$rc" -ne 0 ]] && assert_eq "invalid scope: non-zero exit" "nonzero" "nonzero" \
+  || assert_eq "invalid scope: non-zero exit" "nonzero" "zero"
+rc=0
+"$LAUNCH" || rc=$?
+[[ "$rc" -ne 0 ]] && assert_eq "no args: non-zero exit" "nonzero" "nonzero" \
+  || assert_eq "no args: non-zero exit" "nonzero" "zero"
+sleep 0.5
+if [[ -e "$MARKER" ]]; then
+  assert_eq "misuse: marker absent" "absent" "present"
+else
+  assert_eq "misuse: marker absent" "absent" "absent"
+fi
+
+# --- Case 3: gate ON, scope=full -> returns fast, then marker records full ---
+echo "== Case 3: gate ON, full =="
+export OFFICE_HOURS_SNAPSHOT_ENABLED=1
+SECONDS=0
+rc=0
+"$LAUNCH" full || rc=$?
+elapsed=$SECONDS
+assert_eq "full: exit 0" "0" "$rc"
+[[ "$elapsed" -lt 10 ]] && assert_eq "full: launcher returns fast (<10s)" "fast" "fast" \
+  || assert_eq "full: launcher returns fast (<10s)" "fast" "slow(${elapsed}s)"
+if wait_for_content "$MARKER" "full"; then
+  assert_eq "full: marker records scope" "full" "$(grep -c '^full$' "$MARKER" >/dev/null && echo full)"
+else
+  assert_eq "full: marker records scope" "full" "MISSING"
+fi
+
+# --- Case 4: gate ON, scope=parked-only -> marker + both lock files exist ----
+echo "== Case 4: gate ON, parked-only =="
+rc=0
+"$LAUNCH" parked-only || rc=$?
+assert_eq "parked-only: exit 0" "0" "$rc"
+if wait_for_content "$MARKER" "parked-only"; then
+  assert_eq "parked-only: marker records scope" "parked-only" "parked-only"
+else
+  assert_eq "parked-only: marker records scope" "parked-only" "MISSING"
+fi
+# Both per-scope lock files should have been created by their runs.
+wait_for_file "$STATE_DIR/office-hours-snapshot-full.lock"
+wait_for_file "$STATE_DIR/office-hours-snapshot-parked-only.lock"
+[[ -e "$STATE_DIR/office-hours-snapshot-full.lock" ]] \
+  && assert_eq "per-scope lock: full.lock exists" "yes" "yes" \
+  || assert_eq "per-scope lock: full.lock exists" "yes" "no"
+[[ -e "$STATE_DIR/office-hours-snapshot-parked-only.lock" ]] \
+  && assert_eq "per-scope lock: parked-only.lock exists" "yes" "yes" \
+  || assert_eq "per-scope lock: parked-only.lock exists" "yes" "no"
+
+report_results


### PR DESCRIPTION
Closes #2661

## What & why

Adds the **low-latency event layer** for the office-hours local snapshot, on top
of the existing local producer (`office-hours-snapshot/`, #2658) and the sibling
Nix systemd timer (#2660). The dispatch router's own events now launch a
best-effort, detached producer refresh so the dashboard reflects chain activity
promptly, without polling.

Two attach points matter for latency — a worker **parking** and **un-parking** —
because they change exactly what the Parked Issues panel shows and are the only
sub-tick-latency events in the chain. A per-tick `full` refresh covers everything
else (merges, phase-completes, and drains all resolve inside a tick, so observing
at tick-start captures them).

## How

A single reusable launcher, invoked at four call sites. It is **env-gated OFF by
default** (`OFFICE_HOURS_SNAPSHOT_ENABLED`), **detached** (`setsid … &`), **never
blocks** its caller, and **never aborts** a tick or hook — so the wiring is
byte-for-byte dormant on every current tick/hook until the snapshot layer is
explicitly enabled. This lets it ship independent of #2660 (no `blocked_by`): when
enabled without #2660 it runs the producer via `npx tsx`; #2660's Nix packaging
later overrides `OFFICE_HOURS_SNAPSHOT_CMD` to the compiled binary.

- **Unit 1** — new `office-hours-snapshot-launch` (+ auto-discovered unit test).
  The shared primitive: arg-validated (`full` | `parked-only`), env-gated,
  synchronous `npx`-presence precondition for the default command, per-scope
  `flock` serialization via a **bounded-wait `flock -w 30` inside the detached
  child** (so a `full` and a `parked-only` run may proceed concurrently while two
  of the same scope serialize, and the caller never waits).
- **Unit 2** — `dispatch-tick`: tick-start `full` refresh beside the existing
  detached side-effect launches. `full` (not `parked-only`) because only `full`
  runs the cores that carry queue-metrics, which the tick-start criterion
  requires.
- **Unit 3** — `dispatch-apply-office-hours`: `parked-only` refresh on the
  fresh-apply (park) path only, past the idempotency no-op so a repeatedly-firing
  hook does not re-launch.
- **Unit 4** — the two un-park hooks: `dispatch-stop.sh`'s
  `strip_office_hours_label()` (gated on the existing park→unpark
  `ISSUE_OFFICE_HOURS_PRESENT=yes` signal) and `dispatch-office-hours-strip.sh`
  (unconditional — already scoped to `<N>-*` worktrees on user engagement).

## Verification

Both auto-runnable `verify` blocks pass:

- `test-office-hours-snapshot-launch.sh` — 14/14 (gate-off no-op, arg misuse,
  gate-on `full`/`parked-only` launches, per-scope lock isolation, and a
  contention case pinning that the `flock` lives in the child so the caller stays
  fast).
- `test-dispatch-scripts.sh` — 4166/4166.

Manual (owner-machine) end-to-end and concurrency checks are noted in the plan's
Verification section for QA; the launcher is a no-op until
`OFFICE_HOURS_SNAPSHOT_ENABLED=1`, so it does not change any current behavior.
