### PR TITLE
analyticsutil: beacon-transport web-vitals + remove dead logEvent wrappers

### DIFF
--- a/packages/analyticsutil/package.json
+++ b/packages/analyticsutil/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./traffic-type": "./src/traffic-type.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/analyticsutil/src/index.ts
+++ b/packages/analyticsutil/src/index.ts
@@ -8,8 +8,9 @@ import type { FirebaseApp } from "firebase/app";
 import { classifyError } from "@commons-systems/errorutil/classify";
 import { logError } from "@commons-systems/errorutil/log";
 import { onLCP, onCLS, onINP, onFCP, onTTFB, type Metric } from "web-vitals";
+import { TRAFFIC_TYPE_STORAGE_KEY } from "./traffic-type";
 
-const STORAGE_KEY = "analytics_traffic_type";
+const STORAGE_KEY = TRAFFIC_TYPE_STORAGE_KEY;
 const PARAM_KEY = "_ct";
 
 /**
@@ -80,22 +81,18 @@ function reportWebVitals(analytics: Analytics): void {
     const metricValue = Math.round(
       metric.name === "CLS" ? metric.value * CLS_SCALE : metric.value,
     );
-    try {
-      logEvent(analytics, "web_vitals", {
-        metric_name: metric.name,
-        metric_value: metricValue,
-        metric_rating: metric.rating,
-        metric_id: metric.id,
-      });
-    } catch (error) {
-      if (classifyError(error) === "programmer") throw error;
-      logError(
-        new Error(
-          `Failed to log web-vital (metric: ${metric.name}): ${error instanceof Error ? error.message : error}`,
-        ),
-        { operation: "analytics-web-vitals" },
-      );
-    }
+    // web-vitals report at page-hide. `transport_type: "beacon"` makes gtag
+    // deliver via navigator.sendBeacon, which survives the unload — without it
+    // short/bounce sessions hidden before firebase's dynamic-config fetch
+    // resolves silently lose CLS/INP/LCP. logEvent never throws for analytics
+    // failures (the SDK swallows them internally), so there is nothing to catch.
+    logEvent(analytics, "web_vitals", {
+      metric_name: metric.name,
+      metric_value: metricValue,
+      metric_rating: metric.rating,
+      metric_id: metric.id,
+      transport_type: "beacon",
+    });
   }
 
   onLCP(report);
@@ -152,16 +149,13 @@ export function initAnalytics(app: FirebaseApp): (path: string) => void {
   reportWebVitals(analytics);
 
   return (path: string) => {
-    try {
-      logEvent(analytics, "page_view", { page_path: path });
-    } catch (error) {
-      if (classifyError(error) === "programmer") throw error;
-      logError(
-        new Error(
-          `Failed to log page view (path: ${path}): ${error instanceof Error ? error.message : error}`,
-        ),
-        { operation: "analytics-page-view" },
-      );
-    }
+    // `transport_type: "beacon"` (see reportWebVitals) delivers the first
+    // page_view of a short/bounce session via sendBeacon so it is not dropped
+    // when the tab is hidden before firebase's config fetch resolves. logEvent
+    // does not throw for analytics failures, so there is nothing to catch.
+    logEvent(analytics, "page_view", {
+      page_path: path,
+      transport_type: "beacon",
+    });
   };
 }

--- a/packages/analyticsutil/src/index.ts
+++ b/packages/analyticsutil/src/index.ts
@@ -82,10 +82,14 @@ function reportWebVitals(analytics: Analytics): void {
       metric.name === "CLS" ? metric.value * CLS_SCALE : metric.value,
     );
     // web-vitals report at page-hide. `transport_type: "beacon"` makes gtag
-    // deliver via navigator.sendBeacon, which survives the unload — without it
-    // short/bounce sessions hidden before firebase's dynamic-config fetch
-    // resolves silently lose CLS/INP/LCP. logEvent never throws for analytics
-    // failures (the SDK swallows them internally), so there is nothing to catch.
+    // deliver via navigator.sendBeacon, which survives the teardown that would
+    // otherwise cancel the request gtag issues at page-hide. Scope note: this
+    // covers sessions whose firebase init (dynamic-config fetch) has resolved
+    // by page-hide; a tab torn down BEFORE init resolves is still lost, since
+    // logEvent suspends awaiting init before gtag ever runs — that residual
+    // segment is TODO(tactic-analytics-preinit-vitals). logEvent never throws
+    // for analytics failures (the SDK swallows them internally), so there is
+    // nothing to catch.
     logEvent(analytics, "web_vitals", {
       metric_name: metric.name,
       metric_value: metricValue,
@@ -149,10 +153,11 @@ export function initAnalytics(app: FirebaseApp): (path: string) => void {
   reportWebVitals(analytics);
 
   return (path: string) => {
-    // `transport_type: "beacon"` (see reportWebVitals) delivers the first
-    // page_view of a short/bounce session via sendBeacon so it is not dropped
-    // when the tab is hidden before firebase's config fetch resolves. logEvent
-    // does not throw for analytics failures, so there is nothing to catch.
+    // `transport_type: "beacon"` (see reportWebVitals) delivers a page_view
+    // fired at/near page-hide via sendBeacon instead of a cancellable request.
+    // Same scope note as reportWebVitals: pre-init teardown is still lost —
+    // TODO(tactic-analytics-preinit-vitals). logEvent does not throw for
+    // analytics failures, so there is nothing to catch.
     logEvent(analytics, "page_view", {
       page_path: path,
       transport_type: "beacon",

--- a/packages/analyticsutil/src/traffic-type.ts
+++ b/packages/analyticsutil/src/traffic-type.ts
@@ -1,0 +1,13 @@
+/**
+ * localStorage key for the persistent internal/organic traffic flag. The GA4
+ * `traffic_type` user property is derived from it (see `initAnalytics`).
+ *
+ * Shared with the Playwright harness
+ * (`@commons-systems/config/playwright-test`), which seeds this key so CI smoke
+ * traffic is tagged `internal` rather than polluting the organic segment. It
+ * lives in its own import-light module (no firebase/web-vitals imports) so the
+ * Node-side Playwright helper can import the constant without pulling the
+ * browser analytics SDK into its module graph. Keeping one source of truth
+ * means a rename can never silently make CI smoke traffic count as organic.
+ */
+export const TRAFFIC_TYPE_STORAGE_KEY = "analytics_traffic_type";

--- a/packages/analyticsutil/test/index.test.ts
+++ b/packages/analyticsutil/test/index.test.ts
@@ -84,6 +84,7 @@ describe("initAnalytics", () => {
 
     expect(logEvent).toHaveBeenCalledWith(fakeAnalytics, "page_view", {
       page_path: "/about",
+      transport_type: "beacon",
     });
   });
 
@@ -97,38 +98,6 @@ describe("initAnalytics", () => {
     expect(() => initAnalytics(app)).toThrow("CSP blocked");
   });
 
-  it("reports error when logEvent throws", () => {
-    const sink: ErrorSink = vi.fn();
-    registerErrorSink(sink);
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never);
-    const badStateError = new Error("bad state");
-    vi.mocked(logEvent).mockImplementation(() => {
-      throw badStateError;
-    });
-
-    const app = { options: { measurementId: "G-TEST", appId: "1:test:web:abc" } } as unknown as FirebaseApp;
-    const tracker = initAnalytics(app);
-
-    expect(() => tracker("/about")).not.toThrow();
-    const reported = (vi.mocked(sink).mock.calls[0][0] as Error);
-    expect(reported.message).toBe(
-      "Failed to log page view (path: /about): bad state",
-    );
-    expect(sink).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ operation: "analytics-page-view" }));
-  });
-
-  it("re-throws TypeError from logEvent", () => {
-    vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never);
-    vi.mocked(logEvent).mockImplementation(() => {
-      throw new TypeError("invalid argument");
-    });
-
-    const app = { options: { measurementId: "G-TEST", appId: "1:test:web:abc" } } as unknown as FirebaseApp;
-    const tracker = initAnalytics(app);
-
-    expect(() => tracker("/about")).toThrow(TypeError);
-  });
 });
 
 describe("traffic tagging", () => {
@@ -334,6 +303,7 @@ describe("web-vitals reporting", () => {
       metric_value: 2500,
       metric_rating: "good",
       metric_id: "v4-1234",
+      transport_type: "beacon",
     });
   });
 
@@ -358,61 +328,10 @@ describe("web-vitals reporting", () => {
       metric_value: 123,
       metric_rating: "good",
       metric_id: "v4-5678",
+      transport_type: "beacon",
     });
   });
 
-  it("reports non-programmer logEvent error without propagating", () => {
-    const sink: ErrorSink = vi.fn();
-    registerErrorSink(sink);
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never);
-    const networkError = new Error("network failure");
-    vi.mocked(logEvent).mockImplementation(() => {
-      throw networkError;
-    });
-
-    initAnalytics(validApp);
-
-    const capturedCallback = vi.mocked(onLCP).mock.calls[0][0];
-    const fakeMetric = {
-      name: "LCP",
-      value: 1800,
-      rating: "good",
-      id: "v4-abc",
-    } as unknown as Parameters<typeof capturedCallback>[0];
-
-    expect(() => capturedCallback(fakeMetric)).not.toThrow();
-    const reported = (vi.mocked(sink).mock.calls[0][0] as Error);
-    expect(reported.message).toBe(
-      "Failed to log web-vital (metric: LCP): network failure",
-    );
-    expect(sink).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ operation: "analytics-web-vitals" }));
-  });
-
-  it.each([
-    ["TypeError", TypeError],
-    ["ReferenceError", ReferenceError],
-  ])(
-    "re-throws %s from logEvent inside web-vital callback",
-    (_name: string, ErrorCtor: new (msg: string) => Error) => {
-      vi.mocked(initializeAnalytics).mockReturnValue({ app: {} } as never); // type-safety-ok: test mock cast, matches established pattern in file
-      vi.mocked(logEvent).mockImplementation(() => {
-        throw new ErrorCtor("invalid argument");
-      });
-
-      initAnalytics(validApp);
-
-      const capturedCallback = vi.mocked(onLCP).mock.calls[0][0];
-      const fakeMetric = {
-        name: "LCP",
-        value: 1800,
-        rating: "good",
-        id: "v4-abc",
-      } as unknown as Parameters<typeof capturedCallback>[0]; // type-safety-ok: cast for synthetic metric fixture, matches established pattern in file
-
-      expect(() => capturedCallback(fakeMetric)).toThrow(ErrorCtor);
-    },
-  );
 });
 
 describe("initAnalyticsSafe", () => {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -8,6 +8,9 @@
     "test:watch": "vitest",
     "lint": "eslint *.js"
   },
+  "dependencies": {
+    "@commons-systems/analyticsutil": "*"
+  },
   "exports": {
     "./tsconfig.app.json": "./tsconfig.app.json",
     "./tsconfig.lib.json": "./tsconfig.lib.json",

--- a/packages/config/playwright-test.ts
+++ b/packages/config/playwright-test.ts
@@ -1,7 +1,5 @@
 import { test as base, expect } from "@playwright/test";
-
-// Must match STORAGE_KEY in analyticsutil/src/index.ts (a non-exported const).
-const STORAGE_KEY = "analytics_traffic_type";
+import { TRAFFIC_TYPE_STORAGE_KEY } from "@commons-systems/analyticsutil/traffic-type";
 
 export const test = base.extend({
   context: async ({ context }, use) => {
@@ -12,7 +10,7 @@ export const test = base.extend({
         // Opaque origins (the initial about:blank) have no accessible
         // localStorage; the flag seeds on the first real navigation.
       }
-    }, STORAGE_KEY);
+    }, TRAFFIC_TYPE_STORAGE_KEY);
     await use(context);
   },
 });


### PR DESCRIPTION
## Context

web-vitals (CLS/INP/LCP) report at page-hide, but firebase `logEvent`
internally awaits a dynamic-config fetch, so a tab hidden before that fetch
resolves loses the metrics and the first `page_view` — systematically censoring
the short/bounce sessions vitals exist to measure. Serves
`strategy-promote-progressive-detachment` via the GA4 export channel.

Graph node: `intentions/tactic-analytics-vitals-delivery.md`.

## Changes

**Unit 1 — beacon/flush delivery on page-hide.** Add GA4
`transport_type: "beacon"` to the `web_vitals` and first `page_view` `logEvent`
calls so gtag delivers via `navigator.sendBeacon`, which survives page-hide/
unload. Scope (qa rescope, author-ratified 2026-07-10): this covers the
post-init segment — sessions whose firebase init (dynamic-config fetch) has
resolved by page-hide, whose gtag request would otherwise be cancelled at
teardown. Tabs torn down before init resolves are still lost (`logEvent`
suspends awaiting init before gtag ever reads `transport_type`); that
residual is recorded as draft `tactic-analytics-preinit-vitals` in the
intentions graph.

**Unit 2 — remove unreachable wrappers; couple the traffic-type key.**
- Remove the `try/catch`+`logError` wrappers around the `web_vitals` and
  `page_view` `logEvent` calls. `logEvent` never throws for analytics failures
  (the SDK swallows them internally), so those catch branches could never fire —
  dead code per the clear-errors rule. The `applyTrafficTag` and
  `initAnalyticsSafe` wrappers (which guard genuinely-throwing calls) are kept.
- Share the traffic-type localStorage key as one constant
  (`@commons-systems/analyticsutil/traffic-type`), imported by both
  analyticsutil and the Playwright harness, replacing the comment-only coupling
  that let a rename on either side silently make CI smoke traffic count as
  organic.

## Test-integrity Signal 2 — escalation (path 2)

Removing the unreachable `logEvent` wrappers deliberately orphans the four tests
that mocked `logEvent` to throw (an impossible path). Deleting them is dead-code
cleanup, not test weakening — but the mechanical test-integrity gate counts 4
net declaration removals and fires Signal 2 (a blocking check). The gate cannot
distinguish legitimate cleanup from weakening; per `check-test-integrity.sh`
guidance path 2, this is escalated to office-hours for a **human
override-merge**. Restoring the tests is not viable: their subject (the swallow-
and-report branch) is intentionally deleted, so they would assert behavior the
code no longer has.

All other checks pass locally: 21 analyticsutil tests, 39 config tests,
typecheck, and lint.
