### PR TITLE
tactic-dispatch-script-hardening: harden dispatch/budget/align automation scripts

### DIFF
--- a/.claude/skills/align-init/scripts/gather-context.sh
+++ b/.claude/skills/align-init/scripts/gather-context.sh
@@ -68,7 +68,10 @@ sensor_open_issues() {
 
 sensor_closed_issues() {
   echo "=== Closed Issues (recent 100) ==="
-  gh_issue_list_rest --state closed --limit 100 --include-title
+  # --paginate: this repo is PR-dominated, so a single mixed issues+PRs page of
+  # 100 would leave far fewer than 100 real issues after PR-filtering, silently.
+  # Forcing the paginate-then-slice path returns the true recent 100 issues.
+  gh_issue_list_rest --state closed --limit 100 --paginate --include-title
 }
 
 sensor_repo_stats() {

--- a/.claude/skills/budget/scripts/budget-apply
+++ b/.claude/skills/budget/scripts/budget-apply
@@ -117,7 +117,7 @@ fi
 # patch reads the current snapshot's rules+transactions, applies the JSON spec,
 # and writes a new staged snapshot. Output MUST differ from input (the binary
 # errors otherwise), hence a distinct /tmp path.
-"$BUDGET_ETL_BIN" patch --input "$current" --spec "$SPEC" --output ${TMPDIR:-/tmp}/stage1.enc.json
+"$BUDGET_ETL_BIN" patch --input "$current" --spec "$SPEC" --output "${TMPDIR:-/tmp}/stage1.enc.json"
 
 # --- Step 7: merge statements into a fresh immutable snapshot ----------------
 # merge HARD-ERRORS if any transaction is still uncategorized — that is the
@@ -125,7 +125,7 @@ fi
 # binary's own exit code with its stderr explaining which transactions remain.
 TS=$(date +%Y-%m-%dT%H-%M-%S)
 OUT="$snapshotDir/budget-$TS.enc.json"
-"$BUDGET_ETL_BIN" merge --input ${TMPDIR:-/tmp}/stage1.enc.json --dir "$statements" --output "$OUT"
+"$BUDGET_ETL_BIN" merge --input "${TMPDIR:-/tmp}/stage1.enc.json" --dir "$statements" --output "$OUT"
 
 # --- Step 8: publish onto `current` -----------------------------------------
 # cp -f, NOT mv and NOT ln -s: the merged snapshot stays in snapshotDir as
@@ -140,7 +140,7 @@ cp -f "$OUT" "$current"
 # budget-etl source: the SKILL.md loop branches on this residual to decide
 # whether to iterate the categorization dialog. report exits 0 even with
 # uncategorized and writes no snapshot.
-"$BUDGET_ETL_BIN" report --input ${TMPDIR:-/tmp}/stage1.enc.json --dir "$statements" --report ${TMPDIR:-/tmp}/inspect.json
+"$BUDGET_ETL_BIN" report --input "${TMPDIR:-/tmp}/stage1.enc.json" --dir "$statements" --report "${TMPDIR:-/tmp}/inspect.json"
 
 # --- Step 10: summary table -------------------------------------------------
 # One row per new statement: institution | new txn count | first date | last
@@ -152,11 +152,11 @@ jq -r '
   .new_statements[]
   | [.institution, (.txn_count | tostring), .date_range[0], .date_range[1], (.balance | tostring)]
   | @tsv
-' ${TMPDIR:-/tmp}/inspect.json | while IFS=$'\t' read -r inst txns first last bal; do
+' "${TMPDIR:-/tmp}/inspect.json" | while IFS=$'\t' read -r inst txns first last bal; do
   printf '%-24s %10s %-12s %-12s %12s\n' "$inst" "$txns" "$first" "$last" "$bal"
 done
 
-residual=$(jq '.uncategorized | length' ${TMPDIR:-/tmp}/inspect.json)
+residual=$(jq '.uncategorized | length' "${TMPDIR:-/tmp}/inspect.json")
 echo ""
 echo "  residual uncategorized: $residual"
 echo "  new snapshot:           $OUT"

--- a/.claude/skills/budget/scripts/budget-sync
+++ b/.claude/skills/budget/scripts/budget-sync
@@ -99,11 +99,11 @@ bash "$SCRIPT_DIR/ingest-downloads.sh" "$downloads" "$statements"
 # --- Step 8: report + signal ------------------------------------------------
 # The `report` subcommand implies --allow-uncategorized and does not write a
 # snapshot. ${TMPDIR:-/tmp}/inspect.json is the durable signal the SKILL.md branches on.
-"$BUDGET_ETL_BIN" report --input "$current" --dir "$statements" --report ${TMPDIR:-/tmp}/inspect.json
+"$BUDGET_ETL_BIN" report --input "$current" --dir "$statements" --report "${TMPDIR:-/tmp}/inspect.json"
 
-new_statements=$(jq '.new_statements | length' ${TMPDIR:-/tmp}/inspect.json)
-new_transactions=$(jq '.new_transactions | length' ${TMPDIR:-/tmp}/inspect.json)
-uncategorized=$(jq '.uncategorized | length' ${TMPDIR:-/tmp}/inspect.json)
+new_statements=$(jq '.new_statements | length' "${TMPDIR:-/tmp}/inspect.json")
+new_transactions=$(jq '.new_transactions | length' "${TMPDIR:-/tmp}/inspect.json")
+uncategorized=$(jq '.uncategorized | length' "${TMPDIR:-/tmp}/inspect.json")
 
 echo "budget-sync: report written to ${TMPDIR:-/tmp}/inspect.json"
 echo "  new statements:    $new_statements"

--- a/.claude/skills/budget/scripts/identify-qfx.sh
+++ b/.claude/skills/budget/scripts/identify-qfx.sh
@@ -19,7 +19,11 @@ exit_code=0
 for file in "$@"; do
   # Extract ORG: handles both XML (<ORG>X</ORG>) and SGML (<ORG>X\n or <ORG>X<...).
   # The regex <ORG>[^<\n]* matches both formats; sed strips the tag prefix.
-  org=$(grep -oE '<ORG>[^<\n]*' "$file" | head -1 | sed 's/<ORG>//')
+  # `|| true` keeps grep's exit-1 on a no-match (any non-OFX file in the ingest
+  # set) from aborting the whole script under `set -euo pipefail` — the intended
+  # empty-org `continue` below is otherwise dead code. `tr -d '\r'` strips the
+  # trailing CR left by CRLF-formatted OFX exports so the ORG_MAP lookup matches.
+  org=$(grep -oE '<ORG>[^<\n]*' "$file" | head -1 | sed 's/<ORG>//' | tr -d '\r' || true)
   if [[ -z "$org" ]]; then
     echo "could not extract ORG from $file" >&2
     exit_code=1
@@ -33,8 +37,8 @@ for file in "$@"; do
     continue
   fi
 
-  # Extract ACCTID: same dual-format handling.
-  raw_acct=$(grep -oE '<ACCTID>[^<\n]*' "$file" | head -1 | sed 's/<ACCTID>//')
+  # Extract ACCTID: same dual-format handling, same no-match guard and CR strip.
+  raw_acct=$(grep -oE '<ACCTID>[^<\n]*' "$file" | head -1 | sed 's/<ACCTID>//' | tr -d '\r' || true)
   if [[ -z "$raw_acct" ]]; then
     echo "could not extract ACCTID from $file" >&2
     exit_code=1

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -331,7 +331,7 @@ dispatch_marker_comment_id() {
 # per-tick scan was self-exhausting (#1601).
 #
 # Contract:
-#   gh_issue_list_rest --state <open|closed|all> [--repo <owner/repo>] [--label <name>] [--limit <n>] [--include-title] [--include-body]
+#   gh_issue_list_rest --state <open|closed|all> [--repo <owner/repo>] [--label <name>] [--limit <n>] [--paginate] [--include-title] [--include-body]
 #
 # Flags:
 #   --state  (required) open|closed|all. `all` is accepted — REST's
@@ -351,6 +351,15 @@ dispatch_marker_comment_id() {
 #            silently truncate to <= 100. The slice preserves the
 #            `len == limit ⇒ truncated` guard semantics: paginate-all-then-slice
 #            yields len == limit iff at least <limit> issues exist.
+#   --paginate (optional) force the paginate-then-slice path even when --limit is
+#            <= 100. Without it, a <= 100 limit fetches a SINGLE page of mixed
+#            issues+PRs, so PR-filtering silently leaves FEWER than <limit> real
+#            issues. With it (and a --limit), we --paginate at per_page=100,
+#            filter PRs, then slice to <limit> — yielding the true recent <limit>
+#            issues. Use this when a limit <= 100 must mean "up to <limit> real
+#            issues" rather than "issues among the first <limit> mixed rows"
+#            (e.g. align's recent-closed-issues context in a PR-dominated repo).
+#            A no-op without --limit (that path already paginates the full set).
 #   --include-title (optional) when present, the projected objects additionally
 #            carry a `title` field. Omitted by default so the repo-wide per-tick
 #            callers stay byte-identical and payload-lean.
@@ -372,7 +381,7 @@ dispatch_marker_comment_id() {
 # On gh failure: errors to stderr and returns 1 (clear-errors convention, no
 # fallback).
 gh_issue_list_rest() {
-  local state="" repo="" label="" limit="" include_title="" include_body=""
+  local state="" repo="" label="" limit="" include_title="" include_body="" force_paginate=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --state) state="$2"; shift 2 ;;
@@ -381,6 +390,7 @@ gh_issue_list_rest() {
       --limit) limit="$2"; shift 2 ;;
       --include-title) include_title=1; shift 1 ;;
       --include-body) include_body=1; shift 1 ;;
+      --paginate) force_paginate=1; shift 1 ;;
       *) echo "error: gh_issue_list_rest: unknown flag '$1'" >&2; return 1 ;;
     esac
   done
@@ -399,13 +409,21 @@ gh_issue_list_rest() {
   # When --limit > 100, REST clamps a single page's per_page to 100, so we must
   # --paginate at per_page=100 and slice the merged result down to <limit> in the
   # projection. A limit <= 100 fits one page (per_page=<limit>, no --paginate).
+  #
+  # The single-page <=100 optimization under-delivers ISSUES: REST returns mixed
+  # issues+PRs, so one page of per_page=<limit> mixed rows yields FEWER than
+  # <limit> real issues after the projection filters PRs out — silently, with no
+  # shortfall indicator. Callers that need up-to-<limit> real issues at a limit
+  # <= 100 pass --paginate to force the paginate-then-slice path (paginate at
+  # per_page=100, filter PRs, slice to <limit>), which returns the true recent
+  # <limit> issues instead.
   local paginate="" per_page="100" slice=""
   if [[ -n "$limit" ]]; then
     if [[ ! "$limit" =~ ^[0-9]+$ ]]; then
       echo "error: gh_issue_list_rest: --limit must be a non-negative integer (got '$limit')" >&2
       return 1
     fi
-    if (( limit > 100 )); then
+    if (( limit > 100 )) || [[ -n "$force_paginate" ]]; then
       paginate=1
       per_page="100"
       slice="$limit"

--- a/.claude/skills/dispatch-propagate/scripts/run-pr-checks-wait.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-pr-checks-wait.sh
@@ -60,10 +60,12 @@ if [[ -n "$output_file" ]]; then
   fi
 fi
 
-# Wait for all checks to complete (--watch blocks until done)
+# Wait for all checks to complete (--watch blocks until done). A non-zero exit
+# here only means some check ended non-green; the authoritative verdict is parsed
+# from --json below, so watch's exit status is deliberately ignored.
 gh pr checks "$pr_number" --watch > /dev/null 2>&1 || true
 
-# Capture final status of all checks (gh pr checks exits non-zero on failure)
+# Capture the human-readable table for the log / output file (display only).
 results=$(gh pr checks "$pr_number" 2>&1) || true
 
 if [[ -n "$output_file" ]]; then
@@ -72,7 +74,19 @@ else
   printf '%s\n' "$results"
 fi
 
-# Exit non-zero if any check failed
-if printf '%s\n' "$results" | grep -q 'fail'; then
+# Authoritative verdict: parse the check-run conclusions as structured JSON
+# rather than grepping the human-readable text. gh's `bucket` field is the
+# normalized category (pass|fail|pending|skipping|cancel), so a check NAMED
+# `fail-fast` or a `failed to…` diagnostic no longer forces red, and a
+# gh/network failure that produces no JSON is treated as an error (exit 2), not
+# as a false green.
+checks_json=$(gh pr checks "$pr_number" --json bucket,state,name 2>/dev/null) || checks_json=""
+if [[ -z "$checks_json" ]] || ! printf '%s' "$checks_json" | jq -e . >/dev/null 2>&1; then
+  echo "Error: could not retrieve check-run status as JSON for PR $pr_number" >&2
+  exit 2
+fi
+
+# Exit non-zero if any check landed in the 'fail' bucket.
+if printf '%s' "$checks_json" | jq -e 'any(.[]; .bucket == "fail")' >/dev/null; then
   exit 1
 fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -294,6 +294,12 @@ case "$args" in
         cat "$STUB_DIR/rest-bigpage-1.json"
         cat "$STUB_DIR/rest-bigpage-2.json"
         ;;
+      dispatch-test-limit-force-paginate)
+        # --paginate-at-limit-<=100 fixture: two pages of MIXED issues+PRs so a
+        # single page would under-deliver real issues after PR-filtering.
+        cat "$STUB_DIR/rest-forcepage-1.json"
+        cat "$STUB_DIR/rest-forcepage-2.json"
+        ;;
       dispatch-test-limit-exact)
         # Exactly-<limit> fixture: serve a single array of exactly limit items so
         # a caller's `len == limit ⇒ truncated` guard fires.
@@ -1480,6 +1486,45 @@ if grep -q -- '--paginate' "$STUB_DIR/gh-issue-list-rest-calls.log"; then
   assert_eq "limit: log does not contain --paginate" "no" "yes"
 else
   assert_eq "limit: log does not contain --paginate" "no" "no"
+fi
+teardown
+
+echo "Test: --paginate flag at limit <= 100 -- forces paginate-then-slice (up to <limit> real issues)"
+setup
+# Page 1: one real issue, one PR object, one real issue (mixed). A single page of
+# per_page=3 would yield only 2 real issues after PR-filtering -- the bug this
+# flag fixes.
+printf '%s\n' '[
+  {"number":401,"created_at":"2024-02-01T00:00:00Z","closed_at":null,"labels":[]},
+  {"number":402,"created_at":"2024-02-02T00:00:00Z","closed_at":null,"labels":[],"pull_request":{"merged_at":null}},
+  {"number":403,"created_at":"2024-02-03T00:00:00Z","closed_at":null,"labels":[]}
+]' > "$STUB_DIR/rest-forcepage-1.json"
+# Page 2: two more real issues -- reachable ONLY if --paginate was passed.
+printf '%s\n' '[
+  {"number":404,"created_at":"2024-02-04T00:00:00Z","closed_at":null,"labels":[]},
+  {"number":405,"created_at":"2024-02-05T00:00:00Z","closed_at":null,"labels":[]}
+]' > "$STUB_DIR/rest-forcepage-2.json"
+: > "$STUB_DIR/gh-issue-list-rest-calls.log"
+actual_fp=$(source "$TMPDIR_TEST/lib.sh"; gh_issue_list_rest --state closed --limit 3 --paginate --label dispatch-test-limit-force-paginate)
+# Merged both pages, filtered PR 402, then sliced to the first 3 real issues:
+# 401, 403, 404 (405 is beyond the slice).
+assert_eq "force-paginate: result length == limit (3)" "3" "$(jq 'length' <<<"$actual_fp")"
+assert_eq "force-paginate: issue 401 present" "true" "$(jq 'any(.[]; .number == 401)' <<<"$actual_fp")"
+assert_eq "force-paginate: issue 403 present (page-1, after filtered PR)" "true" "$(jq 'any(.[]; .number == 403)' <<<"$actual_fp")"
+assert_eq "force-paginate: issue 404 present (page-2 -- proves pagination)" "true" "$(jq 'any(.[]; .number == 404)' <<<"$actual_fp")"
+assert_eq "force-paginate: PR object 402 filtered out" "false" "$(jq 'any(.[]; .number == 402)' <<<"$actual_fp")"
+assert_eq "force-paginate: issue 405 sliced off (beyond limit)" "false" "$(jq 'any(.[]; .number == 405)' <<<"$actual_fp")"
+# The call log must contain --paginate (the forced path was taken) ...
+if grep -q -- '--paginate' "$STUB_DIR/gh-issue-list-rest-calls.log"; then
+  assert_eq "force-paginate: log contains --paginate" "yes" "yes"
+else
+  assert_eq "force-paginate: log contains --paginate" "yes" "no"
+fi
+# ... at per_page=100 (paginate clamp), NOT per_page=3 (the single-page value).
+if grep -q 'per_page=100[^0-9]' "$STUB_DIR/gh-issue-list-rest-calls.log"; then
+  assert_eq "force-paginate: log contains per_page=100" "yes" "yes"
+else
+  assert_eq "force-paginate: log contains per_page=100" "yes" "no"
 fi
 teardown
 


### PR DESCRIPTION
Implements the graph node `tactic-dispatch-script-hardening` (serves `strategy-autonomous-execution`). Fixes a cluster of automation-script false-pass/false-fail reliability bugs from the 2026-07-05 review.

## Unit 1 — dispatch CI wrapper false-pass/false-fail
- `run-pr-checks-wait.sh`: the verdict was `grep -q 'fail'` on the human-readable `gh pr checks` text — a gh/network error lacking "fail" read as green, and a check *named* `fail-fast` or a `failed to…` line forced red on a green PR. Now parses gh's `--json bucket` check-run conclusions (`any(.bucket == "fail")`); no JSON at all is a hard error (exit 2), not a false green.
- `run-smoke-tests.sh` curl-under-`set -e` sub-item: **already fixed on main** — the inline curl was refactored into `lib.sh`'s `wait_for_stable_propagation`, which already guards each curl with `|| true` so a transport failure is retry-eligible. No change needed.

## Unit 2 — identify-qfx.sh dead error path + CRLF
- Guard the ORG/ACCTID `grep | head | sed` pipelines with `|| true` so a non-OFX file's no-match no longer aborts the whole ingest under `set -euo pipefail` (the intended per-file `continue` was dead code).
- `tr -d '\r'` strips the trailing CR from CRLF-formatted OFX so the institution-map lookup matches.

## Unit 3 — quote TMPDIR expansions
- `budget-sync` and `budget-apply`: every `${TMPDIR:-/tmp}/…` command argument is now quoted so a TMPDIR containing a space cannot word-split the `--report`/`--input`/`--output` args.

## Unit 4 — paginate align's closed-issue context fetch
- `gh_issue_list_rest` gains an opt-in `--paginate` flag that forces the paginate-then-slice path even at `--limit <= 100`, returning up-to-N *real* issues rather than the issues among the first N mixed issues+PRs (the single-page default silently under-delivered in this PR-dominated repo).
- `align-init/scripts/gather-context.sh` routes its recent-closed-issues fetch through it. The `<=100` single-page default is unchanged (existing callers/tests unaffected).

## Verification
`test-dispatch-scripts.sh`: 8 new tests for the `--paginate`-at-limit-<=100 path all pass. Full suite: same 3 pre-existing unrelated failures (`phase-model`, `reopened window`) on both this branch and the pristine base — zero new failures.