### PR TITLE
graph: grounding gap sensor (tactic-grounding-gap-analysis)

### DIFF
--- a/packages/intentionsutil/scripts/grounding-gap.ts
+++ b/packages/intentionsutil/scripts/grounding-gap.ts
@@ -1,0 +1,51 @@
+// Grounding gap sensor CLI — loads every node with listNodes, runs
+// analyzeGrounding, and prints the durable-layer census plus the unmarked
+// nodes ranked by deference/capture exposure. This is a SENSOR, not a gate:
+// it always exits 0 (a reported gap is the expected initial state of
+// strategy-complete-grounding, not an error).
+//
+// Usage:
+//   npx tsx packages/intentionsutil/scripts/grounding-gap.ts [intentionsDir] [--json]
+//
+// Defaults to `intentions` (relative to cwd) when no directory is given.
+// `--json` emits the whole GroundingReport as one JSON object for tooling
+// (the worker consumes this ranking at tick).
+
+import { listNodes } from "../src/store.js";
+import { analyzeGrounding, type GroundingReport } from "../src/grounding.js";
+
+function parseArgs(argv: string[]): { dir: string; json: boolean } {
+  let dir: string | undefined;
+  let json = false;
+  for (const arg of argv) {
+    if (arg === "--json") {
+      json = true;
+    } else if (dir === undefined) {
+      dir = arg;
+    }
+  }
+  return { dir: dir ?? "intentions", json };
+}
+
+function renderHuman(report: GroundingReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `durable-layer: ${report.durableTotal} nodes — ` +
+      `marked-by-traditions ${report.markedByTraditions}, ` +
+      `marked-by-grounding ${report.markedByGrounding}, ` +
+      `unmarked ${report.unmarked}`,
+  );
+  for (const r of report.ranked) {
+    lines.push(`${r.rank}. [${r.kind}] ${r.id} — exposure ${r.exposure} (${r.factors})`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+function main(): void {
+  const { dir, json } = parseArgs(process.argv.slice(2));
+  const nodes = listNodes(dir);
+  const report = analyzeGrounding(nodes);
+  process.stdout.write(json ? JSON.stringify(report) + "\n" : renderHuman(report));
+}
+
+main();

--- a/packages/intentionsutil/src/grounding.ts
+++ b/packages/intentionsutil/src/grounding.ts
@@ -1,0 +1,303 @@
+// Grounding gap analysis — the sensor behind strategy-complete-grounding's
+// success signal ("the tick gap analysis reports zero unmarked durable-layer
+// nodes"). Pure functions over IntentionNode[]: enumerate the durable layer,
+// partition marked vs unmarked, and rank the unmarked by deference/capture
+// exposure so a worker can consume the ranking at tick.
+//
+// The marking convention (strategy-complete-grounding clarifications 1 and 5;
+// kind-tradition's grounding clarification):
+//
+//   - Durable layer = nodes whose `kind` is one of virtue, strategy, kind,
+//     delegation. Tactics inherit grounding through the strategy they serve,
+//     and `tradition-*` records ARE the grounding, so both are exempt.
+//   - A durable-layer node is MARKED when its `attributes` carry a
+//     `traditions` list (tradition-* ids) or a `grounding` string
+//     ("circumstantial: <why>" / "none-found: <date>"). Neither present =
+//     unmarked, the gap this sensor reports.
+//
+// This module never WRITES marks (strategy clarification 4 — marks are
+// author-side); it only reads the graph and reports.
+
+import type { IntentionNode } from "./schema.js";
+
+// --- Durable-layer membership ------------------------------------------------
+
+/** The kinds that must carry grounding; tactics and traditions are exempt. */
+export const DURABLE_KINDS: ReadonlySet<string> = new Set([
+  "virtue",
+  "strategy",
+  "kind",
+  "delegation",
+]);
+
+/** Whether a node belongs to the audited durable layer. */
+export function isDurable(node: IntentionNode): boolean {
+  return DURABLE_KINDS.has(node.kind);
+}
+
+// --- Mark detection ----------------------------------------------------------
+// `attributes` is a free-form kind-specific map (Record<string, unknown>), not
+// schema-typed. The mark is the mere PRESENCE of an own `traditions` or
+// `grounding` key — an author who has considered the node's grounding writes
+// one of them (even `"none-found: <date>"` counts). Absence = unconsidered.
+
+function hasOwn(obj: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+/** Whether the node carries an `attributes.traditions` mark. */
+export function hasTraditionsMark(node: IntentionNode): boolean {
+  return hasOwn(node.attributes, "traditions");
+}
+
+/** Whether the node carries an `attributes.grounding` mark. */
+export function hasGroundingMark(node: IntentionNode): boolean {
+  return hasOwn(node.attributes, "grounding");
+}
+
+/** Whether the node is marked by either convention. */
+export function isMarked(node: IntentionNode): boolean {
+  return hasTraditionsMark(node) || hasGroundingMark(node);
+}
+
+// --- Capture-axis scoring (delegation nodes) ---------------------------------
+// Reads the two capture axes off a delegation's freeform attributes, in the
+// same spirit as src/attention.ts's capture term: a missing/malformed axis
+// scores 0 (boundary validation, not a fallback — attributes shape is data,
+// not a code contract). Token/prefix matching, not exact-match, so the store's
+// real compound values ("low-moderate", "partially — ...") parse to real
+// intent instead of silently zeroing.
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Divergence severity of a delegation, ranked high > moderate > low-moderate >
+ * low (strategy plan: parse the leading token of the free-text level). A
+ * compound value is dispatched on its leading severity band, with
+ * `low-moderate` checked before the bare `low` prefix it shares. Unrecognized
+ * or absent → 0.
+ */
+export function divergenceRank(delegation: IntentionNode): number {
+  const divergence = delegation.attributes.divergence;
+  if (!isPlainObject(divergence)) return 0;
+  const level = divergence.level;
+  if (typeof level !== "string") return 0;
+  const t = level.trim().toLowerCase();
+  if (t.startsWith("high")) return 4;
+  if (t.startsWith("moderate")) return 3;
+  if (t.startsWith("low-moderate") || t.startsWith("low moderate")) return 2;
+  if (t.startsWith("low")) return 1;
+  return 0;
+}
+
+/**
+ * Irreversibility of a delegation from `attributes.irreversibility.gated`: a
+ * string beginning `true` outranks one beginning `false`; a present, non-empty
+ * middle-ground string ("partially — ...") sits between; absent/malformed → 0
+ * (mirrors src/attention.ts's `irreversibilityScore`).
+ */
+export function gatedRank(delegation: IntentionNode): number {
+  const irreversibility = delegation.attributes.irreversibility;
+  if (!isPlainObject(irreversibility)) return 0;
+  const gated = irreversibility.gated;
+  if (typeof gated !== "string") return 0;
+  const g = gated.trim().toLowerCase();
+  if (g === "") return 0;
+  if (g.startsWith("true")) return 3;
+  if (g.startsWith("false")) return 1;
+  return 2;
+}
+
+/**
+ * A delegation's own capture exposure. Divergence dominates gating: a one-step
+ * divergence difference (weight 10) always outranks any gating difference
+ * (0..3), so the ordering guarantee "delegation-divergence dominance" holds.
+ */
+export function delegationScore(delegation: IntentionNode): number {
+  return divergenceRank(delegation) * 10 + gatedRank(delegation);
+}
+
+// --- Recovers-proximity (non-delegation durable nodes) -----------------------
+
+// A non-delegation durable node's exposure is inherited from the nearest
+// delegation reachable over serves/recovers edges (either direction), decaying
+// with hop distance. Delegations sit in their own band strictly above every
+// non-delegation (DELEGATION_BAND), so category 1 (delegations) always ranks
+// above category 2 (non-delegations), per the strategy plan.
+const DELEGATION_BAND = 1000;
+
+interface Proximity {
+  /** Nearest-delegation base score (max across delegations at the nearest hop). */
+  base: number;
+  /** Hop distance to the nearest delegation, or null if none reachable. */
+  hops: number | null;
+  /** The nearest delegation id (lowest id among the max-score set), for reporting. */
+  nearest: string | null;
+}
+
+/**
+ * BFS over the undirected serves/recovers graph from `start` to the nearest
+ * delegation node. Returns the hop distance, the max delegationScore among the
+ * delegations found at that nearest hop, and one representative id. No
+ * delegation reachable → { base: 0, hops: null, nearest: null }.
+ */
+function nearestDelegation(
+  start: IntentionNode,
+  byId: Map<string, IntentionNode>,
+  adjacency: Map<string, Set<string>>,
+): Proximity {
+  const visited = new Set<string>([start.id]);
+  let frontier: string[] = [start.id];
+  let hops = 0;
+  while (frontier.length > 0) {
+    // Collect delegations discovered at this BFS level.
+    const delegationsHere: IntentionNode[] = [];
+    for (const id of frontier) {
+      const node = byId.get(id);
+      // The start node is non-delegation by construction, so hop 0 yields none.
+      if (node !== undefined && node.kind === "delegation") delegationsHere.push(node);
+    }
+    if (delegationsHere.length > 0) {
+      let base = -1;
+      let nearest: string | null = null;
+      // Max score; ties broken by lowest id for a deterministic representative.
+      for (const d of [...delegationsHere].sort((a, b) => (a.id < b.id ? -1 : 1))) {
+        const score = delegationScore(d);
+        if (score > base) {
+          base = score;
+          nearest = d.id;
+        }
+      }
+      return { base, hops, nearest };
+    }
+    const next: string[] = [];
+    for (const id of frontier) {
+      for (const neighbor of adjacency.get(id) ?? []) {
+        if (!visited.has(neighbor)) {
+          visited.add(neighbor);
+          next.push(neighbor);
+        }
+      }
+    }
+    frontier = next;
+    hops += 1;
+  }
+  return { base: 0, hops: null, nearest: null };
+}
+
+/** Build the undirected serves/recovers adjacency over existing node ids. */
+function buildAdjacency(nodes: IntentionNode[], byId: Map<string, IntentionNode>): Map<string, Set<string>> {
+  const adjacency = new Map<string, Set<string>>();
+  const link = (a: string, b: string): void => {
+    let set = adjacency.get(a);
+    if (set === undefined) {
+      set = new Set<string>();
+      adjacency.set(a, set);
+    }
+    set.add(b);
+  };
+  for (const node of nodes) {
+    for (const target of [...node.serves, ...node.recovers]) {
+      if (byId.has(target)) {
+        link(node.id, target);
+        link(target, node.id);
+      }
+    }
+  }
+  return adjacency;
+}
+
+// --- Tie-breaks --------------------------------------------------------------
+// At equal exposure: virtue outranks kind outranks strategy (2026-07-07
+// interview: "virtue roots outrank strategies at equal exposure"), then id
+// ascending for determinism. Delegations sit in their own band and never tie
+// with these three.
+const KIND_TIE_RANK: Record<string, number> = { virtue: 3, kind: 2, strategy: 1, delegation: 0 };
+
+// --- Report ------------------------------------------------------------------
+
+/** One unmarked durable-layer node in the ranking, with its exposure factors. */
+export interface RankedUnmarked {
+  rank: number;
+  id: string;
+  kind: string;
+  exposure: number;
+  /** Human-readable exposure factors, e.g. "divergence=high gated=true" or "nearest=delegation-x hops=2". */
+  factors: string;
+}
+
+/** The full grounding gap report. */
+export interface GroundingReport {
+  durableTotal: number;
+  markedByTraditions: number;
+  markedByGrounding: number;
+  unmarked: number;
+  ranked: RankedUnmarked[];
+}
+
+/**
+ * Analyze the graph's grounding coverage: durable-layer census, mark
+ * partition, and the unmarked nodes ranked by deference/capture exposure
+ * (descending). Pure and deterministic.
+ */
+export function analyzeGrounding(nodes: IntentionNode[]): GroundingReport {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const durable = nodes.filter(isDurable);
+
+  const markedByTraditions = durable.filter(hasTraditionsMark).length;
+  const markedByGrounding = durable.filter(hasGroundingMark).length;
+  const unmarkedNodes = durable.filter((n) => !isMarked(n));
+
+  const adjacency = buildAdjacency(nodes, byId);
+
+  interface Scored {
+    node: IntentionNode;
+    exposure: number;
+    factors: string;
+  }
+
+  const scored: Scored[] = unmarkedNodes.map((node) => {
+    if (node.kind === "delegation") {
+      const dScore = delegationScore(node);
+      return {
+        node,
+        exposure: DELEGATION_BAND + dScore,
+        factors: `divergence=${divergenceRank(node)} gated=${gatedRank(node)}`,
+      };
+    }
+    const { base, hops, nearest } = nearestDelegation(node, byId, adjacency);
+    // Fewer hops = higher exposure; inherit the delegation's own score as base.
+    const exposure = hops === null ? 0 : base / (hops + 1);
+    const factors =
+      hops === null
+        ? "no-delegation-reachable"
+        : `nearest=${nearest} hops=${hops} base=${base}`;
+    return { node, exposure, factors };
+  });
+
+  scored.sort((a, b) => {
+    if (a.exposure !== b.exposure) return b.exposure - a.exposure;
+    const ka = KIND_TIE_RANK[a.node.kind] ?? -1;
+    const kb = KIND_TIE_RANK[b.node.kind] ?? -1;
+    if (ka !== kb) return kb - ka;
+    return a.node.id < b.node.id ? -1 : a.node.id > b.node.id ? 1 : 0;
+  });
+
+  const ranked: RankedUnmarked[] = scored.map((s, i) => ({
+    rank: i + 1,
+    id: s.node.id,
+    kind: s.node.kind,
+    exposure: s.exposure,
+    factors: s.factors,
+  }));
+
+  return {
+    durableTotal: durable.length,
+    markedByTraditions,
+    markedByGrounding,
+    unmarked: unmarkedNodes.length,
+    ranked,
+  };
+}

--- a/packages/intentionsutil/test/grounding.test.ts
+++ b/packages/intentionsutil/test/grounding.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import type { IntentionNode } from "../src/schema.js";
+import { analyzeGrounding } from "../src/grounding.js";
+
+/** Build a full IntentionNode fixture, filling required/default fields. */
+function anode(partial: Partial<IntentionNode> & { id: string; kind: string }): IntentionNode {
+  return {
+    id: partial.id,
+    kind: partial.kind,
+    statement: partial.statement ?? `Statement for ${partial.id}`,
+    owner: partial.owner ?? "human",
+    status: partial.status ?? "codified",
+    parent: partial.parent ?? null,
+    serves: partial.serves ?? [],
+    recovers: partial.recovers ?? [],
+    rationale: partial.rationale ?? null,
+    reading: partial.reading ?? null,
+    gap: partial.gap ?? null,
+    clarifications: partial.clarifications ?? [],
+    tooling_goals: partial.tooling_goals ?? [],
+    success_signal: partial.success_signal ?? null,
+    attention: partial.attention ?? null,
+    phase: partial.phase ?? null,
+    execution: partial.execution ?? null,
+    validates: partial.validates ?? [],
+    blocked_by: partial.blocked_by ?? [],
+    office_hours: partial.office_hours ?? null,
+    pace_exempt: partial.pace_exempt ?? false,
+    rounds: partial.rounds ?? null,
+    attributes: partial.attributes ?? {},
+  };
+}
+
+/**
+ * A fixture graph exercising every ordering guarantee.
+ *
+ *   - Three delegations of descending divergence: high > moderate > low.
+ *   - `strategy-hub` recovers the moderate delegation and serves three
+ *     non-delegation nodes, putting each of them two hops from that delegation
+ *     over the undirected serves/recovers graph (strategy-hub itself is one
+ *     hop). virtue-v, strategy-tie-a, strategy-tie-b thus share one exposure
+ *     score, exercising the virtue-over-strategy and id tie-breaks.
+ *   - `tactic-*` and `tradition-*` are outside the durable layer.
+ *   - `strategy-marked-traditions` and `virtue-marked-grounding` carry marks
+ *     and must be excluded.
+ */
+function fixture(): IntentionNode[] {
+  return [
+    anode({ id: "delegation-high", kind: "delegation", attributes: { divergence: { level: "high" } } }),
+    anode({ id: "delegation-mid", kind: "delegation", attributes: { divergence: { level: "moderate" } } }),
+    anode({ id: "delegation-low", kind: "delegation", attributes: { divergence: { level: "low" } } }),
+    anode({
+      id: "strategy-hub",
+      kind: "strategy",
+      recovers: ["delegation-mid"],
+      serves: ["virtue-v", "strategy-tie-a", "strategy-tie-b"],
+    }),
+    anode({ id: "virtue-v", kind: "virtue" }),
+    anode({ id: "strategy-tie-a", kind: "strategy" }),
+    anode({ id: "strategy-tie-b", kind: "strategy" }),
+    anode({ id: "tactic-t", kind: "tactic", serves: ["strategy-hub"] }),
+    anode({ id: "tradition-x", kind: "tradition" }),
+    anode({
+      id: "strategy-marked-traditions",
+      kind: "strategy",
+      attributes: { traditions: ["tradition-x"] },
+    }),
+    anode({
+      id: "virtue-marked-grounding",
+      kind: "virtue",
+      attributes: { grounding: "none-found: 2026-01-01" },
+    }),
+  ];
+}
+
+const rankedIds = (nodes: IntentionNode[]): string[] =>
+  analyzeGrounding(nodes).ranked.map((r) => r.id);
+
+const indexOf = (ids: string[], id: string): number => ids.indexOf(id);
+
+describe("analyzeGrounding", () => {
+  it("(a) excludes tactic and tradition kinds from the report", () => {
+    const ids = rankedIds(fixture());
+    expect(ids).not.toContain("tactic-t");
+    expect(ids).not.toContain("tradition-x");
+  });
+
+  it("(b) excludes nodes marked by attributes.traditions or attributes.grounding", () => {
+    const ids = rankedIds(fixture());
+    expect(ids).not.toContain("strategy-marked-traditions");
+    expect(ids).not.toContain("virtue-marked-grounding");
+  });
+
+  it("(c) ranks a high-divergence delegation above a low-divergence one", () => {
+    const ids = rankedIds(fixture());
+    expect(indexOf(ids, "delegation-high")).toBeLessThan(indexOf(ids, "delegation-low"));
+  });
+
+  it("(c') ranks every delegation above every non-delegation", () => {
+    const report = analyzeGrounding(fixture());
+    const worstDelegation = Math.max(
+      ...report.ranked.filter((r) => r.kind === "delegation").map((r) => r.rank),
+    );
+    const bestNonDelegation = Math.min(
+      ...report.ranked.filter((r) => r.kind !== "delegation").map((r) => r.rank),
+    );
+    expect(worstDelegation).toBeLessThan(bestNonDelegation);
+  });
+
+  it("(d) ranks an unmarked virtue above an unmarked strategy at equal proximity", () => {
+    const ids = rankedIds(fixture());
+    expect(indexOf(ids, "virtue-v")).toBeLessThan(indexOf(ids, "strategy-tie-a"));
+  });
+
+  it("(e) is deterministic: id ascending breaks ties, order independent of input order", () => {
+    const ids = rankedIds(fixture());
+    // Two same-kind, same-exposure strategies: lower id first.
+    expect(indexOf(ids, "strategy-tie-a")).toBeLessThan(indexOf(ids, "strategy-tie-b"));
+
+    // Shuffling the input must not change the ranking.
+    const shuffled = [...fixture()].reverse();
+    expect(rankedIds(shuffled)).toEqual(ids);
+  });
+
+  it("(f) reports counts matching the fixture, and the report is JSON round-trippable", () => {
+    const report = analyzeGrounding(fixture());
+    // durable = 3 delegation + 4 strategy + 2 virtue = 9; tactic/tradition excluded.
+    expect(report.durableTotal).toBe(9);
+    expect(report.markedByTraditions).toBe(1);
+    expect(report.markedByGrounding).toBe(1);
+    expect(report.unmarked).toBe(7);
+    expect(report.ranked).toHaveLength(7);
+
+    const roundTripped = JSON.parse(JSON.stringify(report));
+    expect(roundTripped.durableTotal).toBe(report.durableTotal);
+    expect(roundTripped.unmarked).toBe(report.unmarked);
+    expect(roundTripped.ranked.map((r: { id: string }) => r.id)).toEqual(
+      report.ranked.map((r) => r.id),
+    );
+  });
+});


### PR DESCRIPTION
Graph-native tactic **tactic-grounding-gap-analysis** — builds `strategy-complete-grounding`'s success-signal instrument.

`strategy-complete-grounding`'s success signal is "the tick gap analysis reports zero unmarked durable-layer nodes"; its sensor is "worker gap analysis at tick". This PR builds that sensor.

## Units
- **Unit 1** — `packages/intentionsutil/src/grounding.ts` (pure `analyzeGrounding`) + `packages/intentionsutil/scripts/grounding-gap.ts` (sensor CLI, human + `--json`, always exit 0).
- **Unit 2** — `packages/intentionsutil/test/grounding.test.ts` pinning the ordering guarantees (delegation-divergence dominance, recovers-proximity, virtue-over-strategy tie-break, id determinism) and the census/`--json` counts.
- **Unit 3** (graph write, landed separately via `graph-commit`) — the first reading `gap analysis 2026-07-10: 75 unmarked durable-layer nodes of 85` was stamped onto `strategy-complete-grounding`.

## Verification
- `npx vitest run --project packages/intentionsutil --root .` — 277 passing (15 new grounding assertions).
- `npx tsx packages/intentionsutil/scripts/grounding-gap.ts` — prints 85 durable / 75 unmarked, all 21 delegations ranked first (high-divergence at top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)