### PR TITLE
intentions: /align-strategy record — strategy-token-economy

### DIFF
--- a/intentions/delegation-anthropic-claude.md
+++ b/intentions/delegation-anthropic-claude.md
@@ -53,7 +53,9 @@ attributes:
   non_delegable_floor: the ability to evaluate what the agent produces; if that
     atrophies the open source is nominal and recovery is severed
   review_trigger: runway-rule breach; open-weight capability gap widening; terms
-    gating individual-scale use
+    gating individual-scale use; plan pricing structure change (prepaid
+    allowance to metered) — the premise strategy-token-economy's throughput
+    framing rests on
   last_assessed: 2026-07-02
 ---
 # Software construction delegated to Anthropic's Claude

--- a/intentions/strategy-graph-native-dispatch.md
+++ b/intentions/strategy-graph-native-dispatch.md
@@ -239,6 +239,25 @@ clarifications:
       the writer then fast-forwards the same SHA to main, rebasing and
       re-running on reject. Heavy CI still guards any diff touching paths
       outside intentions/. Implementation is tactic-graph-commit Unit 2."
+  - question: Beyond the pace curve (clarification 14), does the legacy
+      router's token-optimization machinery carry over to the graph-native
+      router?
+    answer: "Yes — parity recorded 2026-07-04 (strategy-token-economy
+      interview). Two commitments. Routing parity: the graph-native launch
+      chain applies per-phase model and effort routing with the same
+      fail-closed demotable allowlist and the audit-written policy file
+      (legacy dispatch-phase-model / dispatch-phase-effort /
+      phase-model-policy.json), and align-family sessions themselves get
+      explicit routing — interview and decomposition sessions on Opus, their
+      Explore fan-out on Sonnet or Haiku. Attribution parity: every
+      graph-native session (align-family, router tick, tactic phase worker)
+      stamps its node id and phase into the transcript sidecar so the token
+      audit gains a by-node join; without it graph-native work lands in the
+      audit's unattributed bucket — already the largest spend line in the
+      2026-06-26→07-03 window — precisely as the queue migrates. The durable
+      home for the requirements and their signal is strategy-token-economy;
+      this clarification records only what the migration must carry.
+      Recorded 2026-07-04 interview."
 tooling_goals:
   - kind: actuator
     statement: /align-strategy — interview-driven strategy recording, superseding

--- a/intentions/strategy-token-economy.md
+++ b/intentions/strategy-token-economy.md
@@ -1,0 +1,118 @@
+---
+id: strategy-token-economy
+kind: strategy
+statement: The prepaid token allowance converts fully into tactic closure —
+  utilization near 100%, closure velocity at or above arrival
+owner: human
+status: refining
+parent: strategy-financial-sustainability
+rationale: "Claude access is prepaid (Max 20x plan): the marginal token is sunk
+  cost, so the economy is throughput, not savings. The two failing states are
+  an under-utilized weekly allowance (paid capacity idle) and an allowance
+  burned without closing work (claude-eligible tactics arriving faster than
+  they close). Efficiency mechanisms — per-phase model and effort routing,
+  context discipline, error hygiene — are throughput levers: an Opus token
+  draws the weekly allowance several times faster than a Sonnet token, so
+  routing and context discipline convert the same allowance into more closed
+  tactics. Dollars enter only at plan renewal, which the parent
+  strategy-financial-sustainability's runway rule owns. The legacy dispatch
+  router embodies five such mechanisms (phase→model routing with the
+  audit-written policy loop, phase→effort routing, context-pack and
+  Explore-subagent context discipline, the pace curve, and the
+  /dispatch-token-audit measurement itself); only the pace curve has a graph
+  home (strategy-graph-native-dispatch clarification 14). This strategy is the
+  durable home for the rest, so the requirements survive
+  tactic-legacy-router-removal. Measurement precedes control: the token audit
+  is this strategy's sensor, and its attribution must survive the graph-native
+  migration (see the attribution-parity clarification on
+  strategy-graph-native-dispatch). The strategy also manages the 'promote the
+  vendor's growth via spend' divergence imported by delegation-anthropic-claude:
+  on prepaid terms that import is bounded at plan price and reviewed at
+  renewal, which is its alignment-of-attachments content."
+reading: null
+gap: null
+serves:
+  - virtue-alignment-of-attachments
+recovers: []
+clarifications:
+  - question: Why a standing strategy rather than clarifications on
+      strategy-graph-native-dispatch?
+    answer: The concern outlives the migration and carries its own signal and
+      conditions — token economy was managed before the graph-native router
+      and continues after the legacy router is deleted. Placement decided in
+      interview — a new strategy holding the standing requirements, plus one
+      parity clarification on strategy-graph-native-dispatch covering what the
+      migration specifically must carry over, mirroring how pace parity was
+      recorded there (clarification 14). Recorded 2026-07-04 interview.
+  - question: What does token optimization mean on a prepaid plan?
+    answer: Throughput per allowance, not spend reduction. The success signal
+      is dual — weekly allowance utilization near 100%, and claude-eligible
+      tactic closure velocity at or above arrival. Full utilization with a
+      growing backlog fails the signal — the response is to operate more
+      efficiently (routing, context discipline), not to spend less. The
+      dollar-denominated figures in the token audit remain useful as
+      allowance-consumption proxies for ranking, not as a bill to minimize.
+      Recorded 2026-07-04 interview.
+  - question: Which routing decisions may the control loop make automatically?
+    answer: Only those grounded in yield metrics whose denominator the routed
+      phase can actually move. The 2026-07-03 audit's qa→Opus promotion is a
+      measurement artifact — qa's fixes route through /implement-unit
+      subagents and never land in the outcome envelope's fixes_applied, so
+      pooled qa hit_rate reads 0 structurally (0 in-envelope fixes against 108
+      findings across 84 sessions) regardless of how well the cheap model
+      performs. Promotions from such metrics stay untrusted until the
+      accounting is fixed or the phase routes on a metric it can move (detail
+      retained on tactic-outcome-envelope-qa-accounting). Recorded 2026-07-04
+      interview.
+  - question: Do the skill-contract disciplines get recorded, or stay folklore?
+    answer: "Recorded, two families. Context discipline: Explore-subagent
+      fan-out returning compact findings, clean-context phase boundaries, and
+      model sonnet/haiku on subagents spawned from Opus- or Fable-priced
+      parents are contract requirements for the align skill family, inheriting
+      the plan-issue/implement-unit discipline — the over-120k-context lens
+      was more than half of all measured spend in the 2026-06-26→07-03
+      window, dominated by unattributed sessions and plan-issue.
+      Initialization defaults: background sessions that author no code
+      (diagnostics, reminders, digest, main-qa verification) launch on Sonnet
+      instead of inheriting Opus (detail retained on
+      tactic-noncodegen-session-model-defaults). Recorded 2026-07-04
+      interview."
+tooling_goals:
+  - kind: sensor
+    statement: token-audit aggregate with node-id attribution — weekly
+      allowance utilization plus per-node/per-phase spend and yield, joined by
+      the intention node id (extends /dispatch-token-audit)
+  - kind: sensor
+    statement: velocity series — claude-eligible tactics created vs closed per
+      strategy subtree (shared with strategy-autonomous-execution via
+      tactic-attention-surface-velocity-pace)
+  - kind: actuator
+    statement: phase→model and phase→effort routing in the graph-native launch
+      chain, with the fail-closed demotable allowlist and the audit-written
+      policy loop
+success_signal:
+  observable: weekly allowance utilization together with claude-eligible
+    tactic closure velocity (created vs closed)
+  sensor: pace telemetry (rate_limits.json weekly utilization) plus the
+    office-hours velocity series (tactic-attention-surface-velocity-pace) and
+    the token-audit aggregate
+  threshold: utilization near 100% of the weekly allowance while open
+    claude-eligible tactics are non-increasing (closure at or above arrival);
+    full utilization with a growing backlog fails the signal
+  is_proxy: true
+attention: null
+attributes:
+  conditions:
+    - the plan stays prepaid with a weekly allowance (Max 20x); metered
+      per-token pricing inverts the economy to spend-minimization and this
+      strategy re-derives from its virtues
+    - the token audit stays runnable and attributable across the router
+      migration — a session that cannot be attributed to a node and phase is
+      invisible to every control loop here
+    - routing automation acts only on yield metrics whose accounting is
+      verified (the qa fixes_applied gap is open as of 2026-07-04)
+    - pace machinery stays operational config outside the graph
+      (strategy-graph-native-dispatch clarification 14); this strategy records
+      requirements, not machinery
+---
+# The prepaid token allowance converts fully into tactic closure — utilization near 100%, closure velocity at or above arrival

--- a/intentions/strategy-token-economy.md
+++ b/intentions/strategy-token-economy.md
@@ -77,6 +77,25 @@ clarifications:
       instead of inheriting Opus (detail retained on
       tactic-noncodegen-session-model-defaults). Recorded 2026-07-04
       interview."
+  - question: What did /align-tactics round 1's drift review find?
+    answer: "Immaterial refinements, no condition failures. (a) qa-fix's fix
+      lane already maintains a landed-fix tally (SKILL.md Step 3.7), so the
+      metric-integrity artifact is better described as metric shape than
+      missing accounting: hit_rate mismeasures a phase whose designed output
+      is triage and follow-ups (68 filed, 0 in-lane fixes in the
+      2026-06-26→07-03 window); the remedy is per-phase metric selection in
+      the policy generator, which clarification 3 already licenses. (b) The
+      audit's 'qa-verify polling loop' reading was wrong — the 405 repeated
+      cd calls are per-issue worktree and session boots for sibling main-qa
+      follow-ups, with browser-verifiability triage running only after the
+      boot; remedy is triage-before-provision
+      (tactic-main-qa-triage-before-provision). (c) A live routing bug:
+      /qa-main is absent from dispatch-launch-worker's skill→phase map, so
+      qa-main sessions inherit Opus despite the recorded main-qa→Sonnet
+      default (tactic-noncodegen-session-model-defaults unit 1). Also this
+      round: success_signal.sensor renamed to the registry name
+      token-economy for the instrument tactic; tactic fingerprints stamped
+      after that edit. Recorded 2026-07-04 /align-tactics round 1."
 tooling_goals:
   - kind: sensor
     statement: token-audit aggregate with node-id attribution — weekly
@@ -93,9 +112,7 @@ tooling_goals:
 success_signal:
   observable: weekly allowance utilization together with claude-eligible
     tactic closure velocity (created vs closed)
-  sensor: pace telemetry (rate_limits.json weekly utilization) plus the
-    office-hours velocity series (tactic-attention-surface-velocity-pace) and
-    the token-audit aggregate
+  sensor: token-economy
   threshold: utilization near 100% of the weekly allowance while open
     claude-eligible tactics are non-increasing (closure at or above arrival);
     full utilization with a growing backlog fails the signal

--- a/intentions/tactic-main-qa-triage-before-provision.md
+++ b/intentions/tactic-main-qa-triage-before-provision.md
@@ -1,0 +1,106 @@
+---
+id: tactic-main-qa-triage-before-provision
+kind: tactic
+statement: main-qa triage before provision — run the browser-verifiability
+  triage in the selection chain so unverifiable follow-ups never cost a
+  worktree and session boot
+owner: ai
+status: codified
+parent: null
+rationale: "Split from the hygiene draft by /align-tactics round 1: the
+  audit's 'qa-verify polling loop' n-gram (405 occurrences / 39 sessions)
+  is per-issue worktree and session boots for sibling main-qa follow-ups,
+  with triage running only after the expensive boot."
+reading: null
+gap: null
+serves:
+  - strategy-token-economy
+recovers: []
+clarifications: []
+tooling_goals: []
+success_signal: null
+attention: null
+attributes:
+  phase: implement
+  execution:
+    strategy_fingerprint: 10f0314e331696714d42b26313b80c5a289d68ab0e3ce4d614bf2c97a94d4a67
+---
+# main-qa triage before provision — run the browser-verifiability triage in the selection chain so unverifiable follow-ups never cost a worktree and session boot
+
+## Context
+
+qa-main's cheap pre-filter — Step 4·0 "is this follow-up
+browser-verifiable?" (`.claude/skills/qa-main/SKILL.md:113-122`) — runs
+inside the worker session, after `dispatch-provision-worktree` and a full
+session boot have already been paid. Nine live
+`<N>-qa-verify-against-main-qa-n` worktrees exist right now; example
+issue #2650 (a NixOS/WSL on-box outcome, not browser-verifiable) still
+cost a worktree + boot to reach its immediate Step 4·0 rejection. The
+audit measured the resulting `cd`-per-boot n-gram at 405 occurrences in
+39 sessions.
+
+Greenfield shape: the triage criteria live in one script consulted by
+both the tick (pre-provision) and qa-main (in-session, as today's Step
+4·0 fallback for directly-invoked runs), so the two can never drift.
+
+## Unit 1 — shared triage script + pre-provision gate
+
+**Recommended model:** opus
+
+Scope:
+- New script
+  `.claude/skills/dispatch-propagate/scripts/dispatch-main-qa-triage`
+  taking an issue number: evaluates the Step 4·0 criteria
+  (browser-verifiable outcome, `URL_PATH` present, deploy-ready state)
+  from one `gh`/`dispatch-context-pack --issue` read; exits 0
+  (verifiable), 3 (not browser-verifiable), or nonzero on error — clear
+  errors, no fallback routing (`.claude/rules/code-style.md`).
+- Selection chain: where the tick's selected target resolves to the
+  main-qa lane (`dispatch-phase:89-90` → `dispatch-route:272` `INVOKE
+  /qa-main`), call the triage before `dispatch-provision-worktree`
+  (provision entry: `dispatch-provision-worktree:5`; launch cd at
+  `dispatch-launch-worker:79-90`). A not-verifiable result applies
+  qa-main's existing cannot-verify disposition path (label/park exactly
+  as the in-session Step 4·0 outcome would) without provisioning or
+  spawning.
+- `.claude/skills/qa-main/SKILL.md:113-122`: Step 4·0 delegates its
+  criteria to the shared script (kept for directly-invoked/interactive
+  runs), so the logic is single-sourced.
+- Tests: a triage-script unit section plus tick-integration cases in
+  `.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`
+  (verifiable → provision proceeds; not-verifiable → no provision, park
+  disposition applied).
+
+## Dependencies
+
+None. Independent of the routing-defaults tactic (which fixes what model
+a provisioned qa-main session gets; this tactic decides whether one is
+provisioned at all).
+
+## Reuse
+
+- `dispatch-context-pack --issue` for the single-read issue slice.
+- qa-main's cannot-verify disposition path (SKILL.md Step 4·0 outcome
+  handling) — reuse its labels/markers verbatim.
+- Test stub patterns for tick/launch in `test-dispatch-scripts.sh`.
+
+## Verification
+
+```verify
+.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+```
+
+Manual: seed a known non-browser-verifiable main-qa issue in a test
+selection pass — the tick logs the triage rejection and no
+`<N>-qa-verify-*` worktree appears; a browser-verifiable one provisions
+as before.
+
+## Implementation notes
+
+Single unit; implement in a subagent with `model: opus` (selection-chain
+change with disposition semantics); supply this Context and Scope;
+constrain to working-tree edits. SKILL.md edits can hit the auto-mode
+agent-behavior commit gate — expect a grant prompt. `strategy_fingerprint`
+recipe (interim until tactic-graph-dispatch-schema lands): sha256 hex of
+`JSON.stringify({statement, clarifications, conditions, serves,
+success_signal, tooling_goals})` as loaded by intentionsutil `listNodes`.

--- a/intentions/tactic-noncodegen-session-model-defaults.md
+++ b/intentions/tactic-noncodegen-session-model-defaults.md
@@ -1,14 +1,14 @@
 ---
 id: tactic-noncodegen-session-model-defaults
 kind: tactic
-statement: "draft: Sonnet-by-default initialization for non-codegen sessions —
-  aux background jobs plus the qa-main and file-issue lanes"
+statement: Sonnet-by-default initialization for non-codegen sessions — fix
+  the /qa-main routing gap and pass --model on the aux background-job spawns
 owner: ai
-status: raw
+status: codified
 parent: null
-rationale: Draft retained from the 2026-07-04 strategy-token-economy interview
-  (retain, not refine). Implements the initialization-defaults half of the
-  strategy's clarification 4.
+rationale: Finalized from the 2026-07-04 interview draft by /align-tactics
+  round 1. The round's recon found the qa-main half is a live routing bug,
+  not just an optimization.
 reading: null
 gap: null
 serves:
@@ -18,32 +18,99 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-attributes: {}
+attributes:
+  phase: implement
+  execution:
+    strategy_fingerprint: 10f0314e331696714d42b26313b80c5a289d68ab0e3ce4d614bf2c97a94d4a67
 ---
-# draft: Sonnet-by-default initialization for non-codegen sessions — aux background jobs plus the qa-main and file-issue lanes
+# Sonnet-by-default initialization for non-codegen sessions — fix the /qa-main routing gap and pass --model on the aux background-job spawns
 
-Notes retained from the interview session:
+## Context
 
-- Measured 2026-06-26→07-03: the unattributed `<none>`+Opus row was $3,600
-  proxy / ~$1,200 real for the week, dominated by sessions that never enter a
-  codegen skill.
-- Aux background jobs that author no code — `dispatch-diagnose-main`,
-  `dispatch-jit-reminder`, `qa-main` verification, digest — can launch with
-  `--model sonnet` at session start instead of inheriting Opus.
-- Highest-confidence phase demotions from the audit: `qa-main` (browser
-  verification against deployed prod) and `file-issue`
-  (classification/dedup) — together ~$285/wk real at Opus rates, ~$170/wk at
-  Sonnet. On the prepaid plan this is allowance headroom, not a bill cut.
-- `file-issue` is being superseded by the align skill family
-  (strategy-graph-native-dispatch), so its half of the requirement transfers
-  to align-session routing: interview/decomposition on Opus, Explore fan-out
-  on Sonnet or Haiku (routing-parity clarification on
-  strategy-graph-native-dispatch).
-- Existing plumbing to reuse: `dispatch-phase-model` /
-  `dispatch-phase-effort` consumption in `dispatch-launch-worker` and
-  `dispatch-spawn-job`; the `force-opus.json` global override remains the
-  kill-switch.
-- Subagent corollary: Fable-priced interactive parents bill at 67% of proxy
-  (vs Opus 33%, Sonnet 20%, Haiku 7% in the window) — fan-out from expensive
-  parents should pass `model: sonnet` (or `haiku` for pure search); the
-  plan-issue+Haiku row proves the plumbing works.
+The `<none>`+Opus row measured $3,600 proxy / ~$1,200 real for
+2026-06-26→07-03, dominated by sessions that never enter a codegen skill.
+Two concrete holes:
+
+1. **qa-main inherits Opus despite a Sonnet default.**
+   `dispatch-phase-model:66-73` maps `main-qa → claude-sonnet-4-6`, but
+   `dispatch-launch-worker`'s SKILL→PHASE case map
+   (`dispatch-launch-worker:146-154`) has no `/qa-main` arm — `PHASE=""`,
+   so `dispatch-phase-model` is never called (guard at line 156) and the
+   spawn omits `--model`. Untested: the launch-worker test section has no
+   `INVOKE /qa-main` case.
+2. **Aux background jobs pass no model.** `dispatch-tick`'s three direct
+   `dispatch-spawn-job` sites — `sync-repair` (tick:513-515),
+   `diagnose-main` (tick:524-526), `jit-reminder-<num>` (tick:535-537) —
+   all omit `--model`, inheriting Opus. Digest rides the jit-reminder
+   session (invoked in-session via the Skill tool), so it is covered by
+   the jit-reminder spawn.
+
+`file-issue` needs no change: it has no independent launch point — it is
+invoked in-session from qa-fix/review-fix (both Sonnet-routed), and its
+requirements-definition role is superseded by the align family, whose
+routing is the routing-parity clarification on
+strategy-graph-native-dispatch. The `force-opus.json` chokepoint
+(`dispatch-spawn-job:232-259`) continues to override everything here —
+the kill-switch is untouched.
+
+## Unit 1 — /qa-main phase mapping in dispatch-launch-worker
+
+**Recommended model:** sonnet
+
+Scope:
+- `dispatch-launch-worker:146-154`: add `/qa-main) PHASE=main-qa ;;` and
+  update the routing comment at line 136.
+- Tests: add an `INVOKE /qa-main` case to the launch-worker section of
+  `.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`
+  (section starts ~line 37282; the section copies the real
+  `dispatch-phase-model`, so assert the spawned argv carries
+  `--model claude-sonnet-4-6` and no `--effort`).
+- Close the adjacent unit-test gap:
+  `.claude/skills/dispatch-propagate/scripts/test-dispatch-phase-model.sh`
+  covers only `qa/review/plan/implement` — add default-map cases for
+  `fix-checks`, `fix-conflicts`, `main-qa`.
+
+## Unit 2 — --model on the aux spawn sites
+
+**Recommended model:** sonnet
+
+Scope:
+- `dispatch-tick:513-515, 524-526, 535-537`: pass
+  `--model claude-sonnet-4-6` on the `sync-repair`, `diagnose-main`, and
+  `jit-reminder-<num>` spawns. None of these author product code:
+  sync-repair runs `/commit-merge-push` (whose conflict recovery already
+  escalates to an Opus subagent internally), diagnose-main diagnoses,
+  jit-reminder runs reminder skills including digest.
+- Tests: extend the dispatch-tick spawn assertions in
+  `test-dispatch-scripts.sh` to assert the forwarded `--model` on each of
+  the three sites.
+
+## Dependencies
+
+None between units; one PR.
+
+## Reuse
+
+- `dispatch-spawn-job`'s existing `--model` forwarding and validation
+  (`dispatch-spawn-job:284-298`) — no spawn-side change needed.
+- Existing launch-worker test stubs (`test-dispatch-scripts.sh:37282+`).
+
+## Verification
+
+```verify
+.claude/skills/dispatch-propagate/scripts/test-dispatch-phase-model.sh
+.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+```
+
+Manual: after merge, the next tick's aux spawns and any main-qa launch
+show `--model claude-sonnet-4-6` in the spawn log; a following
+/dispatch-token-audit window shows the `<none>`+Opus row shrinking.
+
+## Implementation notes
+
+Two units, one PR; implement each in a subagent with `model: sonnet`;
+supply this Context and the unit's Scope; constrain to working-tree edits.
+`strategy_fingerprint` recipe (interim until tactic-graph-dispatch-schema
+lands): sha256 hex of `JSON.stringify({statement, clarifications,
+conditions, serves, success_signal, tooling_goals})` as loaded by
+intentionsutil `listNodes`.

--- a/intentions/tactic-noncodegen-session-model-defaults.md
+++ b/intentions/tactic-noncodegen-session-model-defaults.md
@@ -1,0 +1,49 @@
+---
+id: tactic-noncodegen-session-model-defaults
+kind: tactic
+statement: "draft: Sonnet-by-default initialization for non-codegen sessions —
+  aux background jobs plus the qa-main and file-issue lanes"
+owner: ai
+status: raw
+parent: null
+rationale: Draft retained from the 2026-07-04 strategy-token-economy interview
+  (retain, not refine). Implements the initialization-defaults half of the
+  strategy's clarification 4.
+reading: null
+gap: null
+serves:
+  - strategy-token-economy
+recovers: []
+clarifications: []
+tooling_goals: []
+success_signal: null
+attention: null
+attributes: {}
+---
+# draft: Sonnet-by-default initialization for non-codegen sessions — aux background jobs plus the qa-main and file-issue lanes
+
+Notes retained from the interview session:
+
+- Measured 2026-06-26→07-03: the unattributed `<none>`+Opus row was $3,600
+  proxy / ~$1,200 real for the week, dominated by sessions that never enter a
+  codegen skill.
+- Aux background jobs that author no code — `dispatch-diagnose-main`,
+  `dispatch-jit-reminder`, `qa-main` verification, digest — can launch with
+  `--model sonnet` at session start instead of inheriting Opus.
+- Highest-confidence phase demotions from the audit: `qa-main` (browser
+  verification against deployed prod) and `file-issue`
+  (classification/dedup) — together ~$285/wk real at Opus rates, ~$170/wk at
+  Sonnet. On the prepaid plan this is allowance headroom, not a bill cut.
+- `file-issue` is being superseded by the align skill family
+  (strategy-graph-native-dispatch), so its half of the requirement transfers
+  to align-session routing: interview/decomposition on Opus, Explore fan-out
+  on Sonnet or Haiku (routing-parity clarification on
+  strategy-graph-native-dispatch).
+- Existing plumbing to reuse: `dispatch-phase-model` /
+  `dispatch-phase-effort` consumption in `dispatch-launch-worker` and
+  `dispatch-spawn-job`; the `force-opus.json` global override remains the
+  kill-switch.
+- Subagent corollary: Fable-priced interactive parents bill at 67% of proxy
+  (vs Opus 33%, Sonnet 20%, Haiku 7% in the window) — fan-out from expensive
+  parents should pass `model: sonnet` (or `haiku` for pure search); the
+  plan-issue+Haiku row proves the plumbing works.

--- a/intentions/tactic-outcome-envelope-qa-accounting.md
+++ b/intentions/tactic-outcome-envelope-qa-accounting.md
@@ -1,0 +1,50 @@
+---
+id: tactic-outcome-envelope-qa-accounting
+kind: tactic
+statement: "draft: qa fixes_applied accounting — delegated implement-unit fixes
+  never land in the outcome envelope, so qa hit_rate reads 0 structurally and
+  falsely promotes qa to Opus"
+owner: ai
+status: raw
+parent: null
+rationale: Draft retained from the 2026-07-04 strategy-token-economy interview
+  (retain, not refine). Grounds the strategy's metric-integrity condition and
+  clarification 3.
+reading: null
+gap: null
+serves:
+  - strategy-token-economy
+recovers: []
+clarifications: []
+tooling_goals: []
+success_signal: null
+attention: null
+attributes: {}
+---
+# draft: qa fixes_applied accounting — delegated implement-unit fixes never land in the outcome envelope, so qa hit_rate reads 0 structurally and falsely promotes qa to Opus
+
+Notes retained from the interview session:
+
+- Mechanism: `fixes_applied > 0` is emitted only on qa-fix's
+  `completed_with_fixes` finalize path (`.claude/skills/qa-fix/SKILL.md`
+  ~911–925); qa fixes authored through `/implement-unit` subagents are never
+  recorded back. Escalation paths (`needs-main`, `needs-human`,
+  `fix-pass-landed-nothing`) all record `fixes_applied = 0` by design.
+- Measured 2026-06-26→07-03: qa surfaced 108 findings, 93 actionable, filed
+  68 follow-ups, recorded 0 in-envelope fixes across 84 sessions → pooled
+  `hit_rate = 0`, below the `HIT_RATE_FLOOR = 0.5` in
+  `generate-phase-model-policy.sh` → the live
+  `dispatch.config/phase-model-policy.json` promotes qa to `claude-opus-4-8`.
+  The metric conflates "phase escalates most residue by design" with "cheap
+  model underperformed".
+- Review's promotion (hit_rate 0.180 over 76 sessions) is also suspect for a
+  softer reason: review is an orchestrator that delegates fix-authoring to
+  Opus subagents, so whether its own chain needs Opus is unexamined; the 0.5
+  floor has no model of delegated fix lanes.
+- Options sketched: record subagent-applied fixes into the envelope; or route
+  qa on a metric its lane can move (e.g. actionability, follow-up validity);
+  or exclude phases with delegated fix lanes from hit_rate routing.
+- Related static gap: the generator and consumer both hardcode the
+  `{qa, review}` demotable allowlist; fix-checks / fix-conflicts / main-qa
+  get the Sonnet default but no measurement can ever move them.
+- Field definitions: `.claude/docs/outcome-envelope.md`.

--- a/intentions/tactic-outcome-envelope-qa-accounting.md
+++ b/intentions/tactic-outcome-envelope-qa-accounting.md
@@ -1,15 +1,16 @@
 ---
 id: tactic-outcome-envelope-qa-accounting
 kind: tactic
-statement: "draft: qa fixes_applied accounting — delegated implement-unit fixes
-  never land in the outcome envelope, so qa hit_rate reads 0 structurally and
-  falsely promotes qa to Opus"
+statement: per-phase routing metric — qa routes on actionability, not
+  hit_rate, so a triage-shaped phase is not promoted to Opus by a rate it
+  cannot move
 owner: ai
-status: raw
+status: codified
 parent: null
-rationale: Draft retained from the 2026-07-04 strategy-token-economy interview
-  (retain, not refine). Grounds the strategy's metric-integrity condition and
-  clarification 3.
+rationale: "Finalized from the 2026-07-04 interview draft by /align-tactics
+  round 1, reframed by the round's drift review (strategy clarification 5):
+  qa-fix's fix lane already maintains a landed-fix tally, so the defect is
+  metric shape, not missing accounting."
 reading: null
 gap: null
 serves:
@@ -19,32 +20,90 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-attributes: {}
+attributes:
+  phase: implement
+  execution:
+    strategy_fingerprint: 10f0314e331696714d42b26313b80c5a289d68ab0e3ce4d614bf2c97a94d4a67
 ---
-# draft: qa fixes_applied accounting — delegated implement-unit fixes never land in the outcome envelope, so qa hit_rate reads 0 structurally and falsely promotes qa to Opus
+# per-phase routing metric — qa routes on actionability, not hit_rate, so a triage-shaped phase is not promoted to Opus by a rate it cannot move
 
-Notes retained from the interview session:
+## Context
 
-- Mechanism: `fixes_applied > 0` is emitted only on qa-fix's
-  `completed_with_fixes` finalize path (`.claude/skills/qa-fix/SKILL.md`
-  ~911–925); qa fixes authored through `/implement-unit` subagents are never
-  recorded back. Escalation paths (`needs-main`, `needs-human`,
-  `fix-pass-landed-nothing`) all record `fixes_applied = 0` by design.
-- Measured 2026-06-26→07-03: qa surfaced 108 findings, 93 actionable, filed
-  68 follow-ups, recorded 0 in-envelope fixes across 84 sessions → pooled
-  `hit_rate = 0`, below the `HIT_RATE_FLOOR = 0.5` in
-  `generate-phase-model-policy.sh` → the live
-  `dispatch.config/phase-model-policy.json` promotes qa to `claude-opus-4-8`.
-  The metric conflates "phase escalates most residue by design" with "cheap
-  model underperformed".
-- Review's promotion (hit_rate 0.180 over 76 sessions) is also suspect for a
-  softer reason: review is an orchestrator that delegates fix-authoring to
-  Opus subagents, so whether its own chain needs Opus is unexamined; the 0.5
-  floor has no model of delegated fix lanes.
-- Options sketched: record subagent-applied fixes into the envelope; or route
-  qa on a metric its lane can move (e.g. actionability, follow-up validity);
-  or exclude phases with delegated fix lanes from hit_rate routing.
-- Related static gap: the generator and consumer both hardcode the
-  `{qa, review}` demotable allowlist; fix-checks / fix-conflicts / main-qa
-  get the Sonnet default but no measurement can ever move them.
-- Field definitions: `.claude/docs/outcome-envelope.md`.
+The routing policy generator
+(`.claude/skills/dispatch-token-audit/scripts/generate-phase-model-policy.sh`)
+routes both allowlisted phases (`qa`, `review`; line 84) on pooled
+`hit_rate = fixes_applied / findings_surfaced`, floor 0.5, min sample 20
+(lines 74-75, 91-99). qa-fix's accounting is correct — its fix lane keeps
+a landed-fix tally incremented only when an `/implement-unit` invocation
+hands control back with a landed commit (`.claude/skills/qa-fix/SKILL.md:866-881`),
+guarded against a zero-fix `completed_with_fixes` (lines 890-900) — but
+qa's designed output is triage and follow-ups: in the 2026-06-26→07-03
+window it surfaced 108 findings, 93 actionable (0.86), filed 68
+follow-ups, and applied 0 in-lane fixes across 84 sessions. Pooled
+hit_rate is structurally 0, so the live
+`dispatch.config/phase-model-policy.json` promotes qa to `claude-opus-4-8`
+on a rate the phase cannot move. Strategy-token-economy's clarification 3
+licenses exactly this remedy: route the phase on a metric it can move.
+
+Review keeps hit_rate: its Workflow counts subagent-applied fixes into
+`fixes_applied` directly (`review-fix/SKILL.md:824-838`;
+`outcome-envelope.md:105-107`), so the rate is meaningful there.
+
+## Unit 1 — per-phase metric selection in the policy generator
+
+**Recommended model:** sonnet
+
+Scope:
+- `generate-phase-model-policy.sh` decision logic (lines 82-99): qa routes
+  on `actionability` (`findings_actionable / findings_surfaced`, already
+  pooled in `by_phase_outcome`) against its own env-overridable floor
+  (`QA_ACTIONABILITY_FLOOR`, default 0.5); review keeps `hit_rate` against
+  `HIT_RATE_FLOOR`. Keep `MIN_SAMPLE` shared. Record the metric name in
+  each rationale entry (`{decision, metric, sessions, <rate>, cost_usd,
+  price_proxy_usd}`) so a reader can see which rate drove the route.
+- Preserve purity (no clock; `generated_at` from `window.until`, lines
+  60-64) and the fail-closed two-phase allowlist (line 84).
+- Update
+  `.claude/skills/dispatch-token-audit/scripts/test-generate-phase-model-policy.sh`
+  (cases at lines 75-129): the healthy fixture's qa decision now derives
+  from actionability (window data: qa flips to `keep-cheap`); add a
+  low-actionability promote case and a `QA_ACTIONABILITY_FLOOR` override
+  case.
+- Doc: `.claude/docs/outcome-envelope.md` — add a short note under the
+  rate formulas (lines 120-130) naming which rate routes which phase and
+  why (delegated fix lanes make hit_rate unmovable for qa).
+- Out of scope: changing qa-fix's envelope emission
+  (`dispatch-emit-outcome` contract unchanged) and the consumer
+  `dispatch-phase-model` (route values are unchanged in shape).
+
+## Dependencies
+
+None.
+
+## Reuse
+
+- Pooled rates already computed in `by_phase_outcome`
+  (`aggregate-usage.sh:682-714`) — no new aggregation needed.
+- Test harness patterns in `test-generate-phase-model-policy.sh`.
+
+## Verification
+
+```verify
+.claude/skills/dispatch-token-audit/scripts/test-generate-phase-model-policy.sh
+```
+
+Manual (operational, after merge): re-run the generator over a fresh
+`tmp/usage-audit.json` and write the policy per the audit skill's step 7 —
+qa's rationale shows `metric: actionability` and, on current data,
+`decision: keep-cheap`, reverting the suspect Opus promotion.
+
+## Implementation notes
+
+Single unit; implement in a subagent with `model: sonnet`; supply this
+Context and Scope; constrain to working-tree edits. Note: the doc edit
+touches `.claude/docs/`, and skill-adjacent commits can hit the auto-mode
+agent-behavior commit gate — expect a grant prompt rather than a failure.
+`strategy_fingerprint` recipe (interim until tactic-graph-dispatch-schema
+lands): sha256 hex of `JSON.stringify({statement, clarifications,
+conditions, serves, success_signal, tooling_goals})` as loaded by
+intentionsutil `listNodes`.

--- a/intentions/tactic-token-audit-node-attribution.md
+++ b/intentions/tactic-token-audit-node-attribution.md
@@ -1,0 +1,51 @@
+---
+id: tactic-token-audit-node-attribution
+kind: tactic
+statement: "draft: node-id session attribution — graph-native sessions stamp
+  node id and phase into the dispatch sidecar; the token audit gains a by-node
+  join"
+owner: ai
+status: raw
+parent: null
+rationale: Draft retained from the 2026-07-04 strategy-token-economy interview
+  (retain, not refine). Implements the attribution-parity commitment on
+  strategy-graph-native-dispatch and the first sensor tooling goal of the
+  strategy it serves.
+reading: null
+gap: null
+serves:
+  - strategy-token-economy
+recovers: []
+clarifications: []
+tooling_goals: []
+success_signal: null
+attention: null
+attributes: {}
+---
+# draft: node-id session attribution — graph-native sessions stamp node id and phase into the dispatch sidecar; the token audit gains a by-node join
+
+Notes retained from the interview session (no plan schema, no quality bar):
+
+- Today's join: the sidecar `<session-id>.dispatch-stamp.json` next to the
+  transcript carries `{repo, issue, pr, base_sha, branch}`; the audit's
+  `.sessions[].artifact` joins on session id
+  (`.claude/skills/dispatch-token-audit/SKILL.md` step 3). Phase attribution
+  comes from the skill frame. Graph-native sessions have neither an issue
+  number nor (for align-family and router ticks) a skill frame the audit
+  recognizes.
+- Consequence measured in the 2026-06-26→07-03 audit: the unattributed
+  `<none>` bucket was the largest single line — $5,680 proxy / $1,842 real,
+  19,733 turns. Every graph-native session added today would land there.
+- Sketch: extend the sidecar with `node_id` and a graph-native `phase`;
+  `aggregate-usage.sh` groups by node id and folds per-node spend/yield;
+  spend-per-closed-tactic becomes derivable, which the strategy's
+  utilization+velocity signal needs.
+- Also fold weekly-allowance utilization (from
+  `~/.local/share/commons-dispatch/rate_limits.json`, the
+  dispatch-target-workers telemetry) into the audit aggregate so one artifact
+  carries both halves of the signal.
+- Open thread from the same audit worth folding in: `aggregate-usage.sh`
+  window computation mixes local-TZ `date -d` with a `TZ=UTC` `find
+  -newermt` comparison — very recent sessions can silently fall outside the
+  window in non-UTC shells (repro in
+  `worktrees/2737-fable-price-table/tmp/dispatch-token-audit-findings.md`).

--- a/intentions/tactic-token-audit-node-attribution.md
+++ b/intentions/tactic-token-audit-node-attribution.md
@@ -1,16 +1,16 @@
 ---
 id: tactic-token-audit-node-attribution
 kind: tactic
-statement: "draft: node-id session attribution — graph-native sessions stamp
-  node id and phase into the dispatch sidecar; the token audit gains a by-node
-  join"
+statement: node-id session attribution — graph-native sessions stamp node id
+  into the dispatch sidecar; the token audit gains a by-node join and a
+  UTC-consistent window
 owner: ai
-status: raw
+status: codified
 parent: null
-rationale: Draft retained from the 2026-07-04 strategy-token-economy interview
-  (retain, not refine). Implements the attribution-parity commitment on
-  strategy-graph-native-dispatch and the first sensor tooling goal of the
-  strategy it serves.
+rationale: Finalized from the 2026-07-04 interview draft by /align-tactics
+  round 1. Implements the attribution-parity commitment on
+  strategy-graph-native-dispatch and the first sensor tooling goal of
+  strategy-token-economy.
 reading: null
 gap: null
 serves:
@@ -20,32 +20,114 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-attributes: {}
+attributes:
+  phase: implement
+  execution:
+    strategy_fingerprint: 10f0314e331696714d42b26313b80c5a289d68ab0e3ce4d614bf2c97a94d4a67
 ---
-# draft: node-id session attribution — graph-native sessions stamp node id and phase into the dispatch sidecar; the token audit gains a by-node join
+# node-id session attribution — graph-native sessions stamp node id into the dispatch sidecar; the token audit gains a by-node join and a UTC-consistent window
 
-Notes retained from the interview session (no plan schema, no quality bar):
+## Context
 
-- Today's join: the sidecar `<session-id>.dispatch-stamp.json` next to the
-  transcript carries `{repo, issue, pr, base_sha, branch}`; the audit's
-  `.sessions[].artifact` joins on session id
-  (`.claude/skills/dispatch-token-audit/SKILL.md` step 3). Phase attribution
-  comes from the skill frame. Graph-native sessions have neither an issue
-  number nor (for align-family and router ticks) a skill frame the audit
-  recognizes.
-- Consequence measured in the 2026-06-26→07-03 audit: the unattributed
-  `<none>` bucket was the largest single line — $5,680 proxy / $1,842 real,
-  19,733 turns. Every graph-native session added today would land there.
-- Sketch: extend the sidecar with `node_id` and a graph-native `phase`;
-  `aggregate-usage.sh` groups by node id and folds per-node spend/yield;
-  spend-per-closed-tactic becomes derivable, which the strategy's
-  utilization+velocity signal needs.
-- Also fold weekly-allowance utilization (from
-  `~/.local/share/commons-dispatch/rate_limits.json`, the
-  dispatch-target-workers telemetry) into the audit aggregate so one artifact
-  carries both halves of the signal.
-- Open thread from the same audit worth folding in: `aggregate-usage.sh`
-  window computation mixes local-TZ `date -d` with a `TZ=UTC` `find
-  -newermt` comparison — very recent sessions can silently fall outside the
-  window in non-UTC shells (repro in
-  `worktrees/2737-fable-price-table/tmp/dispatch-token-audit-findings.md`).
+The token audit attributes cost two ways: per-session GitHub artifacts via
+the `<session-id>.dispatch-stamp.json` sidecar, and phase via skill-frame
+detection. Both go blind on graph-native sessions:
+
+- The sidecar writer
+  (`.claude/skills/dispatch-propagate/scripts/dispatch-stamp-session`,
+  Mode A at lines 20-39) no-ops unless the branch matches `^[0-9]+-`
+  (line 30) — graph-native branches (`graph-*`, node-id names) get no
+  sidecar at all.
+- The session-type classifier
+  (`.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh:269-280`)
+  recognizes only the legacy phase-skill command names; align-family
+  sessions classify as `other`.
+
+Measured 2026-06-26→07-03: the unattributed `<none>` bucket was the
+largest single line — $5,680 proxy / $1,842 real, 19,733 turns. Every
+graph-native session added today lands there. Separately, the window
+computation mixes local-TZ `date -d` (`aggregate-usage.sh:163-174`) with a
+`TZ=UTC find -newermt` consumer (`aggregate-usage.sh:846`), silently
+shifting the window boundary by the local UTC offset (repro in the
+2026-07-03 findings doc).
+
+## Unit 1 — sidecar node-id stamping
+
+**Recommended model:** sonnet
+
+Scope:
+- `dispatch-stamp-session` Mode A (lines 20-39): extend branch
+  recognition. Numeric `^[0-9]+-` branches keep today's behavior; add
+  graph-native recognition — a branch named `graph-<slug>` or exactly a
+  node id (`tactic-*` / `strategy-*`) stamps `node_id` (the node id, or
+  the slug's best-effort node id for `graph-` branches when a matching
+  `intentions/<id>.md` exists, else null) with `issue: null`.
+- Extend the documented sidecar shape (doc comment lines 15-18) with
+  `"node_id": <string|null>`; preserve idempotency across resumes
+  (lines 35-39) and the atomic tmp+mv write (line 48).
+- Hook (`.claude/hooks/stamp-dispatch-session.sh`) unchanged — it only
+  forwards session id and transcript path.
+- Tests: extend the dispatch-stamp-session coverage in
+  `.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`
+  with a graph-branch case and a node-id-branch case.
+
+## Unit 2 — aggregate by-node join and align-family classification
+
+**Recommended model:** sonnet
+
+Scope:
+- `aggregate-usage.sh` stage-1 join (line 401): carry `node_id` through
+  the artifact object (`{repo, issue, pr, base_sha, branch, node_id}`).
+- Stage-2 assembly (lines 776-811): add a top-level `by_node` sibling key
+  — per `artifact.node_id`, summed `price_proxy_usd`, `cost_usd`, `turns`,
+  `sessions` — following the `$by_phase` reduce pattern (lines 554-577).
+- Session-type classifier (lines 269-280): add
+  `align-strategy|align-tactics|align-init` to the worker command-name
+  alternation, per the maintenance comment at lines 275-278.
+- Fixture test mirroring the haiku/fable fixtures
+  (`test-aggregate-usage.sh:831-915`): a session whose sidecar carries a
+  `node_id`, asserting the `by_node` row and worker classification.
+- Depends on Unit 1's sidecar field shape (same PR, ordered).
+
+## Unit 3 — UTC-consistent window computation
+
+**Recommended model:** sonnet
+
+Scope:
+- `aggregate-usage.sh:163-174`: compute `SINCE`/`UNTIL` with `date -u`
+  consistently so the strings match the `TZ=UTC` interpretation at the
+  `find` call (line 846). `--day` mode already computes `UNTIL` with
+  `-u` (line 165) — make `SINCE` forms match.
+- Fixture test: a `.jsonl` with `mtime = now` must appear in a `--days 7`
+  window regardless of host TZ (run the aggregator under `TZ=America/New_York`
+  in the test to pin the regression).
+
+## Dependencies
+
+Unit 2 depends on Unit 1 (sidecar shape). One tactic, one PR.
+
+## Reuse
+
+- Sidecar writer atomic-write and idempotency patterns —
+  `dispatch-stamp-session:35-48`.
+- Fixture-test structure — `test-aggregate-usage.sh:831-915` (isolated
+  mktemp root, two-line transcript, targeted asserts).
+
+## Verification
+
+```verify
+.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+```
+
+Manual: run the aggregator over the live transcripts directory after a
+graph-native session has run — the session appears with
+`artifact.node_id` set and in `by_node`, not in the `<none>` bucket.
+
+## Implementation notes
+
+Three units, one PR; implement each in a subagent with its Recommended
+model; supply this Context and the unit's Scope; constrain to working-tree
+edits. `strategy_fingerprint` recipe (interim until
+tactic-graph-dispatch-schema lands): sha256 hex of
+`JSON.stringify({statement, clarifications, conditions, serves,
+success_signal, tooling_goals})` as loaded by intentionsutil `listNodes`.

--- a/intentions/tactic-token-economy-sensor.md
+++ b/intentions/tactic-token-economy-sensor.md
@@ -1,0 +1,125 @@
+---
+id: tactic-token-economy-sensor
+kind: tactic
+statement: token-economy sensor — registry sensor computing weekly allowance
+  utilization and claude-eligible tactic velocity, populating
+  strategy-token-economy's reading
+owner: ai
+status: codified
+parent: null
+rationale: "Round-1 instrument tactic: the strategy's reading is null, so the
+  round must include the tactic that makes the sensor runnable
+  (strategy-graph-native-dispatch clarification 3 — a strategy that cannot be
+  measured must first buy its own instrument). Planned 2026-07-04
+  /align-tactics round 1."
+reading: null
+gap: null
+serves:
+  - strategy-token-economy
+recovers: []
+clarifications: []
+tooling_goals: []
+success_signal: null
+attention: null
+attributes:
+  phase: implement
+  validates:
+    - strategy-token-economy
+  execution:
+    strategy_fingerprint: 10f0314e331696714d42b26313b80c5a289d68ab0e3ce4d614bf2c97a94d4a67
+---
+# token-economy sensor — registry sensor computing weekly allowance utilization and claude-eligible tactic velocity, populating strategy-token-economy's reading
+
+## Context
+
+`strategy-token-economy`'s success signal is dual: weekly prepaid-allowance
+utilization near 100%, and claude-eligible tactic closure velocity at or
+above arrival. Its `success_signal.sensor` is the registry name
+`token-economy` (renamed from prose in the round-1 record); no sensor of
+that name exists yet, so `read-sensors` reports it unregistered and the
+node's `reading` stays null. This tactic registers the sensor. It carries
+the `validates` edge for the strategy's signal: it produces the reading the
+threshold is judged against.
+
+Utilization is already computed for us: the statusline hook
+(`.claude/hooks/statusline.sh:16-18`) pipes harness telemetry through
+`.claude/skills/dispatch-propagate/scripts/update-rate-limits.sh` into
+`~/.local/share/commons-dispatch/rate_limits.json`, whose
+`.seven_day.used_percentage` is the weekly figure — pre-computed, no math
+(`update-rate-limits.sh:12,19-25`). Velocity has no existing helper: the
+office-hours queue metrics parse a Firestore doc, not git
+(`office-hours-snapshot/src/produce.ts:399-401`), so the intentions/
+git-history derivation is new code.
+
+## Unit 1 — register the token-economy sensor in read-sensors
+
+**Recommended model:** opus
+
+Scope:
+- `packages/intentionsutil/scripts/read-sensors.ts`: add a `token-economy`
+  sensor to `buildDefaultRegistry()` (registration point
+  `read-sensors.ts:99-104`), honoring the total-never-throw contract
+  (comment at `read-sensors.ts:47-51`): every failure becomes a status
+  reading string, never an exception.
+- Utilization half: read
+  `$HOME/.local/share/commons-dispatch/rate_limits.json` (allow an env
+  override for tests, mirroring
+  `DISPATCH_TARGET_WORKERS_RATE_LIMITS_PATH` in
+  `dispatch-target-workers:276`), extract `.seven_day.used_percentage`
+  with the sanitization discipline of `dispatch-target-workers:299-343`
+  (non-numeric or >100 treated as missing). Missing file or field →
+  `utilization: unknown` in the reading, not a throw.
+- Velocity half: derive from the local clone's `intentions/` git history
+  over a trailing 28-day window, via `execFileSync` with `cwd: repoRoot`
+  (pattern: the `vitest`/`git` sensors at `read-sensors.ts:66-93`).
+  Created = first commit adding an `intentions/tactic-*.md` with
+  `owner: ai`; closed = commit setting that node's `attributes.phase` to
+  `done` or deleting the file. Draft tactics (`status: raw`, no phase)
+  count as created — they are claude-eligible work entering the graph.
+- Reading string, stable and parseable:
+  `utilization: <p>% weekly; tactics 28d: <c> created / <d> closed (net <±n>)`.
+- `deriveGap` stays the mechanical string-equality rule
+  (`packages/intentionsutil/src/sensors.ts:88-102`); the prose threshold
+  will not string-equal the reading, so `gap` stays populated — consistent
+  with existing nodes, and the honest state until threshold evaluation
+  grows richer.
+- Tests in `packages/intentionsutil/test/sensors.test.ts` (extend) or a
+  sibling file: healthy read against fixture telemetry + fixture git
+  history, missing telemetry file, empty history window, sanitization of a
+  non-numeric percentage.
+
+## Dependencies
+
+None — the strategy's `success_signal.sensor` already names
+`token-economy`.
+
+## Reuse
+
+- `SensorRegistry` / `deriveGap` — `packages/intentionsutil/src/sensors.ts:13-102`.
+- Driver read/write-back flow (`readFrontierSensors`) —
+  `packages/intentionsutil/scripts/read-sensors.ts:122-152`; unregistered
+  names are collected to stderr, so shipping the sensor removes that
+  report line.
+- Telemetry extraction idiom — `dispatch-target-workers:299-309`.
+
+## Verification
+
+```verify
+npx vitest run --project intentionsutil --root .
+npx tsx packages/intentionsutil/scripts/validate-graph.ts intentions
+```
+
+Manual: run
+`npx tsx packages/intentionsutil/scripts/read-sensors.ts` — the
+`strategy-token-economy` node gains a non-null `reading` matching the
+format above, and the utilization figure matches the `7d:` percentage the
+statusline shows.
+
+## Implementation notes
+
+Single unit; implement in a subagent with `model: opus`; supply this
+Context and Scope; constrain to working-tree edits.
+`strategy_fingerprint` recipe (interim until tactic-graph-dispatch-schema
+lands): sha256 hex of `JSON.stringify({statement, clarifications,
+conditions, serves, success_signal, tooling_goals})` as loaded by
+intentionsutil `listNodes`.

--- a/intentions/tactic-token-hygiene-sweep.md
+++ b/intentions/tactic-token-hygiene-sweep.md
@@ -1,14 +1,16 @@
 ---
 id: tactic-token-hygiene-sweep
 kind: tactic
-statement: "draft: token hygiene sweep — recurring avoidable tool errors,
-  scriptable call sequences, and oversized tool-result payloads"
+statement: read-before-edit preamble line in the fix-lane subagent prompts —
+  the one hygiene item with a repo-controlled landing spot
 owner: ai
-status: raw
+status: codified
 parent: null
-rationale: Draft retained from the 2026-07-04 strategy-token-economy interview
-  (retain, not refine). Lower measured magnitude than the routing and
-  attribution drafts; kept visible rather than dropped.
+rationale: "Finalized and narrowed from the 2026-07-04 interview draft by
+  /align-tactics round 1: the payload-discipline item is already satisfied
+  in the qa skills, the EnterWorktree item has no repo-controlled landing
+  spot, and the qa-verify item was reinterpreted and split to
+  tactic-main-qa-triage-before-provision."
 reading: null
 gap: null
 serves:
@@ -18,25 +20,83 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-attributes: {}
+attributes:
+  phase: implement
+  execution:
+    strategy_fingerprint: 10f0314e331696714d42b26313b80c5a289d68ab0e3ce4d614bf2c97a94d4a67
 ---
-# draft: token hygiene sweep — recurring avoidable tool errors, scriptable call sequences, and oversized tool-result payloads
+# read-before-edit preamble line in the fix-lane subagent prompts — the one hygiene item with a repo-controlled landing spot
 
-Notes retained from the interview session (magnitudes from the
-2026-06-26→07-03 audit):
+## Context
 
-- `File has not been read yet` edit-rejection: 143× across 126 sessions —
-  clearest scriptable win; add a read-before-first-Edit/Write line to the
-  implement/qa skill preambles.
-- `Cannot enter worktree: PATH is the current working directory`: 29× across
-  29 sessions — workers re-issuing EnterWorktree while already inside one;
-  the bg-session "skip if cwd already under the worktrees root" check is
-  being missed.
-- qa-verify polling loop: a `cd …qa-verify… > cd …` two-gram occurred 405×
-  in 39 sessions (~10 repeats/session) — should be one script with an
-  internal wait, not per-tick tool calls.
-- Payload bytes: 72.5MB total tool-result payload in the window; browser
-  screenshots ~48KB each — prefer `read_page`/targeted `find` over
-  screenshots in qa phases where the check is textual.
-- These stay report-visible through the token-audit lenses (1, 2, 8); this
-  draft exists so the fixes are schedulable rather than folklore.
+The `File has not been read yet` edit rejection fired 143 times across
+126 sessions in the 2026-06-26→07-03 window — the audit's clearest
+scriptable win. The landing spots are where implementation subagents are
+prompted, since the phase skills themselves delegate edits:
+
+- `implement-unit/SKILL.md:41-51` (Step 1 subagent launch) — the one
+  skill whose subagent performs the edits; the constraint block at lines
+  44-45 is where the line lands.
+- qa-fix's fix lane constructs `/implement-unit` invocations at
+  `qa-fix/SKILL.md:852-888`; review-fix's Workflow fix fan-out at
+  `review-fix/SKILL.md:~301` — both forward unit context into subagent
+  prompts and should carry the same line.
+
+Items examined and deliberately dropped (recorded, not silent):
+
+- **EnterWorktree double-entry (29×/29 sessions):** dispatch phase skills
+  are EnterWorktree-free by ratchet
+  (`test-dispatch-scripts.sh:27354-27394` asserts zero mentions), and the
+  offending preamble is harness-injected in background jobs — no
+  repo-controlled landing spot. Revisit if the count persists in the next
+  audit window.
+- **Screenshot/payload discipline:** already satisfied —
+  `qa-main/SKILL.md:171-181` (cheapest-read-first) and
+  `qa-fix/SKILL.md:456-468` (minimize browser payload).
+- **qa-verify boots:** reinterpreted by drift review; split to
+  `tactic-main-qa-triage-before-provision`.
+
+## Unit 1 — the preamble line
+
+**Recommended model:** sonnet
+
+Scope:
+- `implement-unit/SKILL.md` Step 1 constraint block (lines 44-45): add
+  "Read any file with the Read tool before your first Edit or Write to it
+  in this session — the edit is rejected otherwise and the retry burns
+  the tokens twice."
+- Forward the same sentence where fix-lane subagent prompts are built:
+  `qa-fix/SKILL.md:852-888` (unit prompt construction) and review-fix's
+  Workflow fix-agent prompt (`review-fix/SKILL.md` Step 2 fan-out).
+- Keep phrasing identical at all three sites so a future consolidation
+  can grep for it.
+- No test surface beyond the existing skill-prose ratchets; verify by
+  grep.
+
+## Dependencies
+
+None.
+
+## Reuse
+
+- Existing constraint block phrasing in `implement-unit/SKILL.md:44-45`.
+
+## Verification
+
+```verify
+grep -c "before your first Edit" .claude/skills/implement-unit/SKILL.md .claude/skills/qa-fix/SKILL.md .claude/skills/review-fix/SKILL.md
+```
+
+Manual: the next audit window's `tool_errors` shows the
+`File has not been read yet` signature falling from its 143×/126-session
+baseline.
+
+## Implementation notes
+
+Single unit; implement in a subagent with `model: sonnet`; supply this
+Context and Scope; constrain to working-tree edits. SKILL.md commits can
+hit the auto-mode agent-behavior gate — expect a grant prompt.
+`strategy_fingerprint` recipe (interim until tactic-graph-dispatch-schema
+lands): sha256 hex of `JSON.stringify({statement, clarifications,
+conditions, serves, success_signal, tooling_goals})` as loaded by
+intentionsutil `listNodes`.

--- a/intentions/tactic-token-hygiene-sweep.md
+++ b/intentions/tactic-token-hygiene-sweep.md
@@ -1,0 +1,42 @@
+---
+id: tactic-token-hygiene-sweep
+kind: tactic
+statement: "draft: token hygiene sweep — recurring avoidable tool errors,
+  scriptable call sequences, and oversized tool-result payloads"
+owner: ai
+status: raw
+parent: null
+rationale: Draft retained from the 2026-07-04 strategy-token-economy interview
+  (retain, not refine). Lower measured magnitude than the routing and
+  attribution drafts; kept visible rather than dropped.
+reading: null
+gap: null
+serves:
+  - strategy-token-economy
+recovers: []
+clarifications: []
+tooling_goals: []
+success_signal: null
+attention: null
+attributes: {}
+---
+# draft: token hygiene sweep — recurring avoidable tool errors, scriptable call sequences, and oversized tool-result payloads
+
+Notes retained from the interview session (magnitudes from the
+2026-06-26→07-03 audit):
+
+- `File has not been read yet` edit-rejection: 143× across 126 sessions —
+  clearest scriptable win; add a read-before-first-Edit/Write line to the
+  implement/qa skill preambles.
+- `Cannot enter worktree: PATH is the current working directory`: 29× across
+  29 sessions — workers re-issuing EnterWorktree while already inside one;
+  the bg-session "skip if cwd already under the worktrees root" check is
+  being missed.
+- qa-verify polling loop: a `cd …qa-verify… > cd …` two-gram occurred 405×
+  in 39 sessions (~10 repeats/session) — should be one script with an
+  internal wait, not per-tick tool calls.
+- Payload bytes: 72.5MB total tool-result payload in the window; browser
+  screenshots ~48KB each — prefer `read_page`/targeted `find` over
+  screenshots in qa phases where the check is textual.
+- These stay report-visible through the token-audit lenses (1, 2, 8); this
+  draft exists so the fixes are schedulable rather than folklore.


### PR DESCRIPTION
State-only intentions/ record from a 2026-07-04 /align-strategy interview (author-decided substance per strategy-graph-native-dispatch condition 4). Inputs: the 2026-07-03 /dispatch-token-audit findings and an inventory of the legacy dispatch router's token-optimization machinery.

## What this records

**New node `strategy-token-economy`** (parent `strategy-financial-sustainability`, serves `virtue-alignment-of-attachments`):
- Reframes token optimization for the prepaid Max 20x plan: the marginal token is sunk cost, so the economy is throughput per allowance, not spend reduction.
- Dual success signal (author-specified): weekly allowance utilization near 100% AND claude-eligible tactic closure velocity at or above arrival — full utilization with a growing backlog fails the signal.
- Conditions: prepaid-plan premise, audit attributability across the router migration, routing automation only on verified metrics, pace machinery stays outside the graph.
- Tooling goals: node-id-attributed audit sensor, velocity series (shared with tactic-attention-surface-velocity-pace), routing actuator in the graph-native launch chain.

**Parity clarification on `strategy-graph-native-dispatch`** (mirrors pace clarification 14): the migration carries per-phase model/effort routing (fail-closed allowlist + policy loop) and node-id session attribution, so graph-native work does not land in the audit's unattributed bucket.

**Four draft tactics** (status raw, retain-not-refine):
- `tactic-token-audit-node-attribution` — sidecar node-id stamping, by-node audit join, utilization folded into the aggregate, TZ window thread.
- `tactic-outcome-envelope-qa-accounting` — the qa hit_rate=0 measurement artifact behind the live qa→Opus promotion.
- `tactic-noncodegen-session-model-defaults` — Sonnet-by-default for aux bg jobs; qa-main/file-issue demotion; subagent model passing.
- `tactic-token-hygiene-sweep` — recurring avoidable errors, the qa-verify polling loop, payload bytes.

## Verification

`npx tsx packages/intentionsutil/scripts/validate-graph.ts intentions` → ok, 100 nodes. Diff is entirely under intentions/ (graph fast-path eligible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)