### PR TITLE
Fail loud in deletedNodeIds when the clone is shallow

### DIFF
--- a/packages/intentionsutil/scripts/lib-deleted-node-ids.ts
+++ b/packages/intentionsutil/scripts/lib-deleted-node-ids.ts
@@ -30,10 +30,41 @@ const repoRoot = dirname(dirname(dirname(scriptDir)));
  * instead of `pruned`. It also makes the result independent of git's
  * similarity heuristic, matching the module's determinism guarantee.
  */
-export function deletedNodeIds(): string[] {
+export function deletedNodeIds(repoRootOverride?: string): string[] {
+  // `repoRootOverride` exists so the shallow guard below can be exercised
+  // against a scratch clone; production callers pass nothing and get the
+  // module-resolved repo root exactly as before.
+  const root = repoRootOverride ?? repoRoot;
+
+  // A SHALLOW clone silently defeats this helper's whole contract. `git log`
+  // still succeeds and still exits 0 — it just cannot see past the graft point,
+  // so every node pruned before the cutoff is missing from the result. Callers
+  // then classify live prose references to those nodes as `missing`, and
+  // validate-graph reports a detailed, plausible, entirely fabricated list of
+  // violations naming real nodes. That is strictly worse than an error: the
+  // natural reading is "main is broken" rather than "my clone is truncated".
+  //
+  // Observed 2026-07-23: a clone grafted at 2026-07-18 returned 37 ids instead
+  // of 240, producing 15 false prose-reference violations for a tree CI
+  // validated clean at the same commit.
+  //
+  // There is no partial-credit answer here — a truncated deletion set cannot be
+  // distinguished from a complete one by inspection — so fail loud rather than
+  // proceeding with it (.claude/rules/code-style.md).
+  const shallow = execFileSync("git", ["-C", root, "rev-parse", "--is-shallow-repository"], {
+    encoding: "utf8",
+  }).trim();
+  if (shallow === "true") {
+    throw new Error(
+      `deletedNodeIds: the repository at ${root} is a SHALLOW clone, so its deletion ` +
+        `history is truncated. Every node pruned before the graft point would be reported as ` +
+        `an unresolved prose reference. Run \`git fetch --unshallow\` and retry.`,
+    );
+  }
+
   const out = execFileSync(
     "git",
-    ["-C", repoRoot, "log", "--diff-filter=D", "--no-renames", "--name-only", "--pretty=format:", "--", "intentions/"],
+    ["-C", root, "log", "--diff-filter=D", "--no-renames", "--name-only", "--pretty=format:", "--", "intentions/"],
     { encoding: "utf8" },
   );
   const ids = new Set<string>();

--- a/packages/intentionsutil/test/deleted-node-ids.test.ts
+++ b/packages/intentionsutil/test/deleted-node-ids.test.ts
@@ -1,0 +1,109 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { deletedNodeIds } from "../scripts/lib-deleted-node-ids.js";
+
+// Tracks scratch dirs so each test cleans up after itself.
+const scratch: string[] = [];
+
+afterEach(() => {
+  while (scratch.length > 0) {
+    const dir = scratch.pop();
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+}
+
+/**
+ * Build an origin repo whose history contains a node ADD followed by a node
+ * DELETE, plus enough later commits that a `--depth 1` clone cannot see the
+ * delete. That gap is precisely the failure this guard exists to catch.
+ */
+function makeOrigin(): string {
+  const dir = mkdtempSync(join(tmpdir(), "deleted-ids-origin-"));
+  scratch.push(dir);
+
+  git(dir, "init", "--quiet", "-b", "main");
+  git(dir, "config", "user.email", "test@example.com");
+  git(dir, "config", "user.name", "Test");
+  mkdirSync(join(dir, "intentions"));
+
+  writeFileSync(join(dir, "intentions", "tactic-gone.md"), "# gone\n");
+  writeFileSync(join(dir, "intentions", "tactic-kept.md"), "# kept\n");
+  git(dir, "add", "-A");
+  git(dir, "commit", "--quiet", "-m", "add two nodes");
+
+  rmSync(join(dir, "intentions", "tactic-gone.md"));
+  git(dir, "add", "-A");
+  git(dir, "commit", "--quiet", "-m", "prune tactic-gone");
+
+  // Later commits so the shallow clone's graft point sits AFTER the delete.
+  for (const n of [1, 2, 3]) {
+    writeFileSync(join(dir, "intentions", `tactic-later-${n}.md`), `# later ${n}\n`);
+    git(dir, "add", "-A");
+    git(dir, "commit", "--quiet", "-m", `later ${n}`);
+  }
+  return dir;
+}
+
+function cloneFull(origin: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "deleted-ids-full-"));
+  scratch.push(dir);
+  const dest = join(dir, "repo");
+  execFileSync("git", ["clone", "--quiet", `file://${origin}`, dest], { encoding: "utf8" });
+  return dest;
+}
+
+function cloneShallow(origin: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "deleted-ids-shallow-"));
+  scratch.push(dir);
+  const dest = join(dir, "repo");
+  execFileSync("git", ["clone", "--quiet", "--depth", "1", `file://${origin}`, dest], {
+    encoding: "utf8",
+  });
+  return dest;
+}
+
+describe("deletedNodeIds shallow-clone guard", () => {
+  it("returns the deleted ids on a full clone", () => {
+    const repo = cloneFull(makeOrigin());
+    expect(git(repo, "rev-parse", "--is-shallow-repository").trim()).toBe("false");
+    expect(deletedNodeIds(repo)).toEqual(["tactic-gone"]);
+  });
+
+  it("throws on a shallow clone instead of returning a truncated set", () => {
+    const repo = cloneShallow(makeOrigin());
+    expect(git(repo, "rev-parse", "--is-shallow-repository").trim()).toBe("true");
+    expect(() => deletedNodeIds(repo)).toThrow(/SHALLOW/);
+  });
+
+  it("names the remedy in the error, so the caller knows how to fix it", () => {
+    const repo = cloneShallow(makeOrigin());
+    expect(() => deletedNodeIds(repo)).toThrow(/--unshallow/);
+  });
+
+  // The regression this guard was written for: without it, the shallow clone
+  // silently returns [] here rather than ["tactic-gone"], and every prose
+  // reference to tactic-gone is then reported as an unresolved violation. Pin
+  // that the shallow repo genuinely cannot see the delete, so the test would
+  // still be meaningful if the guard were ever removed.
+  it("the shallow clone genuinely cannot see the delete (guard is load-bearing)", () => {
+    const repo = cloneShallow(makeOrigin());
+    const log = git(
+      repo,
+      "log",
+      "--diff-filter=D",
+      "--no-renames",
+      "--name-only",
+      "--pretty=format:",
+      "--",
+      "intentions/",
+    );
+    expect(log).not.toContain("tactic-gone");
+  });
+});


### PR DESCRIPTION
## Context

`deletedNodeIds()` shells out to `git log --diff-filter=D ... -- intentions/` to
find nodes whose file was deleted. `validate-graph.ts` uses that set to classify
a prose id-reference as `pruned` (fine) rather than `missing` (a violation).

A **shallow clone** defeats this silently. `git log` still succeeds and still
exits 0 — it just cannot see past the graft point, so every node pruned before
the cutoff drops out of the set, and every live prose reference to one is
reported as an unresolved violation.

The helper's own doc comment already promised the opposite behavior:

> a git failure surfaces as a clear error rather than a silent empty list
> (see .claude/rules/code-style.md)

A shallow clone is not a git *failure*, so nothing caught it.

## The incident

On 2026-07-23 a clone grafted at 2026-07-18 returned **37** deleted ids instead
of **240**, producing **15** prose-reference violations across unrelated tactics
— for a tree that CI validated clean at the same commit (`ok — prose refs: 0
unresolved`). `git fetch --unshallow` took the count to 240 and the violations
to 0.

The failure mode is worse than a plain false negative because it is *plausible*:
the violations name real nodes and real referencing tactics, so the natural
reading is "main is broken" rather than "my clone is truncated". I reported main
as red on the strength of it before spotting the shallow flag.

## What this does

Detects `git rev-parse --is-shallow-repository` before the `git log` and throws,
naming both the cause and the remedy (`git fetch --unshallow`). A truncated
deletion set cannot be distinguished from a complete one by inspection, so there
is no partial-credit answer — fail loud rather than proceed
(`.claude/rules/code-style.md`).

`deletedNodeIds` gains an optional `repoRootOverride` purely so the guard is
testable against a scratch clone; production callers pass nothing and behave
exactly as before. This is a small addition beyond the node's stated Unit 1
scope, taken because the guard was otherwise untestable — the repo root was
resolved from the module's own file location and could not be redirected.

## Tests

Four cases in `packages/intentionsutil/test/deleted-node-ids.test.ts`, against
real scratch clones of a purpose-built origin repo (add node → delete node →
later commits, so a `--depth 1` clone's graft point sits after the delete):

- full clone returns the deleted id
- shallow clone throws rather than returning a truncated set
- the error names `--unshallow`, so the caller knows the fix
- the shallow clone genuinely cannot see the delete — pins that the guard is
  load-bearing, so the suite stays meaningful if the guard is ever removed

Full `packages/intentionsutil` suite: 607/607 pass. `validate-graph` verify
block: `ok — 415 nodes`, `0 unresolved`.

## Not done here

The 15 observed violations were never real, so they are deliberately **not**
added to `prose-ref-baseline.json` — baselining them would permanently blind the
check to 15 genuine future regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
