### PR TITLE
fix: pass -C REPO_ROOT from clear-park and resolve-park to graph-commit

### DIFF
--- a/packages/intentionsutil/scripts/clear-park
+++ b/packages/intentionsutil/scripts/clear-park
@@ -166,7 +166,19 @@ else
   MESSAGE="graph: clear office_hours park on $NODE_ID"
 fi
 
-if ! "$SCRIPT_DIR/graph-commit" --base "$NODE_ID=$FRESH_BLOB" -m "$MESSAGE" "$NODE_ID"; then
+# -C "$REPO_ROOT" is mandatory, not cosmetic. This script's REPO_ROOT is derived
+# from SCRIPT_DIR (its own on-disk location), and every write above -- the
+# origin/main refresh and the office_hours clear -- targets "$INTENTIONS_DIR"
+# under THAT repo. graph-commit, by contrast, resolves its repo from -C if
+# given, else from cwd. Callers routinely invoke the main checkout's copy of
+# this script by absolute path from inside a worktree, so without -C the two
+# resolve to DIFFERENT checkouts: the edit is written to the script's repo
+# while graph-commit inspects the caller's cwd repo, finds nothing staged for
+# the id and its HEAD blob equal to origin/main, takes the benign "no new
+# changes to stage" branch, and prints "landed ... on main" / exits 0 having
+# committed nothing -- leaving the real edit dirty and unpushed in the other
+# checkout. Mirrors park-node, which already passes -C for the same reason.
+if ! "$SCRIPT_DIR/graph-commit" -C "$REPO_ROOT" --base "$NODE_ID=$FRESH_BLOB" -m "$MESSAGE" "$NODE_ID"; then
   echo "clear-park: graph-commit failed for $NODE_ID; the office_hours write was rolled back" >&2
   exit 1
 fi

--- a/packages/intentionsutil/scripts/resolve-park
+++ b/packages/intentionsutil/scripts/resolve-park
@@ -173,7 +173,19 @@ COMMIT_MSG="graph: resolve-park $NODE_ID ($DISPOSITION PR #$PR)"
 if [[ -n "$NOTE" ]]; then
   COMMIT_MSG="$COMMIT_MSG - $NOTE"
 fi
-if ! "$SCRIPT_DIR/graph-commit" --base "$NODE_ID=$FRESH_BLOB" -m "$COMMIT_MSG" "$NODE_ID"; then
+# -C "$REPO_ROOT" is mandatory, not cosmetic. This script's REPO_ROOT is derived
+# from SCRIPT_DIR (its own on-disk location), and every write above -- the
+# origin/main refresh and the office_hours clear -- targets "$INTENTIONS_DIR"
+# under THAT repo. graph-commit, by contrast, resolves its repo from -C if
+# given, else from cwd. Callers routinely invoke the main checkout's copy of
+# this script by absolute path from inside a worktree, so without -C the two
+# resolve to DIFFERENT checkouts: the edit is written to the script's repo
+# while graph-commit inspects the caller's cwd repo, finds nothing staged for
+# the id and its HEAD blob equal to origin/main, takes the benign "no new
+# changes to stage" branch, and prints "landed ... on main" / exits 0 having
+# committed nothing -- leaving the real edit dirty and unpushed in the other
+# checkout. Mirrors park-node, which already passes -C for the same reason.
+if ! "$SCRIPT_DIR/graph-commit" -C "$REPO_ROOT" --base "$NODE_ID=$FRESH_BLOB" -m "$COMMIT_MSG" "$NODE_ID"; then
   echo "resolve-park: graph-commit failed for $NODE_ID; office_hours clear is on disk but not landed (PR #$PR disposition ($DISPOSITION) already applied)" >&2
   exit 1
 fi


### PR DESCRIPTION
## Root cause

`clear-park` and `resolve-park` derive `REPO_ROOT` from their own on-disk location (`SCRIPT_DIR`), and write the `office_hours` clear into the intentions directory under **that** repo. Both then invoked `graph-commit` **without** `-C`. `graph-commit` resolves its repo from `-C` when given, otherwise from **cwd** (`packages/intentionsutil/scripts/graph-commit:1337`).

When a session invokes the main checkout's copy of either script by absolute path from inside a worktree, the two resolve to different checkouts. The edit lands in the script's repo while `graph-commit` inspects the caller's cwd repo, where nothing is staged for the node id and the HEAD blob equals `origin/main`. That is the benign equal-blob branch (`graph-commit:1477`): it prints a "landed" message and exits 0 having **committed nothing**. The real edit is left dirty and unpushed in the other checkout, and the park silently persists.

The failure mode is caller-side repo targeting. It is **not** a concurrency race in `graph-commit`'s staleness detection — it reproduces deterministically with a single writer.

## Fix

Both call sites now pass `-C "$REPO_ROOT"`, mirroring `park-node:263` and `demote-node-to-implement:115`, which already do this for the same reason. An explanatory comment at each site records why the flag is mandatory rather than cosmetic, so a future edit does not drop it as noise.

- `packages/intentionsutil/scripts/clear-park:181`
- `packages/intentionsutil/scripts/resolve-park:188`

No other files change. No test was added, weakened, skipped, or deleted.

## Verification

Run from the branch after merging current `origin/main`:

- `bash -n` clean on both scripts.
- `packages/intentionsutil/scripts/test-graph-commit.sh` — **passed 43, failed 0**. This suite already covers the targeting contract directly (`-C targeting: script physically inside w16, targeting w17 via -C from an unrelated cwd, lands in w17's repo`) and both fail-loud guards around the equal-blob branch.
- `packages/intentionsutil/scripts/test-park-node.sh` — **passed 14, failed 1**. The single failure is `demote-node-to-implement byte-identical restore`, an `ERR_MODULE_NOT_FOUND` in a helper import. It is **pre-existing on clean `origin/main`** and is not caused by this change; it was confirmed failing on an unmodified checkout before and after this edit. It is left failing deliberately — it is signal, not an obstacle.

## Follow-up

The systemic concern this surfaced — that a caller can receive a "landed" message and exit 0 while nothing was committed — is tracked separately as its own tactic rather than expanded here. This PR fixes the two concrete call sites.

Node: `tactic-graph-commit-staleness-silent-revert`
