### PR TITLE
fellspiral prerender: buildTimeFeeds parity

### DIFF
--- a/fellspiral/scripts/blog-roll-feeds-artifact.ts
+++ b/fellspiral/scripts/blog-roll-feeds-artifact.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { LatestPost } from "@commons-systems/blog/blog-roll/types";
+
+// Absolute path of the build-time blog-roll feed snapshot. `vite.config.ts`'s
+// feedFetchPlugin writes it at build end; the post-build tsx prerender
+// (scripts/prerender.ts) reads it and passes it as `buildTimeFeeds`, so the
+// prerendered info-panel hydrates from the SAME data the client's
+// `virtual:blog-roll-feeds` bundle inlines. Resolved relative to THIS module so
+// both importers (vite.config at the app root, prerender under scripts/) agree
+// regardless of their own location. Lives under `tmp/` (root .gitignore's
+// `**/tmp/`) — a build scratch artifact, not deployed content.
+const here = dirname(fileURLToPath(import.meta.url));
+export const BLOG_ROLL_FEEDS_ARTIFACT = join(
+  here,
+  "..",
+  "tmp",
+  "blog-roll-feeds.json",
+);
+
+/**
+ * Read the build-time feed snapshot the vite `feedFetchPlugin` persisted (it
+ * inlines the same data into the client via `virtual:blog-roll-feeds`, which the
+ * standalone tsx prerender cannot import). Returned as `buildTimeFeeds`, it makes
+ * the prerendered info-panel byte-match the client's first render — the
+ * InfoPanelRegion initializer is a pure function of `data`, so identical
+ * `blogRoll` + `buildTimeFeeds` on both sides means no hydration mismatch on the
+ * panel root (the prod bug #2173 failure class).
+ *
+ * Fails loudly rather than silently prerendering empty feeds:
+ *  - a missing/malformed artifact is a build misconfiguration (the vite build
+ *    must run before the prerender);
+ *  - a **parity assertion** requires the artifact's ids to match `expectedIds`
+ *    exactly. `expectedIds` is the blogRoll id-space the client hydrates (the
+ *    feed registry), so any drift — stale artifact, registry change, partial
+ *    write — would resurface an SSR/client mismatch and fails the build instead.
+ */
+export function readBlogRollFeedsArtifact(
+  expectedIds: readonly string[],
+  artifactPath: string = BLOG_ROLL_FEEDS_ARTIFACT,
+): Record<string, LatestPost | null> {
+  let raw: string;
+  try {
+    raw = readFileSync(artifactPath, "utf8");
+  } catch (err) {
+    throw new Error(
+      `Blog-roll feed artifact not found at ${artifactPath}. It is written by ` +
+        `feedFetchPlugin during \`vite build\`; run the vite build before the ` +
+        `prerender (see fellspiral/package.json "build").`,
+      { cause: err },
+    );
+  }
+  // Boundary parse of a build artifact this module's own writer (feedFetchPlugin)
+  // produced; the id-set parity assertion below validates its keys.
+  const feeds = JSON.parse(raw) as Record<string, LatestPost | null>; // type-safety-ok: boundary parse of a self-produced build artifact validated by the parity assertion below
+
+  const wantIds = [...expectedIds].sort();
+  const gotIds = Object.keys(feeds).sort();
+  const equal =
+    wantIds.length === gotIds.length && wantIds.every((id, i) => id === gotIds[i]);
+  if (!equal) {
+    throw new Error(
+      `Blog-roll feed parity check failed: artifact ids [${gotIds.join(", ")}] ` +
+        `do not match the expected blogRoll ids [${wantIds.join(", ")}]. The ` +
+        `prerendered info-panel would diverge from the client hydration.`,
+    );
+  }
+  return feeds;
+}

--- a/fellspiral/scripts/prerender.ts
+++ b/fellspiral/scripts/prerender.ts
@@ -14,8 +14,16 @@ import {
   AUTHOR,
   REL_ME,
 } from "../src/site-config.js";
+import { readBlogRollFeedsArtifact } from "./blog-roll-feeds-artifact.js";
 
 const distDir = join(dirname(new URL(import.meta.url).pathname), "..", "dist");
+
+// The build-time feed snapshot the vite `feedFetchPlugin` persisted, keyed by
+// FEED_REGISTRY id (the same data the client's `virtual:blog-roll-feeds` bundle
+// inlines). Passed below as `buildTimeFeeds` so the prerendered info-panel
+// hydrates from identical input — closing the SSR/client mismatch on the panel
+// root. Throws on a missing/drifted artifact (the build-time parity assertion).
+const buildTimeFeeds = readBlogRollFeedsArtifact(FEED_REGISTRY.map((f) => f.id));
 
 try {
   await prerenderPosts({
@@ -30,6 +38,7 @@ try {
       blogRoll: FEED_REGISTRY.map((f) => ({ id: f.id, name: f.name, url: f.homeUrl })),
       rssFeedUrl: "/feed.xml",
       opmlUrl: "/blogroll.opml",
+      buildTimeFeeds,
     },
     siteDefaults: SITE_DEFAULTS,
     organization: ORGANIZATION,

--- a/fellspiral/test/blog-roll-feeds-artifact.test.ts
+++ b/fellspiral/test/blog-roll-feeds-artifact.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readBlogRollFeedsArtifact } from "../scripts/blog-roll-feeds-artifact.js";
+
+function withArtifact(
+  contents: string,
+  run: (path: string) => void,
+): void {
+  const dir = mkdtempSync(join(tmpdir(), "feeds-artifact-"));
+  const path = join(dir, "blog-roll-feeds.json");
+  writeFileSync(path, contents, "utf8");
+  try {
+    run(path);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("readBlogRollFeedsArtifact", () => {
+  it("returns the parsed feed map when artifact ids match the expected ids", () => {
+    const feeds = {
+      a: { title: "A", url: "https://a.example/1", publishedAt: "2026-01-01T00:00:00Z" },
+      b: null,
+    };
+    withArtifact(JSON.stringify(feeds), (path) => {
+      expect(readBlogRollFeedsArtifact(["a", "b"], path)).toEqual(feeds);
+      // Id-set equality is order-insensitive.
+      expect(readBlogRollFeedsArtifact(["b", "a"], path)).toEqual(feeds);
+    });
+  });
+
+  it("throws a parity error when the artifact omits an expected id", () => {
+    withArtifact(JSON.stringify({ a: null }), (path) => {
+      expect(() => readBlogRollFeedsArtifact(["a", "b"], path)).toThrow(
+        /parity check failed/,
+      );
+    });
+  });
+
+  it("throws a parity error when the artifact carries an unexpected id", () => {
+    withArtifact(JSON.stringify({ a: null, extra: null }), (path) => {
+      expect(() => readBlogRollFeedsArtifact(["a"], path)).toThrow(
+        /parity check failed/,
+      );
+    });
+  });
+
+  it("throws a clear error when the artifact file is missing", () => {
+    expect(() =>
+      readBlogRollFeedsArtifact(["a"], join(tmpdir(), "does-not-exist-xyz.json")),
+    ).toThrow(/feed artifact not found/);
+  });
+});

--- a/fellspiral/vite.config.ts
+++ b/fellspiral/vite.config.ts
@@ -6,6 +6,7 @@ import { blogPostsPlugin } from "@commons-systems/blog/vite-plugin-blog-posts";
 import { buildFeedXml } from "@commons-systems/blog/feed";
 import { FEED_REGISTRY } from "@commons-systems/blog/blog-roll/feed-registry";
 import appSeed from "./seeds/firestore.js";
+import { BLOG_ROLL_FEEDS_ARTIFACT } from "./scripts/blog-roll-feeds-artifact.js";
 
 const FUNCTIONS_PORT = process.env.VITE_FUNCTIONS_EMULATOR_PORT ?? "5001";
 const FIREBASE_PROJECT_ID = process.env.VITE_FIREBASE_PROJECT_ID;
@@ -13,7 +14,10 @@ const FIREBASE_PROJECT_ID = process.env.VITE_FIREBASE_PROJECT_ID;
 export default createAppConfig({
   plugins: [
     blogPostsPlugin({ seed: appSeed, postDir: resolve(__dirname, "post") }),
-    feedFetchPlugin(FEED_REGISTRY.map((f) => ({ id: f.id, url: f.feedUrl }))),
+    feedFetchPlugin(
+      FEED_REGISTRY.map((f) => ({ id: f.id, url: f.feedUrl })),
+      { emitPath: BLOG_ROLL_FEEDS_ARTIFACT },
+    ),
     feedXmlPlugin(() =>
       buildFeedXml({
         title: "fellspiral",

--- a/packages/blog/src/blog-roll/vite-plugin-feed-fetch.ts
+++ b/packages/blog/src/blog-roll/vite-plugin-feed-fetch.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import type { Plugin } from "vite";
 import { classifyError } from "@commons-systems/errorutil";
 import type { LatestPost } from "./types.ts";
@@ -8,10 +10,23 @@ export interface FeedConfig {
   url: string;
 }
 
+export interface FeedFetchPluginOptions {
+  /** When set, the fetched feed snapshot is persisted to this absolute path at
+   *  build end (`writeBundle`). The post-build tsx prerender reads the same file
+   *  and passes it as `buildTimeFeeds`, so the prerendered info-panel hydrates
+   *  from the SAME data the client's `virtual:blog-roll-feeds` bundle inlines —
+   *  closing the SSR/client parity gap (the `virtual:` module only exists inside
+   *  the vite build, so the standalone tsx prerender cannot import it). */
+  emitPath?: string;
+}
+
 const VIRTUAL_MODULE_ID = "virtual:blog-roll-feeds";
 const RESOLVED_VIRTUAL_MODULE_ID = "\0" + VIRTUAL_MODULE_ID;
 
-export function feedFetchPlugin(feeds: FeedConfig[]): Plugin {
+export function feedFetchPlugin(
+  feeds: FeedConfig[],
+  options: FeedFetchPluginOptions = {},
+): Plugin {
   let feedData: Record<string, LatestPost | null> = {};
 
   return {
@@ -67,6 +82,15 @@ export function feedFetchPlugin(feeds: FeedConfig[]): Plugin {
       if (id === RESOLVED_VIRTUAL_MODULE_ID) {
         return `export default ${JSON.stringify(feedData)};`;
       }
+    },
+    // Persist the same snapshot the virtual module inlined so the post-build tsx
+    // prerender can read it (it cannot import the `virtual:` module). Runs after
+    // the bundle is written, so `feedData` from `buildStart` is fully populated.
+    writeBundle() {
+      const { emitPath } = options;
+      if (!emitPath) return;
+      mkdirSync(dirname(emitPath), { recursive: true });
+      writeFileSync(emitPath, JSON.stringify(feedData, null, 2), "utf8");
     },
   };
 }

--- a/packages/blog/test/blog-roll/vite-plugin-feed-fetch.test.ts
+++ b/packages/blog/test/blog-roll/vite-plugin-feed-fetch.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   feedFetchPlugin,
   parseAtomFeedXml,
@@ -223,5 +226,64 @@ describe("feedFetchPlugin buildStart error handling", () => {
     await expect((plugin as any).buildStart()).rejects.toThrow( // type-safety-ok: invoking Vite plugin hook directly in unit test
       "invalid fetch configuration",
     );
+  });
+});
+
+describe("feedFetchPlugin emitPath artifact", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("persists the same snapshot the virtual module inlines to emitPath", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "feed-fetch-"));
+    // Nested subdir the plugin must create (mkdirSync recursive).
+    const emitPath = join(dir, "nested", "blog-roll-feeds.json");
+    try {
+      const xml = `<feed><entry>
+        <title>Latest</title>
+        <link rel="alternate" href="https://example.com/latest" />
+        <published>2026-05-01T00:00:00Z</published>
+      </entry></feed>`;
+      vi.stubGlobal("fetch", () =>
+        Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(xml) }),
+      );
+
+      const plugin = feedFetchPlugin(
+        [{ id: "test", url: "https://example.com/feed.xml" }],
+        { emitPath },
+      );
+
+      await (plugin as any).buildStart(); // type-safety-ok: invoking Vite plugin hook directly in unit test
+      (plugin as any).writeBundle(); // type-safety-ok: invoking Vite plugin hook directly in unit test
+
+      // The persisted artifact must equal what the virtual module inlines — one
+      // source feeds both the client bundle and the prerender.
+      const virtualCode = (plugin as any).load("\0virtual:blog-roll-feeds"); // type-safety-ok: invoking Vite plugin hook directly in unit test
+      const virtualData = parseVirtualModule(virtualCode);
+      const artifact = JSON.parse(readFileSync(emitPath, "utf8"));
+      expect(artifact).toEqual(virtualData);
+      expect(artifact).toEqual({
+        test: {
+          title: "Latest",
+          url: "https://example.com/latest",
+          publishedAt: "2026-05-01T00:00:00Z",
+        },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not write any file when emitPath is omitted", async () => {
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve("<feed></feed>") }),
+    );
+    const plugin = feedFetchPlugin([
+      { id: "test", url: "https://example.com/feed.xml" },
+    ]);
+    await (plugin as any).buildStart(); // type-safety-ok: invoking Vite plugin hook directly in unit test
+    // No emitPath configured: writeBundle is a no-op and must not throw.
+    expect(() => (plugin as any).writeBundle()).not.toThrow(); // type-safety-ok: invoking Vite plugin hook directly in unit test
   });
 });


### PR DESCRIPTION
## Context

`fellspiral/scripts/prerender.ts` omitted `buildTimeFeeds` from the info-panel
data while the client hydrates `InfoPanelRegion` with it
(`fellspiral/src/main.ts` -> `virtual:blog-roll-feeds`), guaranteeing an
SSR/client mismatch on the panel root whenever the build-time feed fetch returned
data — the same failure class as prod bug #2173. Structural cause:
`virtual:blog-roll-feeds` only exists inside the vite build, so the post-build
tsx prerender cannot import it.

Graph node: `tactic-fellspiral-prerender-feed-parity` (serves
`strategy-tabletop-storytelling`).

## Change

- `feedFetchPlugin` gains an optional `emitPath`. When set, a `writeBundle` hook
  persists the fetched feed snapshot — the SAME data it inlines into the client
  bundle — to that path at build end.
- `fellspiral/vite.config.ts` passes `emitPath`; a shared
  `scripts/blog-roll-feeds-artifact.ts` module holds the path (under `tmp/`, a
  build scratch artifact) so `vite.config` and the prerender agree on it.
- `fellspiral/scripts/prerender.ts` reads the artifact and passes it as
  `buildTimeFeeds`, so both sides hydrate the info-panel from identical input.
- Build-time parity assertion (`readBlogRollFeedsArtifact`): fails the build if
  the artifact's ids drift from the feed registry (stale artifact, registry
  change, partial write), or if the artifact is missing.

## Greenfield vs migration

The greenfield ideal is to run the prerender *inside* the vite build so
`virtual:blog-roll-feeds` resolves directly and no artifact is needed. That is a
cross-app change (every blog app uses a post-build tsx prerender), out of scope
for one PR. This PR takes the artifact-handoff migration step, which keeps the
existing post-build prerender architecture.

## Verification

- `npm run build --prefix fellspiral` completes; the prerendered
  `dist/index.html` info-panel now carries the build-time post titles in the
  date-sorted order the client initializer produces from the same
  `buildTimeFeeds` (SSR now matches the client's first render).
- Unit tests: `feedFetchPlugin` `writeBundle` persists the artifact matching the
  virtual module; `readBlogRollFeedsArtifact` parity assertion covers
  match/drift/missing.

```verify
npx vitest run --project packages/blog --project fellspiral --root .
```