### PR TITLE
Baseline 6 false-positive dangling prose refs blocking the graph guard

### DIFF
--- a/packages/intentionsutil/prose-ref-baseline.json
+++ b/packages/intentionsutil/prose-ref-baseline.json
@@ -14,5 +14,29 @@
   {
     "ref": "tactic-stale",
     "referencedBy": "tactic-freeze-resurface-stale-children-only"
+  },
+  {
+    "ref": "delegation-food-supply",
+    "referencedBy": "tactic-delegation-food-supply-record"
+  },
+  {
+    "ref": "tactic-only",
+    "referencedBy": "tactic-graph-digest-tooling"
+  },
+  {
+    "ref": "tactic-signal-path-attention",
+    "referencedBy": "tactic-graph-native-dispatch"
+  },
+  {
+    "ref": "virtue-anthropic-claude-growth",
+    "referencedBy": "tactic-mount-delegation-migration"
+  },
+  {
+    "ref": "strategy-stoicism-premeditatio-malorum",
+    "referencedBy": "tactic-mount-tradition-migration"
+  },
+  {
+    "ref": "issue-siblings",
+    "referencedBy": "tactic-review-lows-automation"
   }
 ]


### PR DESCRIPTION
## Summary

The Graph Fast Path `guard` job (`validate-graph.ts`) is currently failing on `origin/main` for **6 prose references that do not resolve to a node** — which blocks *every* `graph-commit` fleet-wide (all node phase-transitions, parks, and reconciles land through that guard).

All 6 are **false positives**: backtick-quoted identifiers used as prose, not real graph edges.

| Node | Ref | What it actually is |
|---|---|---|
| `tactic-review-lows-automation` | `issue-siblings` | a deleted **script name** ("Dead-script deletions") |
| `tactic-graph-digest-tooling` | `tactic-only` | cited as an **example** of a false-positive wildcard match |
| `tactic-graph-native-dispatch` | `tactic-signal-path-attention` | historical mention of a node that **"was pruned"** |
| `tactic-mount-delegation-migration` | `virtue-anthropic-claude-growth` | example `grafts:` **field value** in prose |
| `tactic-mount-tradition-migration` | `strategy-stoicism-premeditatio-malorum` | example field value |
| `tactic-delegation-food-supply-record` | `delegation-food-supply` | the **record-name** the tactic exists to author |

They began failing only when the open tactics that used to *plan* these ids closed/merged, exposing the prose mentions as dangling. The node bodies are correct and must not change, so the grandfather baseline (`packages/intentionsutil/prose-ref-baseline.json`) is the right mechanism — the same one already used for `tactic-only` (referencedBy `tactic-graph-split-orphan-guard`) and other prose-example refs.

## Change

Adds 6 `{ref, referencedBy}` entries to `prose-ref-baseline.json`. No intention-node bodies change.

## Verification

```
$ npx tsx packages/intentionsutil/scripts/validate-graph.ts intentions
ok — 403 nodes
ok — prose refs: 0 unresolved (10 grandfathered by baseline)
```