### PR TITLE
budget: unify aggregate-trend week axis and guard override-add clobber

### DIFF
--- a/budget/src/balance.ts
+++ b/budget/src/balance.ts
@@ -393,6 +393,15 @@ export function toSundayEntry(d: Date): { label: string; ms: number } {
   return { label, ms: sun.getTime() };
 }
 
+/** Normalize a Date to the Monday 00:00 UTC starting its Mon–Sun week (the budget-period convention), returning "M/D" label and ms timestamp. */
+export function toMondayEntry(d: Date): { label: string; ms: number } {
+  if (isNaN(d.getTime())) throw new DataIntegrityError("toMondayEntry received an invalid Date");
+  const ms = weekStart(d.getTime());
+  const mon = new Date(ms);
+  const label = `${mon.getUTCMonth() + 1}/${mon.getUTCDate()}`;
+  return { label, ms };
+}
+
 /** Build ordered unique week entries and sum totals per week. Returns weeks sorted chronologically. */
 function indexPeriodsByWeek(periods: BudgetPeriod[]): {
   weeks: [number, string][];
@@ -411,22 +420,41 @@ function indexPeriodsByWeek(periods: BudgetPeriod[]): {
 
 /**
  * Compute aggregate trend data: rolling averages of credits and spending per week.
- * Weeks are derived from budget periods. Credits are transactions with negative net amounts.
+ *
+ * The week axis is Monday-start (`toMondayEntry`), matching the budget-period
+ * convention, so spending and credits share one axis: a credit is bucketed to
+ * the same Mon–Sun week as the budget period that contains its date (a
+ * weekend-dated credit no longer lands one week late). Weeks are seeded from
+ * budget periods and additionally registered for any credit that falls in a
+ * period-less week — the same asymmetry `computePerBudgetTrend` avoids by
+ * registering extra "Other" weeks — so a paycheck in a week with no budget
+ * period is not silently dropped from the credit average.
  */
 export function computeAggregateTrend(
   periods: BudgetPeriod[],
   transactions: Transaction[],
 ): AggregatePoint[] {
-  const { weeks, weeklySpending } = indexPeriodsByWeek(periods);
-  if (weeks.length === 0) return [];
+  // Seed the Monday-start week axis and per-week spending from budget periods.
+  const weekLabels = new Map<number, string>();
+  const weeklySpending = new Map<number, number>();
+  for (const p of periods) {
+    const entry = toMondayEntry(p.periodStart.toDate());
+    if (!weekLabels.has(entry.ms)) weekLabels.set(entry.ms, entry.label);
+    weeklySpending.set(entry.ms, (weeklySpending.get(entry.ms) ?? 0) + p.total);
+  }
 
-  // Weekly credits: sum credit transactions (negative net) per week, negated to positive.
+  // Weekly credits: sum credit transactions (negative net) per Monday-start
+  // week, negated to positive. Register the week if no budget period covers it.
   const creditTxns = filterCreditTransactions(transactions);
   const weeklyCredits = new Map<number, number>();
   for (const t of creditTxns) {
-    const entry = toSundayEntry(t.timestamp.toDate());
+    const entry = toMondayEntry(t.timestamp.toDate());
+    if (!weekLabels.has(entry.ms)) weekLabels.set(entry.ms, entry.label);
     weeklyCredits.set(entry.ms, (weeklyCredits.get(entry.ms) ?? 0) + (-netAmount(t)));
   }
+
+  const weeks: [number, string][] = [...weekLabels.entries()].sort((a, b) => a[0] - b[0]);
+  if (weeks.length === 0) return [];
 
   const spendingValues = weeks.map(([ms]) => weeklySpending.get(ms) ?? 0);
   const creditValues = weeks.map(([ms]) => weeklyCredits.get(ms) ?? 0);

--- a/budget/src/pages/use-budget-table.ts
+++ b/budget/src/pages/use-budget-table.ts
@@ -242,6 +242,29 @@ export function useOverridesTableInteractivity(
         const firstBudget = budgets[0];
         const dateStr = toISODate(Date.now());
 
+        // Overrides are deduped by date (collectOverridesForBudget keys a Map by
+        // dateMs). Inserting a today-dated $0 row when one already exists for
+        // today would silently clobber it on the immediate save. Instead, edit
+        // the existing same-date override in place: focus its balance input so
+        // the user updates the real value rather than zeroing it.
+        const existingRow = [
+          ...container.querySelectorAll<HTMLElement>(`.override-row[data-budget-id="${firstBudget.id}"]`),
+        ].find(
+          (r) => r.querySelector<HTMLInputElement>(".edit-override-date")?.value === dateStr,
+        );
+        if (existingRow) {
+          const balanceInput = existingRow.querySelector<HTMLInputElement>(".edit-override-balance");
+          if (balanceInput) {
+            balanceInput.focus();
+            balanceInput.select();
+            // Bring the row into view where the environment supports it.
+            if (typeof balanceInput.scrollIntoView === "function") {
+              balanceInput.scrollIntoView({ block: "nearest" });
+            }
+          }
+          return;
+        }
+
         const newRow = document.createElement("div");
         newRow.className = "override-row";
         newRow.dataset.budgetId = firstBudget.id;

--- a/budget/test/balance.test.ts
+++ b/budget/test/balance.test.ts
@@ -787,6 +787,43 @@ describe("computeAggregateTrend", () => {
     const result = computeAggregateTrend(periods, txns);
     expect(result[0].avg12Credits).toBe(1200);
   });
+
+  it("a Sunday-dated credit aligns to the Monday-start week of its period, not one week later", () => {
+    // Period week is Mon 2025-01-06 .. Sun 2025-01-12. A credit dated Sunday
+    // 2025-01-12 falls inside that week; it must land in the same aggregate
+    // week as the period, not spill into a phantom following week.
+    const periods = [
+      makePeriod({ id: "food-w1", budgetId: "food", periodStart: ts("2025-01-06"), periodEnd: ts("2025-01-13"), total: 50 }),
+    ];
+    const txns = [
+      makeTxn({ id: "credit-sun", category: "Income:Salary", amount: -800, timestamp: ts("2025-01-12"), budget: null }),
+    ];
+    const result = computeAggregateTrend(periods, txns);
+    expect(result).toHaveLength(1);
+    expect(result[0].avg12Spending).toBe(50);
+    expect(result[0].avg12Credits).toBe(800);
+  });
+
+  it("registers a credit in a period-less week instead of dropping it from the credit average", () => {
+    // Only week 1 (Mon 2025-01-06) has a budget period. A paycheck lands in
+    // week 2 (Mon 2025-01-13), which has no period; that week must still be
+    // registered so the credit is not silently dropped.
+    const periods = [
+      makePeriod({ id: "food-w1", budgetId: "food", periodStart: ts("2025-01-06"), periodEnd: ts("2025-01-13"), total: 50 }),
+    ];
+    const txns = [
+      makeTxn({ id: "credit-w2", category: "Income:Salary", amount: -300, timestamp: ts("2025-01-13"), budget: null }),
+    ];
+    const result = computeAggregateTrend(periods, txns);
+    expect(result).toHaveLength(2);
+    // Week 1: spending 50, no credits.
+    expect(result[0].weekMs).toBe(new Date("2025-01-06").getTime());
+    expect(result[0].avg12Credits).toBe(0);
+    // Week 2 (period-less): credit registered, rolling avg of [0, 300] = 150.
+    expect(result[1].weekMs).toBe(new Date("2025-01-13").getTime());
+    expect(result[1].avg12Credits).toBe(150);
+    expect(result[1].avg12Spending).toBe(25);
+  });
 });
 
 describe("computePerBudgetTrend", () => {

--- a/budget/test/pages/budgets-hydrate.test.tsx
+++ b/budget/test/pages/budgets-hydrate.test.tsx
@@ -347,6 +347,27 @@ describe("Budgets overrides table interactivity — Unit 3 contract", () => {
     expect(calledOverrides).toHaveLength(1);
   });
 
+  it("does not clobber an existing same-date override; edits it in place instead", async () => {
+    // An override already exists for today's date. Clicking "Add Override"
+    // (which would insert a today-dated $0 row and save) must not overwrite it.
+    const now = new Date();
+    const todayUTC = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+    const c = await renderBudgets([
+      budget({ overrides: [{ date: Timestamp.fromMillis(todayUTC), balance: 42 }] }),
+    ]);
+    const addBtn = c.querySelector("#add-override") as HTMLButtonElement;
+    addBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await flush();
+    // No second row inserted, and no clobbering save fired.
+    expect(c.querySelectorAll("#overrides-table .override-row").length).toBe(1);
+    expect(activeDS.updateBudgetOverrides).not.toHaveBeenCalled();
+    // The existing override's balance is focused for in-place editing, and its
+    // value is untouched (not zeroed).
+    const balanceInput = c.querySelector("#overrides-table .edit-override-balance") as HTMLInputElement;
+    expect(document.activeElement).toBe(balanceInput);
+    expect(balanceInput.value).toBe("42");
+  });
+
   it("reverts a deleted row and flags save-error when the delete re-write fails", async () => {
     const c = await renderBudgets([overrideBudget()], [], {
       updateBudgetOverrides: vi.fn().mockRejectedValue(new Error("network error")),

--- a/budget/test/pages/budgets-hydrate.test.tsx
+++ b/budget/test/pages/budgets-hydrate.test.tsx
@@ -355,7 +355,7 @@ describe("Budgets overrides table interactivity — Unit 3 contract", () => {
     const c = await renderBudgets([
       budget({ overrides: [{ date: Timestamp.fromMillis(todayUTC), balance: 42 }] }),
     ]);
-    const addBtn = c.querySelector("#add-override") as HTMLButtonElement;
+    const addBtn = c.querySelector("#add-override") as HTMLButtonElement; // type-safety-ok: test DOM query cast, file convention
     addBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     await flush();
     // No second row inserted, and no clobbering save fired.
@@ -363,7 +363,7 @@ describe("Budgets overrides table interactivity — Unit 3 contract", () => {
     expect(activeDS.updateBudgetOverrides).not.toHaveBeenCalled();
     // The existing override's balance is focused for in-place editing, and its
     // value is untouched (not zeroed).
-    const balanceInput = c.querySelector("#overrides-table .edit-override-balance") as HTMLInputElement;
+    const balanceInput = c.querySelector("#overrides-table .edit-override-balance") as HTMLInputElement; // type-safety-ok: test DOM query cast, file convention
     expect(document.activeElement).toBe(balanceInput);
     expect(balanceInput.value).toBe("42");
   });


### PR DESCRIPTION
Implements graph tactic `tactic-budget-week-axis-consistency` (serves `strategy-recover-finance`). Two verified budget-app correctness defects from the 2026-07-05 code review, both rated medium.

## Unit 1 — unify the week axis in computeAggregateTrend
`computeAggregateTrend` keyed spending by the period's Monday-start week but credits by `toSundayEntry`, so a Sunday-dated credit landed one week later than the Monday-aligned period containing it, misaligning `avg12Credits`/`avg12NetCredits` against `avg12Spending`. It also derived its week axis solely from budget periods, silently dropping a credit falling in a week with no budget period.

Fix: a new `toMondayEntry` helper gives a single Monday-start axis (matching the budget-period convention) used for both spending and credits; credit weeks with no period are registered the same way `computePerBudgetTrend` registers extra "Other" weeks.

## Unit 2 — stop override-row add from silently clobbering
Overrides are deduped by `dateMs` (last wins). "Add Override" inserted a today-dated `$0` row and saved immediately, silently clobbering an existing same-date override to `$0`. Fix: before inserting, the handler checks for an existing same-date override for the target budget and, if found, focuses that row's balance input for in-place editing instead of adding a clobbering row.

## Verification
- `budget` unit suite: 962 passing (added 2 aggregate-trend tests for the Sunday-credit alignment and the period-less-week credit, and 1 override-clobber test).
- `budget` typecheck passes.