### PR TITLE
tactic-fork-doc-census: fork-doc census instrument

### DIFF
--- a/packages/intentionsutil/scripts/audit-fork-docs.ts
+++ b/packages/intentionsutil/scripts/audit-fork-docs.ts
@@ -1,0 +1,246 @@
+// Audit the public artifacts to produce the machine-verifiable half of the
+// `strategy-open-source-as-gift` signal reading. It enumerates the public
+// artifacts — the whole-repo fork surface (`repo`, documented by the root
+// `README.md`) plus one artifact per Firebase hosting target read from
+// `.firebaserc` — machine-checks the presence half of the threshold (fork
+// documentation exists per artifact), and prints the sufficiency attestation
+// checklist only the owner can complete.
+//
+// Report-only: it does NOT write `reading`/`gap` onto any node. The owner review
+// at office-hours consumes this report, completes the attestation checklist, and
+// stamps `reading`/`gap` on `intentions/strategy-open-source-as-gift.md`.
+//
+// Deliberately NOT registered in `read-sensors.ts`'s default registry: although
+// this census is local-first/no-network, that registry auto-writes `reading`/`gap`,
+// and this sensor's sufficiency half is owner judgment — report-only mirrors the
+// `audit-publishing.ts` precedent. Run from the repo root:
+//   npx tsx packages/intentionsutil/scripts/audit-fork-docs.ts
+//
+// Exit 0 when every artifact's README is present and non-empty; exit 1 when any
+// is missing (the missing list is the gap evidence). An unreadable or unparseable
+// `.firebaserc`, zero or multiple project entries under `targets`, an empty
+// hosting map, or a hosting target whose same-named source directory does not
+// exist is a FATAL error (clear errors over fallbacks) — a broken enumeration
+// means the instrument cannot produce an honest reading.
+
+import { readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+/** Narrow an unknown thrown value to a message string without a type cast. */
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// --- IO contract -----------------------------------------------------------
+// A tiny injected fs facade so the pure core never touches the real tree. All
+// paths are repo-root-relative. `readText` returns `null` for a missing file.
+export interface FsFacade {
+  readText(path: string): string | null;
+  isDir(path: string): boolean;
+}
+
+// --- Result shapes ---------------------------------------------------------
+export interface Artifact {
+  name: string;
+  readme: string;
+}
+export interface ArtifactResult {
+  name: string;
+  readme: string;
+  /** True when the README file exists and is non-empty. */
+  present: boolean;
+}
+export interface AuditSummary {
+  artifacts: ArtifactResult[];
+  /** True when every artifact's README is present. */
+  allPresent: boolean;
+  /** Process exit code: 0 when allPresent, else 1. */
+  exitCode: number;
+}
+
+// --- Enumeration -----------------------------------------------------------
+
+/**
+ * Enumerate the public artifacts. Always includes the `repo` artifact
+ * (whole-repo fork surface, root `README.md`); then parses `.firebaserc` and
+ * appends one artifact per hosting target. Throws a fatal error when the
+ * enumeration cannot be produced honestly: unreadable or unparseable
+ * `.firebaserc`, zero or multiple project entries under `targets`, an empty
+ * hosting map, or a hosting target whose same-named source directory is absent.
+ */
+export function enumerateArtifacts(fs: FsFacade): Artifact[] {
+  const artifacts: Artifact[] = [{ name: "repo", readme: "README.md" }];
+
+  const raw = fs.readText(".firebaserc");
+  if (raw === null) {
+    throw new Error(
+      "audit-fork-docs: cannot read .firebaserc — enumeration requires it",
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `audit-fork-docs: cannot parse .firebaserc as JSON: ${errMessage(err)}`,
+    );
+  }
+
+  const targets =
+    parsed && typeof parsed === "object"
+      ? (parsed as Record<string, unknown>).targets
+      : undefined;
+  if (!targets || typeof targets !== "object") {
+    throw new Error(
+      "audit-fork-docs: .firebaserc has no `targets` object — cannot enumerate hosting targets",
+    );
+  }
+
+  // Fork-friendly: a fork changes the Firebase project id, so do not hardcode
+  // `commons-systems`. Require exactly one project entry under `targets`.
+  const projectKeys = Object.keys(targets as Record<string, unknown>);
+  if (projectKeys.length !== 1) {
+    throw new Error(
+      `audit-fork-docs: expected exactly one project under .firebaserc \`targets\`, found ${projectKeys.length} (${projectKeys.join(", ") || "none"})`,
+    );
+  }
+
+  const project = (targets as Record<string, unknown>)[projectKeys[0]];
+  const hosting =
+    project && typeof project === "object"
+      ? (project as Record<string, unknown>).hosting
+      : undefined;
+  if (!hosting || typeof hosting !== "object") {
+    throw new Error(
+      `audit-fork-docs: .firebaserc project \`${projectKeys[0]}\` has no \`hosting\` map`,
+    );
+  }
+
+  const targetNames = Object.keys(hosting as Record<string, unknown>);
+  if (targetNames.length === 0) {
+    throw new Error(
+      `audit-fork-docs: .firebaserc project \`${projectKeys[0]}\` has an empty \`hosting\` map — nothing to enumerate`,
+    );
+  }
+
+  for (const name of targetNames) {
+    if (!fs.isDir(name)) {
+      throw new Error(
+        `audit-fork-docs: hosting target \`${name}\` has no same-named source directory — cannot enumerate its fork docs`,
+      );
+    }
+    artifacts.push({ name, readme: `${name}/README.md` });
+  }
+
+  return artifacts;
+}
+
+// --- Core audit ------------------------------------------------------------
+
+/**
+ * Enumerate the public artifacts and machine-check the presence half of the
+ * threshold: each artifact's README exists and is non-empty. Pure except for the
+ * injected fs facade. A missing README is a per-artifact finding (recorded, does
+ * not abort); a broken enumeration throws (see `enumerateArtifacts`).
+ */
+export function auditForkDocs(fs: FsFacade): AuditSummary {
+  const artifacts = enumerateArtifacts(fs);
+  const results: ArtifactResult[] = [];
+  let allPresent = true;
+
+  for (const artifact of artifacts) {
+    const content = fs.readText(artifact.readme);
+    const present = content !== null && content.trim().length > 0;
+    if (!present) allPresent = false;
+    results.push({ name: artifact.name, readme: artifact.readme, present });
+  }
+
+  return { artifacts: results, allPresent, exitCode: allPresent ? 0 : 1 };
+}
+
+// --- Report ----------------------------------------------------------------
+
+/** Escape the characters that would break a markdown table cell. */
+function cell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\n/g, " ").trim();
+}
+
+/** Render the audit summary as a markdown report (stdout). */
+export function formatReport(summary: AuditSummary): string {
+  const lines: string[] = [];
+  lines.push("# Fork-doc census — strategy-open-source-as-gift");
+  lines.push("");
+  lines.push("Public artifacts and whether each carries fork documentation.");
+  lines.push("");
+  lines.push("| Artifact | README | present |");
+  lines.push("| --- | --- | --- |");
+  for (const a of summary.artifacts) {
+    lines.push(`| ${cell(a.name)} | ${cell(a.readme)} | ${a.present ? "yes" : "no"} |`);
+  }
+  lines.push("");
+
+  lines.push("## Attestation checklist (owner)");
+  lines.push("");
+  lines.push(
+    "The machine check above confirms only that documentation *exists*. Whether it",
+  );
+  lines.push(
+    "is *sufficient for a shallow fork to stand alone* is owner judgment — complete",
+  );
+  lines.push("one line per artifact:");
+  lines.push("");
+  for (const a of summary.artifacts) {
+    lines.push(
+      `- [ ] ${a.name}: documentation sufficient for a shallow fork to stand alone? (scope incl. @commons-systems/* deps / architecture & data flow / build & run from a fresh clone / deployment & required services / dependency inlining-or-replacement guidance / CC-BY-SA share-alike terms)`,
+    );
+  }
+  lines.push("");
+  lines.push(
+    "Result lands via the owner: stamp `reading`/`gap` on `intentions/strategy-open-source-as-gift.md` (write-node.ts + graph-commit).",
+  );
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+// --- Main ------------------------------------------------------------------
+// The script lives at `packages/intentionsutil/scripts/audit-fork-docs.ts`, so
+// the repo root is three directories up. Resolve from this file's own location,
+// never from cwd.
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(dirname(dirname(scriptDir)));
+
+/** fs facade wired to `node:fs`, resolving repo-root-relative paths. */
+const nodeFs: FsFacade = {
+  readText(path) {
+    try {
+      return readFileSync(join(repoRoot, path), "utf8");
+    } catch {
+      return null;
+    }
+  },
+  isDir(path) {
+    try {
+      return statSync(join(repoRoot, path)).isDirectory();
+    } catch {
+      return false;
+    }
+  },
+};
+
+export function main(): number {
+  const summary = auditForkDocs(nodeFs);
+  process.stdout.write(formatReport(summary));
+  return summary.exitCode;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    process.exit(main());
+  } catch (err) {
+    process.stderr.write(`${errMessage(err)}\n`);
+    process.exit(1);
+  }
+}

--- a/packages/intentionsutil/scripts/audit-fork-docs.ts
+++ b/packages/intentionsutil/scripts/audit-fork-docs.ts
@@ -89,7 +89,7 @@ export function enumerateArtifacts(fs: FsFacade): Artifact[] {
     parsed = JSON.parse(raw);
   } catch (err) {
     throw new Error(
-      `audit-fork-docs: .firebaserc is not valid JSON: ${errMessage(err)}`,
+      `audit-fork-docs: could not parse .firebaserc — invalid JSON: ${errMessage(err)}`,
     );
   }
 

--- a/packages/intentionsutil/scripts/audit-fork-docs.ts
+++ b/packages/intentionsutil/scripts/audit-fork-docs.ts
@@ -32,6 +32,11 @@ function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+/** Type guard: a non-null, non-array object indexable by string. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 // --- IO contract -----------------------------------------------------------
 // A tiny injected fs facade so the pure core never touches the real tree. All
 // paths are repo-root-relative. `readText` returns `null` for a missing file.
@@ -84,15 +89,12 @@ export function enumerateArtifacts(fs: FsFacade): Artifact[] {
     parsed = JSON.parse(raw);
   } catch (err) {
     throw new Error(
-      `audit-fork-docs: cannot parse .firebaserc as JSON: ${errMessage(err)}`,
+      `audit-fork-docs: .firebaserc is not valid JSON: ${errMessage(err)}`,
     );
   }
 
-  const targets =
-    parsed && typeof parsed === "object"
-      ? (parsed as Record<string, unknown>).targets
-      : undefined;
-  if (!targets || typeof targets !== "object") {
+  const targets = isRecord(parsed) ? parsed.targets : undefined;
+  if (!isRecord(targets)) {
     throw new Error(
       "audit-fork-docs: .firebaserc has no `targets` object — cannot enumerate hosting targets",
     );
@@ -100,25 +102,22 @@ export function enumerateArtifacts(fs: FsFacade): Artifact[] {
 
   // Fork-friendly: a fork changes the Firebase project id, so do not hardcode
   // `commons-systems`. Require exactly one project entry under `targets`.
-  const projectKeys = Object.keys(targets as Record<string, unknown>);
+  const projectKeys = Object.keys(targets);
   if (projectKeys.length !== 1) {
     throw new Error(
       `audit-fork-docs: expected exactly one project under .firebaserc \`targets\`, found ${projectKeys.length} (${projectKeys.join(", ") || "none"})`,
     );
   }
 
-  const project = (targets as Record<string, unknown>)[projectKeys[0]];
-  const hosting =
-    project && typeof project === "object"
-      ? (project as Record<string, unknown>).hosting
-      : undefined;
-  if (!hosting || typeof hosting !== "object") {
+  const project = targets[projectKeys[0]];
+  const hosting = isRecord(project) ? project.hosting : undefined;
+  if (!isRecord(hosting)) {
     throw new Error(
       `audit-fork-docs: .firebaserc project \`${projectKeys[0]}\` has no \`hosting\` map`,
     );
   }
 
-  const targetNames = Object.keys(hosting as Record<string, unknown>);
+  const targetNames = Object.keys(hosting);
   if (targetNames.length === 0) {
     throw new Error(
       `audit-fork-docs: .firebaserc project \`${projectKeys[0]}\` has an empty \`hosting\` map — nothing to enumerate`,

--- a/packages/intentionsutil/test/audit-fork-docs.test.ts
+++ b/packages/intentionsutil/test/audit-fork-docs.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import {
+  auditForkDocs,
+  enumerateArtifacts,
+  formatReport,
+  type FsFacade,
+} from "../scripts/audit-fork-docs.js";
+
+/** A `.firebaserc` fixture with the given hosting-target names under one project. */
+function firebaserc(project: string, targets: string[]): string {
+  const hosting = Object.fromEntries(targets.map((t) => [t, [`site-${t}`]]));
+  return JSON.stringify({
+    projects: { default: project },
+    targets: { [project]: { hosting } },
+  });
+}
+
+/**
+ * Build an fs facade from a file map (path→content) and a set of directory
+ * paths. Any path absent from `files` reads as `null`.
+ */
+function fsFixture(files: Record<string, string>, dirs: string[] = []): FsFacade {
+  const dirSet = new Set(dirs);
+  return {
+    readText(path) {
+      return path in files ? files[path] : null;
+    },
+    isDir(path) {
+      return dirSet.has(path);
+    },
+  };
+}
+
+describe("enumerateArtifacts", () => {
+  it("always includes the repo artifact plus one per hosting target", () => {
+    const fs = fsFixture(
+      { ".firebaserc": firebaserc("commons-systems", ["landing", "budget"]) },
+      ["landing", "budget"],
+    );
+    expect(enumerateArtifacts(fs)).toEqual([
+      { name: "repo", readme: "README.md" },
+      { name: "landing", readme: "landing/README.md" },
+      { name: "budget", readme: "budget/README.md" },
+    ]);
+  });
+
+  it("derives target names from .firebaserc so a new app enters automatically", () => {
+    const fs = fsFixture(
+      { ".firebaserc": firebaserc("my-fork", ["landing", "newapp"]) },
+      ["landing", "newapp"],
+    );
+    const names = enumerateArtifacts(fs).map((a) => a.name);
+    expect(names).toEqual(["repo", "landing", "newapp"]);
+  });
+
+  it("is fork-friendly: does not hardcode the project id", () => {
+    const fs = fsFixture(
+      { ".firebaserc": firebaserc("someone-elses-fork", ["landing"]) },
+      ["landing"],
+    );
+    expect(enumerateArtifacts(fs).map((a) => a.name)).toEqual(["repo", "landing"]);
+  });
+
+  it("throws when .firebaserc is unreadable", () => {
+    const fs = fsFixture({}, []);
+    expect(() => enumerateArtifacts(fs)).toThrow(".firebaserc");
+  });
+
+  it("throws when .firebaserc is unparseable", () => {
+    const fs = fsFixture({ ".firebaserc": "{ not json" }, []);
+    expect(() => enumerateArtifacts(fs)).toThrow("parse");
+  });
+
+  it("throws when there is more than one project under targets", () => {
+    const fs = fsFixture(
+      {
+        ".firebaserc": JSON.stringify({
+          targets: { one: { hosting: { a: ["x"] } }, two: { hosting: { b: ["y"] } } },
+        }),
+      },
+      ["a", "b"],
+    );
+    expect(() => enumerateArtifacts(fs)).toThrow("exactly one project");
+  });
+
+  it("throws when there are zero projects under targets", () => {
+    const fs = fsFixture({ ".firebaserc": JSON.stringify({ targets: {} }) }, []);
+    expect(() => enumerateArtifacts(fs)).toThrow("exactly one project");
+  });
+
+  it("throws on an empty hosting map", () => {
+    const fs = fsFixture(
+      { ".firebaserc": JSON.stringify({ targets: { p: { hosting: {} } } }) },
+      [],
+    );
+    expect(() => enumerateArtifacts(fs)).toThrow("empty");
+  });
+
+  it("throws when a hosting target has no same-named source directory", () => {
+    const fs = fsFixture(
+      { ".firebaserc": firebaserc("commons-systems", ["landing", "ghost"]) },
+      ["landing"], // "ghost" dir absent
+    );
+    expect(() => enumerateArtifacts(fs)).toThrow("ghost");
+  });
+});
+
+describe("auditForkDocs", () => {
+  it("classifies each artifact present/missing and reports exit 0 when all present", () => {
+    const fs = fsFixture(
+      {
+        ".firebaserc": firebaserc("commons-systems", ["landing"]),
+        "README.md": "# Repo\nfork docs here",
+        "landing/README.md": "# Landing\nfork docs here",
+      },
+      ["landing"],
+    );
+    const summary = auditForkDocs(fs);
+    expect(summary.allPresent).toBe(true);
+    expect(summary.exitCode).toBe(0);
+    expect(summary.artifacts).toEqual([
+      { name: "repo", readme: "README.md", present: true },
+      { name: "landing", readme: "landing/README.md", present: true },
+    ]);
+  });
+
+  it("treats a missing README as absent and reports exit 1", () => {
+    const fs = fsFixture(
+      {
+        ".firebaserc": firebaserc("commons-systems", ["landing"]),
+        "README.md": "# Repo\nfork docs",
+        // landing/README.md absent
+      },
+      ["landing"],
+    );
+    const summary = auditForkDocs(fs);
+    expect(summary.allPresent).toBe(false);
+    expect(summary.exitCode).toBe(1);
+    expect(summary.artifacts.map((a) => a.present)).toEqual([true, false]);
+  });
+
+  it("treats an empty (whitespace-only) README as absent", () => {
+    const fs = fsFixture(
+      {
+        ".firebaserc": firebaserc("commons-systems", ["landing"]),
+        "README.md": "# Repo",
+        "landing/README.md": "   \n  \n",
+      },
+      ["landing"],
+    );
+    const summary = auditForkDocs(fs);
+    expect(summary.allPresent).toBe(false);
+    expect(summary.exitCode).toBe(1);
+    expect(summary.artifacts[1]).toMatchObject({ name: "landing", present: false });
+  });
+});
+
+describe("formatReport", () => {
+  it("renders the artifact table and one attestation line per artifact", () => {
+    const report = formatReport({
+      allPresent: false,
+      exitCode: 1,
+      artifacts: [
+        { name: "repo", readme: "README.md", present: true },
+        { name: "landing", readme: "landing/README.md", present: false },
+      ],
+    });
+    expect(report).toContain("| repo | README.md | yes |");
+    expect(report).toContain("| landing | landing/README.md | no |");
+    expect(report).toContain(
+      "- [ ] repo: documentation sufficient for a shallow fork to stand alone?",
+    );
+    expect(report).toContain(
+      "- [ ] landing: documentation sufficient for a shallow fork to stand alone?",
+    );
+    expect(report).toContain("CC-BY-SA share-alike terms");
+    expect(report).toContain("intentions/strategy-open-source-as-gift.md");
+  });
+});


### PR DESCRIPTION
## Context

`strategy-open-source-as-gift` has `reading: null`; its signal threshold is
"each public artifact carries documentation sufficient for a shallow fork to
stand alone". Nothing enumerated the public artifacts or their doc state, so
the office-hours review had no evidence.

This report-only instrument makes the review runnable. It enumerates the
public artifacts — the whole-repo `repo` surface (root `README.md`) plus one
artifact per Firebase hosting target read from `.firebaserc` — machine-checks
the presence half of the threshold (per-artifact README exists and is
non-empty), and prints the sufficiency attestation checklist only the owner
can complete.

## Unit 1 — `audit-fork-docs.ts` script + tests

- `packages/intentionsutil/scripts/audit-fork-docs.ts`: pure core
  (`enumerateArtifacts`, `auditForkDocs`) over an injected fs facade, `main`
  wires it to `node:fs` with script-relative repo-root resolution and the
  `import.meta.url` main-guard.
- Enumeration derives target names from `.firebaserc` (fork-friendly, no
  hardcoded project id); fatal on unreadable/unparseable `.firebaserc`, zero
  or multiple project entries, empty hosting map, or a target without a
  same-named source directory.
- Exit 0 when every README present, 1 when any missing (gap evidence),
  surfaced via the returned summary object.
- `packages/intentionsutil/test/audit-fork-docs.test.ts`: injected-fs
  fixtures covering enumeration, present/missing/empty classification, the
  fatal cases, and exit semantics.

Report-only, mirroring `audit-publishing.ts`: it does not write `reading`/`gap`
and is not registered in `read-sensors.ts`. The owner review at office-hours
consumes the report and stamps `reading`/`gap` on
`intentions/strategy-open-source-as-gift.md`.

Manual run today: `repo` present, six app READMEs missing, exit 1 — the
expected gap evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)