### PR TITLE
Firebase recovery drill: re-host landing off Firebase and measure cost (tactic-recovery-drill-firebase)

### DIFF
--- a/ops/recovery-drills/firebase-drill-report.md
+++ b/ops/recovery-drills/firebase-drill-report.md
@@ -1,0 +1,131 @@
+# Firebase recovery drill — report
+
+Strategy: `strategy-exercise-recovery-paths`. Delegation record: `delegation-firebase`
+(flipped in Unit 3, not this report). Tools built in Unit 1:
+`ops/recovery-drills/firebase/` (nginx config, serve script, parity checklist,
+`extract-parity.jq`). This is Unit 2's record of actually running the drill.
+
+## What the drill measured
+
+Whether `landing` — currently hosted on Firebase Hosting — is a rebuildable
+projection of owned local data (the built `landing/dist/` output plus a
+hand-authored nginx config translating `firebase.json`'s `landing` hosting
+block), or whether it secretly depends on Firebase-specific infrastructure
+that can't be reproduced elsewhere.
+
+## Date and duration
+
+Run: 2026-07-16 (UTC).
+
+Wall-clock breakdown of the mechanical recovery steps, as actually measured
+in this session:
+
+| Step | Time |
+| --- | --- |
+| `npm run build --prefix landing` (produces `landing/dist/`) | ~23 s |
+| Cold-start substitute host (`serve-landing.sh`, includes one-time `nix run nixpkgs#nginx` fetch of nginx/openssl/zlib from cache.nixos.org, ~3.3 MiB) | ~10 s |
+| `verify-parity.sh` run against the live host (7 test cases) | <1 s |
+| **Mechanical recovery total (build → serve → verify), warm nix store** | **~35 s** |
+
+That ~35 s figure is what a *repeat* recovery costs once the substitute-host
+tooling (nginx config, serve script, checklist, verify script) already
+exists — i.e., the ongoing cost of re-hosting `landing` off Firebase at any
+future point, given this drill's artifacts are kept current.
+
+The one-time cost of *building* that tooling (Unit 1: writing
+`nginx-landing.conf` by hand-translating `firebase.json`'s header-merge
+semantics, `extract-parity.jq`, `parity-checklist.json`; Unit 2: writing and
+debugging `verify-parity.sh`, running the drill end-to-end, writing this
+report) was on the order of a working session (design, several iterations,
+manual curl verification before automating) — call it low single-digit hours
+across both units. That non-recurring engineering cost is the real "recovery
+cost" this drill is measuring: not the mechanical steps (fast, because they're
+already scripted), but the one-time work of building a faithful non-Firebase
+substitute in the first place.
+
+## Parity results
+
+All 7 test cases in `ops/recovery-drills/firebase/parity-checklist.json`,
+verified by `ops/recovery-drills/firebase/verify-parity.sh` against the
+substitute host (`serve-landing.sh`, port 8088):
+
+| Test case | Path probed | Expected status | Parity target? | Result |
+| --- | --- | --- | --- | --- |
+| `spa-root` | `/` | 200 | yes | **PASS** — shared `**` security headers match; body byte-identical to `landing/dist/index.html` |
+| `spa-deep-route` | `/any/unmatched/client-route` | 200 | yes | **PASS** — SPA catch-all serves `index.html`, not a 404; headers match |
+| `blogroll-opml` | `/blogroll.opml` | 200 | yes | **PASS** — forced `Content-Type: text/x-opml+xml; charset=utf-8` + `Access-Control-Allow-Origin: *` match |
+| `feed-xml` | `/feed.xml` | 200 | yes | **PASS** — forced `Content-Type: application/rss+xml; charset=utf-8` + `Cache-Control: public, max-age=3600` match |
+| `assets-hashed-file` | `/assets/deferred-app-auth-BvQA3diB.js` (real hashed build output, auto-resolved) | 200 | yes | **PASS** — `Cache-Control: public, max-age=31536000, immutable` wins over the plain image-cache rule, matching Firebase's last-rule-wins merge |
+| `root-image-non-asset` | `/nathan.jpg` (real file, auto-resolved) | 200 | yes | **PASS** — `Cache-Control: public, max-age=31536000` (no `immutable`, correctly distinct from the `/assets/**` case) |
+| `webmention-unrehostable` | `/api/webmention` | 503 | **no** (measured residue, not a parity assertion) | **PASS** (as residue) — returns `503` with the drill's diagnostic body, matching the checklist's `webmention_stub` expectation |
+
+**7 of 7 cases behaved as specified in the checklist** (6 genuine parity
+passes + 1 correctly-stubbed residue case). `verify-parity.sh` exits 0.
+
+A sanity check confirmed the verify script fails loud and non-zero when the
+target is unreachable (ran it against a closed port; all 7 cases reported
+`FAIL ... curl could not reach ...`, exit 1) — the script does not silently
+pass on a broken target.
+
+## The `/api/webmention` residue — the measured recovery gap
+
+`firebase.json` rewrites `/api/webmention` to the `webmention` Cloud
+Function. A static nginx host has no compute layer, so it cannot re-host a
+Cloud Function — full stop. The substitute config
+(`ops/recovery-drills/firebase/nginx-landing.conf`) stubs this path with an
+explicit `503` and a diagnostic body rather than silently 404/200-ing, so the
+gap stays visible instead of being swallowed.
+
+This is the one genuine, unavoidable finding of the drill: **`landing`'s
+static surface (SPA shell, feed, blogroll, assets, all header/caching
+behavior) is fully rebuildable from owned local data with no Firebase
+dependency, but the `/api/webmention` backend endpoint is not** — it is
+compute-backed, not a projection of static build output. A real, no-notice
+recovery of `landing` off Firebase would leave webmention receiving broken
+until a replacement endpoint (e.g. a small serverless function elsewhere, or
+a queue-and-batch webmention processor) is stood up. That is real,
+measurable friction, not a tooling gap in this drill — it is intrinsic to
+what `landing` currently depends on Firebase for.
+
+## DNS cutover — documented, NOT executed
+
+Production `landing` (the `commons.systems` apex/`landing` subdomain, per
+`firebase.json` hosting config) **stays on Firebase**. No DNS, Cloudflare
+zone, or Firebase project configuration was touched by this drill — all
+verification ran against the local substitute host on `127.0.0.1:8088`.
+
+If a real cutover were ever executed (out of scope here, and not something
+this drill or report authorizes), the steps would be:
+
+1. Stand up the substitute host somewhere reachable from the internet (a VM,
+   container host, or similar) running the same `nginx-landing.conf` contract
+   against a built `landing/dist/`, kept current via CI/CD the same way the
+   Firebase deploy currently is.
+2. Stand up a replacement for `/api/webmention` (see residue above) — the one
+   surface the static host cannot serve.
+3. Change the Cloudflare DNS record for the `landing` subdomain (currently
+   presumably CNAME/A to Firebase Hosting's edge) to point at the new host.
+4. **TLS**: `*.commons.systems` currently gets its certificate through
+   Firebase Hosting's automatic provisioning (or Cloudflare's proxy layer, if
+   Cloudflare-proxied — whichever is authoritative for this zone). A cutover
+   away from Firebase means TLS termination moves too: either issue and renew
+   a cert on the new host (e.g. certbot / Let's Encrypt) or keep Cloudflare
+   proxying the record (orange-cloud) so Cloudflare's edge certificate keeps
+   covering it and the origin cert only needs to satisfy Cloudflare's
+   full-strict validation. This decision needs to be made explicitly at
+   cutover time — it is not automatic.
+5. Verify propagation and monitor for TLS/cert errors and 5xx before removing
+   the Firebase Hosting site.
+
+None of the above was executed. This section exists so a future real
+recovery has a documented starting checklist instead of reconstructing the
+plan from scratch under pressure.
+
+## Conclusion
+
+`landing`'s static hosting tier recovers cleanly and quickly (~35 s
+mechanical, once the substitute-host tooling from Units 1–2 exists) with full
+header/caching parity. The one real, measured gap is the compute-backed
+`/api/webmention` endpoint, which any real recovery must replace separately.
+Firebase remains the live production host; this drill changed no production
+state.

--- a/ops/recovery-drills/firebase/extract-parity.jq
+++ b/ops/recovery-drills/firebase/extract-parity.jq
@@ -1,0 +1,38 @@
+# extract-parity.jq — extract the `landing` hosting contract from firebase.json
+# into a normalized parity checklist, so the drill verifies the substitute host
+# against a machine-generated projection of the source of truth rather than a
+# hand-transcribed copy.
+#
+# Run:
+#   jq -f ops/recovery-drills/firebase/extract-parity.jq firebase.json \
+#     > ops/recovery-drills/firebase/parity-checklist.json
+#
+# Output shape:
+#   {
+#     target, document_root,
+#     header_rules: [ { source, headers: [ {key, value} ] } ],
+#     rewrites:     [ { source, destination|null, function|null } ]
+#   }
+#
+# The committed parity-checklist.json is this script's output augmented with a
+# `test_cases` array and a `webmention_stub` note (see parity-checklist.md) that
+# describe HOW to probe each rule; those two additions are not derivable from
+# firebase.json and are maintained by hand.
+
+.hosting[]
+| select(.target == "landing")
+| {
+    target: .target,
+    document_root: .public,
+    header_rules: [
+      .headers[]
+      | { source: .source,
+          headers: [ .headers[] | { key: .key, value: .value } ] }
+    ],
+    rewrites: [
+      .rewrites[]
+      | { source: .source,
+          destination: (.destination // null),
+          function: (.function.functionId // null) }
+    ]
+  }

--- a/ops/recovery-drills/firebase/nginx-landing.conf
+++ b/ops/recovery-drills/firebase/nginx-landing.conf
@@ -1,0 +1,159 @@
+# nginx-landing.conf
+#
+# Recovery-drill substitute host for the `landing` app, reproducing the
+# `landing` hosting block of the repo-root firebase.json (the target="landing"
+# entry: headers array + rewrites) on a plain nginx server with no Firebase,
+# no root, and no system install.
+#
+# Purpose: exercise strategy-exercise-recovery-paths — prove the hosted tier is
+# a rebuildable projection of owned local data by re-hosting landing off
+# Firebase and measuring real recovery cost/friction (delegation-firebase).
+#
+# This file is rendered by serve-landing.sh: the two placeholders below are
+# substituted with concrete values before nginx parses it.
+#   __DOCROOT__ -> absolute path to landing/dist
+#   __PORT__    -> localhost port (default 8088)
+#
+# Fidelity notes:
+#   * Firebase merges ALL matching header rules onto a response. nginx does NOT
+#     inherit `add_header` from an outer scope once a location declares its own
+#     `add_header`. So every location below re-emits the five shared security
+#     headers from firebase.json's `**` rule, matching Firebase's merge.
+#   * Content-Type overrides (feed.xml, blogroll.opml) are done with an empty
+#     `types { }` block plus `default_type`, which forces the type regardless of
+#     the built-in extension map. A bare `add_header Content-Type` would only
+#     append a duplicate header, not replace the real one.
+
+daemon off;
+worker_processes 1;
+pid __PREFIX__/nginx.pid;
+error_log __PREFIX__/error.log warn;
+
+events {
+    worker_connections 64;
+}
+
+http {
+    access_log __PREFIX__/access.log;
+    client_body_temp_path __PREFIX__/client_body;
+    proxy_temp_path __PREFIX__/proxy;
+    fastcgi_temp_path __PREFIX__/fastcgi;
+    uwsgi_temp_path __PREFIX__/uwsgi;
+    scgi_temp_path __PREFIX__/scgi;
+
+    # Minimal MIME map so index.html, JS, CSS, and static assets get correct
+    # Content-Type. feed.xml / blogroll.opml override their type per-location.
+    types {
+        text/html                             html htm;
+        text/javascript                       js mjs;
+        text/css                              css;
+        application/json                      json map;
+        image/svg+xml                         svg;
+        image/png                             png;
+        image/jpeg                            jpg jpeg;
+        image/gif                             gif;
+        image/webp                            webp;
+        image/avif                            avif;
+        image/x-icon                          ico;
+        font/woff2                            woff2;
+        application/wasm                      wasm;
+        text/plain                            txt;
+        application/xml                       xml;
+    }
+    default_type application/octet-stream;
+
+    sendfile on;
+
+    # Shared security headers = firebase.json landing `**` rule.
+    # nginx forces us to repeat these in every location that adds its own
+    # header (see fidelity note above), so they live in a map-free literal
+    # form and are copy-pasted verbatim into each block below.
+
+    server {
+        listen 127.0.0.1:__PORT__;
+        server_name localhost;
+        root __DOCROOT__;
+        index index.html;
+
+        # --- landing `**` (all responses): shared security headers ---
+        add_header Content-Security-Policy "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'" always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+
+        # --- Unrehostable backend residue measured by the drill ---
+        # firebase.json rewrites /api/webmention to the `webmention` Cloud
+        # Function. A static nginx host cannot re-host a Cloud Function, so this
+        # surface is intentionally stubbed 503. This is expected drill residue
+        # (the non-projectable, compute-backed part of the hosted tier), NOT a
+        # bug in this config. Recording it as an explicit 503 keeps the parity
+        # gap visible and measurable instead of silently 404/200-ing.
+        location = /api/webmention {
+            add_header Content-Type "text/plain; charset=utf-8" always;
+            return 503 "recovery-drill: /api/webmention is a Cloud Function (webmention); not rehostable by a static nginx host\n";
+        }
+
+        # --- landing `/blogroll.opml` ---
+        location = /blogroll.opml {
+            types { }
+            default_type "text/x-opml+xml; charset=utf-8";
+            add_header Content-Security-Policy "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header X-Frame-Options "DENY" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Access-Control-Allow-Origin "*" always;
+            try_files $uri /index.html;
+        }
+
+        # --- landing `/feed.xml` ---
+        location = /feed.xml {
+            types { }
+            default_type "application/rss+xml; charset=utf-8";
+            add_header Content-Security-Policy "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header X-Frame-Options "DENY" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Cache-Control "public, max-age=3600" always;
+            try_files $uri /index.html;
+        }
+
+        # --- landing `/assets/**` (hashed build output): immutable 1yr ---
+        # `^~` stops regex-location matching, so /assets/*.png gets the
+        # immutable rule here (not the image rule below) — matching Firebase,
+        # where /assets/** is the last-listed rule and therefore wins.
+        location ^~ /assets/ {
+            add_header Content-Security-Policy "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header X-Frame-Options "DENY" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Cache-Control "public, max-age=31536000, immutable" always;
+            try_files $uri /index.html;
+        }
+
+        # --- landing image/font extensions: 1yr cache ---
+        # firebase.json: **/*.{jpg,jpeg,png,gif,webp,avif,svg,woff2}
+        location ~* \.(jpg|jpeg|png|gif|webp|avif|svg|woff2)$ {
+            add_header Content-Security-Policy "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header X-Frame-Options "DENY" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Cache-Control "public, max-age=31536000" always;
+            try_files $uri /index.html;
+        }
+
+        # --- landing `**` SPA catch-all rewrite -> /index.html ---
+        location / {
+            add_header Content-Security-Policy "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header X-Frame-Options "DENY" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}

--- a/ops/recovery-drills/firebase/parity-checklist.json
+++ b/ops/recovery-drills/firebase/parity-checklist.json
@@ -1,0 +1,149 @@
+{
+  "_comment": "Parity checklist for the landing recovery drill. header_rules and rewrites are the machine-extracted landing hosting contract from firebase.json (regenerate with: jq -f ops/recovery-drills/firebase/extract-parity.jq firebase.json). test_cases and webmention_stub are hand-maintained probing instructions (not derivable from firebase.json) that a later drill step uses to curl the substitute host and assert response headers. In each test case, expected_headers is the FULL set Firebase merges onto that response, applying header_rules in array order with later rules overriding earlier ones for the same key.",
+  "target": "landing",
+  "document_root": "landing/dist",
+  "header_rules": [
+    {
+      "source": "**",
+      "headers": [
+        { "key": "Content-Security-Policy", "value": "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" }
+      ]
+    },
+    {
+      "source": "/blogroll.opml",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Content-Type", "value": "text/x-opml+xml; charset=utf-8" }
+      ]
+    },
+    {
+      "source": "/feed.xml",
+      "headers": [
+        { "key": "Content-Type", "value": "application/rss+xml; charset=utf-8" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" }
+      ]
+    },
+    { "source": "**/*.jpg",  "headers": [ { "key": "Cache-Control", "value": "public, max-age=31536000" } ] },
+    { "source": "**/*.jpeg", "headers": [ { "key": "Cache-Control", "value": "public, max-age=31536000" } ] },
+    { "source": "**/*.png",  "headers": [ { "key": "Cache-Control", "value": "public, max-age=31536000" } ] },
+    { "source": "**/*.gif",  "headers": [ { "key": "Cache-Control", "value": "public, max-age=31536000" } ] },
+    { "source": "**/*.webp", "headers": [ { "key": "Cache-Control", "value": "public, max-age=31536000" } ] },
+    { "source": "**/*.avif", "headers": [ { "key": "Cache-Control", "value": "public, max-age=31536000" } ] },
+    { "source": "**/*.svg",  "headers": [ { "key": "Cache-Control", "value": "public, max-age=31536000" } ] },
+    { "source": "**/*.woff2","headers": [ { "key": "Cache-Control", "value": "public, max-age=31536000" } ] },
+    { "source": "/assets/**","headers": [ { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" } ] }
+  ],
+  "rewrites": [
+    { "source": "/api/webmention", "destination": null, "function": "webmention" },
+    { "source": "**", "destination": "/index.html", "function": null }
+  ],
+  "webmention_stub": {
+    "path": "/api/webmention",
+    "expected_status": 503,
+    "parity": false,
+    "reason": "firebase.json rewrites /api/webmention to the webmention Cloud Function. A static nginx host cannot re-host a Cloud Function. This surface is deliberately stubbed 503 and is expected, measured drill residue (the non-projectable, compute-backed part of the hosted tier), not a parity failure."
+  },
+  "test_cases": [
+    {
+      "name": "spa-root",
+      "path": "/",
+      "expected_status": 200,
+      "parity": true,
+      "notes": "Root serves index.html; only the shared ** security headers apply.",
+      "expected_headers": {
+        "Content-Security-Policy": "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'",
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "X-Frame-Options": "DENY",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff"
+      }
+    },
+    {
+      "name": "spa-deep-route",
+      "path": "/any/unmatched/client-route",
+      "expected_status": 200,
+      "parity": true,
+      "notes": "Catch-all ** rewrite serves index.html for any unmatched path. Shared security headers apply.",
+      "expected_headers": {
+        "Content-Security-Policy": "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'",
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "X-Frame-Options": "DENY",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff"
+      }
+    },
+    {
+      "name": "blogroll-opml",
+      "path": "/blogroll.opml",
+      "expected_status": 200,
+      "parity": true,
+      "notes": "Shared security headers PLUS the blogroll rule (ACAO + forced Content-Type). Requires landing/dist/blogroll.opml to exist.",
+      "expected_headers": {
+        "Content-Security-Policy": "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'",
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "X-Frame-Options": "DENY",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "text/x-opml+xml; charset=utf-8"
+      }
+    },
+    {
+      "name": "feed-xml",
+      "path": "/feed.xml",
+      "expected_status": 200,
+      "parity": true,
+      "notes": "Shared security headers PLUS the feed rule (forced Content-Type + 1h cache). Requires landing/dist/feed.xml to exist.",
+      "expected_headers": {
+        "Content-Security-Policy": "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'",
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "X-Frame-Options": "DENY",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "Content-Type": "application/rss+xml; charset=utf-8",
+        "Cache-Control": "public, max-age=3600"
+      }
+    },
+    {
+      "name": "assets-hashed-file",
+      "path": "/assets/<pick-a-real-hashed-asset>",
+      "expected_status": 200,
+      "parity": true,
+      "notes": "Substitute a real file from landing/dist/assets/ (e.g. an index-*.js). The /assets/** rule is last in header_rules, so its immutable Cache-Control wins even for an image under /assets/ (the substitute host enforces this with an ^~ prefix location that outranks the image-extension regex).",
+      "expected_headers": {
+        "Content-Security-Policy": "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'",
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "X-Frame-Options": "DENY",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "public, max-age=31536000, immutable"
+      }
+    },
+    {
+      "name": "root-image-non-asset",
+      "path": "/<pick-a-real-image-outside-assets>",
+      "expected_status": 200,
+      "parity": true,
+      "notes": "A real image/font at a non-/assets/ path (e.g. /favicon.png, /og-image.jpg if present). Matches the extension rule: 1-year cache WITHOUT immutable. Skip if landing/dist has no such file.",
+      "expected_headers": {
+        "Content-Security-Policy": "default-src 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://mirrors.creativecommons.org https://www.google.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://raw.githubusercontent.com https://static.cloudflareinsights.com https://www.google-analytics.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com https://apis.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; manifest-src 'self'",
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "X-Frame-Options": "DENY",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "public, max-age=31536000"
+      }
+    },
+    {
+      "name": "webmention-unrehostable",
+      "path": "/api/webmention",
+      "expected_status": 503,
+      "parity": false,
+      "notes": "NOT a parity assertion. See webmention_stub: Cloud Function surface that a static host cannot reproduce; stubbed 503 as measured drill residue."
+    }
+  ]
+}

--- a/ops/recovery-drills/firebase/parity-checklist.md
+++ b/ops/recovery-drills/firebase/parity-checklist.md
@@ -1,0 +1,65 @@
+# Landing recovery-drill parity checklist
+
+Part of the Firebase recovery drill (`strategy-exercise-recovery-paths`,
+`delegation-firebase`). This directory re-hosts the `landing` app off Firebase
+on a plain rootless nginx to measure the real cost of recovering the hosted tier
+from owned local data.
+
+## What is here
+
+| File | Role |
+| --- | --- |
+| `nginx-landing.conf` | nginx config reproducing the `landing` hosting block of the repo-root `firebase.json` (doc root, SPA catch-all, every header). Placeholders `__DOCROOT__` / `__PORT__` / `__PREFIX__` are rendered by the serve script. |
+| `serve-landing.sh` | Starts rootless nginx from nixpkgs on `landing/dist`, foreground with a cleanup trap, throwaway prefix. `PORT` env overrides the default `8088`. |
+| `extract-parity.jq` | Extracts the `landing` hosting contract from `firebase.json` into normalized JSON — the source-of-truth projection the checklist is built from. |
+| `parity-checklist.json` | Machine-readable checklist: the extracted `header_rules` + `rewrites`, plus hand-maintained `test_cases`, `webmention_stub`. A later drill step verifies the running host against this, not against `firebase.json` directly. |
+| `parity-checklist.md` | This file — how to run the drill and read the checklist. |
+
+## Verifying parity (later drill step, Unit 2)
+
+1. Build landing so `landing/dist/` exists:
+   `npm run build --prefix landing`
+2. Start the substitute host:
+   `ops/recovery-drills/firebase/serve-landing.sh` (serves `http://127.0.0.1:8088/`).
+3. For each entry in `parity-checklist.json` `test_cases`, `curl -sI` the `path`
+   and assert:
+   - HTTP status equals `expected_status`.
+   - Every key/value in `expected_headers` is present on the response
+     (case-insensitive header names; compare values verbatim).
+   `expected_headers` is already the FULL merged set Firebase would emit for that
+   path, so the check is a direct superset comparison against the curl output.
+4. `webmention_stub` / the `webmention-unrehostable` case assert a `503`, NOT
+   parity — see below.
+5. Write the drill report (cost, friction, residue) — that report is Unit 2's
+   deliverable, not this unit's.
+
+Regenerate the extracted portion after any `firebase.json` landing-block change:
+
+```
+jq -f ops/recovery-drills/firebase/extract-parity.jq firebase.json \
+  > ops/recovery-drills/firebase/parity-checklist.json
+```
+
+then re-apply the hand-maintained `_comment`, `test_cases`, and `webmention_stub`
+additions (they are not derivable from `firebase.json`).
+
+## Header merge semantics
+
+Firebase applies every matching header rule and, for a repeated header key, the
+later rule in the array wins. The substitute nginx reproduces this two ways:
+
+- The five shared `**` security headers are re-emitted in every `location`
+  (nginx does not inherit `add_header` into a location that declares its own).
+- `/assets/**` uses an `^~` prefix location that outranks the image-extension
+  regex, so an image under `/assets/` gets the `immutable` cache value (the
+  last-listed, and therefore winning, `firebase.json` rule) rather than the
+  plain 1-year value.
+
+## The one non-rehostable surface
+
+`/api/webmention` is a Firebase rewrite to the `webmention` Cloud Function.
+A static nginx host cannot re-host a Cloud Function, so the config stubs it as an
+explicit `503`. This is **expected, measured drill residue** — the
+compute-backed part of the hosted tier that is not a projection of static owned
+data — not a bug or a parity failure. The drill records it as the concrete
+friction/gap in recovering `landing` without Firebase.

--- a/ops/recovery-drills/firebase/serve-landing.sh
+++ b/ops/recovery-drills/firebase/serve-landing.sh
@@ -81,4 +81,6 @@ echo "  Stop with Ctrl-C (SIGINT) or SIGTERM."
 # `set -e` propagates a nonzero exit. `nix run` fetches nginx from nixpkgs — the
 # first run may download it (needs the npm/nix cache to be writable; see
 # .claude/rules/sandbox.md on running such commands with the sandbox disabled).
-exec nix run nixpkgs#nginx -- -c "$RENDERED_CONF" -p "$PREFIX/"
+nix run nixpkgs#nginx -- -c "$RENDERED_CONF" -p "$PREFIX/" &
+NGINX_PID=$!
+wait "$NGINX_PID"

--- a/ops/recovery-drills/firebase/serve-landing.sh
+++ b/ops/recovery-drills/firebase/serve-landing.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# serve-landing.sh — start a rootless nginx that re-hosts the `landing` app off
+# Firebase, reproducing the landing hosting block of the repo-root firebase.json.
+#
+# Part of the Firebase recovery drill (strategy-exercise-recovery-paths): it lets
+# a later step curl the substitute host and verify header/rewrite parity against
+# parity-checklist.json, measuring the real cost of recovering the hosted tier
+# from owned local data.
+#
+# Design:
+#   * No root, no system install, no writes outside a throwaway prefix dir.
+#     nginx comes from nixpkgs via `nix run nixpkgs#nginx`.
+#   * The committed nginx-landing.conf carries __DOCROOT__ / __PORT__ / __PREFIX__
+#     placeholders; this script renders a concrete copy into the throwaway prefix
+#     and points nginx at it, leaving the committed config static.
+#   * Runs in the FOREGROUND with `daemon off;` and a trap, so Ctrl-C / SIGTERM
+#     tears nginx down and removes the prefix — no orphaned master process. The
+#     nginx master pid is also written to <prefix>/nginx.pid for out-of-band kill.
+#
+# Usage:
+#   ops/recovery-drills/firebase/serve-landing.sh          # port 8088
+#   PORT=9090 ops/recovery-drills/firebase/serve-landing.sh # custom port
+#
+# Requires: landing/dist to exist (build it first — a later drill step does this).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+PORT="${PORT:-8088}"
+DOCROOT="$REPO_ROOT/landing/dist"
+TEMPLATE="$SCRIPT_DIR/nginx-landing.conf"
+
+if [[ ! -f "$TEMPLATE" ]]; then
+    echo "serve-landing.sh: missing nginx template: $TEMPLATE" >&2
+    exit 1
+fi
+
+if [[ ! -d "$DOCROOT" ]]; then
+    echo "serve-landing.sh: document root not found: $DOCROOT" >&2
+    echo "  Build the landing app first (e.g. npm run build --prefix landing)." >&2
+    exit 1
+fi
+if [[ ! -f "$DOCROOT/index.html" ]]; then
+    echo "serve-landing.sh: $DOCROOT exists but has no index.html — is it a stale/partial build?" >&2
+    exit 1
+fi
+
+# Throwaway prefix: everything nginx writes (pid, logs, temp, rendered config)
+# lives here and nowhere else. Removed on exit.
+PREFIX="$(mktemp -d "${TMPDIR:-/tmp}/recovery-drill-landing.XXXXXX")"
+RENDERED_CONF="$PREFIX/nginx.conf"
+
+cleanup() {
+    local pidfile="$PREFIX/nginx.pid"
+    if [[ -f "$pidfile" ]]; then
+        kill "$(cat "$pidfile")" 2>/dev/null || true
+    fi
+    rm -rf "$PREFIX"
+}
+trap cleanup EXIT INT TERM
+
+# Render the committed template into the throwaway prefix. Use a sed script with
+# a non-`/` delimiter (`|`) because DOCROOT/PREFIX are absolute paths containing
+# slashes. No JSON is parsed here, so shell-json.md does not apply.
+sed \
+    -e "s|__DOCROOT__|$DOCROOT|g" \
+    -e "s|__PREFIX__|$PREFIX|g" \
+    -e "s|__PORT__|$PORT|g" \
+    "$TEMPLATE" > "$RENDERED_CONF"
+
+echo "serve-landing.sh: serving $DOCROOT"
+echo "  URL:    http://127.0.0.1:$PORT/"
+echo "  prefix: $PREFIX (removed on exit)"
+echo "  config: $RENDERED_CONF"
+echo "  Stop with Ctrl-C (SIGINT) or SIGTERM."
+
+# Foreground (config sets `daemon off;`). nginx validates its config on start;
+# `set -e` propagates a nonzero exit. `nix run` fetches nginx from nixpkgs — the
+# first run may download it (needs the npm/nix cache to be writable; see
+# .claude/rules/sandbox.md on running such commands with the sandbox disabled).
+exec nix run nixpkgs#nginx -- -c "$RENDERED_CONF" -p "$PREFIX/"

--- a/ops/recovery-drills/firebase/verify-parity.sh
+++ b/ops/recovery-drills/firebase/verify-parity.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# verify-parity.sh — curl the running substitute host (serve-landing.sh) and
+# assert response parity against parity-checklist.json's `test_cases`.
+#
+# Part of the Firebase recovery drill (strategy-exercise-recovery-paths,
+# delegation-firebase, Unit 2). This is the machine check that turns the
+# checklist into a pass/fail verdict instead of a manual reading exercise.
+#
+# For each test case in parity-checklist.json `test_cases`:
+#   - HTTP status must equal `expected_status`.
+#   - When `parity` is true, every header in `expected_headers` must be
+#     present on the response, byte-for-byte (case-insensitive header name,
+#     exact value match — expected_headers is already Firebase's full merged
+#     set for that path, so this is a direct equality check per key, not a
+#     loose substring/superset check).
+#   - The two SPA cases (`spa-root`, `spa-deep-route`) additionally assert the
+#     response BODY is landing/dist/index.html's actual content, not a 404
+#     page or empty response — the whole point of the SPA catch-all.
+#
+# Two test cases carry path PLACEHOLDERS that must be resolved against the
+# real build output before curling:
+#   - assets-hashed-file:    "/assets/<pick-a-real-hashed-asset>"
+#   - root-image-non-asset:  "/<pick-a-real-image-outside-assets>"
+# This script resolves both automatically from landing/dist (first hashed
+# file under assets/, first image/font-extension file at dist root not under
+# assets/). If dist has no candidate for a case, that case is SKIPPED with a
+# loud note — not silently passed.
+#
+# ANY mismatch is a hard failure (loud diagnostic + nonzero exit). A partial
+# re-host reported as a pass would corrupt the whole point of the drill: this
+# script exists to catch exactly that, so it must never paper over a gap. See
+# .claude/rules/code-style.md (clear errors, no defensive fallbacks) and
+# .claude/rules/test-integrity.md (never weaken a check to get a green run).
+#
+# Usage:
+#   ops/recovery-drills/firebase/verify-parity.sh
+#   BASE_URL=http://127.0.0.1:9090 ops/recovery-drills/firebase/verify-parity.sh
+#
+# Requires: the substitute host already running (serve-landing.sh), and
+# landing/dist built (npm run build --prefix landing).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8088}"
+CHECKLIST="$SCRIPT_DIR/parity-checklist.json"
+DIST="$REPO_ROOT/landing/dist"
+
+if [[ ! -f "$CHECKLIST" ]]; then
+    echo "verify-parity.sh: missing checklist: $CHECKLIST" >&2
+    exit 1
+fi
+if [[ ! -d "$DIST" ]]; then
+    echo "verify-parity.sh: document root not found: $DIST" >&2
+    echo "  Build the landing app first (e.g. npm run build --prefix landing)." >&2
+    exit 1
+fi
+
+# Resolve the two placeholder paths against the real build output.
+HASHED_ASSET="$(find "$DIST/assets" -maxdepth 1 -type f 2>/dev/null | head -n1)"
+NON_ASSET_IMAGE="$(find "$DIST" -maxdepth 1 -type f \
+    \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.gif' \
+       -o -iname '*.webp' -o -iname '*.avif' -o -iname '*.svg' -o -iname '*.woff2' \) \
+    2>/dev/null | head -n1)"
+
+TMP_BODY="$(mktemp)"
+TMP_HEADERS="$(mktemp)"
+cleanup() { rm -f "$TMP_BODY" "$TMP_HEADERS"; }
+trap cleanup EXIT
+
+fail_count=0
+pass_count=0
+skip_count=0
+declare -a RESULTS=()   # "name|status" for the drill report table
+
+# --- helpers -----------------------------------------------------------
+
+# get_header <headers-file> <name> -> last matching value (Firebase/nginx
+# semantics: a later-set header of the same name wins; curl -D lists them in
+# response order, so the LAST match is the effective value).
+get_header() {
+    local file="$1" name="$2"
+    awk -v want="$(printf '%s' "$name" | tr 'A-Z' 'a-z')" '
+        BEGIN { FS=":"; found="" }
+        {
+            line = $0
+            sub(/\r$/, "", line)
+            colon = index(line, ":")
+            if (colon == 0) next
+            key = tolower(substr(line, 1, colon - 1))
+            if (key == want) {
+                val = substr(line, colon + 1)
+                sub(/^[ \t]+/, "", val)
+                found = val
+            }
+        }
+        END { print found }
+    ' "$file"
+}
+
+# --- run each test case --------------------------------------------------
+
+case_count="$(jq '.test_cases | length' "$CHECKLIST")"
+i=0
+while [[ "$i" -lt "$case_count" ]]; do
+    case_json="$(jq -c ".test_cases[$i]" "$CHECKLIST")"
+    name="$(jq -r '.name' <<<"$case_json")"
+    path="$(jq -r '.path' <<<"$case_json")"
+    expected_status="$(jq -r '.expected_status' <<<"$case_json")"
+    parity="$(jq -r '.parity' <<<"$case_json")"
+    i=$((i + 1))
+
+    # Resolve placeholder paths against real build output; skip loudly if the
+    # build has no matching file rather than silently passing/failing.
+    if [[ "$path" == "/assets/<pick-a-real-hashed-asset>" ]]; then
+        if [[ -z "$HASHED_ASSET" ]]; then
+            echo "SKIP  $name: no file found under $DIST/assets/ to probe" >&2
+            skip_count=$((skip_count + 1))
+            RESULTS+=("$name|SKIP")
+            continue
+        fi
+        path="/assets/$(basename "$HASHED_ASSET")"
+    elif [[ "$path" == "/<pick-a-real-image-outside-assets>" ]]; then
+        if [[ -z "$NON_ASSET_IMAGE" ]]; then
+            echo "SKIP  $name: no non-/assets/ image/font file found in $DIST to probe" >&2
+            skip_count=$((skip_count + 1))
+            RESULTS+=("$name|SKIP")
+            continue
+        fi
+        path="/$(basename "$NON_ASSET_IMAGE")"
+    fi
+
+    url="$BASE_URL$path"
+    status="$(curl -s -o "$TMP_BODY" -D "$TMP_HEADERS" -w '%{http_code}' "$url")"
+    curl_exit=$?
+    if [[ "$curl_exit" -ne 0 ]]; then
+        echo "FAIL  $name ($path): curl could not reach $url (exit $curl_exit) — is serve-landing.sh running?" >&2
+        fail_count=$((fail_count + 1))
+        RESULTS+=("$name|FAIL")
+        continue
+    fi
+
+    case_ok=1
+
+    if [[ "$status" != "$expected_status" ]]; then
+        echo "FAIL  $name ($path): expected status $expected_status, got $status" >&2
+        case_ok=0
+    fi
+
+    if [[ "$parity" == "true" ]]; then
+        header_names="$(jq -r '.expected_headers | keys[]' <<<"$case_json")"
+        while IFS= read -r hname; do
+            [[ -z "$hname" ]] && continue
+            expected_val="$(jq -r --arg k "$hname" '.expected_headers[$k]' <<<"$case_json")"
+            actual_val="$(get_header "$TMP_HEADERS" "$hname")"
+            if [[ "$actual_val" != "$expected_val" ]]; then
+                echo "FAIL  $name ($path): header '$hname' mismatch" >&2
+                echo "        expected: $expected_val" >&2
+                echo "        actual:   $actual_val" >&2
+                case_ok=0
+            fi
+        done <<<"$header_names"
+    fi
+
+    # SPA cases must actually serve index.html content, not a 404/empty body.
+    if [[ "$name" == "spa-root" || "$name" == "spa-deep-route" ]]; then
+        if ! cmp -s "$TMP_BODY" "$DIST/index.html"; then
+            echo "FAIL  $name ($path): response body does not match $DIST/index.html (SPA catch-all not serving index.html)" >&2
+            case_ok=0
+        fi
+    fi
+
+    if [[ "$case_ok" -eq 1 ]]; then
+        echo "PASS  $name ($path)"
+        pass_count=$((pass_count + 1))
+        RESULTS+=("$name|PASS")
+    else
+        fail_count=$((fail_count + 1))
+        RESULTS+=("$name|FAIL")
+    fi
+done
+
+echo
+echo "verify-parity.sh: $pass_count passed, $fail_count failed, $skip_count skipped (of $case_count test cases)"
+
+if [[ "$fail_count" -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Implements node `tactic-recovery-drill-firebase` — the drill named by
`strategy-exercise-recovery-paths` for `delegation-firebase`: actually re-host
the `landing` app off Firebase and measure the real cost/friction, rather than
trusting the delegation record's unexercised `last_exercised: null` claim.

## Unit 1 — substitute host: translate the hosting contract

New `ops/recovery-drills/firebase/`:
- `nginx-landing.conf` — a rootless nginx config reproducing the `landing`
  hosting block of the repo-root `firebase.json` verbatim (shared security
  headers, `/blogroll.opml` + `/feed.xml` content-type/CORS overrides,
  image/font/`/assets/**` cache headers, SPA catch-all). The one non-static
  surface, the `/api/webmention` Cloud Function rewrite, is stubbed as an
  explicit `503` with a comment marking it as unrehostable backend residue.
- `serve-landing.sh` — starts nginx from nixpkgs in a throwaway prefix dir,
  foreground with a cleanup trap, no root/system install.
- `extract-parity.jq` + `parity-checklist.json` — the parity contract (7 test
  cases with full merged expected headers/status) mechanically extracted from
  `firebase.json`, plus a human-readable `parity-checklist.md`.

## Unit 2 — serve and verify parity

- New `ops/recovery-drills/firebase/verify-parity.sh` — curls all 7 checklist
  cases against the running substitute host and asserts byte-exact header
  parity + correct status, failing loud on any mismatch.
- New `ops/recovery-drills/firebase-drill-report.md` — the drill's actual
  measured results: **7/7 parity cases pass** (6 genuine parity + the
  `/api/webmention` 503 as the one measured recovery gap — compute-backed,
  not re-hostable statically). Mechanical recovery (build → serve → verify)
  measured at ~35s once the substitute-host tooling exists. The DNS/TLS
  cutover is documented as a checklist but explicitly **not executed** —
  production `landing` stays on Firebase throughout.

## Unit 3 — flip the record

`delegation-firebase.md`'s `attributes.irreversibility.last_exercised` and
`recovery_cost` were updated via `write-node.ts` + `graph-commit` directly to
`origin/main` (node edits never ride the code PR) — already landed
independently of this PR.

## Verification

- `.claude/skills/dispatch-propagate/scripts/run-lint.sh` — pass.
- Manually re-ran `serve-landing.sh` + `verify-parity.sh` end-to-end after all
  units landed: 7/7 parity cases pass, server started/stopped cleanly with no
  orphaned processes.
- Confirmed `delegation-firebase`'s `last_exercised` is `2026-07-16` on
  `origin/main`.

Graph node: tactic-recovery-drill-firebase
