### PR TITLE
Hold the router's reservation claim through the worker boot window

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
@@ -42,11 +42,16 @@
 #          `<skill> <id>`. Mechanical provision dispositions are handled here at
 #          zero token cost (no `claude` session), mirroring
 #          dispatch-launch-worker.
-#   4. Clears the node's reservation-ledger marker on a successful kick — the
-#      live node-id-named session carries the claim from there (mirrors
-#      dispatch-launch-worker's release-on-resolve). On a failed kick the marker
-#      is LEFT for the sweep, so the budget still counts the slot until
-#      reconciliation.
+#   4. Hands off (does not drop) the node's reservation-ledger marker on a
+#      successful kick: it is re-stamped `origin=spawned` with a fresh
+#      timestamp (reservation_mark_spawned) instead of cleared outright, so the
+#      claim survives the boot window before the worker's own live session
+#      registers. It is released by reservation_sweep rule (a) once that
+#      session registers, or by the handoff TTL if it never does. The
+#      stale-selection (exit 12) and scope-stale (exit 13) dispositions still
+#      clear the marker outright — no spawn happened there. On a failed kick
+#      the marker is still LEFT for the sweep, so the budget still counts the
+#      slot until reconciliation.
 #
 # Usage: dispatch-graph-execute <id:kind:phase> [<id:kind:phase> ...]
 #
@@ -190,7 +195,9 @@ for spec in "$@"; do
     if "$SCRIPT_DIR/dispatch-spawn-job" --no-verify --name "$id" \
         --cwd "$PROJECT_ROOT" --model "$ORCH_MODEL" "${EFFORT_ARGS[@]}" \
         "$SKILL $id" 1>&2; then
-      reservation_clear "$id" || true
+      # Hold the claim through the boot window; reservation_sweep rule (a)
+      # releases it once the worker registers.
+      reservation_mark_spawned "$id" || true
       echo "launched $id $SKILL"
     else
       echo "failed $id spawn-failed"
@@ -215,7 +222,9 @@ for spec in "$@"; do
       if "$SCRIPT_DIR/dispatch-spawn-job" --no-verify --name "$id" \
           --cwd "$WT" --model "$ORCH_MODEL" "${EFFORT_ARGS[@]}" \
           "$SKILL $id" 1>&2; then
-        reservation_clear "$id" || true
+        # Hold the claim through the boot window; reservation_sweep rule (a)
+        # releases it once the worker registers.
+        reservation_mark_spawned "$id" || true
         echo "launched $id $SKILL"
       else
         # Leave the reservation for the sweep — the budget keeps counting the
@@ -286,7 +295,9 @@ for spec in "$@"; do
           --cwd "$CONFLICT_WT" --model "$ORCH_MODEL" \
           "/dispatch-conflict $id" 1>&2; then
         rm -f "$STRIKE_FILE"
-        reservation_clear "$id" || true
+        # Hold the claim through the boot window; reservation_sweep rule (a)
+        # releases it once the worker registers.
+        reservation_mark_spawned "$id" || true
         echo "conflict-lane $id"
         continue
       fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
@@ -146,6 +146,20 @@ CONFLICT_STRIKE_CAP=5
 
 FAILURES=0
 
+# hand_off_reservation <id> — the spawn handoff, at every successful-kick site.
+# Non-fatal by design: the worker is already launched, so failing the kick here
+# would be worse than the degradation. But the degradation is NOT silent — if the
+# re-stamp fails (unwritable ledger dir, failed mv), the OLD marker survives with
+# its selection-time origin, so reservation_sweep falls back to the pre-handoff
+# lifecycle and reclaims it as dead-session-stranded once the 30s boot grace
+# lapses. That is exactly the duplicate-worker window this handoff exists to
+# close, so name the consequence on stderr where a log grep can find it.
+hand_off_reservation() {
+  local node_id="$1"
+  reservation_mark_spawned "$node_id" || \
+    echo "dispatch-graph-execute: WARNING: spawn handoff re-stamp failed for $node_id; the claim reverts to the pre-handoff sweep lifecycle and the boot-window duplicate-worker guard is OFF for this node" >&2
+}
+
 for spec in "$@"; do
   IFS=: read -r id kind phase <<<"$spec"
   if [[ -z "$id" || -z "$kind" || -z "$phase" ]]; then
@@ -197,7 +211,7 @@ for spec in "$@"; do
         "$SKILL $id" 1>&2; then
       # Hold the claim through the boot window; reservation_sweep rule (a)
       # releases it once the worker registers.
-      reservation_mark_spawned "$id" || true
+      hand_off_reservation "$id"
       echo "launched $id $SKILL"
     else
       echo "failed $id spawn-failed"
@@ -224,7 +238,7 @@ for spec in "$@"; do
           "$SKILL $id" 1>&2; then
         # Hold the claim through the boot window; reservation_sweep rule (a)
         # releases it once the worker registers.
-        reservation_mark_spawned "$id" || true
+        hand_off_reservation "$id"
         echo "launched $id $SKILL"
       else
         # Leave the reservation for the sweep — the budget keeps counting the
@@ -297,7 +311,7 @@ for spec in "$@"; do
         rm -f "$STRIKE_FILE"
         # Hold the claim through the boot window; reservation_sweep rule (a)
         # releases it once the worker registers.
-        reservation_mark_spawned "$id" || true
+        hand_off_reservation "$id"
         echo "conflict-lane $id"
         continue
       fi

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -727,13 +727,19 @@ elif [[ -n "$MANUAL" ]]; then
   # dispatch-materialize-spawn's existing --gap N machinery (the highest rank level
   # is globally exhausted first; the `priority` label is the cap bypass, not an
   # ordering signal). LIVE_COUNT mirrors the
-  # autonomous block's effective-live count (busy workers + reservations); the
-  # manual path does NOT sweep the reservation ledger (a possibly-stale count
-  # can only make manual fan-out more conservative, which is safe).
+  # autonomous block's effective-live count (busy workers + reservations), and —
+  # like that block — it SWEEPS the ledger before counting. The sweep is
+  # load-bearing since the spawn handoff landed: a claim is no longer cleared at
+  # the spawn kick but re-stamped `origin=spawned` and held until the worker
+  # registers, so between registration and the next sweep the SAME node is both a
+  # busy worker and an outstanding reservation. Counting unswept would charge it
+  # twice and shrink manual fan-out for up to a full tick interval. Sweep rule (a)
+  # drops exactly those redundant markers.
   # shellcheck source=/dev/null
   source "$SCRIPT_DIR/lib-claude-agents.sh"
   # shellcheck source=/dev/null
   source "$SCRIPT_DIR/lib-reservation-ledger.sh"
+  reservation_sweep 1>&2 || true
   if BUSY=$(claude_agents_count_busy_workers); then
     RESV=$(reservation_count)
     LIVE_COUNT=$(( BUSY + RESV ))

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -216,7 +216,11 @@ refresh_lock() {
 # name, rule (c) needs the reserving session dead), so each failed explicit
 # dispatch would permanently add 1 to LIVE_COUNT. Omitted (empty) on the
 # autonomous and manual lanes, whose claims are consumed by the same tick's
-# fan-out and are covered by rules (a)/(c).
+# fan-out: a claim that reaches a successful spawn is re-stamped
+# `origin=spawned` by dispatch-graph-execute and covered by the sweep's
+# handoff rule (released once the worker registers as live, or via the
+# bounded handoff TTL if it never does); the old rule (c) (dead-session
+# reclamation) now only reclaims claims that never reached a spawn.
 #   return 0 — decision line emitted; the caller exits 0.
 #   return 1 — stdin held no node lines; the caller falls through to the
 #              legacy selector.

--- a/.claude/skills/dispatch-propagate/scripts/graph-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/graph-select-target
@@ -319,6 +319,17 @@ if [[ -n "$STANDALONE" ]]; then
   # the same fail-open floor, TOP=1 (the standalone analogue of
   # dispatch-select-tick's "GAP stays 1"), never leaving TOP unclamped when the
   # live-worker count or the ceiling is unknown.
+  #
+  # The ledger is SWEPT before it is counted, mirroring dispatch-select-tick's
+  # autonomous gate. Since the spawn handoff landed, a launched claim is no
+  # longer cleared at the kick but re-stamped `origin=spawned` and held until its
+  # worker registers — so an unswept count charges a registered worker twice
+  # (once busy, once reserved). That matters more here than on the manual lane:
+  # this path deliberately omits the floor-of-1 above, so an inflated LIVE_COUNT
+  # drives HEADROOM to 0 and the run selects NOTHING while real headroom exists.
+  # Sweep rule (a) drops exactly those redundant markers. The dispatch lock is
+  # already held (step (a) above), so the sweep cannot race a concurrent tick.
+  reservation_sweep 1>&2 || true
   if BUSY=$(claude_agents_count_busy_workers); then
     RESV=$(reservation_count)
     LIVE_COUNT=$(( BUSY + RESV ))

--- a/.claude/skills/dispatch-propagate/scripts/graph-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/graph-select-target
@@ -58,8 +58,12 @@
 #                        otherwise wraps around this selector. CLAIM OBLIGATION:
 #                        each claim is a budget-consuming marker. A caller that
 #                        launches its selections hands the marker to
-#                        dispatch-graph-execute (which clears it on spawn); a
-#                        caller that does NOT launch MUST `reservation_clear <id>`
+#                        dispatch-graph-execute, which re-stamps it
+#                        `origin=spawned` on a successful spawn kick and lets
+#                        reservation_sweep release it once the worker
+#                        registers as live (or via the bounded handoff TTL if
+#                        it never does); a caller that does NOT launch MUST
+#                        `reservation_clear <id>`
 #                        for every emitted node. Markers written by this flag carry
 #                        `origin=standalone` so reservation_sweep reclaims them
 #                        once they age past DISPATCH_RESERVATION_STANDALONE_TTL_S
@@ -696,8 +700,10 @@ while IFS=$'\t' read -r id kind phase pr pace_exempt pushed_sha fix_since; do
   # the failure posture of dispatch-select-tick's own emit_graph_selection call.
   #
   # The `standalone` ORIGIN stamp (4th arg) bounds the claim's lifetime. Unlike a
-  # tick claim — handed straight to dispatch-graph-execute, which clears it on
-  # spawn — a standalone claim has no guaranteed consumer: a caller that discards
+  # tick claim — handed straight to dispatch-graph-execute, which re-stamps it
+  # `origin=spawned` on a successful spawn kick and lets reservation_sweep
+  # release it once the worker registers as live (or via the bounded handoff
+  # TTL if it never does) — a standalone claim has no guaranteed consumer: a caller that discards
   # the output, crashes, or is interrupted between selection and launch leaves the
   # marker behind, and reservation_sweep's dead-session rule never reclaims it while
   # the (long-lived) calling session stays alive. Markers stamped `origin=standalone`

--- a/.claude/skills/dispatch-propagate/scripts/lib-reservation-ledger.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-reservation-ledger.sh
@@ -26,6 +26,7 @@
 #   reservation_dir
 #   reservation_write   <worktree-basename> <issue-N> <session-id> [origin]
 #   reservation_clear   <worktree-basename>
+#   reservation_mark_spawned <worktree-basename>
 #   reservation_exists  <worktree-basename>
 #   reservation_count
 #   reserved_claimed_nums
@@ -79,6 +80,35 @@
 #               ledger).
 #     return 1 — missing or unsafe argument only.
 #
+# reservation_mark_spawned <worktree-basename>
+#   Spawn handoff: re-stamp the claim as `origin=spawned` with a FRESH timestamp,
+#   so it stays in force from the spawn kick until the spawned worker registers
+#   under its worktree-basename name in `claude agents` (sweep rule (a) then
+#   reclaims it) — or until the handoff TTL expires (rule (a-handoff)). Callers
+#   (dispatch-graph-execute) call this INSTEAD of reservation_clear on a
+#   successful spawn: clearing synchronously reopened a duplicate-worker window
+#   between the kick and registration, during which the node was covered by
+#   neither the ledger guard nor the live-session guard.
+#     - The `session=` value is the FIRST NON-EMPTY of: the existing marker's
+#       `session=`, `${CLAUDE_CODE_SESSION_ID:-}`, then the literal
+#       `spawn-handoff`. It is never empty — reservation_write rejects an empty
+#       session id, and an empty `session=` would land the marker on sweep rule
+#       (b), which KEEPS it forever (an immortal slot).
+#     - The `issue=` value is the existing marker's `issue=` if non-empty, else
+#       the basename.
+#     - The write is delegated to `reservation_write <bn> <issue> <session>
+#       spawned`, reusing its path guard, 0700 mkdir, atomic tempfile+mv, and
+#       DISPATCH_RESERVATION_NOW handling.
+#     - The timestamp is refreshed to NOW = spawn time (load-bearing:
+#       selection→spawn includes provision-node-worktree's fetch/worktree-add and
+#       can take minutes, so keeping the selection stamp could hand back an
+#       already-expired handoff).
+#     - Idempotent, and creates the marker if none exists, so a caller that
+#       reached spawn without a ledger entry still gets covered.
+#     return 0 — marker written with origin=spawned.
+#     return 1 — a missing/unsafe basename, or a reservation_write failure
+#               (status propagated).
+#
 # reservation_exists <worktree-basename>
 #   Fast-path membership test: return 0 if a reservation marker named exactly
 #   <worktree-basename> exists in the ledger dir, 1 otherwise. No daemon
@@ -120,6 +150,19 @@
 #        spawned worker is still booting and has not yet registered. A marker
 #        with an unparseable/absent timestamp has no age protection — it falls
 #        through to the session rules below (fail-safe to the pre-grace behavior).
+#     (a-handoff) else the marker carries `origin=spawned` (written by
+#        reservation_mark_spawned on a successful spawn kick) and its timestamp
+#        parsed → the claim is in the spawn handoff: HELD until the worker
+#        registers (rule (a), above, releases it the instant a live session named
+#        by the worktree basename appears), and reclaimed
+#        (spawn-handoff-expired) only once it has aged past
+#        DISPATCH_RESERVATION_HANDOFF_TTL_S (default 300s). This rule must sit
+#        AFTER (a) so a registered worker still releases the claim immediately,
+#        and BEFORE (c) so the tick's synthetic `headless:<INVOCATION_ID>`
+#        reserving session — which never appears in `claude agents` — no longer
+#        strands the handoff at the 30s boot grace, reopening the
+#        duplicate-worker window. An unparseable/absent timestamp falls through
+#        to the rules below (same fail-safe posture as the boot grace).
 #     (c-ttl) else the marker carries a TTL-reclaimable origin (`standalone` or
 #        `explicit`) AND has aged past DISPATCH_RESERVATION_STANDALONE_TTL_S
 #        (default 600s) → reclaim (ttl-expired), REGARDLESS of whether the
@@ -133,10 +176,11 @@
 #        (typically long-lived, often interactive) calling session stays alive —
 #        so without this rule the marker is immortal and a handful of such calls
 #        can pin LIVE_COUNT at the ceiling and stall the whole fleet. A claim that
-#        DOES launch is cleared far sooner (dispatch-graph-execute clears it on
-#        spawn, and rule (a) is an age-independent backstop), so the TTL only ever
-#        reclaims a leak. Rule (a) still precedes it, so a live worker is never
-#        disturbed.
+#        DOES launch is not cleared on the spawn kick but RE-STAMPED
+#        `origin=spawned` (reservation_mark_spawned), and is then released by rule
+#        (a) the moment its worker registers — or by the shorter handoff TTL
+#        (rule (a-handoff)) if it never does — so this TTL only ever reclaims a
+#        leak. Rule (a) still precedes it, so a live worker is never disturbed.
 #     c. else reserving session id ∉ live-session-ids AND the marker has aged
 #        past the grace → reserving session is DEAD and never converted; reclaim
 #        (stranded).
@@ -169,6 +213,18 @@
 #                             reserving session's liveness. A non-numeric value
 #                             falls back to 600. (Named for the origin that first
 #                             needed it; it governs both.)
+#   DISPATCH_RESERVATION_HANDOFF_TTL_S
+#                             The spawn-handoff TTL (seconds, default 300) after
+#                             which the sweep reclaims an `origin=spawned` marker
+#                             whose worker never registered (rule (a-handoff)). A
+#                             non-numeric value falls back to 300. Tuning: the
+#                             value must comfortably exceed the worst observed
+#                             worker-registration latency (90s observed
+#                             2026-07-30) — set below that and the
+#                             duplicate-worker window reopens. Set above it and
+#                             the only cost is that one budget slot and one node
+#                             stay claimed for that long after a spawn that died
+#                             during boot.
 #   DISPATCH_RESERVATION_SWEEP_NOW_EPOCH
 #                             Override the sweep's "now" epoch (deterministic
 #                             grace-boundary tests). Default: `date -u +%s`. A
@@ -293,6 +349,44 @@ if [[ -z "${_LIB_RESERVATION_LEDGER_LOADED:-}" ]]; then
     dir=$(reservation_dir) || return 0
     rm -f "$dir/$wt_name" 2>/dev/null || true
     return 0
+  }
+
+  # reservation_mark_spawned <worktree-basename> — re-stamp the claim as
+  # `origin=spawned` with a fresh timestamp (the spawn handoff).
+  # See the header comment for the return-code contract.
+  reservation_mark_spawned() {
+    local wt_name="${1:-}"
+    if [[ -z "$wt_name" ]]; then
+      printf 'lib-reservation-ledger: reservation_mark_spawned requires a <worktree-basename> argument\n' >&2
+      return 1
+    fi
+    # Same path guard as the sibling primitives — reservation_write re-checks it,
+    # but guard here too so the read below can never stat outside the ledger dir.
+    case "$wt_name" in
+      *..*|*/*|*[[:cntrl:]]*)
+        printf 'lib-reservation-ledger: reservation_mark_spawned: unsafe worktree-basename %q\n' "$wt_name" >&2
+        return 1
+        ;;
+    esac
+
+    local dir session="" issue=""
+    if dir=$(reservation_dir) && [[ -f "$dir/$wt_name" ]]; then
+      # Same robust first-match-wins parse the sweep uses.
+      session=$(sed -n 's/^session=//p' "$dir/$wt_name" 2>/dev/null | head -n1)
+      issue=$(sed -n 's/^issue=//p' "$dir/$wt_name" 2>/dev/null | head -n1)
+    fi
+    # The session value must NEVER be empty: reservation_write rejects an empty
+    # session id, and an empty `session=` would land the marker on sweep rule (b)
+    # (malformed → KEEP forever), making the slot immortal.
+    [[ -n "$session" ]] || session="${CLAUDE_CODE_SESSION_ID:-}"
+    [[ -n "$session" ]] || session="spawn-handoff"
+    [[ -n "$issue" ]] || issue="$wt_name"
+
+    # Delegate to the one marker writer (path guard, 0700 mkdir, atomic
+    # tempfile+mv, DISPATCH_RESERVATION_NOW). The timestamp is refreshed to NOW =
+    # spawn time, which is load-bearing: selection→spawn can take minutes, so
+    # carrying the selection stamp forward could hand back an expired handoff.
+    reservation_write "$wt_name" "$issue" "$session" spawned
   }
 
   # reservation_exists <worktree-basename> — fast-path marker membership test.
@@ -454,6 +548,10 @@ if [[ -z "${_LIB_RESERVATION_LEDGER_LOADED:-}" ]]; then
     # backward compatibility; it governs both origins.
     local ttl_s="${DISPATCH_RESERVATION_STANDALONE_TTL_S:-600}"
     [[ "$ttl_s" =~ ^[0-9]+$ ]] || ttl_s=600
+    # TTL for the spawn handoff — `origin=spawned` (rule (a-handoff)). Must
+    # comfortably exceed the worst worker-registration latency (90s observed).
+    local handoff_ttl_s="${DISPATCH_RESERVATION_HANDOFF_TTL_S:-300}"
+    [[ "$handoff_ttl_s" =~ ^[0-9]+$ ]] || handoff_ttl_s=300
 
     local had_nullglob=0
     shopt -q nullglob && had_nullglob=1
@@ -496,6 +594,22 @@ if [[ -z "${_LIB_RESERVATION_LEDGER_LOADED:-}" ]]; then
         # future-stamped marker (now - epoch < 0) is < grace, so it is kept too
         # (the safe direction). KEEP — fall through to nothing.
         :
+      elif [[ "$marker_origin" == "spawned" ]] && [[ "$marker_epoch" =~ ^[0-9]+$ ]]; then
+        # (a-handoff) The claim was handed off to a spawned worker
+        # (reservation_mark_spawned re-stamped it at spawn time). HOLD it until
+        # the worker registers — rule (a), above, releases it the instant a live
+        # session named by this basename appears — and reclaim only once the
+        # handoff TTL has elapsed with no such worker. Placed AFTER (a) so a
+        # registered worker still releases immediately, and BEFORE (c) so the
+        # tick's synthetic `headless:<INVOCATION_ID>` reserving session (never
+        # present in `claude agents`) can no longer strand the handoff the moment
+        # the boot grace lapses — which is exactly what reopened the
+        # duplicate-worker window. An unparseable timestamp fails this guard and
+        # falls through to the rules below (same posture as the boot grace).
+        if (( now - marker_epoch >= handoff_ttl_s )); then
+          reservation_clear "$bn"
+          printf 'lib-reservation-ledger: reclaimed reservation %s (spawn-handoff-expired after %ss with no live worker)\n' "$bn" "$handoff_ttl_s" >&2
+        fi
       elif [[ "$marker_origin" == "standalone" || "$marker_origin" == "explicit" ]] \
            && [[ "$marker_epoch" =~ ^[0-9]+$ ]] \
            && (( now - marker_epoch >= ttl_s )); then

--- a/.claude/skills/dispatch-propagate/scripts/lib-reservation-ledger.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-reservation-ledger.sh
@@ -46,14 +46,22 @@
 #   <worktree-basename> in the ledger dir, with the three documented lines (plus
 #   an `origin=` line when the optional 4th argument is given — a bare
 #   [A-Za-z0-9_-] token; anything else prints a diagnostic and returns 1). The
-#   origin names the claim's writer so the sweep can bound its lifetime. Two
-#   origins are TTL-reclaimable (see reservation_sweep rule (c-ttl)) because
-#   neither has a guaranteed consumer:
+#   origin names the claim's writer so the sweep can bound its lifetime. Three
+#   origins are recognized. Two are TTL-reclaimable (see reservation_sweep rule
+#   (c-ttl)) because neither has a guaranteed consumer:
 #     `standalone` — a claim written by `graph-select-target --standalone`.
 #     `explicit`   — a claim written by `dispatch-select-tick`'s explicit
 #                    single-node lane (`dispatch <node-id>`), typically run from
 #                    inside a long-lived interactive session whose id stays live
 #                    for hours.
+#   The third is the spawn handoff:
+#     `spawned`    — a claim RE-STAMPED by reservation_mark_spawned at a
+#                    successful spawn kick. It is governed by sweep rule
+#                    (a-handoff) and DISPATCH_RESERVATION_HANDOFF_TTL_S — NOT by
+#                    the standalone TTL — and its intended release is an event:
+#                    rule (a) drops it the instant the spawned worker registers.
+#                    Callers write it via reservation_mark_spawned, not by
+#                    passing the token here.
 #   All
 #   three positional arguments are required and must be non-empty (an empty arg prints a
 #   diagnostic to stderr and returns 1, matching the arg-validation style of the
@@ -185,10 +193,17 @@
 #        past the grace → reserving session is DEAD and never converted; reclaim
 #        (stranded).
 #     d. else (reserving session alive, no live worker yet) → in-flight; KEEP.
-#   Reclaim = `reservation_clear <basename>` plus a one-line stderr note
-#   distinguishing the two reasons (live-worker-redundant vs dead-session-
-#   stranded), mirroring dispatch-sweep's reclaim-note style. `.tmp`/dot
-#   tempfiles are skipped.
+#   Reclaim = `reservation_clear <basename>` plus a one-line stderr note naming
+#   which of the four reasons fired, mirroring dispatch-sweep's reclaim-note
+#   style:
+#     `live-worker-redundant`  rule (a) — the worker registered.
+#     `spawn-handoff-expired`  rule (a-handoff) — an origin=spawned claim aged
+#                              past DISPATCH_RESERVATION_HANDOFF_TTL_S with no
+#                              live worker.
+#     `<origin>-ttl-expired`   rule (c-ttl) — a `standalone`/`explicit` claim
+#                              aged past DISPATCH_RESERVATION_STANDALONE_TTL_S.
+#     `dead-session-stranded`  rule (c) — the reserving session is dead.
+#   `.tmp`/dot tempfiles are skipped.
 #     return 0 — always (sweep completed, or fail-safe no-op on UNKNOWN /
 #               absent ledger).
 #

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-graph-execute.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-graph-execute.sh
@@ -142,6 +142,12 @@ assert_eq "implement hands off the reservation marker, does not clear it" "prese
   "$([ -e "$RES_DIR/tactic-foo" ] && echo present || echo gone)"
 assert_contains "implement marker is re-stamped origin=spawned" "origin=spawned" \
   "$(cat "$RES_DIR/tactic-foo")"
+# The re-stamp preserves the selection marker's identity fields rather than
+# falling back to the synthesized create-if-absent values (Case 15).
+assert_contains "implement handoff preserves the selection session=" "session=headless:t" \
+  "$(cat "$RES_DIR/tactic-foo")"
+assert_contains "implement handoff preserves the selection issue=" "issue=tactic-foo" \
+  "$(cat "$RES_DIR/tactic-foo")"
 
 # ============================================================================
 # Case 2: per-phase skill map (review/qa/fix/main-qa)
@@ -199,7 +205,10 @@ assert_eq "waiting spawns nothing" "" "$(cat "$SPAWN_LOG")"
 # ============================================================================
 echo "Case 5: provision exit 11 -> conflict lane spawned, no strike, no graph write"
 rm -f "$MAIN_WT/.claude/worktrees/tactic-c.conflict-strikes"
-touch "$RES_DIR/tactic-c"
+# A WELL-FORMED selection-time marker, not a bare `touch`: the handoff must carry
+# the existing session=/issue= forward. An empty marker would instead exercise the
+# create-if-absent fallback, which Case 15 already covers.
+printf 'session=headless:c\nissue=tactic-c\ntimestamp=2026-01-01T00:00:00Z\n' > "$RES_DIR/tactic-c"
 PROV_RC=11 run_exec "tactic-c:tactic:qa"
 SPAWN=$(cat "$SPAWN_LOG")
 assert_eq "conflict-lane stdout" "conflict-lane tactic-c" "$OUT"
@@ -219,12 +228,18 @@ assert_eq "conflict-lane hands off the reservation marker, does not clear it" "p
   "$([ -e "$RES_DIR/tactic-c" ] && echo present || echo gone)"
 assert_contains "conflict-lane marker is re-stamped origin=spawned" "origin=spawned" \
   "$(cat "$RES_DIR/tactic-c")"
+# The re-stamp must PRESERVE the selection marker's identity fields, not
+# overwrite them with the create-if-absent fallback (session=spawn-handoff).
+assert_contains "conflict-lane handoff preserves the selection session=" "session=headless:c" \
+  "$(cat "$RES_DIR/tactic-c")"
+assert_contains "conflict-lane handoff preserves the selection issue=" "issue=tactic-c" \
+  "$(cat "$RES_DIR/tactic-c")"
 
 # A successful kick must also CLEAR a strike file left by earlier failed kicks:
 # the backstop's counter means "consecutive failures to launch the lane", which
 # is what its hold reason asserts.
 printf '%s\n' "3" > "$MAIN_WT/.claude/worktrees/tactic-c.conflict-strikes"
-touch "$RES_DIR/tactic-c"
+printf 'session=headless:c\nissue=tactic-c\ntimestamp=2026-01-01T00:00:00Z\n' > "$RES_DIR/tactic-c"
 PROV_RC=11 run_exec "tactic-c:tactic:qa"
 assert_eq "conflict-lane stdout after prior strikes" "conflict-lane tactic-c" "$OUT"
 assert_eq "a successful kick resets the strike counter" "gone" \

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-graph-execute.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-graph-execute.sh
@@ -123,6 +123,7 @@ run_exec() {
 # Case 1: tactic:implement -> /implement, sonnet, --cwd worktree, --effort medium
 # ============================================================================
 echo "Case 1: tactic:implement launches /implement directly"
+printf 'session=headless:t\nissue=tactic-foo\ntimestamp=2026-01-01T00:00:00Z\n' > "$RES_DIR/tactic-foo"
 run_exec "tactic-foo:tactic:implement"
 SPAWN=$(cat "$SPAWN_LOG")
 assert_eq "implement stdout" "launched tactic-foo /implement" "$OUT"
@@ -137,6 +138,10 @@ assert_contains "implement --effort medium" "--effort medium" "$SPAWN"
 GT_NEEDLE="dispatch-graph""-tick"
 assert_not_contains "implement carries no retired-workflow string" "$GT_NEEDLE" "$SPAWN"
 assert_not_contains "implement does not invoke the Workflow tool" "Invoke the Workflow tool" "$SPAWN"
+assert_eq "implement hands off the reservation marker, does not clear it" "present" \
+  "$([ -e "$RES_DIR/tactic-foo" ] && echo present || echo gone)"
+assert_contains "implement marker is re-stamped origin=spawned" "origin=spawned" \
+  "$(cat "$RES_DIR/tactic-foo")"
 
 # ============================================================================
 # Case 2: per-phase skill map (review/qa/fix/main-qa)
@@ -164,6 +169,7 @@ assert_not_contains "main-qa has no --effort (unmapped phase)" "--effort" "$SPAW
 # Case 3: strategy lane — no pre-provision, cwd=project root, /align-tactics
 # ============================================================================
 echo "Case 3: strategy lane spawns /align-tactics at the project root"
+printf 'session=headless:s\nissue=strategy-x\ntimestamp=2026-01-01T00:00:00Z\n' > "$RES_DIR/strategy-x"
 run_exec "strategy-x:strategy:align"
 SPAWN=$(cat "$SPAWN_LOG")
 assert_eq "strategy stdout" "launched strategy-x /align-tactics" "$OUT"
@@ -171,6 +177,10 @@ assert_eq "strategy exit 0" "0" "$RC"
 assert_contains "strategy invokes /align-tactics" "/align-tactics strategy-x" "$SPAWN"
 assert_contains "strategy cwd is the project root" "--cwd $MAIN_WT" "$SPAWN"
 assert_contains "strategy model sonnet" "--model sonnet" "$SPAWN"
+assert_eq "strategy hands off the reservation marker, does not clear it" "present" \
+  "$([ -e "$RES_DIR/strategy-x" ] && echo present || echo gone)"
+assert_contains "strategy marker is re-stamped origin=spawned" "origin=spawned" \
+  "$(cat "$RES_DIR/strategy-x")"
 
 # ============================================================================
 # Case 4: provision exit 10 -> ci-waiting (no spawn)
@@ -184,7 +194,8 @@ assert_eq "waiting spawns nothing" "" "$(cat "$SPAWN_LOG")"
 # ============================================================================
 # Case 5: provision exit 11 -> the /dispatch-conflict Lane 3 session is the
 # first responder: it is spawned in the node's own worktree, the reservation is
-# cleared, and NO strike file, NO hold-node call and NO park-node write happen.
+# HANDED OFF (re-stamped origin=spawned, not cleared), and NO strike file, NO
+# hold-node call and NO park-node write happen.
 # ============================================================================
 echo "Case 5: provision exit 11 -> conflict lane spawned, no strike, no graph write"
 rm -f "$MAIN_WT/.claude/worktrees/tactic-c.conflict-strikes"
@@ -204,8 +215,10 @@ assert_eq "conflict-lane makes no park-node write" "" "$(cat "$PARK_LOG")"
 assert_eq "conflict-lane makes no hold-node write" "" "$(cat "$HOLD_LOG")"
 assert_eq "conflict-lane writes no strike file" "gone" \
   "$([ -e "$MAIN_WT/.claude/worktrees/tactic-c.conflict-strikes" ] && echo present || echo gone)"
-assert_eq "conflict-lane clears the reservation marker" "gone" \
+assert_eq "conflict-lane hands off the reservation marker, does not clear it" "present" \
   "$([ -e "$RES_DIR/tactic-c" ] && echo present || echo gone)"
+assert_contains "conflict-lane marker is re-stamped origin=spawned" "origin=spawned" \
+  "$(cat "$RES_DIR/tactic-c")"
 
 # A successful kick must also CLEAR a strike file left by earlier failed kicks:
 # the backstop's counter means "consecutive failures to launch the lane", which
@@ -277,11 +290,14 @@ assert_eq "stale clears the reservation marker" "gone" \
 # Case 7: provision exit 13 -> scope-stale, demote called, no spawn
 # ============================================================================
 echo "Case 7: provision exit 13 -> scope-stale via demote, no spawn"
+touch "$RES_DIR/tactic-d"
 PROV_RC=13 run_exec "tactic-d:tactic:qa"
 assert_eq "scope-stale stdout" "scope-stale tactic-d" "$OUT"
 assert_eq "scope-stale exit 0" "0" "$RC"
 assert_eq "scope-stale spawns nothing" "" "$(cat "$SPAWN_LOG")"
 assert_contains "scope-stale demotes the node" "tactic-d" "$(cat "$DEMOTE_LOG")"
+assert_eq "scope-stale clears the reservation marker" "gone" \
+  "$([ -e "$RES_DIR/tactic-d" ] && echo present || echo gone)"
 
 # ============================================================================
 # Case 8: provision exit 2 (or other) -> parked, no spawn
@@ -321,9 +337,16 @@ assert_eq "residue hold-fail exit 1" "1" "$RC"
 # Case 9: a failed spawn kick -> failed, exit 1
 # ============================================================================
 echo "Case 9: spawn kick failure -> failed, exit 1"
+printf 'session=headless:k\nissue=tactic-k\ntimestamp=2026-01-01T00:00:00Z\n' > "$RES_DIR/tactic-k"
 SPAWN_RC=1 run_exec "tactic-k:tactic:implement"
 assert_eq "kick-fail stdout" "failed tactic-k spawn-failed" "$OUT"
 assert_eq "kick-fail exit 1" "1" "$RC"
+# A failed kick leaves the selection claim for the sweep — it does NOT stamp a
+# spawn handoff, since no worker session was actually launched.
+assert_eq "kick-fail leaves the reservation marker" "present" \
+  "$([ -e "$RES_DIR/tactic-k" ] && echo present || echo gone)"
+assert_not_contains "kick-fail marker is not stamped origin=spawned" "origin=spawned" \
+  "$(cat "$RES_DIR/tactic-k")"
 
 # ============================================================================
 # Case 10: hold-node failure once the conflict strike cap is exceeded ->
@@ -361,6 +384,23 @@ echo "Case 13: unmapped kind:phase -> failed, exit 1"
 run_exec "tactic-u:tactic:bogus"
 assert_eq "unmapped stdout" "failed tactic-u unmapped-kind-phase:tactic:bogus" "$OUT"
 assert_eq "unmapped exit 1" "1" "$RC"
+
+# ============================================================================
+# Case 15: no reservation marker present at spawn time -> a successful kick
+# still creates one, stamped origin=spawned. This covers a spawn racing ahead
+# of (or outliving) whatever wrote the original selection-time marker.
+# ============================================================================
+echo "Case 15: a successful kick creates a marker even if none existed at spawn time"
+rm -f "$RES_DIR/tactic-nomark"
+run_exec "tactic-nomark:tactic:implement"
+assert_eq "no-prior-marker stdout" "launched tactic-nomark /implement" "$OUT"
+assert_eq "no-prior-marker exit 0" "0" "$RC"
+assert_eq "no-prior-marker creates the reservation marker" "present" \
+  "$([ -e "$RES_DIR/tactic-nomark" ] && echo present || echo gone)"
+assert_contains "no-prior-marker is stamped origin=spawned" "origin=spawned" \
+  "$(cat "$RES_DIR/tactic-nomark")"
+assert_contains "no-prior-marker has a non-empty session= line" "session=" \
+  "$(cat "$RES_DIR/tactic-nomark")"
 
 # ============================================================================
 # Case 14: usage error (no args) -> exit 2

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-reservation-ledger.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-reservation-ledger.sh
@@ -416,14 +416,42 @@ rl_teardown
 # reservation_clear on a successful kick, so the claim stays in force until the
 # worker registers. The existing session=/issue= values are preserved and the
 # timestamp is refreshed to spawn time.
-echo "Test: reservation_mark_spawned re-stamps an existing marker as origin=spawned, preserving session/issue"
+# The two DISPATCH_RESERVATION_NOW values are DISTINCT on purpose: the refresh is
+# load-bearing (selection→spawn includes provision-node-worktree's fetch/
+# worktree-add and can take minutes, so carrying the selection stamp forward
+# could hand back an already-expired handoff). Pinning both writes to one value
+# would let a regression that preserved the ORIGINAL stamp pass this assertion.
+echo "Test: reservation_mark_spawned re-stamps an existing marker as origin=spawned, preserving session/issue and refreshing the timestamp"
 rl_setup
+export DISPATCH_RESERVATION_NOW="2025-12-31T23:50:00Z"   # selection time
 reservation_write "tactic-x" "tactic-x" "headless:abc"
+export DISPATCH_RESERVATION_NOW="2026-01-01T00:00:00Z"   # spawn time, 10min later
 if reservation_mark_spawned "tactic-x"; then rc=0; else rc=$?; fi
 assert_eq "rl-mark-spawned-content: exits 0" "0" "$rc"
-assert_eq "rl-mark-spawned-content: marker is the 4 documented lines with origin=spawned" \
+assert_eq "rl-mark-spawned-content: marker is the 4 documented lines with origin=spawned and the SPAWN-time stamp" \
   "$(printf 'session=headless:abc\nissue=tactic-x\norigin=spawned\ntimestamp=2026-01-01T00:00:00Z')" \
   "$(cat "$DISPATCH_RESERVATION_DIR/tactic-x")"
+rl_teardown
+
+# --- Test D2: the refreshed stamp is what the sweep's handoff TTL measures -----
+# End-to-end guard for the refresh: a marker whose ORIGINAL (selection) stamp is
+# older than the handoff TTL, but whose spawn re-stamp is fresh, must SURVIVE the
+# sweep. A regression that carried the selection stamp forward would hand back an
+# already-expired handoff and the marker would be reclaimed here.
+echo "Test: an origin=spawned marker whose ORIGINAL stamp predates the handoff TTL survives the sweep on its refreshed stamp"
+rl_setup
+export DISPATCH_RESERVATION_NOW="2025-12-31T23:50:00Z"   # 600s before spawn time
+reservation_write "tactic-x" "tactic-x" "headless:abc"
+export DISPATCH_RESERVATION_NOW="2026-01-01T00:00:00Z"   # spawn time (epoch 1767225600)
+reservation_mark_spawned "tactic-x"
+# Neither the reserving session nor a worker named tactic-x is live.
+rl_write_fake_claude '[{"sessionId":"other","pid":1,"status":"busy","name":"someworker"}]'
+# 90s past SPAWN time — well inside the 300s handoff TTL, but 690s past the
+# selection stamp, i.e. past it had the refresh not happened.
+export DISPATCH_RESERVATION_SWEEP_NOW_EPOCH=$((1767225600 + 90))
+reservation_sweep 2>/dev/null
+assert_eq "rl-mark-spawned-refresh: handoff measured from the SPAWN stamp, marker kept (count 1)" "1" \
+  "$(reservation_count)"
 rl_teardown
 
 # --- Test E: reservation_mark_spawned creates a marker when none exists --------

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-reservation-ledger.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-reservation-ledger.sh
@@ -42,7 +42,7 @@ rl_teardown() {
   RL_FAKE=""
   unset DISPATCH_RESERVATION_DIR CLAUDE_AGENTS_CMD DISPATCH_RESERVATION_NOW \
     DISPATCH_RESERVATION_SWEEP_NOW_EPOCH DISPATCH_RESERVATION_BOOT_GRACE_S \
-    DISPATCH_RESERVATION_STANDALONE_TTL_S
+    DISPATCH_RESERVATION_STANDALONE_TTL_S DISPATCH_RESERVATION_HANDOFF_TTL_S
 }
 
 # rl_write_fake_claude <json-array> — install a fake `claude` that prints the
@@ -409,6 +409,110 @@ if printf '%s' "$err" | grep -q 'live-worker-redundant'; then
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: rl-sweep-redundant-young: note mentions live-worker-redundant"
 fi
+rl_teardown
+
+# --- Test D: reservation_mark_spawned re-stamps the claim as origin=spawned ----
+# The spawn handoff: dispatch-graph-execute calls this INSTEAD of
+# reservation_clear on a successful kick, so the claim stays in force until the
+# worker registers. The existing session=/issue= values are preserved and the
+# timestamp is refreshed to spawn time.
+echo "Test: reservation_mark_spawned re-stamps an existing marker as origin=spawned, preserving session/issue"
+rl_setup
+reservation_write "tactic-x" "tactic-x" "headless:abc"
+if reservation_mark_spawned "tactic-x"; then rc=0; else rc=$?; fi
+assert_eq "rl-mark-spawned-content: exits 0" "0" "$rc"
+assert_eq "rl-mark-spawned-content: marker is the 4 documented lines with origin=spawned" \
+  "$(printf 'session=headless:abc\nissue=tactic-x\norigin=spawned\ntimestamp=2026-01-01T00:00:00Z')" \
+  "$(cat "$DISPATCH_RESERVATION_DIR/tactic-x")"
+rl_teardown
+
+# --- Test E: reservation_mark_spawned creates a marker when none exists --------
+# A caller that reached spawn without a ledger entry must still get covered, and
+# the synthesized session= must be NON-EMPTY: reservation_write rejects an empty
+# session id, and an empty session= would land the marker on sweep rule (b),
+# which KEEPS it forever (an immortal slot).
+echo "Test: reservation_mark_spawned creates a covering marker with a non-empty session when none exists"
+rl_setup
+if reservation_mark_spawned "tactic-y"; then rc=0; else rc=$?; fi
+assert_eq "rl-mark-spawned-absent: exits 0" "0" "$rc"
+assert_eq "rl-mark-spawned-absent: marker created" "1" \
+  "$([ -f "$DISPATCH_RESERVATION_DIR/tactic-y" ] && echo 1 || echo 0)"
+assert_eq "rl-mark-spawned-absent: origin=spawned stamped" "1" \
+  "$(grep -qx 'origin=spawned' "$DISPATCH_RESERVATION_DIR/tactic-y" && echo 1 || echo 0)"
+assert_eq "rl-mark-spawned-absent: session= line is non-empty" "1" \
+  "$([ -n "$(sed -n 's/^session=//p' "$DISPATCH_RESERVATION_DIR/tactic-y" | head -n1)" ] && echo 1 || echo 0)"
+rl_teardown
+
+# --- Test F: sweep HOLDS an origin=spawned marker with a dead reserving session -
+# The core regression guard. The tick's reserving session is the synthetic
+# `headless:<INVOCATION_ID>`, which never appears in `claude agents` — so without
+# rule (a-handoff) this marker is reclaimed as dead-session-stranded the moment
+# the 30s boot grace lapses, reopening the duplicate-worker window while the
+# spawned worker is still booting (90s registration latency observed 2026-07-30).
+echo "Test: reservation_sweep HOLDS an origin=spawned marker past the boot grace when its reserving session is dead"
+rl_setup
+reservation_write "tactic-x" "tactic-x" "headless:abc" "spawned"
+# Neither the reserving session nor a worker named tactic-x is live.
+rl_write_fake_claude '[{"sessionId":"other","pid":1,"status":"busy","name":"someworker"}]'
+export DISPATCH_RESERVATION_SWEEP_NOW_EPOCH=$((1767225600 + 90))
+reservation_sweep 2>/dev/null
+assert_eq "rl-sweep-spawned-held: handoff marker kept at +90s (count 1)" "1" "$(reservation_count)"
+rl_teardown
+
+# --- Test G: sweep reclaims an origin=spawned marker past the handoff TTL ------
+echo "Test: reservation_sweep reclaims an origin=spawned marker once it ages past the handoff TTL"
+rl_setup
+reservation_write "tactic-x" "tactic-x" "headless:abc" "spawned"
+rl_write_fake_claude '[{"sessionId":"other","pid":1,"status":"busy","name":"someworker"}]'
+export DISPATCH_RESERVATION_SWEEP_NOW_EPOCH=$((1767225600 + 301))
+err=$(reservation_sweep 2>&1 1>/dev/null)
+assert_eq "rl-sweep-spawned-expired: aged handoff marker reclaimed (count 0)" "0" "$(reservation_count)"
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$err" | grep -q 'spawn-handoff-expired'; then
+  PASS=$((PASS + 1)); echo "  PASS: rl-sweep-spawned-expired: note mentions spawn-handoff-expired"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: rl-sweep-spawned-expired: note mentions spawn-handoff-expired"
+  echo "    stderr: $err"
+fi
+rl_teardown
+
+# --- Test H: a registered worker releases the handoff via rule (a) -------------
+# The handoff's intended release is an EVENT, not a timeout: the instant a live
+# session named by the worktree basename appears, rule (a) reclaims the marker.
+echo "Test: reservation_sweep releases an origin=spawned marker as soon as its worker registers (rule (a))"
+rl_setup
+reservation_write "tactic-x" "tactic-x" "headless:abc" "spawned"
+rl_write_fake_claude '[{"sessionId":"x","pid":1,"status":"busy","name":"tactic-x"}]'
+export DISPATCH_RESERVATION_SWEEP_NOW_EPOCH=$((1767225600 + 90))
+err=$(reservation_sweep 2>&1 1>/dev/null)
+assert_eq "rl-sweep-spawned-released: handoff released on registration (count 0)" "0" "$(reservation_count)"
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$err" | grep -q 'live-worker-redundant'; then
+  PASS=$((PASS + 1)); echo "  PASS: rl-sweep-spawned-released: note mentions live-worker-redundant"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: rl-sweep-spawned-released: note mentions live-worker-redundant"
+  echo "    stderr: $err"
+fi
+# A benign release is NOT a dead-strand: the launch-log diagnostic must stay off.
+TOTAL=$((TOTAL + 1))
+if printf '%s' "$err" | grep -q 'inspect tmp/dispatch-launch'; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: rl-sweep-spawned-released: benign release stays silent (no launch-log diagnostic)"
+  echo "    stderr: $err"
+else
+  PASS=$((PASS + 1)); echo "  PASS: rl-sweep-spawned-released: benign release stays silent (no launch-log diagnostic)"
+fi
+rl_teardown
+
+# --- Test I: the boot grace still short-circuits a young spawned marker --------
+# Control for Tests F/G: a handoff marker inside the boot grace is kept by the
+# grace branch, which precedes the new rule — the new rule did not disturb it.
+echo "Test: reservation_sweep keeps a young origin=spawned marker via the boot grace (unchanged)"
+rl_setup
+reservation_write "tactic-x" "tactic-x" "headless:abc" "spawned"
+rl_write_fake_claude '[{"sessionId":"other","pid":1,"status":"busy","name":"someworker"}]'
+export DISPATCH_RESERVATION_SWEEP_NOW_EPOCH=$((1767225600 + 5))
+reservation_sweep 2>/dev/null
+assert_eq "rl-sweep-spawned-young: young handoff marker kept (count 1)" "1" "$(reservation_count)"
 rl_teardown
 
 # --- Test 13: reservation_exists tracks write/clear and guards its arg --------


### PR DESCRIPTION
## Summary

The dispatch router's per-node reservation claim was supposed to be one continuous span — the reservation-ledger marker covering selection→spawn, and a live `claude agents` session covering spawn→exit. In practice `dispatch-graph-execute` deleted the marker synchronously on a successful spawn kick, while the worker had not yet registered as a live session. For that boot window the node was covered by neither guard, and a concurrent tick could re-select it and launch a second worker into the same worktree. Two live duplicates were observed (90s and 6s gaps).

This lands the handoff design from the tactic node's plan:

- **Unit 1** (`lib-reservation-ledger.sh`) — new `reservation_mark_spawned` primitive that re-stamps a marker `origin=spawned` with a fresh timestamp, and a new sweep rule that HOLDS a spawned-origin marker regardless of the reserving session's liveness until a bounded `DISPATCH_RESERVATION_HANDOFF_TTL_S` (default 300s) elapses — closing the gap where a synthetic `headless:*` session id let the old dead-session rule reclaim the marker at the 30s boot-grace boundary.
- **Unit 2** (`dispatch-graph-execute`) — the three successful-kick call sites now call `reservation_mark_spawned` instead of `reservation_clear`; the two non-spawn exits (stale-selection, scope-stale) are untouched.
- **Unit 3** — corrects stale "clears it on spawn" doctrine comments in `graph-select-target` and `dispatch-select-tick` to describe the handoff.

Release stays event-driven: the existing age-independent sweep rule (a), `live-worker-redundant`, still fires the instant the worker registers, releasing the claim at the next sweep — the TTL is only the backstop for a spawn that dies during boot.

## Verification

All four affected/neighboring test suites pass, plus prose lint:

```verify
.claude/skills/dispatch-propagate/scripts/test-lib-reservation-ledger.sh
```
```verify
.claude/skills/dispatch-propagate/scripts/test-dispatch-graph-execute.sh
```
```verify
.claude/skills/dispatch-propagate/scripts/test-dispatch-select-tick.sh
```
```verify
.claude/skills/dispatch-propagate/scripts/test-dispatch-tick.sh
```
```verify
.claude/skills/dispatch-propagate/scripts/run-lint.sh --prose
```

Manual check: `grep -n 'reservation_clear\|reservation_mark_spawned' dispatch-graph-execute` shows exactly 3 `reservation_mark_spawned` lines (strategy lane, tactic exit-0, conflict exit-11) and exactly 2 surviving `reservation_clear` lines (exits 12/13).

**Observe in production (post-merge, judgment call).** No unit test reproduces the live-fleet race end to end:
1. A `launched <id> <skill>` tick-journal line should never be followed by a second `launched <id>` from a different tick pid within the same boot window.
2. `tmp/dispatch-reservations/` should now be non-empty during a worker's boot window (it was empty at all three recorded duplicates).
3. Watch for `spawn-handoff-expired` reclaim notes — a steady trickle is expected/healthy; a flood means the TTL is shorter than real registration latency (raise it, don't revert the rule).
4. Expect `live-worker-redundant` reclaim counts (via `dispatch-reclaim-audit`) to rise substantially post-fix — every successful spawn now leaves a marker for that rule to reclaim, where before it left none. That script's dead-vs-redundant ratio thesis is report-only and ages as a result; out of scope here.

**Remediation runbook if a duplicate is observed while verifying:** both sessions share one worktree. `claude rm <session-id>` deletes the session *and its worktree* — use `claude stop` on the newer session instead and leave the worktree to the survivor.

## Out of scope

- Lengthening `DISPATCH_RESERVATION_BOOT_GRACE_S` — the grace only protects markers that still exist; that was never the defect.
- The 814s duplicate occurrence (`/review-fix` on a different node) — a live-session *read* defect owned by a sibling node, not this spawn-window mechanism. A duplicate observed after this lands with a gap far larger than the handoff window is that mechanism, not a regression here.
- `dispatch-spawn-job`'s own name/cwd dedup — unchanged, defeated by the same registration latency, hardening it is the sibling node's territory.
- `graph-select-target`'s claimed-set gate and `dispatch-reclaim-audit` — no code changes needed; both already do the right thing once the marker persists / are additive-safe to the new reclaim reason string.
