### PR TITLE
Model the CI-fix interrupt as orthogonal execution state, not a phase value

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/graph-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/graph-select-target
@@ -17,8 +17,19 @@
 #
 # The store is read at origin/main ONLY (never a branch, never the working
 # tree): `git archive origin/main intentions` into a temp dir. Selection makes
-# NO graph writes — parks (e.g. a strategy at the rounds cap) are events in the
-# selection log for the transition writer, never writes from here.
+# NO graph writes for eligibility/ordering parks (e.g. a strategy at the rounds
+# cap) — those are events in the selection log for the transition writer.
+#
+# The ONE exception is the CI-fix interrupt (tactic-fix-interrupt-orthogonal-state):
+# selection is the sole CI-routing authority. On a fix-interruptible ladder phase
+# (implement/qa/review) whose PR CI has CONCLUDED-RED and which carries no active
+# interrupt, the gate ENTERS the interrupt — `apply-fix-state --set-fix` +
+# `graph-commit` (a state-only commit on main, mirroring what transition-node
+# used to do at the transition seam) — and emits the candidate as `fix` the same
+# tick. On CONCLUDED-GREEN of an active interrupt it RESOLVES it — `apply-fix-state
+# --clear-fix` (+ the re-review reset when past review) + `graph-commit`, and
+# disarms auto-merge (`gh pr ready --undo`) — then emits the resolved ladder
+# phase. These two graph-commit writes are the only writes selection makes.
 #
 # Usage: graph-select-target [--top <n>] [--pace-exempt-only]
 #
@@ -185,17 +196,126 @@ skip_note() { # <id> <reason>
     <<<"$SKIPPED_JSON") || true
 }
 
-# sensor_gate <id> <phase> <pr> — the phase's environmental sensor (§3.1).
-#   0 = satisfied; 1 = not satisfied (reason on stdout); 2 = environment error.
+# --- CI-fix interrupt helpers (tactic-fix-interrupt-orthogonal-state) ---------
+# The store writes land in the MAIN checkout's working tree ($NATIVE_ROOT) and
+# are committed to origin/main via graph-commit — the same state-only-commit-on-
+# main convention transition-node/park-node use. NATIVE_ROOT is resolved below,
+# before the per-candidate loop that invokes these.
+
+# _apply_fix <id> <mode-flag...> — run apply-fix-state against the main store.
+# Its JSON result is on stdout for the caller to capture.
+_apply_fix() {
+  ( cd "$NATIVE_ROOT" \
+    && npx tsx packages/intentionsutil/scripts/apply-fix-state.ts "$@" --dir "$NATIVE_ROOT/intentions" )
+}
+
+# _graph_commit_fix <message> <id> — land the on-disk fix-state write on main.
+_graph_commit_fix() {
+  ( cd "$NATIVE_ROOT" \
+    && packages/intentionsutil/scripts/graph-commit -m "$1" "$2" ) >/dev/null 2>&1
+}
+
+# _read_pr_ci <pr> — one gh_pr_view_rest + one CI verdict, into globals
+# _CI_MERGED / _CI_HEAD / _CI_VERDICT. rc 1 when the PR is unreadable.
+_read_pr_ci() {
+  local pr="$1" pv
+  _CI_MERGED=""; _CI_HEAD=""; _CI_VERDICT=""
+  pv=$(gh_pr_view_rest "$pr" 2>/dev/null) || return 1
+  _CI_MERGED=$(jq -r '.mergedAt // empty' <<<"$pv" 2>/dev/null)
+  _CI_HEAD=$(jq -r '.headRefOid // empty' <<<"$pv" 2>/dev/null)
+  [[ -n "$_CI_HEAD" ]] || return 1
+  _CI_VERDICT=$(dispatch_ci_verdict_rest "$_CI_HEAD" 2>/dev/null || echo pending)
+  return 0
+}
+
+# _gate_maybe_interrupt <id> <pr> — for a fix-interruptible ladder phase carrying
+# NO active interrupt: enter `fix` iff the PR's CI has CONCLUDED-RED. On entry it
+# writes execution.fix and lands it on main.
+#   rc 0 — interrupt entered (caller emits `fix` this tick).
+#   rc 1 — no interrupt (caller falls through to the phase's normal gate).
+#   rc 3 — interrupt was due but the write/commit failed (reason printed; skip).
+_gate_maybe_interrupt() {
+  local id="$1" pr="$2"
+  [[ "$pr" == "null" || -z "$pr" ]] && return 1
+  _read_pr_ci "$pr" || return 1               # unreadable PR → do not interrupt
+  [[ -n "$_CI_MERGED" ]] && return 1          # merged-awaiting-reconcile → not an interrupt
+  [[ "$_CI_VERDICT" == "failing" ]] || return 1
+  # CONCLUDED-RED at an interruptible phase, fix null (guaranteed: the router
+  # would have emitted phase `fix` otherwise). Enter the interrupt this tick.
+  if _apply_fix "$id" --set-fix >/dev/null 2>&1 \
+     && _graph_commit_fix "graph: enter fix-interrupt on $id" "$id"; then
+    return 0
+  fi
+  echo "fix-write-failed"
+  return 3
+}
+
+# _gate_fix_active <id> <pr> <pushed_sha> — the candidate already carries an
+# active interrupt (router emitted phase `fix`). Resolve on green, guard/retry
+# otherwise. Prints the phase to emit (rc 0), a skip reason (rc 1), or an env
+# error (rc 2).
+_gate_fix_active() {
+  local id="$1" pr="$2" pushed_sha="$3" out phase
+  if [[ "$pr" == "null" || -z "$pr" ]]; then echo "no-pr"; return 1; fi
+  if ! _read_pr_ci "$pr"; then echo "pr-state-unknown"; return 1; fi
+  if [[ -n "$_CI_MERGED" ]]; then echo "pr-merged-awaiting-reconcile"; return 1; fi
+  case "$_CI_VERDICT" in
+    passing)
+      # Resolution: clear the interrupt (+ the re-review reset when past review),
+      # disarm any live auto-merge arm, and emit the resolved ladder phase.
+      out=$(_apply_fix "$id" --clear-fix 2>/dev/null) || { echo "fix-clear-failed"; return 1; }
+      if ! _graph_commit_fix "graph: resolve fix-interrupt on $id" "$id"; then
+        echo "fix-clear-commit-failed"; return 1
+      fi
+      gh pr ready --undo "$pr" >/dev/null 2>&1 || true
+      phase=$(jq -r '.phase // "implement"' <<<"$out" 2>/dev/null) || phase="implement"
+      echo "$phase"; return 0 ;;
+    pending)
+      # Pending-CI guard: the fix worker pushed and CI has not reported on that
+      # exact sha yet — not ready (never misread a pending pushed-sha as green).
+      if [[ -n "$pushed_sha" && "$pushed_sha" != "null" && "$pushed_sha" == "$_CI_HEAD" ]]; then
+        echo "pending-ci-guard"; return 1
+      fi
+      # CI (re)running but not on a recorded push → stay in fix, ready to launch
+      # /fix-checks.
+      echo "fix"; return 0 ;;
+    *)
+      # failing again (a fix attempt did not clear CI) → stay in fix, ready to
+      # retry; do NOT re-clear or re-set anything.
+      echo "fix"; return 0 ;;
+  esac
+}
+
+# sensor_gate <id> <phase> <pr> <pushed_sha> — the phase's environmental sensor
+# and CI-routing authority (§3.1; tactic-fix-interrupt-orthogonal-state).
+#   0 = satisfied, the PHASE TO EMIT is on stdout (may differ from <phase>: a
+#       fresh interrupt emits `fix`; a resolved interrupt emits the ladder phase).
+#   1 = not satisfied (skip reason on stdout); 2 = environment error.
 sensor_gate() {
-  local id="$1" phase="$2" pr="$3" rc merged_at
+  local id="$1" phase="$2" pr="$3" pushed_sha="$4" rc merged_at
   case "$phase" in
-    implement|align-tactics)
-      return 0 ;;
-    fix|qa|review)
-      # CI verdict present before fix/qa/review. The node-id branch is the PR
-      # head (§3.4), so dispatch-ci-ready's branch form applies: `waiting`
-      # means a draft PR's checks have not concluded — no actionable verdict.
+    fix)
+      # An active interrupt (router override). Resolve/guard/retry.
+      _gate_fix_active "$id" "$pr" "$pushed_sha"; return $? ;;
+    align-tactics)
+      echo "align-tactics"; return 0 ;;
+    implement)
+      # Interruptible: a red PR at implement enters fix this tick; else ready
+      # (implement has no CI gate of its own).
+      _gate_maybe_interrupt "$id" "$pr"
+      case $? in
+        0) echo "fix"; return 0 ;;
+        3) return 1 ;;
+      esac
+      echo "implement"; return 0 ;;
+    qa|review)
+      # Interruptible: a red PR enters fix this tick; otherwise the existing
+      # CI-verdict-present gate.
+      _gate_maybe_interrupt "$id" "$pr"
+      case $? in
+        0) echo "fix"; return 0 ;;
+        3) return 1 ;;
+      esac
       if [[ "$pr" == "null" || -z "$pr" ]]; then echo "no-pr"; return 1; fi
       # Defense in depth (tactic-graph-census-recurrence Unit 1): a merge that
       # lands between the tick's reconcile-graph-merged sweep and this selection
@@ -210,7 +330,7 @@ sensor_gate() {
       "$SCRIPT_DIR/dispatch-ci-ready" "$id" >/dev/null 2>&1
       rc=$?
       case "$rc" in
-        0) return 0 ;;
+        0) echo "$phase"; return 0 ;;
         1) echo "ci-pending"; return 1 ;;
         *) echo "graph-select-target: dispatch-ci-ready failed (exit $rc) for $id" >&2; return 2 ;;
       esac ;;
@@ -224,7 +344,7 @@ sensor_gate() {
       if ! merged_at=$(gh_pr_view_rest "$pr" 2>/dev/null | jq -r '.mergedAt // empty'); then
         echo "pr-state-unknown"; return 1
       fi
-      [[ -n "$merged_at" ]] && return 0
+      [[ -n "$merged_at" ]] && { echo "main-qa"; return 0; }
       echo "pr-not-merged"; return 1 ;;
     *)
       echo "unknown-phase"; return 1 ;;
@@ -233,7 +353,7 @@ sensor_gate() {
 
 SELECTED_COUNT=0
 SELECTED_LINES=""
-while IFS=$'\t' read -r id kind phase pr pace_exempt; do
+while IFS=$'\t' read -r id kind phase pr pace_exempt pushed_sha; do
   [[ -n "$id" ]] || continue
   ELIGIBLE_COUNT=$(( ELIGIBLE_COUNT + 1 ))
   (( SELECTED_COUNT >= TOP )) && continue
@@ -254,19 +374,23 @@ while IFS=$'\t' read -r id kind phase pr pace_exempt; do
     continue
   fi
 
-  reason=$(sensor_gate "$id" "$phase" "$pr")
+  # sensor_gate returns the PHASE TO EMIT on stdout when satisfied — it may
+  # differ from the candidate's `phase` (a fresh CI-fix interrupt emits `fix`
+  # after writing execution.fix; a resolved interrupt emits the resolved ladder
+  # phase after clearing it). On not-satisfied the stdout is the skip reason.
+  emit_phase=$(sensor_gate "$id" "$phase" "$pr" "$pushed_sha")
   rc=$?
   if (( rc == 2 )); then
     exit 2
   elif (( rc == 1 )); then
-    skip_note "$id" "$reason"
+    skip_note "$id" "$emit_phase"
     continue
   fi
 
-  SELECTED_LINES+="node $id $kind $phase"$'\n'
+  SELECTED_LINES+="node $id $kind $emit_phase"$'\n'
   SELECTED_JSON=$(jq -c --arg id "$id" '. + [$id]' <<<"$SELECTED_JSON") || true
   SELECTED_COUNT=$(( SELECTED_COUNT + 1 ))
-done < <(jq -r '.candidates[] | [.id, .kind, .phase, (.pr // "null"), (.pace_exempt | tostring)] | @tsv' \
+done < <(jq -r '.candidates[] | [.id, .kind, .phase, (.pr // "null"), (.pace_exempt | tostring), (.fix.pushed_sha // "null")] | @tsv' \
   <<<"$SELECTION")
 
 if (( SELECTED_COUNT == 0 )); then

--- a/.claude/skills/dispatch-propagate/scripts/transition-node
+++ b/.claude/skills/dispatch-propagate/scripts/transition-node
@@ -7,21 +7,21 @@
 # origin/main through graph-commit.
 #
 # Spec: intentions/tactic-graph-native-dispatch.md §1.1, §2.4; strategy
-# clarifications 10, 18, 22. The DECISION (ladder edge, fix interrupt + resume,
+# clarifications 10, 18, 22. The DECISION (unconditional forward ladder edge,
 # residue→main-qa, freshness holds) lives in the pure `transitions` module,
 # applied via apply-node-transition.ts; this wrapper owns only the environmental
-# parts: the origin/main snapshot, the CI verdict sensor, the fingerprint gates,
-# arming gh auto-merge, and refreshing the phase-start stamp.
+# parts: the origin/main snapshot, the fingerprint gates, arming gh auto-merge,
+# and refreshing the phase-start stamp.
+#
+# The forward transition is CI-BLIND: it never reads a CI verdict and never
+# routes a tactic into `fix`. A CI-fix interrupt is carried orthogonally on
+# `execution.fix` and routed by the selector, leaving `phase` at its real ladder
+# position — so this wrapper has no CI sensor.
 #
 # Doctrine: the transition is a STATE-ONLY commit on main, never on the work PR
 # branch (strategy clarification 15). Run this from a main-based checkout; from
 # a PR-branch worktree the caller applies the reset-dance graph-commit needs
 # (same constraint as park-node).
-#
-# Sensor: CI verdict via dispatch_ci_verdict_rest on the PR head sha
-# (passing/failing/pending; pending maps to the pure layer's `unknown` = not
-# a fix interrupt). No PR yet → unknown (a pre-PR implement completion advances
-# to qa without a CI gate).
 #
 # Freshness gates (compute-freshness.ts over the origin/main snapshot):
 #   - scope-stale → delegate to demote-node-to-implement (the backward
@@ -103,19 +103,6 @@ PHASE="$(jq -r '.phase // "implement"' <<<"$NODE_JSON")"
 PR="$SET_PR"
 [[ -z "$PR" ]] && PR="$(jq -r '.execution.pr // empty' <<<"$NODE_JSON")"
 
-# --- CI verdict sensor -------------------------------------------------------
-CI="unknown"
-if [[ -n "$PR" ]]; then
-  HEAD_SHA="$(gh_pr_view_rest "$PR" 2>/dev/null | jq -r '.headRefOid // empty')" || true
-  if [[ -n "$HEAD_SHA" ]]; then
-    case "$(dispatch_ci_verdict_rest "$HEAD_SHA" 2>/dev/null || echo pending)" in
-      failing) CI="failing" ;;
-      passing) CI="passing" ;;
-      *) CI="unknown" ;;
-    esac
-  fi
-fi
-
 # --- Freshness gates over an origin/main snapshot ----------------------------
 SNAP_DIR="$(mktemp -d)" || { echo "transition-node: mktemp failed" >&2; exit 2; }
 trap 'rm -rf "$SNAP_DIR"' EXIT
@@ -144,8 +131,8 @@ if [[ "$SCOPE_STALE" == "true" && "$PHASE" != "main-qa" ]]; then
   exit 1
 fi
 
-# --- Apply the forward/hold/fix decision to the local store ------------------
-APPLY_FLAGS=("$NODE_ID" "--ci" "$CI")
+# --- Apply the forward/hold decision to the local store ----------------------
+APPLY_FLAGS=("$NODE_ID")
 [[ "$STRATEGY_STALE" == "true" ]] && APPLY_FLAGS+=("--strategy-stale")
 [[ -n "$SET_PR" ]] && APPLY_FLAGS+=("--set-pr" "$SET_PR")
 if ! RESULT="$( (cd "$REPO_ROOT" && node --import tsx/esm "$UTIL_SCRIPTS/apply-node-transition.ts" "${APPLY_FLAGS[@]}") )"; then

--- a/.claude/skills/fix-checks/SKILL.md
+++ b/.claude/skills/fix-checks/SKILL.md
@@ -32,7 +32,12 @@ than restarting the pass.
 **Target resolution — keyspace split.** The current worktree dictates the
 target. Split on its name before Step 1: `[0-9]*-*` is a legacy issue worktree
 (unchanged); anything else is a graph-native node id, and
-`intentions/<id>.md` must exist at `origin/main` with `phase == fix` (else exit 1).
+`intentions/<id>.md` must exist at `origin/main` under an active CI-fix interrupt
+— `execution.fix != null` (else exit 1). Note `phase` is NOT `fix`: a CI-fix
+interrupt is carried orthogonally on `execution.fix`, leaving `phase` at its real
+ladder position (implement/qa/review), so the gate reads `execution.fix`, never
+`phase`. Nested YAML is fragile to `sed`-scrape, so read the node through
+`readNode` and test `.execution.fix` with `jq`.
 
 ```bash
 BRANCH=$(basename "$(git rev-parse --show-toplevel)")
@@ -42,13 +47,21 @@ case "$BRANCH" in
   *)
     NODE_ID="$BRANCH"
     git fetch origin main --quiet
-    NODE_MD=$(git archive origin/main "intentions/$NODE_ID.md" 2>/dev/null | tar -xO 2>/dev/null) || {
+    # Extract the node from origin/main into a temp store and read it via
+    # readNode (the single validation gate), rather than sed-scraping frontmatter.
+    NODE_TMP=$(mktemp -d)
+    if ! git archive origin/main "intentions/$NODE_ID.md" 2>/dev/null | tar -x -C "$NODE_TMP" 2>/dev/null; then
       echo "/fix-checks: '$BRANCH' is neither a legacy '<N>-…' worktree nor a node with intentions/$NODE_ID.md at origin/main" >&2
       exit 1
-    }
-    NODE_PHASE=$(printf '%s\n' "$NODE_MD" | sed -n 's/^phase: *//p' | head -1)
-    if [ "$NODE_PHASE" != "fix" ]; then
-      echo "/fix-checks: node '$NODE_ID' phase is '$NODE_PHASE' at origin/main, not 'fix'" >&2
+    fi
+    NODE_JSON=$(node --import tsx/esm -e '
+      const { readNode } = await import("./packages/intentionsutil/src/store.js");
+      process.stdout.write(JSON.stringify(readNode(process.argv[1], process.argv[2])));
+    ' "$NODE_TMP/intentions" "$NODE_ID") || {
+      echo "/fix-checks: could not read node '$NODE_ID' from origin/main" >&2; exit 1; }
+    rm -rf "$NODE_TMP"
+    if [ "$(jq -r '.execution.fix // "null"' <<<"$NODE_JSON")" = "null" ]; then
+      echo "/fix-checks: node '$NODE_ID' is not under a CI-fix interrupt (execution.fix is null) at origin/main" >&2
       exit 1
     fi
     N="$NODE_ID"; TARGET_KIND=node ;;
@@ -63,18 +76,54 @@ performs does not apply — use `dispatch-context-pack`'s `--pr-is-number` flag
 instead, see Step 1 below. fix-checks never runs without an open PR, so an
 empty result here is a real error — write `$CLAUDE_JOB_DIR/office-hours-reason`
 per the Escalation note below and stop, never `dispatch-mark-deviation`, which
-is issue-only) — never pass `--issue`; on a clean
-fix (CI green after the push) the completion seam invokes the graph-native
-transition writer instead of any `dispatch-complete-phase` /
-`dispatch-mark-complete` — it consults the CI verdict and returns the node from
-`fix` to the interrupted ladder position as one state-only graph-commit on
-`origin/main`:
+is issue-only) — never pass `--issue`.
+
+**Node-lane completion — the fix worker does NOT resolve the interrupt.** The
+selector, not this worker, owns clearing `execution.fix` (it decides when CI has
+gone green on the pushed sha, on a LATER tick). This worker's completion duty is
+only to RECORD what this iteration did and stop:
+
+- **If this iteration pushed a commit** (a real fix, or the Step 4
+  "main-already-fixed-it" merge-commit push): record the pushed sha onto the
+  active interrupt via `apply-fix-state --record-push`, then land that state-only
+  write on `origin/main` with `graph-commit`. Recording the sha arms the
+  selector's pending-CI guard, so a pending verdict on this exact sha is never
+  misread as a green resolution. Run this from the PR-branch worktree with the
+  reset-dance `graph-commit` needs there (same as `/implement`'s node-lane
+  completion did with `transition-node`):
+
+  ```bash
+  HEAD_SHA=$(git rev-parse HEAD)
+  node --import tsx/esm packages/intentionsutil/scripts/apply-fix-state.ts \
+    "$N" --record-push "$HEAD_SHA"
+  .claude/skills/dispatch-propagate/scripts/graph-commit \
+    -m "graph: record fix push $HEAD_SHA on $N" "$N"
+  ```
+
+- **If this iteration pushed NOTHING** (the generic-no-repro / flake outcomes
+  Step 4 documents as pushing nothing): make NO graph write. There is no new sha
+  to record and the interrupt stays exactly as it was; the selector re-launches
+  `/fix-checks` next tick (or the flake path files its own issue and the node is
+  no longer re-routed to fix — see Step 4).
+
+Do NOT call `transition-node` here: after the CI-blind redesign it no longer
+knows about `fix` and would force the ladder forward regardless of whether the
+fix actually worked. Do NOT clear `execution.fix`, reset `phase`, or write any
+completion marker — those are the selector's on a later green tick. The Stop hook
+(`.claude/hooks/dispatch-stop.sh`) needs nothing from this seam for a clean pass
+(it only backstops the escalation park); chain continuation is carried by the
+systemd heartbeat and the tick's convergence reseed.
+
+**Disarm auto-merge on every push.** Whenever this worker pushes ANY commit (a
+fix or the main-already-fixed-it merge), disarm auto-merge immediately as a
+safety action — a past-review node may still carry a stale merge-arm from before
+the regression, and the newly pushed code must not merge before it is re-reviewed
+(the selector applies the re-review reset when it later resolves the interrupt):
 
 ```bash
-.claude/skills/dispatch-propagate/scripts/transition-node "$N" --set-pr "$PR_NUM"
+gh pr ready --undo "$PR_NUM"   # idempotent no-op when the PR was not merge-armed
 ```
 
-The graph-tick worker runs it with the reset-dance a PR-branch worktree needs.
 Escalation writes `$CLAUDE_JOB_DIR/office-hours-reason` (+
 `office-hours-recommendation`) for the Stop hook's `park-node`, never a gh label.
 **On the node lane no gh issue is ever read or written.**
@@ -211,6 +260,10 @@ Escalation writes `$CLAUDE_JOB_DIR/office-hours-reason` (+
      ```bash
      git push origin HEAD
      ```
+
+     **Node lane:** this counts as a push — after it, disarm auto-merge
+     (`gh pr ready --undo "$PR_NUM"`) and record the pushed sha per the node-lane
+     completion seam above (`apply-fix-state --record-push` + `graph-commit`).
 
    - **Flake** — `is_flake == true`: the failure is an upstream flaky test or a
      CI-infrastructure hiccup, unrelated to this PR's own changes. Re-running
@@ -402,6 +455,10 @@ Escalation writes `$CLAUDE_JOB_DIR/office-hours-reason` (+
    classification — generic and flake push nothing, main-fixed pushed the merge
    commit — so there is nothing more to do here.
 
+   **Node lane:** immediately after `/implement-unit` pushes the fix, disarm
+   auto-merge (`gh pr ready --undo "$PR_NUM"`) and record the pushed HEAD sha per
+   the node-lane completion seam (`apply-fix-state --record-push` + `graph-commit`).
+
    `/implement-unit` returning here is mid-pass, not the end of the turn. Continue
    through Steps 7–9; the pass ends only at the Step 9 `dispatch-mark-complete`
    marker (or the Step 4 needs-human stop). Do not emit a closing summary; the next
@@ -417,19 +474,28 @@ Escalation writes `$CLAUDE_JOB_DIR/office-hours-reason` (+
    ```
 
 9. **Write the phase-completed marker, then stop.** Reached by every outcome
-   **except** needs-human (which stopped in Step 4 without a marker). The Stop hook
-   (`.claude/hooks/dispatch-stop.sh`) reads this to decide propagate vs park.
+   **except** needs-human (which stopped in Step 4 without a marker).
    `CLAUDE_JOB_DIR` unset = interactive run; the script no-ops with a clear
    diagnostic.
+
+   **Legacy lane only** (`TARGET_KIND=issue`):
 
    ```bash
    .claude/skills/dispatch-propagate/scripts/dispatch-mark-complete \
      --phase fix-checks --pr "$PR_NUM"
    ```
 
+   **Node lane** (`TARGET_KIND=node`): write NO `dispatch-mark-complete` marker
+   (it is a gh-label vehicle, issue-only). The node lane's completion is the
+   `apply-fix-state --record-push` + `graph-commit` write from the completion
+   seam above (when this iteration pushed), or nothing (when it pushed nothing).
+   The Stop hook (`.claude/hooks/dispatch-stop.sh`) needs no marker from a clean
+   node pass — it only backstops the escalation park.
+
    Then **stop**. The `/dispatch-propagate` background-job chain drives the
-   next iteration — the next `/dispatch-propagate` job re-derives the phase
-   from CI ground truth and re-invokes `/fix-checks` if checks still fail.
+   next iteration — the selector observes the pushed sha's CI verdict on a later
+   tick and either resolves the interrupt (green) or re-invokes `/fix-checks`
+   (still red).
 
 ## Accumulator
 

--- a/packages/intentionsutil/scripts/apply-fix-state.ts
+++ b/packages/intentionsutil/scripts/apply-fix-state.ts
@@ -1,0 +1,201 @@
+// apply-fix-state — the store-mutation primitive for the orthogonal CI-fix
+// interrupt (tactic-fix-interrupt-orthogonal-state Unit 3). It sets, clears, or
+// records-a-push on a tactic's `execution.fix` field, leaving the node's ladder
+// `phase` untouched (the interrupt is orthogonal to the ladder). Sibling of
+// `apply-node-transition.ts`: pure of git/gh, reads the node via `readNode`,
+// mutates `execution.fix` through the validated `writeNode`, and prints one JSON
+// object on stdout for the shell caller (`graph-select-target`, `/fix-checks`)
+// to act on and to land via `graph-commit`.
+//
+// The three modes are mutually exclusive:
+//
+//   --set-fix          Enter the interrupt. Writes
+//                      `execution.fix = { since: <today UTC>, attempt: 1,
+//                      pushed_sha: null }` when there is no interrupt yet. If an
+//                      interrupt is already in flight (a defensive double-call)
+//                      it bumps `attempt` and preserves `since`/`pushed_sha`
+//                      rather than clobbering the in-progress count.
+//                      Called by the selector when it first observes CONCLUDED-RED
+//                      CI on a fix-interruptible ladder phase.
+//
+//   --clear-fix        Resolve the interrupt. Writes `execution.fix = null`. If
+//                      the node already carries the `reviewed` marker (the fix
+//                      landed AFTER review completed), it ALSO resets
+//                      `node.phase` to `review` — the re-review reset: new code
+//                      pushed after review must be re-reviewed. Reports the
+//                      resolved phase (post-reset) so the caller knows which
+//                      ladder phase to emit/log.
+//                      Called by the selector when it observes CONCLUDED-GREEN
+//                      CI on a node with an active interrupt.
+//
+//   --record-push <sha>  Record that `/fix-checks` pushed <sha> onto the
+//                      already-set interrupt: writes `execution.fix.pushed_sha`
+//                      only, preserving `since`/`attempt` and the ladder `phase`.
+//                      This is the selector's pending-CI guard input (a pending
+//                      verdict on the recorded sha is a fresh push awaiting CI,
+//                      not a green resolution). Errors if no interrupt is set.
+//
+// Usage:
+//   node --import tsx/esm apply-fix-state.ts <node-id> \
+//     (--set-fix | --clear-fix | --record-push <sha>) [--dir <intentions-dir>]
+//
+// Stdout: one JSON object, shape per mode —
+//   set-fix:      { "mode": "set",    "id", "attempt": <n>, "since": <date>, "wrote": true }
+//   clear-fix:    { "mode": "clear",  "id", "phase": <resolved>, "reset": bool, "wrote": true }
+//   record-push:  { "mode": "record", "id", "pushed_sha": <sha>, "wrote": true }
+
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { readNode, writeNode } from "../src/store.js";
+import type { Execution, FixState } from "../src/schema.js";
+import { REVIEWED_MARKER } from "../src/transitions.js";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(dirname(dirname(scriptDir)));
+
+type Mode = "set" | "clear" | "record";
+
+interface Args {
+  id: string;
+  mode: Mode;
+  pushedSha: string | null;
+  dir: string;
+}
+
+/** Today's date in UTC as YYYY-MM-DD — the `FixState.since` stamp. */
+function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function parseArgs(argv: string[]): Args {
+  let id = "";
+  let mode: Mode | null = null;
+  let pushedSha: string | null = null;
+  let dir = join(repoRoot, "intentions");
+  const setMode = (m: Mode): void => {
+    if (mode !== null) {
+      throw new Error("apply-fix-state: --set-fix, --clear-fix, and --record-push are mutually exclusive");
+    }
+    mode = m;
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--set-fix":
+        setMode("set");
+        break;
+      case "--clear-fix":
+        setMode("clear");
+        break;
+      case "--record-push": {
+        setMode("record");
+        const v = argv[++i];
+        if (v === undefined || v === "" || v.startsWith("--")) {
+          throw new Error("apply-fix-state: --record-push requires a <sha> argument");
+        }
+        pushedSha = v;
+        break;
+      }
+      case "--dir": {
+        const v = argv[++i];
+        if (v === undefined || v === "") throw new Error("apply-fix-state: --dir requires a directory argument");
+        dir = v;
+        break;
+      }
+      default:
+        if (a.startsWith("--")) throw new Error(`apply-fix-state: unknown flag '${a}'`);
+        if (id !== "") throw new Error(`apply-fix-state: unexpected extra argument '${a}'`);
+        id = a;
+    }
+  }
+  if (id === "") throw new Error("apply-fix-state: <node-id> is required");
+  if (mode === null) {
+    throw new Error("apply-fix-state: one of --set-fix | --clear-fix | --record-push <sha> is required");
+  }
+  return { id, mode, pushedSha, dir };
+}
+
+/** A fresh execution record for a tactic that has none yet. */
+function defaultExecution(id: string): Execution {
+  return { branch: id, pr: null, attempts: {}, markers: [], strategy_fingerprint: null, fix: null };
+}
+
+export interface FixStateResult {
+  mode: Mode;
+  id: string;
+  wrote: boolean;
+  /** set: the attempt counter written. */
+  attempt?: number;
+  /** set: the `since` date written. */
+  since?: string;
+  /** clear: the resolved ladder phase to emit (post re-review reset). */
+  phase?: string;
+  /** clear: whether the re-review reset moved the phase to `review`. */
+  reset?: boolean;
+  /** record: the pushed sha written to `execution.fix.pushed_sha`. */
+  pushed_sha?: string;
+}
+
+/**
+ * Read the tactic, apply the `execution.fix` mutation, write it back through the
+ * validating `writeNode`, and return the result. Exported so the store
+ * round-trip is unit-tested without spawning a process. Pure of git/gh — the
+ * caller owns landing the write on main via `graph-commit`.
+ */
+export function applyFixState(args: Args): FixStateResult {
+  const node = readNode(args.dir, args.id);
+  if (node.kind !== "tactic") {
+    throw new Error(`apply-fix-state: ${args.id} is kind '${node.kind}', not a tactic`);
+  }
+  const execution: Execution = node.execution ?? defaultExecution(args.id);
+  const currentFix: FixState | null = execution.fix ?? null;
+
+  if (args.mode === "set") {
+    // Enter the interrupt. Fresh when none is set; a defensive double-call bumps
+    // `attempt` and preserves `since`/`pushed_sha` so an in-flight count is not
+    // clobbered.
+    const fix: FixState =
+      currentFix === null
+        ? { since: todayUtc(), attempt: 1, pushed_sha: null }
+        : { ...currentFix, attempt: currentFix.attempt + 1 };
+    node.execution = { ...execution, fix };
+    writeNode(args.dir, node);
+    return { mode: "set", id: args.id, wrote: true, attempt: fix.attempt, since: fix.since };
+  }
+
+  if (args.mode === "clear") {
+    // Resolve the interrupt. Re-review reset: a fix landed after review must be
+    // re-reviewed, so return the node to `review` when it carries the reviewed
+    // marker — AND strip that marker, so the review pass actually re-runs (both
+    // the selector's phase:review+reviewed emit-guard and check-node-selection's
+    // reviewed-marker guard would otherwise treat the node as already-reviewed
+    // and skip/exit-12 it). `qa-done`/`planned` are kept: only review re-runs,
+    // not qa. When not past review, `phase` is preserved at its ladder position.
+    const reset = execution.markers.includes(REVIEWED_MARKER);
+    if (reset) node.phase = "review";
+    const markers = reset ? execution.markers.filter((m) => m !== REVIEWED_MARKER) : execution.markers;
+    node.execution = { ...execution, markers, fix: null };
+    writeNode(args.dir, node);
+    return { mode: "clear", id: args.id, wrote: true, phase: node.phase ?? "implement", reset };
+  }
+
+  // record: stamp the pushed sha onto an already-set interrupt.
+  if (currentFix === null) {
+    throw new Error(
+      `apply-fix-state: --record-push on ${args.id} but execution.fix is null (no interrupt in flight to record a push against)`,
+    );
+  }
+  const sha = args.pushedSha as string;
+  node.execution = { ...execution, fix: { ...currentFix, pushed_sha: sha } };
+  writeNode(args.dir, node);
+  return { mode: "record", id: args.id, wrote: true, pushed_sha: sha };
+}
+
+function main(argv: string[]): void {
+  const result = applyFixState(parseArgs(argv));
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2));
+}

--- a/packages/intentionsutil/scripts/apply-fix-state.ts
+++ b/packages/intentionsutil/scripts/apply-fix-state.ts
@@ -62,7 +62,7 @@ interface Args {
   dir: string;
 }
 
-/** Today's date in UTC as YYYY-MM-DD — the `FixState.since` stamp. */
+/** Today's date in UTC, formatted YYYY-MM-DD — the `FixState.since` stamp. */
 function todayUtc(): string {
   return new Date().toISOString().slice(0, 10);
 }
@@ -185,7 +185,10 @@ export function applyFixState(args: Args): FixStateResult {
       `apply-fix-state: --record-push on ${args.id} but execution.fix is null (no interrupt in flight to record a push against)`,
     );
   }
-  const sha = args.pushedSha as string;
+  if (args.pushedSha === null) {
+    throw new Error("apply-fix-state: --record-push requires a sha (mode is 'record' but pushedSha is null)");
+  }
+  const sha = args.pushedSha;
   node.execution = { ...execution, fix: { ...currentFix, pushed_sha: sha } };
   writeNode(args.dir, node);
   return { mode: "record", id: args.id, wrote: true, pushed_sha: sha };

--- a/packages/intentionsutil/scripts/apply-fix-state.ts
+++ b/packages/intentionsutil/scripts/apply-fix-state.ts
@@ -164,6 +164,16 @@ export function applyFixState(args: Args): FixStateResult {
   }
 
   if (args.mode === "clear") {
+    // Null-interrupt guard, mirroring `--record-push`: clearing a node that
+    // carries no active interrupt is meaningless, and — worse — would spuriously
+    // trip the re-review reset below on a `reviewed` node (resetting `phase` to
+    // `review` and stripping the marker, forcing a needless re-review and
+    // disarming a valid merge). Refuse rather than proceed unconditionally.
+    if (currentFix === null) {
+      throw new Error(
+        `apply-fix-state: --clear-fix on ${args.id} but execution.fix is null (no interrupt in flight to clear)`,
+      );
+    }
     // Resolve the interrupt. Re-review reset: a fix landed after review must be
     // re-reviewed, so return the node to `review` when it carries the reviewed
     // marker — AND strip that marker, so the review pass actually re-runs (both

--- a/packages/intentionsutil/scripts/apply-node-transition.ts
+++ b/packages/intentionsutil/scripts/apply-node-transition.ts
@@ -9,13 +9,15 @@
 //
 // This script authors NO markdown and makes NO git/gh calls — the wrapper
 // (`.claude/skills/dispatch-propagate/scripts/transition-node`) owns the
-// origin/main reads, the CI/mergeability sensors, and the graph-commit landing.
+// origin/main reads, the mergeability sensor, and the graph-commit landing.
 // Splitting the decision+mutation here keeps it exercised by the pure
-// `transitions` unit tests and store round-trip, not buried in bash.
+// `transitions` unit tests and store round-trip, not buried in bash. The
+// forward decision is CI-blind (a CI-fix interrupt is the selector's job via
+// `execution.fix`), so this script no longer takes a CI verdict.
 //
 // Usage:
 //   node --import tsx/esm apply-node-transition.ts <node-id> \
-//     [--ci passing|failing|unknown] [--scope-stale] [--strategy-stale] \
+//     [--scope-stale] [--strategy-stale] \
 //     [--set-pr <n>] [--strategy-fingerprint <strategy-id>=<hash> ...] \
 //     [--strategy-sha <sha>] [--dir <intentions-dir>]
 //
@@ -44,7 +46,6 @@ import {
   addMarker,
   decideTransition,
   hasNeedsMainResidue,
-  type CiVerdict,
 } from "../src/transitions.js";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -52,7 +53,6 @@ const repoRoot = dirname(dirname(dirname(scriptDir)));
 
 interface Args {
   id: string;
-  ci: CiVerdict;
   scopeStale: boolean;
   strategyStale: boolean;
   setPr: number | null;
@@ -63,7 +63,6 @@ interface Args {
 export function parseArgs(argv: string[]): Args {
   const out: Args = {
     id: "",
-    ci: "unknown",
     scopeStale: false,
     strategyStale: false,
     setPr: null,
@@ -75,14 +74,6 @@ export function parseArgs(argv: string[]): Args {
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     switch (a) {
-      case "--ci": {
-        const v = argv[++i];
-        if (v !== "passing" && v !== "failing" && v !== "unknown") {
-          throw new Error(`apply-node-transition: --ci must be passing|failing|unknown, got '${v}'`);
-        }
-        out.ci = v;
-        break;
-      }
       case "--scope-stale":
         out.scopeStale = true;
         break;
@@ -183,28 +174,19 @@ export function applyNodeTransition(args: Args): ApplyResult {
 
   const decision = decideTransition({
     phase: prevPhase,
-    markers: execution.markers,
-    ci: args.ci,
     hasResidue,
     scopeStale: args.scopeStale,
     strategyStale: args.strategyStale,
   });
 
   // A ladder phase completes cleanly when the tactic advances off it (or, for
-  // review, arms the merge). On a fix interrupt, a hold, or a demotion the
-  // phase did not complete, so no marker is written.
+  // review, arms the merge). On a hold or a demotion the phase did not complete,
+  // so no marker is written. The decision is CI-blind and never routes into
+  // `fix`, so there is no fix-interrupt case to exclude here.
   const marker = PHASE_COMPLETION_MARKER[prevPhase];
   const advanced =
-    decision.armMerge ||
-    (!decision.hold && !decision.demote && decision.phase !== "fix" && decision.phase !== prevPhase);
+    decision.armMerge || (!decision.hold && !decision.demote && decision.phase !== prevPhase);
   if (marker !== undefined && advanced) execution = addMarker(execution, marker);
-
-  // Strip any markers the decision cleared (the fix interrupt clears qa-done and
-  // reviewed so a resume out of fix re-runs qa and review). Runs for every
-  // decision carrying clearMarkers; a demotion below wholesale-clears anyway.
-  if (decision.clearMarkers.length > 0) {
-    execution = { ...execution, markers: execution.markers.filter((m) => !decision.clearMarkers.includes(m)) };
-  }
 
   // Apply the phase write. A demotion clears the completion markers so the
   // re-selected implement worker re-runs the ladder against the new scope.

--- a/packages/intentionsutil/scripts/check-node-selection.ts
+++ b/packages/intentionsutil/scripts/check-node-selection.ts
@@ -51,7 +51,7 @@ import {
 } from "../src/router.js";
 import { isFingerprintStale, REVIEWED_MARKER } from "../src/transitions.js";
 import { isPlainObject } from "../src/schema.js";
-import type { IntentionNode, StrategyStampValue } from "../src/schema.js";
+import type { FixState, IntentionNode, StrategyStampValue } from "../src/schema.js";
 import { IntentionSchemaError } from "../src/errors.js";
 
 // --- Exit codes ------------------------------------------------------------
@@ -152,6 +152,27 @@ function readMarkers(node: IntentionNode): string[] {
 }
 
 /**
+ * The node's active CI-fix interrupt (`execution.fix`), first-class or squatter,
+ * else null (tactic-fix-interrupt-orthogonal-state). The interrupt is
+ * graph-native-only and the squatter subtrees (attention-surface / token-economy)
+ * predate it, so in practice only the first-class read fires; the squatter
+ * fallback is kept for uniformity with `readMarkers` / `readStrategyFingerprint`.
+ */
+function readFixState(node: IntentionNode): FixState | null {
+  const firstClass = node.execution?.fix ?? null;
+  if (firstClass !== null) return firstClass;
+  const squatExec = node.attributes.execution;
+  if (squatExec !== null && typeof squatExec === "object" && "fix" in squatExec) {
+    const fix = (squatExec as { fix?: unknown }).fix;
+    if (isPlainObject(fix) && typeof fix.since === "string" && typeof fix.attempt === "number") {
+      const pushed = fix.pushed_sha;
+      return { since: fix.since, attempt: fix.attempt, pushed_sha: typeof pushed === "string" ? pushed : null };
+    }
+  }
+  return null;
+}
+
+/**
  * Run the five re-validation checks against a store the caller guarantees is at
  * fresh origin/main. Pure: reads files, returns a result — no process exit, no
  * direct stdio. Throws only on a genuinely malformed store (a node file that
@@ -189,8 +210,24 @@ export function evaluateSelection(opts: SelectionOpts): SelectionResult {
   // not-parked check so a parked strategy fails with the clearer not-parked
   // message. All other phases keep the literal stored-phase equality (tactic
   // phases are first-class and persisted, so equality is correct there).
+  //
+  // `fix` is likewise a directive the selector emits but never stores on the
+  // node: a CI-fix interrupt lives on `execution.fix` while `phase` stays at its
+  // real ladder position (implement/qa/review), so `phase` is never literally
+  // `"fix"`. A literal `readPhase === "fix"` would exit-12 every fix candidate.
+  // For `fix` the equality is replaced by an interrupt-presence gate: the
+  // interrupt must still be set (a null `execution.fix` means it was resolved
+  // between selection and execute-time — a stale selection).
   const phase = readPhase(node);
-  if (selectedPhase === "align-tactics") {
+  if (selectedPhase === "fix") {
+    if (readFixState(node) === null) {
+      return fail(
+        EXIT_STALE_SELECTION,
+        "phase",
+        `selected fix but ${nodeId} carries no execution.fix interrupt (resolved since selection)`,
+      );
+    }
+  } else if (selectedPhase === "align-tactics") {
     if (node.kind === "strategy") {
       // A strategy is align-selected at its native null phase; any non-null
       // stored phase (first-class or squatter) is a stale advance.

--- a/packages/intentionsutil/src/index.ts
+++ b/packages/intentionsutil/src/index.ts
@@ -19,7 +19,6 @@ export {
   tacticScopeFingerprint,
   servingStrategyIds,
   readingDate,
-  PHASE_LADDER,
 } from "./router.js";
 export type { GraphCandidate, GraphSelection, SelectionEvent } from "./router.js";
 export {

--- a/packages/intentionsutil/src/index.ts
+++ b/packages/intentionsutil/src/index.ts
@@ -30,7 +30,6 @@ export {
   LADDER,
   forwardPhase,
   fixInterrupt,
-  resumeAfterFix,
   decideTransition,
   addMarker,
   incrementAttempt,

--- a/packages/intentionsutil/src/router.ts
+++ b/packages/intentionsutil/src/router.ts
@@ -18,25 +18,6 @@ import type { FixState, IntentionNode, Phase } from "./schema.js";
 
 // --- Types -------------------------------------------------------------------
 
-/**
- * The phase ladder, closest-to-done first (strategy clarification 22).
- *
- * Historical: this drove the within-rank selection tiebreak until
- * tactic-graph-frozen-tactic-dispatch replaced it with a progression ordinal
- * over the full `PHASES` order (see `progressionIndex`). The selection sort no
- * longer consults it; it is retained as a public export for downstream
- * consumers. Note the progression ordinal reorders `fix` vs `qa` relative to
- * this ladder (`qa` is now more-progressed than `fix`).
- */
-export const PHASE_LADDER: readonly string[] = [
-  "main-qa",
-  "review",
-  "fix",
-  "qa",
-  "implement",
-  "align-tactics",
-];
-
 /** One selectable node, in selection order. */
 export interface GraphCandidate {
   id: string;

--- a/packages/intentionsutil/src/router.ts
+++ b/packages/intentionsutil/src/router.ts
@@ -297,7 +297,10 @@ export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
     candidates.push({
       id: t.id,
       kind: "tactic",
-      phase: t.phase,
+      // A tactic under an active CI-fix interrupt (`execution.fix` set) is
+      // emitted as a `fix` candidate regardless of its preserved ladder `phase`;
+      // its real `phase` stays put and the interrupt is carried orthogonally.
+      phase: t.execution?.fix != null ? "fix" : t.phase,
       rank: attention.get(t.id)?.value ?? 0,
       pace_exempt: t.pace_exempt,
       pr: t.execution?.pr ?? null,

--- a/packages/intentionsutil/src/router.ts
+++ b/packages/intentionsutil/src/router.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { computeSignalPath, isSignalUnvalidated, resolveAttention } from "./attention.js";
 import { isStrategyStale, REVIEWED_MARKER } from "./transitions.js";
 import { PHASES } from "./schema.js";
-import type { IntentionNode, Phase } from "./schema.js";
+import type { FixState, IntentionNode, Phase } from "./schema.js";
 
 // Graph router v2, first half: selection (tactic-graph-router-selector).
 //
@@ -49,6 +49,16 @@ export interface GraphCandidate {
   pace_exempt: boolean;
   /** The tactic's execution.pr — the wrapper's sensor-gate input. Null for strategies. */
   pr: number | null;
+  /**
+   * The tactic's raw `execution.fix` interrupt state, or null. Surfaced so the
+   * shell sensor-gate (`graph-select-target`) reads the interrupt AND its
+   * `pushed_sha` (the pending-CI guard) straight off the candidate object
+   * without a second store read — the CI-routing decision (enter/resolve fix)
+   * is bash's, but the state it keys on stays in this pure TS layer. Null for
+   * strategies and for a tactic with no active interrupt. Note `phase` above is
+   * already overwritten to `"fix"` whenever this is non-null.
+   */
+  fix: FixState | null;
   /**
    * True when this candidate is a soft-freeze re-evaluation session (strategy
    * clarification 10) rather than an ordinary decomposition round — a stale
@@ -304,6 +314,7 @@ export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
       rank: attention.get(t.id)?.value ?? 0,
       pace_exempt: t.pace_exempt,
       pr: t.execution?.pr ?? null,
+      fix: t.execution?.fix ?? null,
       reevaluation: false,
     });
   }
@@ -328,6 +339,7 @@ export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
         rank: attention.get(t.id)?.value ?? 0,
         pace_exempt: t.pace_exempt,
         pr: null,
+        fix: null,
         reevaluation: false,
       });
     } else if (frozenTacticIds.has(t.id) && isOpenTactic(t)) {
@@ -338,6 +350,7 @@ export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
         rank: attention.get(t.id)?.value ?? 0,
         pace_exempt: t.pace_exempt,
         pr: t.execution?.pr ?? null,
+        fix: t.execution?.fix ?? null,
         reevaluation: true,
       });
     }
@@ -354,6 +367,7 @@ export function selectGraphTargets(nodes: IntentionNode[]): GraphSelection {
       rank: attention.get(s.id)?.value ?? 0,
       pace_exempt: s.pace_exempt,
       pr: null,
+      fix: null,
       reevaluation,
     });
 

--- a/packages/intentionsutil/src/schema.ts
+++ b/packages/intentionsutil/src/schema.ts
@@ -27,12 +27,15 @@ export const TOOLING_KINDS: readonly ToolingKind[] = ["actuator", "sensor"];
 /**
  * Persisted dispatch phase a tactic sits in. A future graph-native router
  * transitions this; the schema only validates the value is one of the enum.
+ *
+ * `"fix"` is deliberately NOT a member: the CI-fix interrupt lives entirely in
+ * the orthogonal `execution.fix` field (see `FixState`), set/cleared by the
+ * graph selector off the live CI verdict, independent of `phase`.
  */
 export type Phase =
   | "draft"
   | "align-tactics"
   | "implement"
-  | "fix"
   | "qa"
   | "review"
   | "main-qa"
@@ -42,7 +45,6 @@ export const PHASES: readonly Phase[] = [
   "draft",
   "align-tactics",
   "implement",
-  "fix",
   "qa",
   "review",
   "main-qa",

--- a/packages/intentionsutil/src/schema.ts
+++ b/packages/intentionsutil/src/schema.ts
@@ -358,12 +358,32 @@ export type StrategyStampValue = string | { hash: string; sha: string };
  *    re-stamp rewrites the field. No hashing logic lives here — only the
  *    typed field.
  */
+/**
+ * A CI-fix interrupt in flight on a tactic, orthogonal to `phase`. `since` is
+ * the interrupt date (`date -u +%Y-%m-%d`); `attempt` is the fix-attempt
+ * counter (replaces the `attempts["fix"]` convention); `pushed_sha` is the
+ * last SHA `/fix-checks` pushed — the pending-CI guard, null before the first
+ * push.
+ */
+export interface FixState {
+  since: string;
+  attempt: number;
+  pushed_sha: string | null;
+}
+
 export interface Execution {
   branch: string;
   pr: number | null;
   attempts: Record<string, number>; // per-phase attempt counts
   markers: string[];
   strategy_fingerprint: string | Record<string, StrategyStampValue> | null;
+  /**
+   * Optional (not just nullable) at the type level: existing `Execution`
+   * object literals across the codebase predate this field and are out of
+   * scope for this additive-only unit. `validateExecution` always populates
+   * it (to a validated object or `null`) on any value it returns.
+   */
+  fix?: FixState | null;
 }
 
 /** A first-class parking record: why a node is in office hours and since when. */
@@ -469,6 +489,22 @@ function validateStrategyFingerprint(
   return out;
 }
 
+/**
+ * Nullable `FixState` object: string `since`, number `attempt`, nullable
+ * string `pushed_sha`.
+ */
+function validateFixState(value: unknown, field: string): FixState | null {
+  if (value == null) return null;
+  if (!isPlainObject(value)) {
+    throw new IntentionSchemaError(`Expected object or null for ${field}, got ${typeof value}`);
+  }
+  return {
+    since: requireDateString(value.since, `${field}.since`),
+    attempt: requireNonNegativeInt(value.attempt, `${field}.attempt`),
+    pushed_sha: optionalString(value.pushed_sha, `${field}.pushed_sha`),
+  };
+}
+
 function validateExecution(value: unknown, field: string): Execution {
   if (!isPlainObject(value)) {
     throw new IntentionSchemaError(`Expected object for ${field}, got ${typeof value}`);
@@ -479,6 +515,7 @@ function validateExecution(value: unknown, field: string): Execution {
     attempts: validateAttempts(value.attempts, `${field}.attempts`),
     markers: validateIdArray(value.markers, `${field}.markers`),
     strategy_fingerprint: validateStrategyFingerprint(value.strategy_fingerprint, `${field}.strategy_fingerprint`),
+    fix: validateFixState(value.fix, `${field}.fix`),
   };
 }
 

--- a/packages/intentionsutil/src/scope-sweep.ts
+++ b/packages/intentionsutil/src/scope-sweep.ts
@@ -21,12 +21,14 @@ import type { IntentionNode } from "./schema.js";
 
 /**
  * The phases whose scope is inherited from a prior phase and therefore chained
- * to the phase-start stamp — fix/qa/review. Mirrors `SCOPE_CHAINED_PHASES` in
+ * to the phase-start stamp — qa/review. Mirrors `SCOPE_CHAINED_PHASES` in
  * `packages/intentionsutil/scripts/check-node-selection.ts` (the worker-start
- * gate's check 5): `implement` re-establishes custody against the latest scope,
- * and `main-qa` is post-merge, so neither is scope-chained.
+ * gate's check 5), which additionally includes the selector's `"fix"`
+ * CANDIDATE directive (never a persisted `node.phase` value — see
+ * `Phase`/`PHASES` in schema.ts): `implement` re-establishes custody against
+ * the latest scope, and `main-qa` is post-merge, so neither is scope-chained.
  */
-const SCOPE_CHAINED_PHASES = new Set(["fix", "qa", "review"]);
+const SCOPE_CHAINED_PHASES = new Set(["qa", "review"]);
 
 /** The phase-start stamp file for a node id: `<stamp-dir>/<id>.scope-fingerprint`. */
 function stampPath(stampDir: string, id: string): string {
@@ -61,7 +63,7 @@ function readStampedFingerprint(stampDir: string, id: string): string | null {
  * A node is stale — and returned — when ALL hold:
  *   - `kind === "tactic"`,
  *   - `office_hours` is null (an author park is handled by its own lane),
- *   - `phase` is one of the scope-chained phases (fix/qa/review),
+ *   - `phase` is one of the scope-chained phases (qa/review),
  *   - the node id is NOT in `liveIds` (an in-flight worker owns its own scope;
  *     the demote is only for idle nodes),
  *   - a scope-fingerprint stamp file exists at

--- a/packages/intentionsutil/src/transitions.ts
+++ b/packages/intentionsutil/src/transitions.ts
@@ -6,9 +6,9 @@ import { servingStrategyIds } from "./router.js";
 //
 // This module is the PURE decision layer that the transition-writer and
 // reconciler shell wrappers call. Same inputs in, same decision out — no gh,
-// no store I/O, no git. The environmental parts (reading origin/main, the CI
-// verdict / PR mergeability sensors, arming gh auto-merge, the stamp file, the
-// graph-commit call) live in the wrappers:
+// no store I/O, no git. The environmental parts (reading origin/main, the PR
+// mergeability sensor, arming gh auto-merge, the stamp file, the graph-commit
+// call) live in the wrappers:
 //   .claude/skills/dispatch-propagate/scripts/transition-node
 //   .claude/skills/dispatch-propagate/scripts/reconcile-graph-merged
 //   packages/intentionsutil/scripts/demote-node-to-implement
@@ -22,8 +22,8 @@ import { servingStrategyIds } from "./router.js";
  * The graph-native completion markers a tactic accumulates in
  * `execution.markers`, successors to the legacy `dispatch:planned`,
  * `dispatch:qa-done`, and `dispatch:reviewed` labels. A marker records that a
- * ladder phase completed; the fix-interrupt resume logic reads them to find
- * where a tactic left off.
+ * ladder phase completed; the selector reads them (e.g. the re-review reset
+ * after a fix lands post-review).
  */
 export const PLANNED_MARKER = "planned";
 export const QA_DONE_MARKER = "qa-done";
@@ -54,25 +54,28 @@ export type CiVerdict = "passing" | "failing" | "unknown";
  * (`fixInterrupt`), and `main-qa` is inserted only when needs-main residue is
  * present (`forwardPhase`). `main-qa` is the phase value `tactic-main-qa-phase`
  * adopted into the schema enum; a node carrying needs-main residue drains it
- * before `done` (same doctrine as `router.ts`'s `PHASE_LADDER`).
+ * before `done` (same doctrine as `router.ts`'s `PHASE_LADDER`). A CI-fix
+ * interrupt does NOT move a tactic off this ladder — it is carried orthogonally
+ * on `execution.fix` (the selector owns that routing), so `phase` stays put.
  */
 export const LADDER: readonly string[] = ["implement", "qa", "review", "done"];
 
 /**
- * The phase reached when a worker COMPLETES `phase` cleanly (CI-green). The
- * `fix` interrupt is decided separately by `fixInterrupt`; this is the
- * green-path forward edge only.
+ * The phase reached when a worker COMPLETES `phase` cleanly. This is the
+ * unconditional forward edge — `decideTransition` fires it CI-blind, never
+ * routing into `fix` (a CI-fix interrupt is decided by the selector from
+ * `execution.fix`, leaving `phase` in place).
  *
  *   implement → qa
  *   qa        → review
  *   review    → main-qa  (needs-main residue present) | done
  *   main-qa   → done
  *
- * Returns `null` for a phase with no forward edge (`done`, or `fix` which
- * resumes via `resumeAfterFix`, or an unknown phase). `review`'s clean
- * completion in practice arms auto-merge rather than writing `done` directly —
- * the reconciler sweep absorbs the out-of-band merge — but the ladder edge is
- * still defined here for the reconciler and for a merge-disabled fallback.
+ * Returns `null` for a phase with no forward edge (`done`, `fix`, or an unknown
+ * phase). `review`'s clean completion in practice arms auto-merge rather than
+ * writing `done` directly — the reconciler sweep absorbs the out-of-band merge —
+ * but the ladder edge is still defined here for the reconciler and for a
+ * merge-disabled fallback.
  */
 export function forwardPhase(phase: string, hasResidue: boolean): string | null {
   switch (phase) {
@@ -95,30 +98,16 @@ export function forwardPhase(phase: string, hasResidue: boolean): string | null 
 const FIX_INTERRUPTIBLE: ReadonlySet<string> = new Set(["implement", "qa", "review"]);
 
 /**
- * Whether a live CI verdict at `phase` should route the tactic into `fix`
- * (spec §1.1, clarification 18; legacy `dispatch-phase` parity: CI verdict is
- * checked before phase logic, so a tactic already past qa/review routes back to
- * the fixer on a CI regression). Only a `failing` verdict at an interruptible
- * ladder phase fires; `unknown`/`passing` never do, and a phase already `fix`
- * or `done` is never re-interrupted.
+ * Whether a live CI verdict at `phase` should set the orthogonal `execution.fix`
+ * interrupt (spec §1.1, clarification 18). Only a `failing` verdict at an
+ * interruptible ladder phase fires; `unknown`/`passing` never do, and a `done`
+ * phase is never interrupted. This predicate is the SELECTOR's routing input —
+ * `decideTransition` is CI-blind and never calls it. The interrupt no longer
+ * overwrites `phase`; `phase` stays at its real ladder position while
+ * `execution.fix` carries the in-flight fix state.
  */
 export function fixInterrupt(phase: string, ci: CiVerdict): boolean {
   return ci === "failing" && FIX_INTERRUPTIBLE.has(phase);
-}
-
-/**
- * Where a tactic resumes when it leaves `fix` with a green CI verdict: the next
- * ladder phase after the furthest completion marker it carries. A tactic that
- * had finished review before the regression resumes at `done` (or `main-qa`
- * with residue); one that had only finished qa resumes at `review`; one past
- * implement resumes at `qa`; a bare tactic resumes at `implement`.
- */
-export function resumeAfterFix(markers: readonly string[], hasResidue: boolean): string {
-  const has = (m: string): boolean => markers.includes(m);
-  if (has(REVIEWED_MARKER)) return hasResidue ? "main-qa" : "done";
-  if (has(QA_DONE_MARKER)) return "review";
-  if (has(PLANNED_MARKER)) return "qa";
-  return "implement";
 }
 
 // --- Whole forward-transition decision ---------------------------------------
@@ -140,29 +129,27 @@ export interface TransitionDecision {
   hold: boolean;
   /** True when the hold is a scope-fingerprint demotion to `implement`. */
   demote: boolean;
-  /**
-   * Completion markers to strip from `execution.markers` as part of this
-   * transition. Non-empty only for the CI-failure fix interrupt, which clears
-   * `qa-done` and `reviewed` so a resume out of `fix` re-runs qa and review (the
-   * regressed code was never seen by the completed review). Empty otherwise.
-   */
-  clearMarkers: readonly string[];
 }
 
 /**
  * Decide the transition at the end of a phase worker's run, given the tactic's
- * current phase, its completion markers, the live CI verdict, whether the node
- * carries needs-main residue, and the two freshness-gate results.
+ * current phase, whether the node carries needs-main residue, and the two
+ * freshness-gate results.
+ *
+ * This decision is CI-BLIND: the forward ladder edge fires unconditionally and
+ * is NEVER routed into `fix` here. A CI-fix interrupt is carried orthogonally on
+ * `execution.fix` and routed by the selector (`fixInterrupt`), leaving `phase`
+ * at its real ladder position — so there is nothing to resume and no marker to
+ * clear at transition time. The re-review reset (clearing qa-done/reviewed when
+ * a fix lands after review) likewise belongs to the selector, not here.
  *
  * Order of precedence (spec §1.1):
  *  1. Scope-fingerprint mismatch → demote to `implement` (the chain-of-custody
  *     backward transition; supersedes stay-at-phase).
  *  2. Strategy-fingerprint mismatch → hold at the current phase (soft-freeze;
  *     the selector queues the re-evaluation, a confirm re-stamps).
- *  3. CI failing at an interruptible phase → `fix`.
- *  4. Leaving `fix` with green CI → resume at the marker-implied phase.
- *  5. Clean `review` completion → arm auto-merge, no phase write.
- *  6. Otherwise → the forward ladder edge.
+ *  3. Clean `review` completion → arm auto-merge, no phase write.
+ *  4. Otherwise → the unconditional forward ladder edge.
  *
  * `scopeStale` and `strategyStale` are the caller's precomputed gate results
  * (the caller owns the origin/main reads and the stamp file). A missing stamp
@@ -172,54 +159,34 @@ export interface TransitionDecision {
  */
 export function decideTransition(args: {
   phase: string;
-  markers: readonly string[];
-  ci: CiVerdict;
   hasResidue: boolean;
   scopeStale: boolean;
   strategyStale: boolean;
 }): TransitionDecision {
-  const { phase, markers, ci, hasResidue, scopeStale, strategyStale } = args;
+  const { phase, hasResidue, scopeStale, strategyStale } = args;
 
   // 1. Scope-fingerprint demotion (pre-merge only; the caller must not invoke
   //    this on a merged tactic — post-merge staleness routes via main-qa).
   if (scopeStale) {
-    return { phase: "implement", armMerge: false, hold: true, demote: true, clearMarkers: [] };
+    return { phase: "implement", armMerge: false, hold: true, demote: true };
   }
 
   // 2. Strategy soft-freeze hold at the completed phase.
   if (strategyStale) {
-    return { phase, armMerge: false, hold: true, demote: false, clearMarkers: [] };
+    return { phase, armMerge: false, hold: true, demote: false };
   }
 
-  // 3. CI-failure interrupt. Clear the qa-done and reviewed markers: the code
-  //    that regressed was never seen by the completed qa/review, so leaving
-  //    `fix` must resume at `qa` and re-run both — `resumeAfterFix`'s cascade
-  //    falls through to `qa` once these markers are gone.
-  if (fixInterrupt(phase, ci)) {
-    return { phase: "fix", armMerge: false, hold: false, demote: false, clearMarkers: [QA_DONE_MARKER, REVIEWED_MARKER] };
-  }
-
-  // 4. Resume out of fix on green CI.
-  if (phase === "fix") {
-    if (ci === "passing") {
-      return { phase: resumeAfterFix(markers, hasResidue), armMerge: false, hold: false, demote: false, clearMarkers: [] };
-    }
-    // Still red — stay in fix. Markers were already cleared on the earlier call
-    // that first entered `fix`; this later branch must not clear again.
-    return { phase: "fix", armMerge: false, hold: true, demote: false, clearMarkers: [] };
-  }
-
-  // 5. Clean review completion arms auto-merge; no graph-side phase write.
+  // 3. Clean review completion arms auto-merge; no graph-side phase write.
   if (phase === "review") {
-    return { phase: "review", armMerge: true, hold: false, demote: false, clearMarkers: [] };
+    return { phase: "review", armMerge: true, hold: false, demote: false };
   }
 
-  // 6. Forward ladder edge.
+  // 4. Unconditional forward ladder edge (CI-blind).
   const next = forwardPhase(phase, hasResidue);
   if (next === null) {
-    return { phase, armMerge: false, hold: true, demote: false, clearMarkers: [] };
+    return { phase, armMerge: false, hold: true, demote: false };
   }
-  return { phase: next, armMerge: false, hold: false, demote: false, clearMarkers: [] };
+  return { phase: next, armMerge: false, hold: false, demote: false };
 }
 
 // --- Execution-state mutation helpers ---------------------------------------

--- a/packages/intentionsutil/test/apply-fix-state.test.ts
+++ b/packages/intentionsutil/test/apply-fix-state.test.ts
@@ -1,0 +1,175 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readNode, writeNode } from "../src/store.js";
+import { applyFixState, parseArgs } from "../scripts/apply-fix-state.js";
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), "fix-state-"));
+}
+
+/** Write a synthetic tactic file with the given phase and markers. */
+function seedTactic(dir: string, phase: string, markers: string[]): void {
+  const frontmatter = [
+    "---",
+    "id: tactic-syn",
+    "kind: tactic",
+    'statement: "synthetic tactic"',
+    "owner: ai",
+    "status: codified",
+    "parent: null",
+    "serves: []",
+    "recovers: []",
+    "rationale: null",
+    "reading: null",
+    "gap: null",
+    "clarifications: []",
+    "tooling_goals: []",
+    "success_signal: null",
+    "attention: null",
+    `phase: ${phase}`,
+    "execution:",
+    "  branch: tactic-syn",
+    "  pr: 4242",
+    "  attempts: {}",
+    `  markers: [${markers.join(", ")}]`,
+    "  strategy_fingerprint: null",
+    "  fix: null",
+    "validates: []",
+    "blocked_by: []",
+    "office_hours: null",
+    "pace_exempt: false",
+    "rounds: null",
+    "attributes: {}",
+    "---",
+    "# body\n",
+  ].join("\n");
+  writeFileSync(join(dir, "tactic-syn.md"), frontmatter);
+}
+
+describe("applyFixState store round-trip", () => {
+  it("--set-fix enters the interrupt with attempt 1 and a null pushed_sha, leaving phase untouched", () => {
+    const dir = tempDir();
+    seedTactic(dir, "qa", []);
+    const r = applyFixState({ id: "tactic-syn", mode: "set", pushedSha: null, dir });
+    expect(r.mode).toBe("set");
+    expect(r.attempt).toBe(1);
+    expect(r.since).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const node = readNode(dir, "tactic-syn");
+    expect(node.phase).toBe("qa"); // ladder phase preserved
+    expect(node.execution?.fix).toEqual({ since: r.since, attempt: 1, pushed_sha: null });
+  });
+
+  it("--set-fix on an already-set interrupt bumps attempt and preserves since/pushed_sha", () => {
+    const dir = tempDir();
+    seedTactic(dir, "qa", []);
+    applyFixState({ id: "tactic-syn", mode: "set", pushedSha: null, dir });
+    // Record a push, then a defensive re-set: since/pushed_sha survive, attempt bumps.
+    applyFixState({ id: "tactic-syn", mode: "record", pushedSha: "deadbeef", dir });
+    const first = readNode(dir, "tactic-syn").execution?.fix;
+    const r = applyFixState({ id: "tactic-syn", mode: "set", pushedSha: null, dir });
+    expect(r.attempt).toBe(2);
+    const fix = readNode(dir, "tactic-syn").execution?.fix;
+    expect(fix?.attempt).toBe(2);
+    expect(fix?.since).toBe(first?.since);
+    expect(fix?.pushed_sha).toBe("deadbeef");
+  });
+
+  it("--clear-fix clears the interrupt and preserves the ladder phase when not past review", () => {
+    const dir = tempDir();
+    seedTactic(dir, "qa", []);
+    applyFixState({ id: "tactic-syn", mode: "set", pushedSha: null, dir });
+    const r = applyFixState({ id: "tactic-syn", mode: "clear", pushedSha: null, dir });
+    expect(r.mode).toBe("clear");
+    expect(r.reset).toBe(false);
+    expect(r.phase).toBe("qa");
+    const node = readNode(dir, "tactic-syn");
+    expect(node.execution?.fix).toBeNull();
+    expect(node.phase).toBe("qa");
+  });
+
+  it("--clear-fix past review applies the re-review reset (phase → review)", () => {
+    const dir = tempDir();
+    // A node that had finished review carries the reviewed marker; its real phase
+    // may have been carried at review while the interrupt was active.
+    seedTactic(dir, "review", ["planned", "qa-done", "reviewed"]);
+    applyFixState({ id: "tactic-syn", mode: "set", pushedSha: null, dir });
+    const r = applyFixState({ id: "tactic-syn", mode: "clear", pushedSha: null, dir });
+    expect(r.reset).toBe(true);
+    expect(r.phase).toBe("review");
+    const node = readNode(dir, "tactic-syn");
+    expect(node.phase).toBe("review");
+    expect(node.execution?.fix).toBeNull();
+    // The reviewed marker is stripped so review actually re-runs; qa-done/planned
+    // survive (only review re-runs, not qa).
+    expect(node.execution?.markers).toEqual(["planned", "qa-done"]);
+  });
+
+  it("--record-push stamps pushed_sha, preserving since/attempt and phase", () => {
+    const dir = tempDir();
+    seedTactic(dir, "review", []);
+    const set = applyFixState({ id: "tactic-syn", mode: "set", pushedSha: null, dir });
+    const r = applyFixState({ id: "tactic-syn", mode: "record", pushedSha: "abc123", dir });
+    expect(r.mode).toBe("record");
+    expect(r.pushed_sha).toBe("abc123");
+    const fix = readNode(dir, "tactic-syn").execution?.fix;
+    expect(fix).toEqual({ since: set.since, attempt: 1, pushed_sha: "abc123" });
+    expect(readNode(dir, "tactic-syn").phase).toBe("review");
+  });
+
+  it("--record-push with no active interrupt is an error", () => {
+    const dir = tempDir();
+    seedTactic(dir, "qa", []);
+    expect(() => applyFixState({ id: "tactic-syn", mode: "record", pushedSha: "abc123", dir })).toThrow(
+      /execution\.fix is null/,
+    );
+  });
+
+  it("rejects a non-tactic node", () => {
+    const dir = tempDir();
+    writeNode(dir, {
+      id: "strategy-x",
+      kind: "strategy",
+      statement: "s",
+      owner: "ai",
+      status: "codified",
+    });
+    expect(() => applyFixState({ id: "strategy-x", mode: "set", pushedSha: null, dir })).toThrow(
+      /not a tactic/,
+    );
+  });
+});
+
+describe("apply-fix-state parseArgs", () => {
+  it("parses --set-fix", () => {
+    const a = parseArgs(["tactic-syn", "--set-fix"]);
+    expect(a).toMatchObject({ id: "tactic-syn", mode: "set", pushedSha: null });
+  });
+
+  it("parses --clear-fix with --dir", () => {
+    const a = parseArgs(["tactic-syn", "--clear-fix", "--dir", "/tmp/x"]);
+    expect(a).toMatchObject({ id: "tactic-syn", mode: "clear", dir: "/tmp/x" });
+  });
+
+  it("parses --record-push <sha>", () => {
+    const a = parseArgs(["tactic-syn", "--record-push", "abc123"]);
+    expect(a).toMatchObject({ id: "tactic-syn", mode: "record", pushedSha: "abc123" });
+  });
+
+  it("rejects combining two modes", () => {
+    expect(() => parseArgs(["tactic-syn", "--set-fix", "--clear-fix"])).toThrow(/mutually exclusive/);
+  });
+
+  it("rejects --record-push with no sha", () => {
+    expect(() => parseArgs(["tactic-syn", "--record-push"])).toThrow(/requires a <sha>/);
+  });
+
+  it("requires a mode", () => {
+    expect(() => parseArgs(["tactic-syn"])).toThrow(/one of --set-fix/);
+  });
+
+  it("requires a node id", () => {
+    expect(() => parseArgs(["--set-fix"])).toThrow(/<node-id> is required/);
+  });
+});

--- a/packages/intentionsutil/test/apply-node-transition.test.ts
+++ b/packages/intentionsutil/test/apply-node-transition.test.ts
@@ -3,7 +3,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { readNode, writeNode } from "../src/store.js";
-import type { CiVerdict } from "../src/transitions.js";
 import { applyNodeTransition, parseArgs } from "../scripts/apply-node-transition.js";
 
 function tempDir(): string {
@@ -45,14 +44,12 @@ function seedTactic(dir: string, phase: string, body: string): void {
 
 const baseArgs: {
   id: string;
-  ci: CiVerdict;
   scopeStale: boolean;
   strategyStale: boolean;
   setPr: number | null;
   strategyFingerprint: Record<string, { hash: string; sha: string }> | null;
 } = {
   id: "tactic-syn",
-  ci: "unknown",
   scopeStale: false,
   strategyStale: false,
   setPr: null,
@@ -71,18 +68,21 @@ describe("applyNodeTransition store round-trip", () => {
     expect(node.execution?.markers).toEqual(["planned"]);
   });
 
-  it("interrupts review→fix on failing CI without writing a marker", () => {
+  it("advances review CI-blind — never routes into fix", () => {
+    // The forward decision no longer reads CI; a review-phase transition arms
+    // merge and never writes phase:"fix" (a CI-fix interrupt is the selector's
+    // orthogonal execution.fix, not a phase overwrite here).
     const dir = tempDir();
     seedTactic(dir, "review", "# body\n");
-    const r = applyNodeTransition({ ...baseArgs, dir, ci: "failing" });
-    expect(r.phase).toBe("fix");
-    expect(readNode(dir, "tactic-syn").execution?.markers).toEqual([]);
+    const r = applyNodeTransition({ ...baseArgs, dir });
+    expect(r.phase).not.toBe("fix");
+    expect(r.armMerge).toBe(true);
   });
 
   it("arms merge at clean review completion and stamps the reviewed marker", () => {
     const dir = tempDir();
     seedTactic(dir, "review", "# body\n");
-    const r = applyNodeTransition({ ...baseArgs, dir, ci: "passing" });
+    const r = applyNodeTransition({ ...baseArgs, dir });
     expect(r.armMerge).toBe(true);
     expect(r.phase).toBe("review");
     expect(readNode(dir, "tactic-syn").execution?.markers).toEqual(["reviewed"]);
@@ -93,7 +93,7 @@ describe("applyNodeTransition store round-trip", () => {
     // Seed a review-phase tactic that already carries markers, via two hops.
     seedTactic(dir, "implement", "# body\n");
     applyNodeTransition({ ...baseArgs, dir }); // implement→qa (planned)
-    applyNodeTransition({ ...baseArgs, dir, ci: "passing" }); // qa→review (qa-done)
+    applyNodeTransition({ ...baseArgs, dir }); // qa→review (qa-done)
     expect(readNode(dir, "tactic-syn").execution?.markers).toEqual(["planned", "qa-done"]);
 
     const r = applyNodeTransition({ ...baseArgs, dir, scopeStale: true });
@@ -104,30 +104,10 @@ describe("applyNodeTransition store round-trip", () => {
     expect(node.execution?.markers).toEqual([]);
   });
 
-  it("clears qa-done and reviewed on a fix interrupt so resume out of fix returns to qa", () => {
-    const dir = tempDir();
-    // Walk implement→qa→review→(arm-merge) so the node carries all three markers.
-    seedTactic(dir, "implement", "# body\n");
-    applyNodeTransition({ ...baseArgs, dir, ci: "passing" }); // implement→qa (planned)
-    applyNodeTransition({ ...baseArgs, dir, ci: "passing" }); // qa→review (qa-done)
-    applyNodeTransition({ ...baseArgs, dir, ci: "passing" }); // review arms merge (reviewed)
-    expect(readNode(dir, "tactic-syn").execution?.markers).toEqual(["planned", "qa-done", "reviewed"]);
-
-    // CI regresses: fix interrupt clears qa-done and reviewed, keeping planned.
-    const fix = applyNodeTransition({ ...baseArgs, dir, ci: "failing" });
-    expect(fix.phase).toBe("fix");
-    expect(readNode(dir, "tactic-syn").execution?.markers).toEqual(["planned"]);
-
-    // Leaving fix on green CI resumes at qa (not review) — the cleared markers
-    // mean the marker cascade falls through past review back to qa.
-    const resume = applyNodeTransition({ ...baseArgs, dir, ci: "passing" });
-    expect(resume.phase).toBe("qa");
-  });
-
   it("routes a residue-bearing clean review to arm-merge and reports hasResidue", () => {
     const dir = tempDir();
     seedTactic(dir, "review", "# body\n\n## needs-main\n\nverify in prod\n");
-    const r = applyNodeTransition({ ...baseArgs, dir, ci: "passing" });
+    const r = applyNodeTransition({ ...baseArgs, dir });
     expect(r.hasResidue).toBe(true);
     expect(r.armMerge).toBe(true);
   });

--- a/packages/intentionsutil/test/check-node-selection.test.ts
+++ b/packages/intentionsutil/test/check-node-selection.test.ts
@@ -118,6 +118,45 @@ describe("evaluateSelection", () => {
     expect(r.exitCode).toBe(0);
   });
 
+  it("passes a fix selection while execution.fix is set (ladder phase preserved)", () => {
+    const dir = tempDir();
+    seed(
+      dir,
+      anode({
+        id: "tactic-fx",
+        kind: "tactic",
+        phase: "qa", // real ladder phase preserved; the interrupt is orthogonal
+        execution: {
+          branch: "b",
+          pr: 1,
+          attempts: {},
+          markers: [],
+          strategy_fingerprint: null,
+          fix: { since: "2026-07-18", attempt: 1, pushed_sha: null },
+        },
+      }),
+    );
+    const r = evaluateSelection({ nodeId: "tactic-fx", selectedPhase: "fix", dir, stamp: null });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("exit 12 on a fix selection once execution.fix was cleared (interrupt resolved since selection)", () => {
+    const dir = tempDir();
+    seed(
+      dir,
+      anode({
+        id: "tactic-fx",
+        kind: "tactic",
+        phase: "qa",
+        execution: { branch: "b", pr: 1, attempts: {}, markers: [], strategy_fingerprint: null, fix: null },
+      }),
+    );
+    const r = evaluateSelection({ nodeId: "tactic-fx", selectedPhase: "fix", dir, stamp: null });
+    expect(r.exitCode).toBe(12);
+    expect(r.stderr[0]).toMatch(/selected fix but tactic-fx carries no execution\.fix interrupt/);
+  });
+
   it("exit 12 when parked first-class (office_hours set after selection)", () => {
     const dir = tempDir();
     seed(

--- a/packages/intentionsutil/test/router.test.ts
+++ b/packages/intentionsutil/test/router.test.ts
@@ -61,6 +61,7 @@ function exec(partial: Partial<Execution> = {}): Execution {
     attempts: partial.attempts ?? {},
     markers: partial.markers ?? [],
     strategy_fingerprint: partial.strategy_fingerprint ?? null,
+    fix: partial.fix ?? null,
   };
 }
 
@@ -147,6 +148,28 @@ describe("tactic eligibility", () => {
       tactic({ id: "tactic-a", phase: "fix", pace_exempt: true, execution: exec({ pr: 42 }) }),
     ]);
     expect(sel.candidates[0]).toMatchObject({ pace_exempt: true, pr: 42 });
+  });
+
+  it("overrides phase to 'fix' and surfaces execution.fix when a CI-fix interrupt is active", () => {
+    // The ladder phase (qa) is preserved on the node; the candidate is emitted as
+    // a fix candidate and carries the raw interrupt state for the shell gate's
+    // pending-CI guard.
+    const fix = { since: "2026-07-18", attempt: 2, pushed_sha: "abc123" };
+    const sel = selectGraphTargets([
+      tactic({ id: "tactic-a", phase: "qa", execution: exec({ pr: 42, fix }) }),
+    ]);
+    const c = sel.candidates.find((x) => x.id === "tactic-a");
+    expect(c?.phase).toBe("fix");
+    expect(c?.fix).toEqual(fix);
+  });
+
+  it("surfaces fix:null and the real ladder phase when no interrupt is active", () => {
+    const sel = selectGraphTargets([
+      tactic({ id: "tactic-a", phase: "qa", execution: exec({ pr: 42 }) }),
+    ]);
+    const c = sel.candidates.find((x) => x.id === "tactic-a");
+    expect(c?.phase).toBe("qa");
+    expect(c?.fix).toBeNull();
   });
 
   it("skips a phase:review tactic once execution.markers includes 'reviewed' (tick-owned)", () => {

--- a/packages/intentionsutil/test/router.test.ts
+++ b/packages/intentionsutil/test/router.test.ts
@@ -170,6 +170,28 @@ describe("tactic eligibility", () => {
     ];
     expect(candidateIds(nodes)).toEqual(["tactic-review"]);
   });
+
+  it("emits a fix candidate when execution.fix is set, regardless of the real ladder phase", () => {
+    // A CI-fix interrupt is carried orthogonally on execution.fix; the node's
+    // real phase (e.g. qa) stays put, but the candidate surfaces as phase:"fix".
+    const nodes = [
+      tactic({
+        id: "tactic-under-fix",
+        phase: "qa",
+        execution: { ...exec({ pr: 7 }), fix: { since: "2026-07-18", attempt: 1, pushed_sha: null } },
+      }),
+    ];
+    const sel = selectGraphTargets(nodes);
+    expect(sel.candidates[0]).toMatchObject({ id: "tactic-under-fix", phase: "fix" });
+  });
+
+  it("emits the real ladder phase when execution.fix is unset", () => {
+    const nodes = [
+      tactic({ id: "tactic-clean", phase: "qa", execution: { ...exec({ pr: 7 }), fix: null } }),
+    ];
+    const sel = selectGraphTargets(nodes);
+    expect(sel.candidates[0]).toMatchObject({ id: "tactic-clean", phase: "qa" });
+  });
 });
 
 describe("strategy eligibility", () => {

--- a/packages/intentionsutil/test/router.test.ts
+++ b/packages/intentionsutil/test/router.test.ts
@@ -145,7 +145,7 @@ describe("tactic eligibility", () => {
 
   it("passes pace_exempt and execution.pr through to the candidate", () => {
     const sel = selectGraphTargets([
-      tactic({ id: "tactic-a", phase: "fix", pace_exempt: true, execution: exec({ pr: 42 }) }),
+      tactic({ id: "tactic-a", phase: "qa", pace_exempt: true, execution: exec({ pr: 42 }) }),
     ]);
     expect(sel.candidates[0]).toMatchObject({ pace_exempt: true, pr: 42 });
   });
@@ -763,18 +763,16 @@ describe("ordering", () => {
     expect(candidateIds(nodes)).toEqual(["tactic-high", "tactic-low"]);
   });
 
-  it("within one rank level, the progression ordinal orders closest-to-done first (qa sorts before fix)", () => {
+  it("within one rank level, the progression ordinal orders closest-to-done first", () => {
     const nodes = [
       strategy({ id: "strategy-s", reading: "validated" }),
       tactic({ id: "tactic-implement", phase: "implement" }),
       tactic({ id: "tactic-review", phase: "review" }),
       tactic({ id: "tactic-qa", phase: "qa" }),
-      tactic({ id: "tactic-fix", phase: "fix" }),
     ];
     expect(candidateIds(nodes)).toEqual([
       "tactic-review",
       "tactic-qa",
-      "tactic-fix",
       "tactic-implement",
     ]);
   });
@@ -802,7 +800,6 @@ describe("ordering", () => {
       "draft",
       "align-tactics",
       "implement",
-      "fix",
       "qa",
       "review",
       "main-qa",

--- a/packages/intentionsutil/test/schema.test.ts
+++ b/packages/intentionsutil/test/schema.test.ts
@@ -78,6 +78,7 @@ describe("validateNode", () => {
       attempts: { implement: 1, qa: 2 },
       markers: ["dispatch:qa"],
       strategy_fingerprint: "abc123",
+      fix: null,
     });
     expect(result.validates).toEqual(["strategy-1"]);
     expect(result.blocked_by).toEqual(["tactic-2"]);
@@ -109,6 +110,7 @@ describe("validateNode", () => {
       attempts: {},
       markers: [],
       strategy_fingerprint: null,
+      fix: null,
     });
   });
 

--- a/packages/intentionsutil/test/scope-sweep.test.ts
+++ b/packages/intentionsutil/test/scope-sweep.test.ts
@@ -52,17 +52,17 @@ function stamp(stampDir: string, id: string, fingerprint: string, sha = "abc1234
 }
 
 describe("listScopeStaleTactics", () => {
-  it("returns a stale fix/qa/review node whose stamp no longer matches", () => {
+  it("returns a stale qa/review node whose stamp no longer matches", () => {
     const dir = tempDir("scope-sweep-store-");
     const stampDir = tempDir("scope-sweep-stamps-");
-    for (const phase of ["fix", "qa", "review"] as const) {
+    for (const phase of ["qa", "review"] as const) {
       const id = `tactic-${phase}`;
       seed(dir, anode({ id, kind: "tactic", phase }));
       // A deliberately-wrong stamp: the current scope has drifted from it.
       stamp(stampDir, id, "f".repeat(64));
     }
     const result = listScopeStaleTactics(listNodes(dir), dir, stampDir, new Set());
-    expect(result.sort()).toEqual(["tactic-fix", "tactic-qa", "tactic-review"]);
+    expect(result.sort()).toEqual(["tactic-qa", "tactic-review"]);
   });
 
   it("excludes a node whose stamp matches the current scope fingerprint", () => {
@@ -96,7 +96,7 @@ describe("listScopeStaleTactics", () => {
   it("excludes a stale node whose id is in the live set", () => {
     const dir = tempDir("scope-sweep-store-");
     const stampDir = tempDir("scope-sweep-stamps-");
-    seed(dir, anode({ id: "tactic-live", kind: "tactic", phase: "fix" }));
+    seed(dir, anode({ id: "tactic-live", kind: "tactic", phase: "qa" }));
     stamp(stampDir, "tactic-live", "f".repeat(64));
     expect(listScopeStaleTactics(listNodes(dir), dir, stampDir, new Set(["tactic-live"]))).toEqual([]);
   });

--- a/packages/intentionsutil/test/transitions.test.ts
+++ b/packages/intentionsutil/test/transitions.test.ts
@@ -1,13 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Execution, IntentionNode } from "../src/schema.js";
-import type { CiVerdict } from "../src/transitions.js";
 import {
   PLANNED_MARKER,
   QA_DONE_MARKER,
-  REVIEWED_MARKER,
   forwardPhase,
   fixInterrupt,
-  resumeAfterFix,
   decideTransition,
   addMarker,
   incrementAttempt,
@@ -101,79 +98,41 @@ describe("fixInterrupt", () => {
   });
 });
 
-describe("resumeAfterFix", () => {
-  it("resumes at the phase after the furthest completion marker", () => {
-    expect(resumeAfterFix([], false)).toBe("implement");
-    expect(resumeAfterFix([PLANNED_MARKER], false)).toBe("qa");
-    expect(resumeAfterFix([PLANNED_MARKER, QA_DONE_MARKER], false)).toBe("review");
-    expect(resumeAfterFix([PLANNED_MARKER, QA_DONE_MARKER, REVIEWED_MARKER], false)).toBe("done");
-  });
-
-  it("resumes a fully-reviewed tactic at main-qa when residue is present", () => {
-    expect(resumeAfterFix([QA_DONE_MARKER, REVIEWED_MARKER], true)).toBe("main-qa");
-  });
-});
-
 describe("decideTransition", () => {
-  const base: { markers: string[]; ci: CiVerdict; hasResidue: boolean; scopeStale: boolean; strategyStale: boolean } = {
-    markers: [],
-    ci: "passing",
+  const base: { hasResidue: boolean; scopeStale: boolean; strategyStale: boolean } = {
     hasResidue: false,
     scopeStale: false,
     strategyStale: false,
   };
 
-  it("advances implement → qa on a clean pass", () => {
+  it("advances implement → qa unconditionally (CI-blind)", () => {
     const d = decideTransition({ ...base, phase: "implement" });
-    expect(d).toEqual({ phase: "qa", armMerge: false, hold: false, demote: false, clearMarkers: [] });
+    expect(d).toEqual({ phase: "qa", armMerge: false, hold: false, demote: false });
   });
 
-  it("advances qa → review on a clean pass", () => {
+  it("advances qa → review unconditionally (CI-blind)", () => {
     expect(decideTransition({ ...base, phase: "qa" }).phase).toBe("review");
   });
 
   it("arms auto-merge and writes no phase at clean review completion", () => {
     const d = decideTransition({ ...base, phase: "review" });
-    expect(d).toEqual({ phase: "review", armMerge: true, hold: false, demote: false, clearMarkers: [] });
+    expect(d).toEqual({ phase: "review", armMerge: true, hold: false, demote: false });
   });
 
-  it("interrupts to fix on failing CI from any ladder phase", () => {
-    for (const phase of ["implement", "qa", "review"]) {
-      expect(decideTransition({ ...base, phase, ci: "failing" }).phase).toBe("fix");
+  it("never routes any phase into fix (fix is the selector's orthogonal interrupt)", () => {
+    for (const phase of ["implement", "qa", "review", "main-qa"]) {
+      expect(decideTransition({ ...base, phase }).phase).not.toBe("fix");
     }
   });
 
-  it("clears qa-done and reviewed on the fix interrupt so resume re-runs qa and review", () => {
-    const d = decideTransition({
-      ...base,
-      phase: "review",
-      ci: "failing",
-      markers: [PLANNED_MARKER, QA_DONE_MARKER, REVIEWED_MARKER],
-    });
-    expect(d.phase).toBe("fix");
-    expect(d.clearMarkers).toEqual([QA_DONE_MARKER, REVIEWED_MARKER]);
-  });
-
-  it("resumes out of fix at the marker-implied phase on green CI", () => {
-    const d = decideTransition({ ...base, phase: "fix", markers: [PLANNED_MARKER, QA_DONE_MARKER] });
-    expect(d.phase).toBe("review");
-    expect(d.hold).toBe(false);
-  });
-
-  it("stays in fix while CI is still red", () => {
-    const d = decideTransition({ ...base, phase: "fix", ci: "failing" });
-    expect(d).toEqual({ phase: "fix", armMerge: false, hold: true, demote: false, clearMarkers: [] });
-  });
-
   it("demotes to implement on a scope-fingerprint mismatch, before any other rule", () => {
-    // Even with a clean forward path and a failing CI, scope-stale wins.
-    const d = decideTransition({ ...base, phase: "review", ci: "failing", scopeStale: true });
-    expect(d).toEqual({ phase: "implement", armMerge: false, hold: true, demote: true, clearMarkers: [] });
+    const d = decideTransition({ ...base, phase: "review", scopeStale: true });
+    expect(d).toEqual({ phase: "implement", armMerge: false, hold: true, demote: true });
   });
 
   it("holds at the completed phase on a strategy-fingerprint mismatch", () => {
     const d = decideTransition({ ...base, phase: "review", strategyStale: true });
-    expect(d).toEqual({ phase: "review", armMerge: false, hold: true, demote: false, clearMarkers: [] });
+    expect(d).toEqual({ phase: "review", armMerge: false, hold: true, demote: false });
   });
 
   it("scope-stale takes precedence over strategy-stale", () => {


### PR DESCRIPTION
## Summary

Models the CI-fix interrupt as an orthogonal execution-state field instead of a
value of the `phase` enum. Previously, entering a fix interrupt overwrote
`phase` with `"fix"`, destroying ladder position and forcing a lossy
marker-based `resumeAfterFix` reconstruction on resume (observed producing a
`fix -> implement -> qa` double-commit on PR #2885, and able to auto-merge
unreviewed code when a fix landed after review had already completed).

- **Unit 1** (`packages/intentionsutil/src/schema.ts`) — additive: adds a
  nullable `execution.fix: { since, attempt, pushed_sha } | null` field and its
  validator. `Phase`/`PHASES` still include `"fix"` at this point.
- **Unit 2** (`transitions.ts`, `router.ts`, `apply-node-transition.ts`,
  `transition-node`) — makes the completion transition (`decideTransition`)
  **CI-blind**: the forward ladder edge (`implement->qa`, `qa->review`,
  `review->arm-merge`) now fires unconditionally, never reading CI and never
  producing `phase: "fix"`. Deletes `resumeAfterFix` — with `phase` preserved
  there is nothing to reconstruct. `router.ts`'s candidate emission surfaces a
  node with `execution.fix` set as a `fix` candidate regardless of its real
  phase.
- **Unit 3** (`graph-select-target`, `apply-fix-state.ts` (new),
  `check-node-selection.ts`, `fix-checks/SKILL.md`) — the graph selector
  becomes the sole CI-routing authority: on concluded-red CI at an
  interruptible phase it sets `execution.fix` and dispatches `/fix-checks`
  same-tick; on concluded-green it clears `execution.fix`, resets
  `phase -> review` and disarms auto-merge if the node was already past review
  (the re-review edge), and dispatches the resolved phase's worker; a
  `pushed_sha` pending-CI guard prevents a fix-worker's own push from being
  misread as a resume window. `fix-checks/SKILL.md`'s stale
  "consult the CI verdict via transition-node" completion description is
  corrected — that call would now force the ladder forward regardless of
  whether the fix worked, since `transition-node` is CI-blind. The worker now
  just records its push (`pushed_sha`) and disarms auto-merge unconditionally
  on push, then stops; the selector resolves the interrupt on a later tick.
- **Unit 4** (schema.ts, router.ts, scope-sweep.ts) — cutover: removes `"fix"`
  from the `Phase` union/`PHASES` array (no live node was at `phase: fix` by
  the time this landed — the two nodes named in the original plan had already
  progressed off it naturally), deletes the now-dead `PHASE_LADDER` export and
  the `fix` entry from `scope-sweep.ts`'s `SCOPE_CHAINED_PHASES`.

Graph node: `tactic-fix-interrupt-orthogonal-state` (no GitHub issue backs this
change).

## Test plan

- [x] `npx vitest run --project packages/intentionsutil --root .` — 547/547 passing (29 files).
- [x] `npx tsx packages/intentionsutil/scripts/validate-graph.ts` — `ok — 403 nodes`.
- [x] `npx tsc --noEmit -p packages/intentionsutil` — clean (one pre-existing, unrelated error in `graph-census-debt.test.ts` predates this branch).
- [ ] Manual: drive a red-CI interrupt end-to-end on a scratch node (deferred to qa/main-qa observation — the plan's Verification section calls this out as manual/observe-in-production).
