### PR TITLE
intentionsutil: attention model — authored injections, derived flow resolver

### DIFF
--- a/.claude/docs/signal-identification.md
+++ b/.claude/docs/signal-identification.md
@@ -157,8 +157,9 @@ step.
 
 1. **Re-prioritize by gap.** Trigger: the frontier is projected. Reads: each frontier
    node's `gap`. Output: gap-present nodes ordered ahead of gap-absent ones. Already
-   realized by `intentionsutil/src/goals.ts::projectGoals`, which sorts gap-present
-   (`gap !== null`) nodes first. Reference it as done.
+   realized by `intentionsutil/src/goals.ts::projectGoals`, whose primary sort key is now
+   resolved attention (the derived attention flow, descending) with gap-present
+   (`gap !== null`) first as the tie-break within equal attention. Reference it as done.
 
 2. **Falsify proxy goals.** Trigger: an `is_proxy` signal's reading contradicts the
    underlying intention (the proxy reads "met" while the real intention plainly is not,

--- a/packages/intentionsutil/SCHEMA.md
+++ b/packages/intentionsutil/SCHEMA.md
@@ -69,6 +69,7 @@ authoritative data.
 | `clarifications` | `Clarification[]`     | no       | Q&A pairs resolved during the dialectic. Defaults to `[]`. |
 | `tooling_goals`  | `ToolingGoal[]`       | no       | Tooling the node aims to produce or change. Defaults to `[]`. |
 | `success_signal` | `SuccessSignal \| null` | no     | A measurable signal the intention is met. Defaults to `null`. |
+| `attention`      | `Attention \| null`   | no       | A user-authored attention injection (weight + rationale). Valid only on goal-layer kinds, enforced by `validateGraph`. The resolved flow it seeds is derived on read by `resolveAttention` and never stored. Defaults to `null`. |
 | `attributes`     | `Record<string, unknown>` | no   | Kind-specific fields (e.g. a delegation's divergence/irreversibility assessment). Validated as a plain object; the meaning of its entries is defined by the node's kind node. Defaults to `{}`. |
 
 ### `SuccessSignal`
@@ -93,6 +94,18 @@ authoritative data.
 | ----------- | -------------- | ------- |
 | `kind`      | `ToolingKind` enum | What the goal codifies. |
 | `statement` | `string`       | The tooling goal, in one sentence. |
+
+### `Attention`
+
+A user-authored injection that seeds the derived attention flow. Valid only on
+goal-layer kinds (see Graph-level validation).
+
+| Name             | Type              | Meaning |
+| ---------------- | ----------------- | ------- |
+| `weight`         | `number`          | The injected weight. Must be finite and `>= 0`; any scale — only ratios matter. |
+| `rationale`      | `string`          | Why this node draws (or defers) attention now. Must be non-empty. |
+| `subordinate_to` | `string[]`        | `id`s of nodes whose claims outrank this one. While non-empty, the injection is damped. Defaults to `[]`. |
+| `review_trigger` | `string \| null`  | The condition that re-opens an explicit deferral. **Required when `weight` is 0** (deferral without a re-open condition is rejected); otherwise `null`. |
 
 ## Enums
 
@@ -138,7 +151,12 @@ nodes as invalid.
 `validateGraph(nodes)` checks referential integrity across a whole node set:
 every node's `kind` has its defining `kind-<kind>` node present, and every
 non-null `parent` and every `serves` and `recovers` entry resolves to an
-existing node id. It
+existing node id. It also checks the `attention` edges: every
+`attention.subordinate_to` entry resolves to an existing node id, and
+`attention` appears only on nodes whose kind node sets
+`attributes.goal_layer: true`. The eligible layer is data (the kind nodes), not
+a kind list in this file — virtues stay unranked because `kind-virtue` carries
+no `goal_layer` flag, not because code names it. It
 throws one error listing all violations. Backfill runs it over the full store
 after regenerating the tactic leaves.
 
@@ -148,8 +166,23 @@ after regenerating the tactic leaves.
 returns an object with exactly the `IntentionNode` fields and all defaults
 applied (`parent: null`, `serves: []`, `recovers: []`, `rationale: null`, `reading: null`,
 `gap: null`, `clarifications: []`, `tooling_goals: []`, `success_signal: null`,
-`attributes: {}`), so constructing a node, writing it to frontmatter, reading
-it back, and validating yields a deep-equal node. `attributes` values must be
+`attention: null`, `attributes: {}`), so constructing a node, writing it to
+frontmatter, reading it back, and validating yields a deep-equal node.
+`attributes` values must be
 YAML-representable data (strings, numbers, booleans, arrays, maps) for the
 guarantee to hold. The cosmetic markdown body is excluded from this guarantee
 by design — only the frontmatter is authoritative.
+
+## Derived attention is never stored
+
+The `attention` field is a user-authored *injection* — only the weight,
+rationale, and edges the author writes. The resolved flow and band that
+`resolveAttention` computes from it are derived on read and NEVER enter
+frontmatter. This contrasts with `gap`, which `deriveGap` computes from
+same-file inputs (`reading` vs `success_signal.threshold`): storing `gap` is
+safe because it is a local function of one node's own fields. Attention is a
+*global* function of the whole graph — a node's flow depends on every other
+node's injections and edges — so storing it would go stale on any edit
+elsewhere in the graph. It is recomputed from the authoritative injections each
+time it is read, the same intent/derivation discipline as `intentions/`
+(authored intent) vs `trackers/` (derived execution state).

--- a/packages/intentionsutil/src/attention.ts
+++ b/packages/intentionsutil/src/attention.ts
@@ -1,0 +1,215 @@
+import { IntentionSchemaError } from "./errors.js";
+import type { IntentionNode } from "./schema.js";
+
+// --- Judgment constants ------------------------------------------------------
+// All four are JUDGMENT CONSTANTS reviewed at office-hours, not fitted
+// parameters. The resolver deliberately has only two signal terms (injection
+// and provenance) — every added weight is a free parameter someone will one
+// day defend.
+
+/**
+ * Multiplier on an injection whose node cannot trace a `serves`/`parent` chain
+ * to any virtue. Own-virtue-justified work outranks work justified only by
+ * delegatee-grafted constraints.
+ */
+export const PROVENANCE_DISCOUNT = 0.5;
+
+/**
+ * Multiplier on an injection whose node declares `subordinate_to`. Applied
+ * unconditionally while the edge exists — removing the edge is the human
+ * review act that lifts the damping.
+ */
+export const SUBORDINATION_DAMP = 0.25;
+
+/**
+ * A node is `top` band when its flow is at least this multiple of the mean
+ * nonzero flow across eligible nodes.
+ */
+export const BAND_HIGH = 4;
+
+/**
+ * A node is `bottom` band when its flow is at most this fraction of the mean
+ * nonzero flow across eligible nodes (or exactly zero while any injection
+ * exists anywhere).
+ */
+export const BAND_LOW = 0.25;
+
+// --- Types -------------------------------------------------------------------
+
+export type AttentionBand = "top" | "middle" | "bottom";
+
+/** The derived attention of one eligible node. Computed on read, NEVER stored. */
+export interface ResolvedAttention {
+  /** The node's retained flow — its rank value. Scale-free; only ratios matter. */
+  value: number;
+  /** Coarse cut of `value` consumed by routers; floats never leave this module's callers. */
+  band: AttentionBand;
+  /**
+   * Ids of the nodes whose authored injections contributed to this flow,
+   * ordered by contribution (largest first, id ascending on ties) — for
+   * explainability ("via strategy-x").
+   */
+  sources: string[];
+}
+
+// --- Resolver ------------------------------------------------------------------
+
+/**
+ * Resolve derived attention for every goal-layer node in the graph.
+ *
+ * Pure and deterministic: same nodes in, deep-equal map out. Derived values
+ * are never written back to node frontmatter — same discipline as `trackers/`
+ * (execution state) vs `intentions/` (intent).
+ *
+ * Algorithm (two signal terms only):
+ *   1. Eligible set — nodes whose kind node sets `attributes.goal_layer: true`.
+ *      All other nodes get no entry.
+ *   2. Injection — `attention.weight`, multiplied by the provenance factor
+ *      (1 when the `serves` ∪ `parent` chain reaches a virtue, else
+ *      PROVENANCE_DISCOUNT) and by SUBORDINATION_DAMP when `subordinate_to`
+ *      is non-empty.
+ *   3. Flow — conserved distribution: a node's flow is its damped injection
+ *      plus its inherited share; a node with children passes its full flow
+ *      divided evenly among them (sub-nodes via `parent`, plus eligible nodes
+ *      that name it in `serves`) while retaining the flow value as its own
+ *      rank. A `parent`/`serves` cycle is surfaced as an IntentionSchemaError
+ *      listing the cycle path.
+ *   4. Banding — scale-invariant against the mean of nonzero flows. When no
+ *      injections exist anywhere, every eligible node is `middle` (the
+ *      pre-attention status quo: nothing escalated, nothing suppressed).
+ */
+export function resolveAttention(nodes: IntentionNode[]): Map<string, ResolvedAttention> {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+
+  const isEligible = (n: IntentionNode): boolean => {
+    const kindNode = byId.get(`kind-${n.kind}`);
+    return kindNode !== undefined && kindNode.attributes.goal_layer === true;
+  };
+
+  // Provenance: walk `serves` ∪ `parent` transitively upward looking for a
+  // virtue. Memoized per node; a visited set guards against revisits (and
+  // makes the walk total even on a cyclic graph — the cycle error below is
+  // the authoritative guard).
+  const reachesVirtue = (start: IntentionNode): boolean => {
+    const visited = new Set<string>();
+    const stack = [start];
+    while (stack.length > 0) {
+      const n = stack.pop();
+      if (n === undefined || visited.has(n.id)) continue;
+      visited.add(n.id);
+      if (n.kind === "virtue") return true;
+      const next = n.parent === null ? [...n.serves] : [...n.serves, n.parent];
+      for (const id of next) {
+        const target = byId.get(id);
+        if (target !== undefined) stack.push(target);
+      }
+    }
+    return false;
+  };
+
+  // Damped injection per eligible node.
+  const injection = (n: IntentionNode): number => {
+    if (!isEligible(n) || n.attention === null) return 0;
+    const provenance = reachesVirtue(n) ? 1 : PROVENANCE_DISCOUNT;
+    const damp = n.attention.subordinate_to.length > 0 ? SUBORDINATION_DAMP : 1;
+    return n.attention.weight * provenance * damp;
+  };
+
+  // Distribution edges. children(s) = { nodes with parent === s.id } ∪
+  // { eligible nodes with s.id ∈ serves }; a child's distributors are the
+  // reverse view of the same definition.
+  const childCount = new Map<string, number>();
+  for (const c of nodes) {
+    const drawsFrom = new Set<string>();
+    if (c.parent !== null && byId.has(c.parent)) drawsFrom.add(c.parent);
+    if (isEligible(c)) {
+      for (const s of c.serves) {
+        if (byId.has(s)) drawsFrom.add(s);
+      }
+    }
+    for (const p of drawsFrom) {
+      childCount.set(p, (childCount.get(p) ?? 0) + 1);
+    }
+  }
+  const distributors = (c: IntentionNode): IntentionNode[] => {
+    const ids = new Set<string>();
+    if (c.parent !== null && byId.has(c.parent)) ids.add(c.parent);
+    if (isEligible(c)) {
+      for (const s of c.serves) {
+        if (byId.has(s)) ids.add(s);
+      }
+    }
+    return [...ids].sort().map((id) => byId.get(id) as IntentionNode);
+  };
+
+  // Flow + per-source contributions, memoized DFS with cycle detection.
+  const flows = new Map<string, number>();
+  const contributions = new Map<string, Map<string, number>>();
+  const onStack = new Set<string>();
+  const stackPath: string[] = [];
+
+  const resolveFlow = (n: IntentionNode): number => {
+    const memo = flows.get(n.id);
+    if (memo !== undefined) return memo;
+    if (onStack.has(n.id)) {
+      const cycle = [...stackPath.slice(stackPath.indexOf(n.id)), n.id];
+      throw new IntentionSchemaError(
+        `attention flow cycle: ${cycle.join(" -> ")}`,
+      );
+    }
+    onStack.add(n.id);
+    stackPath.push(n.id);
+
+    const inj = injection(n);
+    const contrib = new Map<string, number>();
+    if (inj > 0) contrib.set(n.id, inj);
+    let flow = inj;
+    for (const p of distributors(n)) {
+      const share = resolveFlow(p) / (childCount.get(p.id) as number);
+      flow += share;
+      const parentFlow = flows.get(p.id) as number;
+      if (parentFlow > 0) {
+        const scale = 1 / (childCount.get(p.id) as number);
+        for (const [src, amt] of contributions.get(p.id) as Map<string, number>) {
+          contrib.set(src, (contrib.get(src) ?? 0) + amt * scale);
+        }
+      }
+    }
+
+    onStack.delete(n.id);
+    stackPath.pop();
+    flows.set(n.id, flow);
+    contributions.set(n.id, contrib);
+    return flow;
+  };
+
+  // Iterate in id order for a deterministic result regardless of input order.
+  const sorted = [...nodes].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  const eligible = sorted.filter(isEligible);
+  for (const n of eligible) resolveFlow(n);
+
+  // Banding, scale-invariant: mean of nonzero eligible flows.
+  const nonzero = eligible
+    .map((n) => flows.get(n.id) as number)
+    .filter((f) => f > 0);
+  const mean = nonzero.length > 0 ? nonzero.reduce((a, b) => a + b, 0) / nonzero.length : 0;
+
+  const band = (flow: number): AttentionBand => {
+    // No injections anywhere → the pre-attention status quo: all middle.
+    if (mean === 0) return "middle";
+    if (flow === 0 || flow <= mean * BAND_LOW) return "bottom";
+    if (flow >= mean * BAND_HIGH) return "top";
+    return "middle";
+  };
+
+  const result = new Map<string, ResolvedAttention>();
+  for (const n of eligible) {
+    const flow = flows.get(n.id) as number;
+    const contrib = contributions.get(n.id) as Map<string, number>;
+    const sources = [...contrib.entries()]
+      .sort((a, b) => (a[1] !== b[1] ? b[1] - a[1] : a[0] < b[0] ? -1 : 1))
+      .map(([src]) => src);
+    result.set(n.id, { value: flow, band: band(flow), sources });
+  }
+  return result;
+}

--- a/packages/intentionsutil/src/goals.ts
+++ b/packages/intentionsutil/src/goals.ts
@@ -1,3 +1,5 @@
+import type { ResolvedAttention } from "./attention.js";
+import { resolveAttention } from "./attention.js";
 import type { IntentionNode, Owner } from "./schema.js";
 
 /**
@@ -11,6 +13,12 @@ export type Realization = "issue-or-pr" | "script-and-tests";
 export interface Goal {
   node: IntentionNode;
   realization: Realization;
+  /**
+   * The node's derived attention, or null when the node is not goal-layer
+   * eligible (no `resolveAttention` entry). Drives the primary sort key and the
+   * band marker in `renderFrontier`.
+   */
+  attention: ResolvedAttention | null;
 }
 
 /**
@@ -49,16 +57,31 @@ export function activeFrontier(nodes: IntentionNode[]): IntentionNode[] {
 /**
  * Project the active frontier into an ordered list of goals.
  *
+ * Attention is resolved over the FULL input node list (not just the frontier),
+ * because a frontier leaf's flow may be inherited from a non-frontier ancestor
+ * (a strategy the leaf serves/parents up to). A frontier node with no resolver
+ * entry carries value 0.
+ *
  * Sort is a TOTAL order, independent of input order:
- *   1. gap-present (non-null) before gap-absent;
- *   2. then success_signal-present (non-null) before absent;
- *   3. then `id` ascending (the unique tiebreak guaranteeing totality).
+ *   1. resolved attention value DESCENDING (the primary key — the derived
+ *      attention flow; a node with no resolver entry has value 0);
+ *   2. then gap-present (non-null) before gap-absent;
+ *   3. then success_signal-present (non-null) before absent;
+ *   4. then `id` ascending (the unique tiebreak guaranteeing totality).
+ *
+ * When no node carries an injection anywhere, every value is 0, so key 1 never
+ * discriminates and the order is EXACTLY the pre-attention gap/signal/id order.
  *
  * The input array is not mutated (a copy is sorted).
  */
 export function projectGoals(nodes: IntentionNode[]): Goal[] {
+  const attention = resolveAttention(nodes);
   const frontier = activeFrontier(nodes);
   const sorted = [...frontier].sort((a, b) => {
+    const aVal = attention.get(a.id)?.value ?? 0;
+    const bVal = attention.get(b.id)?.value ?? 0;
+    if (aVal !== bVal) return bVal - aVal;
+
     const aGap = a.gap !== null ? 0 : 1;
     const bGap = b.gap !== null ? 0 : 1;
     if (aGap !== bGap) return aGap - bGap;
@@ -69,7 +92,11 @@ export function projectGoals(nodes: IntentionNode[]): Goal[] {
 
     return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
   });
-  return sorted.map((node) => ({ node, realization: realizationForOwner(node.owner) }));
+  return sorted.map((node) => ({
+    node,
+    realization: realizationForOwner(node.owner),
+    attention: attention.get(node.id) ?? null,
+  }));
 }
 
 function renderRealization(realization: Realization): string {
@@ -81,14 +108,27 @@ function renderRealization(realization: Realization): string {
  * `projectGoals` order. The output is byte-stable across repeated calls with
  * the same input: no dates, no wall-clock, no environment data. Ends with a
  * trailing newline.
+ *
+ * Each non-`middle` band gets a marker appended after the `_(owner: … → …)_`
+ * segment and before the gap suffix: ` [<band> via <sources[0]>]` naming the
+ * top contributing source, or ` [<band>]` when `sources` is empty. `middle`
+ * (and no-attention) goals render unmarked, so a store with no injection
+ * anywhere is byte-identical to the pre-attention render.
  */
 export function renderFrontier(goals: Goal[]): string {
   if (goals.length === 0) {
     return "_No active frontier goals._\n";
   }
-  const lines = goals.map(({ node, realization }) => {
-    const base = `- **${node.id}** — ${node.statement} _(owner: ${node.owner} → ${renderRealization(realization)})_`;
-    return node.gap !== null ? `${base} — gap: ${node.gap}` : base;
+  const lines = goals.map(({ node, realization, attention }) => {
+    let line = `- **${node.id}** — ${node.statement} _(owner: ${node.owner} → ${renderRealization(realization)})_`;
+    if (attention !== null && attention.band !== "middle") {
+      line +=
+        attention.sources.length > 0
+          ? ` [${attention.band} via ${attention.sources[0]}]`
+          : ` [${attention.band}]`;
+    }
+    if (node.gap !== null) line += ` — gap: ${node.gap}`;
+    return line;
   });
   return `${lines.join("\n")}\n`;
 }

--- a/packages/intentionsutil/src/index.ts
+++ b/packages/intentionsutil/src/index.ts
@@ -7,7 +7,16 @@ export type {
   Clarification,
   ToolingGoal,
   ToolingKind,
+  Attention,
 } from "./schema.js";
+export {
+  resolveAttention,
+  PROVENANCE_DISCOUNT,
+  SUBORDINATION_DAMP,
+  BAND_HIGH,
+  BAND_LOW,
+} from "./attention.js";
+export type { ResolvedAttention, AttentionBand } from "./attention.js";
 export { IntentionSchemaError, ghErrorText } from "./errors.js";
 export { writeNode, readNode, listNodes } from "./store.js";
 export { writeTracker, readTracker, listTrackers, nodeIdToIssue, issueToNodeId } from "./tracker.js";

--- a/packages/intentionsutil/src/schema.ts
+++ b/packages/intentionsutil/src/schema.ts
@@ -39,6 +39,20 @@ export interface ToolingGoal {
   statement: string;
 }
 
+/**
+ * A user-authored attention injection: a weight plus the rationale for why
+ * this node draws (or defers) attention now. Valid only on goal-layer kinds
+ * (those whose kind node sets `attributes.goal_layer: true`) — enforced by
+ * `validateGraph`, not here. The resolved flow this seeds is derived on read
+ * by `resolveAttention` and is NEVER stored in frontmatter.
+ */
+export interface Attention {
+  weight: number; // finite, >= 0; any scale — only ratios matter
+  rationale: string;
+  subordinate_to: string[]; // node ids whose claims outrank this one
+  review_trigger: string | null; // required when weight === 0 (explicit deferral)
+}
+
 // --- Node ------------------------------------------------------------------
 
 /**
@@ -74,6 +88,7 @@ export interface IntentionNode {
   clarifications: Clarification[];
   tooling_goals: ToolingGoal[];
   success_signal: SuccessSignal | null;
+  attention: Attention | null;
   attributes: Record<string, unknown>; // kind-specific fields; semantics defined by the kind-<kind> node
 }
 
@@ -98,6 +113,7 @@ export interface IntentionNodeInput {
   clarifications?: Clarification[];
   tooling_goals?: ToolingGoal[];
   success_signal?: SuccessSignal | null;
+  attention?: Attention | null;
   attributes?: Record<string, unknown>;
 }
 
@@ -202,6 +218,37 @@ function validateToolingGoals(value: unknown, field: string): ToolingGoal[] {
   });
 }
 
+function validateAttention(value: unknown, field: string): Attention {
+  if (!isPlainObject(value)) {
+    throw new IntentionSchemaError(`Expected object for ${field}, got ${typeof value}`);
+  }
+  if (typeof value.weight !== "number" || !Number.isFinite(value.weight)) {
+    throw new IntentionSchemaError(`Expected finite number for ${field}.weight`);
+  }
+  if (value.weight < 0) {
+    throw new IntentionSchemaError(`${field}.weight must be >= 0, got ${value.weight}`);
+  }
+  const rationale = requireString(value.rationale, `${field}.rationale`);
+  if (rationale === "") {
+    throw new IntentionSchemaError(`${field}.rationale must be a non-empty string`);
+  }
+  const review_trigger = optionalString(value.review_trigger, `${field}.review_trigger`);
+  // Weight 0 is the explicit-deferral form; a deferral without a re-open
+  // condition is the old undefined "deferred for a cycle".
+  if (value.weight === 0 && review_trigger === null) {
+    throw new IntentionSchemaError(`${field}.review_trigger is required when ${field}.weight is 0`);
+  }
+  return {
+    weight: value.weight,
+    rationale,
+    subordinate_to:
+      value.subordinate_to == null
+        ? []
+        : validateIdArray(value.subordinate_to, `${field}.subordinate_to`),
+    review_trigger,
+  };
+}
+
 // --- Validator -------------------------------------------------------------
 
 /**
@@ -257,6 +304,8 @@ export function validateNode(value: unknown): IntentionNode {
       value.success_signal == null
         ? null
         : validateSuccessSignal(value.success_signal, "success_signal"),
+    attention:
+      value.attention == null ? null : validateAttention(value.attention, "attention"),
     attributes:
       value.attributes == null
         ? {}
@@ -276,12 +325,18 @@ export function validateNode(value: unknown): IntentionNode {
  *   2. Every non-null `parent` resolves to an existing node id.
  *   3. Every `serves` entry resolves to an existing node id.
  *   4. Every `recovers` entry resolves to an existing node id.
+ *   5. Every `attention.subordinate_to` entry resolves to an existing node id.
+ *   6. `attention` appears only on nodes whose kind node sets
+ *      `attributes.goal_layer: true`. The eligible layer is data (the kind
+ *      nodes), not a kind list in this file — virtues stay unranked because
+ *      kind-virtue carries no goal_layer flag, not because code names it.
  *
  * Throws a single IntentionSchemaError listing ALL problems found, so one run
  * surfaces every dangling reference rather than the first.
  */
 export function validateGraph(nodes: IntentionNode[]): void {
-  const ids = new Set(nodes.map((n) => n.id));
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const ids = new Set(byId.keys());
   const problems: string[] = [];
   for (const node of nodes) {
     if (!ids.has(`kind-${node.kind}`)) {
@@ -298,6 +353,21 @@ export function validateGraph(nodes: IntentionNode[]): void {
     for (const target of node.recovers) {
       if (!ids.has(target)) {
         problems.push(`${node.id}: recovers "${target}" does not resolve to a node`);
+      }
+    }
+    if (node.attention !== null) {
+      for (const target of node.attention.subordinate_to) {
+        if (!ids.has(target)) {
+          problems.push(
+            `${node.id}: subordinate_to "${target}" does not resolve to a node`,
+          );
+        }
+      }
+      const kindNode = byId.get(`kind-${node.kind}`);
+      if (kindNode !== undefined && kindNode.attributes.goal_layer !== true) {
+        problems.push(
+          `${node.id}: attention is only valid on goal-layer kinds — kind-${node.kind} does not set attributes.goal_layer`,
+        );
       }
     }
   }

--- a/packages/intentionsutil/test/attention.test.ts
+++ b/packages/intentionsutil/test/attention.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+import type { Attention, IntentionNode } from "../src/schema.js";
+import { IntentionSchemaError } from "../src/errors.js";
+import { resolveAttention } from "../src/attention.js";
+
+/** Build a full IntentionNode fixture, filling required/default fields. */
+function anode(partial: Partial<IntentionNode> & { id: string; kind: string }): IntentionNode {
+  return {
+    id: partial.id,
+    kind: partial.kind,
+    statement: partial.statement ?? `Statement for ${partial.id}`,
+    owner: partial.owner ?? "human",
+    status: partial.status ?? "raw",
+    parent: partial.parent ?? null,
+    serves: partial.serves ?? [],
+    recovers: partial.recovers ?? [],
+    rationale: partial.rationale ?? null,
+    reading: partial.reading ?? null,
+    gap: partial.gap ?? null,
+    clarifications: partial.clarifications ?? [],
+    tooling_goals: partial.tooling_goals ?? [],
+    success_signal: partial.success_signal ?? null,
+    attention: partial.attention ?? null,
+    attributes: partial.attributes ?? {},
+  };
+}
+
+/** Shorthand for a well-formed attention injection with the given weight. */
+function attn(weight: number, extra: Partial<Attention> = {}): Attention {
+  return {
+    weight,
+    rationale: extra.rationale ?? "because",
+    subordinate_to: extra.subordinate_to ?? [],
+    review_trigger: extra.review_trigger ?? (weight === 0 ? "when unblocked" : null),
+  };
+}
+
+/**
+ * The kind nodes every fixture needs. Eligibility is data: kind-strategy and
+ * kind-tactic set `goal_layer: true`, kind-virtue and kind-kind do not. So
+ * strategies and tactics are eligible for a flow entry; virtues and kind nodes
+ * never are.
+ */
+function kinds(): IntentionNode[] {
+  return [
+    anode({ id: "kind-kind", kind: "kind", status: "codified" }),
+    anode({
+      id: "kind-strategy",
+      kind: "kind",
+      status: "codified",
+      attributes: { goal_layer: true },
+    }),
+    anode({
+      id: "kind-tactic",
+      kind: "kind",
+      status: "codified",
+      attributes: { goal_layer: true },
+    }),
+    anode({ id: "kind-virtue", kind: "kind", status: "codified" }),
+  ];
+}
+
+describe("resolveAttention eligibility", () => {
+  it("gives an injected node value > 0 with itself in sources, and no entry to ineligible nodes", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
+      anode({
+        id: "strategy-1",
+        kind: "strategy",
+        serves: ["virtue-root"],
+        attention: attn(5),
+      }),
+    ];
+
+    const result = resolveAttention(nodes);
+
+    // Only the eligible, injected strategy gets an entry.
+    expect(result.size).toBe(1);
+    const s = result.get("strategy-1");
+    expect(s).toBeDefined();
+    expect(s?.value).toBe(5);
+    expect(s?.sources).toEqual(["strategy-1"]);
+
+    // Virtues and kind nodes are ineligible — no entry at all.
+    expect(result.has("virtue-root")).toBe(false);
+    expect(result.has("kind-kind")).toBe(false);
+    expect(result.has("kind-strategy")).toBe(false);
+    expect(result.has("kind-tactic")).toBe(false);
+    expect(result.has("kind-virtue")).toBe(false);
+  });
+});
+
+describe("resolveAttention flow", () => {
+  it("splits a strategy's flow evenly among its children while retaining its own rank", () => {
+    // strategy-parent (weight 6, serves a virtue → provenance 1) has 3 children:
+    // two sub-strategies via `parent` and one tactic via `serves`. Each child
+    // receives 6 / 3 = 2, while the strategy itself retains value 6.
+    const nodes = [
+      ...kinds(),
+      anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
+      anode({
+        id: "strategy-parent",
+        kind: "strategy",
+        serves: ["virtue-root"],
+        attention: attn(6),
+      }),
+      anode({ id: "sub-1", kind: "strategy", parent: "strategy-parent" }),
+      anode({ id: "sub-2", kind: "strategy", parent: "strategy-parent" }),
+      anode({ id: "tactic-1", kind: "tactic", serves: ["strategy-parent"] }),
+    ];
+
+    const result = resolveAttention(nodes);
+
+    expect(result.get("strategy-parent")?.value).toBe(6);
+    expect(result.get("sub-1")?.value).toBe(2);
+    expect(result.get("sub-2")?.value).toBe(2);
+    expect(result.get("tactic-1")?.value).toBe(2);
+    // A child's inherited share carries the parent's source.
+    expect(result.get("sub-1")?.sources).toEqual(["strategy-parent"]);
+  });
+
+  it("discounts an injection whose chain reaches no virtue by PROVENANCE_DISCOUNT (0.5)", () => {
+    const nodes = [
+      ...kinds(),
+      // No serves/parent chain to any virtue → provenance 0.5.
+      anode({ id: "strategy-orphan", kind: "strategy", attention: attn(10) }),
+    ];
+
+    const result = resolveAttention(nodes);
+    expect(result.get("strategy-orphan")?.value).toBe(5); // 10 * 0.5
+  });
+
+  it("damps an injection with a non-empty subordinate_to by SUBORDINATION_DAMP (0.25), stacking with the provenance discount", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
+      // Reaches a virtue (provenance 1) but is subordinate → 8 * 1 * 0.25 = 2.
+      anode({
+        id: "strategy-sub",
+        kind: "strategy",
+        serves: ["virtue-root"],
+        attention: attn(8, { subordinate_to: ["virtue-root"] }),
+      }),
+      // Reaches no virtue AND subordinate → 8 * 0.5 * 0.25 = 1.
+      anode({
+        id: "strategy-both",
+        kind: "strategy",
+        attention: attn(8, { subordinate_to: ["virtue-root"] }),
+      }),
+    ];
+
+    const result = resolveAttention(nodes);
+    expect(result.get("strategy-sub")?.value).toBe(2);
+    expect(result.get("strategy-both")?.value).toBe(1);
+  });
+});
+
+describe("resolveAttention banding", () => {
+  it("bands a weight-0 (explicitly deferred) node as bottom when another node carries a positive injection", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
+      anode({
+        id: "strategy-active",
+        kind: "strategy",
+        serves: ["virtue-root"],
+        attention: attn(5),
+      }),
+      anode({
+        id: "strategy-deferred",
+        kind: "strategy",
+        serves: ["virtue-root"],
+        attention: attn(0),
+      }),
+    ];
+
+    const result = resolveAttention(nodes);
+    const deferred = result.get("strategy-deferred");
+    expect(deferred?.value).toBe(0);
+    expect(deferred?.band).toBe("bottom");
+  });
+
+  it("bands every eligible node middle with value 0 when there are no injections anywhere", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "strategy-a", kind: "strategy" }),
+      anode({ id: "strategy-b", kind: "strategy" }),
+    ];
+
+    const result = resolveAttention(nodes);
+    for (const id of ["strategy-a", "strategy-b"]) {
+      expect(result.get(id)?.value).toBe(0);
+      expect(result.get(id)?.band).toBe("middle");
+    }
+  });
+
+  it("assigns top / middle / bottom by the mean-of-nonzero-flows thresholds", () => {
+    // Five independent strategies serving the same virtue (each retains its own
+    // injection; the virtue carries zero flow). Flows {20, 2, 1, 1, 1} have
+    // mean 5, so BAND_HIGH*mean = 20 and BAND_LOW*mean = 1.25:
+    //   20 >= 20        → top
+    //   1.25 < 2 < 20   → middle
+    //   1 <= 1.25       → bottom
+    const nodes = [
+      ...kinds(),
+      anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
+      anode({ id: "s-top", kind: "strategy", serves: ["virtue-root"], attention: attn(20) }),
+      anode({ id: "s-mid", kind: "strategy", serves: ["virtue-root"], attention: attn(2) }),
+      anode({ id: "s-bot-1", kind: "strategy", serves: ["virtue-root"], attention: attn(1) }),
+      anode({ id: "s-bot-2", kind: "strategy", serves: ["virtue-root"], attention: attn(1) }),
+      anode({ id: "s-bot-3", kind: "strategy", serves: ["virtue-root"], attention: attn(1) }),
+    ];
+
+    const result = resolveAttention(nodes);
+    expect(result.get("s-top")?.value).toBe(20);
+    expect(result.get("s-top")?.band).toBe("top");
+    expect(result.get("s-mid")?.value).toBe(2);
+    expect(result.get("s-mid")?.band).toBe("middle");
+    expect(result.get("s-bot-1")?.value).toBe(1);
+    expect(result.get("s-bot-1")?.band).toBe("bottom");
+  });
+});
+
+describe("resolveAttention cycle guard", () => {
+  it("throws IntentionSchemaError on a parent-edge cycle", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "cyc-a", kind: "strategy", parent: "cyc-b" }),
+      anode({ id: "cyc-b", kind: "strategy", parent: "cyc-a" }),
+    ];
+
+    expect(() => resolveAttention(nodes)).toThrow(IntentionSchemaError);
+    expect(() => resolveAttention(nodes)).toThrow(/attention flow cycle/);
+  });
+});
+
+describe("resolveAttention determinism", () => {
+  it("returns deep-equal maps for the same input and a shuffled copy", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
+      anode({
+        id: "strategy-parent",
+        kind: "strategy",
+        serves: ["virtue-root"],
+        attention: attn(6),
+      }),
+      anode({ id: "sub-1", kind: "strategy", parent: "strategy-parent" }),
+      anode({ id: "sub-2", kind: "strategy", parent: "strategy-parent" }),
+      anode({ id: "tactic-1", kind: "tactic", serves: ["strategy-parent"] }),
+    ];
+    const shuffled = [...nodes].reverse();
+
+    const a = Object.fromEntries(resolveAttention(nodes));
+    const b = Object.fromEntries(resolveAttention([...nodes]));
+    const c = Object.fromEntries(resolveAttention(shuffled));
+
+    expect(b).toEqual(a);
+    expect(c).toEqual(a);
+  });
+});

--- a/packages/intentionsutil/test/committed-store.test.ts
+++ b/packages/intentionsutil/test/committed-store.test.ts
@@ -1,0 +1,29 @@
+// Every future intentions/ graph edit is CI-checked through this test
+// (run-unit-tests.sh → npx vitest run --project packages/intentionsutil).
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "vitest";
+import { resolveAttention } from "../src/attention.js";
+import { validateGraph } from "../src/schema.js";
+import { listNodes } from "../src/store.js";
+
+// The test file lives at packages/intentionsutil/test/, so repo root is three
+// dirname() calls up from this file's own location — same pattern as
+// packages/intentionsutil/scripts/frontier-view.ts.
+const testDir = dirname(fileURLToPath(import.meta.url));
+const intentionsDir = join(dirname(dirname(dirname(testDir))), "intentions");
+
+// Skip cleanly when the directory is absent: the package test suite must stay
+// self-contained when run outside the repo (e.g. in an isolated npm pack or
+// a stripped CI cache that does not include the intentions/ store).
+describe.skipIf(!existsSync(intentionsDir))("committed intentions/ store", () => {
+  it("whole-graph integrity: validateGraph does not throw", () => {
+    validateGraph(listNodes(intentionsDir));
+  });
+
+  it("attention resolution: resolveAttention does not throw", () => {
+    resolveAttention(listNodes(intentionsDir));
+  });
+});

--- a/packages/intentionsutil/test/goals.test.ts
+++ b/packages/intentionsutil/test/goals.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { IntentionNode, Owner } from "../src/schema.js";
+import type { Goal } from "../src/goals.js";
 import {
   activeFrontier,
   projectGoals,
@@ -24,6 +25,7 @@ function node(partial: Partial<IntentionNode> & { id: string }): IntentionNode {
     clarifications: partial.clarifications ?? [],
     tooling_goals: partial.tooling_goals ?? [],
     success_signal: partial.success_signal ?? null,
+    attention: partial.attention ?? null,
     attributes: partial.attributes ?? {},
   };
 }
@@ -118,6 +120,112 @@ describe("projectGoals", () => {
     const byId = Object.fromEntries(goals.map((g) => [g.node.id, g.realization]));
     expect(byId.p).toBe("script-and-tests");
     expect(byId.h).toBe("issue-or-pr");
+  });
+});
+
+describe("projectGoals attention ordering", () => {
+  // Goal-layer kind nodes (codified, childless → excluded from the frontier)
+  // whose `attributes.goal_layer: true` makes strategy/tactic nodes eligible.
+  const kindStrategy = node({
+    id: "kind-strategy",
+    kind: "kind",
+    status: "codified",
+    attributes: { goal_layer: true },
+  });
+  const kindTactic = node({
+    id: "kind-tactic",
+    kind: "kind",
+    status: "codified",
+    attributes: { goal_layer: true },
+  });
+  const kindKind = node({ id: "kind-kind", kind: "kind", status: "codified" });
+
+  it("floats an injected strategy's frontier leaf above gap/id-favored siblings", () => {
+    // The injected strategy is a non-leaf (its child names it as parent), so it
+    // is not on the frontier itself — its flow inherits down to the leaf tactic.
+    const strategy = node({
+      id: "strategy-s",
+      kind: "strategy",
+      status: "raw",
+      attention: { weight: 10, rationale: "urgent", subordinate_to: [], review_trigger: null },
+    });
+    // The frontier leaf that inherits the strategy's flow. Highest id, no gap —
+    // so gap/id keys alone would rank it LAST.
+    const injected = node({ id: "z-inject-tactic", kind: "tactic", status: "raw", parent: "strategy-s" });
+    // Competing frontier leaves the pre-attention keys would rank first.
+    const gapA = node({ id: "a-tactic", kind: "tactic", status: "raw", gap: "g" });
+    const gapB = node({ id: "b-tactic", kind: "tactic", status: "raw", gap: "g" });
+
+    const goals = projectGoals([gapA, gapB, injected, strategy, kindStrategy, kindTactic, kindKind]);
+    expect(goals.map((g) => g.node.id)).toEqual(["z-inject-tactic", "a-tactic", "b-tactic"]);
+  });
+
+  it("sets Goal.attention null for non-eligible nodes and populated for eligible ones", () => {
+    const kindNote = node({ id: "kind-note", kind: "kind", status: "codified" });
+    const eligible = node({
+      id: "t-eligible",
+      kind: "tactic",
+      status: "raw",
+      attention: { weight: 10, rationale: "r", subordinate_to: [], review_trigger: null },
+    });
+    // kind "note" has no goal_layer flag → not eligible → no resolver entry.
+    const ineligible = node({ id: "n-note", kind: "note", status: "raw" });
+
+    const goals = projectGoals([kindTactic, kindKind, kindNote, eligible, ineligible]);
+    const byId = Object.fromEntries(goals.map((g) => [g.node.id, g.attention]));
+    expect(byId["t-eligible"]).not.toBeNull();
+    expect(byId["t-eligible"]?.value).toBeGreaterThan(0);
+    expect(byId["n-note"]).toBeNull();
+  });
+});
+
+describe("renderFrontier attention markers", () => {
+  it("emits `[top via <id>]` for a top-band goal and no marker for a middle goal", () => {
+    // Drive renderFrontier from Goal literals directly: it reads only `band`
+    // and `sources[0]`, so this decouples the marker assertion from the
+    // resolver's scale-invariant banding math.
+    const goals: Goal[] = [
+      {
+        node: node({ id: "top-goal", status: "raw" }),
+        realization: "issue-or-pr",
+        attention: { value: 20, band: "top", sources: ["strategy-x"] },
+      },
+      {
+        node: node({ id: "mid-goal", status: "raw" }),
+        realization: "issue-or-pr",
+        attention: { value: 1, band: "middle", sources: ["strategy-y"] },
+      },
+    ];
+    expect(renderFrontier(goals)).toBe(
+      "- **top-goal** — Statement for top-goal _(owner: human → issue/PR)_ [top via strategy-x]\n" +
+        "- **mid-goal** — Statement for mid-goal _(owner: human → issue/PR)_\n",
+    );
+  });
+
+  it("emits a bare `[bottom]` marker when sources is empty", () => {
+    const goals: Goal[] = [
+      {
+        node: node({ id: "b-goal", status: "raw" }),
+        realization: "issue-or-pr",
+        attention: { value: 0, band: "bottom", sources: [] },
+      },
+    ];
+    expect(renderFrontier(goals)).toBe(
+      "- **b-goal** — Statement for b-goal _(owner: human → issue/PR)_ [bottom]\n",
+    );
+  });
+
+  it("is byte-identical to the pre-attention format when no node carries an injection", () => {
+    // No kind nodes → nothing eligible → every Goal.attention is null → no
+    // markers. The exact expected string is the pre-change render.
+    const goals = projectGoals([
+      node({ id: "z", status: "raw", gap: "missing tooling" }),
+      node({ id: "a", status: "raw" }),
+    ]);
+    expect(renderFrontier(goals)).toBe(
+      "- **z** — Statement for z _(owner: human → issue/PR)_ — gap: missing tooling\n" +
+        "- **a** — Statement for a _(owner: human → issue/PR)_\n",
+    );
   });
 });
 

--- a/packages/intentionsutil/test/rungs.test.ts
+++ b/packages/intentionsutil/test/rungs.test.ts
@@ -19,6 +19,7 @@ function node(partial: Partial<IntentionNode> & { id: string }): IntentionNode {
     clarifications: partial.clarifications ?? [],
     tooling_goals: partial.tooling_goals ?? [],
     success_signal: partial.success_signal ?? null,
+    attention: partial.attention ?? null,
     attributes: partial.attributes ?? {},
   };
 }

--- a/packages/intentionsutil/test/schema.test.ts
+++ b/packages/intentionsutil/test/schema.test.ts
@@ -24,6 +24,12 @@ describe("validateNode", () => {
         threshold: "th",
         is_proxy: true,
       },
+      attention: {
+        weight: 2,
+        rationale: "Draws attention now.",
+        subordinate_to: ["p"],
+        review_trigger: "Revisit next cycle.",
+      },
       attributes: { source: "github:natb1/commons.systems#1" },
     };
     expect(validateNode(input)).toEqual(input);
@@ -52,6 +58,7 @@ describe("validateNode", () => {
       clarifications: [],
       tooling_goals: [],
       success_signal: null,
+      attention: null,
       attributes: {},
     });
   });
@@ -124,6 +131,58 @@ describe("validateNode", () => {
       }),
     ).toThrow();
   });
+
+  it("rejects an attention with a negative weight", () => {
+    expect(() =>
+      validateNode({
+        id: "n8",
+        kind: "strategy",
+        statement: "Negative weight.",
+        owner: "human",
+        status: "raw",
+        attention: { weight: -1, rationale: "r" },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an attention missing a rationale", () => {
+    expect(() =>
+      validateNode({
+        id: "n9",
+        kind: "strategy",
+        statement: "No rationale.",
+        owner: "human",
+        status: "raw",
+        attention: { weight: 1 },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an attention with weight 0 and no review_trigger", () => {
+    expect(() =>
+      validateNode({
+        id: "n10",
+        kind: "strategy",
+        statement: "Deferral without a re-open condition.",
+        owner: "human",
+        status: "raw",
+        attention: { weight: 0, rationale: "r" },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an attention with a non-array subordinate_to", () => {
+    expect(() =>
+      validateNode({
+        id: "n11",
+        kind: "strategy",
+        statement: "Bad subordinate_to.",
+        owner: "human",
+        status: "raw",
+        attention: { weight: 1, rationale: "r", subordinate_to: "not-an-array" },
+      }),
+    ).toThrow();
+  });
 });
 
 describe("validateGraph", () => {
@@ -144,6 +203,7 @@ describe("validateGraph", () => {
       clarifications: partial.clarifications ?? [],
       tooling_goals: partial.tooling_goals ?? [],
       success_signal: partial.success_signal ?? null,
+      attention: partial.attention ?? null,
       attributes: partial.attributes ?? {},
     };
   }
@@ -154,7 +214,12 @@ describe("validateGraph", () => {
       gnode({ id: "kind-kind", kind: "kind", status: "codified" }),
       gnode({ id: "kind-virtue", kind: "kind", status: "codified" }),
       gnode({ id: "kind-tactic", kind: "kind", status: "codified" }),
-      gnode({ id: "kind-strategy", kind: "kind", status: "codified" }),
+      gnode({
+        id: "kind-strategy",
+        kind: "kind",
+        status: "codified",
+        attributes: { goal_layer: true },
+      }),
       gnode({ id: "kind-delegation", kind: "kind", status: "codified" }),
       gnode({ id: "virtue-root", kind: "virtue", status: "codified", parent: null }),
       gnode({ id: "delegation-1", kind: "delegation" }),
@@ -163,6 +228,12 @@ describe("validateGraph", () => {
         kind: "strategy",
         serves: ["virtue-root"],
         recovers: ["delegation-1"],
+        attention: {
+          weight: 3,
+          rationale: "A live strategy that draws attention.",
+          subordinate_to: [],
+          review_trigger: null,
+        },
       }),
       gnode({
         id: "tactic-1",
@@ -215,15 +286,73 @@ describe("validateGraph", () => {
     );
   });
 
-  it("lists ALL violations in one throw (kind + parent + serves + recovers)", () => {
+  it("throws when an attention.subordinate_to does not resolve to a node", () => {
     const nodes = [
       gnode({ id: "kind-kind", kind: "kind", status: "codified" }),
+      gnode({
+        id: "kind-strategy",
+        kind: "kind",
+        status: "codified",
+        attributes: { goal_layer: true },
+      }),
+      gnode({
+        id: "strategy-1",
+        kind: "strategy",
+        attention: {
+          weight: 1,
+          rationale: "r",
+          subordinate_to: ["no-such-node"],
+          review_trigger: null,
+        },
+      }),
+    ];
+    expect(() => validateGraph(nodes)).toThrow(
+      /subordinate_to "no-such-node" does not resolve to a node/,
+    );
+  });
+
+  it("throws when attention is on a node whose kind lacks goal_layer", () => {
+    const nodes = [
+      gnode({ id: "kind-kind", kind: "kind", status: "codified" }),
+      // kind-virtue is present but carries no goal_layer flag, so virtues are
+      // not a goal-layer kind and may not carry attention.
+      gnode({ id: "kind-virtue", kind: "kind", status: "codified" }),
+      gnode({
+        id: "virtue-1",
+        kind: "virtue",
+        attention: {
+          weight: 1,
+          rationale: "r",
+          subordinate_to: [],
+          review_trigger: null,
+        },
+      }),
+    ];
+    expect(() => validateGraph(nodes)).toThrow(/attention is only valid on goal-layer kinds/);
+  });
+
+  it("lists ALL violations in one throw (kind + parent + serves + recovers + attention)", () => {
+    const nodes = [
+      gnode({ id: "kind-kind", kind: "kind", status: "codified" }),
+      // kind-virtue present without goal_layer, so attention on a virtue is a
+      // goal-layer violation.
+      gnode({ id: "kind-virtue", kind: "kind", status: "codified" }),
       gnode({
         id: "broken-1",
         kind: "ghost",
         parent: "no-such-parent",
         serves: ["no-such-target"],
         recovers: ["no-such-delegation"],
+      }),
+      gnode({
+        id: "broken-2",
+        kind: "virtue",
+        attention: {
+          weight: 1,
+          rationale: "r",
+          subordinate_to: ["no-such-node"],
+          review_trigger: null,
+        },
       }),
     ];
     let caught: unknown;
@@ -238,5 +367,7 @@ describe("validateGraph", () => {
     expect(caught.message).toContain('parent "no-such-parent" does not resolve to a node');
     expect(caught.message).toContain('serves "no-such-target" does not resolve to a node');
     expect(caught.message).toContain('recovers "no-such-delegation" does not resolve to a node');
+    expect(caught.message).toContain('subordinate_to "no-such-node" does not resolve to a node');
+    expect(caught.message).toContain("attention is only valid on goal-layer kinds");
   });
 });

--- a/packages/intentionsutil/test/sensors.test.ts
+++ b/packages/intentionsutil/test/sensors.test.ts
@@ -29,6 +29,7 @@ function node(partial: Partial<IntentionNode> & { id: string }): IntentionNode {
     clarifications: partial.clarifications ?? [],
     tooling_goals: partial.tooling_goals ?? [],
     success_signal: partial.success_signal ?? null,
+    attention: partial.attention ?? null,
     attributes: partial.attributes ?? {},
   };
 }

--- a/packages/intentionsutil/test/store.test.ts
+++ b/packages/intentionsutil/test/store.test.ts
@@ -35,6 +35,12 @@ describe("store round-trip", () => {
         threshold: "0 orphans",
         is_proxy: false,
       },
+      attention: {
+        weight: 4,
+        rationale: "This root draws attention this cycle.",
+        subordinate_to: ["charter"],
+        review_trigger: "Revisit when the charter changes.",
+      },
       attributes: { source: "github:natb1/commons.systems#1", weight: 3 },
     };
 
@@ -77,6 +83,7 @@ describe("store round-trip", () => {
         threshold: "0 diff",
         is_proxy: false,
       },
+      attention: null,
       attributes: {},
     };
 
@@ -112,6 +119,7 @@ describe("store round-trip", () => {
       clarifications: [],
       tooling_goals: [],
       success_signal: null,
+      attention: null,
       attributes: {},
     });
   });


### PR DESCRIPTION
## Summary

First of two PRs implementing the attention model for the intention graph (2026-07-02 design session). This PR is intentionsutil-only; a second PR based on this branch adds the skill-text projection and the graph node edits.

- **Authored layer (stored in git, sparse):** new optional `attention` field on intention nodes — a weight plus required rationale, optional `subordinate_to` damping edges, and a `review_trigger` required for explicit deferrals (weight 0). Valid only on goal-layer kinds, enforced data-driven: the kind node must set `attributes.goal_layer: true` (no kinds hardcoded).
- **Derived layer (computed on read, never stored):** `resolveAttention` propagates injections down `parent`/`serves` edges as conserved flow, applies a provenance discount when no virtue is reachable and a subordination damp, and cuts results into scale-invariant `top`/`middle`/`bottom` bands. Constants are named exports documented as judgment constants. Two signal terms only in v1.
- **Frontier ordering:** `projectGoals` sorts by resolved attention first, existing comparator as tie-break; `renderFrontier` marks non-middle bands with the top contributing source. Frontier-view output verified byte-identical while no injections exist (none do yet — `goal_layer` lands in PR 2).
- **CI gate for the committed store:** new `committed-store.test.ts` runs `validateGraph` + `resolveAttention` over the real `intentions/` directory — previously nothing in CI validated it.

## Verification

- `npx vitest run --project packages/intentionsutil --root .` — 147/147 across 12 files (attention resolver: 9 tests — split, provenance, damping, banding, cycle guard, determinism).
- `tsc -p packages/intentionsutil --noEmit` clean.
- `frontier-view.ts` output byte-identical to the pre-change committed baseline (114 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)