### PR TITLE
intentions: worker concurrency, claiming, worktree isolation, and pace parity — clarifications 12-14 + /align-tactics re-evaluation

### DIFF
--- a/intentions/strategy-graph-native-dispatch.md
+++ b/intentions/strategy-graph-native-dispatch.md
@@ -17,12 +17,11 @@ rationale: "strategy-graph-drives-dispatch made the loop real — intent enters
   being); and the align skill family — /align-init for fork onboarding and
   virtue review (retiring the legacy /align skill), /align-strategy for
   recording strategy under interview, /align-tactics for breaking a strategy
-  into executable tactic subtrees — supersedes /file-issue and /plan-issue
-  as the interface for intent entering execution.
-  The legacy gh router runs concurrently until the gh queue drains, then it is
-  removed; full /file-issue and /plan-issue coverage is mapped into the align
-  family before removal (coverage matrix retained as draft content on
-  tactic-graph-native-dispatch)."
+  into executable tactic subtrees — supersedes /file-issue and /plan-issue as
+  the interface for intent entering execution. The legacy gh router runs
+  concurrently until the gh queue drains, then it is removed; full /file-issue
+  and /plan-issue coverage is mapped into the align family before removal
+  (coverage matrix retained as draft content on tactic-graph-native-dispatch)."
 reading: null
 gap: null
 serves:
@@ -84,8 +83,8 @@ clarifications:
       strategy eligibility for /align-tactics; they are its input: it finalizes,
       splits, merges, or prunes them. Until tactic-body preservation ships in
       the store, draft bodies are hand-maintained (safe interim: no automated
-      writer touches tactic bodies). Recorded 2026-07-03; supersedes this record's
-      own first draft, which parked the design outside the graph in
+      writer touches tactic bodies). Recorded 2026-07-03; supersedes this
+      record's own first draft, which parked the design outside the graph in
       packages/intentionsutil/DISPATCH.md."
   - question: How does the /align-strategy dialectic handle requirements for UI
       design, where text questions under-specify?
@@ -111,8 +110,8 @@ clarifications:
       reject; immaterial observations land as clarifications without
       interrupting the round. Keeps condition substance human-decided (condition
       4). Recorded 2026-07-03 interview."
-  - question: Round 1 deferred the /align-init entrypoint by omission — how do deferrals
-      stay visible without competing with signal work?
+  - question: Round 1 deferred the /align-init entrypoint by omission — how do
+      deferrals stay visible without competing with signal work?
     answer: "Deferrals are recorded, not omitted: work off the minimum path to
       validating a signal lands as a backlog tactic — fully planned, selectable,
       demoted. The demotion is part of calculated attention: resolveAttention
@@ -163,6 +162,18 @@ clarifications:
       weight changes are reviewed PRs. The backlog flag is deleted; strategy
       eligibility counts only on-path children, also derived. Recorded
       2026-07-03 interview."
+  - question: Does per-issue worktree isolation carry over — where does a
+      graph-native tactic's worker execute?
+    answer: "Yes — one worktree per tactic. When the router launches a worker for a
+      tactic, it provisions a dedicated worktree keyed by the tactic's node id,
+      the same isolation the legacy router gives each issue. This is the
+      launch-side commitment behind worktree anchoring
+      (tactic-graph-native-dispatch §3.4: <tactic-id> is the
+      branch/worktree/reservation/session key) and the worktree-create.sh
+      node-id naming unit (tactic-graph-router-selector unit 3). Until that unit
+      lands, the hook still rejects node-id names — graph-native sessions must
+      borrow a numeric anchor, which this requirement removes. Recorded
+      2026-07-03 from author direction."
 tooling_goals:
   - kind: actuator
     statement: /align-strategy — interview-driven strategy recording, superseding
@@ -172,9 +183,8 @@ tooling_goals:
       nodes with clean-session plans, superseding /file-issue epic structuring
       and /plan-issue
   - kind: actuator
-    statement: "/align-init — fork entrypoint: orient, validate deployment,
-      review virtues, delegate to /align-strategy; retires the legacy
-      /align skill"
+    statement: "/align-init — fork entrypoint: orient, validate deployment, review
+      virtues, delegate to /align-strategy; retires the legacy /align skill"
   - kind: actuator
     statement: graph-native router tick — selects by resolved rank across strategies
       and tactics, transitions persisted phase, direct-push rebase-retry writes

--- a/intentions/strategy-graph-native-dispatch.md
+++ b/intentions/strategy-graph-native-dispatch.md
@@ -174,6 +174,35 @@ clarifications:
       lands, the hook still rejects node-id names — graph-native sessions must
       borrow a numeric anchor, which this requirement removes. Recorded
       2026-07-03 from author direction."
+  - question: Can workers execute nodes concurrently — and what stops two workers
+      claiming the same node?
+    answer: "Concurrency is a first-class requirement, not an inherited detail: the
+      router runs up to the paced worker target in parallel across eligible
+      non-parked nodes of both kinds — tactic phase sessions and strategy
+      /align-tactics sessions. Claiming and isolation are uniform by node id:
+      every launched worker enters the one claimed set / reservation ledger
+      under its node id — strategy ids included, so an in-flight /align-tactics
+      session claims its strategy and closes the duplicate-spawn window while
+      its tactics have not yet landed on origin/main — and runs in a worktree
+      keyed by that id, giving liveness detection (live session ⇔ worktree) one
+      rule for both kinds. Write safety stays the single-node rebase-retry
+      commit path (clarification 2). Recorded 2026-07-03 interview."
+  - question: Does the graph-native router keep the legacy pace function — and where
+      does its priority override live?
+    answer: "Full parity, machinery unchanged and outside the graph:
+      dispatch-target-workers' weekly cumulative pace curve stays the binary
+      spend gate (whether to spend) and the 5-hour linear ramp decides how many
+      concurrent workers (0..max_concurrent_workers); telemetry
+      (rate_limits.json) and tunables stay operational config — the graph
+      records the requirement, not the machinery, since rate-limit telemetry is
+      machine state, not intent. One pace budget spans both routers during
+      coexistence and counts strategy sessions as workers. The legacy priority
+      label maps to a first-class authored pace-exempt flag on goal-layer nodes
+      (schema home: tactic-graph-dispatch-schema), deliberately orthogonal to
+      attention ordering: it admits one gate-exempt worker past a paced-to-zero
+      budget — it bypasses the gate, not the count or the order — and never
+      overrides genuine token exhaustion (the --exhausted hard floor,
+      main-broken parity). Recorded 2026-07-03 interview."
 tooling_goals:
   - kind: actuator
     statement: /align-strategy — interview-driven strategy recording, superseding

--- a/intentions/tactic-graph-dispatch-schema.md
+++ b/intentions/tactic-graph-dispatch-schema.md
@@ -28,9 +28,11 @@ attributes:
 
 ## Context
 
-`strategy-graph-native-dispatch` (clarifications 1, 4, 5, 9, 10) makes the
-graph the state machine: tactics carry a persisted `phase` the router
-transitions, parking is a first-class `office_hours` field, strategies
+`strategy-graph-native-dispatch` (clarifications 1, 4, 5, 9, 10, 14) makes
+the graph the state machine: tactics carry a persisted `phase` the router
+transitions, parking is a first-class `office_hours` field, goal-layer
+nodes carry the authored `pace_exempt` pace-gate bypass (the legacy
+priority label's graph home, orthogonal to attention ordering), strategies
 carry `rounds` accounting, tactic bodies are authoritative plan content,
 signal-validating tactics carry a factual `validates` edge (the
 calculated-attention signal term's terminals), and executions carry the
@@ -60,13 +62,19 @@ Scope:
     11)
   - `blocked_by: string[]` (default `[]`)
   - `office_hours: { reason: string; since: string } | null`
+  - `pace_exempt: boolean` (default `false`) — authored pace-gate bypass
+    (strategy clarification 14): the selector may admit one gate-exempt
+    worker for a flagged node past a paced-to-zero budget; never
+    overrides genuine token exhaustion; deliberately a separate field
+    from `attention` (bypass ≠ ordering)
   - `rounds: { count: number; last_completed: string | null } | null`
 - `packages/intentionsutil/src/schema.ts:291` (`validateNode`): parse and
   default the new fields, strict on shape.
 - `packages/intentionsutil/src/schema.ts:378` (`validateGraph`) layer rules:
   `phase`/`execution`/`blocked_by`/`validates` valid on tactics only;
-  `office_hours` on goal-layer kinds only (same `attributes.goal_layer`
-  gate as attention, `schema.ts:401`); `rounds` on strategies only; every
+  `office_hours` and `pace_exempt` on goal-layer kinds only (same
+  `attributes.goal_layer` gate as attention, `schema.ts:401`); `rounds`
+  on strategies only; every
   `blocked_by` id must exist and be a tactic; every `validates` id must
   exist and be a strategy; reject `blocked_by` cycles.
 

--- a/intentions/tactic-graph-native-dispatch.md
+++ b/intentions/tactic-graph-native-dispatch.md
@@ -71,6 +71,13 @@ execution:
 ```yaml
 # on any goal-layer node (strategy or tactic)
 office_hours: { reason: "<why>", since: 2026-07-03 } | null
+pace_exempt: false             # authored pace-gate bypass (clarification 14):
+                               # admits one gate-exempt worker past a
+                               # paced-to-zero budget — bypasses the gate, not
+                               # the count or the order — and never overrides
+                               # genuine token exhaustion; the graph home of
+                               # the legacy priority label, orthogonal to
+                               # attention ordering
 ```
 
 ```yaml
@@ -290,6 +297,17 @@ Claimed-set, reservation ledger, concurrency pacing
 `dispatch-spawn-tick` heartbeat carry over unchanged — the heartbeat is the
 seam: the tick consults **both** selectors during coexistence.
 
+Pacing keeps full legacy parity (clarification 14): the weekly cumulative
+curve is the binary spend gate, the 5-hour linear ramp decides the
+concurrent worker count, and one pace budget spans both routers and both
+node kinds — a strategy's `/align-tactics` session counts as a worker.
+Telemetry and tunables stay operational config outside the graph. The
+legacy `priority` label's bypass maps to the authored `pace_exempt` flag:
+at a paced-to-zero budget the tick probes pace-exempt eligible nodes and
+admits one gate-exempt worker — bypassing the gate, not the count or the
+order — with `dispatch-target-workers --exhausted` as the hard floor no
+flag overrides (main-broken parity).
+
 ### 3.3 Coexistence and drain
 
 The two routers run in parallel over **disjoint state** — no gh↔graph
@@ -308,12 +326,19 @@ GitHub is a separate strategy; design TBD.)
   selector/phase-derivation scripts and the `dispatch:*` label
   conventions.
 
-### 3.4 Worktree anchoring
+### 3.4 Worktree anchoring and claiming
 
-The `<issue-num>-<slug>` branch convention is re-keyed to node ids:
-`<tactic-id>` becomes the branch/worktree/reservation/session key.
-Draining legacy gh work keeps its numeric form, so both keyspaces
-coexist.
+The `<issue-num>-<slug>` branch convention is re-keyed to node ids, and
+the rule is uniform across node kinds (clarifications 12–13): every
+launched worker — a tactic's phase session or a strategy's
+`/align-tactics` session — enters the one claimed set / reservation
+ledger under its node id and runs in a dedicated worktree keyed by that
+id. The strategy claim closes the duplicate-spawn window while an
+in-flight `/align-tactics` session's tactics have not yet landed on
+`origin/main` (the eligibility gates alone would still pass); the
+uniform worktree gives liveness detection (live session ⇔ worktree) one
+rule for both kinds. Draining legacy gh work keeps its numeric form, so
+both keyspaces coexist.
 
 ## 4. Coverage matrix
 
@@ -384,14 +409,18 @@ tactic-intentions-branch-protection (park) ┤                                 �
   reaches it, so the calculated-attention signal term demotes it at read
   time; no stored flag (clarifications 9/11). Round 1 had deferred it by
   omission.
-- **Re-evaluations (2026-07-03):** two same-day mid-flight strategy edits
-  (clarifications 8–10, then 11), each followed by the clarification-10
-  re-evaluation run inline because no router exists yet. The first added
-  the attention tactic and recorded the `/align-init` deferral; the second
-  replaced the banded backlog mechanism with calculated attention:
-  `tactic-signal-path-attention` was pruned and replaced by
-  `tactic-calculated-attention` (on-path — it hard-blocks legacy
-  removal), the `backlog` flag was removed from the store, and
-  `validates` edges were stamped on the two terminals.
+- **Re-evaluations (2026-07-03):** three same-day mid-flight strategy edits
+  (clarifications 8–10, then 11, then 12–14), each followed by the
+  clarification-10 re-evaluation run inline because no router exists yet.
+  The first added the attention tactic and recorded the `/align-init`
+  deferral; the second replaced the banded backlog mechanism with
+  calculated attention: `tactic-signal-path-attention` was pruned and
+  replaced by `tactic-calculated-attention` (on-path — it hard-blocks
+  legacy removal), the `backlog` flag was removed from the store, and
+  `validates` edges were stamped on the two terminals. The third recorded
+  worker concurrency/claiming and pace parity: `pace_exempt` added to the
+  schema tactic, strategy-id claiming, the pace-exempt probe lane, and
+  uniform node-id worktree keys added to the selector tactic, §1.1/§3.2/
+  §3.4 amended; no tactic was pruned and no `blocked_by` changed.
 - This parent is not directly executable (no `phase`); it completes when
   its last child completes, which stamps the strategy's `rounds`.

--- a/intentions/tactic-graph-native-dispatch.md
+++ b/intentions/tactic-graph-native-dispatch.md
@@ -340,6 +340,18 @@ uniform worktree gives liveness detection (live session ⇔ worktree) one
 rule for both kinds. Draining legacy gh work keeps its numeric form, so
 both keyspaces coexist.
 
+The launch chain follows the same keyspace split: selection hands the
+node id to the legacy launch scripts
+(`dispatch-materialize-spawn` → `dispatch-launch-worker` →
+`dispatch-spawn-job`), which provision the node-id worktree and spawn the
+session — `/align-tactics <id>` for a strategy, the tactic's persisted
+`phase` mapped to its phase skill otherwise. `dispatch-route`'s
+label/PR-derived phase derivation does not apply to node targets (phase
+is persisted, clarification 1); its deterministic provisioning prelude
+carries over. Launch-failure dispositions park the node via the
+`office_hours` graph write. Scoped in `tactic-graph-router-selector`
+unit 4.
+
 ## 4. Coverage matrix
 
 Every legacy behavior maps to a home in the new family; nothing silently
@@ -419,8 +431,9 @@ tactic-intentions-branch-protection (park) ┤                                 �
   legacy removal), the `backlog` flag was removed from the store, and
   `validates` edges were stamped on the two terminals. The third recorded
   worker concurrency/claiming and pace parity: `pace_exempt` added to the
-  schema tactic, strategy-id claiming, the pace-exempt probe lane, and
-  uniform node-id worktree keys added to the selector tactic, §1.1/§3.2/
-  §3.4 amended; no tactic was pruned and no `blocked_by` changed.
+  schema tactic, strategy-id claiming, the pace-exempt probe lane,
+  uniform node-id worktree keys, and the node-target launch chain (unit
+  4) added to the selector tactic, §1.1/§3.2/§3.4 amended; no tactic was
+  pruned and no `blocked_by` changed.
 - This parent is not directly executable (no `phase`); it completes when
   its last child completes, which stamps the strategy's `rounds`.

--- a/intentions/tactic-graph-router-selector.md
+++ b/intentions/tactic-graph-router-selector.md
@@ -69,6 +69,17 @@ Scope: new `.claude/skills/dispatch-propagate/scripts/graph-select-target`:
   `execution.strategy_fingerprint` → skip new selections in that subtree,
   let in-flight phases finish, enqueue one re-evaluation `/align-tactics`
   session for the strategy, and log the freeze to the selection log.
+- Uniform claiming (strategy clarification 13): every selection enters the
+  claimed set / reservation ledger under its node id — strategy ids
+  included, so an in-flight `/align-tactics` session keeps its strategy
+  unselectable until its tactics land on `origin/main` (the eligibility
+  gates alone still pass mid-session).
+- Pace-exempt probe lane (strategy clarification 14, legacy `priority`
+  parity): when the paced worker target is 0, first check
+  `dispatch-target-workers --exhausted` — `exhausted` is a hard stop no
+  flag overrides; otherwise probe eligible nodes with `pace_exempt: true`
+  and admit at most one gate-exempt worker — bypassing the gate, not the
+  count or the rank order. Spec: `tactic-graph-native-dispatch` §3.2.
 - Emit one selection-log line per invocation (jsonl in the dispatch state
   dir alongside the phase log written by `dispatch-write-phase-log`) — the
   input `tactic-dispatch-lifecycle-sensor` reads.
@@ -83,17 +94,24 @@ Scope: `.claude/skills/dispatch-propagate/scripts/dispatch-select-tick`
 (invoked by `dispatch-tick`): under the one selection lock, query
 graph-select-target first, fall back to the legacy
 `dispatch-select-target`; one claimed set and one reservation ledger
-spanning both keyspaces (node ids and issue numbers).
+spanning both keyspaces (node ids and issue numbers); one pace budget
+across both, with strategy `/align-tactics` sessions counted as workers.
+The tick's existing at-cap priority bypass extends across keyspaces: the
+probe consults graph pace-exempt nodes (Unit 1's lane) alongside the
+legacy `--priority-only` probe, still admitting at most one gate-exempt
+worker total.
 
 ## Unit 3 — node-id worktree keys
 
 **Recommended model:** sonnet
 
-Scope: `.claude/hooks/worktree-create.sh` — accept `<tactic-id>` worktree
-names alongside the `<issue-num>-<slug>` convention; draining legacy gh
-work keeps its numeric names. (This removes the friction the 2739 session hit:
-a graph-native session needing a synthetic anchor issue just to name its
-worktree.)
+Scope: `.claude/hooks/worktree-create.sh` — accept `<node-id>` worktree
+names alongside the `<issue-num>-<slug>` convention: tactic ids for phase
+sessions and strategy ids for `/align-tactics` sessions (uniform node-id
+keying, strategy clarifications 12–13; spec §3.4). Draining legacy gh
+work keeps its numeric names. (This removes the friction the 2739 and
+2740 sessions hit: a graph-native session needing a synthetic numeric
+anchor just to name its worktree.)
 
 ## Dependencies
 
@@ -108,8 +126,9 @@ worktree.)
 ## Reuse
 
 - `resolveAttention`/`src/goals.ts`, the selection lock,
-  `dispatch-target-workers` pacing, and the `dispatch-spawn-tick`
-  heartbeat — all unchanged.
+  `dispatch-target-workers` pacing (count mode and the `--exhausted`
+  hard-floor query, reused as-is by the pace-exempt lane), and the
+  `dispatch-spawn-tick` heartbeat — all unchanged.
 
 ## Verification
 

--- a/intentions/tactic-graph-router-selector.md
+++ b/intentions/tactic-graph-router-selector.md
@@ -113,6 +113,36 @@ work keeps its numeric names. (This removes the friction the 2739 and
 2740 sessions hit: a graph-native session needing a synthetic numeric
 anchor just to name its worktree.)
 
+## Unit 4 — launch chain for node targets
+
+**Recommended model:** opus
+
+Depends on: Units 1–3.
+
+Scope: extend the post-selection launch chain to node-id targets, so a
+graph selection actually becomes a running worker (selection alone leaves
+the launch scripts issue-only):
+- `.claude/skills/dispatch-propagate/scripts/dispatch-materialize-spawn`
+  and `dispatch-launch-worker`: accept a `<node-id>` target alongside
+  `<issue-num>` (keyspace split: all-numeric = legacy issue, otherwise
+  node id); worktree path and spawn `--name` are the node id (Unit 3's
+  hook accepts it).
+- For node targets, `dispatch-route`'s phase *derivation* is bypassed —
+  phase is persisted (strategy clarification 1). The directive comes from
+  the node: strategy → `INVOKE /align-tactics <node-id>`; tactic by
+  `phase` → implement → `/implement`, fix → `/fix-checks`, qa →
+  `/qa-fix`, review → `/review-fix`. The deterministic provisioning
+  prelude (worktree provision + origin/main merge, CI-ready gate where a
+  PR exists) runs unchanged, preserving the merged-tree guarantee.
+- `dispatch-spawn-job` is reused as-is (generic primitive): `--name` =
+  node id, `--cwd` = the node-id worktree, prompt = the mapped skill
+  invocation.
+- Mechanical failure dispositions (provision-failed, merge conflict that
+  cannot invoke `/fix-conflicts`, wrong-worktree) park the node via the
+  `office_hours` graph write instead of an office-hours label —
+  coordinate with `tactic-graph-router-transitions`, which owns the
+  ongoing phase/marker writes, and use the `graph-commit` primitive.
+
 ## Dependencies
 
 - `tactic-graph-dispatch-schema` — the fields the gates read.
@@ -122,6 +152,9 @@ anchor just to name its worktree.)
   live so the derived terms are in effect from the first tick; not a hard
   blocker for this tactic (the selector functions without it, minus the
   derived terms), but it does hard-block `tactic-legacy-router-removal`.
+- `tactic-graph-commit` — Unit 4's failure-disposition park writes go
+  through the primitive; not a hard blocker for Units 1–3 (selection and
+  the tick wiring make no graph writes).
 
 ## Reuse
 


### PR DESCRIPTION
Bootstrap `/align-strategy` + `/align-tactics` session recorded on the graph, in three commits:

**Clarifications 12–14 on `strategy-graph-native-dispatch`** (written via `write-node.ts`, the single validation gate; author decisions from the interview):

1. **Per-tactic worktrees** — the router provisions a dedicated worktree per launched tactic, keyed by node id (legacy per-issue parity).
2. **Concurrency + uniform claiming** — concurrent workers are a first-class requirement across both node kinds; every worker (tactic phase session or strategy `/align-tactics` session) claims its node id in the one claimed set and runs in a worktree keyed by that id. Strategy claiming closes the duplicate-`/align-tactics` window; uniform worktrees give liveness detection one rule.
3. **Pace parity + pace-exempt flag** — weekly curve as binary spend gate, 5-hour ramp for worker count, machinery staying outside the graph; the legacy `priority` label becomes a first-class authored `pace_exempt` flag orthogonal to attention ordering, bypassing the gate (not count/order) and honoring the `--exhausted` hard floor.

**`/align-tactics` re-evaluation** (clarification 10's soft-freeze protocol, run inline — no router exists yet; hand-edited tactic bodies per the interim body-preservation doctrine):

- `tactic-graph-dispatch-schema`: `pace_exempt: boolean` (goal-layer only) added to the schema plan.
- `tactic-graph-router-selector`: uniform node-id claiming, pace-exempt probe lane, cross-keyspace tick bypass, worktree keys extended to strategy ids.
- `tactic-graph-native-dispatch` spec body: §1.1 field shape, §3.2 pace narrative, §3.4 worktree anchoring and claiming, re-evaluation history.

No tactic pruned, no `blocked_by` changed. Verification: `npm test --prefix packages/intentionsutil` — 109/109 pass.

Delivered as a PR because the worker direct-push lane is not live yet (`tactic-intentions-branch-protection` is parked on the author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Follow-up (same session):** selector Unit 4 added — the node-target launch chain (`dispatch-materialize-spawn` → `dispatch-launch-worker` → `dispatch-spawn-job` accept node ids; `dispatch-route`'s phase derivation bypassed for persisted-phase targets, its provisioning prelude kept; launch failures park via the `office_hours` graph write). Closes the gap where a graph selection had no scoped path to becoming a running worker. Spec §3.4 and the re-evaluation history updated.