### PR TITLE
typecheck: stop branch-new files poisoning the origin/main baseline

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/run-typecheck.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-typecheck.sh
@@ -94,6 +94,13 @@ git -C "$REPO_ROOT" fetch origin main --quiet 2>/dev/null || \
 ensure_deps
 
 REGRESSIONS=()
+# Skips are tracked by class: a tsconfig-less workspace has nothing to check and
+# is benign, whereas a baseline-failure skip means we verified nothing about a
+# workspace we were asked to verify. Reporting at the bottom depends on the
+# distinction, so the two are never merged into one counter.
+SKIPPED_NO_TSCONFIG=()
+SKIPPED_BASELINE=()
+CHECKED=0
 
 for ws in "${APP_DIRS[@]}"; do
   echo "=== Typecheck: $ws ==="
@@ -106,6 +113,7 @@ for ws in "${APP_DIRS[@]}"; do
   # misreported as a pre-existing typecheck failure.
   if [ ! -f "$REPO_ROOT/$ws/tsconfig.json" ]; then
     echo "$ws: no tsconfig.json — skipping (non-TS workspace)"
+    SKIPPED_NO_TSCONFIG+=("$ws")
     continue
   fi
 
@@ -113,6 +121,24 @@ for ws in "${APP_DIRS[@]}"; do
   if git -C "$REPO_ROOT" rev-parse --verify "origin/main:$ws" >/dev/null 2>&1; then
     TOUCHED_WORKSPACES+=("$ws")
     git -C "$REPO_ROOT" checkout origin/main -- "$ws"
+
+    # `checkout origin/main -- "$ws"` reverts every file origin/main HAS, but it
+    # cannot delete a file origin/main does NOT have. So without this step every
+    # branch-new file stays on disk at HEAD content while the code it depends on
+    # reverts to origin/main — and the baseline compile fails on the branch's own
+    # new code. That failure was then reported as "origin/main has pre-existing
+    # typecheck errors" and the workspace skipped, meaning ANY PR that adds a
+    # file to a workspace silently disabled typechecking for that whole
+    # workspace. Remove those files so the baseline is really origin/main; the
+    # reset->checkout->clean restore below brings them back, since they are
+    # tracked at HEAD. `--no-renames` matters: with rename detection on, a file
+    # moved within the workspace is reported as R rather than A, so its new path
+    # would survive the probe and poison the baseline exactly as before.
+    while IFS= read -r added_file; do
+      [ -z "$added_file" ] && continue
+      rm -f "$REPO_ROOT/$added_file"
+    done < <(git -C "$REPO_ROOT" diff --name-only --no-renames --diff-filter=A origin/main HEAD -- "$ws")
+
     baseline_ok=true
     (cd "$REPO_ROOT" && npx tsc --noEmit --project "$ws") >/dev/null 2>&1 || baseline_ok=false
     # Restore HEAD version immediately; don't wait for the trap.
@@ -129,7 +155,8 @@ for ws in "${APP_DIRS[@]}"; do
     git -C "$REPO_ROOT" clean -fdq -- "$ws"
 
     if [ "$baseline_ok" = false ]; then
-      echo "$ws: skipping — origin/main has pre-existing typecheck errors"
+      echo "$ws: skipping — origin/main has pre-existing typecheck errors" >&2
+      SKIPPED_BASELINE+=("$ws")
       continue
     fi
   else
@@ -137,6 +164,7 @@ for ws in "${APP_DIRS[@]}"; do
     pass_suffix=" (new workspace)"
   fi
 
+  CHECKED=$((CHECKED + 1))
   if (cd "$REPO_ROOT" && npx tsc --noEmit --project "$ws"); then
     echo "$ws: typecheck passed$pass_suffix"
   else
@@ -152,4 +180,22 @@ if [ ${#REGRESSIONS[@]} -gt 0 ]; then
   exit 1
 fi
 
-echo "All typecheck targets passed."
+# A baseline-failure skip means this run verified nothing about a workspace it
+# was asked to verify, so it is always reported — never folded into a pass line.
+if [ ${#SKIPPED_BASELINE[@]} -gt 0 ]; then
+  echo "" >&2
+  echo "WARNING: NOT typechecked (origin/main baseline fails): ${SKIPPED_BASELINE[*]}" >&2
+fi
+
+# Nothing was actually typechecked. This exits 0 on purpose: a baseline skip now
+# means origin/main is genuinely broken, and a PR author is not responsible for
+# that (the contract is pinned by test-run-typecheck.sh "Test 3: dirty baseline
+# + dirty HEAD -> skipped", which asserts exit 0). What must not happen is
+# claiming a pass — so say plainly that nothing was verified.
+if [ "$CHECKED" -eq 0 ]; then
+  echo "No workspace was typechecked: ${#SKIPPED_NO_TSCONFIG[@]} non-TS, ${#SKIPPED_BASELINE[@]} baseline-skipped."
+  echo "This run verified nothing — it is not a pass."
+  exit 0
+fi
+
+echo "All typecheck targets passed ($CHECKED checked, $(( ${#SKIPPED_NO_TSCONFIG[@]} + ${#SKIPPED_BASELINE[@]} )) skipped)."

--- a/.claude/skills/dispatch-propagate/scripts/test-run-typecheck.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-run-typecheck.sh
@@ -233,4 +233,32 @@ assert_eq "deletion: working tree clean after run (nothing resurrected/staged)" 
 [ ! -f "$REPO/ws/src/extra.ts" ] && _t6_extra=absent || _t6_extra=present
 assert_eq "deletion: deleted file not left on disk" "absent" "$_t6_extra"
 
+# --- Test 7: addition branch — HEAD adds a file origin/main does not have -----
+# Mirror image of Test 6. `git checkout origin/main -- <ws>` reverts the files
+# origin/main has but cannot delete one it lacks, so a branch-new file used to
+# survive into the baseline probe at HEAD content while everything it depends on
+# reverted. The baseline then failed on the branch's own new code and the whole
+# workspace was skipped as "pre-existing errors" — so ANY branch that added a
+# file silently disabled typechecking for that workspace, and a real error in it
+# was reported as a pass. Here the added file is the one carrying the error: it
+# must surface as a regression, not a skip.
+echo "Test 7: addition branch -> error in a branch-new file is detected, not skipped"
+make_repo ws clean clean
+write_state dirty "$REPO/ws/src/added.ts"
+git -C "$REPO" add -A
+git -C "$REPO" commit --quiet -m "head (add added.ts carrying the error)"
+make_shims "$REPO"
+run_sut
+[ "$RC" -ne 0 ] && _t7_rc=nonzero || _t7_rc=zero
+assert_eq "addition: exit non-zero" "nonzero" "$_t7_rc"
+assert_contains "addition: reported as a regression" "Typecheck regressions" "$OUT"
+case "$OUT" in
+  *pre-existing*) _t7_skip=skipped ;;
+  *) _t7_skip=not-skipped ;;
+esac
+assert_eq "addition: baseline not poisoned by the added file" "not-skipped" "$_t7_skip"
+assert_eq "addition: working tree clean after run" "" "$(git -C "$REPO" status --porcelain)"
+[ -f "$REPO/ws/src/added.ts" ] && _t7_added=present || _t7_added=absent
+assert_eq "addition: added file restored after baseline probe" "present" "$_t7_added"
+
 report_results


### PR DESCRIPTION
## Problem

`run-typecheck.sh` builds its baseline by swapping a workspace to origin/main
with `git checkout origin/main -- <ws>`. That reverts every file origin/main
*has* — but it cannot delete a file origin/main *lacks*.

So every **branch-new** file survived into the baseline probe at HEAD content
while the code it depends on reverted to origin/main. The baseline compile then
failed on the branch's own new code, and the script reported that as:

```
<ws>: skipping — origin/main has pre-existing typecheck errors
```

**Any PR that adds a file to a workspace silently disabled typechecking for that
entire workspace** — and a real type error in it was reported as a pass.

The script's existing comment handles the mirror case (origin/main-only files
staged `A` after the swap, cleaned via reset->checkout->clean). The HEAD-only
direction was never considered.

## Evidence

Reproduced on the #2805 branch, which adds `office-hours/src/snapshot-wire.ts`
and `office-hours-snapshot/src/roundtrip.test.ts`:

- A **pure** origin/main checkout typechecks both workspaces clean (rc=0, zero
  diagnostics) — so the "pre-existing errors" diagnosis was false.
- The script skipped **both** workspaces and printed `All typecheck targets passed.`

With a deliberate type error added to `snapshot-wire.ts`, same commit content:

| script | exit | output |
| --- | --- | --- |
| before | **0** | `All typecheck targets passed.` — error invisible |
| after | **1** | `Typecheck regressions in: office-hours-snapshot office-hours` |

## Change

- Remove branch-new paths before the baseline probe. `--no-renames` so an
  intra-workspace move decomposes to D+A rather than R, which would otherwise
  let the new path survive. The existing reset->checkout->clean restore brings
  them back, since they are tracked at HEAD.
- Stop claiming success when nothing was verified: count checked vs skipped,
  warn on stderr for baseline skips, and when zero workspaces were checked say
  so rather than printing a pass line.

Exit stays 0 when everything skips, **by design** — `test-run-typecheck.sh`
"Test 3: dirty baseline + dirty HEAD -> skipped" pins the contract that a
genuinely broken origin/main must not fail a PR author's CI. I hit that test
while making zero-checked a hard failure and fixed my code rather than the test.

## Tests

`test-run-typecheck.sh` gains **Test 7 (addition branch)** as the mirror of the
existing Test 6 (deletion branch). It fails 3/5 against the old script and
passes 5/5 against this one.

```
Results: 24/24 passed, 0 failed
```

## Open question for review

Should a run that verified nothing exit non-zero? Test 3 says no, and this PR
follows that. It is worth a deliberate decision rather than inheriting the
existing contract by default — a broken main currently means PRs merge with
zero typecheck coverage and only a stderr warning to show for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
