### PR TITLE
intentions: bootstrap-transition doctrine — phase writes on main are what schedule QA/review/merge workers (clarification 15)

### DIFF
--- a/intentions/strategy-graph-native-dispatch.md
+++ b/intentions/strategy-graph-native-dispatch.md
@@ -203,6 +203,27 @@ clarifications:
       budget — it bypasses the gate, not the count or the order — and never
       overrides genuine token exhaustion (the --exhausted hard floor,
       main-broken parity). Recorded 2026-07-03 interview."
+  - question: Before the transitions tactic lands, who advances a graph-native
+      tactic's phase on main — how do QA, review, CI-gated fix, and merge
+      workers get scheduled?
+    answer: "Bootstrap-transition doctrine. Parity with the legacy router means the
+      completing worker's state write to origin/main is what schedules the next
+      phase worker (dispatch-complete-phase parity): selection reads main, so a
+      phase that ends without the write schedules nothing. Until
+      tactic-graph-router-transitions and tactic-graph-commit are live, every
+      session completing a phase on a graph-native tactic must itself end the
+      phase with the transition write to main — phase (implement -> fix/qa ->
+      review -> done, per the CI-verdict and mergeability sensors), execution.pr
+      when the work PR opens, attempt counters, and markers. The write is a
+      state-only intentions/ commit, never part of the work PR (the work PR
+      merges at the end of the lifecycle; state must land on main while it is
+      still open): direct-pushed once tactic-intentions-branch-protection lands,
+      delivered as a state-only PR the author merges until then. Fields ride
+      squatted attributes.* until tactic-graph-dispatch-schema is on main, since
+      main's validator gates the first-class shapes. Gap observed live
+      2026-07-03: PR #2742 opened with the schema tactic still phase: implement
+      on main, leaving qa/review/merge unscheduled. The doctrine retires when
+      the transitions tactic lands. Recorded 2026-07-03 from author review."
 tooling_goals:
   - kind: actuator
     statement: /align-strategy — interview-driven strategy recording, superseding

--- a/intentions/tactic-graph-native-dispatch.md
+++ b/intentions/tactic-graph-native-dispatch.md
@@ -325,6 +325,14 @@ GitHub is a separate strategy; design TBD.)
 - **Removal:** when the gh queue is empty, delete the legacy
   selector/phase-derivation scripts and the `dispatch:*` label
   conventions.
+- **Bootstrap transitions (clarification 15):** until
+  `tactic-graph-router-transitions` lands, no machinery advances a
+  graph-native tactic's phase on `origin/main` — so a completing session
+  writes the transition itself as a state-only commit (never on the work
+  PR branch; squatted `attributes.*` until the schema tactic merges;
+  delivered as a state-only PR until `tactic-intentions-branch-protection`
+  lands). Without that write, the next phase worker — fix, qa, review —
+  is never scheduled.
 
 ### 3.4 Worktree anchoring and claiming
 
@@ -421,10 +429,10 @@ tactic-intentions-branch-protection (park) ┤                                 �
   reaches it, so the calculated-attention signal term demotes it at read
   time; no stored flag (clarifications 9/11). Round 1 had deferred it by
   omission.
-- **Re-evaluations (2026-07-03):** three same-day mid-flight strategy edits
-  (clarifications 8–10, then 11, then 12–14), each followed by the
-  clarification-10 re-evaluation run inline because no router exists yet.
-  The first added the attention tactic and recorded the `/align-init`
+- **Re-evaluations (2026-07-03):** four same-day mid-flight strategy edits
+  (clarifications 8–10, then 11, then 12–14, then 15), each followed by
+  the clarification-10 re-evaluation run inline because no router exists
+  yet. The first added the attention tactic and recorded the `/align-init`
   deferral; the second replaced the banded backlog mechanism with
   calculated attention: `tactic-signal-path-attention` was pruned and
   replaced by `tactic-calculated-attention` (on-path — it hard-blocks
@@ -434,6 +442,12 @@ tactic-intentions-branch-protection (park) ┤                                 �
   schema tactic, strategy-id claiming, the pace-exempt probe lane,
   uniform node-id worktree keys, and the node-target launch chain (unit
   4) added to the selector tactic, §1.1/§3.2/§3.4 amended; no tactic was
+  pruned and no `blocked_by` changed. The fourth recorded the
+  bootstrap-transition doctrine after the first graph-native implement PR
+  (#2742, the schema tactic) opened with no path to scheduling its own
+  qa/review/merge: §3.3 gained the bootstrap bullet, and the transitions
+  tactic's context/unit 1 now state the write-is-scheduling parity rule,
+  the by-hand interim, and explicit auto-merge arming; no tactic was
   pruned and no `blocked_by` changed.
 - This parent is not directly executable (no `phase`); it completes when
   its last child completes, which stamps the strategy's `rounds`.

--- a/intentions/tactic-graph-router-transitions.md
+++ b/intentions/tactic-graph-router-transitions.md
@@ -35,6 +35,15 @@ truth to sensors consulted before a transition commits. Out-of-band gh
 events are absorbed by a reconciler sweep. Spec:
 `intentions/tactic-graph-native-dispatch.md` §1.1 and §2.4.
 
+The transition write is the scheduling mechanism (legacy parity): selection
+reads `origin/main`, so the write that ends a phase is what makes the next
+phase worker — fix, qa, review — selectable, exactly as
+`dispatch-complete-phase`'s label edits do today. Until this tactic lands,
+sessions completing a phase on a graph-native tactic apply the
+bootstrap-transition doctrine by hand (strategy clarification 15: the
+completing session writes the transition to main as a state-only commit,
+never on the work PR branch); that doctrine retires here.
+
 ## Unit 1 — phase transitions and execution state as graph writes
 
 **Recommended model:** opus
@@ -52,6 +61,12 @@ read-only gh calls (the read side of
 `.claude/skills/dispatch-propagate/scripts/dispatch-phase` survives as this
 sensor layer; its derivation-to-phase logic does not apply to graph-native
 tactics).
+
+Merge-when-ready parity: a clean review completion arms gh auto-merge on
+the PR (same config gate as today, `dispatch-auto-merge` conventions
+unchanged — spec §2.4's carried-over phase-skill internals); the merge
+itself lands out-of-band and Unit 2's sweep absorbs it into `done`. No
+graph-side merge step exists.
 
 ## Unit 2 — reconciler sweep and completion pruning
 


### PR DESCRIPTION
Parity gap caught by author review: the recorded design covers steady-state scheduling of QA, review, CI-gated fix, and merge-when-ready workers (transitions tactic + selector sensor gates + carried-over auto-merge), but nothing recorded how a graph-native tactic's phase advances on `origin/main` *before* `tactic-graph-router-transitions` lands. In that window a completed implement phase schedules nothing — observed live when PR #2742 opened with its tactic still `phase: implement` on main, leaving qa/review/merge unscheduled.

Three single-node commits:

1. **Clarification 15 on `strategy-graph-native-dispatch`** (via `write-node.ts`): the bootstrap-transition doctrine. The completing session ends its phase with the transition write to main — `phase` per the CI/mergeability sensors, `execution.pr`, attempts, markers — as a state-only `intentions/` commit, never on the work PR branch (the work PR merges at the end of the lifecycle; state must land while it is open). Squatted `attributes.*` until the schema tactic merges; state-only PR until `tactic-intentions-branch-protection` lands. Retires when the transitions tactic lands.
2. **`tactic-graph-router-transitions`** (clarification-10 re-evaluation, hand-edited body): context states the write-is-scheduling parity rule and the by-hand interim; unit 1 makes merge-when-ready explicit — clean review arms gh auto-merge (config gate unchanged), the merge lands out-of-band, unit 2's sweep absorbs it into `done`.
3. **Spec parent §3.3 + §5**: bootstrap-transition bullet in coexistence; re-evaluation history now records four same-day strategy edits.

No tactic pruned, no `blocked_by` changed; the rest of the subtree is unaffected (the doctrine is transitional and lives at the transition seam). Record-only — no worker steps executed; #2742's own state stamp deliberately not written per author direction.

Verification: `npm test --prefix packages/intentionsutil` — 109/109 pass (includes `validateGraph` over the live store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)