### PR TITLE
intentions: bootstrap-transition — schema tactic implement -> qa

### DIFF
--- a/intentions/tactic-graph-dispatch-schema.md
+++ b/intentions/tactic-graph-dispatch-schema.md
@@ -21,8 +21,12 @@ tooling_goals: []
 success_signal: null
 attention: null
 attributes:
-  phase: implement
+  phase: qa
   blocked_by: []
+  execution:
+    pr: 2742
+    attempts:
+      fix: 1
 ---
 # intentionsutil: first-class execution state — phase, execution, blocked_by, office_hours, rounds — and tactic-body preservation in writeNode
 


### PR DESCRIPTION
State-only phase write, per strategy clarification 15's bootstrap-transition doctrine (#2744).

`tactic-graph-dispatch-schema` (#2742) opened during `implement` with a failing `type-safety-sensor` check (net-new non-null assertions in the new `validateGraph` rules 13/14). This session fixed it directly on #2742's branch (commit 885bd94b) — all 21 CI checks are now green and the PR is `MERGEABLE`.

Per legacy-router parity, selection reads `origin/main`, so the phase write that ends a phase is what schedules the next phase worker. Without this commit, QA never gets scheduled for the schema tactic even though its PR is ready. This writes `phase: implement -> qa` and records the fix attempt, riding squatted `attributes.*` since main's `schema.ts` predates the first-class fields #2742 itself introduces.

Not part of #2742 — state must land on main while that PR is still open, per the doctrine.

Verification: a local harness calling `validateGraph(listNodes(...))` confirms all 91 nodes still pass graph integrity checks; tactic body preserved byte-for-byte (frontmatter-only diff).