### PR TITLE
tactic-flake-fingerprint-stability: pin flake fingerprint stable-id precedence, add near-miss advisory

### DIFF
--- a/.claude/skills/fix-checks/SKILL.md
+++ b/.claude/skills/fix-checks/SKILL.md
@@ -379,9 +379,34 @@ atomic tempfile+`mv` write) so the park records `execution.pr`
         runs).** The fingerprint is `<failing-check-name> — <stable-id>`, where
         `<stable-id>` is chosen by this **fixed precedence** (use the first the
         failure excerpt provides):
-        1. the **test node id** — e.g. `path/to/test.spec.ts:LINE:COL test title`;
-        2. else the **file path:line**;
-        3. else the **CI workflow name**.
+        1. the failing **test name / assertion label exactly as the suite prints
+           it**, verbatim — a Jest/Mocha/vitest/pytest test title, a shell
+           test's assertion description, or any comparable human-readable label
+           the test runner itself emits. This is **not** a `file:line` pointer.
+        2. **only when the excerpt contains no such label**, the failing **file
+           path with NO line number** — e.g.
+           `.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`,
+           never `…:22026`. Line numbers drift whenever an unrelated edit lands
+           above that line in the file, so a line-number-bearing id
+           re-fingerprints the *same* failure differently across unrelated
+           commits — dedup then misses and mints a second tracking node for one
+           flake. That is why the `file:line` form is **disallowed**, not merely
+           a different-but-acceptable spelling.
+
+        **Never** include any of these in `<stable-id>`: a **line number**, a
+        **run id**, a **timestamp**, or a **PR number**. Each of them varies
+        across recurrences of one defect, so including one defeats dedup by
+        construction.
+
+        Worked example (2026-07-22 incident). One assertion failure produced two
+        divergent fingerprints under the old rule:
+        `hook-tests — .claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh:22026`
+        (keyed on `file:line`) and
+        `hook-tests — select-tick on-main but primary checkout off-main → guard halts (exit 2)`
+        (keyed on the test name) — dedup missed and two nodes were minted for one
+        flake. Under this rule both collapse to the test-name form,
+        `hook-tests — select-tick on-main but primary checkout off-main → guard halts (exit 2)`.
+
         Read `<stable-id>` from the excerpt strictly by this precedence and
         **never paraphrase or summarize it** — the same flake must yield a
         byte-identical fingerprint string on every run, or dedup silently fails in

--- a/.claude/skills/fix-checks/SKILL.md
+++ b/.claude/skills/fix-checks/SKILL.md
@@ -545,6 +545,32 @@ atomic tempfile+`mv` write) so the park records `execution.pr`
                re-run CI — the head is simply missing a fix that already landed.
              - **`CURRENT`** — proceed with the node write below, unchanged.
 
+             **Near-miss advisory check (`CURRENT` only, never blocks).**
+             `dispatch-flake-dedup-node` matched nothing because it greps the
+             **full** `Fingerprint: <fingerprint>` line as a fixed string, so a
+             stable-id that diverges even slightly from an existing node's
+             spelling reads as `NONE` and mints a second node with no signal to
+             a human. Before writing, grep for the **mechanical half alone** —
+             the failing check name and the ` — ` separator, not the full
+             fingerprint:
+             ```bash
+             NEARMISS=$(grep -rlF -- "Fingerprint: <failing-check-name> — " intentions/tactic-*.md 2>/dev/null || true)
+             ```
+             This is a plain `grep`, not a new script — this step introduces no
+             script surface and no new test file.
+             - **No hit** — proceed silently; add no accumulator bullet.
+             - **Hit** — the matched node(s) share this failing check but carry a
+               different stable-id. **Still mint the new node exactly as below** —
+               two distinct flakes under one check (e.g. two different assertions
+               both failing under `hook-tests`) is a normal, expected case, so
+               this must never block or delay filing. The only difference: carry
+               an advisory note into the accumulator alongside the flake-tracking
+               id bullet (the same mechanism the `STALE-SUPPRESSED` /
+               `STALE-HEAD-SUPPRESSED` notes use), naming the matched tactic
+               id(s) — e.g. `possible duplicate of <tactic-id>[, <tactic-id>…]:
+               same failing check, different stable-id` — so a human reviewing
+               flake tracking can judge whether to collapse them by hand.
+
              On `CURRENT`, write a **new** flake
              tactic node. Construct its frontmatter JSON and pass it to
              `write-node.ts` (same recipe as `align-tactics/SKILL.md`'s

--- a/.claude/skills/fix-checks/SKILL.md
+++ b/.claude/skills/fix-checks/SKILL.md
@@ -392,6 +392,20 @@ atomic tempfile+`mv` write) so the park records `execution.pr`
            commits — dedup then misses and mints a second tracking node for one
            flake. That is why the `file:line` form is **disallowed**, not merely
            a different-but-acceptable spelling.
+        3. **only when the excerpt provides neither** — the reachable case is a
+           CI-infrastructure hiccup (Step 4's "a CI-infrastructure hiccup"
+           flake diagnosis) whose log carries no runner-emitted test label and
+           names no failing file — the failing **CI workflow / job name exactly
+           as CI reports it**. The stable-id half then repeats the check-name
+           half; that redundancy is deliberate. It makes every label-less,
+           path-less failure under one check collapse to one deterministic
+           fingerprint, which is strictly better than leaving the worker to
+           improvise a string — improvised strings are the nondeterminism this
+           precedence exists to eliminate.
+
+        The precedence is **total**: tier 3 always applies when tiers 1 and 2
+        do not, so there is never a case where `<stable-id>` is undefined and
+        the worker must invent one.
 
         **Never** include any of these in `<stable-id>`: a **line number**, a
         **run id**, a **timestamp**, or a **PR number**. Each of them varies
@@ -552,14 +566,31 @@ atomic tempfile+`mv` write) so the park records `execution.pr`
              spelling reads as `NONE` and mints a second node with no signal to
              a human. Before writing, grep for the **mechanical half alone** —
              the failing check name and the ` — ` separator, not the full
-             fingerprint:
+             fingerprint. Anchor the glob at the repo root (the same reason
+             `dispatch-flake-dedup-node` `cd`s to `git rev-parse
+             --show-toplevel`): if cwd is not the worktree root the glob matches
+             nothing, zsh aborts the command, `|| true` swallows it, and an
+             empty `NEARMISS` is indistinguishable from a genuine no-hit.
              ```bash
-             NEARMISS=$(grep -rlF -- "Fingerprint: <failing-check-name> — " intentions/tactic-*.md 2>/dev/null || true)
+             ROOT=$(git rev-parse --show-toplevel)
+             NEARMISS=$(grep -rlF -- "Fingerprint: <failing-check-name> — " "$ROOT"/intentions/tactic-*.md 2>/dev/null || true)
              ```
-             This is a plain `grep`, not a new script — this step introduces no
-             script surface and no new test file.
+             `NEARMISS` holds absolute paths; take each tactic id from the
+             basename with the `.md` suffix stripped. This is a plain `grep`,
+             not a new script — this step introduces no script surface and no
+             new test file.
              - **No hit** — proceed silently; add no accumulator bullet.
-             - **Hit** — the matched node(s) share this failing check but carry a
+             - **Hit** — before naming any match, **confirm it is actually a
+               flake-tracking tactic** (a node whose body records a flake
+               fingerprint, reproduce command, and failure excerpt). Matching
+               only the mechanical half drops the stable-id anchoring that
+               `dispatch-flake-dedup-node` relies on to keep a coincidental
+               quote of a `Fingerprint:` line in an unrelated node's prose — a
+               planning or meta node, of which this repo has several — from
+               reading as a flake tracker. Discard every non-tracker match; if
+               none survive, treat it as **No hit**.
+
+               The surviving node(s) share this failing check but carry a
                different stable-id. **Still mint the new node exactly as below** —
                two distinct flakes under one check (e.g. two different assertions
                both failing under `hook-tests`) is a normal, expected case, so
@@ -834,6 +865,11 @@ atomic tempfile+`mv` write) so the park records `execution.pr`
     does not reproduce at `origin/main`, so **no node was created at all** and
     there is no id to name. Record alongside it that the remedy is to merge
     `origin/main` and re-run.
+    On the node lane's `CREATED` path, the near-miss advisory check (Step 4's
+    Flake sub-path) may append a trailing advisory clause to this same bullet:
+    `<tactic-id> (CREATED) — possible duplicate of <tactic-id>[, <tactic-id>…]:
+    same failing check, different stable-id`. The clause is advisory only — it
+    never changes the parenthesized disposition and never suppresses the write.
     Omit for every other outcome.
   - **Fingerprint** — *`flake` outcome only* — the dedupe key computed in the
     Flake sub-path (the failing check name plus the stable identifier). Omit for


### PR DESCRIPTION
Implements `tactic-flake-fingerprint-stability`.

`dispatch-flake-dedup-node` dedupes flake tracking nodes by an exact
fixed-string grep on a canonical `Fingerprint: <fingerprint>` line, where
`fingerprint = <failing-check-name> — <stable-id>`. The check name is
mechanical, but the stable id was chosen by the model implementing
`/fix-checks` from an open-ended precedence — and its `file:line` fallback was
itself unstable, since a line number drifts whenever an unrelated edit lands
above it. Two CI recurrences of the *same* failure could therefore mint two
different fingerprints, and dedup silently missed. This happened for real on
2026-07-22: one assertion failure in
`.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` produced
two flake tactics three minutes apart (both later pruned as non-defects).

## Unit 1 — pin the stable-id rule

In `.claude/skills/fix-checks/SKILL.md`, replaced the open-ended precedence
with a strict two-item rule: (1) the failing test name / assertion label
verbatim, (2) only if absent, the file path with **no line number**. Added an
explicit "never a line number/run id/timestamp/PR number" list, and a worked
example from the 2026-07-22 incident showing both original fingerprints
collapsing to the test-name form under the new rule.

## Unit 2 — narrow the blast radius of a near-miss

Added an advisory-only near-miss check to the node lane's `NONE` disposition:
before minting a new flake node, grep node bodies for the failing check name
alone (the mechanical half of the fingerprint). A hit means an existing node
shares the check but carries a different stable-id — surfaced as an advisory
accumulator note for a human to judge, never blocking or delaying filing (a
genuinely distinct flake under the same check is normal and expected). This is
a plain inline `grep`, not a new script — no new script surface, no new test
file.

## Out of scope

`dispatch-flake-dedup-node`'s matching logic is untouched — it's correct as
written; the defect was upstream, in what the caller fed it. No retroactive
normalization of fingerprints already recorded in existing nodes.

## Verification

```verify
bash .claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh
```

Ran and passed. Manually re-checked the incident's two divergent fingerprints
against the new rule — both now collapse to the test-name form.
