### PR TITLE
Fix stale align/ path refs in two intention node bodies

### DIFF
--- a/intentions/tactic-dispatch-script-hardening.md
+++ b/intentions/tactic-dispatch-script-hardening.md
@@ -111,7 +111,7 @@ Scope:
 **Recommended model:** sonnet
 
 Scope:
-- `.claude/skills/align/scripts/gather-context.sh:71` via
+- `.claude/skills/align-init/scripts/gather-context.sh:74` via
   `lib.sh:412-455`: `gh_issue_list_rest --state closed --limit 100`
   fetches one page of 100 *mixed* issues+PRs, then filters PRs out
   client-side. In this PR-dominated repo the "recent 100 closed issues"

--- a/intentions/tactic-sync-reader-skill.md
+++ b/intentions/tactic-sync-reader-skill.md
@@ -341,7 +341,7 @@ Out of scope: file naming, reader I/O, report.
   allowlist), relay the printed report to the user verbatim, and — for
   first-time setup — copy `sync-reader.example.json` to
   `<project-root>/dispatch.config/sync-reader.json` and fill in the two
-  paths. Invocation style precedent: `.claude/skills/align/SKILL.md:106`.
+  paths. Invocation style precedent: `.claude/skills/align-init/SKILL.md:141`.
 - `.claude/skills/sync-reader/sync-reader.example.json` — committed
   template: `{"reader_dir": "/media/<user>/<device>", "share_dir": "/mnt/print-share"}`
   (precedent: `.claude/skills/dispatch-propagate/scripts/auto-merge.example.json`).


### PR DESCRIPTION
## Summary

Fixes two stale `.claude/skills/align/` path:line anchors left in landed
tactic node bodies after the `/align` -> `/align-init` skill rename (PR #2781
deleted the `align/` directory; the terminal review of that PR swept code but
not `intentions/` node bodies).

- `intentions/tactic-dispatch-script-hardening.md:114` — now cites
  `.claude/skills/align-init/scripts/gather-context.sh:74` (verified against
  the current file: the `--paginate` closed-issues call).
- `intentions/tactic-sync-reader-skill.md:344` — now cites
  `.claude/skills/align-init/SKILL.md:141` (verified against the current
  file: the `RUNG=$(npx tsx ...)` invocation example).

Both edits are body-text only; no frontmatter or code changes. Three other
`align/` mentions found in the same repo-wide sweep were deliberately left
untouched — they are forward-looking or accurate-history references, not
stale.

## Test plan

- `npx tsx packages/intentionsutil/scripts/validate-graph.ts` passes.
- `grep -rn '\.claude/skills/align/' intentions/tactic-dispatch-script-hardening.md intentions/tactic-sync-reader-skill.md` returns nothing.
