### PR TITLE
intentions + skills: emit-time band projection, goal-layer wiring

### DIFF
--- a/.claude/skills/intention-emit/SKILL.md
+++ b/.claude/skills/intention-emit/SKILL.md
@@ -50,8 +50,10 @@ Paths used below:
 Every step below that calls `gh`, `npx`, or otherwise touches the network must
 run with `dangerouslyDisableSandbox: true`. `gh` fails TLS verification under the
 sandbox, and `npx tsx` may need to fetch packages; both require the live network.
-See `.claude/rules/sandbox.md`. Steps 1 and 3 (node read, sentinel parse) are
-purely local and do not need it.
+See `.claude/rules/sandbox.md`. Every `npx tsx` invocation below (step 1's node
+read and band gate, step 5's refresh.ts) needs `dangerouslyDisableSandbox: true`
+even when it does no network work, because the sandbox blocks tsx's IPC pipe.
+Only the step 3 sentinel parse — pure shell — does not.
 
 ---
 
@@ -60,7 +62,8 @@ purely local and do not need it.
 Read the node and decide whether the issue already exists.
 
 ```bash
-# Local, no network. Resolve N = the mapped issue number, or null.
+# dangerouslyDisableSandbox: true — tsx's IPC pipe is blocked by the sandbox.
+# Resolve N = the mapped issue number, or null.
 npx tsx -e '
   import { readNode } from "./intentionsutil/src/store.js";
   import { nodeIdToIssue } from "./intentionsutil/src/tracker.js";
@@ -83,6 +86,31 @@ Decision rule:
 - Otherwise → **emit path**: continue to steps 2–3 to create the issue. Read
   the node with `readNode(intentionsDir, <id>)` to obtain `statement`,
   `rationale`, `reading`, and `parent` for the steps below.
+
+### Band gate (emit path only)
+
+On the emit path, resolve the node's attention band before creating anything.
+The band is derived on read and never stored, so resolve it fresh over the whole
+graph with `resolveAttention`:
+
+```bash
+# dangerouslyDisableSandbox: true — tsx's IPC pipe is blocked by the sandbox.
+npx tsx -e '
+  import { listNodes } from "./intentionsutil/src/store.js";
+  import { resolveAttention } from "./intentionsutil/src/attention.js";
+  const id = process.argv[1];
+  const band = resolveAttention(listNodes("intentions")).get(id)?.band;
+  console.log(band ?? "none");
+' "<id>"
+```
+
+If the band is `bottom` → **STOP**: do not emit. Report to the user `node is
+bottom-band (deferred); raise its attention or clear its subordination to emit`
+and exit the skill. Any other result (`top`, `middle`, or `none` — an ineligible
+node with no entry) → continue. Carry the resolved band forward to step 5.
+
+The link path (step 1 took the shortcut) skips this gate: the issue is already
+emitted, so the band check gates only fresh emission.
 
 ---
 
@@ -216,13 +244,17 @@ non-`tactic-N` node — the number must be persisted so a later
 `nodeIdToIssue(<id>, trackersDir)` resolves it.
 
 ```bash
-# dangerouslyDisableSandbox: true (both touch GitHub)
+# dangerouslyDisableSandbox: true (all three touch GitHub)
 # 1. Discoverable mapping comment on the issue (Unit 3 script; <N> first).
 .claude/skills/dispatch-propagate/scripts/intention-stamp-node <N> <id>
 
 # 2. Create/refresh trackers/<id>.json with issue_number = N and current
 #    execution state (Unit 4 read-only refresh script).
 npx tsx intentionsutil/scripts/refresh.ts <id>
+
+# 3. If step 1 resolved the band as `top`, project the priority label. Skip
+#    otherwise (middle/none, or the link path where no band was resolved).
+gh issue edit <N> --add-label priority
 ```
 
 After this, `trackers/<id>.json` exists with `issue_number = N`, and the issue
@@ -238,11 +270,11 @@ running step 5 there is safe and keeps the tracker current.
 
 | Step | Kind | What runs it |
 |---|---|---|
-| 1. Resolve emit-or-link | **script** | `readNode` + `nodeIdToIssue` (local) |
+| 1. Resolve emit-or-link + band gate | **script** | `readNode` + `nodeIdToIssue` + `resolveAttention` (local) |
 | 2. Create the issue | **agent / Skill** | forked subagent → `/file-issue` |
 | 3. Parse sentinel block | **script** (orchestrator) | string parse of the subagent message |
 | 4. Relationships | **script** | `gh api` (network) |
-| 5. Stamp + tracker | **script** | `intention-stamp-node` + `refresh.ts` (network) |
+| 5. Stamp + tracker + top-band priority label | **script** | `intention-stamp-node` + `refresh.ts` + `gh issue edit` (network) |
 
 Only step 2 is an agent/Skill step. Everything else is pure script.
 

--- a/.claude/skills/ref-issue-labels/SKILL.md
+++ b/.claude/skills/ref-issue-labels/SKILL.md
@@ -147,10 +147,14 @@ alongside a topic label.
   Keyword signals: "audio", "audio app".
 
 - **`priority`** — a separate axis from the topic labels above. A
-  human-applied escalation marker that routes the issue (or any PR closing it)
-  ahead of non-priority items across all topic categories in `/dispatch-propagate` queue selection. Apply only
-  when a human explicitly asks to escalate; `/file-issue` never applies it
-  automatically. May be combined with any topic label.
+  human-sourced escalation marker that routes the issue (or any PR closing it)
+  ahead of non-priority items across all topic categories in `/dispatch-propagate` queue selection. It has two
+  legitimate sources, both human: a human explicitly asking to escalate, and the
+  intention graph's resolved `top` band, which `intention-emit` projects onto the
+  issue at emit time. The graph source stays human-sourced — the human act is
+  authoring the node's `attention` injection in git, which `resolveAttention`
+  derives the band from. `/file-issue` never applies it automatically. May be
+  combined with any topic label.
 
 - **Neither** — apply no topic label when nothing matches. There is no
   "other" sentinel label.

--- a/intentions/kind-kind.md
+++ b/intentions/kind-kind.md
@@ -52,6 +52,7 @@ attributes:
     - "serves: cross-layer edge — ids of the nodes this node expresses"
     - "recovers: strategy→delegation edge — ids of the delegation records this node's work unwinds"
     - "rationale: why this node exists"
+    - "attention: authored attention injection (weight, rationale, subordinate_to, review_trigger); valid only on nodes whose kind sets goal_layer: true; resolved flow and band are derived on read and never stored"
     - "attributes: kind-specific fields, defined by the kind node"
   entry_point: this node is the entry point of the graph
 ---

--- a/intentions/kind-strategy.md
+++ b/intentions/kind-strategy.md
@@ -43,8 +43,10 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attributes:
+  goal_layer: true
   fields:
     - "conditions: list of world-premises that make this strategy apt; each is a standing review trigger"
+    - "attention: authored weight (>= 0), required rationale, optional subordinate_to ids that damp the injection, and review_trigger (required when weight is 0 as a deferral re-open condition); resolved flow and band are computed on read by resolveAttention and never stored in frontmatter"
   edges:
     - "recovers: ids of the delegation records this strategy's work unwinds (top-level field, resolved by validateGraph)"
 ---

--- a/intentions/kind-tactic.md
+++ b/intentions/kind-tactic.md
@@ -33,7 +33,9 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attributes:
+  goal_layer: true
   fields:
     - "source: sync source for generated tactics, e.g. github:natb1/commons.systems#2711; absent on hand-authored tactics"
+    - "attention: authored weight (>= 0), required rationale, optional subordinate_to ids that damp the injection, and review_trigger (required when weight is 0 as a deferral re-open condition); resolved flow and band are computed on read by resolveAttention and never stored in frontmatter"
 ---
 # Tactic — a completable unit of execution

--- a/intentions/kind-virtue.md
+++ b/intentions/kind-virtue.md
@@ -20,6 +20,8 @@ rationale: >-
   (`attributes.tension_with`): they are balanced, not summed, and maximizing
   one against its partner is failure, not progress. Whatever consumes this
   graph must never total virtue children into a parent completion score.
+  Virtues never carry attention injections and are never conduits for flow;
+  the resolver reads provenance off the `serves` chain as a fact.
 
 
   A virtue applied to present conditions generates strategies (kind-strategy);

--- a/intentions/strategy-commons-income.md
+++ b/intentions/strategy-commons-income.md
@@ -1,0 +1,59 @@
+---
+id: strategy-commons-income
+kind: strategy
+statement: Commons-derived income — the artifacts may earn, on gift terms only
+owner: human
+status: raw
+parent: null
+rationale: >-
+  Minted 2026-07-02 from the owner interview as a sibling of
+  strategy-diversify-income: income derived from the commons artifacts
+  themselves — paid hosting, support, productized versions — is a viable lane
+  of the diversified pipeline, distinct from client work because its
+  conditions differ: it depends on non-author users whose demand supports
+  paying for convenience, and on monetization shapes that never gate the
+  capability.
+
+
+  Deliberately low priority, and the reasons are the interesting part. First,
+  it sits in tension with intentions that outrank it: monetizing the
+  artifacts pulls against strategy-open-source-as-gift (an offering optimizes
+  for the user's dependency; a gift transfers capability — paying may buy
+  speed, hosting, or guidance, never the capability itself), and
+  strategy-financial-sustainability already fixes the funding shape this must
+  fit (reversible, no payroll, degrade by inaction). Second, income appears
+  in this graph at all only because institutional capture makes it necessary
+  — it serves recovery, never growth, so an income lane can never outrank the
+  recovery work it exists to fund. This subordination is recorded here as
+  prose; when the attention/priority schema lands it becomes structured
+  (subordinate to strategy-diversify-income, constrained by
+  strategy-open-source-as-gift), so it is re-derived — not defended — when
+  the dominating claims change.
+reading: null
+gap: null
+serves:
+  - virtue-alignment-of-attachments
+  - virtue-respect-for-persons
+recovers:
+  - delegation-client-income
+clarifications: []
+tooling_goals: []
+success_signal:
+  observable: commons-derived revenue appearing as an independent income source,
+    with every paid tier passing the gift test — nothing a non-paying user
+    loses except convenience
+  sensor: the owned budgeting pipeline (strategy-recover-finance) for the
+    revenue share; gift-integrity review at office-hours for the terms
+  threshold: any recurring commons-derived income exists while no artifact's
+    capability is gated behind payment
+  is_proxy: true
+attributes:
+  conditions:
+    - commons artifacts have non-author users whose demand supports paid
+      hosting, support, or productized tiers
+    - monetization can be shaped so paying buys convenience or speed, never
+      the capability — the gift stays whole
+    - strategy-diversify-income's client pipeline remains the primary income
+      lane; this lane supplements, it does not replace
+---
+# Commons-derived income — the artifacts may earn, on gift terms only

--- a/intentions/strategy-exercise-voice.md
+++ b/intentions/strategy-exercise-voice.md
@@ -14,9 +14,20 @@ rationale: >-
   management move first-class: voice — vendor feedback, upstream
   contributions, standards participation — pressure that pulls a delegatee's
   alignment toward held virtues instead of leaving. Voice earns the most
-  exactly where exit costs the most: the concentrated delegations
-  (delegation-github, delegation-anthropic-claude) whose recovery is priciest
-  are where a maintained feedback channel is the affordable alignment move.
+  exactly where exit costs the most, and that set is defined mechanically
+  from the ledger, not by intuition: a delegation is HIGH-COST-OF-EXIT when
+  its record shows `irreversibility.gated` other than false, or a
+  `recovery_cost` not bounded in days (weeks-plus, unbounded, or unassessed —
+  unknown exit cost is treated as high until assessed). New records qualify
+  automatically as they enter the ledger. Under this predicate today the set
+  is delegation-anthropic-claude (unbounded cost), delegation-mobile-platform,
+  delegation-identity-root, delegation-banking, delegation-communications,
+  delegation-attention-services, delegation-health-records,
+  delegation-knowledge-notes, delegation-media-libraries, and
+  delegation-client-income (unassessed). Notably delegation-github drops out —
+  its record reads days-bounded and un-gated — so a voice channel there is
+  permitted, not required; if that feels wrong, the fix is re-assessing the
+  record, never widening this set by hand.
 
 
   The guard is the virtue itself: voice must not invert into advocacy.
@@ -30,14 +41,22 @@ gap: null
 serves:
   - virtue-alignment-of-attachments
 recovers: []
-clarifications: []
+clarifications:
+  - question: Which delegations count as high-cost-of-exit — the threshold
+      quantifies over that set but only two records were named in prose?
+    answer: "The set is mechanical from ledger fields, never a hand-kept list:
+      a record qualifies when irreversibility.gated is not false, or its
+      recovery_cost is not bounded in days (weeks-plus, unbounded, or
+      unassessed). Disagreement with the predicate's output is resolved by
+      re-assessing the record (clarified 2026-07-02)."
 tooling_goals: []
 success_signal:
   observable: voice actions (feedback filed, upstream contributions, standards
     participation) recorded against delegation records at portfolio review
   sensor: owner review at office-hours over the delegation records
-  threshold: each high-cost-of-exit delegation shows a live voice channel,
-    exercised within its review window
+  threshold: each high-cost-of-exit delegation (mechanical set — gated recovery
+    or cost not bounded in days, unassessed included) shows a live voice
+    channel, exercised within its review window
   is_proxy: true
 attributes:
   conditions:

--- a/intentions/strategy-graph-drives-dispatch.md
+++ b/intentions/strategy-graph-drives-dispatch.md
@@ -26,8 +26,17 @@ serves:
   - virtue-philosophical-mobility
   - virtue-progressive-detachment
 recovers: []
-clarifications: []
-tooling_goals: []
+clarifications:
+  - question: Where do attention injections live, and what does the router consume?
+    answer: Authored attention injections live in git (frontmatter); flow is derived
+      on read by resolveAttention, never stored; the dispatch router consumes bands
+      (top / middle / bottom), not floats; v1 has two signal terms only (injection
+      and provenance). Recorded 2026-07-02.
+tooling_goals:
+  - kind: actuator
+    statement: resolveAttention + emit-time band projection
+  - kind: sensor
+    statement: frontier-view renders the resolved ranking
 success_signal:
   observable: the fraction of open dispatch work traceable to a serving node, and
     readings populated by the loop rather than by hand


### PR DESCRIPTION
## Summary

Second half of the attention model, following the intentionsutil resolver merged in PR #2728. Replaces PR #2729, which GitHub closed when its stacked base branch was deleted at #2728's merge; the branch is now rebased onto main.

- **intention-emit band gate:** Step 1's emit path resolves the node's band via `resolveAttention` before creating anything. Bottom band → stop, do not emit ("deferred; raise its attention or clear its subordination to emit"). Step 5 projects the `priority` label (`gh issue edit <N> --add-label priority`) when the band is top. The link path (already-emitted nodes) skips the gate; `/file-issue` Step 6 stays graph-unaware.
- **ref-issue-labels:** the `priority` entry now names both legitimate sources — an explicit human escalation ask, and the graph's resolved top band projected at emit time. Both are human-sourced: the human act is authoring the attention injection in git. The untrusted-body injection guard is unchanged.
- **Goal-layer wiring (self-describing):** `kind-strategy` and `kind-tactic` set `attributes.goal_layer: true`, activating attention eligibility, with field docs for the authored injection. `kind-virtue` records that virtues never carry or conduct attention. `kind-kind` adds `attention` to `fields_defined_for_all_nodes`. `strategy-graph-drives-dispatch` gains tooling_goals (resolver actuator, frontier-view sensor) and a clarification recording the 2026-07-02 design decision.
- **2026-07-02 interview nodes (previously uncommitted working-tree state):** `strategy-exercise-voice` now derives its high-cost-of-exit set mechanically from ledger fields; new `strategy-commons-income` node (gift-terms income lane, deliberately subordinate).

No node carries an injection yet, so all goal-layer nodes resolve to middle band: nothing gets the priority label, nothing is suppressed, and frontier output is unchanged.

## Verification

- `npx vitest run --project packages/intentionsutil --root .` — 147/147; the committed-store test validates the goal_layer YAML and both interview nodes against the real graph.
- `frontier-view.ts` output unchanged: 114 lines, no band markers.
- SKILL.md edits dry-read against the plan: band gate on emit path only, top-band label in Step 5, summary table and sandbox notes updated for coherence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)