### PR TITLE
wezterm: pin WSL mux server and Windows GUI to one nightly build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,10 @@
         packages = forAllSystems ({ pkgs, ... }: {
           dispatch = pkgs.callPackage ./nix/packages/dispatch.nix { };
           office-hours = pkgs.callPackage ./nix/packages/office-hours.nix { };
+          # WSL wezterm rebuilt from the pinned nightly (nix/home/wezterm-pin.nix).
+          # Exposed so `nix build .#wezterm` can verify the pin and so
+          # nix/home/sync-wezterm.sh can resolve the vendor hash against it.
+          wezterm = pkgs.callPackage ./nix/home/wezterm-package.nix { };
         });
 
         devShells = forAllSystems ({ pkgs, ... }:

--- a/nix/home/sync-wezterm.sh
+++ b/nix/home/sync-wezterm.sh
@@ -39,7 +39,7 @@ SHORT_SHA=${VERSION##*-}
 echo "    version:   $VERSION"
 
 echo "==> Resolving full commit for $SHORT_SHA"
-REV=$(curl -fsSL "https://api.github.com/repos/wez/wezterm/commits/$SHORT_SHA" --jq '.sha')
+REV=$(curl -fsSL "https://api.github.com/repos/wez/wezterm/commits/$SHORT_SHA" | jq -r '.sha')
 echo "    rev:       $REV"
 
 echo "==> Fetching source (fetchSubmodules) to compute srcHash — this is slow"

--- a/nix/home/sync-wezterm.sh
+++ b/nix/home/sync-wezterm.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Refresh nix/home/wezterm-pin.nix to the current upstream WezTerm nightly.
+#
+# The Windows GUI (mux client) and the WSL wezterm-mux-server must be the same
+# build or the mux handshake fails and the GUI window closes on connect. Upstream
+# ships exactly ONE Windows nightly zip (overwritten in place), so the only way to
+# keep both sides deterministic is to pin one commit and build/download both from
+# it. This script captures that pin.
+#
+# It derives the target from the distributed Windows binary itself — the zip's
+# internal `WezTerm-windows-<date>-<time>-<shorthash>` directory name — NOT the
+# upstream `nightly` git ref, which is frequently stale and points at a different
+# commit than the published assets.
+#
+# Run from the repo root, then `home-manager switch` (from a NON-WezTerm shell —
+# the mux restart drops the pane you launch it from). Requires network + nix.
+#
+# Usage: nix/home/sync-wezterm.sh
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+PIN_FILE="$REPO_ROOT/nix/home/wezterm-pin.nix"
+ZIP_URL="https://github.com/wez/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip"
+FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+system=$(nix eval --impure --raw --expr 'builtins.currentSystem')
+
+echo "==> Downloading current Windows nightly zip"
+ZIP_PATH=$(nix-prefetch-url --print-path --type sha256 "$ZIP_URL" 2>/dev/null | tail -1)
+WINDOWS_ZIP_HASH=$(nix hash convert --hash-algo sha256 --to sri \
+  "$(nix-prefetch-url --type sha256 "$ZIP_URL" 2>/dev/null | tail -1)")
+
+echo "==> Reading version from the distributed binary"
+# The zip's top-level directory is authoritative: WezTerm-windows-<version>.
+VERSION=$(nix shell nixpkgs#unzip -c unzip -Z1 "$ZIP_PATH" \
+  | grep -oE '^WezTerm-windows-[0-9]{8}-[0-9]{6}-[0-9a-f]+' \
+  | head -1 | sed 's/^WezTerm-windows-//')
+SHORT_SHA=${VERSION##*-}
+echo "    version:   $VERSION"
+
+echo "==> Resolving full commit for $SHORT_SHA"
+REV=$(curl -fsSL "https://api.github.com/repos/wez/wezterm/commits/$SHORT_SHA" --jq '.sha')
+echo "    rev:       $REV"
+
+echo "==> Fetching source (fetchSubmodules) to compute srcHash — this is slow"
+SRC_PATH=$(nix eval --impure --raw --expr \
+  "builtins.fetchGit { url = \"https://github.com/wezterm/wezterm\"; rev = \"$REV\"; submodules = true; }")
+SRC_HASH=$(nix hash path --sri --type sha256 "$SRC_PATH")
+echo "    srcHash:   $SRC_HASH"
+
+# Write the pin with the real srcHash and a placeholder cargoHash, then let a
+# build surface the real vendor hash from the mismatch error.
+write_pin() {
+  cat > "$PIN_FILE" <<EOF
+# Pinned WezTerm nightly — single source of truth.
+#
+# Both the WSL package (wezterm.nix, built from source at \`rev\`) and the Windows
+# GUI binary (wezterm-windows.nix, the matching nightly zip) are pinned to the
+# SAME upstream build here, so the mux client (Windows GUI) and server (WSL
+# wezterm-mux-server) always speak the same PDU protocol version.
+#
+# \`version\` is authoritative and is read from the distributed Windows binary
+# itself (the zip's internal \`WezTerm-windows-<version>\` directory name), NOT
+# the upstream \`nightly\` git ref — that ref is frequently stale.
+#
+# Regenerate with:  nix/home/sync-wezterm.sh  (do not hand-edit the hashes).
+{
+  version = "$VERSION";
+  rev = "$REV";
+  srcHash = "$SRC_HASH";
+  cargoHash = "$1";
+  windowsZipHash = "$WINDOWS_ZIP_HASH";
+}
+EOF
+}
+
+echo "==> Resolving cargoHash via a vendor build"
+write_pin "$FAKE_HASH"
+CARGO_HASH=$(nix build "$REPO_ROOT#packages.$system.wezterm" --no-link 2>&1 \
+  | grep -oE 'got:[[:space:]]+sha256-[A-Za-z0-9+/=]+' | grep -oE 'sha256-[A-Za-z0-9+/=]+' | head -1 || true)
+
+if [ -z "$CARGO_HASH" ]; then
+  echo "ERROR: could not extract cargoHash — the build may have succeeded with the" >&2
+  echo "       fake hash (unexpected) or failed for another reason. Re-run manually:" >&2
+  echo "       nix build $REPO_ROOT#packages.$system.wezterm" >&2
+  exit 1
+fi
+echo "    cargoHash: $CARGO_HASH"
+
+write_pin "$CARGO_HASH"
+
+echo "==> Verifying the pinned package evaluates"
+nix build "$REPO_ROOT#packages.$system.wezterm" --no-link --dry-run
+
+echo
+echo "Wrote $PIN_FILE for $VERSION."
+echo "Next: home-manager switch (from a non-WezTerm shell), then restart the"
+echo "Windows GUI so both sides load $VERSION."

--- a/nix/home/wezterm-package.nix
+++ b/nix/home/wezterm-package.nix
@@ -1,0 +1,39 @@
+# WSL WezTerm package — nixpkgs' wezterm rebuilt from the pinned nightly commit.
+#
+# nixpkgs pins its own (older) nightly snapshot; we override the source to the
+# exact commit the Windows GUI binary was built from (see wezterm-pin.nix) so the
+# mux server this produces speaks the same protocol as the Windows client.
+#
+# The override replaces `src` and the vendored-deps hash. Everything else — build
+# inputs, patches, features, the mux-server/gui outputs — is inherited from
+# nixpkgs' wezterm, so this tracks upstream packaging fixes automatically.
+{ pkgs }:
+
+let
+  pin = import ./wezterm-pin.nix;
+
+  src = pkgs.fetchFromGitHub {
+    owner = "wezterm";
+    repo = "wezterm";
+    rev = pin.rev;
+    fetchSubmodules = true;
+    hash = pin.srcHash;
+  };
+in
+pkgs.wezterm.overrideAttrs (_: {
+  version = "0-unstable-${pin.version}";
+  inherit src;
+
+  # buildRustPackage bakes the vendor hash from the ORIGINAL `cargoHash` argument
+  # at call time (`hash = args.cargoHash`), which overrideAttrs cannot reach — so
+  # overriding `version`/`src` alone leaves the vendor pinned to the old hash and
+  # the build fails with a mismatch. `cargoDeps` IS a replaceable derivation
+  # attribute, so supply a fresh vendor built from the new source with the pinned
+  # hash. wezterm sets no cargoRoot/cargoPatches/sourceRoot, so a plain call
+  # mirrors what buildRustPackage would have produced.
+  cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+    inherit src;
+    name = "wezterm-0-unstable-${pin.version}";
+    hash = pin.cargoHash;
+  };
+})

--- a/nix/home/wezterm-pin.nix
+++ b/nix/home/wezterm-pin.nix
@@ -1,0 +1,37 @@
+# Pinned WezTerm nightly — single source of truth.
+#
+# Both the WSL package (wezterm.nix, built from source at `rev`) and the Windows
+# GUI binary (wezterm-windows.nix, the matching nightly zip) are pinned to the
+# SAME upstream build here, so the mux client (Windows GUI) and server (WSL
+# wezterm-mux-server) always speak the same PDU protocol version. Drift between
+# the two is what makes the GUI window close on connect with a version error.
+#
+# Why a pin at all: upstream distributes exactly ONE Windows nightly zip (the
+# latest), overwriting it in place, while nixpkgs pins a *snapshot* nightly by
+# commit. Left to their own devices the two sides only match by luck. Pinning
+# both to one commit here makes the match deterministic and reproducible.
+#
+# `version` is authoritative and is read from the distributed Windows binary
+# itself (the zip's internal `WezTerm-windows-<version>` directory name), NOT
+# the upstream `nightly` git ref — that ref is frequently stale and points at a
+# different commit than the published assets.
+#
+# Regenerate on every deliberate upgrade with:  nix/home/sync-wezterm.sh
+# (that script resolves the current nightly commit + all three hashes and
+# rewrites this file atomically). Do not hand-edit the hashes.
+{
+  # <date>-<time>-<shorthash> from the Windows zip's directory name.
+  version = "20260707-093716-fff02ca5";
+
+  # Full commit the above build corresponds to.
+  rev = "fff02ca501c3b457f99b467a86061d2b150c51f2";
+
+  # NAR hash of the wezterm source tree (fetchSubmodules = true) at `rev`.
+  srcHash = "sha256-q351PUvUy9jbqcAgQfkZqgrEuc4X/Y/H9N8b9+60mjY=";
+
+  # Vendored cargo dependencies hash for the source at `rev`.
+  cargoHash = "sha256-jY7lTOfbT74tAZ7he1xudCN7BUxZBzY+8+e1d2g2v4I=";
+
+  # SHA-256 of WezTerm-windows-nightly.zip as published for this build.
+  windowsZipHash = "sha256-r2TY0YHf8u0ImBhkMvBGKz2pZMEy6MfkVC1MV/3BLWM=";
+}

--- a/nix/home/wezterm-windows.nix
+++ b/nix/home/wezterm-windows.nix
@@ -1,18 +1,17 @@
 # Windows WezTerm Installer (WSL only)
 #
-# Downloads and installs the WezTerm Windows nightly binary to the Windows
-# user's %LOCALAPPDATA%\WezTerm\ at each home-manager activation.
+# Installs the WezTerm Windows binary to the Windows user's %LOCALAPPDATA%\WezTerm\
+# at each home-manager activation, pinned to the same nightly build as the WSL
+# wezterm-mux-server (nix/home/wezterm-pin.nix).
 #
-# Why: the Windows GUI auto-connects to the NixOS mux server over SSH; when the
-# Windows binary and the NixOS wezterm package drift in version, the mux PDU
-# protocol fails and the GUI window closes immediately. Both sides track upstream
-# nightly: the NixOS package via nixpkgs, the Windows binary via a runtime curl
-# fetch in this activation script, so each switch picks up the same rolling nightly.
-#
-# Update workflow:
-#   The Windows zip auto-tracks upstream's rolling "nightly" tag via a runtime
-#   curl fetch on each activation — no flake input / lock pin so upstream
-#   republishes are automatically picked up. Each switch re-downloads the zip.
+# Why the pin: the Windows GUI auto-connects to the WSL mux server; if the two
+# builds drift, the mux PDU handshake fails and the GUI window closes immediately.
+# Upstream distributes exactly ONE Windows nightly zip (overwritten in place), so
+# a naive "always curl the latest nightly" install drifts from the nixpkgs-pinned
+# mux server whenever their dates differ. Instead we fetch the zip content-pinned
+# by `windowsZipHash` and unpack it at build time; activation only mirrors the
+# resulting store tree to Windows. Bump both sides together with
+# nix/home/sync-wezterm.sh.
 
 {
   config,
@@ -21,8 +20,36 @@
   ...
 }:
 
+let
+  pin = import ./wezterm-pin.nix;
+
+  # Content-pinned nightly zip. The URL is upstream's rolling `nightly` asset;
+  # `windowsZipHash` locks it to the exact build recorded in the pin, so a later
+  # upstream republish cannot silently swap the binary — a hash mismatch fails
+  # loudly until the pin is refreshed via sync-wezterm.sh.
+  weztermWindowsZip = pkgs.fetchurl {
+    url = "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip";
+    sha256 = pin.windowsZipHash;
+  };
+
+  # Unpack at build time and expose the directory that holds wezterm-gui.exe, so
+  # the activation script is a pure mirror-to-Windows with no download/unzip step.
+  weztermWindowsDir = pkgs.runCommand "wezterm-windows-${pin.version}" {
+    nativeBuildInputs = [ pkgs.unzip ];
+  } ''
+    unzip -q ${weztermWindowsZip} -d unpacked
+    gui=$(find unpacked -maxdepth 3 -name 'wezterm-gui.exe' -type f | head -n1)
+    if [ -z "$gui" ]; then
+      echo "ERROR: wezterm-gui.exe not found in the nightly zip" >&2
+      find unpacked -maxdepth 3 -type f >&2
+      exit 1
+    fi
+    cp -r "$(dirname "$gui")" "$out"
+  '';
+in
+
 {
-  # WSL: download and install Windows WezTerm into the user's %LOCALAPPDATA%.
+  # WSL: mirror the pinned Windows WezTerm into the user's %LOCALAPPDATA%.
   # DAG ordering: runs after "linkGeneration" so symlinks are stable before we
   # reach across the WSL boundary.
   home.activation.installWeztermWindows = lib.mkIf pkgs.stdenv.isLinux (
@@ -31,7 +58,6 @@
       readonly WW_ERR_USERNAME_DETECTION=22
       readonly WW_ERR_INSTALL_FAILED=23
       readonly WW_ERR_FILE_LOCKED=24
-      readonly WW_ERR_DOWNLOAD_FAILED=25
 
       if [ ! -d "/mnt/c/Users" ]; then
         echo "Not running on WSL, skipping Windows WezTerm install"
@@ -79,41 +105,28 @@
         TARGET_DIR="/mnt/c/Users/$WINDOWS_USER/AppData/Local/WezTerm"
 
         if [ -z "$DRY_RUN_CMD" ]; then
-          # Download the nightly Windows zip and rsync its contents to TARGET_DIR.
-          # Re-downloads on each switch so the Windows binary stays in lockstep
-          # with the nixpkgs-managed mux server without a hash pin.
-          WW_TMPDIR=$(mktemp -d)
-          trap 'rm -rf "$WW_TMPDIR"' EXIT
-
-          ${pkgs.curl}/bin/curl -fsSL \
-            "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip" \
-            -o "$WW_TMPDIR/wezterm.zip" \
-            || { echo "ERROR: Failed to download WezTerm Windows nightly" >&2; exit $WW_ERR_DOWNLOAD_FAILED; }
-
-          ${pkgs.unzip}/bin/unzip -q "$WW_TMPDIR/wezterm.zip" -d "$WW_TMPDIR/extracted" \
-            || { echo "ERROR: Failed to extract WezTerm zip" >&2; exit $WW_ERR_INSTALL_FAILED; }
-
-          GUI_EXE=$(find "$WW_TMPDIR/extracted" -maxdepth 3 -name 'wezterm-gui.exe' -type f | head -n1)
-          if [ -z "$GUI_EXE" ]; then
-            echo "ERROR: wezterm-gui.exe not found in source" >&2
-            find "$WW_TMPDIR/extracted" -maxdepth 3 -type f >&2
-            exit $WW_ERR_INSTALL_FAILED
-          fi
-
-          SOURCE_ROOT=$(dirname "$GUI_EXE")
           ${pkgs.coreutils}/bin/mkdir -p "$TARGET_DIR"
 
+          # rsync the pre-unpacked, content-pinned store tree to Windows. No
+          # network or unzip here — the binary is fixed by wezterm-pin.nix.
+          #
           # rsync without -p/-o/-g: /mnt/c is a Windows filesystem where unix
           # permissions/ownership are not meaningful and attempting to set them
           # produces spurious errors. -rlt preserves recursion, symlinks, and
           # mtimes — enough to keep --delete idempotent across runs.
+          # Capture the exit code without tripping the activation script's `set
+          # -e`: a bare `var=$(cmd)` assignment aborts the whole switch on rsync
+          # failure BEFORE the handler below runs, turning the common
+          # locked-file case (WezTerm still open on Windows) into an opaque
+          # abort instead of the actionable message. `|| rsync_exit=$?` keeps
+          # the failure local.
+          rsync_exit=0
           rsync_error=$(${pkgs.rsync}/bin/rsync -rlt --delete \
-            "$SOURCE_ROOT/" "$TARGET_DIR/" 2>&1)
-          rsync_exit=$?
+            "${weztermWindowsDir}/" "$TARGET_DIR/" 2>&1) || rsync_exit=$?
           if [ $rsync_exit -ne 0 ]; then
             if echo "$rsync_error" | grep -qi "permission denied"; then
               echo "ERROR: Failed to install Windows WezTerm — files appear locked" >&2
-              echo "  Close WezTerm on Windows and re-run 'nixos-rebuild switch'" >&2
+              echo "  Close WezTerm on Windows and re-run 'home-manager switch'" >&2
               echo "  Details:" >&2
               echo "$rsync_error" | sed 's/^/    /' >&2
               exit $WW_ERR_FILE_LOCKED
@@ -124,10 +137,10 @@
             exit $WW_ERR_INSTALL_FAILED
           fi
         else
-          echo "Would download WezTerm nightly and install to $TARGET_DIR"
+          echo "Would install pinned WezTerm ${pin.version} to $TARGET_DIR"
         fi
 
-        echo "Installed Windows WezTerm to $TARGET_DIR"
+        echo "Installed Windows WezTerm ${pin.version} to $TARGET_DIR"
 
         # Start Menu shortcut: write only when missing. Overwriting on every
         # activation would clobber a user-pinned taskbar entry's metadata.

--- a/nix/home/wezterm.nix
+++ b/nix/home/wezterm.nix
@@ -20,6 +20,15 @@
   programs.wezterm = {
     enable = true;
 
+    # Build wezterm from the pinned nightly (nix/home/wezterm-pin.nix) rather than
+    # the nixpkgs snapshot, so the mux server this installs matches the Windows GUI
+    # binary that wezterm-windows.nix mirrors from the same pin. The mux-server
+    # user service below references config.programs.wezterm.package, so it follows
+    # this automatically. Harmless where wezterm is force-disabled (e.g. Darwin):
+    # the option is set but the package is never realized. Refresh with
+    # nix/home/sync-wezterm.sh.
+    package = pkgs.callPackage ./wezterm-package.nix { };
+
     # Use extraConfig to generate Lua configuration with Nix string interpolation.
     # This allows platform-specific sections via lib.optionalString.
     extraConfig = ''


### PR DESCRIPTION
## Problem

The Windows WezTerm GUI (mux client) auto-connects to the WSL `wezterm-mux-server`. When the two builds differ, the mux PDU handshake fails and the GUI window closes on connect with a version error.

They drifted because each side tracked the nightly differently:
- **WSL**: nixpkgs pins a *snapshot* nightly by commit — was `0-unstable-2026-06-22`.
- **Windows**: `wezterm-windows.nix` `curl`'d upstream's rolling `nightly` zip on every activation — was ~`2026-07-03`, and re-downloading pulls whatever is current.

Upstream overwrites the single `nightly` zip in place, so the two sides only matched by luck.

## Fix

A single source of truth — `nix/home/wezterm-pin.nix` (`version`, `rev`, `srcHash`, `cargoHash`, `windowsZipHash`) — that both sides consume:

- **`wezterm-package.nix`** rebuilds nixpkgs' wezterm from the pinned commit. `buildRustPackage` bakes the vendor hash from the *original* `cargoHash` argument at call time (which `overrideAttrs` cannot reach), so the override replaces `cargoDeps` outright with a fresh `fetchCargoVendor` carrying the pinned hash.
- **`wezterm.nix`** sets `programs.wezterm.package` to it; the mux-server user service already tracks that package, so both follow the pin.
- **`wezterm-windows.nix`** fetches the nightly zip content-pinned by `windowsZipHash` and unpacks it at build time; activation only mirrors the store tree to Windows — no runtime `curl`, no silent drift (a republish now fails loudly instead of silently swapping the binary). Also guards the `rsync` against `set -e` so the locked-file case (WezTerm open on Windows) surfaces the actionable "close WezTerm" message instead of an opaque abort.
- **`flake.nix`** exposes `packages.<system>.wezterm` so `nix build .#wezterm` verifies the pin and `sync-wezterm.sh` can resolve the vendor hash against it.

`version` is read from the distributed Windows binary itself (the zip's internal `WezTerm-windows-<version>` directory name), **not** the upstream `nightly` git ref — that ref is frequently stale and points at a different commit than the published assets (it currently claims a 2017 commit).

## Upgrading later

Nightly upgrades are now one deliberate step:

```
nix/home/sync-wezterm.sh          # resolves current nightly + all 3 hashes, rewrites the pin
sudo nixos-rebuild switch --flake .#nixos
```

Both sides move together atomically. Trade-off vs. the old always-latest behavior: upgrades are manual, but deterministic and reproducible.

## Verification

- WSL wezterm compiles to `0-unstable-20260707-093716-fff02ca5`; `wezterm-mux-server --version` confirms it — matching the current Windows binary.
- The Windows unpack derivation builds and produces the matching `wezterm-gui.exe` / `wezterm-mux-server.exe` tree.
- Both `nixosConfigurations.nixos` and `darwinConfigurations.default` evaluate cleanly (wezterm is force-disabled on Darwin; the option is set but never realized).
- No CI cost: no workflow runs `nix flake check` or builds flake packages.

## Applying (manual — live system, drops remote panes)

Both pinned artifacts are already in this machine's `/nix/store` from the verification build, so this applies from cache with no network dependency on the (now-moved-past) nightly:

1. **Close WezTerm on Windows** (else the locked `wezterm-gui.exe` fails the install).
2. From a **non-WezTerm** shell (Windows Terminal → `wsl`, or a raw console):
   ```
   cd <repo>
   sudo nixos-rebuild switch --flake .#nixos
   systemctl --user restart wezterm-mux-server   # ensure the running mux is on the new build
   ```
3. Reopen the WezTerm GUI on Windows — both sides now load `20260707-093716-fff02ca5`.