### PR TITLE
wezterm: refresh windowsZipHash for unchanged build 20260716-195552-76b606ec

### DIFF
--- a/nix/home/wezterm-pin.nix
+++ b/nix/home/wezterm-pin.nix
@@ -39,5 +39,5 @@
   # reports a mismatch, first confirm the live zip still unpacks to
   # WezTerm-windows-${version}; if it does, only this hash needs refreshing and
   # the other four fields must be left alone.
-  windowsZipHash = "sha256-QiVmQOEZToNMDnFfVLujiHPl4MrKYXyoLtvCfqzv5X8=";
+  windowsZipHash = "sha256-bTvVHVpB8Mh6g2lF2RB9Egs2IApanVb5Z1R2M9UCZZ8=";
 }


### PR DESCRIPTION
Holding action for the stale WezTerm Windows zip hash.

## What moved

Upstream re-uploaded `WezTerm-windows-nightly.zip` at `2026-07-23T04:50:10Z`.
The zip still unpacks to `WezTerm-windows-20260716-195552-76b606ec` — the same
build `nix/home/wezterm-pin.nix` already names — so only the byte hash changed.
Per that file's own header comment, `version`/`rev`/`srcHash`/`cargoHash` are
left untouched.

```
old  sha256-QiVmQOEZToNMDnFfVLujiHPl4MrKYXyoLtvCfqzv5X8=
new  sha256-bTvVHVpB8Mh6g2lF2RB9Egs2IApanVb5Z1R2M9UCZZ8=
```

## Verification

- `nix-prefetch-url` on the live URL yields exactly the new hash.
- The zip's single top-level directory is `WezTerm-windows-20260716-195552-76b606ec`,
  so build identity is unchanged and the GUI/mux PDU invariant still holds.
- The `fetchurl` fixed-output derivation builds clean against the new hash
  (`/nix/store/48a41mahfbvafmmjhbixfmhr3mwqjwvc-WezTerm-windows-nightly.zip`).

## This is a stopgap, and it will go stale again

`fetchurl`'s `sha256` pins **byte** identity. The actual requirement is **build**
identity — the Windows GUI and the WSL `wezterm-mux-server` must be the same
wezterm build or the mux PDU handshake fails and the GUI window closes on
connect. Upstream overwrites this one asset in place and does not maintain byte
stability across repackages of an unchanged build.

So the mechanism pins a stronger property than the requirement needs, and one
upstream does not offer. Consequence: **every repackage is a false failure.**
Two repackages of this single build in eight days; the previous refresh held for
under 24 hours. No refresh cadence reachable through the PR cycle can keep a
byte pin valid against a mutable URL.

The durable fix is recorded at `intentions/tactic-wezterm-owned-asset-mirror.md`
— have `nix/home/sync-wezterm.sh` fetch once, assert the unpacked directory
equals `WezTerm-windows-${version}`, republish those exact bytes to an asset we
own and never overwrite, and pin the mirror. The general invariant landed as a
clarification on `strategy-distribute-workflow`: a content-hash pin is sound
only against a reference the publisher cannot overwrite.

Merging this unblocks `nixos-build` on nix-touching branches today; it does not
retire the underlying defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)