### PR TITLE
recovery drill: GitHub export/import round-trip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ result
 
 # dispatch-review-erosion temp dirs (cleaned up by trap, but excluded if SIGKILL)
 .erosion-baseline.*
+
+# recovery-drill raw JSON archives (ops/recovery-drills/github-export.sh) — large
+# per-run API dumps; only the summary archives-manifest.json is committed.
+ops/recovery-drills/archives/
 .erosion-jscpd-head.*
 .erosion-jscpd-base.*
 

--- a/ops/recovery-drills/archives-manifest.json
+++ b/ops/recovery-drills/archives-manifest.json
@@ -1,0 +1,16 @@
+{
+  "repo": "natb1/commons.systems",
+  "exported_at": "20260716T040733Z",
+  "archive_dir": "archives/20260716T040733Z",
+  "note": "Raw JSON archive is gitignored (ops/recovery-drills/archives/). Secrets are a known non-exportable gap — workflow file names are exported, secret values cannot be read back through the API by design.",
+  "counts": {
+    "issues": 0,
+    "issue_comments": 6343,
+    "pull_requests": 1312,
+    "releases": 0,
+    "workflows": 16,
+    "sub_issue_edges": 0,
+    "blocked_by_edges": 0,
+    "blocking_edges": 0
+  }
+}

--- a/ops/recovery-drills/github-drill-report.md
+++ b/ops/recovery-drills/github-drill-report.md
@@ -1,0 +1,135 @@
+# GitHub recovery drill — export → substitute-forge import round-trip
+
+Exercises the recovery path recorded on `intentions/delegation-github.md`
+(`recovery_path: re-host — git is portable by design; issues/PR relationships
+export via API; Actions workflows would need porting to another runner`). The
+drill stands up a substitute forge, loads it with this repo's GitHub data using
+the substitute's *own* migration tooling, and measures what survives. Per the
+strategy's scope note it stops short of production cutover — the forge is stood
+up, loaded, and inspected, not adopted.
+
+## Run metadata
+
+- **Drill date:** 2026-07-16
+- **Export (Unit 1) captured at:** 2026-07-16T04:07:33Z (`archives-manifest.json`)
+- **Import (Unit 2) run at:** 2026-07-16T04:14–04:34Z
+- **Effort:** ~30 min active wall-clock for the import leg (Gitea stand-up ~5
+  min; migration ~15 min of unattended import before it hit the rate-limit wall
+  and was halted). A *complete* import would have taken >1 hour because of
+  GitHub REST rate-limit backoff (see friction below).
+- **Substitute forge:** Gitea 1.26.4 (`nix build nixpkgs#gitea`, no Docker),
+  SQLite backend, throwaway data dir under `ops/recovery-drills/archives/`
+  (gitignored), listening on `127.0.0.1:3939`. Process stopped and data dir
+  removed at end of drill.
+- **Import mechanism:** Gitea's built-in GitHub migrator (`POST
+  /api/v1/repos/migrate`, `service: github`), authenticated with the
+  interactive `gh` CLI token. Deliberately the forge's own tooling, not a
+  bespoke importer — the drill measures what a real substitute preserves.
+
+## Survived / lost table
+
+Exported counts are from the Unit 1 manifest (`archives-manifest.json`).
+Imported counts are read directly from Gitea's SQLite tables at the point the
+migration was halted.
+
+| Entity | Exported (manifest) | Imported (Gitea) | Verdict |
+|---|---|---|---|
+| Non-PR issues | 0 | 0 | N/A — none exist (tracking migrated to `intentions/`) |
+| Pull requests | 1312 | 1317 | **Survived (full).** +5 is live drift: the fleet opened 5 PRs in the export→import gap. PR bodies + state spot-checked and render. |
+| PR / issue comments | 6343 | 1196 (and climbing when halted) | **Survives faithfully, throughput-bound.** Comments imported correctly; the count is partial only because the run was halted at the rate-limit wall, not because comments are dropped. |
+| PR reviews (threads) | (not counted in manifest) | 5 (stalled) | **Partial — this is where the REST budget ran out.** Per-PR review fetch is the rate-limit killer (~1 call/PR × 1317). |
+| Labels | (not counted) | 60 | **Survived.** |
+| Milestones | (not counted) | 0 | N/A — none exist. |
+| Releases | 0 | 2 | **Over-count, not loss.** Gitea auto-registers git tags as tag-releases (`last-prod-deploy`, `archive/896-…`). No GitHub Releases existed; these are tag artifacts. |
+| Workflow files (as files) | 16 registered / 8 live `.yml` in HEAD | 8/8 present in migrated git repo | **Survived as files** (git content is 100%). They do **not execute** in Gitea — see porting cost. (Manifest's 16 is the Actions API `total_count`, which includes deleted workflows + the dynamic CodeQL entry; only 8 live files exist in HEAD.) |
+| Sub-issue edges | 0 | 0 (unsupported) | **Capability gap, no data lost.** Gitea's migrator predates GitHub's sub-issues API and imports none. 0 existed here. |
+| Issue dependency edges (blocked_by / blocking) | 0 | 0 (`issue_dependency` table empty) | **Capability gap, no data lost.** Gitea's migrator does not import GitHub issue dependencies. 0 existed — dependencies live in the graph's own `blocked_by` field, not GitHub. |
+| Git history / branches | (out of scope for export — mirrored clones exist) | Full clone (47 MB) imported | **Survived (trivial leg).** This is `delegation-github`'s `non_delegable_floor`; `git clone --mirror` is the easy part. |
+| Actions run history / logs / check status | not exportable via API | not imported | **Lost.** No migrator imports this; it is GitHub-only and unrecoverable through a forge migration. |
+| Secrets | not exportable (known gap) | n/a | **Lost by design** — API cannot read secret values back. Noted in Unit 1 manifest. |
+
+## Measured recovery friction
+
+**Easy / worked cleanly:**
+- Standing up Gitea from nixpkgs (no Docker) and initializing it non-interactively
+  (`gitea migrate` + `gitea admin user create` + generated access token): minutes.
+- The git leg: full `git clone` of the 47 MB repo completed instantly and the
+  working tree (including all 8 `.github/workflows/*.yml`) is intact in the
+  migrated repo.
+- Kicking off the import is a single authenticated API call; Gitea runs it as an
+  async task and imports repo + PRs + labels + comments + reviews with its own
+  tooling. No bespoke import code was written — exactly the point of the drill.
+- Data fidelity where it imported: PR titles/bodies/state, comment bodies, and
+  labels all render correctly.
+
+**Needed intervention / hit a wall (the headline finding):**
+- **The migration exhausted the entire 5000-request/hour GitHub REST rate limit
+  before finishing.** It consumed ~4650 REST calls reaching the per-PR review
+  phase, then drained the bucket to **0/5000** and stalled with reviews only 5
+  of ~1300 done. The per-PR review/thread fetch (~1 call per PR × 1317 PRs) is
+  the cost driver that overruns the hourly budget.
+- Because Gitea's downloader backs off and sleeps until the rate-limit reset,
+  a *complete* import of this repo (1312 PRs + 6343 comments + per-PR reviews)
+  must span **multiple hourly reset windows** — turning a ~20-minute job into a
+  multi-hour one. The drill was halted at the wall rather than left to drain
+  reset windows, both because the measurement was already conclusive and to
+  protect the shared token budget.
+- **Shared-token blast radius:** the import ran on the interactive `gh` CLI
+  token, which shares the same 5000/hr REST bucket as the live dispatch fleet.
+  A real recovery must use a **dedicated PAT** so the migration's rate-limit
+  consumption does not starve concurrent automation. This is a concrete
+  tooling/process gap, not a theoretical one — the drill measurably drove the
+  shared bucket to zero.
+- Minor, expected: Gitea logged `GetBranchCommitID: can't find commit ID for
+  head` warnings for PRs whose source branches were deleted after merge. The PR
+  record and diff still import; only the live head ref is absent (it lives in
+  git history, not as a branch). Non-issue for an archival re-host.
+
+## Residual dependence assessment
+
+**What GitHub still uniquely holds for this project.** The intention graph
+(`intentions/`, 378 nodes) is now the source-of-truth issue tracker, and the
+export confirms it: **0 non-PR GitHub issues exist.** So the classic "issue
+tracker" dependence is already gone — issues are local Markdown, versioned in
+git, and would survive GitHub's disappearance untouched. The load-bearing
+GitHub-only residual has shrunk to three things:
+
+1. **Pull requests (1312).** The review/merge substrate the dispatch chain
+   drives. Gitea's migrator imports the PR records, bodies, and diffs faithfully
+   — so the *history* re-hosts. The fragile parts are (a) in-flight open/draft
+   PRs mid-workflow, and (b) per-PR review threads, which are exactly what the
+   rate limit throttled.
+2. **CI execution and its history.** This is the genuine, non-mechanical loss.
+   Workflow *files* migrate as text but **do not run** in Gitea, and Actions
+   **run history, logs, and check-status are not exported at all** — no migrator
+   recovers them. Re-establishing CI means porting 8 workflow files to Gitea
+   Actions (or another runner): they use 2 distinct third-party actions
+   (`DeterminateSystems/nix-installer-action`, `softprops/action-gh-release`)
+   plus 5 first-party `actions/*` (`checkout`, `cache`, `setup-node`,
+   `setup-go`, `setup-java`) that Gitea Actions largely mirrors. Porting is
+   hours of rewriting `uses:` references and validating the Nix-based build
+   steps — bounded, but real.
+3. **PR/issue comments (6343).** The dispatch chain posts plan, status, QA, and
+   review comments on PRs — the audit trail of autonomous work. These migrate,
+   but slowly (rate-limit-bound), and historical CI-status comments reference
+   runs that no longer exist post-migration.
+
+**What the dispatch/build chain would actually lose today if GitHub vanished:**
+- **Not** the issue graph — it is local in `intentions/*.md` and git-versioned.
+- **Not** the git history — mirrored clones exist on local machines at all times
+  (`non_delegable_floor`); this is the trivial leg.
+- **Would lose:** live CI execution (until 8 workflows are ported to a new
+  runner), all historical CI run logs/status (unrecoverable), and it would face
+  a **multi-hour, rate-limited re-import** of the PR + comment corpus before the
+  substitute forge holds the full review/audit history.
+
+**Measured recovery cost (for the record flip).** Substitute-forge stand-up:
+minutes. Git re-host: trivial (mirror clones already exist). PR + comment
+corpus re-host: **multi-hour, rate-limit-bound** (spans several 5000/hr windows
+for 1312 PRs + 6343 comments + per-PR reviews; requires a dedicated PAT to avoid
+starving live automation). CI: the real porting cost — 8 workflow files to a new
+runner. Net: **hours-to-about-a-day of migration work, dominated by CI porting
+and the rate-limited PR/comment re-import; the issue graph and git history carry
+near-zero recovery cost.** Structural capability gaps (sub-issue and dependency
+edges are not imported by Gitea's migrator) cost nothing here because those
+edges are unused — dependencies live in the graph's own `blocked_by` field.

--- a/ops/recovery-drills/github-export.sh
+++ b/ops/recovery-drills/github-export.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# github-export.sh — GitHub-graph recovery-drill exporter.
+#
+# Walks the "delegation-github" irreversibility drill: exports this repo's issue
+# and PR graph via the GitHub REST API into a timestamped local archive of raw
+# JSON pages, then writes a small COMMITTED summary manifest with per-entity
+# counts from the most recent run. Unit 2 imports the archive into a substitute
+# forge and diffs what survived; Unit 3 flips the delegation record.
+#
+# Design notes:
+#   - REST only, never GraphQL: bulk pulls exhaust the GraphQL 5000/hr bucket
+#     (see .claude/rules/sandbox.md "dispatch GitHub GraphQL bucket exhaustion").
+#     `gh api --paginate` on REST list endpoints follows Link headers with no
+#     silent truncation.
+#   - Fail loud: `set -euo pipefail`, every non-200 aborts (no silent
+#     fallbacks) per .claude/rules/code-style.md.
+#   - JSON handling never pipes a captured shell variable through `echo` into
+#     `jq` — we use `jq <<<"$VAR"`, `gh ... --jq`, direct pipes, or files on
+#     disk (see .claude/rules/shell-json.md).
+#
+# Known non-exportable gap (NOT a bug): repository secrets (Actions/Dependabot
+# secrets) cannot be read back through the API by design. We export the workflow
+# FILE LIST only; secret VALUES are a permanent recovery gap the drill records.
+#
+# Out of scope here: git-data mirroring. The git object graph itself is already
+# fully replicated by every local clone/worktree — that is the drill's
+# non-delegable floor and needs no API export. This script covers only the
+# GitHub-hosted metadata layered on top of the git data.
+
+set -euo pipefail
+
+REPO="natb1/commons.systems"
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARCHIVES_DIR="$SCRIPT_DIR/archives"
+MANIFEST="$SCRIPT_DIR/archives-manifest.json"
+
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT_DIR="$ARCHIVES_DIR/$TIMESTAMP"
+
+# ---------------------------------------------------------------------------
+# gh helpers — mirror the conventions in
+# .claude/skills/dispatch-propagate/scripts/lib.sh (gh_retry / gh_api_array).
+# We reimplement a trimmed copy here rather than sourcing that file so this
+# recovery-drill script stays self-contained (the whole point of the drill is
+# that it must run even when the surrounding tooling is being reconstituted).
+# ---------------------------------------------------------------------------
+
+# Classify a captured gh stderr blob as transient (retryable). Deterministic
+# failures (404/401/403/422, bare primary rate limit) fail fast.
+_gh_error_is_transient() {
+  local stderr="$1"
+  printf '%s' "$stderr" | grep -qiE \
+    'HTTP 5[0-9][0-9]|Bad Gateway|Gateway Time-?out|Service Unavailable|Internal Server Error|timed out|\btimeout\b|i/o timeout|deadline exceeded|connection reset|TLS handshake|secondary rate limit|abuse detection|retry your request|temporarily unavailable'
+}
+
+# gh_retry <cmd...> — run a gh command, retrying transient failures with
+# exponential backoff. On success prints stdout; on deterministic failure or
+# exhausted attempts forwards stderr and returns the real exit code.
+gh_retry() {
+  local attempts="${GH_RETRY_ATTEMPTS:-4}"
+  local delay="${GH_RETRY_BASE_DELAY:-2}"
+  local attempt out rc err tmpfile
+  tmpfile=$(mktemp) || { echo "error: could not create temp file" >&2; return 1; }
+  for (( attempt=1; attempt<=attempts; attempt++ )); do
+    out=$("$@" 2>"$tmpfile")
+    rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+      printf '%s\n' "$out"
+      rm -f "$tmpfile"
+      return 0
+    fi
+    err=$(cat "$tmpfile")
+    if [[ "$attempt" -ge "$attempts" ]] || ! _gh_error_is_transient "$err"; then
+      printf '%s' "$err" >&2
+      rm -f "$tmpfile"
+      return "$rc"
+    fi
+    echo "gh_retry: transient gh failure (attempt $attempt/$attempts), retrying in ${delay}s" >&2
+    sleep "$delay"
+    delay=$(( delay * 2 ))
+  done
+  rm -f "$tmpfile"
+  return 1
+}
+
+# fetch_paginated <api_path> <out_file> — fetch ALL pages of a REST list
+# endpoint (per_page=100, --paginate follows Link headers) into a single JSON
+# file on disk. --paginate concatenates the page arrays into one JSON array.
+# Fails loud on any non-2xx response (gh api exits non-zero → gh_retry forwards).
+fetch_paginated() {
+  local api_path="$1" out_file="$2"
+  echo "  fetch (paginated): $api_path" >&2
+  gh_retry gh api --paginate --cache 0 \
+    "$api_path" > "$out_file"
+}
+
+# fetch_single <api_path> <out_file> — fetch a single (non-list) endpoint.
+fetch_single() {
+  local api_path="$1" out_file="$2"
+  echo "  fetch (single): $api_path" >&2
+  gh_retry gh api --cache 0 "$api_path" > "$out_file"
+}
+
+# count_json <file> <jq_len_filter> — count entities in a saved JSON file.
+# Reads from the file (no captured-variable echo), so shell-json rule is safe.
+count_json() {
+  local file="$1" filter="${2:-length}"
+  jq "$filter" "$file"
+}
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+echo "recovery-drill github-export: repo=$REPO archive=$OUT_DIR" >&2
+mkdir -p "$OUT_DIR"
+
+# 1. Issues (all states) — bodies, labels, milestones are embedded in the issue
+#    objects. NOTE: GitHub's issues endpoint also returns PRs; we keep the raw
+#    dump as-is and additionally pull PRs explicitly below. Counts below exclude
+#    PR rows from the issue count via the `.pull_request` discriminator.
+fetch_paginated "/repos/$OWNER/$NAME/issues?state=all&per_page=100" \
+  "$OUT_DIR/issues.json"
+
+# 2. Issue comments (repo-wide, all issues) — single bulk endpoint.
+fetch_paginated "/repos/$OWNER/$NAME/issues/comments?per_page=100" \
+  "$OUT_DIR/issue-comments.json"
+
+# 3. Pull requests (all states) — bodies embedded. Review threads are
+#    best-effort / optional and are NOT pulled here (they would require a
+#    per-PR fan-out; Unit 2 can decide whether the diff needs them).
+fetch_paginated "/repos/$OWNER/$NAME/pulls?state=all&per_page=100" \
+  "$OUT_DIR/pulls.json"
+
+# 4. Sub-issue relationships and dependencies (blocked_by / blocking), per
+#    issue. These are per-issue endpoints (no repo-wide bulk endpoint exists),
+#    so we fan out over the issue numbers we just pulled. See
+#    .claude/skills/ref-github-issues/SKILL.md for the endpoint shapes.
+#    We record one relationships file keyed by issue number.
+echo "  fetch: sub-issue + dependency relationships (per-issue fan-out)" >&2
+RELATIONSHIPS="$OUT_DIR/relationships.json"
+: > "$OUT_DIR/relationships.ndjson"
+
+# Extract issue numbers (exclude PRs via .pull_request) from the saved dump.
+# Read numbers from the file into an array — no echo-into-jq.
+mapfile -t ISSUE_NUMBERS < <(jq -r '.[] | select(has("pull_request") | not) | .number' "$OUT_DIR/issues.json")
+
+for num in "${ISSUE_NUMBERS[@]}"; do
+  sub_file="$OUT_DIR/.rel-sub-$num.json"
+  blocked_file="$OUT_DIR/.rel-blocked-$num.json"
+  blocking_file="$OUT_DIR/.rel-blocking-$num.json"
+  # Each endpoint returns a JSON array; a missing relationship set returns [].
+  gh_retry gh api --paginate --cache 0 \
+    "/repos/$OWNER/$NAME/issues/$num/sub_issues?per_page=100" > "$sub_file"
+  gh_retry gh api --paginate --cache 0 \
+    "/repos/$OWNER/$NAME/issues/$num/dependencies/blocked_by?per_page=100" > "$blocked_file"
+  gh_retry gh api --paginate --cache 0 \
+    "/repos/$OWNER/$NAME/issues/$num/dependencies/blocking?per_page=100" > "$blocking_file"
+  # Fold the three per-issue arrays into one NDJSON row. jq reads the files
+  # directly (no captured-variable echo); --argjson pulls each file in.
+  jq -n \
+    --arg number "$num" \
+    --slurpfile subs "$sub_file" \
+    --slurpfile blocked_by "$blocked_file" \
+    --slurpfile blocking "$blocking_file" \
+    '{number: ($number|tonumber),
+      sub_issues: $subs[0],
+      blocked_by: $blocked_by[0],
+      blocking: $blocking[0]}' >> "$OUT_DIR/relationships.ndjson"
+  rm -f "$sub_file" "$blocked_file" "$blocking_file"
+done
+# Collapse the NDJSON stream into one JSON array for the archive.
+jq -s '.' "$OUT_DIR/relationships.ndjson" > "$RELATIONSHIPS"
+rm -f "$OUT_DIR/relationships.ndjson"
+
+# 5. Releases.
+fetch_paginated "/repos/$OWNER/$NAME/releases?per_page=100" \
+  "$OUT_DIR/releases.json"
+
+# 6. Repo metadata: workflow FILE LIST only (names of .github/workflows/*.yml).
+#    We do NOT export secrets — see the header "Known non-exportable gap".
+fetch_single "/repos/$OWNER/$NAME/actions/workflows" \
+  "$OUT_DIR/workflows.json"
+
+# 7. Repo metadata object (name, default branch, visibility, timestamps).
+fetch_single "/repos/$OWNER/$NAME" \
+  "$OUT_DIR/repo.json"
+
+# ---------------------------------------------------------------------------
+# Counts + committed manifest
+# ---------------------------------------------------------------------------
+
+ISSUE_COUNT=$(jq '[.[] | select(has("pull_request") | not)] | length' "$OUT_DIR/issues.json")
+ISSUE_COMMENT_COUNT=$(count_json "$OUT_DIR/issue-comments.json")
+PR_COUNT=$(count_json "$OUT_DIR/pulls.json")
+RELEASE_COUNT=$(count_json "$OUT_DIR/releases.json")
+WORKFLOW_COUNT=$(jq '.total_count' "$OUT_DIR/workflows.json")
+# Relationship edge counts, summed across issues.
+SUBISSUE_EDGES=$(jq '[.[].sub_issues | length] | add // 0' "$RELATIONSHIPS")
+BLOCKED_BY_EDGES=$(jq '[.[].blocked_by | length] | add // 0' "$RELATIONSHIPS")
+BLOCKING_EDGES=$(jq '[.[].blocking | length] | add // 0' "$RELATIONSHIPS")
+
+echo "recovery-drill github-export: writing manifest $MANIFEST" >&2
+jq -n \
+  --arg repo "$REPO" \
+  --arg timestamp "$TIMESTAMP" \
+  --arg archive "archives/$TIMESTAMP" \
+  --argjson issues "$ISSUE_COUNT" \
+  --argjson issue_comments "$ISSUE_COMMENT_COUNT" \
+  --argjson pulls "$PR_COUNT" \
+  --argjson releases "$RELEASE_COUNT" \
+  --argjson workflows "$WORKFLOW_COUNT" \
+  --argjson sub_issue_edges "$SUBISSUE_EDGES" \
+  --argjson blocked_by_edges "$BLOCKED_BY_EDGES" \
+  --argjson blocking_edges "$BLOCKING_EDGES" \
+  '{
+    repo: $repo,
+    exported_at: $timestamp,
+    archive_dir: $archive,
+    note: "Raw JSON archive is gitignored (ops/recovery-drills/archives/). Secrets are a known non-exportable gap — workflow file names are exported, secret values cannot be read back through the API by design.",
+    counts: {
+      issues: $issues,
+      issue_comments: $issue_comments,
+      pull_requests: $pulls,
+      releases: $releases,
+      workflows: $workflows,
+      sub_issue_edges: $sub_issue_edges,
+      blocked_by_edges: $blocked_by_edges,
+      blocking_edges: $blocking_edges
+    }
+  }' > "$MANIFEST"
+
+echo "recovery-drill github-export: done." >&2
+jq '.counts' "$MANIFEST" >&2


### PR DESCRIPTION
Walks the GitHub recovery path for `delegation-github` (recovery drill: one
export/import round-trip of the issue/PR graph), per `strategy-exercise-recovery-paths`.

## What this does

- **Unit 1** — `ops/recovery-drills/github-export.sh`: exports this repo's
  issue/PR graph via `gh api` REST endpoints (issues, PR, comments, sub-issue
  and dependency relationships, releases, workflow file list) into a
  timestamped gitignored archive, plus a committed count manifest
  (`ops/recovery-drills/archives-manifest.json`).
- **Unit 2** — `ops/recovery-drills/github-drill-report.md`: stands up a local
  Gitea, imports the archived data using Gitea's own GitHub-migration tooling
  (not a bespoke importer), and measures what survived vs. was lost. Headline
  finding: PRs/labels/comments/git-content import faithfully, but a full
  import of this repo's 1312 PRs would exhaust the GitHub REST 5000/hr rate
  limit and span multiple hourly windows. Sub-issue/dependency edges are not
  imported by Gitea's migrator (moot here — this repo's dependencies live in
  the intention graph's own `blocked_by`, not GitHub). CI execution/history
  does not migrate at all — porting 8 workflow files to a new runner is the
  real recovery cost.
- **Unit 3** — flips `intentions/delegation-github.md`'s
  `attributes.irreversibility.last_exercised` and `recovery_cost` with the
  measured result. This landed directly on `main` via `graph-commit` (state-only
  fast path; node edits never ride the code PR) — already merged as
  `95607999` before this PR opened, so it is not part of this diff.

Per the strategy's scope note, the drill stops short of production cutover:
the substitute forge was stood up, loaded, and inspected, not adopted (and was
torn down at the end of the drill).
