### PR TITLE
dispatch: router reads the tree — rank-ordered selection, tactic-layer gate

### DIFF
--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -219,22 +219,38 @@ acts on the script's one output line; the mechanics below are reference, not
 per-tick action.
 
 Priority order the script implements, top to bottom: JIT scan →
-`origin/main` CI health gate → priority × topic-category × phase ladder.
-A jit-reminder surfaces even when `origin/main` is red because the JIT scan
-precedes the main-broken gate.
+`origin/main` CI health gate → attention-rank × enhancement × topic-category ×
+phase ladder. A jit-reminder surfaces even when `origin/main` is red because
+the JIT scan precedes the main-broken gate.
 
-The priority × topic-category × phase ladder is three-tier: the **priority
-bit** is the outermost axis, a topic **category** nests inside it, and the
-phase **ladder** runs innermost. The selector exhausts the entire `priority=1`
-tier — every topic category, every phase — before considering any `priority=0`
-item, so a `priority` item in a low-ranked topic outranks every non-priority
-item in a higher-ranked topic. Within one priority level, categories run
+The attention-rank × enhancement × topic-category × phase ladder nests four
+axes: the **attention rank** is the outermost (continuous) axis, the
+**enhancement** bit nests inside it (issue path only), a topic **category**
+nests inside that, and the phase **ladder** runs innermost. Attention rank is
+resolved from the intention graph by `packages/intentionsutil/scripts/rank-map.ts`
+(issue → node via the `trackers/` map or the `tactic-<N>` emitted-leaf
+convention); an issue absent from the map is rank 0 (the baseline). A PR
+inherits the **max** rank over the issues it closes. The selector drains the
+distinct rank values descending — it exhausts an entire rank level (every
+enhancement value, every topic category, every phase) before considering any
+lower-rank item, so a high-rank item in a low-ranked topic outranks every
+lower-rank item in a higher-ranked topic. Within one rank level, categories run
 highest first: `security` → `bug` → `testing infrastructure` → `dispatch` →
-`landing` → `fellspiral` → `budget` → `print` → `audio` → `other`. The
+`landing` → `fellspiral` → `budget` → `print` → `audio` → `other`.
+
+The `priority` label = **cap/pacing bypass only, no ordering effect**. It is
+de-ordered entirely: a `priority`-labeled unranked item does not jump the queue
+past a ranked non-priority item. The label survives solely as the at-cap
+`--priority-only` bypass and the dispatch-tick pace-curve exemption. The
 `priority` label is human-applied — `/file-issue` never applies it automatically.
 A PR's category is the highest-priority topic among the labels of every issue
 it closes; an issue's category is the highest-priority topic among its own
 labels; anything with no topic label is `other`.
+
+If `rank-map.ts` fails (a broken `intentions/` store or tsx error), selection
+exits loudly with an error rather than falling back to an all-zero map that
+would silently reorder the queue — the health/JIT heartbeat paths run before the
+rank map loads, so they are unaffected.
 
 Within each category the ladder is (highest first; within a tier, oldest PR
 wins; PRs and `help wanted` issues with a local worktree are skipped; a PR
@@ -246,7 +262,7 @@ ranked closest-to-done first — `review` is the closest-to-done non-QA tier;
 `help wanted` issues rank below all non-QA PRs but above QA PRs. Within the
 `help wanted` issue tier, a planned issue (carrying `dispatch:planned`,
 `implement` phase) outranks an unplanned issue (`plan` phase) in the same
-(category, priority) bucket — in-flight work advances before new planning
+(category, rank) bucket — in-flight work advances before new planning
 begins. The resolved winner is the leaf (from `dispatch-trace-leaf`), not the
 `help wanted` root; the `dispatch:planned` check is on the leaf. A queue with
 no topic-labeled items resolves entirely to `other`, reproducing the flat
@@ -483,7 +499,7 @@ baked into the script):
 | `five_hour_target_floor_pct` (`floor5`) | 50 | `used_5h` % at which workers reach max (gate open) |
 | `five_hour_target_ceiling_pct` (`ceil5`) | 80 | `used_5h` % at which workers reach zero (gate open) |
 | `max_concurrent_workers` | 8 | max worker count |
-| `exhaustion_threshold_pct` | 98 | used_% (either window) at/near 100, with resets_at in the future, treated as genuine token exhaustion — a hard stop even for priority/main-broken work |
+| `exhaustion_threshold_pct` | 98 | used_% (either window) at/near 100, with resets_at in the future, treated as genuine token exhaustion — a hard stop even for priority-labeled (gate-bypass)/main-broken work |
 
 Recalibration: raise `weekly_curve_power` to back-load spend later in the
 week — a higher `p` keeps `W` nearer the floor longer, then climbs faster to
@@ -503,7 +519,7 @@ raise `weekly_increment_cap_pct` (which also lowers the shoulder).
 
 Keep `exhaustion_threshold_pct` above `five_hour_target_ceiling_pct` (default 98
 > 80) so the 5h ramp's zero-point and the exhaustion floor stay distinct: the
-band between them (80→98) is "paced to 0", which priority/main-broken work
+band between them (80→98) is "paced to 0", which priority-labeled (gate-bypass)/main-broken work
 overrides, while only used_% at/above the threshold is genuine token exhaustion,
 a hard stop for all work. Setting the threshold at or below the ceiling would
 collapse that override band into a hard stop.
@@ -732,7 +748,7 @@ retriaged.
 
 CI-wait handling splits on available queue size, not invocation mode. In a
 multi-item fan-out run (`--gap N>1`), a `ci-waiting` target is a `skipped`
-outcome: the loop moves on to the next ready priority, and other live workers'
+outcome: the loop moves on to the next ready target, and other live workers'
 Stop-hooks bring the chain back to that target later. The single-target path —
 an explicit `/dispatch <N>`, or a `--gap 1` run whose only candidate is
 not-ready — has no "next". So instead of draining as a no-op, it calls

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-target
@@ -31,7 +31,8 @@
 #
 # --top <N> (default 1; valid in default mode and with --priority-only) emits up
 # to N distinct decision lines
-# in the existing priority order (priority axis → topic category → phase ladder),
+# in the rank order (attention-rank axis → enhancement → topic category → phase
+# ladder),
 # one per line — the fan-out caller consumes the list in a single scan instead of
 # re-invoking the selector once per slot (#1317). Each scan dedups internally: no
 # target is returned twice, and live/reserved/office-hours/excluded targets are
@@ -45,10 +46,12 @@
 # Default-mode priority, top to bottom:
 #   1. JIT scan (jit-reminder)
 #   2. origin/main CI health gate (main-broken)
-#   3. the priority × enhancement × topic-category × phase ladder over open PRs
-#      and help-wanted issues. The enhancement axis applies to the ISSUE path
-#      only: within a priority tier all non-enhancement work (PRs and
-#      non-enhancement issues) drains before any enhancement issue. PRs are never
+#   3. the attention-rank × enhancement × topic-category × phase ladder over open
+#      PRs and help-wanted issues. Attention rank (resolved from the intention
+#      graph, see RANK_MAP_JSON below) is the OUTERMOST axis: distinct rank values
+#      drain descending. The enhancement axis applies to the ISSUE path only:
+#      within a rank level all non-enhancement work (PRs and non-enhancement
+#      issues) drains before any enhancement issue. PRs are never
 #      enhancement-classified, so an in-flight PR completes normally.
 #
 # --health-only mode runs the JIT scan and the origin/main CI health gate, then
@@ -65,10 +68,12 @@
 #   pr <num> <branch>           — the QA PR to work on
 #
 # --priority-only mode is the at-cap bypass selector (#1134): it runs the
-# origin/main CI health gate, then scans ONLY the `priority=1` tier of the
-# PR/issue ladder, returning the single highest-priority priority item. The JIT
-# scan is suppressed (a reminder is not priority/main-broken fix work). Every
-# default-mode skip rule is preserved (worktree ownership/reservation,
+# origin/main CI health gate, then scans ONLY the items carrying the `priority`
+# label (its ONE surviving meaning — the cap/pacing bypass, NOT an ordering
+# signal), returning the single highest-ranked priority-labeled item. Within that
+# label-filtered set the ordinary rank → enh → topic → phase ladder decides the
+# winner. The JIT scan is suppressed (a reminder is not priority/main-broken fix
+# work). Every default-mode skip rule is preserved (worktree ownership/reservation,
 # blocked_by, ready-PR-closes-issue, not-ready PR). dispatch-select-tick consults
 # it when the autonomous tick is at the worker cap but not token-exhausted, to
 # spawn a priority/main-broken item as one gate-exempt worker; its manual fan-out
@@ -76,35 +81,39 @@
 #
 # Output for the no-`--top` (TOP=1) case is exactly one line:
 #   main-broken <sha>           — origin/main's HEAD CI has a failing check
-#   pr <num> <branch> <phase>   — the highest-priority priority=1 PR
-#   issue <num>                 — the highest-priority priority=1 help-wanted issue
-#   waiting <issue#>            — a priority item exists but its draft PR's CI is
-#                                 still pending (skipped solely by dispatch-ci-ready)
-#   empty                       — no priority=1 item eligible
+#   pr <num> <branch> <phase>   — the highest-ranked priority-labeled PR
+#   issue <num>                 — the highest-ranked priority-labeled help-wanted issue
+#   waiting <issue#>            — a priority-labeled item exists but its draft PR's
+#                                 CI is still pending (skipped solely by dispatch-ci-ready)
+#   empty                       — no priority-labeled item eligible
 #
-# With --top N, --priority-only returns UP TO N eligible priority=1 decision
+# With --top N, --priority-only returns UP TO N eligible priority-labeled decision
 # lines (`pr <num> <branch> <phase>` / `issue <num>`), one per line, or `empty`.
-# The TOP>1 path has NO `waiting` branch: a priority tier whose only items are
-# CI-pending yields `empty` under `--priority-only --top N` — correct, since
-# CI-pending items are not selectable. (The single-line contract above, including
-# `waiting <issue#>` and `main-broken <sha>`, still holds for the TOP=1 case.)
+# The TOP>1 path has NO `waiting` branch: a set whose only items are CI-pending
+# yields `empty` under `--priority-only --top N` — correct, since CI-pending items
+# are not selectable. (The single-line contract above, including `waiting <issue#>`
+# and `main-broken <sha>`, still holds for the TOP=1 case.)
 #
-# Selection nests four axes for the ISSUE path: the `priority` label is the
+# Selection nests four axes for the ISSUE path: attention *rank* is the
 # *outermost* axis, the `enhancement` bit nests inside it, topic *category* nests
-# inside that, and the phase *ladder* runs innermost. The selector exhausts the
-# entire `priority=1` tier — every enhancement value, every topic category, every
-# phase — before considering any `priority=0` item, so a `priority` item in a
-# low-ranked topic still outranks every non-priority item in a higher-ranked
-# topic (a priority-escalated enhancement still jumps the queue). Within one
-# priority level, all non-enhancement work (enh=0) drains before any enhancement
-# issue (enh=1); within one (priority, enh) level, topic categories run highest
-# priority first:
+# inside that, and the phase *ladder* runs innermost. The selector exhausts an
+# entire rank level — every enhancement value, every topic category, every phase —
+# before considering any lower-rank item, so a high-rank item in a low-ranked
+# topic still outranks every lower-rank item in a higher-ranked topic. Within one
+# rank level, all non-enhancement work (enh=0) drains before any enhancement issue
+# (enh=1); within one (rank, enh) level, topic categories run highest priority
+# first:
 #   security → bug → testing infrastructure → dispatch → landing → fellspiral → budget → print → audio → other
-# and within each (priority, enh, topic) bucket the phase ladder runs innermost.
+# and within each (rank, enh, topic) bucket the phase ladder runs innermost.
+#
+# The `priority` label has NO ordering effect: it is de-ordered entirely and
+# survives only as the cap/pacing bypass (the --priority-only probe here and the
+# dispatch-tick pace-curve exemption). A priority-labeled unranked item does not
+# jump the queue past a ranked non-priority item.
 #
 # The enhancement axis applies to the ISSUE path ONLY. A PR is never
 # enhancement-classified — its bucket key stays the 3-part
-# `<category>|<priority>|<phase>` and it is drawn only on the enh=0 pass, so an
+# `<category>|<rank>|<phase>` and it is drawn only on the enh=0 pass, so an
 # enhancement issue that has already reached a PR completes normally (its PR is
 # NOT re-deprioritized). An issue's enhancement bit is 1 if its own labels carry
 # `enhancement`, else 0.
@@ -112,12 +121,13 @@
 # A PR's category is the highest-priority topic among the labels of every issue
 # it closes (closingIssuesReferences); a PR that closes no issue, or whose
 # closing issues carry no topic label, is "other". An issue's category is the
-# highest-priority topic among its own labels, else "other". A PR's priority
-# bit is 1 if any closing issue, or any open ancestor of a closing issue (up to
-# 6 levels), carries the `priority` label, else 0; an issue's priority bit is 1
-# if its own labels carry `priority`, else 0.
+# highest-priority topic among its own labels, else "other". A PR inherits the
+# MAX attention rank over the issues it closes (rank inheritance); an issue's rank
+# is its own graph-derived rank, 0 if unmapped. (The `priority` LABEL is still
+# derived — via pr_priority_bit / has_priority_in_labels — but ONLY for the
+# --priority-only bypass filter and DEBUG_CLASSIFY, never for ordering.)
 #
-# Within each (priority, topic) bucket, default-mode priority (oldest PR wins
+# Within each (rank, topic) bucket, default-mode priority (oldest PR wins
 # within a tier):
 #   1. Oldest "fix-conflicts" PR (draft, mergeable == CONFLICTING)
 #   2. Oldest "review"      PR (draft + dispatch:qa-done)
@@ -159,9 +169,9 @@
 # the flat ladder exactly.
 #
 # --qa mode priority:
-#   1. Oldest QA PR in the highest-priority (priority, topic) bucket that has
-#      one — same outer iteration as default mode (priority axis outermost,
-#      then topic category), restricted to the qa phase
+#   1. Oldest QA PR in the highest-ranked (rank, topic) bucket that has one — same
+#      outer iteration as default mode (attention-rank axis outermost, then topic
+#      category), restricted to the qa phase
 #   2. empty
 set -euo pipefail
 
@@ -504,6 +514,53 @@ ISSUE_LIST=$(gh_issue_list_rest --state open)
 ISSUE_LABELS_JSON=$(printf '%s' "$ISSUE_LIST" \
   | jq -c 'reduce .[] as $i ({}; .[$i.number | tostring] = ($i.labels // []))')
 
+# Attention-rank map: issue number (string) -> rank (number). This is the
+# OUTERMOST ordering axis — the queue drains distinct rank values descending,
+# with the existing enh → topic-category → phase ladder as tie-break WITHIN each
+# rank level. The `priority` label no longer orders anything; it survives only as
+# the cap/pacing bypass (the --priority-only probe and dispatch-tick pace-curve
+# exemption still read it). Ranks are derived from the intention graph by
+# packages/intentionsutil/scripts/rank-map.ts; a missing key means rank 0.
+#
+# Test seam first (DISPATCH_RANK_MAP_JSON), mirroring DISPATCH_PR_LIST_FILE /
+# DISPATCH_RESERVATION_DIR. Placed AFTER every early-exit mode (--main-broken-sha,
+# --health-only, the default-mode JIT/main-broken gates) so the heartbeat/health
+# paths never depend on the rank map — a broken intentions/ store cannot stall
+# the health re-seed.
+#
+# Rank strings are OPAQUE in shell: every numeric operation (lookup, max, sort,
+# distinct) happens jq-side against the one canonicalized map below; bash only
+# does string-keyed bucket lookups. Because RANK_LEVELS and pr_rank_of both derive
+# their rank strings from this single jq-parsed value via `tostring` with no
+# arithmetic in between, a float's textual form can never drift between the bucket
+# keys and the level list. The "|" bucket-key separator stays collision-free: rank
+# strings are jq number literals.
+if [[ -n "${DISPATCH_RANK_MAP_JSON:-}" ]]; then
+  RANK_MAP_JSON="$DISPATCH_RANK_MAP_JSON"
+else
+  RANK_ROOT=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel) || {
+    echo "error: dispatch-select-target: cannot resolve repo root for rank-map.ts" >&2; exit 1; }
+  RANK_MAP_JSON=$(cd "$RANK_ROOT" && npx tsx packages/intentionsutil/scripts/rank-map.ts) || {
+    echo "error: dispatch-select-target: rank-map.ts failed; refusing to order the queue with unknown attention ranks" >&2
+    exit 1
+  }
+fi
+# Canonicalize + validate in ONE jq pass: every rank string downstream (bucket
+# keys AND the level list) derives from this one jq-parsed value, so float
+# formatting can never drift between sites. Fail closed (clear-errors rule): a
+# map that is not a JSON object of numbers exits 1 loudly — never an all-zero
+# fallback that would silently reorder the queue.
+RANK_MAP_JSON=$(printf '%s' "$RANK_MAP_JSON" \
+  | jq -ce 'if type == "object" and all(.[]; type == "number") then . else empty end') || {
+  echo "error: dispatch-select-target: rank map is not a JSON object of numbers" >&2
+  exit 1
+}
+# Distinct rank levels, descending, as canonical jq strings. Always includes the
+# rank-0 baseline. A superset of candidate levels — iterating an unused level is
+# a harmless empty-bucket pass.
+mapfile -t RANK_LEVELS < <(printf '%s' "$RANK_MAP_JSON" \
+  | jq -r '([.[]] + [0]) | unique | reverse | .[] | tostring')
+
 # Planned-issue lookup: number → 1 for every open issue carrying
 # dispatch:planned (the implement-phase discriminator, per dispatch-phase).
 # Reuses the already-fetched ISSUE_LIST — no extra gh call. A leaf absent from
@@ -609,16 +666,15 @@ fi
 
 # Topic categories in priority order; "other" is the implicit fallback for any
 # label set with no topic label. `security` ranks first, so a security-labeled
-# item outranks a plain-`bug` item at the same priority level. The `priority`
-# label is the *outermost* axis: every `priority` item ranks above every
-# non-priority item, regardless of topic. Topic category nests *inside* the
-# priority axis, and the phase ladder runs innermost. TOPIC_CATEGORIES is the
-# single source of the topic ordering — category_of_labels resolves against it
-# and the default-mode loop iterates CATEGORIES within each priority level.
-# `priority` is derived alongside the category via the has_priority_in_labels
-# helper; topic category is the tie-break among items at the same priority
-# level. The companion classifier that *applies* these labels is ref-ready
-# SKILL.md Step 6; keep the two label sets in sync.
+# item outranks a plain-`bug` item at the same rank level. Attention *rank* is
+# the *outermost* axis: every higher-rank item ranks above every lower-rank item,
+# regardless of topic. Topic category nests *inside* the rank axis (below the enh
+# bit), and the phase ladder runs innermost. TOPIC_CATEGORIES is the single source
+# of the topic ordering — category_of_labels resolves against it and the
+# default-mode loop iterates CATEGORIES within each rank level. Topic category is
+# the tie-break among items at the same rank level. The companion classifier that
+# *applies* these labels is ref-ready SKILL.md Step 6; keep the two label sets in
+# sync.
 #
 # Disambiguation: the `security` *topic* label here is its own namespace, kept
 # apart from any `dispatch:*` workflow marker by exact-match resolution. A bare
@@ -634,8 +690,10 @@ TOPIC_CATEGORIES_JSON=$(printf '%s\n' "${TOPIC_CATEGORIES[@]}" | jq -Rcn '[input
 # [.[].name] itself, so callers pass the raw label array. category_of_labels /
 # has_priority_in_labels wrap these, and the ISSUE_SORTED filter below calls
 # the same defs — there is now exactly one copy of each expression.
-# has_enhancement is called only by ISSUE_SORTED (the enhancement axis is on the
-# issue-selection path only — PRs are never enhancement-classified), but lives
+# has_priority still exists but ONLY feeds the --priority-only bypass filter and
+# DEBUG_CLASSIFY — the `priority` label no longer orders the queue (attention rank
+# does). has_enhancement is called only by ISSUE_SORTED (the enhancement axis is on
+# the issue-selection path only — PRs are never enhancement-classified), but lives
 # here so the `enhancement` label expression has a single source too.
 JQ_LABEL_DEFS='
   def has_priority: [.[].name] | if index("priority") then 1 else 0 end;
@@ -683,28 +741,38 @@ pr_priority_bit() {
       | has_priority'
 }
 
-# Top-N ranked PRs per (category, priority-bit, phase): key =
-# "<category>|<priority-bit>|<phase>", value = a NEWLINE-DELIMITED list (no
+# Max attention rank over a PR's closing issues (rank inheritance): a PR inherits
+# the highest rank among the issues it closes. "0" when it closes nothing or
+# nothing maps. Canonical jq tostring — matches RANK_LEVELS by construction, since
+# both derive from the same RANK_MAP_JSON. NOTE: here `$map` is RANK_MAP_JSON (the
+# rank map), NOT ISSUE_LABELS_JSON as in pr_priority_bit / pr_combined_labels.
+pr_rank_of() {
+  printf '%s' "$1" | jq -r --argjson map "$RANK_MAP_JSON" \
+    '[ .[].number | tostring as $n | ($map[$n] // 0) ] | (max // 0) | tostring'
+}
+
+# Top-N ranked PRs per (category, rank, phase): key =
+# "<category>|<rank>|<phase>", value = a NEWLINE-DELIMITED list (no
 # leading/trailing newline) of up to TOP entries, each "<num> <branch>", oldest
-# first. The "|" separator is collision-free — priority bits are literal `0`/`1`,
-# phase names are fixed identifiers, and no TOPIC_CATEGORIES name contains "|".
-# PRs are NOT enhancement-classified: this key stays 3-part (unlike the 4-part
-# FIRST_ISSUE key) and the emission loops draw it only on the enh==0 pass, so an
-# in-flight PR completes normally rather than being deprioritized below
+# first. The "|" separator is collision-free — rank strings are jq number literals
+# (no "|"), phase names are fixed identifiers, and no TOPIC_CATEGORIES name
+# contains "|". PRs are NOT enhancement-classified: this key stays 3-part (unlike
+# the 4-part FIRST_ISSUE key) and the emission loops draw it only on the enh==0
+# pass, so an in-flight PR completes normally rather than being deprioritized below
 # enhancement issues.
 # PR_SORTED is pre-sorted oldest-first, so entries accumulate oldest-first. For
 # TOP=1 a bucket holds at most one entry — the oldest — and expands to the bare
 # entry with no trailing newline, byte-identical to the former single-entry map.
 declare -A FIRST_PR
-# Top-N ranked help-wanted issues per (category, priority-bit, enh-bit, phase):
-# key = "<category>|<priority-bit>|<enh-bit>|<phase>" where phase ∈ {implement,
+# Top-N ranked help-wanted issues per (category, rank, enh-bit, phase):
+# key = "<category>|<rank>|<enh-bit>|<phase>" where phase ∈ {implement,
 # plan}, value = a NEWLINE-DELIMITED list (no leading/trailing newline) of up to
 # TOP "<num>" entries, oldest first. The enh-bit (1 if the issue carries the
-# `enhancement` label, else 0) is an axis between priority and topic-category:
-# within a priority tier all non-enhancement issues (enh=0) drain before any
+# `enhancement` label, else 0) is an axis between rank and topic-category:
+# within a rank level all non-enhancement issues (enh=0) drain before any
 # enhancement issue (enh=1). The issue path is the ONLY enhancement-classified
 # path — PRs are never enhancement-classified, so FIRST_PR keeps the 3-part
-# "<category>|<priority-bit>|<phase>" key (a PR that has already reached a phase
+# "<category>|<rank>|<phase>" key (a PR that has already reached a phase
 # completes normally; its in-flight work is not re-deprioritized). Splitting the
 # bucket by phase lets a planned issue (implement) be selected ahead of an
 # unplanned one (plan) in the same bucket.
@@ -745,26 +813,28 @@ bucket_append() {
   return 0
 }
 
-# group_emittable_count <category> <priority-bit> <enh-bit> — total entries the
-# emission loops could draw from this (category, priority, enh) group:
-# FIRST_ISSUE across the issue ladder (ISSUE_PHASE_PRIORITY) keyed
-# cat|pri|enh|phase always, and FIRST_PR across the PR phase ladder
-# (PHASE_PRIORITY) plus qa keyed cat|pri|phase ONLY when enh==0 — matching the
-# emission order, where PRs (never enhancement-classified, so always in the
-# enh==0 pass) are drawn only on the enh==0 iteration. Drives the walk's global
-# early-exit (#1452): once the strictly-higher-rank groups already hold TOP such
-# entries combined, emission fills its TOP results from them before reaching any
-# lower-rank group, so the remaining lower-rank roots cannot change the output
-# and the walk can stop.
+# group_emittable_count <category> <rank> <enh-bit> — total entries the emission
+# loops could draw from this (category, rank, enh) group: FIRST_ISSUE across the
+# issue ladder (ISSUE_PHASE_PRIORITY) keyed cat|rank|enh|phase always, and
+# FIRST_PR across the PR phase ladder (PHASE_PRIORITY) plus qa keyed cat|rank|phase
+# ONLY when enh==0 — matching the emission order, where PRs (never
+# enhancement-classified, so always in the enh==0 pass) are drawn only on the
+# enh==0 iteration. Drives the walk's global early-exit (#1452): once the
+# strictly-higher-rank groups already hold TOP such entries combined, emission
+# fills its TOP results from them before reaching any lower-rank group, so the
+# remaining lower-rank roots cannot change the output and the walk can stop. The
+# count is exact for groups the walk visits and a conservative undercount for
+# rank levels that carry PRs but no help-wanted issue (never folded → never stops
+# early), so the early-exit stays sound.
 group_emittable_count() {
-  local _gec_cat="$1" _gec_pri="$2" _gec_enh="$3" _gec_total=0 _gec_p
+  local _gec_cat="$1" _gec_rank="$2" _gec_enh="$3" _gec_total=0 _gec_p
   if (( _gec_enh == 0 )); then
     for _gec_p in "${PHASE_PRIORITY[@]}" qa; do
-      _gec_total=$(( _gec_total + $(bucket_count FIRST_PR "$_gec_cat|$_gec_pri|$_gec_p") ))
+      _gec_total=$(( _gec_total + $(bucket_count FIRST_PR "$_gec_cat|$_gec_rank|$_gec_p") ))
     done
   fi
   for _gec_p in "${ISSUE_PHASE_PRIORITY[@]}"; do
-    _gec_total=$(( _gec_total + $(bucket_count FIRST_ISSUE "$_gec_cat|$_gec_pri|$_gec_enh|$_gec_p") ))
+    _gec_total=$(( _gec_total + $(bucket_count FIRST_ISSUE "$_gec_cat|$_gec_rank|$_gec_enh|$_gec_p") ))
   done
   echo "$_gec_total"
 }
@@ -804,10 +874,11 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   # here and reuse it (claimed skip, office-hours skip, exclude skip).
   pr_issue_num="${pr_branch%%-*}"
 
-  # --priority-only scans only the priority=1 tier. Skip any PR whose
-  # closing-issue label union does not carry `priority` BEFORE the expensive
-  # per-PR dispatch-ci-ready / dispatch-phase gh calls — a non-priority PR is
-  # never selectable in this mode, so it pays nothing.
+  # --priority-only scans only priority-LABELED items (the bypass filter — the
+  # label's one surviving meaning). Skip any PR whose closing-issue label union
+  # (incl. ancestors) does not carry `priority` BEFORE the expensive per-PR
+  # dispatch-ci-ready / dispatch-phase gh calls — a non-priority PR is never
+  # selectable in this mode, so it pays nothing.
   if [[ "$PRIORITY_ONLY" == "true" ]] \
      && [[ "$(pr_priority_bit "$pr_closing")" != "1" ]]; then
     continue
@@ -922,19 +993,19 @@ while IFS=$'\t' read -r pr_num _created pr_branch pr_closing; do
   # first-seen guard.
   pr_combined=$(pr_combined_labels "$pr_closing")
   pr_cat=$(category_of_labels "$pr_combined")
-  pr_pri=$(pr_priority_bit "$pr_closing")
-  pr_key="$pr_cat|$pr_pri|$phase"
+  pr_rank=$(pr_rank_of "$pr_closing")
+  pr_key="$pr_cat|$pr_rank|$phase"
   bucket_append FIRST_PR "$pr_key" "$pr_num $pr_branch" || true
 done <<< "$PR_SORTED"
 
 if [[ "$QA_MODE" == "true" ]]; then
-  # --qa mode: oldest QA PR in the highest-priority (priority, topic) bucket
-  # that has one — priority is the outermost axis (1 then 0), topic category
-  # nested inside — without the <phase> field. The issue queue is irrelevant
-  # here, so the leaf-resolution loop below is skipped entirely.
-  for pri in 1 0; do
+  # --qa mode: oldest QA PR in the highest-rank (rank, topic) bucket that has
+  # one — attention rank is the outermost axis (RANK_LEVELS, descending), topic
+  # category nested inside — without the <phase> field. The issue queue is
+  # irrelevant here, so the leaf-resolution loop below is skipped entirely.
+  for rank_lvl in "${RANK_LEVELS[@]}"; do
     for category in "${CATEGORIES[@]}"; do
-      qa_key="$category|$pri|qa"
+      qa_key="$category|$rank_lvl|qa"
       if [[ -n "${FIRST_PR[$qa_key]:-}" ]]; then
         echo "pr ${FIRST_PR[$qa_key]}"
         exit 0
@@ -982,22 +1053,23 @@ done < <(printf '%s' "$PR_LIST" | jq -r '
 # help-wanted issue — is what gets recorded; the category is still the
 # top-level issue's own.
 #
-# The roots are now emitted in (priority desc, enh asc, category-rank asc,
+# The roots are now emitted in (attention-rank desc, enh asc, category-rank asc,
 # createdAt asc) order — the SAME rank order the emission loops drain — so each
-# (priority, enh, category) group's roots are contiguous, enabling the walk's
-# global early-exit (#1452). The enh bit (1 if the issue carries `enhancement`,
-# else 0) nests BETWEEN priority and topic-category: within a priority tier all
-# non-enhancement issues (enh=0) sort before any enhancement issue (enh=1), and
-# enhancement issues then order by the existing topic ladder. pri/enh/catname are
-# computed by the shared JQ_LABEL_DEFS defs — the same defs category_of_labels /
-# has_priority_in_labels call — so the two sites cannot drift; cat-rank is the
-# CATEGORIES iteration order. Bucket keys are unchanged. (1 - .pri) sorts
-# priority=1 first; .enh sorts non-enhancement (0) first; jq sort_by is stable
-# and createdAt is an ISO string sorting chronologically, so within a
-# (pri, enh, cat-rank) group roots stay oldest-first — byte-identical to the old
-# order for that group. The TSV now carries the precomputed pri/enh/cat-rank/cat
-# columns.
-ISSUE_SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r --argjson cats "$TOPIC_CATEGORIES_JSON" "$JQ_LABEL_DEFS"'
+# (rank, enh, category) group's roots are contiguous, enabling the walk's global
+# early-exit (#1452). The enh bit (1 if the issue carries `enhancement`, else 0)
+# nests BETWEEN rank and topic-category: within a rank level all non-enhancement
+# issues (enh=0) sort before any enhancement issue (enh=1), and enhancement issues
+# then order by the existing topic ladder. pri/enh/catname are computed by the
+# shared JQ_LABEL_DEFS defs — the same defs category_of_labels /
+# has_priority_in_labels call — so the two sites cannot drift; rank is looked up in
+# RANK_MAP_JSON (0 if unmapped); cat-rank is the CATEGORIES iteration order. Bucket
+# keys carry rank in place of the former priority bit. -.rank sorts higher ranks
+# first; .enh sorts non-enhancement (0) first; jq sort_by is stable and createdAt
+# is an ISO string sorting chronologically, so within a (rank, enh, cat-rank) group
+# roots stay oldest-first. The `pri` column is RETAINED in the TSV solely for the
+# --priority-only bypass filter and DEBUG_CLASSIFY — it no longer participates in
+# ordering. The TSV carries the precomputed pri/rank/enh/cat-rank/cat columns.
+ISSUE_SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r --argjson cats "$TOPIC_CATEGORIES_JSON" --argjson map "$RANK_MAP_JSON" "$JQ_LABEL_DEFS"'
   [ .[]
     | select((.labels // []) | any(.name == "help wanted"))
     | select((.labels // []) | any(.name == "dispatch:office-hours") | not)
@@ -1005,19 +1077,22 @@ ISSUE_SORTED=$(printf '%s' "$ISSUE_LIST" | jq -r --argjson cats "$TOPIC_CATEGORI
     | ((.labels // []) | has_enhancement) as $enh
     | ((.labels // []) | category_of($cats)) as $catname
     | (($cats | index($catname)) // ($cats | length)) as $catrank
-    | { number: .number, createdAt: .createdAt, pri: $pri, enh: $enh, catrank: $catrank, catname: $catname }
+    | (($map[(.number | tostring)]) // 0) as $rank
+    | { number: .number, createdAt: .createdAt, pri: $pri, rank: $rank, enh: $enh, catrank: $catrank, catname: $catname }
   ]
-  | sort_by([ (1 - .pri), .enh, .catrank, .createdAt ])
-  | .[] | [.number, .pri, .enh, .catrank, .catname] | @tsv')
+  | sort_by([ -.rank, .enh, .catrank, .createdAt ])
+  | .[] | [.number, .pri, (.rank|tostring), .enh, .catrank, .catname] | @tsv')
 
 if [[ "$DEBUG_CLASSIFY" == "true" ]]; then
   # Emit, for each surviving issue, the REAL inline ISSUE_SORTED jq classification
   # (sorted_*) alongside the REAL shell-helper classification (helper_*), so the
   # test can prove the two classification sources agree (#1490). The TSV now
-  # carries an enh column between pri and catrank; skip it here (DEBUG_CLASSIFY
-  # checks only pri/category agreement).
+  # carries a rank column (after pri) and an enh column (between rank and
+  # catrank); skip both here (DEBUG_CLASSIFY checks only pri/category agreement —
+  # pri is still computed two ways for the bypass filter, so the assertion stays
+  # meaningful).
   # number <tab> sorted_pri <tab> sorted_cat <tab> helper_pri <tab> helper_cat
-  while IFS=$'\t' read -r dbg_num dbg_pri _dbg_enh _dbg_catrank dbg_cat; do
+  while IFS=$'\t' read -r dbg_num dbg_pri _dbg_rank _dbg_enh _dbg_catrank dbg_cat; do
     [[ -z "$dbg_num" ]] && continue
     dbg_labels=$(printf '%s' "$ISSUE_LIST" \
       | jq -c --argjson n "$dbg_num" '(.[] | select(.number == $n) | .labels) // []')
@@ -1030,14 +1105,14 @@ fi
 
 walk_prev_group=""
 walk_prev_cat=""
-walk_prev_pri=""
+walk_prev_rank=""
 walk_prev_enh=""
 walk_cum_emittable=0
-while IFS=$'\t' read -r issue_num issue_pri issue_enh issue_catrank issue_cat; do
+while IFS=$'\t' read -r issue_num issue_pri issue_rank issue_enh issue_catrank issue_cat; do
   [[ -z "$issue_num" ]] && continue
-  # Global early-exit across (priority, enh, category) groups (#1452). The walk
-  # now runs in (pri desc, enh asc, cat-rank asc, createdAt asc) order — the SAME
-  # rank order the emission loops drain. Roots of one group are contiguous, so
+  # Global early-exit across (rank, enh, category) groups (#1452). The walk now
+  # runs in (attention-rank desc, enh asc, cat-rank asc, createdAt asc) order — the
+  # SAME rank order the emission loops drain. Roots of one group are contiguous, so
   # when the group changes the previous group is fully resolved: fold its
   # emittable count (FIRST_ISSUE across all its phases, plus FIRST_PR only when
   # enh==0) into the cumulative. If the strictly-higher-rank groups already hold
@@ -1047,17 +1122,17 @@ while IFS=$'\t' read -r issue_num issue_pri issue_enh issue_catrank issue_cat; d
   # walk: each group's FIRST_ISSUE buckets are fed only by that group's own roots,
   # so the reorder leaves bucket contents byte-identical (the within-group
   # createdAt order is preserved).
-  cur_group="$issue_pri|$issue_enh|$issue_catrank"
+  cur_group="$issue_rank|$issue_enh|$issue_catrank"
   if [[ "$cur_group" != "$walk_prev_group" ]]; then
     if [[ -n "$walk_prev_group" ]]; then
-      walk_cum_emittable=$(( walk_cum_emittable + $(group_emittable_count "$walk_prev_cat" "$walk_prev_pri" "$walk_prev_enh") ))
+      walk_cum_emittable=$(( walk_cum_emittable + $(group_emittable_count "$walk_prev_cat" "$walk_prev_rank" "$walk_prev_enh") ))
     fi
     if (( walk_cum_emittable >= TOP )); then
       break
     fi
     walk_prev_group="$cur_group"
     walk_prev_cat="$issue_cat"
-    walk_prev_pri="$issue_pri"
+    walk_prev_rank="$issue_rank"
     walk_prev_enh="$issue_enh"
   fi
   # Skip an open issue already closed by a non-draft (ready) PR (#920).
@@ -1069,20 +1144,22 @@ while IFS=$'\t' read -r issue_num issue_pri issue_enh issue_catrank issue_cat; d
   if num_is_claimed "$issue_num"; then
     continue
   fi
-  # Category and priority bit both arrive precomputed from the sorted TSV
-  # (issue_cat / issue_pri), derived from the top-level help-wanted issue's own
-  # labels by the same expressions category_of_labels / has_priority_in_labels
-  # use. Once a (category, priority) bucket has a winner the remaining issues in
-  # it are skipped — including the expensive leaf trace.
-  # --priority-only scans only the priority=1 tier — skip non-priority issues
+  # Category, rank, and the priority bit all arrive precomputed from the sorted
+  # TSV (issue_cat / issue_rank / issue_pri), derived from the top-level
+  # help-wanted issue's own labels/rank by the same expressions category_of_labels
+  # / has_priority_in_labels / the rank map use. Once a (category, rank) bucket has
+  # a winner the remaining issues in it are skipped — including the expensive leaf
+  # trace. The priority bit (issue_pri) is now used ONLY for the --priority-only
+  # bypass filter below — it no longer affects ordering.
+  # --priority-only scans only priority-LABELED issues — skip non-priority issues
   # before the expensive dispatch-trace-leaf descent.
   [[ "$PRIORITY_ONLY" == "true" && "$issue_pri" != "1" ]] && continue
   # Coarse pre-trace skip: only when BOTH phase sub-buckets already hold TOP
   # entries is the expensive leaf trace pointless. If either implement or plan
   # slot is still under TOP, descend — the leaf's phase isn't known until after
   # the trace.
-  impl_bucket="$issue_cat|$issue_pri|$issue_enh|implement"
-  plan_bucket="$issue_cat|$issue_pri|$issue_enh|plan"
+  impl_bucket="$issue_cat|$issue_rank|$issue_enh|implement"
+  plan_bucket="$issue_cat|$issue_rank|$issue_enh|plan"
   if (( $(bucket_count FIRST_ISSUE "$impl_bucket") >= TOP )) \
      && (( $(bucket_count FIRST_ISSUE "$plan_bucket") >= TOP )); then
     continue
@@ -1172,7 +1249,7 @@ while IFS=$'\t' read -r issue_num issue_pri issue_enh issue_catrank issue_cat; d
       # (the cap subsumes the former first-seen guard).
       leaf_phase=plan
       [[ -n "${ISSUE_PLANNED[$leaf]:-}" ]] && leaf_phase=implement
-      leaf_bucket="$issue_cat|$issue_pri|$issue_enh|$leaf_phase"
+      leaf_bucket="$issue_cat|$issue_rank|$issue_enh|$leaf_phase"
       root_excl["$leaf"]=1
       if bucket_append FIRST_ISSUE "$leaf_bucket" "$leaf"; then
         root_recorded=$(( root_recorded + 1 ))
@@ -1204,42 +1281,43 @@ while IFS=$'\t' read -r issue_num issue_pri issue_enh issue_catrank issue_cat; d
   unset root_excl
 done <<< "$ISSUE_SORTED"
 
-# Default mode: priority is the outermost axis (1 then 0); the enhancement bit
-# nests inside it (non-enhancement enh=0 then enhancement enh=1) on the ISSUE
-# path only; topic category nests inside that; and the phase ladder runs
-# innermost (see the header for the full order). The entire priority=1 tier is
-# exhausted before any priority=0 item is considered; within one priority level
-# all non-enhancement work drains before any enhancement issue, then topic
-# category is the tie-break, and within each bucket the phase ladder runs
-# innermost. PRs are never enhancement-classified: FIRST_PR / qa buckets keep the
-# 3-part cat|pri|phase key and are drawn ONLY on the enh==0 pass, so a PR that has
-# already reached a phase completes normally rather than being re-deprioritized.
-# Resulting nesting: pri ⊃ enh ⊃ category ⊃ {PRs+qa if enh==0, then issues}.
+# Default mode: attention rank is the outermost axis (RANK_LEVELS, descending);
+# the enhancement bit nests inside it (non-enhancement enh=0 then enhancement
+# enh=1) on the ISSUE path only; topic category nests inside that; and the phase
+# ladder runs innermost (see the header for the full order). An entire rank level
+# is exhausted before any lower-rank item is considered; within one rank level all
+# non-enhancement work drains before any enhancement issue, then topic category is
+# the tie-break, and within each bucket the phase ladder runs innermost. PRs are
+# never enhancement-classified: FIRST_PR / qa buckets keep the 3-part cat|rank|phase
+# key and are drawn ONLY on the enh==0 pass, so a PR that has already reached a
+# phase completes normally rather than being re-deprioritized.
+# Resulting nesting: rank ⊃ enh ⊃ category ⊃ {PRs+qa if enh==0, then issues}.
 #
 # In --priority-only mode the scan loops above already `continue` on every
-# priority=0 item, so FIRST_PR/FIRST_ISSUE hold only priority=1 keys; the pri=0
-# pass below is then a guaranteed no-op (every lookup misses). It is left in the
-# shared loop rather than special-cased — the empty-map iteration is harmless
-# and keeps the default and --priority-only output paths identical.
+# non-priority-labeled item, so FIRST_PR/FIRST_ISSUE hold only priority-labeled
+# keys (at whatever ranks those items carry); iterating the full RANK_LEVELS below
+# simply skips the empty rank buckets. It is left in the shared loop rather than
+# special-cased — the empty-bucket iteration is harmless and keeps the default and
+# --priority-only output paths identical.
 if (( TOP == 1 )); then
   # TOP=1: emit the single highest-priority decision line and exit. Each bucket
   # holds at most one entry (no trailing newline), so the direct expansion below
   # is byte-identical to the former single-entry map's output.
-  for pri in 1 0; do
+  for rank_lvl in "${RANK_LEVELS[@]}"; do
     for enh in 0 1; do
       for category in "${CATEGORIES[@]}"; do
         # PRs (never enhancement-classified, 3-part key) are drawn only on the
         # enh==0 pass, so an in-flight PR completes ahead of any enhancement issue.
         if (( enh == 0 )); then
           for phase in "${PHASE_PRIORITY[@]}"; do
-            pr_key="$category|$pri|$phase"
+            pr_key="$category|$rank_lvl|$phase"
             if [[ -n "${FIRST_PR[$pr_key]:-}" ]]; then
               echo "pr ${FIRST_PR[$pr_key]} $phase"
               exit 0
             fi
           done
 
-          qa_key="$category|$pri|qa"
+          qa_key="$category|$rank_lvl|qa"
           if [[ -n "${FIRST_PR[$qa_key]:-}" ]]; then
             echo "pr ${FIRST_PR[$qa_key]} qa"
             exit 0
@@ -1247,7 +1325,7 @@ if (( TOP == 1 )); then
         fi
 
         for iphase in "${ISSUE_PHASE_PRIORITY[@]}"; do
-          issue_key="$category|$pri|$enh|$iphase"
+          issue_key="$category|$rank_lvl|$enh|$iphase"
           if [[ -n "${FIRST_ISSUE[$issue_key]:-}" ]]; then
             echo "issue ${FIRST_ISSUE[$issue_key]}"
             exit 0
@@ -1295,23 +1373,23 @@ else
     return 0
   }
 
-  for pri in 1 0; do
+  for rank_lvl in "${RANK_LEVELS[@]}"; do
     for enh in 0 1; do
       for category in "${CATEGORIES[@]}"; do
         # PRs (never enhancement-classified, 3-part key) are drained only on the
         # enh==0 pass, so in-flight PRs complete ahead of any enhancement issue.
         if (( enh == 0 )); then
           for phase in "${PHASE_PRIORITY[@]}"; do
-            drain_bucket FIRST_PR "$category|$pri|$phase" pr "$phase"
+            drain_bucket FIRST_PR "$category|$rank_lvl|$phase" pr "$phase"
             (( ${#results[@]} >= TOP )) && { printf '%s\n' "${results[@]}"; exit 0; }
           done
 
-          drain_bucket FIRST_PR "$category|$pri|qa" pr qa
+          drain_bucket FIRST_PR "$category|$rank_lvl|qa" pr qa
           (( ${#results[@]} >= TOP )) && { printf '%s\n' "${results[@]}"; exit 0; }
         fi
 
         for iphase in "${ISSUE_PHASE_PRIORITY[@]}"; do
-          drain_bucket FIRST_ISSUE "$category|$pri|$enh|$iphase" issue ""
+          drain_bucket FIRST_ISSUE "$category|$rank_lvl|$enh|$iphase" issue ""
           (( ${#results[@]} >= TOP )) && { printf '%s\n' "${results[@]}"; exit 0; }
         done
       done

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -423,8 +423,8 @@ refresh_lock
 # (claude_agents_count_busy_workers + reservation_count), not busy workers alone
 # — a reservation counts against the budget the instant it is written, with no
 # wait for worker registration. Under cap: GAP bounds how many workers a fan-out
-# run may spawn, and normal selection (Step 3) already runs priority-first, so a
-# priority item under budget is handled there. Daemon UNKNOWN (the busy-worker
+# run may spawn, and normal selection (Step 3) already runs rank-first, so a
+# high-rank item under budget is handled there. Daemon UNKNOWN (the busy-worker
 # read fails; reservation_count never fails) → fail open (GAP=1); the
 # per-worktree dedup in dispatch-spawn-job is the last-line defense.
 #
@@ -507,7 +507,8 @@ if [[ -z "$MANUAL" && -z "$ARG" ]]; then
         echo "concurrency-cap"
         exit 0
       fi
-      # Not exhausted: probe the priority tier only (JIT output suppressed). The
+      # Not exhausted: probe the priority-LABELED bypass items only (JIT output
+      # suppressed; the `priority` label = cap bypass, not ordering). The
       # main-broken health gate runs first inside --priority-only, so a main that
       # broke WHILE at cap is now surfaced (the old early-exit fired before any
       # selection ran).
@@ -587,12 +588,13 @@ elif [[ -n "$MANUAL" ]]; then
   # out) but HONORS the genuine rate-limit floor (--exhausted) and the ceiling:
   #   HEADROOM = max(0, MAX_WORKERS − LIVE_COUNT)   absolute ceiling
   #   GAP      = max(0, TARGET_N − LIVE_COUNT)      pace-curve budget gap
-  #   N_PRIO   = count of selectable priority=1 targets, capped at HEADROOM
+  #   N_PRIO   = count of selectable priority-LABELED (bypass) targets, capped at HEADROOM
   #   SPAWN_N  = min(HEADROOM, max(N_PRIO, GAP, 1))
-  # Priority and gap combine as a max (union), not additive buckets, so the
-  # total is capped at MAX_WORKERS. The fan-out itself runs priority-first
-  # through dispatch-materialize-spawn's existing --gap N machinery (the
-  # priority=1 tier is globally exhausted first). LIVE_COUNT mirrors the
+  # The priority bypass and gap combine as a max (union), not additive buckets, so
+  # the total is capped at MAX_WORKERS. The fan-out itself runs rank-first through
+  # dispatch-materialize-spawn's existing --gap N machinery (the highest rank level
+  # is globally exhausted first; the `priority` label is the cap bypass, not an
+  # ordering signal). LIVE_COUNT mirrors the
   # autonomous block's effective-live count (busy workers + reservations); the
   # manual path does NOT sweep the reservation ledger (a possibly-stale count
   # can only make manual fan-out more conservative, which is safe).
@@ -634,9 +636,9 @@ elif [[ -n "$MANUAL" ]]; then
     fi
     GAP_BUDGET=$(( TARGET_N - LIVE_COUNT ))
     (( GAP_BUDGET < 0 )) && GAP_BUDGET=0
-    # N_PRIO: count selectable priority=1 targets, capped at HEADROOM via --top.
-    # Only `pr`/`issue` lines count; `waiting` / `empty` / `main-broken` are 0
-    # (CI-pending priority items are not selectable — keeps N_PRIO consistent
+    # N_PRIO: count selectable priority-LABELED (bypass) targets, capped at HEADROOM
+    # via --top. Only `pr`/`issue` lines count; `waiting` / `empty` / `main-broken`
+    # are 0 (CI-pending priority items are not selectable — keeps N_PRIO consistent
     # with #1448's CI-cadence reseed instead of double-counting against it).
     N_PRIO=0
     PRIO_LINES=$("$SCRIPT_DIR/dispatch-select-target" --priority-only --top "$HEADROOM") || PRIO_LINES=""

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -18,7 +18,7 @@
 # tick is launched by systemd (the #725 heartbeat) and by the worker Stop-hook in
 # a later unit; it runs bare and keeps the concurrency gate. A human-typed
 # `dispatch` runs one tick as foreground bash, passing `--manual` to spawn a
-# context-dependent SPAWN_N workers (priority-first), exempt from the pace-curve
+# context-dependent SPAWN_N workers (rank-first), exempt from the pace-curve
 # throttle but bounded by the `MAX_WORKERS` ceiling and the `--exhausted` floor.
 # The audit record is this script's journal output
 # (every captured stdout line is echoed through) plus the spawned workers'
@@ -34,7 +34,8 @@
 #   `dispatch` (bare, no argument): skips the pace-curve throttle (a budget pause
 #   to TARGET_N=0 still fans out) but honors the `MAX_WORKERS` ceiling and the
 #   `--exhausted` hard floor; spawns SPAWN_N = min(HEADROOM, max(N_PRIO, GAP, 1))
-#   workers, priority-first (the highest-priority queue targets). Emits
+#   workers, rank-first (the highest-rank queue targets; the `priority` label is
+#   the pace-curve/cap bypass, not an ordering signal). Emits
 #   `concurrency-cap` when SPAWN_N=0 (at the ceiling or exhausted).
 #
 #   Exhaustion hard floor (both autonomous and manual paths): when the 5-hour or
@@ -51,7 +52,8 @@
 #   `LIVE_COUNT >= TARGET_N` but `--exhausted` reports `ok`, the tick does NOT
 #   immediately emit `concurrency-cap`. Instead it runs
 #   `dispatch-select-target --priority-only`, which checks the main-broken health
-#   gate first, then scans only the `priority=1` queue tier. If a
+#   gate first, then scans only priority-LABELED items (the label's one surviving
+#   meaning — the cap/pacing bypass, not ordering). If a
 #   `priority`-labeled PR or help-wanted issue (including any `dispatch:main-broken`
 #   issue) is found, the tick holds the lock and spawns exactly ONE gate-exempt
 #   worker (`GAP=1`) — the same treatment as an explicit `dispatch <N>`. This also closes

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-trace-leaf
@@ -6,6 +6,12 @@
 # lowest-numbered open child first, to find the lowest-numbered reachable
 # open leaf. Prints one issue number.
 #
+# Blocking is a tactic-layer gate: while a node has ANY open blocker, ONLY the
+# blocking subtree is descended — its sub-issues stay unreachable until every
+# blocker closes (open_children returns the open blockers alone and suppresses
+# sub-issue gathering). A node's sub-issues become reachable only once all its
+# blockers close.
+#
 # The optional --exclude <n>... argument names already-processed leaves the
 # trace must never return (#1062). It is the fan-out caller's running SEEN set:
 # a multi-leaf subtree whose first leaf was already spawned (and whose worktree
@@ -209,6 +215,20 @@ open_children() {
     while IFS= read -r num; do
       [[ -n "$num" ]] && children+=("$num")
     done < <(printf '%s' "$blocker_json" | jq -r 'select(.state == "OPEN" or .state == "open") | .number' 2>/dev/null || true)
+  fi
+
+  # Blocking is a tactic-layer gate: an open blocker makes this node's WHOLE
+  # subtree unreachable until every blocker closes. If any open blocker was
+  # collected, descend ONLY the blocking subtree — print the blockers and return
+  # WITHOUT gathering sub-issues, so a sub-issue (even a lower-numbered one) can
+  # never be reached past an open blocker. Once all blockers close, `children`
+  # is empty here and the sub-issue gathering below runs normally. When the
+  # blocking subtree's startable leaves are all claimed/parked, find_leaf on this
+  # node returns 1 (nothing) rather than falling through to sub-issues — the gate
+  # holds until blockers close.
+  if [[ ${#children[@]} -gt 0 ]]; then
+    printf '%s\n' "${children[@]}" | sort -un
+    return 0
   fi
 
   # Gather open sub-issues. Same hard-error contract as the blocker lookup.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -193,6 +193,15 @@ STUB
   # stays green; a reserved-skip test creates a marker file here to opt in.
   export DISPATCH_RESERVATION_DIR="$TMPDIR_TEST/reservations"
 
+  # Attention-rank map seam (Attention v2). Default to the all-zero baseline: an
+  # empty map means every candidate sits at rank 0, so the rank axis degenerates
+  # to a single level and the existing enh → topic-category → phase tie-break
+  # ladder decides everything — byte-identical to pre-rank behavior for any queue
+  # with no priority-labeled items. A rank test overrides this per-test to opt in.
+  # The seam short-circuits the `npx tsx rank-map.ts` load, so no test touches the
+  # intentions/ store or needs a git repo under TMPDIR_TEST.
+  export DISPATCH_RANK_MAP_JSON='{}'
+
   # dispatch-select-target calls dispatch-phase as "$SCRIPT_DIR/dispatch-phase".
   # Since we copied them all to TMPDIR_TEST, SCRIPT_DIR inside each copy will
   # resolve to TMPDIR_TEST correctly.
@@ -1203,6 +1212,9 @@ teardown() {
   unset DISPATCH_AGENTS_SNAPSHOT DISPATCH_TRACE_CACHE_DIR
   # The reservation-ledger override (#1046) must not leak across tests either.
   unset DISPATCH_RESERVATION_DIR
+  # The attention-rank seam (Attention v2) must not leak either — a per-test rank
+  # override would otherwise poison the next test's baseline.
+  unset DISPATCH_RANK_MAP_JSON
 }
 trap '[ -n "${TMPDIR_TEST:-}" ] && rm -rf "$TMPDIR_TEST"' EXIT
 
@@ -5204,11 +5216,13 @@ assert_eq "issue 6 not masked by 60-foo worktree" "issue 6" "$result"
 teardown
 
 # --- topic-category prioritization (issue #707) -----------------------------
-# The `priority` label is the outermost axis: every `priority` item ranks above
-# every non-priority item, regardless of topic. Topic category
-# (security → bug → testing infrastructure → dispatch → landing → fellspiral → budget → print → audio → other) nests inside the priority
-# axis, and the phase ladder runs innermost. A PR's category is resolved from
-# the labels of the issues it closes; an issue's category from its own labels.
+# Attention v2: attention rank is the outermost axis — every higher-rank item
+# ranks above every lower-rank item, regardless of topic (rank supplied via the
+# DISPATCH_RANK_MAP_JSON seam). Topic category
+# (security → bug → testing infrastructure → dispatch → landing → fellspiral → budget → print → audio → other) nests inside the rank
+# axis (below the enh bit), and the phase ladder runs innermost. A PR's category
+# is resolved from the labels of the issues it closes; an issue's category from
+# its own labels. The `priority` label no longer orders (cap/pacing bypass only).
 
 # 28. A PR closing a `bug` issue outranks a PR closing a `dispatch` issue, even
 #     when the dispatch PR is older — category beats age.
@@ -5258,75 +5272,80 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "PR with no closing issue is 'other'; bug issue wins" "issue 500" "$result"
 teardown
 
-# 30b. A PR closing a `priority`-only issue outranks a PR closing a plain `bug`
-#      issue — `priority` is the outermost axis, so a `priority` item in topic
-#      `other` ranks above a non-priority `bug` item. The priority-only-closing
-#      PR wins even though it is newer and its topic (`other`) is lower-ranked.
-echo "Test: PR closing a priority-only issue beats PR closing a bug issue"
+# 30b. A PR closing a rank-2 (untopiced) issue outranks a PR closing a plain
+#      `bug` issue — attention rank is the outermost axis, so a ranked item in
+#      topic `other` ranks above an unranked `bug` item. The ranked-closing PR
+#      wins even though it is newer and its topic (`other`) is lower-ranked.
+echo "Test: PR closing a rank-2 issue beats PR closing a bug issue"
 setup
-# PR 20 (older) closes bug issue 200; PR 10 (newer) closes priority-only issue 100.
+export DISPATCH_RANK_MAP_JSON='{"100": 2}'
+# PR 20 (older) closes bug issue 200; PR 10 (newer) closes rank-2 issue 100.
 UNION='['
 UNION+="$(make_pr_union 20 "20-bug-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
-UNION+="$(make_pr_union 10 "10-priority-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100}]')"
+UNION+="$(make_pr_union 10 "10-ranked-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100}]')"
 UNION+=']'
 setup_union_pr_list "$UNION"
-# Issues 100/200 are the closing issues — they carry the topic label that the
-# PRs inherit. No "help wanted" label, so they are not themselves queue items.
-printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"priority"}]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
+# Issues 100/200 are the closing issues — 100 is untopiced (rank 2 via the map),
+# 200 carries `bug`. No "help wanted" label, so they are not themselves queue items.
+printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
   > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "priority-only-closing PR beats bug-closing PR" "pr 10 10-priority-pr fix-checks" "$result"
+assert_eq "rank-2-closing PR beats bug-closing PR" "pr 10 10-ranked-pr fix-checks" "$result"
 teardown
 
-# 30c. A PR closing a `(bug, priority)` issue outranks a PR closing a plain
-#      `bug` issue, even when the plain-bug PR is older — `priority` is the
-#      outermost axis, so both PRs share topic `bug` and the `priority` one
-#      wins. Topic category is the tie-break only within one priority level.
-echo "Test: PR closing a (bug, priority) issue beats PR closing a plain bug issue"
+# 30c. A PR closing a rank-2 `bug` issue outranks a PR closing an unranked `bug`
+#      issue, even when the unranked-bug PR is older — attention rank is the
+#      outermost axis, so both PRs share topic `bug` and the higher-ranked one
+#      wins. Topic category is the tie-break only within one rank level.
+echo "Test: PR closing a rank-2 bug issue beats PR closing an unranked bug issue"
 setup
-# PR 20 (older) closes plain bug issue 200; PR 10 (newer) closes (bug, priority) issue 100.
+export DISPATCH_RANK_MAP_JSON='{"100": 2}'
+# PR 20 (older) closes unranked bug issue 200; PR 10 (newer) closes rank-2 bug issue 100.
 UNION='['
 UNION+="$(make_pr_union 20 "20-bug-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
-UNION+="$(make_pr_union 10 "10-bug-priority-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100}]')"
+UNION+="$(make_pr_union 10 "10-bug-ranked-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100}]')"
 UNION+=']'
 setup_union_pr_list "$UNION"
-# Issue 100 carries both `bug` and `priority`; issue 200 carries only `bug`.
-printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"},{"name":"priority"}]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
+# Issue 100 carries `bug` and is rank 2 via the map; issue 200 carries only `bug`.
+printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
   > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "(bug, priority)-closing PR beats plain-bug-closing PR" "pr 10 10-bug-priority-pr fix-checks" "$result"
+assert_eq "rank-2-bug-closing PR beats unranked-bug-closing PR" "pr 10 10-bug-ranked-pr fix-checks" "$result"
 teardown
 
-# 30d. A PR closing a `(dispatch, priority)` issue outranks a PR closing a plain
-#      `bug` issue — `priority` is the outermost axis, so it crosses topic
-#      boundaries: a `priority` item in topic `dispatch` lifts above a
-#      non-priority `bug` item. The (dispatch, priority)-closing PR wins.
-echo "Test: PR closing a (dispatch, priority) issue beats PR closing a plain bug issue"
+# 30d. A PR closing a rank-2 `dispatch` issue outranks a PR closing an unranked
+#      `bug` issue — attention rank is the outermost axis, so it crosses topic
+#      boundaries: a ranked item in topic `dispatch` lifts above an unranked
+#      `bug` item. The rank-2 dispatch-closing PR wins.
+echo "Test: PR closing a rank-2 dispatch issue beats PR closing an unranked bug issue"
 setup
-# PR 10 (older) closes (dispatch, priority) issue 100; PR 20 (newer) closes plain bug issue 200.
+export DISPATCH_RANK_MAP_JSON='{"100": 2}'
+# PR 10 (older) closes rank-2 dispatch issue 100; PR 20 (newer) closes unranked bug issue 200.
 UNION='['
-UNION+="$(make_pr_union 10 "10-dispatch-priority-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100}]')"','
+UNION+="$(make_pr_union 10 "10-dispatch-ranked-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100}]')"','
 UNION+="$(make_pr_union 20 "20-bug-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"
 UNION+=']'
 setup_union_pr_list "$UNION"
-# Issue 100 carries both `dispatch` and `priority`; issue 200 carries only `bug`.
-printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"dispatch"},{"name":"priority"}]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
+# Issue 100 carries `dispatch` and is rank 2 via the map; issue 200 carries only `bug`.
+printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"dispatch"}]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"bug"}]}]\n' \
   > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "(dispatch, priority) PR beats plain-bug PR — priority crosses topics" "pr 10 10-dispatch-priority-pr fix-checks" "$result"
+assert_eq "rank-2 dispatch PR beats unranked-bug PR — rank crosses topics" "pr 10 10-dispatch-ranked-pr fix-checks" "$result"
 teardown
 
-# 30e. The 2026-05-29 reproduction (#905). A queue of bug+priority PRs, all but
-#      one carrying an *orphan* worktree, alongside a lower-priority bug
-#      help-wanted issue with no worktree. Before the fix the orphan worktrees
-#      skipped every priority PR and the selector fell through to the
-#      help-wanted issue, violating the priority order. After the fix only the
-#      live-session-owned PR (#898) is skipped; the oldest remaining
-#      review-phase priority PR (#895) wins.
-echo "Test: orphan-worktree bug+priority PRs still beat a no-worktree help-wanted issue (#905)"
+# 30e. The 2026-05-29 reproduction (#905). A queue of bug PRs, all but one
+#      carrying an *orphan* worktree, alongside a bug help-wanted issue with no
+#      worktree. Before the #905 fix the orphan worktrees skipped every PR and the
+#      selector fell through to the help-wanted issue, violating phase order.
+#      After the fix only the live-session-owned PR (#898) is skipped; the oldest
+#      remaining review-phase PR (#895) wins. Attention v2: all PRs and the issue
+#      sit at rank 0 (same bucket), so the within-bucket phase ladder (review
+#      before qa before issue) decides — the #905 orphan-not-skipped behavior is
+#      what this test guards, orthogonal to rank.
+echo "Test: orphan-worktree bug PRs still beat a no-worktree help-wanted issue (#905)"
 setup
 UNION='['
 UNION+="$(make_pr_union 898 "898-review" "2026-05-20T00:00:00Z" "true" '[{"name":"dispatch:qa-done"}]' "$GREEN_ROLLUP" '[{"number":896}]')"','
@@ -5335,9 +5354,9 @@ UNION+="$(make_pr_union 893 "893-qa" "2026-05-22T00:00:00Z" "true" "$NO_LABELS" 
 UNION+="$(make_pr_union 883 "883-qa" "2026-05-23T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP" '[{"number":879}]')"
 UNION+=']'
 setup_union_pr_list "$UNION"
-# Each PR's closing issue carries bug + priority; issue 886 is a lower-priority
-# (no `priority`) bug help-wanted issue with no worktree.
-printf '%s\n' '[{"number":896,"created_at":"2026-05-01T00:00:00Z","labels":[{"name":"bug"},{"name":"priority"}]},{"number":806,"created_at":"2026-05-01T00:00:00Z","labels":[{"name":"bug"},{"name":"priority"}]},{"number":892,"created_at":"2026-05-01T00:00:00Z","labels":[{"name":"bug"},{"name":"priority"}]},{"number":879,"created_at":"2026-05-01T00:00:00Z","labels":[{"name":"bug"},{"name":"priority"}]},{"number":886,"created_at":"2026-05-02T00:00:00Z","labels":[{"name":"bug"},{"name":"help wanted"}]}]' \
+# Each PR's closing issue is a plain `bug` (rank 0); issue 886 is a `bug`
+# help-wanted issue with no worktree — all in the same rank-0 `bug` bucket.
+printf '%s\n' '[{"number":896,"created_at":"2026-05-01T00:00:00Z","labels":[{"name":"bug"}]},{"number":806,"created_at":"2026-05-01T00:00:00Z","labels":[{"name":"bug"}]},{"number":892,"created_at":"2026-05-01T00:00:00Z","labels":[{"name":"bug"}]},{"number":879,"created_at":"2026-05-01T00:00:00Z","labels":[{"name":"bug"}]},{"number":886,"created_at":"2026-05-02T00:00:00Z","labels":[{"name":"bug"},{"name":"help wanted"}]}]' \
   > "$STUB_DIR/issue-list.json"
 # Worktrees exist for all four PR branches; none for issue 886.
 printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/898-review\nHEAD a1\nbranch refs/heads/898-review\n\nworktree /worktrees/895-review\nHEAD a2\nbranch refs/heads/895-review\n\nworktree /worktrees/893-qa\nHEAD a3\nbranch refs/heads/893-qa\n\nworktree /worktrees/883-qa\nHEAD a4\nbranch refs/heads/883-qa\n\n' \
@@ -5345,7 +5364,7 @@ printf 'worktree /repo\nHEAD abc123\n\nworktree /worktrees/898-review\nHEAD a1\n
 # Only #898's worktree has a live session; #895/#893/#883 are orphans.
 select_target_fake_claude "898-review"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "orphan priority PRs not skipped; oldest review priority PR wins" "pr 895 895-review review" "$result"
+assert_eq "orphan PRs not skipped; oldest review PR wins" "pr 895 895-review review" "$result"
 teardown
 
 # 30f. A PR closing a `security` issue outranks a PR closing a `bug` issue, even
@@ -5368,23 +5387,24 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "security-closing PR beats bug-closing PR" "pr 10 10-security-pr fix-checks" "$result"
 teardown
 
-# 30g. A PR closing a `(security, priority)` issue outranks a PR closing a plain
-#      `security` issue — `priority` is the outermost axis, so both PRs share
-#      topic `security` and the `priority` one wins.
-echo "Test: PR closing a (security, priority) issue beats PR closing a plain security issue"
+# 30g. A PR closing a rank-2 `security` issue outranks a PR closing an unranked
+#      `security` issue — attention rank is the outermost axis, so both PRs share
+#      topic `security` and the higher-ranked one wins.
+echo "Test: PR closing a rank-2 security issue beats PR closing an unranked security issue"
 setup
-# PR 20 (older) closes plain security issue 200; PR 10 (newer) closes (security, priority) issue 100.
+export DISPATCH_RANK_MAP_JSON='{"100": 2}'
+# PR 20 (older) closes unranked security issue 200; PR 10 (newer) closes rank-2 security issue 100.
 UNION='['
 UNION+="$(make_pr_union 20 "20-security-pr" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
-UNION+="$(make_pr_union 10 "10-security-priority-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100}]')"
+UNION+="$(make_pr_union 10 "10-security-ranked-pr" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100}]')"
 UNION+=']'
 setup_union_pr_list "$UNION"
-# Issue 100 carries both `security` and `priority`; issue 200 carries only `security`.
-printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"security"},{"name":"priority"}]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"security"}]}]\n' \
+# Issue 100 carries `security` and is rank 2 via the map; issue 200 carries only `security`.
+printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"security"}]},{"number":200,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"security"}]}]\n' \
   > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "(security, priority)-closing PR beats plain-security-closing PR" "pr 10 10-security-priority-pr fix-checks" "$result"
+assert_eq "rank-2-security-closing PR beats unranked-security-closing PR" "pr 10 10-security-ranked-pr fix-checks" "$result"
 teardown
 
 # 30h. A help-wanted `security` issue outranks a help-wanted issue with no topic
@@ -5631,22 +5651,23 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "security+enh beats audio+enh (topic ladder within enh tier)" "issue 100" "$result"
 teardown
 
-# ENH3. Criterion 3 — cross-axis: priority is the outermost axis. A
-#       `priority`+`enhancement`+`audio` issue (pri=1, enh=1, low topic) beats
-#       a plain `security` issue (pri=0, enh=0, high topic). Priority outermost
-#       means a priority enhancement still jumps the queue over all non-priority
-#       work regardless of enhancement or topic.
-echo "Test: priority+enhancement+audio beats non-priority non-enhancement security (priority is outermost)"
+# ENH3. Criterion 3 — cross-axis: attention rank is the outermost axis. A
+#       rank-2 `enhancement`+`audio` issue (rank=2, enh=1, low topic) beats a
+#       rank-0 `security` issue (rank=0, enh=0, high topic). Rank outermost means
+#       a ranked enhancement still jumps the queue over all lower-ranked work
+#       regardless of enhancement or topic.
+echo "Test: rank-2+enhancement+audio beats rank-0 non-enhancement security (rank is outermost)"
 setup
+export DISPATCH_RANK_MAP_JSON='{"100": 2}'
 setup_union_pr_list '[]'
-# Issue 100 (older): priority+enhancement+audio (pri=1, enh=1, topic=audio).
-# Issue 200 (newer): security (pri=0, enh=0, topic=security).
-# Despite enhancement and low topic, issue 100 wins because priority is outermost.
-printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"},{"name":"enhancement"},{"name":"audio"}]},{"number":200,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"security"}]}]\n' \
+# Issue 100 (older): rank-2+enhancement+audio (rank=2, enh=1, topic=audio).
+# Issue 200 (newer): security (rank=0, enh=0, topic=security).
+# Despite enhancement and low topic, issue 100 wins because rank is outermost.
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"enhancement"},{"name":"audio"}]},{"number":200,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"security"}]}]\n' \
   > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "priority+enh+audio beats non-priority security (priority outermost)" "issue 100" "$result"
+assert_eq "rank-2+enh+audio beats rank-0 security (rank outermost)" "issue 100" "$result"
 teardown
 
 # ENH4. Regression guard — bug/security ordering within non-enh tier unchanged:
@@ -5722,6 +5743,147 @@ printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"enh
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
 assert_eq "--qa: enh-closing PR 10 wins on age (PRs not enh-classified)" "pr 10 10-enh-qa" "$result"
+teardown
+
+# --- attention-rank ordering (Attention v2) ---------------------------------
+# Attention rank is the OUTERMOST ordering axis: distinct rank values drain
+# descending, with the existing enh → topic-category → phase ladder as the
+# tie-break WITHIN each rank level. Ranks are supplied via the DISPATCH_RANK_MAP_JSON
+# seam (issue number → rank). The `priority` label no longer orders anything; it
+# survives only as the cap/pacing bypass (--priority-only).
+
+# RANK1. A ranked issue beats an older unranked issue — rank is outermost, so age
+#        does not save the rank-0 item.
+echo "Test: RANK1 — ranked issue beats older unranked issue"
+setup
+export DISPATCH_RANK_MAP_JSON='{"100": 3}'
+setup_union_pr_list '[]'
+# Issue 200 (older) is unranked (rank 0); issue 100 (newer) is rank 3.
+printf '[{"number":200,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":100,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "RANK1 — rank-3 issue 100 beats older unranked issue 200" "issue 100" "$result"
+teardown
+
+# RANK2. Float rank levels and multi-level drain. --top 3 emits the rank-4 issue,
+#        then the rank-0.25 issue, then the unranked (rank-0) issue — proving both
+#        the descending multi-level drain AND float bucket keys.
+echo "Test: RANK2 — float rank levels drain descending under --top 3"
+setup
+export DISPATCH_RANK_MAP_JSON='{"10": 4, "20": 0.25}'
+setup_union_pr_list '[]'
+# Three untopiced help-wanted issues: 10 (rank 4), 20 (rank 0.25), 30 (rank 0).
+# createdAt is irrelevant to ordering here since each sits at a distinct rank.
+printf '[{"number":10,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":20,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":30,"createdAt":"2024-01-03T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --top 3)
+assert_eq "RANK2 — float levels drain 4 → 0.25 → 0" "$(printf 'issue 10\nissue 20\nissue 30')" "$result"
+teardown
+
+# RANK3. A PR inherits the MAX rank over the issues it closes. PR 10 closes a
+#        rank-1 and a rank-5 issue (inherits 5); PR 20 (older) closes a rank-3
+#        issue. PR 10 outranks PR 20 despite being newer.
+echo "Test: RANK3 — PR inherits max rank over closing issues"
+setup
+export DISPATCH_RANK_MAP_JSON='{"100": 1, "101": 5, "200": 3}'
+UNION='['
+UNION+="$(make_pr_union 20 "20-single" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":200}]')"','
+UNION+="$(make_pr_union 10 "10-multi" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$FAILING_ROLLUP" '[{"number":100},{"number":101}]')"
+UNION+=']'
+setup_union_pr_list "$UNION"
+# Closing issues supply rank only (no help wanted — not queue items themselves).
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[]},{"number":101,"createdAt":"2024-01-01T00:00:00Z","labels":[]},{"number":200,"createdAt":"2024-01-01T00:00:00Z","labels":[]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "RANK3 — PR 10 (inherits max rank 5) beats older PR 20 (rank 3)" "pr 10 10-multi fix-checks" "$result"
+teardown
+
+# RANK4. Regression: the `priority` label is DE-ORDERED. A priority-labeled but
+#        unranked (rank 0) issue does NOT outrank a ranked non-priority issue.
+echo "Test: RANK4 — priority label does not outrank a ranked non-priority item"
+setup
+export DISPATCH_RANK_MAP_JSON='{"200": 2}'
+setup_union_pr_list '[]'
+# Issue 100 (older): priority label, rank 0. Issue 200 (newer): no priority, rank 2.
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"}]},{"number":200,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target")
+assert_eq "RANK4 — rank-2 issue 200 beats older priority-labeled rank-0 issue 100" "issue 200" "$result"
+teardown
+
+# RANK5. Rank tie → the within-level ladder is intact: enh → topic-category →
+#        phase → oldest. Mirrors ENH5 with all four issues at an EQUAL rank, so
+#        the tie-break ladder alone decides the order.
+echo "Test: RANK5 — equal ranks fall through to the enh/category/age tie-break ladder"
+setup
+export DISPATCH_RANK_MAP_JSON='{"10":2,"20":2,"30":2,"40":2}'
+setup_union_pr_list '[]'
+# All rank 2: 30 (security, enh=0), 20 (audio, enh=0), 10 (security, enh=1),
+# 40 (audio, enh=1). Expected order 30 → 20 → 10 → 40 (all non-enh before any enh).
+printf '[{"number":30,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"security"}]},{"number":20,"createdAt":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"audio"}]},{"number":10,"createdAt":"2024-01-03T00:00:00Z","labels":[{"name":"help wanted"},{"name":"security"},{"name":"enhancement"}]},{"number":40,"createdAt":"2024-01-04T00:00:00Z","labels":[{"name":"help wanted"},{"name":"audio"},{"name":"enhancement"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --top 4)
+assert_eq "RANK5 — equal ranks → enh/category/age ladder (30 20 10 40)" "$(printf 'issue 30\nissue 20\nissue 10\nissue 40')" "$result"
+teardown
+
+# RANK6. --qa mode orders by rank: the newer QA PR wins because its closing issue
+#        outranks the older QA PR's closing issue.
+echo "Test: RANK6 — --qa orders by rank"
+setup
+export DISPATCH_RANK_MAP_JSON='{"200": 5}'
+UNION='['
+UNION+="$(make_pr_union 10 "10-qa" "2024-01-01T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP" '[{"number":100}]')"','
+UNION+="$(make_pr_union 20 "20-qa" "2024-01-02T00:00:00Z" "true" "$NO_LABELS" "$GREEN_ROLLUP" '[{"number":200}]')"
+UNION+=']'
+setup_union_pr_list "$UNION"
+# Issue 100 unranked (rank 0); issue 200 rank 5. Neither is help wanted.
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[]},{"number":200,"createdAt":"2024-01-01T00:00:00Z","labels":[]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --qa)
+assert_eq "RANK6 — --qa: rank-5 PR 20 beats older rank-0 PR 10" "pr 20 20-qa" "$result"
+teardown
+
+# RANK7. Fail closed (clear-errors rule): a rank map that is not a JSON object of
+#        numbers exits 1 loudly — never an all-zero fallback that silently reorders.
+echo "Test: RANK7 — invalid rank map → exit 1 with clear error"
+setup
+setup_union_pr_list '[]'
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+export DISPATCH_RANK_MAP_JSON='[]'
+err_out=$("$TMPDIR_TEST/dispatch-select-target" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err_out" in
+  *"rank map is not a JSON object of numbers"*"EXIT=1") status_arr="ok" ;;
+  *) status_arr="bad: $err_out" ;;
+esac
+assert_eq "RANK7 — array rank map → exit 1" "ok" "$status_arr"
+export DISPATCH_RANK_MAP_JSON='{"5":"x"}'
+err_out=$("$TMPDIR_TEST/dispatch-select-target" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err_out" in
+  *"rank map is not a JSON object of numbers"*"EXIT=1") status_str="ok" ;;
+  *) status_str="bad: $err_out" ;;
+esac
+assert_eq "RANK7 — non-number-valued rank map → exit 1" "ok" "$status_str"
+teardown
+
+# RANK8. --priority-only bypass is orthogonal to rank: it still returns a
+#        priority-labeled rank-0 item (the label survives as the cap bypass).
+echo "Test: RANK8 — --priority-only returns a priority-labeled rank-0 item"
+setup
+export DISPATCH_RANK_MAP_JSON='{}'
+setup_union_pr_list '[]'
+printf '[{"number":100,"createdAt":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"}]}]\n' \
+  > "$STUB_DIR/issue-list.json"
+printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
+result=$("$TMPDIR_TEST/dispatch-select-target" --priority-only)
+assert_eq "RANK8 — --priority-only selects priority rank-0 issue 100 (bypass orthogonal to rank)" "issue 100" "$result"
 teardown
 
 # --- blocked-issue PR skip (issue #786) -------------------------------------
@@ -6074,14 +6236,14 @@ teardown
 
 # --- --top N: single-pass multi-target selection (#1317) ---------------------
 # `--top N` emits up to N DISTINCT ranked decision lines in ONE queue scan,
-# preserving the existing priority order (priority axis 1→0, then topic category,
-# then the phase ladder), oldest-first within a bucket — replacing the old
-# once-per-slot serialized selector calls. `--top 1` is byte-identical to the
+# preserving the rank order (attention-rank desc, then enhancement, then topic
+# category, then the phase ladder), oldest-first within a bucket — replacing the
+# old once-per-slot serialized selector calls. `--top 1` is byte-identical to the
 # no-flag call. These run end-to-end through the real trace/ci-ready/phase copies.
 
-# T1. --top N returns N distinct ranked lines across buckets, in the priority-
-#     axis → topic-category → phase order. Three help-wanted issues, all
-#     priority 0, no PRs (so all in `plan` phase) but in DIFFERENT topic
+# T1. --top N returns N distinct ranked lines across buckets, in the attention-
+#     rank → topic-category → phase order. Three help-wanted issues, all
+#     rank 0, no PRs (so all in `plan` phase) but in DIFFERENT topic
 #     categories: 30 (security) → 20 (bug) → 10 (no topic = other). The category
 #     order is the only discriminator, so the output is deterministically
 #     security, bug, other regardless of issue-number or createdAt order.
@@ -6384,7 +6546,7 @@ echo "Test: default mode — done-ready leaf skipped, next eligible issue select
 setup
 UNION='['"$(make_pr_union 100 "100-foo" "2024-01-01T00:00:00Z" "false" "$NO_LABELS" "$GREEN_ROLLUP")"']'
 setup_union_pr_list "$UNION"
-printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"}]},{"number":200,"created_at":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"}]}]\n' \
+printf '[{"number":100,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":200,"created_at":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
   > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
@@ -6584,53 +6746,53 @@ setup_ancestor_priority_fixture() {
   fi
 }
 
-# PO-ANC1. A PR whose closing issue carries NO own `priority` label, but whose
-#           ancestor epic IS open and carries `priority`, is lifted into the
-#           priority tier via ancestor inheritance (#1914). In DEFAULT mode this
-#           PR (priority-via-ancestor) outranks an older PR whose closing issue
-#           carries `bug` but no priority. The priority axis is the outermost
-#           sort key, so the inherited-priority PR wins regardless of topic
-#           category or creation order.
+# PO-ANC1. Attention v2 converts this to a direct PR-rank-inheritance test.
+#           Historically (#1914) this proved ancestor-`priority` ORDERING
+#           inheritance; that ordering inheritance is removed — attention rank now
+#           carries ordering. Here PR 20 closes rank-2 issue 101 and inherits rank
+#           2, outranking older PR 10 (closes unranked bug issue 200).
 #
-#           Fixture:
-#             issue 100  labels: [priority]        (the open ancestor epic)
-#             issue 101  labels: [help wanted]      (leaf; child of 100 via parent-101.json)
-#             issue 200  labels: [bug]              (unrelated, non-priority issue)
-#             PR 10 (older, 2024-01-01) closes issue 200 (bug, no priority)
-#             PR 20 (newer, 2024-01-02) closes issue 101 (help wanted, no own
-#                     priority — priority only via ancestor 100)
+#           Fixture (the ancestor `priority` structure is retained but inert for
+#           ordering — it only exercises the still-present bypass machinery):
+#             issue 100  labels: [priority]        (the open ancestor epic; inert for ordering)
+#             issue 101  labels: [help wanted]      (leaf; child of 100 via parent-101.json; rank 2 via the map)
+#             issue 200  labels: [bug]              (unrelated issue; rank 0)
+#             PR 10 (older, 2024-01-01) closes issue 200 (bug, rank 0)
+#             PR 20 (newer, 2024-01-02) closes issue 101 (help wanted, rank 2)
 #           parent-101.json → 100; no parent-100.json; no parent-200.json
-#           issue-list.json: 100, 101, 200 — all open; issue 101 is help-wanted
-#             but has no own `priority` so it stays OUT of the issue priority
-#             tier (ISSUE_SORTED uses own labels only). Issues 100 and 200 lack
-#             `help wanted` and are never startable. The issue queue produces
-#             no priority-1 selection — only the PR path selects here.
+#           issue-list.json: 100, 101, 200 — all open; issues 100 and 200 lack
+#             `help wanted` and are never startable, so only the PR path selects here.
 #
-#           This is the ONLY assertion that proves ancestor-priority lifts PR 20
-#           above PR 10. Without ancestor inheritance, both PRs have pri=0 and
-#           PR 10 (older) wins. With it, PR 20 gets pri=1 and wins outright.
-echo "Test: default mode — ancestor priority lifts PR over non-priority PR"
+#           Attention v2: priority-label ORDERING inheritance is removed — the
+#           attention rank now carries ordering. This proves PR RANK inheritance:
+#           PR 20 closes rank-2 issue 101 and so inherits rank 2 (max over its
+#           closing issues), lifting it above older PR 10 (closes unranked bug
+#           issue 200). The ancestor `priority` epic in the fixture is now inert
+#           for ordering (it survives only as the cap/pacing bypass). Without rank
+#           inheritance both PRs sit at rank 0 and PR 10 (older) wins; with it PR
+#           20 gets rank 2 and wins outright.
+echo "Test: default mode — PR rank inheritance lifts PR over unranked PR"
 setup
+export DISPATCH_RANK_MAP_JSON='{"101": 2}'
 setup_ancestor_priority_fixture 1 "$FAILING_ROLLUP"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "ancestor priority lifts PR 20 over older PR 10 (default mode)" "pr 20 20-leaf-pr fix-checks" "$result"
+assert_eq "rank-2 closing issue lifts PR 20 over older PR 10 (default mode)" "pr 20 20-leaf-pr fix-checks" "$result"
 teardown
 
-# PO-ANC-TRUNC. The depth-7 truncation warning must fire WITHOUT disabling
-#           ancestor-priority evaluation across the supported window. This is a
-#           two-PR contest, not an uncontested selection: without ancestor
-#           inheritance PR 10 wins on the higher `bug` topic category (and is
-#           also older); with it, issue 95's depth-6 priority lifts PR 20 on the
-#           outermost priority axis. So a correct result REQUIRES ancestor
-#           priority to be evaluated correctly across the supported window WHILE
-#           the depth-7 chain trips the truncation warning. Placing `priority`
-#           on the depth-6 (deepest in-window) ancestor proves both happen at
-#           once.
+# PO-ANC-TRUNC. The depth-7 truncation warning must still fire — the ancestor
+#           chain is walked regardless (ANCESTOR_NUMS feeds the cap/pacing bypass).
+#           Attention v2 re-anchors the ORDERING assertion: ancestor `priority` no
+#           longer orders, so under the all-zero rank baseline this is an unranked
+#           two-PR contest where PR 10 wins on the higher `bug` topic category (and
+#           is also older). So a correct result requires BOTH the truncation warning
+#           to fire (deep chain walked) AND PR 10 to win (ancestor priority does not
+#           lift PR 20). Placing `priority` on the depth-6 ancestor exercises the
+#           deep-chain walk without affecting ordering.
 #
 #           Fixture:
-#             issue 101  labels: [help wanted]   (leaf; closed by PR 20; no own priority)
-#             issue 95   labels: [priority]       (depth-6 ancestor of 101; priority-only)
-#             issue 200  labels: [bug]            (closed by PR 10; no priority)
+#             issue 101  labels: [help wanted]   (leaf; closed by PR 20; rank 0)
+#             issue 95   labels: [priority]       (depth-6 ancestor of 101; inert for ordering)
+#             issue 200  labels: [bug]            (closed by PR 10; rank 0)
 #             PR 10 (older, 2024-01-01) closes issue 200 (bug, no priority)
 #             PR 20 (newer, 2024-01-02) closes issue 101 (help wanted, no own
 #                     priority — priority only via depth-6 ancestor 95)
@@ -6657,7 +6819,12 @@ done
 result=$("$TMPDIR_TEST/dispatch-select-target" 2>"$TMPDIR_TEST/stderr") && rc=0 || rc=$?
 stderr=$(cat "$TMPDIR_TEST/stderr")
 assert_eq "deep-chain selection still exits 0" "0" "$rc"
-assert_eq "ancestor priority lifts PR 20 over older PR 10 despite truncation" "pr 20 20-deep-chain-leaf fix-checks" "$result"
+# Attention v2: the depth-7 ancestor chain is still walked (ANCESTOR_NUMS feeds
+# the cap/pacing bypass), so the truncation warning still fires. But ancestor
+# `priority` no longer ORDERS: under the all-zero rank baseline both PRs sit at
+# rank 0, so PR 10 (topic `bug`, older) wins on the tie-break ladder. The
+# assertion is re-anchored to the warning firing + PR 10 winning.
+assert_eq "unranked default ordering: PR 10 (bug, older) wins despite deep chain" "pr 10 10-bug-pr fix-checks" "$result"
 assert_eq "truncation warning on stderr" "1" "$(grep -c 'ancestor chain deeper than supported depth (6) for issue 101' <<<"$stderr")"
 teardown
 
@@ -6713,13 +6880,16 @@ teardown
 #           Issue 102's neutral labels keep it out of the startable issue queue so
 #           it does not perturb selection. Without depth-2 recursion both PRs have
 #           pri=0 and PR 10 (older) wins; with it PR 20 gets pri=1 and wins.
-echo "Test: default mode — depth-2 ancestor priority lifts PR over non-priority PR"
+echo "Test: default mode — PR rank inheritance lifts PR over unranked PR (depth-2 fixture)"
 setup
-# Fixture written by setup_ancestor_priority_fixture 2: grandparent 100 carries
-# `priority`; neutral intermediate 102 connects 101→102→100 (see helper comment).
+# Attention v2: converted to a direct rank test (ordering inheritance removed).
+# PR 20 closes rank-2 issue 101 and inherits rank 2, winning over older unranked
+# PR 10. The depth-2 ancestor `priority` structure in the fixture is inert for
+# ordering (cap/pacing bypass only).
+export DISPATCH_RANK_MAP_JSON='{"101": 2}'
 setup_ancestor_priority_fixture 2 "$FAILING_ROLLUP"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "depth-2 ancestor priority lifts PR 20 over older PR 10 (PO-ANC3)" "pr 20 20-leaf-pr fix-checks" "$result"
+assert_eq "rank-2 closing issue lifts PR 20 over older PR 10 (PO-ANC3)" "pr 20 20-leaf-pr fix-checks" "$result"
 teardown
 
 # PO-ANC4. Depth-2 ancestor priority, --priority-only mode. Same fixture as
@@ -6976,9 +7146,10 @@ teardown
 # `empty`.
 
 # PT1. --priority-only --top 3 returns up to 3 priority lines in topic-category
-#      order. All three issues carry BOTH `help wanted` and `priority`, so the
-#      priority axis does not discriminate; topic category (security > bug >
-#      other) is the only discriminator — mirrors T1 with priority labels added.
+#      order. All three issues carry BOTH `help wanted` and `priority`, and all are
+#      rank 0, so neither the bypass filter nor the attention rank discriminates;
+#      topic category (security > bug > other) is the only discriminator — mirrors
+#      T1 with the priority (bypass) label added.
 echo "Test: --priority-only --top 3 returns 3 priority lines in topic-category order"
 setup
 setup_union_pr_list '[]'
@@ -9336,6 +9507,46 @@ assert_eq "trace-leaf transient retry → leaf 900" "900" "$result"
 assert_eq "trace-leaf transient retry → rc 0" "0" "$rc"
 hit_count=$(cat "$STUB_DIR/gh-transient-blocked_by-900.count")
 assert_eq "trace-leaf transient retry → blocked_by hit exactly 3 times" "3" "$hit_count"
+teardown
+
+# 27. Blocking is a tactic-layer gate. Node 100 has an open blocker 999 AND a
+#     lower-numbered open sub-issue 50. Pre-fix, open_children unioned {50, 999}
+#     and descended 50 first, returning the sub-issue past an open blocker. After
+#     the fix an open blocker suppresses sub-issue gathering: only the blocking
+#     subtree is descended, so the blocker leaf 999 is returned.
+echo "Test: queue mode → open blocker gates the subtree; blocker leaf returned, not lower sub-issue"
+setup
+printf '[{"number":999,"state":"open"}]\n' > "$STUB_DIR/blockers-100.json"
+printf '[{"number":50}]\n' > "$STUB_DIR/subissues-100.json"
+printf '{"title":"Issue 999","body":"","comments":[],"number":999,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-999.json"
+printf '{"title":"Issue 50","body":"","comments":[],"number":50,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-50.json"
+result=$("$TMPDIR_TEST/dispatch-trace-leaf" "100" "queue")
+assert_eq "queue: open blocker gates subtree → blocker leaf 999 (sub-issue 50 suppressed)" "999" "$result"
+teardown
+
+# 28. Same shape, but the whole blocking subtree is claimed (999 reserved). The
+#     gate holds — the descent finds no startable leaf in the blocking subtree
+#     and does NOT fall through to the sub-issue 50. Exit 2 (no startable leaf).
+echo "Test: queue mode → blocker subtree fully claimed → exit 2 (sub-issue not reachable)"
+setup
+printf '[{"number":999,"state":"open"}]\n' > "$STUB_DIR/blockers-100.json"
+printf '[{"number":50}]\n' > "$STUB_DIR/subissues-100.json"
+printf '{"title":"Issue 999","body":"","comments":[],"number":999,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-999.json"
+printf '{"title":"Issue 50","body":"","comments":[],"number":50,"state":"OPEN"}\n' \
+  > "$STUB_DIR/issue-50.json"
+# No live sessions; a reservation marker claims the blocker leaf 999.
+select_target_fake_claude
+mkdir -p "$DISPATCH_RESERVATION_DIR"
+printf 'session=resv-sess\nissue=999\ntimestamp=2026-01-01T00:00:00Z\n' > "$DISPATCH_RESERVATION_DIR/999-blocker"
+err_out=$("$TMPDIR_TEST/dispatch-trace-leaf" "100" "queue" 2>&1 1>/dev/null && echo "EXIT=0" || echo "EXIT=$?")
+case "$err_out" in
+  *"worktree-conflicted"*"EXIT=2") status="ok" ;;
+  *) status="bad: $err_out" ;;
+esac
+assert_eq "queue: blocker subtree claimed → exit 2, sub-issue 50 not returned" "ok" "$status"
 teardown
 
 # ============================================================================
@@ -38536,36 +38747,38 @@ result=$("$TMPDIR_TEST/dispatch-select-target")
 assert_eq "#1452 F(a) — security leaf 920 wins over audio leaf 910" "issue 920" "$result"
 teardown
 
-# F(a) case 2: a priority (pri1) root vs a pri0 root created EARLIER — priority is
-#    the outermost axis, so the priority leaf wins regardless of age.
-echo "Test: #1452 F(a) — priority root beats earlier non-priority root"
+# F(a) case 2: a rank-2 root vs a rank-0 root created EARLIER — attention rank is
+#    the outermost axis, so the higher-rank leaf wins regardless of age.
+echo "Test: #1452 F(a) — higher-rank root beats earlier lower-rank root"
 setup
+export DISPATCH_RANK_MAP_JSON='{"940": 2}'
 setup_union_pr_list '[]'
-printf '[{"number":930,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":940,"created_at":"2024-02-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"}]}]\n' \
+printf '[{"number":930,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":940,"created_at":"2024-02-01T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
   > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "#1452 F(a) — priority leaf 940 wins over earlier pri0 leaf 930" "issue 940" "$result"
+assert_eq "#1452 F(a) — rank-2 leaf 940 wins over earlier rank-0 leaf 930" "issue 940" "$result"
 teardown
 
-# F(b). Lower tiers not traced. R_hi (priority help-wanted root 940) traces to an
-#    emittable leaf in orphan world; R_lo (pri0/other root 950) is a strictly
+# F(b). Lower tiers not traced. R_hi (rank-2 help-wanted root 940) traces to an
+#    emittable leaf in orphan world; R_lo (rank-0/other root 950) is a strictly
 #    lower-rank group. With default TOP=1, once R_hi's group holds its one
 #    emittable entry the walk early-exits BEFORE tracing R_lo — so R_lo's
 #    blocker lookup never fires (grep count 0). R_hi and R_lo MUST sit in
-#    different (pri, cat-rank) groups for the group-boundary fold to fire, and
+#    different (rank, cat-rank) groups for the group-boundary fold to fire, and
 #    R_hi's leaf must be emittable (no ready closing PR, orphan world) so it fills
 #    TOP=1.
 echo "Test: #1452 F(b) — early-exit skips tracing the lower-rank root"
 setup
+export DISPATCH_RANK_MAP_JSON='{"940": 2}'
 setup_union_pr_list '[]'
-# 940 = priority help-wanted (pri1), its own emittable leaf. 950 = plain
-# help-wanted (pri0, other) — strictly lower rank. No worktrees, no closing PRs.
-printf '[{"number":940,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"},{"name":"priority"}]},{"number":950,"created_at":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
+# 940 = rank-2 help-wanted, its own emittable leaf. 950 = plain help-wanted
+# (rank-0, other) — strictly lower rank. No worktrees, no closing PRs.
+printf '[{"number":940,"created_at":"2024-01-01T00:00:00Z","labels":[{"name":"help wanted"}]},{"number":950,"created_at":"2024-01-02T00:00:00Z","labels":[{"name":"help wanted"}]}]\n' \
   > "$STUB_DIR/issue-list.json"
 printf 'worktree /repo\nHEAD abc123\n\n' > "$STUB_DIR/worktree-list.txt"
 result=$("$TMPDIR_TEST/dispatch-select-target")
-assert_eq "#1452 F(b) — priority leaf 940 selected" "issue 940" "$result"
+assert_eq "#1452 F(b) — rank-2 leaf 940 selected" "issue 940" "$result"
 lo_c=$(grep -c "^950$" "$STUB_DIR/issue-blocking-calls.log" 2>/dev/null || true)
 assert_eq "#1452 F(b) — lower-rank root 950 never traced (early-exit)" "0" "$lo_c"
 teardown

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The tick runs a single selection ladder, top to bottom. The ladder spans both qu
 2. **JIT scan** — surface the most-overdue jit-reminder. Bypasses the `origin/main` health gate so reminders fire even when main is red.
 3. **`origin/main` health gate** — if main is red, stop; do not start new work. [`/dispatch-diagnose-main`](.claude/skills/dispatch-diagnose-main/SKILL.md) reports the failing checks.
 4. **Sweep orphan adoption** — adopt a stray `<N>-…` worktree with no live session (see #847).
-5. **Priority × topic-category × phase ladder.** Three tiers nest from outermost to innermost. The **priority bit** is the outermost axis: the selector exhausts every `priority=1` item — across all topics and phases — before any non-priority item, so a `priority` item in a low-ranked topic outranks every non-priority item in a higher-ranked one (`priority` is human-applied; the selector never adds it automatically). Within one priority level, **topic categories**, highest first: `security` → `bug` → `testing infrastructure` → `dispatch` → `landing` → `fellspiral` → `budget` → `print` → `audio` → `other`. Within each `(priority, topic)` bucket, the **phase ladder** runs closest-to-done first: oldest `review` PR → oldest `fix-checks` PR → oldest `help wanted` issue (planned/`implement` before unplanned/`plan`) → oldest `qa` PR. The selector exhausts one bucket's full phase ladder before moving to the next.
+5. **Attention-rank × enhancement × topic-category × phase ladder.** Four axes nest from outermost to innermost. **Attention rank** is the outermost axis: a continuous rank resolved from the intention graph (an issue absent from the map is rank 0; a PR inherits the max rank over the issues it closes). The selector drains distinct rank values descending — it exhausts an entire rank level, across all topics and phases, before any lower-rank item, so a high-rank item in a low-ranked topic outranks every lower-rank item in a higher-ranked one. The **enhancement** bit nests inside rank (issue path only): within a rank level all non-enhancement work drains before any enhancement issue. Within one `(rank, enhancement)` level, **topic categories**, highest first: `security` → `bug` → `testing infrastructure` → `dispatch` → `landing` → `fellspiral` → `budget` → `print` → `audio` → `other`. Within each `(rank, enhancement, topic)` bucket, the **phase ladder** runs closest-to-done first: oldest `review` PR → oldest `fix-checks` PR → oldest `help wanted` issue (planned/`implement` before unplanned/`plan`) → oldest `qa` PR. The selector exhausts one bucket's full phase ladder before moving to the next. The `priority` label has **no ordering effect** — it survives only as the cap/pacing bypass (human-applied; the selector never adds it automatically).
 
 Concurrent worker count scales with the rate-limit window (see Section 5).
 
@@ -184,7 +184,7 @@ same; the dialectic engine synthesizes the four inputs into priorities; a
 contrarian challenges the synthesis; the engine re-synthesizes; and the open
 backlog is triaged (add `help wanted`, update body, or close as not planned for
 each unlabeled issue). Run it interactively to step back from the queue and ask
-whether the priority ladder still matches the project's direction. It also runs
+whether the attention-rank ladder still matches the project's direction. It also runs
 autonomously on a 7-day `align` jit cadence — posting the full report as a
 comment on the review issue and closing it to anchor the next cycle.
 


### PR DESCRIPTION
## Summary

PR 3 of 3 for attention v2 (follows PR #2733 resolver and PR #2734 docs). The dispatch router becomes the single enforcement point for attention.

**Rank-ordered selection** (`dispatch-select-target`):
- Loads an issue → rank map from `packages/intentionsutil/scripts/rank-map.ts` (env seam `DISPATCH_RANK_MAP_JSON` for tests), canonicalized and validated in one jq pass so rank strings can never drift between bucket keys and the level list.
- Rank is the outermost ordering axis: distinct rank levels drain descending; the existing enh → topic-category → phase ladder is unchanged as tie-break within each level. PRs inherit the max rank over their closing issues; unranked candidates rank 0.
- Fail-closed: a rank-map failure exits 1 loudly — never an all-zero fallback that silently reorders the queue. Health/JIT/main-broken paths run before the load, so the heartbeat survives a broken `intentions/` store.
- The `priority` label is removed from ordering entirely. It keeps exactly one meaning: cap/pacing bypass — the at-cap `--priority-only` probe and dispatch-tick pace-curve exemption work off the label exactly as before, including ancestor inheritance. The three chain-health writers are untouched.

**Tactic-layer blocking gate** (`dispatch-trace-leaf`): an open blocker now gates the node's whole subtree — `open_children` returns only the blockers, so sub-issues stay unreachable until every blocker closes. Previously a lower-numbered sub-issue could be returned startable past an open blocker.

**Tests** (`test-dispatch-scripts.sh`): `DISPATCH_RANK_MAP_JSON='{}'` baseline in `setup()` (proves the end-state invariant: with no ranks, selection is byte-identical to today); priority ordering fixtures converted to rank fixtures; new RANK1–RANK8 tests (ranked-beats-unranked, float rank levels, PR max-rank inheritance, the label-de-ordering regression, tie-break ladder intact, `--qa` rank ordering, invalid-map fail-closed, bypass orthogonal to rank) plus two trace-leaf gating tests.

**Docs**: `reference.md` selection-ladder mechanics rewritten to the rank ladder; README prioritization bullet and /align line updated; select-tick/tick header comments corrected (comment-only).

## Verification

- `bash .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` — 4176/4177 pass. The one failure is a pre-existing environmental match: a stray untracked local worktree under `.claude/worktrees/` trips the BFD4F2-uniqueness grep; the file is not in git and won't exist in CI's clean checkout.
- `npx vitest run --project packages/intentionsutil --root .` — 153/153; `npx tsc -p packages/intentionsutil --noEmit` clean.
- End-state: `rank-map.ts` prints `{}` against the real store (no injections authored yet), so the live selection path degenerates to the rank-0 baseline and current queue behavior is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)