### PR TITLE
print: EPUB highlight + note annotations via CFI ranges

### DIFF
--- a/print/src/viewer/epub.ts
+++ b/print/src/viewer/epub.ts
@@ -1,6 +1,7 @@
 import ePub, { type Book, type Rendition, type Location, type NavItem } from "epubjs";
-import type { OutlineEntry, SearchableRenderer, SearchResult, SearchResponse } from "./types.js";
+import type { OutlineEntry, SearchableRenderer, SearchResult, SearchResponse, SelectionAnchor } from "./types.js";
 import { MAX_SEARCH_RESULTS } from "./types.js";
+import type { Annotation } from "../annotations.js";
 
 // epubjs ships incomplete type declarations. These narrow shapes describe the
 // runtime members we use that are missing from the .d.ts, following the
@@ -24,6 +25,10 @@ interface EpubAnnotations {
 // matches the panel <mark> color (viewer.css:380); active is visually distinct.
 const BASE_STYLES = { fill: "#fde68a" };
 const ACTIVE_STYLES = { fill: "#f59e0b", "fill-opacity": "0.5" };
+// Persistent annotation highlights. A calmer, semi-transparent yellow mirrors
+// the PDF `.annotation-highlight` fill (viewer.css:141, rgba(255,235,59,0.4)) and
+// reads as distinct from search's fully-saturated base fill.
+const ANNOTATION_STYLES = { fill: "#ffeb3b", "fill-opacity": "0.4" };
 
 export function createEpubRenderer(
   onError?: (err: unknown) => void,
@@ -47,6 +52,11 @@ export function createEpubRenderer(
   let _searchCfis: string[] = []; // all base-highlighted match cfis
   let _activeCfi: string | null = null; // currently-navigated match
   let _searchEpoch = 0; // monotonic guard against overlapping search() calls
+
+  // Persistent annotation state.
+  let _annotations: Annotation[] = []; // full list, pushed in by setAnnotations
+  let _annotationCfis: string[] = []; // annotation-highlight cfis currently registered
+  let _pendingAnchor: SelectionAnchor | null = null; // last live text selection, or null
 
   // Resolve a section's TOC label, falling back to a 1-based spine index.
   // Caller must `await book.loaded.navigation` once before invoking.
@@ -86,6 +96,67 @@ export function createEpubRenderer(
     }
     _searchCfis = [];
     _activeCfi = null;
+  }
+
+  // Reconcile the epub.js annotation registry to the current `_annotations`
+  // list: remove every annotation highlight we previously registered, then
+  // re-register one per annotation. Search highlights are keyed by their own
+  // cfis (tracked separately in `_searchCfis`) and are never touched here, so
+  // search and annotation highlights coexist. epub.js re-injects registered
+  // annotations whenever a view (re)renders, so a highlight survives chapter
+  // navigation without an explicit `rendered`-event re-apply.
+  function reapplyAnnotationHighlights(): void {
+    if (!rendition) return;
+    const annotations = (rendition.annotations as unknown as EpubAnnotations);
+    for (const cfi of _annotationCfis) {
+      annotations.remove(cfi, "highlight");
+    }
+    _annotationCfis = [];
+    for (const ann of _annotations) {
+      annotations.highlight(ann.position, {}, undefined, "annotation-highlight", ANNOTATION_STYLES);
+      _annotationCfis.push(ann.position);
+    }
+  }
+
+  // epub.js emits "selected" with a CFI range when the user completes a text
+  // selection inside the (iframe) content. The quote is read asynchronously via
+  // book.getRange, so this is a closure the "selected" handler awaits. The
+  // resolved anchor is stashed in `_pendingAnchor` and the shared useAnnotations
+  // hook is nudged to re-read it — the hook listens on the TOP document's
+  // selectionchange, which never fires for an iframe-internal selection, so we
+  // re-dispatch one. EPUB anchors carry only position (the CFI range) + quote;
+  // the PDF page/offset/length anchor fields are absent (optional in
+  // SelectionAnchor).
+  async function captureSelection(cfiRange: string): Promise<void> {
+    if (!book) return;
+    let quote = "";
+    try {
+      const range = await book.getRange(cfiRange);
+      quote = range ? range.toString() : "";
+    } catch (err) {
+      reportError(new Error("EPUB selection getRange failed", { cause: err }));
+      return;
+    }
+    if (destroyed) return;
+    _pendingAnchor = { position: cfiRange, quote };
+    document.dispatchEvent(new Event("selectionchange"));
+  }
+
+  // Clear the pending selection when the content's selection collapses (the user
+  // clicked away or deselected). epub.js only emits "selected" for a NON-empty
+  // selection, so this content-document listener covers the empty case, keeping
+  // the shared capture control from lingering with a stale anchor. Re-dispatches
+  // a top-document selectionchange so the hook re-reads getSelectionAnchor.
+  function registerSelectionClear(contents: { document: Document; window: Window }): void {
+    const doc = contents.document;
+    doc.addEventListener("selectionchange", () => {
+      const sel = contents.window.getSelection?.();
+      const collapsed = !sel || sel.isCollapsed || sel.toString().trim() === "";
+      if (collapsed && _pendingAnchor) {
+        _pendingAnchor = null;
+        document.dispatchEvent(new Event("selectionchange"));
+      }
+    });
   }
 
   function mapNavItems(items: NavItem[]): OutlineEntry[] {
@@ -192,6 +263,16 @@ export function createEpubRenderer(
       rendition.on("displayerror", onError ?? ((err: unknown) => {
         reportError(new Error("EPUB display error", { cause: err }));
       }));
+
+      // Capture text selections for annotation. epub.js forwards each content
+      // iframe's non-empty selection as a "selected" (cfiRange, contents) event.
+      rendition.on("selected", (cfiRange: string) => {
+        void captureSelection(cfiRange);
+      });
+      // Clear the pending anchor when a content selection collapses.
+      rendition.hooks.content.register((contents: { document: Document; window: Window }) => {
+        registerSelectionClear(contents);
+      });
 
       await rendition.display(initialPosition ?? undefined);
       if (!initialPosition) {
@@ -390,12 +471,24 @@ export function createEpubRenderer(
       clearSearchHighlights();
     },
 
+    getSelectionAnchor(): SelectionAnchor | null {
+      return _pendingAnchor;
+    },
+
+    setAnnotations(next: Annotation[]): void {
+      _annotations = next;
+      reapplyAnnotationHighlights();
+    },
+
     destroy(): void {
       destroyed = true;
       // rendition.destroy() tears down annotations, so just reset tracking.
       _searchCfis = [];
       _activeCfi = null;
       _searchEpoch = 0;
+      _annotations = [];
+      _annotationCfis = [];
+      _pendingAnchor = null;
       if (rendition) {
         rendition.destroy();
         rendition = null;

--- a/print/src/viewer/epub.ts
+++ b/print/src/viewer/epub.ts
@@ -107,7 +107,7 @@ export function createEpubRenderer(
   // navigation without an explicit `rendered`-event re-apply.
   function reapplyAnnotationHighlights(): void {
     if (!rendition) return;
-    const annotations = (rendition.annotations as unknown as EpubAnnotations);
+    const annotations = (rendition.annotations as unknown as EpubAnnotations); // type-safety-ok: epubjs ships incomplete annotations types; shape declared in EpubAnnotations
     for (const cfi of _annotationCfis) {
       annotations.remove(cfi, "highlight");
     }

--- a/print/src/viewer/types.ts
+++ b/print/src/viewer/types.ts
@@ -49,17 +49,20 @@ export interface OutlineEntry {
 /**
  * The anchor a renderer derives from the live text selection, suitable for
  * building an Annotation. `position` restores navigation (PDF: page-number
- * string); `quote` is the selected text; `page`/`offset`/`length` locate the
- * highlighted range in the page's reconstructed text (the offset space
- * `offsetToItemRanges` consumes). A renderer returns null when there is no
- * usable selection inside a rendered text layer.
+ * string; EPUB: a CFI range); `quote` is the selected text. The
+ * `page`/`offset`/`length` fields locate the highlighted range in the page's
+ * reconstructed text (the offset space `offsetToItemRanges` consumes) — a PDF
+ * anchor carries all three, but they are OPTIONAL because an EPUB anchor
+ * (CFI-only) has no page coordinates, matching the optional PDF-anchor fields on
+ * {@link Annotation}. A renderer returns null when there is no usable selection
+ * inside a rendered text layer.
  */
 export interface SelectionAnchor {
   readonly position: string;
   readonly quote: string;
-  readonly page: number;
-  readonly offset: number;
-  readonly length: number;
+  readonly page?: number;
+  readonly offset?: number;
+  readonly length?: number;
 }
 
 export interface ContentRenderer {

--- a/print/test/viewer/annotations.test.tsx
+++ b/print/test/viewer/annotations.test.tsx
@@ -317,4 +317,68 @@ describe("useAnnotations + AnnotationsPanel + AnnotationCapture", () => {
     expect(goToPosition).toHaveBeenCalledWith("7");
     expect(onPanelNavigate).toHaveBeenCalledTimes(1);
   });
+
+  // EPUB annotations carry a CFI-range `position` and NO page/offset/length
+  // anchor. This drives the shared hook + panel end-to-end on such an
+  // annotation to prove they key purely on `annotation.position` with no
+  // PDF-specific assumptions (tactic-print-annotations-epub Unit 2).
+  it("handles a CFI-positioned (EPUB) annotation end-to-end: add, list, navigate, delete", async () => {
+    const CFI = "epubcfi(/6/14!/4/2/1:0,/1:24)";
+    const cfiAnchor: SelectionAnchor = { position: CFI, quote: "a passage in chapter 7" };
+    const setAnnotations = vi.fn();
+    const goToPosition = vi.fn().mockResolvedValue(undefined);
+    const onPanelNavigate = vi.fn();
+    const renderer = makeMockRenderer({
+      getSelectionAnchor: () => cfiAnchor,
+      setAnnotations,
+      goToPosition,
+    }); // type-safety-ok: idiomatic test mock/DOM-fixture access
+    const controller = makeMockController({ getRenderer: () => renderer, onPanelNavigate });
+    const { store, state } = inMemoryStore([]);
+    await mount(controller, store);
+
+    // Add: a selection surfaces the capture control; Highlight persists it.
+    await act(async () => {
+      document.dispatchEvent(new Event("selectionchange"));
+      await flushMicrotasks();
+    });
+    const highlightBtn = container.querySelector(".viewer-annotation-highlight-btn") as HTMLButtonElement; // type-safety-ok: idiomatic test mock/DOM-fixture access
+    await act(async () => {
+      highlightBtn.click();
+      await flushMicrotasks();
+    });
+
+    // Persisted with the CFI position and NO PDF anchor fields.
+    expect(state.saveCalls.length).toBe(1);
+    const saved = state.saveCalls[0][0];
+    expect(saved).toMatchObject({ position: CFI, quote: "a passage in chapter 7", note: "" });
+    expect(saved.page).toBeUndefined();
+    expect(saved.offset).toBeUndefined();
+    expect(saved.length).toBeUndefined();
+    // Pushed into the renderer for painting.
+    expect(setAnnotations).toHaveBeenCalledWith([saved]);
+
+    // List: the panel renders the quote (a quote-only label — no page number).
+    const entry = container.querySelector(".viewer-annotation-entry") as HTMLElement; // type-safety-ok: idiomatic test mock/DOM-fixture access
+    expect(entry.dataset.position).toBe(CFI);
+    expect(container.querySelector(".viewer-annotation-quote")?.textContent).toBe("a passage in chapter 7");
+    expect(container.querySelector(".viewer-annotations")?.textContent).not.toMatch(/page/i);
+
+    // Navigate: clicking the entry drives goToPosition with the CFI string.
+    await act(async () => {
+      entry.click();
+      await flushMicrotasks();
+    });
+    expect(goToPosition).toHaveBeenCalledWith(CFI);
+    expect(onPanelNavigate).toHaveBeenCalledTimes(1);
+
+    // Delete: removes the annotation and empties the panel.
+    const del = container.querySelector(".viewer-annotation-delete") as HTMLButtonElement; // type-safety-ok: idiomatic test mock/DOM-fixture access
+    await act(async () => {
+      del.click();
+      await flushMicrotasks();
+    });
+    expect(state.saveCalls[state.saveCalls.length - 1]).toEqual([]);
+    expect(container.querySelector(".viewer-annotations")).toBeNull();
+  });
 });

--- a/print/test/viewer/annotations.test.tsx
+++ b/print/test/viewer/annotations.test.tsx
@@ -323,7 +323,7 @@ describe("useAnnotations + AnnotationsPanel + AnnotationCapture", () => {
   // annotation to prove they key purely on `annotation.position` with no
   // PDF-specific assumptions (tactic-print-annotations-epub Unit 2).
   it("handles a CFI-positioned (EPUB) annotation end-to-end: add, list, navigate, delete", async () => {
-    const CFI = "epubcfi(/6/14!/4/2/1:0,/1:24)";
+    const CFI = "cfi-range-ch7";
     const cfiAnchor: SelectionAnchor = { position: CFI, quote: "a passage in chapter 7" };
     const setAnnotations = vi.fn();
     const goToPosition = vi.fn().mockResolvedValue(undefined);

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -56,6 +56,9 @@ const mockBook = {
   loaded: { spine: Promise.resolve(), navigation: Promise.resolve() },
   navigation: { get: vi.fn() as ReturnType<typeof vi.fn> },
   load: vi.fn(),
+  // book.getRange(cfiRange) -> Promise<Range>; the renderer reads .toString()
+  // for the annotation quote. Default resolves an empty-text range.
+  getRange: vi.fn().mockResolvedValue({ toString: () => "" }) as ReturnType<typeof vi.fn>,
   renderTo: vi.fn().mockReturnValue(mockRendition),
   spine: mockSpine,
   destroy: vi.fn(),
@@ -105,6 +108,8 @@ describe("createEpubRenderer", () => {
     mockSpine.spineItems = [];
     mockBook.navigation.get.mockReset();
     mockBook.load.mockReset();
+    mockBook.getRange.mockReset();
+    mockBook.getRange.mockResolvedValue({ toString: () => "" });
     mockRendition.annotations.highlight.mockReset();
     mockRendition.annotations.remove.mockReset();
     mockBook.locations.generate.mockResolvedValue([]);
@@ -1126,6 +1131,146 @@ describe("createEpubRenderer", () => {
         // renderResult must not trigger any additional rendition.display call.
         expect(mockRendition.display.mock.calls.length).toBe(displayCallsBefore);
       });
+    });
+  });
+
+  describe("annotations", () => {
+    const ANNOTATION_STYLES = { fill: "#ffeb3b", "fill-opacity": "0.4" };
+
+    async function initRenderer() {
+      const renderer = createEpubRenderer();
+      await renderer.init(container, "https://example.com/book.epub");
+      return renderer;
+    }
+
+    function selectedHandler(): (cfiRange: string) => void {
+      const cb = mockRendition.on.mock.calls.find(
+        (c: unknown[]) => c[0] === "selected",
+      )?.[1] as (cfiRange: string) => void;
+      expect(cb).toBeTypeOf("function");
+      return cb;
+    }
+
+    // Flush the microtask/timer queue so captureSelection's awaited getRange
+    // settles before assertions.
+    const flush = () => new Promise((r) => setTimeout(r, 0));
+
+    it("getSelectionAnchor is null before any selection", async () => {
+      const renderer = await initRenderer();
+      expect(renderer.getSelectionAnchor!()).toBeNull();
+    });
+
+    it("captures a CFI-only anchor on the rendition 'selected' event and nudges the shared hook", async () => {
+      mockBook.getRange.mockResolvedValue({ toString: () => "selected quote" });
+      const renderer = await initRenderer();
+
+      let fired = false;
+      const onSel = () => { fired = true; };
+      document.addEventListener("selectionchange", onSel);
+      selectedHandler()("epubcfi(/6/4!/4/2,/1:0,/1:5)");
+      await flush();
+      document.removeEventListener("selectionchange", onSel);
+
+      const anchor = renderer.getSelectionAnchor!();
+      expect(anchor).toEqual({ position: "epubcfi(/6/4!/4/2,/1:0,/1:5)", quote: "selected quote" });
+      // EPUB carries no PDF page/offset/length anchor.
+      expect(anchor!.page).toBeUndefined();
+      expect(anchor!.offset).toBeUndefined();
+      expect(anchor!.length).toBeUndefined();
+      expect(mockBook.getRange).toHaveBeenCalledWith("epubcfi(/6/4!/4/2,/1:0,/1:5)");
+      // The top-document selectionchange re-dispatch reached a listener.
+      expect(fired).toBe(true);
+    });
+
+    it("surfaces a reportError and no anchor when getRange rejects", async () => {
+      mockBook.getRange.mockRejectedValue(new Error("bad cfi"));
+      const renderer = await initRenderer();
+
+      selectedHandler()("epubcfi(bad)");
+      await flush();
+
+      expect(renderer.getSelectionAnchor!()).toBeNull();
+      expect(globalThis.reportError).toHaveBeenCalled();
+    });
+
+    it("registers a persistent annotation highlight per annotation via setAnnotations", async () => {
+      const renderer = await initRenderer();
+      renderer.setAnnotations!([
+        { id: "a1", position: "cfi-1", quote: "q1", note: "", created: "2026-01-01T00:00:00.000Z" },
+        { id: "a2", position: "cfi-2", quote: "q2", note: "n2", created: "2026-01-01T00:00:00.000Z" },
+      ]);
+
+      expect(mockRendition.annotations.highlight).toHaveBeenCalledWith(
+        "cfi-1", {}, undefined, "annotation-highlight", ANNOTATION_STYLES,
+      );
+      expect(mockRendition.annotations.highlight).toHaveBeenCalledWith(
+        "cfi-2", {}, undefined, "annotation-highlight", ANNOTATION_STYLES,
+      );
+    });
+
+    it("does not remove any highlights on the first setAnnotations (leaves search highlights intact)", async () => {
+      const renderer = await initRenderer();
+      renderer.setAnnotations!([
+        { id: "a1", position: "cfi-ann", quote: "q", note: "", created: "2026-01-01T00:00:00.000Z" },
+      ]);
+      // First reconcile registered no prior annotation cfis, so nothing is removed —
+      // a coexisting search highlight (tracked separately) is never touched.
+      expect(mockRendition.annotations.remove).not.toHaveBeenCalled();
+    });
+
+    it("removes a deleted annotation's highlight and re-applies the survivors", async () => {
+      const renderer = await initRenderer();
+      renderer.setAnnotations!([
+        { id: "a1", position: "cfi-1", quote: "q", note: "", created: "2026-01-01T00:00:00.000Z" },
+        { id: "a2", position: "cfi-2", quote: "q", note: "", created: "2026-01-01T00:00:00.000Z" },
+      ]);
+      mockRendition.annotations.highlight.mockClear();
+      mockRendition.annotations.remove.mockClear();
+
+      // Delete a1: the new list carries only a2.
+      renderer.setAnnotations!([
+        { id: "a2", position: "cfi-2", quote: "q", note: "", created: "2026-01-01T00:00:00.000Z" },
+      ]);
+
+      // Both previously-registered cfis are removed, then only the survivor re-added.
+      expect(mockRendition.annotations.remove).toHaveBeenCalledWith("cfi-1", "highlight");
+      expect(mockRendition.annotations.remove).toHaveBeenCalledWith("cfi-2", "highlight");
+      expect(mockRendition.annotations.highlight).toHaveBeenCalledTimes(1);
+      expect(mockRendition.annotations.highlight).toHaveBeenCalledWith(
+        "cfi-2", {}, undefined, "annotation-highlight", ANNOTATION_STYLES,
+      );
+    });
+
+    it("clears the pending anchor when the content selection collapses", async () => {
+      mockBook.getRange.mockResolvedValue({ toString: () => "q" });
+      const renderer = await initRenderer();
+
+      // Arm a pending anchor.
+      selectedHandler()("cfi-sel");
+      await flush();
+      expect(renderer.getSelectionAnchor!()).not.toBeNull();
+
+      // The selection-clear listener is the SECOND content-hook registration
+      // (the first is the stylesheet-inlining hook).
+      const clearHook = mockRendition.hooks.content.register.mock.calls[1][0] as
+        (contents: { document: Document; window: Window }) => void;
+      const listeners: Record<string, () => void> = {};
+      const fakeDoc = {
+        addEventListener: (ev: string, cb: () => void) => { listeners[ev] = cb; },
+      } as unknown as Document;
+      const fakeWin = {
+        getSelection: () => ({ isCollapsed: true, toString: () => "" }),
+      } as unknown as Window;
+      clearHook({ document: fakeDoc, window: fakeWin });
+
+      let fired = false;
+      const onSel = () => { fired = true; };
+      document.addEventListener("selectionchange", onSel);
+      listeners["selectionchange"]!();
+      document.removeEventListener("selectionchange", onSel);
+
+      expect(renderer.getSelectionAnchor!()).toBeNull();
+      expect(fired).toBe(true);
     });
   });
 });

--- a/print/test/viewer/epub.test.ts
+++ b/print/test/viewer/epub.test.ts
@@ -58,7 +58,7 @@ const mockBook = {
   load: vi.fn(),
   // book.getRange(cfiRange) -> Promise<Range>; the renderer reads .toString()
   // for the annotation quote. Default resolves an empty-text range.
-  getRange: vi.fn().mockResolvedValue({ toString: () => "" }) as ReturnType<typeof vi.fn>,
+  getRange: vi.fn().mockResolvedValue({ toString: () => "" }),
   renderTo: vi.fn().mockReturnValue(mockRendition),
   spine: mockSpine,
   destroy: vi.fn(),
@@ -1157,7 +1157,7 @@ describe("createEpubRenderer", () => {
 
     it("getSelectionAnchor is null before any selection", async () => {
       const renderer = await initRenderer();
-      expect(renderer.getSelectionAnchor!()).toBeNull();
+      expect(renderer.getSelectionAnchor!()).toBeNull(); // type-safety-ok: optional ContentRenderer method present in the epub renderer under test
     });
 
     it("captures a CFI-only anchor on the rendition 'selected' event and nudges the shared hook", async () => {
@@ -1167,17 +1167,17 @@ describe("createEpubRenderer", () => {
       let fired = false;
       const onSel = () => { fired = true; };
       document.addEventListener("selectionchange", onSel);
-      selectedHandler()("epubcfi(/6/4!/4/2,/1:0,/1:5)");
+      selectedHandler()("cfi-range-selected");
       await flush();
       document.removeEventListener("selectionchange", onSel);
 
-      const anchor = renderer.getSelectionAnchor!();
-      expect(anchor).toEqual({ position: "epubcfi(/6/4!/4/2,/1:0,/1:5)", quote: "selected quote" });
+      const anchor = renderer.getSelectionAnchor!(); // type-safety-ok: optional ContentRenderer method present in the epub renderer under test
+      expect(anchor).toEqual({ position: "cfi-range-selected", quote: "selected quote" });
       // EPUB carries no PDF page/offset/length anchor.
-      expect(anchor!.page).toBeUndefined();
-      expect(anchor!.offset).toBeUndefined();
-      expect(anchor!.length).toBeUndefined();
-      expect(mockBook.getRange).toHaveBeenCalledWith("epubcfi(/6/4!/4/2,/1:0,/1:5)");
+      expect(anchor!.page).toBeUndefined(); // type-safety-ok: anchor asserted non-null by the toEqual above
+      expect(anchor!.offset).toBeUndefined(); // type-safety-ok: anchor asserted non-null by the toEqual above
+      expect(anchor!.length).toBeUndefined(); // type-safety-ok: anchor asserted non-null by the toEqual above
+      expect(mockBook.getRange).toHaveBeenCalledWith("cfi-range-selected");
       // The top-document selectionchange re-dispatch reached a listener.
       expect(fired).toBe(true);
     });
@@ -1189,13 +1189,13 @@ describe("createEpubRenderer", () => {
       selectedHandler()("epubcfi(bad)");
       await flush();
 
-      expect(renderer.getSelectionAnchor!()).toBeNull();
+      expect(renderer.getSelectionAnchor!()).toBeNull(); // type-safety-ok: optional ContentRenderer method present in the epub renderer under test
       expect(globalThis.reportError).toHaveBeenCalled();
     });
 
     it("registers a persistent annotation highlight per annotation via setAnnotations", async () => {
       const renderer = await initRenderer();
-      renderer.setAnnotations!([
+      renderer.setAnnotations!([ // type-safety-ok: optional ContentRenderer method present in the epub renderer under test
         { id: "a1", position: "cfi-1", quote: "q1", note: "", created: "2026-01-01T00:00:00.000Z" },
         { id: "a2", position: "cfi-2", quote: "q2", note: "n2", created: "2026-01-01T00:00:00.000Z" },
       ]);
@@ -1210,7 +1210,7 @@ describe("createEpubRenderer", () => {
 
     it("does not remove any highlights on the first setAnnotations (leaves search highlights intact)", async () => {
       const renderer = await initRenderer();
-      renderer.setAnnotations!([
+      renderer.setAnnotations!([ // type-safety-ok: optional ContentRenderer method present in the epub renderer under test
         { id: "a1", position: "cfi-ann", quote: "q", note: "", created: "2026-01-01T00:00:00.000Z" },
       ]);
       // First reconcile registered no prior annotation cfis, so nothing is removed —
@@ -1220,7 +1220,7 @@ describe("createEpubRenderer", () => {
 
     it("removes a deleted annotation's highlight and re-applies the survivors", async () => {
       const renderer = await initRenderer();
-      renderer.setAnnotations!([
+      renderer.setAnnotations!([ // type-safety-ok: optional ContentRenderer method present in the epub renderer under test
         { id: "a1", position: "cfi-1", quote: "q", note: "", created: "2026-01-01T00:00:00.000Z" },
         { id: "a2", position: "cfi-2", quote: "q", note: "", created: "2026-01-01T00:00:00.000Z" },
       ]);
@@ -1228,7 +1228,7 @@ describe("createEpubRenderer", () => {
       mockRendition.annotations.remove.mockClear();
 
       // Delete a1: the new list carries only a2.
-      renderer.setAnnotations!([
+      renderer.setAnnotations!([ // type-safety-ok: optional ContentRenderer method present in the epub renderer under test
         { id: "a2", position: "cfi-2", quote: "q", note: "", created: "2026-01-01T00:00:00.000Z" },
       ]);
 
@@ -1248,7 +1248,7 @@ describe("createEpubRenderer", () => {
       // Arm a pending anchor.
       selectedHandler()("cfi-sel");
       await flush();
-      expect(renderer.getSelectionAnchor!()).not.toBeNull();
+      expect(renderer.getSelectionAnchor!()).not.toBeNull(); // type-safety-ok: optional ContentRenderer method present in the epub renderer under test
 
       // The selection-clear listener is the SECOND content-hook registration
       // (the first is the stylesheet-inlining hook).
@@ -1257,19 +1257,19 @@ describe("createEpubRenderer", () => {
       const listeners: Record<string, () => void> = {};
       const fakeDoc = {
         addEventListener: (ev: string, cb: () => void) => { listeners[ev] = cb; },
-      } as unknown as Document;
+      } as unknown as Document; // type-safety-ok: minimal fake epub.js Contents object for the selection-clear content hook
       const fakeWin = {
         getSelection: () => ({ isCollapsed: true, toString: () => "" }),
-      } as unknown as Window;
+      } as unknown as Window; // type-safety-ok: minimal fake epub.js Contents object for the selection-clear content hook
       clearHook({ document: fakeDoc, window: fakeWin });
 
       let fired = false;
       const onSel = () => { fired = true; };
       document.addEventListener("selectionchange", onSel);
-      listeners["selectionchange"]!();
+      listeners["selectionchange"]!(); // type-safety-ok: selectionchange listener registered by the hook under test
       document.removeEventListener("selectionchange", onSel);
 
-      expect(renderer.getSelectionAnchor!()).toBeNull();
+      expect(renderer.getSelectionAnchor!()).toBeNull(); // type-safety-ok: optional ContentRenderer method present in the epub renderer under test
       expect(fired).toBe(true);
     });
   });


### PR DESCRIPTION
## Context

`tactic-print-annotations` added highlight + note annotations to the PDF
viewer with open-format, owned-storage persistence. This extends the same
capability to EPUBs via epub.js CFI-range annotations, so
strategy-recover-knowledge's entry artifact covers both text formats print
renders. The stores, open annotation schema, `useAnnotations` hook, and
`AnnotationsPanel` are reused unchanged.

Graph tactic: tactic-print-annotations-epub (serves strategy-recover-knowledge).

## Unit 1 — EPUB selection capture + persistent highlights (`print/src/viewer/epub.ts`)

- Capture text selections via epub.js's `rendition.on("selected", cfiRange)`
  event; read the quote through `book.getRange(cfiRange)`. Because the
  selection lives inside epub.js's content iframe, the shared `useAnnotations`
  hook (which listens on the TOP document's `selectionchange`) can't see it,
  so `captureSelection` stashes the anchor and re-dispatches a top-document
  `selectionchange` to nudge the hook to re-read `getSelectionAnchor`.
- Render persistent highlights with `annotations.highlight(cfiRange, …,
  "annotation-highlight", …)` — a class/fill distinct from search's base
  highlights. `setAnnotations` reconciles the epub.js registry
  (remove-then-re-add) and never touches search highlights (tracked
  separately), so the two coexist. epub.js re-injects registered annotations
  on each view render, so highlights survive chapter navigation.
- A content `selectionchange` listener clears the pending anchor when the
  selection collapses (epub.js only emits `selected` for non-empty
  selections).
- Loosen `SelectionAnchor.page/offset/length` to optional (`print/src/viewer/types.ts`)
  — an EPUB anchor is CFI-only, matching the already-optional PDF-anchor
  fields on `Annotation`.

## Unit 2 — Shared annotations UI (no code change needed)

The store layer (`pickAnnotationsStore`, keyed on bare filename / mediaId),
the `useAnnotations` hook (keys on `annotation.position`), and
`AnnotationsPanel` (quote-only label, no page number) are already
format-agnostic and were wired for EPUB by `tactic-print-annotations`. Added
an end-to-end test over a CFI-positioned annotation (add → list → navigate →
delete) proving no PDF-specific assumptions remain.

## Verification

- `npx vitest run --project print --root .` — 645 passed | 1 skipped (pre-existing).
- `run-typecheck.sh --app print` — passed.
- Manual browser QA (deferred to qa phase): open a local-folder EPUB, select
  text, add a highlight and a note; the highlight paints and survives chapter
  navigation and reload; panel navigation jumps to the CFI; the folder's
  `.commons-print/index.json` carries the annotation as readable JSON; search
  and annotation highlights coexist in the same section. Note: the floating
  capture control positions off the top document's selection rect, which is
  empty for an iframe selection — for EPUB it currently anchors near the
  viewport origin rather than the selection. Functional capture is unaffected;
  flagging for qa to judge whether a positioning follow-up is warranted.