### PR TITLE
planning: add interactive-planning rule for clean-session-executable, model-routed plans

### DIFF
--- a/.claude/rules/planning.md
+++ b/.claude/rules/planning.md
@@ -14,7 +14,10 @@ Required sections match the `/plan-issue` plan-comment schema
 (`.claude/skills/plan-issue/SKILL.md`, "Plan-comment output schema", lines 500–527):
 
 - **Context** — why the change is being made (problem, need, intended outcome).
-- **Scope** per unit — what files/behavior change, with `path:line` anchors.
+- **Scope** per unit — what files/behavior change, what is explicitly out of
+  scope, with `path:line` anchors.
+- **Dependencies** — prior units that must complete first (omit if none), so
+  execution order is explicit in the plan text.
 - **Reuse** — existing functions/utilities to reuse, with their file paths.
 - **Verification** — how to test the change end-to-end. Auto-runnable checks
   (test suites, typechecks, builds) go in fenced ` ```verify ` blocks; manual

--- a/.claude/rules/planning.md
+++ b/.claude/rules/planning.md
@@ -1,0 +1,43 @@
+# Interactive Planning
+
+This rule applies when a session uses the built-in interactive planning tool
+(`EnterPlanMode` → `ExitPlanMode`). It governs the plan that tool produces.
+It is advisory guidance the model follows on entering interactive planning —
+not hook-enforced — so no hook alternative is proposed.
+
+## Produce clean-session-executable plans
+
+The plan must be self-contained: a fresh session with no memory of the planning
+session must be able to execute it from the plan text alone.
+
+Required sections match the `/plan-issue` plan-comment schema
+(`.claude/skills/plan-issue/SKILL.md`, "Plan-comment output schema", lines 500–527):
+
+- **Context** — why the change is being made (problem, need, intended outcome).
+- **Scope** per unit — what files/behavior change, with `path:line` anchors.
+- **Reuse** — existing functions/utilities to reuse, with their file paths.
+- **Verification** — how to test the change end-to-end. Auto-runnable checks
+  (test suites, typechecks, builds) go in fenced ` ```verify ` blocks; manual
+  steps, judgment calls, and observe-in-production checks stay as prose.
+
+Do not rely on context loaded during the planning session (open files, prior
+search results, skill bodies). Every fact the implementer needs must appear in
+the plan text.
+
+## Tag each unit with a model and delegate implementation to a subagent
+
+Each logical unit of the plan must carry a **Recommended model** (`sonnet` or
+`opus`), chosen per the model-selection heuristic — whose single canonical home
+is `.claude/skills/implement-unit/SKILL.md` ("Model-selection heuristic",
+lines 31–39; canonical home declared at lines 17–18). Do not restate the
+heuristic bullets here.
+
+The plan must also include explicit instructions to implement each unit in a
+subagent launched with the unit's selected model. Mechanism: spawn a subagent
+via the Agent or Task tool with `model` set to the unit's chosen value
+(`model: sonnet` or `model: opus`). Supply the unit's `context` and `scope`
+to the subagent prompt; constrain it to working-tree edits only.
+
+Do not mandate `/implement-unit` or any `dispatch-*` script — those commit,
+merge, and push, which is dispatch-specific behavior outside the scope of
+interactive sessions.


### PR DESCRIPTION
Closes #2731

## Summary

Adds `.claude/rules/planning.md` so that interactive planning sessions (built-in
`EnterPlanMode` → `ExitPlanMode`) emit plans matching the two disciplines that
`/plan-issue` already enforces on the autonomous dispatch path but the built-in
plan tool does not:

1. **Clean-session-executable plans** — the plan must be self-contained (Context,
   per-unit Scope with `path:line` anchors, Reuse notes, Verification), so it
   executes in a fresh session with no reliance on the planning session's loaded
   state.
2. **Per-unit model routing + subagent delegation** — each unit carries a
   Recommended model (`sonnet`/`opus`), and the plan instructs the implementer to
   build each unit in a subagent launched with that model.

## Design

`.claude/rules/*.md` is auto-loaded into every session unconditionally (there is
no `CLAUDE.md`/`AGENTS.md` — see `README.md:9`), so the new file is picked up
with no registration step. Because rules load unconditionally with no hook gating
on `EnterPlanMode`, the rule self-scopes in its own prose: it is advisory
guidance the model follows on entering interactive planning, not a hook-enforced
gate.

The rule targets **interactive human** planning sessions. `/plan-issue` owns the
autonomous dispatch path and deliberately avoids interactive plan mode, so the
rule references the generic subagent mechanism (Agent/Task tool with a `model`
override) and does **not** mandate dispatch-specific machinery (`/implement-unit`,
`dispatch-*` scripts). Both disciplines reference their canonical homes —
the plan-comment schema at `.claude/skills/plan-issue/SKILL.md` and the
model-selection heuristic at `.claude/skills/implement-unit/SKILL.md` — rather
than restating them divergently.

## Verification

The deliverable is a single markdown rules file. No test suite, typecheck, or
build validates a `.claude/rules/*.md` file, and the repo's prose linter is
scoped to committed shell scripts only, so there is no CI-safe automated check to
place in a ` ```verify ` block. Verified by inspection against the five
acceptance criteria: the file exists and self-scopes; it requires a
clean-session-executable plan (Context / `path:line` Scope / Reuse /
Verification); it requires a per-unit Recommended model referenced from the
`/implement-unit` heuristic; it requires subagent-per-unit delegation with a
`model` override without mandating dispatch scripts; and it follows
`ref-write-instructions` conventions and sibling-rule house style.
