### PR TITLE
trace-decisions digest — decision-trace candidate events for strategy-explicit-intent

### DIFF
--- a/packages/intentionsutil/scripts/trace-decisions.ts
+++ b/packages/intentionsutil/scripts/trace-decisions.ts
@@ -69,6 +69,10 @@ export interface TraceEvent {
 
 // --- Patch heuristics ------------------------------------------------------
 
+/** Unit-separator sentinel between the hash and date in the git `--format`.
+ * A diff never contains this control character, so a header line is unambiguous. */
+const COMMIT_SEP = String.fromCharCode(0x1f);
+
 const STRATEGY_PATH = /^intentions\/strategy-[^/]+\.md$/;
 const STRATEGY_OR_VIRTUE_PATH = /^intentions\/(strategy|virtue)-[^/]+\.md$/;
 const NODE_PATH = /^intentions\/[^/]+\.md$/;
@@ -113,8 +117,9 @@ export function scanDecisionTrace(repoDir: string, since = "30 days ago"): Trace
       `--since=${since}`,
       "--no-renames",
       // Distinctive sentinel per commit: hash <US> author-ISO-date. The unit
-      // separator (\x1f) never appears in a diff, so the header is unambiguous.
-      "--format=%H\x1f%aI",
+      // separator (COMMIT_SEP) never appears in a diff, so the header is
+      // unambiguous.
+      `--format=%H${COMMIT_SEP}%aI`,
       "-p",
       "--",
       "intentions/",
@@ -146,13 +151,13 @@ export function scanDecisionTrace(repoDir: string, since = "30 days ago"): Trace
   };
 
   for (const line of patch.split("\n")) {
-    // The \x1f unit-separator sentinel is deliberate — a git diff never
-    // contains it, so the commit header is unambiguous.
-    // eslint-disable-next-line no-control-regex
-    const commitHeader = /^([0-9a-f]{40})\x1f(.+)$/.exec(line);
-    if (commitHeader !== null) {
-      commit = commitHeader[1];
-      date = commitHeader[2];
+    // A commit header is `<40-hex><COMMIT_SEP><iso-date>` — detect it by the
+    // separator at offset 40 with a 40-hex prefix. Using a string separator
+    // (not a control char in a regex literal) keeps the hash check clean.
+    const sepIdx = line.indexOf(COMMIT_SEP);
+    if (sepIdx === 40 && /^[0-9a-f]{40}$/.test(line.slice(0, 40))) {
+      commit = line.slice(0, 40);
+      date = line.slice(41);
       continue;
     }
 

--- a/packages/intentionsutil/scripts/trace-decisions.ts
+++ b/packages/intentionsutil/scripts/trace-decisions.ts
@@ -142,6 +142,25 @@ export function scanDecisionTrace(repoDir: string, since = "30 days ago"): Trace
   let isDeletedFile = false;
   let isNewFile = false;
 
+  // Class 3 needs a genuine before/after value transition, not a field merely
+  // materializing. A multi-field commit that backfills a previously-absent
+  // `attention: null` onto an existing file (e.g. a schema catch-up alongside
+  // unrelated edits) shows only an added line with no removed counterpart —
+  // that is field creation, not a calibration challenge moving a node. Buffer
+  // attention-line signs per (commit, path) and only emit once BOTH an added
+  // and a removed attention-related line have been seen for that file within
+  // the current commit, flushing at each file/commit boundary.
+  let attentionAdded = false;
+  let attentionRemoved = false;
+  // The added ("after") line is the more useful summary for a reviewer — it
+  // shows what the value became, not what it stopped being. Fall back to the
+  // removed line only if no added line matched (kept for defensive coverage;
+  // not expected given the add+remove pairing this class requires).
+  let attentionAddedSummary: string | null = null;
+  let attentionRemovedSummary: string | null = null;
+  let attentionAddedSummaryIsNested = false;
+  let attentionRemovedSummaryIsNested = false;
+
   const emit = (node: string, eventClass: TraceClass, summary: string): void => {
     if (commit === null || date === null) return;
     const key = `${commit}\x00${node}\x00${eventClass}`;
@@ -150,12 +169,26 @@ export function scanDecisionTrace(repoDir: string, since = "30 days ago"): Trace
     events.push({ date, commit: commit.slice(0, 7), node, eventClass, summary });
   };
 
+  const flushAttention = (): void => {
+    if (path !== null && NODE_PATH.test(path) && attentionAdded && attentionRemoved) {
+      const summary = attentionAddedSummary ?? attentionRemovedSummary ?? "attention changed";
+      emit(nodeIdFromPath(path), "calibration-moves-node", summary);
+    }
+    attentionAdded = false;
+    attentionRemoved = false;
+    attentionAddedSummary = null;
+    attentionRemovedSummary = null;
+    attentionAddedSummaryIsNested = false;
+    attentionRemovedSummaryIsNested = false;
+  };
+
   for (const line of patch.split("\n")) {
     // A commit header is `<40-hex><COMMIT_SEP><iso-date>` — detect it by the
     // separator at offset 40 with a 40-hex prefix. Using a string separator
     // (not a control char in a regex literal) keeps the hash check clean.
     const sepIdx = line.indexOf(COMMIT_SEP);
     if (sepIdx === 40 && /^[0-9a-f]{40}$/.test(line.slice(0, 40))) {
+      flushAttention();
       commit = line.slice(0, 40);
       date = line.slice(41);
       continue;
@@ -163,6 +196,7 @@ export function scanDecisionTrace(repoDir: string, since = "30 days ago"): Trace
 
     const fileHeader = /^diff --git a\/(\S+) b\/(\S+)$/.exec(line);
     if (fileHeader !== null) {
+      flushAttention();
       path = fileHeader[2];
       isDeletedFile = false;
       isNewFile = false;
@@ -208,10 +242,31 @@ export function scanDecisionTrace(repoDir: string, since = "30 days ago"): Trace
     }
 
     // Class 3 — a calibration challenge moves a node (attention injection).
+    // Buffered: only a paired add+remove within this (commit, path) is a real
+    // value transition (see flushAttention above); a lone addition is a field
+    // materializing (e.g. schema backfill), not a challenge.
     if (ATTENTION_LINE.test(line)) {
-      emit(node, "calibration-moves-node", summarize(line));
+      // A nested `boost:`/`override:` line carries the actual value and is a
+      // more useful summary than the bare top-level `attention:` line; prefer
+      // it if one appears (in either position), but don't require it — a
+      // bare `attention:` line alone is still a valid fallback summary.
+      const isNested = /^[+-]\s+(boost|override):/.test(line);
+      if (line.startsWith("+")) {
+        attentionAdded = true;
+        if (attentionAddedSummary === null || (isNested && !attentionAddedSummaryIsNested)) {
+          attentionAddedSummary = summarize(line);
+          attentionAddedSummaryIsNested = isNested;
+        }
+      } else {
+        attentionRemoved = true;
+        if (attentionRemovedSummary === null || (isNested && !attentionRemovedSummaryIsNested)) {
+          attentionRemovedSummary = summarize(line);
+          attentionRemovedSummaryIsNested = isNested;
+        }
+      }
     }
   }
+  flushAttention();
 
   return events;
 }

--- a/packages/intentionsutil/scripts/trace-decisions.ts
+++ b/packages/intentionsutil/scripts/trace-decisions.ts
@@ -1,0 +1,283 @@
+// Decision-trace digest — mechanically assemble the candidate decision-trace
+// events that strategy-explicit-intent's success signal names, so the owner can
+// judge the threshold at an office-hours sitting.
+//
+// The strategy's observable is: "decisions trace to the graph — dialectic
+// outputs cite node ids, a failed condition retires or re-derives a strategy, a
+// calibration challenge moves a node"; its sensor is "owner review at
+// office-hours" (`is_proxy: true`). A machine must NEVER auto-write that reading
+// — human judgment records it. This script only assembles the raw candidate
+// events from the graph's git history and prints them for the sitting; it writes
+// nothing to the store and touches no network.
+//
+// All three observable clauses are graph-visible events, so the digest reads
+// them from `git log -p -- intentions/` line-level patch heuristics — the same
+// technique `readTacticVelocity` uses (`read-sensors.ts`).
+//
+// Run from anywhere (the repo root is resolved relative to this file, not cwd):
+//   npx tsx packages/intentionsutil/scripts/trace-decisions.ts [--since <git-date>] [--json]
+//
+// `--since` accepts any git approxidate (default `30 days ago`); `--json` emits
+// the events as a JSON array instead of the human-readable digest. A git failure
+// (not a repo, bad `--since`) exits non-zero with the error — clear errors over
+// fallbacks (`.claude/rules/code-style.md`); this is an operator-run script, not
+// a total batch sensor.
+
+import { execFileSync } from "node:child_process";
+import { dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+// --- Paths -----------------------------------------------------------------
+// The script lives at `packages/intentionsutil/scripts/trace-decisions.ts`, so
+// the repo root is three directories up. Resolve from this file's own location,
+// never from cwd — the git scan runs with `cwd: repoRoot`.
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(dirname(dirname(scriptDir)));
+
+// --- Event model -----------------------------------------------------------
+
+/** One of the three observable clauses a candidate event can attest. */
+export type TraceClass = "dialectic-cites-node" | "condition-retires-strategy" | "calibration-moves-node";
+
+/** Human-facing heading for each class, in observable-clause order. */
+export const CLASS_LABELS: Record<TraceClass, string> = {
+  "dialectic-cites-node": "Dialectic outputs cite node ids",
+  "condition-retires-strategy": "A failed condition retires or re-derives a strategy",
+  "calibration-moves-node": "A calibration challenge moves a node",
+};
+
+/** Stable class ordering for grouped output. */
+export const CLASS_ORDER: TraceClass[] = [
+  "dialectic-cites-node",
+  "condition-retires-strategy",
+  "calibration-moves-node",
+];
+
+/** One candidate decision-trace event surfaced from the graph's git history. */
+export interface TraceEvent {
+  /** ISO-8601 author date of the commit. */
+  date: string;
+  /** Abbreviated (7-char) commit hash. */
+  commit: string;
+  /** Node id the event touched, derived from the intentions file path. */
+  node: string;
+  /** Which observable clause this event attests. */
+  eventClass: TraceClass;
+  /** One-line human summary — the representative changed line (or a note). */
+  summary: string;
+}
+
+// --- Patch heuristics ------------------------------------------------------
+
+const STRATEGY_PATH = /^intentions\/strategy-[^/]+\.md$/;
+const STRATEGY_OR_VIRTUE_PATH = /^intentions\/(strategy|virtue)-[^/]+\.md$/;
+const NODE_PATH = /^intentions\/[^/]+\.md$/;
+
+/** Added clarifications entry (`- question:` / `answer:`) on a strategy/virtue. */
+const CLARIFICATION_LINE = /^\+\s*-?\s*(question|answer):/;
+
+/** A strategy's substance/condition lines, added or removed (`success_signal`
+ * block included via its nested keys). Only applied to strategy files. */
+const STRATEGY_SUBSTANCE_LINE =
+  /^[+-]\s*(statement|conditions|success_signal|observable|sensor|threshold|is_proxy):/;
+
+/** An attention injection: the top-level `attention:` key toggling, or a nested
+ * `boost:` / `override:` (both unambiguous — they appear only under attention). */
+const ATTENTION_LINE = /^[+-]attention:|^[+-]\s+(boost|override):/;
+
+/** Derive the node id from an `intentions/<id>.md` path. */
+export function nodeIdFromPath(path: string): string {
+  return path.replace(/^intentions\//, "").replace(/\.md$/, "");
+}
+
+/** Strip the diff `+`/`-` marker and surrounding whitespace for a summary. */
+function summarize(line: string): string {
+  const body = line.replace(/^[+-]\s*/, "").trim();
+  return body.length > 120 ? body.slice(0, 117) + "..." : body;
+}
+
+/**
+ * Scan `git log --since=<since> -p -- intentions/` and return the candidate
+ * decision-trace events, one per (commit, node, class). A single commit editing
+ * one node in several ways yields one event per class it attests; the first
+ * matching changed line is kept as that class's summary.
+ *
+ * Throws on a git failure (not a repo, bad `--since`) — this is an operator-run
+ * digest, not a total batch sensor, so the error surfaces rather than degrading.
+ */
+export function scanDecisionTrace(repoDir: string, since = "30 days ago"): TraceEvent[] {
+  const patch = execFileSync(
+    "git",
+    [
+      "log",
+      `--since=${since}`,
+      "--no-renames",
+      // Distinctive sentinel per commit: hash <US> author-ISO-date. The unit
+      // separator (\x1f) never appears in a diff, so the header is unambiguous.
+      "--format=%H\x1f%aI",
+      "-p",
+      "--",
+      "intentions/",
+    ],
+    {
+      cwd: repoDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  );
+
+  const events: TraceEvent[] = [];
+  // Dedup key `${commit}\x00${node}\x00${class}` -> already emitted.
+  const seen = new Set<string>();
+
+  let commit: string | null = null;
+  let date: string | null = null;
+  let path: string | null = null;
+  let isDeletedFile = false;
+  let isNewFile = false;
+
+  const emit = (node: string, eventClass: TraceClass, summary: string): void => {
+    if (commit === null || date === null) return;
+    const key = `${commit}\x00${node}\x00${eventClass}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    events.push({ date, commit: commit.slice(0, 7), node, eventClass, summary });
+  };
+
+  for (const line of patch.split("\n")) {
+    // The \x1f unit-separator sentinel is deliberate — a git diff never
+    // contains it, so the commit header is unambiguous.
+    // eslint-disable-next-line no-control-regex
+    const commitHeader = /^([0-9a-f]{40})\x1f(.+)$/.exec(line);
+    if (commitHeader !== null) {
+      commit = commitHeader[1];
+      date = commitHeader[2];
+      continue;
+    }
+
+    const fileHeader = /^diff --git a\/(\S+) b\/(\S+)$/.exec(line);
+    if (fileHeader !== null) {
+      path = fileHeader[2];
+      isDeletedFile = false;
+      isNewFile = false;
+      continue;
+    }
+
+    if (path === null || !NODE_PATH.test(path)) continue;
+
+    if (line.startsWith("new file mode")) {
+      // A brand-new node is authoring, not a change to an existing decision;
+      // its content lines are excluded from all three classes.
+      isNewFile = true;
+      continue;
+    }
+
+    if (line.startsWith("deleted file mode")) {
+      isDeletedFile = true;
+      // A deleted strategy file is itself a class-2 event (a retired strategy).
+      if (STRATEGY_PATH.test(path)) {
+        emit(nodeIdFromPath(path), "condition-retires-strategy", "strategy file deleted");
+      }
+      continue;
+    }
+
+    // Diff bookkeeping lines (`+++`, `---`) start with the change markers but
+    // are never content; skip them so they cannot match a heuristic.
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+
+    // A new file's added content is initial authoring, not a decision change.
+    if (isNewFile) continue;
+
+    const node = nodeIdFromPath(path);
+
+    // Class 1 — dialectic outputs cite node ids (added clarifications entries).
+    if (STRATEGY_OR_VIRTUE_PATH.test(path) && CLARIFICATION_LINE.test(line)) {
+      emit(node, "dialectic-cites-node", summarize(line));
+    }
+
+    // Class 2 — a failed condition retires or re-derives a strategy (condition /
+    // substance edits on a strategy; deletion handled above).
+    if (STRATEGY_PATH.test(path) && !isDeletedFile && STRATEGY_SUBSTANCE_LINE.test(line)) {
+      emit(node, "condition-retires-strategy", summarize(line));
+    }
+
+    // Class 3 — a calibration challenge moves a node (attention injection).
+    if (ATTENTION_LINE.test(line)) {
+      emit(node, "calibration-moves-node", summarize(line));
+    }
+  }
+
+  return events;
+}
+
+// --- Rendering -------------------------------------------------------------
+
+/** Render the events as a human-readable digest grouped by class with counts. */
+export function formatDigest(events: TraceEvent[], since: string): string {
+  const lines: string[] = [];
+  lines.push(`Decision-trace digest — candidate events since "${since}"`);
+  lines.push(`(sensor is owner review at office-hours; this only assembles the candidates)`);
+  lines.push("");
+
+  for (const eventClass of CLASS_ORDER) {
+    const group = events
+      .filter((e) => e.eventClass === eventClass)
+      .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+    lines.push(`${CLASS_LABELS[eventClass]} (${group.length})`);
+    if (group.length === 0) {
+      lines.push("  (none)");
+    } else {
+      for (const e of group) {
+        lines.push(`  ${e.date.slice(0, 10)}  ${e.commit}  ${e.node}  ${e.summary}`);
+      }
+    }
+    lines.push("");
+  }
+
+  lines.push(`Total candidate events: ${events.length}`);
+  return lines.join("\n");
+}
+
+// --- CLI -------------------------------------------------------------------
+
+interface Args {
+  since: string;
+  json: boolean;
+}
+
+/** Parse `--since <git-date>` and `--json`; unknown flags exit non-zero. */
+export function parseArgs(argv: string[]): Args {
+  let since = "30 days ago";
+  let json = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--since") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        throw new Error("--since requires a git-date argument");
+      }
+      since = value;
+      i++;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return { since, json };
+}
+
+function main(): void {
+  const { since, json } = parseArgs(process.argv.slice(2));
+  const events = scanDecisionTrace(repoRoot, since);
+  if (json) {
+    process.stdout.write(JSON.stringify(events, null, 2) + "\n");
+  } else {
+    process.stdout.write(formatDigest(events, since) + "\n");
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/packages/intentionsutil/test/trace-decisions.test.ts
+++ b/packages/intentionsutil/test/trace-decisions.test.ts
@@ -159,6 +159,58 @@ describe("scanDecisionTrace", () => {
     expect(condition[0].summary).toBe("strategy file deleted");
   });
 
+  it("does not attribute a schema-backfill of a previously-absent attention field to class 3", () => {
+    const repo = initRepo();
+    // Baseline: an existing node whose file predates the `attention` field
+    // being part of the schema at all (no `attention:` line present).
+    writeNodeFile(
+      repo,
+      "tactic-zeta",
+      ["---", "id: tactic-zeta", "kind: tactic", "statement: t", "owner: ai", "status: raw", "parent: null", "---", "# tactic-zeta", ""].join("\n"),
+    );
+    commitAll(repo, "add tactic-zeta", "2026-07-01T12:00:00Z");
+
+    // A later commit backfills the field onto the existing file at its
+    // default/absent-equivalent value (`null`) alongside unrelated schema
+    // catch-up — this is field materialization, not a calibration challenge,
+    // and must not be attributed to class 3.
+    writeNodeFile(
+      repo,
+      "tactic-zeta",
+      ["---", "id: tactic-zeta", "kind: tactic", "statement: t", "owner: ai", "status: raw", "parent: null", "attention: null", "phase: null", "---", "# tactic-zeta", ""].join("\n"),
+    );
+    commitAll(repo, "backfill schema fields on tactic-zeta", "2026-07-02T12:00:00Z");
+
+    const events = scanDecisionTrace(repo, "2026-06-01");
+    expect(ofClass(events, "calibration-moves-node")).toHaveLength(0);
+  });
+
+  it("attributes a real attention value transition to class 3 with the boost as summary", () => {
+    const repo = initRepo();
+    writeNodeFile(
+      repo,
+      "tactic-eta",
+      ["---", "id: tactic-eta", "kind: tactic", "statement: t", "owner: ai", "status: raw", "parent: null", "attention: null", "---", "# tactic-eta", ""].join("\n"),
+    );
+    commitAll(repo, "add tactic-eta", "2026-07-01T12:00:00Z");
+
+    // A genuine transition: `attention: null` is replaced by a populated
+    // block — this is a real value change (paired add+remove of the
+    // top-level key within the same commit), unlike the backfill case above.
+    writeNodeFile(
+      repo,
+      "tactic-eta",
+      ["---", "id: tactic-eta", "kind: tactic", "statement: t", "owner: ai", "status: raw", "parent: null", "attention:", "  boost: 6", "  override: null", "  rationale: real challenge", "---", "# tactic-eta", ""].join("\n"),
+    );
+    commitAll(repo, "boost tactic-eta", "2026-07-02T12:00:00Z");
+
+    const events = scanDecisionTrace(repo, "2026-06-01");
+    const calibration = ofClass(events, "calibration-moves-node");
+    expect(calibration).toHaveLength(1);
+    expect(calibration[0].node).toBe("tactic-eta");
+    expect(calibration[0].summary).toBe("boost: 6");
+  });
+
   it("does not attribute a plain tactic conditions/statement edit to class 2 (strategy-only)", () => {
     const repo = initRepo();
     writeNodeFile(

--- a/packages/intentionsutil/test/trace-decisions.test.ts
+++ b/packages/intentionsutil/test/trace-decisions.test.ts
@@ -1,0 +1,236 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { nodeIdFromPath, parseArgs, scanDecisionTrace, type TraceClass } from "../scripts/trace-decisions.js";
+
+// --- Fixture-repo helpers (temp-fixture-repo pattern of lifecycle-sensor.test) ---
+
+const repos: string[] = [];
+
+function git(repo: string, args: string[], env: Record<string, string> = {}): void {
+  execFileSync("git", args, {
+    cwd: repo,
+    stdio: "ignore",
+    env: { ...process.env, ...env },
+  });
+}
+
+/** Init a fixture repo with an intentions/ dir and deterministic config. */
+function initRepo(): string {
+  const repo = mkdtempSync(join(tmpdir(), "trace-decisions-"));
+  repos.push(repo);
+  git(repo, ["init", "-q", "-b", "main"]);
+  git(repo, ["config", "user.email", "test@example.com"]);
+  git(repo, ["config", "user.name", "Test"]);
+  git(repo, ["config", "commit.gpgsign", "false"]);
+  mkdirSync(join(repo, "intentions"));
+  return repo;
+}
+
+/** Commit everything with a deterministic backdated author/committer date. */
+function commitAll(repo: string, message: string, isoDate: string): void {
+  git(repo, ["add", "-A"]);
+  git(repo, ["commit", "-q", "-m", message], {
+    GIT_AUTHOR_DATE: isoDate,
+    GIT_COMMITTER_DATE: isoDate,
+  });
+}
+
+function writeNodeFile(repo: string, id: string, body: string): void {
+  writeFileSync(join(repo, "intentions", `${id}.md`), body);
+}
+
+afterEach(() => {
+  while (repos.length > 0) {
+    const repo = repos.pop();
+    if (repo !== undefined) rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+/** Return the events of one class, for focused assertions. */
+function ofClass(events: ReturnType<typeof scanDecisionTrace>, cls: TraceClass) {
+  return events.filter((e) => e.eventClass === cls);
+}
+
+// --- Frontmatter fixtures --------------------------------------------------
+
+function strategyBase(id: string): string {
+  return [
+    "---",
+    `id: ${id}`,
+    "kind: strategy",
+    "statement: original statement",
+    "owner: ai",
+    "status: codified",
+    "parent: null",
+    "attention: null",
+    "attributes:",
+    "  conditions:",
+    "    - the original world premise holds",
+    "---",
+    `# ${id}`,
+    "",
+  ].join("\n");
+}
+
+describe("scanDecisionTrace", () => {
+  it("attributes one fixture commit per event class and a no-match control", () => {
+    const repo = initRepo();
+
+    // Baseline: a strategy and a tactic exist. (Adding files is not a trace event.)
+    writeNodeFile(repo, "strategy-alpha", strategyBase("strategy-alpha"));
+    writeNodeFile(
+      repo,
+      "tactic-beta",
+      ["---", "id: tactic-beta", "kind: tactic", "statement: t", "owner: ai", "status: raw", "parent: null", "attention: null", "---", "# tactic-beta", ""].join("\n"),
+    );
+    commitAll(repo, "baseline", "2026-07-01T12:00:00Z");
+
+    // Class 1 — dialectic cites node ids: add a clarifications entry to the strategy.
+    writeNodeFile(
+      repo,
+      "strategy-alpha",
+      strategyBase("strategy-alpha").replace(
+        "attention: null\n",
+        "attention: null\nclarifications:\n  - question: Does intent trace to nodes?\n    answer: Yes, via graph history.\n",
+      ),
+    );
+    commitAll(repo, "clarify strategy-alpha", "2026-07-02T12:00:00Z");
+
+    // Class 2 — a failed condition retires/re-derives: edit the strategy's conditions + statement.
+    writeNodeFile(
+      repo,
+      "strategy-alpha",
+      strategyBase("strategy-alpha")
+        .replace("statement: original statement", "statement: re-derived statement")
+        .replace("    - the original world premise holds", "    - the premise no longer holds; re-derived"),
+    );
+    commitAll(repo, "re-derive strategy-alpha", "2026-07-03T12:00:00Z");
+
+    // Class 3 — a calibration challenge moves a node: inject an attention boost on the tactic.
+    writeNodeFile(
+      repo,
+      "tactic-beta",
+      ["---", "id: tactic-beta", "kind: tactic", "statement: t", "owner: ai", "status: raw", "parent: null", "attention:", "  boost: 5", "  rationale: bumped by calibration", "---", "# tactic-beta", ""].join("\n"),
+    );
+    commitAll(repo, "boost tactic-beta", "2026-07-04T12:00:00Z");
+
+    // No-match control: a body-only edit changes nothing tracked by the heuristics.
+    writeNodeFile(
+      repo,
+      "tactic-beta",
+      ["---", "id: tactic-beta", "kind: tactic", "statement: t", "owner: ai", "status: raw", "parent: null", "attention:", "  boost: 5", "  rationale: bumped by calibration", "---", "# tactic-beta", "", "New body prose, no frontmatter change.", ""].join("\n"),
+    );
+    commitAll(repo, "body-only edit", "2026-07-05T12:00:00Z");
+
+    const events = scanDecisionTrace(repo, "2026-06-01");
+
+    const cite = ofClass(events, "dialectic-cites-node");
+    expect(cite).toHaveLength(1);
+    expect(cite[0].node).toBe("strategy-alpha");
+
+    const condition = ofClass(events, "condition-retires-strategy");
+    expect(condition).toHaveLength(1);
+    expect(condition[0].node).toBe("strategy-alpha");
+
+    const calibration = ofClass(events, "calibration-moves-node");
+    expect(calibration).toHaveLength(1);
+    expect(calibration[0].node).toBe("tactic-beta");
+
+    // The no-match control commit contributed nothing.
+    expect(events.some((e) => e.commit && e.summary.includes("New body prose"))).toBe(false);
+    expect(events).toHaveLength(3);
+  });
+
+  it("treats a deleted strategy file as a condition-retires-strategy event", () => {
+    const repo = initRepo();
+    writeNodeFile(repo, "strategy-gamma", strategyBase("strategy-gamma"));
+    commitAll(repo, "add strategy-gamma", "2026-07-01T12:00:00Z");
+
+    unlinkSync(join(repo, "intentions", "strategy-gamma.md"));
+    commitAll(repo, "retire strategy-gamma", "2026-07-02T12:00:00Z");
+
+    const events = scanDecisionTrace(repo, "2026-06-01");
+    const condition = ofClass(events, "condition-retires-strategy");
+    expect(condition).toHaveLength(1);
+    expect(condition[0].node).toBe("strategy-gamma");
+    expect(condition[0].summary).toBe("strategy file deleted");
+  });
+
+  it("does not attribute a plain tactic conditions/statement edit to class 2 (strategy-only)", () => {
+    const repo = initRepo();
+    writeNodeFile(
+      repo,
+      "tactic-delta",
+      ["---", "id: tactic-delta", "kind: tactic", "statement: original", "owner: ai", "status: raw", "parent: null", "attention: null", "---", "# tactic-delta", ""].join("\n"),
+    );
+    commitAll(repo, "add tactic-delta", "2026-07-01T12:00:00Z");
+
+    writeNodeFile(
+      repo,
+      "tactic-delta",
+      ["---", "id: tactic-delta", "kind: tactic", "statement: changed", "owner: ai", "status: raw", "parent: null", "attention: null", "---", "# tactic-delta", ""].join("\n"),
+    );
+    commitAll(repo, "edit tactic-delta statement", "2026-07-02T12:00:00Z");
+
+    const events = scanDecisionTrace(repo, "2026-06-01");
+    expect(ofClass(events, "condition-retires-strategy")).toHaveLength(0);
+  });
+
+  it("emits ISO date, short hash, node id, class and summary in JSON shape", () => {
+    const repo = initRepo();
+    writeNodeFile(repo, "strategy-epsilon", strategyBase("strategy-epsilon"));
+    commitAll(repo, "add", "2026-07-01T12:00:00Z");
+    writeNodeFile(
+      repo,
+      "strategy-epsilon",
+      strategyBase("strategy-epsilon").replace(
+        "attention: null\n",
+        "attention: null\nclarifications:\n  - question: q?\n    answer: a.\n",
+      ),
+    );
+    commitAll(repo, "clarify", "2026-07-02T12:00:00Z");
+
+    const events = scanDecisionTrace(repo, "2026-06-01");
+    expect(events).toHaveLength(1);
+    const e = events[0];
+    // git %aI renders the backdated UTC commit as strict ISO-8601.
+    expect(e.date).toMatch(/^2026-07-02T12:00:00(Z|\+00:00)$/);
+    expect(e.commit).toMatch(/^[0-9a-f]{7}$/);
+    expect(e.node).toBe("strategy-epsilon");
+    expect(e.eventClass).toBe("dialectic-cites-node");
+    expect(typeof e.summary).toBe("string");
+    // Serializes cleanly to a JSON array.
+    expect(() => JSON.parse(JSON.stringify(events))).not.toThrow();
+  });
+
+  it("throws on a git failure (not a repo)", () => {
+    const bogus = mkdtempSync(join(tmpdir(), "trace-decisions-nogit-"));
+    repos.push(bogus);
+    expect(() => scanDecisionTrace(bogus, "2026-06-01")).toThrow();
+  });
+});
+
+describe("nodeIdFromPath", () => {
+  it("derives the node id from an intentions path", () => {
+    expect(nodeIdFromPath("intentions/strategy-explicit-intent.md")).toBe("strategy-explicit-intent");
+    expect(nodeIdFromPath("intentions/tactic-x.md")).toBe("tactic-x");
+  });
+});
+
+describe("parseArgs", () => {
+  it("defaults to a 30-day window and human output", () => {
+    expect(parseArgs([])).toEqual({ since: "30 days ago", json: false });
+  });
+  it("parses --since and --json", () => {
+    expect(parseArgs(["--since", "2026-07-07", "--json"])).toEqual({ since: "2026-07-07", json: true });
+  });
+  it("rejects --since without a value", () => {
+    expect(() => parseArgs(["--since"])).toThrow(/requires a git-date/);
+  });
+  it("rejects an unknown flag", () => {
+    expect(() => parseArgs(["--bogus"])).toThrow(/unknown argument/);
+  });
+});


### PR DESCRIPTION
Node: tactic-decision-trace-instrument (serves strategy-explicit-intent).

## What

New operator-run script `packages/intentionsutil/scripts/trace-decisions.ts` that mechanically assembles the candidate decision-trace events strategy-explicit-intent's success signal names, so the owner can judge the threshold at an office-hours sitting (the recorded sensor is owner review; `is_proxy: true`). The script writes nothing to the store and touches no network.

It scans `git log -p -- intentions/` (the same patch-heuristic technique `readTacticVelocity` uses) and groups candidate events into the three observable clauses:

1. **Dialectic outputs cite node ids** — added `clarifications` entries on a `strategy-*` / `virtue-*` node.
2. **A failed condition retires or re-derives a strategy** — condition/`statement`/`success_signal` edits on a `strategy-*` node, or a deleted strategy file.
3. **A calibration challenge moves a node** — `attention:` injections (top-level toggle or nested `boost`/`override`) on any node.

CLI: `npx tsx packages/intentionsutil/scripts/trace-decisions.ts [--since <git-date>] [--json]` (default 30-day window; human-readable digest by default, `--json` for machine use). New-file creations are excluded from all classes (initial authoring is not a decision change); a not-a-repo git failure surfaces non-zero rather than degrading.

## Out of scope

- No sensor registered in `buildDefaultRegistry` and no automatic `reading` write — the sitting (tactic-decision-trace-first-reading) records the reading.
- No office-hours UI surfacing; no gh/network IO.

## Verification

- `npm test --prefix packages/intentionsutil` — 376 tests pass, incl. new `test/trace-decisions.test.ts` (10 tests: class attribution, node-id derivation, deletion-as-retirement, strategy-only class-2 scoping, `--json` shape, git-failure throw).
- Manual: `trace-decisions.ts --since 2026-07-01` against this clone lists the 2026-07-08/09 clarification amendments on `strategy-explicit-intent` under class 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)