### PR TITLE
intentionsutil: lifecycle sensor for strategy-graph-native-dispatch

### DIFF
--- a/packages/intentionsutil/scripts/read-sensors.ts
+++ b/packages/intentionsutil/scripts/read-sensors.ts
@@ -310,6 +310,234 @@ const tokenEconomySensor: Sensor = {
   },
 };
 
+// --- lifecycle sensor --------------------------------------------------------
+// Name is the exact `success_signal.sensor` string
+// `strategy-graph-native-dispatch` declares — the driver resolves a sensor by
+// that verbatim name (`token-economy` uses the same match-the-declared-name
+// contract). The reading is dual, mirroring the strategy's dual source:
+//   (a) the phase-transition history in the local `intentions/` git log, and
+//   (b) the router's own selection log (emitted by graph-select-target).
+// Format (stable and parseable):
+//   `lifecycle: <id> implement→qa→review→done (<YYYY-MM-DD>); router selections: <R> records, <D> nodes`
+// with the lifecycle half degrading to `none yet` (no completed graph-native
+// tactic lifecycle in history) and the selections half to `unknown` (missing or
+// unreadable log) — never a throw (total-sensor contract above).
+
+/** The verbatim `success_signal.sensor` name on strategy-graph-native-dispatch. */
+const LIFECYCLE_SENSOR_NAME = "the intention store and the router's selection log";
+
+/**
+ * Phases a graph-native tactic passes through; a full lifecycle observes ALL of
+ * them for one node. A graph-native lifecycle IS gh-free by construction — its
+ * phase transitions live as `intentions/*.md` commits, not gh labels — so
+ * observing a completed node in this history satisfies the observable's "no
+ * GitHub label or issue required" clause without a gh query.
+ */
+const LIFECYCLE_REQUIRED_PHASES = ["implement", "qa", "review", "done"] as const;
+
+/**
+ * Where graph-select-target appends its selection log. Mirrors that script's
+ * default (`$HOME/.local/share/commons-dispatch/graph-selection.jsonl`);
+ * `DISPATCH_SELECTION_LOG_FILE` / `DISPATCH_SELECTION_LOG_DIR` override it,
+ * matching the script's env contract and enabling fixture injection in tests.
+ */
+const SELECTION_LOG_DEFAULT_PATH = join(
+  homedir(),
+  ".local",
+  "share",
+  "commons-dispatch",
+  "graph-selection.jsonl",
+);
+
+/**
+ * Lifecycle half: the latest full graph-native tactic lifecycle observed in the
+ * local clone's `intentions/` git history. A single line-level patch pass over
+ * `git log -p` collects, per tactic path, the set of phases it transitioned
+ * through (added `+phase: <x>` lines) and the date of its latest `phase: done`
+ * transition. The `done` recognition is gated on the node declaring `owner: ai`
+ * as of that commit (`git show <commit>:<path>`), so a human-owned node that
+ * also carries a dispatch phase (a main-qa or reading-review node) cannot count
+ * — the same ownership gate `readTacticVelocity` applies to closures.
+ *
+ * A node counts as a full lifecycle only when its phase set contains every
+ * `LIFECYCLE_REQUIRED_PHASES` entry; among those, the one with the latest
+ * `done` date wins. Reads `none yet` when no node qualifies, and `unknown` when
+ * git history is unavailable (not a repo, no commits) — never a throw.
+ */
+export function readLifecyclePhaseHistory(repoDir: string): string {
+  let patch: string;
+  try {
+    patch = execFileSync(
+      "git",
+      [
+        "log",
+        "--diff-filter=AM",
+        "--no-renames",
+        "--format=%H %cI",
+        "-p",
+        "--",
+        "intentions/tactic-*.md",
+      ],
+      {
+        cwd: repoDir,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        maxBuffer: 64 * 1024 * 1024,
+      },
+    );
+  } catch {
+    return "unknown";
+  }
+
+  /**
+   * Whether `filePath` declares `owner: ai` as of `commitHash`. A failed lookup
+   * degrades to "not ai-owned" rather than throwing, honoring the total-sensor
+   * contract (mirrors `readTacticVelocity`'s `isAiOwnedAt`).
+   */
+  function isAiOwnedAt(commitHash: string, filePath: string): boolean {
+    try {
+      const content = execFileSync("git", ["show", `${commitHash}:${filePath}`], {
+        cwd: repoDir,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      return /^owner:\s*ai\s*$/m.test(content);
+    } catch {
+      return false;
+    }
+  }
+
+  const phasesByPath = new Map<string, Set<string>>();
+  const doneDateByPath = new Map<string, string>(); // YYYY-MM-DD of latest owner:ai done
+  let commit: string | null = null;
+  let commitDate: string | null = null;
+  let path: string | null = null;
+
+  for (const line of patch.split("\n")) {
+    const commitLine = /^([0-9a-f]{40}) (\S+)$/.exec(line);
+    if (commitLine !== null) {
+      commit = commitLine[1];
+      commitDate = commitLine[2];
+      continue;
+    }
+    const header = /^diff --git a\/(\S+) b\/(\S+)$/.exec(line);
+    if (header !== null) {
+      path = header[2];
+      continue;
+    }
+    if (path === null) {
+      continue;
+    }
+    const phaseAdd = /^\+\s*phase:\s*(\S+)\s*$/.exec(line);
+    if (phaseAdd === null) {
+      continue;
+    }
+    const phase = phaseAdd[1];
+    let set = phasesByPath.get(path);
+    if (set === undefined) {
+      set = new Set<string>();
+      phasesByPath.set(path, set);
+    }
+    set.add(phase);
+    if (phase === "done" && commit !== null && isAiOwnedAt(commit, path)) {
+      const day = (commitDate ?? "").slice(0, 10);
+      const prev = doneDateByPath.get(path);
+      if (prev === undefined || day > prev) {
+        doneDateByPath.set(path, day);
+      }
+    }
+  }
+
+  let bestPath: string | null = null;
+  let bestDate = "";
+  for (const [candidatePath, day] of doneDateByPath) {
+    const set = phasesByPath.get(candidatePath);
+    if (set === undefined) {
+      continue;
+    }
+    if (!LIFECYCLE_REQUIRED_PHASES.every((ph) => set.has(ph))) {
+      continue;
+    }
+    if (bestPath === null || day > bestDate) {
+      bestPath = candidatePath;
+      bestDate = day;
+    }
+  }
+
+  if (bestPath === null) {
+    return "none yet";
+  }
+  const id = bestPath.replace(/^intentions\//, "").replace(/\.md$/, "");
+  return `${id} implement→qa→review→done (${bestDate})`;
+}
+
+/**
+ * Selections half: a summary of the router's own selection log, the JSONL file
+ * `graph-select-target` appends one record per invocation to. Counts total
+ * records and the distinct node ids across every record's `selected` array —
+ * the corroborating evidence that the router autonomously drove nodes through
+ * the lifecycle observed above. Malformed lines are skipped (best-effort log,
+ * like the appender); a missing or unreadable file reads `unknown`, never a
+ * throw.
+ */
+export function readSelectionLog(selectionLogPath: string): string {
+  let content: string;
+  try {
+    content = readFileSync(selectionLogPath, "utf8");
+  } catch {
+    return "unknown";
+  }
+  let records = 0;
+  const nodes = new Set<string>();
+  for (const line of content.split("\n")) {
+    if (line.trim() === "") {
+      continue;
+    }
+    let record: unknown;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!isPlainObject(record)) {
+      continue;
+    }
+    records += 1;
+    const selected = record.selected;
+    if (Array.isArray(selected)) {
+      for (const id of selected) {
+        if (typeof id === "string") {
+          nodes.add(id);
+        }
+      }
+    }
+  }
+  return `${records} records, ${nodes.size} nodes`;
+}
+
+/**
+ * Compose the full lifecycle reading from its two halves. Exported for unit
+ * tests, which inject a fixture git repo and a fixture selection log.
+ */
+export function readLifecycleReading(repoDir: string, selectionLogPath: string): string {
+  return (
+    `lifecycle: ${readLifecyclePhaseHistory(repoDir)}; ` +
+    `router selections: ${readSelectionLog(selectionLogPath)}`
+  );
+}
+
+const lifecycleSensor: Sensor = {
+  name: LIFECYCLE_SENSOR_NAME,
+  read(): string {
+    const selectionLogPath =
+      process.env.DISPATCH_SELECTION_LOG_FILE ??
+      (process.env.DISPATCH_SELECTION_LOG_DIR !== undefined
+        ? join(process.env.DISPATCH_SELECTION_LOG_DIR, "graph-selection.jsonl")
+        : SELECTION_LOG_DEFAULT_PATH);
+    return readLifecycleReading(repoRoot, selectionLogPath);
+  },
+};
+
 /**
  * Build the default registry of local-first own-execution sensors. Exported so
  * the registration set can be unit-tested (verification deferred to #2372/QA).
@@ -319,6 +547,7 @@ export function buildDefaultRegistry(): SensorRegistry {
   registry.register(vitestSensor);
   registry.register(gitSensor);
   registry.register(tokenEconomySensor);
+  registry.register(lifecycleSensor);
   return registry;
 }
 

--- a/packages/intentionsutil/test/lifecycle-sensor.test.ts
+++ b/packages/intentionsutil/test/lifecycle-sensor.test.ts
@@ -1,0 +1,175 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildDefaultRegistry,
+  readLifecyclePhaseHistory,
+  readLifecycleReading,
+  readSelectionLog,
+} from "../scripts/read-sensors.js";
+
+const LIFECYCLE_SENSOR_NAME = "the intention store and the router's selection log";
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), "lifecycle-sensor-"));
+}
+
+function git(repo: string, args: string[], env: Record<string, string> = {}): void {
+  execFileSync("git", args, {
+    cwd: repo,
+    stdio: "ignore",
+    env: { ...process.env, ...env },
+  });
+}
+
+/** Init a fixture repo with an intentions/ dir and deterministic config. */
+function initRepo(): string {
+  const repo = tempDir();
+  git(repo, ["init", "-q", "-b", "main"]);
+  git(repo, ["config", "user.email", "test@example.com"]);
+  git(repo, ["config", "user.name", "Test"]);
+  git(repo, ["config", "commit.gpgsign", "false"]);
+  mkdirSync(join(repo, "intentions"));
+  return repo;
+}
+
+/** Commit everything, optionally backdating both author and committer dates. */
+function commitAll(repo: string, message: string, isoDate?: string): void {
+  git(repo, ["add", "-A"]);
+  const env: Record<string, string> =
+    isoDate === undefined ? {} : { GIT_AUTHOR_DATE: isoDate, GIT_COMMITTER_DATE: isoDate };
+  git(repo, ["commit", "-q", "-m", message], env);
+}
+
+/** Minimal tactic-node frontmatter fixture with a top-level phase field. */
+function tacticFile(id: string, opts: { owner?: string; phase?: string } = {}): string {
+  const owner = opts.owner ?? "ai";
+  const phase = opts.phase === undefined ? "" : `phase: ${opts.phase}\n`;
+  return `---\nid: ${id}\nkind: tactic\nstatement: s\nowner: ${owner}\nstatus: raw\nparent: null\n${phase}---\n# ${id}\n`;
+}
+
+/** Drive a tactic file through a sequence of phases, one commit per phase. */
+function driveLifecycle(
+  repo: string,
+  id: string,
+  phases: string[],
+  owner = "ai",
+  isoDate?: string,
+): void {
+  const path = join(repo, "intentions", `${id}.md`);
+  for (const phase of phases) {
+    writeFileSync(path, tacticFile(id, { owner, phase }));
+    commitAll(repo, `${id} -> ${phase}`, isoDate);
+  }
+}
+
+/** Write a fixture selection-log JSONL file and return its path. */
+function selectionLogFile(lines: string[]): string {
+  const path = join(tempDir(), "graph-selection.jsonl");
+  writeFileSync(path, lines.join("\n") + (lines.length > 0 ? "\n" : ""));
+  return path;
+}
+
+describe("readLifecyclePhaseHistory", () => {
+  it("reports the latest owner: ai tactic that observed the full lifecycle", () => {
+    const repo = initRepo();
+    driveLifecycle(repo, "tactic-full", ["implement", "qa", "review", "done"], "ai", "2026-07-05T12:00:00Z");
+    expect(readLifecyclePhaseHistory(repo)).toBe(
+      "tactic-full implement→qa→review→done (2026-07-05)",
+    );
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("reads none yet when a node reaches done without passing every phase", () => {
+    const repo = initRepo();
+    // implement -> done, skipping qa and review: not a full lifecycle.
+    driveLifecycle(repo, "tactic-partial", ["implement", "done"]);
+    expect(readLifecyclePhaseHistory(repo)).toBe("none yet");
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("reads none yet when a node runs the phases but never reaches done", () => {
+    const repo = initRepo();
+    driveLifecycle(repo, "tactic-open", ["implement", "qa", "review"]);
+    expect(readLifecyclePhaseHistory(repo)).toBe("none yet");
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("does not count a human-owned node that completes the lifecycle", () => {
+    const repo = initRepo();
+    driveLifecycle(repo, "tactic-human", ["implement", "qa", "review", "done"], "human");
+    expect(readLifecyclePhaseHistory(repo)).toBe("none yet");
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("picks the node with the latest done date among multiple full lifecycles", () => {
+    const repo = initRepo();
+    driveLifecycle(repo, "tactic-early", ["implement", "qa", "review", "done"], "ai", "2026-06-01T12:00:00Z");
+    driveLifecycle(repo, "tactic-late", ["implement", "qa", "review", "done"], "ai", "2026-07-01T12:00:00Z");
+    expect(readLifecyclePhaseHistory(repo)).toBe(
+      "tactic-late implement→qa→review→done (2026-07-01)",
+    );
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("reads unknown when git history is unavailable (not a repo)", () => {
+    expect(readLifecyclePhaseHistory(tempDir())).toBe("unknown");
+  });
+});
+
+describe("readSelectionLog", () => {
+  it("counts records and the distinct selected node ids", () => {
+    const path = selectionLogFile([
+      JSON.stringify({ site: "graph-select-target", disposition: "node", selected: ["tactic-a"] }),
+      JSON.stringify({ site: "graph-select-target", disposition: "node", selected: ["tactic-b", "tactic-a"] }),
+      JSON.stringify({ site: "graph-select-target", disposition: "empty", selected: [] }),
+    ]);
+    expect(readSelectionLog(path)).toBe("3 records, 2 nodes");
+  });
+
+  it("skips malformed lines without failing the whole read", () => {
+    const path = selectionLogFile([
+      JSON.stringify({ selected: ["tactic-a"] }),
+      "{ not valid json",
+      JSON.stringify({ selected: ["tactic-b"] }),
+    ]);
+    expect(readSelectionLog(path)).toBe("2 records, 2 nodes");
+  });
+
+  it("reads unknown when the selection log is missing", () => {
+    expect(readSelectionLog(join(tempDir(), "absent.jsonl"))).toBe("unknown");
+  });
+});
+
+describe("readLifecycleReading", () => {
+  it("composes the dual reading from history and the selection log", () => {
+    const repo = initRepo();
+    driveLifecycle(repo, "tactic-full", ["implement", "qa", "review", "done"], "ai", "2026-07-05T12:00:00Z");
+    const log = selectionLogFile([
+      JSON.stringify({ selected: ["tactic-full"] }),
+    ]);
+    expect(readLifecycleReading(repo, log)).toBe(
+      "lifecycle: tactic-full implement→qa→review→done (2026-07-05); router selections: 1 records, 1 nodes",
+    );
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("degrades each half independently (no lifecycle, missing log)", () => {
+    const repo = initRepo();
+    writeFileSync(join(repo, "intentions", "tactic-open.md"), tacticFile("tactic-open", { phase: "implement" }));
+    commitAll(repo, "add tactic-open");
+    expect(readLifecycleReading(repo, join(tempDir(), "absent.jsonl"))).toBe(
+      "lifecycle: none yet; router selections: unknown",
+    );
+    rmSync(repo, { recursive: true, force: true });
+  });
+});
+
+describe("buildDefaultRegistry", () => {
+  it("registers the lifecycle sensor under the name the strategy declares", () => {
+    const registry = buildDefaultRegistry();
+    expect(registry.resolve(LIFECYCLE_SENSOR_NAME).name).toBe(LIFECYCLE_SENSOR_NAME);
+  });
+});


### PR DESCRIPTION
Registers a local-first `lifecycle` sensor in `read-sensors.ts`'s
`buildDefaultRegistry`, under the exact `success_signal.sensor` name
`strategy-graph-native-dispatch` declares ("the intention store and the
router's selection log"). Buys round 1 its own instrument (fresh-reading
gate, clarification 3): a reading for the observable — "a tactic completes
the full lifecycle with no GitHub label or issue required" — derived from
the store itself with no gh query.

The dual reading mirrors the strategy's dual source:

- **phase history** — a single line-level pass over `git log -p` of
  `intentions/tactic-*.md` finds the latest `owner: ai` tactic whose phase
  set observed the full `implement -> qa -> review -> done` lifecycle (the
  `done` transition gated on `owner: ai` as of that commit, like
  `readTacticVelocity`), or `none yet`. A graph-native lifecycle is gh-free
  by construction — its transitions are `intentions/*.md` commits, not gh
  labels — so observing a completed node satisfies the "no GitHub label or
  issue required" clause without a gh query.
- **selection log** — record and distinct-selected-node counts over
  `graph-select-target`'s `graph-selection.jsonl` (default path and
  `DISPATCH_SELECTION_LOG_FILE`/`_DIR` overrides mirror the script).

Each half degrades independently (`none yet` / `unknown`) and `read()`
never throws (total-sensor contract). Reuses `SensorRegistry`, the
`gitSensor`/`readTacticVelocity` patterns, `deriveGap`, and
`readFrontierSensors` as the invocation path — no new entrypoint. The
driver, on its next run, writes the strategy's `reading`/`gap`, re-opening
the fresh-reading gate for a round-2 /align-tactics.

## Verification

- `npm test --prefix packages/intentionsutil` — 348 pass (11 new
  lifecycle-sensor cases).
- tsc `--noEmit` over the package tsconfig passes.

Implements tactic-dispatch-lifecycle-sensor.