### PR TITLE
graph-commit --expect repo-targeting assertion; clear-park --base pin; clear-park/resolve-park test coverage

### DIFF
--- a/packages/intentionsutil/scripts/clear-park
+++ b/packages/intentionsutil/scripts/clear-park
@@ -44,11 +44,13 @@
 # assert_clean_outside_ids guard for every other unrelated node in that
 # worktree.
 #
-# Usage: clear-park <node-id> [note]
+# Usage: clear-park [--base <blobsha>|<id>=<blobsha>|<manifest-file>] <node-id> [note]
 #
 # Exit codes: 0 cleared and landed on main (or already-clear no-op); 1 the
 # write, the origin/main refresh, or graph-commit failed (including a refused
-# stale-base compare-and-swap); 2 usage error.
+# stale-base compare-and-swap); 2 usage error (including a malformed or
+# unresolvable --base); 3 the supplied --base no longer matches origin/main
+# (stale-diagnosis) — nothing was written.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -56,12 +58,82 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 INTENTIONS_DIR="$REPO_ROOT/intentions"
 STORE_MODULE="$REPO_ROOT/packages/intentionsutil/src/store.js"
 
-NODE_ID="${1:-}"
+USAGE="usage: clear-park [--base <blobsha>|<id>=<blobsha>|<manifest-file>] <node-id> [note]"
+
+# Leading-flags-only parse: consume flags while the current arg starts with
+# `--`; the first non-flag argument ends flag parsing and every remaining
+# argument is positional VERBATIM (no re-scan for flags — <node-id> and
+# <note> are free text that may start with `-`).
+BASE_ARG=""
+ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo "$USAGE" >&2
+        exit 2
+      fi
+      BASE_ARG="$1"
+      shift
+      ;;
+    --base=*)
+      BASE_ARG="${1#--base=}"
+      shift
+      ;;
+    --*)
+      echo "$USAGE" >&2
+      exit 2
+      ;;
+    *)
+      # First non-flag argument: stop flag parsing, take everything verbatim.
+      ARGS=("$@")
+      break
+      ;;
+  esac
+done
+
+NODE_ID="${ARGS[0]:-}"
 # Optional 2nd arg: free-text note folded into the commit message.
-NOTE="${2:-}"
-if [[ $# -lt 1 || $# -gt 2 || -z "$NODE_ID" ]]; then
-  echo "usage: clear-park <node-id> [note]" >&2
+NOTE="${ARGS[1]:-}"
+if [[ ${#ARGS[@]} -lt 1 || ${#ARGS[@]} -gt 2 || -z "$NODE_ID" ]]; then
+  echo "$USAGE" >&2
   exit 2
+fi
+
+# Resolve --base (if supplied) to a 40-hex blob sha, before any network call,
+# so a malformed base is a cheap usage error rather than a mid-flight failure.
+PINNED_BASE=""
+if [[ -n "$BASE_ARG" ]]; then
+  if [[ -f "$BASE_ARG" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      [[ -z "$line" ]] && continue
+      line_id="${line%%=*}"
+      line_sha="${line#*=}"
+      if [[ "$line_id" == "$NODE_ID" ]]; then
+        PINNED_BASE="$line_sha"
+        break
+      fi
+    done <"$BASE_ARG"
+    if [[ -z "$PINNED_BASE" ]]; then
+      echo "clear-park: manifest '$BASE_ARG' has no entry for node id '$NODE_ID'" >&2
+      exit 2
+    fi
+  elif [[ "$BASE_ARG" == *=* ]]; then
+    pair_id="${BASE_ARG%%=*}"
+    pair_sha="${BASE_ARG#*=}"
+    if [[ "$pair_id" != "$NODE_ID" ]]; then
+      echo "clear-park: --base id '$pair_id' does not match node id '$NODE_ID'" >&2
+      exit 2
+    fi
+    PINNED_BASE="$pair_sha"
+  else
+    PINNED_BASE="$BASE_ARG"
+  fi
+  if [[ ! "$PINNED_BASE" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "clear-park: --base resolved to '$PINNED_BASE', not a full 40-hex blob sha" >&2
+    exit 2
+  fi
 fi
 
 TMPTS="$(mktemp --suffix=.mts)" \
@@ -124,6 +196,17 @@ if ! FRESH_BLOB="$(git -C "$REPO_ROOT" rev-parse "origin/main:intentions/$NODE_I
   echo "clear-park: intentions/$NODE_ID.md does not exist on origin/main — cannot clear a park on a node that is not landed" >&2
   exit 1
 fi
+
+# The pin check runs before ANY mutation — before the local-file overwrite
+# below and before MUTATED is set to 1. The temp files and the EXIT trap
+# already exist at this point (mktemp'd above, before the fetch), but the
+# trap's restore is a no-op while MUTATED is still 0, and the node file itself
+# has not been touched, so a stale pin has zero side effects to roll back.
+if [[ -n "$PINNED_BASE" && "$PINNED_BASE" != "$FRESH_BLOB" ]]; then
+  echo "clear-park: stale-diagnosis — intentions/$NODE_ID.md on origin/main is now $FRESH_BLOB but the pinned --base is $PINNED_BASE; the node changed between diagnosis and execution. Re-read the node, re-decide the disposition, and retry with a freshly captured base. Nothing was written." >&2
+  exit 3
+fi
+
 MUTATED=1
 if ! git -C "$REPO_ROOT" show "origin/main:intentions/$NODE_ID.md" > "$INTENTIONS_DIR/$NODE_ID.md"; then
   echo "clear-park: could not refresh intentions/$NODE_ID.md from origin/main" >&2

--- a/packages/intentionsutil/scripts/clear-park
+++ b/packages/intentionsutil/scripts/clear-park
@@ -160,6 +160,15 @@ elif [[ $npx_status -ne 0 ]]; then
   exit 1
 fi
 
+# EXPECT_BLOB captures the blob this script just wrote to intentions/$NODE_ID.md
+# under its OWN REPO_ROOT, for graph-commit's --expect guard below. Hashing
+# failure is genuine environment breakage — fail loudly rather than omitting
+# --expect (code-style.md).
+if ! EXPECT_BLOB="$(git -C "$REPO_ROOT" hash-object -- "intentions/$NODE_ID.md" 2>/dev/null)"; then
+  echo "clear-park: could not hash intentions/$NODE_ID.md after the office_hours clear" >&2
+  exit 1
+fi
+
 if [[ -n "$NOTE" ]]; then
   MESSAGE="graph: clear office_hours park on $NODE_ID ($NOTE)"
 else
@@ -178,7 +187,10 @@ fi
 # changes to stage" branch, and prints "landed ... on main" / exits 0 having
 # committed nothing -- leaving the real edit dirty and unpushed in the other
 # checkout. Mirrors park-node, which already passes -C for the same reason.
-if ! "$SCRIPT_DIR/graph-commit" -C "$REPO_ROOT" --base "$NODE_ID=$FRESH_BLOB" -m "$MESSAGE" "$NODE_ID"; then
+# --expect is the second half of the same guarantee: -C points graph-commit at
+# the right checkout, and --expect proves the content this script wrote is
+# really there by asserting the on-disk blob matches EXPECT_BLOB.
+if ! "$SCRIPT_DIR/graph-commit" -C "$REPO_ROOT" --base "$NODE_ID=$FRESH_BLOB" --expect "$NODE_ID=$EXPECT_BLOB" -m "$MESSAGE" "$NODE_ID"; then
   echo "clear-park: graph-commit failed for $NODE_ID; the office_hours write was rolled back" >&2
   exit 1
 fi

--- a/packages/intentionsutil/scripts/clear-park
+++ b/packages/intentionsutil/scripts/clear-park
@@ -65,6 +65,13 @@ USAGE="usage: clear-park [--base <blobsha>|<id>=<blobsha>|<manifest-file>] <node
 # argument is positional VERBATIM (no re-scan for flags — <node-id> and
 # <note> are free text that may start with `-`).
 BASE_ARG=""
+# Flag PRESENCE is tracked separately from the flag's VALUE: an explicitly
+# supplied but empty base (`--base ''` / `--base=`) must be a usage error, not
+# a silent degradation to an unpinned clear. Gating the resolver on
+# `-n "$BASE_ARG"` alone would make that case indistinguishable from omitting
+# the flag, quietly dropping the compare-and-swap guarantee the caller asked
+# for (.claude/skills/ref-diagnosis-time-cas/SKILL.md).
+BASE_SUPPLIED=0
 ARGS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -75,10 +82,12 @@ while [[ $# -gt 0 ]]; do
         exit 2
       fi
       BASE_ARG="$1"
+      BASE_SUPPLIED=1
       shift
       ;;
     --base=*)
       BASE_ARG="${1#--base=}"
+      BASE_SUPPLIED=1
       shift
       ;;
     --*)
@@ -104,7 +113,11 @@ fi
 # Resolve --base (if supplied) to a 40-hex blob sha, before any network call,
 # so a malformed base is a cheap usage error rather than a mid-flight failure.
 PINNED_BASE=""
-if [[ -n "$BASE_ARG" ]]; then
+if [[ $BASE_SUPPLIED -eq 1 && -z "$BASE_ARG" ]]; then
+  echo "clear-park: --base requires a non-empty <blobsha>|<id>=<blobsha>|<manifest-file> value" >&2
+  exit 2
+fi
+if [[ $BASE_SUPPLIED -eq 1 ]]; then
   if [[ -f "$BASE_ARG" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
       [[ -z "$line" ]] && continue
@@ -270,9 +283,16 @@ fi
 # changes to stage" branch, and prints "landed ... on main" / exits 0 having
 # committed nothing -- leaving the real edit dirty and unpushed in the other
 # checkout. Mirrors park-node, which already passes -C for the same reason.
-# --expect is the second half of the same guarantee: -C points graph-commit at
-# the right checkout, and --expect proves the content this script wrote is
-# really there by asserting the on-disk blob matches EXPECT_BLOB.
+#
+# --expect does NOT add a second, independent check on -C from this call site:
+# EXPECT_BLOB is hashed under the same "$REPO_ROOT" that is passed as -C, so
+# the assertion is self-satisfying whenever -C resolves to the tree this script
+# wrote. What it buys here is narrower: it asserts graph-commit's
+# `git rev-parse --show-toplevel` resolution of -C lands on the same tree this
+# script wrote to (they can differ if REPO_ROOT is not itself a git toplevel),
+# and it guards against a concurrent writer touching intentions/$NODE_ID.md
+# between the hash above and graph-commit's staging. See park-node's fuller
+# note at the same call site.
 if ! "$SCRIPT_DIR/graph-commit" -C "$REPO_ROOT" --base "$NODE_ID=$FRESH_BLOB" --expect "$NODE_ID=$EXPECT_BLOB" -m "$MESSAGE" "$NODE_ID"; then
   echo "clear-park: graph-commit failed for $NODE_ID; the office_hours write was rolled back" >&2
   exit 1

--- a/packages/intentionsutil/scripts/dump-node.ts
+++ b/packages/intentionsutil/scripts/dump-node.ts
@@ -113,7 +113,7 @@ function readManifest(manifestPath: string): Map<string, string> {
  *   manifest line makes ("this is the content that was read"), and it is the
  *   only claim a later call is in a position to re-assert.
  * - An unverifiable leftover is dropped with a loud stderr warning naming the
- *   id. It is NOT carried forward: `graph-commit`'s `add_base_pair` accepts a
+ *   id. It is NOT carried forward: `graph-commit`'s `add_blob_pair` accepts a
  *   `--base` entry for any id with no membership check against the ids being
  *   committed, and `check_base_freshness` iterates every entry independently —
  *   so a stale blob for an unrelated, already-landed node makes graph-commit

--- a/packages/intentionsutil/scripts/graph-commit
+++ b/packages/intentionsutil/scripts/graph-commit
@@ -29,7 +29,7 @@
 # retries, and deletes it on every exit path).
 #
 # Usage:
-#   graph-commit [-C <repo-path>] [-m <message>] [--prune <id>]... [--base <id>=<blobsha>|<manifest-file>]... <node-id> [<node-id> ...]
+#   graph-commit [-C <repo-path>] [-m <message>] [--prune <id>]... [--base <id>=<blobsha>|<manifest-file>]... [--expect <id>=<blobsha>|<manifest-file>]... <node-id> [<node-id> ...]
 #   graph-commit -m 'graph: seed dispatch state' tactic-graph-commit
 #   graph-commit -C /path/to/worktree -m 'graph: land edit' tactic-foo
 #
@@ -49,6 +49,24 @@
 #   pair per line): optional compare-and-swap freshness check. If any entry's
 #   blob no longer matches origin/main after a fetch, the write is refused
 #   before any local commit is made. Omit entirely to keep pre-CAS behavior.
+#
+# --expect <id>=<blobsha> (repeatable) or --expect <manifest-file> (one
+#   <id>=<sha> pair per line): optional wrong-repo assertion. The sha is the
+#   blob of the content the caller WROTE — `git hash-object -- intentions/<id>.md`
+#   run in the caller's OWN checkout after its edit. Before any tree mutation,
+#   graph-commit hashes the same path in the repo it resolved (-C/--repo, else
+#   cwd) and refuses to land on a mismatch.
+#
+#   --base and --expect assert different things and are not interchangeable:
+#   --base asserts the PRE-edit blob against origin/main (a freshness /
+#   compare-and-swap check about concurrent writers), while --expect asserts the
+#   POST-edit blob against the resolved checkout (a targeting check about WHICH
+#   repo this invocation is committing). Only --expect can catch a wrong-repo
+#   invocation whose blob happens to equal origin/main: the nothing-staged guard
+#   below only fires when the wrong repo's blob DIFFERS from origin/main, so a
+#   wrong repo that is merely in sync with origin/main slips through it and
+#   reports a false "landed" while the caller's real edit sits dirty elsewhere.
+#   Omit entirely to keep pre-assertion behavior.
 #
 # Exit status — four observable outcomes across rc 0 and rc 1:
 #   0  the edit landed on main. Two sub-cases, distinguished only by a log line
@@ -140,6 +158,9 @@ LOCK_WAIT_SECONDS="${GRAPH_COMMIT_LOCK_WAIT_SECONDS:-$((MAX_PUSH_ATTEMPTS * (CHE
 # BASE        — optional --base compare-and-swap manifest: node id -> the blob
 #               SHA the caller read it at (git hash-object at read time).
 #               Empty unless --base was passed; empty means skip the check.
+# EXPECT_BLOB — optional --expect assertion manifest: node id -> the blob SHA of
+#               the content the caller WROTE (git hash-object after its edit).
+#               Empty unless --expect was passed.
 # EXPECTED    — associative set of the exact staged paths we permit.
 # SNAP_DIR    — tempdir holding the on-disk node content we are trying to land.
 # KEEP_SNAP   — 1 when SNAP_DIR must survive exit (the fail-closed conflict
@@ -150,6 +171,7 @@ declare -a IDS=()
 declare -a PRUNE_IDS=()
 declare -a ALL_IDS=()
 declare -A BASE=()
+declare -A EXPECT_BLOB=()
 declare -A EXPECTED=()
 SNAP_DIR=""
 KEEP_SNAP=0
@@ -203,7 +225,7 @@ die() {
 }
 
 usage() {
-  echo "usage: graph-commit [-C <repo-path>] [-m <message>] [--prune <id>]... [--base <id>=<blobsha>|<manifest-file>]... <node-id> [<node-id> ...]" >&2
+  echo "usage: graph-commit [-C <repo-path>] [-m <message>] [--prune <id>]... [--base <id>=<blobsha>|<manifest-file>]... [--expect <id>=<blobsha>|<manifest-file>]... <node-id> [<node-id> ...]" >&2
 }
 
 # --- Prune / base id helpers -------------------------------------------------
@@ -227,32 +249,85 @@ validate_id_chars() {
   esac
 }
 
-# Record one <id>=<blobsha> pair into BASE.
-add_base_pair() {
-  local pair="$1" id sha
+# Record one <id>=<blobsha> pair into the named associative array (BASE for
+# --base, EXPECT_BLOB for --expect). The target array is passed BY NAME and
+# bound with a bash nameref (requires bash 4.3; the script already requires
+# bash 4 for `declare -A`), so --base and --expect share one parser instead of
+# maintaining two copies that can drift.
+add_blob_pair() { # <array-name> <flag-name> <pair>
+  local -n _target="$1"
+  local flag="$2" pair="$3" id sha
   id="${pair%%=*}"
   sha="${pair#*=}"
   if [[ -z "$id" || "$id" == "$pair" || -z "$sha" ]]; then
-    die "invalid --base entry '$pair' (expected <id>=<blobsha>)"
+    die "invalid $flag entry '$pair' (expected <id>=<blobsha>)"
   fi
-  BASE["$id"]="$sha"
+  _target["$id"]="$sha"
 }
 
-# A --base argument is either a literal <id>=<blobsha> pair or, when it names
-# an existing file, a manifest of such pairs (one per line, blank lines
-# ignored) — so a caller holding a whole dump's worth of base shas can pass
-# one flag instead of one --base per node.
-parse_base_arg() {
-  local arg="$1"
+# A --base/--expect argument is either a literal <id>=<blobsha> pair or, when it
+# names an existing file, a manifest of such pairs (one per line, blank lines
+# ignored) — so a caller holding a whole dump's worth of blob shas can pass one
+# flag instead of one flag per node.
+parse_blob_arg() { # <array-name> <flag-name> <arg>
+  local arr="$1" flag="$2" arg="$3"
   if [[ -f "$arg" ]]; then
     local line
     while IFS= read -r line || [[ -n "$line" ]]; do
       [[ -z "$line" ]] && continue
-      add_base_pair "$line"
+      add_blob_pair "$arr" "$flag" "$line"
     done <"$arg"
   else
-    add_base_pair "$arg"
+    add_blob_pair "$arr" "$flag" "$arg"
   fi
+}
+
+# --- Wrong-repo assertion (--expect) ----------------------------------------
+# Assert that the repo this invocation RESOLVED actually holds the content the
+# caller wrote. The caller computes `git hash-object -- intentions/<id>.md` in
+# its OWN checkout after its edit and passes it as --expect <id>=<sha>; here we
+# hash the same path in REPO_ROOT and compare.
+#
+# Why this exists on top of the nothing-staged guard in main(): that guard only
+# fires when the wrongly-targeted repo's blob DIFFERS from origin/main. When the
+# wrong repo happens to be in sync with origin/main — the common case for an
+# idle checkout — both blobs are equal, the guard passes, and graph-commit
+# reports a false "landed" while the caller's real edit sits dirty in a
+# different checkout. --expect closes that hole because it asserts the caller's
+# POST-edit content, independent of any pre-edit or origin/main state.
+#
+# Ordering is load-bearing: this must run before check_base_freshness (layer 3's
+# auto-merge overwrites $INTENTIONS_DIR/$id.md on disk) and before
+# ensure_intentions_only_base (which can `git reset --hard` the tree). Later
+# would hash content graph-commit itself rewrote, not the caller's.
+#
+# Opt-in: no --expect means no behavior change for existing callers.
+assert_expected_content() {
+  [[ "${#EXPECT_BLOB[@]}" -eq 0 ]] && return 0
+  local id
+  # Pass 1 — validation. A --prune is a deletion: there is no content to
+  # assert, so pinning one is a usage error (exit 2, like the other argument
+  # validators; die() would exit 1). Keys naming neither an ordinary id nor a
+  # prune id are ignored, matching --base manifest semantics where one batch
+  # manifest may cover more nodes than a given invocation commits.
+  for id in "${!EXPECT_BLOB[@]}"; do
+    if is_prune_id "$id"; then
+      echo "error: graph-commit: --expect $id=... names a --prune id — a deletion has no content to assert" >&2
+      exit 2
+    fi
+  done
+  # Pass 2 — assertion over the ordinary edit ids only. main() has already
+  # cd'd to REPO_ROOT, so the repo-relative path is correct.
+  local sha actual
+  for id in "${IDS[@]}"; do
+    sha="${EXPECT_BLOB[$id]:-}"
+    [[ -z "$sha" ]] && continue
+    actual="$(git hash-object -- "intentions/$id.md")" \
+      || die "could not hash intentions/$id.md in the resolved repo ($REPO_ROOT)"
+    if [[ "$actual" != "$sha" ]]; then
+      die "the resolved repo ($REPO_ROOT) does not hold the content the caller asserted for intentions/$id.md (--expect $sha, on disk $actual) — the edit was made in a DIFFERENT checkout: mis-pointed -C/--repo (or cwd targeting the wrong checkout). Refusing to land."
+    fi
+  done
 }
 
 # Reconcile each --base entry against origin/main after a fetch. If an entry's
@@ -1319,7 +1394,9 @@ main() {
       --prune) [[ $# -ge 2 ]] || { usage; die "--prune requires a node id argument"; }
                PRUNE_IDS+=("$2"); shift 2 ;;
       --base) [[ $# -ge 2 ]] || { usage; die "--base requires an <id>=<blobsha> argument or a manifest file path"; }
-              parse_base_arg "$2"; shift 2 ;;
+              parse_blob_arg BASE --base "$2"; shift 2 ;;
+      --expect) [[ $# -ge 2 ]] || { usage; die "--expect requires an <id>=<blobsha> argument or a manifest file path"; }
+                parse_blob_arg EXPECT_BLOB --expect "$2"; shift 2 ;;
       -h|--help) usage; exit 0 ;;
       --) shift; while [[ $# -gt 0 ]]; do IDS+=("$1"); shift; done ;;
       -*) usage; echo "error: graph-commit: unknown option '$1'" >&2; exit 2 ;;
@@ -1411,6 +1488,12 @@ main() {
   # `git reset --hard`; the guard must run ahead of it so a stray dirty file is
   # surfaced (and named) rather than silently discarded.
   assert_clean_outside_ids
+
+  # Wrong-repo assertion (opt-in via --expect). MUST run here: before
+  # check_base_freshness (whose layer-3 auto-merge rewrites node files on disk)
+  # and before ensure_intentions_only_base (which can `git reset --hard` the
+  # tree). Running it any later would hash content graph-commit itself wrote.
+  assert_expected_content
 
   # Capture the writer's intended on-disk content BEFORE check_base_freshness.
   # Layer 3's stale-base park (park_and_exit, reached from inside

--- a/packages/intentionsutil/scripts/park-node
+++ b/packages/intentionsutil/scripts/park-node
@@ -260,7 +260,25 @@ if ! (cd "$REPO_ROOT" && npx tsx "$TMPTS" "$STORE_MODULE" "$INTENTIONS_DIR" "$SI
   exit 1
 fi
 
-if ! "$SCRIPT_DIR/graph-commit" -C "$REPO_ROOT" --base "$NODE_ID=$FRESH_BLOB" -m "graph: park $NODE_ID ($REASON)" "$NODE_ID"; then
+# EXPECT_BLOB captures the blob this script just wrote to intentions/$NODE_ID.md
+# under its OWN REPO_ROOT, for graph-commit's --expect guard below. Hashing
+# failure is genuine environment breakage — fail loudly rather than omitting
+# --expect (code-style.md).
+if ! EXPECT_BLOB="$(git -C "$REPO_ROOT" hash-object -- "intentions/$NODE_ID.md" 2>/dev/null)"; then
+  echo "park-node: could not hash intentions/$NODE_ID.md after the office_hours write" >&2
+  exit 1
+fi
+
+# -C "$REPO_ROOT" is mandatory, not cosmetic: this script's REPO_ROOT is derived
+# from SCRIPT_DIR (its own on-disk location), and the office_hours write above
+# targets "$INTENTIONS_DIR" under THAT repo, while graph-commit resolves its own
+# repo from -C if given, else from cwd. Callers routinely invoke the main
+# checkout's copy of this script by absolute path from inside a worktree, so
+# without -C the two would resolve to DIFFERENT checkouts. --expect is the
+# second half of the same guarantee: -C points graph-commit at the right
+# checkout, and --expect proves the content this script wrote is really there
+# by asserting the on-disk blob matches EXPECT_BLOB.
+if ! "$SCRIPT_DIR/graph-commit" -C "$REPO_ROOT" --base "$NODE_ID=$FRESH_BLOB" --expect "$NODE_ID=$EXPECT_BLOB" -m "graph: park $NODE_ID ($REASON)" "$NODE_ID"; then
   echo "park-node: graph-commit failed for $NODE_ID; the office_hours write was rolled back" >&2
   exit 1
 fi

--- a/packages/intentionsutil/scripts/park-node
+++ b/packages/intentionsutil/scripts/park-node
@@ -92,6 +92,13 @@ USAGE="usage: park-node [--pr <n>] [--base <blobsha>|<id>=<blobsha>|<manifest-fi
 # <recommendation> are free text that may start with `-`).
 PR_ARG=""
 BASE_ARG=""
+# Flag PRESENCE is tracked separately from the flag's VALUE: an explicitly
+# supplied but empty base (`--base ''` / `--base=`) must be a usage error, not
+# a silent degradation to an unpinned park. Gating the resolver on
+# `-n "$BASE_ARG"` alone would make that case indistinguishable from omitting
+# the flag, quietly dropping the compare-and-swap guarantee the caller asked
+# for (.claude/skills/ref-diagnosis-time-cas/SKILL.md).
+BASE_SUPPLIED=0
 ARGS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -115,10 +122,12 @@ while [[ $# -gt 0 ]]; do
         exit 2
       fi
       BASE_ARG="$1"
+      BASE_SUPPLIED=1
       shift
       ;;
     --base=*)
       BASE_ARG="${1#--base=}"
+      BASE_SUPPLIED=1
       shift
       ;;
     --*)
@@ -147,7 +156,11 @@ fi
 # Resolve --base (if supplied) to a 40-hex blob sha, before any network call,
 # so a malformed base is a cheap usage error rather than a mid-flight failure.
 PINNED_BASE=""
-if [[ -n "$BASE_ARG" ]]; then
+if [[ $BASE_SUPPLIED -eq 1 && -z "$BASE_ARG" ]]; then
+  echo "park-node: --base requires a non-empty <blobsha>|<id>=<blobsha>|<manifest-file> value" >&2
+  exit 2
+fi
+if [[ $BASE_SUPPLIED -eq 1 ]]; then
   if [[ -f "$BASE_ARG" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
       [[ -z "$line" ]] && continue
@@ -274,10 +287,19 @@ fi
 # targets "$INTENTIONS_DIR" under THAT repo, while graph-commit resolves its own
 # repo from -C if given, else from cwd. Callers routinely invoke the main
 # checkout's copy of this script by absolute path from inside a worktree, so
-# without -C the two would resolve to DIFFERENT checkouts. --expect is the
-# second half of the same guarantee: -C points graph-commit at the right
-# checkout, and --expect proves the content this script wrote is really there
-# by asserting the on-disk blob matches EXPECT_BLOB.
+# without -C the two would resolve to DIFFERENT checkouts.
+#
+# --expect does NOT add a second, independent check on -C from this call site:
+# EXPECT_BLOB is hashed under the same "$REPO_ROOT" that is passed as -C, so
+# for these three wrappers the assertion is self-satisfying whenever -C
+# resolves to the tree this script wrote. What it does buy here is narrower and
+# still worth the two lines: (1) it asserts graph-commit's
+# `git rev-parse --show-toplevel` resolution of -C lands on the same tree this
+# script wrote to — which can differ if REPO_ROOT is not itself a git toplevel
+# — and (2) it is a race guard, catching a concurrent writer that touched
+# intentions/$NODE_ID.md between the hash above and graph-commit's staging.
+# The wrong-repo case --expect exists for (graph-commit's header) is reached by
+# callers that pass -C and the hash from different trees, not by this one.
 if ! "$SCRIPT_DIR/graph-commit" -C "$REPO_ROOT" --base "$NODE_ID=$FRESH_BLOB" --expect "$NODE_ID=$EXPECT_BLOB" -m "graph: park $NODE_ID ($REASON)" "$NODE_ID"; then
   echo "park-node: graph-commit failed for $NODE_ID; the office_hours write was rolled back" >&2
   exit 1

--- a/packages/intentionsutil/scripts/resolve-park
+++ b/packages/intentionsutil/scripts/resolve-park
@@ -194,9 +194,16 @@ fi
 # changes to stage" branch, and prints "landed ... on main" / exits 0 having
 # committed nothing -- leaving the real edit dirty and unpushed in the other
 # checkout. Mirrors park-node, which already passes -C for the same reason.
-# --expect is the second half of the same guarantee: -C points graph-commit at
-# the right checkout, and --expect proves the content this script wrote is
-# really there by asserting the on-disk blob matches EXPECT_BLOB.
+#
+# --expect does NOT add a second, independent check on -C from this call site:
+# EXPECT_BLOB is hashed under the same "$REPO_ROOT" that is passed as -C, so
+# the assertion is self-satisfying whenever -C resolves to the tree this script
+# wrote. What it buys here is narrower: it asserts graph-commit's
+# `git rev-parse --show-toplevel` resolution of -C lands on the same tree this
+# script wrote to (they can differ if REPO_ROOT is not itself a git toplevel),
+# and it guards against a concurrent writer touching intentions/$NODE_ID.md
+# between the hash above and graph-commit's staging. See park-node's fuller
+# note at the same call site.
 if ! "$SCRIPT_DIR/graph-commit" -C "$REPO_ROOT" --base "$NODE_ID=$FRESH_BLOB" --expect "$NODE_ID=$EXPECT_BLOB" -m "$COMMIT_MSG" "$NODE_ID"; then
   echo "resolve-park: graph-commit failed for $NODE_ID; office_hours clear is on disk but not landed (PR #$PR disposition ($DISPOSITION) already applied)" >&2
   exit 1

--- a/packages/intentionsutil/scripts/resolve-park
+++ b/packages/intentionsutil/scripts/resolve-park
@@ -169,6 +169,15 @@ if ! (cd "$REPO_ROOT" && npx tsx "$TMPTS" "$STORE_MODULE" "$INTENTIONS_DIR" "$NO
   exit 1
 fi
 
+# EXPECT_BLOB captures the blob this script just wrote to intentions/$NODE_ID.md
+# under its OWN REPO_ROOT, for graph-commit's --expect guard below. Hashing
+# failure is genuine environment breakage — fail loudly rather than omitting
+# --expect (code-style.md).
+if ! EXPECT_BLOB="$(git -C "$REPO_ROOT" hash-object -- "intentions/$NODE_ID.md" 2>/dev/null)"; then
+  echo "resolve-park: could not hash intentions/$NODE_ID.md after the office_hours clear" >&2
+  exit 1
+fi
+
 COMMIT_MSG="graph: resolve-park $NODE_ID ($DISPOSITION PR #$PR)"
 if [[ -n "$NOTE" ]]; then
   COMMIT_MSG="$COMMIT_MSG - $NOTE"
@@ -185,7 +194,10 @@ fi
 # changes to stage" branch, and prints "landed ... on main" / exits 0 having
 # committed nothing -- leaving the real edit dirty and unpushed in the other
 # checkout. Mirrors park-node, which already passes -C for the same reason.
-if ! "$SCRIPT_DIR/graph-commit" -C "$REPO_ROOT" --base "$NODE_ID=$FRESH_BLOB" -m "$COMMIT_MSG" "$NODE_ID"; then
+# --expect is the second half of the same guarantee: -C points graph-commit at
+# the right checkout, and --expect proves the content this script wrote is
+# really there by asserting the on-disk blob matches EXPECT_BLOB.
+if ! "$SCRIPT_DIR/graph-commit" -C "$REPO_ROOT" --base "$NODE_ID=$FRESH_BLOB" --expect "$NODE_ID=$EXPECT_BLOB" -m "$COMMIT_MSG" "$NODE_ID"; then
   echo "resolve-park: graph-commit failed for $NODE_ID; office_hours clear is on disk but not landed (PR #$PR disposition ($DISPOSITION) already applied)" >&2
   exit 1
 fi

--- a/packages/intentionsutil/scripts/test-graph-commit.sh
+++ b/packages/intentionsutil/scripts/test-graph-commit.sh
@@ -1239,8 +1239,13 @@ elsewhere_sha="$(printf 'content that lives in some OTHER checkout\n' | git -C "
 before_sha="$(origin_sha)"
 out="$(run_gc "$W34" -m 'test: expect wrong repo' --expect "t-expect-wrong-repo=$elsewhere_sha" t-expect-wrong-repo 2>&1)"; rc=$?
 after_sha="$(origin_sha)"
+# The assertion greps an --expect-SPECIFIC substring. 'mis-pointed -C/--repo'
+# appears in BOTH the --expect die and the pre-existing nothing-staged guard
+# (which case 27 greps with exactly that string), so it cannot tell the two
+# apart — and this case exists precisely to prove --expect fired where the
+# nothing-staged guard structurally could not.
 if [[ $rc -ne 0 ]] \
-   && grep -q 'mis-pointed -C/--repo' <<<"$out" \
+   && grep -q 'does not hold the content the caller asserted' <<<"$out" \
    && ! grep -q 'landed t-expect-wrong-repo on main' <<<"$out" \
    && [[ "$after_sha" == "$before_sha" ]]; then
   ok "--expect: equal-blob wrong-repo invocation dies loudly, never emits a false landed"

--- a/packages/intentionsutil/scripts/test-graph-commit.sh
+++ b/packages/intentionsutil/scripts/test-graph-commit.sh
@@ -107,6 +107,15 @@
 #  32. lock-ref hygiene: refs/graph/landing-lock is absent after a normal
 #      landing and never appears under refs/heads/graph/** (disjoint from
 #      the scratch-branch namespace graph-fast-path.yml triggers on)
+#  33. --expect happy path: an --expect entry matching the blob the caller
+#      actually wrote is transparent — exit 0, the edit lands
+#  34. --expect catches the equal-blob wrong-repo case that case 28's benign
+#      path cannot: a clone synced bit-for-bit to origin/main (nothing staged,
+#      local blob == origin/main blob, so the nothing-staged guard passes)
+#      invoked with an --expect sha for content that is NOT there — dies
+#      naming "mis-pointed -C/--repo", never reaches "landed", main untouched
+#  35. --expect on a --prune id is a usage error (exit 2, origin untouched) —
+#      a deletion has no content to assert
 #
 # No network and no real gh/node needed; requires only bash + git + jq.
 
@@ -164,7 +173,8 @@ for id in t-happy t-merge t-conflict t-ckfail t-ghfail t-pending t-desync v1..v2
           t-prune-edit t-prune t-prune-guard t-prune-solo t-base t-base-manifest \
           t-farahead t-farahead-prune t-prune-conflict t-dirty-preflight \
           t-cwd-target t-fail-loud-diff t-fail-loud-benign \
-          t-lock-contend t-lock-steal t-lock-wait t-lock-hygiene; do
+          t-lock-contend t-lock-steal t-lock-wait t-lock-hygiene \
+          t-expect-happy t-expect-wrong-repo t-expect-prune; do
   seed_node "$id"
 done
 
@@ -1197,6 +1207,63 @@ if ! git -C "$ORIGIN" for-each-ref --format='%(refname)' 'refs/heads/graph/**' |
   ok "lock hygiene: refs/heads/graph/** never lists the landing-lock ref (disjoint namespaces)"
 else
   no "lock hygiene: landing-lock ref leaked into refs/heads/graph/**"
+fi
+
+# --- Case 33: --expect is transparent on the happy path -----------------------
+# The caller hashes the content it just wrote in its OWN checkout and pins it.
+# The resolved repo is that same checkout, so the assertion holds and the edit
+# lands exactly as it would without --expect.
+set_mode green
+W33="$WORK/w33"; make_clone "$W33" writer-33
+sync_clone "$W33"
+edit_line "$W33" t-expect-happy 1 expect-happy-lands
+expect_sha="$(git -C "$W33" hash-object -- intentions/t-expect-happy.md)"
+out="$(run_gc "$W33" -m 'test: expect happy' --expect "t-expect-happy=$expect_sha" t-expect-happy 2>&1)"; rc=$?
+if [[ $rc -eq 0 ]] && origin_show t-expect-happy | grep -q 'line1: expect-happy-lands'; then
+  ok "--expect happy path: matching blob assertion is transparent, edit lands"
+else
+  no "--expect happy path (rc=$rc)"; printf '%s\n' "$out"
+fi
+
+# --- Case 34: --expect catches the equal-blob wrong-repo case -------------------
+# The exact hole case 28 leaves open. This clone is bit-for-bit at origin/main
+# and has nothing staged, so the nothing-staged guard sees local_blob ==
+# main_blob and proceeds benignly ("no new changes to stage" + "landed") — a
+# false success when the caller's real edit lives in a DIFFERENT checkout.
+# With --expect naming the content the caller actually wrote, graph-commit must
+# refuse instead.
+set_mode green
+W34="$WORK/w34"; make_clone "$W34" writer-34
+sync_clone "$W34"   # bit-for-bit at origin/main, nothing staged
+elsewhere_sha="$(printf 'content that lives in some OTHER checkout\n' | git -C "$W34" hash-object --stdin)"
+before_sha="$(origin_sha)"
+out="$(run_gc "$W34" -m 'test: expect wrong repo' --expect "t-expect-wrong-repo=$elsewhere_sha" t-expect-wrong-repo 2>&1)"; rc=$?
+after_sha="$(origin_sha)"
+if [[ $rc -ne 0 ]] \
+   && grep -q 'mis-pointed -C/--repo' <<<"$out" \
+   && ! grep -q 'landed t-expect-wrong-repo on main' <<<"$out" \
+   && [[ "$after_sha" == "$before_sha" ]]; then
+  ok "--expect: equal-blob wrong-repo invocation dies loudly, never emits a false landed"
+else
+  no "--expect wrong-repo (rc=$rc)"; printf '%s\n' "$out"
+fi
+
+# --- Case 35: --expect on a --prune id is a usage error ------------------------
+# A deletion has no content to assert, so pinning one is a caller mistake.
+set_mode green
+W35="$WORK/w35"; make_clone "$W35" writer-35
+sync_clone "$W35"
+prune_sha="$(git -C "$W35" hash-object -- intentions/t-expect-prune.md)"
+rm -f "$W35/intentions/t-expect-prune.md"   # --prune requires the file gone on disk
+before_sha="$(origin_sha)"
+out="$(run_gc "$W35" -m 'test: expect prune' --prune t-expect-prune --expect "t-expect-prune=$prune_sha" 2>&1)"; rc=$?
+after_sha="$(origin_sha)"
+if [[ $rc -eq 2 ]] \
+   && grep -q 'no content to assert' <<<"$out" \
+   && [[ "$after_sha" == "$before_sha" ]]; then
+  ok "--expect on a --prune id is a usage error (exit 2), origin untouched"
+else
+  no "--expect on a prune id (rc=$rc)"; printf '%s\n' "$out"
 fi
 
 # --- No scratch branches left behind anywhere ------------------------------------

--- a/packages/intentionsutil/scripts/test-park-node.sh
+++ b/packages/intentionsutil/scripts/test-park-node.sh
@@ -83,6 +83,33 @@
 #      free-text arguments start with `-` and contain embedded spaces still
 #      parks successfully (exit 0) — proving the "first non-flag argument ends
 #      flag parsing" rule isn't fooled by dash-prefixed positionals.
+#  16. clear-park happy path: a parked node is cleared on origin/main
+#      (office_hours: null) with no working-tree residue left in the clone.
+#  17. clear-park idempotent no-op: re-running on an already-cleared node exits
+#      0 with a "nothing to do" note, leaves origin/main byte-unchanged, and
+#      restores the node file the origin/main refresh had overwritten (no
+#      working-tree diff) — the explicit restore-before-exit-0 path.
+#  18. clear-park byte-identical restore-on-failure: with graph-commit swapped
+#      for a wrapper that fails AFTER the office_hours clear landed on disk,
+#      the trap restores intentions/<id>.md exactly (git diff empty).
+#  19. clear-park `--base` diagnosis-time pin, mirroring cases 12-13: a
+#      matching pin is transparent (exit 0, cleared on origin); a stale pin
+#      refuses BEFORE any mutation (exit 3, `stale-diagnosis` on stderr,
+#      origin/main unchanged, no local diff).
+#  20. clear-park repo targeting — THE regression guard for
+#      tactic-clear-park-repo-targeting-guard. clear-park derives REPO_ROOT
+#      from its own script location and writes there, but graph-commit resolves
+#      its repo from `-C` if given else from CWD. Invoking clone X's clear-park
+#      by absolute path from clone Y's cwd (and again from a non-repo dir) must
+#      still land the clear on origin/main and must leave clone Y's intentions/
+#      untouched. Without the `-C "$REPO_ROOT"` on clear-park's graph-commit
+#      call this fails: graph-commit inspects Y, finds nothing staged for the id
+#      and its HEAD blob equal to origin/main, and takes the benign
+#      "no new changes" branch — exiting 0 having committed nothing (or, with
+#      Unit 1's --expect guard, failing loudly).
+#  21. resolve-park repo targeting: the same construction for resolve-park
+#      --ratify — invoked from a foreign cwd, `gh pr ready` still fires, the
+#      clear lands on origin/main, and the foreign clone stays clean.
 #
 # No network needed. Cases 1-3 and 6-15 need only bash + git + jq (the gh and
 # npx PATH shims stand in for the GitHub API and the tsx writers). Cases 4-5
@@ -97,11 +124,13 @@ REAL_REPO_ROOT="$(cd "$HARNESS_DIR/../../.." && pwd)"
 PN_SCRIPT="$HARNESS_DIR/park-node"
 GC_SCRIPT="$HARNESS_DIR/graph-commit"
 RP_SCRIPT="$HARNESS_DIR/resolve-park"
+CP_SCRIPT="$HARNESS_DIR/clear-park"
 DEMOTE_SCRIPT="$HARNESS_DIR/demote-node-to-implement"
 APPLY_TS="$HARNESS_DIR/apply-node-transition.ts"
 [[ -f "$PN_SCRIPT" ]] || { echo "error: park-node not found at $PN_SCRIPT" >&2; exit 1; }
 [[ -f "$GC_SCRIPT" ]] || { echo "error: graph-commit not found at $GC_SCRIPT" >&2; exit 1; }
 [[ -f "$RP_SCRIPT" ]] || { echo "error: resolve-park not found at $RP_SCRIPT" >&2; exit 1; }
+[[ -f "$CP_SCRIPT" ]] || { echo "error: clear-park not found at $CP_SCRIPT" >&2; exit 1; }
 [[ -f "$DEMOTE_SCRIPT" ]] || { echo "error: demote-node-to-implement not found at $DEMOTE_SCRIPT" >&2; exit 1; }
 command -v jq >/dev/null || { echo "error: jq not found (required by the gh shim)" >&2; exit 1; }
 
@@ -130,11 +159,13 @@ mkdir -p "$SEED/intentions" \
 cp "$PN_SCRIPT" "$SEED/packages/intentionsutil/scripts/park-node"
 cp "$GC_SCRIPT" "$SEED/packages/intentionsutil/scripts/graph-commit"
 cp "$RP_SCRIPT" "$SEED/packages/intentionsutil/scripts/resolve-park"
+cp "$CP_SCRIPT" "$SEED/packages/intentionsutil/scripts/clear-park"
 cp "$DEMOTE_SCRIPT" "$SEED/packages/intentionsutil/scripts/demote-node-to-implement"
 cp "$APPLY_TS" "$SEED/packages/intentionsutil/scripts/apply-node-transition.ts"
 chmod +x "$SEED/packages/intentionsutil/scripts/park-node" \
          "$SEED/packages/intentionsutil/scripts/graph-commit" \
          "$SEED/packages/intentionsutil/scripts/resolve-park" \
+         "$SEED/packages/intentionsutil/scripts/clear-park" \
          "$SEED/packages/intentionsutil/scripts/demote-node-to-implement"
 # Cases 1-3 (npx-shimmed) never load a real store module, so a stub `store.js`
 # would suffice for them — but case 5 runs the REAL apply-node-transition.ts,
@@ -157,7 +188,8 @@ seed_node() { # <id> — 12 numbered lines so distant edits rebase cleanly
     for i in $(seq 1 12); do echo "line$i: base"; done
   } >"$SEED/intentions/$1.md"
 }
-for id in t-stale t-concurrent t-pr t-pr-bad-arg t-resolve-ratify t-resolve-reject t-resolve-unparked t-pinned; do
+for id in t-stale t-concurrent t-pr t-pr-bad-arg t-resolve-ratify t-resolve-reject t-resolve-unparked t-pinned \
+          t-clear-happy t-clear-noop t-clear-rollback t-clear-pinned t-clear-cwd t-resolve-cwd; do
   seed_node "$id"
 done
 # t-demote: a schema-VALID node (only id/kind/statement/owner/status are
@@ -262,13 +294,31 @@ if [[ "$2" == *merge-node.ts ]]; then
 fi
 helper="$2"
 # (d) resolve-park's two helpers — state-read (dir, id) and clear-write
-# (dir, id) — both leave exactly 2 args after stripping tsx/helper/store,
-# distinct from (a)'s 6 and (b)'s 6+. The two are disambiguated from each
-# other by the helper file's own content (readable — it is a plain tempfile).
+# (dir, id) — plus clear-park's single clear-write helper (dir, id): all
+# leave exactly 2 args after stripping tsx/helper/store, distinct from (a)'s 6
+# and (b)'s 6+. They are disambiguated from each other by the helper file's own
+# content (readable — it is a plain tempfile). The clear-write branch covers
+# both resolve-park's and clear-park's writers, whose bodies each emit
+# "cleared office_hours on ${id}"; only clear-park's ALSO refuses an
+# already-clear node with exit 3, which the branch emulates below (harmless for
+# resolve-park, which only reaches its clear-write after its own state-read has
+# already confirmed the node is parked).
 if [[ $# -eq 5 ]]; then
   rp_dir="$4"; rp_id="$5"
   [[ -f "$rp_dir/$rp_id.md" ]] || { echo "npx shim: unreadable node $rp_id" >&2; exit 1; }
   if grep -q 'cleared office_hours' "$helper"; then
+    # Parked-ness is the LAST office_hours line in the file, since this
+    # harness's clears/parks append rather than rewrite (same `grep | tail -1`
+    # idiom the state-read branch below uses for execution_pr).
+    last_oh=""
+    if grep -q '^office_hours' "$rp_dir/$rp_id.md"; then
+      last_oh="$(grep '^office_hours' "$rp_dir/$rp_id.md" | tail -1)"
+    fi
+    if [[ -z "$last_oh" || "$last_oh" == "office_hours: null" ]]; then
+      # clear-park's helper: `if (node.office_hours == null) process.exit(3)`.
+      echo "clear-park: $rp_id is not parked (office_hours already null)" >&2
+      exit 3
+    fi
     # Naive simulation of the real writer's office_hours=null: since this
     # harness's seed content isn't real YAML, "clearing" is simulated by
     # appending a sentinel line a test can grep for.
@@ -342,6 +392,19 @@ run_rp() { # <clone> <gh-log-file> [resolve-park args...]
     export GRAPH_COMMIT_CHECK_TIMEOUT_SECONDS=5
     export GRAPH_COMMIT_MAX_ATTEMPTS=5
     bash packages/intentionsutil/scripts/resolve-park "$@"
+  )
+}
+
+run_cp() { # <clone> [clear-park args...]
+  local clone="$1"; shift
+  (
+    cd "$clone" || exit 99
+    export PATH="$WORK/bin:$PATH"
+    export GC_FIXTURE_DIR="$FIXTURE_DIR"
+    export GRAPH_COMMIT_CHECK_POLL_SECONDS=0
+    export GRAPH_COMMIT_CHECK_TIMEOUT_SECONDS=5
+    export GRAPH_COMMIT_MAX_ATTEMPTS=5
+    bash packages/intentionsutil/scripts/clear-park "$@"
   )
 }
 
@@ -762,6 +825,190 @@ else
   printf 'unknown: %s\n' "$out_unknown"
   printf 'badsha: %s\n' "$out_badsha"
   printf 'dash: %s\n' "$out_dash"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 16: clear-park happy path.
+# ---------------------------------------------------------------------------
+M_CLEAR="$WORK/m-clear"
+make_clone "$M_CLEAR" writer-m-clear
+run_pn "$M_CLEAR" t-clear-happy 'unit-test clear-park setup' >/dev/null 2>&1
+sync_clone "$M_CLEAR"
+out="$(run_cp "$M_CLEAR" t-clear-happy 'drain disposition' 2>&1)"; rc=$?
+content="$(origin_show t-clear-happy)"
+porcelain="$(git -C "$M_CLEAR" status --porcelain -- intentions/)"
+if [[ $rc -eq 0 ]] \
+   && grep -q 'office_hours: null' <<<"$content" \
+   && [[ -z "$porcelain" ]]; then
+  ok "clear-park happy path: office_hours cleared on origin/main, no working-tree residue"
+else
+  no "clear-park happy path (rc=$rc)"
+  printf '%s\n' "$out"; printf '%s\n' "$content"; printf 'porcelain: %s\n' "$porcelain"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 17: clear-park idempotent no-op restores the tree.
+# ---------------------------------------------------------------------------
+# Re-running on the node case 16 just cleared: the helper's not-parked exit 3
+# is translated into a deliberate exit-0 no-op. Because clear-park's
+# origin/main refresh ALREADY overwrote the local file before that discovery,
+# the no-op path must restore it explicitly — assert `git diff` is empty, not
+# merely that the command exited 0.
+before_sha="$(origin_sha)"
+out="$(run_cp "$M_CLEAR" t-clear-happy 'second call' 2>&1)"; rc=$?
+diff_after="$(git -C "$M_CLEAR" diff -- intentions/t-clear-happy.md)"
+if [[ $rc -eq 0 ]] \
+   && grep -q 'nothing to do' <<<"$out" \
+   && [[ "$(origin_sha)" == "$before_sha" ]] \
+   && [[ -z "$diff_after" ]]; then
+  ok "clear-park idempotent no-op: exit 0 with 'nothing to do', main unchanged, refresh overwrite restored (git diff empty)"
+else
+  no "clear-park idempotent no-op (rc=$rc)"
+  printf '%s\n' "$out"; printf 'diff: %s\n' "$diff_after"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 18: clear-park byte-identical rollback when graph-commit fails.
+# ---------------------------------------------------------------------------
+# Same shape as case 4: park the node first through a clone with the REAL
+# graph-commit, then run clear-park in a SECOND clone whose graph-commit is a
+# wrapper that unconditionally fails after the office_hours clear already
+# landed on disk. The trap must restore intentions/t-clear-rollback.md exactly.
+N_SETUP="$WORK/n-setup"
+make_clone "$N_SETUP" writer-n-setup
+run_pn "$N_SETUP" t-clear-rollback 'unit-test clear-park rollback setup' >/dev/null 2>&1
+
+N_CLEAR="$WORK/n-clear"
+make_clone "$N_CLEAR" writer-n-clear
+mv "$N_CLEAR/packages/intentionsutil/scripts/graph-commit" \
+   "$N_CLEAR/packages/intentionsutil/scripts/graph-commit.real"
+cat >"$N_CLEAR/packages/intentionsutil/scripts/graph-commit" <<'SH'
+#!/usr/bin/env bash
+echo "graph-commit wrapper: simulated post-mutation failure" >&2
+exit 1
+SH
+chmod +x "$N_CLEAR/packages/intentionsutil/scripts/graph-commit"
+
+out="$(run_cp "$N_CLEAR" t-clear-rollback 'simulated failure' 2>&1)"; rc=$?
+diff_after="$(git -C "$N_CLEAR" diff -- intentions/t-clear-rollback.md)"
+if [[ $rc -eq 1 ]] \
+   && grep -q 'office_hours write was rolled back' <<<"$out" \
+   && [[ -z "$diff_after" ]]; then
+  ok "clear-park byte-identical restore: graph-commit failure rolls back the office_hours clear (git diff empty)"
+else
+  no "clear-park byte-identical restore (rc=$rc)"
+  printf '%s\n' "$out"; printf 'diff: %s\n' "$diff_after"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 19: clear-park --base diagnosis-time pin (mirrors cases 12-13).
+# ---------------------------------------------------------------------------
+# (a) A pin matching origin/main's current blob is transparent — the clear
+# lands exactly as an unpinned call would. (b) Reusing that now-stale pin on a
+# second call refuses BEFORE any mutation: exit 3, `stale-diagnosis` on stderr,
+# origin/main byte-unchanged, and no local diff for the trap to roll back.
+P_PIN="$WORK/p-pin"
+make_clone "$P_PIN" writer-p-pin
+run_pn "$P_PIN" t-clear-pinned 'unit-test clear-park pin setup' >/dev/null 2>&1
+sync_clone "$P_PIN"
+clear_pin="$(git -C "$ORIGIN" rev-parse main:intentions/t-clear-pinned.md)"
+
+out_match="$(run_cp "$P_PIN" --base "$clear_pin" t-clear-pinned 2>&1)"; rc_match=$?
+content="$(origin_show t-clear-pinned)"
+
+before_sha="$(origin_sha)"
+out_stale="$(run_cp "$P_PIN" --base "$clear_pin" t-clear-pinned 2>&1)"; rc_stale=$?
+diff_after="$(git -C "$P_PIN" diff -- intentions/t-clear-pinned.md)"
+
+if [[ $rc_match -eq 0 ]] && grep -q 'office_hours: null' <<<"$content" \
+   && [[ $rc_stale -eq 3 ]] && grep -q 'stale-diagnosis' <<<"$out_stale" \
+   && [[ "$(origin_sha)" == "$before_sha" ]] \
+   && [[ -z "$diff_after" ]]; then
+  ok "clear-park --base: matching pin clears normally (exit 0); stale pin refuses before any mutation (exit 3, stale-diagnosis, main unchanged, no local diff)"
+else
+  no "clear-park --base pin (rc_match=$rc_match rc_stale=$rc_stale)"
+  printf 'match: %s\n' "$out_match"; printf 'stale: %s\n' "$out_stale"
+  printf 'diff: %s\n' "$diff_after"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 20: clear-park repo targeting — cwd is a DIFFERENT checkout.
+# ---------------------------------------------------------------------------
+# The regression guard this node exists for (mirrors test-graph-commit.sh's
+# case 25 construction). clear-park derives REPO_ROOT from its own script
+# location and performs every write there; graph-commit resolves its repo from
+# `-C` if given, else from CWD. So invoking clone X's clear-park by absolute
+# path from clone Y's cwd (and from a plain non-repo directory) must still land
+# the clear in X and push it to origin/main, leaving Y's intentions/ untouched.
+# Strip the `-C "$REPO_ROOT"` from clear-park's graph-commit call and this goes
+# red: graph-commit inspects Y instead, where nothing is staged for the id, and
+# either silently commits nothing or trips Unit 1's --expect guard.
+X_CWD="$WORK/x-cwd"; make_clone "$X_CWD" writer-x-cwd
+Y_CWD="$WORK/y-cwd"; make_clone "$Y_CWD" writer-y-cwd
+NOREPO_CWD="$WORK/norepo-cwd"; mkdir -p "$NOREPO_CWD"
+
+run_cp_from() { # <cwd> <script-owning-clone> [clear-park args...]
+  local at="$1" owner="$2"; shift 2
+  (
+    cd "$at" || exit 99
+    export PATH="$WORK/bin:$PATH"
+    export GC_FIXTURE_DIR="$FIXTURE_DIR"
+    export GRAPH_COMMIT_CHECK_POLL_SECONDS=0
+    export GRAPH_COMMIT_CHECK_TIMEOUT_SECONDS=5
+    export GRAPH_COMMIT_MAX_ATTEMPTS=5
+    bash "$owner/packages/intentionsutil/scripts/clear-park" "$@"
+  )
+}
+
+# (a) cwd = a different clone.
+run_pn "$X_CWD" t-clear-cwd 'unit-test foreign-cwd setup' >/dev/null 2>&1
+out_a="$(run_cp_from "$Y_CWD" "$X_CWD" t-clear-cwd 'from foreign clone' 2>&1)"; rc_a=$?
+content_a="$(origin_show t-clear-cwd)"
+porcelain_a="$(git -C "$Y_CWD" status --porcelain -- intentions/)"
+
+# (b) cwd = a directory that is not a git repository at all.
+run_pn "$X_CWD" t-clear-cwd 'unit-test non-repo-cwd setup' >/dev/null 2>&1
+out_b="$(run_cp_from "$NOREPO_CWD" "$X_CWD" t-clear-cwd 'from non-repo dir' 2>&1)"; rc_b=$?
+content_b="$(origin_show t-clear-cwd)"
+porcelain_b="$(git -C "$Y_CWD" status --porcelain -- intentions/)"
+
+if [[ $rc_a -eq 0 ]] && grep -q 'office_hours: null' <<<"$content_a" && [[ -z "$porcelain_a" ]] \
+   && [[ $rc_b -eq 0 ]] && grep -q 'office_hours: null' <<<"$content_b" && [[ -z "$porcelain_b" ]]; then
+  ok "clear-park repo targeting: script in clone X invoked from clone Y's cwd and from a non-repo cwd still lands the clear on origin/main; Y's intentions/ never written"
+else
+  no "clear-park repo targeting (rc_a=$rc_a rc_b=$rc_b porcelain_a='$porcelain_a' porcelain_b='$porcelain_b')"
+  printf 'a: %s\n' "$out_a"; printf '%s\n' "$content_a"
+  printf 'b: %s\n' "$out_b"; printf '%s\n' "$content_b"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 21: resolve-park repo targeting — same construction.
+# ---------------------------------------------------------------------------
+X_RP="$WORK/x-rp"; make_clone "$X_RP" writer-x-rp
+Y_RP="$WORK/y-rp"; make_clone "$Y_RP" writer-y-rp
+run_pn "$X_RP" --pr 3003 t-resolve-cwd 'unit-test resolve foreign-cwd setup' >/dev/null 2>&1
+sync_clone "$X_RP"
+GHLOG_CWD="$WORK/ghlog-resolve-cwd"
+out="$(
+  cd "$Y_RP" || exit 99
+  export PATH="$WORK/bin:$PATH"
+  export GC_FIXTURE_DIR="$FIXTURE_DIR"
+  export GH_LOG="$GHLOG_CWD"
+  export GRAPH_COMMIT_CHECK_POLL_SECONDS=0
+  export GRAPH_COMMIT_CHECK_TIMEOUT_SECONDS=5
+  export GRAPH_COMMIT_MAX_ATTEMPTS=5
+  bash "$X_RP/packages/intentionsutil/scripts/resolve-park" t-resolve-cwd --ratify 2>&1
+)"; rc=$?
+content="$(origin_show t-resolve-cwd)"
+porcelain="$(git -C "$Y_RP" status --porcelain -- intentions/)"
+if [[ $rc -eq 0 ]] \
+   && grep -q '^ready 3003$' "$GHLOG_CWD" \
+   && grep -q 'office_hours: null' <<<"$content" \
+   && [[ -z "$porcelain" ]]; then
+  ok "resolve-park repo targeting: script in clone X invoked from clone Y's cwd still readies the PR and lands the clear on origin/main; Y's intentions/ never written"
+else
+  no "resolve-park repo targeting (rc=$rc porcelain='$porcelain')"
+  printf '%s\n' "$out"; printf '%s\n' "$content"
 fi
 
 echo

--- a/packages/intentionsutil/scripts/test-park-node.sh
+++ b/packages/intentionsutil/scripts/test-park-node.sh
@@ -967,16 +967,24 @@ content_a="$(origin_show t-clear-cwd)"
 porcelain_a="$(git -C "$Y_CWD" status --porcelain -- intentions/)"
 
 # (b) cwd = a directory that is not a git repository at all.
+# `office_hours: null` alone is NOT discriminating here: part (a) already
+# cleared this same id, and the harness's clear shim APPENDS the sentinel
+# rather than rewriting the file, so (a)'s leftover line satisfies the grep
+# even if (b) landed nothing at all. Pin origin/main's sha immediately before
+# the run and require it to MOVE, so this arm proves a commit actually landed.
 run_pn "$X_CWD" t-clear-cwd 'unit-test non-repo-cwd setup' >/dev/null 2>&1
+before_sha_b="$(origin_sha)"
 out_b="$(run_cp_from "$NOREPO_CWD" "$X_CWD" t-clear-cwd 'from non-repo dir' 2>&1)"; rc_b=$?
 content_b="$(origin_show t-clear-cwd)"
 porcelain_b="$(git -C "$Y_CWD" status --porcelain -- intentions/)"
+after_sha_b="$(origin_sha)"
 
 if [[ $rc_a -eq 0 ]] && grep -q 'office_hours: null' <<<"$content_a" && [[ -z "$porcelain_a" ]] \
-   && [[ $rc_b -eq 0 ]] && grep -q 'office_hours: null' <<<"$content_b" && [[ -z "$porcelain_b" ]]; then
+   && [[ $rc_b -eq 0 ]] && grep -q 'office_hours: null' <<<"$content_b" && [[ -z "$porcelain_b" ]] \
+   && [[ "$after_sha_b" != "$before_sha_b" ]]; then
   ok "clear-park repo targeting: script in clone X invoked from clone Y's cwd and from a non-repo cwd still lands the clear on origin/main; Y's intentions/ never written"
 else
-  no "clear-park repo targeting (rc_a=$rc_a rc_b=$rc_b porcelain_a='$porcelain_a' porcelain_b='$porcelain_b')"
+  no "clear-park repo targeting (rc_a=$rc_a rc_b=$rc_b porcelain_a='$porcelain_a' porcelain_b='$porcelain_b' before_sha_b=$before_sha_b after_sha_b=$after_sha_b)"
   printf 'a: %s\n' "$out_a"; printf '%s\n' "$content_a"
   printf 'b: %s\n' "$out_b"; printf '%s\n' "$content_b"
 fi


### PR DESCRIPTION
## Root cause recap

`clear-park` and `resolve-park` derive `REPO_ROOT` from their own on-disk
location (`SCRIPT_DIR`), and write their mutation into the intentions
directory under **that** repo. Both invoke `graph-commit`, which resolves its
target repo from `-C` when given, otherwise from the caller's **cwd**. The
concrete two-call-site fix (adding `-C "$REPO_ROOT"` to both) already landed
separately as commit `29952532` (PR #2978). This PR covers the systemic
residue that let the missing `-C` ship undetected in the first place — two
distinct gaps, closed as two units each, plus a fourth unit adding the test
coverage that would have caught it.

## Unit 1 — graph-commit `--expect` post-edit content assertion

`graph-commit`'s nothing-staged guard only refuses when the resolved repo's
blob for a node **differs** from `origin/main`'s. When a wrong-repo invocation
happens to be in sync with `origin/main` (the common case), both blobs match,
the guard passes, and graph-commit reports a false "landed" success while the
caller's real edit sits dirty and unpushed in a different checkout — a false
success indistinguishable from the benign "already landed" case.

Added a new opt-in `--expect <id>=<blobsha>` token: graph-commit hashes
`intentions/<id>.md` in the **resolved** repo and refuses to proceed when it
doesn't match the blob the caller says it wrote. This subsumes both the
equal-blob and differing-blob wrong-repo cases and works on both the dirty and
nothing-staged paths. No `--expect` passed means no behavior change for
existing callers.

Chose the **nameref** generalization over duplicating the `--base` parser:
`add_base_pair`/`parse_base_arg` became `add_blob_pair`/`parse_blob_arg`,
each parameterized by target array name via `local -n` (the script already
requires bash 4 for `declare -A`; namerefs need only 4.3, and bash 5.3 is
present).

## Unit 2 — wire `--expect` from the three park-lifecycle wrappers

`clear-park`, `resolve-park`, and `park-node` each now hash the file they just
wrote (under their own `REPO_ROOT`) and pass it as `--expect` alongside their
existing `-C "$REPO_ROOT"`. `-C` points graph-commit at the right checkout;
`--expect` proves the content is really there. `hold-node`/`resolve-hold`
(which invoke graph-commit via `(cd "$REPO_ROOT" && ...)`, so cwd and target
can't diverge) and `demote-node-to-implement` (not part of the park lifecycle)
are unchanged.

## Unit 3 — `clear-park --base` diagnosis-time pin (exit 3 `stale-diagnosis`)

`.claude/skills/ref-diagnosis-time-cas/SKILL.md` documents a
`clear-park --base <manifest-path> <id> [note]` invocation with an exit-3
`stale-diagnosis` contract — but `clear-park` never implemented it (it only
took `<node-id> [note]` with exit codes 0/1/2). `park-node` already implements
this exact pattern. `clear-park` now mirrors it: a `--base` flag resolving to
a 40-hex blob sha (bare sha, `<id>=<sha>` pair, or manifest-file form), checked
against the freshly-fetched `origin/main` blob **before any mutation** — a
stale pin refuses with `exit 3` and zero side effects.

## Unit 4 — clear-park / resolve-park functional test coverage

`clear-park` had **zero** test coverage — grep over the repo's `test-*.sh`
files found no reference to it, which is precisely why the missing `-C`
shipped. `resolve-park`'s existing coverage never constructed the cwd vs.
`REPO_ROOT` divergence that produces the defect (every prior case ran with cwd
equal to the clone root).

Added cases 16-21 to `packages/intentionsutil/scripts/test-park-node.sh`:
happy path, idempotent no-op (restoring the refresh overwrite), byte-identical
rollback on a `graph-commit` failure, the `--base` pin (matching + stale), and
— the two cases the whole node exists for — **repo targeting**: invoking
`clear-park`/`resolve-park` by absolute path from a foreign checkout's cwd
(and from a non-repo cwd) still lands the mutation in the *owning* checkout
and leaves the foreign cwd's `intentions/` untouched. Confirmed both
repo-targeting cases are genuine regression guards by temporarily stripping
`-C "$REPO_ROOT"` from each call site, watching the corresponding case go red,
and restoring it (not included in this diff).

## Verification

```verify
packages/intentionsutil/scripts/test-graph-commit.sh
packages/intentionsutil/scripts/test-park-node.sh
bash packages/intentionsutil/scripts/test-transition-node.sh
bash packages/intentionsutil/scripts/test-hold-node.sh
.claude/skills/dispatch-propagate/scripts/test-graph-write-rollback.sh
.claude/skills/dispatch-propagate/scripts/run-lint.sh
npx tsx packages/intentionsutil/scripts/validate-graph.ts
npx vitest run --project packages/intentionsutil --root .
```

All pass: test-graph-commit.sh (46/0), test-park-node.sh (21/0),
test-transition-node.sh (3/0), test-hold-node.sh (11/0),
test-graph-write-rollback.sh (4/0), run-lint.sh (pass), validate-graph.ts
(428 nodes ok), vitest (711/711).

Node: `tactic-clear-park-repo-targeting-guard`
