### PR TITLE
nix: export claude-code overlay + mkPkgs helper so instances stop copying pkgs construction

### DIFF
--- a/examples/office-hours-nate/README.md
+++ b/examples/office-hours-nate/README.md
@@ -55,8 +55,10 @@ homeConfiguration, and add the flag only if that eval actually fails.
 
 ## Do not strip the claude-code overlay
 
-The template builds `pkgs` with `claude-code-nix.overlays.default` applied. The
-framework's `homeManagerModules.default` installs `pkgs.claude-code`, which only
-exists when that overlay is present. Remove it and eval fails with
-`attribute 'claude-code' missing in set`. The template already wires it; leave
-it in place.
+The template builds `pkgs` via `commons-systems.mkPkgs { inherit system; }`,
+which applies the claude-code-nix overlay for you. The framework's
+`homeManagerModules.default` installs `pkgs.claude-code`, which only exists
+when that overlay is present. Don't replace `mkPkgs` with a hand-rolled
+`import nixpkgs { ... }` that omits the overlay — eval fails with
+`attribute 'claude-code' missing in set`. Use `mkPkgs`; it already carries
+the overlay for you.

--- a/examples/office-hours-nate/README.md
+++ b/examples/office-hours-nate/README.md
@@ -57,8 +57,10 @@ homeConfiguration, and add the flag only if that eval actually fails.
 
 The template builds `pkgs` via `commons-systems.mkPkgs { inherit system; }`,
 which applies the claude-code-nix overlay for you. The framework's
-`homeManagerModules.default` installs `pkgs.claude-code`, which only exists
-when that overlay is present. Don't replace `mkPkgs` with a hand-rolled
-`import nixpkgs { ... }` that omits the overlay — eval fails with
-`attribute 'claude-code' missing in set`. Use `mkPkgs`; it already carries
-the overlay for you.
+`homeManagerModules.default` installs `pkgs.claude-code`. Don't replace
+`mkPkgs` with a hand-rolled `import nixpkgs { ... }` that omits the overlay.
+Recent nixpkgs ships its own `claude-code` derivation, so eval will *succeed*
+without the overlay — but it silently swaps in nixpkgs' build/version instead
+of the pinned sadjow fork (`claude-code-nix`), which tracks upstream releases
+hourly (see `nix/home/claude-code.nix`). Use `mkPkgs`; it already carries the
+overlay for you.

--- a/examples/office-hours-nate/flake.nix
+++ b/examples/office-hours-nate/flake.nix
@@ -35,36 +35,21 @@
       url = "github:nix-community/home-manager/master";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    claude-code-nix = {
-      url = "github:sadjow/claude-code-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
-  outputs = inputs@{ commons-systems, nixpkgs, home-manager, claude-code-nix, ... }:
+  outputs = inputs@{ commons-systems, nixpkgs, home-manager, ... }:
     let
       # Select the system explicitly. This is a pure string literal — not
       # derived from the current system or the environment — so eval needs no
       # --impure.
       system = "aarch64-darwin";
 
-      # direnv 2.37.1 checkPhase hangs when built from source; skip tests.
-      # The framework does not export this overlay, so define it inline.
-      direnvSkipTestsOverlay = final: prev: {
-        direnv = prev.direnv.overrideAttrs (_: { doCheck = false; });
-      };
-
-      # Build pkgs WITH the claude-code-nix overlay. This is load-bearing:
-      # commons-systems.homeManagerModules.default imports nix/home/claude-code.nix,
-      # which installs pkgs.claude-code. That attribute exists only when
-      # claude-code-nix.overlays.default is applied. Without it, eval fails with
-      # `error: attribute 'claude-code' missing in set`.
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [ claude-code-nix.overlays.default direnvSkipTestsOverlay ];
-        config.allowUnfreePredicate =
-          pkg: builtins.elem (nixpkgs.lib.getName pkg) [ "claude-code" ];
-      };
+      # Build the fully-configured pkgs set from the framework's exported helper.
+      # mkPkgs applies the claude-code-nix overlay (so pkgs.claude-code resolves,
+      # required by commons-systems.homeManagerModules.default), applies the direnv
+      # test-skip, and allows claude-code as unfree. The framework is the single
+      # source of this wiring, so instances no longer copy it.
+      pkgs = commons-systems.mkPkgs { inherit system; };
     in
     {
       # `home-manager switch --flake .#aarch64-darwin` resolves this attribute.

--- a/examples/office-hours-nate/flake.nix
+++ b/examples/office-hours-nate/flake.nix
@@ -37,7 +37,7 @@
     };
   };
 
-  outputs = inputs@{ commons-systems, nixpkgs, home-manager, ... }:
+  outputs = inputs@{ commons-systems, home-manager, ... }:
     let
       # Select the system explicitly. This is a pure string literal — not
       # derived from the current system or the environment — so eval needs no
@@ -45,10 +45,13 @@
       system = "aarch64-darwin";
 
       # Build the fully-configured pkgs set from the framework's exported helper.
-      # mkPkgs applies the claude-code-nix overlay (so pkgs.claude-code resolves,
-      # required by commons-systems.homeManagerModules.default), applies the direnv
-      # test-skip, and allows claude-code as unfree. The framework is the single
-      # source of this wiring, so instances no longer copy it.
+      # mkPkgs applies the claude-code-nix overlay (which pins pkgs.claude-code to
+      # the sadjow fork used by commons-systems.homeManagerModules.default),
+      # applies the direnv test-skip, and allows claude-code as unfree. Recent
+      # nixpkgs ships its own claude-code, so dropping the overlay would not fail
+      # eval — it would silently swap in nixpkgs' build/version instead of the
+      # pinned fork. The framework is the single source of this wiring, so
+      # instances no longer copy it.
       pkgs = commons-systems.mkPkgs { inherit system; };
     in
     {

--- a/flake.nix
+++ b/flake.nix
@@ -32,11 +32,13 @@
       claudeUnfreePredicate =
         pkg: builtins.elem (nixpkgs.lib.getName pkg) [ "claude-code" ];
 
-      # Single composed overlay every consumer needs: claude-code-nix (provides
-      # pkgs.claude-code, required by homeManagerModules.default) then the direnv
-      # test-skip. Exported as overlays.default so instance flakes stop hand-copying
-      # the list. Composing into one function keeps it a valid overlay output
-      # (nix flake check rejects a list here).
+      # Single composed overlay every consumer needs: claude-code-nix (pins
+      # pkgs.claude-code to the sadjow fork used by homeManagerModules.default;
+      # recent nixpkgs ships its own claude-code, so without this overlay eval
+      # still succeeds but resolves to nixpkgs' build/version instead) then the
+      # direnv test-skip. Exported as overlays.default so instance flakes stop
+      # hand-copying the list. Composing into one function keeps it a valid overlay
+      # output (nix flake check rejects a list here).
       claudeOverlay = nixpkgs.lib.composeManyExtensions [
         claude-code-nix.overlays.default
         direnvSkipTestsOverlay

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,31 @@
         direnv = prev.direnv.overrideAttrs (_: { doCheck = false; });
       };
 
+      # The unfree package names the framework permits (claude-code is unfree).
+      claudeUnfreePredicate =
+        pkg: builtins.elem (nixpkgs.lib.getName pkg) [ "claude-code" ];
+
+      # Single composed overlay every consumer needs: claude-code-nix (provides
+      # pkgs.claude-code, required by homeManagerModules.default) then the direnv
+      # test-skip. Exported as overlays.default so instance flakes stop hand-copying
+      # the list. Composing into one function keeps it a valid overlay output
+      # (nix flake check rejects a list here).
+      claudeOverlay = nixpkgs.lib.composeManyExtensions [
+        claude-code-nix.overlays.default
+        direnvSkipTestsOverlay
+      ];
+
+      # Build a fully-configured pkgs set for `system`: the composed overlay applied
+      # and claude-code allowed as unfree. Instance flakes call this instead of
+      # copying the `import nixpkgs { … }` block. Closes over the framework's own
+      # nixpkgs/claude-code-nix inputs, which instance flakes make follow their
+      # nixpkgs via `inputs.nixpkgs.follows`.
+      mkPkgs = { system }: import nixpkgs {
+        inherit system;
+        overlays = [ claudeOverlay ];
+        config.allowUnfreePredicate = claudeUnfreePredicate;
+      };
+
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = fn: nixpkgs.lib.genAttrs systems (system: fn {
         pkgs = nixpkgs.legacyPackages.${system};
@@ -114,9 +139,8 @@
       mkIntegratedHmConfig = { hostPlatform, homeDirectory }: {
         nixpkgs.hostPlatform = hostPlatform;
 
-        nixpkgs.overlays = [ claude-code-nix.overlays.default direnvSkipTestsOverlay ];
-        nixpkgs.config.allowUnfreePredicate =
-          pkg: builtins.elem (nixpkgs.lib.getName pkg) [ "claude-code" ];
+        nixpkgs.overlays = [ claudeOverlay ];
+        nixpkgs.config.allowUnfreePredicate = claudeUnfreePredicate;
 
         home-manager.useGlobalPkgs = true;
         home-manager.useUserPackages = true;
@@ -204,5 +228,8 @@
         ];
       };
     in
-    systemOutputs // { inherit darwinConfigurations nixosConfigurations homeManagerModules darwinModules; };
+    systemOutputs // {
+      inherit darwinConfigurations nixosConfigurations homeManagerModules darwinModules mkPkgs;
+      overlays.default = claudeOverlay;
+    };
 }


### PR DESCRIPTION
Closes #2767

## What

Makes the framework flake the single source of the claude-code overlay + unfree
wiring, so instance flakes stop hand-copying the `pkgs` construction.

Before this change, every instance flake (e.g. `examples/office-hours-nate/flake.nix`)
duplicated three things from the framework's own `flake.nix`:

1. `direnvSkipTestsOverlay` — disables direnv's hanging checkPhase.
2. The overlay list `[ claude-code-nix.overlays.default direnvSkipTestsOverlay ]`
   — `claude-code-nix.overlays.default` is what makes `pkgs.claude-code` exist,
   which `commons-systems.homeManagerModules.default` requires.
3. `config.allowUnfreePredicate` allowing `claude-code` (unfree) to build.

The framework exported none of it, so instances copied it inline — and would
silently drift out of sync if the framework's overlay/unfree logic changed.

## Changes

**Unit 1 — framework `flake.nix`:** factored the wiring into shared `let`
bindings (`claudeUnfreePredicate`, `claudeOverlay`, `mkPkgs`), rewired the
framework's own `mkIntegratedHmConfig` to consume them, and exported two new
outputs:

- `overlays.default` — a **single composed overlay** built with
  `nixpkgs.lib.composeManyExtensions [ claude-code-nix.overlays.default direnvSkipTestsOverlay ]`.
  It is a single `final: prev: …` function (not a list) so it passes
  `nix flake check`'s overlay validation, and is equivalent — same order — to
  applying the two-element list.
- `mkPkgs { system }` — a fully-configured `import nixpkgs { … }` set with the
  composed overlay applied and `claude-code` allowed as unfree. Because
  `allowUnfreePredicate` is config (not an overlay) it cannot live in
  `overlays.default`; instances need a configured pkgs set, so they consume
  `mkPkgs`.

**Unit 2 — `examples/office-hours-nate/flake.nix` + `README.md`:** dropped the
`claude-code-nix` input and the inline `direnvSkipTestsOverlay` /
`import nixpkgs { … }` block, replacing them with
`pkgs = commons-systems.mkPkgs { inherit system; }`. Synced the README's
"Do not strip the claude-code overlay" prose to describe the overlay as coming
from `mkPkgs` rather than being hand-wired.

Dropping `claude-code-nix` from the instance inputs is safe: the home modules
consume `pkgs.claude-code` (provided by the overlay), never
`inputs.claude-code-nix`. `mkPkgs` closes over the framework's own
`claude-code-nix` input, whose nixpkgs follows the framework's nixpkgs, which
the instance makes follow its own via
`commons-systems.inputs.nixpkgs.follows = "nixpkgs"` — so `pkgs.claude-code` is
built against the same nixpkgs the home modules evaluate against.

## On acceptance criterion #2 (direct overlay consumer)

The instance consumes the exported overlay **transitively** via `mkPkgs` — it
needs a configured pkgs set, not a bare overlay, so wiring `overlays.default` in
directly would be redundant double-wiring. `overlays.default`'s direct in-repo
consumer is the framework's own `mkIntegratedHmConfig`, which sets it as a module
option. This satisfies both criteria #1 (export) and #2 (consumed in-repo)
without awkward double-wiring.

## Verification

- `nix flake check --impure .` passes (CI-equivalent) — evaluates/builds the
  darwin + nixos host configs and the `checks` output, and validates
  `overlays.default` is a well-formed overlay. The `unknown flake output 'mkPkgs'`
  warning is expected: `mkPkgs` is not a checked output type, so `nix flake check`
  does not deeply evaluate it (it also warns on the pre-existing
  `homeManagerModules` output).
- `nix eval --impure .#mkPkgs --apply builtins.isFunction` → `true`
- `nix eval --impure .#overlays.default --apply builtins.isFunction` → `true`

`mkPkgs` correctness against the instance is an observe-in-production step: the
example points `commons-systems.url` at published `github:natb1/commons.systems`
and has no `flake.lock`, so a bare `nix flake check` there passes only once this
PR merges.
