### PR TITLE
budget: Projected runway readout on the Accounts page

### DIFF
--- a/budget/src/balance.ts
+++ b/budget/src/balance.ts
@@ -729,6 +729,27 @@ export function computeCashFlow(points: NetWorthPoint[]): CashFlowPoint[] {
   }));
 }
 
+/**
+ * Projected runway in months: latest liquid net worth divided by trailing
+ * monthly spend. Points arrive in ascending week order, so the last point is
+ * the latest reading. Monthly spend converts the trailing weekly average
+ * (`computeAverageWeeklySpending`) at 52 weeks / 12 months.
+ *
+ * Returns `null` when there is no data to divide (no net-worth points) or the
+ * denominator is non-positive (no spend) — no metric, never `Infinity`/`NaN`.
+ * A negative net worth returns its raw negative quotient (the UI shows it).
+ */
+export function computeProjectedRunway(
+  netWorthPoints: NetWorthPoint[],
+  averageWeeklySpending: number,
+): number | null {
+  if (netWorthPoints.length === 0) return null;
+  const monthlySpend = (averageWeeklySpending * 52) / 12;
+  if (monthlySpend <= 0) return null;
+  const latestNetWorth = netWorthPoints[netWorthPoints.length - 1].netWorth;
+  return latestNetWorth / monthlySpend;
+}
+
 interface BalanceDivergence {
   readonly institution: string;
   readonly account: string;

--- a/budget/src/pages/Accounts.tsx
+++ b/budget/src/pages/Accounts.tsx
@@ -29,6 +29,8 @@ import {
   computeAggregateTrend,
   computeNetWorth,
   computeCashFlow,
+  computeAverageWeeklySpending,
+  computeProjectedRunway,
   computeDerivedBalances,
   type AggregatePoint,
   type NetWorthPoint,
@@ -285,7 +287,7 @@ function tone(n: number): "favorable" | "unfavorable" | undefined {
   return undefined;
 }
 
-function HeadlineMetrics({ report }: { report: IncomeStatementReport }) {
+function HeadlineMetrics({ report, runwayMonths }: { report: IncomeStatementReport; runwayMonths: number | null }) {
   const net = report.netIncome.current;
   const netChange = report.cashFlow.current.netChange;
   return (
@@ -293,6 +295,7 @@ function HeadlineMetrics({ report }: { report: IncomeStatementReport }) {
       <Metric label="Net income" value={formatCurrency(net)} delta={report.currentLabel} deltaTone={tone(net)} />
       <Metric label="Savings rate" value={formatPercent(report.savingsRate.current)} delta={report.currentLabel} />
       <Metric label="Net change" value={formatSignedCurrency(netChange)} delta={report.currentLabel} deltaTone={tone(netChange)} />
+      {runwayMonths !== null ? <Metric label="Projected runway" value={runwayMonths.toFixed(1) + " months"} /> : null}
     </Card>
   );
 }
@@ -440,6 +443,7 @@ interface LoadedData {
   derivedBalances: DerivedAccountBalance[];
   report: IncomeStatementReport | null;
   chartData: ChartData | null; // null → render chart-error fallback
+  runwayMonths: number | null; // null → no runway metric (no data / chart fallback)
 }
 
 type LoadState =
@@ -484,22 +488,25 @@ function useAccountsData(options: RenderPageOptions): LoadState {
         const report = computeIncomeStatementReport(transactions, Date.now());
 
         let chartData: ChartData | null;
+        let runwayMonths: number | null = null;
         try {
           const aggregateTrend = computeAggregateTrend(periods, transactions);
           const trendWeeks = aggregateTrend.map(p => ({ label: p.weekLabel, ms: p.weekMs }));
           const { points: netWorthPoints } = computeNetWorth(transactions, statements, trendWeeks);
           const cashFlowPoints = computeCashFlow(netWorthPoints);
           chartData = { aggregateTrend, netWorthPoints, cashFlowPoints };
+          runwayMonths = computeProjectedRunway(netWorthPoints, computeAverageWeeklySpending(periods));
         } catch (chartError) {
           const kind = classifyError(chartError);
           if (kind === "programmer" || kind === "data-integrity" || kind === "range") throw chartError;
           reportError(chartError);
           logError(chartError, { operation: "compute-chart" });
           chartData = null; // → <p className="chart-error">Chart unavailable.</p>
+          runwayMonths = null;
         }
 
         if (cancelled) return;
-        setState({ status: "loaded", data: { rows, derivedBalances, report, chartData } });
+        setState({ status: "loaded", data: { rows, derivedBalances, report, chartData, runwayMonths } });
       } catch (error) {
         if (cancelled) return;
         if (!deferProgrammerError(error)) logError(error, { operation: "router-render" });
@@ -516,7 +523,7 @@ function useAccountsData(options: RenderPageOptions): LoadState {
 function LoadedAccounts({ data }: { data: LoadedData }) {
   return (
     <>
-      {data.report !== null ? <HeadlineMetrics report={data.report} /> : null}
+      {data.report !== null ? <HeadlineMetrics report={data.report} runwayMonths={data.runwayMonths} /> : null}
       {data.report !== null ? <IncomeStatement report={data.report} /> : null}
       {data.report !== null ? <CashFlowSummaryTable report={data.report} /> : null}
       <DivergenceWarning derivedBalances={data.derivedBalances} />

--- a/budget/test/balance.test.ts
+++ b/budget/test/balance.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { Timestamp } from "firebase/firestore";
-import { weekStart, computeNetAmount, findPeriodForTimestamp, computeBudgetBalance, computeAllBudgetBalances, computePeriodBalances, findOverrideInPeriod, computeAverageWeeklyCredits, computeRollingAverage, computeAggregateTrend, computePerBudgetTrend, computeAverageWeeklySpending, computeNetWorth, computeCashFlow, computeDerivedBalances, periodAllowance, weeklyEquivalent, periodEquivalent, computeBudgetStatsAndVariances, MATERIALITY_THRESHOLD } from "../src/balance";
+import { weekStart, computeNetAmount, findPeriodForTimestamp, computeBudgetBalance, computeAllBudgetBalances, computePeriodBalances, findOverrideInPeriod, computeAverageWeeklyCredits, computeRollingAverage, computeAggregateTrend, computePerBudgetTrend, computeAverageWeeklySpending, computeNetWorth, computeCashFlow, computeProjectedRunway, computeDerivedBalances, periodAllowance, weeklyEquivalent, periodEquivalent, computeBudgetStatsAndVariances, MATERIALITY_THRESHOLD } from "../src/balance";
 import type { BudgetDiff, PerBudgetStats } from "../src/balance";
 import type { Budget, BudgetOverride, BudgetPeriod, Statement, Transaction, WeeklyAggregate } from "../src/firestore";
 
@@ -1227,6 +1227,35 @@ describe("computeCashFlow", () => {
     ];
     const result = computeCashFlow(points);
     expect(result[0].cashFlow).toBe(-200);
+  });
+});
+
+describe("computeProjectedRunway", () => {
+  it("divides latest net worth by trailing monthly spend", () => {
+    const points = [
+      { weekLabel: "1/5", weekMs: 1000, netWorth: 5000, isStatementAnchored: false },
+      { weekLabel: "1/12", weekMs: 2000, netWorth: 12000, isStatementAnchored: true },
+    ];
+    // avg weekly spend 100 -> monthly 100 * 52 / 12 ≈ 433.33 -> 12000 / 433.33 ≈ 27.69
+    const result = computeProjectedRunway(points, 100);
+    expect(result).not.toBeNull();
+    expect(result).toBeCloseTo(12000 / ((100 * 52) / 12), 6);
+  });
+
+  it("returns null for empty points (no data yields no metric)", () => {
+    expect(computeProjectedRunway([], 100)).toBeNull();
+  });
+
+  it("returns null for zero spending (no Infinity/NaN)", () => {
+    const points = [{ weekLabel: "1/5", weekMs: 1000, netWorth: 5000, isStatementAnchored: false }];
+    expect(computeProjectedRunway(points, 0)).toBeNull();
+  });
+
+  it("returns the raw negative quotient for negative net worth (no clamp)", () => {
+    const points = [{ weekLabel: "1/5", weekMs: 1000, netWorth: -2000, isStatementAnchored: false }];
+    const result = computeProjectedRunway(points, 100);
+    expect(result).toBeCloseTo(-2000 / ((100 * 52) / 12), 6);
+    expect(result! < 0).toBe(true);
   });
 });
 

--- a/budget/test/balance.test.ts
+++ b/budget/test/balance.test.ts
@@ -1255,7 +1255,7 @@ describe("computeProjectedRunway", () => {
     const points = [{ weekLabel: "1/5", weekMs: 1000, netWorth: -2000, isStatementAnchored: false }];
     const result = computeProjectedRunway(points, 100);
     expect(result).toBeCloseTo(-2000 / ((100 * 52) / 12), 6);
-    expect(result! < 0).toBe(true);
+    expect(result).toBeLessThan(0);
   });
 });
 

--- a/budget/test/pages/Accounts.test.tsx
+++ b/budget/test/pages/Accounts.test.tsx
@@ -235,13 +235,18 @@ describe("Accounts (renderAccounts markup parity)", () => {
     expect(html).toContain("Net change");
   });
 
+  // Two months of transactions so the income report (and thus the headline
+  // card) is non-null vs. today's date; ids default (report keys on
+  // normalizedId, not id).
+  const reportTxns = () => [
+    txn({ category: "Salary", amount: -3000, timestamp: ts("2025-02-10") }),
+    txn({ category: "Food", amount: 500, timestamp: ts("2025-02-12") }),
+    txn({ category: "Salary", amount: -2800, timestamp: ts("2025-01-10") }),
+  ];
+
   it("renders the Projected runway metric when net worth and trailing spend both exist", async () => {
     const html = await renderAccounts(localOptions({
-      getTransactions: vi.fn().mockResolvedValue([
-        txn({ id: "i1" as never, category: "Salary", amount: -3000, timestamp: ts("2025-02-10") }),
-        txn({ id: "e1" as never, category: "Food", amount: 500, timestamp: ts("2025-02-12") }),
-        txn({ id: "i0" as never, category: "Salary", amount: -2800, timestamp: ts("2025-01-10") }),
-      ]),
+      getTransactions: vi.fn().mockResolvedValue(reportTxns()),
       getStatements: vi.fn().mockResolvedValue([stmt({ period: "2025-02", lastTransactionDate: ts("2025-02-12") })]),
       getBudgetPeriods: vi.fn().mockResolvedValue([
         {
@@ -262,11 +267,7 @@ describe("Accounts (renderAccounts markup parity)", () => {
 
   it("omits the Projected runway metric when there are no statements (no net-worth points)", async () => {
     const html = await renderAccounts(localOptions({
-      getTransactions: vi.fn().mockResolvedValue([
-        txn({ id: "i1" as never, category: "Salary", amount: -3000, timestamp: ts("2025-02-10") }),
-        txn({ id: "e1" as never, category: "Food", amount: 500, timestamp: ts("2025-02-12") }),
-        txn({ id: "i0" as never, category: "Salary", amount: -2800, timestamp: ts("2025-01-10") }),
-      ]),
+      getTransactions: vi.fn().mockResolvedValue(reportTxns()),
       getStatements: vi.fn().mockResolvedValue([]),
       getBudgetPeriods: vi.fn().mockResolvedValue([]),
     }));

--- a/budget/test/pages/Accounts.test.tsx
+++ b/budget/test/pages/Accounts.test.tsx
@@ -235,6 +235,46 @@ describe("Accounts (renderAccounts markup parity)", () => {
     expect(html).toContain("Net change");
   });
 
+  it("renders the Projected runway metric when net worth and trailing spend both exist", async () => {
+    const html = await renderAccounts(localOptions({
+      getTransactions: vi.fn().mockResolvedValue([
+        txn({ id: "i1" as never, category: "Salary", amount: -3000, timestamp: ts("2025-02-10") }),
+        txn({ id: "e1" as never, category: "Food", amount: 500, timestamp: ts("2025-02-12") }),
+        txn({ id: "i0" as never, category: "Salary", amount: -2800, timestamp: ts("2025-01-10") }),
+      ]),
+      getStatements: vi.fn().mockResolvedValue([stmt({ period: "2025-02", lastTransactionDate: ts("2025-02-12") })]),
+      getBudgetPeriods: vi.fn().mockResolvedValue([
+        {
+          id: "food-w1", budgetId: "food",
+          periodStart: ts("2025-01-13"), periodEnd: ts("2025-01-20"),
+          total: 200, count: 2, categoryBreakdown: {}, groupId: null,
+        },
+        {
+          id: "food-w2", budgetId: "food",
+          periodStart: ts("2025-01-20"), periodEnd: ts("2025-01-27"),
+          total: 300, count: 3, categoryBreakdown: {}, groupId: null,
+        },
+      ]),
+    }));
+    expect(html).toContain("Projected runway");
+    expect(html).toMatch(/[\d.]+ months/);
+  });
+
+  it("omits the Projected runway metric when there are no statements (no net-worth points)", async () => {
+    const html = await renderAccounts(localOptions({
+      getTransactions: vi.fn().mockResolvedValue([
+        txn({ id: "i1" as never, category: "Salary", amount: -3000, timestamp: ts("2025-02-10") }),
+        txn({ id: "e1" as never, category: "Food", amount: 500, timestamp: ts("2025-02-12") }),
+        txn({ id: "i0" as never, category: "Salary", amount: -2800, timestamp: ts("2025-01-10") }),
+      ]),
+      getStatements: vi.fn().mockResolvedValue([]),
+      getBudgetPeriods: vi.fn().mockResolvedValue([]),
+    }));
+    // The headline card still renders (report is non-null) but no runway metric.
+    expect(html).toContain("Net income");
+    expect(html).not.toContain("Projected runway");
+  });
+
   it("keeps the three period labels word-bounded in the income-table header text", async () => {
     // Regression guard for the React port: the legacy string renderer separated
     // header <th> cells with whitespace, so accounts-income-statement.spec.ts can


### PR DESCRIPTION
## Context

`strategy-financial-sustainability`'s success signal reads projected runway (available funds / trailing monthly spend) against the private time-to-revenue-self-sufficiency horizon, but the strategy has no reading. The budget app already computes both halves of the quotient (`computeNetWorth`, `computeAverageWeeklySpending`) but surfaces no runway number.

This is the instrument tactic for that strategy's null reading: a "Projected runway" headline metric on the Accounts page, in months. No horizon value, threshold, or comparison coloring — the self-sufficiency horizon lives in the private `natb1/office-hours-nate` repo, and the author compares at office-hours.

Node: `tactic-budget-runway-instrument`

## Units

- **Unit 1** — `computeProjectedRunway(netWorthPoints, averageWeeklySpending)` in `budget/src/balance.ts`: latest net worth / monthly spend (`avgWeekly * 52 / 12`). Returns `null` on empty points or non-positive denominator (no `Infinity`/`NaN`); a negative net worth returns the raw negative quotient. Unit tests in `budget/test/balance.test.ts`.
- **Unit 2** — Accounts page readout in `budget/src/pages/Accounts.tsx`: compute `runwayMonths` in the chart block (null on the chart error fallback), carry it on `LoadedData`, and render a `Projected runway` `Metric` in `HeadlineMetrics` when non-null. Page tests in `budget/test/pages/Accounts.test.tsx`.

## Verification

- `npx vitest run --project budget --root .` — 991 passed
- `run-typecheck.sh --app budget` — passed

Manual: open the budget app unauthenticated (seed-data view), Accounts page — the headline card shows "Projected runway" with a plausible months figure; with no statement data the metric is simply absent.