### PR TITLE
Close two auto-approve hook command-separator bypasses

### DIFF
--- a/.claude/hooks/approve-workflow-commands.sh
+++ b/.claude/hooks/approve-workflow-commands.sh
@@ -195,6 +195,29 @@ extract_and_validate_subst() {
   return 0
 }
 
+# validate_segments — split a command string into top-level segments (respecting
+# quotes) via split-command.py, and require every segment to be an allowed
+# command or an allowed worktree-scoped `git -C`. Returns 0 if all segments are
+# safe, 1 otherwise. Shared by the single-line path and the multi-line heredoc
+# path so both enforce the same separator set and per-segment allowlist.
+# The helper treats unquoted |, ;, &, &&, || as segment separators so that a
+# payload hidden after any separator is classified on its own, while regex
+# alternations like grep -E "foo|bar" stay intact inside quotes.
+validate_segments() {
+  local cleaned="$1"
+  local _SEGMENTS
+  _SEGMENTS=$(printf '%s' "$cleaned" | "$HOOK_DIR/split-command.py") || return 1
+  while IFS= read -r _SEG; do
+    [ -z "$_SEG" ] && continue
+    local cmd_token
+    cmd_token=$(printf '%s' "$_SEG" | awk '{print $1}' | sed "s/^[\"'(]*//; s/[)]*$//")
+    if ! is_allowed_cmd "$cmd_token" && ! is_allowed_git_c "$_SEG"; then
+      return 1
+    fi
+  done <<< "$_SEGMENTS"
+  return 0
+}
+
 # validate_command — validate a full command string (may contain pipes, semicolons, $()).
 # First extracts and validates $() substitutions, then splits on | and ; and checks
 # each segment for allowed commands.
@@ -224,18 +247,7 @@ validate_command() {
   fi
 
   # Split into top-level segments (respecting quotes) and validate each.
-  # The helper treats unquoted |, ;, &&, || as segment separators so that
-  # regex alternations like grep -E "foo|bar" stay intact.
-  local _SEGMENTS
-  _SEGMENTS=$(printf '%s' "$cleaned" | "$HOOK_DIR/split-command.py") || return 1
-  while IFS= read -r _SEG; do
-    [ -z "$_SEG" ] && continue
-    local cmd_token
-    cmd_token=$(printf '%s' "$_SEG" | awk '{print $1}' | sed "s/^[\"'(]*//; s/[)]*$//")
-    if ! is_allowed_cmd "$cmd_token" && ! is_allowed_git_c "$_SEG"; then
-      return 1
-    fi
-  done <<< "$_SEGMENTS"
+  validate_segments "$cleaned" || return 1
   return 0
 }
 
@@ -245,26 +257,18 @@ validate_command() {
 JOINED=$(printf '%s' "$COMMAND" | sed -e ':a' -e '/\\$/{N;s/\\\n/ /;ba}')
 FIRST_LINE=$(printf '%s' "$JOINED" | head -n 1)
 
-# Multi-line commands are rejected unless every command in the first line is an
-# approved git -C command and the line contains a heredoc (<<) explaining why
-# there are extra lines. Split on && and || to validate each part independently.
+# Multi-line commands are rejected unless every top-level segment of the first
+# line is allowed and the line contains a heredoc (<<) explaining why there are
+# extra lines. Route the first line through validate_segments — the same
+# separator-splitting (|, ;, &, &&, ||) and per-segment allowlist the
+# single-line path uses — so a payload hidden after any separator (e.g. a
+# trailing `; rm -rf /x` after the heredoc redirect) is classified on its own
+# instead of riding inside the git -C prefix that is_allowed_git_c only reads
+# fields $1-$4 of. validate_command itself is unusable here because its <>
+# rejection would reject the heredoc's own << redirect operator.
 if [ "$JOINED" != "$FIRST_LINE" ]; then
   if printf '%s\n' "$FIRST_LINE" | grep -qF '<<'; then
-    local_approved=true
-    # Split first line on && and || to validate each command independently
-    IFS_SAVE="$IFS"
-    # Replace && and || with a delimiter we can split on
-    _parts=$(printf '%s' "$FIRST_LINE" | sed 's/ *&& */ \n /g; s/ *|| */ \n /g')
-    while IFS= read -r _part; do
-      _part=$(printf '%s' "$_part" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-      [ -z "$_part" ] && continue
-      if ! is_allowed_git_c "$_part"; then
-        local_approved=false
-        break
-      fi
-    done <<< "$_parts"
-    IFS="$IFS_SAVE"
-    if [ "$local_approved" = true ]; then
+    if validate_segments "$FIRST_LINE"; then
       printf '%s\n' "$APPROVE"
     fi
   fi

--- a/.claude/hooks/split-command.py
+++ b/.claude/hooks/split-command.py
@@ -2,7 +2,9 @@
 """Split a shell command string into top-level segments, respecting quotes.
 
 Reads command from stdin. Writes one segment per line to stdout.
-A segment is separated from its neighbors by an unquoted |, ;, &&, or ||.
+A segment is separated from its neighbors by an unquoted |, ;, &, &&, or ||.
+A single & backgrounds the preceding command, so the text after it is a
+separate top-level command and must be classified on its own.
 Exits 0 on success, 1 on unbalanced quotes.
 
 Quote handling:
@@ -71,7 +73,9 @@ def split_segments(cmd: str) -> list[str]:
             i += 2
             continue
 
-        if ch in ("|", ";"):
+        # A bare & (not && — that is handled above) backgrounds the preceding
+        # command; the remainder is a separate top-level command.
+        if ch in ("|", ";", "&"):
             flush()
             i += 1
             continue

--- a/.claude/hooks/test-approve-workflow-commands.sh
+++ b/.claude/hooks/test-approve-workflow-commands.sh
@@ -347,6 +347,50 @@ assert_passthrough \
   "Bash" \
   "head file.txt | grep -E \"a|b\" | evil-command"
 
+# --- Command-separator bypass regressions ---
+# (tactic-approve-hook-command-separators)
+
+# Unit 1: a bare & backgrounds the preceding command; the payload after it must
+# be classified on its own, not ride inside the approved `echo` segment.
+assert_passthrough \
+  "bare & backgrounds echo then runs rm payload (Unit 1 regression)" \
+  "Bash" \
+  "echo hi & rm -rf /x"
+
+assert_approves \
+  "bare & between two allowed commands still approves" \
+  "Bash" \
+  "echo hi & echo bye"
+
+# Unit 2: the multi-line heredoc branch must apply the same separator-splitting
+# and per-segment allowlist as the single-line path. Build a worktree-scoped
+# git -C path the same way the hook derives its roots, and create it so
+# is_allowed_git_c's realpath() resolves.
+_GCD=$(git -C "$SCRIPT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+_DUMMY_WT="$(dirname "$_GCD")/worktrees/test-approve-hook-dummy"
+mkdir -p "$_DUMMY_WT"
+trap 'rm -rf "$_DUMMY_WT" 2>/dev/null || true' EXIT
+
+assert_approves \
+  "heredoc git -C commit to worktree (legit multi-line)" \
+  "Bash" \
+  "$(printf 'git -C %s commit -F - <<'\''EOF'\''\ncommit body\nEOF' "$_DUMMY_WT")"
+
+assert_approves \
+  "heredoc git -C commit && push (legit && chain)" \
+  "Bash" \
+  "$(printf 'git -C %s commit -F - <<'\''EOF'\'' && git -C %s push\ncommit body\nEOF' "$_DUMMY_WT" "$_DUMMY_WT")"
+
+assert_passthrough \
+  "heredoc git commit with trailing ; payload is not approved (Unit 2 regression)" \
+  "Bash" \
+  "$(printf 'git -C %s commit -F - <<'\''EOF'\'' ; rm -rf /x\ncommit body\nEOF' "$_DUMMY_WT")"
+
+assert_passthrough \
+  "heredoc git commit with trailing & payload is not approved (Unit 2 regression)" \
+  "Bash" \
+  "$(printf 'git -C %s commit -F - <<'\''EOF'\'' & rm -rf /x\ncommit body\nEOF' "$_DUMMY_WT")"
+
 # --- Other edge cases ---
 
 assert_passthrough_raw \


### PR DESCRIPTION
Graph-native tactic: `tactic-approve-hook-command-separators` (serves `strategy-autonomous-execution`).

Closes two independent auto-approve hook bypasses surfaced by the 2026-07-05 review, where a payload after a command separator could ride inside an already-approved segment and execute with no human prompt.

## Unit 1 — bare `&` separator in `split-command.py`
The splitter treated `&&`, `||`, `|`, and `;` as separators but not a single `&`. `echo hi & rm -rf /x` classified as one `echo`-headed segment and was approved. Added a bare-`&` split (excluding `&&`) so each backgrounded command is classified independently. `&&` and `&` inside quotes stay intact.

## Unit 2 — heredoc branch in `approve-workflow-commands.sh`
The multi-line heredoc branch split the first line only on `&&`/`||` and checked each part with `is_allowed_git_c`, which reads only awk fields `$1-$4`. A heredoc `git commit` with a trailing `; rm -rf /x` was approved though the single-line form is rejected. Extracted the single-line path's segment-splitting + per-segment allowlist into a shared `validate_segments` helper and routed the heredoc branch through it.

## Verification
`.claude/hooks/test-approve-workflow-commands.sh` — 66 pass, including new regressions for both bypass shapes (bare-`&` payload, heredoc trailing-`;`/`&` payload) plus positive guards (legit heredoc `git -C` commit, `&&`-chained heredoc, `&` between two allowed commands).