### PR TITLE
Ratchet the fix-checks node-lane CAS guard with a regression test

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -33442,10 +33442,23 @@ echo "=== fix-checks: node-lane completion recipes --base CAS guard ==="
 # refresh-then---base pattern was landed by PR #2939 and is tracked by
 # tactic-graph-write-recipes-base-cas and tactic-fix-checks-pushed-nothing-base.
 #
-# If a count below legitimately changes (e.g. a new completion recipe is
-# added), update the expected number here AND confirm every recipe still
-# carries the full refresh + --base sequence — never lower a count just to
-# make this suite green.
+# The guard binds each key to the recipe it protects: it extracts every
+# ```bash fence in the skill that spends an attempt (that is what makes a
+# fence a node-lane completion recipe) and asserts that fence carries the
+# WHOLE documented sequence exactly once —
+#
+#   1. git fetch origin main            (refresh the remote-tracking ref)
+#   2. FRESH_BLOB=$(git rev-parse …)    (capture the CAS base blob)
+#   3. git show origin/main:… > …       (refresh the working file)
+#   4. graph-commit --base "$N=…"       (pin the write to that base)
+#
+# A file-global occurrence count would let the totals stay correct while one
+# recipe is left unguarded — exactly the regression this exists to catch — so
+# the per-recipe report below is the assertion, not a count.
+#
+# If the expectation below legitimately changes (e.g. a new completion recipe
+# is added), add its row here AND confirm every recipe still carries all four
+# steps — never drop a row or a step just to make this suite green.
 
 FIXCHECKS_GUARD_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
 FIXCHECKS_GUARD_SKILL="$FIXCHECKS_GUARD_ROOT/.claude/skills/fix-checks/SKILL.md"
@@ -33454,14 +33467,30 @@ if [[ ! -f "$FIXCHECKS_GUARD_SKILL" ]]; then
   TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
   echo "  FAIL: fix-checks CAS guard: file missing: .claude/skills/fix-checks/SKILL.md"
 else
-  actual=$({ grep -cF -- '--base "$N=$FRESH_BLOB"' "$FIXCHECKS_GUARD_SKILL" || true; })
-  assert_eq "fix-checks CAS guard: --base \"\$N=\$FRESH_BLOB\" count" "2" "$actual"
-
-  actual=$({ grep -cF -- 'FRESH_BLOB="$(git rev-parse "origin/main:intentions/$N.md"' "$FIXCHECKS_GUARD_SKILL" || true; })
-  assert_eq "fix-checks CAS guard: FRESH_BLOB=\$(git rev-parse origin/main:intentions/\$N.md count" "2" "$actual"
-
-  actual=$({ grep -cF -- 'git show "origin/main:intentions/$N.md" > "intentions/$N.md"' "$FIXCHECKS_GUARD_SKILL" || true; })
-  assert_eq "fix-checks CAS guard: git show origin/main:intentions/\$N.md refresh count" "2" "$actual"
+  actual=$(awk '
+    function countsub(hay, needle,   c, p) {
+      c = 0
+      while ((p = index(hay, needle)) > 0) { c++; hay = substr(hay, p + length(needle)) }
+      return c
+    }
+    /^[[:space:]]*```bash[[:space:]]*$/ { inblock = 1; buf = ""; next }
+    inblock && /^[[:space:]]*```[[:space:]]*$/ {
+      inblock = 0
+      if (index(buf, "--spend-attempt") > 0) {
+        n += 1
+        printf "recipe %d: fetch=%d rev-parse=%d show=%d base=%d\n", n,
+          countsub(buf, "git fetch origin main >&2"),
+          countsub(buf, "FRESH_BLOB=\"$(git rev-parse \"origin/main:intentions/$N.md\""),
+          countsub(buf, "git show \"origin/main:intentions/$N.md\" > \"intentions/$N.md\""),
+          countsub(buf, "--base \"$N=$FRESH_BLOB\"")
+      }
+      next
+    }
+    inblock { buf = buf $0 "\n" }
+  ' "$FIXCHECKS_GUARD_SKILL")
+  assert_eq "fix-checks CAS guard: each attempt-spending recipe carries fetch + rev-parse + show + --base" \
+    'recipe 1: fetch=1 rev-parse=1 show=1 base=1
+recipe 2: fetch=1 rev-parse=1 show=1 base=1' "$actual"
 
   # Tripwire: forces a deliberate revisit of the guard when a new graph-commit
   # call site is added to this file (2 completion-seam invocations + 3 on the

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh
@@ -33428,6 +33428,49 @@ unset REPO_HEALTH_STATE_FILE
 teardown
 
 # ============================================================================
+# fix-checks: node-lane completion recipes carry the graph-write --base CAS
+# guard (tactic-graph-write-recipes-base-cas / tactic-fix-checks-pushed-nothing-base)
+# ============================================================================
+echo "=== fix-checks: node-lane completion recipes --base CAS guard ==="
+#
+# The two node-lane completion recipes (record-push and pushed-nothing) in
+# .claude/skills/fix-checks/SKILL.md must each refresh intentions/$N.md from
+# origin/main and pass graph-commit --base before writing. graph-commit does
+# whole-file replacement of intentions/<id>.md, so an unpinned write from a
+# stale worktree silently reverts sibling frontmatter another writer landed
+# concurrently — this happened for real on 2026-07-22 on PR #2927. The
+# refresh-then---base pattern was landed by PR #2939 and is tracked by
+# tactic-graph-write-recipes-base-cas and tactic-fix-checks-pushed-nothing-base.
+#
+# If a count below legitimately changes (e.g. a new completion recipe is
+# added), update the expected number here AND confirm every recipe still
+# carries the full refresh + --base sequence — never lower a count just to
+# make this suite green.
+
+FIXCHECKS_GUARD_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+FIXCHECKS_GUARD_SKILL="$FIXCHECKS_GUARD_ROOT/.claude/skills/fix-checks/SKILL.md"
+
+if [[ ! -f "$FIXCHECKS_GUARD_SKILL" ]]; then
+  TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+  echo "  FAIL: fix-checks CAS guard: file missing: .claude/skills/fix-checks/SKILL.md"
+else
+  actual=$({ grep -cF -- '--base "$N=$FRESH_BLOB"' "$FIXCHECKS_GUARD_SKILL" || true; })
+  assert_eq "fix-checks CAS guard: --base \"\$N=\$FRESH_BLOB\" count" "2" "$actual"
+
+  actual=$({ grep -cF -- 'FRESH_BLOB="$(git rev-parse "origin/main:intentions/$N.md"' "$FIXCHECKS_GUARD_SKILL" || true; })
+  assert_eq "fix-checks CAS guard: FRESH_BLOB=\$(git rev-parse origin/main:intentions/\$N.md count" "2" "$actual"
+
+  actual=$({ grep -cF -- 'git show "origin/main:intentions/$N.md" > "intentions/$N.md"' "$FIXCHECKS_GUARD_SKILL" || true; })
+  assert_eq "fix-checks CAS guard: git show origin/main:intentions/\$N.md refresh count" "2" "$actual"
+
+  # Tripwire: forces a deliberate revisit of the guard when a new graph-commit
+  # call site is added to this file (2 completion-seam invocations + 3 on the
+  # flake-tracking path, as of PR #2939).
+  actual=$({ grep -cF -- 'packages/intentionsutil/scripts/graph-commit' "$FIXCHECKS_GUARD_SKILL" || true; })
+  assert_eq "fix-checks CAS guard: packages/intentionsutil/scripts/graph-commit call-site count" "5" "$actual"
+fi
+
+# ============================================================================
 # summary
 # ============================================================================
 report_results


### PR DESCRIPTION
Implements the graph node `tactic-fix-checks-pushed-nothing-base`.

## Context

`graph-commit` does whole-file replacement of `intentions/<id>.md`. A
completion recipe that reads/mutates/writes the LOCAL node file without first
refreshing it from `origin/main` silently reverts any sibling frontmatter
field another writer landed in the meantime — no textual conflict, no error.
PR #2939 already brought both fix-checks node-lane completion recipes
(record-push and pushed-nothing) up to the `graph-commit --base` CAS-guard
standard, going beyond that PR's own stated plan scope.

This node was filed as the residual of `tactic-graph-write-recipes-base-cas`,
which had explicitly declared the pushed-nothing branch out of scope. Re-
verification against `origin/main` at the time this node was written
(`b552dfa2`) found the residual already closed by PR #2939 — so the code edit
named by this node's statement was a no-op. What was still missing was
durability: nothing in the repo recorded the guard as intentional, so a future
edit could silently drop `--base` or the refresh from either recipe and every
CI check would stay green.

## Changes

- **Unit 1** — re-verified the CAS guard is present in both node-lane
  completion recipes in `.claude/skills/fix-checks/SKILL.md`. All three guard
  markers report the expected count of 2 (one per recipe); no regression since
  PR #2939, so no code changes were needed here.
- **Unit 2** — added a doctrine-ratchet test section to
  `.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh`
  (modeled on the existing EnterWorktree/ExitWorktree mid-session guard),
  asserting exact counts for the CAS-guard markers (2 each) and the total
  `graph-commit` call-site count in that file (5). A future edit that drops
  the guard from either recipe, or adds an unaudited new `graph-commit` call
  site, now fails CI instead of passing silently.

## Test plan

- [x] `.claude/skills/dispatch-propagate/scripts/test-dispatch-scripts.sh` —
      3223/3223 passed, 0 failed (was 3219/3219 before the 4 new assertions)
- [x] `.claude/skills/dispatch-propagate/scripts/run-lint.sh` — clean
- [x] `npx tsx packages/intentionsutil/scripts/validate-graph.ts` — clean
- [x] Manually confirmed the new assertions are load-bearing by reading both
      completion recipes end-to-end: `HEAD_SHA` is captured before the
      `origin/main` refresh overwrites `intentions/$N.md` in the record-push
      recipe, and both recipes call the correct
      `packages/intentionsutil/scripts/graph-commit` path (not the
      nonexistent pre-#2939 `dispatch-propagate/scripts/graph-commit` path)
