### PR TITLE
bootstrap: node-terminal declaration + dump-node manifest CAS guard

### DIFF
--- a/.claude/skills/align-tactics/references/write-path.md
+++ b/.claude/skills/align-tactics/references/write-path.md
@@ -46,6 +46,11 @@ mechanically rather than by rebase luck (the 2026-07-06 near-miss). Nodes
 this round **creates** (new tactics, new gates) have no origin/main blob and
 take no `--base` entry.
 
+The two recipes below are alternatives — pick one. Either way, a single
+`dump-node.ts` call must name **every** id the `graph-commit` will land: a
+manifest only guards the ids it holds, and the rest land with no
+compare-and-swap at all.
+
 ```bash
 BASE=$(npx tsx packages/intentionsutil/scripts/dump-node.ts \
   --out-dir "$TMPDIR/dump" <pre-existing-id> [<pre-existing-id> ...])

--- a/.claude/skills/dispatch-conflict/SKILL.md
+++ b/.claude/skills/dispatch-conflict/SKILL.md
@@ -544,11 +544,13 @@ the JSON with `dump-node.ts` (it writes `$SCRATCH/$NODE_ID.json`, the exact
 shape `readNode` returns, ready to pipe back into `write-node.ts`). It also
 writes a base-manifest — **ignore it**; this land is a normal edit with no
 `--base` (see below). Use an explicit `/tmp/claude-<uid>` scratch path, not
-`$TMPDIR` (unset under `dangerouslyDisableSandbox`):
+`$TMPDIR` (unset under `dangerouslyDisableSandbox`). The path is specific to
+this branch (`-resolved`) so it never shares an out-dir with the `ambiguous`
+path's dump further down — one out-dir per `graph-commit`:
 
 ```bash
 git checkout origin/main -- "intentions/$NODE_ID.md"
-SCRATCH="/tmp/claude-$(id -u)/dispatch-conflict-$NODE_ID"
+SCRATCH="/tmp/claude-$(id -u)/dispatch-conflict-resolved-$NODE_ID"
 mkdir -p "$SCRATCH"
 npx tsx packages/intentionsutil/scripts/dump-node.ts --out-dir "$SCRATCH" "$NODE_ID"
 ```
@@ -639,11 +641,13 @@ already in `office_hours.recommendation`, the skill **may** append it to that
 field — same write-back shape as the `resolved` path above, but appending text
 to `.office_hours.recommendation` rather than clearing `.office_hours`
 (schema `packages/intentionsutil/src/schema.ts:392-397`). This is optional; the
-default acceptable behavior is confirm-and-report only, with no write:
+default acceptable behavior is confirm-and-report only, with no write. As on
+the `resolved` path, the scratch dir is specific to this branch (`-note`) so
+the two never share an out-dir:
 
 ```bash
 git checkout origin/main -- "intentions/$NODE_ID.md"
-SCRATCH="/tmp/claude-$(id -u)/dispatch-conflict-$NODE_ID"
+SCRATCH="/tmp/claude-$(id -u)/dispatch-conflict-note-$NODE_ID"
 mkdir -p "$SCRATCH"
 npx tsx packages/intentionsutil/scripts/dump-node.ts --out-dir "$SCRATCH" "$NODE_ID"
 jq --arg extra "$NEXT_STEP" \

--- a/.claude/skills/fix-checks/SKILL.md
+++ b/.claude/skills/fix-checks/SKILL.md
@@ -639,10 +639,14 @@ atomic tempfile+`mv` write) so the park records `execution.pr`
            - **`EXISTING <tactic-id>` / `REOPENED <tactic-id>`** — a matching
              flake tactic already exists. First dump a `--base` manifest for it
              (pre-existing node — same optimistic-concurrency guard
-             `align-tactics` Step 5 uses):
+             `align-tactics` Step 5 uses). Note the `--out-dir`: this dump feeds
+             its own `graph-commit`, so it gets its own directory, separate from
+             sub-step 4's dump of `$N` below. One out-dir per `graph-commit` —
+             sharing one leaves a manifest whose entries the later commit never
+             meant to guard:
              ```bash
              BASE=$(npx tsx packages/intentionsutil/scripts/dump-node.ts \
-               --out-dir /tmp/claude-<uid>/dump <tactic-id>)
+               --out-dir /tmp/claude-<uid>/dump-flake-tactic <tactic-id>)
              ```
              `Edit` the existing tactic's body to **append** the recurrence
              content (`tmp/flake-recurrence.md`'s content) — never replace the
@@ -701,10 +705,13 @@ atomic tempfile+`mv` write) so the park records `execution.pr`
         Read `$N`'s current `blocked_by` array (`dump-node.ts`/reading
         `intentions/$N.md`'s frontmatter). If the flake tactic's id is already
         present, this is a no-op (idempotent re-run) — skip the write. Otherwise
-        append it and land the one-field frontmatter change:
+        append it and land the one-field frontmatter change. This is a second,
+        separate `graph-commit`, so it takes its own `--out-dir` — never
+        sub-step 3's `dump-flake-tactic` directory, whose entry the flake
+        `graph-commit` has already consumed and landed:
         ```bash
         BASE_N=$(npx tsx packages/intentionsutil/scripts/dump-node.ts \
-          --out-dir /tmp/claude-<uid>/dump "$N")
+          --out-dir /tmp/claude-<uid>/dump-source-tactic "$N")
         npx tsx packages/intentionsutil/scripts/write-node.ts --file <updated-N.json>
         packages/intentionsutil/scripts/graph-commit --base "$BASE_N" "$N"
         ```

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -410,7 +410,11 @@ each fork site.
    take the **escalate finalize path** instead (`fix-pass-landed-nothing`).
    Otherwise run Step 4, Step 5, `dispatch-mark-complete --phase qa` (NO
    `dispatch:qa-done`), emit the outcome envelope (`--disposition
-   completed_with_fixes`, `--fixes-applied <fixes_applied_count>`), and **STOP**.
+   completed_with_fixes`, `--fixes-applied <fixes_applied_count>`); node lane
+   then writes `mark-node-terminal "$N" fix-attempt` (**after** the PR
+   comment, phase marker, and outcome envelope — `Stop` fires on every turn
+   yield, not only terminal exit, so writing it any earlier risks the hook
+   reaping the job mid-write); and **STOP**.
 
    **Escalate finalize path** (cap / scope-deviation / planning-failed /
    fix-pass-landed-nothing / no-progress / gate said `escalate`): run Step 4, Step

--- a/.claude/skills/qa-fix/references/auto-fix-lane.md
+++ b/.claude/skills/qa-fix/references/auto-fix-lane.md
@@ -176,7 +176,19 @@ Otherwise (opus-fixable items present), choose exactly one path:
      --subagents-launched <SKILL_SUBAGENTS + result.subagents_launched> \
      --disposition completed_with_fixes
    ```
-6. **STOP.**
+6. **Write the node lane's terminal-disposition marker** (`TARGET_KIND=node`
+   only; the legacy issue lane has no such marker). This must come **after**
+   the PR comment (Step 4), the phase-completed marker (item 4 above), and the
+   outcome envelope (item 5 above) — `Stop` fires on every turn yield, not
+   only on terminal exit, so writing this marker early would let the hook reap
+   the job before those writes land:
+   ```bash
+   packages/intentionsutil/scripts/mark-node-terminal "$N" fix-attempt
+   ```
+   `fix-attempt` is correct here too: this pass spent an attempt via the fix
+   lane, same as `/fix-checks`' own node lane (retry by design — the selector
+   re-routes on a later tick).
+7. **STOP.**
 
 ## Escalate finalize path
 

--- a/packages/intentionsutil/scripts/dump-node.ts
+++ b/packages/intentionsutil/scripts/dump-node.ts
@@ -16,12 +16,17 @@
 //   npx tsx packages/intentionsutil/scripts/dump-node.ts --out-dir <dir> <id> [<id> ...]
 //
 // For each <id> it writes `<dir>/<id>.json` (the shape `readNode` returns, ready
-// to pipe back into write-node.ts after reconciliation) and appends a
-// `<id>=<blobsha>` line to `<dir>/base-manifest.txt`. It prints the manifest
+// to pipe back into write-node.ts after reconciliation) and merges a
+// `<id>=<blobsha>` line into `<dir>/base-manifest.txt`. It prints the manifest
 // path on stdout so the caller can pass it straight to `graph-commit --base`.
+//
+// The manifest merge (see dumpNodes below) exists because a second dump into an
+// out-dir used to truncate the manifest, silently dropping the earlier ids' base
+// tokens — so `graph-commit --base` guarded one node while the rest landed with
+// no compare-and-swap at all.
 
 import { execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { readNode } from "../src/store.js";
@@ -37,9 +42,60 @@ const intentionsDir = join(repoRoot, "intentions");
 const USAGE =
   "usage: dump-node.ts --out-dir <dir> <id> [<id> ...]\n" +
   "  Writes <dir>/<id>.json for each node and a <dir>/base-manifest.txt of\n" +
-  "  <id>=<blobsha> lines; prints the manifest path for `graph-commit --base`.\n";
+  "  <id>=<blobsha> lines; prints the manifest path for `graph-commit --base`.\n" +
+  "  The manifest is merged by id, so a repeat dump into the same --out-dir\n" +
+  "  keeps the earlier ids it can still verify. One --out-dir per graph-commit.\n";
 
 // --- Core helper (exported for tests) --------------------------------------
+
+/**
+ * Blob sha of the on-disk node file. `git hash-object` is content-only (no side
+ * effects, no index touch), so it is safe from any worktree.
+ */
+function hashNodeFile(repoRoot: string, id: string): string {
+  return execFileSync("git", ["-C", repoRoot, "hash-object", `intentions/${id}.md`], {
+    encoding: "utf8",
+  }).trim();
+}
+
+/**
+ * Same hash, but for re-checking a manifest line this call did not produce.
+ * A node that has since been pruned cannot be hashed, and that is an expected
+ * outcome here rather than a broken environment — report it as "absent" so the
+ * caller can drop the entry and say why.
+ */
+function hashNodeFileIfPresent(repoRoot: string, id: string): string | null {
+  try {
+    return execFileSync("git", ["-C", repoRoot, "hash-object", `intentions/${id}.md`], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read an existing `base-manifest.txt` into id -> blobsha pairs, preserving
+ * line order. A line that is not `<id>=<blobsha>` is a corrupt manifest, not
+ * something to skip past: throw rather than quietly produce a thinner guard.
+ */
+function readManifest(manifestPath: string): Map<string, string> {
+  const entries = new Map<string, string>();
+  for (const raw of readFileSync(manifestPath, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (line === "") continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0 || eq === line.length - 1) {
+      throw new Error(
+        `dump-node: malformed line in existing manifest ${manifestPath}: ${JSON.stringify(line)} ` +
+          "(expected <id>=<blobsha>)",
+      );
+    }
+    entries.set(line.slice(0, eq), line.slice(eq + 1));
+  }
+  return entries;
+}
 
 /**
  * Dump each node in `ids` to JSON in `outDir` and write a base manifest of
@@ -47,23 +103,67 @@ const USAGE =
  * file — i.e. the exact content that was read — so `graph-commit --base` can
  * refuse the write if origin/main's blob has since moved.
  *
+ * The manifest is merged by id, not truncated:
+ *
+ * - An id named in THIS call always gets this call's freshly-read blob; an
+ *   existing line for that id is overwritten in place.
+ * - An id left over from an EARLIER call into the same out-dir is preserved
+ *   only if this call can still verify it — the node file on disk must still
+ *   hash to the blob the earlier line recorded. That is the whole claim a
+ *   manifest line makes ("this is the content that was read"), and it is the
+ *   only claim a later call is in a position to re-assert.
+ * - An unverifiable leftover is dropped with a loud stderr warning naming the
+ *   id. It is NOT carried forward: `graph-commit`'s `add_base_pair` accepts a
+ *   `--base` entry for any id with no membership check against the ids being
+ *   committed, and `check_base_freshness` iterates every entry independently —
+ *   so a stale blob for an unrelated, already-landed node makes graph-commit
+ *   attempt a three-way merge on that node and, on divergence, `park_and_exit`,
+ *   parking the write that was actually in flight. Silently unioning leftovers
+ *   would trade one silent failure for a worse one.
+ *
+ * The out-dir is therefore the dump scope: one out-dir holds the base tokens
+ * for one `graph-commit`. Unrelated writes must use separate out-dirs, and the
+ * ids for a single commit are best captured in a single call.
+ *
  * Returns the absolute manifest path.
  */
 export function dumpNodes(intentionsDir: string, repoRoot: string, outDir: string, ids: string[]): string {
   mkdirSync(outDir, { recursive: true });
-  const manifestLines: string[] = [];
+  const manifestPath = join(outDir, "base-manifest.txt");
+  const merged = new Map<string, string>();
+
+  if (existsSync(manifestPath)) {
+    const callIds = new Set(ids);
+    for (const [id, blob] of readManifest(manifestPath)) {
+      if (callIds.has(id)) {
+        // This call re-reads the node; reserve its line position and let the
+        // fresh read below supply the value.
+        merged.set(id, "");
+        continue;
+      }
+      const current = hashNodeFileIfPresent(repoRoot, id);
+      if (current === blob) {
+        merged.set(id, blob);
+        continue;
+      }
+      process.stderr.write(
+        `dump-node: dropping stale manifest entry '${id}' from ${manifestPath} — ` +
+          `intentions/${id}.md no longer matches the recorded base blob ${blob} ` +
+          `(now ${current ?? "absent"}). Its compare-and-swap guard is NOT in this manifest. ` +
+          "Capture every id a single graph-commit lands in one dump-node.ts call, " +
+          "and give unrelated writes their own --out-dir.\n",
+      );
+    }
+  }
+
   for (const id of ids) {
     const node = readNode(intentionsDir, id);
     writeFileSync(join(outDir, `${id}.json`), `${JSON.stringify(node, null, 2)}\n`);
-    // Blob sha of the file actually read. `git hash-object` is content-only
-    // (no side effects, no index touch), so it is safe from any worktree.
-    const blob = execFileSync("git", ["-C", repoRoot, "hash-object", `intentions/${id}.md`], {
-      encoding: "utf8",
-    }).trim();
-    manifestLines.push(`${id}=${blob}`);
+    merged.set(id, hashNodeFile(repoRoot, id));
   }
-  const manifestPath = join(outDir, "base-manifest.txt");
-  writeFileSync(manifestPath, `${manifestLines.join("\n")}\n`);
+
+  const lines = [...merged].map(([id, blob]) => `${id}=${blob}`);
+  writeFileSync(manifestPath, `${lines.join("\n")}\n`);
   return manifestPath;
 }
 

--- a/packages/intentionsutil/test/dump-node.test.ts
+++ b/packages/intentionsutil/test/dump-node.test.ts
@@ -1,0 +1,177 @@
+import { execFileSync } from "node:child_process";
+import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { dumpNodes } from "../scripts/dump-node.js";
+import { writeNodeFromJson } from "../scripts/write-node.js";
+
+/**
+ * `dumpNodes` shells out to `git -C <repoRoot> hash-object intentions/<id>.md`,
+ * so the fixture must be a real repo with a real `intentions/` directory. No
+ * commit is ever made, so no git identity is needed.
+ */
+function fixtureRepo(): { repoRoot: string; intentionsDir: string; outDir: string } {
+  const repoRoot = mkdtempSync(join(tmpdir(), "dump-node-"));
+  execFileSync("git", ["-C", repoRoot, "init", "-q", "-b", "main"]);
+  const intentionsDir = join(repoRoot, "intentions");
+  mkdirSync(intentionsDir, { recursive: true });
+  const outDir = join(repoRoot, "dump");
+  return { repoRoot, intentionsDir, outDir };
+}
+
+function seedNode(intentionsDir: string, id: string): void {
+  writeNodeFromJson(
+    intentionsDir,
+    JSON.stringify({
+      id,
+      kind: "tactic",
+      statement: `Statement for ${id}.`,
+      owner: "ai",
+      status: "codified",
+      parent: null,
+    }),
+  );
+}
+
+function manifestEntries(manifestPath: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of readFileSync(manifestPath, "utf8").split("\n")) {
+    if (line.trim() === "") continue;
+    const eq = line.indexOf("=");
+    out[line.slice(0, eq)] = line.slice(eq + 1);
+  }
+  return out;
+}
+
+/**
+ * Collect what `fn` writes to stderr. The chunks are gathered inside the mock
+ * because `mockRestore()` clears `mock.calls` along with the spy.
+ */
+function captureStderr<T>(fn: () => T): { result: T; warnings: string } {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write);
+  let result: T;
+  try {
+    result = fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return { result, warnings: chunks.join("") };
+}
+
+function blobOf(repoRoot: string, id: string): string {
+  return execFileSync("git", ["-C", repoRoot, "hash-object", `intentions/${id}.md`], {
+    encoding: "utf8",
+  }).trim();
+}
+
+describe("dumpNodes base manifest", () => {
+  it("writes one line per id for a single multi-id call", () => {
+    const { repoRoot, intentionsDir, outDir } = fixtureRepo();
+    seedNode(intentionsDir, "tactic-alpha");
+    seedNode(intentionsDir, "tactic-beta");
+
+    const manifestPath = dumpNodes(intentionsDir, repoRoot, outDir, ["tactic-alpha", "tactic-beta"]);
+
+    expect(manifestEntries(manifestPath)).toEqual({
+      "tactic-alpha": blobOf(repoRoot, "tactic-alpha"),
+      "tactic-beta": blobOf(repoRoot, "tactic-beta"),
+    });
+  });
+
+  // The defect: a second single-node dump into the same --out-dir used to
+  // truncate the manifest, so `graph-commit --base` guarded only the second id
+  // while the first landed with no compare-and-swap at all.
+  it("preserves the first id's line when a second single-node dump reuses the out-dir", () => {
+    const { repoRoot, intentionsDir, outDir } = fixtureRepo();
+    seedNode(intentionsDir, "tactic-alpha");
+    seedNode(intentionsDir, "tactic-beta");
+
+    dumpNodes(intentionsDir, repoRoot, outDir, ["tactic-alpha"]);
+    const manifestPath = dumpNodes(intentionsDir, repoRoot, outDir, ["tactic-beta"]);
+
+    expect(manifestEntries(manifestPath)).toEqual({
+      "tactic-alpha": blobOf(repoRoot, "tactic-alpha"),
+      "tactic-beta": blobOf(repoRoot, "tactic-beta"),
+    });
+    // Both JSON dumps survive too.
+    expect(() => readFileSync(join(outDir, "tactic-alpha.json"), "utf8")).not.toThrow();
+    expect(() => readFileSync(join(outDir, "tactic-beta.json"), "utf8")).not.toThrow();
+  });
+
+  it("overwrites only its own id's line, in place, when an id is dumped twice", () => {
+    const { repoRoot, intentionsDir, outDir } = fixtureRepo();
+    seedNode(intentionsDir, "tactic-alpha");
+    seedNode(intentionsDir, "tactic-beta");
+
+    dumpNodes(intentionsDir, repoRoot, outDir, ["tactic-alpha", "tactic-beta"]);
+    const alphaBlob = blobOf(repoRoot, "tactic-alpha");
+
+    // Re-read beta after its content moved; alpha is untouched.
+    appendFileSync(join(intentionsDir, "tactic-beta.md"), "\nAn appended paragraph.\n");
+    const manifestPath = dumpNodes(intentionsDir, repoRoot, outDir, ["tactic-beta"]);
+
+    const lines = readFileSync(manifestPath, "utf8").split("\n").filter((l) => l !== "");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe(`tactic-alpha=${alphaBlob}`);
+    expect(lines[1]).toBe(`tactic-beta=${blobOf(repoRoot, "tactic-beta")}`);
+  });
+
+  // A leftover id whose node file has moved on since the earlier dump cannot be
+  // re-asserted. Carrying it forward is what makes `graph-commit` attempt a
+  // three-way merge on an unrelated node and park the write actually in flight.
+  it("drops an unverifiable leftover entry and warns on stderr", () => {
+    const { repoRoot, intentionsDir, outDir } = fixtureRepo();
+    seedNode(intentionsDir, "tactic-alpha");
+    seedNode(intentionsDir, "tactic-beta");
+
+    dumpNodes(intentionsDir, repoRoot, outDir, ["tactic-alpha"]);
+    // Stand in for "an earlier graph-commit already landed an edit to alpha":
+    // its on-disk content no longer matches the recorded base blob.
+    appendFileSync(join(intentionsDir, "tactic-alpha.md"), "\nLanded by an earlier commit.\n");
+
+    const { result: manifestPath, warnings } = captureStderr(() =>
+      dumpNodes(intentionsDir, repoRoot, outDir, ["tactic-beta"]),
+    );
+
+    expect(manifestEntries(manifestPath)).toEqual({
+      "tactic-beta": blobOf(repoRoot, "tactic-beta"),
+    });
+    expect(warnings).toContain("tactic-alpha");
+    expect(warnings).toContain("dropping stale manifest entry");
+  });
+
+  it("drops a leftover entry whose node file no longer exists", () => {
+    const { repoRoot, intentionsDir, outDir } = fixtureRepo();
+    seedNode(intentionsDir, "tactic-alpha");
+    seedNode(intentionsDir, "tactic-beta");
+
+    dumpNodes(intentionsDir, repoRoot, outDir, ["tactic-alpha"]);
+    rmSync(join(intentionsDir, "tactic-alpha.md"));
+
+    const { result: manifestPath, warnings } = captureStderr(() =>
+      dumpNodes(intentionsDir, repoRoot, outDir, ["tactic-beta"]),
+    );
+
+    expect(manifestEntries(manifestPath)).toEqual({
+      "tactic-beta": blobOf(repoRoot, "tactic-beta"),
+    });
+    expect(warnings).toContain("absent");
+  });
+
+  it("throws on a corrupt existing manifest rather than silently thinning the guard", () => {
+    const { repoRoot, intentionsDir, outDir } = fixtureRepo();
+    seedNode(intentionsDir, "tactic-alpha");
+
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, "base-manifest.txt"), "not-a-pair\n");
+
+    expect(() => dumpNodes(intentionsDir, repoRoot, outDir, ["tactic-alpha"])).toThrow(
+      /malformed line in existing manifest/,
+    );
+  });
+});


### PR DESCRIPTION
Two integrity guards on the graph write path, surfaced while bootstrapping the
autonomous dispatch pipeline. Both are node-lane defects that fail *silently* —
one freezes a job, the other drops a compare-and-swap guard without erroring.

## 1. `/qa-fix`'s fix-finalize path declares its terminal disposition

`/qa-fix`'s node lane has three terminal paths. Clean-pass goes through
`transition-node` and escalation goes through `park-node`, both of which declare
internally. Step 3.7's **fix-finalize** path called only
`dispatch-mark-complete --phase qa` and declared nothing — so
`dispatch-self-close --node` never saw the `node-terminal` marker it requires
before reaping. The job stayed HELD and the node stayed claimed. Confirmed live
on PR #2985.

Adds `mark-node-terminal "$N" fix-attempt` as the last durable action of that
path, in both `references/auto-fix-lane.md` and its condensed `SKILL.md` mirror
so they do not drift. `fix-attempt` is the existing enum member for "a fix pass
spent an attempt (retry by design)" — this path's exact shape — so no enum
change.

Timing is load-bearing and stated in the inserted prose: `Stop` fires on every
turn yield, not only on terminal exit, so the declaration must follow the PR
comment, phase-log and outcome-envelope writes.

## 2. `dump-node.ts` merges `base-manifest.txt` by id instead of truncating it

The manifest was written with a truncating `writeFileSync`. A second single-node
dump into the same `--out-dir` left a manifest holding only the second id, and
`graph-commit --base` then guarded that one node while the others landed with
**no** compare-and-swap.

A naive union would be worse than the bug. `graph-commit`'s `add_base_pair`
accepts a `--base` entry for any id with no membership check, and
`check_base_freshness` iterates the base map independently — so a stale entry for
an unrelated node reaches `park_and_exit`, which parks the commit's **own** ids,
aborting the legitimate write in flight.

So the merge re-verifies rather than unions: an id named in this call gets this
call's fresh blob; a leftover from an earlier call survives only if its recorded
blob still matches the node file on disk. Unverifiable leftovers are dropped with
a stderr warning naming the id, and a malformed manifest line throws rather than
silently thinning the guard.

Also gives the live double-call sites distinct `--out-dir`s:

- `fix-checks` — the firing case: the flake tactic's `graph-commit` has already
  moved the blob by the time the second dump runs.
- `dispatch-conflict` — same `$SCRATCH` used twice.
- `align-tactics/references/write-path.md` — alternatives, not sequential, so the
  recipes keep their shape and gain a caution that one call must name every id
  the commit will land.

## Tests

`packages/intentionsutil/test/dump-node.test.ts` is new — the first coverage of
`dumpNodes` at all. Six cases, including the two-call case, in-place overwrite,
the dropped unverifiable leftover, and the malformed-manifest throw.

Run locally, all green:

- `npx vitest run --project packages/intentionsutil --root .` — 38 files, 711 tests
- `packages/intentionsutil/scripts/test-graph-commit.sh` — 43 passed
- `.claude/skills/dispatch-propagate/scripts/test-resolve-hold.sh` — 56/56
- `.claude/skills/dispatch-propagate/scripts/test-graph-write-rollback.sh` — 4 passed
- `run-lint.sh` — no matching targets

## Out of scope

- `park-node`'s early-arming hazard.
- Unit 2 of `tactic-qa-fix-node-terminal-declaration` (the mechanical coverage
  guard) — stays a graph node.
- A second undeclaring terminal lane found by audit: `/dispatch-conflict` Lane 2's
  `resolved` path calls only `dispatch-mark-complete` and never declares. It is
  phase-agnostic and **not reachable by the autonomous fleet** (only Lane 3 is
  auto-spawned), so it strands nothing today. Reported, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
