### PR TITLE
Each kind declares its own status vocabulary; validateGraph checks it

### DIFF
--- a/intentions/kind-delegation.md
+++ b/intentions/kind-delegation.md
@@ -113,5 +113,10 @@ attributes:
       recorded at office-hours — never seeded or inferred by a session
       (tactic-household-consent-instrument seeds shared/basis proposals only;
       ratification is tactic-household-consent-offering)."
+  status_vocabulary:
+    raw: a future-candidate capture named before any recovery strategy exists,
+      awaiting selection
+    refining: under active dialectic
+    codified: the author has personally settled this attachment record
 ---
 # Delegation — an attachment record; where capture is detected and recovery kept real

--- a/intentions/kind-kind.md
+++ b/intentions/kind-kind.md
@@ -108,5 +108,7 @@ attributes:
     - "attributes: kind-specific fields, defined by the kind node — the kind
       nodes own the which-kinds-carry-which-fields statement"
   entry_point: this node is the entry point of the graph
+  status_vocabulary:
+    codified: the author has personally settled this kind's semantics
 ---
 # A kind defines the semantics of a class of nodes

--- a/intentions/kind-strategy.md
+++ b/intentions/kind-strategy.md
@@ -83,5 +83,9 @@ attributes:
   edges:
     - "recovers: ids of the delegation records this strategy's work unwinds
       (top-level field, resolved by validateGraph)"
+  status_vocabulary:
+    raw: not yet dialectically examined
+    refining: under active dialectic
+    codified: the author has personally settled this strategy against present conditions
 ---
 # Strategy — the highest goals a virtue generates against present conditions

--- a/intentions/kind-tactic.md
+++ b/intentions/kind-tactic.md
@@ -62,5 +62,11 @@ attributes:
   fields:
     - "attention: valid on this kind (goal_layer: true) — a TOP-LEVEL field, not
       an attributes entry; canonical definition on kind-kind's field list"
+  status_vocabulary:
+    raw: not yet dialectically examined
+    refining: under active dialectic
+    delegated: Claude-authored on trust; the decisions remain the author's
+    codified: the plan is written and the tactic is ready to dispatch — the author
+      has settled its execution plan
 ---
 # Tactic — a completable unit of execution

--- a/intentions/kind-tradition.md
+++ b/intentions/kind-tradition.md
@@ -109,5 +109,11 @@ attributes:
       auditable"
     - "review_trigger: what prompts reassessment of this record"
     - "last_assessed: date of the last dialectic round that touched this record"
+  status_vocabulary:
+    delegated: the detail is held on trust from
+      delegation-philosophical-articulation — the decisions the record supports
+      are the author's, the scholarship is borrowed
+    codified: the author has personally verified the record's
+      adopted/diverged/chosen_over content against the cited texts
 ---
 # Tradition — an examined intellectual attachment; where philosophical alignment and divergence stay auditable

--- a/intentions/kind-virtue.md
+++ b/intentions/kind-virtue.md
@@ -131,5 +131,7 @@ attributes:
       exceptionless, never balanced or summed; set where a virtue carries a
       floor the tension machinery must not touch (see
       virtue-respect-for-persons)"
+  status_vocabulary:
+    codified: the author has personally settled this virtue's articulation
 ---
 # Virtue — a disposition held and exercised, never completed

--- a/intentions/tactic-status-kind-vocabularies.md
+++ b/intentions/tactic-status-kind-vocabularies.md
@@ -117,7 +117,7 @@ codified}.
 ## Verification
 
 ```verify
-npx vitest run --project intentionsutil --root .
+npx vitest run --project packages/intentionsutil --root .
 npx tsx packages/intentionsutil/scripts/validate-graph.ts
 ```
 

--- a/packages/intentionsutil/src/schema.ts
+++ b/packages/intentionsutil/src/schema.ts
@@ -7,10 +7,17 @@ export type Owner = "human" | "ai" | "procedure";
 
 export const OWNERS: readonly Owner[] = ["human", "ai", "procedure"];
 
-/** Lifecycle stage of a node as it moves from raw intention to codified work. */
-export type Status = "raw" | "refining" | "delegated" | "codified";
+/**
+ * Lifecycle stage of a node as it moves from raw intention to codified work.
+ * Widened to `string`: the set of valid statuses is per-kind data (each kind
+ * node's `attributes.status_vocabulary`), not a central enum in code —
+ * enforced by `validateGraph`, not `validateNode` (which has no graph
+ * context). `STATUSES` is kept as the legacy default vocabulary values for
+ * callers that still reference it.
+ */
+export type Status = string;
 
-export const STATUSES: readonly Status[] = ["raw", "refining", "delegated", "codified"];
+export const STATUSES: readonly string[] = ["raw", "refining", "delegated", "codified"];
 
 /** What kind of tooling a goal codifies. */
 export type ToolingKind = "actuator" | "sensor";
@@ -478,6 +485,10 @@ export function validateNode(value: unknown): IntentionNode {
   if (kind === "") {
     throw new IntentionSchemaError("kind must be a non-empty string");
   }
+  const status = requireString(value.status, "status");
+  if (status === "") {
+    throw new IntentionSchemaError("status must be a non-empty string");
+  }
 
   return {
     // Required core.
@@ -485,7 +496,7 @@ export function validateNode(value: unknown): IntentionNode {
     kind,
     statement: requireString(value.statement, "statement"),
     owner: requireOneOf(value.owner, OWNERS, "owner"),
-    status: requireOneOf(value.status, STATUSES, "status"),
+    status,
 
     // Optional scalars — absent/null tolerated, default null.
     parent: optionalString(value.parent, "parent"),
@@ -566,6 +577,9 @@ export function validateNode(value: unknown): IntentionNode {
  *  14. Every `validates` entry resolves to an existing `kind: "strategy"` node.
  *  15. `blocked_by` edges contain no cycle (a tactic transitively blocked by
  *      itself is invalid).
+ *  16. Every node's `status` must be a key in its kind node's declared
+ *      `attributes.status_vocabulary` (a missing declaration on the kind node
+ *      is itself an error).
  *
  * Rules 6-9 only judge edges whose target already resolves (rules 2-4 above
  * report the dangling case); this avoids double-reporting the same broken
@@ -723,6 +737,22 @@ export function validateGraph(nodes: IntentionNode[]): void {
         problems.push(
           `${node.id}: validates "${target}" must resolve to a kind "strategy" node, got kind "${targetNode.kind}"`,
         );
+      }
+    }
+    // Rule 16: status must be a key in the kind node's status_vocabulary.
+    {
+      const kindNode = byId.get(`kind-${node.kind}`);
+      if (kindNode !== undefined) {
+        const vocab = kindNode.attributes.status_vocabulary;
+        if (!isPlainObject(vocab) || Object.keys(vocab).length === 0) {
+          problems.push(
+            `${node.id}: kind-${node.kind} has no attributes.status_vocabulary declared`,
+          );
+        } else if (!Object.prototype.hasOwnProperty.call(vocab, node.status)) {
+          problems.push(
+            `${node.id}: status "${node.status}" is not declared in kind-${node.kind}'s status_vocabulary`,
+          );
+        }
       }
     }
   }

--- a/packages/intentionsutil/test/digest.test.ts
+++ b/packages/intentionsutil/test/digest.test.ts
@@ -73,8 +73,15 @@ function section(out: string, tag: string): string {
 
 /** A minimal closed graph: the kind nodes, a virtue, a strategy, a tactic. */
 function closedGraph(): IntentionNode[] {
+  // Every fixture node here defaults to status "raw" (anode()'s default), so
+  // each kind node's status_vocabulary just needs to cover "raw"; "codified"
+  // is included too to mirror the default schema.test.ts's gnode() applies.
+  const statusVocabulary = { raw: "Not yet started.", codified: "Complete." };
   return [
-    ...kinds(),
+    ...kinds().map((n) => ({
+      ...n,
+      attributes: { ...n.attributes, status_vocabulary: statusVocabulary },
+    })),
     anode({ id: "virtue-root", kind: "virtue" }),
     anode({ id: "strategy-a", kind: "strategy", serves: ["virtue-root"] }),
     anode({ id: "tactic-a", kind: "tactic", serves: ["strategy-a"], validates: ["strategy-a"] }),

--- a/packages/intentionsutil/test/schema.test.ts
+++ b/packages/intentionsutil/test/schema.test.ts
@@ -463,6 +463,29 @@ describe("validateNode", () => {
     ).toThrow();
   });
 
+  it("accepts any non-empty status string (status is not a central enum)", () => {
+    const result = validateNode({
+      id: "n3d",
+      kind: "tactic",
+      statement: "Custom kind-specific status.",
+      owner: "human",
+      status: "anything-nonempty",
+    });
+    expect(result.status).toBe("anything-nonempty");
+  });
+
+  it("rejects an empty-string status", () => {
+    expect(() =>
+      validateNode({
+        id: "n3e",
+        kind: "tactic",
+        statement: "Empty status.",
+        owner: "human",
+        status: "",
+      }),
+    ).toThrow(/status must be a non-empty string/);
+  });
+
   it("rejects a bad enum value", () => {
     expect(() =>
       validateNode({
@@ -656,7 +679,14 @@ describe("validateGraph", () => {
       office_hours: partial.office_hours ?? null,
       pace_exempt: partial.pace_exempt ?? false,
       rounds: partial.rounds ?? null,
-      attributes: partial.attributes ?? {},
+      // Default status_vocabulary covers the "raw"/"codified" statuses these
+      // fixtures use, so kind-node fixtures satisfy rule 16 (every node's
+      // status must be a key in its kind node's status_vocabulary) without
+      // every test needing to declare one explicitly. Tests that need to
+      // exercise rule 16 itself pass their own `attributes` to override this.
+      attributes: partial.attributes ?? {
+        status_vocabulary: { raw: "Not yet started.", codified: "Complete." },
+      },
     };
   }
 
@@ -670,7 +700,10 @@ describe("validateGraph", () => {
         id: "kind-strategy",
         kind: "kind",
         status: "codified",
-        attributes: { goal_layer: true },
+        attributes: {
+          goal_layer: true,
+          status_vocabulary: { raw: "Not yet started.", codified: "Complete." },
+        },
       }),
       gnode({ id: "kind-delegation", kind: "kind", status: "codified" }),
       gnode({ id: "virtue-root", kind: "virtue", status: "codified", parent: null }),
@@ -934,13 +967,19 @@ describe("validateGraph", () => {
         id: "kind-strategy",
         kind: "kind",
         status: "codified",
-        attributes: { goal_layer: true },
+        attributes: {
+          goal_layer: true,
+          status_vocabulary: { raw: "Not yet started.", codified: "Complete." },
+        },
       }),
       gnode({
         id: "kind-tactic",
         kind: "kind",
         status: "codified",
-        attributes: { goal_layer: true },
+        attributes: {
+          goal_layer: true,
+          status_vocabulary: { raw: "Not yet started.", codified: "Complete." },
+        },
       }),
     ];
   }
@@ -1147,5 +1186,48 @@ describe("validateGraph", () => {
       gnode({ id: "tactic-c", kind: "tactic" }),
     ];
     expect(() => validateGraph(nodes)).not.toThrow();
+  });
+
+  // --- Rule 16: status must be a key in the kind node's status_vocabulary --
+
+  it("passes when a node's status is a key in its kind node's status_vocabulary", () => {
+    const nodes = [
+      gnode({ id: "kind-kind", kind: "kind", status: "codified" }),
+      gnode({
+        id: "kind-tactic",
+        kind: "kind",
+        status: "codified",
+        attributes: { status_vocabulary: { codified: "Complete." } },
+      }),
+      gnode({ id: "tactic-1", kind: "tactic", status: "codified" }),
+    ];
+    expect(() => validateGraph(nodes)).not.toThrow();
+  });
+
+  it("throws when a node's status is not declared in its kind node's status_vocabulary", () => {
+    const nodes = [
+      gnode({ id: "kind-kind", kind: "kind", status: "codified" }),
+      gnode({
+        id: "kind-tactic",
+        kind: "kind",
+        status: "codified",
+        attributes: { status_vocabulary: { codified: "Complete." } },
+      }),
+      gnode({ id: "tactic-1", kind: "tactic", status: "raw" }),
+    ];
+    expect(() => validateGraph(nodes)).toThrow(
+      /tactic-1: status "raw" is not declared in kind-tactic's status_vocabulary/,
+    );
+  });
+
+  it("throws when a kind node has no attributes.status_vocabulary declared", () => {
+    const nodes = [
+      gnode({ id: "kind-kind", kind: "kind", status: "codified" }),
+      gnode({ id: "kind-tactic", kind: "kind", status: "codified", attributes: {} }),
+      gnode({ id: "tactic-1", kind: "tactic", status: "raw" }),
+    ];
+    expect(() => validateGraph(nodes)).toThrow(
+      /tactic-1: kind-tactic has no attributes\.status_vocabulary declared/,
+    );
   });
 });


### PR DESCRIPTION
## Summary

`status` carried three overloaded meanings under one central lifecycle enum
(`raw | refining | delegated | codified`): the central lifecycle, tradition
provenance (kind-tradition redefines `delegated`/`codified`), and the tactic
layer's plan-written sense. Per the author decision recorded on this tactic
(2026-07-09 interview), the field must not be overloaded — each kind now
declares its own status vocabulary, exactly as kinds already own `attributes`,
and the validator checks a node's status against its kind's declaration
instead of the central enum.

- Each of the six `intentions/kind-*.md` nodes gains `attributes.status_vocabulary`
  — a plain object mapping each valid status value to its kind-local meaning.
  Values match every currently-stored node status exactly; no non-kind node's
  stored status changed.
- `validateNode` (`packages/intentionsutil/src/schema.ts`) no longer enforces
  the central `STATUSES` enum on `status` — it now requires a non-empty string,
  since per-node validation has no graph context. `STATUSES` is kept as a
  legacy default-vocabulary constant (still re-exported by `graph.ts`/`index.ts`).
- `validateGraph` gains a new rule (16): every node's `status` must be a key
  in its kind node's declared `attributes.status_vocabulary`; a kind node with
  no (or an empty) declaration is itself a graph-integrity error.
- Fixed a stale `--project intentionsutil` flag in this tactic's own
  Verification block — the real vitest workspace project name is
  `packages/intentionsutil`.

## Test plan

- [x] `npx vitest run --project packages/intentionsutil --root .` — 458 tests pass
- [x] `npx tsx packages/intentionsutil/scripts/validate-graph.ts` — `ok — 378 nodes`
- [x] Manually flipped this tactic's own `status` to an undeclared value and
      confirmed `validate-graph.ts` fails naming both the node and its kind
      (`kind-tactic`), then reverted — no stored status changed in the diff.
