### PR TITLE
Fix two typecheck gaps: census node typing and silent --app no-op

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/run-typecheck.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-typecheck.sh
@@ -15,6 +15,19 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --app)
       [[ $# -lt 2 ]] && { echo "Error: --app requires an argument" >&2; exit 1; }
+      # --app takes a workspace DIRECTORY, repo-root-relative (`packages/foo`),
+      # not a bare package name (`foo`). Reject a path that does not exist
+      # instead of carrying it forward: a non-existent dir has no tsconfig.json,
+      # so it would fall into the "no tsconfig.json — skipping (non-TS
+      # workspace)" branch below and the run would exit 0 having verified
+      # nothing. That failure mode is silent and reads as a pass, so a typo or a
+      # missing `packages/` prefix disables typechecking for the workspace the
+      # caller believed it was checking.
+      if [ ! -d "$REPO_ROOT/$2" ]; then
+        echo "Error: --app '$2': no such workspace directory under $REPO_ROOT" >&2
+        echo "Pass a repo-root-relative workspace dir, e.g. --app packages/intentionsutil" >&2
+        exit 1
+      fi
       DIRTY_APPS["$2"]=1
       EXPLICIT=true
       shift 2

--- a/.claude/skills/dispatch-propagate/scripts/test-run-typecheck.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-run-typecheck.sh
@@ -122,7 +122,7 @@ run_sut() {
   prev_dir=$(pwd)
   cd "$REPO"
   set +e
-  OUT=$(PATH="$SHIM_BIN:$PATH" "$SUT" 2>&1)
+  OUT=$(PATH="$SHIM_BIN:$PATH" "$SUT" "$@" 2>&1)
   RC=$?
   set -e
   cd "$prev_dir"
@@ -260,5 +260,36 @@ assert_eq "addition: baseline not poisoned by the added file" "not-skipped" "$_t
 assert_eq "addition: working tree clean after run" "" "$(git -C "$REPO" status --porcelain)"
 [ -f "$REPO/ws/src/added.ts" ] && _t7_added=present || _t7_added=absent
 assert_eq "addition: added file restored after baseline probe" "present" "$_t7_added"
+
+# --- Test 8: --app with a non-existent workspace dir ---
+# Regression guard. `--app` takes a repo-root-relative workspace DIRECTORY, but
+# the natural typo is the bare package name (`--app intentionsutil` instead of
+# `--app packages/intentionsutil`). A non-existent dir has no tsconfig.json, so
+# it used to land in the "no tsconfig.json — skipping (non-TS workspace)" branch
+# and the run exited 0 reporting a benign non-TS skip — indistinguishable from a
+# real pass, silently verifying nothing about the workspace the caller named.
+echo "Test 8: --app with a non-existent dir -> hard error, not a silent skip"
+make_repo ws clean clean
+make_shims "$REPO"
+run_sut --app definitely-not-a-workspace
+[ "$RC" -ne 0 ] && _t8_rc=nonzero || _t8_rc=zero
+assert_eq "bad --app: exit non-zero" "nonzero" "$_t8_rc"
+assert_contains "bad --app: error names the bad value" "definitely-not-a-workspace" "$OUT"
+assert_contains "bad --app: error explains the expected form" "repo-root-relative" "$OUT"
+case "$OUT" in
+  *"non-TS workspace"*) _t8_silent=silently-skipped ;;
+  *) _t8_silent=errored ;;
+esac
+assert_eq "bad --app: not misreported as a non-TS workspace" "errored" "$_t8_silent"
+
+# --- Test 9: --app with a real workspace dir still works ---
+# Pins the guard to rejecting only paths that do not exist: the valid explicit
+# form must still run a full baseline-vs-HEAD check.
+echo "Test 9: --app with a real dir -> still typechecks normally"
+make_repo ws clean clean
+make_shims "$REPO"
+run_sut --app ws
+assert_eq "good --app: exit 0" "0" "$RC"
+assert_contains "good --app: workspace reported as passing" "ws: typecheck passed" "$OUT"
 
 report_results

--- a/packages/intentionsutil/scripts/graph-census-debt.ts
+++ b/packages/intentionsutil/scripts/graph-census-debt.ts
@@ -44,7 +44,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { listNodes } from "../src/store.js";
-import type { IntentionNode } from "../src/schema.js";
+import type { IntentionNode, IntentionNodeInput } from "../src/schema.js";
 
 const CENSUS_SERVES = "strategy-graph-native-dispatch";
 const OPEN_PHASES = new Set(["implement", "fix", "qa", "review", "main-qa"]);
@@ -152,6 +152,25 @@ export function computeDebt(nodes: IntentionNode[], mergedIds: Set<string>): Cen
   };
 }
 
+/**
+ * `attributes` payload of a born-parked census node. `IntentionNode.attributes`
+ * is deliberately `Record<string, unknown>` — kind-specific fields are defined
+ * by the `kind-<kind>` node, not the schema — so the census kind names its own
+ * shape here. That keeps the batch lists typed for every reader instead of
+ * making each one cast `unknown` back to an array.
+ */
+export interface CensusAttributes {
+  census: true;
+  batch: {
+    donePresent: string[];
+    mergedUnabsorbed: string[];
+    orphans: string[];
+  };
+}
+
+/** A born-parked census node: the write-input shape with census attributes. */
+export type CensusNode = IntentionNodeInput & { attributes: CensusAttributes };
+
 /** Build the born-parked census node object + its markdown body. */
 function buildCensusNode(id: string, now: string, debt: CensusDebt) {
   const batchLine = `${debt.donePresent.length} owed prune(s), ${debt.mergedUnabsorbed.length} unverified PR-merge(s), ${debt.orphans.length} orphan(s)`;
@@ -159,7 +178,12 @@ function buildCensusNode(id: string, now: string, debt: CensusDebt) {
     `Reconciliation debt reached ${debt.total} (${batchLine}); a census is owed to drain it. ` +
     `Next steps: run the census over the batch listed in this node's body — for each done-but-present node, FIRST verify its execution.completion evidence (a real merge = mergedAt AND mergeCommitSha both non-null; or an out-of-band landing = graphCommitSha non-null); prune ONLY the verified ones with graph-commit --prune (repairing inbound blocked_by edges in the same commit, per tactic-graph-self-consistency-sweep) and LEAVE every evidence-less node in place as an integrity defect to investigate; absorb any unverified PR-merge, and repair any orphan's dangling parent/serves; then resolve this node (phase -> done) so the recurrence latch clears.`;
 
-  const node = {
+  // Typed rather than left to literal inference: the born-parked contract is
+  // defined by which optional fields are OMITTED — `phase` above all — and an
+  // inferred literal type has no `phase` key at all, so a reader asserting
+  // `node.phase === undefined` cannot even name the field. The annotation makes
+  // the omission part of the type and pins owner/status to their schema unions.
+  const node: CensusNode = {
     id,
     kind: "tactic",
     statement:
@@ -168,7 +192,12 @@ function buildCensusNode(id: string, now: string, debt: CensusDebt) {
     status: "codified",
     parent: null,
     serves: [CENSUS_SERVES],
-    office_hours: { reason, since: now, recommendation: null },
+    // `session_type: "other"` is stated rather than left to
+    // `validateOfficeHours`'s absent-field substitution: this is a
+    // machine-authored park with no natural sitting type, which is exactly what
+    // "other" documents, and spelling it out keeps the written node identical to
+    // the validated one.
+    office_hours: { reason, since: now, recommendation: null, session_type: "other" },
     attributes: {
       census: true,
       batch: {
@@ -220,7 +249,7 @@ function buildCensusNode(id: string, now: string, debt: CensusDebt) {
 
 export interface CensusDecision extends CensusDebt {
   shouldBirth: boolean;
-  node?: ReturnType<typeof buildCensusNode>["node"];
+  node?: CensusNode;
   node_body?: string;
 }
 


### PR DESCRIPTION
Ad-hoc fix for two typecheck gaps found while resolving merge conflicts across eight PRs (#2856, #2875, #2904, #2936, #2971, #2972, #2975, #2976). Neither is caused by those PRs — both predate them on `main`. They share a failure mode: a typecheck run that reports success while verifying nothing.

## 1. `packages/intentionsutil` failed `tsc --noEmit` on `origin/main`

`test/graph-census-debt.test.ts:108` asserts `d.node?.phase` is undefined — the born-parked contract, which is defined by the fields the census node **omits**. But `buildCensusNode` returned an un-annotated object literal, so the inferred type had no `phase` key at all and the assertion could not name the field it was checking:

```
test/graph-census-debt.test.ts(108,20): error TS2339: Property 'phase' does not exist on type '{ id: string; kind: string; ... }'
```

The test was right; the source type was under-specified. Annotating the literal as `IntentionNodeInput` makes the omission part of the type and pins `owner`/`status` to their schema unions.

That annotation immediately surfaced a latent gap: `office_hours` was missing `session_type`, required by `OfficeHours` since that field was added. **Runtime was already correct** — `validateOfficeHours` substitutes `"other"` when the field is absent — so the node actually written to the graph is unchanged. Stating it keeps the emitted node identical to the validated one, and `"other"` is precisely what the schema docs prescribe for a machine-authored park with no natural sitting type.

`attributes` gets a named `CensusAttributes` shape, since `IntentionNode.attributes` is deliberately `Record<string, unknown>` (kind-specific fields are defined by the `kind-<kind>` node). This keeps the batch lists typed for readers instead of each one casting `unknown` back to an array.

**No test file was changed.** The assertions that already existed now typecheck as written.

Knock-on effect worth noting: because this baseline failure made `run-typecheck.sh` skip the whole workspace (`origin/main has pre-existing typecheck errors`), `intentionsutil` was effectively **un-typechecked in CI** until now. This PR restores that coverage.

## 2. `run-typecheck.sh --app <bad-dir>` exited 0 having checked nothing

`--app` takes a repo-root-relative workspace **directory**, but the natural typo is the bare package name — `--app intentionsutil` rather than `--app packages/intentionsutil`. A non-existent dir has no `tsconfig.json`, so it fell into the `no tsconfig.json — skipping (non-TS workspace)` branch, a benign-skip class meant for CSS-only workspaces, and the run exited 0.

This is not hypothetical: two separate agents independently reported `intentionsutil` as *having no `tsconfig.json`* on the strength of that message. It has one.

A path that does not exist is now a hard error at parse time, per the project's prefer-clear-errors-over-fallbacks rule. A directory that exists but genuinely has no `tsconfig.json` keeps the existing benign skip — the two cases are now distinguished rather than merged.

## Verification

- `npx tsc --noEmit --project packages/intentionsutil` — clean (was 1 error)
- `npx vitest run --project packages/intentionsutil --root .` — **698 passed**, 37 files
- `test-run-typecheck.sh` — **30/30 passed**, including two new cases

New `Test 8` was verified to be a real guard, not a tautology: run against `origin/main`'s pre-fix `run-typecheck.sh`, it fails 3 assertions (`exit non-zero`, the error text, and `not misreported as a non-TS workspace`) and passes after the fix. `Test 9` pins that a valid `--app` still runs a full baseline-vs-HEAD check, so the guard rejects only paths that do not exist.

Note that `run-typecheck.sh --app packages/intentionsutil` still reports `skipping — origin/main has pre-existing typecheck errors` **on this branch**, which is the correct contract: `origin/main` genuinely is broken until this merges. Direct `tsc --noEmit` is the authoritative check for HEAD, and it is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
