### PR TITLE
CI change-detection: transitive dep closure + root-file blind spots

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/detect-changes.sh
+++ b/.claude/skills/dispatch-propagate/scripts/detect-changes.sh
@@ -45,11 +45,14 @@ if echo "$CHANGED" | grep -qE '\.(ts|tsx|js|jsx|mjs|cjs)$|^knip\.(json|jsonc|ts)
 fi
 # go-tests needs the Go toolchain. Set go=true when a changed file is under a
 # discovered Go module. list-go-modules.sh discovers module roots from go.mod
-# locations, so a new Go module needs no edit here.
+# locations, so a new Go module needs no edit here. The root go.work / go.work.sum
+# files sit under no module prefix, yet they define the workspace every module
+# builds in — a change to them must still run go-tests, so match them directly.
 GO_MODULE_PREFIXES=$("$(dirname "$0")/list-go-modules.sh" | sed 's|$|/|')
+GO_REGEX='^go\.work(\.sum)?$'
 if [ -n "$GO_MODULE_PREFIXES" ]; then
-  GO_REGEX=$(printf '%s\n' "$GO_MODULE_PREFIXES" | paste -sd'|' -)
-  if echo "$CHANGED" | grep -qE "^($GO_REGEX)"; then
-    echo "go=true" >> "$GITHUB_OUTPUT"
-  fi
+  GO_REGEX="$GO_REGEX|^($(printf '%s\n' "$GO_MODULE_PREFIXES" | paste -sd'|' -))"
+fi
+if echo "$CHANGED" | grep -qE "$GO_REGEX"; then
+  echo "go=true" >> "$GITHUB_OUTPUT"
 fi

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -1958,9 +1958,16 @@ resolve_dirty_apps() {
       [ -n "${_seen[$cur]+x}" ] && continue
       _seen["$cur"]=1
       # If cur is itself an internal package other apps consume, its direct
-      # dependents are transitive dependents of root_pkg too.
-      if [ -n "${direct_dependents[$cur]+x}" ]; then
-        for nxt in ${direct_dependents["$cur"]}; do
+      # dependents are transitive dependents of root_pkg too. direct_dependents
+      # is keyed on the dependency SHORT name (e.g. "blog"), but cur holds a
+      # full app/workspace path (e.g. "packages/blog") — the same short-name
+      # bridge the resolve loop below uses (`short="${ws##*/}"`). Looking up
+      # direct_dependents[$cur] directly here would silently never match for
+      # any package nested under packages/ (all of them), truncating the
+      # closure at depth 1.
+      local cur_short="${cur##*/}"
+      if [ -n "${direct_dependents[$cur_short]+x}" ]; then
+        for nxt in ${direct_dependents["$cur_short"]}; do
           _queue+=("$nxt")
         done
       fi

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -1922,8 +1922,9 @@ resolve_dirty_apps() {
     return 1
   fi
 
-  # Build reverse dependency map: shared package -> consuming apps
-  declare -A shared_pkgs
+  # Build the DIRECT reverse dependency map: shared package -> apps that
+  # declare it directly in their package.json.
+  declare -A direct_dependents
   local app pkg dep_list dep_dir
   for app in "${!all_apps[@]}"; do
     pkg="$repo_root/$app/package.json"
@@ -1933,9 +1934,44 @@ resolve_dirty_apps() {
     fi
     while IFS= read -r dep_dir; do
       [ -z "$dep_dir" ] && continue
-      shared_pkgs["$dep_dir"]+="$app "
+      direct_dependents["$dep_dir"]+="$app "
     done <<< "$dep_list"
   done
+
+  # Compute the TRANSITIVE closure of internal-package dependents. Internal
+  # packages are themselves workspaces, so a dependent may in turn be consumed
+  # by other apps: a change to a leaf package must mark every app that depends
+  # on it transitively, not just its direct declarers. Concretely, fellspiral
+  # imports @commons-systems/blog which imports @commons-systems/ds, but
+  # fellspiral never declares ds — so a ds-only change must still test and
+  # deploy fellspiral. shared_pkgs[pkg] holds the transitive dependent set,
+  # keyed on the same leaf-dir short name the resolve loop below looks up.
+  declare -A shared_pkgs
+  local root_pkg cur nxt acc
+  for root_pkg in "${!direct_dependents[@]}"; do
+    unset _seen
+    declare -A _seen=()
+    local -a _queue=(${direct_dependents["$root_pkg"]})
+    while [ ${#_queue[@]} -gt 0 ]; do
+      cur="${_queue[0]}"
+      _queue=("${_queue[@]:1}")
+      [ -n "${_seen[$cur]+x}" ] && continue
+      _seen["$cur"]=1
+      # If cur is itself an internal package other apps consume, its direct
+      # dependents are transitive dependents of root_pkg too.
+      if [ -n "${direct_dependents[$cur]+x}" ]; then
+        for nxt in ${direct_dependents["$cur"]}; do
+          _queue+=("$nxt")
+        done
+      fi
+    done
+    acc=""
+    for cur in "${!_seen[@]}"; do
+      acc+="$cur "
+    done
+    shared_pkgs["$root_pkg"]="$acc"
+  done
+  unset _seen
 
   declare -A dirty_apps
   local file
@@ -1943,8 +1979,11 @@ resolve_dirty_apps() {
   while IFS= read -r file; do
     [ -z "$file" ] && continue
     case "$file" in
-      firebase.json|firestore.rules|storage.rules|package.json|package-lock.json)
-        # Root-level config changes affect all workspaces
+      firebase.json|firestore.rules|storage.rules|package.json|package-lock.json|vitest.config.ts)
+        # Root-level config changes affect all workspaces. vitest.config.ts is
+        # the root test config shared by every workspace's suite, so editing it
+        # alone must still resolve a non-empty dirty set (otherwise
+        # run-unit-tests exits 0 and a broken test config merges green).
         for app in "${!all_apps[@]}"; do
           dirty_apps["$app"]=1
         done

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -40950,6 +40950,43 @@ out=$(printf '%s\n' "package.json" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty
 assert_eq "resolve_dirty_apps: root-config fan-out marks all workspaces" \
   $'blog\nlanding\npackages/ds' "$out"
 
+# vitest.config.ts is the shared root test config: editing it alone must fan out
+# to every workspace, otherwise a broken test config resolves an empty dirty set
+# and run-unit-tests exits green. (#tactic-ci-change-detection-transitive Unit 2)
+echo "Test: resolve_dirty_apps -- vitest.config.ts fan-out marks all workspaces"
+out=$(printf '%s\n' "vitest.config.ts" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$TMPDIR_TEST") | sort)
+assert_eq "resolve_dirty_apps: vitest.config.ts fan-out marks all workspaces" \
+  $'blog\nlanding\npackages/ds' "$out"
+
+rm -rf "$TMPDIR_TEST"
+TMPDIR_TEST=""
+
+# Transitive internal-dep closure (#tactic-ci-change-detection-transitive Unit 1).
+# fellspiral -> @commons-systems/blog -> @commons-systems/ds, but fellspiral
+# never declares ds. A ds-only change must still mark fellspiral dirty via the
+# transitive closure, not just blog (its direct declarer).
+echo ""
+echo "=== resolve_dirty_apps: transitive internal-dep closure ==="
+
+echo "Test: resolve_dirty_apps -- ds change marks transitive dependent fellspiral"
+TMPDIR_TEST=$(mktemp -d)
+mkdir -p "$TMPDIR_TEST/fellspiral" "$TMPDIR_TEST/blog" "$TMPDIR_TEST/packages/ds"
+printf '%s' '{"workspaces":["fellspiral","blog","packages/ds"]}' > "$TMPDIR_TEST/package.json"
+printf '%s' '{"dependencies":{"@commons-systems/blog":"*"}}' > "$TMPDIR_TEST/fellspiral/package.json"
+printf '%s' '{"dependencies":{"@commons-systems/ds":"*"}}' > "$TMPDIR_TEST/blog/package.json"
+printf '%s' '{}' > "$TMPDIR_TEST/packages/ds/package.json"
+
+out=$(printf '%s\n' "packages/ds/base.css" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$TMPDIR_TEST") | sort)
+assert_eq "resolve_dirty_apps: ds change marks blog and transitive fellspiral" \
+  $'blog\nfellspiral\npackages/ds' "$out"
+
+# A change to the mid-tier package (blog) marks only blog and its dependent
+# fellspiral, never the leaf ds it consumes (dependents propagate up, not down).
+echo "Test: resolve_dirty_apps -- blog change marks fellspiral but not ds"
+out=$(printf '%s\n' "blog/index.ts" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$TMPDIR_TEST") | sort)
+assert_eq "resolve_dirty_apps: blog change marks blog and fellspiral only" \
+  $'blog\nfellspiral' "$out"
+
 rm -rf "$TMPDIR_TEST"
 TMPDIR_TEST=""
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -41009,6 +41009,28 @@ assert_eq "resolve_dirty_apps: blog change marks blog and fellspiral only" \
 rm -rf "$TMPDIR_TEST"
 TMPDIR_TEST=""
 
+# Same transitive closure, but with the mid-tier package nested under packages/
+# (the real repo's actual layout: every internal @commons-systems/* package
+# lives at packages/<name>, never at a bare top-level <name> dir). The
+# dependency-short-name key ("blog") and the workspace app path
+# ("packages/blog") diverge here, which the flat-workspace fixture above
+# cannot exercise — a BFS that mistakenly re-keys on the full app path instead
+# of re-deriving the short name silently truncates the closure at depth 1.
+echo "Test: resolve_dirty_apps -- ds change marks transitive dependent fellspiral (nested packages/ mid-tier)"
+TMPDIR_TEST=$(mktemp -d)
+mkdir -p "$TMPDIR_TEST/fellspiral" "$TMPDIR_TEST/packages/blog" "$TMPDIR_TEST/packages/ds"
+printf '%s' '{"workspaces":["fellspiral","packages/blog","packages/ds"]}' > "$TMPDIR_TEST/package.json"
+printf '%s' '{"dependencies":{"@commons-systems/blog":"*"}}' > "$TMPDIR_TEST/fellspiral/package.json"
+printf '%s' '{"peerDependencies":{"@commons-systems/ds":"*"}}' > "$TMPDIR_TEST/packages/blog/package.json"
+printf '%s' '{}' > "$TMPDIR_TEST/packages/ds/package.json"
+
+out=$(printf '%s\n' "packages/ds/base.css" | (source "$SCRIPT_DIR/lib.sh"; resolve_dirty_apps "$TMPDIR_TEST") | sort)
+assert_eq "resolve_dirty_apps: ds change marks nested packages/blog and transitive fellspiral" \
+  $'fellspiral\npackages/blog\npackages/ds' "$out"
+
+rm -rf "$TMPDIR_TEST"
+TMPDIR_TEST=""
+
 # dispatch-review-erosion tests
 # ============================================================================
 #


### PR DESCRIPTION
## What

Fixes two CI change-detection blind spots that let real changes ship untested/undeployed. Graph node `tactic-ci-change-detection-transitive` (serves strategy-autonomous-execution).

### Unit 1 — transitive internal-dep propagation
`resolve_dirty_apps` in `lib.sh` mapped each internal package to its *direct* declarers only. Internal packages are themselves workspaces, so a leaf change never reached transitive dependents: a `ds`-only change tested/deployed every app except fellspiral, which imports `@commons-systems/blog` which imports `@commons-systems/ds` but never declares `ds` itself. Now computes the transitive closure of the reverse-dependency graph.

### Unit 2 — root-file blind spots
- `lib.sh`: added `vitest.config.ts` to the mark-all-dirty root-file list. A PR editing only it resolved zero dirty apps, so run-unit-tests exited 0 and a broken test config merged green.
- `detect-changes.sh`: added a root `go.work` / `go.work.sum` arm. Those files sit under no discovered Go module prefix, so a go.work change previously skipped go-tests.

## Tests
Added fixtures to `test-dispatch-scripts.sh`:
- ds change marks blog + transitive fellspiral
- blog change marks fellspiral but not the leaf ds it consumes
- vitest.config.ts fan-out marks all workspaces

All pass; the go.work regex is anchored to repo root (nested `foo/go.work` does not match).
