### PR TITLE
dispatch-token-audit: add claude-fable-5 to the actual-rates price table

### DIFF
--- a/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
@@ -444,14 +444,16 @@ def price(u):
 # retired Claude 3.x generation. Claude 3 cache rates are formula-derived
 # (1.25x write / 0.1x read of input), not exact historical cents.
 def ACTUAL_RATES:
-  { opus:      {input:5,    cache_creation:6.25,    cache_read:0.50,  output:25},
+  { fable:     {input:10,   cache_creation:12.50,   cache_read:1.00,  output:50},
+    opus:      {input:5,    cache_creation:6.25,    cache_read:0.50,  output:25},
     sonnet:    {input:3,    cache_creation:3.75,    cache_read:0.30,  output:15},
     haiku:     {input:1,    cache_creation:1.25,    cache_read:0.10,  output:5},
     opus_3:    {input:15,   cache_creation:18.75,   cache_read:1.50,  output:75},
     haiku_3:   {input:0.25, cache_creation:0.3125,  cache_read:0.025, output:1.25},
     haiku_3_5: {input:0.80, cache_creation:1.00,    cache_read:0.08,  output:4.00} };
 def family($m):
-  if   ($m | startswith("claude-opus") or startswith("claude-3-opus")) then "opus"
+  if   ($m | startswith("claude-fable") or startswith("claude-mythos")) then "fable"
+  elif ($m | startswith("claude-opus") or startswith("claude-3-opus")) then "opus"
   elif ($m | startswith("claude-sonnet")
          or startswith("claude-3-sonnet")
          or startswith("claude-3-5-sonnet")

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -391,6 +391,8 @@ assert_eq "price_model.input_per_mtok (proxy unchanged)" "15" \
   "$(jq '.price_model.input_per_mtok' <<<"$OUT")"
 assert_eq "price_model.actual_rates_per_mtok.opus.output" "25" \
   "$(jq '.price_model.actual_rates_per_mtok.opus.output' <<<"$OUT")"
+assert_eq "price_model.actual_rates_per_mtok.fable.output" "50" \
+  "$(jq '.price_model.actual_rates_per_mtok.fable.output' <<<"$OUT")"
 
 assert_eq "by_session_type.worker.sessions" "1" \
   "$(jq '.by_session_type.worker.sessions' <<<"$OUT")"
@@ -869,6 +871,49 @@ assert_eq 'by_model["claude-haiku-4-5"].cost_usd (haiku)' "$EXPECTED_HAIKU_COST"
   "$(jq '.by_model["claude-haiku-4-5"].cost_usd' <<<"$OUT_HAIKU")"
 
 rm -rf "$HAIKU_ROOT"
+
+# ---------------------------------------------------------------------------
+# Fable per-model cost (#2737). ISOLATED fixture: a worker session whose
+# assistant message carries `claude-fable-5` with distinct nonzero usage in
+# ALL FOUR components. This is the ONLY coverage of family()'s
+# `startswith("claude-fable")` branch and the ACTUAL_RATES.fable row — before
+# that branch existed, any fable session in the window aborted the whole
+# aggregation via the unpriceable-model guard. Distinct counts make a rate
+# swap between any two fable components visible; the expected value uses the
+# full four-term formula at fable rates (10 / 12.50 / 1.00 / 50 per Mtok).
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- fable per-model cost (#2737) ---"
+
+FABLE_ROOT=$(mktemp -d)
+trap 'rm -rf "$FABLE_ROOT" "$FAKE_WRITER_DIR"; teardown' EXIT INT TERM
+fable_worktree="$FABLE_ROOT/-home-x-worktrees-2737-fable"
+mkdir -p "$fable_worktree"
+fable_jsonl="$fable_worktree/sess-fable.jsonl"
+
+# line 1: first user line — classifies as worker
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/plan-issue</command-name>"}}' \
+  >> "$fable_jsonl"
+# line 2: assistant — claude-fable-5, distinct nonzero usage in all four components
+printf '%s\n' '{"type":"assistant","attributionSkill":"plan-implement","isSidechain":false,"gitBranch":"2737-fable","message":{"model":"claude-fable-5","usage":{"input_tokens":1000,"cache_creation_input_tokens":2000,"cache_read_input_tokens":4000,"output_tokens":500}}}' \
+  >> "$fable_jsonl"
+jq . "$fable_jsonl" >/dev/null
+touch "$fable_jsonl"
+
+OUT_FABLE=$(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$FABLE_ROOT"
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7
+)
+
+# Fable rates: input 10 / cache_creation 12.50 / cache_read 1.00 / output 50 per Mtok.
+EXPECTED_FABLE_COST=$(jq -n '(1000*10 + 2000*12.50 + 4000*1.00 + 500*50)/1e6')
+assert_eq "sessions[sess-fable].cost_usd (fable)" "$EXPECTED_FABLE_COST" \
+  "$(jq '[.sessions[]|select(.id=="sess-fable")][0].cost_usd' <<<"$OUT_FABLE")"
+assert_eq 'by_model["claude-fable-5"].cost_usd (fable)' "$EXPECTED_FABLE_COST" \
+  "$(jq '.by_model["claude-fable-5"].cost_usd' <<<"$OUT_FABLE")"
+
+rm -rf "$FABLE_ROOT"
 
 # ---------------------------------------------------------------------------
 # Claude 3 classification + generation-aware pricing + no-abort completeness


### PR DESCRIPTION
Closes #2737

The fail-closed pricing guard in aggregate-usage.sh aborted the entire aggregation once claude-fable-5 sessions appeared in the 7-day transcript window (34M tokens carried by the unpriceable model), making /dispatch-token-audit unrunnable.

- Add a `fable` rate class to ACTUAL_RATES: input 10 / cache_creation 12.50 / cache_read 1.00 / output 50 per MTok — list price with the same 1.25x write / 0.1x read cache ratios the table already uses.
- Match `claude-fable-5` (and `claude-mythos-5`) in `family()`; `rate_class()` falls through to the bare family key, consistent with the current-generation convention.
- Tests: isolated fable fixture mirroring the haiku per-model cost test (distinct nonzero usage in all four components so any rate transposition is visible), plus a rate-row assert on the shared fixture.

Verified end-to-end: the aggregation that previously aborted now completes over the full 1877-session window (files_failed=0) and prices fable sessions ($323.39 cost_usd on $485 proxy in the current window). The local test suite has ~97 pre-existing environment failures on unmodified main; the new assertions follow the same fixture pattern as the existing haiku/opus3 tests, and the rate-row assert passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)