### PR TITLE
blog prerender: function-form replace at the three injection sites

### DIFF
--- a/packages/blog/src/prerender.ts
+++ b/packages/blog/src/prerender.ts
@@ -273,7 +273,7 @@ function stripHomeExtra(html: string): string {
 }
 
 function injectBeforeHead(html: string, block: string, context: string): string {
-  const result = html.replace("</head>", `    ${block}\n  </head>`);
+  const result = html.replace("</head>", () => `    ${block}\n  </head>`);
   if (result === html) throw new Error(`</head> marker not found in ${context}`);
   return result;
 }
@@ -439,7 +439,7 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
     html = injectBeforeHead(html, ogBlock, "post template");
     html = injectBeforeHead(html, postSeoHead, "post template");
     const beforeTitle = html;
-    html = html.replace(/<title>.*?<\/title>/, `<title>${escapeHtml(formatPageTitle(titleSuffix, meta.title))}</title>`);
+    html = html.replace(/<title>.*?<\/title>/, () => `<title>${escapeHtml(formatPageTitle(titleSuffix, meta.title))}</title>`);
     if (html === beforeTitle) throw new Error(`<title> tag not found in template`);
 
     if (shell) {
@@ -503,7 +503,7 @@ export function prerenderStaticPage(config: StaticPageConfig): void {
   const beforeTitle = html;
   html = html.replace(
     /<title>.*?<\/title>/,
-    `<title>${escapeHtml(formatPageTitle(titleSuffix, page.title))}</title>`,
+    () => `<title>${escapeHtml(formatPageTitle(titleSuffix, page.title))}</title>`,
   );
   if (html === beforeTitle) throw new Error(`<title> tag not found in template`);
 

--- a/packages/blog/test/prerender-static.test.ts
+++ b/packages/blog/test/prerender-static.test.ts
@@ -98,6 +98,28 @@ describe("prerenderStaticPage", () => {
     expect(html).not.toContain("<title>My Blog</title>");
   });
 
+  it("does not interpret $-sequences in the page title or description as replacement patterns", () => {
+    // Regression: the static <title> and SEO/OG block are injected via
+    // String.replace. A string-form replacement interprets `$&`, `$'`, `$$`
+    // in the (escapeHtml'd) title/description as replacement patterns — e.g.
+    // `$&` splices the matched `</head>` mid-attribute. Function-form
+    // replacers must insert the text verbatim.
+    prerenderStaticPage(
+      makeStaticConfig({}, { title: "Big $& Sale", description: "Deal $& save $' now $$ end" }),
+    );
+    const html = getWrittenHtml("/dist/about/index.html");
+
+    // Exactly one </head> — no `$&`-spliced copy injected mid-attribute.
+    expect(html.split("</head>")).toHaveLength(2);
+    expect(html).toContain("<title>My Blog - Big $&amp; Sale</title>");
+    expect(html).toContain(
+      '<meta property="og:description" content="Deal $&amp; save $&#39; now $$ end">',
+    );
+    expect(html).toContain(
+      '<meta name="description" content="Deal $&amp; save $&#39; now $$ end">',
+    );
+  });
+
   it("injects canonical link pointing at siteUrl + path", () => {
     prerenderStaticPage(makeStaticConfig());
     const html = getWrittenHtml("/dist/about/index.html");

--- a/packages/blog/test/prerender.test.ts
+++ b/packages/blog/test/prerender.test.ts
@@ -230,7 +230,7 @@ describe("prerenderPosts", () => {
     const perPostCall = vi.mocked(fs.writeFileSync).mock.calls.find(
       (c) => String(c[0]).includes("post/hello-world"),
     );
-    const html = perPostCall![1] as string;
+    const html = perPostCall![1] as string; // type-safety-ok: mock.calls tuple access, matches existing tests in this file
 
     // Exactly one </head> — no `$&`-spliced copy injected mid-attribute.
     expect(html.split("</head>")).toHaveLength(2);

--- a/packages/blog/test/prerender.test.ts
+++ b/packages/blog/test/prerender.test.ts
@@ -214,6 +214,36 @@ describe("prerenderPosts", () => {
     expect(html).not.toContain("<title>My Blog</title>");
   });
 
+  it("does not interpret $-sequences in the post title or description as replacement patterns", async () => {
+    // Regression: prerender.ts injects the title and SEO/OG block via
+    // String.replace. A string-form replacement interprets `$&`, `$'`, `$$`
+    // in the (escapeHtml'd) title/description as replacement patterns — e.g.
+    // `$&` splices the matched `</head>` mid-attribute, corrupting the
+    // prerendered head. Function-form replacers must insert the text verbatim.
+    const config = makeConfig();
+    const doc = config.seed.collections[0].documents[0];
+    doc.data.title = "Big $& Sale";
+    doc.data.previewDescription = "Deal $& save $' now $$ end";
+
+    await prerenderPosts(config);
+
+    const perPostCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      (c) => String(c[0]).includes("post/hello-world"),
+    );
+    const html = perPostCall![1] as string;
+
+    // Exactly one </head> — no `$&`-spliced copy injected mid-attribute.
+    expect(html.split("</head>")).toHaveLength(2);
+    // Title and description survive with their escaped-literal $-sequences.
+    expect(html).toContain("<title>My Blog - Big $&amp; Sale</title>");
+    expect(html).toContain(
+      '<meta property="og:description" content="Deal $&amp; save $&#39; now $$ end">',
+    );
+    expect(html).toContain(
+      '<meta name="description" content="Deal $&amp; save $&#39; now $$ end">',
+    );
+  });
+
   it("skips unpublished posts", async () => {
     const config = makeConfig();
     config.seed.collections[0].documents.push({


### PR DESCRIPTION
## Context

Graph-native tactic `tactic-blog-prerender-injection`, serving
`strategy-recover-publishing`.

`packages/blog/src/prerender.ts` used string/template `String.replace` at three
injection sites, so JS `$`-patterns in post/page titles and descriptions were
interpreted at build time. Verified 2026-07-05 (reproduced): a post
`previewDescription` of `Save $& more` prerenders a literal `</head>`
mid-attribute on the SEO-critical prerendered surface. `escapeHtml` amplifies
the class (`$'` -> `$&#39;`, which itself contains the `$&` pattern). Line 200's
`injectRoot` already documented the function-replacement contract these three
sites missed.

## Change

- `prerender.ts:276` (`injectBeforeHead`) and both `<title>` replacements
  (`:442`, `:506`) converted to function-form replacers (`() => value`) so the
  replacement string is never pattern-interpreted.
- Regression tests in `test/prerender.test.ts` (post path) and
  `test/prerender-static.test.ts` (static-page path) with titles/descriptions
  containing `$&`, `$'`, and `$$`, asserting the escaped-literal text survives
  and exactly one `</head>` remains (10 before the fix, from the `$&` splice).

## Verification

- `npx vitest run --root . packages/blog/test/` — 452 pass. The two new tests
  fail without the src fix (confirmed by reverting) and pass with it.