### PR TITLE
Duplicate-worker stand-down: winner-liveness re-check (tactic-standdown-winner-liveness)

### DIFF
--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -212,6 +212,36 @@ worktree, each advancing its own issue's phase without contention. Only the
 router selection step is serialized; the worker execution path is per-
 worktree-parallel.
 
+## Duplicate-worker stand-down
+
+Sometimes a bug elsewhere in the spawn path produces two live sessions for the
+same graph node. The stand-down protocol resolves that without interrupting
+whichever session is actually ahead:
+
+1. The session holding uncommitted/unpushed work wins. The other stands down.
+2. The standing-down session calls `dispatch-standdown <node-id> --winner
+   <winner-sid>` and yields the turn. The script re-checks the winner's
+   liveness one more time, right at the moment of decision, before writing
+   anything — a stale premise (the winner already died) must not produce a
+   stand-down record naming a winner that was never actually there.
+3. It writes NO office-hours park itself. A park here would spuriously knock a
+   node another session is actively working out of the dispatch lane —
+   precisely the interruption this protocol exists to avoid.
+4. It never self-closes via `claude rm`. The worktree is shared with the
+   winner, and `claude rm` deletes the job's worktree along with the job — if
+   the winner's fix is still uncommitted or unpushed there, self-closing would
+   destroy it.
+
+Yielding the turn without a `node-terminal` marker leaves the job HELD by the
+Stop hook (dispatch-self-close's Invariant 2) rather than reaped. That hold
+used to be an invisible trap: nothing re-checked whether the winner was still
+alive, so a winner that died before pushing left the node stranded forever.
+`standdown_recheck_sweep` (lib-standdown-recheck.sh), run on both
+`dispatch-tick` cadences, closes that gap — it re-checks every stand-down
+marker's declared winner against the live-session registry and parks the node
+to office-hours if the winner turns out to be definitely gone, surfacing the
+stall to a human instead of leaving it silent.
+
 ## Selection-ladder mechanics
 
 This explains what `dispatch-select-target` does internally. The router only

--- a/.claude/skills/dispatch-propagate/reference.md
+++ b/.claude/skills/dispatch-propagate/reference.md
@@ -223,7 +223,12 @@ whichever session is actually ahead:
    <winner-sid>` and yields the turn. The script re-checks the winner's
    liveness one more time, right at the moment of decision, before writing
    anything — a stale premise (the winner already died) must not produce a
-   stand-down record naming a winner that was never actually there.
+   stand-down record naming a winner that was never actually there. **Yield
+   only on exit 0 (`stood-down`).** Exit 3 (`winner-absent`) means there is no
+   winner to stand down for — become the worker instead. Exit 4
+   (`ledger-unwritable`) means the stand-down was not recorded, so nothing will
+   ever re-check it — do not yield on it either; fix the ledger and re-run, or
+   keep working the node.
 3. It writes NO office-hours park itself. A park here would spuriously knock a
    node another session is actively working out of the dispatch lane —
    precisely the interruption this protocol exists to avoid.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-self-close
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-self-close
@@ -81,6 +81,12 @@
 #   stays claimed until someone clears it. The distinctive log line is the
 #   canary; broad or repeated firing means a lane is failing to declare.
 #
+#   Asking "why is my job being held?" and finding no matching terminal-
+#   disposition lane above: check whether it is a duplicate-worker stand-down
+#   instead — see `dispatch-standdown` and `standdown_recheck_sweep`
+#   (lib-standdown-recheck.sh), which deliberately hold a job this way while a
+#   winner session is re-checked on the tick cadence.
+#
 # Neither invariant applies to: an empty/missing name with no `--node` (legacy /
 # plain managed-job callers, e.g. dispatch-finalize-phase), which keeps its
 # existing unconditional behavior.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-standdown
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-standdown
@@ -70,8 +70,10 @@
 #      decision_log_append` guard, built with `jq -c -n` — never fatal to this
 #      script.
 #   4. Print exactly one stdout token and exit accordingly:
-#        stood-down       marker written.                 exit 0
-#        winner-absent    winner definitely gone; no marker written.  exit 3
+#        stood-down        marker written.                exit 0
+#        winner-absent     winner definitely gone; no marker written.  exit 3
+#        ledger-unwritable the ledger dir could not be resolved or written; no
+#                          marker written.                exit 4
 #      No other stdout output on any path — diagnostics go to stderr.
 #
 # Arguments:
@@ -83,9 +85,18 @@
 # Exit codes:
 #   0  stood-down — the ledger marker was written.
 #   2  usage error — missing/malformed <node-id>, missing --winner, or
-#      malformed <session-id>.
+#      malformed <session-id>. Retry with corrected arguments.
 #   3  winner-absent — the named winner is definitely not live; no marker
 #      written. The caller must decide what to do next (this script does not).
+#   4  ledger-unwritable — the arguments were valid and the winner was live,
+#      but the ledger dir could not be resolved or written, so NO marker
+#      exists. Distinct from 2 because the caller must act differently: the
+#      stand-down is UNRECORDED, so `standdown_recheck_sweep` will never
+#      re-check it. Do NOT yield the turn on this — a held job with no ledger
+#      marker is exactly the silent trap this protocol closes. Fix the ledger
+#      (its dir is <project-root>/tmp/dispatch-standdown unless
+#      DISPATCH_STANDDOWN_DIR overrides it) and re-run, or keep working the
+#      node yourself.
 #
 # Environment:
 #   CLAUDE_CODE_SESSION_ID  This session's own id, folded into the marker's
@@ -184,8 +195,14 @@ else
 fi
 
 if ! standdown_write "$NODE_ID" declared "$WINNER_SID" "$SESSIONS_CSV"; then
-  echo "dispatch-standdown: could not write the stand-down ledger marker for $NODE_ID (winner=$WINNER_SID)" >&2
-  exit 2
+  # Exit 4, NOT the usage-error 2: the arguments were fine, the ledger was not
+  # writable. The distinction is what the caller acts on — a usage error means
+  # retry with different arguments, while an unwritable ledger means the
+  # stand-down was NOT RECORDED, so yielding the turn now re-creates the exact
+  # silent hold this script exists to close.
+  echo "dispatch-standdown: could not write the stand-down ledger marker for $NODE_ID (winner=$WINNER_SID); the stand-down is NOT recorded — do NOT yield the turn on it" >&2
+  echo "ledger-unwritable"
+  exit 4
 fi
 
 if command -v decision_log_append >/dev/null 2>&1; then

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-standdown
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-standdown
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# dispatch-standdown — CLI entry point for the losing session in the
+# duplicate-worker stand-down protocol.
+#
+# Usage: dispatch-standdown <node-id> --winner <session-id>
+#
+# Two sessions can get spawned for the same graph node (a bug elsewhere in the
+# spawn path). The session holding uncommitted/unpushed work wins; the other
+# stands down. A stand-down that is only implicit — the losing session simply
+# stops acting — is unsafe: if the winner then dies before pushing (crash,
+# OOM, API error, classifier denial), the loser (and the node) is stranded on
+# a session that no longer exists, with nobody watching. This script makes the
+# stand-down a durable, re-checkable record instead: it writes a ledger marker
+# naming the declared winner, and `standdown_recheck_sweep`
+# (lib-standdown-recheck.sh, run on both dispatch-tick cadences) re-checks that
+# winner's liveness on every subsequent tick, parking the node to office-hours
+# if the winner turns out to have died with work unpushed.
+#
+# Before writing anything, this script re-checks the winner's liveness ONE
+# MORE TIME, right now — it does not just trust the caller's premise. A
+# session decides to stand down because it believes another session is ahead
+# of it; by the time it actually calls this script, that belief may already be
+# stale. If the named winner is DEFINITELY gone at this exact moment, there is
+# no one to stand down FOR — writing a stand-down marker in that case would
+# strand the node on a winner that was never actually alive. So this script
+# refuses to write the marker in that case; it is the caller's job to notice
+# `winner-absent` and decide what to do next (most likely: become the worker
+# itself), not this script's.
+#
+# WHAT THE CALLER DOES NEXT, on `stood-down` (exit 0): yield the turn WITHOUT
+# writing a `node-terminal` marker (see `packages/intentionsutil/scripts/
+# mark-node-terminal` and dispatch-self-close's Invariant 2). The Stop hook
+# then HOLDS the job — it does not reap it — because no terminal-disposition
+# marker names this node. That hold is now SAFE: before this protocol existed
+# it was a silent trap (a held job nobody re-checks); now it is recorded in the
+# stand-down ledger, and `standdown_recheck_sweep` (tick-cadence, in
+# lib-standdown-recheck.sh) owns re-checking it from here — it will park the
+# node to office-hours if the winner dies before pushing.
+#
+# THE STANDING-DOWN SESSION MUST NEVER `claude rm` ITSELF (self-close). Both
+# duplicate sessions run in the SAME shared worktree — that is the root reason
+# this whole protocol exists. `claude rm` deletes the job AND its worktree. If
+# the winner's fix is still uncommitted or unpushed in that worktree when the
+# loser self-closes, the fix is destroyed along with it. Yielding the turn and
+# letting the Stop hook hold the job is the only safe path; the ledger marker
+# this script writes is what makes that hold observable and recoverable rather
+# than a silent stall.
+#
+# THE STANDING-DOWN SESSION MUST NEVER WRITE ITS OWN OFFICE-HOURS PARK either.
+# A park here would spuriously knock the node out of the dispatch lane while
+# the winner is still actively working it — exactly the interruption this
+# protocol exists to avoid. Only `standdown_recheck_sweep`, once it has
+# confirmed the winner is definitely gone, parks the node.
+#
+# Behavior, in order:
+#   1. Validate arguments (see the regexes below). A missing --winner flag, or
+#      either argument failing its regex, is a hard usage error — never a
+#      fallback to a default. Bad args → stderr diagnostic, exit 2.
+#   2. Re-check the winner's liveness right now via `claude_session_id_is_live`
+#      (lib-claude-agents.sh). A DEFINITE 1 (the registry queried successfully,
+#      no such session) means the winner is confirmed gone: print
+#      `winner-absent`, write NO marker, exit 3.
+#   3. Otherwise (live, or the daemon query was UNKNOWN — which
+#      claude_session_id_is_live folds into "live", fail-safe) write the
+#      ledger marker via `standdown_write <node-id> declared <winner-sid>
+#      <sessions-csv>`, where <sessions-csv> is "<winner-sid>,<own-sid>" when
+#      $CLAUDE_CODE_SESSION_ID is non-empty, or just "<winner-sid>" (no
+#      trailing comma) when it is empty/unset. Then append one best-effort
+#      decision-log record (site "standdown-declared") behind a `command -v
+#      decision_log_append` guard, built with `jq -c -n` — never fatal to this
+#      script.
+#   4. Print exactly one stdout token and exit accordingly:
+#        stood-down       marker written.                 exit 0
+#        winner-absent    winner definitely gone; no marker written.  exit 3
+#      No other stdout output on any path — diagnostics go to stderr.
+#
+# Arguments:
+#   <node-id>            Must match ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ — the same
+#                         node-id shape mark-node-terminal and
+#                         dispatch-graph-execute validate against.
+#   --winner <session-id> Required. Must match ^[0-9a-fA-F-]+$.
+#
+# Exit codes:
+#   0  stood-down — the ledger marker was written.
+#   2  usage error — missing/malformed <node-id>, missing --winner, or
+#      malformed <session-id>.
+#   3  winner-absent — the named winner is definitely not live; no marker
+#      written. The caller must decide what to do next (this script does not).
+#
+# Environment:
+#   CLAUDE_CODE_SESSION_ID  This session's own id, folded into the marker's
+#                           sessions= field alongside the winner's. Optional —
+#                           an unset/empty value omits it (and the trailing
+#                           comma) rather than writing a malformed field.
+#   CLAUDE_AGENTS_CMD       Forwarded to lib-claude-agents.sh (the winner-
+#                           liveness query). Test override; default `claude`.
+#   DISPATCH_STANDDOWN_*    Forwarded to lib-standdown-recheck.sh (ledger
+#                           location, clock, etc). See that file's header.
+#   DISPATCH_DECISION_LOG_DIR / _FILE  Forwarded to lib-decision-log.sh.
+#
+# Sandbox: the winner-liveness re-check reaches the local Claude daemon over a
+# Unix socket, so callers must run this with `dangerouslyDisableSandbox: true`
+# — see `.claude/rules/sandbox.md`.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-claude-agents.sh
+source "$SCRIPT_DIR/lib-claude-agents.sh"
+# shellcheck source=lib-standdown-recheck.sh
+source "$SCRIPT_DIR/lib-standdown-recheck.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib-decision-log.sh" 2>/dev/null || true
+
+usage() {
+  echo "usage: dispatch-standdown <node-id> --winner <session-id>" >&2
+}
+
+# ---- Step 1: parse and validate arguments -----------------------------------
+NODE_ID=""
+WINNER_SID=""
+HAVE_WINNER=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --winner)
+      if [[ $# -lt 2 ]]; then
+        echo "dispatch-standdown: --winner requires a value" >&2
+        usage
+        exit 2
+      fi
+      WINNER_SID="$2"
+      HAVE_WINNER=1
+      shift 2
+      ;;
+    *)
+      if [[ -n "$NODE_ID" ]]; then
+        echo "dispatch-standdown: unexpected extra argument: $1" >&2
+        usage
+        exit 2
+      fi
+      NODE_ID="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$NODE_ID" ]]; then
+  echo "dispatch-standdown: missing required <node-id> argument" >&2
+  usage
+  exit 2
+fi
+if [[ ! "$NODE_ID" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]]; then
+  echo "dispatch-standdown: invalid node id: $NODE_ID" >&2
+  usage
+  exit 2
+fi
+if [[ "$HAVE_WINNER" -eq 0 || -z "$WINNER_SID" ]]; then
+  echo "dispatch-standdown: missing required --winner <session-id>" >&2
+  usage
+  exit 2
+fi
+if [[ ! "$WINNER_SID" =~ ^[0-9a-fA-F-]+$ ]]; then
+  echo "dispatch-standdown: invalid --winner session id: $WINNER_SID" >&2
+  usage
+  exit 2
+fi
+
+# ---- Step 2: re-check the winner's liveness RIGHT NOW -----------------------
+# claude_session_id_is_live returns 0 (live) both on an actual match and on a
+# daemon-UNKNOWN query — folded fail-safe. Only a definite 1 (registry
+# queried, no such session) means the winner is confirmed gone.
+if ! claude_session_id_is_live "$WINNER_SID"; then
+  echo "dispatch-standdown: winner session $WINNER_SID is definitely not live; refusing to stand down for it (node=$NODE_ID)" >&2
+  echo "winner-absent"
+  exit 3
+fi
+
+# ---- Step 3: write the ledger marker ----------------------------------------
+OWN_SID="${CLAUDE_CODE_SESSION_ID:-}"
+if [[ -n "$OWN_SID" ]]; then
+  SESSIONS_CSV="${WINNER_SID},${OWN_SID}"
+else
+  SESSIONS_CSV="${WINNER_SID}"
+fi
+
+if ! standdown_write "$NODE_ID" declared "$WINNER_SID" "$SESSIONS_CSV"; then
+  echo "dispatch-standdown: could not write the stand-down ledger marker for $NODE_ID (winner=$WINNER_SID)" >&2
+  exit 2
+fi
+
+if command -v decision_log_append >/dev/null 2>&1; then
+  standdown_json=$(jq -c -n \
+    --arg ts       "$(date -u +%FT%TZ)" \
+    --arg site     "standdown-declared" \
+    --arg node     "$NODE_ID" \
+    --arg winner   "$WINNER_SID" \
+    --arg sessions "$SESSIONS_CSV" \
+    '{ts: $ts, site: $site, node: $node, winner: $winner, sessions: $sessions}' \
+    2>/dev/null) && decision_log_append "$standdown_json" || true
+fi
+
+echo "dispatch-standdown: stood down for node $NODE_ID in favour of winner $WINNER_SID (sessions=$SESSIONS_CSV); yield the turn WITHOUT a node-terminal marker so the Stop hook holds the job" >&2
+echo "stood-down"
+exit 0

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -96,6 +96,15 @@
 #                            reservations are the claim. On the autonomous path a
 #                            successful execute arms a convergence reseed.
 #        anything else     → diagnostic to stderr; exit 2.
+#   3. Run the stand-down winner-liveness re-check sweep
+#      (standdown_recheck_sweep, lib-standdown-recheck.sh) on TWO cadences: on
+#      the paused branch (so a stranded stand-down marker still surfaces even
+#      while dispatch is paused — that `exit 0` is the only autonomous path
+#      that never reaches dispatch-select-tick's own sweeps), and on the
+#      normal path, after the per-tick daemon snapshot is captured and before
+#      Step 1 target selection (so it reuses the snapshot and any node it
+#      parks is already excluded from this tick's own selection). Never gates
+#      the tick — a load failure logs loudly and the tick continues.
 #
 # The legacy gh-issue lane (explicit/pr/issue decisions →
 # dispatch-materialize-spawn → dispatch-launch-worker, and the recoverable-death
@@ -293,6 +302,24 @@ if [[ -z "$MANUAL" && -e "$DISPATCH_PAUSE_FLAG" ]]; then
   else
     echo "dispatch-tick: lib-reservation-ledger.sh failed to load; reservation ledger NOT swept this tick" >&2
   fi
+
+  # A stranded stand-down marker (winner session died mid-work, loser waiting
+  # forever) must still surface even while dispatch is paused, for the same
+  # reason the reservation sweep runs on this branch: this `exit 0` path is the
+  # ONLY autonomous tick path that never reaches dispatch-select-tick's own
+  # sweeps, so nothing else would ever re-check a stand-down marker while
+  # paused. Same conditional-source + verify + loud-failure idiom as
+  # reservation_sweep above, applied to lib-standdown-recheck.sh.
+  if ! declare -f standdown_recheck_sweep >/dev/null 2>&1; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/lib-standdown-recheck.sh"
+  fi
+  if declare -f standdown_recheck_sweep >/dev/null 2>&1; then
+    standdown_recheck_sweep 1>&2
+  else
+    echo "dispatch-tick: lib-standdown-recheck.sh failed to load; stand-down re-check NOT run this tick" >&2
+  fi
+
   echo "dispatch-tick: paused (sentinel present at $DISPATCH_PAUSE_FLAG); no scheduling this tick"
   exit 0
 fi
@@ -411,6 +438,25 @@ else
   # NOT abort the tick — degrade to the pre-#1452 behavior. (#1452)
   rm -f "$_SNAPSHOT_FILE"
   echo "dispatch-tick: claude agents snapshot capture failed; selection will use live per-call reads (#1452)" >&2
+fi
+
+# --- Stand-down winner-liveness re-check sweep --------------------------------
+# Placement matters: this runs AFTER the daemon snapshot above (so the sweep's
+# machine-wide session-registry reads reuse this tick's single
+# DISPATCH_AGENTS_SNAPSHOT instead of an extra round-trip `claude agents --json`
+# call) and BEFORE Step 1 target selection below, so that any node the sweep
+# parks to `office_hours` lands on `main` before selection runs — this tick's
+# own selection already excludes whatever the sweep just parked. Same
+# conditional-source + verify + loud-failure idiom as the paused-branch call
+# above.
+if ! declare -f standdown_recheck_sweep >/dev/null 2>&1; then
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/lib-standdown-recheck.sh"
+fi
+if declare -f standdown_recheck_sweep >/dev/null 2>&1; then
+  standdown_recheck_sweep 1>&2
+else
+  echo "dispatch-tick: lib-standdown-recheck.sh failed to load; stand-down re-check NOT run this tick" >&2
 fi
 
 # --- Step 1: select the target ------------------------------------------------

--- a/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh
@@ -151,18 +151,44 @@
 #
 # claude_session_id_is_live <sid>
 #   The winner-liveness predicate for the duplicate-worker stand-down protocol.
-#   Built on ONE `claude_agents_list_all` fetch — never a bespoke `claude agents
-#   --json` call. Exact-matches column 1 (sessionId) against <sid> with
-#   `awk -F'\t'`, never a substring grep — session ids share prefixes, so a
-#   substring match could conflate two distinct sessions.
+#   Queries `claude agents --json --all` DIRECTLY — with `--all`, and NOT via
+#   `claude_agents_list_all` / `_claude_agents_raw`. This is load-bearing, not a
+#   style choice: the default (active-only) listing HIDES a session that stopped
+#   but was never `claude rm`'d (`state: "done"` / `stopped`), and that is the
+#   COMMON state for a stand-down winner — a Stop-hook-held or errored session
+#   whose fix is still uncommitted in the SHARED worktree. Reading the
+#   active-only listing would report such a winner as definitely gone, and the
+#   documented `winner-absent` response ("become the worker itself") would take
+#   over that worktree and destroy the winner's uncommitted work — exactly the
+#   loss this protocol exists to prevent. The tick snapshot
+#   (DISPATCH_AGENTS_SNAPSHOT) is bypassed for the same reason
+#   `claude_sessions_with_name_all` bypasses it: it is captured without `--all`
+#   and so lacks the very rows this predicate must see.
+#   Matches `.sessionId` with jq's exact `==`, never a substring test — session
+#   ids share prefixes, so a substring match could conflate two distinct sessions.
 #   This is the SAME fail-safe posture as `worktree_has_live_session`
 #   (occupied-on-unknown), applied to a session id instead of a worktree name —
 #   the inversion is load-bearing: a caller parking a node on `return 1` must
 #   never park because the daemon hiccupped.
-#     return 0 — LIVE: <sid> matched a row in a successfully-queried registry,
-#               OR the registry could not be queried (UNKNOWN folds to live).
-#     return 1 — definitely NOT live: the registry was queried successfully
-#               and no row's sessionId equals <sid>.
+#   THREE registry states are distinguished, folded into two return codes so the
+#   fail-safe direction is preserved for every existing boolean caller:
+#     return 0 — LIVE or STOPPED-BUT-PRESENT: <sid> matched a row in a
+#               successfully-queried registry (whatever its state), OR the
+#               registry could not be queried (UNKNOWN folds to live).
+#     return 1 — ABSENT: the registry was queried successfully WITH `--all` and
+#               no row's sessionId equals <sid>. The session is gone from the
+#               daemon entirely — only then is "definitely not live" true.
+#   The granular verdict is published in the global CLAUDE_SESSION_ID_LIVE_STATE,
+#   set on EVERY call to exactly one of:
+#     live     — present and in a non-terminal state (working/busy/waiting/idle/…)
+#     stopped  — present but in a terminal state (done/stopped/killed/failed/…):
+#               the session is finished yet still registered, so its worktree may
+#               still hold uncommitted work. Callers that want to report a
+#               distinct `winner-stopped` disposition read this — it must
+#               ESCALATE, never invite a peer to take over the worktree.
+#     absent   — queried successfully, no such session (the only `return 1`).
+#     unknown  — the registry could not be queried, or no <sid> was passed.
+#   Callers that ignore the variable keep byte-identical two-state behavior.
 #   Empty/missing <sid>: prints a stderr diagnostic and returns 0 (fail safe),
 #   mirroring `worktree_has_live_session`'s own empty-arg handling.
 #
@@ -205,6 +231,11 @@
 # and `verify_agent_registered_under` (its bounded retry). Both back the
 # launcher's async-registration-race poll, which must observe a just-spawned
 # agent the instant the daemon registers it — a tick-old snapshot would miss it.
+# The `--all` functions (`claude_sessions_with_name_all`,
+# `claude_sessions_with_name_prefix_all`, `claude_job_id_for_name_all`,
+# `claude_session_id_is_live`) are excluded for a different reason: the snapshot
+# is captured WITHOUT `--all`, so it lacks the terminal-state rows they exist to
+# see. Reading it would silently hide them.
 #
 # Test override: LIB_CLAUDE_AGENTS_VERIFY_INTERVAL_S overrides the
 # `verify_agent_registered_under` inter-attempt sleep (default 0.2 s). Tests that
@@ -622,37 +653,83 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
     return 1
   }
 
+  # CLAUDE_SESSION_ID_LIVE_STATE — the granular verdict of the most recent
+  # `claude_session_id_is_live` call: live | stopped | absent | unknown. Every
+  # call sets it before returning; see the header comment for what each value
+  # obliges a caller to do. Initialized here so a read before the first call
+  # under `set -u` is not an unbound-variable error.
+  CLAUDE_SESSION_ID_LIVE_STATE="unknown"
+
   # claude_session_id_is_live <sid> — fail-safe winner-liveness predicate for
   # the duplicate-worker stand-down protocol. See the header comment for the
   # return-code contract (the inversion is load-bearing: UNKNOWN folds to
   # LIVE, the same fail-safe posture as `worktree_has_live_session` applied to
-  # a session id instead of a worktree name).
+  # a session id instead of a worktree name) and for why the query carries
+  # `--all` (a stopped-but-not-removed winner is HIDDEN from the default
+  # listing, and reporting it absent invites a peer to take over the shared
+  # worktree its uncommitted work still sits in).
   claude_session_id_is_live() {
+    CLAUDE_SESSION_ID_LIVE_STATE="unknown"
     local sid="${1:-}"
     if [[ -z "$sid" ]]; then
       printf 'lib-claude-agents: claude_session_id_is_live requires a <sid> argument\n' >&2
       return 0  # fail safe: treat as live
     fi
 
-    # One machine-wide fetch — claude_agents_list_all is the fetch-once
-    # primitive.
-    local all
-    if ! all=$(claude_agents_list_all); then
-      # Unknown — the daemon could not be queried. Fail safe: live.
+    # --all so a session that stopped without being `claude rm`'d is still
+    # visible; queried DIRECTLY (not via _claude_agents_raw / claude_agents_list_all)
+    # to bypass the tick snapshot, which is captured without --all and lacks
+    # exactly those rows. 2>/dev/null drops daemon noise; only the exit code and
+    # a well-formed JSON array on stdout are trusted. A non-zero exit means the
+    # session state cannot be determined: UNKNOWN → fail safe: live.
+    local out
+    if ! out=$("${CLAUDE_AGENTS_CMD:-claude}" agents --json --all 2>/dev/null); then
+      return 0
+    fi
+    if [[ -z "${out//[[:space:]]/}" ]]; then
       return 0
     fi
 
-    # claude_agents_list_all emits sessionId<TAB>status<TAB>name (sessionId is
-    # column 1). Exact match only — never a substring grep, since session ids
-    # share prefixes.
-    if awk -F'\t' -v sid="$sid" '$1 == sid { found = 1; exit } END { exit !found }' \
-        <<<"$all"; then
+    # One jq pass validates the array shape and resolves <sid> to one of
+    # `absent` or `present:<state>`. Exact `==` on .sessionId — never a
+    # substring test, since session ids share prefixes. `.state` is the granular
+    # field the --all listing carries; `.status` is the coarse fallback for a
+    # row that has no `.state`; a row with neither is still PRESENT and resolves
+    # to `present:` (empty state), which classifies as live. The `present:`
+    # prefix keeps a literal state value named `absent` from being conflated
+    # with a genuine absence. Non-array input errors out → UNKNOWN → live.
+    local verdict
+    if ! verdict=$(jq -r --arg sid "$sid" '
+      if type == "array"
+      then [ .[] | select(.sessionId == $sid) ] as $m
+        | if ($m | length) == 0 then "absent"
+          else "present:" + ((($m[0].state // $m[0].status) // "") | tostring)
+          end
+      else error("claude agents --json output is not a JSON array")
+      end' <<<"$out" 2>/dev/null); then
       return 0
     fi
 
-    # The query succeeded and no row's sessionId equals <sid>: definitely not
-    # live.
-    return 1
+    # The query succeeded WITH --all and no row's sessionId equals <sid>: the
+    # session is gone from the daemon entirely — definitely not live.
+    if [[ "$verdict" == "absent" ]]; then
+      CLAUDE_SESSION_ID_LIVE_STATE="absent"
+      return 1
+    fi
+
+    # Present. A terminal state means the session finished but was never
+    # `claude rm`'d, so its worktree may still hold uncommitted work: report it
+    # as `stopped` for callers that escalate on that, and return 0 (NOT live-
+    # absent) so a boolean caller never treats it as "nobody is there".
+    case "${verdict#present:}" in
+      done|stopped|killed|failed|errored|error|cancelled|canceled|terminated)
+        CLAUDE_SESSION_ID_LIVE_STATE="stopped"
+        ;;
+      *)
+        CLAUDE_SESSION_ID_LIVE_STATE="live"
+        ;;
+    esac
+    return 0
   }
 
   # claude_agents_list_duplicate_node_names — emit one line per graph-node
@@ -671,9 +748,20 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
     # shape (^tactic-|^strategy-, the same keyspace claude_agents_count_busy_workers
     # counts — excludes routers and legacy <N>-slug issue workers), group
     # sessionIds by name in registry order, then emit name<TAB>sid1,sid2,...
-    # for every name with >= 2 sessions, sorted by name for deterministic
-    # output.
-    awk -F'\t' '
+    # for every name with >= 2 sessions.
+    #
+    # POSIX awk only — no `asorti`, which is a gawk extension: under mawk (the
+    # default `awk` on ubuntu-latest runners and most Debian hosts) it is a
+    # FATAL error, and a fatal awk pass here would print nothing while this
+    # function still returned 0 — i.e. it would report a DEFINITE "the registry
+    # holds no duplicate" and silently disable the observed half of the
+    # stand-down protocol. Determinism instead comes from piping the END-block
+    # output (emitted in registry order) through `LC_ALL=C sort`.
+    #
+    # The awk status is captured and checked for the same reason: a failed pass
+    # is UNKNOWN (return 1), never a definite answer.
+    local dups
+    if ! dups=$(awk -F'\t' '
       $3 ~ /^tactic-|^strategy-/ {
         if (!($3 in seen)) { order[++n] = $3; seen[$3] = 1 }
         if (sids[$3] == "") { sids[$3] = $1 } else { sids[$3] = sids[$3] "," $1 }
@@ -682,14 +770,16 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
       END {
         for (i = 1; i <= n; i++) {
           name = order[i]
-          if (count[name] >= 2) { dup[name] = sids[name] }
+          if (count[name] >= 2) { print name "\t" sids[name] }
         }
-        m = asorti(dup, sorted_names)
-        for (i = 1; i <= m; i++) {
-          name = sorted_names[i]
-          print name "\t" dup[name]
-        }
-      }' <<<"$all"
+      }' <<<"$all"); then
+      return 1
+    fi
+
+    # No duplicate is a DEFINITE answer: empty stdout, return 0.
+    if [[ -n "$dups" ]]; then
+      LC_ALL=C sort <<<"$dups"
+    fi
     return 0
   }
 

--- a/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh
@@ -17,6 +17,8 @@
 #   verify_agent_registered_under      <agent-name> <cwd>
 #   claude_agents_snapshot_capture     <path>
 #   claude_job_id_for_name_all         <name>
+#   claude_session_id_is_live          <sid>
+#   claude_agents_list_duplicate_node_names
 #
 # claude_sessions_under <path>
 #   The cwd-based low-level primitive. Runs `claude agents --json --cwd <path>`,
@@ -146,6 +148,40 @@
 #     return 0 — a row with the given <agent-name> was observed.
 #     return 1 — exhaustion: the agent never appeared within the budget.
 #   Used by `dispatch-launch-worker` / `dispatch-spawn-job` Step 4 verify.
+#
+# claude_session_id_is_live <sid>
+#   The winner-liveness predicate for the duplicate-worker stand-down protocol.
+#   Built on ONE `claude_agents_list_all` fetch — never a bespoke `claude agents
+#   --json` call. Exact-matches column 1 (sessionId) against <sid> with
+#   `awk -F'\t'`, never a substring grep — session ids share prefixes, so a
+#   substring match could conflate two distinct sessions.
+#   This is the SAME fail-safe posture as `worktree_has_live_session`
+#   (occupied-on-unknown), applied to a session id instead of a worktree name —
+#   the inversion is load-bearing: a caller parking a node on `return 1` must
+#   never park because the daemon hiccupped.
+#     return 0 — LIVE: <sid> matched a row in a successfully-queried registry,
+#               OR the registry could not be queried (UNKNOWN folds to live).
+#     return 1 — definitely NOT live: the registry was queried successfully
+#               and no row's sessionId equals <sid>.
+#   Empty/missing <sid>: prints a stderr diagnostic and returns 0 (fail safe),
+#   mirroring `worktree_has_live_session`'s own empty-arg handling.
+#
+# claude_agents_list_duplicate_node_names
+#   The observed-pair detector for the duplicate-worker stand-down protocol.
+#   Takes no arguments. One `claude_agents_list_all` fetch, then keeps only rows
+#   whose name (column 3) matches the graph-node worker shape `^tactic-|^strategy-`
+#   — the same keyspace `claude_agents_count_busy_workers` counts — which
+#   excludes routers (`dispatch-<short-id>`) and legacy `<N>-slug` issue workers
+#   (those have no graph node to park). Groups by name and emits one line per
+#   name with TWO OR MORE live sessions: `name<TAB>sid1,sid2,...` — sids in the
+#   order the registry returned them, output lines sorted by name for
+#   deterministic output. Implemented as a single awk pass; no per-name
+#   shell-out.
+#     return 0 — daemon queried successfully. Stdout carries one line per
+#               duplicated name (empty when the registry holds no duplicate —
+#               a definite "no duplicates" answer, not a failure).
+#     return 1 — UNKNOWN. `claude_agents_list_all` could not be queried. Stdout
+#               is empty.
 #
 # Test override: CLAUDE_AGENTS_CMD replaces the `claude` invocation with an
 # arbitrary command (e.g. an absolute path to a fake script), so the helper is
@@ -584,6 +620,77 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
 
     # The query succeeded and matched neither name: definitely free.
     return 1
+  }
+
+  # claude_session_id_is_live <sid> — fail-safe winner-liveness predicate for
+  # the duplicate-worker stand-down protocol. See the header comment for the
+  # return-code contract (the inversion is load-bearing: UNKNOWN folds to
+  # LIVE, the same fail-safe posture as `worktree_has_live_session` applied to
+  # a session id instead of a worktree name).
+  claude_session_id_is_live() {
+    local sid="${1:-}"
+    if [[ -z "$sid" ]]; then
+      printf 'lib-claude-agents: claude_session_id_is_live requires a <sid> argument\n' >&2
+      return 0  # fail safe: treat as live
+    fi
+
+    # One machine-wide fetch — claude_agents_list_all is the fetch-once
+    # primitive.
+    local all
+    if ! all=$(claude_agents_list_all); then
+      # Unknown — the daemon could not be queried. Fail safe: live.
+      return 0
+    fi
+
+    # claude_agents_list_all emits sessionId<TAB>status<TAB>name (sessionId is
+    # column 1). Exact match only — never a substring grep, since session ids
+    # share prefixes.
+    if awk -F'\t' -v sid="$sid" '$1 == sid { found = 1; exit } END { exit !found }' \
+        <<<"$all"; then
+      return 0
+    fi
+
+    # The query succeeded and no row's sessionId equals <sid>: definitely not
+    # live.
+    return 1
+  }
+
+  # claude_agents_list_duplicate_node_names — emit one line per graph-node
+  # worker name with two or more live sessions. See the header comment for the
+  # return-code contract.
+  claude_agents_list_duplicate_node_names() {
+    # One machine-wide fetch — claude_agents_list_all is the fetch-once
+    # primitive.
+    local all
+    if ! all=$(claude_agents_list_all); then
+      # Unknown — the daemon could not be queried.
+      return 1
+    fi
+
+    # Single awk pass: keep only rows whose name matches the graph-node worker
+    # shape (^tactic-|^strategy-, the same keyspace claude_agents_count_busy_workers
+    # counts — excludes routers and legacy <N>-slug issue workers), group
+    # sessionIds by name in registry order, then emit name<TAB>sid1,sid2,...
+    # for every name with >= 2 sessions, sorted by name for deterministic
+    # output.
+    awk -F'\t' '
+      $3 ~ /^tactic-|^strategy-/ {
+        if (!($3 in seen)) { order[++n] = $3; seen[$3] = 1 }
+        if (sids[$3] == "") { sids[$3] = $1 } else { sids[$3] = sids[$3] "," $1 }
+        count[$3]++
+      }
+      END {
+        for (i = 1; i <= n; i++) {
+          name = order[i]
+          if (count[name] >= 2) { dup[name] = sids[name] }
+        }
+        m = asorti(dup, sorted_names)
+        for (i = 1; i <= m; i++) {
+          name = sorted_names[i]
+          print name "\t" dup[name]
+        }
+      }' <<<"$all"
+    return 0
   }
 
   # claude_agents_count_busy_workers — emit the count of live sessions that are

--- a/.claude/skills/dispatch-propagate/scripts/lib-standdown-recheck.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-standdown-recheck.sh
@@ -1,0 +1,680 @@
+#!/usr/bin/env bash
+# lib-standdown-recheck.sh — the stand-down ledger and its liveness re-check
+# sweep for the duplicate-worker stand-down protocol.
+#
+# The failure this closes: two sessions get spawned for the same graph node.
+# The session holding uncommitted work wins; the other stands down WITHOUT
+# parking the node (a park would spuriously interrupt a node another session is
+# actively working). That is correct — but only while the winner is actually
+# still alive. When the winner dies mid-work (crash, OOM, API error, classifier
+# denial), the loser waits forever on a session that no longer exists, holding
+# the node with the fix unpushed. Nothing today re-checks that assumption: no
+# liveness check, no timeout, no surfacing. The node is stranded, invisibly,
+# with the work in a worktree nobody will push. (Observed in production
+# 2026-07-31 and repaired by hand.)
+#
+# The design turns the stand-down from emergent session judgment into a durable
+# record plus a re-check. A standing-down session writes a marker naming the
+# winner (`origin=declared`); this sweep additionally records any duplicate it
+# OBSERVES itself (`origin=observed`, no attributable winner). Every tick the
+# sweep re-checks each marker against the live-session registry, and when the
+# winner is DEFINITELY gone it parks the node to `office_hours` — the only place
+# a human can actually recover the unpushed work.
+#
+# THE INVARIANT: a `declared` marker NEVER expires on age. There is no TTL, no
+# grace, no idle term on that path. A stand-down waits as long as the winner
+# lives, however long that is — only `claude_session_id_is_live` returning a
+# DEFINITE 1 (registry queried successfully, no such session) advances the state
+# machine. An age-based timeout here would park nodes that are being actively
+# worked, which is precisely the interruption the stand-down protocol exists to
+# avoid. The one idle-grace term in this file (rule (e)) applies ONLY on the
+# `origin=observed` path, where there is no attributed winner to test, and it
+# GATES A PARK — it never releases anything.
+#
+# Usage: source this file, then call:
+#   standdown_dir
+#   standdown_write   <node-id> <declared|observed> <winner-sid> <sessions-csv>
+#   standdown_clear   <node-id>
+#   standdown_exists  <node-id>
+#   standdown_recheck_sweep
+#
+# The ledger is a directory of marker files at the SHARED project root
+# (`<project-root>/tmp/dispatch-standdown/`), project-root-shared like the
+# reservation ledger so concurrent ticks in different worktrees contend on one
+# ledger. Each marker file is named exactly by the node id and carries four
+# lines in this FIXED order (so a reader can
+# `sed -n 's/^winner=//p' | head -n1` regardless):
+#   origin=<declared|observed>
+#   winner=<sid|>                  (empty when origin=observed)
+#   sessions=<sid1,sid2,...>
+#   observed=<epoch-seconds>
+#
+# `origin=declared` means a standing-down session explicitly named the winner
+# (written by the `dispatch-standdown` CLI); `winner=` is authoritative there.
+# `origin=observed` means this sweep itself saw two live sessions under the node
+# name and cannot attribute the work to either, so `winner=` is empty.
+#
+# standdown_dir
+#   Print the ledger directory path to stdout. If DISPATCH_STANDDOWN_DIR is set
+#   and non-empty, print that (the test override, authoritative — bypasses the
+#   git lookup, so no git repo is required). Otherwise print
+#   `<resolve_project_root>/tmp/dispatch-standdown`. Shape copied from
+#   `reservation_dir` in lib-reservation-ledger.sh.
+#     return 0 — path printed.
+#     return 1 — no override and not in a git repo; nothing printed.
+#
+# standdown_write <node-id> <origin> <winner-sid> <sessions-csv>
+#   Write the marker file named exactly <node-id> with the four documented lines
+#   in the documented order. <node-id> and <origin> are required; <origin> must
+#   be `declared` or `observed`. <winner-sid> may be empty (and MUST be for
+#   `observed`). The node id must be free of path separators, `..` components,
+#   and control characters — the same defense-in-depth guard reservation_write
+#   applies, so the name can never escape the ledger dir on the `mv`. The dir is
+#   `mkdir -p -m 0700`'d first (owner-only: a host co-tenant must not be able to
+#   read session ids out of markers nor forge one). The write is atomic — a
+#   dot-prefixed `.tmp` tempfile in the SAME dir, then `mv` into place — so the
+#   sweep never observes a partial marker.
+#     return 0 — marker written.
+#     return 1 — a missing/unsafe argument, an unresolvable ledger dir, or a
+#               write/mv failure.
+#
+# standdown_clear <node-id>
+#   Best-effort idempotent removal of the marker, behind the same path-safety
+#   guard.
+#     return 0 — file absent after the call (removed, never existed, or no
+#               ledger dir).
+#     return 1 — missing or unsafe argument only.
+#
+# standdown_exists <node-id>
+#   Membership test behind the same guard: 0 if a marker named exactly <node-id>
+#   exists, 1 otherwise (including a missing/unsafe argument or absent ledger).
+#
+# standdown_recheck_sweep
+#   No arguments. Containment/observability only — it is NEVER a gate, so it
+#   ALWAYS returns 0, on every path including an unqueryable daemon, an
+#   unresolvable repo root, an unwritable ledger, and a failed `park-node`.
+#   Every disposition is one greppable stderr line per node per pass, and the
+#   sweep ends with EXACTLY ONE summary line.
+#     return 0 — ALWAYS.
+#
+#   Step 0 — record observed duplicates. One
+#   `claude_agents_list_duplicate_node_names` call. Each duplicated name with no
+#   marker yet gets `standdown_write <name> observed "" <sids>` and a `recorded`
+#   line. UNKNOWN (non-zero) records nothing (fail safe) but does NOT abort the
+#   pass — the re-check loop still runs against the markers already on disk.
+#
+#   Then, for each marker file in the ledger dir (dotfiles and `.tmp*` files
+#   skipped, exactly as reservation_sweep does), this rule ladder IN THIS EXACT
+#   ORDER — the order is the correctness property:
+#     a. node id fails the node-id regex → `unsafe-id`, keep, next.
+#     b. origin=declared AND `claude_session_id_is_live <winner>` → `observing`,
+#        next. NO AGE TERM. See THE INVARIANT above.
+#     c. origin=observed AND >= 2 live sessions still named <node> →
+#        `observing-pair`, next.
+#     d. exactly 0 live sessions named <node> → clear the marker,
+#        `cleared-no-live-session`, next. Nobody is waiting; nothing to park.
+#     e. origin=observed AND the one surviving session's transcript idle time is
+#        under the grace → `observing`, next. The survivor is progressing, so
+#        the pair has resolved itself into ordinary single-session work. This is
+#        the ONLY idle term in this file and it gates a park, never a release;
+#        the `tactic-stopped-session-blocks-node` sweep owns the complementary
+#        "survivor stopped making progress" case.
+#     f. node id absent from origin/main's `intentions/` → `not-a-node`, keep;
+#        or the node is already parked → `already-parked`, keep. Next.
+#        (Lazy `git fetch`, at most once per invocation, precedes this read.)
+#     -  worktree directory missing → clear the marker, `cleared-no-worktree`,
+#        next. A variant of "no unpushed work is possible", checked explicitly
+#        here because rules (h)/(i) assume the worktree exists.
+#     g. the park cap for this pass is spent → `deferred`, keep, next.
+#     h. the worktree is NOT in sync — BOTH `worktree_in_sync` and
+#        `worktree_merged_in_sync` are false → PARK,
+#        `standdown-winner-dead-work-unpushed`. The second predicate is what
+#        keeps a post-squash-merge local merge commit from being misread as
+#        stranded work.
+#     i. otherwise (in sync, node still held) → PARK,
+#        `standdown-winner-dead-node-held`.
+#
+#   Fail-safe posture: if EITHER underlying liveness call is UNKNOWN, every
+#   marker is treated as `observing` for the pass and nothing is parked or
+#   cleared. An unreadable transcript is UNKNOWN too and means "keep". The only
+#   paths that park require a DEFINITELY-absent winner.
+#
+#   One `git fetch` per invocation at most, and it is LAZY: it runs only when a
+#   marker actually reaches rule (f), so a pass with nothing to adjudicate does
+#   no network I/O. Park cap: `park-node` pushes to `main` through
+#   `graph-commit`'s landing lock, so an unbounded batch would serialize N
+#   pushes inside one tick; excess candidates are deferred to the next pass.
+#
+# Environment overrides (all optional; each integer-valued one is
+# integer-guarded, falling back to its default on a malformed value):
+#   DISPATCH_STANDDOWN_DIR            Ledger directory. When set, the helper does
+#                                     NOT require a git repo (bypasses
+#                                     resolve_project_root). Default:
+#                                     <project-root>/tmp/dispatch-standdown.
+#   DISPATCH_STANDDOWN_NOW_EPOCH      Pinned clock (epoch seconds), for the
+#                                     `observed=` stamp and the idle math.
+#                                     Default: `date -u +%s`.
+#   DISPATCH_STANDDOWN_IDLE_GRACE_S   Rule (e) transcript-idle grace, seconds.
+#                                     Default: 900 (matching the frozen-session
+#                                     sweep's grace).
+#   DISPATCH_STANDDOWN_PARK_MAX       Maximum parks per invocation. Default: 3.
+#   DISPATCH_STANDDOWN_PROJECTS_ROOT  Transcript store root. Default:
+#                                     $HOME/.claude/projects.
+#   DISPATCH_STANDDOWN_REPO_ROOT      Repo root for the `git show origin/main:`
+#                                     reads and the worktree-path derivation.
+#                                     Default: resolve_project_root (lib.sh).
+#   DISPATCH_STANDDOWN_PARK_NODE      park-node path. Default:
+#                                     <repo-root>/packages/intentionsutil/
+#                                     scripts/park-node.
+# Respected via the libraries this file sources, NOT redefined here:
+#   CLAUDE_AGENTS_CMD                 lib-claude-agents.sh — replaces the
+#                                     `claude` invocation (testable, no daemon).
+#   DISPATCH_AGENTS_SNAPSHOT          lib-claude-agents.sh — per-tick registry
+#                                     snapshot reused across machine-wide calls.
+#   DISPATCH_DECISION_LOG_DIR / _FILE lib-decision-log.sh — the JSONL sink.
+#
+# Sandbox: the liveness queries reach the local Claude daemon over a Unix
+# socket, so callers must run this with `dangerouslyDisableSandbox: true` — see
+# `.claude/rules/sandbox.md`. A sandboxed call yields `[]`, a definite "no
+# sessions", which would clear markers rather than park them.
+#
+# Safe to source multiple times. Does NOT use set -e (must return, not exit).
+#
+# Side effect: sourcing this file once sets `-u` and `-o pipefail` in the caller
+# shell (via its own load-guard, and transitively via the siblings below).
+
+# Source siblings via BASH_SOURCE dirname, matching lib-reservation-ledger.sh
+# and lib-frozen-session-park.sh. lib.sh is plain function definitions; the
+# other three are load-guarded. lib-decision-log.sh is sourced non-fatally — its
+# log is a best-effort observability sink, exactly as dispatch-select-tick
+# sources it.
+_lsr_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$_lsr_dir/lib.sh"
+# shellcheck source=lib-claude-agents.sh
+source "$_lsr_dir/lib-claude-agents.sh"
+# shellcheck source=lib-worktree-in-sync.sh
+source "$_lsr_dir/lib-worktree-in-sync.sh"
+# shellcheck source=/dev/null
+source "$_lsr_dir/lib-decision-log.sh" 2>/dev/null || true
+
+if [[ -z "${_LIB_STANDDOWN_RECHECK_LOADED:-}" ]]; then
+  _LIB_STANDDOWN_RECHECK_LOADED=1
+
+  set -uo pipefail
+
+  # standdown_dir — print the ledger directory path.
+  # See the header comment for the return-code contract.
+  standdown_dir() {
+    if [[ -n "${DISPATCH_STANDDOWN_DIR:-}" ]]; then
+      printf '%s\n' "$DISPATCH_STANDDOWN_DIR"
+      return 0
+    fi
+    local root
+    root=$(resolve_project_root) || return 1
+    printf '%s\n' "$root/tmp/dispatch-standdown"
+    return 0
+  }
+
+  # _standdown_id_is_safe <node-id> — the shared path-safety guard. The marker is
+  # named exactly by the node id, so a value carrying a path separator, a `..`
+  # component, or a control character could escape the ledger dir on the `mv` /
+  # `rm`. Copied from reservation_write's guard.
+  _standdown_id_is_safe() {
+    case "${1:-}" in
+      *..*|*/*|*[[:cntrl:]]*) return 1 ;;
+    esac
+    return 0
+  }
+
+  # standdown_write <node-id> <origin> <winner-sid> <sessions-csv> — record a
+  # stand-down. See the header comment for the format and return-code contract.
+  standdown_write() {
+    local node="${1:-}" origin="${2:-}" winner="${3:-}" sessions="${4:-}"
+    if [[ -z "$node" || -z "$origin" ]]; then
+      printf 'lib-standdown-recheck: standdown_write requires <node-id> <origin> <winner-sid> <sessions-csv>\n' >&2
+      return 1
+    fi
+    if [[ "$origin" != "declared" && "$origin" != "observed" ]]; then
+      printf 'lib-standdown-recheck: standdown_write: origin must be declared or observed, got %q\n' "$origin" >&2
+      return 1
+    fi
+    if ! _standdown_id_is_safe "$node"; then
+      printf 'lib-standdown-recheck: standdown_write: unsafe node-id %q\n' "$node" >&2
+      return 1
+    fi
+
+    local dir
+    dir=$(standdown_dir) || {
+      printf 'lib-standdown-recheck: standdown_write could not resolve the ledger dir (not in a git repo and DISPATCH_STANDDOWN_DIR unset)\n' >&2
+      return 1
+    }
+    # Owner-only (0700), same rationale as the reservation ledger: a co-tenant
+    # must not read session ids out of markers nor inject a forged one.
+    mkdir -p -m 0700 "$dir" || return 1
+
+    local now
+    if [[ "${DISPATCH_STANDDOWN_NOW_EPOCH:-}" =~ ^[0-9]+$ ]]; then
+      now="$DISPATCH_STANDDOWN_NOW_EPOCH"
+    else
+      now=$(date -u +%s)
+    fi
+
+    # Atomic write: dot-prefixed `.tmp` tempfile in the SAME dir (so the `mv` is
+    # a rename within one filesystem), then rename into place.
+    local tmpfile="$dir/.${node}.$$.tmp"
+    {
+      printf 'origin=%s\n' "$origin"
+      printf 'winner=%s\n' "$winner"
+      printf 'sessions=%s\n' "$sessions"
+      printf 'observed=%s\n' "$now"
+    } >"$tmpfile" || { rm -f "$tmpfile" 2>/dev/null; return 1; }
+
+    if ! mv -f "$tmpfile" "$dir/$node"; then
+      rm -f "$tmpfile" 2>/dev/null
+      return 1
+    fi
+    return 0
+  }
+
+  # standdown_clear <node-id> — best-effort idempotent removal.
+  standdown_clear() {
+    local node="${1:-}"
+    if [[ -z "$node" ]]; then
+      printf 'lib-standdown-recheck: standdown_clear requires a <node-id> argument\n' >&2
+      return 1
+    fi
+    if ! _standdown_id_is_safe "$node"; then
+      printf 'lib-standdown-recheck: standdown_clear: unsafe node-id %q\n' "$node" >&2
+      return 1
+    fi
+    local dir
+    # Unresolvable ledger dir → nothing to clear (best-effort cleanup).
+    dir=$(standdown_dir) || return 0
+    rm -f "$dir/$node" 2>/dev/null || true
+    return 0
+  }
+
+  # standdown_exists <node-id> — marker membership test.
+  standdown_exists() {
+    local node="${1:-}"
+    if [[ -z "$node" ]]; then
+      printf 'lib-standdown-recheck: standdown_exists requires a <node-id> argument\n' >&2
+      return 1
+    fi
+    if ! _standdown_id_is_safe "$node"; then
+      printf 'lib-standdown-recheck: standdown_exists: unsafe node-id %q\n' "$node" >&2
+      return 1
+    fi
+    local dir
+    dir=$(standdown_dir) || return 1
+    [[ -f "$dir/$node" ]]
+  }
+
+  # _standdown_session_idle_s <sid> — print the session's transcript idle time in
+  # seconds. The transcript lives at <projects-root>/<project>/<sid>.jsonl —
+  # keyed on the globally-unique session id, so the project-dir slug (a mangling
+  # of the session's cwd) never has to be reconstructed. Takes the NEWEST mtime
+  # across matches. No match, or an unreadable mtime, is UNKNOWN: return 1 with
+  # no output, which every caller treats as "keep".
+  #
+  # This block deliberately DUPLICATES the equivalent block in
+  # lib-frozen-session-park.sh. That sibling is not merged to main yet (it lands
+  # on its own branch), so there is no shared helper to call; extracting one is a
+  # follow-up once both are on main, not this unit's job.
+  _standdown_session_idle_s() {
+    local sid="${1:-}" now="${2:-}"
+    [[ -n "$sid" ]] || return 1
+    # The sid feeds a `find -name` glob; validate its shape at this edge (input
+    # validation at a system boundary), matching lib-frozen-session-park.sh.
+    [[ "$sid" =~ ^[0-9a-fA-F-]+$ ]] || return 1
+    local projects_root="${DISPATCH_STANDDOWN_PROJECTS_ROOT:-$HOME/.claude/projects}"
+    local matches transcript best="" cur
+    matches=$(find "$projects_root" -mindepth 2 -maxdepth 2 -name "${sid}.jsonl" 2>/dev/null)
+    [[ -n "$matches" ]] || return 1
+    while IFS= read -r transcript; do
+      [[ -n "$transcript" ]] || continue
+      cur=$(stat -c %Y "$transcript" 2>/dev/null) || continue
+      [[ "$cur" =~ ^[0-9]+$ ]] || continue
+      if [[ -z "$best" ]] || (( cur > best )); then
+        best="$cur"
+      fi
+    done <<<"$matches"
+    [[ -n "$best" ]] || return 1
+    printf '%s\n' $(( now - best ))
+    return 0
+  }
+
+  # _standdown_log_decision <node> <origin> <winner> <survivors> <unpushed> <disposition>
+  # — append one best-effort JSONL decision record. Mirrors
+  # dispatch-select-tick's _dlog_select_emit and lib-frozen-session-park's own
+  # helper: build with `jq -c -n`, hand to `decision_log_append` behind a
+  # `command -v` guard, never fail the caller. <unpushed> is "true"/"false", or
+  # empty for a disposition where the question does not arise (→ null).
+  _standdown_log_decision() {
+    local node="$1" origin="$2" winner="$3" survivors="$4" unpushed="$5" disposition="$6"
+    local json
+    json=$(jq -c -n \
+      --arg ts          "$(date -u +%FT%TZ)" \
+      --arg site        "standdown-recheck-sweep" \
+      --arg node        "$node" \
+      --arg origin      "$origin" \
+      --arg winner      "$winner" \
+      --arg survivors   "$survivors" \
+      --arg unpushed    "$unpushed" \
+      --arg disposition "$disposition" \
+      '
+      {
+        ts:          $ts,
+        site:        $site,
+        node:        $node,
+        origin:      $origin,
+        winner:      $winner,
+        survivors:   $survivors,
+        unpushed:    (if $unpushed == "true" then true
+                      elif $unpushed == "false" then false
+                      else null end),
+        disposition: $disposition
+      }' 2>/dev/null) || return 0
+    command -v decision_log_append >/dev/null 2>&1 && decision_log_append "$json" || true
+    return 0
+  }
+
+  # standdown_recheck_sweep — record observed duplicates, then re-check every
+  # marker against the live-session registry. See the header comment for the full
+  # rule ladder and the fail-safe posture. ALWAYS returns 0.
+  standdown_recheck_sweep() {
+    local markers=0 recorded=0 parked_count=0 observing=0 cleared=0 deferred=0
+
+    # --- tunables, computed ONCE ---------------------------------------------
+    local now
+    if [[ "${DISPATCH_STANDDOWN_NOW_EPOCH:-}" =~ ^[0-9]+$ ]]; then
+      now="$DISPATCH_STANDDOWN_NOW_EPOCH"
+    else
+      now=$(date -u +%s)
+    fi
+    local grace="${DISPATCH_STANDDOWN_IDLE_GRACE_S:-900}"
+    [[ "$grace" =~ ^[0-9]+$ ]] || grace=900
+    local park_max="${DISPATCH_STANDDOWN_PARK_MAX:-3}"
+    [[ "$park_max" =~ ^[0-9]+$ ]] || park_max=3
+
+    # --- Step 0: observe duplicates -------------------------------------------
+    # One duplicate-name query. UNKNOWN records nothing (fail safe) but does not
+    # abort the pass: the re-check loop below still runs against the markers
+    # already on disk.
+    local unknown=0 dups="" dup_name dup_sids
+    if ! dups=$(claude_agents_list_duplicate_node_names); then
+      unknown=1
+      dups=""
+      printf 'lib-standdown-recheck: duplicate-name query unqueryable; recording nothing this pass\n' >&2
+    fi
+    if [[ -n "$dups" ]]; then
+      while IFS=$'\t' read -r dup_name dup_sids; do
+        [[ -n "$dup_name" && -n "$dup_sids" ]] || continue
+        _standdown_id_is_safe "$dup_name" || continue
+        if standdown_exists "$dup_name"; then
+          continue
+        fi
+        if standdown_write "$dup_name" observed "" "$dup_sids"; then
+          recorded=$(( recorded + 1 ))
+          printf 'lib-standdown-recheck: recorded %s (observed duplicate; sessions=%s)\n' "$dup_name" "$dup_sids" >&2
+          _standdown_log_decision "$dup_name" "observed" "" "$dup_sids" "" "recorded"
+        else
+          printf 'lib-standdown-recheck: could not record observed duplicate %s (ledger unwritable)\n' "$dup_name" >&2
+        fi
+      done <<<"$dups"
+    fi
+
+    # --- the live-session-name index ------------------------------------------
+    # One machine-wide fetch supplies the per-name survivor set for EVERY marker
+    # (the duplicate query above only covers names with >= 2 sessions; a name
+    # with 0 or 1 needs this). UNKNOWN from either query folds into `unknown`,
+    # under which every marker is `observing` and nothing is parked or cleared.
+    local all="" sid status name
+    declare -A live_sids=()
+    declare -A live_count=()
+    if ! all=$(claude_agents_list_all); then
+      unknown=1
+      all=""
+      printf 'lib-standdown-recheck: session registry unqueryable; observing every marker this pass\n' >&2
+    fi
+    if [[ -n "$all" ]]; then
+      while IFS=$'\t' read -r sid status name; do
+        [[ -n "$name" && -n "$sid" ]] || continue
+        if [[ -z "${live_sids[$name]:-}" ]]; then
+          live_sids["$name"]="$sid"
+        else
+          live_sids["$name"]="${live_sids[$name]},$sid"
+        fi
+        live_count["$name"]=$(( ${live_count[$name]:-0} + 1 ))
+      done <<<"$all"
+    fi
+
+    # --- the ledger ------------------------------------------------------------
+    local dir
+    if ! dir=$(standdown_dir) || [[ ! -d "$dir" ]]; then
+      printf 'lib-standdown-recheck: sweep complete (markers=%s recorded=%s parked=%s observing=%s cleared=%s deferred=%s)\n' \
+        "$markers" "$recorded" "$parked_count" "$observing" "$cleared" "$deferred" >&2
+      return 0
+    fi
+
+    # --- the repo root ---------------------------------------------------------
+    local repo_root="${DISPATCH_STANDDOWN_REPO_ROOT:-}"
+    if [[ -z "$repo_root" ]]; then
+      repo_root=$(resolve_project_root) || repo_root=""
+    fi
+    if [[ -z "$repo_root" ]]; then
+      printf 'lib-standdown-recheck: repo root unresolvable; parking nothing\n' >&2
+      printf 'lib-standdown-recheck: sweep complete (markers=%s recorded=%s parked=%s observing=%s cleared=%s deferred=%s)\n' \
+        "$markers" "$recorded" "$parked_count" "$observing" "$cleared" "$deferred" >&2
+      return 0
+    fi
+    local park_node="${DISPATCH_STANDDOWN_PARK_NODE:-$repo_root/packages/intentionsutil/scripts/park-node}"
+
+    # The lazy-fetch latch: at most one `git fetch` per invocation, and none at
+    # all when no marker reaches rule (f).
+    local fetched=0
+
+    local had_nullglob=0
+    shopt -q nullglob && had_nullglob=1
+    shopt -s nullglob
+    local f node m_origin m_winner m_sessions survivors n_live idle
+    for f in "$dir"/*; do
+      # Regular files directly in the dir only. The default glob already excludes
+      # the dot-prefixed `.tmp` in-flight tempfiles from standdown_write; the
+      # explicit `.tmp` test covers any non-dot variant.
+      [[ -f "$f" ]] || continue
+      node=$(basename "$f")
+      case "$node" in .*|*.tmp*) continue ;; esac
+      markers=$(( markers + 1 ))
+
+      m_origin=$(sed -n 's/^origin=//p' "$f" 2>/dev/null | head -n1)
+      m_winner=$(sed -n 's/^winner=//p' "$f" 2>/dev/null | head -n1)
+      m_sessions=$(sed -n 's/^sessions=//p' "$f" 2>/dev/null | head -n1)
+
+      # UNKNOWN liveness → observe everything, park and clear nothing. Checked
+      # ahead of the ladder so a daemon hiccup can never advance a marker.
+      if (( unknown )); then
+        observing=$(( observing + 1 ))
+        printf 'lib-standdown-recheck: observing %s (liveness unknown this pass; taking no action)\n' "$node" >&2
+        continue
+      fi
+
+      survivors="${live_sids[$node]:-}"
+      n_live="${live_count[$node]:-0}"
+
+      # (a) The node id becomes a path component in the `git show origin/main:`
+      # read and the worktree-path derivation below, so validate its shape at
+      # this edge with the SAME node-id regex office-hours-graph applies before
+      # provisioning. A clear skip beats an opaque git failure — or a path
+      # escape — downstream. The marker is KEPT: a human should see it.
+      if [[ ! "$node" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]]; then
+        printf 'lib-standdown-recheck: unsafe-id %s (marker name is not a valid node id); keeping marker, taking no action\n' "$node" >&2
+        continue
+      fi
+
+      # (b) THE INVARIANT. A `declared` stand-down waits as long as its winner
+      # lives — however long that is. There is NO age term here, deliberately:
+      # an aged-out declared marker would park a node another session is
+      # actively working, which is exactly the interruption the stand-down
+      # protocol exists to avoid. Only a DEFINITE absence (the registry queried
+      # successfully with no such session id) advances past this rule;
+      # claude_session_id_is_live folds UNKNOWN into "live" for that reason.
+      if [[ "$m_origin" == "declared" ]]; then
+        if [[ -z "$m_winner" ]]; then
+          # A declared marker with no winner is malformed — it names no session
+          # to test. Treat it like an unreadable marker: keep and flag, never
+          # park (an empty winner must not be conflated with a dead one).
+          printf 'lib-standdown-recheck: observing %s (declared marker has no winner= line; malformed, keeping)\n' "$node" >&2
+          observing=$(( observing + 1 ))
+          continue
+        fi
+        if claude_session_id_is_live "$m_winner"; then
+          observing=$(( observing + 1 ))
+          printf 'lib-standdown-recheck: observing %s (declared winner %s is still live; age-independent, no timeout applies)\n' \
+            "$node" "$m_winner" >&2
+          continue
+        fi
+      fi
+
+      # (c) An observed pair that is still a pair: two live sessions under the
+      # node name, neither attributable. Nothing has resolved yet.
+      if [[ "$m_origin" == "observed" ]] && (( n_live >= 2 )); then
+        observing=$(( observing + 1 ))
+        printf 'lib-standdown-recheck: observing-pair %s (%s live sessions still registered under this name)\n' "$node" "$n_live" >&2
+        continue
+      fi
+
+      # (d) Nobody is left holding the node. There is no loser waiting on a dead
+      # winner, so there is nothing to surface — drop the marker.
+      if (( n_live == 0 )); then
+        standdown_clear "$node"
+        cleared=$(( cleared + 1 ))
+        printf 'lib-standdown-recheck: cleared-no-live-session %s (no live session under this name remains)\n' "$node" >&2
+        _standdown_log_decision "$node" "$m_origin" "$m_winner" "$survivors" "" "cleared-no-live-session"
+        continue
+      fi
+
+      # (e) An observed pair that shrank to one, whose survivor is still making
+      # progress. The pair resolved itself into ordinary single-session work;
+      # parking would interrupt it. This is the ONLY idle term in this file, it
+      # applies ONLY on the observed path (there is no attributed winner to
+      # test), and it gates a PARK — never a release. The complementary case (a
+      # survivor that stopped making progress but still holds the node) belongs
+      # to `tactic-stopped-session-blocks-node`, not here. An unmeasurable idle
+      # is UNKNOWN → keep.
+      if [[ "$m_origin" == "observed" ]] && (( n_live == 1 )); then
+        if ! idle=$(_standdown_session_idle_s "$survivors" "$now"); then
+          observing=$(( observing + 1 ))
+          printf 'lib-standdown-recheck: observing %s (survivor %s transcript unreadable — idle unmeasurable, keeping)\n' \
+            "$node" "$survivors" >&2
+          continue
+        fi
+        if (( idle < grace )); then
+          observing=$(( observing + 1 ))
+          printf 'lib-standdown-recheck: observing %s (survivor %s idle_seconds=%s < grace_seconds=%s; still progressing)\n' \
+            "$node" "$survivors" "$idle" "$grace" >&2
+          continue
+        fi
+      fi
+
+      # (f) Lazy fetch, once per sweep, then the origin/main reads. A fetch
+      # failure is non-fatal: fall back to whatever `origin/main` ref this
+      # checkout already has rather than blocking the sweep on a network blip
+      # (copied from office-hours-graph / lib-frozen-session-park).
+      if (( fetched == 0 )); then
+        git -C "$repo_root" fetch origin main --quiet 2>/dev/null || true
+        fetched=1
+      fi
+
+      local body
+      if ! body=$(git -C "$repo_root" show "origin/main:intentions/${node}.md" 2>/dev/null); then
+        printf 'lib-standdown-recheck: not-a-node %s (no intentions/%s.md on origin/main); keeping marker\n' "$node" "$node" >&2
+        continue
+      fi
+
+      # Already parked. Idiom copied VERBATIM from `park_live_on_main` in
+      # `packages/intentionsutil/scripts/office-hours-graph`. The frontmatter
+      # scoping is load-bearing: restricting the test to the YAML block (between
+      # the first two `---` fences) means a column-0 `office_hours:` line in the
+      # markdown BODY (documentation of the serialization) can never be misread
+      # as park state.
+      local frontmatter parked_already=0
+      frontmatter=$(awk 'NR==1&&/^---/{f=1;next} f&&/^---[[:space:]]*$/{exit} f' <<<"$body")
+      if grep -q '^office_hours:' <<<"$frontmatter"; then
+        if ! grep -qE '^office_hours:[[:space:]]*null[[:space:]]*$' <<<"$frontmatter"; then
+          parked_already=1
+        fi
+      fi
+      if (( parked_already )); then
+        printf 'lib-standdown-recheck: already-parked %s (office_hours is already non-null on origin/main); keeping marker\n' "$node" >&2
+        continue
+      fi
+
+      # Worktree path, DERIVED (never read from the daemon), mirroring
+      # dispatch-graph-execute's CONFLICT_WT composition. A missing directory
+      # means no unpushed work is possible and nothing is held in a checkout —
+      # drop the marker. Checked here, ahead of rules (h)/(i), because both
+      # assume the worktree exists.
+      local wt="$repo_root/.claude/worktrees/$node"
+      if [[ ! -d "$wt" ]]; then
+        standdown_clear "$node"
+        cleared=$(( cleared + 1 ))
+        printf 'lib-standdown-recheck: cleared-no-worktree %s (no worktree at %s)\n' "$node" "$wt" >&2
+        _standdown_log_decision "$node" "$m_origin" "$m_winner" "$survivors" "" "cleared-no-worktree"
+        continue
+      fi
+
+      # (g) Cap. Excess candidates are deferred to the next pass rather than
+      # serializing N graph-commit landing-lock pushes inside this one.
+      if (( parked_count >= park_max )); then
+        deferred=$(( deferred + 1 ))
+        printf 'lib-standdown-recheck: deferred %s (park cap %s reached this sweep)\n' "$node" "$park_max" >&2
+        continue
+      fi
+
+      # (h)/(i) The park. BOTH sync predicates must be false for "work is
+      # stranded": worktree_merged_in_sync is what keeps a post-squash-merge
+      # local merge commit (which `rev-list --not --remotes` over-counts as
+      # unpushed) from being misread as stranded work.
+      local unpushed_flag reason_tag reason recommendation unpushed_head=""
+      if ! worktree_in_sync "$wt" && ! worktree_merged_in_sync "$wt"; then
+        unpushed_flag="true"
+        reason_tag="standdown-winner-dead-work-unpushed"
+        # Never fatal: any git failure yields an empty head summary.
+        unpushed_head=$(git -C "$wt" log --oneline -n 3 origin/main..HEAD 2>/dev/null) || unpushed_head=""
+        printf -v reason \
+          'standdown-winner-dead-work-unpushed: a session stood down for this node in favour of winner session %s, which is no longer registered with the Claude daemon (crash, OOM, API error, or classifier denial). The stand-down is unconditional on the winner living, so the standing-down session(s) %s are still waiting on a session that no longer exists, and the winner left work UNPUSHED in %s. Unpushed head (origin/main..HEAD): %s' \
+          "${m_winner:-(unattributed — observed duplicate, no winner declared)}" \
+          "${survivors:-none}" "$wt" "${unpushed_head:-<unavailable>}"
+      else
+        unpushed_flag="false"
+        reason_tag="standdown-winner-dead-node-held"
+        printf -v reason \
+          'standdown-winner-dead-node-held: a session stood down for this node in favour of winner session %s, which is no longer registered with the Claude daemon. No work is unpushed — the worktree at %s is clean and fully pushed — but the node is still held by session(s) %s waiting on a session that no longer exists, so nothing will advance it without intervention.' \
+          "${m_winner:-(unattributed — observed duplicate, no winner declared)}" "$wt" "${survivors:-none}"
+      fi
+      recommendation="Find the holding job with 'claude agents --all' and attach it ('claude attach <job-id>') to see where it stopped. If the worktree at $wt has unpushed commits, verify them and push them from there FIRST. To release the holding session use 'claude stop <job-id>' — NEVER 'claude rm', which deletes the session AND its worktree, destroying any unpushed work still in the shared worktree. Once the work is safe and the session is stopped, run 'clear-park $node' to return the node to the lane. Accepted residual: while a live session still holds the node-id session name, office-hours reports this node as 'all-held' rather than launching a review session for it — that is expected, not a bug."
+
+      local rc=0
+      "$park_node" "$node" "$reason" "$recommendation" >/dev/null || rc=$?
+      if (( rc == 0 )); then
+        parked_count=$(( parked_count + 1 ))
+        printf 'lib-standdown-recheck: parked %s (%s; winner=%s survivors=%s)\n' \
+          "$node" "$reason_tag" "${m_winner:-none}" "${survivors:-none}" >&2
+        _standdown_log_decision "$node" "$m_origin" "$m_winner" "$survivors" "$unpushed_flag" "parked"
+      else
+        # A park failure is never fatal to the sweep or the tick: log it, KEEP
+        # the marker so the next pass retries, and move on.
+        printf 'lib-standdown-recheck: park failed for %s (park-node exit %s); keeping marker, will retry next tick\n' "$node" "$rc" >&2
+        _standdown_log_decision "$node" "$m_origin" "$m_winner" "$survivors" "$unpushed_flag" "park-failed"
+      fi
+    done
+    (( had_nullglob )) || shopt -u nullglob
+
+    printf 'lib-standdown-recheck: sweep complete (markers=%s recorded=%s parked=%s observing=%s cleared=%s deferred=%s)\n' \
+      "$markers" "$recorded" "$parked_count" "$observing" "$cleared" "$deferred" >&2
+    return 0
+  }
+
+fi

--- a/.claude/skills/dispatch-propagate/scripts/lib-standdown-recheck.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-standdown-recheck.sh
@@ -113,11 +113,19 @@
 #        `observing-pair`, next.
 #     d. exactly 0 live sessions named <node> → clear the marker,
 #        `cleared-no-live-session`, next. Nobody is waiting; nothing to park.
-#     e. origin=observed AND the one surviving session's transcript idle time is
-#        under the grace → `observing`, next. The survivor is progressing, so
-#        the pair has resolved itself into ordinary single-session work. This is
-#        the ONLY idle term in this file and it gates a park, never a release;
-#        the `tactic-stopped-session-blocks-node` sweep owns the complementary
+#     e. origin=observed AND the one surviving session is still working →
+#        `observing`, next. "Still working" is TWO signals, either of which
+#        alone means keep: its transcript idle time is under the grace, OR the
+#        registry reports its status as `busy` (the same "actively working"
+#        predicate `claude_agents_count_busy_workers` uses). The status term is
+#        load-bearing: a transcript is only appended between tool calls, so a
+#        session sitting inside ONE long call (a `gh run watch` over a slow CI
+#        run, a long subagent fan-out) looks arbitrarily idle while being the
+#        healthiest possible worker — parking it is exactly the spurious
+#        interruption this protocol exists to avoid. The pair has resolved
+#        itself into ordinary single-session work. This is the ONLY idle term in
+#        this file and it gates a park, never a release; the
+#        `tactic-stopped-session-blocks-node` sweep owns the complementary
 #        "survivor stopped making progress" case.
 #     f. node id absent from origin/main's `intentions/` → `not-a-node`, keep;
 #        or the node is already parked → `already-parked`, keep. Next.
@@ -430,16 +438,29 @@ if [[ -z "${_LIB_STANDDOWN_RECHECK_LOADED:-}" ]]; then
     # (the duplicate query above only covers names with >= 2 sessions; a name
     # with 0 or 1 needs this). UNKNOWN from either query folds into `unknown`,
     # under which every marker is `observing` and nothing is parked or cleared.
-    local all="" sid status name
+    local all="" line rest sid status name
     declare -A live_sids=()
     declare -A live_count=()
+    declare -A sid_status=()
     if ! all=$(claude_agents_list_all); then
       unknown=1
       all=""
       printf 'lib-standdown-recheck: session registry unqueryable; observing every marker this pass\n' >&2
     fi
     if [[ -n "$all" ]]; then
-      while IFS=$'\t' read -r sid status name; do
+      while IFS= read -r line; do
+        # Split the 3-column TSV BY HAND. `IFS=$'\t' read -r sid status name`
+        # cannot be used here: TAB is IFS whitespace, so bash collapses a RUN of
+        # tabs into one delimiter, and the daemon reports `status: null` — which
+        # `@tsv` renders as an EMPTY middle field — for every held/blocked
+        # session. That is precisely the session a stand-down leaves behind, so
+        # the collapsing parse would drop the surviving loser from this index,
+        # read n_live as 0, and let rule (d) silently clear the marker.
+        [[ "$line" == *$'\t'*$'\t'* ]] || continue
+        sid="${line%%$'\t'*}"
+        rest="${line#*$'\t'}"
+        status="${rest%%$'\t'*}"
+        name="${rest#*$'\t'}"
         [[ -n "$name" && -n "$sid" ]] || continue
         if [[ -z "${live_sids[$name]:-}" ]]; then
           live_sids["$name"]="$sid"
@@ -447,6 +468,8 @@ if [[ -z "${_LIB_STANDDOWN_RECHECK_LOADED:-}" ]]; then
           live_sids["$name"]="${live_sids[$name]},$sid"
         fi
         live_count["$name"]=$(( ${live_count[$name]:-0} + 1 ))
+        # Keyed by sid, not name: rule (e) tests the ONE survivor's own status.
+        sid_status["$sid"]="$status"
       done <<<"$all"
     fi
 
@@ -563,6 +586,16 @@ if [[ -z "${_LIB_STANDDOWN_RECHECK_LOADED:-}" ]]; then
       # survivor that stopped making progress but still holds the node) belongs
       # to `tactic-stopped-session-blocks-node`, not here. An unmeasurable idle
       # is UNKNOWN → keep.
+      #
+      # TWO independent "still working" signals, either sufficient to keep:
+      # transcript idle under the grace, and a registry status of `busy`. The
+      # status term exists because the transcript is only appended BETWEEN tool
+      # calls — a session inside one long call (a `gh run watch` over a slow CI
+      # run, a long subagent fan-out) reads as arbitrarily idle while being the
+      # healthiest possible worker. A stood-down loser is never `busy`: the
+      # daemon reports it `status: null` / `state: blocked` while the Stop hook
+      # holds it, so this gate narrows the false-park window without closing the
+      # park path this sweep exists to open.
       if [[ "$m_origin" == "observed" ]] && (( n_live == 1 )); then
         if ! idle=$(_standdown_session_idle_s "$survivors" "$now"); then
           observing=$(( observing + 1 ))
@@ -574,6 +607,12 @@ if [[ -z "${_LIB_STANDDOWN_RECHECK_LOADED:-}" ]]; then
           observing=$(( observing + 1 ))
           printf 'lib-standdown-recheck: observing %s (survivor %s idle_seconds=%s < grace_seconds=%s; still progressing)\n' \
             "$node" "$survivors" "$idle" "$grace" >&2
+          continue
+        fi
+        if [[ "${sid_status[$survivors]:-}" == "busy" ]]; then
+          observing=$(( observing + 1 ))
+          printf 'lib-standdown-recheck: observing %s (survivor %s reports status=busy — actively working inside a long tool call; idle_seconds=%s ignored)\n' \
+            "$node" "$survivors" "$idle" >&2
           continue
         fi
       fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-standdown.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-standdown.sh
@@ -156,4 +156,22 @@ assert_eq "stdout is exactly stood-down" "stood-down" "$DS_OUT"
 assert_eq "marker sessions=<winner> only" "aaaa1111-1111-1111-1111-111111111111" "$(ds_marker_field tactic-some-node sessions)"
 ds_teardown
 
+# --- Test 6: an unwritable ledger is exit 4, NOT the usage-error 2 -----------
+# The caller must be able to tell "your arguments were wrong" (retry with
+# different ones) from "the stand-down was NOT recorded" — yielding the turn on
+# the latter re-creates the silent hold this protocol exists to close.
+echo "Test: an unwritable ledger dir -> exit 4 ledger-unwritable, no marker, distinct from usage error"
+ds_setup
+ds_add_session "aaaa1111-1111-1111-1111-111111111111" "tactic-some-node"
+ds_install_claude 0
+# A regular file where the ledger dir's PARENT must be: standdown_write's
+# `mkdir -p` cannot succeed, so the marker cannot be written.
+printf 'not a directory\n' > "$DS_DIR/blocker"
+DS_LEDGER="$DS_DIR/blocker/ledger"
+ds_run "tactic-some-node" --winner "aaaa1111-1111-1111-1111-111111111111"
+assert_eq "exit code 4" "4" "$DS_RC"
+assert_eq "stdout is exactly ledger-unwritable" "ledger-unwritable" "$DS_OUT"
+assert_eq "no marker file written" "no" "$( [[ -f "$DS_LEDGER/tactic-some-node" ]] && echo yes || echo no )"
+ds_teardown
+
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-standdown.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-standdown.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Tests for dispatch-standdown — the CLI entry point a losing duplicate
+# session calls to record its stand-down, after one final winner-liveness
+# re-check at the moment of decision.
+#
+# Everything is faked: `claude agents --json` via CLAUDE_AGENTS_CMD (a small
+# script printing a controlled registry array, the same idiom
+# test-lib-standdown-recheck.sh and test-lib-claude-agents.sh use), and the
+# ledger via DISPATCH_STANDDOWN_DIR (a scratch dir — no git repo required,
+# standdown_dir's DISPATCH_STANDDOWN_DIR override bypasses resolve_project_root).
+set -uo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$FIXTURE_DIR/dispatch-test-fixture.sh"
+
+DS_CMD="$SCRIPT_DIR/dispatch-standdown"
+
+echo "=== dispatch-standdown ==="
+
+DS_DIR=""
+DS_FAKE=""
+DS_LEDGER=""
+DS_ENTRIES=()
+DS_OUT=""
+DS_ERR=""
+DS_RC=0
+
+ds_setup() {
+  DS_DIR=$(mktemp -d)
+  DS_FAKE="$DS_DIR/fake-claude"
+  DS_LEDGER="$DS_DIR/ledger"
+  DS_ENTRIES=()
+  DS_OUT=""
+  DS_ERR=""
+  DS_RC=0
+}
+
+ds_teardown() {
+  rm -rf "$DS_DIR"
+  DS_DIR=""
+  unset CLAUDE_AGENTS_CMD DISPATCH_STANDDOWN_DIR CLAUDE_CODE_SESSION_ID || true
+}
+
+# ds_add_session <sid> <name> — append one live registry entry.
+ds_add_session() {
+  DS_ENTRIES+=("{\"sessionId\":\"$1\",\"name\":\"$2\",\"status\":\"busy\"}")
+}
+
+# ds_install_claude [exit-code] — install the fake `claude` emitting the
+# accumulated registry array (or, on a non-zero exit code, failing outright to
+# model an unqueryable daemon) and point CLAUDE_AGENTS_CMD at it.
+ds_install_claude() {
+  local exit_code="${1:-0}" payload
+  payload=$( IFS=,; printf '[%s]' "${DS_ENTRIES[*]}" )
+  printf '%s' "$payload" > "$DS_DIR/payload.json"
+  cat > "$DS_FAKE" <<FAKE
+#!/usr/bin/env bash
+if [[ "$exit_code" -ne 0 ]]; then
+  echo "fake claude: simulated daemon failure" >&2
+  exit $exit_code
+fi
+cat "$DS_DIR/payload.json"
+exit 0
+FAKE
+  chmod +x "$DS_FAKE"
+  CLAUDE_AGENTS_CMD="$DS_FAKE"
+  export CLAUDE_AGENTS_CMD
+}
+
+ds_run() {
+  DISPATCH_STANDDOWN_DIR="$DS_LEDGER"
+  export DISPATCH_STANDDOWN_DIR
+  if DS_OUT=$("$DS_CMD" "$@" 2>"$DS_DIR/err"); then DS_RC=0; else DS_RC=$?; fi
+  DS_ERR=$(cat "$DS_DIR/err")
+}
+
+ds_marker_field() {
+  sed -n "s/^$2=//p" "$DS_LEDGER/$1" | head -n1
+}
+
+# --- Test 1: winner live → stood-down, marker written -----------------------
+echo "Test: winner live in the registry -> stood-down, marker written"
+ds_setup
+ds_add_session "aaaa1111-1111-1111-1111-111111111111" "tactic-some-node"
+ds_install_claude 0
+CLAUDE_CODE_SESSION_ID="bbbb2222-2222-2222-2222-222222222222"
+export CLAUDE_CODE_SESSION_ID
+ds_run "tactic-some-node" --winner "aaaa1111-1111-1111-1111-111111111111"
+assert_eq "exit code 0" "0" "$DS_RC"
+assert_eq "stdout is exactly stood-down" "stood-down" "$DS_OUT"
+assert_eq "marker file exists" "yes" "$( [[ -f "$DS_LEDGER/tactic-some-node" ]] && echo yes || echo no )"
+assert_eq "marker origin=declared" "declared" "$(ds_marker_field tactic-some-node origin)"
+assert_eq "marker winner=<sid>" "aaaa1111-1111-1111-1111-111111111111" "$(ds_marker_field tactic-some-node winner)"
+assert_eq "marker sessions=winner,own" "aaaa1111-1111-1111-1111-111111111111,bbbb2222-2222-2222-2222-222222222222" "$(ds_marker_field tactic-some-node sessions)"
+ds_teardown
+
+# --- Test 2: winner definitely absent → winner-absent, no marker ------------
+echo "Test: winner definitely absent from the registry -> winner-absent, no marker written"
+ds_setup
+ds_add_session "cccc3333-3333-3333-3333-333333333333" "some-other-node"
+ds_install_claude 0
+ds_run "tactic-some-node" --winner "aaaa1111-1111-1111-1111-111111111111"
+assert_eq "exit code 3" "3" "$DS_RC"
+assert_eq "stdout is exactly winner-absent" "winner-absent" "$DS_OUT"
+assert_eq "no marker file written" "no" "$( [[ -f "$DS_LEDGER/tactic-some-node" ]] && echo yes || echo no )"
+ds_teardown
+
+# --- Test 3: daemon UNKNOWN → fail safe to stood-down ------------------------
+echo "Test: fake claude fails (daemon UNKNOWN) -> fail-safe stood-down, exit 0"
+ds_setup
+ds_install_claude 1
+ds_run "tactic-some-node" --winner "aaaa1111-1111-1111-1111-111111111111"
+assert_eq "exit code 0 (fail-safe)" "0" "$DS_RC"
+assert_eq "stdout is exactly stood-down" "stood-down" "$DS_OUT"
+assert_eq "marker file exists" "yes" "$( [[ -f "$DS_LEDGER/tactic-some-node" ]] && echo yes || echo no )"
+ds_teardown
+
+# --- Test 4: bad arguments ----------------------------------------------------
+echo "Test: bad node id -> exit 2, no marker"
+ds_setup
+ds_add_session "aaaa1111-1111-1111-1111-111111111111" "tactic-some-node"
+ds_install_claude 0
+ds_run "Not-A-Valid-Node-ID" --winner "aaaa1111-1111-1111-1111-111111111111"
+assert_eq "exit code 2" "2" "$DS_RC"
+assert_eq "no marker file written" "no" "$( [[ -f "$DS_LEDGER/Not-A-Valid-Node-ID" ]] && echo yes || echo no )"
+ds_teardown
+
+echo "Test: bad session id -> exit 2, no marker"
+ds_setup
+ds_add_session "aaaa1111-1111-1111-1111-111111111111" "tactic-some-node"
+ds_install_claude 0
+ds_run "tactic-some-node" --winner "not-hex!!"
+assert_eq "exit code 2" "2" "$DS_RC"
+assert_eq "no marker file written" "no" "$( [[ -f "$DS_LEDGER/tactic-some-node" ]] && echo yes || echo no )"
+ds_teardown
+
+echo "Test: missing --winner flag -> exit 2, no marker"
+ds_setup
+ds_add_session "aaaa1111-1111-1111-1111-111111111111" "tactic-some-node"
+ds_install_claude 0
+ds_run "tactic-some-node"
+assert_eq "exit code 2" "2" "$DS_RC"
+assert_eq "no marker file written" "no" "$( [[ -f "$DS_LEDGER/tactic-some-node" ]] && echo yes || echo no )"
+ds_teardown
+
+# --- Test 5: CLAUDE_CODE_SESSION_ID unset -> sessions holds only the winner --
+echo "Test: CLAUDE_CODE_SESSION_ID unset -> marker sessions= holds only the winner sid, no trailing comma"
+ds_setup
+ds_add_session "aaaa1111-1111-1111-1111-111111111111" "tactic-some-node"
+ds_install_claude 0
+unset CLAUDE_CODE_SESSION_ID || true
+ds_run "tactic-some-node" --winner "aaaa1111-1111-1111-1111-111111111111"
+assert_eq "exit code 0" "0" "$DS_RC"
+assert_eq "stdout is exactly stood-down" "stood-down" "$DS_OUT"
+assert_eq "marker sessions=<winner> only" "aaaa1111-1111-1111-1111-111111111111" "$(ds_marker_field tactic-some-node sessions)"
+ds_teardown
+
+report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-tick.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-tick.sh
@@ -47,6 +47,12 @@ tick_setup() {
   # invocation tests need.
   export DISPATCH_STANDDOWN_DIR="$TMPDIR_TEST/standdown"
   mkdir -p "$DISPATCH_STANDDOWN_DIR"
+  # The scratch repo root the comment above promises. Without it the sweep falls
+  # back to resolve_project_root — the developer's REAL checkout — so the moment
+  # a future test here seeds a marker, the pass would `git fetch origin main`
+  # and `git show origin/main:intentions/...` against it.
+  export DISPATCH_STANDDOWN_REPO_ROOT="$TMPDIR_TEST/standdown-repo"
+  mkdir -p "$DISPATCH_STANDDOWN_REPO_ROOT"
   chmod +x "$TMPDIR_TEST/dispatch-tick"
   # Pin the canonical main worktree so the advisory diagnose-main / jit-reminder
   # spawns get a deterministic --cwd independent of the host repo layout and the
@@ -147,7 +153,7 @@ tick_teardown() {
     TICK_SEL_PRE TICK_GRAPH_EXEC_PRE TICK_SPAWN_RESULT DISPATCH_TICK_MAIN_WORKTREE \
     DISPATCH_LOCK_FILE TICK_REFRESH_RC TICK_CONVERGE_RC DISPATCH_PAUSE_FLAG \
     DISPATCH_RESERVATION_DIR CLAUDE_AGENTS_CMD DISPATCH_RESERVATION_SWEEP_NOW_EPOCH \
-    DISPATCH_STANDDOWN_DIR
+    DISPATCH_STANDDOWN_DIR DISPATCH_STANDDOWN_REPO_ROOT
 }
 
 run_tick() { "$TMPDIR_TEST/dispatch-tick" "$@" 2>/dev/null; }

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-tick.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-tick.sh
@@ -32,6 +32,21 @@ tick_setup() {
   # paused-branch reservation_sweep genuinely runs instead of source-failing.
   cp "$SCRIPT_DIR/lib-claude-agents.sh" "$TMPDIR_TEST/lib-claude-agents.sh"
   cp "$SCRIPT_DIR/lib-reservation-ledger.sh" "$TMPDIR_TEST/lib-reservation-ledger.sh"
+  # lib-standdown-recheck.sh (Unit 3 wiring) and its own sourced siblings, so
+  # the tick's paused-branch and normal-path standdown_recheck_sweep calls
+  # genuinely run instead of source-failing, matching the lib-claude-agents.sh
+  # / lib-reservation-ledger.sh copies above.
+  cp "$SCRIPT_DIR/lib-standdown-recheck.sh" "$TMPDIR_TEST/lib-standdown-recheck.sh"
+  cp "$SCRIPT_DIR/lib-worktree-in-sync.sh" "$TMPDIR_TEST/lib-worktree-in-sync.sh"
+  cp "$SCRIPT_DIR/lib-decision-log.sh" "$TMPDIR_TEST/lib-decision-log.sh"
+  # Isolate the sweep's own ledger dir from the host's real
+  # tmp/dispatch-standdown, and give it a scratch repo root so its lazy
+  # `git fetch` / `git show origin/main:...` reads never touch the real repo.
+  # An empty scratch ledger dir means the sweep's re-check loop finds no
+  # markers and simply logs the sweep-complete summary line, which is all these
+  # invocation tests need.
+  export DISPATCH_STANDDOWN_DIR="$TMPDIR_TEST/standdown"
+  mkdir -p "$DISPATCH_STANDDOWN_DIR"
   chmod +x "$TMPDIR_TEST/dispatch-tick"
   # Pin the canonical main worktree so the advisory diagnose-main / jit-reminder
   # spawns get a deterministic --cwd independent of the host repo layout and the
@@ -131,7 +146,8 @@ tick_teardown() {
   unset TICK_DECISION TICK_SEL_RC TICK_GRAPH_EXEC_RC \
     TICK_SEL_PRE TICK_GRAPH_EXEC_PRE TICK_SPAWN_RESULT DISPATCH_TICK_MAIN_WORKTREE \
     DISPATCH_LOCK_FILE TICK_REFRESH_RC TICK_CONVERGE_RC DISPATCH_PAUSE_FLAG \
-    DISPATCH_RESERVATION_DIR CLAUDE_AGENTS_CMD DISPATCH_RESERVATION_SWEEP_NOW_EPOCH
+    DISPATCH_RESERVATION_DIR CLAUDE_AGENTS_CMD DISPATCH_RESERVATION_SWEEP_NOW_EPOCH \
+    DISPATCH_STANDDOWN_DIR
 }
 
 run_tick() { "$TMPDIR_TEST/dispatch-tick" "$@" 2>/dev/null; }
@@ -690,6 +706,63 @@ out=$(run_tick) && rc=0 || rc=$?
 assert_eq "refresh-failsafe: exit 0 despite probe failure" "0" "$rc"
 assert_eq "refresh-failsafe: tick still ran select after failed refresh" \
   "$(printf 'refresh\nselect')" "$(cat "$TMPDIR_TEST/logs/order.log")"
+tick_teardown
+
+# --- tactic-standdown-winner-liveness Unit 3: standdown_recheck_sweep wiring --
+# Both call sites run the REAL standdown_recheck_sweep (lib-standdown-recheck.sh,
+# copied into TMPDIR_TEST by tick_setup, same idiom as lib-reservation-ledger.sh
+# for the sibling reservation_sweep call) against an empty scratch ledger dir
+# (DISPATCH_STANDDOWN_DIR), so the sweep finds no markers and simply emits its
+# one-line "sweep complete" summary to stderr — sufficient to assert invocation.
+# There is no existing ordering-assertion mechanism for the sibling
+# reservation_sweep call (it has no counterpart on the normal path at all), so
+# per the unit's scope, only invocation is asserted here, not ordering.
+
+echo "Test: dispatch-tick paused branch invokes standdown_recheck_sweep"
+tick_setup
+: > "$TMPDIR_TEST/paused"
+export TICK_DECISION="empty"
+err=$("$TMPDIR_TEST/dispatch-tick" 2>&1 1>/dev/null) && rc=0 || rc=$?
+assert_eq "paused-standdown: exit 0" "0" "$rc"
+assert_eq "paused-standdown: standdown_recheck_sweep ran (sweep-complete line on stderr)" "1" \
+  "$(printf '%s' "$err" | grep -qF 'lib-standdown-recheck: sweep complete' && echo 1 || echo 0)"
+tick_teardown
+
+echo "Test: dispatch-tick normal path invokes standdown_recheck_sweep"
+tick_setup
+export TICK_DECISION="empty"
+err=$("$TMPDIR_TEST/dispatch-tick" 2>&1 1>/dev/null) && rc=0 || rc=$?
+assert_eq "normal-standdown: exit 0" "0" "$rc"
+assert_eq "normal-standdown: standdown_recheck_sweep ran (sweep-complete line on stderr)" "1" \
+  "$(printf '%s' "$err" | grep -qF 'lib-standdown-recheck: sweep complete' && echo 1 || echo 0)"
+tick_teardown
+
+# --- lib-standdown-recheck.sh fails to load → loud diagnostic, tick still completes ---
+# Replace the copied lib with an unsourceable file (invalid bash syntax) so the
+# tick's `source` fails and `declare -f standdown_recheck_sweep` comes back
+# false on BOTH call sites. Both must log the loud diagnostic and the tick must
+# still complete (exit 0) rather than abort.
+echo "Test: dispatch-tick lib-standdown-recheck.sh load failure → loud diagnostic, tick still completes"
+tick_setup
+printf 'this is not valid bash ((( \n' > "$TMPDIR_TEST/lib-standdown-recheck.sh"
+: > "$TMPDIR_TEST/paused"
+export TICK_DECISION="empty"
+err=$("$TMPDIR_TEST/dispatch-tick" 2>&1 1>/dev/null) && rc=0 || rc=$?
+assert_eq "standdown-load-fail: tick still exits 0 (paused branch)" "0" "$rc"
+assert_eq "standdown-load-fail: loud diagnostic on stderr" "1" \
+  "$(printf '%s' "$err" | grep -qF 'lib-standdown-recheck.sh failed to load; stand-down re-check NOT run this tick' && echo 1 || echo 0)"
+assert_eq "standdown-load-fail: no sweep-complete line (sweep never ran)" "0" \
+  "$(printf '%s' "$err" | grep -cF 'lib-standdown-recheck: sweep complete')"
+tick_teardown
+
+echo "Test: dispatch-tick lib-standdown-recheck.sh load failure on normal path → loud diagnostic, tick still completes"
+tick_setup
+printf 'this is not valid bash ((( \n' > "$TMPDIR_TEST/lib-standdown-recheck.sh"
+export TICK_DECISION="empty"
+err=$("$TMPDIR_TEST/dispatch-tick" 2>&1 1>/dev/null) && rc=0 || rc=$?
+assert_eq "standdown-load-fail-normal: tick still exits 0" "0" "$rc"
+assert_eq "standdown-load-fail-normal: loud diagnostic on stderr" "1" \
+  "$(printf '%s' "$err" | grep -qF 'lib-standdown-recheck.sh failed to load; stand-down re-check NOT run this tick' && echo 1 || echo 0)"
 tick_teardown
 
 # <<< END MOVED <<<

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-claude-agents.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-claude-agents.sh
@@ -638,6 +638,106 @@ assert_eq "live-claimed unique: 10 and 20 each once" \
   "$(printf '10\n20')" "$(printf '%s\n' "$out" | sort -n)"
 ca_teardown
 
+# --- claude_session_id_is_live (tactic-standdown-winner-liveness) -----------
+# The winner-liveness predicate for the duplicate-worker stand-down protocol:
+# exact-matches a sessionId against a single claude_agents_list_all fetch,
+# folding UNKNOWN to LIVE (return 0) — the same fail-safe inversion as
+# worktree_has_live_session, applied to a session id.
+
+# --- Test 36: sid-live-exact — exact match, no substring match --------------
+echo "Test: claude_session_id_is_live exact-matches sessionId, no substring match"
+ca_setup
+write_fake_claude '[{"sessionId":"aaa","pid":1,"status":"busy","name":"tactic-x"},{"sessionId":"aab","pid":2,"status":"busy","name":"tactic-y"}]' 0
+if claude_session_id_is_live "aaa"; then rc=0; else rc=$?; fi
+assert_eq "sid-live-exact: aaa is live" "0" "$rc"
+if claude_session_id_is_live "aab"; then rc=0; else rc=$?; fi
+assert_eq "sid-live-exact: aab is live" "0" "$rc"
+if claude_session_id_is_live "aa"; then rc=0; else rc=$?; fi
+assert_eq "sid-live-exact: aa (substring only) is not live" "1" "$rc"
+ca_teardown
+
+# --- Test 37: sid-live-absent — well-formed registry without the sid --------
+echo "Test: claude_session_id_is_live returns 1 for a sid absent from a well-formed registry"
+ca_setup
+write_fake_claude '[{"sessionId":"other","pid":1,"status":"busy","name":"tactic-x"}]' 0
+if claude_session_id_is_live "missing-sid"; then rc=0; else rc=$?; fi
+assert_eq "sid-live-absent: absent sid is not live" "1" "$rc"
+ca_teardown
+
+ca_setup
+write_fake_claude '[]' 0
+if claude_session_id_is_live "missing-sid"; then rc=0; else rc=$?; fi
+assert_eq "sid-live-absent: empty registry, absent sid is not live" "1" "$rc"
+ca_teardown
+
+# --- Test 38: sid-live-unknown — daemon failure folds to live (fail safe) ---
+echo "Test: claude_session_id_is_live folds daemon UNKNOWN to live"
+ca_setup
+write_fake_claude '' 1
+if claude_session_id_is_live "any-sid"; then rc=0; else rc=$?; fi
+assert_eq "sid-live-unknown: non-zero exit folds to live" "0" "$rc"
+ca_teardown
+
+ca_setup
+write_fake_claude '{}' 0
+if claude_session_id_is_live "any-sid"; then rc=0; else rc=$?; fi
+assert_eq "sid-live-unknown: non-array output folds to live" "0" "$rc"
+ca_teardown
+
+# --- Test 39: sid-live-empty-arg — missing argument fails safe to live ------
+echo "Test: claude_session_id_is_live fails safe to live with no argument and warns on stderr"
+ca_setup
+if out=$(claude_session_id_is_live 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "sid-live-empty-arg: no argument is live" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if err=$(claude_session_id_is_live 2>&1 1>/dev/null) && printf '%s' "$err" | grep -q "requires a <sid> argument"; then
+  PASS=$((PASS + 1)); echo "  PASS: sid-live-empty-arg: warns on stderr"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: sid-live-empty-arg: warns on stderr"
+fi
+ca_teardown
+
+# --- claude_agents_list_duplicate_node_names (tactic-standdown-winner-liveness) --
+# The observed-pair detector: groups live graph-node-worker (^tactic-|^strategy-)
+# sessions by name and emits one line per name with >= 2 live sessions.
+
+# --- Test 40: dup-names-pair — one duplicated name amid noise ---------------
+echo "Test: claude_agents_list_duplicate_node_names emits only the duplicated name"
+ca_setup
+write_fake_claude '[
+  {"sessionId":"s1","pid":1,"status":"busy","name":"tactic-x"},
+  {"sessionId":"s2","pid":2,"status":"busy","name":"tactic-x"},
+  {"sessionId":"s3","pid":3,"status":"busy","name":"tactic-y"},
+  {"sessionId":"s4","pid":4,"status":"busy","name":"dispatch-abc"},
+  {"sessionId":"s5","pid":5,"status":"busy","name":"1234-slug"}
+]' 0
+if out=$(claude_agents_list_duplicate_node_names); then rc=0; else rc=$?; fi
+assert_eq "dup-names-pair: exits 0" "0" "$rc"
+assert_eq "dup-names-pair: only tactic-x with both sids, in registry order" \
+  "$(printf 'tactic-x\ts1,s2')" "$out"
+ca_teardown
+
+# --- Test 41: dup-names-none — one row per name, no duplicates --------------
+echo "Test: claude_agents_list_duplicate_node_names returns 0 with no output when nothing duplicates"
+ca_setup
+write_fake_claude '[
+  {"sessionId":"s1","pid":1,"status":"busy","name":"tactic-x"},
+  {"sessionId":"s2","pid":2,"status":"busy","name":"strategy-y"}
+]' 0
+if out=$(claude_agents_list_duplicate_node_names); then rc=0; else rc=$?; fi
+assert_eq "dup-names-none: exits 0" "0" "$rc"
+assert_eq "dup-names-none: prints nothing" "" "$out"
+ca_teardown
+
+# --- Test 42: dup-names-unknown — daemon failure returns 1, empty stdout ----
+echo "Test: claude_agents_list_duplicate_node_names returns 1 with empty stdout on daemon UNKNOWN"
+ca_setup
+write_fake_claude '' 1
+if out=$(claude_agents_list_duplicate_node_names); then rc=0; else rc=$?; fi
+assert_eq "dup-names-unknown: exits 1" "1" "$rc"
+assert_eq "dup-names-unknown: prints nothing" "" "$out"
+ca_teardown
+
 # <<< END MOVED <<<
 
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-claude-agents.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-claude-agents.sh
@@ -640,9 +640,34 @@ ca_teardown
 
 # --- claude_session_id_is_live (tactic-standdown-winner-liveness) -----------
 # The winner-liveness predicate for the duplicate-worker stand-down protocol:
-# exact-matches a sessionId against a single claude_agents_list_all fetch,
+# exact-matches a sessionId against ONE `claude agents --json --all` query,
 # folding UNKNOWN to LIVE (return 0) — the same fail-safe inversion as
-# worktree_has_live_session, applied to a session id.
+# worktree_has_live_session, applied to a session id. `--all` is load-bearing:
+# a stopped-but-not-removed session is hidden from the default listing, and
+# reporting it absent invites a peer to take over the shared worktree its
+# uncommitted work still sits in. The granular verdict rides on
+# CLAUDE_SESSION_ID_LIVE_STATE (live | stopped | absent | unknown).
+
+# write_fake_claude_all <payload> — install a fake `claude` that is FAITHFUL to
+# the daemon's --all semantics: rows whose state is `done` (or `stopped`) are
+# returned ONLY when `--all` appears in argv, exactly as production behaves
+# (same idiom as office_hours_state_fake_claude in dispatch-test-fixture.sh).
+# A naive fake that served terminal rows regardless of --all would let an
+# --all-forgetting regression still pass.
+write_fake_claude_all() {
+  local payload="$1"
+  printf '%s' "$payload" > "$CA_DIR/payload.json"
+  cat > "$CA_FAKE" <<FAKE
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  [[ "\$arg" == "--all" ]] && { cat "$CA_DIR/payload.json"; exit 0; }
+done
+jq -c 'map(select(.state != "done" and .state != "stopped"))' "$CA_DIR/payload.json"
+exit 0
+FAKE
+  chmod +x "$CA_FAKE"
+  CLAUDE_AGENTS_CMD="$CA_FAKE"
+}
 
 # --- Test 36: sid-live-exact — exact match, no substring match --------------
 echo "Test: claude_session_id_is_live exact-matches sessionId, no substring match"
@@ -695,6 +720,51 @@ if err=$(claude_session_id_is_live 2>&1 1>/dev/null) && printf '%s' "$err" | gre
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: sid-live-empty-arg: warns on stderr"
 fi
+# Called directly (NOT in a command substitution) so the state variable the
+# function sets is observable in this shell.
+CLAUDE_SESSION_ID_LIVE_STATE="sentinel"
+claude_session_id_is_live 2>/dev/null || true
+assert_eq "sid-live-empty-arg: state is unknown" "unknown" "$CLAUDE_SESSION_ID_LIVE_STATE"
+ca_teardown
+
+# --- Test 39a: sid-live-stopped — a stopped-but-present winner is NOT absent -
+# The red-team case: a winner that stopped mid-work without being `claude rm`'d
+# is hidden from the default listing while its uncommitted fix still sits in the
+# SHARED worktree. Reporting it absent makes dispatch-standdown print
+# `winner-absent`, whose documented response ("become the worker itself")
+# destroys that work. It must read as live (return 0), state `stopped`.
+echo "Test: claude_session_id_is_live reports a stopped-but-present session as live"
+ca_setup
+write_fake_claude_all '[{"sessionId":"win","pid":1,"state":"done","status":null,"name":"tactic-x"}]'
+if claude_session_id_is_live "win"; then rc=0; else rc=$?; fi
+assert_eq "sid-live-stopped: done-state winner is not absent" "0" "$rc"
+assert_eq "sid-live-stopped: state is stopped" "stopped" "$CLAUDE_SESSION_ID_LIVE_STATE"
+ca_teardown
+
+ca_setup
+write_fake_claude_all '[{"sessionId":"win","pid":1,"state":"stopped","status":null,"name":"tactic-x"}]'
+if claude_session_id_is_live "win"; then rc=0; else rc=$?; fi
+assert_eq "sid-live-stopped: stopped-state winner is not absent" "0" "$rc"
+assert_eq "sid-live-stopped: state is stopped" "stopped" "$CLAUDE_SESSION_ID_LIVE_STATE"
+ca_teardown
+
+# --- Test 39b: sid-live-state — the granular verdict for live and absent -----
+echo "Test: claude_session_id_is_live publishes live/absent in CLAUDE_SESSION_ID_LIVE_STATE"
+ca_setup
+write_fake_claude_all '[{"sessionId":"win","pid":1,"state":"working","status":"busy","name":"tactic-x"}]'
+if claude_session_id_is_live "win"; then rc=0; else rc=$?; fi
+assert_eq "sid-live-state: working session is live" "0" "$rc"
+assert_eq "sid-live-state: state is live" "live" "$CLAUDE_SESSION_ID_LIVE_STATE"
+if claude_session_id_is_live "gone"; then rc=0; else rc=$?; fi
+assert_eq "sid-live-state: unregistered sid is absent" "1" "$rc"
+assert_eq "sid-live-state: state is absent" "absent" "$CLAUDE_SESSION_ID_LIVE_STATE"
+ca_teardown
+
+ca_setup
+write_fake_claude '' 1
+if claude_session_id_is_live "any-sid"; then rc=0; else rc=$?; fi
+assert_eq "sid-live-state: daemon UNKNOWN is live" "0" "$rc"
+assert_eq "sid-live-state: state is unknown" "unknown" "$CLAUDE_SESSION_ID_LIVE_STATE"
 ca_teardown
 
 # --- claude_agents_list_duplicate_node_names (tactic-standdown-winner-liveness) --

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-standdown-recheck.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-standdown-recheck.sh
@@ -107,9 +107,17 @@ PARK
   chmod +x "$SD_PARK"
 }
 
-# sd_add_session <sid> <name> — append one live registry entry.
+# sd_add_session <sid> <name> [status] — append one live registry entry.
+# [status] defaults to "busy" (state "working"); pass the empty string for the
+# shape the daemon actually reports for a HELD/blocked session — `"status":null`
+# with `"state":"blocked"`, which `@tsv` renders as an EMPTY middle column.
 sd_add_session() {
-  SD_ENTRIES+=("{\"sessionId\":\"$1\",\"name\":\"$2\",\"state\":\"working\",\"status\":\"busy\",\"cwd\":\"/tmp/$2\"}")
+  local sid="$1" name="$2" status="${3-busy}"
+  if [[ -z "$status" ]]; then
+    SD_ENTRIES+=("{\"sessionId\":\"$sid\",\"name\":\"$name\",\"state\":\"blocked\",\"status\":null,\"cwd\":\"/tmp/$name\"}")
+  else
+    SD_ENTRIES+=("{\"sessionId\":\"$sid\",\"name\":\"$name\",\"state\":\"working\",\"status\":\"$status\",\"cwd\":\"/tmp/$name\"}")
+  fi
 }
 
 # sd_install_claude [exit-code] — install the fake `claude` emitting the
@@ -392,13 +400,18 @@ assert_eq "observed-record: stderr reports the still-live pair" "yes" \
 sd_teardown
 
 # --- Test 6: an observed pair that shrank to one idle survivor is parked -----
+# The survivor is registered the way the daemon actually registers a HELD
+# session — `"status":null` / `"state":"blocked"` — which is also the regression
+# guard for the TSV parse: `@tsv` renders that null as an empty middle column,
+# and an `IFS=$'\t' read -r sid status name` collapse would drop the row from
+# the live-name index, read n_live as 0, and clear the marker instead of parking.
 
-echo "Test: an observed pair shrunk to one idle survivor with unpushed work is parked"
+echo "Test: an observed pair shrunk to one idle HELD survivor with unpushed work is parked"
 sd_setup
 sd_write_node "tactic-shrunk-idle" unparked
 sd_commit_nodes
 sd_write_worktree "tactic-shrunk-idle" unpushed
-sd_add_session "0bb2-2222" "tactic-shrunk-idle"
+sd_add_session "0bb2-2222" "tactic-shrunk-idle" ""
 sd_install_claude 0
 sd_write_transcript "0bb2-2222" $(( SD_NOW - 1000 ))
 standdown_write "tactic-shrunk-idle" observed "" "0aa1-1111,0bb2-2222"
@@ -428,6 +441,32 @@ assert_eq "shrunk-busy: sweep returns 0" "0" "$SD_RC"
 assert_eq "shrunk-busy: park-node not invoked" "0" "$(sd_park_calls)"
 assert_eq "shrunk-busy: stderr reports observing" "yes" \
   "$(sd_contains 'observing tactic-shrunk-busy (survivor 0bb2-2222 idle_seconds=10 < grace_seconds=900')"
+sd_teardown
+
+# --- Test 7b: a busy survivor is never parked on transcript age alone --------
+# The transcript is only appended BETWEEN tool calls, so a session sitting
+# inside ONE long call (a `gh run watch` over a slow CI run, a long subagent
+# fan-out) reads as arbitrarily idle while being the healthiest possible
+# worker. Rule (e)'s second signal — the registry's own `status: busy` — is what
+# keeps that from becoming a spurious park of an actively-working session, the
+# inverse failure this node's Verification section says to fix in the predicate.
+
+echo "Test: an observed survivor the registry still reports BUSY is not parked however stale its transcript"
+sd_setup
+sd_write_node "tactic-busy-stale" unparked
+sd_commit_nodes
+sd_write_worktree "tactic-busy-stale" unpushed
+sd_add_session "0bb2-2222" "tactic-busy-stale" busy
+sd_install_claude 0
+# Ten times the grace: any transcript-only rule would park here.
+sd_write_transcript "0bb2-2222" $(( SD_NOW - 9000 ))
+standdown_write "tactic-busy-stale" observed "" "0aa1-1111,0bb2-2222"
+sd_run
+assert_eq "busy-stale: sweep returns 0" "0" "$SD_RC"
+assert_eq "busy-stale: park-node not invoked" "0" "$(sd_park_calls)"
+assert_eq "busy-stale: stderr reports the busy survivor" "yes" \
+  "$(sd_contains 'observing tactic-busy-stale (survivor 0bb2-2222 reports status=busy')"
+assert_eq "busy-stale: the marker is kept" "observed" "$(sd_marker_field tactic-busy-stale origin)"
 sd_teardown
 
 # --- Test 8: no live session of that name remains → the marker is dropped ----

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-standdown-recheck.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-standdown-recheck.sh
@@ -1,0 +1,639 @@
+#!/usr/bin/env bash
+# Tests for lib-standdown-recheck.sh — the stand-down ledger and the liveness
+# re-check sweep that turns "the duplicate-worker stand-down winner died and the
+# work is stranded" into an observable office-hours park.
+#
+# Everything the sweep touches is faked: `claude agents --json` via
+# CLAUDE_AGENTS_CMD (a small script printing a controlled registry array), the
+# ledger via DISPATCH_STANDDOWN_DIR, the transcript store via
+# DISPATCH_STANDDOWN_PROJECTS_ROOT (files whose mtime `touch -d` sets), the graph
+# via DISPATCH_STANDDOWN_REPO_ROOT (a scratch git repo whose
+# refs/remotes/origin/main is set by hand — the sweep only ever READS
+# `git show origin/main:` and its fetch is non-fatal, so no real remote is
+# needed), the per-node worktrees as standalone scratch repos under
+# <repo>/.claude/worktrees/<node>, `park-node` via DISPATCH_STANDDOWN_PARK_NODE
+# (an argv logger with a test-controlled exit code), and the clock via
+# DISPATCH_STANDDOWN_NOW_EPOCH.
+#
+# standdown_recheck_sweep always returns 0, but every call is still wrapped in an
+# `if` to capture the code — the test shell runs under `set -e`.
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$FIXTURE_DIR/dispatch-test-fixture.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib-claude-agents.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib-standdown-recheck.sh"
+
+echo "=== lib-standdown-recheck.sh ==="
+
+# A fixed clock for every test. Transcript mtimes and marker stamps are
+# expressed relative to it.
+SD_NOW=1700000000
+
+SD_DIR=""
+SD_FAKE=""
+SD_REPO=""
+SD_PROJ=""
+SD_LEDGER=""
+SD_PARK=""
+SD_PARKLOG=""
+SD_ENTRIES=()
+SD_RC=0
+SD_ERR=""
+
+sd_setup() {
+  SD_DIR=$(mktemp -d)
+  SD_FAKE="$SD_DIR/fake-claude"
+  SD_REPO="$SD_DIR/repo"
+  SD_PROJ="$SD_DIR/projects"
+  SD_LEDGER="$SD_DIR/ledger"
+  SD_PARK="$SD_DIR/fake-park-node"
+  SD_PARKLOG="$SD_DIR/park-node.log"
+  SD_ENTRIES=()
+  mkdir -p "$SD_REPO/intentions" "$SD_PROJ/proj-a" "$SD_DIR/decisions" "$SD_LEDGER"
+  : > "$SD_PARKLOG"
+
+  git -C "$SD_REPO" init -q
+  git -C "$SD_REPO" config user.email "test@example.com"
+  git -C "$SD_REPO" config user.name "Test"
+
+  # The sweep must never see a tick snapshot: CLAUDE_AGENTS_CMD is the fake we
+  # want exercised (_claude_agents_raw prefers the snapshot when it is set).
+  unset DISPATCH_AGENTS_SNAPSHOT || true
+
+  DISPATCH_STANDDOWN_NOW_EPOCH="$SD_NOW"
+  DISPATCH_STANDDOWN_DIR="$SD_LEDGER"
+  DISPATCH_STANDDOWN_REPO_ROOT="$SD_REPO"
+  DISPATCH_STANDDOWN_PROJECTS_ROOT="$SD_PROJ"
+  DISPATCH_STANDDOWN_PARK_NODE="$SD_PARK"
+  unset DISPATCH_STANDDOWN_IDLE_GRACE_S || true
+  unset DISPATCH_STANDDOWN_PARK_MAX || true
+
+  # lib-decision-log.sh resolves DECISION_LOG_FILE ONCE, at source time, inside
+  # its load guard — so a per-test DISPATCH_DECISION_LOG_DIR set after sourcing
+  # would not be read. Set the env var for documentation/parity and re-point the
+  # already-resolved variable at the same scratch path.
+  DISPATCH_DECISION_LOG_DIR="$SD_DIR/decisions"
+  DECISION_LOG_FILE="$DISPATCH_DECISION_LOG_DIR/routing-decisions.jsonl"
+
+  sd_write_park_node 0
+}
+
+sd_teardown() {
+  rm -rf "$SD_DIR"
+  SD_DIR=""
+  unset CLAUDE_AGENTS_CMD || true
+  unset DISPATCH_STANDDOWN_NOW_EPOCH DISPATCH_STANDDOWN_DIR \
+        DISPATCH_STANDDOWN_REPO_ROOT DISPATCH_STANDDOWN_PROJECTS_ROOT \
+        DISPATCH_STANDDOWN_PARK_NODE DISPATCH_STANDDOWN_IDLE_GRACE_S \
+        DISPATCH_STANDDOWN_PARK_MAX DISPATCH_DECISION_LOG_DIR || true
+}
+
+# sd_write_park_node <exit-code> — install the fake park-node: it appends its
+# argc and each positional argument to the log, then exits <exit-code>.
+sd_write_park_node() {
+  cat > "$SD_PARK" <<PARK
+#!/usr/bin/env bash
+{
+  printf 'ARGC=%s\n' "\$#"
+  for a in "\$@"; do printf 'ARG=%s\n' "\$a"; done
+} >> "$SD_PARKLOG"
+exit $1
+PARK
+  chmod +x "$SD_PARK"
+}
+
+# sd_add_session <sid> <name> — append one live registry entry.
+sd_add_session() {
+  SD_ENTRIES+=("{\"sessionId\":\"$1\",\"name\":\"$2\",\"state\":\"working\",\"status\":\"busy\",\"cwd\":\"/tmp/$2\"}")
+}
+
+# sd_install_claude [exit-code] — install the fake `claude` emitting the
+# accumulated registry array and point CLAUDE_AGENTS_CMD at it.
+sd_install_claude() {
+  local exit_code="${1:-0}" payload
+  payload=$( IFS=,; printf '[%s]' "${SD_ENTRIES[*]}" )
+  printf '%s' "$payload" > "$SD_DIR/payload.json"
+  cat > "$SD_FAKE" <<FAKE
+#!/usr/bin/env bash
+cat "$SD_DIR/payload.json"
+exit $exit_code
+FAKE
+  chmod +x "$SD_FAKE"
+  CLAUDE_AGENTS_CMD="$SD_FAKE"
+}
+
+# sd_write_node <id> <unparked|parked|bodymention> — write one node markdown file
+# into the scratch repo's intentions/ dir.
+sd_write_node() {
+  local id="$1" kind="$2"
+  local f="$SD_REPO/intentions/$id.md"
+  case "$kind" in
+    parked)
+      cat > "$f" <<NODE
+---
+id: $id
+kind: tactic
+office_hours:
+  reason: parked earlier by something else
+  recommendation: null
+---
+
+Body text.
+NODE
+      ;;
+    bodymention)
+      # Frontmatter park state is null, but the markdown BODY carries a
+      # column-0 \`office_hours:\` line (documentation of the serialization).
+      # The frontmatter-scoped test must NOT read this as park state.
+      cat > "$f" <<NODE
+---
+id: $id
+kind: tactic
+office_hours: null
+---
+
+The park record serializes as:
+
+office_hours:
+  reason: ...
+NODE
+      ;;
+    *)
+      cat > "$f" <<NODE
+---
+id: $id
+kind: tactic
+office_hours: null
+---
+
+Body text.
+NODE
+      ;;
+  esac
+}
+
+# sd_commit_nodes — commit whatever is in intentions/ and publish it as
+# origin/main (no bare remote needed; the sweep only reads the ref). Only
+# intentions/ is added: the per-node scratch worktrees live under
+# <repo>/.claude/worktrees/ and are independent git repos that must not be
+# absorbed as gitlinks.
+sd_commit_nodes() {
+  git -C "$SD_REPO" add intentions
+  git -C "$SD_REPO" commit -q -m "nodes"
+  git -C "$SD_REPO" update-ref refs/remotes/origin/main HEAD
+}
+
+# sd_write_worktree <node> <insync|unpushed> — create the node's worktree at the
+# derived path (<repo>/.claude/worktrees/<node>) as a standalone scratch repo.
+#   insync   — clean, HEAD == refs/remotes/origin/main (worktree_in_sync true).
+#   unpushed — clean, HEAD one commit ahead of origin/main with a different tree
+#              (both worktree_in_sync and worktree_merged_in_sync false).
+sd_write_worktree() {
+  local node="$1" kind="$2"
+  local wt="$SD_REPO/.claude/worktrees/$node"
+  mkdir -p "$wt"
+  git -C "$wt" init -q
+  git -C "$wt" config user.email "test@example.com"
+  git -C "$wt" config user.name "Test"
+  printf 'base\n' > "$wt/f.txt"
+  git -C "$wt" add -A
+  git -C "$wt" commit -q -m "base"
+  git -C "$wt" update-ref refs/remotes/origin/main HEAD
+  if [[ "$kind" == "unpushed" ]]; then
+    printf 'the fix nobody pushed\n' > "$wt/f.txt"
+    git -C "$wt" add -A
+    git -C "$wt" commit -q -m "the unpushed fix"
+  fi
+}
+
+# sd_write_transcript <sid> <mtime-epoch>
+sd_write_transcript() {
+  printf '{}\n' > "$SD_PROJ/proj-a/$1.jsonl"
+  touch -d "@$2" "$SD_PROJ/proj-a/$1.jsonl"
+}
+
+sd_run() {
+  if standdown_recheck_sweep 2>"$SD_DIR/err"; then SD_RC=0; else SD_RC=$?; fi
+  SD_ERR=$(cat "$SD_DIR/err")
+}
+
+sd_contains() {
+  case "$SD_ERR" in *"$1"*) printf 'yes' ;; *) printf 'no' ;; esac
+}
+
+sd_park_calls() {
+  local c
+  c=$(grep -c '^ARGC=' "$SD_PARKLOG" 2>/dev/null) || c=0
+  [[ -n "$c" ]] || c=0
+  printf '%s' "$c"
+}
+
+# sd_park_reason — the reason argument ($2) of the FIRST park-node invocation.
+sd_park_reason() {
+  grep '^ARG=' "$SD_PARKLOG" | sed -n '2p' | sed 's/^ARG=//'
+}
+
+# sd_park_recommendation — the recommendation argument ($3) of the FIRST call.
+sd_park_recommendation() {
+  grep '^ARG=' "$SD_PARKLOG" | sed -n '3p' | sed 's/^ARG=//'
+}
+
+sd_err_count() {
+  local c
+  c=$(grep -c -- "$1" <<<"$SD_ERR") || c=0
+  [[ -n "$c" ]] || c=0
+  printf '%s' "$c"
+}
+
+sd_marker_field() {
+  sed -n "s/^$2=//p" "$SD_LEDGER/$1" | head -n1
+}
+
+sd_log_dispositions() {
+  [[ -f "$DECISION_LOG_FILE" ]] || return 0
+  jq -r 'select(.site == "standdown-recheck-sweep") | .disposition' "$DECISION_LOG_FILE"
+}
+
+# --- Test 1: THE INVARIANT — a declared marker never times out ---------------
+# The regression guard for the whole unit: however old the stand-down record is,
+# a LIVE declared winner means observe, never park.
+
+echo "Test: a 10-day-old declared marker whose winner is still live is observed, never parked"
+sd_setup
+sd_write_node "tactic-declared-live" unparked
+sd_commit_nodes
+sd_write_worktree "tactic-declared-live" unpushed
+sd_add_session "0aa1-1111" "tactic-declared-live"
+sd_install_claude 0
+standdown_write "tactic-declared-live" declared "0aa1-1111" "0aa1-1111,0bb2-2222"
+# Back-date the record ten days: any age-based timeout would fire here.
+sed -i "s/^observed=.*/observed=$(( SD_NOW - 864000 ))/" "$SD_LEDGER/tactic-declared-live"
+sd_run
+assert_eq "declared-live-old: sweep returns 0" "0" "$SD_RC"
+assert_eq "declared-live-old: park-node NEVER invoked" "0" "$(sd_park_calls)"
+assert_eq "declared-live-old: stderr reports observing" "yes" "$(sd_contains 'observing tactic-declared-live (declared winner 0aa1-1111 is still live')"
+assert_eq "declared-live-old: the marker is kept" "declared" "$(sd_marker_field tactic-declared-live origin)"
+sd_teardown
+
+# --- Test 2: declared winner dead, work unpushed → park ----------------------
+
+echo "Test: a declared winner that is gone with unpushed work parks the node"
+sd_setup
+sd_write_node "tactic-dead-unpushed" unparked
+sd_commit_nodes
+sd_write_worktree "tactic-dead-unpushed" unpushed
+# Only the LOSER is live; the winner is absent from the registry.
+sd_add_session "0bb2-2222" "tactic-dead-unpushed"
+sd_install_claude 0
+standdown_write "tactic-dead-unpushed" declared "0aa1-1111" "0aa1-1111,0bb2-2222"
+sd_run
+assert_eq "dead-unpushed: sweep returns 0" "0" "$SD_RC"
+assert_eq "dead-unpushed: park-node invoked exactly once" "1" "$(sd_park_calls)"
+assert_eq "dead-unpushed: park-node received 3 positional args" "ARGC=3" "$(grep '^ARGC=' "$SD_PARKLOG")"
+assert_eq "dead-unpushed: node id is \$1" "tactic-dead-unpushed" \
+  "$(grep '^ARG=' "$SD_PARKLOG" | head -n1 | sed 's/^ARG=//')"
+case "$(sd_park_reason)" in
+  standdown-winner-dead-work-unpushed*) sd_reason_tag="yes" ;;
+  *) sd_reason_tag="no" ;;
+esac
+assert_eq "dead-unpushed: reason carries the work-unpushed tag" "yes" "$sd_reason_tag"
+case "$(sd_park_reason)" in
+  *"$SD_REPO/.claude/worktrees/tactic-dead-unpushed"*) sd_reason_wt="yes" ;;
+  *) sd_reason_wt="no" ;;
+esac
+assert_eq "dead-unpushed: reason names the worktree path" "yes" "$sd_reason_wt"
+case "$(sd_park_reason)" in
+  *"0aa1-1111"*) sd_reason_sid="yes" ;;
+  *) sd_reason_sid="no" ;;
+esac
+assert_eq "dead-unpushed: reason names the dead winner sid" "yes" "$sd_reason_sid"
+case "$(sd_park_reason)" in
+  *"the unpushed fix"*) sd_reason_head="yes" ;;
+  *) sd_reason_head="no" ;;
+esac
+assert_eq "dead-unpushed: reason carries the unpushed head summary" "yes" "$sd_reason_head"
+case "$(sd_park_recommendation)" in
+  *"NEVER 'claude rm'"*) sd_rec_rm="yes" ;;
+  *) sd_rec_rm="no" ;;
+esac
+assert_eq "dead-unpushed: recommendation forbids claude rm" "yes" "$sd_rec_rm"
+case "$(sd_park_recommendation)" in
+  *"all-held"*) sd_rec_held="yes" ;;
+  *) sd_rec_held="no" ;;
+esac
+assert_eq "dead-unpushed: recommendation states the all-held residual" "yes" "$sd_rec_held"
+assert_eq "dead-unpushed: one decision record, disposition=parked" "parked" "$(sd_log_dispositions)"
+sd_teardown
+
+# --- Test 3: declared winner dead, worktree in sync → node-held park ---------
+
+echo "Test: a declared winner that is gone with a fully-pushed worktree parks node-held"
+sd_setup
+sd_write_node "tactic-dead-insync" unparked
+sd_commit_nodes
+sd_write_worktree "tactic-dead-insync" insync
+sd_add_session "0bb2-2222" "tactic-dead-insync"
+sd_install_claude 0
+standdown_write "tactic-dead-insync" declared "0aa1-1111" "0aa1-1111,0bb2-2222"
+sd_run
+assert_eq "dead-insync: sweep returns 0" "0" "$SD_RC"
+assert_eq "dead-insync: park-node invoked exactly once" "1" "$(sd_park_calls)"
+case "$(sd_park_reason)" in
+  standdown-winner-dead-node-held*) sd_reason_tag="yes" ;;
+  *) sd_reason_tag="no" ;;
+esac
+assert_eq "dead-insync: reason carries the node-held tag" "yes" "$sd_reason_tag"
+sd_teardown
+
+# --- Test 4: an unqueryable daemon parks nothing and keeps the marker --------
+
+echo "Test: an unqueryable daemon observes every marker and parks nothing"
+sd_setup
+sd_write_node "tactic-unknown-daemon" unparked
+sd_commit_nodes
+sd_write_worktree "tactic-unknown-daemon" unpushed
+sd_add_session "0bb2-2222" "tactic-unknown-daemon"
+standdown_write "tactic-unknown-daemon" declared "0aa1-1111" "0aa1-1111,0bb2-2222"
+sd_install_claude 1
+sd_run
+assert_eq "daemon-unknown: sweep returns 0" "0" "$SD_RC"
+assert_eq "daemon-unknown: park-node not invoked" "0" "$(sd_park_calls)"
+assert_eq "daemon-unknown: the marker is kept" "declared" "$(sd_marker_field tactic-unknown-daemon origin)"
+assert_eq "daemon-unknown: stderr reports the unknown liveness" "yes" \
+  "$(sd_contains 'observing tactic-unknown-daemon (liveness unknown this pass')"
+sd_teardown
+
+# --- Test 5: an observed duplicate pair is recorded --------------------------
+
+echo "Test: two live sessions under one node name are recorded as an observed pair"
+sd_setup
+sd_write_node "tactic-observed-pair" unparked
+sd_commit_nodes
+sd_write_worktree "tactic-observed-pair" unpushed
+sd_add_session "0aa1-1111" "tactic-observed-pair"
+sd_add_session "0bb2-2222" "tactic-observed-pair"
+sd_install_claude 0
+sd_run
+assert_eq "observed-record: sweep returns 0" "0" "$SD_RC"
+assert_eq "observed-record: a marker now exists" "yes" \
+  "$(standdown_exists tactic-observed-pair && printf 'yes' || printf 'no')"
+assert_eq "observed-record: origin is observed" "observed" "$(sd_marker_field tactic-observed-pair origin)"
+assert_eq "observed-record: winner is empty" "" "$(sd_marker_field tactic-observed-pair winner)"
+assert_eq "observed-record: both sids are recorded" "0aa1-1111,0bb2-2222" \
+  "$(sd_marker_field tactic-observed-pair sessions)"
+assert_eq "observed-record: park-node not invoked" "0" "$(sd_park_calls)"
+assert_eq "observed-record: stderr reports the still-live pair" "yes" \
+  "$(sd_contains 'observing-pair tactic-observed-pair (2 live sessions')"
+sd_teardown
+
+# --- Test 6: an observed pair that shrank to one idle survivor is parked -----
+
+echo "Test: an observed pair shrunk to one idle survivor with unpushed work is parked"
+sd_setup
+sd_write_node "tactic-shrunk-idle" unparked
+sd_commit_nodes
+sd_write_worktree "tactic-shrunk-idle" unpushed
+sd_add_session "0bb2-2222" "tactic-shrunk-idle"
+sd_install_claude 0
+sd_write_transcript "0bb2-2222" $(( SD_NOW - 1000 ))
+standdown_write "tactic-shrunk-idle" observed "" "0aa1-1111,0bb2-2222"
+sd_run
+assert_eq "shrunk-idle: sweep returns 0" "0" "$SD_RC"
+assert_eq "shrunk-idle: park-node invoked exactly once" "1" "$(sd_park_calls)"
+case "$(sd_park_reason)" in
+  standdown-winner-dead-work-unpushed*) sd_reason_tag="yes" ;;
+  *) sd_reason_tag="no" ;;
+esac
+assert_eq "shrunk-idle: reason carries the work-unpushed tag" "yes" "$sd_reason_tag"
+sd_teardown
+
+# --- Test 7: an observed pair whose survivor is busy is left alone -----------
+
+echo "Test: an observed pair shrunk to one BUSY survivor is observed, not parked"
+sd_setup
+sd_write_node "tactic-shrunk-busy" unparked
+sd_commit_nodes
+sd_write_worktree "tactic-shrunk-busy" unpushed
+sd_add_session "0bb2-2222" "tactic-shrunk-busy"
+sd_install_claude 0
+sd_write_transcript "0bb2-2222" $(( SD_NOW - 10 ))
+standdown_write "tactic-shrunk-busy" observed "" "0aa1-1111,0bb2-2222"
+sd_run
+assert_eq "shrunk-busy: sweep returns 0" "0" "$SD_RC"
+assert_eq "shrunk-busy: park-node not invoked" "0" "$(sd_park_calls)"
+assert_eq "shrunk-busy: stderr reports observing" "yes" \
+  "$(sd_contains 'observing tactic-shrunk-busy (survivor 0bb2-2222 idle_seconds=10 < grace_seconds=900')"
+sd_teardown
+
+# --- Test 8: no live session of that name remains → the marker is dropped ----
+
+echo "Test: a marker with zero live sessions of its name is cleared, not parked"
+sd_setup
+sd_write_node "tactic-nobody-left" unparked
+sd_commit_nodes
+sd_write_worktree "tactic-nobody-left" unpushed
+sd_add_session "0cc3-3333" "tactic-some-other-node"
+sd_install_claude 0
+standdown_write "tactic-nobody-left" declared "0aa1-1111" "0aa1-1111,0bb2-2222"
+sd_run
+assert_eq "no-live: sweep returns 0" "0" "$SD_RC"
+assert_eq "no-live: park-node not invoked" "0" "$(sd_park_calls)"
+assert_eq "no-live: the marker file is removed" "no" \
+  "$(standdown_exists tactic-nobody-left && printf 'yes' || printf 'no')"
+assert_eq "no-live: stderr reports the clear" "yes" "$(sd_contains 'cleared-no-live-session tactic-nobody-left')"
+assert_eq "no-live: the decision record says cleared" "cleared-no-live-session" "$(sd_log_dispositions)"
+sd_teardown
+
+# --- Test 9: an already-parked node is never re-parked -----------------------
+
+echo "Test: an already-parked node is skipped and its marker kept"
+sd_setup
+sd_write_node "tactic-already-parked" parked
+sd_commit_nodes
+sd_write_worktree "tactic-already-parked" unpushed
+sd_add_session "0bb2-2222" "tactic-already-parked"
+sd_install_claude 0
+standdown_write "tactic-already-parked" declared "0aa1-1111" "0aa1-1111,0bb2-2222"
+sd_run
+assert_eq "already-parked: sweep returns 0" "0" "$SD_RC"
+assert_eq "already-parked: park-node not invoked" "0" "$(sd_park_calls)"
+assert_eq "already-parked: stderr reports the skip" "yes" "$(sd_contains 'already-parked tactic-already-parked')"
+assert_eq "already-parked: the marker is kept" "declared" "$(sd_marker_field tactic-already-parked origin)"
+sd_teardown
+
+# --- Test 10: a body-only office_hours line is NOT park state ----------------
+
+echo "Test: a column-0 office_hours line in the node BODY does not read as park state"
+sd_setup
+sd_write_node "tactic-body-mention" bodymention
+sd_commit_nodes
+sd_write_worktree "tactic-body-mention" unpushed
+sd_add_session "0bb2-2222" "tactic-body-mention"
+sd_install_claude 0
+standdown_write "tactic-body-mention" declared "0aa1-1111" "0aa1-1111,0bb2-2222"
+sd_run
+assert_eq "body-mention: sweep returns 0" "0" "$SD_RC"
+assert_eq "body-mention: the node is parked anyway" "1" "$(sd_park_calls)"
+assert_eq "body-mention: stderr does not report an already-parked skip" "no" "$(sd_contains 'already-parked')"
+sd_teardown
+
+# --- Test 11: the per-sweep park cap defers the excess -----------------------
+
+echo "Test: the park cap bounds parks per sweep and defers the rest"
+sd_setup
+DISPATCH_STANDDOWN_PARK_MAX=2
+for n in one two three four; do
+  sd_write_node "tactic-cap-$n" unparked
+done
+sd_commit_nodes
+i=1
+for n in one two three four; do
+  sd_write_worktree "tactic-cap-$n" unpushed
+  sd_add_session "0cab-000$i" "tactic-cap-$n"
+  standdown_write "tactic-cap-$n" declared "0dead-000$i" "0dead-000$i,0cab-000$i"
+  i=$(( i + 1 ))
+done
+sd_install_claude 0
+sd_run
+assert_eq "cap: sweep returns 0" "0" "$SD_RC"
+assert_eq "cap: exactly two park-node invocations" "2" "$(sd_park_calls)"
+assert_eq "cap: two deferred lines" "2" "$(sd_err_count 'lib-standdown-recheck: deferred ')"
+assert_eq "cap: summary counts the deferrals" "yes" \
+  "$(sd_contains 'sweep complete (markers=4 recorded=0 parked=2 observing=0 cleared=0 deferred=2)')"
+sd_teardown
+
+# --- Test 12: a park-node failure is non-fatal and keeps the marker ----------
+
+echo "Test: a park-node failure is logged, the marker kept, and the sweep still returns 0"
+sd_setup
+sd_write_park_node 3
+sd_write_node "tactic-park-fails" unparked
+sd_commit_nodes
+sd_write_worktree "tactic-park-fails" unpushed
+sd_add_session "0bb2-2222" "tactic-park-fails"
+sd_install_claude 0
+standdown_write "tactic-park-fails" declared "0aa1-1111" "0aa1-1111,0bb2-2222"
+sd_run
+assert_eq "park-fail: sweep returns 0" "0" "$SD_RC"
+assert_eq "park-fail: park-node was attempted" "1" "$(sd_park_calls)"
+assert_eq "park-fail: stderr reports the failure" "yes" \
+  "$(sd_contains 'park failed for tactic-park-fails (park-node exit 3)')"
+assert_eq "park-fail: the marker is kept for the next pass" "declared" \
+  "$(sd_marker_field tactic-park-fails origin)"
+assert_eq "park-fail: the decision record says park-failed" "park-failed" "$(sd_log_dispositions)"
+assert_eq "park-fail: summary counts zero parks" "yes" \
+  "$(sd_contains 'sweep complete (markers=1 recorded=0 parked=0 observing=0 cleared=0 deferred=0)')"
+sd_teardown
+
+# --- Test 13: the sweep always returns 0, with exactly one summary line ------
+# Three independent degenerate environments: an absent ledger dir, an
+# unresolvable repo root, and a failing daemon.
+
+echo "Test: an absent ledger dir still returns 0 with exactly one summary line"
+sd_setup
+DISPATCH_STANDDOWN_DIR="$SD_DIR/no-such-ledger"
+sd_write_node "tactic-zero-a" unparked
+sd_commit_nodes
+sd_install_claude 0
+sd_run
+assert_eq "always-zero/no-ledger: sweep returns 0" "0" "$SD_RC"
+assert_eq "always-zero/no-ledger: exactly one summary line" "1" "$(sd_err_count 'sweep complete')"
+sd_teardown
+
+echo "Test: an unresolvable repo root still returns 0 with exactly one summary line"
+sd_setup
+sd_write_node "tactic-zero-b" unparked
+sd_commit_nodes
+sd_add_session "0bb2-2222" "tactic-zero-b"
+sd_install_claude 0
+standdown_write "tactic-zero-b" declared "0aa1-1111" "0aa1-1111,0bb2-2222"
+unset DISPATCH_STANDDOWN_REPO_ROOT
+# resolve_project_root walks up from the cwd, so run from a scratch dir with a
+# GIT_CEILING_DIRECTORIES fence that stops the walk before any enclosing repo.
+mkdir -p "$SD_DIR/nonrepo/sub"
+if ( cd "$SD_DIR/nonrepo/sub" && GIT_CEILING_DIRECTORIES="$SD_DIR/nonrepo" standdown_recheck_sweep ) 2>"$SD_DIR/err"; then
+  SD_RC=0
+else
+  SD_RC=$?
+fi
+SD_ERR=$(cat "$SD_DIR/err")
+assert_eq "always-zero/no-root: sweep returns 0" "0" "$SD_RC"
+assert_eq "always-zero/no-root: stderr reports the unresolvable root" "yes" \
+  "$(sd_contains 'repo root unresolvable; parking nothing')"
+assert_eq "always-zero/no-root: exactly one summary line" "1" "$(sd_err_count 'sweep complete')"
+assert_eq "always-zero/no-root: park-node not invoked" "0" "$(sd_park_calls)"
+sd_teardown
+
+echo "Test: a failing daemon still returns 0 with exactly one summary line"
+sd_setup
+sd_write_node "tactic-zero-c" unparked
+sd_commit_nodes
+sd_add_session "0bb2-2222" "tactic-zero-c"
+standdown_write "tactic-zero-c" declared "0aa1-1111" "0aa1-1111,0bb2-2222"
+sd_install_claude 1
+sd_run
+assert_eq "always-zero/daemon-fail: sweep returns 0" "0" "$SD_RC"
+assert_eq "always-zero/daemon-fail: exactly one summary line" "1" "$(sd_err_count 'sweep complete')"
+assert_eq "always-zero/daemon-fail: park-node not invoked" "0" "$(sd_park_calls)"
+sd_teardown
+
+# --- Test 14: an unsafe marker name is never used to build a path ------------
+
+echo "Test: a marker whose name fails the node-id regex is kept and skipped"
+sd_setup
+sd_write_node "tactic-valid" unparked
+sd_commit_nodes
+sd_add_session "0bb2-2222" "tactic-Bad_Id"
+sd_install_claude 0
+# Written directly: standdown_write's own guard rejects separators, but an
+# uppercase/underscore name is path-safe yet not a node id — the sweep's rule
+# (a) is what catches it.
+printf 'origin=declared\nwinner=0aa1-1111\nsessions=0aa1-1111,0bb2-2222\nobserved=%s\n' "$SD_NOW" \
+  > "$SD_LEDGER/tactic-Bad_Id"
+sd_run
+assert_eq "unsafe-id: sweep returns 0" "0" "$SD_RC"
+assert_eq "unsafe-id: park-node not invoked" "0" "$(sd_park_calls)"
+assert_eq "unsafe-id: stderr reports the unsafe id" "yes" "$(sd_contains 'unsafe-id tactic-Bad_Id')"
+assert_eq "unsafe-id: the marker is kept" "declared" "$(sd_marker_field tactic-Bad_Id origin)"
+sd_teardown
+
+# --- Test 15: a node with no worktree drops its marker -----------------------
+
+echo "Test: a marker whose node has no worktree is cleared"
+sd_setup
+sd_write_node "tactic-no-worktree" unparked
+sd_commit_nodes
+sd_add_session "0bb2-2222" "tactic-no-worktree"
+sd_install_claude 0
+standdown_write "tactic-no-worktree" declared "0aa1-1111" "0aa1-1111,0bb2-2222"
+sd_run
+assert_eq "no-worktree: sweep returns 0" "0" "$SD_RC"
+assert_eq "no-worktree: park-node not invoked" "0" "$(sd_park_calls)"
+assert_eq "no-worktree: the marker file is removed" "no" \
+  "$(standdown_exists tactic-no-worktree && printf 'yes' || printf 'no')"
+assert_eq "no-worktree: stderr reports the clear" "yes" "$(sd_contains 'cleared-no-worktree tactic-no-worktree')"
+sd_teardown
+
+# --- Test 16: a name with no node file on origin/main is kept, not parked ----
+
+echo "Test: a marker naming something that is not a graph node is kept"
+sd_setup
+sd_write_node "tactic-real" unparked
+sd_commit_nodes
+sd_write_worktree "tactic-not-a-node" unpushed
+sd_add_session "0bb2-2222" "tactic-not-a-node"
+sd_install_claude 0
+standdown_write "tactic-not-a-node" declared "0aa1-1111" "0aa1-1111,0bb2-2222"
+sd_run
+assert_eq "not-a-node: sweep returns 0" "0" "$SD_RC"
+assert_eq "not-a-node: park-node not invoked" "0" "$(sd_park_calls)"
+assert_eq "not-a-node: stderr reports it" "yes" "$(sd_contains 'not-a-node tactic-not-a-node')"
+assert_eq "not-a-node: the marker is kept" "declared" "$(sd_marker_field tactic-not-a-node origin)"
+sd_teardown
+
+report_results


### PR DESCRIPTION
## Context

The duplicate-worker stand-down protocol — the session with uncommitted/unpushed
work wins, the other stands down without writing a park — was emergent session
judgment with no code and no liveness check on the winner. When the winner died
mid-work (observed live 2026-07-31), the loser waited forever on a session that
no longer existed, holding the node with the fix unpushed in the shared worktree.
Nothing timed out and nothing surfaced it; recovery required a human noticing.

## What changed

- **`lib-claude-agents.sh`**: two new primitives — `claude_session_id_is_live
  <sid>` (fail-safe to "live" on daemon UNKNOWN, `return 1` only on definite
  absence) and `claude_agents_list_duplicate_node_names` (emits `name<TAB>sids`
  for any tactic-/strategy- node name with 2+ live sessions).
- **`lib-standdown-recheck.sh`** (new): a sidecar ledger (`standdown_write` /
  `standdown_clear` / `standdown_exists`) recording a node's stand-down origin
  (`declared` or `observed`) and winner sid, plus `standdown_recheck_sweep` — a
  rule-ladder re-check that waits indefinitely while a `declared` winner is
  live (no age term on that path — the load-bearing invariant this tactic
  exists to guarantee), and parks the node once the winner is definitely gone:
  `standdown-winner-dead-work-unpushed` if the worktree still carries unpushed
  commits, `standdown-winner-dead-node-held` otherwise. An `observed` pair
  (the sweep's own fallback when it sees two live sessions and no marker) gets
  a short idle grace before parking, since the sweep can't tell winner from
  loser on that path.
- **`dispatch-tick`**: wires `standdown_recheck_sweep` in on both the paused
  branch and the normal path (after the daemon snapshot, before target
  selection), so a stand-down freeze surfaces even while dispatch is paused.
- **`dispatch-standdown`** (new): the CLI a losing session calls to record its
  stand-down. Re-checks the winner's liveness one more time at the moment of
  the call — if the winner is already definitely gone, it refuses to stand
  down (`winner-absent`, exit 3) rather than writing a ledger entry for a
  winner that never existed at decision time.
- **`reference.md`** and **`dispatch-self-close`**: documented the protocol
  (four rules) and pointed the "why is my job held?" reader at
  `dispatch-standdown` / `standdown_recheck_sweep`.

The action is always a park (a surfacing), never an auto-release — no branch
`claude rm`s, `claude stop`s, or `git push`s. This keeps the design compatible
with `tactic-stopped-session-blocks-node`'s requirement that release stay an
explicit human act.

## Verification

- `test-lib-claude-agents.sh` — 91/91 passed (15 new).
- `test-lib-standdown-recheck.sh` — 78/78 passed.
- `test-dispatch-standdown.sh` — 21/21 passed.
- `test-dispatch-tick.sh` — 101/101 passed (6 new).
- `run-lint.sh --prose` — clean.
- Manual check: `GRACE`/`TTL`/`idle` terms in `lib-standdown-recheck.sh` appear
  only inside the `origin=observed` branch; no branch calls `claude rm`,
  `claude stop`, or `git push`.

Graph node: tactic-standdown-winner-liveness
