### PR TITLE
intentionsutil: resolveAttention as a weighted term registry

### DIFF
--- a/packages/intentionsutil/src/attention.ts
+++ b/packages/intentionsutil/src/attention.ts
@@ -3,16 +3,91 @@ import type { IntentionNode } from "./schema.js";
 
 // --- Types -------------------------------------------------------------------
 
+/** One term's contribution to a node's composed rank, for explainability. */
+export interface TermContribution {
+  term: string;
+  value: number;
+}
+
 /** The derived attention (rank) of one eligible node. Computed on read, NEVER stored. */
 export interface ResolvedAttention {
-  /** The node's rank — the sum of its own outgoing source set's amounts. */
+  /** The node's rank — the weighted sum of every term's contribution. */
   value: number;
   /**
    * Ids of the source nodes whose authored boosts/overrides contribute to this
-   * node's rank, ordered by contribution (largest first, id ascending on ties)
-   * — for explainability ("via strategy-x").
+   * node's rank via the `authored` term, ordered by contribution (largest
+   * first, id ascending on ties) — for explainability ("via strategy-x").
    */
   sources: string[];
+  /**
+   * Every registered term's contribution to `value`, in registry order — the
+   * per-term breakdown behind the composed score (strategy clarification 11:
+   * "expose the composed score and per-term contributions for explainability
+   * in frontier views"). Optional so hand-built `ResolvedAttention` literals
+   * (e.g. in tests driving `renderFrontier` directly) need not supply it;
+   * `resolveAttention` itself always populates it.
+   */
+  terms?: TermContribution[];
+}
+
+// --- Weights -----------------------------------------------------------------
+// Terms and weights live in code, per clarification 11 — a weight change is an
+// ordinary reviewed PR, never a graph edit. The authored term's own DFS values
+// are used as-is (implicit weight 1); the two derived terms below are scaled
+// so a typical authored boost (small integers, 1-10 across the current graph)
+// still dominates — a max derived contribution is
+// SIGNAL_TERM_WEIGHT + CAPTURE_TERM_WEIGHT = 2.
+
+/** Flat bonus for a node on the path to an unvalidated signal's terminal. */
+const SIGNAL_TERM_WEIGHT = 1;
+
+/** Scales the normalized (0..1 per delegation) capture-resolution sum. */
+const CAPTURE_TERM_WEIGHT = 1;
+
+// --- Helpers -------------------------------------------------------------------
+
+function isPlainObjectLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** A strategy's signal is unvalidated iff it has a gap, or no reading yet. */
+function isUnvalidated(strategy: IntentionNode): boolean {
+  return strategy.gap !== null || strategy.reading === null;
+}
+
+// --- Capture-resolution scoring ------------------------------------------------
+// Reads the two capture axes (kind-delegation: divergence, irreversibility) off
+// a delegation node's freeform `attributes` (kind-specific, not schema-typed) —
+// defensive parsing here is boundary validation, not a fallback: a
+// missing/malformed axis simply contributes 0 rather than throwing, since
+// `attributes` shape is data (the kind node), not a code contract.
+
+function divergenceScore(delegation: IntentionNode): number {
+  const divergence = delegation.attributes.divergence;
+  if (!isPlainObjectLike(divergence)) return 0;
+  switch (divergence.level) {
+    case "low":
+      return 1;
+    case "moderate":
+      return 2;
+    case "high":
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+function irreversibilityScore(delegation: IntentionNode): number {
+  const irreversibility = delegation.attributes.irreversibility;
+  if (!isPlainObjectLike(irreversibility)) return 0;
+  const gated = irreversibility.gated;
+  const gatedText = typeof gated === "string" ? gated : String(gated ?? "");
+  return gatedText.trim().toLowerCase().startsWith("true") ? 2 : 1;
+}
+
+/** One delegation's capture severity, normalized to the 1/3..1 range (max axis sum 6). */
+function captureScore(delegation: IntentionNode): number {
+  return (divergenceScore(delegation) + irreversibilityScore(delegation)) / 6;
 }
 
 // --- Resolver ------------------------------------------------------------------
@@ -24,41 +99,46 @@ export interface ResolvedAttention {
  * are never written back to node frontmatter — `intentions/` stores intent,
  * not derived execution state.
  *
- * v2 model — additive source sets, undecayed and undiluted. See the
- * clarifications on `intentions/strategy-graph-drives-dispatch.md` for the
- * decision record (supersedes the same-day v1 conserved-flow / banded design
- * after the 2026-07-02 scenario interview).
+ * v3 model — a term registry composed as a weighted sum (strategy
+ * clarification 11, superseding the v2 single-term additive-flow design
+ * described on `intentions/strategy-graph-drives-dispatch.md`). Terms:
  *
- * Each node accumulates an OUTGOING source set: a `Map<sourceId, amount>`. Rank
- * flows DOWN `parent` + `serves` edges without decay or dilution — a child
- * inherits an ancestor's full claim regardless of depth or sibling count ("hot
- * means hot"). Each authored source counts once per node (set union dedupes by
- * source id, so diamonds don't double-count; genuinely serving two strategies
- * adds both).
+ *   - `authored` — the v2 additive-flow algorithm unchanged: rank flows down
+ *     `parent` + `serves` edges without decay or dilution ("hot means hot"),
+ *     via an outgoing `Map<sourceId, amount>` per node. An `override` REPLACES
+ *     a node's outgoing set with `{(self, override)}` (incoming discarded — a
+ *     cap on this node's own branch, though a descendant's OTHER parents still
+ *     contribute their own claims); a `boost` adds `(self, boost)` to the
+ *     incoming union. This term is also the one that reports `sources` (the
+ *     "via strategy-x" explainability marker) and short-circuits the whole
+ *     composition on `override` — clarification 11: "an override pins the
+ *     value absolutely."
+ *   - `signal` — structural: a node is on-path iff it (transitively) blocks —
+ *     reachable by walking `blocked_by` in reverse (who lists me as a
+ *     blocker), or inherits down a `parent` chain — a validates-terminal: a
+ *     tactic bearing a `validates` edge to a strategy whose signal is
+ *     unvalidated, or such a strategy itself (a strategy is its own
+ *     validates-terminal while unvalidated). On-path contributes
+ *     `SIGNAL_TERM_WEIGHT`; off-path contributes 0. Self-updating: a new
+ *     `validates` edge upstream lifts every node that blocks it, with no other
+ *     change.
+ *   - `capture` — from the node's own `recovers` (strategies) or its serving
+ *     strategy's `recovers` (tactics, via `serves`): each resolved delegation
+ *     contributes its normalized divergence/irreversibility axis sum (kind-
+ *     delegation), scaled by `CAPTURE_TERM_WEIGHT`.
  *
- * Algorithm (memoized DFS per node):
- *   1. Eligible set — nodes whose kind node sets `attributes.goal_layer: true`.
- *      All other nodes get no result entry (but can still pass a source through,
- *      e.g. a virtue root relaying nothing).
- *   2. Incoming — the union (by source id) over the node's distributors of each
- *      distributor's outgoing set. A distributor is the node's `parent` (if it
- *      resolves) plus, for eligible nodes, each `serves` target that resolves.
- *      Amounts for the same source id are identical by construction (undiluted),
- *      so the union is a plain overwrite.
- *   3. Outgoing —
- *        - `attention.override` present → `{(self, override)}` (incoming
- *          discarded; the override CAPS this branch — a descendant reachable
- *          only through this node reads the capped value, but a descendant's
- *          OTHER parents still contribute their own claims);
- *        - else `attention.boost` present → incoming ∪ `{(self, boost)}`;
- *        - else → incoming.
- *   4. rank(node) = sum of the node's OWN outgoing set's amounts (for an
- *      override node, exactly the override value).
- *   5. Cycle guard — a `parent`/`serves` cycle surfaces as an
- *      IntentionSchemaError listing the cycle path.
+ * New attention conditions add as terms with weights — never bands.
  *
- * Rank 0 is the neutral baseline: with no injections anywhere every eligible
- * node resolves to value 0 with no sources.
+ * Cycle guards: the authored term's DFS surfaces a `parent`/`serves` cycle as
+ * an `IntentionSchemaError` (values there are ill-defined under a cycle — see
+ * below). The signal term's reachability DFS does NOT throw on a cycle: a
+ * boolean OR-over-paths query is well-defined even with a cycle in the mix — a
+ * node fully enclosed in a cycle with no external escape to a terminal simply
+ * isn't on-path, which is the correct answer, not an error.
+ *
+ * Rank 0 is the neutral baseline: with no injections, no `validates` edges
+ * (or all signals already validated), and no `recovers` edges anywhere, every
+ * eligible node resolves to value 0 with no sources.
  */
 export function resolveAttention(nodes: IntentionNode[]): Map<string, ResolvedAttention> {
   const byId = new Map(nodes.map((n) => [n.id, n]));
@@ -67,6 +147,8 @@ export function resolveAttention(nodes: IntentionNode[]): Map<string, ResolvedAt
     const kindNode = byId.get(`kind-${n.kind}`);
     return kindNode !== undefined && kindNode.attributes.goal_layer === true;
   };
+
+  // --- Authored term (v2 algorithm, unchanged) ---------------------------
 
   // Distribution edges. distributors(c) = { c.parent } ∪ (eligible c only)
   // { c.serves }, each restricted to ids that resolve. Sorted for determinism.
@@ -82,12 +164,12 @@ export function resolveAttention(nodes: IntentionNode[]): Map<string, ResolvedAt
   };
 
   // Outgoing source set per node, memoized DFS with cycle detection.
-  const outgoing = new Map<string, Map<string, number>>();
+  const authoredOutgoing = new Map<string, Map<string, number>>();
   const onStack = new Set<string>();
   const stackPath: string[] = [];
 
-  const compute = (n: IntentionNode): Map<string, number> => {
-    const memo = outgoing.get(n.id);
+  const computeAuthored = (n: IntentionNode): Map<string, number> => {
+    const memo = authoredOutgoing.get(n.id);
     if (memo !== undefined) return memo;
     if (onStack.has(n.id)) {
       const cycle = [...stackPath.slice(stackPath.indexOf(n.id)), n.id];
@@ -101,7 +183,7 @@ export function resolveAttention(nodes: IntentionNode[]): Map<string, ResolvedAt
     // sees every edge (traverse-and-discard).
     const incoming = new Map<string, number>();
     for (const d of distributors(n)) {
-      for (const [src, amt] of compute(d)) {
+      for (const [src, amt] of computeAuthored(d)) {
         incoming.set(src, amt); // dedupe by src; amounts identical (undiluted)
       }
     }
@@ -119,24 +201,135 @@ export function resolveAttention(nodes: IntentionNode[]): Map<string, ResolvedAt
 
     onStack.delete(n.id);
     stackPath.pop();
-    outgoing.set(n.id, out);
+    authoredOutgoing.set(n.id, out);
     return out;
   };
+
+  // --- Signal-satisfaction term -------------------------------------------
+
+  const terminalIds = new Set<string>();
+  for (const n of nodes) {
+    if (n.kind === "strategy" && isUnvalidated(n)) {
+      terminalIds.add(n.id);
+    } else if (n.kind === "tactic") {
+      for (const target of n.validates) {
+        const strategy = byId.get(target);
+        if (strategy !== undefined && strategy.kind === "strategy" && isUnvalidated(strategy)) {
+          terminalIds.add(n.id);
+          break;
+        }
+      }
+    }
+  }
+
+  // reverseBlockers(id) = every node that lists `id` in its OWN blocked_by —
+  // i.e. the nodes `id` blocks. Walking this (plus parent, downward) is how a
+  // node reaches a validates-terminal: completing it is on the path to
+  // completing something that validates a signal.
+  const reverseBlockers = new Map<string, string[]>();
+  for (const n of nodes) {
+    for (const blocker of n.blocked_by) {
+      const list = reverseBlockers.get(blocker);
+      if (list) list.push(n.id);
+      else reverseBlockers.set(blocker, [n.id]);
+    }
+  }
+
+  const onPathMemo = new Map<string, boolean>();
+  const onPathStack = new Set<string>();
+
+  const isOnPath = (id: string): boolean => {
+    const memo = onPathMemo.get(id);
+    if (memo !== undefined) return memo;
+    if (onPathStack.has(id)) return false; // cycle: this path contributes nothing, don't cache
+    onPathStack.add(id);
+
+    let result = terminalIds.has(id);
+    if (!result) {
+      const node = byId.get(id);
+      if (node?.parent !== null && node?.parent !== undefined && byId.has(node.parent)) {
+        result = isOnPath(node.parent);
+      }
+    }
+    if (!result) {
+      for (const blocked of reverseBlockers.get(id) ?? []) {
+        if (isOnPath(blocked)) {
+          result = true;
+          break;
+        }
+      }
+    }
+
+    onPathStack.delete(id);
+    onPathMemo.set(id, result);
+    return result;
+  };
+
+  // --- Capture-resolution term ---------------------------------------------
+
+  const captureScoreFor = (n: IntentionNode): number => {
+    const strategies: IntentionNode[] =
+      n.kind === "strategy"
+        ? [n]
+        : n.serves
+            .map((id) => byId.get(id))
+            .filter((s): s is IntentionNode => s !== undefined && s.kind === "strategy");
+
+    const delegationIds = new Set<string>();
+    for (const strategy of strategies) {
+      for (const id of strategy.recovers) delegationIds.add(id);
+    }
+
+    let sum = 0;
+    for (const id of delegationIds) {
+      const delegation = byId.get(id);
+      if (delegation !== undefined && delegation.kind === "delegation") {
+        sum += captureScore(delegation);
+      }
+    }
+    return sum;
+  };
+
+  // --- Compose --------------------------------------------------------------
 
   // Iterate in id order for a deterministic result regardless of input order.
   const sorted = [...nodes].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
   const eligible = sorted.filter(isEligible);
-  for (const n of eligible) compute(n);
+  for (const n of eligible) computeAuthored(n);
 
   const result = new Map<string, ResolvedAttention>();
   for (const n of eligible) {
-    const out = compute(n);
-    let value = 0;
-    for (const amt of out.values()) value += amt;
-    const sources = [...out.entries()]
+    const authoredOut = computeAuthored(n);
+    let authoredValue = 0;
+    for (const amt of authoredOut.values()) authoredValue += amt;
+    const sources = [...authoredOut.entries()]
       .sort((a, b) => (a[1] !== b[1] ? b[1] - a[1] : a[0] < b[0] ? -1 : 1))
       .map(([src]) => src);
-    result.set(n.id, { value, sources });
+
+    const overridden = n.attention !== null && n.attention.override !== null;
+    if (overridden) {
+      // Clarification 11: an override pins the value absolutely — derived
+      // terms never silently overwhelm (or even touch) it.
+      result.set(n.id, {
+        value: authoredValue,
+        sources,
+        terms: [{ term: "authored", value: authoredValue }],
+      });
+      continue;
+    }
+
+    const signalValue = isOnPath(n.id) ? SIGNAL_TERM_WEIGHT : 0;
+    const captureValue = CAPTURE_TERM_WEIGHT * captureScoreFor(n);
+    const value = authoredValue + signalValue + captureValue;
+    result.set(n.id, {
+      value,
+      sources,
+      terms: [
+        { term: "authored", value: authoredValue },
+        { term: "signal", value: signalValue },
+        { term: "capture", value: captureValue },
+      ],
+    });
   }
   return result;
 }

--- a/packages/intentionsutil/src/attention.ts
+++ b/packages/intentionsutil/src/attention.ts
@@ -78,7 +78,7 @@ function divergenceScore(delegation: IntentionNode): number {
   if (!isPlainObjectLike(divergence)) return 0;
   const level = divergence.level;
   if (typeof level !== "string") return 0;
-  const tokens = level.toLowerCase().match(/low|moderate|high/g);
+  const tokens = level.toLowerCase().match(/\blow\b|\bmoderate\b|\bhigh\b/g);
   if (tokens === null) return 0;
   // A compound value ("low-moderate") names two severities at once; score the
   // more severe one — understating capture risk is the wrong direction to
@@ -90,12 +90,18 @@ function irreversibilityScore(delegation: IntentionNode): number {
   const irreversibility = delegation.attributes.irreversibility;
   if (!isPlainObjectLike(irreversibility)) return 0;
   const gated = irreversibility.gated;
-  const gatedText = (typeof gated === "string" ? gated : String(gated ?? "")).trim().toLowerCase();
+  // A missing/malformed axis contributes 0 rather than partial (mirrors
+  // `divergenceScore`): an unfilled `irreversibility` object must not score
+  // HIGHER than one explicitly authored as fully open.
+  if (typeof gated !== "string") return 0;
+  const gatedText = gated.trim().toLowerCase();
+  if (gatedText === "") return 0;
   if (gatedText.startsWith("true")) return 3;
   if (gatedText.startsWith("false")) return 1;
   // The store's real middle ground ("partially — ...", "largely — ...") is
-  // real, described gating — distinct from both the fully-open and
-  // fully-closed poles, never collapsed into either.
+  // real, described gating — a present, non-empty string that names neither
+  // pole — distinct from both the fully-open and fully-closed poles, never
+  // collapsed into either.
   return 2;
 }
 
@@ -252,32 +258,54 @@ export function resolveAttention(nodes: IntentionNode[]): Map<string, ResolvedAt
   const onPathMemo = new Map<string, boolean>();
   const onPathStack = new Set<string>();
 
-  const isOnPath = (id: string): boolean => {
+  // `provisional` marks a `false` that was only reached by short-circuiting on a
+  // node still mid-DFS (a cycle formed by MIXING `parent` and `blocked_by`
+  // edges). Such a `false` saw only the truncated cycle view, not the node's
+  // true reachability, so it must NOT be memoized: caching it would permanently
+  // mis-record a node as off-path when its sole route to a terminal runs back
+  // through an ancestor that had not yet resolved, and would make the result
+  // depend on input/traversal order. It is recomputed instead — every eligible
+  // node is entered as a fresh DFS root by the compose loop, at which point its
+  // former on-stack ancestors are fully-resolved descendants. A `true` is always
+  // final (some path reached a terminal) and is always cached.
+  const resolveOnPath = (id: string): { result: boolean; provisional: boolean } => {
     const memo = onPathMemo.get(id);
-    if (memo !== undefined) return memo;
-    if (onPathStack.has(id)) return false; // cycle: this path contributes nothing, don't cache
+    if (memo !== undefined) return { result: memo, provisional: false };
+    if (onPathStack.has(id)) return { result: false, provisional: true }; // cycle short-circuit
     onPathStack.add(id);
 
     let result = terminalIds.has(id);
+    let provisional = false;
     if (!result) {
       const node = byId.get(id);
       if (node?.parent !== null && node?.parent !== undefined && byId.has(node.parent)) {
-        result = isOnPath(node.parent);
+        const parent = resolveOnPath(node.parent);
+        if (parent.result) result = true;
+        else provisional = provisional || parent.provisional;
       }
     }
     if (!result) {
       for (const blocked of reverseBlockers.get(id) ?? []) {
-        if (isOnPath(blocked)) {
+        const sub = resolveOnPath(blocked);
+        if (sub.result) {
           result = true;
           break;
         }
+        provisional = provisional || sub.provisional;
       }
     }
 
     onPathStack.delete(id);
-    onPathMemo.set(id, result);
-    return result;
+    // Cache only final answers: any `true`, or a `false` that did not depend on
+    // an unresolved cycle short-circuit. Provisional falses recompute later.
+    if (result || !provisional) {
+      onPathMemo.set(id, result);
+      return { result, provisional: false };
+    }
+    return { result, provisional: true };
   };
+
+  const isOnPath = (id: string): boolean => resolveOnPath(id).result;
 
   // --- Capture-resolution term ---------------------------------------------
 
@@ -301,7 +329,11 @@ export function resolveAttention(nodes: IntentionNode[]): Map<string, ResolvedAt
         sum += captureScore(delegation);
       }
     }
-    return sum;
+    // Cap at 1 so the capture term never exceeds CAPTURE_TERM_WEIGHT: the
+    // "Weights" invariant (derived terms max out at SIGNAL_TERM_WEIGHT +
+    // CAPTURE_TERM_WEIGHT = 2, so an authored boost still dominates) only holds
+    // if a node recovering several high-severity delegations can't sum past 1.
+    return Math.min(1, sum);
   };
 
   // --- Compose --------------------------------------------------------------

--- a/packages/intentionsutil/src/attention.ts
+++ b/packages/intentionsutil/src/attention.ts
@@ -61,28 +61,42 @@ function isUnvalidated(strategy: IntentionNode): boolean {
 // defensive parsing here is boundary validation, not a fallback: a
 // missing/malformed axis simply contributes 0 rather than throwing, since
 // `attributes` shape is data (the kind node), not a code contract.
+//
+// Both axes are authored as free text, not an enum the schema gates — the live
+// store already carries compound/qualified values (`low-moderate`,
+// `moderate — would-be`) alongside the plain `low`/`moderate`/`high` the
+// kind-delegation field spec documents, so an exact-match switch silently
+// zeroes real, already-recovered delegations (e.g. delegation-hosted-publishing
+// feeds strategy-recover-publishing's capture term today). Token matching
+// against the free text is the boundary-validation move here: real authored
+// intent still parses, and only genuinely unrecognized text falls to 0.
+
+const DIVERGENCE_LEVEL_SCORES: Record<string, number> = { low: 1, moderate: 2, high: 3 };
 
 function divergenceScore(delegation: IntentionNode): number {
   const divergence = delegation.attributes.divergence;
   if (!isPlainObjectLike(divergence)) return 0;
-  switch (divergence.level) {
-    case "low":
-      return 1;
-    case "moderate":
-      return 2;
-    case "high":
-      return 3;
-    default:
-      return 0;
-  }
+  const level = divergence.level;
+  if (typeof level !== "string") return 0;
+  const tokens = level.toLowerCase().match(/low|moderate|high/g);
+  if (tokens === null) return 0;
+  // A compound value ("low-moderate") names two severities at once; score the
+  // more severe one — understating capture risk is the wrong direction to
+  // round on a term whose purpose is flagging it.
+  return Math.max(...tokens.map((t) => DIVERGENCE_LEVEL_SCORES[t]));
 }
 
 function irreversibilityScore(delegation: IntentionNode): number {
   const irreversibility = delegation.attributes.irreversibility;
   if (!isPlainObjectLike(irreversibility)) return 0;
   const gated = irreversibility.gated;
-  const gatedText = typeof gated === "string" ? gated : String(gated ?? "");
-  return gatedText.trim().toLowerCase().startsWith("true") ? 2 : 1;
+  const gatedText = (typeof gated === "string" ? gated : String(gated ?? "")).trim().toLowerCase();
+  if (gatedText.startsWith("true")) return 3;
+  if (gatedText.startsWith("false")) return 1;
+  // The store's real middle ground ("partially — ...", "largely — ...") is
+  // real, described gating — distinct from both the fully-open and
+  // fully-closed poles, never collapsed into either.
+  return 2;
 }
 
 /** One delegation's capture severity, normalized to the 1/3..1 range (max axis sum 6). */

--- a/packages/intentionsutil/src/goals.ts
+++ b/packages/intentionsutil/src/goals.ts
@@ -112,17 +112,24 @@ function formatRank(value: number): string {
 }
 
 /**
- * Render a per-term breakdown suffix (e.g. ` {authored 6, signal 1}`) when
- * `terms` carries more than one nonzero contribution — the explainability
- * detail behind a composed rank (strategy clarification 11). Absent `terms`
- * (hand-built `ResolvedAttention` literals) or a single contributing term
- * (the common case: authored-only) renders nothing extra, so most output is
- * unaffected by the term registry's introduction.
+ * Render a per-term breakdown suffix (e.g. ` {authored 6, signal 1}`) — the
+ * explainability detail behind a composed rank (strategy clarification 11).
+ * Absent `terms` (hand-built `ResolvedAttention` literals) renders nothing.
+ *
+ * A single nonzero `authored` term is suppressed because a nonzero authored
+ * contribution always populates `sources`, which `renderFrontier` already
+ * surfaces as `[rank N via X]` — the breakdown would be redundant. But
+ * `signal` and `capture` never populate `sources`, so a single nonzero
+ * `signal`/`capture` term is the value's only explanation and must be shown;
+ * otherwise it renders as a bare `[rank N]` indistinguishable from a legacy
+ * anonymous boost. So render whenever more than one term is nonzero, OR the
+ * sole nonzero term is not `authored`.
  */
 function formatTermBreakdown(terms: TermContribution[] | undefined): string {
   if (terms === undefined) return "";
   const nonZero = terms.filter((t) => t.value !== 0);
-  if (nonZero.length <= 1) return "";
+  if (nonZero.length === 0) return "";
+  if (nonZero.length === 1 && nonZero[0].term === "authored") return "";
   return ` {${nonZero.map((t) => `${t.term} ${formatRank(t.value)}`).join(", ")}}`;
 }
 

--- a/packages/intentionsutil/src/goals.ts
+++ b/packages/intentionsutil/src/goals.ts
@@ -1,4 +1,4 @@
-import type { ResolvedAttention } from "./attention.js";
+import type { ResolvedAttention, TermContribution } from "./attention.js";
 import { resolveAttention } from "./attention.js";
 import type { IntentionNode, Owner } from "./schema.js";
 
@@ -112,6 +112,21 @@ function formatRank(value: number): string {
 }
 
 /**
+ * Render a per-term breakdown suffix (e.g. ` {authored 6, signal 1}`) when
+ * `terms` carries more than one nonzero contribution — the explainability
+ * detail behind a composed rank (strategy clarification 11). Absent `terms`
+ * (hand-built `ResolvedAttention` literals) or a single contributing term
+ * (the common case: authored-only) renders nothing extra, so most output is
+ * unaffected by the term registry's introduction.
+ */
+function formatTermBreakdown(terms: TermContribution[] | undefined): string {
+  if (terms === undefined) return "";
+  const nonZero = terms.filter((t) => t.value !== 0);
+  if (nonZero.length <= 1) return "";
+  return ` {${nonZero.map((t) => `${t.term} ${formatRank(t.value)}`).join(", ")}}`;
+}
+
+/**
  * Render the projected goals as deterministic markdown, one line per goal in
  * `projectGoals` order. The output is byte-stable across repeated calls with
  * the same input: no dates, no wall-clock, no environment data. Ends with a
@@ -122,7 +137,8 @@ function formatRank(value: number): string {
  * ` [rank <value> via <sources[0]>]` naming the top contributing source, or
  * ` [rank <value>]` when `sources` is empty. Value 0 / null renders unmarked,
  * so a store with no injection anywhere is byte-identical to the pre-attention
- * render.
+ * render. When more than one term contributes, a ` {term v, term v}`
+ * breakdown follows the rank marker for explainability.
  */
 export function renderFrontier(goals: Goal[]): string {
   if (goals.length === 0) {
@@ -136,6 +152,7 @@ export function renderFrontier(goals: Goal[]): string {
         attention.sources.length > 0
           ? ` [rank ${rank} via ${attention.sources[0]}]`
           : ` [rank ${rank}]`;
+      line += formatTermBreakdown(attention.terms);
     }
     if (node.gap !== null) line += ` — gap: ${node.gap}`;
     return line;

--- a/packages/intentionsutil/src/index.ts
+++ b/packages/intentionsutil/src/index.ts
@@ -10,7 +10,7 @@ export type {
   Attention,
 } from "./schema.js";
 export { resolveAttention } from "./attention.js";
-export type { ResolvedAttention } from "./attention.js";
+export type { ResolvedAttention, TermContribution } from "./attention.js";
 export { IntentionSchemaError } from "./errors.js";
 export { writeNode, readNode, listNodes } from "./store.js";
 export { projectGoals, activeFrontier, realizationForOwner, renderFrontier } from "./goals.js";

--- a/packages/intentionsutil/test/attention.test.ts
+++ b/packages/intentionsutil/test/attention.test.ts
@@ -420,6 +420,49 @@ describe("resolveAttention capture-resolution term", () => {
     expect(strategyValue).toBeGreaterThan(0);
     expect(tacticValue).toBe(strategyValue);
   });
+
+  // Both capture axes are free text, not a schema-gated enum — the live store
+  // already authors values beyond the plain low/moderate/high + true/false the
+  // kind-delegation field spec documents: delegation-anthropic-claude and
+  // delegation-banking use `low-moderate`; delegation-hosted-publishing uses
+  // `moderate — would-be`; every gated delegation with a description reads
+  // `partially — ...` or `largely — ...`, never a bare `true`. An exact-match
+  // parse silently zeroes (divergence) or under-scores (irreversibility) these
+  // real, already-recovered delegations; these cases pin the real vocabulary.
+
+  function withCaptureAxes(attributes: Record<string, unknown>): IntentionNode[] {
+    return [
+      ...kinds(),
+      anode({ id: "delegation-under-test", kind: "delegation", status: "codified", attributes }),
+      svnode({ id: "strategy-under-test", recovers: ["delegation-under-test"] }),
+    ];
+  }
+
+  it("scores a compound divergence level ('low-moderate') as its more severe component, not 0", () => {
+    const result = resolveAttention(withCaptureAxes({ divergence: { level: "low-moderate" } }));
+    // moderate (2) / 6 — not 0, and strictly above a plain "low" (1/6).
+    expect(result.get("strategy-under-test")?.value).toBeCloseTo(2 / 6);
+  });
+
+  it("scores a qualified divergence level ('moderate — would-be') by its recognized token, not 0", () => {
+    const result = resolveAttention(withCaptureAxes({ divergence: { level: "moderate — would-be" } }));
+    expect(result.get("strategy-under-test")?.value).toBeCloseTo(2 / 6);
+  });
+
+  it("scores 'partially gated' strictly between 'false' and 'true' — never collapsed onto 'false'", () => {
+    const falseValue = resolveAttention(
+      withCaptureAxes({ irreversibility: { gated: "false" } }),
+    ).get("strategy-under-test")?.value;
+    const partialValue = resolveAttention(
+      withCaptureAxes({ irreversibility: { gated: "partially — the authoritative record is the vendor's" } }),
+    ).get("strategy-under-test")?.value;
+    const trueValue = resolveAttention(
+      withCaptureAxes({ irreversibility: { gated: "true — no export path" } }),
+    ).get("strategy-under-test")?.value;
+
+    expect(partialValue).toBeGreaterThan(falseValue ?? 0);
+    expect(trueValue).toBeGreaterThan(partialValue ?? 0);
+  });
 });
 
 describe("resolveAttention term composition is modular", () => {

--- a/packages/intentionsutil/test/attention.test.ts
+++ b/packages/intentionsutil/test/attention.test.ts
@@ -32,6 +32,18 @@ function anode(partial: Partial<IntentionNode> & { id: string; kind: string }): 
   };
 }
 
+/**
+ * A strategy fixture whose signal already reads as validated (`reading`
+ * non-null, no `gap`) — the default in every describe block below EXCEPT the
+ * dedicated "signal-satisfaction term" block, so those tests exercise the
+ * `authored` term in isolation, undisturbed by the new `signal` term (which
+ * would otherwise treat any strategy with the schema's default
+ * `reading: null` as its own unvalidated validates-terminal).
+ */
+function svnode(partial: Partial<IntentionNode> & { id: string }): IntentionNode {
+  return anode({ reading: "measured", ...partial, kind: "strategy" });
+}
+
 /** A relative boost injection. */
 function boost(amount: number, rationale = "because"): Attention {
   return { boost: amount, override: null, rationale };
@@ -64,6 +76,7 @@ function kinds(): IntentionNode[] {
       attributes: { goal_layer: true },
     }),
     anode({ id: "kind-virtue", kind: "kind", status: "codified" }),
+    anode({ id: "kind-delegation", kind: "kind", status: "codified" }),
   ];
 }
 
@@ -72,7 +85,7 @@ describe("resolveAttention eligibility", () => {
     const nodes = [
       ...kinds(),
       anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      anode({ id: "strategy-1", kind: "strategy", serves: ["virtue-root"], attention: boost(5) }),
+      svnode({ id: "strategy-1", serves: ["virtue-root"], attention: boost(5) }),
     ];
 
     const result = resolveAttention(nodes);
@@ -93,11 +106,13 @@ describe("resolveAttention eligibility", () => {
   it("gives an eligible node with no injection a value-0 entry with empty sources", () => {
     const nodes = [
       ...kinds(),
-      anode({ id: "strategy-quiet", kind: "strategy" }),
+      svnode({ id: "strategy-quiet" }),
     ];
 
     const result = resolveAttention(nodes);
-    expect(result.get("strategy-quiet")).toEqual({ value: 0, sources: [] });
+    const quiet = result.get("strategy-quiet");
+    expect(quiet?.value).toBe(0);
+    expect(quiet?.sources).toEqual([]);
   });
 });
 
@@ -108,11 +123,11 @@ describe("resolveAttention boost (undecayed, undiluted)", () => {
     const nodes = [
       ...kinds(),
       anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      anode({ id: "strategy-parent", kind: "strategy", serves: ["virtue-root"], attention: boost(6) }),
-      anode({ id: "sub-1", kind: "strategy", parent: "strategy-parent" }),
-      anode({ id: "sub-2", kind: "strategy", parent: "strategy-parent" }),
+      svnode({ id: "strategy-parent", serves: ["virtue-root"], attention: boost(6) }),
+      svnode({ id: "sub-1", parent: "strategy-parent" }),
+      svnode({ id: "sub-2", parent: "strategy-parent" }),
       anode({ id: "tactic-1", kind: "tactic", serves: ["strategy-parent"] }),
-      anode({ id: "grand-1", kind: "strategy", parent: "sub-1" }),
+      svnode({ id: "grand-1", parent: "sub-1" }),
     ];
 
     const result = resolveAttention(nodes);
@@ -126,10 +141,10 @@ describe("resolveAttention boost (undecayed, undiluted)", () => {
     const nodes = [
       ...kinds(),
       anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      anode({ id: "s1", kind: "strategy", serves: ["virtue-root"], attention: boost(2) }),
-      anode({ id: "s2", kind: "strategy", serves: ["virtue-root"], attention: boost(6) }),
+      svnode({ id: "s1", serves: ["virtue-root"], attention: boost(2) }),
+      svnode({ id: "s2", serves: ["virtue-root"], attention: boost(6) }),
       // child draws from s1 (parent) and s2 (serves).
-      anode({ id: "child", kind: "strategy", parent: "s1", serves: ["s2"] }),
+      svnode({ id: "child", parent: "s1", serves: ["s2"] }),
     ];
 
     const result = resolveAttention(nodes);
@@ -144,10 +159,10 @@ describe("resolveAttention boost (undecayed, undiluted)", () => {
     const nodes = [
       ...kinds(),
       anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      anode({ id: "top", kind: "strategy", serves: ["virtue-root"], attention: boost(4) }),
-      anode({ id: "mid1", kind: "strategy", parent: "top" }),
-      anode({ id: "mid2", kind: "strategy", serves: ["top"] }),
-      anode({ id: "bottom", kind: "strategy", parent: "mid1", serves: ["mid2"] }),
+      svnode({ id: "top", serves: ["virtue-root"], attention: boost(4) }),
+      svnode({ id: "mid1", parent: "top" }),
+      svnode({ id: "mid2", serves: ["top"] }),
+      svnode({ id: "bottom", parent: "mid1", serves: ["mid2"] }),
     ];
 
     const result = resolveAttention(nodes);
@@ -159,9 +174,9 @@ describe("resolveAttention boost (undecayed, undiluted)", () => {
     const nodes = [
       ...kinds(),
       anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      anode({ id: "anc", kind: "strategy", serves: ["virtue-root"], attention: boost(3) }),
-      anode({ id: "mid", kind: "strategy", parent: "anc", attention: boost(2) }),
-      anode({ id: "leaf", kind: "strategy", parent: "mid" }),
+      svnode({ id: "anc", serves: ["virtue-root"], attention: boost(3) }),
+      svnode({ id: "mid", parent: "anc", attention: boost(2) }),
+      svnode({ id: "leaf", parent: "mid" }),
     ];
 
     const result = resolveAttention(nodes);
@@ -183,11 +198,11 @@ describe("resolveAttention override (branch cap)", () => {
     const nodes = [
       ...kinds(),
       anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      anode({ id: "s1", kind: "strategy", serves: ["virtue-root"], attention: boost(10) }),
-      anode({ id: "c", kind: "strategy", parent: "s1", attention: override(2) }),
-      anode({ id: "d", kind: "strategy", parent: "c" }),
-      anode({ id: "s2", kind: "strategy", serves: ["virtue-root"], attention: boost(6) }),
-      anode({ id: "t", kind: "strategy", parent: "c", serves: ["s2"] }),
+      svnode({ id: "s1", serves: ["virtue-root"], attention: boost(10) }),
+      svnode({ id: "c", parent: "s1", attention: override(2) }),
+      svnode({ id: "d", parent: "c" }),
+      svnode({ id: "s2", serves: ["virtue-root"], attention: boost(6) }),
+      svnode({ id: "t", parent: "c", serves: ["s2"] }),
     ];
 
     const result = resolveAttention(nodes);
@@ -206,11 +221,11 @@ describe("resolveAttention override (branch cap)", () => {
     const nodes = [
       ...kinds(),
       anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      anode({ id: "root", kind: "strategy", serves: ["virtue-root"], attention: boost(100) }),
-      anode({ id: "outer", kind: "strategy", parent: "root", attention: override(5) }),
-      anode({ id: "between", kind: "strategy", parent: "outer" }),
-      anode({ id: "inner", kind: "strategy", parent: "outer", attention: override(2) }),
-      anode({ id: "leaf", kind: "strategy", parent: "inner" }),
+      svnode({ id: "root", serves: ["virtue-root"], attention: boost(100) }),
+      svnode({ id: "outer", parent: "root", attention: override(5) }),
+      svnode({ id: "between", parent: "outer" }),
+      svnode({ id: "inner", parent: "outer", attention: override(2) }),
+      svnode({ id: "leaf", parent: "inner" }),
     ];
 
     const result = resolveAttention(nodes);
@@ -220,14 +235,56 @@ describe("resolveAttention override (branch cap)", () => {
     expect(result.get("leaf")?.value).toBe(2); // nearest (inner) wins
     expect(result.get("leaf")?.sources).toEqual(["inner"]);
   });
+
+  it("authored override is unaffected by any derived term", () => {
+    // c overrides down to 2 despite also being on the signal path (it blocks
+    // tactic-terminal, which validates the unvalidated strategy-target) AND
+    // serving a strategy with a high-capture delegation — both derived terms
+    // would otherwise add on top, but the override pins the total absolutely.
+    const nodes = [
+      ...kinds(),
+      anode({
+        id: "delegation-x",
+        kind: "delegation",
+        status: "codified",
+        attributes: {
+          divergence: { level: "high" },
+          irreversibility: { gated: "true — no export path" },
+        },
+      }),
+      anode({ id: "strategy-target", kind: "strategy" }), // reading: null omitted → unvalidated
+      svnode({
+        id: "strategy-captured",
+        recovers: ["delegation-x"],
+      }),
+      anode({
+        id: "c",
+        kind: "tactic",
+        blocked_by: [],
+        serves: ["strategy-captured"],
+        attention: override(2),
+      }),
+      anode({
+        id: "tactic-terminal",
+        kind: "tactic",
+        blocked_by: ["c"],
+        validates: ["strategy-target"],
+      }),
+    ];
+
+    const result = resolveAttention(nodes);
+    const c = result.get("c");
+    expect(c?.value).toBe(2);
+    expect(c?.terms).toEqual([{ term: "authored", value: 2 }]);
+  });
 });
 
 describe("resolveAttention cycle guard", () => {
   it("throws IntentionSchemaError on a parent-edge cycle", () => {
     const nodes = [
       ...kinds(),
-      anode({ id: "cyc-a", kind: "strategy", parent: "cyc-b" }),
-      anode({ id: "cyc-b", kind: "strategy", parent: "cyc-a" }),
+      svnode({ id: "cyc-a", parent: "cyc-b" }),
+      svnode({ id: "cyc-b", parent: "cyc-a" }),
     ];
 
     expect(() => resolveAttention(nodes)).toThrow(IntentionSchemaError);
@@ -240,10 +297,10 @@ describe("resolveAttention determinism", () => {
     const nodes = [
       ...kinds(),
       anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
-      anode({ id: "s1", kind: "strategy", serves: ["virtue-root"], attention: boost(2) }),
-      anode({ id: "s2", kind: "strategy", serves: ["virtue-root"], attention: boost(6) }),
-      anode({ id: "c", kind: "strategy", parent: "s1", attention: override(3) }),
-      anode({ id: "child", kind: "strategy", parent: "c", serves: ["s2"] }),
+      svnode({ id: "s1", serves: ["virtue-root"], attention: boost(2) }),
+      svnode({ id: "s2", serves: ["virtue-root"], attention: boost(6) }),
+      svnode({ id: "c", parent: "s1", attention: override(3) }),
+      svnode({ id: "child", parent: "c", serves: ["s2"] }),
       anode({ id: "tactic-1", kind: "tactic", serves: ["s2"] }),
     ];
     const shuffled = [...nodes].reverse();
@@ -254,5 +311,145 @@ describe("resolveAttention determinism", () => {
 
     expect(b).toEqual(a);
     expect(c).toEqual(a);
+  });
+});
+
+describe("resolveAttention signal-satisfaction term", () => {
+  it("ranks an on-path node (validates an unvalidated strategy) above an otherwise-identical off-path node", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "strategy-target", kind: "strategy" }), // reading: null (default) → unvalidated
+      anode({ id: "tactic-on", kind: "tactic", validates: ["strategy-target"] }),
+      anode({ id: "tactic-off", kind: "tactic", validates: [] }),
+    ];
+
+    const result = resolveAttention(nodes);
+    expect(result.get("tactic-on")?.value).toBe(1); // SIGNAL_TERM_WEIGHT
+    expect(result.get("tactic-off")?.value).toBe(0);
+  });
+
+  it("does not treat a tactic validating an already-validated strategy as a terminal", () => {
+    const nodes = [
+      ...kinds(),
+      svnode({ id: "strategy-done", reading: "the signal reads clean" }),
+      anode({ id: "tactic-done", kind: "tactic", validates: ["strategy-done"] }),
+    ];
+
+    const result = resolveAttention(nodes);
+    expect(result.get("tactic-done")?.value).toBe(0);
+  });
+
+  it("lifts an upstream blocker when a downstream tactic gains a validates edge, with no other change", () => {
+    const strategyTarget = anode({ id: "strategy-target", kind: "strategy" }); // unvalidated
+    const tacticA = anode({ id: "tactic-a", kind: "tactic", blocked_by: [] });
+    const tacticBBefore = anode({ id: "tactic-b", kind: "tactic", blocked_by: ["tactic-a"], validates: [] });
+    const tacticBAfter = anode({ id: "tactic-b", kind: "tactic", blocked_by: ["tactic-a"], validates: ["strategy-target"] });
+
+    const before = resolveAttention([...kinds(), strategyTarget, tacticA, tacticBBefore]);
+    const after = resolveAttention([...kinds(), strategyTarget, tacticA, tacticBAfter]);
+
+    expect(before.get("tactic-a")?.value).toBe(0);
+    expect(after.get("tactic-a")?.value).toBe(1); // lifted by the new downstream validates edge
+  });
+
+  it("inherits on-path status down a parent chain", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "strategy-target", kind: "strategy" }), // unvalidated
+      anode({ id: "epic", kind: "tactic", blocked_by: [], validates: ["strategy-target"] }),
+      anode({ id: "child", kind: "tactic", parent: "epic" }),
+    ];
+
+    const result = resolveAttention(nodes);
+    expect(result.get("child")?.value).toBe(1);
+  });
+});
+
+describe("resolveAttention capture-resolution term", () => {
+  it("orders two strategies by their recovered delegations' divergence/irreversibility axes", () => {
+    const nodes = [
+      ...kinds(),
+      anode({
+        id: "delegation-low",
+        kind: "delegation",
+        status: "codified",
+        attributes: {
+          divergence: { level: "low" },
+          irreversibility: { gated: "false — fully portable" },
+        },
+      }),
+      anode({
+        id: "delegation-high",
+        kind: "delegation",
+        status: "codified",
+        attributes: {
+          divergence: { level: "high" },
+          irreversibility: { gated: "true — no export path" },
+        },
+      }),
+      svnode({ id: "strategy-low-capture", recovers: ["delegation-low"] }),
+      svnode({ id: "strategy-high-capture", recovers: ["delegation-high"] }),
+    ];
+
+    const result = resolveAttention(nodes);
+    const low = result.get("strategy-low-capture")?.value ?? 0;
+    const high = result.get("strategy-high-capture")?.value ?? 0;
+    expect(high).toBeGreaterThan(low);
+    expect(low).toBeGreaterThan(0);
+  });
+
+  it("carries a serving tactic's capture score from its strategy's recovers edge", () => {
+    const nodes = [
+      ...kinds(),
+      anode({
+        id: "delegation-x",
+        kind: "delegation",
+        status: "codified",
+        attributes: {
+          divergence: { level: "moderate" },
+          irreversibility: { gated: "false" },
+        },
+      }),
+      svnode({ id: "strategy-x", recovers: ["delegation-x"] }),
+      anode({ id: "tactic-x", kind: "tactic", serves: ["strategy-x"] }),
+    ];
+
+    const result = resolveAttention(nodes);
+    const strategyValue = result.get("strategy-x")?.value ?? 0;
+    const tacticValue = result.get("tactic-x")?.value ?? 0;
+    expect(strategyValue).toBeGreaterThan(0);
+    expect(tacticValue).toBe(strategyValue);
+  });
+});
+
+describe("resolveAttention term composition is modular", () => {
+  it("leaves an authored-only node's value untouched by a sibling's unrelated signal/capture contributions", () => {
+    const nodes = [
+      ...kinds(),
+      anode({
+        id: "delegation-heavy",
+        kind: "delegation",
+        status: "codified",
+        attributes: {
+          divergence: { level: "high" },
+          irreversibility: { gated: "true" },
+        },
+      }),
+      anode({ id: "virtue-root", kind: "virtue", status: "codified" }),
+      // Sibling with no relation to the boosted node: its own signal/capture
+      // contributions must not leak into strategy-boosted's composition.
+      anode({ id: "strategy-target", kind: "strategy" }), // unvalidated — an on-path terminal
+      svnode({ id: "strategy-captured", recovers: ["delegation-heavy"] }),
+      svnode({ id: "strategy-boosted", serves: ["virtue-root"], attention: boost(7) }),
+    ];
+
+    const result = resolveAttention(nodes);
+    const boosted = result.get("strategy-boosted");
+    expect(boosted?.value).toBe(7);
+    expect(boosted?.terms).toEqual([
+      { term: "authored", value: 7 },
+      { term: "signal", value: 0 },
+      { term: "capture", value: 0 },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Implements `tactic-calculated-attention` from the `tactic-graph-native-dispatch` subtree (intentions/tactic-calculated-attention.md), executed as the next ready on-path unit in strategy-graph-native-dispatch's round 1.

Restructures `resolveAttention` from a single additive-flow algorithm into a term registry composed as a weighted sum, per strategy clarification 11 on `strategy-graph-native-dispatch`:

- **authored** — the existing v2 boost/override flow, unchanged (`parent`/`serves` propagation, undecayed/undiluted).
- **signal** — structural: a node is on-path iff it (transitively) blocks — reachable by walking `blocked_by` in reverse, or inherits down a `parent` chain — a validates-terminal (a tactic with a `validates` edge to an unvalidated strategy, or such a strategy itself).
- **capture** — from the node's own `recovers` (strategies) or its serving strategy's `recovers` (tactics via `serves`): each resolved delegation contributes a normalized divergence/irreversibility axis score.

An authored `override` still pins the total absolutely — derived terms never touch it. `ResolvedAttention` gains an optional `terms` field exposing the per-term breakdown, and `renderFrontier` surfaces it as a `{term v, term v}` suffix when more than one term contributes, for explainability.

Manually verified against the live store: `tactic-align-init-skill`, `tactic-graph-commit-hardening`, and `tactic-graph-write-validation-hardening` (off-path — no `blocked_by` chain to a validates-terminal) rank below their on-path siblings in the same subtree, with no backlog flag anywhere in the store.

## Test plan

- [x] `npm test --prefix packages/intentionsutil` — 149 tests pass (existing suite + new signal/capture/composition tests)
- [x] `npx tsc --noEmit -p packages/intentionsutil` — clean
- [x] lint (`eslint src/`) — clean
- [x] Manual: `npx tsx packages/intentionsutil/scripts/frontier-view.ts` and a direct `resolveAttention` check against the live `intentions/` store confirm the documented on-path/off-path ranking for the tactic-graph-native-dispatch subtree

🤖 Generated with [Claude Code](https://claude.com/claude-code)