### PR TITLE
intentions: record strategy-attention-surface — office hours runs on the graph

### DIFF
--- a/intentions/delegation-web-analytics.md
+++ b/intentions/delegation-web-analytics.md
@@ -1,0 +1,53 @@
+---
+id: delegation-web-analytics
+kind: delegation
+statement: Site analytics and search telemetry delegated to Google (GA4, Search
+  Console, PageSpeed)
+owner: human
+status: raw
+parent: null
+rationale: "Recorded on intake per strategy-complete-ledger — a raw record with
+  first-pass axes beats an invisible edge; assessment follows. The
+  project-signals pipeline ingests GA4, Search Console, and PageSpeed telemetry
+  for the marketing and adoption signals surfaced at office hours
+  (strategy-promote-progressive-detachment, strategy-own-audience); the
+  attachment predates this record — the 2026-07-03 attention-surface interview
+  caught it as an unrecorded sensor. Divergence is the notable axis: engagement
+  metrics import the engagement-optimizer's framing of audience value into how
+  the owned sites' reach is read — the same framing capture the attention
+  strategies exist to resist — so the review trigger watches for these signals
+  steering publishing decisions rather than merely describing them.
+  Irreversibility is low: the sites are owned and keep publishing with the
+  sensor absent; losing the vendor loses historical series, not capability."
+reading: null
+gap: null
+serves: []
+recovers: []
+clarifications: []
+tooling_goals: []
+success_signal: null
+attention: null
+attributes:
+  delegatee: Google (Analytics 4, Search Console, PageSpeed Insights)
+  delegated: audience, traffic, and search-performance measurement for the owned sites
+  origin: chosen
+  divergence:
+    level: moderate
+    imported:
+      - engagement-metric framing of audience value
+      - third-party measurement collection on owned pages
+    contradictions: []
+  irreversibility:
+    recovery_path: substitute — server-log or owned privacy-respecting analytics;
+      the sites publish unchanged without the sensor
+    recovery_cost: low; historical series lost, capability retained
+    gated: false
+    last_exercised: null
+  classification: tool
+  non_delegable_floor: the owned sites remain fully functional and publishable
+    with the analytics absent
+  review_trigger: analytics signals begin driving publishing or marketing
+    decisions (framing risk), or export/API access narrows
+  last_assessed: 2026-07-03
+---
+# Site analytics and search telemetry delegated to Google (GA4, Search Console, PageSpeed)

--- a/intentions/strategy-attention-surface.md
+++ b/intentions/strategy-attention-surface.md
@@ -1,0 +1,135 @@
+---
+id: strategy-attention-surface
+kind: strategy
+statement: Office hours runs on the graph — one local-first surface (status
+  signals and goals exploration) allocates the author's strategic attention
+owner: human
+status: refining
+parent: strategy-explicit-intent
+rationale: "The office-hours surface was the materialization of several
+  strategies' sensors — strategy-autonomous-execution names the dashboard as its
+  observability surface, strategy-explicit-intent names the intention-tree view
+  among its artifacts, strategy-graph-native-dispatch defines the office-hours
+  queue as a projection over parked nodes — yet no node owned the surface
+  itself. This strategy owns it: the place where the graph meets the author's
+  attention. Two pages. STATUS is one attention-ranked queue of typed signals;
+  every signal belongs to an owning graph node (a strategy's success_signal or a
+  standing condition) and the surface renders readings it does not own: runway
+  and dollar spend belong to strategy-financial-sustainability with the sensor
+  supplied by strategy-recover-finance's budget pipeline; token spend reads
+  against strategy-autonomous-execution's frontier-economy condition (pace
+  telemetry stays operational config outside the graph); velocity and backlog
+  growth belong to strategy-autonomous-execution's attention-economics signal,
+  computed from the store's own history per the graph-native lifecycle sensor;
+  marketing and adoption signals belong to
+  strategy-promote-progressive-detachment and strategy-own-audience, sensed
+  through the exports recorded in delegation-web-analytics. GOALS is direct
+  graph exploration: virtue roots and their strategies, the shape and
+  development of subtrees, where delegation and capture concentrate, where
+  attention resolves, what the router is executing and queuing, and the
+  office-hours queue. Local-first per the recovery strategies: the graph is read
+  from the local repo clone, signals from non-versioned files on local disk and
+  network shares; the surface is a read-only projection — acting on a signal
+  (clearing a park, authoring attention) stays a session act through the graph
+  write path. Artifacts in prose per kind-strategy: the office-hours app
+  (redesigned), the design-system OfficeHours template with ContextPanel and
+  BudgetPaceChart, the office-hours-snapshot local producer. The legacy
+  gh-router work already migrating office-hours off hosted Firestore drains in
+  parallel; this strategy consumes its output rather than duplicating it."
+reading: null
+gap: null
+serves:
+  - virtue-alignment-of-attachments
+recovers:
+  - delegation-firebase
+clarifications:
+  - question: Is the office-hours redesign a new strategy, or edits to the
+      strategies that already name the surface?
+    answer: A new sub-strategy of strategy-explicit-intent. The surface is the
+      cross-cutting materialization of several strategies' sensors and none
+      owned it — no single node carried its success_signal, conditions, or
+      recovers edge. Apps stay prose-named artifacts; the strategy is the
+      standing posture that attention is allocated from one graph-backed
+      surface. Recorded 2026-07-03 interview.
+  - question: What is the status page's core shape — bespoke domain cards or a
+      uniform list?
+    answer: One attention-ranked queue of typed signals. Signals are of a type; each
+      type is associated with a compact view (rendered in the list) and a
+      context view (rendered in the context panel when the signal is selected).
+      The design-system OfficeHours template's Budgets card rows generalize into
+      signal rows; BudgetPaceChart becomes the context view of the budget signal
+      types. Recorded 2026-07-03 interview.
+  - question: Where do the example status-page signals live in the graph — are new
+      strategies required?
+    answer: "No new signal strategies. Runway and dollar-spend budgets:
+      strategy-financial-sustainability's success_signal (projected runway),
+      sensor supplied by strategy-recover-finance. Velocity (tactics created vs
+      closed, backlog growth by subtree): strategy-autonomous-execution's
+      attention-economics signal, raw data from the store's phase-transition
+      history and selection log (the graph-native lifecycle sensor).
+      Marketing/analytics/performance: strategy-promote-progressive-detachment
+      (adoption with migration freedom) and strategy-own-audience (platform-free
+      reach). The surface renders these strategies' readings; it owns only its
+      own signal. Recorded 2026-07-03 interview."
+  - question: Where does the token-spend budget signal live, given pace telemetry is
+      deliberately outside the graph?
+    answer: As the sensor for strategy-autonomous-execution's standing condition
+      that frontier-agent access remains economical at individual scale.
+      Conditions are standing review triggers; the status page reads the local
+      pace telemetry files and attributes the signal to that condition.
+      Telemetry and tunables stay operational config outside the graph per
+      strategy-graph-native-dispatch clarification 14. Recorded 2026-07-03
+      interview.
+  - question: Does the surface write to the graph?
+    answer: Read-only v1. The graph is read from the local clone (File System Access
+      API over intentions/, per the existing local-first package), signals from
+      network-share files. Acting on a signal — clearing an office_hours park,
+      authoring an attention boost — stays a session/graph-commit act outside
+      the browser, keeping a single writer implementation while graph-commit
+      itself is still being built. Recorded 2026-07-03 interview.
+  - question: Where do the legacy dashboard panels (History, Audit, Reminders,
+      Queue, Parked, ProjectSignals) land in the two-page redesign?
+    answer: Everything is represented as a signal or a view of the graph; that
+      accounts for everything on the legacy second page, which ceases to exist
+      as a concept. Reminders, project signals, and queue health become typed
+      signals in the status queue; parked nodes, router now/queue, and
+      history/audit become goals-page projections of the graph. Recorded
+      2026-07-03 interview.
+tooling_goals:
+  - kind: actuator
+    statement: status page — one attention-ranked queue of typed signals, each type
+      carrying a compact list view and a context panel view
+  - kind: actuator
+    statement: "goals page — graph exploration views: virtue roots and strategies,
+      subtree shape and development, delegation and capture, resolved attention,
+      router now/queue, office-hours queue"
+  - kind: actuator
+    statement: browser graph read layer — File System Access API over the local
+      clone's intentions/, client-side tree build and resolveAttention
+  - kind: sensor
+    statement: local signal adapters mapping non-versioned files (budget .benc,
+      office-hours snapshot, pace telemetry, analytics exports) to their owning
+      strategies' signals
+success_signal:
+  observable: office-hours sessions conducted from the surface, with every
+    rendered signal tracing to a graph node (success_signal or condition) and a
+    local data source
+  sensor: owner review at office-hours plus the surface's own source-of-truth audit
+  threshold: the office-hours ritual runs on the redesigned surface and the hosted
+    Firestore owner tier is retired — all owner data local-first
+  is_proxy: false
+attention: null
+attributes:
+  conditions:
+    - the local clone the surface reads stays fresh enough that attention and
+      rank read from it track origin/main
+    - signal files on local disk and network shares stay reachable from the
+      browser host; when a source is unreachable the surface fails loudly rather
+      than rendering stale signals
+    - strategy-graph-native-dispatch holds — orchestration state (phases, parks,
+      selection log) is readable from the store, so the router and queue views
+      need no GitHub queries
+    - the File System Access API, or an equivalent local read path, remains
+      available in the author's browser
+---
+# Office hours runs on the graph — one local-first surface (status signals and goals exploration) allocates the author's strategic attention

--- a/intentions/tactic-attention-surface-goals-page.md
+++ b/intentions/tactic-attention-surface-goals-page.md
@@ -1,0 +1,43 @@
+---
+id: tactic-attention-surface-goals-page
+kind: tactic
+statement: "draft: goals page — direct graph exploration views"
+owner: ai
+status: raw
+parent: null
+rationale: "Draft retained from the 2026-07-03 /align-strategy interview per the
+  retain-not-refine contract: tactical context only, no plan schema;
+  /align-tactics finalizes, splits, merges, or prunes."
+reading: null
+gap: null
+serves:
+  - strategy-attention-surface
+recovers: []
+clarifications: []
+tooling_goals: []
+success_signal: null
+attention: null
+attributes: {}
+---
+# draft: goals page — direct graph exploration views
+
+Retained draft context (2026-07-03 interview + exploration). Not a plan.
+
+Views, each answering one of the author's exploration questions:
+
+- Core virtues and strategies: virtue roots with their `serves` edges —
+  seed exists in `office-hours/src/components/IntentionTreePanel.tsx` and
+  `intention-tree.ts` `buildTree()`.
+- Shape and development: per-strategy subtree statistics (node counts,
+  status mix, tactic churn) — which strategies are most developed.
+- Delegation and capture: `recovers` edges plus delegation-record axes
+  (divergence/irreversibility) — where delegation concentrates and where
+  capture is highest.
+- Attention: resolved-rank overlay (`resolveAttention`; cf. the
+  frontier-view tooling goal on strategy-graph-drives-dispatch).
+- Router now/queue: persisted `phase` fields, the claimed set, and the
+  selection log (graph-native dispatch §3) — what is executing, what is
+  queued, in rank order.
+- Office-hours queue: the projection over `office_hours != null` nodes
+  (graph-native dispatch §1.3), replacing the legacy Parked panel; history
+  and audit render as graph views here too (strategy clarification 6).

--- a/intentions/tactic-attention-surface-graph-read.md
+++ b/intentions/tactic-attention-surface-graph-read.md
@@ -1,0 +1,40 @@
+---
+id: tactic-attention-surface-graph-read
+kind: tactic
+statement: "draft: browser graph read layer — File System Access API over the
+  local clone's intentions/, client-side tree build and resolveAttention"
+owner: ai
+status: raw
+parent: null
+rationale: "Draft retained from the 2026-07-03 /align-strategy interview per the
+  retain-not-refine contract: tactical context only, no plan schema;
+  /align-tactics finalizes, splits, merges, or prunes."
+reading: null
+gap: null
+serves:
+  - strategy-attention-surface
+recovers: []
+clarifications: []
+tooling_goals: []
+success_signal: null
+attention: null
+attributes: {}
+---
+# draft: browser graph read layer — File System Access API over the local clone's intentions/, client-side tree build and resolveAttention
+
+Retained draft context (2026-07-03 interview + exploration). Not a plan.
+
+- Read the graph from the local repo clone: FSA directory handle over
+  `intentions/`, persisted via `@commons-systems/local-first`
+  (`createFsaHandleStore`, `detectFsaCapabilities`) — the same pattern the
+  budget app and the office-hours `.benc` reader already use.
+- Parse node frontmatter in the browser (YAML) and reuse
+  `office-hours/src/intention-tree.ts` `buildTree()`; rank ordering comes
+  from intentionsutil's `resolveAttention`, which needs a browser-safe
+  import path (type-only imports are already the office-hours convention).
+- Supersedes the build-time seed
+  (`office-hours/src/vite-plugin-intention-tree-seed.ts`) for the owner
+  tier; the seed can remain the demo-tier data source.
+- Staleness is a recorded strategy condition: surface the clone's HEAD age
+  and fail loudly when it no longer tracks origin/main — never render stale
+  rank silently.

--- a/intentions/tactic-attention-surface-signal-types.md
+++ b/intentions/tactic-attention-surface-signal-types.md
@@ -1,0 +1,49 @@
+---
+id: tactic-attention-surface-signal-types
+kind: tactic
+statement: "draft: typed signal model — signal-type registry with compact and
+  context views, local file adapters, owning-node attribution"
+owner: ai
+status: raw
+parent: null
+rationale: "Draft retained from the 2026-07-03 /align-strategy interview per the
+  retain-not-refine contract: tactical context only, no plan schema;
+  /align-tactics finalizes, splits, merges, or prunes."
+reading: null
+gap: null
+serves:
+  - strategy-attention-surface
+recovers: []
+clarifications: []
+tooling_goals: []
+success_signal: null
+attention: null
+attributes: {}
+---
+# draft: typed signal model — signal-type registry with compact and context views, local file adapters, owning-node attribution
+
+Retained draft context (2026-07-03 interview + exploration). Not a plan.
+
+- Author decision (strategy clarification 2): signals are of a type; each
+  type carries a compact view (list row) and a context view (context
+  panel). Registry entry shape, roughly: `{ typeId, owningNode:
+  {id, signalKind: success_signal | condition}, sourceAdapter, CompactView,
+  ContextView }`.
+- Source adapters read non-versioned local/network-share files:
+  - budget `.benc` snapshots (runway + dollar spend →
+    strategy-financial-sustainability; reuse `budget/src/local-file.ts`
+    patterns and `office-hours/src/snapshot.ts` + `crypto.ts` decryption);
+  - `office-hours-current.benc` from the `office-hours-snapshot/` local
+    producer (reminders, queue metrics, project signals);
+  - pace telemetry (`rate_limits.json`, target-workers config) →
+    strategy-autonomous-execution's frontier-economy condition;
+  - analytics exports (GA4/GSC/PSI, per delegation-web-analytics) →
+    strategy-promote-progressive-detachment / strategy-own-audience.
+- Velocity (created vs closed, backlog growth by subtree) computes from the
+  store itself — phase-transition history in the `intentions/` git log and
+  the router selection log (see tactic-dispatch-lifecycle-sensor). Open
+  question for /align-tactics: the browser cannot run git; either the
+  office-hours-snapshot producer folds a velocity series into the snapshot,
+  or the clone-read layer derives it from node state alone.
+- Reminders, project signals, and queue health from the legacy dashboard
+  become signal types here (strategy clarification 6).

--- a/intentions/tactic-attention-surface-status-page.md
+++ b/intentions/tactic-attention-surface-status-page.md
@@ -1,0 +1,42 @@
+---
+id: tactic-attention-surface-status-page
+kind: tactic
+statement: "draft: status page — attention-ranked signal queue with per-signal
+  context panel"
+owner: ai
+status: raw
+parent: null
+rationale: "Draft retained from the 2026-07-03 /align-strategy interview per the
+  retain-not-refine contract: tactical context only, no plan schema;
+  /align-tactics finalizes, splits, merges, or prunes."
+reading: null
+gap: null
+serves:
+  - strategy-attention-surface
+recovers: []
+clarifications: []
+tooling_goals: []
+success_signal: null
+attention: null
+attributes: {}
+---
+# draft: status page — attention-ranked signal queue with per-signal context panel
+
+Retained draft context (2026-07-03 interview + exploration). Not a plan.
+
+- Generalize the design-system two-page proposal
+  (`packages/ds/src/templates/OfficeHours.tsx`, `page: "status"`): the
+  Budgets card's clickable rows become signal rows in one attention-ranked
+  queue; every legacy panel either becomes a signal type or moves to the
+  goals page (strategy clarification 6).
+- Ordering: `resolveAttention` over each signal's owning node; threshold
+  breaches (non-null `gap`) float within their rank tier.
+- Context panel: reuse `packages/ds/src/templates/ContextPanel.tsx`
+  (`ContextPanel`/`ContextPanelToggle`) and
+  `packages/ds/src/charts/BudgetPaceChart.tsx` as the context view for the
+  budget signal types; each signal type supplies its own context view per
+  the typed-signal registry (tactic-attention-surface-signal-types).
+- Canvas: the DS `OfficeHours.stories.tsx` stories (`Status`,
+  `StatusBudgetSelected`) are the design-canvas artifacts for /align-tactics
+  to iterate against via DesignSync (canvas is stale until the claude.ai
+  project is opened/refreshed).


### PR DESCRIPTION
## /align-strategy session record

Interview-driven strategy recording per `tactic-graph-native-dispatch` §2.2 (the /align-strategy skill is not yet built — this session ran its five steps manually; graph-commit is likewise not yet built, so the record lands via PR per the bootstrap precedent).

**Requirement:** the office-hours UI project redesigned onto the intention graph — a status page (attention-prioritized typed signals, compact list + context panel, sources on local disk/network shares) and a goals page (direct graph exploration), reading the graph from a local clone via the existing local-first patterns.

### Nodes

- `strategy-attention-surface` — new sub-strategy of `strategy-explicit-intent`; recovers `delegation-firebase`; six dated clarifications from the 2026-07-03 interview (placement, typed-signal status page, signal homes, token-spend home, read-only v1, legacy-panel fate); success threshold: the office-hours ritual runs on the redesigned surface and the hosted Firestore owner tier is retired.
- `delegation-web-analytics` — raw intake record (GA4/GSC/PSI), a complete-ledger leak caught during signal mapping: divergence moderate (engagement-metric framing), irreversibility low.
- Four draft tactics (`status: raw`, retain-not-refine): graph-read layer, typed signal model + adapters, status page, goals page — input for a future /align-tactics round, not plans.

### Signal homes decided in the interview

- Runway + dollar budgets → `strategy-financial-sustainability` (sensor from `strategy-recover-finance`)
- Token budgets → `strategy-autonomous-execution`'s frontier-economy condition (pace telemetry stays outside the graph)
- Velocity/backlog → `strategy-autonomous-execution` (data per the graph-native lifecycle sensor)
- Marketing/analytics → `strategy-promote-progressive-detachment` + `strategy-own-audience` via `delegation-web-analytics`

No new signal strategies were required.

### Verification

`npm test --prefix packages/intentionsutil` — 109/109 passed; explicit `listNodes` + `validateGraph` over the store — OK, 91 nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)