### PR TITLE
provision-node-worktree: separate unusable-worktree residue from a genuine merge conflict, align to pushed tip, prune orphans

### DIFF
--- a/.claude/skills/dispatch-conflict/SKILL.md
+++ b/.claude/skills/dispatch-conflict/SKILL.md
@@ -210,7 +210,22 @@ With `NODE_MD` in hand, parse the node's frontmatter and apply these four cases
    action. Do **not** call `dispatch-mark-deviation` here: this is not a deviation
    to escalate — the caller invoked `/dispatch-conflict` against a node that isn't
    in a state it handles. It is a plain "wrong tool for this node" exit; say so
-   and stop. Because the tick can reach this lane (see "Who enters each lane"),
+   and stop.
+
+   One id class lands here **deliberately and by design**: a
+   `tactic-hold-residue-*` hold, i.e. `attributes.hold_kind == "worktree-residue"`
+   (born by `dispatch-graph-execute`'s exit-14 arm). It is not a
+   `provision-conflict` hold, so case 2 does not claim it, and it has no branch
+   of its own, so case 3 does not either. That is correct: its source's worktree
+   carries **mechanical residue**, not a content conflict — there is nothing to
+   reproduce and nothing to resolve here, and `origin/main` merges clean once the
+   residue is cleared. `/dispatch-conflict` is the wrong tool for it. It is
+   drained by **office-hours**, from the hold's own recommendation text (inspect
+   the recorded `git status` / `git diff --stat`, land or discard the uncommitted
+   content, then resolve the hold tactic to `phase: done` and prune it). Say that
+   plainly and stop — do not attempt a merge.
+
+   Because the tick can reach this lane (see "Who enters each lane"),
    still declare the terminal disposition on the way out —
    `mark-node-terminal "$NODE_ID" conflict-hold` — so the session does not hold
    the node's live-session slot open.
@@ -703,6 +718,22 @@ worktree and branch **in place**, with the merge already **aborted** and the tre
 clean (`provision-node-worktree`, the merged-tree-guarantee block: on a failed
 `git merge --no-edit origin/main` it runs `git merge --abort` and exits 11). So
 the markers are gone and Lane 3 must re-create them itself (Step 3).
+
+That invariant is now **enforced**, not merely assumed. `provision-node-worktree`
+runs a precondition guard over the worktree *before* it attempts any merge: a
+worktree carrying mechanical residue from a dead session — a dirty tracked tree,
+or a detached HEAD / in-progress operation it could not auto-repair — exits **14**
+(`worktree-residue`), never 11, and so never reaches this lane. The abort on the
+exit-11 path is checked too: a failed abort also exits 14. So an exit-11 entry is
+a genuine content conflict on a clean tree.
+
+Exit 11 has a **second cause**, though: the same script now merges the node's own
+pushed tip (`origin/<id>`) into the local branch before it merges `origin/main`,
+and a conflict *there* also exits 11. If `git merge origin/$SOURCE_ID` is not
+already a no-op when you arrive, resolve **that** merge first — merge
+`origin/$SOURCE_ID` and land it — before reproducing the `origin/main` merge in
+Step 3. Otherwise you resolve `origin/main` against a stale local ref and the
+next provisioning run conflicts again on the tip you skipped.
 
 ### 2. Resolve the PR, if any
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
@@ -69,6 +69,16 @@
 #                           consecutive failure — a tracked hold tactic was
 #                           born/re-entered via hold-node; the source's own
 #                           office_hours is never written.
+#   held <id> worktree-residue
+#                           provision exit 14 (worktree unusable — mechanical
+#                           residue from a dead session, NOT a content
+#                           conflict). A `worktree-residue` tracked hold tactic
+#                           was born/re-entered via hold-node, carrying the
+#                           `git status` / `git diff --stat` evidence. Escalates
+#                           on the FIRST occurrence — no strike ladder, because
+#                           the state is steady and has no autonomous repair
+#                           path. Never routed to the conflict lane; the
+#                           source's own office_hours is never written.
 #   failed <id> <reason>    the node could neither launch nor cleanly dispose.
 #                           On exit 11 below the cap this is
 #                           `failed <id> spawn-failed (strike N/CAP)`: the
@@ -76,7 +86,8 @@
 #                           counter was bumped, and no graph write was made.
 #
 # Exit codes: 0 every node launched or cleanly disposed (launched/waiting/
-# skipped/scope-stale/parked/conflict-lane/held are all RC-0 dispositions);
+# skipped/scope-stale/parked/conflict-lane/held — including the exit-14
+# `held <id> worktree-residue` disposition — are all RC-0 dispositions);
 # 1 at least one node could neither launch nor cleanly dispose (a spawn kick
 # failed — no park is attempted, the marker is left for the sweep — or a
 # park-node/hold-node/demote call itself failed); 2 usage/configuration error.
@@ -356,6 +367,58 @@ for spec in "$@"; do
         echo "failed $id demote-failed"
         FAILURES=$(( FAILURES + 1 ))
       fi
+      ;;
+    14)
+      # worktree-residue: provision-node-worktree's precondition guard refused
+      # the worktree because it carries MECHANICAL RESIDUE from a dead session
+      # (a dirty tracked tree, or a detached HEAD / in-progress operation it
+      # could not auto-repair). This is NOT a content conflict — origin/main
+      # merges clean the instant the residue is cleared — so it must never be
+      # routed to /dispatch-conflict's Lane 3, whose whole contract assumes a
+      # clean tree with a reproducible merge conflict.
+      #
+      # NO STRIKE LADDER. Exit 14 is a steady state with no autonomous repair
+      # path: nothing a later tick does clears a dirty file or an unreferenced
+      # detached HEAD, and the one repair that IS safe (aborting an in-progress
+      # operation) already happened inside provision-node-worktree before it
+      # chose this exit. So it escalates on the FIRST occurrence — deliberately
+      # not reusing CONFLICT_STRIKE_CAP or the `.conflict-strikes` sidecar,
+      # which count consecutive failures of a thing that could have succeeded.
+      #
+      # Like the exit-11 backstop, this births a born-parked HOLD TACTIC via
+      # hold-node and adds a blocked_by edge from the source; the source's own
+      # office_hours is never written, so NO park-node call belongs here.
+      RESIDUE_WT="$PROJECT_ROOT/.claude/worktrees/$id"
+      TMPDIR_HOLD14=$(mktemp -d) || {
+        echo "failed $id hold-mktemp-failed"
+        FAILURES=$(( FAILURES + 1 ))
+        continue
+      }
+      REASON_FILE="$TMPDIR_HOLD14/reason"
+      RECOMMENDATION_FILE="$TMPDIR_HOLD14/recommendation"
+      # The evidence is captured HERE, once, so the drain has the diff in hand
+      # without re-entering the worktree. The script runs `set -uo pipefail`
+      # (no -e) and each git call is `|| echo`-guarded, so an unreadable
+      # worktree yields an explanatory line rather than a silently empty
+      # section — and cannot abort the loop.
+      {
+        printf '%s\n\n' "provision-node-worktree refused to provision this tactic's worktree: it carries mechanical residue from a dead session (exit 14), not a content conflict. \`origin/main\` merges clean once the residue is cleared."
+        printf '%s\n' "\`git -C $RESIDUE_WT status --porcelain --untracked-files=no\`:"
+        git -C "$RESIDUE_WT" status --porcelain --untracked-files=no 2>&1 \
+          || echo "(could not read the worktree at $RESIDUE_WT)"
+        printf '\n%s\n' "\`git -C $RESIDUE_WT diff --stat\`:"
+        git -C "$RESIDUE_WT" diff --stat 2>&1 \
+          || echo "(could not read the worktree at $RESIDUE_WT)"
+      } > "$REASON_FILE"
+      printf '%s\n' "Inspect the diff recorded above in \`.claude/worktrees/$id\` and decide what the uncommitted content IS. If it is unlanded work, land it — \`graph-commit\` for an intentions/ node write, or commit and push the branch for code — and never discard it sight-unseen; the uncommitted edit may be its only copy. If it is safely discardable (build output, a half-applied edit already landed elsewhere), clear it with \`git restore\`. A detached HEAD with commits on it needs a branch before anything is reset. Once the worktree is clean, the next tick provisions it normally. Then resolve THIS HOLD TACTIC to \`phase: done\` and prune it — clearing \`office_hours\` alone does not unblock the source." > "$RECOMMENDATION_FILE"
+      if "$HOLD_NODE" "$id" --kind worktree-residue \
+          --reason-file "$REASON_FILE" --recommendation-file "$RECOMMENDATION_FILE"; then
+        echo "held $id worktree-residue"
+      else
+        echo "failed $id hold-failed"
+        FAILURES=$(( FAILURES + 1 ))
+      fi
+      rm -rf "$TMPDIR_HOLD14"
       ;;
     *)
       # 2 / any other: a mechanical error (bad node id, unresolvable project

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
@@ -328,8 +328,15 @@ for spec in "$@"; do
         }
         REASON_FILE="$TMPDIR_HOLD11/reason"
         RECOMMENDATION_FILE="$TMPDIR_HOLD11/recommendation"
-        printf '%s\n' "origin/main has not merged clean into this tactic's branch (provision exit 11), and the /dispatch-conflict Lane 3 session that resolves it could not be launched for $STRIKES consecutive ticks." > "$REASON_FILE"
-        printf '%s\n' "Run \`/dispatch-conflict $id\` by hand (Lane 3 reproduces and resolves the merge on the node's own branch), or resolve the conflict directly in \`.claude/worktrees/$id\` and push the branch. Either way, also check why the autonomous launch kept failing. Then resolve THIS HOLD TACTIC to \`phase: done\` and prune it — clearing \`office_hours\` alone does not unblock the source." > "$RECOMMENDATION_FILE"
+        # Exit 11 has TWO causes, and this producer cannot tell them apart: the
+        # branch does not merge origin/main clean, OR it does not merge its OWN
+        # pushed tip origin/<id> clean (provision-node-worktree's pushed-tip
+        # alignment, which runs first). Naming only origin/main here
+        # would state something false half the time — exactly the wrong-reason
+        # failure this hold path exists to avoid. The provision stderr line in
+        # the tick journal names the actual conflicting ref.
+        printf '%s\n' "This tactic's branch does not merge clean (provision exit 11) — either against \`origin/main\` or against its own pushed tip \`origin/$id\`; the provision stderr line in the tick journal names which ref — and the /dispatch-conflict Lane 3 session that resolves it could not be launched for $STRIKES consecutive ticks." > "$REASON_FILE"
+        printf '%s\n' "Run \`/dispatch-conflict $id\` by hand (Lane 3 reproduces and resolves the merge on the node's own branch; it merges \`origin/$id\` before reproducing the \`origin/main\` merge, which covers both causes), or resolve the conflict directly in \`.claude/worktrees/$id\` and push the branch. Either way, also check why the autonomous launch kept failing. Then resolve THIS HOLD TACTIC to \`phase: done\` and prune it — clearing \`office_hours\` alone does not unblock the source." > "$RECOMMENDATION_FILE"
         if "$HOLD_NODE" "$id" --kind provision-conflict \
             --reason-file "$REASON_FILE" --recommendation-file "$RECOMMENDATION_FILE"; then
           rm -f "$STRIKE_FILE"
@@ -402,7 +409,7 @@ for spec in "$@"; do
       # worktree yields an explanatory line rather than a silently empty
       # section — and cannot abort the loop.
       {
-        printf '%s\n\n' "provision-node-worktree refused to provision this tactic's worktree: it carries mechanical residue from a dead session (exit 14), not a content conflict. \`origin/main\` merges clean once the residue is cleared."
+        printf '%s\n\n' "provision-node-worktree refused to provision this tactic's worktree: it carries mechanical residue from a dead session (exit 14), not a content conflict. \`origin/main\` merges clean once the residue is cleared — with one exception the status output below distinguishes: on the \`failed-merge-abort\` condition a merge git could NOT abort is still in progress (MERGE_HEAD present, \`UU\` paths), and that merge has to be finished or aborted before anything else."
         printf '%s\n' "\`git -C $RESIDUE_WT status --porcelain --untracked-files=no\`:"
         git -C "$RESIDUE_WT" status --porcelain --untracked-files=no 2>&1 \
           || echo "(could not read the worktree at $RESIDUE_WT)"
@@ -410,7 +417,7 @@ for spec in "$@"; do
         git -C "$RESIDUE_WT" diff --stat 2>&1 \
           || echo "(could not read the worktree at $RESIDUE_WT)"
       } > "$REASON_FILE"
-      printf '%s\n' "Inspect the diff recorded above in \`.claude/worktrees/$id\` and decide what the uncommitted content IS. If it is unlanded work, land it — \`graph-commit\` for an intentions/ node write, or commit and push the branch for code — and never discard it sight-unseen; the uncommitted edit may be its only copy. If it is safely discardable (build output, a half-applied edit already landed elsewhere), clear it with \`git restore\`. A detached HEAD with commits on it needs a branch before anything is reset. Once the worktree is clean, the next tick provisions it normally. Then resolve THIS HOLD TACTIC to \`phase: done\` and prune it — clearing \`office_hours\` alone does not unblock the source." > "$RECOMMENDATION_FILE"
+      printf '%s\n' "Inspect the diff recorded above in \`.claude/worktrees/$id\` and decide what the uncommitted content IS. If it is unlanded work, land it — \`graph-commit\` for an intentions/ node write, or commit and push the branch for code — and never discard it sight-unseen; the uncommitted edit may be its only copy. If it is safely discardable (build output, a half-applied edit already landed elsewhere), clear it with \`git restore\` — but NOT while a merge is live: if the status above shows \`UU\` paths or the worktree has a MERGE_HEAD, abort or complete THAT merge first, since \`git restore\` inside one discards the wrong side. A detached HEAD with commits on it needs a branch before anything is reset, and a worktree sitting on a branch other than \`$id\` (the \`wrong-branch\` condition) needs that branch's own state settled before it is switched back. Once the worktree is clean, the next tick provisions it normally. Then resolve THIS HOLD TACTIC to \`phase: done\` and prune it — clearing \`office_hours\` alone does not unblock the source. \`resolve-hold $id --kind worktree-residue\` does the resolve and the source's \`blocked_by\` clear in one landed write." > "$RECOMMENDATION_FILE"
       if "$HOLD_NODE" "$id" --kind worktree-residue \
           --reason-file "$REASON_FILE" --recommendation-file "$RECOMMENDATION_FILE"; then
         echo "held $id worktree-residue"

--- a/.claude/skills/dispatch-propagate/scripts/provision-node-worktree
+++ b/.claude/skills/dispatch-propagate/scripts/provision-node-worktree
@@ -8,12 +8,22 @@
 #   1. Resolve the native location: <project-root>/.claude/worktrees/<node-id>,
 #      where the project root is the worktree with `main` checked out. No
 #      graph-native path assumes the legacy `.bare` common-dir layout.
-#   2. `git worktree add` from origin/main (reusing an existing worktree, a
-#      remote branch, or a local branch named <node-id> when present).
-#   3. Merge origin/main into the branch — the merged-tree guarantee every
-#      phase runs under. A conflict is NOT resolved here (exit 11; the caller
-#      routes it to /dispatch-conflict's Lane 3, which resolves it on the
-#      node's own branch — see dispatch-graph-execute's case 11).
+#   2. `git worktree prune` (clear orphan registrations whose checkout is
+#      already gone, which would otherwise make `git worktree add` refuse a
+#      path git still believes is taken), then `git worktree add` from
+#      origin/main (reusing an existing worktree, a remote branch, or a local
+#      branch named <node-id> when present).
+#   3. Assert the worktree is USABLE before touching it — the precondition
+#      guard: an in-progress rebase/merge/cherry-pick is auto-repaired
+#      (aborted) and re-checked; a detached HEAD or a dirty tracked tree is
+#      mechanical residue from a dead session and exits 14 with the tree left
+#      exactly as found. Then align the local branch to its OWN pushed tip
+#      (merge origin/<node-id> when the remote branch exists) so a stale local
+#      ref cannot shadow it, and merge origin/main into the branch — the
+#      merged-tree guarantee every phase runs under. A conflict is NOT resolved
+#      here (exit 11; the caller routes it to /dispatch-conflict's Lane 3,
+#      which resolves it on the node's own branch — see
+#      dispatch-graph-execute's case 11).
 #   4. CI-ready gate where a PR exists (dispatch-ci-ready, branch form): a
 #      draft PR whose checks have not concluded is not actionable (exit 10).
 #   5. direnv warm-up so the agent's non-interactive subshells have node on
@@ -39,6 +49,15 @@
 #       current state. (tactic-worker-start-revalidation)
 #   13  scope-stale: the tactic's scope changed after the previous phase ran.
 #       The caller demotes the node to `implement` and reports `scope-stale`.
+#   14  worktree unusable — mechanical residue from a dead session (a dirty
+#       tracked tree, or a detached HEAD / in-progress operation that could not
+#       be auto-repaired). This is NOT a content conflict: both branches merge
+#       clean the instant the residue is cleared. The tree is left EXACTLY as
+#       found (nothing is auto-discarded — the uncommitted edit may be the sole
+#       copy of unlanded work); stderr carries the condition plus the raw
+#       `git status --porcelain --untracked-files=no` and `git diff --stat`
+#       evidence. The caller routes it to a tracked hold, not to the conflict
+#       lane.
 #   2   usage or mechanical error (bad node id, unresolvable project root,
 #       failed add/fetch). The caller parks the node via the office_hours
 #       graph write (park-node) — never an office-hours label.
@@ -105,10 +124,29 @@ fi
 ORIGIN_SHA=$(git -C "$PROJECT_ROOT" rev-parse origin/main)
 printf '%s %s\n' "$GATE_FP" "$ORIGIN_SHA" >"$STAMP_PATH"
 
+# Does this node have a pushed branch? Probe (and fetch) ONCE, before the add
+# block: the pushed-tip alignment below needs origin/<node-id> on the REUSED
+# worktree path too, not just the fresh one. A fetch failure is a broken
+# environment, not a state to fall through silently (.claude/rules/code-style.md).
+REMOTE_BRANCH=0
+if git -C "$PROJECT_ROOT" ls-remote --heads --exit-code origin "$NODE_ID" >/dev/null 2>&1; then
+  REMOTE_BRANCH=1
+  if ! git -C "$PROJECT_ROOT" fetch origin "$NODE_ID" 1>&2; then
+    echo "provision-node-worktree: git fetch origin $NODE_ID failed" >&2
+    exit 2
+  fi
+fi
+
+# Clear orphan registrations: a `.git/worktrees/<name>` entry whose checkout
+# directory is gone survives forever, and git refuses to re-register a path it
+# still believes is taken. Cheap, idempotent, and it only touches registrations
+# whose checkout is already gone — safe to run unconditionally against a shared
+# repo with a live fleet.
+git -C "$PROJECT_ROOT" worktree prune 1>&2 || true
+
 if [[ ! -d "$WT" ]]; then
-  if git -C "$PROJECT_ROOT" ls-remote --heads --exit-code origin "$NODE_ID" >/dev/null 2>&1; then
-    git -C "$PROJECT_ROOT" fetch origin "$NODE_ID" 1>&2 \
-      && git -C "$PROJECT_ROOT" worktree add "$WT" "$NODE_ID" 1>&2
+  if [[ "$REMOTE_BRANCH" -eq 1 ]]; then
+    git -C "$PROJECT_ROOT" worktree add "$WT" "$NODE_ID" 1>&2
   elif git -C "$PROJECT_ROOT" rev-parse --verify --quiet "$NODE_ID" >/dev/null 2>&1; then
     git -C "$PROJECT_ROOT" worktree add "$WT" "$NODE_ID" 1>&2
   else
@@ -120,11 +158,128 @@ if [[ ! -d "$WT" ]]; then
   fi
 fi
 
+# --- Precondition guard: is this worktree USABLE? ---------------------------
+# Runs on BOTH the fresh and the reused path, before anything else touches $WT.
+# Without it, a dirty tree or a stranded rebase makes the origin/main merge
+# below fail and its `merge --abort` fail too, and the residue is reported as a
+# content conflict it is not. Assert the precondition; do not infer it from a
+# merge exit code.
+
+# Resolve a git-path (rebase-merge, MERGE_HEAD, …) as an ABSOLUTE path.
+# Modelled on graph-commit's rebase_in_progress() (packages/intentionsutil/
+# scripts/graph-commit:634-639). One caveat that helper does not face: it runs
+# with cwd inside the repo, whereas `git -C "$WT" rev-parse --git-path X` prints
+# a path relative to $WT — absolute for a linked worktree, but relative for a
+# plain repo, where a bare `[[ -d ]]` from another cwd would silently miss it.
+wt_git_path() {   # $1 = git-path name; prints an absolute path
+  local p
+  p=$(git -C "$WT" rev-parse --git-path "$1") || return 1
+  [[ "$p" == /* ]] || p="$WT/$p"
+  printf '%s\n' "$p"
+}
+
+# Exit 14: mechanical residue, NOT a content conflict. Leave the tree exactly
+# as found and hand the drain the evidence it needs without re-entering the
+# worktree.  $1 = condition slug.
+unusable_worktree() {
+  echo "provision-node-worktree: worktree unusable for $NODE_ID ($1); not a content conflict" >&2
+  git -C "$WT" status --porcelain --untracked-files=no >&2 || true
+  git -C "$WT" diff --stat >&2 || true
+  exit 14
+}
+
+check_worktree_usable() {
+  local rebase_merge rebase_apply merge_head cherry_head
+  rebase_merge=$(wt_git_path rebase-merge) || return 1
+  rebase_apply=$(wt_git_path rebase-apply) || return 1
+  merge_head=$(wt_git_path MERGE_HEAD) || return 1
+  cherry_head=$(wt_git_path CHERRY_PICK_HEAD) || return 1
+
+  # (a) An operation in progress. Auto-repair: aborting restores the
+  # pre-operation branch tip, reattaches HEAD, and is non-destructive with
+  # respect to committed work; the residue is by definition unattended (the
+  # session that created it is gone). Return 2 = "repaired, re-check".
+  if [[ -d "$rebase_merge" || -d "$rebase_apply" ]]; then
+    if git -C "$WT" rebase --abort 1>&2; then
+      echo "provision-node-worktree: auto-repaired an abandoned rebase in $WT" >&2
+      return 2
+    fi
+    unusable_worktree operation-in-progress
+  fi
+  if [[ -f "$merge_head" ]]; then
+    if git -C "$WT" merge --abort 1>&2; then
+      echo "provision-node-worktree: auto-repaired an abandoned merge in $WT" >&2
+      return 2
+    fi
+    unusable_worktree operation-in-progress
+  fi
+  if [[ -f "$cherry_head" ]]; then
+    if git -C "$WT" cherry-pick --abort 1>&2; then
+      echo "provision-node-worktree: auto-repaired an abandoned cherry-pick in $WT" >&2
+      return 2
+    fi
+    unusable_worktree operation-in-progress
+  fi
+
+  # (b) Detached HEAD with no operation in progress: do NOT repair — the
+  # commits there may be unreferenced.
+  if ! git -C "$WT" symbolic-ref -q HEAD >/dev/null; then
+    unusable_worktree detached-head
+  fi
+
+  # (c) Dirty tracked tree: NEVER auto-discard — the uncommitted edit could be
+  # the sole copy of unlanded work. --untracked-files=no is load-bearing: node
+  # worktrees routinely carry build output.
+  if [[ -n "$(git -C "$WT" status --porcelain --untracked-files=no)" ]]; then
+    unusable_worktree dirty-tracked-tree
+  fi
+  return 0
+}
+
+# One auto-repair pass, then a full re-check (the repair may reveal a second
+# condition, e.g. a dirty tree underneath an aborted rebase).
+check_worktree_usable
+GUARD_RC=$?
+if [[ "$GUARD_RC" -eq 2 ]]; then
+  check_worktree_usable
+  GUARD_RC=$?
+fi
+if [[ "$GUARD_RC" -ne 0 ]]; then
+  echo "provision-node-worktree: cannot inspect the worktree state in $WT" >&2
+  exit 2
+fi
+
+# Align the local branch to its OWN pushed tip. `git worktree add <path> <id>`
+# resolves <id> to the LOCAL branch when one exists, so a stale local ref left
+# by a failed earlier provisioning run silently shadows the fetched tip — which
+# manufactures false exit-11 dispatches. A MERGE, not `worktree add -B`: -B
+# force-moves the local ref and would silently discard genuinely-unpushed local
+# commits. The merge is a no-op fast-forward when the local ref is behind or
+# equal, preserves a local ref that is ahead, and surfaces a true divergence
+# through the ordinary conflict disposition. This also covers the REUSED
+# worktree path, which had no such check at all.
+if [[ "$REMOTE_BRANCH" -eq 1 ]]; then
+  if ! git -C "$WT" merge --no-edit "origin/$NODE_ID" 1>&2; then
+    if ! git -C "$WT" merge --abort 1>&2; then
+      echo "provision-node-worktree: worktree unusable for $NODE_ID (failed-merge-abort); not a content conflict" >&2
+      exit 14
+    fi
+    echo "provision-node-worktree: origin/$NODE_ID does not merge clean into the local $NODE_ID branch" >&2
+    exit 11
+  fi
+fi
+
 # Merged-tree guarantee: every phase runs on a tree that already contains
 # origin/main. A conflict is the caller's disposition, not ours — abort and
 # leave the tree clean.
 if ! git -C "$WT" merge --no-edit origin/main 1>&2; then
-  git -C "$WT" merge --abort 1>&2 || true
+  # A CHECKED abort: with the guard in front this is unreachable, so it is a
+  # defensive assertion at a system edge, not a fallback. A failed abort means
+  # the state was never mergeable and must not be reported as a conflict.
+  if ! git -C "$WT" merge --abort 1>&2; then
+    echo "provision-node-worktree: worktree unusable for $NODE_ID (failed-merge-abort); not a content conflict" >&2
+    exit 14
+  fi
   echo "provision-node-worktree: origin/main does not merge clean into $NODE_ID" >&2
   exit 11
 fi

--- a/.claude/skills/dispatch-propagate/scripts/provision-node-worktree
+++ b/.claude/skills/dispatch-propagate/scripts/provision-node-worktree
@@ -13,21 +13,27 @@
 #      path git still believes is taken), then `git worktree add` from
 #      origin/main (reusing an existing worktree, a remote branch, or a local
 #      branch named <node-id> when present).
-#   3. Assert the worktree is USABLE before touching it — the precondition
+#   3. Assert the directory IS the linked worktree for <node-id> (the identity
+#      assertion) before running a single `git -C "$WT"` command — orphan
+#      residue inside the project root's own working tree makes every such
+#      command silently address the `main` checkout instead (exit 2).
+#   4. Assert the worktree is USABLE before touching it — the precondition
 #      guard: an in-progress rebase/merge/cherry-pick is auto-repaired
-#      (aborted) and re-checked; a detached HEAD or a dirty tracked tree is
-#      mechanical residue from a dead session and exits 14 with the tree left
-#      exactly as found. Then align the local branch to its OWN pushed tip
+#      (aborted) and re-checked; a detached HEAD, a branch other than
+#      <node-id> checked out, or a dirty tracked tree is mechanical residue
+#      from a dead session and exits 14 with the tree left exactly as found. Then align the local branch to its OWN pushed tip
 #      (merge origin/<node-id> when the remote branch exists) so a stale local
 #      ref cannot shadow it, and merge origin/main into the branch — the
 #      merged-tree guarantee every phase runs under. A conflict is NOT resolved
 #      here (exit 11; the caller routes it to /dispatch-conflict's Lane 3,
 #      which resolves it on the node's own branch — see
 #      dispatch-graph-execute's case 11).
-#   4. CI-ready gate where a PR exists (dispatch-ci-ready, branch form): a
+#   5. CI-ready gate where a PR exists (dispatch-ci-ready, branch form): a
 #      draft PR whose checks have not concluded is not actionable (exit 10).
-#   5. direnv warm-up so the agent's non-interactive subshells have node on
-#      PATH (same rationale as .claude/hooks/worktree-create.sh).
+#   6. direnv warm-up so the agent's non-interactive subshells have node on
+#      PATH (same rationale as .claude/hooks/worktree-create.sh) — gated on the
+#      worktree's `.envrc` being byte-identical to origin/main's, because the
+#      warm-up EXECUTES it on the operator's host with the sandbox disabled.
 #
 # Usage: provision-node-worktree <node-id> <selected-phase>
 #
@@ -50,17 +56,27 @@
 #   13  scope-stale: the tactic's scope changed after the previous phase ran.
 #       The caller demotes the node to `implement` and reports `scope-stale`.
 #   14  worktree unusable — mechanical residue from a dead session (a dirty
-#       tracked tree, or a detached HEAD / in-progress operation that could not
-#       be auto-repaired). This is NOT a content conflict: both branches merge
-#       clean the instant the residue is cleared. The tree is left EXACTLY as
-#       found (nothing is auto-discarded — the uncommitted edit may be the sole
-#       copy of unlanded work); stderr carries the condition plus the raw
-#       `git status --porcelain --untracked-files=no` and `git diff --stat`
-#       evidence. The caller routes it to a tracked hold, not to the conflict
-#       lane.
+#       tracked tree, a branch other than <node-id> checked out, or a detached
+#       HEAD / in-progress operation that could not be auto-repaired). This is
+#       NOT a content conflict: both branches merge clean the instant the
+#       residue is cleared. Nothing is auto-discarded — the uncommitted edit
+#       may be the sole copy of unlanded work — and on every condition the
+#       GUARD reports, the tree is left EXACTLY as found. The one exception is
+#       the `failed-merge-abort` condition, reached from a merge below the
+#       guard: git refused to abort that merge, so it is still IN PROGRESS
+#       (MERGE_HEAD present, conflict markers written) and the drain must
+#       finish or abort it before restoring anything. stderr carries the
+#       condition plus the raw `git status --porcelain --untracked-files=no`
+#       and `git diff --stat` evidence. The caller routes it to a tracked
+#       hold, not to the conflict lane.
 #   2   usage or mechanical error (bad node id, unresolvable project root,
-#       failed add/fetch). The caller parks the node via the office_hours
-#       graph write (park-node) — never an office-hours label.
+#       failed add/fetch, an `orphan-directory` that is not the node's linked
+#       worktree, or an `.envrc` that differs from origin/main's). The caller
+#       parks the node via the office_hours graph write (park-node) — never an
+#       office-hours label. Note the caller does NOT re-enter the directory
+#       with git on this code, which is why `orphan-directory` routes here
+#       rather than to exit 14 (whose evidence capture would serialize the
+#       MAIN checkout's status into a hold node).
 #
 # Requires `dangerouslyDisableSandbox: true` from a Claude session: git push
 # fetch/worktree writes, gh (inside dispatch-ci-ready), and direnv.
@@ -158,6 +174,38 @@ if [[ ! -d "$WT" ]]; then
   fi
 fi
 
+# --- Identity assertion: is $WT the linked worktree it claims to be? --------
+# Runs BEFORE the first `git -C "$WT" …` of any kind. $WT lives INSIDE the
+# project root's own working tree ($PROJECT_ROOT/.claude/worktrees/<node-id>),
+# so when the directory exists but carries no valid `.git` file, git discovery
+# walks UP and every `git -C "$WT" …` silently addresses the PROJECT ROOT — the
+# `main` checkout. That state is not hypothetical: the unconditional
+# `git worktree prune` above MANUFACTURES it (prune deregisters a worktree whose
+# `.git` file is missing while leaving its files on disk), and the `[[ ! -d
+# "$WT" ]]` gate then skips `worktree add` for the surviving directory. Left
+# unchecked, the guard below would abort an unrelated in-progress rebase/merge
+# in main's checkout, report main's dirt as this node's residue, and the
+# origin/main merge would merge INTO main's checkout — the failed-cd hazard,
+# reached without any cd.
+#
+# On mismatch: no repair. The directory is orphan residue whose files may be the
+# only copy of unlanded work, and it is not a worktree to clean. exit 2 (not 14)
+# so the caller parks it via park-node — the exit-14 route would re-enter the
+# directory with git and serialize the MAIN checkout's status into a hold node
+# committed to origin/main.
+WT_REAL=$(cd "$WT" && pwd -P)
+WT_TOP=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null)
+WT_TOP_REAL=""
+if [[ -n "$WT_TOP" && -d "$WT_TOP" ]]; then
+  WT_TOP_REAL=$(cd "$WT_TOP" && pwd -P)
+fi
+WT_GITDIR=$(git -C "$WT" rev-parse --absolute-git-dir 2>/dev/null)
+if [[ -z "$WT_REAL" || "$WT_TOP_REAL" != "$WT_REAL" || "$WT_GITDIR" != */worktrees/"$NODE_ID" ]]; then
+  echo "provision-node-worktree: $WT is not the linked worktree for $NODE_ID (orphan-directory: toplevel='${WT_TOP_REAL:-<none>}', git-dir='${WT_GITDIR:-<none>}')" >&2
+  echo "provision-node-worktree: refusing to run any git command there — it would resolve to the enclosing checkout at $PROJECT_ROOT. Inspect the directory by hand: if it holds unlanded work, land it; otherwise remove it so the next tick re-adds the worktree." >&2
+  exit 2
+fi
+
 # --- Precondition guard: is this worktree USABLE? ---------------------------
 # Runs on BOTH the fresh and the reused path, before anything else touches $WT.
 # Without it, a dirty tree or a stranded rebase makes the origin/main merge
@@ -174,7 +222,16 @@ fi
 wt_git_path() {   # $1 = git-path name; prints an absolute path
   local p
   p=$(git -C "$WT" rev-parse --git-path "$1") || return 1
-  [[ "$p" == /* ]] || p="$WT/$p"
+  [[ "$p" == /* ]] || p="$WT_REAL/$p"
+  # Reject a resolved path that escapes this worktree's OWN git dir. An orphan
+  # directory yields the relative `../.git/<name>`, which the prefixing above
+  # turns into the MAIN checkout's operation state — and `[[ -d ]]` on it is
+  # true whenever main is mid-rebase. The identity assertion above already
+  # makes that unreachable; this is the boundary assertion that keeps it so.
+  if [[ "$p" != "$WT_GITDIR"/* ]]; then
+    echo "provision-node-worktree: git-path '$1' resolved to '$p', outside this worktree's git dir ($WT_GITDIR)" >&2
+    return 1
+  fi
   printf '%s\n' "$p"
 }
 
@@ -227,6 +284,20 @@ check_worktree_usable() {
     unusable_worktree detached-head
   fi
 
+  # (b2) Attached, but to some OTHER branch. The identity assertion above
+  # proves the directory IS this node's linked worktree; it does not prove
+  # `<node-id>` is what the worktree has checked out. Left unchecked, the
+  # pushed-tip merge below merges `origin/<node-id>` into an unrelated branch,
+  # the origin/main merge lands on that branch too, and the phase agent is
+  # handed a cwd whose derived BRANCH is not the node's. Mechanical residue of
+  # the same class as a detached HEAD: do NOT repair (a checkout would strand
+  # whatever put it there, and the other branch may carry unpushed commits).
+  local wt_branch
+  wt_branch=$(git -C "$WT" symbolic-ref --short HEAD) || return 1
+  if [[ "$wt_branch" != "$NODE_ID" ]]; then
+    unusable_worktree "wrong-branch (checked out: $wt_branch)"
+  fi
+
   # (c) Dirty tracked tree: NEVER auto-discard — the uncommitted edit could be
   # the sole copy of unlanded work. --untracked-files=no is load-bearing: node
   # worktrees routinely carry build output.
@@ -236,14 +307,26 @@ check_worktree_usable() {
   return 0
 }
 
-# One auto-repair pass, then a full re-check (the repair may reveal a second
-# condition, e.g. a dirty tree underneath an aborted rebase).
-check_worktree_usable
-GUARD_RC=$?
-if [[ "$GUARD_RC" -eq 2 ]]; then
+# Auto-repair, then a full re-check — and a repair can reveal a SECOND
+# repairable condition underneath the first (a stale CHERRY_PICK_HEAD beside
+# the rebase state that was just aborted), so re-check until the pass reports
+# a verdict other than "repaired". Bounded: a worktree that keeps reporting
+# repairable after GUARD_REPAIR_PASSES repairs is not converging, and that is
+# unattended residue (exit 14), not an inspection failure (exit 2). A single
+# pass would report the converging case as "cannot inspect" and the caller's
+# catch-all would park the source — the one write this producer never makes.
+GUARD_REPAIR_PASSES=3
+GUARD_PASSES=0
+while :; do
   check_worktree_usable
   GUARD_RC=$?
-fi
+  [[ "$GUARD_RC" -eq 2 ]] || break
+  GUARD_PASSES=$(( GUARD_PASSES + 1 ))
+  if (( GUARD_PASSES >= GUARD_REPAIR_PASSES )); then
+    echo "provision-node-worktree: $WT still reports a repairable operation after $GUARD_PASSES auto-repair passes" >&2
+    unusable_worktree operation-in-progress
+  fi
+done
 if [[ "$GUARD_RC" -ne 0 ]]; then
   echo "provision-node-worktree: cannot inspect the worktree state in $WT" >&2
   exit 2
@@ -261,8 +344,11 @@ fi
 if [[ "$REMOTE_BRANCH" -eq 1 ]]; then
   if ! git -C "$WT" merge --no-edit "origin/$NODE_ID" 1>&2; then
     if ! git -C "$WT" merge --abort 1>&2; then
-      echo "provision-node-worktree: worktree unusable for $NODE_ID (failed-merge-abort); not a content conflict" >&2
-      exit 14
+      # Same disposition, same message shape, and the same evidence capture as
+      # every other exit-14 condition — emitted from one place. Note the merge
+      # is still IN PROGRESS here (see the exit-14 header note): the status
+      # output below is what tells the drain that.
+      unusable_worktree failed-merge-abort
     fi
     echo "provision-node-worktree: origin/$NODE_ID does not merge clean into the local $NODE_ID branch" >&2
     exit 11
@@ -277,8 +363,7 @@ if ! git -C "$WT" merge --no-edit origin/main 1>&2; then
   # defensive assertion at a system edge, not a fallback. A failed abort means
   # the state was never mergeable and must not be reported as a conflict.
   if ! git -C "$WT" merge --abort 1>&2; then
-    echo "provision-node-worktree: worktree unusable for $NODE_ID (failed-merge-abort); not a content conflict" >&2
-    exit 14
+    unusable_worktree failed-merge-abort
   fi
   echo "provision-node-worktree: origin/main does not merge clean into $NODE_ID" >&2
   exit 11
@@ -295,6 +380,27 @@ if (( CI_RC == 1 )); then
   exit 10
 elif (( CI_RC != 0 )); then
   echo "provision-node-worktree: dispatch-ci-ready failed (exit $CI_RC) for $NODE_ID" >&2
+  exit 2
+fi
+
+# .envrc provenance gate, BEFORE the warm-up below. `direnv allow` re-approves
+# and `direnv exec` then EXECUTES whatever .envrc the tree now holds — on the
+# operator's host, with the sandbox disabled (see the header). Provisioning
+# merges `origin/<node-id>` into the worktree on every tick, and node branches
+# are not protected refs: anyone who can push one (leaked or over-scoped token,
+# compromised CI credential) could otherwise get arbitrary code executed as the
+# operator on the next tick. So approve only content that is already on
+# origin/main, where branch protection and review apply. The working-tree file
+# is hashed (not HEAD:.envrc) because that is the byte string direnv actually
+# runs, and an UNTRACKED .envrc would be invisible to a HEAD lookup.
+ENVRC_MAIN=$(git -C "$PROJECT_ROOT" rev-parse --quiet --verify "origin/main:.envrc" 2>/dev/null) || ENVRC_MAIN=""
+ENVRC_WT=""
+if [[ -e "$WT/.envrc" ]]; then
+  ENVRC_WT=$(git -C "$WT" hash-object -- "$WT/.envrc" 2>/dev/null) || ENVRC_WT=""
+fi
+if [[ "$ENVRC_WT" != "$ENVRC_MAIN" ]]; then
+  echo "provision-node-worktree: .envrc in $WT (blob ${ENVRC_WT:-<none>}) differs from origin/main's (blob ${ENVRC_MAIN:-<none>}); refusing to direnv allow/exec unreviewed .envrc content" >&2
+  echo "provision-node-worktree: review the .envrc diff by hand. If the change is a legitimate tactic edit, land it on origin/main first; if it is not, treat the node branch as compromised." >&2
   exit 2
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-graph-execute.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-graph-execute.sh
@@ -5,8 +5,8 @@
 # spawns a top-level sonnet orchestrator session that invokes the phase skill
 # DIRECTLY (never a runner session that invokes a workflow). Covers the per-phase
 # skill map, the strategy/tactic lane split, and every provision-exit disposition
-# (0/10/11/12/13/2) — routed here at zero token cost with no `claude` session on
-# any non-zero path.
+# (0/10/11/12/13/14/2) — routed here at zero token cost with no `claude` session
+# on any non-zero path.
 #
 # Harness (mirrors the per-SUT test-*.sh files sharing dispatch-test-fixture.sh):
 # copy the SUT + its sourced libs
@@ -292,6 +292,30 @@ assert_eq "prov-error stdout" "parked tactic-e" "$OUT"
 assert_eq "prov-error exit 0" "0" "$RC"
 assert_eq "prov-error spawns nothing" "" "$(cat "$SPAWN_LOG")"
 assert_contains "prov-error parks the node" "tactic-e" "$(cat "$PARK_LOG")"
+
+# ============================================================================
+# Case 8b: provision exit 14 -> a worktree-residue tracked hold, born on the
+# FIRST occurrence. No strike ladder, no conflict-lane spawn, no park-node
+# write — the residue is not a content conflict and the source's own
+# office_hours is never written by this producer.
+# ============================================================================
+echo "Case 8b: provision exit 14 -> held via a worktree-residue hold, first occurrence"
+PROV_RC=14 run_exec "tactic-res:tactic:qa"
+HOLD=$(cat "$HOLD_LOG")
+assert_eq "residue stdout" "held tactic-res worktree-residue" "$OUT"
+assert_eq "residue exit 0" "0" "$RC"
+assert_eq "residue spawns nothing" "" "$(cat "$SPAWN_LOG")"
+assert_eq "residue makes no park-node write" "" "$(cat "$PARK_LOG")"
+assert_contains "residue calls hold-node with --kind worktree-residue" \
+  "tactic-res --kind worktree-residue" "$HOLD"
+
+# ============================================================================
+# Case 8c: exit 14 where hold-node itself fails -> failed, exit 1
+# ============================================================================
+echo "Case 8c: provision exit 14 with a failing hold-node -> failed, exit 1"
+PROV_RC=14 HOLD_RC=1 run_exec "tactic-resf:tactic:qa"
+assert_eq "residue hold-fail stdout" "failed tactic-resf hold-failed" "$OUT"
+assert_eq "residue hold-fail exit 1" "1" "$RC"
 
 # ============================================================================
 # Case 9: a failed spawn kick -> failed, exit 1

--- a/.claude/skills/dispatch-propagate/scripts/test-provision-node-worktree.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-provision-node-worktree.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# Script-level test harness for provision-node-worktree — the graph lane's
+# one-command worktree provisioning primitive
+# (tactic-provision-exit11-worktree-residue, Unit 2).
+#
+# DELIBERATE DEVIATION: the node's own Verification section and the sibling
+# node intentions/tactic-provision-worktree-script-tests.md both name
+# test-dispatch-scripts.sh as the target file for this coverage.
+# test-dispatch-scripts.sh is a `gh`-stub harness with NO git-worktree
+# fixtures, and forcing worktree fixtures into it would be worse for both
+# tactics than one purpose-built file. This new file is that purpose-built
+# host; it also creates the fixture scaffolding
+# tactic-provision-worktree-script-tests can extend for the
+# check-node-selection gate-plumbing coverage (arg forwarding, exit 12/13
+# pass-through, stamp write) that this file does NOT cover. That sibling
+# node's frontmatter `statement` has been updated to name this file instead
+# of test-dispatch-scripts.sh, so the two nodes point at the same host.
+#
+# Covers the three defects fixed in Unit 1 of
+# intentions/tactic-provision-exit11-worktree-residue.md:
+#   - Defect 1: an unusable worktree (dirty tracked tree, in-progress
+#     rebase/merge, detached HEAD) must exit 14, never fall through to the
+#     exit-11 conflict lane.
+#   - Defect 2: a stale LOCAL branch must not shadow the pushed
+#     origin/<node-id> tip.
+#   - Defect 3: orphan `.git/worktrees/<name>` registrations must be pruned
+#     so a re-provision of a manually-removed worktree succeeds.
+#
+# Harness (modeled on
+# .claude/skills/dispatch-propagate/scripts/test-dispatch-graph-execute.sh:39-119):
+# a bare origin repo + a `main` checkout (PROJECT_ROOT), with
+# DISPATCH_GRAPH_MAIN_WORKTREE pointing at it so
+# lib-graph-worktree.sh's resolve_main_worktree skips `git worktree list`.
+# The SUT and lib-graph-worktree.sh are copied into a scratch scripts dir so
+# "$SCRIPT_DIR/dispatch-ci-ready" resolves to a stub sibling (the CI gate is
+# not under test). PATH shims stand in for `npx` (the SUT's
+# check-node-selection.ts gate call — the shim ignores its args and always
+# prints a fixed fingerprint) and `direnv` (both subcommands exit 0). Does
+# NOT cover the check-node-selection gate plumbing itself (arg forwarding,
+# exit 12/13, stamp contents) — that is
+# tactic-provision-worktree-script-tests.
+#
+# Assertion helpers (assert_eq, assert_contains, report_results) come from
+# test-helpers.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/test-helpers.sh"
+
+# --- harness ------------------------------------------------------------
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+ORIGIN="$TMP/origin.git"
+MAIN_WT="$TMP/main"
+SUT_DIR="$TMP/scripts"
+BIN_DIR="$TMP/bin"
+STDERR_FILE="$TMP/stderr.log"
+
+mkdir -p "$SUT_DIR" "$BIN_DIR"
+
+git init -q --bare "$ORIGIN"
+git clone -q "$ORIGIN" "$MAIN_WT"
+git -C "$MAIN_WT" symbolic-ref HEAD refs/heads/main
+git -C "$MAIN_WT" config user.email test@example.com
+git -C "$MAIN_WT" config user.name "Test User"
+echo "seed" >"$MAIN_WT/README.md"
+git -C "$MAIN_WT" add README.md
+git -C "$MAIN_WT" commit -q -m "seed"
+git -C "$MAIN_WT" push -q -u origin main
+mkdir -p "$MAIN_WT/.claude/worktrees"
+
+export DISPATCH_GRAPH_MAIN_WORKTREE="$MAIN_WT"
+
+# Copy the SUT and its sourced lib so "$SCRIPT_DIR/<name>" inside the copy
+# resolves to the stub sibling below.
+cp "$SCRIPT_DIR/provision-node-worktree" "$SUT_DIR/provision-node-worktree"
+cp "$SCRIPT_DIR/lib-graph-worktree.sh" "$SUT_DIR/lib-graph-worktree.sh"
+chmod +x "$SUT_DIR/provision-node-worktree"
+
+# dispatch-ci-ready stub: the CI gate is not under test here.
+cat >"$SUT_DIR/dispatch-ci-ready" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$SUT_DIR/dispatch-ci-ready"
+
+# npx shim: the SUT runs `npx tsx …/check-node-selection.ts …`; ignore the
+# args and always report a fixed passing fingerprint.
+cat >"$BIN_DIR/npx" <<'STUB'
+#!/usr/bin/env bash
+echo "test-fixed-fingerprint"
+exit 0
+STUB
+chmod +x "$BIN_DIR/npx"
+
+# direnv shim: `direnv allow` / `direnv exec … true` both no-op successfully.
+cat >"$BIN_DIR/direnv" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$BIN_DIR/direnv"
+
+wt_path() { printf '%s/.claude/worktrees/%s\n' "$MAIN_WT" "$1"; }
+
+# add_commit_on_branch <branch> <file> <content> <msg> — commit onto an
+# EXISTING local branch via a throwaway linked worktree (so $MAIN_WT itself
+# never leaves `main`).
+add_commit_on_branch() {
+  local branch="$1" file="$2" content="$3" msg="$4"
+  local scratch="$TMP/setup-$branch"
+  git -C "$MAIN_WT" worktree add -q "$scratch" "$branch"
+  printf '%s\n' "$content" >"$scratch/$file"
+  git -C "$scratch" add "$file"
+  git -C "$scratch" commit -q -m "$msg"
+  git -C "$MAIN_WT" worktree remove --force "$scratch"
+}
+
+# create_branch_with_commit <branch> <base> <file> <content> <msg> — create a
+# new local branch at <base> and add one commit to it.
+create_branch_with_commit() {
+  local branch="$1" base="$2" file="$3" content="$4" msg="$5"
+  git -C "$MAIN_WT" branch "$branch" "$base"
+  add_commit_on_branch "$branch" "$file" "$content" "$msg"
+}
+
+make_plain_branch() {  # $1=branch $2=base — no commit, just the ref.
+  git -C "$MAIN_WT" branch "$1" "$2"
+}
+
+push_local_branch_to_origin() {  # $1=local branch $2=remote branch name
+  git -C "$MAIN_WT" push -q origin "refs/heads/$1:refs/heads/$2"
+}
+
+# run_prov <node-id> [phase] — run the SUT with the shimmed PATH and capture
+# stdout in PROV_OUT, stderr in PROV_STDERR, exit code in PROV_RC.
+PROV_OUT=""
+PROV_STDERR=""
+PROV_RC=0
+run_prov() {
+  local id="$1" phase="${2:-implement}"
+  set +e
+  PROV_OUT=$(PATH="$BIN_DIR:$PATH" DISPATCH_GRAPH_MAIN_WORKTREE="$MAIN_WT" \
+    "$SUT_DIR/provision-node-worktree" "$id" "$phase" 2>"$STDERR_FILE")
+  PROV_RC=$?
+  set -e
+  PROV_STDERR=$(cat "$STDERR_FILE")
+}
+
+# ==========================================================================
+# Case 1: clean tree + conflicting content on the branch -> exit 11, tree
+# clean afterwards.
+# ==========================================================================
+echo "Case 1: clean tree, conflicting content on the branch -> exit 11"
+id1="prov-case-conflict-clean"
+echo "orig1" >"$MAIN_WT/case1.txt"
+git -C "$MAIN_WT" add case1.txt
+git -C "$MAIN_WT" commit -q -m "seed case1.txt"
+git -C "$MAIN_WT" push -q origin main
+BASE1=$(git -C "$MAIN_WT" rev-parse origin/main)
+create_branch_with_commit "$id1" "$BASE1" "case1.txt" "branch-edit1" "case1 branch edit"
+WT1=$(wt_path "$id1")
+git -C "$MAIN_WT" worktree add -q "$WT1" "$id1"
+echo "main-edit1" >"$MAIN_WT/case1.txt"
+git -C "$MAIN_WT" add case1.txt
+git -C "$MAIN_WT" commit -q -m "case1 main edit"
+git -C "$MAIN_WT" push -q origin main
+
+run_prov "$id1"
+assert_eq "case1 exit 11" "11" "$PROV_RC"
+CLEAN1=$(git -C "$WT1" status --porcelain --untracked-files=no)
+assert_eq "case1 tree clean after conflict abort" "" "$CLEAN1"
+
+# ==========================================================================
+# Case 2: dirty tracked file -> exit 14, content byte-identical afterwards.
+# ==========================================================================
+echo "Case 2: dirty tracked file -> exit 14, nothing auto-discarded"
+id2="prov-case-dirty-tracked"
+TIP=$(git -C "$MAIN_WT" rev-parse origin/main)
+make_plain_branch "$id2" "$TIP"
+WT2=$(wt_path "$id2")
+git -C "$MAIN_WT" worktree add -q "$WT2" "$id2"
+printf 'dirty-edit\n' >>"$WT2/README.md"
+BEFORE2=$(cat "$WT2/README.md")
+
+run_prov "$id2"
+assert_eq "case2 exit 14" "14" "$PROV_RC"
+AFTER2=$(cat "$WT2/README.md")
+assert_eq "case2 file byte-identical after run" "$BEFORE2" "$AFTER2"
+assert_contains "case2 stderr names dirty-tracked-tree" "dirty-tracked-tree" "$PROV_STDERR"
+
+# ==========================================================================
+# Case 3: rebase-merge state present -> exit 0 after auto-repair, HEAD
+# reattached to the branch's pre-rebase tip, merge-tree vs origin/main clean.
+# ==========================================================================
+echo "Case 3: abandoned rebase -> auto-repaired, exit 0"
+id3="prov-case-rebase-repair"
+TIP3=$(git -C "$MAIN_WT" rev-parse origin/main)
+create_branch_with_commit "$id3" "$TIP3" "case3.txt" "id3-edit" "case3 own commit"
+WT3=$(wt_path "$id3")
+git -C "$MAIN_WT" worktree add -q "$WT3" "$id3"
+PRE_REBASE_HEAD=$(git -C "$WT3" rev-parse HEAD)
+create_branch_with_commit "prov-case-rebase-repair-target" "$TIP3" "case3.txt" "target-edit" "case3 conflicting target"
+set +e
+git -C "$WT3" rebase "prov-case-rebase-repair-target" >/dev/null 2>&1
+set -e
+
+run_prov "$id3"
+assert_eq "case3 exit 0 after auto-repair" "0" "$PROV_RC"
+POST_HEAD=$(git -C "$WT3" rev-parse HEAD)
+assert_eq "case3 HEAD reattached to pre-rebase tip" "$PRE_REBASE_HEAD" "$POST_HEAD"
+set +e
+git -C "$WT3" merge-tree --write-tree HEAD origin/main >/dev/null 2>&1
+MT_RC=$?
+set -e
+assert_eq "case3 merge-tree clean vs origin/main" "0" "$MT_RC"
+
+# ==========================================================================
+# Case 4: detached HEAD with no operation in progress -> exit 14.
+# ==========================================================================
+echo "Case 4: detached HEAD, no operation in progress -> exit 14"
+id4="prov-case-detached-head"
+TIP=$(git -C "$MAIN_WT" rev-parse origin/main)
+make_plain_branch "$id4" "$TIP"
+WT4=$(wt_path "$id4")
+git -C "$MAIN_WT" worktree add -q "$WT4" "$id4"
+git -C "$WT4" checkout -q --detach HEAD
+
+run_prov "$id4"
+assert_eq "case4 exit 14" "14" "$PROV_RC"
+assert_contains "case4 stderr names detached-head" "detached-head" "$PROV_STDERR"
+
+# ==========================================================================
+# Case 5: untracked-only files -> exit 0 (regression guard on
+# --untracked-files=no).
+# ==========================================================================
+echo "Case 5: untracked-only files -> exit 0"
+id5="prov-case-untracked-only"
+TIP=$(git -C "$MAIN_WT" rev-parse origin/main)
+make_plain_branch "$id5" "$TIP"
+WT5=$(wt_path "$id5")
+git -C "$MAIN_WT" worktree add -q "$WT5" "$id5"
+echo "junk" >"$WT5/untracked.txt"
+
+run_prov "$id5"
+assert_eq "case5 exit 0 (untracked files do not trip the guard)" "0" "$PROV_RC"
+
+# ==========================================================================
+# Case 6: local branch strictly behind origin/<id> -> provisioned HEAD
+# equals the pushed tip, not the stale local ref.
+# ==========================================================================
+echo "Case 6: local branch behind origin/<id> -> HEAD is the pushed tip"
+id6="prov-case-behind-remote"
+TIP6=$(git -C "$MAIN_WT" rev-parse origin/main)
+make_plain_branch "$id6" "$TIP6"
+create_branch_with_commit "$id6-remote-scratch" "$TIP6" "case6.txt" "remote-ahead" "case6 ahead commit"
+PUSHED_SHA6=$(git -C "$MAIN_WT" rev-parse "$id6-remote-scratch")
+push_local_branch_to_origin "$id6-remote-scratch" "$id6"
+git -C "$MAIN_WT" branch -D "$id6-remote-scratch"
+
+run_prov "$id6"
+assert_eq "case6 exit 0" "0" "$PROV_RC"
+WT6=$(wt_path "$id6")
+ACTUAL6=$(git -C "$WT6" rev-parse HEAD)
+assert_eq "case6 HEAD is the pushed tip, not the stale local ref" "$PUSHED_SHA6" "$ACTUAL6"
+
+# ==========================================================================
+# Case 7: local branch ahead of origin/<id> -> local commits survive
+# provisioning (regression guard against `worktree add -B`).
+# ==========================================================================
+echo "Case 7: local branch ahead of origin/<id> -> local commits survive"
+id7="prov-case-ahead-remote"
+TIP7=$(git -C "$MAIN_WT" rev-parse origin/main)
+make_plain_branch "$id7" "$TIP7"
+push_local_branch_to_origin "$id7" "$id7"
+add_commit_on_branch "$id7" "case7.txt" "local-ahead" "case7 ahead commit"
+
+run_prov "$id7"
+assert_eq "case7 exit 0" "0" "$PROV_RC"
+WT7=$(wt_path "$id7")
+ACTUAL7=$(cat "$WT7/case7.txt" 2>/dev/null || echo MISSING)
+assert_eq "case7 local-only commit survives provisioning" "local-ahead" "$ACTUAL7"
+
+# ==========================================================================
+# Case 8: local branch diverged from origin/<id> with a conflicting change
+# -> exit 11, tree clean afterwards.
+# ==========================================================================
+echo "Case 8: local branch diverged from origin/<id> -> exit 11"
+id8="prov-case-diverged-remote"
+TIP8=$(git -C "$MAIN_WT" rev-parse origin/main)
+create_branch_with_commit "$id8" "$TIP8" "case8.txt" "remote-edit" "case8 remote commit"
+push_local_branch_to_origin "$id8" "$id8"
+git -C "$MAIN_WT" branch -D "$id8"
+create_branch_with_commit "$id8" "$TIP8" "case8.txt" "local-edit" "case8 local commit"
+
+run_prov "$id8"
+assert_eq "case8 exit 11" "11" "$PROV_RC"
+WT8=$(wt_path "$id8")
+CLEAN8=$(git -C "$WT8" status --porcelain --untracked-files=no)
+assert_eq "case8 tree clean after divergence conflict abort" "" "$CLEAN8"
+
+# ==========================================================================
+# Case 9: orphan registration -> `git worktree prune` clears it, so a
+# re-provision succeeds.
+# ==========================================================================
+echo "Case 9: orphan worktree registration -> prune clears it, re-add succeeds"
+id9="prov-case-orphan-prune"
+
+run_prov "$id9"
+assert_eq "case9 first provision exit 0" "0" "$PROV_RC"
+WT9=$(wt_path "$id9")
+assert_eq "case9 worktree exists after first provision" "yes" "$([[ -d "$WT9" ]] && echo yes || echo no)"
+rm -rf "$WT9"
+
+run_prov "$id9"
+assert_eq "case9 re-provision exit 0 after orphan prune" "0" "$PROV_RC"
+assert_eq "case9 worktree recreated" "yes" "$([[ -d "$WT9" ]] && echo yes || echo no)"
+
+report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-provision-node-worktree.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-provision-node-worktree.sh
@@ -95,9 +95,14 @@ exit 0
 STUB
 chmod +x "$BIN_DIR/npx"
 
-# direnv shim: `direnv allow` / `direnv exec … true` both no-op successfully.
-cat >"$BIN_DIR/direnv" <<'STUB'
+# direnv shim: `direnv allow` / `direnv exec … true` both no-op successfully,
+# and each invocation is journalled so a test can assert the .envrc gate
+# refused BEFORE anything approved or executed the file.
+DIRENV_LOG="$TMP/direnv.log"
+: >"$DIRENV_LOG"
+cat >"$BIN_DIR/direnv" <<STUB
 #!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$DIRENV_LOG"
 exit 0
 STUB
 chmod +x "$BIN_DIR/direnv"
@@ -316,5 +321,114 @@ rm -rf "$WT9"
 run_prov "$id9"
 assert_eq "case9 re-provision exit 0 after orphan prune" "0" "$PROV_RC"
 assert_eq "case9 worktree recreated" "yes" "$([[ -d "$WT9" ]] && echo yes || echo no)"
+
+# ==========================================================================
+# Case 10: the OPPOSITE of case 9 — the registration is gone but the
+# DIRECTORY survives (`rm <wt>/.git` + prune). The directory then sits inside
+# the project root's own working tree with no `.git` file, so every
+# `git -C "$WT" …` resolves to the PROJECT ROOT. The identity assertion must
+# refuse (exit 2, `orphan-directory`) before running any of them — in
+# particular it must NOT abort the main checkout's in-progress rebase, and
+# must NOT report the main checkout's dirt as this node's residue (exit 14).
+# ==========================================================================
+echo "Case 10: orphan directory (registration pruned, files left) -> exit 2, main checkout untouched"
+id10="prov-case-orphan-directory"
+
+run_prov "$id10"
+assert_eq "case10 first provision exit 0" "0" "$PROV_RC"
+WT10=$(wt_path "$id10")
+rm -f "$WT10/.git"
+git -C "$MAIN_WT" worktree prune
+echo "residue-content" >"$WT10/residue.txt"
+
+# Stage an in-progress, conflicted rebase in the MAIN checkout. Pre-fix, the
+# guard's `git -C "$WT" rebase --abort` aborted exactly this.
+git -C "$MAIN_WT" checkout -q -b case10-topic
+echo "topic" >"$MAIN_WT/case10.txt"
+git -C "$MAIN_WT" add case10.txt
+git -C "$MAIN_WT" commit -q -m "case10 topic edit"
+git -C "$MAIN_WT" checkout -q main
+echo "mainline" >"$MAIN_WT/case10.txt"
+git -C "$MAIN_WT" add case10.txt
+git -C "$MAIN_WT" commit -q -m "case10 main edit"
+git -C "$MAIN_WT" checkout -q case10-topic
+set +e
+git -C "$MAIN_WT" rebase main >/dev/null 2>&1
+set -e
+assert_eq "case10 fixture: main checkout is mid-rebase" "yes" \
+  "$([[ -d "$MAIN_WT/.git/rebase-merge" || -d "$MAIN_WT/.git/rebase-apply" ]] && echo yes || echo no)"
+
+run_prov "$id10"
+assert_eq "case10 exit 2 (orphan directory is not a worktree)" "2" "$PROV_RC"
+assert_contains "case10 stderr names the orphan-directory refusal" \
+  "is not the linked worktree for" "$PROV_STDERR"
+assert_eq "case10 main checkout's rebase NOT aborted" "yes" \
+  "$([[ -d "$MAIN_WT/.git/rebase-merge" || -d "$MAIN_WT/.git/rebase-apply" ]] && echo yes || echo no)"
+assert_eq "case10 residue left untouched" "residue-content" "$(cat "$WT10/residue.txt")"
+
+set +e
+git -C "$MAIN_WT" rebase --abort >/dev/null 2>&1
+git -C "$MAIN_WT" checkout -q main
+set -e
+
+# ==========================================================================
+# Cases 11-12: the .envrc provenance gate. Provisioning merges
+# origin/<node-id> into the worktree and then `direnv allow` / `direnv exec`
+# it on the operator's host with the sandbox disabled, so an .envrc that is
+# not already on origin/main must never be approved or executed.
+# From here on origin/main carries an .envrc.
+# ==========================================================================
+echo "Cases 11-12: .envrc provenance gate"
+printf 'export CASE_ENVRC=1\n' >"$MAIN_WT/.envrc"
+git -C "$MAIN_WT" add .envrc
+git -C "$MAIN_WT" commit -q -m "add .envrc"
+git -C "$MAIN_WT" push -q origin main
+ENVRC_TIP=$(git -C "$MAIN_WT" rev-parse origin/main)
+
+# Case 11: .envrc matching origin/main -> exit 0, direnv ran.
+id11="prov-case-envrc-match"
+make_plain_branch "$id11" "$ENVRC_TIP"
+: >"$DIRENV_LOG"
+run_prov "$id11"
+assert_eq "case11 exit 0 (.envrc identical to origin/main)" "0" "$PROV_RC"
+assert_eq "case11 direnv ran" "yes" \
+  "$([[ -s "$DIRENV_LOG" ]] && echo yes || echo no)"
+
+# Case 12: the node branch rewrites .envrc -> exit 2, direnv never invoked.
+id12="prov-case-envrc-drift"
+create_branch_with_commit "$id12" "$ENVRC_TIP" ".envrc" \
+  'export CASE_ENVRC=1; echo pwned' "case12 hostile .envrc"
+: >"$DIRENV_LOG"
+run_prov "$id12"
+assert_eq "case12 exit 2 (.envrc differs from origin/main)" "2" "$PROV_RC"
+assert_contains "case12 stderr names the .envrc refusal" \
+  "refusing to direnv allow/exec" "$PROV_STDERR"
+assert_eq "case12 direnv never invoked" "" "$(cat "$DIRENV_LOG")"
+
+# ==========================================================================
+# Case 13: the worktree IS this node's registered worktree, but it has some
+# OTHER branch checked out. The identity assertion passes (the git dir is
+# .git/worktrees/<node-id>), so without the branch check the pushed-tip merge
+# would merge origin/<node-id> into the unrelated branch and the phase agent
+# would be handed a cwd deriving the wrong BRANCH. Expect exit 14
+# (`wrong-branch`), with the foreign branch's own commit untouched.
+# ==========================================================================
+echo "Case 13: worktree on a foreign branch -> exit 14 (wrong-branch)"
+id13="prov-case-wrong-branch"
+TIP13=$(git -C "$MAIN_WT" rev-parse origin/main)
+make_plain_branch "$id13" "$TIP13"
+WT13=$(wt_path "$id13")
+git -C "$MAIN_WT" worktree add -q "$WT13" "$id13"
+git -C "$WT13" checkout -q -b "$id13-foreign"
+echo "foreign-work" >"$WT13/case13.txt"
+git -C "$WT13" add case13.txt
+git -C "$WT13" commit -q -m "case13 foreign-branch commit"
+FOREIGN_HEAD13=$(git -C "$WT13" rev-parse HEAD)
+
+run_prov "$id13"
+assert_eq "case13 exit 14" "14" "$PROV_RC"
+assert_contains "case13 stderr names wrong-branch" "wrong-branch" "$PROV_STDERR"
+assert_eq "case13 foreign branch still checked out, untouched" "$FOREIGN_HEAD13" \
+  "$(git -C "$WT13" rev-parse HEAD)"
 
 report_results

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -220,6 +220,8 @@ jobs:
         run: .claude/skills/dispatch-propagate/scripts/test-mark-node-terminal.sh
       - name: Run dispatch-graph-execute tests
         run: .claude/skills/dispatch-propagate/scripts/test-dispatch-graph-execute.sh
+      - name: Run provision-node-worktree tests
+        run: .claude/skills/dispatch-propagate/scripts/test-provision-node-worktree.sh
       - name: Run dispatch-derive-node-target tests
         run: .claude/skills/dispatch-propagate/scripts/test-dispatch-derive-node-target.sh
       - name: Run dispatch-daemon-liveness sensor tests

--- a/intentions/tactic-provision-worktree-script-tests.md
+++ b/intentions/tactic-provision-worktree-script-tests.md
@@ -3,7 +3,7 @@ id: tactic-provision-worktree-script-tests
 kind: tactic
 statement: Add script-level test coverage for provision-node-worktree's
   worker-start gate integration (selected-phase arg, exit 12/13 pass-through,
-  scope-fingerprint stamp write) in test-dispatch-scripts.sh
+  scope-fingerprint stamp write) in test-provision-node-worktree.sh
 owner: ai
 status: raw
 parent: null

--- a/packages/intentionsutil/scripts/graph-commit
+++ b/packages/intentionsutil/scripts/graph-commit
@@ -409,6 +409,27 @@ check_base_freshness() {
 # failure never masks the real exit status.
 cleanup() {
   local rc=$?
+  # Abort a rebase this run stranded. main() refuses to start at all when a
+  # rebase is ALREADY in progress (see the pre-flight check there, which
+  # deliberately runs BEFORE this trap is installed), so any rebase still in
+  # progress here was necessarily started by THIS run's `git pull --rebase` —
+  # that is the load-bearing premise for aborting unconditionally, with no
+  # separate "did we start it" flag.
+  #
+  # This MUST precede the RESTORE_HEAD `git reset --hard` below: a reset --hard
+  # inside a live rebase moves the tree but leaves the rebase state dir behind,
+  # which is exactly the mid-operation residue this is meant to clear.
+  #
+  # Deliberately incomplete: a SIGKILL fires no trap at all, so this cannot be
+  # the only defense. provision-node-worktree's precondition guard (which
+  # detects and repairs an abandoned rebase before handing a worktree to a
+  # session) is the primary one; this is the secondary, cheap backstop.
+  # Best-effort (|| true), on the same footing as the lock release and the
+  # scratch-branch delete below — its failure must never mask the real exit
+  # status, which this function still returns as $rc.
+  if rebase_in_progress; then
+    git rebase --abort >&2 || true
+  fi
   # Restore the original (far-ahead) HEAD if ensure_intentions_only_base() moved
   # the worktree onto origin/main to land an intentions/-only SHA. The intended
   # edit is already on main by this point (or failed to land); either way the
@@ -1416,6 +1437,22 @@ main() {
   fi
   INTENTIONS_DIR="$REPO_ROOT/intentions"
   cd "$REPO_ROOT"
+
+  # Refuse to run on a mid-operation worktree. A clear error at a system edge,
+  # not a fallback: a rebase in progress means someone (or something) else owns
+  # this checkout's HEAD right now, and graph-commit's own rebase/reset flow
+  # would compound the damage.
+  #
+  # Placement is load-bearing — this must run BEFORE `trap cleanup EXIT` is
+  # installed further down. cleanup() aborts any rebase in progress on exit; if
+  # this refusal ran after the trap were armed, the very die() below would abort
+  # the caller's own rebase — including an `edit`-stopped one, which leaves a
+  # CLEAN tree and would otherwise slip past assert_clean_outside_ids entirely.
+  # Refusing before the trap exists is what makes cleanup()'s unconditional
+  # abort provably safe: any rebase seen there was started by this run.
+  if rebase_in_progress; then
+    die "a rebase is already in progress in $REPO_ROOT — graph-commit will not run on a mid-operation worktree; finish or 'git rebase --abort' it first"
+  fi
 
   if [[ "${#IDS[@]}" -eq 0 && "${#PRUNE_IDS[@]}" -eq 0 ]]; then
     usage

--- a/packages/intentionsutil/scripts/hold-node
+++ b/packages/intentionsutil/scripts/hold-node
@@ -31,7 +31,8 @@
 # for it.
 #
 # Usage:
-#   hold-node <source-node-id> --kind <provision-conflict|fix-attempt-cap>
+#   hold-node <source-node-id>
+#             --kind <provision-conflict|fix-attempt-cap|worktree-residue>
 #             --reason-file <f> --recommendation-file <f>
 #             [--body-file <f>] [--reset-fix-attempt]
 #
@@ -60,7 +61,7 @@ DUMP_NODE_TS="$SCRIPT_DIR/dump-node.ts"
 APPLY_FIX_TS="$SCRIPT_DIR/apply-fix-state.ts"
 GRAPH_COMMIT="$SCRIPT_DIR/graph-commit"
 
-USAGE="usage: hold-node <source-node-id> --kind <provision-conflict|fix-attempt-cap> --reason-file <f> --recommendation-file <f> [--body-file <f>] [--reset-fix-attempt]"
+USAGE="usage: hold-node <source-node-id> --kind <provision-conflict|fix-attempt-cap|worktree-residue> --reason-file <f> --recommendation-file <f> [--body-file <f>] [--reset-fix-attempt]"
 
 SOURCE_ID=""
 KIND=""

--- a/packages/intentionsutil/scripts/hold-node-decide.ts
+++ b/packages/intentionsutil/scripts/hold-node-decide.ts
@@ -18,7 +18,7 @@
 //
 // Usage:
 //   node --import tsx/esm hold-node-decide.ts --source <id>
-//     --kind <provision-conflict|fix-attempt-cap>
+//     --kind <provision-conflict|fix-attempt-cap|worktree-residue>
 //     --reason-file <f> --recommendation-file <f>
 //     [--body-file <f>] [--now <YYYY-MM-DD>] [--intentions <dir>]
 //
@@ -44,30 +44,49 @@ import type { IntentionNode } from "../src/schema.js";
  *  - `fix-cap`     — fix-attempt-cap: the CI-fix interrupt exhausted
  *                    FIX_ATTEMPT_CAP attempts (see src/transitions.ts).
  *                    IMPLEMENTED.
+ *  - `residue`     — worktree-residue: provision-node-worktree refused to
+ *                    provision the node's worktree because it carries
+ *                    mechanical residue from a dead session (exit 14 — a dirty
+ *                    tracked tree, or a detached HEAD / in-progress operation
+ *                    that could not be auto-repaired). NOT a content conflict:
+ *                    origin/main merges clean once the residue is cleared, so
+ *                    it never reaches the /dispatch-conflict lane. It is a
+ *                    steady state with no autonomous repair path, so the
+ *                    producer escalates on the FIRST occurrence — there is no
+ *                    strike ladder in front of it. IMPLEMENTED.
  *  - `no-progress` — RESERVED for a different tactic's future per-node
  *                    no-progress fuse. Deliberately NOT wired to a producer
  *                    kind or a CLI case here; the name is reserved so the id
  *                    scheme (`tactic-hold-no-progress-<source>`) is documented
  *                    and cannot be claimed for something else.
  */
-export const HOLD_KINDS = ["provision-conflict", "fix-attempt-cap"] as const;
+export const HOLD_KINDS = [
+  "provision-conflict",
+  "fix-attempt-cap",
+  "worktree-residue",
+] as const;
 
 export type HoldKind = (typeof HOLD_KINDS)[number];
 
 const KIND_SLUGS: Record<HoldKind, string> = {
   "provision-conflict": "conflict",
   "fix-attempt-cap": "fix-cap",
+  "worktree-residue": "residue",
 };
 
-/** Type guard narrowing a raw CLI string to `HoldKind`. */
+/**
+ * Type guard narrowing a raw CLI string to `HoldKind`. Derived from HOLD_KINDS
+ * (the single source of truth) rather than an enumerated `||` chain, so adding
+ * a kind above cannot leave a stale second list behind here.
+ */
 function isHoldKind(k: string): k is HoldKind {
-  return k === "provision-conflict" || k === "fix-attempt-cap";
+  return (HOLD_KINDS as readonly string[]).includes(k);
 }
 
 /** Reserved-but-unimplemented kind slugs (see KIND_SLUGS' doc comment). */
 export const RESERVED_KIND_SLUGS: readonly string[] = ["no-progress"];
 
-/** The node-id slug shape provision-node-worktree:56 enforces. */
+/** The node-id slug shape provision-node-worktree:79 enforces. */
 const NODE_ID_RE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
 
 /** The load-bearing closing sentence of every hold body's "How to resolve". */
@@ -98,7 +117,7 @@ export interface HoldInput {
 
 /**
  * Derive the deterministic hold id and assert it matches the node-id slug shape
- * enforced at .claude/skills/dispatch-propagate/scripts/provision-node-worktree:56.
+ * enforced at .claude/skills/dispatch-propagate/scripts/provision-node-worktree:79.
  * Throws (the CLI turns this into a non-zero exit + stderr) rather than emitting
  * an id the provisioner would later reject.
  */
@@ -288,7 +307,9 @@ function parseArgs(argv: string[]): Args {
   }
 
   if (sourceId === null || sourceId === "") fail("--source <node-id> is required");
-  if (kind === null) fail("--kind <provision-conflict|fix-attempt-cap> is required");
+  if (kind === null) {
+    fail("--kind <provision-conflict|fix-attempt-cap|worktree-residue> is required");
+  }
   if (!isHoldKind(kind)) {
     fail(`--kind must be one of ${HOLD_KINDS.join("|")}, got "${kind}"`);
   }

--- a/packages/intentionsutil/scripts/resolve-hold
+++ b/packages/intentionsutil/scripts/resolve-hold
@@ -75,10 +75,14 @@
 # `blocked_by` still names the hold is rejected by validate-graph, so prune
 # ordering is a separate concern (the owed-prune census), not this script's.
 #
-# Usage: resolve-hold <source-node-id> [--kind <provision-conflict|fix-attempt-cap>]
+# Usage: resolve-hold <source-node-id> [--kind <provision-conflict|fix-attempt-cap|worktree-residue>]
 #
 # --kind defaults to `provision-conflict` (the Lane-3 case). It selects which
 #   hold id is resolved, since a source can in principle carry one hold per kind.
+#   The list must stay in sync with hold-node-decide.ts's HOLD_KINDS — a kind
+#   missing from it here is silently undrainable in practice: a human reading
+#   the usage omits --kind and resolves a hold that does not exist (an
+#   idempotent no-op), leaving the real hold in place.
 #
 # Stdout on success: exactly one line — `resolved <hold-id> (unblocked <source-id>)`.
 #
@@ -102,7 +106,7 @@ DUMP_NODE_TS="$SCRIPT_DIR/dump-node.ts"
 WRITE_NODE_TS="$SCRIPT_DIR/write-node.ts"
 GRAPH_COMMIT="$SCRIPT_DIR/graph-commit"
 
-USAGE="usage: resolve-hold <source-node-id> [--kind <provision-conflict|fix-attempt-cap>]"
+USAGE="usage: resolve-hold <source-node-id> [--kind <provision-conflict|fix-attempt-cap|worktree-residue>]"
 
 SOURCE_ID=""
 KIND="provision-conflict"

--- a/packages/intentionsutil/scripts/test-graph-commit.sh
+++ b/packages/intentionsutil/scripts/test-graph-commit.sh
@@ -116,6 +116,14 @@
 #      naming "mis-pointed -C/--repo", never reaches "landed", main untouched
 #  35. --expect on a --prune id is a usage error (exit 2, origin untouched) —
 #      a deletion has no content to assert
+#  36. a rebase ALREADY in progress in the target checkout: refused up front
+#      (non-zero exit naming "already in progress"), main untouched, zero gh
+#      calls — graph-commit never runs on a mid-operation worktree, so a
+#      caller's own stopped rebase is never aborted by case 37's cleanup
+#  37. a rebase THIS run stranded (a die() fires while the pull --rebase
+#      conflict is still live) is aborted by cleanup(): no rebase state dir
+#      survives, HEAD is reattached to the branch, and the checkout's local
+#      commits are intact
 #
 # No network and no real gh/node needed; requires only bash + git + jq.
 
@@ -174,7 +182,8 @@ for id in t-happy t-merge t-conflict t-ckfail t-ghfail t-pending t-desync v1..v2
           t-farahead t-farahead-prune t-prune-conflict t-dirty-preflight \
           t-cwd-target t-fail-loud-diff t-fail-loud-benign \
           t-lock-contend t-lock-steal t-lock-wait t-lock-hygiene \
-          t-expect-happy t-expect-wrong-repo t-expect-prune; do
+          t-expect-happy t-expect-wrong-repo t-expect-prune \
+          t-preexist-conflict t-preexist-rebase t-strand-other t-strand-main; do
   seed_node "$id"
 done
 
@@ -1269,6 +1278,87 @@ if [[ $rc -eq 2 ]] \
   ok "--expect on a --prune id is a usage error (exit 2), origin untouched"
 else
   no "--expect on a prune id (rc=$rc)"; printf '%s\n' "$out"
+fi
+
+# --- Case 36: a pre-existing rebase is refused up front -------------------------
+# graph-commit must not run on a mid-operation worktree. The refusal runs before
+# the EXIT trap is installed, precisely so this caller-owned rebase survives the
+# refusal untouched (case 37's cleanup abort would otherwise destroy it).
+set_mode green
+W36="$WORK/w36"; make_clone "$W36" writer-36
+sync_clone "$W36"
+OTHER36="$WORK/other36"; make_clone "$OTHER36" other36
+sync_clone "$OTHER36"
+edit_line "$OTHER36" t-preexist-conflict 1 landed-remote
+git -C "$OTHER36" commit -qam 'concurrent edit lands on origin (case 36 fixture)'
+git -C "$OTHER36" push -q origin main
+# W36 is now stale: give it a conflicting local commit and start the rebase that
+# stops on it, leaving a live rebase state dir and a detached HEAD.
+edit_line "$W36" t-preexist-conflict 1 local-side
+git -C "$W36" commit -qam 'local conflicting commit (case 36 fixture)'
+git -C "$W36" fetch -q origin main
+git -C "$W36" rebase FETCH_HEAD >/dev/null 2>&1
+rebase_started=0
+[[ -d "$W36/.git/rebase-merge" || -d "$W36/.git/rebase-apply" ]] && rebase_started=1
+# An unrelated node edit, so the invocation would otherwise be a normal landing.
+edit_line "$W36" t-preexist-rebase 1 should-never-land
+set_mode green   # resets the gh call log
+before_sha="$(origin_sha)"
+out="$(run_gc "$W36" -m 'test: pre-existing rebase' t-preexist-rebase 2>&1)"; rc=$?
+after_sha="$(origin_sha)"
+if [[ "$rebase_started" -eq 1 && $rc -ne 0 ]] \
+   && grep -q 'a rebase is already in progress' <<<"$out" \
+   && [[ "$after_sha" == "$before_sha" ]] \
+   && [[ "$(gh_calls)" -eq 0 ]]; then
+  ok "pre-existing rebase: refused up front, main untouched, zero gh calls"
+else
+  no "pre-existing rebase refusal (rebase_started=$rebase_started rc=$rc gh_calls=$(gh_calls))"; printf '%s\n' "$out"
+fi
+# The caller's rebase must still be there — the refusal aborts nothing.
+if [[ -d "$W36/.git/rebase-merge" || -d "$W36/.git/rebase-apply" ]]; then
+  ok "pre-existing rebase: the caller's own rebase is left in progress, not aborted"
+else
+  no "pre-existing rebase: the caller's rebase was destroyed by the refusal"
+fi
+git -C "$W36" rebase --abort >/dev/null 2>&1
+
+# --- Case 37: a rebase this run stranded is aborted by cleanup() ----------------
+# End-to-end (not the sourced-function fallback): the run is driven down a real
+# die() that fires while `git pull --rebase origin main`'s conflict is still
+# live. The lever is try_layer2_resolve()'s broken-staging-invariant die — an
+# EXTRA local commit touching a DIFFERENT node id conflicts on the rebase, and
+# that conflicted path is outside this invocation's node set, so layer 2 dies
+# instead of reaching its own explicit `git rebase --abort`. Only cleanup() can
+# clear the rebase on this path. (The extra commit is intentions/-only, so
+# ensure_intentions_only_base() leaves the worktree alone and the commit
+# survives to be replayed.)
+set_mode green
+W37="$WORK/w37"; make_clone "$W37" writer-37
+sync_clone "$W37"
+OTHER37="$WORK/other37"; make_clone "$OTHER37" other37
+sync_clone "$OTHER37"
+edit_line "$OTHER37" t-strand-other 1 landed-remote
+git -C "$OTHER37" commit -qam 'concurrent edit lands on origin (case 37 fixture)'
+git -C "$OTHER37" push -q origin main
+edit_line "$W37" t-strand-other 1 local-strand
+git -C "$W37" commit -qam 'local conflicting commit on an out-of-set node (case 37 fixture)'
+edit_line "$W37" t-strand-main 1 strand-edit   # the node actually passed to graph-commit
+before_sha="$(origin_sha)"
+out="$(run_gc "$W37" -m 'test: stranded rebase' t-strand-main 2>&1)"; rc=$?
+after_sha="$(origin_sha)"
+if [[ $rc -ne 0 ]] \
+   && grep -q 'unexpected conflicted path' <<<"$out" \
+   && [[ "$after_sha" == "$before_sha" ]]; then
+  ok "stranded rebase: the run dies mid-rebase on the broken-staging-invariant path"
+else
+  no "stranded rebase setup (rc=$rc)"; printf '%s\n' "$out"
+fi
+if [[ ! -d "$W37/.git/rebase-merge" && ! -d "$W37/.git/rebase-apply" ]] \
+   && [[ "$(git -C "$W37" symbolic-ref -q HEAD)" == "refs/heads/main" ]] \
+   && git -C "$W37" show HEAD:intentions/t-strand-other.md | grep -q 'line1: local-strand'; then
+  ok "stranded rebase: cleanup() aborted it — no state dir, HEAD reattached, local commits intact"
+else
+  no "stranded rebase not aborted by cleanup (HEAD=$(git -C "$W37" symbolic-ref -q HEAD))"; printf '%s\n' "$out"
 fi
 
 # --- No scratch branches left behind anywhere ------------------------------------

--- a/packages/intentionsutil/test/hold-node-decide.test.ts
+++ b/packages/intentionsutil/test/hold-node-decide.test.ts
@@ -69,6 +69,12 @@ describe("holdIdFor", () => {
     );
   });
 
+  it("derives the residue slug id for worktree-residue", () => {
+    expect(holdIdFor("worktree-residue", "tactic-some-work")).toBe(
+      "tactic-hold-residue-some-work",
+    );
+  });
+
   it("strips only a leading tactic- prefix", () => {
     expect(holdIdFor("provision-conflict", "strategy-thing")).toBe(
       "tactic-hold-conflict-strategy-thing",
@@ -145,6 +151,15 @@ describe("decideHold dispositions", () => {
     expect(d.node?.attributes).toEqual({
       hold_for: SOURCE,
       hold_kind: "fix-attempt-cap",
+    });
+  });
+
+  it("uses the residue hold id when the kind is worktree-residue", () => {
+    const d = decideHold([source()], input({ kind: "worktree-residue" }));
+    expect(d.hold_id).toBe("tactic-hold-residue-some-work");
+    expect(d.node?.attributes).toEqual({
+      hold_for: SOURCE,
+      hold_kind: "worktree-residue",
     });
   });
 


### PR DESCRIPTION
Implements the graph node `tactic-provision-exit11-worktree-residue`.

## Summary

`provision-node-worktree` is the graph lane's one-command worktree provisioning
primitive; `dispatch-graph-execute` routes entirely on its exit code. Three
distinct defects there funneled unrelated failure modes into the same wrong
lane (exit 11, the content-conflict lane), and a fourth defect in `graph-commit`
produced one of those failure modes in the first place.

- **Defect 1** — a dirty tracked tree, an abandoned rebase, and a genuine
  merge conflict all collapsed into exit 11. Neither of the first two is
  transient, so the strike ladder burned its cap deterministically and
  produced a factually wrong hold reason.
- **Defect 2** — a stale local branch shadowed the pushed remote tip on the
  reused-worktree path, silently handing agents old code and manufacturing
  false exit-11 dispatches from a third direction.
- **Defect 3** — orphan worktree registrations were never pruned, permanently
  blocking re-registration of a path git still believed was taken.
- **Defect 4** — `graph-commit`'s `cleanup()` had no backstop for an
  in-progress rebase, so any exit that missed the single explicit
  `git rebase --abort` site (a tool timeout, a session reap, an unexpected
  `die()`) stranded the rebase in the node's worktree permanently — the
  mechanism that produces defect 1's "abandoned rebase" mode.

## What changed

1. **`provision-node-worktree`** — prunes orphan registrations up front;
   hoists the remote-branch fetch so the reused-worktree path also aligns to
   its own pushed tip (a real merge, not a force-reset, so unpushed local
   commits survive); adds a precondition guard (new exit **14**) that
   auto-repairs an in-progress rebase/merge/cherry-pick, but never
   auto-discards a dirty tracked tree or a detached HEAD with no operation in
   progress; and hardens the existing origin/main merge-abort to a checked
   abort.
2. **New test harness** `test-provision-node-worktree.sh` — 9 cases covering
   every exit-11/14/0 path, pushed-tip alignment (behind/ahead/diverged), and
   orphan-registration pruning. Wired into CI. This is a deliberate deviation
   from the node's own Verification section and from the sibling node
   `tactic-provision-worktree-script-tests`, both of which named the existing
   `test-dispatch-scripts.sh` (a `gh`-stub harness with no git-worktree
   fixtures) as the target — see the new file's header for the full rationale.
   The sibling node's `statement` was repointed at the new file so both nodes
   agree on the host.
3. **`dispatch-graph-execute` + `hold-node-decide.ts` + `hold-node`** — a new
   `worktree-residue` hold kind, and a no-strike-ladder `14)` arm that holds
   on the *first* occurrence (exit 14 is a steady state; retries cannot help)
   with the `git status`/`git diff --stat` evidence baked into the hold's
   reason file. `dispatch-conflict/SKILL.md` documents that this hold kind
   deliberately lands outside its lane.
4. **`graph-commit`** — refuses to start if a rebase is already in progress
   (protects a caller's own `edit`-stopped rebase), and aborts any rebase this
   run itself strands, as the first step of `cleanup()`. Deliberately
   incomplete (a SIGKILL fires no trap), so Unit 1's provision-side guard
   remains the primary defense.

## Self-modification note

This tactic edits `.claude/skills/**`. The commits landed normally in this
session (script-first `commit-merge-push`, no denial encountered) rather than
being blocked by the permission classifier as anticipated by the node's own
"Notes for the implementer" — noting this in case it's relevant to how this PR
is routed downstream.

## Verification deviation

The plan's `## Verification` section hardcodes
`cd /home/.../.claude/worktrees/strategy-graph-native-dispatch` in every
```verify``` block — a stale, unrelated worktree (different branch, detached
HEAD) left over from wherever the planning session ran. All checks were run
instead from this PR's own worktree root, per the surrounding prose ("Run from
the worktree root"): `test-provision-node-worktree.sh` (21/21),
`test-dispatch-graph-execute.sh` (100/100), `test-graph-commit.sh` (50/50),
`test-hold-node.sh` (11/11), `vitest run --project packages/intentionsutil`
(719/719), `run-typecheck.sh`, `run-lint.sh`, and `validate-graph.ts` all pass.
`git worktree prune --dry-run -v` reports no orphan registrations remaining.
