### PR TITLE
budget-etl: fix derived balance-history + virtual/merge correctness

### DIFF
--- a/projects/budget-etl/internal/export/export.go
+++ b/projects/budget-etl/internal/export/export.go
@@ -402,10 +402,18 @@ func (o Output) Validate() error {
 			return fmt.Errorf("journalLegs[%d]: entryId %q does not reference any journal entry in journalEntries", i, l.EntryID)
 		}
 	}
+	seenTxnIDs := make(map[string]bool, len(o.Transactions))
 	for i, t := range o.Transactions {
 		if t.JournalEntryID != nil && !entryIDs[*t.JournalEntryID] {
 			return fmt.Errorf("transactions[%d]: journalEntryId %q does not reference any journal entry in journalEntries", i, *t.JournalEntryID)
 		}
+		// Doc IDs are Firestore document IDs; a collision silently overwrites one
+		// transaction's document with another on upload, dropping data. Reject a
+		// duplicate here so a future collision fails loudly at the write boundary.
+		if seenTxnIDs[t.ID] {
+			return fmt.Errorf("transactions[%d]: duplicate transaction doc id %q", i, t.ID)
+		}
+		seenTxnIDs[t.ID] = true
 	}
 	return nil
 }

--- a/projects/budget-etl/internal/export/export_test.go
+++ b/projects/budget-etl/internal/export/export_test.go
@@ -70,10 +70,10 @@ func TestWriteFileRoundTrip(t *testing.T) {
 		},
 		Budgets: []Budget{
 			{
-				ID:              "budget-food",
-				Name:            "groceries",
+				ID:        "budget-food",
+				Name:      "groceries",
 				Allowance: 150.00,
-				Rollover:        "debt",
+				Rollover:  "debt",
 			},
 		},
 		BudgetPeriods: []BudgetPeriod{
@@ -1077,9 +1077,9 @@ func TestJournalLegValidate(t *testing.T) {
 
 func TestAccountValidate(t *testing.T) {
 	tests := []struct {
-		name    string
+		name     string
 		acctType AccountType
-		wantErr bool
+		wantErr  bool
 	}{
 		{"asset", AccountTypeAsset, false},
 		{"liability", AccountTypeLiability, false},
@@ -1163,6 +1163,28 @@ func TestWriteFileValidatesOutput(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "accounts[0]") {
 			t.Errorf("error should name the offending account index, got %v", err)
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("file should not exist after validation failure, stat err = %v", err)
+		}
+	})
+
+	t.Run("duplicate transaction doc id writes no file", func(t *testing.T) {
+		out := minimalOutput("household")
+		// Two transactions sharing a doc ID: on upload one Firestore document
+		// silently overwrites the other, so Validate must reject it.
+		out.Transactions = []Transaction{
+			{ID: "dup", Institution: "x", Account: "1", Description: "A", Amount: 1, Timestamp: "2025-01-01T00:00:00Z", StatementID: "x-1-2025-01", Category: "C"},
+			{ID: "dup", Institution: "x", Account: "1", Description: "B", Amount: 2, Timestamp: "2025-01-02T00:00:00Z", StatementID: "x-1-2025-01", Category: "C"},
+		}
+
+		path := filepath.Join(t.TempDir(), "budget.json")
+		err := WriteFile(path, out, "")
+		if err == nil {
+			t.Fatal("WriteFile: expected error for duplicate transaction doc id")
+		}
+		if !strings.Contains(err.Error(), "duplicate transaction doc id") {
+			t.Errorf("error should name the duplicate doc id, got %v", err)
 		}
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Errorf("file should not exist after validation failure, stat err = %v", err)

--- a/projects/budget-etl/internal/parse/sgml.go
+++ b/projects/budget-etl/internal/parse/sgml.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // parseSGML parses OFX 1.x / QFX SGML files by scanning for SGML tags.
@@ -212,7 +214,80 @@ func sgmlTagValue(content, tag string) string {
 	// Value continues until next '<' or end of content
 	end := strings.Index(content[start:], "<")
 	if end < 0 {
-		return strings.TrimSpace(content[start:])
+		return decodeXMLEntities(strings.TrimSpace(content[start:]))
 	}
-	return strings.TrimSpace(content[start : start+end])
+	return decodeXMLEntities(strings.TrimSpace(content[start : start+end]))
+}
+
+// decodeXMLEntities decodes the five predefined XML entities and numeric
+// character references (&#nn; / &#xHH;) so the SGML path matches encoding/xml's
+// automatic entity decoding on the XML path — otherwise an OFX 1.x
+// "AT&amp;T" is stored literally while its OFX 2.x twin decodes to "AT&T",
+// causing garbled descriptions, failed categorization, and cross-format double
+// counting. An unknown entity or a bare '&' (OFX 1.x sometimes emits one
+// unescaped) is left unchanged, matching a lenient reader.
+func decodeXMLEntities(s string) string {
+	if !strings.ContainsRune(s, '&') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if s[i] != '&' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		semi := strings.IndexByte(s[i:], ';')
+		if semi < 0 {
+			// No terminator; emit the rest verbatim.
+			b.WriteString(s[i:])
+			break
+		}
+		ent := s[i : i+semi+1] // includes leading '&' and trailing ';'
+		switch ent {
+		case "&amp;":
+			b.WriteByte('&')
+		case "&lt;":
+			b.WriteByte('<')
+		case "&gt;":
+			b.WriteByte('>')
+		case "&quot;":
+			b.WriteByte('"')
+		case "&apos;":
+			b.WriteByte('\'')
+		default:
+			if r, ok := decodeCharRef(ent); ok {
+				b.WriteRune(r)
+			} else {
+				// Unknown entity or stray '&…;'; keep it verbatim.
+				b.WriteString(ent)
+			}
+		}
+		i += semi + 1
+	}
+	return b.String()
+}
+
+// decodeCharRef decodes a numeric character reference of the form &#123; or
+// &#x1F600; (case-insensitive x). Returns (rune, true) on success; (0, false)
+// for anything else.
+func decodeCharRef(ent string) (rune, bool) {
+	if len(ent) < 4 || !strings.HasPrefix(ent, "&#") || ent[len(ent)-1] != ';' {
+		return 0, false
+	}
+	body := ent[2 : len(ent)-1] // digits between "&#" and ";"
+	base := 10
+	if body != "" && (body[0] == 'x' || body[0] == 'X') {
+		base = 16
+		body = body[1:]
+	}
+	if body == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(body, base, 32)
+	if err != nil || n < 0 || !utf8.ValidRune(rune(n)) {
+		return 0, false
+	}
+	return rune(n), true
 }

--- a/projects/budget-etl/internal/parse/sgml_test.go
+++ b/projects/budget-etl/internal/parse/sgml_test.go
@@ -1,6 +1,7 @@
 package parse
 
 import (
+	"encoding/xml"
 	"os"
 	"path/filepath"
 	"strings"
@@ -266,5 +267,51 @@ func TestParseSGML_CreditCardLiability(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("account %q not found in journal result", wantID)
+	}
+}
+
+func TestSGMLTagValueDecodesEntities(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		tag     string
+		want    string
+	}{
+		{"ampersand", "<NAME>AT&amp;T Wireless<FITID>1", "NAME", "AT&T Wireless"},
+		{"all predefined", "<MEMO>a&lt;b&gt;c&quot;d&apos;e&amp;f<FOO>", "MEMO", `a<b>c"d'e&f`},
+		{"decimal char ref", "<NAME>caf&#233;<FITID>1", "NAME", "café"},
+		{"hex char ref", "<NAME>caf&#xE9;<FITID>1", "NAME", "café"},
+		{"bare ampersand kept", "<NAME>Tom & Jerry<FITID>1", "NAME", "Tom & Jerry"},
+		{"unknown entity kept", "<NAME>a&nbsp;b<FITID>1", "NAME", "a&nbsp;b"},
+		{"no entity identity", "<NAME>Plain Text<FITID>1", "NAME", "Plain Text"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sgmlTagValue(tc.content, tc.tag); got != tc.want {
+				t.Errorf("sgmlTagValue(%q, %q) = %q, want %q", tc.content, tc.tag, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSGMLEntityParityWithXML confirms the SGML path decodes an entity to the
+// same value encoding/xml produces on the OFX 2.x (XML) twin, so a description
+// like AT&amp;T is stored identically regardless of source format.
+func TestSGMLEntityParityWithXML(t *testing.T) {
+	const raw = "AT&amp;T"
+
+	sgmlGot := sgmlTagValue("<NAME>"+raw+"<FITID>1", "NAME")
+
+	var xmlGot struct {
+		Name string `xml:"NAME"`
+	}
+	if err := xml.Unmarshal([]byte("<STMTTRN><NAME>"+raw+"</NAME></STMTTRN>"), &xmlGot); err != nil {
+		t.Fatalf("xml.Unmarshal: %v", err)
+	}
+	if sgmlGot != xmlGot.Name {
+		t.Errorf("SGML decode %q != XML decode %q", sgmlGot, xmlGot.Name)
+	}
+	if sgmlGot != "AT&T" {
+		t.Errorf("decoded value = %q, want %q", sgmlGot, "AT&T")
 	}
 }

--- a/projects/budget-etl/internal/rules/rules.go
+++ b/projects/budget-etl/internal/rules/rules.go
@@ -281,20 +281,29 @@ func selectPrimary(group []budget.NormTxn) budget.NormTxn {
 	return best
 }
 
-// autoNormKey is the grouping key for auto-normalization.
+// autoNormKey is the grouping key for auto-normalization. Institution and
+// account are part of the key so two distinct same-day, same-amount,
+// same-description charges on different accounts are not collapsed into one
+// (which would silently drop a real transaction); auto-normalization only
+// dedups the same account's transactions across overlapping statement periods.
 type autoNormKey struct {
+	institution string
+	account     string
 	description string // lowercased
 	amount      int64
 	day         string // "2006-01-02" in UTC
 }
 
-// autoNormalize groups transactions with matching description (case-insensitive),
-// amount, and date from different statements. These are exact duplicates from
-// overlapping statement periods that don't require a rule.
+// autoNormalize groups transactions with matching institution, account,
+// description (case-insensitive), amount, and date from different statements.
+// These are exact duplicates from overlapping statement periods that don't
+// require a rule.
 func autoNormalize(txns []budget.NormTxn, normalized map[string]bool) []budget.NormalizationUpdate {
 	groups := make(map[autoNormKey][]budget.NormTxn)
 	for _, txn := range txns {
 		key := autoNormKey{
+			institution: txn.Institution,
+			account:     txn.Account,
 			description: strings.ToLower(txn.Description),
 			amount:      txn.Amount,
 			day:         txn.Timestamp.UTC().Truncate(24 * time.Hour).Format("2006-01-02"),

--- a/projects/budget-etl/internal/rules/rules_test.go
+++ b/projects/budget-etl/internal/rules/rules_test.go
@@ -555,6 +555,44 @@ func TestApplyNormalization_ExactDateOnly(t *testing.T) {
 	}
 }
 
+func TestApplyNormalization_DifferentAccountsNotCollapsed(t *testing.T) {
+	base := time.Date(2025, 3, 1, 12, 0, 0, 0, time.UTC)
+	// Two genuinely distinct charges: same day, amount, and description, but on
+	// different accounts and in different statements. Without an account key in
+	// the auto-normalization grouping these collapse into one, silently dropping
+	// a real transaction. They must remain distinct (no updates).
+	txns := []budget.NormTxn{
+		{DocID: "acctA", Description: "COSTCO GAS", Amount: 6000, Institution: "visa", Account: "1111", Timestamp: base, StatementID: "s1"},
+		{DocID: "acctB", Description: "COSTCO GAS", Amount: 6000, Institution: "visa", Account: "2222", Timestamp: base, StatementID: "s2"},
+	}
+
+	updates, err := ApplyNormalization(txns, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(updates) != 0 {
+		t.Errorf("distinct-account charges collapsed: got %d updates, want 0 (%+v)", len(updates), updates)
+	}
+}
+
+func TestApplyNormalization_SameAccountAcrossStatementsStillDedups(t *testing.T) {
+	base := time.Date(2025, 3, 1, 12, 0, 0, 0, time.UTC)
+	// The same account's overlapping statements still auto-dedup after the key
+	// gained institution/account — the account key does not disable it.
+	txns := []budget.NormTxn{
+		{DocID: "x1", Description: "SPOTIFY", Amount: 999, Institution: "amex", Account: "3333", Timestamp: base, StatementID: "s1"},
+		{DocID: "x2", Description: "SPOTIFY", Amount: 999, Institution: "amex", Account: "3333", Timestamp: base, StatementID: "s2"},
+	}
+
+	updates, err := ApplyNormalization(txns, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(updates) != 2 {
+		t.Errorf("same-account duplicate not deduped: got %d updates, want 2", len(updates))
+	}
+}
+
 func TestApplyNormalization_PrimarySelection(t *testing.T) {
 	base := time.Date(2025, 3, 1, 12, 0, 0, 0, time.UTC)
 	// Same date, 3 overlapping statements

--- a/projects/budget-etl/main.go
+++ b/projects/budget-etl/main.go
@@ -260,6 +260,21 @@ func virtualStmtPrefix(targetInstitution, targetAccount string) string {
 	return targetInstitution + "-" + targetAccount + "-"
 }
 
+// virtualRuleKey returns a stable identity for a virtual-transaction rule,
+// folded into each generated virtual doc ID so two distinct rules matching one
+// source transaction produce distinct doc IDs instead of colliding (and
+// silently overwriting one Firestore doc). Two genuinely different rules differ
+// in at least one field; identical rules are true duplicates that may share an
+// ID harmlessly. It is deterministic across runs, so a virtual transaction's
+// doc ID is stable and re-imports upsert rather than duplicate.
+func virtualRuleKey(r export.VirtualTransactionRule) string {
+	return strings.Join([]string{
+		r.Institution, r.Account, r.Category, r.DescriptionContains,
+		r.TargetInstitution, r.TargetAccount, r.TargetCategory, r.TargetBudget,
+		r.BudgetID,
+	}, "\x00")
+}
+
 // seedLegacyVirtualTransactionRules seeds the legacy Synchrony->pet rule when
 // vrules is nil (absent in JSON from a pre-refactor snapshot). An explicit empty
 // slice is left alone.
@@ -335,13 +350,12 @@ func generateVirtualTransactions(
 		txnsByBudgetID: make(map[string][]budget.TransactionData),
 	}
 
-	type dateAmount struct {
-		date   string
-		amount int64
-	}
-
 	for _, rule := range vrules {
-		seen := make(map[dateAmount]bool)
+		// Dedup matched sources by source doc ID (which embeds the FITID) per
+		// rule, not by (date, amount): a same-day split payment is two distinct
+		// source transactions with equal date and amount, and keying on
+		// (date, amount) would collapse them into a single virtual transaction.
+		seen := make(map[string]bool)
 		periods := make(map[string]bool)
 
 		for i, txn := range allTxns {
@@ -364,16 +378,16 @@ func generateVirtualTransactions(
 				continue
 			}
 
-			// Dedup by (date, amount) per rule
-			key := dateAmount{date: txn.Timestamp.Format("2006-01-02"), amount: txn.Amount}
-			if seen[key] {
+			if seen[txnDocIDs[i]] {
 				continue
 			}
-			seen[key] = true
+			seen[txnDocIDs[i]] = true
 
 			period := txn.Timestamp.Format("2006-01")
 			stmtID := virtualStmtPrefix(rule.TargetInstitution, rule.TargetAccount) + period
-			virtualDocID := "virtual-" + txnDocIDs[i]
+			// Fold the rule identity into the doc ID so two rules matching this
+			// same source transaction do not collide on "virtual-"+source.
+			virtualDocID := "virtual-" + budget.TransactionDocID(virtualRuleKey(rule), txnDocIDs[i])
 
 			vtxn := budget.TransactionData{
 				Institution:   rule.TargetInstitution,
@@ -1267,6 +1281,17 @@ func runMerge(input fileOpts, dir, groupName string, disc parse.DiscoverOpts, ou
 		dirDocIDs[id] = true
 	}
 
+	// Preserve user edits (Note, Reimbursement) on input transactions the dir
+	// path does not re-parse — notably regenerated virtual transactions, which
+	// are skipped below and whose doc IDs are stable across runs. Mirrors
+	// runInputJSON, which seeds editsMap from every input transaction; without
+	// this, runMerge silently drops the user's edits on virtual transactions.
+	for _, t := range inp.Transactions {
+		if _, ok := editsMap[t.ID]; !ok {
+			editsMap[t.ID] = txnEdits{note: t.Note, reimbursement: t.Reimbursement}
+		}
+	}
+
 	// Append input-only transactions (not in dir), skipping virtual transactions
 	for _, t := range inp.Transactions {
 		if dirDocIDs[t.ID] || t.Virtual {
@@ -1334,7 +1359,7 @@ func runMerge(input fileOpts, dir, groupName string, disc parse.DiscoverOpts, ou
 
 	// Merge statements: dir overrides by statementID, retain input-only
 	maxDates := maxTransactionDates(allTxns)
-	exportStmts := mergeStatements(dirStmts, inp.Statements, maxDates)
+	exportStmts := mergeStatements(dirStmts, inp.Statements, maxDates, vrules)
 	// Append virtual Synchrony statements
 	exportStmts = append(exportStmts, vsr.statements...)
 
@@ -1372,10 +1397,16 @@ func runMerge(input fileOpts, dir, groupName string, disc parse.DiscoverOpts, ou
 // Merge priority by statementID: real dir > real input > derived/virtual anchor.
 // A real dir statement overrides the stale snapshot copy of the same ID. A
 // derived/virtual anchor never shadows a real statement (dir or input); it
-// gap-fills only — emitted solely for a period with no real statement. Virtual
-// input statements (stale prior-snapshot anchors) are skipped and recomputed.
+// gap-fills only — emitted solely for a period with no real statement.
+//
+// Derived monthly anchors carried in the input snapshot are retained as
+// gap-fillers, mirroring runInputJSON: deriveMonthlyStatements only re-derives
+// anchors for single-statement accounts, so once a second file joins an
+// account the dir path stops producing them and the input's stored anchors are
+// the only surviving source of that account's balance history. Only *generated*
+// virtual statements (recomputed from vrules after this merge) are dropped here.
 // Uses maxDates to set LastTransactionDate on all statements (dir and input-only).
-func mergeStatements(dirStmts []budget.StatementData, inputStmts []export.Statement, maxDates map[string]*time.Time) []export.Statement {
+func mergeStatements(dirStmts []budget.StatementData, inputStmts []export.Statement, maxDates map[string]*time.Time, vrules []export.VirtualTransactionRule) []export.Statement {
 	for i := range dirStmts {
 		key := accountKey(dirStmts[i].Institution, dirStmts[i].Account)
 		dirStmts[i].LastTransactionDate = maxDates[key]
@@ -1405,8 +1436,9 @@ func mergeStatements(dirStmts []budget.StatementData, inputStmts []export.Statem
 		covered[s.StatementID] = true
 	}
 
-	// Real input statements: skip virtual ones and those overridden by a real
-	// dir statement; otherwise retain and update LastTransactionDate.
+	// Real input statements: skip virtual ones (handled by the derived-input
+	// anchor gap-fill below) and those overridden by a real dir statement;
+	// otherwise retain and update LastTransactionDate.
 	for _, s := range inputStmts {
 		if s.Virtual || realDirByStmtID[s.StatementID] {
 			continue
@@ -1426,6 +1458,24 @@ func mergeStatements(dirStmts []budget.StatementData, inputStmts []export.Statem
 	for _, s := range dirExport {
 		if !s.Virtual || covered[s.StatementID] {
 			continue
+		}
+		result = append(result, s)
+		covered[s.StatementID] = true
+	}
+
+	// Derived input anchors gap-fill: retain a virtual input statement that is a
+	// derived monthly anchor (NOT a generated virtual statement, which runMerge
+	// recomputes from the rules) when no real statement or dir anchor already
+	// covers its period. Without this, a multi-file account — whose dir path no
+	// longer re-derives anchors — permanently loses its balance history.
+	for _, s := range inputStmts {
+		if !s.Virtual || covered[s.StatementID] || isGeneratedVirtualStmt(s.StatementID, vrules) {
+			continue
+		}
+		key := accountKey(s.Institution, s.Account)
+		if t, ok := maxDates[key]; ok {
+			v := export.FormatTimestamp(*t)
+			s.LastTransactionDate = &v
 		}
 		result = append(result, s)
 		covered[s.StatementID] = true
@@ -1503,18 +1553,22 @@ func deriveMonthlyStatements(parsed []parsedFile) []budget.StatementData {
 			continue
 		}
 
-		// For each month boundary (first of month), derive the balance by computing
-		// the sum of all transactions on or after that boundary, then:
-		//   derived_balance = known_balance + txn_sum_from_boundary_onward
-		// This reverses the effect of those transactions to get the earlier balance.
+		// For each month boundary, derive the balance at the END of that month
+		// (its last day) by reversing only the transactions that occur AFTER the
+		// month — those dated on or after the first of the *next* month:
+		//   derived_balance = known_balance + txn_sum_from_next_month_onward
+		// Reversing the month's own transactions too would yield the balance at
+		// the START of the month, leaving every anchor one month stale.
 		//
 		// Skip the balance date's own month — the original statement already covers it.
 		beforeLen := len(derived)
 		for m := firstMonth; m.Before(balMonth); m = m.AddDate(0, 1, 0) {
-			// Sum all transactions with date >= boundary (first of this month)
+			// Sum all transactions dated on or after the first of the next month,
+			// so month m's own transactions stay in its end-of-month balance.
+			nextMonth := m.AddDate(0, 1, 0)
 			var txnSum int64
 			for _, t := range pf.result.Transactions {
-				if !t.Date.Before(m) {
+				if !t.Date.Before(nextMonth) {
 					txnSum += t.Amount
 				}
 			}

--- a/projects/budget-etl/main_test.go
+++ b/projects/budget-etl/main_test.go
@@ -1058,25 +1058,28 @@ func TestDeriveMonthlyStatements(t *testing.T) {
 			}
 		}
 
-		// Verify 2025-12 balance: known balance + all txns from Dec onward
-		// txns from 2025-12-01 onward: 10000 + (-5000) + 20000 + 15000 + 8000 = 48000
-		// derived = -431299 + 48000 = -383299 (-$3832.99)
-		if derived[0].Balance != -383299 {
-			t.Errorf("derived[0].Balance = %d, want %d", derived[0].Balance, -383299)
-		}
+		// Each anchor is the balance at the END of its month: reverse only the
+		// transactions dated AFTER that month (first of the next month onward).
 
-		// Verify 2026-01 balance: known balance + txns from Jan onward
+		// Verify 2025-12 end-of-month balance: reverse txns from 2026-01 onward
 		// txns from 2026-01-01 onward: 20000 + 15000 + 8000 = 43000
 		// derived = -431299 + 43000 = -388299 (-$3882.99)
-		if derived[1].Balance != -388299 {
-			t.Errorf("derived[1].Balance = %d, want %d", derived[1].Balance, -388299)
+		if derived[0].Balance != -388299 {
+			t.Errorf("derived[0].Balance = %d, want %d", derived[0].Balance, -388299)
 		}
 
-		// Verify 2026-02 balance: known balance + txns from Feb onward
+		// Verify 2026-01 end-of-month balance: reverse txns from 2026-02 onward
 		// txns from 2026-02-01 onward: 15000 + 8000 = 23000
 		// derived = -431299 + 23000 = -408299 (-$4082.99)
-		if derived[2].Balance != -408299 {
-			t.Errorf("derived[2].Balance = %d, want %d", derived[2].Balance, -408299)
+		if derived[1].Balance != -408299 {
+			t.Errorf("derived[1].Balance = %d, want %d", derived[1].Balance, -408299)
+		}
+
+		// Verify 2026-02 end-of-month balance: reverse txns from 2026-03 onward
+		// txns from 2026-03-01 onward: 8000
+		// derived = -431299 + 8000 = -423299 (-$4232.99)
+		if derived[2].Balance != -423299 {
+			t.Errorf("derived[2].Balance = %d, want %d", derived[2].Balance, -423299)
 		}
 
 		// Verify balance dates are last day of each month
@@ -1269,7 +1272,7 @@ func TestMergeStatementsPreservesRealOverDerivedAnchor(t *testing.T) {
 
 	maxDates := map[string]*time.Time{} // no transactions; LastTransactionDate stays nil
 
-	result := mergeStatements(dirStmts, inputStmts, maxDates)
+	result := mergeStatements(dirStmts, inputStmts, maxDates, nil)
 
 	// Index the result by StatementID for easy lookup.
 	byStmtID := make(map[string]export.Statement, len(result))
@@ -1307,6 +1310,83 @@ func TestMergeStatementsPreservesRealOverDerivedAnchor(t *testing.T) {
 	// 3. Exactly the two expected statements — no extras.
 	if len(result) != 2 {
 		t.Errorf("expected 2 statements in merge result, got %d", len(result))
+	}
+}
+
+// TestMergeStatementsPreservesDerivedInputAnchor guards the multi-file
+// regression: once a second file joins an account, deriveMonthlyStatements
+// stops re-deriving that account's anchors (single-file only), so the input
+// snapshot's stored derived anchors are the only surviving balance history.
+// mergeStatements must retain a derived (non-generated) virtual input anchor
+// for a period no real statement covers, while still dropping a generated
+// virtual input statement (recomputed from the rules) and letting a real
+// statement win its own period.
+func TestMergeStatementsPreservesDerivedInputAnchor(t *testing.T) {
+	// vrules whose generated statements use the "synchrony-virtual-" prefix.
+	vrules := []export.VirtualTransactionRule{
+		{TargetInstitution: "synchrony", TargetAccount: "virtual"},
+	}
+
+	// A real dir statement for 2026-03 (the account's newest, joined file).
+	bdMar := time.Date(2026, 3, 31, 0, 0, 0, 0, time.UTC)
+	dirStmts := []budget.StatementData{
+		{
+			StatementID: "bank-acct-2026-03",
+			Institution: "bank",
+			Account:     "acct",
+			Balance:     30000,
+			Period:      "2026-03",
+			BalanceDate: &bdMar,
+			Virtual:     false,
+		},
+	}
+
+	inputStmts := []export.Statement{
+		// A derived monthly anchor for 2026-01 that dir no longer produces.
+		{
+			ID:          budget.StatementDocID("bank-acct-2026-01"),
+			StatementID: "bank-acct-2026-01",
+			Institution: "bank",
+			Account:     "acct",
+			Balance:     10000,
+			Period:      "2026-01",
+			Virtual:     true,
+		},
+		// A generated virtual statement recomputed elsewhere — must be dropped.
+		{
+			ID:          budget.StatementDocID("synchrony-virtual-2026-01"),
+			StatementID: "synchrony-virtual-2026-01",
+			Institution: "synchrony",
+			Account:     "virtual",
+			Balance:     0,
+			Period:      "2026-01",
+			Virtual:     true,
+		},
+	}
+
+	maxDates := map[string]*time.Time{}
+	result := mergeStatements(dirStmts, inputStmts, maxDates, vrules)
+
+	byStmtID := make(map[string]export.Statement, len(result))
+	for _, s := range result {
+		byStmtID[s.StatementID] = s
+	}
+
+	if _, ok := byStmtID["bank-acct-2026-03"]; !ok {
+		t.Error("real dir statement bank-acct-2026-03 missing from merge result")
+	}
+	anchor, ok := byStmtID["bank-acct-2026-01"]
+	if !ok {
+		t.Fatal("derived input anchor bank-acct-2026-01 dropped — balance history lost")
+	}
+	if !anchor.Virtual || anchor.Balance != 10000 {
+		t.Errorf("derived input anchor changed: Virtual=%v Balance=%v, want true/10000", anchor.Virtual, anchor.Balance)
+	}
+	if _, ok := byStmtID["synchrony-virtual-2026-01"]; ok {
+		t.Error("generated virtual input statement was retained; it must be dropped and recomputed")
+	}
+	if len(result) != 2 {
+		t.Errorf("expected 2 statements (real + derived anchor), got %d", len(result))
 	}
 }
 
@@ -1848,16 +1928,19 @@ func TestGenerateVirtualTransactions(t *testing.T) {
 			t.Error("expected StatementID synchrony-virtual-2025-03")
 		}
 
-		// Verify TransactionIDs are "virtual-" + source docID
+		// Verify TransactionIDs fold the rule identity into the source docID so
+		// each (rule, source) pair yields a distinct, stable doc ID.
 		txnIDSet := make(map[string]bool)
 		for _, vt := range res.transactions {
 			txnIDSet[vt.TransactionID] = true
 		}
-		if !txnIDSet["virtual-doc-sync-1"] {
-			t.Error("expected TransactionID virtual-doc-sync-1")
+		wantID1 := "virtual-" + budget.TransactionDocID(virtualRuleKey(synchronyRule), "doc-sync-1")
+		wantID2 := "virtual-" + budget.TransactionDocID(virtualRuleKey(synchronyRule), "doc-sync-2")
+		if !txnIDSet[wantID1] {
+			t.Errorf("expected TransactionID %q", wantID1)
 		}
-		if !txnIDSet["virtual-doc-sync-2"] {
-			t.Error("expected TransactionID virtual-doc-sync-2")
+		if !txnIDSet[wantID2] {
+			t.Errorf("expected TransactionID %q", wantID2)
 		}
 
 		// Verify 2 statements with correct fields
@@ -1957,8 +2040,9 @@ func TestGenerateVirtualTransactions(t *testing.T) {
 		if !strings.HasPrefix(vt.StatementID, "amazonstore-virtual-") {
 			t.Errorf("StatementID %q does not have prefix %q", vt.StatementID, "amazonstore-virtual-")
 		}
-		if vt.TransactionID != "virtual-doc-amz-1" {
-			t.Errorf("TransactionID: got %q, want %q", vt.TransactionID, "virtual-doc-amz-1")
+		wantID := "virtual-" + budget.TransactionDocID(virtualRuleKey(amazonRule), "doc-amz-1")
+		if vt.TransactionID != wantID {
+			t.Errorf("TransactionID: got %q, want %q", vt.TransactionID, wantID)
 		}
 
 		// 1 statement for the single matched period
@@ -1975,8 +2059,10 @@ func TestGenerateVirtualTransactions(t *testing.T) {
 		}
 	})
 
-	t.Run("per-rule dedup by date and amount", func(t *testing.T) {
-		// Two txns with same date and amount under the synchrony rule -> only 1 virtual txn
+	t.Run("same-day same-amount split payment yields two virtual txns", func(t *testing.T) {
+		// A same-day split payment is two DISTINCT source transactions (distinct
+		// FITIDs / doc IDs) that happen to share a date and amount. Dedup keys on
+		// the source doc ID (FITID), not (date, amount), so both survive.
 		allTxns := []budget.TransactionData{
 			{
 				Institution:   "pnc",
@@ -2003,8 +2089,87 @@ func TestGenerateVirtualTransactions(t *testing.T) {
 
 		res := generateVirtualTransactions(allTxns, docIDs, []export.VirtualTransactionRule{synchronyRule})
 
+		if len(res.transactions) != 2 {
+			t.Errorf("expected 2 virtual transactions for a split payment, got %d", len(res.transactions))
+		}
+		ids := make(map[string]bool, len(res.transactions))
+		for _, vt := range res.transactions {
+			if ids[vt.TransactionID] {
+				t.Errorf("duplicate virtual TransactionID %q", vt.TransactionID)
+			}
+			ids[vt.TransactionID] = true
+		}
+	})
+
+	t.Run("same source doc id matched twice per rule dedups", func(t *testing.T) {
+		// A genuine duplicate — the same source transaction (same doc ID)
+		// appearing twice — is deduped to a single virtual transaction per rule.
+		allTxns := []budget.TransactionData{
+			{
+				Institution:   "pnc",
+				Account:       "5111",
+				Description:   "Online Payment To SYNCHRONY BANK",
+				Amount:        50000,
+				Timestamp:     time.Date(2025, 2, 15, 0, 0, 0, 0, time.UTC),
+				StatementID:   "pnc-5111-2025-02",
+				TransactionID: "txn-dup",
+				Category:      "Transfer:CardPayment",
+			},
+			{
+				Institution:   "pnc",
+				Account:       "5111",
+				Description:   "Online Payment To SYNCHRONY BANK",
+				Amount:        50000,
+				Timestamp:     time.Date(2025, 2, 15, 0, 0, 0, 0, time.UTC),
+				StatementID:   "pnc-5111-2025-02",
+				TransactionID: "txn-dup",
+				Category:      "Transfer:CardPayment",
+			},
+		}
+		docIDs := []string{"doc-dup", "doc-dup"}
+
+		res := generateVirtualTransactions(allTxns, docIDs, []export.VirtualTransactionRule{synchronyRule})
+
 		if len(res.transactions) != 1 {
-			t.Errorf("expected 1 transaction after per-rule dedup, got %d", len(res.transactions))
+			t.Errorf("expected 1 transaction after per-source-doc-id dedup, got %d", len(res.transactions))
+		}
+	})
+
+	t.Run("two rules matching one source yield distinct doc ids", func(t *testing.T) {
+		// Two distinct rules that both match the single source transaction must
+		// emit two virtual transactions with distinct doc IDs — previously they
+		// collided on "virtual-"+source, silently overwriting one Firestore doc.
+		ruleA := export.VirtualTransactionRule{
+			Institution: "pnc", Account: "5111", Category: "Transfer:CardPayment",
+			TargetInstitution: "synchrony", TargetAccount: "virtual",
+			TargetCategory: "Pet:Veterinarian", TargetBudget: "pet", BudgetID: "pet",
+		}
+		ruleB := export.VirtualTransactionRule{
+			Institution: "pnc", Account: "5111", Category: "Transfer:CardPayment",
+			TargetInstitution: "synchrony", TargetAccount: "virtual",
+			TargetCategory: "Shopping:Online", TargetBudget: "shopping", BudgetID: "shopping",
+		}
+		allTxns := []budget.TransactionData{
+			{
+				Institution:   "pnc",
+				Account:       "5111",
+				Description:   "Online Payment To SYNCHRONY BANK",
+				Amount:        50000,
+				Timestamp:     time.Date(2025, 2, 15, 0, 0, 0, 0, time.UTC),
+				StatementID:   "pnc-5111-2025-02",
+				TransactionID: "txn-x",
+				Category:      "Transfer:CardPayment",
+			},
+		}
+		docIDs := []string{"doc-x"}
+
+		res := generateVirtualTransactions(allTxns, docIDs, []export.VirtualTransactionRule{ruleA, ruleB})
+
+		if len(res.transactions) != 2 {
+			t.Fatalf("expected 2 virtual transactions from 2 rules, got %d", len(res.transactions))
+		}
+		if res.transactions[0].TransactionID == res.transactions[1].TransactionID {
+			t.Errorf("doc IDs collide: both %q", res.transactions[0].TransactionID)
 		}
 	})
 


### PR DESCRIPTION
Implements graph tactic `tactic-budget-etl-balance-history`. Fixes a cluster of money-history correctness bugs in the Go budget-etl pipeline surfaced by the 2026-07-05 review, several of which had tests asserting the wrong (shifted) values.

## Unit 1 — off-by-one month anchor
`deriveMonthlyStatements` labeled each anchor "end of month m" but reversed month m's own transactions too, producing the *start*-of-month balance — every anchor was one month stale. Now reverses only transactions dated on/after the first of the next month. The `TestDeriveMonthlyStatements` assertions that cemented the shifted values are corrected to the right end-of-month balances (per test-integrity: fixed, not weakened).

## Unit 2 — merge preserves derived history and virtual edits
- `mergeStatements` retains derived (non-generated) virtual input anchors as gap-fillers, mirroring `runInputJSON`. `deriveMonthlyStatements` only re-derives anchors for single-statement accounts, so once a second file joins an account the dir path stops producing them; dropping the snapshot's stored anchors permanently deleted that account's balance history. Only *generated* virtual statements (recomputed from the rules) are still dropped.
- `runMerge` seeds `editsMap` from every input transaction, so user Note/Reimbursement edits on regenerated virtual transactions survive (parity with `runInputJSON`).

## Unit 3 — dedup and entity-decode correctness
- `autoNormalize` keys on institution/account, so two distinct same-day same-amount charges on different accounts no longer collapse (dropping one).
- `generateVirtualTransactions` dedups matched sources by source doc id (FITID) per rule, not (date, amount), so a same-day split payment yields two virtual transactions.
- `sgmlTagValue` decodes XML entities (five predefined + numeric char refs) so OFX 1.x `AT&amp;T` matches the XML path's decoded `AT&T`.

## Unit 4 — unique virtual transaction doc IDs
Virtual doc IDs fold in the matching rule's identity, so two rules matching one source no longer collide and silently overwrite one Firestore doc. `Output.Validate()` now rejects duplicate transaction doc ids so a future collision fails loudly.

## Verification
`go build ./...`, `go vet ./...`, and `go test ./...` all pass under `projects/budget-etl`. New tests: split-payment and genuine-duplicate dedup, two-rules-one-source distinct doc IDs, `Output.Validate()` duplicate-doc-id rejection, SGML entity decode + XML-twin parity, account-blind normalization, and a multi-file merge preserving a derived input anchor.