### PR TITLE
Guard the flake classifier's NONE path against stale-head false positives

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-flake-stale-head-check
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-flake-stale-head-check
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Stale-head guard for the flake classifier's NONE path.
+# Usage:
+#   dispatch-flake-stale-head-check --head-ref <sha> --reproduce-cmd <cmd>
+#
+# Prints exactly one line:
+#   CURRENT     — the failure is trustworthy as a new flake; the caller files it.
+#   STALE-HEAD  — the failure does not reproduce at origin/main; do NOT file.
+#                 The PR's remedy is to merge origin/main and re-run.
+#
+# WHY THIS EXISTS
+#   `dispatch-flake-dedup-node` already has a stale-head gate, but its header is
+#   explicit that it applies to ONE branch only:
+#
+#     "--head-ref is REQUIRED only when this branch is actually reached (a
+#      phase: done match found) ... OPEN/NONE never consult it."
+#
+#   So when NO node yet tracks a fingerprint (the NONE disposition), the caller
+#   files a fresh flake tactic with no staleness check at all. A CI failure that
+#   is fully deterministic on an out-of-date PR head — already fixed on
+#   origin/main — is therefore minted as a brand-new "flake" that nobody can
+#   reproduce.
+#
+#   This fired on 2026-07-22: a shadowed `case` arm in test-dispatch-scripts.sh's
+#   fake-git stub made a dispatch-select-tick guard-halt wiring test fail
+#   deterministically. The arm was unified on origin/main, but four PR heads
+#   predating the unification kept emitting the signature and produced TWO
+#   separate flake tactic nodes (filed 3 minutes apart), both later pruned as
+#   non-defects.
+#
+# WHY BEHAVIORAL, NOT ANCESTRY
+#   On NONE there is no prior node, hence no fix commit F to test ancestry
+#   against — `git merge-base --is-ancestor <fix> <head>`, the technique the
+#   done-branch gate uses, simply has no second operand here. The only decisive
+#   question is behavioral: does the failure still reproduce at current
+#   origin/main? So tier 2 below actually runs the reproduce command there.
+#
+# WHY A SEPARATE SCRIPT
+#   `dispatch-flake-dedup-node` is contractually "purely a search+decide+print
+#   tool", does "NO NETWORK", and never executes anything. Running a test suite
+#   inside it would break all three properties, so this lives alongside it
+#   instead of within it.
+#
+# FAIL LOUD
+#   Every error path exits non-zero WITHOUT printing a disposition. A guard that
+#   silently answered CURRENT on error would re-open the exact hole it closes
+#   (.claude/rules/code-style.md).
+set -euo pipefail
+
+head_ref=""
+reproduce_cmd=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --head-ref)
+      [[ $# -ge 2 ]] || { echo "error: dispatch-flake-stale-head-check: --head-ref requires a value" >&2; exit 2; }
+      head_ref="$2"; shift 2 ;;
+    --reproduce-cmd)
+      [[ $# -ge 2 ]] || { echo "error: dispatch-flake-stale-head-check: --reproduce-cmd requires a value" >&2; exit 2; }
+      reproduce_cmd="$2"; shift 2 ;;
+    *)
+      echo "error: dispatch-flake-stale-head-check: unexpected argument '$1'" >&2
+      echo "usage: dispatch-flake-stale-head-check --head-ref <sha> --reproduce-cmd <cmd>" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$head_ref" ]]; then
+  echo "error: dispatch-flake-stale-head-check: --head-ref <sha> is required" >&2
+  exit 2
+fi
+if [[ -z "$reproduce_cmd" ]]; then
+  echo "error: dispatch-flake-stale-head-check: --reproduce-cmd <cmd> is required" >&2
+  exit 2
+fi
+
+# Operate from the repo root so the throwaway worktree path and the reproduce
+# command's relative paths both resolve. A failure here is a misconfigured
+# environment — fail loud, do not fall back (.claude/rules/code-style.md).
+repo_root=$(git rev-parse --show-toplevel) || {
+  echo "error: dispatch-flake-stale-head-check: not inside a git repository" >&2
+  exit 2
+}
+cd "$repo_root"
+
+# The head ref must resolve — an unknown/typo'd SHA must not be silently treated
+# as "behind main" (which would suppress a real flake as STALE-HEAD).
+if ! git rev-parse --verify --quiet "${head_ref}^{commit}" >/dev/null; then
+  echo "error: dispatch-flake-stale-head-check: --head-ref '$head_ref' does not resolve to a commit" >&2
+  exit 2
+fi
+
+# origin/main is the comparison baseline for both tiers; it must be fetched.
+if ! git rev-parse --verify --quiet origin/main >/dev/null; then
+  echo "error: dispatch-flake-stale-head-check: origin/main is not available (fetch it first)" >&2
+  exit 2
+fi
+
+# --- Tier 1: cheap ancestry short-circuit -------------------------------------
+# If origin/main's tip is already contained in the head, the head is current:
+# whatever it is failing on cannot be explained by a fix it is missing. Trust the
+# failure and skip the (expensive) suite run entirely.
+# --is-ancestor exits 0/1 cleanly; any OTHER exit is a bad ref etc. — fail loud.
+if git merge-base --is-ancestor origin/main "$head_ref"; then
+  echo "CURRENT"
+  exit 0
+else
+  rc=$?
+  if [[ "$rc" -ne 1 ]]; then
+    echo "error: dispatch-flake-stale-head-check: git merge-base --is-ancestor failed (exit $rc) comparing origin/main against --head-ref '$head_ref'" >&2
+    exit 2
+  fi
+fi
+
+# --- Tier 2: behavioral check at origin/main ----------------------------------
+# The head is behind main, so the failure MIGHT be explained by a fix the head
+# lacks. Settle it by running the reproduce command against a clean checkout of
+# origin/main. A throwaway detached worktree keeps the caller's tree untouched.
+probe_dir=$(mktemp -d) || {
+  echo "error: dispatch-flake-stale-head-check: could not create a temp dir for the origin/main probe" >&2
+  exit 2
+}
+probe_tree="$probe_dir/main"
+
+cleanup() {
+  # Remove the registration first, then the directory: `git worktree remove`
+  # refuses a dirty tree (the reproduce command may have left artifacts), so
+  # --force is required for the removal to be reliable.
+  git -C "$repo_root" worktree remove --force "$probe_tree" >/dev/null 2>&1 || true
+  rm -rf "$probe_dir"
+}
+trap cleanup EXIT
+
+if ! git worktree add --detach "$probe_tree" origin/main >/dev/null 2>&1; then
+  echo "error: dispatch-flake-stale-head-check: could not create an origin/main probe worktree at '$probe_tree'" >&2
+  exit 2
+fi
+
+# Run the reproduce command at origin/main. Its stdout/stderr go to OUR stderr so
+# the disposition stays the only thing on stdout, and so a caller inspecting the
+# log can see what main actually did.
+probe_rc=0
+( cd "$probe_tree" && eval "$reproduce_cmd" ) >&2 2>&1 || probe_rc=$?
+
+# Distinguish "the command could not run at all" from "the command ran and
+# failed". 126 (not executable) and 127 (not found) mean the probe was never a
+# real test — treating that as "still fails at main" would wrongly answer
+# CURRENT, so fail loud instead.
+if [[ "$probe_rc" -eq 126 || "$probe_rc" -eq 127 ]]; then
+  echo "error: dispatch-flake-stale-head-check: reproduce command was not runnable at origin/main (exit $probe_rc): $reproduce_cmd" >&2
+  exit 2
+fi
+
+if [[ "$probe_rc" -eq 0 ]]; then
+  # Passes at main, fails on the head → the head is missing the fix.
+  echo "dispatch-flake-stale-head-check: '$reproduce_cmd' passes at origin/main but the head '$head_ref' is behind it — stale head, not a flake" >&2
+  echo "STALE-HEAD"
+  exit 0
+fi
+
+# Still fails at main → the head being behind does not explain it. Real signal.
+echo "CURRENT"
+exit 0

--- a/.claude/skills/dispatch-propagate/scripts/test-flake-stale-head-check.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-flake-stale-head-check.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# test-flake-stale-head-check.sh — tests for dispatch-flake-stale-head-check,
+# the stale-head guard on the flake classifier's NONE path
+# (tactic-flake-classifier-stale-head-guard).
+#
+# The guard answers one question: is a CI failure trustworthy as a NEW flake, or
+# is it a deterministic failure on a PR head that is merely missing a fix already
+# on origin/main? Two tiers:
+#   Tier 1 — origin/main's tip is already an ancestor of the head → CURRENT,
+#            with NO suite run (the expensive path is skipped).
+#   Tier 2 — head is behind main → actually run the reproduce command against a
+#            throwaway origin/main worktree. Passes there → STALE-HEAD.
+#            Still fails there → CURRENT.
+#
+# Every case runs against a REAL scratch git repo (not a PATH-shimmed git), so
+# the ancestry math and the throwaway-worktree lifecycle are exercised for real
+# rather than mocked.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+
+GUARD="$SCRIPT_DIR/dispatch-flake-stale-head-check"
+
+WORK=""
+REPO=""
+
+# Build a scratch repo shaped like the real situation:
+#
+#   A ── B(fix) ── C      <- origin/main
+#    \
+#     └── S               <- the "stale head": branched from A, missing B
+#
+# `probe.sh` is the reproduce command's target: it exits 1 at A/S (bug present)
+# and exits 0 from B onward (fixed). marker.txt records each probe invocation so
+# a test can assert whether tier 2 ran at all.
+setup_repo() {
+  WORK="$(mktemp -d)"
+  REPO="$WORK/repo"
+  mkdir -p "$REPO"
+  git -C "$REPO" init --quiet -b main
+  git -C "$REPO" config user.email "test@example.com"
+  git -C "$REPO" config user.name "Test"
+
+  # A — buggy
+  cat > "$REPO/probe.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "probe ran" >> "${PROBE_MARKER:-/dev/null}"
+exit 1
+EOF
+  chmod +x "$REPO/probe.sh"
+  git -C "$REPO" add probe.sh
+  git -C "$REPO" commit --quiet -m "A: buggy"
+  A=$(git -C "$REPO" rev-parse HEAD)
+
+  # S — the stale head, branched from A (never gets the fix)
+  git -C "$REPO" checkout --quiet -b stale "$A"
+  echo "unrelated head-only change" > "$REPO/head-only.txt"
+  git -C "$REPO" add head-only.txt
+  git -C "$REPO" commit --quiet -m "S: unrelated work on the PR branch"
+  STALE_HEAD=$(git -C "$REPO" rev-parse HEAD)
+
+  # B — the fix; C — a later unrelated commit
+  git -C "$REPO" checkout --quiet main
+  cat > "$REPO/probe.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "probe ran" >> "${PROBE_MARKER:-/dev/null}"
+exit 0
+EOF
+  chmod +x "$REPO/probe.sh"
+  git -C "$REPO" add probe.sh
+  git -C "$REPO" commit --quiet -m "B: fix"
+  git -C "$REPO" commit --quiet --allow-empty -m "C: later commit"
+  MAIN_TIP=$(git -C "$REPO" rev-parse HEAD)
+
+  # A head that HAS main's tip merged in (the up-to-date case).
+  git -C "$REPO" checkout --quiet -b current "$MAIN_TIP"
+  git -C "$REPO" commit --quiet --allow-empty -m "D: work on top of current main"
+  CURRENT_HEAD=$(git -C "$REPO" rev-parse HEAD)
+
+  git -C "$REPO" checkout --quiet main
+
+  # The guard resolves origin/main, so give the repo a self-referential remote
+  # ref rather than a second clone — same ref name, no network.
+  git -C "$REPO" update-ref refs/remotes/origin/main "$MAIN_TIP"
+
+  export PROBE_MARKER="$WORK/probe-marker.txt"
+  : > "$PROBE_MARKER"
+}
+
+teardown_repo() {
+  [[ -n "$WORK" ]] && rm -rf "$WORK"
+  WORK=""; REPO=""
+  unset PROBE_MARKER
+}
+
+# Count probe invocations. NOTE `grep -c` prints the count AND exits 1 when the
+# count is zero, so the `|| true` is what keeps an empty marker printing exactly
+# one "0" rather than falling through to a second echo.
+probe_runs() {
+  if [[ -f "$PROBE_MARKER" ]]; then
+    grep -c . "$PROBE_MARKER" || true
+  else
+    echo 0
+  fi
+}
+
+echo "=== dispatch-flake-stale-head-check ==="
+
+# --- Tier 1: head already contains main's tip → CURRENT, no suite run --------
+echo "Test: head contains origin/main tip → CURRENT without running the probe"
+setup_repo
+out=$(cd "$REPO" && "$GUARD" --head-ref "$CURRENT_HEAD" --reproduce-cmd "./probe.sh" 2>/dev/null)
+assert_eq "tier1: disposition CURRENT" "CURRENT" "$out"
+assert_eq "tier1: probe NOT run (expensive path skipped)" "0" "$(probe_runs)"
+teardown_repo
+
+# --- Tier 2: behind main + probe passes at main → STALE-HEAD -----------------
+# This is the 2026-07-22 incident's exact shape: the head fails, main is fixed.
+echo "Test: head behind main and probe passes at origin/main → STALE-HEAD"
+setup_repo
+out=$(cd "$REPO" && "$GUARD" --head-ref "$STALE_HEAD" --reproduce-cmd "./probe.sh" 2>/dev/null)
+assert_eq "tier2 stale: disposition STALE-HEAD" "STALE-HEAD" "$out"
+assert_eq "tier2 stale: probe ran at origin/main" "1" "$(probe_runs)"
+teardown_repo
+
+# --- Tier 2: behind main but probe STILL fails at main → CURRENT -------------
+# Being behind main does not by itself excuse a failure: if main is red too, the
+# signal is real and must still be filed.
+echo "Test: head behind main but probe still fails at origin/main → CURRENT"
+setup_repo
+# Land the bug on main as well, so the probe fails at origin/main too.
+git -C "$REPO" checkout --quiet main
+cat > "$REPO/probe.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "probe ran" >> "${PROBE_MARKER:-/dev/null}"
+exit 1
+EOF
+chmod +x "$REPO/probe.sh"
+git -C "$REPO" add probe.sh
+git -C "$REPO" commit --quiet -m "E: main is red too"
+git -C "$REPO" update-ref refs/remotes/origin/main "$(git -C "$REPO" rev-parse HEAD)"
+out=$(cd "$REPO" && "$GUARD" --head-ref "$STALE_HEAD" --reproduce-cmd "./probe.sh" 2>/dev/null)
+assert_eq "tier2 red-main: disposition CURRENT" "CURRENT" "$out"
+assert_eq "tier2 red-main: probe ran at origin/main" "1" "$(probe_runs)"
+teardown_repo
+
+# --- Throwaway worktree is cleaned up on BOTH paths --------------------------
+echo "Test: origin/main probe worktree is removed after the run"
+setup_repo
+(cd "$REPO" && "$GUARD" --head-ref "$STALE_HEAD" --reproduce-cmd "./probe.sh" >/dev/null 2>&1)
+assert_eq "cleanup: no probe worktree left registered" "1" \
+  "$(git -C "$REPO" worktree list | grep -c .)"
+teardown_repo
+
+# A probe that leaves the tree DIRTY must still be removable (the cleanup uses
+# --force precisely for this).
+echo "Test: probe worktree removed even when the probe dirties the tree"
+setup_repo
+(cd "$REPO" && "$GUARD" --head-ref "$STALE_HEAD" \
+  --reproduce-cmd "echo dirt > probe.sh; ./probe.sh" >/dev/null 2>&1) || true
+assert_eq "cleanup dirty: no probe worktree left registered" "1" \
+  "$(git -C "$REPO" worktree list | grep -c .)"
+teardown_repo
+
+# --- Fail-loud argument handling ---------------------------------------------
+# Each of these must exit non-zero and print NO disposition: silently answering
+# CURRENT on a broken invocation would re-open the hole this guard closes.
+echo "Test: missing --head-ref → exit 2, no disposition"
+setup_repo
+rc=0; out=$(cd "$REPO" && "$GUARD" --reproduce-cmd "./probe.sh" 2>/dev/null) || rc=$?
+assert_eq "missing head-ref: exit 2" "2" "$rc"
+assert_eq "missing head-ref: no disposition on stdout" "" "$out"
+teardown_repo
+
+echo "Test: missing --reproduce-cmd → exit 2, no disposition"
+setup_repo
+rc=0; out=$(cd "$REPO" && "$GUARD" --head-ref "$STALE_HEAD" 2>/dev/null) || rc=$?
+assert_eq "missing reproduce-cmd: exit 2" "2" "$rc"
+assert_eq "missing reproduce-cmd: no disposition on stdout" "" "$out"
+teardown_repo
+
+echo "Test: unresolvable --head-ref → exit 2, no disposition"
+setup_repo
+rc=0; out=$(cd "$REPO" && "$GUARD" --head-ref "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" \
+  --reproduce-cmd "./probe.sh" 2>/dev/null) || rc=$?
+assert_eq "bad head-ref: exit 2" "2" "$rc"
+assert_eq "bad head-ref: no disposition on stdout" "" "$out"
+teardown_repo
+
+echo "Test: unknown flag → exit 2, no disposition"
+setup_repo
+rc=0; out=$(cd "$REPO" && "$GUARD" --head-ref "$STALE_HEAD" --nope x 2>/dev/null) || rc=$?
+assert_eq "unknown flag: exit 2" "2" "$rc"
+assert_eq "unknown flag: no disposition on stdout" "" "$out"
+teardown_repo
+
+# A reproduce command that cannot run at all is NOT evidence that main is red —
+# treating exit 127 as "still fails at main" would wrongly answer CURRENT.
+echo "Test: unrunnable reproduce command → exit 2, no disposition"
+setup_repo
+rc=0; out=$(cd "$REPO" && "$GUARD" --head-ref "$STALE_HEAD" \
+  --reproduce-cmd "definitely-not-a-real-command-xyz" 2>/dev/null) || rc=$?
+assert_eq "unrunnable probe: exit 2" "2" "$rc"
+assert_eq "unrunnable probe: no disposition on stdout" "" "$out"
+teardown_repo
+
+report_results

--- a/.claude/skills/fix-checks/SKILL.md
+++ b/.claude/skills/fix-checks/SKILL.md
@@ -426,7 +426,29 @@ Escalation writes `$CLAUDE_JOB_DIR/office-hours-reason` (+
            `REOPENED <tactic-id>`, or `STALE <tactic-id>`. Parse it into a
            disposition and (when present) the tactic id.
         4. Branch on the disposition:
-           - **`NONE`** — no matching flake tactic exists. Write a **new** flake
+           - **`NONE`** — no matching flake tactic exists. **Before filing
+             anything, run the stale-head guard.** `dispatch-flake-dedup-node`'s
+             own stale-head gate covers the `phase: done` branch ONLY — its
+             header states "OPEN/NONE never consult it" — so without this step a
+             failure that is deterministic on a head merely missing a fix already
+             on `origin/main` gets minted as a brand-new unreproducible flake
+             (the 2026-07-22 incident that produced two such nodes, both pruned):
+             ```bash
+             STALE=$(.claude/skills/dispatch-propagate/scripts/dispatch-flake-stale-head-check \
+               --head-ref "$HEAD_SHA" --reproduce-cmd "<reproduce command>")
+             ```
+             It prints `CURRENT` or `STALE-HEAD`, and exits non-zero **without**
+             a disposition on any error — treat a non-zero exit as a hard stop,
+             never as `CURRENT`.
+             - **`STALE-HEAD`** — the failure does not reproduce at
+               `origin/main`. Do **not** write a flake node and do not block the
+               PR on one. Record the outcome as `STALE-HEAD-SUPPRESSED` (see the
+               accumulator's flake-tracking-id bullet) and note in the accumulator
+               that the remedy is to merge `origin/main` into the PR branch and
+               re-run CI — the head is simply missing a fix that already landed.
+             - **`CURRENT`** — proceed with the node write below, unchanged.
+
+             On `CURRENT`, write a **new** flake
              tactic node. Construct its frontmatter JSON and pass it to
              `write-node.ts` (same recipe as `align-tactics/SKILL.md`'s
              "Step 5 — Record"; `dangerouslyDisableSandbox: true`, and use an
@@ -675,6 +697,11 @@ Escalation writes `$CLAUDE_JOB_DIR/office-hours-reason` (+
     `dispatch-flake-dedup-node` disposition — parallel to the legacy form, just
     a tactic id instead of an issue number. `STALE-SUPPRESSED` marks a
     recurrence suppressed as a stale-head false positive — no reopen was fired.
+    A sixth value, bare `STALE-HEAD-SUPPRESSED` with no tactic id, marks the
+    `NONE`-path counterpart: `dispatch-flake-stale-head-check` found the failure
+    does not reproduce at `origin/main`, so **no node was created at all** and
+    there is no id to name. Record alongside it that the remedy is to merge
+    `origin/main` and re-run.
     Omit for every other outcome.
   - **Fingerprint** — *`flake` outcome only* — the dedupe key computed in the
     Flake sub-path (the failing check name plus the stable identifier). Omit for

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -201,6 +201,8 @@ jobs:
         run: .claude/skills/budget/scripts/test-budget-config-load.sh
       - name: Run write-phase-log tests
         run: .claude/skills/dispatch-propagate/scripts/test-write-phase-log.sh
+      - name: Run flake stale-head guard tests
+        run: .claude/skills/dispatch-propagate/scripts/test-flake-stale-head-check.sh
       - name: Run stable-propagation gate tests
         run: .claude/skills/dispatch-propagate/scripts/test-run-smoke-tests.sh
       - name: Run prose-rule lint tests


### PR DESCRIPTION
## Context

`dispatch-flake-dedup-node` already has a stale-head gate, but its own header is
explicit that it applies to one branch only:

> `--head-ref` is REQUIRED only when this branch is actually reached (a
> `phase: done` match found) ... **OPEN/NONE never consult it.**

So on the `NONE` disposition — no node yet tracks this fingerprint — the caller
files a fresh flake tactic with **no staleness check at all**. A CI failure that
is fully deterministic on a PR head merely missing a fix already on
`origin/main` gets minted as a brand-new "flake" nobody can reproduce.

That fired on 2026-07-22. A shadowed `case` arm in `test-dispatch-scripts.sh`'s
fake-git stub made a `dispatch-select-tick` guard-halt wiring test fail
deterministically: the first arm matched every `-C <path> symbolic-ref --short
HEAD` call and returned `main`, so the guard never fired. The arms were later
unified on main, but four PR heads predating the unification kept emitting the
signature and produced **two** separate flake tactic nodes, filed 3 minutes
apart. Both have since been pruned as non-defects.

## Why behavioral rather than ancestry

On `NONE` there is no prior node, hence no fix commit `F` to test ancestry
against — `git merge-base --is-ancestor`, the technique the done-branch gate
uses, has no second operand here. The only decisive question is whether the
failure still reproduces at current `origin/main`.

## What this adds

- **`dispatch-flake-stale-head-check`** — prints `CURRENT` or `STALE-HEAD`.
  Tier 1: if `origin/main`'s tip is already an ancestor of the head, answer
  `CURRENT` with no suite run. Tier 2: otherwise run the reproduce command in a
  throwaway detached `origin/main` worktree; passes there → `STALE-HEAD`, still
  fails → `CURRENT`. Every error path exits non-zero **without** printing a
  disposition — silently answering `CURRENT` on error would re-open the hole
  this closes.
- **`test-flake-stale-head-check.sh`** — 18 assertions against a real scratch
  git repo (not a PATH-shimmed git), so the ancestry math and throwaway-worktree
  lifecycle run for real. Covers both tiers, cleanup on the dirty-tree path, and
  every fail-loud argument case. Added as an explicit `hook-tests` step;
  `run-unit-tests.sh` already globs `test-*.sh` so `unit-tests` picks it up too.
- **`fix-checks/SKILL.md`** — runs the guard on `NONE` before any node write,
  with a `STALE-HEAD-SUPPRESSED` accumulator outcome recording that the remedy
  is to merge `origin/main` and re-run.

Kept as a sibling script rather than folded into `dispatch-flake-dedup-node`,
whose contract is "purely a search+decide+print tool" that does "NO NETWORK" and
never executes anything — running a suite inside it would break all three.

## Verification

Both plan `verify` blocks pass: 18/18 guard tests, and the prose-rule lint.

The real acceptance check is replaying the incident. Against the actual suite,
the failing heads `78fbbedd` and `9f01d16b` each classify `STALE-HEAD` — the
guard would have blocked both nodes that were filed.

**Correction to the plan as written:** the node's Verification section also
claimed the green heads `2d4a2ac3` / `dc387443` must classify `CURRENT`. That
criterion is meaningless — those heads *passed* CI, so the flake classifier is
never invoked on them and the guard is never asked. The meaningful `CURRENT`
cases are tier-1 (head contains main's tip) and tier-2-with-red-main, both
covered by unit tests. I am correcting the node body separately.

## Known residual, deliberately out of scope

The two pruned nodes carried *different* fingerprints for the identical failure
(one keyed on `file:line`, one on the test name), so fingerprint dedup never had
a chance to collapse them. This guard blocks both regardless, which is why
fingerprint stability is left as a smaller follow-up rather than a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
