### PR TITLE
worktree: fix SIGPIPE (exit 141) in main-worktree resolution under pipefail

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -101,7 +101,7 @@ else
   # clarification 23: `main` is checked out at the project root). Resolved from
   # the worktree registry, never from the git common dir.
   PROJECT_ROOT=$(git worktree list --porcelain \
-    | awk '/^worktree /{wt=substr($0,10)} /^branch refs\/heads\/main$/{print wt; exit}')
+    | awk '/^worktree /{wt=substr($0,10)} /^branch refs\/heads\/main$/{if(!f){print wt; f=1}}')
   [ -n "$PROJECT_ROOT" ] \
     || { echo "[worktree-create] ERROR: no worktree with 'main' checked out; cannot resolve the project root for node-id worktree '$BRANCH'" >&2; exit 1; }
   NEW_PATH="$PROJECT_ROOT/.claude/worktrees/$BRANCH"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
@@ -58,7 +58,7 @@ if [[ -n "${DISPATCH_GRAPH_MAIN_WORKTREE:-}" ]]; then
   PROJECT_ROOT="$DISPATCH_GRAPH_MAIN_WORKTREE"
 else
   PROJECT_ROOT=$(git worktree list --porcelain 2>/dev/null \
-    | awk '/^worktree /{wt=substr($0,10)} /^branch refs\/heads\/main$/{print wt; exit}')
+    | awk '/^worktree /{wt=substr($0,10)} /^branch refs\/heads\/main$/{if(!f){print wt; f=1}}')
 fi
 if [[ -z "$PROJECT_ROOT" || ! -d "$PROJECT_ROOT" ]]; then
   echo "dispatch-graph-execute: cannot resolve the project root (no worktree with 'main' checked out)" >&2

--- a/.claude/skills/dispatch-propagate/scripts/graph-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/graph-select-target
@@ -177,7 +177,7 @@ done
 # name-keyed on the basename, so the root resolution is presentational — the
 # basename (the node id) is what is matched against live session names.
 NATIVE_ROOT=$(git -C "$REPO_ROOT" worktree list --porcelain \
-  | awk '/^worktree /{wt=substr($0,10)} /^branch refs\/heads\/main$/{print wt; exit}')
+  | awk '/^worktree /{wt=substr($0,10)} /^branch refs\/heads\/main$/{if(!f){print wt; f=1}}')
 NATIVE_ROOT="${NATIVE_ROOT:-$REPO_ROOT}"
 
 skip_note() { # <id> <reason>

--- a/.claude/skills/dispatch-propagate/scripts/provision-node-worktree
+++ b/.claude/skills/dispatch-propagate/scripts/provision-node-worktree
@@ -54,7 +54,7 @@ if [[ -n "${DISPATCH_GRAPH_MAIN_WORKTREE:-}" ]]; then
   PROJECT_ROOT="$DISPATCH_GRAPH_MAIN_WORKTREE"
 else
   PROJECT_ROOT=$(git worktree list --porcelain 2>/dev/null \
-    | awk '/^worktree /{wt=substr($0,10)} /^branch refs\/heads\/main$/{print wt; exit}')
+    | awk '/^worktree /{wt=substr($0,10)} /^branch refs\/heads\/main$/{if(!f){print wt; f=1}}')
 fi
 if [[ -z "$PROJECT_ROOT" || ! -d "$PROJECT_ROOT" ]]; then
   echo "provision-node-worktree: cannot resolve the project root (no worktree with 'main' checked out)" >&2


### PR DESCRIPTION
## Problem

Worktree creation fails with:

```
WorktreeCreate hook failed: worktree-create.sh: [worktree-create] ERROR: unexpected error on line 104 (exit 141)
```

Exit 141 = 128 + 13 = SIGPIPE.

The graph-lane project-root lookup pipes `git worktree list --porcelain` into an awk that `exit`s on the first `main` branch match:

```sh
git worktree list --porcelain \
  | awk '/^worktree /{wt=substr($0,10)} /^branch refs\/heads\/main$/{print wt; exit}'
```

Under `set -o pipefail`, awk's early `exit` closes the pipe while `git` is still streaming its output, so `git` dies on SIGPIPE and the pipeline's status becomes 141 — failing the whole step and rolling back the worktree. It only manifests once the worktree list is long enough that `git` has not finished writing when awk exits; with 57 worktrees and `main` near the top of the list, it fires **deterministically** (reproduced 20/20), breaking every graph-lane `WorktreeCreate`.

## Fix

Drop the early `exit` and keep only the first `main` match via a flag, so awk drains all of git's output:

```sh
awk '/^worktree /{wt=substr($0,10)} /^branch refs\/heads\/main$/{if(!f){print wt; f=1}}'
```

Same result (first `main` worktree), no SIGPIPE. Verified 20/20 exit 0, and the fixed hook run end-to-end on an existing node returns the correct project root 3/3.

The identical pipeline existed at four sites, all under `set -o pipefail`; all four are fixed:

- `.claude/hooks/worktree-create.sh`
- `.claude/skills/dispatch-propagate/scripts/graph-select-target`
- `.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute`
- `.claude/skills/dispatch-propagate/scripts/provision-node-worktree`

## Verification

```verify
bash -n .claude/hooks/worktree-create.sh
bash -n .claude/skills/dispatch-propagate/scripts/graph-select-target
bash -n .claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
bash -n .claude/skills/dispatch-propagate/scripts/provision-node-worktree
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)