### PR TITLE
human-invoked align sessions claim their node id (tactic-align-session-claiming)

### DIFF
--- a/.claude/skills/align-strategy/SKILL.md
+++ b/.claude/skills/align-strategy/SKILL.md
@@ -48,6 +48,43 @@ bounded choices with a recommended option listed first, per the
 conversational turn, prose reply captured as-is (same split as
 `.claude/skills/align-init/SKILL.md`'s rung-0 intent interview).
 
+## Step 0 — Claim and isolate
+
+Before the first write, claim the target node id and author in its
+worktree — the same uniform node-id reservation discipline the router's
+fan-out workers follow (`strategy-graph-native-dispatch`'s 2026-07-06
+concurrency-safety clarification). Never author strategy edits in the
+shared `main` checkout: a second concurrent session's dirty tracked file
+blocks your `graph-commit` rebase, and a stale read races live phase state
+(both happened live the day that clarification landed).
+
+1. **Resolve the target node id.** For an edit, an improvement pass, or a
+   doctrine round, it is the primary `strategy-*` being edited — claimed
+   before the first write. A brand-new strategy has no id until step 5
+   constructs it; author it in the worktree and claim its id as soon as the
+   id is fixed.
+2. **Check the claim.** If `<project-root>/.claude/worktrees/<node-id>`
+   already exists with a live session — `worktree_has_live_session <path>`
+   (`.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh:15`,
+   run with `dangerouslyDisableSandbox: true`) — the claim is held by
+   another session: stop and report the held claim to the author. Do
+   **not** park the node — a held claim is not a defect.
+3. **Enter the worktree.** Otherwise create or re-enter it — native
+   `EnterWorktree` with the node id as the worktree name, or the
+   `provision-node-worktree`
+   (`.claude/skills/dispatch-propagate/scripts/provision-node-worktree`)
+   primitive — and do all authoring and the step-5 `graph-commit` from
+   there. The worktree **is** the claim: the same live-session ⇔ worktree
+   liveness rule the router uses, so no separate lock is needed.
+
+**Doctrine-recording rounds pin the pace curve.** A round that records
+governing dispatch doctrine (a concurrency-safety or
+dispatch-discipline clarification) pins
+`dispatch.config/target-workers.json` to floor 0 / terminal 1 for its
+audit window so the fleet quiesces while the doctrine settles, then
+restores the standing 50 / 100 curve after — the practice the 2026-07-06
+clarification records.
+
 ## Step 1 — Frame
 
 **With requirement text:**
@@ -236,9 +273,20 @@ frontmatter:
   core plus `serves`, `rationale`, `clarifications`, `success_signal`,
   `attributes.conditions`, `recovers` from step 3) and pipe or `--file` it
   into `write-node.ts`.
-- **Edit:** read the existing node's frontmatter in full (`readNode` via a
-  small `tsx` one-liner, or just read the file — only the frontmatter is
-  authoritative). **Amendment completeness** (strategy clarification 38,
+- **Edit:** read the existing node's frontmatter in full by **dumping it
+  through `dump-node.ts`**, which captures both the JSON to reconcile and a
+  base manifest recording the blob you read — the compare-and-swap token
+  step 5's `graph-commit --base` checks (never a bare `readNode` one-liner,
+  which records no base):
+
+  ```bash
+  BASE=$(npx tsx packages/intentionsutil/scripts/dump-node.ts \
+    --out-dir "$TMPDIR/dump" <strategy-id>)
+  # reconcile from "$TMPDIR/dump/<strategy-id>.json"; pass "$BASE" to graph-commit below
+  ```
+
+  Only the frontmatter is authoritative. **Amendment completeness**
+  (strategy clarification 38,
   widening clarification 32's tactic-amendment bar to any node amendment in
   any align skill): an edit round is a **whole-node reconciliation**, never
   a patch applied in isolation. Reconcile the edited strategy's `statement`,
@@ -258,11 +306,18 @@ npx tsx packages/intentionsutil/scripts/write-node.ts --file "$TMPDIR/strategy.j
 ```
 
 Then land it — `graph-commit` is the **only** write path, never a
-hand-rolled `git commit`/`git push`:
+hand-rolled `git commit`/`git push`. For an **edit**, pass the base
+manifest from `dump-node.ts` via `--base` so a stale read is refused
+mechanically (before any commit) rather than left to rebase luck:
 
 ```bash
-packages/intentionsutil/scripts/graph-commit <strategy-id> [<draft-tactic-id> ...]
+packages/intentionsutil/scripts/graph-commit --base "$BASE" \
+  <strategy-id> [<draft-tactic-id> ...]
 ```
+
+A brand-new strategy has no origin/main blob to compare, so it takes no
+`--base` entry — omit the flag (or the id) for nodes this round creates;
+`--base` covers only the pre-existing nodes you dumped.
 
 Bundle any draft tactic nodes authored in the same pass into the same
 `graph-commit` call as their serving strategy — one call, one commit,

--- a/.claude/skills/align-tactics/SKILL.md
+++ b/.claude/skills/align-tactics/SKILL.md
@@ -42,6 +42,32 @@ On-demand or router-invoked. The sole argument is the id of the strategy to
 decompose: `/align-tactics strategy-<slug>`. With no argument, stop and report
 that a strategy id is required — this skill never selects its own target.
 
+## Step 0 — Claim and isolate
+
+Before the first write, claim the target strategy's node id and author in
+its worktree — the same uniform node-id reservation discipline the router's
+fan-out workers follow (`strategy-graph-native-dispatch`'s 2026-07-06
+concurrency-safety clarification). Never author in the shared `main`
+checkout: a concurrent session's dirty tracked file blocks this run's
+`graph-commit` rebase, and a stale read races live phase state.
+
+1. **Resolve the target node id** — the `strategy-<slug>` argument (this
+   skill never selects its own target).
+2. **Check the claim.** If `<project-root>/.claude/worktrees/<node-id>`
+   already exists with a live session — `worktree_has_live_session <path>`
+   (`.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh:15`,
+   run with `dangerouslyDisableSandbox: true`) — the claim is held by
+   another session: stop and report the held claim, then end the run. A
+   held claim is **not** an `office_hours` park (it is not one of the three
+   autonomy-contract conditions below) and **not** a defect.
+3. **Enter the worktree.** Otherwise create or re-enter it — native
+   `EnterWorktree` with the node id as the worktree name, or the
+   `provision-node-worktree`
+   (`.claude/skills/dispatch-propagate/scripts/provision-node-worktree`)
+   primitive — and do all authoring and the step-5 `graph-commit` from
+   there. The worktree **is** the claim: the same live-session ⇔ worktree
+   liveness rule the router uses, so no separate lock is needed.
+
 ## Autonomy contract
 
 Runs to completion without user interaction. Parks to `office_hours` — never
@@ -307,6 +333,19 @@ The write path mirrors `/align-strategy` Step 5 exactly — `write-node.ts` is
 the single validation gate; never hand-author YAML frontmatter, and
 `graph-commit` is the **only** landing path.
 
+**Capture a base manifest for every pre-existing node this round edits** —
+the serving strategy (a drift clarification, a `rounds` bump, a park) and any
+existing tactic finalized from a draft. Dump them through `dump-node.ts`
+*before* rewriting, then pass the manifest to `graph-commit --base` (item 3)
+so a stale read of a live node is refused mechanically rather than by rebase
+luck (the 2026-07-06 near-miss). Nodes this round **creates** have no
+origin/main blob and take no `--base` entry.
+
+```bash
+BASE=$(npx tsx packages/intentionsutil/scripts/dump-node.ts \
+  --out-dir "$TMPDIR/dump" <pre-existing-id> [<pre-existing-id> ...])
+```
+
 **Artifact-owner placement** (strategy clarification 27): `serves` names the
 strategy that actually owns the artifact the tactic changes. Normally that is
 the strategy under decomposition, but a byproduct that genuinely changes a
@@ -352,9 +391,14 @@ Per tactic:
    strategy alongside the round's tactics) in one call:
 
    ```bash
-   packages/intentionsutil/scripts/graph-commit <tactic-id> [<tactic-id> ...] [<strategy-id>]
+   packages/intentionsutil/scripts/graph-commit --base "$BASE" \
+     <tactic-id> [<tactic-id> ...] [<strategy-id>]
    ```
 
+   Pass `--base "$BASE"` (the manifest from `dump-node.ts` above) whenever the
+   call touches a pre-existing node; omit it for a round that only creates new
+   tactics. `--base` covers only the dumped pre-existing ids — newly created
+   ids in the same call are simply absent from the manifest and unchecked.
    `graph-commit` stages exactly `intentions/<id>.md` for each id (frontmatter
    and the body `Edit` both live there), commits, stamps the four required
    checks via the `graph/**` fast path, and fast-forwards onto `main` with a

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -42304,6 +42304,87 @@ assert_eq "dispatch-find-owning-pr: non-digit N exits 2" "2" "$rc"
 find_owning_pr_teardown
 
 # ============================================================================
+# Test: graph-select-target — a human-created node-id worktree is a held claim
+# (tactic-align-session-claiming Unit 3)
+# ============================================================================
+# Uniform node-id claiming (strategy clarification 13) must cover worktrees a
+# HUMAN-invoked /align-strategy or /align-tactics session created — sessions
+# that claim by authoring in <root>/.claude/worktrees/<node-id> and never write
+# a router reservation-ledger marker. graph-select-target's claimed-set gate is
+# worktree_has_live_session, name-keyed on the worktree basename, so a live
+# session named <node-id> claims the node no matter who created the worktree.
+# Per the #1474 doctrine, worktree DIRECTORY existence alone is NOT a claim
+# (orphan worktrees fail open) — the live session is; the negative control
+# below pins that (dir present, no session -> selected). The skip<->select
+# delta also rules out a daemon-UNKNOWN fold-to-occupied false pass.
+#
+# graph-select-target reads the store via `git archive origin/main intentions`
+# and derives REPO_ROOT from its own on-disk location, so it needs a real git
+# repo with the script physically copied in (a symlink's pwd would resolve back
+# out of the fixture). select-targets.ts (the pure candidate computation) is
+# stubbed with a fake `npx` on PATH so the fixture exercises ONLY the
+# environmental claimed-set gate this unit covers; the snapshot is irrelevant.
+echo "Test: graph-select-target — live session in a human-created node-id worktree is skipped (Unit 3)"
+GSC_ROOT=$(mktemp -d)
+GSC_BARE=$(mktemp -d)
+GSC_SCRIPTS="$GSC_ROOT/.claude/skills/dispatch-propagate/scripts"
+mkdir -p "$GSC_SCRIPTS" "$GSC_ROOT/bin"
+# Copy the script under test + every sourced lib (lib.sh plus the lib-*.sh
+# helpers). REPO_ROOT is derived from the script's real location, so the copy
+# must be physical.
+cp "$SCRIPT_DIR"/graph-select-target "$SCRIPT_DIR"/lib.sh "$SCRIPT_DIR"/lib-*.sh "$GSC_SCRIPTS/"
+# Fake npx: intercept `npx tsx …/select-targets.ts …` and emit one selectable
+# implement-phase candidate. An implement candidate's sensor_gate returns 0
+# without touching gh, so no further environmental dependency is exercised.
+cat > "$GSC_ROOT/bin/npx" <<'GSCNPX'
+#!/usr/bin/env bash
+echo '{"candidates":[{"id":"tactic-fixture","kind":"tactic","phase":"implement","pr":null,"pace_exempt":false}],"events":[]}'
+exit 0
+GSCNPX
+chmod +x "$GSC_ROOT/bin/npx"
+# A git repo whose origin/main carries an intentions/ tree, main checked out at
+# the fixture root so NATIVE_ROOT resolves there.
+git init -q -b main "$GSC_ROOT"
+git -C "$GSC_ROOT" config user.email t@t
+git -C "$GSC_ROOT" config user.name t
+mkdir -p "$GSC_ROOT/intentions"
+echo '# placeholder' > "$GSC_ROOT/intentions/placeholder.md"
+git -C "$GSC_ROOT" add -A
+git -C "$GSC_ROOT" commit -q -m seed
+git init -q --bare -b main "$GSC_BARE"
+git -C "$GSC_ROOT" remote add origin "$GSC_BARE"
+git -C "$GSC_ROOT" push -q origin main
+git -C "$GSC_ROOT" fetch -q origin
+# The human session's claim: the node-id worktree directory exists.
+mkdir -p "$GSC_ROOT/.claude/worktrees/tactic-fixture"
+# Fake `claude agents --json`: payload driven by a file the two cases rewrite.
+cat > "$GSC_ROOT/bin/claude" <<'GSCCLAUDE'
+#!/usr/bin/env bash
+_root="$(cd "$(dirname "$0")/.." && pwd)"
+cat "$_root/claude-payload.json"
+exit 0
+GSCCLAUDE
+chmod +x "$GSC_ROOT/bin/claude"
+GSC_GST="$GSC_SCRIPTS/graph-select-target"
+# Case 1 — a live session named after the node id owns the worktree -> skipped.
+printf '%s' '[{"sessionId":"s1","pid":1,"status":"busy","name":"tactic-fixture","cwd":""}]' \
+  > "$GSC_ROOT/claude-payload.json"
+gsc_skip=$(PATH="$GSC_ROOT/bin:$SAVED_PATH" \
+  CLAUDE_AGENTS_CMD="$GSC_ROOT/bin/claude" DISPATCH_RESERVATION_DIR="$GSC_ROOT/reservations" \
+  DISPATCH_SELECTION_LOG_DIR="$GSC_ROOT/seldir" "$GSC_GST" 2>/dev/null)
+assert_eq "graph-select-target: live-session-owned human node-id worktree is skipped" "empty" "$gsc_skip"
+# Case 2 (negative control) — same fixture, daemon reports NO sessions ([]).
+# The worktree dir still exists, so this pins that existence alone does not
+# claim: the node IS selected.
+echo "Test: graph-select-target — orphan node-id worktree (no live session) stays selectable (Unit 3 negative control)"
+printf '%s' '[]' > "$GSC_ROOT/claude-payload.json"
+gsc_sel=$(PATH="$GSC_ROOT/bin:$SAVED_PATH" \
+  CLAUDE_AGENTS_CMD="$GSC_ROOT/bin/claude" DISPATCH_RESERVATION_DIR="$GSC_ROOT/reservations" \
+  DISPATCH_SELECTION_LOG_DIR="$GSC_ROOT/seldir" "$GSC_GST" 2>/dev/null)
+assert_eq "graph-select-target: orphan node-id worktree (no session) is selected" "node tactic-fixture tactic implement" "$gsc_sel"
+rm -rf "$GSC_ROOT" "$GSC_BARE"
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results

--- a/packages/intentionsutil/scripts/dump-node.ts
+++ b/packages/intentionsutil/scripts/dump-node.ts
@@ -1,0 +1,98 @@
+// Dumps one or more intention nodes as JSON into a target directory AND writes a
+// base manifest recording, per id, the blob sha of the node file actually read
+// (`git hash-object intentions/<id>.md`). The manifest is the compare-and-swap
+// token `graph-commit --base <manifest>` checks against origin/main before it
+// lands a write, so a stale read fails mechanically rather than by rebase luck
+// (the 2026-07-06 near-miss: a stale dump of a live node avoided a textual
+// conflict and nearly clobbered concurrent phase state).
+//
+// This replaces the ad-hoc per-session `readNode` dump one-liners the align
+// skills used before capturing base state was uniform.
+//
+// The intentions/ directory is resolved from import.meta.url, not cwd, so the
+// store read is always the repo-canonical one — matching write-node.ts.
+//
+// Usage:
+//   npx tsx packages/intentionsutil/scripts/dump-node.ts --out-dir <dir> <id> [<id> ...]
+//
+// For each <id> it writes `<dir>/<id>.json` (the shape `readNode` returns, ready
+// to pipe back into write-node.ts after reconciliation) and appends a
+// `<id>=<blobsha>` line to `<dir>/base-manifest.txt`. It prints the manifest
+// path on stdout so the caller can pass it straight to `graph-commit --base`.
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { readNode } from "../src/store.js";
+
+// --- Paths -----------------------------------------------------------------
+// The script lives at `packages/intentionsutil/scripts/dump-node.ts`, so the
+// repo root is three directories up. Resolve from this file's own location,
+// never from cwd.
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(dirname(dirname(scriptDir)));
+const intentionsDir = join(repoRoot, "intentions");
+
+const USAGE =
+  "usage: dump-node.ts --out-dir <dir> <id> [<id> ...]\n" +
+  "  Writes <dir>/<id>.json for each node and a <dir>/base-manifest.txt of\n" +
+  "  <id>=<blobsha> lines; prints the manifest path for `graph-commit --base`.\n";
+
+// --- Core helper (exported for tests) --------------------------------------
+
+/**
+ * Dump each node in `ids` as JSON into `outDir` and write a base manifest of
+ * `<id>=<blobsha>` lines. `blobsha` is `git hash-object` of the on-disk node
+ * file — i.e. the exact content that was read — so `graph-commit --base` can
+ * refuse the write if origin/main's blob has since moved.
+ *
+ * Returns the absolute manifest path.
+ */
+export function dumpNodes(intentionsDir: string, repoRoot: string, outDir: string, ids: string[]): string {
+  mkdirSync(outDir, { recursive: true });
+  const manifestLines: string[] = [];
+  for (const id of ids) {
+    const node = readNode(intentionsDir, id);
+    writeFileSync(join(outDir, `${id}.json`), `${JSON.stringify(node, null, 2)}\n`);
+    // Blob sha of the file actually read. `git hash-object` is content-only
+    // (no side effects, no index touch), so it is safe from any worktree.
+    const blob = execFileSync("git", ["-C", repoRoot, "hash-object", `intentions/${id}.md`], {
+      encoding: "utf8",
+    }).trim();
+    manifestLines.push(`${id}=${blob}`);
+  }
+  const manifestPath = join(outDir, "base-manifest.txt");
+  writeFileSync(manifestPath, `${manifestLines.join("\n")}\n`);
+  return manifestPath;
+}
+
+// --- Main ------------------------------------------------------------------
+
+function main(): void {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(USAGE);
+    return;
+  }
+
+  const outIdx = args.indexOf("--out-dir");
+  if (outIdx === -1 || !args[outIdx + 1]) {
+    process.stderr.write("dump-node: --out-dir <dir> is required\n" + USAGE);
+    process.exit(1);
+  }
+  const outDir = args[outIdx + 1];
+  const ids = args.filter((a, i) => i !== outIdx && i !== outIdx + 1 && !a.startsWith("-"));
+  if (ids.length === 0) {
+    process.stderr.write("dump-node: at least one node id is required\n" + USAGE);
+    process.exit(1);
+  }
+
+  const manifestPath = dumpNodes(intentionsDir, repoRoot, outDir, ids);
+  process.stdout.write(`${manifestPath}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/packages/intentionsutil/scripts/dump-node.ts
+++ b/packages/intentionsutil/scripts/dump-node.ts
@@ -42,7 +42,7 @@ const USAGE =
 // --- Core helper (exported for tests) --------------------------------------
 
 /**
- * Dump each node in `ids` as JSON into `outDir` and write a base manifest of
+ * Dump each node in `ids` to JSON in `outDir` and write a base manifest of
  * `<id>=<blobsha>` lines. `blobsha` is `git hash-object` of the on-disk node
  * file — i.e. the exact content that was read — so `graph-commit --base` can
  * refuse the write if origin/main's blob has since moved.


### PR DESCRIPTION
Implements the human-session half of the 2026-07-06 concurrency-safety
clarification on `strategy-graph-native-dispatch`: human-invoked
`/align-strategy` and `/align-tactics` sessions now claim their node id,
author in a worktree (never the shared main checkout), and pass a base
manifest through the write path so a stale read is refused mechanically.

Graph-native node: `tactic-align-session-claiming` (serves
`strategy-graph-native-dispatch`).

## Unit 1 — claim-and-isolate step in both align skills

Adds a **Step 0 — Claim and isolate** to `.claude/skills/align-strategy/SKILL.md`
and `.claude/skills/align-tactics/SKILL.md`: resolve the target node id,
stop-and-report if a live session already holds the worktree (no park —
a held claim is not a defect), otherwise author in the node-id worktree.
A doctrine-recording `/align-strategy` round pins the pace curve for its
audit window and restores it after.

## Unit 2 — automatic base manifest through the write path

New `packages/intentionsutil/scripts/dump-node.ts` dumps each node's JSON
plus a base manifest of `<id>=<blobsha>` (of the file actually read);
both align skills' record steps now dump through it and pass the manifest
to `graph-commit --base` so a stale read fails compare-and-swap rather
than by rebase luck.

## Unit 3 — selector claimed-set covers human-created worktrees

`graph-select-target`'s live-session claimed-set gate already covers a
human-created node-id worktree (it is basename-keyed and source-agnostic —
it does not require a router reservation-ledger marker). Adds a hermetic
fixture test asserting a live-session-owned node-id worktree is skipped,
with a negative control (orphan worktree, no session -> selected) that
pins worktree-directory existence alone is not a claim (the forward-derived
claimed-set doctrine) and rules out a daemon-UNKNOWN false pass.

## Verification

- `grep -q 'Claim and isolate'` in both SKILLs; `dump-node.ts --help` and
  a functional dump (manifest blob matches `git hash-object`).
- New Unit 3 tests pass in `test-dispatch-scripts.sh`.
- `run-lint.sh` clean.