### PR TITLE
Add review-coverage sensor for strategy-graph-review-curriculum

### DIFF
--- a/packages/intentionsutil/scripts/review-coverage.ts
+++ b/packages/intentionsutil/scripts/review-coverage.ts
@@ -1,0 +1,45 @@
+// Review-coverage projection of the intention graph to stdout.
+//
+// Renders the review-coverage table by reading the local `intentions/` store,
+// computing the per-durable-node review mode / path / last-reviewed row, and
+// writing the rendered table to stdout. It reads only the local store (no gh,
+// no network) and writes only stdout — no committed report file. This is the
+// interim mechanical sensor for strategy-graph-review-curriculum's coverage
+// signal; the graph digest and /align-audit report absorb its output when
+// those host tactics land.
+//
+// Run from anywhere (the store dir is resolved relative to this file, not cwd):
+//   npx tsx packages/intentionsutil/scripts/review-coverage.ts
+//
+// Determinism: `listNodes` returns nodes in id-sorted order, the render sorts
+// by id, and the output carries no wall-clock/environment data — two runs on
+// the same store emit byte-identical stdout.
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { listNodes } from "../src/store.js";
+import { computeReviewCoverage, renderCoverageTable } from "../src/coverage.js";
+
+// --- Paths -----------------------------------------------------------------
+// The script lives at `packages/intentionsutil/scripts/review-coverage.ts`, so
+// the repo root is three directories up. Resolve from this file's own
+// location, never from cwd.
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(dirname(dirname(scriptDir)));
+const intentionsDir = join(repoRoot, "intentions");
+
+// --- Main ------------------------------------------------------------------
+
+function main(): void {
+  const nodes = listNodes(intentionsDir);
+  const bodyById = new Map<string, string>();
+  for (const node of nodes) {
+    bodyById.set(node.id, readFileSync(join(intentionsDir, `${node.id}.md`), "utf8"));
+  }
+  process.stdout.write(renderCoverageTable(computeReviewCoverage(nodes, bodyById)));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/packages/intentionsutil/src/coverage.ts
+++ b/packages/intentionsutil/src/coverage.ts
@@ -1,0 +1,217 @@
+// Review-coverage sensor for strategy-graph-review-curriculum.
+//
+// Computes, per durable-layer node, its review mode (A = held on trust,
+// re-validate against source; B = author-owned, re-affirm against broadened
+// context), a derived review path, and a last-reviewed date — the mechanical
+// half of the strategy's coverage signal (zero durable-layer nodes without a
+// review path).
+//
+// The module is pure: callers supply the parsed nodes plus a map from node id
+// to the node's raw markdown text (frontmatter + body). Reading the store off
+// disk is the script's job (scripts/review-coverage.ts), not this module's, so
+// the logic stays unit-testable on in-memory fixtures.
+
+import type { IntentionNode } from "./schema.js";
+import { readingDate } from "./router.js";
+
+/** One durable-layer node's review-coverage row. */
+export interface CoverageRow {
+  id: string;
+  kind: string;
+  mode: "A" | "B";
+  path: string;
+  last_reviewed: string | null;
+}
+
+/**
+ * Durable layer: the nodes a review curriculum is responsible for. Tactics are
+ * excluded — live tactics are covered through their serving strategy,
+ * born-parked review items are curriculum *entries* not subjects, and done
+ * tactics are pruned (strategy-graph-review-curriculum clarification 2).
+ */
+const DURABLE_KINDS: ReadonlySet<string> = new Set([
+  "virtue",
+  "strategy",
+  "kind",
+  "tradition",
+  "delegation",
+]);
+
+/** The sentinel path for a durable node with no derivable review path. */
+const MISSING = "MISSING";
+
+/**
+ * Mode of a durable node (strategy clarification 3):
+ * - `A` — content held on trust: delegations, traditions (delegated
+ *   articulations of primary texts), and anything explicitly `delegated`.
+ * - `B` — author-owned: re-affirmed against a broadened context.
+ */
+function modeOf(node: IntentionNode): "A" | "B" {
+  if (node.kind === "delegation") return "A";
+  if (node.kind === "tradition") return "A";
+  if (node.status === "delegated") return "A";
+  return "B";
+}
+
+/**
+ * The ids of nodes that are frontier review *entries*: `office_hours` non-null
+ * and `phase` not `"done"` (a done-phase parked node is spent, not a live
+ * curriculum entry). Born-parked review items name their subject in prose, so
+ * the mechanical linkage is: the entry's raw text contains the subject's id as
+ * a substring.
+ */
+function frontierEntryFor(
+  subjectId: string,
+  nodes: readonly IntentionNode[],
+  bodyById: ReadonlyMap<string, string>,
+): string | null {
+  let best: string | null = null;
+  for (const candidate of nodes) {
+    if (candidate.id === subjectId) continue;
+    if (candidate.office_hours === null) continue;
+    if (candidate.phase === "done") continue;
+    const body = bodyById.get(candidate.id);
+    if (body === undefined || !body.includes(subjectId)) continue;
+    if (best === null || candidate.id < best) best = candidate.id;
+  }
+  return best;
+}
+
+/** A `review_trigger` attribute with a non-empty string value. */
+function hasReviewTrigger(node: IntentionNode): boolean {
+  const trigger = node.attributes["review_trigger"];
+  return typeof trigger === "string" && trigger.trim() !== "";
+}
+
+/** A non-empty `conditions` array in attributes. */
+function hasConditions(node: IntentionNode): boolean {
+  const conditions = node.attributes["conditions"];
+  return Array.isArray(conditions) && conditions.length > 0;
+}
+
+/**
+ * The review path for a durable node — first matching rule wins:
+ *
+ *   1. a frontier review entry naming this node → `frontier-entry:<id>`
+ *   2. delegation → `event-based-review` (has `review_trigger`) else `MISSING`
+ *   3. tradition → `reading-program`
+ *   4. author-owned strategy with recorded conditions → `condition-sweep`
+ *   5. any other author-owned node → `frontier-reachable`
+ *   6. otherwise (a mode-A node no class rule covers) → `MISSING`
+ */
+function pathOf(
+  node: IntentionNode,
+  mode: "A" | "B",
+  nodes: readonly IntentionNode[],
+  bodyById: ReadonlyMap<string, string>,
+): string {
+  const entry = frontierEntryFor(node.id, nodes, bodyById);
+  if (entry !== null) return `frontier-entry:${entry}`;
+
+  if (node.kind === "delegation") {
+    return hasReviewTrigger(node) ? "event-based-review" : MISSING;
+  }
+  if (node.kind === "tradition") return "reading-program";
+
+  if (mode === "B") {
+    if (node.kind === "strategy" && hasConditions(node)) return "condition-sweep";
+    return "frontier-reachable";
+  }
+
+  return MISSING;
+}
+
+/**
+ * Recursively collect every string value carried under an attributes key named
+ * `last_assessed` or `last_exercised`, at any nesting depth. Delegations carry
+ * `attributes.last_assessed` top-level and, e.g.,
+ * `attributes.irreversibility.last_exercised` nested.
+ */
+function collectStampStrings(value: unknown, out: string[]): void {
+  if (Array.isArray(value)) {
+    for (const element of value) collectStampStrings(element, out);
+    return;
+  }
+  if (value !== null && typeof value === "object") {
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      if ((key === "last_assessed" || key === "last_exercised") && typeof nested === "string") {
+        out.push(nested);
+      }
+      collectStampStrings(nested, out);
+    }
+  }
+}
+
+/**
+ * The newest ISO date (YYYY-MM-DD) across the node's clarification answers and
+ * its `last_assessed`/`last_exercised` attribute stamps, or `null` when none of
+ * those texts carry a parseable date.
+ */
+function lastReviewedOf(node: IntentionNode): string | null {
+  const dates: string[] = [];
+  for (const clarification of node.clarifications) {
+    const date = readingDate(clarification.answer);
+    if (date !== null) dates.push(date);
+  }
+  const stamps: string[] = [];
+  collectStampStrings(node.attributes, stamps);
+  for (const stamp of stamps) {
+    const date = readingDate(stamp);
+    if (date !== null) dates.push(date);
+  }
+  if (dates.length === 0) return null;
+  return dates.reduce((a, b) => (a > b ? a : b));
+}
+
+/**
+ * Compute the review-coverage rows for the durable layer. Non-durable kinds
+ * (tactics included) are excluded from the result entirely. Input order is
+ * preserved; the script passes id-sorted nodes.
+ */
+export function computeReviewCoverage(
+  nodes: readonly IntentionNode[],
+  bodyById: ReadonlyMap<string, string>,
+): CoverageRow[] {
+  const rows: CoverageRow[] = [];
+  for (const node of nodes) {
+    if (!DURABLE_KINDS.has(node.kind)) continue;
+    const mode = modeOf(node);
+    rows.push({
+      id: node.id,
+      kind: node.kind,
+      mode,
+      path: pathOf(node, mode, nodes, bodyById),
+      last_reviewed: lastReviewedOf(node),
+    });
+  }
+  return rows;
+}
+
+/**
+ * Render the coverage rows as a deterministic stdout block: an id-sorted
+ * markdown table, then a trailing summary line naming the nodes with no review
+ * path. No wall-clock or environment data — byte-identical across runs on the
+ * same store.
+ */
+export function renderCoverageTable(rows: readonly CoverageRow[]): string {
+  const sorted = [...rows].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  const lines: string[] = [];
+  lines.push("| id | kind | mode | path | last_reviewed |");
+  lines.push("| --- | --- | --- | --- | --- |");
+  for (const row of sorted) {
+    lines.push(
+      `| ${row.id} | ${row.kind} | ${row.mode} | ${row.path} | ${row.last_reviewed ?? "—"} |`,
+    );
+  }
+
+  const missing = sorted.filter((row) => row.path === MISSING).map((row) => row.id);
+  const summary =
+    missing.length === 0
+      ? `${sorted.length} durable nodes; 0 missing a review path`
+      : `${sorted.length} durable nodes; ${missing.length} missing a review path: ${missing.join(", ")}`;
+
+  lines.push("");
+  lines.push(summary);
+  return lines.join("\n") + "\n";
+}

--- a/packages/intentionsutil/src/coverage.ts
+++ b/packages/intentionsutil/src/coverage.ts
@@ -121,6 +121,11 @@ function pathOf(
   return MISSING;
 }
 
+/** A non-array, non-null object — a plain record we can enumerate by key. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 /**
  * Recursively collect every string value carried under an attributes key named
  * `last_assessed` or `last_exercised`, at any nesting depth. Delegations carry
@@ -132,8 +137,8 @@ function collectStampStrings(value: unknown, out: string[]): void {
     for (const element of value) collectStampStrings(element, out);
     return;
   }
-  if (value !== null && typeof value === "object") {
-    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+  if (isRecord(value)) {
+    for (const [key, nested] of Object.entries(value)) {
       if ((key === "last_assessed" || key === "last_exercised") && typeof nested === "string") {
         out.push(nested);
       }

--- a/packages/intentionsutil/test/coverage.test.ts
+++ b/packages/intentionsutil/test/coverage.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from "vitest";
+import type { IntentionNode } from "../src/schema.js";
+import { computeReviewCoverage, renderCoverageTable } from "../src/coverage.js";
+
+/** Build an IntentionNode fixture, filling required/default fields. */
+function node(partial: Partial<IntentionNode> & { id: string }): IntentionNode {
+  return {
+    id: partial.id,
+    kind: partial.kind ?? "tactic",
+    statement: partial.statement ?? `Statement for ${partial.id}`,
+    owner: partial.owner ?? "human",
+    status: partial.status ?? "codified",
+    parent: partial.parent ?? null,
+    serves: partial.serves ?? [],
+    recovers: partial.recovers ?? [],
+    rationale: partial.rationale ?? null,
+    reading: partial.reading ?? null,
+    gap: partial.gap ?? null,
+    clarifications: partial.clarifications ?? [],
+    tooling_goals: partial.tooling_goals ?? [],
+    success_signal: partial.success_signal ?? null,
+    attention: partial.attention ?? null,
+    phase: partial.phase ?? null,
+    execution: partial.execution ?? null,
+    validates: partial.validates ?? [],
+    blocked_by: partial.blocked_by ?? [],
+    office_hours: partial.office_hours ?? null,
+    pace_exempt: partial.pace_exempt ?? false,
+    rounds: partial.rounds ?? null,
+    attributes: partial.attributes ?? {},
+  };
+}
+
+/** A body map that yields empty text for every id (no frontier entries). */
+function noBodies(): Map<string, string> {
+  return new Map();
+}
+
+/** Look up the single row for an id, asserting exactly one exists. */
+function rowFor(rows: ReturnType<typeof computeReviewCoverage>, id: string) {
+  const matches = rows.filter((r) => r.id === id);
+  expect(matches).toHaveLength(1);
+  return matches[0];
+}
+
+describe("computeReviewCoverage — denominator", () => {
+  it("includes only durable kinds; excludes tactics and unknown kinds", () => {
+    const nodes = [
+      node({ id: "v", kind: "virtue" }),
+      node({ id: "s", kind: "strategy" }),
+      node({ id: "k", kind: "kind" }),
+      node({ id: "tr", kind: "tradition" }),
+      node({ id: "d", kind: "delegation", attributes: { review_trigger: "x" } }),
+      node({ id: "t", kind: "tactic" }),
+      node({ id: "u", kind: "somethingelse" }),
+    ];
+    const rows = computeReviewCoverage(nodes, noBodies());
+    expect(rows.map((r) => r.id).sort()).toEqual(["d", "k", "s", "tr", "v"]);
+  });
+
+  it("preserves input order of the surviving durable nodes", () => {
+    const nodes = [
+      node({ id: "z", kind: "virtue" }),
+      node({ id: "a", kind: "strategy" }),
+    ];
+    const rows = computeReviewCoverage(nodes, noBodies());
+    expect(rows.map((r) => r.id)).toEqual(["z", "a"]);
+  });
+});
+
+describe("computeReviewCoverage — mode derivation (rule 2)", () => {
+  it("delegation is mode A", () => {
+    const rows = computeReviewCoverage(
+      [node({ id: "d", kind: "delegation", attributes: { review_trigger: "x" } })],
+      noBodies(),
+    );
+    expect(rowFor(rows, "d").mode).toBe("A");
+  });
+
+  it("tradition is mode A", () => {
+    const rows = computeReviewCoverage([node({ id: "tr", kind: "tradition" })], noBodies());
+    expect(rowFor(rows, "tr").mode).toBe("A");
+  });
+
+  it("a delegated-status node of another kind is mode A", () => {
+    const rows = computeReviewCoverage(
+      [node({ id: "s", kind: "strategy", status: "delegated" })],
+      noBodies(),
+    );
+    expect(rowFor(rows, "s").mode).toBe("A");
+  });
+
+  it("an author-owned node defaults to mode B", () => {
+    const rows = computeReviewCoverage(
+      [node({ id: "s", kind: "strategy", status: "codified" })],
+      noBodies(),
+    );
+    expect(rowFor(rows, "s").mode).toBe("B");
+  });
+});
+
+describe("computeReviewCoverage — path precedence (rule 3)", () => {
+  it("a frontier entry beats the class path", () => {
+    const subject = node({ id: "strategy-x", kind: "strategy", status: "codified" });
+    const entry = node({
+      id: "tactic-parked-review",
+      kind: "tactic",
+      phase: "draft",
+      office_hours: { reason: "review strategy-x someday" } as never,
+    });
+    const bodyById = new Map<string, string>([
+      ["tactic-parked-review", "This entry reviews strategy-x in prose."],
+    ]);
+    const rows = computeReviewCoverage([subject, entry], bodyById);
+    expect(rowFor(rows, "strategy-x").path).toBe("frontier-entry:tactic-parked-review");
+  });
+
+  it("picks the lexicographically smallest entry id when several match", () => {
+    const subject = node({ id: "strategy-x", kind: "strategy" });
+    const bodyById = new Map<string, string>([
+      ["entry-b", "names strategy-x"],
+      ["entry-a", "names strategy-x"],
+    ]);
+    const nodes = [
+      subject,
+      node({ id: "entry-b", kind: "tactic", phase: "qa", office_hours: { reason: "r" } as never }),
+      node({ id: "entry-a", kind: "tactic", phase: "qa", office_hours: { reason: "r" } as never }),
+    ];
+    const rows = computeReviewCoverage(nodes, bodyById);
+    expect(rowFor(rows, "strategy-x").path).toBe("frontier-entry:entry-a");
+  });
+
+  it("a done-phase parked node does not count as a frontier entry", () => {
+    const subject = node({ id: "strategy-x", kind: "strategy", status: "codified" });
+    const doneEntry = node({
+      id: "tactic-done",
+      kind: "tactic",
+      phase: "done",
+      office_hours: { reason: "review strategy-x" } as never,
+    });
+    const bodyById = new Map<string, string>([["tactic-done", "reviews strategy-x"]]);
+    const rows = computeReviewCoverage([subject, doneEntry], bodyById);
+    // Falls through to the class path, not frontier-entry.
+    expect(rowFor(rows, "strategy-x").path).toBe("frontier-reachable");
+  });
+
+  it("a null-office_hours node naming the subject is not a frontier entry", () => {
+    const subject = node({ id: "strategy-x", kind: "strategy", status: "codified" });
+    const other = node({ id: "strategy-y", kind: "strategy", office_hours: null });
+    const bodyById = new Map<string, string>([["strategy-y", "mentions strategy-x"]]);
+    const rows = computeReviewCoverage([subject, other], bodyById);
+    expect(rowFor(rows, "strategy-x").path).toBe("frontier-reachable");
+  });
+});
+
+describe("computeReviewCoverage — class paths (rules 2b, 3, 4, 5, 6)", () => {
+  it("delegation with review_trigger → event-based-review", () => {
+    const rows = computeReviewCoverage(
+      [node({ id: "d", kind: "delegation", attributes: { review_trigger: "runway breach" } })],
+      noBodies(),
+    );
+    expect(rowFor(rows, "d").path).toBe("event-based-review");
+  });
+
+  it("delegation without review_trigger → MISSING", () => {
+    const rows = computeReviewCoverage(
+      [node({ id: "d", kind: "delegation", attributes: {} })],
+      noBodies(),
+    );
+    expect(rowFor(rows, "d").path).toBe("MISSING");
+  });
+
+  it("delegation with an empty-string review_trigger → MISSING", () => {
+    const rows = computeReviewCoverage(
+      [node({ id: "d", kind: "delegation", attributes: { review_trigger: "   " } })],
+      noBodies(),
+    );
+    expect(rowFor(rows, "d").path).toBe("MISSING");
+  });
+
+  it("tradition → reading-program", () => {
+    const rows = computeReviewCoverage([node({ id: "tr", kind: "tradition" })], noBodies());
+    expect(rowFor(rows, "tr").path).toBe("reading-program");
+  });
+
+  it("author-owned strategy with non-empty conditions → condition-sweep", () => {
+    const rows = computeReviewCoverage(
+      [node({ id: "s", kind: "strategy", attributes: { conditions: ["c1", "c2"] } })],
+      noBodies(),
+    );
+    expect(rowFor(rows, "s").path).toBe("condition-sweep");
+  });
+
+  it("author-owned strategy with an empty conditions array → frontier-reachable", () => {
+    const rows = computeReviewCoverage(
+      [node({ id: "s", kind: "strategy", attributes: { conditions: [] } })],
+      noBodies(),
+    );
+    expect(rowFor(rows, "s").path).toBe("frontier-reachable");
+  });
+
+  it("author-owned virtue (no conditions rule) → frontier-reachable", () => {
+    const rows = computeReviewCoverage([node({ id: "v", kind: "virtue" })], noBodies());
+    expect(rowFor(rows, "v").path).toBe("frontier-reachable");
+  });
+
+  it("a mode-A node no class rule covers → MISSING", () => {
+    // A delegated-status virtue: mode A, not delegation/tradition, no frontier
+    // entry → falls through to MISSING.
+    const rows = computeReviewCoverage(
+      [node({ id: "v", kind: "virtue", status: "delegated" })],
+      noBodies(),
+    );
+    expect(rowFor(rows, "v").path).toBe("MISSING");
+  });
+});
+
+describe("computeReviewCoverage — last_reviewed (rule 4)", () => {
+  it("picks the newest date across clarification provenance", () => {
+    const rows = computeReviewCoverage(
+      [
+        node({
+          id: "s",
+          kind: "strategy",
+          clarifications: [
+            { question: "q1", answer: "Recorded 2026-05-01." },
+            { question: "q2", answer: "Amended 2026-06-15." },
+          ],
+        }),
+      ],
+      noBodies(),
+    );
+    expect(rowFor(rows, "s").last_reviewed).toBe("2026-06-15");
+  });
+
+  it("picks the newest across nested last_assessed / last_exercised stamps", () => {
+    const rows = computeReviewCoverage(
+      [
+        node({
+          id: "d",
+          kind: "delegation",
+          attributes: {
+            review_trigger: "x",
+            last_assessed: "2026-07-02",
+            irreversibility: { last_exercised: "2026-07-08" },
+          },
+        }),
+      ],
+      noBodies(),
+    );
+    expect(rowFor(rows, "d").last_reviewed).toBe("2026-07-08");
+  });
+
+  it("combines clarification and attribute dates, taking the newest overall", () => {
+    const rows = computeReviewCoverage(
+      [
+        node({
+          id: "d",
+          kind: "delegation",
+          clarifications: [{ question: "q", answer: "Reviewed 2026-08-01." }],
+          attributes: { review_trigger: "x", last_assessed: "2026-07-02" },
+        }),
+      ],
+      noBodies(),
+    );
+    expect(rowFor(rows, "d").last_reviewed).toBe("2026-08-01");
+  });
+
+  it("ignores a null nested stamp with no other date → null", () => {
+    const rows = computeReviewCoverage(
+      [
+        node({
+          id: "d",
+          kind: "delegation",
+          attributes: { review_trigger: "x", irreversibility: { last_exercised: null } },
+        }),
+      ],
+      noBodies(),
+    );
+    expect(rowFor(rows, "d").last_reviewed).toBeNull();
+  });
+
+  it("is null when no date is present anywhere", () => {
+    const rows = computeReviewCoverage([node({ id: "v", kind: "virtue" })], noBodies());
+    expect(rowFor(rows, "v").last_reviewed).toBeNull();
+  });
+});
+
+describe("renderCoverageTable", () => {
+  it("is deterministic — two calls are byte-identical", () => {
+    const rows = computeReviewCoverage(
+      [
+        node({ id: "b", kind: "strategy", attributes: { conditions: ["c"] } }),
+        node({ id: "a", kind: "virtue" }),
+      ],
+      noBodies(),
+    );
+    expect(renderCoverageTable(rows)).toBe(renderCoverageTable(rows));
+  });
+
+  it("sorts rows by id regardless of input order", () => {
+    const rows = computeReviewCoverage(
+      [node({ id: "z", kind: "virtue" }), node({ id: "a", kind: "virtue" })],
+      noBodies(),
+    );
+    const out = renderCoverageTable(rows);
+    const dataLines = out.split("\n").filter((l) => l.startsWith("| a ") || l.startsWith("| z "));
+    expect(dataLines[0].startsWith("| a ")).toBe(true);
+    expect(dataLines[1].startsWith("| z ")).toBe(true);
+  });
+
+  it("names the missing nodes in the summary line", () => {
+    const rows = computeReviewCoverage(
+      [
+        node({ id: "d1", kind: "delegation", attributes: {} }),
+        node({ id: "ok", kind: "tradition" }),
+        node({ id: "d2", kind: "delegation", attributes: {} }),
+      ],
+      noBodies(),
+    );
+    const out = renderCoverageTable(rows);
+    expect(out.trimEnd().endsWith("3 durable nodes; 2 missing a review path: d1, d2")).toBe(true);
+  });
+
+  it("reports 0 missing when every durable node has a path", () => {
+    const rows = computeReviewCoverage(
+      [node({ id: "tr", kind: "tradition" }), node({ id: "v", kind: "virtue" })],
+      noBodies(),
+    );
+    const out = renderCoverageTable(rows);
+    expect(out.trimEnd().endsWith("2 durable nodes; 0 missing a review path")).toBe(true);
+  });
+});

--- a/packages/intentionsutil/test/coverage.test.ts
+++ b/packages/intentionsutil/test/coverage.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { IntentionNode } from "../src/schema.js";
+import type { IntentionNode, OfficeHours } from "../src/schema.js";
 import { computeReviewCoverage, renderCoverageTable } from "../src/coverage.js";
+
+/** A well-formed office_hours record for a parked fixture node. */
+function parked(reason: string): OfficeHours {
+  return { reason, since: "2026-07-01", recommendation: null };
+}
 
 /** Build an IntentionNode fixture, filling required/default fields. */
 function node(partial: Partial<IntentionNode> & { id: string }): IntentionNode {
@@ -106,7 +111,7 @@ describe("computeReviewCoverage — path precedence (rule 3)", () => {
       id: "tactic-parked-review",
       kind: "tactic",
       phase: "draft",
-      office_hours: { reason: "review strategy-x someday" } as never,
+      office_hours: parked("review strategy-x someday"),
     });
     const bodyById = new Map<string, string>([
       ["tactic-parked-review", "This entry reviews strategy-x in prose."],
@@ -123,8 +128,8 @@ describe("computeReviewCoverage — path precedence (rule 3)", () => {
     ]);
     const nodes = [
       subject,
-      node({ id: "entry-b", kind: "tactic", phase: "qa", office_hours: { reason: "r" } as never }),
-      node({ id: "entry-a", kind: "tactic", phase: "qa", office_hours: { reason: "r" } as never }),
+      node({ id: "entry-b", kind: "tactic", phase: "qa", office_hours: parked("r") }),
+      node({ id: "entry-a", kind: "tactic", phase: "qa", office_hours: parked("r") }),
     ];
     const rows = computeReviewCoverage(nodes, bodyById);
     expect(rowFor(rows, "strategy-x").path).toBe("frontier-entry:entry-a");
@@ -136,7 +141,7 @@ describe("computeReviewCoverage — path precedence (rule 3)", () => {
       id: "tactic-done",
       kind: "tactic",
       phase: "done",
-      office_hours: { reason: "review strategy-x" } as never,
+      office_hours: parked("review strategy-x"),
     });
     const bodyById = new Map<string, string>([["tactic-done", "reviews strategy-x"]]);
     const rows = computeReviewCoverage([subject, doneEntry], bodyById);


### PR DESCRIPTION
## Context

strategy-graph-review-curriculum's success signal reads coverage — zero durable-layer nodes without a review path. This ships the mechanical coverage half: a deterministic review-coverage table computed from the `intentions/` store. The named hosts (the graph digest and the /align-audit report) are still draft tactics, so the table ships as a standalone script the same shape as `frontier-view.ts`; those hosts absorb its output when they land.

Implements node `tactic-review-curriculum-coverage-sensor` (graph-native dispatch; no GitHub issue).

## Units

- **Unit 1 — coverage module + tests.** `packages/intentionsutil/src/coverage.ts` (pure `computeReviewCoverage` + `renderCoverageTable`) and `test/coverage.test.ts`. Durable-layer denominator; mode A/B derivation; first-match review-path rules; newest `last_reviewed` across clarification provenance and nested `last_assessed`/`last_exercised` stamps. Reuses `IntentionNode` and `readingDate`.
- **Unit 2 — script.** `packages/intentionsutil/scripts/review-coverage.ts`, a standalone stdout script mirroring `frontier-view.ts` (repo-root from `import.meta.url`, `main()` behind the `pathToFileURL` guard, no args, no network).

## Verification

- `npx vitest run --project packages/intentionsutil --root .` — 241 passed.
- `npx tsx packages/intentionsutil/scripts/review-coverage.ts` — 91 durable nodes; 0 missing a review path; byte-identical across two runs.
- Typecheck and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)