### PR TITLE
graph: backfill squatted dispatch state to promoted schema

### DIFF
--- a/intentions/tactic-attention-surface-analytics-collector.md
+++ b/intentions/tactic-attention-surface-analytics-collector.md
@@ -21,22 +21,20 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-phase: null
-execution: null
+phase: qa
+execution:
+  branch: tactic-attention-surface-analytics-collector
+  pr: 2783
+  attempts:
+    fix: 1
+  markers: []
+  strategy_fingerprint: null
 validates: []
 blocked_by: []
 office_hours: null
 pace_exempt: false
 rounds: null
-attributes:
-  phase: qa
-  blocked_by: []
-  execution:
-    branch: tactic-attention-surface-analytics-collector
-    pr: 2783
-    attempts:
-      fix: 1
-    markers: []
+attributes: {}
 ---
 # analytics collector — local scheduled job (nix-managed timer) gathers GA4/Search Console/PageSpeed/GitHub signals into the snapshot, replacing the Firestore function
 

--- a/intentions/tactic-attention-surface-firestore-retire.md
+++ b/intentions/tactic-attention-surface-firestore-retire.md
@@ -20,16 +20,20 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-attributes:
-  phase: implement
-  validates:
-    - strategy-attention-surface
-  blocked_by:
-    - tactic-attention-surface-status-page
-    - tactic-attention-surface-goals-page
-    - tactic-attention-surface-velocity-pace
-    - tactic-attention-surface-instrument
-    - tactic-attention-surface-analytics-collector
+phase: implement
+execution: null
+validates:
+  - strategy-attention-surface
+blocked_by:
+  - tactic-attention-surface-status-page
+  - tactic-attention-surface-goals-page
+  - tactic-attention-surface-velocity-pace
+  - tactic-attention-surface-instrument
+  - tactic-attention-surface-analytics-collector
+office_hours: null
+pace_exempt: false
+rounds: null
+attributes: {}
 ---
 # retire the hosted Firestore owner tier — office-hours owner data goes fully local-first
 

--- a/intentions/tactic-attention-surface-goals-page.md
+++ b/intentions/tactic-attention-surface-goals-page.md
@@ -18,10 +18,15 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-attributes:
-  phase: implement
-  blocked_by:
-    - tactic-attention-surface-graph-read
+phase: implement
+execution: null
+validates: []
+blocked_by:
+  - tactic-attention-surface-graph-read
+office_hours: null
+pace_exempt: false
+rounds: null
+attributes: {}
 ---
 # goals page — direct graph exploration views: virtues, subtree shape, delegation and capture, attention, router now/queue, office-hours queue
 

--- a/intentions/tactic-attention-surface-graph-read.md
+++ b/intentions/tactic-attention-surface-graph-read.md
@@ -18,22 +18,20 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-phase: null
-execution: null
+phase: fix
+execution:
+  branch: tactic-attention-surface-graph-read
+  pr: 2780
+  attempts:
+    fix: 1
+  markers: []
+  strategy_fingerprint: null
 validates: []
 blocked_by: []
 office_hours: null
 pace_exempt: false
 rounds: null
-attributes:
-  phase: fix
-  blocked_by: []
-  execution:
-    branch: tactic-attention-surface-graph-read
-    pr: 2780
-    attempts:
-      fix: 1
-    markers: []
+attributes: {}
 ---
 # browser graph read layer — File System Access API over the local clone, client-side tree build and resolveAttention, staleness surfaced loudly
 

--- a/intentions/tactic-attention-surface-instrument.md
+++ b/intentions/tactic-attention-surface-instrument.md
@@ -19,13 +19,17 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-attributes:
-  phase: implement
-  validates:
-    - strategy-attention-surface
-  blocked_by:
-    - tactic-attention-surface-status-page
-    - tactic-attention-surface-goals-page
+phase: implement
+execution: null
+validates:
+  - strategy-attention-surface
+blocked_by:
+  - tactic-attention-surface-status-page
+  - tactic-attention-surface-goals-page
+office_hours: null
+pace_exempt: false
+rounds: null
+attributes: {}
 ---
 # instrument: source-of-truth audit sensor — every rendered signal traces to a graph node and a local source; populates the strategy's reading
 

--- a/intentions/tactic-attention-surface-signal-types.md
+++ b/intentions/tactic-attention-surface-signal-types.md
@@ -20,10 +20,15 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-attributes:
-  phase: implement
-  blocked_by:
-    - tactic-attention-surface-graph-read
+phase: implement
+execution: null
+validates: []
+blocked_by:
+  - tactic-attention-surface-graph-read
+office_hours: null
+pace_exempt: false
+rounds: null
+attributes: {}
 ---
 # typed signal model — signal-type registry with compact and context views, owning-node attribution, budget/snapshot/analytics adapters
 

--- a/intentions/tactic-attention-surface-status-page.md
+++ b/intentions/tactic-attention-surface-status-page.md
@@ -18,10 +18,15 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-attributes:
-  phase: implement
-  blocked_by:
-    - tactic-attention-surface-signal-types
+phase: implement
+execution: null
+validates: []
+blocked_by:
+  - tactic-attention-surface-signal-types
+office_hours: null
+pace_exempt: false
+rounds: null
+attributes: {}
 ---
 # status page — one attention-ranked queue of typed signals with per-signal context panel
 

--- a/intentions/tactic-attention-surface-velocity-pace.md
+++ b/intentions/tactic-attention-surface-velocity-pace.md
@@ -22,10 +22,15 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-attributes:
-  phase: implement
-  blocked_by:
-    - tactic-attention-surface-signal-types
+phase: implement
+execution: null
+validates: []
+blocked_by:
+  - tactic-attention-surface-signal-types
+office_hours: null
+pace_exempt: false
+rounds: null
+attributes: {}
 ---
 # velocity and pace signals — host-side velocity series folded into the office-hours snapshot; pace-telemetry adapter for the frontier-economy condition
 

--- a/intentions/tactic-main-qa-triage-before-provision.md
+++ b/intentions/tactic-main-qa-triage-before-provision.md
@@ -20,23 +20,21 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-phase: null
-execution: null
+phase: review
+execution:
+  branch: tactic-main-qa-triage-before-provision
+  pr: 2784
+  attempts:
+    qa: 1
+  markers:
+    - qa-done
+  strategy_fingerprint: 157bc07dd1dbc4a1c7a5095f7c3094ee88accf5879271bc6d2c4cd4794029848
 validates: []
 blocked_by: []
 office_hours: null
 pace_exempt: false
 rounds: null
-attributes:
-  phase: review
-  execution:
-    strategy_fingerprint: 157bc07dd1dbc4a1c7a5095f7c3094ee88accf5879271bc6d2c4cd4794029848
-    branch: tactic-main-qa-triage-before-provision
-    pr: 2784
-    attempts:
-      qa: 1
-    markers:
-      - qa-done
+attributes: {}
 ---
 # main-qa triage before provision — run the browser-verifiability triage in the selection chain so unverifiable follow-ups never cost a worktree and session boot
 

--- a/intentions/tactic-noncodegen-session-model-defaults.md
+++ b/intentions/tactic-noncodegen-session-model-defaults.md
@@ -18,23 +18,21 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-phase: null
-execution: null
+phase: review
+execution:
+  branch: tactic-noncodegen-session-model-defaults
+  pr: 2776
+  attempts:
+    qa: 1
+  markers:
+    - qa-done
+  strategy_fingerprint: 157bc07dd1dbc4a1c7a5095f7c3094ee88accf5879271bc6d2c4cd4794029848
 validates: []
 blocked_by: []
 office_hours: null
 pace_exempt: false
 rounds: null
-attributes:
-  phase: review
-  execution:
-    strategy_fingerprint: 157bc07dd1dbc4a1c7a5095f7c3094ee88accf5879271bc6d2c4cd4794029848
-    branch: tactic-noncodegen-session-model-defaults
-    pr: 2776
-    attempts:
-      qa: 1
-    markers:
-      - qa-done
+attributes: {}
 ---
 # Sonnet-by-default initialization for non-codegen sessions — fix the /qa-main routing gap and pass --model on the aux background-job spawns
 

--- a/intentions/tactic-outcome-envelope-qa-accounting.md
+++ b/intentions/tactic-outcome-envelope-qa-accounting.md
@@ -19,23 +19,21 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-phase: null
-execution: null
+phase: review
+execution:
+  branch: tactic-outcome-envelope-qa-accounting
+  pr: 2774
+  attempts:
+    qa: 1
+  markers:
+    - qa-done
+  strategy_fingerprint: 157bc07dd1dbc4a1c7a5095f7c3094ee88accf5879271bc6d2c4cd4794029848
 validates: []
 blocked_by: []
 office_hours: null
 pace_exempt: false
 rounds: null
-attributes:
-  phase: review
-  execution:
-    strategy_fingerprint: 157bc07dd1dbc4a1c7a5095f7c3094ee88accf5879271bc6d2c4cd4794029848
-    branch: tactic-outcome-envelope-qa-accounting
-    pr: 2774
-    attempts:
-      qa: 1
-    markers:
-      - qa-done
+attributes: {}
 ---
 # per-phase routing metric — qa routes on actionability, not hit_rate, so a triage-shaped phase is not promoted to Opus by a rate it cannot move
 

--- a/intentions/tactic-token-audit-node-attribution.md
+++ b/intentions/tactic-token-audit-node-attribution.md
@@ -20,23 +20,21 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-phase: null
-execution: null
+phase: review
+execution:
+  branch: tactic-token-audit-node-attribution
+  pr: 2777
+  attempts:
+    qa: 1
+  markers:
+    - qa-done
+  strategy_fingerprint: 157bc07dd1dbc4a1c7a5095f7c3094ee88accf5879271bc6d2c4cd4794029848
 validates: []
 blocked_by: []
 office_hours: null
 pace_exempt: false
 rounds: null
-attributes:
-  phase: review
-  execution:
-    strategy_fingerprint: 157bc07dd1dbc4a1c7a5095f7c3094ee88accf5879271bc6d2c4cd4794029848
-    branch: tactic-token-audit-node-attribution
-    pr: 2777
-    attempts:
-      qa: 1
-    markers:
-      - qa-done
+attributes: {}
 ---
 # node-id session attribution — graph-native sessions stamp node id into the dispatch sidecar; the token audit gains a by-node join and a UTC-consistent window
 

--- a/intentions/tactic-token-economy-sensor.md
+++ b/intentions/tactic-token-economy-sensor.md
@@ -21,24 +21,21 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-phase: null
-execution: null
-validates: []
+phase: qa
+execution:
+  branch: tactic-token-economy-sensor
+  pr: 2779
+  attempts:
+    fix: 1
+  markers: []
+  strategy_fingerprint: 157bc07dd1dbc4a1c7a5095f7c3094ee88accf5879271bc6d2c4cd4794029848
+validates:
+  - strategy-token-economy
 blocked_by: []
 office_hours: null
 pace_exempt: false
 rounds: null
-attributes:
-  phase: qa
-  validates:
-    - strategy-token-economy
-  execution:
-    strategy_fingerprint: 157bc07dd1dbc4a1c7a5095f7c3094ee88accf5879271bc6d2c4cd4794029848
-    branch: tactic-token-economy-sensor
-    pr: 2779
-    attempts:
-      fix: 1
-    markers: []
+attributes: {}
 ---
 # token-economy sensor — registry sensor computing weekly allowance utilization and claude-eligible tactic velocity, populating strategy-token-economy's reading
 

--- a/intentions/tactic-token-hygiene-sweep.md
+++ b/intentions/tactic-token-hygiene-sweep.md
@@ -20,23 +20,21 @@ clarifications: []
 tooling_goals: []
 success_signal: null
 attention: null
-phase: null
-execution: null
+phase: review
+execution:
+  branch: tactic-token-hygiene-sweep
+  pr: 2782
+  attempts:
+    qa: 1
+  markers:
+    - qa-done
+  strategy_fingerprint: 157bc07dd1dbc4a1c7a5095f7c3094ee88accf5879271bc6d2c4cd4794029848
 validates: []
 blocked_by: []
 office_hours: null
 pace_exempt: false
 rounds: null
-attributes:
-  phase: review
-  execution:
-    strategy_fingerprint: 157bc07dd1dbc4a1c7a5095f7c3094ee88accf5879271bc6d2c4cd4794029848
-    branch: tactic-token-hygiene-sweep
-    pr: 2782
-    attempts:
-      qa: 1
-    markers:
-      - qa-done
+attributes: {}
 ---
 # read-before-edit preamble line in the fix-lane subagent prompts — the one hygiene item with a repo-controlled landing spot
 


### PR DESCRIPTION
## Summary

Implements tactic-schema-migration-backfill (serves strategy-graph-native-dispatch).

`tactic-graph-dispatch-schema` promoted `phase` / `execution` / `validates` /
`blocked_by` / `office_hours` / `rounds` to first-class top-level frontmatter,
but 14 nodes authored before it landed still squat those fields under
`attributes.*`. The router and `/align-tactics` idempotency read top-level
`phase`, so a squatted node misreads as an untriaged draft and already-planned
work is invisible to selection.

## Unit 1 — lift, normalize, land

For each of the 14 nodes named in the 2026-07-06 census (eight
attention-surface tactics, four token-economy tactics,
main-qa-triage-before-provision, noncodegen-session-model-defaults):
`readNode` -> move present `attributes.{phase,execution,validates,blocked_by,
office_hours,rounds}` to top level -> delete from `attributes` -> `writeNode`
(the single validation gate).

- All 14 squatted `phase` values were valid `PHASES` members; none aborted.
- All squatted `execution` objects carried `branch`; missing
  `attempts`/`markers`/`strategy_fingerprint` filled with schema defaults
  (`{}`/`[]`/`null`).
- No node had squatted `office_hours` or `rounds`.
- Bodies are byte-identical before/after (writeNode's tactic-body
  preservation kicked in since every file already existed on disk).

Out of scope: the `main-qa` enum addition (tactic-main-qa-phase); any semantic
re-planning of the migrated nodes.

## Verification

- `npx tsx packages/intentionsutil/scripts/validate-graph.ts` -> `ok — 219 nodes`
- Frontmatter-only grep for squatted `phase|execution|validates|blocked_by|office_hours|rounds` under any node's `attributes:` block -> zero hits across `intentions/tactic-*.md`
- Manually diffed all 14 nodes: only the frontmatter block changed in each; markdown bodies are unchanged

## Note on landing mechanism

The node body's Reuse section names `graph-commit` (direct-to-main scratch-branch
landing) as the mechanism. This PR instead lands via the standard feature-branch
+ draft-PR workflow-phase-worker contract, since `graph-commit` bypasses the
qa/review pipeline this phase worker's chain depends on. Atomicity (the plan's
actual concern) is preserved: all 14 nodes land in this one commit.

Graph-native context: tactic-schema-migration-backfill, serves
strategy-graph-native-dispatch.