### PR TITLE
nix: split overlays.default into separate claude-code and direnv-skip-tests outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,13 +32,15 @@
       claudeUnfreePredicate =
         pkg: builtins.elem (nixpkgs.lib.getName pkg) [ "claude-code" ];
 
-      # Single composed overlay every consumer needs: claude-code-nix (pins
+      # The framework's full opinionated stack, composing claude-code-nix (pins
       # pkgs.claude-code to the sadjow fork used by homeManagerModules.default;
       # recent nixpkgs ships its own claude-code, so without this overlay eval
-      # still succeeds but resolves to nixpkgs' build/version instead) then the
-      # direnv test-skip. Exported as overlays.default so instance flakes stop
-      # hand-copying the list. Composing into one function keeps it a valid overlay
-      # output (nix flake check rejects a list here).
+      # still succeeds but resolves to nixpkgs' build/version instead) with the
+      # direnv test-skip. Consumed internally by mkPkgs/mkIntegratedHmConfig and
+      # exported as overlays.default; a consumer wanting only the claude-code
+      # capability (without the direnv rebuild) applies overlays.claude-code
+      # instead. Composing into one function keeps it a valid overlay output
+      # (nix flake check rejects a list here).
       claudeOverlay = nixpkgs.lib.composeManyExtensions [
         claude-code-nix.overlays.default
         direnvSkipTestsOverlay
@@ -232,6 +234,18 @@
     in
     systemOutputs // {
       inherit darwinConfigurations nixosConfigurations homeManagerModules darwinModules mkPkgs;
-      overlays.default = claudeOverlay;
+      overlays = {
+        # The only overlay homeManagerModules.default requires: pins
+        # pkgs.claude-code to the sadjow fork. A consumer wanting just the
+        # claude-code capability applies this alone.
+        claude-code = claude-code-nix.overlays.default;
+        # Optional, independent build workaround (direnv doCheck = false); not
+        # required by claude-code.
+        direnv-skip-tests = direnvSkipTestsOverlay;
+        # The framework's full opinionated stack (both composed). Applying it
+        # rebuilds direnv with doCheck = false, so a consumer wanting only
+        # claude-code should apply overlays.claude-code instead.
+        default = claudeOverlay;
+      };
     };
 }


### PR DESCRIPTION
Closes #2769

## Problem

PR #2768 promoted the repo's inline `claudeOverlay` binding to a public flake
output, `overlays.default`. That single value welds together **two independent
concerns**:

1. `claude-code-nix.overlays.default` — pins `pkgs.claude-code` to the sadjow
   fork that `homeManagerModules.default` requires. A **functional requirement**
   of the exported module.
2. `direnvSkipTestsOverlay` — an unrelated build-time workaround that rebuilds
   `direnv` with `doCheck = false` (direnv 2.37.1's `checkPhase` hangs when built
   from source).

Because both were bundled under one output named `overlays.default` — with a
comment reading "Single composed overlay every consumer needs" — a consumer
wanting only the claude-code capability had no way to opt out of also silently
rebuilding direnv.

## Change

Split the two concerns into separate named overlay outputs, keeping the composed
value as `overlays.default` for the framework's own convenience:

```nix
overlays = {
  claude-code       = claude-code-nix.overlays.default;  # the module's requirement
  direnv-skip-tests = direnvSkipTestsOverlay;            # optional build workaround
  default           = claudeOverlay;                     # full opinionated stack (both)
};
```

`nix eval .#overlays --apply builtins.attrNames` now prints
`[ "claude-code" "default" "direnv-skip-tests" ]` (was `[ "default" ]`).

Also reworded the misleading "every consumer needs" doc comment to state plainly
that `claudeOverlay` is the framework's full opinionated stack, consumed
internally by `mkPkgs`/`mkIntegratedHmConfig` and exported as `overlays.default`,
and that the claude-code capability alone is available as `overlays.claude-code`.

## Backwards compatibility

Purely additive. `overlays.default` keeps its exact prior value (`claudeOverlay`);
`mkPkgs` and `mkIntegratedHmConfig` are untouched, so this repo's darwin/nixos
configs and the `office-hours-nate` example (which consumes `mkPkgs`) build
unchanged. No migration path needed — the change only splits one leaf output into
three and rewords a comment.

## Verification

- `nix flake check --impure .` — passes; `overlays` is now a schema-recognized
  output and each `overlays.<name>` validates as a well-formed overlay function
  (evaluates `darwinConfigurations`/`nixosConfigurations` too, covering the AC2
  in-repo-configs-still-build clause).
- `nix eval --impure .#overlays --apply builtins.attrNames` →
  `[ "claude-code" "default" "direnv-skip-tests" ]` (AC1 deliverable).
