### PR TITLE
Fix Graph Fast Path guard's race-dependent false-fail

### DIFF
--- a/.github/scripts/check-graph-fast-path.sh
+++ b/.github/scripts/check-graph-fast-path.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Verify a graph/** fast-path push is intentions/-only, anchored to the pushed
+# commit SHAs rather than to a moving ref.
+#
+# WHY NOT a three-dot `git diff origin/main...HEAD`: graph-commit pushes a
+# scratch SHA to trigger this workflow, then fast-forwards that SAME SHA onto
+# main. actions/checkout re-fetches origin/main at job start. If origin/main has
+# already advanced to CONTAIN HEAD by that fetch (a race), merge-base(origin/main,
+# HEAD) == HEAD, the three-dot diff is empty, and the guard false-fails a
+# genuinely valid push. The push-event payload's commit list is frozen at push
+# time and immune to where main's tip later stands, so we anchor to it instead.
+#
+# Contract: read env PUSHED_COMMITS (a JSON array of SHA strings), operate on the
+# current git repo (CWD), signal pass/fail via exit code (0 = pass, non-zero =
+# reject). Every pushed commit is examined — the fast path stamps required checks
+# green without real CI, so a multi-commit push must not slip a non-intentions
+# commit through by only inspecting HEAD.
+set -euo pipefail
+
+# Require jq (clear error over fallback, code-style.md; matches the
+# graph-commit `command -v` convention).
+if ! command -v jq >/dev/null 2>&1; then
+  echo "::error::jq is required to parse PUSHED_COMMITS but was not found on PATH."
+  exit 1
+fi
+
+# Parse the JSON array of pushed commit SHAs.
+mapfile -t SHAS < <(printf '%s' "${PUSHED_COMMITS:-}" | jq -r '.[]')
+
+# Fail-closed on an empty commit list. An empty `commits` array occurs only in
+# the degenerate "scratch SHA already reachable from another ref at push time"
+# case (a re-push of an already-landed SHA). Today's three-dot guard ALSO
+# false-fails in that same case, so refusing here is not a new regression — it is
+# the intended fail-closed behavior. Falling back to head_commit.id or an
+# origin/main range would fail OPEN and defeat the guard's purpose.
+if [ "${#SHAS[@]}" -eq 0 ]; then
+  echo "::error::PUSHED_COMMITS is empty — no pushed commits to verify. Refusing to fast-path (fail-closed)."
+  exit 1
+fi
+
+BAD_PATHS=""
+NONREGULAR=""
+ANY_CHANGES=""
+
+for sha in "${SHAS[@]}"; do
+  # Reject merge commits (>1 parent): `git diff-tree` without -m/-c prints
+  # NOTHING for a merge commit, so its changes would silently go unexamined.
+  # The guard sits over attacker-influenceable push content, so this must be
+  # explicit. `rev-list --no-walk --parents` prints "<commit> <parent>..." — the
+  # parent count is the word count minus one.
+  parents_line=$(git rev-list --no-walk --parents "$sha")
+  nwords=$(printf '%s\n' "$parents_line" | wc -w)
+  nparents=$(( nwords - 1 ))
+  if [ "$nparents" -gt 1 ]; then
+    echo "::error::graph/** fast path rejects merge commits. $sha has $nparents parents."
+    exit 1
+  fi
+
+  # Collect changed entries. --root makes a parentless (first) commit show as
+  # all-adds instead of printing nothing; -r recurses into subtrees to real file
+  # paths; --no-commit-id drops the leading commit-SHA-only header line. Each
+  # line: ":<srcmode> <dstmode> <srcsha> <dstsha> <status>\t<path>".
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    ANY_CHANGES="yes"
+    # Destination mode is whitespace field 2 (field 1 is ":<srcmode>").
+    dstmode=$(printf '%s' "$line" | awk '{print $2}')
+    # Path is everything after the first TAB (a path could contain a space).
+    path=${line#*$'\t'}
+    if [ "$dstmode" = "120000" ] || [ "$dstmode" = "160000" ]; then
+      NONREGULAR+="$sha: $line"$'\n'
+    fi
+    case "$path" in
+      intentions/*) ;;
+      *) BAD_PATHS+="$sha: $path"$'\n' ;;
+    esac
+  done < <(git diff-tree --no-commit-id --raw -r --root "$sha")
+done
+
+if [ -n "$BAD_PATHS" ]; then
+  echo "::error::graph/** fast path only accepts intentions/-only pushes. Non-intentions/ paths changed:"
+  printf '%s' "$BAD_PATHS"
+  exit 1
+fi
+
+if [ -n "$NONREGULAR" ]; then
+  echo "::error::graph/** fast path only accepts regular files under intentions/. Symlink/gitlink entries changed:"
+  printf '%s' "$NONREGULAR"
+  exit 1
+fi
+
+# Exit 0 requires a non-empty union of changed paths. If every pushed commit was
+# a no-op (empty diff), there is nothing to fast-path — fail-closed, matching the
+# old guard's "-z CHANGED" rejection.
+if [ -z "$ANY_CHANGES" ]; then
+  echo "::error::No changes across the pushed commits — nothing to fast-path."
+  exit 1
+fi
+
+exit 0

--- a/.github/scripts/test-check-graph-fast-path.sh
+++ b/.github/scripts/test-check-graph-fast-path.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# Test suite for check-graph-fast-path.sh
+# Usage: ./test-check-graph-fast-path.sh
+#
+# Creates hermetic temp git repos and drives the guard script by setting the
+# PUSHED_COMMITS env var to a JSON array of commit SHAs, with CWD set to the
+# temp repo. Each case asserts the expected exit code and, where relevant, that
+# stderr names the offending path / reason.
+#
+# The core regression case simulates the original race: a valid intentions/-only
+# commit whose SHA is ALSO reachable from origin/main at check time (so the old
+# three-dot `git diff origin/main...HEAD` guard would resolve to an empty diff
+# and false-fail). The rewritten guard reads the frozen PUSHED_COMMITS list and
+# never consults origin/main, so it still passes.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-graph-fast-path.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# ---------------------------------------------------------------------------
+# Cleanup: remove all temp dirs on exit
+# ---------------------------------------------------------------------------
+TMPDIRS=()
+cleanup() {
+  for d in "${TMPDIRS[@]}"; do
+    rm -rf "$d"
+  done
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# make_temp_repo — initialise a hermetic git repo (identity set, no commits).
+# Prints the repo path.
+make_temp_repo() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  TMPDIRS+=("$tmpdir")
+
+  git -C "$tmpdir" init -q -b main
+  git -C "$tmpdir" config user.email "test@test.local"
+  git -C "$tmpdir" config user.name "Test"
+
+  printf '%s\n' "$tmpdir"
+}
+
+# shas_json SHA... — build a JSON array of SHA strings for PUSHED_COMMITS.
+# Uses jq --args so any SHA value is quoted correctly; prints "[]" for no args.
+shas_json() {
+  jq -n '$ARGS.positional' --args "$@"
+}
+
+# run_check REPO_DIR SHAS_JSON — run check-graph-fast-path.sh with CWD=repo and
+# PUSHED_COMMITS=SHAS_JSON. Sets RC and STDERR (combined stdout+stderr, since the
+# guard emits its ::error:: messages on stdout) for assertion helpers.
+RC=0
+STDERR=""
+run_check() {
+  local repo="$1" shas="$2"
+  RC=0
+  STDERR=""
+  STDERR=$(cd "$repo" && export PUSHED_COMMITS="$shas" && "$CHECK_SCRIPT" 2>&1) || RC=$?
+}
+
+# assert_exit EXPECTED_RC DESCRIPTION
+assert_exit() {
+  local expected="$1" desc="$2"
+  TOTAL=$((TOTAL + 1))
+  if [ "$RC" -eq "$expected" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc — expected exit $expected, got $RC"
+    if [ -n "$STDERR" ]; then
+      printf '%s\n' "$STDERR" | sed 's/^/    /'
+    fi
+  fi
+}
+
+# assert_stderr_contains PATTERN DESCRIPTION
+assert_stderr_contains() {
+  local pattern="$1" desc="$2"
+  TOTAL=$((TOTAL + 1))
+  if printf '%s\n' "$STDERR" | grep -qF -- "$pattern"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc — stderr missing pattern: $pattern"
+    if [ -n "$STDERR" ]; then
+      printf '%s\n' "$STDERR" | sed 's/^/    /'
+    else
+      echo "    <empty stderr>"
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case (a): Race regression — origin/main already CONTAINS the pushed commit.
+#
+# THE CORE CASE. Commit an intentions/-only change, then advance origin/main to
+# point AT that same commit (merge-base(origin/main,HEAD) == HEAD). A three-dot
+# `git diff origin/main...HEAD` would be empty and false-fail. The guard reads
+# only PUSHED_COMMITS, examines the commit's own diff, sees intentions/-only, and
+# passes.
+# ---------------------------------------------------------------------------
+echo "--- case (a): race — origin/main contains commit → exit 0 ---"
+REPO=$(make_temp_repo)
+
+mkdir -p "$REPO/intentions"
+printf 'strategy body\n' > "$REPO/intentions/strategy-foo.md"
+git -C "$REPO" add intentions/strategy-foo.md
+git -C "$REPO" commit -q -m "add intention"
+SHA=$(git -C "$REPO" rev-parse HEAD)
+# Advance origin/main to CONTAIN (== ) the pushed commit — the race condition.
+git -C "$REPO" update-ref refs/remotes/origin/main "$SHA"
+
+run_check "$REPO" "$(shas_json "$SHA")"
+assert_exit 0 "(a) race regression: exit 0"
+
+# ---------------------------------------------------------------------------
+# Case (b): Multi-commit push, all intentions/-only → exit 0.
+#
+# Two commits, each touching a distinct intentions/ file. Asserts EVERY listed
+# commit is examined and accepted, not just HEAD.
+# ---------------------------------------------------------------------------
+echo "--- case (b): multi-commit intentions-only → exit 0 ---"
+REPO=$(make_temp_repo)
+
+mkdir -p "$REPO/intentions"
+printf 'a\n' > "$REPO/intentions/a.md"
+git -C "$REPO" add intentions/a.md
+git -C "$REPO" commit -q -m "add a"
+SHA1=$(git -C "$REPO" rev-parse HEAD)
+
+printf 'b\n' > "$REPO/intentions/b.md"
+git -C "$REPO" add intentions/b.md
+git -C "$REPO" commit -q -m "add b"
+SHA2=$(git -C "$REPO" rev-parse HEAD)
+
+run_check "$REPO" "$(shas_json "$SHA1" "$SHA2")"
+assert_exit 0 "(b) multi-commit intentions-only: exit 0"
+
+# ---------------------------------------------------------------------------
+# Case (c): A pushed commit touches a non-intentions/ path → exit 1.
+#
+# The commit adds an intentions/ file AND a repo-root source file. Asserts the
+# guard rejects and names the offending path.
+# ---------------------------------------------------------------------------
+echo "--- case (c): non-intentions/ path in push → exit 1 ---"
+REPO=$(make_temp_repo)
+
+mkdir -p "$REPO/intentions"
+printf 'a\n' > "$REPO/intentions/a.md"
+printf 'export const x = 1;\n' > "$REPO/src.ts"
+git -C "$REPO" add intentions/a.md src.ts
+git -C "$REPO" commit -q -m "add intention + stray source"
+SHA=$(git -C "$REPO" rev-parse HEAD)
+
+run_check "$REPO" "$(shas_json "$SHA")"
+assert_exit 1 "(c) non-intentions/ path: exit 1"
+assert_stderr_contains "src.ts" "(c) non-intentions/ path: offending path named"
+
+# ---------------------------------------------------------------------------
+# Case (d): Symlink-mode (120000) entry under intentions/ → exit 1.
+#
+# Built hermetically with update-index --cacheinfo so no filesystem symlink
+# support is required. The blob content is the (irrelevant) link target text; the
+# 120000 mode is what the guard rejects.
+# ---------------------------------------------------------------------------
+echo "--- case (d): symlink-mode entry under intentions/ → exit 1 ---"
+REPO=$(make_temp_repo)
+
+BLOB=$(printf 'some/target/path' | git -C "$REPO" hash-object -w --stdin)
+git -C "$REPO" update-index --add --cacheinfo "120000,$BLOB,intentions/x.md"
+git -C "$REPO" commit -q -m "add symlink under intentions"
+SHA=$(git -C "$REPO" rev-parse HEAD)
+
+run_check "$REPO" "$(shas_json "$SHA")"
+assert_exit 1 "(d) symlink-mode entry: exit 1"
+assert_stderr_contains "intentions/x.md" "(d) symlink-mode entry: offending path named"
+
+# ---------------------------------------------------------------------------
+# Case (d2): Gitlink-mode (160000) entry under intentions/ → exit 1.
+#
+# A submodule-style gitlink entry (a commit SHA at a tree path). The 160000 mode
+# is rejected as non-regular.
+# ---------------------------------------------------------------------------
+echo "--- case (d2): gitlink-mode entry under intentions/ → exit 1 ---"
+REPO=$(make_temp_repo)
+
+# Any 40-hex value serves as the gitlink's target commit for mode purposes.
+GITLINK_SHA="0123456789012345678901234567890123456789"
+git -C "$REPO" update-index --add --cacheinfo "160000,$GITLINK_SHA,intentions/sub"
+git -C "$REPO" commit -q -m "add gitlink under intentions"
+SHA=$(git -C "$REPO" rev-parse HEAD)
+
+run_check "$REPO" "$(shas_json "$SHA")"
+assert_exit 1 "(d2) gitlink-mode entry: exit 1"
+assert_stderr_contains "intentions/sub" "(d2) gitlink-mode entry: offending path named"
+
+# ---------------------------------------------------------------------------
+# Case (e): Empty PUSHED_COMMITS ([]) → exit 1 (fail-closed).
+# ---------------------------------------------------------------------------
+echo "--- case (e): empty PUSHED_COMMITS → exit 1 (fail-closed) ---"
+REPO=$(make_temp_repo)
+
+run_check "$REPO" "$(shas_json)"
+assert_exit 1 "(e) empty PUSHED_COMMITS: exit 1"
+assert_stderr_contains "empty" "(e) empty PUSHED_COMMITS: fail-closed reason named"
+
+# ---------------------------------------------------------------------------
+# Case (f): A merge commit among the pushed SHAs → exit 1.
+#
+# `git diff-tree` without -m prints nothing for a merge, so its changes would go
+# unexamined — the guard rejects any pushed SHA with >1 parent outright.
+# ---------------------------------------------------------------------------
+echo "--- case (f): merge commit in push → exit 1 ---"
+REPO=$(make_temp_repo)
+
+mkdir -p "$REPO/intentions"
+printf 'base\n' > "$REPO/intentions/base.md"
+git -C "$REPO" add intentions/base.md
+git -C "$REPO" commit -q -m "base"
+
+git -C "$REPO" checkout -q -b side
+printf 'a\n' > "$REPO/intentions/a.md"
+git -C "$REPO" add intentions/a.md
+git -C "$REPO" commit -q -m "side add a"
+
+git -C "$REPO" checkout -q main
+printf 'b\n' > "$REPO/intentions/b.md"
+git -C "$REPO" add intentions/b.md
+git -C "$REPO" commit -q -m "main add b"
+
+git -C "$REPO" merge -q --no-ff --no-edit side
+MERGE_SHA=$(git -C "$REPO" rev-parse HEAD)
+
+run_check "$REPO" "$(shas_json "$MERGE_SHA")"
+assert_exit 1 "(f) merge commit in push: exit 1"
+assert_stderr_contains "merge commits" "(f) merge commit in push: merge reason named"
+
+# ---------------------------------------------------------------------------
+# Case (g): A path with a space under intentions/ → exit 0.
+#
+# Asserts the guard's TAB-based path parsing: `git diff-tree --raw` emits
+# ":<srcmode> <dstmode> <srcsha> <dstsha> <status>\t<path>", so a space in the
+# path must not be misread as a field boundary.
+# ---------------------------------------------------------------------------
+echo "--- case (g): space in intentions/ path → exit 0 ---"
+REPO=$(make_temp_repo)
+
+mkdir -p "$REPO/intentions"
+printf 'x\n' > "$REPO/intentions/my node.md"
+git -C "$REPO" add "intentions/my node.md"
+git -C "$REPO" commit -q -m "add spaced-path intention"
+SHA=$(git -C "$REPO" rev-parse HEAD)
+
+run_check "$REPO" "$(shas_json "$SHA")"
+assert_exit 0 "(g) space in intentions/ path: exit 0"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $TOTAL total"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+echo "All tests passed."

--- a/.github/workflows/graph-fast-path.yml
+++ b/.github/workflows/graph-fast-path.yml
@@ -18,30 +18,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Verify the push is intentions/-only
-        run: |
-          set -euo pipefail
-          CHANGED=$(git diff --name-only origin/main...HEAD)
-          if [ -z "$CHANGED" ]; then
-            echo "::error::No changes relative to origin/main — nothing to fast-path."
-            exit 1
-          fi
-          BAD=$(printf '%s\n' "$CHANGED" | grep -v '^intentions/' || true)
-          if [ -n "$BAD" ]; then
-            echo "::error::graph/** fast path only accepts intentions/-only pushes. Non-intentions/ paths changed:"
-            printf '%s\n' "$BAD"
-            exit 1
-          fi
-          # The name-only filter above says nothing about file TYPE: a committed
-          # symlink (mode 120000) or gitlink (mode 160000) at intentions/x.md
-          # passes the name check. Reject any changed intentions/ entry whose
-          # destination mode is not a regular blob, so validate-graph below only
-          # ever parses regular files.
-          NONREGULAR=$(git diff --raw origin/main...HEAD -- intentions/ | awk '$2 == "120000" || $2 == "160000"' || true)
-          if [ -n "$NONREGULAR" ]; then
-            echo "::error::graph/** fast path only accepts regular files under intentions/. Symlink/gitlink entries changed:"
-            printf '%s\n' "$NONREGULAR"
-            exit 1
-          fi
+        env:
+          PUSHED_COMMITS: ${{ toJSON(github.event.commits.*.id) }}
+        run: .github/scripts/check-graph-fast-path.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .node-version

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -213,6 +213,8 @@ jobs:
         run: .github/scripts/test-check-firestore-query-bounds.sh
       - name: Run test-integrity script tests
         run: .github/scripts/test-check-test-integrity.sh
+      - name: Run graph fast-path guard script tests
+        run: .github/scripts/test-check-graph-fast-path.sh
 
   test-integrity:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes a race-dependent false-fail in the Graph Fast Path guard job
(`.github/workflows/graph-fast-path.yml`): the guard used to run
`git diff --name-only origin/main...HEAD`, whose merge-base collapses to HEAD
(empty diff) once `origin/main` has advanced to contain HEAD by checkout time —
a race `graph-commit`'s scratch-push-then-fast-forward flow can trigger.

The fix anchors the check to the frozen push-payload commit SHAs
(`github.event.commits.*.id`) instead of the moving `origin/main` ref, examining
every pushed commit (not just HEAD) so a multi-commit push can't slip a
non-intentions commit past the guard.

- `.github/scripts/check-graph-fast-path.sh` — the extracted, ref-independent
  guard script (fails closed on an empty commit list, rejects merge commits,
  non-`intentions/` paths, and symlink/gitlink entries).
- `.github/workflows/graph-fast-path.yml` — the guard step now invokes the
  script with `PUSHED_COMMITS` from the push payload.
- `.github/scripts/test-check-graph-fast-path.sh` — hermetic test suite,
  including the core race-regression case, wired into `unit-tests.yml`'s
  `hook-tests` job.

Implements tactic-graph-fastpath-guard-diff-base.
