### PR TITLE
nixos/tailscale: auto-rebind tailscaled when the WSL2 eth0 IP rotates

### DIFF
--- a/nix/nixos/tailscale.nix
+++ b/nix/nixos/tailscale.nix
@@ -20,6 +20,7 @@
 
 {
   config,
+  pkgs,
   ...
 }:
 
@@ -47,6 +48,41 @@
     # Optional: Enable checkReversePath for Tailscale
     # This might be needed in some network configurations
     checkReversePath = "loose";
+  };
+
+  # Rebind tailscaled when the WSL2 NAT IP rotates under it.
+  #
+  # WSL2 runs eth0 behind a NAT-mode virtual adapter whose IP can change while
+  # the daemon is already running. When that happens, tailscaled's magicsock
+  # socket and DERP receive path stay bound to the OLD eth0 IP: outbound keeps
+  # working (fresh NAT mappings still open, host-initiated `tailscale ping`
+  # pongs), but cold INBOUND is dead — a peer's `tailscale ping <host>` times
+  # out over both direct and DERP, so SSH to the host hangs. A `systemctl
+  # restart tailscaled` re-runs endpoint discovery and re-homes DERP on the
+  # current eth0 IP, reclaiming the same Tailscale IP.
+  #
+  # This watcher automates that: it tails address-change events and restarts
+  # tailscaled whenever eth0 gains an address. `ip monitor` has no per-device
+  # filter, so we match "eth0" in the event text; the delete half of a rotation
+  # is ignored, and tailscale0's own up/down churn is filtered out (we only act
+  # on eth0), so a restart cannot feed back into another restart.
+  systemd.services.tailscaled-wsl-rebind = {
+    description = "Restart tailscaled when the WSL2 eth0 NAT IP rotates under it";
+    after = [ "tailscaled.service" ];
+    wantedBy = [ "multi-user.target" ];
+    path = [ pkgs.iproute2 ];
+    serviceConfig = {
+      Restart = "always";
+      RestartSec = 5;
+    };
+    script = ''
+      ip monitor address | while read -r line; do
+        case "$line" in
+          Deleted*) ;;                       # ignore the delete half of a rotation
+          *eth0*"inet "*) systemctl restart tailscaled ;;
+        esac
+      done
+    '';
   };
 
   # Optional: Enable IP forwarding if you want to use this as a subnet router


### PR DESCRIPTION
## Problem

SSH from the Mac to the WSL2/NixOS host intermittently times out even though both machines are on the same tailnet, both show online, and MagicDNS resolves the host to the correct Tailscale IP. Diagnosed 2026-07-09:

- WSL2 runs `eth0` behind a NAT-mode adapter whose IP can rotate **while tailscaled is already running** (`netcheck` logs `gateway and self IP changed`).
- tailscaled's magicsock socket and DERP receive path stay bound to the **old** `eth0` IP. Result is a directional failure:
  - **Outbound works** — host-initiated `tailscale ping <peer>` pongs (fresh NAT mappings still open).
  - **Cold inbound is dead** — a peer's `tailscale ping <host>` times out over both direct and DERP, so SSH into the host hangs.
- `sudo systemctl restart tailscaled` fixes it immediately: re-runs endpoint discovery and re-homes DERP on the current `eth0` IP, reclaiming the same Tailscale IP.

A normal reboot is unaffected — tailscaled starts *after* the IP is assigned. Only a mid-session rotation strands it.

## Change

Add a small `systemd` watcher (`tailscaled-wsl-rebind`) that tails `ip monitor address` and restarts tailscaled whenever `eth0` gains an address, so the host self-heals within seconds instead of needing a manual restart.

- `ip monitor` has no per-device filter, so the script matches `eth0` in the event text.
- The delete half of a rotation is ignored (`Deleted*`).
- tailscale0's own up/down churn is filtered out (we act on `eth0` only), so a restart cannot feed back into another restart.

## Verification

- `nix-instantiate --parse nix/nixos/tailscale.nix` → parses.
- `nix eval .#nixosConfigurations.nixos.config.systemd.services.tailscaled-wsl-rebind.description` → evaluates in the full flake (module schema + `pkgs` scoping validated).
- Confirmed the generated unit's PATH contains both `iproute2` (for `ip`) and `systemd` (for the bare `systemctl` call).
- Full end-to-end verification requires a `nixos-rebuild switch` on the host and observing a rotation self-heal — not run from the PR branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)