### PR TITLE
Fix wezterm-mux-server crash-looping on --daemonize=false

### DIFF
--- a/nix/home/wezterm.nix
+++ b/nix/home/wezterm.nix
@@ -140,7 +140,10 @@
       After = [ "default.target" ];
     };
     Service = {
-      ExecStart = "${config.programs.wezterm.package}/bin/wezterm-mux-server --daemonize=false";
+      # --daemonize is a bare boolean flag (no `=value` form accepted); its
+      # absence already means "run in the foreground", which is what a
+      # systemd-supervised process needs.
+      ExecStart = "${config.programs.wezterm.package}/bin/wezterm-mux-server";
       Restart = "on-failure";
     };
     Install.WantedBy = [ "default.target" ];


### PR DESCRIPTION
## Summary
- `wezterm-mux-server`'s `ExecStart` passed `--daemonize=false`, but current wezterm nightly made `--daemonize` a bare boolean flag that rejects `=value`, so the systemd unit crash-looped on every start (`error: unexpected value 'false' for '--daemonize'`)
- With no mux server ever listening, the Windows GUI's `default_gui_startup_args = { 'connect', 'nixos' }` has nothing to attach to, so the window opens and immediately closes
- Fix: drop the flag entirely — its absence already means foreground, which is what the systemd `Restart=on-failure` supervision wants

## Test plan
- [x] Reproduced the crash loop via `journalctl --user -u wezterm-mux-server.service` (`status=2/INVALIDARGUMENT`, "Start request repeated too quickly")
- [x] Verified `wezterm-mux-server` (no flag) runs correctly in the foreground and stays up
- [x] Applied a live systemd drop-in override with the corrected `ExecStart` and confirmed the service is `active (running)` and listening on `/run/user/1000/wezterm/sock`
- [ ] Confirm Windows `wezterm-gui.exe` connects and stays open after the next `home-manager switch` regenerates the unit from this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)