### PR TITLE
nix: export reusable nixosModules.default from the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -122,18 +122,28 @@
       # `error: attribute 'claude-code' missing in set` at eval time. Apply
       # claude-code-nix.overlays.default to nixpkgs before using this module.
       #
-      # The WSL box is now built in-flake as nixosConfigurations.nixos (below),
-      # consuming nixos-wsl as a flake input rather than the channel — so the old
-      # channel-unresolvability caveat is gone. nix/nixos/configuration.nix is now
-      # identity-parameterized: the host user comes from config.instance.hostUser
-      # (this instance supplies it below), so no user name is hardcoded there.
-      # But a *reusable* nixosModules.default export is still NOT provided:
-      # exporting a reusable module — with the claude-code overlay threaded through
-      # and full instance parameterization (wsl.* and the rest) — is a larger step,
-      # deliberately deferred beyond this parameterization work and out of scope
-      # here.
+      # The WSL box is built in-flake as nixosConfigurations.nixos (below),
+      # consuming nixos-wsl as a flake input rather than the channel.
+      # nix/nixos/configuration.nix is identity-parameterized: the host user
+      # comes from config.instance.hostUser (this instance supplies it below),
+      # so no user name is hardcoded there.
+      #
+      # nixosModules.default exports that framework NixOS layer as a bare path,
+      # mirroring the two exports above. configuration.nix threads no flake
+      # inputs itself, but a consumer building a host from it must supply two
+      # things the module leaves open:
+      #   - nixos-wsl.nixosModules.default, which provides the wsl.* options
+      #     (wsl.enable, wsl.defaultUser) configuration.nix sets — without it
+      #     eval fails with an undefined-option error for wsl.enable.
+      #   - instance.hostUser (a typed str with no default, defined in
+      #     nix/nixos/host-user.nix and read throughout configuration.nix), the
+      #     host user name.
+      # A consumer that also wires home-manager.users.<name> through
+      # homeManagerModules.default additionally inherits that module's
+      # claude-code overlay prerequisite noted above.
       homeManagerModules = { default = ./nix/home/default.nix; };
       darwinModules      = { default = ./nix/darwin/default.nix; };
+      nixosModules       = { default = ./nix/nixos/configuration.nix; };
 
       # Shared integrated home-manager wiring for the two host configs.
       # darwinConfigurations.default and nixosConfigurations.nixos embed the same
@@ -210,7 +220,9 @@
         specialArgs = { inherit inputs; };
         modules = [
           nixos-wsl.nixosModules.default
-          ./nix/nixos/configuration.nix
+          # Consume the framework export a forker uses, not the path directly,
+          # so the in-repo host exercises the same entry point.
+          nixosModules.default
           home-manager.nixosModules.home-manager
           (mkIntegratedHmConfig {
             hostPlatform = "x86_64-linux";
@@ -253,7 +265,7 @@
       };
     in
     systemOutputs // {
-      inherit darwinConfigurations nixosConfigurations homeManagerModules darwinModules mkPkgs;
+      inherit darwinConfigurations nixosConfigurations homeManagerModules darwinModules nixosModules mkPkgs;
       overlays = {
         # The only overlay homeManagerModules.default requires: pins
         # pkgs.claude-code to the sadjow fork. A consumer wanting just the

--- a/nix/home/wezterm-pin.nix
+++ b/nix/home/wezterm-pin.nix
@@ -33,5 +33,5 @@
   cargoHash = "sha256-jY7lTOfbT74tAZ7he1xudCN7BUxZBzY+8+e1d2g2v4I=";
 
   # SHA-256 of WezTerm-windows-nightly.zip as published for this build.
-  windowsZipHash = "sha256-r2TY0YHf8u0ImBhkMvBGKz2pZMEy6MfkVC1MV/3BLWM=";
+  windowsZipHash = "sha256-Beo9PtQ5UmqdmBbagYfVoS0hglseF/1F/uUMHtGxr1c=";
 }


### PR DESCRIPTION
Graph-native tactic `tactic-nix-export-nixos-modules` (implement phase).

## What

Export `nixosModules.default` from the flake — the framework/instance step
deliberately deferred at flake.nix:126-130. Residual greenfield work from
epic #2446 (nix framework/instance split; sub-issues #2447-#2450 all merged).

- Add `nixosModules = { default = ./nix/nixos/configuration.nix; }` beside the
  existing `homeManagerModules` / `darwinModules` bare-path exports, and add
  `nixosModules` to the final outputs `inherit` list.
- Rewire `nixosConfigurations.nixos` to consume `nixosModules.default` instead
  of importing `./nix/nixos/configuration.nix` directly, so the in-repo host
  exercises the same entry point a forker uses.
- Replace the deferral comment with a description of the now-real export and
  its two consumer prerequisites (`nixos-wsl.nixosModules.default` for the
  `wsl.*` options, and `instance.hostUser`).

Out of scope: moving personal values out of flake.nix (that is
`tactic-nix-instance-flake-extraction`, which is blocked_by this tactic); any
change to what the NixOS modules configure.

## Verification

`nix flake check --no-build` passes locally: the new `nixosModules` output is
recognized, `nixosModules.default` validates as a NixOS module, and
`nixosConfigurations.nixos` (now consuming it) evaluates cleanly. Authoritative
build gate is CI `nixos-build` / `darwin-build`.