### PR TITLE
Add participation-log instrument (parser + review report)

### DIFF
--- a/packages/intentionsutil/scripts/participation-review.ts
+++ b/packages/intentionsutil/scripts/participation-review.ts
@@ -1,0 +1,152 @@
+// Participation-log review — the human-readable report an office-hours owner
+// reads to attest `strategy-join-existing-practice`'s participation evidence
+// and to check whether any logged challenge has reached
+// `strategy-external-calibration`.
+//
+// Run from anywhere (the store dir is resolved relative to this file, not cwd):
+//   npx tsx packages/intentionsutil/scripts/participation-review.ts
+//
+// Report-only: this script never writes `reading`/`gap` onto any node. It only
+// reads the live `intentions/` store and prints evidence.
+//
+// Log-append recipe (for the author, after each participation event):
+//   1. Dump the strategy node:
+//        npx tsx packages/intentionsutil/scripts/dump-node.ts strategy-join-existing-practice
+//   2. Append a `{date, venue, activity, challenge}` entry to
+//      `attributes.participation_log` in the resulting JSON (challenge is a
+//      string or null).
+//   3. Rewrite the node from the edited JSON:
+//        npx tsx packages/intentionsutil/scripts/write-node.ts <path-to-edited-json>
+//   4. Land it: `packages/intentionsutil/scripts/graph-commit`.
+//
+// Owner attestation recipe (after reviewing this report):
+//   Stamp `reading`/`gap` on `intentions/strategy-join-existing-practice.md`
+//   via the same dump-node.ts / write-node.ts / graph-commit sequence above,
+//   editing `reading`/`gap` (and, on round completion, `rounds`) instead of
+//   `attributes.participation_log`.
+
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { readNode } from "../src/store.js";
+import {
+  parseParticipationLog,
+  participationSummary,
+  challengeState,
+} from "../src/participation.js";
+
+/** Narrow an unknown thrown value to a message string without a type cast. */
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// --- Paths -----------------------------------------------------------------
+// The script lives at `packages/intentionsutil/scripts/participation-review.ts`,
+// so the repo root is three directories up. Resolve from this file's own
+// location, never from cwd.
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(dirname(dirname(scriptDir)));
+const intentionsDir = join(repoRoot, "intentions");
+
+const STRATEGY_ID = "strategy-join-existing-practice";
+const EXTERNAL_ID = "strategy-external-calibration";
+
+export function main(): number {
+  const strategyNode = readNode(intentionsDir, STRATEGY_ID);
+  const externalNode = readNode(intentionsDir, EXTERNAL_ID);
+
+  const { entries, malformed } = parseParticipationLog(strategyNode);
+
+  const lines: string[] = [];
+  lines.push(`# Participation review — ${STRATEGY_ID}`);
+  lines.push("");
+
+  if (malformed.length > 0) {
+    lines.push("## MALFORMED");
+    lines.push("");
+    lines.push(
+      `attributes.participation_log on ${STRATEGY_ID} has ${malformed.length} defect(s) — ` +
+        "the log must be fixed before an honest report can be produced:",
+    );
+    lines.push("");
+    for (const defect of malformed) {
+      lines.push(`- ${defect}`);
+    }
+    lines.push("");
+    process.stdout.write(lines.join("\n") + "\n");
+    return 1;
+  }
+
+  lines.push("## Entries");
+  lines.push("");
+  if (entries.length === 0) {
+    lines.push("(none — no participation recorded yet; the reading is honestly zero)");
+  } else {
+    lines.push("| Date | Venue | Activity | Challenge |");
+    lines.push("| --- | --- | --- | --- |");
+    for (const e of entries) {
+      lines.push(`| ${e.date} | ${e.venue} | ${e.activity} | ${e.challenge ?? "—"} |`);
+    }
+  }
+  lines.push("");
+
+  const today = new Date().toISOString().slice(0, 10);
+  const summary = participationSummary(entries, today);
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(`- count: ${summary.count}`);
+  lines.push(`- firstDate: ${summary.firstDate ?? "—"}`);
+  lines.push(`- lastDate: ${summary.lastDate ?? "—"}`);
+  lines.push(`- distinctVenues: ${summary.distinctVenues}`);
+  lines.push(`- last30Days: ${summary.last30Days}`);
+  lines.push(`- last90Days: ${summary.last90Days}`);
+  lines.push("");
+
+  const challenges = challengeState(entries, externalNode);
+  lines.push("## Challenges");
+  lines.push("");
+  if (challenges.logged.length === 0) {
+    lines.push("(none logged)");
+  } else {
+    lines.push("Logged entries with a challenge:");
+    lines.push("");
+    for (const e of challenges.logged) {
+      lines.push(`- ${e.date} (${e.venue}, ${e.activity}): ${e.challenge}`);
+    }
+    lines.push("");
+    lines.push(
+      `ADVISORY — confirm each logged challenge above is recorded on ${EXTERNAL_ID} as a ` +
+        `dated clarification. That is what "reaches" ${EXTERNAL_ID} means, per ` +
+        `${STRATEGY_ID}'s 2026-07-11 clarification.`,
+    );
+  }
+  lines.push("");
+  lines.push(`### ${EXTERNAL_ID} — current reading/gap (verbatim)`);
+  lines.push("");
+  lines.push(`- reading: ${challenges.externalReading ?? "—"}`);
+  lines.push(`- gap: ${challenges.externalGap ?? "—"}`);
+  lines.push("");
+
+  lines.push("## Owner attestation");
+  lines.push("");
+  lines.push(
+    `Stamp \`reading\`/\`gap\` on \`intentions/${STRATEGY_ID}.md\` via dump-node.ts / ` +
+      "write-node.ts / graph-commit, per the recipe in this script's header comment.",
+  );
+  lines.push(
+    `Round completion also stamps \`rounds\` — see \`tactic-join-indieweb\`'s parked ` +
+      `recommendation for that node's role.`,
+  );
+  lines.push("");
+
+  process.stdout.write(lines.join("\n") + "\n");
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    process.exit(main());
+  } catch (err) {
+    process.stderr.write(`${errMessage(err)}\n`);
+    process.exit(1);
+  }
+}

--- a/packages/intentionsutil/scripts/participation-review.ts
+++ b/packages/intentionsutil/scripts/participation-review.ts
@@ -129,12 +129,37 @@ export function main(): number {
   lines.push("## Owner attestation");
   lines.push("");
   lines.push(
-    `Stamp \`reading\`/\`gap\` on \`intentions/${STRATEGY_ID}.md\` via dump-node.ts / ` +
-      "write-node.ts / graph-commit, per the recipe in this script's header comment.",
+    `Stamp \`reading\`/\`gap\` on **${STRATEGY_ID}** — this tactic's signal-target ` +
+      `node. Do NOT stamp ${EXTERNAL_ID}: its \`reading\`/\`gap\` is quoted verbatim in ` +
+      `\`## Challenges\` above only for context, and is not the node this report attests.`,
+  );
+  lines.push("");
+  lines.push(
+    `Stamp it on \`intentions/${STRATEGY_ID}.md\` via this dump-node.ts / write-node.ts / ` +
+      `graph-commit sequence (identical to this script's header recipe, but editing ` +
+      `\`reading\`/\`gap\` — and, on round completion, \`rounds\` — instead of ` +
+      `\`attributes.participation_log\`):`,
+  );
+  lines.push("");
+  lines.push(
+    `  1. Dump the strategy node:\n` +
+      `       npx tsx packages/intentionsutil/scripts/dump-node.ts ${STRATEGY_ID}`,
   );
   lines.push(
-    `Round completion also stamps \`rounds\` — see \`tactic-join-indieweb\`'s parked ` +
-      `recommendation for that node's role.`,
+    `  2. In the resulting JSON, set \`reading\`/\`gap\` (and, on round completion, ` +
+      `\`rounds\`) on ${STRATEGY_ID} — NOT on ${EXTERNAL_ID}.`,
+  );
+  lines.push(
+    `  3. Rewrite the node from the edited JSON:\n` +
+      `       npx tsx packages/intentionsutil/scripts/write-node.ts <path-to-edited-json>`,
+  );
+  lines.push(
+    `  4. Land it: \`packages/intentionsutil/scripts/graph-commit\`.`,
+  );
+  lines.push("");
+  lines.push(
+    `Round completion's \`rounds\` stamp on ${STRATEGY_ID} — see \`tactic-join-indieweb\`'s ` +
+      `parked recommendation for that node's role.`,
   );
   lines.push("");
 

--- a/packages/intentionsutil/src/participation.ts
+++ b/packages/intentionsutil/src/participation.ts
@@ -111,7 +111,7 @@ export interface ParticipationSummary {
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-/** Days between two YYYY-MM-DD dates (`to` minus `from`), treating each as UTC midnight. */
+/** Days between two YYYY-MM-DD dates (`to` minus `from`); each is read at UTC midnight. */
 function daysBetween(from: string, to: string): number {
   return Math.round((Date.parse(`${to}T00:00:00Z`) - Date.parse(`${from}T00:00:00Z`)) / MS_PER_DAY);
 }
@@ -138,8 +138,8 @@ export function participationSummary(
 
   // entries is expected sorted ascending by parseParticipationLog, but derive
   // first/last defensively rather than assume caller-supplied order.
-  let firstDate = entries[0]!.date;
-  let lastDate = entries[0]!.date;
+  let firstDate = entries[0].date;
+  let lastDate = entries[0].date;
   const venues = new Set<string>();
   let last30Days = 0;
   let last90Days = 0;

--- a/packages/intentionsutil/src/participation.ts
+++ b/packages/intentionsutil/src/participation.ts
@@ -1,0 +1,190 @@
+import type { IntentionNode } from "./schema.js";
+
+// --- Types -------------------------------------------------------------------
+
+/** One author-logged participation event on `attributes.participation_log`. */
+export interface ParticipationEntry {
+  date: string;
+  venue: string;
+  activity: string;
+  challenge: string | null;
+}
+
+// --- Helpers -------------------------------------------------------------------
+
+function isPlainObjectLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value !== "";
+}
+
+/**
+ * Validate one raw log entry, returning the parsed `ParticipationEntry` or a
+ * defect message describing why it's malformed. Defensive parsing at the
+ * boundary — `attributes` shape is data (author-maintained YAML), not a code
+ * contract, so a malformed entry is described and skipped rather than thrown.
+ */
+function parseEntry(raw: unknown, index: number): ParticipationEntry | string {
+  if (!isPlainObjectLike(raw)) {
+    return `entry ${index}: expected an object, got ${typeof raw}`;
+  }
+  if (!isNonEmptyString(raw.date) || !DATE_RE.test(raw.date)) {
+    return `entry ${index}: expected a YYYY-MM-DD date string for "date", got ${JSON.stringify(raw.date)}`;
+  }
+  if (!isNonEmptyString(raw.venue)) {
+    return `entry ${index}: expected a non-empty string for "venue", got ${JSON.stringify(raw.venue)}`;
+  }
+  if (!isNonEmptyString(raw.activity)) {
+    return `entry ${index}: expected a non-empty string for "activity", got ${JSON.stringify(raw.activity)}`;
+  }
+  const challenge = raw.challenge;
+  if (challenge != null && typeof challenge !== "string") {
+    return `entry ${index}: expected a string or null for "challenge", got ${typeof challenge}`;
+  }
+
+  return {
+    date: raw.date,
+    venue: raw.venue,
+    activity: raw.activity,
+    challenge: challenge ?? null,
+  };
+}
+
+/**
+ * Parse `node.attributes.participation_log` — the author-maintained record of
+ * participation events (strategy clarification on
+ * strategy-join-existing-practice: "a list of {date, venue, activity,
+ * challenge} entries the author appends after each participation event").
+ *
+ * Defensive at the boundary: absent/empty is an honest zero (`{entries: [],
+ * malformed: []}`), not an error. A non-array attribute, or any entry missing
+ * or mistyping a required field, is described in `malformed` by index and
+ * defect while parsing continues over the rest. Returned entries are sorted
+ * by `date` ascending.
+ */
+export function parseParticipationLog(node: IntentionNode): {
+  entries: ParticipationEntry[];
+  malformed: string[];
+} {
+  const raw = node.attributes.participation_log;
+  if (raw == null) {
+    return { entries: [], malformed: [] };
+  }
+  if (!Array.isArray(raw)) {
+    return {
+      entries: [],
+      malformed: [`attributes.participation_log: expected an array, got ${typeof raw}`],
+    };
+  }
+
+  const entries: ParticipationEntry[] = [];
+  const malformed: string[] = [];
+  raw.forEach((item, index) => {
+    const parsed = parseEntry(item, index);
+    if (typeof parsed === "string") {
+      malformed.push(parsed);
+    } else {
+      entries.push(parsed);
+    }
+  });
+
+  entries.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+  return { entries, malformed };
+}
+
+// --- Summary -------------------------------------------------------------------
+
+/** Evidence assembly over a parsed log — counts only, never a pass/fail verdict. */
+export interface ParticipationSummary {
+  count: number;
+  firstDate: string | null;
+  lastDate: string | null;
+  distinctVenues: number;
+  last30Days: number;
+  last90Days: number;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Days between two YYYY-MM-DD dates (`to` minus `from`), treating each as UTC midnight. */
+function daysBetween(from: string, to: string): number {
+  return Math.round((Date.parse(`${to}T00:00:00Z`) - Date.parse(`${from}T00:00:00Z`)) / MS_PER_DAY);
+}
+
+/**
+ * Summarize a parsed participation log as-of `today` (YYYY-MM-DD). Evidence
+ * only — no scoring or thresholding of the recurrence judgment; that's an
+ * owner-review call, not this function's.
+ */
+export function participationSummary(
+  entries: ParticipationEntry[],
+  today: string,
+): ParticipationSummary {
+  if (entries.length === 0) {
+    return {
+      count: 0,
+      firstDate: null,
+      lastDate: null,
+      distinctVenues: 0,
+      last30Days: 0,
+      last90Days: 0,
+    };
+  }
+
+  // entries is expected sorted ascending by parseParticipationLog, but derive
+  // first/last defensively rather than assume caller-supplied order.
+  let firstDate = entries[0]!.date;
+  let lastDate = entries[0]!.date;
+  const venues = new Set<string>();
+  let last30Days = 0;
+  let last90Days = 0;
+
+  for (const entry of entries) {
+    if (entry.date < firstDate) firstDate = entry.date;
+    if (entry.date > lastDate) lastDate = entry.date;
+    venues.add(entry.venue);
+
+    const age = daysBetween(entry.date, today); // >= 0 means entry.date <= today
+    if (age >= 0 && age <= 30) last30Days++;
+    if (age >= 0 && age <= 90) last90Days++;
+  }
+
+  return {
+    count: entries.length,
+    firstDate,
+    lastDate,
+    distinctVenues: venues.size,
+    last30Days,
+    last90Days,
+  };
+}
+
+// --- Challenge routing state -----------------------------------------------------
+
+export interface ChallengeState {
+  logged: ParticipationEntry[];
+  externalReading: string | null;
+  externalGap: string | null;
+}
+
+/**
+ * Assemble the challenge-routing evidence: which logged entries carry a
+ * challenge, alongside `strategy-external-calibration`'s current
+ * reading/gap (verbatim, no boolean routed/unrouted heuristic — that
+ * judgment is the owner's at review).
+ */
+export function challengeState(
+  entries: ParticipationEntry[],
+  externalCalibration: IntentionNode,
+): ChallengeState {
+  return {
+    logged: entries.filter((entry) => entry.challenge !== null),
+    externalReading: externalCalibration.reading,
+    externalGap: externalCalibration.gap,
+  };
+}

--- a/packages/intentionsutil/test/participation.test.ts
+++ b/packages/intentionsutil/test/participation.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+import type { IntentionNode } from "../src/schema.js";
+import {
+  challengeState,
+  parseParticipationLog,
+  participationSummary,
+} from "../src/participation.js";
+
+/** Build a full IntentionNode fixture, filling required/default fields. */
+function anode(partial: Partial<IntentionNode> & { id: string; kind: string }): IntentionNode {
+  return {
+    id: partial.id,
+    kind: partial.kind,
+    statement: partial.statement ?? `Statement for ${partial.id}`,
+    owner: partial.owner ?? "human",
+    status: partial.status ?? "raw",
+    parent: partial.parent ?? null,
+    serves: partial.serves ?? [],
+    recovers: partial.recovers ?? [],
+    rationale: partial.rationale ?? null,
+    reading: partial.reading ?? null,
+    gap: partial.gap ?? null,
+    clarifications: partial.clarifications ?? [],
+    tooling_goals: partial.tooling_goals ?? [],
+    success_signal: partial.success_signal ?? null,
+    attention: partial.attention ?? null,
+    phase: partial.phase ?? null,
+    execution: partial.execution ?? null,
+    validates: partial.validates ?? [],
+    blocked_by: partial.blocked_by ?? [],
+    office_hours: partial.office_hours ?? null,
+    pace_exempt: partial.pace_exempt ?? false,
+    rounds: partial.rounds ?? null,
+    attributes: partial.attributes ?? {},
+  };
+}
+
+/** A strategy fixture carrying `attributes.participation_log`. */
+function strategyNode(participationLog: unknown): IntentionNode {
+  return anode({
+    id: "strategy-join-existing-practice",
+    kind: "strategy",
+    attributes: { participation_log: participationLog },
+  });
+}
+
+describe("parseParticipationLog", () => {
+  it("returns an honest zero when the attribute is absent", () => {
+    const node = anode({ id: "strategy-join-existing-practice", kind: "strategy" });
+    expect(parseParticipationLog(node)).toEqual({ entries: [], malformed: [] });
+  });
+
+  it("returns an honest zero for an empty list", () => {
+    const node = strategyNode([]);
+    expect(parseParticipationLog(node)).toEqual({ entries: [], malformed: [] });
+  });
+
+  it("parses well-formed entries given out of order, sorted by date ascending", () => {
+    const node = strategyNode([
+      { date: "2026-03-15", venue: "IndieWeb meetup", activity: "talk", challenge: null },
+      { date: "2026-01-10", venue: "local-first chat", activity: "discussion", challenge: "why not CRDTs" },
+      { date: "2026-02-20", venue: "IndieWeb meetup", activity: "workshop", challenge: null },
+    ]);
+    const { entries, malformed } = parseParticipationLog(node);
+    expect(malformed).toEqual([]);
+    expect(entries.map((e) => e.date)).toEqual(["2026-01-10", "2026-02-20", "2026-03-15"]);
+  });
+
+  it("flags a non-array attribute as malformed and returns no entries", () => {
+    const node = strategyNode({ not: "an array" });
+    const { entries, malformed } = parseParticipationLog(node);
+    expect(entries).toEqual([]);
+    expect(malformed).toHaveLength(1);
+    expect(malformed[0]).toMatch(/expected an array/);
+  });
+
+  it("flags an entry missing venue, keeps parsing the rest", () => {
+    const node = strategyNode([
+      { date: "2026-01-10", activity: "discussion", challenge: null },
+      { date: "2026-02-20", venue: "IndieWeb meetup", activity: "workshop", challenge: null },
+    ]);
+    const { entries, malformed } = parseParticipationLog(node);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.date).toBe("2026-02-20");
+    expect(malformed).toHaveLength(1);
+    expect(malformed[0]).toMatch(/entry 0.*venue/);
+  });
+
+  it("flags an entry with a non-string date, keeps parsing the rest", () => {
+    const node = strategyNode([
+      { date: 20260110, venue: "local-first chat", activity: "discussion", challenge: null },
+      { date: "2026-02-20", venue: "IndieWeb meetup", activity: "workshop", challenge: null },
+    ]);
+    const { entries, malformed } = parseParticipationLog(node);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.date).toBe("2026-02-20");
+    expect(malformed).toHaveLength(1);
+    expect(malformed[0]).toMatch(/entry 0.*date/);
+  });
+
+  it("defaults a missing challenge field to null without flagging malformed", () => {
+    const node = strategyNode([
+      { date: "2026-01-10", venue: "local-first chat", activity: "discussion" },
+    ]);
+    const { entries, malformed } = parseParticipationLog(node);
+    expect(malformed).toEqual([]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.challenge).toBeNull();
+  });
+});
+
+describe("participationSummary", () => {
+  it("returns the empty-log shape when there are no entries", () => {
+    expect(participationSummary([], "2026-07-16")).toEqual({
+      count: 0,
+      firstDate: null,
+      lastDate: null,
+      distinctVenues: 0,
+      last30Days: 0,
+      last90Days: 0,
+    });
+  });
+
+  it("computes count, first/last date, and distinct venues", () => {
+    const { entries } = parseParticipationLog(
+      strategyNode([
+        { date: "2026-01-10", venue: "local-first chat", activity: "discussion", challenge: null },
+        { date: "2026-03-15", venue: "IndieWeb meetup", activity: "talk", challenge: null },
+        { date: "2026-02-20", venue: "local-first chat", activity: "workshop", challenge: null },
+      ]),
+    );
+    const summary = participationSummary(entries, "2026-07-16");
+    expect(summary.count).toBe(3);
+    expect(summary.firstDate).toBe("2026-01-10");
+    expect(summary.lastDate).toBe("2026-03-15");
+    expect(summary.distinctVenues).toBe(2);
+  });
+
+  it("counts an entry exactly 30 days before today inside the last30Days window", () => {
+    const { entries } = parseParticipationLog(
+      strategyNode([
+        { date: "2026-06-16", venue: "IndieWeb meetup", activity: "talk", challenge: null },
+      ]),
+    );
+    const summary = participationSummary(entries, "2026-07-16");
+    expect(summary.last30Days).toBe(1);
+    expect(summary.last90Days).toBe(1);
+  });
+
+  it("excludes an entry 31 days before today from last30Days but includes it in last90Days", () => {
+    const { entries } = parseParticipationLog(
+      strategyNode([
+        { date: "2026-06-15", venue: "IndieWeb meetup", activity: "talk", challenge: null },
+      ]),
+    );
+    const summary = participationSummary(entries, "2026-07-16");
+    expect(summary.last30Days).toBe(0);
+    expect(summary.last90Days).toBe(1);
+  });
+
+  it("counts an entry exactly 90 days before today inside the last90Days window", () => {
+    const { entries } = parseParticipationLog(
+      strategyNode([
+        { date: "2026-04-17", venue: "IndieWeb meetup", activity: "talk", challenge: null },
+      ]),
+    );
+    const summary = participationSummary(entries, "2026-07-16");
+    expect(summary.last90Days).toBe(1);
+  });
+
+  it("excludes an entry 91 days before today from last90Days", () => {
+    const { entries } = parseParticipationLog(
+      strategyNode([
+        { date: "2026-04-16", venue: "IndieWeb meetup", activity: "talk", challenge: null },
+      ]),
+    );
+    const summary = participationSummary(entries, "2026-07-16");
+    expect(summary.last90Days).toBe(0);
+  });
+
+  it("excludes an entry dated after today from both windows", () => {
+    const { entries } = parseParticipationLog(
+      strategyNode([
+        { date: "2026-07-20", venue: "IndieWeb meetup", activity: "talk", challenge: null },
+      ]),
+    );
+    const summary = participationSummary(entries, "2026-07-16");
+    expect(summary.last30Days).toBe(0);
+    expect(summary.last90Days).toBe(0);
+  });
+});
+
+describe("challengeState", () => {
+  function externalCalibrationNode(reading: string | null, gap: string | null): IntentionNode {
+    return anode({
+      id: "strategy-external-calibration",
+      kind: "strategy",
+      reading,
+      gap,
+    });
+  }
+
+  it("reports no logged challenges and passes reading/gap through verbatim when none arrived", () => {
+    const { entries } = parseParticipationLog(
+      strategyNode([
+        { date: "2026-01-10", venue: "local-first chat", activity: "discussion", challenge: null },
+      ]),
+    );
+    const external = externalCalibrationNode(null, "no challenges yet");
+    const state = challengeState(entries, external);
+    expect(state.logged).toEqual([]);
+    expect(state.externalReading).toBeNull();
+    expect(state.externalGap).toBe("no challenges yet");
+  });
+
+  it("collects entries carrying a non-null challenge and passes reading/gap through verbatim", () => {
+    const { entries } = parseParticipationLog(
+      strategyNode([
+        { date: "2026-01-10", venue: "local-first chat", activity: "discussion", challenge: "why not CRDTs" },
+        { date: "2026-02-20", venue: "IndieWeb meetup", activity: "workshop", challenge: null },
+      ]),
+    );
+    const external = externalCalibrationNode("measured", null);
+    const state = challengeState(entries, external);
+    expect(state.logged).toHaveLength(1);
+    expect(state.logged[0]!.challenge).toBe("why not CRDTs");
+    expect(state.externalReading).toBe("measured");
+    expect(state.externalGap).toBeNull();
+  });
+});

--- a/packages/intentionsutil/test/participation.test.ts
+++ b/packages/intentionsutil/test/participation.test.ts
@@ -81,7 +81,7 @@ describe("parseParticipationLog", () => {
     ]);
     const { entries, malformed } = parseParticipationLog(node);
     expect(entries).toHaveLength(1);
-    expect(entries[0]!.date).toBe("2026-02-20");
+    expect(entries[0].date).toBe("2026-02-20");
     expect(malformed).toHaveLength(1);
     expect(malformed[0]).toMatch(/entry 0.*venue/);
   });
@@ -93,7 +93,7 @@ describe("parseParticipationLog", () => {
     ]);
     const { entries, malformed } = parseParticipationLog(node);
     expect(entries).toHaveLength(1);
-    expect(entries[0]!.date).toBe("2026-02-20");
+    expect(entries[0].date).toBe("2026-02-20");
     expect(malformed).toHaveLength(1);
     expect(malformed[0]).toMatch(/entry 0.*date/);
   });
@@ -105,7 +105,7 @@ describe("parseParticipationLog", () => {
     const { entries, malformed } = parseParticipationLog(node);
     expect(malformed).toEqual([]);
     expect(entries).toHaveLength(1);
-    expect(entries[0]!.challenge).toBeNull();
+    expect(entries[0].challenge).toBeNull();
   });
 });
 
@@ -223,7 +223,7 @@ describe("challengeState", () => {
     const external = externalCalibrationNode("measured", null);
     const state = challengeState(entries, external);
     expect(state.logged).toHaveLength(1);
-    expect(state.logged[0]!.challenge).toBe("why not CRDTs");
+    expect(state.logged[0].challenge).toBe("why not CRDTs");
     expect(state.externalReading).toBe("measured");
     expect(state.externalGap).toBeNull();
   });


### PR DESCRIPTION
Implements tactic-participation-log-instrument: the participation-log convention parser/summary module and the office-hours review report script that together produce the `strategy-join-existing-practice` signal reading.

## What this adds

- `packages/intentionsutil/src/participation.ts` — parses the author-maintained `attributes.participation_log` convention on `strategy-join-existing-practice`, with defensive boundary parsing (malformed entries described, not thrown), a `participationSummary` evidence-count helper, and a `challengeState` helper that pairs logged challenges with `strategy-external-calibration`'s current reading/gap.
- `packages/intentionsutil/test/participation.test.ts` — unit coverage of the above.
- `packages/intentionsutil/scripts/participation-review.ts` — the report-only script the owner runs at office-hours: prints the participation entries, the summary, and the challenge-routing state, then the attestation instructions for stamping `reading`/`gap` on `strategy-join-existing-practice`. Never writes graph state itself.

Report-only, local-only: no network, no writes to `intentions/`. The born-parked sibling `tactic-join-indieweb` (blocked_by this tactic) will log real participation and produce the strategy's first reading.

## Test plan

- [x] `npx vitest run --project packages/intentionsutil --root .` — 469/469 pass
- [x] `npx tsx packages/intentionsutil/scripts/participation-review.ts` — runs cleanly against the live store (empty log today), exit 0
