### PR TITLE
Add clear-park primitive (scripted inverse of park-node)

### DIFF
--- a/packages/intentionsutil/scripts/clear-park
+++ b/packages/intentionsutil/scripts/clear-park
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# clear-park — clear one intention node's office_hours park via the graph
+# write (strategy-graph-native-dispatch, clarification 65). The scripted
+# inverse of park-node: a future drain-lane skill
+# (tactic-office-hours-self-modification-skill) invokes this as its mandatory
+# terminal park disposition on green CI, since park-node currently has no
+# scripted inverse — a park is cleared today only by an incidental commit
+# side-effect or a hand-rolled inline sequence, which is unreliable for the
+# drain lane whose fix commit lands on the PR branch and never touches the
+# node frontmatter.
+#
+# Content is written through store.ts's readNode → writeNode (the validated
+# writer — frontmatter serialized correctly, tactic bodies preserved); this
+# script authors no markdown. The commit/stamp/fast-forward mechanics are
+# graph-commit's.
+#
+# If the node's office_hours is already null, this is a deliberate idempotent
+# no-op: print an informative note and exit 0 without calling graph-commit.
+#
+# Usage: clear-park <node-id> [note]
+#
+# Exit codes: 0 cleared and landed on main (or already-clear no-op); 1 the
+# write or graph-commit failed; 2 usage error.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+INTENTIONS_DIR="$REPO_ROOT/intentions"
+STORE_MODULE="$REPO_ROOT/packages/intentionsutil/src/store.js"
+
+NODE_ID="${1:-}"
+# Optional 2nd arg: free-text note folded into the commit message.
+NOTE="${2:-}"
+if [[ $# -lt 1 || $# -gt 2 || -z "$NODE_ID" ]]; then
+  echo "usage: clear-park <node-id> [note]" >&2
+  exit 2
+fi
+
+TMPTS="$(mktemp --suffix=.mts)" \
+  || { echo "clear-park: could not create temp file for the clearing write" >&2; exit 1; }
+trap 'rm -f "$TMPTS"' EXIT
+cat >"$TMPTS" <<'TS'
+// argv: <storeModule> <intentionsDir> <id>
+const [storePath, intentionsDir, id] = process.argv.slice(2);
+const { readNode, writeNode } = await import(storePath);
+const node = readNode(intentionsDir, id);
+if (node.office_hours == null) {
+  process.stderr.write(`clear-park: ${id} is not parked (office_hours already null)\n`);
+  process.exit(3);
+}
+node.office_hours = null;
+writeNode(intentionsDir, node);
+process.stderr.write(`clear-park: cleared office_hours on ${id}\n`);
+TS
+
+npx_status=0
+(cd "$REPO_ROOT" && npx tsx "$TMPTS" "$STORE_MODULE" "$INTENTIONS_DIR" "$NODE_ID" >&2) || npx_status=$?
+
+if [[ $npx_status -eq 3 ]]; then
+  echo "clear-park: $NODE_ID is not parked (office_hours already null); nothing to do" >&2
+  exit 0
+elif [[ $npx_status -ne 0 ]]; then
+  echo "clear-park: failed to clear the office_hours record for $NODE_ID" >&2
+  exit 1
+fi
+
+if [[ -n "$NOTE" ]]; then
+  MESSAGE="graph: clear office_hours park on $NODE_ID ($NOTE)"
+else
+  MESSAGE="graph: clear office_hours park on $NODE_ID"
+fi
+
+if ! "$SCRIPT_DIR/graph-commit" -m "$MESSAGE" "$NODE_ID"; then
+  echo "clear-park: graph-commit failed for $NODE_ID; the office_hours write is on disk but not landed" >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## What

Add `packages/intentionsutil/scripts/clear-park`, the scripted atomic inverse of
`park-node`. It clears a node's first-class `office_hours` field (`readNode →
office_hours=null → writeNode`) and lands the change on `main` through
`graph-commit`, mirroring `park-node`'s structure line-for-line.

## Why

`park-node` sets a node's `office_hours` park but has no scripted inverse. A park
is cleared today only by an incidental commit side-effect (any edit touching the
node's own frontmatter) or a hand-rolled inline sequence. The self-modification
**drain** lane triggers neither reliably — its fix commit lands on the PR branch
and never touches the node frontmatter — so a drained node was observed going
park → drain → **re-park** → clear across separate sessions
(`tactic-phase-standup-audit-lens`). `strategy-graph-native-dispatch`
clarification 65 makes an explicit, atomic terminal park disposition mandatory;
this primitive delivers the `clear-park` half of it.

## Behavior

- `clear-park <node-id> [note]` — one required node id, optional note folded into
  the commit message.
- Already-cleared guard (intentional, idempotent, not a fallback): if
  `office_hours` is already `null`, prints a note and exits 0 **without** a
  `graph-commit` (avoids an empty-diff commit).
- Exit codes mirror `park-node`: `0` cleared/landed (or already-clear no-op),
  `1` write or graph-commit failed, `2` usage error.

## Scope

One new executable script only. No change to `park-node`, `graph-commit`,
`store.ts`, `schema.ts`, the drain skill, or the emulated prompt — wiring the
call into the drain skill is the separate
`tactic-office-hours-self-modification-skill`.

## Verification

- `npx vitest run --project packages/intentionsutil --root .` — the `store.ts`
  round-trip the script relies on (533/533 passing).
- Structural inspection: mirrors `park-node`'s arg-guard, path-resolution,
  heredoc, and `graph-commit` invocation, differing only in the
  `office_hours=null` payload, the dropped `reason`/`recommendation` args, the
  already-cleared no-op guard, and the commit message.
