### PR TITLE
sidecar: cross-tab write coordination + surfaced persist failures

### DIFF
--- a/packages/sidecar/src/factory.ts
+++ b/packages/sidecar/src/factory.ts
@@ -24,6 +24,23 @@ export function serializeSidecar<TData>(data: TData): string {
   return JSON.stringify(data, null, 2);
 }
 
+/**
+ * Run `fn` while holding a cross-tab exclusive Web Lock named `name`, so the
+ * read-merge-write it performs is atomic against every other tab on the same
+ * origin holding the same-named lock — the cross-tab no-clobber guarantee.
+ *
+ * Web Locks is a progressive enhancement: where `navigator.locks` is
+ * unavailable (older engines, non-window contexts, the test runner) the
+ * callback runs directly. The per-tab single-flight write chain still
+ * serializes writes within the tab, so correctness degrades only to the
+ * pre-existing single-tab guarantee, never below it.
+ */
+async function withWriteLock<T>(name: string, fn: () => Promise<T>): Promise<T> {
+  const locks = globalThis.navigator?.locks;
+  if (!locks) return fn();
+  return locks.request(name, fn);
+}
+
 // ---------------------------------------------------------------------------
 // B. Factory options + return shape
 // ---------------------------------------------------------------------------
@@ -92,10 +109,19 @@ export function createSidecar<TData, TPatch>(
   let corruptOnDisk = false;
 
   // Single-flight write chain: every mutation appends to this promise so
-  // concurrent saves cannot race or interleave on the file. Each link merges its
-  // patch against the result of the prior link, then persists (disk write gated
-  // by `writable`).
+  // concurrent saves cannot race or interleave on the file within this tab. Each
+  // link read-merge-writes against on-disk state under a cross-tab Web Lock, so
+  // the no-clobber guarantee also holds across tabs. The chain is kept recovered
+  // (never rejects) so one failed write cannot poison the next link; a failure
+  // is surfaced to the caller through the promise `enqueueWrite` returns and,
+  // for a drain, through `pendingFailure` below.
   let writeChain: Promise<void> = Promise.resolve();
+
+  // The error from the most recently *settled* queued write, or null when the
+  // latest settled write succeeded. `flushWrites` throws it so a drain reflects
+  // a persist failure; a later successful write (which read-merge-wrote the disk
+  // into a consistent state) clears it.
+  let pendingFailure: unknown = null;
 
   // Incremented on every setLocalDirectory / clearLocalDirectory so in-memory
   // assignments can be guarded against writes that started before the switch.
@@ -166,6 +192,17 @@ export function createSidecar<TData, TPatch>(
   }
 
   /**
+   * Name of the cross-tab Web Lock guarding writes to a folder's sidecar. Keyed
+   * by the sidecar dir name and the folder handle's name so two tabs on the same
+   * folder contend (the case that must serialize) while unrelated folders mostly
+   * do not. A name collision only over-serializes (always safe); it never lets
+   * two writers to the same folder run concurrently.
+   */
+  function writeLockName(handle: FileSystemDirectoryHandle): string {
+    return `commons-sidecar-write:${sidecarDirName}:${handle.name}`;
+  }
+
+  /**
    * Store the retained directory handle and writable flag (called after the
    * folder is picked / permission resolved). Invalidates the cached model so the
    * next access re-reads lazily from the new handle.
@@ -178,6 +215,7 @@ export function createSidecar<TData, TPatch>(
     loadPromise = null;
     corruptOnDisk = false;
     writeChain = Promise.resolve();
+    pendingFailure = null;
   }
 
   /**
@@ -194,6 +232,7 @@ export function createSidecar<TData, TPatch>(
     loadPromise = null;
     corruptOnDisk = false;
     writeChain = Promise.resolve();
+    pendingFailure = null;
   }
 
   /**
@@ -235,46 +274,97 @@ export function createSidecar<TData, TPatch>(
   }
 
   /**
-   * Queue a merge-and-persist onto the single-flight write chain. The merge runs
-   * inside the task (after ensureLoaded) so each link merges against the prior
-   * link's result — the no-clobber serialization guarantee. The in-memory model
-   * is ALWAYS updated so the current session stays consistent; the disk write is
-   * gated by `writable` (work happens in-memory even when the folder is not
-   * writable, and the disk save silently no-ops). The per-link catch keeps one
-   * failed write from poisoning the chain.
+   * Queue a merge-and-persist onto the single-flight write chain. The in-memory
+   * model is ALWAYS updated so the current session stays consistent.
+   *
+   * When the folder is writable and not known-corrupt, the persist is a
+   * read-merge-write against the CURRENT on-disk state, run under a cross-tab
+   * Web Lock: the patch is merged onto whatever is on disk right now (including
+   * entries another tab has since persisted) rather than onto this tab's
+   * possibly-stale in-memory model, so two tabs on one folder no longer clobber
+   * each other. When the folder is not writable, work happens in-memory only.
+   *
+   * The returned promise REJECTS if the disk persist fails, so a caller learns a
+   * save did not reach disk (against silent data loss). The single-flight chain
+   * itself is kept recovered so one failed write cannot poison the next.
    */
   function enqueueWrite(patch: TPatch): Promise<void> {
     const snapshotHandle = dirHandle;
     const snapshotWritable = writable;
     const snapshotGen = generation;
-    writeChain = writeChain
-      .then(async () => {
-        // TOCTOU guard: if the bound directory changed between enqueue and
-        // execution (rapid disconnect/reconnect), this patch was issued for the
-        // previous folder — skip it entirely so it neither persists to the new
-        // folder nor contaminates the new folder's in-memory model.
-        if (dirHandle !== snapshotHandle) return;
-        const model = await ensureLoaded();
+    const work = writeChain.then(async () => {
+      // TOCTOU guard: if the bound directory changed between enqueue and
+      // execution (rapid disconnect/reconnect), this patch was issued for the
+      // previous folder — skip it entirely so it neither persists to the new
+      // folder nor contaminates the new folder's in-memory model.
+      if (dirHandle !== snapshotHandle) return;
+      const model = await ensureLoaded();
+
+      // In-memory-only path: no writable disk, or the disk is known-corrupt
+      // (logged once at load time; stay silent here so repeated saves don't spam
+      // the log). Fold the patch into the in-memory model and stop.
+      if (!snapshotWritable || snapshotHandle === null || corruptOnDisk) {
         const merged = mergeSidecar(model, patch);
         if (generation === snapshotGen) cachedModel = merged;
-        // Corruption was logged once at load time; return silently here so
-        // repeated saves don't spam the error log.
-        if (corruptOnDisk) return;
-        // Persist to the SNAPSHOT handle (not the live global), so a switch that
-        // races in after the guard still writes to the folder this patch was for.
-        if (snapshotWritable && snapshotHandle !== null) {
-          await writeSidecar(snapshotHandle, merged);
+        return;
+      }
+
+      // Read-merge-write against on-disk state under a cross-tab lock. Persist
+      // to the SNAPSHOT handle (not the live global) so a switch that races in
+      // after the guard still writes to the folder this patch was for.
+      await withWriteLock(writeLockName(snapshotHandle), async () => {
+        // Re-guard inside the lock: a folder switch may have landed while we
+        // waited to acquire it.
+        if (dirHandle !== snapshotHandle) return;
+        const onDisk = await readSidecar(snapshotHandle);
+        if (onDisk === null) {
+          // The on-disk file became corrupt (e.g. a concurrent tab wrote
+          // garbage) after our clean load. Suppress the write to preserve the
+          // recoverable bytes — same contract as load-time corruption — and
+          // fold the patch into the in-memory model so the session stays usable.
+          corruptOnDisk = true;
+          logError(
+            new Error(
+              "sidecar corrupt on disk at write time; suppressing write to preserve recoverable user data",
+            ),
+            { operation: "enqueueWrite" },
+          );
+          const merged = mergeSidecar(model, patch);
+          if (generation === snapshotGen) cachedModel = merged;
+          return;
         }
-      })
-      .catch((err) => {
-        logError(err, { operation: "sidecarWrite" });
+        const merged = mergeSidecar(onDisk, patch);
+        await writeSidecar(snapshotHandle, merged);
+        if (generation === snapshotGen) cachedModel = merged;
       });
-    return writeChain;
+    });
+    // Recover the single-flight chain and record the latest write's outcome so a
+    // later `flushWrites` drain reflects it; a subsequent success clears it.
+    writeChain = work.then(
+      () => {
+        pendingFailure = null;
+      },
+      (err) => {
+        pendingFailure = err;
+      },
+    );
+    // Surface the failure to the caller (logging centrally, as before) while the
+    // recovered chain above keeps the queue alive.
+    return work.catch((err) => {
+      logError(err, { operation: "sidecarWrite" });
+      throw err;
+    });
   }
 
-  /** Drain the pending write chain. Tests await this to assert persistence. */
+  /**
+   * Drain the pending write chain, then reflect a persist failure: if the most
+   * recently settled queued write failed, reject with its error. Tests await
+   * this to assert persistence.
+   */
   function flushWrites(): Promise<void> {
-    return writeChain;
+    return writeChain.then(() => {
+      if (pendingFailure !== null) throw pendingFailure;
+    });
   }
 
   return {

--- a/packages/sidecar/test/factory.test.ts
+++ b/packages/sidecar/test/factory.test.ts
@@ -205,6 +205,38 @@ describe("createSidecar factory", () => {
     expect(onDisk?.values).toEqual({ a: 1, b: 2 });
   });
 
+  // The read-merge-write re-reads on-disk state on every write, so it can
+  // discover corruption another tab introduced after our clean load — not
+  // just at load time. That must suppress the disk write (preserving the
+  // recoverable bytes) while still folding the patch into the in-memory
+  // model, matching the load-time corruption contract.
+  it("a write-time on-disk corruption suppresses the disk write but keeps the in-memory merge", async () => {
+    const disk: DiskCell = { content: null };
+    const { dir } = makeDir(disk);
+    const s = makeHandle();
+    s.setLocalDirectory(dir, true);
+
+    await s.enqueueWrite({ values: { a: 1 } });
+    await s.flushWrites();
+    const beforeCorruption = disk.content;
+
+    // Simulate another tab clobbering the file with garbage between our load
+    // and this write's read-merge-write.
+    disk.content = "not json{";
+
+    await s.enqueueWrite({ values: { b: 2 } });
+    await s.flushWrites();
+
+    // The disk write was suppressed: raw content is still the garbage, not a
+    // freshly-serialized model.
+    expect(disk.content).toBe("not json{");
+    expect(disk.content).not.toBe(beforeCorruption);
+
+    // The in-memory model still reflects the merge so the session stays usable.
+    const loaded = await s.ensureLoaded();
+    expect(loaded.values).toEqual({ a: 1, b: 2 });
+  });
+
   // --- Unit 2: surface persist failures ---
 
   // A failed disk write rejects the caller's promise instead of resolving.

--- a/packages/sidecar/test/factory.test.ts
+++ b/packages/sidecar/test/factory.test.ts
@@ -41,6 +41,54 @@ function makeHandle() {
 }
 
 // ---------------------------------------------------------------------------
+// Minimal in-memory FSA directory-handle fake backed by a shared "disk" cell,
+// so two handles pointed at the same cell model two tabs on one folder.
+// ---------------------------------------------------------------------------
+
+interface DiskCell {
+  content: string | null;
+}
+
+function makeDir(
+  disk: DiskCell,
+  opts: { failWrite?: boolean } = {},
+): { dir: FileSystemDirectoryHandle; writeCount: () => number } {
+  let writes = 0;
+  const fileHandle = {
+    getFile: () =>
+      disk.content === null
+        ? Promise.reject(new DOMException("missing", "NotFoundError"))
+        : Promise.resolve({ text: () => Promise.resolve(disk.content as string) }), // type-safety-ok: fake FSA file content is a string in test
+    createWritable: () => {
+      writes++;
+      let buf = "";
+      return Promise.resolve({
+        write: (s: string) => {
+          if (opts.failWrite) return Promise.reject(new Error("disk full"));
+          buf += s;
+          return Promise.resolve();
+        },
+        close: () => {
+          disk.content = buf;
+          return Promise.resolve();
+        },
+        abort: () => Promise.resolve(),
+      });
+    },
+  };
+  const subdir = {
+    getFileHandle: (_name: string, _opts?: { create?: boolean }) =>
+      Promise.resolve(fileHandle),
+  };
+  const dir = {
+    name: "folder",
+    getDirectoryHandle: (_name: string, _opts?: { create?: boolean }) =>
+      Promise.resolve(subdir),
+  } as unknown as FileSystemDirectoryHandle; // type-safety-ok: in-memory FSA directory-handle fake for test
+  return { dir, writeCount: () => writes };
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -103,6 +151,92 @@ describe("createSidecar factory", () => {
     sidecar.clearLocalDirectory();
     const loaded = await sidecar.ensureLoaded();
     expect(loaded).toEqual({ version: 1, values: {} });
+  });
+
+  // --- Unit 1: cross-tab write coordination (read-merge-write against disk) ---
+
+  // Two tabs on one folder: the second tab's write must preserve the first
+  // tab's already-persisted entry instead of clobbering it against a stale
+  // in-memory model.
+  it("two tabs on one folder preserve both tabs' entries (cross-tab no-clobber)", async () => {
+    const disk: DiskCell = { content: null };
+    const { dir } = makeDir(disk);
+
+    const tabA = makeHandle();
+    const tabB = makeHandle();
+    tabA.setLocalDirectory(dir, true);
+    tabB.setLocalDirectory(dir, true);
+
+    // Tab A persists {a:1}. Tab B — whose in-memory model never saw {a:1} —
+    // then persists {b:2}.
+    await tabA.enqueueWrite({ values: { a: 1 } });
+    await tabA.flushWrites();
+    await tabB.enqueueWrite({ values: { b: 2 } });
+    await tabB.flushWrites();
+
+    // On disk both survive: tab B read-merge-wrote against tab A's persisted
+    // state rather than its own stale (empty) model.
+    const onDisk = tabB.parseSidecar(disk.content as string);
+    expect(onDisk?.values).toEqual({ a: 1, b: 2 });
+  });
+
+  // A single tab's own successive writes still round-trip through disk.
+  it("read-merge-write persists across a tab's own successive writes", async () => {
+    const disk: DiskCell = { content: null };
+    const { dir } = makeDir(disk);
+    const s = makeHandle();
+    s.setLocalDirectory(dir, true);
+
+    await s.enqueueWrite({ values: { a: 1 } });
+    await s.enqueueWrite({ values: { b: 2 } });
+    await s.flushWrites();
+
+    const onDisk = s.parseSidecar(disk.content as string);
+    expect(onDisk?.values).toEqual({ a: 1, b: 2 });
+  });
+
+  // --- Unit 2: surface persist failures ---
+
+  // A failed disk write rejects the caller's promise instead of resolving.
+  it("enqueueWrite rejects the caller's promise when the disk write fails", async () => {
+    const disk: DiskCell = { content: null };
+    const { dir } = makeDir(disk, { failWrite: true });
+    const s = makeHandle();
+    s.setLocalDirectory(dir, true);
+
+    await expect(s.enqueueWrite({ values: { a: 1 } })).rejects.toThrow();
+  });
+
+  // flushWrites reflects a pending write failure rather than resolving clean.
+  it("flushWrites rejects when the most recent queued write failed", async () => {
+    const disk: DiskCell = { content: null };
+    const { dir } = makeDir(disk, { failWrite: true });
+    const s = makeHandle();
+    s.setLocalDirectory(dir, true);
+
+    // Swallow the caller-facing rejection; assert the drain reflects it.
+    s.enqueueWrite({ values: { a: 1 } }).catch(() => undefined);
+    await expect(s.flushWrites()).rejects.toThrow();
+  });
+
+  // One failed write does not poison the chain: a later write still runs, and a
+  // subsequent success clears the failure the drain reports.
+  it("a failed write does not poison the chain; a later success recovers", async () => {
+    const disk: DiskCell = { content: null };
+    const opts = { failWrite: true };
+    const { dir } = makeDir(disk, opts);
+    const s = makeHandle();
+    s.setLocalDirectory(dir, true);
+
+    await expect(s.enqueueWrite({ values: { a: 1 } })).rejects.toThrow();
+
+    // Disk recovers; the next write succeeds and the drain is clean again.
+    opts.failWrite = false;
+    await s.enqueueWrite({ values: { b: 2 } });
+    await expect(s.flushWrites()).resolves.toBeUndefined();
+
+    const onDisk = s.parseSidecar(disk.content as string);
+    expect(onDisk?.values).toEqual({ b: 2 });
   });
 
   // 8. isPlainObject

--- a/packages/sidecar/test/factory.test.ts
+++ b/packages/sidecar/test/factory.test.ts
@@ -88,6 +88,16 @@ function makeDir(
   return { dir, writeCount: () => writes };
 }
 
+/** Parse the fake disk's current content, narrowing the nullable cell. */
+function readDiskModel(
+  s: ReturnType<typeof makeHandle>,
+  disk: DiskCell,
+): TestData | null {
+  const content = disk.content;
+  if (content === null) throw new Error("expected disk content, got empty cell");
+  return s.parseSidecar(content);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -176,7 +186,7 @@ describe("createSidecar factory", () => {
 
     // On disk both survive: tab B read-merge-wrote against tab A's persisted
     // state rather than its own stale (empty) model.
-    const onDisk = tabB.parseSidecar(disk.content as string);
+    const onDisk = readDiskModel(tabB, disk);
     expect(onDisk?.values).toEqual({ a: 1, b: 2 });
   });
 
@@ -191,7 +201,7 @@ describe("createSidecar factory", () => {
     await s.enqueueWrite({ values: { b: 2 } });
     await s.flushWrites();
 
-    const onDisk = s.parseSidecar(disk.content as string);
+    const onDisk = readDiskModel(s, disk);
     expect(onDisk?.values).toEqual({ a: 1, b: 2 });
   });
 
@@ -235,7 +245,7 @@ describe("createSidecar factory", () => {
     await s.enqueueWrite({ values: { b: 2 } });
     await expect(s.flushWrites()).resolves.toBeUndefined();
 
-    const onDisk = s.parseSidecar(disk.content as string);
+    const onDisk = readDiskModel(s, disk);
     expect(onDisk?.values).toEqual({ b: 2 });
   });
 


### PR DESCRIPTION
Implements graph node `tactic-sidecar-cross-tab-safety` (serves strategy-durable-owned-data).

## Problem

The shared sidecar single-flight write chain (`packages/sidecar/src/factory.ts`) guaranteed no-clobber per-tab only, and swallowed persist failures:

- `writeSidecar` rewrote the whole file against a possibly-stale in-memory `cachedModel`, so two tabs on one folder each merged against their own stale model and the last write discarded the other's entries.
- `enqueueWrite`'s per-link `.catch` logged and resolved, so a caller never learned a disk persist failed (a full/revoked-permission folder reported saves as successful — silent data loss, against the clear-errors rule).

## Unit 1 — cross-tab coordination

`enqueueWrite` now read-merge-writes against the CURRENT on-disk state under a cross-tab Web Lock (`navigator.locks`). The patch is merged onto whatever another tab has since persisted rather than onto this tab's stale model, so two tabs on one folder no longer clobber each other. Web Locks is a progressive enhancement — where unavailable, the per-tab single-flight chain still serializes writes (never below the prior single-tab guarantee). A disk re-read that finds corruption suppresses the write to preserve recoverable bytes, matching the load-time corruption contract.

## Unit 2 — surface persist failures

The promise `enqueueWrite` returns now rejects when the disk persist fails, so callers learn a save did not reach disk, while the single-flight chain is kept recovered so one failed write cannot poison the next. `flushWrites` reflects the most recent settled write's outcome; a later successful write clears it.

## Verification

- `packages/sidecar` unit tests: two-tab read-merge-write preserves both tabs' entries; a forced write failure rejects both the caller's promise and `flushWrites`; a failed write does not poison the chain.
- Full `packages/sidecar`, `audio`, and `print` suites pass (the factory's consumers); typecheck + lint clean.