### PR TITLE
Scope-inert re-stamp primitive for align-round tactic body edits

### DIFF
--- a/.claude/skills/align-strategy/SKILL.md
+++ b/.claude/skills/align-strategy/SKILL.md
@@ -474,6 +474,55 @@ landed with `office_hours` set instead of the intended content (a
 concurrent-edit conflict) — tell the author and stop; do not retry
 automatically.
 
+**Scope-inert re-stamp — protect a tactic's own scope custody.** If this
+round's edit touched the **body** (not just frontmatter) of an in-flight
+tactic — a node with a phase set, i.e. an open child (not `draft`, not
+`done`), the same population the Materiality-scoped-freeze section below
+discusses — then that body edit trips the tactic's own chain-of-custody
+scope gate: the worktree-local `.claude/worktrees/<id>.scope-fingerprint`
+stamp no longer matches the tactic's current body fingerprint, and the gate
+demotes the tactic back to `implement`, discarding its qa/review custody.
+That is correct for a real plan-substance change, but this interview
+sometimes must edit an open tactic's body for a **scope-inert** reason — a
+reconciliation note, a drift-review correction, a provenance annotation, or
+any other body edit clarification 38's amendment-completeness bar produces —
+where the plan substance is unchanged. For those, the demotion is spurious.
+
+Classify this round's own edit, per tactic, as **scope-inert** (plan
+substance unchanged — e.g. a provenance/reconciliation annotation) versus
+**material or unsure**. The rule is fail-closed: **only** a confident
+scope-inert verdict re-stamps; on **any** doubt — including a merely
+plausible substance change — do nothing further here. Leave the stamp
+untouched and let custody demote the tactic exactly as it does today. That
+demotion-on-doubt is the existing correct behavior, not a failure mode to
+work around.
+
+For each tactic whose edit is confidently scope-inert, **after** the body
+edit has landed via `graph-commit` in this **same** round (so it is on
+origin/main), run:
+
+```bash
+npx tsx packages/intentionsutil/scripts/restamp-scope-fingerprint.ts <tactic-id>
+```
+
+It must run post-`graph-commit`: the script reads the tactic's current
+on-disk body and the current `origin/main` sha to compute the stamp, so a
+pre-landing run would stamp stale content. It re-writes **only** the
+worktree-local `.scope-fingerprint` file — it is never a node write and
+never a `graph-commit` of its own.
+
+Record the classification in this round's own record/summary — the
+scope-inert verdict and the tactic ids re-stamped — as the audit trail the
+doctrine requires.
+
+This is a **separate** stamp from the Materiality-scoped-freeze section that
+follows, not an extension of it. That section's `execution.strategy_fingerprint`
+freeze protects open children broadly against **strategy**-substance drift;
+this step's worktree-local `.scope-fingerprint` re-stamp protects a single
+**tactic**'s own scope-custody gate from being tripped by a scope-inert edit
+to that tactic's own body. Two unrelated stamps, two unrelated mechanisms —
+do not conflate them.
+
 **Materiality-scoped freeze — classify each open child.** If this is an edit
 to a strategy that has open (non-draft, non-`done`) child tactics with an
 existing stamped `execution.strategy_fingerprint` entry for this strategy, the

--- a/.claude/skills/align-tactics/SKILL.md
+++ b/.claude/skills/align-tactics/SKILL.md
@@ -623,6 +623,51 @@ decompose fresh. It:
    against this strategy without disturbing the others. (A tactic still at
    `execution: null` has no map to re-stamp until the machinery seeds one.)
 4. Lands the amendments via `graph-commit`.
+5. **Scope-inert re-stamp — protect each amended tactic's own scope custody.**
+   Step 2's amendment edits the **body** of open (non-`draft`, non-`done`)
+   tactics — precisely clarification 32's amendment-completeness scenario. A
+   body edit to an in-flight tactic trips that tactic's own chain-of-custody
+   scope gate: the worktree-local `.claude/worktrees/<id>.scope-fingerprint`
+   stamp no longer matches the tactic's current body fingerprint, and the gate
+   demotes the tactic back to `implement`, discarding its qa/review custody.
+   That is correct for a real plan-substance change, but an amendment mandated
+   solely by the completeness bar — a reconciliation note, a provenance
+   annotation, a drift-review correction — often leaves the plan substance
+   unchanged, and there the demotion is spurious (PR #2888 was falsely demoted
+   from review to implement this way).
+
+   Classify this round's own edit, **per tactic**, as **scope-inert** (plan
+   substance unchanged) versus **material or unsure**. The rule is fail-closed:
+   **only** a confident scope-inert verdict re-stamps; on **any** doubt — a
+   merely plausible substance change included — do nothing further here. Leave
+   the worktree-local stamp untouched and let custody demote the tactic exactly
+   as it does today; that demotion-on-doubt is the existing correct behavior,
+   not a failure mode to work around.
+
+   For each confidently scope-inert tactic, **after** its amendment has landed
+   via `graph-commit` in this **same** round (step 4, so it is on origin/main),
+   run:
+
+   ```bash
+   npx tsx packages/intentionsutil/scripts/restamp-scope-fingerprint.ts <tactic-id>
+   ```
+
+   It must run post-`graph-commit`: the script reads the tactic's current
+   on-disk body and the current `origin/main` sha to compute the stamp, so a
+   pre-landing run would stamp stale content. Record the scope-inert
+   classification and the re-stamped tactic ids in this round's record.
+
+   This is a **completely different** mechanism from item 3's re-stamp — do not
+   conflate the two. Item 3 re-stamps `execution.strategy_fingerprint`, a
+   **node-frontmatter** map keyed per serving strategy, computed via
+   `strategyFingerprint`, and landed as a node write in the round's
+   `graph-commit`; it tracks per-strategy substance drift across the subtree.
+   This item re-stamps the worktree-local
+   `.claude/worktrees/<id>.scope-fingerprint` **file**, computed via
+   `tacticScopeFingerprint` through the Unit-1 script; it is **never** a node
+   write and **never** a `graph-commit` of its own, and it tracks a single
+   tactic's own body-scope drift. Two unrelated stamps, two unrelated
+   mechanisms.
 
 Until a live router exists, re-evaluation runs **inline** in the same session
 that recorded the strategy edit — the way every round on

--- a/packages/intentionsutil/scripts/restamp-scope-fingerprint.ts
+++ b/packages/intentionsutil/scripts/restamp-scope-fingerprint.ts
@@ -1,0 +1,163 @@
+// restamp-scope-fingerprint — re-stamp a tactic's worktree-local
+// scope-custody stamp after an author-present align round classifies its own
+// tactic-body edit as scope-inert (tactic-scope-inert-restamp-primitive
+// Unit 1).
+//
+// The chain-of-custody gate demotes an in-flight tactic to phase `implement`
+// whenever its worktree-local `.scope-fingerprint` stamp no longer matches
+// the current `tacticScopeFingerprint(statement, body)`. When an align round
+// edits a tactic's body in a way that does NOT change its scope (a
+// scope-inert edit — e.g. wording, formatting, a residue note that does not
+// alter what the tactic commits to), it needs a way to re-stamp so the next
+// freshness check does not demote the tactic for an edit a human already
+// classified as harmless. This script performs exactly that mechanical
+// re-stamp, once told to.
+//
+// This is a standalone TypeScript PORT of transition-node's `refresh_stamp()`
+// bash recipe (`.claude/skills/dispatch-propagate/scripts/transition-node:85-98`),
+// NOT a shared helper — the two have different failure-mode contracts:
+// `refresh_stamp()` is a best-effort background refresh that fails OPEN (every
+// step is guarded by `|| return 0`, so a failure silently no-ops); this script
+// fails LOUD, because it IS the re-stamp action following a human
+// classification decision — a silent failure here would leave the align round
+// believing the stamp was refreshed when it was not. This unit does not
+// modify `transition-node` or its `refresh_stamp()` function in any way; that
+// script keeps working exactly as it does today.
+//
+// Usage:
+//   npx tsx packages/intentionsutil/scripts/restamp-scope-fingerprint.ts \
+//     [--repo-root <dir>] [--main-root <dir>] <id>
+//
+// Writes `<mainRoot>/.claude/worktrees/<id>.scope-fingerprint` with content
+// `<fingerprint> <sha>\n` (matching `parseScopeStamp` in
+// packages/intentionsutil/src/transitions.ts, which splits on whitespace and
+// expects exactly two fields), and prints the same line to stdout.
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { tacticScopeFingerprint } from "../src/router.js";
+import { readNode, readNodeBody } from "../src/store.js";
+
+// --- Paths -------------------------------------------------------------
+// The script lives at `packages/intentionsutil/scripts/restamp-scope-fingerprint.ts`,
+// so the repo root is three directories up. Resolve from this file's own
+// location, never from cwd — matching dump-node.ts.
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const defaultRepoRoot = dirname(dirname(dirname(scriptDir)));
+
+const USAGE =
+  "usage: restamp-scope-fingerprint.ts [--repo-root <dir>] [--main-root <dir>] <id>\n" +
+  "  Re-stamps <main-root>/.claude/worktrees/<id>.scope-fingerprint with the\n" +
+  "  current tacticScopeFingerprint(statement, body) and the current\n" +
+  "  origin/main sha. Prints '<fingerprint> <sha>' to stdout on success.\n";
+
+// --- Core helper (exported for tests) -----------------------------------
+
+/**
+ * Re-stamp the worktree-local scope-custody stamp for tactic `id`.
+ *
+ * Reads the node's current statement/body from `intentionsDir`, recomputes
+ * `tacticScopeFingerprint`, resolves the current `origin/main` sha from
+ * `repoRoot`, and writes `<mainRoot>/.claude/worktrees/<id>.scope-fingerprint`
+ * as `<fingerprint> <sha>\n`.
+ *
+ * Unlike transition-node's `refresh_stamp()`, this function propagates every
+ * failure (a nonexistent node id, a git failure, a write failure) as a
+ * thrown error rather than swallowing it — the caller is expected to be an
+ * explicit human-invoked re-stamp action, not a best-effort background step.
+ */
+export function restampScope(
+  intentionsDir: string,
+  repoRoot: string,
+  mainRoot: string,
+  id: string,
+): { fingerprint: string; sha: string } {
+  const statement = readNode(intentionsDir, id).statement;
+  const body = readNodeBody(intentionsDir, id);
+  const fingerprint = tacticScopeFingerprint(statement, body);
+  const sha = execFileSync("git", ["rev-parse", "origin/main"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  }).trim();
+
+  const stampPath = join(mainRoot, ".claude", "worktrees", `${id}.scope-fingerprint`);
+  mkdirSync(dirname(stampPath), { recursive: true });
+  writeFileSync(stampPath, `${fingerprint} ${sha}\n`);
+
+  return { fingerprint, sha };
+}
+
+// --- Main ----------------------------------------------------------------
+
+function resolveMainRoot(): string {
+  const gitCommonDir = execFileSync(
+    "git",
+    ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    { encoding: "utf8" },
+  ).trim();
+  return dirname(gitCommonDir);
+}
+
+function run(): void {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(USAGE);
+    return;
+  }
+
+  let repoRoot = defaultRepoRoot;
+  const repoRootIdx = args.indexOf("--repo-root");
+  if (repoRootIdx !== -1) {
+    const v = args[repoRootIdx + 1];
+    if (!v) {
+      process.stderr.write("restamp-scope-fingerprint: --repo-root requires a directory argument\n" + USAGE);
+      process.exit(1);
+    }
+    repoRoot = v;
+  }
+
+  let mainRoot = resolveMainRoot();
+  const mainRootIdx = args.indexOf("--main-root");
+  if (mainRootIdx !== -1) {
+    const v = args[mainRootIdx + 1];
+    if (!v) {
+      process.stderr.write("restamp-scope-fingerprint: --main-root requires a directory argument\n" + USAGE);
+      process.exit(1);
+    }
+    mainRoot = v;
+  }
+
+  const intentionsDir = join(repoRoot, "intentions");
+
+  const skipIdx = new Set<number>();
+  if (repoRootIdx !== -1) {
+    skipIdx.add(repoRootIdx);
+    skipIdx.add(repoRootIdx + 1);
+  }
+  if (mainRootIdx !== -1) {
+    skipIdx.add(mainRootIdx);
+    skipIdx.add(mainRootIdx + 1);
+  }
+  const positional = args.filter((a, i) => !skipIdx.has(i) && !a.startsWith("-"));
+  if (positional.length !== 1) {
+    process.stderr.write("restamp-scope-fingerprint: exactly one node id is required\n" + USAGE);
+    process.exit(1);
+  }
+  const id = positional[0];
+
+  try {
+    const { fingerprint, sha } = restampScope(intentionsDir, repoRoot, mainRoot, id);
+    process.stdout.write(`${fingerprint} ${sha}\n`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`restamp-scope-fingerprint: ${message}\n`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run();
+}

--- a/packages/intentionsutil/scripts/restamp-scope-fingerprint.ts
+++ b/packages/intentionsutil/scripts/restamp-scope-fingerprint.ts
@@ -91,11 +91,11 @@ export function restampScope(
 
 // --- Main ----------------------------------------------------------------
 
-function resolveMainRoot(): string {
+function resolveMainRoot(repoRoot: string): string {
   const gitCommonDir = execFileSync(
     "git",
     ["rev-parse", "--path-format=absolute", "--git-common-dir"],
-    { encoding: "utf8" },
+    { cwd: repoRoot, encoding: "utf8" },
   ).trim();
   return dirname(gitCommonDir);
 }
@@ -119,29 +119,45 @@ function run(): void {
     repoRoot = v;
   }
 
-  let mainRoot = resolveMainRoot();
+  // Capture the --main-root override but do NOT resolve the main root yet: when
+  // it is supplied we must not shell out to git at all, and when it is absent
+  // the resolution must run inside the try/catch below so a git failure surfaces
+  // through the clean error path rather than as an uncaught throw.
   const mainRootIdx = args.indexOf("--main-root");
+  let mainRootValue: string | null = null;
   if (mainRootIdx !== -1) {
     const v = args[mainRootIdx + 1];
     if (!v) {
       process.stderr.write("restamp-scope-fingerprint: --main-root requires a directory argument\n" + USAGE);
       process.exit(1);
     }
-    mainRoot = v;
+    mainRootValue = v;
   }
 
   const intentionsDir = join(repoRoot, "intentions");
 
-  const skipIdx = new Set<number>();
+  // Indices consumed by recognized flags and their values. Anything left that
+  // begins with `-` is an unrecognized flag: reject it (mirroring
+  // compute-freshness.ts) rather than silently dropping it as a fallback.
+  const consumed = new Set<number>();
   if (repoRootIdx !== -1) {
-    skipIdx.add(repoRootIdx);
-    skipIdx.add(repoRootIdx + 1);
+    consumed.add(repoRootIdx);
+    consumed.add(repoRootIdx + 1);
   }
   if (mainRootIdx !== -1) {
-    skipIdx.add(mainRootIdx);
-    skipIdx.add(mainRootIdx + 1);
+    consumed.add(mainRootIdx);
+    consumed.add(mainRootIdx + 1);
   }
-  const positional = args.filter((a, i) => !skipIdx.has(i) && !a.startsWith("-"));
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (consumed.has(i)) continue;
+    const a = args[i];
+    if (a.startsWith("-")) {
+      process.stderr.write(`restamp-scope-fingerprint: unknown flag '${a}'\n` + USAGE);
+      process.exit(1);
+    }
+    positional.push(a);
+  }
   if (positional.length !== 1) {
     process.stderr.write("restamp-scope-fingerprint: exactly one node id is required\n" + USAGE);
     process.exit(1);
@@ -149,6 +165,7 @@ function run(): void {
   const id = positional[0];
 
   try {
+    const mainRoot = mainRootValue ?? resolveMainRoot(repoRoot);
     const { fingerprint, sha } = restampScope(intentionsDir, repoRoot, mainRoot, id);
     process.stdout.write(`${fingerprint} ${sha}\n`);
   } catch (err) {

--- a/packages/intentionsutil/test/restamp-scope-fingerprint.test.ts
+++ b/packages/intentionsutil/test/restamp-scope-fingerprint.test.ts
@@ -73,4 +73,32 @@ describe("restampScope", () => {
 
     expect(() => restampScope(intentionsDir, realRepoRoot, mainRoot, "tactic-does-not-exist")).toThrow();
   });
+
+  it("propagates a git failure (fails LOUD) when origin/main cannot be resolved", () => {
+    // The node exists, so readNode/readNodeBody succeed and the failure comes
+    // from the `git rev-parse origin/main` call — exercising the script's
+    // central distinguishing contract versus transition-node's
+    // `refresh_stamp()`, which fails OPEN. `repoRoot` here is a bare scratch
+    // dir that is not a git repo, so `git rev-parse origin/main` fails and the
+    // error must propagate rather than be swallowed.
+    const intentionsDir = tempDir();
+    const mainRoot = tempDir();
+    const nonGitRepoRoot = tempDir();
+
+    writeNodeFromJson(
+      intentionsDir,
+      JSON.stringify({
+        id: "tactic-git-failure-fixture",
+        kind: "tactic",
+        statement: "Fail loud when origin/main cannot be resolved.",
+        owner: "human",
+        status: "codified",
+        parent: null,
+      }),
+    );
+
+    expect(() =>
+      restampScope(intentionsDir, nonGitRepoRoot, mainRoot, "tactic-git-failure-fixture"),
+    ).toThrow();
+  });
 });

--- a/packages/intentionsutil/test/restamp-scope-fingerprint.test.ts
+++ b/packages/intentionsutil/test/restamp-scope-fingerprint.test.ts
@@ -1,0 +1,76 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { tacticScopeFingerprint } from "../src/router.js";
+import { restampScope } from "../scripts/restamp-scope-fingerprint.js";
+import { writeNodeFromJson } from "../scripts/write-node.js";
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), "intentions-"));
+}
+
+// `restampScope` shells out to `git rev-parse origin/main`, so `repoRoot`
+// must be a real checkout with a real `origin/main` — use this repo's own
+// root rather than a fixture repo. `intentionsDir` and `mainRoot` stay
+// scratch temp dirs so the test never touches the real
+// `.claude/worktrees/` stamp directory.
+const realRepoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+
+describe("restampScope", () => {
+  it("writes a two-field stamp matching the recomputed fingerprint and current origin/main sha", () => {
+    const intentionsDir = tempDir();
+    const mainRoot = tempDir();
+    const statement = "Restamp scope after a scope-inert align-round edit.";
+
+    writeNodeFromJson(
+      intentionsDir,
+      JSON.stringify({
+        id: "tactic-restamp-fixture",
+        kind: "tactic",
+        statement,
+        owner: "human",
+        status: "codified",
+        parent: null,
+      }),
+    );
+
+    const result = restampScope(intentionsDir, realRepoRoot, mainRoot, "tactic-restamp-fixture");
+
+    const stampPath = join(mainRoot, ".claude", "worktrees", "tactic-restamp-fixture.scope-fingerprint");
+    const content = readFileSync(stampPath, "utf8");
+
+    // Exactly one line, trailing newline, exactly two whitespace-separated fields.
+    expect(content.endsWith("\n")).toBe(true);
+    const lines = content.split("\n").filter((l) => l !== "");
+    expect(lines).toHaveLength(1);
+    const parts = lines[0].split(/\s+/);
+    expect(parts).toHaveLength(2);
+
+    const [fingerprintField, shaField] = parts;
+    const expectedSha = execFileSync("git", ["rev-parse", "origin/main"], {
+      cwd: realRepoRoot,
+      encoding: "utf8",
+    }).trim();
+    // The body of a freshly-written node is the generated `# ${statement}\n`
+    // placeholder (writeNode's fallback for a brand-new file).
+    const expectedFingerprint = tacticScopeFingerprint(statement, `# ${statement}\n`);
+
+    expect(fingerprintField).toBe(expectedFingerprint);
+    expect(shaField).toBe(expectedSha);
+    expect(content).toBe(`${expectedFingerprint} ${expectedSha}\n`);
+
+    expect(result.fingerprint).toBe(expectedFingerprint);
+    expect(result.sha).toBe(expectedSha);
+  });
+
+  it("throws on a nonexistent node id", () => {
+    const intentionsDir = tempDir();
+    const mainRoot = tempDir();
+
+    expect(() => restampScope(intentionsDir, realRepoRoot, mainRoot, "tactic-does-not-exist")).toThrow();
+  });
+});


### PR DESCRIPTION
## Context

Surfaced by the 2026-07-18 `/align-strategy` interview investigating the false demotion of `tactic-graph-selector-reviewed-exclusion` (PR #2888): a doctrine-mandated scope-inert reconciliation note tripped the tactic's chain-of-custody scope-fingerprint gate and demoted a fully-reviewed node from `review` back to `implement`, discarding its qa and review custody — three redundant phase sessions. The 2026-07-18 scope-inert-restamp clarification on `strategy-graph-native-dispatch` is the authoritative doctrine; this PR implements its sanctioned re-stamp mechanism.

## What changed

- **`packages/intentionsutil/scripts/restamp-scope-fingerprint.ts`** (new) — a standalone, fail-loud TypeScript port of `transition-node`'s `refresh_stamp()` bash recipe. Given a tactic id, it recomputes `tacticScopeFingerprint(statement, body)` against the node's current on-disk state and writes `<mainRoot>/.claude/worktrees/<id>.scope-fingerprint` as `<fingerprint> <sha>`. Unlike `refresh_stamp()` (a best-effort background refresh that fails open), this script throws on any failure — it IS the re-stamp action following a human classification decision, so a write failure must be visible, not silently absorbed. `transition-node` itself is untouched.
- **`packages/intentionsutil/test/restamp-scope-fingerprint.test.ts`** (new) — unit coverage for the exported `restampScope` core function.
- **`.claude/skills/align-strategy/SKILL.md`** — new "Scope-inert re-stamp" step in Step 5 — Record: after an author-present round classifies its own body edit to an in-flight tactic as scope-inert (fail-closed — any doubt leaves the stamp untouched), run the new script post-`graph-commit`. Explicitly disambiguated from the adjacent Materiality-scoped-freeze section's unrelated `execution.strategy_fingerprint` mechanism.
- **`.claude/skills/align-tactics/SKILL.md`** — the same step wired into Re-evaluation mode, where clarification 32's amendment-completeness bar is exactly the scenario producing scope-inert body edits. Disambiguated from item 3's unrelated `execution.strategy_fingerprint` re-stamp.

## Out of scope

No change to `transition-node`, `compute-freshness.ts`, `transitions.ts`, or `router.ts`. No change to the `execution.strategy_fingerprint` mechanism in either SKILL.md. No classification heuristic beyond scope-inert / material-or-unsure — the align round makes that call; this PR only builds the mechanical re-stamp.

## Verification

- `cd packages/intentionsutil && npx tsc --noEmit` — one pre-existing, unrelated failure in `test/graph-census-debt.test.ts` (confirmed present on `origin/main` before this PR, last touched by #2866; no error in either new file).
- `cd packages/intentionsutil && npx vitest run test/transitions.test.ts test/router.test.ts test/scope-sweep.test.ts test/restamp-scope-fingerprint.test.ts` — 110/110 passed.
- End-to-end: ran the new script against a scratch main-root for this repo's own `tactic-scope-inert-restamp-primitive` node; the written fingerprint/sha matched independently-computed values.
- Fail-loud check: running the script against a nonexistent node id exits 1 with a clear stderr message (not a silent no-op, unlike `refresh_stamp()`).
- Read both SKILL.md insertions in full file context: fail-closed framing is unambiguous, and neither conflates the new worktree-local `.scope-fingerprint` stamp with the existing `execution.strategy_fingerprint` mechanism.
