### PR TITLE
skills: repoint three SCHEMA.md references at intentions/kind-kind.md

### DIFF
--- a/.claude/skills/align-init/SKILL.md
+++ b/.claude/skills/align-init/SKILL.md
@@ -99,7 +99,7 @@ The router reads the graph at `origin/main` and schedules eligible tactics
 autonomously; the align skill family (`/align-init`, `/align-strategy`,
 `/align-tactics`) is the human interface that populates it. Keep the
 orientation to one screen — the schema reference is
-`packages/intentionsutil/SCHEMA.md` for anyone who wants depth.
+`intentions/kind-kind.md` for anyone who wants depth.
 
 ## Step 2 — Validate deployment
 

--- a/.claude/skills/align-tactics/SKILL.md
+++ b/.claude/skills/align-tactics/SKILL.md
@@ -371,10 +371,10 @@ a strategy.
      this is a checklist step, not mechanized scope detection. In-scope copy:
      the landing page, the about page, app heroes and onboarding text, the
      README, and blog posts. Explicitly **excluded**: in-app UI strings,
-     practitioner reference docs (`SCHEMA.md`, package READMEs), and GitHub
-     issue/PR prose. Exempt: mechanical fixes (typos, broken links, factual
-     corrections with no reframing and no new claims) are ungated; any doubt
-     means gated.
+     practitioner reference docs (`intentions/kind-kind.md`, package READMEs),
+     and GitHub issue/PR prose. Exempt: mechanical fixes (typos, broken links,
+     factual corrections with no reframing and no new claims) are ungated; any
+     doubt means gated.
    - **Mint a sibling approval gate** in the born-parked shape (Step 4;
      `intentions/tactic-readme-copy-approval.md` is the reference instance):
      `owner: human`, `status: delegated`, `office_hours: {reason, since}` set at

--- a/.claude/skills/dispatch-propagate/scripts/audit-copy-changes.sh
+++ b/.claude/skills/dispatch-propagate/scripts/audit-copy-changes.sh
@@ -62,8 +62,8 @@ done
 # Grounded in strategy-author-approved-copy's scope clarification: in-scope
 # copy is landing, the about page, app heroes and onboarding text, the README,
 # and blog posts. Explicitly EXCLUDED (and therefore absent below): in-app UI
-# strings, practitioner reference docs (SCHEMA.md, package READMEs), and
-# GitHub issue/PR prose.
+# strings, practitioner reference docs (intentions/kind-kind.md, package
+# READMEs), and GitHub issue/PR prose.
 #
 # When a later strategy clarification widens in-scope copy, edit this one
 # block — nothing else in the script encodes scope.


### PR DESCRIPTION
Repoints the three `packages/intentionsutil/SCHEMA.md` references that live under `.claude/skills/**` to `intentions/kind-kind.md`. Prose and comment only, no logic change.

## Redirected sites

| File | What it said |
| --- | --- |
| `.claude/skills/align-init/SKILL.md` | the depth pointer in the orientation section |
| `.claude/skills/align-tactics/SKILL.md` | the practitioner-reference-docs example in the copy-gate exclusion list |
| `.claude/skills/dispatch-propagate/scripts/audit-copy-changes.sh` | the comment mirroring that exclusion list |

The script's in-scope copy allowlist regexes are untouched, so `audit-copy-changes.sh` behaves identically — the changed line is a comment. The two four-line hunks are line-wrap reflows forced by the longer path; the surrounding wording is word-for-word unchanged.

## Completion condition

`grep -rn 'SCHEMA\.md' .claude/skills` is now empty. That is the condition named at `intentions/tactic-schema-md-deprecation.md:151` and in `strategy-graph-self-description`'s success threshold.

`packages/intentionsutil/SCHEMA.md` still exists on `main`, so this is a **redirection, not a dangling-reference repair**. The redirect target is consistent with what the doc being redirected away from already says — `SCHEMA.md:16` itself directs readers to `intentions/kind-kind.md`.

## Scope

The three `.claude/skills` sites only. `strategy-graph-self-description` records an 11-file SCHEMA.md census and notes that three of the eleven live under `.claude/skills`; the other eight (`README.md`, `intentions/README.md`, `packages/intentionsutil/SEPARABILITY.md`, and several intention-node bodies) belong to `tactic-schema-md-deprecation` Unit 2 and are deliberately untouched here.

## Graph context

This lands the self-modification gate node `tactic-align-skill-schema-pointers`. The node `tactic-schema-md-deprecation` lists that gate in its `blocked_by`, so this work clears its path — the `blocked_by` edge itself is left in place for a separate authorized graph change.

Landed through the self-modification office-hours lane: auto-mode blocks agent commits under `.claude/skills`, so the author granted this commit explicitly.

## Verification

- `grep -rn 'SCHEMA\.md' .claude/skills` — empty
- `bash -n .claude/skills/dispatch-propagate/scripts/audit-copy-changes.sh` — passes
- `run-lint.sh --prose` — passes
- No test file references `audit-copy-changes.sh`; no test was touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
