### PR TITLE
intentionsutil: attention v2 — additive source-set ranks, banding removed

### DIFF
--- a/.claude/docs/signal-identification.md
+++ b/.claude/docs/signal-identification.md
@@ -158,8 +158,8 @@ step.
 1. **Re-prioritize by gap.** Trigger: the frontier is projected. Reads: each frontier
    node's `gap`. Output: gap-present nodes ordered ahead of gap-absent ones. Already
    realized by `intentionsutil/src/goals.ts::projectGoals`, whose primary sort key is now
-   resolved attention (the derived attention flow, descending) with gap-present
-   (`gap !== null`) first as the tie-break within equal attention. Reference it as done.
+   derived attention rank (descending) with gap-present
+   (`gap !== null`) first as the tie-break within equal rank. Reference it as done.
 
 2. **Falsify proxy goals.** Trigger: an `is_proxy` signal's reading contradicts the
    underlying intention (the proxy reads "met" while the real intention plainly is not,

--- a/packages/intentionsutil/SCHEMA.md
+++ b/packages/intentionsutil/SCHEMA.md
@@ -69,7 +69,7 @@ authoritative data.
 | `clarifications` | `Clarification[]`     | no       | Q&A pairs resolved during the dialectic. Defaults to `[]`. |
 | `tooling_goals`  | `ToolingGoal[]`       | no       | Tooling the node aims to produce or change. Defaults to `[]`. |
 | `success_signal` | `SuccessSignal \| null` | no     | A measurable signal the intention is met. Defaults to `null`. |
-| `attention`      | `Attention \| null`   | no       | A user-authored attention injection (weight + rationale). Valid only on goal-layer kinds, enforced by `validateGraph`. The resolved flow it seeds is derived on read by `resolveAttention` and never stored. Defaults to `null`. |
+| `attention`      | `Attention \| null`   | no       | A user-authored attention injection (a `boost` XOR an `override`, plus a rationale). Valid only on goal-layer kinds, enforced by `validateGraph`. The rank it seeds is derived on read by `resolveAttention` and never stored. Defaults to `null`. |
 | `attributes`     | `Record<string, unknown>` | no   | Kind-specific fields (e.g. a delegation's divergence/irreversibility assessment). Validated as a plain object; the meaning of its entries is defined by the node's kind node. Defaults to `{}`. |
 
 ### `SuccessSignal`
@@ -97,15 +97,18 @@ authoritative data.
 
 ### `Attention`
 
-A user-authored injection that seeds the derived attention flow. Valid only on
-goal-layer kinds (see Graph-level validation).
+A user-authored injection that seeds the derived rank. Exactly one of `boost` /
+`override` is set (the authored YAML supplies one key; the other resolves to
+`null`). Valid only on goal-layer kinds (see Graph-level validation).
 
-| Name             | Type              | Meaning |
-| ---------------- | ----------------- | ------- |
-| `weight`         | `number`          | The injected weight. Must be finite and `>= 0`; any scale — only ratios matter. |
-| `rationale`      | `string`          | Why this node draws (or defers) attention now. Must be non-empty. |
-| `subordinate_to` | `string[]`        | `id`s of nodes whose claims outrank this one. While non-empty, the injection is damped. Defaults to `[]`. |
-| `review_trigger` | `string \| null`  | The condition that re-opens an explicit deferral. **Required when `weight` is 0** (deferral without a re-open condition is rejected); otherwise `null`. |
+| Name         | Type              | Meaning |
+| ------------ | ----------------- | ------- |
+| `boost`      | `number \| null`  | A RELATIVE claim: adds `(self, boost)` to this node's outgoing source set, surviving upstream re-weighting. Must be finite and `> 0` (a zero boost is meaningless — use `override: 0` to explicitly zero a branch). `null` when `override` is set. |
+| `override`   | `number \| null`  | An ABSOLUTE cap: replaces this node's outgoing set with `{(self, override)}`, capping its own branch only (a descendant's other parents still contribute). Must be finite and `>= 0`. `null` when `boost` is set. |
+| `rationale`  | `string`          | Why this node draws (or defers) attention now. Must be non-empty. |
+
+Setting both `boost` and `override`, or neither, is rejected by
+`validateAttention`.
 
 ## Enums
 
@@ -151,12 +154,10 @@ nodes as invalid.
 `validateGraph(nodes)` checks referential integrity across a whole node set:
 every node's `kind` has its defining `kind-<kind>` node present, and every
 non-null `parent` and every `serves` and `recovers` entry resolves to an
-existing node id. It also checks the `attention` edges: every
-`attention.subordinate_to` entry resolves to an existing node id, and
-`attention` appears only on nodes whose kind node sets
-`attributes.goal_layer: true`. The eligible layer is data (the kind nodes), not
-a kind list in this file — virtues stay unranked because `kind-virtue` carries
-no `goal_layer` flag, not because code names it. It
+existing node id. It also checks that `attention` appears only on nodes whose
+kind node sets `attributes.goal_layer: true`. The eligible layer is data (the
+kind nodes), not a kind list in this file — virtues stay unranked because
+`kind-virtue` carries no `goal_layer` flag, not because code names it. It
 throws one error listing all violations. Backfill runs it over the full store
 after regenerating the tactic leaves.
 
@@ -175,14 +176,19 @@ by design — only the frontmatter is authoritative.
 
 ## Derived attention is never stored
 
-The `attention` field is a user-authored *injection* — only the weight,
-rationale, and edges the author writes. The resolved flow and band that
-`resolveAttention` computes from it are derived on read and NEVER enter
-frontmatter. This contrasts with `gap`, which `deriveGap` computes from
-same-file inputs (`reading` vs `success_signal.threshold`): storing `gap` is
-safe because it is a local function of one node's own fields. Attention is a
-*global* function of the whole graph — a node's flow depends on every other
-node's injections and edges — so storing it would go stale on any edit
-elsewhere in the graph. It is recomputed from the authoritative injections each
-time it is read, the same intent/derivation discipline as `intentions/`
-(authored intent) vs `trackers/` (derived execution state).
+The `attention` field is a user-authored *injection* — only the `boost` or
+`override` and its rationale the author writes. The resolved rank that
+`resolveAttention` computes from it is derived on read and NEVER enters
+frontmatter. `resolveAttention` accumulates, per node, a set of
+`(source-node, amount)` pairs flowing DOWN `parent` + `serves` edges — undecayed
+and undiluted, each authored source counted once per node — and a node's rank is
+the sum of its own set (a `boost` adds `(self, boost)`; an `override` replaces
+the set with `{(self, override)}`, capping its branch). This contrasts with
+`gap`, which `deriveGap` computes from same-file inputs (`reading` vs
+`success_signal.threshold`): storing `gap` is safe because it is a local function
+of one node's own fields. Attention is a *global* function of the whole graph —
+a node's rank depends on every ancestor's injections and edges — so storing it
+would go stale on any edit elsewhere in the graph. It is recomputed from the
+authoritative injections each time it is read, the same intent/derivation
+discipline as `intentions/` (authored intent) vs `trackers/` (derived execution
+state).

--- a/packages/intentionsutil/scripts/rank-map.ts
+++ b/packages/intentionsutil/scripts/rank-map.ts
@@ -1,0 +1,50 @@
+// Resolved-rank map of the intention graph to stdout, keyed by issue number.
+//
+// Reads the local `intentions/` store, runs `resolveAttention`, and prints a
+// single JSON object mapping GitHub issue numbers to their NONZERO derived
+// ranks. The dispatch router consumes this to order the queue directly from the
+// tree (the priority label is retired). Missing keys default to rank 0 in the
+// consumer, so zero ranks are omitted here.
+//
+// Issue-number resolution per resolved node id:
+//   - `tactic-<N>`         → key <N>            (the emitted-leaf convention);
+//   - any other node id    → `nodeIdToIssue(id, trackers/)` when it resolves
+//                            (a hand-authored node with a recorded tracker).
+// `nodeIdToIssue` handles both cases, so it is the single lookup.
+//
+// Run from anywhere (paths resolve relative to this file, not cwd):
+//   npx tsx packages/intentionsutil/scripts/rank-map.ts
+//
+// Errors are loud (clear-errors rule): a missing intentions/ dir or any
+// validation/resolution failure exits non-zero — there is no empty-map fallback.
+
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { listNodes } from "../src/store.js";
+import { resolveAttention } from "../src/attention.js";
+import { nodeIdToIssue } from "../src/tracker.js";
+
+// --- Paths -----------------------------------------------------------------
+// The script lives at `packages/intentionsutil/scripts/rank-map.ts`, so the
+// repo root is three directories up. Resolve from this file's own location.
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(dirname(dirname(scriptDir)));
+const intentionsDir = join(repoRoot, "intentions");
+const trackersDir = join(repoRoot, "trackers");
+
+// --- Main ------------------------------------------------------------------
+
+function main(): void {
+  const resolved = resolveAttention(listNodes(intentionsDir));
+  const rankByIssue: Record<number, number> = {};
+  for (const [nodeId, { value }] of resolved) {
+    if (value === 0) continue;
+    const issue = nodeIdToIssue(nodeId, trackersDir);
+    if (issue !== null) rankByIssue[issue] = value;
+  }
+  process.stdout.write(JSON.stringify(rankByIssue) + "\n");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/packages/intentionsutil/src/attention.ts
+++ b/packages/intentionsutil/src/attention.ts
@@ -1,53 +1,16 @@
 import { IntentionSchemaError } from "./errors.js";
 import type { IntentionNode } from "./schema.js";
 
-// --- Judgment constants ------------------------------------------------------
-// All four are JUDGMENT CONSTANTS reviewed at office-hours, not fitted
-// parameters. The resolver deliberately has only two signal terms (injection
-// and provenance) — every added weight is a free parameter someone will one
-// day defend.
-
-/**
- * Multiplier on an injection whose node cannot trace a `serves`/`parent` chain
- * to any virtue. Own-virtue-justified work outranks work justified only by
- * delegatee-grafted constraints.
- */
-export const PROVENANCE_DISCOUNT = 0.5;
-
-/**
- * Multiplier on an injection whose node declares `subordinate_to`. Applied
- * unconditionally while the edge exists — removing the edge is the human
- * review act that lifts the damping.
- */
-export const SUBORDINATION_DAMP = 0.25;
-
-/**
- * A node is `top` band when its flow is at least this multiple of the mean
- * nonzero flow across eligible nodes.
- */
-export const BAND_HIGH = 4;
-
-/**
- * A node is `bottom` band when its flow is at most this fraction of the mean
- * nonzero flow across eligible nodes (or exactly zero while any injection
- * exists anywhere).
- */
-export const BAND_LOW = 0.25;
-
 // --- Types -------------------------------------------------------------------
 
-export type AttentionBand = "top" | "middle" | "bottom";
-
-/** The derived attention of one eligible node. Computed on read, NEVER stored. */
+/** The derived attention (rank) of one eligible node. Computed on read, NEVER stored. */
 export interface ResolvedAttention {
-  /** The node's retained flow — its rank value. Scale-free; only ratios matter. */
+  /** The node's rank — the sum of its own outgoing source set's amounts. */
   value: number;
-  /** Coarse cut of `value` consumed by routers; floats never leave this module's callers. */
-  band: AttentionBand;
   /**
-   * Ids of the nodes whose authored injections contributed to this flow,
-   * ordered by contribution (largest first, id ascending on ties) — for
-   * explainability ("via strategy-x").
+   * Ids of the source nodes whose authored boosts/overrides contribute to this
+   * node's rank, ordered by contribution (largest first, id ascending on ties)
+   * — for explainability ("via strategy-x").
    */
   sources: string[];
 }
@@ -55,28 +18,47 @@ export interface ResolvedAttention {
 // --- Resolver ------------------------------------------------------------------
 
 /**
- * Resolve derived attention for every goal-layer node in the graph.
+ * Resolve derived attention (rank) for every goal-layer node in the graph.
  *
- * Pure and deterministic: same nodes in, deep-equal map out. Derived values
- * are never written back to node frontmatter — same discipline as `trackers/`
+ * Pure and deterministic: same nodes in, deep-equal map out. Derived values are
+ * never written back to node frontmatter — same discipline as `trackers/`
  * (execution state) vs `intentions/` (intent).
  *
- * Algorithm (two signal terms only):
+ * v2 model — additive source sets, undecayed and undiluted. See the
+ * clarifications on `intentions/strategy-graph-drives-dispatch.md` for the
+ * decision record (supersedes the same-day v1 conserved-flow / banded design
+ * after the 2026-07-02 scenario interview).
+ *
+ * Each node accumulates an OUTGOING source set: a `Map<sourceId, amount>`. Rank
+ * flows DOWN `parent` + `serves` edges without decay or dilution — a child
+ * inherits an ancestor's full claim regardless of depth or sibling count ("hot
+ * means hot"). Each authored source counts once per node (set union dedupes by
+ * source id, so diamonds don't double-count; genuinely serving two strategies
+ * adds both).
+ *
+ * Algorithm (memoized DFS per node):
  *   1. Eligible set — nodes whose kind node sets `attributes.goal_layer: true`.
- *      All other nodes get no entry.
- *   2. Injection — `attention.weight`, multiplied by the provenance factor
- *      (1 when the `serves` ∪ `parent` chain reaches a virtue, else
- *      PROVENANCE_DISCOUNT) and by SUBORDINATION_DAMP when `subordinate_to`
- *      is non-empty.
- *   3. Flow — conserved distribution: a node's flow is its damped injection
- *      plus its inherited share; a node with children passes its full flow
- *      divided evenly among them (sub-nodes via `parent`, plus eligible nodes
- *      that name it in `serves`) while retaining the flow value as its own
- *      rank. A `parent`/`serves` cycle is surfaced as an IntentionSchemaError
- *      listing the cycle path.
- *   4. Banding — scale-invariant against the mean of nonzero flows. When no
- *      injections exist anywhere, every eligible node is `middle` (the
- *      pre-attention status quo: nothing escalated, nothing suppressed).
+ *      All other nodes get no result entry (but can still pass a source through,
+ *      e.g. a virtue root relaying nothing).
+ *   2. Incoming — the union (by source id) over the node's distributors of each
+ *      distributor's outgoing set. A distributor is the node's `parent` (if it
+ *      resolves) plus, for eligible nodes, each `serves` target that resolves.
+ *      Amounts for the same source id are identical by construction (undiluted),
+ *      so the union is a plain overwrite.
+ *   3. Outgoing —
+ *        - `attention.override` present → `{(self, override)}` (incoming
+ *          discarded; the override CAPS this branch — a descendant reachable
+ *          only through this node reads the capped value, but a descendant's
+ *          OTHER parents still contribute their own claims);
+ *        - else `attention.boost` present → incoming ∪ `{(self, boost)}`;
+ *        - else → incoming.
+ *   4. rank(node) = sum of the node's OWN outgoing set's amounts (for an
+ *      override node, exactly the override value).
+ *   5. Cycle guard — a `parent`/`serves` cycle surfaces as an
+ *      IntentionSchemaError listing the cycle path.
+ *
+ * Rank 0 is the neutral baseline: with no injections anywhere every eligible
+ * node resolves to value 0 with no sources.
  */
 export function resolveAttention(nodes: IntentionNode[]): Map<string, ResolvedAttention> {
   const byId = new Map(nodes.map((n) => [n.id, n]));
@@ -86,51 +68,8 @@ export function resolveAttention(nodes: IntentionNode[]): Map<string, ResolvedAt
     return kindNode !== undefined && kindNode.attributes.goal_layer === true;
   };
 
-  // Provenance: walk `serves` ∪ `parent` transitively upward looking for a
-  // virtue. Memoized per node; a visited set guards against revisits (and
-  // makes the walk total even on a cyclic graph — the cycle error below is
-  // the authoritative guard).
-  const reachesVirtue = (start: IntentionNode): boolean => {
-    const visited = new Set<string>();
-    const stack = [start];
-    while (stack.length > 0) {
-      const n = stack.pop();
-      if (n === undefined || visited.has(n.id)) continue;
-      visited.add(n.id);
-      if (n.kind === "virtue") return true;
-      const next = n.parent === null ? [...n.serves] : [...n.serves, n.parent];
-      for (const id of next) {
-        const target = byId.get(id);
-        if (target !== undefined) stack.push(target);
-      }
-    }
-    return false;
-  };
-
-  // Damped injection per eligible node.
-  const injection = (n: IntentionNode): number => {
-    if (!isEligible(n) || n.attention === null) return 0;
-    const provenance = reachesVirtue(n) ? 1 : PROVENANCE_DISCOUNT;
-    const damp = n.attention.subordinate_to.length > 0 ? SUBORDINATION_DAMP : 1;
-    return n.attention.weight * provenance * damp;
-  };
-
-  // Distribution edges. children(s) = { nodes with parent === s.id } ∪
-  // { eligible nodes with s.id ∈ serves }; a child's distributors are the
-  // reverse view of the same definition.
-  const childCount = new Map<string, number>();
-  for (const c of nodes) {
-    const drawsFrom = new Set<string>();
-    if (c.parent !== null && byId.has(c.parent)) drawsFrom.add(c.parent);
-    if (isEligible(c)) {
-      for (const s of c.serves) {
-        if (byId.has(s)) drawsFrom.add(s);
-      }
-    }
-    for (const p of drawsFrom) {
-      childCount.set(p, (childCount.get(p) ?? 0) + 1);
-    }
-  }
+  // Distribution edges. distributors(c) = { c.parent } ∪ (eligible c only)
+  // { c.serves }, each restricted to ids that resolve. Sorted for determinism.
   const distributors = (c: IntentionNode): IntentionNode[] => {
     const ids = new Set<string>();
     if (c.parent !== null && byId.has(c.parent)) ids.add(c.parent);
@@ -142,74 +81,62 @@ export function resolveAttention(nodes: IntentionNode[]): Map<string, ResolvedAt
     return [...ids].sort().map((id) => byId.get(id) as IntentionNode);
   };
 
-  // Flow + per-source contributions, memoized DFS with cycle detection.
-  const flows = new Map<string, number>();
-  const contributions = new Map<string, Map<string, number>>();
+  // Outgoing source set per node, memoized DFS with cycle detection.
+  const outgoing = new Map<string, Map<string, number>>();
   const onStack = new Set<string>();
   const stackPath: string[] = [];
 
-  const resolveFlow = (n: IntentionNode): number => {
-    const memo = flows.get(n.id);
+  const compute = (n: IntentionNode): Map<string, number> => {
+    const memo = outgoing.get(n.id);
     if (memo !== undefined) return memo;
     if (onStack.has(n.id)) {
       const cycle = [...stackPath.slice(stackPath.indexOf(n.id)), n.id];
-      throw new IntentionSchemaError(
-        `attention flow cycle: ${cycle.join(" -> ")}`,
-      );
+      throw new IntentionSchemaError(`attention flow cycle: ${cycle.join(" -> ")}`);
     }
     onStack.add(n.id);
     stackPath.push(n.id);
 
-    const inj = injection(n);
-    const contrib = new Map<string, number>();
-    if (inj > 0) contrib.set(n.id, inj);
-    let flow = inj;
-    for (const p of distributors(n)) {
-      const share = resolveFlow(p) / (childCount.get(p.id) as number);
-      flow += share;
-      const parentFlow = flows.get(p.id) as number;
-      if (parentFlow > 0) {
-        const scale = 1 / (childCount.get(p.id) as number);
-        for (const [src, amt] of contributions.get(p.id) as Map<string, number>) {
-          contrib.set(src, (contrib.get(src) ?? 0) + amt * scale);
-        }
+    // Union incoming from all distributors. We ALWAYS walk distributors — even
+    // for an override node whose incoming is discarded — so the cycle guard
+    // sees every edge (traverse-and-discard).
+    const incoming = new Map<string, number>();
+    for (const d of distributors(n)) {
+      for (const [src, amt] of compute(d)) {
+        incoming.set(src, amt); // dedupe by src; amounts identical (undiluted)
       }
+    }
+
+    const attention = isEligible(n) ? n.attention : null;
+    let out: Map<string, number>;
+    if (attention !== null && attention.override !== null) {
+      out = new Map([[n.id, attention.override]]); // cap: incoming discarded
+    } else {
+      if (attention !== null && attention.boost !== null) {
+        incoming.set(n.id, attention.boost); // relative claim added
+      }
+      out = incoming;
     }
 
     onStack.delete(n.id);
     stackPath.pop();
-    flows.set(n.id, flow);
-    contributions.set(n.id, contrib);
-    return flow;
+    outgoing.set(n.id, out);
+    return out;
   };
 
   // Iterate in id order for a deterministic result regardless of input order.
   const sorted = [...nodes].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
   const eligible = sorted.filter(isEligible);
-  for (const n of eligible) resolveFlow(n);
-
-  // Banding, scale-invariant: mean of nonzero eligible flows.
-  const nonzero = eligible
-    .map((n) => flows.get(n.id) as number)
-    .filter((f) => f > 0);
-  const mean = nonzero.length > 0 ? nonzero.reduce((a, b) => a + b, 0) / nonzero.length : 0;
-
-  const band = (flow: number): AttentionBand => {
-    // No injections anywhere → the pre-attention status quo: all middle.
-    if (mean === 0) return "middle";
-    if (flow === 0 || flow <= mean * BAND_LOW) return "bottom";
-    if (flow >= mean * BAND_HIGH) return "top";
-    return "middle";
-  };
+  for (const n of eligible) compute(n);
 
   const result = new Map<string, ResolvedAttention>();
   for (const n of eligible) {
-    const flow = flows.get(n.id) as number;
-    const contrib = contributions.get(n.id) as Map<string, number>;
-    const sources = [...contrib.entries()]
+    const out = compute(n);
+    let value = 0;
+    for (const amt of out.values()) value += amt;
+    const sources = [...out.entries()]
       .sort((a, b) => (a[1] !== b[1] ? b[1] - a[1] : a[0] < b[0] ? -1 : 1))
       .map(([src]) => src);
-    result.set(n.id, { value: flow, band: band(flow), sources });
+    result.set(n.id, { value, sources });
   }
   return result;
 }

--- a/packages/intentionsutil/src/goals.ts
+++ b/packages/intentionsutil/src/goals.ts
@@ -104,16 +104,25 @@ function renderRealization(realization: Realization): string {
 }
 
 /**
+ * Format a rank value with up to 2 decimal places, trailing zeros trimmed.
+ * Examples: 20 → "20", 1.5 → "1.5", 0.25 → "0.25".
+ */
+function formatRank(value: number): string {
+  return parseFloat(value.toFixed(2)).toString();
+}
+
+/**
  * Render the projected goals as deterministic markdown, one line per goal in
  * `projectGoals` order. The output is byte-stable across repeated calls with
  * the same input: no dates, no wall-clock, no environment data. Ends with a
  * trailing newline.
  *
- * Each non-`middle` band gets a marker appended after the `_(owner: … → …)_`
- * segment and before the gap suffix: ` [<band> via <sources[0]>]` naming the
- * top contributing source, or ` [<band>]` when `sources` is empty. `middle`
- * (and no-attention) goals render unmarked, so a store with no injection
- * anywhere is byte-identical to the pre-attention render.
+ * Goals with `value > 0` get a rank marker appended after the
+ * `_(owner: … → …)_` segment and before the gap suffix:
+ * ` [rank <value> via <sources[0]>]` naming the top contributing source, or
+ * ` [rank <value>]` when `sources` is empty. Value 0 / null renders unmarked,
+ * so a store with no injection anywhere is byte-identical to the pre-attention
+ * render.
  */
 export function renderFrontier(goals: Goal[]): string {
   if (goals.length === 0) {
@@ -121,11 +130,12 @@ export function renderFrontier(goals: Goal[]): string {
   }
   const lines = goals.map(({ node, realization, attention }) => {
     let line = `- **${node.id}** — ${node.statement} _(owner: ${node.owner} → ${renderRealization(realization)})_`;
-    if (attention !== null && attention.band !== "middle") {
+    if (attention !== null && attention.value > 0) {
+      const rank = formatRank(attention.value);
       line +=
         attention.sources.length > 0
-          ? ` [${attention.band} via ${attention.sources[0]}]`
-          : ` [${attention.band}]`;
+          ? ` [rank ${rank} via ${attention.sources[0]}]`
+          : ` [rank ${rank}]`;
     }
     if (node.gap !== null) line += ` — gap: ${node.gap}`;
     return line;

--- a/packages/intentionsutil/src/index.ts
+++ b/packages/intentionsutil/src/index.ts
@@ -9,14 +9,8 @@ export type {
   ToolingKind,
   Attention,
 } from "./schema.js";
-export {
-  resolveAttention,
-  PROVENANCE_DISCOUNT,
-  SUBORDINATION_DAMP,
-  BAND_HIGH,
-  BAND_LOW,
-} from "./attention.js";
-export type { ResolvedAttention, AttentionBand } from "./attention.js";
+export { resolveAttention } from "./attention.js";
+export type { ResolvedAttention } from "./attention.js";
 export { IntentionSchemaError, ghErrorText } from "./errors.js";
 export { writeNode, readNode, listNodes } from "./store.js";
 export { writeTracker, readTracker, listTrackers, nodeIdToIssue, issueToNodeId } from "./tracker.js";

--- a/packages/intentionsutil/src/schema.ts
+++ b/packages/intentionsutil/src/schema.ts
@@ -40,17 +40,25 @@ export interface ToolingGoal {
 }
 
 /**
- * A user-authored attention injection: a weight plus the rationale for why
- * this node draws (or defers) attention now. Valid only on goal-layer kinds
- * (those whose kind node sets `attributes.goal_layer: true`) — enforced by
- * `validateGraph`, not here. The resolved flow this seeds is derived on read
- * by `resolveAttention` and is NEVER stored in frontmatter.
+ * A user-authored attention injection. Exactly one of `boost` / `override` is
+ * non-null (authored YAML supplies one key); the other is `null`.
+ *
+ *  - `boost` adds `(self, boost)` to this node's outgoing source set — a
+ *    RELATIVE claim that survives upstream re-weighting. Must be finite and
+ *    `> 0` (a zero boost is meaningless; use `override: 0` to explicitly zero a
+ *    branch).
+ *  - `override` REPLACES this node's outgoing set with `{(self, override)}` —
+ *    an ABSOLUTE cap on this node's own branch. Must be finite and `>= 0`.
+ *
+ * Valid only on goal-layer kinds (those whose kind node sets
+ * `attributes.goal_layer: true`) — enforced by `validateGraph`, not here. The
+ * rank this seeds is derived on read by `resolveAttention` and is NEVER stored
+ * in frontmatter.
  */
 export interface Attention {
-  weight: number; // finite, >= 0; any scale — only ratios matter
-  rationale: string;
-  subordinate_to: string[]; // node ids whose claims outrank this one
-  review_trigger: string | null; // required when weight === 0 (explicit deferral)
+  boost: number | null; // finite, > 0 when present
+  override: number | null; // finite, >= 0 when present
+  rationale: string; // required, non-empty
 }
 
 // --- Node ------------------------------------------------------------------
@@ -222,31 +230,50 @@ function validateAttention(value: unknown, field: string): Attention {
   if (!isPlainObject(value)) {
     throw new IntentionSchemaError(`Expected object for ${field}, got ${typeof value}`);
   }
-  if (typeof value.weight !== "number" || !Number.isFinite(value.weight)) {
-    throw new IntentionSchemaError(`Expected finite number for ${field}.weight`);
+
+  const hasBoost = value.boost != null;
+  const hasOverride = value.override != null;
+  if (hasBoost && hasOverride) {
+    throw new IntentionSchemaError(
+      `${field} must set exactly one of boost/override, not both`,
+    );
   }
-  if (value.weight < 0) {
-    throw new IntentionSchemaError(`${field}.weight must be >= 0, got ${value.weight}`);
+  if (!hasBoost && !hasOverride) {
+    throw new IntentionSchemaError(
+      `${field} must set exactly one of boost/override, got neither`,
+    );
   }
+
+  let boost: number | null = null;
+  let override: number | null = null;
+  if (hasBoost) {
+    if (typeof value.boost !== "number" || !Number.isFinite(value.boost)) {
+      throw new IntentionSchemaError(`Expected finite number for ${field}.boost`);
+    }
+    if (value.boost <= 0) {
+      throw new IntentionSchemaError(
+        `${field}.boost must be > 0, got ${value.boost} (use override: 0 to explicitly zero a branch)`,
+      );
+    }
+    boost = value.boost;
+  } else {
+    if (typeof value.override !== "number" || !Number.isFinite(value.override)) {
+      throw new IntentionSchemaError(`Expected finite number for ${field}.override`);
+    }
+    if (value.override < 0) {
+      throw new IntentionSchemaError(
+        `${field}.override must be >= 0, got ${value.override}`,
+      );
+    }
+    override = value.override;
+  }
+
   const rationale = requireString(value.rationale, `${field}.rationale`);
   if (rationale === "") {
     throw new IntentionSchemaError(`${field}.rationale must be a non-empty string`);
   }
-  const review_trigger = optionalString(value.review_trigger, `${field}.review_trigger`);
-  // Weight 0 is the explicit-deferral form; a deferral without a re-open
-  // condition is the old undefined "deferred for a cycle".
-  if (value.weight === 0 && review_trigger === null) {
-    throw new IntentionSchemaError(`${field}.review_trigger is required when ${field}.weight is 0`);
-  }
-  return {
-    weight: value.weight,
-    rationale,
-    subordinate_to:
-      value.subordinate_to == null
-        ? []
-        : validateIdArray(value.subordinate_to, `${field}.subordinate_to`),
-    review_trigger,
-  };
+
+  return { boost, override, rationale };
 }
 
 // --- Validator -------------------------------------------------------------
@@ -325,8 +352,7 @@ export function validateNode(value: unknown): IntentionNode {
  *   2. Every non-null `parent` resolves to an existing node id.
  *   3. Every `serves` entry resolves to an existing node id.
  *   4. Every `recovers` entry resolves to an existing node id.
- *   5. Every `attention.subordinate_to` entry resolves to an existing node id.
- *   6. `attention` appears only on nodes whose kind node sets
+ *   5. `attention` appears only on nodes whose kind node sets
  *      `attributes.goal_layer: true`. The eligible layer is data (the kind
  *      nodes), not a kind list in this file — virtues stay unranked because
  *      kind-virtue carries no goal_layer flag, not because code names it.
@@ -356,13 +382,6 @@ export function validateGraph(nodes: IntentionNode[]): void {
       }
     }
     if (node.attention !== null) {
-      for (const target of node.attention.subordinate_to) {
-        if (!ids.has(target)) {
-          problems.push(
-            `${node.id}: subordinate_to "${target}" does not resolve to a node`,
-          );
-        }
-      }
       const kindNode = byId.get(`kind-${node.kind}`);
       if (kindNode !== undefined && kindNode.attributes.goal_layer !== true) {
         problems.push(

--- a/packages/intentionsutil/test/attention.test.ts
+++ b/packages/intentionsutil/test/attention.test.ts
@@ -25,20 +25,20 @@ function anode(partial: Partial<IntentionNode> & { id: string; kind: string }): 
   };
 }
 
-/** Shorthand for a well-formed attention injection with the given weight. */
-function attn(weight: number, extra: Partial<Attention> = {}): Attention {
-  return {
-    weight,
-    rationale: extra.rationale ?? "because",
-    subordinate_to: extra.subordinate_to ?? [],
-    review_trigger: extra.review_trigger ?? (weight === 0 ? "when unblocked" : null),
-  };
+/** A relative boost injection. */
+function boost(amount: number, rationale = "because"): Attention {
+  return { boost: amount, override: null, rationale };
+}
+
+/** An absolute branch-capping override injection. */
+function override(amount: number, rationale = "because"): Attention {
+  return { boost: null, override: amount, rationale };
 }
 
 /**
  * The kind nodes every fixture needs. Eligibility is data: kind-strategy and
  * kind-tactic set `goal_layer: true`, kind-virtue and kind-kind do not. So
- * strategies and tactics are eligible for a flow entry; virtues and kind nodes
+ * strategies and tactics are eligible for a rank entry; virtues and kind nodes
  * never are.
  */
 function kinds(): IntentionNode[] {
@@ -61,24 +61,17 @@ function kinds(): IntentionNode[] {
 }
 
 describe("resolveAttention eligibility", () => {
-  it("gives an injected node value > 0 with itself in sources, and no entry to ineligible nodes", () => {
+  it("ranks a boosted node by its boost with itself in sources; ineligible nodes get no entry", () => {
     const nodes = [
       ...kinds(),
       anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      anode({
-        id: "strategy-1",
-        kind: "strategy",
-        serves: ["virtue-root"],
-        attention: attn(5),
-      }),
+      anode({ id: "strategy-1", kind: "strategy", serves: ["virtue-root"], attention: boost(5) }),
     ];
 
     const result = resolveAttention(nodes);
 
-    // Only the eligible, injected strategy gets an entry.
     expect(result.size).toBe(1);
     const s = result.get("strategy-1");
-    expect(s).toBeDefined();
     expect(s?.value).toBe(5);
     expect(s?.sources).toEqual(["strategy-1"]);
 
@@ -89,136 +82,136 @@ describe("resolveAttention eligibility", () => {
     expect(result.has("kind-tactic")).toBe(false);
     expect(result.has("kind-virtue")).toBe(false);
   });
+
+  it("gives an eligible node with no injection a value-0 entry with empty sources", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "strategy-quiet", kind: "strategy" }),
+    ];
+
+    const result = resolveAttention(nodes);
+    expect(result.get("strategy-quiet")).toEqual({ value: 0, sources: [] });
+  });
 });
 
-describe("resolveAttention flow", () => {
-  it("splits a strategy's flow evenly among its children while retaining its own rank", () => {
-    // strategy-parent (weight 6, serves a virtue → provenance 1) has 3 children:
-    // two sub-strategies via `parent` and one tactic via `serves`. Each child
-    // receives 6 / 3 = 2, while the strategy itself retains value 6.
+describe("resolveAttention boost (undecayed, undiluted)", () => {
+  it("ranks a boosted node and all its descendants at the full boost, at any depth", () => {
+    // strategy-parent boost 6 has three children (two via parent, one via
+    // serves) and one grandchild. None dilutes: every descendant reads 6.
     const nodes = [
       ...kinds(),
       anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      anode({
-        id: "strategy-parent",
-        kind: "strategy",
-        serves: ["virtue-root"],
-        attention: attn(6),
-      }),
+      anode({ id: "strategy-parent", kind: "strategy", serves: ["virtue-root"], attention: boost(6) }),
       anode({ id: "sub-1", kind: "strategy", parent: "strategy-parent" }),
       anode({ id: "sub-2", kind: "strategy", parent: "strategy-parent" }),
       anode({ id: "tactic-1", kind: "tactic", serves: ["strategy-parent"] }),
+      anode({ id: "grand-1", kind: "strategy", parent: "sub-1" }),
     ];
 
     const result = resolveAttention(nodes);
-
-    expect(result.get("strategy-parent")?.value).toBe(6);
-    expect(result.get("sub-1")?.value).toBe(2);
-    expect(result.get("sub-2")?.value).toBe(2);
-    expect(result.get("tactic-1")?.value).toBe(2);
-    // A child's inherited share carries the parent's source.
-    expect(result.get("sub-1")?.sources).toEqual(["strategy-parent"]);
-  });
-
-  it("discounts an injection whose chain reaches no virtue by PROVENANCE_DISCOUNT (0.5)", () => {
-    const nodes = [
-      ...kinds(),
-      // No serves/parent chain to any virtue → provenance 0.5.
-      anode({ id: "strategy-orphan", kind: "strategy", attention: attn(10) }),
-    ];
-
-    const result = resolveAttention(nodes);
-    expect(result.get("strategy-orphan")?.value).toBe(5); // 10 * 0.5
-  });
-
-  it("damps an injection with a non-empty subordinate_to by SUBORDINATION_DAMP (0.25), stacking with the provenance discount", () => {
-    const nodes = [
-      ...kinds(),
-      anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      // Reaches a virtue (provenance 1) but is subordinate → 8 * 1 * 0.25 = 2.
-      anode({
-        id: "strategy-sub",
-        kind: "strategy",
-        serves: ["virtue-root"],
-        attention: attn(8, { subordinate_to: ["virtue-root"] }),
-      }),
-      // Reaches no virtue AND subordinate → 8 * 0.5 * 0.25 = 1.
-      anode({
-        id: "strategy-both",
-        kind: "strategy",
-        attention: attn(8, { subordinate_to: ["virtue-root"] }),
-      }),
-    ];
-
-    const result = resolveAttention(nodes);
-    expect(result.get("strategy-sub")?.value).toBe(2);
-    expect(result.get("strategy-both")?.value).toBe(1);
-  });
-});
-
-describe("resolveAttention banding", () => {
-  it("bands a weight-0 (explicitly deferred) node as bottom when another node carries a positive injection", () => {
-    const nodes = [
-      ...kinds(),
-      anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      anode({
-        id: "strategy-active",
-        kind: "strategy",
-        serves: ["virtue-root"],
-        attention: attn(5),
-      }),
-      anode({
-        id: "strategy-deferred",
-        kind: "strategy",
-        serves: ["virtue-root"],
-        attention: attn(0),
-      }),
-    ];
-
-    const result = resolveAttention(nodes);
-    const deferred = result.get("strategy-deferred");
-    expect(deferred?.value).toBe(0);
-    expect(deferred?.band).toBe("bottom");
-  });
-
-  it("bands every eligible node middle with value 0 when there are no injections anywhere", () => {
-    const nodes = [
-      ...kinds(),
-      anode({ id: "strategy-a", kind: "strategy" }),
-      anode({ id: "strategy-b", kind: "strategy" }),
-    ];
-
-    const result = resolveAttention(nodes);
-    for (const id of ["strategy-a", "strategy-b"]) {
-      expect(result.get(id)?.value).toBe(0);
-      expect(result.get(id)?.band).toBe("middle");
+    for (const id of ["strategy-parent", "sub-1", "sub-2", "tactic-1", "grand-1"]) {
+      expect(result.get(id)?.value).toBe(6);
+      expect(result.get(id)?.sources).toEqual(["strategy-parent"]);
     }
   });
 
-  it("assigns top / middle / bottom by the mean-of-nonzero-flows thresholds", () => {
-    // Five independent strategies serving the same virtue (each retains its own
-    // injection; the virtue carries zero flow). Flows {20, 2, 1, 1, 1} have
-    // mean 5, so BAND_HIGH*mean = 20 and BAND_LOW*mean = 1.25:
-    //   20 >= 20        → top
-    //   1.25 < 2 < 20   → middle
-    //   1 <= 1.25       → bottom
+  it("adds two parents' claims on a shared child", () => {
     const nodes = [
       ...kinds(),
       anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      anode({ id: "s-top", kind: "strategy", serves: ["virtue-root"], attention: attn(20) }),
-      anode({ id: "s-mid", kind: "strategy", serves: ["virtue-root"], attention: attn(2) }),
-      anode({ id: "s-bot-1", kind: "strategy", serves: ["virtue-root"], attention: attn(1) }),
-      anode({ id: "s-bot-2", kind: "strategy", serves: ["virtue-root"], attention: attn(1) }),
-      anode({ id: "s-bot-3", kind: "strategy", serves: ["virtue-root"], attention: attn(1) }),
+      anode({ id: "s1", kind: "strategy", serves: ["virtue-root"], attention: boost(2) }),
+      anode({ id: "s2", kind: "strategy", serves: ["virtue-root"], attention: boost(6) }),
+      // child draws from s1 (parent) and s2 (serves).
+      anode({ id: "child", kind: "strategy", parent: "s1", serves: ["s2"] }),
     ];
 
     const result = resolveAttention(nodes);
-    expect(result.get("s-top")?.value).toBe(20);
-    expect(result.get("s-top")?.band).toBe("top");
-    expect(result.get("s-mid")?.value).toBe(2);
-    expect(result.get("s-mid")?.band).toBe("middle");
-    expect(result.get("s-bot-1")?.value).toBe(1);
-    expect(result.get("s-bot-1")?.band).toBe("bottom");
+    const child = result.get("child");
+    expect(child?.value).toBe(8);
+    expect(child?.sources).toEqual(["s2", "s1"]); // ordered by contribution desc
+  });
+
+  it("counts a source reached via two paths (a diamond) exactly once", () => {
+    // top boost 4 reaches bottom via mid1 (parent chain) AND mid2 (serves
+    // chain). The union dedupes by source id, so bottom reads 4, not 8.
+    const nodes = [
+      ...kinds(),
+      anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
+      anode({ id: "top", kind: "strategy", serves: ["virtue-root"], attention: boost(4) }),
+      anode({ id: "mid1", kind: "strategy", parent: "top" }),
+      anode({ id: "mid2", kind: "strategy", serves: ["top"] }),
+      anode({ id: "bottom", kind: "strategy", parent: "mid1", serves: ["mid2"] }),
+    ];
+
+    const result = resolveAttention(nodes);
+    expect(result.get("bottom")?.value).toBe(4);
+    expect(result.get("bottom")?.sources).toEqual(["top"]);
+  });
+
+  it("adds a boost on a child of a boosted ancestor (relative boost)", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
+      anode({ id: "anc", kind: "strategy", serves: ["virtue-root"], attention: boost(3) }),
+      anode({ id: "mid", kind: "strategy", parent: "anc", attention: boost(2) }),
+      anode({ id: "leaf", kind: "strategy", parent: "mid" }),
+    ];
+
+    const result = resolveAttention(nodes);
+    // mid carries the ancestor's 3 PLUS its own 2.
+    expect(result.get("mid")?.value).toBe(5);
+    expect(result.get("mid")?.sources).toEqual(["anc", "mid"]);
+    // leaf inherits both, undiluted.
+    expect(result.get("leaf")?.value).toBe(5);
+    expect(result.get("leaf")?.sources).toEqual(["anc", "mid"]);
+  });
+});
+
+describe("resolveAttention override (branch cap)", () => {
+  it("caps its own branch while a second parent's claim still adds — T reads 8, not 2", () => {
+    // S1 boosts 10; C overrides that branch down to 2 (its own rank). D hangs
+    // only off C, so D reads the capped 2. S2 boosts 6 independently. T draws
+    // from both C (capped 2) and S2 (6), so T reads 8 — the override caps its
+    // branch, it does not silence T's other parent.
+    const nodes = [
+      ...kinds(),
+      anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
+      anode({ id: "s1", kind: "strategy", serves: ["virtue-root"], attention: boost(10) }),
+      anode({ id: "c", kind: "strategy", parent: "s1", attention: override(2) }),
+      anode({ id: "d", kind: "strategy", parent: "c" }),
+      anode({ id: "s2", kind: "strategy", serves: ["virtue-root"], attention: boost(6) }),
+      anode({ id: "t", kind: "strategy", parent: "c", serves: ["s2"] }),
+    ];
+
+    const result = resolveAttention(nodes);
+    // Override value is the node's own rank (s1's 10 is discarded, not summed).
+    expect(result.get("c")?.value).toBe(2);
+    expect(result.get("c")?.sources).toEqual(["c"]);
+    // Reachable only through the override branch → capped.
+    expect(result.get("d")?.value).toBe(2);
+    expect(result.get("d")?.sources).toEqual(["c"]);
+    // Two parents, one capped: 2 + 6 = 8.
+    expect(result.get("t")?.value).toBe(8);
+    expect(result.get("t")?.sources).toEqual(["s2", "c"]);
+  });
+
+  it("resolves nested overrides — the nearest override wins for the subtree below it", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
+      anode({ id: "root", kind: "strategy", serves: ["virtue-root"], attention: boost(100) }),
+      anode({ id: "outer", kind: "strategy", parent: "root", attention: override(5) }),
+      anode({ id: "between", kind: "strategy", parent: "outer" }),
+      anode({ id: "inner", kind: "strategy", parent: "outer", attention: override(2) }),
+      anode({ id: "leaf", kind: "strategy", parent: "inner" }),
+    ];
+
+    const result = resolveAttention(nodes);
+    expect(result.get("outer")?.value).toBe(5);
+    expect(result.get("between")?.value).toBe(5); // outer's cap
+    expect(result.get("inner")?.value).toBe(2);
+    expect(result.get("leaf")?.value).toBe(2); // nearest (inner) wins
+    expect(result.get("leaf")?.sources).toEqual(["inner"]);
   });
 });
 
@@ -240,15 +233,11 @@ describe("resolveAttention determinism", () => {
     const nodes = [
       ...kinds(),
       anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      anode({
-        id: "strategy-parent",
-        kind: "strategy",
-        serves: ["virtue-root"],
-        attention: attn(6),
-      }),
-      anode({ id: "sub-1", kind: "strategy", parent: "strategy-parent" }),
-      anode({ id: "sub-2", kind: "strategy", parent: "strategy-parent" }),
-      anode({ id: "tactic-1", kind: "tactic", serves: ["strategy-parent"] }),
+      anode({ id: "s1", kind: "strategy", serves: ["virtue-root"], attention: boost(2) }),
+      anode({ id: "s2", kind: "strategy", serves: ["virtue-root"], attention: boost(6) }),
+      anode({ id: "c", kind: "strategy", parent: "s1", attention: override(3) }),
+      anode({ id: "child", kind: "strategy", parent: "c", serves: ["s2"] }),
+      anode({ id: "tactic-1", kind: "tactic", serves: ["s2"] }),
     ];
     const shuffled = [...nodes].reverse();
 

--- a/packages/intentionsutil/test/goals.test.ts
+++ b/packages/intentionsutil/test/goals.test.ts
@@ -147,7 +147,7 @@ describe("projectGoals attention ordering", () => {
       id: "strategy-s",
       kind: "strategy",
       status: "raw",
-      attention: { weight: 10, rationale: "urgent", subordinate_to: [], review_trigger: null },
+      attention: { boost: 10, override: null, rationale: "urgent" },
     });
     // The frontier leaf that inherits the strategy's flow. Highest id, no gap —
     // so gap/id keys alone would rank it LAST.
@@ -166,7 +166,7 @@ describe("projectGoals attention ordering", () => {
       id: "t-eligible",
       kind: "tactic",
       status: "raw",
-      attention: { weight: 10, rationale: "r", subordinate_to: [], review_trigger: null },
+      attention: { boost: 10, override: null, rationale: "r" },
     });
     // kind "note" has no goal_layer flag → not eligible → no resolver entry.
     const ineligible = node({ id: "n-note", kind: "note", status: "raw" });
@@ -180,38 +180,38 @@ describe("projectGoals attention ordering", () => {
 });
 
 describe("renderFrontier attention markers", () => {
-  it("emits `[top via <id>]` for a top-band goal and no marker for a middle goal", () => {
-    // Drive renderFrontier from Goal literals directly: it reads only `band`
+  it("emits `[rank <value> via <id>]` for value > 0 and no marker for value = 0", () => {
+    // Drive renderFrontier from Goal literals directly: it reads only `value`
     // and `sources[0]`, so this decouples the marker assertion from the
-    // resolver's scale-invariant banding math.
+    // resolver's additive-rank math.
     const goals: Goal[] = [
       {
-        node: node({ id: "top-goal", status: "raw" }),
+        node: node({ id: "hi-goal", status: "raw" }),
         realization: "issue-or-pr",
-        attention: { value: 20, band: "top", sources: ["strategy-x"] },
+        attention: { value: 20, sources: ["strategy-x"] },
       },
       {
-        node: node({ id: "mid-goal", status: "raw" }),
+        node: node({ id: "lo-goal", status: "raw" }),
         realization: "issue-or-pr",
-        attention: { value: 1, band: "middle", sources: ["strategy-y"] },
+        attention: { value: 0, sources: [] },
       },
     ];
     expect(renderFrontier(goals)).toBe(
-      "- **top-goal** — Statement for top-goal _(owner: human → issue/PR)_ [top via strategy-x]\n" +
-        "- **mid-goal** — Statement for mid-goal _(owner: human → issue/PR)_\n",
+      "- **hi-goal** — Statement for hi-goal _(owner: human → issue/PR)_ [rank 20 via strategy-x]\n" +
+        "- **lo-goal** — Statement for lo-goal _(owner: human → issue/PR)_\n",
     );
   });
 
-  it("emits a bare `[bottom]` marker when sources is empty", () => {
+  it("emits a bare `[rank <value>]` marker when sources is empty and value > 0", () => {
     const goals: Goal[] = [
       {
-        node: node({ id: "b-goal", status: "raw" }),
+        node: node({ id: "r-goal", status: "raw" }),
         realization: "issue-or-pr",
-        attention: { value: 0, band: "bottom", sources: [] },
+        attention: { value: 5, sources: [] },
       },
     ];
     expect(renderFrontier(goals)).toBe(
-      "- **b-goal** — Statement for b-goal _(owner: human → issue/PR)_ [bottom]\n",
+      "- **r-goal** — Statement for r-goal _(owner: human → issue/PR)_ [rank 5]\n",
     );
   });
 

--- a/packages/intentionsutil/test/schema.test.ts
+++ b/packages/intentionsutil/test/schema.test.ts
@@ -25,10 +25,9 @@ describe("validateNode", () => {
         is_proxy: true,
       },
       attention: {
-        weight: 2,
+        boost: 2,
+        override: null,
         rationale: "Draws attention now.",
-        subordinate_to: ["p"],
-        review_trigger: "Revisit next cycle.",
       },
       attributes: { source: "github:natb1/commons.systems#1" },
     };
@@ -132,56 +131,119 @@ describe("validateNode", () => {
     ).toThrow();
   });
 
-  it("rejects an attention with a negative weight", () => {
+  it("accepts an attention with only a boost", () => {
+    const result = validateNode({
+      id: "n8a",
+      kind: "strategy",
+      statement: "Boosted.",
+      owner: "human",
+      status: "raw",
+      attention: { boost: 3, rationale: "urgent" },
+    });
+    expect(result.attention).toEqual({ boost: 3, override: null, rationale: "urgent" });
+  });
+
+  it("accepts an attention with only an override (including override 0)", () => {
+    const result = validateNode({
+      id: "n8b",
+      kind: "strategy",
+      statement: "Zeroed branch.",
+      owner: "human",
+      status: "raw",
+      attention: { override: 0, rationale: "parked" },
+    });
+    expect(result.attention).toEqual({ boost: null, override: 0, rationale: "parked" });
+  });
+
+  it("rejects an attention that sets both boost and override", () => {
     expect(() =>
       validateNode({
-        id: "n8",
+        id: "n8c",
         kind: "strategy",
-        statement: "Negative weight.",
+        statement: "Both set.",
         owner: "human",
         status: "raw",
-        attention: { weight: -1, rationale: "r" },
+        attention: { boost: 1, override: 2, rationale: "r" },
+      }),
+    ).toThrow(/exactly one of boost\/override/);
+  });
+
+  it("rejects an attention that sets neither boost nor override", () => {
+    expect(() =>
+      validateNode({
+        id: "n8d",
+        kind: "strategy",
+        statement: "Neither set.",
+        owner: "human",
+        status: "raw",
+        attention: { rationale: "r" },
+      }),
+    ).toThrow(/exactly one of boost\/override/);
+  });
+
+  it("rejects a boost of 0 (points at override: 0 for explicit zeroing)", () => {
+    expect(() =>
+      validateNode({
+        id: "n8e",
+        kind: "strategy",
+        statement: "Zero boost.",
+        owner: "human",
+        status: "raw",
+        attention: { boost: 0, rationale: "r" },
+      }),
+    ).toThrow(/boost must be > 0.*override: 0/);
+  });
+
+  it("rejects a negative boost", () => {
+    expect(() =>
+      validateNode({
+        id: "n8f",
+        kind: "strategy",
+        statement: "Negative boost.",
+        owner: "human",
+        status: "raw",
+        attention: { boost: -1, rationale: "r" },
       }),
     ).toThrow();
+  });
+
+  it("rejects a negative override", () => {
+    expect(() =>
+      validateNode({
+        id: "n9a",
+        kind: "strategy",
+        statement: "Negative override.",
+        owner: "human",
+        status: "raw",
+        attention: { override: -1, rationale: "r" },
+      }),
+    ).toThrow(/override must be >= 0/);
   });
 
   it("rejects an attention missing a rationale", () => {
     expect(() =>
       validateNode({
-        id: "n9",
+        id: "n9b",
         kind: "strategy",
         statement: "No rationale.",
         owner: "human",
         status: "raw",
-        attention: { weight: 1 },
+        attention: { boost: 1 },
       }),
     ).toThrow();
   });
 
-  it("rejects an attention with weight 0 and no review_trigger", () => {
+  it("rejects an attention with an empty-string rationale", () => {
     expect(() =>
       validateNode({
-        id: "n10",
+        id: "n9c",
         kind: "strategy",
-        statement: "Deferral without a re-open condition.",
+        statement: "Empty rationale.",
         owner: "human",
         status: "raw",
-        attention: { weight: 0, rationale: "r" },
+        attention: { boost: 1, rationale: "" },
       }),
-    ).toThrow();
-  });
-
-  it("rejects an attention with a non-array subordinate_to", () => {
-    expect(() =>
-      validateNode({
-        id: "n11",
-        kind: "strategy",
-        statement: "Bad subordinate_to.",
-        owner: "human",
-        status: "raw",
-        attention: { weight: 1, rationale: "r", subordinate_to: "not-an-array" },
-      }),
-    ).toThrow();
+    ).toThrow(/rationale must be a non-empty string/);
   });
 });
 
@@ -229,10 +291,9 @@ describe("validateGraph", () => {
         serves: ["virtue-root"],
         recovers: ["delegation-1"],
         attention: {
-          weight: 3,
+          boost: 3,
+          override: null,
           rationale: "A live strategy that draws attention.",
-          subordinate_to: [],
-          review_trigger: null,
         },
       }),
       gnode({
@@ -286,31 +347,6 @@ describe("validateGraph", () => {
     );
   });
 
-  it("throws when an attention.subordinate_to does not resolve to a node", () => {
-    const nodes = [
-      gnode({ id: "kind-kind", kind: "kind", status: "codified" }),
-      gnode({
-        id: "kind-strategy",
-        kind: "kind",
-        status: "codified",
-        attributes: { goal_layer: true },
-      }),
-      gnode({
-        id: "strategy-1",
-        kind: "strategy",
-        attention: {
-          weight: 1,
-          rationale: "r",
-          subordinate_to: ["no-such-node"],
-          review_trigger: null,
-        },
-      }),
-    ];
-    expect(() => validateGraph(nodes)).toThrow(
-      /subordinate_to "no-such-node" does not resolve to a node/,
-    );
-  });
-
   it("throws when attention is on a node whose kind lacks goal_layer", () => {
     const nodes = [
       gnode({ id: "kind-kind", kind: "kind", status: "codified" }),
@@ -320,12 +356,7 @@ describe("validateGraph", () => {
       gnode({
         id: "virtue-1",
         kind: "virtue",
-        attention: {
-          weight: 1,
-          rationale: "r",
-          subordinate_to: [],
-          review_trigger: null,
-        },
+        attention: { boost: 1, override: null, rationale: "r" },
       }),
     ];
     expect(() => validateGraph(nodes)).toThrow(/attention is only valid on goal-layer kinds/);
@@ -347,12 +378,7 @@ describe("validateGraph", () => {
       gnode({
         id: "broken-2",
         kind: "virtue",
-        attention: {
-          weight: 1,
-          rationale: "r",
-          subordinate_to: ["no-such-node"],
-          review_trigger: null,
-        },
+        attention: { boost: 1, override: null, rationale: "r" },
       }),
     ];
     let caught: unknown;
@@ -367,7 +393,6 @@ describe("validateGraph", () => {
     expect(caught.message).toContain('parent "no-such-parent" does not resolve to a node');
     expect(caught.message).toContain('serves "no-such-target" does not resolve to a node');
     expect(caught.message).toContain('recovers "no-such-delegation" does not resolve to a node');
-    expect(caught.message).toContain('subordinate_to "no-such-node" does not resolve to a node');
     expect(caught.message).toContain("attention is only valid on goal-layer kinds");
   });
 });

--- a/packages/intentionsutil/test/store.test.ts
+++ b/packages/intentionsutil/test/store.test.ts
@@ -36,12 +36,41 @@ describe("store round-trip", () => {
         is_proxy: false,
       },
       attention: {
-        weight: 4,
+        boost: 4,
+        override: null,
         rationale: "This root draws attention this cycle.",
-        subordinate_to: ["charter"],
-        review_trigger: "Revisit when the charter changes.",
       },
       attributes: { source: "github:natb1/commons.systems#1", weight: 3 },
+    };
+
+    writeNode(dir, node);
+    const read = readNode(dir, node.id);
+    expect(read).toEqual(node);
+  });
+
+  it("round-trips a node carrying an override injection", () => {
+    const dir = tempDir();
+    const node: IntentionNode = {
+      id: "capped-1",
+      kind: "strategy",
+      statement: "A branch capped by an override.",
+      owner: "human",
+      status: "refining",
+      parent: "root-1",
+      serves: [],
+      recovers: [],
+      rationale: null,
+      reading: null,
+      gap: null,
+      clarifications: [],
+      tooling_goals: [],
+      success_signal: null,
+      attention: {
+        boost: null,
+        override: 0,
+        rationale: "Parked this branch until the blocker clears.",
+      },
+      attributes: {},
     };
 
     writeNode(dir, node);


### PR DESCRIPTION
## Summary

PR 1 of 3 implementing attention v2 (decision record: the 2026-07-03 clarifications on `intentions/strategy-graph-drives-dispatch.md`). Replaces the v1 conserved-flow/banding model in `packages/intentionsutil` with the additive source-set model.

- **Schema**: authored `attention` is now `boost` XOR `override` plus a required `rationale`. `weight`, `subordinate_to`, and `review_trigger` are removed from the attention schema and validators (the unrelated delegation-layer `review_trigger` field is untouched). Goal-layer eligibility rule unchanged.
- **Resolver** (`src/attention.ts`): each node's rank is the sum of a source set flowing undiluted down `parent` + `serves` edges. Set union dedupes diamond paths by source id; a boost adds `(self, boost)` to the outgoing set; an override replaces the node's outgoing set with `{(self, override)}`, capping its own branch only. Bands, `PROVENANCE_DISCOUNT`, `SUBORDINATION_DAMP`, and `AttentionBand` are deleted. Cycle detection, determinism, and derived-never-stored discipline survive from v1.
- **New `scripts/rank-map.ts`**: prints an issue-number → nonzero-rank JSON map for the dispatch router (PR 3 consumes it). Fails loud on a broken store — no empty-map fallback.
- **Frontier rendering** (`src/goals.ts`): band marker replaced with `[rank <value> via <source>]` for value > 0; the no-injection render stays byte-identical to the committed baseline.
- Docs: `SCHEMA.md` attention section rewritten; one wording update in `.claude/docs/signal-identification.md`.

Follow-ups land separately: PR 2 rewrites the intention-graph node docs and skill text (emit gate + `priority` label meaning); PR 3 makes `dispatch-select-target` order by resolved rank.

## Verification

- `npx vitest run --project packages/intentionsutil --root .` — 153/153 pass
- `npx tsc -p packages/intentionsutil --noEmit` — clean
- `npx tsx packages/intentionsutil/scripts/rank-map.ts` — prints `{}` (no injections authored yet)
- `npx tsx packages/intentionsutil/scripts/frontier-view.ts` — 114 lines, no markers, byte-identical to baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)