### PR TITLE
budget-etl: accept overlapping same-month balance anchors (keep latest as-of)

### DIFF
--- a/projects/budget-etl/pipeline.go
+++ b/projects/budget-etl/pipeline.go
@@ -58,39 +58,83 @@ func parseStatementDir(dir string, disc parse.DiscoverOpts) (parsed []parsedFile
 }
 
 // dedupStatementData deduplicates a slice of StatementData by StatementID,
-// preserving first-seen order. When two entries share a StatementID but have
-// different Balance values, it returns an error naming both source files and
-// balances so the caller can surface a clear failure rather than emitting
-// conflicting records. Equal-balance duplicates are silently dropped.
+// preserving first-seen order. Equal-balance duplicates are silently dropped.
+//
+// When two entries share a StatementID but disagree on Balance, they are
+// overlapping observations of the same account-month anchor. The collision is
+// resolved by as-of date (BalanceDate): the later observation is kept and a
+// single reconciliation line naming both source files, both balances, and the
+// delta is logged (log output stays on the operator's machine, so amounts are
+// fine there). A nil BalanceDate loses to a non-nil one. When there is no basis
+// to choose — both BalanceDate nil, or the same instant — the disagreement
+// stays an error naming both source files and balances. When a later entry
+// replaces an earlier survivor it takes the earlier entry's output position, so
+// first-seen order is preserved.
 func dedupStatementData(stmts []budget.StatementData) ([]budget.StatementData, error) {
-	seen := make(map[string]budget.StatementData, len(stmts))
+	idx := make(map[string]int, len(stmts)) // StatementID -> index into out
 	out := make([]budget.StatementData, 0, len(stmts))
 	for _, s := range stmts {
-		prior, dup := seen[s.StatementID]
+		pos, dup := idx[s.StatementID]
 		if !dup {
-			seen[s.StatementID] = s
+			idx[s.StatementID] = len(out)
 			out = append(out, s)
 			continue
 		}
+		prior := out[pos]
 		if s.Balance == prior.Balance {
 			continue
 		}
-		srcA := prior.SourceFile
-		if srcA == "" {
-			srcA = "<derived>"
+		srcA := srcOrDerived(prior.SourceFile)
+		srcB := srcOrDerived(s.SourceFile)
+		winner, ok := laterAnchor(prior, s)
+		if !ok {
+			return nil, fmt.Errorf(
+				"statement %q: balance disagreement between %s ($%.2f) and %s ($%.2f)",
+				s.StatementID,
+				srcA, budget.DollarAmount(prior.Balance),
+				srcB, budget.DollarAmount(s.Balance),
+			)
 		}
-		srcB := s.SourceFile
-		if srcB == "" {
-			srcB = "<derived>"
-		}
-		return nil, fmt.Errorf(
-			"statement %q: balance disagreement between %s ($%.2f) and %s ($%.2f)",
+		log.Printf(
+			"statement %q: reconciling overlapping balance anchors by as-of date — %s ($%.2f) vs %s ($%.2f), delta $%.2f; keeping the later observation",
 			s.StatementID,
 			srcA, budget.DollarAmount(prior.Balance),
 			srcB, budget.DollarAmount(s.Balance),
+			budget.DollarAmount(s.Balance-prior.Balance),
 		)
+		out[pos] = winner
 	}
 	return out, nil
+}
+
+// srcOrDerived renders a StatementData.SourceFile for log/error messages,
+// substituting a placeholder for the empty path of an ETL-synthesized anchor.
+func srcOrDerived(src string) string {
+	if src == "" {
+		return "<derived>"
+	}
+	return src
+}
+
+// laterAnchor chooses between two same-statement anchors that disagree on
+// Balance by their as-of date (BalanceDate): the later observation wins, and a
+// nil BalanceDate loses to a non-nil one. ok is false when there is no basis to
+// choose — both BalanceDate nil, or the same instant.
+func laterAnchor(a, b budget.StatementData) (winner budget.StatementData, ok bool) {
+	switch {
+	case a.BalanceDate == nil && b.BalanceDate == nil:
+		return budget.StatementData{}, false
+	case a.BalanceDate == nil:
+		return b, true
+	case b.BalanceDate == nil:
+		return a, true
+	case b.BalanceDate.After(*a.BalanceDate):
+		return b, true
+	case a.BalanceDate.After(*b.BalanceDate):
+		return a, true
+	default: // identical instant — no basis to choose
+		return budget.StatementData{}, false
+	}
 }
 
 // buildTransactions iterates parsed files and deduplicates transactions by

--- a/projects/budget-etl/pipeline_test.go
+++ b/projects/budget-etl/pipeline_test.go
@@ -216,6 +216,18 @@ func TestParseStatementDir_DiscoverError(t *testing.T) {
 	}
 }
 
+// asOf parses a YYYY-MM-DD date into a *time.Time for a StatementData
+// BalanceDate in the dedup table tests. Callers pass identical date strings to
+// get equal instants (reflect.DeepEqual on the *time.Time compares by value).
+func asOf(t *testing.T, date string) *time.Time {
+	t.Helper()
+	parsed, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		t.Fatalf("asOf: parsing %q: %v", date, err)
+	}
+	return &parsed
+}
+
 func TestDedupStatementData(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -312,6 +324,88 @@ func TestDedupStatementData(t *testing.T) {
 				"bank/acct/2025-02/c.ofx",
 				"30.00",
 				"99.99",
+			},
+		},
+		{
+			name: "disagree, later as-of arrives second — later observation replaces earlier in place",
+			input: []budget.StatementData{
+				{StatementID: "STMT-6", Balance: 1000, BalanceDate: asOf(t, "2025-01-15"), SourceFile: "bank/acct/2025-01/early.ofx"},
+				{StatementID: "STMT-6", Balance: 1200, BalanceDate: asOf(t, "2025-01-28"), SourceFile: "bank/acct/2025-01/late.ofx"},
+			},
+			wantOut: []budget.StatementData{
+				{StatementID: "STMT-6", Balance: 1200, BalanceDate: asOf(t, "2025-01-28"), SourceFile: "bank/acct/2025-01/late.ofx"},
+			},
+		},
+		{
+			name: "disagree, later as-of arrives first — earlier survivor kept",
+			input: []budget.StatementData{
+				{StatementID: "STMT-7", Balance: 1200, BalanceDate: asOf(t, "2025-01-28"), SourceFile: "bank/acct/2025-01/late.ofx"},
+				{StatementID: "STMT-7", Balance: 1000, BalanceDate: asOf(t, "2025-01-15"), SourceFile: "bank/acct/2025-01/early.ofx"},
+			},
+			wantOut: []budget.StatementData{
+				{StatementID: "STMT-7", Balance: 1200, BalanceDate: asOf(t, "2025-01-28"), SourceFile: "bank/acct/2025-01/late.ofx"},
+			},
+		},
+		{
+			name: "disagree, prior has nil BalanceDate — set as-of wins",
+			input: []budget.StatementData{
+				{StatementID: "STMT-8", Balance: 1000, SourceFile: "bank/acct/2025-01/undated.ofx"},
+				{StatementID: "STMT-8", Balance: 1300, BalanceDate: asOf(t, "2025-01-20"), SourceFile: "bank/acct/2025-01/dated.ofx"},
+			},
+			wantOut: []budget.StatementData{
+				{StatementID: "STMT-8", Balance: 1300, BalanceDate: asOf(t, "2025-01-20"), SourceFile: "bank/acct/2025-01/dated.ofx"},
+			},
+		},
+		{
+			name: "disagree, later entry has nil BalanceDate — set as-of survivor kept",
+			input: []budget.StatementData{
+				{StatementID: "STMT-9", Balance: 1300, BalanceDate: asOf(t, "2025-01-20"), SourceFile: "bank/acct/2025-01/dated.ofx"},
+				{StatementID: "STMT-9", Balance: 1000, SourceFile: "bank/acct/2025-01/undated.ofx"},
+			},
+			wantOut: []budget.StatementData{
+				{StatementID: "STMT-9", Balance: 1300, BalanceDate: asOf(t, "2025-01-20"), SourceFile: "bank/acct/2025-01/dated.ofx"},
+			},
+		},
+		{
+			name: "disagree, both BalanceDate nil — still an error",
+			input: []budget.StatementData{
+				{StatementID: "STMT-10", Balance: 1000, SourceFile: "bank/acct/2025-01/a.ofx"},
+				{StatementID: "STMT-10", Balance: 2000, SourceFile: "bank/acct/2025-01/b.ofx"},
+			},
+			wantErr: true,
+			wantErrSubstrs: []string{
+				"STMT-10",
+				"bank/acct/2025-01/a.ofx",
+				"bank/acct/2025-01/b.ofx",
+				"10.00",
+				"20.00",
+			},
+		},
+		{
+			name: "disagree, identical as-of instant — still an error",
+			input: []budget.StatementData{
+				{StatementID: "STMT-11", Balance: 1000, BalanceDate: asOf(t, "2025-01-31"), SourceFile: "bank/acct/2025-01/a.ofx"},
+				{StatementID: "STMT-11", Balance: 2000, BalanceDate: asOf(t, "2025-01-31"), SourceFile: "bank/acct/2025-01/b.ofx"},
+			},
+			wantErr: true,
+			wantErrSubstrs: []string{
+				"STMT-11",
+				"bank/acct/2025-01/a.ofx",
+				"bank/acct/2025-01/b.ofx",
+				"10.00",
+				"20.00",
+			},
+		},
+		{
+			name: "reconciled replacement preserves surrounding first-seen order",
+			input: []budget.StatementData{
+				{StatementID: "STMT-P", Balance: 1000, BalanceDate: asOf(t, "2025-01-10"), SourceFile: "bank/acct/2025-01/p-early.ofx"},
+				{StatementID: "STMT-Q", Balance: 2000, SourceFile: "bank/acct/2025-01/q.ofx"},
+				{StatementID: "STMT-P", Balance: 1500, BalanceDate: asOf(t, "2025-01-25"), SourceFile: "bank/acct/2025-01/p-late.ofx"},
+			},
+			wantOut: []budget.StatementData{
+				{StatementID: "STMT-P", Balance: 1500, BalanceDate: asOf(t, "2025-01-25"), SourceFile: "bank/acct/2025-01/p-late.ofx"},
+				{StatementID: "STMT-Q", Balance: 2000, SourceFile: "bank/acct/2025-01/q.ofx"},
 			},
 		},
 	}


### PR DESCRIPTION
## Context

Graph tactic `tactic-budget-overlap-anchor-merge`, serving `strategy-recover-finance`.

`dedupStatementData` (projects/budget-etl/pipeline.go) hard-errored when two statements shared a StatementID (`{institution}-{account}-{YYYY-MM}`) with different balances. The 2026-07 monthly sync failed on mutually consistent overlapping exports. Per strategy clarification 2, overlapping evidence is surfaced, not gated.

## Change

When two same-StatementID entries disagree on Balance:
- Keep the entry with the later `BalanceDate` (as-of); a nil `BalanceDate` loses to a non-nil one.
- Log one reconciliation line naming both source files, both balances, and the delta (operator's machine — amounts fine there).
- Both-nil or identical-instant disagreements stay an error (no basis to choose).
- First-seen output order preserved; a later replacement takes the earlier survivor's position.

Equal-balance duplicate drop and caller signatures unchanged.

## Verification

```
go -C projects/budget-etl test ./...
```

Extended `TestDedupStatementData` with: later as-of arrives second (replacement), later as-of arrives first (kept), nil-vs-set BalanceDate (both orders), both-nil still errors, identical-instant still errors, order preservation across a reconciled replacement.