### PR TITLE
ci: graph/** fast path for intentions/-only direct pushes to main

### DIFF
--- a/.github/workflows/graph-fast-path.yml
+++ b/.github/workflows/graph-fast-path.yml
@@ -1,0 +1,69 @@
+name: Graph Fast Path
+
+on:
+  push:
+    branches: ['graph/**']
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+      - name: Verify the push is intentions/-only
+        run: |
+          set -euo pipefail
+          CHANGED=$(git diff --name-only origin/main...HEAD)
+          if [ -z "$CHANGED" ]; then
+            echo "::error::No changes relative to origin/main — nothing to fast-path."
+            exit 1
+          fi
+          BAD=$(printf '%s\n' "$CHANGED" | grep -v '^intentions/' || true)
+          if [ -n "$BAD" ]; then
+            echo "::error::graph/** fast path only accepts intentions/-only pushes. Non-intentions/ paths changed:"
+            printf '%s\n' "$BAD"
+            exit 1
+          fi
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: .node-version
+          cache: 'npm'
+      - name: Install workspace dependencies
+        run: npm ci
+      - name: Validate intention graph
+        run: npx tsx packages/intentionsutil/scripts/validate-graph.ts intentions
+
+  acceptance:
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: echo "graph fast path — intentions/-only push; required context stamped (real check runs in PR CI for code changes)"
+
+  preview-and-smoke:
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: echo "graph fast path — intentions/-only push; required context stamped (real check runs in PR CI for code changes)"
+
+  lint:
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: echo "graph fast path — intentions/-only push; required context stamped (real check runs in PR CI for code changes)"
+
+  unit-tests:
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: echo "graph fast path — intentions/-only push; required context stamped (real check runs in PR CI for code changes)"

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -16,6 +16,7 @@ on:
       - "*.md"
       - "*.nix"
       - "flake.lock"
+      - "intentions/**"
 
 permissions:
   contents: read

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - main
+      - 'graph/**'
 
 permissions:
   contents: read

--- a/intentions/tactic-graph-commit.md
+++ b/intentions/tactic-graph-commit.md
@@ -24,7 +24,9 @@ attributes:
   blocked_by:
     - tactic-graph-dispatch-schema
   execution:
-    pr: 2748
+    pr: null
+    markers:
+      - unit-2-merged:2748
 ---
 # graph-commit primitive: validated single-node writes direct-pushed to main with rebase-retry, restricted to intentions/; CI fast path for intentions/-only pushes
 
@@ -57,9 +59,12 @@ Out of scope: converting callers (sibling tactics adopt the primitive).
 
 ## Unit 2 — CI fast path for intentions/-only pushes
 
+**Status:** merged 2026-07-04 via this PR (#2748).
+
 **Recommended model:** sonnet
 
-Independent of Unit 1 (parallel-safe).
+Independent of Unit 1 (parallel-safe) — shipped ahead of it since Unit 1
+remains blocked by `tactic-graph-dispatch-schema`.
 
 Scope (per the 2026-07-03 branch-protection decision, strategy
 clarification 16):

--- a/packages/intentionsutil/scripts/validate-graph.ts
+++ b/packages/intentionsutil/scripts/validate-graph.ts
@@ -1,0 +1,24 @@
+// Validates the intention-graph state directory: loads every node with
+// listNodes, then runs validateGraph's integrity checks (dangling refs,
+// cycles, etc.) across the whole set. Used as the guard step of the
+// graph/** CI fast path — an intentions/-only push validates its own state
+// in seconds, rather than waiting on the full PR CI lane.
+//
+// Usage:
+//   npx tsx packages/intentionsutil/scripts/validate-graph.ts [intentionsDir]
+//
+// Defaults to `intentions` (relative to cwd) when no argument is given.
+// validateGraph throws IntentionSchemaError on any problem — this script
+// lets that propagate, so a bad graph exits non-zero with the error message.
+
+import { listNodes } from "../src/store.js";
+import { validateGraph } from "../src/schema.js";
+
+function main(): void {
+  const intentionsDir = process.argv[2] ?? "intentions";
+  const nodes = listNodes(intentionsDir);
+  validateGraph(nodes);
+  process.stdout.write(`ok — ${nodes.length} nodes\n`);
+}
+
+main();


### PR DESCRIPTION
## Mechanism

The repo ruleset on `main` requires four status checks (`acceptance`, `preview-and-smoke`, `lint`, `unit-tests`) but has no pull-request requirement — checks attach to commit SHAs, so a direct push to `main` is accepted once the pushed SHA already carries all four passing contexts.

This adds `.github/workflows/graph-fast-path.yml`, scoped to `push` on `graph/**` scratch branches:

1. **`guard` job** — checks out with `fetch-depth: 0`, computes `CHANGED=$(git diff --name-only origin/main...HEAD)`, and hard-fails (exit 1) if the diff is empty or any changed path is not under `intentions/`. It then runs the new `packages/intentionsutil/scripts/validate-graph.ts` (a thin CLI over `listNodes` + `validateGraph`) against the `intentions/` directory to confirm graph integrity (no dangling refs, no cycles, schema-valid nodes).
2. **Four stamp jobs** — `acceptance`, `preview-and-smoke`, `lint`, `unit-tests` (job id *is* the check context, no `name:` field), each `needs: guard`, each a single `echo` step. On success they stamp the four required contexts onto the SHA in roughly a minute.
3. The intention-graph writer then fast-forwards that same SHA onto `main` — no re-run, no PR merge, since the SHA already carries all four required contexts.

Two guard-rail edits keep this isolated:
- `unit-tests.yml` adds `graph/**` to its `branches-ignore` list, so the heavy CI lane doesn't also fire on scratch pushes and produce duplicate `unit-tests`/`lint` contexts.
- `prod-deploy.yml` adds `intentions/**` to `paths-ignore`, so state-only pushes to `main` don't trigger a production deploy.

`pr-checks.yml` is `pull_request`-only and untouched, so it never runs on a `graph/**` push and can't produce a conflicting context.

## References

- tactic-graph-commit, Unit 2
- strategy-graph-native-dispatch, clarification 16
- sibling state PR #2747

## Post-merge verification

1. Author a whitespace-only commit under `intentions/` (no code changes).
2. Push it to a scratch branch, e.g. `graph/verify-branch-protection`.
3. Wait for `graph-fast-path.yml` to go green — `guard` should pass in well under a minute, followed by the four stamp jobs.
4. Fast-forward the stamped SHA onto `main`: `git push origin <sha>:main`.
5. Confirm the ruleset accepts the push (all four required contexts present) and that `prod-deploy.yml` does *not* fire for this SHA.
6. Revert the whitespace change through the same lane (new intentions/-only commit → `graph/**` branch → green → fast-forward to `main`) to confirm the round-trip is repeatable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErSgRZ7C2rzHn1tjQmDerJ