### PR TITLE
Add interactive-shell Tailscale auth check with named banner + login URL

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -102,13 +102,16 @@
           let
             weztermTests = pkgs.callPackage ./nix/home/wezterm.test.nix { };
             claudeCodeTests = pkgs.callPackage ./nix/home/claude-code.test.nix { };
+            zshTests = pkgs.callPackage ./nix/home/zsh.test.nix { };
           in
           {
             wezterm-test-suite = weztermTests.wezterm-test-suite;
             claude-code-test-suite = claudeCodeTests.claude-code-test-suite;
+            zsh-test-suite = zshTests.zsh-test-suite;
           }
           // weztermTests.wezterm-tests
           // claudeCodeTests.claude-code-tests
+          // zshTests.zsh-tests
         );
       };
 

--- a/nix/home/zsh.nix
+++ b/nix/home/zsh.nix
@@ -25,6 +25,26 @@
       }
       precmd_functions+=(__wezterm_set_git_branch)
       chpwd_functions+=(__wezterm_set_git_branch)
+
+      __tailscale_auth_check() {
+        [[ -o interactive ]] || return 0
+        command -v tailscale >/dev/null 2>&1 || return 0
+        local status_json
+        status_json=$(tailscale status --json 2>/dev/null) || return 0
+        local backend_state auth_url
+        backend_state=$(printf '%s' "$status_json" | jq -r '.BackendState // ""' 2>/dev/null) || return 0
+        [[ -n "$backend_state" && "$backend_state" != "Running" ]] || return 0
+        auth_url=$(printf '%s' "$status_json" | jq -r '.AuthURL // ""' 2>/dev/null)
+        {
+          echo "tailscale is not logged in on $(hostname) (BackendState: $backend_state)"
+          if [[ -n "$auth_url" ]]; then
+            echo "$auth_url"
+          else
+            echo "run: sudo tailscale up"
+          fi
+        } >&2
+      }
+      __tailscale_auth_check
     '';
   };
 }

--- a/nix/home/zsh.test.nix
+++ b/nix/home/zsh.test.nix
@@ -1,0 +1,126 @@
+# Zsh Module Tests
+#
+# Validates the Zsh Home Manager module's initContent:
+# 1. The wezterm git-branch OSC1337 helper is still present (regression guard)
+# 2. The tailscale auth-check helper guards on interactivity
+# 3. The tailscale auth-check helper inspects `tailscale status --json` BackendState
+# 4. The tailscale auth-check helper prints an AuthURL / remediation command
+
+{ pkgs, lib, ... }:
+
+let
+  # Import the zsh module for testing
+  zshModule = import ./zsh.nix;
+
+  # Test helper: Evaluate module. zsh.nix takes { lib, pkgs, ... } with no
+  # config param, so there's no username/homeDirectory to mock.
+  evaluateModule = { }: zshModule { inherit lib pkgs; };
+
+  # Test helper: Extract the raw initContent string from the module
+  # evaluation. `initContent` is wrapped in `lib.mkOrder 1000 "..."`, which
+  # evaluates to `{ _type = "order"; priority = 1000; content = "..."; }`;
+  # `.content` yields the plain string for lib.hasInfix checks.
+  extractInitContent = moduleResult: moduleResult.programs.zsh.initContent.content;
+
+  # Test 1: wezterm git-branch helper still present (regression guard)
+  test-wezterm-git-branch-present =
+    let
+      initContent = extractInitContent (evaluateModule { });
+    in
+    pkgs.runCommand "test-zsh-wezterm-git-branch-present" { } ''
+      ${
+        if lib.hasInfix "__wezterm_set_git_branch" initContent then
+          "echo 'PASS: initContent still defines __wezterm_set_git_branch'"
+        else
+          "echo 'FAIL: initContent missing __wezterm_set_git_branch' && exit 1"
+      }
+      touch $out
+    '';
+
+  # Test 2: tailscale auth-check guards on interactive shells
+  test-tailscale-interactive-guard =
+    let
+      initContent = extractInitContent (evaluateModule { });
+    in
+    pkgs.runCommand "test-zsh-tailscale-interactive-guard" { } ''
+      ${
+        if lib.hasInfix "-o interactive" initContent then
+          "echo 'PASS: initContent guards tailscale check on interactive shells'"
+        else
+          "echo 'FAIL: initContent missing interactive-shell guard' && exit 1"
+      }
+      touch $out
+    '';
+
+  # Test 3: tailscale auth-check inspects BackendState via tailscale status --json
+  test-tailscale-backend-state-check =
+    let
+      initContent = extractInitContent (evaluateModule { });
+    in
+    pkgs.runCommand "test-zsh-tailscale-backend-state-check" { } ''
+      ${
+        if lib.hasInfix "tailscale status --json" initContent then
+          "echo 'PASS: initContent calls tailscale status --json'"
+        else
+          "echo 'FAIL: initContent missing tailscale status --json call' && exit 1"
+      }
+      ${
+        if lib.hasInfix "BackendState" initContent then
+          "echo 'PASS: initContent inspects BackendState'"
+        else
+          "echo 'FAIL: initContent missing BackendState check' && exit 1"
+      }
+      touch $out
+    '';
+
+  # Test 4: tailscale auth-check prints an AuthURL / remediation command
+  test-tailscale-auth-remediation =
+    let
+      initContent = extractInitContent (evaluateModule { });
+    in
+    pkgs.runCommand "test-zsh-tailscale-auth-remediation" { } ''
+      ${
+        if lib.hasInfix "AuthURL" initContent then
+          "echo 'PASS: initContent reads AuthURL'"
+        else
+          "echo 'FAIL: initContent missing AuthURL check' && exit 1"
+      }
+      ${
+        if lib.hasInfix "sudo tailscale up" initContent then
+          "echo 'PASS: initContent prints sudo tailscale up remediation'"
+        else
+          "echo 'FAIL: initContent missing sudo tailscale up remediation' && exit 1"
+      }
+      touch $out
+    '';
+
+  # Aggregate all tests into a test suite
+  allTests = [
+    test-wezterm-git-branch-present
+    test-tailscale-interactive-guard
+    test-tailscale-backend-state-check
+    test-tailscale-auth-remediation
+  ];
+
+  zsh-test-suite = pkgs.runCommand "zsh-test-suite" { buildInputs = allTests; } ''
+    echo "Zsh Module Test Suite"
+    echo ""
+    ${lib.concatMapStringsSep "\n" (test: "echo \"  ${test.name}\"") allTests}
+    echo ""
+    echo "All Zsh tests passed!"
+    touch $out
+  '';
+
+in
+{
+  zsh-tests = {
+    inherit
+      test-wezterm-git-branch-present
+      test-tailscale-interactive-guard
+      test-tailscale-backend-state-check
+      test-tailscale-auth-remediation
+      ;
+  };
+
+  inherit zsh-test-suite;
+}


### PR DESCRIPTION
Implements tactic node `tactic-tailscale-shell-health-check`: an interactive-shell Tailscale auth check that prints a named banner with the ready login URL when `tailscale status --json` reports `BackendState != "Running"`.

Motivated by the 2026-07-07 wezterm incident, where tailscale on the dispatch-router host was logged out and the only symptom surfaced two layers away as a cryptic wezterm GUI close. This adds the detection half of `strategy-tailscale-auth-visibility`.

## Changes

- `nix/home/zsh.nix`: adds `__tailscale_auth_check`, called once at interactive shell init (guarded on `[[ -o interactive ]]`), fetches `tailscale status --json` once, and prints a named banner + `AuthURL` (or `sudo tailscale up` fallback) to stderr when `BackendState != Running`. Silent when `tailscale` is absent or the call fails — never blocks shell startup.
- `nix/home/zsh.test.nix`: nix flake check mirroring `wezterm.test.nix`'s module-eval + `lib.hasInfix` harness — asserts the interactive guard, the `BackendState`/`tailscale status --json` check, the `AuthURL`/remediation output, and that the existing wezterm git-branch helper is untouched.
- `flake.nix`: wires the new test suite into `checks`.

Out of scope (separate tactics): the router-host office-hours feed, the wezterm loud-fail, and any auto-remediation (`tailscale up` stays manual).

## Test plan

- [x] `nix flake check` passes (25/25 checks, including the 4 new zsh tests)
- [ ] Manual, per machine: `home-manager switch`, open a fresh interactive shell with tailscale Running → no banner; `sudo tailscale logout`, open a fresh interactive shell → named banner + login URL print; `zsh -c 'true'` (non-interactive) → silent
