### PR TITLE
instrument: managed dispatch daemon liveness sensor

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-daemon-liveness
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-daemon-liveness
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+#
+# dispatch-daemon-liveness — report whether the managed dispatch daemon is up
+# and ticking unattended, distinguishing the managed lingering unit from a
+# transient interactive daemon.
+#
+# strategy-autonomous-execution's success signal needs a liveness observable on
+# the managed lingering daemon (dispatch-claude-daemon.service, defined at
+# nix/home/claude-code.nix). An interactive `claude agents` invocation spawns
+# its OWN transient `claude daemon` process — a child of that session, living
+# OUTSIDE the unit cgroup — which masks a dead managed service (on 2026-07-08 a
+# transient daemon masked a dead managed unit for roughly a day). Backlog drain
+# alone therefore cannot prove UNATTENDED execution: the queue can drain while
+# the managed unit is dead, carried by a transient daemon that dies with the
+# interactive session. This sensor reads systemd/proc facts directly and
+# classifies every live `claude daemon` process by cgroup — managed (inside the
+# unit cgroup) vs transient (any other) — so the masking case is legible.
+#
+# Report-only. No remediation, no office-hours/dashboard integration (graph-fed
+# panels are tactic-attention-surface-velocity-pace's surface).
+#
+# Verdicts and exit codes (clear errors over fallbacks — .claude/rules/code-style.md):
+#   0  managed-live            — a managed daemon (unit cgroup) is running AND
+#                                linger is on AND the heartbeat timer is active.
+#   2  transient-substituting  — no managed daemon, but a transient daemon IS
+#                                serving (the 2026-07-08 masking case).
+#   3  down                    — no `claude daemon` process at all.
+#   4  degraded                — a managed daemon is running but linger is off
+#                                or the heartbeat timer is inactive (autonomy is
+#                                not durable: it will not survive a logout /
+#                                reboot, or ticks are not firing on schedule).
+#
+# The daemon census is the source of truth for liveness: a unit systemctl
+# reports "active" whose MainPID is dead still yields `down` because no process
+# is classified managed. Unit ActiveState/MainPID/ActiveEnterTimestamp/NRestarts
+# are surfaced verbatim for continuity ("active since before the logout window,
+# no restarts during it").
+#
+# Why proc/systemd over `claude agents --json`: the sandbox's network namespace
+# blocks the daemon socket, so a sandboxed `claude agents` query returns `[]`
+# indistinguishable from "no sessions" (see lib-claude-agents.sh's UNKNOWN
+# fail-safe). systemd unit state and /proc/<pid>/cgroup are readable facts that
+# do not depend on the daemon answering. Run this sensor unsandboxed on the host.
+#
+# Usage:
+#   dispatch-daemon-liveness            human-readable report
+#   dispatch-daemon-liveness --json     machine-readable JSON reading
+#   dispatch-daemon-liveness -h|--help  this help
+#
+# Command injection points (default to the real binaries; overridden by the
+# test harness — mirrors the $systemctl_cmd pattern at lib.sh:2775):
+#   DISPATCH_LIVENESS_SYSTEMCTL_CMD  (default: systemctl)
+#   DISPATCH_LIVENESS_LOGINCTL_CMD   (default: loginctl)
+#   DISPATCH_LIVENESS_PGREP_CMD      (default: pgrep)
+#   DISPATCH_LIVENESS_PROC_DIR       (default: /proc)   — dir holding <pid>/cgroup
+#   DISPATCH_LIVENESS_USER           (default: $USER)    — subject of loginctl
+
+set -uo pipefail
+
+readonly UNIT="dispatch-claude-daemon.service"
+readonly HEARTBEAT_TIMER="dispatch-heartbeat.timer"
+# pgrep -f matches against the full command line; the managed unit's ExecStart
+# is `claude daemon run`, and a transient interactive daemon runs the same
+# `claude daemon` command, so this pattern enumerates both.
+readonly DAEMON_PATTERN="claude daemon"
+
+SYSTEMCTL_CMD="${DISPATCH_LIVENESS_SYSTEMCTL_CMD:-systemctl}"
+LOGINCTL_CMD="${DISPATCH_LIVENESS_LOGINCTL_CMD:-loginctl}"
+PGREP_CMD="${DISPATCH_LIVENESS_PGREP_CMD:-pgrep}"
+PROC_DIR="${DISPATCH_LIVENESS_PROC_DIR:-/proc}"
+LIVENESS_USER="${DISPATCH_LIVENESS_USER:-${USER:-$(id -un)}}"
+
+# Exit codes, keyed by verdict.
+readonly CODE_MANAGED_LIVE=0
+readonly CODE_TRANSIENT_SUBSTITUTING=2
+readonly CODE_DOWN=3
+readonly CODE_DEGRADED=4
+
+usage() {
+  sed -n '2,/^set -uo/p' "$0" | sed '$d; s/^# \{0,1\}//'
+}
+
+JSON=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) JSON=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "dispatch-daemon-liveness: unknown argument: $1" >&2; echo "usage: dispatch-daemon-liveness [--json]" >&2; exit 64 ;;
+  esac
+done
+
+# --- systemd property read --------------------------------------------------
+# `systemctl --user show <unit> -p K1 -p K2 ...` prints one `KEY=VALUE` line per
+# property (VALUE may itself contain `=`; split on the FIRST `=` only). Returns
+# the value of $2 from the output captured in $1, or empty if absent. A truly
+# missing systemctl binary is an environment error and dies (clear errors over
+# fallbacks); an inactive/absent unit is NOT an error — systemctl prints
+# ActiveState=inactive and exits 0.
+show_prop() {
+  local show_output="$1" key="$2" line
+  while IFS= read -r line; do
+    if [[ "$line" == "$key="* ]]; then
+      printf '%s' "${line#"$key"=}"
+      return 0
+    fi
+  done <<<"$show_output"
+  printf ''
+}
+
+# --- gather managed-unit facts ----------------------------------------------
+if ! UNIT_SHOW="$("$SYSTEMCTL_CMD" --user show "$UNIT" \
+      -p ActiveState -p SubState -p MainPID -p ActiveEnterTimestamp -p NRestarts 2>&1)"; then
+  echo "dispatch-daemon-liveness: '$SYSTEMCTL_CMD --user show $UNIT' failed:" >&2
+  echo "$UNIT_SHOW" >&2
+  exit 69
+fi
+UNIT_ACTIVE_STATE="$(show_prop "$UNIT_SHOW" ActiveState)"
+UNIT_SUB_STATE="$(show_prop "$UNIT_SHOW" SubState)"
+UNIT_MAIN_PID="$(show_prop "$UNIT_SHOW" MainPID)"
+UNIT_ACTIVE_ENTER="$(show_prop "$UNIT_SHOW" ActiveEnterTimestamp)"
+UNIT_NRESTARTS="$(show_prop "$UNIT_SHOW" NRestarts)"
+
+# --- gather heartbeat-timer facts -------------------------------------------
+if ! HB_SHOW="$("$SYSTEMCTL_CMD" --user show "$HEARTBEAT_TIMER" \
+      -p ActiveState -p SubState -p LastTriggerUSec 2>&1)"; then
+  echo "dispatch-daemon-liveness: '$SYSTEMCTL_CMD --user show $HEARTBEAT_TIMER' failed:" >&2
+  echo "$HB_SHOW" >&2
+  exit 69
+fi
+HB_ACTIVE_STATE="$(show_prop "$HB_SHOW" ActiveState)"
+HB_SUB_STATE="$(show_prop "$HB_SHOW" SubState)"
+HB_LAST_TRIGGER="$(show_prop "$HB_SHOW" LastTriggerUSec)"
+
+# --- gather linger fact ------------------------------------------------------
+# `loginctl show-user <user> --property=Linger --value` prints `yes`/`no`. On a
+# host where the user has no session AND linger is off, loginctl exits non-zero
+# ("No such user/process") — that unqueryable state is itself the degraded
+# signal we want to report, so treat a failed query as "not yes" (LINGER=""),
+# surface it raw, and let the verdict gate flag it. This is report data, not an
+# operation failure to abort on.
+if ! LINGER="$("$LOGINCTL_CMD" show-user "$LIVENESS_USER" --property=Linger --value 2>/dev/null)"; then
+  LINGER=""
+fi
+
+# --- daemon census -----------------------------------------------------------
+# Enumerate every live `claude daemon` process and classify each by cgroup:
+# /proc/<pid>/cgroup containing the unit name => managed (inside the unit
+# cgroup); anything else (or an unreadable cgroup) => transient. pgrep exits 1
+# when there are NO matches — that is "no daemons", not an error, hence `|| true`.
+DAEMON_PIDS="$("$PGREP_CMD" -f "$DAEMON_PATTERN" 2>/dev/null || true)"
+
+MANAGED_COUNT=0
+TRANSIENT_COUNT=0
+# CENSUS_ROWS: newline-delimited "<pid> <class>" — fed to jq for the --json array.
+CENSUS_ROWS=""
+if [[ -n "$DAEMON_PIDS" ]]; then
+  while IFS= read -r pid; do
+    [[ -n "$pid" ]] || continue
+    local_class="transient"
+    cgroup_file="$PROC_DIR/$pid/cgroup"
+    if [[ -r "$cgroup_file" ]] && grep -q "$UNIT" "$cgroup_file" 2>/dev/null; then
+      local_class="managed"
+      MANAGED_COUNT=$((MANAGED_COUNT + 1))
+    else
+      TRANSIENT_COUNT=$((TRANSIENT_COUNT + 1))
+    fi
+    CENSUS_ROWS+="$pid $local_class"$'\n'
+  done <<<"$DAEMON_PIDS"
+fi
+
+MANAGED_PRESENT=false
+[[ "$MANAGED_COUNT" -gt 0 ]] && MANAGED_PRESENT=true
+TRANSIENT_PRESENT=false
+[[ "$TRANSIENT_COUNT" -gt 0 ]] && TRANSIENT_PRESENT=true
+
+# --- verdict -----------------------------------------------------------------
+HB_IS_ACTIVE=false
+[[ "$HB_ACTIVE_STATE" == "active" ]] && HB_IS_ACTIVE=true
+
+if [[ "$MANAGED_PRESENT" == true ]]; then
+  if [[ "$LINGER" == "yes" && "$HB_IS_ACTIVE" == true ]]; then
+    VERDICT="managed-live"
+    EXIT_CODE=$CODE_MANAGED_LIVE
+  else
+    VERDICT="degraded"
+    EXIT_CODE=$CODE_DEGRADED
+  fi
+elif [[ "$TRANSIENT_PRESENT" == true ]]; then
+  VERDICT="transient-substituting"
+  EXIT_CODE=$CODE_TRANSIENT_SUBSTITUTING
+else
+  VERDICT="down"
+  EXIT_CODE=$CODE_DOWN
+fi
+
+# Reason for the verdict — the degraded specifics matter to a reader.
+DEGRADED_REASON=""
+if [[ "$VERDICT" == "degraded" ]]; then
+  [[ "$LINGER" != "yes" ]] && DEGRADED_REASON+="linger not enabled (Linger=${LINGER:-<unqueryable>}); "
+  [[ "$HB_IS_ACTIVE" != true ]] && DEGRADED_REASON+="heartbeat timer not active (ActiveState=${HB_ACTIVE_STATE:-<empty>}); "
+  DEGRADED_REASON="${DEGRADED_REASON%; }"
+fi
+
+# --- output ------------------------------------------------------------------
+# Build the census JSON array from the "<pid> <class>" rows. printf|jq is used
+# (never `echo "$VAR" | jq` — banned by .claude/rules/shell-json.md) so no shell
+# escape interpretation touches the data.
+CENSUS_JSON="$(printf '%s' "$CENSUS_ROWS" | jq -R -s '
+  split("\n") | map(select(length > 0) | (split(" ")) | {pid: (.[0] | tonumber), class: .[1]})')"
+
+if [[ "$JSON" -eq 1 ]]; then
+  jq -n \
+    --arg verdict "$VERDICT" \
+    --argjson exit_code "$EXIT_CODE" \
+    --arg unit_name "$UNIT" \
+    --arg unit_active_state "$UNIT_ACTIVE_STATE" \
+    --arg unit_sub_state "$UNIT_SUB_STATE" \
+    --arg unit_main_pid "$UNIT_MAIN_PID" \
+    --arg unit_active_enter "$UNIT_ACTIVE_ENTER" \
+    --arg unit_nrestarts "$UNIT_NRESTARTS" \
+    --arg linger "$LINGER" \
+    --arg hb_timer "$HEARTBEAT_TIMER" \
+    --arg hb_active_state "$HB_ACTIVE_STATE" \
+    --arg hb_sub_state "$HB_SUB_STATE" \
+    --arg hb_last_trigger "$HB_LAST_TRIGGER" \
+    --argjson managed_present "$MANAGED_PRESENT" \
+    --argjson transient_present "$TRANSIENT_PRESENT" \
+    --argjson census "$CENSUS_JSON" \
+    --arg degraded_reason "$DEGRADED_REASON" \
+    '{
+      verdict: $verdict,
+      exit_code: $exit_code,
+      degraded_reason: (if $degraded_reason == "" then null else $degraded_reason end),
+      unit: {
+        name: $unit_name,
+        active_state: $unit_active_state,
+        sub_state: $unit_sub_state,
+        main_pid: $unit_main_pid,
+        active_enter_timestamp: $unit_active_enter,
+        n_restarts: $unit_nrestarts
+      },
+      linger: $linger,
+      heartbeat: {
+        timer: $hb_timer,
+        active_state: $hb_active_state,
+        sub_state: $hb_sub_state,
+        last_trigger_usec: $hb_last_trigger
+      },
+      managed_present: $managed_present,
+      transient_present: $transient_present,
+      census: $census
+    }'
+  exit "$EXIT_CODE"
+fi
+
+# Human-readable report.
+printf 'dispatch daemon liveness: %s\n' "$VERDICT"
+[[ -n "$DEGRADED_REASON" ]] && printf '  reason: %s\n' "$DEGRADED_REASON"
+printf '\n'
+printf 'Managed unit (%s):\n' "$UNIT"
+printf '  ActiveState=%s SubState=%s MainPID=%s\n' "$UNIT_ACTIVE_STATE" "$UNIT_SUB_STATE" "$UNIT_MAIN_PID"
+printf '  ActiveEnterTimestamp=%s\n' "$UNIT_ACTIVE_ENTER"
+printf '  NRestarts=%s\n' "$UNIT_NRESTARTS"
+printf 'Linger (%s): %s\n' "$LIVENESS_USER" "${LINGER:-<unqueryable>}"
+printf 'Heartbeat (%s):\n' "$HEARTBEAT_TIMER"
+printf '  ActiveState=%s SubState=%s LastTriggerUSec=%s\n' "$HB_ACTIVE_STATE" "$HB_SUB_STATE" "$HB_LAST_TRIGGER"
+printf 'Daemon census (managed=%s transient=%s):\n' "$MANAGED_COUNT" "$TRANSIENT_COUNT"
+if [[ -n "$CENSUS_ROWS" ]]; then
+  while IFS= read -r row; do
+    [[ -n "$row" ]] || continue
+    printf '  pid %s\n' "$row"
+  done <<<"$CENSUS_ROWS"
+else
+  printf '  (no claude daemon processes)\n'
+fi
+
+exit "$EXIT_CODE"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-daemon-liveness.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-daemon-liveness.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# test-dispatch-daemon-liveness.sh — unit-test harness for dispatch-daemon-liveness.
+#
+# Dependency-injects the systemctl / loginctl / pgrep invocations and the
+# /proc/<pid>/cgroup reads through the sensor's DISPATCH_LIVENESS_* command
+# overrides (the $systemctl_cmd pattern used around lib.sh:2775). No systemd, no
+# real daemon, no network — only bash + jq. Covers all four verdicts, their exit
+# codes, the census cgroup classification (managed wins over a co-present
+# transient), the linger-unqueryable path, and the --json shape.
+#
+# House pattern mirrors packages/intentionsutil/scripts/test-graph-commit.sh and
+# .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh. Run under
+# bash -c, never zsh.
+
+set -uo pipefail
+
+HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HARNESS_DIR/dispatch-daemon-liveness"
+[[ -x "$SCRIPT" ]] || { echo "error: dispatch-daemon-liveness not found/executable at $SCRIPT" >&2; exit 1; }
+
+WORK="$(mktemp -d)" || { echo "error: mktemp failed" >&2; exit 1; }
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0; FAIL=0
+ok() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+no() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+assert_eq() { # <label> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then ok "$1"; else no "$1 (expected '$2', got '$3')"; fi
+}
+
+# --- stubs ------------------------------------------------------------------
+# Written once; behavior is driven per-case by STUB_* env vars read at call time.
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+
+cat > "$BIN/systemctl" <<'STUB'
+#!/usr/bin/env bash
+# usage: systemctl --user show <unit> -p ...  — emit KEY=VALUE lines.
+unit=""
+for a in "$@"; do
+  case "$a" in
+    dispatch-claude-daemon.service|dispatch-heartbeat.timer) unit="$a" ;;
+  esac
+done
+if [[ "$unit" == "dispatch-claude-daemon.service" ]]; then
+  printf 'ActiveState=%s\n' "${STUB_UNIT_ACTIVE:-inactive}"
+  printf 'SubState=%s\n' "${STUB_UNIT_SUBSTATE:-dead}"
+  printf 'MainPID=%s\n' "${STUB_UNIT_MAINPID:-0}"
+  printf 'ActiveEnterTimestamp=%s\n' "${STUB_UNIT_AET:-}"
+  printf 'NRestarts=%s\n' "${STUB_UNIT_NRESTARTS:-0}"
+elif [[ "$unit" == "dispatch-heartbeat.timer" ]]; then
+  printf 'ActiveState=%s\n' "${STUB_HB_ACTIVE:-inactive}"
+  printf 'SubState=%s\n' "${STUB_HB_SUBSTATE:-dead}"
+  printf 'LastTriggerUSec=%s\n' "${STUB_HB_LAST:-}"
+fi
+STUB
+chmod +x "$BIN/systemctl"
+
+cat > "$BIN/loginctl" <<'STUB'
+#!/usr/bin/env bash
+# usage: loginctl show-user <user> --property=Linger --value
+[[ "${STUB_LINGER_FAIL:-0}" == "1" ]] && exit 1
+printf '%s\n' "${STUB_LINGER:-no}"
+STUB
+chmod +x "$BIN/loginctl"
+
+cat > "$BIN/pgrep" <<'STUB'
+#!/usr/bin/env bash
+# usage: pgrep -f 'claude daemon' — print one PID per line; exit 1 when none.
+[[ -z "${STUB_PIDS:-}" ]] && exit 1
+# shellcheck disable=SC2086 — intentional word-split of the space-list.
+printf '%s\n' $STUB_PIDS
+STUB
+chmod +x "$BIN/pgrep"
+
+# mk_proc <procdir> <pid>:<managed|transient> ...
+# Build a fake /proc where each pid's cgroup file marks it managed or transient.
+mk_proc() {
+  local procdir="$1"; shift
+  local spec pid cls
+  for spec in "$@"; do
+    pid="${spec%%:*}"; cls="${spec##*:}"
+    mkdir -p "$procdir/$pid"
+    if [[ "$cls" == "managed" ]]; then
+      printf '0::/user.slice/user-1000.slice/user@1000.service/app.slice/dispatch-claude-daemon.service\n' > "$procdir/$pid/cgroup"
+    else
+      printf '0::/user.slice/user-1000.slice/session-3.scope\n' > "$procdir/$pid/cgroup"
+    fi
+  done
+}
+
+# run_case captures stdout and exit code into RUN_OUT / RUN_RC. All STUB_*/PROC
+# vars are passed inline so each case is isolated.
+run_case() {
+  local procdir="$1"; shift  # remaining args: extra flags to the script (e.g. --json)
+  set +e
+  RUN_OUT="$(
+    DISPATCH_LIVENESS_SYSTEMCTL_CMD="$BIN/systemctl" \
+    DISPATCH_LIVENESS_LOGINCTL_CMD="$BIN/loginctl" \
+    DISPATCH_LIVENESS_PGREP_CMD="$BIN/pgrep" \
+    DISPATCH_LIVENESS_PROC_DIR="$procdir" \
+    DISPATCH_LIVENESS_USER="tester" \
+    STUB_UNIT_ACTIVE="${STUB_UNIT_ACTIVE:-}" \
+    STUB_UNIT_SUBSTATE="${STUB_UNIT_SUBSTATE:-}" \
+    STUB_UNIT_MAINPID="${STUB_UNIT_MAINPID:-}" \
+    STUB_UNIT_AET="${STUB_UNIT_AET:-}" \
+    STUB_UNIT_NRESTARTS="${STUB_UNIT_NRESTARTS:-}" \
+    STUB_HB_ACTIVE="${STUB_HB_ACTIVE:-}" \
+    STUB_HB_SUBSTATE="${STUB_HB_SUBSTATE:-}" \
+    STUB_HB_LAST="${STUB_HB_LAST:-}" \
+    STUB_LINGER="${STUB_LINGER:-}" \
+    STUB_LINGER_FAIL="${STUB_LINGER_FAIL:-}" \
+    STUB_PIDS="${STUB_PIDS:-}" \
+    bash "$SCRIPT" "$@"
+  )"
+  RUN_RC=$?
+  set -e
+}
+
+# Reset all per-case STUB_* vars to their inactive/empty defaults.
+reset_stubs() {
+  unset STUB_UNIT_ACTIVE STUB_UNIT_SUBSTATE STUB_UNIT_MAINPID STUB_UNIT_AET STUB_UNIT_NRESTARTS
+  unset STUB_HB_ACTIVE STUB_HB_SUBSTATE STUB_HB_LAST STUB_LINGER STUB_LINGER_FAIL STUB_PIDS
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: managed-live — managed daemon in unit cgroup, linger on, heartbeat active.
+reset_stubs
+P="$WORK/proc1"; mk_proc "$P" 1001:managed
+STUB_UNIT_ACTIVE=active STUB_UNIT_SUBSTATE=running STUB_UNIT_MAINPID=1001 \
+  STUB_UNIT_AET="Tue 2026-07-08 09:00:00 UTC" STUB_UNIT_NRESTARTS=0 \
+  STUB_HB_ACTIVE=active STUB_HB_SUBSTATE=waiting STUB_LINGER=yes STUB_PIDS=1001 \
+  run_case "$P"
+assert_eq "managed-live exit code" 0 "$RUN_RC"
+[[ "$RUN_OUT" == *"managed-live"* ]] && ok "managed-live verdict in report" || no "managed-live verdict missing"
+
+# ---------------------------------------------------------------------------
+# Case 2: transient-substituting — unit inactive, a transient daemon serving.
+reset_stubs
+P="$WORK/proc2"; mk_proc "$P" 2002:transient
+STUB_UNIT_ACTIVE=inactive STUB_UNIT_SUBSTATE=dead STUB_UNIT_MAINPID=0 \
+  STUB_HB_ACTIVE=inactive STUB_LINGER=no STUB_PIDS=2002 \
+  run_case "$P"
+assert_eq "transient-substituting exit code" 2 "$RUN_RC"
+[[ "$RUN_OUT" == *"transient-substituting"* ]] && ok "transient-substituting verdict" || no "transient-substituting verdict missing"
+
+# ---------------------------------------------------------------------------
+# Case 3: down — no claude daemon process at all.
+reset_stubs
+P="$WORK/proc3"; mkdir -p "$P"
+STUB_UNIT_ACTIVE=inactive STUB_UNIT_MAINPID=0 STUB_HB_ACTIVE=inactive STUB_LINGER=no STUB_PIDS="" \
+  run_case "$P"
+assert_eq "down exit code" 3 "$RUN_RC"
+[[ "$RUN_OUT" == *"down"* ]] && ok "down verdict" || no "down verdict missing"
+
+# ---------------------------------------------------------------------------
+# Case 4a: degraded — managed daemon present but linger OFF.
+reset_stubs
+P="$WORK/proc4a"; mk_proc "$P" 1001:managed
+STUB_UNIT_ACTIVE=active STUB_UNIT_MAINPID=1001 STUB_HB_ACTIVE=active STUB_LINGER=no STUB_PIDS=1001 \
+  run_case "$P"
+assert_eq "degraded (linger off) exit code" 4 "$RUN_RC"
+[[ "$RUN_OUT" == *"degraded"* && "$RUN_OUT" == *"linger"* ]] && ok "degraded linger reason" || no "degraded linger reason missing"
+
+# ---------------------------------------------------------------------------
+# Case 4b: degraded — managed daemon present, linger on, but heartbeat INACTIVE.
+reset_stubs
+P="$WORK/proc4b"; mk_proc "$P" 1001:managed
+STUB_UNIT_ACTIVE=active STUB_UNIT_MAINPID=1001 STUB_HB_ACTIVE=inactive STUB_LINGER=yes STUB_PIDS=1001 \
+  run_case "$P"
+assert_eq "degraded (heartbeat inactive) exit code" 4 "$RUN_RC"
+[[ "$RUN_OUT" == *"degraded"* && "$RUN_OUT" == *"heartbeat"* ]] && ok "degraded heartbeat reason" || no "degraded heartbeat reason missing"
+
+# ---------------------------------------------------------------------------
+# Case 5: managed wins over a co-present transient daemon.
+reset_stubs
+P="$WORK/proc5"; mk_proc "$P" 1001:managed 3003:transient
+STUB_UNIT_ACTIVE=active STUB_UNIT_MAINPID=1001 STUB_HB_ACTIVE=active STUB_LINGER=yes STUB_PIDS="1001 3003" \
+  run_case "$P"
+assert_eq "managed-wins exit code" 0 "$RUN_RC"
+[[ "$RUN_OUT" == *"managed-live"* ]] && ok "managed wins over transient" || no "managed did not win over transient"
+
+# ---------------------------------------------------------------------------
+# Case 6: loginctl failure (linger unqueryable) with a managed daemon -> degraded.
+reset_stubs
+P="$WORK/proc6"; mk_proc "$P" 1001:managed
+STUB_UNIT_ACTIVE=active STUB_UNIT_MAINPID=1001 STUB_HB_ACTIVE=active STUB_LINGER_FAIL=1 STUB_PIDS=1001 \
+  run_case "$P"
+assert_eq "linger-unqueryable exit code" 4 "$RUN_RC"
+[[ "$RUN_OUT" == *"degraded"* ]] && ok "linger-unqueryable -> degraded" || no "linger-unqueryable did not degrade"
+
+# ---------------------------------------------------------------------------
+# Case 7: --json shape — verdict, exit_code, census classification, presence flags.
+reset_stubs
+P="$WORK/proc7"; mk_proc "$P" 1001:managed 3003:transient
+STUB_UNIT_ACTIVE=active STUB_UNIT_MAINPID=1001 STUB_UNIT_NRESTARTS=2 \
+  STUB_UNIT_AET="Tue 2026-07-08 09:00:00 UTC" \
+  STUB_HB_ACTIVE=active STUB_HB_SUBSTATE=waiting STUB_LINGER=yes STUB_PIDS="1001 3003" \
+  run_case "$P" --json
+assert_eq "json exit code" 0 "$RUN_RC"
+# Valid JSON?
+if jq -e . >/dev/null 2>&1 <<<"$RUN_OUT"; then ok "json parses"; else no "json does not parse"; fi
+assert_eq "json verdict"          "managed-live" "$(jq -r '.verdict' <<<"$RUN_OUT")"
+assert_eq "json exit_code field"  "0"            "$(jq -r '.exit_code' <<<"$RUN_OUT")"
+assert_eq "json unit active"      "active"       "$(jq -r '.unit.active_state' <<<"$RUN_OUT")"
+assert_eq "json unit nrestarts"   "2"            "$(jq -r '.unit.n_restarts' <<<"$RUN_OUT")"
+assert_eq "json unit active_enter" "Tue 2026-07-08 09:00:00 UTC" "$(jq -r '.unit.active_enter_timestamp' <<<"$RUN_OUT")"
+assert_eq "json linger"           "yes"          "$(jq -r '.linger' <<<"$RUN_OUT")"
+assert_eq "json managed_present"  "true"         "$(jq -r '.managed_present' <<<"$RUN_OUT")"
+assert_eq "json transient_present" "true"        "$(jq -r '.transient_present' <<<"$RUN_OUT")"
+assert_eq "json census length"    "2"            "$(jq -r '.census | length' <<<"$RUN_OUT")"
+assert_eq "json managed pid class" "managed"     "$(jq -r '.census[] | select(.pid==1001) | .class' <<<"$RUN_OUT")"
+assert_eq "json transient pid class" "transient" "$(jq -r '.census[] | select(.pid==3003) | .class' <<<"$RUN_OUT")"
+
+# ---------------------------------------------------------------------------
+# Case 8: --json exit_code tracks a non-zero verdict (down).
+reset_stubs
+P="$WORK/proc8"; mkdir -p "$P"
+STUB_UNIT_ACTIVE=inactive STUB_UNIT_MAINPID=0 STUB_HB_ACTIVE=inactive STUB_LINGER=no STUB_PIDS="" \
+  run_case "$P" --json
+assert_eq "json down exit code" 3 "$RUN_RC"
+assert_eq "json down verdict" "down" "$(jq -r '.verdict' <<<"$RUN_OUT")"
+assert_eq "json down exit_code field" "3" "$(jq -r '.exit_code' <<<"$RUN_OUT")"
+assert_eq "json down census empty" "0" "$(jq -r '.census | length' <<<"$RUN_OUT")"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+echo "================================"
+[[ "$FAIL" -eq 0 ]]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -189,6 +189,8 @@ jobs:
         run: .claude/hooks/test-approve-workflow-commands.sh
       - name: Run dispatch script tests
         run: .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+      - name: Run dispatch-daemon-liveness sensor tests
+        run: .claude/skills/dispatch-propagate/scripts/test-dispatch-daemon-liveness.sh
       - name: Run budget-config-load tests
         run: .claude/skills/budget/scripts/test-budget-config-load.sh
       - name: Run write-phase-log tests


### PR DESCRIPTION
Graph node: `tactic-dispatch-daemon-liveness-sensor` (serves `strategy-autonomous-execution`).

## What

Adds `dispatch-daemon-liveness`, a host-side report-only sensor for the round-1 instrument the strategy's `tooling_goals` names. It reports whether the managed `dispatch-claude-daemon.service` is up and ticking unattended, and distinguishes the managed lingering unit from a transient interactive daemon — the 2026-07-08 masking case where an interactive `claude agents` session's transient daemon masked a dead managed unit for roughly a day, so backlog drain alone could not prove *unattended* execution.

## How

- **Managed unit facts** — `systemctl --user show dispatch-claude-daemon.service` for `ActiveState/SubState/MainPID/ActiveEnterTimestamp/NRestarts` (surfaced verbatim for continuity).
- **Linger** — `loginctl show-user --property=Linger`.
- **Heartbeat** — `dispatch-heartbeat.timer` ActiveState/SubState/LastTriggerUSec.
- **Daemon census** — every live `claude daemon` process classified by cgroup: `/proc/<pid>/cgroup` containing the unit name = managed; anything else = transient.
- **Verdict / exit code** — `managed-live` (0), `transient-substituting` (2), `down` (3), `degraded` (4, managed daemon up but linger off or heartbeat inactive). `--json` emits a machine reading.

The census is the source of truth for liveness, so a unit systemctl reports active whose process is dead still reads `down`. Reads systemd/proc facts rather than `claude agents --json` because the sandbox network namespace blocks the daemon socket (a sandboxed query returns `[]` indistinguishable from none); run unsandboxed on the host.

Report-only: no remediation, no dashboard integration (graph-fed panels are `tactic-attention-surface-velocity-pace`'s surface).

## Tests

`test-dispatch-daemon-liveness.sh` dependency-injects the systemctl/loginctl/pgrep invocations and `/proc` cgroup reads through `DISPATCH_LIVENESS_*` command overrides — no systemd, no real daemon, no network. Covers all four verdicts, their exit codes, census classification (managed wins over a co-present transient), the linger-unqueryable path, and the `--json` shape (31 assertions). Wired into `unit-tests.yml`.

## Verify

```
bash .claude/skills/dispatch-propagate/scripts/test-dispatch-daemon-liveness.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)