### PR TITLE
qa-main cannot-verify park: pin diagnosis-time --base through the Stop hook

### DIFF
--- a/.claude/hooks/dispatch-stop.sh
+++ b/.claude/hooks/dispatch-stop.sh
@@ -26,7 +26,15 @@
 # label. When the session also left an office-hours-pr marker, that PR number is
 # threaded through to park-node's own --pr flag so the park records
 # execution.pr (tactic-office-hours-pr-custody) — still gh-free: this hook only
-# reads a file the session already wrote, no network call.
+# reads a file the session already wrote, no network call. When the session also
+# left an office-hours-base marker (a 40-hex blob sha of the node at origin/main,
+# read at the session's DIAGNOSIS time), it is threaded through to park-node's
+# own --base flag so the park is a compare-and-swap: it lands only against the
+# state the session actually diagnosed, and otherwise refuses with exit 3
+# (`stale-diagnosis`) having written nothing, rather than silently reverting a
+# newer transition that landed while the session was still verifying
+# (tactic-qa-main-park-base-cas; incident 2026-07-28). The marker is OPT-IN: its
+# absence keeps today's unpinned park.
 #
 # CRITICAL: `Stop` fires whenever the model YIELDS THE TURN, not only on terminal
 # exit. A worker that launches background subagents, posts an interim message and
@@ -75,24 +83,61 @@ if [[ -n "$JOB_NAME" && -n "$_HOOK_ROOT" && -f "$_HOOK_ROOT/intentions/$JOB_NAME
         _OH_PR="$_OH_PR_RAW"
       fi
     fi
+    # Diagnosis-time compare-and-swap pin. OPT-IN by design: absence of this
+    # marker keeps today's unpinned park — fix-checks, review-fix, qa-fix and
+    # dispatch-conflict do not write it yet, and a fail-closed hook would break
+    # every park they make. A malformed value is ignored (degrades to unpinned)
+    # rather than passed through, which park-node would reject as a usage error.
+    _OH_BASE=""
+    if [ -s "$CLAUDE_JOB_DIR/office-hours-base" ]; then
+      _OH_BASE_RAW="$(cat "$CLAUDE_JOB_DIR/office-hours-base" 2>/dev/null || true)"
+      if [[ "$_OH_BASE_RAW" =~ ^[0-9a-f]{40}$ ]]; then
+        _OH_BASE="$_OH_BASE_RAW"
+      fi
+    fi
     _PARK="$_HOOK_ROOT/packages/intentionsutil/scripts/park-node"
     if [ -n "$_OH_REASON" ] && [ -x "$_PARK" ]; then
       # Backstop park via the graph-commit primitive. Best-effort: a failure
       # (e.g. graph-commit's PR-branch fast-path guard — the worker's own
       # in-session park applies the reset-dance; this backstop does not) is
       # non-fatal, matching this hook's best-effort philosophy.
-      _PARK_ARGS=("$JOB_NAME")
-      if [ -n "$_OH_PR" ]; then
-        _PARK_ARGS=("--pr" "$_OH_PR" "$JOB_NAME")
+      # park-node's parser is leading-flags-only — it stops scanning at the
+      # first non-flag argument — so every flag must precede the node id.
+      _PARK_ARGS=()
+      if [ -n "$_OH_BASE" ]; then
+        _PARK_ARGS+=("--base" "$_OH_BASE")
       fi
-      _PARK_ARGS+=("$_OH_REASON")
+      if [ -n "$_OH_PR" ]; then
+        _PARK_ARGS+=("--pr" "$_OH_PR")
+      fi
+      _PARK_ARGS+=("$JOB_NAME" "$_OH_REASON")
       if [ -n "$_OH_RECO" ]; then
         _PARK_ARGS+=("$_OH_RECO")
       fi
-      if "$_PARK" "${_PARK_ARGS[@]}" >/dev/null 2>&1; then
-        rm -f "$_OH_REASON_FILE" "$CLAUDE_JOB_DIR/office-hours-recommendation" "$CLAUDE_JOB_DIR/office-hours-pr"
+      # stdout is silenced, but stderr is CAPTURED (not swallowed) so park-node's
+      # own diagnostic — notably the `stale-diagnosis` marker on exit 3 — can be
+      # surfaced on this hook's stderr below.
+      _PARK_ERR=""
+      _PARK_RC=0
+      _PARK_ERR="$("$_PARK" "${_PARK_ARGS[@]}" 2>&1 >/dev/null)" || _PARK_RC=$?
+      if [ "$_PARK_RC" -eq 0 ]; then
+        rm -f "$_OH_REASON_FILE" "$CLAUDE_JOB_DIR/office-hours-recommendation" \
+          "$CLAUDE_JOB_DIR/office-hours-pr" "$CLAUDE_JOB_DIR/office-hours-base"
+      elif [ "$_PARK_RC" -eq 3 ]; then
+        # stale-diagnosis: the node changed on origin/main between the session's
+        # diagnosis-time read and this park, so park-node REFUSED and wrote
+        # nothing. The newer landed state stands. Markers are deliberately NOT
+        # consumed and the park is NOT retried (and never re-run unpinned) — the
+        # next run against the node's current state is the re-diagnosis.
+        echo "[dispatch-stop] WARNING: park-node for '$JOB_NAME' refused with stale-diagnosis (exit 3): the node changed on origin/main since this session read it; nothing was written, markers left in place (non-fatal)" >&2
+        if [ -n "$_PARK_ERR" ]; then
+          echo "[dispatch-stop] park-node stderr: $_PARK_ERR" >&2
+        fi
       else
         echo "[dispatch-stop] WARNING: park-node for '$JOB_NAME' failed (non-fatal)" >&2
+        if [ -n "$_PARK_ERR" ]; then
+          echo "[dispatch-stop] park-node stderr: $_PARK_ERR" >&2
+        fi
       fi
     fi
   fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-derive-node-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-derive-node-target
@@ -34,6 +34,10 @@
 #   === NODE <node-id> ===
 #   PHASE: <phase>
 #   PR: <num>|none
+#   BASE: <40-hex blob sha> — the diagnosis-time compare-and-swap token: pass
+#     this value to park-node --base / clear-park --base so execution refuses
+#     (stale-diagnosis, exit 3) if the node changed on origin/main between
+#     diagnosis and execution, instead of silently overwriting it.
 #   === NODE-JSON ===
 #   <compact single-line JSON — the full readNode() frontmatter object>
 #   === NODE-BODY ===
@@ -134,6 +138,17 @@ if ! git archive origin/main "intentions/$NODE_ID.md" 2>/dev/null | tar -x -C "$
   exit 1
 fi
 
+# Resolve the origin/main blob sha for the node file at diagnosis time. This is
+# the same expression packages/intentionsutil/scripts/park-node uses (its
+# FRESH_BLOB resolution) so the two shas are directly comparable as a
+# diagnosis-time compare-and-swap token — a caller passes this value to
+# park-node --base / clear-park --base. A failure here is a hard error: never
+# fall back to an empty base.
+BASE_BLOB="$(git rev-parse "origin/main:intentions/$NODE_ID.md")" || {
+  echo "dispatch-derive-node-target: could not resolve the origin/main blob sha for intentions/$NODE_ID.md" >&2
+  exit 1
+}
+
 # --- Step 4: read the node via the intentionsutil store primitives ----------
 COMBINED_JSON="$( (cd "$REPO_ROOT" && node --import tsx/esm -e '
   const { readNode, readNodeBody } = await import("./packages/intentionsutil/src/store.js");
@@ -184,6 +199,7 @@ if [[ -n "$PR_NUM" ]]; then
 else
   printf 'PR: none\n'
 fi
+printf 'BASE: %s\n' "$BASE_BLOB"
 printf '=== NODE-JSON ===\n'
 jq -c '.node' <<<"$COMBINED_JSON"
 printf '=== NODE-BODY ===\n'

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-derive-node-target.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-derive-node-target.sh
@@ -217,6 +217,16 @@ NODE_JSON_LINE=$(printf '%s\n' "$OUT" | sed -n '/=== NODE-JSON ===/{n;p}')
 JSON_PHASE=$(jq -r '.phase' <<<"$NODE_JSON_LINE")
 assert_eq "pr-mode-required-found: NODE-JSON .phase" "implement" "$JSON_PHASE"
 assert_contains "pr-mode-required-found: NODE-BODY has fixture marker" "$BODY_MARKER" "$OUT"
+assert_contains "pr-mode-required-found: stdout has BASE line" "BASE: " "$OUT"
+BASE_LINE=$(printf '%s\n' "$OUT" | grep '^BASE: ')
+BASE_VAL="${BASE_LINE#BASE: }"
+if [[ "$BASE_VAL" =~ ^[0-9a-f]{40}$ ]]; then
+  assert_eq "pr-mode-required-found: BASE value is 40-hex" "$BASE_VAL" "$BASE_VAL"
+else
+  assert_eq "pr-mode-required-found: BASE value is 40-hex" "<40-hex sha>" "$BASE_VAL"
+fi
+EXPECTED_BASE=$(git -C "$REPO" rev-parse "origin/main:intentions/tactic-pr-required-found.md")
+assert_eq "pr-mode-required-found: BASE matches origin/main blob sha" "$EXPECTED_BASE" "$BASE_VAL"
 
 # ---------------------------------------------------------------------------
 # Test 6: node present at implement, --pr-mode optional, gh returns empty ->

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-stop-hook.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-stop-hook.sh
@@ -58,7 +58,15 @@ stopnc_setup() {
 _root="$(cd "$(dirname "$0")/../../.." && pwd)"
 printf '%s\n' "$*" >> "$_root/park-calls.log"
 echo "park" >> "$_root/order.log"
-if [[ -f "$_root/park-exit" ]]; then exit "$(cat "$_root/park-exit")"; fi
+if [[ -f "$_root/park-exit" ]]; then
+  ec="$(cat "$_root/park-exit")"
+  # Exit 3 is park-node's `stale-diagnosis` refusal; the real script prints that
+  # stable marker on ITS stderr, and the hook must surface (not swallow) it.
+  if [[ "$ec" == "3" ]]; then
+    echo "park-node: stale-diagnosis — fake refusal for test" >&2
+  fi
+  exit "$ec"
+fi
 exit 0
 FAKE
   chmod +x "$ROOT/packages/intentionsutil/scripts/park-node"
@@ -187,6 +195,120 @@ rc=$(stopnc_run)
 assert_eq "stop: node park+reco → exit 0" "0" "$rc"
 assert_eq "stop: node park+reco → argv carries the recommendation" \
   "tactic-some-node needs a human decision try approach X" "$(cat "$ROOT/park-calls.log")"
+stopnc_teardown
+
+# --- office-hours-base marker → --base pin precedes the node id -------------
+#
+# tactic-qa-main-park-base-cas: /qa-main's cannot-verify park has a real gap
+# (a multi-minute browser verification) between its diagnosis-time node read and
+# this hook's execution, so it writes the diagnosis-time blob sha to
+# office-hours-base and the hook threads it through as park-node --base.
+# park-node's parser is leading-flags-only, so every flag must precede the id.
+echo "Test: dispatch-stop office-hours-base marker → park-node --base <sha> <id> <reason>"
+stopnc_setup
+stopnc_state "tactic-some-node"
+: > "$ROOT/intentions/tactic-some-node.md"
+printf 'needs a human decision' > "$JOB_DIR/office-hours-reason"
+printf '0123456789abcdef0123456789abcdef01234567' > "$JOB_DIR/office-hours-base"
+rc=$(stopnc_run)
+assert_eq "stop: base marker → exit 0" "0" "$rc"
+assert_eq "stop: base marker → park-node called once" "1" "$(wc -l < "$ROOT/park-calls.log")"
+assert_eq "stop: base marker → argv is --base <sha> <id> <reason>" \
+  "--base 0123456789abcdef0123456789abcdef01234567 tactic-some-node needs a human decision" \
+  "$(cat "$ROOT/park-calls.log")"
+stopnc_teardown
+
+# --- base + pr markers → BOTH flags precede the node id ---------------------
+echo "Test: dispatch-stop office-hours-base + office-hours-pr → both flags before the id"
+stopnc_setup
+stopnc_state "tactic-some-node"
+: > "$ROOT/intentions/tactic-some-node.md"
+printf 'needs a human decision' > "$JOB_DIR/office-hours-reason"
+printf '0123456789abcdef0123456789abcdef01234567' > "$JOB_DIR/office-hours-base"
+printf '42' > "$JOB_DIR/office-hours-pr"
+rc=$(stopnc_run)
+assert_eq "stop: base+pr → exit 0" "0" "$rc"
+assert_eq "stop: base+pr → argv is --base <sha> --pr <n> <id> <reason>" \
+  "--base 0123456789abcdef0123456789abcdef01234567 --pr 42 tactic-some-node needs a human decision" \
+  "$(cat "$ROOT/park-calls.log")"
+stopnc_teardown
+
+# --- no base marker → unpinned park, argv unchanged from today --------------
+echo "Test: dispatch-stop with no office-hours-base marker → no --base in argv"
+stopnc_setup
+stopnc_state "tactic-some-node"
+: > "$ROOT/intentions/tactic-some-node.md"
+printf 'needs a human decision' > "$JOB_DIR/office-hours-reason"
+rc=$(stopnc_run)   # no office-hours-base marker written
+assert_eq "stop: no base marker → exit 0" "0" "$rc"
+assert_eq "stop: no base marker → argv carries no --base" \
+  "tactic-some-node needs a human decision" "$(cat "$ROOT/park-calls.log")"
+stopnc_teardown
+
+# --- malformed base marker → degrades to an UNPINNED park -------------------
+#
+# Deliberate: a non-40-hex value is ignored rather than passed through. Passing
+# it would make park-node itself reject the invocation as a usage error (exit 2)
+# and land no park at all — strictly worse than the unpinned park that is
+# today's behavior for every caller that writes no marker.
+echo "Test: dispatch-stop malformed office-hours-base → ignored, unpinned park, exit 0"
+stopnc_setup
+stopnc_state "tactic-some-node"
+: > "$ROOT/intentions/tactic-some-node.md"
+printf 'needs a human decision' > "$JOB_DIR/office-hours-reason"
+printf 'not-a-valid-sha' > "$JOB_DIR/office-hours-base"
+rc=$(stopnc_run)
+assert_eq "stop: malformed base → exit 0" "0" "$rc"
+assert_eq "stop: malformed base → park-node still called once" "1" "$(wc -l < "$ROOT/park-calls.log")"
+assert_eq "stop: malformed base → argv carries no --base" \
+  "tactic-some-node needs a human decision" "$(cat "$ROOT/park-calls.log")"
+stopnc_teardown
+
+# --- park-node exit 3 (stale-diagnosis) → refusal is non-fatal, no consume ---
+#
+# The pin's whole point: park-node refused and wrote NOTHING, so the newer state
+# that landed on origin/main stands. The hook must stay best-effort (exit 0),
+# must NOT retry or re-invoke unpinned (park-node called exactly once), must
+# leave every marker in place, and must surface park-node's `stale-diagnosis`
+# marker on its own stderr rather than swallowing it.
+echo "Test: dispatch-stop park-node exit 3 (stale-diagnosis) → exit 0, markers survive, stderr surfaced"
+stopnc_setup
+stopnc_state "tactic-some-node"
+: > "$ROOT/intentions/tactic-some-node.md"
+printf 'needs a human decision' > "$JOB_DIR/office-hours-reason"
+printf 'try approach X' > "$JOB_DIR/office-hours-recommendation"
+printf '0123456789abcdef0123456789abcdef01234567' > "$JOB_DIR/office-hours-base"
+printf '3' > "$ROOT/park-exit"   # fake park-node refuses with stale-diagnosis
+rc=$(stopnc_run)
+assert_eq "stop: stale-diagnosis → hook still exits 0" "0" "$rc"
+assert_eq "stop: stale-diagnosis → park-node called exactly once (no retry, no unpinned fallback)" \
+  "1" "$(wc -l < "$ROOT/park-calls.log")"
+[ -e "$JOB_DIR/office-hours-reason" ]
+assert_eq "stop: stale-diagnosis → reason marker survives" "0" "$?"
+[ -e "$JOB_DIR/office-hours-recommendation" ]
+assert_eq "stop: stale-diagnosis → recommendation marker survives" "0" "$?"
+[ -e "$JOB_DIR/office-hours-base" ]
+assert_eq "stop: stale-diagnosis → base marker survives" "0" "$?"
+TOTAL=$((TOTAL + 1))
+if grep -q 'stale-diagnosis' "$ROOT/hook-stderr.log"; then
+  PASS=$((PASS + 1)); echo "  PASS: stop: stale-diagnosis → park-node stderr reaches the hook's stderr"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: stop: stale-diagnosis → park-node stderr reaches the hook's stderr"
+  echo "    hook stderr: $(cat "$ROOT/hook-stderr.log")"
+fi
+stopnc_teardown
+
+# --- successful park consumes the base marker too ---------------------------
+echo "Test: dispatch-stop successful park consumes the office-hours-base marker"
+stopnc_setup
+stopnc_state "tactic-some-node"
+: > "$ROOT/intentions/tactic-some-node.md"
+printf 'needs a human decision' > "$JOB_DIR/office-hours-reason"
+printf '0123456789abcdef0123456789abcdef01234567' > "$JOB_DIR/office-hours-base"
+rc=$(stopnc_run)
+assert_eq "stop: base marker success → exit 0" "0" "$rc"
+[ ! -e "$JOB_DIR/office-hours-base" ]
+assert_eq "stop: base marker success → base marker deleted" "0" "$?"
 stopnc_teardown
 
 # --- best-effort: park-node failure still exits 0 ---------------------------

--- a/.claude/skills/qa-main/SKILL.md
+++ b/.claude/skills/qa-main/SKILL.md
@@ -80,6 +80,12 @@ case "$BRANCH" in
     # is one compact line; NODE-BODY is raw markdown.
     NODE_JSON=$(printf '%s\n' "$FRONT_DOOR" | sed -n '/^=== NODE-JSON ===$/,/^=== NODE-BODY ===$/p' | sed '1d;$d')
     NODE_BODY=$(printf '%s\n' "$FRONT_DOOR" | sed -n '/^=== NODE-BODY ===$/,$p' | sed '1d')
+    # Diagnosis-time compare-and-swap token: the blob sha of
+    # intentions/$NODE_ID.md at origin/main as of THIS read. Parsed from the
+    # header region only (everything before the NODE-JSON fence) — a line inside
+    # the node body could otherwise begin with `BASE: `. Used by the
+    # cannot-verify exit below to pin the Stop-hook park.
+    NODE_BASE=$(printf '%s\n' "$FRONT_DOOR" | sed -n '1,/^=== NODE-JSON ===$/p' | sed -n 's/^BASE: //p' | head -1)
     ;;
 esac
 ```
@@ -197,14 +203,36 @@ asymmetric — when the signal is unclear, route to **cannot-verify**.
   Then **STOP**.
 
 - **cannot-verify** → the safety valve. Do **not** call `dispatch-mark-deviation`
-  (a gh path). Write the specific reason to `$CLAUDE_JOB_DIR/office-hours-reason`
-  and the best-next-steps recommendation — **what the human must verify and how**
-  (strategy clarification 30 / condition 6) — to
-  `$CLAUDE_JOB_DIR/office-hours-recommendation`. The Stop hook parks the node via
-  `park-node`, writing `office_hours` `{reason, recommendation, since}` on
-  `origin/main`. See `.claude/hooks/dispatch-stop.sh`. Then **STOP**. Always name
-  the specific reason so the office-hours surface tells the human exactly what to
-  check.
+  (a gh path). Write **three** markers into `$CLAUDE_JOB_DIR`, each with the
+  atomic tempfile+`mv` convention this codebase uses for marker writes (write the
+  value to `<marker>.tmp`, then `mv` it onto `<marker>` — the idiom at the tail of
+  `.claude/skills/dispatch-propagate/scripts/dispatch-mark-deviation`):
+
+  1. `office-hours-reason` — the specific reason.
+  2. `office-hours-recommendation` — the best-next-steps recommendation, **what
+     the human must verify and how** (strategy clarification 30 / condition 6).
+  3. `office-hours-base` — the value of `$NODE_BASE` bound by the front-door
+     block above (the 40-hex blob sha of `intentions/$N.md` at `origin/main` as
+     of this session's diagnosis-time read).
+
+  The Stop hook parks the node via `park-node`, writing `office_hours`
+  `{reason, recommendation, since}` on `origin/main`, and threads
+  `office-hours-base` through as `park-node --base`. See
+  `.claude/hooks/dispatch-stop.sh`. Then **STOP**. Always name the specific
+  reason so the office-hours surface tells the human exactly what to check.
+
+  **What the base pin buys.** Browser verification takes minutes, so
+  `origin/main` can advance between the front door's read and the Stop hook's
+  park. Unpinned, the park would silently revert whatever landed in between (a
+  `main-qa → done` transition, for instance). Pinned, `park-node` compares the
+  supplied base against `origin/main`'s current blob before any mutation.
+
+  **What an exit-3 refusal means.** `park-node` exits 3 (`stale-diagnosis`), the
+  park is **refused and nothing is written**, the node keeps whatever newer state
+  landed on `origin/main`, and the job is **held** (not reaped) for a human to
+  look at. Do **not** retry the park, and do **not** re-park without the pin —
+  the next `/qa-main` run against the node's current state is the re-diagnosis.
+  See `.claude/skills/ref-diagnosis-time-cas/SKILL.md`.
 
 ## Sandbox
 

--- a/.claude/skills/ref-diagnosis-time-cas/SKILL.md
+++ b/.claude/skills/ref-diagnosis-time-cas/SKILL.md
@@ -43,6 +43,17 @@ the node keeps whatever newer state landed on `origin/main`; the job is **held**
 unpinned. The next `/qa-main` run against the node's current state IS the
 re-diagnosis.
 
+**Invoking the pinned form is not gated.** A 2026-07-30 measurement reported
+that the PreToolUse auto-mode classifier denied `park-node --base ...` and
+`graph-commit --base ...` Bash calls while permitting the same commands without
+`--base` — the safer pinned form harder to invoke than the unpinned one. A
+re-measurement the same day did not reproduce it: `graph-commit --help` and
+`--base`-carrying invocations of both scripts ran with no classifier prompt or
+block, failing only on their own validation. No entry was added to
+`.claude/hooks/approve-workflow-commands.sh` — with no reproducible cause, an
+allowlist change would be speculative. If the denial resurfaces, re-measure
+before adding one.
+
 ## The three-step protocol
 
 **1. Capture** — at diagnosis time, dump every node under consideration:

--- a/.claude/skills/ref-diagnosis-time-cas/SKILL.md
+++ b/.claude/skills/ref-diagnosis-time-cas/SKILL.md
@@ -15,9 +15,33 @@ during that interview window would be silently absorbed by park-node's /
 clear-park's own execution-time self-refresh of origin/main, including one
 that changes what the human should have decided.
 
-NOT needed for immediate mechanical parks that diagnose and execute in the
-same breath — e.g. the Stop-hook backstop (`.claude/hooks/dispatch-stop.sh`),
-which parks right after detecting a failure, with no interview gap.
+The criterion is the **gap**, not the caller. NOT needed for a disposition that
+diagnoses and executes in the same breath — e.g. a provisioning failure, which
+parks immediately on detecting the failure, with nothing able to intervene.
+Being executed by the Stop-hook backstop (`.claude/hooks/dispatch-stop.sh`) does
+NOT by itself mean there is no gap: the hook executes a decision the session made
+earlier, and how much earlier varies by caller.
+
+`/qa-main`'s **cannot-verify** park is exactly such a case, and it DOES use the
+pin. Its diagnosis-time read is the front door's node snapshot
+(`dispatch-derive-node-target`, which prints the node's `origin/main` blob sha on
+a `BASE:` line); a multi-minute browser-verification pass against deployed prod
+runs before the session writes its markers and yields. A `main-qa → done`
+transition landing in that window would be silently reverted by an unpinned park
+(incident 2026-07-28: the revert landed 54 seconds after the transition and
+deadlocked a downstream node). The seam is the **`office-hours-base` marker**:
+`/qa-main` writes the base sha to `$CLAUDE_JOB_DIR/office-hours-base` alongside
+`office-hours-reason` / `office-hours-recommendation`, and the Stop hook threads
+it through as `park-node --base`. That marker is this contract's single home —
+any other Stop-hook-executed park with a real gap should adopt it (`fix-checks`,
+`review-fix`, `qa-fix`, and `dispatch-conflict` do not write it yet, so the hook
+treats it as opt-in: absent marker → today's unpinned park).
+
+**Exit-3 disposition on this path.** The park is refused and nothing is written;
+the node keeps whatever newer state landed on `origin/main`; the job is **held**
+(not reaped), its markers left in place, and it is neither retried nor re-parked
+unpinned. The next `/qa-main` run against the node's current state IS the
+re-diagnosis.
 
 ## The three-step protocol
 


### PR DESCRIPTION
## Summary
- `/qa-main`'s cannot-verify park writes its escalation via marker files the Stop hook (`.claude/hooks/dispatch-stop.sh`) picks up and lands via `park-node`, with no diagnosis-time compare-and-swap. Since a browser-verification pass runs for minutes between the read and the park, a phase transition that lands on `origin/main` mid-verification is silently reverted by the unconditional park — this happened for real on 2026-07-28, reverting a `main-qa → done` transition 54 seconds after it landed and deadlocking a downstream node.
- Unit 1: `dispatch-derive-node-target` (the shared front-door target-derivation script) now emits a `BASE: <40-hex blob sha>` line — the diagnosis-time blob sha of the node it read, byte-comparable to what `park-node` computes as `FRESH_BLOB`.
- Unit 2: `/qa-main`'s node lane binds that sha and, on a cannot-verify exit, writes it to a new `office-hours-base` marker alongside the existing `office-hours-reason`/`office-hours-recommendation` markers. `dispatch-stop.sh` reads the marker (opt-in — absence keeps today's unpinned park) and threads it through as `park-node --base`, so the park either lands against exactly the diagnosed state or refuses with `stale-diagnosis` (exit 3) and writes nothing. The hook no longer swallows `park-node`'s stderr, so the refusal reason is visible. `ref-diagnosis-time-cas`'s doctrine is corrected: the criterion for needing the pin is the diagnosis-execution gap, not merely "executed by the Stop hook."
- Unit 3: re-measured the 2026-07-30 report that the auto-mode classifier denies `--base`-carrying `park-node`/`graph-commit` invocations while permitting the unpinned form. It did not reproduce in this session, so no permission-hook change was made — documented in `ref-diagnosis-time-cas` for the next person who hits it.

## Test plan
- [x] `.claude/skills/dispatch-propagate/scripts/test-dispatch-derive-node-target.sh` — 23/23 passed
- [x] `.claude/skills/dispatch-propagate/scripts/test-dispatch-stop-hook.sh` — 61/61 passed
- [x] `.claude/hooks/test-approve-workflow-commands.sh` — 66/66 passed
- [x] `packages/intentionsutil/scripts/test-park-node.sh` — 21/21 passed, unmodified (regression net for `--base` untouched)
- [x] `.claude/skills/dispatch-propagate/scripts/run-lint.sh` — clean
- [x] `npx tsx packages/intentionsutil/scripts/validate-graph.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
