### PR TITLE
graph: align-tactics gate accepts a strategy's native phase:null

### DIFF
--- a/packages/intentionsutil/scripts/check-node-selection.ts
+++ b/packages/intentionsutil/scripts/check-node-selection.ts
@@ -40,7 +40,12 @@
 import { pathToFileURL } from "node:url";
 import { readFileSync } from "node:fs";
 import { listNodes, readNode, readNodeBody } from "../src/store.js";
-import { servingStrategyIds, strategyFingerprint, tacticScopeFingerprint } from "../src/router.js";
+import {
+  servingStrategyIds,
+  strategyAlignSelectable,
+  strategyFingerprint,
+  tacticScopeFingerprint,
+} from "../src/router.js";
 import type { IntentionNode } from "../src/schema.js";
 import { IntentionSchemaError } from "../src/errors.js";
 
@@ -120,15 +125,48 @@ export function evaluateSelection(opts: SelectionOpts): SelectionResult {
     throw err;
   }
 
-  // 2. phase — persisted phase must equal the selected phase (never re-derived).
+  // 2. phase — the selected phase must still match the node.
+  //
+  // A strategy is selected at the derived `align-tactics` rung, a string the
+  // selector emits on the candidate but never stores on the node (strategies
+  // carry `phase: null` natively). A literal `readPhase === selectedPhase`
+  // computes `null !== "align-tactics"` and exit-12s every strategy, blocking
+  // the whole align lane. For `align-tactics` the equality is replaced by a
+  // strategy-aware gate: the node must be a strategy still at its native null
+  // phase (an advance to any non-null phase — first-class or squatter — is a
+  // stale selection). The align-eligibility re-check is deferred to below the
+  // not-parked check so a parked strategy fails with the clearer not-parked
+  // message. All other phases keep the literal stored-phase equality (tactic
+  // phases are first-class and persisted, so equality is correct there).
   const phase = readPhase(node);
-  if (phase !== selectedPhase) {
+  if (selectedPhase === "align-tactics") {
+    if (node.kind !== "strategy") {
+      return fail(EXIT_STALE_SELECTION, "phase", `selected align-tactics but ${nodeId} is a ${node.kind}, not a strategy`);
+    }
+    if (phase !== null) {
+      return fail(EXIT_STALE_SELECTION, "phase", `selected align-tactics but strategy ${nodeId} phase advanced to ${phase}`);
+    }
+  } else if (phase !== selectedPhase) {
     return fail(EXIT_STALE_SELECTION, "phase", `selected ${selectedPhase} but node is now ${phase ?? "draft/null"}`);
   }
 
   // 3. not parked — an author park landing after selection yields the worker.
   if (readParked(node)) {
     return fail(EXIT_STALE_SELECTION, "not-parked", `${nodeId} was parked to office_hours after selection`);
+  }
+
+  // 3b. align-eligibility — for an align-tactics selection, the selector must
+  //     still emit the strategy as an align candidate (signal still unvalidated,
+  //     under the rounds cap, no non-draft on-path child, not soft-frozen out).
+  //     Deferred to here so the not-parked check above owns the parked verdict;
+  //     defers wholesale to the pure selector (single source of truth).
+  if (selectedPhase === "align-tactics" && !strategyAlignSelectable(node, listNodes(dir))) {
+    return fail(
+      EXIT_STALE_SELECTION,
+      "phase",
+      `selected align-tactics but strategy ${nodeId} is no longer align-eligible ` +
+        `(signal validated, rounds cap, on-path child, or soft-frozen out)`,
+    );
   }
 
   // 4. fingerprint — a strategy substance edit after selection yields the

--- a/packages/intentionsutil/src/router.ts
+++ b/packages/intentionsutil/src/router.ts
@@ -351,3 +351,28 @@ export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
 
   return { candidates, events };
 }
+
+/**
+ * Would the graph selector emit `strategy` as an `align-tactics` candidate over
+ * this store snapshot right now? True iff `strategy` appears among
+ * `selectGraphTargets(nodes).candidates` as a `kind: "strategy"` candidate at
+ * the derived `align-tactics` rung — covering both a fresh align-arm-eligible
+ * strategy and the one queued soft-freeze re-evaluation session.
+ *
+ * The selector is the single source of truth for align-selectability (single-
+ * callsite doctrine): this helper is membership in its output, never a re-
+ * implementation of its per-strategy gates (child/signal/rounds/freeze). The
+ * worker-start re-validation gate (`check-node-selection.ts`) calls it so a
+ * strategy selected at `align-tactics` re-validates against exactly the
+ * selector's current verdict, closing the `null !== "align-tactics"` literal-
+ * equality regression that exit-12'd every strategy.
+ *
+ * `office_hours` gating is intentionally in scope (a parked strategy is not
+ * emitted), but the gate applies its dedicated not-parked check first, so in
+ * practice this is only reached for an unparked node.
+ */
+export function strategyAlignSelectable(strategy: IntentionNode, nodes: IntentionNode[]): boolean {
+  return selectGraphTargets(nodes).candidates.some(
+    (c) => c.id === strategy.id && c.kind === "strategy" && c.phase === "align-tactics",
+  );
+}

--- a/packages/intentionsutil/test/check-node-selection.test.ts
+++ b/packages/intentionsutil/test/check-node-selection.test.ts
@@ -188,6 +188,100 @@ describe("evaluateSelection", () => {
     expect(fp3).not.toBe(fp1);
   });
 
+  describe("align-tactics (strategy phase:null) selection", () => {
+    it("passes a codified, phase:null strategy the selector would emit (exit 0)", () => {
+      const dir = tempDir();
+      // reading:null, gap:null => unvalidated signal => an align candidate.
+      seed(dir, anode({ id: "strategy-a", kind: "strategy", status: "codified" }));
+      const r = evaluateSelection({ nodeId: "strategy-a", selectedPhase: "align-tactics", dir, stamp: null });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("exit 12 when the strategy was parked after selection (not-parked owns the verdict)", () => {
+      const dir = tempDir();
+      seed(
+        dir,
+        anode({
+          id: "strategy-a",
+          kind: "strategy",
+          office_hours: { reason: "author park", since: "2026-07-11", recommendation: null },
+        }),
+      );
+      const r = evaluateSelection({ nodeId: "strategy-a", selectedPhase: "align-tactics", dir, stamp: null });
+      expect(r.exitCode).toBe(12);
+      expect(r.stderr[0]).toMatch(/not-parked/);
+    });
+
+    it("exit 12 when the signal became validated (no longer align-eligible)", () => {
+      const dir = tempDir();
+      // reading set, gap null => validated signal => selector drops the strategy.
+      seed(dir, anode({ id: "strategy-a", kind: "strategy", reading: "holding at threshold" }));
+      const r = evaluateSelection({ nodeId: "strategy-a", selectedPhase: "align-tactics", dir, stamp: null });
+      expect(r.exitCode).toBe(12);
+      expect(r.stderr[0]).toMatch(/no longer align-eligible/);
+    });
+
+    it("exit 12 when the strategy gained a non-draft on-path child", () => {
+      const dir = tempDir();
+      seed(dir, anode({ id: "strategy-a", kind: "strategy" }));
+      seed(
+        dir,
+        anode({
+          id: "tactic-child",
+          kind: "tactic",
+          serves: ["strategy-a"],
+          validates: ["strategy-a"],
+          phase: "implement",
+        }),
+      );
+      const r = evaluateSelection({ nodeId: "strategy-a", selectedPhase: "align-tactics", dir, stamp: null });
+      expect(r.exitCode).toBe(12);
+      expect(r.stderr[0]).toMatch(/no longer align-eligible/);
+    });
+
+    it("exit 12 when the strategy is at the rounds cap", () => {
+      const dir = tempDir();
+      seed(
+        dir,
+        anode({
+          id: "strategy-a",
+          kind: "strategy",
+          gap: "still gapped",
+          reading: "fresh 2026-07-10",
+          rounds: { count: 2, last_completed: "2026-07-01T00:00:00Z" },
+        }),
+      );
+      const r = evaluateSelection({ nodeId: "strategy-a", selectedPhase: "align-tactics", dir, stamp: null });
+      expect(r.exitCode).toBe(12);
+      expect(r.stderr[0]).toMatch(/no longer align-eligible/);
+    });
+
+    it("exit 12 when the stored phase advanced to a non-null value", () => {
+      const dir = tempDir();
+      // A squatter phase advance stands in for any non-null stored phase.
+      seed(dir, anode({ id: "strategy-a", kind: "strategy", attributes: { phase: "implement" } }));
+      const r = evaluateSelection({ nodeId: "strategy-a", selectedPhase: "align-tactics", dir, stamp: null });
+      expect(r.exitCode).toBe(12);
+      expect(r.stderr[0]).toMatch(/phase advanced to implement/);
+    });
+
+    it("exit 12 when a tactic id is passed at align-tactics (not a strategy)", () => {
+      const dir = tempDir();
+      seed(dir, anode({ id: "tactic-a", kind: "tactic", phase: "implement" }));
+      const r = evaluateSelection({ nodeId: "tactic-a", selectedPhase: "align-tactics", dir, stamp: null });
+      expect(r.exitCode).toBe(12);
+      expect(r.stderr[0]).toMatch(/not a strategy/);
+    });
+
+    it("a normal tactic phase still round-trips unchanged at align-tactics-adjacent phases", () => {
+      const dir = tempDir();
+      seed(dir, anode({ id: "tactic-q", kind: "tactic", phase: "qa" }));
+      expect(evaluateSelection({ nodeId: "tactic-q", selectedPhase: "qa", dir, stamp: null }).exitCode).toBe(0);
+      expect(evaluateSelection({ nodeId: "tactic-q", selectedPhase: "implement", dir, stamp: null }).exitCode).toBe(12);
+    });
+  });
+
   describe("scope chain (--stamp)", () => {
     function seedTactic(dir: string, phase: Phase): string {
       seed(dir, anode({ id: "tactic-c", kind: "tactic", phase }));

--- a/packages/intentionsutil/test/router.test.ts
+++ b/packages/intentionsutil/test/router.test.ts
@@ -4,6 +4,7 @@ import {
   PHASE_LADDER,
   readingDate,
   selectGraphTargets,
+  strategyAlignSelectable,
   strategyFingerprint,
 } from "../src/router.js";
 
@@ -433,6 +434,63 @@ describe("strategyFingerprint", () => {
     const base = strategy({ id: "strategy-s", serves: ["virtue-a", "virtue-b"] });
     const reordered = strategy({ id: "strategy-s", serves: ["virtue-b", "virtue-a"] });
     expect(strategyFingerprint(base)).toBe(strategyFingerprint(reordered));
+  });
+});
+
+describe("strategyAlignSelectable", () => {
+  // A fixture graph exercising every strategy-selectability branch: a fresh
+  // eligible strategy, a validated (dropped) one, a soft-frozen re-evaluation
+  // one, a parked one, and a strategy blocked by a non-draft on-path child.
+  const fixture = (): IntentionNode[] => {
+    const frozenStrategy = strategy({ id: "strategy-frozen" });
+    return [
+      ...kinds(),
+      strategy({ id: "strategy-fresh" }),
+      strategy({ id: "strategy-validated", reading: "holding at threshold" }),
+      strategy({
+        id: "strategy-parked",
+        office_hours: { reason: "parked", since: "2026-07-01", recommendation: null },
+      }),
+      strategy({ id: "strategy-blocked" }),
+      tactic({
+        id: "tactic-onpath",
+        serves: ["strategy-blocked"],
+        validates: ["strategy-blocked"],
+        phase: "implement",
+      }),
+      frozenStrategy,
+      tactic({
+        id: "tactic-frozen-child",
+        serves: ["strategy-frozen"],
+        phase: "implement",
+        execution: exec({ strategy_fingerprint: "stale-fingerprint" }),
+      }),
+    ];
+  };
+
+  it("agrees with selectGraphTargets membership across the fixture graph (behavior-preserving)", () => {
+    const nodes = fixture();
+    const emitted = new Set(
+      selectGraphTargets(nodes)
+        .candidates.filter((c) => c.kind === "strategy" && c.phase === "align-tactics")
+        .map((c) => c.id),
+    );
+    for (const n of nodes) {
+      expect(strategyAlignSelectable(n, nodes)).toBe(emitted.has(n.id));
+    }
+  });
+
+  it("is true for a fresh eligible strategy and the frozen re-evaluation strategy", () => {
+    const nodes = fixture();
+    expect(strategyAlignSelectable(strategy({ id: "strategy-fresh" }), nodes)).toBe(true);
+    expect(strategyAlignSelectable(strategy({ id: "strategy-frozen" }), nodes)).toBe(true);
+  });
+
+  it("is false for validated, parked, and on-path-blocked strategies", () => {
+    const nodes = fixture();
+    expect(strategyAlignSelectable(strategy({ id: "strategy-validated" }), nodes)).toBe(false);
+    expect(strategyAlignSelectable(strategy({ id: "strategy-parked" }), nodes)).toBe(false);
+    expect(strategyAlignSelectable(strategy({ id: "strategy-blocked" }), nodes)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Context

`check-node-selection.ts` (the worker-start re-validation gate, PR #2792) check #2 did a literal `readPhase(node) !== selectedPhase` test. A `strategy` node carries `phase: null` natively; the selector's *derived* rung for an align-arm-eligible strategy is the never-stored string `align-tactics`. So the gate computed `null !== "align-tactics"` and returned exit 12 for **every** strategy regardless of status, blocking the entire align lane — `provision-node-worktree <strategy> align-tactics` could never proceed, so no strategy was ever decomposed and the graph could not grow new tactic work autonomously.

Node: `intentions/tactic-align-gate-strategy-phase.md`.

## Unit 1 — `strategyAlignSelectable` predicate

Export `strategyAlignSelectable(strategy, nodes)` from `packages/intentionsutil/src/router.ts`, defined as membership in `selectGraphTargets(nodes).candidates` (a `kind: "strategy"` candidate at the `align-tactics` rung). The selector stays the single source of truth for align-selectability and is left untouched, so all existing selector tests stay green.

## Unit 2 — strategy-aware gate

`evaluateSelection` check #2 is now phase-aware: for `selectedPhase === "align-tactics"` it accepts iff the node is a strategy still at its native `null` phase and `strategyAlignSelectable` holds; the align-eligibility re-check is deferred past the not-parked check so a parked strategy fails with the clearer not-parked message. All other phases keep the literal stored-phase equality.

Tests: pass (exit 0); park → 12; signal-validated / rounds-cap / non-draft on-path child → 12; stored phase advanced → 12; tactic id at `align-tactics` → 12; normal tactic phase still round-trips; plus a selector-side test asserting the extraction agrees with `selectGraphTargets` membership across a fixture graph.

## Verification

- `npx vitest run --project packages/intentionsutil --root .` — 354 passed.
- Manual: `node --import tsx/esm packages/intentionsutil/scripts/check-node-selection.ts strategy-autonomous-execution align-tactics --dir intentions` now exits 0 (was 12).

Implemented inline (no subagent-spawn tool available in this worker); both units were tagged `Recommended model: opus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)