### PR TITLE
frozen-node dispatch: selector selects and ranks frozen (draft/soft-frozen) tactics, resolves strategy entry to highest-ranked descendant, /align-tactics accepts a tactic target

### DIFF
--- a/.claude/skills/align-tactics/SKILL.md
+++ b/.claude/skills/align-tactics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: align-tactics
-description: Autonomously break a recorded `strategy-*` intention node into PR-sized tactic subtrees carrying full clean-session plans — the graph-native successor to `/plan-issue` and `/file-issue`'s epic-structuring role. Two-sided drift review, decompose to the signal, plan each claude-eligible tactic into its node body, park the rest; lands via `graph-commit`. Never files a GitHub issue; never `AskUserQuestion` mid-run.
+description: Autonomously break a recorded `strategy-*` intention node into PR-sized tactic subtrees carrying full clean-session plans, or finalize/re-plan a single frozen `tactic-*` node directly — the graph-native successor to `/plan-issue` and `/file-issue`'s epic-structuring role. Two-sided drift review, decompose to the signal, plan each claude-eligible tactic into its node body, park the rest; lands via `graph-commit`. Never files a GitHub issue; never `AskUserQuestion` mid-run.
 user-invocable: true
 ---
 
@@ -38,21 +38,30 @@ It inherits along two axes, each with a part it deliberately does **not** take:
 
 ## Trigger and input
 
-On-demand or router-invoked. The sole argument is the id of the strategy to
-decompose: `/align-tactics strategy-<slug>`. With no argument, stop and report
-that a strategy id is required — this skill never selects its own target.
+On-demand or router-invoked. The sole argument is a node id, either:
+
+- `/align-tactics strategy-<slug>` — decompose a recorded strategy into its
+  executable tactic subtree (Steps 1–5 below), or
+- `/align-tactics tactic-<slug>` — finalize or re-plan a single **frozen**
+  tactic (draft/raw, or soft-frozen — the router selects exactly the tactics
+  its `frozenTacticSelectable` gate approves,
+  `packages/intentionsutil/src/router.ts:482`). This is the per-node target
+  path (see "Tactic target — per-node finalize or re-plan", below).
+
+With no argument, stop and report that a node id (`strategy-<slug>` or
+`tactic-<slug>`) is required — this skill never selects its own target.
 
 ## Step 0 — Claim and isolate
 
-Before the first write, claim the target strategy's node id and author in
-its worktree — the same uniform node-id reservation discipline the router's
-fan-out workers follow (`strategy-graph-native-dispatch`'s 2026-07-06
+Before the first write, claim the target node id (strategy or tactic) and
+author in its worktree — the same uniform node-id reservation discipline the
+router's fan-out workers follow (`strategy-graph-native-dispatch`'s 2026-07-06
 concurrency-safety clarification). Never author in the shared `main`
 checkout: a concurrent session's dirty tracked file blocks this run's
 `graph-commit` rebase, and a stale read races live phase state.
 
-1. **Resolve the target node id** — the `strategy-<slug>` argument (this
-   skill never selects its own target).
+1. **Resolve the target node id** — the `strategy-<slug>` or `tactic-<slug>`
+   argument (this skill never selects its own target).
 2. **Check the claim.** If `<project-root>/.claude/worktrees/<node-id>`
    already exists with a live session — `worktree_has_live_session <path>`
    (`.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh:15`,
@@ -67,6 +76,74 @@ checkout: a concurrent session's dirty tracked file blocks this run's
    primitive — and do all authoring and the step-5 `graph-commit` from
    there. The worktree **is** the claim: the same live-session ⇔ worktree
    liveness rule the router uses, so no separate lock is needed.
+
+## Tactic target — per-node finalize or re-plan
+
+When the argument is a `tactic-<slug>` (not a `strategy-<slug>`), this session
+operates on **exactly one pre-existing tactic node** — the router queued it
+because its `frozenTacticSelectable` gate approved it as an `align-tactics`
+candidate (`packages/intentionsutil/src/router.ts:482`;
+`resolveFrozenDescendant` at line 453 is the strategy-side inverse the selector
+uses). There is **no** strategy decomposition, no draft sweep, and no `rounds`
+bump here — Steps 1–5 below are the strategy-target flow; this subsection is the
+parallel tactic-target flow, reusing pieces of them **by reference**. It runs
+the same Step 0 claim/worktree mechanics (keyed on the tactic id) and the same
+Autonomy contract (below).
+
+A frozen tactic target is **either** draft/raw or soft-frozen; read its
+frontmatter to tell which:
+
+- **Draft/raw** (`phase` absent — `phase: null`, never decomposed) →
+  **finalize** it. This is Step 3 ("Plan each claude-eligible tactic") applied
+  to exactly this **one** tactic: run the Explore/Plan fan-out (or, for a
+  trivial tactic, write the plan directly), landing it at `phase: implement`
+  with a full clean-session plan in its body per the Step-3 plan schema. Do
+  **NOT** sweep the serving strategy's other draft tactics — that draft
+  consume/split/merge/prune path is the strategy-target flow's job (Step 2 item
+  2). Do **NOT** bump the strategy's `rounds` counter — round accounting is
+  completion-time and prod-verified (see "Strategy round accounting" in Step 5).
+  **Whole-node reconcile** (clarification 32, per "Re-evaluation mode" item 2):
+  rewrite any stale draft narrative in `statement`, `rationale`,
+  `attention.rationale`, and the body so none of it contradicts the finalized
+  state — **while preserving the authored `attention.boost` value** (do not
+  reset or renumber it). Frontmatter on landing: `status: codified`,
+  `phase: implement`, `execution: null`, and `validates: []` unless this tactic
+  itself produces the strategy's signal reading (in which case
+  `validates: [<strategy-id>]`, the Step 2 item 5 convention).
+
+- **Soft-frozen** (`phase` already set to an in-flight value — `implement`,
+  `fix`, `qa` — but its `execution.strategy_fingerprint` entry for one serving
+  strategy is stale) → **re-plan** it. This is exactly "## Re-evaluation mode"
+  (below) applied to this **one** tactic instead of a strategy-wide open-child
+  sweep. Reconcile the whole node against the current serving-strategy substance
+  (the whole-node reconciliation bar, clarification 32, per Re-evaluation mode
+  item 2), re-stamp **only** the re-evaluated strategy's entry in
+  `execution.strategy_fingerprint` and leave every other serving strategy's
+  entry untouched (Re-evaluation mode item 3 — a tactic still at
+  `execution: null` has no map to re-stamp), and land via `graph-commit`.
+
+**Both cases land the single pre-existing node** via `graph-commit --base` —
+dump it first with `dump-node.ts`, the exact Step-5 "Capture a base manifest"
+mechanic, so a stale read of a live node is refused mechanically:
+
+```bash
+BASE=$(npx tsx packages/intentionsutil/scripts/dump-node.ts \
+  --out-dir "$TMPDIR/dump" <tactic-id>)
+packages/intentionsutil/scripts/graph-commit --base "$BASE" <tactic-id>
+```
+
+There is **no strategy edit** in either case — a per-node tactic-target session
+never touches the serving strategy's frontmatter (`rounds`, clarifications, or
+otherwise), in contrast to the strategy-target flow, which may. If a
+tactic-target session discovers the strategy's own record needs an edit, that is
+a record-completeness defect to name in a park (see the Autonomy contract's
+unrecorded-context framing), not something this session writes onto the
+strategy.
+
+**Autonomy contract binds unchanged.** A tactic target that hits requirement
+ambiguity, major scope deviation, or an unverifiable blocker parks the
+**tactic** node (never the strategy) via the same `office_hours` write mechanism
+in "Autonomy contract", below.
 
 ## Autonomy contract
 
@@ -514,6 +591,14 @@ decompose fresh. It:
 Until a live router exists, re-evaluation runs **inline** in the same session
 that recorded the strategy edit — the way every round on
 `strategy-graph-native-dispatch` has executed it by hand.
+
+**Per-node re-evaluation.** Under `tactic-graph-frozen-tactic-dispatch`, the
+router may now queue re-evaluation as a **per-node** `/align-tactics
+<tactic-id>` session targeting exactly one soft-frozen tactic, rather than only
+the strategy-wide open-child sweep this section historically described. The
+disposition bar is identical — the same whole-node reconciliation (item 2) and
+single-strategy re-stamp (item 3) — applied to the one target. See "Tactic
+target — per-node finalize or re-plan", above, for that flow.
 
 A strategy-corpus census script is planned as an enumeration hook for the
 open-child sweep above (`tactic-align-tactics-mechanical-floor` Unit 2);

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
@@ -124,6 +124,7 @@ for spec in "$@"; do
   # Directive mapping from the persisted phase (never re-derived).
   case "$kind:$phase" in
     strategy:*)          SKILL="/align-tactics"; MODEL_PHASE="align-tactics" ;;
+    tactic:align-tactics) SKILL="/align-tactics"; MODEL_PHASE="align-tactics" ;;
     tactic:implement)    SKILL="/implement";     MODEL_PHASE="implement" ;;
     tactic:fix)          SKILL="/fix-checks";    MODEL_PHASE="fix-checks" ;;
     tactic:qa)           SKILL="/qa-fix";        MODEL_PHASE="qa" ;;
@@ -144,9 +145,11 @@ for spec in "$@"; do
   EFFORT_ARGS=()
   [[ -n "$EFFORT" ]] && EFFORT_ARGS=(--effort "$EFFORT")
 
-  if [[ "$kind" == "strategy" ]]; then
-    # Strategy lane: no pre-provision — /align-tactics owns its own worktree
-    # claim/entry. Spawn cwd=PROJECT_ROOT and let the skill enter its worktree.
+  if [[ "$kind" == "strategy" || "$phase" == "align-tactics" ]]; then
+    # Strategy lane (and a frozen-tactic align target): no pre-provision —
+    # /align-tactics owns its own worktree claim/entry, keyed on the node id
+    # (a strategy's id, or a frozen tactic's id). Spawn cwd=PROJECT_ROOT and let
+    # the skill enter its worktree.
     if "$SCRIPT_DIR/dispatch-spawn-job" --no-verify --name "$id" \
         --cwd "$PROJECT_ROOT" --model "$ORCH_MODEL" "${EFFORT_ARGS[@]}" \
         "$SKILL $id" 1>&2; then

--- a/intentions/tactic-graph-native-dispatch.md
+++ b/intentions/tactic-graph-native-dispatch.md
@@ -337,16 +337,46 @@ A **strategy** is eligible for an `/align-tactics` session iff:
   newer than `rounds.last_completed`, and
 - `rounds.count < 2` (at the cap, the router parks it instead).
 
-A **tactic** is eligible for its phase skill iff `office_hours` is null,
-`phase` is neither `draft` nor `done`, its `blocked_by` set is fully
-complete, and its phase's sensor gate is satisfied.
+A **tactic** is eligible for its **phase skill** (e.g. `/implement`,
+`/fix-checks`, `/qa-fix`) iff `office_hours` is null, `phase` is neither
+`draft` nor `done`, its `blocked_by` set is fully complete, and its
+phase's sensor gate is satisfied. A frozen tactic — draft/raw (`phase`
+absent), or soft-frozen per the gate below — is ineligible for its phase
+skill by this same test, but is separately eligible for an
+`/align-tactics` session per the next paragraph.
+
+A **frozen tactic** (draft/raw, `phase` absent; or soft-frozen, per the
+soft-freeze gate below) is eligible for its own `/align-tactics` session
+iff `office_hours` is null and its `blocked_by` set is fully complete —
+parallel to how a strategy is eligible for its own `/align-tactics`
+session above. This is the first-class-selectability behavior implemented
+by `selectGraphTargets` in `packages/intentionsutil/src/router.ts`.
+
+A strategy with one or more eligible frozen descendants resolves, as the
+`/align-tactics` candidate, to its highest-ranked frozen descendant (by
+the same resolved-attention rank and ordering used everywhere else) —
+not to the strategy node itself; a strategy with no tactic children (a
+zero-tactic strategy) resolves to itself. The implementing primitive is
+`resolveFrozenDescendant` in `packages/intentionsutil/src/router.ts`.
+
+Within one attention-rank level, candidates now sort by a **progression
+ordinal** over the full schema `PHASES` order — `draft < align-tactics <
+implement < fix < qa < review < main-qa < done` — more-progressed first.
+This generalizes and replaces the old closest-to-done `PHASE_LADDER`
+(see §3.2, which also needs the corresponding update). It reorders `fix`
+and `qa`: under the progression ordinal, `qa` (further along the
+pipeline) now sorts before `fix`, the opposite of the old ladder's `fix`
+before `qa`.
 
 **Soft-freeze gate** (clarification 10): before selecting within a
 subtree, the router recomputes the serving strategy's substance
 fingerprint; any open tactic stamped with a stale
 `execution.strategy_fingerprint` freezes the subtree — no new selections,
-in-flight phases finish, one re-evaluation `/align-tactics` session is
-queued, the freeze is logged to the selection log. State writes
+in-flight phases finish, one re-evaluation `/align-tactics <tactic-id>`
+session is queued **per frozen tactic** in the subtree (not a single
+strategy-level session) — each frozen tactic re-surfaces individually as
+an `align-tactics` candidate at its own node id, per `selectGraphTargets`
+— the freeze is logged to the selection log. State writes
 (`reading`/`gap`/`rounds`/`office_hours`) never change the fingerprint.
 
 ### 3.2 Selection
@@ -358,9 +388,14 @@ weighted sum of read-time-derived terms — explicit author attention (an
 `override` pins), signal satisfaction (structural reachability to
 `validates`-terminals of unvalidated signals), capture resolution (from
 `recovers`-edge delegation axes) — with new conditions added as terms,
-never bands; clarification 11) → 4. within a rank level, phase ladder
-closest-to-done first: `main-qa → review → fix → qa → implement →
-align-tactics(strategy)`. Topic categories retire — topical priority is
+never bands; clarification 11) → 4. within a rank level, the progression
+ordinal over the full schema `PHASES` order (`draft < align-tactics <
+implement < fix < qa < review < main-qa < done`) sorts more-progressed
+first, i.e. closest-to-done first: `main-qa → review → qa → fix →
+implement → align-tactics`. This reorders `fix`/`qa` relative to the old
+closest-to-done ladder (which had `fix` before `qa`); `align-tactics` now
+covers both a strategy candidate and a frozen-tactic candidate at that
+same directive rung. Topic categories retire — topical priority is
 authored attention on the owning strategy.
 
 Claimed-set, reservation ledger, concurrency pacing
@@ -502,8 +537,9 @@ worktrees where they are) and their conventions retire with
 hands the node-id set to a thin tick workflow script (the Workflow
 primitive) that fans out one `agent()` per selected node — never to the
 legacy launch scripts, which stay issue-lane-only and retire with the
-drain. The directive per node is `/align-tactics <id>` for a strategy,
-the tactic's persisted `phase` mapped to its phase skill otherwise;
+drain. The directive per node is `/align-tactics <id>` for a strategy or a
+frozen tactic (draft/raw, or soft-frozen), the tactic's persisted `phase`
+mapped to its phase skill for a non-frozen open tactic;
 `dispatch-route`'s label/PR-derived phase derivation does not apply to
 node targets (phase is persisted, clarification 1). Mechanics stay owned
 and deterministic per the thin-script condition: agents invoke a

--- a/packages/intentionsutil/scripts/check-node-selection.ts
+++ b/packages/intentionsutil/scripts/check-node-selection.ts
@@ -209,7 +209,15 @@ export function evaluateSelection(opts: SelectionOpts): SelectionResult {
 
   // 4. fingerprint — a strategy substance edit after selection yields the
   //    worker. Only meaningful once stamping has started (null is never stale).
-  const stampedFp = readStrategyFingerprint(node);
+  //
+  //    Skipped entirely for an align-tactics selection. A strategy's stamp is
+  //    null anyway (nothing to compare). For a soft-frozen tactic — the exact
+  //    re-evaluation target an align-tactics session exists to handle — the
+  //    stale execution.strategy_fingerprint IS the selection reason, not a yield
+  //    reason: 3b (frozenTacticSelectable) already admitted it, so re-testing the
+  //    same staleness here would reject the node 3b just admitted and strand the
+  //    re-evaluation worker at exit 12.
+  const stampedFp = selectedPhase === "align-tactics" ? null : readStrategyFingerprint(node);
   if (stampedFp !== null) {
     const byId = new Map(listNodes(dir).map((n) => [n.id, n]));
     for (const sid of servingStrategyIds(node, byId)) {

--- a/packages/intentionsutil/scripts/check-node-selection.ts
+++ b/packages/intentionsutil/scripts/check-node-selection.ts
@@ -43,6 +43,7 @@ import { pathToFileURL } from "node:url";
 import { readFileSync } from "node:fs";
 import { listNodes, readNode, readNodeBody } from "../src/store.js";
 import {
+  frozenTacticSelectable,
   servingStrategyIds,
   strategyAlignSelectable,
   strategyFingerprint,
@@ -159,11 +160,18 @@ export function evaluateSelection(opts: SelectionOpts): SelectionResult {
   // phases are first-class and persisted, so equality is correct there).
   const phase = readPhase(node);
   if (selectedPhase === "align-tactics") {
-    if (node.kind !== "strategy") {
-      return fail(EXIT_STALE_SELECTION, "phase", `selected align-tactics but ${nodeId} is a ${node.kind}, not a strategy`);
-    }
-    if (phase !== null) {
-      return fail(EXIT_STALE_SELECTION, "phase", `selected align-tactics but strategy ${nodeId} phase advanced to ${phase}`);
+    if (node.kind === "strategy") {
+      // A strategy is align-selected at its native null phase; any non-null
+      // stored phase (first-class or squatter) is a stale advance.
+      if (phase !== null) {
+        return fail(EXIT_STALE_SELECTION, "phase", `selected align-tactics but strategy ${nodeId} phase advanced to ${phase}`);
+      }
+    } else {
+      // A frozen tactic is align-selected either at draft (phase null) OR while
+      // carrying an in-flight phase if it is soft-frozen. That distinction is
+      // not cheaply recomputable here, so the phase-literal check is skipped for
+      // a tactic target: eligibility is decided wholesale by the 3b re-check
+      // below (frozenTacticSelectable, the single source of truth).
     }
   } else if (phase !== selectedPhase) {
     return fail(EXIT_STALE_SELECTION, "phase", `selected ${selectedPhase} but node is now ${phase ?? "draft/null"}`);
@@ -179,13 +187,24 @@ export function evaluateSelection(opts: SelectionOpts): SelectionResult {
   //     under the rounds cap, no non-draft on-path child, not soft-frozen out).
   //     Deferred to here so the not-parked check above owns the parked verdict;
   //     defers wholesale to the pure selector (single source of truth).
-  if (selectedPhase === "align-tactics" && !strategyAlignSelectable(node, listNodes(dir))) {
-    return fail(
-      EXIT_STALE_SELECTION,
-      "phase",
-      `selected align-tactics but strategy ${nodeId} is no longer align-eligible ` +
-        `(signal validated, rounds cap, on-path child, or soft-frozen out)`,
-    );
+  if (selectedPhase === "align-tactics") {
+    if (node.kind === "strategy") {
+      if (!strategyAlignSelectable(node, listNodes(dir))) {
+        return fail(
+          EXIT_STALE_SELECTION,
+          "phase",
+          `selected align-tactics but strategy ${nodeId} is no longer align-eligible ` +
+            `(signal validated, rounds cap, on-path child, or soft-frozen out)`,
+        );
+      }
+    } else if (!frozenTacticSelectable(node, listNodes(dir))) {
+      return fail(
+        EXIT_STALE_SELECTION,
+        "phase",
+        `selected align-tactics but tactic ${nodeId} is no longer frozen-eligible ` +
+          `(advanced past draft and not soft-frozen, parked, or resolved)`,
+      );
+    }
   }
 
   // 4. fingerprint — a strategy substance edit after selection yields the

--- a/packages/intentionsutil/src/router.ts
+++ b/packages/intentionsutil/src/router.ts
@@ -50,8 +50,11 @@ export interface GraphCandidate {
   /** The tactic's execution.pr — the wrapper's sensor-gate input. Null for strategies. */
   pr: number | null;
   /**
-   * True when this strategy candidate is the soft-freeze re-evaluation session
-   * (strategy clarification 10) rather than an ordinary decomposition round.
+   * True when this candidate is a soft-freeze re-evaluation session (strategy
+   * clarification 10) rather than an ordinary decomposition round — a stale
+   * frozen tactic re-surfacing at `align-tactics`
+   * (tactic-graph-frozen-tactic-dispatch). False for a fresh draft-tactic or
+   * strategy align candidate.
    */
   reevaluation: boolean;
 }
@@ -219,11 +222,23 @@ function progressionIndex(candidate: GraphCandidate, byId: Map<string, Intention
  * Soft-freeze gate (strategy clarification 10): an open tactic stamped with a
  * non-null `execution.strategy_fingerprint` differing from the serving
  * strategy's current substance fingerprint freezes the subtree — its tactics
- * are excluded from selection (in-flight phases finish on their own), one
- * re-evaluation `/align-tactics` candidate is emitted for the strategy
- * (bypassing the child/signal/rounds gates; `office_hours` still applies), and
- * a `freeze` event is logged. Null fingerprints are not stale — stamping
- * starts when the align machinery lands.
+ * are excluded from their normal phase skill (in-flight phases finish on their
+ * own), and a `freeze` event is logged. Per
+ * tactic-graph-frozen-tactic-dispatch (clarification 52) the re-evaluation now
+ * targets the frozen TACTICS directly: each subtree tactic re-surfaces as a
+ * `kind: "tactic", phase: "align-tactics", reevaluation: true` candidate
+ * (office_hours null and complete blockers still apply), rather than the
+ * strategy id. Null fingerprints are not stale — stamping starts when the
+ * align machinery lands.
+ *
+ * Frozen-tactic candidates (tactic-graph-frozen-tactic-dispatch): draft/raw
+ * tactics (`phase: draft` or null) are also first-class selectable candidates
+ * that route to `/align-tactics` (`reevaluation: false`, `pr: null`), gated on
+ * office_hours null and complete blockers. Their candidate `phase` is the
+ * directive rung `align-tactics`, but the progression ordinal reads the node's
+ * REAL phase (draft, index 0) for sorting, so a draft sorts last among ties.
+ * A strategy with only draft children still emits its own fresh-round
+ * align-tactics candidate; the two compete by rank.
  *
  * Order: resolved attention rank outermost (node-keyed, directly from
  * `resolveAttention` — the retired node↔issue rank-map bridge is not revived);
@@ -250,7 +265,6 @@ export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
 
   // --- Soft-freeze scan ------------------------------------------------------
   const frozenTacticIds = new Set<string>();
-  const frozenStrategyIds = new Set<string>();
   for (const s of strategies) {
     const fp = strategyFingerprint(s);
     const children = childrenOf.get(s.id) ?? [];
@@ -261,7 +275,6 @@ export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
     // its serving strategies has since drifted.
     const stale = children.filter((t) => isOpenTactic(t) && isStrategyStale(t.execution, s.id, fp));
     if (stale.length === 0) continue;
-    frozenStrategyIds.add(s.id);
     for (const t of children) frozenTacticIds.add(t.id);
     events.push({
       event: "freeze",
@@ -289,6 +302,41 @@ export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
     });
   }
 
+  // --- Frozen tactic candidates ------------------------------------------------
+  // Draft/raw tactics and soft-frozen tactics are first-class selectable nodes
+  // that route to /align-tactics (tactic-graph-frozen-tactic-dispatch). A draft
+  // is a decomposition input surfaced for its own align session; a soft-frozen
+  // tactic's normal phase skill is suppressed above, but a re-evaluation
+  // /align-tactics candidate is emitted here so the stale plan is re-aligned
+  // against the drifted strategy. Both gate on office_hours null and complete
+  // blockers. A tactic that is neither draft nor soft-frozen is already handled
+  // by the executable loop above (or is done / not eligible) and skipped here.
+  for (const t of tactics) {
+    if (t.office_hours !== null) continue;
+    if (!blockersComplete(t, byId)) continue;
+    if (isDraft(t)) {
+      candidates.push({
+        id: t.id,
+        kind: "tactic",
+        phase: "align-tactics", // directive rung, not the node's real (null) phase
+        rank: attention.get(t.id)?.value ?? 0,
+        pace_exempt: t.pace_exempt,
+        pr: null,
+        reevaluation: false,
+      });
+    } else if (frozenTacticIds.has(t.id)) {
+      candidates.push({
+        id: t.id,
+        kind: "tactic",
+        phase: "align-tactics",
+        rank: attention.get(t.id)?.value ?? 0,
+        pace_exempt: t.pace_exempt,
+        pr: t.execution?.pr ?? null,
+        reevaluation: true,
+      });
+    }
+  }
+
   // --- Strategy candidates -------------------------------------------------------
   for (const s of strategies) {
     if (s.office_hours !== null) continue;
@@ -302,12 +350,6 @@ export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
       pr: null,
       reevaluation,
     });
-
-    if (frozenStrategyIds.has(s.id)) {
-      // The one queued re-evaluation session for a frozen subtree.
-      candidates.push(asCandidate(true));
-      continue;
-    }
 
     // No non-draft child tactics on the strategy's signal path.
     const children = childrenOf.get(s.id) ?? [];
@@ -391,5 +433,54 @@ export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
 export function strategyAlignSelectable(strategy: IntentionNode, nodes: IntentionNode[]): boolean {
   return selectGraphTargets(nodes).candidates.some(
     (c) => c.id === strategy.id && c.kind === "strategy" && c.phase === "align-tactics",
+  );
+}
+
+/**
+ * The strategy's highest-ranked eligible FROZEN descendant, or null
+ * (tactic-graph-frozen-tactic-dispatch). A frozen descendant is a tactic that
+ * (a) counts `strategy.id` among its `servingStrategyIds` (serves/parent-chain
+ * membership) and (b) the selector emits as a `kind: "tactic",
+ * phase: "align-tactics"` candidate — i.e. a draft/raw or soft-frozen tactic
+ * with office_hours null and complete blockers.
+ *
+ * The selector is the single source of truth: this walks its ALREADY-SORTED
+ * candidate list (rank desc, progression ordinal desc, id asc) and returns the
+ * node behind the first qualifying candidate, so ranking/tiebreaks match the
+ * real selection exactly. Returns null for a zero-tactic strategy or one whose
+ * descendants are all non-frozen.
+ */
+export function resolveFrozenDescendant(
+  strategy: IntentionNode,
+  nodes: IntentionNode[],
+): IntentionNode | null {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  for (const c of selectGraphTargets(nodes).candidates) {
+    if (c.kind !== "tactic" || c.phase !== "align-tactics") continue;
+    const node = byId.get(c.id);
+    if (node === undefined) continue;
+    if (!servingStrategyIds(node, byId).has(strategy.id)) continue;
+    return node;
+  }
+  return null;
+}
+
+/**
+ * Would the graph selector emit `tactic` as an `align-tactics` candidate over
+ * this store snapshot right now? True iff `tactic` appears among
+ * `selectGraphTargets(nodes).candidates` as a `kind: "tactic"` candidate at the
+ * directive `align-tactics` rung — the frozen-tactic (draft/raw or soft-frozen)
+ * analog of `strategyAlignSelectable`.
+ *
+ * The selector is the single source of truth for frozen-tactic selectability
+ * (single-callsite doctrine): this is membership in its output, never a
+ * re-implementation of its per-tactic gates (draft/soft-freeze/office_hours/
+ * blockers). The worker-start re-validation gate calls it so a tactic selected
+ * at `align-tactics` re-validates against exactly the selector's current
+ * verdict.
+ */
+export function frozenTacticSelectable(tactic: IntentionNode, nodes: IntentionNode[]): boolean {
+  return selectGraphTargets(nodes).candidates.some(
+    (c) => c.id === tactic.id && c.kind === "tactic" && c.phase === "align-tactics",
   );
 }

--- a/packages/intentionsutil/src/router.ts
+++ b/packages/intentionsutil/src/router.ts
@@ -324,7 +324,7 @@ export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
         pr: null,
         reevaluation: false,
       });
-    } else if (frozenTacticIds.has(t.id)) {
+    } else if (frozenTacticIds.has(t.id) && isOpenTactic(t)) {
       candidates.push({
         id: t.id,
         kind: "tactic",

--- a/packages/intentionsutil/src/router.ts
+++ b/packages/intentionsutil/src/router.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { computeSignalPath, isSignalUnvalidated, resolveAttention } from "./attention.js";
 import { isStrategyStale } from "./transitions.js";
+import { PHASES } from "./schema.js";
 import type { IntentionNode, Phase } from "./schema.js";
 
 // Graph router v2, first half: selection (tactic-graph-router-selector).
@@ -18,12 +19,14 @@ import type { IntentionNode, Phase } from "./schema.js";
 // --- Types -------------------------------------------------------------------
 
 /**
- * The phase ladder, closest-to-done first (strategy clarification 22). Within
- * one resolved-attention rank level, candidates drain in this order; the
- * `align-tactics` rung is where eligible strategies (an `/align-tactics`
- * session) sort. `main-qa` (adopted into the schema `Phase` enum by
- * tactic-main-qa-phase) sorts closest-to-done: a merged tactic carrying
- * needs-main residue drains its main-qa verification before `done`.
+ * The phase ladder, closest-to-done first (strategy clarification 22).
+ *
+ * Historical: this drove the within-rank selection tiebreak until
+ * tactic-graph-frozen-tactic-dispatch replaced it with a progression ordinal
+ * over the full `PHASES` order (see `progressionIndex`). The selection sort no
+ * longer consults it; it is retained as a public export for downstream
+ * consumers. Note the progression ordinal reorders `fix` vs `qa` relative to
+ * this ladder (`qa` is now more-progressed than `fix`).
  */
 export const PHASE_LADDER: readonly string[] = [
   "main-qa",
@@ -61,7 +64,7 @@ export interface SelectionEvent {
 }
 
 export interface GraphSelection {
-  /** Eligible nodes in selection order: rank desc, phase ladder, id asc. */
+  /** Eligible nodes in selection order: rank desc, progression ordinal desc, id asc. */
   candidates: GraphCandidate[];
   /** Freeze / cap / gate events observed during the scan. */
   events: SelectionEvent[];
@@ -170,12 +173,26 @@ function blockersComplete(tactic: IntentionNode, byId: Map<string, IntentionNode
   return true;
 }
 
-function ladderIndex(phase: string): number {
-  const idx = PHASE_LADDER.indexOf(phase);
-  // An unknown phase (schema drift) sorts after every ladder rung rather than
-  // throwing: the wrapper's sensor gate is the loud failure point for a phase
-  // it cannot map.
-  return idx === -1 ? PHASE_LADDER.length : idx;
+/**
+ * A candidate's progression ordinal over the full `PHASES` order (schema.ts):
+ * the index of its effective phase, so a MORE-progressed candidate carries a
+ * HIGHER index. The sort comparator reverses this (descending) to drain
+ * closest-to-done first.
+ *
+ * A strategy carries no persisted phase — its directive rung is `align-tactics`
+ * (index 1). A tactic uses its node's persisted `phase`, falling back to
+ * `draft` (index 0) when the node lookup somehow fails, matching the draft
+ * convention (`phase: null` == draft).
+ *
+ * Note this reorders `fix` vs `qa` relative to the retired `PHASE_LADDER`: under
+ * `PHASES`, `qa` (index 4) is more-progressed than `fix` (index 3), so `qa` now
+ * sorts before `fix` — a deliberate behavior change.
+ */
+function progressionIndex(candidate: GraphCandidate, byId: Map<string, IntentionNode>): number {
+  const node = byId.get(candidate.id);
+  const p: Phase =
+    candidate.kind === "strategy" ? "align-tactics" : node?.phase ?? "draft";
+  return PHASES.indexOf(p);
 }
 
 // --- Selector ------------------------------------------------------------------
@@ -210,8 +227,8 @@ function ladderIndex(phase: string): number {
  *
  * Order: resolved attention rank outermost (node-keyed, directly from
  * `resolveAttention` — the retired node↔issue rank-map bridge is not revived);
- * within a rank level the phase ladder closest-to-done first; id ascending as
- * the deterministic tiebreak.
+ * within a rank level the progression ordinal (full `PHASES` order) sorts the
+ * more-progressed candidate first; id ascending as the deterministic tiebreak.
  */
 export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
   const byId = new Map(nodes.map((n) => [n.id, n]));
@@ -343,9 +360,9 @@ export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
   // --- Order -------------------------------------------------------------------
   candidates.sort((a, b) => {
     if (a.rank !== b.rank) return b.rank - a.rank;
-    const al = ladderIndex(a.phase);
-    const bl = ladderIndex(b.phase);
-    if (al !== bl) return al - bl;
+    const ap = progressionIndex(a, byId);
+    const bp = progressionIndex(b, byId);
+    if (ap !== bp) return bp - ap;
     return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
   });
 

--- a/packages/intentionsutil/test/check-node-selection.test.ts
+++ b/packages/intentionsutil/test/check-node-selection.test.ts
@@ -365,6 +365,32 @@ describe("evaluateSelection", () => {
       expect(r.stdout).toMatch(/^[0-9a-f]{64}$/);
     });
 
+    it("passes a soft-frozen tactic (stale fingerprint) the selector re-surfaces (exit 0)", () => {
+      const dir = tempDir();
+      seed(dir, anode({ id: "strategy-x", kind: "strategy", statement: "Own the substrate." }));
+      // An open tactic carrying a STALE serving-strategy fingerprint is
+      // soft-frozen: the selector re-surfaces it as an align-tactics candidate.
+      // The stale fingerprint IS the re-evaluation reason, so step 4 must be
+      // skipped at align-tactics — a literal fingerprint check would exit-12 the
+      // very node 3b just admitted and strand the re-evaluation worker.
+      seed(
+        dir,
+        anode({
+          id: "tactic-frozen",
+          kind: "tactic",
+          phase: "qa",
+          serves: ["strategy-x"],
+          execution: { branch: "b", pr: 1, attempts: {}, markers: [], strategy_fingerprint: "0".repeat(64) },
+        }),
+      );
+      // Sanity: the SAME node selected at its stored phase exit-12s on the stale
+      // fingerprint — proving align-tactics is what suppresses step 4, not the fixture.
+      expect(evaluateSelection({ nodeId: "tactic-frozen", selectedPhase: "qa", dir, stamp: null }).exitCode).toBe(12);
+      const r = evaluateSelection({ nodeId: "tactic-frozen", selectedPhase: "align-tactics", dir, stamp: null });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/^[0-9a-f]{64}$/);
+    });
+
     it("exit 12 when a draft tactic was parked after selection (not-parked owns the verdict)", () => {
       const dir = tempDir();
       // A parked draft tactic never reaches 3b — the earlier not-parked check

--- a/packages/intentionsutil/test/check-node-selection.test.ts
+++ b/packages/intentionsutil/test/check-node-selection.test.ts
@@ -345,12 +345,42 @@ describe("evaluateSelection", () => {
       expect(r.stderr[0]).toMatch(/phase advanced to implement/);
     });
 
-    it("exit 12 when a tactic id is passed at align-tactics (not a strategy)", () => {
+    it("exit 12 when a non-frozen tactic is passed at align-tactics (advanced past draft, not soft-frozen)", () => {
       const dir = tempDir();
+      // An ordinary open tactic (phase set, not draft, not soft-frozen) is not a
+      // frozenTacticSelectable candidate, so it fails the 3b re-eligibility check.
       seed(dir, anode({ id: "tactic-a", kind: "tactic", phase: "implement" }));
       const r = evaluateSelection({ nodeId: "tactic-a", selectedPhase: "align-tactics", dir, stamp: null });
       expect(r.exitCode).toBe(12);
-      expect(r.stderr[0]).toMatch(/not a strategy/);
+      expect(r.stderr[0]).toMatch(/no longer frozen-eligible/);
+    });
+
+    it("passes a frozen (draft, phase:null) tactic the selector would emit (exit 0)", () => {
+      const dir = tempDir();
+      // A draft tactic with office_hours null and no blockers is a frozen
+      // align-tactics candidate — routes to /align-tactics.
+      seed(dir, anode({ id: "tactic-draft", kind: "tactic", phase: null }));
+      const r = evaluateSelection({ nodeId: "tactic-draft", selectedPhase: "align-tactics", dir, stamp: null });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("exit 12 when a draft tactic was parked after selection (not-parked owns the verdict)", () => {
+      const dir = tempDir();
+      // A parked draft tactic never reaches 3b — the earlier not-parked check
+      // fires first.
+      seed(
+        dir,
+        anode({
+          id: "tactic-draft-p",
+          kind: "tactic",
+          phase: null,
+          office_hours: { reason: "author park", since: "2026-07-16", recommendation: null },
+        }),
+      );
+      const r = evaluateSelection({ nodeId: "tactic-draft-p", selectedPhase: "align-tactics", dir, stamp: null });
+      expect(r.exitCode).toBe(12);
+      expect(r.stderr[0]).toMatch(/not-parked/);
     });
 
     it("a normal tactic phase still round-trips unchanged at align-tactics-adjacent phases", () => {

--- a/packages/intentionsutil/test/router.test.ts
+++ b/packages/intentionsutil/test/router.test.ts
@@ -394,6 +394,28 @@ describe("soft-freeze gate", () => {
     expect(ids).toContain("tactic-sibling");
   });
 
+  it("a done child of a frozen subtree is NOT re-emitted as an align-tactics re-eval candidate", () => {
+    // A `done` tactic can sit in the store during a freeze because transition-node
+    // writes `done` without pruning (prune is a separate, lagging step). The
+    // soft-freeze scan must not surface it as a `/align-tactics` re-eval target:
+    // done (the highest progression ordinal) would otherwise sort to the TOP and
+    // dispatch a re-plan against a completed/merged tactic.
+    const nodes: IntentionNode[] = [
+      strategy({ id: "strategy-s" }),
+      tactic({
+        id: "tactic-stale",
+        serves: ["strategy-s"],
+        phase: "implement",
+        execution: exec({ strategy_fingerprint: "stale-fingerprint" }),
+      }),
+      tactic({ id: "tactic-done", serves: ["strategy-s"], phase: "done" }),
+    ];
+    const ids = selectGraphTargets(nodes).candidates.map((c) => c.id);
+    expect(ids).not.toContain("tactic-done");
+    // the open frozen child still re-surfaces
+    expect(ids).toContain("tactic-stale");
+  });
+
   // Multi-serves: the per-strategy map stamp must not false-freeze siblings.
   // An honest tactic serving two strategies carries one fingerprint per serving
   // strategy; a single legacy string cannot equal two substance hashes, which is

--- a/packages/intentionsutil/test/router.test.ts
+++ b/packages/intentionsutil/test/router.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Execution, IntentionNode } from "../src/schema.js";
+import { PHASES } from "../src/schema.js";
 import {
-  PHASE_LADDER,
   readingDate,
   selectGraphTargets,
   strategyAlignSelectable,
@@ -417,7 +417,7 @@ describe("ordering", () => {
     expect(candidateIds(nodes)).toEqual(["tactic-high", "tactic-low"]);
   });
 
-  it("within one rank level, the phase ladder orders closest-to-done first", () => {
+  it("within one rank level, the progression ordinal orders closest-to-done first (qa sorts before fix)", () => {
     const nodes = [
       strategy({ id: "strategy-s", reading: "validated" }),
       tactic({ id: "tactic-implement", phase: "implement" }),
@@ -427,13 +427,15 @@ describe("ordering", () => {
     ];
     expect(candidateIds(nodes)).toEqual([
       "tactic-review",
-      "tactic-fix",
       "tactic-qa",
+      "tactic-fix",
       "tactic-implement",
     ]);
   });
 
   it("an eligible strategy sorts at the align-tactics rung, after tactics of equal rank", () => {
+    // Under the progression ordinal, implement (PHASES index 2) is more-progressed
+    // than a strategy's align-tactics rung (index 1), so the tactic sorts first.
     const nodes = [
       strategy({ id: "strategy-s" }),
       tactic({ id: "tactic-implement", phase: "implement" }),
@@ -449,8 +451,17 @@ describe("ordering", () => {
     expect(candidateIds(nodes)).toEqual(["tactic-a", "tactic-b"]);
   });
 
-  it("the ladder covers every selectable phase", () => {
-    expect(PHASE_LADDER).toEqual(["main-qa", "review", "fix", "qa", "implement", "align-tactics"]);
+  it("the progression ordinal runs over the full PHASES order", () => {
+    expect(PHASES).toEqual([
+      "draft",
+      "align-tactics",
+      "implement",
+      "fix",
+      "qa",
+      "review",
+      "main-qa",
+      "done",
+    ]);
   });
 });
 

--- a/packages/intentionsutil/test/router.test.ts
+++ b/packages/intentionsutil/test/router.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import type { Execution, IntentionNode } from "../src/schema.js";
 import { PHASES } from "../src/schema.js";
 import {
+  frozenTacticSelectable,
   readingDate,
+  resolveFrozenDescendant,
   selectGraphTargets,
   strategyAlignSelectable,
   strategyFingerprint,
@@ -101,13 +103,20 @@ describe("tactic eligibility", () => {
     expect(candidateIds(nodes)).toEqual([]);
   });
 
-  it("skips draft (explicit and null-phase) and done tactics", () => {
+  it("skips a done tactic; draft tactics now surface at align-tactics", () => {
+    // tactic-graph-frozen-tactic-dispatch: a draft/raw tactic (explicit or
+    // null-phase) is now a first-class candidate at the align-tactics rung; only
+    // a DONE tactic is fully excluded.
     const nodes = [
       tactic({ id: "tactic-draft", phase: "draft" }),
       tactic({ id: "tactic-nophase", phase: null }),
       tactic({ id: "tactic-done", phase: "done" }),
     ];
-    expect(candidateIds(nodes)).toEqual([]);
+    // Both drafts sort at the draft progression index (0), id ascending.
+    expect(candidateIds(nodes)).toEqual(["tactic-draft", "tactic-nophase"]);
+    for (const c of selectGraphTargets(nodes).candidates) {
+      expect(c).toMatchObject({ kind: "tactic", phase: "align-tactics", reevaluation: false });
+    }
   });
 
   it("skips a tactic with a present, not-done blocker", () => {
@@ -170,13 +179,17 @@ describe("strategy eligibility", () => {
     expect(candidateIds(nodes)).toEqual(["tactic-child"]);
   });
 
-  it("draft children do not block a strategy (drafts are input)", () => {
+  it("draft children do not block a strategy's fresh round (drafts are input)", () => {
     const nodes = [
       strategy({ id: "strategy-s" }),
       tactic({ id: "tactic-child", serves: ["strategy-s"], validates: ["strategy-s"], phase: "draft" }),
       tactic({ id: "tactic-child2", serves: ["strategy-s"], validates: ["strategy-s"], phase: null }),
     ];
-    expect(candidateIds(nodes)).toEqual(["strategy-s"]);
+    // The strategy still emits its fresh align-tactics round; additively, each
+    // draft child ALSO surfaces as its own align-tactics candidate
+    // (tactic-graph-frozen-tactic-dispatch). The strategy sorts first (align
+    // rung, index 1) ahead of the drafts (draft index 0), then id ascending.
+    expect(candidateIds(nodes)).toEqual(["strategy-s", "tactic-child", "tactic-child2"]);
   });
 
   it("an OFF-path non-draft child does not block the strategy", () => {
@@ -292,15 +305,42 @@ describe("soft-freeze gate", () => {
     ];
   };
 
-  it("a stale fingerprint freezes the subtree and emits one re-evaluation candidate", () => {
+  it("a stale fingerprint re-surfaces the frozen tactics at align-tactics", () => {
     const sel = selectGraphTargets(frozenGraph("stale-fingerprint"));
-    // Both subtree tactics are excluded; the strategy surfaces as the one
-    // queued re-evaluation /align-tactics session.
-    expect(sel.candidates.map((c) => c.id)).toEqual(["strategy-s"]);
-    expect(sel.candidates[0]?.reevaluation).toBe(true);
+    // tactic-graph-frozen-tactic-dispatch: the re-evaluation now targets the
+    // frozen TACTICS directly (not the strategy id). Both subtree tactics are
+    // excluded from their normal phase skill and re-emitted as align-tactics
+    // re-evaluation candidates. strategy-s ALSO emits its own fresh round here
+    // because its frozen children carry no `validates` edge — they are off the
+    // signal path, so the fresh-round child gate does not block the strategy.
+    // Order: rank 0 across the board, then progression ordinal desc over each
+    // node's REAL phase (tactic-sibling qa=4 > tactic-stale implement=2 >
+    // strategy-s align=1).
+    expect(sel.candidates.map((c) => c.id)).toEqual([
+      "tactic-sibling",
+      "tactic-stale",
+      "strategy-s",
+    ]);
+    const stale = sel.candidates.find((c) => c.id === "tactic-stale");
+    const sibling = sel.candidates.find((c) => c.id === "tactic-sibling");
+    expect(stale).toMatchObject({ kind: "tactic", phase: "align-tactics", reevaluation: true });
+    expect(sibling).toMatchObject({ kind: "tactic", phase: "align-tactics", reevaluation: true });
     expect(sel.events).toEqual([
       expect.objectContaining({ event: "freeze", strategy: "strategy-s" }),
     ]);
+  });
+
+  it("a frozen tactic's normal phase-skill candidate is suppressed (only align-tactics remains)", () => {
+    const sel = selectGraphTargets(frozenGraph("stale-fingerprint"));
+    // tactic-stale is at phase `implement`, tactic-sibling at `qa`, but neither
+    // emits an executable phase-skill candidate — only the single align-tactics
+    // re-eval candidate.
+    const staleCands = sel.candidates.filter((c) => c.id === "tactic-stale");
+    expect(staleCands).toHaveLength(1);
+    expect(staleCands[0]).toMatchObject({ phase: "align-tactics" });
+    const siblingCands = sel.candidates.filter((c) => c.id === "tactic-sibling");
+    expect(siblingCands).toHaveLength(1);
+    expect(siblingCands[0]).toMatchObject({ phase: "align-tactics" });
   });
 
   it("a matching fingerprint does not freeze", () => {
@@ -325,17 +365,33 @@ describe("soft-freeze gate", () => {
     expect(sel.candidates.map((c) => c.id)).toContain("tactic-stale");
   });
 
-  it("a parked strategy emits no re-evaluation candidate even when frozen", () => {
+  it("parking the strategy drops its own candidate but not the frozen tactics' re-eval", () => {
+    // The re-eval now targets the tactics directly, so parking the STRATEGY no
+    // longer suppresses them — only the strategy's own (fresh-round) candidate
+    // is gated out. The tactics carry office_hours null and still emit.
     const nodes = frozenGraph("stale-fingerprint").map((n) =>
       n.id === "strategy-s"
         ? { ...n, office_hours: { reason: "parked", since: "2026-07-01", recommendation: null } }
         : n,
     );
     const sel = selectGraphTargets(nodes);
-    expect(sel.candidates).toEqual([]);
+    expect(sel.candidates.map((c) => c.id)).toEqual(["tactic-sibling", "tactic-stale"]);
+    expect(sel.candidates.every((c) => c.kind === "tactic" && c.phase === "align-tactics")).toBe(true);
     expect(sel.events).toEqual([
       expect.objectContaining({ event: "freeze", strategy: "strategy-s" }),
     ]);
+  });
+
+  it("parking a frozen tactic drops its own re-eval candidate", () => {
+    // office_hours gating applies to the frozen-tactic emission too.
+    const nodes = frozenGraph("stale-fingerprint").map((n) =>
+      n.id === "tactic-stale"
+        ? { ...n, office_hours: { reason: "parked", since: "2026-07-01", recommendation: null } }
+        : n,
+    );
+    const ids = selectGraphTargets(nodes).candidates.map((c) => c.id);
+    expect(ids).not.toContain("tactic-stale");
+    expect(ids).toContain("tactic-sibling");
   });
 
   // Multi-serves: the per-strategy map stamp must not false-freeze siblings.
@@ -395,6 +451,165 @@ describe("soft-freeze gate", () => {
     // One string cannot match two substance hashes, so both strategies freeze —
     // the legacy behavior this migration preserves until a re-stamp converts it.
     expect(frozen).toEqual(["strategy-a", "strategy-b"]);
+  });
+});
+
+describe("frozen-node candidates", () => {
+  it("a draft tactic (unparked, unblocked) emits an align-tactics candidate", () => {
+    const sel = selectGraphTargets([tactic({ id: "tactic-draft", phase: "draft" })]);
+    expect(sel.candidates).toHaveLength(1);
+    expect(sel.candidates[0]).toMatchObject({
+      id: "tactic-draft",
+      kind: "tactic",
+      phase: "align-tactics",
+      pr: null,
+      reevaluation: false,
+    });
+  });
+
+  it("a null-phase (raw) tactic emits an align-tactics candidate", () => {
+    const sel = selectGraphTargets([tactic({ id: "tactic-raw", phase: null })]);
+    expect(sel.candidates[0]).toMatchObject({
+      id: "tactic-raw",
+      kind: "tactic",
+      phase: "align-tactics",
+      reevaluation: false,
+    });
+  });
+
+  it("a parked draft tactic emits no candidate", () => {
+    const nodes = [
+      tactic({
+        id: "tactic-draft",
+        phase: "draft",
+        office_hours: { reason: "needs a human", since: "2026-07-01", recommendation: null },
+      }),
+    ];
+    expect(candidateIds(nodes)).toEqual([]);
+  });
+
+  it("a draft tactic with a present, not-done blocker emits no candidate", () => {
+    const nodes = [
+      tactic({ id: "tactic-draft", phase: "draft", blocked_by: ["tactic-b"] }),
+      tactic({ id: "tactic-b", phase: "implement" }),
+    ];
+    // Only the executable blocker candidate; the draft is gated out by its
+    // incomplete blocker.
+    expect(candidateIds(nodes)).toEqual(["tactic-b"]);
+  });
+
+  it("a soft-frozen tactic emits a single align-tactics re-eval candidate carrying its PR", () => {
+    const s = strategy({ id: "strategy-s", reading: "validated" });
+    const nodes = [
+      s,
+      tactic({
+        id: "tactic-stale",
+        serves: ["strategy-s"],
+        phase: "implement",
+        execution: exec({ pr: 77, strategy_fingerprint: "stale-fingerprint" }),
+      }),
+    ];
+    const sel = selectGraphTargets(nodes);
+    const cands = sel.candidates.filter((c) => c.id === "tactic-stale");
+    expect(cands).toHaveLength(1);
+    expect(cands[0]).toMatchObject({
+      kind: "tactic",
+      phase: "align-tactics",
+      pr: 77,
+      reevaluation: true,
+    });
+    // No executable `implement` candidate for the same id.
+    expect(cands.some((c) => c.phase === "implement")).toBe(false);
+  });
+});
+
+describe("resolveFrozenDescendant", () => {
+  it("returns the higher-ranked frozen descendant (draft vs soft-frozen)", () => {
+    const s = strategy({ id: "strategy-s", reading: "validated" });
+    const nodes = [
+      ...kinds(),
+      s,
+      // A draft child, boosted so it out-ranks the soft-frozen sibling.
+      tactic({
+        id: "tactic-draft",
+        serves: ["strategy-s"],
+        phase: "draft",
+        attention: { boost: 5, override: null, rationale: "hot" },
+      }),
+      // A soft-frozen (open, stale-fingerprint) child at lower rank.
+      tactic({
+        id: "tactic-stale",
+        serves: ["strategy-s"],
+        phase: "implement",
+        execution: exec({ strategy_fingerprint: "stale-fingerprint" }),
+      }),
+    ];
+    const resolved = resolveFrozenDescendant(s, nodes);
+    expect(resolved?.id).toBe("tactic-draft");
+  });
+
+  it("resolves a descendant reached through the parent chain", () => {
+    const s = strategy({ id: "strategy-s", reading: "validated" });
+    const nodes = [
+      ...kinds(),
+      s,
+      tactic({ id: "tactic-root", serves: ["strategy-s"], phase: "draft" }),
+      // Inherits strategy membership via parent; itself a draft frozen node.
+      tactic({ id: "tactic-leaf", parent: "tactic-root", phase: "draft" }),
+    ];
+    const resolved = resolveFrozenDescendant(s, nodes);
+    // Both are drafts at rank 0; id ascending picks tactic-leaf first.
+    expect(resolved?.id).toBe("tactic-leaf");
+  });
+
+  it("returns null for a strategy with no tactic children", () => {
+    const s = strategy({ id: "strategy-s", reading: "validated" });
+    expect(resolveFrozenDescendant(s, [...kinds(), s])).toBeNull();
+  });
+
+  it("returns null when all descendants are non-frozen (open, in-flight)", () => {
+    const s = strategy({ id: "strategy-s", reading: "validated" });
+    const nodes = [
+      ...kinds(),
+      s,
+      tactic({ id: "tactic-open", serves: ["strategy-s"], phase: "implement" }),
+    ];
+    expect(resolveFrozenDescendant(s, nodes)).toBeNull();
+  });
+});
+
+describe("frozenTacticSelectable", () => {
+  it("is true for an eligible draft tactic (agrees with candidate membership)", () => {
+    const nodes = [tactic({ id: "tactic-draft", phase: "draft" })];
+    expect(frozenTacticSelectable(nodes[0], nodes)).toBe(true);
+  });
+
+  it("is false for a non-frozen open tactic (routes to its phase skill, not align-tactics)", () => {
+    const nodes = [tactic({ id: "tactic-open", phase: "implement" })];
+    expect(frozenTacticSelectable(nodes[0], nodes)).toBe(false);
+  });
+
+  it("is false for a parked draft tactic", () => {
+    const nodes = [
+      tactic({
+        id: "tactic-draft",
+        phase: "draft",
+        office_hours: { reason: "parked", since: "2026-07-01", recommendation: null },
+      }),
+    ];
+    expect(frozenTacticSelectable(nodes[0], nodes)).toBe(false);
+  });
+
+  it("is true for a soft-frozen tactic", () => {
+    const s = strategy({ id: "strategy-s", reading: "validated" });
+    const stale = tactic({
+      id: "tactic-stale",
+      serves: ["strategy-s"],
+      phase: "implement",
+      execution: exec({ strategy_fingerprint: "stale-fingerprint" }),
+    });
+    const nodes = [s, stale];
+    expect(frozenTacticSelectable(stale, nodes)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Implements the graph node `tactic-graph-frozen-tactic-dispatch` — frozen-node
dispatch (`strategy-graph-native-dispatch` clarification 52).

## Problem

The graph selector excluded frozen nodes from selection entirely: a
never-decomposed draft tactic (`phase` absent) was not a selection candidate
at all, and a soft-frozen tactic (a planned tactic whose serving strategy's
substance changed underneath it) was excluded from its phase skill with only
a strategy-level re-evaluation candidate emitted in its place. `/align-tactics`
accepted only a `strategy-<slug>` target. The consequence: a boosted draft
tactic was inert — boosting it could not make it run, because a draft was
never a selection candidate in the first place. Every author-boosted draft
tactic was blocked on this capability landing first.

## Change

- **Selector** (`packages/intentionsutil/src/router.ts`): a draft/raw tactic
  and a soft-frozen tactic are now first-class `align-tactics` candidates
  (`office_hours` null, `blocked_by` complete), routed individually rather than
  via one strategy-level re-evaluation candidate. Added `resolveFrozenDescendant`
  (a strategy resolves to its highest-ranked frozen descendant) and
  `frozenTacticSelectable` (membership check, the tactic analog of
  `strategyAlignSelectable`). Replaced the closest-to-done `PHASE_LADDER`
  secondary sort key with a progression ordinal over the full schema `PHASES`
  order — this reorders `fix`/`qa` (`qa` now sorts before `fix`, matching true
  pipeline progression).
- **Execution wiring** (`dispatch-graph-execute`, `check-node-selection.ts`): a
  `tactic:align-tactics` directive routes through the same no-pre-provision
  claim lane a strategy target uses, and the worker-start re-validation gate
  accepts a frozen-tactic target via `frozenTacticSelectable`.
- **`/align-tactics`**: accepts a `tactic-<slug>` argument naming a frozen
  tactic, alongside the existing `strategy-<slug>` argument. A draft tactic is
  finalized in place (no strategy-wide sweep, no `rounds` bump); a soft-frozen
  tactic is re-planned in place (Re-evaluation mode applied to one node). Both
  land the single pre-existing node via `graph-commit`, with no strategy edit.
- **Spec** (`intentions/tactic-graph-native-dispatch.md`): reconciled §3.1
  eligibility, §3.2 selection ordering, and the directive-per-node prose with
  the landed behavior.

## Units

1. Progression-ordinal tiebreak over the full phase order (router.ts sort).
2. Frozen-node eligibility + strategy-entry resolution (selector core).
3. Execute-side gate + directive wiring for a `tactic:align-tactics` target.
4. `/align-tactics` accepts a tactic target (per-node finalize/re-plan).
5. Spec reconciliation in `tactic-graph-native-dispatch.md`.

## Verification

- `npx vitest run --root . packages/intentionsutil/test/router.test.ts packages/intentionsutil/test/attention.test.ts packages/intentionsutil/test/check-node-selection.test.ts` — 109 passed.
- `npx tsc --noEmit -p packages/intentionsutil/tsconfig.json` — no new errors (one pre-existing, unrelated error in `graph-census-debt.test.ts`).
- `npx tsx packages/intentionsutil/scripts/validate-graph.ts` — `ok — 385 nodes`.
