### PR TITLE
dispatch: add a first-class pause sentinel to dispatch-tick

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -229,6 +229,22 @@ for a in "$@"; do
   esac
 done
 
+# --- Pause sentinel: stop autonomous scheduling, do not interfere with running work ---
+# When the pause flag file exists, an AUTONOMOUS tick (heartbeat timer, reseed
+# timer) does nothing: it exits here — before dispatch-select-tick, any spawn,
+# and any reseed-arming — so no new workers are scheduled and the tick arms no
+# follow-up reseed. Already-running workers are separate sessions and are left
+# untouched, so they run to completion. This is the durable, non-interfering
+# pause: unlike stopping/masking the systemd timers (which ensure_heartbeat_units
+# recreates on the next tick), a firing timer here becomes a harmless no-op.
+# A manual `dispatch --manual` run OVERRIDES the pause (deliberate human action).
+# Resume by removing the flag file. The path is overridable for tests.
+DISPATCH_PAUSE_FLAG="${DISPATCH_PAUSE_FLAG:-${XDG_DATA_HOME:-$HOME/.local/share}/commons-dispatch/paused}"
+if [[ -z "$MANUAL" && -e "$DISPATCH_PAUSE_FLAG" ]]; then
+  echo "dispatch-tick: paused (sentinel present at $DISPATCH_PAUSE_FLAG); no scheduling this tick"
+  exit 0
+fi
+
 # --- Synthesize a session identity for the headless tick ---------------------
 # The terminal `dispatch` command may or may not run inside a .claude session:
 # when invoked from within a Claude session it inherits a stable

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -22550,6 +22550,11 @@ tick_setup() {
   # (#1068) the tick writes resolves through dispatch_lock_file to a path inside
   # the test tree (not the host repo's tmp/).
   export DISPATCH_LOCK_FILE="$TMPDIR_TEST/dispatch.lock"
+  # Pin the pause sentinel to a path INSIDE the test tree that does not exist by
+  # default, so the tick's pause guard never fires from a real host flag file at
+  # the default $HOME/.local/share/commons-dispatch/paused. A pause test creates
+  # this file explicitly to exercise the guard.
+  export DISPATCH_PAUSE_FLAG="$TMPDIR_TEST/paused"
 
   # Fake dispatch-select-tick: echoes any TICK_SEL_PRE passthrough lines, then
   # the test-controlled decision line (TICK_DECISION) as the LAST line. Exits
@@ -22618,7 +22623,7 @@ tick_teardown() {
   TMPDIR_TEST=""
   unset TICK_DECISION TICK_SEL_RC TICK_GRAPH_EXEC_RC \
     TICK_SEL_PRE TICK_GRAPH_EXEC_PRE TICK_SPAWN_RESULT DISPATCH_TICK_MAIN_WORKTREE \
-    DISPATCH_LOCK_FILE TICK_REFRESH_RC TICK_CONVERGE_RC
+    DISPATCH_LOCK_FILE TICK_REFRESH_RC TICK_CONVERGE_RC DISPATCH_PAUSE_FLAG
 }
 
 run_tick() { "$TMPDIR_TEST/dispatch-tick" "$@" 2>/dev/null; }
@@ -22633,6 +22638,42 @@ assert_eq "busy: no graph-execute call" "0" \
   "$([ -f "$TMPDIR_TEST/logs/graph-execute.log" ] && echo 1 || echo 0)"
 assert_eq "busy: no spawn-job call" "0" \
   "$([ -f "$TMPDIR_TEST/logs/spawn-job.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+# --- pause sentinel: autonomous tick with flag present → no-op before select ---
+# The pause flag makes an AUTONOMOUS tick exit before dispatch-select-tick and
+# before dispatch-refresh-rate-limits, so it spawns nothing and arms no reseed.
+# Already-running workers are separate sessions the tick never signals, so this
+# pause does not interfere with in-flight work.
+echo "Test: dispatch-tick paused (flag present, autonomous) → exit 0, no select-tick/refresh/spawn"
+tick_setup
+: > "$TMPDIR_TEST/paused"
+export TICK_DECISION="empty"
+out=$(run_tick) && rc=0 || rc=$?
+assert_eq "paused: exit 0" "0" "$rc"
+assert_eq "paused: stdout announces pause" "1" \
+  "$(printf '%s' "$out" | grep -qi 'paused (sentinel present' && echo 1 || echo 0)"
+assert_eq "paused: select-tick NOT called" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/select-tick.log" ] && echo 1 || echo 0)"
+assert_eq "paused: refresh-rate-limits NOT run (guard exits before it)" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/order.log" ] && echo 1 || echo 0)"
+assert_eq "paused: no graph-execute" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/graph-execute.log" ] && echo 1 || echo 0)"
+assert_eq "paused: no spawn-job" "0" \
+  "$([ -f "$TMPDIR_TEST/logs/spawn-job.log" ] && echo 1 || echo 0)"
+tick_teardown
+
+# --- pause sentinel: --manual overrides the flag → the tick runs normally ------
+echo "Test: dispatch-tick --manual with flag present → overrides pause, runs select-tick"
+tick_setup
+: > "$TMPDIR_TEST/paused"
+export TICK_DECISION="busy"
+out=$(run_tick --manual) && rc=0 || rc=$?
+assert_eq "manual-override: exit 0" "0" "$rc"
+assert_eq "manual-override: select-tick WAS called" "1" \
+  "$([ -f "$TMPDIR_TEST/logs/select-tick.log" ] && echo 1 || echo 0)"
+assert_eq "manual-override: not announced as paused" "0" \
+  "$(printf '%s' "$out" | grep -qi 'paused (sentinel present' && echo 1 || echo 0)"
 tick_teardown
 
 # --- concurrency-cap / sync-repair-pending / sync-broken ---------------------


### PR DESCRIPTION
## Problem

There is no durable way to pause the autonomous dispatch chain. This came up when a request to "stop scheduled workers" could not be honored:

- **Config can't do it.** The graph selector (`graph-select-target`) reads no config; the only budget input, `target-workers`, is usage-conditional (it pauses only when `used_weekly >= curve`) and *fails open to 8 workers* when set to any `0`/rejected value. At 0% weekly usage nothing pauses it.
- **Stopping/masking the systemd timers doesn't hold.** `ensure_heartbeat_units` / `ensure_sweep_timer` recreate and re-enable the `dispatch-heartbeat` / `dispatch-sweep-periodic` units on the next tick — and a tick is fired by the durable `dispatch-claude-daemon`, by transient reseed timers (armed by running workers on each graph execute), or by a manual run. Any mask is `mv`-overwritten and re-enabled.

## Change

Add the pause where it actually gates scheduling: near the top of `dispatch-tick`, after flag parsing and *before* `dispatch-select-tick`, any spawn, and any reseed-arming.

When the flag file `${XDG_DATA_HOME:-$HOME/.local/share}/commons-dispatch/paused` exists, an **autonomous** tick exits immediately as a no-op: it schedules no workers and arms no reseed, so a firing heartbeat/reseed timer becomes a harmless no-op — no timer-fighting required. Already-running workers are separate sessions the tick never signals, so **in-flight work runs to completion untouched**. A manual `dispatch --manual` run **overrides** the pause (deliberate human action). Resume by removing the flag file.

This is the greenfield first-class pause the system was missing; it supersedes the fragile timer-mask approach entirely.

## Tests

- `tick_setup` now pins `DISPATCH_PAUSE_FLAG` to a non-existent path inside the test tree, so existing autonomous-tick tests never trip the guard from a real host flag at the default location.
- Two new tests: the paused no-op (exit 0, announces pause, no select-tick / no rate-limit refresh / no graph-execute / no spawn-job) and the `--manual` override (select-tick runs, not announced paused).

Verified via the dispatch-tick harness in isolation: 9/9 new assertions pass. (The full monolithic `test-dispatch-scripts.sh` has a pre-existing local early-exit ~18k lines earlier in `office-hours-select-target`'s gh-fail-injection test, unrelated to this change; that suite is authoritative in CI.)

## Operational note

To pause: `touch ~/.local/share/commons-dispatch/paused`. To resume: `rm` it. No systemd or config changes needed.