### PR TITLE
deps: bump @playwright/test 1.60.0 -> 1.61.1 to match nix chromium 1228

### DIFF
--- a/audio/package.json
+++ b/audio/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@commons-systems/config": "file:../packages/config",
     "@eslint/js": "^9.19.0",
-    "@playwright/test": "1.60.0",
+    "@playwright/test": "1.61.1",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "eslint": "^9.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@firebase/rules-unit-testing": "^5.0.0",
-        "@playwright/test": "1.60.0",
+        "@playwright/test": "1.61.1",
         "@types/dompurify": "^3.0.5",
         "critters": "^0.0.23",
         "eslint": "^9.19.0",
@@ -83,7 +83,7 @@
       "devDependencies": {
         "@commons-systems/config": "file:../packages/config",
         "@eslint/js": "^9.19.0",
-        "@playwright/test": "1.60.0",
+        "@playwright/test": "1.61.1",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "eslint": "^9.19.0",
@@ -5364,12 +5364,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14863,12 +14863,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14881,9 +14881,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -18981,7 +18981,10 @@
     },
     "packages/config": {
       "name": "@commons-systems/config",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "@commons-systems/analyticsutil": "*"
+      }
     },
     "packages/criticalcssutil": {
       "name": "@commons-systems/criticalcssutil",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@eslint/js": "^9.19.0",
     "@firebase/rules-unit-testing": "^5.0.0",
-    "@playwright/test": "1.60.0",
+    "@playwright/test": "1.61.1",
     "@types/dompurify": "^3.0.5",
     "critters": "^0.0.23",
     "eslint": "^9.19.0",


### PR DESCRIPTION
## Problem

During a dispatch tick, `check-playwright-version-sync.sh` failed with:

```
ERROR: playwright chromium revision drift
  npm playwright-core expects: chromium revision 1223
  nix playwright-driver ships: chromium revision 1228
```

`playwright test` would fail with "Executable doesn't exist" because the
nix-provisioned `playwright-driver.browsers` ships chromium revision 1228,
while `@playwright/test` 1.60.0 expects revision 1223.

## Root cause

The 2026-07-21 flake.lock bump (a12b1779, "Update flake.lock: bump ...
nixpkgs") moved nixpkgs forward, taking `playwright-driver` to **1.61.1**
(chromium **1228**). The npm-pinned `@playwright/test` stayed at **1.60.0**
(chromium **1223**). An automated nix input bump moved the nix side forward
with no matching npm bump.

## Fix

Align npm to what nix already ships — bump `@playwright/test` to **1.61.1**
in both the root and `audio` workspace and regenerate `package-lock.json`.

## Verification

- `node_modules/playwright-core/browsers.json` now declares chromium `1228`.
- `check-playwright-version-sync.sh` passes against the nix browsers path
  (`chromium_headless_shell-1228` exists in `playwright-driver.browsers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)