### PR TITLE
shared UI packages: router escape + Card keyboard + a11y fixes

### DIFF
--- a/audio/src/style/theme.css
+++ b/audio/src/style/theme.css
@@ -19,9 +19,3 @@
   .content-grid { max-width: none; }
   main { max-inline-size: none; }
 }
-
-.cc-badge {
-  width: 117px;
-  height: 41px;
-  vertical-align: middle;
-}

--- a/budget/src/style/theme.css
+++ b/budget/src/style/theme.css
@@ -540,12 +540,6 @@ svg [aria-label="tip"] text { fill: #222; /* ds-lint-disable-line: Plot tooltip 
   color: var(--error);
 }
 
-.cc-badge {
-  width: 117px;
-  height: 41px;
-  vertical-align: middle;
-}
-
 /* --- Normalized transaction groups --- */
 
 .normalized-originals {

--- a/packages/components/src/autocomplete.ts
+++ b/packages/components/src/autocomplete.ts
@@ -61,6 +61,7 @@ export function showDropdown(input: HTMLInputElement, options: string[], filterO
     const item = document.createElement("div");
     item.className = "autocomplete-item";
     item.setAttribute("role", "option");
+    item.setAttribute("aria-selected", "false");
     item.id = `autocomplete-option-${i}`;
     item.textContent = opt;
     item.addEventListener("mousedown", (e) => {
@@ -72,11 +73,22 @@ export function showDropdown(input: HTMLInputElement, options: string[], filterO
   });
 
   function updateSelection(index: number): void {
-    items.forEach((el) => el.classList.remove("selected"));
+    items.forEach((el) => {
+      el.classList.remove("selected");
+      el.setAttribute("aria-selected", "false");
+    });
     selectedIndex = index;
     if (index >= 0 && index < items.length) {
-      items[index].classList.add("selected");
-      input.setAttribute("aria-activedescendant", items[index].id);
+      const el = items[index];
+      el.classList.add("selected");
+      el.setAttribute("aria-selected", "true");
+      // The list is scrollable; without this the highlight can move below the
+      // fold invisibly once there are more options than fit. Guard the call for
+      // environments (jsdom/happy-dom) that do not implement scrollIntoView.
+      if (typeof el.scrollIntoView === "function") {
+        el.scrollIntoView({ block: "nearest" });
+      }
+      input.setAttribute("aria-activedescendant", el.id);
     } else {
       input.removeAttribute("aria-activedescendant");
     }

--- a/packages/components/src/panel-toggle.ts
+++ b/packages/components/src/panel-toggle.ts
@@ -11,8 +11,16 @@ export function initPanelToggle(
   const { signal } = controller;
 
   const close = (): void => {
+    // Restore focus to the toggle only when focus was inside the closing panel,
+    // so an Escape/outside-click close does not leave focus stranded on a
+    // now-hidden element. Skip when focus already moved elsewhere (e.g. an
+    // outside click landed on another focusable element) to avoid yanking it.
+    const restoreFocus = panel.contains(document.activeElement);
     panel.classList.remove("open");
     toggle.setAttribute("aria-expanded", "false");
+    if (restoreFocus) {
+      toggle.focus();
+    }
   };
 
   toggle.addEventListener(

--- a/packages/ds/base.css
+++ b/packages/ds/base.css
@@ -58,6 +58,17 @@ footer {
   color: var(--text-muted);
 }
 
+/* CC-BY-SA badge in the shared footer (FOOTER_HTML in
+   src/templates/footer.ts). Single source: the badge image is 88x31 intrinsic
+   and must render at its intended 117x41. Apps that import this file via
+   @commons-systems/style/default.css inherit it; standalone stylesheets that
+   do not (e.g. packages/blog) keep their own copy. */
+.cc-badge {
+  width: 117px;
+  height: 41px;
+  vertical-align: middle;
+}
+
 *,
 *::before,
 *::after {

--- a/packages/ds/src/charts/chart-util.ts
+++ b/packages/ds/src/charts/chart-util.ts
@@ -20,7 +20,29 @@ export function mountResponsiveChart(slot: HTMLElement, render: (width: number) 
   const w = slot.clientWidth || FALLBACK_CONTAINER_WIDTH;
   slot.replaceChildren(render(w));
   let last = w;
-  if (typeof ResizeObserver === "undefined") return () => {};
+
+  // The first render can run before the slot is laid out or attached, forcing
+  // the fallback width (640) and fallback theme colors (getThemeFg -> #ddd on a
+  // detached node). The ResizeObserver correction below is gated on a >=1px
+  // delta, so a real slot width coincidentally within 1px of 640 would freeze
+  // the chart on the fallback color forever. Re-measure once after mount,
+  // unconditionally, so the corrective render always runs regardless of the
+  // delta. rAF fires after layout, so clientWidth and getComputedStyle are
+  // accurate by then.
+  let rafId = 0;
+  if (typeof requestAnimationFrame !== "undefined") {
+    rafId = requestAnimationFrame(() => {
+      if (!slot.isConnected) return;
+      const measured = slot.clientWidth || FALLBACK_CONTAINER_WIDTH;
+      last = measured;
+      slot.replaceChildren(render(measured));
+    });
+  }
+  const cancelRaf = () => {
+    if (rafId && typeof cancelAnimationFrame !== "undefined") cancelAnimationFrame(rafId);
+  };
+
+  if (typeof ResizeObserver === "undefined") return cancelRaf;
   const obs = new ResizeObserver((entries) => {
     if (!slot.isConnected) {
       obs.disconnect();
@@ -34,7 +56,10 @@ export function mountResponsiveChart(slot: HTMLElement, render: (width: number) 
     }
   });
   obs.observe(slot);
-  return () => obs.disconnect();
+  return () => {
+    cancelRaf();
+    obs.disconnect();
+  };
 }
 
 /** Reads a trimmed CSS custom property off `container` (or a provided computed style). */

--- a/packages/ds/src/core/Card.tsx
+++ b/packages/ds/src/core/Card.tsx
@@ -1,4 +1,9 @@
-import type { CSSProperties, ElementType, HTMLAttributes } from "react";
+import type {
+  CSSProperties,
+  ElementType,
+  HTMLAttributes,
+  KeyboardEventHandler,
+} from "react";
 
 export interface CardProps extends HTMLAttributes<HTMLElement> {
   as?: ElementType;
@@ -13,7 +18,12 @@ export function Card(props: CardProps) {
   // Accessibility/safety defaults applied to the rendered element, each only
   // when the consumer did not already supply it. Kept in a separate object
   // because `type` is not part of HTMLAttributes<HTMLElement>.
-  const extraProps: { type?: "button"; tabIndex?: number; role?: string } = {};
+  const extraProps: {
+    type?: "button";
+    tabIndex?: number;
+    role?: string;
+    onKeyDown?: KeyboardEventHandler<HTMLElement>;
+  } = {};
 
   // A bare <button> defaults to type="submit", which submits an enclosing
   // form on click. Default it to "button" unless the consumer set a type.
@@ -38,6 +48,18 @@ export function Card(props: CardProps) {
     }
     if (rest.role === undefined) {
       extraProps.role = "button";
+    }
+    // A div with role="button" + tabIndex does not activate on Enter/Space the
+    // way a native button does. Synthesize a keydown handler that dispatches a
+    // click so the onClick handler runs for keyboard users. Respect a
+    // consumer-supplied onKeyDown.
+    if (rest.onKeyDown === undefined) {
+      extraProps.onKeyDown = (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          e.currentTarget.click();
+        }
+      };
     }
   }
 

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -90,7 +90,12 @@ function createNavigator(
         const message =
           options?.formatError?.(error) ??
           "Something went wrong. Please try again.";
-        outlet.innerHTML = `<p>${message}</p>`;
+        // Assign via textContent, not innerHTML: formatError output is
+        // app-supplied and may carry attacker-influenced text, which would
+        // otherwise execute as markup (XSS sink).
+        const p = document.createElement("p");
+        p.textContent = message;
+        outlet.replaceChildren(p);
       }
     }
   }

--- a/print/src/style/theme.css
+++ b/print/src/style/theme.css
@@ -9,12 +9,6 @@
   color-scheme: dark;
 }
 
-.cc-badge {
-  width: 117px;
-  height: 41px;
-  vertical-align: middle;
-}
-
 /* Media list */
 #media-list {
   list-style: none;


### PR DESCRIPTION
Implements the tactic-shared-ui-correctness plan: a cluster of shared UI-package correctness/a11y defects surfaced by the 2026-07-05 review.

## Units

1. **router error output escaping (XSS)** — `packages/router/src/index.ts`: the render-error path assigned app-supplied `formatError(error)` output via `innerHTML` unescaped. Now builds a `<p>`, sets `textContent`, and `replaceChildren`.
2. **interactive Card keyboard handler** — `packages/ds/src/core/Card.tsx`: an interactive Card set `role=button` + `tabIndex=0` on a div with no `onKeyDown`, so Enter/Space did nothing. Added a keydown handler that dispatches a click, respecting a consumer-supplied `onKeyDown`. This is the reference pattern consumers copy (OfficeHours template).
3. **autocomplete + panel-toggle a11y** — `packages/components/src/autocomplete.ts`: `updateSelection` now `scrollIntoView`s the highlight and toggles `aria-selected` on `role=option` items. `packages/components/src/panel-toggle.ts`: `close()` restores focus to the toggle when focus was inside the closing panel.
4. **ds footer badge styling** — `packages/ds/base.css`: added the `.cc-badge` rule as the single source. Apps importing it via `@commons-systems/style/default.css` (budget, print, audio, office-hours) now inherit it, so per-app duplicate copies removed from budget/print/audio. `packages/blog` keeps its own copy (standalone stylesheet, no ds import; also serves landing). Fixes office-hours' footer badge rendering unstyled at intrinsic 88×31.
5. **BudgetPaceChart fallback freeze** — `packages/ds/src/charts/chart-util.ts`: `mountResponsiveChart` now schedules an unconditional rAF remeasure after mount, so a real slot width within 1px of the 640 fallback no longer freezes the chart on near-invisible `#ddd` fallback color. Hardening ahead of use (no current prod consumer).

## Verification

- `npx vitest run --project packages/router --project packages/ds --project packages/components --root .` — 209 pass
- `run-typecheck.sh --app packages/router --app packages/ds --app packages/components` — pass
- `run-lint.sh` — pass (including ds-drift)

Graph-native tactic node; not filed as a GitHub issue.